### PR TITLE
feat(sparse): improve performance of batch distances calculation 

### DIFF
--- a/src/algorithm/sindi/sindi.cpp
+++ b/src/algorithm/sindi/sindi.cpp
@@ -416,7 +416,7 @@ SINDI::CalDistanceById(const DatasetPtr& query, const int64_t* ids, int64_t coun
     for (auto i = 0; i < count; i++) {
         valid_ids[ids[i]] = i;
     }
-    auto filter = [valid_ids](int64_t id) -> bool { return valid_ids.count(id) != 0; };
+    auto filter = [&valid_ids](int64_t id) -> bool { return valid_ids.count(id) != 0; };
     auto filter_ptr = std::make_shared<WhiteListFilter>(filter);
 
     // search

--- a/src/algorithm/sindi/sindi.cpp
+++ b/src/algorithm/sindi/sindi.cpp
@@ -408,7 +408,7 @@ SINDI::CalDistanceById(const DatasetPtr& query, const int64_t* ids, int64_t coun
     auto result = Dataset::Make();
     result->Owner(true, allocator_);
     auto* distances = (float*)allocator_->Allocate(sizeof(float) * count);
-    std::fill_n(distances, count, -1.0f);
+    std::fill_n(distances, count, -1.0F);
     result->Distances(distances);
 
     // assume count is small, otherwise we should use bitmap to construct filter function

--- a/src/algorithm/sindi/sindi.cpp
+++ b/src/algorithm/sindi/sindi.cpp
@@ -408,6 +408,7 @@ SINDI::CalDistanceById(const DatasetPtr& query, const int64_t* ids, int64_t coun
     auto result = Dataset::Make();
     result->Owner(true, allocator_);
     auto* distances = (float*)allocator_->Allocate(sizeof(float) * count);
+    std::fill_n(distances, count, -1.0f);
     result->Distances(distances);
 
     // assume count is small, otherwise we should use bitmap to construct filter function
@@ -419,7 +420,7 @@ SINDI::CalDistanceById(const DatasetPtr& query, const int64_t* ids, int64_t coun
     auto filter_ptr = std::make_shared<WhiteListFilter>(filter);
 
     // search
-    auto search_param_fmt = R"(
+    const auto* search_param_fmt = R"(
     {{
         "sindi": {{
             "query_prune_ratio": 0,
@@ -431,7 +432,7 @@ SINDI::CalDistanceById(const DatasetPtr& query, const int64_t* ids, int64_t coun
         this->KnnSearch(query, count, fmt::format(search_param_fmt, count), filter_ptr);
 
     // flush results
-    for (auto i = 0; i < search_res->GetNumElements(); i++) {
+    for (auto i = 0; i < search_res->GetDim(); i++) {
         float dist = search_res->GetDistances()[i];
         int64_t id = search_res->GetIds()[i];
         distances[valid_ids[id]] = dist;

--- a/src/algorithm/sindi/sindi.cpp
+++ b/src/algorithm/sindi/sindi.cpp
@@ -397,6 +397,49 @@ SINDI::CalcDistanceById(const DatasetPtr& vector, int64_t id) const {
     return term_list->CalcDistanceByInnerId(computer, inner_id - window_start_id);
 }
 
+DatasetPtr
+SINDI::CalDistanceById(const DatasetPtr& query, const int64_t* ids, int64_t count) const {
+    if (use_reorder_) {
+        std::shared_lock rlock(this->global_mutex_);
+        return this->rerank_flat_index_->CalDistanceById(query, ids, count);
+    }
+
+    // prepare result
+    auto result = Dataset::Make();
+    result->Owner(true, allocator_);
+    auto* distances = (float*)allocator_->Allocate(sizeof(float) * count);
+    result->Distances(distances);
+
+    // assume count is small, otherwise we should use bitmap to construct filter function
+    std::unordered_map<int64_t, uint32_t> valid_ids;
+    for (auto i = 0; i < count; i++) {
+        valid_ids[ids[i]] = i;
+    }
+    auto filter = [valid_ids](int64_t id) -> bool { return valid_ids.count(id) != 0; };
+    auto filter_ptr = std::make_shared<WhiteListFilter>(filter);
+
+    // search
+    auto search_param_fmt = R"(
+    {{
+        "sindi": {{
+            "query_prune_ratio": 0,
+            "n_candidate": {}
+        }}
+    }}
+    )";
+    auto search_res =
+        this->KnnSearch(query, count, fmt::format(search_param_fmt, count), filter_ptr);
+
+    // flush results
+    for (auto i = 0; i < search_res->GetNumElements(); i++) {
+        float dist = search_res->GetDistances()[i];
+        int64_t id = search_res->GetIds()[i];
+        distances[valid_ids[id]] = dist;
+    }
+
+    return result;
+}
+
 void
 SINDI::SetImmutable() {
     std::scoped_lock wlock(this->global_mutex_);

--- a/src/algorithm/sindi/sindi.h
+++ b/src/algorithm/sindi/sindi.h
@@ -93,6 +93,9 @@ public:
     float
     CalcDistanceById(const DatasetPtr& vector, int64_t id) const override;
 
+    DatasetPtr
+    CalDistanceById(const DatasetPtr& query, const int64_t* ids, int64_t count) const override;
+
     bool
     UpdateId(int64_t old_id, int64_t new_id) override;
 

--- a/src/algorithm/sparse_index.cpp
+++ b/src/algorithm/sparse_index.cpp
@@ -253,8 +253,12 @@ SparseIndex::CalDistanceById(const DatasetPtr& query, const int64_t* ids, int64_
 
     // cal distances one by one
     for (int64_t i = 0; i < count; i++) {
-        uint32_t inner_id = this->label_table_->GetIdByLabel(ids[i]);
-        distances[i] = CalDistanceByIdUnsafe(sorted_ids, sorted_vals, inner_id);
+        try {
+            uint32_t inner_id = this->label_table_->GetIdByLabel(ids[i]);
+            distances[i] = CalDistanceByIdUnsafe(sorted_ids, sorted_vals, inner_id);
+        } catch (std::runtime_error& e) {
+            distances[i] = -1;
+        }
     }
     return result;
 }

--- a/src/algorithm/sparse_index.h
+++ b/src/algorithm/sparse_index.h
@@ -39,10 +39,7 @@ public:
     Add(const DatasetPtr& base) override;
 
     DatasetPtr
-    CalDistanceById(const float* query, const int64_t* ids, int64_t count) const override {
-        throw VsagException(vsag::ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                            "no support CalDistanceById in " + GetName());
-    }
+    CalDistanceById(const DatasetPtr& query, const int64_t* ids, int64_t count) const override;
 
     float
     CalcDistanceById(const DatasetPtr& vector, int64_t id) const override;

--- a/tests/test_index.cpp
+++ b/tests/test_index.cpp
@@ -850,13 +850,13 @@ TestIndex::TestBatchCalcDistanceById(const IndexPtr& index,
         }
     }
     SECTION("test non-existing id") {
-        queries->NumElements(1);
         int64_t test_num = 10;
         std::vector<int64_t> no_exist_ids(test_num);
         for (int i = 0; i < test_num; ++i) {
             no_exist_ids[i] = -i - 1;
         }
         tl::expected<DatasetPtr, vsag::Error> result;
+        queries->NumElements(1);
         if (is_sparse) {
             result = index->CalDistanceById(queries, no_exist_ids.data(), test_num);
         } else {
@@ -867,6 +867,7 @@ TestIndex::TestBatchCalcDistanceById(const IndexPtr& index,
             fixtures::dist_t dist = result.value()->GetDistances()[i];
             REQUIRE(dist == -1);
         }
+        queries->NumElements(query_count);
     }
 }
 

--- a/tests/test_index.cpp
+++ b/tests/test_index.cpp
@@ -850,6 +850,7 @@ TestIndex::TestBatchCalcDistanceById(const IndexPtr& index,
         }
     }
     SECTION("test non-existing id") {
+        queries->NumElements(1);
         int64_t test_num = 10;
         std::vector<int64_t> no_exist_ids(test_num);
         for (int i = 0; i < test_num; ++i) {


### PR DESCRIPTION
close #1191

## Summary by Sourcery

Introduce batch distance calculation methods for SINDI and SparseIndex, along with performance optimizations for sparse queries and filtering.

New Features:
- Add CalDistanceById for SINDI to compute distances for multiple IDs in a single call
- Add CalDistanceById for SparseIndex to compute batch distances efficiently

Enhancements:
- Optimize SparseIndex by sorting the sparse query vector only once per batch
- Use white-list filtering and reordering lock in SINDI to accelerate batch distance calculations