### PR TITLE
typo(test): replace "[]" with "()" for catch2 test

### DIFF
--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -518,13 +518,13 @@ TestHGraphBuildAndContinueAdd(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("[PR] HGraph Build & ContinueAdd Test", "[ft][hgraph][pr]") {
+TEST_CASE("(PR) HGraph Build & ContinueAdd Test", "[ft][hgraph][pr]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(true);
     TestHGraphBuildAndContinueAdd(test_index, resource);
 }
 
-TEST_CASE("[Daily] HGraph Build & ContinueAdd Test", "[ft][hgraph][daily]") {
+TEST_CASE("(Daily) HGraph Build & ContinueAdd Test", "[ft][hgraph][daily]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(false);
     TestHGraphBuildAndContinueAdd(test_index, resource);
@@ -564,13 +564,13 @@ TestHGraphTrainAndAddTest(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("[PR] HGraph Train & Add Test", "[ft][hgraph][pr]") {
+TEST_CASE("(PR) HGraph Train & Add Test", "[ft][hgraph][pr]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(true);
     TestHGraphTrainAndAddTest(test_index, resource);
 }
 
-TEST_CASE("[Daily] HGraph Train & Add Test", "[ft][hgraph][daily]") {
+TEST_CASE("(Daily) HGraph Train & Add Test", "[ft][hgraph][daily]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(false);
     TestHGraphTrainAndAddTest(test_index, resource);
@@ -654,13 +654,13 @@ TestHGraphBuild(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("[PR] HGraph Build Test", "[ft][hgraph][pr]") {
+TEST_CASE("(PR) HGraph Build Test", "[ft][hgraph][pr]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(true);
     TestHGraphBuild(test_index, resource);
 }
 
-TEST_CASE("[Daily] HGraph Build Test", "[ft][hgraph][daily]") {
+TEST_CASE("(Daily) HGraph Build Test", "[ft][hgraph][daily]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(false);
     TestHGraphBuild(test_index, resource);
@@ -721,13 +721,13 @@ TestHGraphWithAttr(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("[PR] HGraph With Attr", "[ft][hgraph][pr]") {
+TEST_CASE("(PR) HGraph With Attr", "[ft][hgraph][pr]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(true);
     TestHGraphWithAttr(test_index, resource);
 }
 
-TEST_CASE("[Daily] HGraph With Attr", "[ft][hgraph][daily]") {
+TEST_CASE("(Daily) HGraph With Attr", "[ft][hgraph][daily]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(false);
     TestHGraphWithAttr(test_index, resource);
@@ -783,13 +783,13 @@ TestHGraphGetRawVector(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("[PR] HGraph Support Get Raw Vector", "[ft][hgraph][pr]") {
+TEST_CASE("(PR) HGraph Support Get Raw Vector", "[ft][hgraph][pr]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(true);
     TestHGraphGetRawVector(test_index, resource);
 }
 
-TEST_CASE("[Daily] HGraph Support Get Raw Vector", "[ft][hgraph][daily]") {
+TEST_CASE("(Daily) HGraph Support Get Raw Vector", "[ft][hgraph][daily]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(false);
     TestHGraphGetRawVector(test_index, resource);
@@ -841,13 +841,13 @@ TestHGraphODescentBuild(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("[PR] HGraph ODescent Build", "[ft][hgraph][pr]") {
+TEST_CASE("(PR) HGraph ODescent Build", "[ft][hgraph][pr]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(true);
     TestHGraphODescentBuild(test_index, resource);
 }
 
-TEST_CASE("[Daily] HGraph ODescent Build", "[ft][hgraph][daily]") {
+TEST_CASE("(Daily) HGraph ODescent Build", "[ft][hgraph][daily]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(false);
     TestHGraphODescentBuild(test_index, resource);
@@ -889,13 +889,13 @@ TestHGraphRemove(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("[PR] HGraph Remove", "[ft][hgraph][pr]") {
+TEST_CASE("(PR) HGraph Remove", "[ft][hgraph][pr]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(true);
     TestHGraphRemove(test_index, resource);
 }
 
-TEST_CASE("[Daily] HGraph Remove", "[ft][hgraph][daily]") {
+TEST_CASE("(Daily) HGraph Remove", "[ft][hgraph][daily]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(false);
     TestHGraphRemove(test_index, resource);
@@ -937,13 +937,13 @@ TestHGraphCompressedBuild(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("[PR] HGraph Compressed Graph Build", "[ft][hgraph][pr]") {
+TEST_CASE("(PR) HGraph Compressed Graph Build", "[ft][hgraph][pr]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(true);
     TestHGraphCompressedBuild(test_index, resource);
 }
 
-TEST_CASE("[Daily] HGraph Compressed Graph Build", "[ft][hgraph][daily]") {
+TEST_CASE("(Daily) HGraph Compressed Graph Build", "[ft][hgraph][daily]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(false);
     TestHGraphCompressedBuild(test_index, resource);
@@ -986,13 +986,13 @@ TestHGraphMerge(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("[PR] HGraph Merge", "[ft][hgraph][pr]") {
+TEST_CASE("(PR) HGraph Merge", "[ft][hgraph][pr]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(true);
     TestHGraphMerge(test_index, resource);
 }
 
-TEST_CASE("[Daily] HGraph Merge", "[ft][hgraph][daily]") {
+TEST_CASE("(Daily) HGraph Merge", "[ft][hgraph][daily]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(false);
     TestHGraphMerge(test_index, resource);
@@ -1035,13 +1035,13 @@ TestHGraphAdd(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("[PR] HGraph Add", "[ft][hgraph][pr]") {
+TEST_CASE("(PR) HGraph Add", "[ft][hgraph][pr]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(true);
     TestHGraphAdd(test_index, resource);
 }
 
-TEST_CASE("[Daily] HGraph Add", "[ft][hgraph][daily]") {
+TEST_CASE("(Daily) HGraph Add", "[ft][hgraph][daily]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(false);
     TestHGraphAdd(test_index, resource);
@@ -1110,13 +1110,13 @@ TestHGraphDuplicate(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("[PR] HGraph Duplicate", "[ft][hgraph][pr]") {
+TEST_CASE("(PR) HGraph Duplicate", "[ft][hgraph][pr]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(true);
     TestHGraphDuplicate(test_index, resource);
 }
 
-TEST_CASE("[Daily] HGraph Duplicate", "[ft][hgraph][daily]") {
+TEST_CASE("(Daily) HGraph Duplicate", "[ft][hgraph][daily]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(false);
     TestHGraphDuplicate(test_index, resource);
@@ -1155,13 +1155,13 @@ TestHGraphSearchWithDirtyVector(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("[PR] HGraph Search with Dirty Vector", "[ft][hgraph][pr]") {
+TEST_CASE("(PR) HGraph Search with Dirty Vector", "[ft][hgraph][pr]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(true);
     TestHGraphSearchWithDirtyVector(test_index, resource);
 }
 
-TEST_CASE("[Daily] HGraph Search with Dirty Vector", "[ft][hgraph][daily]") {
+TEST_CASE("(Daily) HGraph Search with Dirty Vector", "[ft][hgraph][daily]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(false);
     TestHGraphSearchWithDirtyVector(test_index, resource);
@@ -1234,13 +1234,13 @@ TestHGraphConcurrentAdd(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("[PR] HGraph Concurrent Add", "[ft][hgraph][pr][concurrent]") {
+TEST_CASE("(PR) HGraph Concurrent Add", "[ft][hgraph][pr][concurrent]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(true);
     TestHGraphConcurrentAdd(test_index, resource);
 }
 
-TEST_CASE("[Daily] HGraph Concurrent Add", "[ft][hgraph][daily][concurrent]") {
+TEST_CASE("(Daily) HGraph Concurrent Add", "[ft][hgraph][daily][concurrent]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(false);
     TestHGraphConcurrentAdd(test_index, resource);
@@ -1293,13 +1293,13 @@ TestHGraphSerialize(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("[PR] HGraph Serialize File", "[ft][hgraph][serialization][pr]") {
+TEST_CASE("(PR) HGraph Serialize File", "[ft][hgraph][serialization][pr]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(true);
     TestHGraphSerialize(test_index, resource);
 }
 
-TEST_CASE("[Daily] HGraph Serialize File", "[ft][hgraph][serialization][daily]") {
+TEST_CASE("(Daily) HGraph Serialize File", "[ft][hgraph][serialization][daily]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(false);
     TestHGraphSerialize(test_index, resource);
@@ -1354,13 +1354,13 @@ TestHGraphReaderIO(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("[PR] HGraph Reader IO", "[ft][hgraph][serialization][pr]") {
+TEST_CASE("(PR) HGraph Reader IO", "[ft][hgraph][serialization][pr]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(true);
     TestHGraphReaderIO(test_index, resource);
 }
 
-TEST_CASE("[Daily] HGraph Reader IO", "[ft][hgraph][serialization][daily]") {
+TEST_CASE("(Daily) HGraph Reader IO", "[ft][hgraph][serialization][daily]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(false);
     TestHGraphReaderIO(test_index, resource);
@@ -1407,13 +1407,13 @@ TestHGraphClone(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("[PR] HGraph Clone", "[ft][hgraph][pr]") {
+TEST_CASE("(PR) HGraph Clone", "[ft][hgraph][pr]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(true);
     TestHGraphClone(test_index, resource);
 }
 
-TEST_CASE("[Daily] HGraph Clone", "[ft][hgraph][daily]") {
+TEST_CASE("(Daily) HGraph Clone", "[ft][hgraph][daily]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(false);
     TestHGraphClone(test_index, resource);
@@ -1460,13 +1460,13 @@ TestHGraphExportModel(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("[PR] HGraph Export Model", "[ft][hgraph][pr]") {
+TEST_CASE("(PR) HGraph Export Model", "[ft][hgraph][pr]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(true);
     TestHGraphExportModel(test_index, resource);
 }
 
-TEST_CASE("[Daily] HGraph Export Model", "[ft][hgraph][daily]") {
+TEST_CASE("(Daily) HGraph Export Model", "[ft][hgraph][daily]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(false);
     TestHGraphExportModel(test_index, resource);
@@ -1513,13 +1513,13 @@ TestHGraphRandomAllocator(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("[PR] HGraph Build & ContinueAdd Test With Random Allocator", "[ft][hgraph][pr]") {
+TEST_CASE("(PR) HGraph Build & ContinueAdd Test With Random Allocator", "[ft][hgraph][pr]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(true);
     TestHGraphRandomAllocator(test_index, resource);
 }
 
-TEST_CASE("[Daily] HGraph Build & ContinueAdd Test With Random Allocator", "[ft][hgraph][daily]") {
+TEST_CASE("(Daily) HGraph Build & ContinueAdd Test With Random Allocator", "[ft][hgraph][daily]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(false);
     TestHGraphRandomAllocator(test_index, resource);
@@ -1562,13 +1562,13 @@ TestHGraphDuplicateBuild(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("[PR] HGraph Duplicate Build", "[ft][hgraph][pr]") {
+TEST_CASE("(PR) HGraph Duplicate Build", "[ft][hgraph][pr]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(true);
     TestHGraphDuplicateBuild(test_index, resource);
 }
 
-TEST_CASE("[Daily] HGraph Duplicate Build", "[ft][hgraph][daily]") {
+TEST_CASE("(Daily) HGraph Duplicate Build", "[ft][hgraph][daily]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(false);
     TestHGraphDuplicateBuild(test_index, resource);
@@ -1615,13 +1615,13 @@ TestHGraphEstimateMemory(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("[PR] HGraph Estimate Memory", "[ft][hgraph][pr]") {
+TEST_CASE("(PR) HGraph Estimate Memory", "[ft][hgraph][pr]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(true);
     TestHGraphEstimateMemory(test_index, resource);
 }
 
-TEST_CASE("[Daily] HGraph Estimate Memory", "[ft][hgraph][daily]") {
+TEST_CASE("(Daily) HGraph Estimate Memory", "[ft][hgraph][daily]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(false);
     TestHGraphEstimateMemory(test_index, resource);
@@ -1703,13 +1703,13 @@ TestHGraphIgnoreReorder(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("[PR] HGraph Ignore Reorder", "[ft][hgraph][pr]") {
+TEST_CASE("(PR) HGraph Ignore Reorder", "[ft][hgraph][pr]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(true);
     TestHGraphIgnoreReorder(test_index, resource);
 }
 
-TEST_CASE("[Daily] HGraph Ignore Reorder", "[ft][hgraph][daily]") {
+TEST_CASE("(Daily) HGraph Ignore Reorder", "[ft][hgraph][daily]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(false);
     TestHGraphIgnoreReorder(test_index, resource);
@@ -1767,13 +1767,13 @@ TestHGraphWithExtraInfo(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("[PR] HGraph With Extra Info", "[ft][hgraph][pr]") {
+TEST_CASE("(PR) HGraph With Extra Info", "[ft][hgraph][pr]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(true);
     TestHGraphWithExtraInfo(test_index, resource);
 }
 
-TEST_CASE("[Daily] HGraph With Extra Info", "[ft][hgraph][daily]") {
+TEST_CASE("(Daily) HGraph With Extra Info", "[ft][hgraph][daily]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(false);
     TestHGraphWithExtraInfo(test_index, resource);
@@ -1818,13 +1818,13 @@ TestHGraphSearchOverTime(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("[PR] HGraph Search Over Time", "[ft][hgraph][pr]") {
+TEST_CASE("(PR) HGraph Search Over Time", "[ft][hgraph][pr]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(true);
     TestHGraphSearchOverTime(test_index, resource);
 }
 
-TEST_CASE("[Daily] HGraph Search Over Time", "[ft][hgraph][daily]") {
+TEST_CASE("(Daily) HGraph Search Over Time", "[ft][hgraph][daily]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(false);
     TestHGraphSearchOverTime(test_index, resource);
@@ -1873,13 +1873,13 @@ TestHGraphDiskIOType(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("[PR] HGraph Disk IO Type Index", "[ft][hgraph][serialization][pr]") {
+TEST_CASE("(PR) HGraph Disk IO Type Index", "[ft][hgraph][serialization][pr]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(true);
     TestHGraphDiskIOType(test_index, resource);
 }
 
-TEST_CASE("[Daily]HGraph Disk IO Type Index", "[ft][hgraph][serialization][daily]") {
+TEST_CASE("(Daily) HGraph Disk IO Type Index", "[ft][hgraph][serialization][daily]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(false);
     TestHGraphDiskIOType(test_index, resource);

--- a/tests/test_ivf.cpp
+++ b/tests/test_ivf.cpp
@@ -457,13 +457,13 @@ TestIVFBuildAndContinueAdd(const fixtures::IVFResourcePtr& resource) {
     }
 }
 
-TEST_CASE("[PR] IVF Build & ContinueAdd Test", "[ft][ivf][pr][concurrent]") {
+TEST_CASE("(PR) IVF Build & ContinueAdd Test", "[ft][ivf][pr][concurrent]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(true);
     TestIVFBuildAndContinueAdd(resource);
 }
 
-TEST_CASE("[Daily] IVF Build & ContinueAdd Test", "[ft][ivf][daily][concurrent]") {
+TEST_CASE("(Daily) IVF Build & ContinueAdd Test", "[ft][ivf][daily][concurrent]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(false);
     TestIVFBuildAndContinueAdd(resource);
@@ -520,13 +520,13 @@ TestIVFBuildWithResidual(const fixtures::IVFResourcePtr& resource) {
     }
 }
 
-TEST_CASE("[PR] IVF Build with Residual", "[ft][ivf][pr]") {
+TEST_CASE("(PR) IVF Build with Residual", "[ft][ivf][pr]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(true);
     TestIVFBuildWithResidual(resource);
 }
 
-TEST_CASE("[Daily] IVF Build with Residual", "[ft][ivf][daily]") {
+TEST_CASE("(Daily) IVF Build with Residual", "[ft][ivf][daily]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(false);
     TestIVFBuildWithResidual(resource);
@@ -593,13 +593,13 @@ TestIVFBuild(const fixtures::IVFResourcePtr& resource) {
     }
 }
 
-TEST_CASE("[PR] IVF Build", "[ft][ivf][pr]") {
+TEST_CASE("(PR) IVF Build", "[ft][ivf][pr]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(true);
     TestIVFBuild(resource);
 }
 
-TEST_CASE("[Daily] IVF Build", "[ft][ivf][daily]") {
+TEST_CASE("(Daily) IVF Build", "[ft][ivf][daily]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(false);
     TestIVFBuild(resource);
@@ -662,13 +662,13 @@ TestIVFSearchOvertime(const fixtures::IVFResourcePtr& resource) {
     }
 }
 
-TEST_CASE("[PR] IVF Search Overtime", "[ft][ivf][pr]") {
+TEST_CASE("(PR) IVF Search Overtime", "[ft][ivf][pr]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(true);
     TestIVFSearchOvertime(resource);
 }
 
-TEST_CASE("[Daily] IVF Search Overtime", "[ft][ivf][daily]") {
+TEST_CASE("(Daily) IVF Search Overtime", "[ft][ivf][daily]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(false);
     TestIVFSearchOvertime(resource);
@@ -715,13 +715,13 @@ TestIVFBuildWithLargeK(const fixtures::IVFResourcePtr& resource) {
     }
 }
 
-TEST_CASE("[PR] IVF Build With Large K", "[ft][ivf][pr]") {
+TEST_CASE("(PR) IVF Build With Large K", "[ft][ivf][pr]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(true);
     TestIVFBuildWithLargeK(resource);
 }
 
-TEST_CASE("[Daily] IVF Build With Large K", "[ft][ivf][daily]") {
+TEST_CASE("(Daily) IVF Build With Large K", "[ft][ivf][daily]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(false);
     TestIVFBuildWithLargeK(resource);
@@ -789,13 +789,13 @@ TestIVFWithAttr(const fixtures::IVFResourcePtr& resource) {
     }
 }
 
-TEST_CASE("[PR] IVF Build With Attribute", "[ft][ivf][pr]") {
+TEST_CASE("(PR) IVF Build With Attribute", "[ft][ivf][pr]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(true);
     TestIVFWithAttr(resource);
 }
 
-TEST_CASE("[Daily] IVF Build With Attribute", "[ft][ivf][daily]") {
+TEST_CASE("(Daily) IVF Build With Attribute", "[ft][ivf][daily]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(false);
     TestIVFWithAttr(resource);
@@ -841,13 +841,13 @@ TestIVFExportModel(const fixtures::IVFResourcePtr& resource) {
     }
 }
 
-TEST_CASE("[PR] IVF Export Model", "[ft][ivf][pr]") {
+TEST_CASE("(PR) IVF Export Model", "[ft][ivf][pr]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(true);
     TestIVFExportModel(resource);
 }
 
-TEST_CASE("[Daily] IVF IVF Export Model", "[ft][ivf][daily]") {
+TEST_CASE("(Daily) IVF IVF Export Model", "[ft][ivf][daily]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(false);
     TestIVFExportModel(resource);
@@ -893,13 +893,13 @@ TestIVFAdd(const fixtures::IVFResourcePtr& resource) {
     }
 }
 
-TEST_CASE("[PR] IVF Add", "[ft][ivf][pr]") {
+TEST_CASE("(PR) IVF Add", "[ft][ivf][pr]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(true);
     TestIVFAdd(resource);
 }
 
-TEST_CASE("[Daily] IVF Add", "[ft][ivf][daily]") {
+TEST_CASE("(Daily) IVF Add", "[ft][ivf][daily]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(false);
     TestIVFAdd(resource);
@@ -951,13 +951,13 @@ TestIVFMerge(const fixtures::IVFResourcePtr& resource) {
     }
 }
 
-TEST_CASE("[PR] IVF Merge", "[ft][ivf][pr]") {
+TEST_CASE("(PR) IVF Merge", "[ft][ivf][pr]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(true);
     TestIVFMerge(resource);
 }
 
-TEST_CASE("[Daily] IVF Merge", "[ft][ivf][daily]") {
+TEST_CASE("(Daily) IVF Merge", "[ft][ivf][daily]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(false);
     TestIVFMerge(resource);
@@ -1009,13 +1009,13 @@ TestIVFConcurrentAdd(const fixtures::IVFResourcePtr& resource) {
     }
 }
 
-TEST_CASE("[PR] IVF Concurrent Add", "[ft][ivf][pr]") {
+TEST_CASE("(PR) IVF Concurrent Add", "[ft][ivf][pr]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(true);
     TestIVFConcurrentAdd(resource);
 }
 
-TEST_CASE("[Daily] IVF Concurrent Add", "[ft][ivf][daily]") {
+TEST_CASE("(Daily) IVF Concurrent Add", "[ft][ivf][daily]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(false);
     TestIVFConcurrentAdd(resource);
@@ -1082,13 +1082,13 @@ TestIVFSerialize(const fixtures::IVFResourcePtr& resource) {
     }
 }
 
-TEST_CASE("[PR] IVF Serialize File", "[ft][ivf][serialization][pr]") {
+TEST_CASE("(PR) IVF Serialize File", "[ft][ivf][serialization][pr]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(true);
     TestIVFSerialize(resource);
 }
 
-TEST_CASE("[Daily] IVF Serialize File", "[ft][ivf][serialization][daily]") {
+TEST_CASE("(Daily) IVF Serialize File", "[ft][ivf][serialization][daily]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(false);
     TestIVFSerialize(resource);
@@ -1133,13 +1133,13 @@ TestIVFClone(const fixtures::IVFResourcePtr& resource) {
     }
 }
 
-TEST_CASE("[PR] IVF Clone", "[ft][ivf][pr]") {
+TEST_CASE("(PR) IVF Clone", "[ft][ivf][pr]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(true);
     TestIVFClone(resource);
 }
 
-TEST_CASE("[Daily] IVF Clone", "[ft][ivf][daily]") {
+TEST_CASE("(Daily) IVF Clone", "[ft][ivf][daily]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(false);
     TestIVFClone(resource);
@@ -1187,13 +1187,13 @@ TestIVFRandomAllocator(const fixtures::IVFResourcePtr& resource) {
     }
 }
 
-TEST_CASE("[PR] IVF Build & ContinueAdd Test With Random Allocator", "[ft][ivf][pr]") {
+TEST_CASE("(PR) IVF Build & ContinueAdd Test With Random Allocator", "[ft][ivf][pr]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(true);
     TestIVFRandomAllocator(resource);
 }
 
-TEST_CASE("[Daily] IVF Build & ContinueAdd Test With Random Allocator", "[ft][ivf][daily]") {
+TEST_CASE("(Daily) IVF Build & ContinueAdd Test With Random Allocator", "[ft][ivf][daily]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(false);
     TestIVFRandomAllocator(resource);
@@ -1237,13 +1237,13 @@ TestIVFEstimateMemory(const fixtures::IVFResourcePtr& resource) {
     }
 }
 
-TEST_CASE("[PR] IVF Estimate Memory", "[ft][ivf][pr]") {
+TEST_CASE("(PR) IVF Estimate Memory", "[ft][ivf][pr]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(true);
     TestIVFEstimateMemory(resource);
 }
 
-TEST_CASE("[Daily] IVF Estimate Memory", "[ft][ivf][daily]") {
+TEST_CASE("(Daily) IVF Estimate Memory", "[ft][ivf][daily]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(false);
     TestIVFEstimateMemory(resource);
@@ -1292,13 +1292,13 @@ TestIVFBuildMultiBucketsPerData(const fixtures::IVFResourcePtr& resource) {
     }
 }
 
-TEST_CASE("[PR] IVF Build Multi Buckets Per Data", "[ft][ivf][pr]") {
+TEST_CASE("(PR) IVF Build Multi Buckets Per Data", "[ft][ivf][pr]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(true);
     TestIVFBuildMultiBucketsPerData(resource);
 }
 
-TEST_CASE("[Daily] IVF Build Multi Buckets Per Data", "[ft][ivf][daily]") {
+TEST_CASE("(Daily) IVF Build Multi Buckets Per Data", "[ft][ivf][daily]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(false);
     TestIVFBuildMultiBucketsPerData(resource);
@@ -1344,13 +1344,13 @@ TestIVFGNOIMIBuild(const fixtures::IVFResourcePtr& resource) {
     }
 }
 
-TEST_CASE("[PR] IVF GNO-IMI Build", "[ft][ivf][pr]") {
+TEST_CASE("(PR) IVF GNO-IMI Build", "[ft][ivf][pr]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(true);
     TestIVFGNOIMIBuild(resource);
 }
 
-TEST_CASE("[Daily] IVF GNO-IMI Build", "[ft][ivf][daily]") {
+TEST_CASE("(Daily) IVF GNO-IMI Build", "[ft][ivf][daily]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(false);
     TestIVFGNOIMIBuild(resource);
@@ -1403,13 +1403,13 @@ TestIVFGNOIMIBuildWithResidual(const fixtures::IVFResourcePtr& resource) {
     }
 }
 
-TEST_CASE("[PR] IVF GNO-IMI Build with Residual", "[ft][ivf][pr]") {
+TEST_CASE("(PR) IVF GNO-IMI Build with Residual", "[ft][ivf][pr]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(true);
     TestIVFGNOIMIBuildWithResidual(resource);
 }
 
-TEST_CASE("[Daily] IVF GNO-IMI Build with Residual", "[ft][ivf][daily]") {
+TEST_CASE("(Daily) IVF GNO-IMI Build with Residual", "[ft][ivf][daily]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(false);
     TestIVFGNOIMIBuildWithResidual(resource);


### PR DESCRIPTION
- catch2 use [] to tag test, so we should not use [Daily] as a common string

## Summary by Sourcery

Tests:
- Use parentheses instead of square brackets for test case titles in catch2 TEST_CASE declarations to avoid tag conflicts in hgraph and ivf tests