### PR TITLE
chore(python): make build wheel only trigger by workflow_dispatch

### DIFF
--- a/.github/workflows/build_release_wheel.yml
+++ b/.github/workflows/build_release_wheel.yml
@@ -1,12 +1,6 @@
 name: Build and Publish Wheels
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
       python-version:


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Limit build_release_wheel workflow to manual dispatch only.