### PR TITLE
Add a batch interface for getDistanceByLabel 

### DIFF
--- a/include/vsag/index.h
+++ b/include/vsag/index.h
@@ -250,6 +250,19 @@ public:
     };
 
     /**
+     * @brief Calculate the distance between the query and the vector of the given ID for batch.
+     *
+     * @param query is the embedding of query
+     * @param ids is the unique identifier of the vector to be calculated in the index.
+     * @param count is the count of ids
+     * @return result is valid distance of input ids. '-1' indicates an invalid distance.
+     */
+    virtual tl::expected<DatasetPtr, Error>
+    CalDistanceById(const float* query, const int64_t* ids, int64_t count) const {
+        throw std::runtime_error("Index doesn't support get distance by id");
+    };
+
+    /**
      * @brief Checks if the specified feature is supported by the index.
      *
      * This method checks whether the given `feature` is supported by the index.

--- a/src/algorithm/hnswlib/algorithm_interface.h
+++ b/src/algorithm/hnswlib/algorithm_interface.h
@@ -24,6 +24,9 @@
 #include "space_interface.h"
 #include "stream_reader.h"
 #include "typing.h"
+#include "vsag/dataset.h"
+#include "vsag/errors.h"
+#include "vsag/expected.hpp"
 
 namespace hnswlib {
 
@@ -65,6 +68,9 @@ public:
 
     virtual float
     getDistanceByLabel(LabelType label, const void* data_point) = 0;
+
+    virtual tl::expected<vsag::DatasetPtr, vsag::Error>
+    getBatchDistanceByLabel(const int64_t* ids, const void* data_point, int64_t count) = 0;
 
     virtual const float*
     getDataByLabel(LabelType label) const = 0;

--- a/src/algorithm/hnswlib/hnswalg.h
+++ b/src/algorithm/hnswlib/hnswalg.h
@@ -38,6 +38,7 @@
 #include "algorithm_interface.h"
 #include "block_manager.h"
 #include "visited_list_pool.h"
+#include "vsag/dataset.h"
 namespace hnswlib {
 using InnerIdType = vsag::InnerIdType;
 using linklistsizeint = unsigned int;
@@ -145,6 +146,9 @@ public:
 
     float
     getDistanceByLabel(LabelType label, const void* data_point) override;
+
+    tl::expected<vsag::DatasetPtr, vsag::Error>
+    getBatchDistanceByLabel(const int64_t* ids, const void* data_point, int64_t count) override;
 
     bool
     isValidLabel(LabelType label) override;

--- a/src/index/hnsw.h
+++ b/src/index/hnsw.h
@@ -148,6 +148,11 @@ public:
         SAFE_CALL(return alg_hnsw_->getDistanceByLabel(id, vector));
     };
 
+    virtual tl::expected<DatasetPtr, Error>
+    CalDistanceById(const float* vector, const int64_t* ids, int64_t count) const override {
+        SAFE_CALL(return alg_hnsw_->getBatchDistanceByLabel(ids, vector, count));
+    };
+
     [[nodiscard]] bool
     CheckFeature(IndexFeature feature) const override;
 

--- a/tests/test_hnsw_new.cpp
+++ b/tests/test_hnsw_new.cpp
@@ -335,6 +335,46 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Update Id", "[ft][hn
     }
 }
 
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Batch Calc Dis Id", "[ft][hnsw]") {
+    auto origin_size = vsag::Options::Instance().block_size_limit();
+    auto size = GENERATE(1024 * 1024 * 2);
+    auto metric_type = GENERATE("l2", "ip", "cosine");
+    const std::string name = "hnsw";
+    auto search_param = fmt::format(search_param_tmp, 100);
+    for (auto& dim : dims) {
+        vsag::Options::Instance().set_block_size_limit(size);
+        auto param = GenerateHNSWBuildParametersString(metric_type, dim);
+        auto index = TestFactory(name, param, true);
+        auto dataset = pool.GetDatasetAndCreate(dim, base_count, metric_type);
+        TestBuildIndex(index, dataset, true);
+        TestBatchCalcDistanceById(index, dataset);
+        vsag::Options::Instance().set_block_size_limit(origin_size);
+    }
+}
+
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex,
+                             "static HNSW Batch Calc Dis Id",
+                             "[ft][hnsw]") {
+    auto origin_size = vsag::Options::Instance().block_size_limit();
+    auto size = GENERATE(1024 * 1024 * 2);
+    auto metric_type = GENERATE("l2");
+    auto use_static = GENERATE(true);
+    const std::string name = "hnsw";
+    auto search_param = fmt::format(search_param_tmp, 100);
+    for (auto& dim : dims) {
+        if (dim % 4 != 0) {
+            dim = ((dim / 4) + 1) * 4;
+        }
+        vsag::Options::Instance().set_block_size_limit(size);
+        auto param = GenerateHNSWBuildParametersString(metric_type, dim, use_static);
+        auto index = TestFactory(name, param, true);
+        auto dataset = pool.GetDatasetAndCreate(dim, base_count, metric_type);
+        TestBuildIndex(index, dataset, true);
+        TestBatchCalcDistanceById(index, dataset);
+        vsag::Options::Instance().set_block_size_limit(origin_size);
+    }
+}
+
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Update Vector", "[ft][hnsw]") {
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);

--- a/tests/test_index.h
+++ b/tests/test_index.h
@@ -117,6 +117,11 @@ protected:
     TestCalcDistanceById(const IndexPtr& index, const TestDatasetPtr& dataset, float error = 1e-5);
 
     static void
+    TestBatchCalcDistanceById(const IndexPtr& index,
+                              const TestDatasetPtr& dataset,
+                              float error = 1e-5);
+
+    static void
     TestSerializeFile(const IndexPtr& index_from,
                       const IndexPtr& index_to,
                       const TestDatasetPtr& dataset,


### PR DESCRIPTION
Add a batch interface for getDistanceByLabel
* param count is the count of vids
* param vids is the unique identifier of the vector to be calculated in the index.
* param vector is the embedding of query
* param distances is the distances between the query and the vector of the given ID
* return result is valid distance of input vids.

virtual tl::expected<int64_t, Error>CalcBatchDistanceById(int64_t count, const int64_t vids, const float vector, float *&distances)