### PR TITLE
[skip ci]chore: update GitHub release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,22 +1,55 @@
 # .github/workflows/release.yml
-name: Release
+name: Create Release
 
 on:
-  push:
-    tags:
-      - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'The branch to create the release from'
+        required: true
+        default: 'main'
+        type: string
+      tag_name:
+        description: 'The tag for the new release (e.g., v1.0.0)'
+        required: true
+        type: string
 
 jobs:
-  build:
+  build-and-release:
+    name: Build and Release
     runs-on: ubuntu-22.04
+
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Build
-        run: bash ./scripts/release/dist.sh
-      - name: Upload vsag distributions
-        uses: softprops/action-gh-release@2
-        if: github.ref_type == 'tag'
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
         with:
-          files: |
-            dist/*.tar.gz
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: false
+          swap-storage: true
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch }}
+          fetch-depth: 0
+
+      - name: Package release assets
+        run: |
+          echo "Packaging release assets..."
+          bash ./scripts/release/dist.sh
+
+      - name: Create GitHub Release and Upload Assets
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.event.inputs.tag_name }}
+          name: ${{ github.event.inputs.tag_name }}
+          generate_release_notes: true
+          files: dist/*.tar.gz
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -114,15 +114,26 @@ release:                 ## Build vsag with release options.
 	cmake ${VSAG_CMAKE_ARGS} -B${RELEASE_BUILD_DIR} -DCMAKE_BUILD_TYPE=Release
 	cmake --build ${RELEASE_BUILD_DIR} --parallel ${COMPILE_JOBS}
 
+.PHONY: run-dist-tests
+run-dist-tests:          ## Run distribution tests.
+	@echo "running tests..."
+	@${RELEASE_BUILD_DIR}/tests/unittests -d yes "~[daily]"
+	@${RELEASE_BUILD_DIR}/tests/functests -d yes "~[daily]"
+	@${RELEASE_BUILD_DIR}/mockimpl/tests_mockimpl -d yes "~[daily]"
+
 .PHONY: dist-old-abi
 dist-pre-cxx11-abi:      ## Build vsag with distribution options.
+	echo "building dist-pre-cxx11-abi..."
 	cmake ${VSAG_CMAKE_ARGS} -B${RELEASE_BUILD_DIR} -DCMAKE_BUILD_TYPE=Release -DENABLE_INTEL_MKL=off -DENABLE_CXX11_ABI=off -DENABLE_LIBCXX=off
 	cmake --build ${RELEASE_BUILD_DIR} --parallel ${COMPILE_JOBS}
+	$(MAKE) run-dist-tests
 
 .PHONY: dist-cxx11-abi
 dist-cxx11-abi:          ## Build vsag with distribution options.
+	echo "building dist-cxx11-abi..."
 	cmake ${VSAG_CMAKE_ARGS} -B${RELEASE_BUILD_DIR} -DCMAKE_BUILD_TYPE=Release -DENABLE_INTEL_MKL=off -DENABLE_CXX11_ABI=on -DENABLE_LIBCXX=off
 	cmake --build ${RELEASE_BUILD_DIR} --parallel ${COMPILE_JOBS}
+	$(MAKE) run-dist-tests
 
 .PHONY: dist-libcxx
 dist-libcxx:             ## Build vsag using libc++.

--- a/scripts/release/dist.sh
+++ b/scripts/release/dist.sh
@@ -17,7 +17,7 @@ build() {
            bash -c "\
            export COMPILE_JOBS=48 && \
            export CMAKE_INSTALL_PREFIX=/tmp/vsag && \
-           make clean-release && make $makefile_target && make install && \
+           make clean-release && make $makefile_target && make run-dist-tests && make install && \
            mkdir -p ./dist && \
            cp -r /tmp/vsag ./dist/ && \
            cd ./dist && \


### PR DESCRIPTION
- Support creating a release on GitHub: `Build`, `Test`, `Package`, `Release`
- update makefile target: add non-daily tests into distribution target in Makefile

## Summary by Sourcery

Overhaul the GitHub release workflow to support manual dispatch with customizable branch and tag inputs, add disk cleanup, unify packaging and release creation with auto-generated notes, and extend Makefile distribution targets to run non-daily tests.

CI:
- Switch the release workflow trigger from tag pushes to manual workflow_dispatch with branch and tag inputs
- Add a free-disk-space step before checkout on the Ubuntu runner
- Consolidate build, packaging, and GitHub release creation into a single ‘build-and-release’ job using softprops/action-gh-release@v2 with generated release notes

Tests:
- Add non-daily unit, functional, and mockimpl test execution to the dist-pre-cxx11-abi and dist-cxx11-abi Makefile targets