### PR TITLE
[skip ci]update output path in perf yaml

### DIFF
--- a/.github/perf-90.yml
+++ b/.github/perf-90.yml
@@ -5,7 +5,7 @@ global:
             to: "stdout"
         e2:
             format: "json"
-            to: "/tmp/perf-90.json"
+            to: "file://tmp/perf-90.json"
     num_threads_building: 16
     num_threads_searching: 16
 

--- a/.github/perf-95.yml
+++ b/.github/perf-95.yml
@@ -5,7 +5,7 @@ global:
             to: "stdout"
         e2:
             format: "json"
-            to: "/tmp/perf-95.json"
+            to: "file://tmp/perf-95.json"
     num_threads_building: 16
     num_threads_searching: 16
 

--- a/.github/perf-99.yml
+++ b/.github/perf-99.yml
@@ -5,7 +5,7 @@ global:
             to: "stdout"
         e2:
             format: "json"
-            to: "/tmp/perf-99.json"
+            to: "file://tmp/perf-99.json"
     num_threads_building: 16
     num_threads_searching: 16
 

--- a/.github/perf-mini.yml
+++ b/.github/perf-mini.yml
@@ -8,7 +8,7 @@ global:
       to: "stdout"
     e2:
       format: "json"
-      to: "/tmp/github-perf.json"
+      to: "file://tmp/github-perf.json"
 
 SIFT:
     datapath: "/tmp/data/sift-128-euclidean.hdf5"


### PR DESCRIPTION
ref: https://github.com/antgroup/vsag/blob/main/tools/eval/eval_template.yaml

```yaml
# eval_template.yml
global:
    exporters:
      print-directly:
        format: "table"
        to: "stdout"
      save-to-file:
        format: "json"
        to: "file://tmp/eval_example_output.json"
...
```
