### PR TITLE
Introduce transform quantizer

### DIFF
--- a/src/data_cell/sparse_vector_datacell.inl
+++ b/src/data_cell/sparse_vector_datacell.inl
@@ -27,7 +27,7 @@ SparseVectorDataCell<QuantTmpl, IOTmpl>::query(float* result_dists,
     for (int i = 0; i < id_count; ++i) {
         bool need_release{true};
         auto codes = this->GetCodesById(idx[i], need_release);
-        result_dists[i] = this->quantizer_->ComputeDist(*computer, codes);
+        result_dists[i] = this->quantizer_->ComputeDist(computer, codes);
         if (need_release) {
             allocator_->Deallocate((void*)codes);
         }

--- a/src/impl/transform/CMakeLists.txt
+++ b/src/impl/transform/CMakeLists.txt
@@ -8,6 +8,8 @@ set (TRANSFORM_SRC
         fht_kac_rotate_transformer.h
         pca_transformer.cpp
         pca_transformer.h
+        vector_transformer_parameter.cpp
+        vector_transformer_parameter.h
 )
 add_library (transform OBJECT ${TRANSFORM_SRC})
 target_link_libraries (transform PUBLIC fmt::fmt coverage_config)

--- a/src/impl/transform/fht_kac_rotate_transformer.cpp
+++ b/src/impl/transform/fht_kac_rotate_transformer.cpp
@@ -61,8 +61,9 @@ FhtKacRotator::Train(const float* data, uint64_t count) {
     this->Train();
 }
 
-void
+TransformerMetaPtr
 FhtKacRotator::Transform(const float* data, float* rotated_vec) const {
+    auto meta = std::make_shared<FHTMeta>();
     auto dim = static_cast<uint64_t>(this->input_dim_);
     std::memcpy(rotated_vec, data, sizeof(float) * dim);
     if (trunc_dim_ == dim) {
@@ -71,7 +72,7 @@ FhtKacRotator::Transform(const float* data, float* rotated_vec) const {
             FHTRotate(rotated_vec, trunc_dim_);
             VecRescale(rotated_vec, trunc_dim_, fac_);
         }
-        return;
+        return meta;
     }
 
     size_t start = dim - trunc_dim_;
@@ -89,6 +90,8 @@ FhtKacRotator::Transform(const float* data, float* rotated_vec) const {
     }
     VecRescale(rotated_vec, dim, 0.25F);
     //origin vec(x,y), after kacs_walk_generic() -> (x+y, x-y),should be resize by sqrt(0.5) for each KacsWalk() to make the len of vector consistent
+
+    return meta;
 }
 void
 FhtKacRotator::InverseTransform(float const* data, float* rotated_vec) const {

--- a/src/impl/transform/fht_kac_rotate_transformer.h
+++ b/src/impl/transform/fht_kac_rotate_transformer.h
@@ -19,13 +19,16 @@
 #include "vector_transformer.h"
 
 namespace vsag {
+
+struct FHTMeta : public TransformerMeta {};
+
 class FhtKacRotator : public VectorTransformer {
 public:
     explicit FhtKacRotator(Allocator* allocator, int64_t dim);
 
     ~FhtKacRotator() override = default;
 
-    void
+    TransformerMetaPtr
     Transform(const float* data, float* rotated_vec) const override;
 
     void

--- a/src/impl/transform/pca_transformer.cpp
+++ b/src/impl/transform/pca_transformer.cpp
@@ -56,8 +56,9 @@ PCATransformer::Train(const float* data, uint64_t count) {
     PerformEigenDecomposition(covariance_matrix.data());
 }
 
-void
+TransformerMetaPtr
 PCATransformer::Transform(const float* input_vec, float* output_vec) const {
+    auto meta = std::make_shared<PCAMeta>();
     vsag::Vector<float> centralized_vec(allocator_);
     centralized_vec.resize(input_dim_, 0.0F);
 
@@ -81,6 +82,8 @@ PCATransformer::Transform(const float* input_vec, float* output_vec) const {
                 0.0F,
                 output_vec,
                 1);
+
+    return meta;
 }
 
 void

--- a/src/impl/transform/pca_transformer.h
+++ b/src/impl/transform/pca_transformer.h
@@ -19,6 +19,35 @@
 
 namespace vsag {
 
+struct PCAMeta : public TransformerMeta {
+    float residual_norm;
+
+    void
+    EncodeMeta(uint8_t* code) override {
+        *((float*)code) = residual_norm;
+    }
+
+    void
+    DecodeMeta(uint8_t* code, uint32_t align_size) override {
+        residual_norm = *((float*)code);
+    }
+
+    static uint32_t
+    GetMetaSize() {
+        return sizeof(float);
+    }
+
+    static uint32_t
+    GetMetaSize(uint32_t align_size) {
+        return std::max(static_cast<uint32_t>(sizeof(float)), align_size);
+    }
+
+    static uint32_t
+    GetAlignSize() {
+        return sizeof(float);
+    }
+};
+
 class PCATransformer : public VectorTransformer {
 public:
     // interface
@@ -33,11 +62,31 @@ public:
     void
     Deserialize(StreamReader& reader) override;
 
-    void
+    TransformerMetaPtr
     Transform(const float* input_vec, float* output_vec) const override;
 
     void
     InverseTransform(const float* input_vec, float* output_vec) const override;
+
+    float
+    RecoveryDistance(float dist, const uint8_t* meta1, const uint8_t* meta2) const override {
+        return dist;
+    };
+
+    uint32_t
+    GetMetaSize() const override {
+        return PCAMeta::GetMetaSize();
+    }
+
+    uint32_t
+    GetMetaSize(uint32_t align_size) const override {
+        return PCAMeta::GetMetaSize(align_size);
+    }
+
+    uint32_t
+    GetAlignSize() const override {
+        return PCAMeta::GetAlignSize();
+    }
 
 public:
     // make public for test

--- a/src/impl/transform/random_orthogonal_transformer.cpp
+++ b/src/impl/transform/random_orthogonal_transformer.cpp
@@ -57,8 +57,9 @@ RandomOrthogonalMatrix::CopyOrthogonalMatrix(float* out_matrix) const {
               out_matrix);
 }
 
-void
+TransformerMetaPtr
 RandomOrthogonalMatrix::Transform(const float* original_vec, float* transformed_vec) const {
+    auto meta = std::make_shared<ROMMeta>();
     // perform matrix-vector multiplication: y = Q * x
     auto dim = static_cast<blasint>(this->input_dim_);
     cblas_sgemv(CblasRowMajor,
@@ -73,6 +74,8 @@ RandomOrthogonalMatrix::Transform(const float* original_vec, float* transformed_
                 0.0F,
                 transformed_vec,
                 1);
+
+    return meta;
 }
 
 void

--- a/src/impl/transform/random_orthogonal_transformer.h
+++ b/src/impl/transform/random_orthogonal_transformer.h
@@ -19,6 +19,8 @@
 
 namespace vsag {
 
+struct ROMMeta : public TransformerMeta {};
+
 class RandomOrthogonalMatrix : public VectorTransformer {
 public:
     explicit RandomOrthogonalMatrix(Allocator* allocator,
@@ -27,7 +29,7 @@ public:
 
     virtual ~RandomOrthogonalMatrix() override = default;
 
-    void
+    TransformerMetaPtr
     Transform(const float* original_vec, float* transformed_vec) const override;
 
     void

--- a/src/impl/transform/vector_transformer_parameter.cpp
+++ b/src/impl/transform/vector_transformer_parameter.cpp
@@ -1,0 +1,59 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "vector_transformer_parameter.h"
+
+#include "inner_string_params.h"
+
+namespace vsag {
+
+void
+VectorTransformerParameter::FromJson(const JsonType& json) {
+    if (json.contains(INPUT_DIM)) {
+        input_dim_ = json[INPUT_DIM];
+    }
+
+    if (json.contains(PCA_DIM)) {
+        pca_dim_ = json[PCA_DIM];
+    }
+}
+
+JsonType
+VectorTransformerParameter::ToJson() const {
+    JsonType json;
+    json[PCA_DIM] = pca_dim_;
+    json[INPUT_DIM] = input_dim_;
+    return json;
+}
+
+bool
+VectorTransformerParameter::CheckCompatibility(const ParamPtr& other) const {
+    auto param = std::dynamic_pointer_cast<VectorTransformerParameter>(other);
+    if (not param) {
+        logger::error(
+            "VectorTransformerParameter::CheckCompatibility: other parameter is not a "
+            "VectorTransformerParameter");
+        return false;
+    }
+    if (pca_dim_ != param->pca_dim_) {
+        return false;
+    }
+    if (input_dim_ != param->input_dim_) {
+        return false;
+    }
+    return true;
+}
+
+}  // namespace vsag

--- a/src/impl/transform/vector_transformer_parameter.h
+++ b/src/impl/transform/vector_transformer_parameter.h
@@ -15,8 +15,28 @@
 
 #pragma once
 
-#include "fht_kac_rotate_transformer.h"
-#include "pca_transformer.h"
-#include "random_orthogonal_transformer.h"
-#include "vector_transformer.h"
-#include "vector_transformer_parameter.h"
+#include "index/index_common_param.h"
+#include "quantization/quantizer_parameter.h"
+
+namespace vsag {
+class VectorTransformerParameter : public Parameter {
+public:
+    VectorTransformerParameter() = default;
+
+    ~VectorTransformerParameter() override = default;
+
+    void
+    FromJson(const JsonType& json) override;
+
+    JsonType
+    ToJson() const override;
+
+    bool
+    CheckCompatibility(const vsag::ParamPtr& other) const override;
+
+public:
+    uint32_t input_dim_;
+    uint32_t pca_dim_;
+};
+
+}  // namespace vsag

--- a/src/impl/transform/vector_transformer_parameter_test.cpp
+++ b/src/impl/transform/vector_transformer_parameter_test.cpp
@@ -1,0 +1,75 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "vector_transformer_parameter.h"
+
+#include <fmt/format.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "inner_string_params.h"
+#include "parameter_test.h"
+
+using namespace vsag;
+
+#define TEST_COMPATIBILITY_CASE(section_name, param_str1, param_str2, expect_compatible) \
+    SECTION(section_name) {                                                              \
+        auto tq_param1 = std::make_shared<vsag::VectorTransformerParameter>();           \
+        auto tq_param2 = std::make_shared<vsag::VectorTransformerParameter>();           \
+        tq_param1->FromString(param_str1);                                               \
+        tq_param2->FromString(param_str2);                                               \
+        if (expect_compatible) {                                                         \
+            REQUIRE(tq_param1->CheckCompatibility(tq_param2));                           \
+        } else {                                                                         \
+            REQUIRE_FALSE(tq_param1->CheckCompatibility(tq_param2));                     \
+        }                                                                                \
+    }
+
+TEST_CASE("Transformer Parameter CheckCompatibility", "[ut][VectorTransformerParameter]") {
+    auto param_template = R"(
+        {{
+            "input_dim": {},
+            "pca_dim": {}
+        }}
+    )";
+    auto param_960_480 = fmt::format(param_template, 960, 480);
+    auto param_959_480 = fmt::format(param_template, 959, 480);
+    auto param_960_959 = fmt::format(param_template, 960, 959);
+
+    SECTION("wrong parameter type") {
+        auto param = std::make_shared<vsag::VectorTransformerParameter>();
+        param->FromString(param_960_480);
+        REQUIRE(param->CheckCompatibility(param));
+        REQUIRE_FALSE(param->CheckCompatibility(std::make_shared<vsag::EmptyParameter>()));
+    }
+
+    TEST_COMPATIBILITY_CASE("different pca_dim", param_960_480, param_960_959, false);
+    TEST_COMPATIBILITY_CASE("different input_dim", param_960_480, param_959_480, false);
+    TEST_COMPATIBILITY_CASE("same", param_960_480, param_960_480, true);
+}
+
+TEST_CASE("Transformer Parameter ToJson Test", "[ut][VectorTransformerParameter]") {
+    std::string param_str = R"(
+        {
+            "input_dim": 960,
+            "pca_dim": 480
+        }
+    )";
+    auto param = std::make_shared<VectorTransformerParameter>();
+    param->FromJson(JsonType::parse(param_str));
+    REQUIRE(param->input_dim_ == 960);
+    REQUIRE(param->pca_dim_ == 480);
+    ParameterTest::TestToJson(param);
+}

--- a/src/inner_string_params.h
+++ b/src/inner_string_params.h
@@ -66,14 +66,26 @@ const char* const QUANTIZATION_TYPE_VALUE_PQ = "pq";
 const char* const QUANTIZATION_TYPE_VALUE_PQFS = "pqfs";
 const char* const QUANTIZATION_TYPE_VALUE_RABITQ = "rabitq";
 const char* const QUANTIZATION_TYPE_VALUE_SPARSE = "sparse";
+const char* const QUANTIZATION_TYPE_VALUE_TQ = "tq";
+
+// vector transformer type
+const char* const TRANSFORMER_TYPE_VALUE_PCA = "pca";
+const char* const TRANSFORMER_TYPE_VALUE_ROM = "rom";
+const char* const TRANSFORMER_TYPE_VALUE_FHT = "fht";
+const char* const TRANSFORMER_TYPE_VALUE_RESIDUAL = "residual";
+const char* const TRANSFORMER_TYPE_VALUE_NORMALIZE = "normalize";
+
+// vector transformer param
+const char* const INPUT_DIM = "input_dim";
+const char* const PCA_DIM = "pca_dim";
+const char* const USE_FHT = "use_fht";
 
 // quantization param
-const char* const PCA_DIM = "pca_dim";
+const char* const TQ_CHAIN = "tq_chain";
 const char* const RABITQ_QUANTIZATION_BITS_PER_DIM_QUERY = "rabitq_bits_per_dim_query";
 const char* const SQ4_UNIFORM_QUANTIZATION_TRUNC_RATE = "sq4_uniform_trunc_rate";
 const char* const PRODUCT_QUANTIZATION_DIM = "pq_dim";
 const char* const PRODUCT_QUANTIZATION_BITS = "pq_bits";
-const char* const USE_FHT = "use_fht";
 
 // graph param value
 const char* const GRAPH_PARAM_MAX_DEGREE = "max_degree";

--- a/src/quantization/CMakeLists.txt
+++ b/src/quantization/CMakeLists.txt
@@ -10,6 +10,7 @@ set (QUANTIZER_SRC
         product_quantization/pq_fastscan_quantizer.cpp
         product_quantization/product_quantizer.cpp
         rabitq_quantization/rabitq_quantizer.cpp
+        transform_quantization/transform_quantizer.cpp
         quantizer_parameter.cpp
         fp32_quantizer_parameter.cpp
         scalar_quantization/sq8_quantizer_parameter.cpp
@@ -22,6 +23,8 @@ set (QUANTIZER_SRC
         rabitq_quantization/rabitq_quantizer_parameter.cpp
         product_quantization/product_quantizer_parameter.cpp
         product_quantization/pq_fastscan_quantizer_parameter.cpp
+        transform_quantization/transform_quantizer_parameter.cpp
+        quantizer_interface.cpp
 )
 
 add_library (quantizer OBJECT ${QUANTIZER_SRC})

--- a/src/quantization/computer_interface.h
+++ b/src/quantization/computer_interface.h
@@ -15,8 +15,32 @@
 
 #pragma once
 
-#include "fht_kac_rotate_transformer.h"
-#include "pca_transformer.h"
-#include "random_orthogonal_transformer.h"
-#include "vector_transformer.h"
-#include "vector_transformer_parameter.h"
+#include <cstdint>
+#include <memory>
+
+#include "metric_type.h"
+
+namespace vsag {
+using DataType = float;
+
+template <typename T>
+class Quantizer;
+
+class ComputerInterface;
+
+using ComputerInterfacePtr = std::shared_ptr<ComputerInterface>;
+
+class ComputerInterface {
+public:
+    ComputerInterface() = default;
+
+    virtual ~ComputerInterface() = default;
+
+    virtual void
+    SetQuery(const DataType* query) = 0;
+
+    virtual ComputerInterfacePtr
+    GetComputerInterfacePtr() = 0;
+};
+
+}  // namespace vsag

--- a/src/quantization/fp32_quantizer.cpp
+++ b/src/quantization/fp32_quantizer.cpp
@@ -25,6 +25,7 @@ template <MetricType metric>
 FP32Quantizer<metric>::FP32Quantizer(int dim, Allocator* allocator)
     : Quantizer<FP32Quantizer<metric>>(dim, allocator) {
     this->code_size_ = dim * sizeof(float);
+    this->query_code_size_ = this->code_size_;
     this->metric_ = metric;
 }
 
@@ -117,7 +118,10 @@ void
 FP32Quantizer<metric>::ProcessQueryImpl(const DataType* query,
                                         Computer<FP32Quantizer<metric>>& computer) const {
     try {
-        computer.buf_ = reinterpret_cast<uint8_t*>(this->allocator_->Allocate(this->code_size_));
+        if (computer.buf_ == nullptr) {
+            computer.buf_ =
+                reinterpret_cast<uint8_t*>(this->allocator_->Allocate(this->query_code_size_));
+        }
     } catch (const std::bad_alloc& e) {
         computer.buf_ = nullptr;
         throw VsagException(ErrorType::NO_ENOUGH_MEMORY, "bad alloc when init computer buf");

--- a/src/quantization/fp32_quantizer_test.cpp
+++ b/src/quantization/fp32_quantizer_test.cpp
@@ -76,7 +76,7 @@ void
 TestSerializeAndDeserializeMetricFP32(uint64_t dim, int count, float error = 1e-5) {
     auto allocator = SafeAllocator::FactoryDefaultAllocator();
     FP32Quantizer<metric> quantizer1(dim, allocator.get());
-    FP32Quantizer<metric> quantizer2(0, allocator.get());
+    FP32Quantizer<metric> quantizer2(dim, allocator.get());
     TestSerializeAndDeserialize<FP32Quantizer<metric>, metric>(
         quantizer1, quantizer2, dim, count, error);
 }

--- a/src/quantization/product_quantization/pq_fastscan_quantizer_test.cpp
+++ b/src/quantization/product_quantization/pq_fastscan_quantizer_test.cpp
@@ -125,11 +125,12 @@ TestComputerBatchPQFS(PQFastScanQuantizer<metric>& quant,
 
     for (int i = 0; i < query_count; ++i) {
         std::shared_ptr<Computer<PQFastScanQuantizer<metric>>> computer;
-        computer = quant.FactoryComputer();
+        computer = std::dynamic_pointer_cast<Computer<PQFastScanQuantizer<metric>>>(
+            quant.FactoryComputer());
         computer->SetQuery(queries.data() + i * dim);
         std::vector<float> dists(count);
 
-        quant.ScanBatchDists(*computer, count, packaged_codes.data(), dists.data());
+        quant.ScanBatchDists(computer, count, packaged_codes.data(), dists.data());
         for (int j = 0; j < count; ++j) {
             auto gt = gt_func(j, i);
             REQUIRE(std::abs(dists[j] - gt) <= error);

--- a/src/quantization/quantizer.h
+++ b/src/quantization/quantizer.h
@@ -21,6 +21,7 @@
 #include "computer.h"
 #include "logger.h"
 #include "metric_type.h"
+#include "quantizer_interface.h"
 #include "storage/stream_reader.h"
 #include "storage/stream_writer.h"
 #include "utils/function_exists_check.h"
@@ -28,12 +29,15 @@
 namespace vsag {
 using DataType = float;
 
+template <MetricType metric = MetricType::METRIC_TYPE_L2SQR>
+class TransformQuantizer;
+
 /**
  * @class Quantizer
  * @brief This class is used for quantization and encoding/decoding of data.
  */
 template <typename QuantT>
-class Quantizer {
+class Quantizer : public QuantizerInterface {
 public:
     explicit Quantizer<QuantT>(int dim, Allocator* allocator)
         : dim_(dim), code_size_(dim * sizeof(DataType)), allocator_(allocator){};
@@ -48,7 +52,7 @@ public:
      * @return True if training was successful; False otherwise.
      */
     bool
-    Train(const DataType* data, uint64_t count) {
+    Train(const DataType* data, uint64_t count) override {
         return cast().TrainImpl(data, count);
     }
 
@@ -60,7 +64,7 @@ public:
      * @return True if training was successful; False otherwise.
      */
     bool
-    ReTrain(const DataType* data, uint64_t count) {
+    ReTrain(const DataType* data, uint64_t count) override {
         this->is_trained_ = false;
         return cast().TrainImpl(data, count);
     }
@@ -73,7 +77,7 @@ public:
      * @return True if encoding was successful; False otherwise.
      */
     bool
-    EncodeOne(const DataType* data, uint8_t* codes) {
+    EncodeOne(const DataType* data, uint8_t* codes) override {
         return cast().EncodeOneImpl(data, codes);
     }
 
@@ -86,7 +90,7 @@ public:
      * @return True if encoding was successful; False otherwise.
      */
     bool
-    EncodeBatch(const DataType* data, uint8_t* codes, uint64_t count) {
+    EncodeBatch(const DataType* data, uint8_t* codes, uint64_t count) override {
         return cast().EncodeBatchImpl(data, codes, count);
     }
 
@@ -98,7 +102,7 @@ public:
      * @return True if decoding was successful; False otherwise.
      */
     bool
-    DecodeOne(const uint8_t* codes, DataType* data) {
+    DecodeOne(const uint8_t* codes, DataType* data) override {
         return cast().DecodeOneImpl(codes, data);
     }
 
@@ -111,7 +115,7 @@ public:
      * @return True if decoding was successful; False otherwise.
      */
     bool
-    DecodeBatch(const uint8_t* codes, DataType* data, uint64_t count) {
+    DecodeBatch(const uint8_t* codes, DataType* data, uint64_t count) override {
         return cast().DecodeBatchImpl(codes, data, count);
     }
 
@@ -124,12 +128,12 @@ public:
      * @return The computed distance between the decoded data points.
      */
     inline float
-    Compute(const uint8_t* codes1, const uint8_t* codes2) {
+    Compute(const uint8_t* codes1, const uint8_t* codes2) override {
         return cast().ComputeImpl(codes1, codes2);
     }
 
     inline void
-    Serialize(StreamWriter& writer) {
+    Serialize(StreamWriter& writer) override {
         StreamWriter::WriteObj(writer, this->dim_);
         StreamWriter::WriteObj(writer, this->metric_);
         StreamWriter::WriteObj(writer, this->code_size_);
@@ -138,7 +142,7 @@ public:
     }
 
     inline void
-    Deserialize(StreamReader& reader) {
+    Deserialize(StreamReader& reader) override {
         StreamReader::ReadObj(reader, this->dim_);
         StreamReader::ReadObj(reader, this->metric_);
         StreamReader::ReadObj(reader, this->code_size_);
@@ -146,38 +150,49 @@ public:
         return cast().DeserializeImpl(reader);
     }
 
-    std::shared_ptr<Computer<QuantT>>
-    FactoryComputer() {
-        return std::make_shared<Computer<QuantT>>(static_cast<QuantT*>(this));
+    ComputerInterfacePtr
+    FactoryComputer() override {
+        auto computer_ptr =
+            std::make_shared<Computer<QuantT>>(static_cast<QuantT*>(this), allocator_);
+        if constexpr (std::is_same_v<QuantT, TransformQuantizer<MetricType::METRIC_TYPE_L2SQR>> or
+                      std::is_same_v<QuantT, TransformQuantizer<MetricType::METRIC_TYPE_IP>> or
+                      std::is_same_v<QuantT, TransformQuantizer<MetricType::METRIC_TYPE_COSINE>>) {
+            computer_ptr->inner_computer_ = cast().quantizer_->FactoryComputer();
+        }
+        return computer_ptr;
     }
 
     inline void
-    ProcessQuery(const DataType* query, Computer<QuantT>& computer) const {
-        return cast().ProcessQueryImpl(query, computer);
+    ProcessQuery(const DataType* query, ComputerInterfacePtr computer) const override {
+        auto computer_ptr = std::dynamic_pointer_cast<Computer<QuantT>>(computer);
+        return cast().ProcessQueryImpl(query, *computer_ptr);
     }
 
     inline void
-    ComputeDist(Computer<QuantT>& computer, const uint8_t* codes, float* dists) const {
-        return cast().ComputeDistImpl(computer, codes, dists);
+    ComputeDist(ComputerInterfacePtr computer, const uint8_t* codes, float* dists) const override {
+        auto computer_ptr = std::dynamic_pointer_cast<Computer<QuantT>>(computer);
+        return cast().ComputeDistImpl(*computer_ptr, codes, dists);
     }
 
     inline float
-    ComputeDist(Computer<QuantT>& computer, const uint8_t* codes) const {
+    ComputeDist(ComputerInterfacePtr computer, const uint8_t* codes) const override {
         float dist = 0.0F;
-        cast().ComputeDistImpl(computer, codes, &dist);
+        auto computer_ptr = std::dynamic_pointer_cast<Computer<QuantT>>(computer);
+        cast().ComputeDistImpl(*computer_ptr, codes, &dist);
         return dist;
     }
 
     inline void
-    ScanBatchDists(Computer<QuantT>& computer,
+    ScanBatchDists(ComputerInterfacePtr computer,
                    uint64_t count,
                    const uint8_t* codes,
-                   float* dists) const {
-        return cast().ScanBatchDistImpl(computer, count, codes, dists);
+                   float* dists) const override {
+        auto computer_ptr = std::dynamic_pointer_cast<Computer<QuantT>>(computer);
+        return cast().ScanBatchDistImpl(*computer_ptr, count, codes, dists);
     }
 
     inline void
-    ComputeDistsBatch4(Computer<QuantT>& computer,
+    ComputeDistsBatch4(ComputerInterfacePtr computer,
                        const uint8_t* codes1,
                        const uint8_t* codes2,
                        const uint8_t* codes3,
@@ -185,38 +200,40 @@ public:
                        float& dists1,
                        float& dists2,
                        float& dists3,
-                       float& dists4) const {
+                       float& dists4) const override {
+        auto computer_ptr = std::dynamic_pointer_cast<Computer<QuantT>>(computer);
         if constexpr (has_ComputeDistsBatch4Impl<QuantT>::value) {
             cast().ComputeDistsBatch4Impl(
-                computer, codes1, codes2, codes3, codes4, dists1, dists2, dists3, dists4);
+                *computer_ptr, codes1, codes2, codes3, codes4, dists1, dists2, dists3, dists4);
         } else {
-            cast().ComputeDistImpl(computer, codes1, &dists1);
-            cast().ComputeDistImpl(computer, codes2, &dists2);
-            cast().ComputeDistImpl(computer, codes3, &dists3);
-            cast().ComputeDistImpl(computer, codes4, &dists4);
+            cast().ComputeDistImpl(*computer_ptr, codes1, &dists1);
+            cast().ComputeDistImpl(*computer_ptr, codes2, &dists2);
+            cast().ComputeDistImpl(*computer_ptr, codes3, &dists3);
+            cast().ComputeDistImpl(*computer_ptr, codes4, &dists4);
         }
     }
 
     inline void
-    ReleaseComputer(Computer<QuantT>& computer) const {
-        cast().ReleaseComputerImpl(computer);
+    ReleaseComputer(ComputerInterfacePtr computer) const override {
+        auto computer_ptr = std::dynamic_pointer_cast<Computer<QuantT>>(computer);
+        cast().ReleaseComputerImpl(*computer_ptr);
     }
 
     [[nodiscard]] virtual std::string
-    Name() const {
+    Name() const override {
         return cast().NameImpl();
     }
 
     [[nodiscard]] MetricType
-    Metric() const {
+    Metric() const override {
         return this->metric_;
     }
 
     virtual void
-    Package32(const uint8_t* codes, uint8_t* packaged_codes, int64_t valid_size) const {};
+    Package32(const uint8_t* codes, uint8_t* packaged_codes, int64_t valid_size) const override{};
 
     virtual void
-    Unpack32(const uint8_t* packaged_codes, uint8_t* codes) const {};
+    Unpack32(const uint8_t* packaged_codes, uint8_t* codes) const override{};
 
     /**
      * @brief Get the size of the encoded code in bytes.
@@ -224,8 +241,13 @@ public:
      * @return The code size in bytes.
      */
     inline uint64_t
-    GetCodeSize() const {
+    GetCodeSize() const override {
         return this->code_size_;
+    }
+
+    inline uint64_t
+    GetQueryCodeSize() const override {
+        return this->query_code_size_;
     }
 
     /**
@@ -234,7 +256,7 @@ public:
      * @return The dimensionality of the input data.
      */
     inline int
-    GetDim() const {
+    GetDim() const override {
         return this->dim_;
     }
 
@@ -253,6 +275,7 @@ private:
 
 private:
     uint64_t dim_{0};
+    uint64_t query_code_size_{0};
     uint64_t code_size_{0};
     bool is_trained_{false};
     MetricType metric_{MetricType::METRIC_TYPE_L2SQR};

--- a/src/quantization/quantizer_headers.h
+++ b/src/quantization/quantizer_headers.h
@@ -20,3 +20,4 @@
 #include "quantizer.h"
 #include "rabitq_quantization/rabitq_quantizer.h"
 #include "scalar_quantization/sq_headers.h"
+#include "sparse_quantization/sparse_quantizer.h"

--- a/src/quantization/quantizer_interface.cpp
+++ b/src/quantization/quantizer_interface.cpp
@@ -1,0 +1,75 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "quantizer_interface.h"
+
+#include "inner_string_params.h"
+#include "quantization/quantizer_headers.h"
+
+namespace vsag {
+template <MetricType metric>
+static QuantizerInterfacePtr
+make_instance(const QuantizerParamPtr& param, const IndexCommonParam& common_param) {
+    std::string quantization_string = param->GetTypeName();
+    if (quantization_string == QUANTIZATION_TYPE_VALUE_SQ8) {
+        return std::make_shared<SQ8Quantizer<metric>>(param, common_param);
+    }
+    if (quantization_string == QUANTIZATION_TYPE_VALUE_FP32) {
+        return std::make_shared<FP32Quantizer<metric>>(param, common_param);
+    }
+    if (quantization_string == QUANTIZATION_TYPE_VALUE_SQ4) {
+        return std::make_shared<SQ4Quantizer<metric>>(param, common_param);
+    }
+    if (quantization_string == QUANTIZATION_TYPE_VALUE_SQ4_UNIFORM) {
+        return std::make_shared<SQ4UniformQuantizer<metric>>(param, common_param);
+    }
+    if (quantization_string == QUANTIZATION_TYPE_VALUE_SQ8_UNIFORM) {
+        return std::make_shared<SQ8UniformQuantizer<metric>>(param, common_param);
+    }
+    if (quantization_string == QUANTIZATION_TYPE_VALUE_BF16) {
+        return std::make_shared<BF16Quantizer<metric>>(param, common_param);
+    }
+    if (quantization_string == QUANTIZATION_TYPE_VALUE_FP16) {
+        return std::make_shared<FP16Quantizer<metric>>(param, common_param);
+    }
+    if (quantization_string == QUANTIZATION_TYPE_VALUE_PQ) {
+        return std::make_shared<ProductQuantizer<metric>>(param, common_param);
+    }
+    if (quantization_string == QUANTIZATION_TYPE_VALUE_RABITQ) {
+        return std::make_shared<RaBitQuantizer<metric>>(param, common_param);
+    }
+    if (quantization_string == QUANTIZATION_TYPE_VALUE_SPARSE) {
+        return std::make_shared<SparseQuantizer<metric>>(param, common_param);
+    }
+    return nullptr;
+}
+
+QuantizerInterfacePtr
+QuantizerInterface::MakeInstance(const QuantizerParamPtr& param,
+                                 const IndexCommonParam& common_param) {
+    auto metric = common_param.metric_;
+    if (metric == MetricType::METRIC_TYPE_L2SQR) {
+        return make_instance<MetricType::METRIC_TYPE_L2SQR>(param, common_param);
+    }
+    if (metric == MetricType::METRIC_TYPE_IP) {
+        return make_instance<MetricType::METRIC_TYPE_IP>(param, common_param);
+    }
+    if (metric == MetricType::METRIC_TYPE_COSINE) {
+        return make_instance<MetricType::METRIC_TYPE_COSINE>(param, common_param);
+    }
+    return nullptr;
+}
+
+}  // namespace vsag

--- a/src/quantization/quantizer_interface.h
+++ b/src/quantization/quantizer_interface.h
@@ -1,0 +1,191 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+
+#include "computer.h"
+#include "index/index_common_param.h"
+#include "logger.h"
+#include "metric_type.h"
+#include "quantizer_parameter.h"
+#include "storage/stream_reader.h"
+#include "storage/stream_writer.h"
+#include "utils/function_exists_check.h"
+
+namespace vsag {
+
+using DataType = float;
+class QuantizerInterface;
+using QuantizerInterfacePtr = std::shared_ptr<QuantizerInterface>;
+
+/**
+ * @class Quantizer
+ * @brief This class is used for quantization and encoding/decoding of data.
+ */
+class QuantizerInterface {
+public:
+    QuantizerInterface() = default;
+
+    static QuantizerInterfacePtr
+    MakeInstance(const QuantizerParamPtr& param, const IndexCommonParam& common_param);
+
+public:
+    /**
+     * @brief Trains the model using the provided data.
+     *
+     * @param data Pointer to the input data.
+     * @param count The number of elements in the data array.
+     * @return True if training was successful; False otherwise.
+     */
+    virtual bool
+    Train(const DataType* data, uint64_t count) = 0;
+
+    /**
+     * @brief Re-Train the model using the provided data.
+     *
+     * @param data Pointer to the input data.
+     * @param count The number of elements in the data array.
+     * @return True if training was successful; False otherwise.
+     */
+    virtual bool
+    ReTrain(const DataType* data, uint64_t count) = 0;
+
+    /**
+     * @brief Encodes one element from the input data into a code.
+     *
+     * @param data Pointer to the input data.
+     * @param codes Output buffer where the encoded code will be stored.
+     * @return True if encoding was successful; False otherwise.
+     */
+    virtual bool
+    EncodeOne(const DataType* data, uint8_t* codes) = 0;
+
+    /**
+     * @brief Encodes multiple elements from the input data into codes.
+     *
+     * @param data Pointer to the input data.
+     * @param codes Output buffer where the encoded codes will be stored.
+     * @param count The number of elements to encode.
+     * @return True if encoding was successful; False otherwise.
+     */
+    virtual bool
+    EncodeBatch(const DataType* data, uint8_t* codes, uint64_t count) = 0;
+
+    /**
+     * @brief Decodes an encoded code back into its original data representation.
+     *
+     * @param codes Pointer to the encoded code.
+     * @param data Output buffer where the decoded data will be stored.
+     * @return True if decoding was successful; False otherwise.
+     */
+    virtual bool
+    DecodeOne(const uint8_t* codes, DataType* data) = 0;
+
+    /**
+     * @brief Decodes multiple encoded codes back into their original data representations.
+     *
+     * @param codes Pointer to the encoded codes.
+     * @param data Output buffer where the decoded data will be stored.
+     * @param count The number of elements to decode.
+     * @return True if decoding was successful; False otherwise.
+     */
+    virtual bool
+    DecodeBatch(const uint8_t* codes, DataType* data, uint64_t count) = 0;
+
+    /**
+     * @brief Compute the distance between two encoded codes.
+     *
+     * @tparam float the computed distance.
+     * @param codes1 Pointer to the first encoded code.
+     * @param codes2 Pointer to the second encoded code.
+     * @return The computed distance between the decoded data points.
+     */
+    virtual float
+    Compute(const uint8_t* codes1, const uint8_t* codes2) = 0;
+
+    virtual void
+    Serialize(StreamWriter& writer) = 0;
+
+    virtual void
+    Deserialize(StreamReader& reader) = 0;
+
+    virtual ComputerInterfacePtr
+    FactoryComputer() = 0;
+
+    virtual void
+    ProcessQuery(const DataType* query, ComputerInterfacePtr computer) const = 0;
+
+    virtual void
+    ComputeDist(ComputerInterfacePtr computer, const uint8_t* codes, float* dists) const = 0;
+
+    virtual float
+    ComputeDist(ComputerInterfacePtr computer, const uint8_t* codes) const = 0;
+
+    virtual void
+    ScanBatchDists(ComputerInterfacePtr computer,
+                   uint64_t count,
+                   const uint8_t* codes,
+                   float* dists) const = 0;
+
+    virtual void
+    ComputeDistsBatch4(ComputerInterfacePtr computer,
+                       const uint8_t* codes1,
+                       const uint8_t* codes2,
+                       const uint8_t* codes3,
+                       const uint8_t* codes4,
+                       float& dists1,
+                       float& dists2,
+                       float& dists3,
+                       float& dists4) const = 0;
+
+    virtual void
+    ReleaseComputer(ComputerInterfacePtr computer) const = 0;
+
+    [[nodiscard]] virtual std::string
+    Name() const = 0;
+
+    [[nodiscard]] virtual MetricType
+    Metric() const = 0;
+
+    virtual void
+    Package32(const uint8_t* codes, uint8_t* packaged_codes, int64_t valid_size) const = 0;
+
+    virtual void
+    Unpack32(const uint8_t* packaged_codes, uint8_t* codes) const = 0;
+
+    /**
+     * @brief Get the size of the encoded code in bytes.
+     *
+     * @return The code size in bytes.
+     */
+    virtual uint64_t
+    GetCodeSize() const = 0;
+
+    virtual uint64_t
+    GetQueryCodeSize() const = 0;
+
+    /**
+     * @brief Get the dimensionality of the input data.
+     *
+     * @return The dimensionality of the input data.
+     */
+    virtual int
+    GetDim() const = 0;
+};
+
+}  // namespace vsag

--- a/src/quantization/quantizer_parameter.cpp
+++ b/src/quantization/quantizer_parameter.cpp
@@ -24,6 +24,7 @@
 #include "rabitq_quantization/rabitq_quantizer_parameter.h"
 #include "scalar_quantization/sq_parameter_headers.h"
 #include "sparse_quantization/sparse_quantizer_parameter.h"
+#include "transform_quantization/transform_quantizer_parameter.h"
 
 namespace vsag {
 QuantizerParamPtr
@@ -63,6 +64,9 @@ QuantizerParameter::GetQuantizerParameterByJson(const JsonType& json) {
         quantizer_param->FromJson(json);
     } else if (type_name == QUANTIZATION_TYPE_VALUE_PQFS) {
         quantizer_param = std::make_shared<PQFastScanQuantizerParameter>();
+        quantizer_param->FromJson(json);
+    } else if (type_name == QUANTIZATION_TYPE_VALUE_TQ) {
+        quantizer_param = std::make_shared<TransformQuantizerParameter>();
         quantizer_param->FromJson(json);
     } else {
         throw VsagException(ErrorType::INVALID_ARGUMENT,

--- a/src/quantization/quantizer_test.h
+++ b/src/quantization/quantizer_test.h
@@ -255,7 +255,7 @@ ComputeAllDists(Quantizer<T>& quantizer, std::vector<float> data, uint32_t count
             if (i == j) {
                 continue;
             }
-            dists[i][j] = quantizer.ComputeDist(*computer, code);
+            dists[i][j] = quantizer.ComputeDist(computer, code);
         }
     }
     return dists;
@@ -338,8 +338,7 @@ TestComputer(Quantizer<T>& quant,
 
     float count_unbounded_related_error = 0, count_unbounded_numeric_error = 0;
     for (int i = 0; i < query_count; ++i) {
-        std::shared_ptr<Computer<T>> computer;
-        computer = quant.FactoryComputer();
+        auto computer = quant.FactoryComputer();
         computer->SetQuery(queries.data() + i * dim);
 
         // Test Compute One Dist;
@@ -349,8 +348,8 @@ TestComputer(Quantizer<T>& quant,
             auto gt = gt_func(j, i);
             uint8_t* code = codes1.data() + j * quant.GetCodeSize();
             quant.EncodeOne(vecs.data() + j * dim, code);
-            quant.ComputeDist(*computer, code, dists1.data() + j);
-            REQUIRE(quant.ComputeDist(*computer, code) == dists1[j]);
+            quant.ComputeDist(computer, code, dists1.data() + j);
+            REQUIRE(quant.ComputeDist(computer, code) == dists1[j]);
             if (std::abs(gt - dists1[j]) > error) {
                 count_unbounded_numeric_error++;
             }
@@ -363,7 +362,7 @@ TestComputer(Quantizer<T>& quant,
         std::vector<uint8_t> codes2(quant.GetCodeSize() * count);
         std::vector<float> dists2(count);
         quant.EncodeBatch(vecs.data(), codes2.data(), count);
-        quant.ScanBatchDists(*computer, count, codes2.data(), dists2.data());
+        quant.ScanBatchDists(computer, count, codes2.data(), dists2.data());
         for (int j = 0; j < count; ++j) {
             REQUIRE(fixtures::dist_t(dists1[j]) == fixtures::dist_t(dists2[j]));
         }

--- a/src/quantization/rabitq_quantization/rabitq_quantizer.cpp
+++ b/src/quantization/rabitq_quantization/rabitq_quantizer.cpp
@@ -548,8 +548,11 @@ void
 RaBitQuantizer<metric>::ProcessQueryImpl(const DataType* query,
                                          Computer<RaBitQuantizer>& computer) const {
     try {
-        computer.buf_ = reinterpret_cast<uint8_t*>(this->allocator_->Allocate(query_code_size_));
-        std::fill(computer.buf_, computer.buf_ + query_code_size_, 0);
+        if (computer.buf_ == nullptr) {
+            computer.buf_ =
+                reinterpret_cast<uint8_t*>(this->allocator_->Allocate(this->query_code_size_));
+        }
+        std::fill(computer.buf_, computer.buf_ + this->query_code_size_, 0);
 
         // use residual term in pca, so it's this->original_dim_
         Vector<DataType> pca_data(this->original_dim_, 0, this->allocator_);

--- a/src/quantization/rabitq_quantization/rabitq_quantizer.h
+++ b/src/quantization/rabitq_quantization/rabitq_quantizer.h
@@ -144,7 +144,6 @@ private:
      */
     uint64_t aligned_dim_{0};
     uint64_t num_bits_per_dim_query_{32};
-    uint64_t query_code_size_{0};
     uint64_t query_offset_lb_{0};
     uint64_t query_offset_delta_{0};
     uint64_t query_offset_sum_{0};

--- a/src/quantization/scalar_quantization/bf16_quantizer.cpp
+++ b/src/quantization/scalar_quantization/bf16_quantizer.cpp
@@ -26,6 +26,7 @@ template <MetricType metric>
 BF16Quantizer<metric>::BF16Quantizer(int dim, Allocator* allocator)
     : Quantizer<BF16Quantizer<metric>>(dim, allocator) {
     this->code_size_ = dim * 2;
+    this->query_code_size_ = this->code_size_;
     this->metric_ = metric;
 }
 
@@ -111,7 +112,10 @@ void
 BF16Quantizer<metric>::ProcessQueryImpl(const DataType* query,
                                         Computer<BF16Quantizer>& computer) const {
     try {
-        computer.buf_ = reinterpret_cast<uint8_t*>(this->allocator_->Allocate(this->code_size_));
+        if (computer.buf_ == nullptr) {
+            computer.buf_ =
+                reinterpret_cast<uint8_t*>(this->allocator_->Allocate(this->query_code_size_));
+        }
         this->EncodeOneImpl(query, computer.buf_);
     } catch (const std::bad_alloc& e) {
         throw VsagException(ErrorType::NO_ENOUGH_MEMORY, "bad alloc when init computer buf");

--- a/src/quantization/scalar_quantization/bf16_quantizer_test.cpp
+++ b/src/quantization/scalar_quantization/bf16_quantizer_test.cpp
@@ -75,7 +75,7 @@ void
 TestSerializeAndDeserializeMetricBF16(uint64_t dim, int count, float error = 1e-5) {
     auto allocator = SafeAllocator::FactoryDefaultAllocator();
     BF16Quantizer<metric> quantizer1(dim, allocator.get());
-    BF16Quantizer<metric> quantizer2(0, allocator.get());
+    BF16Quantizer<metric> quantizer2(dim, allocator.get());
     TestSerializeAndDeserialize<BF16Quantizer<metric>, metric>(
         quantizer1, quantizer2, dim, count, error);
 }

--- a/src/quantization/scalar_quantization/fp16_quantizer.cpp
+++ b/src/quantization/scalar_quantization/fp16_quantizer.cpp
@@ -26,6 +26,7 @@ template <MetricType metric>
 FP16Quantizer<metric>::FP16Quantizer(int dim, Allocator* allocator)
     : Quantizer<FP16Quantizer<metric>>(dim, allocator) {
     this->code_size_ = dim * 2;
+    this->query_code_size_ = this->code_size_;
     this->metric_ = metric;
 }
 
@@ -111,7 +112,10 @@ void
 FP16Quantizer<metric>::ProcessQueryImpl(const DataType* query,
                                         Computer<FP16Quantizer>& computer) const {
     try {
-        computer.buf_ = reinterpret_cast<uint8_t*>(this->allocator_->Allocate(this->code_size_));
+        if (computer.buf_ == nullptr) {
+            computer.buf_ =
+                reinterpret_cast<uint8_t*>(this->allocator_->Allocate(this->query_code_size_));
+        }
         this->EncodeOneImpl(query, computer.buf_);
     } catch (std::bad_alloc& e) {
         throw VsagException(

--- a/src/quantization/scalar_quantization/fp16_quantizer_test.cpp
+++ b/src/quantization/scalar_quantization/fp16_quantizer_test.cpp
@@ -74,7 +74,7 @@ void
 TestSerializeAndDeserializeMetricFP16(uint64_t dim, int count, float error = 1e-5) {
     auto allocator = SafeAllocator::FactoryDefaultAllocator();
     FP16Quantizer<metric> quantizer1(dim, allocator.get());
-    FP16Quantizer<metric> quantizer2(0, allocator.get());
+    FP16Quantizer<metric> quantizer2(dim, allocator.get());
     TestSerializeAndDeserialize<FP16Quantizer<metric>, metric>(
         quantizer1, quantizer2, dim, count, error);
 }

--- a/src/quantization/scalar_quantization/sq4_quantizer_test.cpp
+++ b/src/quantization/scalar_quantization/sq4_quantizer_test.cpp
@@ -80,7 +80,7 @@ void
 TestSerializeAndDeserializeMetricSQ4(uint64_t dim, int count, float error = 1e-5) {
     auto allocator = SafeAllocator::FactoryDefaultAllocator();
     SQ4Quantizer<metric> quantizer1(dim, allocator.get());
-    SQ4Quantizer<metric> quantizer2(0, allocator.get());
+    SQ4Quantizer<metric> quantizer2(dim, allocator.get());
     TestSerializeAndDeserialize<SQ4Quantizer<metric>, metric>(
         quantizer1, quantizer2, dim, count, error);
 }

--- a/src/quantization/scalar_quantization/sq4_uniform_quantizer.cpp
+++ b/src/quantization/scalar_quantization/sq4_uniform_quantizer.cpp
@@ -65,6 +65,8 @@ SQ4UniformQuantizer<metric>::SQ4UniformQuantizer(int dim, Allocator* allocator, 
 
     // align 64 bytes (512 bits) to avoid illegal memory access in SIMD
     this->code_size_ = ceil_int(this->code_size_, 64);
+
+    this->query_code_size_ = this->code_size_;
 }
 
 template <MetricType metric>

--- a/src/quantization/scalar_quantization/sq4_uniform_quantizer_test.cpp
+++ b/src/quantization/scalar_quantization/sq4_uniform_quantizer_test.cpp
@@ -75,7 +75,7 @@ void
 TestSerializeAndDeserializeMetricSQ4Uniform(uint64_t dim, int count, float error = 1e-5) {
     auto allocator = SafeAllocator::FactoryDefaultAllocator();
     SQ4UniformQuantizer<metric> quantizer1(dim, allocator.get());
-    SQ4UniformQuantizer<metric> quantizer2(0, allocator.get());
+    SQ4UniformQuantizer<metric> quantizer2(dim, allocator.get());
     TestSerializeAndDeserialize<SQ4UniformQuantizer<metric>, metric, true>(
         quantizer1, quantizer2, dim, count, error);
 }

--- a/src/quantization/scalar_quantization/sq8_quantizer_test.cpp
+++ b/src/quantization/scalar_quantization/sq8_quantizer_test.cpp
@@ -80,7 +80,7 @@ void
 TestSerializeAndDeserializeMetricSQ8(uint64_t dim, int count, float error = 1e-5) {
     auto allocator = SafeAllocator::FactoryDefaultAllocator();
     SQ8Quantizer<metric> quantizer1(dim, allocator.get());
-    SQ8Quantizer<metric> quantizer2(0, allocator.get());
+    SQ8Quantizer<metric> quantizer2(dim, allocator.get());
     TestSerializeAndDeserialize<SQ8Quantizer<metric>, metric>(
         quantizer1, quantizer2, dim, count, error);
 }

--- a/src/quantization/scalar_quantization/sq8_uniform_quantizer.cpp
+++ b/src/quantization/scalar_quantization/sq8_uniform_quantizer.cpp
@@ -54,6 +54,8 @@ SQ8UniformQuantizer<metric>::SQ8UniformQuantizer(int dim, Allocator* allocator)
         offset_sum_ = this->code_size_;
         this->code_size_ += ceil_int(sizeof(sum_type), static_cast<int64_t>(align_size));
     }
+
+    this->query_code_size_ = this->code_size_;
 }
 
 template <MetricType metric>
@@ -196,7 +198,10 @@ void
 SQ8UniformQuantizer<metric>::ProcessQueryImpl(const DataType* query,
                                               Computer<SQ8UniformQuantizer>& computer) const {
     try {
-        computer.buf_ = reinterpret_cast<uint8_t*>(this->allocator_->Allocate(this->code_size_));
+        if (computer.buf_ == nullptr) {
+            computer.buf_ =
+                reinterpret_cast<uint8_t*>(this->allocator_->Allocate(this->query_code_size_));
+        }
         this->EncodeOneImpl(query, computer.buf_);
     } catch (const std::bad_alloc& e) {
         throw VsagException(ErrorType::NO_ENOUGH_MEMORY, "bad alloc when init computer buf");

--- a/src/quantization/scalar_quantization/sq8_uniform_quantizer_test.cpp
+++ b/src/quantization/scalar_quantization/sq8_uniform_quantizer_test.cpp
@@ -75,7 +75,7 @@ void
 TestSerializeAndDeserializeMetricSQ8Uniform(uint64_t dim, int count, float error = 1e-5) {
     auto allocator = SafeAllocator::FactoryDefaultAllocator();
     SQ8UniformQuantizer<metric> quantizer1(dim, allocator.get());
-    SQ8UniformQuantizer<metric> quantizer2(0, allocator.get());
+    SQ8UniformQuantizer<metric> quantizer2(dim, allocator.get());
     TestSerializeAndDeserialize<SQ8UniformQuantizer<metric>, metric, true>(
         quantizer1, quantizer2, dim, count, error);
 }

--- a/src/quantization/transform_quantization/transform_quantizer.cpp
+++ b/src/quantization/transform_quantization/transform_quantizer.cpp
@@ -1,0 +1,251 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "transform_quantizer.h"
+
+#include "impl/transform/transformer_headers.h"
+#include "typing.h"
+#include "utils/util_functions.h"
+
+namespace vsag {
+
+template <MetricType metric>
+TransformQuantizer<metric>::TransformQuantizer(const QuantizerParamPtr& param,
+                                               const IndexCommonParam& common_param)
+    : TransformQuantizer<metric>(std::dynamic_pointer_cast<TransformQuantizerParameter>(param),
+                                 common_param) {
+}
+
+template <MetricType metric>
+TransformQuantizer<metric>::TransformQuantizer(const TransformQuantizerParamPtr& param,
+                                               const IndexCommonParam& common_param)
+    : Quantizer<TransformQuantizer<metric>>(common_param.dim_, common_param.allocator_.get()),
+      base_meta_offsets_(common_param.allocator_.get()),
+      query_meta_offsets_(common_param.allocator_.get()) {
+    // 1. init quantizer
+    auto detailed_quantizer_param =
+        QuantizerParameter::GetQuantizerParameterByJson(param->base_quantizer_json_);
+    this->quantizer_ = this->MakeInstance(detailed_quantizer_param, common_param);
+
+    // 2. init transform chain
+    VectorTransformerParameter transformer_param;
+    transformer_param.FromJson(param->base_quantizer_json_);
+    transformer_param.input_dim_ = this->dim_;
+    for (const auto& transform_str : param->tq_chain_) {
+        transform_chain_.emplace_back(MakeTransformerInstance(transform_str, transformer_param));
+        transformer_param.input_dim_ = transform_chain_.back()->GetOutputDim();
+    }
+
+    // 3. compute align_size
+    align_size_ = sizeof(float);
+    for (const auto& vector_transformer : this->transform_chain_) {
+        auto meta_size = vector_transformer->GetMetaSize();
+        auto align_size = vector_transformer->GetAlignSize();
+        align_size_ = std::max(align_size_, align_size);
+    }
+
+    // 4. compute code_size
+    this->code_size_ = ((quantizer_->GetCodeSize() + align_size_ - 1) / align_size_) * align_size_;
+    this->query_code_size_ =
+        ((quantizer_->GetQueryCodeSize() + align_size_ - 1) / align_size_) * align_size_;
+
+    for (const auto& vector_transformer : this->transform_chain_) {
+        base_meta_offsets_.push_back(this->code_size_);
+        query_meta_offsets_.push_back(this->query_code_size_);
+        auto aligned_meta_size = vector_transformer->GetMetaSize(align_size_);
+        this->code_size_ += aligned_meta_size;
+        this->query_code_size_ += aligned_meta_size;
+    }
+}
+
+template <MetricType metric>
+VectorTransformerPtr
+TransformQuantizer<metric>::MakeTransformerInstance(std::string transform_str,
+                                                    const VectorTransformerParameter& param) const {
+    uint32_t input_dim = param.input_dim_;
+    uint32_t output_dim = input_dim;
+
+    if (transform_str == TRANSFORMER_TYPE_VALUE_PCA) {
+        if (param.pca_dim_ != 0) {
+            output_dim = param.pca_dim_;
+        }
+        return std::make_shared<PCATransformer>(this->allocator_, input_dim, output_dim);
+    }
+
+    if (transform_str == TRANSFORMER_TYPE_VALUE_FHT) {
+        return std::make_shared<FhtKacRotator>(this->allocator_, input_dim);
+    }
+
+    if (transform_str == TRANSFORMER_TYPE_VALUE_ROM) {
+        return std::make_shared<RandomOrthogonalMatrix>(this->allocator_, input_dim, output_dim);
+    }
+
+    throw VsagException(ErrorType::INVALID_ARGUMENT,
+                        fmt::format("invalid transformer name {}", transform_str));
+};
+
+template <MetricType metric>
+bool
+TransformQuantizer<metric>::TrainImpl(const DataType* data, uint64_t count) {
+    // 1. train transformer based on original data
+    for (const auto& vector_transformer : this->transform_chain_) {
+        vector_transformer->Train(data, count);
+    }
+
+    // 2. execute transform on original data
+    Vector<DataType> transformed_data(this->dim_ * count, 0, this->allocator_);
+    Vector<uint8_t> tmp_codes(this->code_size_, 0, this->allocator_);
+    transformed_data.assign(data, data + count * this->dim_);
+    for (auto i = 0; i < count; i++) {
+        ExecuteChainTransform(
+            transformed_data.data() + i * this->dim_, base_meta_offsets_.data(), tmp_codes.data());
+    }
+
+    // 3. train quantizer based on transformed data
+    return quantizer_->Train(transformed_data.data(), count);
+}
+
+template <MetricType metric>
+void
+TransformQuantizer<metric>::ExecuteChainTransform(DataType* prev_data,
+                                                  const uint32_t* meta_offsets,
+                                                  uint8_t* codes) const {
+    Vector<DataType> next_data(this->dim_, 0, this->allocator_);
+
+    for (uint32_t i = 0; i < this->transform_chain_.size(); i++) {
+        auto vector_transformer = this->transform_chain_[i];
+        auto meta_offset = meta_offsets[i];
+
+        auto meta = vector_transformer->Transform(prev_data, next_data.data());
+        meta->EncodeMeta(codes + meta_offset);
+
+        memcpy(prev_data, next_data.data(), this->dim_ * sizeof(DataType));
+    }
+}
+
+template <MetricType metric>
+bool
+TransformQuantizer<metric>::EncodeOneImpl(const DataType* data, uint8_t* codes) const {
+    // 1. execute transform
+    Vector<DataType> data_buffer(this->code_size_, 0, this->allocator_);
+    data_buffer.assign(data, data + this->dim_);
+    ExecuteChainTransform(data_buffer.data(), base_meta_offsets_.data(), codes);
+
+    // 2. execute quantize
+    return quantizer_->EncodeOne(data_buffer.data(), codes);
+};
+
+template <MetricType metric>
+void
+TransformQuantizer<metric>::ProcessQueryImpl(const vsag::DataType* query,
+                                             Computer<TransformQuantizer>& computer) const {
+    // 0. allocate
+    try {
+        computer.buf_ =
+            reinterpret_cast<uint8_t*>(this->allocator_->Allocate(this->query_code_size_));
+    } catch (const std::bad_alloc& e) {
+        computer.buf_ = nullptr;
+        throw VsagException(ErrorType::NO_ENOUGH_MEMORY, "bad alloc when init computer buf");
+    }
+
+    // 1. execute transform
+    Vector<DataType> data_buffer(this->code_size_, 0, this->allocator_);
+    data_buffer.assign(query, query + this->dim_);
+    ExecuteChainTransform(data_buffer.data(), query_meta_offsets_.data(), computer.buf_);
+
+    // 2. execute quantize
+    // note that only when computer.buf_ == nullptr, quantizer_ will allocate data to buf_
+    quantizer_->ProcessQuery(query, computer.inner_computer_);
+};
+
+template <MetricType metric>
+float
+TransformQuantizer<metric>::ExecuteChainDistanceRecovery(float quantize_dist,
+                                                         const uint32_t* meta_offsets_1,
+                                                         const uint32_t* meta_offsets_2,
+                                                         const uint8_t* codes_1,
+                                                         const uint8_t* codes_2) const {
+    auto dist = quantize_dist;
+    for (uint32_t i = 0; i < this->transform_chain_.size(); i++) {
+        auto vector_transformer = this->transform_chain_[i];
+        const auto* meta_1 = codes_1 + meta_offsets_1[i];
+        const auto* meta_2 = codes_2 + meta_offsets_2[i];
+
+        dist = vector_transformer->RecoveryDistance(dist, meta_1, meta_2);
+    }
+
+    return dist;
+}
+
+template <MetricType metric>
+void
+TransformQuantizer<metric>::ComputeDistImpl(Computer<TransformQuantizer>& computer,
+                                            const uint8_t* codes,
+                                            float* dists) const {
+    const auto* meta_offset_1 = query_meta_offsets_.data();
+    const auto* meta_offset_2 = base_meta_offsets_.data();
+
+    const auto* codes_1 = computer.buf_;
+    const auto* codes_2 = codes;
+
+    auto quantize_dist = quantizer_->ComputeDist(computer.inner_computer_, codes);
+    dists[0] =
+        ExecuteChainDistanceRecovery(quantize_dist, meta_offset_1, meta_offset_2, codes_1, codes_2);
+};
+
+template <MetricType metric>
+float
+TransformQuantizer<metric>::ComputeImpl(const uint8_t* codes1, const uint8_t* codes2) const {
+    const auto* meta_offset = base_meta_offsets_.data();
+
+    auto quantize_dist = quantizer_->Compute(codes1, codes2);
+    auto dist =
+        ExecuteChainDistanceRecovery(quantize_dist, meta_offset, meta_offset, codes1, codes2);
+
+    return dist;
+}
+
+template <MetricType metric>
+void
+TransformQuantizer<metric>::ScanBatchDistImpl(Computer<TransformQuantizer<metric>>& computer,
+                                              uint64_t count,
+                                              const uint8_t* codes,
+                                              float* dists) const {
+    for (uint64_t i = 0; i < count; ++i) {
+        this->ComputeDistImpl(computer, codes + i * this->code_size_, dists + i);
+    }
+}
+
+template <MetricType metric>
+void
+TransformQuantizer<metric>::ReleaseComputerImpl(
+    Computer<TransformQuantizer<metric>>& computer) const {
+    this->allocator_->Deallocate(computer.buf_);
+}
+
+template <MetricType metric>
+bool
+TransformQuantizer<metric>::EncodeBatchImpl(const DataType* data,
+                                            uint8_t* codes,
+                                            uint64_t count) const {
+    for (uint64_t i = 0; i < count; ++i) {
+        EncodeOneImpl(data + i * this->dim_, codes + i * this->code_size_);
+    }
+    return true;
+}
+
+TEMPLATE_QUANTIZER(TransformQuantizer)
+
+}  // namespace vsag

--- a/src/quantization/transform_quantization/transform_quantizer.h
+++ b/src/quantization/transform_quantization/transform_quantizer.h
@@ -1,0 +1,121 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <sstream>
+#include <string>
+
+#include "impl/transform/transformer_headers.h"
+#include "index/index_common_param.h"
+#include "inner_string_params.h"
+#include "quantization/quantizer.h"
+#include "quantization/quantizer_interface.h"
+#include "transform_quantizer_parameter.h"
+
+namespace vsag {
+
+using DataType = float;
+
+template <MetricType metric>
+class TransformQuantizer : public Quantizer<TransformQuantizer<metric>> {
+public:
+    explicit TransformQuantizer(const TransformQuantizerParamPtr& param,
+                                const IndexCommonParam& common_param);
+
+    explicit TransformQuantizer(const QuantizerParamPtr& param,
+                                const IndexCommonParam& common_param);
+
+    bool
+    TrainImpl(const DataType* data, uint64_t count);
+
+    bool
+    EncodeOneImpl(const DataType* data, uint8_t* codes) const;
+
+    bool
+    EncodeBatchImpl(const DataType* data, uint8_t* codes, uint64_t count) const;
+
+    bool
+    DecodeOneImpl(const uint8_t* codes, DataType* data) {
+        return false;
+    }
+
+    bool
+    DecodeBatchImpl(const uint8_t* codes, DataType* data, uint64_t count) {
+        return false;
+    }
+
+    float
+    ComputeImpl(const uint8_t* codes1, const uint8_t* codes2) const;
+
+    void
+    ProcessQueryImpl(const DataType* query, Computer<TransformQuantizer>& computer) const;
+
+    void
+    ComputeDistImpl(Computer<TransformQuantizer>& computer,
+                    const uint8_t* codes,
+                    float* dists) const;
+
+    void
+    ScanBatchDistImpl(Computer<TransformQuantizer<metric>>& computer,
+                      uint64_t count,
+                      const uint8_t* codes,
+                      float* dists) const;
+
+    void
+    ReleaseComputerImpl(Computer<TransformQuantizer<metric>>& computer) const;
+
+    void
+    SerializeImpl(StreamWriter& writer) {
+        return;
+    }
+
+    void
+    DeserializeImpl(StreamReader& reader) {
+        return;
+    };
+
+    [[nodiscard]] std::string
+    NameImpl() const {
+        return QUANTIZATION_TYPE_VALUE_TQ;
+    }
+
+public:
+    VectorTransformerPtr
+    MakeTransformerInstance(std::string transform_str,
+                            const VectorTransformerParameter& param) const;
+
+    void
+    ExecuteChainTransform(DataType* prev_data, const uint32_t* meta_offsets, uint8_t* codes) const;
+
+    float
+    ExecuteChainDistanceRecovery(float quantize_dist,
+                                 const uint32_t* meta_offsets_1,
+                                 const uint32_t* meta_offsets_2,
+                                 const uint8_t* codes_1,
+                                 const uint8_t* codes_2) const;
+
+public:
+    Vector<uint32_t> base_meta_offsets_;   // note that code(quantizer) offset is always 0
+    Vector<uint32_t> query_meta_offsets_;  // note that code(quantizer) offset is always 0
+
+    uint32_t align_size_{0};
+
+    QuantizerInterfacePtr quantizer_;
+
+    std::vector<VectorTransformerPtr> transform_chain_;
+};
+
+}  // namespace vsag

--- a/src/quantization/transform_quantization/transform_quantizer_parameter.cpp
+++ b/src/quantization/transform_quantization/transform_quantizer_parameter.cpp
@@ -1,0 +1,105 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "transform_quantizer_parameter.h"
+
+#include "inner_string_params.h"
+#include "logger.h"
+
+namespace vsag {
+
+TransformQuantizerParameter::TransformQuantizerParameter()
+    : QuantizerParameter(QUANTIZATION_TYPE_VALUE_TQ) {
+}
+
+void
+TransformQuantizerParameter::FromJson(const JsonType& json) {
+    std::string chain_str;
+    if (json.contains(TQ_CHAIN)) {
+        chain_str = json[TQ_CHAIN];
+        this->tq_chain_ = SplitString(chain_str);
+    }
+
+    base_quantizer_json_ = json;
+    base_quantizer_json_[QUANTIZATION_TYPE_KEY] = tq_chain_.back();
+    tq_chain_.pop_back();
+}
+
+std::vector<std::string>
+TransformQuantizerParameter::SplitString(const std::string& input, char delimiter) {
+    std::vector<std::string> result;
+    std::stringstream ss(input);
+    std::string item;
+
+    while (std::getline(ss, item, delimiter)) {
+        item.erase(item.begin(), std::find_if(item.begin(), item.end(), [](unsigned char ch) {
+                       return std::isspace(ch) == 0;
+                   }));
+        item.erase(
+            std::find_if(
+                item.rbegin(), item.rend(), [](unsigned char ch) { return std::isspace(ch) == 0; })
+                .base(),
+            item.end());
+
+        if (!item.empty()) {
+            result.push_back(item);
+        }
+    }
+
+    return result;
+}
+
+std::string
+TransformQuantizerParameter::MergeStrings(const std::vector<std::string>& vec, char delimiter) {
+    std::ostringstream oss;
+    for (size_t i = 0; i < vec.size(); ++i) {
+        oss << vec[i];
+        if (i != vec.size() - 1) {
+            oss << delimiter;
+        }
+    }
+    return oss.str();
+}
+
+JsonType
+TransformQuantizerParameter::ToJson() const {
+    JsonType json = base_quantizer_json_;
+    auto tmp_tq_chain = tq_chain_;
+    tmp_tq_chain.emplace_back(json[QUANTIZATION_TYPE_KEY]);
+    json[TQ_CHAIN] = MergeStrings(tmp_tq_chain);
+    return json;
+}
+
+bool
+TransformQuantizerParameter::CheckCompatibility(const ParamPtr& other) const {
+    auto tq_param = std::dynamic_pointer_cast<TransformQuantizerParameter>(other);
+    if (not tq_param) {
+        logger::error(
+            "TransformQuantizerParameter::CheckCompatibility: other parameter is not a "
+            "TransformQuantizerParameter");
+        return false;
+    }
+    if (tq_param->tq_chain_.size() != this->tq_chain_.size()) {
+        return false;
+    }
+    for (auto i = 0; i < tq_param->tq_chain_.size(); i++) {
+        if (this->tq_chain_[i] != tq_param->tq_chain_[i]) {
+            return false;
+        }
+    }
+    return this->base_quantizer_json_[QUANTIZATION_TYPE_KEY] ==
+           tq_param->base_quantizer_json_[QUANTIZATION_TYPE_KEY];
+}
+}  // namespace vsag

--- a/src/quantization/transform_quantization/transform_quantizer_parameter.h
+++ b/src/quantization/transform_quantization/transform_quantizer_parameter.h
@@ -1,0 +1,49 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "quantization/quantizer_parameter.h"
+
+namespace vsag {
+class TransformQuantizerParameter : public QuantizerParameter {
+public:
+    TransformQuantizerParameter();
+
+    ~TransformQuantizerParameter() override = default;
+
+    void
+    FromJson(const JsonType& json) override;
+
+    JsonType
+    ToJson() const override;
+
+    bool
+    CheckCompatibility(const vsag::ParamPtr& other) const override;
+
+    static std::vector<std::string>
+    SplitString(const std::string& input, char delimiter = ',');
+
+    static std::string
+    MergeStrings(const std::vector<std::string>& vec, char delimiter = ',');
+
+public:
+    std::vector<std::string> tq_chain_;
+    JsonType base_quantizer_json_;  // store param of base quantizer
+};
+
+using TransformQuantizerParamPtr = std::shared_ptr<TransformQuantizerParameter>;
+
+}  // namespace vsag

--- a/src/quantization/transform_quantization/transform_quantizer_parameter_test.cpp
+++ b/src/quantization/transform_quantization/transform_quantizer_parameter_test.cpp
@@ -1,0 +1,89 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "transform_quantizer_parameter.h"
+
+#include <fmt/format.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "inner_string_params.h"
+#include "parameter_test.h"
+
+using namespace vsag;
+
+#define TEST_COMPATIBILITY_CASE(section_name, param_str1, param_str2, expect_compatible) \
+    SECTION(section_name) {                                                              \
+        auto tq_param1 = std::make_shared<vsag::TransformQuantizerParameter>();          \
+        auto tq_param2 = std::make_shared<vsag::TransformQuantizerParameter>();          \
+        tq_param1->FromString(param_str1);                                               \
+        tq_param2->FromString(param_str2);                                               \
+        if (expect_compatible) {                                                         \
+            REQUIRE(tq_param1->CheckCompatibility(tq_param2));                           \
+        } else {                                                                         \
+            REQUIRE_FALSE(tq_param1->CheckCompatibility(tq_param2));                     \
+        }                                                                                \
+    }
+
+TEST_CASE("Transform Quantizer Parameter CheckCompatibility", "[ut][TransformQuantizerParameter]") {
+    auto param_template = R"(
+        {{
+            "tq_chain": "{}",
+            "rabitq_use_fht": true,
+            "pca_dim": 960
+        }}
+    )";
+    auto param_pca_rom_rabitq = fmt::format(param_template, "pca, rom, rabitq");
+    auto param_pca_rom_fp32 = fmt::format(param_template, "pca, rom, fp32");
+    auto param_pca_fht_fp32 = fmt::format(param_template, "pca, fht, fp32");
+    auto param_pca_fp32 = fmt::format(param_template, "pca, fp32");
+    auto param_pca_fht_fp32_no_space = fmt::format(param_template, "pca,fht,fp32");
+
+    SECTION("wrong parameter type") {
+        auto param = std::make_shared<vsag::TransformQuantizerParameter>();
+        param->FromString(param_pca_rom_rabitq);
+        REQUIRE(param->CheckCompatibility(param));
+        REQUIRE_FALSE(param->CheckCompatibility(std::make_shared<vsag::EmptyParameter>()));
+    }
+
+    TEST_COMPATIBILITY_CASE(
+        "different base quantization", param_pca_rom_rabitq, param_pca_rom_fp32, false);
+    TEST_COMPATIBILITY_CASE("different pre-process", param_pca_rom_fp32, param_pca_fht_fp32, false);
+    TEST_COMPATIBILITY_CASE("different length", param_pca_fp32, param_pca_fht_fp32, false);
+    TEST_COMPATIBILITY_CASE(
+        "different space", param_pca_fht_fp32_no_space, param_pca_fht_fp32, true);
+}
+
+TEST_CASE("TQ Parameter ToJson Test", "[ut][TransformQuantizerParameter]") {
+    std::string param_str = R"(
+        {
+            "tq_chain": "pca, rom, rabitq",
+            "rabitq_use_fht": true,
+            "pca_dim": 960
+        }
+    )";
+    auto param = std::make_shared<TransformQuantizerParameter>();
+    param->FromJson(JsonType::parse(param_str));
+    REQUIRE(param->base_quantizer_json_[QUANTIZATION_TYPE_KEY] == "rabitq");
+    REQUIRE(param->tq_chain_.size() == 2);
+    ParameterTest::TestToJson(param);
+}
+
+TEST_CASE("TQ parameter Split Merge String Test", "[ut][TransformQuantizerParameter]") {
+    std::string str = "pca,rom,rabitq";
+    auto chain_str = TransformQuantizerParameter::SplitString(str);
+    auto recover_str = TransformQuantizerParameter::MergeStrings(chain_str);
+    REQUIRE(str == recover_str);
+}

--- a/src/quantization/transform_quantization/transform_quantizer_test.cpp
+++ b/src/quantization/transform_quantization/transform_quantizer_test.cpp
@@ -1,0 +1,70 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "transform_quantizer.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+#include <vector>
+
+#include "fixtures.h"
+#include "impl/allocator/safe_allocator.h"
+#include "quantization/quantizer_test.h"
+
+using namespace vsag;
+
+const auto dims = fixtures::get_common_used_dims(10, 114);
+const auto counts = {101, 1001};
+
+template <MetricType metric>
+void
+TestComputeMetricTQ(std::string tq_chain, uint64_t dim, int count, float error = 1e-5) {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    TransformQuantizerParamPtr param = std::make_shared<TransformQuantizerParameter>();
+    auto param_template = R"(
+        {{
+            "tq_chain": "{}",
+            "pca_dim": {}
+        }}
+    )";
+    auto param_str = fmt::format(param_template, tq_chain, dim - 1);
+    auto param_json = vsag::JsonType::parse(param_str);
+    param->FromJson(param_json);
+
+    IndexCommonParam common_param;
+    common_param.allocator_ = allocator;
+    common_param.dim_ = dim;
+    TransformQuantizer<metric> quantizer(param, common_param);
+
+    REQUIRE(quantizer.NameImpl() == QUANTIZATION_TYPE_VALUE_TQ);
+
+    TestComputeCodes<TransformQuantizer<metric>, metric>(quantizer, dim, count, error);
+    TestComputer<TransformQuantizer<metric>, metric>(quantizer, dim, count, error);
+}
+
+TEST_CASE("TQ Compute", "[ut][TransformQuantizer]") {
+    constexpr MetricType metrics[1] = {MetricType::METRIC_TYPE_L2SQR};
+
+    auto tq_chain = GENERATE("rom, pca, fp32", "rom, fp32", "fht, fp32");
+    float error = 0.1;
+    for (auto dim : dims) {
+        if (dim < 100) {
+            continue;
+        }
+        for (auto count : counts) {
+            TestComputeMetricTQ<metrics[0]>(tq_chain, dim, count, error);
+        }
+    }
+}


### PR DESCRIPTION
close #1013

## Performance Comparision on perf-90.yml
this PR:
<img width="1410" height="780" alt="after" src="https://github.com/user-attachments/assets/0f85b8d8-6a49-47a9-85d5-3e1b2f4c744e" />
<img width="1425" height="791" alt="after" src="https://github.com/user-attachments/assets/b34ec839-e510-4cb9-8e5f-50efe83e0361" />

main:
<img width="1416" height="737" alt="before" src="https://github.com/user-attachments/assets/97809b0b-2a7f-4629-82ba-f8058c5b59ea" />
<img width="1423" height="750" alt="before" src="https://github.com/user-attachments/assets/db7909a8-07e7-4a32-9f16-ff7211c74cbf" />


## Summary by Sourcery

Introduce a new transform-based quantizer that composes a configurable chain of vector transformations with an underlying base quantizer, and refactor the quantizer and computer APIs to common interfaces.

New Features:
- Add QuantizerInterface and ComputerInterface to standardize quantizer and compute operations.
- Implement TransformQuantizer type to apply a sequence of vector transformers (PCA, FHT, Random Orthogonal, Normalize) before quantization.
- Provide VectorTransformer and concrete implementations (PCA, FHT, Random Orthogonal) with metadata support.
- Introduce TransformQuantizerParameter and VectorTransformerParameter for JSON-driven configuration of transformation and quantization chains.

Enhancements:
- Refactor Quantizer and Computer classes to inherit from new interfaces and support query code sizes with lazy buffer allocation.
- Add GetQueryCodeSize, override methods, and dynamic pointer usage for improved modularity.
- Update inner_string_params and parameter parsing to include new transformer and TQ options.

Build:
- Update CMakeLists to include transform framework and transform_quantization sources.

Tests:
- Add unit tests for TransformQuantizerParameter, vector transformer parameters, and end-to-end TransformQuantizer functionality.