### PR TITLE
fix: Add missing <functional> header for readerset.h

### DIFF
--- a/include/vsag/readerset.h
+++ b/include/vsag/readerset.h
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <string>
 #include <tuple>


### PR DESCRIPTION
This PR resolves the issue of missing `<functional>` header, which is required for using `std::function`
in the definition of the `CallBack` type alias. 
Although `<functional>` is included in all scenarios where `CallBack` is currently referenced, so it doesn't lead to compilation errors. However, for the sake of code robustness and portability, I think that the `<functional>` header file should be added to the definition header file itself of `readerset.h`.