### PR TITLE
refactor heap merge on ivf parallel search

### DIFF
--- a/src/algorithm/ivf.cpp
+++ b/src/algorithm/ivf.cpp
@@ -687,7 +687,10 @@ IVF::search(const DatasetPtr& query, const InnerSearchParam& param) const {
     const auto& ft = param.is_inner_id_allowed;
 
     auto bucket_count = candidate_buckets.size();
-    const auto search_thread_count = param.parallel_search_thread_count;
+    auto search_thread_count = param.parallel_search_thread_count;
+    if (this->thread_pool_ == nullptr) {
+        search_thread_count = 1;
+    }
     std::vector<DistHeapPtr> heaps(search_thread_count);
 
     auto search_func = [&](int64_t thread_id) -> void {
@@ -768,9 +771,10 @@ IVF::search(const DatasetPtr& query, const InnerSearchParam& param) const {
         }
         search_result = DistanceHeap::MakeInstanceBySize<true, true>(this->allocator_, topk);
         for (auto& heap : heaps) {
-            while (not heap->Empty()) {
-                search_result->Push(heap->Top());
-                heap->Pop();
+            auto size = heap->Size();
+            const auto* data = heap->GetData();
+            for (int i = 0; i < size; ++i) {
+                search_result->Push(data[i]);
             }
         }
     }


### PR DESCRIPTION
## Summary by Sourcery

Refactor the heap merging logic in IVF::search to use direct data iteration and ensure single-thread fallback when no thread pool is available.

Enhancements:
- Use a single-thread search when thread_pool_ is null to avoid invalid parallel execution.
- Replace pop-based heap merging with direct iteration over heap data for more efficient result aggregation.