### PR TITLE
fix(src): reinit vsag by explicitly calling init()

### DIFF
--- a/src/vsag.cpp
+++ b/src/vsag.cpp
@@ -31,7 +31,7 @@ version() {
 }
 
 bool
-init() {
+_init() {
 #ifndef NDEBUG
     // set debug level by default in debug version of VSAG
     logger::set_level(logger::level::debug);
@@ -58,6 +58,11 @@ init() {
     return true;
 }
 
-static bool _init = init();
+static bool _is_init = _init();
+
+bool
+init() {
+    return _is_init;
+}
 
 }  // namespace vsag


### PR DESCRIPTION
related: #108 

if we use `VSAG` by static lib, we need  explicitly call `vsag::init()`
but it will reinit `VSAG`, since `init()` has been called to initializing `_init`. https://github.com/alipay/vsag/blob/185eccffd8b3db6e77c3c24d378c40bc15243d36/src/vsag.cpp#L61
although reinitializing `VSAG` does not cause bugs yet.
But this code is not elegant, on the other hand, the init log will repeat twice in `debug` mode