### PR TITLE
support simd of rabitq-fp32

### DIFF
--- a/src/quantization/rabitq_quantization/rabitq_quantizer.h
+++ b/src/quantization/rabitq_quantization/rabitq_quantizer.h
@@ -238,7 +238,8 @@ RaBitQuantizer<metric>::EncodeOneImpl(const DataType* data, uint8_t* codes) cons
     }
 
     // 4. compute encode error
-    error_type error = RaBitQFloatBinaryIP(normed_data.data(), codes + offset_code_, this->dim_);
+    error_type error = RaBitQFloatBinaryIP(
+        normed_data.data(), codes + offset_code_, this->dim_, 1.0f / sqrt(this->dim_));
 
     // 5. store norm and error
     *(norm_type*)(codes + offset_norm_) = norm;
@@ -308,7 +309,8 @@ RaBitQuantizer<metric>::ComputeQueryBaseImpl(const uint8_t* query_codes,
         base_error = (base_error > 0) ? 1.0f : -1.0f;
     }
 
-    float ip_bq_1_32 = RaBitQFloatBinaryIP((DataType*)query_codes, base_codes, this->dim_);
+    float ip_bq_1_32 = RaBitQFloatBinaryIP(
+        (DataType*)query_codes, base_codes, this->dim_, 1.0f / sqrt(this->dim_));
     float ip_bb_1_32 = base_error;
     float ip_est = ip_bq_1_32 / ip_bb_1_32;
 

--- a/src/quantization/rabitq_quantization/rabitq_quantizer.h
+++ b/src/quantization/rabitq_quantization/rabitq_quantizer.h
@@ -110,6 +110,8 @@ private:
     }
 
 private:
+    float inv_sqrt_d_{0};
+
     std::shared_ptr<RandomOrthogonalMatrix> rom_;
     std::vector<float> centroid_;  // TODO(ZXY): use centroids (e.g., IVF or Graph) outside
 
@@ -134,6 +136,9 @@ RaBitQuantizer<metric>::RaBitQuantizer(int dim, Allocator* allocator)
 
     // random orthogonal matrix
     rom_.reset(new RandomOrthogonalMatrix(dim, allocator));
+
+    // distance function related variable
+    inv_sqrt_d_ = 1.0f / sqrt(this->dim_);
 
     // base code layout
     size_t align_size = std::max(sizeof(error_type), sizeof(norm_type));
@@ -238,8 +243,8 @@ RaBitQuantizer<metric>::EncodeOneImpl(const DataType* data, uint8_t* codes) cons
     }
 
     // 4. compute encode error
-    error_type error = RaBitQFloatBinaryIP(
-        normed_data.data(), codes + offset_code_, this->dim_, 1.0f / sqrt(this->dim_));
+    error_type error =
+        RaBitQFloatBinaryIP(normed_data.data(), codes + offset_code_, this->dim_, inv_sqrt_d_);
 
     // 5. store norm and error
     *(norm_type*)(codes + offset_norm_) = norm;
@@ -264,12 +269,11 @@ RaBitQuantizer<metric>::DecodeOneImpl(const uint8_t* codes, DataType* data) {
     // 1. init
     Vector<DataType> normed_data(this->dim_, 0, this->allocator_);
     Vector<DataType> transformed_data(this->dim_, 0, this->allocator_);
-    float inv_sqrt_d = 1.0f / std::sqrt(static_cast<float>(this->dim_));
 
     // 2. decode with BQ
     for (uint64_t d = 0; d < this->dim_; ++d) {
         bool bit = ((codes[d / 8] >> (d % 8)) & 1) != 0;
-        normed_data[d] = bit ? inv_sqrt_d : -inv_sqrt_d;
+        normed_data[d] = bit ? inv_sqrt_d_ : -inv_sqrt_d_;
     }
 
     // 3. inverse normalize
@@ -309,8 +313,8 @@ RaBitQuantizer<metric>::ComputeQueryBaseImpl(const uint8_t* query_codes,
         base_error = (base_error > 0) ? 1.0f : -1.0f;
     }
 
-    float ip_bq_1_32 = RaBitQFloatBinaryIP(
-        (DataType*)query_codes, base_codes, this->dim_, 1.0f / sqrt(this->dim_));
+    float ip_bq_1_32 =
+        RaBitQFloatBinaryIP((DataType*)query_codes, base_codes, this->dim_, inv_sqrt_d_);
     float ip_bb_1_32 = base_error;
     float ip_est = ip_bq_1_32 / ip_bb_1_32;
 

--- a/src/simd/avx.cpp
+++ b/src/simd/avx.cpp
@@ -539,28 +539,29 @@ RaBitQFloatBinaryIP(const float* vector, const uint8_t* bits, uint64_t dim, floa
     alignas(32) float temp[8];
     __m256 sum = _mm256_setzero_ps();
     const __m256 inv_sqrt_d_vec = _mm256_set1_ps(inv_sqrt_d);
-    const __m256 neg_inv_sqrt_d_vec = _mm256_set1_ps(-inv_sqrt_d);
 
     for (; d + 8 <= dim; d += 8) {
         __m256 vec = _mm256_loadu_ps(vector + d);
 
-        __m256 mask = _mm256_setzero_ps();
-        for (int j = 0; j < 8; ++j) {
-            int bit = (bits[d / 8] >> j) & 1;
-            __m256 val = _mm256_set1_ps(bit ? 1.0f : 0.0f);
-            mask = _mm256_add_ps(mask, _mm256_mul_ps(val, _mm256_set1_ps(1 << j)));
-        }
+        uint8_t byte = bits[d / 8];
+        __m256 b_vec = _mm256_set_ps(((byte >> 7) & 1) ? 1.0f : -1.0f,
+                                     ((byte >> 6) & 1) ? 1.0f : -1.0f,
+                                     ((byte >> 5) & 1) ? 1.0f : -1.0f,
+                                     ((byte >> 4) & 1) ? 1.0f : -1.0f,
+                                     ((byte >> 3) & 1) ? 1.0f : -1.0f,
+                                     ((byte >> 2) & 1) ? 1.0f : -1.0f,
+                                     ((byte >> 1) & 1) ? 1.0f : -1.0f,
+                                     ((byte >> 0) & 1) ? 1.0f : -1.0f);
 
-        __m256 b_vec = _mm256_add_ps(
-            _mm256_mul_ps(mask, inv_sqrt_d_vec),
-            _mm256_mul_ps(_mm256_sub_ps(_mm256_set1_ps(1.0f), mask), neg_inv_sqrt_d_vec));
+        b_vec = _mm256_mul_ps(b_vec, inv_sqrt_d_vec);
 
         sum = _mm256_add_ps(_mm256_mul_ps(b_vec, vec), sum);
     }
 
     _mm256_store_ps(temp, sum);
-    for (float val : temp) {
-        result += val;
+
+    for (int j = 0; j < 8; ++j) {
+        result += temp[j];
     }
 
     result += sse::RaBitQFloatBinaryIP(vector + d, bits + d / 8, dim - d, inv_sqrt_d);

--- a/src/simd/avx.cpp
+++ b/src/simd/avx.cpp
@@ -548,7 +548,7 @@ RaBitQFloatBinaryIP(const float* vector, const uint8_t* bits, uint64_t dim, floa
         for (int j = 0; j < 8; ++j) {
             int bit = (bits[d / 8] >> j) & 1;
             __m256 val = _mm256_set1_ps(bit ? 1.0f : 0.0f);
-            mask = _mm256_blend_ps(mask, val, 1 << j);
+            mask = _mm256_add_ps(mask, _mm256_mul_ps(val, _mm256_set1_ps(1 << j)));
         }
 
         __m256 b_vec = _mm256_add_ps(

--- a/src/simd/avx.cpp
+++ b/src/simd/avx.cpp
@@ -527,6 +527,15 @@ SQ8UniformComputeCodesIP(const uint8_t* codes1, const uint8_t* codes2, uint64_t 
 #endif
 }
 
+float
+RaBitQFloatBinaryIP(const float* vector, const uint8_t* bits, uint64_t dim, float inv_sqrt_d) {
+#if defined(ENABLE_AVX)
+    return sse::RaBitQFloatBinaryIP(vector, bits, dim, inv_sqrt_d);
+#else
+    return sse::RaBitQFloatBinaryIP(vector, bits, dim, inv_sqrt_d);
+#endif
+}
+
 void
 DivScalar(const float* from, float* to, uint64_t dim, float scalar) {
 #if defined(ENABLE_AVX)

--- a/src/simd/avx.cpp
+++ b/src/simd/avx.cpp
@@ -563,9 +563,8 @@ RaBitQFloatBinaryIP(const float* vector, const uint8_t* bits, uint64_t dim, floa
     }
 
     _mm256_store_ps(temp, sum);
-
-    for (int j = 0; j < 8; ++j) {
-        result += temp[j];
+    for (float val : temp) {
+        result += val;
     }
 
     result += sse::RaBitQFloatBinaryIP(vector + d, bits + d / 8, dim - d, inv_sqrt_d);

--- a/src/simd/avx.cpp
+++ b/src/simd/avx.cpp
@@ -534,6 +534,10 @@ RaBitQFloatBinaryIP(const float* vector, const uint8_t* bits, uint64_t dim, floa
         return 0.0f;
     }
 
+    if (dim < 8) {
+        return sse::RaBitQFloatBinaryIP(vector, bits, dim, inv_sqrt_d);
+    }
+
     uint64_t d = 0;
     float result = 0.0f;
     alignas(32) float temp[8];

--- a/src/simd/avx2.cpp
+++ b/src/simd/avx2.cpp
@@ -574,6 +574,10 @@ RaBitQFloatBinaryIP(const float* vector, const uint8_t* bits, uint64_t dim, floa
         return 0.0f;
     }
 
+    if (dim < 8) {
+        return sse::RaBitQFloatBinaryIP(vector, bits, dim, inv_sqrt_d);
+    }
+
     uint64_t d = 0;
     float result = 0.0f;
     alignas(32) float temp[8];

--- a/src/simd/avx2.cpp
+++ b/src/simd/avx2.cpp
@@ -570,7 +570,7 @@ SQ8UniformComputeCodesIP(const uint8_t* codes1, const uint8_t* codes2, uint64_t 
 float
 RaBitQFloatBinaryIP(const float* vector, const uint8_t* bits, uint64_t dim, float inv_sqrt_d) {
 #if defined(ENABLE_AVX2)
-    if (dim == 0 || vector == nullptr || bits == nullptr) {
+    if (dim == 0) {
         return 0.0f;
     }
 
@@ -602,6 +602,7 @@ RaBitQFloatBinaryIP(const float* vector, const uint8_t* bits, uint64_t dim, floa
     }
 
     result += avx::RaBitQFloatBinaryIP(vector + d, bits + d / 8, dim - d, inv_sqrt_d);
+
     return result;
 #else
     return avx::RaBitQFloatBinaryIP(vector, bits, dim, inv_sqrt_d);

--- a/src/simd/avx2.cpp
+++ b/src/simd/avx2.cpp
@@ -567,6 +567,47 @@ SQ8UniformComputeCodesIP(const uint8_t* codes1, const uint8_t* codes2, uint64_t 
 #endif
 }
 
+float
+RaBitQFloatBinaryIP(const float* vector, const uint8_t* bits, uint64_t dim, float inv_sqrt_d) {
+#if defined(ENABLE_AVX2)
+    if (dim == 0 || vector == nullptr || bits == nullptr) {
+        return 0.0f;
+    }
+
+    uint64_t d = 0;
+    float result = 0.0f;
+    alignas(32) float temp[8];
+    __m256 sum = _mm256_setzero_ps();
+    const __m256 inv_sqrt_d_vec = _mm256_set1_ps(inv_sqrt_d);
+    const __m256 neg_inv_sqrt_d_vec = _mm256_set1_ps(-inv_sqrt_d);
+
+    for (; d + 8 <= dim; d += 8) {
+        __m256 vec = _mm256_loadu_ps(vector + d);
+
+        __m256i mask = _mm256_set1_epi32(static_cast<int>(bits[d / 8]));
+        mask = _mm256_and_si256(mask,
+                                _mm256_setr_epi32(0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80));
+        mask = _mm256_cmpeq_epi32(mask, _mm256_setzero_si256());
+        mask = _mm256_andnot_si256(mask, _mm256_set1_epi32(0xFFFFFFFF));
+
+        __m256 b_vec =
+            _mm256_blendv_ps(neg_inv_sqrt_d_vec, inv_sqrt_d_vec, _mm256_castsi256_ps(mask));
+
+        sum = _mm256_fmadd_ps(b_vec, vec, sum);
+    }
+
+    _mm256_storeu_ps(temp, sum);
+    for (float val : temp) {
+        result += val;
+    }
+
+    result += avx::RaBitQFloatBinaryIP(vector + d, bits + d / 8, dim - d, inv_sqrt_d);
+    return result;
+#else
+    return avx::RaBitQFloatBinaryIP(vector, bits, dim, inv_sqrt_d);
+#endif
+}
+
 void
 DivScalar(const float* from, float* to, uint64_t dim, float scalar) {
 #if defined(ENABLE_AVX2)

--- a/src/simd/avx512.cpp
+++ b/src/simd/avx512.cpp
@@ -510,6 +510,10 @@ RaBitQFloatBinaryIP(const float* vector, const uint8_t* bits, uint64_t dim, floa
         return 0.0f;
     }
 
+    if (dim < 16) {
+        return avx2::RaBitQFloatBinaryIP(vector, bits, dim, inv_sqrt_d);
+    }
+
     uint64_t d = 0;
     __m512 sum = _mm512_setzero_ps();
     const __m512 inv_sqrt_d_vec = _mm512_set1_ps(inv_sqrt_d);

--- a/src/simd/avx512.cpp
+++ b/src/simd/avx512.cpp
@@ -16,6 +16,7 @@
 #include <immintrin.h>
 #endif
 
+#include <cassert>
 #include <cmath>
 
 #include "simd.h"
@@ -499,6 +500,38 @@ SQ8UniformComputeCodesIP(const uint8_t* codes1, const uint8_t* codes2, uint64_t 
     return static_cast<float>(result);
 #else
     return avx2::SQ8UniformComputeCodesIP(codes1, codes2, dim);
+#endif
+}
+
+float
+RaBitQFloatBinaryIP(const float* vector, const uint8_t* bits, uint64_t dim, float inv_sqrt_d) {
+#if defined(ENABLE_AVX512)
+    if (dim == 0) {
+        return 0.0f;
+    }
+
+    uint64_t d = 0;
+    __m512 sum = _mm512_setzero_ps();
+    const __m512 inv_sqrt_d_vec = _mm512_set1_ps(inv_sqrt_d);
+    const __m512 neg_inv_sqrt_d_vec = _mm512_set1_ps(-inv_sqrt_d);
+
+    for (; d + 16 <= dim; d += 16) {
+        __m512 vec = _mm512_loadu_ps(vector + d);
+
+        __mmask16 mask = static_cast<__mmask16>(bits[d / 8 + 1] << 8 | bits[d / 8]);
+
+        __m512 b_vec = _mm512_mask_blend_ps(mask, neg_inv_sqrt_d_vec, inv_sqrt_d_vec);
+
+        sum = _mm512_fmadd_ps(b_vec, vec, sum);
+    }
+
+    float result = _mm512_reduce_add_ps(sum);
+
+    result += avx2::RaBitQFloatBinaryIP(vector + d, bits + (d / 8), dim - d, inv_sqrt_d);
+
+    return result;
+#else
+    return avx2::RaBitQFloatBinaryIP(vector, bits, dim, inv_sqrt_d);
 #endif
 }
 

--- a/src/simd/generic.cpp
+++ b/src/simd/generic.cpp
@@ -379,8 +379,11 @@ SQ8UniformComputeCodesIP(const uint8_t* codes1, const uint8_t* codes2, uint64_t 
 }
 
 float
-RaBitQFloatBinaryIP(const float* vector, const uint8_t* bits, uint64_t dim) {
-    float inv_sqrt_d = 1.0f / std::sqrt(static_cast<float>(dim));
+RaBitQFloatBinaryIP(const float* vector, const uint8_t* bits, uint64_t dim, float inv_sqrt_d) {
+    if (dim == 0) {
+        return 0.0f;
+    }
+
     float result = 0.0f;
 
     for (std::size_t d = 0; d < dim; ++d) {

--- a/src/simd/rabitq_simd.cpp
+++ b/src/simd/rabitq_simd.cpp
@@ -15,10 +15,29 @@
 
 #include "rabitq_simd.h"
 
+#include "simd_status.h"
+
 namespace vsag {
 
 static RaBitQFloatBinaryType
 GetRaBitQFloatBinaryIP() {
+    if (SimdStatus::SupportAVX512()) {
+#if defined(ENABLE_AVX512)
+        return avx512::RaBitQFloatBinaryIP;
+#endif
+    } else if (SimdStatus::SupportAVX2()) {
+#if defined(ENABLE_AVX2)
+        return avx2::RaBitQFloatBinaryIP;
+#endif
+    } else if (SimdStatus::SupportAVX()) {
+#if defined(ENABLE_AVX)
+        return avx::RaBitQFloatBinaryIP;
+#endif
+    } else if (SimdStatus::SupportSSE()) {
+#if defined(ENABLE_SSE)
+        return sse::RaBitQFloatBinaryIP;
+#endif
+    }
     return generic::RaBitQFloatBinaryIP;
 }
 

--- a/src/simd/rabitq_simd.cpp
+++ b/src/simd/rabitq_simd.cpp
@@ -15,8 +15,6 @@
 
 #include "rabitq_simd.h"
 
-#include "simd_status.h"
-
 namespace vsag {
 
 static RaBitQFloatBinaryType

--- a/src/simd/rabitq_simd.h
+++ b/src/simd/rabitq_simd.h
@@ -17,6 +17,8 @@
 
 #include <cstdint>
 
+#include "simd_status.h"
+
 namespace vsag {
 namespace avx512 {
 float

--- a/src/simd/rabitq_simd.h
+++ b/src/simd/rabitq_simd.h
@@ -18,12 +18,35 @@
 #include <cstdint>
 
 namespace vsag {
+namespace avx512 {
+float
+RaBitQFloatBinaryIP(const float* vector, const uint8_t* bits, uint64_t dim, float inv_sqrt_d);
+}  // namespace avx512
+
+namespace avx2 {
+float
+RaBitQFloatBinaryIP(const float* vector, const uint8_t* bits, uint64_t dim, float inv_sqrt_d);
+}  // namespace avx2
+
+namespace avx {
+float
+RaBitQFloatBinaryIP(const float* vector, const uint8_t* bits, uint64_t dim, float inv_sqrt_d);
+}  // namespace avx
+
+namespace sse {
+float
+RaBitQFloatBinaryIP(const float* vector, const uint8_t* bits, uint64_t dim, float inv_sqrt_d);
+}  // namespace sse
+
 namespace generic {
 float
-RaBitQFloatBinaryIP(const float* vector, const uint8_t* bits, uint64_t dim);
+RaBitQFloatBinaryIP(const float* vector, const uint8_t* bits, uint64_t dim, float inv_sqrt_d);
 }  // namespace generic
 
-using RaBitQFloatBinaryType = float (*)(const float* vector, const uint8_t* bits, uint64_t dim);
+using RaBitQFloatBinaryType = float (*)(const float* vector,
+                                        const uint8_t* bits,
+                                        uint64_t dim,
+                                        float inv_sqrt_d);
 
 extern RaBitQFloatBinaryType RaBitQFloatBinaryIP;
 }  // namespace vsag

--- a/src/simd/rabitq_simd_test.cpp
+++ b/src/simd/rabitq_simd_test.cpp
@@ -36,19 +36,29 @@ TEST_CASE("RaBitQ FP32-BQ SIMD Compute Codes", "[ut][simd]") {
             auto* query = queries.data() + i * dim;
             auto* base = bases.data() + i * code_size;
 
-            auto ip_32_1_generic = generic::RaBitQFloatBinaryIP(query, base, dim, inv_sqrt_d);
-            auto ip_32_1_sse = sse::RaBitQFloatBinaryIP(query, base, dim, inv_sqrt_d);
-            auto ip_32_1_avx = avx::RaBitQFloatBinaryIP(query, base, dim, inv_sqrt_d);
-            auto ip_32_1_avx2 = avx2::RaBitQFloatBinaryIP(query, base, dim, inv_sqrt_d);
-            auto ip_32_1_avx512 = avx512::RaBitQFloatBinaryIP(query, base, dim, inv_sqrt_d);
-
             auto ip_32_32 = FP32ComputeIP(query, query, dim);
-
+            auto ip_32_1_generic = generic::RaBitQFloatBinaryIP(query, base, dim, inv_sqrt_d);
             REQUIRE(std::abs(ip_32_1_generic - ip_32_32) < 1e-4);
-            REQUIRE(std::abs(ip_32_1_sse - ip_32_32) < 1e-4);
-            REQUIRE(std::abs(ip_32_1_avx - ip_32_32) < 1e-4);
-            REQUIRE(std::abs(ip_32_1_avx2 - ip_32_32) < 1e-4);
-            REQUIRE(std::abs(ip_32_1_avx512 - ip_32_32) < 1e-4);
+
+            if (SimdStatus::SupportAVX512()) {
+                auto ip_32_1_avx512 = avx512::RaBitQFloatBinaryIP(query, base, dim, inv_sqrt_d);
+                REQUIRE(std::abs(ip_32_1_avx512 - ip_32_32) < 1e-4);
+            }
+
+            if (SimdStatus::SupportAVX2()) {
+                auto ip_32_1_avx2 = avx2::RaBitQFloatBinaryIP(query, base, dim, inv_sqrt_d);
+                REQUIRE(std::abs(ip_32_1_avx2 - ip_32_32) < 1e-4);
+            }
+
+            if (SimdStatus::SupportAVX()) {
+                auto ip_32_1_avx = avx::RaBitQFloatBinaryIP(query, base, dim, inv_sqrt_d);
+                REQUIRE(std::abs(ip_32_1_avx - ip_32_32) < 1e-4);
+            }
+
+            if (SimdStatus::SupportSSE()) {
+                auto ip_32_1_sse = sse::RaBitQFloatBinaryIP(query, base, dim, inv_sqrt_d);
+                REQUIRE(std::abs(ip_32_1_sse - ip_32_32) < 1e-4);
+            }
         }
     }
 }

--- a/src/simd/rabitq_simd_test.cpp
+++ b/src/simd/rabitq_simd_test.cpp
@@ -20,8 +20,6 @@
 
 #include "fixtures.h"
 #include "fp32_simd.h"
-#include "iostream"
-#include "simd_status.h"
 
 using namespace vsag;
 

--- a/src/simd/simd.h
+++ b/src/simd/simd.h
@@ -23,6 +23,7 @@
 #include "fp16_simd.h"
 #include "fp32_simd.h"
 #include "normalize.h"
+#include "rabitq_simd.h"
 #include "simd_status.h"
 #include "sq4_simd.h"
 #include "sq4_uniform_simd.h"

--- a/src/simd/sse.cpp
+++ b/src/simd/sse.cpp
@@ -491,6 +491,15 @@ SQ8UniformComputeCodesIP(const uint8_t* codes1, const uint8_t* codes2, uint64_t 
 #endif
 }
 
+float
+RaBitQFloatBinaryIP(const float* vector, const uint8_t* bits, uint64_t dim, float inv_sqrt_d) {
+#if defined(ENABLE_SSE)
+    return generic::RaBitQFloatBinaryIP(vector, bits, dim, inv_sqrt_d);
+#else
+    return generic::RaBitQFloatBinaryIP(vector, bits, dim, inv_sqrt_d);
+#endif
+}
+
 void
 DivScalar(const float* from, float* to, uint64_t dim, float scalar) {
 #if defined(ENABLE_SSE)

--- a/src/simd/sse.cpp
+++ b/src/simd/sse.cpp
@@ -494,7 +494,7 @@ SQ8UniformComputeCodesIP(const uint8_t* codes1, const uint8_t* codes2, uint64_t 
 float
 RaBitQFloatBinaryIP(const float* vector, const uint8_t* bits, uint64_t dim, float inv_sqrt_d) {
 #if defined(ENABLE_SSE)
-    return generic::RaBitQFloatBinaryIP(vector, bits, dim, inv_sqrt_d);
+    return generic::RaBitQFloatBinaryIP(vector, bits, dim, inv_sqrt_d);  // TODO(zxy): implement
 #else
     return generic::RaBitQFloatBinaryIP(vector, bits, dim, inv_sqrt_d);
 #endif


### PR DESCRIPTION
- add simd support for rabitq-fp32 for avx512, avx2 (not support avx and below for now since there are environmental issues occur in machine that not support avx)
- expected QPS is same with FP32-avx512
- #320

old version:
<img width="1509" alt="image" src="https://github.com/user-attachments/assets/a8f47893-427f-4b9d-883a-9632a374fa8d" />

with avx512
<img width="1520" alt="image" src="https://github.com/user-attachments/assets/f41fc884-5b8f-4f0c-b491-54f837f04cfa" />
