### PR TITLE
refactor: declare shared_ptr/unique_ptr with marco

### DIFF
--- a/src/algorithm/brute_force.cpp
+++ b/src/algorithm/brute_force.cpp
@@ -19,7 +19,9 @@
 
 #include "attr/argparse.h"
 #include "attr/executor/executor.h"
+#include "data_cell/attribute_inverted_interface.h"
 #include "data_cell/flatten_datacell.h"
+#include "data_cell/flatten_interface.h"
 #include "fmt/chrono.h"
 #include "impl/heap/standard_heap.h"
 #include "inner_string_params.h"
@@ -324,7 +326,7 @@ BruteForce::Deserialize(StreamReader& reader) {
         auto basic_info = metadata->Get("basic_info");
         if (basic_info.contains(INDEX_PARAM)) {
             std::string index_param_string = basic_info[INDEX_PARAM];
-            BruteForceParameterPtr index_param = std::make_shared<BruteForceParameter>();
+            auto index_param = std::make_shared<BruteForceParameter>();
             index_param->FromString(index_param_string);
             if (not this->create_param_ptr_->CheckCompatibility(index_param)) {
                 auto message =

--- a/src/algorithm/brute_force.h
+++ b/src/algorithm/brute_force.h
@@ -17,14 +17,15 @@
 
 #include "algorithm/inner_index_interface.h"
 #include "brute_force_parameter.h"
-#include "data_cell/attribute_inverted_interface.h"
-#include "data_cell/flatten_interface.h"
 #include "label_table.h"
+#include "pointer_define.h"
 #include "typing.h"
 #include "vsag/filter.h"
 
 namespace vsag {
 
+DEFINE_POINTER2(AttrInvertedInterface, AttributeInvertedInterface);
+DEFINE_POINTER(FlattenInterface);
 // BruteForce index was introduced since v0.13
 class BruteForce : public InnerIndexInterface {
 public:

--- a/src/algorithm/brute_force_parameter.cpp
+++ b/src/algorithm/brute_force_parameter.cpp
@@ -17,6 +17,7 @@
 
 #include <fmt/format.h>
 
+#include "data_cell/flatten_datacell_parameter.h"
 #include "inner_string_params.h"
 #include "logger.h"
 #include "vsag/constants.h"

--- a/src/algorithm/brute_force_parameter.h
+++ b/src/algorithm/brute_force_parameter.h
@@ -14,11 +14,11 @@
 // limitations under the License.
 
 #pragma once
-#include "data_cell/flatten_datacell_parameter.h"
 #include "parameter.h"
+#include "pointer_define.h"
 #include "typing.h"
-
 namespace vsag {
+DEFINE_POINTER2(FlattenDataCellParam, FlattenDataCellParameter);
 class BruteForceParameter : public Parameter {
 public:
     explicit BruteForceParameter();
@@ -38,6 +38,6 @@ public:
     bool use_attribute_filter{false};
 };
 
-using BruteForceParameterPtr = std::shared_ptr<BruteForceParameter>;
+DEFINE_POINTER(BruteForceParameter);
 
 }  // namespace vsag

--- a/src/algorithm/hgraph.h
+++ b/src/algorithm/hgraph.h
@@ -20,8 +20,6 @@
 #include <shared_mutex>
 #include <string>
 
-#include "algorithm/hnswlib/algorithm_interface.h"
-#include "algorithm/hnswlib/visited_list_pool.h"
 #include "common.h"
 #include "data_cell/attribute_inverted_interface.h"
 #include "data_cell/extra_info_interface.h"

--- a/src/algorithm/hgraph_parameter.cpp
+++ b/src/algorithm/hgraph_parameter.cpp
@@ -15,9 +15,13 @@
 
 #include "hgraph_parameter.h"
 
+#include "data_cell/extra_info_datacell_parameter.h"
+#include "data_cell/flatten_datacell_parameter.h"
 #include "data_cell/graph_datacell_parameter.h"
 #include "data_cell/graph_interface_parameter.h"
+#include "data_cell/sparse_graph_datacell_parameter.h"
 #include "data_cell/sparse_vector_datacell_parameter.h"
+#include "impl/odescent_graph_parameter.h"
 #include "inner_string_params.h"
 #include "vsag/constants.h"
 

--- a/src/algorithm/hgraph_parameter.h
+++ b/src/algorithm/hgraph_parameter.h
@@ -15,17 +15,19 @@
 
 #pragma once
 
-#include "data_cell/extra_info_datacell_parameter.h"
-#include "data_cell/flatten_datacell_parameter.h"
-#include "data_cell/graph_interface_parameter.h"
-#include "data_cell/sparse_graph_datacell_parameter.h"
 #include "data_type.h"
-#include "impl/odescent_graph_parameter.h"
 #include "parameter.h"
+#include "pointer_define.h"
 #include "vsag/constants.h"
 
 namespace vsag {
+DEFINE_POINTER2(ExtraInfoDataCellParam, ExtraInfoDataCellParameter);
+DEFINE_POINTER2(FlattenInterfaceParam, FlattenInterfaceParameter);
+DEFINE_POINTER2(GraphInterfaceParam, GraphInterfaceParameter);
+DEFINE_POINTER2(SparseGraphDatacellParam, SparseGraphDatacellParameter);
+DEFINE_POINTER(ODescentParameter);
 
+DEFINE_POINTER(HGraphParameter);
 class HGraphParameter : public Parameter {
 public:
     explicit HGraphParameter(const JsonType& json);
@@ -68,8 +70,6 @@ public:
 
     std::string name;
 };
-
-using HGraphParameterPtr = std::shared_ptr<HGraphParameter>;
 
 class HGraphSearchParameters {
 public:

--- a/src/algorithm/hgraph_parameter_test.cpp
+++ b/src/algorithm/hgraph_parameter_test.cpp
@@ -15,6 +15,8 @@
 
 #include "hgraph_parameter.h"
 
+#include <fmt/format.h>
+
 #include <catch2/catch_test_macros.hpp>
 
 #include "parameter_test.h"

--- a/src/algorithm/inner_index_interface.h
+++ b/src/algorithm/inner_index_interface.h
@@ -22,6 +22,7 @@
 #include "index_feature_list.h"
 #include "label_table.h"
 #include "parameter.h"
+#include "pointer_define.h"
 #include "storage/stream_reader.h"
 #include "storage/stream_writer.h"
 #include "utils/function_exists_check.h"
@@ -30,8 +31,7 @@
 
 namespace vsag {
 
-class InnerIndexInterface;
-using InnerIndexPtr = std::shared_ptr<InnerIndexInterface>;
+DEFINE_POINTER2(InnerIndex, InnerIndexInterface);
 
 class InnerIndexInterface {
 public:

--- a/src/algorithm/ivf_parameter.h
+++ b/src/algorithm/ivf_parameter.h
@@ -22,9 +22,12 @@
 #include "data_cell/flatten_datacell_parameter.h"
 #include "inner_string_params.h"
 #include "parameter.h"
+#include "pointer_define.h"
 #include "typing.h"
 
 namespace vsag {
+
+DEFINE_POINTER(IVFParameter);
 class IVFParameter : public Parameter {
 public:
     explicit IVFParameter();
@@ -51,9 +54,6 @@ public:
 
     FlattenDataCellParamPtr flatten_param{nullptr};
 };
-
-using IVFParameterPtr = std::shared_ptr<IVFParameter>;
-
 class IVFSearchParameters {
 public:
     static IVFSearchParameters

--- a/src/algorithm/pyramid_zparameters.h
+++ b/src/algorithm/pyramid_zparameters.h
@@ -23,11 +23,13 @@
 #include "data_cell/graph_interface.h"
 #include "impl/odescent_graph_parameter.h"
 #include "index/index_common_param.h"
+#include "pointer_define.h"
 #include "typing.h"
 #include "vsag/index.h"
 
 namespace vsag {
 
+DEFINE_POINTER2(PyramidParam, PyramidParameters);
 struct PyramidParameters : public Parameter {
 public:
     void
@@ -59,7 +61,4 @@ public:
 private:
     PyramidSearchParameters() = default;
 };
-
-using PyramidParamPtr = std::shared_ptr<PyramidParameters>;
-
 }  // namespace vsag

--- a/src/algorithm/sindi/sindi_parameter.h
+++ b/src/algorithm/sindi/sindi_parameter.h
@@ -17,6 +17,7 @@
 
 #include "index/index_common_param.h"
 #include "parameter.h"
+#include "pointer_define.h"
 
 namespace vsag {
 
@@ -27,7 +28,9 @@ static constexpr float DEFAULT_DOC_PRUNE_RATIO = 0.0F;
 static constexpr float DEFAULT_TERM_PRUNE_RATIO = 0.0F;
 static constexpr uint32_t DEFAULT_N_CANDIDATE = 0;
 
-struct SINDIParameter : public Parameter {
+DEFINE_POINTER(SINDIParameter);
+
+class SINDIParameter : public Parameter {
 public:
     void
     FromJson(const JsonType& json) override;
@@ -45,9 +48,7 @@ public:
     float doc_prune_ratio{0};
 };
 
-using SINDIParameterPtr = std::shared_ptr<SINDIParameter>;
-
-struct SINDISearchParameter : public Parameter {
+class SINDISearchParameter : public Parameter {
 public:
     void
     FromJson(const JsonType& json) override;

--- a/src/algorithm/sparse_index_parameters.h
+++ b/src/algorithm/sparse_index_parameters.h
@@ -17,8 +17,10 @@
 
 #include "index/index_common_param.h"
 #include "parameter.h"
+#include "pointer_define.h"
 
 namespace vsag {
+DEFINE_POINTER2(SparseIndexParameter, SparseIndexParameters);
 
 struct SparseIndexParameters : public Parameter {
 public:
@@ -33,7 +35,4 @@ public:
 public:
     bool need_sort{true};
 };
-
-using SparseIndexParameterPtr = std::shared_ptr<SparseIndexParameters>;
-
 }  // namespace vsag

--- a/src/attr/attr_value_map.h
+++ b/src/attr/attr_value_map.h
@@ -18,6 +18,7 @@
 
 #include "impl/allocator/safe_allocator.h"
 #include "multi_bitset_manager.h"
+#include "pointer_define.h"
 #include "storage/stream_reader.h"
 #include "storage/stream_writer.h"
 #include "typing.h"
@@ -26,8 +27,7 @@
 
 namespace vsag {
 
-class AttrValueMap;
-using ValueMapPtr = std::shared_ptr<AttrValueMap>;
+DEFINE_POINTER2(ValueMap, AttrValueMap);
 
 class AttrValueMap {
 public:

--- a/src/attr/executor/executor.h
+++ b/src/attr/executor/executor.h
@@ -18,10 +18,10 @@
 #include "data_cell/attribute_inverted_interface.h"
 #include "impl/bitset/computable_bitset.h"
 #include "impl/filter/filter_headers.h"
+#include "pointer_define.h"
 
 namespace vsag {
-class Executor;
-using ExecutorPtr = std::shared_ptr<Executor>;
+DEFINE_POINTER(Executor);
 
 class Executor {
 public:

--- a/src/data_cell/attribute_inverted_interface.h
+++ b/src/data_cell/attribute_inverted_interface.h
@@ -19,6 +19,7 @@
 
 #include "attr/attr_type_schema.h"
 #include "attr/multi_bitset_manager.h"
+#include "pointer_define.h"
 #include "storage/stream_reader.h"
 #include "storage/stream_writer.h"
 #include "typing.h"
@@ -26,9 +27,7 @@
 #include "vsag_exception.h"
 
 namespace vsag {
-class AttributeInvertedInterface;
-using AttrInvertedInterfacePtr = std::shared_ptr<AttributeInvertedInterface>;
-
+DEFINE_POINTER2(AttrInvertedInterface, AttributeInvertedInterface);
 class AttributeInvertedInterface {
 public:
     static AttrInvertedInterfacePtr

--- a/src/data_cell/bucket_interface.h
+++ b/src/data_cell/bucket_interface.h
@@ -19,14 +19,14 @@
 
 #include "bucket_datacell_parameter.h"
 #include "index/index_common_param.h"
+#include "pointer_define.h"
 #include "quantization/computer.h"
 #include "storage/stream_reader.h"
 #include "storage/stream_writer.h"
 #include "typing.h"
 
 namespace vsag {
-class BucketInterface;
-using BucketInterfacePtr = std::shared_ptr<BucketInterface>;
+DEFINE_POINTER(BucketInterface);
 
 class BucketInterface {
 public:

--- a/src/data_cell/compressed_graph_datacell_parameter.h
+++ b/src/data_cell/compressed_graph_datacell_parameter.h
@@ -17,8 +17,10 @@
 
 #include "graph_interface_parameter.h"
 #include "inner_string_params.h"
+#include "pointer_define.h"
 
 namespace vsag {
+DEFINE_POINTER2(CompressedGraphDatacellParam, CompressedGraphDatacellParameter);
 class CompressedGraphDatacellParameter : public GraphInterfaceParameter {
 public:
     CompressedGraphDatacellParameter()
@@ -40,6 +42,4 @@ public:
         return json;
     }
 };
-
-using CompressedGraphDatacellParamPtr = std::shared_ptr<CompressedGraphDatacellParameter>;
 }  // namespace vsag

--- a/src/data_cell/extra_info_datacell_parameter.h
+++ b/src/data_cell/extra_info_datacell_parameter.h
@@ -17,7 +17,10 @@
 
 #include "io/io_parameter.h"
 #include "parameter.h"
+#include "pointer_define.h"
+
 namespace vsag {
+DEFINE_POINTER2(ExtraInfoDataCellParam, ExtraInfoDataCellParameter);
 
 class ExtraInfoDataCellParameter : public Parameter {
 public:
@@ -35,7 +38,4 @@ public:
 public:
     IOParamPtr io_parameter{nullptr};
 };
-
-using ExtraInfoDataCellParamPtr = std::shared_ptr<ExtraInfoDataCellParameter>;
-
 }  // namespace vsag

--- a/src/data_cell/extra_info_interface.h
+++ b/src/data_cell/extra_info_interface.h
@@ -19,14 +19,14 @@
 
 #include "extra_info_datacell_parameter.h"
 #include "index/index_common_param.h"
+#include "pointer_define.h"
 #include "quantization/computer.h"
 #include "storage/stream_reader.h"
 #include "storage/stream_writer.h"
 #include "typing.h"
 
 namespace vsag {
-class ExtraInfoInterface;
-using ExtraInfoInterfacePtr = std::shared_ptr<ExtraInfoInterface>;
+DEFINE_POINTER(ExtraInfoInterface);
 
 class ExtraInfoInterface {
 public:

--- a/src/data_cell/flatten_datacell_parameter.h
+++ b/src/data_cell/flatten_datacell_parameter.h
@@ -18,8 +18,11 @@
 #include "flatten_interface_parameter.h"
 #include "io/io_parameter.h"
 #include "parameter.h"
+#include "pointer_define.h"
 #include "quantization/quantizer_parameter.h"
+
 namespace vsag {
+DEFINE_POINTER2(FlattenDataCellParam, FlattenDataCellParameter);
 
 class FlattenDataCellParameter : public FlattenInterfaceParameter {
 public:
@@ -34,7 +37,4 @@ public:
     bool
     CheckCompatibility(const vsag::ParamPtr& other) const override;
 };
-
-using FlattenDataCellParamPtr = std::shared_ptr<FlattenDataCellParameter>;
-
 }  // namespace vsag

--- a/src/data_cell/flatten_interface.h
+++ b/src/data_cell/flatten_interface.h
@@ -23,6 +23,7 @@
 #include "impl/runtime_parameter.h"
 #include "index/index_common_param.h"
 #include "io/reader_io.h"
+#include "pointer_define.h"
 #include "quantization/computer.h"
 #include "storage/stream_reader.h"
 #include "storage/stream_writer.h"
@@ -30,8 +31,7 @@
 #include "vsag/constants.h"
 
 namespace vsag {
-class FlattenInterface;
-using FlattenInterfacePtr = std::shared_ptr<FlattenInterface>;
+DEFINE_POINTER(FlattenInterface);
 
 class FlattenInterface {
 public:

--- a/src/data_cell/flatten_interface_parameter.h
+++ b/src/data_cell/flatten_interface_parameter.h
@@ -17,9 +17,11 @@
 
 #include "io/io_parameter.h"
 #include "parameter.h"
+#include "pointer_define.h"
 #include "quantization/quantizer_parameter.h"
 
 namespace vsag {
+DEFINE_POINTER2(FlattenInterfaceParam, FlattenInterfaceParameter);
 
 class FlattenInterfaceParameter : public Parameter {
 public:
@@ -32,7 +34,4 @@ public:
 
     std::string name;
 };
-
-using FlattenInterfaceParamPtr = std::shared_ptr<FlattenInterfaceParameter>;
-
 }  // namespace vsag

--- a/src/data_cell/graph_datacell_parameter.h
+++ b/src/data_cell/graph_datacell_parameter.h
@@ -17,8 +17,10 @@
 
 #include "graph_interface_parameter.h"
 #include "io/io_parameter.h"
+#include "pointer_define.h"
 
 namespace vsag {
+DEFINE_POINTER2(GraphDataCellParam, GraphDataCellParameter);
 class GraphDataCellParameter : public GraphInterfaceParameter {
 public:
     GraphDataCellParameter() : GraphInterfaceParameter(GraphStorageTypes::GRAPH_STORAGE_TYPE_FLAT) {
@@ -41,6 +43,4 @@ public:
     bool support_remove_{false};
     uint32_t remove_flag_bit_{8};
 };
-
-using GraphDataCellParamPtr = std::shared_ptr<GraphDataCellParameter>;
 }  // namespace vsag

--- a/src/data_cell/graph_interface.h
+++ b/src/data_cell/graph_interface.h
@@ -24,14 +24,13 @@
 #include "graph_interface_parameter.h"
 #include "index/index_common_param.h"
 #include "inner_string_params.h"
+#include "pointer_define.h"
 #include "storage/stream_reader.h"
 #include "storage/stream_writer.h"
 #include "typing.h"
 
 namespace vsag {
-
-class GraphInterface;
-using GraphInterfacePtr = std::shared_ptr<GraphInterface>;
+DEFINE_POINTER(GraphInterface);
 
 class GraphInterface {
 public:

--- a/src/data_cell/graph_interface_parameter.h
+++ b/src/data_cell/graph_interface_parameter.h
@@ -16,11 +16,9 @@
 #pragma once
 
 #include "parameter.h"
-
+#include "pointer_define.h"
 namespace vsag {
-
-class GraphInterfaceParameter;
-using GraphInterfaceParamPtr = std::shared_ptr<GraphInterfaceParameter>;
+DEFINE_POINTER2(GraphInterfaceParam, GraphInterfaceParameter);
 
 enum class GraphStorageTypes {
     GRAPH_STORAGE_TYPE_FLAT = 0,

--- a/src/data_cell/sparse_graph_datacell_parameter.h
+++ b/src/data_cell/sparse_graph_datacell_parameter.h
@@ -18,9 +18,11 @@
 #include "graph_interface_parameter.h"
 #include "inner_string_params.h"
 #include "logger.h"
+#include "pointer_define.h"
 #include "vsag/constants.h"
 
 namespace vsag {
+DEFINE_POINTER2(SparseGraphDatacellParam, SparseGraphDatacellParameter);
 class SparseGraphDatacellParameter : public GraphInterfaceParameter {
 public:
     SparseGraphDatacellParameter();
@@ -38,6 +40,4 @@ public:
     bool support_delete_{false};
     uint32_t remove_flag_bit_{8};
 };
-
-using SparseGraphDatacellParamPtr = std::shared_ptr<SparseGraphDatacellParameter>;
 }  // namespace vsag

--- a/src/data_cell/sparse_term_datacell.h
+++ b/src/data_cell/sparse_term_datacell.h
@@ -17,12 +17,14 @@
 
 #include "algorithm/sindi/sindi_parameter.h"
 #include "impl/basic_searcher.h"
+#include "pointer_define.h"
 #include "quantization/sparse_quantization//sparse_term_computer.h"
 #include "storage/stream_reader.h"
 #include "storage/stream_writer.h"
 #include "vsag/dataset.h"
 
 namespace vsag {
+DEFINE_POINTER(SparseTermDataCell);
 class SparseTermDataCell {
 public:
     SparseTermDataCell() = default;
@@ -75,7 +77,4 @@ public:
 
     Allocator* const allocator_{nullptr};
 };
-
-using SparseTermDataCellPtr = std::shared_ptr<SparseTermDataCell>;
-
 }  // namespace vsag

--- a/src/data_cell/sparse_vector_datacell_parameter.h
+++ b/src/data_cell/sparse_vector_datacell_parameter.h
@@ -19,9 +19,10 @@
 
 #include "flatten_interface.h"
 #include "inner_string_params.h"
+#include "pointer_define.h"
 
 namespace vsag {
-
+DEFINE_POINTER2(SparseVectorDataCellParam, SparseVectorDataCellParameter);
 class SparseVectorDataCellParameter : public FlattenInterfaceParameter {
 public:
     explicit SparseVectorDataCellParameter() : FlattenInterfaceParameter(SPARSE_VECTOR_DATA_CELL) {
@@ -62,7 +63,4 @@ public:
         return this->quantizer_parameter->CheckCompatibility(sparse_param->quantizer_parameter);
     }
 };
-
-using SparseVectorDataCellParamPtr = std::shared_ptr<SparseVectorDataCellParameter>;
-
 }  // namespace vsag

--- a/src/impl/basic_searcher.h
+++ b/src/impl/basic_searcher.h
@@ -23,6 +23,7 @@
 #include "index/iterator_filter.h"
 #include "inner_search_param.h"
 #include "lock_strategy.h"
+#include "pointer_define.h"
 #include "utils/timer.h"
 #include "utils/visited_list.h"
 
@@ -31,7 +32,7 @@ namespace vsag {
 static constexpr uint32_t OPTIMIZE_SEARCHER_SAMPLE_SIZE = 10000;
 
 constexpr float THRESHOLD_ERROR = 2e-6;
-
+DEFINE_POINTER(BasicSearcher);
 class BasicSearcher {
 public:
     explicit BasicSearcher(const IndexCommonParam& common_param,
@@ -117,7 +118,4 @@ private:
     // runtime parameters
     uint32_t prefetch_stride_visit_{3};
 };
-
-using BasicSearcherPtr = std::shared_ptr<BasicSearcher>;
-
 }  // namespace vsag

--- a/src/impl/bitset/computable_bitset.h
+++ b/src/impl/bitset/computable_bitset.h
@@ -15,13 +15,12 @@
 
 #pragma once
 
+#include "pointer_define.h"
 #include "storage/stream_reader.h"
 #include "storage/stream_writer.h"
 #include "vsag/bitset.h"
-
 namespace vsag {
-class ComputableBitset;
-using ComputableBitsetPtr = std::shared_ptr<ComputableBitset>;
+DEFINE_POINTER(ComputableBitset);
 
 enum class ComputableBitsetType { SparseBitset, FastBitset };
 

--- a/src/impl/bitset/fast_bitset.h
+++ b/src/impl/bitset/fast_bitset.h
@@ -18,10 +18,13 @@
 #include <shared_mutex>
 
 #include "computable_bitset.h"
+#include "pointer_define.h"
 #include "typing.h"
 #include "vsag/allocator.h"
 
 namespace vsag {
+
+DEFINE_POINTER(FastBitset);
 class FastBitset : public ComputableBitset {
 public:
     explicit FastBitset(Allocator* allocator)
@@ -110,5 +113,4 @@ private:
     uint32_t capacity_{0};
 };
 
-using FastBitsetPtr = std::shared_ptr<FastBitset>;
 }  // namespace vsag

--- a/src/impl/heap/distance_heap.h
+++ b/src/impl/heap/distance_heap.h
@@ -18,12 +18,13 @@
 #include <type_traits>
 #include <utility>
 
+#include "pointer_define.h"
 #include "typing.h"
 #include "vsag/allocator.h"
 
 namespace vsag {
-class DistanceHeap;
-using DistHeapPtr = std::shared_ptr<DistanceHeap>;
+
+DEFINE_POINTER2(DistHeap, DistanceHeap);
 
 class DistanceHeap {
 public:
@@ -86,7 +87,4 @@ protected:
     Allocator* allocator_{nullptr};
     int64_t max_size_{-1};
 };
-
-using DistHeapPtr = std::shared_ptr<DistanceHeap>;
-
 }  // namespace vsag

--- a/src/impl/inner_search_param.h
+++ b/src/impl/inner_search_param.h
@@ -15,12 +15,14 @@
 
 #pragma once
 
-#include "attr/executor/executor.h"
+#include "pointer_define.h"
 #include "typing.h"
 #include "utils/timer.h"
-#include "vsag/filter.h"
 
 namespace vsag {
+
+DEFINE_POINTER(Filter);
+DEFINE_POINTER(Executor);
 
 enum InnerSearchMode { KNN_SEARCH = 1, RANGE_SEARCH = 2 };
 
@@ -29,7 +31,7 @@ enum InnerSearchType { PURE = 1, WITH_FILTER = 2 };
 class InnerSearchParam {
 public:
     int64_t topk{0};
-    float radius{0.0f};
+    float radius{0.0F};
     InnerIdType ep{0};
     uint64_t ef{10};
     FilterPtr is_inner_id_allowed{nullptr};

--- a/src/impl/odescent_graph_parameter.h
+++ b/src/impl/odescent_graph_parameter.h
@@ -16,10 +16,10 @@
 #pragma once
 
 #include "parameter.h"
-
+#include "pointer_define.h"
 namespace vsag {
-
-struct ODescentParameter : public Parameter {
+DEFINE_POINTER(ODescentParameter);
+class ODescentParameter : public Parameter {
 public:
     ODescentParameter() = default;
 
@@ -37,7 +37,4 @@ public:
     int64_t max_degree{32};
     int64_t block_size{10000};
 };
-
-using ODescentParameterPtr = std::shared_ptr<ODescentParameter>;
-
 }  // namespace vsag

--- a/src/impl/transform/vector_transformer.h
+++ b/src/impl/transform/vector_transformer.h
@@ -16,14 +16,15 @@
 
 #pragma once
 
+#include "pointer_define.h"
 #include "storage/stream_reader.h"
 #include "storage/stream_writer.h"
 #include "vsag/allocator.h"
 
 namespace vsag {
 
-class VectorTransformer;
-using VectorTransformerPtr = std::shared_ptr<VectorTransformer>;
+DEFINE_POINTER(VectorTransformer);
+DEFINE_POINTER(TransformerMeta);
 
 enum class VectorTransformerType { NONE, PCA, RANDOM_ORTHOGONAL, FHT, RESIDUAL, NORMALIZE };
 
@@ -38,9 +39,6 @@ struct TransformerMeta {
         return;
     };
 };
-
-using TransformerMetaPtr = std::shared_ptr<TransformerMeta>;
-
 class VectorTransformer {
 public:
     explicit VectorTransformer(Allocator* allocator, int64_t input_dim, int64_t output_dim);

--- a/src/index_feature_list.h
+++ b/src/index_feature_list.h
@@ -19,9 +19,13 @@
 #include <memory>
 #include <vector>
 
+#include "pointer_define.h"
 #include "vsag/index_features.h"
 
 namespace vsag {
+
+DEFINE_POINTER(IndexFeatureList);
+
 class IndexFeatureList {
 public:
     explicit IndexFeatureList();
@@ -40,7 +44,4 @@ private:
 
     const uint32_t feature_count_{0};
 };
-
-using IndexFeatureListPtr = std::shared_ptr<IndexFeatureList>;
-
 }  // namespace vsag

--- a/src/io/async_io_parameter.h
+++ b/src/io/async_io_parameter.h
@@ -16,8 +16,10 @@
 #pragma once
 
 #include "io_parameter.h"
+#include "pointer_define.h"
 
 namespace vsag {
+DEFINE_POINTER(AsyncIOParameter);
 class AsyncIOParameter : public IOParameter {
 public:
     AsyncIOParameter();
@@ -33,7 +35,4 @@ public:
 public:
     std::string path_{};
 };
-
-using AsyncIOParameterPtr = std::shared_ptr<AsyncIOParameter>;
-
 }  // namespace vsag

--- a/src/io/buffer_io_parameter.h
+++ b/src/io/buffer_io_parameter.h
@@ -16,8 +16,9 @@
 #pragma once
 
 #include "io_parameter.h"
-
+#include "pointer_define.h"
 namespace vsag {
+DEFINE_POINTER(BufferIOParameter);
 class BufferIOParameter : public IOParameter {
 public:
     BufferIOParameter();
@@ -33,7 +34,5 @@ public:
 public:
     std::string path_{};
 };
-
-using BufferIOParameterPtr = std::shared_ptr<BufferIOParameter>;
 
 }  // namespace vsag

--- a/src/io/io_parameter.h
+++ b/src/io/io_parameter.h
@@ -16,11 +16,10 @@
 #pragma once
 
 #include "parameter.h"
+#include "pointer_define.h"
 
 namespace vsag {
-
-class IOParameter;
-using IOParamPtr = std::shared_ptr<IOParameter>;
+DEFINE_POINTER2(IOParam, IOParameter);
 
 class IOParameter : public Parameter {
 public:

--- a/src/io/memory_block_io_parameter.h
+++ b/src/io/memory_block_io_parameter.h
@@ -16,8 +16,11 @@
 #pragma once
 
 #include "io_parameter.h"
+#include "pointer_define.h"
 
 namespace vsag {
+DEFINE_POINTER2(MemoryBlockIOParam, MemoryBlockIOParameter);
+
 class MemoryBlockIOParameter : public IOParameter {
 public:
     MemoryBlockIOParameter();
@@ -36,7 +39,4 @@ public:
 public:
     uint64_t block_size_{};
 };
-
-using MemoryBlockIOParamPtr = std::shared_ptr<MemoryBlockIOParameter>;
-
 }  // namespace vsag

--- a/src/io/memory_io_parameter.h
+++ b/src/io/memory_io_parameter.h
@@ -16,8 +16,11 @@
 #pragma once
 
 #include "io_parameter.h"
+#include "pointer_define.h"
 
 namespace vsag {
+DEFINE_POINTER2(MemoryIOParam, MemoryIOParameter);
+
 class MemoryIOParameter : public IOParameter {
 public:
     MemoryIOParameter();
@@ -30,7 +33,4 @@ public:
     JsonType
     ToJson() const override;
 };
-
-using MemoryIOParamPtr = std::shared_ptr<MemoryIOParameter>;
-
 }  // namespace vsag

--- a/src/io/mmap_io.cpp
+++ b/src/io/mmap_io.cpp
@@ -42,7 +42,7 @@ MMapIO::MMapIO(std::string filename, Allocator* allocator)
     this->start_ = static_cast<uint8_t*>(addr);
 }
 
-MMapIO::MMapIO(const MMapIOParameterPtr& io_param, const IndexCommonParam& common_param)
+MMapIO::MMapIO(const MMapIOParamPtr& io_param, const IndexCommonParam& common_param)
     : MMapIO(io_param->path_, common_param.allocator_.get()){};
 
 MMapIO::MMapIO(const IOParamPtr& param, const IndexCommonParam& common_param)

--- a/src/io/mmap_io.h
+++ b/src/io/mmap_io.h
@@ -33,7 +33,7 @@ public:
 public:
     MMapIO(std::string filename, Allocator* allocator);
 
-    explicit MMapIO(const MMapIOParameterPtr& io_param, const IndexCommonParam& common_param);
+    explicit MMapIO(const MMapIOParamPtr& io_param, const IndexCommonParam& common_param);
 
     explicit MMapIO(const IOParamPtr& param, const IndexCommonParam& common_param);
 

--- a/src/io/mmap_io_parameter.h
+++ b/src/io/mmap_io_parameter.h
@@ -16,8 +16,10 @@
 #pragma once
 
 #include "io_parameter.h"
-
+#include "pointer_define.h"
 namespace vsag {
+DEFINE_POINTER2(MMapIOParam, MMapIOParameter);
+
 class MMapIOParameter : public IOParameter {
 public:
     MMapIOParameter();
@@ -35,7 +37,4 @@ public:
 public:
     std::string path_{};
 };
-
-using MMapIOParameterPtr = std::shared_ptr<MMapIOParameter>;
-
 }  // namespace vsag

--- a/src/io/reader_io_parameter.h
+++ b/src/io/reader_io_parameter.h
@@ -17,9 +17,10 @@
 
 #include "inner_string_params.h"
 #include "io_parameter.h"
+#include "pointer_define.h"
 #include "vsag/readerset.h"
-
 namespace vsag {
+DEFINE_POINTER2(ReaderIOParam, ReaderIOParameter);
 /**
  * @brief ReaderIOParameter is a class that represents the parameters for a reader in the vsag project.
  * It inherits from IOParameter and is used to define the specific parameters required for reading operations.
@@ -40,7 +41,4 @@ public:
 
     std::shared_ptr<Reader> reader;
 };
-
-using ReaderIOParamPtr = std::shared_ptr<ReaderIOParameter>;
-
 }  // namespace vsag

--- a/src/label_table.h
+++ b/src/label_table.h
@@ -19,14 +19,15 @@
 
 #include <atomic>
 
+#include "pointer_define.h"
 #include "storage/stream_reader.h"
 #include "storage/stream_writer.h"
 #include "typing.h"
 
 namespace vsag {
 
-class LabelTable;
-using LabelTablePtr = std::shared_ptr<LabelTable>;
+DEFINE_POINTER(LabelTable);
+
 using IdMapFunction = std::function<std::tuple<bool, int64_t>(int64_t)>;
 
 struct DuplicateRecord {

--- a/src/lock_strategy.h
+++ b/src/lock_strategy.h
@@ -17,9 +17,11 @@
 
 #include <shared_mutex>
 
+#include "pointer_define.h"
 #include "typing.h"
 
 namespace vsag {
+DEFINE_POINTER(MutexArray);
 
 class MutexArray {
 public:
@@ -38,8 +40,6 @@ public:
     virtual void
     Resize(uint32_t new_element_num) = 0;
 };
-
-using MutexArrayPtr = std::shared_ptr<MutexArray>;
 
 class PointsMutex : public MutexArray {
 public:

--- a/src/parameter.h
+++ b/src/parameter.h
@@ -16,12 +16,11 @@
 #pragma once
 
 #include "common.h"
+#include "pointer_define.h"
 #include "typing.h"
-
 namespace vsag {
 
-class Parameter;
-using ParamPtr = std::shared_ptr<Parameter>;
+DEFINE_POINTER2(Param, Parameter);
 
 class Parameter {
 public:

--- a/src/pointer_define.h
+++ b/src/pointer_define.h
@@ -1,0 +1,33 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace vsag {
+
+#define DEFINE_POINTER(class_name)                                  \
+    class class_name;                                               \
+    using class_name##Ptr = std::shared_ptr<class_name>;            \
+    using class_name##UPtr = std::unique_ptr<class_name>;           \
+    using class_name##ConstPtr = std::shared_ptr<const class_name>; \
+    using class_name##ConstUPtr = std::unique_ptr<const class_name>;
+
+#define DEFINE_POINTER2(pointer_name, class_name)                     \
+    class class_name;                                                 \
+    using pointer_name##Ptr = std::shared_ptr<class_name>;            \
+    using pointer_name##UPtr = std::unique_ptr<class_name>;           \
+    using pointer_name##ConstPtr = std::shared_ptr<const class_name>; \
+    using pointer_name##ConstUPtr = std::unique_ptr<const class_name>;
+}  // namespace vsag

--- a/src/quantization/computer.h
+++ b/src/quantization/computer.h
@@ -19,9 +19,10 @@
 #include <memory>
 
 #include "metric_type.h"
+#include "pointer_define.h"
 #include "vsag/allocator.h"
-
 namespace vsag {
+DEFINE_POINTER(ComputerInterface);
 
 using DataType = float;
 
@@ -31,8 +32,6 @@ public:
 
     virtual ~ComputerInterface() = default;
 };
-
-using ComputerInterfacePtr = std::shared_ptr<ComputerInterface>;
 
 template <typename T>
 class Computer : public ComputerInterface {

--- a/src/quantization/fp32_quantizer_parameter.h
+++ b/src/quantization/fp32_quantizer_parameter.h
@@ -15,9 +15,10 @@
 
 #pragma once
 
+#include "pointer_define.h"
 #include "quantizer_parameter.h"
-
 namespace vsag {
+DEFINE_POINTER2(FP32QuantizerParam, FP32QuantizerParameter);
 class FP32QuantizerParameter : public QuantizerParameter {
 public:
     FP32QuantizerParameter();
@@ -33,6 +34,4 @@ public:
 public:
     bool hold_molds{false};
 };
-
-using FP32QuantizerParamPtr = std::shared_ptr<FP32QuantizerParameter>;
 }  // namespace vsag

--- a/src/quantization/product_quantization/pq_fastscan_quantizer_parameter.h
+++ b/src/quantization/product_quantization/pq_fastscan_quantizer_parameter.h
@@ -15,9 +15,10 @@
 
 #pragma once
 
+#include "pointer_define.h"
 #include "quantization/quantizer_parameter.h"
-
 namespace vsag {
+DEFINE_POINTER2(PQFastScanQuantizerParam, PQFastScanQuantizerParameter);
 class PQFastScanQuantizerParameter : public QuantizerParameter {
 public:
     PQFastScanQuantizerParameter();
@@ -36,7 +37,4 @@ public:
 public:
     int64_t pq_dim_{1};
 };
-
-using PQFastScanQuantizerParamPtr = std::shared_ptr<PQFastScanQuantizerParameter>;
-
 }  // namespace vsag

--- a/src/quantization/product_quantization/product_quantizer_parameter.h
+++ b/src/quantization/product_quantization/product_quantizer_parameter.h
@@ -15,9 +15,10 @@
 
 #pragma once
 
+#include "pointer_define.h"
 #include "quantization/quantizer_parameter.h"
-
 namespace vsag {
+DEFINE_POINTER2(ProductQuantizerParam, ProductQuantizerParameter);
 class ProductQuantizerParameter : public QuantizerParameter {
 public:
     ProductQuantizerParameter();
@@ -37,7 +38,4 @@ public:
     int64_t pq_dim_{1};
     int64_t pq_bits_{8};
 };
-
-using ProductQuantizerParamPtr = std::shared_ptr<ProductQuantizerParameter>;
-
 }  // namespace vsag

--- a/src/quantization/quantizer_parameter.h
+++ b/src/quantization/quantizer_parameter.h
@@ -16,11 +16,9 @@
 #pragma once
 
 #include "parameter.h"
-
+#include "pointer_define.h"
 namespace vsag {
-
-class QuantizerParameter;
-using QuantizerParamPtr = std::shared_ptr<QuantizerParameter>;
+DEFINE_POINTER2(QuantizerParam, QuantizerParameter);
 
 class QuantizerParameter : public Parameter {
 public:

--- a/src/quantization/rabitq_quantization/rabitq_quantizer_parameter.h
+++ b/src/quantization/rabitq_quantization/rabitq_quantizer_parameter.h
@@ -15,9 +15,10 @@
 
 #pragma once
 
+#include "pointer_define.h"
 #include "quantization/quantizer_parameter.h"
-
 namespace vsag {
+DEFINE_POINTER2(RaBitQuantizerParam, RaBitQuantizerParameter);
 class RaBitQuantizerParameter : public QuantizerParameter {
 public:
     RaBitQuantizerParameter();
@@ -38,7 +39,4 @@ public:
     uint64_t num_bits_per_dim_query_{32};
     bool use_fht_{false};
 };
-
-using RaBitQuantizerParamPtr = std::shared_ptr<RaBitQuantizerParameter>;
-
 }  // namespace vsag

--- a/src/quantization/scalar_quantization/bf16_quantizer_parameter.h
+++ b/src/quantization/scalar_quantization/bf16_quantizer_parameter.h
@@ -15,9 +15,10 @@
 
 #pragma once
 
+#include "pointer_define.h"
 #include "quantization/quantizer_parameter.h"
-
 namespace vsag {
+DEFINE_POINTER2(BF16QuantizerParam, BF16QuantizerParameter);
 class BF16QuantizerParameter : public QuantizerParameter {
 public:
     BF16QuantizerParameter();
@@ -32,7 +33,4 @@ public:
 
 public:
 };
-
-using BF16QuantizerParamPtr = std::shared_ptr<BF16QuantizerParameter>;
-
 }  // namespace vsag

--- a/src/quantization/scalar_quantization/fp16_quantizer_parameter.h
+++ b/src/quantization/scalar_quantization/fp16_quantizer_parameter.h
@@ -15,9 +15,10 @@
 
 #pragma once
 
+#include "pointer_define.h"
 #include "quantization/quantizer_parameter.h"
-
 namespace vsag {
+DEFINE_POINTER2(FP16QuantizerParam, FP16QuantizerParameter);
 class FP16QuantizerParameter : public QuantizerParameter {
 public:
     FP16QuantizerParameter();
@@ -32,7 +33,4 @@ public:
 
 public:
 };
-
-using FP16QuantizerParamPtr = std::shared_ptr<FP16QuantizerParameter>;
-
 }  // namespace vsag

--- a/src/quantization/scalar_quantization/sq4_quantizer_parameter.h
+++ b/src/quantization/scalar_quantization/sq4_quantizer_parameter.h
@@ -15,9 +15,11 @@
 
 #pragma once
 
+#include "pointer_define.h"
 #include "quantization/quantizer_parameter.h"
 
 namespace vsag {
+DEFINE_POINTER2(SQ4QuantizerParam, SQ4QuantizerParameter)
 class SQ4QuantizerParameter : public QuantizerParameter {
 public:
     SQ4QuantizerParameter();
@@ -32,7 +34,4 @@ public:
 
 public:
 };
-
-using SQ4QuantizerParamPtr = std::shared_ptr<SQ4QuantizerParameter>;
-
 }  // namespace vsag

--- a/src/quantization/scalar_quantization/sq4_uniform_quantizer_parameter.h
+++ b/src/quantization/scalar_quantization/sq4_uniform_quantizer_parameter.h
@@ -15,9 +15,11 @@
 
 #pragma once
 
+#include "pointer_define.h"
 #include "quantization/quantizer_parameter.h"
 
 namespace vsag {
+DEFINE_POINTER2(SQ4UniformQuantizerParam, SQ4UniformQuantizerParameter)
 class SQ4UniformQuantizerParameter : public QuantizerParameter {
 public:
     SQ4UniformQuantizerParameter();
@@ -36,6 +38,4 @@ public:
 public:
     float trunc_rate_{0.05F};
 };
-
-using SQ4UniformQuantizerParamPtr = std::shared_ptr<SQ4UniformQuantizerParameter>;
 }  // namespace vsag

--- a/src/quantization/scalar_quantization/sq8_quantizer_parameter.h
+++ b/src/quantization/scalar_quantization/sq8_quantizer_parameter.h
@@ -15,9 +15,10 @@
 
 #pragma once
 
+#include "pointer_define.h"
 #include "quantization/quantizer_parameter.h"
-
 namespace vsag {
+DEFINE_POINTER2(SQ8QuantizerParam, SQ8QuantizerParameter)
 class SQ8QuantizerParameter : public QuantizerParameter {
 public:
     SQ8QuantizerParameter();
@@ -32,6 +33,4 @@ public:
 
 public:
 };
-
-using SQ8QuantizerParamPtr = std::shared_ptr<SQ8QuantizerParameter>;
 }  // namespace vsag

--- a/src/quantization/scalar_quantization/sq8_uniform_quantizer_parameter.h
+++ b/src/quantization/scalar_quantization/sq8_uniform_quantizer_parameter.h
@@ -15,9 +15,10 @@
 
 #pragma once
 
+#include "pointer_define.h"
 #include "quantization/quantizer_parameter.h"
-
 namespace vsag {
+DEFINE_POINTER2(SQ8UniformQuantizerParam, SQ8UniformQuantizerParameter)
 class SQ8UniformQuantizerParameter : public QuantizerParameter {
 public:
     SQ8UniformQuantizerParameter();
@@ -29,9 +30,5 @@ public:
 
     JsonType
     ToJson() const override;
-
-public:
 };
-
-using SQ8UniformQuantizerParamPtr = std::shared_ptr<SQ8UniformQuantizerParameter>;
 }  // namespace vsag

--- a/src/quantization/sparse_quantization/sparse_quantizer_parameter.h
+++ b/src/quantization/sparse_quantization/sparse_quantizer_parameter.h
@@ -15,10 +15,12 @@
 
 #pragma once
 
+#include "pointer_define.h"
 #include "quantization/quantizer_parameter.h"
 #include "typing.h"
-
 namespace vsag {
+DEFINE_POINTER2(SparseQuantizerParam, SparseQuantizerParameter);
+
 class SparseQuantizerParameter : public QuantizerParameter {
 public:
     SparseQuantizerParameter() : QuantizerParameter(QUANTIZATION_TYPE_VALUE_SPARSE) {
@@ -37,6 +39,4 @@ public:
         return json;
     }
 };
-
-using SparseQuantizerParamPtr = std::shared_ptr<SparseQuantizerParameter>;
 }  // namespace vsag

--- a/src/quantization/sparse_quantization/sparse_term_computer.h
+++ b/src/quantization/sparse_quantization/sparse_term_computer.h
@@ -20,12 +20,12 @@
 
 #include "algorithm/sindi/sindi_parameter.h"
 #include "metric_type.h"
+#include "pointer_define.h"
 #include "utils/sparse_vector_transform.h"
-
 namespace vsag {
 
 static constexpr int INVALID_TERM = -1;
-
+DEFINE_POINTER(SparseTermComputer)
 class SparseTermComputer {
 public:
     ~SparseTermComputer() = default;
@@ -120,7 +120,4 @@ public:
 
     Allocator* const allocator_{nullptr};
 };
-
-using SparseTermComputerPtr = std::shared_ptr<SparseTermComputer>;
-
 }  // namespace vsag

--- a/src/quantization/transform_quantization/transform_quantizer_parameter.h
+++ b/src/quantization/transform_quantization/transform_quantizer_parameter.h
@@ -15,9 +15,10 @@
 
 #pragma once
 
+#include "pointer_define.h"
 #include "quantization/quantizer_parameter.h"
-
 namespace vsag {
+DEFINE_POINTER2(TransformQuantizerParam, TransformQuantizerParameter)
 class TransformQuantizerParameter : public QuantizerParameter {
 public:
     TransformQuantizerParameter();
@@ -43,7 +44,4 @@ public:
     std::vector<std::string> tq_chain_;
     JsonType base_quantizer_json_;  // store param of base quantizer
 };
-
-using TransformQuantizerParamPtr = std::shared_ptr<TransformQuantizerParameter>;
-
 }  // namespace vsag

--- a/src/quantization/transform_quantization/transform_quantizer_test.cpp
+++ b/src/quantization/transform_quantization/transform_quantizer_test.cpp
@@ -32,7 +32,7 @@ template <MetricType metric>
 void
 TestComputeMetricTQ(std::string tq_chain, uint64_t dim, int count, float error = 1e-5) {
     auto allocator = SafeAllocator::FactoryDefaultAllocator();
-    TransformQuantizerParamPtr param = std::make_shared<TransformQuantizerParameter>();
+    auto param = std::make_shared<TransformQuantizerParameter>();
     constexpr static const char* param_template = R"(
         {{
             "tq_chain": "{}",

--- a/src/safe_thread_pool.h
+++ b/src/safe_thread_pool.h
@@ -17,8 +17,9 @@
 
 #include "default_thread_pool.h"
 #include "logger.h"
-
+#include "pointer_define.h"
 namespace vsag {
+DEFINE_POINTER(SafeThreadPool);
 
 class SafeThreadPool : public ThreadPool {
 public:
@@ -85,7 +86,5 @@ private:
     std::shared_ptr<ThreadPool> pool_ptr_{nullptr};
     bool owner_{false};
 };
-
-using SafeThreadPoolPtr = std::shared_ptr<SafeThreadPool>;
 
 }  // namespace vsag

--- a/src/storage/serialization.h
+++ b/src/storage/serialization.h
@@ -24,6 +24,7 @@
 
 #include "../logger.h"
 #include "../typing.h"
+#include "pointer_define.h"
 #include "stream_reader.h"
 #include "stream_writer.h"
 #include "utils/function_exists_check.h"
@@ -33,8 +34,7 @@
 namespace vsag {
 
 // Metadata is using to describe how is the index create
-class Metadata;
-using MetadataPtr = std::shared_ptr<Metadata>;
+DEFINE_POINTER(Metadata);
 class Metadata {
 public:
     [[nodiscard]] JsonType
@@ -118,8 +118,7 @@ private:
 };
 
 // Footer is a wrapper of metadata, only used in all-in-one serialize format
-class Footer;
-using FooterPtr = std::shared_ptr<Footer>;
+DEFINE_POINTER(Footer);
 class Footer {
 public:
     static FooterPtr
@@ -168,5 +167,3 @@ private:
 };
 
 };  // namespace vsag
-
-// namespace vsag

--- a/src/utils/visited_list.h
+++ b/src/utils/visited_list.h
@@ -16,6 +16,7 @@
 #pragma once
 #include <cstring>
 
+#include "pointer_define.h"
 #include "prefetch.h"
 #include "resource_object.h"
 #include "resource_object_pool.h"
@@ -24,6 +25,7 @@
 
 namespace vsag {
 
+DEFINE_POINTER(VisitedList);
 class VisitedList : public ResourceObject {
 public:
     using VisitedListType = uint16_t;
@@ -61,6 +63,4 @@ private:
 };
 
 using VisitedListPool = ResourceObjectPool<VisitedList>;
-using VisitedListPtr = std::shared_ptr<VisitedList>;
-
 }  // namespace vsag


### PR DESCRIPTION
## Summary by Sourcery

Introduce a centralized pointer alias system and refactor existing pointer type declarations

Enhancements:
- Add pointer_define.h defining macros for shared_ptr and unique_ptr aliases
- Replace manual shared_ptr/unique_ptr using declarations with DEFINE_POINTER/DEFINE_POINTER2 macros throughout the codebase
- Update header includes to pull in pointer_define.h and remove redundant alias definitions
- Adjust source files to use the new pointer alias names consistently
- Apply minor formatting tweaks such as float literal suffix corrections