### PR TITLE
add more tag index check on compatibility

### DIFF
--- a/scripts/check_compatibility.sh
+++ b/scripts/check_compatibility.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/bash
 
-old_version_indexes="v0.14.0_hgraph v0.14.0_hnsw \
+old_version_indexes="v0.16.0_hgraph v0.16.0_hnsw \
+                     v0.15.0_hgraph v0.15.0_hnsw \
+                     v0.15.1_hgraph v0.15.1_hnsw \
+                     v0.14.0_hgraph v0.14.0_hnsw \
                      v0.14.1_hgraph v0.14.1_hnsw \
                      v0.14.2_hgraph v0.14.2_hnsw \
                      v0.14.8_hgraph v0.14.8_hnsw \


### PR DESCRIPTION
## Summary by Sourcery

Expand the compatibility checker to validate additional legacy index versions.

Enhancements:
- Include version 0.16.0_hgraph and 0.16.0_hnsw in the compatibility index list
- Include version 0.15.0_hgraph and 0.15.0_hnsw in the compatibility index list
- Include version 0.15.1_hgraph and 0.15.1_hnsw in the compatibility index list