### PR TITLE
cherry-pick #880 to 0.15 (improve compressed graph in compression ratio) 

### DIFF
--- a/src/data_cell/compressed_graph_datacell.h
+++ b/src/data_cell/compressed_graph_datacell.h
@@ -32,6 +32,8 @@ public:
     explicit CompressedGraphDataCell(const CompressedGraphDatacellParamPtr& graph_param,
                                      const IndexCommonParam& common_param);
 
+    ~CompressedGraphDataCell();
+
     void
     InsertNeighborsById(InnerIdType id, const Vector<InnerIdType>& neighbor_ids) override;
 

--- a/src/impl/elias_fano_encoder.cpp
+++ b/src/impl/elias_fano_encoder.cpp
@@ -87,8 +87,10 @@ EliasFanoEncoder::get_low_bits(size_t index) const {
 }
 
 void
-EliasFanoEncoder::Encode(const Vector<InnerIdType>& values, InnerIdType max_value) {
-    Clear();
+EliasFanoEncoder::Encode(const Vector<InnerIdType>& values,
+                         InnerIdType max_value,
+                         Allocator* allocator) {
+    Clear(allocator);
     if (values.empty()) {
         return;
     }
@@ -116,7 +118,7 @@ EliasFanoEncoder::Encode(const Vector<InnerIdType>& values, InnerIdType max_valu
 
     // Allocate combined space for both low and high bits
     bits = static_cast<uint64_t*>(
-        allocator_->Allocate((low_bits_size + high_bits_size) * sizeof(uint64_t)));
+        allocator->Allocate((low_bits_size + high_bits_size) * sizeof(uint64_t)));
     std::fill(bits, bits + low_bits_size + high_bits_size, 0);
 
     // Encode each value

--- a/src/impl/elias_fano_encoder.h
+++ b/src/impl/elias_fano_encoder.h
@@ -23,25 +23,20 @@ namespace vsag {
 /// @note Our adjacency list size is mostly no more than 255, so we use uint8_t to store the number of elements
 class EliasFanoEncoder {
 public:
-    EliasFanoEncoder(Allocator* allocator) : allocator_(allocator) {
-    }
-
-    ~EliasFanoEncoder() {
-        Clear();
-    }
+    EliasFanoEncoder() = default;
 
     // Encode ordered sequence
     void
-    Encode(const Vector<InnerIdType>& values, InnerIdType max_value);
+    Encode(const Vector<InnerIdType>& values, InnerIdType max_value, Allocator* allocator);
 
     // Decompress all values
     void
     DecompressAll(Vector<InnerIdType>& neighbors) const;
 
     void
-    Clear() {
+    Clear(Allocator* allocator) {
         if (bits != nullptr) {
-            allocator_->Deallocate(bits);
+            allocator->Deallocate(bits);
             bits = nullptr;
         }
         num_elements = 0;
@@ -74,8 +69,6 @@ private:
 
     [[nodiscard]] InnerIdType
     get_low_bits(size_t index) const;
-
-    Allocator* allocator_;
 };
 
 }  // namespace vsag

--- a/src/impl/elias_fano_encoder_test.cpp
+++ b/src/impl/elias_fano_encoder_test.cpp
@@ -32,7 +32,7 @@ TEST_CASE("EliasFanoEncoder, original seq equal to decoded seq", "[ut][EliasFano
     std::uniform_int_distribution<InnerIdType> dist(0, max_id);
 
     auto allocator = SafeAllocator::FactoryDefaultAllocator();
-    std::shared_ptr<EliasFanoEncoder> encoder = std::make_shared<EliasFanoEncoder>(allocator.get());
+    std::shared_ptr<EliasFanoEncoder> encoder = std::make_shared<EliasFanoEncoder>();
 
     for (int size = 0; size <= max_size; size++) {
         Vector<InnerIdType> values(allocator.get());
@@ -44,7 +44,7 @@ TEST_CASE("EliasFanoEncoder, original seq equal to decoded seq", "[ut][EliasFano
         }
         std::sort(values.begin(), values.end());
 
-        encoder->Encode(values, max_id);
+        encoder->Encode(values, max_id, allocator.get());
         REQUIRE(encoder->Size() == values.size());
 
         // check if original seq equal to decoded seq
@@ -55,6 +55,7 @@ TEST_CASE("EliasFanoEncoder, original seq equal to decoded seq", "[ut][EliasFano
             REQUIRE(decompressed[i] == values[i]);
         }
     }
+    encoder->Clear(allocator.get());
 }
 
 }  // namespace vsag


### PR DESCRIPTION
## Summary by Sourcery

Improve memory management for compressed graph cells by refactoring EliasFanoEncoder to accept allocators at call time, adding cleanup logic in CompressedGraphDataCell destructor, and updating related methods and tests to the new API

Enhancements:
- Refactor EliasFanoEncoder to remove constructor-based allocator and accept an allocator in Encode and Clear methods
- Add a destructor to CompressedGraphDataCell to clear and reset neighbor encoders on destruction
- Update InsertNeighborsById and Deserialize in CompressedGraphDataCell to clear existing encoders before reuse

Tests:
- Update EliasFanoEncoder unit tests to instantiate without allocator and use the new Encode and Clear signatures