### PR TITLE
use CHECK instead of REQUIRE for some index tests

### DIFF
--- a/tests/test_index.cpp
+++ b/tests/test_index.cpp
@@ -311,7 +311,8 @@ TestIndex::TestKnnSearch(const IndexPtr& index,
         auto val = Intersection(gt, gt_topK, result, topk);
         cur_recall += static_cast<float>(val) / static_cast<float>(gt_topK);
     }
-    REQUIRE(cur_recall > expected_recall * query_count);
+    CHECK(cur_recall > expected_recall * query_count);
+    REQUIRE(cur_recall > expected_recall * query_count * RECALL_THRESHOLD);
 }
 
 void
@@ -347,7 +348,8 @@ TestIndex::TestRangeSearch(const IndexPtr& index,
         auto val = Intersection(gt, gt_topK, result, res.value()->GetDim());
         cur_recall += static_cast<float>(val) / static_cast<float>(gt_topK);
     }
-    REQUIRE(cur_recall > expected_recall * query_count);
+    CHECK(cur_recall > expected_recall * query_count);
+    REQUIRE(cur_recall > expected_recall * query_count * RECALL_THRESHOLD);
 }
 void
 TestIndex::TestFilterSearch(const TestIndex::IndexPtr& index,
@@ -379,7 +381,8 @@ TestIndex::TestFilterSearch(const TestIndex::IndexPtr& index,
         auto val = Intersection(gt, gt_topK, result, topk);
         cur_recall += static_cast<float>(val) / static_cast<float>(gt_topK);
     }
-    REQUIRE(cur_recall > expected_recall * query_count);
+    CHECK(cur_recall > expected_recall * query_count);
+    REQUIRE(cur_recall > expected_recall * query_count * RECALL_THRESHOLD);
 }
 
 void
@@ -605,7 +608,8 @@ TestIndex::TestConcurrentKnnSearch(const TestIndex::IndexPtr& index,
     }
 
     auto cur_recall = std::accumulate(search_results.begin(), search_results.end(), 0.0f);
-    REQUIRE(cur_recall > expected_recall * query_count);
+    CHECK(cur_recall > expected_recall * query_count);
+    REQUIRE(cur_recall > expected_recall * query_count * RECALL_THRESHOLD);
 }
 
 void
@@ -684,8 +688,10 @@ TestIndex::TestEstimateMemory(const std::string& index_name,
             auto build_index = index->Build(dataset->base_);
             REQUIRE(build_index.has_value());
             auto real_memory = allocator->GetCurrentMemory();
-            REQUIRE(estimate_memory >= static_cast<uint64_t>(real_memory * 0.8));
-            REQUIRE(estimate_memory <= static_cast<uint64_t>(real_memory * 1.2));
+            CHECK(estimate_memory >= static_cast<uint64_t>(real_memory * 0.8));
+            CHECK(estimate_memory <= static_cast<uint64_t>(real_memory * 1.2));
+            REQUIRE(estimate_memory >= static_cast<uint64_t>(real_memory * 0.5));
+            REQUIRE(estimate_memory <= static_cast<uint64_t>(real_memory * 1.5));
         }
     }
 }

--- a/tests/test_index.h
+++ b/tests/test_index.h
@@ -153,6 +153,8 @@ protected:
 
     static void
     TestCheckIdExist(const IndexPtr& index, const TestDatasetPtr& dataset);
+
+    constexpr static float RECALL_THRESHOLD = 0.95;
 };
 
 }  // namespace fixtures


### PR DESCRIPTION
- recall & estimate memory use CHECK