### PR TITLE
refactor: avoiding similar declare in simd

### DIFF
--- a/src/simd/avx.cpp
+++ b/src/simd/avx.cpp
@@ -88,6 +88,11 @@ PQDistanceFloat256(const void* single_dim_centers, float single_dim_val, void* r
 #endif
 }
 
+void
+Prefetch(const void* data) {
+    sse::Prefetch(data);
+}
+
 #if defined(ENABLE_AVX)
 __inline __m256i __attribute__((__always_inline__)) load_8_char_and_convert(const uint8_t* data) {
     __m128i first_8 =

--- a/src/simd/avx2.cpp
+++ b/src/simd/avx2.cpp
@@ -90,6 +90,11 @@ PQDistanceFloat256(const void* single_dim_centers, float single_dim_val, void* r
 #endif
 }
 
+void
+Prefetch(const void* data) {
+    avx::Prefetch(data);
+}
+
 #if defined(ENABLE_AVX2)
 __inline __m128i __attribute__((__always_inline__)) load_8_char(const uint8_t* data) {
     return _mm_loadl_epi64(reinterpret_cast<const __m128i*>(data));

--- a/src/simd/avx512.cpp
+++ b/src/simd/avx512.cpp
@@ -72,6 +72,11 @@ PQDistanceFloat256(const void* single_dim_centers, float single_dim_val, void* r
     return avx2::PQDistanceFloat256(single_dim_centers, single_dim_val, result);
 }
 
+void
+Prefetch(const void* data) {
+    avx2::Prefetch(data);
+}
+
 float
 FP32ComputeIP(const float* RESTRICT query, const float* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_AVX512)

--- a/src/simd/basic_func.h
+++ b/src/simd/basic_func.h
@@ -19,132 +19,35 @@
 
 namespace vsag {
 
-namespace generic {
-float
-L2Sqr(const void* pVect1v, const void* pVect2v, const void* qty_ptr);
-float
-InnerProduct(const void* pVect1, const void* pVect2, const void* qty_ptr);
-float
-InnerProductDistance(const void* pVect1, const void* pVect2, const void* qty_ptr);
-float
-INT8L2Sqr(const void* pVect1v, const void* pVect2v, const void* qty_ptr);
-float
-INT8InnerProduct(const void* pVect1, const void* pVect2, const void* qty_ptr);
-float
-INT8InnerProductDistance(const void* pVect1, const void* pVect2, const void* qty_ptr);
-void
-PQDistanceFloat256(const void* single_dim_centers, float single_dim_val, void* result);
-void
-Prefetch(const void* data);
-}  // namespace generic
+#define DECLARE_BASIC_FUNCTIONS(ns)                                                         \
+    namespace ns {                                                                          \
+    float                                                                                   \
+    L2Sqr(const void* pVect1v, const void* pVect2v, const void* qty_ptr);                   \
+    float                                                                                   \
+    InnerProduct(const void* pVect1, const void* pVect2, const void* qty_ptr);              \
+    float                                                                                   \
+    InnerProductDistance(const void* pVect1, const void* pVect2, const void* qty_ptr);      \
+    float                                                                                   \
+    INT8L2Sqr(const void* pVect1v, const void* pVect2v, const void* qty_ptr);               \
+    float                                                                                   \
+    INT8InnerProduct(const void* pVect1, const void* pVect2, const void* qty_ptr);          \
+    float                                                                                   \
+    INT8InnerProductDistance(const void* pVect1, const void* pVect2, const void* qty_ptr);  \
+    void                                                                                    \
+    PQDistanceFloat256(const void* single_dim_centers, float single_dim_val, void* result); \
+    void                                                                                    \
+    Prefetch(const void* data);                                                             \
+    }  // namespace ns
 
-namespace sse {
-float
-L2Sqr(const void* pVect1v, const void* pVect2v, const void* qty_ptr);
-float
-InnerProduct(const void* pVect1, const void* pVect2, const void* qty_ptr);
-float
-InnerProductDistance(const void* pVect1, const void* pVect2, const void* qty_ptr);
-float
-INT8L2Sqr(const void* pVect1v, const void* pVect2v, const void* qty_ptr);
-float
-INT8InnerProduct(const void* pVect1, const void* pVect2, const void* qty_ptr);
-float
-INT8InnerProductDistance(const void* pVect1, const void* pVect2, const void* qty_ptr);
-void
-PQDistanceFloat256(const void* single_dim_centers, float single_dim_val, void* result);
-void
-Prefetch(const void* data);
-}  // namespace sse
+DECLARE_BASIC_FUNCTIONS(generic)
+DECLARE_BASIC_FUNCTIONS(sse)
+DECLARE_BASIC_FUNCTIONS(avx)
+DECLARE_BASIC_FUNCTIONS(avx2)
+DECLARE_BASIC_FUNCTIONS(avx512)
+DECLARE_BASIC_FUNCTIONS(neon)
+DECLARE_BASIC_FUNCTIONS(sve)
 
-namespace avx {
-float
-L2Sqr(const void* pVect1v, const void* pVect2v, const void* qty_ptr);
-float
-InnerProduct(const void* pVect1, const void* pVect2, const void* qty_ptr);
-float
-InnerProductDistance(const void* pVect1, const void* pVect2, const void* qty_ptr);
-float
-INT8L2Sqr(const void* pVect1v, const void* pVect2v, const void* qty_ptr);
-float
-INT8InnerProduct(const void* pVect1, const void* pVect2, const void* qty_ptr);
-float
-INT8InnerProductDistance(const void* pVect1, const void* pVect2, const void* qty_ptr);
-void
-PQDistanceFloat256(const void* single_dim_centers, float single_dim_val, void* result);
-}  // namespace avx
-
-namespace avx2 {
-float
-L2Sqr(const void* pVect1v, const void* pVect2v, const void* qty_ptr);
-float
-InnerProduct(const void* pVect1, const void* pVect2, const void* qty_ptr);
-float
-InnerProductDistance(const void* pVect1, const void* pVect2, const void* qty_ptr);
-float
-INT8L2Sqr(const void* pVect1v, const void* pVect2v, const void* qty_ptr);
-float
-INT8InnerProduct(const void* pVect1, const void* pVect2, const void* qty_ptr);
-float
-INT8InnerProductDistance(const void* pVect1, const void* pVect2, const void* qty_ptr);
-void
-PQDistanceFloat256(const void* single_dim_centers, float single_dim_val, void* result);
-}  // namespace avx2
-
-namespace avx512 {
-float
-L2Sqr(const void* pVect1v, const void* pVect2v, const void* qty_ptr);
-float
-InnerProduct(const void* pVect1, const void* pVect2, const void* qty_ptr);
-float
-InnerProductDistance(const void* pVect1, const void* pVect2, const void* qty_ptr);
-float
-INT8L2Sqr(const void* pVect1v, const void* pVect2v, const void* qty_ptr);
-float
-INT8InnerProduct(const void* pVect1, const void* pVect2, const void* qty_ptr);
-float
-INT8InnerProductDistance(const void* pVect1, const void* pVect2, const void* qty_ptr);
-void
-PQDistanceFloat256(const void* single_dim_centers, float single_dim_val, void* result);
-}  // namespace avx512
-
-namespace neon {
-float
-L2Sqr(const void* pVect1v, const void* pVect2v, const void* qty_ptr);
-float
-InnerProduct(const void* pVect1, const void* pVect2, const void* qty_ptr);
-float
-InnerProductDistance(const void* pVect1, const void* pVect2, const void* qty_ptr);
-float
-INT8L2Sqr(const void* pVect1v, const void* pVect2v, const void* qty_ptr);
-float
-INT8InnerProduct(const void* pVect1, const void* pVect2, const void* qty_ptr);
-float
-INT8InnerProductDistance(const void* pVect1, const void* pVect2, const void* qty_ptr);
-void
-PQDistanceFloat256(const void* single_dim_centers, float single_dim_val, void* result);
-void
-Prefetch(const void* data);
-}  // namespace neon
-
-namespace sve {
-float
-L2Sqr(const void* pVect1v, const void* pVect2v, const void* qty_ptr);
-float
-InnerProduct(const void* pVect1, const void* pVect2, const void* qty_ptr);
-float
-InnerProductDistance(const void* pVect1, const void* pVect2, const void* qty_ptr);
-float
-INT8L2Sqr(const void* pVect1v, const void* pVect2v, const void* qty_ptr);
-float
-INT8InnerProduct(const void* pVect1, const void* pVect2, const void* qty_ptr);
-float
-INT8InnerProductDistance(const void* pVect1, const void* pVect2, const void* qty_ptr);
-void
-PQDistanceFloat256(const void* single_dim_centers, float single_dim_val, void* result);
-void
-Prefetch(const void* data);
-}  // namespace sve
+#undef DECLARE_BASIC_FUNCTIONS
 
 using DistanceFuncType = float (*)(const void* query1, const void* query2, const void* qty_ptr);
 extern DistanceFuncType L2Sqr;

--- a/src/simd/bf16_simd.h
+++ b/src/simd/bf16_simd.h
@@ -21,58 +21,30 @@
 
 namespace vsag {
 
+#define DECLARE_BF16_FUNCTIONS(ns)                                                                \
+    namespace ns {                                                                                \
+    float                                                                                         \
+    BF16ComputeIP(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim);    \
+    float                                                                                         \
+    BF16ComputeL2Sqr(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim); \
+    }  // namespace ns
+
 namespace generic {
-float
-BF16ComputeIP(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim);
-float
-BF16ComputeL2Sqr(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim);
 float
 BF16ToFloat(const uint16_t bf16_value);
 uint16_t
 FloatToBF16(const float fp32_value);
 }  // namespace generic
 
-namespace sse {
-float
-BF16ComputeIP(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim);
-float
-BF16ComputeL2Sqr(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim);
-}  // namespace sse
+DECLARE_BF16_FUNCTIONS(generic)
+DECLARE_BF16_FUNCTIONS(sse)
+DECLARE_BF16_FUNCTIONS(avx)
+DECLARE_BF16_FUNCTIONS(avx2)
+DECLARE_BF16_FUNCTIONS(avx512)
+DECLARE_BF16_FUNCTIONS(neon)
+DECLARE_BF16_FUNCTIONS(sve)
 
-namespace avx {
-float
-BF16ComputeIP(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim);
-float
-BF16ComputeL2Sqr(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim);
-}  // namespace avx
-
-namespace avx2 {
-float
-BF16ComputeIP(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim);
-float
-BF16ComputeL2Sqr(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim);
-}  // namespace avx2
-
-namespace avx512 {
-float
-BF16ComputeIP(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim);
-float
-BF16ComputeL2Sqr(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim);
-}  // namespace avx512
-
-namespace neon {
-float
-BF16ComputeIP(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim);
-float
-BF16ComputeL2Sqr(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim);
-}  // namespace neon
-
-namespace sve {
-float
-BF16ComputeIP(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim);
-float
-BF16ComputeL2Sqr(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim);
-}  // namespace sve
+#undef DECLARE_BF16_FUNCTIONS
 
 using BF16ComputeType = float (*)(const uint8_t* RESTRICT query,
                                   const uint8_t* RESTRICT codes,

--- a/src/simd/bit_simd.h
+++ b/src/simd/bit_simd.h
@@ -19,82 +19,26 @@
 
 namespace vsag {
 
-namespace generic {
-void
-BitAnd(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* result);
-void
-BitOr(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* result);
-void
-BitXor(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* result);
-void
-BitNot(const uint8_t* x, const uint64_t num_byte, uint8_t* result);
-}  // namespace generic
+#define DECLARE_BIT_FUNCTIONS(ns)                                                         \
+    namespace ns {                                                                        \
+    void                                                                                  \
+    BitAnd(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* result); \
+    void                                                                                  \
+    BitOr(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* result);  \
+    void                                                                                  \
+    BitXor(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* result); \
+    void                                                                                  \
+    BitNot(const uint8_t* x, const uint64_t num_byte, uint8_t* result);                   \
+    }  // namespace ns
+DECLARE_BIT_FUNCTIONS(generic)
+DECLARE_BIT_FUNCTIONS(sse)
+DECLARE_BIT_FUNCTIONS(avx)
+DECLARE_BIT_FUNCTIONS(avx2)
+DECLARE_BIT_FUNCTIONS(avx512)
+DECLARE_BIT_FUNCTIONS(neon)
+DECLARE_BIT_FUNCTIONS(sve)
 
-namespace sse {
-void
-BitAnd(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* result);
-void
-BitOr(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* result);
-void
-BitXor(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* result);
-void
-BitNot(const uint8_t* x, const uint64_t num_byte, uint8_t* result);
-}  // namespace sse
-
-namespace avx {
-void
-BitAnd(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* result);
-void
-BitOr(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* result);
-void
-BitXor(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* result);
-void
-BitNot(const uint8_t* x, const uint64_t num_byte, uint8_t* result);
-}  // namespace avx
-
-namespace avx2 {
-void
-BitAnd(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* result);
-void
-BitOr(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* result);
-void
-BitXor(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* result);
-void
-BitNot(const uint8_t* x, const uint64_t num_byte, uint8_t* result);
-}  // namespace avx2
-
-namespace avx512 {
-void
-BitAnd(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* result);
-void
-BitOr(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* result);
-void
-BitXor(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* result);
-void
-BitNot(const uint8_t* x, const uint64_t num_byte, uint8_t* result);
-}  // namespace avx512
-
-namespace neon {
-void
-BitAnd(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* result);
-void
-BitOr(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* result);
-void
-BitXor(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* result);
-void
-BitNot(const uint8_t* x, const uint64_t num_byte, uint8_t* result);
-}  // namespace neon
-
-namespace sve {
-void
-BitAnd(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* result);
-void
-BitOr(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* result);
-void
-BitXor(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* result);
-void
-BitNot(const uint8_t* x, const uint64_t num_byte, uint8_t* result);
-}  // namespace sve
+#undef DECLARE_BIT_FUNCTIONS
 
 using BitOperatorType = void (*)(const uint8_t* x,
                                  const uint8_t* y,

--- a/src/simd/fp16_simd.h
+++ b/src/simd/fp16_simd.h
@@ -20,58 +20,30 @@
 #include "simd_marco.h"
 namespace vsag {
 
+#define DECLARE_FP16_FUNCTIONS(ns)                                                                \
+    namespace ns {                                                                                \
+    float                                                                                         \
+    FP16ComputeIP(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim);    \
+    float                                                                                         \
+    FP16ComputeL2Sqr(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim); \
+    }  // namespace ns
+
 namespace generic {
-float
-FP16ComputeIP(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim);
-float
-FP16ComputeL2Sqr(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim);
 float
 FP16ToFloat(const uint16_t bf16_value);
 uint16_t
 FloatToFP16(const float fp32_value);
 }  // namespace generic
 
-namespace sse {
-float
-FP16ComputeIP(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim);
-float
-FP16ComputeL2Sqr(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim);
-}  // namespace sse
+DECLARE_FP16_FUNCTIONS(generic)
+DECLARE_FP16_FUNCTIONS(sse)
+DECLARE_FP16_FUNCTIONS(avx)
+DECLARE_FP16_FUNCTIONS(avx2)
+DECLARE_FP16_FUNCTIONS(avx512)
+DECLARE_FP16_FUNCTIONS(neon)
+DECLARE_FP16_FUNCTIONS(sve)
 
-namespace avx {
-float
-FP16ComputeIP(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim);
-float
-FP16ComputeL2Sqr(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim);
-}  // namespace avx
-
-namespace avx2 {
-float
-FP16ComputeIP(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim);
-float
-FP16ComputeL2Sqr(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim);
-}  // namespace avx2
-
-namespace avx512 {
-float
-FP16ComputeIP(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim);
-float
-FP16ComputeL2Sqr(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim);
-}  // namespace avx512
-
-namespace neon {
-float
-FP16ComputeIP(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim);
-float
-FP16ComputeL2Sqr(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim);
-}  // namespace neon
-
-namespace sve {
-float
-FP16ComputeIP(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim);
-float
-FP16ComputeL2Sqr(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim);
-}  // namespace sve
+#undef DECLARE_FP16_FUNCTIONS
 
 using FP16ComputeType = float (*)(const uint8_t* RESTRICT query,
                                   const uint8_t* RESTRICT codes,

--- a/src/simd/fp32_simd.h
+++ b/src/simd/fp32_simd.h
@@ -20,285 +20,54 @@
 #include "simd_marco.h"
 namespace vsag {
 
-namespace generic {
-float
-FP32ComputeIP(const float* RESTRICT query, const float* RESTRICT codes, uint64_t dim);
-float
-FP32ComputeL2Sqr(const float* RESTRICT query, const float* RESTRICT codes, uint64_t dim);
-void
-FP32ComputeIPBatch4(const float* RESTRICT query,
-                    uint64_t dim,
-                    const float* RESTRICT codes1,
-                    const float* RESTRICT codes2,
-                    const float* RESTRICT codes3,
-                    const float* RESTRICT codes4,
-                    float& result1,
-                    float& result2,
-                    float& result3,
-                    float& result4);
-void
-FP32ComputeL2SqrBatch4(const float* RESTRICT query,
-                       uint64_t dim,
-                       const float* RESTRICT codes1,
-                       const float* RESTRICT codes2,
-                       const float* RESTRICT codes3,
-                       const float* RESTRICT codes4,
-                       float& result1,
-                       float& result2,
-                       float& result3,
-                       float& result4);
-void
-FP32Sub(const float* x, const float* y, float* z, uint64_t dim);
-void
-FP32Add(const float* x, const float* y, float* z, uint64_t dim);
-void
-FP32Mul(const float* x, const float* y, float* z, uint64_t dim);
-void
-FP32Div(const float* x, const float* y, float* z, uint64_t dim);
+#define DECLARE_FP32_FUNCTIONS(ns)                                                            \
+    namespace ns {                                                                            \
+    float                                                                                     \
+    FP32ComputeIP(const float* RESTRICT query, const float* RESTRICT codes, uint64_t dim);    \
+    float                                                                                     \
+    FP32ComputeL2Sqr(const float* RESTRICT query, const float* RESTRICT codes, uint64_t dim); \
+    void                                                                                      \
+    FP32ComputeIPBatch4(const float* RESTRICT query,                                          \
+                        uint64_t dim,                                                         \
+                        const float* RESTRICT codes1,                                         \
+                        const float* RESTRICT codes2,                                         \
+                        const float* RESTRICT codes3,                                         \
+                        const float* RESTRICT codes4,                                         \
+                        float& result1,                                                       \
+                        float& result2,                                                       \
+                        float& result3,                                                       \
+                        float& result4);                                                      \
+    void                                                                                      \
+    FP32ComputeL2SqrBatch4(const float* RESTRICT query,                                       \
+                           uint64_t dim,                                                      \
+                           const float* RESTRICT codes1,                                      \
+                           const float* RESTRICT codes2,                                      \
+                           const float* RESTRICT codes3,                                      \
+                           const float* RESTRICT codes4,                                      \
+                           float& result1,                                                    \
+                           float& result2,                                                    \
+                           float& result3,                                                    \
+                           float& result4);                                                   \
+    void                                                                                      \
+    FP32Sub(const float* x, const float* y, float* z, uint64_t dim);                          \
+    void                                                                                      \
+    FP32Add(const float* x, const float* y, float* z, uint64_t dim);                          \
+    void                                                                                      \
+    FP32Mul(const float* x, const float* y, float* z, uint64_t dim);                          \
+    void                                                                                      \
+    FP32Div(const float* x, const float* y, float* z, uint64_t dim);                          \
+    float                                                                                     \
+    FP32ReduceAdd(const float* x, uint64_t dim);                                              \
+    }  // namespace ns
 
-float
-FP32ReduceAdd(const float* x, uint64_t dim);
-}  // namespace generic
-
-namespace sse {
-float
-FP32ComputeIP(const float* RESTRICT query, const float* RESTRICT codes, uint64_t dim);
-float
-FP32ComputeL2Sqr(const float* RESTRICT query, const float* RESTRICT codes, uint64_t dim);
-void
-FP32ComputeIPBatch4(const float* RESTRICT query,
-                    uint64_t dim,
-                    const float* RESTRICT codes1,
-                    const float* RESTRICT codes2,
-                    const float* RESTRICT codes3,
-                    const float* RESTRICT codes4,
-                    float& result1,
-                    float& result2,
-                    float& result3,
-                    float& result4);
-void
-FP32ComputeL2SqrBatch4(const float* RESTRICT query,
-                       uint64_t dim,
-                       const float* RESTRICT codes1,
-                       const float* RESTRICT codes2,
-                       const float* RESTRICT codes3,
-                       const float* RESTRICT codes4,
-                       float& result1,
-                       float& result2,
-                       float& result3,
-                       float& result4);
-void
-FP32Sub(const float* x, const float* y, float* z, uint64_t dim);
-void
-FP32Add(const float* x, const float* y, float* z, uint64_t dim);
-void
-FP32Mul(const float* x, const float* y, float* z, uint64_t dim);
-void
-FP32Div(const float* x, const float* y, float* z, uint64_t dim);
-
-float
-FP32ReduceAdd(const float* x, uint64_t dim);
-}  // namespace sse
-
-namespace avx {
-float
-FP32ComputeIP(const float* RESTRICT query, const float* RESTRICT codes, uint64_t dim);
-float
-FP32ComputeL2Sqr(const float* RESTRICT query, const float* RESTRICT codes, uint64_t dim);
-void
-FP32ComputeIPBatch4(const float* RESTRICT query,
-                    uint64_t dim,
-                    const float* RESTRICT codes1,
-                    const float* RESTRICT codes2,
-                    const float* RESTRICT codes3,
-                    const float* RESTRICT codes4,
-                    float& result1,
-                    float& result2,
-                    float& result3,
-                    float& result4);
-void
-FP32ComputeL2SqrBatch4(const float* RESTRICT query,
-                       uint64_t dim,
-                       const float* RESTRICT codes1,
-                       const float* RESTRICT codes2,
-                       const float* RESTRICT codes3,
-                       const float* RESTRICT codes4,
-                       float& result1,
-                       float& result2,
-                       float& result3,
-                       float& result4);
-void
-FP32Sub(const float* x, const float* y, float* z, uint64_t dim);
-void
-FP32Add(const float* x, const float* y, float* z, uint64_t dim);
-void
-FP32Mul(const float* x, const float* y, float* z, uint64_t dim);
-void
-FP32Div(const float* x, const float* y, float* z, uint64_t dim);
-
-float
-FP32ReduceAdd(const float* x, uint64_t dim);
-}  // namespace avx
-
-namespace avx2 {
-float
-FP32ComputeIP(const float* RESTRICT query, const float* RESTRICT codes, uint64_t dim);
-float
-FP32ComputeL2Sqr(const float* RESTRICT query, const float* RESTRICT codes, uint64_t dim);
-void
-FP32ComputeIPBatch4(const float* RESTRICT query,
-                    uint64_t dim,
-                    const float* RESTRICT codes1,
-                    const float* RESTRICT codes2,
-                    const float* RESTRICT codes3,
-                    const float* RESTRICT codes4,
-                    float& result1,
-                    float& result2,
-                    float& result3,
-                    float& result4);
-void
-FP32ComputeL2SqrBatch4(const float* RESTRICT query,
-                       uint64_t dim,
-                       const float* RESTRICT codes1,
-                       const float* RESTRICT codes2,
-                       const float* RESTRICT codes3,
-                       const float* RESTRICT codes4,
-                       float& result1,
-                       float& result2,
-                       float& result3,
-                       float& result4);
-void
-FP32Sub(const float* x, const float* y, float* z, uint64_t dim);
-void
-FP32Add(const float* x, const float* y, float* z, uint64_t dim);
-void
-FP32Mul(const float* x, const float* y, float* z, uint64_t dim);
-void
-FP32Div(const float* x, const float* y, float* z, uint64_t dim);
-
-float
-FP32ReduceAdd(const float* x, uint64_t dim);
-}  // namespace avx2
-
-namespace avx512 {
-float
-FP32ComputeIP(const float* RESTRICT query, const float* RESTRICT codes, uint64_t dim);
-float
-FP32ComputeL2Sqr(const float* RESTRICT query, const float* RESTRICT codes, uint64_t dim);
-void
-FP32ComputeIPBatch4(const float* RESTRICT query,
-                    uint64_t dim,
-                    const float* RESTRICT codes1,
-                    const float* RESTRICT codes2,
-                    const float* RESTRICT codes3,
-                    const float* RESTRICT codes4,
-                    float& result1,
-                    float& result2,
-                    float& result3,
-                    float& result4);
-void
-FP32ComputeL2SqrBatch4(const float* RESTRICT query,
-                       uint64_t dim,
-                       const float* RESTRICT codes1,
-                       const float* RESTRICT codes2,
-                       const float* RESTRICT codes3,
-                       const float* RESTRICT codes4,
-                       float& result1,
-                       float& result2,
-                       float& result3,
-                       float& result4);
-void
-FP32Sub(const float* x, const float* y, float* z, uint64_t dim);
-void
-FP32Add(const float* x, const float* y, float* z, uint64_t dim);
-void
-FP32Mul(const float* x, const float* y, float* z, uint64_t dim);
-void
-FP32Div(const float* x, const float* y, float* z, uint64_t dim);
-
-float
-FP32ReduceAdd(const float* x, uint64_t dim);
-}  // namespace avx512
-
-namespace neon {
-float
-FP32ComputeIP(const float* RESTRICT query, const float* RESTRICT codes, uint64_t dim);
-float
-FP32ComputeL2Sqr(const float* RESTRICT query, const float* RESTRICT codes, uint64_t dim);
-void
-FP32ComputeIPBatch4(const float* RESTRICT query,
-                    uint64_t dim,
-                    const float* RESTRICT codes1,
-                    const float* RESTRICT codes2,
-                    const float* RESTRICT codes3,
-                    const float* RESTRICT codes4,
-                    float& result1,
-                    float& result2,
-                    float& result3,
-                    float& result4);
-void
-FP32ComputeL2SqrBatch4(const float* RESTRICT query,
-                       uint64_t dim,
-                       const float* RESTRICT codes1,
-                       const float* RESTRICT codes2,
-                       const float* RESTRICT codes3,
-                       const float* RESTRICT codes4,
-                       float& result1,
-                       float& result2,
-                       float& result3,
-                       float& result4);
-void
-FP32Sub(const float* x, const float* y, float* z, uint64_t dim);
-void
-FP32Add(const float* x, const float* y, float* z, uint64_t dim);
-void
-FP32Mul(const float* x, const float* y, float* z, uint64_t dim);
-void
-FP32Div(const float* x, const float* y, float* z, uint64_t dim);
-
-float
-FP32ReduceAdd(const float* x, uint64_t dim);
-}  // namespace neon
-
-namespace sve {
-float
-FP32ComputeIP(const float* RESTRICT query, const float* RESTRICT codes, uint64_t dim);
-float
-FP32ComputeL2Sqr(const float* RESTRICT query, const float* RESTRICT codes, uint64_t dim);
-void
-FP32ComputeIPBatch4(const float* RESTRICT query,
-                    uint64_t dim,
-                    const float* RESTRICT codes1,
-                    const float* RESTRICT codes2,
-                    const float* RESTRICT codes3,
-                    const float* RESTRICT codes4,
-                    float& result1,
-                    float& result2,
-                    float& result3,
-                    float& result4);
-void
-FP32ComputeL2SqrBatch4(const float* RESTRICT query,
-                       uint64_t dim,
-                       const float* RESTRICT codes1,
-                       const float* RESTRICT codes2,
-                       const float* RESTRICT codes3,
-                       const float* RESTRICT codes4,
-                       float& result1,
-                       float& result2,
-                       float& result3,
-                       float& result4);
-void
-FP32Sub(const float* x, const float* y, float* z, uint64_t dim);
-void
-FP32Add(const float* x, const float* y, float* z, uint64_t dim);
-void
-FP32Mul(const float* x, const float* y, float* z, uint64_t dim);
-void
-FP32Div(const float* x, const float* y, float* z, uint64_t dim);
-
-float
-FP32ReduceAdd(const float* x, uint64_t dim);
-}  // namespace sve
+DECLARE_FP32_FUNCTIONS(generic)
+DECLARE_FP32_FUNCTIONS(sse)
+DECLARE_FP32_FUNCTIONS(avx)
+DECLARE_FP32_FUNCTIONS(avx2)
+DECLARE_FP32_FUNCTIONS(avx512)
+DECLARE_FP32_FUNCTIONS(neon)
+DECLARE_FP32_FUNCTIONS(sve)
+#undef DECLARE_FP32_FUNCTIONS
 
 using FP32ComputeType = float (*)(const float* RESTRICT query,
                                   const float* RESTRICT codes,

--- a/src/simd/int8_simd.h
+++ b/src/simd/int8_simd.h
@@ -20,61 +20,23 @@
 #include "simd_marco.h"
 namespace vsag {
 
-namespace generic {
-float
-INT8ComputeL2Sqr(const int8_t* RESTRICT query, const int8_t* RESTRICT codes, uint64_t dim);
+#define DECLARE_INT8_FUNCTIONS(ns)                                                              \
+    namespace ns {                                                                              \
+    float                                                                                       \
+    INT8ComputeIP(const int8_t* RESTRICT query, const int8_t* RESTRICT codes, uint64_t dim);    \
+    float                                                                                       \
+    INT8ComputeL2Sqr(const int8_t* RESTRICT query, const int8_t* RESTRICT codes, uint64_t dim); \
+    }  // namespace ns
 
-float
-INT8ComputeIP(const int8_t* RESTRICT query, const int8_t* RESTRICT codes, uint64_t dim);
-}  // namespace generic
+DECLARE_INT8_FUNCTIONS(generic)
+DECLARE_INT8_FUNCTIONS(sse)
+DECLARE_INT8_FUNCTIONS(avx)
+DECLARE_INT8_FUNCTIONS(avx2)
+DECLARE_INT8_FUNCTIONS(avx512)
+DECLARE_INT8_FUNCTIONS(neon)
+DECLARE_INT8_FUNCTIONS(sve)
+#undef DECLARE_INT8_FUNCTIONS
 
-namespace sse {
-float
-INT8ComputeL2Sqr(const int8_t* RESTRICT query, const int8_t* RESTRICT codes, uint64_t dim);
-
-float
-INT8ComputeIP(const int8_t* RESTRICT query, const int8_t* RESTRICT codes, uint64_t dim);
-}  // namespace sse
-
-namespace avx {
-float
-INT8ComputeL2Sqr(const int8_t* RESTRICT query, const int8_t* RESTRICT codes, uint64_t dim);
-
-float
-INT8ComputeIP(const int8_t* RESTRICT query, const int8_t* RESTRICT codes, uint64_t dim);
-}  // namespace avx
-
-namespace avx2 {
-float
-INT8ComputeL2Sqr(const int8_t* RESTRICT query, const int8_t* RESTRICT codes, uint64_t dim);
-
-float
-INT8ComputeIP(const int8_t* RESTRICT query, const int8_t* RESTRICT codes, uint64_t dim);
-}  // namespace avx2
-
-namespace avx512 {
-float
-INT8ComputeL2Sqr(const int8_t* RESTRICT query, const int8_t* RESTRICT codes, uint64_t dim);
-
-float
-INT8ComputeIP(const int8_t* RESTRICT query, const int8_t* RESTRICT codes, uint64_t dim);
-}  // namespace avx512
-
-namespace neon {
-float
-INT8ComputeL2Sqr(const int8_t* RESTRICT query, const int8_t* RESTRICT codes, uint64_t dim);
-
-float
-INT8ComputeIP(const int8_t* RESTRICT query, const int8_t* RESTRICT codes, uint64_t dim);
-}  // namespace neon
-
-namespace sve {
-float
-INT8ComputeL2Sqr(const int8_t* RESTRICT query, const int8_t* RESTRICT codes, uint64_t dim);
-
-float
-INT8ComputeIP(const int8_t* RESTRICT query, const int8_t* RESTRICT codes, uint64_t dim);
-}  // namespace sve
 using INT8ComputeType = float (*)(const int8_t* RESTRICT query,
                                   const int8_t* RESTRICT codes,
                                   uint64_t dim);

--- a/src/simd/normalize.h
+++ b/src/simd/normalize.h
@@ -18,68 +18,32 @@
 #include <cstdint>
 
 namespace vsag {
+
+#define DECLARE_NORMALIZE_FUNCTIONS(ns)                                  \
+    namespace ns {                                                       \
+    void                                                                 \
+    DivScalar(const float* from, float* to, uint64_t dim, float scalar); \
+    float                                                                \
+    Normalize(const float* from, float* to, uint64_t dim);               \
+    }  // namespace ns
+
 namespace generic {
-void
-DivScalar(const float* from, float* to, uint64_t dim, float scalar);
-
-float
-Normalize(const float* from, float* to, uint64_t dim);
-
 float
 NormalizeWithCentroid(const float* from, const float* centroid, float* to, uint64_t dim);
-
 void
 InverseNormalizeWithCentroid(
     const float* from, const float* centroid, float* to, uint64_t dim, float norm);
 }  // namespace generic
 
-namespace sse {
-void
-DivScalar(const float* from, float* to, uint64_t dim, float scalar);
+DECLARE_NORMALIZE_FUNCTIONS(generic)
+DECLARE_NORMALIZE_FUNCTIONS(sse)
+DECLARE_NORMALIZE_FUNCTIONS(avx)
+DECLARE_NORMALIZE_FUNCTIONS(avx2)
+DECLARE_NORMALIZE_FUNCTIONS(avx512)
+DECLARE_NORMALIZE_FUNCTIONS(neon)
+DECLARE_NORMALIZE_FUNCTIONS(sve)
 
-float
-Normalize(const float* from, float* to, uint64_t dim);
-}  // namespace sse
-
-namespace avx {
-void
-DivScalar(const float* from, float* to, uint64_t dim, float scalar);
-
-float
-Normalize(const float* from, float* to, uint64_t dim);
-}  // namespace avx
-
-namespace avx2 {
-void
-DivScalar(const float* from, float* to, uint64_t dim, float scalar);
-
-float
-Normalize(const float* from, float* to, uint64_t dim);
-}  // namespace avx2
-
-namespace avx512 {
-void
-DivScalar(const float* from, float* to, uint64_t dim, float scalar);
-
-float
-Normalize(const float* from, float* to, uint64_t dim);
-}  // namespace avx512
-
-namespace neon {
-void
-DivScalar(const float* from, float* to, uint64_t dim, float scalar);
-
-float
-Normalize(const float* from, float* to, uint64_t dim);
-}  // namespace neon
-
-namespace sve {
-void
-DivScalar(const float* from, float* to, uint64_t dim, float scalar);
-
-float
-Normalize(const float* from, float* to, uint64_t dim);
-}  // namespace sve
+#undef DECLARE_NORMALIZE_FUNCTIONS
 
 using NormalizeType = float (*)(const float* from, float* to, uint64_t dim);
 extern NormalizeType Normalize;

--- a/src/simd/pqfs_simd.h
+++ b/src/simd/pqfs_simd.h
@@ -21,61 +21,24 @@
 
 namespace vsag {
 
-namespace generic {
-void
-PQFastScanLookUp32(const uint8_t* RESTRICT lookup_table,
-                   const uint8_t* RESTRICT codes,
-                   uint64_t pq_dim,
-                   int32_t* RESTRICT result);
-}  // namespace generic
+#define DECLARE_PQFS_FUNCTIONS(ns)                           \
+    namespace ns {                                           \
+    void                                                     \
+    PQFastScanLookUp32(const uint8_t* RESTRICT lookup_table, \
+                       const uint8_t* RESTRICT codes,        \
+                       uint64_t pq_dim,                      \
+                       int32_t* RESTRICT result);            \
+    }  // namespace ns
 
-namespace sse {
-void
-PQFastScanLookUp32(const uint8_t* RESTRICT lookup_table,
-                   const uint8_t* RESTRICT codes,
-                   uint64_t pq_dim,
-                   int32_t* RESTRICT result);
-}  // namespace sse
+DECLARE_PQFS_FUNCTIONS(generic)
+DECLARE_PQFS_FUNCTIONS(sse)
+DECLARE_PQFS_FUNCTIONS(avx)
+DECLARE_PQFS_FUNCTIONS(avx2)
+DECLARE_PQFS_FUNCTIONS(avx512)
+DECLARE_PQFS_FUNCTIONS(neon)
+DECLARE_PQFS_FUNCTIONS(sve)
 
-namespace avx {
-void
-PQFastScanLookUp32(const uint8_t* RESTRICT lookup_table,
-                   const uint8_t* RESTRICT codes,
-                   uint64_t pq_dim,
-                   int32_t* RESTRICT result);
-}  // namespace avx
-
-namespace avx2 {
-void
-PQFastScanLookUp32(const uint8_t* RESTRICT lookup_table,
-                   const uint8_t* RESTRICT codes,
-                   uint64_t pq_dim,
-                   int32_t* RESTRICT result);
-}  // namespace avx2
-
-namespace avx512 {
-void
-PQFastScanLookUp32(const uint8_t* RESTRICT lookup_table,
-                   const uint8_t* RESTRICT codes,
-                   uint64_t pq_dim,
-                   int32_t* RESTRICT result);
-}  // namespace avx512
-
-namespace neon {
-void
-PQFastScanLookUp32(const uint8_t* RESTRICT lookup_table,
-                   const uint8_t* RESTRICT codes,
-                   uint64_t pq_dim,
-                   int32_t* RESTRICT result);
-}  // namespace neon
-
-namespace sve {
-void
-PQFastScanLookUp32(const uint8_t* RESTRICT lookup_table,
-                   const uint8_t* RESTRICT codes,
-                   uint64_t pq_dim,
-                   int32_t* RESTRICT result);
-}  // namespace sve
+#undef DECLARE_PQFS_FUNCTIONS
 
 using PQFastScanLookUp32Type = void (*)(const uint8_t* RESTRICT lookup_table,
                                         const uint8_t* RESTRICT codes,

--- a/src/simd/sq4_simd.h
+++ b/src/simd/sq4_simd.h
@@ -20,194 +20,44 @@
 #include "simd_marco.h"
 
 namespace vsag {
-namespace generic {
-float
-SQ4ComputeIP(const float* RESTRICT query,
-             const uint8_t* RESTRICT codes,
-             const float* RESTRICT lower_bound,
-             const float* RESTRICT diff,
-             uint64_t dim);
-float
-SQ4ComputeL2Sqr(const float* RESTRICT query,
-                const uint8_t* RESTRICT codes,
-                const float* RESTRICT lower_bound,
-                const float* RESTRICT diff,
-                uint64_t dim);
-float
-SQ4ComputeCodesIP(const uint8_t* RESTRICT codes1,
-                  const uint8_t* RESTRICT codes2,
-                  const float* RESTRICT lower_bound,
-                  const float* RESTRICT diff,
-                  uint64_t dim);
-float
-SQ4ComputeCodesL2Sqr(const uint8_t* RESTRICT codes1,
-                     const uint8_t* RESTRICT codes2,
-                     const float* RESTRICT lower_bound,
-                     const float* RESTRICT diff,
-                     uint64_t dim);
-}  // namespace generic
 
-namespace sse {
-float
-SQ4ComputeIP(const float* RESTRICT query,
-             const uint8_t* RESTRICT codes,
-             const float* RESTRICT lower_bound,
-             const float* RESTRICT diff,
-             uint64_t dim);
-float
-SQ4ComputeL2Sqr(const float* RESTRICT query,
-                const uint8_t* RESTRICT codes,
-                const float* RESTRICT lower_bound,
-                const float* RESTRICT diff,
-                uint64_t dim);
-float
-SQ4ComputeCodesIP(const uint8_t* RESTRICT codes1,
-                  const uint8_t* RESTRICT codes2,
-                  const float* RESTRICT lower_bound,
-                  const float* RESTRICT diff,
-                  uint64_t dim);
-float
-SQ4ComputeCodesL2Sqr(const uint8_t* RESTRICT codes1,
-                     const uint8_t* RESTRICT codes2,
-                     const float* RESTRICT lower_bound,
-                     const float* RESTRICT diff,
-                     uint64_t dim);
-}  // namespace sse
+#define DECLARE_SQ4_FUNCTIONS(ns)                           \
+    namespace ns {                                          \
+    float                                                   \
+    SQ4ComputeIP(const float* RESTRICT query,               \
+                 const uint8_t* RESTRICT codes,             \
+                 const float* RESTRICT lower_bound,         \
+                 const float* RESTRICT diff,                \
+                 uint64_t dim);                             \
+    float                                                   \
+    SQ4ComputeL2Sqr(const float* RESTRICT query,            \
+                    const uint8_t* RESTRICT codes,          \
+                    const float* RESTRICT lower_bound,      \
+                    const float* RESTRICT diff,             \
+                    uint64_t dim);                          \
+    float                                                   \
+    SQ4ComputeCodesIP(const uint8_t* RESTRICT codes1,       \
+                      const uint8_t* RESTRICT codes2,       \
+                      const float* RESTRICT lower_bound,    \
+                      const float* RESTRICT diff,           \
+                      uint64_t dim);                        \
+    float                                                   \
+    SQ4ComputeCodesL2Sqr(const uint8_t* RESTRICT codes1,    \
+                         const uint8_t* RESTRICT codes2,    \
+                         const float* RESTRICT lower_bound, \
+                         const float* RESTRICT diff,        \
+                         uint64_t dim);                     \
+    }  // namespace ns
 
-namespace avx {
-float
-SQ4ComputeIP(const float* RESTRICT query,
-             const uint8_t* RESTRICT codes,
-             const float* RESTRICT lower_bound,
-             const float* RESTRICT diff,
-             uint64_t dim);
-float
-SQ4ComputeL2Sqr(const float* RESTRICT query,
-                const uint8_t* RESTRICT codes,
-                const float* RESTRICT lower_bound,
-                const float* RESTRICT diff,
-                uint64_t dim);
-float
-SQ4ComputeCodesIP(const uint8_t* RESTRICT codes1,
-                  const uint8_t* RESTRICT codes2,
-                  const float* RESTRICT lower_bound,
-                  const float* RESTRICT diff,
-                  uint64_t dim);
-float
-SQ4ComputeCodesL2Sqr(const uint8_t* RESTRICT codes1,
-                     const uint8_t* RESTRICT codes2,
-                     const float* RESTRICT lower_bound,
-                     const float* RESTRICT diff,
-                     uint64_t dim);
-}  // namespace avx
+DECLARE_SQ4_FUNCTIONS(generic)
+DECLARE_SQ4_FUNCTIONS(sse)
+DECLARE_SQ4_FUNCTIONS(avx)
+DECLARE_SQ4_FUNCTIONS(avx2)
+DECLARE_SQ4_FUNCTIONS(avx512)
+DECLARE_SQ4_FUNCTIONS(neon)
+DECLARE_SQ4_FUNCTIONS(sve)
 
-namespace avx2 {
-float
-SQ4ComputeIP(const float* RESTRICT query,
-             const uint8_t* RESTRICT codes,
-             const float* RESTRICT lower_bound,
-             const float* RESTRICT diff,
-             uint64_t dim);
-float
-SQ4ComputeL2Sqr(const float* RESTRICT query,
-                const uint8_t* RESTRICT codes,
-                const float* RESTRICT lower_bound,
-                const float* RESTRICT diff,
-                uint64_t dim);
-float
-SQ4ComputeCodesIP(const uint8_t* RESTRICT codes1,
-                  const uint8_t* RESTRICT codes2,
-                  const float* RESTRICT lower_bound,
-                  const float* RESTRICT diff,
-                  uint64_t dim);
-float
-SQ4ComputeCodesL2Sqr(const uint8_t* RESTRICT codes1,
-                     const uint8_t* RESTRICT codes2,
-                     const float* RESTRICT lower_bound,
-                     const float* RESTRICT diff,
-                     uint64_t dim);
-}  // namespace avx2
-
-namespace avx512 {
-float
-SQ4ComputeIP(const float* RESTRICT query,
-             const uint8_t* RESTRICT codes,
-             const float* RESTRICT lower_bound,
-             const float* RESTRICT diff,
-             uint64_t dim);
-float
-SQ4ComputeL2Sqr(const float* RESTRICT query,
-                const uint8_t* RESTRICT codes,
-                const float* RESTRICT lower_bound,
-                const float* RESTRICT diff,
-                uint64_t dim);
-float
-SQ4ComputeCodesIP(const uint8_t* RESTRICT codes1,
-                  const uint8_t* RESTRICT codes2,
-                  const float* RESTRICT lower_bound,
-                  const float* RESTRICT diff,
-                  uint64_t dim);
-float
-SQ4ComputeCodesL2Sqr(const uint8_t* RESTRICT codes1,
-                     const uint8_t* RESTRICT codes2,
-                     const float* RESTRICT lower_bound,
-                     const float* RESTRICT diff,
-                     uint64_t dim);
-}  // namespace avx512
-
-namespace neon {
-float
-SQ4ComputeIP(const float* RESTRICT query,
-             const uint8_t* RESTRICT codes,
-             const float* RESTRICT lower_bound,
-             const float* RESTRICT diff,
-             uint64_t dim);
-float
-SQ4ComputeL2Sqr(const float* RESTRICT query,
-                const uint8_t* RESTRICT codes,
-                const float* RESTRICT lower_bound,
-                const float* RESTRICT diff,
-                uint64_t dim);
-float
-SQ4ComputeCodesIP(const uint8_t* RESTRICT codes1,
-                  const uint8_t* RESTRICT codes2,
-                  const float* RESTRICT lower_bound,
-                  const float* RESTRICT diff,
-                  uint64_t dim);
-float
-SQ4ComputeCodesL2Sqr(const uint8_t* RESTRICT codes1,
-                     const uint8_t* RESTRICT codes2,
-                     const float* RESTRICT lower_bound,
-                     const float* RESTRICT diff,
-                     uint64_t dim);
-}  // namespace neon
-
-namespace sve {
-float
-SQ4ComputeIP(const float* RESTRICT query,
-             const uint8_t* RESTRICT codes,
-             const float* RESTRICT lower_bound,
-             const float* RESTRICT diff,
-             uint64_t dim);
-float
-SQ4ComputeL2Sqr(const float* RESTRICT query,
-                const uint8_t* RESTRICT codes,
-                const float* RESTRICT lower_bound,
-                const float* RESTRICT diff,
-                uint64_t dim);
-float
-SQ4ComputeCodesIP(const uint8_t* RESTRICT codes1,
-                  const uint8_t* RESTRICT codes2,
-                  const float* RESTRICT lower_bound,
-                  const float* RESTRICT diff,
-                  uint64_t dim);
-float
-SQ4ComputeCodesL2Sqr(const uint8_t* RESTRICT codes1,
-                     const uint8_t* RESTRICT codes2,
-                     const float* RESTRICT lower_bound,
-                     const float* RESTRICT diff,
-                     uint64_t dim);
-}  // namespace sve
+#undef DECLARE_SQ4_FUNCTIONS
 
 using SQ4ComputeType = float (*)(const float* RESTRICT query,
                                  const uint8_t* RESTRICT codes,

--- a/src/simd/sq4_uniform_simd.h
+++ b/src/simd/sq4_uniform_simd.h
@@ -20,54 +20,23 @@
 #include "simd_marco.h"
 
 namespace vsag {
-namespace generic {
-float
-SQ4UniformComputeCodesIP(const uint8_t* RESTRICT codes1,
-                         const uint8_t* RESTRICT codes2,
-                         uint64_t dim);
-}  // namespace generic
 
-namespace sse {
-float
-SQ4UniformComputeCodesIP(const uint8_t* RESTRICT codes1,
-                         const uint8_t* RESTRICT codes2,
-                         uint64_t dim);
-}  // namespace sse
+#define DECLARE_SQ4_UNIFORM_FUNCTIONS(ns)                    \
+    namespace ns {                                           \
+    float                                                    \
+    SQ4UniformComputeCodesIP(const uint8_t* RESTRICT codes1, \
+                             const uint8_t* RESTRICT codes2, \
+                             uint64_t dim);                  \
+    }  // namespace ns
+DECLARE_SQ4_UNIFORM_FUNCTIONS(generic)
+DECLARE_SQ4_UNIFORM_FUNCTIONS(sse)
+DECLARE_SQ4_UNIFORM_FUNCTIONS(avx)
+DECLARE_SQ4_UNIFORM_FUNCTIONS(avx2)
+DECLARE_SQ4_UNIFORM_FUNCTIONS(avx512)
+DECLARE_SQ4_UNIFORM_FUNCTIONS(neon)
+DECLARE_SQ4_UNIFORM_FUNCTIONS(sve)
 
-namespace avx {
-float
-SQ4UniformComputeCodesIP(const uint8_t* RESTRICT codes1,
-                         const uint8_t* RESTRICT codes2,
-                         uint64_t dim);
-}  // namespace avx
-
-namespace avx2 {
-float
-SQ4UniformComputeCodesIP(const uint8_t* RESTRICT codes1,
-                         const uint8_t* RESTRICT codes2,
-                         uint64_t dim);
-}  // namespace avx2
-
-namespace avx512 {
-float
-SQ4UniformComputeCodesIP(const uint8_t* RESTRICT codes1,
-                         const uint8_t* RESTRICT codes2,
-                         uint64_t dim);
-}  // namespace avx512
-
-namespace neon {
-float
-SQ4UniformComputeCodesIP(const uint8_t* RESTRICT codes1,
-                         const uint8_t* RESTRICT codes2,
-                         uint64_t dim);
-}  // namespace neon
-
-namespace sve {
-float
-SQ4UniformComputeCodesIP(const uint8_t* RESTRICT codes1,
-                         const uint8_t* RESTRICT codes2,
-                         uint64_t dim);
-}  // namespace sve
+#undef DECLARE_SQ4_UNIFORM_FUNCTIONS
 
 using SQ4UniformComputeCodesType = float (*)(const uint8_t* RESTRICT codes1,
                                              const uint8_t* RESTRICT codes2,

--- a/src/simd/sq8_simd.h
+++ b/src/simd/sq8_simd.h
@@ -19,194 +19,44 @@
 
 #include "simd_marco.h"
 namespace vsag {
-namespace generic {
-float
-SQ8ComputeIP(const float* RESTRICT query,
-             const uint8_t* RESTRICT codes,
-             const float* RESTRICT lower_bound,
-             const float* RESTRICT diff,
-             uint64_t dim);
-float
-SQ8ComputeL2Sqr(const float* RESTRICT query,
-                const uint8_t* RESTRICT codes,
-                const float* RESTRICT lower_bound,
-                const float* RESTRICT diff,
-                uint64_t dim);
-float
-SQ8ComputeCodesIP(const uint8_t* RESTRICT codes1,
-                  const uint8_t* RESTRICT codes2,
-                  const float* RESTRICT lower_bound,
-                  const float* RESTRICT diff,
-                  uint64_t dim);
-float
-SQ8ComputeCodesL2Sqr(const uint8_t* RESTRICT codes1,
-                     const uint8_t* RESTRICT codes2,
-                     const float* RESTRICT lower_bound,
-                     const float* RESTRICT diff,
-                     uint64_t dim);
-}  // namespace generic
 
-namespace sse {
-float
-SQ8ComputeIP(const float* RESTRICT query,
-             const uint8_t* RESTRICT codes,
-             const float* RESTRICT lower_bound,
-             const float* RESTRICT diff,
-             uint64_t dim);
-float
-SQ8ComputeL2Sqr(const float* RESTRICT query,
-                const uint8_t* RESTRICT codes,
-                const float* RESTRICT lower_bound,
-                const float* RESTRICT diff,
-                uint64_t dim);
-float
-SQ8ComputeCodesIP(const uint8_t* RESTRICT codes1,
-                  const uint8_t* RESTRICT codes2,
-                  const float* RESTRICT lower_bound,
-                  const float* RESTRICT diff,
-                  uint64_t dim);
-float
-SQ8ComputeCodesL2Sqr(const uint8_t* RESTRICT codes1,
-                     const uint8_t* RESTRICT codes2,
-                     const float* RESTRICT lower_bound,
-                     const float* RESTRICT diff,
-                     uint64_t dim);
-}  // namespace sse
+#define DECLARE_SQ8_FUNCTIONS(ns)                           \
+    namespace ns {                                          \
+    float                                                   \
+    SQ8ComputeIP(const float* RESTRICT query,               \
+                 const uint8_t* RESTRICT codes,             \
+                 const float* RESTRICT lower_bound,         \
+                 const float* RESTRICT diff,                \
+                 uint64_t dim);                             \
+    float                                                   \
+    SQ8ComputeL2Sqr(const float* RESTRICT query,            \
+                    const uint8_t* RESTRICT codes,          \
+                    const float* RESTRICT lower_bound,      \
+                    const float* RESTRICT diff,             \
+                    uint64_t dim);                          \
+    float                                                   \
+    SQ8ComputeCodesIP(const uint8_t* RESTRICT codes1,       \
+                      const uint8_t* RESTRICT codes2,       \
+                      const float* RESTRICT lower_bound,    \
+                      const float* RESTRICT diff,           \
+                      uint64_t dim);                        \
+    float                                                   \
+    SQ8ComputeCodesL2Sqr(const uint8_t* RESTRICT codes1,    \
+                         const uint8_t* RESTRICT codes2,    \
+                         const float* RESTRICT lower_bound, \
+                         const float* RESTRICT diff,        \
+                         uint64_t dim);                     \
+    }  // namespace ns
 
-namespace avx {
-float
-SQ8ComputeIP(const float* RESTRICT query,
-             const uint8_t* RESTRICT codes,
-             const float* RESTRICT lower_bound,
-             const float* RESTRICT diff,
-             uint64_t dim);
-float
-SQ8ComputeL2Sqr(const float* RESTRICT query,
-                const uint8_t* RESTRICT codes,
-                const float* RESTRICT lower_bound,
-                const float* RESTRICT diff,
-                uint64_t dim);
-float
-SQ8ComputeCodesIP(const uint8_t* RESTRICT codes1,
-                  const uint8_t* RESTRICT codes2,
-                  const float* RESTRICT lower_bound,
-                  const float* RESTRICT diff,
-                  uint64_t dim);
-float
-SQ8ComputeCodesL2Sqr(const uint8_t* RESTRICT codes1,
-                     const uint8_t* RESTRICT codes2,
-                     const float* RESTRICT lower_bound,
-                     const float* RESTRICT diff,
-                     uint64_t dim);
-}  // namespace avx
+DECLARE_SQ8_FUNCTIONS(generic)
+DECLARE_SQ8_FUNCTIONS(sse)
+DECLARE_SQ8_FUNCTIONS(avx)
+DECLARE_SQ8_FUNCTIONS(avx2)
+DECLARE_SQ8_FUNCTIONS(avx512)
+DECLARE_SQ8_FUNCTIONS(neon)
+DECLARE_SQ8_FUNCTIONS(sve)
 
-namespace avx2 {
-float
-SQ8ComputeIP(const float* RESTRICT query,
-             const uint8_t* RESTRICT codes,
-             const float* RESTRICT lower_bound,
-             const float* RESTRICT diff,
-             uint64_t dim);
-float
-SQ8ComputeL2Sqr(const float* RESTRICT query,
-                const uint8_t* RESTRICT codes,
-                const float* RESTRICT lower_bound,
-                const float* RESTRICT diff,
-                uint64_t dim);
-float
-SQ8ComputeCodesIP(const uint8_t* RESTRICT codes1,
-                  const uint8_t* RESTRICT codes2,
-                  const float* RESTRICT lower_bound,
-                  const float* RESTRICT diff,
-                  uint64_t dim);
-float
-SQ8ComputeCodesL2Sqr(const uint8_t* RESTRICT codes1,
-                     const uint8_t* RESTRICT codes2,
-                     const float* RESTRICT lower_bound,
-                     const float* RESTRICT diff,
-                     uint64_t dim);
-}  // namespace avx2
-
-namespace avx512 {
-float
-SQ8ComputeIP(const float* RESTRICT query,
-             const uint8_t* RESTRICT codes,
-             const float* RESTRICT lower_bound,
-             const float* RESTRICT diff,
-             uint64_t dim);
-float
-SQ8ComputeL2Sqr(const float* RESTRICT query,
-                const uint8_t* RESTRICT codes,
-                const float* RESTRICT lower_bound,
-                const float* RESTRICT diff,
-                uint64_t dim);
-float
-SQ8ComputeCodesIP(const uint8_t* RESTRICT codes1,
-                  const uint8_t* RESTRICT codes2,
-                  const float* RESTRICT lower_bound,
-                  const float* RESTRICT diff,
-                  uint64_t dim);
-float
-SQ8ComputeCodesL2Sqr(const uint8_t* RESTRICT codes1,
-                     const uint8_t* RESTRICT codes2,
-                     const float* RESTRICT lower_bound,
-                     const float* RESTRICT diff,
-                     uint64_t dim);
-}  // namespace avx512
-
-namespace neon {
-float
-SQ8ComputeIP(const float* RESTRICT query,
-             const uint8_t* RESTRICT codes,
-             const float* RESTRICT lower_bound,
-             const float* RESTRICT diff,
-             uint64_t dim);
-float
-SQ8ComputeL2Sqr(const float* RESTRICT query,
-                const uint8_t* RESTRICT codes,
-                const float* RESTRICT lower_bound,
-                const float* RESTRICT diff,
-                uint64_t dim);
-float
-SQ8ComputeCodesIP(const uint8_t* RESTRICT codes1,
-                  const uint8_t* RESTRICT codes2,
-                  const float* RESTRICT lower_bound,
-                  const float* RESTRICT diff,
-                  uint64_t dim);
-float
-SQ8ComputeCodesL2Sqr(const uint8_t* RESTRICT codes1,
-                     const uint8_t* RESTRICT codes2,
-                     const float* RESTRICT lower_bound,
-                     const float* RESTRICT diff,
-                     uint64_t dim);
-}  // namespace neon
-
-namespace sve {
-float
-SQ8ComputeIP(const float* RESTRICT query,
-             const uint8_t* RESTRICT codes,
-             const float* RESTRICT lower_bound,
-             const float* RESTRICT diff,
-             uint64_t dim);
-float
-SQ8ComputeL2Sqr(const float* RESTRICT query,
-                const uint8_t* RESTRICT codes,
-                const float* RESTRICT lower_bound,
-                const float* RESTRICT diff,
-                uint64_t dim);
-float
-SQ8ComputeCodesIP(const uint8_t* RESTRICT codes1,
-                  const uint8_t* RESTRICT codes2,
-                  const float* RESTRICT lower_bound,
-                  const float* RESTRICT diff,
-                  uint64_t dim);
-float
-SQ8ComputeCodesL2Sqr(const uint8_t* RESTRICT codes1,
-                     const uint8_t* RESTRICT codes2,
-                     const float* RESTRICT lower_bound,
-                     const float* RESTRICT diff,
-                     uint64_t dim);
-}  // namespace sve
+#undef DECLARE_SQ8_FUNCTIONS
 
 using SQ8ComputeType = float (*)(const float* RESTRICT query,
                                  const uint8_t* RESTRICT codes,

--- a/src/simd/sq8_uniform_simd.h
+++ b/src/simd/sq8_uniform_simd.h
@@ -20,54 +20,23 @@
 #include "simd_marco.h"
 
 namespace vsag {
-namespace generic {
-float
-SQ8UniformComputeCodesIP(const uint8_t* RESTRICT codes1,
-                         const uint8_t* RESTRICT codes2,
-                         uint64_t dim);
-}  // namespace generic
 
-namespace sse {
-float
-SQ8UniformComputeCodesIP(const uint8_t* RESTRICT codes1,
-                         const uint8_t* RESTRICT codes2,
-                         uint64_t dim);
-}  // namespace sse
+#define DECLARE_SQ8_UNIFORM_FUNCTIONS(ns)                    \
+    namespace ns {                                           \
+    float                                                    \
+    SQ8UniformComputeCodesIP(const uint8_t* RESTRICT codes1, \
+                             const uint8_t* RESTRICT codes2, \
+                             uint64_t dim);                  \
+    }  // namespace ns
+DECLARE_SQ8_UNIFORM_FUNCTIONS(generic)
+DECLARE_SQ8_UNIFORM_FUNCTIONS(sse)
+DECLARE_SQ8_UNIFORM_FUNCTIONS(avx)
+DECLARE_SQ8_UNIFORM_FUNCTIONS(avx2)
+DECLARE_SQ8_UNIFORM_FUNCTIONS(avx512)
+DECLARE_SQ8_UNIFORM_FUNCTIONS(neon)
+DECLARE_SQ8_UNIFORM_FUNCTIONS(sve)
 
-namespace avx {
-float
-SQ8UniformComputeCodesIP(const uint8_t* RESTRICT codes1,
-                         const uint8_t* RESTRICT codes2,
-                         uint64_t dim);
-}  // namespace avx
-
-namespace avx2 {
-float
-SQ8UniformComputeCodesIP(const uint8_t* RESTRICT codes1,
-                         const uint8_t* RESTRICT codes2,
-                         uint64_t dim);
-}  // namespace avx2
-
-namespace avx512 {
-float
-SQ8UniformComputeCodesIP(const uint8_t* RESTRICT codes1,
-                         const uint8_t* RESTRICT codes2,
-                         uint64_t dim);
-}  // namespace avx512
-
-namespace neon {
-float
-SQ8UniformComputeCodesIP(const uint8_t* RESTRICT codes1,
-                         const uint8_t* RESTRICT codes2,
-                         uint64_t dim);
-}  // namespace neon
-
-namespace sve {
-float
-SQ8UniformComputeCodesIP(const uint8_t* RESTRICT codes1,
-                         const uint8_t* RESTRICT codes2,
-                         uint64_t dim);
-}  // namespace sve
+#undef DECLARE_SQ8_UNIFORM_FUNCTIONS
 
 using SQ8UniformComputeCodesType = float (*)(const uint8_t* RESTRICT codes1,
                                              const uint8_t* RESTRICT codes2,


### PR DESCRIPTION
## Summary by Sourcery

Refactor SIMD headers to eliminate repetitive function declarations by introducing macros that generate per-architecture namespaces, and add a Prefetch implementation in the AVX512 backend.

Enhancements:
- Abstract SIMD function prototypes into DECLARE_* macros across multiple headers to remove duplicate namespace declarations for fp32, SQ4, SQ8, basic, bit, PQFS, INT8, normalize, SQ4/SQ8 uniform, BF16, and FP16 modules
- Replace individual per-architecture declarations with macro invocations and undefine macros after use
- Add a Prefetch function implementation in avx512.cpp