### PR TITLE
support update attr on BruteForce

### DIFF
--- a/src/algorithm/brute_force.cpp
+++ b/src/algorithm/brute_force.cpp
@@ -446,4 +446,18 @@ BruteForce::GetVectorByInnerId(InnerIdType inner_id, float* data) const {
     inner_codes_->Decode(codes.data(), data);
 }
 
+void
+BruteForce::UpdateAttribute(int64_t id, const AttributeSet& new_attrs) {
+    auto inner_id = this->label_table_->GetIdByLabel(id);
+    this->attr_filter_index_->UpdateBitsetsByAttr(new_attrs, inner_id, 0);
+}
+
+void
+BruteForce::UpdateAttribute(int64_t id,
+                            const AttributeSet& new_attrs,
+                            const AttributeSet& origin_attrs) {
+    auto inner_id = this->label_table_->GetIdByLabel(id);
+    this->attr_filter_index_->UpdateBitsetsByAttr(new_attrs, inner_id, 0, origin_attrs);
+}
+
 }  // namespace vsag

--- a/src/algorithm/brute_force.h
+++ b/src/algorithm/brute_force.h
@@ -106,6 +106,14 @@ public:
     [[nodiscard]] virtual DatasetPtr
     SearchWithRequest(const SearchRequest& request) const override;
 
+    void
+    UpdateAttribute(int64_t id, const AttributeSet& new_attrs) override;
+
+    void
+    UpdateAttribute(int64_t id,
+                    const AttributeSet& new_attrs,
+                    const AttributeSet& origin_attrs) override;
+
 private:
     void
     resize(uint64_t new_size);

--- a/tests/test_brute_force.cpp
+++ b/tests/test_brute_force.cpp
@@ -406,7 +406,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::BruteForceTestIndex,
             auto index = TestFactory(name, param, true);
             auto dataset = pool.GetDatasetAndCreate(dim, base_count, metric_type);
             TestBuildIndex(index, dataset, true);
-            TestWithAttr(index, dataset, search_param, false);
+            TestWithAttr(index, dataset, search_param);
             vsag::Options::Instance().set_block_size_limit(origin_size);
         }
     }


### PR DESCRIPTION
closed: #999

## Summary by Sourcery

Add Methods to Update Attributes in BruteForce and Refresh Test Signatures

New Features:
- Introduce two overloads of BruteForce::UpdateAttribute to propagate new attribute sets (with or without original attributes) to the attribute filter index

Tests:
- Update TestWithAttr invocation to match the new UpdateAttribute method signature