### PR TITLE
support ip and cos in rabitq

### DIFF
--- a/src/data_cell/flatten_datacell_test.cpp
+++ b/src/data_cell/flatten_datacell_test.cpp
@@ -30,7 +30,7 @@ using namespace vsag;
 void
 TestFlattenDataCell(FlattenDataCellParamPtr& param,
                     IndexCommonParam& common_param,
-                    float error = 1e-5) {
+                    float error = 1e-3) {
     auto count = GENERATE(100, 1000);
     auto flatten = FlattenInterface::MakeInstance(param, common_param);
 

--- a/src/data_cell/flatten_interface.cpp
+++ b/src/data_cell/flatten_interface.cpp
@@ -68,11 +68,7 @@ make_instance(const FlattenInterfaceParamPtr& param, const IndexCommonParam& com
         return make_instance<ProductQuantizer<metric>, IOTemp>(param, common_param);
     }
     if (quantization_string == QUANTIZATION_TYPE_VALUE_RABITQ) {
-        if constexpr (metric == MetricType::METRIC_TYPE_L2SQR) {
-            return make_instance<RaBitQuantizer<metric>, IOTemp>(param, common_param);
-        } else {
-            return nullptr;
-        }
+        return make_instance<RaBitQuantizer<metric>, IOTemp>(param, common_param);
     }
     if (quantization_string == QUANTIZATION_TYPE_VALUE_SPARSE) {
         return make_instance<SparseQuantizer<metric>, IOTemp>(param, common_param);

--- a/src/quantization/quantizer_test.h
+++ b/src/quantization/quantizer_test.h
@@ -234,12 +234,15 @@ TestComputer(Quantizer<T>& quant,
              float unbounded_numeric_error_rate = 1.0f,
              float unbounded_related_error_rate = 1.0f) {
     auto query_count = 10;
-    bool need_normalize = true;
-    if constexpr (metric == vsag::MetricType::METRIC_TYPE_COSINE) {
-        need_normalize = false;
-    }
+    bool need_normalize = false;
     auto vecs = fixtures::generate_vectors(count, dim, need_normalize);
     auto queries = fixtures::generate_vectors(query_count, dim, need_normalize, 165);
+    for (int d = 0; d < dim; d++) {
+        vecs[d] = 0.0f;
+    }
+    for (int d = 0; d < dim; d++) {
+        queries[query_count * dim / 2 + d] = 0.0f;
+    }
     if (retrain) {
         quant.ReTrain(vecs.data(), count);
     }
@@ -277,7 +280,7 @@ TestComputer(Quantizer<T>& quant,
             if (std::abs(gt - dists1[j]) > error) {
                 count_unbounded_numeric_error++;
             }
-            if (std::abs(gt - dists1[j]) > related_error * gt) {
+            if (std::abs(gt - dists1[j]) > std::abs(related_error * gt)) {
                 count_unbounded_related_error++;
             }
         }

--- a/src/quantization/rabitq_quantization/rabitq_quantizer.h
+++ b/src/quantization/rabitq_quantization/rabitq_quantizer.h
@@ -192,7 +192,6 @@ template <MetricType metric>
 RaBitQuantizer<metric>::RaBitQuantizer(
     int dim, uint64_t pca_dim, uint64_t num_bits_per_dim_query, bool use_fht, Allocator* allocator)
     : Quantizer<RaBitQuantizer<metric>>(dim, allocator) {
-
     // dim
     pca_dim_ = pca_dim;
     original_dim_ = dim;

--- a/src/quantization/rabitq_quantization/rabitq_quantizer.h
+++ b/src/quantization/rabitq_quantization/rabitq_quantizer.h
@@ -176,6 +176,7 @@ private:
     uint64_t query_offset_delta_{0};
     uint64_t query_offset_sum_{0};
     uint64_t query_offset_norm_{0};
+    uint64_t query_offset_raw_norm_{0};
 
     /***
      * code layout: bq-code(required) + norm(required) + error(required) + sum(sq4)
@@ -184,13 +185,13 @@ private:
     uint64_t offset_norm_{0};
     uint64_t offset_error_{0};
     uint64_t offset_sum_{0};
+    uint64_t offset_raw_norm_{0};
 };
 
 template <MetricType metric>
 RaBitQuantizer<metric>::RaBitQuantizer(
     int dim, uint64_t pca_dim, uint64_t num_bits_per_dim_query, bool use_fht, Allocator* allocator)
     : Quantizer<RaBitQuantizer<metric>>(dim, allocator) {
-    static_assert(metric == MetricType::METRIC_TYPE_L2SQR, "Unsupported metric type");
 
     // dim
     pca_dim_ = pca_dim;
@@ -239,6 +240,11 @@ RaBitQuantizer<metric>::RaBitQuantizer(
         this->code_size_ += ((sizeof(sum_type) + align_size - 1) / align_size) * align_size;
     }
 
+    if constexpr (metric == MetricType::METRIC_TYPE_IP or
+                  metric == MetricType::METRIC_TYPE_COSINE) {
+        offset_raw_norm_ = this->code_size_;
+        this->code_size_ += ((sizeof(norm_type) + align_size - 1) / align_size) * align_size;
+    }
     // query code layout
     if (num_bits_per_dim_query_ == 4) {
         // Re-order the SQ4U Code Layout (align with 8 bits)
@@ -263,6 +269,11 @@ RaBitQuantizer<metric>::RaBitQuantizer(
 
     query_offset_norm_ = this->query_code_size_;
     this->query_code_size_ += ((sizeof(norm_type) + align_size - 1) / align_size) * align_size;
+    if constexpr (metric == MetricType::METRIC_TYPE_IP or
+                  metric == MetricType::METRIC_TYPE_COSINE) {
+        query_offset_raw_norm_ = this->query_code_size_;
+        this->query_code_size_ += ((sizeof(norm_type) + align_size - 1) / align_size) * align_size;
+    }
 }
 
 template <MetricType metric>
@@ -335,6 +346,14 @@ RaBitQuantizer<metric>::EncodeOneImpl(const DataType* data, uint8_t* codes) cons
     Vector<DataType> transformed_data(this->dim_, 0, this->allocator_);
     Vector<DataType> normed_data(this->dim_, 0, this->allocator_);
 
+    float raw_norm = 0;
+    if constexpr (metric == MetricType::METRIC_TYPE_IP or
+                  metric == MetricType::METRIC_TYPE_COSINE) {
+        for (uint64_t d = 0; d < this->dim_; ++d) {
+            raw_norm += data[d] * data[d];
+        }
+    }
+    raw_norm = std::sqrt(raw_norm);
     // 1. pca
     if (pca_dim_ != this->original_dim_) {
         pca_->Transform(data, pca_data.data());
@@ -371,6 +390,10 @@ RaBitQuantizer<metric>::EncodeOneImpl(const DataType* data, uint8_t* codes) cons
         *(sum_type*)(codes + offset_sum_) = sum;
     }
 
+    if constexpr (metric == MetricType::METRIC_TYPE_IP or
+                  metric == MetricType::METRIC_TYPE_COSINE) {
+        *(norm_type*)(codes + offset_raw_norm_) = raw_norm;
+    }
     return true;
 }
 
@@ -455,6 +478,15 @@ RaBitQuantizer<metric>::ComputeQueryBaseImpl(const uint8_t* query_codes,
 
     norm_type query_norm = *((norm_type*)(query_codes + query_offset_norm_));
     norm_type base_norm = *((norm_type*)(base_codes + offset_norm_));
+
+    norm_type quer_raw_norm = 0;
+    norm_type base_raw_norm = 0;
+    if constexpr (metric == MetricType::METRIC_TYPE_IP or
+                  metric == MetricType::METRIC_TYPE_COSINE) {
+        quer_raw_norm = *((norm_type*)(query_codes + query_offset_raw_norm_));
+        base_raw_norm = *((norm_type*)(base_codes + offset_raw_norm_));
+    }
+
     error_type base_error = *((error_type*)(base_codes + offset_error_));
     if (std::abs(base_error) < 1e-5) {
         base_error = (base_error > 0) ? 1.0f : -1.0f;
@@ -464,6 +496,23 @@ RaBitQuantizer<metric>::ComputeQueryBaseImpl(const uint8_t* query_codes,
     float ip_est = ip_bq_estimate / ip_bb_1_32;
 
     float result = L2_UBE(base_norm, query_norm, ip_est);
+
+    if constexpr (metric == MetricType::METRIC_TYPE_COSINE) {
+        if (is_approx_zero(quer_raw_norm) or is_approx_zero(base_raw_norm)) {
+            result = 1;
+        } else {
+            result = 1 - (quer_raw_norm * quer_raw_norm + base_raw_norm * base_raw_norm - result) *
+                             0.5F / (quer_raw_norm * base_raw_norm);
+        }
+    }
+    if constexpr (metric == MetricType::METRIC_TYPE_IP) {
+        if (is_approx_zero(quer_raw_norm) or is_approx_zero(base_raw_norm)) {
+            result = 1;
+        } else {
+            result =
+                1 - (quer_raw_norm * quer_raw_norm + base_raw_norm * base_raw_norm - result) * 0.5F;
+        }
+    }
 
     return result;
 }
@@ -611,6 +660,14 @@ RaBitQuantizer<metric>::ProcessQueryImpl(const DataType* query,
         Vector<DataType> transformed_data(this->dim_, 0, this->allocator_);
         Vector<DataType> normed_data(this->dim_, 0, this->allocator_);
 
+        float query_raw_norm = 0;
+        if constexpr (metric == MetricType::METRIC_TYPE_IP or
+                      metric == MetricType::METRIC_TYPE_COSINE) {
+            for (uint64_t d = 0; d < this->dim_; ++d) {
+                query_raw_norm += query[d] * query[d];
+            }
+        }
+        query_raw_norm = std::sqrt(query_raw_norm);
         // 1. pca
         if (pca_dim_ != this->original_dim_) {
             pca_->Transform(query, pca_data.data());
@@ -651,6 +708,10 @@ RaBitQuantizer<metric>::ProcessQueryImpl(const DataType* query,
 
         // 5. store norm
         *(norm_type*)(computer.buf_ + query_offset_norm_) = query_norm;
+        if constexpr (metric == MetricType::METRIC_TYPE_IP or
+                      metric == MetricType::METRIC_TYPE_COSINE) {
+            *(norm_type*)(computer.buf_ + query_offset_raw_norm_) = query_raw_norm;
+        }
     } catch (std::bad_alloc& e) {
         logger::error("bad alloc when init computer buf");
         throw e;

--- a/src/quantization/rabitq_quantization/rabitq_quantizer_test.cpp
+++ b/src/quantization/rabitq_quantization/rabitq_quantizer_test.cpp
@@ -102,7 +102,7 @@ TEST_CASE("RaBitQ Compute", "[ut][RaBitQuantizer]") {
         for (auto count : counts) {
             auto allocator = SafeAllocator::FactoryDefaultAllocator();
             RaBitQuantizer<MetricType::METRIC_TYPE_COSINE> quantizer(
-                dim, dim, num_bits_per_dim, use_fht,  allocator.get());
+                dim, dim, num_bits_per_dim, use_fht, allocator.get());
 
             TestComputer<RaBitQuantizer<MetricType::METRIC_TYPE_COSINE>,
                          MetricType::METRIC_TYPE_COSINE>(quantizer,
@@ -136,11 +136,8 @@ TEST_CASE("RaBitQ Compute", "[ut][RaBitQuantizer]") {
             RaBitQuantizer<MetricType::METRIC_TYPE_L2SQR> quantizer_l2(
                 dim, dim, num_bits_per_dim, use_fht, allocator.get());
             TestComputer<RaBitQuantizer<MetricType::METRIC_TYPE_L2SQR>,
-                        MetricType::METRIC_TYPE_L2SQR>(quantizer_l2,
-                                                    dim,
-                                                    count,
-                                                    numeric_error,
-                                                    unbounded_related_error_rate);
+                         MetricType::METRIC_TYPE_L2SQR>(
+                quantizer_l2, dim, count, numeric_error, unbounded_related_error_rate);
             REQUIRE_THROWS(TestComputeCodes<RaBitQuantizer<MetricType::METRIC_TYPE_L2SQR>,
                                             MetricType::METRIC_TYPE_L2SQR>(
                 quantizer_l2, dim, count, numeric_error, false));

--- a/src/quantization/rabitq_quantization/rabitq_quantizer_test.cpp
+++ b/src/quantization/rabitq_quantization/rabitq_quantizer_test.cpp
@@ -66,6 +66,18 @@ TEST_CASE("RaBitQ Encode and Decode", "[ut][RaBitQuantizer]") {
 
             TestEncodeDecodeRaBitQ<RaBitQuantizer<MetricType::METRIC_TYPE_L2SQR>>(
                 quantizer, dim, count);
+
+            RaBitQuantizer<MetricType::METRIC_TYPE_IP> quantizer_ip(
+                dim, dim, num_bits_per_dim, use_fht, allocator.get());
+
+            TestEncodeDecodeRaBitQ<RaBitQuantizer<MetricType::METRIC_TYPE_IP>>(
+                quantizer_ip, dim, count);
+
+            RaBitQuantizer<MetricType::METRIC_TYPE_COSINE> quantizer_cos(
+                dim, dim, num_bits_per_dim, use_fht, allocator.get());
+
+            TestEncodeDecodeRaBitQ<RaBitQuantizer<MetricType::METRIC_TYPE_COSINE>>(
+                quantizer_cos, dim, count);
         }
     }
 }
@@ -74,7 +86,7 @@ TEST_CASE("RaBitQ Compute", "[ut][RaBitQuantizer]") {
     bool use_fht = GENERATE(true, false);
     auto num_bits_per_dim = GENERATE(4, 32);
     for (auto dim : dims) {
-        float numeric_error = 0.01 / std::sqrt(dim) * dim;
+        float numeric_error = 1 / std::sqrt(dim) * dim;
         float related_error = 0.05f;
         float unbounded_numeric_error_rate = 0.05f;
         float unbounded_related_error_rate = 0.1f;
@@ -89,21 +101,49 @@ TEST_CASE("RaBitQ Compute", "[ut][RaBitQuantizer]") {
         }
         for (auto count : counts) {
             auto allocator = SafeAllocator::FactoryDefaultAllocator();
-            RaBitQuantizer<MetricType::METRIC_TYPE_L2SQR> quantizer(
+            RaBitQuantizer<MetricType::METRIC_TYPE_COSINE> quantizer(
+                dim, dim, num_bits_per_dim, use_fht,  allocator.get());
+
+            TestComputer<RaBitQuantizer<MetricType::METRIC_TYPE_COSINE>,
+                         MetricType::METRIC_TYPE_COSINE>(quantizer,
+                                                         dim,
+                                                         count,
+                                                         numeric_error,
+                                                         related_error,
+                                                         true,
+                                                         unbounded_numeric_error_rate,
+                                                         unbounded_related_error_rate);
+            REQUIRE_THROWS(TestComputeCodes<RaBitQuantizer<MetricType::METRIC_TYPE_COSINE>,
+                                            MetricType::METRIC_TYPE_COSINE>(
+                quantizer, dim, count, numeric_error, false));
+
+            RaBitQuantizer<MetricType::METRIC_TYPE_IP> quantizer_ip(
                 dim, dim, num_bits_per_dim, use_fht, allocator.get());
 
+            TestComputer<RaBitQuantizer<MetricType::METRIC_TYPE_IP>, MetricType::METRIC_TYPE_IP>(
+                quantizer_ip,
+                dim,
+                count,
+                numeric_error,
+                related_error,
+                true,
+                unbounded_numeric_error_rate,
+                unbounded_related_error_rate);
+            REQUIRE_THROWS(TestComputeCodes<RaBitQuantizer<MetricType::METRIC_TYPE_IP>,
+                                            MetricType::METRIC_TYPE_IP>(
+                quantizer_ip, dim, count, numeric_error, false));
+
+            RaBitQuantizer<MetricType::METRIC_TYPE_L2SQR> quantizer_l2(
+                dim, dim, num_bits_per_dim, use_fht, allocator.get());
             TestComputer<RaBitQuantizer<MetricType::METRIC_TYPE_L2SQR>,
-                         MetricType::METRIC_TYPE_L2SQR>(quantizer,
-                                                        dim,
-                                                        count,
-                                                        numeric_error,
-                                                        related_error,
-                                                        true,
-                                                        unbounded_numeric_error_rate,
-                                                        unbounded_related_error_rate);
+                        MetricType::METRIC_TYPE_L2SQR>(quantizer_l2,
+                                                    dim,
+                                                    count,
+                                                    numeric_error,
+                                                    unbounded_related_error_rate);
             REQUIRE_THROWS(TestComputeCodes<RaBitQuantizer<MetricType::METRIC_TYPE_L2SQR>,
                                             MetricType::METRIC_TYPE_L2SQR>(
-                quantizer, dim, count, numeric_error, false));
+                quantizer_l2, dim, count, numeric_error, false));
         }
     }
 }
@@ -112,7 +152,7 @@ TEST_CASE("RaBitQ Serialize and Deserialize", "[ut][RaBitQuantizer]") {
     bool use_fht = GENERATE(true, false);
     auto num_bits_per_dim = GENERATE(4, 32);
     for (auto dim : dims) {
-        float numeric_error = 0.01 / std::sqrt(dim) * dim;
+        float numeric_error = 1 / std::sqrt(dim) * dim;
         float related_error = 0.05f;
         float unbounded_numeric_error_rate = 0.05f;
         float unbounded_related_error_rate = 0.1f;
@@ -139,6 +179,37 @@ TEST_CASE("RaBitQ Serialize and Deserialize", "[ut][RaBitQuantizer]") {
                                                                        unbounded_numeric_error_rate,
                                                                        unbounded_related_error_rate,
                                                                        true);
+            RaBitQuantizer<MetricType::METRIC_TYPE_IP> quantizer_ip1(
+                dim, dim, num_bits_per_dim, use_fht, allocator.get());
+            RaBitQuantizer<MetricType::METRIC_TYPE_IP> quantizer_ip2(
+                dim, dim, num_bits_per_dim, use_fht, allocator.get());
+
+            TestSerializeAndDeserialize<RaBitQuantizer<MetricType::METRIC_TYPE_IP>,
+                                        MetricType::METRIC_TYPE_IP>(quantizer_ip1,
+                                                                    quantizer_ip2,
+                                                                    dim,
+                                                                    count,
+                                                                    numeric_error,
+                                                                    related_error,
+                                                                    unbounded_numeric_error_rate,
+                                                                    unbounded_related_error_rate,
+                                                                    true);
+            RaBitQuantizer<MetricType::METRIC_TYPE_COSINE> quantizer_cos1(
+                dim, dim, num_bits_per_dim, use_fht, allocator.get());
+            RaBitQuantizer<MetricType::METRIC_TYPE_COSINE> quantizer_cos2(
+                dim, dim, num_bits_per_dim, use_fht, allocator.get());
+
+            TestSerializeAndDeserialize<RaBitQuantizer<MetricType::METRIC_TYPE_COSINE>,
+                                        MetricType::METRIC_TYPE_COSINE>(
+                quantizer_cos1,
+                quantizer_cos2,
+                dim,
+                count,
+                numeric_error,
+                related_error,
+                unbounded_numeric_error_rate,
+                unbounded_related_error_rate,
+                true);
         }
     }
 }

--- a/src/simd/avx.cpp
+++ b/src/simd/avx.cpp
@@ -946,10 +946,7 @@ VecRescale(float* data, size_t dim, float val) {
         __m256 result_vec = _mm256_mul_ps(data_vec, val_vec);
         _mm256_storeu_ps(&data[i], result_vec);
     }
-
-    for (; i < dim; i++) {
-        data[i] *= val;
-    }
+    sse::VecRescale(data + i, dim - i, val);
 #else
     return sse::VecRescale(data, dim, val);
 #endif

--- a/src/simd/avx2.cpp
+++ b/src/simd/avx2.cpp
@@ -1000,9 +1000,7 @@ VecRescale(float* data, size_t dim, float val) {
         __m256 result_vec = _mm256_mul_ps(data_vec, val_vec);
         _mm256_storeu_ps(&data[i], result_vec);
     }
-    for (; i < dim; i++) {
-        data[i] *= val;
-    }
+    sse::VecRescale(data + i, dim - i, val);
 #else
     return avx::VecRescale(data, dim, val);
 #endif

--- a/src/simd/avx512.cpp
+++ b/src/simd/avx512.cpp
@@ -1148,9 +1148,7 @@ VecRescale(float* data, size_t dim, float val) {
         vec = _mm512_mul_ps(vec, scalar);
         _mm512_storeu_ps(&data[i], vec);
     }
-    for (; i < dim; i++) {
-        data[i] *= val;
-    }
+    avx2::VecRescale(data + i, dim - i, val);
 #else
     return avx2::VecRescale(data, dim, val);
 #endif

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -420,9 +420,6 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HgraphTestIndex,
         for (auto& [base_quantization_str, recall] : test_cases) {
             INFO(fmt::format("quantizer str: {}", base_quantization_str));
             if (IsRaBitQ(base_quantization_str)) {
-                if (std::string(metric_type) != "l2") {
-                    continue;
-                }
                 if (dim <= fixtures::RABITQ_MIN_RACALL_DIM) {
                     dim += fixtures::RABITQ_MIN_RACALL_DIM;
                 }
@@ -452,9 +449,6 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HgraphTestIndex, "HGraph Train & Add Test
         for (auto& [base_quantization_str, recall] : test_cases) {
             INFO(fmt::format("quantizer str: {}", base_quantization_str));
             if (IsRaBitQ(base_quantization_str)) {
-                if (std::string(metric_type) != "l2") {
-                    continue;
-                }
                 if (dim <= fixtures::RABITQ_MIN_RACALL_DIM) {
                     dim += fixtures::RABITQ_MIN_RACALL_DIM;
                 }
@@ -525,9 +519,6 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HgraphTestIndex, "HGraph Build", "[ft][hg
         for (auto& [base_quantization_str, recall] : test_cases) {
             INFO(fmt::format("quantizer str: {}", base_quantization_str));
             if (IsRaBitQ(base_quantization_str)) {
-                if (std::string(metric_type) != "l2") {
-                    continue;
-                }
                 if (dim <= fixtures::RABITQ_MIN_RACALL_DIM) {
                     dim += fixtures::RABITQ_MIN_RACALL_DIM;
                 }
@@ -558,9 +549,6 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HgraphTestIndex, "HGraph Build With Attr"
         for (auto& [base_quantization_str, recall] : test_cases) {
             INFO(fmt::format("quantizer str: {}", base_quantization_str));
             if (IsRaBitQ(base_quantization_str)) {
-                if (std::string(metric_type) != "l2") {
-                    continue;
-                }
                 if (dim <= fixtures::RABITQ_MIN_RACALL_DIM) {
                     dim += fixtures::RABITQ_MIN_RACALL_DIM;
                 }
@@ -598,9 +586,6 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HgraphTestIndex, "HGraph ODescent Build",
         for (auto& [base_quantization_str, recall] : test_cases) {
             INFO(fmt::format("quantizer str: {}", base_quantization_str));
             if (IsRaBitQ(base_quantization_str)) {
-                if (std::string(metric_type) != "l2") {
-                    continue;
-                }
                 if (dim <= fixtures::RABITQ_MIN_RACALL_DIM) {
                     dim += fixtures::RABITQ_MIN_RACALL_DIM;
                 }
@@ -631,9 +616,6 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HgraphTestIndex, "HGraph Remove", "[ft][h
         for (auto& [base_quantization_str, recall] : test_cases) {
             INFO(fmt::format("quantizer str: {}", base_quantization_str));
             if (IsRaBitQ(base_quantization_str)) {
-                if (std::string(metric_type) != "l2") {
-                    continue;
-                }
                 if (dim <= fixtures::RABITQ_MIN_RACALL_DIM) {
                     dim += fixtures::RABITQ_MIN_RACALL_DIM;
                 }
@@ -666,9 +648,6 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HgraphTestIndex,
         for (auto& [base_quantization_str, recall] : test_cases) {
             INFO(fmt::format("quantizer str: {}", base_quantization_str));
             if (IsRaBitQ(base_quantization_str)) {
-                if (std::string(metric_type) != "l2") {
-                    continue;
-                }
                 if (dim <= fixtures::RABITQ_MIN_RACALL_DIM) {
                     dim += fixtures::RABITQ_MIN_RACALL_DIM;
                 }
@@ -696,9 +675,6 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HgraphTestIndex, "HGraph Graph Merge", "[
     for (auto dim : dims) {
         for (auto& [base_quantization_str, recall] : test_cases) {
             if (IsRaBitQ(base_quantization_str)) {
-                if (std::string(metric_type) != "l2") {
-                    continue;
-                }
                 if (dim <= fixtures::RABITQ_MIN_RACALL_DIM) {
                     dim += fixtures::RABITQ_MIN_RACALL_DIM;
                 }
@@ -731,9 +707,6 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HgraphTestIndex, "HGraph Add", "[ft][hgra
         for (auto& [base_quantization_str, recall] : test_cases) {
             INFO(fmt::format("quantizer str: {}", base_quantization_str));
             if (IsRaBitQ(base_quantization_str)) {
-                if (std::string(metric_type) != "l2") {
-                    continue;
-                }
                 if (dim <= fixtures::RABITQ_MIN_RACALL_DIM) {
                     dim += fixtures::RABITQ_MIN_RACALL_DIM;
                 }
@@ -768,9 +741,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HgraphTestIndex,
     for (auto& [base_quantization_str, recall] : test_cases) {
         INFO(fmt::format("quantizer str: {}", base_quantization_str));
         if (IsRaBitQ(base_quantization_str)) {
-            if (std::string(metric_type) != "l2") {
-                continue;
-            }
+
         }
         vsag::Options::Instance().set_block_size_limit(size);
         auto param = GenerateHGraphBuildParametersString(metric_type, dim, base_quantization_str);
@@ -816,9 +787,6 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HgraphTestIndex,
         for (auto& [base_quantization_str, recall] : test_cases) {
             INFO(fmt::format("quantizer str: {}", base_quantization_str));
             if (IsRaBitQ(base_quantization_str)) {
-                if (std::string(metric_type) != "l2") {
-                    continue;
-                }
                 if (dim <= fixtures::RABITQ_MIN_RACALL_DIM) {
                     dim += fixtures::RABITQ_MIN_RACALL_DIM;
                 }
@@ -854,9 +822,6 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HgraphTestIndex,
         for (auto& [base_quantization_str, recall] : test_cases) {
             INFO(fmt::format("quantizer str: {}", base_quantization_str));
             if (IsRaBitQ(base_quantization_str)) {
-                if (std::string(metric_type) != "l2") {
-                    continue;
-                }
                 if (dim <= fixtures::RABITQ_MIN_RACALL_DIM) {
                     dim += fixtures::RABITQ_MIN_RACALL_DIM;
                 }
@@ -898,9 +863,6 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HgraphTestIndex, "HGraph Clone", "[ft][hg
         for (auto& [base_quantization_str, recall] : test_cases) {
             INFO(fmt::format("quantizer str: {}", base_quantization_str));
             if (IsRaBitQ(base_quantization_str)) {
-                if (std::string(metric_type) != "l2") {
-                    continue;
-                }
                 if (dim <= fixtures::RABITQ_MIN_RACALL_DIM) {
                     dim += fixtures::RABITQ_MIN_RACALL_DIM;
                 }
@@ -936,9 +898,6 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HgraphTestIndex, "HGraph Export Model", "
         for (auto& [base_quantization_str, recall] : test_cases) {
             INFO(fmt::format("quantizer str: {}", base_quantization_str));
             if (IsRaBitQ(base_quantization_str)) {
-                if (std::string(metric_type) != "l2") {
-                    continue;
-                }
                 if (dim <= fixtures::RABITQ_MIN_RACALL_DIM) {
                     dim += fixtures::RABITQ_MIN_RACALL_DIM;
                 }
@@ -975,9 +934,6 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HgraphTestIndex,
         for (auto& [base_quantization_str, recall] : test_cases) {
             INFO(fmt::format("quantizer str: {}", base_quantization_str));
             if (IsRaBitQ(base_quantization_str)) {
-                if (std::string(metric_type) != "l2") {
-                    continue;
-                }
                 if (dim <= fixtures::RABITQ_MIN_RACALL_DIM) {
                     dim += fixtures::RABITQ_MIN_RACALL_DIM;
                 }
@@ -1010,9 +966,6 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HgraphTestIndex, "HGraph Duplicate Build"
         for (auto& [base_quantization_str, recall] : test_cases) {
             INFO(fmt::format("quantizer str: {}", base_quantization_str));
             if (IsRaBitQ(base_quantization_str)) {
-                if (std::string(metric_type) != "l2") {
-                    continue;
-                }
                 if (dim <= fixtures::RABITQ_MIN_RACALL_DIM) {
                     dim += fixtures::RABITQ_MIN_RACALL_DIM;
                 }
@@ -1046,9 +999,6 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HgraphTestIndex, "HGraph Estimate Memory"
         for (auto& [base_quantization_str, recall] : test_cases) {
             INFO(fmt::format("quantizer str: {}", base_quantization_str));
             if (IsRaBitQ(base_quantization_str)) {
-                if (std::string(metric_type) != "l2") {
-                    continue;
-                }
                 if (dim <= fixtures::RABITQ_MIN_RACALL_DIM) {
                     dim += fixtures::RABITQ_MIN_RACALL_DIM;
                 }
@@ -1158,9 +1108,6 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HgraphTestIndex, "HGraph With Extra Info"
         for (auto& [base_quantization_str, recall] : test_cases) {
             INFO(fmt::format("quantizer str: {}", base_quantization_str));
             if (IsRaBitQ(base_quantization_str)) {
-                if (std::string(metric_type) != "l2") {
-                    continue;
-                }
                 if (dim <= fixtures::RABITQ_MIN_RACALL_DIM) {
                     dim += fixtures::RABITQ_MIN_RACALL_DIM;
                 }
@@ -1204,9 +1151,6 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HgraphTestIndex,
     for (auto dim : dims) {
         for (auto& [memory_io_str, disk_io_str] : io_cases) {
             if (IsRaBitQ(memory_io_str)) {
-                if (std::string(metric_type) != "l2") {
-                    continue;
-                }
                 if (dim <= fixtures::RABITQ_MIN_RACALL_DIM) {
                     dim += fixtures::RABITQ_MIN_RACALL_DIM;
                 }

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -741,7 +741,10 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HgraphTestIndex,
     for (auto& [base_quantization_str, recall] : test_cases) {
         INFO(fmt::format("quantizer str: {}", base_quantization_str));
         if (IsRaBitQ(base_quantization_str)) {
+<<<<<<< HEAD
 
+=======
+>>>>>>> e0516ac (fmt)
         }
         vsag::Options::Instance().set_block_size_limit(size);
         auto param = GenerateHGraphBuildParametersString(metric_type, dim, base_quantization_str);

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -741,10 +741,6 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HgraphTestIndex,
     for (auto& [base_quantization_str, recall] : test_cases) {
         INFO(fmt::format("quantizer str: {}", base_quantization_str));
         if (IsRaBitQ(base_quantization_str)) {
-<<<<<<< HEAD
-
-=======
->>>>>>> e0516ac (fmt)
         }
         vsag::Options::Instance().set_block_size_limit(size);
         auto param = GenerateHGraphBuildParametersString(metric_type, dim, base_quantization_str);


### PR DESCRIPTION
```+------------+--------+------------+-----+----------+------------+----------------------------------------+---------------+------------+--------------+------------------------------+----------------+-------------+----------------+-----------+
| Name       | Index  | NumVectors | Dim | DataType | MetricType | IndexParam                             | Memory(build) | BuildTime  | TPS          | SearchParam                  | Memory(search) | QPS         | LatencyAvg(ms) | RecallAvg |
+------------+--------+------------+-----+----------+------------+----------------------------------------+---------------+------------+--------------+------------------------------+----------------+-------------+----------------+-----------+
| eval_case1 | hgraph | 1000000    | 768 | float32  | cosine     | {"base_quantization_type":"rabitq","e- | 6.47 GB       | 250.305496 | 3995.117920  | {"hgraph":{"ef_search":100}} | 6.77 GB        | 496.930420  | 2.012354       | 0.960400  |
|            |        |            |     |          |            | f_construction":200,"ignore_reorder":- |               |            |              |                              |                |             |                |           |
|            |        |            |     |          |            | false,"max_degree":32,"precise_io_typ- |               |            |              |                              |                |             |                |           |
|            |        |            |     |          |            | e":"block_memory_io","precise_quantiz- |               |            |              |                              |                |             |                |           |
|            |        |            |     |          |            | ation_type":"fp32","rabitq_use_fht":t- |               |            |              |                              |                |             |                |           |
|            |        |            |     |          |            | rue,"use_reorder":true}                |               |            |              |                              |                |             |                |           |
+------------+--------+------------+-----+----------+------------+----------------------------------------+---------------+------------+--------------+------------------------------+----------------+-------------+----------------+-----------+
| ip         | hgraph | 1000000    | 768 | float32  | ip         | {"base_quantization_type":"rabitq","e- | 6.08 GB       | 298.632233 | 3348.600342  | {"hgraph":{"ef_search":100}} | 6.36 GB        | 1380.080078 | 0.724596       | 1.000000  |
|            |        |            |     |          |            | f_construction":200,"ignore_reorder":- |               |            |              |                              |                |             |                |           |
|            |        |            |     |          |            | false,"max_degree":32,"precise_io_typ- |               |            |              |                              |                |             |                |           |
|            |        |            |     |          |            | e":"block_memory_io","precise_quantiz- |               |            |              |                              |                |             |                |           |
|            |        |            |     |          |            | ation_type":"fp32","rabitq_use_fht":t- |               |            |              |                              |                |             |                |           |
|            |        |            |     |          |            | rue,"use_reorder":true}                |               |            |              |                              |                |             |                |           |
+------------+--------+------------+-----+----------+------------+----------------------------------------+---------------+------------+--------------+------------------------------+----------------+-------------+----------------+-----------+
| ip2        | hgraph | 1000000    | 128 | float32  | l2         | {"base_quantization_type":"rabitq","e- | 1.30 GB       | 98.800980  | 10121.357422 | {"hgraph":{"ef_search":100}} | 1.49 GB        | 2564.886230 | 0.389881       | 0.745080  |
|            |        |            |     |          |            | f_construction":200,"ignore_reorder":- |               |            |              |                              |                |             |                |           |
|            |        |            |     |          |            | false,"max_degree":32,"precise_io_typ- |               |            |              |                              |                |             |                |           |
|            |        |            |     |          |            | e":"block_memory_io","precise_quantiz- |               |            |              |                              |                |             |                |           |
|            |        |            |     |          |            | ation_type":"fp32","rabitq_use_fht":t- |               |            |              |                              |                |             |                |           |
|            |        |            |     |          |            | rue,"use_reorder":true}                |               |            |              |                              |                |             |                |           |
+------------+--------+------------+-----+----------+------------+----------------------------------------+---------------+------------+--------------+------------------------------+----------------+-------------+----------------+-----------+
```
local test meets the expectation

cp the pull request (#892) to 0.15