### PR TITLE
feat(SINDI): support set immutable

### DIFF
--- a/src/algorithm/sindi/sindi.cpp
+++ b/src/algorithm/sindi/sindi.cpp
@@ -44,7 +44,7 @@ SINDI::SINDI(const SINDIParameterPtr& param, const IndexCommonParam& common_para
 
 std::vector<int64_t>
 SINDI::Add(const DatasetPtr& base) {
-    std::unique_lock wlock(this->global_mutex_);
+    std::scoped_lock wlock(this->global_mutex_);
 
     auto data_num = base->GetNumElements();
     CHECK_ARGUMENT(data_num > 0, "data_num is zero when add vectors");
@@ -277,7 +277,8 @@ SINDI::Serialize(StreamWriter& writer) const {
 
 void
 SINDI::Deserialize(StreamReader& reader) {
-    std::unique_lock wlock(this->global_mutex_);
+    std::scoped_lock wlock(this->global_mutex_);
+
     if (not deserialize_without_footer_) {
         auto footer = Footer::Parse(reader);
         auto metadata = footer->GetMetadata();
@@ -314,7 +315,7 @@ SINDI::UpdateId(int64_t old_id, int64_t new_id) {
         return true;
     }
 
-    std::unique_lock wlock(this->global_mutex_);
+    std::scoped_lock wlock(this->global_mutex_);
     label_table_->UpdateLabel(old_id, new_id);
     return true;
 }
@@ -374,6 +375,12 @@ SINDI::CalcDistanceById(const DatasetPtr& vector, int64_t id) const {
     search_param.term_prune_ratio = 0;
     auto computer = std::make_shared<SparseTermComputer>(sparse_query, search_param, allocator_);
     return term_list->CalcDistanceByInnerId(computer, inner_id - window_start_id);
+}
+
+void
+SINDI::SetImmutable() {
+    std::scoped_lock wlock(this->global_mutex_);
+    this->immutable_ = true;
 }
 
 void

--- a/src/algorithm/sindi/sindi.h
+++ b/src/algorithm/sindi/sindi.h
@@ -99,6 +99,9 @@ public:
     std::pair<int64_t, int64_t>
     GetMinAndMaxId() const override;
 
+    void
+    SetImmutable() override;
+
 private:
     template <InnerSearchMode mode>
     DatasetPtr

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -266,6 +266,7 @@ HGraphTestIndex::TestGeneral(const TestIndex::IndexPtr& index,
     TestUpdateVector(index, dataset, search_param, false);
     TestUpdateId(index, dataset, search_param, true);
     TestMemoryUsageDetail(index);
+    TestIndexStatus(index);
 }
 
 void

--- a/tests/test_index.cpp
+++ b/tests/test_index.cpp
@@ -2244,6 +2244,27 @@ TestIndex::TestGetDataById(const IndexPtr& index, const TestDatasetPtr& dataset)
 }
 
 void
+TestIndex::TestIndexStatus(const IndexPtr& index) {
+    auto set_result = index->SetImmutable();
+    if (not set_result.has_value()) {
+        return;
+    }
+    REQUIRE_FALSE(index->Train(nullptr));
+    REQUIRE_FALSE(index->Build(nullptr));
+    REQUIRE_FALSE(index->Add(nullptr));
+    std::ifstream inf;
+    REQUIRE_FALSE(index->Deserialize(inf));
+    REQUIRE_FALSE(index->Remove(0));
+    std::vector<vsag::MergeUnit> merge_units;
+    REQUIRE_FALSE(index->Merge(merge_units));
+    vsag::AttributeSet new_attrs;
+    REQUIRE_FALSE(index->UpdateAttribute(0, new_attrs));
+    REQUIRE_FALSE(index->UpdateAttribute(0, new_attrs, new_attrs));
+    REQUIRE_FALSE(index->UpdateId(0, 0));
+    REQUIRE_FALSE(index->UpdateVector(0, nullptr, false));
+}
+
+void
 TestIndex::TestGetDataByIdWithFlag(const IndexPtr& index, const TestDatasetPtr& dataset) {
 }
 

--- a/tests/test_index.h
+++ b/tests/test_index.h
@@ -295,6 +295,9 @@ public:
     static void
     TestGetDataByIdWithFlag(const IndexPtr& index, const TestDatasetPtr& dataset);
 
+    static void
+    TestIndexStatus(const IndexPtr& index);
+
     constexpr static float RECALL_THRESHOLD = 0.95;
 };
 

--- a/tests/test_sindi.cpp
+++ b/tests/test_sindi.cpp
@@ -86,6 +86,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex, "SINDI Build and Search",
     TestBatchCalcDistanceById(index, dataset, 1e-4, true, true);
     TestUpdateId(index, dataset, search_param, true);
     TestEstimateMemory("sindi", build_param, dataset);
+    TestIndexStatus(index);
 }
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex, "SINDI Concurrent", "[ft][sindi]") {


### PR DESCRIPTION
close #1129 

## Summary by Sourcery

Introduce immutability support to the SINDI index by adding SetImmutable, which prevents any further modifications once invoked, and validate this behavior through new tests.

New Features:
- Add SetImmutable method to the index interface and SINDI implementation to mark an index as immutable
- Enforce that operations like Train, Build, Add, Remove, Merge, and updates fail after an index is set immutable

Tests:
- Implement TestIndexStatus to verify that all modification operations are rejected on an immutable index and integrate it into existing HGraph and SINDI test suites