### PR TITLE
fix(dataset): fix the string deep copy not being properly implemented

### DIFF
--- a/src/dataset_impl.cpp
+++ b/src/dataset_impl.cpp
@@ -153,7 +153,7 @@ DatasetImpl::DeepCopy(Allocator* allocator) const {
     auto* paths = new std::string[num_elements];
     copy_dataset->Paths(paths);
     for (int i = 0; i < num_elements; ++i) {
-        paths[i] = this->GetPaths()[i];
+        paths[i] += this->GetPaths()[i];
     }
 
     if (this->GetAttributeSets() != nullptr) {
@@ -223,12 +223,12 @@ DatasetImpl::Append(const DatasetPtr& other) {
         auto* ptr = const_cast<std::string*>(std::get<const std::string*>(iter->second));
         auto* paths_copy = new std::string[old_num_elements + new_num_elements];
         for (int i = 0; i < old_num_elements; ++i) {
-            paths_copy[i] = ptr[i];
+            paths_copy[i] += ptr[i];
         }
         delete[] ptr;  // Free the old memory if it was allocated with new[]
         ptr = nullptr;
         for (int i = 0; i < new_num_elements; ++i) {
-            paths_copy[old_num_elements + i] = other->GetPaths()[i];
+            paths_copy[old_num_elements + i] += other->GetPaths()[i];
         }
         this->Paths(paths_copy);
     }

--- a/src/dataset_impl_test.cpp
+++ b/src/dataset_impl_test.cpp
@@ -243,6 +243,17 @@ EqualDataset(const vsag::DatasetPtr& data1, const vsag::DatasetPtr& data2) {
     return true;
 }
 
+template <typename T>
+bool
+AreAllPointersDifferent(T* original, T* copy, size_t num_elements) {
+    for (size_t i = 0; i < num_elements; ++i) {
+        if (std::memcmp(original + i, copy + i, sizeof(T)) == 0) {
+            return false;
+        }
+    }
+    return true;
+}
+
 TEST_CASE("Dataset Copy and Append Test", "[ut][Dataset]") {
     std::random_device rd;
     std::mt19937 gen(rd());
@@ -264,15 +275,13 @@ TEST_CASE("Dataset Copy and Append Test", "[ut][Dataset]") {
             use_allocator ? vsag::Engine::CreateDefaultAllocator() : nullptr;
         auto copy = original->DeepCopy(copy_allocator.get());
         REQUIRE(EqualDataset(original, copy));
-        REQUIRE(memcmp(original->GetSparseVectors(),
-                       copy->GetSparseVectors(),
-                       sizeof(vsag::SparseVector) * num_elements) != 0);
-        REQUIRE(memcmp(original->GetAttributeSets(),
-                       copy->GetAttributeSets(),
-                       sizeof(vsag::AttributeSet) * num_elements) != 0);
-        REQUIRE(memcmp(original->GetPaths(),
-                       copy->GetPaths(),
-                       sizeof(std::string) * num_elements) != 0);
+        REQUIRE(AreAllPointersDifferent(
+            original->GetSparseVectors(), copy->GetSparseVectors(), num_elements));
+
+        REQUIRE(AreAllPointersDifferent(
+            original->GetAttributeSets(), copy->GetAttributeSets(), num_elements));
+
+        REQUIRE(AreAllPointersDifferent(original->GetPaths(), copy->GetPaths(), num_elements));
     }
     SECTION("Append") {
         auto copy = original->DeepCopy();


### PR DESCRIPTION
close: #1213

## Summary by Sourcery

Ensure dataset string fields are properly deep-copied by allocating new buffers and update tests to verify unique pointers

Bug Fixes:
- Fix string deep copy in DatasetImpl::DeepCopy and Append to allocate distinct string buffers

Tests:
- Add AreAllPointersDifferent helper and update copy tests to assert distinct pointers for sparse vectors, attribute sets, and paths