### PR TITLE
refactor(attr): use parameter to create attribute datacell

### DIFF
--- a/src/algorithm/brute_force.cpp
+++ b/src/algorithm/brute_force.cpp
@@ -44,11 +44,6 @@ BruteForce::BruteForce(const BruteForceParameterPtr& param, const IndexCommonPar
         this->build_pool_ = SafeThreadPool::FactoryDefaultThreadPool();
     }
     this->use_attribute_filter_ = param->use_attribute_filter;
-    if (this->use_attribute_filter_) {
-        this->attr_filter_index_ =
-            AttributeInvertedInterface::MakeInstance(allocator_, true /*have_bucket*/);
-        this->has_attribute_ = true;
-    }
     this->has_raw_vector_ = true;
 }
 
@@ -425,7 +420,10 @@ static const std::string BRUTE_FORCE_PARAMS_TEMPLATE =
             "nbits": 8,
             "{HOLD_MOLDS}": false
         },
-        "{USE_ATTRIBUTE_FILTER_KEY}": false
+        "{USE_ATTRIBUTE_FILTER_KEY}": false,
+        "{ATTR_PARAMS_KEY}": {
+            "{HAS_BUCKETS_KEY}": true
+        }
     })";
 
 ParamPtr

--- a/src/algorithm/brute_force.h
+++ b/src/algorithm/brute_force.h
@@ -140,7 +140,5 @@ private:
     std::atomic<InnerIdType> max_capacity_{0};
 
     static constexpr uint64_t DEFAULT_RESIZE_BIT = 10;
-
-    AttrInvertedInterfacePtr attr_filter_index_{nullptr};
 };
 }  // namespace vsag

--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -96,10 +96,6 @@ HGraph::HGraph(const HGraphParameterPtr& hgraph_param, const vsag::IndexCommonPa
     if (use_elp_optimizer_) {
         optimizer_ = std::make_shared<Optimizer<BasicSearcher>>(common_param);
     }
-    if (this->use_attribute_filter_) {
-        this->attr_filter_index_ =
-            AttributeInvertedInterface::MakeInstance(allocator_, false /*have_bucket*/);
-    }
     check_and_init_raw_vector(hgraph_param->raw_vector_param, common_param);
 }
 void
@@ -1269,6 +1265,9 @@ static const std::string HGRAPH_PARAMS_TEMPLATE =
                 "{IO_TYPE_KEY}": "{IO_TYPE_VALUE_BLOCK_MEMORY_IO}",
                 "{IO_FILE_PATH}": "{DEFAULT_FILE_PATH_VALUE}"
             }
+        },
+        "{ATTR_PARAMS_KEY}": {
+            "{HAS_BUCKETS_KEY}": false
         },
         "{HGRAPH_SUPPORT_DUPLICATE}": false,
         "{HGRAPH_SUPPORT_TOMBSTONE}": false,

--- a/src/algorithm/hgraph.h
+++ b/src/algorithm/hgraph.h
@@ -366,8 +366,6 @@ private:
 
     std::shared_ptr<Optimizer<BasicSearcher>> optimizer_;
 
-    AttrInvertedInterfacePtr attr_filter_index_{nullptr};
-
     bool create_new_raw_vector_{false};
     FlattenInterfacePtr raw_vector_{nullptr};
 };

--- a/src/algorithm/inner_index_interface.cpp
+++ b/src/algorithm/inner_index_interface.cpp
@@ -55,6 +55,12 @@ InnerIndexInterface::InnerIndexInterface(const InnerIndexParameterPtr& index_par
         this->build_pool_ = SafeThreadPool::FactoryDefaultThreadPool();
         this->build_pool_->SetPoolSize(build_thread_count_);
     }
+
+    if (this->use_attribute_filter_) {
+        this->attr_filter_index_ = AttributeInvertedInterface::MakeInstance(
+            allocator_, index_param->attr_inverted_interface_param);
+        this->has_attribute_ = true;
+    }
 }
 
 InnerIndexInterface::~InnerIndexInterface() = default;

--- a/src/algorithm/inner_index_interface.h
+++ b/src/algorithm/inner_index_interface.h
@@ -19,6 +19,7 @@
 #include <vector>
 
 #include "data_type.h"
+#include "datacell/attribute_inverted_interface.h"
 #include "datacell/extra_info_interface.h"
 #include "dataset_impl.h"
 #include "inner_index_parameter.h"
@@ -413,6 +414,8 @@ protected:
     uint64_t build_thread_count_{100};
 
     std::shared_ptr<SafeThreadPool> build_pool_{nullptr};
+
+    AttrInvertedInterfacePtr attr_filter_index_{nullptr};
 };
 
 }  // namespace vsag

--- a/src/algorithm/inner_index_parameter.cpp
+++ b/src/algorithm/inner_index_parameter.cpp
@@ -16,6 +16,7 @@
 #include "inner_index_parameter.h"
 
 #include "common.h"
+#include "datacell/attribute_inverted_interface_parameter.h"
 #include "datacell/extra_info_datacell_parameter.h"
 #include "datacell/flatten_datacell_parameter.h"
 #include "impl/logger/logger.h"
@@ -32,6 +33,14 @@ InnerIndexParameter::FromJson(const JsonType& json) {
 
     if (json.Contains(USE_ATTRIBUTE_FILTER_KEY)) {
         this->use_attribute_filter = json[USE_ATTRIBUTE_FILTER_KEY].GetBool();
+    }
+
+    if (this->use_attribute_filter) {
+        this->attr_inverted_interface_param =
+            std::make_shared<AttributeInvertedInterfaceParameter>();
+        if (json.Contains(ATTR_PARAMS_KEY)) {
+            this->attr_inverted_interface_param->FromJson(json[ATTR_PARAMS_KEY]);
+        }
     }
 
     if (json.Contains(BUILD_THREAD_COUNT_KEY)) {
@@ -74,6 +83,9 @@ InnerIndexParameter::ToJson() const {
     }
     if (this->extra_info_param) {
         json[EXTRA_INFO_KEY].SetJson(this->extra_info_param->ToJson());
+    }
+    if (this->use_attribute_filter) {
+        json[ATTR_PARAMS_KEY].SetJson(this->attr_inverted_interface_param->ToJson());
     }
     auto str = json.Dump(4);
     return json;

--- a/src/algorithm/inner_index_parameter.h
+++ b/src/algorithm/inner_index_parameter.h
@@ -23,6 +23,7 @@ namespace vsag {
 DEFINE_POINTER(InnerIndexParameter);
 DEFINE_POINTER2(ExtraInfoDataCellParam, ExtraInfoDataCellParameter);
 DEFINE_POINTER2(FlattenInterfaceParam, FlattenInterfaceParameter);
+DEFINE_POINTER2(AttributeInvertedInterfaceParam, AttributeInvertedInterfaceParameter);
 
 class InnerIndexParameter : public Parameter {
 public:
@@ -51,5 +52,7 @@ public:
     FlattenInterfaceParamPtr raw_vector_param{nullptr};
 
     ExtraInfoDataCellParamPtr extra_info_param{nullptr};
+
+    AttributeInvertedInterfaceParamPtr attr_inverted_interface_param{nullptr};
 };
 }  // namespace vsag

--- a/src/algorithm/ivf.cpp
+++ b/src/algorithm/ivf.cpp
@@ -76,6 +76,9 @@ static constexpr const char* IVF_PARAMS_TEMPLATE =
                 "{QUANTIZATION_TYPE_KEY}": "{QUANTIZATION_TYPE_VALUE_FP32}",
                 "{PRODUCT_QUANTIZATION_DIM}": 0
             }
+        },
+        "{ATTR_PARAMS_KEY}": {
+            "{HAS_BUCKETS_KEY}": true
         }
     })";
 
@@ -238,11 +241,6 @@ IVF::IVF(const IVFParameterPtr& param, const IndexCommonParam& common_param)
             FlattenInterface::MakeInstance(param->precise_codes_param, common_param);
     }
     this->use_residual_ = param->bucket_param->use_residual_;
-    if (this->use_attribute_filter_) {
-        this->attr_filter_index_ =
-            AttributeInvertedInterface::MakeInstance(allocator_, true /*have_bucket*/);
-        this->has_attribute_ = true;
-    }
 
     this->thread_pool_ = common_param.thread_pool_;
     if (param->build_thread_count > 1 and this->thread_pool_ == nullptr) {

--- a/src/algorithm/ivf.h
+++ b/src/algorithm/ivf.h
@@ -169,8 +169,6 @@ private:
 
     FlattenInterfacePtr reorder_codes_{nullptr};
 
-    AttrInvertedInterfacePtr attr_filter_index_{nullptr};
-
     std::shared_ptr<SafeThreadPool> thread_pool_{nullptr};
 
     Vector<uint64_t> location_map_;

--- a/src/datacell/attribute_inverted_interface.cpp
+++ b/src/datacell/attribute_inverted_interface.cpp
@@ -27,4 +27,14 @@ AttributeInvertedInterface::MakeInstance(Allocator* allocator, bool have_bucket)
     return std::make_shared<AttributeBucketInvertedDataCell>(allocator,
                                                              ComputableBitsetType::FastBitset);
 }
+
+AttrInvertedInterfacePtr
+AttributeInvertedInterface::MakeInstance(Allocator* allocator,
+                                         const AttributeInvertedInterfaceParamPtr& param) {
+    if (param == nullptr) {
+        return MakeInstance(allocator, false);
+    }
+    return MakeInstance(allocator, param->has_buckets_);
+}
+
 }  // namespace vsag

--- a/src/datacell/attribute_inverted_interface.h
+++ b/src/datacell/attribute_inverted_interface.h
@@ -19,6 +19,7 @@
 
 #include "attr/attr_type_schema.h"
 #include "attr/multi_bitset_manager.h"
+#include "attribute_inverted_interface_parameter.h"
 #include "storage/stream_reader.h"
 #include "storage/stream_writer.h"
 #include "typing.h"
@@ -32,6 +33,9 @@ class AttributeInvertedInterface {
 public:
     static AttrInvertedInterfacePtr
     MakeInstance(Allocator* allocator, bool have_bucket = false);
+
+    static AttrInvertedInterfacePtr
+    MakeInstance(Allocator* allocator, const AttributeInvertedInterfaceParamPtr& param);
 
 public:
     AttributeInvertedInterface(Allocator* allocator, ComputableBitsetType bitset_type)

--- a/src/datacell/attribute_inverted_interface_parameter.cpp
+++ b/src/datacell/attribute_inverted_interface_parameter.cpp
@@ -1,0 +1,44 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "attribute_inverted_interface_parameter.h"
+
+#include "inner_string_params.h"
+
+namespace vsag {
+
+void
+AttributeInvertedInterfaceParameter::FromJson(const JsonType& json) {
+    if (json.Contains(ATTR_HAS_BUCKETS_KEY)) {
+        this->has_buckets_ = json[ATTR_HAS_BUCKETS_KEY].GetBool();
+    }
+}
+
+JsonType
+AttributeInvertedInterfaceParameter::ToJson() const {
+    JsonType json;
+    json[ATTR_HAS_BUCKETS_KEY].SetBool(this->has_buckets_);
+    return json;
+}
+bool
+AttributeInvertedInterfaceParameter::CheckCompatibility(const ParamPtr& other) const {
+    auto other_param = std::dynamic_pointer_cast<AttributeInvertedInterfaceParameter>(other);
+    if (other_param == nullptr) {
+        return false;
+    }
+    return has_buckets_ == other_param->has_buckets_;
+}
+
+}  // namespace vsag

--- a/src/datacell/attribute_inverted_interface_parameter.h
+++ b/src/datacell/attribute_inverted_interface_parameter.h
@@ -1,0 +1,45 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "io/io_parameter.h"
+#include "parameter.h"
+#include "quantization/quantizer_parameter.h"
+
+namespace vsag {
+
+class AttributeInvertedInterfaceParameter : public Parameter {
+public:
+    explicit AttributeInvertedInterfaceParameter() = default;
+
+    ~AttributeInvertedInterfaceParameter() override = default;
+
+    void
+    FromJson(const JsonType& json) override;
+
+    JsonType
+    ToJson() const override;
+
+    bool
+    CheckCompatibility(const ParamPtr& other) const override;
+
+public:
+    bool has_buckets_{false};
+};
+
+using AttributeInvertedInterfaceParamPtr = std::shared_ptr<AttributeInvertedInterfaceParameter>;
+
+}  // namespace vsag

--- a/src/datacell/attribute_inverted_interface_parameter_test.cpp
+++ b/src/datacell/attribute_inverted_interface_parameter_test.cpp
@@ -1,0 +1,64 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "attribute_inverted_interface_parameter.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "parameter_test.h"
+
+using namespace vsag;
+
+TEST_CASE("AttributeInvertedInterfaceParameter ToJson Test",
+          "[ut][AttributeInvertedInterfaceParameter]") {
+    std::string param_str = R"(
+    {
+        "has_buckets": true
+    })";
+    auto param = std::make_shared<AttributeInvertedInterfaceParameter>();
+    auto json = JsonType::Parse(param_str);
+    param->FromJson(json);
+    REQUIRE(param->has_buckets_ == true);
+    ParameterTest::TestToJson(param);
+
+    param_str = R"(
+    {
+        "has_buckets": false
+    })";
+    json = JsonType::Parse(param_str);
+    param->FromJson(json);
+    REQUIRE(param->has_buckets_ == false);
+    ParameterTest::TestToJson(param);
+}
+
+TEST_CASE("AttributeInvertedInterfaceParameter CheckCompatibility Test",
+          "[ut][AttributeInvertedInterfaceParameter]") {
+    std::string param_str = R"(
+    {
+        "has_buckets": true
+    })";
+    auto param = std::make_shared<AttributeInvertedInterfaceParameter>();
+    auto json = JsonType::Parse(param_str);
+    param->FromJson(json);
+
+    std::string other_param_str = R"(
+    {
+        "has_buckets": false
+    })";
+    auto other_json = JsonType::Parse(other_param_str);
+    auto other_param = std::make_shared<AttributeInvertedInterfaceParameter>();
+    other_param->FromJson(other_json);
+    REQUIRE(param->CheckCompatibility(other_param) == false);
+}

--- a/src/inner_string_params.h
+++ b/src/inner_string_params.h
@@ -34,6 +34,8 @@ const char* const BUILD_THREAD_COUNT_KEY = "build_thread_count";
 const char* const PRECISE_CODES_KEY = "precise_codes";
 const char* const STORE_RAW_VECTOR_KEY = "store_raw_vector";
 const char* const RAW_VECTOR_KEY = "raw_vector";
+const char* const ATTR_HAS_BUCKETS_KEY = "has_buckets";
+const char* const ATTR_PARAMS_KEY = "attr_params";
 
 // Parameter key for hgraph
 const char* const HGRAPH_USE_ELP_OPTIMIZER_KEY = "use_elp_optimizer";
@@ -227,6 +229,8 @@ const std::unordered_map<std::string, std::string> DEFAULT_MAP = {
     {"IVF_PARTITION_STRATEGY_TYPE_GNO_IMI", IVF_PARTITION_STRATEGY_TYPE_GNO_IMI},
     {"STORE_RAW_VECTOR_KEY", STORE_RAW_VECTOR_KEY},
     {"RAW_VECTOR_KEY", RAW_VECTOR_KEY},
+    {"ATTR_HAS_BUCKETS_KEY", ATTR_HAS_BUCKETS_KEY},
+    {"ATTR_PARAMS_KEY", ATTR_PARAMS_KEY},
 };
 
 }  // namespace vsag


### PR DESCRIPTION
## Summary by Sourcery

Enable configurable attribute inverted interface by introducing a dedicated parameter class and refactoring index algorithms to initialize attribute filters based on JSON parameters instead of hard-coded logic.

New Features:
- Introduce AttributeInvertedInterfaceParameter for JSON-configurable attribute filter settings
- Add ATTR_PARAMS_KEY and ATTR_HAS_BUCKETS_KEY to inner string parameters and include them in default algorithm templates

Enhancements:
- Refactor InnerIndexParameter and InnerIndexInterface to hold and apply the new attribute interface parameter
- Unify attribute filter initialization in the base InnerIndexInterface and remove redundant logic from BruteForce, IVF, and HGraph implementations
- Add MakeInstance overload in AttributeInvertedInterface to accept AttributeInvertedInterfaceParameter

Tests:
- Add unit tests for AttributeInvertedInterfaceParameter JSON serialization, deserialization, and compatibility checks