### PR TITLE
fix(simd): Add CPU support detection to benchmark tests

### DIFF
--- a/src/simd/bf16_simd_test.cpp
+++ b/src/simd/bf16_simd_test.cpp
@@ -99,16 +99,36 @@ TEST_CASE("BF16 Benchmark", "[ut][simd][!benchmark]") {
     auto vec2_fp32 = fixtures::generate_vectors(count, dim, false, 86);
     auto vec2 = encode_bf16(vec2_fp32, count * dim);
     BENCHMARK_SIMD_COMPUTE(generic, BF16ComputeIP);
-    BENCHMARK_SIMD_COMPUTE(sse, BF16ComputeIP);
-    BENCHMARK_SIMD_COMPUTE(avx, BF16ComputeIP);
-    BENCHMARK_SIMD_COMPUTE(avx2, BF16ComputeIP);
-    BENCHMARK_SIMD_COMPUTE(avx512, BF16ComputeIP);
-    BENCHMARK_SIMD_COMPUTE(neon, BF16ComputeIP);
+    if (SimdStatus::SupportSSE()) {
+        BENCHMARK_SIMD_COMPUTE(sse, BF16ComputeIP);
+    }
+    if (SimdStatus::SupportAVX()) {
+        BENCHMARK_SIMD_COMPUTE(avx, BF16ComputeIP);
+    }
+    if (SimdStatus::SupportAVX2()) {
+        BENCHMARK_SIMD_COMPUTE(avx2, BF16ComputeIP);
+    }
+    if (SimdStatus::SupportAVX512()) {
+        BENCHMARK_SIMD_COMPUTE(avx512, BF16ComputeIP);
+    }
+    if (SimdStatus::SupportNEON()) {
+        BENCHMARK_SIMD_COMPUTE(neon, BF16ComputeIP);
+    }
 
     BENCHMARK_SIMD_COMPUTE(generic, BF16ComputeL2Sqr);
-    BENCHMARK_SIMD_COMPUTE(sse, BF16ComputeL2Sqr);
-    BENCHMARK_SIMD_COMPUTE(avx, BF16ComputeL2Sqr);
-    BENCHMARK_SIMD_COMPUTE(avx2, BF16ComputeL2Sqr);
-    BENCHMARK_SIMD_COMPUTE(avx512, BF16ComputeL2Sqr);
-    BENCHMARK_SIMD_COMPUTE(neon, BF16ComputeL2Sqr);
+    if (SimdStatus::SupportSSE()) {
+        BENCHMARK_SIMD_COMPUTE(sse, BF16ComputeL2Sqr);
+    }
+    if (SimdStatus::SupportAVX()) {
+        BENCHMARK_SIMD_COMPUTE(avx, BF16ComputeL2Sqr);
+    }
+    if (SimdStatus::SupportAVX2()) {
+        BENCHMARK_SIMD_COMPUTE(avx2, BF16ComputeL2Sqr);
+    }
+    if (SimdStatus::SupportAVX512()) {
+        BENCHMARK_SIMD_COMPUTE(avx512, BF16ComputeL2Sqr);
+    }
+    if (SimdStatus::SupportNEON()) {
+        BENCHMARK_SIMD_COMPUTE(neon, BF16ComputeL2Sqr);
+    }
 }

--- a/src/simd/bit_simd_test.cpp
+++ b/src/simd/bit_simd_test.cpp
@@ -172,37 +172,77 @@ TEST_CASE("Bit Operator (AND, OR, XOR, NOT)", "[!benchmark][simd]") {
 
     SECTION("Bit Operator And") {
         BENCHMARK_BIT_OPERATOR_COMPUTE(generic, BitAnd);
-        BENCHMARK_BIT_OPERATOR_COMPUTE(sse, BitAnd);
-        BENCHMARK_BIT_OPERATOR_COMPUTE(avx, BitAnd);
-        BENCHMARK_BIT_OPERATOR_COMPUTE(avx2, BitAnd);
-        BENCHMARK_BIT_OPERATOR_COMPUTE(avx512, BitAnd);
-        BENCHMARK_BIT_OPERATOR_COMPUTE(neon, BitAnd);
+        if (SimdStatus::SupportSSE()) {
+            BENCHMARK_BIT_OPERATOR_COMPUTE(sse, BitAnd);
+        }
+        if (SimdStatus::SupportAVX()) {
+            BENCHMARK_BIT_OPERATOR_COMPUTE(avx, BitAnd);
+        }
+        if (SimdStatus::SupportAVX2()) {
+            BENCHMARK_BIT_OPERATOR_COMPUTE(avx2, BitAnd);
+        }
+        if (SimdStatus::SupportAVX512()) {
+            BENCHMARK_BIT_OPERATOR_COMPUTE(avx512, BitAnd);
+        }
+        if (SimdStatus::SupportNEON()) {
+            BENCHMARK_BIT_OPERATOR_COMPUTE(neon, BitAnd);
+        }
     }
 
     SECTION("Bit Operator Or") {
         BENCHMARK_BIT_OPERATOR_COMPUTE(generic, BitOr);
-        BENCHMARK_BIT_OPERATOR_COMPUTE(sse, BitOr);
-        BENCHMARK_BIT_OPERATOR_COMPUTE(avx, BitOr);
-        BENCHMARK_BIT_OPERATOR_COMPUTE(avx2, BitOr);
-        BENCHMARK_BIT_OPERATOR_COMPUTE(avx512, BitOr);
-        BENCHMARK_BIT_OPERATOR_COMPUTE(neon, BitOr);
+        if (SimdStatus::SupportSSE()) {
+            BENCHMARK_BIT_OPERATOR_COMPUTE(sse, BitOr);
+        }
+        if (SimdStatus::SupportAVX()) {
+            BENCHMARK_BIT_OPERATOR_COMPUTE(avx, BitOr);
+        }
+        if (SimdStatus::SupportAVX2()) {
+            BENCHMARK_BIT_OPERATOR_COMPUTE(avx2, BitOr);
+        }
+        if (SimdStatus::SupportAVX512()) {
+            BENCHMARK_BIT_OPERATOR_COMPUTE(avx512, BitOr);
+        }
+        if (SimdStatus::SupportNEON()) {
+            BENCHMARK_BIT_OPERATOR_COMPUTE(neon, BitOr);
+        }
     }
 
     SECTION("Bit Operator Xor") {
         BENCHMARK_BIT_OPERATOR_COMPUTE(generic, BitXor);
-        BENCHMARK_BIT_OPERATOR_COMPUTE(sse, BitXor);
-        BENCHMARK_BIT_OPERATOR_COMPUTE(avx, BitXor);
-        BENCHMARK_BIT_OPERATOR_COMPUTE(avx2, BitXor);
-        BENCHMARK_BIT_OPERATOR_COMPUTE(avx512, BitXor);
-        BENCHMARK_BIT_OPERATOR_COMPUTE(neon, BitXor);
+        if (SimdStatus::SupportSSE()) {
+            BENCHMARK_BIT_OPERATOR_COMPUTE(sse, BitXor);
+        }
+        if (SimdStatus::SupportAVX()) {
+            BENCHMARK_BIT_OPERATOR_COMPUTE(avx, BitXor);
+        }
+        if (SimdStatus::SupportAVX2()) {
+            BENCHMARK_BIT_OPERATOR_COMPUTE(avx2, BitXor);
+        }
+        if (SimdStatus::SupportAVX512()) {
+            BENCHMARK_BIT_OPERATOR_COMPUTE(avx512, BitXor);
+        }
+        if (SimdStatus::SupportNEON()) {
+            BENCHMARK_BIT_OPERATOR_COMPUTE(neon, BitXor);
+        }
     }
 
     SECTION("Bit Operator Not") {
         BENCHMARK_BIT_NOT_COMPUTE(generic, BitNot);
-        BENCHMARK_BIT_NOT_COMPUTE(sse, BitNot);
-        BENCHMARK_BIT_NOT_COMPUTE(avx, BitNot);
-        BENCHMARK_BIT_NOT_COMPUTE(avx2, BitNot);
-        BENCHMARK_BIT_NOT_COMPUTE(avx512, BitNot);
-        BENCHMARK_BIT_NOT_COMPUTE(neon, BitNot);
+        if (SimdStatus::SupportSSE()) {
+            BENCHMARK_BIT_NOT_COMPUTE(sse, BitNot);
+        }
+        if (SimdStatus::SupportAVX()) {
+            BENCHMARK_BIT_NOT_COMPUTE(avx, BitNot);
+        }
+        if (SimdStatus::SupportAVX2()) {
+            BENCHMARK_BIT_NOT_COMPUTE(avx2, BitNot);
+        }
+        if (SimdStatus::SupportAVX512()) {
+            BENCHMARK_BIT_NOT_COMPUTE(avx512, BitNot);
+        }
+        if (SimdStatus::SupportNEON()) {
+            BENCHMARK_BIT_NOT_COMPUTE(neon, BitNot);
+        }
     }
 }

--- a/src/simd/fp16_simd_test.cpp
+++ b/src/simd/fp16_simd_test.cpp
@@ -104,14 +104,30 @@ TEST_CASE("FP16 Benchmark", "[ut][simd][!benchmark]") {
     auto vec2_fp32 = fixtures::generate_vectors(count, dim, false, 86);
     auto vec2 = encode_fp16(vec2_fp32, count * dim);
     BENCHMARK_SIMD_COMPUTE(generic, FP16ComputeIP);
-    BENCHMARK_SIMD_COMPUTE(sse, FP16ComputeIP);
-    BENCHMARK_SIMD_COMPUTE(avx2, FP16ComputeIP);
-    BENCHMARK_SIMD_COMPUTE(avx512, FP16ComputeIP);
-    BENCHMARK_SIMD_COMPUTE(neon, FP16ComputeIP);
+    if (SimdStatus::SupportSSE()) {
+        BENCHMARK_SIMD_COMPUTE(sse, FP16ComputeIP);
+    }
+    if (SimdStatus::SupportAVX2()) {
+        BENCHMARK_SIMD_COMPUTE(avx2, FP16ComputeIP);
+    }
+    if (SimdStatus::SupportAVX512()) {
+        BENCHMARK_SIMD_COMPUTE(avx512, FP16ComputeIP);
+    }
+    if (SimdStatus::SupportNEON()) {
+        BENCHMARK_SIMD_COMPUTE(neon, FP16ComputeIP);
+    }
 
     BENCHMARK_SIMD_COMPUTE(generic, FP16ComputeL2Sqr);
-    BENCHMARK_SIMD_COMPUTE(sse, FP16ComputeL2Sqr);
-    BENCHMARK_SIMD_COMPUTE(avx2, FP16ComputeL2Sqr);
-    BENCHMARK_SIMD_COMPUTE(avx512, FP16ComputeL2Sqr);
-    BENCHMARK_SIMD_COMPUTE(neon, FP16ComputeL2Sqr);
+    if (SimdStatus::SupportSSE()) {
+        BENCHMARK_SIMD_COMPUTE(sse, FP16ComputeL2Sqr);
+    }
+    if (SimdStatus::SupportAVX2()) {
+        BENCHMARK_SIMD_COMPUTE(avx2, FP16ComputeL2Sqr);
+    }
+    if (SimdStatus::SupportAVX512()) {
+        BENCHMARK_SIMD_COMPUTE(avx512, FP16ComputeL2Sqr);
+    }
+    if (SimdStatus::SupportNEON()) {
+        BENCHMARK_SIMD_COMPUTE(neon, FP16ComputeL2Sqr);
+    }
 }

--- a/src/simd/fp32_simd_test.cpp
+++ b/src/simd/fp32_simd_test.cpp
@@ -229,18 +229,38 @@ TEST_CASE("FP32 Benchmark", "[ut][simd][!benchmark]") {
     auto vec1 = fixtures::generate_vectors(count * 2, dim);
     std::vector<float> vec2(vec1.begin() + count, vec1.end());
     BENCHMARK_SIMD_COMPUTE(generic, FP32ComputeIP);
-    BENCHMARK_SIMD_COMPUTE(sse, FP32ComputeIP);
-    BENCHMARK_SIMD_COMPUTE(avx, FP32ComputeIP);
-    BENCHMARK_SIMD_COMPUTE(avx2, FP32ComputeIP);
-    BENCHMARK_SIMD_COMPUTE(avx512, FP32ComputeIP);
-    BENCHMARK_SIMD_COMPUTE(neon, FP32ComputeIP);
+    if (SimdStatus::SupportSSE()) {
+        BENCHMARK_SIMD_COMPUTE(sse, FP32ComputeIP);
+    }
+    if (SimdStatus::SupportAVX()) {
+        BENCHMARK_SIMD_COMPUTE(avx, FP32ComputeIP);
+    }
+    if (SimdStatus::SupportAVX2()) {
+        BENCHMARK_SIMD_COMPUTE(avx2, FP32ComputeIP);
+    }
+    if (SimdStatus::SupportAVX512()) {
+        BENCHMARK_SIMD_COMPUTE(avx512, FP32ComputeIP);
+    }
+    if (SimdStatus::SupportNEON()) {
+        BENCHMARK_SIMD_COMPUTE(neon, FP32ComputeIP);
+    }
 
     BENCHMARK_SIMD_COMPUTE(generic, FP32ComputeL2Sqr);
-    BENCHMARK_SIMD_COMPUTE(sse, FP32ComputeL2Sqr);
-    BENCHMARK_SIMD_COMPUTE(avx, FP32ComputeL2Sqr);
-    BENCHMARK_SIMD_COMPUTE(avx2, FP32ComputeL2Sqr);
-    BENCHMARK_SIMD_COMPUTE(avx512, FP32ComputeL2Sqr);
-    BENCHMARK_SIMD_COMPUTE(neon, FP32ComputeL2Sqr);
+    if (SimdStatus::SupportSSE()) {
+        BENCHMARK_SIMD_COMPUTE(sse, FP32ComputeL2Sqr);
+    }
+    if (SimdStatus::SupportAVX()) {
+        BENCHMARK_SIMD_COMPUTE(avx, FP32ComputeL2Sqr);
+    }
+    if (SimdStatus::SupportAVX2()) {
+        BENCHMARK_SIMD_COMPUTE(avx2, FP32ComputeL2Sqr);
+    }
+    if (SimdStatus::SupportAVX512()) {
+        BENCHMARK_SIMD_COMPUTE(avx512, FP32ComputeL2Sqr);
+    }
+    if (SimdStatus::SupportNEON()) {
+        BENCHMARK_SIMD_COMPUTE(neon, FP32ComputeL2Sqr);
+    }
 }
 
 #define BENCHMARK_SIMD_COMPUTE_BATCH4(Simd, Comp)        \
@@ -268,16 +288,36 @@ TEST_CASE("FP32 Benchmark Batch4", "[ut][simd][!benchmark]") {
     auto vec1 = fixtures::generate_vectors(count * 2, dim);
     std::vector<float> vec2(vec1.begin() + count, vec1.end());
     BENCHMARK_SIMD_COMPUTE_BATCH4(generic, FP32ComputeIPBatch4);
-    BENCHMARK_SIMD_COMPUTE_BATCH4(sse, FP32ComputeIPBatch4);
-    BENCHMARK_SIMD_COMPUTE_BATCH4(avx, FP32ComputeIPBatch4);
-    BENCHMARK_SIMD_COMPUTE_BATCH4(avx2, FP32ComputeIPBatch4);
-    BENCHMARK_SIMD_COMPUTE_BATCH4(avx512, FP32ComputeIPBatch4);
-    BENCHMARK_SIMD_COMPUTE_BATCH4(neon, FP32ComputeIPBatch4);
+    if (SimdStatus::SupportSSE()) {
+        BENCHMARK_SIMD_COMPUTE_BATCH4(sse, FP32ComputeIPBatch4);
+    }
+    if (SimdStatus::SupportAVX()) {
+        BENCHMARK_SIMD_COMPUTE_BATCH4(avx, FP32ComputeIPBatch4);
+    }
+    if (SimdStatus::SupportAVX2()) {
+        BENCHMARK_SIMD_COMPUTE_BATCH4(avx2, FP32ComputeIPBatch4);
+    }
+    if (SimdStatus::SupportAVX512()) {
+        BENCHMARK_SIMD_COMPUTE_BATCH4(avx512, FP32ComputeIPBatch4);
+    }
+    if (SimdStatus::SupportNEON()) {
+        BENCHMARK_SIMD_COMPUTE_BATCH4(neon, FP32ComputeIPBatch4);
+    }
 
     BENCHMARK_SIMD_COMPUTE_BATCH4(generic, FP32ComputeL2SqrBatch4);
-    BENCHMARK_SIMD_COMPUTE_BATCH4(sse, FP32ComputeL2SqrBatch4);
-    BENCHMARK_SIMD_COMPUTE_BATCH4(avx, FP32ComputeL2SqrBatch4);
-    BENCHMARK_SIMD_COMPUTE_BATCH4(avx2, FP32ComputeL2SqrBatch4);
-    BENCHMARK_SIMD_COMPUTE_BATCH4(avx512, FP32ComputeL2SqrBatch4);
-    BENCHMARK_SIMD_COMPUTE_BATCH4(neon, FP32ComputeL2SqrBatch4);
+    if (SimdStatus::SupportSSE()) {
+        BENCHMARK_SIMD_COMPUTE_BATCH4(sse, FP32ComputeL2SqrBatch4);
+    }
+    if (SimdStatus::SupportAVX()) {
+        BENCHMARK_SIMD_COMPUTE_BATCH4(avx, FP32ComputeL2SqrBatch4);
+    }
+    if (SimdStatus::SupportAVX2()) {
+        BENCHMARK_SIMD_COMPUTE_BATCH4(avx2, FP32ComputeL2SqrBatch4);
+    }
+    if (SimdStatus::SupportAVX512()) {
+        BENCHMARK_SIMD_COMPUTE_BATCH4(avx512, FP32ComputeL2SqrBatch4);
+    }
+    if (SimdStatus::SupportNEON()) {
+        BENCHMARK_SIMD_COMPUTE_BATCH4(neon, FP32ComputeL2SqrBatch4);
+    }
 }

--- a/src/simd/normalize_test.cpp
+++ b/src/simd/normalize_test.cpp
@@ -90,8 +90,16 @@ TEST_CASE("Normalize Benchmark", "[ut][simd][!benchmark]") {
     auto vec1 = fixtures::generate_vectors(count * 2, dim);
     std::vector<float> vec2(vec1.begin() + count, vec1.end());
     BENCHMARK_SIMD_COMPUTE(generic, Normalize);
-    BENCHMARK_SIMD_COMPUTE(sse, Normalize);
-    BENCHMARK_SIMD_COMPUTE(avx2, Normalize);
-    BENCHMARK_SIMD_COMPUTE(avx512, Normalize);
-    BENCHMARK_SIMD_COMPUTE(neon, Normalize);
+    if (SimdStatus::SupportSSE()) {
+        BENCHMARK_SIMD_COMPUTE(sse, Normalize);
+    }
+    if (SimdStatus::SupportAVX2()) {
+        BENCHMARK_SIMD_COMPUTE(avx2, Normalize);
+    }
+    if (SimdStatus::SupportAVX512()) {
+        BENCHMARK_SIMD_COMPUTE(avx512, Normalize);
+    }
+    if (SimdStatus::SupportNEON()) {
+        BENCHMARK_SIMD_COMPUTE(neon, Normalize);
+    }
 }

--- a/src/simd/pqfs_simd_test.cpp
+++ b/src/simd/pqfs_simd_test.cpp
@@ -101,9 +101,19 @@ TEST_CASE("PQFastScan Benchmark", "[ut][simd][!benchmark]") {
     std::vector<int32_t> gt(32);
 
     BENCHMARK_SIMD_COMPUTE(generic, PQFastScanLookUp32);
-    BENCHMARK_SIMD_COMPUTE(sse, PQFastScanLookUp32);
-    BENCHMARK_SIMD_COMPUTE(avx, PQFastScanLookUp32);
-    BENCHMARK_SIMD_COMPUTE(avx2, PQFastScanLookUp32);
-    BENCHMARK_SIMD_COMPUTE(avx512, PQFastScanLookUp32);
-    BENCHMARK_SIMD_COMPUTE(neon, PQFastScanLookUp32);
+    if (SimdStatus::SupportSSE()) {
+        BENCHMARK_SIMD_COMPUTE(sse, PQFastScanLookUp32);
+    }
+    if (SimdStatus::SupportAVX()) {
+        BENCHMARK_SIMD_COMPUTE(avx, PQFastScanLookUp32);
+    }
+    if (SimdStatus::SupportAVX2()) {
+        BENCHMARK_SIMD_COMPUTE(avx2, PQFastScanLookUp32);
+    }
+    if (SimdStatus::SupportAVX512()) {
+        BENCHMARK_SIMD_COMPUTE(avx512, PQFastScanLookUp32);
+    }
+    if (SimdStatus::SupportNEON()) {
+        BENCHMARK_SIMD_COMPUTE(neon, PQFastScanLookUp32);
+    }
 }

--- a/src/simd/rabitq_simd_test.cpp
+++ b/src/simd/rabitq_simd_test.cpp
@@ -88,8 +88,12 @@ TEST_CASE("RaBitQ SQ4U-BQ Compute Benchmark", "[ut][simd][!benchmark]") {
     int count = 10000;
     int dim = 32;
     BENCHMARK_SIMD_COMPUTE_SQ4(generic, RaBitQSQ4UBinaryIP);
-    BENCHMARK_SIMD_COMPUTE_SQ4(avx512, RaBitQSQ4UBinaryIP);
-    BENCHMARK_SIMD_COMPUTE_SQ4(avx512vpopcntdq, RaBitQSQ4UBinaryIP);
+    if (SimdStatus::SupportAVX512()) {
+        BENCHMARK_SIMD_COMPUTE_SQ4(avx512, RaBitQSQ4UBinaryIP);
+    }
+    if (SimdStatus::SupportAVX512VPOPCNTDQ()) {
+        BENCHMARK_SIMD_COMPUTE_SQ4(avx512vpopcntdq, RaBitQSQ4UBinaryIP);
+    }
 }
 
 TEST_CASE("RaBitQ SQ4U-BQ Compute Codes", "[ut][simd]") {
@@ -158,11 +162,21 @@ TEST_CASE("RaBitQ FP32-BQ SIMD Compute Benchmark", "[ut][simd][!benchmark]") {
     std::tie(queries, bases) = fixtures::GenerateBinaryVectorsAndCodes(count, dim);
 
     BENCHMARK_SIMD_COMPUTE(generic, RaBitQFloatBinaryIP);
-    BENCHMARK_SIMD_COMPUTE(sse, RaBitQFloatBinaryIP);
-    BENCHMARK_SIMD_COMPUTE(avx, RaBitQFloatBinaryIP);
-    BENCHMARK_SIMD_COMPUTE(avx2, RaBitQFloatBinaryIP);
-    BENCHMARK_SIMD_COMPUTE(avx512, RaBitQFloatBinaryIP);
-    BENCHMARK_SIMD_COMPUTE(neon, RaBitQFloatBinaryIP);
+    if (SimdStatus::SupportSSE()) {
+        BENCHMARK_SIMD_COMPUTE(sse, RaBitQFloatBinaryIP);
+    }
+    if (SimdStatus::SupportAVX()) {
+        BENCHMARK_SIMD_COMPUTE(avx, RaBitQFloatBinaryIP);
+    }
+    if (SimdStatus::SupportAVX2()) {
+        BENCHMARK_SIMD_COMPUTE(avx2, RaBitQFloatBinaryIP);
+    }
+    if (SimdStatus::SupportAVX512()) {
+        BENCHMARK_SIMD_COMPUTE(avx512, RaBitQFloatBinaryIP);
+    }
+    if (SimdStatus::SupportNEON()) {
+        BENCHMARK_SIMD_COMPUTE(neon, RaBitQFloatBinaryIP);
+    }
 }
 TEST_CASE("SIMD test for rescale", "[ut][simd]") {
     auto dims = fixtures::get_common_used_dims();

--- a/src/simd/sq4_simd_test.cpp
+++ b/src/simd/sq4_simd_test.cpp
@@ -19,7 +19,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "fixtures.h"
-
+#include "simd_status.h"
 using namespace vsag;
 
 #define TEST_ACCURACY(Func)                                        \
@@ -116,9 +116,19 @@ TEST_CASE("SQ4 SIMD Compute Benchmark", "[ut][simd][!benchmark]") {
     auto lb = fixtures::generate_vectors(1, dim, true, 180);
     auto diff = fixtures::generate_vectors(1, dim, true, 6217);
     BENCHMARK_SIMD_COMPUTE(generic, SQ4ComputeIP);
-    BENCHMARK_SIMD_COMPUTE(sse, SQ4ComputeIP);
-    BENCHMARK_SIMD_COMPUTE(avx, SQ4ComputeIP);
-    BENCHMARK_SIMD_COMPUTE(avx2, SQ4ComputeIP);
-    BENCHMARK_SIMD_COMPUTE(avx512, SQ4ComputeIP);
-    BENCHMARK_SIMD_COMPUTE(neon, SQ4ComputeIP);
+    if (SimdStatus::SupportSSE()) {
+        BENCHMARK_SIMD_COMPUTE(sse, SQ4ComputeIP);
+    }
+    if (SimdStatus::SupportAVX()) {
+        BENCHMARK_SIMD_COMPUTE(avx, SQ4ComputeIP);
+    }
+    if (SimdStatus::SupportAVX2()) {
+        BENCHMARK_SIMD_COMPUTE(avx2, SQ4ComputeIP);
+    }
+    if (SimdStatus::SupportAVX512()) {
+        BENCHMARK_SIMD_COMPUTE(avx512, SQ4ComputeIP);
+    }
+    if (SimdStatus::SupportNEON()) {
+        BENCHMARK_SIMD_COMPUTE(neon, SQ4ComputeIP);
+    }
 }

--- a/src/simd/sq4_uniform_simd_test.cpp
+++ b/src/simd/sq4_uniform_simd_test.cpp
@@ -83,9 +83,19 @@ TEST_CASE("SQ4 Uniform SIMD Compute Benchmark", "[ut][simd][!benchmark]") {
     auto codes1 = fixtures::generate_int4_codes(count, dim, 114);
     auto codes2 = fixtures::generate_int4_codes(count, dim, 514);
     BENCHMARK_SIMD_COMPUTE(generic, SQ4UniformComputeCodesIP);
-    BENCHMARK_SIMD_COMPUTE(sse, SQ4UniformComputeCodesIP);
-    BENCHMARK_SIMD_COMPUTE(avx, SQ4UniformComputeCodesIP);
-    BENCHMARK_SIMD_COMPUTE(avx2, SQ4UniformComputeCodesIP);
-    BENCHMARK_SIMD_COMPUTE(avx512, SQ4UniformComputeCodesIP);
-    BENCHMARK_SIMD_COMPUTE(neon, SQ4UniformComputeCodesIP);
+    if (SimdStatus::SupportSSE()) {
+        BENCHMARK_SIMD_COMPUTE(sse, SQ4UniformComputeCodesIP);
+    }
+    if (SimdStatus::SupportAVX()) {
+        BENCHMARK_SIMD_COMPUTE(avx, SQ4UniformComputeCodesIP);
+    }
+    if (SimdStatus::SupportAVX2()) {
+        BENCHMARK_SIMD_COMPUTE(avx2, SQ4UniformComputeCodesIP);
+    }
+    if (SimdStatus::SupportAVX512()) {
+        BENCHMARK_SIMD_COMPUTE(avx512, SQ4UniformComputeCodesIP);
+    }
+    if (SimdStatus::SupportNEON()) {
+        BENCHMARK_SIMD_COMPUTE(neon, SQ4UniformComputeCodesIP);
+    }
 }

--- a/src/simd/sq8_simd_test.cpp
+++ b/src/simd/sq8_simd_test.cpp
@@ -116,9 +116,19 @@ TEST_CASE("SQ8 SIMD Compute Benchmark", "[ut][simd][!benchmark]") {
     auto lb = fixtures::generate_vectors(1, dim, true, 180);
     auto diff = fixtures::generate_vectors(1, dim, true, 6217);
     BENCHMARK_SIMD_COMPUTE(generic, SQ8ComputeIP);
-    BENCHMARK_SIMD_COMPUTE(sse, SQ8ComputeIP);
-    BENCHMARK_SIMD_COMPUTE(avx, SQ8ComputeIP);
-    BENCHMARK_SIMD_COMPUTE(avx2, SQ8ComputeIP);
-    BENCHMARK_SIMD_COMPUTE(avx512, SQ8ComputeIP);
-    BENCHMARK_SIMD_COMPUTE(neon, SQ8ComputeIP);
+    if (SimdStatus::SupportSSE()) {
+        BENCHMARK_SIMD_COMPUTE(sse, SQ8ComputeIP);
+    }
+    if (SimdStatus::SupportAVX()) {
+        BENCHMARK_SIMD_COMPUTE(avx, SQ8ComputeIP);
+    }
+    if (SimdStatus::SupportAVX2()) {
+        BENCHMARK_SIMD_COMPUTE(avx2, SQ8ComputeIP);
+    }
+    if (SimdStatus::SupportAVX512()) {
+        BENCHMARK_SIMD_COMPUTE(avx512, SQ8ComputeIP);
+    }
+    if (SimdStatus::SupportNEON()) {
+        BENCHMARK_SIMD_COMPUTE(neon, SQ8ComputeIP);
+    }
 }

--- a/src/simd/sq8_uniform_simd_test.cpp
+++ b/src/simd/sq8_uniform_simd_test.cpp
@@ -83,9 +83,19 @@ TEST_CASE("SQ8 Uniform SIMD Compute Benchmark", "[ut][simd][!benchmark]") {
     auto codes1 = fixtures::generate_uint8_codes(count, dim, 114);
     auto codes2 = fixtures::generate_uint8_codes(count, dim, 514);
     BENCHMARK_SIMD_COMPUTE(generic, SQ8UniformComputeCodesIP);
-    BENCHMARK_SIMD_COMPUTE(sse, SQ8UniformComputeCodesIP);
-    BENCHMARK_SIMD_COMPUTE(avx, SQ8UniformComputeCodesIP);
-    BENCHMARK_SIMD_COMPUTE(avx2, SQ8UniformComputeCodesIP);
-    BENCHMARK_SIMD_COMPUTE(avx512, SQ8UniformComputeCodesIP);
-    BENCHMARK_SIMD_COMPUTE(neon, SQ8UniformComputeCodesIP);
+    if (SimdStatus::SupportSSE()) {
+        BENCHMARK_SIMD_COMPUTE(sse, SQ8UniformComputeCodesIP);
+    }
+    if (SimdStatus::SupportAVX()) {
+        BENCHMARK_SIMD_COMPUTE(avx, SQ8UniformComputeCodesIP);
+    }
+    if (SimdStatus::SupportAVX2()) {
+        BENCHMARK_SIMD_COMPUTE(avx2, SQ8UniformComputeCodesIP);
+    }
+    if (SimdStatus::SupportAVX512()) {
+        BENCHMARK_SIMD_COMPUTE(avx512, SQ8UniformComputeCodesIP);
+    }
+    if (SimdStatus::SupportNEON()) {
+        BENCHMARK_SIMD_COMPUTE(neon, SQ8UniformComputeCodesIP);
+    }
 }


### PR DESCRIPTION
This commit fixes an `illegal instruction` error that occurred when running benchmark tests on CPUs without the required SIMD instruction set support. as belows：
<img width="1374" height="718" alt="image" src="https://github.com/user-attachments/assets/a52692ec-87fe-42e1-8554-e93b8281c8b6" />


By adding checks for SSE, AVX, AVX2, AVX512, and NEON support, the tests are now safely skipped on unsupported hardware, preventing the program from crashing.

The following files were modified:
- bf16_simd_test.cpp
- bit_simd_test.cpp
- fp16_simd_test.cpp
- fp32_simd_test.cpp
- normalize_test.cpp
- pqfs_simd_test.cpp
- rabitq_simd_test.cpp
- sq4_simd_test.cpp
- sq4_uniform_simd_test.cpp
- sq8_simd_test.cpp
- sq8_uniform_simd_test.cpp