### PR TITLE
support analyze HGraph by searching

### DIFF
--- a/include/vsag/index.h
+++ b/include/vsag/index.h
@@ -681,6 +681,18 @@ public:
     }
 
     /**
+      * @brief Perform analysis on the index using a search request.
+      *
+      *
+      * @param request The search request to use for index analysis.
+      * @return A JSON-formatted string containing the index analysis result
+      */
+    virtual std::string
+    AnalyzeIndexBySearch(const SearchRequest& request) {
+        throw std::runtime_error("Index not support analyze index by search");
+    }
+
+    /**
       * @brief Check if a specific ID exists in the index.
       *
       * @param id The ID to check for existence in the index.

--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -1815,7 +1815,7 @@ HGraph::UpdateAttribute(int64_t id,
     this->attr_filter_index_->UpdateBitsetsByAttr(new_attrs, inner_id, 0, origin_attrs);
 }
 
-const static uint64_t QUERY_SAMPLE_SIZE = 100;
+const static uint64_t QUERY_SAMPLE_SIZE = 10;
 const static int64_t DEFAULT_TOPK = 100;
 
 std::string
@@ -1828,12 +1828,12 @@ HGraph::GetStats() const {
         stats["total_count"] = 0;
         return stats.dump();
     }
-    // TODO(inabao): configure in next pr
-    std::string search_params = R"({
-        "hgraph": {
-            "ef_search": 200
-        }
-    })";
+    constexpr static const char* search_params_template = R"({{
+        "hgraph": {{
+            "ef_search": {}
+        }}
+    }})";
+    std::string search_params = fmt::format(search_params_template, ef_construct_);
     stats["total_count"] = this->total_count_;
     // duplicate rate
     size_t duplicate_num = 0;
@@ -1849,13 +1849,13 @@ HGraph::GetStats() const {
     stats["deleted_count"] = delete_count_.load();
     this->analyze_graph_connection(stats);
     this->analyze_graph_recall(stats, sample_base_datas, sample_size, topk, search_params);
-    this->analyze_quantizer(stats, sample_base_datas, sample_size, topk, search_params);
+    this->analyze_quantizer(stats, sample_base_datas.data(), sample_size, topk, search_params);
     return stats.dump(4);
 }
 
 void
 HGraph::analyze_quantizer(JsonType& stats,
-                          const Vector<float>& data,
+                          const float* data,
                           uint64_t sample_data_size,
                           int64_t topk,
                           const std::string& search_param) const {
@@ -1868,7 +1868,7 @@ HGraph::analyze_quantizer(JsonType& stats,
             float tmp_bias_ratio = 0.0F;
             float tmp_inversion_count_rate = 0.0F;
             this->use_reorder_ = false;
-            const auto* query_data = data.data() + i * dim_;
+            const auto* query_data = data + i * dim_;
             auto query = Dataset::Make();
             query->Owner(false)->NumElements(1)->Float32Vectors(query_data)->Dim(dim_);
             auto search_result = this->KnnSearch(query, topk, search_param, nullptr);
@@ -1912,6 +1912,10 @@ HGraph::analyze_graph_recall(JsonType& stats,
                              uint64_t sample_data_size,
                              int64_t topk,
                              const std::string& search_param) const {
+    if (this->use_reorder_ && not this->high_precise_codes_->InMemory()) {
+        logger::info(
+            "analyze_graph_recall: high_precise_codes_ is not in memory, skip base recall test");
+    }
     // recall of "base" when searching for "base"
     logger::info("analyze_graph_recall: sample_data_size = {}, topk = {}", sample_data_size, topk);
     auto codes = this->use_reorder_ ? this->high_precise_codes_ : this->basic_flatten_codes_;
@@ -1932,8 +1936,8 @@ HGraph::analyze_graph_recall(JsonType& stats,
             if (groundtruth->Size() < topk) {
                 groundtruth->Push({dist, j});
             } else if (dist < groundtruth->Top().first) {
-                groundtruth->Pop();
                 groundtruth->Push({dist, j});
+                groundtruth->Pop();
             }
         }
         // neighbors of a point and the proximity relationship of a point
@@ -2056,6 +2060,80 @@ HGraph::check_and_init_raw_vector(const FlattenInterfaceParamPtr& raw_vector_par
         raw_vector_ = high_precise_codes_;
         return;
     }
+}
+
+std::string
+HGraph::AnalyzeIndexBySearch(const SearchRequest& request) {
+    JsonType stats;
+    Vector<float> distances(this->total_count_, allocator_);
+    Vector<InnerIdType> ids(this->total_count_, allocator_);
+    std::iota(ids.begin(), ids.end(), 0);
+    auto codes = (this->use_reorder_) ? this->high_precise_codes_ : this->basic_flatten_codes_;
+    auto querys = request.query_;
+    auto topk = std::min(request.topk_, GetNumElements());
+
+    int64_t num_elements = querys->GetNumElements();
+    DistHeapPtr heap = std::make_shared<StandardHeap<true, false>>(allocator_, -1);
+    Vector<UnorderedSet<InnerIdType>> ground_truths(
+        num_elements, UnorderedSet<InnerIdType>(allocator_), allocator_);
+    float dist = 0.0F;
+    for (int64_t i = 0; i < num_elements; i++) {
+        auto query_data = get_data(querys, i);
+        auto computer = codes->FactoryComputer(query_data);
+        if (i % 10 == 0) {
+            logger::info("calculate groundtruth for query data {} of {}", i, i + 10);
+        }
+        codes->Query(distances.data(), computer, ids.data(), this->total_count_);
+        for (int64_t j = 0; j < this->total_count_; ++j) {
+            if (heap->Size() < topk) {
+                heap->Push({distances[j], ids[j]});
+            } else if (distances[j] < heap->Top().first) {
+                heap->Push({distances[j], ids[j]});
+                heap->Pop();
+            }
+        }
+        while (not heap->Empty()) {
+            ground_truths[i].insert(heap->Top().second);
+            dist += heap->Top().first;
+            heap->Pop();
+        }
+    }
+    dist /= static_cast<float>(num_elements * topk);
+    stats["avg_distance_query"] = dist;
+    auto param_str = request.params_str_;
+    double time_cost = 0.0;
+    int64_t result_hit = 0;
+    for (int64_t i = 0; i < num_elements; ++i) {
+        auto query = Dataset::Make();
+        query->NumElements(1)
+            ->Dim(dim_)
+            ->Float32Vectors((const float*)get_data(querys, i))
+            ->Owner(false);
+        DatasetPtr search_result;
+        double single_query_time;
+        {
+            Timer t(single_query_time);
+            search_result = this->KnnSearch(query, topk, param_str, nullptr);
+        }
+        if (search_result->GetDim() != topk) {
+            logger::error(
+                "search result size mismatch: expected {}, got {}", topk, search_result->GetDim());
+            continue;
+        }
+        int64_t hit_count = 0;
+        for (int64_t j = 0; j < search_result->GetDim(); ++j) {
+            if (ground_truths[i].count(search_result->GetIds()[j]) > 0) {
+                hit_count++;
+            }
+        }
+        result_hit += hit_count;
+        time_cost += single_query_time;
+    }
+    stats["recall_query"] =
+        static_cast<double>(result_hit) / static_cast<double>(num_elements * topk);
+    stats["time_cost_query"] = time_cost / static_cast<double>(num_elements);
+    this->analyze_quantizer(stats, querys->GetFloat32Vectors(), num_elements, topk, param_str);
+    return stats.dump(4);
 }
 
 }  // namespace vsag

--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -1915,6 +1915,7 @@ HGraph::analyze_graph_recall(JsonType& stats,
     if (this->use_reorder_ && not this->high_precise_codes_->InMemory()) {
         logger::info(
             "analyze_graph_recall: high_precise_codes_ is not in memory, skip base recall test");
+        return;
     }
     // recall of "base" when searching for "base"
     logger::info("analyze_graph_recall: sample_data_size = {}, topk = {}", sample_data_size, topk);

--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -2079,7 +2079,7 @@ HGraph::AnalyzeIndexBySearch(const SearchRequest& request) {
         num_elements, UnorderedSet<InnerIdType>(allocator_), allocator_);
     float dist = 0.0F;
     for (int64_t i = 0; i < num_elements; i++) {
-        auto query_data = get_data(querys, i);
+        const auto* query_data = get_data(querys, i);
         auto computer = codes->FactoryComputer(query_data);
         if (i % 10 == 0) {
             logger::info("calculate groundtruth for query data {} of {}", i, i + 10);

--- a/src/algorithm/hgraph.h
+++ b/src/algorithm/hgraph.h
@@ -199,6 +199,9 @@ public:
     std::string
     GetStats() const override;
 
+    std::string
+    AnalyzeIndexBySearch(const SearchRequest& request) override;
+
 private:
     const void*
     get_data(const DatasetPtr& dataset, uint32_t index = 0) const {
@@ -293,7 +296,7 @@ private:
 private:
     void
     analyze_quantizer(JsonType& stats,
-                      const Vector<float>& data,
+                      const float* data,
                       uint64_t sample_data_size,
                       int64_t topk,
                       const std::string& search_param) const;

--- a/src/algorithm/inner_index_interface.h
+++ b/src/algorithm/inner_index_interface.h
@@ -320,6 +320,12 @@ public:
                             "Index doesn't support GetStats");
     }
 
+    virtual std::string
+    AnalyzeIndexBySearch(const SearchRequest& request) {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "Index doesn't support analyze index by search");
+    }
+
     [[nodiscard]] virtual bool
     CheckIdExist(int64_t id) const {
         return this->label_table_->CheckLabel(id);

--- a/src/index/index_impl.h
+++ b/src/index/index_impl.h
@@ -425,6 +425,11 @@ public:
         return this->inner_index_->GetStats();
     }
 
+    std::string
+    AnalyzeIndexBySearch(const SearchRequest& request) override {
+        return this->inner_index_->AnalyzeIndexBySearch(request);
+    }
+
     [[nodiscard]] bool
     CheckIdExist(int64_t id) const override {
         return this->inner_index_->CheckIdExist(id);

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -467,6 +467,14 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HGraphTestIndex, "HGraph GetStatus", "[ft
                     dim, resource->base_count, metric_type);
                 TestIndex::TestBuildIndex(index, dataset, true);
                 INFO(index->GetStats());
+                vsag::SearchRequest request;
+                request.topk_ = 100;
+                request.params_str_ = fmt::format(fixtures::search_param_tmp, 200, false);
+                request.query_ = dataset->query_;
+                auto raw_num = dataset->query_->GetNumElements();
+                dataset->query_->NumElements(10);
+                INFO(index->AnalyzeIndexBySearch(request));
+                dataset->query_->NumElements(raw_num);
             }
         }
     }

--- a/tools/analyze_index/AnalysisReportInterpretation.md
+++ b/tools/analyze_index/AnalysisReportInterpretation.md
@@ -1,0 +1,40 @@
+# Index Analysis Report
+**Index Name**: [index name]
+
+---
+
+## 1. **Index Configuration Overview**
+- **Vector Dimension**: [dim value]
+- **Data Type**: [float32/int8/...]
+- **Distance Metric**: [l2/ip/...]
+- **Index Type**: [HGraph/IVF/...]
+- **Storage Backend**: [block_memory_io/memory_io/...]
+
+---
+
+## 2. **Index Inner Property Explanation**
+```json
+{
+    "avg_distance_base": "Average distance between vectors in the base dataset (pre-indexing)",
+    "connect_components": "Number of connected components in the index graph structure",
+    "deleted_count": "Number of vectors marked for deletion in the index",
+    "duplicate_rate": "Proportion of duplicate vectors in the dataset",
+    "proximity_recall_neighbor": "Recall rate for neighbor proximity verification in the index",
+    "quantization_bias_ratio": "Ratio representing quantization bias in compressed vector representation",
+    "quantization_inversion_count_rate": "Rate of quantization-induced distance inversions (incorrect orderings)",
+    "recall_base": "Recall rate of the base dataset (ground truth for comparison)",
+    "total_count": "Total number of vectors in the index"
+}
+
+```
+
+## 3. **Search Analyze Explanation**
+```json
+{
+    "avg_distance_query": "Average distance between query vectors and retrieved nearest neighbors",
+    "quantization_bias_ratio": "Quantization bias observed during search phase",
+    "quantization_inversion_count_rate": "Rate of distance inversions caused by quantization during search",
+    "recall_query": "Recall rate of the search (proportion of true nearest neighbors retrieved)",
+    "time_cost_query": "Average time cost per query in milliseconds"
+}
+```

--- a/tools/analyze_index/analyze_index.cpp
+++ b/tools/analyze_index/analyze_index.cpp
@@ -133,15 +133,15 @@ public:
         return create_index_without_param(index_name_, reader);
     }
 
-    bool
+    void
     AnalyzeQuery(const DatasetPtr& query_dataset, int64_t topk, const std::string& search_param) {
         if (not index_) {
             logger::error("Index not loaded");
-            return false;
+            return;
         }
         if (not query_dataset) {
             logger::error("Query dataset is null");
-            return false;
+            return;
         }
         SearchRequest query_request;
         query_request.query_ = query_dataset;
@@ -149,7 +149,6 @@ public:
         query_request.params_str_ = search_param;
         auto search_result = index_->AnalyzeIndexBySearch(query_request);
         logger::info("Search Analyze: {}", search_result);
-        return true;
     }
 
     void

--- a/tools/analyze_index/analyze_index.cpp
+++ b/tools/analyze_index/analyze_index.cpp
@@ -27,6 +27,10 @@
 
 using namespace vsag;
 
+constexpr static const char* DEFAULT_BUILD_PARAM = "default";
+constexpr static const char* DEFAULT_SEARCH_PARAM = "default";
+constexpr static const char* EMPTY_QUERY_PATH = "empty";
+
 inline const std::string
 MetricTypeToString(MetricType type) {
     switch (type) {
@@ -63,6 +67,25 @@ parse_args(argparse::ArgumentParser& parser, int argc, char** argv) {
         .required()
         .help("The index path for load or save");
 
+    parser.add_argument<std::string>("--build_parameter", "-bp")
+        .default_value(DEFAULT_BUILD_PARAM)
+        .help(
+            "The parameter for build index, "
+            "if not set, will use default parameter in index file");
+
+    parser.add_argument<std::string>("--query_path", "-qp")
+        .default_value(DEFAULT_SEARCH_PARAM)
+        .help("The query dataset path, if not set, will not do query analysis");
+
+    parser.add_argument<std::string>("--search_parameter", "-sp")
+        .default_value(EMPTY_QUERY_PATH)
+        .help("The parameter for search, if not set, will use default parameter");
+
+    parser.add_argument("--topk", "-k")
+        .default_value(100)
+        .help("The topk for search")
+        .scan<'i', int>();
+
     try {
         parser.parse_args(argc, argv);
     } catch (const std::runtime_error& err) {
@@ -71,62 +94,171 @@ parse_args(argparse::ArgumentParser& parser, int argc, char** argv) {
     }
 }
 
-IndexPtr
-get_index(const std::string& index_path) {
-    std::fstream in_stream(index_path);
-    IOStreamReader reader(in_stream);
-    auto footer = Footer::Parse(reader);
-    if (not footer) {
-        logger::error("Failed to parse footer");
-        exit(-1);
+DatasetPtr
+load_query(const std::string& query_path) {
+    std::fstream in_stream(query_path);
+    if (not in_stream.is_open()) {
+        logger::error("Failed to open query file: {}", query_path);
+        return nullptr;
     }
-    auto meta_data = footer->GetMetadata();
-    auto basic_info = meta_data->Get(BASIC_INFO);
-    if (not basic_info.contains(INDEX_PARAM)) {
-        logger::error("Index parameter not found in metadata");
-        exit(-1);
-    }
-    // parse basic info
-    int64_t dim = basic_info[DIM];
-    int64_t extra_info_size = basic_info["extra_info_size"];
-    DataTypes data_type = static_cast<DataTypes>(basic_info["data_type"].get<int64_t>());
-    MetricType metric_type = static_cast<MetricType>(basic_info["metric"].get<int64_t>());
-    std::string param_str = basic_info[INDEX_PARAM];
-    auto index_param = JsonType::parse(param_str);
-    std::string index_name = index_param[INDEX_TYPE];
-    logger::info("index name: {}", index_name);
-    logger::info("index dim: {}", dim);
-    logger::info("index data type: {}", DataTypesToString(data_type));
-    logger::info("index metric: {}", MetricTypeToString(metric_type));
-    logger::info("index param: {}", index_param.dump(4));
-
-    // create index common parameters
-    IndexCommonParam index_common_params;
-    index_common_params.dim_ = dim;
-    index_common_params.metric_ = metric_type;
-    index_common_params.allocator_ = Engine::CreateDefaultAllocator();
-    index_common_params.data_type_ = data_type;
-    index_common_params.extra_info_size_ = extra_info_size;
-    // create index and deserialize
-    if (index_name == INDEX_HGRAPH) {
-        auto hgraph_parameter = std::make_shared<HGraphParameter>();
-        hgraph_parameter->FromJson(index_param);
-        hgraph_parameter->data_type = data_type;
-        auto inner_index = std::make_shared<HGraph>(hgraph_parameter, index_common_params);
-        inner_index->Deserialize(reader);
-        return std::make_shared<IndexImpl<HGraph>>(inner_index, index_common_params);
-    }
-    logger::error("Index type {} not supported", index_name);
-    exit(-1);
+    uint32_t rows, cols;
+    in_stream.read(reinterpret_cast<char*>(&rows), sizeof(rows));
+    in_stream.read(reinterpret_cast<char*>(&cols), sizeof(cols));
+    size_t num_elements = static_cast<size_t>(rows) * cols;
+    auto dataset = Dataset::Make();
+    auto query_data = new float[num_elements];
+    dataset->Float32Vectors(query_data)->Owner(true)->NumElements(rows)->Dim(cols);
+    in_stream.read(reinterpret_cast<char*>(query_data), num_elements * sizeof(float));
+    return dataset;
 }
+
+class AnalyzedIndex {
+public:
+    AnalyzedIndex(const std::string& build_param) : build_param_(build_param) {
+    }
+
+    bool
+    LoadIndex(const std::string& index_path) {
+        std::fstream in_stream(index_path);
+        IOStreamReader reader(in_stream);
+        if (not parse_reader(reader)) {
+            return false;
+        }
+        if (build_param_ != DEFAULT_BUILD_PARAM) {
+            if (not create_index_with_param(index_name_, in_stream)) {
+                return false;
+            }
+            return true;
+        }
+        return create_index_without_param(index_name_, reader);
+    }
+
+    bool
+    AnalyzeQuery(const DatasetPtr& query_dataset, int64_t topk, const std::string& search_param) {
+        if (not index_) {
+            logger::error("Index not loaded");
+            return false;
+        }
+        if (not query_dataset) {
+            logger::error("Query dataset is null");
+            return false;
+        }
+        SearchRequest query_request;
+        query_request.query_ = query_dataset;
+        query_request.topk_ = topk;
+        query_request.params_str_ = search_param;
+        auto search_result = index_->AnalyzeIndexBySearch(query_request);
+        logger::info("Search Analyze: {}", search_result);
+        return true;
+    }
+
+    void
+    ShowIndexProperty() const {
+        logger::info("index inner property: {}", index_->GetStats());
+    }
+
+private:
+    bool
+    parse_reader(StreamReader& reader) {
+        auto footer = Footer::Parse(reader);
+        if (not footer) {
+            logger::error("Failed to parse footer");
+            return false;
+        }
+        auto meta_data = footer->GetMetadata();
+        auto basic_info = meta_data->Get(BASIC_INFO);
+        if (not basic_info.contains(INDEX_PARAM)) {
+            logger::error("Index parameter not found in metadata");
+            return false;
+        }
+        // parse basic info
+        dim_ = basic_info[DIM];
+        extra_info_size_ = basic_info["extra_info_size"];
+        data_type_ = static_cast<DataTypes>(basic_info["data_type"].get<int64_t>());
+        metric_type_ = static_cast<MetricType>(basic_info["metric"].get<int64_t>());
+        std::string inner_param = basic_info[INDEX_PARAM];
+        index_param_ = JsonType::parse(inner_param);
+        index_name_ = index_param_[INDEX_TYPE];
+        logger::info("index name: {}", index_name_);
+        logger::info("index dim: {}", dim_);
+        logger::info("index data type: {}", DataTypesToString(data_type_));
+        logger::info("index metric: {}", MetricTypeToString(metric_type_));
+        logger::info("index param: {}", index_param_.dump(4));
+        return true;
+    }
+
+    bool
+    create_index_with_param(const std::string& index_name, std::istream& in_stream) {
+        auto create_result = Factory::CreateIndex(index_name, build_param_);
+        if (not create_result.has_value()) {
+            logger::error("Failed to create index with name: {}, due to: {}",
+                          index_name,
+                          create_result.error().message);
+            return false;
+        }
+        index_ = create_result.value();
+        auto deserialize_result = index_->Deserialize(in_stream);
+        if (not deserialize_result.has_value()) {
+            logger::error("Failed to deserialize index from file, due to: {}",
+                          deserialize_result.error().message);
+            return false;
+        }
+        return true;
+    }
+
+    bool
+    create_index_without_param(const std::string& index_name, StreamReader& reader) {
+        // create index common parameters
+        IndexCommonParam index_common_params;
+        index_common_params.dim_ = dim_;
+        index_common_params.metric_ = metric_type_;
+        index_common_params.allocator_ = Engine::CreateDefaultAllocator();
+        index_common_params.data_type_ = data_type_;
+        index_common_params.extra_info_size_ = extra_info_size_;
+        // create index and deserialize
+        if (index_name_ == INDEX_HGRAPH) {
+            auto hgraph_parameter = std::make_shared<HGraphParameter>();
+            hgraph_parameter->FromJson(index_param_);
+            hgraph_parameter->data_type = data_type_;
+            auto inner_index = std::make_shared<HGraph>(hgraph_parameter, index_common_params);
+            inner_index->Deserialize(reader);
+            index_ = std::make_shared<IndexImpl<HGraph>>(inner_index, index_common_params);
+            return true;
+        } else {
+            logger::error("Index type {} not supported", index_name_);
+            return false;
+        }
+    }
+
+private:
+    IndexPtr index_{nullptr};
+    std::string build_param_;
+    int64_t dim_;
+    int64_t extra_info_size_;
+    DataTypes data_type_;
+    MetricType metric_type_;
+    std::string index_name_;
+    std::string inner_param_;
+    JsonType index_param_;
+};
 
 int
 main(int argc, char** argv) {
-    argparse::ArgumentParser program("analyze_index");
-    parse_args(program, argc, argv);
-    std::string index_path = program.get<std::string>("--index_path");
+    argparse::ArgumentParser parser("analyze_index");
+    parse_args(parser, argc, argv);
+    std::string index_path = parser.get<std::string>("--index_path");
+    std::string build_param = parser.get<std::string>("--build_parameter");
     // parse index
-    auto index = get_index(index_path);
+    AnalyzedIndex index(build_param);
+    index.LoadIndex(index_path);
     // get index property
-    logger::info("index inner property: {}", index->GetStats());
+    index.ShowIndexProperty();
+    // analyze query
+    std::string query_path = parser.get<std::string>("--query_path");
+    std::string search_param = parser.get<std::string>("--search_parameter");
+    int64_t topk = parser.get<int>("--topk");
+    if (query_path != EMPTY_QUERY_PATH) {
+        auto querys = load_query(query_path);
+        index.AnalyzeQuery(querys, topk, search_param);
+    }
 }


### PR DESCRIPTION
close #1034

## Summary by Sourcery

Enable search-based analysis of HGraph indices by adding a unified AnalyzedIndex workflow, new CLI parameters for query testing, and implementing an AnalyzeIndexBySearch interface across core index classes.

New Features:
- Add CLI options (--build_parameter, --query_path, --search_parameter, --topk) to configure index build and query analysis in the analyze_index tool
- Introduce AnalyzedIndex class to encapsulate index loading, property display, and query-based analysis
- Implement AnalyzeIndexBySearch in Index, InnerIndexInterface, IndexImpl, and HGraph to perform search-based index analysis
- Support loading query datasets from a binary file for analysis

Enhancements:
- Refactor analyze_index.cpp to streamline argument parsing, index instantiation, and optional query analysis
- Update HGraph GetStats logic to use dynamic ef_construct_ parameter template and reduce default query sample size