### PR TITLE
feat(reader): add the MultRead method to the reader interface

### DIFF
--- a/include/vsag/readerset.h
+++ b/include/vsag/readerset.h
@@ -92,6 +92,9 @@ public:
     virtual void
     AsyncRead(uint64_t offset, uint64_t len, void* dest, CallBack callback) = 0;
 
+    virtual bool
+    MultiRead(uint8_t* datas, const uint64_t* sizes, const uint64_t* offsets, uint64_t count);
+
     /**
      * @brief Returns the size of the data source.
      *

--- a/include/vsag/readerset.h
+++ b/include/vsag/readerset.h
@@ -92,8 +92,32 @@ public:
     virtual void
     AsyncRead(uint64_t offset, uint64_t len, void* dest, CallBack callback) = 0;
 
+    /**
+     * @brief Performs multiple synchronous read operations from the data source.
+     *
+     * This virtual function initiates a batch of read operations, each reading a specified
+     * number of bytes from the source starting at a given offset and copying them to a
+     * corresponding destination buffer. The parameters are provided as arrays where each
+     * index corresponds to a single read operation.
+     *
+     * @param dests    Array of pointers to the memory buffers where the read bytes will be copied.
+     *                 Each element corresponds to a specific read operation.
+     * @param lens     Array of lengths (in bytes) for each read operation. Must match the
+     *                 number of operations specified by `count`.
+     * @param offsets  Array of starting positions in the data source for each read operation.
+     *                 Must match the number of operations specified by `count`.
+     * @param count    The total number of read operations to perform.
+     *
+     * @return         Returns `true` if all read operations completed successfully,
+     *                 `false` otherwise (e.g., due to invalid parameters or I/O errors).
+     *
+     * @note This function is thread-safe and operates synchronously, blocking until all
+     *       read operations are completed.
+     * @note The arrays `dests`, `lens`, and `offsets` must be valid and contain exactly `count`
+     *       elements. Passing null pointers or mismatched array sizes may result in undefined behavior.
+     */
     virtual bool
-    MultiRead(uint8_t* datas, const uint64_t* sizes, const uint64_t* offsets, uint64_t count);
+    MultiRead(uint8_t* dests, const uint64_t* lens, const uint64_t* offsets, uint64_t count);
 
     /**
      * @brief Returns the size of the data source.

--- a/mockimpl/vsag/factory.cpp
+++ b/mockimpl/vsag/factory.cpp
@@ -77,6 +77,36 @@ Factory::CreateLocalFileReader(const std::string& filename, int64_t base_offset,
     return std::make_shared<LocalFileReader>(filename, base_offset, size);
 }
 
+bool
+Reader::MultiRead(uint8_t* datas, const uint64_t* sizes, const uint64_t* offsets, uint64_t count) {
+    std::atomic<bool> succeed(true);
+    std::string error_message;
+    std::atomic<uint64_t> counter(count);
+    std::promise<void> total_promise;
+    uint8_t* dest = datas;
+    auto total_future = total_promise.get_future();
+    for (int i = 0; i < count; ++i) {
+        uint64_t offset = offsets[i];
+        uint64_t size = sizes[i];
+        auto callback = [&counter, &total_promise, &succeed, &error_message](
+                            IOErrorCode code, const std::string& message) {
+            if (code != vsag::IOErrorCode::IO_SUCCESS) {
+                bool expected = true;
+                if (succeed.compare_exchange_strong(expected, false)) {
+                    error_message = message;
+                }
+            }
+            if (--counter == 0) {
+                total_promise.set_value();
+            }
+        };
+        AsyncRead(offset, size, dest, callback);
+        dest += size;
+    }
+    total_future.wait();
+    return succeed;
+}
+
 float
 l2sqr(const void* vec1, const void* vec2, int64_t dim) {
     float* v1 = (float*)vec1;

--- a/mockimpl/vsag/factory.cpp
+++ b/mockimpl/vsag/factory.cpp
@@ -78,16 +78,17 @@ Factory::CreateLocalFileReader(const std::string& filename, int64_t base_offset,
 }
 
 bool
-Reader::MultiRead(uint8_t* datas, const uint64_t* sizes, const uint64_t* offsets, uint64_t count) {
+Reader::MultiRead(uint8_t* dests, const uint64_t* lens, const uint64_t* offsets, uint64_t count) {
     std::atomic<bool> succeed(true);
     std::string error_message;
     std::atomic<uint64_t> counter(count);
     std::promise<void> total_promise;
-    uint8_t* dest = datas;
+    uint8_t* dest = dests;
     auto total_future = total_promise.get_future();
+
     for (int i = 0; i < count; ++i) {
         uint64_t offset = offsets[i];
-        uint64_t size = sizes[i];
+        uint64_t size = lens[i];
         auto callback = [&counter, &total_promise, &succeed, &error_message](
                             IOErrorCode code, const std::string& message) {
             if (code != vsag::IOErrorCode::IO_SUCCESS) {
@@ -103,8 +104,10 @@ Reader::MultiRead(uint8_t* datas, const uint64_t* sizes, const uint64_t* offsets
         AsyncRead(offset, size, dest, callback);
         dest += size;
     }
+
     total_future.wait();
-    return succeed;
+    return succeed.load();
+    ;
 }
 
 float

--- a/mockimpl/vsag/factory.cpp
+++ b/mockimpl/vsag/factory.cpp
@@ -107,7 +107,6 @@ Reader::MultiRead(uint8_t* dests, const uint64_t* lens, const uint64_t* offsets,
 
     total_future.wait();
     return succeed.load();
-    ;
 }
 
 float

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -1,0 +1,48 @@
+#include <fmt/format.h>
+
+#include <future>
+
+#include "vsag/readerset.h"
+#include "vsag_exception.h"
+
+namespace vsag {
+
+bool
+Reader::MultiRead(uint8_t* datas, const uint64_t* sizes, const uint64_t* offsets, uint64_t count) {
+    std::atomic<bool> succeed(true);
+    std::string error_message;
+    std::atomic<uint64_t> counter(count);
+    std::promise<void> total_promise;
+    uint8_t* dest = datas;
+    auto total_future = total_promise.get_future();
+    for (int i = 0; i < count; ++i) {
+        uint64_t offset = offsets[i];
+        uint64_t size = sizes[i];
+        if (size + offset > Size()) {
+            throw VsagException(ErrorType::INTERNAL_ERROR,
+                                fmt::format("ReaderIO MultiReadImpl size mismatch: "
+                                            "offset {}, size {}, total size {}",
+                                            offset,
+                                            size,
+                                            Size()));
+        }
+        auto callback = [&counter, &total_promise, &succeed, &error_message](
+                            IOErrorCode code, const std::string& message) {
+            if (code != vsag::IOErrorCode::IO_SUCCESS) {
+                bool expected = true;
+                if (succeed.compare_exchange_strong(expected, false)) {
+                    error_message = message;
+                }
+            }
+            if (--counter == 0) {
+                total_promise.set_value();
+            }
+        };
+        AsyncRead(offset, size, dest, callback);
+        dest += size;
+    }
+    total_future.wait();
+    return succeed;
+}
+
+}  // namespace vsag

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -45,7 +45,6 @@ Reader::MultiRead(uint8_t* dests, const uint64_t* lens, const uint64_t* offsets,
 
     total_future.wait();
     return succeed.load();
-    ;
 }
 
 }  // namespace vsag


### PR DESCRIPTION
## Summary by Sourcery

Introduce a unified MultiRead method on Reader to support batch read operations, implement it in the base and mock classes, and refactor ReaderIO to delegate its multi-read logic to this new interface

New Features:
- Add virtual MultiRead method to the Reader interface
- Provide default implementation of Reader::MultiRead in base class and mock implementation in factory

Enhancements:
- Refactor ReaderIO::MultiReadImpl to compute real offsets and delegate to the new MultiRead interface
- Remove inline async read batching logic from ReaderIO and centralize it in Reader::MultiRead