### PR TITLE
feat(c_api): introduce some simple C api

### DIFF
--- a/include/vsag/vsag_c_api.h
+++ b/include/vsag/vsag_c_api.h
@@ -1,0 +1,45 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+extern "C" {
+#include <stdint.h>
+typedef void* vsag_index_t;
+vsag_index_t
+vsag_index_factory(const char* index_name, const char* index_param);
+
+bool
+vsag_index_destroy(vsag_index_t index);
+
+bool
+vsag_index_build(
+    vsag_index_t index, const float* data, const int64_t* ids, uint64_t dim, uint64_t count);
+
+bool
+vsag_index_knn_search(vsag_index_t index,
+                      const float* query,
+                      uint64_t dim,
+                      int64_t k,
+                      const char* parameters,
+                      float* results,
+                      int64_t* ids);
+
+bool
+vsag_serialize_file(vsag_index_t index, const char* file_path);
+
+bool
+vsag_deserialize_file(vsag_index_t index, const char* file_path);
+}

--- a/src/vsag_c_api.cpp
+++ b/src/vsag_c_api.cpp
@@ -1,0 +1,138 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <vsag/factory.h>
+#include <vsag/index.h>
+#include <vsag/vsag_c_api.h>
+
+#include <fstream>
+
+class VsagIndex {
+public:
+    VsagIndex(std::shared_ptr<vsag::Index> index) : index_(std::move(index)) {
+    }
+
+    std::shared_ptr<vsag::Index> index_;
+};
+
+extern "C" {
+vsag_index_t
+vsag_index_factory(const char* index_name, const char* index_param) {
+    try {
+        auto index = vsag::Factory::CreateIndex(index_name, index_param);
+        if (index.has_value()) {
+            return new VsagIndex(index.value());
+        }
+        return nullptr;
+
+    } catch (const std::exception& e) {
+        return nullptr;
+    }
+}
+
+bool
+vsag_index_destroy(vsag_index_t index) {
+    try {
+        auto* vsag_index = static_cast<VsagIndex*>(index);
+        delete vsag_index;
+        return true;
+    } catch (const std::exception& e) {
+        return false;
+    }
+}
+
+bool
+vsag_index_build(
+    vsag_index_t index, const float* data, const int64_t* ids, uint64_t dim, uint64_t count) {
+    try {
+        auto* vsag_index = static_cast<VsagIndex*>(index);
+        if (vsag_index != nullptr) {
+            auto dataset = vsag::Dataset::Make();
+            dataset->Owner(false)
+                ->Dim(static_cast<int64_t>(dim))
+                ->NumElements(static_cast<int64_t>(count))
+                ->Ids(ids)
+                ->Float32Vectors(data);
+            vsag_index->index_->Build(dataset);
+        }
+        return true;
+    } catch (const std::exception& e) {
+        return false;
+    }
+}
+
+bool
+vsag_index_knn_search(vsag_index_t index,
+                      const float* query,
+                      uint64_t dim,
+                      int64_t k,
+                      const char* parameters,
+                      float* results,
+                      int64_t* ids) {
+    try {
+        auto* vsag_index = static_cast<VsagIndex*>(index);
+        if (vsag_index != nullptr) {
+            auto query_dataset = vsag::Dataset::Make();
+            query_dataset->Owner(false)
+                ->Dim(static_cast<int64_t>(dim))
+                ->NumElements(static_cast<int64_t>(1))
+                ->Float32Vectors(query);
+            auto result = vsag_index->index_->KnnSearch(query_dataset, k, parameters);
+            if (result.has_value()) {
+                const auto* ids_view = result.value()->GetIds();
+                const auto* dists_view = result.value()->GetDistances();
+                auto real_k = result.value()->GetDim();
+                for (int i = 0; i < real_k; ++i) {
+                    ids[i] = ids_view[i];
+                    results[i] = dists_view[i];
+                }
+            }
+        }
+        return true;
+    } catch (const std::exception& e) {
+        return false;
+    }
+}
+
+bool
+vsag_serialize_file(vsag_index_t index, const char* file_path) {
+    try {
+        auto* vsag_index = static_cast<VsagIndex*>(index);
+        if (vsag_index != nullptr) {
+            std::ofstream file(file_path, std::ios::binary);
+            vsag_index->index_->Serialize(file);
+            file.close();
+        }
+        return true;
+    } catch (const std::exception& e) {
+        return false;
+    }
+}
+
+bool
+vsag_deserialize_file(vsag_index_t index, const char* file_path) {
+    try {
+        auto* vsag_index = static_cast<VsagIndex*>(index);
+        if (vsag_index != nullptr) {
+            std::ifstream file(file_path, std::ios::binary);
+            vsag_index->index_->Deserialize(file);
+            file.close();
+        }
+        return true;
+    } catch (const std::exception& e) {
+        return false;
+    }
+}
+}

--- a/src/vsag_c_api_test.cpp
+++ b/src/vsag_c_api_test.cpp
@@ -1,0 +1,97 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <vsag/vsag_c_api.h>
+
+#include <catch2/catch_test_macros.hpp>
+#include <random>
+
+TEST_CASE("vsag_c_api basic test", "[vsag_c_api][ut]") {
+    const char* index_name = "hgraph";
+    const char* index_param = R"(
+    {
+        "dtype": "float32",
+        "metric_type": "l2",
+        "dim": 128,
+        "index_param": {
+            "base_quantization_type": "fp32",
+            "max_degree": 64,
+            "ef_construction": 200,
+            "alpha":1.2
+        }
+    }
+    )";
+    auto index = vsag_index_factory(index_name, index_param);
+    REQUIRE(index != nullptr);
+
+    int64_t num_vectors = 500;
+    int64_t dim = 128;
+    std::vector<int64_t> ids(num_vectors);
+    std::vector<float> datas(num_vectors * dim);
+    std::mt19937 rng(47);
+    std::uniform_real_distribution<float> distrib_real;
+    for (int64_t i = 0; i < num_vectors; ++i) {
+        ids[i] = i;
+    }
+    for (int64_t i = 0; i < dim * num_vectors; ++i) {
+        datas[i] = distrib_real(rng);
+    }
+    bool ret = vsag_index_build(index, datas.data(), ids.data(), dim, num_vectors);
+    REQUIRE(ret);
+    auto func = [&](vsag_index_t index1) {
+        const char* hgraph_search_parameters = R"(
+            {
+                "hgraph": {
+                    "ef_search": 200
+                }
+            }
+            )";
+        int64_t topk = 10;
+        for (int i = 0; i < num_vectors; ++i) {
+            std::vector<int64_t> results(topk);
+            std::vector<float> scores(topk);
+            ret = vsag_index_knn_search(index1,
+                                        datas.data() + i * dim,
+                                        dim,
+                                        topk,
+                                        hgraph_search_parameters,
+                                        scores.data(),
+                                        results.data());
+            REQUIRE(ret);
+            bool in_results = false;
+            for (int64_t j = 0; j < topk; ++j) {
+                if (results[j] == i) {
+                    in_results = true;
+                    break;
+                }
+            }
+            REQUIRE(in_results);
+        }
+    };
+    func(index);
+
+    const char* file_name = "/tmp/test_c_api.vsag";
+    ret = vsag_serialize_file(index, file_name);
+    REQUIRE(ret);
+    vsag_index_t index2 = vsag_index_factory(index_name, index_param);
+    ret = vsag_deserialize_file(index2, file_name);
+    REQUIRE(ret);
+    REQUIRE(index2 != nullptr);
+
+    func(index2);
+
+    vsag_index_destroy(index);
+    vsag_index_destroy(index2);
+}


### PR DESCRIPTION
closed: #1271 

## Summary by Sourcery

Provide a simple C-compatible interface for the vsag indexing library and cover its core operations with unit tests

New Features:
- Introduce a C API for vsag::Index including create, destroy, build, knn search, serialize, and deserialize functions

Tests:
- Add Catch2-based unit tests to validate C API functionality for index creation, building, searching, serialization, and deserialization