### PR TITLE
feat(sindi): support exclude the footer during deserialization (cp 0.16)

### DIFF
--- a/src/algorithm/sindi/sindi.h
+++ b/src/algorithm/sindi/sindi.h
@@ -106,6 +106,7 @@ private:
     float doc_retain_ratio_{0};
 
     std::shared_ptr<SparseIndex> rerank_flat_index_{nullptr};
+    bool deserialize_without_footer_{false};
 };
 
 }  // namespace vsag

--- a/src/algorithm/sindi/sindi_parameter.cpp
+++ b/src/algorithm/sindi/sindi_parameter.cpp
@@ -38,6 +38,9 @@ SINDIParameter::FromJson(const JsonType& json) {
     } else {
         window_size = DEFAULT_WINDOW_SIZE;
     }
+    if (json.contains(SPARSE_DESERIALIZE_WITHOUT_FOOTER)) {
+        deserialize_without_footer = json[SPARSE_DESERIALIZE_WITHOUT_FOOTER];
+    }
 }
 
 JsonType

--- a/src/algorithm/sindi/sindi_parameter.h
+++ b/src/algorithm/sindi/sindi_parameter.h
@@ -43,6 +43,9 @@ public:
     bool use_reorder{false};
 
     float doc_prune_ratio{0};
+
+    // temporal parameter
+    bool deserialize_without_footer{false};
 };
 
 using SINDIParameterPtr = std::shared_ptr<SINDIParameter>;

--- a/src/inner_string_params.h
+++ b/src/inner_string_params.h
@@ -82,6 +82,7 @@ const char* const SPARSE_TERM_PRUNE_RATIO = "term_prune_ratio";
 const char* const SPARSE_WINDOW_SIZE = "window_size";
 const char* const SPARSE_USE_REORDER = "use_reorder";
 const char* const SPARSE_N_CANDIDATE = "n_candidate";
+const char* const SPARSE_DESERIALIZE_WITHOUT_FOOTER = "deserialize_without_footer";
 
 // graph param value
 const char* const GRAPH_PARAM_MAX_DEGREE = "max_degree";


### PR DESCRIPTION
link to: #1122

## Summary by Sourcery

Add 'deserialize_without_footer' option to SINDI to allow skipping footer parsing on deserialization and update tests to cover both modes.

New Features:
- Introduce a 'deserialize_without_footer' build parameter to optionally bypass footer parsing during deserialization.

Enhancements:
- Extend SINDIParameter and SINDI classes to handle the new parameter and conditionally skip footer compatibility checks.
- Add SPARSE_DESERIALIZE_WITHOUT_FOOTER constant to inner string parameters.
- Refactor SINDI tests with a SINDIParam struct and GenerateBuildParameter to dynamically configure and test both footer exclusion scenarios.