### PR TITLE
make thirdparty library static

### DIFF
--- a/extern/cpuinfo/cpuinfo.cmake
+++ b/extern/cpuinfo/cpuinfo.cmake
@@ -16,6 +16,7 @@ set(CPUINFO_BUILD_UNIT_TESTS OFF CACHE BOOL "Disable some option in the library"
 set(CPUINFO_BUILD_MOCK_TESTS OFF CACHE BOOL "Disable some option in the library" FORCE)
 set(CPUINFO_BUILD_BENCHMARKS OFF CACHE BOOL "Disable some option in the library" FORCE)
 set(CPUINFO_BUILD_PKG_CONFIG OFF CACHE BOOL "Disable some option in the library" FORCE)
+set(CPUINFO_LIBRARY_TYPE "static")
 
 # exclude cpuinfo in vsag installation
 FetchContent_GetProperties(cpuinfo)

--- a/src/simd/CMakeLists.txt
+++ b/src/simd/CMakeLists.txt
@@ -62,7 +62,7 @@ set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-builtin-free")
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fopenmp -fopenmp-simd")
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -funroll-loops")
 
-add_library (simd ${SIMD_SRCS})
+add_library (simd STATIC ${SIMD_SRCS})
 
 macro (simd_add_definitions flag1 flag2)
     if (${flag1})
@@ -77,5 +77,9 @@ simd_add_definitions (DIST_CONTAINS_AVX512 -DENABLE_AVX512=1)
 simd_add_definitions (DIST_CONTAINS_AVX512VPOPCNTDQ -DENABLE_AVX512VPOPCNTDQ=1)
 simd_add_definitions (DIST_CONTAINS_NEON -DENABLE_NEON=1)
 
-target_link_libraries (simd INTERFACE cpuinfo coverage_config)
+target_link_libraries (simd
+  PRIVATE cpuinfo
+  INTERFACE coverage_config
+  )
+add_dependencies (simd cpuinfo)
 install (TARGETS simd ARCHIVE DESTINATION lib)


### PR DESCRIPTION
- use the static library of `cpuinfo` instead of the dynamic library
- make the submodule `simd` output a static library, not a dynamic library