### PR TITLE
Support data export on IVF Index

### DIFF
--- a/include/vsag/index.h
+++ b/include/vsag/index.h
@@ -478,6 +478,25 @@ public:
     };
 
     /**
+     * @brief Retrieve all data associated with vectors identified by given IDs.
+     *
+     * This method fetches data stored with the vectors in the index
+     * (e.g., attributes, labels, or extra infos).
+     *
+     * @param ids Array of vector IDs for which extra information is requested.
+     * @param count Number of IDs in the 'ids' array.
+     * @return tl::expected<DatasetPtr, Error>
+     *         - On success: A DatasetPtr containing the extra data, attribute and vector
+     *         - On failure: An error object (e.g., invalid ID, out of memory).
+     * @throws std::runtime_error If the index implementation does not support this operation
+     *            (default behavior for base class).
+     */
+    virtual tl::expected<DatasetPtr, Error>
+    GetDataByIds(const int64_t* ids, int64_t count) const {
+        throw std::runtime_error("Index doesn't support GetDataByIds");
+    };
+
+    /**
      * @brief Checks if the specified feature is supported by the index.
      *
      * This method checks whether the given `feature` is supported by the index.

--- a/include/vsag/index_features.h
+++ b/include/vsag/index_features.h
@@ -68,6 +68,7 @@ enum IndexFeature {
     SUPPORT_GET_EXTRA_INFO_BY_ID, /**< Supports get extra_info by id */
 
     SUPPORT_GET_RAW_VECTOR_BY_IDS, /**< Supports get raw vectors by ids */
+    SUPPORT_GET_DATA_BY_IDS,       /**< Supports get data by ids */
 
     SUPPORT_EXPORT_IDS, /**< Supports export ids */
 

--- a/src/algorithm/inner_index_interface.h
+++ b/src/algorithm/inner_index_interface.h
@@ -89,6 +89,12 @@ public:
                             "Index doesn't support GetNumberRemoved");
     }
 
+    [[nodiscard]] virtual DatasetPtr
+    GetDataByIds(const int64_t* ids, int64_t count) const {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "Index doesn't support GetDataByIds");
+    }
+
     DatasetPtr
     GetVectorByIds(const int64_t* ids, int64_t count) const;
 

--- a/src/algorithm/ivf.h
+++ b/src/algorithm/ivf.h
@@ -112,6 +112,12 @@ public:
     int64_t
     GetNumElements() const override;
 
+    [[nodiscard]] DatasetPtr
+    GetDataByIds(const int64_t* ids, int64_t count) const override;
+
+    void
+    GetCodeByInnerId(InnerIdType inner_id, uint8_t* data) const override;
+
 private:
     InnerSearchParam
     create_search_param(const std::string& parameters, const FilterPtr& filter) const;
@@ -133,7 +139,10 @@ private:
     fill_location_map();
 
     std::pair<BucketIdType, InnerIdType>
-    get_location(InnerIdType inner_id);
+    get_location(InnerIdType inner_id) const;
+
+    void
+    get_attr_by_inner_id(InnerIdType inner_id, AttributeSet* attr) const;
 
 private:
     BucketInterfacePtr bucket_{nullptr};

--- a/src/attr/attr_value_map.h
+++ b/src/attr/attr_value_map.h
@@ -91,6 +91,27 @@ public:
         }
     }
 
+    template <class T>
+    Attribute*
+    GetAttr(InnerIdType inner_id, BucketIdType bucket_id = 0) {
+        auto& map = this->get_map_by_type<T>();
+        AttributeValue<T>* result = nullptr;
+        bool is_new = true;
+        for (auto& [key, manager] : map) {
+            if (manager != nullptr) {
+                auto* bitset = manager->GetOneBitset(bucket_id);
+                if (bitset != nullptr and bitset->Test(inner_id)) {
+                    if (is_new) {
+                        result = new AttributeValue<T>();
+                        is_new = false;
+                    }
+                    result->GetValue().emplace_back(key);
+                }
+            }
+        }
+        return result;
+    }
+
     void
     Serialize(StreamWriter& writer);
 

--- a/src/data_cell/attribute_bucket_inverted_datacell.cpp
+++ b/src/data_cell/attribute_bucket_inverted_datacell.cpp
@@ -244,4 +244,68 @@ AttributeBucketInvertedDataCell::UpdateBitsetsByAttr(const AttributeSet& attribu
     }
 }
 
+template <typename T>
+static Attribute*
+get_attr_by_type(const std::shared_ptr<AttrValueMap>& value_map,
+                 InnerIdType inner_id,
+                 BucketIdType bucket_id,
+                 const std::string& name) {
+    auto* attr = value_map->template GetAttr<T>(inner_id, bucket_id);
+    if (attr != nullptr) {
+        attr->name_ = name;
+        return attr;
+    }
+    return nullptr;
+}
+
+static Attribute*
+get_attr_by_type(const std::shared_ptr<AttrValueMap>& value_map,
+                 AttrValueType value_type,
+                 InnerIdType inner_id,
+                 BucketIdType bucket_id,
+                 const std::string& name) {
+    if (value_type == AttrValueType::INT32) {
+        return get_attr_by_type<int32_t>(value_map, inner_id, bucket_id, name);
+    }
+    if (value_type == AttrValueType::INT64) {
+        return get_attr_by_type<int64_t>(value_map, inner_id, bucket_id, name);
+    }
+    if (value_type == AttrValueType::INT16) {
+        return get_attr_by_type<int16_t>(value_map, inner_id, bucket_id, name);
+    }
+    if (value_type == AttrValueType::INT8) {
+        return get_attr_by_type<int8_t>(value_map, inner_id, bucket_id, name);
+    }
+    if (value_type == AttrValueType::UINT32) {
+        return get_attr_by_type<uint32_t>(value_map, inner_id, bucket_id, name);
+    }
+    if (value_type == AttrValueType::UINT64) {
+        return get_attr_by_type<uint64_t>(value_map, inner_id, bucket_id, name);
+    }
+    if (value_type == AttrValueType::UINT16) {
+        return get_attr_by_type<uint16_t>(value_map, inner_id, bucket_id, name);
+    }
+    if (value_type == AttrValueType::UINT8) {
+        return get_attr_by_type<uint8_t>(value_map, inner_id, bucket_id, name);
+    }
+    if (value_type == AttrValueType::STRING) {
+        return get_attr_by_type<std::string>(value_map, inner_id, bucket_id, name);
+    }
+    throw VsagException(ErrorType::INTERNAL_ERROR, "Unsupported value type");
+}
+
+void
+AttributeBucketInvertedDataCell::GetAttribute(BucketIdType bucket_id,
+                                              InnerIdType inner_id,
+                                              AttributeSet* attr) {
+    std::shared_lock lock(this->global_mutex_);
+    for (const auto& [name, value_map] : this->field_2_value_map_) {
+        auto value_type = this->field_type_map_.GetTypeOfField(name);
+        auto* attr_ptr = get_attr_by_type(value_map, value_type, inner_id, bucket_id, name);
+        if (attr_ptr != nullptr) {
+            attr->attrs_.emplace_back(attr_ptr);
+        }
+    }
+}
+
 }  // namespace vsag

--- a/src/data_cell/attribute_bucket_inverted_datacell.h
+++ b/src/data_cell/attribute_bucket_inverted_datacell.h
@@ -55,6 +55,9 @@ public:
     void
     Deserialize(lvalue_or_rvalue<StreamReader> reader) override;
 
+    void
+    GetAttribute(BucketIdType bucket_id, InnerIdType inner_id, AttributeSet* attr) override;
+
 private:
     UnorderedMap<std::string, ValueMapPtr> field_2_value_map_;
 

--- a/src/data_cell/attribute_inverted_interface.h
+++ b/src/data_cell/attribute_inverted_interface.h
@@ -63,6 +63,9 @@ public:
                         const AttributeSet& origin_attributes) = 0;
 
     virtual void
+    GetAttribute(BucketIdType bucket_id, InnerIdType inner_id, AttributeSet* attr) = 0;
+
+    virtual void
     Serialize(StreamWriter& writer) {
         this->field_type_map_.Serialize(writer);
     }

--- a/src/data_cell/bucket_datacell.h
+++ b/src/data_cell/bucket_datacell.h
@@ -115,6 +115,9 @@ public:
         return this->bucket_sizes_[bucket_id];
     }
 
+    void
+    GetCodesById(BucketIdType bucket_id, InnerIdType offset_id, uint8_t* data) const override;
+
 private:
     inline void
     check_valid_bucket_id(BucketIdType bucket_id) {
@@ -409,6 +412,24 @@ BucketDataCell<QuantTmpl, IOTmpl>::MergeOther(const BucketInterfacePtr& other, I
             this->inner_ids_[i].emplace_back(id + bias);
         }
     }
+}
+
+template <typename QuantTmpl, typename IOTmpl>
+void
+BucketDataCell<QuantTmpl, IOTmpl>::GetCodesById(BucketIdType bucket_id,
+                                                InnerIdType offset_id,
+                                                uint8_t* data) const {
+    if (bucket_id >= this->bucket_count_) {
+        throw VsagException(
+            ErrorType::INTERNAL_ERROR,
+            fmt::format("Get code by inner id failed: bucket id ({}) is invalid", bucket_id));
+    }
+    if (offset_id >= this->bucket_sizes_[bucket_id]) {
+        throw VsagException(
+            ErrorType::INTERNAL_ERROR,
+            fmt::format("Get code by inner id failed: offset id ({}) is invalid", offset_id));
+    }
+    this->datas_[bucket_id]->Read(this->code_size_, offset_id * this->code_size_, data);
 }
 
 }  // namespace vsag

--- a/src/data_cell/bucket_interface.h
+++ b/src/data_cell/bucket_interface.h
@@ -64,6 +64,9 @@ public:
     virtual void
     Prefetch(BucketIdType bucket_id, InnerIdType offset_id) = 0;
 
+    virtual void
+    GetCodesById(BucketIdType bucket_id, InnerIdType offset_id, uint8_t* data) const = 0;
+
     [[nodiscard]] virtual std::string
     GetQuantizerName() = 0;
 

--- a/src/index/index_impl.h
+++ b/src/index/index_impl.h
@@ -323,6 +323,15 @@ public:
         SAFE_CALL(return this->inner_index_->GetVectorByIds(ids, count));
     };
 
+    tl::expected<DatasetPtr, Error>
+    GetDataByIds(const int64_t* ids, int64_t count) const override {
+        if (not CheckFeature(IndexFeature::SUPPORT_GET_DATA_BY_IDS)) {
+            return tl::unexpected(Error(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                                        "index no support to get data by ids"));
+        }
+        SAFE_CALL(return this->inner_index_->GetDataByIds(ids, count));
+    };
+
     tl::expected<void, Error>
     Merge(const std::vector<MergeUnit>& merge_units) override {
         if (this->inner_index_->immutable_) {

--- a/tests/test_index.h
+++ b/tests/test_index.h
@@ -213,7 +213,7 @@ public:
                    bool expect_success = true);
 
     static IndexPtr
-    TestMergeIndexWithSameModel(const IndexPtr model,
+    TestMergeIndexWithSameModel(const IndexPtr& model,
                                 const TestDatasetPtr& dataset,
                                 int32_t split_num = 1,
                                 bool expect_success = true);
@@ -285,6 +285,9 @@ public:
 
     static void
     TestExportIDs(const IndexPtr& index, const TestDatasetPtr& dataset);
+
+    static void
+    TestGetDataById(const IndexPtr& model, const TestDatasetPtr& dataset);
 
     constexpr static float RECALL_THRESHOLD = 0.95;
 };

--- a/tests/test_ivf.cpp
+++ b/tests/test_ivf.cpp
@@ -738,12 +738,12 @@ TestIVFWithAttr(const fixtures::IVFTestIndexPtr& test_index,
                     auto build_result = index1->Build(dataset->base_);
                     REQUIRE(build_result.has_value());
                     IVFTestIndex::TestWithAttr(index1, dataset, search_param, false);
+                    TestIndex::TestGetDataById(index1, dataset);
                     auto index = TestIndex::TestFactory(IVFTestIndex::name, param, true);
 
                     REQUIRE_NOTHROW(test_serializion_file(*index1, *index, "serialize"));
 
                     IVFTestIndex::TestWithAttr(index, dataset, search_param);
-
                     vsag::Options::Instance().set_block_size_limit(origin_size);
                 }
             }


### PR DESCRIPTION
closed: #1051
- add new interface GetDataById
- include raw vector and attribute

## Summary by Sourcery

Enable data export on IVF index by introducing a GetDataByIds interface and implementing it alongside attribute extraction support

New Features:
- Add GetDataByIds API in Index and InnerIndexInterface for exporting raw vectors and attributes by IDs
- Implement GetDataByIds in IVF index to assemble a Dataset containing float vectors and associated AttributeSets

Enhancements:
- Introduce SUPPORT_GET_DATA_BY_IDS flag in IndexFeature and enforce it in IndexImpl
- Extend AttributeInvertedInterface and AttributeBucketInvertedDataCell with GetAttribute support and add AttrValueMap::GetAttr template method for typed attribute retrieval