### PR TITLE
refactor(index): reorder the huge index's function

### DIFF
--- a/src/algorithm/brute_force.h
+++ b/src/algorithm/brute_force.h
@@ -41,35 +41,49 @@ public:
 
     ~BruteForce() override = default;
 
-    [[nodiscard]] std::string
-    GetName() const override {
-        return INDEX_BRUTE_FORCE;
-    }
+    std::vector<int64_t>
+    Add(const DatasetPtr& data) override;
+
+    std::vector<int64_t>
+    Build(const DatasetPtr& data) override;
+
+    float
+    CalcDistanceById(const float* vector, int64_t id) const override;
+
+    void
+    Deserialize(StreamReader& reader) override;
+
+    uint64_t
+    EstimateMemory(uint64_t num_elements) const override;
 
     [[nodiscard]] InnerIndexPtr
     Fork(const IndexCommonParam& param) override {
         return std::make_shared<BruteForce>(this->create_param_ptr_, param);
     }
 
-    void
-    InitFeatures() override;
-
-    std::vector<int64_t>
-    Build(const DatasetPtr& data) override;
-
     IndexType
     GetIndexType() override {
         return IndexType::BRUTEFORCE;
     }
 
+    int64_t
+    GetMemoryUsage() const override;
+
+    std::string
+    GetName() const override {
+        return INDEX_BRUTE_FORCE;
+    }
+
+    int64_t
+    GetNumElements() const override {
+        return this->total_count_;
+    }
+
     void
-    Train(const DatasetPtr& data) override;
+    GetVectorByInnerId(InnerIdType inner_id, float* data) const override;
 
-    std::vector<int64_t>
-    Add(const DatasetPtr& data) override;
-
-    bool
-    Remove(int64_t label) override;
+    void
+    InitFeatures() override;
 
     DatasetPtr
     KnnSearch(const DatasetPtr& query,
@@ -84,31 +98,17 @@ public:
                 const FilterPtr& filter,
                 int64_t limited_size = -1) const override;
 
-    float
-    CalcDistanceById(const float* vector, int64_t id) const override;
+    bool
+    Remove(int64_t label) override;
+
+    DatasetPtr
+    SearchWithRequest(const SearchRequest& request) const override;
 
     void
     Serialize(StreamWriter& writer) const override;
 
     void
-    Deserialize(StreamReader& reader) override;
-
-    [[nodiscard]] int64_t
-    GetNumElements() const override {
-        return this->total_count_;
-    }
-
-    [[nodiscard]] int64_t
-    GetMemoryUsage() const override;
-
-    [[nodiscard]] uint64_t
-    EstimateMemory(uint64_t num_elements) const override;
-
-    void
-    GetVectorByInnerId(InnerIdType inner_id, float* data) const override;
-
-    [[nodiscard]] virtual DatasetPtr
-    SearchWithRequest(const SearchRequest& request) const override;
+    Train(const DatasetPtr& data) override;
 
     void
     UpdateAttribute(int64_t id, const AttributeSet& new_attrs) override;

--- a/src/algorithm/inner_index_interface.h
+++ b/src/algorithm/inner_index_interface.h
@@ -36,49 +36,146 @@ DEFINE_POINTER2(InnerIndex, InnerIndexInterface);
 class InnerIndexInterface {
 public:
     InnerIndexInterface() = default;
-
     explicit InnerIndexInterface(ParamPtr index_param, const IndexCommonParam& common_param);
-
     virtual ~InnerIndexInterface() = default;
 
     constexpr static char fast_string_delimiter = '|';
 
-    static InnerIndexPtr
-    FastCreateIndex(const std::string& index_fast_str, const IndexCommonParam& common_param);
-
-    [[nodiscard]] virtual std::string
-    GetName() const = 0;
-
-    [[nodiscard]] virtual IndexType
-    GetIndexType() = 0;
-
-    virtual void
-    InitFeatures() = 0;
-
     virtual std::vector<int64_t>
     Add(const DatasetPtr& base) = 0;
 
-    [[nodiscard]] virtual DatasetPtr
-    KnnSearch(const DatasetPtr& query,
-              int64_t k,
-              const std::string& parameters,
-              const FilterPtr& filter) const = 0;
+    virtual std::string
+    AnalyzeIndexBySearch(const SearchRequest& request) {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "Index doesn't support analyze index by search");
+    }
 
-    [[nodiscard]] virtual DatasetPtr
-    RangeSearch(const DatasetPtr& query,
-                float radius,
-                const std::string& parameters,
-                const FilterPtr& filter,
-                int64_t limited_size = -1) const = 0;
+    virtual std::vector<int64_t>
+    Build(const DatasetPtr& base);
+
+    virtual float
+    CalcDistanceById(const float* query, int64_t id) const {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "Index doesn't support calculate distance by id");
+    }
+
+    virtual DatasetPtr
+    CalDistanceById(const float* query, const int64_t* ids, int64_t count) const;
+
+    virtual uint64_t
+    CalSerializeSize() const;
+
+    [[nodiscard]] virtual bool
+    CheckFeature(IndexFeature feature) const {
+        return this->index_feature_list_->CheckFeature(feature);
+    }
+
+    [[nodiscard]] virtual bool
+    CheckIdExist(int64_t id) const {
+        return this->label_table_->CheckLabel(id);
+    }
+
+    virtual InnerIndexPtr
+    Clone(const IndexCommonParam& param);
+
+    virtual Index::Checkpoint
+    ContinueBuild(const DatasetPtr& base, const BinarySet& binary_set) {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "Index doesn't support ContinueBuild");
+    }
 
     virtual void
-    Serialize(StreamWriter& writer) const = 0;
+    Deserialize(const BinarySet& binary_set);
+
+    virtual void
+    Deserialize(const ReaderSet& reader_set);
+
+    virtual void
+    Deserialize(std::istream& in_stream);
 
     virtual void
     Deserialize(StreamReader& reader) = 0;
 
+    [[nodiscard]] virtual uint64_t
+    EstimateMemory(uint64_t num_elements) const {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "Index doesn't support EstimateMemory");
+    }
+
+    static InnerIndexPtr
+    FastCreateIndex(const std::string& index_fast_str, const IndexCommonParam& common_param);
+
+    virtual DatasetPtr
+    ExportIDs() const;
+
+    virtual InnerIndexPtr
+    ExportModel(const IndexCommonParam& param) const {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "Index doesn't support ExportModel");
+    }
+
+    virtual uint32_t
+    Feedback(const DatasetPtr& query,
+             int64_t k,
+             const std::string& parameters,
+             int64_t global_optimum_tag_id = std::numeric_limits<int64_t>::max()) {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "Index doesn't support Feedback");
+    }
+
     [[nodiscard]] virtual InnerIndexPtr
-    Fork(const IndexCommonParam& param) = 0;
+    Fork(const IndexCommonParam& param) {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION, "Index doesn't support Fork");
+    }
+
+    virtual void
+    GetCodeByInnerId(InnerIdType inner_id, uint8_t* data) const {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "Index doesn't support GetCodeByInnerId");
+    }
+
+    [[nodiscard]] virtual DatasetPtr
+    GetDataByIds(const int64_t* ids, int64_t count) const {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "Index doesn't support GetDataByIds");
+    }
+
+    [[nodiscard]] virtual int64_t
+    GetEstimateBuildMemory(const int64_t num_elements) const {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "Index doesn't support GetEstimateBuildMemory");
+    }
+
+    virtual void
+    GetExtraInfoByIds(const int64_t* ids, int64_t count, char* extra_infos) const {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "Index doesn't support GetExtraInfoByIds");
+    }
+
+    [[nodiscard]] virtual IndexType
+    GetIndexType() = 0;
+
+    [[nodiscard]] virtual int64_t
+    GetMemoryUsage() const {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "Index doesn't support GetMemoryUsage");
+    }
+
+    [[nodiscard]] virtual std::string
+    GetMemoryUsageDetail() const {
+        // TODO(deming): implement func for every types of inner index
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "Index doesn't support GetMemoryUsageDetail");
+    }
+
+    virtual std::pair<int64_t, int64_t>
+    GetMinAndMaxId() const {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "Index doesn't support GetMinAndMaxId");
+    }
+
+    [[nodiscard]] virtual std::string
+    GetName() const = 0;
 
     [[nodiscard]] virtual int64_t
     GetNumElements() const = 0;
@@ -89,33 +186,35 @@ public:
                             "Index doesn't support GetNumberRemoved");
     }
 
-    [[nodiscard]] virtual DatasetPtr
-    GetDataByIds(const int64_t* ids, int64_t count) const {
+    [[nodiscard]] virtual std::string
+    GetStats() const {
         throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                            "Index doesn't support GetDataByIds");
+                            "Index doesn't support GetStats");
+    }
+
+    virtual void
+    GetVectorByInnerId(InnerIdType inner_id, float* data) const {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "Index doesn't support GetVectorByInnerId");
     }
 
     DatasetPtr
     GetVectorByIds(const int64_t* ids, int64_t count) const;
 
-public:
     virtual void
-    Train(const DatasetPtr& base){};
+    InitFeatures() = 0;
 
-    virtual std::vector<int64_t>
-    Build(const DatasetPtr& base);
+    [[nodiscard]] virtual DatasetPtr
+    KnnSearch(const DatasetPtr& query,
+              int64_t k,
+              const std::string& parameters,
+              const FilterPtr& filter) const = 0;
 
     [[nodiscard]] virtual DatasetPtr
     KnnSearch(const DatasetPtr& query,
               int64_t k,
               const std::string& parameters,
               const BitsetPtr& invalid) const;
-
-    [[nodiscard]] virtual DatasetPtr
-    KnnSearch(const DatasetPtr& query,
-              int64_t k,
-              const std::string& parameters,
-              const std::function<bool(int64_t)>& filter) const;
 
     [[nodiscard]] virtual DatasetPtr
     KnnSearch(const DatasetPtr& query,
@@ -139,15 +238,33 @@ public:
     };
 
     [[nodiscard]] virtual DatasetPtr
+    KnnSearch(const DatasetPtr& query,
+              int64_t k,
+              const std::string& parameters,
+              const std::function<bool(int64_t)>& filter) const;
+
+    [[nodiscard]] virtual DatasetPtr
     KnnSearch(const DatasetPtr& query, int64_t k, SearchParam& search_param) const {
         throw std::runtime_error("Index doesn't support new filter");
     }
 
-    [[nodiscard]] virtual DatasetPtr
-    SearchWithRequest(const SearchRequest& request) const {
-        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                            "Index doesn't support SearchWithRequest");
+    virtual void
+    Merge(const std::vector<MergeUnit>& merge_units) {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION, "Index doesn't support Merge");
     }
+
+    virtual uint32_t
+    Pretrain(const std::vector<int64_t>& base_tag_ids, uint32_t k, const std::string& parameters) {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "Index doesn't support Pretrain");
+    }
+
+    [[nodiscard]] virtual DatasetPtr
+    RangeSearch(const DatasetPtr& query,
+                float radius,
+                const std::string& parameters,
+                const FilterPtr& filter,
+                int64_t limited_size = -1) const = 0;
 
     [[nodiscard]] virtual DatasetPtr
     RangeSearch(const DatasetPtr& query,
@@ -155,6 +272,15 @@ public:
                 const std::string& parameters,
                 const BitsetPtr& invalid,
                 int64_t limited_size = -1) const;
+
+    [[nodiscard]] virtual DatasetPtr
+    RangeSearch(const DatasetPtr& query,
+                float radius,
+                const std::string& parameters,
+                const FilterPtr& filter,
+                Allocator* allocator) const {
+        throw std::runtime_error("Index doesn't support new filter");
+    }
 
     [[nodiscard]] virtual DatasetPtr
     RangeSearch(const DatasetPtr& query,
@@ -172,28 +298,38 @@ public:
         return this->RangeSearch(query, radius, parameters, filter, limited_size);
     }
 
-    virtual Index::Checkpoint
-    ContinueBuild(const DatasetPtr& base, const BinarySet& binary_set) {
-        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                            "Index doesn't support ContinueBuild");
-    }
-
     virtual bool
     Remove(int64_t id) {
         throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION, "Index doesn't support Remove");
     }
 
-    virtual bool
-    UpdateId(int64_t old_id, int64_t new_id) {
+    [[nodiscard]] virtual DatasetPtr
+    SearchWithRequest(const SearchRequest& request) const {
         throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                            "Index doesn't support UpdateId");
+                            "Index doesn't support SearchWithRequest");
     }
 
-    virtual bool
-    UpdateVector(int64_t id, const DatasetPtr& new_base, bool force_update = false) {
-        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                            "Index doesn't support UpdateVector");
+    virtual void
+    Serialize(std::ostream& out_stream) const;
+
+    virtual void
+    Serialize(StreamWriter& writer) const = 0;
+
+    [[nodiscard]] virtual BinarySet
+    Serialize() const;
+
+    virtual void
+    SetIO(const std::shared_ptr<Reader> reader) {
     }
+
+    virtual void
+    SetImmutable() {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "Index doesn't support SetImmutable");
+    }
+
+    virtual void
+    Train(const DatasetPtr& base){};
 
     virtual void
     UpdateAttribute(int64_t id, const AttributeSet& new_attrs) {
@@ -213,164 +349,28 @@ public:
                             "Index doesn't support UpdateVector");
     }
 
-    virtual uint32_t
-    Pretrain(const std::vector<int64_t>& base_tag_ids, uint32_t k, const std::string& parameters) {
+    virtual bool
+    UpdateId(int64_t old_id, int64_t new_id) {
         throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                            "Index doesn't support Pretrain");
+                            "Index doesn't support UpdateId");
     }
 
-    virtual uint32_t
-    Feedback(const DatasetPtr& query,
-             int64_t k,
-             const std::string& parameters,
-             int64_t global_optimum_tag_id = std::numeric_limits<int64_t>::max()) {
+    virtual bool
+    UpdateVector(int64_t id, const DatasetPtr& new_base, bool force_update = false) {
         throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                            "Index doesn't support Feedback");
-    }
-
-    virtual float
-    CalcDistanceById(const float* query, int64_t id) const {
-        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                            "Index doesn't support calculate distance by id");
-    }
-
-    virtual DatasetPtr
-    CalDistanceById(const float* query, const int64_t* ids, int64_t count) const;
-
-    virtual std::pair<int64_t, int64_t>
-    GetMinAndMaxId() const {
-        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                            "Index doesn't support GetMinAndMaxId");
-    }
-
-    virtual void
-    GetExtraInfoByIds(const int64_t* ids, int64_t count, char* extra_infos) const {
-        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                            "Index doesn't support GetExtraInfoByIds");
-    }
-
-    virtual void
-    Merge(const std::vector<MergeUnit>& merge_units) {
-        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION, "Index doesn't support Merge");
-    }
-
-    virtual InnerIndexPtr
-    Clone(const IndexCommonParam& param);
-
-    virtual InnerIndexPtr
-    ExportModel(const IndexCommonParam& param) const {
-        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                            "Index doesn't support ExportModel");
-    }
-
-    virtual DatasetPtr
-    ExportIDs() const;
-
-    virtual void
-    SetImmutable() {
-        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                            "Index doesn't support SetImmutable");
-    }
-
-    [[nodiscard]] virtual BinarySet
-    Serialize() const;
-
-    virtual void
-    Serialize(std::ostream& out_stream) const;
-
-    virtual void
-    Deserialize(const BinarySet& binary_set);
-
-    virtual void
-    Deserialize(const ReaderSet& reader_set);
-
-    virtual void
-    Deserialize(std::istream& in_stream);
-
-    virtual uint64_t
-    CalSerializeSize() const;
-
-    [[nodiscard]] virtual bool
-    CheckFeature(IndexFeature feature) const {
-        return this->index_feature_list_->CheckFeature(feature);
-    }
-
-    [[nodiscard]] virtual int64_t
-    GetMemoryUsage() const {
-        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                            "Index doesn't support GetMemoryUsage");
-    }
-
-    [[nodiscard]] virtual std::string
-    GetMemoryUsageDetail() const {
-        // TODO(deming): implement func for every types of inner index
-        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                            "Index doesn't support GetMemoryUsageDetail");
-    }
-
-    [[nodiscard]] virtual uint64_t
-    EstimateMemory(uint64_t num_elements) const {
-        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                            "Index doesn't support EstimateMemory");
-    }
-
-    [[nodiscard]] virtual int64_t
-    GetEstimateBuildMemory(const int64_t num_elements) const {
-        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                            "Index doesn't support GetEstimateBuildMemory");
-    }
-
-    [[nodiscard]] virtual std::string
-    GetStats() const {
-        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                            "Index doesn't support GetStats");
-    }
-
-    virtual std::string
-    AnalyzeIndexBySearch(const SearchRequest& request) {
-        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                            "Index doesn't support analyze index by search");
-    }
-
-    [[nodiscard]] virtual bool
-    CheckIdExist(int64_t id) const {
-        return this->label_table_->CheckLabel(id);
-    }
-
-    virtual void
-    GetCodeByInnerId(InnerIdType inner_id, uint8_t* data) const {
-        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                            "Index doesn't support GetCodeByInnerId");
-    }
-
-    virtual void
-    GetVectorByInnerId(InnerIdType inner_id, float* data) const {
-        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                            "Index doesn't support GetVectorByInnerId");
-    }
-
-    virtual void
-    SetIO(const std::shared_ptr<Reader> reader) {
+                            "Index doesn't support UpdateVector");
     }
 
 public:
     LabelTablePtr label_table_{nullptr};
-
     LabelTablePtr tomb_label_table_{nullptr};
-
     Allocator* allocator_{nullptr};
-
     IndexFeatureListPtr index_feature_list_{nullptr};
-
     mutable std::shared_mutex label_lookup_mutex_{};  // lock for label_lookup_ & labels_
-
     const ParamPtr create_param_ptr_{nullptr};
-
     int64_t dim_{0};
     bool immutable_{false};
-
     MetricType metric_{MetricType::METRIC_TYPE_L2SQR};
-
     DataTypes data_type_{DataTypes::DATA_TYPE_FLOAT};
 };
 

--- a/src/algorithm/ivf.h
+++ b/src/algorithm/ivf.h
@@ -46,35 +46,44 @@ public:
 
     ~IVF() override = default;
 
-    [[nodiscard]] std::string
-    GetName() const override {
-        return INDEX_IVF;
-    }
+    std::vector<int64_t>
+    Add(const DatasetPtr& base) override;
+
+    std::vector<int64_t>
+    Build(const DatasetPtr& base) override;
+
+    void
+    Deserialize(StreamReader& reader) override;
+
+    [[nodiscard]] InnerIndexPtr
+    ExportModel(const IndexCommonParam& param) const override;
 
     [[nodiscard]] InnerIndexPtr
     Fork(const IndexCommonParam& param) override {
         return std::make_shared<IVF>(this->create_param_ptr_, param);
     }
 
-    void
-    InitFeatures() override;
-
-    std::vector<int64_t>
-    Build(const DatasetPtr& base) override;
+    DatasetPtr
+    GetDataByIds(const int64_t* ids, int64_t count) const override;
 
     IndexType
     GetIndexType() override {
         return IndexType::IVF;
     }
 
-    std::vector<int64_t>
-    Add(const DatasetPtr& base) override;
+    std::string
+    GetName() const override {
+        return INDEX_IVF;
+    }
+
+    int64_t
+    GetNumElements() const override;
 
     void
-    Train(const DatasetPtr& data) override;
+    GetCodeByInnerId(InnerIdType inner_id, uint8_t* data) const override;
 
-    InnerIndexPtr
-    ExportModel(const IndexCommonParam& param) const override;
+    void
+    InitFeatures() override;
 
     DatasetPtr
     KnnSearch(const DatasetPtr& query,
@@ -82,8 +91,8 @@ public:
               const std::string& parameters,
               const FilterPtr& filter) const override;
 
-    [[nodiscard]] DatasetPtr
-    SearchWithRequest(const SearchRequest& request) const override;
+    void
+    Merge(const std::vector<MergeUnit>& merge_units) override;
 
     DatasetPtr
     RangeSearch(const DatasetPtr& query,
@@ -92,8 +101,14 @@ public:
                 const FilterPtr& filter,
                 int64_t limited_size = -1) const override;
 
+    DatasetPtr
+    SearchWithRequest(const SearchRequest& request) const override;
+
     void
-    Merge(const std::vector<MergeUnit>& merge_units) override;
+    Serialize(StreamWriter& writer) const override;
+
+    void
+    Train(const DatasetPtr& data) override;
 
     void
     UpdateAttribute(int64_t id, const AttributeSet& new_attrs) override;
@@ -102,21 +117,6 @@ public:
     UpdateAttribute(int64_t id,
                     const AttributeSet& new_attrs,
                     const AttributeSet& origin_attrs) override;
-
-    void
-    Serialize(StreamWriter& writer) const override;
-
-    void
-    Deserialize(StreamReader& reader) override;
-
-    int64_t
-    GetNumElements() const override;
-
-    [[nodiscard]] DatasetPtr
-    GetDataByIds(const int64_t* ids, int64_t count) const override;
-
-    void
-    GetCodeByInnerId(InnerIdType inner_id, uint8_t* data) const override;
 
 private:
     InnerSearchParam

--- a/src/algorithm/pyramid.h
+++ b/src/algorithm/pyramid.h
@@ -95,9 +95,20 @@ public:
     explicit Pyramid(const ParamPtr& param, const IndexCommonParam& common_param)
         : Pyramid(std::dynamic_pointer_cast<PyramidParameters>(param), common_param){};
 
-    std::string
-    GetName() const override {
-        return INDEX_PYRAMID;
+    ~Pyramid() = default;
+
+    std::vector<int64_t>
+    Add(const DatasetPtr& base) override;
+
+    std::vector<int64_t>
+    Build(const DatasetPtr& base) override;
+
+    void
+    Deserialize(StreamReader& reader) override;
+
+    [[nodiscard]] InnerIndexPtr
+    Fork(const IndexCommonParam& param) override {
+        return std::make_shared<Pyramid>(this->create_param_ptr_, param);
     }
 
     IndexType
@@ -105,18 +116,19 @@ public:
         return IndexType::PYRAMID;
     }
 
-    [[nodiscard]] InnerIndexPtr
-    Fork(const IndexCommonParam& param) override {
-        return std::make_shared<Pyramid>(this->create_param_ptr_, param);
+    int64_t
+    GetMemoryUsage() const override;
+
+    std::string
+    GetName() const override {
+        return INDEX_PYRAMID;
     }
 
-    ~Pyramid() = default;
+    int64_t
+    GetNumElements() const override;
 
-    std::vector<int64_t>
-    Build(const DatasetPtr& base) override;
-
-    std::vector<int64_t>
-    Add(const DatasetPtr& base) override;
+    void
+    InitFeatures() override;
 
     DatasetPtr
     KnnSearch(const DatasetPtr& query,
@@ -130,20 +142,9 @@ public:
                 const std::string& parameters,
                 const FilterPtr& filter,
                 int64_t limited_size = -1) const override;
+
     void
     Serialize(StreamWriter& writer) const override;
-
-    void
-    Deserialize(StreamReader& reader) override;
-
-    int64_t
-    GetNumElements() const override;
-
-    int64_t
-    GetMemoryUsage() const override;
-
-    void
-    InitFeatures() override;
 
 private:
     void

--- a/src/index/index_impl.h
+++ b/src/index/index_impl.h
@@ -50,6 +50,20 @@ public:
 
 public:
     tl::expected<std::vector<int64_t>, Error>
+    Add(const DatasetPtr& base) override {
+        if (this->inner_index_->immutable_) {
+            return tl::unexpected(
+                Error(ErrorType::UNSUPPORTED_INDEX_OPERATION, "immutable index no support add"));
+        }
+        SAFE_CALL(return this->inner_index_->Add(base));
+    }
+
+    std::string
+    AnalyzeIndexBySearch(const SearchRequest& request) override {
+        return this->inner_index_->AnalyzeIndexBySearch(request);
+    }
+
+    tl::expected<std::vector<int64_t>, Error>
     Build(const DatasetPtr& base) override {
         if (this->inner_index_->immutable_) {
             return tl::unexpected(
@@ -58,18 +72,33 @@ public:
         SAFE_CALL(return this->inner_index_->Build(base));
     }
 
-    IndexType
-    GetIndexType() override {
-        return this->inner_index_->GetIndexType();
+    tl::expected<float, Error>
+    CalcDistanceById(const float* vector, int64_t id) const override {
+        SAFE_CALL(return this->inner_index_->CalcDistanceById(vector, id));
     }
 
-    tl::expected<void, Error>
-    Train(const DatasetPtr& data) override {
-        if (this->inner_index_->immutable_) {
-            return tl::unexpected(
-                Error(ErrorType::UNSUPPORTED_INDEX_OPERATION, "immutable index no support train"));
+    tl::expected<DatasetPtr, Error>
+    CalDistanceById(const float* query, const int64_t* ids, int64_t count) const override {
+        SAFE_CALL(return this->inner_index_->CalDistanceById(query, ids, count));
+    }
+
+    [[nodiscard]] bool
+    CheckFeature(IndexFeature feature) const override {
+        return this->inner_index_->CheckFeature(feature);
+    }
+
+    [[nodiscard]] bool
+    CheckIdExist(int64_t id) const override {
+        return this->inner_index_->CheckIdExist(id);
+    }
+
+    tl::expected<IndexPtr, Error>
+    Clone() const override {
+        auto clone_value = this->clone_inner_index();
+        if (not clone_value.has_value()) {
+            LOG_ERROR_AND_RETURNS(clone_value.error().type, clone_value.error().message);
         }
-        SAFE_CALL(this->inner_index_->Train(data));
+        return std::make_shared<IndexImpl<T>>(clone_value.value(), this->common_param_);
     }
 
     tl::expected<Checkpoint, Error>
@@ -81,81 +110,104 @@ public:
         SAFE_CALL(return this->inner_index_->ContinueBuild(base, binary_set));
     }
 
-    tl::expected<std::vector<int64_t>, Error>
-    Add(const DatasetPtr& base) override {
-        if (this->inner_index_->immutable_) {
-            return tl::unexpected(
-                Error(ErrorType::UNSUPPORTED_INDEX_OPERATION, "immutable index no support add"));
-        }
-        SAFE_CALL(return this->inner_index_->Add(base));
-    }
-
-    tl::expected<bool, Error>
-    Remove(int64_t id) override {
-        if (this->inner_index_->immutable_) {
-            return tl::unexpected(
-                Error(ErrorType::UNSUPPORTED_INDEX_OPERATION, "immutable index no support remove"));
-        }
-        SAFE_CALL(return this->inner_index_->Remove(id));
-    }
-
-    tl::expected<bool, Error>
-    UpdateId(int64_t old_id, int64_t new_id) override {
-        if (this->inner_index_->immutable_) {
-            return tl::unexpected(Error(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                                        "immutable index no support update id"));
-        }
-        SAFE_CALL(return this->inner_index_->UpdateId(old_id, new_id));
-    }
-
-    tl::expected<bool, Error>
-    UpdateVector(int64_t id, const DatasetPtr& new_base, bool force_update = false) override {
-        if (this->inner_index_->immutable_) {
-            return tl::unexpected(Error(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                                        "immutable index no support update vector"));
-        }
-        SAFE_CALL(return this->inner_index_->UpdateVector(id, new_base, force_update));
-    }
-
-    virtual tl::expected<void, Error>
-    UpdateAttribute(int64_t id, const AttributeSet& new_attrs) override {
-        if (this->inner_index_->immutable_) {
-            return tl::unexpected(Error(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                                        "immutable index no support update attribute"));
-        }
-        SAFE_CALL(this->inner_index_->UpdateAttribute(id, new_attrs));
+    tl::expected<void, Error>
+    Deserialize(const BinarySet& binary_set) override {
+        SAFE_CALL(this->inner_index_->Deserialize(binary_set));
     }
 
     tl::expected<void, Error>
-    UpdateAttribute(int64_t id,
-                    const AttributeSet& new_attrs,
-                    const AttributeSet& origin_attrs) override {
-        if (this->inner_index_->immutable_) {
-            return tl::unexpected(
-                Error(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                      "immutable index no support update attribute with origin attributes"));
-        }
-        SAFE_CALL(this->inner_index_->UpdateAttribute(id, new_attrs, origin_attrs));
+    Deserialize(const ReaderSet& reader_set) override {
+        SAFE_CALL(this->inner_index_->Deserialize(reader_set));
     }
 
-    virtual tl::expected<bool, Error>
-    UpdateExtraInfo(const DatasetPtr& new_base) override {
-        if (this->inner_index_->immutable_) {
+    tl::expected<void, Error>
+    Deserialize(std::istream& in_stream) override {
+        SAFE_CALL(this->inner_index_->Deserialize(in_stream));
+    }
+
+    [[nodiscard]] uint64_t
+    EstimateMemory(uint64_t num_elements) const override {
+        return this->inner_index_->EstimateMemory(num_elements);
+    }
+
+    tl::expected<DatasetPtr, Error>
+    ExportIDs() const override {
+        SAFE_CALL(return this->inner_index_->ExportIDs());
+    }
+
+    tl::expected<IndexPtr, Error>
+    ExportModel() const override {
+        auto model_value = this->export_model_inner();
+        if (not model_value.has_value()) {
+            LOG_ERROR_AND_RETURNS(model_value.error().type, model_value.error().message);
+        }
+        return std::make_shared<IndexImpl<T>>(model_value.value(), this->common_param_);
+    }
+
+    tl::expected<DatasetPtr, Error>
+    GetDataByIds(const int64_t* ids, int64_t count) const override {
+        if (not CheckFeature(IndexFeature::SUPPORT_GET_DATA_BY_IDS)) {
             return tl::unexpected(Error(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                                        "immutable index no support update extra info"));
+                                        "index no support to get data by ids"));
         }
-        SAFE_CALL(return this->inner_index_->UpdateExtraInfo(new_base));
+        SAFE_CALL(return this->inner_index_->GetDataByIds(ids, count));
+    };
+
+    [[nodiscard]] int64_t
+    GetEstimateBuildMemory(const int64_t num_elements) const override {
+        return this->inner_index_->GetEstimateBuildMemory(num_elements);
     }
 
-    [[nodiscard]] tl::expected<DatasetPtr, Error>
-    SearchWithRequest(const SearchRequest& request) const override {
-        if (GetNumElements() == 0) {
-            return DatasetImpl::MakeEmptyDataset();
-        }
-        SAFE_CALL(return this->inner_index_->SearchWithRequest(request));
+    virtual tl::expected<void, Error>
+    GetExtraInfoByIds(const int64_t* ids, int64_t count, char* extra_infos) const override {
+        SAFE_CALL(this->inner_index_->GetExtraInfoByIds(ids, count, extra_infos));
+    };
+
+    IndexType
+    GetIndexType() override {
+        return this->inner_index_->GetIndexType();
     }
 
-    [[nodiscard]] tl::expected<DatasetPtr, Error>
+    [[nodiscard]] int64_t
+    GetMemoryUsage() const override {
+        return this->inner_index_->GetMemoryUsage();
+    }
+
+    [[nodiscard]] std::string
+    GetMemoryUsageDetail() const override {
+        return this->inner_index_->GetMemoryUsageDetail();
+    }
+
+    tl::expected<std::pair<int64_t, int64_t>, Error>
+    GetMinAndMaxId() const override {
+        SAFE_CALL(return this->inner_index_->GetMinAndMaxId());
+    }
+
+    [[nodiscard]] int64_t
+    GetNumElements() const override {
+        return this->inner_index_->GetNumElements();
+    }
+
+    [[nodiscard]] int64_t
+    GetNumberRemoved() const override {
+        return this->inner_index_->GetNumberRemoved();
+    }
+
+    virtual tl::expected<DatasetPtr, Error>
+    GetRawVectorByIds(const int64_t* ids, int64_t count) const override {
+        if (not CheckFeature(IndexFeature::SUPPORT_GET_RAW_VECTOR_BY_IDS)) {
+            return tl::unexpected(Error(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                                        "index no support to get raw vector by ids"));
+        }
+        SAFE_CALL(return this->inner_index_->GetVectorByIds(ids, count));
+    };
+
+    [[nodiscard]] std::string
+    GetStats() const override {
+        return this->inner_index_->GetStats();
+    }
+
+    tl::expected<DatasetPtr, Error>
     KnnSearch(const DatasetPtr& query,
               int64_t k,
               const std::string& parameters,
@@ -221,6 +273,38 @@ public:
             query, k, parameters, filter, nullptr, iter_ctx, is_last_filter));
     }
 
+    tl::expected<void, Error>
+    Merge(const std::vector<MergeUnit>& merge_units) override {
+        if (this->inner_index_->immutable_) {
+            return tl::unexpected(
+                Error(ErrorType::UNSUPPORTED_INDEX_OPERATION, "immutable index no support merge"));
+        }
+        SAFE_CALL(this->inner_index_->Merge(merge_units));
+    }
+
+    tl::expected<uint32_t, Error>
+    Pretrain(const std::vector<int64_t>& base_tag_ids,
+             uint32_t k,
+             const std::string& parameters) override {
+        if (this->inner_index_->immutable_) {
+            return tl::unexpected(Error(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                                        "immutable index no support pretrain"));
+        }
+        SAFE_CALL(return this->inner_index_->Pretrain(base_tag_ids, k, parameters));
+    }
+
+    tl::expected<uint32_t, Error>
+    Feedback(const DatasetPtr& query,
+             int64_t k,
+             const std::string& parameters,
+             int64_t global_optimum_tag_id = std::numeric_limits<int64_t>::max()) override {
+        if (this->inner_index_->immutable_) {
+            return tl::unexpected(Error(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                                        "immutable index no support feedback"));
+        }
+        SAFE_CALL(return this->inner_index_->Feedback(query, k, parameters, global_optimum_tag_id));
+    }
+
     [[nodiscard]] tl::expected<DatasetPtr, Error>
     RangeSearch(const DatasetPtr& query,
                 float radius,
@@ -271,102 +355,13 @@ public:
             query, radius, parameters, filter, limited_size));
     }
 
-    tl::expected<uint32_t, Error>
-    Pretrain(const std::vector<int64_t>& base_tag_ids,
-             uint32_t k,
-             const std::string& parameters) override {
-        if (this->inner_index_->immutable_) {
-            return tl::unexpected(Error(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                                        "immutable index no support pretrain"));
-        }
-        SAFE_CALL(return this->inner_index_->Pretrain(base_tag_ids, k, parameters));
-    }
-
-    tl::expected<uint32_t, Error>
-    Feedback(const DatasetPtr& query,
-             int64_t k,
-             const std::string& parameters,
-             int64_t global_optimum_tag_id = std::numeric_limits<int64_t>::max()) override {
-        if (this->inner_index_->immutable_) {
-            return tl::unexpected(Error(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                                        "immutable index no support feedback"));
-        }
-        SAFE_CALL(return this->inner_index_->Feedback(query, k, parameters, global_optimum_tag_id));
-    }
-
-    tl::expected<float, Error>
-    CalcDistanceById(const float* vector, int64_t id) const override {
-        SAFE_CALL(return this->inner_index_->CalcDistanceById(vector, id));
-    }
-
-    tl::expected<DatasetPtr, Error>
-    CalDistanceById(const float* query, const int64_t* ids, int64_t count) const override {
-        SAFE_CALL(return this->inner_index_->CalDistanceById(query, ids, count));
-    }
-
-    virtual tl::expected<void, Error>
-    GetExtraInfoByIds(const int64_t* ids, int64_t count, char* extra_infos) const override {
-        SAFE_CALL(this->inner_index_->GetExtraInfoByIds(ids, count, extra_infos));
-    };
-
-    tl::expected<std::pair<int64_t, int64_t>, Error>
-    GetMinAndMaxId() const override {
-        SAFE_CALL(return this->inner_index_->GetMinAndMaxId());
-    }
-
-    virtual tl::expected<DatasetPtr, Error>
-    GetRawVectorByIds(const int64_t* ids, int64_t count) const override {
-        if (not CheckFeature(IndexFeature::SUPPORT_GET_RAW_VECTOR_BY_IDS)) {
-            return tl::unexpected(Error(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                                        "index no support to get raw vector by ids"));
-        }
-        SAFE_CALL(return this->inner_index_->GetVectorByIds(ids, count));
-    };
-
-    tl::expected<DatasetPtr, Error>
-    GetDataByIds(const int64_t* ids, int64_t count) const override {
-        if (not CheckFeature(IndexFeature::SUPPORT_GET_DATA_BY_IDS)) {
-            return tl::unexpected(Error(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                                        "index no support to get data by ids"));
-        }
-        SAFE_CALL(return this->inner_index_->GetDataByIds(ids, count));
-    };
-
-    tl::expected<void, Error>
-    Merge(const std::vector<MergeUnit>& merge_units) override {
+    tl::expected<bool, Error>
+    Remove(int64_t id) override {
         if (this->inner_index_->immutable_) {
             return tl::unexpected(
-                Error(ErrorType::UNSUPPORTED_INDEX_OPERATION, "immutable index no support merge"));
+                Error(ErrorType::UNSUPPORTED_INDEX_OPERATION, "immutable index no support remove"));
         }
-        SAFE_CALL(this->inner_index_->Merge(merge_units));
-    }
-
-    tl::expected<IndexPtr, Error>
-    Clone() const override {
-        auto clone_value = this->clone_inner_index();
-        if (not clone_value.has_value()) {
-            LOG_ERROR_AND_RETURNS(clone_value.error().type, clone_value.error().message);
-        }
-        return std::make_shared<IndexImpl<T>>(clone_value.value(), this->common_param_);
-    }
-
-    tl::expected<IndexPtr, Error>
-    ExportModel() const override {
-        auto model_value = this->export_model_inner();
-        if (not model_value.has_value()) {
-            LOG_ERROR_AND_RETURNS(model_value.error().type, model_value.error().message);
-        }
-        return std::make_shared<IndexImpl<T>>(model_value.value(), this->common_param_);
-    }
-
-    tl::expected<DatasetPtr, Error>
-    ExportIDs() const override {
-        SAFE_CALL(return this->inner_index_->ExportIDs());
-    }
-
-    tl::expected<void, Error>
-    SetImmutable() override {
-        SAFE_CALL(this->inner_index_->SetImmutable());
+        SAFE_CALL(return this->inner_index_->Remove(id));
     }
 
     [[nodiscard]] tl::expected<BinarySet, Error>
@@ -375,75 +370,81 @@ public:
     }
 
     tl::expected<void, Error>
-    Deserialize(const BinarySet& binary_set) override {
-        SAFE_CALL(this->inner_index_->Deserialize(binary_set));
-    }
-
-    tl::expected<void, Error>
-    Deserialize(const ReaderSet& reader_set) override {
-        SAFE_CALL(this->inner_index_->Deserialize(reader_set));
-    }
-
-    tl::expected<void, Error>
     Serialize(std::ostream& out_stream) override {
         SAFE_CALL(this->inner_index_->Serialize(out_stream));
     }
 
+    [[nodiscard]] tl::expected<DatasetPtr, Error>
+    SearchWithRequest(const SearchRequest& request) const override {
+        if (GetNumElements() == 0) {
+            return DatasetImpl::MakeEmptyDataset();
+        }
+        SAFE_CALL(return this->inner_index_->SearchWithRequest(request));
+    }
+
     tl::expected<void, Error>
-    Deserialize(std::istream& in_stream) override {
-        SAFE_CALL(this->inner_index_->Deserialize(in_stream));
+    SetImmutable() override {
+        SAFE_CALL(this->inner_index_->SetImmutable());
     }
 
-    [[nodiscard]] bool
-    CheckFeature(IndexFeature feature) const override {
-        return this->inner_index_->CheckFeature(feature);
+    tl::expected<void, Error>
+    Train(const DatasetPtr& data) override {
+        if (this->inner_index_->immutable_) {
+            return tl::unexpected(
+                Error(ErrorType::UNSUPPORTED_INDEX_OPERATION, "immutable index no support train"));
+        }
+        SAFE_CALL(this->inner_index_->Train(data));
     }
 
-    [[nodiscard]] int64_t
-    GetNumElements() const override {
-        return this->inner_index_->GetNumElements();
+    virtual tl::expected<void, Error>
+    UpdateAttribute(int64_t id, const AttributeSet& new_attrs) override {
+        if (this->inner_index_->immutable_) {
+            return tl::unexpected(Error(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                                        "immutable index no support update attribute"));
+        }
+        SAFE_CALL(this->inner_index_->UpdateAttribute(id, new_attrs));
     }
 
-    [[nodiscard]] int64_t
-    GetNumberRemoved() const override {
-        return this->inner_index_->GetNumberRemoved();
+    tl::expected<void, Error>
+    UpdateAttribute(int64_t id,
+                    const AttributeSet& new_attrs,
+                    const AttributeSet& origin_attrs) override {
+        if (this->inner_index_->immutable_) {
+            return tl::unexpected(
+                Error(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                      "immutable index no support update attribute with origin attributes"));
+        }
+        SAFE_CALL(this->inner_index_->UpdateAttribute(id, new_attrs, origin_attrs));
     }
 
-    [[nodiscard]] int64_t
-    GetMemoryUsage() const override {
-        return this->inner_index_->GetMemoryUsage();
+    virtual tl::expected<bool, Error>
+    UpdateExtraInfo(const DatasetPtr& new_base) override {
+        if (this->inner_index_->immutable_) {
+            return tl::unexpected(Error(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                                        "immutable index no support update extra info"));
+        }
+        SAFE_CALL(return this->inner_index_->UpdateExtraInfo(new_base));
     }
 
-    [[nodiscard]] std::string
-    GetMemoryUsageDetail() const override {
-        return this->inner_index_->GetMemoryUsageDetail();
+    tl::expected<bool, Error>
+    UpdateId(int64_t old_id, int64_t new_id) override {
+        if (this->inner_index_->immutable_) {
+            return tl::unexpected(Error(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                                        "immutable index no support update id"));
+        }
+        SAFE_CALL(return this->inner_index_->UpdateId(old_id, new_id));
     }
 
-    [[nodiscard]] uint64_t
-    EstimateMemory(uint64_t num_elements) const override {
-        return this->inner_index_->EstimateMemory(num_elements);
+    tl::expected<bool, Error>
+    UpdateVector(int64_t id, const DatasetPtr& new_base, bool force_update = false) override {
+        if (this->inner_index_->immutable_) {
+            return tl::unexpected(Error(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                                        "immutable index no support update vector"));
+        }
+        SAFE_CALL(return this->inner_index_->UpdateVector(id, new_base, force_update));
     }
 
-    [[nodiscard]] int64_t
-    GetEstimateBuildMemory(const int64_t num_elements) const override {
-        return this->inner_index_->GetEstimateBuildMemory(num_elements);
-    }
-
-    [[nodiscard]] std::string
-    GetStats() const override {
-        return this->inner_index_->GetStats();
-    }
-
-    std::string
-    AnalyzeIndexBySearch(const SearchRequest& request) override {
-        return this->inner_index_->AnalyzeIndexBySearch(request);
-    }
-
-    [[nodiscard]] bool
-    CheckIdExist(int64_t id) const override {
-        return this->inner_index_->CheckIdExist(id);
-    }
-
+public:
     [[nodiscard]] inline InnerIndexPtr
     GetInnerIndex() const {
         return this->inner_index_;
@@ -467,7 +468,6 @@ private:
 
 private:
     InnerIndexPtr inner_index_{nullptr};
-
     IndexCommonParam common_param_{};
 };
 


### PR DESCRIPTION
- use dictionary order

## Summary by Sourcery

Reorder and alphabetize index interface and implementation methods across multiple header files to maintain a consistent dictionary order and improve code organization

Enhancements:
- Sort IndexImpl methods alphabetically in index_impl.h
- Reorder InnerIndexInterface declarations in inner_index_interface.h
- Alphabetically arrange member declarations in algorithm-specific index headers (HGraph, SparseIndex, BruteForce, IVF, Pyramid)