### PR TITLE
Add PSO training mode to ScalarQuantizationTrainer

### DIFF
--- a/src/quantization/scalar_quantization/scalar_quantization_trainer.cpp
+++ b/src/quantization/scalar_quantization/scalar_quantization_trainer.cpp
@@ -49,6 +49,7 @@ ScalarQuantizationTrainer::pso_train(const float* data,
                                      uint64_t count,
                                      float* upper_bound,
                                      float* lower_bound) const {
+    this->classic_train(data, count, upper_bound, lower_bound);
     float div = (1 << this->bits_) - 1;
 
 #pragma omp parallel for

--- a/src/quantization/scalar_quantization/scalar_quantization_trainer.cpp
+++ b/src/quantization/scalar_quantization/scalar_quantization_trainer.cpp
@@ -39,6 +39,137 @@ ScalarQuantizationTrainer::Train(const float* data,
         this->classic_train(sample_datas.data(), sample_count, upper_bound, lower_bound);
     } else if (mode == TRUNC_BOUND) {
         this->trunc_bound_train(sample_datas.data(), sample_count, upper_bound, lower_bound);
+    } else if (mode == PSO) {
+        this->pso_train(sample_datas.data(), sample_count, upper_bound, lower_bound);
+    }
+}
+
+void
+ScalarQuantizationTrainer::pso_train(const float* data,
+                                     uint64_t count,
+                                     float* upper_bound,
+                                     float* lower_bound) const {
+    float div = (1 << this->bits_) - 1;
+
+#pragma omp parallel for
+    for (uint64_t i = 0; i < dim_; ++i) {
+        float init_upper_bound = upper_bound[i];
+        float init_lower_bound = lower_bound[i];
+        const float init_range_width = init_upper_bound - init_lower_bound;
+        const float init_range_center = (init_lower_bound + init_upper_bound) * 0.5f;
+
+        std::random_device rd;
+        std::mt19937 gen(rd());
+        std::uniform_real_distribution<float> v_dis(-init_range_width * 0.1f,
+                                                    init_range_width * 0.1f);
+        std::uniform_real_distribution<float> p_dis(0.0f, 1.0f);
+
+        constexpr size_t max_iter = 128;
+        constexpr size_t grid_side_length = 8;
+        constexpr float grid_scale_factor = 0.1f;
+        constexpr float init_inertia = 0.9f;
+        constexpr float final_inertia = 0.4f;
+        constexpr float c1 = 1.8f;
+        constexpr float c2 = 1.8f;
+
+        auto loss = [=](float center, float width) {
+            float step_size = width / div;
+            step_size = std::max(step_size, 1e-8f);
+            float total_loss = 0.0f;
+            for (uint64_t j = 0; j < count; ++j) {
+                float value = data[j * dim_ + i];
+                float quantized_code = std::round((value - center) / step_size);
+                quantized_code = std::min(quantized_code, div);
+                quantized_code = std::max(quantized_code, 0.0f);
+                float error = (value - (center + quantized_code * step_size)) *
+                              (value - (center + quantized_code * step_size));
+                total_loss += error;
+            }
+            return total_loss * step_size * step_size;
+        };
+
+        struct Particle {
+            float center;
+            float width;
+            float v_center;
+            float v_width;
+            float best_center;
+            float best_width;
+            float min_loss;
+
+            Particle(const float c_val, const float w_val, const float vc_val, const float vw_val)
+                : center(c_val),
+                  width(w_val),
+                  v_center(vc_val),
+                  v_width(vw_val),
+                  best_center(c_val),
+                  best_width(w_val),
+                  min_loss(std::numeric_limits<float>::max()) {
+            }
+        };
+
+        std::vector<Particle> swarm;
+        swarm.reserve(grid_side_length * grid_side_length);
+        for (size_t m = 0; m < grid_side_length; ++m) {
+            for (size_t n = 0; n < grid_side_length; ++n) {
+                float lower = init_lower_bound - grid_scale_factor * init_range_width +
+                              static_cast<float>(m) * 2 * grid_scale_factor * init_range_width /
+                                  grid_side_length;
+                float upper = init_upper_bound - grid_scale_factor * init_range_width +
+                              static_cast<float>(n) * 2 * grid_scale_factor * init_range_width /
+                                  grid_side_length;
+                float particle_center = (lower + upper) * 0.5f;
+                float particle_width = upper - lower;
+                swarm.emplace_back(particle_center, particle_width, v_dis(gen), v_dis(gen));
+            }
+        }
+
+        float global_best_center = init_range_center;
+        float global_best_width = init_range_width;
+        float global_min_loss = loss(init_range_center, init_range_width);
+        for (auto& particle : swarm) {
+            float curr_lower = particle.center - particle.width * 0.5f;
+            float curr_loss = loss(particle.center, particle.width);
+            particle.min_loss = curr_loss;
+            if (curr_loss < global_min_loss) {
+                global_min_loss = curr_loss;
+                global_best_center = particle.center;
+                global_best_width = particle.width;
+            }
+        }
+
+        for (size_t iter = 0; iter < max_iter; ++iter) {
+            float inertia =
+                init_inertia - (init_inertia - final_inertia) * static_cast<float>(iter) / max_iter;
+            for (auto& particle : swarm) {
+                float r1 = p_dis(gen);
+                float r2 = p_dis(gen);
+                particle.v_center = inertia * particle.v_center +
+                                    c1 * r1 * (particle.best_center - particle.center) +
+                                    c2 * r2 * (global_best_center - particle.center);
+                particle.v_width = inertia * particle.v_width +
+                                   c1 * r1 * (particle.best_width - particle.width) +
+                                   c2 * r2 * (global_best_width - particle.width);
+                particle.center += particle.v_center;
+                particle.width += particle.v_width;
+                if (particle.width <= std::numeric_limits<float>::epsilon()) {
+                    particle.width = std::numeric_limits<float>::epsilon();
+                }
+                float curr_loss = loss(particle.center, particle.width);
+                if (curr_loss < particle.min_loss) {
+                    particle.min_loss = curr_loss;
+                    particle.best_center = particle.center;
+                    particle.best_width = particle.width;
+                }
+                if (curr_loss < global_min_loss) {
+                    global_min_loss = curr_loss;
+                    global_best_center = particle.center;
+                    global_best_width = particle.width;
+                }
+            }
+        }
+        lower_bound[i] = global_best_center - global_best_width * 0.5f;
+        upper_bound[i] = global_best_center + global_best_width * 0.5f;
     }
 }
 
@@ -59,6 +190,14 @@ ScalarQuantizationTrainer::TrainUniform(const float* data,
         lower_bound = *std::min_element(lower.begin(), lower.end());
     } else if (mode == TRUNC_BOUND) {
         this->trunc_bound_train(sample_datas.data(), sample_count, upper.data(), lower.data());
+        upper_bound = *std::min_element(upper.begin(), upper.end());
+        lower_bound = *std::max_element(lower.begin(), lower.end());
+        if (lower_bound > upper_bound) {
+            // case for count == 1 or trunc_rate > 0.5
+            std::swap(lower_bound, upper_bound);
+        }
+    } else if (mode == PSO) {
+        this->pso_train(sample_datas.data(), sample_count, upper.data(), lower.data());
         upper_bound = *std::min_element(upper.begin(), upper.end());
         lower_bound = *std::max_element(lower.begin(), lower.end());
         if (lower_bound > upper_bound) {

--- a/src/quantization/scalar_quantization/scalar_quantization_trainer.cpp
+++ b/src/quantization/scalar_quantization/scalar_quantization_trainer.cpp
@@ -49,14 +49,39 @@ ScalarQuantizationTrainer::pso_train(const float* data,
                                      uint64_t count,
                                      float* upper_bound,
                                      float* lower_bound) const {
-    return pso_train_impl(data, count, upper_bound, lower_bound);
+    constexpr size_t max_iter = 128;
+    constexpr size_t grid_side_length = 8;
+    constexpr float grid_scale_factor = 0.1f;
+    constexpr float init_inertia = 0.9f;
+    constexpr float final_inertia = 0.4f;
+    constexpr float c1 = 1.8f;
+    constexpr float c2 = 1.8f;
+
+    return pso_train_impl(data,
+                          count,
+                          upper_bound,
+                          lower_bound,
+                          max_iter,
+                          grid_side_length,
+                          grid_scale_factor,
+                          init_inertia,
+                          final_inertia,
+                          c1,
+                          c2);
 }
 
 void
 ScalarQuantizationTrainer::pso_train_impl(const float* data,
                                           uint64_t count,
                                           float* upper_bound,
-                                          float* lower_bound) const {
+                                          float* lower_bound,
+                                          size_t max_iter,
+                                          size_t grid_side_length,
+                                          float grid_scale_factor,
+                                          float init_inertia,
+                                          float final_inertia,
+                                          float c1,
+                                          float c2) const {
     this->classic_train(data, count, upper_bound, lower_bound);
     float div = (1 << this->bits_) - 1;
 
@@ -72,14 +97,6 @@ ScalarQuantizationTrainer::pso_train_impl(const float* data,
         std::uniform_real_distribution<float> v_dis(-init_range_width * 0.1f,
                                                     init_range_width * 0.1f);
         std::uniform_real_distribution<float> p_dis(0.0f, 1.0f);
-
-        constexpr size_t max_iter = 128;
-        constexpr size_t grid_side_length = 8;
-        constexpr float grid_scale_factor = 0.1f;
-        constexpr float init_inertia = 0.9f;
-        constexpr float final_inertia = 0.4f;
-        constexpr float c1 = 1.8f;
-        constexpr float c2 = 1.8f;
 
         auto loss = [=](float center, float width) {
             float step_size = width / div;

--- a/src/quantization/scalar_quantization/scalar_quantization_trainer.cpp
+++ b/src/quantization/scalar_quantization/scalar_quantization_trainer.cpp
@@ -49,6 +49,14 @@ ScalarQuantizationTrainer::pso_train(const float* data,
                                      uint64_t count,
                                      float* upper_bound,
                                      float* lower_bound) const {
+    return pso_train_impl(data, count, upper_bound, lower_bound);
+}
+
+void
+ScalarQuantizationTrainer::pso_train_impl(const float* data,
+                                          uint64_t count,
+                                          float* upper_bound,
+                                          float* lower_bound) const {
     this->classic_train(data, count, upper_bound, lower_bound);
     float div = (1 << this->bits_) - 1;
 

--- a/src/quantization/scalar_quantization/scalar_quantization_trainer.h
+++ b/src/quantization/scalar_quantization/scalar_quantization_trainer.h
@@ -71,6 +71,9 @@ private:
     void
     pso_train(const float* data, uint64_t count, float* upper_bound, float* lower_bound) const;
 
+    void
+    pso_train_impl(const float* data, uint64_t count, float* upper_bound, float* lower_bound) const;
+
     uint64_t
     sample_train_data(const float* data,
                       uint64_t count,

--- a/src/quantization/scalar_quantization/scalar_quantization_trainer.h
+++ b/src/quantization/scalar_quantization/scalar_quantization_trainer.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <cstdint>
+#include <vector>
 
 #include "typing.h"
 
@@ -72,7 +73,17 @@ private:
     pso_train(const float* data, uint64_t count, float* upper_bound, float* lower_bound) const;
 
     void
-    pso_train_impl(const float* data, uint64_t count, float* upper_bound, float* lower_bound) const;
+    pso_train_impl(const float* data,
+                   uint64_t count,
+                   float* upper_bound,
+                   float* lower_bound,
+                   size_t max_iter,
+                   size_t grid_side_length,
+                   float grid_scale_factor,
+                   float init_inertia,
+                   float final_inertia,
+                   float c1,
+                   float c2) const;
 
     uint64_t
     sample_train_data(const float* data,

--- a/src/quantization/scalar_quantization/scalar_quantization_trainer.h
+++ b/src/quantization/scalar_quantization/scalar_quantization_trainer.h
@@ -59,7 +59,6 @@ public:
         this->trunc_rate_ = trunc_rate;
     }
 
-private:
     void
     classic_train(const float* data, uint64_t count, float* upper_bound, float* lower_bound) const;
 
@@ -72,6 +71,7 @@ private:
     void
     pso_train(const float* data, uint64_t count, float* upper_bound, float* lower_bound) const;
 
+private:
     void
     pso_train_impl(const float* data,
                    uint64_t count,

--- a/src/quantization/scalar_quantization/scalar_quantization_trainer.h
+++ b/src/quantization/scalar_quantization/scalar_quantization_trainer.h
@@ -59,6 +59,7 @@ public:
         this->trunc_rate_ = trunc_rate;
     }
 
+private:
     void
     classic_train(const float* data, uint64_t count, float* upper_bound, float* lower_bound) const;
 
@@ -71,7 +72,6 @@ public:
     void
     pso_train(const float* data, uint64_t count, float* upper_bound, float* lower_bound) const;
 
-private:
     void
     pso_train_impl(const float* data,
                    uint64_t count,

--- a/src/quantization/scalar_quantization/scalar_quantization_trainer.h
+++ b/src/quantization/scalar_quantization/scalar_quantization_trainer.h
@@ -25,6 +25,7 @@ enum SQTrainMode {
     CLASSIC = 1,
     K_MEANS = 2,
     TRUNC_BOUND = 3,
+    PSO = 4,
 };
 
 class ScalarQuantizationTrainer {
@@ -37,7 +38,7 @@ public:
           float* upper_bound,
           float* lower_bound,
           bool need_normalize = false,
-          SQTrainMode mode = SQTrainMode::TRUNC_BOUND);
+          SQTrainMode mode = SQTrainMode::PSO);  // suggest to use PSO
 
     void
     TrainUniform(const float* data,
@@ -66,6 +67,9 @@ private:
                       uint64_t count,
                       float* upper_bound,
                       float* lower_bound) const;
+
+    void
+    pso_train(const float* data, uint64_t count, float* upper_bound, float* lower_bound) const;
 
     uint64_t
     sample_train_data(const float* data,

--- a/src/quantization/scalar_quantization/scalar_quantization_trainer.h
+++ b/src/quantization/scalar_quantization/scalar_quantization_trainer.h
@@ -38,7 +38,7 @@ public:
           float* upper_bound,
           float* lower_bound,
           bool need_normalize = false,
-          SQTrainMode mode = SQTrainMode::PSO);  // suggest to use PSO
+          SQTrainMode mode = SQTrainMode::TRUNC_BOUND);
 
     void
     TrainUniform(const float* data,

--- a/src/quantization/scalar_quantization/scalar_quantization_trainer_test.cpp
+++ b/src/quantization/scalar_quantization/scalar_quantization_trainer_test.cpp
@@ -56,15 +56,15 @@ TEST_CASE("ScalarQuantizationTrainer", "[ft][scalar_quantization_trainer]") {
     vsag::ScalarQuantizationTrainer trainer(1, bits);
 
     // CLASSIC
-    trainer.Train(data.data(), data.size(), &lower_c, &upper_c, vsag::SQTrainMode::CLASSIC);
+    trainer.Train(data.data(), data.size(), &upper_c, &lower_c, vsag::SQTrainMode::CLASSIC);
     float mse_classic = compute_mse(data, lower_c, upper_c, bits);
 
     // TRUNC_BOUND
-    trainer.Train(data.data(), data.size(), &lower_t, &upper_t, vsag::SQTrainMode::TRUNC_BOUND);
+    trainer.Train(data.data(), data.size(), &upper_t, &lower_t, vsag::SQTrainMode::TRUNC_BOUND);
     float mse_trunc = compute_mse(data, lower_t, upper_t, bits);
 
     // PSO
-    trainer.Train(data.data(), data.size(), &lower_p, &upper_p, vsag::SQTrainMode::PSO);
+    trainer.Train(data.data(), data.size(), &upper_p, &lower_p, vsag::SQTrainMode::PSO);
     float mse_pso = compute_mse(data, lower_p, upper_p, bits);
 
     REQUIRE(lower_c <= upper_c);

--- a/src/quantization/scalar_quantization/scalar_quantization_trainer_test.cpp
+++ b/src/quantization/scalar_quantization/scalar_quantization_trainer_test.cpp
@@ -54,15 +54,15 @@ TEST_CASE("ScalarQuantizationTrainer", "[ft][scalar_quantization_trainer]") {
     ScalarQuantizationTrainer trainer(1, bits);
 
     // CLASSIC
-    trainer.classic_train(data.data(), data.size(), upper_c, lower_c);
+    trainer.Train(data.data(), data.size(), upper_c, lower_c, false, vsag::CLASSIC);
     float mse_classic = compute_mse(data, lower_c[0], upper_c[0], bits);
 
     // TRUNC_BOUND
-    trainer.trunc_bound_train(data.data(), data.size(), upper_t, lower_t);
+    trainer.Train(data.data(), data.size(), upper_t, lower_t, false, vsag::TRUNC_BOUND);
     float mse_trunc = compute_mse(data, lower_t[0], upper_t[0], bits);
 
     // PSO
-    trainer.pso_train(data.data(), data.size(), upper_p, lower_p);
+    trainer.Train(data.data(), data.size(), upper_p, lower_p, false, vsag::PSO);
     float mse_pso = compute_mse(data, lower_p[0], upper_p[0], bits);
 
     REQUIRE(lower_c <= upper_c);

--- a/src/quantization/scalar_quantization/scalar_quantization_trainer_test.cpp
+++ b/src/quantization/scalar_quantization/scalar_quantization_trainer_test.cpp
@@ -25,8 +25,6 @@
 #include <random>
 #include <vector>
 
-#include "vsag/vsag.h"
-
 using namespace vsag;
 
 float
@@ -71,6 +69,6 @@ TEST_CASE("ScalarQuantizationTrainer", "[ft][scalar_quantization_trainer]") {
     REQUIRE(lower_t <= upper_t);
     REQUIRE(lower_p <= upper_p);
 
-    REQUIRE(mse_pso < mse_classic * 0.95);
-    REQUIRE(mse_pso < mse_trunc);
+    REQUIRE(mse_pso <= mse_classic * 0.95);
+    REQUIRE(mse_pso <= mse_trunc);
 }

--- a/src/quantization/scalar_quantization/scalar_quantization_trainer_test.cpp
+++ b/src/quantization/scalar_quantization/scalar_quantization_trainer_test.cpp
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "scalar_quantization_trainer.h"
+
 #include <algorithm>
 #include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
@@ -23,7 +25,6 @@
 #include <random>
 #include <vector>
 
-#include "quantization/scalar_quantization/scalar_quantization_trainer.h"
 #include "vsag/vsag.h"
 
 using namespace vsag;
@@ -50,17 +51,22 @@ TEST_CASE("ScalarQuantizationTrainer", "[ft][scalar_quantization_trainer]") {
         data.push_back(dist(gen));
     }
     int bits = 4;
-    float lower_c, upper_c, lower_p, upper_p;
+    float lower_c, upper_c, lower_t, upper_t, lower_p, upper_p;
 
     vsag::ScalarQuantizationTrainer trainer(1, bits);
 
-    // classic
+    // CLASSIC
     trainer.Train(data.data(), data.size(), &lower_c, &upper_c, vsag::SQTrainMode::CLASSIC);
     float mse_classic = compute_mse(data, lower_c, upper_c, bits);
+
+    // TRUNC_BOUND
+    trainer.Train(data.data(), data.size(), &lower_t, &upper_t, vsag::SQTrainMode::TRUNC_BOUND);
+    float mse_trunc = compute_mse(data, lower_t, upper_t, bits);
 
     // PSO
     trainer.Train(data.data(), data.size(), &lower_p, &upper_p, vsag::SQTrainMode::PSO);
     float mse_pso = compute_mse(data, lower_p, upper_p, bits);
 
     REQUIRE(mse_pso < mse_classic * 0.95);
+    REQUIRE(mse_pso < mse_trunc);
 }

--- a/src/quantization/scalar_quantization/scalar_quantization_trainer_test.cpp
+++ b/src/quantization/scalar_quantization/scalar_quantization_trainer_test.cpp
@@ -67,6 +67,10 @@ TEST_CASE("ScalarQuantizationTrainer", "[ft][scalar_quantization_trainer]") {
     trainer.Train(data.data(), data.size(), &lower_p, &upper_p, vsag::SQTrainMode::PSO);
     float mse_pso = compute_mse(data, lower_p, upper_p, bits);
 
+    REQUIRE(lower_c <= upper_c);
+    REQUIRE(lower_t <= upper_t);
+    REQUIRE(lower_p <= upper_p);
+
     REQUIRE(mse_pso < mse_classic * 0.95);
     REQUIRE(mse_pso < mse_trunc);
 }

--- a/tests/test_scalar_quantization_trainer.cpp
+++ b/tests/test_scalar_quantization_trainer.cpp
@@ -1,0 +1,66 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <algorithm>
+#include <catch2/catch_message.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <cstdint>
+#include <fstream>
+#include <iostream>
+#include <numeric>
+#include <random>
+#include <vector>
+
+#include "quantization/scalar_quantization/scalar_quantization_trainer.h"
+#include "vsag/vsag.h"
+
+using namespace vsag;
+
+float
+compute_mse(const std::vector<float>& data, float lower, float upper, int bits) {
+    float div = (1 << bits) - 1;
+    float step = (upper - lower) / div;
+    float mse = 0.0f;
+    for (float v : data) {
+        float code = std::round((v - lower) / step);
+        code = std::min(std::max(code, 0.0f), div);
+        float recon = lower + code * step;
+        mse += (v - recon) * (v - recon);
+    }
+    return mse / data.size();
+}
+
+TEST_CASE("ScalarQuantizationTrainer", "[ft][scalar_quantization_trainer]") {
+    std::vector<float> data;
+    std::mt19937 gen(42);
+    std::normal_distribution<float> dist(0.0f, 1.0f);
+    for (int i = 0; i < 1000; ++i) {
+        data.push_back(dist(gen));
+    }
+    int bits = 4;
+    float lower_c, upper_c, lower_p, upper_p;
+
+    vsag::ScalarQuantizationTrainer trainer(1, bits);
+
+    // classic
+    trainer.Train(data.data(), data.size(), &lower_c, &upper_c, vsag::SQTrainMode::CLASSIC);
+    float mse_classic = compute_mse(data, lower_c, upper_c, bits);
+
+    // PSO
+    trainer.Train(data.data(), data.size(), &lower_p, &upper_p, vsag::SQTrainMode::PSO);
+    float mse_pso = compute_mse(data, lower_p, upper_p, bits);
+
+    REQUIRE(mse_pso < mse_classic * 0.95);
+}


### PR DESCRIPTION
Traditional training methods or TRUNC's training approach are unable to adapt to complex data distributions. We introduce machine learning algorithms to train the error parameters of SQ, and testing results demonstrate that the mean squared error achieves below 95% of the original error.

Why Choose the PSO Algorithm?

In my latest paper, I compared the PSO algorithm with an EM-like boundary training algorithm used in the Faiss library. I found that, under the same training time, the MSE of the PSO algorithm was lower than that of Faiss on the SIFT, Word2Vec, GIST, MSong, ImageNet, and Deep datasets. This is attributed to the swarm intelligence of PSO, which helps avoid local optima.