### PR TITLE
feat(index): support GetDataByIdWithFlag

### DIFF
--- a/include/vsag/index.h
+++ b/include/vsag/index.h
@@ -44,6 +44,13 @@ struct MergeUnit {
 
 enum class IndexType { HNSW, DISKANN, HGRAPH, IVF, PYRAMID, BRUTEFORCE, SPARSE, SINDI };
 
+#define DATA_FLAG_FLOAT32_VECTOR 0x01
+#define DATA_FLAG_INT8_VECTOR 0x02
+#define DATA_FLAG_SPARSE_VECTOR 0x04
+#define DATA_FLAG_EXTRA_INFO 0x10
+#define DATA_FLAG_ATTRIBUTE 0x20
+#define DATA_FLAG_ID 0x40
+
 class Index {
 public:
     // [basic methods]
@@ -485,11 +492,32 @@ public:
      *
      * @param ids Array of vector IDs for which extra information is requested.
      * @param count Number of IDs in the 'ids' array.
+     * @param selected_data_flag selected data flag, set with DATA_FLAG_*
      * @return tl::expected<DatasetPtr, Error>
      *         - On success: A DatasetPtr containing the extra data, attribute and vector
      *         - On failure: An error object (e.g., invalid ID, out of memory).
      * @throws std::runtime_error If the index implementation does not support this operation
      *            (default behavior for base class).
+     */
+    virtual tl::expected<DatasetPtr, Error>
+    GetDataByIdsWithFlag(const int64_t* ids, int64_t count, uint64_t selected_data_flag) const {
+        throw std::runtime_error("Index doesn't support GetDataByIdsWithFlag");
+    };
+
+    /**
+     * @brief Retrieve all data associated with vectors identified by given IDs.
+     *
+     * This method fetches data stored with the vectors in the index
+     * (e.g., attributes, labels, or extra infos).
+     *
+     * @param ids Array of vector IDs for which extra information is requested.
+     * @param count Number of IDs in the 'ids' array.
+     * @return tl::expected<DatasetPtr, Error>
+     *         - On success: A DatasetPtr containing the extra data, attribute and vector
+     *         - On failure: An error object (e.g., invalid ID, out of memory).
+     * @throws std::runtime_error If the index implementation does not support this operation
+     *            (default behavior for base class).
+     * @note The default implementation returns all data which in current index
      */
     virtual tl::expected<DatasetPtr, Error>
     GetDataByIds(const int64_t* ids, int64_t count) const {

--- a/src/algorithm/brute_force.cpp
+++ b/src/algorithm/brute_force.cpp
@@ -510,4 +510,9 @@ BruteForce::UpdateAttribute(int64_t id,
     this->attr_filter_index_->UpdateBitsetsByAttr(new_attrs, inner_id, 0, origin_attrs);
 }
 
+void
+BruteForce::GetAttributeSetByInnerId(InnerIdType inner_id, AttributeSet* attr) const {
+    this->attr_filter_index_->GetAttribute(0, inner_id, attr);
+}
+
 }  // namespace vsag

--- a/src/algorithm/brute_force.h
+++ b/src/algorithm/brute_force.h
@@ -61,20 +61,23 @@ public:
         return std::make_shared<BruteForce>(this->create_param_ptr_, param);
     }
 
-    IndexType
+    void
+    GetAttributeSetByInnerId(InnerIdType inner_id, AttributeSet* attr) const override;
+
+    [[nodiscard]] IndexType
     GetIndexType() override {
         return IndexType::BRUTEFORCE;
     }
 
-    int64_t
+    [[nodiscard]] int64_t
     GetMemoryUsage() const override;
 
-    std::string
+    [[nodiscard]] std::string
     GetName() const override {
         return INDEX_BRUTE_FORCE;
     }
 
-    int64_t
+    [[nodiscard]] int64_t
     GetNumElements() const override {
         return this->total_count_;
     }
@@ -85,13 +88,13 @@ public:
     void
     InitFeatures() override;
 
-    DatasetPtr
+    [[nodiscard]] DatasetPtr
     KnnSearch(const DatasetPtr& query,
               int64_t k,
               const std::string& parameters,
               const FilterPtr& filter) const override;
 
-    DatasetPtr
+    [[nodiscard]] DatasetPtr
     RangeSearch(const DatasetPtr& query,
                 float radius,
                 const std::string& parameters,
@@ -101,7 +104,7 @@ public:
     bool
     Remove(int64_t label) override;
 
-    DatasetPtr
+    [[nodiscard]] DatasetPtr
     SearchWithRequest(const SearchRequest& request) const override;
 
     void

--- a/src/algorithm/hgraph.h
+++ b/src/algorithm/hgraph.h
@@ -22,7 +22,6 @@
 
 #include "common.h"
 #include "data_cell/attribute_inverted_interface.h"
-#include "data_cell/extra_info_interface.h"
 #include "data_cell/flatten_interface.h"
 #include "data_cell/graph_interface.h"
 #include "data_cell/sparse_graph_datacell_parameter.h"
@@ -82,6 +81,9 @@ public:
 
     uint64_t
     EstimateMemory(uint64_t num_elements) const override;
+
+    void
+    GetAttributeSetByInnerId(InnerIdType inner_id, AttributeSet* attr) const override;
 
     void
     GetCodeByInnerId(InnerIdType inner_id, uint8_t* data) const override;
@@ -326,8 +328,7 @@ private:
 private:
     FlattenInterfacePtr basic_flatten_codes_{nullptr};
     FlattenInterfacePtr high_precise_codes_{nullptr};
-    bool create_new_raw_vector_{false};
-    FlattenInterfacePtr raw_vector_{nullptr};
+
     Vector<GraphInterfacePtr> route_graphs_;
     GraphInterfacePtr bottom_graph_{nullptr};
     SparseGraphDatacellParamPtr hierarchical_datacell_param_{nullptr};
@@ -366,9 +367,6 @@ private:
     uint64_t resize_increase_count_bit_{
         DEFAULT_RESIZE_BIT};  // 2^resize_increase_count_bit_ for resize count
 
-    ExtraInfoInterfacePtr extra_infos_{nullptr};
-    uint64_t extra_info_size_{0};
-
     static constexpr uint64_t DEFAULT_RESIZE_BIT = 10;
 
     std::atomic<int64_t> delete_count_{0};
@@ -376,5 +374,8 @@ private:
     std::shared_ptr<Optimizer<BasicSearcher>> optimizer_;
 
     AttrInvertedInterfacePtr attr_filter_index_{nullptr};
+
+    bool create_new_raw_vector_{false};
+    FlattenInterfacePtr raw_vector_{nullptr};
 };
 }  // namespace vsag

--- a/src/algorithm/inner_index_interface.h
+++ b/src/algorithm/inner_index_interface.h
@@ -17,6 +17,7 @@
 #include <shared_mutex>
 #include <vector>
 
+#include "data_cell/extra_info_interface.h"
 #include "dataset_impl.h"
 #include "index/index_common_param.h"
 #include "index_feature_list.h"
@@ -129,16 +130,22 @@ public:
     }
 
     virtual void
+    GetAttributeSetByInnerId(InnerIdType inner_id, AttributeSet* attr) const {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "Index doesn't support GetAttributeSetByInnerId");
+    }
+
+    virtual void
     GetCodeByInnerId(InnerIdType inner_id, uint8_t* data) const {
         throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
                             "Index doesn't support GetCodeByInnerId");
     }
 
     [[nodiscard]] virtual DatasetPtr
-    GetDataByIds(const int64_t* ids, int64_t count) const {
-        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                            "Index doesn't support GetDataByIds");
-    }
+    GetDataByIds(const int64_t* ids, int64_t count) const;
+
+    [[nodiscard]] virtual DatasetPtr
+    GetDataByIdsWithFlag(const int64_t* ids, int64_t count, uint64_t selected_data_flag) const;
 
     [[nodiscard]] virtual int64_t
     GetEstimateBuildMemory(const int64_t num_elements) const {
@@ -363,15 +370,26 @@ public:
 
 public:
     LabelTablePtr label_table_{nullptr};
-    LabelTablePtr tomb_label_table_{nullptr};
-    Allocator* allocator_{nullptr};
-    IndexFeatureListPtr index_feature_list_{nullptr};
     mutable std::shared_mutex label_lookup_mutex_{};  // lock for label_lookup_ & labels_
-    const ParamPtr create_param_ptr_{nullptr};
+
+    LabelTablePtr tomb_label_table_{nullptr};
+
+    Allocator* const allocator_{nullptr};
     int64_t dim_{0};
-    bool immutable_{false};
     MetricType metric_{MetricType::METRIC_TYPE_L2SQR};
     DataTypes data_type_{DataTypes::DATA_TYPE_FLOAT};
+
+    IndexFeatureListPtr index_feature_list_{nullptr};
+
+    const ParamPtr create_param_ptr_{nullptr};
+    bool immutable_{false};
+
+protected:
+    bool has_raw_vector_{false};
+    bool has_attribute_{false};
+
+    uint64_t extra_info_size_{0};
+    ExtraInfoInterfacePtr extra_infos_{nullptr};
 };
 
 }  // namespace vsag

--- a/src/algorithm/ivf.h
+++ b/src/algorithm/ivf.h
@@ -69,29 +69,32 @@ public:
         return std::make_shared<IVF>(this->create_param_ptr_, param);
     }
 
-    DatasetPtr
-    GetDataByIds(const int64_t* ids, int64_t count) const override;
-
-    IndexType
-    GetIndexType() override {
-        return IndexType::IVF;
-    }
-
-    std::string
-    GetName() const override {
-        return INDEX_IVF;
-    }
-
-    int64_t
-    GetNumElements() const override;
+    void
+    GetAttributeSetByInnerId(InnerIdType inner_id, AttributeSet* attr) const override;
 
     void
     GetCodeByInnerId(InnerIdType inner_id, uint8_t* data) const override;
 
+    [[nodiscard]] IndexType
+    GetIndexType() override {
+        return IndexType::IVF;
+    }
+
+    [[nodiscard]] std::string
+    GetName() const override {
+        return INDEX_IVF;
+    }
+
+    [[nodiscard]] int64_t
+    GetNumElements() const override;
+
+    void
+    GetVectorByInnerId(InnerIdType inner_id, float* data) const override;
+
     void
     InitFeatures() override;
 
-    DatasetPtr
+    [[nodiscard]] DatasetPtr
     KnnSearch(const DatasetPtr& query,
               int64_t k,
               const std::string& parameters,
@@ -100,14 +103,14 @@ public:
     void
     Merge(const std::vector<MergeUnit>& merge_units) override;
 
-    DatasetPtr
+    [[nodiscard]] DatasetPtr
     RangeSearch(const DatasetPtr& query,
                 float radius,
                 const std::string& parameters,
                 const FilterPtr& filter,
                 int64_t limited_size = -1) const override;
 
-    DatasetPtr
+    [[nodiscard]] DatasetPtr
     SearchWithRequest(const SearchRequest& request) const override;
 
     void
@@ -146,9 +149,6 @@ private:
 
     std::pair<BucketIdType, InnerIdType>
     get_location(InnerIdType inner_id) const;
-
-    void
-    get_attr_by_inner_id(InnerIdType inner_id, AttributeSet* attr) const;
 
 private:
     BucketInterfacePtr bucket_{nullptr};

--- a/src/index/index_impl.h
+++ b/src/index/index_impl.h
@@ -153,6 +153,13 @@ public:
         SAFE_CALL(return this->inner_index_->GetDataByIds(ids, count));
     };
 
+    tl::expected<DatasetPtr, Error>
+    GetDataByIdsWithFlag(const int64_t* ids,
+                         int64_t count,
+                         uint64_t selected_data_flag) const override {
+        SAFE_CALL(return this->inner_index_->GetDataByIdsWithFlag(ids, count, selected_data_flag));
+    };
+
     [[nodiscard]] int64_t
     GetEstimateBuildMemory(const int64_t num_elements) const override {
         return this->inner_index_->GetEstimateBuildMemory(num_elements);

--- a/tests/test_index.cpp
+++ b/tests/test_index.cpp
@@ -2180,11 +2180,11 @@ compare_attr_set(const vsag::AttributeSet& attr1, const vsag::AttributeSet& attr
 }
 
 void
-TestIndex::TestGetDataById(const IndexPtr& model, const TestDatasetPtr& dataset) {
-    if (not model->CheckFeature(vsag::SUPPORT_GET_DATA_BY_IDS)) {
+TestIndex::TestGetDataById(const IndexPtr& index, const TestDatasetPtr& dataset) {
+    if (not index->CheckFeature(vsag::SUPPORT_GET_DATA_BY_IDS)) {
         return;
     }
-    auto result = model->GetDataByIds(dataset->base_->GetIds(), dataset->base_->GetNumElements());
+    auto result = index->GetDataByIds(dataset->base_->GetIds(), dataset->base_->GetNumElements());
     REQUIRE(result.has_value());
     auto data = result.value();
     REQUIRE(data->GetNumElements() == dataset->base_->GetNumElements());
@@ -2204,6 +2204,10 @@ TestIndex::TestGetDataById(const IndexPtr& model, const TestDatasetPtr& dataset)
         auto& gt_attr = gt_attrs[i];
         compare_attr_set(attr, gt_attr);
     }
+}
+
+void
+TestIndex::TestGetDataByIdWithFlag(const IndexPtr& index, const TestDatasetPtr& dataset) {
 }
 
 }  // namespace fixtures

--- a/tests/test_index.h
+++ b/tests/test_index.h
@@ -287,7 +287,10 @@ public:
     TestExportIDs(const IndexPtr& index, const TestDatasetPtr& dataset);
 
     static void
-    TestGetDataById(const IndexPtr& model, const TestDatasetPtr& dataset);
+    TestGetDataById(const IndexPtr& index, const TestDatasetPtr& dataset);
+
+    static void
+    TestGetDataByIdWithFlag(const IndexPtr& index, const TestDatasetPtr& dataset);
 
     constexpr static float RECALL_THRESHOLD = 0.95;
 };


### PR DESCRIPTION
closed: #1050 
- get data/attribute/extrainfo with flag

## Summary by Sourcery

Introduce a flag-based API for retrieving vector data, attributes, extra info, and IDs by label in the index, unify the logic in the base interface, and update concrete index implementations to support the new operations.

New Features:
- Add GetDataByIdsWithFlag API to retrieve selected data components by ID based on DATA_FLAG_* constants
- Extend Index and InnerIndexInterface with flag definitions and default implementations for GetDataByIds and GetDataByIdsWithFlag
- Expose GetAttributeSetByInnerId in inner index interface and override it in IVF, HGraph, and BruteForce implementations

Enhancements:
- Unify data fetching logic in InnerIndexInterface to delegate to the new flag-based method
- Refactor IVF to remove its custom GetDataByIds and rely on the generic base implementation
- Add internal tracking flags (has_raw_vector_, has_attribute_, extra_info_size_) and extra info support across index types

Tests:
- Update TestGetDataById to use the new interface naming
- Add stub for TestGetDataByIdWithFlag in test fixtures to prepare for flag-based testing