### PR TITLE
fix coredump in hgraph when using empty parameter (cp 0.15)

### DIFF
--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -1248,12 +1248,12 @@ static const std::string HGRAPH_PARAMS_TEMPLATE =
             },
             "codes_type": "flatten_codes",
             "{QUANTIZATION_PARAMS_KEY}": {
-                "{QUANTIZATION_TYPE_KEY}": "{QUANTIZATION_TYPE_VALUE_PQ}",
+                "{QUANTIZATION_TYPE_KEY}": "{QUANTIZATION_TYPE_VALUE_FP32}",
                 "{SQ4_UNIFORM_QUANTIZATION_TRUNC_RATE}": 0.05,
                 "{PCA_DIM}": 0,
                 "{RABITQ_QUANTIZATION_BITS_PER_DIM_QUERY}": 32,
                 "nbits": 8,
-                "{PRODUCT_QUANTIZATION_DIM}": 0
+                "{PRODUCT_QUANTIZATION_DIM}": 1
             }
         },
         "{HGRAPH_PRECISE_CODES_KEY}": {
@@ -1266,7 +1266,7 @@ static const std::string HGRAPH_PARAMS_TEMPLATE =
                 "{QUANTIZATION_TYPE_KEY}": "{QUANTIZATION_TYPE_VALUE_FP32}",
                 "{SQ4_UNIFORM_QUANTIZATION_TRUNC_RATE}": 0.05,
                 "{PCA_DIM}": 0,
-                "{PRODUCT_QUANTIZATION_DIM}": 0
+                "{PRODUCT_QUANTIZATION_DIM}": 1
             }
         },
         "{BUILD_PARAMS_KEY}": {

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -377,6 +377,35 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HgraphTestIndex,
 }
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::HgraphTestIndex,
+                             "HGraph Factory Test With Correct Parameters",
+                             "[ft][hgraph]") {
+    // bug issue #883
+    SECTION("Empty index_param") {
+        auto param = R"(
+        {
+            "dtype": "float32",
+            "dim": 128,
+            "metric_type": "l2",
+            "index_param": {
+            }
+        })";
+        REQUIRE(TestFactory("hgraph", param, true));
+    }
+    SECTION("pq index_param") {
+        auto param = R"(
+        {
+            "dtype": "float32",
+            "dim": 128,
+            "metric_type": "l2",
+            "index_param": {
+                "base_quantization_type": "pq"
+            }
+        })";
+        REQUIRE(TestFactory("hgraph", param, true));
+    }
+}
+
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::HgraphTestIndex,
                              "HGraph Build & ContinueAdd Test",
                              "[ft][hgraph]") {
     auto origin_size = vsag::Options::Instance().block_size_limit();


### PR DESCRIPTION
cp the pr (#855) to 0.15