### PR TITLE
feat(sindi): support exclude the footer during deserialize

### DIFF
--- a/src/algorithm/sindi/sindi.cpp
+++ b/src/algorithm/sindi/sindi.cpp
@@ -33,7 +33,8 @@ SINDI::SINDI(const SINDIParameterPtr& param, const IndexCommonParam& common_para
       use_reorder_(param->use_reorder),
       window_size_(param->window_size),
       doc_retain_ratio_(1.0F - param->doc_prune_ratio),
-      window_term_list_(common_param.allocator_.get()) {
+      window_term_list_(common_param.allocator_.get()),
+      deserialize_without_footer_(param->deserialize_without_footer) {
     if (use_reorder_) {
         SparseIndexParameterPtr rerank_param = std::make_shared<SparseIndexParameters>();
         rerank_param->need_sort = true;
@@ -274,16 +275,17 @@ SINDI::Serialize(StreamWriter& writer) const {
 void
 SINDI::Deserialize(StreamReader& reader) {
     std::unique_lock wlock(this->global_mutex_);
-
-    auto footer = Footer::Parse(reader);
-    auto metadata = footer->GetMetadata();
-    JsonType jsonify_basic_info = metadata->Get("basic_info");
-    // Check if the index parameter is compatible
-    {
-        auto param = jsonify_basic_info[INDEX_PARAM];
-        SINDIParameterPtr index_param = std::make_shared<SINDIParameter>();
-        index_param->FromJson(param);
-        this->create_param_ptr_->CheckCompatibility(index_param);
+    if (not deserialize_without_footer_) {
+        auto footer = Footer::Parse(reader);
+        auto metadata = footer->GetMetadata();
+        JsonType jsonify_basic_info = metadata->Get("basic_info");
+        // Check if the index parameter is compatible
+        {
+            auto param = jsonify_basic_info[INDEX_PARAM];
+            SINDIParameterPtr index_param = std::make_shared<SINDIParameter>();
+            index_param->FromJson(param);
+            this->create_param_ptr_->CheckCompatibility(index_param);
+        }
     }
 
     StreamReader::ReadObj(reader, cur_element_count_);

--- a/src/algorithm/sindi/sindi.h
+++ b/src/algorithm/sindi/sindi.h
@@ -118,6 +118,7 @@ private:
     float doc_retain_ratio_{0};
 
     std::shared_ptr<SparseIndex> rerank_flat_index_{nullptr};
+    bool deserialize_without_footer_{false};
 };
 
 }  // namespace vsag

--- a/src/algorithm/sindi/sindi_parameter.cpp
+++ b/src/algorithm/sindi/sindi_parameter.cpp
@@ -38,6 +38,9 @@ SINDIParameter::FromJson(const JsonType& json) {
     } else {
         window_size = DEFAULT_WINDOW_SIZE;
     }
+    if (json.contains(SPARSE_DESERIALIZE_WITHOUT_FOOTER)) {
+        deserialize_without_footer = json[SPARSE_DESERIALIZE_WITHOUT_FOOTER];
+    }
 }
 
 JsonType

--- a/src/algorithm/sindi/sindi_parameter.h
+++ b/src/algorithm/sindi/sindi_parameter.h
@@ -46,6 +46,9 @@ public:
     bool use_reorder{false};
 
     float doc_prune_ratio{0};
+
+    // temporal parameter
+    bool deserialize_without_footer{false};
 };
 
 class SINDISearchParameter : public Parameter {

--- a/src/inner_string_params.h
+++ b/src/inner_string_params.h
@@ -94,6 +94,7 @@ const char* const SPARSE_TERM_PRUNE_RATIO = "term_prune_ratio";
 const char* const SPARSE_WINDOW_SIZE = "window_size";
 const char* const SPARSE_USE_REORDER = "use_reorder";
 const char* const SPARSE_N_CANDIDATE = "n_candidate";
+const char* const SPARSE_DESERIALIZE_WITHOUT_FOOTER = "deserialize_without_footer";
 
 // graph param value
 const char* const GRAPH_PARAM_MAX_DEGREE = "max_degree";

--- a/tests/test_sindi.cpp
+++ b/tests/test_sindi.cpp
@@ -21,33 +21,17 @@
 
 namespace fixtures {
 
+struct SINDIParam {
+    bool use_reorder = true;
+    float doc_prune_ratio = 0.0;
+    int window_size = 100;
+    bool deserialize_without_footer = false;
+};
+
 class SINDITestIndex : public fixtures::TestIndex {
 public:
     static TestDatasetPool pool;
     constexpr static uint64_t base_count = 1000;
-    constexpr static const char* build_param_reorder = R"(
-        {
-            "dim": 16,
-            "dtype": "sparse",
-            "metric_type": "ip",
-            "index_param": {
-                "use_reorder": true,
-                "doc_prune_ratio": 0.0,
-                "window_size": 100
-            }
-        })";
-
-    constexpr static const char* build_param_flat = R"(
-        {
-            "dim": 16,
-            "dtype": "sparse",
-            "metric_type": "ip",
-            "index_param": {
-                "use_reorder": false,
-                "doc_prune_ratio": 0.0,
-                "window_size": 100
-            }
-        })";
     constexpr static const char* search_param = R"(
         {
             "sindi":
@@ -57,13 +41,37 @@ public:
                 "term_prune_ratio": 0.0
             }
         })";
+
+    static std::string
+    GenerateBuildParameter(const SINDIParam& param) {
+        constexpr static const char* build_param_template = R"(
+        {{
+            "dim": 16,
+            "dtype": "sparse",
+            "metric_type": "ip",
+            "index_param": {{
+                "use_reorder": {},
+                "doc_prune_ratio": {},
+                "window_size": {},
+                "deserialize_without_footer": {}
+
+            }}
+        }})";
+        return fmt::format(build_param_template,
+                           param.use_reorder,
+                           param.doc_prune_ratio,
+                           param.window_size,
+                           param.deserialize_without_footer);
+    }
 };
 TestDatasetPool SINDITestIndex::pool{};
 
 }  // namespace fixtures
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex, "SINDI Build and Search", "[ft][sindi]") {
-    auto build_param = GENERATE(build_param_reorder, build_param_flat);
+    fixtures::SINDIParam param;
+    param.use_reorder = GENERATE(true, false);
+    auto build_param = fixtures::SINDITestIndex::GenerateBuildParameter(param);
     auto index = TestFactory("sindi", build_param, true);
     auto dataset = pool.GetSparseDatasetAndCreate(base_count, 128, 0.8);
     REQUIRE(index->GetIndexType() == vsag::IndexType::SINDI);
@@ -80,7 +88,9 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex, "SINDI Build and Search",
 }
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex, "SINDI Concurrent", "[ft][sindi]") {
-    auto build_param = GENERATE(build_param_reorder, build_param_flat);
+    fixtures::SINDIParam param;
+    param.use_reorder = GENERATE(true, false);
+    auto build_param = fixtures::SINDITestIndex::GenerateBuildParameter(param);
     auto index = TestFactory("sindi", build_param, true);
     auto dataset = pool.GetSparseDatasetAndCreate(base_count, 128, 0.8);
     REQUIRE(index->GetIndexType() == vsag::IndexType::SINDI);
@@ -88,7 +98,10 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex, "SINDI Concurrent", "[ft]
 }
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex, "SINDI Serialize File", "[ft][sindi]") {
-    auto build_param = GENERATE(build_param_reorder, build_param_flat);
+    fixtures::SINDIParam param;
+    param.deserialize_without_footer = GENERATE(true, false);
+    param.use_reorder = GENERATE(true, false);
+    auto build_param = fixtures::SINDITestIndex::GenerateBuildParameter(param);
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
     auto metric_type = GENERATE("ip");


### PR DESCRIPTION
## Summary by Sourcery

Add support for excluding the footer during SINDI index deserialization via a new parameter and update tests accordingly

New Features:
- Allow disabling footer parsing during SINDI deserialization with the "deserialize_without_footer" parameter

Enhancements:
- Introduce "deserialize_without_footer" field in SINDIParameter and SINDI classes
- Conditionally skip footer parsing in SINDI::Deserialize when the new flag is set
- Define new JSON key constant "SPARSE_DESERIALIZE_WITHOUT_FOOTER"

Tests:
- Add SINDIParam struct and GenerateBuildParameter helper to build dynamic JSON parameters
- Parameterize existing SINDI tests over use_reorder and deserialize_without_footer flags