### PR TITLE
Improve sq8 ipc and decrease building cost in ARM.

### DIFF
--- a/src/simd/neon.cpp
+++ b/src/simd/neon.cpp
@@ -1743,10 +1743,10 @@ shuffle_16_char(const uint8x16_t* a, const uint8x16_t* b) {
 #endif
 
 void
-Prefetch(const void* data){
-    // #if defined(ENABLE_NEON)
-    //     __builtin_prefetch(data, 0, 1);
-    // #endif
+Prefetch(const void* data) {
+#if defined(ENABLE_NEON)
+    __builtin_prefetch(data, 0, 3);
+#endif
 };
 
 void


### PR DESCRIPTION
In ARM, use below optimizations to decrease build time (237s -> 232s), improve search QPS(2482 -> 5216) and ipc(2.08 -> 2.16) by decreasing instructions' stalls:
- Loop unrolling from 4 elements to 12 elements.
- FMA instruction performs both multiplication and addition.
- Prefetch to decrease instruction pipeline stalls.
- Pre-calculate `inv255` to avoid repeated calculations in the loop.
- Optimize `RabitQFloatBinary`. 

Before optimizing:
<img width="1444" height="380" alt="截屏2025-07-14 13 13 18" src="https://github.com/user-attachments/assets/788ccdd3-dd5d-488c-83c9-3ede80e8ecb3" />

After optimizing:
<img width="2116" height="209" alt="5E47CE4B-0F78-474B-9A0B-9D7C1EEF15BB" src="https://github.com/user-attachments/assets/d0e10599-503c-401e-b778-c2cb77f3c43d" />


