### PR TITLE
rename the parameter and fix bug in sindi example

### DIFF
--- a/.github/perf-90.yml
+++ b/.github/perf-90.yml
@@ -95,8 +95,8 @@ global:
     datapath: "/tmp/data/wholenet-sparse-1m-ip.hdf5"
     type: "build,search" # build, search
     index_name: "sindi"
-    create_params: '{"dim":512,"dtype":"sparse","metric_type":"ip","index_param":{"use_reorder": true, "doc_prune_ratio": 1, "window_size": 100000}}'
-    search_params: '{"sindi":{"query_prune_ratio": 0.75, "term_prune_ratio": 1, "n_candidate": 35}}'
+    create_params: '{"dim":512,"dtype":"sparse","metric_type":"ip","index_param":{"use_reorder": true, "doc_prune_ratio": 0.0, "window_size": 100000}}'
+    search_params: '{"sindi":{"query_prune_ratio": 0.25, "term_prune_ratio": 0, "n_candidate": 35}}'
     index_path: "/tmp/wholenet-sparse-1m-ip/index/wholenet_index"
     topk: 10
     search_mode: "knn"

--- a/.github/perf-95.yml
+++ b/.github/perf-95.yml
@@ -90,3 +90,15 @@ global:
     topk: 10
     search_mode: "knn"
     delete_index_after_search: false
+
+
+95/INTERNET:
+    datapath: "/tmp/data/wholenet-sparse-1m-ip.hdf5"
+    type: "build,search" # build, search
+    index_name: "sindi"
+    create_params: '{"dim":512,"dtype":"sparse","metric_type":"ip","index_param":{"use_reorder": true, "doc_prune_ratio": 0.0, "window_size": 100000}}'
+    search_params: '{"sindi":{"query_prune_ratio": 0.1, "term_prune_ratio": 0, "n_candidate": 30}}'
+    index_path: "/tmp/wholenet-sparse-1m-ip/index/wholenet_index"
+    topk: 10
+    search_mode: "knn"
+    delete_index_after_search: false

--- a/.github/perf-99.yml
+++ b/.github/perf-99.yml
@@ -90,3 +90,14 @@ global:
     topk: 10
     search_mode: "knn"
     delete_index_after_search: false
+
+99/INTERNET:
+    datapath: "/tmp/data/wholenet-sparse-1m-ip.hdf5"
+    type: "build,search" # build, search
+    index_name: "sindi"
+    create_params: '{"dim":512,"dtype":"sparse","metric_type":"ip","index_param":{"use_reorder": false, "doc_prune_ratio": 0.0, "window_size": 100000}}'
+    search_params: '{"sindi":{"query_prune_ratio": 0.0, "term_prune_ratio": 0, "n_candidate": 0}}'
+    index_path: "/tmp/wholenet-sparse-1m-ip/index/wholenet_index"
+    topk: 10
+    search_mode: "knn"
+    delete_index_after_search: false

--- a/src/algorithm/brute_force.cpp
+++ b/src/algorithm/brute_force.cpp
@@ -23,7 +23,6 @@
 #include "storage/serialization.h"
 #include "utils/slow_task_timer.h"
 #include "utils/util_functions.h"
-
 namespace vsag {
 
 BruteForce::BruteForce(const BruteForceParameterPtr& param, const IndexCommonParam& common_param)

--- a/src/algorithm/sindi/sindi.cpp
+++ b/src/algorithm/sindi/sindi.cpp
@@ -31,11 +31,11 @@ SINDI::SINDI(const SINDIParameterPtr& param, const IndexCommonParam& common_para
     : InnerIndexInterface(param, common_param),
       use_reorder_(param->use_reorder),
       window_size_(param->window_size),
-      doc_prune_ratio_(param->doc_prune_ratio),
+      doc_retain_ratio_(1.0F - param->doc_prune_ratio),
       window_term_list_(common_param.allocator_.get()) {
     window_term_list_.resize(1, nullptr);
     this->window_term_list_[0] =
-        std::make_shared<SparseTermDataCell>(doc_prune_ratio_, common_param.allocator_.get());
+        std::make_shared<SparseTermDataCell>(doc_retain_ratio_, common_param.allocator_.get());
 
     if (use_reorder_) {
         SparseIndexParameterPtr rerank_param = std::make_shared<SparseIndexParameters>();
@@ -61,7 +61,7 @@ SINDI::Add(const DatasetPtr& base) {
         window_term_list_.resize(final_add_window + 1);
     }
     for (uint32_t i = start_add_window + 1; i < window_term_list_.size(); i++) {
-        window_term_list_[i] = std::make_shared<SparseTermDataCell>(doc_prune_ratio_, allocator_);
+        window_term_list_[i] = std::make_shared<SparseTermDataCell>(doc_retain_ratio_, allocator_);
     }
 
     // add process
@@ -280,7 +280,7 @@ SINDI::Deserialize(StreamReader& reader) {
     for (auto i = 0; i < window_term_list_.size(); i++) {
         if (i != 0) {
             window_term_list_[i] =
-                std::make_shared<SparseTermDataCell>(doc_prune_ratio_, allocator_);
+                std::make_shared<SparseTermDataCell>(doc_retain_ratio_, allocator_);
         }
         window_term_list_[i]->Deserialize(reader);
     }

--- a/src/algorithm/sindi/sindi.h
+++ b/src/algorithm/sindi/sindi.h
@@ -101,7 +101,7 @@ private:
     int64_t cur_element_count_{0};
 
     bool use_reorder_{false};
-    float doc_prune_ratio_{0};
+    float doc_retain_ratio_{0};
 
     std::shared_ptr<SparseIndex> rerank_flat_index_{nullptr};
 };

--- a/src/algorithm/sindi/sindi_parameter.h
+++ b/src/algorithm/sindi/sindi_parameter.h
@@ -22,9 +22,9 @@ namespace vsag {
 
 static constexpr uint32_t DEFAULT_WINDOW_SIZE = 100000;
 static constexpr bool DEFAULT_USE_REORDER = false;
-static constexpr float DEFAULT_QUERY_PRUNE_RATIO = 1;
-static constexpr float DEFAULT_DOC_PRUNE_RATIO = 1;
-static constexpr float DEFAULT_TERM_PRUNE_RATIO = 1;
+static constexpr float DEFAULT_QUERY_PRUNE_RATIO = 0.0F;
+static constexpr float DEFAULT_DOC_PRUNE_RATIO = 0.0F;
+static constexpr float DEFAULT_TERM_PRUNE_RATIO = 0.0F;
 static constexpr uint32_t DEFAULT_N_CANDIDATE = 0;
 
 struct SINDIParameter : public Parameter {

--- a/src/algorithm/sindi/sindi_test.cpp
+++ b/src/algorithm/sindi/sindi_test.cpp
@@ -60,9 +60,8 @@ TEST_CASE("SINDI Basic Test", "[ut][SINDI]") {
 
     constexpr static auto param_str = R"({{
         "use_reorder": {},
-        "query_prune_ratio": 1,
-        "doc_prune_ratio": 1,
-        "term_prune_ratio": 1,
+        "doc_prune_ratio": 0.0,
+        "term_prune_ratio": 0.0,
         "window_size": 1000
     }})";
 
@@ -96,6 +95,8 @@ TEST_CASE("SINDI Basic Test", "[ut][SINDI]") {
     std::string search_param_str = R"(
     {
         "sindi": {
+            "query_prune_ratio": 0.0,
+            "term_prune_ratio": 0.0,
             "n_candidate": 20
         }
     }

--- a/src/data_cell/sparse_term_datacell.cpp
+++ b/src/data_cell/sparse_term_datacell.cpp
@@ -38,7 +38,7 @@ SparseTermDataCell::Query(float* global_dists, const SparseTermComputerPtr& comp
                                     term_ids_[term].data(),
                                     term_datas_[term].data(),
                                     static_cast<uint32_t>(static_cast<float>(term_sizes_[term]) *
-                                                          computer->term_prune_ratio_),
+                                                          computer->term_retain_ratio_),
                                     global_dists);
     }
     computer->ResetTerm();
@@ -73,7 +73,7 @@ SparseTermDataCell::InsertHeap(float* dists,
 
         uint32_t i = 0;
         auto term_size = static_cast<uint32_t>(static_cast<float>(term_sizes_[term]) *
-                                               computer->term_prune_ratio_);
+                                               computer->term_retain_ratio_);
         bool is_valid = false;
         if constexpr (mode == InnerSearchMode::KNN_SEARCH) {
             if (heap.size() < n_candidate) {

--- a/src/data_cell/sparse_term_datacell_test.cpp
+++ b/src/data_cell/sparse_term_datacell_test.cpp
@@ -57,9 +57,9 @@ TEST_CASE("SparseTermDatacell Basic Test", "[ut][SparseTermDatacell]") {
     }
 
     // prepare data_cell
-    float query_prune_ratio = 1.0;
+    float query_prune_ratio = 0.0;
     float doc_prune_ratio = 0.5;
-    float term_prune_ratio = 1.0;
+    float term_prune_ratio = 0.0;
     auto allocator = SafeAllocator::FactoryDefaultAllocator();
     auto data_cell = std::make_shared<SparseTermDataCell>(doc_prune_ratio, allocator.get());
     REQUIRE(std::abs(data_cell->doc_prune_ratio_ - doc_prune_ratio) < 1e-3);
@@ -69,7 +69,7 @@ TEST_CASE("SparseTermDatacell Basic Test", "[ut][SparseTermDatacell]") {
     search_params.term_prune_ratio = term_prune_ratio;
     search_params.query_prune_ratio = query_prune_ratio;
     auto computer = data_cell->FactoryComputer(query_sv, search_params);
-    REQUIRE(computer->pruned_len_ == query_prune_ratio * query_sv.len_);
+    REQUIRE(computer->pruned_len_ == (1.0F - query_prune_ratio) * query_sv.len_);
 
     // test insert
     auto exp_id_size = 19;

--- a/src/quantization/sparse_quantization/sparse_term_computer.h
+++ b/src/quantization/sparse_quantization/sparse_term_computer.h
@@ -34,12 +34,12 @@ public:
                                 const SINDISearchParameter& search_param,
                                 Allocator* allocator = nullptr)
         : sorted_query_(allocator),
-          query_prune_ratio_(search_param.query_prune_ratio),
-          term_prune_ratio_(search_param.term_prune_ratio),
+          query_retain_ratio_(1.0F - search_param.query_prune_ratio),
+          term_retain_ratio_(1.0F - search_param.term_prune_ratio),
           raw_query_(sparse_query) {
         sort_sparse_vector(sparse_query, sorted_query_);
 
-        pruned_len_ = (uint32_t)(query_prune_ratio_ * sparse_query.len_);
+        pruned_len_ = (uint32_t)(query_retain_ratio_ * sparse_query.len_);
         if (pruned_len_ == 0) {
             if (sorted_query_.size() != 0) {
                 pruned_len_ = 1;
@@ -55,7 +55,7 @@ public:
     SetQuery(const SparseVector& sparse_query) {
         sort_sparse_vector(sparse_query, sorted_query_);
 
-        pruned_len_ = (uint32_t)(query_prune_ratio_ * sparse_query.len_);
+        pruned_len_ = (uint32_t)(query_retain_ratio_ * sparse_query.len_);
         if (pruned_len_ == 0) {
             if (sorted_query_.size() != 0) {
                 pruned_len_ = 1;
@@ -110,9 +110,9 @@ public:
 
     const SparseVector& raw_query_;
 
-    float query_prune_ratio_{0};
+    float query_retain_ratio_{0.0F};
 
-    float term_prune_ratio_{0.0f};
+    float term_retain_ratio_{0.0F};
 
     uint32_t pruned_len_{0};
 

--- a/src/quantization/sparse_quantization/sparse_term_computer_test.cpp
+++ b/src/quantization/sparse_quantization/sparse_term_computer_test.cpp
@@ -25,7 +25,7 @@ using namespace vsag;
 
 TEST_CASE("SparseTermComputer Basic Test", "[ut][SparseTermComputer]") {
     // prepare data
-    auto query_prune_ratio = 0.8;
+    auto query_prune_ratio = 0.2;
     auto query_len = 10;
     SparseVector query_sv;
     query_sv.len_ = query_len;
@@ -42,7 +42,7 @@ TEST_CASE("SparseTermComputer Basic Test", "[ut][SparseTermComputer]") {
     auto computer = std::make_shared<SparseTermComputer>(query_sv, search_params, allocator.get());
 
     REQUIRE(computer->sorted_query_.size() == query_len);
-    REQUIRE(computer->pruned_len_ == query_len * query_prune_ratio);
+    REQUIRE(computer->pruned_len_ == query_len * (1.0F - query_prune_ratio));
     for (auto i = 0; i < computer->sorted_query_.size(); i++) {
         auto id = query_len - i - 1;
         REQUIRE(computer->sorted_query_[i].first == id);

--- a/tests/test_sindi.cpp
+++ b/tests/test_sindi.cpp
@@ -32,7 +32,7 @@ public:
             "metric_type": "ip",
             "index_param": {
                 "use_reorder": true,
-                "doc_prune_ratio": 1,
+                "doc_prune_ratio": 0.0,
                 "window_size": 100000
             }
         })";
@@ -41,8 +41,8 @@ public:
             "sindi":
             {
                 "n_candidate": 20,
-                "query_prune_ratio": 0.9,
-                "term_prune_ratio": 1
+                "query_prune_ratio": 0.1,
+                "term_prune_ratio": 0.0
             }
         })";
 };


### PR DESCRIPTION
## Summary by Sourcery

Fix parameter semantics for SINDI sparse index by renaming prune_ratio to retain_ratio and inverting their values, adjust example and configs accordingly, and correct related bugs.

Bug Fixes:
- Correct Dataset::Owner flag for base and query vectors in the sindi example
- Clear gt_results before destroying the brute-force index to prevent use-after-free

Enhancements:
- Rename query_prune_ratio and term_prune_ratio to retain-based semantics (query_retain_ratio and term_retain_ratio) in SparseTermComputer and SparseTermDataCell and update pruned length calculations
- Rename doc_prune_ratio to doc_retain_ratio in SINDI implementation and SINDIParameter, updating constructor and window term list logic
- Update default prune ratios from 1 to 0.0 in parameters, tests, examples, and perf workflow configs
- Add detailed comments to example build_params and search_params for sparse indexing
- Include missing argparse header in brute_force.cpp to fix build

Documentation:
- Enhance inline documentation for example configuration parameters