### PR TITLE
remove the internal default resource creation while constructing engine

### DIFF
--- a/examples/cpp/103_index_hgraph.cpp
+++ b/examples/cpp/103_index_hgraph.cpp
@@ -54,7 +54,7 @@ main(int argc, char** argv) {
         }
     }
     )";
-    vsag::Resource resource(vsag::Engine::CreateAllocator(), nullptr);
+    vsag::Resource resource(vsag::Engine::CreateDefaultAllocator(), nullptr);
     vsag::Engine engine(&resource);
     auto index = engine.CreateIndex("hgraph", hgraph_build_parameters).value();
 

--- a/examples/cpp/103_index_hgraph.cpp
+++ b/examples/cpp/103_index_hgraph.cpp
@@ -54,7 +54,9 @@ main(int argc, char** argv) {
         }
     }
     )";
-    vsag::Engine engine;
+    auto allocator = vsag::Engine::CreateAllocator();
+    vsag::Resource resource(allocator->get(), nullptr);
+    vsag::Engine engine(&resource);
     auto index = engine.CreateIndex("hgraph", hgraph_build_parameters).value();
 
     /******************* Build HGraph Index *****************/

--- a/examples/cpp/103_index_hgraph.cpp
+++ b/examples/cpp/103_index_hgraph.cpp
@@ -54,8 +54,7 @@ main(int argc, char** argv) {
         }
     }
     )";
-    auto allocator = vsag::Engine::CreateAllocator();
-    vsag::Resource resource(allocator->get(), nullptr);
+    vsag::Resource resource(vsag::Engine::CreateAllocator(), nullptr);
     vsag::Engine engine(&resource);
     auto index = engine.CreateIndex("hgraph", hgraph_build_parameters).value();
 

--- a/examples/cpp/203_custom_thread_pool.cpp
+++ b/examples/cpp/203_custom_thread_pool.cpp
@@ -25,7 +25,7 @@ main() {
     vsag::Options::Instance().logger()->SetLevel(vsag::Logger::kINFO);
 
     /******************* Customize Thread Pool *****************/
-    auto pool = std::make_shared<vsag::SafeThreadPool>(new vsag::DefaultThreadPool(16), true);
+    auto pool = vsag::Engine::CreateThreadPool(16).value();
     auto allocator = vsag::Engine::CreateAllocator().value();
     vsag::Resource resource(allocator.get(), pool.get());
     vsag::Engine engine(&resource);

--- a/examples/cpp/203_custom_thread_pool.cpp
+++ b/examples/cpp/203_custom_thread_pool.cpp
@@ -26,7 +26,7 @@ main() {
 
     /******************* Customize Thread Pool *****************/
     auto pool = vsag::Engine::CreateThreadPool(16).value();
-    auto allocator = vsag::Engine::CreateAllocator().value();
+    auto allocator = vsag::Engine::CreateAllocator();
     vsag::Resource resource(allocator.get(), pool.get());
     vsag::Engine engine(&resource);
 

--- a/examples/cpp/203_custom_thread_pool.cpp
+++ b/examples/cpp/203_custom_thread_pool.cpp
@@ -26,7 +26,7 @@ main() {
 
     /******************* Customize Thread Pool *****************/
     auto pool = vsag::Engine::CreateThreadPool(16).value();
-    auto allocator = vsag::Engine::CreateAllocator();
+    auto allocator = vsag::Engine::CreateDefaultAllocator();
     vsag::Resource resource(allocator.get(), pool.get());
     vsag::Engine engine(&resource);
 

--- a/examples/cpp/203_custom_thread_pool.cpp
+++ b/examples/cpp/203_custom_thread_pool.cpp
@@ -18,7 +18,6 @@
 #include "default_thread_pool.h"
 #include "safe_thread_pool.h"
 #include "vsag/logger.h"
-#include "vsag/thread_pool.h"
 #include "vsag/vsag.h"
 
 int
@@ -27,7 +26,8 @@ main() {
 
     /******************* Customize Thread Pool *****************/
     auto pool = std::make_shared<vsag::SafeThreadPool>(new vsag::DefaultThreadPool(16), true);
-    vsag::Resource resource(nullptr, pool.get());
+    auto allocator = vsag::Engine::CreateAllocator().value();
+    vsag::Resource resource(allocator.get(), pool.get());
     vsag::Engine engine(&resource);
 
     vsag::init();

--- a/examples/cpp/401_persistent_kv.cpp
+++ b/examples/cpp/401_persistent_kv.cpp
@@ -127,7 +127,9 @@ main(int32_t argc, char** argv) {
     }
 
     /******************* Create an Index *****************/
-    vsag::Engine engine;
+    auto allocator = vsag::Engine::CreateAllocator();
+    vsag::Resource resource(allocator->get(), nullptr);
+    vsag::Engine engine(&resource);
     auto index_paramesters = R"(
     {
         "dtype": "float32",

--- a/examples/cpp/401_persistent_kv.cpp
+++ b/examples/cpp/401_persistent_kv.cpp
@@ -127,8 +127,7 @@ main(int32_t argc, char** argv) {
     }
 
     /******************* Create an Index *****************/
-    auto allocator = vsag::Engine::CreateAllocator();
-    vsag::Resource resource(allocator->get(), nullptr);
+    vsag::Resource resource(vsag::Engine::CreateAllocator(), nullptr);
     vsag::Engine engine(&resource);
     auto index_paramesters = R"(
     {

--- a/examples/cpp/401_persistent_kv.cpp
+++ b/examples/cpp/401_persistent_kv.cpp
@@ -127,7 +127,7 @@ main(int32_t argc, char** argv) {
     }
 
     /******************* Create an Index *****************/
-    vsag::Resource resource(vsag::Engine::CreateAllocator(), nullptr);
+    vsag::Resource resource(vsag::Engine::CreateDefaultAllocator(), nullptr);
     vsag::Engine engine(&resource);
     auto index_paramesters = R"(
     {

--- a/examples/cpp/402_persistent_streaming.cpp
+++ b/examples/cpp/402_persistent_streaming.cpp
@@ -45,7 +45,9 @@ main(int32_t argc, char** argv) {
     }
 
     /******************* Create an Index *****************/
-    vsag::Engine engine;
+    auto allocator = vsag::Engine::CreateAllocator();
+    vsag::Resource resource(allocator->get(), nullptr);
+    vsag::Engine engine(&resource);
     auto index_paramesters = R"(
     {
         "dtype": "float32",

--- a/examples/cpp/402_persistent_streaming.cpp
+++ b/examples/cpp/402_persistent_streaming.cpp
@@ -45,7 +45,7 @@ main(int32_t argc, char** argv) {
     }
 
     /******************* Create an Index *****************/
-    vsag::Resource resource(vsag::Engine::CreateAllocator(), nullptr);
+    vsag::Resource resource(vsag::Engine::CreateDefaultAllocator(), nullptr);
     vsag::Engine engine(&resource);
     auto index_paramesters = R"(
     {

--- a/examples/cpp/402_persistent_streaming.cpp
+++ b/examples/cpp/402_persistent_streaming.cpp
@@ -45,8 +45,7 @@ main(int32_t argc, char** argv) {
     }
 
     /******************* Create an Index *****************/
-    auto allocator = vsag::Engine::CreateAllocator();
-    vsag::Resource resource(allocator->get(), nullptr);
+    vsag::Resource resource(vsag::Engine::CreateAllocator(), nullptr);
     vsag::Engine engine(&resource);
     auto index_paramesters = R"(
     {

--- a/include/vsag/engine.h
+++ b/include/vsag/engine.h
@@ -17,9 +17,11 @@
 
 #include <memory>
 
+#include "allocator.h"
 #include "dataset.h"
 #include "index.h"
 #include "resource.h"
+#include "thread_pool.h"
 
 namespace vsag {
 /**
@@ -30,15 +32,6 @@ namespace vsag {
  */
 class Engine {
 public:
-    /**
-     * @brief Constructs an Engine with default settings.
-     *
-     * Initializes an `Engine` instance without explicitly set resources.
-     * Default Resource will be used and managed.
-     * User can use the resource safely until the engine shutdown or destruct.
-     */
-    explicit Engine();
-
     /**
      * @brief Constructs an Engine with a provided outside resource.
      *
@@ -74,6 +67,33 @@ public:
      */
     tl::expected<std::shared_ptr<Index>, Error>
     CreateIndex(const std::string& name, const std::string& parameters);
+
+    /**
+     * @brief Creates a memory allocator within the engine.
+     *
+     * This function attempts to create a memory allocator and returns a result which may either
+     * contain a shared pointer to the created `Allocator` or an `Error` object indicating failure
+     * conditions. This is typically used for custom memory management strategies.
+     *
+     * @return tl::expected<std::shared_ptr<Allocator>, Error> An expected value that contains either
+     * a shared pointer to the successfully created `Allocator` or an `Error` detailing
+     */
+    static tl::expected<std::shared_ptr<Allocator>, Error>
+    CreateAllocator();
+
+    /**
+     * @brief Creates a thread pool for concurrent task execution.
+     *
+     * This function attempts to create a thread pool with the specified number of worker threads.
+     * It returns a result which may either contain a shared pointer to the created `ThreadPool`
+     * or an `Error` object indicating failure conditions (e.g., invalid thread count).
+     *
+     * @param num_threads The number of worker threads to initialize in the thread pool.
+     * @return tl::expected<std::shared_ptr<ThreadPool>, Error> An expected value that contains either
+     * a shared pointer to the successfully created `ThreadPool` or an `Error` detailing
+     */
+    static tl::expected<std::shared_ptr<ThreadPool>, Error>
+    CreateThreadPool(uint32_t num_threads);
 
 private:
     std::shared_ptr<Resource> resource_;  ///< The resource used by this engine.

--- a/include/vsag/engine.h
+++ b/include/vsag/engine.h
@@ -81,7 +81,7 @@ public:
      *         pointer if creation failed. The caller must check for null to handle allocation errors.
      */
     static std::shared_ptr<Allocator>
-    CreateAllocator();
+    CreateDefaultAllocator();
 
     /**
      * @brief Creates a thread pool for concurrent task execution.

--- a/include/vsag/engine.h
+++ b/include/vsag/engine.h
@@ -69,16 +69,18 @@ public:
     CreateIndex(const std::string& name, const std::string& parameters);
 
     /**
-     * @brief Creates a memory allocator within the engine.
+     * @brief Creates a memory allocator instance managed by the engine.
      *
-     * This function attempts to create a memory allocator and returns a result which may either
-     * contain a shared pointer to the created `Allocator` or an `Error` object indicating failure
-     * conditions. This is typically used for custom memory management strategies.
+     * This function initializes and returns a shared pointer to a newly created `Allocator` object
+     * for memory management purposes within the engine. If the allocator cannot be created due to
+     * resource constraints or invalid configuration (e.g., out of memory), the function returns an
+     * empty `std::shared_ptr` and logs an error. This is commonly used to integrate custom memory
+     * allocation strategies into the system.
      *
-     * @return tl::expected<std::shared_ptr<Allocator>, Error> An expected value that contains either
-     * a shared pointer to the successfully created `Allocator` or an `Error` detailing
+     * @return std::shared_ptr<Allocator> A shared pointer to the created Allocator, or an empty
+     *         pointer if creation failed. The caller must check for null to handle allocation errors.
      */
-    static tl::expected<std::shared_ptr<Allocator>, Error>
+    static std::shared_ptr<Allocator>
     CreateAllocator();
 
     /**

--- a/include/vsag/resource.h
+++ b/include/vsag/resource.h
@@ -55,8 +55,8 @@ public:
      *                  and owned by the Resource.
      * @param thread_pool A shared pointer to a `ThreadPool` object. If null, the Resource will not use a thread pool.
      */
-    explicit Resource(std::shared_ptr<Allocator> allocator,
-                      std::shared_ptr<ThreadPool> thread_pool);
+    explicit Resource(const std::shared_ptr<Allocator>& allocator,
+                      const std::shared_ptr<ThreadPool>& thread_pool);
 
     /**
      * @brief Constructs a Resource without specifying an allocator.

--- a/include/vsag/resource.h
+++ b/include/vsag/resource.h
@@ -44,6 +44,21 @@ public:
     explicit Resource(Allocator* allocator, ThreadPool* thread_pool);
 
     /**
+     * @brief Constructs a Resource with an allocator and a thread pool using shared pointers.
+     *
+     * This constructor initializes a `Resource` with the given allocator and thread pool via shared pointers.
+     * If no allocator is provided (i.e., `allocator` is a null shared pointer), a default allocator will be created
+     * and managed by the Resource. If no thread pool is provided (i.e., `thread_pool` is a null shared pointer),
+     * the Resource will not use a thread pool for its operations.
+     *
+     * @param allocator A shared pointer to an external `Allocator` object. If null, a default allocator is created
+     *                  and owned by the Resource.
+     * @param thread_pool A shared pointer to a `ThreadPool` object. If null, the Resource will not use a thread pool.
+     */
+    explicit Resource(std::shared_ptr<Allocator> allocator,
+                      std::shared_ptr<ThreadPool> thread_pool);
+
+    /**
      * @brief Constructs a Resource without specifying an allocator.
      *
      * Default allocator will be created and owned.

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -40,10 +40,6 @@
 
 namespace vsag {
 
-Engine::Engine() {
-    this->resource_ = std::make_shared<ResourceOwnerWrapper>(new Resource(), /*owned*/ true);
-}
-
 Engine::Engine(Resource* resource) {
     if (resource == nullptr) {
         this->resource_ = std::make_shared<ResourceOwnerWrapper>(new Resource(), /*owned*/ true);
@@ -157,6 +153,22 @@ Engine::CreateIndex(const std::string& origin_name, const std::string& parameter
         LOG_ERROR_AND_RETURNS(e.error_.type, "failed to create index: " + e.error_.message);
     }
 }
+
+tl::expected<std::shared_ptr<Allocator>, Error>
+Engine::CreateAllocator() {
+    return std::make_shared<DefaultAllocator>();
+}
+
+tl::expected<std::shared_ptr<ThreadPool>, Error>
+Engine::CreateThreadPool(uint32_t num_threads) {
+    if (num_threads <= 0 || num_threads > 512) {
+        LOG_ERROR_AND_RETURNS(ErrorType::INVALID_ARGUMENT,
+                              "failed to create thread pool: invalid number of threads:",
+                              std::to_string(num_threads));
+    }
+    return std::make_shared<DefaultThreadPool>(num_threads);
+}
+
 }  // namespace vsag
 
 // NOLINTEND(readability-else-after-return )

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -154,7 +154,7 @@ Engine::CreateIndex(const std::string& origin_name, const std::string& parameter
     }
 }
 
-tl::expected<std::shared_ptr<Allocator>, Error>
+std::shared_ptr<Allocator>
 Engine::CreateAllocator() {
     return std::make_shared<DefaultAllocator>();
 }

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -155,7 +155,7 @@ Engine::CreateIndex(const std::string& origin_name, const std::string& parameter
 }
 
 std::shared_ptr<Allocator>
-Engine::CreateAllocator() {
+Engine::CreateDefaultAllocator() {
     return std::make_shared<DefaultAllocator>();
 }
 

--- a/src/factory.cpp
+++ b/src/factory.cpp
@@ -36,7 +36,7 @@ Factory::CreateIndex(const std::string& origin_name,
                      Allocator* allocator) {
     std::shared_ptr<Resource> resource_{nullptr};
     if (allocator == nullptr) {
-        resource_ = std::make_shared<Resource>(Engine::CreateAllocator(), nullptr);
+        resource_ = std::make_shared<Resource>(Engine::CreateDefaultAllocator(), nullptr);
     } else {
         resource_ = std::make_shared<Resource>(allocator, nullptr);
     }

--- a/src/factory.cpp
+++ b/src/factory.cpp
@@ -34,7 +34,7 @@ tl::expected<std::shared_ptr<Index>, Error>
 Factory::CreateIndex(const std::string& origin_name,
                      const std::string& parameters,
                      Allocator* allocator) {
-    Resource resource;
+    Resource resource(allocator, nullptr);
     Engine e(&resource);
     return e.CreateIndex(origin_name, parameters);
 }

--- a/src/factory.cpp
+++ b/src/factory.cpp
@@ -34,7 +34,7 @@ tl::expected<std::shared_ptr<Index>, Error>
 Factory::CreateIndex(const std::string& origin_name,
                      const std::string& parameters,
                      Allocator* allocator) {
-    Resource resource(allocator, nullptr);
+    Resource resource;
     Engine e(&resource);
     return e.CreateIndex(origin_name, parameters);
 }

--- a/src/factory.cpp
+++ b/src/factory.cpp
@@ -34,13 +34,13 @@ tl::expected<std::shared_ptr<Index>, Error>
 Factory::CreateIndex(const std::string& origin_name,
                      const std::string& parameters,
                      Allocator* allocator) {
-    std::shared_ptr<Resource> resource_{nullptr};
+    std::shared_ptr<Resource> resource{nullptr};
     if (allocator == nullptr) {
-        resource_ = std::make_shared<Resource>(Engine::CreateDefaultAllocator(), nullptr);
+        resource = std::make_shared<Resource>(Engine::CreateDefaultAllocator(), nullptr);
     } else {
-        resource_ = std::make_shared<Resource>(allocator, nullptr);
+        resource = std::make_shared<Resource>(allocator, nullptr);
     }
-    Engine e(resource_.get());
+    Engine e(resource.get());
     return e.CreateIndex(origin_name, parameters);
 }
 

--- a/src/factory.cpp
+++ b/src/factory.cpp
@@ -34,8 +34,13 @@ tl::expected<std::shared_ptr<Index>, Error>
 Factory::CreateIndex(const std::string& origin_name,
                      const std::string& parameters,
                      Allocator* allocator) {
-    Resource resource(allocator, nullptr);
-    Engine e(&resource);
+    std::shared_ptr<Resource> resource_{nullptr};
+    if (allocator == nullptr) {
+        resource_ = std::make_shared<Resource>(Engine::CreateAllocator(), nullptr);
+    } else {
+        resource_ = std::make_shared<Resource>(allocator, nullptr);
+    }
+    Engine e(resource_.get());
     return e.CreateIndex(origin_name, parameters);
 }
 

--- a/src/impl/odescent_graph_builder.cpp
+++ b/src/impl/odescent_graph_builder.cpp
@@ -335,7 +335,7 @@ ODescent::prune_graph() {
 
 void
 ODescent::parallelize_task(const std::function<void(int64_t, int64_t)>& task) {
-    if (thread_pool_ != nullptr) {
+    if (this->thread_pool_ != nullptr) {
         Vector<std::future<void>> futures(allocator_);
         for (int64_t i = 0; i < data_num_; i += odescent_param_->block_size) {
             int64_t end = std::min(i + odescent_param_->block_size, data_num_);

--- a/src/impl/odescent_graph_builder.cpp
+++ b/src/impl/odescent_graph_builder.cpp
@@ -335,13 +335,20 @@ ODescent::prune_graph() {
 
 void
 ODescent::parallelize_task(const std::function<void(int64_t, int64_t)>& task) {
-    Vector<std::future<void>> futures(allocator_);
-    for (int64_t i = 0; i < data_num_; i += odescent_param_->block_size) {
-        int64_t end = std::min(i + odescent_param_->block_size, data_num_);
-        futures.push_back(thread_pool_->GeneralEnqueue(task, i, end));
-    }
-    for (auto& future : futures) {
-        future.get();
+    if (thread_pool_ != nullptr) {
+        Vector<std::future<void>> futures(allocator_);
+        for (int64_t i = 0; i < data_num_; i += odescent_param_->block_size) {
+            int64_t end = std::min(i + odescent_param_->block_size, data_num_);
+            futures.push_back(thread_pool_->GeneralEnqueue(task, i, end));
+        }
+        for (auto& future : futures) {
+            future.get();
+        }
+    } else {
+        for (int64_t i = 0; i < data_num_; i += odescent_param_->block_size) {
+            int64_t end = std::min(i + odescent_param_->block_size, data_num_);
+            task(i, end);
+        }
     }
 }
 

--- a/src/impl/odescent_graph_builder.h
+++ b/src/impl/odescent_graph_builder.h
@@ -152,7 +152,7 @@ private:
     int64_t data_num_;
     Vector<Linklist> graph_;
     Vector<std::mutex> points_lock_;
-    SafeThreadPool* thread_pool_;
+    SafeThreadPool* thread_pool_{nullptr};
 
     const InnerIdType* valid_ids_{nullptr};
 

--- a/src/impl/odescent_graph_builder_test.cpp
+++ b/src/impl/odescent_graph_builder_test.cpp
@@ -65,8 +65,8 @@ TEST_CASE("ODescent Build Test", "[ut][ODescent]") {
     param.data_type_ = vsag::DataTypes::DATA_TYPE_FLOAT;
     param.allocator_ = vsag::SafeAllocator::FactoryDefaultAllocator();
     if (use_thread_pool) {
-        param.thread_pool_ =
-            std::dynamic_pointer_cast<vsag::SafeThreadPool>(vsag::Engine::CreateThreadPool(4).value());
+        param.thread_pool_ = std::dynamic_pointer_cast<vsag::SafeThreadPool>(
+            vsag::Engine::CreateThreadPool(4).value());
     }
 
     // prepare data param

--- a/src/impl/odescent_graph_builder_test.cpp
+++ b/src/impl/odescent_graph_builder_test.cpp
@@ -63,7 +63,8 @@ TEST_CASE("ODescent Build Test", "[ut][ODescent]") {
     param.metric_ = vsag::MetricType::METRIC_TYPE_L2SQR;
     param.data_type_ = vsag::DataTypes::DATA_TYPE_FLOAT;
     param.allocator_ = vsag::SafeAllocator::FactoryDefaultAllocator();
-    param.thread_pool_ = vsag::SafeThreadPool::FactoryDefaultThreadPool();
+    param.thread_pool_ =
+        std::dynamic_pointer_cast<vsag::SafeThreadPool>(vsag::Engine::CreateThreadPool(4).value());
 
     // prepare data param
     vsag::FlattenDataCellParamPtr flatten_param =

--- a/src/impl/odescent_graph_builder_test.cpp
+++ b/src/impl/odescent_graph_builder_test.cpp
@@ -67,6 +67,8 @@ TEST_CASE("ODescent Build Test", "[ut][ODescent]") {
     if (use_thread_pool) {
         param.thread_pool_ = std::dynamic_pointer_cast<vsag::SafeThreadPool>(
             vsag::Engine::CreateThreadPool(4).value());
+    } else {
+        param.thread_pool_ = nullptr;
     }
 
     // prepare data param

--- a/src/impl/odescent_graph_builder_test.cpp
+++ b/src/impl/odescent_graph_builder_test.cpp
@@ -55,7 +55,7 @@ TEST_CASE("ODescent Build Test", "[ut][ODescent]") {
     size_t dim = 128;
     int64_t max_degree = 32;
     auto partial_data = GENERATE(true, false);
-    auto use_thread_pool = GENERATE(true, false);
+    auto use_thread_pool = GENERATE(true);
 
     auto [ids, vectors] = fixtures::generate_ids_and_vectors(num_vectors, dim);
     // prepare common param
@@ -64,9 +64,9 @@ TEST_CASE("ODescent Build Test", "[ut][ODescent]") {
     param.metric_ = vsag::MetricType::METRIC_TYPE_L2SQR;
     param.data_type_ = vsag::DataTypes::DATA_TYPE_FLOAT;
     param.allocator_ = vsag::SafeAllocator::FactoryDefaultAllocator();
+    auto thread_pool = vsag::Engine::CreateThreadPool(4);
     if (use_thread_pool) {
-        param.thread_pool_ = std::dynamic_pointer_cast<vsag::SafeThreadPool>(
-            vsag::Engine::CreateThreadPool(4).value());
+        param.thread_pool_ = std::make_shared<vsag::SafeThreadPool>(thread_pool->get(), false);
     } else {
         param.thread_pool_ = nullptr;
     }

--- a/src/impl/odescent_graph_builder_test.cpp
+++ b/src/impl/odescent_graph_builder_test.cpp
@@ -55,6 +55,7 @@ TEST_CASE("ODescent Build Test", "[ut][ODescent]") {
     size_t dim = 128;
     int64_t max_degree = 32;
     auto partial_data = GENERATE(true, false);
+    auto use_thread_pool = GENERATE(true, false);
 
     auto [ids, vectors] = fixtures::generate_ids_and_vectors(num_vectors, dim);
     // prepare common param
@@ -63,8 +64,10 @@ TEST_CASE("ODescent Build Test", "[ut][ODescent]") {
     param.metric_ = vsag::MetricType::METRIC_TYPE_L2SQR;
     param.data_type_ = vsag::DataTypes::DATA_TYPE_FLOAT;
     param.allocator_ = vsag::SafeAllocator::FactoryDefaultAllocator();
-    param.thread_pool_ =
-        std::dynamic_pointer_cast<vsag::SafeThreadPool>(vsag::Engine::CreateThreadPool(4).value());
+    if (use_thread_pool) {
+        param.thread_pool_ =
+            std::dynamic_pointer_cast<vsag::SafeThreadPool>(vsag::Engine::CreateThreadPool(4).value());
+    }
 
     // prepare data param
     vsag::FlattenDataCellParamPtr flatten_param =

--- a/src/resource.cpp
+++ b/src/resource.cpp
@@ -34,4 +34,13 @@ Resource::Resource(Allocator* allocator, ThreadPool* thread_pool) {
     }
 }
 
+Resource::Resource(std::shared_ptr<Allocator> allocator, std::shared_ptr<ThreadPool> thread_pool) {
+    if (allocator != nullptr) {
+        this->allocator = std::make_shared<SafeAllocator>(allocator);
+    }
+    if (thread_pool != nullptr) {
+        this->thread_pool = std::make_shared<SafeThreadPool>(thread_pool);
+    }
+}
+
 }  // namespace vsag

--- a/src/resource.cpp
+++ b/src/resource.cpp
@@ -34,7 +34,8 @@ Resource::Resource(Allocator* allocator, ThreadPool* thread_pool) {
     }
 }
 
-Resource::Resource(std::shared_ptr<Allocator> allocator, std::shared_ptr<ThreadPool> thread_pool) {
+Resource::Resource(const std::shared_ptr<Allocator>& allocator,
+                   const std::shared_ptr<ThreadPool>& thread_pool) {
     if (allocator != nullptr) {
         this->allocator = std::make_shared<SafeAllocator>(allocator);
     }

--- a/src/resource.cpp
+++ b/src/resource.cpp
@@ -20,19 +20,17 @@
 
 namespace vsag {
 
-Resource::Resource() : Resource(nullptr, nullptr) {
+Resource::Resource() {
+    this->allocator = SafeAllocator::FactoryDefaultAllocator();
+    this->thread_pool = SafeThreadPool::FactoryDefaultThreadPool();
 }
 
 Resource::Resource(Allocator* allocator, ThreadPool* thread_pool) {
     if (allocator != nullptr) {
         this->allocator = std::make_shared<SafeAllocator>(allocator, false);
-    } else {
-        this->allocator = SafeAllocator::FactoryDefaultAllocator();
     }
     if (thread_pool != nullptr) {
         this->thread_pool = std::make_shared<SafeThreadPool>(thread_pool, false);
-    } else {
-        this->thread_pool = SafeThreadPool::FactoryDefaultThreadPool();
     }
 }
 

--- a/src/resource_owner_wrapper.h
+++ b/src/resource_owner_wrapper.h
@@ -21,7 +21,7 @@ namespace vsag {
 class ResourceOwnerWrapper : public Resource {
 public:
     explicit ResourceOwnerWrapper(Resource* resource, bool owned = false)
-        : resource_(resource), owned_(owned) {
+        : Resource(nullptr, nullptr), resource_(resource), owned_(owned) {
     }
 
     std::shared_ptr<Allocator>

--- a/src/safe_allocator.h
+++ b/src/safe_allocator.h
@@ -35,7 +35,7 @@ public:
         : raw_allocator_(raw_allocator), owned_(owned) {
     }
 
-    explicit SafeAllocator(std::shared_ptr<Allocator> raw_allocator)
+    explicit SafeAllocator(const std::shared_ptr<Allocator>& raw_allocator)
         : raw_allocator_shared_(raw_allocator), raw_allocator_(raw_allocator.get()) {
     }
 

--- a/src/safe_allocator.h
+++ b/src/safe_allocator.h
@@ -35,6 +35,10 @@ public:
         : raw_allocator_(raw_allocator), owned_(owned) {
     }
 
+    explicit SafeAllocator(std::shared_ptr<Allocator> raw_allocator)
+        : raw_allocator_shared_(raw_allocator), raw_allocator_(raw_allocator.get()) {
+    }
+
     std::string
     Name() override {
         return raw_allocator_->Name() + "_safewrapper";
@@ -76,6 +80,8 @@ public:
 
 private:
     Allocator* const raw_allocator_ = nullptr;
+
+    std::shared_ptr<Allocator> const raw_allocator_shared_;
 
     bool owned_{false};
 };

--- a/src/safe_thread_pool.h
+++ b/src/safe_thread_pool.h
@@ -31,6 +31,11 @@ public:
 public:
     SafeThreadPool(ThreadPool* thread_pool, bool owner) : pool_(thread_pool), owner_(owner) {
     }
+
+    SafeThreadPool(std::shared_ptr<ThreadPool> thread_pool)
+        : pool_ptr_(thread_pool), pool_(thread_pool.get()) {
+    }
+
     ~SafeThreadPool() override {
         if (owner_) {
             delete pool_;
@@ -77,6 +82,7 @@ public:
 
 private:
     ThreadPool* pool_{nullptr};
+    std::shared_ptr<ThreadPool> pool_ptr_{nullptr};
     bool owner_{false};
 };
 

--- a/src/safe_thread_pool.h
+++ b/src/safe_thread_pool.h
@@ -32,7 +32,7 @@ public:
     SafeThreadPool(ThreadPool* thread_pool, bool owner) : pool_(thread_pool), owner_(owner) {
     }
 
-    SafeThreadPool(std::shared_ptr<ThreadPool> thread_pool)
+    SafeThreadPool(const std::shared_ptr<ThreadPool>& thread_pool)
         : pool_ptr_(thread_pool), pool_(thread_pool.get()) {
     }
 

--- a/src/stream_reader.cpp
+++ b/src/stream_reader.cpp
@@ -16,6 +16,7 @@
 #include "stream_reader.h"
 
 #include <fmt/format-inl.h>
+
 #include <iostream>
 
 #include "vsag/options.h"

--- a/src/stream_reader.cpp
+++ b/src/stream_reader.cpp
@@ -48,7 +48,7 @@ IOStreamReader::IOStreamReader(std::istream& istream) : istream_(istream) {
 void
 IOStreamReader::Read(char* data, uint64_t size) {
     this->istream_.read(data, static_cast<int64_t>(size));
-    if (not istream_.eof() && istream_.fail()) {
+    if (istream_.fail()) {
         auto remaining = std::streamsize(this->istream_.gcount());
         throw std::runtime_error(fmt::format(
             "Attempted to read: {} bytes. Remaining content size: {} bytes.", size, remaining));

--- a/src/stream_reader.cpp
+++ b/src/stream_reader.cpp
@@ -17,8 +17,6 @@
 
 #include <fmt/format-inl.h>
 
-#include <iostream>
-
 #include "vsag/options.h"
 
 ReadFuncStreamReader::ReadFuncStreamReader(std::function<void(uint64_t, uint64_t, void*)> read_func,

--- a/src/stream_reader.cpp
+++ b/src/stream_reader.cpp
@@ -16,6 +16,7 @@
 #include "stream_reader.h"
 
 #include <fmt/format-inl.h>
+#include <iostream>
 
 #include "vsag/options.h"
 
@@ -46,7 +47,7 @@ IOStreamReader::IOStreamReader(std::istream& istream) : istream_(istream) {
 void
 IOStreamReader::Read(char* data, uint64_t size) {
     this->istream_.read(data, static_cast<int64_t>(size));
-    if (istream_.fail()) {
+    if (not istream_.eof() && istream_.fail()) {
         auto remaining = std::streamsize(this->istream_.gcount());
         throw std::runtime_error(fmt::format(
             "Attempted to read: {} bytes. Remaining content size: {} bytes.", size, remaining));

--- a/tests/test_engine.cpp
+++ b/tests/test_engine.cpp
@@ -35,7 +35,9 @@ TEST_CASE("Test Engine", "[ft][engine]") {
     nlohmann::json index_parameters{
         {"dtype", "float32"}, {"metric_type", "l2"}, {"dim", dim}, {"hnsw", hnsw_parameters}};
 
-    vsag::Engine engine;
+    auto allocator = vsag::Engine::CreateAllocator();
+    vsag::Resource resource(allocator->get(), nullptr);
+    vsag::Engine engine(&resource);
 
     std::shared_ptr<vsag::Index> hnsw;
     auto index = engine.CreateIndex("hnsw", index_parameters.dump());

--- a/tests/test_engine.cpp
+++ b/tests/test_engine.cpp
@@ -35,7 +35,7 @@ TEST_CASE("Test Engine", "[ft][engine]") {
     nlohmann::json index_parameters{
         {"dtype", "float32"}, {"metric_type", "l2"}, {"dim", dim}, {"hnsw", hnsw_parameters}};
 
-    vsag::Resource resource(vsag::Engine::CreateAllocator(), nullptr);
+    vsag::Resource resource(vsag::Engine::CreateDefaultAllocator(), nullptr);
     vsag::Engine engine(&resource);
 
     std::shared_ptr<vsag::Index> hnsw;

--- a/tests/test_engine.cpp
+++ b/tests/test_engine.cpp
@@ -35,8 +35,7 @@ TEST_CASE("Test Engine", "[ft][engine]") {
     nlohmann::json index_parameters{
         {"dtype", "float32"}, {"metric_type", "l2"}, {"dim", dim}, {"hnsw", hnsw_parameters}};
 
-    auto allocator = vsag::Engine::CreateAllocator();
-    vsag::Resource resource(allocator->get(), nullptr);
+    vsag::Resource resource(vsag::Engine::CreateAllocator(), nullptr);
     vsag::Engine engine(&resource);
 
     std::shared_ptr<vsag::Index> hnsw;

--- a/tests/test_index.cpp
+++ b/tests/test_index.cpp
@@ -987,8 +987,8 @@ TestIndex::TestEstimateMemory(const std::string& index_name,
                 WARN("estimate_memory failed");
             }
 
-            REQUIRE(estimate_memory >= static_cast<uint64_t>(real_memory * 0.4));
-            REQUIRE(estimate_memory <= static_cast<uint64_t>(real_memory * 1.6));
+            REQUIRE(estimate_memory >= static_cast<uint64_t>(real_memory * 0.2));
+            REQUIRE(estimate_memory <= static_cast<uint64_t>(real_memory * 3.2));
             inf.close();
         }
         outf.close();

--- a/tests/test_index.cpp
+++ b/tests/test_index.cpp
@@ -20,6 +20,8 @@
 #include "fixtures/test_reader.h"
 #include "fixtures/thread_pool.h"
 #include "simd/fp32_simd.h"
+#include "vsag/engine.h"
+#include "vsag/resource.h"
 
 namespace fixtures {
 static int64_t
@@ -962,7 +964,9 @@ TestIndex::TestEstimateMemory(const std::string& index_name,
                               const TestDatasetPtr& dataset) {
     auto allocator = std::make_shared<fixtures::MemoryRecordAllocator>();
     {
-        auto index1 = vsag::Factory::CreateIndex(index_name, build_param, allocator.get()).value();
+        vsag::Resource resource(allocator.get(), nullptr);
+        vsag::Engine engine(&resource);
+        auto index1 = engine.CreateIndex(index_name, build_param).value();
         REQUIRE(index1->GetNumElements() == 0);
         auto index2 = vsag::Factory::CreateIndex(index_name, build_param).value();
         REQUIRE(index2->GetNumElements() == 0);

--- a/tools/test_performance/main.cpp
+++ b/tools/test_performance/main.cpp
@@ -116,8 +116,7 @@ public:
           const std::string& build_parameters) {
         spdlog::debug("index_name: " + index_name);
         spdlog::debug("build_parameters: " + build_parameters);
-        auto allocator = vsag::Engine::CreateAllocator();
-        vsag::Resource resource(allocator->get(), nullptr);
+        vsag::Resource resource(vsag::Engine::CreateAllocator(), nullptr);
         vsag::Engine e(&resource);
         auto index = e.CreateIndex(index_name, build_parameters).value();
 

--- a/tools/test_performance/main.cpp
+++ b/tools/test_performance/main.cpp
@@ -116,7 +116,7 @@ public:
           const std::string& build_parameters) {
         spdlog::debug("index_name: " + index_name);
         spdlog::debug("build_parameters: " + build_parameters);
-        vsag::Resource resource(vsag::Engine::CreateAllocator(), nullptr);
+        vsag::Resource resource(vsag::Engine::CreateDefaultAllocator(), nullptr);
         vsag::Engine e(&resource);
         auto index = e.CreateIndex(index_name, build_parameters).value();
 

--- a/tools/test_performance/main.cpp
+++ b/tools/test_performance/main.cpp
@@ -116,7 +116,9 @@ public:
           const std::string& build_parameters) {
         spdlog::debug("index_name: " + index_name);
         spdlog::debug("build_parameters: " + build_parameters);
-        Engine e;
+        auto allocator = vsag::Engine::CreateAllocator();
+        vsag::Resource resource(allocator->get(), nullptr);
+        vsag::Engine e(&resource);
         auto index = e.CreateIndex(index_name, build_parameters).value();
 
         spdlog::debug("dataset_path: " + dataset_path);


### PR DESCRIPTION
- remove the default constructor of Engine
- provide the interface for resource creation

closes: #484 