### PR TITLE
fix(serialize): support empty serialize for export model

### DIFF
--- a/src/algorithm/brute_force.cpp
+++ b/src/algorithm/brute_force.cpp
@@ -47,7 +47,9 @@ BruteForce::BruteForce(const BruteForceParameterPtr& param, const IndexCommonPar
     if (this->use_attribute_filter_) {
         this->attr_filter_index_ =
             AttributeInvertedInterface::MakeInstance(allocator_, true /*have_bucket*/);
+        this->has_attribute_ = true;
     }
+    this->has_raw_vector_ = true;
 }
 
 uint64_t

--- a/src/algorithm/inner_index_interface.cpp
+++ b/src/algorithm/inner_index_interface.cpp
@@ -120,20 +120,6 @@ InnerIndexInterface::Serialize() const {
     std::string time_record_name = this->GetName() + " Serialize";
     SlowTaskTimer t(time_record_name);
 
-    if (GetNumElements() == 0) {
-        // TODO(wxyu): remove this if condition
-        // if (not Options::Instance().new_version()) {
-        //     return EmptyIndexBinarySet::Make(this->GetName());
-        // }
-
-        auto metadata = std::make_shared<Metadata>();
-        metadata->SetEmptyIndex(true);
-
-        BinarySet bs;
-        bs.Set(SERIAL_META_KEY, metadata->ToBinary());
-        return bs;
-    }
-
     uint64_t num_bytes = this->CalSerializeSize();
     // TODO(LHT): use try catch
 
@@ -151,16 +137,8 @@ InnerIndexInterface::Serialize() const {
     return bs;
 }
 
-#define CHECK_SELF_EMPTY                                                  \
-    if (this->GetNumElements() > 0) {                                     \
-        throw VsagException(ErrorType::INDEX_NOT_EMPTY,                   \
-                            "failed to Deserialize: index is not empty"); \
-    }
-
 void
 InnerIndexInterface::Deserialize(const BinarySet& binary_set) {
-    CHECK_SELF_EMPTY;
-
     std::string time_record_name = this->GetName() + " Deserialize";
     SlowTaskTimer t(time_record_name);
 
@@ -198,7 +176,6 @@ InnerIndexInterface::Deserialize(const BinarySet& binary_set) {
 
 void
 InnerIndexInterface::Deserialize(const ReaderSet& reader_set) {
-    CHECK_SELF_EMPTY;
     std::string time_record_name = this->GetName() + " Deserialize";
     SlowTaskTimer t(time_record_name);
     if (reader_set.Contains(SERIAL_META_KEY)) {
@@ -248,29 +225,12 @@ void
 InnerIndexInterface::Serialize(std::ostream& out_stream) const {
     std::string time_record_name = this->GetName() + " Serialize";
     SlowTaskTimer t(time_record_name);
-
-    if (GetNumElements() == 0) {
-        // TODO(wxyu): remove this if condition
-        // if (not Options::Instance().new_version()) {
-        //     return;
-        // }
-
-        auto metadata = std::make_shared<Metadata>();
-        metadata->SetEmptyIndex(true);
-        auto footer = std::make_shared<Footer>(metadata);
-        IOStreamWriter writer(out_stream);
-        footer->Write(writer);
-        return;
-    }
-
     IOStreamWriter writer(out_stream);
     this->Serialize(writer);
 }
 
 void
 InnerIndexInterface::Deserialize(std::istream& in_stream) {
-    CHECK_SELF_EMPTY;
-
     std::string time_record_name = this->GetName() + " Deserialize";
     SlowTaskTimer t(time_record_name);
     try {

--- a/src/algorithm/inner_index_interface_test.cpp
+++ b/src/algorithm/inner_index_interface_test.cpp
@@ -165,11 +165,6 @@ TEST_CASE("InnerIndexInterface NOT Implemented", "[ut][InnerIndexInterface]") {
     REQUIRE_THROWS(empty_index->UpdateAttribute(0, new_attrs));
     REQUIRE_THROWS(empty_index->UpdateAttribute(1, new_attrs, old_attrs));
 
-    std::stringstream stream;
-    empty_index->Serialize(stream);
-    stream.seekg(0);
-    REQUIRE_NOTHROW(empty_index->Deserialize(stream));
-
     REQUIRE_NOTHROW(empty_index->Train(nullptr));
 
     SearchRequest req;

--- a/src/algorithm/ivf.cpp
+++ b/src/algorithm/ivf.cpp
@@ -39,7 +39,7 @@ static constexpr const char* IVF_PARAMS_TEMPLATE =
     {
         "type": "{INDEX_TYPE_IVF}",
         "{IVF_TRAIN_TYPE_KEY}": "{IVF_TRAIN_TYPE_KMEANS}",
-        "{IVF_USE_ATTRIBUTE_FILTER_KEY}": false,
+        "{USE_ATTRIBUTE_FILTER_KEY}": false,
         "{USE_REORDER_KEY}": false,
         "{BUILD_THREAD_COUNT_KEY}": 1,
         "{BUCKET_PARAMS_KEY}": {
@@ -233,13 +233,11 @@ IVF::IVF(const IVFParameterPtr& param, const IndexCommonParam& common_param)
         this->partition_strategy_ = std::make_shared<GNOIMIPartition>(
             common_param, param->ivf_partition_strategy_parameter);
     }
-    this->use_reorder_ = param->use_reorder;
     if (this->use_reorder_) {
         this->reorder_codes_ =
             FlattenInterface::MakeInstance(param->precise_codes_param, common_param);
     }
     this->use_residual_ = param->bucket_param->use_residual_;
-    this->use_attribute_filter_ = param->use_attribute_filter;
     if (this->use_attribute_filter_) {
         this->attr_filter_index_ =
             AttributeInvertedInterface::MakeInstance(allocator_, true /*have_bucket*/);

--- a/src/algorithm/ivf.h
+++ b/src/algorithm/ivf.h
@@ -166,7 +166,6 @@ private:
 
     bool is_trained_{false};
     bool use_residual_{false};
-    bool use_attribute_filter_{false};
 
     FlattenInterfacePtr reorder_codes_{nullptr};
 

--- a/src/index/index_impl.h
+++ b/src/index/index_impl.h
@@ -166,10 +166,6 @@ public:
 
     tl::expected<DatasetPtr, Error>
     GetDataByIds(const int64_t* ids, int64_t count) const override {
-        if (not CheckFeature(IndexFeature::SUPPORT_GET_DATA_BY_IDS)) {
-            return tl::unexpected(Error(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                                        "index no support to get data by ids"));
-        }
         SAFE_CALL(return this->inner_index_->GetDataByIds(ids, count));
     };
 


### PR DESCRIPTION
fixed: #1162 
- remove get data check(for attribute/extra info ...)

## Summary by Sourcery

Allow empty indices to be serialized and exported without special-case code and remove the unsupported-operation guard for data retrieval by IDs

Enhancements:
- Remove early-return and metadata-only path for empty index serialization in InnerIndexInterface
- Remove CHECK_SELF_EMPTY guards in all Deserialize overloads to allow deserializing into non-empty indices
- Remove unsupported-operation check for GetDataByIds in IndexImpl to permit direct data retrieval