### PR TITLE
add tool to analyze index for hgraph

### DIFF
--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -1811,7 +1811,7 @@ HGraph::analyze_quantizer(JsonType& stats,
             float tmp_bias_ratio = 0.0F;
             float tmp_inversion_count_rate = 0.0F;
             this->use_reorder_ = false;
-            auto* query_data = data.data() + i * dim_;
+            const auto* query_data = data.data() + i * dim_;
             auto query = Dataset::Make();
             query->Owner(false)->NumElements(1)->Float32Vectors(query_data)->Dim(dim_);
             auto search_result = this->KnnSearch(query, topk, search_param, nullptr);
@@ -1837,9 +1837,9 @@ HGraph::analyze_quantizer(JsonType& stats,
                     }
                 }
             }
-            tmp_inversion_count_rate =
-                static_cast<float>(inversion_count) /
-                static_cast<float>(search_result->GetDim() * (search_result->GetDim() - 1) / 2);
+            int64_t search_count = search_result->GetDim();
+            tmp_inversion_count_rate = static_cast<float>(inversion_count) /
+                                       static_cast<float>(search_count * (search_count - 1) / 2);
             inversion_count_rate += tmp_inversion_count_rate;
         }
         stats["quantization_bias_ratio"] = bias_ratio / static_cast<float>(sample_data_size);

--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -1838,8 +1838,9 @@ HGraph::analyze_quantizer(JsonType& stats,
                 }
             }
             int64_t search_count = search_result->GetDim();
-            tmp_inversion_count_rate = static_cast<float>(inversion_count) /
-                                       static_cast<float>(search_count * (search_count - 1) / 2);
+            tmp_inversion_count_rate =
+                static_cast<float>(inversion_count) /
+                (static_cast<float>(search_count * (search_count - 1)) / 2.0F);
             inversion_count_rate += tmp_inversion_count_rate;
         }
         stats["quantization_bias_ratio"] = bias_ratio / static_cast<float>(sample_data_size);

--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -648,6 +648,8 @@ HGraph::serialize_basic_info() const {
     TO_JSON(jsonify_basic_info, metric);
     TO_JSON(jsonify_basic_info, entry_point_id);
     TO_JSON(jsonify_basic_info, ef_construct);
+    TO_JSON(jsonify_basic_info, extra_info_size);
+    TO_JSON(jsonify_basic_info, data_type);
     // logger::debug("mult: {}", this->mult_);
     TO_JSON_BASE64(jsonify_basic_info, mult);
     TO_JSON_ATOMIC(jsonify_basic_info, max_capacity);
@@ -657,7 +659,12 @@ HGraph::serialize_basic_info() const {
     return jsonify_basic_info;
 }
 
-#define FROM_JSON(json_obj, var) this->var##_ = (json_obj)[#var];
+#define FROM_JSON(json_obj, var)             \
+    do {                                     \
+        if ((json_obj).contains(#var)) {     \
+            this->var##_ = (json_obj)[#var]; \
+        }                                    \
+    } while (0)
 
 #define FROM_JSON_BASE64(json_obj, var) base64_decode_obj((json_obj)[#var], this->var##_);
 
@@ -671,6 +678,8 @@ HGraph::deserialize_basic_info(JsonType jsonify_basic_info) {
     FROM_JSON(jsonify_basic_info, metric);
     FROM_JSON(jsonify_basic_info, entry_point_id);
     FROM_JSON(jsonify_basic_info, ef_construct);
+    FROM_JSON(jsonify_basic_info, extra_info_size);
+    FROM_JSON(jsonify_basic_info, data_type);
     FROM_JSON_BASE64(jsonify_basic_info, mult);
     // logger::debug("mult: {}", this->mult_);
     FROM_JSON_ATOMIC(jsonify_basic_info, max_capacity);
@@ -772,7 +781,7 @@ HGraph::Serialize(StreamWriter& writer) const {
     // serialize footer (introduced since v0.15)
     auto jsonify_basic_info = this->serialize_basic_info();
     auto metadata = std::make_shared<Metadata>();
-    metadata->Set("basic_info", jsonify_basic_info);
+    metadata->Set(BASIC_INFO, jsonify_basic_info);
     logger::debug(jsonify_basic_info.dump());
 
     auto footer = std::make_shared<Footer>(metadata);
@@ -819,7 +828,7 @@ HGraph::Deserialize(StreamReader& reader) {
 
         auto metadata = footer->GetMetadata();
         // metadata should NOT be nullptr if footer is not nullptr
-        this->deserialize_basic_info(metadata->Get("basic_info"));
+        this->deserialize_basic_info(metadata->Get(BASIC_INFO));
         this->deserialize_label_info(buffer_reader);
 
         this->basic_flatten_codes_->Deserialize(buffer_reader);
@@ -1747,6 +1756,175 @@ HGraph::UpdateAttribute(int64_t id,
                         const AttributeSet& origin_attrs) {
     auto inner_id = this->label_table_->GetIdByLabel(id);
     this->attr_filter_index_->UpdateBitsetsByAttr(new_attrs, inner_id, 0, origin_attrs);
+}
+
+std::string
+HGraph::GetStats() const {
+    JsonType stats;
+    stats["total_count"] = this->total_count_;
+    // duplicate rate
+    int64_t duplicate_num = 0;
+    if (this->label_table_->CompressDuplicateData()) {
+        for (int i = 0; i < this->total_count_; ++i) {
+            if (this->label_table_->duplicate_records_[i] != nullptr) {
+                duplicate_num += this->label_table_->duplicate_records_[i]->duplicate_ids.size();
+            }
+        }
+    }
+    stats["duplicate_rate"] = static_cast<float>(duplicate_num) / this->total_count_;
+    // graph connection
+    Vector<bool> visited(total_count_, false, allocator_);
+    int64_t connect_components = 0;
+    if (this->label_table_->CompressDuplicateData()) {
+        for (int i = 0; i < this->total_count_; ++i) {
+            if (this->label_table_->duplicate_records_[i] != nullptr) {
+                for (const auto& dup_id :
+                     this->label_table_->duplicate_records_[i]->duplicate_ids) {
+                    visited[dup_id] = true;
+                }
+            }
+        }
+    }
+    for (int64_t i = 0; i < total_count_; ++i) {
+        if (not visited[i] and (deleted_ids_.count(i) == 0)) {
+            connect_components++;
+            int64_t component_size = 0;
+            std::queue<int64_t> q;
+            q.push(i);
+            visited[i] = true;
+            while (not q.empty()) {
+                auto node = q.front();
+                q.pop();
+                component_size++;
+                Vector<InnerIdType> neighbors(allocator_);
+                this->bottom_graph_->GetNeighbors(node, neighbors);
+                for (const auto& nb : neighbors) {
+                    if (not visited[nb] and (deleted_ids_.count(nb) == 0)) {
+                        visited[nb] = true;
+                        q.push(nb);
+                    }
+                }
+            }
+        }
+    }
+    stats["connect_components"] = connect_components;
+    stats["deleted_count"] = delete_count_.load();
+    // recall of "base" when searching for "base"
+    uint64_t const_size = 100;
+    int64_t topk = 100;
+    uint64_t sample_size = std::min(const_size, this->total_count_);
+    Vector<float> sample_base_datas(dim_ * sample_size, 0.0f, allocator_);
+    auto codes = this->use_reorder_ ? this->high_precise_codes_ : this->basic_flatten_codes_;
+
+    std::string search_params = R"({
+        "hgraph": {
+            "ef_search": 200
+        }
+    })";
+    int64_t hit_count = 0;
+    int64_t all_neighbor_count = 0;
+    int64_t hit_neighbor_count = 0;
+    float avg_distance_base = 0.0f;
+    for (uint64_t i = 0; i < sample_size; ++i) {
+        InnerIdType sample_id = rand() % this->total_count_;
+        GetVectorByInnerId(sample_id, sample_base_datas.data() + i * dim_);
+        // generate groundtruth
+        DistHeapPtr groundtruth = std::make_shared<StandardHeap<true, false>>(allocator_, -1);
+        for (uint64_t j = 0; j < this->total_count_; ++j) {
+            float dist = codes->ComputePairVectors(sample_id, j);
+            if (groundtruth->Size() < topk) {
+                groundtruth->Push({dist, j});
+            } else if (dist < groundtruth->Top().first) {
+                groundtruth->Pop();
+                groundtruth->Push({dist, j});
+            }
+        }
+        // neighbors of a point and the proximity relationship of a point
+        Vector<InnerIdType> neighbors(allocator_);
+        this->bottom_graph_->GetNeighbors(sample_id, neighbors);
+        size_t neighbor_size = neighbors.size();
+        UnorderedSet<LabelType> groundtruth_ids(allocator_);
+        UnorderedSet<LabelType> neighbor_groundtruth_ids(allocator_);
+        while (not groundtruth->Empty()) {
+            auto id = groundtruth->Top().second;
+            groundtruth_ids.insert(this->label_table_->GetLabelById(id));
+            if (groundtruth->Size() <= neighbor_size) {
+                neighbor_groundtruth_ids.insert(this->label_table_->GetLabelById(id));
+            }
+            avg_distance_base += groundtruth->Top().first;
+            groundtruth->Pop();
+        }
+        all_neighbor_count += neighbor_size;
+        for (const auto& id : neighbors) {
+            if (neighbor_groundtruth_ids.count(this->label_table_->GetLabelById(id)) > 0) {
+                hit_neighbor_count++;
+            }
+        }
+
+        // search
+        auto query = Dataset::Make();
+        query->Owner(false)
+            ->NumElements(1)
+            ->Float32Vectors(sample_base_datas.data() + i * dim_)
+            ->Dim(dim_);
+        auto result = this->KnnSearch(query, topk, search_params, nullptr);
+        // calculate recall
+        for (int64_t j = 0; j < result->GetDim(); ++j) {
+            auto id = result->GetIds()[j];
+            if (groundtruth_ids.count(id) > 0) {
+                hit_count++;
+            }
+        }
+    }
+    stats["recall_base"] = static_cast<float>(hit_count) / (sample_size * topk);
+    stats["proximity_recall_neighbor"] =
+        static_cast<float>(hit_neighbor_count) / all_neighbor_count;
+    stats["avg_distance_base"] = avg_distance_base / (sample_size * (topk - 1));
+
+    // record quantized information
+    if (this->use_reorder_) {
+        float bias_ratio = 0.0f;
+        float inversion_count_rate = 0.0f;
+        for (uint64_t i = 0; i < sample_size; ++i) {
+            float tmp_bias_ratio = 0.0f;
+            float tmp_inversion_count_rate = 0.0f;
+            this->use_reorder_ = false;
+            auto query_data = sample_base_datas.data() + i * dim_;
+            auto query = Dataset::Make();
+            query->Owner(false)->NumElements(1)->Float32Vectors(query_data)->Dim(dim_);
+            auto search_result = this->KnnSearch(query, topk, search_params, nullptr);
+            this->use_reorder_ = true;
+            auto distance_result =
+                this->CalDistanceById(query_data, search_result->GetIds(), search_result->GetDim());
+            auto ground_distances = distance_result->GetDistances();
+            auto approximate_distances = search_result->GetDistances();
+            for (int64_t j = 0; j < topk; ++j) {
+                if (ground_distances[j] > 0) {
+                    tmp_bias_ratio += std::abs(approximate_distances[j] - ground_distances[j]) /
+                                      ground_distances[j];
+                }
+            }
+            tmp_bias_ratio /= topk;
+            bias_ratio += tmp_bias_ratio;
+            // calculate inversion count rate
+            int64_t inversion_count = 0;
+            for (int64_t j = 0; j < search_result->GetDim() - 1; ++j) {
+                for (int64_t k = j + 1; k < search_result->GetDim(); ++k) {
+                    if (ground_distances[j] > ground_distances[k]) {
+                        inversion_count++;
+                    }
+                }
+            }
+            tmp_inversion_count_rate =
+                static_cast<float>(inversion_count) /
+                (search_result->GetDim() * (search_result->GetDim() - 1) / 2);
+            inversion_count_rate += tmp_inversion_count_rate;
+        }
+        stats["quantization_bias_ratio"] = bias_ratio / sample_size;
+        stats["quantization_inversion_count_rate"] = inversion_count_rate / sample_size;
+    }
+
+    return stats.dump(4);
 }
 
 }  // namespace vsag

--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -1758,12 +1758,28 @@ HGraph::UpdateAttribute(int64_t id,
     this->attr_filter_index_->UpdateBitsetsByAttr(new_attrs, inner_id, 0, origin_attrs);
 }
 
+const static uint64_t QUERY_SAMPLE_SIZE = 100;
+const static int64_t DEFAULT_TOPK = 100;
+
 std::string
 HGraph::GetStats() const {
     JsonType stats;
+    int64_t topk = DEFAULT_TOPK;
+    uint64_t sample_size = std::min(QUERY_SAMPLE_SIZE, this->total_count_);
+    Vector<float> sample_base_datas(dim_ * sample_size, 0.0F, allocator_);
+    if (this->total_count_ == 0) {
+        stats["total_count"] = 0;
+        return stats.dump();
+    }
+    // TODO(inabao): configure in next pr
+    std::string search_params = R"({
+        "hgraph": {
+            "ef_search": 200
+        }
+    })";
     stats["total_count"] = this->total_count_;
     // duplicate rate
-    int64_t duplicate_num = 0;
+    size_t duplicate_num = 0;
     if (this->label_table_->CompressDuplicateData()) {
         for (int i = 0; i < this->total_count_; ++i) {
             if (this->label_table_->duplicate_records_[i] != nullptr) {
@@ -1771,7 +1787,141 @@ HGraph::GetStats() const {
             }
         }
     }
-    stats["duplicate_rate"] = static_cast<float>(duplicate_num) / this->total_count_;
+    stats["duplicate_rate"] =
+        static_cast<float>(duplicate_num) / static_cast<float>(this->total_count_);
+    stats["deleted_count"] = delete_count_.load();
+    this->analyze_graph_connection(stats);
+    this->analyze_graph_recall(stats, sample_base_datas, sample_size, topk, search_params);
+    this->analyze_quantizer(stats, sample_base_datas, sample_size, topk, search_params);
+    return stats.dump(4);
+}
+
+void
+HGraph::analyze_quantizer(JsonType& stats,
+                          const Vector<float>& data,
+                          uint64_t sample_data_size,
+                          int64_t topk,
+                          const std::string& search_param) const {
+    // record quantized information
+    if (this->use_reorder_) {
+        logger::info("analyze_quantizer: sample_data_size = {}, topk = {}", sample_data_size, topk);
+        float bias_ratio = 0.0F;
+        float inversion_count_rate = 0.0F;
+        for (uint64_t i = 0; i < sample_data_size; ++i) {
+            float tmp_bias_ratio = 0.0F;
+            float tmp_inversion_count_rate = 0.0F;
+            this->use_reorder_ = false;
+            auto* query_data = data.data() + i * dim_;
+            auto query = Dataset::Make();
+            query->Owner(false)->NumElements(1)->Float32Vectors(query_data)->Dim(dim_);
+            auto search_result = this->KnnSearch(query, topk, search_param, nullptr);
+            this->use_reorder_ = true;
+            auto distance_result =
+                this->CalDistanceById(query_data, search_result->GetIds(), search_result->GetDim());
+            const auto* ground_distances = distance_result->GetDistances();
+            const auto* approximate_distances = search_result->GetDistances();
+            for (int64_t j = 0; j < topk; ++j) {
+                if (ground_distances[j] > 0) {
+                    tmp_bias_ratio += std::abs(approximate_distances[j] - ground_distances[j]) /
+                                      ground_distances[j];
+                }
+            }
+            tmp_bias_ratio /= static_cast<float>(topk);
+            bias_ratio += tmp_bias_ratio;
+            // calculate inversion count rate
+            int64_t inversion_count = 0;
+            for (int64_t j = 0; j < search_result->GetDim() - 1; ++j) {
+                for (int64_t k = j + 1; k < search_result->GetDim(); ++k) {
+                    if (ground_distances[j] > ground_distances[k]) {
+                        inversion_count++;
+                    }
+                }
+            }
+            tmp_inversion_count_rate =
+                static_cast<float>(inversion_count) /
+                static_cast<float>(search_result->GetDim() * (search_result->GetDim() - 1) / 2);
+            inversion_count_rate += tmp_inversion_count_rate;
+        }
+        stats["quantization_bias_ratio"] = bias_ratio / static_cast<float>(sample_data_size);
+        stats["quantization_inversion_count_rate"] =
+            inversion_count_rate / static_cast<float>(sample_data_size);
+    }
+}
+
+void
+HGraph::analyze_graph_recall(JsonType& stats,
+                             Vector<float>& data,
+                             uint64_t sample_data_size,
+                             int64_t topk,
+                             const std::string& search_param) const {
+    // recall of "base" when searching for "base"
+    logger::info("analyze_graph_recall: sample_data_size = {}, topk = {}", sample_data_size, topk);
+    auto codes = this->use_reorder_ ? this->high_precise_codes_ : this->basic_flatten_codes_;
+    int64_t hit_count = 0;
+    size_t all_neighbor_count = 0;
+    int64_t hit_neighbor_count = 0;
+    float avg_distance_base = 0.0F;
+    for (uint64_t i = 0; i < sample_data_size; ++i) {
+        InnerIdType sample_id = rand() % this->total_count_;
+        GetVectorByInnerId(sample_id, data.data() + i * dim_);
+        // generate groundtruth
+        DistHeapPtr groundtruth = std::make_shared<StandardHeap<true, false>>(allocator_, -1);
+        if (i % 10 == 0) {
+            logger::info("calculate groundtruth for sample {} of {}", i, i + 10);
+        }
+        for (uint64_t j = 0; j < this->total_count_; ++j) {
+            float dist = codes->ComputePairVectors(sample_id, j);
+            if (groundtruth->Size() < topk) {
+                groundtruth->Push({dist, j});
+            } else if (dist < groundtruth->Top().first) {
+                groundtruth->Pop();
+                groundtruth->Push({dist, j});
+            }
+        }
+        // neighbors of a point and the proximity relationship of a point
+        Vector<InnerIdType> neighbors(allocator_);
+        this->bottom_graph_->GetNeighbors(sample_id, neighbors);
+        size_t neighbor_size = neighbors.size();
+        UnorderedSet<LabelType> groundtruth_ids(allocator_);
+        UnorderedSet<LabelType> neighbor_groundtruth_ids(allocator_);
+        while (not groundtruth->Empty()) {
+            auto id = groundtruth->Top().second;
+            groundtruth_ids.insert(this->label_table_->GetLabelById(id));
+            if (groundtruth->Size() <= neighbor_size) {
+                neighbor_groundtruth_ids.insert(this->label_table_->GetLabelById(id));
+            }
+            avg_distance_base += groundtruth->Top().first;
+            groundtruth->Pop();
+        }
+        all_neighbor_count += neighbor_size;
+        for (const auto& id : neighbors) {
+            if (neighbor_groundtruth_ids.count(this->label_table_->GetLabelById(id)) > 0) {
+                hit_neighbor_count++;
+            }
+        }
+
+        // search
+        auto query = Dataset::Make();
+        query->Owner(false)->NumElements(1)->Float32Vectors(data.data() + i * dim_)->Dim(dim_);
+        auto result = this->KnnSearch(query, topk, search_param, nullptr);
+        // calculate recall
+        for (int64_t j = 0; j < result->GetDim(); ++j) {
+            auto id = result->GetIds()[j];
+            if (groundtruth_ids.count(id) > 0) {
+                hit_count++;
+            }
+        }
+    }
+    stats["recall_base"] =
+        static_cast<float>(hit_count) / static_cast<float>(sample_data_size * topk);
+    stats["proximity_recall_neighbor"] =
+        static_cast<float>(hit_neighbor_count) / static_cast<float>(all_neighbor_count);
+    stats["avg_distance_base"] =
+        avg_distance_base / static_cast<float>(sample_data_size * (topk - 1));
+}
+
+void
+HGraph::analyze_graph_connection(JsonType& stats) const {
     // graph connection
     Vector<bool> visited(total_count_, false, allocator_);
     int64_t connect_components = 0;
@@ -1808,123 +1958,6 @@ HGraph::GetStats() const {
         }
     }
     stats["connect_components"] = connect_components;
-    stats["deleted_count"] = delete_count_.load();
-    // recall of "base" when searching for "base"
-    uint64_t const_size = 100;
-    int64_t topk = 100;
-    uint64_t sample_size = std::min(const_size, this->total_count_);
-    Vector<float> sample_base_datas(dim_ * sample_size, 0.0f, allocator_);
-    auto codes = this->use_reorder_ ? this->high_precise_codes_ : this->basic_flatten_codes_;
-
-    std::string search_params = R"({
-        "hgraph": {
-            "ef_search": 200
-        }
-    })";
-    int64_t hit_count = 0;
-    int64_t all_neighbor_count = 0;
-    int64_t hit_neighbor_count = 0;
-    float avg_distance_base = 0.0f;
-    for (uint64_t i = 0; i < sample_size; ++i) {
-        InnerIdType sample_id = rand() % this->total_count_;
-        GetVectorByInnerId(sample_id, sample_base_datas.data() + i * dim_);
-        // generate groundtruth
-        DistHeapPtr groundtruth = std::make_shared<StandardHeap<true, false>>(allocator_, -1);
-        for (uint64_t j = 0; j < this->total_count_; ++j) {
-            float dist = codes->ComputePairVectors(sample_id, j);
-            if (groundtruth->Size() < topk) {
-                groundtruth->Push({dist, j});
-            } else if (dist < groundtruth->Top().first) {
-                groundtruth->Pop();
-                groundtruth->Push({dist, j});
-            }
-        }
-        // neighbors of a point and the proximity relationship of a point
-        Vector<InnerIdType> neighbors(allocator_);
-        this->bottom_graph_->GetNeighbors(sample_id, neighbors);
-        size_t neighbor_size = neighbors.size();
-        UnorderedSet<LabelType> groundtruth_ids(allocator_);
-        UnorderedSet<LabelType> neighbor_groundtruth_ids(allocator_);
-        while (not groundtruth->Empty()) {
-            auto id = groundtruth->Top().second;
-            groundtruth_ids.insert(this->label_table_->GetLabelById(id));
-            if (groundtruth->Size() <= neighbor_size) {
-                neighbor_groundtruth_ids.insert(this->label_table_->GetLabelById(id));
-            }
-            avg_distance_base += groundtruth->Top().first;
-            groundtruth->Pop();
-        }
-        all_neighbor_count += neighbor_size;
-        for (const auto& id : neighbors) {
-            if (neighbor_groundtruth_ids.count(this->label_table_->GetLabelById(id)) > 0) {
-                hit_neighbor_count++;
-            }
-        }
-
-        // search
-        auto query = Dataset::Make();
-        query->Owner(false)
-            ->NumElements(1)
-            ->Float32Vectors(sample_base_datas.data() + i * dim_)
-            ->Dim(dim_);
-        auto result = this->KnnSearch(query, topk, search_params, nullptr);
-        // calculate recall
-        for (int64_t j = 0; j < result->GetDim(); ++j) {
-            auto id = result->GetIds()[j];
-            if (groundtruth_ids.count(id) > 0) {
-                hit_count++;
-            }
-        }
-    }
-    stats["recall_base"] = static_cast<float>(hit_count) / (sample_size * topk);
-    stats["proximity_recall_neighbor"] =
-        static_cast<float>(hit_neighbor_count) / all_neighbor_count;
-    stats["avg_distance_base"] = avg_distance_base / (sample_size * (topk - 1));
-
-    // record quantized information
-    if (this->use_reorder_) {
-        float bias_ratio = 0.0f;
-        float inversion_count_rate = 0.0f;
-        for (uint64_t i = 0; i < sample_size; ++i) {
-            float tmp_bias_ratio = 0.0f;
-            float tmp_inversion_count_rate = 0.0f;
-            this->use_reorder_ = false;
-            auto query_data = sample_base_datas.data() + i * dim_;
-            auto query = Dataset::Make();
-            query->Owner(false)->NumElements(1)->Float32Vectors(query_data)->Dim(dim_);
-            auto search_result = this->KnnSearch(query, topk, search_params, nullptr);
-            this->use_reorder_ = true;
-            auto distance_result =
-                this->CalDistanceById(query_data, search_result->GetIds(), search_result->GetDim());
-            auto ground_distances = distance_result->GetDistances();
-            auto approximate_distances = search_result->GetDistances();
-            for (int64_t j = 0; j < topk; ++j) {
-                if (ground_distances[j] > 0) {
-                    tmp_bias_ratio += std::abs(approximate_distances[j] - ground_distances[j]) /
-                                      ground_distances[j];
-                }
-            }
-            tmp_bias_ratio /= topk;
-            bias_ratio += tmp_bias_ratio;
-            // calculate inversion count rate
-            int64_t inversion_count = 0;
-            for (int64_t j = 0; j < search_result->GetDim() - 1; ++j) {
-                for (int64_t k = j + 1; k < search_result->GetDim(); ++k) {
-                    if (ground_distances[j] > ground_distances[k]) {
-                        inversion_count++;
-                    }
-                }
-            }
-            tmp_inversion_count_rate =
-                static_cast<float>(inversion_count) /
-                (search_result->GetDim() * (search_result->GetDim() - 1) / 2);
-            inversion_count_rate += tmp_inversion_count_rate;
-        }
-        stats["quantization_bias_ratio"] = bias_ratio / sample_size;
-        stats["quantization_inversion_count_rate"] = inversion_count_rate / sample_size;
-    }
-
-    return stats.dump(4);
 }
 
 }  // namespace vsag

--- a/src/algorithm/hgraph.h
+++ b/src/algorithm/hgraph.h
@@ -291,6 +291,24 @@ private:
     elp_optimize();
 
 private:
+    void
+    analyze_quantizer(JsonType& stats,
+                      const Vector<float>& data,
+                      uint64_t sample_data_size,
+                      int64_t topk,
+                      const std::string& search_param) const;
+
+    void
+    analyze_graph_recall(JsonType& stats,
+                         Vector<float>& data,
+                         uint64_t sample_data_size,
+                         int64_t topk,
+                         const std::string& search_param) const;
+
+    void
+    analyze_graph_connection(JsonType& stats) const;
+
+private:
     FlattenInterfacePtr basic_flatten_codes_{nullptr};
     FlattenInterfacePtr high_precise_codes_{nullptr};
     Vector<GraphInterfacePtr> route_graphs_;

--- a/src/algorithm/hgraph.h
+++ b/src/algorithm/hgraph.h
@@ -196,6 +196,9 @@ public:
     bool
     UpdateExtraInfo(const DatasetPtr& new_base) override;
 
+    std::string
+    GetStats() const override;
+
 private:
     const void*
     get_data(const DatasetPtr& dataset, uint32_t index = 0) const {

--- a/src/algorithm/ivf.cpp
+++ b/src/algorithm/ivf.cpp
@@ -529,7 +529,7 @@ IVF::Serialize(StreamWriter& writer) const {
     basic_info[INDEX_PARAM] = this->create_param_ptr_->ToString();
 
     auto metadata = std::make_shared<Metadata>();
-    metadata->Set("basic_info", basic_info);
+    metadata->Set(BASIC_INFO, basic_info);
     metadata->Set("datacell_offsets", datacell_offsets);
     metadata->Set("datacell_sizes", datacell_sizes);
 
@@ -575,7 +575,7 @@ IVF::Deserialize(StreamReader& reader) {
             return;
         }
 
-        auto basic_info = metadata->Get("basic_info");
+        auto basic_info = metadata->Get(BASIC_INFO);
         this->total_elements_ = basic_info["total_elements"];
         this->use_reorder_ = basic_info["use_reorder"];
         this->is_trained_ = basic_info["is_trained"];

--- a/src/inner_string_params.h
+++ b/src/inner_string_params.h
@@ -134,6 +134,8 @@ const char* const SUPPORT_DUPLICATE = "support_duplicate";
 
 const char* const DATACELL_OFFSETS = "datacell_offsets";
 const char* const DATACELL_SIZES = "datacell_sizes";
+const char* const BASIC_INFO = "basic_info";
+const char* const INDEX_TYPE = "type";
 
 const std::unordered_map<std::string, std::string> DEFAULT_MAP = {
     {"INDEX_TYPE_HGRAPH", INDEX_TYPE_HGRAPH},

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -2,4 +2,5 @@
 add_subdirectory (test_performance)
 add_subdirectory (eval)
 add_subdirectory (check_compatibility)
+add_subdirectory (analyze_index)
 # add_subdirectory (groundtruth)

--- a/tools/analyze_index/CMakeLists.txt
+++ b/tools/analyze_index/CMakeLists.txt
@@ -1,0 +1,9 @@
+
+add_executable (analyze_index analyze_index.cpp)
+target_link_libraries (analyze_index
+        PRIVATE
+        argparse::argparse
+        vsag
+)
+
+

--- a/tools/analyze_index/analyze_index.cpp
+++ b/tools/analyze_index/analyze_index.cpp
@@ -1,0 +1,132 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <vsag/vsag.h>
+
+#include <argparse/argparse.hpp>
+#include <fstream>
+#include <iostream>
+
+#include "algorithm/hgraph.h"
+#include "index/index_impl.h"
+#include "inner_string_params.h"
+#include "storage/serialization.h"
+#include "storage/stream_reader.h"
+
+using namespace vsag;
+
+inline const std::string
+MetricTypeToString(MetricType type) {
+    switch (type) {
+        case MetricType::METRIC_TYPE_L2SQR:
+            return "l2";
+        case MetricType::METRIC_TYPE_IP:
+            return "ip";
+        case MetricType::METRIC_TYPE_COSINE:
+            return "cosine";
+        default:
+            return "unknown";
+    }
+}
+
+std::string
+DataTypesToString(DataTypes type) {
+    switch (type) {
+        case DataTypes::DATA_TYPE_FLOAT:
+            return "float";
+        case DataTypes::DATA_TYPE_INT8:
+            return "int8";
+        case DataTypes::DATA_TYPE_FP16:
+            return "fp16";
+        case DataTypes::DATA_TYPE_SPARSE:
+            return "sparse";
+        default:
+            return "unknown";
+    }
+}
+
+void
+parse_args(argparse::ArgumentParser& parser, int argc, char** argv) {
+    parser.add_argument<std::string>("--index_path", "-i")
+        .required()
+        .help("The index path for load or save");
+
+    try {
+        parser.parse_args(argc, argv);
+    } catch (const std::runtime_error& err) {
+        std::cerr << err.what() << std::endl;
+        std::cerr << parser;
+    }
+}
+
+IndexPtr
+get_index(const std::string& index_path) {
+    std::fstream in_stream(index_path);
+    IOStreamReader reader(in_stream);
+    auto footer = Footer::Parse(reader);
+    if (not footer) {
+        logger::error("Failed to parse footer");
+        exit(-1);
+    }
+    auto meta_data = footer->GetMetadata();
+    auto basic_info = meta_data->Get(BASIC_INFO);
+    if (not basic_info.contains(INDEX_PARAM)) {
+        logger::error("Index parameter not found in metadata");
+        exit(-1);
+    }
+    // parse basic info
+    int64_t dim = basic_info[DIM];
+    int64_t extra_info_size = basic_info["extra_info_size"];
+    DataTypes data_type = static_cast<DataTypes>(basic_info["data_type"].get<int64_t>());
+    MetricType metric_type = static_cast<MetricType>(basic_info["metric"].get<int64_t>());
+    std::string param_str = basic_info[INDEX_PARAM];
+    auto index_param = JsonType::parse(param_str);
+    std::string index_name = index_param[INDEX_TYPE];
+    logger::info("index name: {}", index_name);
+    logger::info("index dim: {}", dim);
+    logger::info("index data type: {}", DataTypesToString(data_type));
+    logger::info("index metric: {}", MetricTypeToString(metric_type));
+    logger::info("index param: {}", index_param.dump(4));
+
+    // create index common parameters
+    IndexCommonParam index_common_params;
+    index_common_params.dim_ = dim;
+    index_common_params.metric_ = metric_type;
+    index_common_params.allocator_ = Engine::CreateDefaultAllocator();
+    index_common_params.data_type_ = data_type;
+    index_common_params.extra_info_size_ = extra_info_size;
+    // create index and deserialize
+    if (index_name == INDEX_HGRAPH) {
+        auto hgraph_parameter = std::make_shared<HGraphParameter>();
+        hgraph_parameter->FromJson(index_param);
+        hgraph_parameter->data_type = data_type;
+        auto inner_index = std::make_shared<HGraph>(hgraph_parameter, index_common_params);
+        inner_index->Deserialize(reader);
+        return std::make_shared<IndexImpl<HGraph>>(inner_index, index_common_params);
+    }
+    logger::error("Index type {} not supported", index_name);
+    exit(-1);
+}
+
+int
+main(int argc, char** argv) {
+    argparse::ArgumentParser program("analyze_index");
+    parse_args(program, argc, argv);
+    std::string index_path = program.get<std::string>("--index_path");
+    // parse index
+    auto index = get_index(index_path);
+    // get index property
+    logger::info("index inner property: {}", index->GetStats());
+}


### PR DESCRIPTION
close #1015

## Summary by Sourcery

Add index analysis support by exposing detailed stats via HGraph::GetStats, updating serialization metadata handling, and introducing a new analyze_index command-line tool with corresponding build entries and tests

New Features:
- Add GetStats method to HGraph for reporting index statistics
- Introduce analyze_index CLI tool to load an index and display its properties

Enhancements:
- Serialize and deserialize extra_info_size and data_type in HGraph
- Switch metadata key to BASIC_INFO constant and make FROM_JSON macro conditional
- Add INDEX_TYPE constant to inner_string_params

Build:
- Include analyze_index tool in CMake build under tools

Tests:
- Add HGraph GetStatus test to verify stats output