### PR TITLE
feat(hgraph): support set topk factor while searching

### DIFF
--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -1877,6 +1877,10 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
     search_param.ef = std::max(params.ef_search, k);
     search_param.is_inner_id_allowed = ft;
     search_param.topk = static_cast<int64_t>(search_param.ef);
+    if (params.topk_factor > 1.0F) {
+        search_param.topk = std::min(
+            search_param.topk, static_cast<int64_t>(static_cast<float>(k) * params.topk_factor));
+    }
     search_param.consider_duplicate = true;
     if (params.enable_time_record) {
         search_param.time_cost = std::make_shared<Timer>();

--- a/src/algorithm/hgraph_parameter.cpp
+++ b/src/algorithm/hgraph_parameter.cpp
@@ -206,6 +206,10 @@ HGraphSearchParameters::FromJson(const std::string& json_string) {
         obj.enable_time_record = true;
     }
 
+    if (params[INDEX_TYPE_HGRAPH].contains(SEARCH_PARAM_FACTOR)) {
+        obj.topk_factor = params[INDEX_TYPE_HGRAPH][SEARCH_PARAM_FACTOR];
+    }
+
     return obj;
 }
 }  // namespace vsag

--- a/src/algorithm/hgraph_parameter.cpp
+++ b/src/algorithm/hgraph_parameter.cpp
@@ -206,8 +206,8 @@ HGraphSearchParameters::FromJson(const std::string& json_string) {
         obj.enable_time_record = true;
     }
 
-    if (params[INDEX_TYPE_HGRAPH].contains(SEARCH_PARAM_FACTOR)) {
-        obj.topk_factor = params[INDEX_TYPE_HGRAPH][SEARCH_PARAM_FACTOR];
+    if (params[INDEX_TYPE_HGRAPH].Contains(SEARCH_PARAM_FACTOR)) {
+        obj.topk_factor = params[INDEX_TYPE_HGRAPH][SEARCH_PARAM_FACTOR].GetFloat();
     }
 
     return obj;

--- a/src/algorithm/hgraph_parameter.h
+++ b/src/algorithm/hgraph_parameter.h
@@ -74,6 +74,7 @@ public:
 
 public:
     int64_t ef_search{30};
+    float topk_factor{0.0F};
     bool use_reorder{false};
     bool use_extra_info_filter{false};
     bool enable_time_record{false};

--- a/src/algorithm/ivf_parameter.h
+++ b/src/algorithm/ivf_parameter.h
@@ -66,8 +66,8 @@ public:
         obj.scan_buckets_count =
             params[INDEX_TYPE_IVF][IVF_SEARCH_PARAM_SCAN_BUCKETS_COUNT].GetInt();
 
-        if (params[INDEX_TYPE_IVF].Contains(IVF_SEARCH_PARAM_FACTOR)) {
-            obj.topk_factor = params[INDEX_TYPE_IVF][IVF_SEARCH_PARAM_FACTOR].GetFloat();
+        if (params[INDEX_TYPE_IVF].Contains(SEARCH_PARAM_FACTOR)) {
+            obj.topk_factor = params[INDEX_TYPE_IVF][SEARCH_PARAM_FACTOR].GetFloat();
         }
 
         if (params[INDEX_TYPE_IVF].Contains(GNO_IMI_SEARCH_PARAM_FIRST_ORDER_SCAN_RATIO)) {

--- a/src/common.h
+++ b/src/common.h
@@ -42,7 +42,7 @@
 
 constexpr static const int64_t INIT_CAPACITY = 10;
 constexpr static const int64_t MAX_CAPACITY_EXTEND = 10000;
-constexpr static const int64_t AMPLIFICATION_FACTOR = 10;
+constexpr static const int64_t AMPLIFICATION_FACTOR = 100;
 constexpr static const int64_t EXPANSION_NUM = 1000000;
 constexpr static const int64_t DEFAULT_MAX_ELEMENT = 1;
 constexpr static const int MINIMAL_M = 8;

--- a/src/index/hnsw_zparameters_test.cpp
+++ b/src/index/hnsw_zparameters_test.cpp
@@ -64,7 +64,7 @@ TEST_CASE("create hnsw with wrong parameter", "[ut][hnsw]") {
     }
     SECTION("big max_degree") {
         auto wrong_param_str = fmt::format(build_parameter_json, 16, 1601);
-        nlohmann::json wrong_parsed_params = nlohmann::json::parse(wrong_param_str);
+        auto wrong_parsed_params = vsag::JsonType::Parse(wrong_param_str);
         REQUIRE_THROWS(vsag::HnswParameters::FromJson(wrong_parsed_params, common_param));
         auto correct_param_str = fmt::format(build_parameter_json, 16, 1600);
         auto correct_parsed_params = vsag::JsonType::Parse(correct_param_str);

--- a/src/index/hnsw_zparameters_test.cpp
+++ b/src/index/hnsw_zparameters_test.cpp
@@ -63,10 +63,10 @@ TEST_CASE("create hnsw with wrong parameter", "[ut][hnsw]") {
         REQUIRE_THROWS(vsag::HnswParameters::FromJson(parsed_params, common_param));
     }
     SECTION("big max_degree") {
-        auto wrong_param_str = fmt::format(build_parameter_json, 16, 1001);
-        auto wrong_parsed_params = vsag::JsonType::Parse(wrong_param_str);
+        auto wrong_param_str = fmt::format(build_parameter_json, 16, 1601);
+        nlohmann::json wrong_parsed_params = nlohmann::json::parse(wrong_param_str);
         REQUIRE_THROWS(vsag::HnswParameters::FromJson(wrong_parsed_params, common_param));
-        auto correct_param_str = fmt::format(build_parameter_json, 16, 1000);
+        auto correct_param_str = fmt::format(build_parameter_json, 16, 1600);
         auto correct_parsed_params = vsag::JsonType::Parse(correct_param_str);
         vsag::HnswParameters::FromJson(correct_parsed_params, common_param);
     }

--- a/src/inner_string_params.h
+++ b/src/inner_string_params.h
@@ -122,7 +122,7 @@ const char* const NO_BUILD_LEVELS = "no_build_levels";
 const char* const BUCKETS_COUNT_KEY = "buckets_count";
 const char* const BUCKET_USE_RESIDUAL = "use_residual";
 const char* const IVF_SEARCH_PARAM_SCAN_BUCKETS_COUNT = "scan_buckets_count";
-const char* const IVF_SEARCH_PARAM_FACTOR = "factor";
+const char* const SEARCH_PARAM_FACTOR = "factor";
 const char* const IVF_SEARCH_PARALLELISM = "parallelism";
 const char* const SEARCH_MAX_TIME_COST_MS = "timeout_ms";
 
@@ -213,7 +213,7 @@ const std::unordered_map<std::string, std::string> DEFAULT_MAP = {
     {"ODESCENT_PARAMETER_GRAPH_ITER_TURN", ODESCENT_PARAMETER_GRAPH_ITER_TURN},
     {"ODESCENT_PARAMETER_NEIGHBOR_SAMPLE_RATE", ODESCENT_PARAMETER_NEIGHBOR_SAMPLE_RATE},
     {"EXTRA_INFO_KEY", EXTRA_INFO_KEY},
-    {"IVF_SEARCH_PARAM_FACTOR", IVF_SEARCH_PARAM_FACTOR},
+    {"SEARCH_PARAM_FACTOR", SEARCH_PARAM_FACTOR},
     {"BUCKET_PER_DATA_KEY", BUCKET_PER_DATA_KEY},
     {"IVF_PARTITION_STRATEGY_PARAMS_KEY", IVF_PARTITION_STRATEGY_PARAMS_KEY},
     {"IVF_PARTITION_STRATEGY_TYPE_KEY", IVF_PARTITION_STRATEGY_TYPE_KEY},

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -574,16 +574,9 @@ TestHGraphFactor(const fixtures::HGraphTestIndexPtr& test_index,
                 auto dataset = HGraphTestIndex::pool.GetDatasetAndCreate(
                     dim, resource->base_count, metric_type);
                 TestIndex::TestContinueAdd(index, dataset, true);
-                {
-                    auto search_param = fmt::format(fixtures::search_param_tmp, 4, false);
-                    TestIndex::TestKnnSearch(index, dataset, search_param, recall, true);
-                }
-                {
-                    auto search_param = fmt::format(fixtures::search_param_tmp, 0.5, false);
-                    TestIndex::TestKnnSearch(index, dataset, search_param, recall, true);
-                }
-                {
-                    auto search_param = fmt::format(fixtures::search_param_tmp, 100, false);
+                float factors[4]{4, 0.5, -2.0F, 100};
+                for (int i = 0; i < 4; i++) {
+                    auto search_param = fmt::format(search_param_template, factors[i], false);
                     TestIndex::TestKnnSearch(index, dataset, search_param, recall, true);
                 }
                 vsag::Options::Instance().set_block_size_limit(origin_size);
@@ -595,7 +588,7 @@ TestHGraphFactor(const fixtures::HGraphTestIndexPtr& test_index,
 TEST_CASE("HGraph Factor Test", "[ft][hgraph][pr]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(true);
-    TestHGraphBuildAndContinueAdd(test_index, resource);
+    TestHGraphFactor(test_index, resource);
 }
 
 void

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -540,6 +540,65 @@ TEST_CASE("(Daily) HGraph Build & ContinueAdd Test", "[ft][hgraph][daily]") {
     TestHGraphBuildAndContinueAdd(test_index, resource);
 }
 
+
+static void
+TestHGraphFactor(const fixtures::HGraphTestIndexPtr& test_index,
+                              const fixtures::HGraphResourcePtr& resource) {
+    using namespace fixtures;
+    auto origin_size = vsag::Options::Instance().block_size_limit();
+    auto size = GENERATE(1024 * 1024 * 2);
+
+    constexpr static const char* search_param_template = R"(
+        {{
+            "hgraph": {{
+                "ef_search": 200,
+                "factor": {}
+            }}
+        }})";
+    for (auto metric_type : resource->metric_types) {
+        for (auto dim : resource->dims) {
+            for (auto& [base_quantization_str, recall] : resource->test_cases) {
+                INFO(fmt::format("metric_type: {}, dim: {}, base_quantization_str: {}, recall: {}",
+                                 metric_type,
+                                 dim,
+                                 base_quantization_str,
+                                 recall));
+                if (HGraphTestIndex::IsRaBitQ(base_quantization_str) &&
+                    dim < fixtures::RABITQ_MIN_RACALL_DIM) {
+                    continue;  // Skip invalid RaBitQ configurations
+                }
+                vsag::Options::Instance().set_block_size_limit(size);
+                HGraphTestIndex::HGraphBuildParam build_param(
+                    metric_type, dim, base_quantization_str);
+                auto param = HGraphTestIndex::GenerateHGraphBuildParametersString(build_param);
+                auto index = TestIndex::TestFactory(test_index->name, param, true);
+                auto dataset = HGraphTestIndex::pool.GetDatasetAndCreate(
+                    dim, resource->base_count, metric_type);
+                TestIndex::TestContinueAdd(index, dataset, true);
+                {
+                    auto search_param = fmt::format(fixtures::search_param_tmp, 4, false);
+                    TestIndex::TestKnnSearch(index, dataset, search_param, recall, true);
+                }
+                {
+                    auto search_param = fmt::format(fixtures::search_param_tmp, 0.5, false);
+                    TestIndex::TestKnnSearch(index, dataset, search_param, recall, true);
+                }
+                {
+                    auto search_param = fmt::format(fixtures::search_param_tmp, 100, false);
+                    TestIndex::TestKnnSearch(index, dataset, search_param, recall, true);
+                }
+                vsag::Options::Instance().set_block_size_limit(origin_size);
+            }
+        }
+    }
+}
+
+TEST_CASE("HGraph Factor Test", "[ft][hgraph][pr]") {
+    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
+    auto resource = test_index->GetResource(true);
+    TestHGraphBuildAndContinueAdd(test_index, resource);
+}
+
 void
 TestHGraphTrainAndAddTest(const fixtures::HGraphTestIndexPtr& test_index,
                           const fixtures::HGraphResourcePtr& resource) {

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -540,10 +540,9 @@ TEST_CASE("(Daily) HGraph Build & ContinueAdd Test", "[ft][hgraph][daily]") {
     TestHGraphBuildAndContinueAdd(test_index, resource);
 }
 
-
 static void
 TestHGraphFactor(const fixtures::HGraphTestIndexPtr& test_index,
-                              const fixtures::HGraphResourcePtr& resource) {
+                 const fixtures::HGraphResourcePtr& resource) {
     using namespace fixtures;
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);


### PR DESCRIPTION
## Summary by Sourcery

Introduce configurable top-k expansion factor for HGraph and IVF searches, standardize the parameter key, and update amplification factor.

New Features:
- Add topk_factor field to HGraphSearchParameters and IVFSearchParameters and populate it from JSON
- Apply topk_factor to cap the search_param.topk value during HGraph search

Enhancements:
- Rename IVF_SEARCH_PARAM_FACTOR constant to SEARCH_PARAM_FACTOR and update default key mappings
- Increase AMPLIFICATION_FACTOR from 10 to 100