### PR TITLE
feat(search): extend search request to cover all search cases

### DIFF
--- a/include/vsag/search_request.h
+++ b/include/vsag/search_request.h
@@ -1,4 +1,3 @@
-
 // Copyright 2024-present the vsag project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,16 +27,147 @@ enum class SearchMode {
 
 class SearchRequest {
 public:
+    // basic params
+    /** 
+     * @brief Query dataset containing the vector to search for
+     * @details This DatasetPtr holds the query vector used for similarity search. 
+     *          Only one query vector is allowed.
+     */
     DatasetPtr query_{nullptr};
-    SearchMode mode_{SearchMode::KNN_SEARCH};
-    int64_t topk_;
-    std::string params_str_;
 
+    /**
+     * @brief Search mode determining the type of similarity search to perform
+     * @details Specifies whether to perform K-Nearest Neighbors (KNN) search or range-based search.
+     *          - KNN_SEARCH: Returns the top-k most similar vectors
+     *          - RANGE_SEARCH: Returns all vectors within a specified distance/radius
+     */
+    SearchMode mode_{SearchMode::KNN_SEARCH};
+
+    /**
+     * @brief Number of nearest neighbors to return in KNN search mode
+     * @details Only applicable when mode_ is set to KNN_SEARCH. 
+     *          Defines how many of the most similar vectors should be returned.
+     *          Default value is 10, must be a positive integer.
+     */
+    int64_t topk_{10};
+
+    /**
+     * @brief Search radius for range-based search mode
+     * @details Only used when mode_ is set to RANGE_SEARCH.
+     *          Defines the maximum distance threshold from the query vector.
+     *          All vectors within this radius will be allowed.
+     *          The result size must be smaller than the limited_size_(when limited_size_ is positive).
+     *          Default value is 0.5, must be a non-negative float.
+     */
+    float radius_{0.5F};
+
+    /**
+     * @brief Limited size for search results
+     * @details Only used when mode_ is set to RANGE_SEARCH.
+     *          Defines the maximum number of results to return.
+     *          Default value is -1, which means no limit.
+     */
+    int64_t limited_size_{-1};
+
+    /**
+     * @brief Additional search parameters as a JSON string
+     * @details Contains algorithm-specific parameters in JSON format.
+     *          Used to pass fine-tuned configuration options to the underlying search algorithm.
+     *          Examples: ef_search, etc.
+     */
+    std::string params_str_{};
+
+    // for attribute filter
+    /**
+     * @brief Flag to enable attribute-based filtering during search
+     * @details When set to true, enables filtering of search results based on vector attributes.
+     *          Requires attribute_filter_str_ to contain valid filter criteria.
+     *          Default is false (no attribute filtering applied).
+     */
     bool enable_attribute_filter_{false};
-    std::string attribute_filter_str_;
+
+    /**
+     * @brief Attribute filter criteria as a SQL string
+     * @details Contains the filtering conditions for vector attributes in SQL format.
+     *          Only used when enable_attribute_filter_ is set to true.
+     *          Format depends on the attribute schema defined in the dataset.
+     *          Examples: 
+     *              1. "category = 'electronics' AND price != 1000",
+     *              2. "multi_in(category, ['electronics', 'clothing']) AND multi_notin(color, ['red', 'blue'])",
+     */
+    std::string attribute_filter_str_{};
+
+    // for callback filter
+    /**
+     * @brief Flag to enable custom callback-based filtering
+     * @details When set to true, enables the use of a custom Filter object for result filtering.
+     *          Requires filter_ to be properly initialized with a valid FilterPtr.
+     *          Default is false (no callback filtering applied).
+     */
+    bool enable_filter_{false};
+
+    /**
+     * @brief Custom filter object for advanced result filtering
+     * @details A smart pointer to a Filter implementation that provides custom filtering logic.
+     *          The filter is applied after the initial similarity search to further refine results.
+     *          Only used when enable_filter_ is set to true.
+     *          Allows for complex filtering scenarios not covered by attribute-based filtering.
+     *          All Filter Use *AND* to connect
+     */
     FilterPtr filter_{nullptr};
 
+    /**
+     * @brief Flag to enable bitset filter
+     * @details When set to true, enables the use of a bitset filter for result filtering.
+     *          Requires bitset_filter_ to be properly initialized with a valid BitsetPtr.
+     *          Default is false (no bitset filter applied).
+     */
+    bool enable_bitset_filter_{false};
+
+    /**
+     * @brief Bitset filter for result filtering
+     * @details A smart pointer to a Bitset implementation that provides result filtering based on a bitset.
+     *          Only used when enable_bitset_filter_ is set to true.
+     *          If the bitset filter's Test(id) return True, the id will be filtered out.
+     *          Default is nullptr (no bitset filter applied).
+     */
+    BitsetPtr bitset_filter_{nullptr};
+
+    // search resource alloc
+    /**
+     * @brief Custom memory allocator for search operations
+     * @details Pointer to a custom Allocator object used for memory management during search.
+     *          If nullptr, the default index allocator is used.
+     *          Useful for memory-constrained environments or when using specialized memory pools.
+     *          Can help optimize memory usage patterns for large-scale searches.
+     */
     Allocator* search_allocator_{nullptr};
+
+    // for iterator search
+    /**
+     * @brief Flag to enable iterator-based search mode
+     * @details When set to true, enables incremental search using an iterator pattern.
+     *          Allows for processing search with steps.
+     *          Hold the current search context in the iterator context.
+     *          Requires p_iter_ctx_ to be properly initialized.
+     *          Default is false (standard search mode).
+     */
+    bool enable_iterator_search_{false};
+
+    /**
+     * @brief Pointer to iterator context for incremental search
+     * @details Double pointer to an IteratorContext object used for maintaining search state
+     *          across multiple incremental search calls. Only used when enable_iterator_search_ is true.
+     *          The context stores the current position in the search space and allows resuming
+     *          searches from where they left off. Must be initialized before starting iterator search.
+     */
+    IteratorContext** p_iter_ctx_{nullptr};
+
+    /**
+     * @brief Flag indicating this is the final search in an iterator sequence
+     * @details When set to true, signals that no more results are expected from this iterator.ß
+     */
+    bool is_last_search_{false};
 };
 
 }  // namespace vsag

--- a/src/index/index_impl.h
+++ b/src/index/index_impl.h
@@ -48,13 +48,21 @@ public:
         this->inner_index_.reset();
     }
 
+#define CHECK_AND_RETURN_EMPTY_DATASET          \
+    if (GetNumElements() == 0) {                \
+        return DatasetImpl::MakeEmptyDataset(); \
+    }
+
+#define CHECK_IMMUTABLE_INDEX(operation_str)                                       \
+    if (this->inner_index_->immutable_) {                                          \
+        return tl::unexpected(Error(ErrorType::UNSUPPORTED_INDEX_OPERATION,        \
+                                    "immutable index no support " operation_str)); \
+    }
+
 public:
     tl::expected<std::vector<int64_t>, Error>
     Add(const DatasetPtr& base) override {
-        if (this->inner_index_->immutable_) {
-            return tl::unexpected(
-                Error(ErrorType::UNSUPPORTED_INDEX_OPERATION, "immutable index no support add"));
-        }
+        CHECK_IMMUTABLE_INDEX("add");
         SAFE_CALL(return this->inner_index_->Add(base));
     }
 
@@ -65,10 +73,7 @@ public:
 
     tl::expected<std::vector<int64_t>, Error>
     Build(const DatasetPtr& base) override {
-        if (this->inner_index_->immutable_) {
-            return tl::unexpected(
-                Error(ErrorType::UNSUPPORTED_INDEX_OPERATION, "immutable index no support build"));
-        }
+        CHECK_IMMUTABLE_INDEX("build");
         SAFE_CALL(return this->inner_index_->Build(base));
     }
 
@@ -108,10 +113,7 @@ public:
 
     tl::expected<Checkpoint, Error>
     ContinueBuild(const DatasetPtr& base, const BinarySet& binary_set) override {
-        if (this->inner_index_->immutable_) {
-            return tl::unexpected(Error(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                                        "immutable index no support continue build"));
-        }
+        CHECK_IMMUTABLE_INDEX("continue build");
         SAFE_CALL(return this->inner_index_->ContinueBuild(base, binary_set));
     }
 
@@ -217,9 +219,7 @@ public:
               int64_t k,
               const std::string& parameters,
               BitsetPtr invalid = nullptr) const override {
-        if (GetNumElements() == 0) {
-            return DatasetImpl::MakeEmptyDataset();
-        }
+        CHECK_AND_RETURN_EMPTY_DATASET;
         SAFE_CALL(return this->inner_index_->KnnSearch(query, k, parameters, invalid));
     }
 
@@ -228,9 +228,7 @@ public:
               int64_t k,
               const std::string& parameters,
               const std::function<bool(int64_t)>& filter) const override {
-        if (GetNumElements() == 0) {
-            return DatasetImpl::MakeEmptyDataset();
-        }
+        CHECK_AND_RETURN_EMPTY_DATASET;
         SAFE_CALL(return this->inner_index_->KnnSearch(query, k, parameters, filter));
     }
 
@@ -239,17 +237,13 @@ public:
               int64_t k,
               const std::string& parameters,
               const FilterPtr& filter) const override {
-        if (GetNumElements() == 0) {
-            return DatasetImpl::MakeEmptyDataset();
-        }
+        CHECK_AND_RETURN_EMPTY_DATASET;
         SAFE_CALL(return this->inner_index_->KnnSearch(query, k, parameters, filter));
     }
 
     tl::expected<DatasetPtr, Error>
     KnnSearch(const DatasetPtr& query, int64_t k, SearchParam& search_param) const override {
-        if (GetNumElements() == 0) {
-            return DatasetImpl::MakeEmptyDataset();
-        }
+        CHECK_AND_RETURN_EMPTY_DATASET;
         if (search_param.is_iter_filter) {
             SAFE_CALL(return this->inner_index_->KnnSearch(query,
                                                            k,
@@ -271,19 +265,14 @@ public:
               const FilterPtr& filter,
               IteratorContext*& iter_ctx,
               bool is_last_filter) const override {
-        if (GetNumElements() == 0) {
-            return DatasetImpl::MakeEmptyDataset();
-        }
+        CHECK_AND_RETURN_EMPTY_DATASET;
         SAFE_CALL(return this->inner_index_->KnnSearch(
             query, k, parameters, filter, nullptr, iter_ctx, is_last_filter));
     }
 
     tl::expected<void, Error>
     Merge(const std::vector<MergeUnit>& merge_units) override {
-        if (this->inner_index_->immutable_) {
-            return tl::unexpected(
-                Error(ErrorType::UNSUPPORTED_INDEX_OPERATION, "immutable index no support merge"));
-        }
+        CHECK_IMMUTABLE_INDEX("merge");
         SAFE_CALL(this->inner_index_->Merge(merge_units));
     }
 
@@ -291,10 +280,7 @@ public:
     Pretrain(const std::vector<int64_t>& base_tag_ids,
              uint32_t k,
              const std::string& parameters) override {
-        if (this->inner_index_->immutable_) {
-            return tl::unexpected(Error(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                                        "immutable index no support pretrain"));
-        }
+        CHECK_IMMUTABLE_INDEX("pretrain");
         SAFE_CALL(return this->inner_index_->Pretrain(base_tag_ids, k, parameters));
     }
 
@@ -303,10 +289,7 @@ public:
              int64_t k,
              const std::string& parameters,
              int64_t global_optimum_tag_id = std::numeric_limits<int64_t>::max()) override {
-        if (this->inner_index_->immutable_) {
-            return tl::unexpected(Error(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                                        "immutable index no support feedback"));
-        }
+        CHECK_IMMUTABLE_INDEX("feedback");
         SAFE_CALL(return this->inner_index_->Feedback(query, k, parameters, global_optimum_tag_id));
     }
 
@@ -315,9 +298,7 @@ public:
                 float radius,
                 const std::string& parameters,
                 int64_t limited_size = -1) const override {
-        if (GetNumElements() == 0) {
-            return DatasetImpl::MakeEmptyDataset();
-        }
+        CHECK_AND_RETURN_EMPTY_DATASET;
         SAFE_CALL(return this->inner_index_->RangeSearch(query, radius, parameters, limited_size));
     }
 
@@ -327,9 +308,7 @@ public:
                 const std::string& parameters,
                 BitsetPtr invalid,
                 int64_t limited_size = -1) const override {
-        if (GetNumElements() == 0) {
-            return DatasetImpl::MakeEmptyDataset();
-        }
+        CHECK_AND_RETURN_EMPTY_DATASET;
         SAFE_CALL(return this->inner_index_->RangeSearch(
             query, radius, parameters, invalid, limited_size));
     }
@@ -340,9 +319,7 @@ public:
                 const std::string& parameters,
                 const std::function<bool(int64_t)>& filter,
                 int64_t limited_size = -1) const override {
-        if (GetNumElements() == 0) {
-            return DatasetImpl::MakeEmptyDataset();
-        }
+        CHECK_AND_RETURN_EMPTY_DATASET;
         SAFE_CALL(return this->inner_index_->RangeSearch(
             query, radius, parameters, filter, limited_size));
     }
@@ -353,19 +330,14 @@ public:
                 const std::string& parameters,
                 const FilterPtr& filter,
                 int64_t limited_size = -1) const override {
-        if (GetNumElements() == 0) {
-            return DatasetImpl::MakeEmptyDataset();
-        }
+        CHECK_AND_RETURN_EMPTY_DATASET;
         SAFE_CALL(return this->inner_index_->RangeSearch(
             query, radius, parameters, filter, limited_size));
     }
 
     tl::expected<bool, Error>
     Remove(int64_t id) override {
-        if (this->inner_index_->immutable_) {
-            return tl::unexpected(
-                Error(ErrorType::UNSUPPORTED_INDEX_OPERATION, "immutable index no support remove"));
-        }
+        CHECK_IMMUTABLE_INDEX("remove");
         SAFE_CALL(return this->inner_index_->Remove(id));
     }
 
@@ -381,9 +353,7 @@ public:
 
     [[nodiscard]] tl::expected<DatasetPtr, Error>
     SearchWithRequest(const SearchRequest& request) const override {
-        if (GetNumElements() == 0) {
-            return DatasetImpl::MakeEmptyDataset();
-        }
+        CHECK_AND_RETURN_EMPTY_DATASET;
         SAFE_CALL(return this->inner_index_->SearchWithRequest(request));
     }
 
@@ -394,19 +364,13 @@ public:
 
     tl::expected<void, Error>
     Train(const DatasetPtr& data) override {
-        if (this->inner_index_->immutable_) {
-            return tl::unexpected(
-                Error(ErrorType::UNSUPPORTED_INDEX_OPERATION, "immutable index no support train"));
-        }
+        CHECK_IMMUTABLE_INDEX("train");
         SAFE_CALL(this->inner_index_->Train(data));
     }
 
     virtual tl::expected<void, Error>
     UpdateAttribute(int64_t id, const AttributeSet& new_attrs) override {
-        if (this->inner_index_->immutable_) {
-            return tl::unexpected(Error(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                                        "immutable index no support update attribute"));
-        }
+        CHECK_IMMUTABLE_INDEX("update attribute");
         SAFE_CALL(this->inner_index_->UpdateAttribute(id, new_attrs));
     }
 
@@ -414,38 +378,25 @@ public:
     UpdateAttribute(int64_t id,
                     const AttributeSet& new_attrs,
                     const AttributeSet& origin_attrs) override {
-        if (this->inner_index_->immutable_) {
-            return tl::unexpected(
-                Error(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                      "immutable index no support update attribute with origin attributes"));
-        }
+        CHECK_IMMUTABLE_INDEX("update attribute with origin attributes");
         SAFE_CALL(this->inner_index_->UpdateAttribute(id, new_attrs, origin_attrs));
     }
 
     virtual tl::expected<bool, Error>
     UpdateExtraInfo(const DatasetPtr& new_base) override {
-        if (this->inner_index_->immutable_) {
-            return tl::unexpected(Error(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                                        "immutable index no support update extra info"));
-        }
+        CHECK_IMMUTABLE_INDEX("update extra info");
         SAFE_CALL(return this->inner_index_->UpdateExtraInfo(new_base));
     }
 
     tl::expected<bool, Error>
     UpdateId(int64_t old_id, int64_t new_id) override {
-        if (this->inner_index_->immutable_) {
-            return tl::unexpected(Error(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                                        "immutable index no support update id"));
-        }
+        CHECK_IMMUTABLE_INDEX("update id");
         SAFE_CALL(return this->inner_index_->UpdateId(old_id, new_id));
     }
 
     tl::expected<bool, Error>
     UpdateVector(int64_t id, const DatasetPtr& new_base, bool force_update = false) override {
-        if (this->inner_index_->immutable_) {
-            return tl::unexpected(Error(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                                        "immutable index no support update vector"));
-        }
+        CHECK_IMMUTABLE_INDEX("update vector");
         SAFE_CALL(return this->inner_index_->UpdateVector(id, new_base, force_update));
     }
 


### PR DESCRIPTION
closed: #1125 

## Summary by Sourcery

Extend the SearchRequest class to support comprehensive search configurations including both KNN and range modes, various filtering options, custom memory allocator, and iterator-based search, and refactor IndexImpl to introduce macros for centralized empty dataset and immutable index checks across its methods.

New Features:
- Add range search parameters (radius and limited_size) and JSON-based algorithm parameters to SearchRequest
- Enable attribute-based, callback-based, and bitset filtering options in SearchRequest
- Introduce custom search_allocator and iterator-based search support with IteratorContext and is_last_search flag in SearchRequest

Enhancements:
- Factor out repetitive empty dataset and immutable index checks into CHECK_AND_RETURN_EMPTY_DATASET and CHECK_IMMUTABLE_INDEX macros in IndexImpl