### PR TITLE
add overtime check on search

### DIFF
--- a/docs/ivf.md
+++ b/docs/ivf.md
@@ -140,12 +140,19 @@ means that the index is built using 50 buckets, the base quantization type is pq
 - **Optional Values**: 1 to INT_MAX
 - **Default Value**: 1 (only the search main thread do the search)
 
+### timeout_ms
+- **Parameter Type**: double
+- **Parameter Description**: Maximum time cost in milliseconds for each query, used to control the search time cost
+- **Optional Values**: 1 to DOUBLE_MAX
+- **Default Value**: DOUBLE_MAX
+
 ## Examples for Search Parameter String
 ```json
 "ivf": {
     "scan_buckets_count": 10,
     "factor": 2.0,
-    "parallelism": 4
+    "parallelism": 4,
+    "timeout_ms": 30.0
 }
 ```
-means that the search will scan 10 buckets, the factor is 2.0, and the parallelism is 4, around 4 threads per query. 
+means that the search will scan 10 buckets, the factor is 2.0, and the parallelism is 4, around 4 threads per query, and the max time cost is 30ms (when search time exceed 30ms, will return the current result). 

--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -1701,6 +1701,10 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
     search_param.is_inner_id_allowed = ft;
     search_param.topk = static_cast<int64_t>(search_param.ef);
     search_param.consider_duplicate = true;
+    if (params.enable_time_record) {
+        search_param.time_cost = std::make_shared<Timer>();
+        search_param.time_cost->SetThreshold(params.timeout_ms);
+    }
     auto search_result = this->search_one_graph(
         raw_query, this->bottom_graph_, this->basic_flatten_codes_, search_param);
 

--- a/src/algorithm/hgraph_parameter.cpp
+++ b/src/algorithm/hgraph_parameter.cpp
@@ -220,6 +220,11 @@ HGraphSearchParameters::FromJson(const std::string& json_string) {
         obj.use_extra_info_filter = params[INDEX_TYPE_HGRAPH][HGRAPH_USE_EXTRA_INFO_FILTER];
     }
 
+    if (params[INDEX_TYPE_HGRAPH].contains(SEARCH_MAX_TIME_COST_MS)) {
+        obj.timeout_ms = params[INDEX_TYPE_HGRAPH][SEARCH_MAX_TIME_COST_MS];
+        obj.enable_time_record = true;
+    }
+
     return obj;
 }
 }  // namespace vsag

--- a/src/algorithm/hgraph_parameter.h
+++ b/src/algorithm/hgraph_parameter.h
@@ -79,6 +79,8 @@ public:
     int64_t ef_search{30};
     bool use_reorder{false};
     bool use_extra_info_filter{false};
+    bool enable_time_record{false};
+    double timeout_ms{std::numeric_limits<double>::max()};
 
 private:
     HGraphSearchParameters() = default;

--- a/src/algorithm/ivf.cpp
+++ b/src/algorithm/ivf.cpp
@@ -638,6 +638,10 @@ IVF::create_search_param(const std::string& parameters, const FilterPtr& filter)
     param.factor = search_param.topk_factor;
     param.first_order_scan_ratio = search_param.first_order_scan_ratio;
     param.parallel_search_thread_count = search_param.parallel_search_thread_count;
+    if (search_param.enable_time_record) {
+        param.time_cost = std::make_shared<Timer>();
+        param.time_cost->SetThreshold(search_param.timeout_ms);
+    }
     return param;
 }
 
@@ -645,7 +649,8 @@ DatasetPtr
 IVF::reorder(int64_t topk, DistHeapPtr& input, const float* query) const {
     auto [dataset_results, dists, labels] = create_fast_dataset(topk, allocator_);
     auto reorder_heap = Reorder::ReorderByFlatten(input, reorder_codes_, query, allocator_, topk);
-    for (int64_t j = topk - 1; j >= 0; --j) {
+    auto size = static_cast<int64_t>(reorder_heap->Size());
+    for (int64_t j = size - 1; j >= 0; --j) {
         dists[j] = reorder_heap->Top().first;
         labels[j] = label_table_->GetLabelById(reorder_heap->Top().second);
         reorder_heap->Pop();
@@ -711,6 +716,9 @@ IVF::search(const DatasetPtr& query, const InnerSearchParam& param) const {
         Vector<float> centroid(dim_, allocator_);
         Vector<float> dist(allocator_);
         for (uint64_t i = 0; i < bucket_count; ++i) {
+            if (param.time_cost != nullptr and param.time_cost->CheckOvertime()) {
+                break;
+            }
             if (i % search_thread_count != thread_id) {
                 continue;
             }

--- a/src/algorithm/ivf_parameter.h
+++ b/src/algorithm/ivf_parameter.h
@@ -85,6 +85,11 @@ public:
             obj.parallel_search_thread_count = params[INDEX_TYPE_IVF][IVF_SEARCH_PARALLELISM];
         }
 
+        if (params[INDEX_TYPE_IVF].contains(SEARCH_MAX_TIME_COST_MS)) {
+            obj.timeout_ms = params[INDEX_TYPE_IVF][SEARCH_MAX_TIME_COST_MS];
+            obj.enable_time_record = true;
+        }
+
         return obj;
     }
 
@@ -93,6 +98,8 @@ public:
     float topk_factor{2.0F};
     float first_order_scan_ratio{1.0F};
     int64_t parallel_search_thread_count{1};
+    double timeout_ms{std::numeric_limits<double>::max()};
+    bool enable_time_record{false};
 
 private:
     IVFSearchParameters() = default;

--- a/src/impl/basic_searcher.cpp
+++ b/src/impl/basic_searcher.cpp
@@ -298,6 +298,11 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
         hops++;
         auto current_node_pair = candidate_set->Top();
 
+        if (inner_search_param.time_cost != nullptr and
+            inner_search_param.time_cost->CheckOvertime()) {
+            break;
+        }
+
         if constexpr (mode == InnerSearchMode::KNN_SEARCH) {
             if ((-current_node_pair.first) > lower_bound && top_candidates->Size() == ef) {
                 break;

--- a/src/impl/basic_searcher.h
+++ b/src/impl/basic_searcher.h
@@ -21,56 +21,14 @@
 #include "impl/heap/distance_heap.h"
 #include "index/index_common_param.h"
 #include "index/iterator_filter.h"
+#include "inner_search_param.h"
 #include "lock_strategy.h"
+#include "utils/timer.h"
 #include "utils/visited_list.h"
 
 namespace vsag {
 
 static constexpr uint32_t OPTIMIZE_SEARCHER_SAMPLE_SIZE = 10000;
-
-enum InnerSearchMode { KNN_SEARCH = 1, RANGE_SEARCH = 2 };
-
-enum InnerSearchType { PURE = 1, WITH_FILTER = 2 };
-
-class InnerSearchParam {
-public:
-    int64_t topk{0};
-    float radius{0.0f};
-    InnerIdType ep{0};
-    uint64_t ef{10};
-    FilterPtr is_inner_id_allowed{nullptr};
-    float skip_ratio{0.8F};
-    InnerSearchMode search_mode{KNN_SEARCH};
-    int range_search_limit_size{-1};
-    int64_t parallel_search_thread_count{1};
-
-    // for ivf
-    int scan_bucket_size{1};
-    float factor{2.0F};
-    float first_order_scan_ratio{1.0F};
-    Allocator* search_alloc{nullptr};
-    std::vector<ExecutorPtr> executors;
-    mutable int64_t duplicate_id{-1};
-    bool consider_duplicate{false};
-
-    InnerSearchParam&
-    operator=(const InnerSearchParam& other) {
-        if (this != &other) {
-            topk = other.topk;
-            radius = other.radius;
-            ep = other.ep;
-            ef = other.ef;
-            skip_ratio = other.skip_ratio;
-            search_mode = other.search_mode;
-            range_search_limit_size = other.range_search_limit_size;
-            is_inner_id_allowed = other.is_inner_id_allowed;
-            scan_bucket_size = other.scan_bucket_size;
-            factor = other.factor;
-            first_order_scan_ratio = other.first_order_scan_ratio;
-        }
-        return *this;
-    }
-};
 
 constexpr float THRESHOLD_ERROR = 2e-6;
 

--- a/src/impl/inner_search_param.h
+++ b/src/impl/inner_search_param.h
@@ -1,0 +1,71 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "attr/executor/executor.h"
+#include "typing.h"
+#include "utils/timer.h"
+#include "vsag/filter.h"
+
+namespace vsag {
+
+enum InnerSearchMode { KNN_SEARCH = 1, RANGE_SEARCH = 2 };
+
+enum InnerSearchType { PURE = 1, WITH_FILTER = 2 };
+
+class InnerSearchParam {
+public:
+    int64_t topk{0};
+    float radius{0.0f};
+    InnerIdType ep{0};
+    uint64_t ef{10};
+    FilterPtr is_inner_id_allowed{nullptr};
+    float skip_ratio{0.8F};
+    InnerSearchMode search_mode{KNN_SEARCH};
+    int range_search_limit_size{-1};
+    int64_t parallel_search_thread_count{1};
+
+    // for ivf
+    int scan_bucket_size{1};
+    float factor{2.0F};
+    float first_order_scan_ratio{1.0F};
+    Allocator* search_alloc{nullptr};
+    std::vector<ExecutorPtr> executors;
+    mutable int64_t duplicate_id{-1};
+    bool consider_duplicate{false};
+
+    // time record
+    std::shared_ptr<Timer> time_cost{nullptr};
+
+    InnerSearchParam&
+    operator=(const InnerSearchParam& other) {
+        if (this != &other) {
+            topk = other.topk;
+            radius = other.radius;
+            ep = other.ep;
+            ef = other.ef;
+            skip_ratio = other.skip_ratio;
+            search_mode = other.search_mode;
+            range_search_limit_size = other.range_search_limit_size;
+            is_inner_id_allowed = other.is_inner_id_allowed;
+            scan_bucket_size = other.scan_bucket_size;
+            factor = other.factor;
+            first_order_scan_ratio = other.first_order_scan_ratio;
+        }
+        return *this;
+    }
+};
+}  // namespace vsag

--- a/src/inner_string_params.h
+++ b/src/inner_string_params.h
@@ -106,6 +106,7 @@ const char* const BUCKET_USE_RESIDUAL = "use_residual";
 const char* const IVF_SEARCH_PARAM_SCAN_BUCKETS_COUNT = "scan_buckets_count";
 const char* const IVF_SEARCH_PARAM_FACTOR = "factor";
 const char* const IVF_SEARCH_PARALLELISM = "parallelism";
+const char* const SEARCH_MAX_TIME_COST_MS = "timeout_ms";
 
 const char* const IVF_USE_REORDER_KEY = "use_reorder";
 const char* const IVF_PRECISE_CODES_KEY = "precise_codes";

--- a/src/utils/timer.cpp
+++ b/src/utils/timer.cpp
@@ -15,14 +15,44 @@
 
 #include "timer.h"
 
+#include <numeric>
+
 namespace vsag {
-Timer::Timer(double& ref) : ref_(ref) {
+Timer::Timer(double* ref) : ref_(ref) {
     start = std::chrono::steady_clock::now();
+    this->threshold_ = std::numeric_limits<double>::max();
+}
+
+Timer::Timer(double& ref) : Timer(&ref){};
+
+Timer::Timer() : Timer(nullptr){};
+
+double
+Timer::Record() {
+    auto finish = std::chrono::steady_clock::now();
+    std::chrono::duration<double, std::milli> duration = finish - start;
+    return duration.count();
+}
+
+bool
+Timer::CheckOvertime() {
+    if (threshold_ == std::numeric_limits<double>::max()) {
+        return false;
+    }
+    double duration = Record();
+    return duration > threshold_;
+}
+
+void
+Timer::SetThreshold(double threshold) {
+    threshold_ = threshold;
 }
 
 Timer::~Timer() {
     auto finish = std::chrono::steady_clock::now();
     std::chrono::duration<double, std::milli> duration = finish - start;
-    ref_ = duration.count();
+    if (ref_ != nullptr) {
+        *ref_ = duration.count();
+    }
 }
 }  // namespace vsag

--- a/src/utils/timer.h
+++ b/src/utils/timer.h
@@ -20,10 +20,25 @@ namespace vsag {
 class Timer {
 public:
     explicit Timer(double& ref);
+
+    explicit Timer(double* ref);
+
+    explicit Timer();
+
     ~Timer();
 
-public:
-    double& ref_;
+    double
+    Record();
+
+    void
+    SetThreshold(double threshold);
+
+    bool
+    CheckOvertime();
+
+private:
+    double* ref_{nullptr};
+    double threshold_{std::numeric_limits<double>::max()};
     std::chrono::steady_clock::time_point start;
 };
 }  // namespace vsag

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -1740,6 +1740,57 @@ TEST_CASE("[Daily] HGraph With Extra Info", "[ft][hgraph][daily]") {
 }
 
 static void
+TestHGraphSearchOverTime(const fixtures::HGraphTestIndexPtr& test_index,
+                         const fixtures::HGraphResourcePtr& resource) {
+    using namespace fixtures;
+    auto origin_size = vsag::Options::Instance().block_size_limit();
+    auto size = GENERATE(1024 * 1024 * 2);
+    constexpr const char* search_param = R"({
+            "hgraph": {
+                "ef_search": 200,
+                "timeout_ms": 5.0
+            }
+        })";
+    for (auto metric_type : resource->metric_types) {
+        for (auto dim : resource->dims) {
+            for (auto& [base_quantization_str, recall] : resource->test_cases) {
+                INFO(fmt::format("metric_type: {}, dim: {}, base_quantization_str: {}, recall: {}",
+                                 metric_type,
+                                 dim,
+                                 base_quantization_str,
+                                 recall));
+                if (HGraphTestIndex::IsRaBitQ(base_quantization_str) &&
+                    dim < fixtures::RABITQ_MIN_RACALL_DIM) {
+                    continue;  // Skip invalid RaBitQ configurations
+                }
+                vsag::Options::Instance().set_block_size_limit(size);
+                HGraphTestIndex::HGraphBuildParam build_param(
+                    metric_type, dim, base_quantization_str);
+                auto param = HGraphTestIndex::GenerateHGraphBuildParametersString(build_param);
+                auto index = TestIndex::TestFactory(test_index->name, param, true);
+                auto dataset = HGraphTestIndex::pool.GetDatasetAndCreate(
+                    dim, resource->base_count, metric_type);
+                TestIndex::TestBuildIndex(index, dataset, true);
+                TestIndex::TestSearchOvertime(index, dataset, search_param);
+                vsag::Options::Instance().set_block_size_limit(origin_size);
+            }
+        }
+    }
+}
+
+TEST_CASE("[PR] HGraph Search Over Time", "[ft][hgraph][pr]") {
+    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
+    auto resource = test_index->GetResource(true);
+    TestHGraphSearchOverTime(test_index, resource);
+}
+
+TEST_CASE("[Daily] HGraph Search Over Time", "[ft][hgraph][daily]") {
+    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
+    auto resource = test_index->GetResource(false);
+    TestHGraphSearchOverTime(test_index, resource);
+}
+
+static void
 TestHGraphDiskIOType(const fixtures::HGraphTestIndexPtr& test_index,
                      const fixtures::HGraphResourcePtr& resource) {
     using namespace fixtures;

--- a/tests/test_index.cpp
+++ b/tests/test_index.cpp
@@ -2081,4 +2081,23 @@ TestIndex::TestBuildDuplicateIndex(const IndexPtr& index,
     }
 }
 
+void
+TestIndex::TestSearchOvertime(const IndexPtr& index,
+                              const TestDatasetPtr& dataset,
+                              const std::string& search_param) {
+    auto queries = dataset->query_;
+    auto query_count = queries->GetNumElements();
+    auto dim = queries->GetDim();
+    for (auto i = 0; i < query_count; ++i) {
+        auto query = vsag::Dataset::Make();
+        query->NumElements(1)
+            ->Dim(dim)
+            ->Float32Vectors(queries->GetFloat32Vectors() + i * dim)
+            ->SparseVectors(queries->GetSparseVectors() + i)
+            ->Paths(queries->GetPaths() + i)
+            ->Owner(false);
+        auto res = index->KnnSearch(query, 10, search_param);
+        REQUIRE(res.has_value());
+    }
+}
 }  // namespace fixtures

--- a/tests/test_index.h
+++ b/tests/test_index.h
@@ -278,6 +278,11 @@ public:
                  const std::string& search_param,
                  bool with_update = true);
 
+    static void
+    TestSearchOvertime(const IndexPtr& index,
+                       const TestDatasetPtr& dataset,
+                       const std::string& search_param);
+
     constexpr static float RECALL_THRESHOLD = 0.95;
 };
 


### PR DESCRIPTION
closed: #1026 
- implement for hgraph & ivf
- introduce new search param: "max_time_cost_ms"(double)
- update doc for ivf

## Summary by Sourcery

Add search time budget controls by introducing a max_time_cost_ms parameter, integrating timers into IVF and HGraph implementations for early termination, updating docs, and adding corresponding tests

New Features:
- Introduce max_time_cost_ms search parameter to limit per-query time budget

Enhancements:
- Integrate Timer utility into IVF and HGraph search loops to break early on timeout
- Extract InnerSearchParam definition to dedicated header and update related code paths

Documentation:
- Update IVF documentation to describe max_time_cost_ms parameter

Tests:
- Add TestSearchOvertime cases for IVF and HGraph to verify timeout behavior