### PR TITLE
support rabitq search with sq4-query

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,8 +9,8 @@ on:
 jobs:
   clang-tidy-check:
     name: Lint
-    # runs-on: ubuntu-latest
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
+    # runs-on: self-hosted
     container:
       image: vsaglib/vsag:ci-x86
     concurrency:

--- a/include/vsag/constants.h
+++ b/include/vsag/constants.h
@@ -119,6 +119,7 @@ extern const char* const SERIALIZE_VERSION;
 
 extern const char* const SQ4_UNIFORM_TRUNC_RATE;
 extern const char* const RABITQ_PCA_DIM;
+extern const char* const RABITQ_BITS_PER_DIM_QUERY;
 
 // hgraph params
 extern const char* const HGRAPH_USE_REORDER;

--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -991,6 +991,14 @@ static const ConstParamMap EXTERNAL_MAPPING = {
             PCA_DIM,
         },
     },
+    {
+        RABITQ_BITS_PER_DIM_QUERY,
+        {
+            HGRAPH_BASE_CODES_KEY,
+            QUANTIZATION_PARAMS_KEY,
+            RABITQ_QUANTIZATION_BITS_PER_DIM_QUERY,
+        },
+    },
 };
 
 static const std::string HGRAPH_PARAMS_TEMPLATE =
@@ -1017,6 +1025,7 @@ static const std::string HGRAPH_PARAMS_TEMPLATE =
                 "{QUANTIZATION_TYPE_KEY}": "{QUANTIZATION_TYPE_VALUE_PQ}",
                 "{SQ4_UNIFORM_QUANTIZATION_TRUNC_RATE}": 0.05,
                 "{PCA_DIM}": 0,
+                "{RABITQ_QUANTIZATION_BITS_PER_DIM_QUERY}": 32,
                 "nbits": 8
             }
         },

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -123,6 +123,7 @@ const char* const SERIALIZE_VERSION = "VERSION";
 
 const char* const SQ4_UNIFORM_TRUNC_RATE = "sq4_uniform_trunc_rate";
 const char* const RABITQ_PCA_DIM = "rabitq_pca_dim";
+const char* const RABITQ_BITS_PER_DIM_QUERY = "rabitq_bits_per_dim_query";
 
 const char* const HGRAPH_USE_REORDER = HGRAPH_USE_REORDER_KEY;
 const char* const HGRAPH_IGNORE_REORDER = "ignore_reorder";

--- a/src/inner_string_params.h
+++ b/src/inner_string_params.h
@@ -58,7 +58,9 @@ const char* const QUANTIZATION_TYPE_VALUE_PQ = "pq";
 const char* const QUANTIZATION_TYPE_VALUE_RABITQ = "rabitq";
 const char* const QUANTIZATION_TYPE_VALUE_SPARSE = "sparse";
 
+// quantization param
 const char* const PCA_DIM = "pca_dim";
+const char* const RABITQ_QUANTIZATION_BITS_PER_DIM_QUERY = "rabitq_bits_per_dim_query";
 const char* const SQ4_UNIFORM_QUANTIZATION_TRUNC_RATE = "sq4_uniform_trunc_rate";
 const char* const PRODUCT_QUANTIZATION_DIM = "pq_dim";
 const char* const PRODUCT_QUANTIZATION_BITS = "pq_bits";

--- a/src/quantization/quantizer_test.h
+++ b/src/quantization/quantizer_test.h
@@ -29,7 +29,7 @@ void
 TestEncodeDecodeRaBitQ(Quantizer<T>& quantizer,
                        uint64_t dim,
                        int count,
-                       float same_sign_rate = 0.6f) {
+                       float same_sign_rate = 0.5f) {
     // Generate centroid and data
     assert(count % 2 == 0);
     auto centroid = fixtures::generate_vectors(1, dim, false, 114514);

--- a/src/quantization/rabitq_quantization/rabitq_quantizer.h
+++ b/src/quantization/rabitq_quantization/rabitq_quantizer.h
@@ -26,6 +26,7 @@
 #include "index/index_common_param.h"
 #include "inner_string_params.h"
 #include "quantization/quantizer.h"
+#include "quantization/scalar_quantization/sq4_uniform_quantizer.h"
 #include "rabitq_quantizer_parameter.h"
 #include "simd/normalize.h"
 #include "simd/rabitq_simd.h"
@@ -45,8 +46,12 @@ class RaBitQuantizer : public Quantizer<RaBitQuantizer<metric>> {
 public:
     using norm_type = float;
     using error_type = float;
+    using sum_type = float;
 
-    explicit RaBitQuantizer(int dim, uint64_t pca_dim, Allocator* allocator);
+    explicit RaBitQuantizer(int dim,
+                            uint64_t pca_dim,
+                            uint64_t num_bits_per_dim_query,
+                            Allocator* allocator);
 
     explicit RaBitQuantizer(const RaBitQuantizerParamPtr& param,
                             const IndexCommonParam& common_param);
@@ -100,13 +105,31 @@ public:
         return QUANTIZATION_TYPE_VALUE_RABITQ;
     }
 
-private:
+public:
+    void
+    ReOrderSQ4(const uint8_t* input, uint8_t* output) const;
+
+    void
+    RecoverOrderSQ4(const uint8_t* output, uint8_t* input) const;
+
     inline float
     L2_UBE(float norm_base_raw, float norm_query_raw, float est_ip_norm) const {
         float p1 = norm_base_raw * norm_base_raw;
         float p2 = norm_query_raw * norm_query_raw;
         float p3 = -2 * norm_base_raw * norm_query_raw * est_ip_norm;
         float ret = p1 + p2 + p3;
+        return ret;
+    }
+
+    inline float
+    RecoverDistBetweenSQ4UandFP32(
+        uint32_t ip_bq_1_4, float base_sum, float query_sum, float lower_bound, float delta) const {
+        // reference: RaBitQ equation 19-20
+        float p1 = inv_sqrt_d_ * delta * 2 * ip_bq_1_4;
+        float p2 = inv_sqrt_d_ * lower_bound * 2 * base_sum;
+        float p3 = inv_sqrt_d_ * delta * query_sum;
+        float p4 = inv_sqrt_d_ * lower_bound * this->dim_;
+        float ret = p1 + p2 - p3 - p4;
         return ret;
     }
 
@@ -123,23 +146,35 @@ private:
     std::uint64_t original_dim_{0};
     std::uint64_t pca_dim_{0};
 
-    // query layout
-    uint64_t query_code_size_{0};  // TODO(ZXY): support various type of query (FP32, SQ4...)
+    /***
+     * query layout: sq-code(required) + lower_bound(sq4) + delta(sq4) + sum(sq4) + norm(required)
+     */
+    uint64_t aligned_dim_{0};
+    uint64_t num_bits_per_dim_query_{32};
+    uint64_t query_code_size_{0};
+    uint64_t query_offset_lb_{0};
+    uint64_t query_offset_delta_{0};
+    uint64_t query_offset_sum_{0};
     uint64_t query_offset_norm_{0};
 
     /***
-     * code layout: sq-code(required) + norm(required) + error(required)
+     * code layout: bq-code(required) + norm(required) + error(required) + sum(sq4)
      */
     uint64_t offset_code_{0};
     uint64_t offset_norm_{0};
     uint64_t offset_error_{0};
+    uint64_t offset_sum_{0};
 };
 
 template <MetricType metric>
-RaBitQuantizer<metric>::RaBitQuantizer(int dim, uint64_t pca_dim, Allocator* allocator)
+RaBitQuantizer<metric>::RaBitQuantizer(int dim,
+                                       uint64_t pca_dim,
+                                       uint64_t num_bits_per_dim_query,
+                                       Allocator* allocator)
     : Quantizer<RaBitQuantizer<metric>>(dim, allocator) {
     static_assert(metric == MetricType::METRIC_TYPE_L2SQR, "Unsupported metric type");
 
+    // dim
     pca_dim_ = pca_dim;
     original_dim_ = dim;
     if (0 < pca_dim_ and pca_dim_ < dim) {
@@ -148,6 +183,9 @@ RaBitQuantizer<metric>::RaBitQuantizer(int dim, uint64_t pca_dim, Allocator* all
     } else {
         pca_dim_ = dim;
     }
+
+    // bits query
+    num_bits_per_dim_query_ = num_bits_per_dim_query;
 
     // centroid
     centroid_.resize(this->dim_, 0);
@@ -159,7 +197,7 @@ RaBitQuantizer<metric>::RaBitQuantizer(int dim, uint64_t pca_dim, Allocator* all
     inv_sqrt_d_ = 1.0f / sqrt(this->dim_);
 
     // base code layout
-    size_t align_size = std::max(sizeof(error_type), sizeof(norm_type));
+    size_t align_size = std::max(std::max(sizeof(error_type), sizeof(norm_type)), sizeof(DataType));
     size_t code_original_size = (this->dim_ + 7) / 8;
 
     this->code_size_ = 0;
@@ -173,8 +211,33 @@ RaBitQuantizer<metric>::RaBitQuantizer(int dim, uint64_t pca_dim, Allocator* all
     offset_error_ = this->code_size_;
     this->code_size_ += ((sizeof(error_type) + align_size - 1) / align_size) * align_size;
 
+    if (num_bits_per_dim_query_ != 32) {
+        offset_sum_ = this->code_size_;
+        this->code_size_ += ((sizeof(sum_type) + align_size - 1) / align_size) * align_size;
+    }
+
     // query code layout
-    this->query_code_size_ = ((sizeof(DataType) * this->dim_) / align_size) * align_size;
+    if (num_bits_per_dim_query_ == 4) {
+        // Re-order the SQ4U Code Layout (align with 8 bits)
+        // e.g., for a float query with dim == 4:   [1, 2, 4, 8]
+        //       suppose original SQ4U code is:     [0001 0010, 0100 1000]  (0001 is 4)
+        //       then, the re-ordered code is:      [1000 0100, 0010 0001]
+        aligned_dim_ = ((this->dim_ + 511) / 512) * 512;
+        auto sq_code_size = aligned_dim_ / 8 * num_bits_per_dim_query_;
+        this->query_code_size_ = (sq_code_size / align_size) * align_size;
+
+        query_offset_lb_ = this->query_code_size_;
+        this->query_code_size_ += ((sizeof(DataType) + align_size - 1) / align_size) * align_size;
+
+        query_offset_delta_ = this->query_code_size_;
+        this->query_code_size_ += ((sizeof(DataType) + align_size - 1) / align_size) * align_size;
+
+        query_offset_sum_ = this->query_code_size_;
+        this->query_code_size_ += ((sizeof(sum_type) + align_size - 1) / align_size) * align_size;
+    } else {
+        this->query_code_size_ = ((sizeof(DataType) * this->dim_) / align_size) * align_size;
+    }
+
     query_offset_norm_ = this->query_code_size_;
     this->query_code_size_ += ((sizeof(norm_type) + align_size - 1) / align_size) * align_size;
 }
@@ -182,7 +245,10 @@ RaBitQuantizer<metric>::RaBitQuantizer(int dim, uint64_t pca_dim, Allocator* all
 template <MetricType metric>
 RaBitQuantizer<metric>::RaBitQuantizer(const RaBitQuantizerParamPtr& param,
                                        const IndexCommonParam& common_param)
-    : RaBitQuantizer<metric>(common_param.dim_, param->pca_dim_, common_param.allocator_.get()){};
+    : RaBitQuantizer<metric>(common_param.dim_,
+                             param->pca_dim_,
+                             param->num_bits_per_dim_query_,
+                             common_param.allocator_.get()){};
 
 template <MetricType metric>
 RaBitQuantizer<metric>::RaBitQuantizer(const QuantizerParamPtr& param,
@@ -277,9 +343,11 @@ RaBitQuantizer<metric>::EncodeOneImpl(const DataType* data, uint8_t* codes) cons
         transformed_data.data(), centroid_.data(), normed_data.data(), this->dim_);
 
     // 4. encode with BQ
+    sum_type sum = 0;
     memset(codes, 0, this->code_size_);
     for (uint64_t d = 0; d < this->dim_; ++d) {
         if (normed_data[d] >= 0.0f) {
+            sum += 1;
             codes[offset_code_ + d / 8] |= (1 << (d % 8));
         }
     }
@@ -288,9 +356,13 @@ RaBitQuantizer<metric>::EncodeOneImpl(const DataType* data, uint8_t* codes) cons
     error_type error =
         RaBitQFloatBinaryIP(normed_data.data(), codes + offset_code_, this->dim_, inv_sqrt_d_);
 
-    // 6. store norm and error
+    // 6. store norm, error, sum
     *(norm_type*)(codes + offset_norm_) = norm;
     *(error_type*)(codes + offset_error_) = error;
+
+    if (num_bits_per_dim_query_ != 32) {
+        *(sum_type*)(codes + offset_sum_) = sum;
+    }
 
     return true;
 }
@@ -355,18 +427,34 @@ RaBitQuantizer<metric>::ComputeQueryBaseImpl(const uint8_t* query_codes,
                                              const uint8_t* base_codes) const {
     // codes1 -> query (fp32, sq8, sq4...) + norm
     // codes2 -> base  (binary) + norm + error
-    norm_type base_norm = *((norm_type*)(base_codes + offset_norm_));
-    norm_type query_norm = *((norm_type*)(query_codes + query_offset_norm_));
+    float ip_bq_estimate;
+    if (num_bits_per_dim_query_ == 4) {
+        std::vector<uint8_t> tmp(aligned_dim_ / 8, 0);
+        memcpy(tmp.data(), base_codes, offset_norm_);
 
+        ip_bq_estimate = RaBitQSQ4UBinaryIP(query_codes, tmp.data(), aligned_dim_);
+
+        sum_type base_sum = *((sum_type*)(base_codes + offset_sum_));
+        sum_type query_sum = *((sum_type*)(query_codes + query_offset_sum_));
+        DataType lower_bound = *((DataType*)(query_codes + query_offset_lb_));
+        DataType delta = *((DataType*)(query_codes + query_offset_delta_));
+
+        ip_bq_estimate =
+            RecoverDistBetweenSQ4UandFP32(ip_bq_estimate, base_sum, query_sum, lower_bound, delta);
+    } else {
+        ip_bq_estimate =
+            RaBitQFloatBinaryIP((DataType*)query_codes, base_codes, this->dim_, inv_sqrt_d_);
+    }
+
+    norm_type query_norm = *((norm_type*)(query_codes + query_offset_norm_));
+    norm_type base_norm = *((norm_type*)(base_codes + offset_norm_));
     error_type base_error = *((error_type*)(base_codes + offset_error_));
     if (std::abs(base_error) < 1e-5) {
         base_error = (base_error > 0) ? 1.0f : -1.0f;
     }
 
-    float ip_bq_1_32 =
-        RaBitQFloatBinaryIP((DataType*)query_codes, base_codes, this->dim_, inv_sqrt_d_);
     float ip_bb_1_32 = base_error;
-    float ip_est = ip_bq_1_32 / ip_bb_1_32;
+    float ip_est = ip_bq_estimate / ip_bb_1_32;
 
     float result = L2_UBE(base_norm, query_norm, ip_est);
 
@@ -381,15 +469,61 @@ RaBitQuantizer<metric>::ComputeImpl(const uint8_t* codes1, const uint8_t* codes2
 
 template <MetricType metric>
 void
+RaBitQuantizer<metric>::ReOrderSQ4(const uint8_t* input, uint8_t* output) const {
+    // note that the codesize of input is different from output
+    // output: align dim bits with 8 bits (1 byte)
+    for (uint64_t bit_pos = 0; bit_pos < num_bits_per_dim_query_; ++bit_pos) {
+        for (uint64_t d = 0; d < this->dim_; d++) {
+            // extract the bit
+            uint8_t bit_value = (input[d / 2] >> ((d % 2) * 4 + bit_pos)) & 0x1;
+
+            // calculate the position
+            uint64_t output_bit_pos = bit_pos * aligned_dim_ + d;
+            uint64_t output_byte_i = output_bit_pos / 8;
+            uint64_t output_bit_i = output_bit_pos % 8;
+
+            // set the bit
+            output[output_byte_i] |= (bit_value << output_bit_i);
+        }
+    }
+}
+
+template <MetricType metric>
+void
+RaBitQuantizer<metric>::RecoverOrderSQ4(const uint8_t* output, uint8_t* input) const {
+    // note that the codesize of input is different from output
+    // output: align dim bits with 8 bits (1 byte)
+    for (uint64_t d = 0; d < this->dim_; ++d) {
+        for (uint64_t bit_pos = 0; bit_pos < num_bits_per_dim_query_; ++bit_pos) {
+            // calculate the position in the reordered output
+            uint64_t output_bit_pos = bit_pos * aligned_dim_ + d;
+            uint64_t output_byte_i = output_bit_pos / 8;
+            uint64_t output_bit_i = output_bit_pos % 8;
+
+            // extract the bit
+            uint8_t bit_value = (output[output_byte_i] >> output_bit_i) & 0x1;
+
+            // calculate the position
+            uint64_t input_byte_i = d / 2;
+            uint64_t input_bit_i = (d % 2) * 4 + bit_pos;
+
+            // set the bit
+            input[input_byte_i] |= (bit_value << input_bit_i);
+        }
+    }
+}
+
+template <MetricType metric>
+void
 RaBitQuantizer<metric>::ProcessQueryImpl(const DataType* query,
                                          Computer<RaBitQuantizer>& computer) const {
     try {
-        // TODO(ZXY): allow process query with SQ4 or SQ8, implement in ComputeDist and Param
         computer.buf_ = reinterpret_cast<uint8_t*>(this->allocator_->Allocate(query_code_size_));
         std::fill(computer.buf_, computer.buf_ + query_code_size_, 0);
 
         Vector<DataType> pca_data(this->dim_, 0, this->allocator_);
         Vector<DataType> transformed_data(this->dim_, 0, this->allocator_);
+        Vector<DataType> normed_data(this->dim_, 0, this->allocator_);
 
         // 1. pca
         if (pca_dim_ != this->original_dim_) {
@@ -403,9 +537,34 @@ RaBitQuantizer<metric>::ProcessQueryImpl(const DataType* query,
 
         // 3. norm
         float query_norm = NormalizeWithCentroid(
-            transformed_data.data(), centroid_.data(), (DataType*)computer.buf_, this->dim_);
+            transformed_data.data(), centroid_.data(), normed_data.data(), this->dim_);
 
-        // 4. store norm
+        // 4. query quantization
+        if (num_bits_per_dim_query_ == 4) {
+            // sq4 quantization
+            Vector<uint8_t> tmp_codes(this->query_code_size_, 0, this->allocator_);
+            SQ4UniformQuantizer<MetricType::METRIC_TYPE_IP> sq4_quantizer(
+                this->dim_, this->allocator_, 0.0f);
+            sq4_quantizer.Train(normed_data.data(), 1);
+            sq4_quantizer.EncodeOneImpl(normed_data.data(), tmp_codes.data());
+
+            // re-order and store codes
+            ReOrderSQ4(tmp_codes.data(), computer.buf_);
+
+            // store info
+            auto lb_and_diff = sq4_quantizer.GetLBandDiff();
+            DataType lower_bound = lb_and_diff.first;
+            DataType delta = lb_and_diff.second / 15.0;
+            *(DataType*)(computer.buf_ + query_offset_lb_) = lower_bound;
+            *(DataType*)(computer.buf_ + query_offset_delta_) = delta;
+            *(sum_type*)(computer.buf_ + query_offset_sum_) =
+                sq4_quantizer.GetCodesSum(tmp_codes.data());
+        } else {
+            // store codes
+            memcpy(computer.buf_, normed_data.data(), normed_data.size() * sizeof(DataType));
+        }
+
+        // 5. store norm
         *(norm_type*)(computer.buf_ + query_offset_norm_) = query_norm;
     } catch (std::bad_alloc& e) {
         logger::error("bad alloc when init computer buf");

--- a/src/quantization/rabitq_quantization/rabitq_quantizer_parameter.cpp
+++ b/src/quantization/rabitq_quantization/rabitq_quantizer_parameter.cpp
@@ -28,6 +28,9 @@ RaBitQuantizerParameter::FromJson(const JsonType& json) {
     if (json.contains(PCA_DIM)) {
         this->pca_dim_ = json[PCA_DIM];
     }
+    if (json.contains(RABITQ_QUANTIZATION_BITS_PER_DIM_QUERY)) {
+        this->num_bits_per_dim_query_ = json[RABITQ_QUANTIZATION_BITS_PER_DIM_QUERY];
+    }
 }
 
 JsonType
@@ -35,6 +38,7 @@ RaBitQuantizerParameter::ToJson() {
     JsonType json;
     json[QUANTIZATION_TYPE_KEY] = QUANTIZATION_TYPE_VALUE_RABITQ;
     json[PCA_DIM] = this->pca_dim_;
+    json[RABITQ_QUANTIZATION_BITS_PER_DIM_QUERY] = this->num_bits_per_dim_query_;
     return json;
 }
 }  // namespace vsag

--- a/src/quantization/rabitq_quantization/rabitq_quantizer_parameter.h
+++ b/src/quantization/rabitq_quantization/rabitq_quantizer_parameter.h
@@ -32,6 +32,7 @@ public:
 
 public:
     uint64_t pca_dim_{0};
+    uint64_t num_bits_per_dim_query_{32};
 };
 
 using RaBitQuantizerParamPtr = std::shared_ptr<RaBitQuantizerParameter>;

--- a/src/quantization/rabitq_quantization/rabitq_quantizer_parameter_test.cpp
+++ b/src/quantization/rabitq_quantization/rabitq_quantizer_parameter_test.cpp
@@ -24,7 +24,8 @@ using namespace vsag;
 TEST_CASE("RaBitQ Quantizer Parameter ToJson Test", "[ut][RaBitQuantizerParameter]") {
     std::string param_str = R"(
         {
-            "pca_dim": 256
+            "pca_dim": 256,
+            "rabitq_bits_per_dim_query": 4
         }
     )";
     auto param = std::make_shared<RaBitQuantizerParameter>();

--- a/src/quantization/rabitq_quantization/rabitq_quantizer_test.cpp
+++ b/src/quantization/rabitq_quantization/rabitq_quantizer_test.cpp
@@ -16,8 +16,10 @@
 #include "rabitq_quantizer.h"
 
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
 #include <vector>
 
+#include "../scalar_quantization/sq4_uniform_quantizer.h"
 #include "default_allocator.h"
 #include "fixtures.h"
 #include "quantization/quantizer_test.h"
@@ -29,6 +31,7 @@ const auto dims = fixtures::get_common_used_dims();
 const auto counts = {10, 100};
 
 TEST_CASE("RaBitQ Basic Test", "[ut][RaBitQuantizer]") {
+    auto num_bits_per_dim = GENERATE(4, 32);
     for (auto dim : dims) {
         uint64_t pca_dim = dim;
         if (dim >= 1500) {
@@ -37,7 +40,8 @@ TEST_CASE("RaBitQ Basic Test", "[ut][RaBitQuantizer]") {
         for (auto count : counts) {
             auto allocator = SafeAllocator::FactoryDefaultAllocator();
             auto vecs = fixtures::generate_vectors(count, dim);
-            RaBitQuantizer<MetricType::METRIC_TYPE_L2SQR> quantizer(dim, pca_dim, allocator.get());
+            RaBitQuantizer<MetricType::METRIC_TYPE_L2SQR> quantizer(
+                dim, pca_dim, num_bits_per_dim, allocator.get());
 
             // name
             REQUIRE(quantizer.NameImpl() == QUANTIZATION_TYPE_VALUE_RABITQ);
@@ -51,10 +55,12 @@ TEST_CASE("RaBitQ Basic Test", "[ut][RaBitQuantizer]") {
 }
 
 TEST_CASE("RaBitQ Encode and Decode", "[ut][RaBitQuantizer]") {
+    auto num_bits_per_dim = GENERATE(4, 32);
     for (auto dim : dims) {
         for (auto count : counts) {
             auto allocator = SafeAllocator::FactoryDefaultAllocator();
-            RaBitQuantizer<MetricType::METRIC_TYPE_L2SQR> quantizer(dim, dim, allocator.get());
+            RaBitQuantizer<MetricType::METRIC_TYPE_L2SQR> quantizer(
+                dim, dim, num_bits_per_dim, allocator.get());
 
             TestEncodeDecodeRaBitQ<RaBitQuantizer<MetricType::METRIC_TYPE_L2SQR>>(
                 quantizer, dim, count);
@@ -63,17 +69,22 @@ TEST_CASE("RaBitQ Encode and Decode", "[ut][RaBitQuantizer]") {
 }
 
 TEST_CASE("RaBitQ Compute", "[ut][RaBitQuantizer]") {
+    auto num_bits_per_dim = GENERATE(4, 32);
     for (auto dim : dims) {
         float numeric_error = 0.01 / std::sqrt(dim) * dim;
         float related_error = 0.05f;
         float unbounded_numeric_error_rate = 0.05f;
         float unbounded_related_error_rate = 0.1f;
+        if (num_bits_per_dim == 4) {
+            unbounded_related_error_rate = 0.12f;
+        }
         if (dim < 900) {
             continue;
         }
         for (auto count : counts) {
             auto allocator = SafeAllocator::FactoryDefaultAllocator();
-            RaBitQuantizer<MetricType::METRIC_TYPE_L2SQR> quantizer(dim, dim, allocator.get());
+            RaBitQuantizer<MetricType::METRIC_TYPE_L2SQR> quantizer(
+                dim, dim, num_bits_per_dim, allocator.get());
 
             TestComputer<RaBitQuantizer<MetricType::METRIC_TYPE_L2SQR>,
                          MetricType::METRIC_TYPE_L2SQR>(quantizer,
@@ -92,18 +103,24 @@ TEST_CASE("RaBitQ Compute", "[ut][RaBitQuantizer]") {
 }
 
 TEST_CASE("RaBitQ Serialize and Deserialize", "[ut][RaBitQuantizer]") {
+    auto num_bits_per_dim = GENERATE(4, 32);
     for (auto dim : dims) {
         float numeric_error = 0.01 / std::sqrt(dim) * dim;
         float related_error = 0.05f;
         float unbounded_numeric_error_rate = 0.05f;
         float unbounded_related_error_rate = 0.1f;
+        if (num_bits_per_dim == 4) {
+            unbounded_related_error_rate = 0.12f;
+        }
         if (dim < 900) {
             continue;
         }
         for (auto count : counts) {
             auto allocator = SafeAllocator::FactoryDefaultAllocator();
-            RaBitQuantizer<MetricType::METRIC_TYPE_L2SQR> quantizer1(dim, dim, allocator.get());
-            RaBitQuantizer<MetricType::METRIC_TYPE_L2SQR> quantizer2(dim, dim, allocator.get());
+            RaBitQuantizer<MetricType::METRIC_TYPE_L2SQR> quantizer1(
+                dim, dim, num_bits_per_dim, allocator.get());
+            RaBitQuantizer<MetricType::METRIC_TYPE_L2SQR> quantizer2(
+                dim, dim, num_bits_per_dim, allocator.get());
 
             TestSerializeAndDeserialize<RaBitQuantizer<MetricType::METRIC_TYPE_L2SQR>,
                                         MetricType::METRIC_TYPE_L2SQR>(quantizer1,
@@ -117,4 +134,57 @@ TEST_CASE("RaBitQ Serialize and Deserialize", "[ut][RaBitQuantizer]") {
                                                                        true);
         }
     }
+}
+
+TEST_CASE("RaBitQ Query SQ4 Transform", "[ut][RaBitQuantizer]") {
+    int dim = 5;
+    uint64_t num_bits_per_dim_query = 4;
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+
+    RaBitQuantizer<MetricType::METRIC_TYPE_L2SQR> quantizer(
+        dim, dim, num_bits_per_dim_query, allocator.get());
+
+    std::vector<float> original_data = {1, 2, 4, 8, 15, 0};
+    // input  [0010 0001, 1000 0100, 0000 1111]
+    std::vector<uint8_t> input = {0x21, 0x84, 0x0f};
+    std::vector<uint8_t> sq_data(4 + 4 + 4, 0);
+
+    // test sq
+    SQ4UniformQuantizer<MetricType::METRIC_TYPE_IP> sq4_quantizer(6, allocator.get(), 0.0f);
+    sq4_quantizer.Train(original_data.data(), 1);
+    sq4_quantizer.EncodeOneImpl(original_data.data(), sq_data.data());
+    auto is_consistent = std::memcmp(sq_data.data(), input.data(), input.size());
+    REQUIRE(is_consistent == 0);
+    REQUIRE(std::abs(*(float*)(&sq_data[4]) - 30) < 1e-5);
+    REQUIRE(std::abs(*(float*)(&sq_data[8]) - 30) < 1e-5);
+
+    // test reorder
+    // output  [0001 0001, 0001 0010, 0001 0100, 0001 1000]
+    std::vector<uint8_t> expected_output;
+    expected_output.reserve(64 * 4);
+    for (auto i = 0; i < 64 * 4; i++) {
+        if (i == 0) {
+            expected_output.push_back(0x11);
+        } else if (i == 64) {
+            expected_output.push_back(0x12);
+        } else if (i == 128) {
+            expected_output.push_back(0x14);
+        } else if (i == 192) {
+            expected_output.push_back(0x18);
+        } else {
+            expected_output.push_back(0);
+        }
+    }
+    std::vector<uint8_t> output(64 * 4, 0);
+    std::vector<uint8_t> recovered_input(3, 0);
+
+    // reorder the input
+    quantizer.ReOrderSQ4(input.data(), output.data());
+    is_consistent = std::memcmp(expected_output.data(), output.data(), output.size());
+    REQUIRE(is_consistent == 0);
+
+    // recover the original order
+    quantizer.RecoverOrderSQ4(output.data(), recovered_input.data());
+    is_consistent = std::memcmp(recovered_input.data(), input.data(), input.size());
+    REQUIRE(is_consistent == 0);
 }

--- a/src/simd/rabitq_simd.cpp
+++ b/src/simd/rabitq_simd.cpp
@@ -39,6 +39,17 @@ GetRaBitQFloatBinaryIP() {
     return generic::RaBitQFloatBinaryIP;
 }
 
+static RaBitQSQ4UBinaryType
+GetRaBitQSQ4UBinaryIP() {
+    if (SimdStatus::SupportAVX512()) {
+#if defined(ENABLE_AVX512)
+        return avx512::RaBitQSQ4UBinaryIP;
+#endif
+    }
+    return generic::RaBitQSQ4UBinaryIP;
+}
+
 RaBitQFloatBinaryType RaBitQFloatBinaryIP = GetRaBitQFloatBinaryIP();
+RaBitQSQ4UBinaryType RaBitQSQ4UBinaryIP = GetRaBitQSQ4UBinaryIP();
 
 }  // namespace vsag

--- a/src/simd/rabitq_simd.h
+++ b/src/simd/rabitq_simd.h
@@ -23,6 +23,9 @@ namespace vsag {
 namespace avx512 {
 float
 RaBitQFloatBinaryIP(const float* vector, const uint8_t* bits, uint64_t dim, float inv_sqrt_d);
+
+uint32_t
+RaBitQSQ4UBinaryIP(const uint8_t* codes, const uint8_t* bits, uint64_t dim);
 }  // namespace avx512
 
 namespace avx2 {
@@ -43,6 +46,9 @@ RaBitQFloatBinaryIP(const float* vector, const uint8_t* bits, uint64_t dim, floa
 namespace generic {
 float
 RaBitQFloatBinaryIP(const float* vector, const uint8_t* bits, uint64_t dim, float inv_sqrt_d);
+
+uint32_t
+RaBitQSQ4UBinaryIP(const uint8_t* codes, const uint8_t* bits, uint64_t dim);
 }  // namespace generic
 
 using RaBitQFloatBinaryType = float (*)(const float* vector,
@@ -50,5 +56,8 @@ using RaBitQFloatBinaryType = float (*)(const float* vector,
                                         uint64_t dim,
                                         float inv_sqrt_d);
 
+using RaBitQSQ4UBinaryType = uint32_t (*)(const uint8_t* codes, const uint8_t* bits, uint64_t dim);
+
 extern RaBitQFloatBinaryType RaBitQFloatBinaryIP;
+extern RaBitQSQ4UBinaryType RaBitQSQ4UBinaryIP;
 }  // namespace vsag

--- a/src/simd/rabitq_simd_test.cpp
+++ b/src/simd/rabitq_simd_test.cpp
@@ -23,6 +23,80 @@
 
 using namespace vsag;
 
+#define TEST_ACCURACY_FP32(Func)                                 \
+    {                                                            \
+        float generic, sse, avx, avx2, avx512;                   \
+        generic = generic::Func(query, base, dim, inv_sqrt_d);   \
+        REQUIRE(std::abs(gt - generic) < 1e-4);                  \
+        if (SimdStatus::SupportSSE()) {                          \
+            sse = sse::Func(query, base, dim, inv_sqrt_d);       \
+            REQUIRE(std::abs(gt - sse) < 1e-4);                  \
+        }                                                        \
+        if (SimdStatus::SupportAVX()) {                          \
+            avx = avx::Func(query, base, dim, inv_sqrt_d);       \
+            REQUIRE(std::abs(gt - avx) < 1e-4);                  \
+        }                                                        \
+        if (SimdStatus::SupportAVX2()) {                         \
+            avx2 = avx2::Func(query, base, dim, inv_sqrt_d);     \
+            REQUIRE(std::abs(gt - avx2) < 1e-4);                 \
+        }                                                        \
+        if (SimdStatus::SupportAVX512()) {                       \
+            avx512 = avx512::Func(query, base, dim, inv_sqrt_d); \
+            REQUIRE(std::abs(gt - avx512) < 1e-4);               \
+        }                                                        \
+    };
+
+#define TEST_ACCURACY_SQ4(Func)                                        \
+    {                                                                  \
+        float gt, avx512;                                              \
+        gt = generic::Func(codes.data(), bits.data(), dim);            \
+        if (SimdStatus::SupportAVX512()) {                             \
+            avx512 = avx512::Func(codes.data(), bits.data(), dim);     \
+            REQUIRE(fixtures::dist_t(gt) == fixtures::dist_t(avx512)); \
+        }                                                              \
+    };
+
+#define BENCHMARK_SIMD_COMPUTE_SQ4(Simd, Comp)          \
+    BENCHMARK_ADVANCED(#Simd #Comp) {                   \
+        for (int i = 0; i < count; ++i) {               \
+            Simd::Comp(codes.data(), bits.data(), dim); \
+        }                                               \
+        return;                                         \
+    }
+
+TEST_CASE("RaBitQ SQ4U-BQ Compute Codes", "[ut][simd]") {
+    std::vector<uint8_t> codes = {0xFF,
+                                  0xFF,  // [1111 1111, 1111 1111]
+                                  0x0F,
+                                  0x0F,  // [0000 1111, 0000 1111]
+                                  0xF0,
+                                  0xF0,  // [1111 0000, 1111 0000]
+                                  0x00,
+                                  0x00};  // [0000 0000, 0000 0000]
+    codes.resize(64);
+    std::vector<uint8_t> bits = {0xAA, 0x55};  // [1010 1010, 0101 0101]
+    bits.resize(64);
+
+    for (auto dim = 0; dim < 17; dim++) {
+        uint32_t result = generic::RaBitQSQ4UBinaryIP(codes.data(), bits.data(), dim);
+        TEST_ACCURACY_SQ4(RaBitQSQ4UBinaryIP);
+        if (dim == 0) {
+            REQUIRE(result == 0);
+        } else if (dim <= 8) {
+            // 4 * 1 + 4 * 2 + 2 * 4 + 2 * 8
+            REQUIRE(result == 36);
+        } else {
+            // 8 * 1 + 4 * 2 + 4 * 4 + 0 * 8
+            REQUIRE(result == 32);
+        }
+    }
+
+    int count = 10000;
+    int dim = 32;
+    BENCHMARK_SIMD_COMPUTE_SQ4(generic, RaBitQSQ4UBinaryIP);
+    BENCHMARK_SIMD_COMPUTE_SQ4(avx512, RaBitQSQ4UBinaryIP);
+}
+
 TEST_CASE("RaBitQ FP32-BQ SIMD Compute Codes", "[ut][simd]") {
     auto dims = fixtures::get_common_used_dims();
     int64_t count = 100;
@@ -36,29 +110,8 @@ TEST_CASE("RaBitQ FP32-BQ SIMD Compute Codes", "[ut][simd]") {
             auto* query = queries.data() + i * dim;
             auto* base = bases.data() + i * code_size;
 
-            auto ip_32_32 = FP32ComputeIP(query, query, dim);
-            auto ip_32_1_generic = generic::RaBitQFloatBinaryIP(query, base, dim, inv_sqrt_d);
-            REQUIRE(std::abs(ip_32_1_generic - ip_32_32) < 1e-4);
-
-            if (SimdStatus::SupportAVX512()) {
-                auto ip_32_1_avx512 = avx512::RaBitQFloatBinaryIP(query, base, dim, inv_sqrt_d);
-                REQUIRE(std::abs(ip_32_1_avx512 - ip_32_32) < 1e-4);
-            }
-
-            if (SimdStatus::SupportAVX2()) {
-                auto ip_32_1_avx2 = avx2::RaBitQFloatBinaryIP(query, base, dim, inv_sqrt_d);
-                REQUIRE(std::abs(ip_32_1_avx2 - ip_32_32) < 1e-4);
-            }
-
-            if (SimdStatus::SupportAVX()) {
-                auto ip_32_1_avx = avx::RaBitQFloatBinaryIP(query, base, dim, inv_sqrt_d);
-                REQUIRE(std::abs(ip_32_1_avx - ip_32_32) < 1e-4);
-            }
-
-            if (SimdStatus::SupportSSE()) {
-                auto ip_32_1_sse = sse::RaBitQFloatBinaryIP(query, base, dim, inv_sqrt_d);
-                REQUIRE(std::abs(ip_32_1_sse - ip_32_32) < 1e-4);
-            }
+            auto gt = FP32ComputeIP(query, query, dim);
+            TEST_ACCURACY_FP32(RaBitQFloatBinaryIP);
         }
     }
 }

--- a/src/simd/rabitq_simd_test.cpp
+++ b/src/simd/rabitq_simd_test.cpp
@@ -64,6 +64,25 @@ using namespace vsag;
         return;                                         \
     }
 
+TEST_CASE("RaBitQ SQ4U-BQ Compute Benchmark", "[ut][simd][!benchmark]") {
+    std::vector<uint8_t> codes = {0xFF,
+                                  0xFF,  // [1111 1111, 1111 1111]
+                                  0x0F,
+                                  0x0F,  // [0000 1111, 0000 1111]
+                                  0xF0,
+                                  0xF0,  // [1111 0000, 1111 0000]
+                                  0x00,
+                                  0x00};  // [0000 0000, 0000 0000]
+    codes.resize(64);
+    std::vector<uint8_t> bits = {0xAA, 0x55};  // [1010 1010, 0101 0101]
+    bits.resize(64);
+
+    int count = 10000;
+    int dim = 32;
+    BENCHMARK_SIMD_COMPUTE_SQ4(generic, RaBitQSQ4UBinaryIP);
+    BENCHMARK_SIMD_COMPUTE_SQ4(avx512, RaBitQSQ4UBinaryIP);
+}
+
 TEST_CASE("RaBitQ SQ4U-BQ Compute Codes", "[ut][simd]") {
     std::vector<uint8_t> codes = {0xFF,
                                   0xFF,  // [1111 1111, 1111 1111]
@@ -90,11 +109,6 @@ TEST_CASE("RaBitQ SQ4U-BQ Compute Codes", "[ut][simd]") {
             REQUIRE(result == 32);
         }
     }
-
-    int count = 10000;
-    int dim = 32;
-    BENCHMARK_SIMD_COMPUTE_SQ4(generic, RaBitQSQ4UBinaryIP);
-    BENCHMARK_SIMD_COMPUTE_SQ4(avx512, RaBitQSQ4UBinaryIP);
 }
 
 TEST_CASE("RaBitQ FP32-BQ SIMD Compute Codes", "[ut][simd]") {


### PR DESCRIPTION
close #654 

- example config:
```
gist-rabitqsq4:
    datapath: "/tbase-project/ann-benchmarks/data/gist-960-euclidean.hdf5"
    type: "search" # build, search
    index_name: "hgraph"
    create_params: '{"dim":960,"dtype":"float32","metric_type":"l2","index_param":{
    "base_quantization_type":"rabitq",
    "rabitq_bits_per_dim_query":4,
    "max_degree":64,
    "ef_construction":300,
    "build_thread_count":32,
    "use_reorder":true,
    "precise_quantization_type":"fp32",
    "precise_io_type":"block_memory_io"}}'
    search_params: '{"hgraph":{"ef_search":80}}'
    index_path: "/tmp/gist-960-euclidean/index/415_index_gist_rabitq_4"
    topk: 10
    search_mode: "knn" # ["knn", "range", "knn_filter", "range_filter"]
    range: 0.5
    delete_index_after_search: false # free up storage space used by index
    num_threads_building: 32
    num_threads_searching: 1

```

- running result:
```
+---------------------------+------------+-----+----------+------------+----------------------------------------+-----------+-----+-----------------------------+------------+----------------+-----------+
| Name                      | NumVectors | Dim | DataType | MetricType | IndexParam                             | BuildTime | TPS | SearchParam                 | QPS        | LatencyAvg(ms) | RecallAvg |
+---------------------------+------------+-----+----------+------------+----------------------------------------+-----------+-----+-----------------------------+------------+----------------+-----------+
| gist-rabitqsq4.           | 1000000    | 960 | float32  | l2         | {"base_quantization_type":"rabitq","b- | N/A       | N/A | {"hgraph":{"ef_search":80}} | 457.387360 | 2.186331       | 0.842700  |
|                           |            |     |          |            | uild_thread_count":32,"ef_constructio- |           |     |                             |            |                |           |
|                           |            |     |          |            | n":300,"max_degree":64,"precise_io_ty- |           |     |                             |            |                |           |
|                           |            |     |          |            | pe":"block_memory_io","precise_quanti- |           |     |                             |            |                |           |
|                           |            |     |          |            | zation_type":"fp32","rabitq_bits_per_- |           |     |                             |            |                |           |
|                           |            |     |          |            | dim_query":4,"use_reorder":true}       |           |     |                             |            |                |           |
+---------------------------+------------+-----+----------+------------+----------------------------------------+-----------+-----+-----------------------------+------------+----------------+-----------+

```