### PR TITLE
improvement: share vt in hgraph's different layer

### DIFF
--- a/src/algorithm/hgraph.h
+++ b/src/algorithm/hgraph.h
@@ -256,7 +256,8 @@ private:
     search_one_graph(const void* query,
                      const GraphInterfacePtr& graph,
                      const FlattenInterfacePtr& flatten,
-                     InnerSearchParam& inner_search_param) const;
+                     InnerSearchParam& inner_search_param,
+                     const VisitedListPtr& vt = nullptr) const;
 
     template <InnerSearchMode mode = InnerSearchMode::KNN_SEARCH>
     DistHeapPtr


### PR DESCRIPTION
- one vt used for one search (refresh in different levels)

## Summary by Sourcery

Share a pooled VisitedList across multiple levels in HGraph searches by adding an optional parameter to search_one_graph and reusing the same instance in SearchWithRequest to reduce pool allocations.

Enhancements:
- Add optional VisitedListPtr parameter to search_one_graph to allow passing and reusing an existing visited list across calls
- Modify search_one_graph to reset provided visited lists instead of always taking a new one from the pool and to return only newly allocated lists
- Update SearchWithRequest to allocate a single visited list for all graph levels and return it once after the bottom graph search