### PR TITLE
reduce memory on fast_bitset

### DIFF
--- a/src/impl/bitset/fast_bitset.h
+++ b/src/impl/bitset/fast_bitset.h
@@ -25,7 +25,7 @@ namespace vsag {
 class FastBitset : public ComputableBitset {
 public:
     explicit FastBitset(Allocator* allocator)
-        : ComputableBitset(), allocator_(allocator), data_(allocator), fill_bit_(false) {
+        : ComputableBitset(), data_(allocator), fill_bit_(false) {
         this->type_ = ComputableBitsetType::FastBitset;
     };
 
@@ -74,15 +74,9 @@ public:
     Dump() override;
 
 private:
-    Vector<uint64_t> data_;
-
-    mutable std::shared_mutex mutex_;
-
-    Allocator* const allocator_{nullptr};
-
     bool fill_bit_{false};
 
-    const uint64_t FILL_ONE = 0xFFFFFFFFFFFFFFFF;
+    Vector<uint64_t> data_;
 };
 
 using FastBitsetPtr = std::shared_ptr<FastBitset>;


### PR DESCRIPTION
## Summary by Sourcery

Reduce memory footprint and simplify FastBitset by removing thread-safety mechanisms, dropping the allocator member, and relocating constants

Enhancements:
- Remove synchronization overhead by eliminating the mutex_ member and all locking in FastBitset methods
- Drop the allocator_ member variable and rely on the constructor parameter for initializing the internal data vector
- Promote FILL_ONE to a file-scope static constexpr and remove the redundant class constant
- Reorder and consolidate data_ declaration in the class for a leaner layout