### PR TITLE
fix(sindi): fix compilation issues of sindi in versions prior to C++17

### DIFF
--- a/src/data_cell/sparse_term_datacell.cpp
+++ b/src/data_cell/sparse_term_datacell.cpp
@@ -104,16 +104,17 @@ SparseTermDataCell::InsertHeap(float* dists,
             if constexpr (type == InnerSearchType::WITH_FILTER) {
                 is_valid = (filter and filter->CheckValid(id + offset_id));
             }
+#if __cplusplus >= 202002L
             if (dists[id] > cur_heap_top or not is_valid) [[likely]] {
+#else
+            if (__builtin_expect(dists[id] > cur_heap_top || !is_valid, 1)) {
+#endif
                 dists[id] = 0;
                 continue;
-            } else {
-                heap.emplace(dists[id], id + offset_id);
             }
+            heap.emplace(dists[id], id + offset_id);
             if constexpr (mode == InnerSearchMode::KNN_SEARCH) {
-                if (heap.size() > n_candidate) [[likely]] {
-                    heap.pop();
-                }
+                heap.pop();
                 cur_heap_top = heap.top().first;
             }
             if constexpr (mode == InnerSearchMode::RANGE_SEARCH) {


### PR DESCRIPTION
close #1081
## Summary by Sourcery

Fix compilation issues in sparse_term_datacell by conditionally falling back to __builtin_expect for branch prediction and restructuring heap operations for standards prior to C++20

Bug Fixes:
- Add preprocessor guard to use __builtin_expect when [[likely]] is unsupported
- Adjust heap operation placement to resolve compilation errors on older C++ standards

Enhancements:
- Remove redundant heap size check under KNN search