### PR TITLE
feat(SINDI): support get memory usage

### DIFF
--- a/src/algorithm/hgraph.h
+++ b/src/algorithm/hgraph.h
@@ -91,11 +91,6 @@ public:
     void
     GetExtraInfoByIds(const int64_t* ids, int64_t count, char* extra_infos) const override;
 
-    int64_t
-    GetMemoryUsage() const override {
-        return static_cast<int64_t>(this->CalSerializeSize());
-    }
-
     std::string
     GetMemoryUsageDetail() const override;
 

--- a/src/algorithm/inner_index_interface.h
+++ b/src/algorithm/inner_index_interface.h
@@ -173,8 +173,7 @@ public:
 
     [[nodiscard]] virtual int64_t
     GetMemoryUsage() const {
-        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                            "Index doesn't support GetMemoryUsage");
+        return this->CalSerializeSize();
     }
 
     [[nodiscard]] virtual std::string

--- a/src/algorithm/pyramid.cpp
+++ b/src/algorithm/pyramid.cpp
@@ -300,11 +300,6 @@ Pyramid::GetNumElements() const {
     return flatten_interface_ptr_->TotalCount();
 }
 
-int64_t
-Pyramid::GetMemoryUsage() const {
-    return 0;
-}
-
 void
 Pyramid::Serialize(StreamWriter& writer) const {
     // FIXME(wxyu): only for testing, remove before merge into the main branch

--- a/src/algorithm/pyramid.h
+++ b/src/algorithm/pyramid.h
@@ -116,9 +116,6 @@ public:
         return IndexType::PYRAMID;
     }
 
-    int64_t
-    GetMemoryUsage() const override;
-
     std::string
     GetName() const override {
         return INDEX_PYRAMID;

--- a/tests/test_index.cpp
+++ b/tests/test_index.cpp
@@ -1449,6 +1449,19 @@ TestIndex::TestEstimateMemory(const std::string& index_name,
             std::ifstream inf(path, std::ios::binary);
             index1->Deserialize(inf);
             auto real_memory = allocator->GetCurrentMemory();
+            auto get_memory = index1->GetMemoryUsage();
+
+            if (get_memory <= static_cast<uint64_t>(real_memory * 0.8) or
+                get_memory >= static_cast<uint64_t>(real_memory * 1.2)) {
+                WARN(fmt::format("get_memory({}) is not in range [{}, {}]",
+                                 get_memory,
+                                 static_cast<uint64_t>(real_memory * 0.8),
+                                 static_cast<uint64_t>(real_memory * 1.2)));
+            }
+
+            REQUIRE(get_memory >= static_cast<uint64_t>(real_memory * 0.2));
+            REQUIRE(get_memory <= static_cast<uint64_t>(real_memory * 3.2));
+
             if (estimate_memory <= static_cast<uint64_t>(real_memory * 0.8) or
                 estimate_memory >= static_cast<uint64_t>(real_memory * 1.2)) {
                 WARN(fmt::format("estimate_memory({}) is not in range [{}, {}]",


### PR DESCRIPTION
## Summary by Sourcery

Add support for retrieving and validating index memory usage

New Features:
- Expose GetMemoryUsage on InnerIndexInterface to report serialized size

Enhancements:
- Move GetMemoryUsage implementation to the base interface and remove redundant overrides in HGraph and Pyramid

Tests:
- Update TestEstimateMemory to verify GetMemoryUsage against actual allocator memory within tolerance