### PR TITLE
tools: Support eval_dataset's Save H5 File

### DIFF
--- a/tools/eval/eval_dataset.h
+++ b/tools/eval/eval_dataset.h
@@ -36,6 +36,9 @@ public:
     static EvalDatasetPtr
     Load(const std::string& filename);
 
+    static void
+    Save(const EvalDatasetPtr& dataset, const std::string& filename);
+
 public:
     [[nodiscard]] const void*
     GetTrain() const {
@@ -229,6 +232,7 @@ private:
     std::string train_data_type_;
     std::string test_data_type_;
     std::string file_path_;
+    std::string metric_;
 
     std::vector<SparseVector> sparse_train_;
     std::vector<SparseVector> sparse_test_;


### PR DESCRIPTION
- eval dataset only support Load, add Save function support

## Summary by Sourcery

Add full HDF5 Save support to EvalDataset, handling both dense and sparse data along with metadata, and fix loading of the metric attribute.

New Features:
- Add EvalDataset::Save method to export datasets to HDF5 including attributes and datasets for train/test, neighbors, distances, and optional labels
- Implement serialize_sparse_vectors helper to flatten sparse vectors for storage

Bug Fixes:
- Restore the distance metric attribute into the dataset object during loading