### PR TITLE
feat(sindi): add parameter check for sindi

### DIFF
--- a/src/algorithm/sindi/sindi.cpp
+++ b/src/algorithm/sindi/sindi.cpp
@@ -46,6 +46,7 @@ SINDI::SINDI(const SINDIParameterPtr& param, const IndexCommonParam& common_para
 std::vector<int64_t>
 SINDI::Add(const DatasetPtr& base) {
     std::scoped_lock wlock(this->global_mutex_);
+    std::vector<int64_t> failed_ids;
 
     auto data_num = base->GetNumElements();
     CHECK_ARGUMENT(data_num > 0, "data_num is zero when add vectors");
@@ -65,6 +66,11 @@ SINDI::Add(const DatasetPtr& base) {
         auto cur_window = cur_element_count_ / window_size_;
         auto window_start_id = cur_window * window_size_;
         const auto& sparse_vector = sparse_vectors[i];
+        if (sparse_vectors->len_ <= 0) {
+            failed_ids.push_back(ids[i]);
+            logger::warn("query.len_ ({}) is invalid for id ({})", sparse_vectors->len_, ids[i]);
+            continue;
+        }
 
         label_table_->Insert(cur_element_count_, ids[i]);  // todo(zxy): check id exists
         uint32_t inner_id = cur_element_count_ - window_start_id;
@@ -77,7 +83,7 @@ SINDI::Add(const DatasetPtr& base) {
         rerank_flat_index_->Add(base);
     }
 
-    return {};
+    return failed_ids;
 }
 
 std::vector<int64_t>
@@ -98,15 +104,19 @@ SINDI::KnnSearch(const DatasetPtr& query,
     const auto* sparse_vectors = query->GetSparseVectors();
     CHECK_ARGUMENT(query->GetNumElements() == 1, "num of query should be 1");
     auto sparse_query = sparse_vectors[0];
+    CHECK_ARGUMENT(sparse_vectors->len_ > 0,
+                   fmt::format("query.len_ ({}) is invalid", sparse_vectors->len_));
 
     // search parameter
     SINDISearchParameter search_param;
     search_param.FromJson(JsonType::parse(parameters));
+    CHECK_ARGUMENT(search_param.n_candidate <= AMPLIFICATION_FACTOR * k,
+                   fmt::format("n_candidate ({}) should be less than {} * k ({})",
+                               search_param.n_candidate,
+                               AMPLIFICATION_FACTOR,
+                               k));
     InnerSearchParam inner_param;
-    inner_param.ef = search_param.n_candidate;
-    if (search_param.n_candidate == DEFAULT_N_CANDIDATE or search_param.n_candidate <= k) {
-        inner_param.ef = k;
-    }
+    inner_param.ef = std::max(static_cast<int64_t>(search_param.n_candidate), k);
     inner_param.topk = k;
 
     FilterPtr ft = nullptr;
@@ -231,6 +241,8 @@ SINDI::RangeSearch(const DatasetPtr& query,
     const auto* sparse_vectors = query->GetSparseVectors();
     CHECK_ARGUMENT(query->GetNumElements() == 1, "num of query should be 1");
     auto sparse_query = sparse_vectors[0];
+    CHECK_ARGUMENT(sparse_vectors->len_ > 0,
+                   fmt::format("query.len_ ({}) is invalid", sparse_vectors->len_));
 
     // search parameter
     SINDISearchParameter search_param;

--- a/src/algorithm/sindi/sindi.cpp
+++ b/src/algorithm/sindi/sindi.cpp
@@ -68,7 +68,8 @@ SINDI::Add(const DatasetPtr& base) {
         const auto& sparse_vector = sparse_vectors[i];
         if (sparse_vectors->len_ <= 0) {
             failed_ids.push_back(ids[i]);
-            logger::warn("query.len_ ({}) is invalid for id ({})", sparse_vectors->len_, ids[i]);
+            logger::warn(
+                "sparse_vectors.len_ ({}) is invalid for id ({})", sparse_vectors->len_, ids[i]);
             continue;
         }
 
@@ -105,7 +106,7 @@ SINDI::KnnSearch(const DatasetPtr& query,
     CHECK_ARGUMENT(query->GetNumElements() == 1, "num of query should be 1");
     auto sparse_query = sparse_vectors[0];
     CHECK_ARGUMENT(sparse_vectors->len_ > 0,
-                   fmt::format("query.len_ ({}) is invalid", sparse_vectors->len_));
+                   fmt::format("sparse_vectors.len_ ({}) is invalid", sparse_vectors->len_));
 
     // search parameter
     SINDISearchParameter search_param;

--- a/src/algorithm/sindi/sindi_parameter.cpp
+++ b/src/algorithm/sindi/sindi_parameter.cpp
@@ -23,7 +23,7 @@ void
 SINDIParameter::FromJson(const JsonType& json) {
     if (json.contains(SPARSE_DOC_PRUNE_RATIO)) {
         doc_prune_ratio = json[SPARSE_DOC_PRUNE_RATIO];
-        CHECK_ARGUMENT((doc_prune_ratio >= 0.0F and doc_prune_ratio <= 0.5F),
+        CHECK_ARGUMENT((0.0F <= doc_prune_ratio and doc_prune_ratio <= 0.5F),
                        fmt::format("doc_prune_ratio must in [0, 0.5], got {}", doc_prune_ratio));
     } else {
         doc_prune_ratio = DEFAULT_DOC_PRUNE_RATIO;
@@ -38,7 +38,7 @@ SINDIParameter::FromJson(const JsonType& json) {
     if (json.contains(SPARSE_WINDOW_SIZE)) {
         window_size = json[SPARSE_WINDOW_SIZE];
         CHECK_ARGUMENT(
-            (window_size >= 10'000 and window_size <= 1'000'000),
+            (10'000 <= window_size and window_size <= 1'000'000),
             fmt::format("window_size must in [10000, 1000000], but now is {}", window_size));
     } else {
         window_size = DEFAULT_WINDOW_SIZE;
@@ -65,7 +65,7 @@ SINDISearchParameter::FromJson(const JsonType& json) {
                    fmt::format("parameters must contains {}", INDEX_SINDI));
     if (json[INDEX_SINDI].contains(SPARSE_TERM_PRUNE_RATIO)) {
         term_prune_ratio = json[INDEX_SINDI][SPARSE_TERM_PRUNE_RATIO];
-        CHECK_ARGUMENT((term_prune_ratio >= 0.0F and term_prune_ratio <= 0.5F),
+        CHECK_ARGUMENT((0.0F <= term_prune_ratio and term_prune_ratio <= 0.5F),
                        fmt::format("term_prune_ratio must in [0, 0.5], got {}", term_prune_ratio));
     } else {
         term_prune_ratio = DEFAULT_TERM_PRUNE_RATIO;
@@ -74,7 +74,7 @@ SINDISearchParameter::FromJson(const JsonType& json) {
     if (json[INDEX_SINDI].contains(SPARSE_QUERY_PRUNE_RATIO)) {
         query_prune_ratio = json[INDEX_SINDI][SPARSE_QUERY_PRUNE_RATIO];
         CHECK_ARGUMENT(
-            (query_prune_ratio >= 0.0F and query_prune_ratio <= 0.5F),
+            (0.0F <= query_prune_ratio and query_prune_ratio <= 0.5F),
             fmt::format("query_prune_ratio must in [0, 0.5], got {}", query_prune_ratio));
     } else {
         query_prune_ratio = DEFAULT_QUERY_PRUNE_RATIO;

--- a/src/algorithm/sindi/sindi_parameter.cpp
+++ b/src/algorithm/sindi/sindi_parameter.cpp
@@ -23,6 +23,8 @@ void
 SINDIParameter::FromJson(const JsonType& json) {
     if (json.contains(SPARSE_DOC_PRUNE_RATIO)) {
         doc_prune_ratio = json[SPARSE_DOC_PRUNE_RATIO];
+        CHECK_ARGUMENT(doc_prune_ratio >= 0.0F and doc_prune_ratio <= 0.5F,
+                       fmt::format("doc_prune_ratio must in [0, 0.5], got {}", doc_prune_ratio));
     } else {
         doc_prune_ratio = DEFAULT_DOC_PRUNE_RATIO;
     }
@@ -35,9 +37,13 @@ SINDIParameter::FromJson(const JsonType& json) {
 
     if (json.contains(SPARSE_WINDOW_SIZE)) {
         window_size = json[SPARSE_WINDOW_SIZE];
+        CHECK_ARGUMENT(
+            (window_size >= 10'000 and window_size <= 1'000'000),
+            fmt::format("window_size must in [10000, 1000000], but now is {}", window_size));
     } else {
         window_size = DEFAULT_WINDOW_SIZE;
     }
+
     if (json.contains(SPARSE_DESERIALIZE_WITHOUT_FOOTER)) {
         deserialize_without_footer = json[SPARSE_DESERIALIZE_WITHOUT_FOOTER];
     }
@@ -59,12 +65,17 @@ SINDISearchParameter::FromJson(const JsonType& json) {
                    fmt::format("parameters must contains {}", INDEX_SINDI));
     if (json[INDEX_SINDI].contains(SPARSE_TERM_PRUNE_RATIO)) {
         term_prune_ratio = json[INDEX_SINDI][SPARSE_TERM_PRUNE_RATIO];
+        CHECK_ARGUMENT(term_prune_ratio >= 0.0F and term_prune_ratio <= 0.5F,
+                       fmt::format("term_prune_ratio must in [0, 0.5], got {}", term_prune_ratio));
     } else {
         term_prune_ratio = DEFAULT_TERM_PRUNE_RATIO;
     }
 
     if (json[INDEX_SINDI].contains(SPARSE_QUERY_PRUNE_RATIO)) {
         query_prune_ratio = json[INDEX_SINDI][SPARSE_QUERY_PRUNE_RATIO];
+        CHECK_ARGUMENT(
+            query_prune_ratio >= 0.0F and query_prune_ratio <= 0.5F,
+            fmt::format("query_prune_ratio must in [0, 0.5], got {}", query_prune_ratio));
     } else {
         query_prune_ratio = DEFAULT_QUERY_PRUNE_RATIO;
     }

--- a/src/algorithm/sindi/sindi_parameter.cpp
+++ b/src/algorithm/sindi/sindi_parameter.cpp
@@ -23,7 +23,7 @@ void
 SINDIParameter::FromJson(const JsonType& json) {
     if (json.contains(SPARSE_DOC_PRUNE_RATIO)) {
         doc_prune_ratio = json[SPARSE_DOC_PRUNE_RATIO];
-        CHECK_ARGUMENT(doc_prune_ratio >= 0.0F and doc_prune_ratio <= 0.5F,
+        CHECK_ARGUMENT((doc_prune_ratio >= 0.0F and doc_prune_ratio <= 0.5F),
                        fmt::format("doc_prune_ratio must in [0, 0.5], got {}", doc_prune_ratio));
     } else {
         doc_prune_ratio = DEFAULT_DOC_PRUNE_RATIO;
@@ -65,7 +65,7 @@ SINDISearchParameter::FromJson(const JsonType& json) {
                    fmt::format("parameters must contains {}", INDEX_SINDI));
     if (json[INDEX_SINDI].contains(SPARSE_TERM_PRUNE_RATIO)) {
         term_prune_ratio = json[INDEX_SINDI][SPARSE_TERM_PRUNE_RATIO];
-        CHECK_ARGUMENT(term_prune_ratio >= 0.0F and term_prune_ratio <= 0.5F,
+        CHECK_ARGUMENT((term_prune_ratio >= 0.0F and term_prune_ratio <= 0.5F),
                        fmt::format("term_prune_ratio must in [0, 0.5], got {}", term_prune_ratio));
     } else {
         term_prune_ratio = DEFAULT_TERM_PRUNE_RATIO;
@@ -74,7 +74,7 @@ SINDISearchParameter::FromJson(const JsonType& json) {
     if (json[INDEX_SINDI].contains(SPARSE_QUERY_PRUNE_RATIO)) {
         query_prune_ratio = json[INDEX_SINDI][SPARSE_QUERY_PRUNE_RATIO];
         CHECK_ARGUMENT(
-            query_prune_ratio >= 0.0F and query_prune_ratio <= 0.5F,
+            (query_prune_ratio >= 0.0F and query_prune_ratio <= 0.5F),
             fmt::format("query_prune_ratio must in [0, 0.5], got {}", query_prune_ratio));
     } else {
         query_prune_ratio = DEFAULT_QUERY_PRUNE_RATIO;

--- a/src/algorithm/sindi/sindi_parameter_test.cpp
+++ b/src/algorithm/sindi/sindi_parameter_test.cpp
@@ -62,7 +62,7 @@ TEST_CASE("SINDI Index Parameters Test", "[ut][SINDIParameter]") {
     auto param = std::make_shared<vsag::SINDIParameter>();
     param->FromJson(param_json);
     REQUIRE(param->use_reorder == true);
-    REQUIRE(std::abs(param->doc_prune_ratio - 0.8) < 1e-3);
+    REQUIRE(std::abs(param->doc_prune_ratio - 0.1F) < 1e-3);
     REQUIRE(param->window_size == 66666);
 
     vsag::ParameterTest::TestToJson(param);

--- a/src/algorithm/sindi/sindi_parameter_test.cpp
+++ b/src/algorithm/sindi/sindi_parameter_test.cpp
@@ -42,7 +42,7 @@ using namespace vsag;
 
 struct SINDIDefaultParam {
     bool use_reorder = true;
-    float doc_prune_ratio = 0.8F;
+    float doc_prune_ratio = 0.1F;
     int window_size = 66666;
 };
 
@@ -69,9 +69,9 @@ TEST_CASE("SINDI Index Parameters Test", "[ut][SINDIParameter]") {
 
     auto search_param_str = R"(
         "sindi": {
-            "query_prune_ratio": 0.9,
+            "query_prune_ratio": 0.2,
             "n_candidate": 20,
-            "term_prune_ratio": 1
+            "term_prune_ratio": 0.1
         }
     )";
     auto search_param = std::make_shared<vsag::SINDIParameter>();
@@ -81,6 +81,6 @@ TEST_CASE("SINDI Index Parameters Test", "[ut][SINDIParameter]") {
 
 TEST_CASE("SINDI Index Parameters Compatibility Test", "[ut][SINDIParameter]") {
     TEST_COMPATIBILITY_CASE("use_reorder compatibility", use_reorder, true, false, false);
-    TEST_COMPATIBILITY_CASE("doc_prune_ratio compatibility", doc_prune_ratio, 0.8F, 0.9F, false);
+    TEST_COMPATIBILITY_CASE("doc_prune_ratio compatibility", doc_prune_ratio, 0.2F, 0.3F, false);
     TEST_COMPATIBILITY_CASE("window_size compatibility", window_size, 66666, 77777, false);
 }

--- a/src/algorithm/sindi/sindi_test.cpp
+++ b/src/algorithm/sindi/sindi_test.cpp
@@ -63,7 +63,7 @@ TEST_CASE("SINDI Basic Test", "[ut][SINDI]") {
         "use_reorder": {},
         "doc_prune_ratio": 0.0,
         "term_prune_ratio": 0.0,
-        "window_size": 1000
+        "window_size": 10000
     }})";
 
     vsag::JsonType param_json = vsag::JsonType::parse(fmt::format(param_str, use_reorder));

--- a/tests/test_index.h
+++ b/tests/test_index.h
@@ -53,10 +53,7 @@ public:
                 bool expect_success = true) {
         auto new_index = vsag::Factory::CreateIndex(name, build_param);
         REQUIRE(new_index.has_value() == expect_success);
-        if (expect_success) {
-            return new_index.value();
-        }
-        return nullptr;
+        return new_index.value();
     }
 
     static void

--- a/tests/test_index.h
+++ b/tests/test_index.h
@@ -53,7 +53,10 @@ public:
                 bool expect_success = true) {
         auto new_index = vsag::Factory::CreateIndex(name, build_param);
         REQUIRE(new_index.has_value() == expect_success);
-        return new_index.value();
+        if (expect_success) {
+            return new_index.value();
+        }
+        return nullptr;
     }
 
     static void

--- a/tests/test_sindi.cpp
+++ b/tests/test_sindi.cpp
@@ -24,7 +24,7 @@ namespace fixtures {
 struct SINDIParam {
     bool use_reorder = true;
     float doc_prune_ratio = 0.0;
-    int window_size = 100;
+    int window_size = 10000;
     bool deserialize_without_footer = false;
 };
 
@@ -67,6 +67,70 @@ public:
 TestDatasetPool SINDITestIndex::pool{};
 
 }  // namespace fixtures
+
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex,
+                             "Invalid Build and Search Parameter",
+                             "[ft][sindi]") {
+    SECTION("invalid doc_prune_ratio") {
+        fixtures::SINDIParam param;
+        param.doc_prune_ratio = 0.6;
+        TestFactory("sindi", fixtures::SINDITestIndex::GenerateBuildParameter(param), false);
+        param.doc_prune_ratio = -0.1;
+        TestFactory("sindi", fixtures::SINDITestIndex::GenerateBuildParameter(param), false);
+    }
+
+    SECTION("invalid window_size") {
+        fixtures::SINDIParam param;
+        param.window_size = 5000;
+        TestFactory("sindi", fixtures::SINDITestIndex::GenerateBuildParameter(param), false);
+        param.window_size = 1100000;
+        TestFactory("sindi", fixtures::SINDITestIndex::GenerateBuildParameter(param), false);
+    }
+    fixtures::SINDIParam param;
+    param.window_size = 10000;
+    auto build_param = fixtures::SINDITestIndex::GenerateBuildParameter(param);
+    auto index = TestFactory("sindi", build_param, true);
+    auto dataset = pool.GetSparseDatasetAndCreate(base_count, 128, 0.8);
+    REQUIRE(index->GetIndexType() == vsag::IndexType::SINDI);
+    TestBuildIndex(index, dataset, true);
+    {
+        auto invalid_search_param = R"({
+            "sindi": {
+                "n_candidate": -1,
+                "query_prune_ratio": 0.0,
+                "term_prune_ratio": 0.0
+            }
+        })";
+        TestKnnSearch(index, dataset, invalid_search_param, 0.99, false);
+        invalid_search_param = R"({
+            "sindi":{
+                "n_candidate": 10,
+                "query_prune_ratio": 1.2,
+                "term_prune_ratio": 0.0
+            }
+        })";
+        TestKnnSearch(index, dataset, invalid_search_param, 0.99, false);
+        invalid_search_param = R"({
+            "sindi":{
+                "n_candidate": 10,
+                "query_prune_ratio": 0.0,
+                "term_prune_ratio": -0.1
+            }
+        })";
+        TestKnnSearch(index, dataset, invalid_search_param, 0.99, false);
+    }
+    vsag::SparseVector sparse_vector;
+    int64_t id = 7777;
+    sparse_vector.len_ = 0;
+    auto data = vsag::Dataset::Make();
+    data->NumElements(1)->Owner(false)->SparseVectors(&sparse_vector)->Ids(&id);
+    auto insert_result = index->Add(data);
+    REQUIRE(insert_result.has_value());
+    auto failed_ids = insert_result.value();
+    REQUIRE(failed_ids[0] == id);
+    auto search_result = index->KnnSearch(data, 1, search_param);
+    REQUIRE_FALSE(search_result.has_value());
+}
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex, "SINDI Build and Search", "[ft][sindi]") {
     fixtures::SINDIParam param;

--- a/tests/test_sindi.cpp
+++ b/tests/test_sindi.cpp
@@ -74,17 +74,21 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex,
     SECTION("invalid doc_prune_ratio") {
         fixtures::SINDIParam param;
         param.doc_prune_ratio = 0.6;
-        TestFactory("sindi", fixtures::SINDITestIndex::GenerateBuildParameter(param), false);
+        REQUIRE_THROWS(
+            TestFactory("sindi", fixtures::SINDITestIndex::GenerateBuildParameter(param), false));
         param.doc_prune_ratio = -0.1;
-        TestFactory("sindi", fixtures::SINDITestIndex::GenerateBuildParameter(param), false);
+        REQUIRE_THROWS(
+            TestFactory("sindi", fixtures::SINDITestIndex::GenerateBuildParameter(param), false));
     }
 
     SECTION("invalid window_size") {
         fixtures::SINDIParam param;
         param.window_size = 5000;
-        TestFactory("sindi", fixtures::SINDITestIndex::GenerateBuildParameter(param), false);
+        REQUIRE_THROWS(
+            TestFactory("sindi", fixtures::SINDITestIndex::GenerateBuildParameter(param), false));
         param.window_size = 1100000;
-        TestFactory("sindi", fixtures::SINDITestIndex::GenerateBuildParameter(param), false);
+        REQUIRE_THROWS(
+            TestFactory("sindi", fixtures::SINDITestIndex::GenerateBuildParameter(param), false));
     }
     fixtures::SINDIParam param;
     param.window_size = 10000;


### PR DESCRIPTION
## Summary by Sourcery

Enforce validation on SINDI index build and search parameters, handle invalid inputs gracefully, and expand tests accordingly

New Features:
- Add runtime checks for doc_prune_ratio and window_size bounds in SINDIParameter
- Add runtime checks for term_prune_ratio, query_prune_ratio, and n_candidate bounds in SINDISearchParameter and KnnSearch
- Return failed IDs for zero‐length vectors in SINDI::Add instead of silently ignoring them

Bug Fixes:
- Fix inner search ef selection logic to ensure ef is at least k

Enhancements:
- Raise default window_size from 100 to 10000
- Modify TestFactory to return nullptr on expected failures

Tests:
- Add tests for invalid build and search parameters and zero‐length vector insertion scenario