### PR TITLE
improvement: split implement of MemoryIO

### DIFF
--- a/src/io/CMakeLists.txt
+++ b/src/io/CMakeLists.txt
@@ -16,6 +16,7 @@
 
 set (IO_SRC
         io_parameter.cpp
+        memory_io.cpp
         memory_io_parameter.cpp
         memory_block_io_parameter.cpp
         buffer_io_parameter.cpp

--- a/src/io/memory_io.cpp
+++ b/src/io/memory_io.cpp
@@ -1,0 +1,56 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "memory_io.h"
+
+namespace vsag {
+
+void
+MemoryIO::WriteImpl(const uint8_t* data, uint64_t size, uint64_t offset) {
+    check_and_realloc(size + offset);
+    memcpy(start_ + offset, data, size);
+}
+
+bool
+MemoryIO::ReadImpl(uint64_t size, uint64_t offset, uint8_t* data) const {
+    bool ret = check_valid_offset(size + offset);
+    if (ret) {
+        memcpy(data, start_ + offset, size);
+    }
+    return ret;
+}
+
+const uint8_t*
+MemoryIO::DirectReadImpl(uint64_t size, uint64_t offset, bool& need_release) const {
+    need_release = false;
+    if (check_valid_offset(size + offset)) {
+        return start_ + offset;
+    }
+    return nullptr;
+}
+bool
+MemoryIO::MultiReadImpl(uint8_t* datas, uint64_t* sizes, uint64_t* offsets, uint64_t count) const {
+    bool ret = true;
+    for (uint64_t i = 0; i < count; ++i) {
+        ret &= this->ReadImpl(sizes[i], offsets[i], datas);
+        datas += sizes[i];
+    }
+    return ret;
+}
+void
+MemoryIO::PrefetchImpl(uint64_t offset, uint64_t cache_line) {
+    PrefetchLines(this->start_ + offset, cache_line);
+}
+}  // namespace vsag

--- a/src/io/memory_io.h
+++ b/src/io/memory_io.h
@@ -46,19 +46,19 @@ public:
         this->allocator_->Deallocate(start_);
     }
 
-    inline void
+    void
     WriteImpl(const uint8_t* data, uint64_t size, uint64_t offset);
 
-    inline bool
+    bool
     ReadImpl(uint64_t size, uint64_t offset, uint8_t* data) const;
 
-    [[nodiscard]] inline const uint8_t*
+    [[nodiscard]] const uint8_t*
     DirectReadImpl(uint64_t size, uint64_t offset, bool& need_release) const;
 
-    inline bool
+    bool
     MultiReadImpl(uint8_t* datas, uint64_t* sizes, uint64_t* offsets, uint64_t count) const;
 
-    inline void
+    void
     PrefetchImpl(uint64_t offset, uint64_t cache_line = 64);
 
 private:
@@ -74,41 +74,4 @@ private:
 private:
     uint8_t* start_{nullptr};
 };
-
-void
-MemoryIO::WriteImpl(const uint8_t* data, uint64_t size, uint64_t offset) {
-    check_and_realloc(size + offset);
-    memcpy(start_ + offset, data, size);
-}
-
-bool
-MemoryIO::ReadImpl(uint64_t size, uint64_t offset, uint8_t* data) const {
-    bool ret = check_valid_offset(size + offset);
-    if (ret) {
-        memcpy(data, start_ + offset, size);
-    }
-    return ret;
-}
-
-const uint8_t*
-MemoryIO::DirectReadImpl(uint64_t size, uint64_t offset, bool& need_release) const {
-    need_release = false;
-    if (check_valid_offset(size + offset)) {
-        return start_ + offset;
-    }
-    return nullptr;
-}
-bool
-MemoryIO::MultiReadImpl(uint8_t* datas, uint64_t* sizes, uint64_t* offsets, uint64_t count) const {
-    bool ret = true;
-    for (uint64_t i = 0; i < count; ++i) {
-        ret &= this->ReadImpl(sizes[i], offsets[i], datas);
-        datas += sizes[i];
-    }
-    return ret;
-}
-void
-MemoryIO::PrefetchImpl(uint64_t offset, uint64_t cache_line) {
-    PrefetchLines(this->start_ + offset, cache_line);
-}
 }  // namespace vsag


### PR DESCRIPTION
## Summary by Sourcery

Refactor MemoryIO by extracting method implementations from the header into a new source file

Enhancements:
- Extract MemoryIO method definitions into memory_io.cpp
- Add Apache 2.0 license header to memory_io.cpp