### PR TITLE
fix(sindi): bad alloc and bench issue caused by term id limit (cp 0.16)

### DIFF
--- a/src/algorithm/sindi/sindi.cpp
+++ b/src/algorithm/sindi/sindi.cpp
@@ -77,9 +77,13 @@ SINDI::Add(const DatasetPtr& base) {
 
         try {
             window_term_list_[cur_window]->InsertVector(sparse_vector, inner_id);
-        } catch (std::runtime_error& e) {
+        } catch (const std::runtime_error& e) {
             failed_ids.push_back(ids[i]);
-            logger::warn(e.what());
+            logger::warn("runtime error: {}", e.what());
+            continue;
+        } catch (const std::bad_alloc& e) {
+            failed_ids.push_back(ids[i]);
+            logger::warn("memory allocation failed: {}", e.what());
             continue;
         }
 

--- a/src/algorithm/sindi/sindi_parameter.cpp
+++ b/src/algorithm/sindi/sindi_parameter.cpp
@@ -33,8 +33,8 @@ SINDIParameter::FromJson(const JsonType& json) {
 
     if (json.contains(SPARSE_DOC_PRUNE_RATIO)) {
         doc_prune_ratio = json[SPARSE_DOC_PRUNE_RATIO];
-        CHECK_ARGUMENT((0.0F <= doc_prune_ratio and doc_prune_ratio <= 0.5F),
-                       fmt::format("doc_prune_ratio must in [0, 0.5], got {}", doc_prune_ratio));
+        CHECK_ARGUMENT((0.0F <= doc_prune_ratio and doc_prune_ratio <= 0.9F),
+                       fmt::format("doc_prune_ratio must in [0, 0.9], got {}", doc_prune_ratio));
     } else {
         doc_prune_ratio = DEFAULT_DOC_PRUNE_RATIO;
     }
@@ -97,8 +97,8 @@ SINDISearchParameter::FromJson(const JsonType& json) {
                    fmt::format("parameters must contains {}", INDEX_SINDI));
     if (json[INDEX_SINDI].contains(SPARSE_TERM_PRUNE_RATIO)) {
         term_prune_ratio = json[INDEX_SINDI][SPARSE_TERM_PRUNE_RATIO];
-        CHECK_ARGUMENT((0.0F <= term_prune_ratio and term_prune_ratio <= 0.5F),
-                       fmt::format("term_prune_ratio must in [0, 0.5], got {}", term_prune_ratio));
+        CHECK_ARGUMENT((0.0F <= term_prune_ratio and term_prune_ratio <= 0.9F),
+                       fmt::format("term_prune_ratio must in [0, 0.9], got {}", term_prune_ratio));
     } else {
         term_prune_ratio = DEFAULT_TERM_PRUNE_RATIO;
     }
@@ -106,8 +106,8 @@ SINDISearchParameter::FromJson(const JsonType& json) {
     if (json[INDEX_SINDI].contains(SPARSE_QUERY_PRUNE_RATIO)) {
         query_prune_ratio = json[INDEX_SINDI][SPARSE_QUERY_PRUNE_RATIO];
         CHECK_ARGUMENT(
-            (0.0F <= query_prune_ratio and query_prune_ratio <= 0.5F),
-            fmt::format("query_prune_ratio must in [0, 0.5], got {}", query_prune_ratio));
+            (0.0F <= query_prune_ratio and query_prune_ratio <= 0.9F),
+            fmt::format("query_prune_ratio must in [0, 0.9], got {}", query_prune_ratio));
     } else {
         query_prune_ratio = DEFAULT_QUERY_PRUNE_RATIO;
     }

--- a/src/common.h
+++ b/src/common.h
@@ -44,7 +44,7 @@ constexpr static const int64_t AMPLIFICATION_FACTOR = 10;
 
 // sindi related
 constexpr static const uint32_t ESTIMATE_DOC_TERM = 100;
-constexpr static const uint32_t DEFAULT_TERM_ID_LIMIT = 100000;
+constexpr static const uint32_t DEFAULT_TERM_ID_LIMIT = 1000000;
 constexpr static const uint32_t DEFAULT_WINDOW_SIZE = 100000;
 constexpr static const bool DEFAULT_USE_REORDER = false;
 constexpr static const float DEFAULT_QUERY_PRUNE_RATIO = 0.0F;

--- a/src/data_cell/sparse_term_datacell.cpp
+++ b/src/data_cell/sparse_term_datacell.cpp
@@ -173,13 +173,22 @@ SparseTermDataCell::InsertVector(const SparseVector& sparse_base, uint32_t base_
 
 void
 SparseTermDataCell::ResizeTermList(InnerIdType new_term_capacity) {
-    if (new_term_capacity <= this->term_capacity_) {
+    if (new_term_capacity <= term_capacity_) {
         return;
     }
-    this->term_capacity_ = new_term_capacity;
-    term_ids_.resize(term_capacity_, Vector<uint32_t>(allocator_));
-    term_datas_.resize(term_capacity_, Vector<float>(allocator_));
-    term_sizes_.resize(term_capacity_, 0);
+
+    Vector<Vector<uint32_t>> new_ids(new_term_capacity, Vector<uint32_t>(allocator_), allocator_);
+    Vector<Vector<float>> new_datas(new_term_capacity, Vector<float>(allocator_), allocator_);
+    Vector<uint32_t> new_sizes(new_term_capacity, 0, allocator_);
+
+    std::move(term_ids_.begin(), term_ids_.end(), new_ids.begin());
+    std::move(term_datas_.begin(), term_datas_.end(), new_datas.begin());
+    std::copy(term_sizes_.begin(), term_sizes_.end(), new_sizes.begin());
+
+    term_ids_.swap(new_ids);
+    term_datas_.swap(new_datas);
+    term_sizes_.swap(new_sizes);
+    term_capacity_ = new_term_capacity;
 }
 
 void

--- a/tests/test_sindi.cpp
+++ b/tests/test_sindi.cpp
@@ -75,7 +75,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex,
                              "[ft][sindi]") {
     SECTION("invalid doc_prune_ratio") {
         fixtures::SINDIParam param;
-        param.doc_prune_ratio = 0.6;
+        param.doc_prune_ratio = 0.99;
         REQUIRE_THROWS(
             TestFactory("sindi", fixtures::SINDITestIndex::GenerateBuildParameter(param), false));
         param.doc_prune_ratio = -0.1;


### PR DESCRIPTION
cp #1242

## Summary by Sourcery

Increase term ID capacity and prune ratio limits in SINDI, improve term list resizing to prevent bad allocations, add handling for memory allocation failures in SINDI::Add, and update tests to match the new validations

Bug Fixes:
- Handle std::bad_alloc in SINDI::Add to prevent crashes on memory allocation failures

Enhancements:
- Implement move-based buffer expansion in SparseTermDataCell::ResizeTermList to reduce allocation overhead
- Raise DEFAULT_TERM_ID_LIMIT and allow prune ratios up to 0.9 in SINDI parameter validations

Tests:
- Adjust tests to enforce the updated prune ratio bounds