### PR TITLE
complete missing neon fuctions

### DIFF
--- a/src/simd/rabitq_simd.cpp
+++ b/src/simd/rabitq_simd.cpp
@@ -58,6 +58,14 @@ GetRaBitQSQ4UBinaryIP() {
 #if defined(ENABLE_AVX512)
         return avx512::RaBitQSQ4UBinaryIP;
 #endif
+    } else if (SimdStatus::SupportSVE()) {
+#if defined(ENABLE_SVE)
+        return sve::RaBitQSQ4UBinaryIP;
+#endif
+    } else if (SimdStatus::SupportNEON()) {
+#if defined(ENABLE_NEON)
+        return neon::RaBitQSQ4UBinaryIP;
+#endif
     }
     return generic::RaBitQSQ4UBinaryIP;
 }


### PR DESCRIPTION
close https://github.com/antgroup/vsag/issues/953

## Summary by Sourcery

Add missing NEON-optimized SIMD routines and integrate them into the dispatch layer, unit tests, and benchmarks

New Features:
- Implement NEON versions of INT8InnerProduct and several SQ4 distance computations (IP, L2Sqr, CodesIP, CodesL2Sqr)
- Add NEON-accelerated RaBitQSQ4UBinaryIP routine
- Provide NEON implementations of KacsWalk, FlipSign, VecRescale, RotateOp, and FHTRotate

Enhancements:
- Extend the SIMD dispatch factory to select NEON variants when supported
- Update unit tests and benchmarks to conditionally include NEON code paths and use std::abs for floating-point assertions

Tests:
- Expand test coverage to verify NEON routines alongside existing SIMD variants
- Add conditional benchmarking for NEON implementations