### PR TITLE
feat(extra info): Support ExtraInfo for all index

### DIFF
--- a/src/algorithm/brute_force.h
+++ b/src/algorithm/brute_force.h
@@ -137,8 +137,6 @@ private:
 
     uint64_t resize_increase_count_bit_{DEFAULT_RESIZE_BIT};
 
-    std::shared_ptr<SafeThreadPool> build_pool_{nullptr};
-
     mutable std::shared_mutex global_mutex_;
     mutable std::shared_mutex add_mutex_;
 
@@ -146,7 +144,6 @@ private:
 
     static constexpr uint64_t DEFAULT_RESIZE_BIT = 10;
 
-    bool use_attribute_filter_{false};
     AttrInvertedInterfacePtr attr_filter_index_{nullptr};
 };
 }  // namespace vsag

--- a/src/algorithm/brute_force_parameter.cpp
+++ b/src/algorithm/brute_force_parameter.cpp
@@ -39,7 +39,7 @@ BruteForceParameter::FromJson(const JsonType& json) {
 JsonType
 BruteForceParameter::ToJson() const {
     auto json = this->flatten_param->ToJson();
-    json["type"] = INDEX_BRUTE_FORCE;
+    json[TYPE_KEY] = INDEX_BRUTE_FORCE;
     json[USE_ATTRIBUTE_FILTER_KEY] = this->use_attribute_filter;
     return json;
 }

--- a/src/algorithm/brute_force_parameter.h
+++ b/src/algorithm/brute_force_parameter.h
@@ -14,12 +14,12 @@
 // limitations under the License.
 
 #pragma once
-#include "parameter.h"
+#include "inner_index_parameter.h"
 #include "pointer_define.h"
 #include "typing.h"
 namespace vsag {
 DEFINE_POINTER2(FlattenDataCellParam, FlattenDataCellParameter);
-class BruteForceParameter : public Parameter {
+class BruteForceParameter : public InnerIndexParameter {
 public:
     explicit BruteForceParameter();
 
@@ -34,8 +34,6 @@ public:
 
 public:
     FlattenDataCellParamPtr flatten_param;
-
-    bool use_attribute_filter{false};
 };
 
 DEFINE_POINTER(BruteForceParameter);

--- a/src/algorithm/hgraph.h
+++ b/src/algorithm/hgraph.h
@@ -88,8 +88,10 @@ public:
     void
     GetCodeByInnerId(InnerIdType inner_id, uint8_t* data) const override;
 
-    void
-    GetExtraInfoByIds(const int64_t* ids, int64_t count, char* extra_infos) const override;
+    int64_t
+    GetMemoryUsage() const override {
+        return static_cast<int64_t>(this->CalSerializeSize());
+    }
 
     std::string
     GetMemoryUsageDetail() const override;
@@ -203,9 +205,6 @@ public:
     UpdateAttribute(int64_t id,
                     const AttributeSet& new_attrs,
                     const AttributeSet& origin_attrs) override;
-
-    bool
-    UpdateExtraInfo(const DatasetPtr& new_base) override;
 
 private:
     const void*
@@ -324,7 +323,6 @@ private:
     bool use_elp_optimizer_{false};
     bool ignore_reorder_{false};
     bool build_by_base_{false};
-    bool use_attribute_filter_{false};
 
     BasicSearcherPtr searcher_;
 
@@ -345,9 +343,6 @@ private:
     mutable std::shared_mutex global_mutex_;
     mutable MutexArrayPtr neighbors_mutex_;
     mutable std::shared_mutex add_mutex_;
-
-    std::shared_ptr<SafeThreadPool> build_pool_{nullptr};
-    uint64_t build_thread_count_{100};
 
     std::atomic<InnerIdType> max_capacity_{0};
 

--- a/src/algorithm/hgraph_parameter.cpp
+++ b/src/algorithm/hgraph_parameter.cpp
@@ -36,9 +36,7 @@ HGraphParameter::HGraphParameter() : name(INDEX_TYPE_HGRAPH) {
 
 void
 HGraphParameter::FromJson(const JsonType& json) {
-    CHECK_ARGUMENT(json.contains(HGRAPH_USE_REORDER_KEY),
-                   fmt::format("hgraph parameters must contains {}", HGRAPH_USE_REORDER_KEY));
-    this->use_reorder = json[HGRAPH_USE_REORDER_KEY];
+    InnerIndexParameter::FromJson(json);
 
     if (json.contains(HGRAPH_USE_ELP_OPTIMIZER_KEY)) {
         this->use_elp_optimizer = json[HGRAPH_USE_ELP_OPTIMIZER_KEY];
@@ -52,10 +50,6 @@ HGraphParameter::FromJson(const JsonType& json) {
         this->build_by_base = json[HGRAPH_BUILD_BY_BASE_QUANTIZATION_KEY];
     }
 
-    if (json.contains(USE_ATTRIBUTE_FILTER_KEY)) {
-        this->use_attribute_filter = json[USE_ATTRIBUTE_FILTER_KEY];
-    }
-
     CHECK_ARGUMENT(json.contains(HGRAPH_BASE_CODES_KEY),
                    fmt::format("hgraph parameters must contains {}", HGRAPH_BASE_CODES_KEY));
     const auto& base_codes_json = json[HGRAPH_BASE_CODES_KEY];
@@ -67,25 +61,15 @@ HGraphParameter::FromJson(const JsonType& json) {
     this->base_codes_param->FromJson(base_codes_json);
 
     if (use_reorder) {
-        CHECK_ARGUMENT(json.contains(HGRAPH_PRECISE_CODES_KEY),
-                       fmt::format("hgraph parameters must contains {}", HGRAPH_PRECISE_CODES_KEY));
-        const auto& precise_codes_json = json[HGRAPH_PRECISE_CODES_KEY];
+        CHECK_ARGUMENT(json.contains(PRECISE_CODES_KEY),
+                       fmt::format("hgraph parameters must contains {}", PRECISE_CODES_KEY));
+        const auto& precise_codes_json = json[PRECISE_CODES_KEY];
         if (data_type == DataTypes::DATA_TYPE_SPARSE) {
             this->precise_codes_param = std::make_shared<SparseVectorDataCellParameter>();
         } else {
             this->precise_codes_param = std::make_shared<FlattenDataCellParameter>();
         }
         this->precise_codes_param->FromJson(precise_codes_json);
-    }
-
-    if (json.contains(STORE_RAW_VECTOR_KEY)) {
-        this->store_raw_vector = json[STORE_RAW_VECTOR_KEY];
-    }
-
-    if (this->store_raw_vector) {
-        const auto& raw_vector_json = json[RAW_VECTOR_KEY];
-        this->raw_vector_param = std::make_shared<FlattenDataCellParameter>();
-        this->raw_vector_param->FromJson(raw_vector_json);
     }
 
     CHECK_ARGUMENT(json.contains(HGRAPH_GRAPH_KEY),
@@ -124,14 +108,12 @@ HGraphParameter::FromJson(const JsonType& json) {
         hierarchical_graph_param->support_delete_ = false;
     }
 
-    if (json.contains(BUILD_PARAMS_KEY)) {
-        const auto& build_params = json[BUILD_PARAMS_KEY];
-        if (build_params.contains(BUILD_EF_CONSTRUCTION)) {
-            this->ef_construction = build_params[BUILD_EF_CONSTRUCTION];
-        }
-        if (build_params.contains(BUILD_THREAD_COUNT)) {
-            this->build_thread_count = build_params[BUILD_THREAD_COUNT];
-        }
+    if (json.contains(HGRAPH_EF_CONSTRUCTION_KEY)) {
+        this->ef_construction = json[HGRAPH_EF_CONSTRUCTION_KEY];
+    }
+
+    if (json.contains(BUILD_THREAD_COUNT_KEY)) {
+        this->build_thread_count = json[BUILD_THREAD_COUNT_KEY];
     }
 
     if (graph_json.contains(GRAPH_TYPE_KEY)) {
@@ -142,11 +124,6 @@ HGraphParameter::FromJson(const JsonType& json) {
         }
     }
 
-    CHECK_ARGUMENT(json.contains(HGRAPH_EXTRA_INFO_KEY),
-                   fmt::format("hgraph parameters must contains {}", HGRAPH_EXTRA_INFO_KEY));
-    const auto& extra_info_json = json[HGRAPH_EXTRA_INFO_KEY];
-    this->extra_info_param = std::make_shared<ExtraInfoDataCellParameter>();
-    this->extra_info_param->FromJson(extra_info_json);
     if (json.contains(SUPPORT_DUPLICATE)) {
         this->support_duplicate = json[SUPPORT_DUPLICATE];
     }
@@ -157,26 +134,14 @@ HGraphParameter::FromJson(const JsonType& json) {
 
 JsonType
 HGraphParameter::ToJson() const {
-    JsonType json;
-    json["type"] = INDEX_TYPE_HGRAPH;
+    JsonType json = InnerIndexParameter::ToJson();
+    json[TYPE_KEY] = INDEX_TYPE_HGRAPH;
 
-    json[HGRAPH_USE_REORDER_KEY] = this->use_reorder;
     json[HGRAPH_USE_ELP_OPTIMIZER_KEY] = this->use_elp_optimizer;
     json[HGRAPH_BASE_CODES_KEY] = this->base_codes_param->ToJson();
-    if (use_reorder) {
-        json[HGRAPH_PRECISE_CODES_KEY] = this->precise_codes_param->ToJson();
-    }
-    if (this->store_raw_vector) {
-        json[STORE_RAW_VECTOR_KEY] = this->raw_vector_param->ToJson();
-    }
     json[HGRAPH_GRAPH_KEY] = this->bottom_graph_param->ToJson();
-
-    json[BUILD_PARAMS_KEY][BUILD_EF_CONSTRUCTION] = this->ef_construction;
-    json[BUILD_PARAMS_KEY][BUILD_THREAD_COUNT] = this->build_thread_count;
-    json[HGRAPH_EXTRA_INFO_KEY] = this->extra_info_param->ToJson();
+    json[HGRAPH_EF_CONSTRUCTION_KEY] = this->ef_construction;
     json[SUPPORT_DUPLICATE] = this->support_duplicate;
-    json[STORE_RAW_VECTOR] = this->store_raw_vector;
-    json[USE_ATTRIBUTE_FILTER_KEY] = this->use_attribute_filter;
     return json;
 }
 

--- a/src/algorithm/hgraph_parameter.h
+++ b/src/algorithm/hgraph_parameter.h
@@ -16,7 +16,7 @@
 #pragma once
 
 #include "data_type.h"
-#include "parameter.h"
+#include "inner_index_parameter.h"
 #include "pointer_define.h"
 #include "vsag/constants.h"
 
@@ -28,7 +28,7 @@ DEFINE_POINTER2(SparseGraphDatacellParam, SparseGraphDatacellParameter);
 DEFINE_POINTER(ODescentParameter);
 
 DEFINE_POINTER(HGraphParameter);
-class HGraphParameter : public Parameter {
+class HGraphParameter : public InnerIndexParameter {
 public:
     explicit HGraphParameter(const JsonType& json);
 
@@ -45,24 +45,18 @@ public:
 
 public:
     FlattenInterfaceParamPtr base_codes_param{nullptr};
-    FlattenInterfaceParamPtr precise_codes_param{nullptr};
-    FlattenInterfaceParamPtr raw_vector_param{nullptr};
     GraphInterfaceParamPtr bottom_graph_param{nullptr};
     SparseGraphDatacellParamPtr hierarchical_graph_param{nullptr};
-    ExtraInfoDataCellParamPtr extra_info_param{nullptr};
+
     ODescentParameterPtr odescent_param{nullptr};
 
     std::string graph_type{GRAPH_TYPE_NSW};
 
-    bool use_reorder{false};
     bool use_elp_optimizer{false};
     bool ignore_reorder{false};
     bool build_by_base{false};
-    bool store_raw_vector{false};
 
-    bool use_attribute_filter{false};
     uint64_t ef_construction{400};
-    uint64_t build_thread_count{100};
 
     bool support_duplicate{false};
     bool support_tombstone{false};

--- a/src/algorithm/hgraph_parameter_test.cpp
+++ b/src/algorithm/hgraph_parameter_test.cpp
@@ -54,7 +54,6 @@ struct HGraphDefaultParam {
     bool use_attribute_filter = false;
     bool support_duplicate = false;
     bool use_reorder = true;
-    bool have_extro_info = false;
 };
 
 std::string

--- a/src/algorithm/inner_index_interface.cpp
+++ b/src/algorithm/inner_index_interface.cpp
@@ -30,16 +30,31 @@
 
 namespace vsag {
 
-InnerIndexInterface::InnerIndexInterface(ParamPtr index_param, const IndexCommonParam& common_param)
+InnerIndexInterface::InnerIndexInterface(const InnerIndexParameterPtr& index_param,
+                                         const IndexCommonParam& common_param)
     : allocator_(common_param.allocator_.get()),
-      create_param_ptr_(std::move(index_param)),
+      create_param_ptr_(index_param),
       dim_(common_param.dim_),
       metric_(common_param.metric_),
-      data_type_(common_param.data_type_) {
+      data_type_(common_param.data_type_),
+      build_thread_count_(index_param->build_thread_count),
+      use_attribute_filter_(index_param->use_attribute_filter),
+      use_reorder_(index_param->use_reorder) {
     this->label_table_ = std::make_shared<LabelTable>(allocator_);
     this->tomb_label_table_ = std::make_shared<LabelTable>(allocator_);
     this->index_feature_list_ = std::make_shared<IndexFeatureList>();
     this->index_feature_list_->SetFeature(SUPPORT_EXPORT_IDS);
+    this->extra_info_size_ = common_param.extra_info_size_;
+    if (this->extra_info_size_ > 0) {
+        this->extra_infos_ =
+            ExtraInfoInterface::MakeInstance(index_param->extra_info_param, common_param);
+    }
+
+    this->build_pool_ = common_param.thread_pool_;
+    if (this->build_thread_count_ > 1 && this->build_pool_ == nullptr) {
+        this->build_pool_ = SafeThreadPool::FactoryDefaultThreadPool();
+        this->build_pool_->SetPoolSize(build_thread_count_);
+    }
 }
 
 std::vector<int64_t>
@@ -454,6 +469,37 @@ InnerIndexInterface::GetDataByIdsWithFlag(const int64_t* ids,
     }
     this->allocator_->Deallocate(inner_ids);
     return dataset;
+}
+
+void
+InnerIndexInterface::GetExtraInfoByIds(const int64_t* ids, int64_t count, char* extra_infos) const {
+    if (this->extra_infos_ == nullptr) {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION, "extra_info is NULL");
+    }
+    for (int64_t i = 0; i < count; ++i) {
+        std::shared_lock<std::shared_mutex> lock(this->label_lookup_mutex_);
+        auto inner_id = this->label_table_->GetIdByLabel(ids[i]);
+        this->extra_infos_->GetExtraInfoById(inner_id, extra_infos + i * extra_info_size_);
+    }
+}
+
+bool
+InnerIndexInterface::UpdateExtraInfo(const DatasetPtr& new_base) {
+    CHECK_ARGUMENT(new_base != nullptr, "new_base is nullptr");
+    CHECK_ARGUMENT(new_base->GetExtraInfos() != nullptr, "extra_infos is nullptr");
+    CHECK_ARGUMENT(new_base->GetExtraInfoSize() == extra_info_size_, "extra_infos size mismatch");
+    CHECK_ARGUMENT(new_base->GetNumElements() == 1, "new_base size must be one");
+    auto label = new_base->GetIds()[0];
+    if (this->extra_infos_ != nullptr) {
+        std::shared_lock label_lock(this->label_lookup_mutex_);
+        if (not this->label_table_->CheckLabel(label)) {
+            return false;
+        }
+        const auto inner_id = this->label_table_->GetIdByLabel(label);
+        this->extra_infos_->InsertExtraInfo(new_base->GetExtraInfos(), inner_id);
+        return true;
+    }
+    throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION, "extra_infos is not initialized");
 }
 
 void

--- a/src/algorithm/inner_index_parameter.cpp
+++ b/src/algorithm/inner_index_parameter.cpp
@@ -1,0 +1,110 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "inner_index_parameter.h"
+
+#include "common.h"
+#include "data_cell/extra_info_datacell_parameter.h"
+#include "data_cell/flatten_datacell_parameter.h"
+#include "inner_string_params.h"
+#include "logger.h"
+#include "vsag/constants.h"
+
+namespace vsag {
+
+void
+InnerIndexParameter::FromJson(const JsonType& json) {
+    if (json.contains(USE_REORDER_KEY)) {
+        this->use_reorder = json[USE_REORDER_KEY];
+    }
+
+    if (json.contains(USE_ATTRIBUTE_FILTER_KEY)) {
+        this->use_attribute_filter = json[USE_ATTRIBUTE_FILTER_KEY];
+    }
+
+    if (json.contains(BUILD_THREAD_COUNT_KEY)) {
+        this->build_thread_count = json[BUILD_THREAD_COUNT_KEY];
+    }
+
+    if (this->use_reorder) {
+        CHECK_ARGUMENT(
+            json.contains(PRECISE_CODES_KEY),
+            fmt::format("ivf parameters must contains {} when enable reorder", PRECISE_CODES_KEY));
+        this->precise_codes_param = std::make_shared<FlattenDataCellParameter>();
+        this->precise_codes_param->FromJson(json[PRECISE_CODES_KEY]);
+    }
+
+    if (json.contains(STORE_RAW_VECTOR_KEY)) {
+        this->store_raw_vector = json[STORE_RAW_VECTOR_KEY];
+    }
+
+    if (this->store_raw_vector) {
+        this->raw_vector_param = std::make_shared<FlattenDataCellParameter>();
+        this->raw_vector_param->FromJson(json[RAW_VECTOR_KEY]);
+    }
+
+    if (json.contains(EXTRA_INFO_KEY)) {
+        this->extra_info_param = std::make_shared<ExtraInfoDataCellParameter>();
+        this->extra_info_param->FromJson(json[EXTRA_INFO_KEY]);
+    }
+}
+
+JsonType
+InnerIndexParameter::ToJson() const {
+    JsonType json;
+    json[USE_REORDER_KEY] = this->use_reorder;
+    json[BUILD_THREAD_COUNT_KEY] = this->build_thread_count;
+    json[USE_ATTRIBUTE_FILTER_KEY] = this->use_attribute_filter;
+    if (use_reorder) {
+        json[PRECISE_CODES_KEY] = this->precise_codes_param->ToJson();
+    }
+    json[STORE_RAW_VECTOR_KEY] = this->store_raw_vector;
+    if (this->store_raw_vector) {
+        json[RAW_VECTOR_KEY] = this->raw_vector_param->ToJson();
+    }
+    if (this->extra_info_param) {
+        json[EXTRA_INFO_KEY] = this->extra_info_param->ToJson();
+    }
+
+    return json;
+}
+bool
+InnerIndexParameter::CheckCompatibility(const ParamPtr& other) const {
+    auto inner_index_param = std::dynamic_pointer_cast<InnerIndexParameter>(other);
+    if (not inner_index_param) {
+        logger::error(
+            "InnerIndexParameter::CheckCompatibility: other parameter is not InnerIndexParameter");
+        return false;
+    }
+    if (this->use_reorder != inner_index_param->use_reorder) {
+        logger::error("InnerIndexParameter::CheckCompatibility: use_reorder mismatch");
+        return false;
+    }
+    if (this->use_reorder) {
+        if (not this->precise_codes_param->CheckCompatibility(
+                inner_index_param->precise_codes_param)) {
+            logger::error("InnerIndexParameter::CheckCompatibility: precise_codes_param mismatch");
+            return false;
+        }
+    }
+
+    if (this->use_attribute_filter != inner_index_param->use_attribute_filter) {
+        logger::error("InnerIndexParameter::CheckCompatibility: use_attribute_filter mismatch");
+        return false;
+    }
+
+    return true;
+}
+}  // namespace vsag

--- a/src/algorithm/inner_index_parameter.h
+++ b/src/algorithm/inner_index_parameter.h
@@ -15,24 +15,21 @@
 
 #pragma once
 
-#include <functional>
-
-#include "algorithm/hgraph_parameter.h"
-#include "data_cell/flatten_interface.h"
-#include "data_cell/graph_datacell_parameter.h"
-#include "data_cell/graph_interface.h"
-#include "impl/odescent_graph_parameter.h"
-#include "index/index_common_param.h"
-#include "inner_index_parameter.h"
+#include "parameter.h"
 #include "pointer_define.h"
 #include "typing.h"
-#include "vsag/index.h"
 
 namespace vsag {
+DEFINE_POINTER(InnerIndexParameter);
+DEFINE_POINTER2(ExtraInfoDataCellParam, ExtraInfoDataCellParameter);
+DEFINE_POINTER2(FlattenInterfaceParam, FlattenInterfaceParameter);
 
-DEFINE_POINTER2(PyramidParam, PyramidParameters);
-struct PyramidParameters : public InnerIndexParameter {
+class InnerIndexParameter : public Parameter {
 public:
+    explicit InnerIndexParameter() = default;
+
+    ~InnerIndexParameter() override = default;
+
     void
     FromJson(const JsonType& json) override;
 
@@ -43,23 +40,16 @@ public:
     CheckCompatibility(const vsag::ParamPtr& other) const override;
 
 public:
-    GraphInterfaceParamPtr graph_param{nullptr};
-    FlattenDataCellParamPtr flatten_data_cell_param{nullptr};
-    ODescentParameterPtr odescent_param{nullptr};
+    bool use_reorder{false};
+    FlattenInterfaceParamPtr precise_codes_param{nullptr};
 
-    std::vector<int32_t> no_build_levels;
-    uint64_t ef_construction{100};
-};
+    bool use_attribute_filter{false};
 
-class PyramidSearchParameters {
-public:
-    static PyramidSearchParameters
-    FromJson(const std::string& json_string);
+    uint64_t build_thread_count{100};
 
-public:
-    int64_t ef_search{100};
+    bool store_raw_vector{false};
+    FlattenInterfaceParamPtr raw_vector_param{nullptr};
 
-private:
-    PyramidSearchParameters() = default;
+    ExtraInfoDataCellParamPtr extra_info_param{nullptr};
 };
 }  // namespace vsag

--- a/src/algorithm/ivf_parameter.cpp
+++ b/src/algorithm/ivf_parameter.cpp
@@ -21,10 +21,14 @@
 #include "vsag/constants.h"
 namespace vsag {
 
-IVFParameter::IVFParameter() = default;
-
 void
 IVFParameter::FromJson(const JsonType& json) {
+    InnerIndexParameter::FromJson(json);
+
+    if (json.contains(BUCKET_PER_DATA_KEY)) {
+        this->buckets_per_data = json[BUCKET_PER_DATA_KEY];
+    }
+
     this->bucket_param = std::make_shared<BucketDataCellParameter>();
     CHECK_ARGUMENT(json.contains(BUCKET_PARAMS_KEY),
                    fmt::format("ivf parameters must contains {}", BUCKET_PARAMS_KEY));
@@ -41,62 +45,26 @@ IVFParameter::FromJson(const JsonType& json) {
             this->ivf_partition_strategy_parameter->gnoimi_param->first_order_buckets_count *
             this->ivf_partition_strategy_parameter->gnoimi_param->second_order_buckets_count);
     }
-
-    if (json.contains(BUCKET_PER_DATA_KEY)) {
-        this->buckets_per_data = json[BUCKET_PER_DATA_KEY];
-    }
-    if (json.contains(IVF_USE_REORDER_KEY)) {
-        this->use_reorder = json[IVF_USE_REORDER_KEY];
-    }
-
-    if (json.contains(USE_ATTRIBUTE_FILTER_KEY)) {
-        this->use_attribute_filter = json[USE_ATTRIBUTE_FILTER_KEY];
-    }
-
-    if (json.contains(IVF_THREAD_COUNT_KEY)) {
-        this->thread_count = json[IVF_THREAD_COUNT_KEY];
-    }
-
-    if (this->use_reorder) {
-        CHECK_ARGUMENT(json.contains(IVF_PRECISE_CODES_KEY),
-                       fmt::format("ivf parameters must contains {} when enable reorder",
-                                   IVF_PRECISE_CODES_KEY));
-        this->flatten_param = std::make_shared<FlattenDataCellParameter>();
-        this->flatten_param->FromJson(json[IVF_PRECISE_CODES_KEY]);
-    }
 }
 
 JsonType
 IVFParameter::ToJson() const {
-    JsonType json;
-    json["type"] = INDEX_IVF;
+    JsonType json = InnerIndexParameter::ToJson();
+    json[TYPE_KEY] = INDEX_IVF;
     json[BUCKET_PARAMS_KEY] = this->bucket_param->ToJson();
     json[IVF_PARTITION_STRATEGY_PARAMS_KEY] = this->ivf_partition_strategy_parameter->ToJson();
     json[BUCKET_PER_DATA_KEY] = this->buckets_per_data;
-    json[IVF_USE_REORDER_KEY] = this->use_reorder;
-    json[IVF_THREAD_COUNT_KEY] = this->thread_count;
-    json[USE_ATTRIBUTE_FILTER_KEY] = this->use_attribute_filter;
-    if (use_reorder) {
-        json[IVF_PRECISE_CODES_KEY] = this->flatten_param->ToJson();
-    }
     return json;
 }
 bool
 IVFParameter::CheckCompatibility(const ParamPtr& other) const {
+    if (not InnerIndexParameter::CheckCompatibility(other)) {
+        return false;
+    }
     auto ivf_param = std::dynamic_pointer_cast<IVFParameter>(other);
     if (not ivf_param) {
         logger::error("IVFParameter::CheckCompatibility: other parameter is not IVFParameter");
         return false;
-    }
-    if (this->use_reorder != ivf_param->use_reorder) {
-        logger::error("IVFParameter::CheckCompatibility: use_reorder mismatch");
-        return false;
-    }
-    if (this->use_reorder) {
-        if (not this->flatten_param->CheckCompatibility(ivf_param->flatten_param)) {
-            logger::error("IVFParameter::CheckCompatibility: flatten_param mismatch");
-            return false;
-        }
     }
 
     if (this->buckets_per_data != ivf_param->buckets_per_data) {
@@ -108,10 +76,7 @@ IVFParameter::CheckCompatibility(const ParamPtr& other) const {
         logger::error("IVFParameter::CheckCompatibility: bucket_param mismatch");
         return false;
     }
-    if (this->use_attribute_filter != ivf_param->use_attribute_filter) {
-        logger::error("IVFParameter::CheckCompatibility: use_attribute_filter mismatch");
-        return false;
-    }
+
     if (not this->ivf_partition_strategy_parameter->CheckCompatibility(
             ivf_param->ivf_partition_strategy_parameter)) {
         logger::error(

--- a/src/algorithm/ivf_parameter.h
+++ b/src/algorithm/ivf_parameter.h
@@ -20,17 +20,17 @@
 #include "algorithm/ivf_partition/ivf_partition_strategy_parameter.h"
 #include "data_cell/bucket_datacell_parameter.h"
 #include "data_cell/flatten_datacell_parameter.h"
+#include "inner_index_parameter.h"
 #include "inner_string_params.h"
-#include "parameter.h"
 #include "pointer_define.h"
 #include "typing.h"
 
 namespace vsag {
 
 DEFINE_POINTER(IVFParameter);
-class IVFParameter : public Parameter {
+class IVFParameter : public InnerIndexParameter {
 public:
-    explicit IVFParameter();
+    explicit IVFParameter() = default;
 
     void
     FromJson(const JsonType& json) override;
@@ -45,15 +45,8 @@ public:
     BucketDataCellParamPtr bucket_param{nullptr};
     IVFPartitionStrategyParametersPtr ivf_partition_strategy_parameter{nullptr};
     BucketIdType buckets_per_data{1};
-
-    bool use_reorder{false};
-
-    bool use_attribute_filter{false};
-
-    int thread_count{1};
-
-    FlattenDataCellParamPtr flatten_param{nullptr};
 };
+
 class IVFSearchParameters {
 public:
     static IVFSearchParameters

--- a/src/algorithm/ivf_parameter_test.cpp
+++ b/src/algorithm/ivf_parameter_test.cpp
@@ -37,7 +37,7 @@ std::string
 generate_ivf_param(const IVFDefaultParam& param) {
     static constexpr auto param_str = R"({{
         "type": "ivf",
-        "thread_count": 3,
+        "build_thread_count": 3,
         "buckets_params": {{
             "io_params": {{
                 "type": "{}"
@@ -96,8 +96,8 @@ TEST_CASE("IVF Parameters Test", "[ut][IVFParameter]") {
             vsag::IVFNearestPartitionTrainerType::KMeansTrainer);
     REQUIRE(param->buckets_per_data == 1);
     REQUIRE(param->use_reorder == true);
-    REQUIRE(param->thread_count == 3);
-    REQUIRE(param->flatten_param->quantizer_parameter->GetTypeName() == "fp32");
+    REQUIRE(param->build_thread_count == 3);
+    REQUIRE(param->precise_codes_param->quantizer_parameter->GetTypeName() == "fp32");
 
     index_param.ivf_train_type = "random";
     index_param.partition_strategy_type = "gno_imi";

--- a/src/algorithm/pyramid_zparameters.cpp
+++ b/src/algorithm/pyramid_zparameters.cpp
@@ -44,8 +44,8 @@ PyramidParameters::FromJson(const JsonType& json) {
             std::make_shared<FP32QuantizerParameter>();
     }
 
-    if (json.contains(BUILD_EF_CONSTRUCTION)) {
-        this->ef_construction = json[BUILD_EF_CONSTRUCTION];
+    if (json.contains(HGRAPH_EF_CONSTRUCTION_KEY)) {
+        this->ef_construction = json[HGRAPH_EF_CONSTRUCTION_KEY];
     }
 
     if (json.contains(NO_BUILD_LEVELS)) {
@@ -61,7 +61,7 @@ PyramidParameters::FromJson(const JsonType& json) {
 }
 JsonType
 PyramidParameters::ToJson() const {
-    JsonType json;
+    JsonType json = InnerIndexParameter::ToJson();
     json[GRAPH_TYPE_ODESCENT] = graph_param->ToJson();
     json[GRAPH_TYPE_ODESCENT].update(odescent_param->ToJson());
     json[PYRAMID_PARAMETER_BASE_CODES] = flatten_data_cell_param->ToJson();

--- a/src/algorithm/sindi/sindi.cpp
+++ b/src/algorithm/sindi/sindi.cpp
@@ -52,6 +52,8 @@ SINDI::Add(const DatasetPtr& base) {
 
     const auto* sparse_vectors = base->GetSparseVectors();
     const auto* ids = base->GetIds();
+    const auto* extra_info = base->GetExtraInfos();
+    const auto extra_info_size = base->GetExtraInfoSize();
 
     // adjust window
     int64_t final_add_window = ceil_int(cur_element_count_ + data_num, window_size_) / window_size_;
@@ -67,6 +69,10 @@ SINDI::Add(const DatasetPtr& base) {
         const auto& sparse_vector = sparse_vectors[i];
 
         label_table_->Insert(cur_element_count_, ids[i]);  // todo(zxy): check id exists
+        if (extra_info_size > 0) {
+            extra_infos_->InsertExtraInfo(extra_info + i * extra_info_size, cur_element_count_);
+        }
+
         uint32_t inner_id = cur_element_count_ - window_start_id;
         window_term_list_[cur_window]->InsertVector(sparse_vector, inner_id);
 

--- a/src/algorithm/sindi/sindi_parameter.cpp
+++ b/src/algorithm/sindi/sindi_parameter.cpp
@@ -49,8 +49,25 @@ SINDIParameter::ToJson() const {
     json[SPARSE_DOC_PRUNE_RATIO] = doc_prune_ratio;
     json[SPARSE_USE_REORDER] = use_reorder;
     json[SPARSE_WINDOW_SIZE] = window_size;
-
     return json;
+}
+
+bool
+SINDIParameter::CheckCompatibility(const vsag::ParamPtr& other) const {
+    auto sindi_param = std::dynamic_pointer_cast<SINDIParameter>(other);
+    if (sindi_param == nullptr) {
+        return false;
+    }
+    if (this->window_size != sindi_param->window_size) {
+        return false;
+    }
+    if (this->doc_prune_ratio != sindi_param->doc_prune_ratio) {
+        return false;
+    }
+    if (this->use_reorder != sindi_param->use_reorder) {
+        return false;
+    }
+    return true;
 }
 
 void

--- a/src/algorithm/sindi/sindi_parameter.h
+++ b/src/algorithm/sindi/sindi_parameter.h
@@ -15,8 +15,8 @@
 
 #pragma once
 
+#include "algorithm/inner_index_parameter.h"
 #include "index/index_common_param.h"
-#include "parameter.h"
 #include "pointer_define.h"
 
 namespace vsag {
@@ -30,7 +30,7 @@ static constexpr uint32_t DEFAULT_N_CANDIDATE = 0;
 
 DEFINE_POINTER(SINDIParameter);
 
-class SINDIParameter : public Parameter {
+class SINDIParameter : public InnerIndexParameter {
 public:
     void
     FromJson(const JsonType& json) override;
@@ -38,12 +38,14 @@ public:
     JsonType
     ToJson() const override;
 
+    bool
+    CheckCompatibility(const vsag::ParamPtr& other) const override;
+
     SINDIParameter() = default;
 
 public:
     // index
     uint32_t window_size{0};
-    bool use_reorder{false};
 
     float doc_prune_ratio{0};
 

--- a/src/algorithm/sparse_index_parameters.h
+++ b/src/algorithm/sparse_index_parameters.h
@@ -16,13 +16,13 @@
 #pragma once
 
 #include "index/index_common_param.h"
-#include "parameter.h"
+#include "inner_index_parameter.h"
 #include "pointer_define.h"
 
 namespace vsag {
 DEFINE_POINTER2(SparseIndexParameter, SparseIndexParameters);
 
-struct SparseIndexParameters : public Parameter {
+struct SparseIndexParameters : public InnerIndexParameter {
 public:
     void
     FromJson(const JsonType& json) override;

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -139,7 +139,7 @@ const char* const RABITQ_USE_FHT = "rabitq_use_fht";
 const char* const HGRAPH_SUPPORT_REMOVE = "support_remove";
 const char* const HGRAPH_REMOVE_FLAG_BIT = "remove_flag_bit";
 
-const char* const HGRAPH_USE_REORDER = HGRAPH_USE_REORDER_KEY;
+const char* const HGRAPH_USE_REORDER = USE_REORDER_KEY;
 const char* const HGRAPH_USE_ELP_OPTIMIZER = HGRAPH_USE_ELP_OPTIMIZER_KEY;
 const char* const HGRAPH_IGNORE_REORDER = "ignore_reorder";
 const char* const HGRAPH_BUILD_BY_BASE_QUANTIZATION = "build_by_base";

--- a/src/inner_string_params.h
+++ b/src/inner_string_params.h
@@ -26,15 +26,22 @@ const char* const INDEX_TYPE_HGRAPH = "hgraph";
 const char* const INDEX_TYPE_IVF = "ivf";
 const char* const INDEX_TYPE_GNO_IMI = "gno_imi";
 
+const char* const TYPE_KEY = "type";
+const char* const USE_REORDER_KEY = "use_reorder";
+const char* const EXTRA_INFO_KEY = "extra_info";
+const char* const USE_ATTRIBUTE_FILTER_KEY = "use_attribute_filter";
+const char* const BUILD_THREAD_COUNT_KEY = "build_thread_count";
+const char* const PRECISE_CODES_KEY = "precise_codes";
+const char* const STORE_RAW_VECTOR_KEY = "store_raw_vector";
+const char* const RAW_VECTOR_KEY = "raw_vector";
+
 // Parameter key for hgraph
-const char* const HGRAPH_USE_REORDER_KEY = "use_reorder";
 const char* const HGRAPH_USE_ELP_OPTIMIZER_KEY = "use_elp_optimizer";
 const char* const HGRAPH_IGNORE_REORDER_KEY = "ignore_reorder";
 const char* const HGRAPH_BUILD_BY_BASE_QUANTIZATION_KEY = "build_by_base";
 const char* const HGRAPH_GRAPH_KEY = "graph";
 const char* const HGRAPH_BASE_CODES_KEY = "base_codes";
-const char* const HGRAPH_PRECISE_CODES_KEY = "precise_codes";
-const char* const HGRAPH_EXTRA_INFO_KEY = "extra_info";
+const char* const HGRAPH_EF_CONSTRUCTION_KEY = "ef_construction";
 
 // IO param key
 const char* const IO_PARAMS_KEY = "io_params";
@@ -100,10 +107,6 @@ const char* const SPARSE_DESERIALIZE_WITHOUT_FOOTER = "deserialize_without_foote
 const char* const GRAPH_PARAM_MAX_DEGREE = "max_degree";
 const char* const GRAPH_PARAM_INIT_MAX_CAPACITY = "init_capacity";
 
-const char* const BUILD_PARAMS_KEY = "build_params";
-const char* const BUILD_THREAD_COUNT = "build_thread_count";
-const char* const BUILD_EF_CONSTRUCTION = "ef_construction";
-
 const char* const GRAPH_TYPE_KEY = "graph_type";
 
 const char* const GRAPH_STORAGE_TYPE_KEY = "graph_storage_type";
@@ -121,10 +124,6 @@ const char* const IVF_SEARCH_PARAM_FACTOR = "factor";
 const char* const IVF_SEARCH_PARALLELISM = "parallelism";
 const char* const SEARCH_MAX_TIME_COST_MS = "timeout_ms";
 
-const char* const IVF_USE_REORDER_KEY = "use_reorder";
-const char* const IVF_PRECISE_CODES_KEY = "precise_codes";
-const char* const USE_ATTRIBUTE_FILTER_KEY = "use_attribute_filter";
-const char* const IVF_THREAD_COUNT_KEY = "thread_count";
 const char* const IVF_TRAIN_TYPE_KEY = "ivf_train_type";
 const char* const IVF_TRAIN_TYPE_RANDOM = "random";
 const char* const IVF_TRAIN_TYPE_KMEANS = "kmeans";
@@ -141,9 +140,6 @@ const char* const GNO_IMI_SEARCH_PARAM_FIRST_ORDER_SCAN_RATIO = "first_order_sca
 const char* const FLATTEN_DATA_CELL = "flatten_data_cell";
 const char* const SPARSE_VECTOR_DATA_CELL = "sparse_vector_data_cell";
 
-const char* const STORE_RAW_VECTOR_KEY = "store_raw_vector";
-const char* const RAW_VECTOR_KEY = "raw_vector";
-
 const char* const GRAPH_SUPPORT_REMOVE = "support_remove";
 const char* const REMOVE_FLAG_BIT = "remove_flag_bit";
 const char* const HOLD_MOLDS = "hold_molds";
@@ -159,13 +155,12 @@ const std::unordered_map<std::string, std::string> DEFAULT_MAP = {
     {"INDEX_TYPE_HGRAPH", INDEX_TYPE_HGRAPH},
     {"INDEX_TYPE_IVF", INDEX_TYPE_IVF},
     {"INDEX_TYPE_GNO_IMI", INDEX_TYPE_GNO_IMI},
-    {"HGRAPH_USE_REORDER_KEY", HGRAPH_USE_REORDER_KEY},
     {"HGRAPH_USE_ELP_OPTIMIZER_KEY", HGRAPH_USE_ELP_OPTIMIZER_KEY},
     {"HGRAPH_IGNORE_REORDER_KEY", HGRAPH_IGNORE_REORDER_KEY},
     {"HGRAPH_BUILD_BY_BASE_QUANTIZATION_KEY", HGRAPH_BUILD_BY_BASE_QUANTIZATION_KEY},
     {"HGRAPH_GRAPH_KEY", HGRAPH_GRAPH_KEY},
     {"HGRAPH_BASE_CODES_KEY", HGRAPH_BASE_CODES_KEY},
-    {"HGRAPH_PRECISE_CODES_KEY", HGRAPH_PRECISE_CODES_KEY},
+    {"PRECISE_CODES_KEY", PRECISE_CODES_KEY},
     {"HGRAPH_SUPPORT_DUPLICATE", HGRAPH_SUPPORT_DUPLICATE},
     {"IO_TYPE_KEY", IO_TYPE_KEY},
     {"IO_TYPE_VALUE_MEMORY_IO", IO_TYPE_VALUE_MEMORY_IO},
@@ -190,15 +185,14 @@ const std::unordered_map<std::string, std::string> DEFAULT_MAP = {
     {"QUANTIZATION_PARAMS_KEY", QUANTIZATION_PARAMS_KEY},
     {"GRAPH_PARAM_MAX_DEGREE", GRAPH_PARAM_MAX_DEGREE},
     {"GRAPH_PARAM_INIT_MAX_CAPACITY", GRAPH_PARAM_INIT_MAX_CAPACITY},
-    {"BUILD_PARAMS_KEY", BUILD_PARAMS_KEY},
-    {"BUILD_THREAD_COUNT", BUILD_THREAD_COUNT},
-    {"BUILD_EF_CONSTRUCTION", BUILD_EF_CONSTRUCTION},
+    {"BUILD_THREAD_COUNT_KEY", BUILD_THREAD_COUNT_KEY},
+    {"HGRAPH_EF_CONSTRUCTION_KEY", HGRAPH_EF_CONSTRUCTION_KEY},
     {"BUCKETS_COUNT_KEY", BUCKETS_COUNT_KEY},
     {"BUCKET_PARAMS_KEY", BUCKET_PARAMS_KEY},
     {"IO_FILE_PATH", IO_FILE_PATH},
     {"DEFAULT_FILE_PATH_VALUE", DEFAULT_FILE_PATH_VALUE},
-    {"IVF_PRECISE_CODES_KEY", IVF_PRECISE_CODES_KEY},
-    {"IVF_USE_REORDER_KEY", IVF_USE_REORDER_KEY},
+    {"PRECISE_CODES_KEY", PRECISE_CODES_KEY},
+    {"USE_REORDER_KEY", USE_REORDER_KEY},
     {"USE_ATTRIBUTE_FILTER_KEY", USE_ATTRIBUTE_FILTER_KEY},
     {"SQ4_UNIFORM_QUANTIZATION_TRUNC_RATE", SQ4_UNIFORM_QUANTIZATION_TRUNC_RATE},
     {"PCA_DIM", PCA_DIM},
@@ -211,14 +205,14 @@ const std::unordered_map<std::string, std::string> DEFAULT_MAP = {
     {"ODESCENT_PARAMETER_ALPHA", ODESCENT_PARAMETER_ALPHA},
     {"ODESCENT_PARAMETER_GRAPH_ITER_TURN", ODESCENT_PARAMETER_GRAPH_ITER_TURN},
     {"ODESCENT_PARAMETER_NEIGHBOR_SAMPLE_RATE", ODESCENT_PARAMETER_NEIGHBOR_SAMPLE_RATE},
-    {"HGRAPH_EXTRA_INFO_KEY", HGRAPH_EXTRA_INFO_KEY},
+    {"EXTRA_INFO_KEY", EXTRA_INFO_KEY},
     {"IVF_SEARCH_PARAM_FACTOR", IVF_SEARCH_PARAM_FACTOR},
     {"BUCKET_PER_DATA_KEY", BUCKET_PER_DATA_KEY},
     {"IVF_PARTITION_STRATEGY_PARAMS_KEY", IVF_PARTITION_STRATEGY_PARAMS_KEY},
     {"IVF_PARTITION_STRATEGY_TYPE_KEY", IVF_PARTITION_STRATEGY_TYPE_KEY},
     {"IVF_PARTITION_STRATEGY_TYPE_NEAREST", IVF_PARTITION_STRATEGY_TYPE_NEAREST},
     {"IVF_TRAIN_TYPE_KMEANS", IVF_TRAIN_TYPE_KMEANS},
-    {"IVF_THREAD_COUNT_KEY", IVF_THREAD_COUNT_KEY},
+    {"BUILD_THREAD_COUNT_KEY", BUILD_THREAD_COUNT_KEY},
     {"IVF_SEARCH_PARALLELISM", IVF_SEARCH_PARALLELISM},
     {"GRAPH_SUPPORT_REMOVE", GRAPH_SUPPORT_REMOVE},
     {"REMOVE_FLAG_BIT", REMOVE_FLAG_BIT},


### PR DESCRIPTION
closed: #1154 
## Summary by Sourcery

Introduce a new base parameter class for inner indexes, unify common configuration and thread-pool logic across all index types, and add full ExtraInfo support to every index implementation.

New Features:
- Support ExtraInfo lifecycle (initialization, retrieval, update) in all index types via InnerIndexInterface
- Add InnerIndexParameter base class to centralize parsing, serialization, and compatibility checks for common index parameters

Enhancements:
- Refactor index-specific parameter classes (HGraph, IVF, BruteForce, SINDI, SparseIndex, Pyramid) to inherit from InnerIndexParameter and remove duplicated fields
- Unify and rename JSON parameter keys (e.g. use_reorder, build_thread_count, precise_codes, extra_info) and streamline external parameter mapping
- Move thread-pool setup into InnerIndexInterface and eliminate per-index duplication in build pool management
- Simplify JSON templates and remove nested build_params blocks in index configuration