### PR TITLE
implement of the engine and rewrite factory

### DIFF
--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -7,6 +7,9 @@ target_link_libraries (example_fresh_hnsw vsag)
 add_executable (example_diskann example_diskann.cpp)
 target_link_libraries (example_diskann vsag_static)
 
+add_executable (example_engine example_engine.cpp)
+target_link_libraries (example_engine vsag_static)
+
 add_executable (simple_hnsw simple_hnsw.cpp)
 target_link_libraries (simple_hnsw vsag_static)
 

--- a/examples/cpp/example_engine.cpp
+++ b/examples/cpp/example_engine.cpp
@@ -1,0 +1,134 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <vsag/vsag.h>
+
+#include <iostream>
+
+class SimpleAllocator : public vsag::Allocator {
+public:
+    SimpleAllocator() = default;
+    ~SimpleAllocator() override = default;
+
+public:
+    std::string
+    Name() override {
+        return "DefaultAllocator";
+    }
+
+    void*
+    Allocate(size_t size) override {
+        auto ptr = malloc(size);
+        allocate_count_++;
+        return ptr;
+    }
+
+    void
+    Deallocate(void* p) override {
+        free(p);
+    }
+
+    void*
+    Reallocate(void* p, size_t size) override {
+        auto ptr = realloc(p, size);
+        return ptr;
+    }
+
+    void
+    Print() {
+        std::cout << "allocate times : " << allocate_count_ << std::endl;
+    }
+    uint64_t allocate_count_{0};
+};
+
+int
+main(int argc, char** argv) {
+    vsag::init();
+
+    int64_t num_vectors = 1000;
+    int64_t dim = 128;
+
+    // prepare ids and vectors
+    auto ids = new int64_t[num_vectors];
+    auto vectors = new float[dim * num_vectors];
+
+    std::mt19937 rng(47);
+    std::uniform_real_distribution<float> distrib_real;
+    for (int64_t i = 0; i < num_vectors; ++i) {
+        ids[i] = i;
+    }
+    for (int64_t i = 0; i < dim * num_vectors; ++i) {
+        vectors[i] = distrib_real(rng);
+    }
+
+    // create index
+    auto hnsw_build_paramesters = R"(
+    {
+        "dtype": "float32",
+        "metric_type": "l2",
+        "dim": 128,
+        "hnsw": {
+            "max_degree": 16,
+            "ef_construction": 100
+        }
+    }
+    )";
+
+    auto* allocator = new SimpleAllocator();
+
+    {
+        vsag::Resource resource(allocator);
+        vsag::Engine engine(&resource);
+        auto index = engine.CreateIndex("hnsw", hnsw_build_paramesters).value();
+        auto base = vsag::Dataset::Make();
+        base->NumElements(num_vectors)->Dim(dim)->Ids(ids)->Float32Vectors(vectors)->Owner(false);
+        index->Build(base);
+
+        // prepare a query vector
+        // memory will be released by query the dataset since owner is set to true when creating the query.
+        auto query_vector = new float[dim];
+        for (int64_t i = 0; i < dim; ++i) {
+            query_vector[i] = distrib_real(rng);
+        }
+
+        // search on the index
+        auto hnsw_search_parameters = R"(
+        {
+            "hnsw": {
+                "ef_search": 100
+            }
+        }
+        )";
+        int64_t topk = 10;
+        auto query = vsag::Dataset::Make();
+        query->NumElements(1)->Dim(dim)->Float32Vectors(query_vector)->Owner(true);
+        auto result = index->KnnSearch(query, topk, hnsw_search_parameters).value();
+
+        // print the results
+        std::cout << "results: " << std::endl;
+        for (int64_t i = 0; i < result->GetDim(); ++i) {
+            std::cout << result->GetIds()[i] << ": " << result->GetDistances()[i] << std::endl;
+        }
+        engine.Shutdown();
+        allocator->Print();
+    }
+
+    // free memory
+    delete[] ids;
+    delete[] vectors;
+    delete allocator;
+
+    return 0;
+}

--- a/include/vsag/engine.h
+++ b/include/vsag/engine.h
@@ -17,16 +17,19 @@
 
 #include <memory>
 
+#include "dataset.h"
 #include "index.h"
 #include "resource.h"
 
 namespace vsag {
 class Engine {
 public:
-    explicit Engine(Resource* resource = nullptr);
+    explicit Engine();
+
+    explicit Engine(Resource* resource);
 
     void
-    Shutdown();
+    Shutdown();  // like ~Engine(), but will warn whether the resources are still reference outside
 
     tl::expected<std::shared_ptr<Index>, Error>
     CreateIndex(const std::string& name, const std::string& parameters);

--- a/include/vsag/resource.h
+++ b/include/vsag/resource.h
@@ -20,15 +20,18 @@
 #include "allocator.h"
 
 namespace vsag {
-struct Resource {
+class Resource {
 public:
     explicit Resource(Allocator* allocator = nullptr);
 
     virtual ~Resource() = default;
 
+    virtual std::shared_ptr<Allocator>
+    GetAllocator() {
+        return this->allocator;
+    }
+
 public:
     std::shared_ptr<Allocator> allocator;
-
-    // std::shared_ptr<> thread_pool;
 };
 }  // namespace vsag

--- a/include/vsag/vsag.h
+++ b/include/vsag/vsag.h
@@ -41,6 +41,7 @@ init();
 #include "bitset.h"
 #include "constants.h"
 #include "dataset.h"
+#include "engine.h"
 #include "errors.h"
 #include "expected.hpp"
 #include "factory.h"

--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -53,14 +53,14 @@ next_multiple_of_power_of_two(uint64_t x, uint64_t n) {
 HGraph::HGraph(const JsonType& index_param, const vsag::IndexCommonParam& common_param) noexcept
     : index_param_(index_param),
       common_param_(common_param),
-      label_lookup_(common_param.allocator_),
-      label_op_mutex_(MAX_LABEL_OPERATION_LOCKS, common_param_.allocator_),
-      neighbors_mutex_(0, common_param_.allocator_),
-      route_graphs_(common_param.allocator_),
-      labels_(common_param.allocator_) {
+      label_lookup_(common_param.allocator_.get()),
+      label_op_mutex_(MAX_LABEL_OPERATION_LOCKS, common_param.allocator_.get()),
+      neighbors_mutex_(0, common_param.allocator_.get()),
+      route_graphs_(common_param.allocator_.get()),
+      labels_(common_param.allocator_.get()) {
     this->dim_ = common_param.dim_;
     this->metric_ = common_param.metric_;
-    this->allocator_ = common_param.allocator_;
+    this->allocator_ = common_param.allocator_.get();
 }
 
 tl::expected<void, Error>

--- a/src/data_cell/flatten_datacell.h
+++ b/src/data_cell/flatten_datacell.h
@@ -130,7 +130,7 @@ template <typename QuantTmpl, typename IOTmpl>
 FlattenDataCell<QuantTmpl, IOTmpl>::FlattenDataCell(const JsonType& quantization_param,
                                                     const JsonType& io_param,
                                                     const IndexCommonParam& common_param)
-    : allocator_(common_param.allocator_) {
+    : allocator_(common_param.allocator_.get()) {
     this->quantizer_ = std::make_shared<QuantTmpl>(quantization_param, common_param);
     this->io_ = std::make_shared<IOTmpl>(io_param, common_param);
     this->code_size_ = quantizer_->GetCodeSize();

--- a/src/data_cell/flatten_datacell_test.cpp
+++ b/src/data_cell/flatten_datacell_test.cpp
@@ -16,6 +16,7 @@
 #include "flatten_datacell.h"
 
 #include <algorithm>
+#include <utility>
 
 #include "catch2/catch_template_test_macros.hpp"
 #include "default_allocator.h"
@@ -23,6 +24,7 @@
 #include "flatten_interface_test.h"
 #include "io/io_headers.h"
 #include "quantization/quantizer_headers.h"
+#include "safe_allocator.h"
 
 using namespace vsag;
 
@@ -36,7 +38,7 @@ TestFlattenDataCell(int dim,
     auto counts = {100, 1000};
     IndexCommonParam common;
     common.dim_ = dim;
-    common.allocator_ = allocator.get();
+    common.allocator_ = std::move(allocator);
     common.metric_ = metric;
     for (auto count : counts) {
         auto flatten =
@@ -67,7 +69,7 @@ TestFlattenDataCellFP32(int dim,
 }
 
 TEST_CASE("fp32", "[ut][flatten_data_cell]") {
-    auto allocator = std::make_shared<DefaultAllocator>();
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
     auto fp32_param = JsonType::parse("{}");
     auto io_param = JsonType::parse("{}");
     auto dims = {8, 64, 512};
@@ -96,7 +98,7 @@ TestFlattenDataCellSQ8(int dim,
 }
 
 TEST_CASE("sq8", "[ut][flatten_data_cell]") {
-    auto allocator = std::make_shared<DefaultAllocator>();
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
     auto sq8_param = JsonType::parse("{}");
     auto io_param = JsonType::parse("{}");
     auto dims = {32, 64, 512};

--- a/src/data_cell/graph_datacell_test.cpp
+++ b/src/data_cell/graph_datacell_test.cpp
@@ -19,6 +19,7 @@
 #include "fmt/format-inl.h"
 #include "graph_interface_test.h"
 #include "io/io_headers.h"
+#include "safe_allocator.h"
 using namespace vsag;
 
 template <typename IOTemp>
@@ -37,7 +38,7 @@ TestGraphDataCell(const JsonType& graph_param,
 }
 
 TEST_CASE("graph basic test", "[ut][graph_datacell]") {
-    auto allocator = std::make_shared<DefaultAllocator>();
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
     auto dims = {32, 64};
     auto max_degrees = {5, 12, 24, 32, 64, 128};
     auto max_capacities = {1, 100, 10000, 10'000'000, 32'179'837};
@@ -58,7 +59,7 @@ TEST_CASE("graph basic test", "[ut][graph_datacell]") {
     for (auto dim : dims) {
         IndexCommonParam param;
         param.dim_ = dim;
-        param.allocator_ = allocator.get();
+        param.allocator_ = allocator;
         for (auto& gp : graph_params) {
             TestGraphDataCell<MemoryIO>(gp, io_param, param);
             TestGraphDataCell<MemoryBlockIO>(gp, io_param, param);

--- a/src/data_cell/graph_interface_test.cpp
+++ b/src/data_cell/graph_interface_test.cpp
@@ -20,12 +20,13 @@
 #include "catch2/catch_test_macros.hpp"
 #include "default_allocator.h"
 #include "fixtures.h"
+#include "safe_allocator.h"
 
 using namespace vsag;
 
 void
 GraphInterfaceTest::BasicTest(uint64_t max_id, uint64_t count, GraphInterfacePtr other) {
-    auto allocator = std::make_shared<DefaultAllocator>();
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
     auto max_degree = this->graph_->MaximumDegree();
     auto old_count = this->graph_->TotalCount();
     UnorderedMap<InnerIdType, std::shared_ptr<Vector<InnerIdType>>> maps(allocator.get());

--- a/src/data_cell/sparse_graph_datacell.cpp
+++ b/src/data_cell/sparse_graph_datacell.cpp
@@ -19,7 +19,7 @@ namespace vsag {
 
 SparseGraphDataCell::SparseGraphDataCell(const JsonType& graph_param,
                                          const IndexCommonParam& common_param)
-    : allocator_(common_param.allocator_), neighbors_(common_param.allocator_) {
+    : allocator_(common_param.allocator_.get()), neighbors_(common_param.allocator_.get()) {
     if (graph_param.contains(GRAPH_PARAM_MAX_DEGREE)) {
         this->maximum_degree_ = graph_param[GRAPH_PARAM_MAX_DEGREE];
     }

--- a/src/data_cell/sparse_graph_datacell_test.cpp
+++ b/src/data_cell/sparse_graph_datacell_test.cpp
@@ -19,6 +19,7 @@
 #include "default_allocator.h"
 #include "fmt/format-inl.h"
 #include "graph_interface_test.h"
+#include "safe_allocator.h"
 
 using namespace vsag;
 
@@ -35,7 +36,7 @@ TestSparseGraphDataCell(const JsonType& graph_param, const IndexCommonParam& par
 }
 
 TEST_CASE("graph basic test", "[ut][sparse_graph_datacell]") {
-    auto allocator = std::make_shared<DefaultAllocator>();
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
     auto dims = {32, 64};
     auto max_degrees = {5, 12, 24, 32, 64, 128};
     auto max_capacities = {1, 100, 10000, 10'000'000, 32'179'837};
@@ -55,7 +56,7 @@ TEST_CASE("graph basic test", "[ut][sparse_graph_datacell]") {
     for (auto dim : dims) {
         IndexCommonParam param;
         param.dim_ = dim;
-        param.allocator_ = allocator.get();
+        param.allocator_ = allocator;
         for (auto& gp : graph_params) {
             TestSparseGraphDataCell(gp, param);
         }

--- a/src/default_allocator.h
+++ b/src/default_allocator.h
@@ -26,16 +26,6 @@ namespace vsag {
 
 class DefaultAllocator : public Allocator {
 public:
-    static std::shared_ptr<Allocator>
-    Instance() {
-        static std::shared_ptr<Allocator> s_instance;
-        if (s_instance == nullptr) {
-            s_instance = std::make_shared<DefaultAllocator>();
-        }
-        return s_instance;
-    }
-
-public:
     DefaultAllocator() = default;
     ~DefaultAllocator() override {
 #ifndef NDEBUG

--- a/src/index/hgraph_index.cpp
+++ b/src/index/hgraph_index.cpp
@@ -18,5 +18,11 @@ namespace vsag {
 HGraphIndex::HGraphIndex(const vsag::JsonType& index_param,
                          const vsag::IndexCommonParam& common_param) noexcept {
     this->hgraph_ = std::make_unique<HGraph>(index_param, common_param);
+    this->allocator_ = common_param.allocator_;
+}
+
+HGraphIndex::~HGraphIndex() {
+    this->hgraph_.reset();
+    this->allocator_.reset();
 }
 }  // namespace vsag

--- a/src/index/hgraph_index.h
+++ b/src/index/hgraph_index.h
@@ -25,6 +25,8 @@ class HGraphIndex : public Index {
 public:
     HGraphIndex(const JsonType& index_param, const IndexCommonParam& common_param) noexcept;
 
+    ~HGraphIndex() override;
+
     tl::expected<void, Error>
     Init() {
         SAFE_CALL(return this->hgraph_->Init());
@@ -141,5 +143,7 @@ public:
 
 private:
     std::unique_ptr<HGraph> hgraph_{nullptr};
+
+    std::shared_ptr<Allocator> allocator_{nullptr};
 };
 }  // namespace vsag

--- a/src/index/hnsw.cpp
+++ b/src/index/hnsw.cpp
@@ -61,11 +61,7 @@ HNSW::HNSW(HnswParameters hnsw_params, const IndexCommonParam& index_common_para
         conjugate_graph_ = std::make_shared<ConjugateGraph>();
     }
 
-    if (not index_common_param.allocator_) {
-        allocator_ = std::make_shared<SafeAllocator>(DefaultAllocator::Instance());
-    } else {
-        allocator_ = std::make_shared<SafeAllocator>(index_common_param.allocator_);
-    }
+    allocator_ = index_common_param.allocator_;
 
     if (!use_static_) {
         alg_hnsw_ =
@@ -276,7 +272,7 @@ HNSW::knn_search(const DatasetPtr& query,
             results.pop();
         }
 
-        result->Dim(results.size())->NumElements(1)->Owner(true, allocator_->GetRawAllocator());
+        result->Dim(results.size())->NumElements(1)->Owner(true, allocator_.get());
 
         int64_t* ids = (int64_t*)allocator_->Allocate(sizeof(int64_t) * results.size());
         result->Ids(ids);
@@ -387,7 +383,7 @@ HNSW::range_search(const DatasetPtr& query,
         if (limited_size >= 1) {
             target_size = std::min((size_t)limited_size, target_size);
         }
-        result->Dim(target_size)->NumElements(1)->Owner(true, allocator_->GetRawAllocator());
+        result->Dim(target_size)->NumElements(1)->Owner(true, allocator_.get());
         int64_t* ids = (int64_t*)allocator_->Allocate(sizeof(int64_t) * target_size);
         result->Ids(ids);
         float* dists = (float*)allocator_->Allocate(sizeof(float) * target_size);
@@ -714,7 +710,7 @@ HNSW::brute_force(const DatasetPtr& query, int64_t k) {
             fmt::format("query.dim({}) must be equal to index.dim({})", query->GetDim(), dim_));
 
         auto result = Dataset::Make();
-        result->NumElements(k)->Owner(true, allocator_->GetRawAllocator());
+        result->NumElements(k)->Owner(true, allocator_.get());
         int64_t* ids = (int64_t*)allocator_->Allocate(sizeof(int64_t) * k);
         result->Ids(ids);
         float* dists = (float*)allocator_->Allocate(sizeof(float) * k);

--- a/src/index/hnsw.h
+++ b/src/index/hnsw.h
@@ -276,7 +276,7 @@ private:
     bool is_init_memory_ = false;
     DataTypes type_;
 
-    std::shared_ptr<SafeAllocator> allocator_;
+    std::shared_ptr<Allocator> allocator_;
 
     mutable std::mutex stats_mutex_;
     mutable std::map<std::string, WindowResultQueue> result_queues_;

--- a/src/index/index_common_param.cpp
+++ b/src/index/index_common_param.cpp
@@ -23,9 +23,9 @@
 namespace vsag {
 
 IndexCommonParam
-IndexCommonParam::CheckAndCreate(JsonType& params, Allocator* allocator) {
+IndexCommonParam::CheckAndCreate(JsonType& params, std::shared_ptr<Allocator> allocator) {
     IndexCommonParam result;
-    result.allocator_ = allocator;
+    result.allocator_ = std::move(allocator);
     // Check DataType
     CHECK_ARGUMENT(params.contains(PARAMETER_DTYPE),
                    fmt::format("parameters must contains {}", PARAMETER_DTYPE));

--- a/src/index/index_common_param.h
+++ b/src/index/index_common_param.h
@@ -29,9 +29,9 @@ public:
     MetricType metric_{MetricType::METRIC_TYPE_L2SQR};
     DataTypes data_type_{DataTypes::DATA_TYPE_FLOAT};
     int64_t dim_{0};
-    Allocator* allocator_{nullptr};
+    std::shared_ptr<Allocator> allocator_{nullptr};
 
     static IndexCommonParam
-    CheckAndCreate(JsonType& params, Allocator* allocator);
+    CheckAndCreate(JsonType& params, std::shared_ptr<Allocator> allocator);
 };
 }  // namespace vsag

--- a/src/io/memory_block_io.h
+++ b/src/io/memory_block_io.h
@@ -41,7 +41,7 @@ public:
     }
 
     MemoryBlockIO(const JsonType& io_param, const IndexCommonParam& common_param)
-        : MemoryBlockIO(common_param.allocator_) {
+        : MemoryBlockIO(common_param.allocator_.get()) {
         if (io_param.contains(BLOCK_IO_BLOCK_SIZE_KEY)) {
             this->block_size_ =
                 io_param[BLOCK_IO_BLOCK_SIZE_KEY];  // TODO(LHT): trans str to uint64_t

--- a/src/io/memory_block_io_test.cpp
+++ b/src/io/memory_block_io_test.cpp
@@ -20,12 +20,14 @@
 
 #include "basic_io_test.h"
 #include "default_allocator.h"
+#include "safe_allocator.h"
+
 using namespace vsag;
 
 auto block_memory_io_block_sizes = {64, 1023, 4096, 123123, 1024 * 1024};
 
 TEST_CASE("read&write [ut][memory_block_io]") {
-    auto allocator = std::make_unique<DefaultAllocator>();
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
     for (auto block_size : block_memory_io_block_sizes) {
         auto io = std::make_unique<MemoryBlockIO>(allocator.get(), block_size);
         TestBasicReadWrite(*io);
@@ -33,7 +35,7 @@ TEST_CASE("read&write [ut][memory_block_io]") {
 }
 
 TEST_CASE("serialize&deserialize [ut][memory_block_io]") {
-    auto allocator = std::make_unique<DefaultAllocator>();
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
     for (auto block_size : block_memory_io_block_sizes) {
         auto wio = std::make_unique<MemoryBlockIO>(allocator.get(), block_size);
         auto rio = std::make_unique<MemoryBlockIO>(allocator.get(), block_size);

--- a/src/io/memory_io.h
+++ b/src/io/memory_io.h
@@ -36,7 +36,7 @@ public:
     }
 
     MemoryIO(const JsonType& io_param, const IndexCommonParam& common_param)
-        : allocator_(common_param.allocator_) {
+        : allocator_(common_param.allocator_.get()) {
         start_ = reinterpret_cast<uint8_t*>(allocator_->Allocate(MIN_SIZE));
         current_size_ = MIN_SIZE;
     }

--- a/src/io/memory_io_test.cpp
+++ b/src/io/memory_io_test.cpp
@@ -20,16 +20,18 @@
 
 #include "basic_io_test.h"
 #include "default_allocator.h"
+#include "safe_allocator.h"
+
 using namespace vsag;
 
 TEST_CASE("read&write [ut][memory_io]") {
-    auto allocator = std::make_unique<DefaultAllocator>();
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
     auto io = std::make_unique<MemoryIO>(allocator.get());
     TestBasicReadWrite(*io);
 }
 
 TEST_CASE("serialize&deserialize [ut][memory_io]") {
-    auto allocator = std::make_unique<DefaultAllocator>();
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
     auto wio = std::make_unique<MemoryIO>(allocator.get());
     auto rio = std::make_unique<MemoryIO>(allocator.get());
     TestSerializeAndDeserialize(*wio, *rio);

--- a/src/quantization/fp32_quantizer.h
+++ b/src/quantization/fp32_quantizer.h
@@ -80,7 +80,7 @@ public:
 template <MetricType metric>
 FP32Quantizer<metric>::FP32Quantizer(const JsonType& quantization_param,
                                      const IndexCommonParam& common_param)
-    : Quantizer<FP32Quantizer<metric>>(common_param.dim_, common_param.allocator_) {
+    : Quantizer<FP32Quantizer<metric>>(common_param.dim_, common_param.allocator_.get()) {
     this->code_size_ = common_param.dim_ * sizeof(float);
 }
 

--- a/src/quantization/fp32_quantizer_test.cpp
+++ b/src/quantization/fp32_quantizer_test.cpp
@@ -21,6 +21,7 @@
 #include "default_allocator.h"
 #include "fixtures.h"
 #include "quantizer_test.h"
+#include "safe_allocator.h"
 
 using namespace vsag;
 
@@ -30,7 +31,7 @@ const auto counts = {10, 101};
 template <MetricType metric>
 void
 TestQuantizerEncodeDecodeMetricFP32(uint64_t dim, int count, float error = 1e-5) {
-    auto allocator = std::make_shared<DefaultAllocator>();
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
     FP32Quantizer<metric> quantizer(dim, allocator.get());
     TestQuantizerEncodeDecode(quantizer, dim, count, error);
     TestQuantizerEncodeDecodeSame(quantizer, dim, count, 65536, error);
@@ -50,7 +51,7 @@ TEST_CASE("encode&decode [ut][fp32_quantizer]") {
 template <MetricType metric>
 void
 TestComputeMetricFP32(uint64_t dim, int count, float error = 1e-5) {
-    auto allocator = std::make_shared<DefaultAllocator>();
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
     FP32Quantizer<metric> quantizer(dim, allocator.get());
     TestComputeCodes<FP32Quantizer<metric>, metric>(quantizer, dim, count, error);
     TestComputeCodesSame<FP32Quantizer<metric>, metric>(quantizer, dim, count, 65536);
@@ -73,7 +74,7 @@ TEST_CASE("compute [ut][fp32_quantizer]") {
 template <MetricType metric>
 void
 TestSerializeAndDeserializeMetricFP32(uint64_t dim, int count, float error = 1e-5) {
-    auto allocator = std::make_shared<DefaultAllocator>();
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
     FP32Quantizer<metric> quantizer1(dim, allocator.get());
     FP32Quantizer<metric> quantizer2(0, allocator.get());
     TestSerializeAndDeserialize<FP32Quantizer<metric>, metric>(

--- a/src/quantization/sq4_quantizer.h
+++ b/src/quantization/sq4_quantizer.h
@@ -90,7 +90,7 @@ SQ4Quantizer<metric>::SQ4Quantizer(int dim, Allocator* allocator)
 template <MetricType metric>
 SQ4Quantizer<metric>::SQ4Quantizer(const JsonType& quantization_param,
                                    const IndexCommonParam& common_param)
-    : SQ4Quantizer<metric>(common_param.dim_, common_param.allocator_){};
+    : SQ4Quantizer<metric>(common_param.dim_, common_param.allocator_.get()){};
 
 template <MetricType metric>
 bool

--- a/src/quantization/sq4_quantizer_test.cpp
+++ b/src/quantization/sq4_quantizer_test.cpp
@@ -21,6 +21,7 @@
 #include "default_allocator.h"
 #include "fixtures.h"
 #include "quantizer_test.h"
+#include "safe_allocator.h"
 
 using namespace vsag;
 
@@ -33,7 +34,7 @@ TestQuantizerEncodeDecodeMetricSQ4(uint64_t dim,
                                    int count,
                                    float error = 1e-5,
                                    float error_same = 1e-2) {
-    auto allocator = std::make_shared<DefaultAllocator>();
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
     SQ4Quantizer<metric> quantizer(dim, allocator.get());
     TestQuantizerEncodeDecode(quantizer, dim, count, error);
     TestQuantizerEncodeDecodeSame(quantizer, dim, count, 15, error_same);
@@ -54,7 +55,7 @@ TEST_CASE("Encode and Decode", "[ut][SQ4Quantizer]") {
 template <MetricType metric>
 void
 TestComputeMetricSQ4(uint64_t dim, int count, float error = 1e-5) {
-    auto allocator = std::make_shared<DefaultAllocator>();
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
     SQ4Quantizer<metric> quantizer(dim, allocator.get());
     TestComputeCodes<SQ4Quantizer<metric>, metric>(quantizer, dim, count, error);
     TestComputer<SQ4Quantizer<metric>, metric>(quantizer, dim, count, error);
@@ -77,7 +78,7 @@ TEST_CASE("compute [ut][sq4_quantizer]") {
 template <MetricType metric>
 void
 TestSerializeAndDeserializeMetricSQ4(uint64_t dim, int count, float error = 1e-5) {
-    auto allocator = std::make_shared<DefaultAllocator>();
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
     SQ4Quantizer<metric> quantizer1(dim, allocator.get());
     SQ4Quantizer<metric> quantizer2(0, allocator.get());
     TestSerializeAndDeserialize<SQ4Quantizer<metric>, metric>(

--- a/src/quantization/sq4_uniform_quantizer.h
+++ b/src/quantization/sq4_uniform_quantizer.h
@@ -137,7 +137,7 @@ SQ4UniformQuantizer<metric>::SQ4UniformQuantizer(int dim, Allocator* allocator)
 template <MetricType metric>
 SQ4UniformQuantizer<metric>::SQ4UniformQuantizer(const JsonType& quantization_param,
                                                  const IndexCommonParam& common_param)
-    : SQ4UniformQuantizer<metric>(common_param.dim_, common_param.allocator_){};
+    : SQ4UniformQuantizer<metric>(common_param.dim_, common_param.allocator_.get()){};
 
 template <MetricType metric>
 bool

--- a/src/quantization/sq4_uniform_quantizer_test.cpp
+++ b/src/quantization/sq4_uniform_quantizer_test.cpp
@@ -21,6 +21,7 @@
 #include "default_allocator.h"
 #include "fixtures.h"
 #include "quantizer_test.h"
+#include "safe_allocator.h"
 
 using namespace vsag;
 
@@ -33,7 +34,7 @@ TestQuantizerEncodeDecodeMetricSQ4Uniform(uint64_t dim,
                                           int count,
                                           float error = 1e-5,
                                           float error_same = 1e-2) {
-    auto allocator = std::make_shared<DefaultAllocator>();
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
     SQ4UniformQuantizer<metric> quantizer(dim, allocator.get());
     TestQuantizerEncodeDecode(quantizer, dim, count, error);
     TestQuantizerEncodeDecodeSame(quantizer, dim, count, 15, error_same);
@@ -54,7 +55,7 @@ TEST_CASE("SQ4 Uniform Encode and Decode", "[ut][SQ4UniformQuantizer]") {
 template <MetricType metric>
 void
 TestComputeMetricSQ4Uniform(uint64_t dim, int count, float error = 1e-5) {
-    auto allocator = std::make_shared<DefaultAllocator>();
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
     SQ4UniformQuantizer<metric> quantizer(dim, allocator.get());
     TestComputeCodesSame<SQ4UniformQuantizer<metric>, metric>(quantizer, dim, count, error);
 }
@@ -73,7 +74,7 @@ TEST_CASE("compute [ut][SQ4UniformQuantizer]") {
 template <MetricType metric>
 void
 TestSerializeAndDeserializeMetricSQ4Uniform(uint64_t dim, int count, float error = 1e-5) {
-    auto allocator = std::make_shared<DefaultAllocator>();
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
     SQ4UniformQuantizer<metric> quantizer1(dim, allocator.get());
     SQ4UniformQuantizer<metric> quantizer2(0, allocator.get());
     TestSerializeAndDeserialize<SQ4UniformQuantizer<metric>, metric, true>(

--- a/src/quantization/sq8_quantizer.h
+++ b/src/quantization/sq8_quantizer.h
@@ -94,9 +94,9 @@ SQ8Quantizer<Metric>::SQ8Quantizer(int dim, Allocator* allocator)
 template <MetricType metric>
 SQ8Quantizer<metric>::SQ8Quantizer(const JsonType& quantization_param,
                                    const IndexCommonParam& common_param)
-    : Quantizer<SQ8Quantizer<metric>>(common_param.dim_, common_param.allocator_),
-      diff_(common_param.allocator_),
-      lower_bound_(common_param.allocator_) {
+    : Quantizer<SQ8Quantizer<metric>>(common_param.dim_, common_param.allocator_.get()),
+      diff_(common_param.allocator_.get()),
+      lower_bound_(common_param.allocator_.get()) {
     // align 64 bytes (512 bits) to avoid illegal memory access in SIMD
     this->code_size_ = this->dim_;
     this->diff_.resize(this->dim_, 0);

--- a/src/quantization/sq8_quantizer_test.cpp
+++ b/src/quantization/sq8_quantizer_test.cpp
@@ -21,6 +21,7 @@
 #include "default_allocator.h"
 #include "fixtures.h"
 #include "quantizer_test.h"
+#include "safe_allocator.h"
 
 using namespace vsag;
 
@@ -32,7 +33,7 @@ TestQuantizerEncodeDecodeMetricSQ8(uint64_t dim,
                                    int count,
                                    float error = 1e-5,
                                    float error_same = 1e-2) {
-    auto allocator = std::make_shared<DefaultAllocator>();
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
     SQ8Quantizer<metric> quantizer(dim, allocator.get());
     TestQuantizerEncodeDecode(quantizer, dim, count, error);
     TestQuantizerEncodeDecodeSame(quantizer, dim, count, 255, error_same);
@@ -54,7 +55,7 @@ TEST_CASE("encode&decode [SQ8Quantizer]") {
 template <MetricType metric>
 void
 TestComputeMetricSQ8(uint64_t dim, int count, float error = 1e-5) {
-    auto allocator = std::make_shared<DefaultAllocator>();
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
     SQ8Quantizer<metric> quantizer(dim, allocator.get());
     TestComputeCodes<SQ8Quantizer<metric>, metric>(quantizer, dim, count, error);
     TestComputer<SQ8Quantizer<metric>, metric>(quantizer, dim, count, error);
@@ -77,7 +78,7 @@ TEST_CASE("compute [ut][sq8_quantizer]") {
 template <MetricType metric>
 void
 TestSerializeAndDeserializeMetricSQ8(uint64_t dim, int count, float error = 1e-5) {
-    auto allocator = std::make_shared<DefaultAllocator>();
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
     SQ8Quantizer<metric> quantizer1(dim, allocator.get());
     SQ8Quantizer<metric> quantizer2(0, allocator.get());
     TestSerializeAndDeserialize<SQ8Quantizer<metric>, metric>(

--- a/src/quantization/sq8_uniform_quantizer.h
+++ b/src/quantization/sq8_uniform_quantizer.h
@@ -124,7 +124,7 @@ SQ8UniformQuantizer<metric>::SQ8UniformQuantizer(int dim, Allocator* allocator)
 template <MetricType metric>
 SQ8UniformQuantizer<metric>::SQ8UniformQuantizer(const JsonType& quantization_param,
                                                  const IndexCommonParam& common_param)
-    : SQ8UniformQuantizer<metric>(common_param.dim_, common_param.allocator_){};
+    : SQ8UniformQuantizer<metric>(common_param.dim_, common_param.allocator_.get()){};
 
 template <MetricType metric>
 bool

--- a/src/quantization/sq8_uniform_quantizer_test.cpp
+++ b/src/quantization/sq8_uniform_quantizer_test.cpp
@@ -21,6 +21,7 @@
 #include "default_allocator.h"
 #include "fixtures.h"
 #include "quantizer_test.h"
+#include "safe_allocator.h"
 
 using namespace vsag;
 
@@ -33,7 +34,7 @@ TestQuantizerEncodeDecodeMetricSQ8Uniform(uint64_t dim,
                                           int count,
                                           float error = 1e-5,
                                           float error_same = 1e-2) {
-    auto allocator = std::make_shared<DefaultAllocator>();
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
     SQ8UniformQuantizer<metric> quantizer(dim, allocator.get());
     TestQuantizerEncodeDecode(quantizer, dim, count, error);
     TestQuantizerEncodeDecodeSame(quantizer, dim, count, 255, error_same);
@@ -54,7 +55,7 @@ TEST_CASE("SQ8 Uniform Encode and Decode", "[ut][SQ8UniformQuantizer]") {
 template <MetricType metric>
 void
 TestComputeMetricSQ8Uniform(uint64_t dim, int count, float error = 1e-5) {
-    auto allocator = std::make_shared<DefaultAllocator>();
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
     SQ8UniformQuantizer<metric> quantizer(dim, allocator.get());
     TestComputeCodesSame<SQ8UniformQuantizer<metric>, metric>(quantizer, dim, count, error);
 }
@@ -73,7 +74,7 @@ TEST_CASE("compute [ut][SQ8UniformQuantizer]") {
 template <MetricType metric>
 void
 TestSerializeAndDeserializeMetricSQ8Uniform(uint64_t dim, int count, float error = 1e-5) {
-    auto allocator = std::make_shared<DefaultAllocator>();
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
     SQ8UniformQuantizer<metric> quantizer1(dim, allocator.get());
     SQ8UniformQuantizer<metric> quantizer2(0, allocator.get());
     TestSerializeAndDeserialize<SQ8UniformQuantizer<metric>, metric, true>(

--- a/src/resource.cpp
+++ b/src/resource.cpp
@@ -21,7 +21,7 @@
 namespace vsag {
 Resource::Resource(Allocator* allocator) {
     if (allocator == nullptr) {
-        this->allocator = std::make_shared<SafeAllocator>(new DefaultAllocator(), true);
+        this->allocator = SafeAllocator::FactoryDefaultAllocator();
     } else {
         this->allocator = std::make_shared<SafeAllocator>(allocator, false);
     }

--- a/src/resource_owner_wrapper.h
+++ b/src/resource_owner_wrapper.h
@@ -24,6 +24,11 @@ public:
         : resource_(resource), owned_(owned) {
     }
 
+    std::shared_ptr<Allocator>
+    GetAllocator() override {
+        return resource_->GetAllocator();
+    }
+
     ~ResourceOwnerWrapper() override {
         if (owned_) {
             delete resource_;

--- a/tests/test_engine.cpp
+++ b/tests/test_engine.cpp
@@ -1,0 +1,82 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <catch2/catch_test_macros.hpp>
+#include <iostream>
+#include <nlohmann/json.hpp>
+
+#include "vsag/vsag.h"
+
+TEST_CASE("index params", "[ft][engine]") {
+    int dim = 16;
+    int max_elements = 1000;
+    int max_degree = 16;
+    int ef_construction = 100;
+    int ef_search = 100;
+
+    nlohmann::json hnsw_parameters{
+        {"max_degree", max_degree},
+        {"ef_construction", ef_construction},
+        {"ef_search", ef_search},
+    };
+    nlohmann::json index_parameters{
+        {"dtype", "float32"}, {"metric_type", "l2"}, {"dim", dim}, {"hnsw", hnsw_parameters}};
+
+    vsag::Engine engine;
+
+    std::shared_ptr<vsag::Index> hnsw;
+    auto index = engine.CreateIndex("hnsw", index_parameters.dump());
+    REQUIRE(index.has_value());
+    hnsw = index.value();
+    // Generate random data
+    std::mt19937 rng(97);
+    std::uniform_real_distribution<float> distrib_real;
+    auto* ids = new int64_t[max_elements];
+    auto* data = new float[dim * max_elements];
+    for (int i = 0; i < max_elements; i++) {
+        ids[i] = i;
+    }
+    for (int i = 0; i < dim * max_elements; i++) {
+        data[i] = distrib_real(rng);
+    }
+
+    auto dataset = vsag::Dataset::Make();
+    dataset->Dim(dim)->NumElements(max_elements)->Ids(ids)->Float32Vectors(data);
+    hnsw->Build(dataset);
+
+    // Query the elements for themselves and measure recall 1@1
+    float correct = 0;
+    for (int i = 0; i < max_elements; i++) {
+        auto query = vsag::Dataset::Make();
+        query->NumElements(1)->Dim(dim)->Float32Vectors(data + i * dim)->Owner(false);
+
+        nlohmann::json parameters{
+            {"hnsw", {{"ef_search", ef_search}}},
+        };
+        int64_t k = 10;
+        if (auto result = hnsw->KnnSearch(query, k, parameters.dump()); result.has_value()) {
+            if (result.value()->GetIds()[0] == i) {
+                correct++;
+            }
+        } else if (result.error().type == vsag::ErrorType::INTERNAL_ERROR) {
+            std::cerr << "failed to search on index: internalError" << std::endl;
+        }
+    }
+    float recall = correct / static_cast<float>(max_elements);
+
+    REQUIRE(recall == 1);
+
+    engine.Shutdown();
+}


### PR DESCRIPTION
issue: #203

- allocator shared_ptr hold in Index and Dataset
- the allocator ptr always point to SafeAllocator
- allocator ptr is used inner index
- only Engine/Resource can create Allocator Object
