### PR TITLE
typo(index): typo error on index's serialize log

### DIFF
--- a/src/algorithm/inner_index_interface.cpp
+++ b/src/algorithm/inner_index_interface.cpp
@@ -213,7 +213,7 @@ InnerIndexInterface::CheckIdExist(int64_t id) const {
 
 void
 InnerIndexInterface::Serialize(std::ostream& out_stream) const {
-    std::string time_record_name = this->GetName() + " Deserialize";
+    std::string time_record_name = this->GetName() + " Serialize";
     SlowTaskTimer t(time_record_name);
 
     if (GetNumElements() == 0) {


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correct the timing log label from "Deserialize" to "Serialize" in the Serialize function