### PR TITLE
fix label_remap size serialize

### DIFF
--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -596,7 +596,7 @@ HGraph::serialize_basic_info_v0_14(StreamWriter& writer) const {
     StreamWriter::WriteObj(writer, capacity);
     StreamWriter::WriteVector(writer, this->label_table_->label_table_);
 
-    uint64_t size = this->total_count_;
+    uint64_t size = this->label_table_->label_remap_.size();
     StreamWriter::WriteObj(writer, size);
     for (const auto& pair : this->label_table_->label_remap_) {
         auto key = pair.first;


### PR DESCRIPTION
fix incorrect label_remap_ size in HGraph::serialize_basic_info_v0_14

## Summary by Sourcery

Bug Fixes:
- Fix incorrect label_remap size serialized in HGraph::serialize_basic_info_v0_14 by using label_remap_.size() instead of total_count_