### PR TITLE
skip threshold Calculation method

### DIFF
--- a/src/algorithm/hnswlib/hnswalg.cpp
+++ b/src/algorithm/hnswlib/hnswalg.cpp
@@ -429,7 +429,7 @@ HierarchicalNSW::searchBaseLayerST(InnerIdType ep_id,
     MaxHeap candidate_set(allocator_);
 
     float valid_ratio = is_id_allowed ? is_id_allowed->ValidRatio() : 1.0F;
-    float skip_threshold = (1 - valid_ratio) * skip_ratio;
+    float skip_threshold = valid_ratio == 1.0F ? 0 : (1 - ((1 - valid_ratio) * skip_ratio));
 
     float lower_bound;
     if ((!has_deletions || !isMarkedDeleted(ep_id)) &&

--- a/src/impl/basic_searcher.cpp
+++ b/src/impl/basic_searcher.cpp
@@ -44,7 +44,10 @@ BasicSearcher::visit(const GraphInterfacePtr& graph,
         graph->GetNeighbors(current_node_pair.second, neighbors);
     }
 
-    float skip_threshold = (filter != nullptr ? (1 - filter->ValidRatio()) * skip_ratio : 0.0F);
+    float skip_threshold =
+        (filter != nullptr
+             ? (filter->ValidRatio() == 1.0F ? 0 : (1 - ((1 - filter->ValidRatio()) * skip_ratio)))
+             : 0.0F);
 
     for (uint32_t i = 0; i < prefetch_jump_visit_size_; i++) {
         vl->Prefetch(neighbors[i]);


### PR DESCRIPTION
Here I will first explain what the abbreviations I will explain below mean:
Efficiency: When querying, the proportion of existing vectors in the index that have not been marked for deletion to the total number of vectors
Skip rate: In order to ensure the connectivity of the graph, the query process does not skip when it finds that the vector is marked for deletion, but skips according to a certain ratio
The logic before the query data was modified was that the higher the efficiency, the lower the skip rate, and the lower the efficiency, the higher the skip rate. When the efficiency is very low, there is a lot of data with a skip rate, which greatly reduces the connectivity of the graph and leads to a low recall rate; the current logic is that the skip rate changes in direct proportion to the efficiency.
As shown in the figure below: Before the modification, the recall rate was very low when the filtering rate was high (i.e., the efficiency was low)
![image](https://github.com/user-attachments/assets/38cff583-df65-41dc-a295-2a2bfea37e39)
After the modification, the recall rate of this part returned to normal
![image](https://github.com/user-attachments/assets/fed61e60-e439-4420-9fb2-c6ca09872528)
