### PR TITLE
fix(sindi): fix parameter checkCompatibility in deserialize 

### DIFF
--- a/src/algorithm/sindi/sindi.cpp
+++ b/src/algorithm/sindi/sindi.cpp
@@ -334,10 +334,16 @@ SINDI::Deserialize(StreamReader& reader) {
         JsonType jsonify_basic_info = metadata->Get("basic_info");
         // Check if the index parameter is compatible
         {
-            auto param = jsonify_basic_info[INDEX_PARAM];
+            auto param = jsonify_basic_info[INDEX_PARAM].GetString();
             SINDIParameterPtr index_param = std::make_shared<SINDIParameter>();
-            index_param->FromJson(param);
-            this->create_param_ptr_->CheckCompatibility(index_param);
+            index_param->FromString(param);
+            if (not this->create_param_ptr_->CheckCompatibility(index_param)) {
+                auto message = fmt::format("SINDI index parameter not match, current: {}, new: {}",
+                                           this->create_param_ptr_->ToString(),
+                                           index_param->ToString());
+                logger::error(message);
+                throw VsagException(ErrorType::INVALID_ARGUMENT, message);
+            }
         }
     }
 


### PR DESCRIPTION
fix: #1263

## Summary by Sourcery

Validate compatibility of index parameter during SINDI deserialization and throw an exception on mismatch with a detailed error message.

Bug Fixes:
- Honor the return value of CheckCompatibility and throw an exception if the index parameter is incompatible
- Parse the index parameter with FromString/GetString instead of FromJson to match the updated method signature

Enhancements:
- Log a descriptive error message showing current and new parameter values on mismatch