### PR TITLE
refactor(reader_io): support reader_io omits I/O operations during deserialization

### DIFF
--- a/src/io/async_io.h
+++ b/src/io/async_io.h
@@ -25,6 +25,7 @@ namespace vsag {
 class AsyncIO : public BasicIO<AsyncIO> {
 public:
     static constexpr bool InMemory = false;
+    static constexpr bool SkipDeserialize = false;
 
 public:
     explicit AsyncIO(std::string filename, Allocator* allocator);

--- a/src/io/buffer_io.h
+++ b/src/io/buffer_io.h
@@ -28,6 +28,7 @@ namespace vsag {
 class BufferIO : public BasicIO<BufferIO> {
 public:
     static constexpr bool InMemory = false;
+    static constexpr bool SkipDeserialize = false;
 
 public:
     BufferIO(std::string filename, Allocator* allocator);

--- a/src/io/memory_block_io.h
+++ b/src/io/memory_block_io.h
@@ -24,6 +24,7 @@ class IndexCommonParam;
 class MemoryBlockIO : public BasicIO<MemoryBlockIO> {
 public:
     static constexpr bool InMemory = true;
+    static constexpr bool SkipDeserialize = false;
 
 public:
     explicit MemoryBlockIO(Allocator* allocator, uint64_t block_size);

--- a/src/io/memory_io.h
+++ b/src/io/memory_io.h
@@ -27,6 +27,7 @@ namespace vsag {
 class MemoryIO : public BasicIO<MemoryIO> {
 public:
     static constexpr bool InMemory = true;
+    static constexpr bool SkipDeserialize = false;
 
 public:
     explicit MemoryIO(Allocator* allocator) : BasicIO<MemoryIO>(allocator) {

--- a/src/io/mmap_io.h
+++ b/src/io/mmap_io.h
@@ -26,6 +26,7 @@ class Allocator;
 class MMapIO : public BasicIO<MMapIO> {
 public:
     static constexpr bool InMemory = false;
+    static constexpr bool SkipDeserialize = false;
 
 public:
     MMapIO(std::string filename, Allocator* allocator);

--- a/src/io/reader_io.h
+++ b/src/io/reader_io.h
@@ -24,6 +24,7 @@ namespace vsag {
 class ReaderIO : public BasicIO<ReaderIO> {
 public:
     static constexpr bool InMemory = false;
+    static constexpr bool SkipDeserialize = true;
 
 public:
     explicit ReaderIO(Allocator* allocator) : BasicIO<ReaderIO>(allocator) {


### PR DESCRIPTION
## Summary by Sourcery

Introduce a SkipDeserialize option in BasicIO and its subclasses to allow omitting actual I/O operations during deserialization for ReaderIO, and clean up the QuantizerAdapter implementation by removing unused pragmas, includes, and commented code stubs while adjusting template instantiation placement.

New Features:
- Add a static SkipDeserialize flag to BasicIO and all IO subclasses to enable optional omission of data reads during deserialization
- Configure ReaderIO to set SkipDeserialize=true so it seeks past data instead of reading it

Enhancements:
- Remove outdated OpenMP simd pragmas, unused headers, and commented ComputeDistsBatch4Impl stubs in QuantizerAdapter
- Move the ProductQuantizer template instantiation into the .cpp file for consistency