### PR TITLE
update perf.yml for COHERE

### DIFF
--- a/benchs/indexes/hgraph-90.yml
+++ b/benchs/indexes/hgraph-90.yml
@@ -82,11 +82,11 @@ HGRAPH/OPENAI/90:
 
 HGRAPH/COHERE/90:
     datapath: "/tmp/data/cohere-768-1m-angular.hdf5"
-    type: "build,search" # build, search
+    type: "search" # build, search
     index_name: "hgraph"
-    create_params: '{"dim":768,"dtype":"float32","metric_type":"cosine","index_param":{"base_quantization_type":"sq8_uniform","max_degree":64,"ef_construction":400, "precise_quantization_type":"fp32", "use_reorder":true}}'
-    search_params: '{"hgraph":{"ef_search":29}}'
-    index_path: "/tmp/cohere-768-1m-angular/index/hgraph_index"
+    create_params: '{"dim":768,"dtype":"float32","metric_type":"cosine","index_param":{"base_quantization_type":"rabitq","max_degree":64,"ef_construction":400, "rabitq_use_fht": true,"precise_quantization_type":"fp32", "use_reorder":true}}'
+    search_params: '{"hgraph":{"ef_search":23}}'
+    index_path: "/tmp/cohere-768-1m-angular/index/hgraph_index_rabitq_fht"
     topk: 10
     search_mode: "knn"
     delete_index_after_search: false

--- a/benchs/indexes/hgraph-90.yml
+++ b/benchs/indexes/hgraph-90.yml
@@ -82,11 +82,11 @@ HGRAPH/OPENAI/90:
 
 HGRAPH/COHERE/90:
     datapath: "/tmp/data/cohere-768-1m-angular.hdf5"
-    type: "search" # build, search
+    type: "build,search" # build, search
     index_name: "hgraph"
     create_params: '{"dim":768,"dtype":"float32","metric_type":"cosine","index_param":{"base_quantization_type":"rabitq","max_degree":64,"ef_construction":400, "rabitq_use_fht": true,"precise_quantization_type":"fp32", "use_reorder":true}}'
     search_params: '{"hgraph":{"ef_search":23}}'
-    index_path: "/tmp/cohere-768-1m-angular/index/hgraph_index_rabitq_fht"
+    index_path: "/tmp/cohere-768-1m-angular/index/hgraph_index"
     topk: 10
     search_mode: "knn"
     delete_index_after_search: false

--- a/benchs/indexes/hgraph-95.yml
+++ b/benchs/indexes/hgraph-95.yml
@@ -84,8 +84,8 @@ HGRAPH/COHERE/95:
     datapath: "/tmp/data/cohere-768-1m-angular.hdf5"
     type: "build,search" # build, search
     index_name: "hgraph"
-    create_params: '{"dim":768,"dtype":"float32","metric_type":"cosine","index_param":{"base_quantization_type":"sq8_uniform","max_degree":64,"ef_construction":400, "precise_quantization_type":"fp32", "use_reorder":true}}'
-    search_params: '{"hgraph":{"ef_search":51}}'
+    create_params: '{"dim":768,"dtype":"float32","metric_type":"cosine","index_param":{"base_quantization_type":"rabitq","max_degree":64,"ef_construction":400, "rabitq_use_fht": true,"precise_quantization_type":"fp32", "use_reorder":true}}'
+    search_params: '{"hgraph":{"ef_search":38}}'
     index_path: "/tmp/cohere-768-1m-angular/index/hgraph_index"
     topk: 10
     search_mode: "knn"

--- a/benchs/indexes/hgraph-99.yml
+++ b/benchs/indexes/hgraph-99.yml
@@ -82,13 +82,14 @@ HGRAPH/OPENAI/99:
 
 HGRAPH/COHERE/99:
     datapath: "/tmp/data/cohere-768-1m-angular.hdf5"
-    type: "search" # build, search
+    type: "build,search" # build, search
     index_name: "hgraph"
     create_params: '{"dim":768,"dtype":"float32","metric_type":"cosine","index_param":{"base_quantization_type":"rabitq","max_degree":64,"ef_construction":400, "rabitq_use_fht": true,"precise_quantization_type":"fp32", "use_reorder":true}}'
     search_params: '{"hgraph":{"ef_search":150}}'
     index_path: "/tmp/cohere-768-1m-angular/index/hgraph_index"
     topk: 10
     search_mode: "knn"
+    delete_index_after_search: false
 
 HGRAPH/INTERNET/99:
     datapath: "/tmp/data/wholenet-sparse-1m-ip.hdf5"

--- a/benchs/indexes/hgraph-99.yml
+++ b/benchs/indexes/hgraph-99.yml
@@ -89,7 +89,6 @@ HGRAPH/COHERE/99:
     index_path: "/tmp/cohere-768-1m-angular/index/hgraph_index"
     topk: 10
     search_mode: "knn"
-    delete_index_after_search: false
 
 HGRAPH/INTERNET/99:
     datapath: "/tmp/data/wholenet-sparse-1m-ip.hdf5"

--- a/benchs/indexes/hgraph-99.yml
+++ b/benchs/indexes/hgraph-99.yml
@@ -82,10 +82,10 @@ HGRAPH/OPENAI/99:
 
 HGRAPH/COHERE/99:
     datapath: "/tmp/data/cohere-768-1m-angular.hdf5"
-    type: "build,search" # build, search
+    type: "search" # build, search
     index_name: "hgraph"
-    create_params: '{"dim":768,"dtype":"float32","metric_type":"cosine","index_param":{"base_quantization_type":"sq8_uniform","max_degree":64,"ef_construction":400, "precise_quantization_type":"fp32", "use_reorder":true}}'
-    search_params: '{"hgraph":{"ef_search":185}}'
+    create_params: '{"dim":768,"dtype":"float32","metric_type":"cosine","index_param":{"base_quantization_type":"rabitq","max_degree":64,"ef_construction":400, "rabitq_use_fht": true,"precise_quantization_type":"fp32", "use_reorder":true}}'
+    search_params: '{"hgraph":{"ef_search":150}}'
     index_path: "/tmp/cohere-768-1m-angular/index/hgraph_index"
     topk: 10
     search_mode: "knn"


### PR DESCRIPTION
## Summary by Sourcery

Update COHERE performance workflows to use rabitq quantization with FHT, run only search, tune search parameters, and update index paths.

Enhancements:
- Run only the search stage for COHERE across perf-90, perf-95, and perf-99 configurations
- Switch Hgraph index creation to use rabitq quantization with FHT
- Adjust ef_search values to 23, 38, and 150 for perf-90, perf-95, and perf-99 respectively
- Update index path suffix for perf-90 and perf-95 to reflect rabitq_FHT index