### PR TITLE
refactor(sindi): remove the dimension check for the sparse vector index

### DIFF
--- a/src/algorithm/sindi/sindi.cpp
+++ b/src/algorithm/sindi/sindi.cpp
@@ -199,6 +199,9 @@ SINDI::search_impl(const SparseTermComputerPtr& computer,
     int64_t cur_size = std::min(static_cast<int64_t>(heap.size()), k);
 
     auto [results, ret_dists, ret_ids] = create_fast_dataset(cur_size, allocator_);
+    if (cur_size == 0) {
+        return results;
+    }
 
     while (heap.size() > k) {
         heap.pop();

--- a/src/index/index_common_param.cpp
+++ b/src/index/index_common_param.cpp
@@ -22,6 +22,8 @@
 
 namespace vsag {
 
+constexpr static const int64_t MAX_DIM_SPARSE = 4096;
+
 inline void
 fill_datatype(IndexCommonParam& result, JsonType::const_reference datatype_obj) {
     CHECK_ARGUMENT(datatype_obj.is_string(),
@@ -102,10 +104,16 @@ IndexCommonParam::CheckAndCreate(JsonType& params, const std::shared_ptr<Resourc
     fill_metrictype(result, metric_obj);
 
     // Check and Fill Dim
-    CHECK_ARGUMENT(params.contains(PARAMETER_DIM),
-                   fmt::format("parameters must contain {}", PARAMETER_DIM));
-    const auto dim_obj = params[PARAMETER_DIM];
-    fill_dim(result, dim_obj);
+    if (params.contains(PARAMETER_DIM)) {
+        const auto dim_obj = params[PARAMETER_DIM];
+        fill_dim(result, dim_obj);
+    } else {
+        if (result.data_type_ != DataTypes::DATA_TYPE_SPARSE) {
+            throw vsag::VsagException(ErrorType::INVALID_ARGUMENT,
+                                      fmt::format("parameters must contain {}", PARAMETER_DIM));
+        }
+        result.dim_ = MAX_DIM_SPARSE;
+    }
 
     if (params.contains(EXTRA_INFO_SIZE)) {
         const auto extra_info_size_obj = params[EXTRA_INFO_SIZE];

--- a/src/utils/util_functions.cpp
+++ b/src/utils/util_functions.cpp
@@ -60,6 +60,9 @@ std::tuple<DatasetPtr, float*, int64_t*>
 create_fast_dataset(int64_t dim, Allocator* allocator) {
     auto dataset = Dataset::Make();
     dataset->Dim(static_cast<int64_t>(dim))->NumElements(1)->Owner(true, allocator);
+    if (dim == 0) {
+        return {dataset, nullptr, nullptr};
+    }
     auto* ids = reinterpret_cast<int64_t*>(allocator->Allocate(sizeof(int64_t) * dim));
     dataset->Ids(ids);
     auto* dists = reinterpret_cast<float*>(allocator->Allocate(sizeof(float) * dim));


### PR DESCRIPTION
## Summary by Sourcery

Allow sparse vector indices to omit explicit dimensions by defaulting to MAX_DIM_SPARSE, centralize and expose quantization analysis across IVF and HGraph, augment IVF with runtime statistics and enriched serialization metadata, update the analyze_index tool to recognize IVF, and handle zero-dimension edge cases in SINDI and dataset utilities.

New Features:
- Add IVF.GetStats and IVF.AnalyzeIndexBySearch for detailed index statistics and quantization error analysis
- Introduce centralized quantizer analysis in InnerIndexInterface and apply to both IVF and HGraph
- Extend analyze_index command-line tool to support IVF indices

Enhancements:
- Remove mandatory dimension parameter for sparse indices by defaulting to MAX_DIM_SPARSE
- Enrich IVF serialization metadata with dimension, extra_info_size, data_type, and metric fields
- Refactor use_reorder handling and consolidate quantizer analysis logic in HGraph and base interface
- Implement statistical summarization helpers (mean, std, min, max, percentiles) for vector data
- Improve SINDI search to handle empty heaps and zero-dimension datasets gracefully

Tests:
- Add a persistent fixture test to validate IVF GetStats and AnalyzeIndexBySearch functionality