### PR TITLE
fix(deserialize): fix core when deserializing empty index

### DIFF
--- a/src/algorithm/inner_index_interface.cpp
+++ b/src/algorithm/inner_index_interface.cpp
@@ -182,9 +182,25 @@ InnerIndexInterface::Deserialize(const BinarySet& binary_set) {
 void
 InnerIndexInterface::Deserialize(const ReaderSet& reader_set) {
     CHECK_SELF_EMPTY;
-
     std::string time_record_name = this->GetName() + " Deserialize";
     SlowTaskTimer t(time_record_name);
+    if (reader_set.Contains(SERIAL_META_KEY)) {
+        logger::debug("parse with new version format");
+        const auto& meta_reader = reader_set.Get(SERIAL_META_KEY);
+        uint64_t size = meta_reader->Size();
+        Binary binary{.data = std::shared_ptr<int8_t[]>(new int8_t[size]), .size = size};
+        meta_reader->Read(0, size, binary.data.get());
+        auto metadata = std::make_shared<Metadata>(binary);
+        if (metadata->EmptyIndex()) {
+            return;
+        }
+    } else {
+        logger::debug("parse with v0.14 version format");
+        // check if binary set is an empty index
+        if (reader_set.Contains(BLANK_INDEX)) {
+            return;
+        }
+    }
 
     try {
         auto index_reader = reader_set.Get(this->GetName());
@@ -242,6 +258,14 @@ InnerIndexInterface::Deserialize(std::istream& in_stream) {
     SlowTaskTimer t(time_record_name);
     try {
         IOStreamReader reader(in_stream);
+
+        auto footer = Footer::Parse(reader);
+        if (footer != nullptr) {
+            auto metadata = footer->GetMetadata();
+            if (metadata->EmptyIndex()) {
+                return;
+            }
+        }
         this->Deserialize(reader);
         return;
     } catch (const std::bad_alloc& e) {

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -611,6 +611,12 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HGraphTestIndex,
         dim, base_count, metric_type, false, 0.8, build_param.extra_info_size);
     TestKnnSearchExFilter(ex_index, ex_dataset, ex_search_param, recall, false);
     TestKnnSearchIter(ex_index, ex_dataset, ex_search_param, recall, false, true);
+    auto index2 = TestIndex::TestFactory(name, param, true);
+    TestIndex::TestSerializeFile(index, index2, dataset, search_param, true);
+    index2 = TestIndex::TestFactory(name, param, true);
+    TestIndex::TestSerializeBinarySet(index, index2, dataset, search_param, true);
+    index2 = TestIndex::TestFactory(name, param, true);
+    TestIndex::TestSerializeReaderSet(index, index2, dataset, search_param, name, true);
     vsag::Options::Instance().set_block_size_limit(origin_size);
 }
 static void

--- a/tests/test_index.cpp
+++ b/tests/test_index.cpp
@@ -920,6 +920,9 @@ TestIndex::TestSerializeFile(const IndexPtr& index_from,
     auto deserialize_index = index_to->Deserialize(infile);
     REQUIRE(deserialize_index.has_value() == expected_success);
     infile.close();
+    if (index_to->GetNumElements() == 0) {
+        return;
+    }
 
     const auto& queries = dataset->query_;
     auto query_count = queries->GetNumElements();
@@ -1009,6 +1012,9 @@ TestIndex::TestSerializeBinarySet(const IndexPtr& index_from,
 
     auto deserialize_index = index_to->Deserialize(serialize_binary.value());
     REQUIRE(deserialize_index.has_value() == expected_success);
+    if (index_to->GetNumElements() == 0) {
+        return;
+    }
 
     const auto& queries = dataset->query_;
     auto query_count = queries->GetNumElements();
@@ -1053,6 +1059,9 @@ TestIndex::TestSerializeReaderSet(const IndexPtr& index_from,
     }
     auto deserialize_index = index_to->Deserialize(rs);
     REQUIRE(deserialize_index.has_value() == expected_success);
+    if (index_to->GetNumElements() == 0) {
+        return;
+    }
 
     const auto& queries = dataset->query_;
     auto query_count = queries->GetNumElements();


### PR DESCRIPTION
close #1149

## Summary by Sourcery

Add early empty-index detection to deserialization routines and update tests to handle and cover empty indices

Bug Fixes:
- Short-circuit Deserialize(reader_set) when metadata or legacy markers indicate an empty index
- Short-circuit Deserialize(istream) when the footer metadata marks an empty index

Tests:
- Skip further validation in TestSerialize* helpers when the deserialized index has zero elements
- Add file, BinarySet, and ReaderSet serialization tests for HGraph indexes