### PR TITLE
support filter search when supporting duplicate data

### DIFF
--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -615,6 +615,7 @@ HGraph::RangeSearch(const DatasetPtr& query,
     search_param.is_inner_id_allowed = ft;
     search_param.radius = radius;
     search_param.search_mode = RANGE_SEARCH;
+    search_param.consider_duplicate = true;
     search_param.range_search_limit_size = static_cast<int>(limited_size);
     auto search_result = this->search_one_graph(
         raw_query, this->bottom_graph_, this->basic_flatten_codes_, search_param);
@@ -760,6 +761,10 @@ HGraph::deserialize_basic_info(JsonType jsonify_basic_info) {
 
 void
 HGraph::serialize_label_info(StreamWriter& writer) const {
+    if (this->label_table_->CompressDuplicateData()) {
+        this->label_table_->Serialize(writer);
+        return;
+    }
     StreamWriter::WriteVector(writer, this->label_table_->label_table_);
     uint64_t size = this->label_table_->label_remap_.size();
     StreamWriter::WriteObj(writer, size);
@@ -772,6 +777,10 @@ HGraph::serialize_label_info(StreamWriter& writer) const {
 
 void
 HGraph::deserialize_label_info(StreamReader& reader) const {
+    if (this->label_table_->CompressDuplicateData()) {
+        this->label_table_->Deserialize(reader);
+        return;
+    }
     StreamReader::ReadVector(reader, this->label_table_->label_table_);
     uint64_t size;
     StreamReader::ReadObj(reader, size);

--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -54,6 +54,7 @@ HGraph::HGraph(const HGraphParameterPtr& hgraph_param, const vsag::IndexCommonPa
       hierarchical_datacell_param_(hgraph_param->hierarchical_graph_param),
       extra_info_size_(common_param.extra_info_size_),
       deleted_ids_(allocator_) {
+    this->label_table_->compress_duplicate_data_ = hgraph_param->support_duplicate;
     neighbors_mutex_ = std::make_shared<PointsMutex>(0, common_param.allocator_.get());
     this->basic_flatten_codes_ =
         FlattenInterface::MakeInstance(hgraph_param->base_codes_param, common_param);
@@ -108,7 +109,6 @@ HGraph::HGraph(const HGraphParameterPtr& hgraph_param, const vsag::IndexCommonPa
         this->attr_filter_index_ =
             AttributeInvertedInterface::MakeInstance(allocator_, false /*have_bucket*/);
     }
-    this->label_table_->compress_duplicate_data_ = hgraph_param->support_duplicate;
 }
 void
 HGraph::Train(const DatasetPtr& base) {

--- a/src/impl/basic_searcher.cpp
+++ b/src/impl/basic_searcher.cpp
@@ -328,7 +328,9 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
                     label_table->CompressDuplicateData()) {
                     const auto& duplicate_ids = label_table->GetDuplicateId(to_be_visited_id[i]);
                     for (const auto& item : duplicate_ids) {
-                        top_candidates->Push(dist, item);
+                        if (not is_id_allowed || is_id_allowed->CheckValid(item)) {
+                            top_candidates->Push(dist, item);
+                        }
                     }
                 }
 

--- a/src/label_table.h
+++ b/src/label_table.h
@@ -115,6 +115,15 @@ public:
     void
     Serialize(StreamWriter& writer) const {
         StreamWriter::WriteVector(writer, label_table_);
+        if (compress_duplicate_data_) {
+            StreamWriter::WriteObj(writer, duplicate_count_);
+            for (InnerIdType i = 0; i < label_table_.size(); ++i) {
+                if (duplicate_records_[i] != nullptr) {
+                    StreamWriter::WriteObj(writer, i);
+                    StreamWriter::WriteVector(writer, duplicate_records_[i]->duplicate_ids);
+                }
+            }
+        }
     }
 
     void
@@ -123,6 +132,16 @@ public:
         if (use_reverse_map_) {
             for (InnerIdType id = 0; id < label_table_.size(); ++id) {
                 this->label_remap_[label_table_[id]] = id;
+            }
+        }
+        if (compress_duplicate_data_) {
+            StreamReader::ReadObj(reader, duplicate_count_);
+            duplicate_records_.resize(label_table_.size(), nullptr);
+            for (InnerIdType i = 0; i < duplicate_count_; ++i) {
+                InnerIdType id;
+                StreamReader::ReadObj<InnerIdType>(reader, id);
+                duplicate_records_[id] = allocator_->New<DuplicateRecord>(allocator_);
+                StreamReader::ReadVector(reader, duplicate_records_[id]->duplicate_ids);
             }
         }
     }
@@ -150,8 +169,10 @@ public:
 
     inline void
     SetDuplicateId(InnerIdType previous_id, InnerIdType current_id) {
+        std::lock_guard duplicate_lock(duplicate_mutex_);
         if (duplicate_records_[previous_id] == nullptr) {
             duplicate_records_[previous_id] = allocator_->New<DuplicateRecord>(allocator_);
+            duplicate_count_++;
         }
         std::lock_guard lock(duplicate_records_[previous_id]->duplicate_mutex);
         duplicate_records_[previous_id]->duplicate_ids.push_back(current_id);
@@ -174,6 +195,9 @@ public:
     UnorderedMap<LabelType, InnerIdType> label_remap_;
 
     bool compress_duplicate_data_{true};
+
+    std::mutex duplicate_mutex_;
+    uint64_t duplicate_count_{0L};
     Vector<DuplicateRecord*> duplicate_records_;
 
     Allocator* allocator_{nullptr};

--- a/src/label_table.h
+++ b/src/label_table.h
@@ -40,7 +40,7 @@ class LabelTable {
 public:
     explicit LabelTable(Allocator* allocator,
                         bool use_reverse_map = true,
-                        bool compress_redundant_data = true)
+                        bool compress_redundant_data = false)
         : allocator_(allocator),
           label_table_(0, allocator),
           label_remap_(0, allocator),

--- a/tests/fixtures/fixtures.h
+++ b/tests/fixtures/fixtures.h
@@ -44,6 +44,16 @@ CopyVector(const std::vector<T>& vec) {
 
 template <typename T>
 T*
+DuplicateCopyVector(const std::vector<T>& vec) {
+    auto result = new T[vec.size()];
+    assert(vec.size() % 2 == 0);
+    memcpy(result, vec.data(), (vec.size() / 2) * sizeof(T));
+    memcpy(result + vec.size() / 2, vec.data(), (vec.size() / 2) * sizeof(T));
+    return result;
+}
+
+template <typename T>
+T*
 CopyVector(const vsag::Vector<T>& vec, vsag::Allocator* allocator) {
     T* result;
     if (allocator) {

--- a/tests/fixtures/fixtures.h
+++ b/tests/fixtures/fixtures.h
@@ -46,7 +46,9 @@ template <typename T>
 T*
 DuplicateCopyVector(const std::vector<T>& vec) {
     auto result = new T[vec.size()];
-    assert(vec.size() % 2 == 0);
+    if (vec.size() % 2 != 0) {
+        throw std::runtime_error("Vector size must be even for duplication.");
+    }
     memcpy(result, vec.data(), (vec.size() / 2) * sizeof(T));
     memcpy(result + vec.size() / 2, vec.data(), (vec.size() / 2) * sizeof(T));
     return result;

--- a/tests/fixtures/test_dataset.h
+++ b/tests/fixtures/test_dataset.h
@@ -34,7 +34,8 @@ public:
                       bool with_path = false,
                       float valid_ratio = 0.8,
                       std::string vector_type = "dense",
-                      uint64_t extra_info_size = 0);
+                      uint64_t extra_info_size = 0,
+                      bool has_duplicate = false);
 
     static std::shared_ptr<TestDataset>
     CreateNanDataset(const std::string& metric_str);

--- a/tests/fixtures/test_dataset_pool.cpp
+++ b/tests/fixtures/test_dataset_pool.cpp
@@ -52,4 +52,21 @@ TestDatasetPool::GetSparseDatasetAndCreate(uint64_t count, uint64_t dim, float v
     return this->pool_.at(key);
 }
 
+TestDatasetPtr
+TestDatasetPool::GetDuplicateDataset(uint64_t dim,
+                                     uint64_t count,
+                                     const std::string& metric_str,
+                                     bool with_path,
+                                     float valid_ratio,
+                                     uint64_t extra_info_size) {
+    auto key =
+        key_gen(dim, count, metric_str, with_path, valid_ratio, extra_info_size) + "_duplicate";
+    if (this->pool_.find(key) == this->pool_.end()) {
+        this->dim_counts_.emplace_back(dim, count);
+        this->pool_[key] = TestDataset::CreateTestDataset(
+            dim, count, metric_str, with_path, valid_ratio, "dense", extra_info_size, true);
+    }
+    return this->pool_.at(key);
+}
+
 }  // namespace fixtures

--- a/tests/fixtures/test_dataset_pool.h
+++ b/tests/fixtures/test_dataset_pool.h
@@ -35,6 +35,14 @@ public:
                         uint64_t extra_info_size = 0);
 
     TestDatasetPtr
+    GetDuplicateDataset(uint64_t dim,
+                        uint64_t count,
+                        const std::string& metric_str = "l2",
+                        bool with_path = false,
+                        float valid_ratio = 0.8,
+                        uint64_t extra_info_size = 0);
+
+    TestDatasetPtr
     GetNanDataset(const std::string& metric_str);
 
     TestDatasetPtr

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -1020,7 +1020,7 @@ TestHGraphDuplicate(const fixtures::HGraphTestIndexPtr& test_index,
     auto duplicate_pos = GENERATE("prefix", "suffix", "middle");
     auto search_param = fmt::format(fixtures::search_param_tmp, 200, false);
     std::unordered_map<std::string, float> ratios{
-        {"prefix", 0.9}, {"suffix", 0.9}, {"middle", 0.5}};
+        {"prefix", 0.9}, {"suffix", 0.9}, {"middle", 1.0}};
     const std::vector<std::pair<std::string, float>> all_test_cases =
         fixtures::RandomSelect<std::pair<std::string, float>>(
             {
@@ -1060,11 +1060,23 @@ TestHGraphDuplicate(const fixtures::HGraphTestIndexPtr& test_index,
                     /*store_raw_vector*/ false,
                     /*support_duplicate*/ true);
                 auto index = TestIndex::TestFactory(test_index->name, param, true);
-                auto dataset = HGraphTestIndex::pool.GetDatasetAndCreate(
+                auto dataset = HGraphTestIndex::pool.GetDuplicateDataset(
                     dim, resource->base_count, metric_type);
                 TestIndex::TestBuildDuplicateIndex(index, dataset, duplicate_pos, true);
-                TestIndex::TestKnnSearch(
-                    index, dataset, search_param, recall * ratios[duplicate_pos], true);
+                TestIndex::TestKnnSearch(index, dataset, search_param, recall, true);
+                // TODO(inabao): Fix knn search iter test
+                // TestIndex::TestKnnSearchIter(index, dataset, search_param, recall, true);
+                TestIndex::TestConcurrentKnnSearch(index, dataset, search_param, recall, true);
+                TestIndex::TestRangeSearch(index, dataset, search_param, recall, 10, true);
+                TestIndex::TestRangeSearch(index, dataset, search_param, recall / 2.0, 5, true);
+                TestIndex::TestFilterSearch(index, dataset, search_param, recall, true, true);
+                TestIndex::TestCheckIdExist(index, dataset);
+                TestIndex::TestCalcDistanceById(index, dataset);
+                TestIndex::TestGetRawVectorByIds(index, dataset);
+                TestIndex::TestBatchCalcDistanceById(index, dataset);
+                TestIndex::TestSearchAllocator(index, dataset, search_param, recall, true);
+                auto index2 = TestIndex::TestFactory(test_index->name, param, true);
+                TestIndex::TestSerializeFile(index, index2, dataset, search_param, true);
                 vsag::Options::Instance().set_block_size_limit(origin_size);
             }
         }

--- a/tests/test_index.cpp
+++ b/tests/test_index.cpp
@@ -1948,10 +1948,8 @@ TestIndex::TestBuildDuplicateIndex(const IndexPtr& index,
         auto result = index->Add(dataset->base_);
         REQUIRE(result.has_value() == expect_success);
     } else if (duplicate_pos == "middle") {
-        for (int64_t i = 0; i < dataset->base_->GetNumElements(); ++i) {
-            auto add_result = index->Add(dataset->base_);
-            REQUIRE(add_result.has_value() == expect_success);
-        }
+        auto add_result = index->Add(dataset->base_);
+        REQUIRE(add_result.has_value() == expect_success);
     } else {
         throw std::invalid_argument("Invalid duplicate position: " + duplicate_pos);
     }

--- a/tests/test_index.cpp
+++ b/tests/test_index.cpp
@@ -647,10 +647,6 @@ TestIndex::TestFilterSearch(const TestIndex::IndexPtr& index,
             auto threshold = res.value()->GetDistances()[topk - 1];
             auto range_result =
                 index->RangeSearch(query, threshold, search_param, dataset->filter_function_);
-            if (range_result.value()->GetDim() < topk) {
-                auto ss =
-                    index->RangeSearch(query, threshold, search_param, dataset->filter_function_);
-            }
             REQUIRE(range_result.value()->GetDim() >= topk);
         }
         auto result = res.value()->GetIds();


### PR DESCRIPTION
## Summary by Sourcery

Add comprehensive support for duplicate data handling and filter search in HGraph and its underlying LabelTable, including serialization, compression, and extended test coverage for duplicate-aware scenarios.

New Features:
- Introduce duplicate data tracking in LabelTable with optional compression and serializable duplicate metadata.
- Enable HGraph to support duplicates via a support_duplicate flag, propagating through serialize/deserialize and search parameters.
- Provide Dataset fixtures and pool methods to generate and retrieve datasets containing duplicate entries for testing.

Enhancements:
- Update BasicSearcher to validate and include duplicate IDs during search.
- Refactor TestBuildDuplicateIndex middle-case insertion for simplicity and make sindi_test’s param_str constexpr static.

Tests:
- Extend HGraph unit tests to cover concurrent knn, range, filter searches, ID existence checks, distance calculations, raw vector retrieval, batch distance computation, search allocator tests, and serialization on duplicate-aware datasets.