### PR TITLE
add "is_timeout" stat for search result

### DIFF
--- a/include/vsag/dataset.h
+++ b/include/vsag/dataset.h
@@ -270,6 +270,32 @@ public:
      */
     virtual int64_t
     GetExtraInfoSize() const = 0;
+
+    /*
+     * @brief Sets the Statstics for the dataset.
+     *
+     * @param Statstics The Statstics string.
+     * @return DatasetPtr A shared pointer to the dataset with updated Statstics.
+     */
+    virtual DatasetPtr
+    Statstics(const std::string& Statstics) = 0;
+
+    /**
+     * @brief Retrieves the all Statstics of the dataset.
+     *
+     * @return std::string The Statstics string.
+     */
+    virtual std::string
+    GetStatstics() const = 0;
+
+    /**
+     * @brief Retrieves the Statstics of the dataset.
+     *
+     * @param stat_keys The vector of stat keys.
+     * @return std::vector<std::string> The vector of stat values.
+     */
+    virtual std::vector<std::string>
+    GetStatstics(const std::vector<std::string>& stat_keys) const = 0;
 };
 
 };  // namespace vsag

--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -985,12 +985,11 @@ HGraph::add_one_point(const void* data, int level, InnerIdType inner_id) {
 bool
 HGraph::graph_add_one(const void* data, int level, InnerIdType inner_id) {
     DistHeapPtr result = nullptr;
-    InnerSearchParam param{
-        .topk = 1,
-        .ep = this->entry_point_id_,
-        .ef = 1,
-        .is_inner_id_allowed = nullptr,
-    };
+    InnerSearchParam param;
+    param.topk = 1;
+    param.ep = this->entry_point_id_;
+    param.ef = 1;
+    param.is_inner_id_allowed = nullptr;
 
     LockGuard cur_lock(neighbors_mutex_, inner_id);
     auto flatten_codes = basic_flatten_codes_;
@@ -1675,6 +1674,7 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
     search_param.ef = 1;
     search_param.is_inner_id_allowed = nullptr;
     search_param.search_alloc = search_allocator;
+
     const auto* raw_query = get_data(query);
     for (auto i = static_cast<int64_t>(this->route_graphs_.size() - 1); i >= 0; --i) {
         auto result = this->search_one_graph(
@@ -1706,6 +1706,7 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
     if (params.enable_time_record) {
         search_param.time_cost = std::make_shared<Timer>();
         search_param.time_cost->SetThreshold(params.timeout_ms);
+        (*search_param.stats)["is_timeout"] = false;
     }
     auto search_result = this->search_one_graph(
         raw_query, this->bottom_graph_, this->basic_flatten_codes_, search_param);
@@ -1738,6 +1739,7 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
         }
         search_result->Pop();
     }
+    dataset_results->Statstics(search_param.stats->dump());
     return std::move(dataset_results);
 }
 

--- a/src/dataset_impl.cpp
+++ b/src/dataset_impl.cpp
@@ -15,6 +15,8 @@
 
 #include "dataset_impl.h"
 
+#include "typing.h"
+
 namespace vsag {
 
 DatasetPtr
@@ -26,6 +28,20 @@ DatasetPtr
 DatasetImpl::MakeEmptyDataset() {
     auto result = std::make_shared<DatasetImpl>();
     result->Dim(0)->NumElements(1);
+    return result;
+}
+
+std::vector<std::string>
+DatasetImpl::GetStatstics(const std::vector<std::string>& stat_keys) const {
+    auto json = JsonType::parse(this->statstics_);
+    std::vector<std::string> result;
+    for (const auto& key : stat_keys) {
+        if (json.contains(key)) {
+            result.emplace_back(json[key].dump());
+        } else {
+            result.emplace_back("");
+        }
+    }
     return result;
 }
 

--- a/src/dataset_impl.h
+++ b/src/dataset_impl.h
@@ -267,6 +267,20 @@ public:
         return 0;
     }
 
+    DatasetPtr
+    Statstics(const std::string& statstics) override {
+        this->statstics_ = statstics;
+        return shared_from_this();
+    }
+
+    std::vector<std::string>
+    GetStatstics(const std::vector<std::string>& stat_keys) const override;
+
+    std::string
+    GetStatstics() const override {
+        return this->statstics_;
+    }
+
     static DatasetPtr
     MakeEmptyDataset();
 
@@ -274,6 +288,8 @@ private:
     bool owner_{true};
     std::unordered_map<std::string, var> data_;
     Allocator* allocator_ = nullptr;
+
+    std::string statstics_;
 };
 
 };  // namespace vsag

--- a/src/impl/basic_searcher.cpp
+++ b/src/impl/basic_searcher.cpp
@@ -300,6 +300,7 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
 
         if (inner_search_param.time_cost != nullptr and
             inner_search_param.time_cost->CheckOvertime()) {
+            (*inner_search_param.stats)["is_timeout"] = true;
             break;
         }
 

--- a/src/impl/inner_search_param.h
+++ b/src/impl/inner_search_param.h
@@ -28,6 +28,11 @@ enum InnerSearchType { PURE = 1, WITH_FILTER = 2 };
 
 class InnerSearchParam {
 public:
+    InnerSearchParam() {
+        stats = std::make_shared<JsonType>();
+    }
+
+public:
     int64_t topk{0};
     float radius{0.0f};
     InnerIdType ep{0};
@@ -49,6 +54,8 @@ public:
 
     // time record
     std::shared_ptr<Timer> time_cost{nullptr};
+
+    std::shared_ptr<JsonType> stats{nullptr};
 
     InnerSearchParam&
     operator=(const InnerSearchParam& other) {

--- a/tests/test_index.cpp
+++ b/tests/test_index.cpp
@@ -2120,6 +2120,12 @@ TestIndex::TestSearchOvertime(const IndexPtr& index,
             ->Owner(false);
         auto res = index->KnnSearch(query, 10, search_param);
         REQUIRE(res.has_value());
+        auto result = res.value();
+        REQUIRE(result->GetStatstics() != "{}");
+        auto stats = result->GetStatstics({"is_timeout"});
+        REQUIRE(stats.size() == 1);
+        bool has_timeout_result = (stats[0] == "true" or stats[0] == "false");
+        REQUIRE(has_timeout_result);
     }
 }
 }  // namespace fixtures


### PR DESCRIPTION
## Summary by Sourcery

Add a generic statistics mechanism to datasets, record the search timeout status in search operations, and expose this information through the Dataset API with accompanying tests.

New Features:
- Expose dataset statistics through Dataset interface with methods to set and retrieve stats
- Capture an "is_timeout" flag in search parameters and include it in search result statistics

Enhancements:
- Store statistics as JSON in DatasetImpl

Tests:
- Add tests to verify the "is_timeout" statistic is present and valid in search results