### PR TITLE
print memory usage detail in eval_performance for HGraph

### DIFF
--- a/include/vsag/index.h
+++ b/include/vsag/index.h
@@ -15,13 +15,12 @@
 
 #pragma once
 
-#include "typing.h"
-
 #include <cstdint>
 #include <limits>
 #include <stdexcept>
 
 #include "bitset.h"
+#include "typing.h"
 #include "vsag/binaryset.h"
 #include "vsag/dataset.h"
 #include "vsag/errors.h"

--- a/include/vsag/index.h
+++ b/include/vsag/index.h
@@ -15,16 +15,14 @@
 
 #pragma once
 
-#include <cstddef>
+#include "typing.h"
+
 #include <cstdint>
 #include <limits>
-#include <queue>
 #include <stdexcept>
 
 #include "bitset.h"
-#include "features.h"
 #include "vsag/binaryset.h"
-#include "vsag/bitset.h"
 #include "vsag/dataset.h"
 #include "vsag/errors.h"
 #include "vsag/expected.hpp"
@@ -515,6 +513,19 @@ public:
       */
     [[nodiscard]] virtual int64_t
     GetMemoryUsage() const = 0;
+
+    /**
+  * @brief Return the memory usage of every component in the index
+  *
+  * @return a json object that contains the memory usage of every component in the index
+  */
+    // TODO(deming): implement func for every types of index
+    // [[nodiscard]] virtual JsonType
+    // GetMemoryUsageDetail() const = 0;
+    [[nodiscard]] virtual JsonType
+    GetMemoryUsageDetail() const {
+        throw std::runtime_error("Index not support GetMemoryUsageDetail");
+    }
 
     /**
       * @brief estimate the memory used by the index with given element counts

--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -677,6 +677,29 @@ HGraph::Deserialize(StreamReader& reader) {
     }
 }
 
+JsonType
+HGraph::GetMemoryUsageDetail() const {
+    JsonType memory_usage;
+    if (this->ignore_reorder_) {
+        this->use_reorder_ = false;
+    }
+    memory_usage["basic_flatten_codes"] = this->basic_flatten_codes_->CalcSerializeSize();
+    memory_usage["bottom_graph"] = this->bottom_graph_->CalcSerializeSize();
+    if (this->use_reorder_) {
+        memory_usage["high_precise_codes"] = this->high_precise_codes_->CalcSerializeSize();
+    }
+    size_t route_graph_size = 0;
+    for (const auto& route_graph : this->route_graphs_) {
+        route_graph_size += route_graph->CalcSerializeSize();
+    }
+    memory_usage["route_graph"] = route_graph_size;
+    if (this->extra_info_size_ > 0 && this->extra_infos_ != nullptr) {
+        memory_usage["extra_infos"] = this->extra_infos_->CalcSerializeSize();
+    }
+    memory_usage["__total_size__"] = this->CalSerializeSize();
+    return memory_usage;
+}
+
 void
 HGraph::deserialize_basic_info(StreamReader& reader) {
     StreamReader::ReadObj(reader, this->use_reorder_);

--- a/src/algorithm/hgraph.h
+++ b/src/algorithm/hgraph.h
@@ -105,17 +105,19 @@ public:
 
     int64_t
     GetNumElements() const override {
-        return this->total_count_;
+        return static_cast<int64_t>(this->total_count_);
     }
 
     uint64_t
     EstimateMemory(uint64_t num_elements) const override;
 
-    // TODO(LHT): implement
-    inline int64_t
+    int64_t
     GetMemoryUsage() const override {
-        return 0;
+        return static_cast<int64_t>(this->CalSerializeSize());
     }
+
+    JsonType
+    GetMemoryUsageDetail() const override;
 
     float
     CalcDistanceById(const float* query, int64_t id) const override;

--- a/src/algorithm/inner_index_interface.h
+++ b/src/algorithm/inner_index_interface.h
@@ -235,6 +235,13 @@ public:
                             "Index doesn't support GetMemoryUsage");
     }
 
+    [[nodiscard]] virtual JsonType
+    GetMemoryUsageDetail() const {
+        // TODO(deming): implement func for every types of inner index
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "Index doesn't support GetMemoryUsageDetail");
+    }
+
     [[nodiscard]] virtual uint64_t
     EstimateMemory(uint64_t num_elements) const {
         throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,

--- a/src/data_cell/extra_info_interface.h
+++ b/src/data_cell/extra_info_interface.h
@@ -99,6 +99,14 @@ public:
         StreamReader::ReadObj(reader, this->extra_info_size_);
     }
 
+    uint64_t
+    CalcSerializeSize() {
+        auto calSizeFunc = [](uint64_t cursor, uint64_t size, void* buf) { return; };
+        WriteFuncStreamWriter writer(calSizeFunc, 0);
+        this->Serialize(writer);
+        return writer.cursor_;
+    }
+
     [[nodiscard]] virtual bool
     InMemory() const {
         return true;

--- a/src/data_cell/flatten_interface.h
+++ b/src/data_cell/flatten_interface.h
@@ -134,6 +134,14 @@ public:
         StreamReader::ReadObj(reader, this->code_size_);
     }
 
+    uint64_t
+    CalcSerializeSize() {
+        auto calSizeFunc = [](uint64_t cursor, uint64_t size, void* buf) { return; };
+        WriteFuncStreamWriter writer(calSizeFunc, 0);
+        this->Serialize(writer);
+        return writer.cursor_;
+    }
+
     [[nodiscard]] virtual bool
     InMemory() const {
         return true;

--- a/src/data_cell/graph_interface.h
+++ b/src/data_cell/graph_interface.h
@@ -73,6 +73,14 @@ public:
         StreamReader::ReadObj(reader, this->maximum_degree_);
     }
 
+    uint64_t
+    CalcSerializeSize() {
+        auto calSizeFunc = [](uint64_t cursor, uint64_t size, void* buf) { return; };
+        WriteFuncStreamWriter writer(calSizeFunc, 0);
+        this->Serialize(writer);
+        return writer.cursor_;
+    }
+
     [[nodiscard]] virtual InnerIdType
     TotalCount() const {
         return this->total_count_;

--- a/src/index/index_impl.h
+++ b/src/index/index_impl.h
@@ -279,6 +279,11 @@ public:
         return this->inner_index_->GetMemoryUsage();
     }
 
+    [[nodiscard]] JsonType
+    GetMemoryUsageDetail() const override {
+        return this->inner_index_->GetMemoryUsageDetail();
+    }
+
     [[nodiscard]] uint64_t
     EstimateMemory(uint64_t num_elements) const override {
         return this->inner_index_->EstimateMemory(num_elements);

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -528,6 +528,38 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HgraphTestIndex,
     }
 }
 
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::HgraphTestIndex,
+                             "HGraph GetMemoryUsageDetail",
+                             "[ft][hgraph]") {
+    auto origin_size = vsag::Options::Instance().block_size_limit();
+    auto size = GENERATE(1024 * 1024 * 2);
+    auto metric_type = GENERATE("l2", "ip", "cosine");
+
+    const std::string name = "hgraph";
+    auto search_param = fmt::format(search_param_tmp, 200, false);
+    for (auto dim : dims) {
+        for (auto& [base_quantization_str, recall] : test_cases) {
+            if (IsRaBitQ(base_quantization_str)) {
+                if (std::string(metric_type) != "l2") {
+                    continue;
+                }
+                if (dim <= fixtures::RABITQ_MIN_RACALL_DIM) {
+                    dim += fixtures::RABITQ_MIN_RACALL_DIM;
+                }
+            }
+            vsag::Options::Instance().set_block_size_limit(size);
+            auto param =
+                GenerateHGraphBuildParametersString(metric_type, dim, base_quantization_str);
+            auto index = TestFactory(name, param, true);
+            auto memory_detail = index->GetMemoryUsageDetail();
+            REQUIRE(memory_detail.contains("basic_flatten_codes"));
+            REQUIRE(memory_detail.contains("bottom_graph"));
+            REQUIRE(memory_detail.contains("route_graph"));
+            vsag::Options::Instance().set_block_size_limit(origin_size);
+        }
+    }
+}
+
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::HgraphTestIndex, "HGraph Add", "[ft][hgraph]") {
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -47,6 +47,9 @@ public:
                 const std::string& search_param,
                 float recall);
 
+    static void
+    TestMemoryUsageDetail(const IndexPtr& index);
+
     static TestDatasetPool pool;
 
     static std::vector<int> dims;
@@ -199,6 +202,15 @@ HgraphTestIndex::TestGeneral(const TestIndex::IndexPtr& index,
     TestCheckIdExist(index, dataset);
     TestCalcDistanceById(index, dataset);
     TestBatchCalcDistanceById(index, dataset);
+    TestMemoryUsageDetail(index);
+}
+
+void
+HgraphTestIndex::TestMemoryUsageDetail(const IndexPtr& index) {
+    auto memory_detail = index->GetMemoryUsageDetail();
+    REQUIRE(memory_detail.contains("basic_flatten_codes"));
+    REQUIRE(memory_detail.contains("bottom_graph"));
+    REQUIRE(memory_detail.contains("route_graph"));
 }
 }  // namespace fixtures
 
@@ -523,38 +535,6 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HgraphTestIndex,
             auto dataset = pool.GetDatasetAndCreate(dim, base_count, metric_type);
             TestBuildIndex(index, dataset, true);
             TestGeneral(index, dataset, search_param, recall);
-            vsag::Options::Instance().set_block_size_limit(origin_size);
-        }
-    }
-}
-
-TEST_CASE_PERSISTENT_FIXTURE(fixtures::HgraphTestIndex,
-                             "HGraph GetMemoryUsageDetail",
-                             "[ft][hgraph]") {
-    auto origin_size = vsag::Options::Instance().block_size_limit();
-    auto size = GENERATE(1024 * 1024 * 2);
-    auto metric_type = GENERATE("l2", "ip", "cosine");
-
-    const std::string name = "hgraph";
-    auto search_param = fmt::format(search_param_tmp, 200, false);
-    for (auto dim : dims) {
-        for (auto& [base_quantization_str, recall] : test_cases) {
-            if (IsRaBitQ(base_quantization_str)) {
-                if (std::string(metric_type) != "l2") {
-                    continue;
-                }
-                if (dim <= fixtures::RABITQ_MIN_RACALL_DIM) {
-                    dim += fixtures::RABITQ_MIN_RACALL_DIM;
-                }
-            }
-            vsag::Options::Instance().set_block_size_limit(size);
-            auto param =
-                GenerateHGraphBuildParametersString(metric_type, dim, base_quantization_str);
-            auto index = TestFactory(name, param, true);
-            auto memory_detail = index->GetMemoryUsageDetail();
-            REQUIRE(memory_detail.contains("basic_flatten_codes"));
-            REQUIRE(memory_detail.contains("bottom_graph"));
-            REQUIRE(memory_detail.contains("route_graph"));
             vsag::Options::Instance().set_block_size_limit(origin_size);
         }
     }

--- a/tools/eval/case/build_eval_case.cpp
+++ b/tools/eval/case/build_eval_case.cpp
@@ -101,6 +101,12 @@ BuildEvalCase::process_result() {
     result["index_info"] = JsonType::parse(config_.build_param);
     result["action"] = "build";
     result["index"] = config_.index_name;
+    // TODO(deming): remove try-catch after implement GetMemoryUsageDetail
+    try {
+        result["memory_detail(B)"] = this->index_->GetMemoryUsageDetail();
+    } catch (std::exception &e) {
+        logger_->Debug(e.what());
+    }
     return result;
 }
 

--- a/tools/eval/case/build_eval_case.cpp
+++ b/tools/eval/case/build_eval_case.cpp
@@ -104,7 +104,7 @@ BuildEvalCase::process_result() {
     // TODO(deming): remove try-catch after implement GetMemoryUsageDetail
     try {
         result["memory_detail(B)"] = this->index_->GetMemoryUsageDetail();
-    } catch (std::exception &e) {
+    } catch (std::exception& e) {
         logger_->Debug(e.what());
     }
     return result;

--- a/tools/eval/case/search_eval_case.cpp
+++ b/tools/eval/case/search_eval_case.cpp
@@ -249,7 +249,7 @@ SearchEvalCase::process_result() {
     // TODO(deming): remove try-catch after implement GetMemoryUsageDetail
     try {
         result["memory_detail(B)"] = this->index_->GetMemoryUsageDetail();
-    } catch (std::exception &e) {
+    } catch (std::exception& e) {
         logger_->Debug(e.what());
     }
     EvalCase::MergeJsonType(this->basic_info_, result);

--- a/tools/eval/case/search_eval_case.cpp
+++ b/tools/eval/case/search_eval_case.cpp
@@ -246,6 +246,12 @@ SearchEvalCase::process_result() {
     result["index_info"] = JsonType::parse(config_.build_param);
     result["search_param"] = config_.search_param;
     result["index"] = config_.index_name;
+    // TODO(deming): remove try-catch after implement GetMemoryUsageDetail
+    try {
+        result["memory_detail(B)"] = this->index_->GetMemoryUsageDetail();
+    } catch (std::exception &e) {
+        logger_->Debug(e.what());
+    }
     EvalCase::MergeJsonType(this->basic_info_, result);
     return result;
 }


### PR DESCRIPTION
close: #752

- add `GetMemoryUsageDetai` in `HGraph, index.h, index_impl.h, inner_index_interface.h`
- print memory usage detail in `eval_performance`

I will add memory usage details for every type of index/inner index in the future.

sample memory detail:

```json 
"memory_detail(B)": {
	"__total_size__": 4190267302,
	"basic_flatten_codes": 784203850,
	"bottom_graph": 264110105,
	"high_precise_codes": 3120562218,
	"route_graph": 1264604
},
```