### PR TITLE
feat(Hgraph): support tunning alpha in MRNG

### DIFF
--- a/examples/cpp/103_index_hgraph.cpp
+++ b/examples/cpp/103_index_hgraph.cpp
@@ -50,7 +50,8 @@ main(int argc, char** argv) {
         "index_param": {
             "base_quantization_type": "sq8",
             "max_degree": 26,
-            "ef_construction": 100
+            "ef_construction": 100,
+            "alpha":1.2
         }
     }
     )";

--- a/include/vsag/constants.h
+++ b/include/vsag/constants.h
@@ -143,6 +143,7 @@ extern const char* const HGRAPH_BUILD_BY_BASE_QUANTIZATION;
 extern const char* const HGRAPH_BASE_QUANTIZATION_TYPE;
 extern const char* const HGRAPH_GRAPH_MAX_DEGREE;
 extern const char* const HGRAPH_BUILD_EF_CONSTRUCTION;
+extern const char* const HGRAPH_BUILD_ALPHA;
 extern const char* const HGRAPH_INIT_CAPACITY;
 extern const char* const HGRAPH_GRAPH_TYPE;
 extern const char* const HGRAPH_GRAPH_STORAGE_TYPE;

--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -47,6 +47,7 @@ HGraph::HGraph(const HGraphParameterPtr& hgraph_param, const vsag::IndexCommonPa
       ignore_reorder_(hgraph_param->ignore_reorder),
       build_by_base_(hgraph_param->build_by_base),
       ef_construct_(hgraph_param->ef_construction),
+      alpha_(hgraph_param->alpha),
       odescent_param_(hgraph_param->odescent_param),
       graph_type_(hgraph_param->graph_type),
       hierarchical_datacell_param_(hgraph_param->hierarchical_graph_param) {
@@ -1023,8 +1024,13 @@ HGraph::graph_add_one(const void* data, int level, InnerIdType inner_id) {
             label_table_->SetDuplicateId(static_cast<InnerIdType>(param.duplicate_id), inner_id);
             return false;
         }
-        mutually_connect_new_element(
-            inner_id, result, this->bottom_graph_, flatten_codes, neighbors_mutex_, allocator_);
+        mutually_connect_new_element(inner_id,
+                                     result,
+                                     this->bottom_graph_,
+                                     flatten_codes,
+                                     neighbors_mutex_,
+                                     allocator_,
+                                     alpha_);
     } else {
         bottom_graph_->InsertNeighborsById(inner_id, Vector<InnerIdType>(allocator_));
     }
@@ -1032,8 +1038,13 @@ HGraph::graph_add_one(const void* data, int level, InnerIdType inner_id) {
     for (int64_t j = 0; j <= level; ++j) {
         if (route_graphs_[j]->TotalCount() != 0) {
             result = search_one_graph(data, route_graphs_[j], flatten_codes, param);
-            mutually_connect_new_element(
-                inner_id, result, route_graphs_[j], flatten_codes, neighbors_mutex_, allocator_);
+            mutually_connect_new_element(inner_id,
+                                         result,
+                                         route_graphs_[j],
+                                         flatten_codes,
+                                         neighbors_mutex_,
+                                         allocator_,
+                                         alpha_);
         } else {
             route_graphs_[j]->InsertNeighborsById(inner_id, Vector<InnerIdType>(allocator_));
         }
@@ -1411,6 +1422,12 @@ HGraph::CheckAndMappingExternalParam(const JsonType& external_param,
                                                 HGRAPH_BUILD_EF_CONSTRUCTION,
                                                 {
                                                     HGRAPH_EF_CONSTRUCTION_KEY,
+                                                },
+                                            },
+                                            {
+                                                HGRAPH_BUILD_ALPHA,
+                                                {
+                                                    HGRAPH_ALPHA_KEY,
                                                 },
                                             },
                                             {

--- a/src/algorithm/hgraph.h
+++ b/src/algorithm/hgraph.h
@@ -346,6 +346,7 @@ private:
     std::string graph_type_{GRAPH_TYPE_NSW};
 
     uint64_t ef_construct_{400};
+    float alpha_{1.0};
 
     uint64_t total_count_{0};
 

--- a/src/algorithm/hgraph_parameter.cpp
+++ b/src/algorithm/hgraph_parameter.cpp
@@ -102,6 +102,10 @@ HGraphParameter::FromJson(const JsonType& json) {
         this->ef_construction = json[HGRAPH_EF_CONSTRUCTION_KEY];
     }
 
+    if (json.contains(HGRAPH_ALPHA_KEY)) {
+        this->alpha = json[HGRAPH_ALPHA_KEY];
+    }
+
     if (json.contains(BUILD_THREAD_COUNT_KEY)) {
         this->build_thread_count = json[BUILD_THREAD_COUNT_KEY];
     }
@@ -131,6 +135,7 @@ HGraphParameter::ToJson() const {
     json[HGRAPH_BASE_CODES_KEY] = this->base_codes_param->ToJson();
     json[HGRAPH_GRAPH_KEY] = this->bottom_graph_param->ToJson();
     json[HGRAPH_EF_CONSTRUCTION_KEY] = this->ef_construction;
+    json[HGRAPH_ALPHA_KEY] = this->alpha;
     json[SUPPORT_DUPLICATE] = this->support_duplicate;
     return json;
 }

--- a/src/algorithm/hgraph_parameter.h
+++ b/src/algorithm/hgraph_parameter.h
@@ -57,6 +57,7 @@ public:
     bool build_by_base{false};
 
     uint64_t ef_construction{400};
+    float alpha{1.0F};
 
     bool support_duplicate{false};
     bool support_tombstone{false};

--- a/src/algorithm/pyramid.cpp
+++ b/src/algorithm/pyramid.cpp
@@ -415,7 +415,8 @@ Pyramid::Add(const DatasetPtr& base) {
                                              node->graph_,
                                              flatten_interface_ptr_,
                                              empty_mutex,
-                                             allocator_);
+                                             allocator_,
+                                             alpha_);
             }
         }
     }

--- a/src/algorithm/pyramid.h
+++ b/src/algorithm/pyramid.h
@@ -85,7 +85,8 @@ public:
     Pyramid(const PyramidParamPtr& pyramid_param, const IndexCommonParam& common_param)
         : InnerIndexInterface(pyramid_param, common_param),
           pyramid_param_(pyramid_param),
-          common_param_(common_param) {
+          common_param_(common_param),
+          alpha_(pyramid_param->alpha) {
         searcher_ = std::make_unique<BasicSearcher>(common_param_);
         flatten_interface_ptr_ =
             FlattenInterface::MakeInstance(pyramid_param_->flatten_data_cell_param, common_param_);
@@ -159,6 +160,7 @@ private:
     std::unique_ptr<BasicSearcher> searcher_ = nullptr;
     int64_t max_capacity_{0};
     int64_t cur_element_count_{0};
+    float alpha_{1.0F};
 
     std::shared_mutex resize_mutex_;
     std::mutex cur_element_count_mutex_;

--- a/src/algorithm/pyramid_zparameters.cpp
+++ b/src/algorithm/pyramid_zparameters.cpp
@@ -48,6 +48,10 @@ PyramidParameters::FromJson(const JsonType& json) {
         this->ef_construction = json[HGRAPH_EF_CONSTRUCTION_KEY];
     }
 
+    if (json.contains(HGRAPH_ALPHA_KEY)) {
+        this->alpha = json[HGRAPH_ALPHA_KEY];
+    }
+
     if (json.contains(NO_BUILD_LEVELS)) {
         const auto& no_build_levels_json = json[NO_BUILD_LEVELS];
         CHECK_ARGUMENT(no_build_levels_json.is_array(),

--- a/src/algorithm/pyramid_zparameters.h
+++ b/src/algorithm/pyramid_zparameters.h
@@ -49,6 +49,7 @@ public:
 
     std::vector<int32_t> no_build_levels;
     uint64_t ef_construction{100};
+    float alpha{1.0F};
 };
 
 class PyramidSearchParameters {

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -146,6 +146,7 @@ const char* const HGRAPH_BUILD_BY_BASE_QUANTIZATION = "build_by_base";
 const char* const HGRAPH_BASE_QUANTIZATION_TYPE = "base_quantization_type";
 const char* const HGRAPH_GRAPH_MAX_DEGREE = "max_degree";
 const char* const HGRAPH_BUILD_EF_CONSTRUCTION = "ef_construction";
+const char* const HGRAPH_BUILD_ALPHA = "alpha";
 const char* const HGRAPH_INIT_CAPACITY = "hgraph_init_capacity";
 const char* const HGRAPH_GRAPH_TYPE = "graph_type";
 const char* const HGRAPH_GRAPH_STORAGE_TYPE = "graph_storage_type";

--- a/src/impl/pruning_strategy.cpp
+++ b/src/impl/pruning_strategy.cpp
@@ -70,9 +70,10 @@ mutually_connect_new_element(InnerIdType cur_c,
                              const GraphInterfacePtr& graph,
                              const FlattenInterfacePtr& flatten,
                              const MutexArrayPtr& neighbors_mutexes,
-                             Allocator* allocator) {
+                             Allocator* allocator,
+                             float alpha) {
     const size_t max_size = graph->MaximumDegree();
-    select_edges_by_heuristic(top_candidates, max_size, flatten, allocator);
+    select_edges_by_heuristic(top_candidates, max_size, flatten, allocator, alpha);
     if (top_candidates->Size() > max_size) {
         throw VsagException(
             ErrorType::INTERNAL_ERROR,
@@ -122,7 +123,7 @@ mutually_connect_new_element(InnerIdType cur_c,
                                  neighbors[j]);
             }
 
-            select_edges_by_heuristic(candidates, max_size, flatten, allocator);
+            select_edges_by_heuristic(candidates, max_size, flatten, allocator, alpha);
 
             Vector<InnerIdType> cand_neighbors(allocator);
             while (not candidates->Empty()) {

--- a/src/impl/pruning_strategy.h
+++ b/src/impl/pruning_strategy.h
@@ -37,6 +37,7 @@ mutually_connect_new_element(InnerIdType cur_c,
                              const GraphInterfacePtr& graph,
                              const FlattenInterfacePtr& flatten,
                              const MutexArrayPtr& neighbors_mutexes,
-                             Allocator* allocator);
+                             Allocator* allocator,
+                             float alpha = 1.0F);
 
 }  // namespace vsag

--- a/src/inner_string_params.h
+++ b/src/inner_string_params.h
@@ -42,6 +42,7 @@ const char* const HGRAPH_BUILD_BY_BASE_QUANTIZATION_KEY = "build_by_base";
 const char* const HGRAPH_GRAPH_KEY = "graph";
 const char* const HGRAPH_BASE_CODES_KEY = "base_codes";
 const char* const HGRAPH_EF_CONSTRUCTION_KEY = "ef_construction";
+const char* const HGRAPH_ALPHA_KEY = "alpha";
 
 // IO param key
 const char* const IO_PARAMS_KEY = "io_params";
@@ -192,6 +193,7 @@ const std::unordered_map<std::string, std::string> DEFAULT_MAP = {
     {"GRAPH_PARAM_INIT_MAX_CAPACITY", GRAPH_PARAM_INIT_MAX_CAPACITY},
     {"BUILD_THREAD_COUNT_KEY", BUILD_THREAD_COUNT_KEY},
     {"HGRAPH_EF_CONSTRUCTION_KEY", HGRAPH_EF_CONSTRUCTION_KEY},
+    {"HGRAPH_ALPHA_KEY", HGRAPH_ALPHA_KEY},
     {"BUCKETS_COUNT_KEY", BUCKETS_COUNT_KEY},
     {"BUCKET_PARAMS_KEY", BUCKET_PARAMS_KEY},
     {"IO_FILE_PATH", IO_FILE_PATH},

--- a/tools/eval/eval_template.yaml
+++ b/tools/eval/eval_template.yaml
@@ -24,4 +24,4 @@ eval_case1:
     range: 0.5
     delete_index_after_search: false # free up storage space used by index
     num_threads_building: 16
-    num_threads_searching: 16[201~
+    num_threads_searching: 16

--- a/tools/eval/eval_template.yaml
+++ b/tools/eval/eval_template.yaml
@@ -24,4 +24,4 @@ eval_case1:
     range: 0.5
     delete_index_after_search: false # free up storage space used by index
     num_threads_building: 16
-    num_threads_searching: 16
+    num_threads_searching: 16[201~


### PR DESCRIPTION
close #1060 

<img width="1899" height="329" alt="alpha=1 0" src="https://github.com/user-attachments/assets/451a8ad3-b167-42b5-b8e5-d262d38082f7" />
<img width="1918" height="342" alt="alpha=1 2" src="https://github.com/user-attachments/assets/fa9f8362-c1fc-4f2f-99df-8d1cff2415ea" />

After alpha is exposed, with Recallavg aligned on the gist-960 dataset, QPS increases by 14.3%.
