### PR TITLE
refactor(test): reduce full test size

### DIFF
--- a/tests/test_ivf.cpp
+++ b/tests/test_ivf.cpp
@@ -67,7 +67,7 @@ public:
 
     static const std::string name;
 
-    constexpr static uint64_t base_count = 1200;
+    constexpr static uint64_t base_count = 1000;
 
     static const std::vector<std::pair<std::string, float>> all_test_cases;
 };
@@ -104,7 +104,7 @@ IVFTestIndex::GetResource(bool sample) {
         resource->test_cases = IVFTestIndex::all_test_cases;
         resource->metric_types = {"ip", "l2", "cosine"};
         resource->train_types = {"kmeans", "random"};
-        resource->base_count = IVFTestIndex::base_count * 10;
+        resource->base_count = IVFTestIndex::base_count * 3;
     }
     return resource;
 }


### PR DESCRIPTION
- refactor bruteforce test
- reduce ful test size

## Summary by Sourcery

Refactor brute-force and IVF test suites to reduce full test size by introducing a resource-based configuration, parameterized helper functions, and separating PR vs Daily runs with smaller sample sets and reduced dataset counts.

Enhancements:
- Refactor brute-force tests to use a resource struct and parameterized helper functions
- Introduce PR and Daily test cases to split sample and full test runs

Tests:
- Reduce base dataset sizes in brute-force and IVF tests from 3000/1200 to 1000 and scale full runs by 3×
- Consolidate individual brute-force test scenarios (build, add, concurrent add, serialize, clone, calc distance, duplicate build, attribute filter, remove by id) into unified helper functions