### PR TITLE
fix(sindi): bad alloc and bench issue caused by term id limit

### DIFF
--- a/src/algorithm/sindi/sindi.cpp
+++ b/src/algorithm/sindi/sindi.cpp
@@ -80,9 +80,13 @@ SINDI::Add(const DatasetPtr& base) {
 
         try {
             window_term_list_[cur_window]->InsertVector(sparse_vector, inner_id);
-        } catch (std::runtime_error& e) {
+        } catch (const std::runtime_error& e) {
             failed_ids.push_back(ids[i]);
-            logger::warn(e.what());
+            logger::warn(std::string("runtime error: ") + e.what());
+            continue;
+        } catch (const std::bad_alloc& e) {
+            failed_ids.push_back(ids[i]);
+            logger::warn(std::string("memory allocation failed: ") + e.what());
             continue;
         }
 

--- a/src/algorithm/sindi/sindi.cpp
+++ b/src/algorithm/sindi/sindi.cpp
@@ -82,11 +82,11 @@ SINDI::Add(const DatasetPtr& base) {
             window_term_list_[cur_window]->InsertVector(sparse_vector, inner_id);
         } catch (const std::runtime_error& e) {
             failed_ids.push_back(ids[i]);
-            logger::warn(std::string("runtime error: ") + e.what());
+            logger::warn("runtime error: {}", e.what());
             continue;
         } catch (const std::bad_alloc& e) {
             failed_ids.push_back(ids[i]);
-            logger::warn(std::string("memory allocation failed: ") + e.what());
+            logger::warn("memory allocation failed: {}", e.what());
             continue;
         }
 

--- a/src/algorithm/sindi/sindi_parameter.cpp
+++ b/src/algorithm/sindi/sindi_parameter.cpp
@@ -25,8 +25,8 @@ SINDIParameter::FromJson(const JsonType& json) {
         term_id_limit = json[SPARSE_TERM_ID_LIMIT].GetInt();
 
         CHECK_ARGUMENT(
-            (0 < term_id_limit and term_id_limit <= 1'000'000),
-            fmt::format("term_id_limit must in (0, 1'000'000], but now is {}", term_id_limit));
+            (0 < term_id_limit and term_id_limit <= 10'000'000),
+            fmt::format("term_id_limit must in (0, 10'000'000], but now is {}", term_id_limit));
     } else {
         term_id_limit = DEFAULT_TERM_ID_LIMIT;
     }

--- a/src/algorithm/sindi/sindi_parameter.cpp
+++ b/src/algorithm/sindi/sindi_parameter.cpp
@@ -33,7 +33,7 @@ SINDIParameter::FromJson(const JsonType& json) {
 
     if (json.Contains(SPARSE_DOC_PRUNE_RATIO)) {
         doc_prune_ratio = json[SPARSE_DOC_PRUNE_RATIO].GetFloat();
-        CHECK_ARGUMENT((0.0F <= doc_prune_ratio and doc_prune_ratio <= 0.5F),
+        CHECK_ARGUMENT((0.0F <= doc_prune_ratio and doc_prune_ratio <= 0.9F),
                        fmt::format("doc_prune_ratio must in [0, 0.5], got {}", doc_prune_ratio));
     } else {
         doc_prune_ratio = DEFAULT_DOC_PRUNE_RATIO;
@@ -96,7 +96,7 @@ SINDISearchParameter::FromJson(const JsonType& json) {
                    fmt::format("parameters must contains {}", INDEX_SINDI));
     if (json[INDEX_SINDI].Contains(SPARSE_TERM_PRUNE_RATIO)) {
         term_prune_ratio = json[INDEX_SINDI][SPARSE_TERM_PRUNE_RATIO].GetFloat();
-        CHECK_ARGUMENT((0.0F <= term_prune_ratio and term_prune_ratio <= 0.5F),
+        CHECK_ARGUMENT((0.0F <= term_prune_ratio and term_prune_ratio <= 0.9F),
                        fmt::format("term_prune_ratio must in [0, 0.5], got {}", term_prune_ratio));
     } else {
         term_prune_ratio = DEFAULT_TERM_PRUNE_RATIO;
@@ -105,7 +105,7 @@ SINDISearchParameter::FromJson(const JsonType& json) {
     if (json[INDEX_SINDI].Contains(SPARSE_QUERY_PRUNE_RATIO)) {
         query_prune_ratio = json[INDEX_SINDI][SPARSE_QUERY_PRUNE_RATIO].GetFloat();
         CHECK_ARGUMENT(
-            (0.0F <= query_prune_ratio and query_prune_ratio <= 0.5F),
+            (0.0F <= query_prune_ratio and query_prune_ratio <= 0.9F),
             fmt::format("query_prune_ratio must in [0, 0.5], got {}", query_prune_ratio));
     } else {
         query_prune_ratio = DEFAULT_QUERY_PRUNE_RATIO;

--- a/src/algorithm/sindi/sindi_parameter.cpp
+++ b/src/algorithm/sindi/sindi_parameter.cpp
@@ -34,7 +34,7 @@ SINDIParameter::FromJson(const JsonType& json) {
     if (json.Contains(SPARSE_DOC_PRUNE_RATIO)) {
         doc_prune_ratio = json[SPARSE_DOC_PRUNE_RATIO].GetFloat();
         CHECK_ARGUMENT((0.0F <= doc_prune_ratio and doc_prune_ratio <= 0.9F),
-                       fmt::format("doc_prune_ratio must in [0, 0.5], got {}", doc_prune_ratio));
+                       fmt::format("doc_prune_ratio must in [0, 0.9], got {}", doc_prune_ratio));
     } else {
         doc_prune_ratio = DEFAULT_DOC_PRUNE_RATIO;
     }
@@ -97,7 +97,7 @@ SINDISearchParameter::FromJson(const JsonType& json) {
     if (json[INDEX_SINDI].Contains(SPARSE_TERM_PRUNE_RATIO)) {
         term_prune_ratio = json[INDEX_SINDI][SPARSE_TERM_PRUNE_RATIO].GetFloat();
         CHECK_ARGUMENT((0.0F <= term_prune_ratio and term_prune_ratio <= 0.9F),
-                       fmt::format("term_prune_ratio must in [0, 0.5], got {}", term_prune_ratio));
+                       fmt::format("term_prune_ratio must in [0, 0.9], got {}", term_prune_ratio));
     } else {
         term_prune_ratio = DEFAULT_TERM_PRUNE_RATIO;
     }
@@ -106,7 +106,7 @@ SINDISearchParameter::FromJson(const JsonType& json) {
         query_prune_ratio = json[INDEX_SINDI][SPARSE_QUERY_PRUNE_RATIO].GetFloat();
         CHECK_ARGUMENT(
             (0.0F <= query_prune_ratio and query_prune_ratio <= 0.9F),
-            fmt::format("query_prune_ratio must in [0, 0.5], got {}", query_prune_ratio));
+            fmt::format("query_prune_ratio must in [0, 0.9], got {}", query_prune_ratio));
     } else {
         query_prune_ratio = DEFAULT_QUERY_PRUNE_RATIO;
     }

--- a/src/common.h
+++ b/src/common.h
@@ -55,7 +55,7 @@ constexpr static const float GENERATE_OMEGA = 0.51;
 
 // sindi related
 constexpr static const uint32_t ESTIMATE_DOC_TERM = 100;
-constexpr static const uint32_t DEFAULT_TERM_ID_LIMIT = 100000;
+constexpr static const uint32_t DEFAULT_TERM_ID_LIMIT = 1000000;
 constexpr static const uint32_t DEFAULT_WINDOW_SIZE = 100000;
 constexpr static const bool DEFAULT_USE_REORDER = false;
 constexpr static const float DEFAULT_QUERY_PRUNE_RATIO = 0.0F;

--- a/src/datacell/sparse_term_datacell.cpp
+++ b/src/datacell/sparse_term_datacell.cpp
@@ -185,20 +185,18 @@ SparseTermDataCell::ResizeTermList(InnerIdType new_term_capacity) {
         return;
     }
 
-    Vector<Vector<uint32_t>> new_ids(new_term_capacity, Vector<uint32_t>(allocator_), allocator_);
-    Vector<Vector<float>> new_datas(new_term_capacity, Vector<float>(allocator_), allocator_);
-    Vector<uint32_t> new_sizes(new_term_capacity, 0, allocator_);
+    Vector<Vector<uint32_t>> new_ids(allocator_);
+    Vector<Vector<float>> new_datas(allocator_);
+    Vector<uint32_t> new_sizes(allocator_);
 
-    for (auto& vec : term_ids_) {
-        new_ids.emplace_back(std::move(vec));
-    }
-    for (auto& vec : term_datas_) {
-        new_datas.emplace_back(std::move(vec));
-    }
+    new_ids.resize(new_term_capacity, Vector<uint32_t>(allocator_));
+    new_datas.resize(new_term_capacity, Vector<float>(allocator_));
+    new_sizes.resize(new_term_capacity, 0);
 
-    while (new_ids.size() < new_term_capacity) {
-        new_ids.emplace_back(allocator_);
-        new_datas.emplace_back(allocator_);
+    for (uint32_t i = 0; i < term_ids_.size(); ++i) {
+        new_ids[i] = std::move(term_ids_[i]);
+        new_datas[i] = std::move(term_datas_[i]);
+        new_sizes[i] = term_sizes_[i];
     }
 
     term_ids_.swap(new_ids);

--- a/src/datacell/sparse_term_datacell.cpp
+++ b/src/datacell/sparse_term_datacell.cpp
@@ -181,13 +181,30 @@ SparseTermDataCell::InsertVector(const SparseVector& sparse_base, uint32_t base_
 
 void
 SparseTermDataCell::ResizeTermList(InnerIdType new_term_capacity) {
-    if (new_term_capacity <= this->term_capacity_) {
+    if (new_term_capacity <= term_capacity_) {
         return;
     }
-    this->term_capacity_ = new_term_capacity;
-    term_ids_.resize(term_capacity_, Vector<uint32_t>(allocator_));
-    term_datas_.resize(term_capacity_, Vector<float>(allocator_));
-    term_sizes_.resize(term_capacity_, 0);
+
+    Vector<Vector<uint32_t>> new_ids(new_term_capacity, Vector<uint32_t>(allocator_), allocator_);
+    Vector<Vector<float>> new_datas(new_term_capacity, Vector<float>(allocator_), allocator_);
+    Vector<uint32_t> new_sizes(new_term_capacity, 0, allocator_);
+
+    for (auto& vec : term_ids_) {
+        new_ids.emplace_back(std::move(vec));
+    }
+    for (auto& vec : term_datas_) {
+        new_datas.emplace_back(std::move(vec));
+    }
+
+    while (new_ids.size() < new_term_capacity) {
+        new_ids.emplace_back(allocator_);
+        new_datas.emplace_back(allocator_);
+    }
+
+    term_ids_.swap(new_ids);
+    term_datas_.swap(new_datas);
+    term_sizes_.swap(new_sizes);
+    term_capacity_ = new_term_capacity;
 }
 
 float

--- a/src/datacell/sparse_term_datacell.cpp
+++ b/src/datacell/sparse_term_datacell.cpp
@@ -185,19 +185,13 @@ SparseTermDataCell::ResizeTermList(InnerIdType new_term_capacity) {
         return;
     }
 
-    Vector<Vector<uint32_t>> new_ids(allocator_);
-    Vector<Vector<float>> new_datas(allocator_);
-    Vector<uint32_t> new_sizes(allocator_);
+    Vector<Vector<uint32_t>> new_ids(new_term_capacity, Vector<uint32_t>(allocator_), allocator_);
+    Vector<Vector<float>> new_datas(new_term_capacity, Vector<float>(allocator_), allocator_);
+    Vector<uint32_t> new_sizes(new_term_capacity, 0, allocator_);
 
-    new_ids.resize(new_term_capacity, Vector<uint32_t>(allocator_));
-    new_datas.resize(new_term_capacity, Vector<float>(allocator_));
-    new_sizes.resize(new_term_capacity, 0);
-
-    for (uint32_t i = 0; i < term_ids_.size(); ++i) {
-        new_ids[i] = std::move(term_ids_[i]);
-        new_datas[i] = std::move(term_datas_[i]);
-        new_sizes[i] = term_sizes_[i];
-    }
+    std::move(term_ids_.begin(), term_ids_.end(), new_ids.begin());
+    std::move(term_datas_.begin(), term_datas_.end(), new_datas.begin());
+    std::copy(term_sizes_.begin(), term_sizes_.end(), new_sizes.begin());
 
     term_ids_.swap(new_ids);
     term_datas_.swap(new_datas);

--- a/tests/test_sindi.cpp
+++ b/tests/test_sindi.cpp
@@ -75,7 +75,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex,
                              "[ft][sindi]") {
     SECTION("invalid doc_prune_ratio") {
         fixtures::SINDIParam param;
-        param.doc_prune_ratio = 0.6;
+        param.doc_prune_ratio = 0.99;
         REQUIRE_THROWS(
             TestFactory("sindi", fixtures::SINDITestIndex::GenerateBuildParameter(param), false));
         param.doc_prune_ratio = -0.1;


### PR DESCRIPTION
close #1244

## Summary by Sourcery

Refactor term list resizing to avoid allocation failures, enhance exception handling and logging in the SINDI algorithm, and raise the term ID limit to 10 million

Bug Fixes:
- Prevent crashes by handling std::bad_alloc during vector insertions and in term list resizing

Enhancements:
- Refactor ResizeTermList to preallocate new buffers, move existing data, and swap the new containers to improve stability
- Catch std::runtime_error by const reference and prepend context to log messages in SINDI::Add
- Increase the validated upper bound for term_id_limit from 1,000,000 to 10,000,000 in SINDIParameter