### PR TITLE
upgrade the lcov version in github ci

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,10 +1,14 @@
 
 # Configuration for CodeCov
 codecov:
+  max_report_age: off
   require_ci_to_pass: no
   notify:
     require_ci_to_pass: no
     wait_for_ci: false
+fixes:
+  - "/__w/vsag/::/"
+
 coverage:
   precision: 2
   round: down
@@ -22,7 +26,7 @@ coverage:
         if_ci_failed: error
 
 comment:
-  layout: "reach, diff, flags, files"
+  layout: "header, diff, files, footer"
   behavior: default
   require_changes: false
   branches:

--- a/.github/workflows/lcov.yml
+++ b/.github/workflows/lcov.yml
@@ -19,7 +19,7 @@ jobs:
           apt update
           apt install -y libcapture-tiny-perl libdatetime-perl curl jq
           git clone https://github.com/linux-test-project/lcov.git
-          cd lcov && git checkout v2.2 && make install
+          cd lcov && git checkout v2.3 && make install
           lcov --version
       - name: Compile with Coverage Flags
         run: make cov
@@ -28,12 +28,15 @@ jobs:
           ./scripts/test_parallel_bg.sh
           ./build/mockimpl/tests_mockimpl -d yes ${UT_FILTER} --allow-running-no-tests ${UT_SHARD}
       - name: Collect Coverage Info
-        run: bash scripts/collect_cpp_coverage.sh
+        run: |
+          bash scripts/collect_cpp_coverage.sh
+          head -n10 coverage/coverage.info
       - name: Upload Coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: true
           files: coverage/coverage.info
+          disable_search: true
           flags: cpp
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true

--- a/scripts/collect_cpp_coverage.sh
+++ b/scripts/collect_cpp_coverage.sh
@@ -4,7 +4,8 @@ set -e
 set -x
 
 SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-ROOT_DIR="${SCRIPTS_DIR}/../"
+ROOT_DIR="$( cd "${SCRIPTS_DIR}/../" && pwd )"
+PARENT_DIR="$( cd "${ROOT_DIR}/../" && pwd )"
 
 COVERAGE_DIR="${ROOT_DIR}/coverage"
 if [ -d "${COVERAGE_DIR}" ]; then
@@ -13,17 +14,25 @@ else
     mkdir -p "${COVERAGE_DIR}"
 fi
 
+pushd "${PARENT_DIR}"
 lcov --rc branch_coverage=1 \
      --rc geninfo_unexecuted_blocks=1 \
      --parallel 8 \
-     --directory . \
+     --directory vsag \
      --capture \
+     --substitute "s#${PARENT_DIR}/##g" \
      --ignore-errors mismatch,mismatch \
      --ignore-errors count,count \
      --output-file ${COVERAGE_DIR}/coverage.info
-
-lcov --remove ${COVERAGE_DIR}/coverage.info '/usr/*' '*/build/*' '*/vsag/tests/*' --ignore-errors inconsistent,inconsistent --output-file ${COVERAGE_DIR}/coverage.info
-lcov --list ${COVERAGE_DIR}/coverage.info --ignore-errors inconsistent,inconsistent
+lcov --remove ${COVERAGE_DIR}/coverage.info \
+     '/usr/*' \
+     'vsag/build/*' \
+     'vsag/tests/*' \
+     --ignore-errors inconsistent,inconsistent \
+     --output-file ${COVERAGE_DIR}/coverage.info
+lcov --list ${COVERAGE_DIR}/coverage.info \
+     --ignore-errors inconsistent,inconsistent
+popd
 
 pushd "${COVERAGE_DIR}"
 coverages=$(ls coverage.info)


### PR DESCRIPTION
there is a coverage results collection issue in v2.2 of lcov, so we decided to upgrade the version lcov.