### PR TITLE
fix(sindi): fix redundant results in the return data

### DIFF
--- a/src/algorithm/sindi/sindi.cpp
+++ b/src/algorithm/sindi/sindi.cpp
@@ -123,7 +123,7 @@ SINDI::search_impl(const SparseTermComputerPtr& computer,
                    const InnerSearchParam& inner_param) const {
     // computer and heap
     MaxHeap heap(this->allocator_);
-    uint32_t k = 0;
+    int64_t k = 0;
 
     if constexpr (mode == KNN_SEARCH) {
         k = inner_param.topk;
@@ -195,13 +195,14 @@ SINDI::search_impl(const SparseTermComputerPtr& computer,
             k = inner_param.range_search_limit_size;
         }
     }
-    auto [results, ret_dists, ret_ids] = create_fast_dataset(static_cast<int64_t>(k), allocator_);
+
+    int64_t cur_size = std::min(static_cast<int64_t>(heap.size()), k);
+
+    auto [results, ret_dists, ret_ids] = create_fast_dataset(cur_size, allocator_);
 
     while (heap.size() > k) {
         heap.pop();
     }
-
-    int cur_size = static_cast<int>(heap.size());
 
     for (int j = cur_size - 1; j >= 0; j--) {
         ret_dists[j] = 1 + heap.top().first;  // dist = -ip -> 1 + dist = 1 - ip

--- a/src/algorithm/sindi/sindi.cpp
+++ b/src/algorithm/sindi/sindi.cpp
@@ -190,7 +190,7 @@ SINDI::search_impl(const SparseTermComputerPtr& computer,
 
     // low precision
     if constexpr (mode == RANGE_SEARCH) {
-        k = heap.size();
+        k = static_cast<int64_t>(heap.size());
         if (inner_param.range_search_limit_size != -1) {
             k = inner_param.range_search_limit_size;
         }
@@ -204,7 +204,7 @@ SINDI::search_impl(const SparseTermComputerPtr& computer,
         heap.pop();
     }
 
-    for (int j = cur_size - 1; j >= 0; j--) {
+    for (auto j = cur_size - 1; j >= 0; j--) {
         ret_dists[j] = 1 + heap.top().first;  // dist = -ip -> 1 + dist = 1 - ip
         ret_ids[j] = label_table_->GetLabelById(heap.top().second);
         heap.pop();

--- a/src/data_cell/sparse_term_datacell.cpp
+++ b/src/data_cell/sparse_term_datacell.cpp
@@ -87,9 +87,11 @@ SparseTermDataCell::InsertHeap(float* dists,
                         }
                     }
 
-                    heap.emplace(dists[id], id + offset_id);
-                    cur_heap_top = heap.top().first;
-                    dists[id] = 0;
+                    if (dists[id] != 0) {
+                        heap.emplace(dists[id], id + offset_id);
+                        cur_heap_top = heap.top().first;
+                        dists[id] = 0;
+                    }
 
                     if (heap.size() == n_candidate) {
                         break;


### PR DESCRIPTION
close: #1107
close: #1112
## Summary by Sourcery

Fix redundant result entries in SINDI search by sizing output buffers to the actual number of heap items and preventing zero-distance candidates from being inserted into the sparse term heap.

Bug Fixes:
- Allocate result arrays in search_impl based on min(heap.size(), k) to avoid empty placeholders in return data.
- Guard heap insertion in SparseTermDataCell to skip zero-distance entries and prevent duplicate results.