### PR TITLE
fix(int8): fix the missing header files issue

### DIFF
--- a/src/factory/CMakeLists.txt
+++ b/src/factory/CMakeLists.txt
@@ -8,4 +8,4 @@ set (FACTORY_SRC
 
 add_library (factory OBJECT ${FACTORY_SRC})
 target_link_libraries (factory PUBLIC fmt::fmt coverage_config)
-maybe_add_dependencies (factory spdlog)
+maybe_add_dependencies (factory spdlog boost)

--- a/src/factory/CMakeLists.txt
+++ b/src/factory/CMakeLists.txt
@@ -8,4 +8,4 @@ set (FACTORY_SRC
 
 add_library (factory OBJECT ${FACTORY_SRC})
 target_link_libraries (factory PUBLIC fmt::fmt coverage_config)
-maybe_add_dependencies (factory spdlog boost)
+maybe_add_dependencies (factory spdlog diskann)

--- a/src/quantization/int8_quantizer.h
+++ b/src/quantization/int8_quantizer.h
@@ -17,7 +17,7 @@
 
 #include <cstdint>
 
-#include "index/index_common_param.h"
+#include "index_common_param.h"
 #include "inner_string_params.h"
 #include "int8_quantizer_parameter.h"
 #include "quantization/computer.h"


### PR DESCRIPTION
close #1166

## Summary by Sourcery

Bug Fixes:
- Correct the include path for index_common_param.h in int8_quantizer.h to resolve missing header file issue.