### PR TITLE
feat(io): introduce io_array to manager multi buckets'IO

### DIFF
--- a/scripts/collect_cpp_coverage.sh
+++ b/scripts/collect_cpp_coverage.sh
@@ -33,7 +33,7 @@ lcov --remove ${COVERAGE_DIR}/coverage.info \
      --ignore-errors unused,unused \
      --output-file ${COVERAGE_DIR}/coverage.info
 lcov --list ${COVERAGE_DIR}/coverage.info \
-     --ignore-errors inconsistent,inconsistent
+     --ignore-errors inconsistent,inconsistent,child
 
 pushd "${COVERAGE_DIR}"
 coverages=$(ls coverage.info)

--- a/src/datacell/sparse_vector_datacell.inl
+++ b/src/datacell/sparse_vector_datacell.inl
@@ -164,7 +164,7 @@ SparseVectorDataCell<QuantTmpl, IOTmpl>::SparseVectorDataCell(
     this->quantizer_ = std::make_shared<QuantTmpl>(quantization_param, common_param);
     this->io_ = std::make_shared<IOTmpl>(io_param, common_param);
     this->offset_io_ =
-        std::make_shared<MemoryBlockIO>(allocator_, Options::Instance().block_size_limit());
+        std::make_shared<MemoryBlockIO>(Options::Instance().block_size_limit(), allocator_);
     this->max_code_size_ = (this->quantizer_->GetDim() * 2 + 1) * sizeof(uint32_t);
     this->max_capacity_ = 0;
     this->code_size_ = this->quantizer_->GetCodeSize();

--- a/src/io/io_array.h
+++ b/src/io/io_array.h
@@ -1,0 +1,109 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "noncontinuous_allocator.h"
+#include "typing.h"
+
+namespace vsag {
+class Allocator;
+
+template <typename IOTmpl>
+class IOArray {
+public:
+    static constexpr bool InMemory = IOTmpl::InMemory;
+
+public:
+    template <typename... Args>
+    explicit IOArray(Allocator* allocator, Args&&... args)
+        : allocator_(allocator), datas_(allocator) {
+        non_continuous_allocator_ = std::make_unique<NonContinuousAllocator>(allocator);
+        using ArgsTuple = std::tuple<std::decay_t<Args>...>;
+        ArgsTuple args_tuple(std::forward<Args>(args)...);
+        if constexpr (InMemory) {
+            io_create_func_ = [args_tuple =
+                                   std::move(args_tuple)]() mutable -> std::shared_ptr<IOTmpl> {
+                return std::apply(
+                    [](auto&&... forwarded_args) -> std::shared_ptr<IOTmpl> {
+                        return std::make_shared<IOTmpl>(
+                            std::forward<decltype(forwarded_args)>(forwarded_args)...);
+                    },
+                    args_tuple);
+            };
+        } else {
+            auto* non_continuous_allocator = non_continuous_allocator_.get();
+            io_create_func_ = [non_continuous_allocator,
+                               allocator,
+                               args_tuple =
+                                   std::move(args_tuple)]() mutable -> std::shared_ptr<IOTmpl> {
+                return std::apply(
+                    [non_continuous_allocator,
+                     allocator](auto&&... forwarded_args) -> std::shared_ptr<IOTmpl> {
+                        return std::make_shared<IOTmpl>(
+                            non_continuous_allocator,
+                            allocator,
+                            std::forward<decltype(forwarded_args)>(forwarded_args)...);
+                    },
+                    args_tuple);
+            };
+        }
+    }
+
+    IOTmpl&
+    operator[](int64_t index) {
+        return *datas_[index];
+    }
+
+    const IOTmpl&
+    operator[](int64_t index) const {
+        return *datas_[index];
+    }
+
+    IOTmpl&
+    At(int64_t index) {
+        if (index >= datas_.size()) {
+            throw std::out_of_range("IOArray index out of range");
+        }
+        return *datas_[index];
+    }
+
+    const IOTmpl&
+    At(int64_t index) const {
+        if (index >= datas_.size()) {
+            throw std::out_of_range("IOArray index out of range");
+        }
+        return *datas_[index];
+    }
+
+    void
+    Resize(int64_t size) {
+        auto cur_size = datas_.size();
+        this->datas_.resize(size, nullptr);
+        for (int64_t i = cur_size; i < size; i++) {
+            datas_[i] = this->io_create_func_();
+        }
+    }
+
+private:
+    Allocator* const allocator_{nullptr};
+
+    Vector<std::shared_ptr<IOTmpl>> datas_;
+
+    std::unique_ptr<NonContinuousAllocator> non_continuous_allocator_{nullptr};
+
+    std::function<std::shared_ptr<IOTmpl>()> io_create_func_;
+};
+}  // namespace vsag

--- a/src/io/io_array_test.cpp
+++ b/src/io/io_array_test.cpp
@@ -1,0 +1,84 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "io_array.h"
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include "async_io.h"
+#include "basic_io_test.h"
+#include "buffer_io.h"
+#include "impl/allocator/safe_allocator.h"
+#include "memory_block_io.h"
+#include "memory_io.h"
+#include "mmap_io.h"
+#include "noncontinuous_io.h"
+
+namespace vsag {
+template <typename IOType>
+class IOArrayTest {
+public:
+    template <typename... Args>
+    IOArrayTest(Allocator* allocator, Args&&... args)
+        : array_(std::make_unique<IOArray<IOType>>(allocator, std::forward<Args>(args)...)) {
+    }
+
+    void
+    TestBasic() {
+        this->array_->Resize(5);
+        for (size_t i = 0; i < 5; ++i) {
+            TestBasicReadWrite((*this->array_)[i]);
+        }
+        for (size_t i = 0; i < 5; ++i) {
+            TestBasicReadWrite(this->array_->At(i));
+        }
+        this->array_->Resize(10);
+        for (size_t i = 5; i < 10; ++i) {
+            TestBasicReadWrite(this->array_->At(i));
+        }
+    }
+
+    std::unique_ptr<IOArray<IOType>> array_{nullptr};
+};
+}  // namespace vsag
+
+using namespace vsag;
+
+TEST_CASE("IOArrayTest MemoryIO Basic Test", "[IOArray][ut]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    IOArrayTest<MemoryIO> test(allocator.get(), allocator.get());
+    test.TestBasic();
+}
+
+TEST_CASE("IOArrayTest MemoryBlockIO Basic Test", "[IOArray][ut]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    IOArrayTest<MemoryBlockIO> test(allocator.get(), static_cast<uint64_t>(4096), allocator.get());
+    test.TestBasic();
+}
+
+TEST_CASE("IOArrayTest BufferIO Basic Test", "[IOArray][ut]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    IOArrayTest<NonContinuousIO<BufferIO>> test(
+        allocator.get(), "/tmp/test_buffer_io", allocator.get());
+    test.TestBasic();
+}
+
+TEST_CASE("IOArrayTest AsyncIO Basic Test", "[IOArray][ut]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    IOArrayTest<NonContinuousIO<AsyncIO>> test(
+        allocator.get(), "/tmp/test_async_io", allocator.get());
+    test.TestBasic();
+}

--- a/src/io/memory_block_io.cpp
+++ b/src/io/memory_block_io.cpp
@@ -25,7 +25,7 @@
 
 namespace vsag {
 
-MemoryBlockIO::MemoryBlockIO(Allocator* allocator, uint64_t block_size)
+MemoryBlockIO::MemoryBlockIO(uint64_t block_size, Allocator* allocator)
     : BasicIO<MemoryBlockIO>(allocator),
       block_size_(MemoryBlockIOParameter::NearestPowerOfTwo(block_size)),
       blocks_(0, allocator) {
@@ -34,7 +34,7 @@ MemoryBlockIO::MemoryBlockIO(Allocator* allocator, uint64_t block_size)
 
 MemoryBlockIO::MemoryBlockIO(const MemoryBlockIOParamPtr& param,
                              const IndexCommonParam& common_param)
-    : MemoryBlockIO(common_param.allocator_.get(), param->block_size_) {
+    : MemoryBlockIO(param->block_size_, common_param.allocator_.get()) {
 }
 
 MemoryBlockIO::MemoryBlockIO(const IOParamPtr& param, const IndexCommonParam& common_param)

--- a/src/io/memory_block_io.h
+++ b/src/io/memory_block_io.h
@@ -27,7 +27,7 @@ public:
     static constexpr bool SkipDeserialize = false;
 
 public:
-    explicit MemoryBlockIO(Allocator* allocator, uint64_t block_size);
+    explicit MemoryBlockIO(uint64_t block_size, Allocator* allocator);
 
     explicit MemoryBlockIO(const MemoryBlockIOParamPtr& param,
                            const IndexCommonParam& common_param);

--- a/src/io/memory_block_io_test.cpp
+++ b/src/io/memory_block_io_test.cpp
@@ -28,7 +28,7 @@ auto block_memory_io_block_sizes = {1023, 4096, 123123, 1024 * 1024};
 TEST_CASE("MemoryBlockIO Read and Write Test", "[ut][MemoryBlockIO]") {
     auto allocator = SafeAllocator::FactoryDefaultAllocator();
     for (auto block_size : block_memory_io_block_sizes) {
-        auto io = std::make_unique<MemoryBlockIO>(allocator.get(), block_size);
+        auto io = std::make_unique<MemoryBlockIO>(block_size, allocator.get());
         TestBasicReadWrite(*io);
     }
 }
@@ -36,8 +36,8 @@ TEST_CASE("MemoryBlockIO Read and Write Test", "[ut][MemoryBlockIO]") {
 TEST_CASE("MemoryBlockIO Serialize and Deserialize Test", "[ut][MemoryBlockIO]") {
     auto allocator = SafeAllocator::FactoryDefaultAllocator();
     for (auto block_size : block_memory_io_block_sizes) {
-        auto wio = std::make_unique<MemoryBlockIO>(allocator.get(), block_size);
-        auto rio = std::make_unique<MemoryBlockIO>(allocator.get(), block_size);
+        auto wio = std::make_unique<MemoryBlockIO>(block_size, allocator.get());
+        auto rio = std::make_unique<MemoryBlockIO>(block_size, allocator.get());
         TestSerializeAndDeserialize(*wio, *rio);
     }
 }

--- a/src/io/noncontinuous_allocator.h
+++ b/src/io/noncontinuous_allocator.h
@@ -1,0 +1,56 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+
+namespace vsag {
+
+class Allocator;
+struct NonContinuousArea {
+public:
+    uint64_t offset{0};
+    uint64_t size{0};
+
+    NonContinuousArea() = default;
+    explicit NonContinuousArea(uint64_t offset, uint64_t size) : offset(offset), size(size){};
+};
+
+class NonContinuousAllocator {
+public:
+    explicit NonContinuousAllocator(Allocator* allocator) : allocator_(allocator) {
+    }
+
+    ~NonContinuousAllocator() = default;
+
+    [[nodiscard]] inline NonContinuousArea
+    Require(uint64_t size) {
+        // 4k align
+        size = (size + ALOGN_SIZE - 1) & ~(ALOGN_SIZE - 1);
+        NonContinuousArea area{last_offset_, size};
+        last_offset_ += size;
+        return area;
+    }
+
+private:
+    Allocator* const allocator_{nullptr};
+
+    uint64_t last_offset_{0};
+
+    static constexpr uint64_t ALOGN_SIZE = 4096;
+};
+
+}  // namespace vsag

--- a/src/io/noncontinuous_io.h
+++ b/src/io/noncontinuous_io.h
@@ -1,0 +1,173 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "basic_io.h"
+#include "io_array.h"
+#include "noncontinuous_allocator.h"
+
+namespace vsag {
+
+class IndexCommonParam;
+class Allocator;
+
+template <typename IOTmpl>
+class NonContinuousIOTest;
+template <typename IOTmpl>
+class NonContinuousIO : public BasicIO<NonContinuousIO<IOTmpl>> {
+public:
+    static constexpr bool InMemory = IOTmpl::InMemory;
+    static constexpr bool SkipDeserialize = false;
+
+    template <typename... Args>
+    NonContinuousIO(NonContinuousAllocator* non_continuous_allocator,
+                    Allocator* allocator,
+                    Args&&... args)
+        : BasicIO<NonContinuousIO<IOTmpl>>(allocator),
+          non_continuous_allocator_(non_continuous_allocator),
+          areas_(allocator),
+          inner_io_(std::make_unique<IOTmpl>(std::forward<Args>(args)...)) {
+    }
+
+    ~NonContinuousIO() override = default;
+
+    void
+    WriteImpl(const uint8_t* data, uint64_t size, uint64_t offset) {
+        auto capacity = this->get_cur_max_size();
+        if (size + offset > capacity) {
+            auto area = this->non_continuous_allocator_->Require(size + offset - capacity);
+            areas_.emplace_back(area, capacity + area.size);
+        }
+        auto start_area = this->get_area(offset);
+        auto start_offset =
+            start_area->first.offset + (offset - start_area->second + start_area->first.size);
+        uint64_t cur_size = 0;
+        while (cur_size < size) {
+            auto area = start_area->first;
+            auto area_size = std::min(size - cur_size, area.size - (start_offset - area.offset));
+            inner_io_->WriteImpl(data + cur_size, area_size, start_offset);
+            cur_size += area_size;
+            start_area++;
+            if (start_area != areas_.end()) {
+                start_offset = start_area->first.offset;
+            }
+        }
+        if (offset + size > this->size_) {
+            this->size_ = offset + size;
+        }
+    }
+
+    bool
+    ReadImpl(uint64_t size, uint64_t offset, uint8_t* data) const {
+        bool ret = this->check_valid_offset(size + offset);
+        if (not ret) {
+            return ret;
+        }
+        auto start_area = this->get_area(offset);
+        auto start_offset =
+            start_area->first.offset + (offset - start_area->second + start_area->first.size);
+        uint64_t cur_size = 0;
+        std::vector<uint64_t> sizes;
+        std::vector<uint64_t> offsets;
+        while (cur_size < size) {
+            auto area = start_area->first;
+            auto area_size = std::min(size - cur_size, area.size - (start_offset - area.offset));
+            sizes.emplace_back(area_size);
+            offsets.emplace_back(start_offset);
+            cur_size += area_size;
+            start_area++;
+            if (start_area != areas_.end()) {
+                start_offset = start_area->first.offset;
+            }
+        }
+        ret = inner_io_->MultiReadImpl(data, sizes.data(), offsets.data(), sizes.size());
+        return ret;
+    }
+
+    [[nodiscard]] const uint8_t*
+    DirectReadImpl(uint64_t size, uint64_t offset, bool& need_release) const {
+        bool ret = this->check_valid_offset(size + offset);
+        if (not ret) {
+            return nullptr;
+        }
+        auto* data = reinterpret_cast<uint8_t*>(this->allocator_->Allocate(size));
+        ret = this->ReadImpl(size, offset, data);
+        if (not ret) {
+            this->allocator_->Deallocate(data);
+            return nullptr;
+        }
+        need_release = true;
+        return data;
+    }
+
+    bool
+    MultiReadImpl(uint8_t* datas, uint64_t* sizes, uint64_t* offsets, uint64_t count) const {
+        bool ret = true;
+        for (uint64_t i = 0; i < count; i++) {
+            ret &= this->ReadImpl(sizes[i], offsets[i], datas);
+            datas += sizes[i];
+        }
+        return ret;
+    }
+
+    void
+    ReleaseImpl(const uint8_t* data) const {
+        this->allocator_->Deallocate(const_cast<uint8_t*>(data));
+    }
+
+private:
+    using PostSizeType = uint64_t;
+
+    friend IOArray<NonContinuousIO<IOTmpl>>;
+
+    // #if defined(ENABLE_TESTS)
+    friend class NonContinuousIOTest<IOTmpl>;
+    // #endif
+
+    uint64_t
+    mapping_offset(uint64_t offset) const {
+        auto it = this->get_area(offset);
+        uint64_t start_size = it->second - it->first.size;
+        return it->first.offset + (offset - start_size);
+    }
+
+    auto
+    get_area(uint64_t offset) const {
+        return std::upper_bound(
+            areas_.begin(),
+            areas_.end(),
+            offset,
+            [](uint64_t offset, const std::pair<NonContinuousArea, PostSizeType>& area) {
+                return offset < area.second;
+            });
+    }
+
+    inline PostSizeType
+    get_cur_max_size() const {
+        if (areas_.empty()) {
+            return 0;
+        }
+        return areas_.back().second;
+    }
+
+private:
+    NonContinuousAllocator* const non_continuous_allocator_{nullptr};
+
+    std::unique_ptr<IOTmpl> inner_io_{nullptr};
+
+    Vector<std::pair<NonContinuousArea, PostSizeType>> areas_;
+};
+}  // namespace vsag

--- a/src/io/noncontinuous_io_test.cpp
+++ b/src/io/noncontinuous_io_test.cpp
@@ -1,0 +1,92 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "noncontinuous_io.h"
+
+#include <catch2/catch_template_test_macros.hpp>
+
+#include "async_io.h"
+#include "basic_io_test.h"
+#include "buffer_io.h"
+#include "impl/allocator/safe_allocator.h"
+#include "mmap_io.h"
+namespace vsag {
+template <typename IOTmpl>
+class NonContinuousIOTest {
+public:
+    NonContinuousIOTest() = default;
+    ~NonContinuousIOTest() = default;
+
+    template <typename... Args>
+    NonContinuousIO<IOTmpl>*
+    CreateNonContinuousIO(NonContinuousAllocator* non_continuous_allocator,
+                          Allocator* allocator,
+                          Args&&... args) {
+        return new NonContinuousIO<IOTmpl>(
+            non_continuous_allocator, allocator, std::forward<Args>(args)...);
+    }
+};
+}  // namespace vsag
+
+using namespace vsag;
+template <typename T>
+void
+NonContinuousIOTestBasic() {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    {
+        NonContinuousIOTest<T> test;
+        auto non_continuous_allocator = std::make_unique<NonContinuousAllocator>(allocator.get());
+        auto io = test.CreateNonContinuousIO(non_continuous_allocator.get(),
+                                             allocator.get(),
+                                             "/tmp/test_noncontinuous_io",
+                                             allocator.get());
+        TestBasicReadWrite(*io);
+        delete io;
+    }
+}
+
+TEST_CASE("NonContinuousIO Basic Test", "[NonContinuousIO][ut]") {
+    NonContinuousIOTestBasic<MMapIO>();
+    NonContinuousIOTestBasic<BufferIO>();
+    NonContinuousIOTestBasic<AsyncIO>();
+}
+
+template <typename T>
+void
+NonContinuousIOTestSerialize() {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    {
+        NonContinuousIOTest<T> test;
+        auto non_continuous_allocator1 = std::make_unique<NonContinuousAllocator>(allocator.get());
+        auto io1 = test.CreateNonContinuousIO(non_continuous_allocator1.get(),
+                                              allocator.get(),
+                                              "/tmp/test_noncontinuous_io1",
+                                              allocator.get());
+        auto non_continuous_allocator2 = std::make_unique<NonContinuousAllocator>(allocator.get());
+        auto io2 = test.CreateNonContinuousIO(non_continuous_allocator2.get(),
+                                              allocator.get(),
+                                              "/tmp/test_noncontinuous_io2",
+                                              allocator.get());
+        TestSerializeAndDeserialize(*io1, *io2);
+        delete io1;
+        delete io2;
+    }
+}
+
+TEST_CASE("NonContinuousIO Serialize Test", "[NonContinuousIO][ut]") {
+    NonContinuousIOTestSerialize<MMapIO>();
+    NonContinuousIOTestSerialize<BufferIO>();
+    NonContinuousIOTestSerialize<AsyncIO>();
+}


### PR DESCRIPTION
closed: #820 

- for ondisk IO, produce "array" view for one IO instance

## Summary by Sourcery

Provide a generic array-based I/O manager and a non-contiguous I/O layer by introducing IOArray, NonContinuousAllocator, and NonContinuousIO, adjust MemoryBlockIO constructor signature, and cover these with new unit tests

New Features:
- Add IOArray template to manage arrays of I/O instances with automatic creation and resizing
- Introduce NonContinuousAllocator for aligned, non-contiguous storage allocation
- Implement NonContinuousIO wrapper to support multi-area writes, reads, and direct reads using underlying I/O backends

Enhancements:
- Swap MemoryBlockIO constructor parameters to standardize ordering of block size and allocator

Tests:
- Add unit tests for IOArray with various I/O backends
- Add unit tests for NonContinuousIO with memory, file-based, and async I/O implementations