### PR TITLE
add rabitq_use_rom parameter

### DIFF
--- a/include/vsag/constants.h
+++ b/include/vsag/constants.h
@@ -121,6 +121,7 @@ extern const char* const SERIALIZE_VERSION;
 extern const char* const SQ4_UNIFORM_TRUNC_RATE;
 extern const char* const RABITQ_PCA_DIM;
 extern const char* const RABITQ_BITS_PER_DIM_QUERY;
+extern const char* const RABITQ_USE_ROM;
 
 // hgraph params
 extern const char* const HGRAPH_USE_REORDER;

--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -996,6 +996,14 @@ static const ConstParamMap EXTERNAL_MAPPING = {
             HGRAPH_BASE_CODES_KEY,
             QUANTIZATION_PARAMS_KEY,
             PRODUCT_QUANTIZATION_DIM,
+        }
+    },
+    {
+        RABITQ_USE_ROM,
+        {
+            HGRAPH_BASE_CODES_KEY,
+            QUANTIZATION_PARAMS_KEY,
+            USE_ROM,
         },
     },
 };
@@ -1026,7 +1034,8 @@ static const std::string HGRAPH_PARAMS_TEMPLATE =
                 "{PCA_DIM}": 0,
                 "{RABITQ_QUANTIZATION_BITS_PER_DIM_QUERY}": 32,
                 "nbits": 8,
-                "{PRODUCT_QUANTIZATION_DIM}": 0
+                "{PRODUCT_QUANTIZATION_DIM}": 0,
+                "{USE_ROM}": true
             }
         },
         "{HGRAPH_PRECISE_CODES_KEY}": {
@@ -1039,7 +1048,8 @@ static const std::string HGRAPH_PARAMS_TEMPLATE =
                 "{QUANTIZATION_TYPE_KEY}": "{QUANTIZATION_TYPE_VALUE_FP32}",
                 "{SQ4_UNIFORM_QUANTIZATION_TRUNC_RATE}": 0.05,
                 "{PCA_DIM}": 0,
-                "{PRODUCT_QUANTIZATION_DIM}": 0
+                "{PRODUCT_QUANTIZATION_DIM}": 0,
+                "{USE_ROM}": true
             }
         },
         "{BUILD_PARAMS_KEY}": {

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -125,6 +125,7 @@ const char* const SERIALIZE_VERSION = "VERSION";
 const char* const SQ4_UNIFORM_TRUNC_RATE = "sq4_uniform_trunc_rate";
 const char* const RABITQ_PCA_DIM = "rabitq_pca_dim";
 const char* const RABITQ_BITS_PER_DIM_QUERY = "rabitq_bits_per_dim_query";
+const char* const RABITQ_USE_ROM = "rabitq_use_rom";
 
 const char* const HGRAPH_USE_REORDER = HGRAPH_USE_REORDER_KEY;
 const char* const HGRAPH_IGNORE_REORDER = "ignore_reorder";

--- a/src/inner_string_params.h
+++ b/src/inner_string_params.h
@@ -61,6 +61,7 @@ const char* const QUANTIZATION_TYPE_VALUE_SPARSE = "sparse";
 // quantization param
 const char* const PCA_DIM = "pca_dim";
 const char* const RABITQ_QUANTIZATION_BITS_PER_DIM_QUERY = "rabitq_bits_per_dim_query";
+const char* const USE_ROM = "use_rom";
 const char* const SQ4_UNIFORM_QUANTIZATION_TRUNC_RATE = "sq4_uniform_trunc_rate";
 const char* const PRODUCT_QUANTIZATION_DIM = "pq_dim";
 const char* const PRODUCT_QUANTIZATION_BITS = "pq_bits";

--- a/src/quantization/rabitq_quantization/rabitq_quantizer.h
+++ b/src/quantization/rabitq_quantization/rabitq_quantizer.h
@@ -51,6 +51,7 @@ public:
     explicit RaBitQuantizer(int dim,
                             uint64_t pca_dim,
                             uint64_t num_bits_per_dim_query,
+                            bool use_rom,
                             Allocator* allocator);
 
     explicit RaBitQuantizer(const RaBitQuantizerParamPtr& param,
@@ -164,13 +165,13 @@ private:
     uint64_t offset_norm_{0};
     uint64_t offset_error_{0};
     uint64_t offset_sum_{0};
+
+    bool use_rom_{true};
 };
 
 template <MetricType metric>
-RaBitQuantizer<metric>::RaBitQuantizer(int dim,
-                                       uint64_t pca_dim,
-                                       uint64_t num_bits_per_dim_query,
-                                       Allocator* allocator)
+RaBitQuantizer<metric>::RaBitQuantizer(
+    int dim, uint64_t pca_dim, uint64_t num_bits_per_dim_query, bool use_rom, Allocator* allocator)
     : Quantizer<RaBitQuantizer<metric>>(dim, allocator) {
     static_assert(metric == MetricType::METRIC_TYPE_L2SQR, "Unsupported metric type");
 
@@ -191,6 +192,8 @@ RaBitQuantizer<metric>::RaBitQuantizer(int dim,
     centroid_.resize(this->dim_, 0);
 
     // random orthogonal matrix
+    use_rom_ = use_rom;
+    // NOTICE: always init rom
     rom_.reset(new RandomOrthogonalMatrix(this->dim_, allocator));
 
     // distance function related variable
@@ -248,6 +251,7 @@ RaBitQuantizer<metric>::RaBitQuantizer(const RaBitQuantizerParamPtr& param,
     : RaBitQuantizer<metric>(common_param.dim_,
                              param->pca_dim_,
                              param->num_bits_per_dim_query_,
+                             param->use_rom_,
                              common_param.allocator_.get()){};
 
 template <MetricType metric>
@@ -296,29 +300,30 @@ RaBitQuantizer<metric>::TrainImpl(const DataType* data, uint64_t count) {
     }
 
     // generate rom
-    rom_->GenerateRandomOrthogonalMatrixWithRetry();
+    if (use_rom_) {
+        rom_->GenerateRandomOrthogonalMatrixWithRetry();
 
-    // validate rom
-    int retries = MAX_RETRIES;
-    bool successful_gen = true;
-    double det = rom_->ComputeDeterminant();
-    if (std::fabs(det - 1) > 1e-4) {
-        for (uint64_t i = 0; i < retries; i++) {
-            successful_gen = rom_->GenerateRandomOrthogonalMatrix();
-            if (successful_gen) {
-                break;
+        // validate rom
+        int retries = MAX_RETRIES;
+        bool successful_gen = true;
+        double det = rom_->ComputeDeterminant();
+        if (std::fabs(det - 1) > 1e-4) {
+            for (uint64_t i = 0; i < retries; i++) {
+                successful_gen = rom_->GenerateRandomOrthogonalMatrix();
+                if (successful_gen) {
+                    break;
+                }
             }
         }
-    }
-    if (not successful_gen) {
-        return false;
-    }
+        if (not successful_gen) {
+            return false;
+        }
 
-    // transform centroid
-    Vector<DataType> rp_centroids(this->dim_, 0, this->allocator_);
-    rom_->Transform(centroid_.data(), rp_centroids.data());
-    centroid_.assign(rp_centroids.begin(), rp_centroids.end());
-
+        // transform centroid
+        Vector<DataType> rp_centroids(this->dim_, 0, this->allocator_);
+        rom_->Transform(centroid_.data(), rp_centroids.data());
+        centroid_.assign(rp_centroids.begin(), rp_centroids.end());
+    }
     this->is_trained_ = true;
     return true;
 }
@@ -339,7 +344,11 @@ RaBitQuantizer<metric>::EncodeOneImpl(const DataType* data, uint8_t* codes) cons
     }
 
     // 2. random projection
-    rom_->Transform(pca_data.data(), transformed_data.data());
+    if (use_rom_) {
+        rom_->Transform(pca_data.data(), transformed_data.data());
+    } else {
+        transformed_data.assign(pca_data.begin(), pca_data.end());
+    }
 
     // 3. normalize
     norm_type norm = NormalizeWithCentroid(
@@ -406,7 +415,13 @@ RaBitQuantizer<metric>::DecodeOneImpl(const uint8_t* codes, DataType* data) {
 
     // 4. inverse random projection
     // Note that the value may be much different between original since inv_sqrt_d is small
-    rom_->InverseTransform(transformed_data.data(), data);
+    if (use_rom_) {
+        rom_->InverseTransform(transformed_data.data(), data);
+    } else {
+        for (uint64_t d = 0; d < this->dim_; ++d) {
+            data[d] = transformed_data[d];
+        }
+    }
     return true;
 }
 
@@ -536,7 +551,11 @@ RaBitQuantizer<metric>::ProcessQueryImpl(const DataType* query,
         }
 
         // 2. random projection
-        rom_->Transform(pca_data.data(), transformed_data.data());
+        if (use_rom_) {
+            rom_->Transform(pca_data.data(), transformed_data.data());
+        } else {
+            transformed_data.assign(pca_data.begin(), pca_data.end());
+        }
 
         // 3. norm
         float query_norm = NormalizeWithCentroid(
@@ -609,6 +628,7 @@ RaBitQuantizer<metric>::SerializeImpl(StreamWriter& writer) {
     if (pca_dim_ != this->original_dim_) {
         this->pca_->Serialize(writer);
     }
+    StreamWriter::WriteObj(writer, this->use_rom_);
 }
 
 template <MetricType metric>
@@ -619,6 +639,7 @@ RaBitQuantizer<metric>::DeserializeImpl(StreamReader& reader) {
     if (pca_dim_ != this->original_dim_) {
         this->pca_->Deserialize(reader);
     }
+    StreamReader::ReadObj(reader, this->use_rom_);
 }
 
 }  // namespace vsag

--- a/src/quantization/rabitq_quantization/rabitq_quantizer_parameter.cpp
+++ b/src/quantization/rabitq_quantization/rabitq_quantizer_parameter.cpp
@@ -31,6 +31,9 @@ RaBitQuantizerParameter::FromJson(const JsonType& json) {
     if (json.contains(RABITQ_QUANTIZATION_BITS_PER_DIM_QUERY)) {
         this->num_bits_per_dim_query_ = json[RABITQ_QUANTIZATION_BITS_PER_DIM_QUERY];
     }
+    if (json.contains(USE_ROM)) {
+        this->use_rom_ = json[USE_ROM];
+    }
 }
 
 JsonType
@@ -39,6 +42,7 @@ RaBitQuantizerParameter::ToJson() {
     json[QUANTIZATION_TYPE_KEY] = QUANTIZATION_TYPE_VALUE_RABITQ;
     json[PCA_DIM] = this->pca_dim_;
     json[RABITQ_QUANTIZATION_BITS_PER_DIM_QUERY] = this->num_bits_per_dim_query_;
+    json[USE_ROM] = this->use_rom_;
     return json;
 }
 }  // namespace vsag

--- a/src/quantization/rabitq_quantization/rabitq_quantizer_parameter.h
+++ b/src/quantization/rabitq_quantization/rabitq_quantizer_parameter.h
@@ -33,6 +33,7 @@ public:
 public:
     uint64_t pca_dim_{0};
     uint64_t num_bits_per_dim_query_{32};
+    bool use_rom_{true};
 };
 
 using RaBitQuantizerParamPtr = std::shared_ptr<RaBitQuantizerParameter>;

--- a/src/quantization/rabitq_quantization/rabitq_quantizer_test.cpp
+++ b/src/quantization/rabitq_quantization/rabitq_quantizer_test.cpp
@@ -32,6 +32,7 @@ const auto counts = {10, 100};
 
 TEST_CASE("RaBitQ Basic Test", "[ut][RaBitQuantizer]") {
     auto num_bits_per_dim = GENERATE(4, 32);
+    bool use_rom = true;
     for (auto dim : dims) {
         uint64_t pca_dim = dim;
         if (dim >= 1500) {
@@ -41,7 +42,7 @@ TEST_CASE("RaBitQ Basic Test", "[ut][RaBitQuantizer]") {
             auto allocator = SafeAllocator::FactoryDefaultAllocator();
             auto vecs = fixtures::generate_vectors(count, dim);
             RaBitQuantizer<MetricType::METRIC_TYPE_L2SQR> quantizer(
-                dim, pca_dim, num_bits_per_dim, allocator.get());
+                dim, pca_dim, num_bits_per_dim, use_rom, allocator.get());
 
             // name
             REQUIRE(quantizer.NameImpl() == QUANTIZATION_TYPE_VALUE_RABITQ);
@@ -56,11 +57,12 @@ TEST_CASE("RaBitQ Basic Test", "[ut][RaBitQuantizer]") {
 
 TEST_CASE("RaBitQ Encode and Decode", "[ut][RaBitQuantizer]") {
     auto num_bits_per_dim = GENERATE(4, 32);
+    bool use_rom = true;
     for (auto dim : dims) {
         for (auto count : counts) {
             auto allocator = SafeAllocator::FactoryDefaultAllocator();
             RaBitQuantizer<MetricType::METRIC_TYPE_L2SQR> quantizer(
-                dim, dim, num_bits_per_dim, allocator.get());
+                dim, dim, num_bits_per_dim, use_rom, allocator.get());
 
             TestEncodeDecodeRaBitQ<RaBitQuantizer<MetricType::METRIC_TYPE_L2SQR>>(
                 quantizer, dim, count);
@@ -70,6 +72,7 @@ TEST_CASE("RaBitQ Encode and Decode", "[ut][RaBitQuantizer]") {
 
 TEST_CASE("RaBitQ Compute", "[ut][RaBitQuantizer]") {
     auto num_bits_per_dim = GENERATE(4, 32);
+    bool use_rom = true;
     for (auto dim : dims) {
         float numeric_error = 0.01 / std::sqrt(dim) * dim;
         float related_error = 0.05f;
@@ -84,7 +87,7 @@ TEST_CASE("RaBitQ Compute", "[ut][RaBitQuantizer]") {
         for (auto count : counts) {
             auto allocator = SafeAllocator::FactoryDefaultAllocator();
             RaBitQuantizer<MetricType::METRIC_TYPE_L2SQR> quantizer(
-                dim, dim, num_bits_per_dim, allocator.get());
+                dim, dim, num_bits_per_dim, use_rom, allocator.get());
 
             TestComputer<RaBitQuantizer<MetricType::METRIC_TYPE_L2SQR>,
                          MetricType::METRIC_TYPE_L2SQR>(quantizer,
@@ -104,6 +107,7 @@ TEST_CASE("RaBitQ Compute", "[ut][RaBitQuantizer]") {
 
 TEST_CASE("RaBitQ Serialize and Deserialize", "[ut][RaBitQuantizer]") {
     auto num_bits_per_dim = GENERATE(4, 32);
+    bool use_rom = true;
     for (auto dim : dims) {
         float numeric_error = 0.01 / std::sqrt(dim) * dim;
         float related_error = 0.05f;
@@ -118,9 +122,9 @@ TEST_CASE("RaBitQ Serialize and Deserialize", "[ut][RaBitQuantizer]") {
         for (auto count : counts) {
             auto allocator = SafeAllocator::FactoryDefaultAllocator();
             RaBitQuantizer<MetricType::METRIC_TYPE_L2SQR> quantizer1(
-                dim, dim, num_bits_per_dim, allocator.get());
+                dim, dim, num_bits_per_dim, use_rom, allocator.get());
             RaBitQuantizer<MetricType::METRIC_TYPE_L2SQR> quantizer2(
-                dim, dim, num_bits_per_dim, allocator.get());
+                dim, dim, num_bits_per_dim, use_rom, allocator.get());
 
             TestSerializeAndDeserialize<RaBitQuantizer<MetricType::METRIC_TYPE_L2SQR>,
                                         MetricType::METRIC_TYPE_L2SQR>(quantizer1,
@@ -139,10 +143,11 @@ TEST_CASE("RaBitQ Serialize and Deserialize", "[ut][RaBitQuantizer]") {
 TEST_CASE("RaBitQ Query SQ4 Transform", "[ut][RaBitQuantizer]") {
     int dim = 5;
     uint64_t num_bits_per_dim_query = 4;
+    bool use_rom = true;
     auto allocator = SafeAllocator::FactoryDefaultAllocator();
 
     RaBitQuantizer<MetricType::METRIC_TYPE_L2SQR> quantizer(
-        dim, dim, num_bits_per_dim_query, allocator.get());
+        dim, dim, num_bits_per_dim_query, use_rom, allocator.get());
 
     std::vector<float> original_data = {1, 2, 4, 8, 15, 0};
     // input  [0010 0001, 1000 0100, 0000 1111]


### PR DESCRIPTION
https://github.com/antgroup/vsag/issues/686
add rabitq_use_rom parameter to disable random orthogonal matrix