### PR TITLE
fix(hgraph): fix HGraph deserialization failure

### DIFF
--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -692,6 +692,7 @@ HGraph::deserialize_basic_info(JsonType jsonify_basic_info) {
     if (jsonify_basic_info.contains(INDEX_PARAM)) {
         std::string index_param_string = jsonify_basic_info[INDEX_PARAM];
         HGraphParameterPtr index_param = std::make_shared<HGraphParameter>();
+        index_param->data_type = this->data_type_;
         index_param->FromString(index_param_string);
         if (not this->create_param_ptr_->CheckCompatibility(index_param)) {
             auto message = fmt::format("HGraph index parameter not match, current: {}, new: {}",

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -1174,6 +1174,8 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HGraphTestIndex,
     auto index = TestFactory(name, param, true);
     TestConcurrentAdd(index, dataset, true);
     TestKnnSearch(index, dataset, search_param, true);
+    auto index2 = TestIndex::TestFactory(name, param, true);
+    TestIndex::TestSerializeFile(index, index2, dataset, search_param, true);
     vsag::Options::Instance().set_block_size_limit(origin_size);
 }
 


### PR DESCRIPTION
close #1084

## Summary by Sourcery

Set the data type on deserialized HGraph parameters to fix compatibility errors and add a round-trip serialization test to ensure correct HGraph persistence.

Bug Fixes:
- Assign data_type to HGraphParameter during deserialization to prevent index compatibility failures.

Tests:
- Add a serialization/deserialization round-trip test for HGraph in the test suite.