### PR TITLE
replace Vector with raw pointer on bitset

### DIFF
--- a/src/impl/bitset/computable_bitset.h
+++ b/src/impl/bitset/computable_bitset.h
@@ -134,9 +134,6 @@ public:
      */
     virtual void
     Clear() = 0;
-
-public:
-    ComputableBitsetType type_{ComputableBitsetType::SparseBitset};
 };
 
 }  // namespace vsag

--- a/src/impl/bitset/sparse_bitset.h
+++ b/src/impl/bitset/sparse_bitset.h
@@ -28,8 +28,8 @@ namespace vsag {
 class SparseBitset : public ComputableBitset {
 public:
     explicit SparseBitset() : ComputableBitset() {
-        this->type_ = ComputableBitsetType::SparseBitset;
     }
+
     ~SparseBitset() override = default;
 
     explicit SparseBitset(Allocator* allocator) : SparseBitset(){};


### PR DESCRIPTION
## Summary by Sourcery

Migrate FastBitset to use manual pointer-based storage instead of a Vector, with explicit size and capacity tracking and a custom resize method.

Enhancements:
- Replace internal Vector<uint64_t> with a raw uint64_t* data buffer alongside size_ and capacity_ members
- Implement a custom resize() routine to manage allocation, copying, and initialization of the raw data buffer
- Update all bitset operations (Set, Test, Count, Or, And, Not, Dump, Serialize, Deserialize, Clear) to use pointer-based storage and manual memory management
- Add proper deletion of the data buffer in the destructor to avoid memory leaks