### PR TITLE
fix(attribute): fix loss json init for bruteforce

### DIFF
--- a/src/algorithm/brute_force_parameter.cpp
+++ b/src/algorithm/brute_force_parameter.cpp
@@ -29,18 +29,15 @@ BruteForceParameter::BruteForceParameter() : flatten_param(nullptr) {
 
 void
 BruteForceParameter::FromJson(const JsonType& json) {
+    InnerIndexParameter::FromJson(json);
     this->flatten_param = std::make_shared<FlattenDataCellParameter>();
     this->flatten_param->FromJson(json);
-    if (json.Contains(USE_ATTRIBUTE_FILTER_KEY)) {
-        this->use_attribute_filter = json[USE_ATTRIBUTE_FILTER_KEY].GetBool();
-    }
 }
 
 JsonType
 BruteForceParameter::ToJson() const {
     auto json = this->flatten_param->ToJson();
     json[TYPE_KEY].SetString(INDEX_BRUTE_FORCE);
-    json[USE_ATTRIBUTE_FILTER_KEY].SetBool(this->use_attribute_filter);
     return json;
 }
 


### PR DESCRIPTION
closed: #1221 

## Summary by Sourcery

Fix JSON initialization of BruteForceParameter by invoking base class deserialization and removing obsolete attribute filter handling

Bug Fixes:
- Call InnerIndexParameter::FromJson in BruteForceParameter::FromJson to properly initialize base parameters
- Remove handling of USE_ATTRIBUTE_FILTER_KEY in both FromJson and ToJson to discard obsolete attribute filter flag