### PR TITLE
Alignment of direct IO object should depend on filesystem for 0.15

### DIFF
--- a/include/vsag/options.h
+++ b/include/vsag/options.h
@@ -132,6 +132,30 @@ public:
     set_block_size_limit(size_t size);
 
     /**
+     * @brief Gets the size of direct IO object align bits.
+     *
+     * This function retrieves the size of direct IO object align bits.
+     * It is thread-safe, using memory order acquire operations.
+     * The size of direct IO object align bits should be smaller than 21(direct IO object smaller than 2M).
+     *
+     * @return size_t The size of direct IO object align bits.
+     */
+    [[nodiscard]] inline size_t
+    direct_IO_object_align_bit() const {
+        return direct_IO_object_align_bit_.load(std::memory_order_acquire);
+    }
+
+    /**
+     * @brief Sets the size of direct IO object align bits.
+     *
+     * This function sets the size of direct IO object align bits.
+     *
+     * @param align_bit The size of direct IO object align bits.
+     */
+    void
+    set_direct_IO_object_align_bit(size_t align_bit);
+
+    /**
      * @brief Gets the current logger instance.
      *
      * @return Logger* Pointer to the current logger instance.
@@ -175,6 +199,12 @@ private:
 
     ///< The size of the maximum memory allocated each time (default is 128MB).
     std::atomic<size_t> block_size_limit_{128 * 1024 * 1024};
+
+    ///< The size of the bits used for DirectIOObject align (default is 9).
+    std::atomic<size_t> direct_IO_object_align_bit_{9};
+
+    ///< A flag to ensure that the set_direct_IO_object_align_bit() is called only once.
+    std::atomic<bool> direct_IO_object_align_bit_flag{false};
 
     ///< Pointer to the logger instance.
     Logger* logger_ = nullptr;

--- a/src/io/async_io.h
+++ b/src/io/async_io.h
@@ -80,8 +80,8 @@ public:
     inline void
     ReleaseImpl(const uint8_t* data) const {
         auto ptr = const_cast<uint8_t*>(data);
-        constexpr auto ALIGN_BIT = DirectIOObject::ALIGN_BIT;
-        free(reinterpret_cast<void*>((reinterpret_cast<uint64_t>(ptr) >> ALIGN_BIT) << ALIGN_BIT));
+        uint64_t align_bit = Options::Instance().direct_IO_object_align_bit();
+        free(reinterpret_cast<void*>((reinterpret_cast<uint64_t>(ptr) >> align_bit) << align_bit));
     }
 
     inline bool

--- a/src/io/direct_io_object.h
+++ b/src/io/direct_io_object.h
@@ -30,15 +30,18 @@ public:
 
     void
     Set(uint64_t size1, uint64_t offset1) {
+        this->align_bit = Options::Instance().direct_IO_object_align_bit();
+        this->align_size = 1 << align_bit;
+        this->align_mask = (1 << align_bit) - 1;
         this->size = size1;
         this->offset = offset1;
         if (align_data) {
             free(align_data);
         }
-        auto new_offset = (offset >> ALIGN_BIT) << ALIGN_BIT;
-        auto inner_offset = offset & ALIGN_MASK;
-        auto new_size = (((size + inner_offset) + ALIGN_MASK) >> ALIGN_BIT) << ALIGN_BIT;
-        this->align_data = static_cast<uint8_t*>(std::aligned_alloc(ALIGN_SIZE, new_size));
+        auto new_offset = (offset >> align_bit) << align_bit;
+        auto inner_offset = offset & align_mask;
+        auto new_size = (((size + inner_offset) + align_mask) >> align_bit) << align_bit;
+        this->align_data = static_cast<uint8_t*>(std::aligned_alloc(align_size, new_size));
         this->data = align_data + inner_offset;
         this->size = new_size;
         this->offset = new_offset;
@@ -57,10 +60,10 @@ public:
     uint64_t offset;
     uint8_t* align_data{nullptr};
 
-    static constexpr int64_t ALIGN_BIT = 9;
+    int64_t align_bit;
 
-    static constexpr int64_t ALIGN_SIZE = 1 << ALIGN_BIT;
+    int64_t align_size;
 
-    static constexpr int64_t ALIGN_MASK = (1 << ALIGN_BIT) - 1;
+    int64_t align_mask;
 };
 }  // namespace vsag

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -35,6 +35,17 @@ Options::logger() {
 }
 
 void
+Options::set_direct_IO_object_align_bit(size_t align_bit) {
+    if (align_bit > 21) {
+        throw std::runtime_error(
+            fmt::format("size ({}) should be smaller than 2^21(2M).", align_bit));
+    }
+    if (!direct_IO_object_align_bit_flag.exchange(true, std::memory_order_acq_rel)) {
+        direct_IO_object_align_bit_.store(align_bit, std::memory_order_release);
+    }
+}
+
+void
 Options::set_block_size_limit(size_t size) {
     if (size < 2ULL * 1024 * 1024) {
         throw std::runtime_error(fmt::format("size ({}) should be greater than 2M.", size));

--- a/src/options_test.cpp
+++ b/src/options_test.cpp
@@ -37,4 +37,13 @@ TEST_CASE("Options Test", "[ut][option]") {
 
     REQUIRE_THROWS(vsag::Option::Instance().set_num_threads_building(0));
     REQUIRE_THROWS(vsag::Option::Instance().set_num_threads_building(201));
+
+    size_t direct_IO_object_align_bit = 12;
+    vsag::Options::Instance().set_direct_IO_object_align_bit(direct_IO_object_align_bit);
+    REQUIRE(vsag::Option::Instance().direct_IO_object_align_bit() == direct_IO_object_align_bit);
+    size_t direct_IO_object_align_bit1 = 9;
+    vsag::Options::Instance().set_direct_IO_object_align_bit(direct_IO_object_align_bit1);
+    REQUIRE(vsag::Option::Instance().direct_IO_object_align_bit() == direct_IO_object_align_bit);
+
+    REQUIRE_THROWS(vsag::Option::Instance().set_direct_IO_object_align_bit(22));
 }


### PR DESCRIPTION
#963 
for the branch 0.15.

## Summary by Sourcery

Allow filesystem-dependent alignment for direct IO objects by replacing hardcoded alignment constants with configurable runtime values in Options, and update DirectIOObject and AsyncIO to use these dynamic alignments.

New Features:
- Add Options::set_direct_IO_object_align_bit and getter to configure direct IO object alignment bits at runtime.

Enhancements:
- Replace static ALIGN_BIT, ALIGN_SIZE, and ALIGN_MASK in DirectIOObject with runtime align_bit, align_size, and align_mask fetched from Options.
- Update AsyncIO::ReleaseImpl to use dynamic alignment bit from Options instead of static constant.

Tests:
- Add unit tests to verify setting and retrieving direct IO alignment bits, enforce one-time setting, and validate limit enforcement.