### PR TITLE
feat(hgraph): ensure that the removing is thread-safe.

### DIFF
--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -1107,6 +1107,7 @@ HGraph::InitFeatures() {
     // concurrency
     this->index_feature_list_->SetFeature(IndexFeature::SUPPORT_SEARCH_CONCURRENT);
     this->index_feature_list_->SetFeature(IndexFeature::SUPPORT_ADD_CONCURRENT);
+    this->index_feature_list_->SetFeature(IndexFeature::SUPPORT_ADD_SEARCH_CONCURRENT);
     this->index_feature_list_->SetFeature(IndexFeature::SUPPORT_ADD_SEARCH_DELETE_CONCURRENT);
     // serialize
     this->index_feature_list_->SetFeatures({
@@ -1616,7 +1617,11 @@ HGraph::GetCodeByInnerId(InnerIdType inner_id, uint8_t* data) const {
 
 bool
 HGraph::Remove(int64_t id) {
-    auto inner_id = this->label_table_->GetIdByLabel(id);
+    InnerIdType inner_id;
+    {
+        std::shared_lock<std::shared_mutex> lock(this->label_lookup_mutex_);
+        inner_id = this->label_table_->GetIdByLabel(id);
+    }
     if (inner_id == this->entry_point_id_) {
         bool find_new_ep = false;
         while (not route_graphs_.empty()) {
@@ -1639,7 +1644,7 @@ HGraph::Remove(int64_t id) {
     }
     {
         {
-            std::scoped_lock lock(this->global_mutex_);
+            std::scoped_lock<std::shared_mutex> wlock(this->global_mutex_);
             for (int level = static_cast<int>(route_graphs_.size()) - 1; level >= 0; --level) {
                 this->route_graphs_[level]->DeleteNeighborsById(inner_id);
             }
@@ -1849,6 +1854,7 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
         (1 <= params.ef_search) and (params.ef_search <= ef_search_threshold),
         fmt::format("ef_search({}) must in range[1, {}]", params.ef_search, ef_search_threshold));
 
+    std::shared_lock shared_lock(this->global_mutex_);
     // check k
     CHECK_ARGUMENT(k > 0, fmt::format("k({}) must be greater than 0", k));
     k = std::min(k, GetNumElements());

--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -1958,7 +1958,7 @@ std::string
 HGraph::GetStats() const {
     JsonType stats;
     int64_t topk = DEFAULT_TOPK;
-    uint64_t sample_size = std::min(QUERY_SAMPLE_SIZE, this->total_count_);
+    uint64_t sample_size = std::min(QUERY_SAMPLE_SIZE, this->total_count_.load());
     Vector<float> sample_base_datas(dim_ * sample_size, 0.0F, allocator_);
     if (this->total_count_ == 0) {
         stats["total_count"].SetInt(0);

--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -1638,11 +1638,14 @@ HGraph::Remove(int64_t id) {
         }
     }
     {
-        std::scoped_lock label_lock(this->label_lookup_mutex_);
-        for (int level = static_cast<int>(route_graphs_.size()) - 1; level >= 0; --level) {
-            this->route_graphs_[level]->DeleteNeighborsById(inner_id);
+        {
+            LockGuard lock(neighbors_mutex_, inner_id);
+            for (int level = static_cast<int>(route_graphs_.size()) - 1; level >= 0; --level) {
+                this->route_graphs_[level]->DeleteNeighborsById(inner_id);
+            }
+            this->bottom_graph_->DeleteNeighborsById(inner_id);
         }
-        this->bottom_graph_->DeleteNeighborsById(inner_id);
+        std::scoped_lock label_lock(this->label_lookup_mutex_);
         this->label_table_->Remove(id);
         delete_count_++;
     }

--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -1639,7 +1639,7 @@ HGraph::Remove(int64_t id) {
     }
     {
         {
-            LockGuard lock(neighbors_mutex_, inner_id);
+            std::scoped_lock lock(this->global_mutex_);
             for (int level = static_cast<int>(route_graphs_.size()) - 1; level >= 0; --level) {
                 this->route_graphs_[level]->DeleteNeighborsById(inner_id);
             }

--- a/src/algorithm/hgraph.h
+++ b/src/algorithm/hgraph.h
@@ -350,7 +350,7 @@ private:
     uint64_t ef_construct_{400};
     float alpha_{1.0};
 
-    uint64_t total_count_{0};
+    std::atomic<uint64_t> total_count_{0};
 
     std::shared_ptr<VisitedListPool> pool_{nullptr};
 

--- a/tests/test_brute_force.cpp
+++ b/tests/test_brute_force.cpp
@@ -250,7 +250,7 @@ TestBruteForceBuild(const fixtures::BruteForceResourcePtr& resource) {
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
     std::vector<int32_t> search_threads_counts{1, 3};
-    std::string search_param_tmp2 = R"(
+    constexpr static const char* search_param_tmp2 = R"(
     {{
         "parallelism": {}
     }})";

--- a/tests/test_index.cpp
+++ b/tests/test_index.cpp
@@ -2399,4 +2399,54 @@ void
 TestIndex::TestGetDataByIdWithFlag(const IndexPtr& index, const TestDatasetPtr& dataset) {
 }
 
+void
+TestIndex::TestConcurrentAddSearchRemove(const TestIndex::IndexPtr& index,
+                                         const TestDatasetPtr& dataset,
+                                         const std::string& search_param,
+                                         bool expected_success) {
+    if (not index->CheckFeature(vsag::SUPPORT_ADD_SEARCH_DELETE_CONCURRENT)) {
+        return;
+    }
+    fixtures::logger::LoggerReplacer _;
+
+    auto base_count = dataset->base_->GetNumElements();
+    auto temp_count = static_cast<int64_t>(base_count * 0.8);
+    auto dim = dataset->base_->GetDim();
+    auto temp_dataset = vsag::Dataset::Make();
+    temp_dataset->Dim(dim)
+        ->Ids(dataset->base_->GetIds())
+        ->NumElements(temp_count)
+        ->Paths(dataset->base_->GetPaths())
+        ->Float32Vectors(dataset->base_->GetFloat32Vectors())
+        ->SparseVectors(dataset->base_->GetSparseVectors())
+        ->Owner(false);
+    index->Build(temp_dataset);
+    fixtures::ThreadPool pool(5);
+    std::vector<std::future<bool>> futures;
+
+    auto func = [&](uint64_t i) -> bool {
+        auto data_one = vsag::Dataset::Make();
+        data_one->Dim(dim)
+            ->Ids(dataset->base_->GetIds() + i)
+            ->NumElements(1)
+            ->Paths(dataset->base_->GetPaths() + i)
+            ->Float32Vectors(dataset->base_->GetFloat32Vectors() + i * dim)
+            ->SparseVectors(dataset->base_->GetSparseVectors() + i)
+            ->Owner(false);
+        auto add_index = index->Add(data_one);
+        auto search_index = index->KnnSearch(data_one, 1, search_param);
+        auto remove_index = index->Remove(*(dataset->base_->GetIds() + i));
+        return add_index.has_value() & search_index.has_value() & remove_index.has_value();
+    };
+
+    for (uint64_t j = temp_count; j < base_count; ++j) {
+        futures.emplace_back(pool.enqueue(func, j));
+    }
+
+    for (auto& res : futures) {
+        auto val = res.get();
+        REQUIRE(val);
+    }
+}
+
 }  // namespace fixtures

--- a/tests/test_index.h
+++ b/tests/test_index.h
@@ -228,6 +228,12 @@ public:
     TestConcurrentAdd(const IndexPtr& index,
                       const TestDatasetPtr& dataset,
                       bool expected_success = true);
+
+    static void
+    TestConcurrentAddSearchRemove(const IndexPtr& index,
+                                  const TestDatasetPtr& dataset,
+                                  const std::string& search_param,
+                                  bool expected_success = true);
     static void
     TestConcurrentAddSearch(const IndexPtr& index,
                             const TestDatasetPtr& dataset,


### PR DESCRIPTION
close: #1268

## Summary by Sourcery

Enable thread-safe removal in HGraph and add end-to-end concurrent add, search, and delete testing

New Features:
- Introduce SUPPORT_ADD_SEARCH_DELETE_CONCURRENT feature flag in HGraph
- Guard remove operations with a mutex to make HGraph deletion thread-safe

Tests:
- Add TestHGraphConcurrentAddSearchRemove with PR and daily test cases
- Implement TestIndex::TestConcurrentAddSearchRemove for concurrent add, search, and remove validation
- Switch search parameter literal in brute force tests to a constexpr static string