### PR TITLE
feat(ivf): support for self-checking and query-based checking of IVF inverted indexes

### DIFF
--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -43,7 +43,6 @@ namespace vsag {
 HGraph::HGraph(const HGraphParameterPtr& hgraph_param, const vsag::IndexCommonParam& common_param)
     : InnerIndexInterface(hgraph_param, common_param),
       route_graphs_(common_param.allocator_.get()),
-      use_reorder_(hgraph_param->use_reorder),
       use_elp_optimizer_(hgraph_param->use_elp_optimizer),
       ignore_reorder_(hgraph_param->ignore_reorder),
       build_by_base_(hgraph_param->build_by_base),
@@ -52,7 +51,8 @@ HGraph::HGraph(const HGraphParameterPtr& hgraph_param, const vsag::IndexCommonPa
       build_thread_count_(hgraph_param->build_thread_count),
       odescent_param_(hgraph_param->odescent_param),
       graph_type_(hgraph_param->graph_type),
-      hierarchical_datacell_param_(hgraph_param->hierarchical_graph_param) {
+      hierarchical_datacell_param_(hgraph_param->hierarchical_graph_param){
+    this->use_reorder_ = hgraph_param->use_reorder;
     this->label_table_->compress_duplicate_data_ = hgraph_param->support_duplicate;
     this->label_table_->support_tombstone_ = hgraph_param->support_tombstone;
     neighbors_mutex_ = std::make_shared<PointsMutex>(0, common_param.allocator_.get());
@@ -1864,59 +1864,6 @@ HGraph::GetStats() const {
     this->analyze_graph_recall(stats, sample_base_datas, sample_size, topk, search_params);
     this->analyze_quantizer(stats, sample_base_datas.data(), sample_size, topk, search_params);
     return stats.dump(4);
-}
-
-void
-HGraph::analyze_quantizer(JsonType& stats,
-                          const float* data,
-                          uint64_t sample_data_size,
-                          int64_t topk,
-                          const std::string& search_param) const {
-    // record quantized information
-    if (this->use_reorder_) {
-        logger::info("analyze_quantizer: sample_data_size = {}, topk = {}", sample_data_size, topk);
-        float bias_ratio = 0.0F;
-        float inversion_count_rate = 0.0F;
-        for (uint64_t i = 0; i < sample_data_size; ++i) {
-            float tmp_bias_ratio = 0.0F;
-            float tmp_inversion_count_rate = 0.0F;
-            this->use_reorder_ = false;
-            const auto* query_data = data + i * dim_;
-            auto query = Dataset::Make();
-            query->Owner(false)->NumElements(1)->Float32Vectors(query_data)->Dim(dim_);
-            auto search_result = this->KnnSearch(query, topk, search_param, nullptr);
-            this->use_reorder_ = true;
-            auto distance_result =
-                this->CalDistanceById(query_data, search_result->GetIds(), search_result->GetDim());
-            const auto* ground_distances = distance_result->GetDistances();
-            const auto* approximate_distances = search_result->GetDistances();
-            for (int64_t j = 0; j < topk; ++j) {
-                if (ground_distances[j] > 0) {
-                    tmp_bias_ratio += std::abs(approximate_distances[j] - ground_distances[j]) /
-                                      ground_distances[j];
-                }
-            }
-            tmp_bias_ratio /= static_cast<float>(topk);
-            bias_ratio += tmp_bias_ratio;
-            // calculate inversion count rate
-            int64_t inversion_count = 0;
-            for (int64_t j = 0; j < search_result->GetDim() - 1; ++j) {
-                for (int64_t k = j + 1; k < search_result->GetDim(); ++k) {
-                    if (ground_distances[j] > ground_distances[k]) {
-                        inversion_count++;
-                    }
-                }
-            }
-            int64_t search_count = search_result->GetDim();
-            tmp_inversion_count_rate =
-                static_cast<float>(inversion_count) /
-                (static_cast<float>(search_count * (search_count - 1)) / 2.0F);
-            inversion_count_rate += tmp_inversion_count_rate;
-        }
-        stats["quantization_bias_ratio"] = bias_ratio / static_cast<float>(sample_data_size);
-        stats["quantization_inversion_count_rate"] =
-            inversion_count_rate / static_cast<float>(sample_data_size);
-    }
 }
 
 void

--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -51,7 +51,7 @@ HGraph::HGraph(const HGraphParameterPtr& hgraph_param, const vsag::IndexCommonPa
       build_thread_count_(hgraph_param->build_thread_count),
       odescent_param_(hgraph_param->odescent_param),
       graph_type_(hgraph_param->graph_type),
-      hierarchical_datacell_param_(hgraph_param->hierarchical_graph_param){
+      hierarchical_datacell_param_(hgraph_param->hierarchical_graph_param) {
     this->use_reorder_ = hgraph_param->use_reorder;
     this->label_table_->compress_duplicate_data_ = hgraph_param->support_duplicate;
     this->label_table_->support_tombstone_ = hgraph_param->support_tombstone;

--- a/src/algorithm/hgraph.h
+++ b/src/algorithm/hgraph.h
@@ -305,13 +305,6 @@ private:
 
 private:
     void
-    analyze_quantizer(JsonType& stats,
-                      const float* data,
-                      uint64_t sample_data_size,
-                      int64_t topk,
-                      const std::string& search_param) const;
-
-    void
     analyze_graph_recall(JsonType& stats,
                          Vector<float>& data,
                          uint64_t sample_data_size,
@@ -333,7 +326,6 @@ private:
     GraphInterfacePtr bottom_graph_{nullptr};
     SparseGraphDatacellParamPtr hierarchical_datacell_param_{nullptr};
 
-    mutable bool use_reorder_{false};
     bool use_elp_optimizer_{false};
     bool ignore_reorder_{false};
     bool build_by_base_{false};

--- a/src/algorithm/inner_index_interface.cpp
+++ b/src/algorithm/inner_index_interface.cpp
@@ -424,4 +424,58 @@ InnerIndexInterface::GetDataByIdsWithFlag(const int64_t* ids,
     return dataset;
 }
 
+void
+InnerIndexInterface::analyze_quantizer(JsonType& stats,
+                                       const float* data,
+                                       uint64_t sample_data_size,
+                                       int64_t topk,
+                                       const std::string& search_param) const {
+    // record quantized information
+    if (this->use_reorder_) {
+        logger::info("analyze_quantizer: sample_data_size = {}, topk = {}", sample_data_size, topk);
+        float bias_ratio = 0.0F;
+        float inversion_count_rate = 0.0F;
+        for (uint64_t i = 0; i < sample_data_size; ++i) {
+            float tmp_bias_ratio = 0.0F;
+            float tmp_inversion_count_rate = 0.0F;
+            this->use_reorder_ = false;
+            const auto* query_data = data + i * dim_;
+            auto query = Dataset::Make();
+            FilterPtr filter = nullptr;
+            query->Owner(false)->NumElements(1)->Float32Vectors(query_data)->Dim(dim_);
+            auto search_result = this->KnnSearch(query, topk, search_param, filter);
+            this->use_reorder_ = true;
+            auto distance_result =
+                this->CalDistanceById(query_data, search_result->GetIds(), search_result->GetDim());
+            const auto* ground_distances = distance_result->GetDistances();
+            const auto* approximate_distances = search_result->GetDistances();
+            for (int64_t j = 0; j < topk; ++j) {
+                if (ground_distances[j] > 0) {
+                    tmp_bias_ratio += std::abs(approximate_distances[j] - ground_distances[j]) /
+                                      ground_distances[j];
+                }
+            }
+            tmp_bias_ratio /= static_cast<float>(topk);
+            bias_ratio += tmp_bias_ratio;
+            // calculate inversion count rate
+            int64_t inversion_count = 0;
+            for (int64_t j = 0; j < search_result->GetDim() - 1; ++j) {
+                for (int64_t k = j + 1; k < search_result->GetDim(); ++k) {
+                    if (ground_distances[j] > ground_distances[k]) {
+                        inversion_count++;
+                    }
+                }
+            }
+            int64_t search_count = search_result->GetDim();
+            tmp_inversion_count_rate =
+                static_cast<float>(inversion_count) /
+                (static_cast<float>(search_count * (search_count - 1)) / 2.0F);
+            inversion_count_rate += tmp_inversion_count_rate;
+        }
+        stats["quantization_bias_ratio"] = bias_ratio / static_cast<float>(sample_data_size);
+        stats["quantization_inversion_count_rate"] =
+            inversion_count_rate / static_cast<float>(sample_data_size);
+    }
+}
+
 }  // namespace vsag

--- a/src/algorithm/inner_index_interface.h
+++ b/src/algorithm/inner_index_interface.h
@@ -374,6 +374,14 @@ public:
                             "Index doesn't support UpdateVector");
     }
 
+protected:
+    void
+    analyze_quantizer(JsonType& stats,
+                      const float* data,
+                      uint64_t sample_data_size,
+                      int64_t topk,
+                      const std::string& search_param) const;
+
 public:
     LabelTablePtr label_table_{nullptr};
     mutable std::shared_mutex label_lookup_mutex_{};  // lock for label_lookup_ & labels_
@@ -382,6 +390,9 @@ public:
 
     Allocator* const allocator_{nullptr};
     int64_t dim_{0};
+
+    mutable bool use_reorder_{false};
+
     MetricType metric_{MetricType::METRIC_TYPE_L2SQR};
     DataTypes data_type_{DataTypes::DATA_TYPE_FLOAT};
 

--- a/src/algorithm/ivf.cpp
+++ b/src/algorithm/ivf.cpp
@@ -1077,7 +1077,7 @@ calculate_percentile(const std::vector<float>& sorted_data, float percentile) {
     }
 
     float fractional = index - static_cast<float>(floor_index);
-    return sorted_data[floor_index] * (1.0 - fractional) + sorted_data[ceil_index] * fractional;
+    return sorted_data[floor_index] * (1.0F - fractional) + sorted_data[ceil_index] * fractional;
 }
 
 void
@@ -1090,7 +1090,7 @@ get_data_stats(const Vector<float>& data, JsonType& json) {
     for (float val : data) {
         sum += val;
     }
-    float mean = sum / data.size();
+    float mean = sum / static_cast<float>(data.size());
     json["mean"] = mean;
 
     float sq_diff_sum = 0.0;

--- a/src/algorithm/ivf.cpp
+++ b/src/algorithm/ivf.cpp
@@ -254,6 +254,7 @@ IVF::IVF(const IVFParameterPtr& param, const IndexCommonParam& common_param)
         this->has_raw_vector_ = true;
     }
 }
+
 void
 IVF::GetCodeByInnerId(InnerIdType inner_id, uint8_t* data) const {
     auto [bucket_id, offset_id] = this->get_location(inner_id);
@@ -569,7 +570,11 @@ IVF::Serialize(StreamWriter& writer) const {
     basic_info["total_elements"] = this->total_elements_;
     basic_info["use_reorder"] = this->use_reorder_;
     basic_info["is_trained"] = this->is_trained_;
+    basic_info[DIM] = this->dim_;
+    basic_info[EXTRA_INFO_SIZE] = 0;
     basic_info[INDEX_PARAM] = this->create_param_ptr_->ToString();
+    basic_info["data_type"] = this->data_type_;
+    basic_info["metric"] = this->metric_;
 
     auto metadata = std::make_shared<Metadata>();
     metadata->Set(BASIC_INFO, basic_info);
@@ -1058,6 +1063,100 @@ void
 IVF::GetVectorByInnerId(InnerIdType inner_id, float* data) const {
     auto [bucket_id, bucket_offset] = this->get_location(inner_id);
     this->bucket_->GetCodesById(bucket_id, bucket_offset, reinterpret_cast<uint8_t*>(data));
+}
+
+float
+calculate_percentile(const std::vector<float>& sorted_data, float percentile) {
+    size_t n = sorted_data.size();
+    float index = percentile * static_cast<float>(n - 1);
+    auto floor_index = static_cast<size_t>(std::floor(index));
+    size_t ceil_index = floor_index + 1;
+
+    if (ceil_index >= n) {
+        return sorted_data[floor_index];
+    }
+
+    float fractional = index - static_cast<float>(floor_index);
+    return sorted_data[floor_index] * (1.0 - fractional) + sorted_data[ceil_index] * fractional;
+}
+
+void
+get_data_stats(const Vector<float>& data, JsonType& json) {
+    if (data.empty()) {
+        throw std::invalid_argument("Vector cannot be empty.");
+    }
+
+    float sum = 0.0;
+    for (float val : data) {
+        sum += val;
+    }
+    float mean = sum / data.size();
+    json["mean"] = mean;
+
+    float sq_diff_sum = 0.0;
+    for (float val : data) {
+        sq_diff_sum += (val - mean) * (val - mean);
+    }
+    float variance = sq_diff_sum / static_cast<float>(data.size());
+    json["std"] = std::sqrt(variance);
+
+    float min_val = *std::min_element(data.begin(), data.end());
+    json["min"] = min_val;
+    float max_val = *std::max_element(data.begin(), data.end());
+    json["max"] = max_val;
+
+    std::vector<float> sorted_data(data.begin(), data.end());
+    std::sort(sorted_data.begin(), sorted_data.end());
+
+    float q25 = calculate_percentile(sorted_data, 0.25);
+    float q50 = calculate_percentile(sorted_data, 0.5);
+    float q75 = calculate_percentile(sorted_data, 0.75);
+    json["q25"] = q25;
+    json["q50"] = q50;
+    json["q75"] = q75;
+}
+
+std::string
+IVF::GetStats() const {
+    JsonType stats;
+    // bucket_radius
+    stats["bucket_count"] = this->bucket_->bucket_count_;
+    Vector<float> centroids(this->dim_, allocator_);
+    Vector<float> bucket_counts(allocator_);
+    Vector<float> bucket_radius(allocator_);
+    for (int i = 0; i < this->bucket_->bucket_count_; ++i) {
+        auto size = bucket_->GetBucketSize(i);
+        if (size == 0) {
+            bucket_counts.push_back(0);
+            continue;
+        }
+        bucket_counts.push_back(static_cast<float>(size));
+        Vector<float> dists(size, allocator_);
+        partition_strategy_->GetCentroid(i, centroids);
+        auto computer = bucket_->FactoryComputer(centroids.data());
+        bucket_->ScanBucketById(dists.data(), computer, i);
+        float max_distance = *std::max_element(dists.begin(), dists.end());
+        bucket_radius.push_back(max_distance);
+    }
+    // bucket_count_std
+    stats["bucket_num"] = JsonType();
+    get_data_stats(bucket_counts, stats["bucket_num"]);
+    // bucket_radius
+    stats["bucket_radius"] = JsonType();
+    get_data_stats(bucket_radius, stats["bucket_radius"]);
+    return stats.dump(4);
+}
+
+std::string
+IVF::AnalyzeIndexBySearch(const SearchRequest& request) {
+    JsonType stats;
+    auto querys = request.query_;
+    auto topk = std::min(request.topk_, GetNumElements());
+    auto num_elements = querys->GetNumElements();
+    auto param_str = request.params_str_;
+    // quantization error
+    this->analyze_quantizer(stats, querys->GetFloat32Vectors(), num_elements, topk, param_str);
+    return stats.dump(4);
 }
 
 }  // namespace vsag

--- a/src/algorithm/ivf.h
+++ b/src/algorithm/ivf.h
@@ -49,6 +49,9 @@ public:
     std::vector<int64_t>
     Add(const DatasetPtr& base) override;
 
+    std::string
+    AnalyzeIndexBySearch(const vsag::SearchRequest& request) override;
+
     std::vector<int64_t>
     Build(const DatasetPtr& base) override;
 
@@ -90,6 +93,9 @@ public:
 
     void
     GetVectorByInnerId(InnerIdType inner_id, float* data) const override;
+
+    std::string
+    GetStats() const override;
 
     void
     InitFeatures() override;
@@ -157,8 +163,6 @@ private:
     BucketIdType buckets_per_data_;
 
     int64_t total_elements_{0};
-
-    bool use_reorder_{false};
 
     bool is_trained_{false};
     bool use_residual_{false};

--- a/tools/analyze_index/analyze_index.cpp
+++ b/tools/analyze_index/analyze_index.cpp
@@ -20,6 +20,7 @@
 #include <iostream>
 
 #include "algorithm/hgraph.h"
+#include "algorithm/ivf.h"
 #include "index/index_impl.h"
 #include "inner_string_params.h"
 #include "storage/serialization.h"
@@ -222,6 +223,13 @@ private:
             auto inner_index = std::make_shared<HGraph>(hgraph_parameter, index_common_params);
             inner_index->Deserialize(reader);
             index_ = std::make_shared<IndexImpl<HGraph>>(inner_index, index_common_params);
+            return true;
+        } else if (index_name_ == INDEX_IVF) {
+            auto ivf_parameter = std::make_shared<IVFParameter>();
+            ivf_parameter->FromJson(index_param_);
+            auto inner_index = std::make_shared<IVF>(ivf_parameter, index_common_params);
+            inner_index->Deserialize(reader);
+            index_ = std::make_shared<IndexImpl<IVF>>(inner_index, index_common_params);
             return true;
         } else {
             logger::error("Index type {} not supported", index_name_);


### PR DESCRIPTION
close: #1093

## Summary by Sourcery

Add self-checking and query-based analysis capabilities to IVF indexes by implementing statistics and quantization error reporting, refactor quantizer analysis into the base index interface, extend serialization metadata, enable the analyze_index tool to handle IVF, and include a test for the new features.

New Features:
- Implement IVF::GetStats to compute and return bucket-level statistics (count distributions and radii percentiles) in JSON
- Implement IVF::AnalyzeIndexBySearch to perform query-based quantization error analysis using the shared analyze_quantizer logic
- Extend IVF serialization to include dimension, data type, metric, and extra_info_size in the index metadata

Enhancements:
- Move analyze_quantizer from HGraph into InnerIndexInterface to unify quantization analysis across indexes and remove duplication
- Add support for loading and analyzing IVF indexes in the analyze_index tool

Tests:
- Add a functional test in test_ivf.cpp to verify IVF GetStats output and query-based analysis via AnalyzeIndexBySearch