### PR TITLE
feat(sindi): support several interfaces

### DIFF
--- a/include/vsag/index.h
+++ b/include/vsag/index.h
@@ -401,6 +401,18 @@ public:
     };
 
     /**
+     * @brief Calculate the distance between the query and the vector of the given ID.
+     *
+     * @param vector is the embedding of query
+     * @param id is the unique identifier of the vector to be calculated in the index.
+     * @return result is the distance between the query and the vector of the given ID.
+     */
+    virtual tl::expected<float, Error>
+    CalcDistanceById(const DatasetPtr& vector, int64_t id) const {
+        throw std::runtime_error("Index doesn't support get distance by id");
+    };
+
+    /**
      * @brief Calculate the distance between the query and the vector of the given ID for batch.
      *
      * @param query is the embedding of query

--- a/src/algorithm/inner_index_interface.h
+++ b/src/algorithm/inner_index_interface.h
@@ -54,6 +54,12 @@ public:
     Build(const DatasetPtr& base);
 
     virtual float
+    CalcDistanceById(const DatasetPtr& vector, int64_t id) const {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "Index doesn't support calculate distance by id");
+    };
+
+    virtual float
     CalcDistanceById(const float* query, int64_t id) const {
         throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
                             "Index doesn't support calculate distance by id");
@@ -357,23 +363,6 @@ public:
 
     virtual bool
     UpdateVector(int64_t id, const DatasetPtr& new_base, bool force_update = false) {
-    virtual float
-    CalcDistanceById(const DatasetPtr& vector, int64_t id) const {
-        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                            "Index doesn't support calculate distance by id");
-    };
-
-    virtual DatasetPtr
-    CalDistanceById(const float* query, const int64_t* ids, int64_t count) const;
-
-    virtual std::pair<int64_t, int64_t>
-    GetMinAndMaxId() const {
-        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                            "Index doesn't support GetMinAndMaxId");
-    }
-
-    virtual void
-    GetExtraInfoByIds(const int64_t* ids, int64_t count, char* extra_infos) const {
         throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
                             "Index doesn't support UpdateVector");
     }

--- a/src/algorithm/inner_index_interface.h
+++ b/src/algorithm/inner_index_interface.h
@@ -357,6 +357,23 @@ public:
 
     virtual bool
     UpdateVector(int64_t id, const DatasetPtr& new_base, bool force_update = false) {
+    virtual float
+    CalcDistanceById(const DatasetPtr& vector, int64_t id) const {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "Index doesn't support calculate distance by id");
+    };
+
+    virtual DatasetPtr
+    CalDistanceById(const float* query, const int64_t* ids, int64_t count) const;
+
+    virtual std::pair<int64_t, int64_t>
+    GetMinAndMaxId() const {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "Index doesn't support GetMinAndMaxId");
+    }
+
+    virtual void
+    GetExtraInfoByIds(const int64_t* ids, int64_t count, char* extra_infos) const {
         throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
                             "Index doesn't support UpdateVector");
     }

--- a/src/algorithm/sindi/sindi.cpp
+++ b/src/algorithm/sindi/sindi.cpp
@@ -398,6 +398,7 @@ SINDI::InitFeatures() {
 
     // info
     this->index_feature_list_->SetFeature(IndexFeature::SUPPORT_CAL_DISTANCE_BY_ID);
+    this->index_feature_list_->SetFeature(IndexFeature::SUPPORT_ESTIMATE_MEMORY);
 
     // concurrency
     this->index_feature_list_->SetFeatures({IndexFeature::SUPPORT_SEARCH_CONCURRENT,

--- a/src/algorithm/sindi/sindi.h
+++ b/src/algorithm/sindi/sindi.h
@@ -87,6 +87,18 @@ public:
         return cur_element_count_;
     }
 
+    [[nodiscard]] uint64_t
+    EstimateMemory(uint64_t num_elements) const override;
+
+    float
+    CalcDistanceById(const DatasetPtr& vector, int64_t id) const override;
+
+    bool
+    UpdateId(int64_t old_id, int64_t new_id) override;
+
+    std::pair<int64_t, int64_t>
+    GetMinAndMaxId() const override;
+
 private:
     template <InnerSearchMode mode>
     DatasetPtr

--- a/src/algorithm/sparse_index.cpp
+++ b/src/algorithm/sparse_index.cpp
@@ -196,4 +196,36 @@ SparseIndex::CalcDistanceById(const DatasetPtr& vector, int64_t id) const {
     return CalDistanceByIdUnsafe(sorted_ids, sorted_vals, inner_id);
 }
 
+void
+SparseIndex::InitFeatures() {
+    // build & add
+    this->index_feature_list_->SetFeatures({
+        IndexFeature::SUPPORT_BUILD,
+        IndexFeature::SUPPORT_ADD_AFTER_BUILD,
+    });
+
+    // search
+    this->index_feature_list_->SetFeatures({
+        IndexFeature::SUPPORT_KNN_SEARCH,
+        IndexFeature::SUPPORT_KNN_SEARCH_WITH_ID_FILTER,
+        IndexFeature::SUPPORT_RANGE_SEARCH,
+        IndexFeature::SUPPORT_RANGE_SEARCH_WITH_ID_FILTER,
+    });
+
+    // serialize
+    this->index_feature_list_->SetFeatures({
+        IndexFeature::SUPPORT_DESERIALIZE_BINARY_SET,
+        IndexFeature::SUPPORT_DESERIALIZE_FILE,
+        IndexFeature::SUPPORT_DESERIALIZE_READER_SET,
+        IndexFeature::SUPPORT_SERIALIZE_BINARY_SET,
+        IndexFeature::SUPPORT_SERIALIZE_FILE,
+    });
+
+    // info
+    this->index_feature_list_->SetFeature(IndexFeature::SUPPORT_CAL_DISTANCE_BY_ID);
+
+    // metric
+    this->index_feature_list_->SetFeature(IndexFeature::SUPPORT_METRIC_TYPE_INNER_PRODUCT);
+}
+
 }  // namespace vsag

--- a/src/algorithm/sparse_index.cpp
+++ b/src/algorithm/sparse_index.cpp
@@ -188,4 +188,12 @@ SparseIndex::CalDistanceByIdUnsafe(Vector<uint32_t>& sorted_ids,
                         (float*)(datas_[inner_id] + 1 + datas_[inner_id][0]));
 }
 
+float
+SparseIndex::CalcDistanceById(const DatasetPtr& vector, int64_t id) const {
+    const auto* sparse_vectors = vector->GetSparseVectors();
+    uint32_t inner_id = this->label_table_->GetIdByLabel(id);
+    auto [sorted_ids, sorted_vals] = sort_sparse_vector(sparse_vectors[0]);
+    return CalDistanceByIdUnsafe(sorted_ids, sorted_vals, inner_id);
+}
+
 }  // namespace vsag

--- a/src/algorithm/sparse_index.h
+++ b/src/algorithm/sparse_index.h
@@ -114,9 +114,7 @@ public:
     }
 
     void
-    InitFeatures() override {
-        this->index_feature_list_->SetFeature(IndexFeature::SUPPORT_CAL_DISTANCE_BY_ID);
-    }
+    InitFeatures() override;
 
     float
     CalDistanceByIdUnsafe(Vector<uint32_t>& sorted_ids,

--- a/src/algorithm/sparse_index.h
+++ b/src/algorithm/sparse_index.h
@@ -87,10 +87,6 @@ public:
         return cur_element_count_;
     }
 
-    void
-    InitFeatures() override {
-    }
-
     DatasetPtr
     KnnSearch(const DatasetPtr& query,
               int64_t k,
@@ -112,6 +108,26 @@ public:
             writer.Write((char*)datas_[i], (2 * len + 1) * sizeof(uint32_t));
         }
         label_table_->Serialize(writer);
+    }
+
+
+    int64_t
+    GetNumElements() const override {
+        return cur_element_count_;
+    }
+
+    DatasetPtr
+    CalDistanceById(const float* query, const int64_t* ids, int64_t count) const override {
+        throw VsagException(vsag::ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "no support CalDistanceById in " + GetName());
+    }
+
+    float
+    CalcDistanceById(const DatasetPtr& vector, int64_t id) const override;
+
+    void
+    InitFeatures() override {
+        this->index_feature_list_->SetFeature(IndexFeature::SUPPORT_CAL_DISTANCE_BY_ID);
     }
 
     float

--- a/src/algorithm/sparse_index.h
+++ b/src/algorithm/sparse_index.h
@@ -52,6 +52,9 @@ public:
                             "no support CalDistanceById in " + GetName());
     }
 
+    float
+    CalcDistanceById(const DatasetPtr& vector, int64_t id) const override;
+
     void
     Deserialize(StreamReader& reader) override {
         StreamReader::ReadObj(reader, cur_element_count_);
@@ -109,21 +112,6 @@ public:
         }
         label_table_->Serialize(writer);
     }
-
-
-    int64_t
-    GetNumElements() const override {
-        return cur_element_count_;
-    }
-
-    DatasetPtr
-    CalDistanceById(const float* query, const int64_t* ids, int64_t count) const override {
-        throw VsagException(vsag::ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                            "no support CalDistanceById in " + GetName());
-    }
-
-    float
-    CalcDistanceById(const DatasetPtr& vector, int64_t id) const override;
 
     void
     InitFeatures() override {

--- a/src/common.h
+++ b/src/common.h
@@ -50,3 +50,7 @@ constexpr static const uint32_t UPDATE_CHECK_SEARCH_K = 10;
 constexpr static const uint32_t GENERATE_SEARCH_L = 400;
 constexpr static const uint32_t UPDATE_CHECK_SEARCH_L = 100;
 constexpr static const float GENERATE_OMEGA = 0.51;
+
+// sindi related
+constexpr static const uint32_t ESTIMATE_DOC_TERM = 100;
+constexpr static const uint32_t ESTIMATE_DOC_DIM = 50000;

--- a/src/data_cell/sparse_term_datacell.cpp
+++ b/src/data_cell/sparse_term_datacell.cpp
@@ -196,7 +196,7 @@ SparseTermDataCell::CalcDistanceByInnerId(const SparseTermComputerPtr& computer,
             it, term_ids_[term].data(), term_datas_[term].data(), term_sizes_[term], base_id, &ip);
     }
     computer->ResetTerm();
-    return 1 - ip;
+    return 1 + ip;
 }
 
 void

--- a/src/data_cell/sparse_term_datacell.cpp
+++ b/src/data_cell/sparse_term_datacell.cpp
@@ -174,6 +174,31 @@ SparseTermDataCell::ResizeTermList(InnerIdType new_term_capacity) {
     term_sizes_.resize(term_capacity_, 0);
 }
 
+float
+SparseTermDataCell::CalcDistanceByInnerId(const SparseTermComputerPtr& computer, uint32_t base_id) {
+    float ip = 0;
+    while (computer->HasNextTerm()) {
+        auto it = computer->NextTermIter();
+        auto term = computer->GetTerm(it);
+        if (computer->HasNextTerm()) {
+            auto next_it = it + 1;
+            auto next_term = computer->GetTerm(next_it);
+            if (next_term >= term_ids_.size()) {
+                continue;
+            }
+            __builtin_prefetch(term_ids_[next_term].data(), 0, 3);
+            __builtin_prefetch(term_datas_[next_term].data(), 0, 3);
+        }
+        if (term >= term_ids_.size()) {
+            continue;
+        }
+        computer->ScanForCalculateDist(
+            it, term_ids_[term].data(), term_datas_[term].data(), term_sizes_[term], base_id, &ip);
+    }
+    computer->ResetTerm();
+    return 1 - ip;
+}
+
 void
 SparseTermDataCell::Serialize(StreamWriter& writer) const {
     StreamWriter::WriteObj(writer, term_capacity_);

--- a/src/data_cell/sparse_term_datacell.h
+++ b/src/data_cell/sparse_term_datacell.h
@@ -64,6 +64,9 @@ public:
     void
     Deserialize(StreamReader& reader);
 
+    float
+    CalcDistanceByInnerId(const SparseTermComputerPtr& computer, uint32_t base_id);
+
 public:
     float doc_prune_ratio_{0};
 

--- a/src/index/index_impl.h
+++ b/src/index/index_impl.h
@@ -73,6 +73,11 @@ public:
     }
 
     tl::expected<float, Error>
+    CalcDistanceById(const DatasetPtr& vector, int64_t id) const override {
+        SAFE_CALL(return this->inner_index_->CalcDistanceById(vector, id));
+    }
+
+    tl::expected<float, Error>
     CalcDistanceById(const float* vector, int64_t id) const override {
         SAFE_CALL(return this->inner_index_->CalcDistanceById(vector, id));
     }

--- a/src/quantization/sparse_quantization/sparse_term_computer.h
+++ b/src/quantization/sparse_quantization/sparse_term_computer.h
@@ -91,12 +91,12 @@ public:
                          const float* term_datas,
                          uint32_t term_count,
                          uint32_t target_id,
-                         float* ip) {
+                         float* dist) {
         float query_val = sorted_query_[term_iterator].second;
 
         for (auto i = 0; i < term_count; i++) {
             if (term_ids[i] == target_id) {
-                *ip += query_val * term_datas[i];
+                *dist += query_val * term_datas[i];
                 break;
             }
         }

--- a/src/quantization/sparse_quantization/sparse_term_computer.h
+++ b/src/quantization/sparse_quantization/sparse_term_computer.h
@@ -85,6 +85,23 @@ public:
         }
     }
 
+    inline void
+    ScanForCalculateDist(uint32_t term_iterator,
+                         const uint32_t* term_ids,
+                         const float* term_datas,
+                         uint32_t term_count,
+                         uint32_t target_id,
+                         float* ip) {
+        float query_val = sorted_query_[term_iterator].second;
+
+        for (auto i = 0; i < term_count; i++) {
+            if (term_ids[i] == target_id) {
+                *ip += query_val * term_datas[i];
+                break;
+            }
+        }
+    }
+
     inline bool
     HasNextTerm() {
         return term_iterator_ < pruned_len_;

--- a/tests/test_index.cpp
+++ b/tests/test_index.cpp
@@ -759,7 +759,8 @@ void
 TestIndex::TestCalcDistanceById(const IndexPtr& index,
                                 const TestDatasetPtr& dataset,
                                 float error,
-                                bool expected_success) {
+                                bool expected_success,
+                                bool is_sparse) {
     if (not index->CheckFeature(vsag::SUPPORT_CAL_DISTANCE_BY_ID)) {
         return;
     }
@@ -779,7 +780,12 @@ TestIndex::TestCalcDistanceById(const IndexPtr& index,
         for (auto j = 0; j < gt_topK; ++j) {
             auto id = gts->GetIds()[i * gt_topK + j];
             auto dist = gts->GetDistances()[i * gt_topK + j];
-            auto result = index->CalcDistanceById(query->GetFloat32Vectors(), id);
+            tl::expected<float, vsag::Error> result;
+            if (is_sparse) {
+                result = index->CalcDistanceById(query, id);
+            } else {
+                result = index->CalcDistanceById(query->GetFloat32Vectors(), id);
+            }
             if (not expected_success) {
                 REQUIRE_FALSE(result.has_value());
                 continue;

--- a/tests/test_index.cpp
+++ b/tests/test_index.cpp
@@ -789,7 +789,7 @@ TestIndex::TestCalcDistanceById(const IndexPtr& index,
                 result = index->CalcDistanceById(query, id);
             } else {
                 result = index->CalcDistanceById(query->GetFloat32Vectors(), id);
-                REQUIRE_THROWS(index->CalcDistanceById(query, id));
+                REQUIRE_FALSE(index->CalcDistanceById(query, id).has_value());
             }
             if (not expected_success) {
                 REQUIRE_FALSE(result.has_value());

--- a/tests/test_index.cpp
+++ b/tests/test_index.cpp
@@ -773,6 +773,8 @@ TestIndex::TestCalcDistanceById(const IndexPtr& index,
         query->NumElements(1)
             ->Dim(dim)
             ->Float32Vectors(queries->GetFloat32Vectors() + i * dim)
+            ->SparseVectors(queries->GetSparseVectors() + i)
+            ->Paths(queries->GetPaths() + i)
             ->Owner(false);
         for (auto j = 0; j < gt_topK; ++j) {
             auto id = gts->GetIds()[i * gt_topK + j];

--- a/tests/test_index.cpp
+++ b/tests/test_index.cpp
@@ -789,6 +789,7 @@ TestIndex::TestCalcDistanceById(const IndexPtr& index,
                 result = index->CalcDistanceById(query, id);
             } else {
                 result = index->CalcDistanceById(query->GetFloat32Vectors(), id);
+                REQUIRE_THROWS(index->CalcDistanceById(query, id));
             }
             if (not expected_success) {
                 REQUIRE_FALSE(result.has_value());

--- a/tests/test_index.cpp
+++ b/tests/test_index.cpp
@@ -104,7 +104,11 @@ TestIndex::TestUpdateId(const IndexPtr& index,
         // round 0 for update, round 1 for validate update results
         for (int i = 0; i < num_vectors; i++) {
             auto query = vsag::Dataset::Make();
-            query->NumElements(1)->Dim(dim)->Float32Vectors(base + i * dim)->Owner(false);
+            query->NumElements(1)
+                ->Dim(dim)
+                ->Float32Vectors(base + i * dim)
+                ->SparseVectors(dataset->base_->GetSparseVectors() + i)
+                ->Owner(false);
 
             auto result = index->KnnSearch(query, gt_topK, search_param);
             REQUIRE(result.has_value());
@@ -791,7 +795,8 @@ TestIndex::TestCalcDistanceById(const IndexPtr& index,
                 continue;
             }
             REQUIRE(result.has_value());
-            REQUIRE(std::abs(dist - result.value()) < error);
+            float estimate_dist = result.value();
+            REQUIRE(std::abs(dist - estimate_dist) < error);
         }
     }
 }

--- a/tests/test_index.h
+++ b/tests/test_index.h
@@ -159,7 +159,8 @@ public:
     TestCalcDistanceById(const IndexPtr& index,
                          const TestDatasetPtr& dataset,
                          float error = 1e-5,
-                         bool expected_success = true);
+                         bool expected_success = true,
+                         bool is_sparse = false);
 
     static void
     TestBatchCalcDistanceById(const IndexPtr& index,

--- a/tests/test_sindi.cpp
+++ b/tests/test_sindi.cpp
@@ -25,13 +25,25 @@ class SINDITestIndex : public fixtures::TestIndex {
 public:
     static TestDatasetPool pool;
     constexpr static uint64_t base_count = 1000;
-    constexpr static const char* build_param = R"(
+    constexpr static const char* build_param_reorder = R"(
         {
             "dim": 16,
             "dtype": "sparse",
             "metric_type": "ip",
             "index_param": {
                 "use_reorder": true,
+                "doc_prune_ratio": 0.0,
+                "window_size": 100
+            }
+        })";
+
+    constexpr static const char* build_param_flat = R"(
+        {
+            "dim": 16,
+            "dtype": "sparse",
+            "metric_type": "ip",
+            "index_param": {
+                "use_reorder": false,
                 "doc_prune_ratio": 0.0,
                 "window_size": 100
             }
@@ -51,6 +63,7 @@ TestDatasetPool SINDITestIndex::pool{};
 }  // namespace fixtures
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex, "SINDI Build and Search", "[ft][sindi]") {
+    auto build_param = GENERATE(build_param_flat);
     auto index = TestFactory("sindi", build_param, true);
     auto dataset = pool.GetSparseDatasetAndCreate(base_count, 128, 0.8);
     REQUIRE(index->GetIndexType() == vsag::IndexType::SINDI);
@@ -61,12 +74,13 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex, "SINDI Build and Search",
     TestFilterSearch(index, dataset, search_param, 0.99, true);
     TestConcurrentKnnSearch(index, dataset, search_param, 0.99, true);
     TestGetMinAndMaxId(index, dataset, true);
-    TestCalcDistanceById(index, dataset, 10, true, true);
+    TestCalcDistanceById(index, dataset, 0.1, true, true);
     TestUpdateId(index, dataset, search_param, true);
     TestEstimateMemory("sindi", build_param, dataset);
 }
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex, "SINDI Concurrent", "[ft][sindi]") {
+    auto build_param = GENERATE(build_param_reorder, build_param_flat);
     auto index = TestFactory("sindi", build_param, true);
     auto dataset = pool.GetSparseDatasetAndCreate(base_count, 128, 0.8);
     REQUIRE(index->GetIndexType() == vsag::IndexType::SINDI);
@@ -74,6 +88,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex, "SINDI Concurrent", "[ft]
 }
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex, "SINDI Serialize File", "[ft][sindi]") {
+    auto build_param = GENERATE(build_param_reorder, build_param_flat);
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
     auto metric_type = GENERATE("ip");

--- a/tests/test_sindi.cpp
+++ b/tests/test_sindi.cpp
@@ -60,6 +60,10 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex, "SINDI Build and Search",
     TestRangeSearch(index, dataset, search_param, 0.49, 5, true);
     TestFilterSearch(index, dataset, search_param, 0.99, true);
     TestConcurrentKnnSearch(index, dataset, search_param, 0.99, true);
+    TestGetMinAndMaxId(index, dataset, true);
+    TestCalcDistanceById(index, dataset, 10, true);
+    TestUpdateId(index, dataset, search_param, true);
+    TestEstimateMemory("sindi", build_param, dataset);
 }
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex, "SINDI Concurrent", "[ft][sindi]") {

--- a/tests/test_sindi.cpp
+++ b/tests/test_sindi.cpp
@@ -61,7 +61,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex, "SINDI Build and Search",
     TestFilterSearch(index, dataset, search_param, 0.99, true);
     TestConcurrentKnnSearch(index, dataset, search_param, 0.99, true);
     TestGetMinAndMaxId(index, dataset, true);
-    TestCalcDistanceById(index, dataset, 10, true);
+    TestCalcDistanceById(index, dataset, 10, true, true);
     TestUpdateId(index, dataset, search_param, true);
     TestEstimateMemory("sindi", build_param, dataset);
 }

--- a/tests/test_sindi.cpp
+++ b/tests/test_sindi.cpp
@@ -63,7 +63,7 @@ TestDatasetPool SINDITestIndex::pool{};
 }  // namespace fixtures
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex, "SINDI Build and Search", "[ft][sindi]") {
-    auto build_param = GENERATE(build_param_flat);
+    auto build_param = GENERATE(build_param_reorder, build_param_flat);
     auto index = TestFactory("sindi", build_param, true);
     auto dataset = pool.GetSparseDatasetAndCreate(base_count, 128, 0.8);
     REQUIRE(index->GetIndexType() == vsag::IndexType::SINDI);

--- a/tests/test_sparse_index.cpp
+++ b/tests/test_sparse_index.cpp
@@ -55,6 +55,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::SparseTestIndex,
     TestRangeSearch(index, dataset, search_param, 0.99, 10, true);
     TestRangeSearch(index, dataset, search_param, 0.49, 5, true);
     TestFilterSearch(index, dataset, search_param, 0.99, true);
+    TestCalcDistanceById(index, dataset, 10, true);
 }
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::SparseTestIndex,

--- a/tests/test_sparse_index.cpp
+++ b/tests/test_sparse_index.cpp
@@ -55,7 +55,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::SparseTestIndex,
     TestRangeSearch(index, dataset, search_param, 0.99, 10, true);
     TestRangeSearch(index, dataset, search_param, 0.49, 5, true);
     TestFilterSearch(index, dataset, search_param, 0.99, true);
-    TestCalcDistanceById(index, dataset, 10, true);
+    TestCalcDistanceById(index, dataset, 10, true, true);
 }
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::SparseTestIndex,


### PR DESCRIPTION
close #1110

## Summary by Sourcery

Add full support for computing distances by element ID to both SINDI and SparseIndex, along with ID management utilities and memory estimation in SINDI.

New Features:
- Implement CalcDistanceById in the base Index, InnerIndexInterface, SINDI, and SparseIndex
- Add SINDI methods UpdateId, GetMinAndMaxId, and EstimateMemory
- Extend SparseTermDataCell with CalcDistanceByInnerId and SparseTermComputer with ScanForCalculateDist

Enhancements:
- Expose SUPPORT_CAL_DISTANCE_BY_ID feature in SINDI and SparseIndex
- Introduce ESTIMATE_DOC_TERM and ESTIMATE_DOC_DIM constants for memory estimation

Tests:
- Update TestCalcDistanceById signature to support sparse vectors
- Add tests for GetMinAndMaxId, UpdateId, and EstimateMemory in SINDI