### PR TITLE
refactor serialize test

### DIFF
--- a/src/algorithm/ivf_partition/gno_imi_partition_test.cpp
+++ b/src/algorithm/ivf_partition/gno_imi_partition_test.cpp
@@ -21,6 +21,7 @@
 #include "fixtures.h"
 #include "impl/allocator/safe_allocator.h"
 #include "impl/basic_searcher.h"
+#include "storage/serialization_template_test.h"
 
 using namespace vsag;
 
@@ -139,18 +140,8 @@ TEST_CASE("GNO-IMI Partition Serialize Test", "[ut][GNOIMIPartition]") {
     auto class_result = partition->ClassifyDatas(vec.data(), data_count, 1);
     REQUIRE(class_result.size() == data_count);
 
-    auto dir = fixtures::TempDir("serialize");
-    auto path = dir.GenerateRandomFile();
-    std::ofstream outfile(path, std::ios::out | std::ios::binary);
-    IOStreamWriter writer(outfile);
-    partition->Serialize(writer);
-    outfile.close();
-    partition = std::make_unique<GNOIMIPartition>(param, strategy_param);
-
-    std::ifstream infile(path, std::ios::in | std::ios::binary);
-    IOStreamReader reader(infile);
-    partition->Deserialize(reader);
-    infile.close();
+    auto partition2 = std::make_unique<GNOIMIPartition>(param, strategy_param);
+    test_serializion(*partition, *partition2);
 
     param_str = R"(
     {
@@ -171,7 +162,7 @@ TEST_CASE("GNO-IMI Partition Serialize Test", "[ut][GNOIMIPartition]") {
         auto query = Dataset::Make();
         query->Dim(dim)->Float32Vectors(vec.data() + i * dim)->NumElements(1)->Owner(false);
         auto result =
-            partition->ClassifyDatasForSearch(vec.data() + i * dim, 1, inner_search_param);
+            partition2->ClassifyDatasForSearch(vec.data() + i * dim, 1, inner_search_param);
         auto id = result[0];
         if (id == class_result[i]) {
             match_count++;

--- a/src/algorithm/ivf_partition/ivf_nearest_partition_test.cpp
+++ b/src/algorithm/ivf_partition/ivf_nearest_partition_test.cpp
@@ -20,6 +20,7 @@
 #include "fixtures.h"
 #include "impl/allocator/safe_allocator.h"
 #include "safe_thread_pool.h"
+#include "storage/serialization_template_test.h"
 
 using namespace vsag;
 
@@ -89,20 +90,10 @@ TEST_CASE("IVF Nearest Partition Serialize Test", "[ut][IVFNearestPartition]") {
     auto class_result = partition->ClassifyDatas(vec.data(), data_count, 1);
     REQUIRE(class_result.size() == data_count);
 
-    auto dir = fixtures::TempDir("serialize");
-    auto path = dir.GenerateRandomFile();
-    std::ofstream outfile(path, std::ios::out | std::ios::binary);
-    IOStreamWriter writer(outfile);
-    partition->Serialize(writer);
-    outfile.close();
-    partition = std::make_unique<IVFNearestPartition>(bucket_count, param, strategy_param);
+    auto partition2 = std::make_unique<IVFNearestPartition>(bucket_count, param, strategy_param);
+    test_serializion(*partition, *partition2);
 
-    std::ifstream infile(path, std::ios::in | std::ios::binary);
-    IOStreamReader reader(infile);
-    partition->Deserialize(reader);
-    infile.close();
-
-    auto index = partition->route_index_ptr_;
+    auto index = partition2->route_index_ptr_;
     std::string route_search_param = R"(
     {
         "hgraph": {

--- a/src/algorithm/sindi/sindi_test.cpp
+++ b/src/algorithm/sindi/sindi_test.cpp
@@ -20,6 +20,7 @@
 
 #include "fixtures.h"
 #include "impl/allocator/safe_allocator.h"
+#include "storage/serialization_template_test.h"
 
 using namespace vsag;
 
@@ -80,17 +81,7 @@ TEST_CASE("SINDI Basic Test", "[ut][SINDI]") {
     REQUIRE(build_res.size() == 0);
     REQUIRE(index->GetNumElements() == num_base);
 
-    auto dir = fixtures::TempDir("serialize");
-    auto path = dir.GenerateRandomFile();
-    std::ofstream outfile(path, std::ios::out | std::ios::binary);
-    IOStreamWriter writer(outfile);
-    index->Serialize(writer);
-    outfile.close();
-
-    std::ifstream infile(path, std::ios::in | std::ios::binary);
-    IOStreamReader reader(infile);
-    another_index->Deserialize(reader);
-    infile.close();
+    test_serializion(*index, *another_index);
     REQUIRE(another_index->GetNumElements() == num_base);
 
     std::string search_param_str = R"(

--- a/src/attr/attr_type_schema.cpp
+++ b/src/attr/attr_type_schema.cpp
@@ -25,7 +25,8 @@ AttrValueType
 AttrTypeSchema::GetTypeOfField(const std::string& field_name) {
     auto iter = this->schema_.find(field_name);
     if (iter == this->schema_.end()) {
-        throw VsagException(ErrorType::INTERNAL_ERROR, "field not found");
+        throw VsagException(ErrorType::INTERNAL_ERROR,
+                            fmt::format("field not found: {}", field_name));
     }
     return iter->second;
 }

--- a/src/attr/attr_value_map_test.cpp
+++ b/src/attr/attr_value_map_test.cpp
@@ -19,6 +19,7 @@
 
 #include "fixtures.h"
 #include "impl/allocator/safe_allocator.h"
+#include "storage/serialization_template_test.h"
 
 using namespace vsag;
 
@@ -53,18 +54,8 @@ TestAttrValueMap() {
     REQUIRE(manager->GetOneBitset(2) == nullptr);
     REQUIRE(manager->GetOneBitset(3)->Test(id) == true);
 
-    auto dir = fixtures::TempDir("value_map");
-    auto path = dir.GenerateRandomFile();
-    std::ofstream ofs(path, std::ios::binary);
-    IOStreamWriter writer(ofs);
-
-    map.Serialize(writer);
-    ofs.close();
-    std::ifstream ifs(path, std::ios::binary);
-    IOStreamReader reader(ifs);
     AttrValueMap map2(allocator.get(), type);
-    map2.Deserialize(reader);
-    ifs.close();
+    test_serializion(map, map2);
 
     manager = map2.GetBitsetByValue(value);
     REQUIRE(manager != nullptr);

--- a/src/attr/multi_bitset_manager_test.cpp
+++ b/src/attr/multi_bitset_manager_test.cpp
@@ -19,6 +19,7 @@
 
 #include "fixtures.h"
 #include "impl/allocator/safe_allocator.h"
+#include "storage/serialization_template_test.h"
 
 using namespace vsag;
 
@@ -41,18 +42,8 @@ TEST_CASE("MultiBitsetManager Basic Test", "[ut][MultiBitsetManager]") {
     REQUIRE(ptr->Test(10) == true);
     REQUIRE(ptr->Test(9) == false);
 
-    auto tmp_dir = fixtures::TempDir("multi_bitset_manager");
-    auto filepath = tmp_dir.GenerateRandomFile();
-    std::ofstream ofile(filepath, std::ios::binary);
-    IOStreamWriter writer(ofile);
-    manager->Serialize(writer);
-    ofile.close();
-
     auto manager2 = std::make_unique<MultiBitsetManager>(allocator.get());
-    std::ifstream ifile(filepath, std::ios::binary);
-    IOStreamReader reader(ifile);
-    manager2->Deserialize(reader);
-    ifile.close();
+    test_serializion(*manager, *manager2);
 
     REQUIRE(manager2->GetOneBitset(100) != nullptr);
 

--- a/src/data_cell/attribute_bucket_inverted_datacell_test.cpp
+++ b/src/data_cell/attribute_bucket_inverted_datacell_test.cpp
@@ -19,6 +19,7 @@
 
 #include "fixtures.h"
 #include "impl/allocator/safe_allocator.h"
+#include "storage/serialization_template_test.h"
 
 using namespace vsag;
 
@@ -124,18 +125,9 @@ TEST_CASE("AttributeBucketInvertedDataCell insert various types",
         REQUIRE(managers[0]->GetOneBitset(bucket_id)->Test(inner_id - 1) == false);
     }
 
-    auto dir = fixtures::TempDir("attr");
-    auto path = dir.GenerateRandomFile();
-    std::ofstream ofs(path, std::ios::binary);
-    IOStreamWriter writer(ofs);
-
-    cell.Serialize(writer);
-    ofs.close();
-    std::ifstream ifs(path, std::ios::binary);
-    IOStreamReader reader(ifs);
     AttributeBucketInvertedDataCell cell2(allocator.get());
-    cell2.Deserialize(reader);
-    ifs.close();
+    test_serializion(cell, cell2);
+
     for (auto* attr : attrSet.attrs_) {
         auto managers = cell2.GetBitsetsByAttr(*attr);
         REQUIRE(managers.size() == 1);

--- a/src/data_cell/bucket_datacell_test.cpp
+++ b/src/data_cell/bucket_datacell_test.cpp
@@ -24,6 +24,7 @@
 #include "impl/allocator/default_allocator.h"
 #include "impl/allocator/safe_allocator.h"
 #include "simd/simd.h"
+#include "storage/serialization_template_test.h"
 
 using namespace vsag;
 
@@ -96,16 +97,7 @@ BucketInterfaceTest::BasicTest(int64_t dim, uint64_t base_count, float error) {
 }
 void
 BucketInterfaceTest::TestSerializeAndDeserialize(int64_t dim, const BucketInterfacePtr& other) {
-    fixtures::TempDir dir("bucket");
-    auto path = dir.GenerateRandomFile();
-    std::ofstream outfile(path.c_str(), std::ios::binary);
-    IOStreamWriter writer(outfile);
-    this->bucket_->Serialize(writer);
-    outfile.close();
-
-    std::ifstream infile(path.c_str(), std::ios::binary);
-    IOStreamReader reader(infile);
-    other->Deserialize(reader);
+    test_serializion(*this->bucket_, *other);
 
     int64_t query_count = 100;
     auto queries = fixtures::generate_vectors(query_count, dim, random());
@@ -133,8 +125,6 @@ BucketInterfaceTest::TestSerializeAndDeserialize(int64_t dim, const BucketInterf
             }
         }
     }
-
-    infile.close();
 }
 
 void

--- a/src/data_cell/extra_info_interface_test.cpp
+++ b/src/data_cell/extra_info_interface_test.cpp
@@ -23,6 +23,7 @@
 #include "impl/allocator/default_allocator.h"
 #include "impl/allocator/safe_allocator.h"
 #include "simd/simd.h"
+#include "storage/serialization_template_test.h"
 
 namespace vsag {
 void
@@ -119,21 +120,10 @@ ExtraInfoInterfaceTest::TestForceInMemory(uint64_t force_count) {
 
 void
 ExtraInfoInterfaceTest::TestSerializeAndDeserialize(ExtraInfoInterfacePtr other) {
-    fixtures::TempDir dir("extra_info");
-    auto path = dir.GenerateRandomFile();
-    std::ofstream outfile(path.c_str(), std::ios::binary);
-    IOStreamWriter writer(outfile);
-    this->extra_info_->Serialize(writer);
-    outfile.close();
-
-    std::ifstream infile(path.c_str(), std::ios::binary);
-    IOStreamReader reader(infile);
-    other->Deserialize(reader);
+    test_serializion(*this->extra_info_, *other);
 
     auto total_count = other->TotalCount();
     REQUIRE(total_count == this->extra_info_->TotalCount());
     REQUIRE(other->ExtraInfoSize() == this->extra_info_->ExtraInfoSize());
-
-    infile.close();
 }
 }  // namespace vsag

--- a/src/data_cell/flatten_interface_test.cpp
+++ b/src/data_cell/flatten_interface_test.cpp
@@ -20,6 +20,7 @@
 
 #include "fixtures.h"
 #include "simd/simd.h"
+#include "storage/serialization_template_test.h"
 
 namespace vsag {
 void
@@ -74,16 +75,7 @@ void
 FlattenInterfaceTest::TestSerializeAndDeserialize(int64_t dim,
                                                   FlattenInterfacePtr other,
                                                   float error) {
-    fixtures::TempDir dir("flatten");
-    auto path = dir.GenerateRandomFile();
-    std::ofstream outfile(path.c_str(), std::ios::binary);
-    IOStreamWriter writer(outfile);
-    this->flatten_->Serialize(writer);
-    outfile.close();
-
-    std::ifstream infile(path.c_str(), std::ios::binary);
-    IOStreamReader reader(infile);
-    other->Deserialize(reader);
+    test_serializion(*this->flatten_, *other);
 
     int64_t query_count = 100;
     auto queries = fixtures::generate_vectors(query_count, dim, random());
@@ -145,7 +137,5 @@ FlattenInterfaceTest::TestSerializeAndDeserialize(int64_t dim,
             }
         }
     }
-
-    infile.close();
 }
 }  // namespace vsag

--- a/src/data_cell/graph_interface_test.cpp
+++ b/src/data_cell/graph_interface_test.cpp
@@ -22,6 +22,7 @@
 #include "fixtures.h"
 #include "impl/allocator/default_allocator.h"
 #include "impl/allocator/safe_allocator.h"
+#include "storage/serialization_template_test.h"
 
 using namespace vsag;
 
@@ -100,16 +101,7 @@ GraphInterfaceTest::BasicTest(uint64_t max_id,
     }
 
     SECTION("Serialize & Deserialize") {
-        fixtures::TempDir dir("");
-        auto path = dir.GenerateRandomFile();
-        std::ofstream outfile(path.c_str(), std::ios::binary);
-        IOStreamWriter writer(outfile);
-        this->graph_->Serialize(writer);
-        outfile.close();
-
-        std::ifstream infile(path.c_str(), std::ios::binary);
-        IOStreamReader reader(infile);
-        other->Deserialize(reader);
+        test_serializion(*this->graph_, *other);
 
         REQUIRE(this->graph_->TotalCount() == other->TotalCount());
         REQUIRE(this->graph_->MaxCapacity() == other->MaxCapacity());
@@ -120,8 +112,6 @@ GraphInterfaceTest::BasicTest(uint64_t max_id,
             REQUIRE(memcmp(neighbors.data(), value->data(), value->size() * sizeof(InnerIdType)) ==
                     0);
         }
-
-        infile.close();
     }
 
     if (test_delete) {

--- a/src/data_cell/sparse_vector_datacell_test.cpp
+++ b/src/data_cell/sparse_vector_datacell_test.cpp
@@ -21,6 +21,7 @@
 #include "impl/allocator/safe_allocator.h"
 #include "index/index_common_param.h"
 #include "quantization/sparse_quantization/sparse_quantizer_parameter.h"
+#include "storage/serialization_template_test.h"
 #include "thread_pool.h"
 
 namespace vsag {
@@ -84,19 +85,8 @@ TEST_CASE("SparseDataCell Basic Test", "[ut][SparseDataCell] ") {
         }
     }
     SECTION("serialize and deserialize") {
-        fixtures::TempDir dir("flatten");
-        auto path = dir.GenerateRandomFile();
-        std::ofstream outfile(path.c_str(), std::ios::binary);
-        IOStreamWriter writer(outfile);
-        data_cell->Serialize(writer);
-        outfile.close();
-
         auto new_data_cell = FlattenInterface::MakeInstance(param, index_common_param);
-
-        std::ifstream infile(path.c_str(), std::ios::binary);
-        IOStreamReader reader(infile);
-        new_data_cell->Deserialize(reader);
-        infile.close();
+        test_serializion(*data_cell, *new_data_cell);
         auto computer = new_data_cell->FactoryComputer(query_sparse_vectors.data());
         std::shared_ptr<float[]> dist = std::shared_ptr<float[]>(new float[base_count]);
         new_data_cell->Query(dist.get(), computer, idx.data(), 1);

--- a/src/impl/bitset/sparse_bitset_test.cpp
+++ b/src/impl/bitset/sparse_bitset_test.cpp
@@ -22,6 +22,7 @@
 
 #include "fixtures.h"
 #include "impl/allocator/safe_allocator.h"
+#include "storage/serialization_template_test.h"
 
 using namespace roaring;
 using namespace vsag;
@@ -51,18 +52,8 @@ TEST_CASE("SparseBitset Test", "[ut][bitset]") {
     auto dumped = bitset.Dump();
     REQUIRE(dumped == "{100}");
 
-    fixtures::TempDir dir("sparse_bitset");
-    auto path = dir.GenerateRandomFile();
-    std::ofstream ofs(path, std::ios::binary);
-    IOStreamWriter writer(ofs);
-    bitset.Serialize(writer);
-    ofs.close();
-
-    std::ifstream ifs(path, std::ios::binary);
-    IOStreamReader reader(ifs);
     SparseBitset bitset2;
-    bitset2.Deserialize(reader);
-    ifs.close();
+    test_serializion(bitset, bitset2);
     dumped = bitset.Dump();
     REQUIRE(dumped == "{100}");
 }

--- a/src/impl/transform/fht_kac_rotate_transformer_test.cpp
+++ b/src/impl/transform/fht_kac_rotate_transformer_test.cpp
@@ -20,6 +20,7 @@
 
 #include "fixtures.h"
 #include "impl/allocator/safe_allocator.h"
+#include "storage/serialization_template_test.h"
 
 using namespace vsag;
 
@@ -106,16 +107,7 @@ TEST_CASE("Hadamard Matrix Serialize / Deserialize Test", "[ut][FhtKacRotator]")
         rom1.Train();
         rom2.Train();
 
-        fixtures::TempDir dir("hadamard");
-        auto filename = dir.GenerateRandomFile();
-        std::ofstream outfile(filename.c_str(), std::ios::binary);
-        IOStreamWriter writer(outfile);
-        rom1.Serialize(writer);
-        outfile.close();
-        std::ifstream infile(filename.c_str(), std::ios::binary);
-        IOStreamReader reader(infile);
-        rom2.Deserialize(reader);
-        infile.close();
+        test_serializion(rom1, rom2);
 
         TestSame(rom1, rom2, dim);
     }

--- a/src/impl/transform/pca_transformer_test.cpp
+++ b/src/impl/transform/pca_transformer_test.cpp
@@ -19,6 +19,7 @@
 
 #include "fixtures.h"
 #include "impl/allocator/safe_allocator.h"
+#include "storage/serialization_template_test.h"
 
 using namespace vsag;
 
@@ -198,18 +199,7 @@ TEST_CASE("PCA Serialize / Deserialize Test", "[ut][PCA]") {
         pca1.Train(vec.data(), count);
 
         // copy pca1 -> pca2
-        fixtures::TempDir dir("pca");
-        auto filename = dir.GenerateRandomFile();
-        std::ofstream outfile(filename.c_str(), std::ios::binary);
-        IOStreamWriter writer(outfile);
-        pca1.Serialize(writer);
-        outfile.close();
-
-        std::ifstream infile(filename.c_str(), std::ios::binary);
-        IOStreamReader reader(infile);
-        pca2.Deserialize(reader);
-        infile.close();
-
+        test_serializion(pca1, pca2);
         // validate pca1 == pca2
         std::vector<float> mean1(dim, 0);
         std::vector<float> mean2(dim, 0);

--- a/src/impl/transform/random_orthogonal_transformer_test.cpp
+++ b/src/impl/transform/random_orthogonal_transformer_test.cpp
@@ -21,6 +21,7 @@
 
 #include "fixtures.h"
 #include "impl/allocator/safe_allocator.h"
+#include "storage/serialization_template_test.h"
 
 using namespace vsag;
 
@@ -155,17 +156,7 @@ TEST_CASE("Random Orthogonal Matrix Serialize / Deserialize Test", "[ut][RandomO
         REQUIRE(rom1.GenerateRandomOrthogonalMatrix() == true);
         REQUIRE(rom2.GenerateRandomOrthogonalMatrix() == true);
 
-        fixtures::TempDir dir("rom");
-        auto filename = dir.GenerateRandomFile();
-        std::ofstream outfile(filename.c_str(), std::ios::binary);
-        IOStreamWriter writer(outfile);
-        rom1.Serialize(writer);
-        outfile.close();
-
-        std::ifstream infile(filename.c_str(), std::ios::binary);
-        IOStreamReader reader(infile);
-        rom2.Deserialize(reader);
-        infile.close();
+        test_serializion(rom1, rom2);
 
         TestOrthogonality(rom1, dim);
         TestTransform(rom1, dim);

--- a/src/io/basic_io_test.h
+++ b/src/io/basic_io_test.h
@@ -22,6 +22,7 @@
 
 #include "basic_io.h"
 #include "fixtures.h"
+#include "storage/serialization_template_test.h"
 
 using namespace vsag;
 
@@ -72,19 +73,11 @@ TestSerializeAndDeserialize(BasicIO<T>& wio, BasicIO<T>& rio) {
     fixtures::TempDir dirname("TestSerializeAndDeserialize");
     for (auto count : counts) {
         for (auto max_length : max_lengths) {
-            auto filename = dirname.GenerateRandomFile();
             auto vecs = fixtures::GenTestItems(count, max_length);
             for (auto& item : vecs) {
                 wio.Write(item.data_, item.length_, item.start_);
             }
-            std::ofstream outfile(filename.c_str(), std::ios::binary);
-            IOStreamWriter writer(outfile);
-            wio.Serialize(writer);
-            outfile.close();
-
-            std::ifstream infile(filename.c_str(), std::ios::binary);
-            IOStreamReader reader(infile);
-            rio.Deserialize(reader);
+            test_serializion(wio, rio);
 
             for (auto& item : vecs) {
                 std::vector<uint8_t> data(item.length_);
@@ -97,7 +90,6 @@ TestSerializeAndDeserialize(BasicIO<T>& wio, BasicIO<T>& rio) {
                     rio.Release(ptr);
                 }
             }
-            infile.close();
         }
     }
 }

--- a/src/quantization/product_quantization/pq_fastscan_quantizer_test.cpp
+++ b/src/quantization/product_quantization/pq_fastscan_quantizer_test.cpp
@@ -21,6 +21,7 @@
 #include "fixtures.h"
 #include "impl/allocator/safe_allocator.h"
 #include "quantization/quantizer_test.h"
+#include "storage/serialization_template_test.h"
 
 using namespace vsag;
 
@@ -172,17 +173,8 @@ TestSerializeAndDeserializeMetricPQFS(uint64_t dim, int64_t pq_dim, int count, f
     PQFastScanQuantizer<metric> quantizer1(dim, pq_dim, allocator.get());
     PQFastScanQuantizer<metric> quantizer2(dim, pq_dim, allocator.get());
     TestComputerBatchPQFS(quantizer1, dim, count, error);
-    fixtures::TempDir dir("quantizer");
-    auto filename = dir.GenerateRandomFile();
-    std::ofstream outfile(filename.c_str(), std::ios::binary);
-    IOStreamWriter writer(outfile);
-    quantizer1.Serialize(writer);
-    outfile.close();
 
-    std::ifstream infile(filename.c_str(), std::ios::binary);
-    IOStreamReader reader(infile);
-    quantizer2.Deserialize(reader);
-    infile.close();
+    test_serializion(quantizer1, quantizer2);
     TestComputerBatchPQFS(quantizer2, dim, count, error, false);
 }
 

--- a/src/quantization/quantizer_test.h
+++ b/src/quantization/quantizer_test.h
@@ -22,6 +22,7 @@
 #include "quantizer.h"
 #include "simd/normalize.h"
 #include "simd/simd.h"
+#include "storage/serialization_template_test.h"
 
 using namespace vsag;
 
@@ -385,17 +386,8 @@ TestSerializeAndDeserialize(Quantizer<T>& quant1,
                             bool is_rabitq = false) {
     auto vecs = fixtures::generate_vectors(count, dim);
     quant1.ReTrain(vecs.data(), count);
-    fixtures::TempDir dir("quantizer");
-    auto filename = dir.GenerateRandomFile();
-    std::ofstream outfile(filename.c_str(), std::ios::binary);
-    IOStreamWriter writer(outfile);
-    quant1.Serialize(writer);
-    outfile.close();
 
-    std::ifstream infile(filename.c_str(), std::ios::binary);
-    IOStreamReader reader(infile);
-    quant2.Deserialize(reader);
-    infile.close();
+    test_serializion(quant1, quant2);
 
     REQUIRE(quant1.GetCodeSize() == quant2.GetCodeSize());
     REQUIRE(quant1.GetDim() == quant2.GetDim());

--- a/src/storage/serialization_template_test.h
+++ b/src/storage/serialization_template_test.h
@@ -1,0 +1,30 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <sstream>
+
+#include "serialization.h"
+
+template <typename T>
+void
+test_serializion(T& old_instance, T& new_instance) {
+    std::stringstream ss;
+    IOStreamWriter writer(ss);
+    old_instance.Serialize(writer);
+    IOStreamReader reader(ss);
+    new_instance.Deserialize(reader);
+}

--- a/tests/fixtures/fixtures.h
+++ b/tests/fixtures/fixtures.h
@@ -300,4 +300,21 @@ RandomSelect(const std::vector<T>& vec, int64_t count = 1) {
     return selected;
 }
 
-}  // Namespace fixtures
+template <typename T>
+void
+test_serializion_file(T& old_instance, T& new_instance, const std::string name) {
+    auto temp_dir = TempDir(name);
+    auto file = temp_dir.GenerateRandomFile();
+    std::ofstream ofs(file);
+    old_instance.Serialize(ofs);
+    ofs.close();
+
+    std::ifstream ifs(file);
+    auto value = new_instance.Deserialize(ifs);
+    ifs.close();
+    if (not value.has_value()) {
+        throw std::runtime_error("deserialize failed: " + value.error().message);
+    }
+}
+
+}  // namespace fixtures

--- a/tests/test_ivf.cpp
+++ b/tests/test_ivf.cpp
@@ -15,8 +15,8 @@
 
 #include "fixtures/fixtures.h"
 #include "fixtures/test_dataset_pool.h"
+#include "storage/serialization_template_test.h"
 #include "test_index.h"
-
 namespace fixtures {
 
 class IVFTestResource {
@@ -667,19 +667,10 @@ TestIVFWithAttr(const fixtures::IVFTestIndexPtr& test_index,
                     auto build_result = index1->Build(dataset->base_);
                     REQUIRE(build_result.has_value());
                     IVFTestIndex::TestWithAttr(index1, dataset, search_param, false);
-
-                    auto dir = fixtures::TempDir("serialize");
-                    auto path = dir.GenerateRandomFile();
-                    std::ofstream outfile(path, std::ios::out | std::ios::binary);
-                    auto serialize_index = index1->Serialize(outfile);
-                    REQUIRE(serialize_index.has_value());
-                    outfile.close();
-
                     auto index = TestIndex::TestFactory(IVFTestIndex::name, param, true);
-                    std::ifstream infile(path, std::ios::in | std::ios::binary);
-                    auto deserialize_index = index->Deserialize(infile);
-                    REQUIRE(deserialize_index.has_value());
-                    infile.close();
+
+                    REQUIRE_NOTHROW(test_serializion_file(*index1, *index, "serialize"));
+
                     IVFTestIndex::TestWithAttr(index, dataset, search_param);
 
                     vsag::Options::Instance().set_block_size_limit(origin_size);


### PR DESCRIPTION
- add logger detail for attr_value_map
- refactor all serialize test with StreamReader/StreamWriter

## Summary by Sourcery

Centralize and simplify serialization tests by introducing a stream-based helper and refactor existing tests to use it, and improve the error message in AttrTypeSchema

Enhancements:
- Add storage/serialization_template_test.h providing test_serializion and test_serializion_file helpers
- Replace file-based I/O in serialize/deserialize tests with streamlined stringstream calls across algorithm, data_cell, quantization, io, and other test modules
- Include the missing field name in AttrTypeSchema’s field-not-found exception using fmt::format