### PR TITLE
improve ivf parallel search

### DIFF
--- a/src/impl/basic_searcher.h
+++ b/src/impl/basic_searcher.h
@@ -49,7 +49,7 @@ public:
     float factor{2.0F};
     float first_order_scan_ratio{1.0F};
     Allocator* search_alloc{nullptr};
-    ExecutorPtr executor{nullptr};
+    std::vector<ExecutorPtr> executors;
     mutable int64_t duplicate_id{-1};
     bool consider_duplicate{false};
 


### PR DESCRIPTION
closed: #833 

## Summary by Sourcery

Refactor IVF search to eliminate shared heap locking by using thread-local heaps and executors, then merge results after parallel execution.

Enhancements:
- Replace a single mutex-protected DistanceHeap with a vector of per-thread heaps and merge them into a final heap after parallel search
- Change attribute filtering to use a vector of per-thread Executor instances instead of a single executor
- Optimize single-thread execution path by assigning the first thread’s heap directly as the search result when parallelism is one