### PR TITLE
support attr filter on bruteforce 

### DIFF
--- a/include/vsag/constants.h
+++ b/include/vsag/constants.h
@@ -175,7 +175,7 @@ extern const char* const IVF_BASE_FILE_PATH;
 extern const char* const IVF_PRECISE_QUANTIZATION_TYPE;
 extern const char* const IVF_PRECISE_IO_TYPE;
 extern const char* const IVF_PRECISE_FILE_PATH;
-extern const char* const IVF_USE_ATTRIBUTE_FILTER;
+extern const char* const USE_ATTRIBUTE_FILTER;
 extern const char* const IVF_THREAD_COUNT;
 
 extern const char* const GNO_IMI_FIRST_ORDER_BUCKETS_COUNT;

--- a/src/algorithm/brute_force.h
+++ b/src/algorithm/brute_force.h
@@ -17,6 +17,7 @@
 
 #include "algorithm/inner_index_interface.h"
 #include "brute_force_parameter.h"
+#include "data_cell/attribute_inverted_interface.h"
 #include "data_cell/flatten_interface.h"
 #include "label_table.h"
 #include "typing.h"
@@ -102,6 +103,9 @@ public:
     void
     GetVectorByInnerId(InnerIdType inner_id, float* data) const override;
 
+    [[nodiscard]] virtual DatasetPtr
+    SearchWithRequest(const SearchRequest& request) const override;
+
 private:
     void
     resize(uint64_t new_size);
@@ -124,5 +128,8 @@ private:
     std::atomic<InnerIdType> max_capacity_{0};
 
     static constexpr uint64_t DEFAULT_RESIZE_BIT = 10;
+
+    bool use_attribute_filter_{false};
+    AttrInvertedInterfacePtr attr_filter_index_{nullptr};
 };
 }  // namespace vsag

--- a/src/algorithm/brute_force_parameter.cpp
+++ b/src/algorithm/brute_force_parameter.cpp
@@ -17,6 +17,7 @@
 
 #include <fmt/format.h>
 
+#include "inner_string_params.h"
 #include "logger.h"
 #include "vsag/constants.h"
 
@@ -29,12 +30,16 @@ void
 BruteForceParameter::FromJson(const JsonType& json) {
     this->flatten_param = std::make_shared<FlattenDataCellParameter>();
     this->flatten_param->FromJson(json);
+    if (json.contains(USE_ATTRIBUTE_FILTER_KEY)) {
+        this->use_attribute_filter = json[USE_ATTRIBUTE_FILTER_KEY];
+    }
 }
 
 JsonType
 BruteForceParameter::ToJson() const {
     auto json = this->flatten_param->ToJson();
     json["type"] = INDEX_BRUTE_FORCE;
+    json[USE_ATTRIBUTE_FILTER_KEY] = this->use_attribute_filter;
     return json;
 }
 

--- a/src/algorithm/brute_force_parameter.h
+++ b/src/algorithm/brute_force_parameter.h
@@ -34,6 +34,8 @@ public:
 
 public:
     FlattenDataCellParamPtr flatten_param;
+
+    bool use_attribute_filter{false};
 };
 
 using BruteForceParameterPtr = std::shared_ptr<BruteForceParameter>;

--- a/src/algorithm/brute_force_parameter_test.cpp
+++ b/src/algorithm/brute_force_parameter_test.cpp
@@ -28,13 +28,15 @@ TEST_CASE("BruteForce Parameters CheckCompatibility",
         "quantization_params": {
             "type": "sq8"
         },
-        "type": "brute_force"
+        "type": "brute_force",
+        "use_attribute_filter": true
     })";
 
     SECTION("wrong parameter type") {
         auto param = std::make_shared<vsag::BruteForceParameter>();
         param->FromString(param_str);
         REQUIRE(param->CheckCompatibility(param));
+        REQUIRE(param->use_attribute_filter == true);
         REQUIRE_FALSE(param->CheckCompatibility(std::make_shared<vsag::EmptyParameter>()));
     }
 }

--- a/src/algorithm/ivf.cpp
+++ b/src/algorithm/ivf.cpp
@@ -84,43 +84,72 @@ IVF::CheckAndMappingExternalParam(const JsonType& external_param,
     const ConstParamMap external_mapping = {
         {
             IVF_BASE_QUANTIZATION_TYPE,
-            {BUCKET_PARAMS_KEY, QUANTIZATION_PARAMS_KEY, QUANTIZATION_TYPE_KEY},
+            {
+                BUCKET_PARAMS_KEY,
+                QUANTIZATION_PARAMS_KEY,
+                QUANTIZATION_TYPE_KEY,
+            },
         },
         {
             IVF_BASE_IO_TYPE,
-            {BUCKET_PARAMS_KEY, IO_PARAMS_KEY, IO_TYPE_KEY},
+            {
+                BUCKET_PARAMS_KEY,
+                IO_PARAMS_KEY,
+                IO_TYPE_KEY,
+            },
         },
         {
             IVF_PRECISE_QUANTIZATION_TYPE,
-            {IVF_PRECISE_CODES_KEY, QUANTIZATION_PARAMS_KEY, QUANTIZATION_TYPE_KEY},
+            {
+                IVF_PRECISE_CODES_KEY,
+                QUANTIZATION_PARAMS_KEY,
+                QUANTIZATION_TYPE_KEY,
+            },
         },
         {
             IVF_PRECISE_IO_TYPE,
-            {IVF_PRECISE_CODES_KEY, IO_PARAMS_KEY, IO_TYPE_KEY},
+            {
+                IVF_PRECISE_CODES_KEY,
+                IO_PARAMS_KEY,
+                IO_TYPE_KEY,
+            },
         },
         {
             IVF_BUCKETS_COUNT,
-            {BUCKET_PARAMS_KEY, BUCKETS_COUNT_KEY},
+            {
+                BUCKET_PARAMS_KEY,
+                BUCKETS_COUNT_KEY,
+            },
         },
         {
             IVF_TRAIN_TYPE,
-            {IVF_PARTITION_STRATEGY_PARAMS_KEY, IVF_TRAIN_TYPE_KEY},
+            {
+                IVF_PARTITION_STRATEGY_PARAMS_KEY,
+                IVF_TRAIN_TYPE_KEY,
+            },
         },
         {
             IVF_PARTITION_STRATEGY_TYPE_KEY,
-            {IVF_PARTITION_STRATEGY_PARAMS_KEY, IVF_PARTITION_STRATEGY_TYPE_KEY},
+            {
+                IVF_PARTITION_STRATEGY_PARAMS_KEY,
+                IVF_PARTITION_STRATEGY_TYPE_KEY,
+            },
         },
         {
             GNO_IMI_FIRST_ORDER_BUCKETS_COUNT,
-            {IVF_PARTITION_STRATEGY_PARAMS_KEY,
-             IVF_PARTITION_STRATEGY_TYPE_GNO_IMI,
-             GNO_IMI_FIRST_ORDER_BUCKETS_COUNT_KEY},
+            {
+                IVF_PARTITION_STRATEGY_PARAMS_KEY,
+                IVF_PARTITION_STRATEGY_TYPE_GNO_IMI,
+                GNO_IMI_FIRST_ORDER_BUCKETS_COUNT_KEY,
+            },
         },
         {
             GNO_IMI_SECOND_ORDER_BUCKETS_COUNT,
-            {IVF_PARTITION_STRATEGY_PARAMS_KEY,
-             IVF_PARTITION_STRATEGY_TYPE_GNO_IMI,
-             GNO_IMI_SECOND_ORDER_BUCKETS_COUNT_KEY},
+            {
+                IVF_PARTITION_STRATEGY_PARAMS_KEY,
+                IVF_PARTITION_STRATEGY_TYPE_GNO_IMI,
+                GNO_IMI_SECOND_ORDER_BUCKETS_COUNT_KEY,
+            },
         },
         {
             BUCKET_PER_DATA_KEY,
@@ -130,10 +159,18 @@ IVF::CheckAndMappingExternalParam(const JsonType& external_param,
             IVF_USE_REORDER,
             {IVF_USE_REORDER_KEY},
         },
-        {IVF_USE_RESIDUAL, {BUCKET_PARAMS_KEY, BUCKET_USE_RESIDUAL}},
         {
-            IVF_USE_ATTRIBUTE_FILTER,
-            {IVF_USE_ATTRIBUTE_FILTER_KEY},
+            IVF_USE_RESIDUAL,
+            {
+                BUCKET_PARAMS_KEY,
+                BUCKET_USE_RESIDUAL,
+            },
+        },
+        {
+            USE_ATTRIBUTE_FILTER,
+            {
+                USE_ATTRIBUTE_FILTER_KEY,
+            },
         },
         {
             IVF_BASE_PQ_DIM,

--- a/src/algorithm/ivf_parameter.cpp
+++ b/src/algorithm/ivf_parameter.cpp
@@ -49,8 +49,8 @@ IVFParameter::FromJson(const JsonType& json) {
         this->use_reorder = json[IVF_USE_REORDER_KEY];
     }
 
-    if (json.contains(IVF_USE_ATTRIBUTE_FILTER_KEY)) {
-        this->use_attribute_filter = json[IVF_USE_ATTRIBUTE_FILTER_KEY];
+    if (json.contains(USE_ATTRIBUTE_FILTER_KEY)) {
+        this->use_attribute_filter = json[USE_ATTRIBUTE_FILTER_KEY];
     }
 
     if (json.contains(IVF_THREAD_COUNT_KEY)) {
@@ -75,7 +75,7 @@ IVFParameter::ToJson() const {
     json[BUCKET_PER_DATA_KEY] = this->buckets_per_data;
     json[IVF_USE_REORDER_KEY] = this->use_reorder;
     json[IVF_THREAD_COUNT_KEY] = this->thread_count;
-    json[IVF_USE_ATTRIBUTE_FILTER_KEY] = this->use_attribute_filter;
+    json[USE_ATTRIBUTE_FILTER_KEY] = this->use_attribute_filter;
     if (use_reorder) {
         json[IVF_PRECISE_CODES_KEY] = this->flatten_param->ToJson();
     }

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -182,7 +182,7 @@ const char* const GNO_IMI_SECOND_ORDER_BUCKETS_COUNT = "second_order_buckets_cou
 const char* const IVF_PRECISE_QUANTIZATION_TYPE = "precise_quantization_type";
 const char* const IVF_PRECISE_IO_TYPE = "precise_io_type";
 const char* const IVF_PRECISE_FILE_PATH = "precise_file_path";
-const char* const IVF_USE_ATTRIBUTE_FILTER = "use_attribute_filter";
+const char* const USE_ATTRIBUTE_FILTER = "use_attribute_filter";
 const char* const IVF_THREAD_COUNT = "thread_count";
 
 const char* const SERIAL_MAGIC_BEGIN = "vsag0000";

--- a/src/inner_string_params.h
+++ b/src/inner_string_params.h
@@ -110,7 +110,7 @@ const char* const IVF_SEARCH_PARALLELISM = "parallelism";
 
 const char* const IVF_USE_REORDER_KEY = "use_reorder";
 const char* const IVF_PRECISE_CODES_KEY = "precise_codes";
-const char* const IVF_USE_ATTRIBUTE_FILTER_KEY = "use_attribute_filter";
+const char* const USE_ATTRIBUTE_FILTER_KEY = "use_attribute_filter";
 const char* const IVF_THREAD_COUNT_KEY = "thread_count";
 const char* const IVF_TRAIN_TYPE_KEY = "ivf_train_type";
 const char* const IVF_TRAIN_TYPE_RANDOM = "random";
@@ -181,7 +181,7 @@ const std::unordered_map<std::string, std::string> DEFAULT_MAP = {
     {"DEFAULT_FILE_PATH_VALUE", DEFAULT_FILE_PATH_VALUE},
     {"IVF_PRECISE_CODES_KEY", IVF_PRECISE_CODES_KEY},
     {"IVF_USE_REORDER_KEY", IVF_USE_REORDER_KEY},
-    {"IVF_USE_ATTRIBUTE_FILTER_KEY", IVF_USE_ATTRIBUTE_FILTER_KEY},
+    {"USE_ATTRIBUTE_FILTER_KEY", USE_ATTRIBUTE_FILTER_KEY},
     {"SQ4_UNIFORM_QUANTIZATION_TRUNC_RATE", SQ4_UNIFORM_QUANTIZATION_TRUNC_RATE},
     {"PCA_DIM", PCA_DIM},
     {"IVF_SEARCH_PARAM_SCAN_BUCKETS_COUNT", IVF_SEARCH_PARAM_SCAN_BUCKETS_COUNT},


### PR DESCRIPTION
closed: #982

## Summary by Sourcery

Add attribute-based filtering support to brute-force and IVF indices by indexing attributes during Add, parsing and applying attribute filters during search, updating parameters and key mappings, and adding corresponding tests.

New Features:
- Support attribute filter creation and insertion in BruteForce and IVF indices
- Implement SearchWithRequest in BruteForce to parse and apply attribute filter expressions during search

Enhancements:
- Extend Add method in BruteForce to index attributes when attribute filtering is enabled
- Update parameter mapping and JSON templates to include use_attribute_filter key
- Refactor constant names for USE_ATTRIBUTE_FILTER across codebase

Tests:
- Add parameter compatibility test for use_attribute_filter in BruteForceParameter
- Add end-to-end tests for brute-force index with attribute filter enabled