### PR TITLE
support store raw vector on HGraph

### DIFF
--- a/include/vsag/constants.h
+++ b/include/vsag/constants.h
@@ -157,11 +157,12 @@ extern const char* const HGRAPH_PARAMETER_EF_RUNTIME;
 extern const char* const HGRAPH_EXTRA_INFO_SIZE;
 extern const char* const HGRAPH_SUPPORT_DUPLICATE;
 extern const char* const HGRAPH_USE_EXTRA_INFO_FILTER;
-extern const char* const HGRAPH_STORE_RAW_VECTOR;
+extern const char* const STORE_RAW_VECTOR;
+extern const char* const RAW_VECTOR_IO_TYPE;
+extern const char* const RAW_VECTOR_FILE_PATH;
 
 extern const char* const BRUTE_FORCE_QUANTIZATION_TYPE;
 extern const char* const BRUTE_FORCE_IO_TYPE;
-extern const char* const BRUTE_FORCE_STORE_RAW_VECTOR;
 
 extern const char* const IVF_USE_RESIDUAL;
 extern const char* const IVF_USE_REORDER;

--- a/src/algorithm/brute_force.cpp
+++ b/src/algorithm/brute_force.cpp
@@ -438,7 +438,7 @@ BruteForce::CheckAndMappingExternalParam(const JsonType& external_param,
             },
         },
         {
-            BRUTE_FORCE_STORE_RAW_VECTOR,
+            STORE_RAW_VECTOR,
             {
                 QUANTIZATION_PARAMS_KEY,
                 HOLD_MOLDS,

--- a/src/algorithm/hgraph.h
+++ b/src/algorithm/hgraph.h
@@ -308,9 +308,15 @@ private:
     void
     analyze_graph_connection(JsonType& stats) const;
 
+    void
+    check_and_init_raw_vector(const FlattenInterfaceParamPtr& raw_vector_param,
+                              const IndexCommonParam& common_param);
+
 private:
     FlattenInterfacePtr basic_flatten_codes_{nullptr};
     FlattenInterfacePtr high_precise_codes_{nullptr};
+    bool create_new_raw_vector_{false};
+    FlattenInterfacePtr raw_vector_{nullptr};
     Vector<GraphInterfacePtr> route_graphs_;
     GraphInterfacePtr bottom_graph_{nullptr};
     SparseGraphDatacellParamPtr hierarchical_datacell_param_{nullptr};

--- a/src/algorithm/hgraph_parameter.cpp
+++ b/src/algorithm/hgraph_parameter.cpp
@@ -74,6 +74,16 @@ HGraphParameter::FromJson(const JsonType& json) {
         this->precise_codes_param->FromJson(precise_codes_json);
     }
 
+    if (json.contains(STORE_RAW_VECTOR_KEY)) {
+        this->store_raw_vector = json[STORE_RAW_VECTOR_KEY];
+    }
+
+    if (this->store_raw_vector) {
+        const auto& raw_vector_json = json[RAW_VECTOR_KEY];
+        this->raw_vector_param = std::make_shared<FlattenDataCellParameter>();
+        this->raw_vector_param->FromJson(raw_vector_json);
+    }
+
     CHECK_ARGUMENT(json.contains(HGRAPH_GRAPH_KEY),
                    fmt::format("hgraph parameters must contains {}", HGRAPH_GRAPH_KEY));
     const auto& graph_json = json[HGRAPH_GRAPH_KEY];
@@ -149,13 +159,16 @@ HGraphParameter::ToJson() const {
     if (use_reorder) {
         json[HGRAPH_PRECISE_CODES_KEY] = this->precise_codes_param->ToJson();
     }
+    if (this->store_raw_vector) {
+        json[STORE_RAW_VECTOR_KEY] = this->raw_vector_param->ToJson();
+    }
     json[HGRAPH_GRAPH_KEY] = this->bottom_graph_param->ToJson();
 
     json[BUILD_PARAMS_KEY][BUILD_EF_CONSTRUCTION] = this->ef_construction;
     json[BUILD_PARAMS_KEY][BUILD_THREAD_COUNT] = this->build_thread_count;
     json[HGRAPH_EXTRA_INFO_KEY] = this->extra_info_param->ToJson();
     json[SUPPORT_DUPLICATE] = this->support_duplicate;
-    json[HGRAPH_STORE_RAW_VECTOR] = this->store_raw_vector;
+    json[STORE_RAW_VECTOR] = this->store_raw_vector;
     json[USE_ATTRIBUTE_FILTER_KEY] = this->use_attribute_filter;
     return json;
 }

--- a/src/algorithm/hgraph_parameter.h
+++ b/src/algorithm/hgraph_parameter.h
@@ -44,6 +44,7 @@ public:
 public:
     FlattenInterfaceParamPtr base_codes_param{nullptr};
     FlattenInterfaceParamPtr precise_codes_param{nullptr};
+    FlattenInterfaceParamPtr raw_vector_param{nullptr};
     GraphInterfaceParamPtr bottom_graph_param{nullptr};
     SparseGraphDatacellParamPtr hierarchical_graph_param{nullptr};
     ExtraInfoDataCellParamPtr extra_info_param{nullptr};

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -160,11 +160,12 @@ const char* const HGRAPH_PARAMETER_EF_RUNTIME = "ef_search";
 const char* const HGRAPH_EXTRA_INFO_SIZE = "extra_info_size";
 const char* const HGRAPH_SUPPORT_DUPLICATE = "support_duplicate";
 const char* const HGRAPH_USE_EXTRA_INFO_FILTER = "use_extra_info_filter";
-const char* const HGRAPH_STORE_RAW_VECTOR = "store_raw_vector";
+const char* const STORE_RAW_VECTOR = "store_raw_vector";
+const char* const RAW_VECTOR_IO_TYPE = "raw_vector_io_type";
+const char* const RAW_VECTOR_FILE_PATH = "raw_vector_file_path";
 
 const char* const BRUTE_FORCE_QUANTIZATION_TYPE = "quantization_type";
 const char* const BRUTE_FORCE_IO_TYPE = "io_type";
-const char* const BRUTE_FORCE_STORE_RAW_VECTOR = "store_raw_vector";
 
 const char* const IVF_USE_RESIDUAL = "use_residual";
 const char* const IVF_USE_REORDER = "use_reorder";

--- a/src/inner_string_params.h
+++ b/src/inner_string_params.h
@@ -140,6 +140,9 @@ const char* const GNO_IMI_SEARCH_PARAM_FIRST_ORDER_SCAN_RATIO = "first_order_sca
 const char* const FLATTEN_DATA_CELL = "flatten_data_cell";
 const char* const SPARSE_VECTOR_DATA_CELL = "sparse_vector_data_cell";
 
+const char* const STORE_RAW_VECTOR_KEY = "store_raw_vector";
+const char* const RAW_VECTOR_KEY = "raw_vector";
+
 const char* const GRAPH_SUPPORT_REMOVE = "support_remove";
 const char* const REMOVE_FLAG_BIT = "remove_flag_bit";
 const char* const HOLD_MOLDS = "hold_molds";
@@ -215,10 +218,12 @@ const std::unordered_map<std::string, std::string> DEFAULT_MAP = {
     {"IVF_TRAIN_TYPE_KMEANS", IVF_TRAIN_TYPE_KMEANS},
     {"IVF_THREAD_COUNT_KEY", IVF_THREAD_COUNT_KEY},
     {"IVF_SEARCH_PARALLELISM", IVF_SEARCH_PARALLELISM},
-    {"HGRAPH_STORE_RAW_VECTOR", HGRAPH_STORE_RAW_VECTOR},
     {"GRAPH_SUPPORT_REMOVE", GRAPH_SUPPORT_REMOVE},
     {"REMOVE_FLAG_BIT", REMOVE_FLAG_BIT},
     {"HOLD_MOLDS", HOLD_MOLDS},
-    {"IVF_PARTITION_STRATEGY_TYPE_GNO_IMI", IVF_PARTITION_STRATEGY_TYPE_GNO_IMI}};
+    {"IVF_PARTITION_STRATEGY_TYPE_GNO_IMI", IVF_PARTITION_STRATEGY_TYPE_GNO_IMI},
+    {"STORE_RAW_VECTOR_KEY", STORE_RAW_VECTOR_KEY},
+    {"RAW_VECTOR_KEY", RAW_VECTOR_KEY},
+};
 
 }  // namespace vsag


### PR DESCRIPTION
closed: #1066


## Summary by Sourcery

Enable optional storage and handling of raw input vectors in both HGraph and BruteForce indices, including configuration, initialization, insertion, and retrieval workflows.

New Features:
- Add support for storing raw vectors in HGraph via a new 'store_raw_vector' configuration and parameter
- Implement raw_vector initialization, insertion, and retrieval logic in HGraph including a check_and_init_raw_vector helper
- Expose raw vector retrieval and distance calculation features in HGraph feature flags
- Extend HGraphParameter JSON schema and templates with raw vector IO settings and update related constants
- Add raw vector support to BruteForce index parameter mapping