### PR TITLE
refactor(headers): improve header include rules

### DIFF
--- a/src/algorithm/brute_force.cpp
+++ b/src/algorithm/brute_force.cpp
@@ -24,6 +24,8 @@
 #include "data_cell/flatten_interface.h"
 #include "fmt/chrono.h"
 #include "impl/heap/standard_heap.h"
+#include "index/index_common_param.h"
+#include "index_feature_list.h"
 #include "inner_string_params.h"
 #include "storage/serialization.h"
 #include "utils/slow_task_timer.h"

--- a/src/algorithm/brute_force.h
+++ b/src/algorithm/brute_force.h
@@ -24,6 +24,8 @@
 
 namespace vsag {
 
+class SafeThreadPool;
+
 DEFINE_POINTER2(AttrInvertedInterface, AttributeInvertedInterface);
 DEFINE_POINTER(FlattenInterface);
 // BruteForce index was introduced since v0.13

--- a/src/algorithm/hgraph.h
+++ b/src/algorithm/hgraph.h
@@ -180,7 +180,7 @@ public:
     void
     Serialize(StreamWriter& writer) const override;
 
-    inline void
+    void
     SetBuildThreadsCount(uint64_t count) {
         this->build_thread_count_ = count;
         this->build_pool_->SetPoolSize(count);

--- a/src/algorithm/inner_index_interface.cpp
+++ b/src/algorithm/inner_index_interface.cpp
@@ -21,6 +21,9 @@
 #include "empty_index_binary_set.h"
 #include "hgraph.h"
 #include "impl/filter/filter_headers.h"
+#include "index/index_common_param.h"
+#include "index_feature_list.h"
+#include "label_table.h"
 #include "storage/serialization.h"
 #include "utils/slow_task_timer.h"
 #include "utils/util_functions.h"
@@ -196,6 +199,16 @@ InnerIndexInterface::Deserialize(const ReaderSet& reader_set) {
     } catch (const std::bad_alloc& e) {
         throw VsagException(ErrorType::READ_ERROR, "failed to Deserialize: ", e.what());
     }
+}
+
+bool
+InnerIndexInterface::CheckFeature(IndexFeature feature) const {
+    return this->index_feature_list_->CheckFeature(feature);
+}
+
+bool
+InnerIndexInterface::CheckIdExist(int64_t id) const {
+    return this->label_table_->CheckLabel(id);
 }
 
 void

--- a/src/algorithm/inner_index_interface.h
+++ b/src/algorithm/inner_index_interface.h
@@ -14,14 +14,14 @@
 // limitations under the License.
 
 #pragma once
+
 #include <shared_mutex>
 #include <vector>
 
 #include "data_cell/extra_info_interface.h"
+#include "data_type.h"
 #include "dataset_impl.h"
-#include "index/index_common_param.h"
-#include "index_feature_list.h"
-#include "label_table.h"
+#include "metric_type.h"
 #include "parameter.h"
 #include "pointer_define.h"
 #include "storage/stream_reader.h"
@@ -33,6 +33,10 @@
 namespace vsag {
 
 DEFINE_POINTER2(InnerIndex, InnerIndexInterface);
+DEFINE_POINTER(LabelTable);
+DEFINE_POINTER(IndexFeatureList);
+
+class IndexCommonParam;
 
 class InnerIndexInterface {
 public:
@@ -73,14 +77,10 @@ public:
     CalSerializeSize() const;
 
     [[nodiscard]] virtual bool
-    CheckFeature(IndexFeature feature) const {
-        return this->index_feature_list_->CheckFeature(feature);
-    }
+    CheckFeature(IndexFeature feature) const;
 
     [[nodiscard]] virtual bool
-    CheckIdExist(int64_t id) const {
-        return this->label_table_->CheckLabel(id);
-    }
+    CheckIdExist(int64_t id) const;
 
     virtual InnerIndexPtr
     Clone(const IndexCommonParam& param);

--- a/src/algorithm/ivf.cpp
+++ b/src/algorithm/ivf.cpp
@@ -23,6 +23,7 @@
 #include "impl/heap/standard_heap.h"
 #include "impl/reorder.h"
 #include "index/index_impl.h"
+#include "index_feature_list.h"
 #include "inner_string_params.h"
 #include "ivf_partition/gno_imi_partition.h"
 #include "ivf_partition/ivf_nearest_partition.h"

--- a/src/algorithm/sindi/sindi.cpp
+++ b/src/algorithm/sindi/sindi.cpp
@@ -16,6 +16,7 @@
 #include "sindi.h"
 
 #include "impl/heap/standard_heap.h"
+#include "index_feature_list.h"
 #include "storage/serialization.h"
 #include "utils/util_functions.h"
 

--- a/src/algorithm/sparse_index.cpp
+++ b/src/algorithm/sparse_index.cpp
@@ -16,11 +16,13 @@
 #include "sparse_index.h"
 
 #include "impl/heap/standard_heap.h"
+#include "index_feature_list.h"
+#include "label_table.h"
 #include "utils/util_functions.h"
 
 namespace vsag {
 
-float
+static float
 get_distance(uint32_t len1,
              const uint32_t* ids1,
              const float* vals1,
@@ -44,6 +46,46 @@ get_distance(uint32_t len1,
     }
 
     return 1 - sum;
+}
+
+SparseIndex::SparseIndex(const SparseIndexParameterPtr& param, const IndexCommonParam& common_param)
+    : InnerIndexInterface(param, common_param),
+      datas_(common_param.allocator_.get()),
+      need_sort_(param->need_sort) {
+}
+
+SparseIndex::SparseIndex(const ParamPtr& param, const IndexCommonParam& common_param)
+    : SparseIndex(std::dynamic_pointer_cast<SparseIndexParameters>(param), common_param){};
+
+SparseIndex::~SparseIndex() {
+    for (auto& data : datas_) {
+        allocator_->Deallocate(data);
+    }
+}
+
+void
+SparseIndex::Deserialize(StreamReader& reader) {
+    StreamReader::ReadObj(reader, cur_element_count_);
+    datas_.resize(cur_element_count_);
+    max_capacity_ = cur_element_count_;
+    for (int i = 0; i < cur_element_count_; ++i) {
+        uint32_t len;
+        StreamReader::ReadObj(reader, len);
+        datas_[i] = (uint32_t*)allocator_->Allocate((2 * len + 1) * sizeof(uint32_t));
+        datas_[i][0] = len;
+        reader.Read((char*)(datas_[i] + 1), static_cast<uint64_t>(2 * len) * sizeof(uint32_t));
+    }
+    label_table_->Deserialize(reader);
+}
+
+void
+SparseIndex::Serialize(StreamWriter& writer) const {
+    StreamWriter::WriteObj(writer, cur_element_count_);
+    for (int i = 0; i < cur_element_count_; ++i) {
+        uint32_t len = datas_[i][0];
+        writer.Write((char*)datas_[i], (2 * len + 1) * sizeof(uint32_t));
+    }
+    label_table_->Serialize(writer);
 }
 
 ParamPtr

--- a/src/algorithm/sparse_index.h
+++ b/src/algorithm/sparse_index.h
@@ -28,20 +28,12 @@ public:
                                  const IndexCommonParam& common_param);
 
 public:
-    explicit SparseIndex(const SparseIndexParameterPtr& param, const IndexCommonParam& common_param)
-        : InnerIndexInterface(param, common_param),
-          datas_(common_param.allocator_.get()),
-          need_sort_(param->need_sort) {
-    }
+    explicit SparseIndex(const SparseIndexParameterPtr& param,
+                         const IndexCommonParam& common_param);
 
-    SparseIndex(const ParamPtr& param, const IndexCommonParam& common_param)
-        : SparseIndex(std::dynamic_pointer_cast<SparseIndexParameters>(param), common_param){};
+    SparseIndex(const ParamPtr& param, const IndexCommonParam& common_param);
 
-    ~SparseIndex() override {
-        for (auto& data : datas_) {
-            allocator_->Deallocate(data);
-        }
-    }
+    ~SparseIndex() override;
 
     std::vector<int64_t>
     Add(const DatasetPtr& base) override;
@@ -56,19 +48,7 @@ public:
     CalcDistanceById(const DatasetPtr& vector, int64_t id) const override;
 
     void
-    Deserialize(StreamReader& reader) override {
-        StreamReader::ReadObj(reader, cur_element_count_);
-        datas_.resize(cur_element_count_);
-        max_capacity_ = cur_element_count_;
-        for (int i = 0; i < cur_element_count_; ++i) {
-            uint32_t len;
-            StreamReader::ReadObj(reader, len);
-            datas_[i] = (uint32_t*)allocator_->Allocate((2 * len + 1) * sizeof(uint32_t));
-            datas_[i][0] = len;
-            reader.Read((char*)(datas_[i] + 1), 2 * len * sizeof(uint32_t));
-        }
-        label_table_->Deserialize(reader);
-    }
+    Deserialize(StreamReader& reader) override;
 
     InnerIndexPtr
     Fork(const IndexCommonParam& param) override {
@@ -104,14 +84,7 @@ public:
                 int64_t limited_size = -1) const override;
 
     void
-    Serialize(StreamWriter& writer) const override {
-        StreamWriter::WriteObj(writer, cur_element_count_);
-        for (int i = 0; i < cur_element_count_; ++i) {
-            uint32_t len = datas_[i][0];
-            writer.Write((char*)datas_[i], (2 * len + 1) * sizeof(uint32_t));
-        }
-        label_table_->Serialize(writer);
-    }
+    Serialize(StreamWriter& writer) const override;
 
     void
     InitFeatures() override;

--- a/src/impl/bitset/fast_bitset.h
+++ b/src/impl/bitset/fast_bitset.h
@@ -20,10 +20,10 @@
 #include "computable_bitset.h"
 #include "pointer_define.h"
 #include "typing.h"
-#include "vsag/allocator.h"
 
 namespace vsag {
 
+class Allocator;
 DEFINE_POINTER(FastBitset);
 class FastBitset : public ComputableBitset {
 public:

--- a/src/impl/heap/distance_heap.h
+++ b/src/impl/heap/distance_heap.h
@@ -20,7 +20,6 @@
 
 #include "pointer_define.h"
 #include "typing.h"
-#include "vsag/allocator.h"
 
 namespace vsag {
 

--- a/src/impl/kmeans_cluster.h
+++ b/src/impl/kmeans_cluster.h
@@ -17,10 +17,9 @@
 
 #include "safe_thread_pool.h"
 #include "typing.h"
-#include "vsag/allocator.h"
 
 namespace vsag {
-
+class Allocator;
 class KMeansCluster {
 public:
     explicit KMeansCluster(int32_t dim,

--- a/src/impl/pruning_strategy.cpp
+++ b/src/impl/pruning_strategy.cpp
@@ -15,8 +15,10 @@
 
 #include "pruning_strategy.h"
 
+#include "data_cell/flatten_datacell.h"
+#include "data_cell/graph_interface.h"
 #include "impl/heap/standard_heap.h"
-
+#include "lock_strategy.h"
 namespace vsag {
 
 void

--- a/src/impl/pruning_strategy.h
+++ b/src/impl/pruning_strategy.h
@@ -15,14 +15,14 @@
 
 #pragma once
 
-#include "data_cell/flatten_datacell.h"
-#include "data_cell/graph_interface.h"
-#include "impl/heap/distance_heap.h"
-#include "lock_strategy.h"
+#include "pointer_define.h"
 #include "typing.h"
-#include "vsag/allocator.h"
 
 namespace vsag {
+DEFINE_POINTER2(DistHeap, DistanceHeap);
+DEFINE_POINTER(FlattenInterface);
+DEFINE_POINTER(GraphInterface);
+DEFINE_POINTER(MutexArray);
 
 void
 select_edges_by_heuristic(const DistHeapPtr& edges,

--- a/src/impl/pruning_strategy_test.cpp
+++ b/src/impl/pruning_strategy_test.cpp
@@ -21,8 +21,10 @@
 #include <memory>
 #include <vector>
 
+#include "data_cell/flatten_datacell.h"
 #include "data_cell/flatten_datacell_parameter.h"
 #include "data_cell/graph_datacell_parameter.h"
+#include "data_cell/graph_interface.h"
 #include "impl/allocator/safe_allocator.h"
 #include "impl/heap/standard_heap.h"
 #include "io/memory_io_parameter.h"

--- a/src/impl/transform/vector_transformer.h
+++ b/src/impl/transform/vector_transformer.h
@@ -19,10 +19,10 @@
 #include "pointer_define.h"
 #include "storage/stream_reader.h"
 #include "storage/stream_writer.h"
-#include "vsag/allocator.h"
 
 namespace vsag {
 
+class Allocator;
 DEFINE_POINTER(VectorTransformer);
 DEFINE_POINTER(TransformerMeta);
 
@@ -39,6 +39,7 @@ struct TransformerMeta {
         return;
     };
 };
+
 class VectorTransformer {
 public:
     explicit VectorTransformer(Allocator* allocator, int64_t input_dim, int64_t output_dim);

--- a/src/index/index_common_param.h
+++ b/src/index/index_common_param.h
@@ -21,7 +21,6 @@
 #include "metric_type.h"
 #include "safe_thread_pool.h"
 #include "typing.h"
-#include "vsag/allocator.h"
 #include "vsag/resource.h"
 
 namespace vsag {

--- a/src/index/index_impl.h
+++ b/src/index/index_impl.h
@@ -17,8 +17,8 @@
 
 #include "algorithm/inner_index_interface.h"
 #include "common.h"
+#include "index_common_param.h"
 #include "vsag/index.h"
-
 namespace vsag {
 
 GENERATE_HAS_STATIC_CLASS_FUNCTION(CheckAndMappingExternalParam,

--- a/src/index/iterator_filter.h
+++ b/src/index/iterator_filter.h
@@ -19,7 +19,6 @@
 
 #include "typing.h"
 #include "utils/visited_list.h"
-#include "vsag/allocator.h"
 #include "vsag/errors.h"
 #include "vsag/expected.hpp"
 #include "vsag/iterator_context.h"

--- a/src/io/memory_block_io.h
+++ b/src/io/memory_block_io.h
@@ -17,7 +17,6 @@
 
 #include "basic_io.h"
 #include "memory_block_io_parameter.h"
-#include "vsag/allocator.h"
 
 namespace vsag {
 class IndexCommonParam;

--- a/src/io/memory_io.h
+++ b/src/io/memory_io.h
@@ -16,13 +16,11 @@
 #pragma once
 
 #include <cstring>
-#include <nlohmann/json.hpp>
 
 #include "basic_io.h"
 #include "index/index_common_param.h"
 #include "memory_io_parameter.h"
 #include "prefetch.h"
-#include "vsag/allocator.h"
 
 namespace vsag {
 

--- a/src/io/mmap_io.cpp
+++ b/src/io/mmap_io.cpp
@@ -15,6 +15,13 @@
 
 #include "mmap_io.h"
 
+#include <sys/mman.h>
+
+#include <filesystem>
+#include <utility>
+
+#include "index/index_common_param.h"
+
 namespace vsag {
 
 MMapIO::MMapIO(std::string filename, Allocator* allocator)

--- a/src/io/mmap_io.h
+++ b/src/io/mmap_io.h
@@ -15,16 +15,13 @@
 
 #pragma once
 
-#include <sys/mman.h>
-
-#include <filesystem>
-#include <utility>
-
 #include "basic_io.h"
-#include "index/index_common_param.h"
 #include "mmap_io_parameter.h"
 
 namespace vsag {
+
+class IndexCommonParam;
+class Allocator;
 
 class MMapIO : public BasicIO<MMapIO> {
 public:

--- a/src/io/mmap_io_test.cpp
+++ b/src/io/mmap_io_test.cpp
@@ -20,6 +20,7 @@
 
 #include "basic_io_test.h"
 #include "impl/allocator/safe_allocator.h"
+#include "index/index_common_param.h"
 
 using namespace vsag;
 

--- a/src/io/reader_io.h
+++ b/src/io/reader_io.h
@@ -18,7 +18,6 @@
 #include "basic_io.h"
 #include "index/index_common_param.h"
 #include "reader_io_parameter.h"
-#include "vsag/allocator.h"
 
 namespace vsag {
 

--- a/src/quantization/computer.h
+++ b/src/quantization/computer.h
@@ -21,6 +21,7 @@
 #include "metric_type.h"
 #include "pointer_define.h"
 #include "vsag/allocator.h"
+
 namespace vsag {
 DEFINE_POINTER(ComputerInterface);
 

--- a/src/quantization/scalar_quantization/sq4_uniform_quantizer.cpp
+++ b/src/quantization/scalar_quantization/sq4_uniform_quantizer.cpp
@@ -17,9 +17,11 @@
 
 #include <cstddef>
 
+#include "index/index_common_param.h"
 #include "scalar_quantization_trainer.h"
 #include "simd/normalize.h"
 #include "simd/sq4_uniform_simd.h"
+#include "sq4_uniform_quantizer_parameter.h"
 #include "typing.h"
 #include "utils/util_functions.h"
 

--- a/src/quantization/scalar_quantization/sq4_uniform_quantizer.h
+++ b/src/quantization/scalar_quantization/sq4_uniform_quantizer.h
@@ -15,12 +15,16 @@
 
 #pragma once
 
-#include "index/index_common_param.h"
 #include "inner_string_params.h"
+#include "metric_type.h"
+#include "pointer_define.h"
 #include "quantization/quantizer.h"
-#include "sq4_uniform_quantizer_parameter.h"
 
 namespace vsag {
+
+DEFINE_POINTER2(SQ4UniformQuantizerParam, SQ4UniformQuantizerParameter);
+DEFINE_POINTER2(QuantizerParam, QuantizerParameter);
+class IndexCommonParam;
 
 using sum_type = float;
 

--- a/src/simd/avx.cpp
+++ b/src/simd/avx.cpp
@@ -31,7 +31,7 @@ float
 L2Sqr(const void* pVect1v, const void* pVect2v, const void* qty_ptr) {
     auto* pVect1 = (float*)pVect1v;
     auto* pVect2 = (float*)pVect2v;
-    auto qty = *((size_t*)qty_ptr);
+    auto qty = *((uint64_t*)qty_ptr);
     return avx::FP32ComputeL2Sqr(pVect1, pVect2, qty);
 }
 
@@ -39,7 +39,7 @@ float
 InnerProduct(const void* pVect1v, const void* pVect2v, const void* qty_ptr) {
     auto* pVect1 = (float*)pVect1v;
     auto* pVect2 = (float*)pVect2v;
-    auto qty = *((size_t*)qty_ptr);
+    auto qty = *((uint64_t*)qty_ptr);
     return avx::FP32ComputeIP(pVect1, pVect2, qty);
 }
 
@@ -52,7 +52,7 @@ float
 INT8L2Sqr(const void* pVect1v, const void* pVect2v, const void* qty_ptr) {
     auto* pVect1 = (int8_t*)pVect1v;
     auto* pVect2 = (int8_t*)pVect2v;
-    auto qty = *((size_t*)qty_ptr);
+    auto qty = *((uint64_t*)qty_ptr);
     return avx::INT8ComputeL2Sqr(pVect1, pVect2, qty);
 }
 
@@ -71,7 +71,7 @@ PQDistanceFloat256(const void* single_dim_centers, float single_dim_val, void* r
 #if defined(ENABLE_AVX)
     auto* float_centers = (const float*)single_dim_centers;
     auto* float_result = (float*)result;
-    for (size_t idx = 0; idx < 256; idx += 8) {
+    for (uint64_t idx = 0; idx < 256; idx += 8) {
         __m256 v_centers_dim = _mm256_loadu_ps(float_centers + idx);
         __m256 v_query_vec = _mm256_set1_ps(single_dim_val);
         __m256 v_diff = _mm256_sub_ps(v_centers_dim, v_query_vec);
@@ -954,7 +954,7 @@ BitNot(const uint8_t* x, const uint64_t num_byte, uint8_t* result) {
 #endif
 }
 void
-VecRescale(float* data, size_t dim, float val) {
+VecRescale(float* data, uint64_t dim, float val) {
 #if defined(ENABLE_AVX)
     int i = 0;
     __m256 val_vec = _mm256_set1_ps(val);
@@ -990,10 +990,10 @@ RotateOp(float* data, int idx, int dim_, int step) {
 }
 
 void
-FHTRotate(float* data, size_t dim_) {
+FHTRotate(float* data, uint64_t dim_) {
 #if defined(ENABLE_AVX)
-    size_t n = dim_;
-    size_t step = 1;
+    uint64_t n = dim_;
+    uint64_t step = 1;
     while (step < n) {
         if (step >= 8) {
             avx::RotateOp(data, 0, dim_, step);
@@ -1010,11 +1010,11 @@ FHTRotate(float* data, size_t dim_) {
 }
 
 void
-KacsWalk(float* data, size_t len) {
+KacsWalk(float* data, uint64_t len) {
 #if defined(ENABLE_AVX)
-    size_t base = len % 2;
-    size_t offset = base + (len / 2);
-    size_t i = 0;
+    uint64_t base = len % 2;
+    uint64_t offset = base + (len / 2);
+    uint64_t i = 0;
 
     for (; i + 8 <= len / 2; i += 8) {
         __m256 x = _mm256_loadu_ps(&data[i]);

--- a/src/simd/avx2.cpp
+++ b/src/simd/avx2.cpp
@@ -52,7 +52,7 @@ float
 INT8L2Sqr(const void* pVect1v, const void* pVect2v, const void* qty_ptr) {
     auto* pVect1 = (int8_t*)pVect1v;
     auto* pVect2 = (int8_t*)pVect2v;
-    auto qty = *((size_t*)qty_ptr);
+    auto qty = *((uint64_t*)qty_ptr);
     return avx2::INT8ComputeL2Sqr(pVect1, pVect2, qty);
 }
 
@@ -912,7 +912,7 @@ PQFastScanLookUp32(const uint8_t* RESTRICT lookup_table,
         return;
     }
     __m256i sum[4];
-    for (size_t i = 0; i < 4; i++) {
+    for (uint64_t i = 0; i < 4; i++) {
         sum[i] = _mm256_setzero_si256();
     }
     const auto sign4 = _mm256_set1_epi8(0x0F);
@@ -1043,7 +1043,7 @@ BitNot(const uint8_t* x, const uint64_t num_byte, uint8_t* result) {
 }
 
 void
-VecRescale(float* data, size_t dim, float val) {
+VecRescale(float* data, uint64_t dim, float val) {
 #if defined(ENABLE_AVX2)
     int i = 0;
     __m256 val_vec = _mm256_set1_ps(val);
@@ -1076,10 +1076,10 @@ RotateOp(float* data, int idx, int dim_, int step) {
 }
 
 void
-FHTRotate(float* data, size_t dim_) {
+FHTRotate(float* data, uint64_t dim_) {
 #if defined(ENABLE_AVX2)
-    size_t n = dim_;
-    size_t step = 1;
+    uint64_t n = dim_;
+    uint64_t step = 1;
     while (step < n) {
         if (step >= 8) {
             avx2::RotateOp(data, 0, dim_, step);
@@ -1096,11 +1096,11 @@ FHTRotate(float* data, size_t dim_) {
 }
 
 void
-KacsWalk(float* data, size_t len) {
+KacsWalk(float* data, uint64_t len) {
 #if defined(ENABLE_AVX2)
-    size_t base = len % 2;
-    size_t offset = base + (len / 2);  // for odd dim
-    size_t i = 0;
+    uint64_t base = len % 2;
+    uint64_t offset = base + (len / 2);  // for odd dim
+    uint64_t i = 0;
     for (; i + 8 < len / 2; i += 8) {
         __m256 x = _mm256_loadu_ps(&data[i]);
         __m256 y = _mm256_loadu_ps(&data[i + offset]);

--- a/src/simd/avx512.cpp
+++ b/src/simd/avx512.cpp
@@ -28,7 +28,7 @@ float
 L2Sqr(const void* pVect1v, const void* pVect2v, const void* qty_ptr) {
     auto* float_vec1 = (float*)pVect1v;
     auto* float_vec2 = (float*)pVect2v;
-    size_t dim = *((size_t*)qty_ptr);
+    uint64_t dim = *((uint64_t*)qty_ptr);
     return avx512::FP32ComputeL2Sqr(float_vec1, float_vec2, dim);
 }
 
@@ -36,7 +36,7 @@ float
 InnerProduct(const void* pVect1v, const void* pVect2v, const void* qty_ptr) {
     auto* float_vec1 = (float*)pVect1v;
     auto* float_vec2 = (float*)pVect2v;
-    size_t dim = *((size_t*)qty_ptr);
+    uint64_t dim = *((uint64_t*)qty_ptr);
     return avx512::FP32ComputeIP(float_vec1, float_vec2, dim);
 }
 
@@ -49,7 +49,7 @@ float
 INT8L2Sqr(const void* pVect1v, const void* pVect2v, const void* qty_ptr) {
     auto* pVect1 = (int8_t*)pVect1v;
     auto* pVect2 = (int8_t*)pVect2v;
-    auto qty = *((size_t*)qty_ptr);
+    auto qty = *((uint64_t*)qty_ptr);
     return avx512::INT8ComputeL2Sqr(pVect1, pVect2, qty);
 }
 
@@ -58,7 +58,7 @@ INT8InnerProduct(const void* pVect1v, const void* pVect2v, const void* qty_ptr) 
 #if defined(ENABLE_AVX512)
     __mmask32 mask = 0xFFFFFFFF;
 
-    auto qty = *((size_t*)qty_ptr);
+    auto qty = *((uint64_t*)qty_ptr);
     const uint32_t n = (qty >> 5);
     if (n == 0) {
         return avx2::INT8InnerProduct(pVect1v, pVect2v, qty_ptr);
@@ -887,12 +887,12 @@ RaBitQSQ4UBinaryIP(const uint8_t* codes, const uint8_t* bits, uint64_t dim) {
                                              0x0403030203020201llu);
 
     uint32_t result = 0;
-    size_t num_bytes = (dim + 7) / 8;
+    uint64_t num_bytes = (dim + 7) / 8;
 
     const __m512i low_mask = _mm512_set1_epi8(0x0F);
 
     for (uint64_t bit_pos = 0; bit_pos < 4; ++bit_pos) {
-        size_t i = 0;
+        uint64_t i = 0;
 
         __m512i acc = _mm512_setzero_si512();
 
@@ -983,7 +983,7 @@ PQFastScanLookUp32(const uint8_t* RESTRICT lookup_table,
         return;
     }
     __m512i sum[4];
-    for (size_t i = 0; i < 4; i++) {
+    for (uint64_t i = 0; i < 4; i++) {
         sum[i] = _mm512_setzero_si512();
     }
     const auto sign4 = _mm512_set1_epi8(0x0F);
@@ -1114,7 +1114,7 @@ BitNot(const uint8_t* x, const uint64_t num_byte, uint8_t* result) {
 }
 
 void
-KacsWalk(float* data, size_t len) {
+KacsWalk(float* data, uint64_t len) {
 #if defined(ENABLE_AVX512)
     int base = len % 2;
     int offset = base + (len / 2);
@@ -1144,10 +1144,10 @@ KacsWalk(float* data, size_t len) {
 }
 
 void
-FlipSign(const uint8_t* flip, float* data, size_t dim) {
+FlipSign(const uint8_t* flip, float* data, uint64_t dim) {
 #if defined(ENABLE_AVX512)
-    constexpr size_t kFloatsPerChunk = 64;
-    size_t i = 0;
+    constexpr uint64_t kFloatsPerChunk = 64;
+    uint64_t i = 0;
     for (; i + 64 < dim; i += kFloatsPerChunk) {
         // Load 64 bits (8 bytes) from the bit sequence
         uint64_t mask_bits;
@@ -1191,10 +1191,10 @@ FlipSign(const uint8_t* flip, float* data, size_t dim) {
 }
 
 void
-VecRescale(float* data, size_t dim, float val) {
+VecRescale(float* data, uint64_t dim, float val) {
 #if defined(ENABLE_AVX512)
     __m512 scalar = _mm512_set1_ps(val);
-    size_t i = 0;
+    uint64_t i = 0;
     for (; i + 16 <= dim; i += 16) {
         __m512 vec = _mm512_loadu_ps(&data[i]);
         vec = _mm512_mul_ps(vec, scalar);
@@ -1223,10 +1223,10 @@ RotateOp(float* data, int idx, int dim_, int step) {
 }
 
 void
-FHTRotate(float* data, size_t dim_) {
+FHTRotate(float* data, uint64_t dim_) {
 #if defined(ENABLE_AVX512)
-    size_t n = dim_;
-    size_t step = 1;
+    uint64_t n = dim_;
+    uint64_t step = 1;
     while (step < n) {
         if (step >= 16) {  // step is the power of 2
             avx512::RotateOp(data, 0, dim_, step);

--- a/src/simd/avx512vpopcntdq.cpp
+++ b/src/simd/avx512vpopcntdq.cpp
@@ -29,10 +29,10 @@ RaBitQSQ4UBinaryIP(const uint8_t* codes, const uint8_t* bits, uint64_t dim) {
     }
 
     uint32_t result = 0;
-    size_t num_bytes = (dim + 7) / 8;
+    uint64_t num_bytes = (dim + 7) / 8;
 
     for (uint64_t bit_pos = 0; bit_pos < 4; ++bit_pos) {
-        size_t i = 0;
+        uint64_t i = 0;
 
         __m512i acc = _mm512_setzero_si512();
         const uint8_t* cur = codes + bit_pos * num_bytes;

--- a/src/simd/basic_func_test.cpp
+++ b/src/simd/basic_func_test.cpp
@@ -84,7 +84,7 @@ TEST_CASE("Int8 SIMD Compute", "[ut][simd][int8]") {
 }
 
 TEST_CASE("PQ Calculation", "[ut][simd]") {
-    size_t dim = 256;
+    uint64_t dim = 256;
     float single_dim_value = 0.571;
     float results_expected[256]{0.0f};
     float results[256]{0.0f};

--- a/src/simd/bf16_simd.h
+++ b/src/simd/bf16_simd.h
@@ -16,7 +16,6 @@
 #pragma once
 
 #include <cstdint>
-#include <string>
 
 #include "simd_marco.h"
 

--- a/src/simd/bit_simd.h
+++ b/src/simd/bit_simd.h
@@ -16,7 +16,6 @@
 #pragma once
 
 #include <cstdint>
-#include <string>
 
 namespace vsag {
 

--- a/src/simd/fp16_simd.h
+++ b/src/simd/fp16_simd.h
@@ -16,7 +16,6 @@
 #pragma once
 
 #include <cstdint>
-#include <string>
 
 #include "simd_marco.h"
 namespace vsag {

--- a/src/simd/fp32_simd.h
+++ b/src/simd/fp32_simd.h
@@ -16,7 +16,6 @@
 #pragma once
 
 #include <cstdint>
-#include <string>
 
 #include "simd_marco.h"
 namespace vsag {

--- a/src/simd/generic.cpp
+++ b/src/simd/generic.cpp
@@ -492,7 +492,7 @@ RaBitQFloatBinaryIP(const float* vector, const uint8_t* bits, uint64_t dim, floa
 
     float result = 0.0f;
 
-    for (std::size_t d = 0; d < dim; ++d) {
+    for (uint64_t d = 0; d < dim; ++d) {
         bool bit = ((bits[d / 8] >> (d % 8)) & 1) != 0;
         float b_i = bit ? inv_sqrt_d : -inv_sqrt_d;
         result += b_i * vector[d];
@@ -510,16 +510,16 @@ RaBitQSQ4UBinaryIP(const uint8_t* codes, const uint8_t* bits, uint64_t dim) {
     }
 
     uint32_t result = 0;
-    size_t num_bytes = (dim + 7) / 8;
-    size_t num_blocks = num_bytes / 8;
-    size_t remainder = num_bytes % 8;
+    uint64_t num_bytes = (dim + 7) / 8;
+    uint64_t num_blocks = num_bytes / 8;
+    uint64_t remainder = num_bytes % 8;
 
     for (uint64_t bit_pos = 0; bit_pos < 4; ++bit_pos) {
         const uint64_t* codes_block =
             reinterpret_cast<const uint64_t*>(codes + bit_pos * num_bytes);
         const uint64_t* bits_block = reinterpret_cast<const uint64_t*>(bits);
 
-        for (size_t i = 0; i < num_blocks; ++i) {
+        for (uint64_t i = 0; i < num_blocks; ++i) {
             uint64_t bitwise_and = codes_block[i] & bits_block[i];
             result += __builtin_popcountll(bitwise_and) << bit_pos;
         }
@@ -528,7 +528,7 @@ RaBitQSQ4UBinaryIP(const uint8_t* codes, const uint8_t* bits, uint64_t dim) {
             uint64_t leftover_code = 0;
             uint64_t leftover_bits = 0;
 
-            for (size_t i = 0; i < remainder; ++i) {
+            for (uint64_t i = 0; i < remainder; ++i) {
                 leftover_code |=
                     static_cast<uint64_t>(codes[bit_pos * num_bytes + num_blocks * 8 + i])
                     << (i * 8);
@@ -599,12 +599,12 @@ PQFastScanLookUp32(const uint8_t* RESTRICT lookup_table,
                    const uint8_t* RESTRICT codes,
                    uint64_t pq_dim,
                    int32_t* RESTRICT result) {
-    for (size_t i = 0; i < pq_dim; i++) {
+    for (uint64_t i = 0; i < pq_dim; i++) {
         const auto* dict = lookup_table;
         lookup_table += 16;
         const auto* code = codes;
         codes += 16;
-        for (size_t j = 0; j < 16; j++) {
+        for (uint64_t j = 0; j < 16; j++) {
             if (j % 2 == 0) {
                 result[j / 2] += static_cast<uint32_t>(dict[code[j] & 0x0F]);
                 result[16 + j / 2] += static_cast<uint32_t>(dict[(code[j] >> 4)]);
@@ -645,10 +645,10 @@ BitNot(const uint8_t* x, const uint64_t num_byte, uint8_t* result) {
 }
 
 void
-KacsWalk(float* data, size_t len) {
-    size_t base = len % 2;
-    size_t offset = base + (len / 2);  // for odd dim
-    for (size_t i = 0; i < len / 2; i++) {
+KacsWalk(float* data, uint64_t len) {
+    uint64_t base = len % 2;
+    uint64_t offset = base + (len / 2);  // for odd dim
+    for (uint64_t i = 0; i < len / 2; i++) {
         float add = data[i] + data[i + offset];
         float sub = data[i] - data[i + offset];
         data[i] = add;
@@ -662,8 +662,8 @@ KacsWalk(float* data, size_t len) {
 }
 
 void
-FlipSign(const uint8_t* flip, float* data, size_t dim) {
-    for (size_t i = 0; i < dim; i++) {
+FlipSign(const uint8_t* flip, float* data, uint64_t dim) {
+    for (uint64_t i = 0; i < dim; i++) {
         bool mask = (flip[i / 8] & (1 << (i % 8))) != 0;
         if (mask) {
             data[i] = -data[i];
@@ -672,7 +672,7 @@ FlipSign(const uint8_t* flip, float* data, size_t dim) {
 }
 
 void
-VecRescale(float* data, size_t dim, float val) {
+VecRescale(float* data, uint64_t dim, float val) {
     for (int i = 0; i < dim; i++) {
         data[i] *= val;
     }
@@ -691,9 +691,9 @@ RotateOp(float* data, int idx, int dim_, int step) {
 }
 
 void
-FHTRotate(float* data, size_t dim_) {
-    size_t n = dim_;
-    size_t step = 1;
+FHTRotate(float* data, uint64_t dim_) {
+    uint64_t n = dim_;
+    uint64_t step = 1;
     while (step < n) {
         generic::RotateOp(data, 0, dim_, step);
         step *= 2;

--- a/src/simd/int8_simd.h
+++ b/src/simd/int8_simd.h
@@ -16,7 +16,6 @@
 #pragma once
 
 #include <cstdint>
-#include <string>
 
 #include "simd_marco.h"
 namespace vsag {

--- a/src/simd/neon.cpp
+++ b/src/simd/neon.cpp
@@ -30,7 +30,7 @@ float
 L2Sqr(const void* pVect1v, const void* pVect2v, const void* qty_ptr) {
     auto* pVect1 = (float*)pVect1v;
     auto* pVect2 = (float*)pVect2v;
-    auto qty = *((size_t*)qty_ptr);
+    auto qty = *((uint64_t*)qty_ptr);
     return neon::FP32ComputeL2Sqr(pVect1, pVect2, qty);
 }
 
@@ -38,7 +38,7 @@ float
 InnerProduct(const void* pVect1v, const void* pVect2v, const void* qty_ptr) {
     auto* pVect1 = (float*)pVect1v;
     auto* pVect2 = (float*)pVect2v;
-    auto qty = *((size_t*)qty_ptr);
+    auto qty = *((uint64_t*)qty_ptr);
     return neon::FP32ComputeIP(pVect1, pVect2, qty);
 }
 
@@ -51,7 +51,7 @@ float
 INT8L2Sqr(const void* pVect1v, const void* pVect2v, const void* qty_ptr) {
     auto* pVect1 = (int8_t*)pVect1v;
     auto* pVect2 = (int8_t*)pVect2v;
-    auto qty = *((size_t*)qty_ptr);
+    auto qty = *((uint64_t*)qty_ptr);
 
     return neon::INT8ComputeL2Sqr(pVect1, pVect2, qty);
 }
@@ -113,7 +113,7 @@ PQDistanceFloat256(const void* single_dim_centers, float single_dim_val, void* r
 #if defined(ENABLE_NEON)
     const auto* float_centers = (const float*)single_dim_centers;
     auto* float_result = (float*)result;
-    for (size_t idx = 0; idx < 256; idx += 8) {
+    for (uint64_t idx = 0; idx < 256; idx += 8) {
         float32x4x2_t v_centers_dim = vld1q_f32_x2(float_centers + idx);
         float32x4x2_t v_query_vec = {vdupq_n_f32(single_dim_val), vdupq_n_f32(single_dim_val)};
 
@@ -1577,7 +1577,7 @@ SQ8UniformComputeCodesIP(const uint8_t* codes1, const uint8_t* codes2, uint64_t 
         d -= 4;
     }
     int32_t rem_sum = 0;
-    for (size_t i = 0; i < d; ++i) {
+    for (uint64_t i = 0; i < d; ++i) {
         rem_sum += static_cast<int32_t>(codes1[i]) * static_cast<int32_t>(codes2[i]);
     }
 
@@ -1590,12 +1590,12 @@ SQ8UniformComputeCodesIP(const uint8_t* codes1, const uint8_t* codes2, uint64_t 
 
 #if defined(ENABLE_NEON)
 __inline void __attribute__((__always_inline__)) extract_12_bits_to_mask(const uint8_t* bits,
-                                                                         size_t bit_offset,
+                                                                         uint64_t bit_offset,
                                                                          uint32x4_t& mask0,
                                                                          uint32x4_t& mask1,
                                                                          uint32x4_t& mask2) {
-    size_t byte_idx = bit_offset / 8;
-    size_t bit_start = bit_offset % 8;
+    uint64_t byte_idx = bit_offset / 8;
+    uint64_t bit_start = bit_offset % 8;
 
     uint32_t mask_bits;
     if (bit_start <= 4) {
@@ -1626,11 +1626,11 @@ __inline void __attribute__((__always_inline__)) extract_12_bits_to_mask(const u
 }
 
 __inline void __attribute__((__always_inline__)) extract_8_bits_to_mask(const uint8_t* bits,
-                                                                        size_t bit_offset,
+                                                                        uint64_t bit_offset,
                                                                         uint32x4_t& mask0,
                                                                         uint32x4_t& mask1) {
-    size_t byte_idx = bit_offset / 8;
-    size_t bit_start = bit_offset % 8;
+    uint64_t byte_idx = bit_offset / 8;
+    uint64_t bit_start = bit_offset % 8;
 
     uint16_t mask_bits;
     if (bit_start == 0) {
@@ -1653,9 +1653,9 @@ __inline void __attribute__((__always_inline__)) extract_8_bits_to_mask(const ui
 }
 
 __inline uint32x4_t __attribute__((__always_inline__))
-extract_4_bits_to_mask(const uint8_t* bits, size_t bit_offset) {
-    size_t byte_idx = bit_offset / 8;
-    size_t bit_start = bit_offset % 8;
+extract_4_bits_to_mask(const uint8_t* bits, uint64_t bit_offset) {
+    uint64_t byte_idx = bit_offset / 8;
+    uint64_t bit_start = bit_offset % 8;
 
     uint8_t mask_bits;
     if (bit_start <= 4) {
@@ -1740,8 +1740,8 @@ RaBitQFloatBinaryIP(const float* vector, const uint8_t* bits, uint64_t dim, floa
 
     if (remaining >= 3) {
         res_vec = vld1q_lane_f32(vector + d, res_vec, 2);
-        size_t byte_idx = d / 8;
-        size_t bit_idx = d % 8;
+        uint64_t byte_idx = d / 8;
+        uint64_t bit_idx = d % 8;
         bool bit_set = (bits[byte_idx] & (1 << bit_idx)) != 0;
         res_b = vsetq_lane_f32(bit_set ? inv_sqrt_d : -inv_sqrt_d, res_b, 2);
         d++;
@@ -1750,8 +1750,8 @@ RaBitQFloatBinaryIP(const float* vector, const uint8_t* bits, uint64_t dim, floa
 
     if (remaining >= 2) {
         res_vec = vld1q_lane_f32(vector + d, res_vec, 1);
-        size_t byte_idx = d / 8;
-        size_t bit_idx = d % 8;
+        uint64_t byte_idx = d / 8;
+        uint64_t bit_idx = d % 8;
         bool bit_set = (bits[byte_idx] & (1 << bit_idx)) != 0;
         res_b = vsetq_lane_f32(bit_set ? inv_sqrt_d : -inv_sqrt_d, res_b, 1);
         d++;
@@ -1760,8 +1760,8 @@ RaBitQFloatBinaryIP(const float* vector, const uint8_t* bits, uint64_t dim, floa
 
     if (remaining >= 1) {
         res_vec = vld1q_lane_f32(vector + d, res_vec, 0);
-        size_t byte_idx = d / 8;
-        size_t bit_idx = d % 8;
+        uint64_t byte_idx = d / 8;
+        uint64_t bit_idx = d % 8;
         bool bit_set = (bits[byte_idx] & (1 << bit_idx)) != 0;
         res_b = vsetq_lane_f32(bit_set ? inv_sqrt_d : -inv_sqrt_d, res_b, 0);
     }
@@ -1828,13 +1828,13 @@ PQFastScanLookUp32(const uint8_t* RESTRICT lookup_table,
                    int32_t* RESTRICT result) {
 #if defined(ENABLE_NEON)
     uint32x4_t sum[4];
-    for (size_t i = 0; i < 4; ++i) {
+    for (uint64_t i = 0; i < 4; ++i) {
         sum[i] = vdupq_n_u32(0);
     }
     const auto sign4 = vdupq_n_u8(0x0F);
     const auto sign8 = vdupq_n_u16(0xFF);
 
-    for (size_t i = 0; i < pq_dim; ++i) {
+    for (uint64_t i = 0; i < pq_dim; ++i) {
         auto dict = vld1q_u8(lookup_table);
         auto code = vld1q_u8(codes);
         lookup_table += 16;
@@ -1967,7 +1967,7 @@ RaBitQSQ4UBinaryIP(const uint8_t* codes, const uint8_t* bits, uint64_t dim) {
 }
 
 void
-KacsWalk(float* data, size_t len) {
+KacsWalk(float* data, uint64_t len) {
 #if defined(ENABLE_NEON)
     // TODO: NEON implementation here
     generic::KacsWalk(data, len);
@@ -1977,7 +1977,7 @@ KacsWalk(float* data, size_t len) {
 }
 
 void
-FlipSign(const uint8_t* flip, float* data, size_t dim) {
+FlipSign(const uint8_t* flip, float* data, uint64_t dim) {
 #if defined(ENABLE_NEON)
     // TODO: NEON implementation here
     generic::FlipSign(flip, data, dim);
@@ -1987,7 +1987,7 @@ FlipSign(const uint8_t* flip, float* data, size_t dim) {
 }
 
 void
-VecRescale(float* data, size_t dim, float val) {
+VecRescale(float* data, uint64_t dim, float val) {
 #if defined(ENABLE_NEON)
     // TODO: NEON implementation here
     generic::VecRescale(data, dim, val);
@@ -2007,7 +2007,7 @@ RotateOp(float* data, int idx, int dim_, int step) {
 }
 
 void
-FHTRotate(float* data, size_t dim_) {
+FHTRotate(float* data, uint64_t dim_) {
 #if defined(ENABLE_NEON)
     // TODO: NEON implementation here
     generic::FHTRotate(data, dim_);

--- a/src/simd/pqfs_simd.h
+++ b/src/simd/pqfs_simd.h
@@ -16,7 +16,6 @@
 #pragma once
 
 #include <cstdint>
-#include <string>
 
 #include "simd_marco.h"
 

--- a/src/simd/pqfs_simd_test.cpp
+++ b/src/simd/pqfs_simd_test.cpp
@@ -29,7 +29,7 @@ compare_vector(std::vector<T>& v1, std::vector<T>& v2) {
     if (v1.size() != v2.size()) {
         return false;
     }
-    for (size_t i = 0; i < v1.size(); ++i) {
+    for (uint64_t i = 0; i < v1.size(); ++i) {
         if (v1[i] != v2[i]) {
             return false;
         }

--- a/src/simd/rabitq_simd.cpp
+++ b/src/simd/rabitq_simd.cpp
@@ -14,6 +14,8 @@
 
 #include "rabitq_simd.h"
 
+#include "simd_status.h"
+
 namespace vsag {
 
 static RaBitQFloatBinaryType

--- a/src/simd/rabitq_simd.h
+++ b/src/simd/rabitq_simd.h
@@ -17,8 +17,6 @@
 
 #include <cstdint>
 
-#include "simd_status.h"
-
 namespace vsag {
 
 namespace avx512vpopcntdq {
@@ -36,16 +34,16 @@ uint32_t
 RaBitQSQ4UBinaryIP(const uint8_t* codes, const uint8_t* bits, uint64_t dim);
 
 void
-KacsWalk(float* data, std::size_t len);
+KacsWalk(float* data, uint64_t len);
 
 void
-VecRescale(float* data, std::size_t dim, float val);
+VecRescale(float* data, uint64_t dim, float val);
 
 void
-FHTRotate(float* data, std::size_t dim_);
+FHTRotate(float* data, uint64_t dim_);
 
 void
-FlipSign(const uint8_t* flip, float* data, std::size_t dim);
+FlipSign(const uint8_t* flip, float* data, uint64_t dim);
 
 void
 RotateOp(float* data, int idx, int dim_, int step);
@@ -56,16 +54,16 @@ float
 RaBitQFloatBinaryIP(const float* vector, const uint8_t* bits, uint64_t dim, float inv_sqrt_d);
 
 void
-FHTRotate(float* data, std::size_t dim_);
+FHTRotate(float* data, uint64_t dim_);
 
 void
 RotateOp(float* data, int idx, int dim_, int step);
 
 void
-VecRescale(float* data, std::size_t dim, float val);
+VecRescale(float* data, uint64_t dim, float val);
 
 void
-KacsWalk(float* data, std::size_t len);
+KacsWalk(float* data, uint64_t len);
 }  // namespace avx2
 
 namespace avx {
@@ -73,19 +71,19 @@ float
 RaBitQFloatBinaryIP(const float* vector, const uint8_t* bits, uint64_t dim, float inv_sqrt_d);
 
 void
-VecRescale(float* data, std::size_t dim, float val);
+VecRescale(float* data, uint64_t dim, float val);
 
 void
-FHTRotate(float* data, std::size_t dim_);
+FHTRotate(float* data, uint64_t dim_);
 
 void
-FlipSign(const uint8_t* flip, float* data, std::size_t dim);
+FlipSign(const uint8_t* flip, float* data, uint64_t dim);
 
 void
 RotateOp(float* data, int idx, int dim_, int step);
 
 void
-KacsWalk(float* data, std::size_t len);
+KacsWalk(float* data, uint64_t len);
 }  // namespace avx
 
 namespace sse {
@@ -93,16 +91,16 @@ float
 RaBitQFloatBinaryIP(const float* vector, const uint8_t* bits, uint64_t dim, float inv_sqrt_d);
 
 void
-FHTRotate(float* data, std::size_t dim_);
+FHTRotate(float* data, uint64_t dim_);
 
 void
 RotateOp(float* data, int idx, int dim_, int step);
 
 void
-VecRescale(float* data, std::size_t dim, float val);
+VecRescale(float* data, uint64_t dim, float val);
 
 void
-KacsWalk(float* data, std::size_t len);
+KacsWalk(float* data, uint64_t len);
 }  // namespace sse
 
 namespace generic {
@@ -113,16 +111,16 @@ uint32_t
 RaBitQSQ4UBinaryIP(const uint8_t* codes, const uint8_t* bits, uint64_t dim);
 
 void
-KacsWalk(float* data, std::size_t len);
+KacsWalk(float* data, uint64_t len);
 
 void
-VecRescale(float* data, std::size_t dim, float val);
+VecRescale(float* data, uint64_t dim, float val);
 
 void
-FHTRotate(float* data, std::size_t dim_);
+FHTRotate(float* data, uint64_t dim_);
 
 void
-FlipSign(const uint8_t* flip, float* data, std::size_t dim);
+FlipSign(const uint8_t* flip, float* data, uint64_t dim);
 
 void
 RotateOp(float* data, int idx, int dim_, int step);
@@ -136,16 +134,16 @@ uint32_t
 RaBitQSQ4UBinaryIP(const uint8_t* codes, const uint8_t* bits, uint64_t dim);
 
 void
-KacsWalk(float* data, std::size_t len);
+KacsWalk(float* data, uint64_t len);
 
 void
-VecRescale(float* data, std::size_t dim, float val);
+VecRescale(float* data, uint64_t dim, float val);
 
 void
-FHTRotate(float* data, std::size_t dim_);
+FHTRotate(float* data, uint64_t dim_);
 
 void
-FlipSign(const uint8_t* flip, float* data, std::size_t dim);
+FlipSign(const uint8_t* flip, float* data, uint64_t dim);
 
 void
 RotateOp(float* data, int idx, int dim_, int step);
@@ -159,16 +157,16 @@ uint32_t
 RaBitQSQ4UBinaryIP(const uint8_t* codes, const uint8_t* bits, uint64_t dim);
 
 void
-KacsWalk(float* data, std::size_t len);
+KacsWalk(float* data, uint64_t len);
 
 void
-VecRescale(float* data, std::size_t dim, float val);
+VecRescale(float* data, uint64_t dim, float val);
 
 void
-FHTRotate(float* data, std::size_t dim_);
+FHTRotate(float* data, uint64_t dim_);
 
 void
-FlipSign(const uint8_t* flip, float* data, std::size_t dim);
+FlipSign(const uint8_t* flip, float* data, uint64_t dim);
 
 void
 RotateOp(float* data, int idx, int dim_, int step);
@@ -181,13 +179,13 @@ using RaBitQFloatBinaryType = float (*)(const float* vector,
 
 using RaBitQSQ4UBinaryType = uint32_t (*)(const uint8_t* codes, const uint8_t* bits, uint64_t dim);
 
-using FHTRotateType = void (*)(float* data, size_t dim_);
+using FHTRotateType = void (*)(float* data, uint64_t dim_);
 
-using KacsWalkType = void (*)(float* data, size_t len);
+using KacsWalkType = void (*)(float* data, uint64_t len);
 
-using VecRescaleType = void (*)(float* data, size_t dim, float val);
+using VecRescaleType = void (*)(float* data, uint64_t dim, float val);
 
-using FlipSignType = void (*)(const uint8_t* flip, float* data, size_t dim);
+using FlipSignType = void (*)(const uint8_t* flip, float* data, uint64_t dim);
 
 using RotateOpType = void (*)(float* data, int idx, int dim_, int step);
 extern RaBitQFloatBinaryType RaBitQFloatBinaryIP;

--- a/src/simd/rabitq_simd_test.cpp
+++ b/src/simd/rabitq_simd_test.cpp
@@ -20,6 +20,7 @@
 
 #include "fixtures.h"
 #include "fp32_simd.h"
+#include "simd_status.h"
 
 using namespace vsag;
 
@@ -363,13 +364,13 @@ TEST_CASE("SIMD test for rotate", "[ut][simd]") {
         const float delta = 1e-5;
         for (int i = 0; i < count; i++) {
             auto* gt_data = gt.data() + i * dim;
-            size_t tmp_dim = dim;
-            size_t ret = 0;
+            uint64_t tmp_dim = dim;
+            uint64_t ret = 0;
             while (tmp_dim > 1) {
                 ret++;
                 tmp_dim >>= 1;
             }
-            size_t trunc_dim = 1 << ret;
+            uint64_t trunc_dim = 1 << ret;
             int start = dim - trunc_dim;
             generic::FHTRotate(gt_data, trunc_dim);
             generic::FHTRotate(gt_data + start, trunc_dim);

--- a/src/simd/simd_test.cpp
+++ b/src/simd/simd_test.cpp
@@ -23,7 +23,7 @@ namespace vsag {
 
 typedef float (*DistanceFunc)(const void* pVect1, const void* pVect2, const void* qty_ptr);
 extern DistanceFunc
-GetL2DistanceFunc(size_t dim);
+GetL2DistanceFunc(uint64_t dim);
 
 }  // namespace vsag
 
@@ -31,10 +31,10 @@ float
 L2SqrGT(const void* pVect1v, const void* pVect2v, const void* qty_ptr) {
     float* pVect1 = (float*)pVect1v;
     float* pVect2 = (float*)pVect2v;
-    size_t qty = *((size_t*)qty_ptr);
+    uint64_t qty = *((uint64_t*)qty_ptr);
 
     float res = 0;
-    for (size_t i = 0; i < qty; i++) {
+    for (uint64_t i = 0; i < qty; i++) {
         float t = *pVect1 - *pVect2;
         pVect1++;
         pVect2++;
@@ -45,7 +45,7 @@ L2SqrGT(const void* pVect1v, const void* pVect2v, const void* qty_ptr) {
 
 float
 InnerProductDistanceGT(const void* pVect1, const void* pVect2, const void* qty_ptr) {
-    size_t qty = *((size_t*)qty_ptr);
+    uint64_t qty = *((uint64_t*)qty_ptr);
     float res = 0;
     for (unsigned i = 0; i < qty; i++) {
         res += ((float*)pVect1)[i] * ((float*)pVect2)[i];
@@ -56,7 +56,7 @@ InnerProductDistanceGT(const void* pVect1, const void* pVect2, const void* qty_p
 TEST_CASE("Test InnerProduct Instructions", "[ut][simd]") {
     std::random_device rd;
     std::mt19937 rng(rd());
-    for (size_t dim = 1; dim < 1026; dim++) {
+    for (uint64_t dim = 1; dim < 1026; dim++) {
         std::uniform_real_distribution<> distrib_real;
         float vector1[dim];
         float vector2[dim];
@@ -73,7 +73,7 @@ TEST_CASE("Test InnerProduct Instructions", "[ut][simd]") {
 TEST_CASE("Test L2 Instructions", "[ut][simd]") {
     std::random_device rd;
     std::mt19937 rng(rd());
-    for (size_t dim = 1; dim < 1026; dim++) {
+    for (uint64_t dim = 1; dim < 1026; dim++) {
         std::uniform_real_distribution<> distrib_real;
         float vector1[dim];
         float vector2[dim];

--- a/src/simd/sse.cpp
+++ b/src/simd/sse.cpp
@@ -30,7 +30,7 @@ float
 L2Sqr(const void* pVect1v, const void* pVect2v, const void* qty_ptr) {
     auto* pVect1 = (float*)pVect1v;
     auto* pVect2 = (float*)pVect2v;
-    auto qty = *((size_t*)qty_ptr);
+    auto qty = *((uint64_t*)qty_ptr);
     return sse::FP32ComputeL2Sqr(pVect1, pVect2, qty);
 }
 
@@ -38,7 +38,7 @@ float
 InnerProduct(const void* pVect1v, const void* pVect2v, const void* qty_ptr) {
     auto* pVect1 = (float*)pVect1v;
     auto* pVect2 = (float*)pVect2v;
-    auto qty = *((size_t*)qty_ptr);
+    auto qty = *((uint64_t*)qty_ptr);
     return sse::FP32ComputeIP(pVect1, pVect2, qty);
 }
 
@@ -51,7 +51,7 @@ float
 INT8L2Sqr(const void* pVect1v, const void* pVect2v, const void* qty_ptr) {
     auto* pVect1 = (int8_t*)pVect1v;
     auto* pVect2 = (int8_t*)pVect2v;
-    auto qty = *((size_t*)qty_ptr);
+    auto qty = *((uint64_t*)qty_ptr);
     return sse::INT8ComputeL2Sqr(pVect1, pVect2, qty);
 }
 
@@ -70,7 +70,7 @@ PQDistanceFloat256(const void* single_dim_centers, float single_dim_val, void* r
 #if defined(ENABLE_SSE)
     const auto* float_centers = (const float*)single_dim_centers;
     auto* float_result = (float*)result;
-    for (size_t idx = 0; idx < 256; idx += 4) {
+    for (uint64_t idx = 0; idx < 256; idx += 4) {
         __m128 v_centers_dim = _mm_loadu_ps(float_centers + idx);
         __m128 v_query_vec = _mm_set1_ps(single_dim_val);
         __m128 v_diff = _mm_sub_ps(v_centers_dim, v_query_vec);
@@ -825,12 +825,12 @@ PQFastScanLookUp32(const uint8_t* RESTRICT lookup_table,
                    int32_t* RESTRICT result) {
 #if defined(ENABLE_SSE)
     __m128i sum[4];
-    for (size_t i = 0; i < 4; i++) {
+    for (uint64_t i = 0; i < 4; i++) {
         sum[i] = _mm_setzero_si128();
     }
     const auto sign4 = _mm_set1_epi8(0x0F);
     const auto sign8 = _mm_set1_epi16(0xFF);
-    for (size_t i = 0; i < pq_dim; i++) {
+    for (uint64_t i = 0; i < pq_dim; i++) {
         auto dict = _mm_loadu_si128((__m128i*)(lookup_table));
         lookup_table += 16;
         auto code = _mm_loadu_si128((__m128i*)(codes));
@@ -968,10 +968,10 @@ RotateOp(float* data, int idx, int dim_, int step) {
 }
 
 void
-FHTRotate(float* data, size_t dim_) {
+FHTRotate(float* data, uint64_t dim_) {
 #if defined(ENABLE_SSE)
-    size_t n = dim_;
-    size_t step = 1;
+    uint64_t n = dim_;
+    uint64_t step = 1;
     while (step < n) {
         if (step >= 4) {
             sse::RotateOp(data, 0, dim_, step);
@@ -986,7 +986,7 @@ FHTRotate(float* data, size_t dim_) {
 }
 
 void
-VecRescale(float* data, size_t dim, float val) {
+VecRescale(float* data, uint64_t dim, float val) {
 #if defined(ENABLE_SSE)
     int i = 0;
     __m128 val_vec = _mm_set1_ps(val);
@@ -1004,11 +1004,11 @@ VecRescale(float* data, size_t dim, float val) {
 }
 
 void
-KacsWalk(float* data, size_t len) {
+KacsWalk(float* data, uint64_t len) {
 #if defined(ENABLE_SSE)
-    size_t base = len % 2;
-    size_t offset = base + (len / 2);  // for odd dim
-    size_t i = 0;
+    uint64_t base = len % 2;
+    uint64_t offset = base + (len / 2);  // for odd dim
+    uint64_t i = 0;
     for (; i + 4 < len / 2; i += 4) {
         __m128 x = _mm_loadu_ps(&data[i]);
         __m128 y = _mm_loadu_ps(&data[i + offset]);

--- a/src/simd/sve.cpp
+++ b/src/simd/sve.cpp
@@ -45,21 +45,21 @@ float
 L2Sqr(const void* pVect1v, const void* pVect2v, const void* qty_ptr) {
     auto* pVect1 = (float*)pVect1v;
     auto* pVect2 = (float*)pVect2v;
-    auto qty = *((size_t*)qty_ptr);
+    auto qty = *((uint64_t*)qty_ptr);
     return sve::FP32ComputeL2Sqr(pVect1, pVect2, qty);
 }
 float
 INT8L2Sqr(const void* pVect1v, const void* pVect2v, const void* qty_ptr) {
     auto* pVect1 = (int8_t*)pVect1v;
     auto* pVect2 = (int8_t*)pVect2v;
-    auto qty = *((size_t*)qty_ptr);
+    auto qty = *((uint64_t*)qty_ptr);
     return sve::INT8ComputeL2Sqr(pVect1, pVect2, qty);
 }
 float
 InnerProduct(const void* pVect1v, const void* pVect2v, const void* qty_ptr) {
     auto* pVect1 = (float*)pVect1v;
     auto* pVect2 = (float*)pVect2v;
-    auto qty = *((size_t*)qty_ptr);
+    auto qty = *((uint64_t*)qty_ptr);
     return sve::FP32ComputeIP(pVect1, pVect2, qty);
 }
 
@@ -73,7 +73,7 @@ INT8InnerProduct(const void* pVect1v, const void* pVect2v, const void* qty_ptr) 
 #if defined(ENABLE_SVE)
     auto* pVect1 = (const int8_t*)pVect1v;
     auto* pVect2 = (const int8_t*)pVect2v;
-    auto qty = *((size_t*)qty_ptr);
+    auto qty = *((uint64_t*)qty_ptr);
 
     svint32_t sum = svdup_s32(0);
     uint64_t i = 0;
@@ -1070,10 +1070,10 @@ RaBitQSQ4UBinaryIP(const uint8_t* codes, const uint8_t* bits, uint64_t dim) {
     }
 
     uint32_t result = 0;
-    size_t num_bytes = (dim + 7) / 8;
+    uint64_t num_bytes = (dim + 7) / 8;
 
     for (uint64_t bit_pos = 0; bit_pos < 4; ++bit_pos) {
-        size_t i = 0;
+        uint64_t i = 0;
         uint64_t sum = 0;
 
         const uint8_t* current_codes = codes + bit_pos * num_bytes;
@@ -1310,10 +1310,10 @@ PQFastScanLookUp32(const uint8_t* RESTRICT lookup_table,
 }
 
 void
-KacsWalk(float* data, size_t len) {
+KacsWalk(float* data, uint64_t len) {
 #if defined(ENABLE_SVE)
-    size_t n = len / 2;
-    size_t offset = (len % 2) + n;
+    uint64_t n = len / 2;
+    uint64_t offset = (len % 2) + n;
     uint64_t i = 0;
     const uint64_t step = svcntw();
     svbool_t predicate = svwhilelt_b32(i, n);
@@ -1337,7 +1337,7 @@ KacsWalk(float* data, size_t len) {
 }
 
 void
-FlipSign(const uint8_t* flip, float* data, size_t dim) {
+FlipSign(const uint8_t* flip, float* data, uint64_t dim) {
 #if defined(ENABLE_SVE)
     auto predicate_array = std::make_unique<uint8_t[]>(dim);
     const uint64_t num_bytes = dim / 8;
@@ -1371,7 +1371,7 @@ FlipSign(const uint8_t* flip, float* data, size_t dim) {
 }
 
 void
-VecRescale(float* data, size_t dim, float val) {
+VecRescale(float* data, uint64_t dim, float val) {
 #if defined(ENABLE_SVE)
     svfloat32_t scale = svdup_f32(val);
     uint64_t i = 0;
@@ -1411,10 +1411,10 @@ RotateOp(float* data, int idx, int dim_, int step) {
 }
 
 void
-FHTRotate(float* data, size_t dim_) {
+FHTRotate(float* data, uint64_t dim_) {
 #if defined(ENABLE_SVE)
-    size_t n = dim_;
-    size_t step = 1;
+    uint64_t n = dim_;
+    uint64_t step = 1;
     while (step < n) {
         sve::RotateOp(data, 0, dim_, step);
         step *= 2;

--- a/src/storage/footer.h
+++ b/src/storage/footer.h
@@ -16,7 +16,6 @@
 #pragma once
 #include <fmt/format.h>
 
-#include "nlohmann/json.hpp"
 #include "stream_reader.h"
 #include "typing.h"
 #include "vsag/constants.h"

--- a/src/storage/stream_reader.h
+++ b/src/storage/stream_reader.h
@@ -17,7 +17,6 @@
 
 #include <cstdint>
 #include <functional>
-#include <iostream>
 #include <istream>
 #include <stack>
 

--- a/src/utils/visited_list.h
+++ b/src/utils/visited_list.h
@@ -14,16 +14,15 @@
 // limitations under the License.
 
 #pragma once
-#include <cstring>
 
 #include "pointer_define.h"
 #include "prefetch.h"
 #include "resource_object.h"
 #include "resource_object_pool.h"
 #include "typing.h"
-#include "vsag/allocator.h"
 
 namespace vsag {
+class Allocator;
 
 DEFINE_POINTER(VisitedList);
 class VisitedList : public ResourceObject {


### PR DESCRIPTION
- less include on .h files but more on .cpp files
- forward declare on header file

## Summary by Sourcery

Streamline header dependencies by removing unnecessary includes from headers and using forward declarations, while adding required includes to corresponding source files; standardize dimension and length parameters from size_t to uint64_t across SIMD and related modules; refactor SparseIndex by relocating constructor, destructor, and serialization logic into the implementation file and cleaning up its header

Enhancements:
- Reduce header file includes and introduce forward declarations to decouple dependencies
- Add missing includes in .cpp files to compensate for header include removals
- Replace std::size_t/size_t with uint64_t for dimension and length parameters consistently across SIMD and other code
- Move SparseIndex method implementations (constructors, destructor, Serialize/Deserialize) from header to source and clean up its header declarations