### PR TITLE
feat(index): add write function for Serialize

### DIFF
--- a/include/vsag/index.h
+++ b/include/vsag/index.h
@@ -52,6 +52,10 @@ enum class IndexType { HNSW, DISKANN, HGRAPH, IVF, PYRAMID, BRUTEFORCE, SPARSE, 
 #define DATA_FLAG_ATTRIBUTE 0x20
 #define DATA_FLAG_ID 0x40
 
+using OffsetType = uint64_t;
+using SizeType = uint64_t;
+using WriteFuncType = std::function<void(OffsetType, SizeType, const void*)>;
+
 class Index {
 public:
     // [basic methods]
@@ -654,6 +658,16 @@ public:
       */
     [[nodiscard]] virtual tl::expected<BinarySet, Error>
     Serialize() const = 0;
+
+    /**
+      * @brief Serialize index by write function
+      *
+      * @param write_func is a function to write serialized index
+      */
+    [[nodiscard]] virtual tl::expected<void, Error>
+    Serialize(WriteFuncType write_func) const {
+        throw std::runtime_error("Index doesn't support Serialize with write function");
+    }
 
     /**
       * @brief Deserialize index from a set of byte array. Causing exception if this index is not empty

--- a/include/vsag/index_features.h
+++ b/include/vsag/index_features.h
@@ -35,6 +35,7 @@ enum IndexFeature {
     SUPPORT_METRIC_TYPE_COSINE,          /**< Supports cosine metric type */
     SUPPORT_SERIALIZE_FILE,              /**< Supports serialization to a file */
     SUPPORT_SERIALIZE_BINARY_SET,        /**< Supports serialization to a binary set */
+    SUPPORT_SERIALIZE_WRITE_FUNC,        /**< Supports serialization to a write function */
     SUPPORT_DESERIALIZE_FILE,            /**< Supports deserialization from a file */
     SUPPORT_DESERIALIZE_BINARY_SET,      /**< Supports deserialization from a binary set */
     SUPPORT_DESERIALIZE_READER_SET,      /**< Supports deserialization from a reader set */

--- a/src/algorithm/brute_force.cpp
+++ b/src/algorithm/brute_force.cpp
@@ -422,6 +422,7 @@ BruteForce::InitFeatures() {
         IndexFeature::SUPPORT_DESERIALIZE_READER_SET,
         IndexFeature::SUPPORT_SERIALIZE_BINARY_SET,
         IndexFeature::SUPPORT_SERIALIZE_FILE,
+        IndexFeature::SUPPORT_SERIALIZE_WRITE_FUNC,
     });
 
     // others

--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -1116,6 +1116,7 @@ HGraph::InitFeatures() {
         IndexFeature::SUPPORT_DESERIALIZE_READER_SET,
         IndexFeature::SUPPORT_SERIALIZE_BINARY_SET,
         IndexFeature::SUPPORT_SERIALIZE_FILE,
+        IndexFeature::SUPPORT_SERIALIZE_WRITE_FUNC,
     });
     // other
     this->index_feature_list_->SetFeatures({

--- a/src/algorithm/inner_index_interface.cpp
+++ b/src/algorithm/inner_index_interface.cpp
@@ -144,6 +144,15 @@ InnerIndexInterface::Serialize() const {
 }
 
 void
+InnerIndexInterface::Serialize(const WriteFuncType& write_func) const {
+    std::string time_record_name = this->GetName() + " Serialize";
+    SlowTaskTimer t(time_record_name);
+
+    WriteFuncStreamWriter writer(write_func, 0);
+    this->Serialize(writer);
+}
+
+void
 InnerIndexInterface::Deserialize(const BinarySet& binary_set) {
     std::string time_record_name = this->GetName() + " Deserialize";
     SlowTaskTimer t(time_record_name);

--- a/src/algorithm/inner_index_interface.h
+++ b/src/algorithm/inner_index_interface.h
@@ -333,6 +333,9 @@ public:
     Serialize(std::ostream& out_stream) const;
 
     virtual void
+    Serialize(const WriteFuncType& write_func) const;
+
+    virtual void
     Serialize(StreamWriter& writer) const = 0;
 
     [[nodiscard]] virtual BinarySet

--- a/src/algorithm/ivf.cpp
+++ b/src/algorithm/ivf.cpp
@@ -296,6 +296,7 @@ IVF::InitFeatures() {
         IndexFeature::SUPPORT_DESERIALIZE_READER_SET,
         IndexFeature::SUPPORT_SERIALIZE_BINARY_SET,
         IndexFeature::SUPPORT_SERIALIZE_FILE,
+        IndexFeature::SUPPORT_SERIALIZE_WRITE_FUNC,
     });
 
     auto name = this->bucket_->GetQuantizerName();

--- a/src/index/index_impl.h
+++ b/src/index/index_impl.h
@@ -381,6 +381,11 @@ public:
         SAFE_CALL(return this->inner_index_->Serialize());
     }
 
+    [[nodiscard]] tl::expected<void, Error>
+    Serialize(WriteFuncType write_func) const override {
+        SAFE_CALL(this->inner_index_->Serialize(write_func));
+    }
+
     tl::expected<void, Error>
     Serialize(std::ostream& out_stream) override {
         SAFE_CALL(this->inner_index_->Serialize(out_stream));

--- a/tests/fixtures/fixtures.cpp
+++ b/tests/fixtures/fixtures.cpp
@@ -383,7 +383,7 @@ CreateAttribute(std::string term_name,
 vsag::AttributeSet*
 generate_attributes(uint64_t count, uint32_t max_term_count, uint32_t max_value_count, int seed) {
     auto* results = new vsag::AttributeSet[count];
-    std::mt19937 gen(seed);
+    thread_local std::mt19937 gen(seed);
     std::uniform_int_distribution<int> term_count_dist(1, max_term_count);
     auto term_count = term_count_dist(gen);
     std::vector<std::pair<std::string, vsag::AttrValueType>> terms(term_count);

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -678,6 +678,8 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HGraphTestIndex,
     TestIndex::TestSerializeBinarySet(index, index2, dataset, search_param, true);
     index2 = TestIndex::TestFactory(name, param, true);
     TestIndex::TestSerializeReaderSet(index, index2, dataset, search_param, name, true);
+    index2 = TestIndex::TestFactory(name, param, true);
+    TestIndex::TestSerializeWriteFunc(index, index2, dataset, search_param, true);
     vsag::Options::Instance().set_block_size_limit(origin_size);
 }
 static void
@@ -1413,6 +1415,8 @@ TestHGraphSerialize(const fixtures::HGraphTestIndexPtr& test_index,
                 index2 = TestIndex::TestFactory(test_index->name, param, true);
                 TestIndex::TestSerializeReaderSet(
                     index, index2, dataset, search_param, test_index->name, true);
+                index2 = TestIndex::TestFactory(test_index->name, param, true);
+                TestIndex::TestSerializeWriteFunc(index, index2, dataset, search_param, true);
                 vsag::Options::Instance().set_block_size_limit(origin_size);
             }
         }

--- a/tests/test_index.h
+++ b/tests/test_index.h
@@ -193,6 +193,13 @@ public:
                            bool expected_success = true);
 
     static void
+    TestSerializeWriteFunc(const IndexPtr& index_from,
+                           const IndexPtr& index_to,
+                           const TestDatasetPtr& dataset,
+                           const std::string& search_param,
+                           bool expected_success = true);
+
+    static void
     TestSerializeReaderSet(const IndexPtr& index_from,
                            const IndexPtr& index_to,
                            const TestDatasetPtr& dataset,

--- a/tests/test_ivf.cpp
+++ b/tests/test_ivf.cpp
@@ -1078,6 +1078,12 @@ TestIVFSerialize(const fixtures::IVFResourcePtr& resource) {
                             IVFTestIndex::TestSerializeReaderSet(
                                 index, index2, dataset, search_param, IVFTestIndex::name, true);
                         }
+                        if (index->CheckFeature(vsag::SUPPORT_SERIALIZE_WRITE_FUNC)) {
+                            auto index2 =
+                                IVFTestIndex::TestFactory(IVFTestIndex::name, param, true);
+                            IVFTestIndex::TestSerializeWriteFunc(
+                                index, index2, dataset, search_param, true);
+                        }
                     }
                     vsag::Options::Instance().set_block_size_limit(origin_size);
                 }

--- a/tests/test_simple_index.cpp
+++ b/tests/test_simple_index.cpp
@@ -159,4 +159,5 @@ TEST_CASE("Test Simple Index", "[ft][simple_index]") {
     REQUIRE_THROWS(index->AnalyzeIndexBySearch(req));
     REQUIRE_THROWS(index->GetIndexType());
     REQUIRE_THROWS(index->GetIndexDetailInfos());
+    REQUIRE_THROWS(index->Serialize(WriteFuncType(nullptr)));
 }


### PR DESCRIPTION
closed: #1282

## Summary by Sourcery

Add support for serializing indexes via a custom write function

New Features:
- Introduce WriteFuncType and offset/size typedefs in index.h
- Add Serialize(write_func) method to Index interface with default implementation
- Implement write-function-based serialization in InnerIndexInterface and IndexImpl
- Enable SUPPORT_SERIALIZE_WRITE_FUNC feature for algorithms (BruteForce, HGraph, IVF)

Tests:
- Add TestSerializeWriteFunc unit test to validate serialization with a write function and ensure round-trip deserialization preserves search results