### PR TITLE
fix(cmake): fix wrong message on RUNTIME_AVX512VPOPCNTDQ (#1198)

### DIFF
--- a/.github/workflows/asan_build_and_test.yml
+++ b/.github/workflows/asan_build_and_test.yml
@@ -19,8 +19,8 @@ jobs:
       group: asan_build_x86-${{ github.event.pull_request.number }}
       cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
-      - name: Free Disk Space
-        run: rm -rf /useless/hostedtoolcache
+      - name: Free Disk Space (Ubuntu)
+        run: rm -rf /useless/*
       - uses: actions/checkout@v4
       - name: Load Cache
         uses: hendrikmuhs/ccache-action@v1.2
@@ -48,8 +48,8 @@ jobs:
       group: asan_build_aarch-${{ github.event.pull_request.number }}
       cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
-      - name: Free Disk Space
-        run: rm -rf /opt/hostedtoolcache
+      - name: Free Disk Space (Ubuntu)
+        run: rm -rf /useless/*
       - uses: actions/checkout@v4
       - name: Prepare Env
         run: sudo bash ./scripts/deps/install_deps_ubuntu.sh
@@ -87,8 +87,8 @@ jobs:
       volumes:
         - /opt:/useless
     steps:
-      - name: Free Disk Space
-        run: rm -rf /opt/hostedtoolcache
+      - name: Free Disk Space (Ubuntu)
+        run: rm -rf /useless/*
       - uses: actions/checkout@v4
       - name: Clean Env
         run: rm -rf ./build
@@ -123,8 +123,8 @@ jobs:
       group: test_asan_aarch64-${{ matrix.test_type }}-${{ github.event.pull_request.number }}
       cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
-      - name: Free Disk Space
-        run: rm -rf /opt/hostedtoolcache
+      - name: Free Disk Space (Ubuntu)
+        run: rm -rf /useless/*
       - uses: actions/checkout@v4
       - name: Prepare Env
         run: sudo bash ./scripts/deps/install_deps_ubuntu.sh

--- a/cmake/CheckSIMDCompilerFlag.cmake
+++ b/cmake/CheckSIMDCompilerFlag.cmake
@@ -1,17 +1,31 @@
 
-file(WRITE ${CMAKE_BINARY_DIR}/instructions_test_avx512.cpp "#include <immintrin.h>\nint main() { __m512 a, b; a = _mm512_sub_ps(a, b); return 0; }")
-try_compile(COMPILER_AVX512_SUPPORTED
-    ${CMAKE_BINARY_DIR}/instructions_test_avx512
-    ${CMAKE_BINARY_DIR}/instructions_test_avx512.cpp
-    COMPILE_DEFINITIONS "-mavx512f"
-    OUTPUT_VARIABLE COMPILE_OUTPUT
-    )
+# Copyright 2024-present the vsag project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 file(WRITE ${CMAKE_BINARY_DIR}/instructions_test_avx512vpopcntdq.cpp "#include <immintrin.h>\nint main() { __m512i a, b; b = _mm512_popcnt_epi64(a); return 0; }")
 try_compile(COMPILER_AVX512VPOPCNTDQ_SUPPORTED
     ${CMAKE_BINARY_DIR}/instructions_test_avx512vpopcntdq
     ${CMAKE_BINARY_DIR}/instructions_test_avx512vpopcntdq.cpp
     COMPILE_DEFINITIONS "-mavx512vpopcntdq"
+    OUTPUT_VARIABLE COMPILE_OUTPUT
+    )
+
+file(WRITE ${CMAKE_BINARY_DIR}/instructions_test_avx512.cpp "#include <immintrin.h>\nint main() { __m512 a, b; a = _mm512_sub_ps(a, b); return 0; }")
+try_compile(COMPILER_AVX512_SUPPORTED
+    ${CMAKE_BINARY_DIR}/instructions_test_avx512
+    ${CMAKE_BINARY_DIR}/instructions_test_avx512.cpp
+    COMPILE_DEFINITIONS "-mavx512f"
     OUTPUT_VARIABLE COMPILE_OUTPUT
     )
 
@@ -39,6 +53,7 @@ try_compile(COMPILER_SSE_SUPPORTED
     OUTPUT_VARIABLE COMPILE_OUTPUT
     )
 
+
 file(WRITE ${CMAKE_BINARY_DIR}/instructions_test_neon.cpp "#include <arm_neon.h>\nint main() { float32x4_t a, b; a = vdupq_n_f32(1.0f); b = vdupq_n_f32(2.0f); a = vaddq_f32(a, b); return 0; }")
 try_compile(COMPILER_NEON_SUPPORTED
     ${CMAKE_BINARY_DIR}/instructions_test_neon
@@ -47,19 +62,19 @@ try_compile(COMPILER_NEON_SUPPORTED
     OUTPUT_VARIABLE COMPILE_OUTPUT
     )
 
+file(WRITE ${CMAKE_BINARY_DIR}/instructions_test_avx512vpopcntdq.cpp "#include <immintrin.h>\nint main() { __m512i a, b; b = _mm512_popcnt_epi64(a); return 0; }")
+try_compile(RUNTIME_AVX512VPOPCNTDQ_SUPPORTED
+    ${CMAKE_BINARY_DIR}/instructions_test_avx512vpopcntdq
+    ${CMAKE_BINARY_DIR}/instructions_test_avx512vpopcntdq.cpp
+    COMPILE_DEFINITIONS "-march=native"
+    OUTPUT_VARIABLE COMPILE_OUTPUT
+    )
+
 file(WRITE ${CMAKE_BINARY_DIR}/instructions_test_avx512.cpp "#include <immintrin.h>\nint main() { __m512 a, b; a = _mm512_sub_ps(a, b); return 0; }")
 try_compile(RUNTIME_AVX512_SUPPORTED
     ${CMAKE_BINARY_DIR}/instructions_test_avx512
     ${CMAKE_BINARY_DIR}/instructions_test_avx512.cpp
     COMPILE_DEFINITIONS "-march=native"
-    OUTPUT_VARIABLE COMPILE_OUTPUT
-    )
-
-file(WRITE ${CMAKE_BINARY_DIR}/instructions_test_avx512vpopcntdq.cpp "#include <immintrin.h>\nint main() { __m512i a, b; b = _mm512_popcnt_epi64(a); return 0; }")
-try_compile(RUNTIME_AVX512VPOPCNTDQ_SUPPORTED
-    ${CMAKE_BINARY_DIR}/instructions_test_avx512vpopcntdq
-    ${CMAKE_BINARY_DIR}/instructions_test_avx512vpopcntdq.cpp
-    COMPILE_DEFINITIONS "-mavx512vpopcntdq"
     OUTPUT_VARIABLE COMPILE_OUTPUT
     )
 


### PR DESCRIPTION
## Summary by Sourcery

Improve SIMD feature detection by fixing the runtime AVX512VPOPCNTDQ flag, adding ARM SVE support checks, and adding the Apache 2.0 license header.

New Features:
- Add compile-time and runtime detection for ARM SVE support

Bug Fixes:
- Use the correct compile definition for the runtime AVX512VPOPCNTDQ check

Enhancements:
- Insert Apache 2.0 license header into the CheckSIMDCompilerFlag.cmake file
- Reorder and consolidate SIMD feature checks for consistency