### PR TITLE
disable simd instructions in diskann

### DIFF
--- a/extern/diskann/DiskANN/include/simd_utils.h
+++ b/extern/diskann/DiskANN/include/simd_utils.h
@@ -16,7 +16,7 @@
 namespace diskann
 {
 
-#if defined(__i386__) || defined(__x86_64__)
+#if defined ENABLE_AVX && (defined(__i386__) || defined(__x86_64__))
 static inline __m256 _mm256_mul_epi8(__m256i X)
 {
     __m256i zero = _mm256_setzero_si256();

--- a/extern/diskann/DiskANN/src/distance.cpp
+++ b/extern/diskann/DiskANN/src/distance.cpp
@@ -10,7 +10,7 @@
 
 #else
 
-#if defined(__i386__) || defined(__x86_64__)
+#if defined ENABLE_AVX && (defined(__i386__) || defined(__x86_64__))
 #include <immintrin.h>
 #elif defined(__ARM_FEATURE_SIMD32) || defined(__ARM_NEON)
 #include <arm_neon.h>
@@ -536,7 +536,7 @@ template <typename T> float DistanceFastL2<T>::norm(const T *a, uint32_t size) c
     return result;
 }
 
-#if defined(__i386__) || defined(__x86_64__)
+#if defined ENABLE_AVX && (defined(__i386__) || defined(__x86_64__))
 float AVXDistanceInnerProductFloat::compare(const float *a, const float *b, uint32_t size) const
 {
     float result = 0.0f;

--- a/extern/diskann/DiskANN/src/index.cpp
+++ b/extern/diskann/DiskANN/src/index.cpp
@@ -3742,7 +3742,7 @@ void Index<T, TagT, LabelT>::search_with_optimized_layout(const T *query, size_t
         if (id >= _nd)
             continue;
     // FIXME: alternative instruction on aarch64
-#if defined(__i386__) || defined(__x86_64__)
+#if defined ENABLE_AVX && (defined(__i386__) || defined(__x86_64__))
         _mm_prefetch(_opt_graph + _node_size * id, _MM_HINT_T0);
 #endif
     }
@@ -3766,7 +3766,7 @@ void Index<T, TagT, LabelT>::search_with_optimized_layout(const T *query, size_t
         auto nbr = retset.closest_unexpanded();
         auto n = nbr.id;
     // FIXME: alternative instruction on aarch64
-#if defined(__i386__) || defined(__x86_64__)
+#if defined ENABLE_AVX && (defined(__i386__) || defined(__x86_64__))
         _mm_prefetch(_opt_graph + _node_size * n + _data_len, _MM_HINT_T0);
 #endif
         neighbors = (uint32_t *)(_opt_graph + _node_size * n + _data_len);
@@ -3774,7 +3774,7 @@ void Index<T, TagT, LabelT>::search_with_optimized_layout(const T *query, size_t
         neighbors++;
         for (uint32_t m = 0; m < MaxM; ++m)
     // FIXME: alternative instruction on aarch64
-#if defined(__i386__) || defined(__x86_64__)
+#if defined ENABLE_AVX && (defined(__i386__) || defined(__x86_64__))
             _mm_prefetch(_opt_graph + _node_size * neighbors[m], _MM_HINT_T0);
 #endif
         for (uint32_t m = 0; m < MaxM; ++m)

--- a/extern/diskann/DiskANN/src/pq.cpp
+++ b/extern/diskann/DiskANN/src/pq.cpp
@@ -385,7 +385,7 @@ void pq_dist_lookup(const uint8_t *pq_ids, const size_t n_pts, const size_t pq_n
 {
     //_mm_prefetch((char*) dists_out, _MM_HINT_T0);
     // FIXME: alternative instruction on aarch64
-#if defined(__i386__) || defined(__x86_64__)
+#if defined ENABLE_AVX && (defined(__i386__) || defined(__x86_64__))
     _mm_prefetch((char *)pq_ids, _MM_HINT_T0);
     _mm_prefetch((char *)(pq_ids + 64), _MM_HINT_T0);
     _mm_prefetch((char *)(pq_ids + 128), _MM_HINT_T0);
@@ -398,7 +398,7 @@ void pq_dist_lookup(const uint8_t *pq_ids, const size_t n_pts, const size_t pq_n
         if (chunk < pq_nchunks - 1)
         {
 	    // FIXME: alternative instruction on aarch64
-#if defined(__i386__) || defined(__x86_64__)
+#if defined ENABLE_AVX && (defined(__i386__) || defined(__x86_64__))
             _mm_prefetch((char *)(chunk_dists + 256), _MM_HINT_T0);
 #endif
         }
@@ -425,7 +425,7 @@ void pq_dist_lookup(const uint8_t *pq_ids, const size_t n_pts, const size_t pq_n
                     float *dists_out)
 {
     // FIXME: alternative instruction on aarch64
-#if defined(__i386__) || defined(__x86_64__)
+#if defined ENABLE_AVX && (defined(__i386__) || defined(__x86_64__))
     _mm_prefetch((char *)dists_out, _MM_HINT_T0);
     _mm_prefetch((char *)pq_ids, _MM_HINT_T0);
     _mm_prefetch((char *)(pq_ids + 64), _MM_HINT_T0);
@@ -438,7 +438,7 @@ void pq_dist_lookup(const uint8_t *pq_ids, const size_t n_pts, const size_t pq_n
         if (chunk < pq_nchunks - 1)
         {
 	    // FIXME: alternative instruction on aarch64
-#if defined(__i386__) || defined(__x86_64__)
+#if defined ENABLE_AVX && (defined(__i386__) || defined(__x86_64__))
             _mm_prefetch((char *)(chunk_dists + 256), _MM_HINT_T0);
 #endif
         }

--- a/extern/diskann/DiskANN/src/pq_flash_index.cpp
+++ b/extern/diskann/DiskANN/src/pq_flash_index.cpp
@@ -1467,7 +1467,7 @@ int64_t PQFlashIndex<T, LabelT>::cached_beam_search(const T *query1, const uint6
     }
 
     // FIXME: alternative instruction on aarch64
-#if defined(__i386__) || defined(__x86_64__)
+#if defined ENABLE_AVX && (defined(__i386__) || defined(__x86_64__))
     _mm_prefetch((char *)aligned_query_T.get(), _MM_HINT_T1);
 #endif
 
@@ -1771,7 +1771,7 @@ int64_t PQFlashIndex<T, LabelT>::cached_beam_search_memory(const T *query, const
     }
 
     // FIXME: alternative instruction on aarch64
-#if defined(__i386__) || defined(__x86_64__)
+#if defined ENABLE_AVX && (defined(__i386__) || defined(__x86_64__))
     _mm_prefetch((char *)aligned_query_T.get(), _MM_HINT_T1);
 #endif
 
@@ -1982,7 +1982,7 @@ int64_t PQFlashIndex<T, LabelT>::cached_beam_search_async(const T *query, const 
     }
 
     // FIXME: alternative instruction on aarch64
-#if defined(__i386__) || defined(__x86_64__)
+#if defined ENABLE_AVX && (defined(__i386__) || defined(__x86_64__))
     _mm_prefetch((char *)aligned_query_T.get(), _MM_HINT_T1);
 #endif
 

--- a/extern/diskann/diskann.cmake
+++ b/extern/diskann/diskann.cmake
@@ -35,12 +35,7 @@ set(DISKANN_SOURCES
 #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mavx2 -mfma -msse2 -ftree-vectorize -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free -fopenmp -fopenmp-simd -funroll-loops -Wfatal-errors -DUSE_AVX2")
 
 add_library(diskann STATIC ${DISKANN_SOURCES})
-# work
-if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86_64")
-  target_compile_options(diskann PRIVATE -mavx -msse2 -ftree-vectorize -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free -fopenmp -fopenmp-simd -funroll-loops -Wfatal-errors -DENABLE_CUSTOM_LOGGER=1)
-else ()
-  target_compile_options(diskann PRIVATE -ftree-vectorize -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free -fopenmp -fopenmp-simd -funroll-loops -Wfatal-errors -DENABLE_CUSTOM_LOGGER=1)
-endif ()
+target_compile_options(diskann PRIVATE -ftree-vectorize -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free -fopenmp -fopenmp-simd -funroll-loops -Wfatal-errors -DENABLE_CUSTOM_LOGGER=1)
 set_property(TARGET diskann PROPERTY CXX_STANDARD 17)
 add_dependencies(diskann boost openblas)
 


### PR DESCRIPTION
fixes: #696

SIMD instructions (avx,sse, ..), in diskann, are not used by vsag now, so we can disable these codes to avoid `illegal instructions` happened on some old platforms.