### PR TITLE
feat(api): introduce an api for GetDetailInfo from Index

### DIFF
--- a/include/vsag/index.h
+++ b/include/vsag/index.h
@@ -25,6 +25,7 @@
 #include "vsag/errors.h"
 #include "vsag/expected.hpp"
 #include "vsag/filter.h"
+#include "vsag/index_detail_info.h"
 #include "vsag/index_features.h"
 #include "vsag/iterator_context.h"
 #include "vsag/readerset.h"
@@ -527,6 +528,23 @@ public:
     virtual tl::expected<DatasetPtr, Error>
     GetDataByIdsWithFlag(const int64_t* ids, int64_t count, uint64_t selected_data_flag) const {
         throw std::runtime_error("Index doesn't support GetDataByIdsWithFlag");
+    };
+
+    /*
+     * @brief Retrieve all detail information associated with the index.
+     *
+     * This method fetches all detail information stored with the index for following get detail datas by name
+     * @see IndexDetailInfo
+     *
+     * @return tl::expected<std::vector<IndexDetailInfo>, Error>
+     *         - On success: A vector of IndexDetailInfo structs containing the detail information.
+     *         - On failure: An error object (e.g., out of memory).
+     * @throws std::runtime_error If the index implementation does not support this operation
+     *            (default behavior for base class).
+     */
+    virtual tl::expected<std::vector<IndexDetailInfo>, Error>
+    GetIndexDetailInfos() const {
+        throw std::runtime_error("Index doesn't support GetIndexDetailInfo");
     };
 
     /**

--- a/include/vsag/index_detail_info.h
+++ b/include/vsag/index_detail_info.h
@@ -1,0 +1,31 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+namespace vsag {
+
+enum class IndexDetailDataType {
+    TYPE_2DArray_INT64,
+    TYPE_1DArray_INT64,
+};
+
+struct IndexDetailInfo {
+    std::string name;
+    std::string description;
+    IndexDetailDataType type;
+};
+}  // namespace vsag

--- a/src/algorithm/inner_index_interface.cpp
+++ b/src/algorithm/inner_index_interface.cpp
@@ -463,6 +463,11 @@ InnerIndexInterface::GetDataByIdsWithFlag(const int64_t* ids,
     return dataset;
 }
 
+std::vector<IndexDetailInfo>
+InnerIndexInterface::GetIndexDetailInfos() const {
+    return {};
+}
+
 void
 InnerIndexInterface::GetExtraInfoByIds(const int64_t* ids, int64_t count, char* extra_infos) const {
     if (this->extra_infos_ == nullptr) {

--- a/src/algorithm/inner_index_interface.h
+++ b/src/algorithm/inner_index_interface.h
@@ -161,6 +161,9 @@ public:
     [[nodiscard]] virtual DatasetPtr
     GetDataByIdsWithFlag(const int64_t* ids, int64_t count, uint64_t selected_data_flag) const;
 
+    virtual std::vector<IndexDetailInfo>
+    GetIndexDetailInfos() const;
+
     [[nodiscard]] virtual int64_t
     GetEstimateBuildMemory(const int64_t num_elements) const {
         throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,

--- a/src/index/index_impl.h
+++ b/src/index/index_impl.h
@@ -180,6 +180,11 @@ public:
         SAFE_CALL(return this->inner_index_->GetDataByIdsWithFlag(ids, count, selected_data_flag));
     };
 
+    tl::expected<std::vector<IndexDetailInfo>, Error>
+    GetIndexDetailInfos() const override {
+        SAFE_CALL(return this->inner_index_->GetIndexDetailInfos());
+    }
+
     [[nodiscard]] int64_t
     GetEstimateBuildMemory(const int64_t num_elements) const override {
         return this->inner_index_->GetEstimateBuildMemory(num_elements);

--- a/tests/test_simple_index.cpp
+++ b/tests/test_simple_index.cpp
@@ -158,4 +158,5 @@ TEST_CASE("Test Simple Index", "[ft][simple_index]") {
     REQUIRE_THROWS(index->ExportIDs());
     REQUIRE_THROWS(index->AnalyzeIndexBySearch(req));
     REQUIRE_THROWS(index->GetIndexType());
+    REQUIRE_THROWS(index->GetIndexDetailInfos());
 }


### PR DESCRIPTION
closed: #1293

## Summary by Sourcery

Introduce a new API to retrieve detailed metadata from indexes by defining IndexDetailInfo and IndexDetailDataType, adding a GetIndexDetailInfos method on the Index interface with default stubs and overrides, and updating tests to cover its behavior.

New Features:
- Add IndexDetailInfo data structure and IndexDetailDataType enum
- Introduce GetIndexDetailInfos API on Index with default stub and override in implementations

Tests:
- Add test to ensure GetIndexDetailInfos throws on unsupported index