### PR TITLE
fix(index): add check for empty input in index

### DIFF
--- a/src/index/index_impl.h
+++ b/src/index/index_impl.h
@@ -59,10 +59,16 @@ public:
                                     "immutable index no support " operation_str)); \
     }
 
+#define CHECK_NONEMPTY_DATASET(dataset)                                               \
+    if ((dataset)->GetNumElements() == 0) {                                           \
+        LOG_ERROR_AND_RETURNS(ErrorType::INVALID_ARGUMENT, "input dataset is empty"); \
+    }
+
 public:
     tl::expected<std::vector<int64_t>, Error>
     Add(const DatasetPtr& base) override {
         CHECK_IMMUTABLE_INDEX("add");
+        CHECK_NONEMPTY_DATASET(base);
         SAFE_CALL(return this->inner_index_->Add(base));
     }
 
@@ -74,6 +80,7 @@ public:
     tl::expected<std::vector<int64_t>, Error>
     Build(const DatasetPtr& base) override {
         CHECK_IMMUTABLE_INDEX("build");
+        CHECK_NONEMPTY_DATASET(base);
         SAFE_CALL(return this->inner_index_->Build(base));
     }
 
@@ -119,6 +126,7 @@ public:
     tl::expected<Checkpoint, Error>
     ContinueBuild(const DatasetPtr& base, const BinarySet& binary_set) override {
         CHECK_IMMUTABLE_INDEX("continue build");
+        CHECK_NONEMPTY_DATASET(base);
         SAFE_CALL(return this->inner_index_->ContinueBuild(base, binary_set));
     }
 
@@ -231,6 +239,7 @@ public:
               int64_t k,
               const std::string& parameters,
               BitsetPtr invalid = nullptr) const override {
+        CHECK_NONEMPTY_DATASET(query);
         CHECK_AND_RETURN_EMPTY_DATASET;
         SAFE_CALL(return this->inner_index_->KnnSearch(query, k, parameters, invalid));
     }
@@ -240,6 +249,7 @@ public:
               int64_t k,
               const std::string& parameters,
               const std::function<bool(int64_t)>& filter) const override {
+        CHECK_NONEMPTY_DATASET(query);
         CHECK_AND_RETURN_EMPTY_DATASET;
         SAFE_CALL(return this->inner_index_->KnnSearch(query, k, parameters, filter));
     }
@@ -249,12 +259,14 @@ public:
               int64_t k,
               const std::string& parameters,
               const FilterPtr& filter) const override {
+        CHECK_NONEMPTY_DATASET(query);
         CHECK_AND_RETURN_EMPTY_DATASET;
         SAFE_CALL(return this->inner_index_->KnnSearch(query, k, parameters, filter));
     }
 
     tl::expected<DatasetPtr, Error>
     KnnSearch(const DatasetPtr& query, int64_t k, SearchParam& search_param) const override {
+        CHECK_NONEMPTY_DATASET(query);
         CHECK_AND_RETURN_EMPTY_DATASET;
         if (search_param.is_iter_filter) {
             SAFE_CALL(return this->inner_index_->KnnSearch(query,
@@ -277,6 +289,7 @@ public:
               const FilterPtr& filter,
               IteratorContext*& iter_ctx,
               bool is_last_filter) const override {
+        CHECK_NONEMPTY_DATASET(query);
         CHECK_AND_RETURN_EMPTY_DATASET;
         SAFE_CALL(return this->inner_index_->KnnSearch(
             query, k, parameters, filter, nullptr, iter_ctx, is_last_filter));
@@ -302,6 +315,7 @@ public:
              const std::string& parameters,
              int64_t global_optimum_tag_id = std::numeric_limits<int64_t>::max()) override {
         CHECK_IMMUTABLE_INDEX("feedback");
+        CHECK_NONEMPTY_DATASET(query);
         SAFE_CALL(return this->inner_index_->Feedback(query, k, parameters, global_optimum_tag_id));
     }
 
@@ -310,6 +324,7 @@ public:
                 float radius,
                 const std::string& parameters,
                 int64_t limited_size = -1) const override {
+        CHECK_NONEMPTY_DATASET(query);
         CHECK_AND_RETURN_EMPTY_DATASET;
         SAFE_CALL(return this->inner_index_->RangeSearch(query, radius, parameters, limited_size));
     }
@@ -320,6 +335,7 @@ public:
                 const std::string& parameters,
                 BitsetPtr invalid,
                 int64_t limited_size = -1) const override {
+        CHECK_NONEMPTY_DATASET(query);
         CHECK_AND_RETURN_EMPTY_DATASET;
         SAFE_CALL(return this->inner_index_->RangeSearch(
             query, radius, parameters, invalid, limited_size));
@@ -331,6 +347,7 @@ public:
                 const std::string& parameters,
                 const std::function<bool(int64_t)>& filter,
                 int64_t limited_size = -1) const override {
+        CHECK_NONEMPTY_DATASET(query);
         CHECK_AND_RETURN_EMPTY_DATASET;
         SAFE_CALL(return this->inner_index_->RangeSearch(
             query, radius, parameters, filter, limited_size));
@@ -342,6 +359,7 @@ public:
                 const std::string& parameters,
                 const FilterPtr& filter,
                 int64_t limited_size = -1) const override {
+        CHECK_NONEMPTY_DATASET(query);
         CHECK_AND_RETURN_EMPTY_DATASET;
         SAFE_CALL(return this->inner_index_->RangeSearch(
             query, radius, parameters, filter, limited_size));
@@ -377,6 +395,7 @@ public:
     tl::expected<void, Error>
     Train(const DatasetPtr& data) override {
         CHECK_IMMUTABLE_INDEX("train");
+        CHECK_NONEMPTY_DATASET(data);
         SAFE_CALL(this->inner_index_->Train(data));
     }
 
@@ -397,6 +416,7 @@ public:
     virtual tl::expected<bool, Error>
     UpdateExtraInfo(const DatasetPtr& new_base) override {
         CHECK_IMMUTABLE_INDEX("update extra info");
+        CHECK_NONEMPTY_DATASET(new_base);
         SAFE_CALL(return this->inner_index_->UpdateExtraInfo(new_base));
     }
 
@@ -409,6 +429,7 @@ public:
     tl::expected<bool, Error>
     UpdateVector(int64_t id, const DatasetPtr& new_base, bool force_update = false) override {
         CHECK_IMMUTABLE_INDEX("update vector");
+        CHECK_NONEMPTY_DATASET(new_base);
         SAFE_CALL(return this->inner_index_->UpdateVector(id, new_base, force_update));
     }
 

--- a/src/index/index_impl_test.cpp
+++ b/src/index/index_impl_test.cpp
@@ -91,3 +91,97 @@ TEST_CASE("immutable index test", "[ut][index_impl]") {
     REQUIRE_FALSE(result_merge.has_value());
     REQUIRE(result_merge.error().type == vsag::ErrorType::UNSUPPORTED_INDEX_OPERATION);
 }
+
+TEST_CASE("index empty input test", "[ut][index_impl]") {
+    vsag::IndexCommonParam common_param;
+    common_param.dim_ = 128;
+    common_param.data_type_ = vsag::DataTypes::DATA_TYPE_FLOAT;
+    common_param.metric_ = vsag::MetricType::METRIC_TYPE_L2SQR;
+    common_param.allocator_ = vsag::Engine::CreateDefaultAllocator();
+    auto build_parameter_json = R"(
+        {
+            "base_quantization_type": "fp32",
+            "max_degree": 16,
+            "ef_construction": 100
+        }
+    )";
+
+    vsag::JsonType hgraph_json;
+    hgraph_json = vsag::JsonType::parse(build_parameter_json);
+    auto index = std::make_shared<vsag::IndexImpl<vsag::HGraph>>(hgraph_json, common_param);
+
+    vsag::DatasetPtr dataset = vsag::Dataset::Make();
+    vsag::BinarySet binary_set;
+
+    auto result_build = index->Build(dataset);
+    REQUIRE_FALSE(result_build.has_value());
+    REQUIRE(result_build.error().type == vsag::ErrorType::INVALID_ARGUMENT);
+
+    auto result_train = index->Train(dataset);
+    REQUIRE_FALSE(result_train.has_value());
+    REQUIRE(result_train.error().type == vsag::ErrorType::INVALID_ARGUMENT);
+
+    auto result_continue_build = index->ContinueBuild(dataset, binary_set);
+    REQUIRE_FALSE(result_continue_build.has_value());
+    REQUIRE(result_continue_build.error().type == vsag::ErrorType::INVALID_ARGUMENT);
+
+    auto result_add = index->Add(dataset);
+    REQUIRE_FALSE(result_add.has_value());
+    REQUIRE(result_add.error().type == vsag::ErrorType::INVALID_ARGUMENT);
+
+    auto result_update_vector = index->UpdateVector(0, dataset);
+    REQUIRE_FALSE(result_update_vector.has_value());
+    REQUIRE(result_update_vector.error().type == vsag::ErrorType::INVALID_ARGUMENT);
+
+    auto result_feedback = index->Feedback(dataset, 0, "");
+    REQUIRE_FALSE(result_feedback.has_value());
+    REQUIRE(result_feedback.error().type == vsag::ErrorType::INVALID_ARGUMENT);
+
+    // test search empty dataset
+    int64_t k = 0;
+    float radius = 0.1;
+    int64_t limited_size = 0;
+    auto query = vsag::Dataset::Make();
+    std::string parameters = "";
+    auto invalid = vsag::Bitset::Make();
+    auto filter = [](int64_t) -> bool { return true; };
+    vsag::FilterPtr filter_ptr = nullptr;
+    vsag::IteratorContext* iter_ctx = nullptr;
+    vsag::SearchParam search_param(true, parameters, filter_ptr, nullptr);
+
+    auto search_result = index->KnnSearch(query, k, parameters, invalid);
+    REQUIRE_FALSE(search_result.has_value());
+    REQUIRE(search_result.error().type == vsag::ErrorType::INVALID_ARGUMENT);
+
+    search_result = index->KnnSearch(query, k, parameters, filter);
+    REQUIRE_FALSE(search_result.has_value());
+    REQUIRE(search_result.error().type == vsag::ErrorType::INVALID_ARGUMENT);
+
+    search_result = index->KnnSearch(query, k, parameters, filter_ptr);
+    REQUIRE_FALSE(search_result.has_value());
+    REQUIRE(search_result.error().type == vsag::ErrorType::INVALID_ARGUMENT);
+
+    search_result = index->KnnSearch(query, k, search_param);
+    REQUIRE_FALSE(search_result.has_value());
+    REQUIRE(search_result.error().type == vsag::ErrorType::INVALID_ARGUMENT);
+
+    search_result = index->KnnSearch(query, k, parameters, filter_ptr, iter_ctx, true);
+    REQUIRE_FALSE(search_result.has_value());
+    REQUIRE(search_result.error().type == vsag::ErrorType::INVALID_ARGUMENT);
+
+    search_result = index->RangeSearch(query, radius, parameters, limited_size);
+    REQUIRE_FALSE(search_result.has_value());
+    REQUIRE(search_result.error().type == vsag::ErrorType::INVALID_ARGUMENT);
+
+    search_result = index->RangeSearch(query, radius, parameters, invalid, limited_size);
+    REQUIRE_FALSE(search_result.has_value());
+    REQUIRE(search_result.error().type == vsag::ErrorType::INVALID_ARGUMENT);
+
+    search_result = index->RangeSearch(query, radius, parameters, filter, limited_size);
+    REQUIRE_FALSE(search_result.has_value());
+    REQUIRE(search_result.error().type == vsag::ErrorType::INVALID_ARGUMENT);
+
+    search_result = index->RangeSearch(query, radius, parameters, filter_ptr, limited_size);
+    REQUIRE_FALSE(search_result.has_value());
+    REQUIRE(search_result.error().type == vsag::ErrorType::INVALID_ARGUMENT);
+}

--- a/src/index/index_impl_test.cpp
+++ b/src/index/index_impl_test.cpp
@@ -133,6 +133,10 @@ TEST_CASE("index empty input test", "[ut][index_impl]") {
     REQUIRE_FALSE(result_update_vector.has_value());
     REQUIRE(result_update_vector.error().type == vsag::ErrorType::INVALID_ARGUMENT);
 
+    auto result_update_extrainfo = index->UpdateExtraInfo(dataset);
+    REQUIRE_FALSE(result_update_extrainfo.has_value());
+    REQUIRE(result_update_extrainfo.error().type == vsag::ErrorType::INVALID_ARGUMENT);
+
     auto result_feedback = index->Feedback(dataset, 0, "");
     REQUIRE_FALSE(result_feedback.has_value());
     REQUIRE(result_feedback.error().type == vsag::ErrorType::INVALID_ARGUMENT);


### PR DESCRIPTION
close #1156

## Summary by Sourcery

Enforce input validation for empty datasets in all IndexImpl operations and add comprehensive unit tests to verify they return INVALID_ARGUMENT errors

Bug Fixes:
- Return INVALID_ARGUMENT when any IndexImpl method is given an empty Dataset
- Introduce CHECK_NONEMPTY_DATASET macro to guard build, train, add, update, feedback, and search methods

Tests:
- Add index empty input unit tests covering build, train, continue build, add, update vector, feedback, and various search functions