### PR TITLE
fix(sindi): fix the issue where Sindi returns irrelevant results

### DIFF
--- a/src/algorithm/sindi/sindi.cpp
+++ b/src/algorithm/sindi/sindi.cpp
@@ -149,14 +149,6 @@ SINDI::search_impl(const SparseTermComputerPtr& computer,
         }
     }
 
-    if constexpr (mode == KNN_SEARCH) {
-        // fill up to k
-        while (heap.size() < k) {
-            heap.push(
-                {std::numeric_limits<float>::max(), 0});  // TODO(ZXY): replace with random points
-        }
-    }
-
     // rerank
     if (use_reorder_) {
         // high precision

--- a/tools/eval/case/search_eval_case.cpp
+++ b/tools/eval/case/search_eval_case.cpp
@@ -181,8 +181,11 @@ SearchEvalCase::do_knn_search() {
             }
             const int64_t* neighbors = result.value()->GetIds();
             int64_t* ground_truth_neighbors = dataset_ptr_->GetNeighbors(i);
-            auto record = std::make_tuple(
-                neighbors, ground_truth_neighbors, dataset_ptr_.get(), query_vector, topk);
+            auto record = std::make_tuple(neighbors,
+                                          ground_truth_neighbors,
+                                          dataset_ptr_.get(),
+                                          query_vector,
+                                          result.value()->GetDim());
             monitor->Record(&record);
         }
         monitor->Stop();


### PR DESCRIPTION
close: #1086

## Summary by Sourcery

Remove placeholder padding in SINDI KNN search and ensure evaluation records correct result dimension

Bug Fixes:
- Remove heap padding of max-distance dummy points in KNN search to avoid returning irrelevant results

Tests:
- Update search evaluation case to record actual result dimension instead of fixed topk value