### PR TITLE
fix(hnsw): performance degradation

### DIFF
--- a/src/algorithm/hnswlib/hnswalg.cpp
+++ b/src/algorithm/hnswlib/hnswalg.cpp
@@ -421,20 +421,16 @@ HierarchicalNSW::searchBaseLayer(InnerIdType ep_id, const void* data_point, int 
                 link_data.get();  // = (int *)(linkList0_ + curNodeNum * size_links_per_element0_);
         size_t size = getListCount((linklistsizeint*)data);
         auto* datal = (InnerIdType*)(data + 1);
-#ifdef USE_SSE
         vsag::PrefetchLines((char*)(visited_array + *(data + 1)), 64);
         vsag::PrefetchLines((char*)(visited_array + *(data + 1) + 64), 64);
         vsag::PrefetchLines(getDataByInternalId(*datal), 64);
         vsag::PrefetchLines(getDataByInternalId(*(datal + 1)), 64);
-#endif
 
         for (size_t j = 0; j < size; j++) {
             InnerIdType candidate_id = *(datal + j);
-#ifdef USE_SSE
             size_t pre_l = std::min(j, size - 2);
             vsag::PrefetchLines((char*)(visited_array + *(datal + pre_l + 1)), 64);
             vsag::PrefetchLines(getDataByInternalId(*(datal + pre_l + 1)), 64);
-#endif
             if (visited_array[candidate_id] == visited_array_tag)
                 continue;
             visited_array[candidate_id] = visited_array_tag;
@@ -443,9 +439,7 @@ HierarchicalNSW::searchBaseLayer(InnerIdType ep_id, const void* data_point, int 
             float dist1 = fstdistfunc_(data_point, currObj1, dist_func_param_);
             if (top_candidates.size() < ef_construction_ || lower_bound > dist1) {
                 candidateSet.emplace(-dist1, candidate_id);
-#ifdef USE_SSE
                 vsag::PrefetchLines(getDataByInternalId(candidateSet.top().second), 64);
-#endif
 
                 if (not isMarkedDeleted(candidate_id))
                     top_candidates.emplace(dist1, candidate_id);
@@ -534,12 +528,10 @@ HierarchicalNSW::searchBaseLayerST(InnerIdType ep_id,
         }
 
         auto vector_data_ptr = data_level0_memory_->GetElementPtr((*(data + 1)), offset_data_);
-#ifdef ENABLE_SSE
         vsag::PrefetchLines((char*)(visited_array + *(data + 1)), 64);
         vsag::PrefetchLines((char*)(visited_array + *(data + 1) + 64), 64);
         vsag::PrefetchLines(vector_data_ptr, data_size_);
         vsag::PrefetchLines((char*)(data + 2), 64);
-#endif
 
         for (size_t j = 1; j <= size; j++) {
             int candidate_id = *(data + j);
@@ -547,11 +539,9 @@ HierarchicalNSW::searchBaseLayerST(InnerIdType ep_id,
             if (pre_l + prefetch_jump_code_size_ <= size) {
                 vector_data_ptr = data_level0_memory_->GetElementPtr(
                     (*(data + pre_l + prefetch_jump_code_size_)), offset_data_);
-#ifdef ENABLE_SSE
                 vsag::PrefetchLines(
                     (char*)(visited_array + *(data + pre_l + prefetch_jump_code_size_)), 64);
                 vsag::PrefetchLines(vector_data_ptr, data_size_);
-#endif
             }
             if (visited_array[candidate_id] != visited_array_tag) {
                 visited_array[candidate_id] = visited_array_tag;
@@ -567,9 +557,7 @@ HierarchicalNSW::searchBaseLayerST(InnerIdType ep_id,
                     candidate_set.emplace(-dist, candidate_id);
                     vector_data_ptr = data_level0_memory_->GetElementPtr(candidate_set.top().second,
                                                                          offsetLevel0_);
-#ifdef ENABLE_SSE
                     vsag::PrefetchLines(vector_data_ptr, 64);
-#endif
 
                     if ((!has_deletions || !isMarkedDeleted(candidate_id)) &&
                         ((!is_id_allowed) ||
@@ -646,22 +634,18 @@ HierarchicalNSW::searchBaseLayerST(InnerIdType ep_id,
         }
 
         auto vector_data_ptr = data_level0_memory_->GetElementPtr((*(data + 1)), offset_data_);
-#ifdef USE_SSE
         vsag::PrefetchLines((char*)(visited_array + *(data + 1)), 64);
         vsag::PrefetchLines((char*)(visited_array + *(data + 1) + 64), 64);
         vsag::PrefetchLines(vector_data_ptr, 64);
         vsag::PrefetchLines((char*)(data + 2), 64);
-#endif
 
         for (size_t j = 1; j <= size; j++) {
             int candidate_id = *(data + j);
             size_t pre_l = std::min(j, size - 2);
             vector_data_ptr =
                 data_level0_memory_->GetElementPtr((*(data + pre_l + 1)), offset_data_);
-#ifdef USE_SSE
             vsag::PrefetchLines((char*)(visited_array + *(data + pre_l + 1)), 64);
-            vsag::PrefetchLines(vector_data_ptr, 64);  ////////////
-#endif
+            vsag::PrefetchLines(vector_data_ptr, 64);
             if (visited_array[candidate_id] != visited_array_tag) {
                 visited_array[candidate_id] = visited_array_tag;
                 ++visited_count;
@@ -674,9 +658,7 @@ HierarchicalNSW::searchBaseLayerST(InnerIdType ep_id,
                     candidate_set.emplace(-dist, candidate_id);
                     vector_data_ptr = data_level0_memory_->GetElementPtr(candidate_set.top().second,
                                                                          offsetLevel0_);
-#ifdef USE_SSE
-                    vsag::PrefetchLines(vector_data_ptr, 64);  ////////////////////////
-#endif
+                    vsag::PrefetchLines(vector_data_ptr, 64);
 
                     if ((!has_deletions || !isMarkedDeleted(candidate_id)) &&
                         ((!is_id_allowed) ||


### PR DESCRIPTION
close #1197

## Summary by Sourcery

Bug Fixes:
- Remove SSE-specific compilation guards around vsag::PrefetchLines calls to always apply prefetching in searchBaseLayer and searchBaseLayerST