### PR TITLE
feat(dataset): support Append and DeepCopy methods in Dataset

### DIFF
--- a/include/vsag/attribute.h
+++ b/include/vsag/attribute.h
@@ -44,6 +44,12 @@ public:
 
     [[nodiscard]] virtual uint64_t
     GetValueCount() const = 0;
+
+    [[nodiscard]] virtual Attribute*
+    DeepCopy() const = 0;
+
+    [[nodiscard]] virtual bool
+    Equal(const Attribute* other) const = 0;
 };
 using AttributePtr = std::shared_ptr<Attribute>;
 
@@ -61,6 +67,12 @@ public:
 
     const std::vector<T>&
     GetValue() const;
+
+    Attribute*
+    DeepCopy() const override;
+
+    bool
+    Equal(const Attribute* other) const override;
 
 private:
     std::vector<T> value_{};

--- a/include/vsag/dataset.h
+++ b/include/vsag/dataset.h
@@ -83,6 +83,12 @@ public:
         return Owner(is_owner, nullptr);
     }
 
+    virtual DatasetPtr
+    Append(const DatasetPtr& other) = 0;
+
+    virtual DatasetPtr
+    DeepCopy(Allocator* allocator = nullptr) const = 0;
+
 public:
     /**
      * @brief Sets the number of elements in the dataset.

--- a/src/attr/attribute.cpp
+++ b/src/attr/attribute.cpp
@@ -15,6 +15,9 @@
 
 #include "vsag/attribute.h"
 
+#include <cstring>
+#include <memory>
+
 namespace vsag {
 
 template <class T>
@@ -57,6 +60,40 @@ template <class T>
 const std::vector<T>&
 AttributeValue<T>::GetValue() const {
     return value_;
+}
+
+template <class T>
+Attribute*
+AttributeValue<T>::DeepCopy() const {
+    auto attr = new AttributeValue<T>();
+    attr->value_ = value_;
+    return attr;
+}
+
+template <class T>
+bool
+AttributeValue<T>::Equal(const Attribute* other) const {
+    if (this->GetValueCount() != other->GetValueCount() ||
+        this->GetValueType() != other->GetValueType()) {
+        return false;
+    }
+
+    auto count = this->GetValueCount();
+    const auto* other_instance = dynamic_cast<const AttributeValue<T>*>(other);
+    if (other_instance) {
+        if (this->GetValueType() != AttrValueType::STRING) {
+            return std::memcmp(
+                       value_.data(), other_instance->GetValue().data(), count * sizeof(T)) == 0;
+        }
+        for (int i = 0; i < count; ++i) {
+            if (value_[i] != other_instance->GetValue()[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    return false;
 }
 
 template class AttributeValue<int32_t>;

--- a/src/attr/attribute_test.cpp
+++ b/src/attr/attribute_test.cpp
@@ -1,0 +1,158 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "vsag/attribute.h"
+
+#include <catch2/catch_all.hpp>
+
+#include "fixtures.h"
+
+using namespace vsag;
+
+TEST_CASE("Attribute Equal Test", "[ut][Attribute]") {
+    auto test_equal = [](const auto& attr1, const auto& attr2, bool expected) {
+        REQUIRE(attr1->Equal(attr2.get()) == expected);
+        REQUIRE(attr2->Equal(attr1.get()) == expected);
+    };
+
+    SECTION("INT32") {
+        auto a1 = std::make_shared<AttributeValue<int32_t>>();
+        a1->GetValue().push_back(123);
+        auto a2 = std::make_shared<AttributeValue<int32_t>>();
+        a2->GetValue().push_back(123);
+        auto a3 = std::make_shared<AttributeValue<int32_t>>();
+        a3->GetValue().push_back(456);
+
+        test_equal(a1, a2, true);
+        test_equal(a1, a3, false);
+    }
+
+    SECTION("UINT32") {
+        auto a1 = std::make_shared<AttributeValue<uint32_t>>();
+        a1->GetValue().push_back(100);
+        auto a2 = std::make_shared<AttributeValue<uint32_t>>();
+        a2->GetValue().push_back(100);
+        auto a3 = std::make_shared<AttributeValue<uint32_t>>();
+        a3->GetValue().push_back(200);
+
+        test_equal(a1, a2, true);
+        test_equal(a1, a3, false);
+    }
+
+    SECTION("INT64") {
+        auto a1 = std::make_shared<AttributeValue<int64_t>>();
+        a1->GetValue().push_back(123456789012345);
+        auto a2 = std::make_shared<AttributeValue<int64_t>>();
+        a2->GetValue().push_back(123456789012345);
+        auto a3 = std::make_shared<AttributeValue<int64_t>>();
+        a3->GetValue().push_back(987654321098765);
+
+        test_equal(a1, a2, true);
+        test_equal(a1, a3, false);
+    }
+
+    SECTION("UINT64") {
+        auto a1 = std::make_shared<AttributeValue<uint64_t>>();
+        a1->GetValue().push_back(1000000000000000000ULL);
+        auto a2 = std::make_shared<AttributeValue<uint64_t>>();
+        a2->GetValue().push_back(1000000000000000000ULL);
+        auto a3 = std::make_shared<AttributeValue<uint64_t>>();
+        a3->GetValue().push_back(2000000000000000000ULL);
+
+        test_equal(a1, a2, true);
+        test_equal(a1, a3, false);
+    }
+
+    SECTION("INT8") {
+        auto a1 = std::make_shared<AttributeValue<int8_t>>();
+        a1->GetValue().push_back(-128);
+        auto a2 = std::make_shared<AttributeValue<int8_t>>();
+        a2->GetValue().push_back(-128);
+        auto a3 = std::make_shared<AttributeValue<int8_t>>();
+        a3->GetValue().push_back(0);
+
+        test_equal(a1, a2, true);
+        test_equal(a1, a3, false);
+    }
+
+    SECTION("UINT8") {
+        auto a1 = std::make_shared<AttributeValue<uint8_t>>();
+        a1->GetValue().push_back(255);
+        auto a2 = std::make_shared<AttributeValue<uint8_t>>();
+        a2->GetValue().push_back(255);
+        auto a3 = std::make_shared<AttributeValue<uint8_t>>();
+        a3->GetValue().push_back(0);
+
+        test_equal(a1, a2, true);
+        test_equal(a1, a3, false);
+    }
+
+    SECTION("INT16") {
+        auto a1 = std::make_shared<AttributeValue<int16_t>>();
+        a1->GetValue().push_back(-32768);
+        auto a2 = std::make_shared<AttributeValue<int16_t>>();
+        a2->GetValue().push_back(-32768);
+        auto a3 = std::make_shared<AttributeValue<int16_t>>();
+        a3->GetValue().push_back(0);
+
+        test_equal(a1, a2, true);
+        test_equal(a1, a3, false);
+    }
+
+    SECTION("UINT16") {
+        auto a1 = std::make_shared<AttributeValue<uint16_t>>();
+        a1->GetValue().push_back(65535);
+        auto a2 = std::make_shared<AttributeValue<uint16_t>>();
+        a2->GetValue().push_back(65535);
+        auto a3 = std::make_shared<AttributeValue<uint16_t>>();
+        a3->GetValue().push_back(0);
+
+        test_equal(a1, a2, true);
+        test_equal(a1, a3, false);
+    }
+
+    SECTION("STRING") {
+        auto a1 = std::make_shared<AttributeValue<std::string>>();
+        a1->GetValue().push_back("hello");
+        auto a2 = std::make_shared<AttributeValue<std::string>>();
+        a2->GetValue().push_back("hello");
+        auto a3 = std::make_shared<AttributeValue<std::string>>();
+        a3->GetValue().push_back("world");
+
+        test_equal(a1, a2, true);
+        test_equal(a1, a3, false);
+    }
+
+    SECTION("Different Type") {
+        auto a1 = std::make_shared<AttributeValue<int32_t>>();
+        a1->GetValue().push_back(123);
+        auto a2 = std::make_shared<AttributeValue<uint32_t>>();
+        a2->GetValue().push_back(123);
+
+        REQUIRE(a1->Equal(a2.get()) == false);
+        REQUIRE(a2->Equal(a1.get()) == false);
+    }
+
+    SECTION("Different Count") {
+        auto a1 = std::make_shared<AttributeValue<int32_t>>();
+        a1->GetValue().push_back(1);
+        a1->GetValue().push_back(2);
+        auto a2 = std::make_shared<AttributeValue<int32_t>>();
+        a2->GetValue().push_back(1);
+
+        REQUIRE(a1->Equal(a2.get()) == false);
+        REQUIRE(a2->Equal(a1.get()) == false);
+    }
+}

--- a/src/dataset_impl.cpp
+++ b/src/dataset_impl.cpp
@@ -15,6 +15,10 @@
 
 #include "dataset_impl.h"
 
+#include <cstring>
+
+#include "vsag_exception.h"
+
 namespace vsag {
 
 DatasetPtr
@@ -27,6 +31,245 @@ DatasetImpl::MakeEmptyDataset() {
     auto result = std::make_shared<DatasetImpl>();
     result->Dim(0)->NumElements(1);
     return result;
+}
+
+template <typename T>
+inline T*
+new_element(T*& old_dest, size_t old_count, size_t new_total) {
+    T* dest = new T[new_total];
+    if (old_dest != nullptr) {
+        memcpy(dest, old_dest, old_count * sizeof(T));
+    }
+    delete[] old_dest;  // Free the old memory if it was allocated with new[]
+    old_dest = nullptr;
+    return dest;
+}
+
+template <typename T>
+inline T*
+allocator_element(Allocator* allocator, T* old_dest, size_t new_size_in_bytes) {
+    if (old_dest != nullptr) {
+        return static_cast<T*>(allocator->Reallocate(old_dest, new_size_in_bytes));
+    }
+    return static_cast<T*>(allocator->Allocate(new_size_in_bytes));
+}
+
+template <typename T>
+T*
+allocate_and_copy(
+    const T* src, size_t count, Allocator* allocator, T* old_dest = nullptr, size_t old_count = 0) {
+    if (src == nullptr || count == 0) {
+        return nullptr;
+    }
+    if (old_dest == nullptr && old_count > 0) {
+        throw VsagException(ErrorType::INVALID_ARGUMENT,
+                            "Old destination cannot be null if old count is greater than zero");
+    }
+    if (old_dest && old_count == 0) {
+        throw VsagException(ErrorType::INVALID_ARGUMENT,
+                            "Old count must be greater than zero if old destination is provided");
+    }
+
+    T* dest;
+    if (allocator != nullptr) {
+        dest = allocator_element<T>(allocator, old_dest, (old_count + count) * sizeof(T));
+    } else {
+        dest = new_element<T>(old_dest, old_count, old_count + count);
+    }
+    memcpy(dest + old_count, src, count * sizeof(T));
+    return dest;
+}
+
+void
+copy_sparse_vector(const SparseVector& src, SparseVector* dest, Allocator* allocator) {
+    size_t len = src.len_;
+    if (allocator != nullptr) {
+        dest->ids_ = static_cast<uint32_t*>(allocator->Allocate(len * sizeof(uint32_t)));
+        dest->vals_ = static_cast<float*>(allocator->Allocate(len * sizeof(float)));
+    } else {
+        dest->ids_ = new uint32_t[len];
+        dest->vals_ = new float[len];
+    }
+    dest->len_ = len;
+    std::memcpy(dest->ids_, src.ids_, len * sizeof(uint32_t));
+    std::memcpy(dest->vals_, src.vals_, len * sizeof(float));
+}
+
+SparseVector*
+allocate_and_copy_sparse_vectors(const SparseVector* src,
+                                 size_t count,
+                                 Allocator* allocator,
+                                 SparseVector* old_dest = nullptr,
+                                 size_t old_count = 0) {
+    if (src == nullptr || count == 0) {
+        return old_dest;
+    }
+
+    size_t new_total = old_count + count;
+    SparseVector* dest = nullptr;
+
+    if (allocator != nullptr) {
+        dest =
+            allocator_element<SparseVector>(allocator, old_dest, new_total * sizeof(SparseVector));
+    } else {
+        dest = new_element<SparseVector>(old_dest, old_count, new_total);
+    }
+
+    for (size_t i = old_count; i < new_total; ++i) {
+        const SparseVector& src_vec = src[i - old_count];
+        copy_sparse_vector(src_vec, &dest[i], allocator);
+    }
+    return dest;
+}
+
+DatasetPtr
+DatasetImpl::DeepCopy(Allocator* allocator) const {
+    auto* allocator_ref = allocator != nullptr ? allocator : this->allocator_;
+    auto copy_dataset = std::make_shared<DatasetImpl>();
+    copy_dataset->Owner(true, allocator_ref);
+
+    auto num_elements = this->GetNumElements();
+    auto dim = this->GetDim();
+
+    copy_dataset->NumElements(num_elements);
+    copy_dataset->Dim(dim);
+
+    copy_dataset->Ids(allocate_and_copy(this->GetIds(), num_elements, allocator_ref));
+    copy_dataset->Distances(
+        allocate_and_copy(this->GetDistances(), num_elements * dim, allocator_ref));
+    copy_dataset->Int8Vectors(
+        allocate_and_copy(this->GetInt8Vectors(), num_elements * dim, allocator_ref));
+    copy_dataset->Float32Vectors(
+        allocate_and_copy(this->GetFloat32Vectors(), num_elements * dim, allocator_ref));
+
+    if (this->GetExtraInfoSize() != 0) {
+        copy_dataset->ExtraInfoSize(this->GetExtraInfoSize());
+        copy_dataset->ExtraInfos(allocate_and_copy(
+            this->GetExtraInfos(), num_elements * this->GetExtraInfoSize(), allocator_ref));
+    }
+    copy_dataset->SparseVectors(
+        allocate_and_copy_sparse_vectors(this->GetSparseVectors(), num_elements, allocator_ref));
+
+    auto* paths = new std::string[num_elements];
+    copy_dataset->Paths(paths);
+    for (int i = 0; i < num_elements; ++i) {
+        paths[i] = this->GetPaths()[i];
+    }
+
+    if (this->GetAttributeSets() != nullptr) {
+        const auto* attrsets = this->GetAttributeSets();
+        auto* attrsets_copy = new AttributeSet[num_elements];
+        copy_dataset->AttributeSets(attrsets_copy);
+
+        for (int i = 0; i < num_elements; ++i) {
+            attrsets_copy[i].attrs_.reserve(attrsets[i].attrs_.size());
+            for (const auto& attr : attrsets[i].attrs_) {
+                attrsets_copy[i].attrs_.emplace_back(attr->DeepCopy());
+            }
+        }
+    }
+
+    return copy_dataset;
+}
+
+#define APPEND_DATA(KEY, TYPE, SETTER_FUNC, MULTIPLIER)                                          \
+    if (auto iter = this->data_.find(KEY); iter != this->data_.end()) {                          \
+        if (other->Get##SETTER_FUNC() == nullptr) {                                              \
+            throw VsagException(ErrorType::INVALID_ARGUMENT,                                     \
+                                "Cannot append dataset without " #KEY " to dataset with " #KEY); \
+        }                                                                                        \
+        auto ptr = const_cast<TYPE>(std::get<const TYPE>(iter->second));                         \
+        this->SETTER_FUNC(allocate_and_copy(other->Get##SETTER_FUNC(),                           \
+                                            new_num_elements*(MULTIPLIER),                       \
+                                            this->allocator_,                                    \
+                                            ptr,                                                 \
+                                            old_num_elements*(MULTIPLIER)));                     \
+    }
+
+DatasetPtr
+DatasetImpl::Append(const DatasetPtr& other) {
+    if (!owner_) {
+        throw VsagException(ErrorType::INVALID_ARGUMENT, "Cannot append to a non-owner dataset");
+    }
+    if (this->GetDim() != other->GetDim()) {
+        throw VsagException(ErrorType::INVALID_ARGUMENT,
+                            "Cannot append datasets with different dimensions");
+    }
+    if (other->GetExtraInfoSize() != this->GetExtraInfoSize()) {
+        throw VsagException(ErrorType::INVALID_ARGUMENT,
+                            "Cannot append datasets with different extra info sizes");
+    }
+
+    auto old_num_elements = this->GetNumElements();
+    auto new_num_elements = other->GetNumElements();
+    auto dim = this->GetDim();
+
+    this->NumElements(old_num_elements + new_num_elements);
+
+    APPEND_DATA(IDS, int64_t*, Ids, 1);
+    APPEND_DATA(DISTS, float*, Distances, dim);
+    APPEND_DATA(INT8_VECTORS, int8_t*, Int8Vectors, dim);
+    APPEND_DATA(FLOAT32_VECTORS, float*, Float32Vectors, dim);
+    if (this->GetExtraInfoSize() != 0) {
+        APPEND_DATA(EXTRA_INFOS, char*, ExtraInfos, this->GetExtraInfoSize());
+    }
+
+    // append paths
+    if (auto iter = this->data_.find(DATASET_PATHS); iter != this->data_.end()) {
+        if (other->GetPaths() == nullptr) {
+            throw VsagException(ErrorType::INVALID_ARGUMENT,
+                                "Cannot append dataset without paths to dataset with paths");
+        }
+        auto* ptr = const_cast<std::string*>(std::get<const std::string*>(iter->second));
+        auto* paths_copy = new std::string[old_num_elements + new_num_elements];
+        for (int i = 0; i < old_num_elements; ++i) {
+            paths_copy[i] = ptr[i];
+        }
+        delete[] ptr;  // Free the old memory if it was allocated with new[]
+        ptr = nullptr;
+        for (int i = 0; i < new_num_elements; ++i) {
+            paths_copy[old_num_elements + i] = other->GetPaths()[i];
+        }
+        this->Paths(paths_copy);
+    }
+
+    // append sparse vectors
+    if (auto iter = this->data_.find(SPARSE_VECTORS); iter != this->data_.end()) {
+        if (other->GetSparseVectors() == nullptr) {
+            throw VsagException(
+                ErrorType::INVALID_ARGUMENT,
+                "Cannot append dataset without sparse vectors to dataset with sparse vectors");
+        }
+        auto* ptr = const_cast<SparseVector*>(std::get<const SparseVector*>(iter->second));
+        this->SparseVectors(allocate_and_copy_sparse_vectors(
+            other->GetSparseVectors(), new_num_elements, this->allocator_, ptr, old_num_elements));
+    }
+
+    // append attribute sets
+    if (auto iter = this->data_.find(ATTRIBUTE_SETS); iter != this->data_.end()) {
+        if (other->GetAttributeSets() == nullptr) {
+            throw VsagException(
+                ErrorType::INVALID_ARGUMENT,
+                "Cannot append dataset without attribute sets to dataset with attribute sets");
+        }
+        auto* ptr = const_cast<AttributeSet*>(std::get<const AttributeSet*>(iter->second));
+        auto* attrsets_copy = new AttributeSet[new_num_elements + old_num_elements];
+        this->AttributeSets(attrsets_copy);
+        for (int i = 0; i < old_num_elements; ++i) {
+            attrsets_copy[i].attrs_.swap(ptr[i].attrs_);
+        }
+        delete[] ptr;
+        ptr = nullptr;
+        const auto* other_attribute_sets = other->GetAttributeSets();
+        for (int i = 0; i < new_num_elements; ++i) {
+            attrsets_copy[old_num_elements + i].attrs_.reserve(
+                other_attribute_sets[i].attrs_.size());
+            for (const auto& attr : other_attribute_sets[i].attrs_) {
+                attrsets_copy[old_num_elements + i].attrs_.emplace_back(attr->DeepCopy());
+            }
+        }
+    }
+    return shared_from_this();
 }
 
 };  // namespace vsag

--- a/src/dataset_impl_test.cpp
+++ b/src/dataset_impl_test.cpp
@@ -16,10 +16,12 @@
 #include "dataset_impl.h"
 
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
 
 #include "fixtures.h"
 #include "impl/allocator/default_allocator.h"
 #include "vsag/dataset.h"
+#include "vsag/engine.h"
 
 TEST_CASE("Dataset Implement Test", "[ut][dataset]") {
     vsag::DefaultAllocator allocator;
@@ -109,5 +111,190 @@ TEST_CASE("Dataset Implement Test", "[ut][dataset]") {
                 REQUIRE(sparse_vectors_ptr[i].vals_[d] < max_val);
             }
         }
+    }
+}
+
+vsag::DatasetPtr
+CreateTestDataset(int num_elements = 777,
+                  int dim = 38,
+                  int64_t extra_info_size = 13,
+                  vsag::Allocator* allocator = nullptr) {
+    auto base = vsag::Dataset::Make();
+    auto vecs = fixtures::generate_vectors(num_elements, dim, false, fixtures::RandomValue(0, 564));
+    auto distances =
+        fixtures::generate_vectors(num_elements, dim, false, fixtures::RandomValue(0, 564));
+    auto vecs_int8 =
+        fixtures::generate_int8_codes(num_elements, dim, fixtures::RandomValue(0, 564));
+    auto attr_sets = fixtures::generate_attributes(num_elements);
+    std::string* paths = new std::string[num_elements];
+    for (int i = 0; i < num_elements; ++i) {
+        paths[i] = fixtures::create_random_string(false);
+    }
+    std::vector<int64_t> ids(num_elements);
+    std::iota(ids.begin(), ids.end(), 0);
+    base->Dim(dim)
+        ->Ids(fixtures::CopyVector(ids, allocator))
+        ->Paths(paths)
+        ->AttributeSets(attr_sets)
+        ->NumElements(num_elements)
+        ->Distances(fixtures::CopyVector(distances, allocator))
+        ->Owner(true, allocator);
+    base->Float32Vectors(fixtures::CopyVector(vecs, allocator))
+        ->Int8Vectors(fixtures::CopyVector(vecs_int8, allocator));
+    if (allocator != nullptr) {
+        base->SparseVectors(fixtures::CopyVector(
+            fixtures::GenerateSparseVectors(allocator, num_elements, dim), allocator));
+    } else {
+        base->SparseVectors(
+            fixtures::CopyVector(fixtures::GenerateSparseVectors(num_elements, dim), allocator));
+    }
+    auto extro_infos = fixtures::generate_extra_infos(num_elements, extra_info_size);
+    base->ExtraInfoSize(extra_info_size)->ExtraInfos(fixtures::CopyVector(extro_infos, allocator));
+    return base;
+}
+
+bool
+EqualDataset(const vsag::DatasetPtr& data1, const vsag::DatasetPtr& data2) {
+    if (data1->GetNumElements() != data2->GetNumElements()) {
+        return false;
+    }
+    if (data1->GetDim() != data2->GetDim()) {
+        return false;
+    }
+    auto num_element = data1->GetNumElements();
+    auto dim = data1->GetDim();
+    if (memcmp(data1->GetIds(), data2->GetIds(), sizeof(int64_t) * num_element) != 0) {
+        return false;
+    }
+    if (memcmp(data1->GetFloat32Vectors(),
+               data2->GetFloat32Vectors(),
+               sizeof(float) * num_element * dim) != 0) {
+        return false;
+    }
+    if (memcmp(data1->GetInt8Vectors(),
+               data2->GetInt8Vectors(),
+               sizeof(int8_t) * num_element * dim) != 0) {
+        return false;
+    }
+    if (memcmp(data1->GetDistances(), data2->GetDistances(), sizeof(float) * num_element * dim) !=
+        0) {
+        return false;
+    }
+
+    auto path1 = data1->GetPaths();
+    auto path2 = data2->GetPaths();
+    if (path1 != nullptr && path2 != nullptr) {
+        for (int i = 0; i < num_element; ++i) {
+            if (path1[i] != path2[i]) {
+                return false;
+            }
+        }
+    } else if (path1 != nullptr || path2 != nullptr) {
+        return false;
+    }
+
+    auto attr_sets1 = data1->GetAttributeSets();
+    auto attr_sets2 = data2->GetAttributeSets();
+    if (attr_sets1 != nullptr && attr_sets2 != nullptr) {
+        if (attr_sets1->attrs_.size() != attr_sets2->attrs_.size()) {
+            return false;
+        }
+        for (int i = 0; i < attr_sets1->attrs_.size(); ++i) {
+            const auto& attrs1 = attr_sets1->attrs_[i];
+            const auto& attrs2 = attr_sets2->attrs_[i];
+            if (not attrs1->Equal(attrs2)) {
+                return false;
+            }
+        }
+    } else if (attr_sets1 != nullptr || attr_sets2 != nullptr) {
+        return false;
+    }
+
+    auto sparse_vectors1 = data1->GetSparseVectors();
+    auto sparse_vectors2 = data2->GetSparseVectors();
+    if (sparse_vectors1 != nullptr && sparse_vectors2 != nullptr) {
+        for (int i = 0; i < num_element; ++i) {
+            if (sparse_vectors1[i].len_ != sparse_vectors2[i].len_) {
+                return false;
+            }
+            if (memcmp(sparse_vectors1[i].vals_,
+                       sparse_vectors2[i].vals_,
+                       sizeof(float) * sparse_vectors1[i].len_) != 0) {
+                return false;
+            }
+            if (memcmp(sparse_vectors1[i].ids_,
+                       sparse_vectors2[i].ids_,
+                       sizeof(uint32_t) * sparse_vectors1[i].len_) != 0) {
+                return false;
+            }
+        }
+    } else if (sparse_vectors1 != nullptr || sparse_vectors2 != nullptr) {
+        return false;
+    }
+    if (data1->GetExtraInfoSize() != data2->GetExtraInfoSize()) {
+        return false;
+    }
+    if (data1->GetExtraInfoSize() > 0 &&
+        memcmp(data1->GetExtraInfos(),
+               data2->GetExtraInfos(),
+               sizeof(char) * data1->GetExtraInfoSize() * num_element) != 0) {
+        return false;
+    }
+    return true;
+}
+
+TEST_CASE("Dataset Copy and Append Test", "[ut][Dataset]") {
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_int_distribution<> great_num(1000, 2000);
+    std::uniform_int_distribution<> append_num(1000, 2000);
+    std::uniform_int_distribution<> dim_random(100, 200);
+    int num_elements = great_num(gen);
+    int append_num_elements = append_num(gen);
+    int dim = dim_random(gen);
+
+    auto use_allocator = GENERATE(true, false);
+    std::shared_ptr<vsag::Allocator> allocator =
+        use_allocator ? vsag::Engine::CreateDefaultAllocator() : nullptr;
+    int64_t extra_info_size = 13;
+    auto original = CreateTestDataset(num_elements, dim, extra_info_size, allocator.get());
+    SECTION("Deep Copy") {
+        auto use_copy_allocator = GENERATE(true, false);
+        std::shared_ptr<vsag::Allocator> copy_allocator =
+            use_allocator ? vsag::Engine::CreateDefaultAllocator() : nullptr;
+        auto copy = original->DeepCopy(copy_allocator.get());
+        REQUIRE(EqualDataset(original, copy));
+        REQUIRE(memcmp(original->GetSparseVectors(),
+                       copy->GetSparseVectors(),
+                       sizeof(vsag::SparseVector) * num_elements) != 0);
+        REQUIRE(memcmp(original->GetAttributeSets(),
+                       copy->GetAttributeSets(),
+                       sizeof(vsag::AttributeSet) * num_elements) != 0);
+        REQUIRE(memcmp(original->GetPaths(),
+                       copy->GetPaths(),
+                       sizeof(std::string) * num_elements) != 0);
+    }
+    SECTION("Append") {
+        auto copy = original->DeepCopy();
+        auto append_dataset = CreateTestDataset(append_num_elements, dim);
+        original->Append(append_dataset);
+        REQUIRE(original->GetNumElements() == num_elements + append_num_elements);
+        original->NumElements(num_elements);
+        REQUIRE(EqualDataset(original, copy));
+        original->NumElements(num_elements + append_num_elements);
+        auto sub_original = vsag::Dataset::Make();
+        sub_original->Dim(dim)
+            ->Ids(original->GetIds() + num_elements)
+            ->SparseVectors(original->GetSparseVectors() + num_elements)
+            ->Float32Vectors(original->GetFloat32Vectors() + num_elements * dim)
+            ->Int8Vectors(original->GetInt8Vectors() + num_elements * dim)
+            ->Distances(original->GetDistances() + num_elements * dim)
+            ->Paths(original->GetPaths() + num_elements)
+            ->AttributeSets(original->GetAttributeSets() + num_elements)
+            ->NumElements(append_num_elements)
+            ->ExtraInfoSize(extra_info_size)
+            ->ExtraInfos(original->GetExtraInfos() + num_elements * extra_info_size)
+            ->Owner(false);
+        REQUIRE(EqualDataset(sub_original, append_dataset));
     }
 }

--- a/tests/fixtures/fixtures.cpp
+++ b/tests/fixtures/fixtures.cpp
@@ -140,6 +140,45 @@ GenerateBinaryVectorsAndCodes(uint32_t count, uint32_t dim, int seed) {
     return {vectors, codes};
 }
 
+std::string
+create_random_string(bool is_full) {
+    const std::vector<std::string> level1 = {"a", "b", "c"};
+    const std::vector<std::string> level2 = {"d", "e"};
+    const std::vector<std::string> level3 = {"f", "g", "h"};
+
+    std::random_device rd;
+    std::mt19937 mt(rd());
+    std::uniform_int_distribution<> distr;
+
+    std::vector<std::string> selected_levels;
+
+    if (is_full) {
+        selected_levels.push_back(level1[distr(mt) % level1.size()]);
+        selected_levels.push_back(level2[distr(mt) % level2.size()]);
+        selected_levels.push_back(level3[distr(mt) % level3.size()]);
+    } else {
+        std::uniform_int_distribution<> dist(1, 3);
+        int num_levels = dist(mt);
+
+        if (num_levels >= 1) {
+            selected_levels.push_back(level1[distr(mt) % level1.size()]);
+        }
+        if (num_levels >= 2) {
+            selected_levels.push_back(level2[distr(mt) % level2.size()]);
+        }
+        if (num_levels == 3) {
+            selected_levels.push_back(level3[distr(mt) % level3.size()]);
+        }
+    }
+
+    std::string random_string = selected_levels.empty() ? "" : selected_levels[0];
+    for (size_t i = 1; i < selected_levels.size(); ++i) {
+        random_string += "/" + selected_levels[i];
+    }
+
+    return random_string;
+}
+
 std::vector<float>
 generate_vectors(uint64_t count, uint32_t dim, bool need_normalize, int seed) {
     return std::move(GenerateVectors<float>(count, dim, seed, need_normalize));

--- a/tests/fixtures/fixtures.h
+++ b/tests/fixtures/fixtures.h
@@ -67,6 +67,19 @@ CopyVector(const vsag::Vector<T>& vec, vsag::Allocator* allocator) {
     return result;
 }
 
+template <typename T>
+T*
+CopyVector(const std::vector<T>& vec, vsag::Allocator* allocator) {
+    T* result;
+    if (allocator) {
+        result = (T*)allocator->Allocate(sizeof(T) * vec.size());
+    } else {
+        result = new T[vec.size()];
+    }
+    memcpy(result, vec.data(), vec.size() * sizeof(T));
+    return result;
+}
+
 template <typename T, typename RT = typename std::enable_if<std::is_integral_v<T>, T>::type>
 std::vector<RT>
 GenerateVectors(uint64_t count,
@@ -119,6 +132,9 @@ GenerateSparseVectors(vsag::Allocator* allocator,
 
 std::pair<std::vector<float>, std::vector<uint8_t>>
 GenerateBinaryVectorsAndCodes(uint32_t count, uint32_t dim, int seed = 47);
+
+std::string
+create_random_string(bool is_full);
 
 std::vector<float>
 generate_vectors(uint64_t count, uint32_t dim, bool need_normalize = true, int seed = 47);

--- a/tests/fixtures/test_dataset.cpp
+++ b/tests/fixtures/test_dataset.cpp
@@ -41,45 +41,6 @@ is_path_belong_to(const std::string& a, const std::string& b) {
     return b.compare(0, a.size(), a) == 0;
 }
 
-std::string
-create_random_string(bool is_full) {
-    const std::vector<std::string> level1 = {"a", "b", "c"};
-    const std::vector<std::string> level2 = {"d", "e"};
-    const std::vector<std::string> level3 = {"f", "g", "h"};
-
-    std::random_device rd;
-    std::mt19937 mt(rd());
-    std::uniform_int_distribution<> distr;
-
-    std::vector<std::string> selected_levels;
-
-    if (is_full) {
-        selected_levels.push_back(level1[distr(mt) % level1.size()]);
-        selected_levels.push_back(level2[distr(mt) % level2.size()]);
-        selected_levels.push_back(level3[distr(mt) % level3.size()]);
-    } else {
-        std::uniform_int_distribution<> dist(1, 3);
-        int num_levels = dist(mt);
-
-        if (num_levels >= 1) {
-            selected_levels.push_back(level1[distr(mt) % level1.size()]);
-        }
-        if (num_levels >= 2) {
-            selected_levels.push_back(level2[distr(mt) % level2.size()]);
-        }
-        if (num_levels == 3) {
-            selected_levels.push_back(level3[distr(mt) % level3.size()]);
-        }
-    }
-
-    std::string random_string = selected_levels.empty() ? "" : selected_levels[0];
-    for (size_t i = 1; i < selected_levels.size(); ++i) {
-        random_string += "/" + selected_levels[i];
-    }
-
-    return random_string;
-}
-
 static TestDataset::DatasetPtr
 GenerateRandomDataset(uint64_t dim,
                       uint64_t count,


### PR DESCRIPTION
close  #1073

## Summary by Sourcery

Implement DeepCopy and Append in the Dataset API with corresponding memory-allocation helpers, extend AttributeValue with deep-copy and equality support, refactor fixtures, and add comprehensive tests for the new functionality.

New Features:
- Add DeepCopy() method to Dataset/DatasetImpl for deep cloning with optional custom allocator
- Add Append() method to DatasetImpl to merge another dataset into the current one

Enhancements:
- Introduce generic AllocateAndCopy and copy_sparse_vector utilities for efficient memory allocation and data copying, including sparse vectors
- Extend AttributeValue with DeepCopy() and Equal() overrides for attribute cloning and comparison
- Clean up path deallocation logic in DatasetImpl

Tests:
- Add dataset_impl_test.cpp tests for DeepCopy and Append using CreateTestDataset and EqualDataset helpers
- Add attribute_test.cpp unit tests for AttributeValue Equal() across various types and scenarios

Chores:
- Move create_random_string helper into fixtures and add CopyVector template for vector-to-array conversion