### PR TITLE
[skip ci] Refresh example code link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ add_dependencies (vsag-cmake-example vsag)
 
 Currently Python and C++ examples are provided, please explore [examples](./examples/) directory for details.
 
-We suggest you start with [simple_hnsw.cpp](./examples/cpp/simple_hnsw.cpp) and [example_hnsw.py](./examples/python/example_hnsw.py).
+We suggest you start with [101_index_hnsw.cpp](./examples/cpp/101_index_hnsw.cpp) and [example_hnsw.py](./examples/python/example_hnsw.py).
 
 ## Building from Source
 Please read the [DEVELOPMENT](./DEVELOPMENT.md) guide for instructions on how to build.


### PR DESCRIPTION
After PR #364 was merged, the example code file link `simple_hnsw.cpp` in the README became invalid because the file was deleted in that PR. 
https://github.com/antgroup/vsag/blob/7524c1a3ba54d93e69da32a991b906efd58c83f8/README.md?plain=1#L62
So, I made modifications to refresh the link to [101_index_hnsw.cpp](https://github.com/antgroup/vsag/blob/main/examples/cpp/101_index_hnsw.cpp).