### PR TITLE
add elias-fano encoder

### DIFF
--- a/src/impl/elias_fano_encoder.cpp
+++ b/src/impl/elias_fano_encoder.cpp
@@ -1,3 +1,4 @@
+
 // Copyright 2024-present the vsag project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/impl/elias_fano_encoder.cpp
+++ b/src/impl/elias_fano_encoder.cpp
@@ -1,0 +1,144 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "elias_fano_encoder.h"
+
+#include <algorithm>
+#include <cmath>
+#include <iostream>
+
+namespace vsag {
+
+size_t
+EliasFanoEncoder::ctzll(uint64_t x) const {
+#ifdef __GNUC__
+    return __builtin_ctzll(x);
+#else
+    if (x == 0)
+        return 64;
+    int count = 0;
+    while ((x & 1) == 0) {
+        x >>= 1;
+        count++;
+    }
+    return count;
+#endif
+}
+
+void
+EliasFanoEncoder::set_low_bits(size_t index, InnerIdType value) {
+    if (low_bits_width_ == 0)
+        return;
+
+    size_t bit_pos = index * low_bits_width_;
+    size_t word_pos = bit_pos >> 6;
+    size_t shift = bit_pos & 63;
+    uint64_t mask = ((1ULL << low_bits_width_) - 1) << shift;
+    low_bits_[word_pos] = (low_bits_[word_pos] & ~mask) | ((uint64_t)value << shift);
+
+    // Handle word boundary crossing
+    if (shift + low_bits_width_ > 64 && word_pos + 1 < low_bits_.size()) {
+        size_t remaining_bits = shift + low_bits_width_ - 64;
+        mask = (1ULL << remaining_bits) - 1;
+        low_bits_[word_pos + 1] =
+            (low_bits_[word_pos + 1] & ~mask) | (value >> (low_bits_width_ - remaining_bits));
+    }
+}
+
+InnerIdType
+EliasFanoEncoder::get_low_bits(size_t index) const {
+    if (low_bits_width_ == 0)
+        return 0;
+
+    size_t bit_pos = index * low_bits_width_;
+    size_t word_pos = bit_pos >> 6;
+    size_t shift = bit_pos & 63;
+    InnerIdType value = (low_bits_[word_pos] >> shift) & ((1ULL << low_bits_width_) - 1);
+
+    // Handle word boundary crossing
+    if (shift + low_bits_width_ > 64 && word_pos + 1 < low_bits_.size()) {
+        size_t remaining_bits = shift + low_bits_width_ - 64;
+        value |= (low_bits_[word_pos + 1] & ((1ULL << remaining_bits) - 1))
+                 << (low_bits_width_ - remaining_bits);
+    }
+    return value;
+}
+
+void
+EliasFanoEncoder::encode(const Vector<InnerIdType>& values, InnerIdType max_value) {
+    clear();
+    if (values.empty())
+        return;
+
+    // Check if number of elements exceeds uint8_t maximum
+    if (values.size() > UINT8_MAX) {
+        num_elements_ = UINT8_MAX;
+        throw std::runtime_error("Error: Elias-Fano encoder, number of elements exceeds 255.");
+    } else {
+        num_elements_ = static_cast<uint8_t>(values.size());
+    }
+
+    InnerIdType universe = max_value + 1;
+
+    // Calculate low bits width
+    low_bits_width_ =
+        static_cast<uint32_t>(std::floor(std::log2(static_cast<double>(universe) / num_elements_)));
+
+    // Allocate space for high bits
+    const size_t high_bits_count = (max_value >> low_bits_width_) + num_elements_ + 1;
+    high_bits_.resize((high_bits_count + 63) / 64, 0);
+
+    // Allocate space for low bits
+    size_t total_low_bits = num_elements_ * low_bits_width_;
+    low_bits_.resize(std::max<size_t>(1, (total_low_bits + 63) / 64), 0);
+
+    // Encode each value
+    for (size_t i = 0; i < num_elements_; ++i) {
+        InnerIdType x = values[i];
+        InnerIdType high = x >> low_bits_width_;
+        InnerIdType low = x & ((1U << low_bits_width_) - 1);
+
+        set_high_bit(high_bits_, i + high);
+        set_low_bits(i, low);
+    }
+}
+
+Vector<InnerIdType>
+EliasFanoEncoder::decompress_all(Allocator* allocator) const {
+    Vector<InnerIdType> result(allocator);
+    result.reserve(num_elements_);
+
+    // Decompress all values at once
+    size_t count = 0;
+
+    for (size_t i = 0; i < high_bits_.size() && count < num_elements_; ++i) {
+        uint64_t word = high_bits_[i];
+
+        // Use ctzll to find position of 1
+        while (word && count < num_elements_) {
+            size_t bit = ctzll(word);
+            // Found 1, calculate corresponding value
+            InnerIdType high = (i * 64 + bit) - count;
+            InnerIdType low = get_low_bits(count);
+            result.push_back((high << low_bits_width_) | low);
+            count++;
+            // Delete lowest 1
+            word &= (word - 1);
+        }
+    }
+
+    return result;
+}
+
+}  // namespace vsag

--- a/src/impl/elias_fano_encoder.cpp
+++ b/src/impl/elias_fano_encoder.cpp
@@ -20,8 +20,9 @@
 
 namespace vsag {
 
-size_t
-EliasFanoEncoder::ctzll(uint64_t x) {
+// Cross-platform implementation of ctzll (count trailing zeros)
+static inline size_t
+ctzll(uint64_t x) {
 #ifdef __GNUC__
     return __builtin_ctzll(x);
 #else
@@ -35,6 +36,11 @@ EliasFanoEncoder::ctzll(uint64_t x) {
     }
     return count;
 #endif
+}
+
+static inline void
+set_high_bit(Vector<uint64_t>& vec, size_t pos) {
+    vec[pos >> 6] |= (1ULL << (pos & 63));
 }
 
 void
@@ -89,7 +95,6 @@ EliasFanoEncoder::Encode(const Vector<InnerIdType>& values, InnerIdType max_valu
     if (values.size() <= UINT8_MAX) {
         num_elements_ = static_cast<uint8_t>(values.size());
     } else {
-        num_elements_ = UINT8_MAX;
         throw std::runtime_error("Error: Elias-Fano encoder, number of elements exceeds 255.");
     }
 

--- a/src/impl/elias_fano_encoder.cpp
+++ b/src/impl/elias_fano_encoder.cpp
@@ -39,8 +39,8 @@ ctzll(uint64_t x) {
 }
 
 static inline void
-set_high_bit(uint64_t* vec, size_t pos, size_t low_bits_size) {
-    vec[low_bits_size + (pos >> 6)] |= (1ULL << (pos & 63));
+set_high_bit(uint64_t* bits_array, size_t pos, size_t low_bits_size) {
+    bits_array[low_bits_size + (pos >> 6)] |= (1ULL << (pos & 63));
 }
 
 void
@@ -104,11 +104,11 @@ EliasFanoEncoder::Encode(const Vector<InnerIdType>& values, InnerIdType max_valu
     low_bits_width_ =
         static_cast<uint32_t>(std::floor(std::log2(static_cast<double>(universe) / num_elements_)));
 
-    // Allocate space for high bits
+    // Calculate the size of high bits
     const size_t high_bits_count = (max_value >> low_bits_width_) + num_elements_ + 1;
     high_bits_size_ = (high_bits_count + 63) / 64;
 
-    // Allocate space for low bits
+    // Calculate the size of low bits
     size_t total_low_bits = static_cast<size_t>(num_elements_) * low_bits_width_;
     low_bits_size_ = std::max<size_t>(1, (total_low_bits + 63) / 64);
 

--- a/src/impl/elias_fano_encoder.h
+++ b/src/impl/elias_fano_encoder.h
@@ -1,3 +1,4 @@
+
 // Copyright 2024-present the vsag project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/impl/elias_fano_encoder.h
+++ b/src/impl/elias_fano_encoder.h
@@ -28,10 +28,10 @@ private:
     uint8_t low_bits_width_{0};   // Width of low bits
 
     // Cross-platform implementation of ctzll (count trailing zeros)
-    size_t
-    ctzll(uint64_t x) const;
+    static size_t
+    ctzll(uint64_t x);
 
-    inline void
+    static inline void
     set_high_bit(Vector<uint64_t>& vec, size_t pos) {
         vec[pos >> 6] |= (1ULL << (pos & 63));
     }
@@ -39,7 +39,7 @@ private:
     void
     set_low_bits(size_t index, InnerIdType value);
 
-    InnerIdType
+    [[nodiscard]] InnerIdType
     get_low_bits(size_t index) const;
 
 public:
@@ -48,28 +48,28 @@ public:
 
     // Encode ordered sequence
     void
-    encode(const Vector<InnerIdType>& values, InnerIdType max_value);
+    Encode(const Vector<InnerIdType>& values, InnerIdType max_value);
 
     // Decompress all values
     Vector<InnerIdType>
-    decompress_all(Allocator* allocator) const;
+    DecompressAll(Allocator* allocator) const;
 
     void
-    clear() {
+    Clear() {
         high_bits_.clear();
         low_bits_.clear();
         num_elements_ = 0;
         low_bits_width_ = 0;
     }
 
-    size_t
-    size_in_bytes() const {
+    [[nodiscard]] size_t
+    SizeInBytes() const {
         return high_bits_.size() * sizeof(uint64_t) + low_bits_.size() * sizeof(uint64_t) +
                sizeof(num_elements_) + sizeof(low_bits_width_);
     }
 
-    uint8_t
-    size() const {
+    [[nodiscard]] uint8_t
+    Size() const {
         return num_elements_;
     }
 };

--- a/src/impl/elias_fano_encoder.h
+++ b/src/impl/elias_fano_encoder.h
@@ -21,27 +21,6 @@ namespace vsag {
 /// @brief Elias-Fano Encoder for *ordered* adjacency list
 /// @note Our adjacency list size is mostly no more than 255, so we use uint8_t to store the number of elements
 class EliasFanoEncoder {
-private:
-    Vector<uint64_t> high_bits_;  // Bitmap storage for high bits
-    Vector<uint64_t> low_bits_;   // Compressed storage for low bits
-    uint8_t num_elements_{0};     // Number of elements, max 255
-    uint8_t low_bits_width_{0};   // Width of low bits
-
-    // Cross-platform implementation of ctzll (count trailing zeros)
-    static size_t
-    ctzll(uint64_t x);
-
-    static inline void
-    set_high_bit(Vector<uint64_t>& vec, size_t pos) {
-        vec[pos >> 6] |= (1ULL << (pos & 63));
-    }
-
-    void
-    set_low_bits(size_t index, InnerIdType value);
-
-    [[nodiscard]] InnerIdType
-    get_low_bits(size_t index) const;
-
 public:
     EliasFanoEncoder(Allocator* allocator) : high_bits_(allocator), low_bits_(allocator) {
     }
@@ -64,14 +43,26 @@ public:
 
     [[nodiscard]] size_t
     SizeInBytes() const {
-        return high_bits_.size() * sizeof(uint64_t) + low_bits_.size() * sizeof(uint64_t) +
-               sizeof(num_elements_) + sizeof(low_bits_width_);
+        return sizeof(EliasFanoEncoder) + high_bits_.size() * sizeof(uint64_t) +
+               low_bits_.size() * sizeof(uint64_t);
     }
 
     [[nodiscard]] uint8_t
     Size() const {
         return num_elements_;
     }
+
+private:
+    void
+    set_low_bits(size_t index, InnerIdType value);
+
+    [[nodiscard]] InnerIdType
+    get_low_bits(size_t index) const;
+
+    Vector<uint64_t> high_bits_;  // Bitmap storage for high bits
+    Vector<uint64_t> low_bits_;   // Compressed storage for low bits
+    uint8_t num_elements_{0};     // Number of elements, max 255
+    uint8_t low_bits_width_{0};   // Width of low bits
 };
 
 }  // namespace vsag

--- a/src/impl/elias_fano_encoder.h
+++ b/src/impl/elias_fano_encoder.h
@@ -1,0 +1,77 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "typing.h"
+
+namespace vsag {
+
+/// @brief Elias-Fano Encoder for *ordered* adjacency list
+/// @note Our adjacency list size is mostly no more than 255, so we use uint8_t to store the number of elements
+class EliasFanoEncoder {
+private:
+    Vector<uint64_t> high_bits_;  // Bitmap storage for high bits
+    Vector<uint64_t> low_bits_;   // Compressed storage for low bits
+    uint8_t num_elements_{0};     // Number of elements, max 255
+    uint8_t low_bits_width_{0};   // Width of low bits
+
+    // Cross-platform implementation of ctzll (count trailing zeros)
+    size_t
+    ctzll(uint64_t x) const;
+
+    inline void
+    set_high_bit(Vector<uint64_t>& vec, size_t pos) {
+        vec[pos >> 6] |= (1ULL << (pos & 63));
+    }
+
+    void
+    set_low_bits(size_t index, InnerIdType value);
+
+    InnerIdType
+    get_low_bits(size_t index) const;
+
+public:
+    EliasFanoEncoder(Allocator* allocator) : high_bits_(allocator), low_bits_(allocator) {
+    }
+
+    // Encode ordered sequence
+    void
+    encode(const Vector<InnerIdType>& values, InnerIdType max_value);
+
+    // Decompress all values
+    Vector<InnerIdType>
+    decompress_all(Allocator* allocator) const;
+
+    void
+    clear() {
+        high_bits_.clear();
+        low_bits_.clear();
+        num_elements_ = 0;
+        low_bits_width_ = 0;
+    }
+
+    size_t
+    size_in_bytes() const {
+        return high_bits_.size() * sizeof(uint64_t) + low_bits_.size() * sizeof(uint64_t) +
+               sizeof(num_elements_) + sizeof(low_bits_width_);
+    }
+
+    uint8_t
+    size() const {
+        return num_elements_;
+    }
+};
+
+}  // namespace vsag

--- a/src/impl/elias_fano_encoder_test.cpp
+++ b/src/impl/elias_fano_encoder_test.cpp
@@ -1,0 +1,59 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "elias_fano_encoder.h"
+
+#include <algorithm>
+#include <catch2/catch_test_macros.hpp>
+#include <random>
+
+#include "safe_allocator.h"
+
+namespace vsag {
+
+TEST_CASE("EliasFanoEncoder, original seq equal to decoded seq", "[ut][EliasFanoEncoder]") {
+    const size_t max_size = 250;
+    const int max_id = 1000000;
+
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_int_distribution<InnerIdType> dist(0, max_id);
+
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    std::shared_ptr<EliasFanoEncoder> encoder = std::make_shared<EliasFanoEncoder>(allocator.get());
+
+    for (int size = 0; size <= max_size; size++) {
+        Vector<InnerIdType> values(allocator.get());
+        values.reserve(size);
+
+        // generate an ordered seq with length ${size}
+        for (size_t i = 0; i < size; i++) {
+            values.push_back(dist(gen));
+        }
+        std::sort(values.begin(), values.end());
+
+        encoder->encode(values, max_id);
+        REQUIRE(encoder->size() == values.size());
+
+        // check if original seq equal to decoded seq
+        auto decompressed = encoder->decompress_all(allocator.get());
+        REQUIRE(decompressed.size() == values.size());
+        for (size_t i = 0; i < values.size(); i++) {
+            REQUIRE(decompressed[i] == values[i]);
+        }
+    }
+}
+
+}  // namespace vsag

--- a/src/impl/elias_fano_encoder_test.cpp
+++ b/src/impl/elias_fano_encoder_test.cpp
@@ -44,11 +44,11 @@ TEST_CASE("EliasFanoEncoder, original seq equal to decoded seq", "[ut][EliasFano
         }
         std::sort(values.begin(), values.end());
 
-        encoder->encode(values, max_id);
-        REQUIRE(encoder->size() == values.size());
+        encoder->Encode(values, max_id);
+        REQUIRE(encoder->Size() == values.size());
 
         // check if original seq equal to decoded seq
-        auto decompressed = encoder->decompress_all(allocator.get());
+        auto decompressed = encoder->DecompressAll(allocator.get());
         REQUIRE(decompressed.size() == values.size());
         for (size_t i = 0; i < values.size(); i++) {
             REQUIRE(decompressed[i] == values[i]);


### PR DESCRIPTION
Add Elias-Fano Encoder

- it can encode an ordered seq (adjacency list) and decode the whole seq
- the max number of elements is 255, as the size of our adjacency list is mostly no more than 100

closes: #548
