### PR TITLE
fix(hnsw): performance degradation after remove 

### DIFF
--- a/src/algorithm/hnswlib/hnswalg.cpp
+++ b/src/algorithm/hnswlib/hnswalg.cpp
@@ -1129,8 +1129,7 @@ HierarchicalNSW::copyDataByLabel(LabelType label, void* data_point) {
     */
 void
 HierarchicalNSW::markDelete(LabelType label) {
-    // lock all operations with element by label
-    std::unique_lock lock_table(label_lookup_lock_);
+    // no need to use lock since we use global rw lock in hnsw.cpp
     auto search = label_lookup_.find(label);
     if (search == label_lookup_.end()) {
         throw std::runtime_error("Label not found");

--- a/src/algorithm/hnswlib/hnswalg.h
+++ b/src/algorithm/hnswlib/hnswalg.h
@@ -366,9 +366,9 @@ public:
     */
     bool
     isMarkedDeleted(InnerIdType internal_id) const {
-        std::shared_ptr<char[]> data = std::shared_ptr<char[]>(new char[size_links_level0_]);
-        getLinklistAtLevel(internal_id, 0, data.get());
-        unsigned char* ll_cur = ((unsigned char*)data.get()) + 2;
+        // no need to use fine-grained lock
+        auto src = data_level0_memory_->GetElementPtr(internal_id, offsetLevel0_);
+        unsigned char* ll_cur = ((unsigned char*)src) + 2;
         return *ll_cur & DELETE_MARK;
     }
 

--- a/tools/eval/eval_template.yaml
+++ b/tools/eval/eval_template.yaml
@@ -1,27 +1,27 @@
 global:
-    exporters:
-      print-directly:
-        format: "table"
-        to: "stdout"
-      save-to-file:
-        format: "json"
-        to: "file://tmp/eval_example_output.json"
-      send-to-influxdb:
-        format: "line_protocol"
-        to: "influxdb://127.0.0.1:8086/api/v2/write?org=7d71a0eb85deafbe&bucket=583a2fd8dd85e66c&precision=ns"
-        vars:
-          token: "Token mlIiP-zVfcooHhMbGG9Yk-KfrkHyDc2h-rphnIBda8UMe_6Qocy8tNmV323yxOPEAsC8uIs6_nb-XUSMEAO76A=="
+  exporters:
+    print-directly:
+      format: "table"
+      to: "stdout"
+    save-to-file:
+      format: "json"
+      to: "file://tmp/eval_example_output.json"
+    send-to-influxdb:
+      format: "line_protocol"
+      to: "influxdb://127.0.0.1:8086/api/v2/write?org=7d71a0eb85deafbe&bucket=583a2fd8dd85e66c&precision=ns"
+      vars:
+        token: "Token mlIiP-zVfcooHhMbGG9Yk-KfrkHyDc2h-rphnIBda8UMe_6Qocy8tNmV323yxOPEAsC8uIs6_nb-XUSMEAO76A=="
 
 eval_case1:
-    datapath: "/tmp/sift-128-euclidean.hdf5"
-    type: "search" # `build` or `search` or `build,search`
-    index_name: "hgraph"
-    create_params: '{"dim":128,"dtype":"float32","metric_type":"l2","index_param":{"base_quantization_type":"fp32","max_degree":32,"ef_construction":300}}'
-    search_params: '{"hgraph":{"ef_search":60}}'
-    index_path: "/tmp/sift-128-euclidean/index/hgraph_index"
-    search_mode: "knn" # ["knn", "range", "knn_filter", "range_filter"]
-    topk: 10
-    range: 0.5
-    delete_index_after_search: false # free up storage space used by index
-    num_threads_building: 16
-    num_threads_searching: 16
+  datapath: "/tbase-project/ann-benchmarks/data/sift-128-euclidean.hdf5"
+  type: "build,search" # `build` or `search` or `build,search`
+  index_name: "hgraph"
+  create_params: '{"dim":128,"dtype":"float32","metric_type":"l2","use_old_serial_format":true,"index_param":{"ef_construction":100,"max_degree":32,"base_quantization_type":"rabitq","build_thread_count":0,"use_reorder":true,"ignore_reorder":true,"precise_quantization_type":"fp32","precise_io_type":"block_memory_io","rabitq_bits_per_dim_query":32,"rabitq_use_fht":false}}'
+  search_params: '{"hgraph":{"ef_search":60}}'
+  index_path: "/tmp/sift-128-euclidean/index/hgraph_index"
+  search_mode: "knn" # ["knn", "range", "knn_filter", "range_filter"]
+  topk: 10
+  range: 0.5
+  delete_index_after_search: false # free up storage space used by index
+  num_threads_building: 32
+  num_threads_searching: 1

--- a/tools/eval/eval_template.yaml
+++ b/tools/eval/eval_template.yaml
@@ -1,27 +1,27 @@
 global:
-  exporters:
-    print-directly:
-      format: "table"
-      to: "stdout"
-    save-to-file:
-      format: "json"
-      to: "file://tmp/eval_example_output.json"
-    send-to-influxdb:
-      format: "line_protocol"
-      to: "influxdb://127.0.0.1:8086/api/v2/write?org=7d71a0eb85deafbe&bucket=583a2fd8dd85e66c&precision=ns"
-      vars:
-        token: "Token mlIiP-zVfcooHhMbGG9Yk-KfrkHyDc2h-rphnIBda8UMe_6Qocy8tNmV323yxOPEAsC8uIs6_nb-XUSMEAO76A=="
+    exporters:
+      print-directly:
+        format: "table"
+        to: "stdout"
+      save-to-file:
+        format: "json"
+        to: "file://tmp/eval_example_output.json"
+      send-to-influxdb:
+        format: "line_protocol"
+        to: "influxdb://127.0.0.1:8086/api/v2/write?org=7d71a0eb85deafbe&bucket=583a2fd8dd85e66c&precision=ns"
+        vars:
+          token: "Token mlIiP-zVfcooHhMbGG9Yk-KfrkHyDc2h-rphnIBda8UMe_6Qocy8tNmV323yxOPEAsC8uIs6_nb-XUSMEAO76A=="
 
 eval_case1:
-  datapath: "/tbase-project/ann-benchmarks/data/sift-128-euclidean.hdf5"
-  type: "build,search" # `build` or `search` or `build,search`
-  index_name: "hgraph"
-  create_params: '{"dim":128,"dtype":"float32","metric_type":"l2","use_old_serial_format":true,"index_param":{"ef_construction":100,"max_degree":32,"base_quantization_type":"rabitq","build_thread_count":0,"use_reorder":true,"ignore_reorder":true,"precise_quantization_type":"fp32","precise_io_type":"block_memory_io","rabitq_bits_per_dim_query":32,"rabitq_use_fht":false}}'
-  search_params: '{"hgraph":{"ef_search":60}}'
-  index_path: "/tmp/sift-128-euclidean/index/hgraph_index"
-  search_mode: "knn" # ["knn", "range", "knn_filter", "range_filter"]
-  topk: 10
-  range: 0.5
-  delete_index_after_search: false # free up storage space used by index
-  num_threads_building: 32
-  num_threads_searching: 1
+    datapath: "/tmp/sift-128-euclidean.hdf5"
+    type: "search" # `build` or `search` or `build,search`
+    index_name: "hgraph"
+    create_params: '{"dim":128,"dtype":"float32","metric_type":"l2","index_param":{"base_quantization_type":"fp32","max_degree":32,"ef_construction":300}}'
+    search_params: '{"hgraph":{"ef_search":60}}'
+    index_path: "/tmp/sift-128-euclidean/index/hgraph_index"
+    search_mode: "knn" # ["knn", "range", "knn_filter", "range_filter"]
+    topk: 10
+    range: 0.5
+    delete_index_after_search: false # free up storage space used by index
+    num_threads_building: 16
+    num_threads_searching: 16


### PR DESCRIPTION
same as #1176

## Summary by Sourcery

Improve thread safety and performance in HNSW index operations by introducing global read–write locks around critical sections and removing redundant per-element locks in the hnswlib implementation; also update the evaluation template with a new data path, adjusted threading settings, and refined index creation parameters.

Bug Fixes:
- Add shared and exclusive locks around HNSW operations (updateVector, copyDataByLabel, distance calculations, etc.) to prevent data races and restore performance after removals

Enhancements:
- Revise tools/eval/eval_template.yaml with updated dataset path, new quantization and threading parameters, and consistent indentation