### PR TITLE
Hnsw iter filter search

### DIFF
--- a/include/vsag/index.h
+++ b/include/vsag/index.h
@@ -30,6 +30,7 @@
 #include "vsag/expected.hpp"
 #include "vsag/filter.h"
 #include "vsag/index_features.h"
+#include "vsag/iterator_context.h"
 #include "vsag/readerset.h"
 
 namespace vsag {
@@ -167,6 +168,27 @@ public:
               int64_t k,
               const std::string& parameters,
               const FilterPtr& filter) const {
+        throw std::runtime_error("Index doesn't support new filter");
+    }
+
+    /**
+      * @brief Performing single KNN search on index
+      *
+      * @param query should contains dim, num_elements and vectors
+      * @param k the result size of every query
+      * @param filter represents whether an element is filtered out by pre-filter
+      * @param iter_ctx iterative filter context
+      * @return result contains
+      *                - num_elements: 1
+      *                - ids, distances: length is (num_elements * k)
+      */
+    virtual tl::expected<DatasetPtr, Error>
+    KnnSearch(const DatasetPtr& query,
+              int64_t k,
+              const std::string& parameters,
+              const FilterPtr& filter,
+              vsag::IteratorContext*& iter_ctx,
+              bool is_last_search) const {
         throw std::runtime_error("Index doesn't support new filter");
     }
 

--- a/include/vsag/index_features.h
+++ b/include/vsag/index_features.h
@@ -27,6 +27,7 @@ enum IndexFeature {
     SUPPORT_KNN_SEARCH_WITH_ID_FILTER, /**< Supports K-nearest neighbor search with ID filtering */
     SUPPORT_RANGE_SEARCH,              /**< Supports range search */
     SUPPORT_RANGE_SEARCH_WITH_ID_FILTER, /**< Supports range search with ID filtering */
+    SUPPORT_KNN_ITERATOR_FILTER_SEARCH,  /**< Support iterator filter search **/
     SUPPORT_DELETE_BY_ID,                /**< Supports deleting elements by ID */
     SUPPORT_BATCH_SEARCH,                /**< Supports batch search */
     SUPPORT_METRIC_TYPE_L2,              /**< Supports L2 metric type */

--- a/include/vsag/iterator_context.h
+++ b/include/vsag/iterator_context.h
@@ -19,6 +19,9 @@
 
 namespace vsag {
 
-class IteratorContext {};
+class IteratorContext {
+public:
+    virtual ~IteratorContext() = default;
+};
 
 };  // namespace vsag

--- a/src/algorithm/hnswlib/algorithm_interface.h
+++ b/src/algorithm/hnswlib/algorithm_interface.h
@@ -21,12 +21,14 @@
 #include <string>
 
 #include "base_filter_functor.h"
+#include "index/iterator_filter.h"
 #include "space_interface.h"
 #include "stream_reader.h"
 #include "typing.h"
 #include "vsag/dataset.h"
 #include "vsag/errors.h"
 #include "vsag/expected.hpp"
+#include "vsag/iterator_context.h"
 
 namespace hnswlib {
 
@@ -43,7 +45,9 @@ public:
               size_t k,
               size_t ef,
               const vsag::FilterPtr is_id_allowed = nullptr,
-              float skip_ratio = 0.9f) const = 0;
+              float skip_ratio = 0.9f,
+              vsag::IteratorFilterContext* iter_ctx = nullptr,
+              bool is_last_filter = false) const = 0;
 
     virtual std::priority_queue<std::pair<dist_t, LabelType>>
     searchRange(const void* query_data,

--- a/src/algorithm/hnswlib/hnswalg.cpp
+++ b/src/algorithm/hnswlib/hnswalg.cpp
@@ -24,6 +24,7 @@
 
 namespace hnswlib {
 
+const static InnerIdType UNUSED_ENTRY_POINT_NODE = 0;
 HierarchicalNSW::HierarchicalNSW(SpaceInterface* s,
                                  size_t max_elements,
                                  vsag::Allocator* allocator,
@@ -419,7 +420,8 @@ HierarchicalNSW::searchBaseLayerST(InnerIdType ep_id,
                                    const void* data_point,
                                    size_t ef,
                                    const vsag::FilterPtr is_id_allowed,
-                                   const float skip_ratio) const {
+                                   const float skip_ratio,
+                                   vsag::IteratorFilterContext* iter_ctx) const {
     vsag::LinearCongruentialGenerator generator;
     VisitedListPtr vl = visited_list_pool_->getFreeVisitedList();
     vl_type* visited_array = vl->mass;
@@ -432,18 +434,33 @@ HierarchicalNSW::searchBaseLayerST(InnerIdType ep_id,
     float skip_threshold = valid_ratio == 1.0F ? 0 : (1 - ((1 - valid_ratio) * skip_ratio));
 
     float lower_bound;
-    if ((!has_deletions || !isMarkedDeleted(ep_id)) &&
-        ((!is_id_allowed) || is_id_allowed->CheckValid(getExternalLabel(ep_id)))) {
-        float dist = fstdistfunc_(data_point, getDataByInternalId(ep_id), dist_func_param_);
-        lower_bound = dist;
-        top_candidates.emplace(dist, ep_id);
-        candidate_set.emplace(-dist, ep_id);
+    if (iter_ctx != nullptr && !iter_ctx->IsFirstUsed()) {
+        lower_bound = 0.0;
+        while (!iter_ctx->Empty()) {
+            uint32_t cur_inner_id = iter_ctx->GetTopID();
+            float cur_dist = iter_ctx->GetTopDist();
+            if (visited_array[cur_inner_id] != visited_array_tag &&
+                iter_ctx->CheckPoint(cur_inner_id)) {
+                visited_array[cur_inner_id] = visited_array_tag;
+                top_candidates.emplace(cur_dist, cur_inner_id);
+                candidate_set.emplace(-cur_dist, cur_inner_id);
+                lower_bound = std::max(lower_bound, cur_dist);
+            }
+            iter_ctx->PopDiscard();
+        }
     } else {
-        lower_bound = std::numeric_limits<float>::max();
-        candidate_set.emplace(-lower_bound, ep_id);
+        if ((!has_deletions || !isMarkedDeleted(ep_id)) &&
+            ((!is_id_allowed) || is_id_allowed->CheckValid(getExternalLabel(ep_id)))) {
+            float dist = fstdistfunc_(data_point, getDataByInternalId(ep_id), dist_func_param_);
+            lower_bound = dist;
+            top_candidates.emplace(dist, ep_id);
+            candidate_set.emplace(-dist, ep_id);
+        } else {
+            lower_bound = std::numeric_limits<float>::max();
+            candidate_set.emplace(-lower_bound, ep_id);
+        }
+        visited_array[ep_id] = visited_array_tag;
     }
-
-    visited_array[ep_id] = visited_array_tag;
 
     while (not candidate_set.empty()) {
         std::pair<float, InnerIdType> current_node_pair = candidate_set.top();
@@ -491,8 +508,9 @@ HierarchicalNSW::searchBaseLayerST(InnerIdType ep_id,
                     not is_id_allowed->CheckValid(getExternalLabel(candidate_id))) {
                     continue;
                 }
+                float dist = 0;
                 char* currObj1 = getDataByInternalId(candidate_id);
-                float dist = fstdistfunc_(data_point, currObj1, dist_func_param_);
+                dist = fstdistfunc_(data_point, currObj1, dist_func_param_);
                 if (top_candidates.size() < ef || lower_bound > dist) {
                     candidate_set.emplace(-dist, candidate_id);
                     vector_data_ptr = data_level0_memory_->GetElementPtr(candidate_set.top().second,
@@ -503,11 +521,20 @@ HierarchicalNSW::searchBaseLayerST(InnerIdType ep_id,
 
                     if ((!has_deletions || !isMarkedDeleted(candidate_id)) &&
                         ((!is_id_allowed) ||
-                         is_id_allowed->CheckValid(getExternalLabel(candidate_id))))
+                         is_id_allowed->CheckValid(getExternalLabel(candidate_id)))) {
+                        if (iter_ctx != nullptr && !iter_ctx->CheckPoint(candidate_id)) {
+                            continue;
+                        }
                         top_candidates.emplace(dist, candidate_id);
+                    }
 
-                    if (top_candidates.size() > ef)
+                    if (top_candidates.size() > ef) {
+                        auto cur_node_pair = top_candidates.top();
+                        if (iter_ctx != nullptr && iter_ctx->CheckPoint(cur_node_pair.second)) {
+                            iter_ctx->AddDiscardNode(cur_node_pair.first, cur_node_pair.second);
+                        }
                         top_candidates.pop();
+                    }
 
                     if (not top_candidates.empty())
                         lower_bound = top_candidates.top().first;
@@ -1424,7 +1451,9 @@ HierarchicalNSW::searchKnn(const void* query_data,
                            size_t k,
                            uint64_t ef,
                            const vsag::FilterPtr is_id_allowed,
-                           const float skip_ratio) const {
+                           const float skip_ratio,
+                           vsag::IteratorFilterContext* iter_ctx,
+                           bool is_last_filter) const {
     std::shared_lock resize_lock(resize_mutex_);
     std::priority_queue<std::pair<float, LabelType>> result;
     if (cur_element_count_ == 0)
@@ -1432,59 +1461,88 @@ HierarchicalNSW::searchKnn(const void* query_data,
 
     std::shared_ptr<float[]> normalize_query;
     normalizeVector(query_data, normalize_query);
-    int64_t currObj;
-    {
-        std::shared_lock data_loc(max_level_mutex_);
-        currObj = enterpoint_node_;
-    }
-    if (currObj > cur_element_count_) {
-        return result;
-    }
+    MaxHeap top_candidates(allocator_);
+    if (iter_ctx != nullptr && !iter_ctx->IsFirstUsed()) {
+        if (iter_ctx->Empty())
+            return result;
+        if (is_last_filter) {
+            while (!iter_ctx->Empty()) {
+                uint32_t cur_inner_id = iter_ctx->GetTopID();
+                float cur_dist = iter_ctx->GetTopDist();
+                result.emplace(cur_dist, getExternalLabel(cur_inner_id));
+                iter_ctx->PopDiscard();
+            }
+            return result;
+        }
+        top_candidates = searchBaseLayerST<false, true>(UNUSED_ENTRY_POINT_NODE,
+                                                        query_data,
+                                                        std::max(ef, k),
+                                                        is_id_allowed,
+                                                        skip_ratio,
+                                                        iter_ctx);
+    } else {
+        int64_t currObj;
+        {
+            std::shared_lock data_loc(max_level_mutex_);
+            currObj = enterpoint_node_;
+        }
+        if (currObj > cur_element_count_) {
+            return result;
+        }
 
-    float curdist = fstdistfunc_(query_data, getDataByInternalId(currObj), dist_func_param_);
-    for (int level = max_level_; level > 0; level--) {
-        bool changed = true;
-        while (changed) {
-            changed = false;
-            auto link_data = getLinklistAtLevelWithLock(currObj, level);
-            auto* data = (unsigned int*)link_data.get();
-            int size = getListCount(data);
-            //            metric_hops_++;
-            //            metric_distance_computations_ += size;
+        float curdist = fstdistfunc_(query_data, getDataByInternalId(currObj), dist_func_param_);
+        for (int level = max_level_; level > 0; level--) {
+            bool changed = true;
+            while (changed) {
+                changed = false;
+                auto link_data = getLinklistAtLevelWithLock(currObj, level);
+                auto* data = (unsigned int*)link_data.get();
+                int size = getListCount(data);
+                //            metric_hops_++;
+                //            metric_distance_computations_ += size;
 
-            auto* datal = (InnerIdType*)(data + 1);
-            for (int i = 0; i < size; i++) {
-                InnerIdType cand = datal[i];
-                if (cand > max_elements_)
-                    throw std::runtime_error("cand error");
-                float d = fstdistfunc_(query_data, getDataByInternalId(cand), dist_func_param_);
+                auto* datal = (InnerIdType*)(data + 1);
+                for (int i = 0; i < size; i++) {
+                    InnerIdType cand = datal[i];
+                    if (cand > max_elements_)
+                        throw std::runtime_error("cand error");
+                    float d = fstdistfunc_(query_data, getDataByInternalId(cand), dist_func_param_);
 
-                if (d < curdist) {
-                    curdist = d;
-                    currObj = cand;
-                    changed = true;
+                    if (d < curdist) {
+                        curdist = d;
+                        currObj = cand;
+                        changed = true;
+                    }
                 }
             }
         }
-    }
 
-    MaxHeap top_candidates(allocator_);
-
-    if (num_deleted_ == 0) {
-        top_candidates = searchBaseLayerST<false, true>(
-            currObj, query_data, std::max(ef, k), is_id_allowed, skip_ratio);
-    } else {
-        top_candidates = searchBaseLayerST<true, true>(
-            currObj, query_data, std::max(ef, k), is_id_allowed, skip_ratio);
+        if (num_deleted_ == 0) {
+            top_candidates = searchBaseLayerST<false, true>(
+                currObj, query_data, std::max(ef, k), is_id_allowed, skip_ratio, iter_ctx);
+        } else {
+            top_candidates = searchBaseLayerST<true, true>(
+                currObj, query_data, std::max(ef, k), is_id_allowed, skip_ratio, iter_ctx);
+        }
     }
 
     while (top_candidates.size() > k) {
+        if (iter_ctx != nullptr) {
+            std::pair<float, InnerIdType> curr = top_candidates.top();
+            iter_ctx->AddDiscardNode(curr.first, curr.second);
+        }
         top_candidates.pop();
     }
     while (not top_candidates.empty()) {
         std::pair<float, InnerIdType> rez = top_candidates.top();
         result.emplace(rez.first, getExternalLabel(rez.second));
+        if (iter_ctx != nullptr) {
+            iter_ctx->SetPoint(rez.second);
+        }
         top_candidates.pop();
+    }
+    if (iter_ctx != nullptr) {
+        iter_ctx->SetOFFFirstUsed();
     }
     return result;
 }
@@ -1578,11 +1636,13 @@ HierarchicalNSW::setDataAndGraph(vsag::FlattenInterfacePtr& data,
 }
 
 template MaxHeap
-HierarchicalNSW::searchBaseLayerST<false, false>(InnerIdType ep_id,
-                                                 const void* data_point,
-                                                 size_t ef,
-                                                 const vsag::FilterPtr is_id_allowed,
-                                                 const float skip_ratio) const;
+HierarchicalNSW::searchBaseLayerST<false, false>(
+    InnerIdType ep_id,
+    const void* data_point,
+    size_t ef,
+    const vsag::FilterPtr is_id_allowed,
+    const float skip_ratio,
+    vsag::IteratorFilterContext* iter_ctx = nullptr) const;
 
 template MaxHeap
 HierarchicalNSW::searchBaseLayerST<false, false>(InnerIdType ep_id,

--- a/src/algorithm/hnswlib/hnswalg.h
+++ b/src/algorithm/hnswlib/hnswalg.h
@@ -37,10 +37,12 @@
 #include "data_cell/flatten_interface.h"
 #include "data_cell/graph_interface.h"
 #include "default_allocator.h"
+#include "index/iterator_filter.h"
 #include "prefetch.h"
 #include "simd/simd.h"
 #include "visited_list_pool.h"
 #include "vsag/dataset.h"
+#include "vsag/iterator_context.h"
 namespace hnswlib {
 using InnerIdType = vsag::InnerIdType;
 using linklistsizeint = unsigned int;
@@ -251,7 +253,8 @@ public:
                       const void* data_point,
                       size_t ef,
                       const vsag::FilterPtr is_id_allowed = nullptr,
-                      const float skip_ratio = 0.9f) const;
+                      const float skip_ratio = 0.9f,
+                      vsag::IteratorFilterContext* iter_ctx = nullptr) const;
 
     template <bool has_deletions, bool collect_metrics = false>
     MaxHeap
@@ -410,7 +413,9 @@ public:
               size_t k,
               uint64_t ef,
               const vsag::FilterPtr is_id_allowed = nullptr,
-              const float skip_ratio = 0.9f) const override;
+              const float skip_ratio = 0.9f,
+              vsag::IteratorFilterContext* iter_ctx = nullptr,
+              bool is_last_filter = false) const override;
 
     std::priority_queue<std::pair<float, LabelType>>
     searchRange(const void* query_data,

--- a/src/algorithm/hnswlib/hnswalg_static.h
+++ b/src/algorithm/hnswlib/hnswalg_static.h
@@ -1450,7 +1450,9 @@ public:
               size_t k,
               uint64_t ef,
               const vsag::FilterPtr is_id_allowed = nullptr,
-              const float skip_ratio = 0.9f) const override {
+              const float skip_ratio = 0.9f,
+              vsag::IteratorFilterContext* iter_ctx = nullptr,
+              bool is_last_filter = false) const override {
         std::priority_queue<std::pair<float, LabelType>> result;
         if (cur_element_count_ == 0)
             return result;

--- a/src/index/hnsw.cpp
+++ b/src/index/hnsw.cpp
@@ -237,7 +237,7 @@ HNSW::knn_search(const DatasetPtr& query,
         auto params = HnswSearchParameters::FromJson(parameters);
 
         if (iter_ctx != nullptr && *iter_ctx == nullptr) {
-            IteratorFilterContext* filter_context = new IteratorFilterContext();
+            auto* filter_context = new IteratorFilterContext();
             filter_context->init(alg_hnsw_->getMaxElements(), params.ef_search, allocator_.get());
             *iter_ctx = filter_context;
         }

--- a/src/index/hnsw.cpp
+++ b/src/index/hnsw.cpp
@@ -203,7 +203,9 @@ tl::expected<DatasetPtr, Error>
 HNSW::knn_search(const DatasetPtr& query,
                  int64_t k,
                  const std::string& parameters,
-                 const FilterPtr& filter_ptr) const {
+                 const FilterPtr& filter_ptr,
+                 vsag::IteratorContext** iter_ctx,
+                 bool is_last_filter) const {
 #ifndef ENABLE_TESTS
     SlowTaskTimer t_total("hnsw knnsearch", 20);
 #endif
@@ -234,6 +236,16 @@ HNSW::knn_search(const DatasetPtr& query,
         // check search parameters
         auto params = HnswSearchParameters::FromJson(parameters);
 
+        if (iter_ctx != nullptr && *iter_ctx == nullptr) {
+            IteratorFilterContext* filter_context = new IteratorFilterContext();
+            filter_context->init(alg_hnsw_->getMaxElements(), params.ef_search, allocator_.get());
+            *iter_ctx = filter_context;
+        }
+        IteratorFilterContext* iter_filter_ctx = nullptr;
+        if (iter_ctx != nullptr) {
+            iter_filter_ctx = static_cast<IteratorFilterContext*>(*iter_ctx);
+        }
+
         // perform search
         int64_t original_k = k;
         std::priority_queue<std::pair<float, LabelType>> results;
@@ -247,7 +259,9 @@ HNSW::knn_search(const DatasetPtr& query,
                                            k,
                                            std::max(params.ef_search, k),
                                            filter_ptr,
-                                           params.skip_ratio);
+                                           params.skip_ratio,
+                                           iter_filter_ctx,
+                                           is_last_filter);
         } catch (const std::runtime_error& e) {
             LOG_ERROR_AND_RETURNS(ErrorType::INTERNAL_ERROR,
                                   "failed to perofrm knn_search(internalError): ",
@@ -954,7 +968,8 @@ HNSW::init_feature_list() {
     feature_list_.SetFeatures({IndexFeature::SUPPORT_KNN_SEARCH,
                                IndexFeature::SUPPORT_RANGE_SEARCH,
                                IndexFeature::SUPPORT_KNN_SEARCH_WITH_ID_FILTER,
-                               IndexFeature::SUPPORT_RANGE_SEARCH_WITH_ID_FILTER});
+                               IndexFeature::SUPPORT_RANGE_SEARCH_WITH_ID_FILTER,
+                               IndexFeature::SUPPORT_KNN_ITERATOR_FILTER_SEARCH});
     // concurrency
     feature_list_.SetFeatures({IndexFeature::SUPPORT_SEARCH_CONCURRENT,
                                IndexFeature::SUPPORT_ADD_SEARCH_CONCURRENT,

--- a/src/index/hnsw.h
+++ b/src/index/hnsw.h
@@ -44,6 +44,7 @@
 #include "vsag/binaryset.h"
 #include "vsag/errors.h"
 #include "vsag/index.h"
+#include "vsag/iterator_context.h"
 #include "vsag/readerset.h"
 
 namespace vsag {
@@ -108,6 +109,17 @@ public:
               const std::string& parameters,
               const FilterPtr& filter) const override {
         SAFE_CALL(return this->knn_search(query, k, parameters, filter));
+    }
+
+    tl::expected<DatasetPtr, Error>
+    KnnSearch(const DatasetPtr& query,
+              int64_t k,
+              const std::string& parameters,
+              const FilterPtr& filter,
+              vsag::IteratorContext*& filter_ctx,
+              bool is_last_search) const override {
+        SAFE_CALL(
+            return this->knn_search(query, k, parameters, filter, &filter_ctx, is_last_search));
     }
 
     tl::expected<DatasetPtr, Error>
@@ -264,7 +276,9 @@ private:
     knn_search(const DatasetPtr& query,
                int64_t k,
                const std::string& parameters,
-               const FilterPtr& filter_ptr) const;
+               const FilterPtr& filter_ptr,
+               vsag::IteratorContext** iter_ctx = nullptr,
+               bool is_last_filter = false) const;
 
     template <typename FilterType>
     tl::expected<DatasetPtr, Error>

--- a/src/index/iterator_filter.h
+++ b/src/index/iterator_filter.h
@@ -32,7 +32,6 @@ public:
 
 public:
     IteratorFilterContext() : is_first_used_(true){};
-
     ~IteratorFilterContext();
 
     tl::expected<void, Error>
@@ -69,9 +68,9 @@ public:
     GetDiscardElementNum();
 
 private:
-    int64_t ef_search_;
+    int64_t ef_search_{-1};
     bool is_first_used_{true};
-    uint32_t max_size_;
+    uint32_t max_size_{0};
     Allocator* allocator_{nullptr};
     VisitedListType* list_{nullptr};
     std::unique_ptr<std::priority_queue<std::pair<float, uint32_t>>> discard_;

--- a/tests/test_hnsw_new.cpp
+++ b/tests/test_hnsw_new.cpp
@@ -218,6 +218,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex,
         auto dataset = pool.GetDatasetAndCreate(dim, base_count, metric_type);
         TestContinueAdd(index, dataset, true);
         TestKnnSearch(index, dataset, search_param, 0.99, true);
+        TestKnnSearchIter(index, dataset, search_param, 0.99, true);
         TestConcurrentKnnSearch(index, dataset, search_param, 0.99, true);
         TestRangeSearch(index, dataset, search_param, 0.99, 10, true);
         TestRangeSearch(index, dataset, search_param, 0.49, 5, true);

--- a/tests/test_index.cpp
+++ b/tests/test_index.cpp
@@ -404,6 +404,75 @@ private:
 };
 
 void
+TestIndex::TestKnnSearchIter(const IndexPtr& index,
+                             const TestDatasetPtr& dataset,
+                             const std::string& search_param,
+                             float expected_recall,
+                             bool expected_success) {
+    if (not index->CheckFeature(vsag::SUPPORT_KNN_ITERATOR_FILTER_SEARCH)) {
+        return;
+    }
+    auto queries = dataset->query_;
+    auto query_count = queries->GetNumElements();
+    auto dim = queries->GetDim();
+    auto gts = dataset->filter_ground_truth_;
+    auto gt_topK = dataset->top_k;
+    float cur_recall = 0.0f;
+    auto topk = gt_topK;
+    auto filter = std::make_shared<FilterObj>(dataset->filter_function_, dataset->valid_ratio_);
+    int64_t first_top = topk / 3;
+    int64_t second_top = topk / 3;
+    int64_t third_top = topk - first_top - second_top;
+    int64_t* ids = new int64_t[topk];
+    for (auto i = 0; i < query_count; ++i) {
+        vsag::IteratorContext* filter_ctx = nullptr;
+        int64_t element_cnt = index->GetNumElements();
+        if (element_cnt < 30) {
+            continue;
+        }
+        auto query = vsag::Dataset::Make();
+        query->NumElements(1)
+            ->Dim(dim)
+            ->Float32Vectors(queries->GetFloat32Vectors() + i * dim)
+            ->Paths(queries->GetPaths() + i)
+            ->Owner(false);
+        auto res = index->KnnSearch(query, first_top, search_param, filter, filter_ctx, false);
+        REQUIRE(res.has_value() == expected_success);
+        if (!expected_success) {
+            return;
+        }
+        int64_t get_cnt = res.value()->GetDim();
+        REQUIRE(res.value()->GetDim() == first_top);
+        memcpy(ids, res.value()->GetIds(), sizeof(int64_t) * first_top);
+        auto res2 = index->KnnSearch(query, second_top, search_param, filter, filter_ctx, false);
+        REQUIRE(res2.has_value() == expected_success);
+        if (!expected_success) {
+            return;
+        }
+        REQUIRE(res2.value()->GetDim() == second_top);
+        memcpy(ids + first_top, res2.value()->GetIds(), sizeof(int64_t) * second_top);
+        auto res3 = index->KnnSearch(query, third_top, search_param, filter, filter_ctx, true);
+        REQUIRE(res3.has_value() == expected_success);
+        if (!expected_success) {
+            return;
+        }
+        REQUIRE(res3.value()->GetDim() == third_top);
+        memcpy(ids + first_top + second_top, res3.value()->GetIds(), sizeof(int64_t) * third_top);
+        auto gt = gts->GetIds() + gt_topK * i;
+        auto val = Intersection(gt, gt_topK, ids, topk);
+        cur_recall += static_cast<float>(val) / static_cast<float>(gt_topK);
+        delete filter_ctx;
+    }
+    delete[] ids;
+    if (cur_recall <= expected_recall * query_count) {
+        WARN(fmt::format("cur_result({}) <= expected_recall * query_count({})",
+                         cur_recall,
+                         expected_recall * query_count));
+    }
+    REQUIRE(cur_recall > expected_recall * query_count * RECALL_THRESHOLD);
+}
+
+void
 TestIndex::TestFilterSearch(const TestIndex::IndexPtr& index,
                             const TestDatasetPtr& dataset,
                             const std::string& search_param,

--- a/tests/test_index.h
+++ b/tests/test_index.h
@@ -95,6 +95,13 @@ protected:
                   bool expected_success = true);
 
     static void
+    TestKnnSearchIter(const IndexPtr& index,
+                      const TestDatasetPtr& dataset,
+                      const std::string& search_param,
+                      float expected_recall = 0.99,
+                      bool expected_success = true);
+
+    static void
     TestSearchWithDirtyVector(const IndexPtr& index,
                               const TestDatasetPtr& dataset,
                               const std::string& search_param,


### PR DESCRIPTION
A discard heap is introduced. The function of the discard heap is to save the nodes discarded in the previous round of queries and sort them by distance. If the results in the first round of queries are insufficient, another round of queries will be performed. In the next round, the nodes in the discard heap are used as candidate sets, and the neighbors that have not been visited are visited as new output results, and the discard heap is updated. Each subsequent round of queries will query ef_search nodes. The query ends when limitK is satisfied or discard is empty.