### PR TITLE
test(ivf): refactor ivf fp16 test on cosine metric

### DIFF
--- a/tests/test_ivf.cpp
+++ b/tests/test_ivf.cpp
@@ -383,8 +383,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::IVFTestIndex,
 }
 
 static void
-TestIVFBuildAndContinueAdd(const fixtures::IVFTestIndexPtr& test_index,
-                           const fixtures::IVFResourcePtr& resource) {
+TestIVFBuildAndContinueAdd(const fixtures::IVFResourcePtr& resource) {
     using namespace fixtures;
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
@@ -394,6 +393,9 @@ TestIVFBuildAndContinueAdd(const fixtures::IVFTestIndexPtr& test_index,
                 for (auto [base_quantization_str, recall] : resource->test_cases) {
                     if (train_type == "kmeans") {
                         recall *= 0.8F;  // Kmeans may not achieve high recall in random datasets
+                    }
+                    if (base_quantization_str == "fp16") {
+                        recall *= (1 - dim / 8192.0F);
                     }
                     auto count = std::min(300, static_cast<int32_t>(dim / 4));
                     auto search_param =
@@ -409,7 +411,7 @@ TestIVFBuildAndContinueAdd(const fixtures::IVFTestIndexPtr& test_index,
                     vsag::Options::Instance().set_block_size_limit(size);
                     auto param = IVFTestIndex::GenerateIVFBuildParametersString(
                         metric_type, dim, base_quantization_str, 300, train_type);
-                    auto index = TestIndex::TestFactory(test_index->name, param, true);
+                    auto index = TestIndex::TestFactory(IVFTestIndex::name, param, true);
                     auto dataset = IVFTestIndex::pool.GetDatasetAndCreate(
                         dim, resource->base_count, metric_type);
                     TestIndex::TestContinueAdd(index, dataset, true);
@@ -426,18 +428,17 @@ TestIVFBuildAndContinueAdd(const fixtures::IVFTestIndexPtr& test_index,
 TEST_CASE("[PR] IVF Build & ContinueAdd Test", "[ft][ivf][pr][concurrent]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(true);
-    TestIVFBuildAndContinueAdd(test_index, resource);
+    TestIVFBuildAndContinueAdd(resource);
 }
 
 TEST_CASE("[Daily] IVF Build & ContinueAdd Test", "[ft][ivf][daily][concurrent]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(false);
-    TestIVFBuildAndContinueAdd(test_index, resource);
+    TestIVFBuildAndContinueAdd(resource);
 }
 
 static void
-TestIVFBuildWithResidual(const fixtures::IVFTestIndexPtr& test_index,
-                         const fixtures::IVFResourcePtr& resource) {
+TestIVFBuildWithResidual(const fixtures::IVFResourcePtr& resource) {
     using namespace fixtures;
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
@@ -457,6 +458,9 @@ TestIVFBuildWithResidual(const fixtures::IVFTestIndexPtr& test_index,
                     if (train_type == "kmeans") {
                         recall *= 0.8F;  // Kmeans may not achieve high recall in random datasets
                     }
+                    if (base_quantization_str == "fp16") {
+                        recall *= (1 - dim / 8192.0F);
+                    }
                     auto search_param =
                         fmt::format(fixtures::search_param_tmp, std::max(250, count));
                     INFO(
@@ -470,7 +474,7 @@ TestIVFBuildWithResidual(const fixtures::IVFTestIndexPtr& test_index,
                     vsag::Options::Instance().set_block_size_limit(size);
                     auto param = IVFTestIndex::GenerateIVFBuildParametersString(
                         metric_type, dim, base_quantization_str, 300, train_type, true);
-                    auto index = IVFTestIndex::TestFactory(test_index->name, param, true);
+                    auto index = IVFTestIndex::TestFactory(IVFTestIndex::name, param, true);
                     auto dataset = IVFTestIndex::pool.GetDatasetAndCreate(
                         dim, resource->base_count, metric_type);
                     IVFTestIndex::TestContinueAdd(index, dataset, true);
@@ -487,18 +491,17 @@ TestIVFBuildWithResidual(const fixtures::IVFTestIndexPtr& test_index,
 TEST_CASE("[PR] IVF Build with Residual", "[ft][ivf][pr]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(true);
-    TestIVFBuildWithResidual(test_index, resource);
+    TestIVFBuildWithResidual(resource);
 }
 
 TEST_CASE("[Daily] IVF Build with Residual", "[ft][ivf][daily]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(false);
-    TestIVFBuildWithResidual(test_index, resource);
+    TestIVFBuildWithResidual(resource);
 }
 
 static void
-TestIVFBuild(const fixtures::IVFTestIndexPtr& test_index,
-             const fixtures::IVFResourcePtr& resource) {
+TestIVFBuild(const fixtures::IVFResourcePtr& resource) {
     using namespace fixtures;
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
@@ -518,6 +521,9 @@ TestIVFBuild(const fixtures::IVFTestIndexPtr& test_index,
                     auto count = std::min(300, static_cast<int32_t>(dim / 4));
                     if (train_type == "kmeans") {
                         recall *= 0.8F;  // Kmeans may not achieve high recall in random datasets
+                    }
+                    if (base_quantization_str == "fp16") {
+                        recall *= (1 - dim / 8192.0F);
                     }
                     auto search_thread_count = GENERATE(1, 3);
                     auto search_param =
@@ -558,18 +564,17 @@ TestIVFBuild(const fixtures::IVFTestIndexPtr& test_index,
 TEST_CASE("[PR] IVF Build", "[ft][ivf][pr]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(true);
-    TestIVFBuild(test_index, resource);
+    TestIVFBuild(resource);
 }
 
 TEST_CASE("[Daily] IVF Build", "[ft][ivf][daily]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(false);
-    TestIVFBuild(test_index, resource);
+    TestIVFBuild(resource);
 }
 
 static void
-TestIVFSearchOvertime(const fixtures::IVFTestIndexPtr& test_index,
-                      const fixtures::IVFResourcePtr& resource) {
+TestIVFSearchOvertime(const fixtures::IVFResourcePtr& resource) {
     using namespace fixtures;
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
@@ -628,18 +633,17 @@ TestIVFSearchOvertime(const fixtures::IVFTestIndexPtr& test_index,
 TEST_CASE("[PR] IVF Search Overtime", "[ft][ivf][pr]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(true);
-    TestIVFSearchOvertime(test_index, resource);
+    TestIVFSearchOvertime(resource);
 }
 
 TEST_CASE("[Daily] IVF Search Overtime", "[ft][ivf][daily]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(false);
-    TestIVFSearchOvertime(test_index, resource);
+    TestIVFSearchOvertime(resource);
 }
 
 static void
-TestIVFBuildWithLargeK(const fixtures::IVFTestIndexPtr& test_index,
-                       const fixtures::IVFResourcePtr& resource) {
+TestIVFBuildWithLargeK(const fixtures::IVFResourcePtr& resource) {
     using namespace fixtures;
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
@@ -682,18 +686,17 @@ TestIVFBuildWithLargeK(const fixtures::IVFTestIndexPtr& test_index,
 TEST_CASE("[PR] IVF Build With Large K", "[ft][ivf][pr]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(true);
-    TestIVFBuildWithLargeK(test_index, resource);
+    TestIVFBuildWithLargeK(resource);
 }
 
 TEST_CASE("[Daily] IVF Build With Large K", "[ft][ivf][daily]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(false);
-    TestIVFBuildWithLargeK(test_index, resource);
+    TestIVFBuildWithLargeK(resource);
 }
 
 static void
-TestIVFWithAttr(const fixtures::IVFTestIndexPtr& test_index,
-                const fixtures::IVFResourcePtr& resource) {
+TestIVFWithAttr(const fixtures::IVFResourcePtr& resource) {
     using namespace fixtures;
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
@@ -707,6 +710,9 @@ TestIVFWithAttr(const fixtures::IVFTestIndexPtr& test_index,
                 for (auto [base_quantization_str, recall] : tmp_test_cases) {
                     if (train_type == "kmeans") {
                         recall *= 0.8F;  // Kmeans may not achieve high recall in random datasets
+                    }
+                    if (base_quantization_str == "fp16") {
+                        recall *= (1 - dim / 8192.0F);
                     }
                     auto count = std::min(300, static_cast<int32_t>(dim / 4));
                     auto search_param =
@@ -754,18 +760,17 @@ TestIVFWithAttr(const fixtures::IVFTestIndexPtr& test_index,
 TEST_CASE("[PR] IVF Build With Attribute", "[ft][ivf][pr]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(true);
-    TestIVFWithAttr(test_index, resource);
+    TestIVFWithAttr(resource);
 }
 
 TEST_CASE("[Daily] IVF Build With Attribute", "[ft][ivf][daily]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(false);
-    TestIVFWithAttr(test_index, resource);
+    TestIVFWithAttr(resource);
 }
 
 static void
-TestIVFExportModel(const fixtures::IVFTestIndexPtr& test_index,
-                   const fixtures::IVFResourcePtr& resource) {
+TestIVFExportModel(const fixtures::IVFResourcePtr& resource) {
     using namespace fixtures;
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
@@ -807,17 +812,17 @@ TestIVFExportModel(const fixtures::IVFTestIndexPtr& test_index,
 TEST_CASE("[PR] IVF Export Model", "[ft][ivf][pr]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(true);
-    TestIVFExportModel(test_index, resource);
+    TestIVFExportModel(resource);
 }
 
 TEST_CASE("[Daily] IVF IVF Export Model", "[ft][ivf][daily]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(false);
-    TestIVFExportModel(test_index, resource);
+    TestIVFExportModel(resource);
 }
 
 static void
-TestIVFAdd(const fixtures::IVFTestIndexPtr& test_index, const fixtures::IVFResourcePtr& resource) {
+TestIVFAdd(const fixtures::IVFResourcePtr& resource) {
     using namespace fixtures;
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
@@ -859,18 +864,17 @@ TestIVFAdd(const fixtures::IVFTestIndexPtr& test_index, const fixtures::IVFResou
 TEST_CASE("[PR] IVF Add", "[ft][ivf][pr]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(true);
-    TestIVFAdd(test_index, resource);
+    TestIVFAdd(resource);
 }
 
 TEST_CASE("[Daily] IVF Add", "[ft][ivf][daily]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(false);
-    TestIVFAdd(test_index, resource);
+    TestIVFAdd(resource);
 }
 
 static void
-TestIVFMerge(const fixtures::IVFTestIndexPtr& test_index,
-             const fixtures::IVFResourcePtr& resource) {
+TestIVFMerge(const fixtures::IVFResourcePtr& resource) {
     using namespace fixtures;
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
@@ -880,6 +884,9 @@ TestIVFMerge(const fixtures::IVFTestIndexPtr& test_index,
                 for (auto [base_quantization_str, recall] : resource->test_cases) {
                     if (train_type == "kmeans") {
                         recall *= 0.8F;  // Kmeans may not achieve high recall in random datasets
+                    }
+                    if (base_quantization_str == "fp16") {
+                        recall *= (1 - dim / 8192.0F);
                     }
                     auto count = std::min(300, static_cast<int32_t>(dim / 4));
                     auto search_param =
@@ -915,18 +922,17 @@ TestIVFMerge(const fixtures::IVFTestIndexPtr& test_index,
 TEST_CASE("[PR] IVF Merge", "[ft][ivf][pr]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(true);
-    TestIVFMerge(test_index, resource);
+    TestIVFMerge(resource);
 }
 
 TEST_CASE("[Daily] IVF Merge", "[ft][ivf][daily]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(false);
-    TestIVFMerge(test_index, resource);
+    TestIVFMerge(resource);
 }
 
 static void
-TestIVFConcurrentAdd(const fixtures::IVFTestIndexPtr& test_index,
-                     const fixtures::IVFResourcePtr& resource) {
+TestIVFConcurrentAdd(const fixtures::IVFResourcePtr& resource) {
     using namespace fixtures;
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
@@ -939,6 +945,9 @@ TestIVFConcurrentAdd(const fixtures::IVFTestIndexPtr& test_index,
                     }
                     if (base_quantization_str == "pqfs,fp16") {
                         continue;
+                    }
+                    if (base_quantization_str == "fp16") {
+                        recall *= (1 - dim / 8192.0F);
                     }
                     auto count = std::min(300, static_cast<int32_t>(dim / 4));
                     auto search_param =
@@ -971,18 +980,17 @@ TestIVFConcurrentAdd(const fixtures::IVFTestIndexPtr& test_index,
 TEST_CASE("[PR] IVF Concurrent Add", "[ft][ivf][pr]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(true);
-    TestIVFConcurrentAdd(test_index, resource);
+    TestIVFConcurrentAdd(resource);
 }
 
 TEST_CASE("[Daily] IVF Concurrent Add", "[ft][ivf][daily]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(false);
-    TestIVFConcurrentAdd(test_index, resource);
+    TestIVFConcurrentAdd(resource);
 }
 
 static void
-TestIVFSerialize(const fixtures::IVFTestIndexPtr& test_index,
-                 const fixtures::IVFResourcePtr& resource) {
+TestIVFSerialize(const fixtures::IVFResourcePtr& resource) {
     using namespace fixtures;
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
@@ -1045,18 +1053,17 @@ TestIVFSerialize(const fixtures::IVFTestIndexPtr& test_index,
 TEST_CASE("[PR] IVF Serialize File", "[ft][ivf][serialization][pr]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(true);
-    TestIVFSerialize(test_index, resource);
+    TestIVFSerialize(resource);
 }
 
 TEST_CASE("[Daily] IVF Serialize File", "[ft][ivf][serialization][daily]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(false);
-    TestIVFSerialize(test_index, resource);
+    TestIVFSerialize(resource);
 }
 
 static void
-TestIVFClone(const fixtures::IVFTestIndexPtr& test_index,
-             const fixtures::IVFResourcePtr& resource) {
+TestIVFClone(const fixtures::IVFResourcePtr& resource) {
     using namespace fixtures;
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
@@ -1097,18 +1104,17 @@ TestIVFClone(const fixtures::IVFTestIndexPtr& test_index,
 TEST_CASE("[PR] IVF Clone", "[ft][ivf][pr]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(true);
-    TestIVFClone(test_index, resource);
+    TestIVFClone(resource);
 }
 
 TEST_CASE("[Daily] IVF Clone", "[ft][ivf][daily]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(false);
-    TestIVFClone(test_index, resource);
+    TestIVFClone(resource);
 }
 
 static void
-TestIVFRandomAllocator(const fixtures::IVFTestIndexPtr& test_index,
-                       const fixtures::IVFResourcePtr& resource) {
+TestIVFRandomAllocator(const fixtures::IVFResourcePtr& resource) {
     auto allocator = std::make_shared<fixtures::RandomAllocator>();
     using namespace fixtures;
     auto origin_size = vsag::Options::Instance().block_size_limit();
@@ -1152,18 +1158,17 @@ TestIVFRandomAllocator(const fixtures::IVFTestIndexPtr& test_index,
 TEST_CASE("[PR] IVF Build & ContinueAdd Test With Random Allocator", "[ft][ivf][pr]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(true);
-    TestIVFRandomAllocator(test_index, resource);
+    TestIVFRandomAllocator(resource);
 }
 
 TEST_CASE("[Daily] IVF Build & ContinueAdd Test With Random Allocator", "[ft][ivf][daily]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(false);
-    TestIVFRandomAllocator(test_index, resource);
+    TestIVFRandomAllocator(resource);
 }
 
 static void
-TestIVFEstimateMemory(const fixtures::IVFTestIndexPtr& test_index,
-                      const fixtures::IVFResourcePtr& resource) {
+TestIVFEstimateMemory(const fixtures::IVFResourcePtr& resource) {
     using namespace fixtures;
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
@@ -1203,18 +1208,17 @@ TestIVFEstimateMemory(const fixtures::IVFTestIndexPtr& test_index,
 TEST_CASE("[PR] IVF Estimate Memory", "[ft][ivf][pr]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(true);
-    TestIVFEstimateMemory(test_index, resource);
+    TestIVFEstimateMemory(resource);
 }
 
 TEST_CASE("[Daily] IVF Estimate Memory", "[ft][ivf][daily]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(false);
-    TestIVFEstimateMemory(test_index, resource);
+    TestIVFEstimateMemory(resource);
 }
 
 static void
-TestIVFBuildMultiBucketsPerData(const fixtures::IVFTestIndexPtr& test_index,
-                                const fixtures::IVFResourcePtr& resource) {
+TestIVFBuildMultiBucketsPerData(const fixtures::IVFResourcePtr& resource) {
     using namespace fixtures;
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
@@ -1224,6 +1228,9 @@ TestIVFBuildMultiBucketsPerData(const fixtures::IVFTestIndexPtr& test_index,
                 for (auto [base_quantization_str, recall] : resource->test_cases) {
                     if (train_type == "kmeans") {
                         recall *= 0.8F;  // Kmeans may not achieve high recall in random datasets
+                    }
+                    if (base_quantization_str == "fp16") {
+                        recall *= (1 - dim / 8192.0F);
                     }
                     auto count = std::min(300, static_cast<int32_t>(dim / 4));
                     auto search_param =
@@ -1256,18 +1263,17 @@ TestIVFBuildMultiBucketsPerData(const fixtures::IVFTestIndexPtr& test_index,
 TEST_CASE("[PR] IVF Build Multi Buckets Per Data", "[ft][ivf][pr]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(true);
-    TestIVFBuildMultiBucketsPerData(test_index, resource);
+    TestIVFBuildMultiBucketsPerData(resource);
 }
 
 TEST_CASE("[Daily] IVF Build Multi Buckets Per Data", "[ft][ivf][daily]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(false);
-    TestIVFBuildMultiBucketsPerData(test_index, resource);
+    TestIVFBuildMultiBucketsPerData(resource);
 }
 
 static void
-TestIVFGNOIMIBuild(const fixtures::IVFTestIndexPtr& test_index,
-                   const fixtures::IVFResourcePtr& resource) {
+TestIVFGNOIMIBuild(const fixtures::IVFResourcePtr& resource) {
     using namespace fixtures;
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
@@ -1275,6 +1281,9 @@ TestIVFGNOIMIBuild(const fixtures::IVFTestIndexPtr& test_index,
         for (auto dim : resource->dims) {
             for (auto train_type : resource->train_types) {
                 for (auto [base_quantization_str, recall] : resource->test_cases) {
+                    if (base_quantization_str == "fp16") {
+                        recall *= (1 - dim / 8192.0F);
+                    }
                     auto count = std::min(400, static_cast<int32_t>(dim / 4));
                     auto search_param =
                         fmt::format(fixtures::search_param_tmp, std::max(350, count));
@@ -1306,18 +1315,17 @@ TestIVFGNOIMIBuild(const fixtures::IVFTestIndexPtr& test_index,
 TEST_CASE("[PR] IVF GNO-IMI Build", "[ft][ivf][pr]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(true);
-    TestIVFGNOIMIBuild(test_index, resource);
+    TestIVFGNOIMIBuild(resource);
 }
 
 TEST_CASE("[Daily] IVF GNO-IMI Build", "[ft][ivf][daily]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(false);
-    TestIVFGNOIMIBuild(test_index, resource);
+    TestIVFGNOIMIBuild(resource);
 }
 
 static void
-TestIVFGNOIMIBuildWithResidual(const fixtures::IVFTestIndexPtr& test_index,
-                               const fixtures::IVFResourcePtr& resource) {
+TestIVFGNOIMIBuildWithResidual(const fixtures::IVFResourcePtr& resource) {
     using namespace fixtures;
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
@@ -1328,6 +1336,9 @@ TestIVFGNOIMIBuildWithResidual(const fixtures::IVFTestIndexPtr& test_index,
                 for (auto [base_quantization_str, recall] : resource->test_cases) {
                     if (train_type == "kmeans") {
                         recall *= 0.8F;  // Kmeans may not achieve high recall in random datasets
+                    }
+                    if (base_quantization_str == "fp16") {
+                        recall *= (1 - dim / 8192.0F);
                     }
                     if (base_quantization_str == "sq8_uniform,fp32") {
                         continue;  // sq8_uniform reduce recall when using residual in GNO-IMI
@@ -1363,11 +1374,11 @@ TestIVFGNOIMIBuildWithResidual(const fixtures::IVFTestIndexPtr& test_index,
 TEST_CASE("[PR] IVF GNO-IMI Build with Residual", "[ft][ivf][pr]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(true);
-    TestIVFGNOIMIBuildWithResidual(test_index, resource);
+    TestIVFGNOIMIBuildWithResidual(resource);
 }
 
 TEST_CASE("[Daily] IVF GNO-IMI Build with Residual", "[ft][ivf][daily]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(false);
-    TestIVFGNOIMIBuildWithResidual(test_index, resource);
+    TestIVFGNOIMIBuildWithResidual(resource);
 }


### PR DESCRIPTION
## Summary by Sourcery

Refactor IVF test suite to simplify helper signatures and incorporate recall adjustments for fp16 quantization.

New Features:
- Introduce a recall scaling factor for fp16 base quantization in build, residual, concurrent add, and GNO-IMI residual tests to better reflect precision constraints

Enhancements:
- Remove the terraform parameter test_index from all IVF test helper functions and TEST_CASE invocations
- Standardize TestFactory calls to use the static IVFTestIndex::name instead of dynamic names

Tests:
- Update all IVF TEST_CASE definitions to align with the refactored helper function signatures