### PR TITLE
fix coredump in hgraph when using empty parameter

### DIFF
--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -1229,7 +1229,7 @@ static const std::string HGRAPH_PARAMS_TEMPLATE =
                 "{PCA_DIM}": 0,
                 "{RABITQ_QUANTIZATION_BITS_PER_DIM_QUERY}": 32,
                 "nbits": 8,
-                "{PRODUCT_QUANTIZATION_DIM}": 0
+                "{PRODUCT_QUANTIZATION_DIM}": 32
             }
         },
         "{HGRAPH_PRECISE_CODES_KEY}": {
@@ -1242,7 +1242,7 @@ static const std::string HGRAPH_PARAMS_TEMPLATE =
                 "{QUANTIZATION_TYPE_KEY}": "{QUANTIZATION_TYPE_VALUE_FP32}",
                 "{SQ4_UNIFORM_QUANTIZATION_TRUNC_RATE}": 0.05,
                 "{PCA_DIM}": 0,
-                "{PRODUCT_QUANTIZATION_DIM}": 0
+                "{PRODUCT_QUANTIZATION_DIM}": 32
             }
         },
         "{BUILD_PARAMS_KEY}": {

--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -1224,12 +1224,12 @@ static const std::string HGRAPH_PARAMS_TEMPLATE =
             },
             "codes_type": "flatten_codes",
             "{QUANTIZATION_PARAMS_KEY}": {
-                "{QUANTIZATION_TYPE_KEY}": "{QUANTIZATION_TYPE_VALUE_PQ}",
+                "{QUANTIZATION_TYPE_KEY}": "{QUANTIZATION_TYPE_VALUE_FP32}",
                 "{SQ4_UNIFORM_QUANTIZATION_TRUNC_RATE}": 0.05,
                 "{PCA_DIM}": 0,
                 "{RABITQ_QUANTIZATION_BITS_PER_DIM_QUERY}": 32,
                 "nbits": 8,
-                "{PRODUCT_QUANTIZATION_DIM}": 32
+                "{PRODUCT_QUANTIZATION_DIM}": 1
             }
         },
         "{HGRAPH_PRECISE_CODES_KEY}": {
@@ -1242,7 +1242,7 @@ static const std::string HGRAPH_PARAMS_TEMPLATE =
                 "{QUANTIZATION_TYPE_KEY}": "{QUANTIZATION_TYPE_VALUE_FP32}",
                 "{SQ4_UNIFORM_QUANTIZATION_TRUNC_RATE}": 0.05,
                 "{PCA_DIM}": 0,
-                "{PRODUCT_QUANTIZATION_DIM}": 32
+                "{PRODUCT_QUANTIZATION_DIM}": 1
             }
         },
         "{BUILD_PARAMS_KEY}": {

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -411,6 +411,35 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HGraphTestIndex,
     }
 }
 
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::HGraphTestIndex,
+                             "HGraph Factory Test With Correct Parameters",
+                             "[ft][hgraph]") {
+    // bug issue #883
+    SECTION("Empty index_param") {
+        auto param = R"(
+        {
+            "dtype": "float32",
+            "dim": 128,
+            "metric_type": "l2",
+            "index_param": {
+            }
+        })";
+        REQUIRE(TestFactory(name, param, true));
+    }
+    SECTION("pq index_param") {
+        auto param = R"(
+        {
+            "dtype": "float32",
+            "dim": 128,
+            "metric_type": "l2",
+            "index_param": {
+                "base_quantization_type": "pq"
+            }
+        })";
+        REQUIRE(TestFactory(name, param, true));
+    }
+}
+
 static void
 TestHGraphBuildAndContinueAdd(const fixtures::HGraphTestIndexPtr& test_index,
                               const fixtures::HGraphResourcePtr& resource) {


### PR DESCRIPTION
closed: #883