### PR TITLE
fix: add missing header file to common.h

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -15,6 +15,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "vsag_exception.h"
 
 #define SAFE_CALL(stmt)                                                              \


### PR DESCRIPTION
fixes: #1280

## Summary by Sourcery

Bug Fixes:
- Add <cstdint> include to src/common.h to fix missing header error (#1280)