### PR TITLE
feat(ivf): add param to support on-disk IVF Index

### DIFF
--- a/src/algorithm/ivf.cpp
+++ b/src/algorithm/ivf.cpp
@@ -44,7 +44,8 @@ static constexpr const char* IVF_PARAMS_TEMPLATE =
         "{BUILD_THREAD_COUNT_KEY}": 1,
         "{BUCKET_PARAMS_KEY}": {
             "{IO_PARAMS_KEY}": {
-                "{IO_TYPE_KEY}": "{IO_TYPE_VALUE_MEMORY_IO}"
+                "{IO_TYPE_KEY}": "{IO_TYPE_VALUE_MEMORY_IO}",
+                "{IO_FILE_PATH}": "{DEFAULT_FILE_PATH_VALUE}"
             },
             "{QUANTIZATION_PARAMS_KEY}": {
                 "{QUANTIZATION_TYPE_KEY}": "{QUANTIZATION_TYPE_VALUE_FP32}",
@@ -100,6 +101,14 @@ IVF::CheckAndMappingExternalParam(const JsonType& external_param,
                 BUCKET_PARAMS_KEY,
                 IO_PARAMS_KEY,
                 IO_TYPE_KEY,
+            },
+        },
+        {
+            IVF_BASE_FILE_PATH,
+            {
+                BUCKET_PARAMS_KEY,
+                IO_PARAMS_KEY,
+                IO_FILE_PATH,
             },
         },
         {

--- a/src/datacell/bucket_interface.cpp
+++ b/src/datacell/bucket_interface.cpp
@@ -100,6 +100,15 @@ BucketInterface::MakeInstance(const BucketDataCellParamPtr& param,
     if (io_type_name == IO_TYPE_VALUE_MEMORY_IO) {
         return make_instance<MemoryIO>(param, common_param);
     }
+    if (io_type_name == IO_TYPE_VALUE_MMAP_IO) {
+        return make_instance<NonContinuousIO<MMapIO>>(param, common_param);
+    }
+    if (io_type_name == IO_TYPE_VALUE_ASYNC_IO) {
+        return make_instance<NonContinuousIO<AsyncIO>>(param, common_param);
+    }
+    if (io_type_name == IO_TYPE_VALUE_BUFFER_IO) {
+        return make_instance<NonContinuousIO<BufferIO>>(param, common_param);
+    }
     return nullptr;
 }
 }  // namespace vsag

--- a/src/io/io_array_test.cpp
+++ b/src/io/io_array_test.cpp
@@ -33,7 +33,8 @@ class IOArrayTest {
 public:
     template <typename... Args>
     IOArrayTest(Allocator* allocator, Args&&... args)
-        : array_(std::make_unique<IOArray<IOType>>(allocator, std::forward<Args>(args)...)) {
+        : array_(std::make_unique<IOArray<IOType>>(allocator, std::forward<Args>(args)...)),
+          array2_(std::make_unique<IOArray<IOType>>(allocator, std::forward<Args>(args)...)) {
     }
 
     void
@@ -49,9 +50,14 @@ public:
         for (size_t i = 5; i < 10; ++i) {
             TestBasicReadWrite(this->array_->At(i));
         }
+        this->array2_->Resize(10);
+        for (size_t i = 0; i < 10; ++i) {
+            TestSerializeAndDeserialize((*this->array_)[i], (*this->array2_)[i]);
+        }
     }
 
     std::unique_ptr<IOArray<IOType>> array_{nullptr};
+    std::unique_ptr<IOArray<IOType>> array2_{nullptr};
 };
 }  // namespace vsag
 

--- a/src/io/io_headers.h
+++ b/src/io/io_headers.h
@@ -21,4 +21,5 @@
 #include "memory_block_io.h"
 #include "memory_io.h"
 #include "mmap_io.h"
+#include "noncontinuous_io.h"
 #include "reader_io.h"


### PR DESCRIPTION
closed: #1284 

## Summary by Sourcery

Add file_path support for on-disk IVF index and extend IO backends with MMapIO, AsyncIO, and BufferIO, updating related parameter templates and tests accordingly

New Features:
- Add support for on-disk IVF index by introducing a file_path parameter in io_params
- Enable new IO backends (MMapIO, AsyncIO, BufferIO) in BucketInterface

Enhancements:
- Include default IO_FILE_PATH in the IVF parameters template and map it during external parameter validation
- Add noncontinuous_io header to io_headers

Tests:
- Extend BucketDataCell tests to generate and use separate file paths for two instances and include buffer_io and async_io types
- Enhance IOArrayTest to include a second array instance and verify serialization/deserialization