### PR TITLE
feat(HGraph): support tombstone recovery

### DIFF
--- a/src/algorithm/hgraph.h
+++ b/src/algorithm/hgraph.h
@@ -297,6 +297,15 @@ private:
     void
     elp_optimize();
 
+    void
+    recover_remove(int64_t id);
+
+    bool
+    try_recover_tombstone(const DatasetPtr& data, std::vector<int64_t>& failed_ids);
+
+    DatasetPtr
+    get_single_dataset(const DatasetPtr& data, uint32_t j);
+
 private:
     void
     analyze_graph_recall(JsonType& stats,

--- a/src/data_cell/graph_datacell.h
+++ b/src/data_cell/graph_datacell.h
@@ -54,6 +54,9 @@ public:
     void
     DeleteNeighborsById(vsag::InnerIdType id) override;
 
+    void
+    RecoverDeleteNeighborsById(vsag::InnerIdType id) override;
+
     [[nodiscard]] uint32_t
     GetNeighborSize(InnerIdType id) const override;
 
@@ -290,6 +293,27 @@ GraphDataCell<IOTmpl>::DeleteNeighborsById(vsag::InnerIdType id) {
                                 fmt::format("remove point {} not exist in GraphDatacell", id));
         }
         node_versions_[id]++;
+    } else {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "disable delete in graph datacell");
+    }
+}
+
+template <typename IOTmpl>
+void
+GraphDataCell<IOTmpl>::RecoverDeleteNeighborsById(vsag::InnerIdType id) {
+    if (is_support_delete_) {
+        if (id <= max_capacity_) {
+            if (node_versions_[id] == 0) {
+                throw VsagException(ErrorType::INTERNAL_ERROR,
+                                    "recover remove point too many times in GraphDatacell");
+            }
+        } else {
+            throw VsagException(
+                ErrorType::INTERNAL_ERROR,
+                fmt::format("recover remove point {} not exist in GraphDatacell", id));
+        }
+        node_versions_[id]--;
     } else {
         throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
                             "disable delete in graph datacell");

--- a/src/data_cell/graph_interface.h
+++ b/src/data_cell/graph_interface.h
@@ -50,6 +50,12 @@ public:
         throw VsagException(ErrorType::INTERNAL_ERROR, "DeleteNeighborsById is not implemented");
     }
 
+    virtual void
+    RecoverDeleteNeighborsById(InnerIdType id) {
+        throw VsagException(ErrorType::INTERNAL_ERROR,
+                            "RecoverDeleteNeighborsById is not implemented");
+    }
+
     virtual uint32_t
     GetNeighborSize(InnerIdType id) const = 0;
 

--- a/src/data_cell/sparse_graph_datacell.h
+++ b/src/data_cell/sparse_graph_datacell.h
@@ -39,6 +39,9 @@ public:
     void
     DeleteNeighborsById(InnerIdType id) override;
 
+    void
+    RecoverDeleteNeighborsById(vsag::InnerIdType id) override;
+
     uint32_t
     GetNeighborSize(InnerIdType id) const override;
 

--- a/tests/test_index.h
+++ b/tests/test_index.h
@@ -78,6 +78,11 @@ public:
                     bool expected_success = true);
 
     static void
+    TestRecoverRemoveIndex(const IndexPtr& index,
+                           const TestDatasetPtr& dataset,
+                           const std::string& search_parameters);
+
+    static void
     TestUpdateId(const IndexPtr& index,
                  const TestDatasetPtr& dataset,
                  const std::string& search_param,

--- a/tools/eval/monitor/recall_monitor.cpp
+++ b/tools/eval/monitor/recall_monitor.cpp
@@ -76,7 +76,11 @@ RecallMonitor::Record(void* input) {
         distances[i] = distance_func(query_data, dataset->GetOneTrain(neighbors[i]), &dim);
         gt_distances[i] = distance_func(query_data, dataset->GetOneTrain(gt_neighbors[i]), &dim);
     }
-    auto val = get_recall(distances.get(), gt_distances.get(), topk, topk);
+
+    float val = 0;
+    if (topk != 0) {
+        val = get_recall(distances.get(), gt_distances.get(), topk, topk);
+    }
     this->recall_records_.emplace_back(val);
 }
 void


### PR DESCRIPTION
close #1055

## Summary by Sourcery

Support tombstone recovery in the HGraph index by enabling removed entries to be recovered, ensuring deleted neighbors and labels can be restored and updated during Add operations, and validating the feature with new end-to-end tests.

New Features:
- Add tombstone recovery mechanism for removed entries in HGraph.
- Expose RecoverRemove and isTombLabel methods in LabelTable to detect and restore deleted labels.
- Implement recover_remove in HGraph to restore graph neighbors and decrement deletion count.

Enhancements:
- Extend GraphInterface with RecoverDeleteNeighborsById and implement it in GraphDataCell to roll back neighbor deletions.
- Modify HGraph::Add logic to detect tombstone labels and attempt recovery before marking an Add as failed.

Tests:
- Add TestRecoverRemoveIndex to validate removal, restoration, and recall consistency after recovery in HGraph.