### PR TITLE
add data export for heap

### DIFF
--- a/src/impl/heap/distance_heap.h
+++ b/src/impl/heap/distance_heap.h
@@ -79,6 +79,9 @@ public:
     [[nodiscard]] virtual bool
     Empty() const = 0;
 
+    [[nodiscard]] virtual const DistanceRecord*
+    GetData() const = 0;
+
 protected:
     Allocator* allocator_{nullptr};
     int64_t max_size_{-1};

--- a/src/impl/heap/distance_heap_test.cpp
+++ b/src/impl/heap/distance_heap_test.cpp
@@ -50,8 +50,18 @@ public:
             gt = &sorted_data_greater;
         }
 
-        std::vector<DistanceHeap::DistanceRecord> temp;
         auto size = heap.Size();
+        std::vector<DistanceHeap::DistanceRecord> temp;
+        std::vector<DistanceHeap::DistanceRecord> temp2(size);
+
+        const auto* data = heap.GetData();
+        memcpy(temp2.data(), data, size * sizeof(DistanceHeap::DistanceRecord));
+        std::sort(temp2.begin(), temp2.end(), [](const auto& a, const auto& b) {
+            return a.first < b.first;
+        });
+        if (use_max) {
+            std::reverse(temp2.begin(), temp2.end());
+        }
         while (not heap.Empty()) {
             temp.emplace_back(heap.Top());
             heap.Pop();
@@ -59,6 +69,7 @@ public:
         REQUIRE(temp.size() == size);
         for (int i = 0; i < size; ++i) {
             REQUIRE(gt->at(size - i - 1) == temp[i]);
+            REQUIRE(gt->at(size - i - 1) == temp2[i]);
         }
     }
 

--- a/src/impl/heap/memmove_heap.h
+++ b/src/impl/heap/memmove_heap.h
@@ -48,6 +48,11 @@ public:
         return this->cur_size_ == 0;
     }
 
+    [[nodiscard]] const DistanceRecord*
+    GetData() const override {
+        return this->ordered_buffer_.data();
+    }
+
 private:
     Vector<DistanceRecord> ordered_buffer_;
 

--- a/src/impl/heap/standard_heap.cpp
+++ b/src/impl/heap/standard_heap.cpp
@@ -24,15 +24,18 @@ StandardHeap<max_heap, fixed_size>::StandardHeap(Allocator* allocator, int64_t m
 template <bool max_heap, bool fixed_size>
 void
 StandardHeap<max_heap, fixed_size>::Push(float dist, InnerIdType id) {
-    if constexpr (fixed_size) {
-        if (this->queue_.size() < max_size_ or (dist < this->queue_.top().first) == max_heap) {
-            queue_.emplace(dist, id);
-            if (this->queue_.size() > this->max_size_) {
-                this->queue_.pop();
-            }
-        }
+    DistanceRecord record{dist, id};
+    this->queue_.emplace_back(std::move(record));
+    if constexpr (max_heap) {
+        std::push_heap(this->queue_.begin(), this->queue_.end(), CompareMax());
     } else {
-        queue_.emplace(dist, id);
+        std::push_heap(this->queue_.begin(), this->queue_.end(), CompareMin());
+    }
+
+    if constexpr (fixed_size) {
+        if (this->queue_.size() > max_size_) {
+            this->Pop();
+        }
     }
 }
 

--- a/src/impl/heap/standard_heap.h
+++ b/src/impl/heap/standard_heap.h
@@ -23,13 +23,6 @@ namespace vsag {
 template <bool max_heap = true, bool fixed_size = true>
 class StandardHeap : public DistanceHeap {
 public:
-    using QueueMax =
-        std::priority_queue<DistanceRecord, Vector<std::pair<float, InnerIdType>>, CompareMax>;
-
-    using QueueMin =
-        std::priority_queue<DistanceRecord, Vector<std::pair<float, InnerIdType>>, CompareMin>;
-
-public:
     explicit StandardHeap(Allocator* allocator, int64_t max_size);
 
     void
@@ -37,12 +30,17 @@ public:
 
     [[nodiscard]] const DistanceRecord&
     Top() const override {
-        return this->queue_.top();
+        return this->queue_.front();
     }
 
     void
     Pop() override {
-        this->queue_.pop();
+        if constexpr (max_heap) {
+            std::pop_heap(queue_.begin(), queue_.end(), CompareMax());
+        } else {
+            std::pop_heap(queue_.begin(), queue_.end(), CompareMin());
+        }
+        queue_.pop_back();
     }
 
     [[nodiscard]] uint64_t
@@ -55,7 +53,12 @@ public:
         return this->queue_.size() == 0;
     }
 
+    [[nodiscard]] const DistanceRecord*
+    GetData() const override {
+        return this->queue_.data();
+    }
+
 private:
-    typename std::conditional<max_heap, QueueMax, QueueMin>::type queue_;
+    Vector<DistanceRecord> queue_;
 };
 }  // namespace vsag


### PR DESCRIPTION
## Summary by Sourcery

Enable direct export of heap contents by introducing GetData() and refactoring StandardHeap to use a vector-based heap with std::push_heap/pop_heap

New Features:
- Add virtual GetData() method to DistanceHeap interface
- Implement GetData() in StandardHeap and MemmoveHeap to return raw DistanceRecord pointer

Enhancements:
- Replace internal priority_queue in StandardHeap with a vector and manual heap operations
- Remove deprecated QueueMax/QueueMin aliases and simplify Push/Pop logic in StandardHeap