### PR TITLE
fix(attribute): fix attribute init with use_bucket

### DIFF
--- a/src/algorithm/brute_force.cpp
+++ b/src/algorithm/brute_force.cpp
@@ -422,7 +422,7 @@ static const std::string BRUTE_FORCE_PARAMS_TEMPLATE =
         },
         "{USE_ATTRIBUTE_FILTER_KEY}": false,
         "{ATTR_PARAMS_KEY}": {
-            "{HAS_BUCKETS_KEY}": true
+            "{ATTR_HAS_BUCKETS_KEY}": true
         }
     })";
 

--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -1268,7 +1268,7 @@ static const std::string HGRAPH_PARAMS_TEMPLATE =
             }
         },
         "{ATTR_PARAMS_KEY}": {
-            "{HAS_BUCKETS_KEY}": false
+            "{ATTR_HAS_BUCKETS_KEY}": false
         },
         "{HGRAPH_SUPPORT_DUPLICATE}": false,
         "{HGRAPH_SUPPORT_TOMBSTONE}": false,

--- a/src/algorithm/ivf.cpp
+++ b/src/algorithm/ivf.cpp
@@ -78,7 +78,7 @@ static constexpr const char* IVF_PARAMS_TEMPLATE =
             }
         },
         "{ATTR_PARAMS_KEY}": {
-            "{HAS_BUCKETS_KEY}": true
+            "{ATTR_HAS_BUCKETS_KEY}": true
         }
     })";
 


### PR DESCRIPTION
fixed: #1215

## Summary by Sourcery

Bug Fixes:
- Replace {HAS_BUCKETS_KEY} with {ATTR_HAS_BUCKETS_KEY} in attribute parameter templates