### PR TITLE
fix(hgraph): fix recall issues in HGraph merge

### DIFF
--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -1763,6 +1763,12 @@ HGraph::Merge(const std::vector<MergeUnit>& merge_units) {
 
     auto build_data = (use_reorder_ and not build_by_base_) ? this->high_precise_codes_
                                                             : this->basic_flatten_codes_;
+    for (InnerIdType inner_id = 0; inner_id < this->total_count_; ++inner_id) {
+        Vector<InnerIdType> neighbors(this->allocator_);
+        this->bottom_graph_->GetNeighbors(inner_id, neighbors);
+        neighbors.resize(neighbors.size() / 2);
+        this->bottom_graph_->InsertNeighborsById(inner_id, neighbors);
+    }
     {
         odescent_param_->max_degree = bottom_graph_->MaximumDegree();
         ODescent odescent_builder(odescent_param_, build_data, allocator_, this->build_pool_.get());


### PR DESCRIPTION
close #1188

## Summary by Sourcery

Bug Fixes:
- Truncate bottom_graph neighbor lists to half their size and reinsert them for each node before odescent build