### PR TITLE
Support basic optimizer

### DIFF
--- a/include/vsag/constants.h
+++ b/include/vsag/constants.h
@@ -52,6 +52,11 @@ extern const char* const DATATYPE_INT8;
 extern const char* const DATATYPE_SPARSE;
 extern const char* const BLANK_INDEX;
 
+// environment-level-parameters
+extern const char* const PREFETCH_STRIDE_VISIT;
+extern const char* const PREFETCH_STRIDE_CODE;
+extern const char* const PREFETCH_DEPTH_CODE;
+
 // parameters
 extern const char* const PARAMETER_DTYPE;
 extern const char* const PARAMETER_DIM;
@@ -124,6 +129,7 @@ extern const char* const RABITQ_BITS_PER_DIM_QUERY;
 
 // hgraph params
 extern const char* const HGRAPH_USE_REORDER;
+extern const char* const HGRAPH_USE_ELP_OPTIMIZER;
 extern const char* const HGRAPH_IGNORE_REORDER;
 extern const char* const HGRAPH_BASE_QUANTIZATION_TYPE;
 extern const char* const HGRAPH_GRAPH_MAX_DEGREE;

--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -46,6 +46,7 @@ HGraph::HGraph(const HGraphParameterPtr& hgraph_param, const vsag::IndexCommonPa
     : InnerIndexInterface(hgraph_param, common_param),
       route_graphs_(common_param.allocator_.get()),
       use_reorder_(hgraph_param->use_reorder),
+      use_elp_optimizer_(hgraph_param->use_elp_optimizer),
       ignore_reorder_(hgraph_param->ignore_reorder),
       ef_construct_(hgraph_param->ef_construction),
       build_thread_count_(hgraph_param->build_thread_count),
@@ -88,6 +89,10 @@ HGraph::HGraph(const HGraphParameterPtr& hgraph_param, const vsag::IndexCommonPa
         this->build_pool_ = SafeThreadPool::FactoryDefaultThreadPool();
         this->build_pool_->SetPoolSize(build_thread_count_);
     }
+
+    if (use_elp_optimizer_) {
+        optimizer_ = std::make_shared<Optimizer<BasicSearcher>>(common_param);
+    }
 }
 void
 HGraph::Train(const DatasetPtr& base) {
@@ -102,6 +107,9 @@ std::vector<int64_t>
 HGraph::Build(const DatasetPtr& data) {
     this->Train(data);
     auto ret = this->Add(data);
+    if (use_elp_optimizer_) {
+        elp_optimize();
+    }
     return ret;
 }
 
@@ -588,6 +596,11 @@ HGraph::Deserialize(StreamReader& reader) {
         this->extra_infos_->Deserialize(reader);
     }
     this->total_count_ = this->basic_flatten_codes_->TotalCount();
+
+    // optimize
+    if (use_elp_optimizer_) {
+        elp_optimize();
+    }
 }
 
 void
@@ -859,6 +872,24 @@ HGraph::InitFeatures() {
 }
 
 void
+HGraph::elp_optimize() {
+    InnerSearchParam param;
+    param.ep = 0;
+    param.ef = 80;
+    param.topk = 10;
+    param.is_inner_id_allowed = nullptr;
+    searcher_->SetMockParameters(bottom_graph_, basic_flatten_codes_, pool_, param, dim_);
+    optimizer_->RegisterParameter(
+        RuntimeParameter(PREFETCH_DEPTH_CODE,
+                         1,
+                         (static_cast<float>(basic_flatten_codes_->code_size_) + 63.0F) / 64.0F + 2,
+                         1));
+    optimizer_->RegisterParameter(RuntimeParameter(PREFETCH_STRIDE_CODE, 1, 10, 1));
+    optimizer_->RegisterParameter(RuntimeParameter(PREFETCH_STRIDE_VISIT, 1, 10, 1));
+    optimizer_->Optimize(searcher_);
+}
+
+void
 HGraph::reorder(const void* query,
                 const FlattenInterfacePtr& flatten_interface,
                 MaxHeap& candidate_heap,
@@ -892,6 +923,12 @@ static const ConstParamMap EXTERNAL_MAPPING = {
         HGRAPH_USE_REORDER,
         {
             HGRAPH_USE_REORDER_KEY,
+        },
+    },
+    {
+        HGRAPH_USE_ELP_OPTIMIZER,
+        {
+            HGRAPH_USE_ELP_OPTIMIZER_KEY,
         },
     },
     {
@@ -1015,6 +1052,7 @@ static const std::string HGRAPH_PARAMS_TEMPLATE =
     {
         "type": "{INDEX_TYPE_HGRAPH}",
         "{HGRAPH_USE_REORDER_KEY}": false,
+        "{HGRAPH_USE_ENV_OPTIMIZER}": false,
         "{HGRAPH_IGNORE_REORDER_KEY}": false,
         "{HGRAPH_GRAPH_KEY}": {
             "{IO_PARAMS_KEY}": {

--- a/src/algorithm/hgraph.h
+++ b/src/algorithm/hgraph.h
@@ -206,6 +206,9 @@ private:
             MaxHeap& candidate_heap,
             int64_t k) const;
 
+    void
+    elp_optimize();
+
 private:
     FlattenInterfacePtr basic_flatten_codes_{nullptr};
     FlattenInterfacePtr high_precise_codes_{nullptr};
@@ -213,6 +216,7 @@ private:
     GraphInterfacePtr bottom_graph_{nullptr};
 
     mutable bool use_reorder_{false};
+    bool use_elp_optimizer_{false};
     bool ignore_reorder_{false};
 
     BasicSearcherPtr searcher_;
@@ -244,5 +248,7 @@ private:
     uint64_t extra_info_size_{0};
 
     static constexpr uint64_t DEFAULT_RESIZE_BIT = 10;
+
+    std::shared_ptr<Optimizer<BasicSearcher>> optimizer_;
 };
 }  // namespace vsag

--- a/src/algorithm/hgraph_parameter.cpp
+++ b/src/algorithm/hgraph_parameter.cpp
@@ -37,6 +37,10 @@ HGraphParameter::FromJson(const JsonType& json) {
                    fmt::format("hgraph parameters must contains {}", HGRAPH_USE_REORDER_KEY));
     this->use_reorder = json[HGRAPH_USE_REORDER_KEY];
 
+    if (json.contains(HGRAPH_USE_ELP_OPTIMIZER_KEY)) {
+        this->use_elp_optimizer = json[HGRAPH_USE_ELP_OPTIMIZER_KEY];
+    }
+
     if (json.contains(HGRAPH_IGNORE_REORDER_KEY)) {
         this->ignore_reorder = json[HGRAPH_IGNORE_REORDER_KEY];
     }
@@ -91,6 +95,7 @@ HGraphParameter::ToJson() {
     json["type"] = INDEX_TYPE_HGRAPH;
 
     json[HGRAPH_USE_REORDER_KEY] = this->use_reorder;
+    json[HGRAPH_USE_ELP_OPTIMIZER_KEY] = this->use_elp_optimizer;
     json[HGRAPH_BASE_CODES_KEY] = this->base_codes_param->ToJson();
     if (use_reorder) {
         json[HGRAPH_PRECISE_CODES_KEY] = this->precise_codes_param->ToJson();

--- a/src/algorithm/hgraph_parameter.h
+++ b/src/algorithm/hgraph_parameter.h
@@ -42,6 +42,7 @@ public:
     ExtraInfoDataCellParamPtr extra_info_param{nullptr};
 
     bool use_reorder{false};
+    bool use_elp_optimizer{false};
     bool ignore_reorder{false};
     uint64_t ef_construction{400};
     uint64_t build_thread_count{100};

--- a/src/algorithm/ivf.cpp
+++ b/src/algorithm/ivf.cpp
@@ -297,7 +297,7 @@ IVF::create_search_param(const std::string& parameters, const FilterPtr& filter)
     param.scan_bucket_size = std::min(static_cast<BucketIdType>(search_param.scan_buckets_count),
                                       bucket_->bucket_count_);
     param.factor = search_param.topk_factor;
-    return std::move(param);
+    return param;
 }
 
 DatasetPtr

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -55,6 +55,11 @@ const char* const DATATYPE_INT8 = "int8";
 const char* const DATATYPE_SPARSE = "sparse";
 const char* const BLANK_INDEX = "blank_index";
 
+// environment-level-parameters
+const char* const PREFETCH_STRIDE_VISIT = "prefetch_stride_visit";
+const char* const PREFETCH_STRIDE_CODE = "prefetch_stride_codes";
+const char* const PREFETCH_DEPTH_CODE = "prefetch_depth_codes";
+
 // parameters
 const char* const PARAMETER_DTYPE = "dtype";
 const char* const PARAMETER_DIM = "dim";
@@ -127,6 +132,7 @@ const char* const RABITQ_PCA_DIM = "rabitq_pca_dim";
 const char* const RABITQ_BITS_PER_DIM_QUERY = "rabitq_bits_per_dim_query";
 
 const char* const HGRAPH_USE_REORDER = HGRAPH_USE_REORDER_KEY;
+const char* const HGRAPH_USE_ELP_OPTIMIZER = HGRAPH_USE_ELP_OPTIMIZER_KEY;
 const char* const HGRAPH_IGNORE_REORDER = "ignore_reorder";
 const char* const HGRAPH_BASE_QUANTIZATION_TYPE = "base_quantization_type";
 const char* const HGRAPH_GRAPH_MAX_DEGREE = "max_degree";

--- a/src/impl/basic_optimizer.cpp
+++ b/src/impl/basic_optimizer.cpp
@@ -1,0 +1,106 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "basic_optimizer.h"
+
+namespace vsag {
+
+template <typename OptimizableOBJ>
+double
+Optimizer<OptimizableOBJ>::Optimize(std::shared_ptr<OptimizableOBJ> obj) {
+    vsag::logger::info(fmt::format("============Start Optimize==========="));
+    bool have_improvement = false;
+    double original_loss = obj->MockRun();
+
+    // generate a group of runtime params
+    UnorderedMap<std::string, float> current_params(allocator_);
+    for (auto& param : parameters_) {
+        bool successful_optimized = false;
+        double before_loss = obj->MockRun();
+        double best_loss = before_loss;
+        double best_improve = 0;
+
+        while (not param.IsEnd()) {
+            current_params[param.name_] = param.Cur();
+            auto set_status = obj->SetRuntimeParameters(current_params);
+            if (not set_status) {
+                continue;
+            }
+
+            // evaluate
+            double loss = obj->MockRun();
+            double improvement = (before_loss - loss) / before_loss * 100;
+            vsag::logger::info(
+                fmt::format("setting {} -> {}, get new loss = {:.3f} from before = {:.3f}, "
+                            "improving = {:.3f} %",
+                            param.name_,
+                            current_params[param.name_],
+                            loss,
+                            before_loss,
+                            improvement));
+
+            // update
+            // overall principle: choose smaller param
+            if (loss < best_loss and                  // condition1. has improvement
+                improvement - best_improve > 0.2 and  // condition2. improvement is noteworthy
+                improvement > 2.0) {                  // condition3. improvement is valid
+                successful_optimized = true;
+                have_improvement = true;
+                best_loss = loss;
+                best_improve = improvement;
+                best_params_[param.name_] = current_params[param.name_];
+            }
+
+            param.Next();
+        }
+
+        if (successful_optimized) {
+            current_params[param.name_] = best_params_[param.name_];
+            vsag::logger::info(fmt::format("setting to best param: {} -> {}, improving {:.3f}%",
+                                           param.name_,
+                                           best_params_[param.name_],
+                                           best_improve));
+        } else {
+            param.Reset();
+            current_params[param.name_] = param.Cur();
+            obj->SetRuntimeParameters(current_params);
+
+            vsag::logger::info(fmt::format(
+                "reset to original param: {} -> {}", param.name_, current_params[param.name_]));
+        }
+
+        param.Reset();
+    }
+
+    vsag::logger::info(fmt::format("============Optimize Report==========="));
+    double end2end_improvement = 0;
+    if (have_improvement) {
+        obj->SetRuntimeParameters(best_params_);
+        double optimized_loss = obj->MockRun();
+        end2end_improvement = (original_loss - optimized_loss) / original_loss * 100;
+        for (auto& param : best_params_) {
+            vsag::logger::info(fmt::format("setting {} -> {:.1f}", param.first, param.second));
+        }
+        vsag::logger::info(fmt::format("improving: {:.3f}%", end2end_improvement));
+    } else {
+        vsag::logger::info(fmt::format("no improvement"));
+    }
+
+    vsag::logger::info(fmt::format("============Finish Optimize==========="));
+    return end2end_improvement;
+}
+
+template class Optimizer<BasicSearcher>;
+}  // namespace vsag

--- a/src/impl/basic_optimizer.h
+++ b/src/impl/basic_optimizer.h
@@ -1,0 +1,57 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <random>
+
+#include "basic_searcher.h"
+#include "common.h"
+#include "data_cell/flatten_datacell.h"
+#include "index/index_common_param.h"
+#include "runtime_parameter.h"
+#include "typing.h"
+
+namespace vsag {
+
+template <typename OptimizableOBJ>
+class Optimizer {
+public:
+    Optimizer(const IndexCommonParam& common_param)
+        : parameters_(common_param.allocator_.get()), best_params_(common_param.allocator_.get()) {
+        allocator_ = common_param.allocator_.get();
+        std::random_device rd;
+        gen_.seed(rd());
+    }
+
+    double
+    Optimize(std::shared_ptr<OptimizableOBJ> obj);
+
+    void
+    RegisterParameter(const RuntimeParameter& runtime_parameter) {
+        parameters_.push_back(runtime_parameter);
+    }
+
+private:
+    Allocator* allocator_{nullptr};
+
+    std::mt19937 gen_;
+
+    Vector<RuntimeParameter> parameters_;
+
+    UnorderedMap<std::string, float> best_params_;
+};
+
+}  // namespace vsag

--- a/src/impl/basic_searcher.cpp
+++ b/src/impl/basic_searcher.cpp
@@ -15,10 +15,6 @@
 
 #include "basic_searcher.h"
 
-#include <limits>
-
-#include "utils/linear_congruential_generator.h"
-
 namespace vsag {
 
 BasicSearcher::BasicSearcher(const IndexCommonParam& common_param, MutexArrayPtr mutex_array)
@@ -50,8 +46,8 @@ BasicSearcher::visit(const GraphInterfacePtr& graph,
              : 0.0F);
 
     for (uint32_t i = 0; i < neighbors.size(); i++) {
-        if (i + prefetch_jump_visit_size_ < neighbors.size()) {
-            vl->Prefetch(neighbors[i + prefetch_jump_visit_size_]);
+        if (i + prefetch_stride_visit_ < neighbors.size()) {
+            vl->Prefetch(neighbors[i + prefetch_stride_visit_]);
         }
         if (not vl->Get(neighbors[i])) {
             if (not filter || count_no_visited == 0 || generator.NextFloat() > skip_threshold ||
@@ -335,6 +331,59 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
     }
 
     return top_candidates;
+}
+
+bool
+BasicSearcher::SetRuntimeParameters(const UnorderedMap<std::string, float>& new_params) {
+    bool ret = false;
+    auto iter = new_params.find(PREFETCH_STRIDE_VISIT);
+    if (iter != new_params.end()) {
+        prefetch_stride_visit_ = static_cast<uint32_t>(iter->second);
+        ret = true;
+    }
+
+    ret |= this->mock_flatten_->SetRuntimeParameters(new_params);
+    return ret;
+}
+
+void
+BasicSearcher::SetMockParameters(const GraphInterfacePtr& graph,
+                                 const FlattenInterfacePtr& flatten,
+                                 const std::shared_ptr<VisitedListPool>& vl_pool,
+                                 const InnerSearchParam& inner_search_param,
+                                 const uint64_t dim,
+                                 const uint32_t n_trials) {
+    mock_graph_ = graph;
+    mock_flatten_ = flatten;
+    mock_vl_pool_ = vl_pool;
+    mock_inner_search_param_ = inner_search_param;
+    mock_dim_ = dim;
+    mock_n_trials_ = n_trials;
+}
+
+double
+BasicSearcher::MockRun() const {
+    uint64_t n_trials = std::min(mock_n_trials_, mock_flatten_->TotalCount());
+
+    double time_cost = 0;
+    for (uint32_t i = 0; i < n_trials; ++i) {
+        // init param
+        Vector<uint8_t> codes(mock_flatten_->code_size_, allocator_);
+        mock_flatten_->GetCodesById(i, codes.data());
+
+        Vector<float> raw_data(mock_dim_, allocator_);
+        mock_flatten_->Decode(codes.data(), raw_data.data());
+        auto vl = mock_vl_pool_->TakeOne();
+
+        // mock run
+        auto st = std::chrono::high_resolution_clock::now();
+        Search(mock_graph_, mock_flatten_, vl, raw_data.data(), mock_inner_search_param_);
+        auto ed = std::chrono::high_resolution_clock::now();
+        time_cost += std::chrono::duration<double>(ed - st).count();
+
+        mock_vl_pool_->ReturnOne(vl);
+    }
+    return time_cost;
 }
 
 }  // namespace vsag

--- a/src/impl/runtime_parameter.h
+++ b/src/impl/runtime_parameter.h
@@ -1,0 +1,82 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <algorithm>
+#include <chrono>
+#include <functional>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <string>
+#include <thread>
+#include <variant>
+#include <vector>
+
+namespace vsag {
+
+struct RuntimeParameter {
+public:
+    RuntimeParameter(const std::string& name, float min, float max, float step = 0)
+        : name_(name), min_(min), cur_(min), max_(max), step_(step) {
+        is_end_ = false;
+        if (std::abs(step_) <= 1e-5) {
+            step_ = (max_ - min_) / 10.0;
+        }
+    }
+
+    float
+    Next() {
+        if (is_end_) {
+            Reset();
+        }
+        float prev = cur_;
+        cur_ += step_;
+        if (cur_ > max_) {
+            cur_ = min_;
+            is_end_ = true;
+        }
+        return prev;
+    }
+
+    float
+    Cur() const {
+        return cur_;
+    }
+
+    void
+    Reset() {
+        cur_ = min_;
+        is_end_ = false;
+    }
+
+    bool
+    IsEnd() const {
+        return is_end_;
+    }
+
+public:
+    std::string name_;
+
+private:
+    float min_{0};
+    float max_{0};
+    float step_{0};
+    float cur_{0};
+    bool is_end_{false};
+};
+
+}  // namespace vsag

--- a/src/inner_string_params.h
+++ b/src/inner_string_params.h
@@ -25,6 +25,7 @@ const char* const INDEX_TYPE_IVF = "ivf";
 
 // Parameter key for hgraph
 const char* const HGRAPH_USE_REORDER_KEY = "use_reorder";
+const char* const HGRAPH_USE_ELP_OPTIMIZER_KEY = "use_elp_optimizer";
 const char* const HGRAPH_IGNORE_REORDER_KEY = "ignore_reorder";
 const char* const HGRAPH_GRAPH_KEY = "graph";
 const char* const HGRAPH_BASE_CODES_KEY = "base_codes";
@@ -94,6 +95,7 @@ const std::unordered_map<std::string, std::string> DEFAULT_MAP = {
     {"INDEX_TYPE_HGRAPH", INDEX_TYPE_HGRAPH},
     {"INDEX_TYPE_IVF", INDEX_TYPE_IVF},
     {"HGRAPH_USE_REORDER_KEY", HGRAPH_USE_REORDER_KEY},
+    {"HGRAPH_USE_ELP_OPTIMIZER_KEY", HGRAPH_USE_ELP_OPTIMIZER_KEY},
     {"HGRAPH_IGNORE_REORDER_KEY", HGRAPH_IGNORE_REORDER_KEY},
     {"HGRAPH_GRAPH_KEY", HGRAPH_GRAPH_KEY},
     {"HGRAPH_BASE_CODES_KEY", HGRAPH_BASE_CODES_KEY},

--- a/tests/test_index.h
+++ b/tests/test_index.h
@@ -100,6 +100,13 @@ protected:
                   bool expected_success = true);
 
     static void
+    TestKnnSearchCompare(const IndexPtr& index_weak,
+                         const IndexPtr& index_strong,
+                         const TestDatasetPtr& dataset,
+                         const std::string& search_param,
+                         bool expected_success = true);
+
+    static void
     TestKnnSearchIter(const IndexPtr& index,
                       const TestDatasetPtr& dataset,
                       const std::string& search_param,


### PR DESCRIPTION
- #278
- baseline:
```
+-----------+------------+-----+----------+------------+----------------------------------------+-----------+-----+-----------------------------+-------------+----------------+-----------+
| Name      | NumVectors | Dim | DataType | MetricType | IndexParam                             | BuildTime | TPS | SearchParam                 | QPS         | LatencyAvg(ms) | RecallAvg |
+-----------+------------+-----+----------+------------+----------------------------------------+-----------+-----+-----------------------------+-------------+----------------+-----------+
| sq4u-fp32 | 1000000    | 960 | float32  | l2         | {"base_quantization_type":"sq4_unifor- | N/A       | N/A | {"hgraph":{"ef_search":80}} | 1000.059570 | 0.999940       | 0.860900  |
|           |            |     |          |            | m","build_thread_count":32,"ef_constr- |           |     |                             |             |                |           |
|           |            |     |          |            | uction":500,"max_degree":72,"precise_- |           |     |                             |             |                |           |
|           |            |     |          |            | io_type":"block_memory_io","precise_q- |           |     |                             |             |                |           |
|           |            |     |          |            | uantization_type":"fp32","use_reorder- |           |     |                             |             |                |           |
|           |            |     |          |            | ":true}                                |           |     |                             |             |                |           |
+-----------+------------+-----+----------+------------+----------------------------------------+-----------+-----+-----------------------------+-------------+----------------+-----------+

```
- running example:
```
[2025-04-22 16:11:59.162] [debug] created a hgraph index
[2025-04-22 16:11:59.167] [debug] train.shape: [1000000,960]
[2025-04-22 16:11:59.167] [debug] test.shape: [1000,960]
[2025-04-22 16:11:59.167] [debug] neighbors.shape: [1000,100]
[2025-04-22 16:12:06.081] [info] ============Start Optimize===========
[2025-04-22 16:12:25.314] [info] setting prefetch_depth_codes -> 1, get new loss = 6.428 from before = 6.354, improving = -1.156 %
[2025-04-22 16:12:31.458] [info] setting prefetch_depth_codes -> 2, get new loss = 6.113 from before = 6.354, improving = 3.795 %
[2025-04-22 16:12:37.719] [info] setting prefetch_depth_codes -> 3, get new loss = 6.230 from before = 6.354, improving = 1.957 %
[2025-04-22 16:12:43.543] [info] setting prefetch_depth_codes -> 4, get new loss = 5.793 from before = 6.354, improving = 8.823 %
[2025-04-22 16:12:49.729] [info] setting prefetch_depth_codes -> 5, get new loss = 6.154 from before = 6.354, improving = 3.156 %
[2025-04-22 16:12:55.482] [info] setting prefetch_depth_codes -> 6, get new loss = 5.722 from before = 6.354, improving = 9.948 %
[2025-04-22 16:13:01.755] [info] setting prefetch_depth_codes -> 7, get new loss = 6.241 from before = 6.354, improving = 1.782 %
[2025-04-22 16:13:06.819] [info] setting prefetch_depth_codes -> 8, get new loss = 5.032 from before = 6.354, improving = 20.804 %
[2025-04-22 16:13:06.819] [info] setting to best param: prefetch_depth_codes -> 8, improving 20.804%
[2025-04-22 16:13:17.205] [info] setting prefetch_stride_codes -> 1, get new loss = 5.091 from before = 5.232, improving = 2.701 %
[2025-04-22 16:13:21.871] [info] setting prefetch_stride_codes -> 2, get new loss = 4.635 from before = 5.232, improving = 11.416 %
[2025-04-22 16:13:26.601] [info] setting prefetch_stride_codes -> 3, get new loss = 4.698 from before = 5.232, improving = 10.206 %
[2025-04-22 16:13:31.125] [info] setting prefetch_stride_codes -> 4, get new loss = 4.493 from before = 5.232, improving = 14.125 %
[2025-04-22 16:13:35.767] [info] setting prefetch_stride_codes -> 5, get new loss = 4.611 from before = 5.232, improving = 11.876 %
[2025-04-22 16:13:40.326] [info] setting prefetch_stride_codes -> 6, get new loss = 4.528 from before = 5.232, improving = 13.451 %
[2025-04-22 16:13:44.553] [info] setting prefetch_stride_codes -> 7, get new loss = 4.196 from before = 5.232, improving = 19.813 %
[2025-04-22 16:13:49.087] [info] setting prefetch_stride_codes -> 8, get new loss = 4.503 from before = 5.232, improving = 13.927 %
[2025-04-22 16:13:53.656] [info] setting prefetch_stride_codes -> 9, get new loss = 4.538 from before = 5.232, improving = 13.268 %
[2025-04-22 16:13:58.162] [info] setting prefetch_stride_codes -> 10, get new loss = 4.475 from before = 5.232, improving = 14.478 %
[2025-04-22 16:13:58.162] [info] setting to best param: prefetch_stride_codes -> 7, improving 19.813%
[2025-04-22 16:14:06.966] [info] setting prefetch_stride_visit -> 1, get new loss = 4.278 from before = 4.464, improving = 4.162 %
[2025-04-22 16:14:11.539] [info] setting prefetch_stride_visit -> 2, get new loss = 4.541 from before = 4.464, improving = -1.714 %
[2025-04-22 16:14:16.007] [info] setting prefetch_stride_visit -> 3, get new loss = 4.438 from before = 4.464, improving = 0.584 %
[2025-04-22 16:14:20.211] [info] setting prefetch_stride_visit -> 4, get new loss = 4.173 from before = 4.464, improving = 6.514 %
[2025-04-22 16:14:24.599] [info] setting prefetch_stride_visit -> 5, get new loss = 4.357 from before = 4.464, improving = 2.404 %
[2025-04-22 16:14:28.624] [info] setting prefetch_stride_visit -> 6, get new loss = 3.995 from before = 4.464, improving = 10.507 %
[2025-04-22 16:14:32.914] [info] setting prefetch_stride_visit -> 7, get new loss = 4.259 from before = 4.464, improving = 4.593 %
[2025-04-22 16:14:37.322] [info] setting prefetch_stride_visit -> 8, get new loss = 4.376 from before = 4.464, improving = 1.967 %
[2025-04-22 16:14:41.607] [info] setting prefetch_stride_visit -> 9, get new loss = 4.254 from before = 4.464, improving = 4.705 %
[2025-04-22 16:14:46.026] [info] setting prefetch_stride_visit -> 10, get new loss = 4.389 from before = 4.464, improving = 1.685 %
[2025-04-22 16:14:46.027] [info] setting to best param: prefetch_stride_visit -> 6, improving 10.507%
[2025-04-22 16:14:46.027] [info] ============Optimize Report===========
[2025-04-22 16:14:50.349] [info] setting prefetch_stride_codes -> 7
[2025-04-22 16:14:50.349] [info] setting prefetch_stride_visit -> 6
[2025-04-22 16:14:50.349] [info] setting prefetch_depth_codes -> 8
[2025-04-22 16:14:50.349] [info] improving: 32.496%
[2025-04-22 16:14:50.349] [info] ============Finish Optimize===========
[2025-04-22 16:14:50.349] [info] hgraph Deserialize cost 168.330s
[2025-04-22 16:14:50.349] [debug] query count is 1000
+-----------+------------+-----+----------+------------+----------------------------------------+-----------+-----+-----------------------------+-------------+----------------+-----------+
| Name      | NumVectors | Dim | DataType | MetricType | IndexParam                             | BuildTime | TPS | SearchParam                 | QPS         | LatencyAvg(ms) | RecallAvg |
+-----------+------------+-----+----------+------------+----------------------------------------+-----------+-----+-----------------------------+-------------+----------------+-----------+
| sq4u-fp32 | 1000000    | 960 | float32  | l2         | {"base_quantization_type":"sq4_unifor- | N/A       | N/A | {"hgraph":{"ef_search":80}} | 1446.742065 | 0.691208       | 0.860900  |
|           |            |     |          |            | m","build_thread_count":32,"ef_constr- |           |     |                             |             |                |           |
|           |            |     |          |            | uction":500,"max_degree":72,"precise_- |           |     |                             |             |                |           |
|           |            |     |          |            | io_type":"block_memory_io","precise_q- |           |     |                             |             |                |           |
|           |            |     |          |            | uantization_type":"fp32","use_elp_opt- |           |     |                             |             |                |           |
|           |            |     |          |            | imizer":true,"use_reorder":true}       |           |     |                             |             |                |           |
+-----------+------------+-----+----------+------------+----------------------------------------+-----------+-----+-----------------------------+-------------+----------------+-----------+


```