### PR TITLE
feat(c_api): add Error_t instead bool as return result

### DIFF
--- a/include/vsag/vsag_c_api.h
+++ b/include/vsag/vsag_c_api.h
@@ -17,18 +17,40 @@
 
 extern "C" {
 #include <stdint.h>
+
+#define VSAG_SUCCESS 0
+#define VSAG_UNKNOWN_ERROR -1
+#define VSAG_INTERNAL_ERROR -2
+#define VSAG_INVALID_ARGUMENT -3
+#define VSAG_WRONG_STATUS -4
+#define VSAG_BUILD_TWICE -5
+#define VSAG_INDEX_NOT_EMPTY -6
+#define VSAG_UNSUPPORTED_INDEX -7
+#define VSAG_UNSUPPORTED_INDEX_OPERATION -8
+#define VSAG_DIMENSION_NOT_EQUAL -9
+#define VSAG_INDEX_EMPTY -10
+#define VSAG_NO_ENOUGH_MEMORY -11
+#define VSAG_READ_ERROR -12
+#define VSAG_MISSING_FILE -13
+#define VSAG_INVALID_BINARY -14
+
+typedef struct Error {
+    int code;
+    char message[1024];
+} Error_t;
+
 typedef void* vsag_index_t;
 vsag_index_t
 vsag_index_factory(const char* index_name, const char* index_param);
 
-bool
+Error_t
 vsag_index_destroy(vsag_index_t index);
 
-bool
+Error_t
 vsag_index_build(
     vsag_index_t index, const float* data, const int64_t* ids, uint64_t dim, uint64_t count);
 
-bool
+Error_t
 vsag_index_knn_search(vsag_index_t index,
                       const float* query,
                       uint64_t dim,
@@ -37,9 +59,9 @@ vsag_index_knn_search(vsag_index_t index,
                       float* results,
                       int64_t* ids);
 
-bool
+Error_t
 vsag_serialize_file(vsag_index_t index, const char* file_path);
 
-bool
+Error_t
 vsag_deserialize_file(vsag_index_t index, const char* file_path);
 }

--- a/src/vsag_c_api_test.cpp
+++ b/src/vsag_c_api_test.cpp
@@ -48,8 +48,8 @@ TEST_CASE("vsag_c_api basic test", "[vsag_c_api][ut]") {
     for (int64_t i = 0; i < dim * num_vectors; ++i) {
         datas[i] = distrib_real(rng);
     }
-    bool ret = vsag_index_build(index, datas.data(), ids.data(), dim, num_vectors);
-    REQUIRE(ret);
+    Error_t ret = vsag_index_build(index, datas.data(), ids.data(), dim, num_vectors);
+    REQUIRE(ret.code == VSAG_SUCCESS);
     auto func = [&](vsag_index_t index1) {
         const char* hgraph_search_parameters = R"(
             {
@@ -69,7 +69,7 @@ TEST_CASE("vsag_c_api basic test", "[vsag_c_api][ut]") {
                                         hgraph_search_parameters,
                                         scores.data(),
                                         results.data());
-            REQUIRE(ret);
+            REQUIRE(ret.code == VSAG_SUCCESS);
             bool in_results = false;
             for (int64_t j = 0; j < topk; ++j) {
                 if (results[j] == i) {
@@ -84,10 +84,10 @@ TEST_CASE("vsag_c_api basic test", "[vsag_c_api][ut]") {
 
     const char* file_name = "/tmp/test_c_api.vsag";
     ret = vsag_serialize_file(index, file_name);
-    REQUIRE(ret);
+    REQUIRE(ret.code == VSAG_SUCCESS);
     vsag_index_t index2 = vsag_index_factory(index_name, index_param);
     ret = vsag_deserialize_file(index2, file_name);
-    REQUIRE(ret);
+    REQUIRE(ret.code == VSAG_SUCCESS);
     REQUIRE(index2 != nullptr);
 
     func(index2);


### PR DESCRIPTION
closed: #1296

## Summary by Sourcery

Replace simple boolean returns in the C API with a structured Error_t type carrying error codes and messages, define a set of VSAG error codes, implement error conversion helpers, and update all API functions and tests to use the new error reporting mechanism

New Features:
- Introduce Error_t struct and predefined VSAG error codes in the C API headers
- Change C API functions to return Error_t instead of bool, using a SUCCESS constant on success

Enhancements:
- Add make_error helper functions to convert vsag::Error and std::exception into structured Error_t responses
- Update C API functions (destroy, build, knn_search, serialize, deserialize) to return detailed error information from underlying operations

Tests:
- Modify C API unit tests to check Error_t.code against VSAG_SUCCESS instead of boolean return values