### PR TITLE
use Catch2::UNSCOPED_INFO to make tests output clear

### DIFF
--- a/extern/diskann/DiskANN/src/index.cpp
+++ b/extern/diskann/DiskANN/src/index.cpp
@@ -1149,8 +1149,8 @@ size_t Index<T, TagT, LabelT>::load_graph(std::stringstream &in, size_t expected
         }
     }
 
-    diskann::cout << "load graph done. Index has " << nodes_read << " nodes and " << cc << " out-edges, _start is set to "
-                  << _start << std::endl;
+    // diskann::cout << "load graph done. Index has " << nodes_read << " nodes and " << cc << " out-edges, _start is set to "
+    //               << _start << std::endl;
     return nodes_read;
 }
 

--- a/src/algorithm/hnswlib/hnswalg_static.h
+++ b/src/algorithm/hnswlib/hnswalg_static.h
@@ -1784,8 +1784,8 @@ public:
             if (use_node_centroid)
                 node_cluster_dist_[i] = dist_to_centroid;
         }
-        std::cout << "encode HNSW finished with ave encode loss:: "
-                  << ave_encode_loss / (float)(right_range - left_range) << std::endl;
+        // std::cout << "encode HNSW finished with ave encode loss:: "
+        //           << ave_encode_loss / (float)(right_range - left_range) << std::endl;
     }
 
     void

--- a/src/bitset_impl_test.cpp
+++ b/src/bitset_impl_test.cpp
@@ -70,14 +70,14 @@ TEST_CASE("roaringbitmap example", "[ut][bitset]") {
     r1.setCopyOnWrite(true);
 
     uint32_t compact_size = r1.getSizeInBytes();
-    std::cout << "size before run optimize " << size << " bytes, and after " << compact_size
-              << " bytes." << std::endl;
+    // std::cout << "size before run optimize " << size << " bytes, and after " << compact_size
+    //           << " bytes." << std::endl;
 
     // create a new bitmap with varargs
     Roaring r2 = Roaring::bitmapOf(5, 1, 2, 3, 5, 6);
 
-    r2.printf();
-    printf("\n");
+    // r2.printf();
+    // printf("\n");
 
     // create a new bitmap with initializer list
     Roaring r2i = Roaring::bitmapOfList({1, 2, 3, 5, 6});

--- a/src/index/diskann_test.cpp
+++ b/src/index/diskann_test.cpp
@@ -534,6 +534,6 @@ TEST_CASE("split building process", "[diskann][ut]") {
         }
     }
     float recall_full = correct / 1000;
-    std::cout << "Recall: " << recall_full << std::endl;
+    vsag::logger::debug("Recall: " + std::to_string(recall_full));
     REQUIRE(recall_full == recall_partial);
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,6 +2,7 @@
 #  unittests
 file (GLOB_RECURSE UNIT_TESTS "../src/*_test.cpp")
 add_executable (unittests ${UNIT_TESTS}
+        test_main.cpp
         fixtures/fixtures.cpp
 )
 if (DIST_CONTAINS_SSE)
@@ -17,7 +18,7 @@ if (DIST_CONTAINS_AVX512)
     target_compile_definitions (unittests PRIVATE ENABLE_AVX512=1)
 endif ()
 target_include_directories (unittests PRIVATE "./fixtures")
-target_link_libraries (unittests PRIVATE Catch2::Catch2WithMain vsag simd)
+target_link_libraries (unittests PRIVATE Catch2::Catch2 vsag simd)
 add_dependencies (unittests spdlog Catch2)
 
 # function tests
@@ -31,5 +32,5 @@ add_executable (functests
 target_include_directories (functests PRIVATE
         ${CMAKE_CURRENT_BINARY_DIR}/spdlog/install/include
         ${HDF5_INCLUDE_DIRS})
-target_link_libraries (functests PRIVATE Catch2::Catch2WithMain vsag simd)
+target_link_libraries (functests PRIVATE Catch2::Catch2 vsag simd)
 add_dependencies (functests spdlog Catch2)

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -1,0 +1,85 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <catch2/catch_session.hpp>
+
+#include "catch2/catch_message.hpp"
+#include "vsag/vsag.h"
+
+// custom logger
+class TestLogger : public vsag::Logger {
+public:
+    inline void
+    SetLevel(Level log_level) override {
+        level_ = log_level - vsag::Logger::Level::kTRACE;
+    }
+
+    inline void
+    Trace(const std::string& msg) override {
+        if (level_ <= 0) {
+            UNSCOPED_INFO("[test-logger]::[trace] " + msg);
+        }
+    }
+
+    inline void
+    Debug(const std::string& msg) override {
+        if (level_ <= 1) {
+            UNSCOPED_INFO("[test-logger]::[debug] " + msg);
+        }
+    }
+
+    inline void
+    Info(const std::string& msg) override {
+        if (level_ <= 2) {
+            UNSCOPED_INFO("[test-logger]::[info] " + msg);
+        }
+    }
+
+    inline void
+    Warn(const std::string& msg) override {
+        if (level_ <= 3) {
+            UNSCOPED_INFO("[test-logger]::[warn] " + msg);
+        }
+    }
+
+    inline void
+    Error(const std::string& msg) override {
+        if (level_ <= 4) {
+            UNSCOPED_INFO("[test-logger]::[error] " + msg);
+        }
+    }
+
+    void
+    Critical(const std::string& msg) override {
+        if (level_ <= 5) {
+            UNSCOPED_INFO("[test-logger]::[critical] " + msg);
+        }
+    }
+
+    int64_t level_ = 0;
+};
+
+int
+main(int argc, char** argv) {
+    // your setup ...
+    TestLogger logger;
+    vsag::Options::Instance().set_logger(&logger);
+
+    int result = Catch::Session().run(argc, argv);
+
+    // your clean-up...
+
+    return result;
+}


### PR DESCRIPTION
- test will only output logs in failure case
- Catch2::UNSCOPED_INFO (https://github.com/catchorg/Catch2/blob/devel/docs/logging.md)
- comment some logs