### PR TITLE
tests: speedup daily test by reduce dims size

### DIFF
--- a/tests/fixtures/fixtures.cpp
+++ b/tests/fixtures/fixtures.cpp
@@ -30,20 +30,8 @@ namespace fixtures {
 
 const int RABITQ_MIN_RACALL_DIM = 960;
 
-std::vector<int>
-get_common_used_dims(uint64_t count, int seed, int limited_dim) {
-    const std::vector<int> dims = {
-        7,    8,   9,    // generic (dim < 32)
-        32,   33,  48,   // sse(32) + generic(dim < 16)
-        64,   65,  70,   // avx(64) + generic(dim < 16)
-        96,   97,  109,  // avx(64) + sse(32) + generic(dim < 16)
-        128,  129,       // avx512(128) + generic(dim < 16)
-        160,  161,       // avx512(128) + sse(32) + generic(dim < 16)
-        192,  193,       // avx512(128) + avx(64) + generic(dim < 16)
-        224,  225,       // avx512(128) + avx(64) + sse(32) + generic(dim < 16)
-        256,  512,       // common used dims
-        784,  960,       // common used dims
-        1024, 1536};     // common used dims
+static std::vector<int>
+select_dims(const std::vector<int>& dims, uint64_t count, int seed, int limited_dim) {
     if (count == -1 || count >= dims.size()) {
         return dims;
     }
@@ -65,6 +53,28 @@ get_common_used_dims(uint64_t count, int seed, int limited_dim) {
     std::shuffle(result.begin(), result.end(), std::mt19937(seed));
     result.resize(count);
     return result;
+}
+std::vector<int>
+get_common_used_dims(uint64_t count, int seed, int limited_dim) {
+    const std::vector<int> dims = {
+        7,    8,   9,    // generic (dim < 32)
+        32,   33,  48,   // sse(32) + generic(dim < 16)
+        64,   65,  70,   // avx(64) + generic(dim < 16)
+        96,   97,  109,  // avx(64) + sse(32) + generic(dim < 16)
+        128,  129,       // avx512(128) + generic(dim < 16)
+        160,  161,       // avx512(128) + sse(32) + generic(dim < 16)
+        192,  193,       // avx512(128) + avx(64) + generic(dim < 16)
+        224,  225,       // avx512(128) + avx(64) + sse(32) + generic(dim < 16)
+        256,  512,       // common used dims
+        784,  960,       // common used dims
+        1024, 1536};     // common used dims
+    return select_dims(dims, count, seed, limited_dim);
+}
+
+std::vector<int>
+get_index_test_dims(uint64_t count, int seed, int limited_dim) {
+    const std::vector<int> dims = {32, 57, 128, 256, 768, 1536};
+    return select_dims(dims, count, seed, limited_dim);
 }
 
 std::vector<vsag::SparseVector>

--- a/tests/fixtures/fixtures.h
+++ b/tests/fixtures/fixtures.h
@@ -34,6 +34,9 @@ extern const int RABITQ_MIN_RACALL_DIM;
 std::vector<int>
 get_common_used_dims(uint64_t count = -1, int seed = 369, int limited_dim = -1);
 
+std::vector<int>
+get_index_test_dims(uint64_t count = -1, int seed = 369, int limited_dim = -1);
+
 template <typename T>
 T*
 CopyVector(const std::vector<T>& vec) {

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -125,7 +125,7 @@ HGraphTestIndex::GetResource(bool sample) {
         resource->metric_types = fixtures::RandomSelect<std::string>({"ip", "l2", "cosine"}, 1);
         resource->base_count = HGraphTestIndex::base_count;
     } else {
-        resource->dims = fixtures::get_common_used_dims();
+        resource->dims = fixtures::get_index_test_dims();
         resource->test_cases = HGraphTestIndex::all_test_cases;
         resource->metric_types = {"ip", "l2", "cosine"};
         resource->base_count = HGraphTestIndex::base_count * 10;

--- a/tests/test_ivf.cpp
+++ b/tests/test_ivf.cpp
@@ -100,7 +100,7 @@ IVFTestIndex::GetResource(bool sample) {
         resource->train_types = fixtures::RandomSelect<std::string>({"kmeans", "random"}, 1);
         resource->base_count = IVFTestIndex::base_count;
     } else {
-        resource->dims = fixtures::get_common_used_dims();
+        resource->dims = fixtures::get_index_test_dims();
         resource->test_cases = IVFTestIndex::all_test_cases;
         resource->metric_types = {"ip", "l2", "cosine"};
         resource->train_types = {"kmeans", "random"};


### PR DESCRIPTION
- only test useful dim for daily test

## Summary by Sourcery

Use a new dimension selection helper to limit tested dimensions in daily index tests for faster execution

Enhancements:
- Add select_dims helper and refactor get_common_used_dims to use it
- Introduce get_index_test_dims for a shorter, index-specific dimension list

Tests:
- Update HGraph and IVF tests to use get_index_test_dims instead of full common dims for daily runs