### PR TITLE
hgraph support extra info filter

### DIFF
--- a/include/vsag/constants.h
+++ b/include/vsag/constants.h
@@ -135,6 +135,7 @@ extern const char* const HGRAPH_PRECISE_IO_TYPE;
 extern const char* const HGRAPH_PRECISE_FILE_PATH;
 extern const char* const HGRAPH_PARAMETER_EF_RUNTIME;
 extern const char* const HGRAPH_EXTRA_INFO_SIZE;
+extern const char* const HGRAPH_USE_EXTRA_INFO_FILTER;
 
 extern const char* const BRUTE_FORCE_QUANTIZATION_TYPE;
 extern const char* const BRUTE_FORCE_IO_TYPE;

--- a/include/vsag/filter.h
+++ b/include/vsag/filter.h
@@ -39,6 +39,19 @@ public:
     CheckValid(int64_t id) const = 0;
 
     /**
+      * @brief Check if a vector is filtered out by pre-filter, true means
+      * not been filtered out, false means have been filtered out, the result
+      * of KnnSearch/RangeSearch will only contain non-filtered-out vectors
+      * 
+      * @param data extra info of the vector
+      * @return true if vector is valid, otherwise false
+      */
+    [[nodiscard]] virtual bool
+    CheckValid(const char* data) const {
+        return true;
+    }
+
+    /**
       * @brief Get valid ratio of pre-filter, 1.0 means all the vectors valid, 
       * none of them have been filter out.
       * 

--- a/include/vsag/index_features.h
+++ b/include/vsag/index_features.h
@@ -66,6 +66,8 @@ enum IndexFeature {
 
     SUPPORT_GET_EXTRA_INFO_BY_ID, /**< Supports get extra_info by id */
 
+    SUPPORT_KNN_SEARCH_WITH_EX_FILTER, /**< Supports K-nearest neighbor search with extra info filtering */
+
     INDEX_FEATURE_COUNT /** must be last one */
 };
 }  // namespace vsag

--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -179,10 +179,6 @@ HGraph::KnnSearch(const DatasetPtr& query,
                   int64_t k,
                   const std::string& parameters,
                   const FilterPtr& filter) const {
-    std::shared_ptr<CommonInnerIdFilter> ft = nullptr;
-    if (filter != nullptr) {
-        ft = std::make_shared<CommonInnerIdFilter>(filter, *this->label_table_);
-    }
     int64_t query_dim = query->GetDim();
     CHECK_ARGUMENT(query_dim == dim_,
                    fmt::format("query.dim({}) must be equal to index.dim({})", query_dim, dim_));
@@ -207,6 +203,14 @@ HGraph::KnnSearch(const DatasetPtr& query,
     }
 
     auto params = HGraphSearchParameters::FromJson(parameters);
+    FilterPtr ft = nullptr;
+    if (filter != nullptr) {
+        if (params.use_extra_info_filter) {
+            ft = std::make_shared<CommonExtraInfoFilter>(filter, this->extra_infos_);
+        } else {
+            ft = std::make_shared<CommonInnerIdFilter>(filter, *this->label_table_);
+        }
+    }
 
     search_param.ef = std::max(params.ef_search, k);
     search_param.is_inner_id_allowed = ft;
@@ -255,10 +259,6 @@ HGraph::KnnSearch(const DatasetPtr& query,
     if (GetNumElements() == 0) {
         return DatasetImpl::MakeEmptyDataset();
     }
-    std::shared_ptr<CommonInnerIdFilter> ft = nullptr;
-    if (filter != nullptr) {
-        ft = std::make_shared<CommonInnerIdFilter>(filter, *this->label_table_);
-    }
     int64_t query_dim = query->GetDim();
     CHECK_ARGUMENT(query_dim == dim_,
                    fmt::format("query.dim({}) must be equal to index.dim({})", query_dim, dim_));
@@ -270,6 +270,15 @@ HGraph::KnnSearch(const DatasetPtr& query,
     CHECK_ARGUMENT(query->GetNumElements() == 1, "query dataset should contain 1 vector only");
 
     auto params = HGraphSearchParameters::FromJson(parameters);
+
+    FilterPtr ft = nullptr;
+    if (filter != nullptr) {
+        if (params.use_extra_info_filter) {
+            ft = std::make_shared<CommonExtraInfoFilter>(filter, this->extra_infos_);
+        } else {
+            ft = std::make_shared<CommonInnerIdFilter>(filter, *this->label_table_);
+        }
+    }
 
     if (iter_ctx == nullptr) {
         auto cur_count = this->bottom_graph_->TotalCount();
@@ -826,6 +835,7 @@ HGraph::init_features() {
 
     if (this->extra_infos_ != nullptr) {
         this->index_feature_list_->SetFeature(IndexFeature::SUPPORT_GET_EXTRA_INFO_BY_ID);
+        this->index_feature_list_->SetFeature(IndexFeature::SUPPORT_KNN_SEARCH_WITH_EX_FILTER);
     }
 }
 

--- a/src/algorithm/hgraph_parameter.cpp
+++ b/src/algorithm/hgraph_parameter.cpp
@@ -111,6 +111,9 @@ HGraphSearchParameters::FromJson(const std::string& json_string) {
         fmt::format(
             "parameters[{}] must contains {}", INDEX_TYPE_HGRAPH, HGRAPH_PARAMETER_EF_RUNTIME));
     obj.ef_search = params[INDEX_TYPE_HGRAPH][HGRAPH_PARAMETER_EF_RUNTIME];
+    if (params[INDEX_TYPE_HGRAPH].contains(HGRAPH_USE_EXTRA_INFO_FILTER)) {
+        obj.use_extra_info_filter = params[INDEX_TYPE_HGRAPH][HGRAPH_USE_EXTRA_INFO_FILTER];
+    }
     CHECK_ARGUMENT((1 <= obj.ef_search) and (obj.ef_search <= 1000),
                    fmt::format("ef_search({}) must in range[1, 1000]", obj.ef_search));
 

--- a/src/algorithm/hgraph_parameter.h
+++ b/src/algorithm/hgraph_parameter.h
@@ -58,6 +58,7 @@ public:
 public:
     int64_t ef_search{30};
     bool use_reorder{false};
+    bool use_extra_info_filter{false};
 
 private:
     HGraphSearchParameters() = default;

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -138,6 +138,7 @@ const char* const HGRAPH_PRECISE_IO_TYPE = "precise_io_type";
 const char* const HGRAPH_PRECISE_FILE_PATH = "precise_file_path";
 const char* const HGRAPH_PARAMETER_EF_RUNTIME = "ef_search";
 const char* const HGRAPH_EXTRA_INFO_SIZE = "extra_info_size";
+const char* const HGRAPH_USE_EXTRA_INFO_FILTER = "use_extra_info_filter";
 
 const char* const BRUTE_FORCE_QUANTIZATION_TYPE = "quantization_type";
 const char* const BRUTE_FORCE_IO_TYPE = "io_type";

--- a/src/data_cell/extra_info_datacell_test.cpp
+++ b/src/data_cell/extra_info_datacell_test.cpp
@@ -29,8 +29,10 @@
 using namespace vsag;
 
 void
-TestExtraInfoDataCell(ExtraInfoDataCellParamPtr& param, IndexCommonParam& common_param) {
-    auto count = GENERATE(100, 1000);
+TestExtraInfoDataCell(ExtraInfoDataCellParamPtr& param,
+                      IndexCommonParam& common_param,
+                      uint64_t spec_count) {
+    auto count = spec_count > 0 ? spec_count : GENERATE(100, 1000);
     auto extra_info = ExtraInfoInterface::MakeInstance(param, common_param);
 
     ExtraInfoInterfaceTest test(extra_info);
@@ -44,7 +46,8 @@ TestExtraInfoDataCell(ExtraInfoDataCellParamPtr& param, IndexCommonParam& common
 TEST_CASE("ExtraInfoDataCell Basic Test", "[ut][ExtraInfoDataCell] ") {
     logger::set_level(logger::level::debug);
     auto allocator = SafeAllocator::FactoryDefaultAllocator();
-    uint64_t extra_info_sizes[3] = {32, 128, 512};
+    uint64_t extra_info_sizes[4] = {32, 128, 512, 3 * 1024 * 1024};
+    uint64_t counts[4] = {0, 0, 0, 50};
     int dim = 512;
     MetricType metric = MetricType::METRIC_TYPE_L2SQR;
     constexpr const char* param_str =
@@ -55,6 +58,7 @@ TEST_CASE("ExtraInfoDataCell Basic Test", "[ut][ExtraInfoDataCell] ") {
             }
         }
         )";
+    int i = 0;
     for (auto& extra_info_size : extra_info_sizes) {
         auto param_json = JsonType::parse(param_str);
         logger::debug("param_json: {}", param_json.dump());
@@ -69,6 +73,7 @@ TEST_CASE("ExtraInfoDataCell Basic Test", "[ut][ExtraInfoDataCell] ") {
         common_param.metric_ = metric;
         common_param.extra_info_size_ = extra_info_size;
 
-        TestExtraInfoDataCell(param, common_param);
+        TestExtraInfoDataCell(param, common_param, counts[i]);
+        i++;
     }
 }

--- a/src/data_cell/extra_info_interface.h
+++ b/src/data_cell/extra_info_interface.h
@@ -51,6 +51,9 @@ public:
     virtual void
     Resize(InnerIdType capacity) = 0;
 
+    virtual void
+    Release(const char* extra_info) = 0;
+
 public:
     virtual void
     SetMaxCapacity(InnerIdType capacity) {

--- a/src/data_cell/extra_info_interface_test.cpp
+++ b/src/data_cell/extra_info_interface_test.cpp
@@ -53,6 +53,16 @@ ExtraInfoInterfaceTest::BasicTest(uint64_t base_count) {
         REQUIRE(extra_info != nullptr);
     }
 
+    for (InnerIdType i = first_one; i <= last_one; ++i) {
+        bool need_release = false;
+        extra_info_->Prefetch(i);
+        const char* ex_info = extra_info_->GetExtraInfoById(i, need_release);
+        REQUIRE(ex_info != nullptr);
+        if (need_release) {
+            extra_info_->Release(ex_info);
+        }
+    }
+
     // test SetMaxCapacity and GetMaxCapacity
     auto origin_capacity = extra_info_->GetMaxCapacity();
     extra_info_->SetMaxCapacity(origin_capacity * 2);
@@ -85,6 +95,16 @@ ExtraInfoInterfaceTest::TestForceInMemory(uint64_t force_count) {
         extra_info_->Prefetch(i);
         extra_info_->GetExtraInfoById(i, extra_info);
         REQUIRE(extra_info != nullptr);
+    }
+
+    for (InnerIdType i = first_one; i <= last_one; ++i) {
+        bool need_release = false;
+        extra_info_->Prefetch(i);
+        const char* ex_info = extra_info_->GetExtraInfoById(i, need_release);
+        REQUIRE(ex_info != nullptr);
+        if (need_release) {
+            extra_info_->Release(ex_info);
+        }
     }
 
     extra_info_->DisableForceInMemory();

--- a/tests/fixtures/test_dataset.h
+++ b/tests/fixtures/test_dataset.h
@@ -51,7 +51,9 @@ public:
 
     DatasetPtr filter_query_{nullptr};
     DatasetPtr filter_ground_truth_{nullptr};
+    DatasetPtr ex_filter_ground_truth_{nullptr};
     std::function<bool(int64_t)> filter_function_{nullptr};
+    std::function<bool(const char*)> ex_filter_function_{nullptr};
 
     uint64_t dim_{0};
     uint64_t count_{0};

--- a/tests/test_index.h
+++ b/tests/test_index.h
@@ -99,7 +99,8 @@ protected:
                       const TestDatasetPtr& dataset,
                       const std::string& search_param,
                       float expected_recall = 0.99,
-                      bool expected_success = true);
+                      bool expected_success = true,
+                      bool use_ex_filter = false);
 
     static void
     TestSearchWithDirtyVector(const IndexPtr& index,
@@ -198,6 +199,12 @@ protected:
                          const TestDatasetPtr& dataset,
                          int64_t extra_info_size);
 
+    static void
+    TestKnnSearchExFilter(const IndexPtr& index,
+                          const TestDatasetPtr& dataset,
+                          const std::string& search_param,
+                          float expected_recall = 0.99,
+                          bool expected_success = true);
     constexpr static float RECALL_THRESHOLD = 0.95;
 };
 


### PR DESCRIPTION
1. Add CommonExtraInfoFilter, support filter input extra info
2. Add hgraph search param : use_extra_info_filter(true/false)
3. Support ExtraInfoDataCell get extra info no-copy interface

Use extra info filter instead of bitmap filter will be better when filter rate is 50%~90% when dataset is large which may cost too much for building bitmap

Here is test by vectordbbench of oceanbase, dataset is Performance768D1M
| Dataset             | QPS                           | Recall                        |
|---------------------|-------------------------------|-------------------------------|
768D1M50P | 713.09 -> 4099.87 (474.94%) | 0.8038 -> 0.8317 (3.47%)
| 768D1M70P | 1018.82 -> 2977.82 (192.28%) | 0.8136 -> 0.8458 (3.96%) |
| 768D1M90P | 1113.09 -> 1134.43 (1.92%)      | 0.8589 -> 0.8906 (3.69%) |

