### PR TITLE
fix: remove invalid thirdparty header files installation path

### DIFF
--- a/extern/cpuinfo/cpuinfo.cmake
+++ b/extern/cpuinfo/cpuinfo.cmake
@@ -30,6 +30,4 @@ include_directories (${cpuinfo_SOURCE_DIR}/include)
 install (
   TARGETS cpuinfo
   ARCHIVE DESTINATION lib
-  # we don't need this, but CMake is always warning
-  PUBLIC_HEADER DESTINATION /dev/null
 )

--- a/tests/test_simple_index.cpp
+++ b/tests/test_simple_index.cpp
@@ -16,6 +16,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <fstream>
 
+#include "fixtures/fixtures.h"
 #include "fixtures/test_dataset_pool.h"
 #include "vsag/index.h"
 
@@ -146,10 +147,11 @@ TEST_CASE("Test Simple Index", "[ft][simple_index]") {
     std::vector<MergeUnit> units;
     REQUIRE_THROWS(index->Merge(units));
 
-    std::ofstream o_file("1234", std::ios::binary);
+    fixtures::TempDir dir("test_simple_index");
+    std::ofstream o_file(dir.path + "1234", std::ios::binary);
     REQUIRE_THROWS(index->Serialize(o_file));
 
-    std::ifstream i_file("1234", std::ios::binary);
+    std::ifstream i_file(dir.path + "1234", std::ios::binary);
     REQUIRE_THROWS(index->Deserialize(i_file));
 
     REQUIRE_THROWS(index->GetDataByIds(nullptr, 1));


### PR DESCRIPTION
fixes: #1227

## Summary by Sourcery

Bug Fixes:
- Remove PUBLIC_HEADER DESTINATION /dev/null from the cpuinfo install block in extern/cpuinfo/cpuinfo.cmake