### PR TITLE
feat(SINDI): add term id limit check

### DIFF
--- a/examples/cpp/109_index_sindi.cpp
+++ b/examples/cpp/109_index_sindi.cpp
@@ -114,6 +114,7 @@ main(int argc, char** argv) {
      * - index_param: Parameters specific to sparse indexing:
      *   - use_reorder: If true, enables full-precision re-ranking of results. This requires storing additional data.
      *     When doc_prune_ratio is 0, use_reorder can be false while still maintaining full-precision results.
+     *   - term_id_limit: Maximum term id (e.g., when term_id_limit = 10, then, term [15: 0.1] in sparse vector is not allowed)
      *   - doc_prune_ratio: Ratio of term pruning in documents (0 = no pruning).
      *   - window_size: Window size for table scanning. Related to L3 cache size; 100000 is an empirically optimal value.
      */
@@ -124,6 +125,7 @@ main(int argc, char** argv) {
         "metric_type": "ip",
         "index_param": {
             "use_reorder": true,
+            "term_id_limit": 1000000,
             "doc_prune_ratio": 0.0,
             "window_size": 100000
         }

--- a/src/algorithm/sindi/sindi.cpp
+++ b/src/algorithm/sindi/sindi.cpp
@@ -32,6 +32,7 @@ SINDI::CheckAndMappingExternalParam(const JsonType& external_param,
 SINDI::SINDI(const SINDIParameterPtr& param, const IndexCommonParam& common_param)
     : InnerIndexInterface(param, common_param),
       use_reorder_(param->use_reorder),
+      term_id_limit_(param->term_id_limit),
       window_size_(param->window_size),
       doc_retain_ratio_(1.0F - param->doc_prune_ratio),
       window_term_list_(common_param.allocator_.get()),
@@ -60,7 +61,7 @@ SINDI::Add(const DatasetPtr& base) {
     int64_t final_add_window = ceil_int(cur_element_count_ + data_num, window_size_) / window_size_;
     while (window_term_list_.size() < final_add_window) {
         window_term_list_.emplace_back(
-            std::make_shared<SparseTermDataCell>(doc_retain_ratio_, allocator_));
+            std::make_shared<SparseTermDataCell>(doc_retain_ratio_, term_id_limit_, allocator_));
     }
 
     // add process
@@ -75,19 +76,33 @@ SINDI::Add(const DatasetPtr& base) {
             continue;
         }
 
+        uint32_t inner_id = cur_element_count_ - window_start_id;
+
+        try {
+            window_term_list_[cur_window]->InsertVector(sparse_vector, inner_id);
+        } catch (std::runtime_error& e) {
+            failed_ids.push_back(ids[i]);
+            logger::warn(e.what());
+            continue;
+        }
+
         label_table_->Insert(cur_element_count_, ids[i]);  // todo(zxy): check id exists
+
         if (extra_info_size > 0) {
             extra_infos_->InsertExtraInfo(extra_info + i * extra_info_size, cur_element_count_);
         }
 
-        uint32_t inner_id = cur_element_count_ - window_start_id;
-        window_term_list_[cur_window]->InsertVector(sparse_vector, inner_id);
-
         cur_element_count_++;
-    }
-    // high precision part
-    if (use_reorder_) {
-        rerank_flat_index_->Add(base);
+
+        // high precision part
+        if (use_reorder_) {
+            auto single_base = Dataset::Make();
+            single_base->NumElements(1)
+                ->SparseVectors(sparse_vectors + i)
+                ->Ids(ids + i)
+                ->Owner(false);
+            rerank_flat_index_->Add(single_base);
+        }
     }
 
     return failed_ids;
@@ -328,7 +343,8 @@ SINDI::Deserialize(StreamReader& reader) {
     StreamReader::ReadObj(reader, window_term_list_size);
     window_term_list_.resize(window_term_list_size);
     for (auto& window : window_term_list_) {
-        window = std::make_shared<SparseTermDataCell>(doc_retain_ratio_, allocator_);
+        window =
+            std::make_shared<SparseTermDataCell>(doc_retain_ratio_, term_id_limit_, allocator_);
         window->Deserialize(reader);
     }
 

--- a/src/algorithm/sindi/sindi.cpp
+++ b/src/algorithm/sindi/sindi.cpp
@@ -399,6 +399,9 @@ SINDI::EstimateMemory(uint64_t num_elements) const {
         mem *= 2;
     }
 
+    // size of term list
+    mem += sizeof(std::vector<float>) * 2 * term_id_limit_;
+
     return mem;
 }
 

--- a/src/algorithm/sindi/sindi.h
+++ b/src/algorithm/sindi/sindi.h
@@ -122,6 +122,8 @@ private:
 private:
     mutable std::shared_mutex global_mutex_;
 
+    uint32_t term_id_limit_{0};
+
     uint32_t window_size_{0};
 
     Vector<SparseTermDataCellPtr> window_term_list_;

--- a/src/algorithm/sindi/sindi_parameter.cpp
+++ b/src/algorithm/sindi/sindi_parameter.cpp
@@ -25,7 +25,7 @@ SINDIParameter::FromJson(const JsonType& json) {
         term_id_limit = json[SPARSE_TERM_ID_LIMIT].GetInt();
 
         CHECK_ARGUMENT(
-            (10'000 <= term_id_limit and term_id_limit <= 1'000'000),
+            (0 < term_id_limit and term_id_limit <= 1'000'000),
             fmt::format("term_id_limit must in (0, 1'000'000], but now is {}", term_id_limit));
     } else {
         term_id_limit = DEFAULT_TERM_ID_LIMIT;

--- a/src/algorithm/sindi/sindi_parameter.cpp
+++ b/src/algorithm/sindi/sindi_parameter.cpp
@@ -21,6 +21,16 @@ namespace vsag {
 
 void
 SINDIParameter::FromJson(const JsonType& json) {
+    if (json.Contains(SPARSE_TERM_ID_LIMIT)) {
+        term_id_limit = json[SPARSE_TERM_ID_LIMIT].GetInt();
+
+        CHECK_ARGUMENT(
+            (10'000 <= term_id_limit and term_id_limit <= 1'000'000),
+            fmt::format("term_id_limit must in (0, 1'000'000], but now is {}", term_id_limit));
+    } else {
+        term_id_limit = DEFAULT_TERM_ID_LIMIT;
+    }
+
     if (json.Contains(SPARSE_DOC_PRUNE_RATIO)) {
         doc_prune_ratio = json[SPARSE_DOC_PRUNE_RATIO].GetFloat();
         CHECK_ARGUMENT((0.0F <= doc_prune_ratio and doc_prune_ratio <= 0.5F),
@@ -52,6 +62,7 @@ SINDIParameter::FromJson(const JsonType& json) {
 JsonType
 SINDIParameter::ToJson() const {
     JsonType json;
+    json[SPARSE_TERM_ID_LIMIT].SetInt(term_id_limit);
     json[SPARSE_DOC_PRUNE_RATIO].SetFloat(doc_prune_ratio);
     json[SPARSE_USE_REORDER].SetBool(use_reorder);
     json[SPARSE_WINDOW_SIZE].SetInt(window_size);
@@ -62,6 +73,9 @@ bool
 SINDIParameter::CheckCompatibility(const vsag::ParamPtr& other) const {
     auto sindi_param = std::dynamic_pointer_cast<SINDIParameter>(other);
     if (sindi_param == nullptr) {
+        return false;
+    }
+    if (this->term_id_limit != sindi_param->term_id_limit) {
         return false;
     }
     if (this->window_size != sindi_param->window_size) {

--- a/src/algorithm/sindi/sindi_parameter.h
+++ b/src/algorithm/sindi/sindi_parameter.h
@@ -20,13 +20,6 @@
 #include "utils/pointer_define.h"
 
 namespace vsag {
-static constexpr uint32_t DEFAULT_TERM_ID_LIMIT = 100000;
-static constexpr uint32_t DEFAULT_WINDOW_SIZE = 100000;
-static constexpr bool DEFAULT_USE_REORDER = false;
-static constexpr float DEFAULT_QUERY_PRUNE_RATIO = 0.0F;
-static constexpr float DEFAULT_DOC_PRUNE_RATIO = 0.0F;
-static constexpr float DEFAULT_TERM_PRUNE_RATIO = 0.0F;
-static constexpr uint32_t DEFAULT_N_CANDIDATE = 0;
 
 DEFINE_POINTER(SINDIParameter);
 

--- a/src/algorithm/sindi/sindi_parameter.h
+++ b/src/algorithm/sindi/sindi_parameter.h
@@ -20,7 +20,7 @@
 #include "utils/pointer_define.h"
 
 namespace vsag {
-
+static constexpr uint32_t DEFAULT_TERM_ID_LIMIT = 100000;
 static constexpr uint32_t DEFAULT_WINDOW_SIZE = 100000;
 static constexpr bool DEFAULT_USE_REORDER = false;
 static constexpr float DEFAULT_QUERY_PRUNE_RATIO = 0.0F;
@@ -45,6 +45,8 @@ public:
 
 public:
     // index
+    uint32_t term_id_limit{0};
+
     uint32_t window_size{0};
 
     float doc_prune_ratio{0};

--- a/src/algorithm/sindi/sindi_parameter_test.cpp
+++ b/src/algorithm/sindi/sindi_parameter_test.cpp
@@ -17,6 +17,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include "inner_string_params.h"
 #include "parameter_test.h"
 
 using namespace vsag;
@@ -44,14 +45,16 @@ struct SINDIDefaultParam {
     bool use_reorder = true;
     float doc_prune_ratio = 0.1F;
     int window_size = 66666;
+    int term_id_limit = 10000;
 };
 
 std::string
 generate_sindi_param(const SINDIDefaultParam& param) {
     vsag::JsonType json;
-    json["use_reorder"].SetBool(param.use_reorder);
-    json["doc_prune_ratio"].SetFloat(param.doc_prune_ratio);
-    json["window_size"].SetInt(param.window_size);
+    json[SPARSE_USE_REORDER].SetBool(param.use_reorder);
+    json[SPARSE_DOC_PRUNE_RATIO].SetFloat(param.doc_prune_ratio);
+    json[SPARSE_WINDOW_SIZE].SetInt(param.window_size);
+    json[SPARSE_TERM_ID_LIMIT].SetInt(param.term_id_limit);
     return json.Dump();
 }
 
@@ -61,9 +64,10 @@ TEST_CASE("SINDI Index Parameters Test", "[ut][SINDIParameter]") {
     vsag::JsonType param_json = vsag::JsonType::Parse(param_str);
     auto param = std::make_shared<vsag::SINDIParameter>();
     param->FromJson(param_json);
-    REQUIRE(param->use_reorder == true);
-    REQUIRE(std::abs(param->doc_prune_ratio - 0.1F) < 1e-3);
-    REQUIRE(param->window_size == 66666);
+    REQUIRE(param->use_reorder == default_param.use_reorder);
+    REQUIRE(std::abs(param->doc_prune_ratio - default_param.doc_prune_ratio) < 1e-3);
+    REQUIRE(param->window_size == default_param.window_size);
+    REQUIRE(param->term_id_limit == default_param.term_id_limit);
 
     vsag::ParameterTest::TestToJson(param);
 
@@ -84,4 +88,5 @@ TEST_CASE("SINDI Index Parameters Compatibility Test", "[ut][SINDIParameter]") {
     TEST_COMPATIBILITY_CASE("use_reorder compatibility", use_reorder, true, false, false);
     TEST_COMPATIBILITY_CASE("doc_prune_ratio compatibility", doc_prune_ratio, 0.2F, 0.3F, false);
     TEST_COMPATIBILITY_CASE("window_size compatibility", window_size, 66666, 77777, false);
+    TEST_COMPATIBILITY_CASE("term_id_limit compatibility", term_id_limit, 10000, 10001, false);
 }

--- a/src/algorithm/sindi/sindi_test.cpp
+++ b/src/algorithm/sindi/sindi_test.cpp
@@ -63,7 +63,8 @@ TEST_CASE("SINDI Basic Test", "[ut][SINDI]") {
         "use_reorder": {},
         "doc_prune_ratio": 0.0,
         "term_prune_ratio": 0.0,
-        "window_size": 10000
+        "window_size": 10000,
+        "term_id_limit": 30001
     }})";
 
     vsag::JsonType param_json = vsag::JsonType::Parse(fmt::format(param_str, use_reorder));
@@ -75,14 +76,32 @@ TEST_CASE("SINDI Basic Test", "[ut][SINDI]") {
     bf_param->need_sort = true;
     auto bf_index = std::make_unique<SparseIndex>(bf_param, common_param);
 
+    // test build
     bf_index->Build(base);
     auto build_res = index->Build(base);
     REQUIRE(build_res.size() == 0);
     REQUIRE(index->GetNumElements() == num_base);
 
+    // test add failed
+    SparseVector invalid_sv;
+    int64_t tmp_id = 999999;
+    uint32_t invalid_term_id = 30002;
+    invalid_sv.ids_ = &invalid_term_id;
+    invalid_sv.len_ = 1;
+    auto invalid_data = vsag::Dataset::Make();
+    invalid_data->NumElements(invalid_sv.len_)
+        ->SparseVectors(&invalid_sv)
+        ->Ids(&tmp_id)
+        ->Owner(false);
+    auto add_res = index->Add(invalid_data);
+    REQUIRE(add_res.size() == 1);
+    REQUIRE(index->GetNumElements() == num_base);
+
+    // test serialize
     test_serializion(*index, *another_index);
     REQUIRE(another_index->GetNumElements() == num_base);
 
+    // test search process
     std::string search_param_str = R"(
     {
         "sindi": {

--- a/src/common.h
+++ b/src/common.h
@@ -55,4 +55,10 @@ constexpr static const float GENERATE_OMEGA = 0.51;
 
 // sindi related
 constexpr static const uint32_t ESTIMATE_DOC_TERM = 100;
-constexpr static const uint32_t ESTIMATE_DOC_DIM = 50000;
+constexpr static const uint32_t DEFAULT_TERM_ID_LIMIT = 100000;
+constexpr static const uint32_t DEFAULT_WINDOW_SIZE = 100000;
+constexpr static const bool DEFAULT_USE_REORDER = false;
+constexpr static const float DEFAULT_QUERY_PRUNE_RATIO = 0.0F;
+constexpr static const float DEFAULT_DOC_PRUNE_RATIO = 0.0F;
+constexpr static const float DEFAULT_TERM_PRUNE_RATIO = 0.0F;
+constexpr static const uint32_t DEFAULT_N_CANDIDATE = 0;

--- a/src/datacell/sparse_term_datacell.cpp
+++ b/src/datacell/sparse_term_datacell.cpp
@@ -155,6 +155,12 @@ SparseTermDataCell::InsertVector(const SparseVector& sparse_base, uint32_t base_
         auto term_id = sparse_base.ids_[i];
         max_term_id = std::max(max_term_id, term_id);
     }
+    if (max_term_id > term_id_limit_) {
+        throw std::runtime_error(
+            fmt::format("max term id of sparse vector {} is greater than term id limit {}",
+                        max_term_id,
+                        term_id_limit_));
+    }
     ResizeTermList(max_term_id + 1);
 
     Vector<std::pair<uint32_t, float>> sorted_base(allocator_);

--- a/src/datacell/sparse_term_datacell.h
+++ b/src/datacell/sparse_term_datacell.h
@@ -29,8 +29,9 @@ class SparseTermDataCell {
 public:
     SparseTermDataCell() = default;
 
-    SparseTermDataCell(float doc_prune_ratio, Allocator* allocator)
+    SparseTermDataCell(float doc_prune_ratio, uint32_t term_id_limit, Allocator* allocator)
         : doc_prune_ratio_(doc_prune_ratio),
+          term_id_limit_(term_id_limit),
           allocator_(allocator),
           term_ids_(0, Vector<uint32_t>(allocator), allocator),
           term_datas_(0, Vector<float>(allocator), allocator),
@@ -68,6 +69,8 @@ public:
     CalcDistanceByInnerId(const SparseTermComputerPtr& computer, uint32_t base_id);
 
 public:
+    uint32_t term_id_limit_{0};
+
     float doc_prune_ratio_{0};
 
     uint32_t term_capacity_{0};

--- a/src/datacell/sparse_term_datacell_test.cpp
+++ b/src/datacell/sparse_term_datacell_test.cpp
@@ -61,7 +61,8 @@ TEST_CASE("SparseTermDatacell Basic Test", "[ut][SparseTermDatacell]") {
     float doc_prune_ratio = 0.5;
     float term_prune_ratio = 0.0;
     auto allocator = SafeAllocator::FactoryDefaultAllocator();
-    auto data_cell = std::make_shared<SparseTermDataCell>(doc_prune_ratio, allocator.get());
+    auto data_cell = std::make_shared<SparseTermDataCell>(
+        doc_prune_ratio, DEFAULT_TERM_ID_LIMIT, allocator.get());
     REQUIRE(std::abs(data_cell->doc_prune_ratio_ - doc_prune_ratio) < 1e-3);
 
     // test factory computer

--- a/src/inner_string_params.h
+++ b/src/inner_string_params.h
@@ -102,6 +102,7 @@ const char* const SPARSE_NEED_SORT = "need_sort";
 const char* const SPARSE_QUERY_PRUNE_RATIO = "query_prune_ratio";
 const char* const SPARSE_DOC_PRUNE_RATIO = "doc_prune_ratio";
 const char* const SPARSE_TERM_PRUNE_RATIO = "term_prune_ratio";
+const char* const SPARSE_TERM_ID_LIMIT = "term_id_limit";
 const char* const SPARSE_WINDOW_SIZE = "window_size";
 const char* const SPARSE_USE_REORDER = "use_reorder";
 const char* const SPARSE_N_CANDIDATE = "n_candidate";

--- a/tests/fixtures/fixtures.h
+++ b/tests/fixtures/fixtures.h
@@ -117,7 +117,7 @@ GenerateVectors(uint64_t count, uint32_t dim, int seed = 47, bool need_normalize
 std::vector<vsag::SparseVector>
 GenerateSparseVectors(uint32_t count,
                       uint32_t max_dim = 100,
-                      uint32_t max_id = DEFAULT_TERM_ID_LIMIT,
+                      uint32_t max_id = 1000,
                       float min_val = -1,
                       float max_val = 1,
                       int seed = 47);
@@ -126,7 +126,7 @@ vsag::Vector<vsag::SparseVector>
 GenerateSparseVectors(vsag::Allocator* allocator,
                       uint32_t count,
                       uint32_t max_dim = 100,
-                      uint32_t max_id = DEFAULT_TERM_ID_LIMIT,
+                      uint32_t max_id = 1000,
                       float min_val = -1,
                       float max_val = 1,
                       int seed = 47);

--- a/tests/fixtures/fixtures.h
+++ b/tests/fixtures/fixtures.h
@@ -23,6 +23,7 @@
 #include <tuple>
 #include <vector>
 
+#include "common.h"
 #include "simd/normalize.h"
 #include "typing.h"
 #include "vsag/vsag.h"
@@ -116,7 +117,7 @@ GenerateVectors(uint64_t count, uint32_t dim, int seed = 47, bool need_normalize
 std::vector<vsag::SparseVector>
 GenerateSparseVectors(uint32_t count,
                       uint32_t max_dim = 100,
-                      uint32_t max_id = 1000,
+                      uint32_t max_id = DEFAULT_TERM_ID_LIMIT,
                       float min_val = -1,
                       float max_val = 1,
                       int seed = 47);
@@ -125,7 +126,7 @@ vsag::Vector<vsag::SparseVector>
 GenerateSparseVectors(vsag::Allocator* allocator,
                       uint32_t count,
                       uint32_t max_dim = 100,
-                      uint32_t max_id = 10000,
+                      uint32_t max_id = DEFAULT_TERM_ID_LIMIT,
                       float min_val = -1,
                       float max_val = 1,
                       int seed = 47);

--- a/tests/test_sindi.cpp
+++ b/tests/test_sindi.cpp
@@ -24,15 +24,15 @@ namespace fixtures {
 struct SINDIParam {
     bool use_reorder = true;
     float doc_prune_ratio = 0.0;
-    int window_size = 10001;
+    int window_size = 10000;
     bool deserialize_without_footer = false;
-    int term_id_limit = 100;
+    int term_id_limit = 2000;
 };
 
 class SINDITestIndex : public fixtures::TestIndex {
 public:
     static TestDatasetPool pool;
-    constexpr static uint64_t base_count = 10000;
+    constexpr static uint64_t base_count = 1000;
     constexpr static const char* search_param = R"(
         {
             "sindi":

--- a/tests/test_sindi.cpp
+++ b/tests/test_sindi.cpp
@@ -24,8 +24,9 @@ namespace fixtures {
 struct SINDIParam {
     bool use_reorder = true;
     float doc_prune_ratio = 0.0;
-    int window_size = 10000;
+    int window_size = 10001;
     bool deserialize_without_footer = false;
+    int term_id_limit = 100;
 };
 
 class SINDITestIndex : public fixtures::TestIndex {
@@ -53,14 +54,15 @@ public:
                 "use_reorder": {},
                 "doc_prune_ratio": {},
                 "window_size": {},
+                "term_id_limit": {},
                 "deserialize_without_footer": {}
-
             }}
         }})";
         return fmt::format(build_param_template,
                            param.use_reorder,
                            param.doc_prune_ratio,
                            param.window_size,
+                           param.term_id_limit,
                            param.deserialize_without_footer);
     }
 };

--- a/tests/test_sindi.cpp
+++ b/tests/test_sindi.cpp
@@ -31,7 +31,7 @@ struct SINDIParam {
 class SINDITestIndex : public fixtures::TestIndex {
 public:
     static TestDatasetPool pool;
-    constexpr static uint64_t base_count = 1000;
+    constexpr static uint64_t base_count = 10000;
     constexpr static const char* search_param = R"(
         {
             "sindi":


### PR DESCRIPTION
close #1196

## Summary by Sourcery

Add support for term_id_limit across the SINDI index to bound term IDs in sparse vectors, enforce the limit at insertion time with runtime errors, handle violations gracefully in Add, and update serialization, memory estimation, tests, and example usage accordingly.

New Features:
- Introduce term_id_limit parameter in SINDIParameter, JSON config, and SINDI constructor
- Enforce maximum term ID in SparseTermDataCell::InsertVector by throwing on limit violations
- Catch term ID limit violations in SINDI::Add to collect and return failed IDs

Enhancements:
- Propagate term_id_limit to deserialization logic and memory estimation
- Add SPARSE_TERM_ID_LIMIT constant and update example documentation to include term_id_limit

Tests:
- Extend tests to cover term_id_limit in parameter parsing, compatibility, Add failure scenarios, and SparseTermDataCell behavior