### PR TITLE
fix(SINDI): sparse vector len check 

### DIFF
--- a/src/algorithm/sindi/sindi.cpp
+++ b/src/algorithm/sindi/sindi.cpp
@@ -69,10 +69,10 @@ SINDI::Add(const DatasetPtr& base) {
         auto cur_window = cur_element_count_ / window_size_;
         auto window_start_id = cur_window * window_size_;
         const auto& sparse_vector = sparse_vectors[i];
-        if (sparse_vectors->len_ <= 0) {
+        if (sparse_vector.len_ <= 0) {
             failed_ids.push_back(ids[i]);
             logger::warn(
-                "sparse_vectors.len_ ({}) is invalid for id ({})", sparse_vectors->len_, ids[i]);
+                "sparse_vector.len_ ({}) is invalid for id ({})", sparse_vector.len_, ids[i]);
             continue;
         }
 
@@ -139,8 +139,9 @@ SINDI::KnnSearch(const DatasetPtr& query,
     const auto* sparse_vectors = query->GetSparseVectors();
     CHECK_ARGUMENT(query->GetNumElements() == 1, "num of query should be 1");
     auto sparse_query = sparse_vectors[0];
-    CHECK_ARGUMENT(sparse_vectors->len_ > 0,
-                   fmt::format("sparse_vectors.len_ ({}) is invalid", sparse_vectors->len_));
+    CHECK_ARGUMENT(
+        sparse_query.len_ > 0,
+        fmt::format("query->GetSparseVectors()->len_ ({}) is invalid", sparse_query.len_));
 
     // search parameter
     SINDISearchParameter search_param;
@@ -277,8 +278,9 @@ SINDI::RangeSearch(const DatasetPtr& query,
     const auto* sparse_vectors = query->GetSparseVectors();
     CHECK_ARGUMENT(query->GetNumElements() == 1, "num of query should be 1");
     auto sparse_query = sparse_vectors[0];
-    CHECK_ARGUMENT(sparse_vectors->len_ > 0,
-                   fmt::format("query.len_ ({}) is invalid", sparse_vectors->len_));
+    CHECK_ARGUMENT(
+        sparse_query.len_ > 0,
+        fmt::format("query->GetSparseVectors()->len_ ({}) is invalid", sparse_query.len_));
 
     // search parameter
     SINDISearchParameter search_param;


### PR DESCRIPTION
close #1265 

## Summary by Sourcery

Validate and reject sparse vectors with non-positive length by fixing the variable references in length checks and adding unit tests to cover both multi-element and single-element scenarios.

New Features:
- Add tests for rejecting invalid sparse vectors in both batch and single-element insertions and searches

Bug Fixes:
- Fix len_ validation in SINDI::Add by referencing the correct sparse_vector variable
- Fix len_ validation and error messages in KnnSearch and RangeSearch to use the actual sparse_query object