### PR TITLE
feat(SINDI): support get memory usage

### DIFF
--- a/src/algorithm/hgraph.h
+++ b/src/algorithm/hgraph.h
@@ -138,11 +138,6 @@ public:
     uint64_t
     EstimateMemory(uint64_t num_elements) const override;
 
-    int64_t
-    GetMemoryUsage() const override {
-        return static_cast<int64_t>(this->CalSerializeSize());
-    }
-
     std::string
     GetMemoryUsageDetail() const override;
 

--- a/src/algorithm/inner_index_interface.h
+++ b/src/algorithm/inner_index_interface.h
@@ -288,8 +288,7 @@ public:
 
     [[nodiscard]] virtual int64_t
     GetMemoryUsage() const {
-        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                            "Index doesn't support GetMemoryUsage");
+        return static_cast<int64_t>(this->CalSerializeSize());
     }
 
     [[nodiscard]] virtual std::string

--- a/src/algorithm/pyramid.cpp
+++ b/src/algorithm/pyramid.cpp
@@ -300,11 +300,6 @@ Pyramid::GetNumElements() const {
     return flatten_interface_ptr_->TotalCount();
 }
 
-int64_t
-Pyramid::GetMemoryUsage() const {
-    return 0;
-}
-
 void
 Pyramid::Serialize(StreamWriter& writer) const {
     // FIXME(wxyu): only for testing, remove before merge into the main branch

--- a/src/algorithm/pyramid.h
+++ b/src/algorithm/pyramid.h
@@ -139,9 +139,6 @@ public:
     int64_t
     GetNumElements() const override;
 
-    int64_t
-    GetMemoryUsage() const override;
-
     void
     InitFeatures() override;
 

--- a/tests/test_index.cpp
+++ b/tests/test_index.cpp
@@ -1425,6 +1425,19 @@ TestIndex::TestEstimateMemory(const std::string& index_name,
 
             REQUIRE(estimate_memory >= static_cast<uint64_t>(real_memory * 0.2));
             REQUIRE(estimate_memory <= static_cast<uint64_t>(real_memory * 3.2));
+
+            auto get_memory = index1->GetMemoryUsage();
+            if (get_memory <= static_cast<uint64_t>(real_memory * 0.8) or
+                get_memory >= static_cast<uint64_t>(real_memory * 1.2)) {
+                WARN(fmt::format("get_memory({}) is not in range [{}, {}]",
+                                 get_memory,
+                                 static_cast<uint64_t>(real_memory * 0.8),
+                                 static_cast<uint64_t>(real_memory * 1.2)));
+            }
+
+            REQUIRE(get_memory >= static_cast<uint64_t>(real_memory * 0.2));
+            REQUIRE(get_memory <= static_cast<uint64_t>(real_memory * 3.2));
+
             inf.close();
         }
     }


### PR DESCRIPTION
## Summary by Sourcery

Provide a unified GetMemoryUsage method for all indices by defaulting it to the serialized size, remove redundant per-index overrides, and add tests to verify its output stays within expected bounds.

New Features:
- Expose GetMemoryUsage for all index types via default interface implementation

Enhancements:
- Move GetMemoryUsage logic into InnerIndexInterface to return CalSerializeSize instead of throwing
- Remove manual GetMemoryUsage overrides in HGraph and Pyramid

Tests:
- Add tests to check GetMemoryUsage falls within acceptable memory estimation ranges