### PR TITLE
fix interface KnnSearch with iter not adapted extra info

### DIFF
--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -636,7 +636,7 @@ HGraph::CalDistanceById(const float* query, const int64_t* ids, int64_t count) c
         for (int64_t i = 0; i < count; ++i) {
             auto iter = this->label_table_->label_remap_.find(ids[i]);
             if (iter == this->label_table_->label_remap_.end()) {
-                logger::error(fmt::format("failed to find id: {}", ids[i]));
+                logger::debug(fmt::format("failed to find id: {}", ids[i]));
                 distances[i] = -1;
                 continue;
             }

--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -276,7 +276,11 @@ HGraph::KnnSearch(const DatasetPtr& query,
     if (iter_ctx == nullptr) {
         auto cur_count = this->bottom_graph_->TotalCount();
         auto* new_ctx = new IteratorFilterContext();
-        new_ctx->init(cur_count, params.ef_search, allocator_);
+        if (auto ret = new_ctx->init(cur_count, params.ef_search, allocator_);
+            not ret.has_value()) {
+            throw vsag::VsagException(ErrorType::INTERNAL_ERROR,
+                                      "failed to init IteratorFilterContext");
+        }
         iter_ctx = new_ctx;
     }
 
@@ -331,10 +335,19 @@ HGraph::KnnSearch(const DatasetPtr& query,
     }
     auto count = static_cast<const int64_t>(search_result.size());
     auto [dataset_results, dists, ids] = CreateFastDataset(count, allocator_);
+    char* extra_infos = nullptr;
+    if (extra_info_size_ > 0) {
+        extra_infos = (char*)allocator_->Allocate(extra_info_size_ * search_result.size());
+        dataset_results->ExtraInfos(extra_infos);
+    }
     for (int64_t j = count - 1; j >= 0; --j) {
         dists[j] = search_result.top().first;
         ids[j] = this->label_table_->GetLabelById(search_result.top().second);
         iter_filter_ctx->SetPoint(search_result.top().second);
+        if (extra_infos != nullptr) {
+            this->extra_infos_->GetExtraInfoById(search_result.top().second,
+                                                 extra_infos + extra_info_size_ * j);
+        }
         search_result.pop();
     }
     iter_filter_ctx->SetOFFFirstUsed();

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -672,6 +672,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HgraphTestIndex, "HGraph With Extra Info"
                                                     extra_info_size);
             TestBuildIndex(index, dataset, true);
             TestKnnSearch(index, dataset, search_param, recall, true);
+            TestKnnSearchIter(index, dataset, search_param, recall, true);
             TestRangeSearch(index, dataset, search_param, recall, 10, true);
             TestGetExtraInfoById(index, dataset, extra_info_size);
             vsag::Options::Instance().set_block_size_limit(origin_size);

--- a/tests/test_index.cpp
+++ b/tests/test_index.cpp
@@ -1118,50 +1118,6 @@ TestIndex::TestMergeIndex(const std::string& name,
 }
 
 void
-TestIndex::TestSearchWithExtraInfo(const IndexPtr& index,
-                                   const TestDatasetPtr& dataset,
-                                   const std::string& search_param,
-                                   int64_t extra_info_size,
-                                   float expected_recall) {
-    auto queries = dataset->query_;
-    auto query_count = queries->GetNumElements();
-    auto dim = queries->GetDim();
-    auto gts = dataset->ground_truth_;
-    auto gt_topK = dataset->top_k;
-    float cur_recall = 0.0f;
-    auto topk = gt_topK;
-    for (auto i = 0; i < query_count; ++i) {
-        auto query = vsag::Dataset::Make();
-        query->NumElements(1)
-            ->Dim(dim)
-            ->Float32Vectors(queries->GetFloat32Vectors() + i * dim)
-            ->Paths(queries->GetPaths() + i)
-            ->Owner(false);
-        auto res = index->KnnSearch(query, topk, search_param);
-        REQUIRE(res.has_value() == true);
-        REQUIRE(res.value()->GetDim() == topk);
-        auto result = res.value()->GetIds();
-        if (extra_info_size > 0) {
-            const char* extra_infos = res.value()->GetExtraInfos();
-            REQUIRE(extra_infos != nullptr);
-            int64_t num = res.value()->GetNumElements();
-            for (int j = 0; j < num; ++j) {
-                REQUIRE((extra_infos + j * extra_info_size) != nullptr);
-            }
-        }
-        auto gt = gts->GetIds() + gt_topK * i;
-        auto val = Intersection(gt, gt_topK, result, topk);
-        cur_recall += static_cast<float>(val) / static_cast<float>(gt_topK);
-    }
-    if (cur_recall <= expected_recall * query_count) {
-        WARN(fmt::format("cur_result({}) <= expected_recall * query_count({})",
-                         cur_recall,
-                         expected_recall * query_count));
-    }
-    REQUIRE(cur_recall > expected_recall * query_count * RECALL_THRESHOLD);
-}
-
-void
 TestIndex::TestGetExtraInfoById(const TestIndex::IndexPtr& index,
                                 const TestDatasetPtr& dataset,
                                 int64_t extra_info_size) {

--- a/tests/test_index.h
+++ b/tests/test_index.h
@@ -194,13 +194,6 @@ protected:
                      bool expected_success = true);
 
     static void
-    TestSearchWithExtraInfo(const IndexPtr& index,
-                            const TestDatasetPtr& dataset,
-                            const std::string& search_param,
-                            int64_t extra_info_size,
-                            float expected_recall = 0.99);
-
-    static void
     TestGetExtraInfoById(const IndexPtr& index,
                          const TestDatasetPtr& dataset,
                          int64_t extra_info_size);


### PR DESCRIPTION
1. `HGraph::KnnSearch` throw INTERNAL_ERROR if  init IteratorFilterContext failed.
2. `HGraph::KnnSearch` adapts extra info
3. delete unused test code