### PR TITLE
fix compiler issues when using clang make libcxx

### DIFF
--- a/src/io/buffer_io_test.cpp
+++ b/src/io/buffer_io_test.cpp
@@ -35,7 +35,7 @@ TEST_CASE("buffer io param", "[ut][buffer_io]") {
     fixtures::TempDir dir("buffer_io");
     auto path = dir.GenerateRandomFile();
     auto allocator = SafeAllocator::FactoryDefaultAllocator();
-    std::string param_str = R"(
+    constexpr static const char* param_str = R"(
     {{
         "type": "buffer_io",
         "file_path" : "{}"

--- a/src/io/memory_block_io.h
+++ b/src/io/memory_block_io.h
@@ -80,9 +80,22 @@ public:
     }
 
 private:
+    inline int
+    countr_zero(uint64_t x) {
+        if (x == 0)
+            return 64;
+
+        int count = 0;
+        while ((x & 1) == 0) {
+            x >>= 1;
+            ++count;
+        }
+        return count;
+    }
+
     inline void
     update_by_block_size() {
-        block_bit_ = std::__countr_zero(block_size_);
+        block_bit_ = countr_zero(block_size_);
         in_block_mask_ = block_size_ - 1;
     }
 


### PR DESCRIPTION
fix #405

std::countr_zero available since C++20: https://en.cppreference.com/w/cpp/numeric/countr_zero