### PR TITLE
chore(tsan): Ignore TSan checks in OpenMP's race

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
           keys:
             - fork-cache-{{ checksum "CMakeLists.txt" }}-{{ checksum ".circleci/fresh_ci_cache.commit" }}
       - run:
-          command: export CMAKE_GENERATOR="Ninja" && make test_parallel
+          command: export CMAKE_GENERATOR="Ninja" && export COMPILE_JOBS=4 && make test_parallel
           no_output_timeout: 50m
       - save_cache:
           key: fork-cache-{{ checksum "CMakeLists.txt" }}-{{ checksum ".circleci/fresh_ci_cache.commit" }}
@@ -47,7 +47,7 @@ jobs:
           keys:
             - main-ccache-{{ checksum "CMakeLists.txt" }}-{{ checksum ".circleci/fresh_ci_cache.commit" }}
       - run:
-          command: export CMAKE_GENERATOR="Ninja" && make test_parallel
+          command: export CMAKE_GENERATOR="Ninja" && export COMPILE_JOBS=4 && make test_parallel
           no_output_timeout: 50m
       - save_cache:
           key: main-ccache-{{ checksum "CMakeLists.txt" }}-{{ checksum ".circleci/fresh_ci_cache.commit" }}

--- a/.github/workflows/tsan_build_and_test.yml
+++ b/.github/workflows/tsan_build_and_test.yml
@@ -59,7 +59,7 @@ jobs:
           path: ./build/
       - name: Run TSAN tests
         run: |
-          echo leak:libomp.so > omp.supp
-          export LSAN_OPTIONS=suppressions=omp.supp
+          echo race:libomp.so > omp.supp
+          export TSAN_OPTIONS=suppressions=omp.supp
           chmod +x ./build/tests/functests
           ./build/tests/functests "[concurrent]~[daily]"


### PR DESCRIPTION
## Summary by Sourcery

CI:
- use race suppression and TSAN_OPTIONS for libomp in the ThreadSanitizer CI workflow