### PR TITLE
tests: add serialize check on export model test

### DIFF
--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -1519,6 +1519,7 @@ TestHGraphExportModel(const fixtures::HGraphTestIndexPtr& test_index,
                 build_param.extra_info_size = extra_info_size;
                 auto param = HGraphTestIndex::GenerateHGraphBuildParametersString(build_param);
                 auto index = TestIndex::TestFactory(test_index->name, param, true);
+                auto index2 = TestIndex::TestFactory(test_index->name, param, true);
                 auto dataset = HGraphTestIndex::pool.GetDatasetAndCreate(dim,
                                                                          resource->base_count,
                                                                          metric_type,
@@ -1526,7 +1527,7 @@ TestHGraphExportModel(const fixtures::HGraphTestIndexPtr& test_index,
                                                                          0.8 /*valid_ratio*/,
                                                                          extra_info_size);
                 TestIndex::TestBuildIndex(index, dataset, true);
-                TestIndex::TestExportModel(index, dataset, search_param);
+                TestIndex::TestExportModel(index, index2, dataset, search_param);
                 vsag::Options::Instance().set_block_size_limit(origin_size);
             }
         }

--- a/tests/test_index.cpp
+++ b/tests/test_index.cpp
@@ -1796,6 +1796,7 @@ TestIndex::TestClone(const TestIndex::IndexPtr& index,
 
 void
 TestIndex::TestExportModel(const TestIndex::IndexPtr& index,
+                           const TestIndex::IndexPtr& index2,
                            const TestDatasetPtr& dataset,
                            const std::string& search_param) {
     if (not index->CheckFeature(vsag::SUPPORT_EXPORT_MODEL)) {
@@ -1803,7 +1804,9 @@ TestIndex::TestExportModel(const TestIndex::IndexPtr& index,
     }
     auto index_model_result = index->ExportModel();
     REQUIRE(index_model_result.has_value() == true);
-    auto& index_model = index_model_result.value();
+    auto index_model = index_model_result.value();
+    fixtures::test_serializion_file(*index_model, *index2, "export_model_test");
+    index_model = index2;
     tl::expected<std::vector<int64_t>, vsag::Error> add_index;
     if (index->CheckFeature(vsag::SUPPORT_ADD_AFTER_BUILD)) {
         add_index = index_model->Add(dataset->base_);

--- a/tests/test_index.h
+++ b/tests/test_index.h
@@ -275,6 +275,7 @@ public:
 
     static void
     TestExportModel(const IndexPtr& index,
+                    const IndexPtr& index2,
                     const TestDatasetPtr& dataset,
                     const std::string& search_param);
 

--- a/tests/test_ivf.cpp
+++ b/tests/test_ivf.cpp
@@ -828,11 +828,12 @@ TestIVFExportModel(const fixtures::IVFResourcePtr& resource) {
                     auto param = IVFTestIndex::GenerateIVFBuildParametersString(
                         metric_type, dim, base_quantization_str, 300, train_type);
                     auto index = IVFTestIndex::TestFactory(IVFTestIndex::name, param, true);
+                    auto index2 = IVFTestIndex::TestFactory(IVFTestIndex::name, param, true);
                     auto dataset = IVFTestIndex::pool.GetDatasetAndCreate(
                         dim, resource->base_count, metric_type);
 
                     IVFTestIndex::TestBuildIndex(index, dataset, true);
-                    IVFTestIndex::TestExportModel(index, dataset, search_param);
+                    IVFTestIndex::TestExportModel(index, index2, dataset, search_param);
 
                     vsag::Options::Instance().set_block_size_limit(origin_size);
                 }


### PR DESCRIPTION
## Summary by Sourcery

Enhance export model tests by validating that exported models can be serialized and deserialized into a new index instance.

Enhancements:
- Add round-trip serialization check to export model tests

Tests:
- Extend TestExportModel signature and invocations to include a second index instance
- Instantiate a second index (index2) in HGraph and IVF export model tests for serialization validation