### PR TITLE
Support Export All ID from index

### DIFF
--- a/include/vsag/index.h
+++ b/include/vsag/index.h
@@ -533,6 +533,17 @@ public:
     }
 
     /**
+     * @brief Export the index's IDs as a dataset.
+     * 
+     * @return DatasetPtr A pointer to the exported IDs dataset.
+     * @throws std::runtime_error If the index does not support exporting the IDs.
+     */
+    virtual tl::expected<DatasetPtr, Error>
+    ExportIDs() const {
+        throw std::runtime_error("Index doesn't support ExportIDs");
+    }
+
+    /**
      * @brief set the index to immutable state.
      * After setting this state, no further modifications are supported, such as no additions or deletions 
      *

--- a/include/vsag/index_features.h
+++ b/include/vsag/index_features.h
@@ -69,6 +69,8 @@ enum IndexFeature {
 
     SUPPORT_GET_RAW_VECTOR_BY_IDS, /**< Supports get raw vectors by ids */
 
+    SUPPORT_EXPORT_IDS, /**< Supports export ids */
+
     SUPPORT_KNN_SEARCH_WITH_EX_FILTER, /**< Supports K-nearest neighbor search with extra info filtering */
 
     SUPPORT_CLONE, /**< Supports clone index */

--- a/src/algorithm/inner_index_interface.h
+++ b/src/algorithm/inner_index_interface.h
@@ -257,6 +257,9 @@ public:
                             "Index doesn't support ExportModel");
     }
 
+    virtual DatasetPtr
+    ExportIDs() const;
+
     virtual void
     SetImmutable() {
         throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,

--- a/src/index/index_impl.h
+++ b/src/index/index_impl.h
@@ -350,6 +350,11 @@ public:
         return std::make_shared<IndexImpl<T>>(model_value.value(), this->common_param_);
     }
 
+    tl::expected<DatasetPtr, Error>
+    ExportIDs() const override {
+        SAFE_CALL(return this->inner_index_->ExportIDs());
+    }
+
     tl::expected<void, Error>
     SetImmutable() override {
         SAFE_CALL(this->inner_index_->SetImmutable());

--- a/src/label_table.h
+++ b/src/label_table.h
@@ -112,6 +112,11 @@ public:
         return this->label_table_[inner_id];
     }
 
+    inline const LabelType*
+    GetAllLabels() const {
+        return label_table_.data();
+    }
+
     void
     Serialize(StreamWriter& writer) const {
         StreamWriter::WriteVector(writer, label_table_);

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -635,6 +635,7 @@ TestHGraphBuild(const fixtures::HGraphTestIndexPtr& test_index,
 
                 TestIndex::TestBuildIndex(index, dataset, true);
                 HGraphTestIndex::TestGeneral(index, dataset, search_param, recall);
+                TestIndex::TestExportIDs(index, dataset);
 
                 vsag::Options::Instance().set_block_size_limit(origin_size);
             }

--- a/tests/test_index.cpp
+++ b/tests/test_index.cpp
@@ -2100,4 +2100,25 @@ TestIndex::TestSearchOvertime(const IndexPtr& index,
         REQUIRE(res.has_value());
     }
 }
+
+void
+TestIndex::TestExportIDs(const IndexPtr& index, const TestDatasetPtr& dataset) {
+    if (not index->CheckFeature(vsag::SUPPORT_EXPORT_IDS)) {
+        return;
+    }
+    auto result = index->ExportIDs();
+    REQUIRE(result.has_value());
+    const auto* ids = result.value()->GetIds();
+    auto num_element = result.value()->GetNumElements();
+    REQUIRE(num_element == dataset->base_->GetNumElements());
+    auto* origin_ids = dataset->base_->GetIds();
+    // check ids, no order
+    std::unordered_set<int64_t> id_set(origin_ids, origin_ids + num_element);
+    for (int64_t i = 0; i < num_element; ++i) {
+        REQUIRE(id_set.find(ids[i]) != id_set.end());
+    }
+    std::unordered_set<int64_t> id_set2(ids, ids + num_element);
+    REQUIRE(id_set2.size() == num_element);
+}
+
 }  // namespace fixtures

--- a/tests/test_index.h
+++ b/tests/test_index.h
@@ -283,6 +283,9 @@ public:
                        const TestDatasetPtr& dataset,
                        const std::string& search_param);
 
+    static void
+    TestExportIDs(const IndexPtr& index, const TestDatasetPtr& dataset);
+
     constexpr static float RECALL_THRESHOLD = 0.95;
 };
 

--- a/tests/test_ivf.cpp
+++ b/tests/test_ivf.cpp
@@ -254,6 +254,7 @@ IVFTestIndex::TestGeneral(const TestIndex::IndexPtr& index,
     TestRangeSearch(index, dataset, search_param, recall / 2.0, 5, true);
     TestFilterSearch(index, dataset, search_param, recall, true);
     TestCheckIdExist(index, dataset);
+    TestExportIDs(index, dataset);
 }
 }  // namespace fixtures
 


### PR DESCRIPTION
closed: #1068

## Summary by Sourcery

Add support for exporting all IDs from an index through a new ExportIDs API, enable it via a feature flag, implement it in index internals, and validate it with unit tests.

New Features:
- Add ExportIDs method in the Index interface and its implementation to export all stored IDs as a Dataset

Enhancements:
- Introduce SUPPORT_EXPORT_IDS feature flag and expose it in the InnerIndexInterface
- Add GetAllLabels in LabelTable for bulk label retrieval

Documentation:
- Document the ExportIDs API in index.h

Tests:
- Add TestExportIDs in TestIndex and invoke it in HGraph and IVF test suites to verify ExportIDs functionality