### PR TITLE
feat(SINDI): add term id limit check (cp 0.16)

### DIFF
--- a/examples/cpp/109_index_sindi.cpp
+++ b/examples/cpp/109_index_sindi.cpp
@@ -114,6 +114,7 @@ main(int argc, char** argv) {
      * - index_param: Parameters specific to sparse indexing:
      *   - use_reorder: If true, enables full-precision re-ranking of results. This requires storing additional data.
      *     When doc_prune_ratio is 0, use_reorder can be false while still maintaining full-precision results.
+     *   - term_id_limit: Maximum term id (e.g., when term_id_limit = 10, then, term [15: 0.1] in sparse vector is not allowed)
      *   - doc_prune_ratio: Ratio of term pruning in documents (0 = no pruning).
      *   - window_size: Window size for table scanning. Related to L3 cache size; 100000 is an empirically optimal value.
      */
@@ -124,6 +125,7 @@ main(int argc, char** argv) {
         "metric_type": "ip",
         "index_param": {
             "use_reorder": true,
+            "term_id_limit": 1000000,
             "doc_prune_ratio": 0.0,
             "window_size": 100000
         }

--- a/src/algorithm/sindi/sindi.cpp
+++ b/src/algorithm/sindi/sindi.cpp
@@ -31,6 +31,7 @@ SINDI::CheckAndMappingExternalParam(const JsonType& external_param,
 SINDI::SINDI(const SINDIParameterPtr& param, const IndexCommonParam& common_param)
     : InnerIndexInterface(param, common_param),
       use_reorder_(param->use_reorder),
+      term_id_limit_(param->term_id_limit),
       window_size_(param->window_size),
       doc_retain_ratio_(1.0F - param->doc_prune_ratio),
       window_term_list_(common_param.allocator_.get()),
@@ -49,6 +50,7 @@ SINDI::Add(const DatasetPtr& base) {
     auto data_num = base->GetNumElements();
     CHECK_ARGUMENT(data_num > 0, "data_num is zero when add vectors");
 
+    std::vector<int64_t> failed_ids;
     const auto* sparse_vectors = base->GetSparseVectors();
     const auto* ids = base->GetIds();
 
@@ -56,7 +58,7 @@ SINDI::Add(const DatasetPtr& base) {
     int64_t final_add_window = ceil_int(cur_element_count_ + data_num, window_size_) / window_size_;
     while (window_term_list_.size() < final_add_window) {
         window_term_list_.emplace_back(
-            std::make_shared<SparseTermDataCell>(doc_retain_ratio_, allocator_));
+            std::make_shared<SparseTermDataCell>(doc_retain_ratio_, term_id_limit_, allocator_));
     }
 
     // add process
@@ -64,19 +66,39 @@ SINDI::Add(const DatasetPtr& base) {
         auto cur_window = cur_element_count_ / window_size_;
         auto window_start_id = cur_window * window_size_;
         const auto& sparse_vector = sparse_vectors[i];
+        if (sparse_vectors->len_ <= 0) {
+            failed_ids.push_back(ids[i]);
+            logger::warn(
+                "sparse_vectors.len_ ({}) is invalid for id ({})", sparse_vectors->len_, ids[i]);
+            continue;
+        }
+
+        uint32_t inner_id = cur_element_count_ - window_start_id;
+
+        try {
+            window_term_list_[cur_window]->InsertVector(sparse_vector, inner_id);
+        } catch (std::runtime_error& e) {
+            failed_ids.push_back(ids[i]);
+            logger::warn(e.what());
+            continue;
+        }
 
         label_table_->Insert(cur_element_count_, ids[i]);  // todo(zxy): check id exists
-        uint32_t inner_id = cur_element_count_ - window_start_id;
-        window_term_list_[cur_window]->InsertVector(sparse_vector, inner_id);
 
         cur_element_count_++;
-    }
-    // high precision part
-    if (use_reorder_) {
-        rerank_flat_index_->Add(base);
+
+        // high precision part
+        if (use_reorder_) {
+            auto single_base = Dataset::Make();
+            single_base->NumElements(1)
+                ->SparseVectors(sparse_vectors + i)
+                ->Ids(ids + i)
+                ->Owner(false);
+            rerank_flat_index_->Add(single_base);
+        }
     }
 
-    return {};
+    return failed_ids;
 }
 
 std::vector<int64_t>
@@ -97,6 +119,8 @@ SINDI::KnnSearch(const DatasetPtr& query,
     const auto* sparse_vectors = query->GetSparseVectors();
     CHECK_ARGUMENT(query->GetNumElements() == 1, "num of query should be 1");
     auto sparse_query = sparse_vectors[0];
+    CHECK_ARGUMENT(sparse_vectors->len_ > 0,
+                   fmt::format("sparse_vectors.len_ ({}) is invalid", sparse_vectors->len_));
 
     // search parameter
     SINDISearchParameter search_param;
@@ -230,6 +254,8 @@ SINDI::RangeSearch(const DatasetPtr& query,
     const auto* sparse_vectors = query->GetSparseVectors();
     CHECK_ARGUMENT(query->GetNumElements() == 1, "num of query should be 1");
     auto sparse_query = sparse_vectors[0];
+    CHECK_ARGUMENT(sparse_vectors->len_ > 0,
+                   fmt::format("query.len_ ({}) is invalid", sparse_vectors->len_));
 
     // search parameter
     SINDISearchParameter search_param;
@@ -297,7 +323,8 @@ SINDI::Deserialize(StreamReader& reader) {
     StreamReader::ReadObj(reader, window_term_list_size);
     window_term_list_.resize(window_term_list_size);
     for (auto& window : window_term_list_) {
-        window = std::make_shared<SparseTermDataCell>(doc_retain_ratio_, allocator_);
+        window =
+            std::make_shared<SparseTermDataCell>(doc_retain_ratio_, term_id_limit_, allocator_);
         window->Deserialize(reader);
     }
 

--- a/src/algorithm/sindi/sindi.cpp
+++ b/src/algorithm/sindi/sindi.cpp
@@ -69,7 +69,7 @@ SINDI::Add(const DatasetPtr& base) {
         if (sparse_vector.len_ <= 0) {
             failed_ids.push_back(ids[i]);
             logger::warn(
-                "sparse_vectors.len_ ({}) is invalid for id ({})", sparse_vector.len_, ids[i]);
+                "sparse_vector.len_ ({}) is invalid for id ({})", sparse_vector.len_, ids[i]);
             continue;
         }
 

--- a/src/algorithm/sindi/sindi.h
+++ b/src/algorithm/sindi/sindi.h
@@ -95,6 +95,8 @@ private:
 private:
     mutable std::shared_mutex global_mutex_;
 
+    uint32_t term_id_limit_{0};
+
     uint32_t window_size_{0};
 
     Vector<SparseTermDataCellPtr> window_term_list_;

--- a/src/algorithm/sindi/sindi_parameter.cpp
+++ b/src/algorithm/sindi/sindi_parameter.cpp
@@ -21,6 +21,16 @@ namespace vsag {
 
 void
 SINDIParameter::FromJson(const JsonType& json) {
+    if (json.contains(SPARSE_TERM_ID_LIMIT)) {
+        term_id_limit = json[SPARSE_TERM_ID_LIMIT];
+
+        CHECK_ARGUMENT(
+            (0 < term_id_limit and term_id_limit <= 1'000'000),
+            fmt::format("term_id_limit must in (0, 1'000'000], but now is {}", term_id_limit));
+    } else {
+        term_id_limit = DEFAULT_TERM_ID_LIMIT;
+    }
+
     if (json.contains(SPARSE_DOC_PRUNE_RATIO)) {
         doc_prune_ratio = json[SPARSE_DOC_PRUNE_RATIO];
     } else {
@@ -46,11 +56,33 @@ SINDIParameter::FromJson(const JsonType& json) {
 JsonType
 SINDIParameter::ToJson() const {
     JsonType json;
+    json[SPARSE_TERM_ID_LIMIT] = term_id_limit;
     json[SPARSE_DOC_PRUNE_RATIO] = doc_prune_ratio;
     json[SPARSE_USE_REORDER] = use_reorder;
     json[SPARSE_WINDOW_SIZE] = window_size;
 
     return json;
+}
+
+bool
+SINDIParameter::CheckCompatibility(const vsag::ParamPtr& other) const {
+    auto sindi_param = std::dynamic_pointer_cast<SINDIParameter>(other);
+    if (sindi_param == nullptr) {
+        return false;
+    }
+    if (this->term_id_limit != sindi_param->term_id_limit) {
+        return false;
+    }
+    if (this->window_size != sindi_param->window_size) {
+        return false;
+    }
+    if (this->doc_prune_ratio != sindi_param->doc_prune_ratio) {
+        return false;
+    }
+    if (this->use_reorder != sindi_param->use_reorder) {
+        return false;
+    }
+    return true;
 }
 
 void

--- a/src/algorithm/sindi/sindi_parameter.cpp
+++ b/src/algorithm/sindi/sindi_parameter.cpp
@@ -33,6 +33,8 @@ SINDIParameter::FromJson(const JsonType& json) {
 
     if (json.contains(SPARSE_DOC_PRUNE_RATIO)) {
         doc_prune_ratio = json[SPARSE_DOC_PRUNE_RATIO];
+        CHECK_ARGUMENT((0.0F <= doc_prune_ratio and doc_prune_ratio <= 0.5F),
+                       fmt::format("doc_prune_ratio must in [0, 0.5], got {}", doc_prune_ratio));
     } else {
         doc_prune_ratio = DEFAULT_DOC_PRUNE_RATIO;
     }
@@ -45,9 +47,13 @@ SINDIParameter::FromJson(const JsonType& json) {
 
     if (json.contains(SPARSE_WINDOW_SIZE)) {
         window_size = json[SPARSE_WINDOW_SIZE];
+        CHECK_ARGUMENT(
+            (10'000 <= window_size and window_size <= 1'000'000),
+            fmt::format("window_size must in [10000, 1000000], but now is {}", window_size));
     } else {
         window_size = DEFAULT_WINDOW_SIZE;
     }
+
     if (json.contains(SPARSE_DESERIALIZE_WITHOUT_FOOTER)) {
         deserialize_without_footer = json[SPARSE_DESERIALIZE_WITHOUT_FOOTER];
     }
@@ -91,12 +97,17 @@ SINDISearchParameter::FromJson(const JsonType& json) {
                    fmt::format("parameters must contains {}", INDEX_SINDI));
     if (json[INDEX_SINDI].contains(SPARSE_TERM_PRUNE_RATIO)) {
         term_prune_ratio = json[INDEX_SINDI][SPARSE_TERM_PRUNE_RATIO];
+        CHECK_ARGUMENT((0.0F <= term_prune_ratio and term_prune_ratio <= 0.5F),
+                       fmt::format("term_prune_ratio must in [0, 0.5], got {}", term_prune_ratio));
     } else {
         term_prune_ratio = DEFAULT_TERM_PRUNE_RATIO;
     }
 
     if (json[INDEX_SINDI].contains(SPARSE_QUERY_PRUNE_RATIO)) {
         query_prune_ratio = json[INDEX_SINDI][SPARSE_QUERY_PRUNE_RATIO];
+        CHECK_ARGUMENT(
+            (0.0F <= query_prune_ratio and query_prune_ratio <= 0.5F),
+            fmt::format("query_prune_ratio must in [0, 0.5], got {}", query_prune_ratio));
     } else {
         query_prune_ratio = DEFAULT_QUERY_PRUNE_RATIO;
     }

--- a/src/algorithm/sindi/sindi_parameter.h
+++ b/src/algorithm/sindi/sindi_parameter.h
@@ -20,13 +20,6 @@
 
 namespace vsag {
 
-static constexpr uint32_t DEFAULT_WINDOW_SIZE = 100000;
-static constexpr bool DEFAULT_USE_REORDER = false;
-static constexpr float DEFAULT_QUERY_PRUNE_RATIO = 0.0F;
-static constexpr float DEFAULT_DOC_PRUNE_RATIO = 0.0F;
-static constexpr float DEFAULT_TERM_PRUNE_RATIO = 0.0F;
-static constexpr uint32_t DEFAULT_N_CANDIDATE = 0;
-
 struct SINDIParameter : public Parameter {
 public:
     void
@@ -35,10 +28,15 @@ public:
     JsonType
     ToJson() const override;
 
+    bool
+    CheckCompatibility(const vsag::ParamPtr& other) const override;
+
     SINDIParameter() = default;
 
 public:
     // index
+    uint32_t term_id_limit{0};
+
     uint32_t window_size{0};
     bool use_reorder{false};
 

--- a/src/algorithm/sindi/sindi_parameter_test.cpp
+++ b/src/algorithm/sindi/sindi_parameter_test.cpp
@@ -17,6 +17,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include "inner_string_params.h"
 #include "parameter_test.h"
 
 using namespace vsag;
@@ -44,14 +45,18 @@ struct SINDIDefaultParam {
     bool use_reorder = true;
     float doc_prune_ratio = 0.8F;
     int window_size = 66666;
+    int term_id_limit = 10000;
 };
 
 std::string
 generate_sindi_param(const SINDIDefaultParam& param) {
     vsag::JsonType json;
-    json["use_reorder"] = param.use_reorder;
-    json["doc_prune_ratio"] = param.doc_prune_ratio;
-    json["window_size"] = param.window_size;
+
+    json[SPARSE_USE_REORDER] = param.use_reorder;
+    json[SPARSE_DOC_PRUNE_RATIO] = param.doc_prune_ratio;
+    json[SPARSE_WINDOW_SIZE] = param.window_size;
+    json[SPARSE_TERM_ID_LIMIT] = param.term_id_limit;
+
     return json.dump();
 }
 
@@ -83,4 +88,5 @@ TEST_CASE("SINDI Index Parameters Compatibility Test", "[ut][SINDIParameter]") {
     TEST_COMPATIBILITY_CASE("use_reorder compatibility", use_reorder, true, false, false);
     TEST_COMPATIBILITY_CASE("doc_prune_ratio compatibility", doc_prune_ratio, 0.8F, 0.9F, false);
     TEST_COMPATIBILITY_CASE("window_size compatibility", window_size, 66666, 77777, false);
+    TEST_COMPATIBILITY_CASE("term_id_limit compatibility", term_id_limit, 10000, 10001, false);
 }

--- a/src/algorithm/sindi/sindi_parameter_test.cpp
+++ b/src/algorithm/sindi/sindi_parameter_test.cpp
@@ -43,7 +43,7 @@ using namespace vsag;
 
 struct SINDIDefaultParam {
     bool use_reorder = true;
-    float doc_prune_ratio = 0.8F;
+    float doc_prune_ratio = 0.1F;
     int window_size = 66666;
     int term_id_limit = 10000;
 };
@@ -67,16 +67,16 @@ TEST_CASE("SINDI Index Parameters Test", "[ut][SINDIParameter]") {
     auto param = std::make_shared<vsag::SINDIParameter>();
     param->FromJson(param_json);
     REQUIRE(param->use_reorder == true);
-    REQUIRE(std::abs(param->doc_prune_ratio - 0.8) < 1e-3);
+    REQUIRE(std::abs(param->doc_prune_ratio - 0.1F) < 1e-3);
     REQUIRE(param->window_size == 66666);
 
     vsag::ParameterTest::TestToJson(param);
 
     auto search_param_str = R"(
         "sindi": {
-            "query_prune_ratio": 0.9,
+            "query_prune_ratio": 0.2,
             "n_candidate": 20,
-            "term_prune_ratio": 1
+            "term_prune_ratio": 0.1
         }
     )";
     auto search_param = std::make_shared<vsag::SINDIParameter>();
@@ -86,7 +86,7 @@ TEST_CASE("SINDI Index Parameters Test", "[ut][SINDIParameter]") {
 
 TEST_CASE("SINDI Index Parameters Compatibility Test", "[ut][SINDIParameter]") {
     TEST_COMPATIBILITY_CASE("use_reorder compatibility", use_reorder, true, false, false);
-    TEST_COMPATIBILITY_CASE("doc_prune_ratio compatibility", doc_prune_ratio, 0.8F, 0.9F, false);
+    TEST_COMPATIBILITY_CASE("doc_prune_ratio compatibility", doc_prune_ratio, 0.2F, 0.3F, false);
     TEST_COMPATIBILITY_CASE("window_size compatibility", window_size, 66666, 77777, false);
     TEST_COMPATIBILITY_CASE("term_id_limit compatibility", term_id_limit, 10000, 10001, false);
 }

--- a/src/common.h
+++ b/src/common.h
@@ -41,3 +41,13 @@
 constexpr static const int64_t INIT_CAPACITY = 10;
 constexpr static const int64_t MAX_CAPACITY_EXTEND = 10000;
 constexpr static const int64_t AMPLIFICATION_FACTOR = 10;
+
+// sindi related
+constexpr static const uint32_t ESTIMATE_DOC_TERM = 100;
+constexpr static const uint32_t DEFAULT_TERM_ID_LIMIT = 100000;
+constexpr static const uint32_t DEFAULT_WINDOW_SIZE = 100000;
+constexpr static const bool DEFAULT_USE_REORDER = false;
+constexpr static const float DEFAULT_QUERY_PRUNE_RATIO = 0.0F;
+constexpr static const float DEFAULT_DOC_PRUNE_RATIO = 0.0F;
+constexpr static const float DEFAULT_TERM_PRUNE_RATIO = 0.0F;
+constexpr static const uint32_t DEFAULT_N_CANDIDATE = 0;

--- a/src/data_cell/sparse_term_datacell.cpp
+++ b/src/data_cell/sparse_term_datacell.cpp
@@ -147,6 +147,12 @@ SparseTermDataCell::InsertVector(const SparseVector& sparse_base, uint32_t base_
         auto term_id = sparse_base.ids_[i];
         max_term_id = std::max(max_term_id, term_id);
     }
+    if (max_term_id > term_id_limit_) {
+        throw std::runtime_error(
+            fmt::format("max term id of sparse vector {} is greater than term id limit {}",
+                        max_term_id,
+                        term_id_limit_));
+    }
     ResizeTermList(max_term_id + 1);
 
     Vector<std::pair<uint32_t, float>> sorted_base(allocator_);

--- a/src/data_cell/sparse_term_datacell.h
+++ b/src/data_cell/sparse_term_datacell.h
@@ -27,8 +27,9 @@ class SparseTermDataCell {
 public:
     SparseTermDataCell() = default;
 
-    SparseTermDataCell(float doc_prune_ratio, Allocator* allocator)
+    SparseTermDataCell(float doc_prune_ratio, uint32_t term_id_limit, Allocator* allocator)
         : doc_prune_ratio_(doc_prune_ratio),
+          term_id_limit_(term_id_limit),
           allocator_(allocator),
           term_ids_(0, Vector<uint32_t>(allocator), allocator),
           term_datas_(0, Vector<float>(allocator), allocator),
@@ -63,6 +64,8 @@ public:
     Deserialize(StreamReader& reader);
 
 public:
+    uint32_t term_id_limit_{0};
+
     float doc_prune_ratio_{0};
 
     uint32_t term_capacity_{0};

--- a/src/data_cell/sparse_term_datacell_test.cpp
+++ b/src/data_cell/sparse_term_datacell_test.cpp
@@ -61,7 +61,8 @@ TEST_CASE("SparseTermDatacell Basic Test", "[ut][SparseTermDatacell]") {
     float doc_prune_ratio = 0.5;
     float term_prune_ratio = 0.0;
     auto allocator = SafeAllocator::FactoryDefaultAllocator();
-    auto data_cell = std::make_shared<SparseTermDataCell>(doc_prune_ratio, allocator.get());
+    auto data_cell = std::make_shared<SparseTermDataCell>(
+        doc_prune_ratio, DEFAULT_TERM_ID_LIMIT, allocator.get());
     REQUIRE(std::abs(data_cell->doc_prune_ratio_ - doc_prune_ratio) < 1e-3);
 
     // test factory computer

--- a/src/inner_string_params.h
+++ b/src/inner_string_params.h
@@ -79,6 +79,7 @@ const char* const SPARSE_NEED_SORT = "need_sort";
 const char* const SPARSE_QUERY_PRUNE_RATIO = "query_prune_ratio";
 const char* const SPARSE_DOC_PRUNE_RATIO = "doc_prune_ratio";
 const char* const SPARSE_TERM_PRUNE_RATIO = "term_prune_ratio";
+const char* const SPARSE_TERM_ID_LIMIT = "term_id_limit";
 const char* const SPARSE_WINDOW_SIZE = "window_size";
 const char* const SPARSE_USE_REORDER = "use_reorder";
 const char* const SPARSE_N_CANDIDATE = "n_candidate";

--- a/tests/fixtures/fixtures.h
+++ b/tests/fixtures/fixtures.h
@@ -23,6 +23,7 @@
 #include <tuple>
 #include <vector>
 
+#include "common.h"
 #include "simd/normalize.h"
 #include "typing.h"
 #include "vsag/vsag.h"
@@ -112,7 +113,7 @@ vsag::Vector<vsag::SparseVector>
 GenerateSparseVectors(vsag::Allocator* allocator,
                       uint32_t count,
                       uint32_t max_dim = 100,
-                      uint32_t max_id = 10000,
+                      uint32_t max_id = 1000,
                       float min_val = -1,
                       float max_val = 1,
                       int seed = 47);

--- a/tests/test_sindi.cpp
+++ b/tests/test_sindi.cpp
@@ -24,7 +24,7 @@ namespace fixtures {
 struct SINDIParam {
     bool use_reorder = true;
     float doc_prune_ratio = 0.0;
-    int window_size = 100;
+    int window_size = 10000;
     bool deserialize_without_footer = false;
     int term_id_limit = 2000;
 };
@@ -69,6 +69,92 @@ public:
 TestDatasetPool SINDITestIndex::pool{};
 
 }  // namespace fixtures
+
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex,
+                             "Invalid Build and Search Parameter",
+                             "[ft][sindi]") {
+    SECTION("invalid doc_prune_ratio") {
+        fixtures::SINDIParam param;
+        param.doc_prune_ratio = 0.6;
+        REQUIRE_THROWS(
+            TestFactory("sindi", fixtures::SINDITestIndex::GenerateBuildParameter(param), false));
+        param.doc_prune_ratio = -0.1;
+        REQUIRE_THROWS(
+            TestFactory("sindi", fixtures::SINDITestIndex::GenerateBuildParameter(param), false));
+    }
+
+    SECTION("invalid window_size") {
+        fixtures::SINDIParam param;
+        param.window_size = 5000;
+        REQUIRE_THROWS(
+            TestFactory("sindi", fixtures::SINDITestIndex::GenerateBuildParameter(param), false));
+        param.window_size = 1100000;
+        REQUIRE_THROWS(
+            TestFactory("sindi", fixtures::SINDITestIndex::GenerateBuildParameter(param), false));
+    }
+    fixtures::SINDIParam param;
+    param.window_size = 10000;
+    auto build_param = fixtures::SINDITestIndex::GenerateBuildParameter(param);
+    auto index = TestFactory("sindi", build_param, true);
+    auto dataset = pool.GetSparseDatasetAndCreate(base_count, 128, 0.8);
+    REQUIRE(index->GetIndexType() == vsag::IndexType::SINDI);
+    TestBuildIndex(index, dataset, true);
+    {
+        auto invalid_search_param = R"({
+            "sindi": {
+                "n_candidate": -1,
+                "query_prune_ratio": 0.0,
+                "term_prune_ratio": 0.0
+            }
+        })";
+        TestKnnSearch(index, dataset, invalid_search_param, 0.99, false);
+        invalid_search_param = R"({
+            "sindi":{
+                "n_candidate": 10,
+                "query_prune_ratio": 1.2,
+                "term_prune_ratio": 0.0
+            }
+        })";
+        TestKnnSearch(index, dataset, invalid_search_param, 0.99, false);
+        invalid_search_param = R"({
+            "sindi":{
+                "n_candidate": 10,
+                "query_prune_ratio": 0.0,
+                "term_prune_ratio": -0.1
+            }
+        })";
+        TestKnnSearch(index, dataset, invalid_search_param, 0.99, false);
+    }
+
+    // test multi data issue
+    vsag::SparseVector invalid_sv_array[2];
+    int64_t ids[2];
+    invalid_sv_array[0].len_ = 0;
+    invalid_sv_array[1].len_ = 0;
+    ids[0] = 114;
+    ids[1] = 514;
+    auto invalid_data = vsag::Dataset::Make();
+    invalid_data->NumElements(2)->SparseVectors(invalid_sv_array)->Ids(ids)->Owner(false);
+    auto insert_result = index->Add(invalid_data);
+    REQUIRE(insert_result.has_value());
+    auto failed_ids = insert_result.value();
+    REQUIRE(failed_ids.size() == 2);
+    REQUIRE(failed_ids[0] == ids[0]);
+    REQUIRE(failed_ids[1] == ids[1]);
+
+    // test single data issue
+    vsag::SparseVector sparse_vector;
+    int64_t id = 7777;
+    sparse_vector.len_ = 0;
+    auto data = vsag::Dataset::Make();
+    data->NumElements(1)->Owner(false)->SparseVectors(&sparse_vector)->Ids(&id);
+    insert_result = index->Add(data);
+    REQUIRE(insert_result.has_value());
+    failed_ids = insert_result.value();
+    REQUIRE(failed_ids[0] == id);
+    auto search_result = index->KnnSearch(data, 1, search_param);
+    REQUIRE_FALSE(search_result.has_value());
+}
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex, "SINDI Build and Search", "[ft][sindi]") {
     fixtures::SINDIParam param;

--- a/tests/test_sindi.cpp
+++ b/tests/test_sindi.cpp
@@ -126,23 +126,25 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex,
         TestKnnSearch(index, dataset, invalid_search_param, 0.99, false);
     }
 
-    // test multi data issue
+    // invalid multi data
+    int64_t ids[2] = {114, 514};
     vsag::SparseVector invalid_sv_array[2];
-    int64_t ids[2];
-    invalid_sv_array[0].len_ = 0;
+    std::vector<uint32_t> sv_ids = {100};
+    std::vector<float> sv_vals = {0.5};
+    invalid_sv_array[0].len_ = 1;
+    invalid_sv_array[0].ids_ = sv_ids.data();
+    invalid_sv_array[0].vals_ = sv_vals.data();
     invalid_sv_array[1].len_ = 0;
-    ids[0] = 114;
-    ids[1] = 514;
+
     auto invalid_data = vsag::Dataset::Make();
     invalid_data->NumElements(2)->SparseVectors(invalid_sv_array)->Ids(ids)->Owner(false);
     auto insert_result = index->Add(invalid_data);
     REQUIRE(insert_result.has_value());
     auto failed_ids = insert_result.value();
-    REQUIRE(failed_ids.size() == 2);
-    REQUIRE(failed_ids[0] == ids[0]);
-    REQUIRE(failed_ids[1] == ids[1]);
+    REQUIRE(failed_ids.size() == 1);
+    REQUIRE(failed_ids[0] == ids[1]);
 
-    // test single data issue
+    // invalid single data
     vsag::SparseVector sparse_vector;
     int64_t id = 7777;
     sparse_vector.len_ = 0;

--- a/tests/test_sindi.cpp
+++ b/tests/test_sindi.cpp
@@ -26,6 +26,7 @@ struct SINDIParam {
     float doc_prune_ratio = 0.0;
     int window_size = 100;
     bool deserialize_without_footer = false;
+    int term_id_limit = 2000;
 };
 
 class SINDITestIndex : public fixtures::TestIndex {
@@ -53,14 +54,15 @@ public:
                 "use_reorder": {},
                 "doc_prune_ratio": {},
                 "window_size": {},
+                "term_id_limit": {},
                 "deserialize_without_footer": {}
-
             }}
         }})";
         return fmt::format(build_param_template,
                            param.use_reorder,
                            param.doc_prune_ratio,
                            param.window_size,
+                           param.term_id_limit,
                            param.deserialize_without_footer);
     }
 };


### PR DESCRIPTION
(cherry picked from commit 45a9f7631cb91f017726416fad7d4a1eedbdd37b)

## Summary by Sourcery

Add configurable term_id_limit to SINDI index and enforce it throughout vector insertion and search, returning failed IDs for out-of-range or invalid vectors and updating parameters, serialization, tests, and examples accordingly

New Features:
- Introduce term_id_limit parameter in SINDIParameter with JSON (de)serialization and compatibility checks
- Integrate term_id_limit into SINDI constructor, data cell, and default constants

Enhancements:
- Enforce term_id_limit in SparseTermDataCell::InsertVector and throw on exceeding IDs
- Modify SINDI::Add to catch insertion errors, log warnings for invalid vectors, and return failed IDs
- Validate non-empty sparse vectors in Add, KnnSearch, and RangeSearch routines

Documentation:
- Update example and parameter documentation to include term_id_limit description

Tests:
- Extend unit tests for term_id_limit in parameter compatibility, index Add failures, data cell limits, and example serialization