### PR TITLE
add file remove check on disk io type

### DIFF
--- a/src/io/CMakeLists.txt
+++ b/src/io/CMakeLists.txt
@@ -8,6 +8,7 @@ set (IO_SRC
         async_io_parameter.cpp
         async_io.cpp
         mmap_io_parameter.cpp
+        mmap_io.cpp
         memory_block_io.cpp
         reader_io.cpp
         reader_io_parameter.cpp

--- a/src/io/async_io.h
+++ b/src/io/async_io.h
@@ -60,5 +60,7 @@ private:
     int rfd_{-1};
 
     int wfd_{-1};
+
+    bool exist_file_{false};
 };
 }  // namespace vsag

--- a/src/io/async_io_test.cpp
+++ b/src/io/async_io_test.cpp
@@ -27,6 +27,7 @@ TEST_CASE("AsyncIO Read And Write", "[ut][AsyncIO]") {
     fixtures::TempDir dir("async_io");
     auto path = dir.GenerateRandomFile();
     auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    TestDistIOWrongInit<AsyncIO>(allocator.get());
     auto io = std::make_unique<AsyncIO>(path, allocator.get());
     TestBasicReadWrite(*io);
 

--- a/src/io/basic_io_test.h
+++ b/src/io/basic_io_test.h
@@ -93,3 +93,14 @@ TestSerializeAndDeserialize(BasicIO<T>& wio, BasicIO<T>& rio) {
         }
     }
 }
+
+template <typename T>
+void
+TestDistIOWrongInit(Allocator* allocator) {
+    if (T::InMemory) {
+        return;
+    }
+    auto dirname = fixtures::TempDir("TestDistIOWrongInit");
+    auto func = [&]() { auto io = std::make_unique<T>(dirname.path, allocator); };
+    REQUIRE_THROWS(func());
+}

--- a/src/io/buffer_io.cpp
+++ b/src/io/buffer_io.cpp
@@ -22,7 +22,16 @@ namespace vsag {
 
 BufferIO::BufferIO(std::string filename, Allocator* allocator)
     : BasicIO<BufferIO>(allocator), filepath_(std::move(filename)) {
+    this->exist_file_ = std::filesystem::exists(this->filepath_);
+    if (std::filesystem::is_directory(this->filepath_)) {
+        throw VsagException(ErrorType::INTERNAL_ERROR,
+                            fmt::format("{} is a directory", this->filepath_));
+    }
     this->fd_ = open(filepath_.c_str(), O_CREAT | O_RDWR, 0644);
+    if (this->fd_ < 0) {
+        throw VsagException(ErrorType::INTERNAL_ERROR,
+                            fmt::format("open file {} error {}", this->filepath_, strerror(errno)));
+    }
 }
 
 BufferIO::BufferIO(const BufferIOParameterPtr& io_param, const IndexCommonParam& common_param)

--- a/src/io/buffer_io.h
+++ b/src/io/buffer_io.h
@@ -35,7 +35,9 @@ public:
     ~BufferIO() override {
         close(this->fd_);
         // remove file
-        std::filesystem::remove(this->filepath_);
+        if (not this->exist_file_) {
+            std::filesystem::remove(this->filepath_);
+        }
     }
 
     void
@@ -57,5 +59,7 @@ private:
     std::string filepath_{};
 
     int fd_{-1};
+
+    bool exist_file_{false};
 };
 }  // namespace vsag

--- a/src/io/buffer_io_test.cpp
+++ b/src/io/buffer_io_test.cpp
@@ -27,6 +27,7 @@ TEST_CASE("BufferIO Read & Write", "[ut][BufferIO]") {
     fixtures::TempDir dir("buffer_io");
     auto path = dir.GenerateRandomFile();
     auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    TestDistIOWrongInit<BufferIO>(allocator.get());
     auto io = std::make_unique<BufferIO>(path, allocator.get());
     TestBasicReadWrite(*io);
 }

--- a/src/io/mmap_io.cpp
+++ b/src/io/mmap_io.cpp
@@ -1,0 +1,111 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "mmap_io.h"
+
+namespace vsag {
+
+MMapIO::MMapIO(std::string filename, Allocator* allocator)
+    : BasicIO<MMapIO>(allocator), filepath_(std::move(filename)) {
+    this->exist_file_ = std::filesystem::exists(this->filepath_);
+    if (std::filesystem::is_directory(this->filepath_)) {
+        throw VsagException(ErrorType::INTERNAL_ERROR,
+                            fmt::format("{} is a directory", this->filepath_));
+    }
+
+    this->fd_ = open(filepath_.c_str(), O_CREAT | O_RDWR, 0644);
+    if (this->fd_ < 0) {
+        throw VsagException(ErrorType::INTERNAL_ERROR,
+                            fmt::format("open file {} error {}", this->filepath_, strerror(errno)));
+    }
+    auto mmap_size = this->size_;
+    if (this->size_ == 0) {
+        mmap_size = DEFAULT_INIT_MMAP_SIZE;
+        auto ret = ftruncate64(this->fd_, static_cast<int64_t>(mmap_size));
+        if (ret == -1) {
+            throw VsagException(ErrorType::INTERNAL_ERROR, "ftruncate64 failed");
+        }
+    }
+    void* addr = mmap(nullptr, mmap_size, PROT_READ | PROT_WRITE, MAP_SHARED, this->fd_, 0);
+    this->start_ = static_cast<uint8_t*>(addr);
+}
+
+MMapIO::MMapIO(const MMapIOParameterPtr& io_param, const IndexCommonParam& common_param)
+    : MMapIO(io_param->path_, common_param.allocator_.get()){};
+
+MMapIO::MMapIO(const IOParamPtr& param, const IndexCommonParam& common_param)
+    : MMapIO(std::dynamic_pointer_cast<MMapIOParameter>(param), common_param){};
+
+MMapIO::~MMapIO() {
+    munmap(this->start_, this->size_);
+    close(this->fd_);
+    // remove file
+    if (not this->exist_file_) {
+        std::filesystem::remove(this->filepath_);
+    }
+}
+
+void
+MMapIO::WriteImpl(const uint8_t* data, uint64_t size, uint64_t offset) {
+    auto new_size = size + offset;
+    auto old_size = this->size_;
+    if (old_size == 0) {
+        old_size = DEFAULT_INIT_MMAP_SIZE;
+    }
+    if (new_size > old_size) {
+        auto ret = ftruncate64(this->fd_, static_cast<int64_t>(new_size));
+        if (ret == -1) {
+            throw VsagException(ErrorType::INTERNAL_ERROR, "ftruncate64 failed");
+        }
+        this->start_ =
+            static_cast<uint8_t*>(mremap(this->start_, old_size, new_size, MREMAP_MAYMOVE));
+    }
+    this->size_ = std::max(this->size_, new_size);
+    memcpy(this->start_ + offset, data, size);
+}
+
+bool
+MMapIO::ReadImpl(uint64_t size, uint64_t offset, uint8_t* data) const {
+    if (offset + size > this->size_) {
+        throw VsagException(
+            ErrorType::INTERNAL_ERROR,
+            fmt::format("read offset {} + size {} > size {}", offset, size, this->size_));
+    }
+    memcpy(data, this->start_ + offset, size);
+    return true;
+}
+
+[[nodiscard]] const uint8_t*
+MMapIO::DirectReadImpl(uint64_t size, uint64_t offset, bool& need_release) const {
+    need_release = false;
+    if (offset + size > this->size_) {
+        throw VsagException(
+            ErrorType::INTERNAL_ERROR,
+            fmt::format("read offset {} + size {} > size {}", offset, size, this->size_));
+    }
+    return reinterpret_cast<const uint8_t*>(this->start_ + offset);
+}
+
+bool
+MMapIO::MultiReadImpl(uint8_t* datas, uint64_t* sizes, uint64_t* offsets, uint64_t count) const {
+    bool ret = true;
+    for (uint64_t i = 0; i < count; ++i) {
+        ret &= ReadImpl(sizes[i], offsets[i], datas);
+        datas += sizes[i];
+    }
+    return ret;
+}
+
+}  // namespace vsag

--- a/src/io/mmap_io.h
+++ b/src/io/mmap_io.h
@@ -31,84 +31,25 @@ public:
     static constexpr bool InMemory = false;
 
 public:
-    MMapIO(std::string filename, Allocator* allocator)
-        : BasicIO<MMapIO>(allocator), filepath_(std::move(filename)) {
-        this->fd_ = open(filepath_.c_str(), O_CREAT | O_RDWR, 0644);
-        auto mmap_size = this->size_;
-        if (this->size_ == 0) {
-            mmap_size = DEFAULT_INIT_MMAP_SIZE;
-            auto ret = ftruncate64(this->fd_, mmap_size);
-            if (ret == -1) {
-                throw VsagException(ErrorType::INTERNAL_ERROR, "ftruncate64 failed");
-            }
-        }
-        void* addr = mmap(nullptr, mmap_size, PROT_READ | PROT_WRITE, MAP_SHARED, this->fd_, 0);
-        this->start_ = static_cast<uint8_t*>(addr);
-    }
+    MMapIO(std::string filename, Allocator* allocator);
 
-    explicit MMapIO(const MMapIOParameterPtr& io_param, const IndexCommonParam& common_param)
-        : MMapIO(io_param->path_, common_param.allocator_.get()){};
+    explicit MMapIO(const MMapIOParameterPtr& io_param, const IndexCommonParam& common_param);
 
-    explicit MMapIO(const IOParamPtr& param, const IndexCommonParam& common_param)
-        : MMapIO(std::dynamic_pointer_cast<MMapIOParameter>(param), common_param){};
+    explicit MMapIO(const IOParamPtr& param, const IndexCommonParam& common_param);
 
-    ~MMapIO() override {
-        munmap(this->start_, this->size_);
-        close(this->fd_);
-        // remove file
-        std::filesystem::remove(this->filepath_);
-    }
+    ~MMapIO() override;
 
-    inline void
-    WriteImpl(const uint8_t* data, uint64_t size, uint64_t offset) {
-        auto new_size = size + offset;
-        auto old_size = this->size_;
-        if (old_size == 0) {
-            old_size = DEFAULT_INIT_MMAP_SIZE;
-        }
-        if (new_size > old_size) {
-            auto ret = ftruncate64(this->fd_, new_size);
-            if (ret == -1) {
-                throw VsagException(ErrorType::INTERNAL_ERROR, "ftruncate64 failed");
-            }
-            this->start_ =
-                static_cast<uint8_t*>(mremap(this->start_, old_size, new_size, MREMAP_MAYMOVE));
-        }
-        this->size_ = std::max(this->size_, new_size);
-        memcpy(this->start_ + offset, data, size);
-    }
+    void
+    WriteImpl(const uint8_t* data, uint64_t size, uint64_t offset);
 
-    inline bool
-    ReadImpl(uint64_t size, uint64_t offset, uint8_t* data) const {
-        if (offset + size > this->size_) {
-            throw VsagException(
-                ErrorType::INTERNAL_ERROR,
-                fmt::format("read offset {} + size {} > size {}", offset, size, this->size_));
-        }
-        memcpy(data, this->start_ + offset, size);
-        return true;
-    }
+    bool
+    ReadImpl(uint64_t size, uint64_t offset, uint8_t* data) const;
 
-    [[nodiscard]] inline const uint8_t*
-    DirectReadImpl(uint64_t size, uint64_t offset, bool& need_release) const {
-        need_release = false;
-        if (offset + size > this->size_) {
-            throw VsagException(
-                ErrorType::INTERNAL_ERROR,
-                fmt::format("read offset {} + size {} > size {}", offset, size, this->size_));
-        }
-        return reinterpret_cast<const uint8_t*>(this->start_ + offset);
-    }
+    [[nodiscard]] const uint8_t*
+    DirectReadImpl(uint64_t size, uint64_t offset, bool& need_release) const;
 
-    inline bool
-    MultiReadImpl(uint8_t* datas, uint64_t* sizes, uint64_t* offsets, uint64_t count) const {
-        bool ret = true;
-        for (uint64_t i = 0; i < count; ++i) {
-            ret &= ReadImpl(sizes[i], offsets[i], datas);
-            datas += sizes[i];
-        }
-        return ret;
-    }
+    bool
+    MultiReadImpl(uint8_t* datas, uint64_t* sizes, uint64_t* offsets, uint64_t count) const;
 
     static constexpr int64_t DEFAULT_INIT_MMAP_SIZE = 4096;
 
@@ -118,5 +59,7 @@ private:
     int fd_{-1};
 
     uint8_t* start_{nullptr};
+
+    bool exist_file_{false};
 };
 }  // namespace vsag

--- a/src/io/mmap_io_test.cpp
+++ b/src/io/mmap_io_test.cpp
@@ -27,6 +27,7 @@ TEST_CASE("MMapIO Read & Write", "[ut][MMapIO]") {
     fixtures::TempDir dir("mmap_io");
     auto path = dir.GenerateRandomFile();
     auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    TestDistIOWrongInit<MMapIO>(allocator.get());
     auto io = std::make_unique<MMapIO>(path, allocator.get());
     TestBasicReadWrite(*io);
 }


### PR DESCRIPTION
## Summary by Sourcery

Add file existence checks to disk IO classes to prevent deleting pre-existing files and to error on directory paths, and refactor MMapIO by extracting its implementation into a new source file

Enhancements:
- Track file existence in MMapIO, AsyncIO, and BufferIO and only remove files created by the process
- Throw an exception when initializing IO classes with a directory path
- Move MMapIO inline method implementations to a new mmap_io.cpp and update CMakeLists to include it