### PR TITLE
tests: speedup daily test by remove some duplicate test

### DIFF
--- a/tests/test_brute_force.cpp
+++ b/tests/test_brute_force.cpp
@@ -82,13 +82,11 @@ BruteForceTestIndex::GetResource(bool sample) {
         resource->dims = fixtures::get_common_used_dims(1, RandomValue(0, 999));
         resource->test_cases = fixtures::RandomSelect(BruteForceTestIndex::all_test_cases, 3);
         resource->metric_types = fixtures::RandomSelect<std::string>({"ip", "l2", "cosine"}, 1);
-        resource->train_types = fixtures::RandomSelect<std::string>({"kmeans", "random"}, 1);
         resource->base_count = BruteForceTestIndex::base_count;
     } else {
-        resource->dims = fixtures::get_common_used_dims();
+        resource->dims = fixtures::get_index_test_dims(3, RandomValue(0, 999));
         resource->test_cases = BruteForceTestIndex::all_test_cases;
-        resource->metric_types = {"ip", "l2", "cosine"};
-        resource->train_types = {"kmeans", "random"};
+        resource->metric_types = fixtures::RandomSelect<std::string>({"ip", "l2", "cosine"}, 2);
         resource->base_count = BruteForceTestIndex::base_count * 3;
     }
     return resource;

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -125,10 +125,10 @@ HGraphTestIndex::GetResource(bool sample) {
         resource->metric_types = fixtures::RandomSelect<std::string>({"ip", "l2", "cosine"}, 1);
         resource->base_count = HGraphTestIndex::base_count;
     } else {
-        resource->dims = fixtures::get_index_test_dims();
+        resource->dims = fixtures::get_index_test_dims(3, RandomValue(0, 999));
         resource->test_cases = HGraphTestIndex::all_test_cases;
-        resource->metric_types = {"ip", "l2", "cosine"};
-        resource->base_count = HGraphTestIndex::base_count * 10;
+        resource->metric_types = fixtures::RandomSelect<std::string>({"ip", "l2", "cosine"}, 2);
+        resource->base_count = HGraphTestIndex::base_count * 3;
     }
     return resource;
 }

--- a/tests/test_ivf.cpp
+++ b/tests/test_ivf.cpp
@@ -100,10 +100,10 @@ IVFTestIndex::GetResource(bool sample) {
         resource->train_types = fixtures::RandomSelect<std::string>({"kmeans", "random"}, 1);
         resource->base_count = IVFTestIndex::base_count;
     } else {
-        resource->dims = fixtures::get_index_test_dims();
+        resource->dims = fixtures::get_index_test_dims(3, RandomValue(0, 999));
         resource->test_cases = IVFTestIndex::all_test_cases;
-        resource->metric_types = {"ip", "l2", "cosine"};
-        resource->train_types = {"kmeans", "random"};
+        resource->metric_types = fixtures::RandomSelect<std::string>({"ip", "l2", "cosine"}, 2);
+        resource->train_types = fixtures::RandomSelect<std::string>({"kmeans", "random"}, 1);
         resource->base_count = IVFTestIndex::base_count * 3;
     }
     return resource;


### PR DESCRIPTION
## Summary by Sourcery

Optimize daily test suite performance by trimming down test parameters and eliminating duplicate checks in various index test implementations.

Enhancements:
- Speed up daily index tests by reducing test resource sizes and redundancy

Tests:
- Remove redundant train type selection in BruteForceTestIndex sample mode
- Limit dims count, randomly select fewer metric and train types, and lower base counts in BruteForce, HGraph, and IVF tests to speed up execution