### PR TITLE
chore: add more tag for compatibility

### DIFF
--- a/scripts/check_compatibility.sh
+++ b/scripts/check_compatibility.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/bash
 
-old_version_indexes="v0.16.0_hgraph v0.16.0_hnsw \
+old_version_indexes="v0.16.2_hgraph v0.16.2_hnsw \
+                     v0.16.1_hgraph v0.16.1_hnsw \
+                     v0.16.0_hgraph v0.16.0_hnsw \
                      v0.15.0_hgraph v0.15.0_hnsw \
                      v0.15.1_hgraph v0.15.1_hnsw \
                      v0.14.0_hgraph v0.14.0_hnsw \


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Include v0.16.1 and v0.16.2 index tags in old_version_indexes for compatibility checks