### PR TITLE
optimize IteratorFilterContext bitmap memory usage

### DIFF
--- a/src/index/iterator_filter.cpp
+++ b/src/index/iterator_filter.cpp
@@ -16,11 +16,16 @@
 #include "iterator_filter.h"
 
 #include "logger.h"
+#include "utils/util_functions.h"
 
 namespace vsag {
 
 IteratorFilterContext::~IteratorFilterContext() {
-    allocator_->Deallocate(list_);
+    if (nullptr != allocator_) {
+        if (nullptr != list_) {
+            allocator_->Deallocate(list_);
+        }
+    }
 }
 
 tl::expected<void, Error>
@@ -34,9 +39,9 @@ IteratorFilterContext::init(InnerIdType max_size, int64_t ef_search, Allocator* 
         allocator_ = allocator;
         max_size_ = max_size;
         discard_ = std::make_unique<MaxHeap>(allocator);
-        list_ = reinterpret_cast<VisitedListType*>(
-            allocator_->Allocate((uint64_t)max_size * sizeof(VisitedListType)));
-        memset(list_, 0, max_size * sizeof(VisitedListType));
+        size_t byte_len = ceil_int(max_size, BITS_PER_BYTE) / BITS_PER_BYTE;
+        list_ = reinterpret_cast<uint8_t*>(allocator_->Allocate(byte_len));
+        memset(list_, 0, byte_len);
     } catch (const std::bad_alloc& e) {
         LOG_ERROR_AND_RETURNS(ErrorType::NO_ENOUGH_MEMORY,
                               "failed to init iterator filter(not enough memory): ",
@@ -89,12 +94,12 @@ IteratorFilterContext::SetOFFFirstUsed() {
 
 void
 IteratorFilterContext::SetPoint(InnerIdType inner_id) {
-    list_[inner_id] = 1;
+    list_[byte_pos(inner_id)] |= (1 << bit_pos(inner_id));
 }
 
 bool
 IteratorFilterContext::CheckPoint(InnerIdType inner_id) {
-    return list_[inner_id] == 0;
+    return (list_[byte_pos(inner_id)] & (1 << bit_pos(inner_id))) == 0;
 }
 
 int64_t

--- a/src/index/iterator_filter.h
+++ b/src/index/iterator_filter.h
@@ -28,9 +28,6 @@ namespace vsag {
 
 class IteratorFilterContext : public IteratorContext {
 public:
-    using VisitedListType = uint16_t;
-
-public:
     IteratorFilterContext() : is_first_used_(true){};
     ~IteratorFilterContext();
 
@@ -68,11 +65,25 @@ public:
     GetDiscardElementNum();
 
 private:
+    constexpr static uint32_t BITS_PER_BYTE = 8;
+    constexpr static uint32_t BYTE_POS_MASK = 3;  // 2^3
+    constexpr static uint32_t BIT_POS_MASK = BITS_PER_BYTE - 1;
+
+    static inline uint32_t
+    byte_pos(uint32_t pos) {
+        return pos >> BYTE_POS_MASK;
+    }
+    static inline uint32_t
+    bit_pos(uint32_t pos) {
+        return pos & BIT_POS_MASK;
+    }
+
+private:
     int64_t ef_search_{-1};
     bool is_first_used_{true};
     uint32_t max_size_{0};
     Allocator* allocator_{nullptr};
-    VisitedListType* list_{nullptr};
+    uint8_t* list_{nullptr};
     std::unique_ptr<MaxHeap> discard_;
 };
 

--- a/src/index/iterator_filter_test.cpp
+++ b/src/index/iterator_filter_test.cpp
@@ -23,7 +23,7 @@
 
 using namespace vsag;
 
-TEST_CASE("Iterator context", "[ut][hnsw]") {
+TEST_CASE("Iterator context", "[ut][hnsw][filter]") {
     auto allocator = std::make_shared<DefaultAllocator>();
     vsag::IteratorFilterContext filter_context = IteratorFilterContext();
     uint32_t max_size = 1000;
@@ -58,4 +58,28 @@ TEST_CASE("Iterator context", "[ut][hnsw]") {
         REQUIRE(filter_context.GetDiscardElementNum() == num_elements - 1);
         REQUIRE(filter_context.CheckPoint(55));
     }
+}
+
+TEST_CASE("Empty Iterator Context Destruction", "[ut][hnsw][filter]") {
+    IteratorFilterContext filter_context = IteratorFilterContext();
+}
+
+TEST_CASE("Iterator Context CheckPoint And SetPoint", "[ut][hnsw][filter]") {
+    auto allocator = std::make_shared<DefaultAllocator>();
+    IteratorFilterContext filter_context = IteratorFilterContext();
+    uint32_t max_size = 1000;
+    int64_t ef_search = 200;
+    auto res = filter_context.init(max_size, ef_search, allocator.get());
+    REQUIRE(res.has_value());
+    REQUIRE(filter_context.CheckPoint(100));
+    filter_context.SetPoint(100);
+    REQUIRE_FALSE(filter_context.CheckPoint(100));
+
+    REQUIRE(filter_context.CheckPoint(128));
+    filter_context.SetPoint(128);
+    REQUIRE_FALSE(filter_context.CheckPoint(128));
+
+    REQUIRE(filter_context.CheckPoint(3));
+    filter_context.SetPoint(3);
+    REQUIRE_FALSE(filter_context.CheckPoint(3));
 }


### PR DESCRIPTION
The current memory overhead of bitmap in IteratorFilterContext is max_size * sizeof(uint16_t). This overhead is too high when there are a large number of vectors, such as tens of millions. Therefore, it is changed to a 1-bit implementation