### PR TITLE
feat(SINDI): support batch distance calculate

### DIFF
--- a/include/vsag/index.h
+++ b/include/vsag/index.h
@@ -433,6 +433,19 @@ public:
     };
 
     /**
+     * @brief Calculate the distance between the query and the vector of the given ID for batch.
+     *
+     * @param query is the embedding of query
+     * @param ids is the unique identifier of the vector to be calculated in the index.
+     * @param count is the count of ids
+     * @return result is valid distance of input ids. '-1' indicates an invalid distance.
+     */
+    virtual tl::expected<DatasetPtr, Error>
+    CalDistanceById(const DatasetPtr& query, const int64_t* ids, int64_t count) const {
+        throw std::runtime_error("Index doesn't support get distance by id");
+    };
+
+    /**
      * @brief Calculate the maximum and minimum labels.
      *
      * @param min_id The minimum id returned

--- a/src/algorithm/inner_index_interface.cpp
+++ b/src/algorithm/inner_index_interface.cpp
@@ -256,6 +256,25 @@ InnerIndexInterface::CalDistanceById(const float* query, const int64_t* ids, int
     return result;
 }
 
+DatasetPtr
+InnerIndexInterface::CalDistanceById(const DatasetPtr& query,
+                                     const int64_t* ids,
+                                     int64_t count) const {
+    auto result = Dataset::Make();
+    result->Owner(true, allocator_);
+    auto* distances = (float*)allocator_->Allocate(sizeof(float) * count);
+    result->Distances(distances);
+    for (int64_t i = 0; i < count; ++i) {
+        try {
+            distances[i] = this->CalcDistanceById(query, ids[i]);
+        } catch (std::runtime_error& e) {
+            logger::debug(fmt::format("failed to find id: {}", ids[i]));
+            distances[i] = -1;
+        }
+    }
+    return result;
+}
+
 InnerIndexPtr
 InnerIndexInterface::Clone(const IndexCommonParam& param) {
     std::stringstream ss;

--- a/src/algorithm/inner_index_interface.h
+++ b/src/algorithm/inner_index_interface.h
@@ -69,6 +69,9 @@ public:
     virtual DatasetPtr
     CalDistanceById(const float* query, const int64_t* ids, int64_t count) const;
 
+    virtual DatasetPtr
+    CalDistanceById(const DatasetPtr& query, const int64_t* ids, int64_t count) const;
+
     virtual uint64_t
     CalSerializeSize() const;
 

--- a/src/index/index_impl.h
+++ b/src/index/index_impl.h
@@ -87,6 +87,11 @@ public:
         SAFE_CALL(return this->inner_index_->CalDistanceById(query, ids, count));
     }
 
+    tl::expected<DatasetPtr, Error>
+    CalDistanceById(const DatasetPtr& query, const int64_t* ids, int64_t count) const override {
+        SAFE_CALL(return this->inner_index_->CalDistanceById(query, ids, count));
+    }
+
     [[nodiscard]] bool
     CheckFeature(IndexFeature feature) const override {
         return this->inner_index_->CheckFeature(feature);

--- a/tests/test_hnsw.cpp
+++ b/tests/test_hnsw.cpp
@@ -441,7 +441,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Batch Calc Dis Id", 
         auto index = TestFactory(name, param, true);
         auto dataset = pool.GetDatasetAndCreate(dim, base_count, metric_type);
         TestBuildIndex(index, dataset, true);
-        TestBatchCalcDistanceById(index, dataset);
+        TestBatchCalcDistanceById(index, dataset, 1e-5, true, false, true);
         vsag::Options::Instance().set_block_size_limit(origin_size);
     }
 }
@@ -464,7 +464,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex,
         auto index = TestFactory(name, param, true);
         auto dataset = pool.GetDatasetAndCreate(dim, base_count, metric_type);
         TestBuildIndex(index, dataset, true);
-        TestBatchCalcDistanceById(index, dataset);
+        TestBatchCalcDistanceById(index, dataset, 1e-5, true, false, true);
         vsag::Options::Instance().set_block_size_limit(origin_size);
     }
 }

--- a/tests/test_index.cpp
+++ b/tests/test_index.cpp
@@ -807,7 +807,8 @@ void
 TestIndex::TestBatchCalcDistanceById(const IndexPtr& index,
                                      const TestDatasetPtr& dataset,
                                      float error,
-                                     bool expected_success) {
+                                     bool expected_success,
+                                     bool is_sparse) {
     if (not index->CheckFeature(vsag::SUPPORT_CAL_DISTANCE_BY_ID)) {
         return;
     }
@@ -821,9 +822,18 @@ TestIndex::TestBatchCalcDistanceById(const IndexPtr& index,
         query->NumElements(1)
             ->Dim(dim)
             ->Float32Vectors(queries->GetFloat32Vectors() + i * dim)
+            ->SparseVectors(queries->GetSparseVectors() + i)
+            ->Paths(queries->GetPaths() + i)
             ->Owner(false);
-        auto result = index->CalDistanceById(
-            query->GetFloat32Vectors(), gts->GetIds() + (i * gt_topK), gt_topK);
+        tl::expected<DatasetPtr, vsag::Error> result;
+        if (is_sparse) {
+            result = index->CalDistanceById(query, gts->GetIds() + (i * gt_topK), gt_topK);
+        } else {
+            result = index->CalDistanceById(
+                query->GetFloat32Vectors(), gts->GetIds() + (i * gt_topK), gt_topK);
+            REQUIRE_FALSE(
+                index->CalDistanceById(query, gts->GetIds() + (i * gt_topK), gt_topK).has_value());
+        }
         if (not expected_success) {
             return;
         }
@@ -838,8 +848,13 @@ TestIndex::TestBatchCalcDistanceById(const IndexPtr& index,
         for (int i = 0; i < test_num; ++i) {
             no_exist_ids[i] = -i - 1;
         }
-        auto result =
-            index->CalDistanceById(queries->GetFloat32Vectors(), no_exist_ids.data(), test_num);
+        tl::expected<DatasetPtr, vsag::Error> result;
+        if (is_sparse) {
+            result = index->CalDistanceById(queries, no_exist_ids.data(), test_num);
+        } else {
+            result =
+                index->CalDistanceById(queries->GetFloat32Vectors(), no_exist_ids.data(), test_num);
+        }
         for (int i = 0; i < test_num; ++i) {
             fixtures::dist_t dist = result.value()->GetDistances()[i];
             REQUIRE(dist == -1);

--- a/tests/test_index.h
+++ b/tests/test_index.h
@@ -167,7 +167,8 @@ public:
                               const TestDatasetPtr& dataset,
                               float error = 1e-5,
                               bool expected_success = true,
-                              bool is_sparse = false);
+                              bool is_sparse = false,
+                              bool is_old_index = false);
 
     static void
     TestGetMinAndMaxId(const IndexPtr& index,

--- a/tests/test_index.h
+++ b/tests/test_index.h
@@ -166,7 +166,8 @@ public:
     TestBatchCalcDistanceById(const IndexPtr& index,
                               const TestDatasetPtr& dataset,
                               float error = 1e-5,
-                              bool expected_success = true);
+                              bool expected_success = true,
+                              bool is_sparse = false);
 
     static void
     TestGetMinAndMaxId(const IndexPtr& index,

--- a/tests/test_sindi.cpp
+++ b/tests/test_sindi.cpp
@@ -74,7 +74,8 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex, "SINDI Build and Search",
     TestFilterSearch(index, dataset, search_param, 0.99, true);
     TestConcurrentKnnSearch(index, dataset, search_param, 0.99, true);
     TestGetMinAndMaxId(index, dataset, true);
-    TestCalcDistanceById(index, dataset, 0.1, true, true);
+    TestCalcDistanceById(index, dataset, 1e-4, true, true);
+    TestBatchCalcDistanceById(index, dataset, 1e-4, true, true);
     TestUpdateId(index, dataset, search_param, true);
     TestEstimateMemory("sindi", build_param, dataset);
 }

--- a/tests/test_sparse_index.cpp
+++ b/tests/test_sparse_index.cpp
@@ -55,7 +55,8 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::SparseTestIndex,
     TestRangeSearch(index, dataset, search_param, 0.99, 10, true);
     TestRangeSearch(index, dataset, search_param, 0.49, 5, true);
     TestFilterSearch(index, dataset, search_param, 0.99, true);
-    TestCalcDistanceById(index, dataset, 10, true, true);
+    TestCalcDistanceById(index, dataset, 1e-4, true, true);
+    TestBatchCalcDistanceById(index, dataset, 1e-4, true, true);
 }
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::SparseTestIndex,


### PR DESCRIPTION
#1129

## Summary by Sourcery

Support batch distance computation by ID across all index types by introducing a new API overload, implementing the logic in the inner index classes, and extending the test suite to cover the new functionality.

New Features:
- Add a batch distance-by-ID API overload (CalDistanceById(query, ids, count)) to the Index interface and expose it through IndexImpl.

Enhancements:
- Provide a default implementation in InnerIndexInterface that iterates over individual IDs and populates a Dataset of distances.
- Augment TestIndex with TestBatchCalcDistanceById to validate batch distance computation for both sparse and dense queries.

Tests:
- Update SINDI and sparse index tests to invoke the new batch distance method and adjust error tolerances accordingly.