### PR TITLE
fix: include missing headerfile for type issues

### DIFF
--- a/src/byte_buffer.h
+++ b/src/byte_buffer.h
@@ -15,6 +15,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "vsag/allocator.h"
 
 namespace vsag {


### PR DESCRIPTION
fix #848 by add missing header file `<cstdint>`