### PR TITLE
fix: LabelTable deserialzie error

### DIFF
--- a/src/impl/label_table.h
+++ b/src/impl/label_table.h
@@ -227,6 +227,7 @@ public:
         if (support_tombstone_) {
             StreamReader::ReadObj(reader, deleted_ids_);
         }
+        this->total_count_.store(label_table_.size());
     }
 
     void


### PR DESCRIPTION
fixed: #1206

## Summary by Sourcery

Bug Fixes:
- Update total_count_ to the size of the deserialized label_table_ in StreamReader to resolve deserialization errors in LabelTable.