### PR TITLE
increase beam width during reordering

### DIFF
--- a/src/impl/reorder.cpp
+++ b/src/impl/reorder.cpp
@@ -25,12 +25,21 @@ Reorder::ReorderByFlatten(const DistHeapPtr& input,
                           int64_t topk) {
     auto reorder_heap = DistanceHeap::MakeInstanceBySize<true, true>(allocator, topk);
     auto computer = flatten->FactoryComputer(query);
-
-    while (not input->Empty()) {
-        auto [dist, id] = input->Top();
-        flatten->Query(&dist, computer, &id, 1);
-        reorder_heap->Push(dist, id);
-        input->Pop();
+    size_t candidate_size = input->Size();
+    const auto* candidate_result = input->GetData();
+    Vector<InnerIdType> ids(candidate_size, allocator);
+    Vector<float> dists(candidate_size, allocator);
+    for (int i = 0; i < candidate_size; ++i) {
+        ids[i] = candidate_result[i].second;
+    }
+    flatten->Query(dists.data(), computer, ids.data(), candidate_size);
+    for (int i = 0; i < candidate_size; ++i) {
+        if (reorder_heap->Size() < topk || dists[i] < reorder_heap->Top().first) {
+            reorder_heap->Push(dists[i], candidate_result[i].second);
+        }
+        if (reorder_heap->Size() > topk) {
+            reorder_heap->Pop();
+        }
     }
     return reorder_heap;
 }

--- a/src/impl/reorder.cpp
+++ b/src/impl/reorder.cpp
@@ -36,9 +36,9 @@ Reorder::ReorderByFlatten(const DistHeapPtr& input,
     for (int i = 0; i < candidate_size; ++i) {
         if (reorder_heap->Size() < topk || dists[i] < reorder_heap->Top().first) {
             reorder_heap->Push(dists[i], candidate_result[i].second);
-        }
-        if (reorder_heap->Size() > topk) {
-            reorder_heap->Pop();
+            if (reorder_heap->Size() > topk) {
+                reorder_heap->Pop();
+            }
         }
     }
     return reorder_heap;

--- a/tests/fixtures/test_reader.h
+++ b/tests/fixtures/test_reader.h
@@ -34,7 +34,7 @@ public:
 
     void
     AsyncRead(uint64_t offset, uint64_t len, void* dest, vsag::CallBack callback) override {
-        Read(offset, len, dest);
+        memcpy((char*)dest, binary_.data.get() + offset, len);
         callback(vsag::IOErrorCode::IO_SUCCESS, "success");
     }
 

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -1301,7 +1301,7 @@ TestHGraphReaderIO(const fixtures::HGraphTestIndexPtr& test_index,
 
                 TestIndex::TestBuildIndex(index, dataset, true);
                 if (base_quantization_str.find(',') != std::string::npos) {
-                    base_quantization_str += ",reader_io";
+                    build_param.quantization_str += ",reader_io";
                 }
                 auto reader_param =
                     HGraphTestIndex::GenerateHGraphBuildParametersString(build_param);


### PR DESCRIPTION
## Summary by Sourcery

Optimize the reordering algorithm by batching distance computations and allowing a larger beam during candidate selection, and fix test utility bugs in AsyncRead and quantization string handling.

Bug Fixes:
- Fix AsyncRead in TestReader to use memcpy for correct buffer copying
- Correct quantization parameter concatenation in HGraph tests by appending to the proper variable

Enhancements:
- Batch compute distances for all candidates in ReorderByFlatten and use a dynamic threshold to expand the reordering beam