### PR TITLE
feat(python): support build python wheel without docker

### DIFF
--- a/scripts/build_cpp_for_cibw.sh
+++ b/scripts/build_cpp_for_cibw.sh
@@ -32,7 +32,7 @@ cmake -S. -B$CMAKE_BUILD_DIR \
     -DPython3_EXECUTABLE="$PYTHON_EXECUTABLE" \
     -DPython3_ROOT_DIR="$(dirname $(dirname $PYTHON_EXECUTABLE))" \
     -DPython3_FIND_STRATEGY=LOCATION \
-    -DMKL_STATIC_LINK=ON
+    -DMKL_STATIC_LINK=OFF
 
 echo "=== Building project ==="
 cmake --build $CMAKE_BUILD_DIR --parallel $(nproc || sysctl -n hw.ncpu)


### PR DESCRIPTION
## Summary by Sourcery

Allow local Python wheel builds to run without Docker by detecting Docker availability and switching between cibuildwheel and python -m build accordingly

New Features:
- Support building Python wheel locally without requiring Docker

Enhancements:
- Introduce HAVE_DOCKER flag to detect Docker availability
- Fallback to python -m build when Docker daemon is not running
- Continue using cibuildwheel only when Docker is available