### PR TITLE
refactor(hgraph): simplify hgraph's sparse parameter parsing logic

### DIFF
--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -1068,8 +1068,10 @@ HGraph::InitFeatures() {
         IndexFeature::SUPPORT_KNN_ITERATOR_FILTER_SEARCH,
     });
     // update
-    this->index_feature_list_->SetFeatures({IndexFeature::SUPPORT_UPDATE_ID_CONCURRENT,
-                                            IndexFeature::SUPPORT_UPDATE_VECTOR_CONCURRENT});
+    if (data_type_ != DataTypes::DATA_TYPE_SPARSE) {
+        this->index_feature_list_->SetFeatures({IndexFeature::SUPPORT_UPDATE_VECTOR_CONCURRENT});
+    }
+    this->index_feature_list_->SetFeatures({IndexFeature::SUPPORT_UPDATE_ID_CONCURRENT});
     // concurrency
     this->index_feature_list_->SetFeature(IndexFeature::SUPPORT_SEARCH_CONCURRENT);
     this->index_feature_list_->SetFeature(IndexFeature::SUPPORT_ADD_CONCURRENT);
@@ -1199,7 +1201,7 @@ static const std::string HGRAPH_PARAMS_TEMPLATE =
                 "{IO_TYPE_KEY}": "{IO_TYPE_VALUE_BLOCK_MEMORY_IO}",
                 "{IO_FILE_PATH}": "{DEFAULT_FILE_PATH_VALUE}"
             },
-            "codes_type": "flatten_codes",
+            "{CODES_TYPE_KEY}": "flatten",
             "{QUANTIZATION_PARAMS_KEY}": {
                 "{QUANTIZATION_TYPE_KEY}": "{QUANTIZATION_TYPE_VALUE_FP32}",
                 "{SQ4_UNIFORM_QUANTIZATION_TRUNC_RATE}": 0.05,
@@ -1215,7 +1217,7 @@ static const std::string HGRAPH_PARAMS_TEMPLATE =
                 "{IO_TYPE_KEY}": "{IO_TYPE_VALUE_BLOCK_MEMORY_IO}",
                 "{IO_FILE_PATH}": "{DEFAULT_FILE_PATH_VALUE}"
             },
-            "codes_type": "flatten_codes",
+            "{CODES_TYPE_KEY}": "flatten",
             "{QUANTIZATION_PARAMS_KEY}": {
                 "{QUANTIZATION_TYPE_KEY}": "{QUANTIZATION_TYPE_VALUE_FP32}",
                 "{SQ4_UNIFORM_QUANTIZATION_TRUNC_RATE}": 0.05,
@@ -1230,6 +1232,7 @@ static const std::string HGRAPH_PARAMS_TEMPLATE =
                 "{IO_TYPE_KEY}": "{IO_TYPE_VALUE_BLOCK_MEMORY_IO}",
                 "{IO_FILE_PATH}": "{DEFAULT_FILE_PATH_VALUE}"
             },
+            "{CODES_TYPE_KEY}": "flatten",
             "{QUANTIZATION_PARAMS_KEY}": {
                 "{QUANTIZATION_TYPE_KEY}": "{QUANTIZATION_TYPE_VALUE_FP32}",
                 "{HOLD_MOLDS}": true
@@ -1525,6 +1528,11 @@ HGraph::CheckAndMappingExternalParam(const JsonType& external_param,
     std::string str = format_map(HGRAPH_PARAMS_TEMPLATE, DEFAULT_MAP);
     auto inner_json = JsonType::parse(str);
     mapping_external_param_to_inner(external_param, external_mapping, inner_json);
+    if (common_param.data_type_ == DataTypes::DATA_TYPE_SPARSE) {
+        inner_json[HGRAPH_BASE_CODES_KEY][CODES_TYPE_KEY] = SPARSE_CODES;
+        inner_json[PRECISE_CODES_KEY][CODES_TYPE_KEY] = SPARSE_CODES;
+        inner_json[RAW_VECTOR_KEY][CODES_TYPE_KEY] = SPARSE_CODES;
+    }
 
     auto hgraph_parameter = std::make_shared<HGraphParameter>();
     hgraph_parameter->data_type = common_param.data_type_;

--- a/src/algorithm/hgraph_parameter.cpp
+++ b/src/algorithm/hgraph_parameter.cpp
@@ -53,23 +53,13 @@ HGraphParameter::FromJson(const JsonType& json) {
     CHECK_ARGUMENT(json.contains(HGRAPH_BASE_CODES_KEY),
                    fmt::format("hgraph parameters must contains {}", HGRAPH_BASE_CODES_KEY));
     const auto& base_codes_json = json[HGRAPH_BASE_CODES_KEY];
-    if (data_type == DataTypes::DATA_TYPE_SPARSE) {
-        this->base_codes_param = std::make_shared<SparseVectorDataCellParameter>();
-    } else {
-        this->base_codes_param = std::make_shared<FlattenDataCellParameter>();
-    }
-    this->base_codes_param->FromJson(base_codes_json);
+    this->base_codes_param = CreateFlattenParam(base_codes_json);
 
     if (use_reorder) {
         CHECK_ARGUMENT(json.contains(PRECISE_CODES_KEY),
                        fmt::format("hgraph parameters must contains {}", PRECISE_CODES_KEY));
         const auto& precise_codes_json = json[PRECISE_CODES_KEY];
-        if (data_type == DataTypes::DATA_TYPE_SPARSE) {
-            this->precise_codes_param = std::make_shared<SparseVectorDataCellParameter>();
-        } else {
-            this->precise_codes_param = std::make_shared<FlattenDataCellParameter>();
-        }
-        this->precise_codes_param->FromJson(precise_codes_json);
+        this->precise_codes_param = CreateFlattenParam(precise_codes_json);
     }
 
     CHECK_ARGUMENT(json.contains(HGRAPH_GRAPH_KEY),

--- a/src/algorithm/inner_index_parameter.cpp
+++ b/src/algorithm/inner_index_parameter.cpp
@@ -42,8 +42,7 @@ InnerIndexParameter::FromJson(const JsonType& json) {
         CHECK_ARGUMENT(
             json.contains(PRECISE_CODES_KEY),
             fmt::format("ivf parameters must contains {} when enable reorder", PRECISE_CODES_KEY));
-        this->precise_codes_param = std::make_shared<FlattenDataCellParameter>();
-        this->precise_codes_param->FromJson(json[PRECISE_CODES_KEY]);
+        this->precise_codes_param = CreateFlattenParam(json[PRECISE_CODES_KEY]);
     }
 
     if (json.contains(STORE_RAW_VECTOR_KEY)) {
@@ -51,8 +50,7 @@ InnerIndexParameter::FromJson(const JsonType& json) {
     }
 
     if (this->store_raw_vector) {
-        this->raw_vector_param = std::make_shared<FlattenDataCellParameter>();
-        this->raw_vector_param->FromJson(json[RAW_VECTOR_KEY]);
+        this->raw_vector_param = CreateFlattenParam(json[RAW_VECTOR_KEY]);
     }
 
     if (json.contains(EXTRA_INFO_KEY)) {

--- a/src/data_cell/flatten_datacell_parameter.cpp
+++ b/src/data_cell/flatten_datacell_parameter.cpp
@@ -43,6 +43,7 @@ JsonType
 FlattenDataCellParameter::ToJson() const {
     JsonType json;
     json[IO_PARAMS_KEY] = this->io_parameter->ToJson();
+    json[CODES_TYPE_KEY] = FLATTEN_CODES;
     json[QUANTIZATION_PARAMS_KEY] = this->quantizer_parameter->ToJson();
     return json;
 }

--- a/src/data_cell/flatten_interface_parameter.cpp
+++ b/src/data_cell/flatten_interface_parameter.cpp
@@ -13,28 +13,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#pragma once
+#include "flatten_interface_parameter.h"
 
-#include "io/io_parameter.h"
-#include "parameter.h"
-#include "pointer_define.h"
-#include "quantization/quantizer_parameter.h"
+#include "flatten_datacell_parameter.h"
+#include "inner_string_params.h"
+#include "sparse_vector_datacell_parameter.h"
 
 namespace vsag {
-DEFINE_POINTER2(FlattenInterfaceParam, FlattenInterfaceParameter);
-
-class FlattenInterfaceParameter : public Parameter {
-public:
-    FlattenInterfaceParameter(std::string name) : name(std::move(name)) {
-    }
-
-    QuantizerParamPtr quantizer_parameter{nullptr};
-
-    IOParamPtr io_parameter{nullptr};
-
-    std::string name;
-};
 
 FlattenInterfaceParamPtr
-CreateFlattenParam(const JsonType& json);
+CreateFlattenParam(const JsonType& json) {
+    FlattenInterfaceParamPtr param = nullptr;
+    if (json.contains(CODES_TYPE_KEY) && json[CODES_TYPE_KEY] == SPARSE_CODES) {
+        param = std::make_shared<SparseVectorDataCellParameter>();
+    } else {
+        param = std::make_shared<FlattenDataCellParameter>();
+    }
+    param->FromJson(json);
+    return param;
+}
+
 }  // namespace vsag

--- a/src/data_cell/sparse_vector_datacell_parameter.h
+++ b/src/data_cell/sparse_vector_datacell_parameter.h
@@ -48,6 +48,7 @@ public:
         JsonType json;
         json[IO_PARAMS_KEY] = this->io_parameter->ToJson();
         json[QUANTIZATION_PARAMS_KEY] = this->quantizer_parameter->ToJson();
+        json[CODES_TYPE_KEY] = SPARSE_CODES;
         return json;
     }
 

--- a/src/inner_string_params.h
+++ b/src/inner_string_params.h
@@ -151,6 +151,10 @@ const char* const DATACELL_SIZES = "datacell_sizes";
 const char* const BASIC_INFO = "basic_info";
 const char* const INDEX_TYPE = "type";
 
+const char* const CODES_TYPE_KEY = "codes_type";
+const char* const FLATTEN_CODES = "flatten";
+const char* const SPARSE_CODES = "sparse";
+
 const std::unordered_map<std::string, std::string> DEFAULT_MAP = {
     {"INDEX_TYPE_HGRAPH", INDEX_TYPE_HGRAPH},
     {"INDEX_TYPE_IVF", INDEX_TYPE_IVF},

--- a/tests/test_brute_force.cpp
+++ b/tests/test_brute_force.cpp
@@ -617,7 +617,7 @@ TestBruteForceEstimateMemory(const fixtures::BruteForceResourcePtr& resource) {
             auto index = TestIndex::TestFactory(BruteForceTestIndex::name, param, true);
             auto dataset = BruteForceTestIndex::pool.GetDatasetAndCreate(
                 dim, BruteForceTestIndex::base_count, metric_type);
-            index->EstimateMemory(1000);
+            TestIndex::TestEstimateMemory(BruteForceTestIndex::name, param, dataset);
             vsag::Options::Instance().set_block_size_limit(origin_size);
         }
     }

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -1200,7 +1200,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HGraphTestIndex,
     auto param = HGraphTestIndex::GenerateHGraphBuildParametersString(build_param);
     auto index = TestFactory(name, param, true);
     TestConcurrentAdd(index, dataset, true);
-    TestKnnSearch(index, dataset, search_param, true);
+    TestGeneral(index, dataset, search_param, true);
     auto index2 = TestIndex::TestFactory(name, param, true);
     TestIndex::TestSerializeFile(index, index2, dataset, search_param, true);
     vsag::Options::Instance().set_block_size_limit(origin_size);

--- a/tests/test_index.cpp
+++ b/tests/test_index.cpp
@@ -561,6 +561,7 @@ TestIndex::TestKnnSearchIter(const IndexPtr& index,
             ->Dim(dim)
             ->Float32Vectors(queries->GetFloat32Vectors() + i * dim)
             ->Paths(queries->GetPaths() + i)
+            ->SparseVectors(queries->GetSparseVectors() + i)
             ->Owner(false);
         auto res = index->KnnSearch(query, first_top, search_param, filter, filter_ctx, false);
         if (not expected_success) {


### PR DESCRIPTION
## Summary by Sourcery

Unify and simplify sparse vs. flatten data cell parameter parsing by introducing a factory function driven by a codes_type key, refactor HGraph and inner index parameter parsing to use it, update JSON templates and constants accordingly, and adapt tests to the new codes_type logic.

Enhancements:
- Introduce CreateFlattenParam factory function to unify creation of flatten and sparse data cell parameters based on JSON codes_type
- Refactor HGraphParameter::FromJson and InnerIndexParameter::FromJson to use the new factory instead of branching on data_type
- Simplify HGraph initialization and external parameter mapping by consolidating sparse handling and replacing literal codes_type entries with a generic placeholder
- Update HGraph JSON template to parameterize codes_type via placeholders and override to sparse in mapping when data_type is sparse
- Add CODES_TYPE_KEY, FLATTEN_CODES, and SPARSE_CODES constants and include codes_type in FlattenDataCellParameter and SparseVectorDataCellParameter JSON output

Tests:
- Replace EstimateMemory call with TestEstimateMemory and switch from TestKnnSearch to TestGeneral in hgraph tests
- Extend KnnSearch iterator test to include sparse vectors in query builder