### PR TITLE
feat(ivf): support calculate distance by id for IVF

### DIFF
--- a/src/algorithm/ivf.cpp
+++ b/src/algorithm/ivf.cpp
@@ -321,7 +321,6 @@ IVF::Build(const DatasetPtr& base) {
     this->Train(base);
     // TODO(LHT): duplicate
     auto result = this->Add(base);
-    this->fill_location_map();
     return result;
 }
 
@@ -410,7 +409,7 @@ IVF::Add(const DatasetPtr& base) {
                 offset_id = bucket_->InsertVector(
                     data_ptr, buckets[idx], idx + current_num * buckets_per_data_);
             }
-            {
+            if (j == 0) {
                 std::lock_guard lock(label_lookup_mutex_);
                 location_map_[i + current_num] =
                     (static_cast<uint64_t>(buckets[idx]) << LOCATION_SPLIT_BIT) |
@@ -965,7 +964,7 @@ IVF::fill_location_map() {
             if (ids[j] >= this->total_elements_ * buckets_per_data_) {
                 throw VsagException(ErrorType::INTERNAL_ERROR, "invalid inner_id");
             }
-            this->location_map_[ids[j]] =
+            this->location_map_[ids[j] / buckets_per_data_] =
                 (static_cast<uint64_t>(i) << LOCATION_SPLIT_BIT) | static_cast<uint64_t>(j);
         }
     }

--- a/src/algorithm/ivf.cpp
+++ b/src/algorithm/ivf.cpp
@@ -506,6 +506,7 @@ IVF::Merge(const std::vector<MergeUnit>& merge_units) {
     for (const auto& unit : merge_units) {
         this->merge_one_unit(unit);
     }
+    this->fill_location_map();
     this->bucket_->Package();
 }
 

--- a/src/algorithm/ivf.cpp
+++ b/src/algorithm/ivf.cpp
@@ -303,6 +303,7 @@ IVF::InitFeatures() {
         IndexFeature::SUPPORT_CLONE,
         IndexFeature::SUPPORT_EXPORT_MODEL,
         IndexFeature::SUPPORT_MERGE_INDEX,
+        IndexFeature::SUPPORT_CAL_DISTANCE_BY_ID
     });
 
     if (this->bucket_->GetQuantizerName() == QUANTIZATION_TYPE_VALUE_PQFS) {

--- a/src/algorithm/ivf.h
+++ b/src/algorithm/ivf.h
@@ -123,6 +123,30 @@ public:
                     const AttributeSet& new_attrs,
                     const AttributeSet& origin_attrs) override;
 
+<<<<<<< HEAD
+=======
+    void
+    Serialize(StreamWriter& writer) const override;
+
+    void
+    Deserialize(StreamReader& reader) override;
+
+    int64_t
+    GetNumElements() const override;
+
+    [[nodiscard]] DatasetPtr
+    GetDataByIds(const int64_t* ids, int64_t count) const override;
+
+    void
+    GetCodeByInnerId(InnerIdType inner_id, uint8_t* data) const override;
+
+    DatasetPtr
+    CalDistanceById(const float* query, const int64_t* ids, int64_t count) const override;
+
+    float
+    CalcDistanceById(const float* query, int64_t id) const override;
+
+>>>>>>> modify
 private:
     InnerSearchParam
     create_search_param(const std::string& parameters, const FilterPtr& filter) const;

--- a/src/algorithm/ivf.h
+++ b/src/algorithm/ivf.h
@@ -52,10 +52,11 @@ public:
     std::vector<int64_t>
     Build(const DatasetPtr& base) override;
 
-
     DatasetPtr
     CalDistanceById(const float* query, const int64_t* ids, int64_t count) const override;
 
+    float
+    CalcDistanceById(const float* query, int64_t id) const override;
 
     void
     Deserialize(StreamReader& reader) override;
@@ -123,30 +124,6 @@ public:
                     const AttributeSet& new_attrs,
                     const AttributeSet& origin_attrs) override;
 
-<<<<<<< HEAD
-=======
-    void
-    Serialize(StreamWriter& writer) const override;
-
-    void
-    Deserialize(StreamReader& reader) override;
-
-    int64_t
-    GetNumElements() const override;
-
-    [[nodiscard]] DatasetPtr
-    GetDataByIds(const int64_t* ids, int64_t count) const override;
-
-    void
-    GetCodeByInnerId(InnerIdType inner_id, uint8_t* data) const override;
-
-    DatasetPtr
-    CalDistanceById(const float* query, const int64_t* ids, int64_t count) const override;
-
-    float
-    CalcDistanceById(const float* query, int64_t id) const override;
-
->>>>>>> modify
 private:
     InnerSearchParam
     create_search_param(const std::string& parameters, const FilterPtr& filter) const;

--- a/src/algorithm/ivf.h
+++ b/src/algorithm/ivf.h
@@ -52,6 +52,11 @@ public:
     std::vector<int64_t>
     Build(const DatasetPtr& base) override;
 
+
+    DatasetPtr
+    CalDistanceById(const float* query, const int64_t* ids, int64_t count) const override;
+
+
     void
     Deserialize(StreamReader& reader) override;
 

--- a/src/data_cell/bucket_datacell.h
+++ b/src/data_cell/bucket_datacell.h
@@ -207,6 +207,9 @@ BucketDataCell<QuantTmpl, IOTmpl>::query_one_by_id(
     if (need_release) {
         this->datas_[bucket_id]->Release(codes);
     }
+    if (use_residual_ && this->quantizer_->Metric() == MetricType::METRIC_TYPE_L2SQR) {
+        ret -= residual_bias_[bucket_id][offset_id];
+    }
     return ret;
 }
 

--- a/tests/test_index.cpp
+++ b/tests/test_index.cpp
@@ -479,7 +479,7 @@ TestIndex::TestRangeSearch(const IndexPtr& index,
         auto result = res.value()->GetIds();
         auto gt = gts->GetIds() + gt_topK * i;
         auto val = Intersection(gt, gt_topK - 1, result, res.value()->GetDim());
-        cur_recall += static_cast<float>(val) / static_cast<float>(gt_topK - 1);
+        cur_recall += static_cast<float>(val) / static_cast<float>(res.value()->GetDim());
     }
     if (cur_recall <= expected_recall * query_count) {
         WARN(fmt::format("cur_result({}) <= expected_recall * query_count({})",

--- a/tests/test_index.cpp
+++ b/tests/test_index.cpp
@@ -479,7 +479,8 @@ TestIndex::TestRangeSearch(const IndexPtr& index,
         auto result = res.value()->GetIds();
         auto gt = gts->GetIds() + gt_topK * i;
         auto val = Intersection(gt, gt_topK - 1, result, res.value()->GetDim());
-        cur_recall += static_cast<float>(val) / static_cast<float>(res.value()->GetDim());
+        cur_recall += static_cast<float>(val) /
+                      static_cast<float>(std::min(gt_topK - 1, res.value()->GetDim()));
     }
     if (cur_recall <= expected_recall * query_count) {
         WARN(fmt::format("cur_result({}) <= expected_recall * query_count({})",

--- a/tests/test_ivf.cpp
+++ b/tests/test_ivf.cpp
@@ -1224,13 +1224,9 @@ TestIVFBuildMultiBucketsPerData(const fixtures::IVFResourcePtr& resource) {
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
     for (auto metric_type : resource->metric_types) {
-        metric_type = "ip";
         for (auto dim : resource->dims) {
-            dim = 48;
             for (auto train_type : resource->train_types) {
                 for (auto [base_quantization_str, recall] : resource->test_cases) {
-                    base_quantization_str = "fp32";
-                    recall = 0.72;
                     if (train_type == "kmeans") {
                         recall *= 0.8F;  // Kmeans may not achieve high recall in random datasets
                     }

--- a/tests/test_ivf.cpp
+++ b/tests/test_ivf.cpp
@@ -456,6 +456,9 @@ TestIVFBuildWithResidual(const fixtures::IVFResourcePtr& resource) {
             for (auto train_type : resource->train_types) {
                 for (auto [base_quantization_str, recall] : tmp_test_cases) {
                     auto count = std::min(300, static_cast<int32_t>(dim / 4));
+                    if (base_quantization_str == "fp16") {
+                        recall *= (1 - 0.2F * dim / 1536.0F);
+                    }
                     if (train_type == "kmeans") {
                         recall *= 0.8F;  // Kmeans may not achieve high recall in random datasets
                     }

--- a/tests/test_ivf.cpp
+++ b/tests/test_ivf.cpp
@@ -253,7 +253,7 @@ IVFTestIndex::TestGeneral(const TestIndex::IndexPtr& index,
     TestRangeSearch(index, dataset, search_param, recall, 10, true);
     TestRangeSearch(index, dataset, search_param, recall / 2.0, 5, true);
     TestFilterSearch(index, dataset, search_param, recall, true);
-    TestCalcDistanceById(index, dataset, 2e-6, false);
+    TestCalcDistanceById(index, dataset, 2e-6, true);
     TestCheckIdExist(index, dataset);
     TestExportIDs(index, dataset);
 }

--- a/tests/test_ivf.cpp
+++ b/tests/test_ivf.cpp
@@ -1224,9 +1224,13 @@ TestIVFBuildMultiBucketsPerData(const fixtures::IVFResourcePtr& resource) {
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
     for (auto metric_type : resource->metric_types) {
+        metric_type = "ip";
         for (auto dim : resource->dims) {
+            dim = 48;
             for (auto train_type : resource->train_types) {
                 for (auto [base_quantization_str, recall] : resource->test_cases) {
+                    base_quantization_str = "fp32";
+                    recall = 0.72;
                     if (train_type == "kmeans") {
                         recall *= 0.8F;  // Kmeans may not achieve high recall in random datasets
                     }

--- a/tests/test_ivf.cpp
+++ b/tests/test_ivf.cpp
@@ -253,6 +253,7 @@ IVFTestIndex::TestGeneral(const TestIndex::IndexPtr& index,
     TestRangeSearch(index, dataset, search_param, recall, 10, true);
     TestRangeSearch(index, dataset, search_param, recall / 2.0, 5, true);
     TestFilterSearch(index, dataset, search_param, recall, true);
+    TestCalcDistanceById(index, dataset, 2e-6, false);
     TestCheckIdExist(index, dataset);
     TestExportIDs(index, dataset);
 }

--- a/tests/test_ivf.cpp
+++ b/tests/test_ivf.cpp
@@ -456,9 +456,6 @@ TestIVFBuildWithResidual(const fixtures::IVFResourcePtr& resource) {
             for (auto train_type : resource->train_types) {
                 for (auto [base_quantization_str, recall] : tmp_test_cases) {
                     auto count = std::min(300, static_cast<int32_t>(dim / 4));
-                    if (base_quantization_str == "fp16") {
-                        recall *= (1 - 0.2F * dim / 1536.0F);
-                    }
                     if (train_type == "kmeans") {
                         recall *= 0.8F;  // Kmeans may not achieve high recall in random datasets
                     }


### PR DESCRIPTION
close: #1094

## Summary by Sourcery

Add support for calculating distances by ID in the IVF index, including residual and cosine metric handling, update get_location signature for const-correctness, and add a corresponding unit test.

New Features:
- Introduce IVF::CalDistanceById to compute distances for specified IDs using IVF indices

Enhancements:
- Mark get_location as const for improved const-correctness

Tests:
- Add TestCalcDistanceById unit test for the new distance calculation method