### PR TITLE
eliminate the effect of data size on the efsearch threshold

### DIFF
--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -297,6 +297,14 @@ HGraph::KnnSearch(const DatasetPtr& query,
             query_dim == dim_,
             fmt::format("query.dim({}) must be equal to index.dim({})", query_dim, dim_));
     }
+
+    auto params = HGraphSearchParameters::FromJson(parameters);
+
+    auto ef_search_threshold = std::max(AMPLIFICATION_FACTOR * k, 1000L);
+    CHECK_ARGUMENT(  // NOLINT
+        (1 <= params.ef_search) and (params.ef_search <= ef_search_threshold),
+        fmt::format("ef_search({}) must in range[1, {}]", params.ef_search, ef_search_threshold));
+
     // check k
     CHECK_ARGUMENT(k > 0, fmt::format("k({}) must be greater than 0", k));
     k = std::min(k, GetNumElements());
@@ -316,13 +324,6 @@ HGraph::KnnSearch(const DatasetPtr& query,
             raw_query, this->route_graphs_[i], this->basic_flatten_codes_, search_param);
         search_param.ep = result->Top().second;
     }
-
-    auto params = HGraphSearchParameters::FromJson(parameters);
-
-    auto ef_search_threshold = std::max(AMPLIFICATION_FACTOR * k, 1000L);
-    CHECK_ARGUMENT(  // NOLINT
-        (1 <= params.ef_search) and (params.ef_search <= ef_search_threshold),
-        fmt::format("ef_search({}) must in range[1, {}]", params.ef_search, ef_search_threshold));
 
     FilterPtr ft = nullptr;
     if (filter != nullptr) {
@@ -389,14 +390,19 @@ HGraph::KnnSearch(const DatasetPtr& query,
             query_dim == dim_,
             fmt::format("query.dim({}) must be equal to index.dim({})", query_dim, dim_));
     }
+
+    auto params = HGraphSearchParameters::FromJson(parameters);
+    auto ef_search_threshold = std::max(AMPLIFICATION_FACTOR * k, 1000L);
+    CHECK_ARGUMENT(  // NOLINT
+        (1 <= params.ef_search) and (params.ef_search <= ef_search_threshold),
+        fmt::format("ef_search({}) must in range[1, {}]", params.ef_search, ef_search_threshold));
+
     // check k
     CHECK_ARGUMENT(k > 0, fmt::format("k({}) must be greater than 0", k));
     k = std::min(k, GetNumElements());
 
     // check query vector
     CHECK_ARGUMENT(query->GetNumElements() == 1, "query dataset should contain 1 vector only");
-
-    auto params = HGraphSearchParameters::FromJson(parameters);
 
     FilterPtr ft = nullptr;
     if (filter != nullptr) {

--- a/src/index/hnsw.cpp
+++ b/src/index/hnsw.cpp
@@ -251,12 +251,6 @@ HNSW::knn_search(const DatasetPtr& query,
             query_dim == dim_,
             fmt::format("query.dim({}) must be equal to index.dim({})", query_dim, dim_));
 
-        // check k
-        CHECK_ARGUMENT(k > 0, fmt::format("k({}) must be greater than 0", k))
-        k = std::min(k, GetNumElements());
-
-        std::shared_lock lock_global(rw_mutex_);
-
         // check search parameters
         auto params = HnswSearchParameters::FromJson(parameters);
         auto ef_search_threshold = std::max(AMPLIFICATION_FACTOR * k, 1000L);
@@ -264,6 +258,12 @@ HNSW::knn_search(const DatasetPtr& query,
             (1 <= params.ef_search) and (params.ef_search <= ef_search_threshold),
             fmt::format(
                 "ef_search({}) must in range[1, {}]", params.ef_search, ef_search_threshold));
+
+        // check k
+        CHECK_ARGUMENT(k > 0, fmt::format("k({}) must be greater than 0", k))
+        k = std::min(k, GetNumElements());
+
+        std::shared_lock lock_global(rw_mutex_);
         if (iter_ctx != nullptr && *iter_ctx == nullptr) {
             auto* filter_context = new IteratorFilterContext();
             filter_context->init(alg_hnsw_->getMaxElements(), params.ef_search, search_allocator);


### PR DESCRIPTION
## Summary by Sourcery

Enforce a consistent ef_search threshold across graph and HNSW searches and consolidate parameter parsing to eliminate code duplication and the impact of data size on the threshold.

Enhancements:
- Unify ef_search threshold logic in HGraph and HNSW to use max(AMPLIFICATION_FACTOR * k, 1000) for range validation
- Consolidate parameter parsing and ef_search validation into a single location in each search overload to remove duplicate code
- Reorder validations to perform ef_search range checks before k constraints and locking operations