### PR TITLE
Support iter filter search

### DIFF
--- a/examples/cpp/309_feature_iter_filter.cpp
+++ b/examples/cpp/309_feature_iter_filter.cpp
@@ -1,0 +1,355 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <vsag/vsag.h>
+
+#include <iostream>
+
+void
+hnsw_iter_filter() {
+    /******************* Prepare Base Dataset *****************/
+    int64_t num_vectors = 10000;
+    int64_t dim = 128;
+    auto ids = new int64_t[num_vectors];
+    auto vectors = new float[dim * num_vectors];
+
+    std::mt19937 rng;
+    rng.seed(47);
+    std::uniform_real_distribution<> distrib_real;
+    for (int64_t i = 0; i < num_vectors; ++i) {
+        ids[i] = i;
+    }
+    for (int64_t i = 0; i < dim * num_vectors; ++i) {
+        vectors[i] = distrib_real(rng);
+    }
+    auto base = vsag::Dataset::Make();
+    // Transfer the ownership of the data (ids, vectors) to the base.
+    base->NumElements(num_vectors)->Dim(dim)->Ids(ids)->Float32Vectors(vectors);
+
+    /******************* Create HNSW Index *****************/
+    // hnsw_build_parameters is the configuration for building an HNSW index.
+    // The "dtype" specifies the data type, which supports float32 and int8.
+    // The "metric_type" indicates the distance metric type (e.g., cosine, inner product, and L2).
+    // The "dim" represents the dimensionality of the vectors, indicating the number of features for each data point.
+    // The "hnsw" section contains parameters specific to HNSW:
+    // - "max_degree": The maximum number of connections for each node in the graph.
+    // - "ef_construction": The size used for nearest neighbor search during graph construction, which affects both speed and the quality of the graph.
+    auto hnsw_build_paramesters = R"(
+    {
+        "dtype": "float32",
+        "metric_type": "l2",
+        "dim": 128,
+        "hnsw": {
+            "max_degree": 16,
+            "ef_construction": 100
+        }
+    }
+    )";
+    auto index = vsag::Factory::CreateIndex("hnsw", hnsw_build_paramesters).value();
+
+    /******************* Build HNSW Index *****************/
+    if (auto build_result = index->Build(base); build_result.has_value()) {
+        std::cout << "After Build(), Index HNSW contains: " << index->GetNumElements() << std::endl;
+    } else {
+        std::cerr << "Failed to build index: " << build_result.error().message << std::endl;
+        exit(-1);
+    }
+
+    /******************* KnnSearch For HNSW Index *****************/
+    auto query_vector = new float[dim];
+    for (int64_t i = 0; i < dim; ++i) {
+        query_vector[i] = distrib_real(rng);
+    }
+
+    // hnsw_search_parameters is the configuration for searching in an HNSW index.
+    // The "hnsw" section contains parameters specific to the search operation:
+    // - "ef_search": The size of the dynamic list used for nearest neighbor search, which influences both recall and search speed.
+    auto hnsw_search_parameters = R"(
+    {
+        "hnsw": {
+            "ef_search": 100
+        }
+    }
+    )";
+    int64_t topk = 10;
+    auto query = vsag::Dataset::Make();
+    query->NumElements(1)->Dim(dim)->Float32Vectors(query_vector)->Owner(true);
+
+    /******************* Prepare Filter Object *****************/
+    class MyFilter : public vsag::Filter {
+    public:
+        bool
+        CheckValid(int64_t id) const override {
+            return id % 2;
+        }
+
+        float
+        ValidRatio() const override {
+            return 0.618f;
+        }
+    };
+    auto filter_object = std::make_shared<MyFilter>();
+    std::unordered_map<int64_t, bool> myMap;
+
+    /******************* Print Search Result All topK * 2 *****************/
+    auto time7 = std::chrono::steady_clock::now();
+    auto knn_result0 = index->KnnSearch(query, topk * 2, hnsw_search_parameters, filter_object);
+    auto time8 = std::chrono::steady_clock::now();
+    std::chrono::duration<double, std::milli> duration0 = time8 - time7;
+    std::cout << "knn_result0: " << duration0.count() << std::endl;
+    if (knn_result0.has_value()) {
+        auto result = knn_result0.value();
+        std::cout << "results0: " << std::endl;
+        for (int64_t i = 0; i < result->GetDim(); ++i) {
+            std::cout << result->GetIds()[i] << ": " << result->GetDistances()[i] << std::endl;
+        }
+    } else {
+        std::cerr << "Search Error: " << knn_result0.error().message << std::endl;
+    }
+
+    vsag::IteratorContextPtr filter_ctx = nullptr;
+    /******************* Search And Print Result1 *****************/
+    auto time0 = std::chrono::steady_clock::now();
+    auto knn_result =
+        index->KnnSearch(query, topk, hnsw_search_parameters, filter_object, &filter_ctx, false);
+    auto time1 = std::chrono::steady_clock::now();
+    std::chrono::duration<double, std::milli> duration = time1 - time0;
+    std::cout << "knn_result1: " << duration.count() << std::endl;
+
+    if (knn_result.has_value()) {
+        auto result = knn_result.value();
+        std::cout << "results1: " << std::endl;
+        for (int64_t i = 0; i < result->GetDim(); ++i) {
+            myMap[result->GetIds()[i]] = true;
+            std::cout << result->GetIds()[i] << ": " << result->GetDistances()[i] << std::endl;
+        }
+    } else {
+        std::cerr << "Search Error: " << knn_result.error().message << std::endl;
+    }
+
+    /******************* Search And Print Result2 *****************/
+    auto time3 = std::chrono::steady_clock::now();
+    auto knn_result2 =
+        index->KnnSearch(query, topk, hnsw_search_parameters, filter_object, &filter_ctx, false);
+
+    auto time4 = std::chrono::steady_clock::now();
+    duration = time4 - time3;
+    std::cout << "knn_result2: " << duration.count() << std::endl;
+
+    if (knn_result2.has_value()) {
+        auto result = knn_result2.value();
+        std::cout << "results2: " << std::endl;
+        for (int64_t i = 0; i < result->GetDim(); ++i) {
+            auto it = myMap.find(result->GetIds()[i]);
+            if (it == myMap.end()) {
+                myMap[result->GetIds()[i]] = true;
+                std::cout << result->GetIds()[i] << ": " << result->GetDistances()[i] << std::endl;
+            } else {
+                std::cerr << "Search Duplicate: " << result->GetIds()[i] << std::endl;
+            }
+        }
+    } else {
+        std::cerr << "Search Error: " << knn_result2.error().message << std::endl;
+    }
+
+    /******************* Search And Print Result3 *****************/
+    auto time5 = std::chrono::steady_clock::now();
+    auto knn_result3 =
+        index->KnnSearch(query, topk, hnsw_search_parameters, filter_object, &filter_ctx, true);
+
+    auto time6 = std::chrono::steady_clock::now();
+    duration = time6 - time5;
+    std::cout << "knn_result3: " << duration.count() << std::endl;
+
+    if (knn_result3.has_value()) {
+        auto result = knn_result3.value();
+        std::cout << "results3: " << std::endl;
+        for (int64_t i = 0; i < result->GetDim(); ++i) {
+            auto it = myMap.find(result->GetIds()[i]);
+            if (it == myMap.end()) {
+                myMap[result->GetIds()[i]] = true;
+                std::cout << result->GetIds()[i] << ": " << result->GetDistances()[i] << std::endl;
+            } else {
+                std::cerr << "Search Duplicate: " << result->GetIds()[i] << std::endl;
+            }
+        }
+    } else {
+        std::cerr << "Search Error: " << knn_result3.error().message << std::endl;
+    }
+}
+
+void
+hgraph_iter_filter() {
+    vsag::init();
+
+    /******************* Prepare Base Dataset *****************/
+    int64_t num_vectors = 10000;
+    int64_t dim = 128;
+    std::vector<int64_t> ids(num_vectors);
+    std::vector<float> datas(num_vectors * dim);
+    std::mt19937 rng(47);
+    std::uniform_real_distribution<float> distrib_real;
+    for (int64_t i = 0; i < num_vectors; ++i) {
+        ids[i] = i;
+    }
+    for (int64_t i = 0; i < dim * num_vectors; ++i) {
+        datas[i] = distrib_real(rng);
+    }
+    auto base = vsag::Dataset::Make();
+    base->NumElements(num_vectors)
+        ->Dim(dim)
+        ->Ids(ids.data())
+        ->Float32Vectors(datas.data())
+        ->Owner(false);
+
+    /******************* Create HGraph Index *****************/
+    std::string hgraph_build_parameters = R"(
+    {
+        "dtype": "float32",
+        "metric_type": "l2",
+        "dim": 128,
+        "index_param": {
+            "base_quantization_type": "sq8",
+            "max_degree": 26,
+            "ef_construction": 100
+        }
+    }
+    )";
+    vsag::Engine engine;
+    auto index = engine.CreateIndex("hgraph", hgraph_build_parameters).value();
+
+    /******************* Build HGraph Index *****************/
+    if (auto build_result = index->Build(base); build_result.has_value()) {
+        std::cout << "After Build(), Index HGraph contains: " << index->GetNumElements()
+                  << std::endl;
+    } else if (build_result.error().type == vsag::ErrorType::INTERNAL_ERROR) {
+        std::cerr << "Failed to build index: internalError" << std::endl;
+        exit(-1);
+    }
+
+    /******************* Prepare Query Dataset *****************/
+    std::vector<float> query_vector(dim);
+    for (int64_t i = 0; i < dim; ++i) {
+        query_vector[i] = distrib_real(rng);
+    }
+    auto query = vsag::Dataset::Make();
+    query->NumElements(1)->Dim(dim)->Float32Vectors(query_vector.data())->Owner(false);
+
+    vsag::IteratorContextPtr iter_ctx = nullptr;
+
+    /******************* Prepare Filter Object *****************/
+    class MyFilter : public vsag::Filter {
+    public:
+        bool
+        CheckValid(int64_t id) const override {
+            return id % 2;
+        }
+
+        float
+        ValidRatio() const override {
+            return 0.618f;
+        }
+    };
+    auto filter_object = std::make_shared<MyFilter>();
+    std::unordered_map<int64_t, bool> myMap;
+
+    /******************* KnnSearch For HGraph Index *****************/
+    auto hgraph_search_parameters = R"(
+    {
+        "hgraph": {
+            "ef_search": 100
+        }
+    }
+    )";
+    int64_t topk = 10;
+
+    /******************* Search And Print Result1 *****************/
+    auto result1 =
+        index->KnnSearch(query, topk, hgraph_search_parameters, filter_object, &iter_ctx, false);
+
+    if (result1.has_value()) {
+        auto result = result1.value();
+        std::cout << "results1: " << std::endl;
+        for (int64_t i = 0; i < result->GetDim(); ++i) {
+            myMap[result->GetIds()[i]] = true;
+            std::cout << result->GetIds()[i] << ": " << result->GetDistances()[i] << std::endl;
+        }
+    } else {
+        std::cerr << "Search Error: " << result1.error().message << std::endl;
+    }
+
+    /******************* Search And Print Result2 *****************/
+    auto result2 =
+        index->KnnSearch(query, topk, hgraph_search_parameters, filter_object, &iter_ctx, false);
+
+    if (result2.has_value()) {
+        auto result = result2.value();
+        std::cout << "results2: " << std::endl;
+        for (int64_t i = 0; i < result->GetDim(); ++i) {
+            auto it = myMap.find(result->GetIds()[i]);
+            if (it == myMap.end()) {
+                myMap[result->GetIds()[i]] = true;
+                std::cout << result->GetIds()[i] << ": " << result->GetDistances()[i] << std::endl;
+            } else {
+                std::cerr << "Search Duplicate: " << result->GetIds()[i] << std::endl;
+            }
+        }
+    } else {
+        std::cerr << "Search Error: " << result2.error().message << std::endl;
+    }
+
+    /******************* Search And Print Result3 *****************/
+    auto result3 =
+        index->KnnSearch(query, topk, hgraph_search_parameters, filter_object, &iter_ctx, true);
+
+    if (result3.has_value()) {
+        auto result = result3.value();
+        std::cout << "results3: " << std::endl;
+        for (int64_t i = 0; i < result->GetDim(); ++i) {
+            auto it = myMap.find(result->GetIds()[i]);
+            if (it == myMap.end()) {
+                myMap[result->GetIds()[i]] = true;
+                std::cout << result->GetIds()[i] << ": " << result->GetDistances()[i] << std::endl;
+            } else {
+                std::cerr << "Search Duplicate: " << result->GetIds()[i] << std::endl;
+            }
+        }
+    } else {
+        std::cerr << "Search Error: " << result3.error().message << std::endl;
+    }
+
+    /******************* Print Search Result All *****************/
+    auto new_filter = [filter_object](int64_t id) -> bool { return filter_object->CheckValid(id); };
+    auto result0 = index->KnnSearch(query, topk * 3, hgraph_search_parameters, new_filter);
+
+    if (result0.has_value()) {
+        auto result = result0.value();
+        std::cout << "results: " << std::endl;
+        for (int64_t i = 0; i < result->GetDim(); ++i) {
+            std::cout << result->GetIds()[i] << ": " << result->GetDistances()[i] << std::endl;
+        }
+    } else {
+        std::cerr << "Search Error: " << result0.error().message << std::endl;
+    }
+
+    engine.Shutdown();
+}
+
+int
+main(int argc, char** argv) {
+    hnsw_iter_filter();
+    hgraph_iter_filter();
+    return 0;
+}

--- a/examples/cpp/309_feature_iter_filter.cpp
+++ b/examples/cpp/309_feature_iter_filter.cpp
@@ -66,6 +66,9 @@ hnsw_iter_filter() {
         std::cerr << "Failed to build index: " << build_result.error().message << std::endl;
         exit(-1);
     }
+    int64_t min, max;
+    index->GetMinAndMaxId(min, max);
+    std::cout << "Min: " << min << " " << "Max: " << max << std::endl;
 
     /******************* KnnSearch For HNSW Index *****************/
     auto query_vector = new float[dim];
@@ -238,6 +241,9 @@ hgraph_iter_filter() {
         std::cerr << "Failed to build index: internalError" << std::endl;
         exit(-1);
     }
+    int64_t min, max;
+    index->GetMinAndMaxId(min, max);
+    std::cout << "Min: " << min << "Max: " << max << std::endl;
 
     /******************* Prepare Query Dataset *****************/
     std::vector<float> query_vector(dim);

--- a/examples/cpp/309_feature_iter_filter.cpp
+++ b/examples/cpp/309_feature_iter_filter.cpp
@@ -68,7 +68,8 @@ hnsw_iter_filter() {
     }
     int64_t min, max;
     index->GetMinAndMaxId(min, max);
-    std::cout << "Min: " << min << " " << "Max: " << max << std::endl;
+    std::cout << "Min: " << min << " "
+              << "Max: " << max << std::endl;
 
     /******************* KnnSearch For HNSW Index *****************/
     auto query_vector = new float[dim];
@@ -243,7 +244,8 @@ hgraph_iter_filter() {
     }
     int64_t min, max;
     index->GetMinAndMaxId(min, max);
-    std::cout << "Min: " << min << "Max: " << max << std::endl;
+    std::cout << "Min: " << min << " "
+              << "Max: " << max << std::endl;
 
     /******************* Prepare Query Dataset *****************/
     std::vector<float> query_vector(dim);

--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -37,6 +37,9 @@ target_link_libraries(304_feature_enhance_graph vsag)
 add_executable(305_feature_update 305_feature_update.cpp)
 target_link_libraries(305_feature_update vsag)
 
+add_executable(309_feature_iter_filter 309_feature_iter_filter.cpp)
+target_link_libraries(309_feature_iter_filter vsag)
+
 add_executable (401_persistent_kv 401_persistent_kv.cpp)
 target_link_libraries (401_persistent_kv vsag)
 

--- a/include/vsag/index.h
+++ b/include/vsag/index.h
@@ -333,9 +333,16 @@ public:
         throw std::runtime_error("Index doesn't support get distance by id");
     };
 
+    /**
+     * @brief Calculate the maximum and minimum labels.
+     *
+     * @param min_id The minimum id returned
+     * @param max_id The maximum id returned
+     * @param count is the count of ids
+     */
     virtual tl::expected<void, Error>
     GetMinAndMaxId(int64_t& min_id, int64_t& max_id) const {
-        throw std::runtime_error("Index doesn't support get distance by id");
+        throw std::runtime_error("Index doesn't support get Min and Max id");
     };
 
     /**

--- a/include/vsag/index.h
+++ b/include/vsag/index.h
@@ -30,6 +30,7 @@
 #include "vsag/expected.hpp"
 #include "vsag/filter.h"
 #include "vsag/index_features.h"
+#include "vsag/iterator_context.h"
 #include "vsag/readerset.h"
 
 namespace vsag {
@@ -171,6 +172,27 @@ public:
     }
 
     /**
+      * @brief Performing single KNN search on index
+      *
+      * @param query should contains dim, num_elements and vectors
+      * @param k the result size of every query
+      * @param filter represents whether an element is filtered out by pre-filter
+      * @param iter_ctx iterative filter context
+      * @return result contains
+      *                - num_elements: 1
+      *                - ids, distances: length is (num_elements * k)
+      */
+    virtual tl::expected<DatasetPtr, Error>
+    KnnSearch(const DatasetPtr& query,
+              int64_t k,
+              const std::string& parameters,
+              const FilterPtr& filter,
+              vsag::IteratorContextPtr* iter_ctx,
+              bool is_last_search) const {
+        throw std::runtime_error("Index doesn't support new filter");
+    }
+
+    /**
       * @brief Performing single range search on index
       *
       * @param query should contains dim, num_elements and vectors
@@ -308,6 +330,11 @@ public:
      */
     virtual tl::expected<DatasetPtr, Error>
     CalDistanceById(const float* query, const int64_t* ids, int64_t count) const {
+        throw std::runtime_error("Index doesn't support get distance by id");
+    };
+
+    virtual tl::expected<void, Error>
+    GetMinAndMaxId(int64_t& min_id, int64_t& max_id) const {
         throw std::runtime_error("Index doesn't support get distance by id");
     };
 

--- a/include/vsag/iterator_context.h
+++ b/include/vsag/iterator_context.h
@@ -1,0 +1,59 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include <memory>
+namespace vsag {
+
+class IteratorContext {
+public:
+    virtual ~IteratorContext() = default;
+    virtual void
+    AddDiscardNode(float dis, uint32_t id) {};
+    virtual uint32_t
+    GetTopID() {
+        return 0;
+    };
+    virtual float
+    GetTopDist() {
+        return 0;
+    };
+    virtual void
+    PopDiscard() {};
+    virtual bool
+    Empty() {
+        return true;
+    };
+    virtual bool
+    IsFirstUsed() {
+        return true;
+    };
+    virtual void
+    SetOFFFirstUsed() {};
+    virtual void
+    SetPoint(uint32_t id) {};
+    virtual bool
+    CheckPoint(uint32_t id) {
+        return false;
+    };
+    virtual int64_t
+    GetDiscardElementNum() {
+        return false;
+    };
+};
+
+using IteratorContextPtr = std::shared_ptr<IteratorContext>;
+
+};  // namespace vsag

--- a/include/vsag/iterator_context.h
+++ b/include/vsag/iterator_context.h
@@ -21,7 +21,7 @@ class IteratorContext {
 public:
     virtual ~IteratorContext() = default;
     virtual void
-    AddDiscardNode(float dis, uint32_t id) {};
+    AddDiscardNode(float dis, uint32_t id){};
     virtual uint32_t
     GetTopID() {
         return 0;
@@ -31,7 +31,7 @@ public:
         return 0;
     };
     virtual void
-    PopDiscard() {};
+    PopDiscard(){};
     virtual bool
     Empty() {
         return true;
@@ -41,9 +41,9 @@ public:
         return true;
     };
     virtual void
-    SetOFFFirstUsed() {};
+    SetOFFFirstUsed(){};
     virtual void
-    SetPoint(uint32_t id) {};
+    SetPoint(uint32_t id){};
     virtual bool
     CheckPoint(uint32_t id) {
         return false;

--- a/src/algorithm/brute_force.cpp
+++ b/src/algorithm/brute_force.cpp
@@ -71,7 +71,9 @@ DatasetPtr
 BruteForce::KnnSearch(const DatasetPtr& query,
                       int64_t k,
                       const std::string& parameters,
-                      const FilterPtr& filter) const {
+                      const FilterPtr& filter,
+                      vsag::IteratorContextPtr* filter_ctx,
+                      bool is_last_filter) const {
     auto computer = this->inner_codes_->FactoryComputer(query->GetFloat32Vectors());
     auto heap = std::make_shared<StandardHeap<true, true>>(this->allocator_, k);
     for (InnerIdType i = 0; i < total_count_; ++i) {

--- a/src/algorithm/brute_force.h
+++ b/src/algorithm/brute_force.h
@@ -57,7 +57,9 @@ public:
     KnnSearch(const DatasetPtr& query,
               int64_t k,
               const std::string& parameters,
-              const FilterPtr& filter) const override;
+              const FilterPtr& filter,
+              vsag::IteratorContextPtr* filter_ctx = nullptr,
+              bool is_last_filter = false) const override;
 
     DatasetPtr
     RangeSearch(const DatasetPtr& query,

--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -482,7 +482,7 @@ HGraph::CalcDistanceById(const float* query, int64_t id) const {
     }
 }
 tl::expected<void, Error>
-HGraph::getMinAndMaxId(int64_t& min_id, int64_t& max_id) const {
+HGraph::GetMinAndMaxId(int64_t& min_id, int64_t& max_id) const {
     min_id = INT64_MAX;
     max_id = INT64_MIN;
     std::shared_lock<std::shared_mutex> lock(this->label_lookup_mutex_);

--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -486,11 +486,9 @@ HGraph::GetMinAndMaxId(int64_t& min_id, int64_t& max_id) const {
     min_id = INT64_MAX;
     max_id = INT64_MIN;
     std::shared_lock<std::shared_mutex> lock(this->label_lookup_mutex_);
-    for (auto it = this->label_table_->label_remap_.begin();
-         it != this->label_table_->label_remap_.end();
-         ++it) {
-        max_id = it->first > max_id ? it->first : max_id;
-        min_id = it->first < min_id ? it->first : min_id;
+    for (auto& it : this->label_table_->label_remap_) {
+        max_id = it.first > max_id ? it.first : max_id;
+        min_id = it.first < min_id ? it.first : min_id;
     }
     return {};
 }

--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -24,6 +24,7 @@
 #include "data_cell/sparse_graph_datacell.h"
 #include "empty_index_binary_set.h"
 #include "impl/pruning_strategy.h"
+#include "index/iterator_filter.h"
 #include "logger.h"
 #include "utils/slow_task_timer.h"
 #include "utils/util_functions.h"
@@ -110,7 +111,9 @@ DatasetPtr
 HGraph::KnnSearch(const DatasetPtr& query,
                   int64_t k,
                   const std::string& parameters,
-                  const FilterPtr& filter) const {
+                  const FilterPtr& filter,
+                  vsag::IteratorContextPtr* iter_ctx,
+                  bool is_last_filter) const {
     std::shared_ptr<CommonInnerIdFilter> ft = nullptr;
     if (filter != nullptr) {
         ft = std::make_shared<CommonInnerIdFilter>(filter, *this->label_table_);
@@ -125,31 +128,57 @@ HGraph::KnnSearch(const DatasetPtr& query,
     // check query vector
     CHECK_ARGUMENT(query->GetNumElements() == 1, "query dataset should contain 1 vector only");
 
-    InnerSearchParam search_param;
-    search_param.ep = this->entry_point_id_;
-    search_param.ef = 1;
-    search_param.is_inner_id_allowed = nullptr;
-    for (auto i = static_cast<int64_t>(this->route_graphs_.size() - 1); i >= 0; --i) {
-        auto result = this->search_one_graph(query->GetFloat32Vectors(),
-                                             this->route_graphs_[i],
-                                             this->basic_flatten_codes_,
-                                             search_param);
-        search_param.ep = result.top().second;
-    }
-
     auto params = HGraphSearchParameters::FromJson(parameters);
 
-    search_param.ef = std::max(params.ef_search, k);
-    search_param.is_inner_id_allowed = ft;
-    search_param.topk = static_cast<int64_t>(search_param.ef);
-    auto search_result = this->search_one_graph(
-        query->GetFloat32Vectors(), this->bottom_graph_, this->basic_flatten_codes_, search_param);
+    if (iter_ctx != nullptr && *iter_ctx == nullptr) {
+        auto cur_count = this->bottom_graph_->TotalCount();
+        auto filter_context = std::make_shared<IteratorFilterContext>();
+        filter_context->init(cur_count, params.ef_search, allocator_);
+        *iter_ctx = filter_context;
+    }
+
+    MaxHeap search_result(allocator_);
+    if (is_last_filter && iter_ctx != nullptr) {
+        while (!(*iter_ctx)->Empty()) {
+            uint32_t cur_inner_id = (*iter_ctx)->GetTopID();
+            float cur_dist = (*iter_ctx)->GetTopDist();
+            search_result.emplace(cur_dist, cur_inner_id);
+            (*iter_ctx)->PopDiscard();
+        }
+    } else {
+        InnerSearchParam search_param;
+        search_param.ep = this->entry_point_id_;
+        search_param.ef = 1;
+        search_param.is_inner_id_allowed = nullptr;
+        if (iter_ctx == nullptr || (iter_ctx != nullptr && (*iter_ctx)->IsFirstUsed())) {
+            for (auto i = static_cast<int64_t>(this->route_graphs_.size() - 1); i >= 0; --i) {
+                auto result = this->search_one_graph(query->GetFloat32Vectors(),
+                                                     this->route_graphs_[i],
+                                                     this->basic_flatten_codes_,
+                                                     search_param);
+                search_param.ep = result.top().second;
+            }
+        }
+
+        search_param.ef = std::max(params.ef_search, k);
+        search_param.is_inner_id_allowed = ft;
+        search_param.topk = static_cast<int64_t>(search_param.ef);
+        search_result = this->search_one_graph(query->GetFloat32Vectors(),
+                                               this->bottom_graph_,
+                                               this->basic_flatten_codes_,
+                                               search_param,
+                                               iter_ctx);
+    }
 
     if (use_reorder_) {
         this->reorder(query->GetFloat32Vectors(), this->high_precise_codes_, search_result, k);
     }
 
     while (search_result.size() > k) {
+        if (iter_ctx != nullptr) {
+            std::pair<float, InnerIdType> curr = search_result.top();
+            (*iter_ctx)->AddDiscardNode(curr.first, curr.second);
+        }
         search_result.pop();
     }
 
@@ -164,7 +193,13 @@ HGraph::KnnSearch(const DatasetPtr& query,
     for (int64_t j = count - 1; j >= 0; --j) {
         dists[j] = search_result.top().first;
         ids[j] = this->label_table_->GetLabelById(search_result.top().second);
+        if (iter_ctx != nullptr) {
+            (*iter_ctx)->SetPoint(search_result.top().second);
+        }
         search_result.pop();
+    }
+    if (iter_ctx != nullptr) {
+        (*iter_ctx)->SetOFFFirstUsed();
     }
     return std::move(dataset_results);
 }
@@ -276,9 +311,11 @@ MaxHeap
 HGraph::search_one_graph(const float* query,
                          const GraphInterfacePtr& graph,
                          const FlattenInterfacePtr& flatten,
-                         InnerSearchParam& inner_search_param) const {
+                         InnerSearchParam& inner_search_param,
+                         vsag::IteratorContextPtr* iter_ctx) const {
     auto visited_list = this->pool_->TakeOne();
-    auto result = this->searcher_->Search(graph, flatten, visited_list, query, inner_search_param);
+    auto result =
+        this->searcher_->Search(graph, flatten, visited_list, query, inner_search_param, iter_ctx);
     this->pool_->ReturnOne(visited_list);
     return result;
 }
@@ -443,6 +480,19 @@ HGraph::CalcDistanceById(const float* query, int64_t id) const {
         flat->Query(&result, computer, &new_id, 1);
         return result;
     }
+}
+tl::expected<void, Error>
+HGraph::getMinAndMaxId(int64_t& min_id, int64_t& max_id) const {
+    min_id = INT64_MAX;
+    max_id = INT64_MIN;
+    std::shared_lock<std::shared_mutex> lock(this->label_lookup_mutex_);
+    for (auto it = this->label_table_->label_remap_.begin();
+         it != this->label_table_->label_remap_.end();
+         ++it) {
+        max_id = it->first > max_id ? it->first : max_id;
+        min_id = it->first < min_id ? it->first : min_id;
+    }
+    return {};
 }
 
 DatasetPtr

--- a/src/algorithm/hgraph.h
+++ b/src/algorithm/hgraph.h
@@ -71,7 +71,9 @@ public:
     KnnSearch(const DatasetPtr& query,
               int64_t k,
               const std::string& parameters,
-              const FilterPtr& filter) const override;
+              const FilterPtr& filter,
+              vsag::IteratorContextPtr* filter_ctx = nullptr,
+              bool is_last_filter = false) const override;
 
     [[nodiscard]] DatasetPtr
     RangeSearch(const DatasetPtr& query,
@@ -102,6 +104,9 @@ public:
 
     float
     CalcDistanceById(const float* query, int64_t id) const override;
+
+    tl::expected<void, Error>
+    getMinAndMaxId(int64_t& min_id, int64_t& max_id) const;
 
     DatasetPtr
     CalDistanceById(const float* query, const int64_t* ids, int64_t count) const override;
@@ -134,7 +139,8 @@ private:
     search_one_graph(const float* query,
                      const GraphInterfacePtr& graph,
                      const FlattenInterfacePtr& flatten,
-                     InnerSearchParam& inner_search_param) const;
+                     InnerSearchParam& inner_search_param,
+                     vsag::IteratorContextPtr* iter_ctx = nullptr) const;
     void
     serialize_basic_info(StreamWriter& writer) const;
 

--- a/src/algorithm/hgraph.h
+++ b/src/algorithm/hgraph.h
@@ -72,7 +72,7 @@ public:
               int64_t k,
               const std::string& parameters,
               const FilterPtr& filter,
-              vsag::IteratorContextPtr* filter_ctx = nullptr,
+              vsag::IteratorContextPtr* iter_ctx = nullptr,
               bool is_last_filter = false) const override;
 
     [[nodiscard]] DatasetPtr

--- a/src/algorithm/hgraph.h
+++ b/src/algorithm/hgraph.h
@@ -106,7 +106,7 @@ public:
     CalcDistanceById(const float* query, int64_t id) const override;
 
     tl::expected<void, Error>
-    getMinAndMaxId(int64_t& min_id, int64_t& max_id) const;
+    GetMinAndMaxId(int64_t& min_id, int64_t& max_id) const override;
 
     DatasetPtr
     CalDistanceById(const float* query, const int64_t* ids, int64_t count) const override;

--- a/src/algorithm/hnswlib/algorithm_interface.h
+++ b/src/algorithm/hnswlib/algorithm_interface.h
@@ -27,6 +27,7 @@
 #include "vsag/dataset.h"
 #include "vsag/errors.h"
 #include "vsag/expected.hpp"
+#include "vsag/iterator_context.h"
 
 namespace hnswlib {
 
@@ -43,7 +44,9 @@ public:
               size_t k,
               size_t ef,
               const vsag::FilterPtr is_id_allowed = nullptr,
-              float skip_ratio = 0.9f) const = 0;
+              float skip_ratio = 0.9f,
+              vsag::IteratorContextPtr* iter_ctx = nullptr,
+              bool is_last_filter = false) const = 0;
 
     virtual std::priority_queue<std::pair<dist_t, LabelType>>
     searchRange(const void* query_data,
@@ -69,6 +72,9 @@ public:
 
     virtual float
     getDistanceByLabel(LabelType label, const void* data_point) = 0;
+
+    virtual void
+    getMinAndMaxId(int64_t& min_id, int64_t& max_id) = 0;
 
     virtual tl::expected<vsag::DatasetPtr, vsag::Error>
     getBatchDistanceByLabel(const int64_t* ids, const void* data_point, int64_t count) = 0;

--- a/src/algorithm/hnswlib/hnswalg.cpp
+++ b/src/algorithm/hnswlib/hnswalg.cpp
@@ -24,6 +24,7 @@
 
 namespace hnswlib {
 
+const static InnerIdType UNUSED_ENTRY_POINT_NODE = 0;
 HierarchicalNSW::HierarchicalNSW(SpaceInterface* s,
                                  size_t max_elements,
                                  vsag::Allocator* allocator,
@@ -177,6 +178,17 @@ HierarchicalNSW::getDistanceByLabel(LabelType label, const void* data_point) {
     normalizeVector(data_point, normalize_query);
     float dist = fstdistfunc_(data_point, getDataByInternalId(internal_id), dist_func_param_);
     return dist;
+}
+
+void
+HierarchicalNSW::getMinAndMaxId(int64_t& min_id, int64_t& max_id) {
+    min_id = INT64_MAX;
+    max_id = INT64_MIN;
+    std::shared_lock lock_table(label_lookup_lock_);
+    for (auto it = label_lookup_.begin(); it != label_lookup_.end(); ++it) {
+        max_id = it->first > max_id ? it->first : max_id;
+        min_id = it->first < min_id ? it->first : min_id;
+    }
 }
 
 tl::expected<vsag::DatasetPtr, vsag::Error>
@@ -419,7 +431,8 @@ HierarchicalNSW::searchBaseLayerST(InnerIdType ep_id,
                                    const void* data_point,
                                    size_t ef,
                                    const vsag::FilterPtr is_id_allowed,
-                                   const float skip_ratio) const {
+                                   const float skip_ratio,
+                                   vsag::IteratorContextPtr* iter_ctx) const {
     vsag::LinearCongruentialGenerator generator;
     VisitedListPtr vl = visited_list_pool_->getFreeVisitedList();
     vl_type* visited_array = vl->mass;
@@ -429,21 +442,36 @@ HierarchicalNSW::searchBaseLayerST(InnerIdType ep_id,
     MaxHeap candidate_set(allocator_);
 
     float valid_ratio = is_id_allowed ? is_id_allowed->ValidRatio() : 1.0F;
-    float skip_threshold = (1 - valid_ratio) * skip_ratio;
+    float skip_threshold = 1 - ((1 - valid_ratio) * skip_ratio);
 
     float lower_bound;
-    if ((!has_deletions || !isMarkedDeleted(ep_id)) &&
-        ((!is_id_allowed) || is_id_allowed->CheckValid(getExternalLabel(ep_id)))) {
-        float dist = fstdistfunc_(data_point, getDataByInternalId(ep_id), dist_func_param_);
-        lower_bound = dist;
-        top_candidates.emplace(dist, ep_id);
-        candidate_set.emplace(-dist, ep_id);
+    if (iter_ctx != nullptr && !(*iter_ctx)->IsFirstUsed()) {
+        lower_bound = 0.0;
+        while (!(*iter_ctx)->Empty()) {
+            uint32_t cur_inner_id = (*iter_ctx)->GetTopID();
+            float cur_dist = (*iter_ctx)->GetTopDist();
+            if (visited_array[cur_inner_id] != visited_array_tag &&
+                (*iter_ctx)->CheckPoint(cur_inner_id)) {
+                visited_array[cur_inner_id] = visited_array_tag;
+                top_candidates.emplace(cur_dist, cur_inner_id);
+                candidate_set.emplace(-cur_dist, cur_inner_id);
+                lower_bound = std::max(lower_bound, cur_dist);
+            }
+            (*iter_ctx)->PopDiscard();
+        }
     } else {
-        lower_bound = std::numeric_limits<float>::max();
-        candidate_set.emplace(-lower_bound, ep_id);
+        if ((!has_deletions || !isMarkedDeleted(ep_id)) &&
+            ((!is_id_allowed) || is_id_allowed->CheckValid(getExternalLabel(ep_id)))) {
+            float dist = fstdistfunc_(data_point, getDataByInternalId(ep_id), dist_func_param_);
+            lower_bound = dist;
+            top_candidates.emplace(dist, ep_id);
+            candidate_set.emplace(-dist, ep_id);
+        } else {
+            lower_bound = std::numeric_limits<float>::max();
+            candidate_set.emplace(-lower_bound, ep_id);
+        }
+        visited_array[ep_id] = visited_array_tag;
     }
-
-    visited_array[ep_id] = visited_array_tag;
 
     while (not candidate_set.empty()) {
         std::pair<float, InnerIdType> current_node_pair = candidate_set.top();
@@ -491,8 +519,9 @@ HierarchicalNSW::searchBaseLayerST(InnerIdType ep_id,
                     not is_id_allowed->CheckValid(getExternalLabel(candidate_id))) {
                     continue;
                 }
+                float dist = 0;
                 char* currObj1 = getDataByInternalId(candidate_id);
-                float dist = fstdistfunc_(data_point, currObj1, dist_func_param_);
+                dist = fstdistfunc_(data_point, currObj1, dist_func_param_);
                 if (top_candidates.size() < ef || lower_bound > dist) {
                     candidate_set.emplace(-dist, candidate_id);
                     vector_data_ptr = data_level0_memory_->GetElementPtr(candidate_set.top().second,
@@ -503,11 +532,20 @@ HierarchicalNSW::searchBaseLayerST(InnerIdType ep_id,
 
                     if ((!has_deletions || !isMarkedDeleted(candidate_id)) &&
                         ((!is_id_allowed) ||
-                         is_id_allowed->CheckValid(getExternalLabel(candidate_id))))
+                         is_id_allowed->CheckValid(getExternalLabel(candidate_id)))) {
+                        if (iter_ctx != nullptr && !(*iter_ctx)->CheckPoint(candidate_id)) {
+                            continue;
+                        }
                         top_candidates.emplace(dist, candidate_id);
+                    }
 
-                    if (top_candidates.size() > ef)
+                    if (top_candidates.size() > ef) {
+                        auto cur_node_pair = top_candidates.top();
+                        if (iter_ctx != nullptr && (*iter_ctx)->CheckPoint(cur_node_pair.second)) {
+                            (*iter_ctx)->AddDiscardNode(cur_node_pair.first, cur_node_pair.second);
+                        }
                         top_candidates.pop();
+                    }
 
                     if (not top_candidates.empty())
                         lower_bound = top_candidates.top().first;
@@ -1424,7 +1462,9 @@ HierarchicalNSW::searchKnn(const void* query_data,
                            size_t k,
                            uint64_t ef,
                            const vsag::FilterPtr is_id_allowed,
-                           const float skip_ratio) const {
+                           const float skip_ratio,
+                           vsag::IteratorContextPtr* iter_ctx,
+                           bool is_last_filter) const {
     std::shared_lock resize_lock(resize_mutex_);
     std::priority_queue<std::pair<float, LabelType>> result;
     if (cur_element_count_ == 0)
@@ -1432,59 +1472,88 @@ HierarchicalNSW::searchKnn(const void* query_data,
 
     std::shared_ptr<float[]> normalize_query;
     normalizeVector(query_data, normalize_query);
-    int64_t currObj;
-    {
-        std::shared_lock data_loc(max_level_mutex_);
-        currObj = enterpoint_node_;
-    }
-    if (currObj > cur_element_count_) {
-        return result;
-    }
+    MaxHeap top_candidates(allocator_);
+    if (iter_ctx != nullptr && !(*iter_ctx)->IsFirstUsed()) {
+        if ((*iter_ctx)->Empty())
+            return result;
+        if (is_last_filter) {
+            while (!(*iter_ctx)->Empty()) {
+                uint32_t cur_inner_id = (*iter_ctx)->GetTopID();
+                float cur_dist = (*iter_ctx)->GetTopDist();
+                result.emplace(cur_dist, getExternalLabel(cur_inner_id));
+                (*iter_ctx)->PopDiscard();
+            }
+            return result;
+        }
+        top_candidates = searchBaseLayerST<false, true>(UNUSED_ENTRY_POINT_NODE,
+                                                        query_data,
+                                                        std::max(ef, k),
+                                                        is_id_allowed,
+                                                        skip_ratio,
+                                                        iter_ctx);
+    } else {
+        int64_t currObj;
+        {
+            std::shared_lock data_loc(max_level_mutex_);
+            currObj = enterpoint_node_;
+        }
+        if (currObj > cur_element_count_) {
+            return result;
+        }
 
-    float curdist = fstdistfunc_(query_data, getDataByInternalId(currObj), dist_func_param_);
-    for (int level = max_level_; level > 0; level--) {
-        bool changed = true;
-        while (changed) {
-            changed = false;
-            auto link_data = getLinklistAtLevelWithLock(currObj, level);
-            auto* data = (unsigned int*)link_data.get();
-            int size = getListCount(data);
-            //            metric_hops_++;
-            //            metric_distance_computations_ += size;
+        float curdist = fstdistfunc_(query_data, getDataByInternalId(currObj), dist_func_param_);
+        for (int level = max_level_; level > 0; level--) {
+            bool changed = true;
+            while (changed) {
+                changed = false;
+                auto link_data = getLinklistAtLevelWithLock(currObj, level);
+                auto* data = (unsigned int*)link_data.get();
+                int size = getListCount(data);
+                //            metric_hops_++;
+                //            metric_distance_computations_ += size;
 
-            auto* datal = (InnerIdType*)(data + 1);
-            for (int i = 0; i < size; i++) {
-                InnerIdType cand = datal[i];
-                if (cand > max_elements_)
-                    throw std::runtime_error("cand error");
-                float d = fstdistfunc_(query_data, getDataByInternalId(cand), dist_func_param_);
+                auto* datal = (InnerIdType*)(data + 1);
+                for (int i = 0; i < size; i++) {
+                    InnerIdType cand = datal[i];
+                    if (cand > max_elements_)
+                        throw std::runtime_error("cand error");
+                    float d = fstdistfunc_(query_data, getDataByInternalId(cand), dist_func_param_);
 
-                if (d < curdist) {
-                    curdist = d;
-                    currObj = cand;
-                    changed = true;
+                    if (d < curdist) {
+                        curdist = d;
+                        currObj = cand;
+                        changed = true;
+                    }
                 }
             }
         }
-    }
 
-    MaxHeap top_candidates(allocator_);
-
-    if (num_deleted_ == 0) {
-        top_candidates = searchBaseLayerST<false, true>(
-            currObj, query_data, std::max(ef, k), is_id_allowed, skip_ratio);
-    } else {
-        top_candidates = searchBaseLayerST<true, true>(
-            currObj, query_data, std::max(ef, k), is_id_allowed, skip_ratio);
+        if (num_deleted_ == 0) {
+            top_candidates = searchBaseLayerST<false, true>(
+                currObj, query_data, std::max(ef, k), is_id_allowed, skip_ratio, iter_ctx);
+        } else {
+            top_candidates = searchBaseLayerST<true, true>(
+                currObj, query_data, std::max(ef, k), is_id_allowed, skip_ratio, iter_ctx);
+        }
     }
 
     while (top_candidates.size() > k) {
+        if (iter_ctx != nullptr) {
+            std::pair<float, InnerIdType> curr = top_candidates.top();
+            (*iter_ctx)->AddDiscardNode(curr.first, curr.second);
+        }
         top_candidates.pop();
     }
     while (not top_candidates.empty()) {
         std::pair<float, InnerIdType> rez = top_candidates.top();
         result.emplace(rez.first, getExternalLabel(rez.second));
+        if (iter_ctx != nullptr) {
+            (*iter_ctx)->SetPoint(rez.second);
+        }
         top_candidates.pop();
+    }
+    if (iter_ctx != nullptr) {
+        (*iter_ctx)->SetOFFFirstUsed();
     }
     return result;
 }
@@ -1578,11 +1647,13 @@ HierarchicalNSW::setDataAndGraph(vsag::FlattenInterfacePtr& data,
 }
 
 template MaxHeap
-HierarchicalNSW::searchBaseLayerST<false, false>(InnerIdType ep_id,
-                                                 const void* data_point,
-                                                 size_t ef,
-                                                 const vsag::FilterPtr is_id_allowed,
-                                                 const float skip_ratio) const;
+HierarchicalNSW::searchBaseLayerST<false, false>(
+    InnerIdType ep_id,
+    const void* data_point,
+    size_t ef,
+    const vsag::FilterPtr is_id_allowed,
+    const float skip_ratio,
+    vsag::IteratorContextPtr* iter_ctx = nullptr) const;
 
 template MaxHeap
 HierarchicalNSW::searchBaseLayerST<false, false>(InnerIdType ep_id,

--- a/src/algorithm/hnswlib/hnswalg.cpp
+++ b/src/algorithm/hnswlib/hnswalg.cpp
@@ -185,9 +185,9 @@ HierarchicalNSW::getMinAndMaxId(int64_t& min_id, int64_t& max_id) {
     min_id = INT64_MAX;
     max_id = INT64_MIN;
     std::shared_lock lock_table(label_lookup_lock_);
-    for (auto it = label_lookup_.begin(); it != label_lookup_.end(); ++it) {
-        max_id = it->first > max_id ? it->first : max_id;
-        min_id = it->first < min_id ? it->first : min_id;
+    for (auto& it : label_lookup_) {
+        max_id = it.first > max_id ? it.first : max_id;
+        min_id = it.first < min_id ? it.first : min_id;
     }
 }
 
@@ -442,7 +442,8 @@ HierarchicalNSW::searchBaseLayerST(InnerIdType ep_id,
     MaxHeap candidate_set(allocator_);
 
     float valid_ratio = is_id_allowed ? is_id_allowed->ValidRatio() : 1.0F;
-    float skip_threshold = 1 - ((1 - valid_ratio) * skip_ratio);
+    float skip_threshold = valid_ratio == 1.0f ? 0 : (1 - ((1 - valid_ratio) * skip_ratio));
+    ;
 
     float lower_bound;
     if (iter_ctx != nullptr && !(*iter_ctx)->IsFirstUsed()) {

--- a/src/algorithm/hnswlib/hnswalg.cpp
+++ b/src/algorithm/hnswlib/hnswalg.cpp
@@ -442,7 +442,7 @@ HierarchicalNSW::searchBaseLayerST(InnerIdType ep_id,
     MaxHeap candidate_set(allocator_);
 
     float valid_ratio = is_id_allowed ? is_id_allowed->ValidRatio() : 1.0F;
-    float skip_threshold = valid_ratio == 1.0f ? 0 : (1 - ((1 - valid_ratio) * skip_ratio));
+    float skip_threshold = valid_ratio == 1.0F ? 0 : (1 - ((1 - valid_ratio) * skip_ratio));
     ;
 
     float lower_bound;

--- a/src/algorithm/hnswlib/hnswalg.h
+++ b/src/algorithm/hnswlib/hnswalg.h
@@ -37,10 +37,12 @@
 #include "data_cell/flatten_interface.h"
 #include "data_cell/graph_interface.h"
 #include "default_allocator.h"
+#include "index/iterator_filter.h"
 #include "prefetch.h"
 #include "simd/simd.h"
 #include "visited_list_pool.h"
 #include "vsag/dataset.h"
+#include "vsag/iterator_context.h"
 namespace hnswlib {
 using InnerIdType = vsag::InnerIdType;
 using linklistsizeint = unsigned int;
@@ -148,6 +150,8 @@ public:
 
     float
     getDistanceByLabel(LabelType label, const void* data_point) override;
+    void
+    getMinAndMaxId(int64_t& min, int64_t& max) override;
 
     tl::expected<vsag::DatasetPtr, vsag::Error>
     getBatchDistanceByLabel(const int64_t* ids, const void* data_point, int64_t count) override;
@@ -251,7 +255,8 @@ public:
                       const void* data_point,
                       size_t ef,
                       const vsag::FilterPtr is_id_allowed = nullptr,
-                      const float skip_ratio = 0.9f) const;
+                      const float skip_ratio = 0.9f,
+                      vsag::IteratorContextPtr* iter_ctx = nullptr) const;
 
     template <bool has_deletions, bool collect_metrics = false>
     MaxHeap
@@ -410,7 +415,9 @@ public:
               size_t k,
               uint64_t ef,
               const vsag::FilterPtr is_id_allowed = nullptr,
-              const float skip_ratio = 0.9f) const override;
+              const float skip_ratio = 0.9f,
+              vsag::IteratorContextPtr* iter_ctx = nullptr,
+              bool is_last_filter = false) const override;
 
     std::priority_queue<std::pair<float, LabelType>>
     searchRange(const void* query_data,

--- a/src/algorithm/hnswlib/hnswalg_static.h
+++ b/src/algorithm/hnswlib/hnswalg_static.h
@@ -33,6 +33,7 @@
 #include "../../default_allocator.h"
 #include "hnswlib.h"
 #include "visited_list_pool.h"
+#include "vsag/iterator_context.h"
 
 namespace hnswlib {
 using tableint = vsag::InnerIdType;
@@ -260,6 +261,11 @@ public:
 
         float dist = fstdistfunc_(data_point, getDataByInternalId(internal_id), dist_func_param_);
         return dist;
+    }
+
+    void
+    getMinAndMaxId(int64_t& min_id, int64_t& max_id) override {
+        // donothing
     }
 
     tl::expected<vsag::DatasetPtr, vsag::Error>
@@ -1450,7 +1456,9 @@ public:
               size_t k,
               uint64_t ef,
               const vsag::FilterPtr is_id_allowed = nullptr,
-              const float skip_ratio = 0.9f) const override {
+              const float skip_ratio = 0.9f,
+              vsag::IteratorContextPtr* iter_ctx = nullptr,
+              bool is_last_filter = false) const override {
         std::priority_queue<std::pair<float, LabelType>> result;
         if (cur_element_count_ == 0)
             return result;

--- a/src/algorithm/hnswlib/hnswalg_static.h
+++ b/src/algorithm/hnswlib/hnswalg_static.h
@@ -265,7 +265,14 @@ public:
 
     void
     getMinAndMaxId(int64_t& min_id, int64_t& max_id) override {
-        // donothing
+        min_id = INT64_MAX;
+        max_id = INT64_MIN;
+        std::unique_lock<std::mutex> lock_table(label_lookup_lock);
+        for (auto it = label_lookup_.begin(); it != label_lookup_.end(); ++it) {
+            max_id = it->first > max_id ? it->first : max_id;
+            min_id = it->first < min_id ? it->first : min_id;
+        }
+        lock_table.unlock();
     }
 
     tl::expected<vsag::DatasetPtr, vsag::Error>

--- a/src/algorithm/inner_index_interface.h
+++ b/src/algorithm/inner_index_interface.h
@@ -47,7 +47,9 @@ public:
     KnnSearch(const DatasetPtr& query,
               int64_t k,
               const std::string& parameters,
-              const FilterPtr& filter) const = 0;
+              const FilterPtr& filter,
+              vsag::IteratorContextPtr* filter_ctx = nullptr,
+              bool is_last_filter = false) const = 0;
 
     [[nodiscard]] virtual DatasetPtr
     RangeSearch(const DatasetPtr& query,

--- a/src/algorithm/inner_index_interface.h
+++ b/src/algorithm/inner_index_interface.h
@@ -144,6 +144,11 @@ public:
     virtual DatasetPtr
     CalDistanceById(const float* query, const int64_t* ids, int64_t count) const;
 
+    virtual tl::expected<void, Error>
+    GetMinAndMaxId(int64_t& min_id, int64_t& max_id) const {
+        throw std::runtime_error("Index doesn't support GetMinAndMaxId");
+    }
+
     virtual void
     Merge(const std::vector<MergeUnit>& merge_units) {
         throw std::runtime_error("Index doesn't support merge");

--- a/src/algorithm/ivf.cpp
+++ b/src/algorithm/ivf.cpp
@@ -142,7 +142,9 @@ DatasetPtr
 IVF::KnnSearch(const vsag::DatasetPtr& query,
                int64_t k,
                const std::string& parameters,
-               const vsag::FilterPtr& filter) const {
+               const vsag::FilterPtr& filter,
+               vsag::IteratorContextPtr* filter_ctx,
+               bool is_last_filter) const {
     auto* allocator = allocator_;
     MaxHeap heap(allocator);
     auto param = IVFSearchParameters::FromJson(parameters);

--- a/src/algorithm/ivf.h
+++ b/src/algorithm/ivf.h
@@ -58,7 +58,9 @@ public:
     KnnSearch(const DatasetPtr& query,
               int64_t k,
               const std::string& parameters,
-              const FilterPtr& filter) const override;
+              const FilterPtr& filter,
+              vsag::IteratorContextPtr* filter_ctx = nullptr,
+              bool is_last_filter = false) const override;
 
     DatasetPtr
     RangeSearch(const DatasetPtr& query,

--- a/src/impl/basic_searcher.cpp
+++ b/src/impl/basic_searcher.cpp
@@ -45,7 +45,9 @@ BasicSearcher::visit(const GraphInterfacePtr& graph,
     }
 
     float skip_threshold =
-        (filter != nullptr ? (1 - ((1 - filter->ValidRatio()) * skip_ratio)) : 0.0F);
+        (filter != nullptr
+             ? (filter->ValidRatio() == 1.0f ? 0 : (1 - ((1 - filter->ValidRatio()) * skip_ratio)))
+             : 0.0F);
 
     for (uint32_t i = 0; i < prefetch_jump_visit_size_; i++) {
         vl->Prefetch(neighbors[i]);
@@ -115,8 +117,9 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
     Vector<float> line_dists(graph->MaximumDegree(), allocator_);
 
     if (iter_ctx != nullptr && !(*iter_ctx)->IsFirstUsed()) {
-        if ((*iter_ctx)->Empty())
+        if ((*iter_ctx)->Empty()) {
             return top_candidates;
+        }
         while (!(*iter_ctx)->Empty()) {
             uint32_t cur_inner_id = (*iter_ctx)->GetTopID();
             float cur_dist = (*iter_ctx)->GetTopDist();

--- a/src/impl/basic_searcher.cpp
+++ b/src/impl/basic_searcher.cpp
@@ -46,7 +46,7 @@ BasicSearcher::visit(const GraphInterfacePtr& graph,
 
     float skip_threshold =
         (filter != nullptr
-             ? (filter->ValidRatio() == 1.0f ? 0 : (1 - ((1 - filter->ValidRatio()) * skip_ratio)))
+             ? (filter->ValidRatio() == 1.0F ? 0 : (1 - ((1 - filter->ValidRatio()) * skip_ratio)))
              : 0.0F);
 
     for (uint32_t i = 0; i < prefetch_jump_visit_size_; i++) {

--- a/src/impl/basic_searcher.h
+++ b/src/impl/basic_searcher.h
@@ -22,6 +22,7 @@
 #include "index/index_common_param.h"
 #include "lock_strategy.h"
 #include "utils/visited_list.h"
+#include "vsag/iterator_context.h"
 
 namespace vsag {
 
@@ -51,7 +52,8 @@ public:
            const FlattenInterfacePtr& flatten,
            const VisitedListPtr& vl,
            const float* query,
-           const InnerSearchParam& inner_search_param) const;
+           const InnerSearchParam& inner_search_param,
+           vsag::IteratorContextPtr* iter_ctx = nullptr) const;
 
 private:
     // rid means the neighbor's rank (e.g., the first neighbor's rid == 0)
@@ -71,7 +73,8 @@ private:
                 const FlattenInterfacePtr& flatten,
                 const VisitedListPtr& vl,
                 const float* query,
-                const InnerSearchParam& inner_search_param) const;
+                const InnerSearchParam& inner_search_param,
+                vsag::IteratorContextPtr* iter_ctx = nullptr) const;
 
 private:
     Allocator* allocator_{nullptr};

--- a/src/index/hnsw.cpp
+++ b/src/index/hnsw.cpp
@@ -30,6 +30,7 @@
 #include "empty_index_binary_set.h"
 #include "impl/odescent_graph_builder.h"
 #include "index/hnsw_zparameters.h"
+#include "index/iterator_filter.h"
 #include "io/memory_block_io_parameter.h"
 #include "quantization/fp32_quantizer_parameter.h"
 #include "safe_allocator.h"
@@ -203,7 +204,9 @@ tl::expected<DatasetPtr, Error>
 HNSW::knn_search(const DatasetPtr& query,
                  int64_t k,
                  const std::string& parameters,
-                 const FilterPtr& filter_ptr) const {
+                 const FilterPtr& filter_ptr,
+                 vsag::IteratorContextPtr* iter_ctx,
+                 bool is_last_filter) const {
 #ifndef ENABLE_TESTS
     SlowTaskTimer t_total("hnsw knnsearch", 20);
 #endif
@@ -234,6 +237,12 @@ HNSW::knn_search(const DatasetPtr& query,
         // check search parameters
         auto params = HnswSearchParameters::FromJson(parameters);
 
+        if (iter_ctx != nullptr && *iter_ctx == nullptr) {
+            auto filter_context = std::make_shared<IteratorFilterContext>();
+            filter_context->init(alg_hnsw_->getMaxElements(), params.ef_search, allocator_.get());
+            *iter_ctx = filter_context;
+        }
+
         // perform search
         int64_t original_k = k;
         std::priority_queue<std::pair<float, LabelType>> results;
@@ -247,7 +256,9 @@ HNSW::knn_search(const DatasetPtr& query,
                                            k,
                                            std::max(params.ef_search, k),
                                            filter_ptr,
-                                           params.skip_ratio);
+                                           params.skip_ratio,
+                                           iter_ctx,
+                                           is_last_filter);
         } catch (const std::runtime_error& e) {
             LOG_ERROR_AND_RETURNS(ErrorType::INTERNAL_ERROR,
                                   "failed to perofrm knn_search(internalError): ",

--- a/src/index/hnsw_test.cpp
+++ b/src/index/hnsw_test.cpp
@@ -939,6 +939,50 @@ TEST_CASE("get data by label", "[ut][hnsw]") {
     }
 }
 
+TEST_CASE("get min and max id", "[ut][hnsw]") {
+    Options::Instance().logger()->SetLevel(Logger::Level::kDEBUG);
+
+    // parameters
+    int dim = 128;
+    int64_t num_base = 1;
+
+    // data
+    auto [base_ids, base_vectors] = fixtures::generate_ids_and_vectors(num_base, dim);
+
+    // hnsw index
+    hnswlib::L2Space space(dim);
+
+    SECTION("hnsw test") {
+        DefaultAllocator allocator;
+        auto* alg_hnsw = new hnswlib::HierarchicalNSW(&space, 100, &allocator);
+        alg_hnsw->init_memory_space();
+        alg_hnsw->addPoint(base_vectors.data(), 0);
+        alg_hnsw->addPoint(base_vectors.data(), 5);
+        int64_t min_id;
+        int64_t max_id;
+        alg_hnsw->getMinAndMaxId(min_id, max_id);
+
+        REQUIRE(min_id == 0);
+        REQUIRE(max_id == 5);
+        delete alg_hnsw;
+    }
+
+    SECTION("static hnsw test") {
+        DefaultAllocator allocator;
+        auto* alg_hnsw_static = new hnswlib::StaticHierarchicalNSW(&space, 100, &allocator);
+        alg_hnsw_static->init_memory_space();
+        alg_hnsw_static->addPoint(base_vectors.data(), 0);
+        alg_hnsw_static->addPoint(base_vectors.data(), 5);
+        int64_t min_id;
+        int64_t max_id;
+        alg_hnsw_static->getMinAndMaxId(min_id, max_id);
+
+        REQUIRE(min_id == 0);
+        REQUIRE(max_id == 5);
+        delete alg_hnsw_static;
+    }
+}
+
 TEST_CASE("extract/set data and graph", "[ut][hnsw]") {
     logger::set_level(logger::level::debug);
 

--- a/src/index/index_impl.h
+++ b/src/index/index_impl.h
@@ -98,6 +98,17 @@ public:
         SAFE_CALL(return this->inner_index_->KnnSearch(query, k, parameters, filter));
     }
 
+    tl::expected<DatasetPtr, Error>
+    KnnSearch(const DatasetPtr& query,
+              int64_t k,
+              const std::string& parameters,
+              const FilterPtr& filter,
+              vsag::IteratorContextPtr* iter_ctx,
+              bool is_last_search) const override {
+        SAFE_CALL(return this->inner_index_->KnnSearch(
+            query, k, parameters, filter, iter_ctx, is_last_search));
+    }
+
     [[nodiscard]] tl::expected<DatasetPtr, Error>
     RangeSearch(const DatasetPtr& query,
                 float radius,

--- a/src/index/index_impl.h
+++ b/src/index/index_impl.h
@@ -173,6 +173,11 @@ public:
     }
 
     tl::expected<void, Error>
+    GetMinAndMaxId(int64_t& min_id, int64_t& max_id) const override {
+        SAFE_CALL(return this->inner_index_->GetMinAndMaxId(min_id, max_id));
+    }
+
+    tl::expected<void, Error>
     Merge(const std::vector<MergeUnit>& merge_units) override {
         SAFE_CALL(this->inner_index_->Merge(merge_units));
     }

--- a/src/index/iterator_filter.cpp
+++ b/src/index/iterator_filter.cpp
@@ -1,0 +1,106 @@
+
+// Copyright 2024-present the vsag project
+//
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "iterator_filter.h"
+
+#include "../logger.h"
+
+namespace vsag {
+
+IteratorFilterContext::~IteratorFilterContext() {
+    allocator_->Deallocate(list_);
+}
+
+tl::expected<void, Error>
+IteratorFilterContext::init(InnerIdType max_size, int64_t ef_search, Allocator* allocator) {
+    if (ef_search == 0 || max_size == 0) {
+        LOG_ERROR_AND_RETURNS(ErrorType::INVALID_ARGUMENT,
+                              "failed to serialize: hnsw index is empty");
+    }
+    try {
+        ef_search_ = ef_search;
+        allocator_ = allocator;
+        max_size_ = max_size;
+        discard_ = std::make_unique<std::priority_queue<std::pair<float, InnerIdType>>>();
+        list_ = reinterpret_cast<VisitedListType*>(
+            allocator_->Allocate((uint64_t)max_size * sizeof(VisitedListType)));
+        memset(list_, 0, max_size * sizeof(VisitedListType));
+    } catch (const std::bad_alloc& e) {
+        LOG_ERROR_AND_RETURNS(ErrorType::NO_ENOUGH_MEMORY,
+                              "failed to init iterator filter(not enough memory): ",
+                              e.what());
+    }
+    return {};
+}
+
+void
+IteratorFilterContext::AddDiscardNode(float dis, uint32_t id) {
+    if (discard_->size() >= ef_search_) {
+        if (discard_->top().first > dis) {
+            discard_->pop();
+            discard_->emplace(dis, id);
+        }
+    } else {
+        discard_->emplace(dis, id);
+    }
+}
+
+uint32_t
+IteratorFilterContext::GetTopID() {
+    return discard_->top().second;
+}
+
+float
+IteratorFilterContext::GetTopDist() {
+    return discard_->top().first;
+}
+
+void
+IteratorFilterContext::PopDiscard() {
+    discard_->pop();
+}
+
+bool
+IteratorFilterContext::Empty() {
+    return discard_->empty();
+}
+
+bool
+IteratorFilterContext::IsFirstUsed() {
+    return is_first_used_;
+}
+void
+IteratorFilterContext::SetOFFFirstUsed() {
+    is_first_used_ = false;
+}
+
+void
+IteratorFilterContext::SetPoint(InnerIdType id) {
+    list_[id] = 1;
+}
+
+bool
+IteratorFilterContext::CheckPoint(InnerIdType id) {
+    return list_[id] == 0;
+}
+
+int64_t
+IteratorFilterContext::GetDiscardElementNum() {
+    return discard_->size();
+}
+
+};  // namespace vsag

--- a/src/index/iterator_filter.cpp
+++ b/src/index/iterator_filter.cpp
@@ -100,7 +100,7 @@ IteratorFilterContext::CheckPoint(InnerIdType id) {
 
 int64_t
 IteratorFilterContext::GetDiscardElementNum() {
-    return discard_->size();
+    return int64_t(discard_->size());
 }
 
 };  // namespace vsag

--- a/src/index/iterator_filter.h
+++ b/src/index/iterator_filter.h
@@ -1,0 +1,71 @@
+
+// Copyright 2024-present the vsag project
+//
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include <queue>
+
+#include "typing.h"
+#include "utils/visited_list.h"
+#include "vsag/allocator.h"
+#include "vsag/errors.h"
+#include "vsag/expected.hpp"
+#include "vsag/iterator_context.h"
+
+namespace vsag {
+
+class IteratorFilterContext : public IteratorContext {
+public:
+    using VisitedListType = uint16_t;
+
+public:
+    IteratorFilterContext() : is_first_used_(true){};
+    ~IteratorFilterContext();
+
+    tl::expected<void, Error>
+    init(InnerIdType max_size, int64_t ef_search, Allocator* allocator);
+    void
+    AddDiscardNode(float dis, uint32_t id) override;
+
+    virtual uint32_t
+    GetTopID() override;
+    virtual float
+    GetTopDist() override;
+    virtual void
+    PopDiscard() override;
+    virtual bool
+    Empty() override;
+    virtual bool
+    IsFirstUsed() override;
+    virtual void
+    SetOFFFirstUsed() override;
+    void
+    SetPoint(uint32_t id) override;
+    bool
+    CheckPoint(uint32_t id) override;
+    int64_t
+    GetDiscardElementNum() override;
+
+private:
+    int64_t ef_search_;
+    bool is_first_used_;
+    uint32_t max_size_;
+    Allocator* allocator_;
+    VisitedListType* list_{nullptr};
+    std::unique_ptr<std::priority_queue<std::pair<float, uint32_t>>> discard_;
+};
+
+};  // namespace vsag

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -150,6 +150,7 @@ HgraphTestIndex::TestGeneral(const TestIndex::IndexPtr& index,
                              const std::string& search_param,
                              float recall) {
     TestKnnSearch(index, dataset, search_param, recall, true);
+    TestKnnSearchIter(index, dataset, search_param, recall, true);
     TestConcurrentKnnSearch(index, dataset, search_param, recall, true);
     TestRangeSearch(index, dataset, search_param, recall, 10, true);
     TestRangeSearch(index, dataset, search_param, recall / 2.0, 5, true);
@@ -157,6 +158,7 @@ HgraphTestIndex::TestGeneral(const TestIndex::IndexPtr& index,
     TestCheckIdExist(index, dataset);
     TestCalcDistanceById(index, dataset);
     TestBatchCalcDistanceById(index, dataset);
+    TestGetMinAndMaxId(index, dataset);
 }
 }  // namespace fixtures
 

--- a/tests/test_hnsw_new.cpp
+++ b/tests/test_hnsw_new.cpp
@@ -218,6 +218,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex,
         auto dataset = pool.GetDatasetAndCreate(dim, base_count, metric_type);
         TestContinueAdd(index, dataset, true);
         TestKnnSearch(index, dataset, search_param, 0.99, true);
+        TestKnnSearchIter(index, dataset, search_param, 0.99, true);
         TestConcurrentKnnSearch(index, dataset, search_param, 0.99, true);
         TestRangeSearch(index, dataset, search_param, 0.99, 10, true);
         TestRangeSearch(index, dataset, search_param, 0.49, 5, true);
@@ -395,6 +396,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Batch Calc Dis Id", 
         auto dataset = pool.GetDatasetAndCreate(dim, base_count, metric_type);
         TestBuildIndex(index, dataset, true);
         TestBatchCalcDistanceById(index, dataset);
+        TestGetMinAndMaxId(index, dataset);
         vsag::Options::Instance().set_block_size_limit(origin_size);
     }
 }
@@ -418,6 +420,27 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex,
         auto dataset = pool.GetDatasetAndCreate(dim, base_count, metric_type);
         TestBuildIndex(index, dataset, true);
         TestBatchCalcDistanceById(index, dataset);
+        vsag::Options::Instance().set_block_size_limit(origin_size);
+    }
+}
+
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex,
+                             "static HNSW Get Min And Min Id",
+                             "[ft][hnsw]") {
+    auto origin_size = vsag::Options::Instance().block_size_limit();
+    auto size = GENERATE(1024 * 1024 * 2);
+    auto metric_type = GENERATE("l2");
+    auto use_static = GENERATE(true);
+    const std::string name = "hnsw";
+    for (auto& dim : dims) {
+        if (dim % 4 != 0) {
+            dim = ((dim / 4) + 1) * 4;
+        }
+        vsag::Options::Instance().set_block_size_limit(size);
+        auto param = GenerateHNSWBuildParametersString(metric_type, dim, use_static);
+        auto index = TestFactory(name, param, true);
+        auto dataset = pool.GetDatasetAndCreate(dim, base_count, metric_type);
+        TestGetMinAndMaxId(index, dataset);
         vsag::Options::Instance().set_block_size_limit(origin_size);
     }
 }

--- a/tests/test_index.h
+++ b/tests/test_index.h
@@ -95,6 +95,13 @@ protected:
                   bool expected_success = true);
 
     static void
+    TestKnnSearchIter(const IndexPtr& index,
+                      const TestDatasetPtr& dataset,
+                      const std::string& search_param,
+                      float expected_recall = 0.99,
+                      bool expected_success = true);
+
+    static void
     TestSearchWithDirtyVector(const IndexPtr& index,
                               const TestDatasetPtr& dataset,
                               const std::string& search_param,
@@ -124,6 +131,8 @@ protected:
                               const TestDatasetPtr& dataset,
                               float error = 1e-5);
 
+    static void
+    TestGetMinAndMaxId(const IndexPtr& index, const TestDatasetPtr& dataset);
     static void
     TestSerializeFile(const IndexPtr& index_from,
                       const IndexPtr& index_to,


### PR DESCRIPTION
A discard heap is introduced. The function of the discard heap is to save the nodes discarded in the previous round of queries and sort them by distance. If the results in the first round of queries are insufficient, another round of queries will be performed. In the next round, the nodes in the discard heap are used as candidate sets, and the neighbors that have not been visited are visited as new output results, and the discard heap is updated. Each subsequent round of queries will query ef_search nodes. The query ends when limitK is satisfied or discard is empty.