### PR TITLE
fix: add missing <cstdint> include in commen.h

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -15,6 +15,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "vsag_exception.h"
 
 #define SAFE_CALL(stmt)                                                              \


### PR DESCRIPTION
The file src/common.h uses uint32_t without including the necessary header, causing build failures on stricter compilers like GCC 14.

fixes: #1126

## Summary by Sourcery

Bug Fixes:
- Add <cstdint> include in src/common.h to resolve undefined uint32_t errors