### PR TITLE
support in-place update in HGraph

### DIFF
--- a/include/vsag/constants.h
+++ b/include/vsag/constants.h
@@ -156,6 +156,7 @@ extern const char* const HGRAPH_PRECISE_FILE_PATH;
 extern const char* const HGRAPH_PARAMETER_EF_RUNTIME;
 extern const char* const HGRAPH_EXTRA_INFO_SIZE;
 extern const char* const HGRAPH_SUPPORT_DUPLICATE;
+extern const char* const HGRAPH_SUPPORT_TOMBSTONE;
 extern const char* const HGRAPH_USE_EXTRA_INFO_FILTER;
 extern const char* const STORE_RAW_VECTOR;
 extern const char* const RAW_VECTOR_IO_TYPE;

--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -2145,6 +2145,11 @@ HGraph::UpdateVector(int64_t id, const DatasetPtr& new_base, bool force_update) 
         float self_dist = 0;
         self_dist = this->CalcDistanceById((float*)new_base_vec, id);
         for (int i = 0; i < neighbors->GetDim(); i++) {
+            // don't compare with itself
+            if (neighbors->GetIds()[i] == id) {
+                continue;
+            }
+
             float neighbor_dist = 0;
             try {
                 neighbor_dist =

--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -710,7 +710,9 @@ HGraph::serialize_label_info(StreamWriter& writer) const {
         this->label_table_->Serialize(writer);
         return;
     }
-    this->tomb_label_table_->Serialize(writer);
+    if (this->support_tombstone_) {
+        this->tomb_label_table_->Serialize(writer);
+    }
     StreamWriter::WriteVector(writer, this->label_table_->label_table_);
     uint64_t size = this->label_table_->label_remap_.size();
     StreamWriter::WriteObj(writer, size);

--- a/src/algorithm/hgraph.h
+++ b/src/algorithm/hgraph.h
@@ -39,6 +39,7 @@
 #include "inner_index_interface.h"
 #include "lock_strategy.h"
 #include "typing.h"
+#include "utils/util_functions.h"
 #include "utils/visited_list.h"
 #include "vsag/index.h"
 #include "vsag/index_features.h"
@@ -178,6 +179,12 @@ public:
 
     [[nodiscard]] DatasetPtr
     SearchWithRequest(const SearchRequest& request) const override;
+
+    bool
+    UpdateId(int64_t old_id, int64_t new_id) override;
+
+    bool
+    UpdateVector(int64_t id, const DatasetPtr& new_base, bool force_update = false) override;
 
     void
     UpdateAttribute(int64_t id, const AttributeSet& new_attrs) override;
@@ -329,6 +336,7 @@ private:
     bool ignore_reorder_{false};
     bool build_by_base_{false};
     bool use_attribute_filter_{false};
+    bool support_tombstone_{false};
 
     BasicSearcherPtr searcher_;
 

--- a/src/algorithm/hgraph.h
+++ b/src/algorithm/hgraph.h
@@ -336,7 +336,6 @@ private:
     bool ignore_reorder_{false};
     bool build_by_base_{false};
     bool use_attribute_filter_{false};
-    bool support_tombstone_{false};
 
     BasicSearcherPtr searcher_;
 

--- a/src/algorithm/hgraph.h
+++ b/src/algorithm/hgraph.h
@@ -371,7 +371,6 @@ private:
 
     static constexpr uint64_t DEFAULT_RESIZE_BIT = 10;
 
-    UnorderedSet<InnerIdType> deleted_ids_;
     std::atomic<int64_t> delete_count_{0};
 
     std::shared_ptr<Optimizer<BasicSearcher>> optimizer_;

--- a/src/algorithm/hgraph_parameter.cpp
+++ b/src/algorithm/hgraph_parameter.cpp
@@ -146,6 +146,9 @@ HGraphParameter::FromJson(const JsonType& json) {
     if (json.contains(SUPPORT_DUPLICATE)) {
         this->support_duplicate = json[SUPPORT_DUPLICATE];
     }
+    if (json.contains(SUPPORT_TOMBSTONE)) {
+        this->support_tombstone = json[SUPPORT_TOMBSTONE];
+    }
 }
 
 JsonType

--- a/src/algorithm/hgraph_parameter.h
+++ b/src/algorithm/hgraph_parameter.h
@@ -63,6 +63,7 @@ public:
     uint64_t build_thread_count{100};
 
     bool support_duplicate{false};
+    bool support_tombstone{false};
 
     DataTypes data_type{DataTypes::DATA_TYPE_FLOAT};
 

--- a/src/algorithm/inner_index_interface.cpp
+++ b/src/algorithm/inner_index_interface.cpp
@@ -34,6 +34,7 @@ InnerIndexInterface::InnerIndexInterface(ParamPtr index_param, const IndexCommon
       metric_(common_param.metric_),
       data_type_(common_param.data_type_) {
     this->label_table_ = std::make_shared<LabelTable>(allocator_);
+    this->tomb_label_table_ = std::make_shared<LabelTable>(allocator_);
     this->index_feature_list_ = std::make_shared<IndexFeatureList>();
     this->index_feature_list_->SetFeature(SUPPORT_EXPORT_IDS);
 }

--- a/src/algorithm/inner_index_interface.h
+++ b/src/algorithm/inner_index_interface.h
@@ -350,6 +350,8 @@ public:
 public:
     LabelTablePtr label_table_{nullptr};
 
+    LabelTablePtr tomb_label_table_{nullptr};
+
     Allocator* allocator_{nullptr};
 
     IndexFeatureListPtr index_feature_list_{nullptr};

--- a/src/common.h
+++ b/src/common.h
@@ -41,3 +41,12 @@
 constexpr static const int64_t INIT_CAPACITY = 10;
 constexpr static const int64_t MAX_CAPACITY_EXTEND = 10000;
 constexpr static const int64_t AMPLIFICATION_FACTOR = 10;
+constexpr static const int64_t EXPANSION_NUM = 1000000;
+constexpr static const int64_t DEFAULT_MAX_ELEMENT = 1;
+constexpr static const int MINIMAL_M = 8;
+constexpr static const int MAXIMAL_M = 64;
+constexpr static const uint32_t GENERATE_SEARCH_K = 50;
+constexpr static const uint32_t UPDATE_CHECK_SEARCH_K = 10;
+constexpr static const uint32_t GENERATE_SEARCH_L = 400;
+constexpr static const uint32_t UPDATE_CHECK_SEARCH_L = 100;
+constexpr static const float GENERATE_OMEGA = 0.51;

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -159,6 +159,7 @@ const char* const HGRAPH_PRECISE_FILE_PATH = "precise_file_path";
 const char* const HGRAPH_PARAMETER_EF_RUNTIME = "ef_search";
 const char* const HGRAPH_EXTRA_INFO_SIZE = "extra_info_size";
 const char* const HGRAPH_SUPPORT_DUPLICATE = "support_duplicate";
+const char* const HGRAPH_SUPPORT_TOMBSTONE = "support_tomb_stone";
 const char* const HGRAPH_USE_EXTRA_INFO_FILTER = "use_extra_info_filter";
 const char* const STORE_RAW_VECTOR = "store_raw_vector";
 const char* const RAW_VECTOR_IO_TYPE = "raw_vector_io_type";

--- a/src/data_cell/flatten_interface.h
+++ b/src/data_cell/flatten_interface.h
@@ -57,6 +57,12 @@ public:
     virtual void
     InsertVector(const void* vector, InnerIdType idx = std::numeric_limits<InnerIdType>::max()) = 0;
 
+    virtual bool
+    UpdateVector(const void* vector, InnerIdType idx = std::numeric_limits<InnerIdType>::max()) {
+        throw VsagException(ErrorType::INTERNAL_ERROR,
+                            "UpdateVector not implemented in FlattenInterface");
+    };
+
     virtual void
     BatchInsertVector(const void* vectors, InnerIdType count, InnerIdType* idx_vec = nullptr) = 0;
 

--- a/src/index/hnsw.cpp
+++ b/src/index/hnsw.cpp
@@ -815,6 +815,11 @@ HNSW::update_vector(int64_t id, const DatasetPtr& new_base, bool force_update) {
             std::reinterpret_pointer_cast<hnswlib::HierarchicalNSW>(alg_hnsw_)->getDistanceByLabel(
                 id, new_base_vec);
         for (int i = 0; i < neighbors->GetDim(); i++) {
+            // don't compare with itself
+            if (neighbors->GetIds()[i] == id) {
+                continue;
+            }
+
             float neighbor_dist = 0;
             try {
                 neighbor_dist = std::reinterpret_pointer_cast<hnswlib::HierarchicalNSW>(alg_hnsw_)

--- a/src/index/hnsw.cpp
+++ b/src/index/hnsw.cpp
@@ -47,16 +47,6 @@
 
 namespace vsag {
 
-const static int64_t EXPANSION_NUM = 1000000;
-const static int64_t DEFAULT_MAX_ELEMENT = 1;
-const static int MINIMAL_M = 8;
-const static int MAXIMAL_M = 64;
-const static uint32_t GENERATE_SEARCH_K = 50;
-const static uint32_t UPDATE_CHECK_SEARCH_K = 10;
-const static uint32_t GENERATE_SEARCH_L = 400;
-const static uint32_t UPDATE_CHECK_SEARCH_L = 100;
-const static float GENERATE_OMEGA = 0.51;
-
 HNSW::HNSW(HnswParameters hnsw_params, const IndexCommonParam& index_common_param)
     : space_(std::move(hnsw_params.space)),
       use_static_(hnsw_params.use_static),
@@ -135,7 +125,7 @@ HNSW::build(const DatasetPtr& base) {
         const auto* ids = base->GetIds();
         void* vectors = nullptr;
         size_t data_size = 0;
-        get_vectors(base, &vectors, &data_size);
+        get_vectors(type_, dim_, base, &vectors, &data_size);
         std::vector<int64_t> failed_ids;
         {
             SlowTaskTimer t("hnsw graph");
@@ -185,7 +175,7 @@ HNSW::add(const DatasetPtr& base) {
         const auto* ids = base->GetIds();
         void* vectors = nullptr;
         size_t data_size = 0;
-        get_vectors(base, &vectors, &data_size);
+        get_vectors(type_, dim_, base, &vectors, &data_size);
         std::vector<int64_t> failed_ids;
         for (int64_t i = 0; i < num_elements; ++i) {
             // noexcept runtime
@@ -278,7 +268,7 @@ HNSW::knn_search(const DatasetPtr& query,
         CHECK_ARGUMENT(query->GetNumElements() == 1, "query dataset should contain 1 vector only");
         void* vector = nullptr;
         size_t data_size = 0;
-        get_vectors(query, &vector, &data_size);
+        get_vectors(type_, dim_, query, &vector, &data_size);
         int64_t query_dim = query->GetDim();
         CHECK_ARGUMENT(
             query_dim == dim_,
@@ -430,7 +420,7 @@ HNSW::range_search(const DatasetPtr& query,
         CHECK_ARGUMENT(query->GetNumElements() == 1, "query dataset should contain 1 vector only");
         void* vector = nullptr;
         size_t data_size = 0;
-        get_vectors(query, &vector, &data_size);
+        get_vectors(type_, dim_, query, &vector, &data_size);
         int64_t query_dim = query->GetDim();
         CHECK_ARGUMENT(
             query_dim == dim_,
@@ -776,25 +766,16 @@ HNSW::update_id(int64_t old_id, int64_t new_id) {
                               "static hnsw does not support update");
     }
 
-    try {
-        std::unique_lock lock(rw_mutex_);
+    std::scoped_lock lock(rw_mutex_);
 
-        if (old_id == new_id) {
-            return true;
-        }
+    if (old_id == new_id) {
+        return true;
+    }
 
-        // note that the validation of old_id is handled within updateLabel.
-        std::reinterpret_pointer_cast<hnswlib::HierarchicalNSW>(alg_hnsw_)->updateLabel(old_id,
-                                                                                        new_id);
-        if (use_conjugate_graph_) {
-            conjugate_graph_->UpdateId(old_id, new_id);
-        }
-    } catch (const std::runtime_error& e) {
-#ifndef ENABLE_TESTS
-        logger::warn(
-            "update error for replace old_id {} to new_id {}: {}", old_id, new_id, e.what());
-#endif
-        return false;
+    // note that the validation of old_id is handled within updateLabel.
+    std::reinterpret_pointer_cast<hnswlib::HierarchicalNSW>(alg_hnsw_)->updateLabel(old_id, new_id);
+    if (use_conjugate_graph_) {
+        conjugate_graph_->UpdateId(old_id, new_id);
     }
 
     return true;
@@ -807,65 +788,50 @@ HNSW::update_vector(int64_t id, const DatasetPtr& new_base, bool force_update) {
                               "static hnsw does not support update");
     }
 
-    try {
-        // the validation of the new vector
-        void* new_base_vec = nullptr;
-        size_t data_size = 0;
-        get_vectors(new_base, &new_base_vec, &data_size);
+    // the validation of the new vector
+    void* new_base_vec = nullptr;
+    size_t data_size = 0;
+    get_vectors(type_, dim_, new_base, &new_base_vec, &data_size);
 
-        if (not force_update) {
-            std::shared_ptr<int8_t[]> base_data(new int8_t[data_size]);
-            auto base = Dataset::Make();
+    if (not force_update) {
+        Vector<int8_t> base_data(data_size, allocator_.get());
+        auto base = Dataset::Make();
 
-            // check if id exists and get copied base data
-            std::reinterpret_pointer_cast<hnswlib::HierarchicalNSW>(alg_hnsw_)->copyDataByLabel(
-                id, base_data.get());
-            set_dataset(base, base_data.get(), 1);
+        // check if id exists and get copied base data
+        std::reinterpret_pointer_cast<hnswlib::HierarchicalNSW>(alg_hnsw_)->copyDataByLabel(
+            id, base_data.data());
+        set_dataset(type_, dim_, base, base_data.data(), 1);
 
-            // search neighbors
-            auto neighbors = *this->knn_search(base,
-                                               vsag::UPDATE_CHECK_SEARCH_K,
-                                               fmt::format(R"({{
-                                                                "hnsw":
-                                                                    {{
-                                                                        "ef_search": {}
-                                                                    }}
-                                                            }})",
-                                                           vsag::UPDATE_CHECK_SEARCH_L),
-                                               nullptr);
+        // search neighbors
+        auto neighbors = *this->knn_search(
+            base,
+            UPDATE_CHECK_SEARCH_K,
+            fmt::format(R"({{"hnsw": {{ "ef_search": {} }} }})", UPDATE_CHECK_SEARCH_L),
+            nullptr);
 
-            // check whether the neighborhood relationship is same
-            float self_dist = 0;
+        // check whether the neighborhood relationship is same
+        float self_dist = 0;
+        self_dist =
+            std::reinterpret_pointer_cast<hnswlib::HierarchicalNSW>(alg_hnsw_)->getDistanceByLabel(
+                id, new_base_vec);
+        for (int i = 0; i < neighbors->GetDim(); i++) {
+            float neighbor_dist = 0;
             try {
-                self_dist = std::reinterpret_pointer_cast<hnswlib::HierarchicalNSW>(alg_hnsw_)
-                                ->getDistanceByLabel(id, new_base_vec);
+                neighbor_dist = std::reinterpret_pointer_cast<hnswlib::HierarchicalNSW>(alg_hnsw_)
+                                    ->getDistanceByLabel(neighbors->GetIds()[i], new_base_vec);
             } catch (const std::runtime_error& e) {
-                self_dist = std::numeric_limits<float>::max();
+                // incase that neighbor has been deleted
+                continue;
             }
-            for (int i = 0; i < neighbors->GetDim(); i++) {
-                float neighbor_dist = 0;
-                try {
-                    neighbor_dist =
-                        std::reinterpret_pointer_cast<hnswlib::HierarchicalNSW>(alg_hnsw_)
-                            ->getDistanceByLabel(neighbors->GetIds()[i], new_base_vec);
-                } catch (const std::runtime_error& e) {
-                    neighbor_dist = self_dist = std::numeric_limits<float>::max();
-                }
-                if (neighbor_dist < self_dist) {
-                    return false;
-                }
+            if (neighbor_dist < self_dist) {
+                return false;
             }
         }
-
-        // note that the validation of old_id is handled within updatePoint.
-        std::reinterpret_pointer_cast<hnswlib::HierarchicalNSW>(alg_hnsw_)->updateVector(
-            id, new_base_vec);
-    } catch (const std::runtime_error& e) {
-#ifndef ENABLE_TESTS
-        logger::warn("update error for replace vector of id {}: {}", id, e.what());
-#endif
-        return false;
     }
+
+    // note that the validation of old_id is handled within updatePoint.
+    std::reinterpret_pointer_cast<hnswlib::HierarchicalNSW>(alg_hnsw_)->updateVector(id,
+                                                                                     new_base_vec);
 
     return true;
 }
@@ -992,7 +958,7 @@ HNSW::brute_force(const DatasetPtr& query, int64_t k) {
 
         void* vector = nullptr;
         size_t data_size = 0;
-        get_vectors(query, &vector, &data_size);
+        get_vectors(type_, dim_, query, &vector, &data_size);
 
         std::shared_lock lock(rw_mutex_);
 
@@ -1052,13 +1018,13 @@ HNSW::pretrain(const std::vector<int64_t>& base_tag_ids,
     std::shared_ptr<int8_t[]> topk_data(new int8_t[data_size]);
 
     std::shared_ptr<int8_t[]> generated_data(new int8_t[data_size]);
-    set_dataset(generated_query, generated_data.get(), 1);
+    set_dataset(type_, dim_, generated_query, generated_data.get(), 1);
 
     for (const int64_t& base_tag_id : base_tag_ids) {
         try {
             std::reinterpret_pointer_cast<hnswlib::HierarchicalNSW>(alg_hnsw_)->copyDataByLabel(
                 base_tag_id, base_data.get());
-            set_dataset(base, base_data.get(), 1);
+            set_dataset(type_, dim_, base, base_data.get(), 1);
         } catch (const std::runtime_error& e) {
             LOG_ERROR_AND_RETURNS(ErrorType::INVALID_ARGUMENT,
                                   fmt::format("failed to pretrain(invalid argument): base tag id "
@@ -1067,7 +1033,7 @@ HNSW::pretrain(const std::vector<int64_t>& base_tag_ids,
         }
 
         auto result = this->knn_search(base,
-                                       vsag::GENERATE_SEARCH_K,
+                                       GENERATE_SEARCH_K,
                                        fmt::format(R"(
                                         {{
                                             "hnsw": {{
@@ -1075,7 +1041,7 @@ HNSW::pretrain(const std::vector<int64_t>& base_tag_ids,
                                                 "use_conjugate_graph": true
                                             }}
                                         }})",
-                                                   vsag::GENERATE_SEARCH_L),
+                                                   GENERATE_SEARCH_L),
                                        nullptr);
 
         for (int i = 0; i < result.value()->GetDim(); i++) {
@@ -1089,13 +1055,12 @@ HNSW::pretrain(const std::vector<int64_t>& base_tag_ids,
 
             for (int d = 0; d < dim_; d++) {
                 if (type_ == DataTypes::DATA_TYPE_INT8) {
-                    generated_data.get()[d] =
-                        vsag::GENERATE_OMEGA * (float)(base_data[d]) +  // NOLINT
-                        (1 - vsag::GENERATE_OMEGA) * (float)(topk_data[d]);
+                    generated_data.get()[d] = GENERATE_OMEGA * (float)(base_data[d]) +  // NOLINT
+                                              (1 - GENERATE_OMEGA) * (float)(topk_data[d]);
                 } else {
                     ((float*)generated_data.get())[d] =
-                        vsag::GENERATE_OMEGA * ((float*)base_data.get())[d] +
-                        (1 - vsag::GENERATE_OMEGA) * ((float*)topk_data.get())[d];
+                        GENERATE_OMEGA * ((float*)base_data.get())[d] +
+                        (1 - GENERATE_OMEGA) * ((float*)topk_data.get())[d];
                 }
             }
 
@@ -1127,32 +1092,6 @@ HNSW::InitMemorySpace() {
     return true;
 }
 
-void
-HNSW::get_vectors(const vsag::DatasetPtr& base, void** vectors_ptr, size_t* data_size_ptr) const {
-    if (type_ == DataTypes::DATA_TYPE_FLOAT) {
-        *vectors_ptr = (void*)base->GetFloat32Vectors();
-        *data_size_ptr = dim_ * sizeof(float);
-    } else if (type_ == DataTypes::DATA_TYPE_INT8) {
-        *vectors_ptr = (void*)base->GetInt8Vectors();
-        *data_size_ptr = dim_ * sizeof(int8_t);
-    } else {
-        throw std::invalid_argument(fmt::format("no support for this metric: {}", (int)type_));
-    }
-}
-
-void
-HNSW::set_dataset(const DatasetPtr& base, const void* vectors_ptr, uint32_t num_element) const {
-    if (type_ == DataTypes::DATA_TYPE_FLOAT) {
-        base->Float32Vectors((float*)vectors_ptr)
-            ->Dim(dim_)
-            ->Owner(false)
-            ->NumElements(num_element);
-    } else if (type_ == DataTypes::DATA_TYPE_INT8) {
-        base->Int8Vectors((int8_t*)vectors_ptr)->Dim(dim_)->Owner(false)->NumElements(num_element);
-    } else {
-        throw std::invalid_argument(fmt::format("no support for this type: {}", (int)type_));
-    }
-}
 bool
 HNSW::CheckFeature(IndexFeature feature) const {
     std::shared_lock status_lock(index_status_mutex_);

--- a/src/index/hnsw.h
+++ b/src/index/hnsw.h
@@ -40,8 +40,10 @@
 #include "index_impl.h"
 #include "logger.h"
 #include "typing.h"
+#include "utils/util_functions.h"
 #include "utils/window_result_queue.h"
 #include "vsag/binaryset.h"
+#include "vsag/constants.h"
 #include "vsag/errors.h"
 #include "vsag/index.h"
 #include "vsag/iterator_context.h"
@@ -101,7 +103,7 @@ public:
 
     tl::expected<bool, Error>
     UpdateVector(int64_t id, const DatasetPtr& new_base, bool force_update = false) override {
-        SAFE_CALL(return this->update_vector(id, new_base, force_update));
+        SAFE_CALL(this->update_vector(id, new_base, force_update));
     }
 
     tl::expected<DatasetPtr, Error>
@@ -399,12 +401,6 @@ private:
 
     tl::expected<void, Error>
     deserialize(std::istream& in_stream);
-
-    void
-    get_vectors(const DatasetPtr& base, void** vectors_ptr, size_t* data_size_ptr) const;
-
-    void
-    set_dataset(const DatasetPtr& base, const void* vectors_ptr, uint32_t num_element) const;
 
     tl::expected<void, Error>
     merge(const std::vector<MergeUnit>& merge_units);

--- a/src/index/hnsw.h
+++ b/src/index/hnsw.h
@@ -103,7 +103,7 @@ public:
 
     tl::expected<bool, Error>
     UpdateVector(int64_t id, const DatasetPtr& new_base, bool force_update = false) override {
-        SAFE_CALL(this->update_vector(id, new_base, force_update));
+        SAFE_CALL(return this->update_vector(id, new_base, force_update));
     }
 
     tl::expected<DatasetPtr, Error>

--- a/src/inner_string_params.h
+++ b/src/inner_string_params.h
@@ -147,6 +147,7 @@ const char* const GRAPH_SUPPORT_REMOVE = "support_remove";
 const char* const REMOVE_FLAG_BIT = "remove_flag_bit";
 const char* const HOLD_MOLDS = "hold_molds";
 const char* const SUPPORT_DUPLICATE = "support_duplicate";
+const char* const SUPPORT_TOMBSTONE = "support_tombstone";
 
 const char* const DATACELL_OFFSETS = "datacell_offsets";
 const char* const DATACELL_SIZES = "datacell_sizes";

--- a/src/label_table.h
+++ b/src/label_table.h
@@ -103,6 +103,32 @@ public:
         return result != label_table_.end();
     }
 
+    inline void
+    UpdateLabel(LabelType old_label, LabelType new_label) {
+        // 1. check whether new_label is occupied
+        if (CheckLabel(new_label)) {
+            throw std::runtime_error(fmt::format("new label {} has been in HGraph", new_label));
+        }
+
+        // 2. check whether old_label exists
+        InnerIdType internal_id = 0;
+
+        auto iter_old = label_remap_.find(old_label);
+        if (iter_old == label_remap_.end()) {
+            // 3. old id not exists
+            throw std::runtime_error(
+                fmt::format("old label {} does not exist in HGraph", old_label));
+        } else {
+            // 4. update label to id
+            internal_id = iter_old->second;
+            label_remap_.erase(iter_old);
+            label_remap_[new_label] = internal_id;
+        }
+
+        // 5. reset id to label
+        label_table_[internal_id] = new_label;
+    }
+
     inline LabelType
     GetLabelById(InnerIdType inner_id) const {
         if (inner_id >= label_table_.size()) {

--- a/src/utils/util_functions.cpp
+++ b/src/utils/util_functions.cpp
@@ -210,4 +210,36 @@ base64_decode(const std::string& in) {
     return out;
 }
 
+void
+get_vectors(DataTypes type,
+            int64_t dim,
+            const vsag::DatasetPtr& base,
+            void** vectors_ptr,
+            size_t* data_size_ptr) {
+    if (type == DataTypes::DATA_TYPE_FLOAT) {
+        *vectors_ptr = (void*)base->GetFloat32Vectors();
+        *data_size_ptr = dim * sizeof(float);
+    } else if (type == DataTypes::DATA_TYPE_INT8) {
+        *vectors_ptr = (void*)base->GetInt8Vectors();
+        *data_size_ptr = dim * sizeof(int8_t);
+    } else {
+        throw std::invalid_argument(fmt::format("no support for this metric: {}", (int)type));
+    }
+}
+
+void
+set_dataset(DataTypes type,
+            int64_t dim,
+            const DatasetPtr& base,
+            const void* vectors_ptr,
+            uint32_t num_element) {
+    if (type == DataTypes::DATA_TYPE_FLOAT) {
+        base->Float32Vectors((float*)vectors_ptr)->Dim(dim)->Owner(false)->NumElements(num_element);
+    } else if (type == DataTypes::DATA_TYPE_INT8) {
+        base->Int8Vectors((int8_t*)vectors_ptr)->Dim(dim)->Owner(false)->NumElements(num_element);
+    } else {
+        throw std::invalid_argument(fmt::format("no support for this type: {}", (int)type));
+    }
+}
+
 }  // namespace vsag

--- a/src/utils/util_functions.h
+++ b/src/utils/util_functions.h
@@ -116,4 +116,18 @@ base64_decode_obj(const std::string& in, T& obj) {
     memcpy(&obj, to_string.c_str(), sizeof(obj));
 }
 
+void
+get_vectors(DataTypes type,
+            int64_t dim,
+            const vsag::DatasetPtr& base,
+            void** vectors_ptr,
+            size_t* data_size_ptr);
+
+void
+set_dataset(DataTypes type,
+            int64_t dim,
+            const DatasetPtr& base,
+            const void* vectors_ptr,
+            uint32_t num_element);
+
 }  // namespace vsag

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -644,8 +644,8 @@ TestHGraphBuild(const fixtures::HGraphTestIndexPtr& test_index,
                     dim, resource->base_count, metric_type);
 
                 TestIndex::TestBuildIndex(index, dataset, true);
-                HGraphTestIndex::TestGeneral(index, dataset, search_param, recall);
                 TestIndex::TestExportIDs(index, dataset);
+                HGraphTestIndex::TestGeneral(index, dataset, search_param, recall);
 
                 vsag::Options::Instance().set_block_size_limit(origin_size);
             }

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -263,6 +263,8 @@ HGraphTestIndex::TestGeneral(const TestIndex::IndexPtr& index,
     TestGetRawVectorByIds(index, dataset);
     TestBatchCalcDistanceById(index, dataset);
     TestSearchAllocator(index, dataset, search_param, recall, true);
+    TestUpdateVector(index, dataset, search_param, false);
+    TestUpdateId(index, dataset, search_param, true);
     TestMemoryUsageDetail(index);
 }
 

--- a/tests/test_multi_thread.cpp
+++ b/tests/test_multi_thread.cpp
@@ -418,7 +418,7 @@ TEST_CASE("Test HNSW Multi-threading read-write with Feedback and Pretrain",
             }));
     }
 
-    uint32_t succ_feedback = 0, succ_pretrain = 0, succ_search = 0;
+    uint32_t succ_feedback = 0, succ_pretrain = 0, succ_search = 0, succ_update_vec = 0;
     for (int64_t i = 0; i < max_elements; ++i) {
         REQUIRE(insert_results[i].get() == 0);
         if (i < max_elements / 2) {
@@ -428,8 +428,10 @@ TEST_CASE("Test HNSW Multi-threading read-write with Feedback and Pretrain",
             if (pretrain_results[i].get()) {
                 succ_pretrain++;
             }
+            if (update_vector_results[i].get()) {
+                succ_update_vec++;
+            }
             succ_search += (search_results[i].get() == ids[i]);
-            REQUIRE(update_vector_results[i].get() == true);
             REQUIRE(delete_re_insert_results[i].get() == true);
         }
     }
@@ -437,4 +439,5 @@ TEST_CASE("Test HNSW Multi-threading read-write with Feedback and Pretrain",
     REQUIRE(succ_search > 0.7 * max_elements / 2);
     REQUIRE(succ_feedback > 0);
     REQUIRE(succ_pretrain > 0);
+    REQUIRE(succ_update_vec > max_elements / 3);
 }


### PR DESCRIPTION
close #1033

## Summary by Sourcery

Support in-place updates within HGraph by adding UpdateId and UpdateVector operations, enable concurrent update features, factor out data handling utilities, centralize constants, and strengthen tests.

New Features:
- Add concurrent in-place ID update support in HGraph
- Add concurrent in-place vector update support in HGraph

Enhancements:
- Introduce tombstone label table to track deleted IDs in HGraph
- Extract and reuse get_vectors and set_dataset utilities for data handling
- Move HNSW index constants to a shared constants module
- Implement LabelTable::UpdateLabel for safe label remapping
- Implement FlattenDataCell::UpdateVector for direct code updates

Tests:
- Add and refine tests for UpdateId and UpdateVector in HGraph
- Adjust update-vector test logic and counters in test_index.cpp