### PR TITLE
fix header include error

### DIFF
--- a/src/algorithm/brute_force.cpp
+++ b/src/algorithm/brute_force.cpp
@@ -15,8 +15,8 @@
 
 #include "brute_force.h"
 
+#include "attr/argparse.h"
 #include "attr/executor/executor.h"
-#include "attr/expression_visitor.h"
 #include "data_cell/flatten_datacell.h"
 #include "impl/heap/standard_heap.h"
 #include "inner_string_params.h"

--- a/tests/test_brute_force.cpp
+++ b/tests/test_brute_force.cpp
@@ -406,7 +406,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::BruteForceTestIndex,
             auto index = TestFactory(name, param, true);
             auto dataset = pool.GetDatasetAndCreate(dim, base_count, metric_type);
             TestBuildIndex(index, dataset, true);
-            TestWithAttr(index, dataset, search_param);
+            TestWithAttr(index, dataset, search_param, false);
             vsag::Options::Instance().set_block_size_limit(origin_size);
         }
     }


### PR DESCRIPTION
closed: #996 

## Summary by Sourcery

Bug Fixes:
- Add missing 'attr/argparse.h' include and remove stale 'attr/expression_visitor.h' include in brute_force.cpp to resolve header include error