### PR TITLE
tests: relax recall threshold to fit random dataset

### DIFF
--- a/tests/test_index.h
+++ b/tests/test_index.h
@@ -301,7 +301,7 @@ public:
     static void
     TestIndexStatus(const IndexPtr& index);
 
-    constexpr static float RECALL_THRESHOLD = 0.95;
+    constexpr static float RECALL_THRESHOLD = 0.85F;
 };
 
 }  // namespace fixtures


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Lower the RECALL_THRESHOLD constant from 0.95 to 0.85 in TestIndexStatus