### PR TITLE
add rabitq_use_rom parameter

### DIFF
--- a/include/vsag/constants.h
+++ b/include/vsag/constants.h
@@ -119,6 +119,7 @@ extern const char* const SERIALIZE_VERSION;
 
 extern const char* const SQ4_UNIFORM_TRUNC_RATE;
 extern const char* const RABITQ_PCA_DIM;
+extern const char* const RABITQ_USE_ROM;
 
 // hgraph params
 extern const char* const HGRAPH_USE_REORDER;

--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -998,6 +998,14 @@ static const ConstParamMap EXTERNAL_MAPPING = {
             PCA_DIM,
         },
     },
+    {
+        RABITQ_USE_ROM,
+        {
+            HGRAPH_BASE_CODES_KEY,
+            QUANTIZATION_PARAMS_KEY,
+            USE_ROM,
+        },
+    },
 };
 
 static const std::string HGRAPH_PARAMS_TEMPLATE =
@@ -1024,7 +1032,8 @@ static const std::string HGRAPH_PARAMS_TEMPLATE =
                 "{QUANTIZATION_TYPE_KEY}": "{QUANTIZATION_TYPE_VALUE_PQ}",
                 "{SQ4_UNIFORM_QUANTIZATION_TRUNC_RATE}": 0.05,
                 "{PCA_DIM}": 0,
-                "nbits": 8
+                "nbits": 8,
+                "{USE_ROM}": true
             }
         },
         "{HGRAPH_PRECISE_CODES_KEY}": {

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -123,6 +123,7 @@ const char* const SERIALIZE_VERSION = "VERSION";
 
 const char* const SQ4_UNIFORM_TRUNC_RATE = "sq4_uniform_trunc_rate";
 const char* const RABITQ_PCA_DIM = "rabitq_pca_dim";
+const char* const RABITQ_USE_ROM = "rabitq_use_rom";
 
 const char* const HGRAPH_USE_REORDER = HGRAPH_USE_REORDER_KEY;
 const char* const HGRAPH_IGNORE_REORDER = "ignore_reorder";

--- a/src/inner_string_params.h
+++ b/src/inner_string_params.h
@@ -58,6 +58,7 @@ const char* const QUANTIZATION_TYPE_VALUE_PQ = "pq";
 const char* const QUANTIZATION_TYPE_VALUE_RABITQ = "rabitq";
 
 const char* const PCA_DIM = "pca_dim";
+const char* const USE_ROM = "use_rom";
 const char* const SQ4_UNIFORM_QUANTIZATION_TRUNC_RATE = "sq4_uniform_trunc_rate";
 
 // graph param value

--- a/src/quantization/rabitq_quantization/rabitq_quantizer_parameter.cpp
+++ b/src/quantization/rabitq_quantization/rabitq_quantizer_parameter.cpp
@@ -28,6 +28,9 @@ RaBitQuantizerParameter::FromJson(const JsonType& json) {
     if (json.contains(PCA_DIM)) {
         this->pca_dim_ = json[PCA_DIM];
     }
+    if (json.contains(USE_ROM)) {
+        this->use_rom_ = json[USE_ROM];
+    }
 }
 
 JsonType
@@ -35,6 +38,7 @@ RaBitQuantizerParameter::ToJson() {
     JsonType json;
     json[QUANTIZATION_TYPE_KEY] = QUANTIZATION_TYPE_VALUE_RABITQ;
     json[PCA_DIM] = this->pca_dim_;
+    json[USE_ROM] = this->use_rom_;
     return json;
 }
 }  // namespace vsag

--- a/src/quantization/rabitq_quantization/rabitq_quantizer_parameter.h
+++ b/src/quantization/rabitq_quantization/rabitq_quantizer_parameter.h
@@ -32,6 +32,7 @@ public:
 
 public:
     uint64_t pca_dim_{0};
+    bool use_rom_{true};
 };
 
 using RaBitQuantizerParamPtr = std::shared_ptr<RaBitQuantizerParameter>;

--- a/src/quantization/rabitq_quantization/rabitq_quantizer_test.cpp
+++ b/src/quantization/rabitq_quantization/rabitq_quantizer_test.cpp
@@ -29,6 +29,7 @@ const auto dims = fixtures::get_common_used_dims();
 const auto counts = {10, 100};
 
 TEST_CASE("RaBitQ Basic Test", "[ut][RaBitQuantizer]") {
+    bool use_rom = true;
     for (auto dim : dims) {
         uint64_t pca_dim = dim;
         if (dim >= 1500) {
@@ -37,7 +38,8 @@ TEST_CASE("RaBitQ Basic Test", "[ut][RaBitQuantizer]") {
         for (auto count : counts) {
             auto allocator = SafeAllocator::FactoryDefaultAllocator();
             auto vecs = fixtures::generate_vectors(count, dim);
-            RaBitQuantizer<MetricType::METRIC_TYPE_L2SQR> quantizer(dim, pca_dim, allocator.get());
+            RaBitQuantizer<MetricType::METRIC_TYPE_L2SQR> quantizer(
+                dim, pca_dim, use_rom, allocator.get());
 
             // name
             REQUIRE(quantizer.NameImpl() == QUANTIZATION_TYPE_VALUE_RABITQ);
@@ -51,10 +53,12 @@ TEST_CASE("RaBitQ Basic Test", "[ut][RaBitQuantizer]") {
 }
 
 TEST_CASE("RaBitQ Encode and Decode", "[ut][RaBitQuantizer]") {
+    bool use_rom = true;
     for (auto dim : dims) {
         for (auto count : counts) {
             auto allocator = SafeAllocator::FactoryDefaultAllocator();
-            RaBitQuantizer<MetricType::METRIC_TYPE_L2SQR> quantizer(dim, dim, allocator.get());
+            RaBitQuantizer<MetricType::METRIC_TYPE_L2SQR> quantizer(
+                dim, dim, use_rom, allocator.get());
 
             TestEncodeDecodeRaBitQ<RaBitQuantizer<MetricType::METRIC_TYPE_L2SQR>>(
                 quantizer, dim, count);
@@ -63,6 +67,7 @@ TEST_CASE("RaBitQ Encode and Decode", "[ut][RaBitQuantizer]") {
 }
 
 TEST_CASE("RaBitQ Compute", "[ut][RaBitQuantizer]") {
+    bool use_rom = true;
     for (auto dim : dims) {
         float numeric_error = 0.01 / std::sqrt(dim) * dim;
         float related_error = 0.05f;
@@ -73,7 +78,8 @@ TEST_CASE("RaBitQ Compute", "[ut][RaBitQuantizer]") {
         }
         for (auto count : counts) {
             auto allocator = SafeAllocator::FactoryDefaultAllocator();
-            RaBitQuantizer<MetricType::METRIC_TYPE_L2SQR> quantizer(dim, dim, allocator.get());
+            RaBitQuantizer<MetricType::METRIC_TYPE_L2SQR> quantizer(
+                dim, dim, use_rom, allocator.get());
 
             TestComputer<RaBitQuantizer<MetricType::METRIC_TYPE_L2SQR>,
                          MetricType::METRIC_TYPE_L2SQR>(quantizer,
@@ -92,6 +98,7 @@ TEST_CASE("RaBitQ Compute", "[ut][RaBitQuantizer]") {
 }
 
 TEST_CASE("RaBitQ Serialize and Deserialize", "[ut][RaBitQuantizer]") {
+    bool use_rom = true;
     for (auto dim : dims) {
         float numeric_error = 0.01 / std::sqrt(dim) * dim;
         float related_error = 0.05f;
@@ -102,8 +109,10 @@ TEST_CASE("RaBitQ Serialize and Deserialize", "[ut][RaBitQuantizer]") {
         }
         for (auto count : counts) {
             auto allocator = SafeAllocator::FactoryDefaultAllocator();
-            RaBitQuantizer<MetricType::METRIC_TYPE_L2SQR> quantizer1(dim, dim, allocator.get());
-            RaBitQuantizer<MetricType::METRIC_TYPE_L2SQR> quantizer2(dim, dim, allocator.get());
+            RaBitQuantizer<MetricType::METRIC_TYPE_L2SQR> quantizer1(
+                dim, dim, use_rom, allocator.get());
+            RaBitQuantizer<MetricType::METRIC_TYPE_L2SQR> quantizer2(
+                dim, dim, use_rom, allocator.get());
 
             TestSerializeAndDeserialize<RaBitQuantizer<MetricType::METRIC_TYPE_L2SQR>,
                                         MetricType::METRIC_TYPE_L2SQR>(quantizer1,


### PR DESCRIPTION
https://github.com/antgroup/vsag/issues/686
add rabitq_use_rom parameter to disable random orthogonal matrix 