### PR TITLE
support attribute for HGraph

### DIFF
--- a/include/vsag/constants.h
+++ b/include/vsag/constants.h
@@ -157,7 +157,6 @@ extern const char* const HGRAPH_PARAMETER_EF_RUNTIME;
 extern const char* const HGRAPH_EXTRA_INFO_SIZE;
 extern const char* const HGRAPH_SUPPORT_DUPLICATE;
 extern const char* const HGRAPH_USE_EXTRA_INFO_FILTER;
-extern const char* const HGRAPH_USE_ATTRIBUTE_FILTER;
 extern const char* const HGRAPH_STORE_RAW_VECTOR;
 
 extern const char* const BRUTE_FORCE_QUANTIZATION_TYPE;

--- a/include/vsag/search_request.h
+++ b/include/vsag/search_request.h
@@ -36,6 +36,8 @@ public:
     bool enable_attribute_filter_{false};
     std::string attribute_filter_str_;
     FilterPtr filter_{nullptr};
+
+    Allocator* search_allocator_{nullptr};
 };
 
 }  // namespace vsag

--- a/src/algorithm/brute_force.cpp
+++ b/src/algorithm/brute_force.cpp
@@ -248,7 +248,9 @@ BruteForce::Serialize(StreamWriter& writer) const {
     //     this->label_table_->Serialize(writer);
     //     return;
     // }
-
+    if (this->use_attribute_filter_ and this->attr_filter_index_ != nullptr) {
+        this->attr_filter_index_->Serialize(writer);
+    }
     this->inner_codes_->Serialize(writer);
     this->label_table_->Serialize(writer);
 
@@ -296,6 +298,10 @@ BruteForce::Deserialize(StreamReader& reader) {
         }
         dim_ = basic_info["dim"];
         total_count_ = basic_info["total_count"];
+
+        if (this->use_attribute_filter_ and this->attr_filter_index_ != nullptr) {
+            this->attr_filter_index_->Deserialize(buffer_reader);
+        }
 
         this->inner_codes_->Deserialize(buffer_reader);
         this->label_table_->Deserialize(buffer_reader);
@@ -397,10 +403,12 @@ BruteForce::CheckAndMappingExternalParam(const JsonType& external_param,
                 HOLD_MOLDS,
             },
         },
-        {USE_ATTRIBUTE_FILTER,
-         {
-             USE_ATTRIBUTE_FILTER_KEY,
-         }},
+        {
+            USE_ATTRIBUTE_FILTER,
+            {
+                USE_ATTRIBUTE_FILTER_KEY,
+            },
+        },
     };
 
     if (common_param.data_type_ == DataTypes::DATA_TYPE_INT8) {

--- a/src/algorithm/hgraph.h
+++ b/src/algorithm/hgraph.h
@@ -176,6 +176,17 @@ public:
     void
     Merge(const std::vector<MergeUnit>& merge_units) override;
 
+    [[nodiscard]] DatasetPtr
+    SearchWithRequest(const SearchRequest& request) const override;
+
+    void
+    UpdateAttribute(int64_t id, const AttributeSet& new_attrs) override;
+
+    void
+    UpdateAttribute(int64_t id,
+                    const AttributeSet& new_attrs,
+                    const AttributeSet& origin_attrs) override;
+
     void
     SetImmutable() override;
 

--- a/src/algorithm/hgraph_parameter.cpp
+++ b/src/algorithm/hgraph_parameter.cpp
@@ -48,8 +48,8 @@ HGraphParameter::FromJson(const JsonType& json) {
         this->build_by_base = json[HGRAPH_BUILD_BY_BASE_QUANTIZATION_KEY];
     }
 
-    if (json.contains(HGRAPH_USE_ATTRIBUTE_FILTER_KEY)) {
-        this->use_attribute_filter = json[HGRAPH_USE_ATTRIBUTE_FILTER_KEY];
+    if (json.contains(USE_ATTRIBUTE_FILTER_KEY)) {
+        this->use_attribute_filter = json[USE_ATTRIBUTE_FILTER_KEY];
     }
 
     CHECK_ARGUMENT(json.contains(HGRAPH_BASE_CODES_KEY),
@@ -156,6 +156,7 @@ HGraphParameter::ToJson() const {
     json[HGRAPH_EXTRA_INFO_KEY] = this->extra_info_param->ToJson();
     json[SUPPORT_DUPLICATE] = this->support_duplicate;
     json[HGRAPH_STORE_RAW_VECTOR] = this->store_raw_vector;
+    json[USE_ATTRIBUTE_FILTER_KEY] = this->use_attribute_filter;
     return json;
 }
 

--- a/src/algorithm/ivf.cpp
+++ b/src/algorithm/ivf.cpp
@@ -880,7 +880,7 @@ IVF::SearchWithRequest(const SearchRequest& request) const {
         param.topk = static_cast<int64_t>(param.factor * static_cast<float>(request.topk_));
     }
     auto query = request.query_;
-    if (request.enable_attribute_filter_) {
+    if (request.enable_attribute_filter_ and this->attr_filter_index_ != nullptr) {
         auto& schema = this->attr_filter_index_->field_type_map_;
         auto expr = AstParse(request.attribute_filter_str_, &schema);
         for (int64_t i = 0; i < param.parallel_search_thread_count; ++i) {

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -160,7 +160,6 @@ const char* const HGRAPH_PARAMETER_EF_RUNTIME = "ef_search";
 const char* const HGRAPH_EXTRA_INFO_SIZE = "extra_info_size";
 const char* const HGRAPH_SUPPORT_DUPLICATE = "support_duplicate";
 const char* const HGRAPH_USE_EXTRA_INFO_FILTER = "use_extra_info_filter";
-const char* const HGRAPH_USE_ATTRIBUTE_FILTER = "use_attribute_filter";
 const char* const HGRAPH_STORE_RAW_VECTOR = "store_raw_vector";
 
 const char* const BRUTE_FORCE_QUANTIZATION_TYPE = "quantization_type";

--- a/src/inner_string_params.h
+++ b/src/inner_string_params.h
@@ -35,7 +35,6 @@ const char* const HGRAPH_GRAPH_KEY = "graph";
 const char* const HGRAPH_BASE_CODES_KEY = "base_codes";
 const char* const HGRAPH_PRECISE_CODES_KEY = "precise_codes";
 const char* const HGRAPH_EXTRA_INFO_KEY = "extra_info";
-const char* const HGRAPH_USE_ATTRIBUTE_FILTER_KEY = "use_attribute_filter";
 
 // IO param key
 const char* const IO_PARAMS_KEY = "io_params";
@@ -147,7 +146,6 @@ const std::unordered_map<std::string, std::string> DEFAULT_MAP = {
     {"HGRAPH_GRAPH_KEY", HGRAPH_GRAPH_KEY},
     {"HGRAPH_BASE_CODES_KEY", HGRAPH_BASE_CODES_KEY},
     {"HGRAPH_PRECISE_CODES_KEY", HGRAPH_PRECISE_CODES_KEY},
-    {"HGRAPH_USE_ATTRIBUTE_FILTER_KEY", HGRAPH_USE_ATTRIBUTE_FILTER_KEY},
     {"HGRAPH_SUPPORT_DUPLICATE", HGRAPH_SUPPORT_DUPLICATE},
     {"IO_TYPE_KEY", IO_TYPE_KEY},
     {"IO_TYPE_VALUE_MEMORY_IO", IO_TYPE_VALUE_MEMORY_IO},

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -1,0 +1,54 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "logger.h"
+
+namespace vsag ::logger {
+void
+set_level(level log_level) {
+    Options::Instance().logger()->SetLevel((Logger::Level)log_level);
+}
+
+void
+trace(const std::string& msg) {
+    Options::Instance().logger()->Trace(msg);
+}
+
+void
+debug(const std::string& msg) {
+    Options::Instance().logger()->Debug(msg);
+}
+
+void
+info(const std::string& msg) {
+    Options::Instance().logger()->Info(msg);
+}
+
+void
+warn(const std::string& msg) {
+    Options::Instance().logger()->Warn(msg);
+}
+
+void
+error(const std::string& msg) {
+    Options::Instance().logger()->Error(msg);
+}
+
+void
+critical(const std::string& msg) {
+    Options::Instance().logger()->Critical(msg);
+}
+
+}  // namespace vsag::logger

--- a/src/logger.h
+++ b/src/logger.h
@@ -34,73 +34,59 @@ enum class level {
     off = Logger::Level::kOFF
 };
 
-inline void
-set_level(level log_level) {
-    Options::Instance().logger()->SetLevel((Logger::Level)log_level);
-}
+void
+set_level(level log_level);
 
-inline void
-trace(const std::string& msg) {
-    Options::Instance().logger()->Trace(msg);
-}
+void
+trace(const std::string& msg);
 
-inline void
-debug(const std::string& msg) {
-    Options::Instance().logger()->Debug(msg);
-}
+void
+debug(const std::string& msg);
 
-inline void
-info(const std::string& msg) {
-    Options::Instance().logger()->Info(msg);
-}
+void
+info(const std::string& msg);
 
-inline void
-warn(const std::string& msg) {
-    Options::Instance().logger()->Warn(msg);
-}
+void
+warn(const std::string& msg);
 
-inline void
-error(const std::string& msg) {
-    Options::Instance().logger()->Error(msg);
-}
+void
+error(const std::string& msg);
 
-inline void
-critical(const std::string& msg) {
-    Options::Instance().logger()->Critical(msg);
-}
+void
+critical(const std::string& msg);
 
 template <typename... Args>
-inline void
+void
 trace(fmt::format_string<Args...> fmt, Args&&... args) {
     trace(fmt::format(fmt, std::forward<Args>(args)...));
 }
 
 template <typename... Args>
-inline void
+void
 debug(fmt::format_string<Args...> fmt, Args&&... args) {
     debug(fmt::format(fmt, std::forward<Args>(args)...));
 }
 
 template <typename... Args>
-inline void
+void
 info(fmt::format_string<Args...> fmt, Args&&... args) {
     info(fmt::format(fmt, std::forward<Args>(args)...));
 }
 
 template <typename... Args>
-inline void
+void
 warn(fmt::format_string<Args...> fmt, Args&&... args) {
     warn(fmt::format(fmt, std::forward<Args>(args)...));
 }
 
 template <typename... Args>
-inline void
+void
 error(fmt::format_string<Args...> fmt, Args&&... args) {
     error(fmt::format(fmt, std::forward<Args>(args)...));
 }
 
 template <typename... Args>
-inline void
+void
 critical(fmt::format_string<Args...> fmt, Args&&... args) {
     critical(fmt::format(fmt, std::forward<Args>(args)...));
 }

--- a/tests/test_brute_force.cpp
+++ b/tests/test_brute_force.cpp
@@ -19,6 +19,7 @@
 #include <catch2/generators/catch_generators.hpp>
 #include <limits>
 
+#include "fixtures/fixtures.h"
 #include "fixtures/test_dataset_pool.h"
 #include "test_index.h"
 #include "vsag/options.h"
@@ -392,6 +393,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::BruteForceTestIndex,
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::BruteForceTestIndex,
                              "BruteForce With Attribute Filter",
                              "[ft][bruteforce]") {
+    using namespace fixtures;
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
     auto metric_type = GENERATE("l2", "ip", "cosine");
@@ -406,7 +408,12 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::BruteForceTestIndex,
             auto index = TestFactory(name, param, true);
             auto dataset = pool.GetDatasetAndCreate(dim, base_count, metric_type);
             TestBuildIndex(index, dataset, true);
-            TestWithAttr(index, dataset, search_param);
+            TestIndex::TestWithAttr(index, dataset, search_param, false);
+            auto index2 = TestIndex::TestFactory(name, param, true);
+
+            REQUIRE_NOTHROW(test_serializion_file(*index, *index2, "serialize_bruteforce"));
+            TestIndex::TestWithAttr(index2, dataset, search_param, true);
+
             vsag::Options::Instance().set_block_size_limit(origin_size);
         }
     }


### PR DESCRIPTION
closed: #1004 
- support build,search,update

## Summary by Sourcery

Enable support for attribute filtering in the HGraph index by extending search and update APIs, integrating an attribute filter executor into the search pipeline, and updating tests to validate the new functionality.

New Features:
- Add attribute-based filtering capability to HGraph search via SearchWithRequest API

Enhancements:
- Integrate attribute filter executor into BasicSearcher to screen candidates during graph search
- Extend SearchRequest to carry custom allocator and attribute filter options
- Expose UpdateAttribute methods in HGraph to update attribute filter index on the fly
- Add null-check guard for attribute filter index in IVF search

Tests:
- Rename and update HGraph attribute tests to exercise attribute-aware build and search