### PR TITLE
refactor(option): modify the minimum block size

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -47,8 +47,8 @@ Options::set_direct_IO_object_align_bit(size_t align_bit) {
 
 void
 Options::set_block_size_limit(size_t size) {
-    if (size < 2ULL * 1024 * 1024) {
-        throw std::runtime_error(fmt::format("size ({}) should be greater than 2M.", size));
+    if (size < 256UL * 1024) {
+        throw std::runtime_error(fmt::format("size ({}) should be greater than 256K.", size));
     }
     block_size_limit_.store(size, std::memory_order_release);
 }


### PR DESCRIPTION
## Summary by Sourcery

Lower the minimum block size limit in the Options class from 2MB to 256KB

Enhancements:
- Update the validation condition to enforce a 256KB minimum block size
- Adjust the error message to reflect the new 256KB threshold