### PR TITLE
add compressed graph datacell with Elias-Fano Encoder

### DIFF
--- a/src/data_cell/compressed_graph_datacell.cpp
+++ b/src/data_cell/compressed_graph_datacell.cpp
@@ -75,12 +75,12 @@ CompressedGraphDataCell::Serialize(StreamWriter& writer) {
             StreamWriter::WriteObj(writer, zero);
         } else {
             const EliasFanoEncoder& encoder = *neighbor_sets_[id];
-            StreamWriter::WriteObj(writer, encoder.num_elements_);
-            StreamWriter::WriteObj(writer, encoder.low_bits_width_);
-            StreamWriter::WriteObj(writer, encoder.low_bits_size_);
-            StreamWriter::WriteObj(writer, encoder.high_bits_size_);
-            for (size_t j = 0; j < encoder.low_bits_size_ + encoder.high_bits_size_; j++) {
-                StreamWriter::WriteObj(writer, encoder.bits_[j]);
+            StreamWriter::WriteObj(writer, encoder.num_elements);
+            StreamWriter::WriteObj(writer, encoder.low_bits_width);
+            StreamWriter::WriteObj(writer, encoder.low_bits_size);
+            StreamWriter::WriteObj(writer, encoder.high_bits_size);
+            for (size_t j = 0; j < encoder.low_bits_size + encoder.high_bits_size; j++) {
+                StreamWriter::WriteObj(writer, encoder.bits[j]);
             }
         }
     }
@@ -98,15 +98,15 @@ CompressedGraphDataCell::Deserialize(StreamReader& reader) {
         if (num_elements > 0) {
             this->neighbor_sets_[id] = std::make_unique<EliasFanoEncoder>(allocator_);
             EliasFanoEncoder& encoder = *this->neighbor_sets_[id];
-            encoder.num_elements_ = num_elements;
-            StreamReader::ReadObj(reader, encoder.low_bits_width_);
-            StreamReader::ReadObj(reader, encoder.low_bits_size_);
-            StreamReader::ReadObj(reader, encoder.high_bits_size_);
+            encoder.num_elements = num_elements;
+            StreamReader::ReadObj(reader, encoder.low_bits_width);
+            StreamReader::ReadObj(reader, encoder.low_bits_size);
+            StreamReader::ReadObj(reader, encoder.high_bits_size);
 
-            encoder.bits_ = static_cast<uint64_t*>(allocator_->Allocate(
-                (encoder.low_bits_size_ + encoder.high_bits_size_) * sizeof(uint64_t)));
-            for (size_t j = 0; j < encoder.low_bits_size_ + encoder.high_bits_size_; j++) {
-                StreamReader::ReadObj(reader, encoder.bits_[j]);
+            encoder.bits = static_cast<uint64_t*>(allocator_->Allocate(
+                (encoder.low_bits_size + encoder.high_bits_size) * sizeof(uint64_t)));
+            for (size_t j = 0; j < encoder.low_bits_size + encoder.high_bits_size; j++) {
+                StreamReader::ReadObj(reader, encoder.bits[j]);
             }
         }
     }

--- a/src/data_cell/compressed_graph_datacell.cpp
+++ b/src/data_cell/compressed_graph_datacell.cpp
@@ -36,18 +36,11 @@ void
 CompressedGraphDataCell::InsertNeighborsById(InnerIdType id,
                                              const Vector<InnerIdType>& neighbor_ids) {
     if (neighbor_ids.size() > this->maximum_degree_) {
-        logger::warn(fmt::format(
+        throw std::invalid_argument(fmt::format(
             "insert neighbors count {} more than {}", neighbor_ids.size(), this->maximum_degree_));
     }
 
-    Vector<InnerIdType> tmp(allocator_);
-    if (neighbor_sets_[id]) {
-        neighbor_sets_[id]->DecompressAll(tmp);
-    }
-    tmp.reserve(neighbor_ids.size() + GetNeighborSize(id));
-    for (auto nbr_id : neighbor_ids) {
-        tmp.push_back(nbr_id);
-    }
+    Vector<InnerIdType> tmp(neighbor_ids.begin(), neighbor_ids.end(), allocator_);
     std::sort(tmp.begin(), tmp.end());
 
     if (not tmp.empty()) {

--- a/src/data_cell/compressed_graph_datacell.cpp
+++ b/src/data_cell/compressed_graph_datacell.cpp
@@ -1,0 +1,133 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "compressed_graph_datacell.h"
+
+#include "graph_datacell_parameter.h"
+
+namespace vsag {
+
+CompressedGraphDataCell::CompressedGraphDataCell(const GraphInterfaceParamPtr& graph_param,
+                                                 const IndexCommonParam& common_param)
+    : CompressedGraphDataCell(std::dynamic_pointer_cast<GraphDataCellParameter>(graph_param),
+                              common_param) {
+}
+
+CompressedGraphDataCell::CompressedGraphDataCell(const GraphDataCellParamPtr& graph_param,
+                                                 const IndexCommonParam& common_param)
+    : allocator_(common_param.allocator_.get()), neighbor_sets_(allocator_) {
+    this->maximum_degree_ = graph_param->max_degree_;
+    this->max_capacity_ = graph_param->init_max_capacity_;
+}
+
+void
+CompressedGraphDataCell::InsertNeighborsById(InnerIdType id,
+                                             const Vector<InnerIdType>& neighbor_ids) {
+    if (neighbor_ids.size() > this->maximum_degree_) {
+        logger::warn(fmt::format(
+            "insert neighbors count {} more than {}", neighbor_ids.size(), this->maximum_degree_));
+    }
+
+    Vector<InnerIdType> tmp(allocator_);
+    if (neighbor_sets_[id]) {
+        neighbor_sets_[id]->DecompressAll(tmp);
+    }
+    tmp.reserve(neighbor_ids.size() + GetNeighborSize(id));
+    for (auto nbr_id : neighbor_ids) {
+        tmp.push_back(nbr_id);
+    }
+    std::sort(tmp.begin(), tmp.end());
+
+    if (not tmp.empty()) {
+        if (neighbor_sets_[id] == nullptr) {
+            neighbor_sets_[id] = std::make_unique<EliasFanoEncoder>(allocator_);
+        }
+        neighbor_sets_[id]->Encode(tmp, max_capacity_);
+    }
+}
+
+uint32_t
+CompressedGraphDataCell::GetNeighborSize(InnerIdType id) const {
+    return (neighbor_sets_[id]) ? neighbor_sets_[id]->Size() : 0;
+}
+
+void
+CompressedGraphDataCell::GetNeighbors(InnerIdType id, Vector<InnerIdType>& neighbor_ids) const {
+    if (GetNeighborSize(id) > 0) {
+        neighbor_sets_[id]->DecompressAll(neighbor_ids);
+    }
+}
+
+void
+CompressedGraphDataCell::Serialize(StreamWriter& writer) {
+    GraphInterface::Serialize(writer);
+
+    auto vertex_num = this->neighbor_sets_.size();
+    StreamWriter::WriteObj(writer, vertex_num);
+    for (InnerIdType id = 0; id < vertex_num; id++) {
+        if (GetNeighborSize(id) == 0) {
+            uint8_t zero = 0;
+            StreamWriter::WriteObj(writer, zero);
+        } else {
+            const EliasFanoEncoder& encoder = *neighbor_sets_[id];
+            StreamWriter::WriteObj(writer, encoder.num_elements_);
+            StreamWriter::WriteObj(writer, encoder.low_bits_width_);
+            StreamWriter::WriteObj(writer, encoder.low_bits_size_);
+            StreamWriter::WriteObj(writer, encoder.high_bits_size_);
+            for (size_t j = 0; j < encoder.low_bits_size_ + encoder.high_bits_size_; j++) {
+                StreamWriter::WriteObj(writer, encoder.bits_[j]);
+            }
+        }
+    }
+}
+
+void
+CompressedGraphDataCell::Deserialize(StreamReader& reader) {
+    GraphInterface::Deserialize(reader);
+    uint64_t vertex_num;
+    StreamReader::ReadObj(reader, vertex_num);
+    Resize(vertex_num);
+    for (uint64_t id = 0; id < vertex_num; ++id) {
+        uint8_t num_elements = 0;
+        StreamReader::ReadObj(reader, num_elements);
+        if (num_elements > 0) {
+            this->neighbor_sets_[id] = std::make_unique<EliasFanoEncoder>(allocator_);
+            EliasFanoEncoder& encoder = *this->neighbor_sets_[id];
+            encoder.num_elements_ = num_elements;
+            StreamReader::ReadObj(reader, encoder.low_bits_width_);
+            StreamReader::ReadObj(reader, encoder.low_bits_size_);
+            StreamReader::ReadObj(reader, encoder.high_bits_size_);
+
+            encoder.bits_ = static_cast<uint64_t*>(allocator_->Allocate(
+                (encoder.low_bits_size_ + encoder.high_bits_size_) * sizeof(uint64_t)));
+            for (size_t j = 0; j < encoder.low_bits_size_ + encoder.high_bits_size_; j++) {
+                StreamReader::ReadObj(reader, encoder.bits_[j]);
+            }
+        }
+    }
+    this->total_count_ = vertex_num;
+}
+
+void
+CompressedGraphDataCell::Resize(InnerIdType new_size) {
+    if (new_size < this->max_capacity_) {
+        return;
+    }
+    neighbor_sets_.resize(new_size);
+    this->max_capacity_ = new_size;
+    this->total_count_ = new_size;
+}
+
+}  // namespace vsag

--- a/src/data_cell/compressed_graph_datacell.h
+++ b/src/data_cell/compressed_graph_datacell.h
@@ -1,0 +1,63 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <shared_mutex>
+
+#include "graph_datacell_parameter.h"
+#include "graph_interface.h"
+#include "impl/elias_fano_encoder.h"
+#include "io/memory_block_io.h"
+
+namespace vsag {
+
+class CompressedGraphDataCell : public GraphInterface {
+public:
+    explicit CompressedGraphDataCell(const GraphInterfaceParamPtr& graph_param,
+                                     const IndexCommonParam& common_param);
+
+    explicit CompressedGraphDataCell(const GraphDataCellParamPtr& graph_param,
+                                     const IndexCommonParam& common_param);
+
+    void
+    InsertNeighborsById(InnerIdType id, const Vector<InnerIdType>& neighbor_ids) override;
+
+    [[nodiscard]] uint32_t
+    GetNeighborSize(InnerIdType id) const override;
+
+    void
+    GetNeighbors(InnerIdType id, Vector<InnerIdType>& neighbor_ids) const override;
+
+    void
+    Resize(InnerIdType new_size) override;
+
+    void
+    Prefetch(InnerIdType id, uint32_t neighbor_i) override {
+        // Not supposed to use
+    }
+
+    void
+    Serialize(StreamWriter& writer) override;
+
+    void
+    Deserialize(StreamReader& reader) override;
+
+private:
+    Allocator* const allocator_{nullptr};
+    Vector<std::unique_ptr<EliasFanoEncoder>> neighbor_sets_;
+};
+
+}  // namespace vsag

--- a/src/data_cell/compressed_graph_datacell_test.cpp
+++ b/src/data_cell/compressed_graph_datacell_test.cpp
@@ -1,0 +1,54 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "compressed_graph_datacell.h"
+
+#include <fmt/format-inl.h>
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+
+#include "graph_datacell_parameter.h"
+#include "graph_interface_test.h"
+#include "safe_allocator.h"
+using namespace vsag;
+
+void
+TestCompressedGraphDataCell(const GraphInterfaceParamPtr& param,
+                            const IndexCommonParam& common_param) {
+    auto count = GENERATE(1000, 2000);
+    auto max_id = 10000;
+
+    auto graph = std::make_shared<CompressedGraphDataCell>(param, common_param);
+    GraphInterfaceTest test(graph, true);
+    auto other = std::make_shared<CompressedGraphDataCell>(param, common_param);
+    test.BasicTest(max_id, count, other);
+}
+
+TEST_CASE("CompressedGraphDataCell Basic Test", "[ut][CompressedGraphDataCell]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    auto dim = GENERATE(32, 64);
+    auto max_degree = GENERATE(5, 12, 32, 64, 128);
+    auto max_capacity = 10000;
+
+    IndexCommonParam common_param;
+    common_param.dim_ = dim;
+    common_param.allocator_ = allocator;
+    auto graph_param = std::make_shared<GraphDataCellParameter>();
+    graph_param->max_degree_ = max_degree;
+    graph_param->init_max_capacity_ = max_capacity;
+    graph_param->graph_storage_type_ = GraphStorageTypes::GRAPH_STORAGE_TYPE_COMPRESSED;
+    TestCompressedGraphDataCell(graph_param, common_param);
+}

--- a/src/data_cell/compressed_graph_datacell_test.cpp
+++ b/src/data_cell/compressed_graph_datacell_test.cpp
@@ -31,9 +31,9 @@ TestCompressedGraphDataCell(const GraphInterfaceParamPtr& param,
     auto count = GENERATE(1000, 2000);
     auto max_id = 10000;
 
-    auto graph = std::make_shared<CompressedGraphDataCell>(param, common_param);
+    auto graph = GraphInterface::MakeInstance(param, common_param);
     GraphInterfaceTest test(graph, true);
-    auto other = std::make_shared<CompressedGraphDataCell>(param, common_param);
+    auto other = GraphInterface::MakeInstance(param, common_param);
     test.BasicTest(max_id, count, other);
 }
 

--- a/src/data_cell/graph_datacell.h
+++ b/src/data_cell/graph_datacell.h
@@ -115,7 +115,7 @@ void
 GraphDataCell<IOTmpl>::InsertNeighborsById(InnerIdType id,
                                            const Vector<InnerIdType>& neighbor_ids) {
     if (neighbor_ids.size() > this->maximum_degree_) {
-        logger::warn(fmt::format(
+        throw std::invalid_argument(fmt::format(
             "insert neighbors count {} more than {}", neighbor_ids.size(), this->maximum_degree_));
     }
     InnerIdType current = total_count_.load();

--- a/src/data_cell/graph_datacell_parameter.h
+++ b/src/data_cell/graph_datacell_parameter.h
@@ -15,7 +15,6 @@
 
 #pragma once
 
-#include "data_cell/graph_storage_type.h"
 #include "graph_interface_parameter.h"
 #include "io/io_parameter.h"
 
@@ -36,8 +35,6 @@ public:
     uint64_t max_degree_{64};
 
     uint64_t init_max_capacity_{100};
-
-    GraphStorageTypes graph_storage_type_{GraphStorageTypes::GRAPH_STORAGE_TYPE_FLAT};
 };
 
 using GraphDataCellParamPtr = std::shared_ptr<GraphDataCellParameter>;

--- a/src/data_cell/graph_interface.cpp
+++ b/src/data_cell/graph_interface.cpp
@@ -15,6 +15,7 @@
 
 #include "graph_interface.h"
 
+#include "compressed_graph_datacell.h"
 #include "graph_datacell.h"
 #include "io/io_headers.h"
 #include "sparse_graph_datacell.h"
@@ -25,6 +26,12 @@ GraphInterfacePtr
 GraphInterface::MakeInstance(const GraphInterfaceParamPtr& param,
                              const IndexCommonParam& common_param,
                              bool is_sparse) {
+    auto graph_storage_type =
+        std::dynamic_pointer_cast<GraphDataCellParameter>(param)->graph_storage_type_;
+    if (graph_storage_type == GraphStorageTypes::GRAPH_STORAGE_TYPE_COMPRESSED) {
+        return std::make_shared<CompressedGraphDataCell>(param, common_param);
+    }
+
     if (is_sparse) {
         return std::make_shared<SparseGraphDataCell>(param, common_param);
     }

--- a/src/data_cell/graph_interface.cpp
+++ b/src/data_cell/graph_interface.cpp
@@ -23,28 +23,27 @@
 namespace vsag {
 
 GraphInterfacePtr
-GraphInterface::MakeInstance(const GraphInterfaceParamPtr& param,
+GraphInterface::MakeInstance(const GraphInterfaceParamPtr& graph_param,
                              const IndexCommonParam& common_param,
                              bool is_sparse) {
-    auto graph_storage_type =
-        std::dynamic_pointer_cast<GraphDataCellParameter>(param)->graph_storage_type_;
+    auto graph_storage_type = graph_param->graph_storage_type_;
     if (graph_storage_type == GraphStorageTypes::GRAPH_STORAGE_TYPE_COMPRESSED) {
-        return std::make_shared<CompressedGraphDataCell>(param, common_param);
+        return std::make_shared<CompressedGraphDataCell>(graph_param, common_param);
     }
 
     if (is_sparse) {
-        return std::make_shared<SparseGraphDataCell>(param, common_param);
+        return std::make_shared<SparseGraphDataCell>(graph_param, common_param);
     }
 
-    auto io_string =
-        std::dynamic_pointer_cast<GraphDataCellParameter>(param)->io_parameter_->GetTypeName();
+    auto io_string = std::dynamic_pointer_cast<GraphDataCellParameter>(graph_param)
+                         ->io_parameter_->GetTypeName();
 
     if (io_string == IO_TYPE_VALUE_BLOCK_MEMORY_IO) {
-        return std::make_shared<GraphDataCell<MemoryBlockIO>>(param, common_param);
+        return std::make_shared<GraphDataCell<MemoryBlockIO>>(graph_param, common_param);
     }
 
     if (io_string == IO_TYPE_VALUE_MEMORY_IO) {
-        return std::make_shared<GraphDataCell<MemoryIO>>(param, common_param);
+        return std::make_shared<GraphDataCell<MemoryIO>>(graph_param, common_param);
     }
 
     return nullptr;

--- a/src/data_cell/graph_interface.h
+++ b/src/data_cell/graph_interface.h
@@ -40,7 +40,7 @@ public:
     virtual ~GraphInterface() = default;
 
     static GraphInterfacePtr
-    MakeInstance(const GraphInterfaceParamPtr& graph_interface_param,
+    MakeInstance(const GraphInterfaceParamPtr& graph_param,
                  const IndexCommonParam& common_param,
                  bool is_sparse = false);
 

--- a/src/data_cell/graph_interface_parameter.h
+++ b/src/data_cell/graph_interface_parameter.h
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include "data_cell/graph_storage_type.h"
 #include "parameter.h"
 
 namespace vsag {
@@ -26,6 +27,9 @@ class GraphInterfaceParameter : public Parameter {
 public:
     static GraphInterfaceParamPtr
     GetGraphParameterByJson(const JsonType& json);
+
+public:
+    GraphStorageTypes graph_storage_type_{GraphStorageTypes::GRAPH_STORAGE_TYPE_FLAT};
 
 protected:
     explicit GraphInterfaceParameter() = default;

--- a/src/data_cell/graph_interface_test.cpp
+++ b/src/data_cell/graph_interface_test.cpp
@@ -39,6 +39,11 @@ GraphInterfaceTest::BasicTest(uint64_t max_id, uint64_t count, const GraphInterf
         auto cur_id = random() % max_id;
         maps[cur_id] = ids;
     }
+    if (require_sorted_) {
+        for (auto& [key, value] : maps) {
+            std::sort(value->begin(), value->end());
+        }
+    }
 
     for (auto& [key, value] : maps) {
         this->graph_->InsertNeighborsById(key, *value);

--- a/src/data_cell/graph_interface_test.cpp
+++ b/src/data_cell/graph_interface_test.cpp
@@ -29,22 +29,27 @@ GraphInterfaceTest::BasicTest(uint64_t max_id, uint64_t count, const GraphInterf
     auto allocator = SafeAllocator::FactoryDefaultAllocator();
     auto max_degree = this->graph_->MaximumDegree();
     this->graph_->Resize(max_id);
-    UnorderedMap<InnerIdType, std::shared_ptr<Vector<InnerIdType>>> maps(allocator.get());
-    for (auto i = 0; i < count; ++i) {
-        auto length = random() % max_degree + 1;
-        auto ids = std::make_shared<Vector<InnerIdType>>(length, allocator.get());
-        for (auto& id : *ids) {
-            id = random() % max_id;
-        }
-        auto cur_id = random() % max_id;
-        maps[cur_id] = ids;
-    }
-    if (require_sorted_) {
-        for (auto& [key, value] : maps) {
-            std::sort(value->begin(), value->end());
-        }
-    }
 
+    auto generate_graph = [&]() {
+        UnorderedMap<InnerIdType, std::shared_ptr<Vector<InnerIdType>>> cur_map(allocator.get());
+        for (auto i = 0; i < count; ++i) {
+            auto length = random() % max_degree + 1;
+            auto ids = std::make_shared<Vector<InnerIdType>>(length, allocator.get());
+            for (auto& id : *ids) {
+                id = random() % max_id;
+            }
+            auto cur_id = random() % max_id;
+            cur_map[cur_id] = ids;
+        }
+        if (require_sorted_) {
+            for (auto& [key, value] : cur_map) {
+                std::sort(value->begin(), value->end());
+            }
+        }
+        return cur_map;
+    };
+
+    UnorderedMap<InnerIdType, std::shared_ptr<Vector<InnerIdType>>> maps = generate_graph();
     for (auto& [key, value] : maps) {
         this->graph_->InsertNeighborsById(key, *value);
     }
@@ -100,5 +105,21 @@ GraphInterfaceTest::BasicTest(uint64_t max_id, uint64_t count, const GraphInterf
         }
 
         infile.close();
+    }
+
+    maps = generate_graph();
+    for (auto& [key, value] : maps) {
+        this->graph_->InsertNeighborsById(key, *value);
+    }
+    SECTION("Test Update Graph") {
+        for (auto& [key, value] : maps) {
+            REQUIRE(this->graph_->GetNeighborSize(key) == value->size());
+        }
+        for (auto& [key, value] : maps) {
+            Vector<InnerIdType> neighbors(allocator.get());
+            this->graph_->GetNeighbors(key, neighbors);
+            REQUIRE(memcmp(neighbors.data(), value->data(), value->size() * sizeof(InnerIdType)) ==
+                    0);
+        }
     }
 }

--- a/src/data_cell/graph_interface_test.h
+++ b/src/data_cell/graph_interface_test.h
@@ -23,12 +23,15 @@
 namespace vsag {
 class GraphInterfaceTest {
 public:
-    explicit GraphInterfaceTest(GraphInterfacePtr graph) : graph_(std::move(graph)){};
+    explicit GraphInterfaceTest(GraphInterfacePtr graph, const bool require_sorted = false)
+        : graph_(std::move(graph)), require_sorted_(require_sorted) {
+    }
 
     void
     BasicTest(uint64_t max_id, uint64_t count, const GraphInterfacePtr& other);
 
 public:
     GraphInterfacePtr graph_{nullptr};
+    bool require_sorted_{false};
 };
 }  // namespace vsag

--- a/src/data_cell/graph_storage_type.h
+++ b/src/data_cell/graph_storage_type.h
@@ -16,9 +16,6 @@
 #pragma once
 
 namespace vsag {
-enum class GraphStorageTypes {
-    GRAPH_STORAGE_TYPE_FLAT = 0,
-    GRAPH_STORAGE_TYPE_COMPRESSED = 1
-};
+enum class GraphStorageTypes { GRAPH_STORAGE_TYPE_FLAT = 0, GRAPH_STORAGE_TYPE_COMPRESSED = 1 };
 
 }  // namespace vsag

--- a/src/data_cell/graph_storage_type.h
+++ b/src/data_cell/graph_storage_type.h
@@ -15,30 +15,11 @@
 
 #pragma once
 
-#include "data_cell/graph_storage_type.h"
-#include "graph_interface_parameter.h"
-#include "io/io_parameter.h"
-
 namespace vsag {
-class GraphDataCellParameter : public GraphInterfaceParameter {
-public:
-    GraphDataCellParameter() = default;
-
-    void
-    FromJson(const JsonType& json) override;
-
-    JsonType
-    ToJson() override;
-
-public:
-    IOParamPtr io_parameter_{nullptr};
-
-    uint64_t max_degree_{64};
-
-    uint64_t init_max_capacity_{100};
-
-    GraphStorageTypes graph_storage_type_{GraphStorageTypes::GRAPH_STORAGE_TYPE_FLAT};
+enum class GraphStorageTypes {
+    GRAPH_STORAGE_TYPE_FLAT = 0,
+    GRAPH_STORAGE_TYPE_SPARSE = 1,
+    GRAPH_STORAGE_TYPE_COMPRESSED = 2
 };
 
-using GraphDataCellParamPtr = std::shared_ptr<GraphDataCellParameter>;
 }  // namespace vsag

--- a/src/data_cell/graph_storage_type.h
+++ b/src/data_cell/graph_storage_type.h
@@ -18,8 +18,7 @@
 namespace vsag {
 enum class GraphStorageTypes {
     GRAPH_STORAGE_TYPE_FLAT = 0,
-    GRAPH_STORAGE_TYPE_SPARSE = 1,
-    GRAPH_STORAGE_TYPE_COMPRESSED = 2
+    GRAPH_STORAGE_TYPE_COMPRESSED = 1
 };
 
 }  // namespace vsag

--- a/src/data_cell/sparse_graph_datacell.cpp
+++ b/src/data_cell/sparse_graph_datacell.cpp
@@ -33,7 +33,7 @@ SparseGraphDataCell::SparseGraphDataCell(const GraphInterfaceParamPtr& param,
 void
 SparseGraphDataCell::InsertNeighborsById(InnerIdType id, const Vector<InnerIdType>& neighbor_ids) {
     if (neighbor_ids.size() > this->maximum_degree_) {
-        logger::warn(fmt::format(
+        throw std::invalid_argument(fmt::format(
             "insert neighbors count {} more than {}", neighbor_ids.size(), this->maximum_degree_));
     }
     auto size = std::min(this->maximum_degree_, (uint32_t)(neighbor_ids.size()));

--- a/src/impl/elias_fano_encoder.cpp
+++ b/src/impl/elias_fano_encoder.cpp
@@ -45,7 +45,7 @@ set_high_bit(uint64_t* bits_array, size_t pos, size_t low_bits_size) {
 }
 
 void
-EliasFanoEncoder::set_low_bits(size_t index, InnerIdType value) {
+EliasFanoEncoder::set_low_bits(size_t index, InnerIdType value) const {
     if (low_bits_width_ == 0) {
         return;
     }
@@ -129,14 +129,12 @@ EliasFanoEncoder::Encode(const Vector<InnerIdType>& values, InnerIdType max_valu
     }
 }
 
-Vector<InnerIdType>
-EliasFanoEncoder::DecompressAll(Allocator* allocator) const {
-    Vector<InnerIdType> result(allocator);
-    result.reserve(num_elements_);
+void
+EliasFanoEncoder::DecompressAll(Vector<InnerIdType>& neighbors) const {
+    neighbors.resize(num_elements_);
 
     // Decompress all values at once
     size_t count = 0;
-
     for (size_t i = 0; i < high_bits_size_ && count < num_elements_; ++i) {
         uint64_t word = bits_[low_bits_size_ + i];
 
@@ -146,14 +144,12 @@ EliasFanoEncoder::DecompressAll(Allocator* allocator) const {
             // Found 1, calculate corresponding value
             InnerIdType high = (i * 64 + bit) - count;
             InnerIdType low = get_low_bits(count);
-            result.push_back((high << low_bits_width_) | low);
+            neighbors[count] = ((high << low_bits_width_) | low);
             count++;
             // Delete lowest 1
             word &= (word - 1);
         }
     }
-
-    return result;
 }
 
 }  // namespace vsag

--- a/src/impl/elias_fano_encoder.cpp
+++ b/src/impl/elias_fano_encoder.cpp
@@ -44,43 +44,44 @@ set_high_bit(uint64_t* bits_array, size_t pos, size_t low_bits_size) {
     bits_array[low_bits_size + (pos >> 6)] |= (1ULL << (pos & 63));
 }
 
+// requires "const" to pass lint check
 void
-EliasFanoEncoder::set_low_bits(size_t index, InnerIdType value) {
-    if (low_bits_width_ == 0) {
+EliasFanoEncoder::set_low_bits(size_t index, InnerIdType value) const {
+    if (low_bits_width == 0) {
         return;
     }
 
-    size_t bit_pos = index * low_bits_width_;
+    size_t bit_pos = index * low_bits_width;
     size_t word_pos = bit_pos >> 6;
     size_t shift = bit_pos & 63;
-    uint64_t mask = ((1ULL << low_bits_width_) - 1) << shift;
-    bits_[word_pos] = (bits_[word_pos] & ~mask) | ((uint64_t)value << shift);
+    uint64_t mask = ((1ULL << low_bits_width) - 1) << shift;
+    bits[word_pos] = (bits[word_pos] & ~mask) | ((uint64_t)value << shift);
 
     // Handle word boundary crossing
-    if (shift + low_bits_width_ > 64 && word_pos + 1 < low_bits_size_) {
-        size_t remaining_bits = shift + low_bits_width_ - 64;
+    if (shift + low_bits_width > 64 && word_pos + 1 < low_bits_size) {
+        size_t remaining_bits = shift + low_bits_width - 64;
         mask = (1ULL << remaining_bits) - 1;
-        bits_[word_pos + 1] =
-            (bits_[word_pos + 1] & ~mask) | (value >> (low_bits_width_ - remaining_bits));
+        bits[word_pos + 1] =
+            (bits[word_pos + 1] & ~mask) | (value >> (low_bits_width - remaining_bits));
     }
 }
 
 InnerIdType
 EliasFanoEncoder::get_low_bits(size_t index) const {
-    if (low_bits_width_ == 0) {
+    if (low_bits_width == 0) {
         return 0;
     }
 
-    size_t bit_pos = index * low_bits_width_;
+    size_t bit_pos = index * low_bits_width;
     size_t word_pos = bit_pos >> 6;
     size_t shift = bit_pos & 63;
-    InnerIdType value = (bits_[word_pos] >> shift) & ((1ULL << low_bits_width_) - 1);
+    InnerIdType value = (bits[word_pos] >> shift) & ((1ULL << low_bits_width) - 1);
 
     // Handle word boundary crossing
-    if (shift + low_bits_width_ > 64 && word_pos + 1 < low_bits_size_) {
-        size_t remaining_bits = shift + low_bits_width_ - 64;
-        value |= (bits_[word_pos + 1] & ((1ULL << remaining_bits) - 1))
-                 << (low_bits_width_ - remaining_bits);
+    if (shift + low_bits_width > 64 && word_pos + 1 < low_bits_size) {
+        size_t remaining_bits = shift + low_bits_width - 64;
+        value |= (bits[word_pos + 1] & ((1ULL << remaining_bits) - 1))
+                 << (low_bits_width - remaining_bits);
     }
     return value;
 }
@@ -94,7 +95,7 @@ EliasFanoEncoder::Encode(const Vector<InnerIdType>& values, InnerIdType max_valu
 
     // Check if number of elements exceeds uint8_t maximum
     if (values.size() <= UINT8_MAX) {
-        num_elements_ = static_cast<uint8_t>(values.size());
+        num_elements = static_cast<uint8_t>(values.size());
     } else {
         throw std::runtime_error("Error: Elias-Fano encoder, number of elements exceeds 255.");
     }
@@ -102,49 +103,49 @@ EliasFanoEncoder::Encode(const Vector<InnerIdType>& values, InnerIdType max_valu
     InnerIdType universe = max_value + 1;
 
     // Calculate low bits width
-    low_bits_width_ =
-        static_cast<uint32_t>(std::floor(std::log2(static_cast<double>(universe) / num_elements_)));
+    low_bits_width =
+        static_cast<uint32_t>(std::floor(std::log2(static_cast<double>(universe) / num_elements)));
 
     // Calculate the size of high bits
-    const size_t high_bits_count = (max_value >> low_bits_width_) + num_elements_ + 1;
-    high_bits_size_ = (high_bits_count + 63) / 64;
+    const size_t high_bits_count = (max_value >> low_bits_width) + num_elements + 1;
+    high_bits_size = (high_bits_count + 63) / 64;
 
     // Calculate the size of low bits
-    size_t total_low_bits = static_cast<size_t>(num_elements_) * low_bits_width_;
-    low_bits_size_ = std::max<size_t>(1, (total_low_bits + 63) / 64);
+    size_t total_low_bits = static_cast<size_t>(num_elements) * low_bits_width;
+    low_bits_size = std::max<size_t>(1, (total_low_bits + 63) / 64);
 
     // Allocate combined space for both low and high bits
-    bits_ = static_cast<uint64_t*>(
-        allocator_->Allocate((low_bits_size_ + high_bits_size_) * sizeof(uint64_t)));
-    std::fill(bits_, bits_ + low_bits_size_ + high_bits_size_, 0);
+    bits = static_cast<uint64_t*>(
+        allocator_->Allocate((low_bits_size + high_bits_size) * sizeof(uint64_t)));
+    std::fill(bits, bits + low_bits_size + high_bits_size, 0);
 
     // Encode each value
-    for (size_t i = 0; i < num_elements_; ++i) {
+    for (size_t i = 0; i < num_elements; ++i) {
         InnerIdType x = values[i];
-        InnerIdType high = x >> low_bits_width_;
-        InnerIdType low = x & ((1U << low_bits_width_) - 1);
+        InnerIdType high = x >> low_bits_width;
+        InnerIdType low = x & ((1U << low_bits_width) - 1);
 
-        set_high_bit(bits_, i + high, low_bits_size_);
+        set_high_bit(bits, i + high, low_bits_size);
         set_low_bits(i, low);
     }
 }
 
 void
 EliasFanoEncoder::DecompressAll(Vector<InnerIdType>& neighbors) const {
-    neighbors.resize(num_elements_);
+    neighbors.resize(num_elements);
 
     // Decompress all values at once
     size_t count = 0;
-    for (size_t i = 0; i < high_bits_size_ && count < num_elements_; ++i) {
-        uint64_t word = bits_[low_bits_size_ + i];
+    for (size_t i = 0; i < high_bits_size && count < num_elements; ++i) {
+        uint64_t word = bits[low_bits_size + i];
 
         // Use ctzll to find position of 1
-        while (word != 0U && count < num_elements_) {
+        while (word != 0U && count < num_elements) {
             size_t bit = ctzll(word);
             // Found 1, calculate corresponding value
             InnerIdType high = (i * 64 + bit) - count;
             InnerIdType low = get_low_bits(count);
-            neighbors[count] = ((high << low_bits_width_) | low);
+            neighbors[count] = ((high << low_bits_width) | low);
             count++;
             // Delete lowest 1
             word &= (word - 1);

--- a/src/impl/elias_fano_encoder.cpp
+++ b/src/impl/elias_fano_encoder.cpp
@@ -45,7 +45,7 @@ set_high_bit(uint64_t* bits_array, size_t pos, size_t low_bits_size) {
 }
 
 void
-EliasFanoEncoder::set_low_bits(size_t index, InnerIdType value) const {
+EliasFanoEncoder::set_low_bits(size_t index, InnerIdType value) {
     if (low_bits_width_ == 0) {
         return;
     }

--- a/src/impl/elias_fano_encoder.h
+++ b/src/impl/elias_fano_encoder.h
@@ -40,35 +40,37 @@ public:
 
     void
     Clear() {
-        if (bits_ != nullptr) {
-            allocator_->Deallocate(bits_);
-            bits_ = nullptr;
+        if (bits != nullptr) {
+            allocator_->Deallocate(bits);
+            bits = nullptr;
         }
-        num_elements_ = 0;
-        low_bits_width_ = 0;
-        low_bits_size_ = 0;
-        high_bits_size_ = 0;
+        num_elements = 0;
+        low_bits_width = 0;
+        low_bits_size = 0;
+        high_bits_size = 0;
     }
 
     [[nodiscard]] size_t
     SizeInBytes() const {
-        return sizeof(EliasFanoEncoder) + (low_bits_size_ + high_bits_size_) * sizeof(uint64_t);
+        return sizeof(EliasFanoEncoder) + (low_bits_size + high_bits_size) * sizeof(uint64_t);
     }
 
     [[nodiscard]] uint8_t
     Size() const {
-        return num_elements_;
+        return num_elements;
     }
 
-    uint64_t* bits_{nullptr};    // Combined storage for low bits and high bits
-    uint8_t num_elements_{0};    // Number of elements, max 255
-    uint8_t low_bits_width_{0};  // Width of low bits
-    uint8_t low_bits_size_{0};   // Size of low_bits_ array
-    uint8_t high_bits_size_{0};  // Size of high_bits_ array
+    uint64_t* bits{nullptr};    // Combined storage for low bits and high bits
+    uint8_t num_elements{0};    // Number of elements, max 255
+    uint8_t low_bits_width{0};  // Width of low bits
+    uint8_t low_bits_size{0};   // Size of low_bits_ array
+    uint8_t high_bits_size{0};  // Size of high_bits_ array
 
 private:
+    // requires "const" to pass lint check
+    // set_low_bits modifies the values pointed by ${bits}, but not the pointer itself
     void
-    set_low_bits(size_t index, InnerIdType value);
+    set_low_bits(size_t index, InnerIdType value) const;
 
     [[nodiscard]] InnerIdType
     get_low_bits(size_t index) const;

--- a/src/impl/elias_fano_encoder.h
+++ b/src/impl/elias_fano_encoder.h
@@ -68,7 +68,7 @@ public:
 
 private:
     void
-    set_low_bits(size_t index, InnerIdType value) const;
+    set_low_bits(size_t index, InnerIdType value);
 
     [[nodiscard]] InnerIdType
     get_low_bits(size_t index) const;

--- a/src/impl/elias_fano_encoder.h
+++ b/src/impl/elias_fano_encoder.h
@@ -35,8 +35,8 @@ public:
     Encode(const Vector<InnerIdType>& values, InnerIdType max_value);
 
     // Decompress all values
-    Vector<InnerIdType>
-    DecompressAll(Allocator* allocator) const;
+    void
+    DecompressAll(Vector<InnerIdType>& neighbors) const;
 
     void
     Clear() {
@@ -60,19 +60,20 @@ public:
         return num_elements_;
     }
 
-private:
-    void
-    set_low_bits(size_t index, InnerIdType value);
-
-    [[nodiscard]] InnerIdType
-    get_low_bits(size_t index) const;
-
-    Allocator* allocator_;
     uint64_t* bits_{nullptr};    // Combined storage for low bits and high bits
     uint8_t num_elements_{0};    // Number of elements, max 255
     uint8_t low_bits_width_{0};  // Width of low bits
     uint8_t low_bits_size_{0};   // Size of low_bits_ array
     uint8_t high_bits_size_{0};  // Size of high_bits_ array
+
+private:
+    void
+    set_low_bits(size_t index, InnerIdType value) const;
+
+    [[nodiscard]] InnerIdType
+    get_low_bits(size_t index) const;
+
+    Allocator* allocator_;
 };
 
 }  // namespace vsag

--- a/src/impl/elias_fano_encoder_test.cpp
+++ b/src/impl/elias_fano_encoder_test.cpp
@@ -48,7 +48,8 @@ TEST_CASE("EliasFanoEncoder, original seq equal to decoded seq", "[ut][EliasFano
         REQUIRE(encoder->Size() == values.size());
 
         // check if original seq equal to decoded seq
-        auto decompressed = encoder->DecompressAll(allocator.get());
+        Vector<InnerIdType> decompressed(allocator.get());
+        encoder->DecompressAll(decompressed);
         REQUIRE(decompressed.size() == values.size());
         for (size_t i = 0; i < values.size(); i++) {
             REQUIRE(decompressed[i] == values[i]);


### PR DESCRIPTION
closes #595

Summary of changes 

1. [src/data_cell/compressed_graph_datacell.h](https://github.com/antgroup/vsag/compare/compressed-graph-datacell?expand=1#diff-84e38497c138a587dab01fdea0a0e41ed31e6d70107bc131256228c34d7f8898) Graph datacell with Elias-Fano encoder that can compress the adjacency list
2. [src/data_cell/graph_storage_type.h](https://github.com/antgroup/vsag/compare/compressed-graph-datacell?expand=1#diff-a2cdbc67c7f7a0f27a79e9b4abe2ff6a632e9dbd39e4775ba762fa6208cf5e9e) Add GraphStorageTypes, can choose to use compressed graph, or sparse graph, or flat one
```c++
enum class GraphStorageTypes {
    GRAPH_STORAGE_TYPE_FLAT = 0,
    GRAPH_STORAGE_TYPE_COMPRESSED = 1
};
```
3. [src/data_cell/graph_interface_test.h](https://github.com/antgroup/vsag/compare/compressed-graph-datacell?expand=1#diff-50a6dfe6e272ecb62f1c889fb56df41e46e204f9206afdeb33886327b80ac1cc) Sort neighbor sets in BasicTest if needed, elias-fano encoder will sort neighbor sets
4. [src/impl/elias_fano_encoder.h](https://github.com/antgroup/vsag/compare/compressed-graph-datacell?expand=1#diff-26fc600650882b8b662c04fb563b9875a4fff4713a5fe20bb592e6eb462be9aa): Update elias-fano encoder
a. Data visibility change to public (to serialize CompressedGraphDatacell)
b. Change `DecompressAll` interface (to fit CompressedGraphDatacell)

```c++
from
    Vector<InnerIdType>
    DecompressAll(Allocator* allocator) const;
to
    void
    DecompressAll(Vector<InnerIdType>& neighbors) const;
``` 