### PR TITLE
tests: speed up functests by reduce dim upperbound

### DIFF
--- a/tests/fixtures/fixtures.cpp
+++ b/tests/fixtures/fixtures.cpp
@@ -31,7 +31,7 @@ namespace fixtures {
 const int RABITQ_MIN_RACALL_DIM = 960;
 
 std::vector<int>
-get_common_used_dims(uint64_t count, int seed) {
+get_common_used_dims(uint64_t count, int seed, int limited_dim) {
     const std::vector<int> dims = {
         7,    8,   9,    // generic (dim < 32)
         32,   33,  48,   // sse(32) + generic(dim < 16)
@@ -46,6 +46,20 @@ get_common_used_dims(uint64_t count, int seed) {
         1024, 1536};     // common used dims
     if (count == -1 || count >= dims.size()) {
         return dims;
+    }
+    if (limited_dim > 0) {
+        // find dim less than or equal to limited_dim (binary search)
+        auto it = std::upper_bound(dims.begin(), dims.end(), limited_dim);
+        if (it != dims.begin()) {
+            std::vector<int> result(dims.begin(), it);
+            if (result.size() < count) {
+                return result;
+            } else {
+                std::shuffle(result.begin(), result.end(), std::mt19937(seed));
+                result.resize(count);
+                return result;
+            }
+        }
     }
     std::vector<int> result(dims.begin(), dims.end());
     std::shuffle(result.begin(), result.end(), std::mt19937(seed));

--- a/tests/fixtures/fixtures.h
+++ b/tests/fixtures/fixtures.h
@@ -32,7 +32,7 @@ namespace fixtures {
 extern const int RABITQ_MIN_RACALL_DIM;
 
 std::vector<int>
-get_common_used_dims(uint64_t count = -1, int seed = 369);
+get_common_used_dims(uint64_t count = -1, int seed = 369, int limited_dim = -1);
 
 template <typename T>
 T*

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -120,8 +120,8 @@ HGraphResourcePtr
 HGraphTestIndex::GetResource(bool sample) {
     auto resource = std::make_shared<HGraphTestResource>();
     if (sample) {
-        resource->dims = fixtures::get_common_used_dims(1, RandomValue(0, 999));
-        resource->test_cases = fixtures::RandomSelect(HGraphTestIndex::all_test_cases, 3);
+        resource->dims = fixtures::get_common_used_dims(1, RandomValue(0, 999), 257);
+        resource->test_cases = fixtures::RandomSelect(HGraphTestIndex::all_test_cases, 2);
         resource->metric_types = fixtures::RandomSelect<std::string>({"ip", "l2", "cosine"}, 1);
         resource->base_count = HGraphTestIndex::base_count;
     } else {

--- a/tests/test_ivf.cpp
+++ b/tests/test_ivf.cpp
@@ -94,7 +94,7 @@ IVFResourcePtr
 IVFTestIndex::GetResource(bool sample) {
     auto resource = std::make_shared<IVFTestResource>();
     if (sample) {
-        resource->dims = fixtures::get_common_used_dims(1, RandomValue(0, 999));
+        resource->dims = fixtures::get_common_used_dims(1, RandomValue(0, 999), 257);
         resource->test_cases = fixtures::RandomSelect(IVFTestIndex::all_test_cases, 3);
         resource->metric_types = fixtures::RandomSelect<std::string>({"ip", "l2", "cosine"}, 1);
         resource->train_types = fixtures::RandomSelect<std::string>({"kmeans", "random"}, 1);


### PR DESCRIPTION
## Summary by Sourcery

Introduce a dimension upper bound and lower sample sizes in functional tests to decrease execution time

Enhancements:
- Add an optional limited_dim parameter to get_common_used_dims to cap the maximum dimension
- Update HGraph and IVF test fixtures to pass limited_dim=257 when sampling dimensions
- Reduce the number of randomly selected test cases in HGraph and IVF tests to speed up execution