### PR TITLE
feat(index): Support get detail data with info from index

### DIFF
--- a/.circleci/fresh_ci_cache.commit
+++ b/.circleci/fresh_ci_cache.commit
@@ -1,1 +1,1 @@
-9f035bade6ddca04b17aff63de4a409f3d0f9de1
+1ac57af14db37de1e8dec583e18b33bfd602ead8

--- a/examples/cpp/317_feature_get_detail_data.cpp
+++ b/examples/cpp/317_feature_get_detail_data.cpp
@@ -1,0 +1,156 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <vsag/vsag.h>
+
+#include <iostream>
+
+std::string
+transform_type(vsag::IndexDetailDataType type) {
+    switch (type) {
+        case vsag::IndexDetailDataType::TYPE_SCALAR_INT64:
+            return "scalar_int64";
+        case vsag::IndexDetailDataType::TYPE_SCALAR_DOUBLE:
+            return "scalar_double";
+        case vsag::IndexDetailDataType::TYPE_SCALAR_BOOL:
+            return "scalar_bool";
+        case vsag::IndexDetailDataType::TYPE_1DArray_INT64:
+            return "1d_array_int64";
+        case vsag::IndexDetailDataType::TYPE_2DArray_INT64:
+            return "2d_array_int64";
+        default:
+            return "unknown";
+    }
+}
+
+void
+print_detail_info(const vsag::IndexDetailInfo& info) {
+    std::cout << "{" << std::endl;
+    std::cout << "    name: " << info.name << std::endl;
+    std::cout << "    type: " << transform_type(info.type) << std::endl;
+    std::cout << "    description: " << info.description << std::endl;
+    std::cout << "}" << std::endl;
+}
+
+std::string
+trans_2d_array_int64(const std::vector<std::vector<int64_t>>& array, int64_t raw, int64_t col) {
+    std::string result = "[";
+
+    for (int64_t i = 0; i < raw; ++i) {
+        result += "[";
+        for (int64_t j = 0; j < col; ++j) {
+            result += std::to_string(array[i][j]) + ",";
+        }
+        result.pop_back();
+        result += "],";
+    }
+    result.pop_back();
+    result += "]";
+    return result;
+}
+
+int
+main(int argc, char** argv) {
+    vsag::init();
+
+    /******************* Prepare Base Dataset *****************/
+    int64_t num_vectors = 10000;
+    int64_t dim = 128;
+    int64_t index_count = 10;
+    std::vector<int64_t> ids(num_vectors);
+    std::vector<float> datas(num_vectors * dim);
+    std::mt19937 rng(47);
+
+    int64_t per_index_size = num_vectors / index_count;
+    std::uniform_real_distribution<float> distrib_real;
+    for (int64_t i = 0; i < num_vectors; ++i) {
+        ids[i] = i + 100;
+    }
+    for (int64_t i = 0; i < dim * num_vectors; ++i) {
+        datas[i] = distrib_real(rng);
+    }
+
+    auto base = vsag::Dataset::Make();
+    base->NumElements(num_vectors)
+        ->Dim(dim)
+        ->Ids(ids.data())
+        ->Float32Vectors(datas.data())
+        ->Owner(false);
+
+    /******************* Create HGraph Index *****************/
+    std::string hgraph_build_parameters = R"(
+    {
+        "dtype": "float32",
+        "metric_type": "l2",
+        "dim": 128,
+        "index_param": {
+            "base_quantization_type": "sq8",
+            "max_degree": 26,
+            "ef_construction": 100
+        }
+    }
+    )";
+
+    /******************* Build HGraph *****************/
+    vsag::Resource resource(vsag::Engine::CreateDefaultAllocator(), nullptr);
+    vsag::Engine engine(&resource);
+    auto index = engine.CreateIndex("hgraph", hgraph_build_parameters).value();
+    if (auto build_result = index->Build(base); build_result.has_value()) {
+        std::cout << "After Build(), Index HGraph contains: " << index->GetNumElements()
+                  << std::endl;
+    } else if (build_result.error().type == vsag::ErrorType::INTERNAL_ERROR) {
+        std::cerr << "Failed to build index: internalError" << std::endl;
+        exit(-1);
+    }
+
+    /********************* Get Index Detail Info *****************/
+    if (auto detail_infos = index->GetIndexDetailInfos(); detail_infos.has_value()) {
+        for (const auto& info : detail_infos.value()) {
+            print_detail_info(info);
+        }
+    } else {
+        std::cerr << "Failed to get index detail info: " << detail_infos.error().message
+                  << std::endl;
+        exit(-1);
+    }
+
+    /*********************** Get Index Detail Datas *****************/
+    vsag::IndexDetailInfo info;
+    if (auto detail_datas = index->GetDetailDataByName("num_elements", info);
+        detail_datas.has_value()) {
+        std::cout << "num_elements(type): " << transform_type(info.type) << std::endl;
+        std::cout << "num_elements(value): " << detail_datas.value()->GetDataScalarInt64()
+                  << std::endl;
+    } else {
+        std::cerr << "Failed to get index detail datas: " << detail_datas.error().message
+                  << std::endl;
+        exit(-1);
+    }
+
+    if (auto detail_datas = index->GetDetailDataByName("label_table", info);
+        detail_datas.has_value()) {
+        std::cout << "label_table(type): " << transform_type(info.type) << std::endl;
+        std::cout << "label_table(value)[:10]: "
+                  << trans_2d_array_int64(detail_datas.value()->GetData2DArrayInt64(), 10, 2)
+                  << std::endl;
+    } else {
+        std::cerr << "Failed to get index detail datas: " << detail_datas.error().message
+                  << std::endl;
+        exit(-1);
+    }
+
+    engine.Shutdown();
+    return 0;
+}

--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -95,6 +95,9 @@ target_link_libraries(315_feature_hgraph_merge vsag)
 add_executable (316_index_int8_hgraph 316_index_int8_hgraph.cpp)
 target_link_libraries (316_index_int8_hgraph vsag)
 
+add_executable(317_feature_get_detail_data 317_feature_get_detail_data.cpp)
+target_link_libraries(317_feature_get_detail_data vsag)
+
 add_executable (401_persistent_kv 401_persistent_kv.cpp)
 target_link_libraries (401_persistent_kv vsag)
 

--- a/include/vsag/index.h
+++ b/include/vsag/index.h
@@ -548,7 +548,23 @@ public:
      */
     virtual tl::expected<std::vector<IndexDetailInfo>, Error>
     GetIndexDetailInfos() const {
-        throw std::runtime_error("Index doesn't support GetIndexDetailInfo");
+        throw std::runtime_error("Index doesn't support GetIndexDetailInfos");
+    };
+
+    /*
+     * @brief Retrieve one detail data associated with the index.
+     *
+     * @param name The detail information name to retrieve.
+     * @param info The detail information struct to retrieve, as return value.
+     * @return tl::expected<DetailDataPtr, Error>
+     *         - On success: A DetailDataPtr containing the detail data.
+     *         - On failure: An error object (e.g., no such detail information name).
+     * @throws std::runtime_error If the index implementation does not support this operation
+     *            (default behavior for base class).
+     */
+    virtual tl::expected<DetailDataPtr, Error>
+    GetDetailDataByName(const std::string& name, IndexDetailInfo& info) const {
+        throw std::runtime_error("Index doesn't support GetDetailDataByName");
     };
 
     /**

--- a/include/vsag/index_detail_info.h
+++ b/include/vsag/index_detail_info.h
@@ -15,17 +15,69 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
+#include <vector>
 namespace vsag {
 
 enum class IndexDetailDataType {
     TYPE_2DArray_INT64,
     TYPE_1DArray_INT64,
+    TYPE_SCALAR_INT64,
+    TYPE_SCALAR_DOUBLE,
+    TYPE_SCALAR_STRING,
+    TYPE_SCALAR_BOOL,
 };
 
-struct IndexDetailInfo {
+class IndexDetailInfo {
+public:
     std::string name;
     std::string description;
     IndexDetailDataType type;
+
+    IndexDetailInfo() = default;
+
+    explicit IndexDetailInfo(const std::string& name,
+                             const std::string& description,
+                             IndexDetailDataType type)
+        : name(name), description(description), type(type) {
+    }
 };
+
+extern const char* INDEX_DETAIL_NAME_NUM_ELEMENTS;
+extern const char* INDEX_DETAIL_NAME_LABEL_TABLE;
+class DetailData {
+public:
+    virtual ~DetailData() = default;
+
+    virtual std::vector<int64_t>
+    GetData1DArrayInt64() = 0;
+
+    virtual const std::vector<int64_t>&
+    GetData1DArrayInt64() const = 0;
+
+    virtual std::vector<std::vector<int64_t>>
+    GetData2DArrayInt64() = 0;
+
+    virtual const std::vector<std::vector<int64_t>>&
+    GetData2DArrayInt64() const = 0;
+
+    virtual std::string
+    GetDataScalarString() = 0;
+
+    virtual const std::string&
+    GetDataScalarString() const = 0;
+
+    virtual bool
+    GetDataScalarBool() = 0;
+
+    virtual int64_t
+    GetDataScalarInt64() = 0;
+
+    virtual double
+    GetDataScalarDouble() = 0;
+};
+
+using DetailDataPtr = std::shared_ptr<DetailData>;
+
 }  // namespace vsag

--- a/include/vsag/vsag.h
+++ b/include/vsag/vsag.h
@@ -47,6 +47,7 @@ init();
 #include "vsag/expected.hpp"
 #include "vsag/factory.h"
 #include "vsag/index.h"
+#include "vsag/index_detail_info.h"
 #include "vsag/index_features.h"
 #include "vsag/iterator_context.h"
 #include "vsag/logger.h"

--- a/src/algorithm/inner_index_interface.cpp
+++ b/src/algorithm/inner_index_interface.cpp
@@ -22,6 +22,7 @@
 #include "impl/filter/filter_headers.h"
 #include "impl/label_table.h"
 #include "index_common_param.h"
+#include "index_detail_data.h"
 #include "index_feature_list.h"
 #include "storage/empty_index_binary_set.h"
 #include "storage/serialization.h"
@@ -537,7 +538,15 @@ InnerIndexInterface::GetDataByIdsWithFlag(const int64_t* ids,
 
 std::vector<IndexDetailInfo>
 InnerIndexInterface::GetIndexDetailInfos() const {
-    return {};
+    std::vector<IndexDetailInfo> infos;
+    infos.emplace_back(INDEX_DETAIL_NAME_NUM_ELEMENTS,
+                       "How many elements in current index",
+                       IndexDetailDataType::TYPE_SCALAR_INT64);
+    infos.emplace_back(INDEX_DETAIL_NAME_LABEL_TABLE,
+                       "Label table of current index, label table is a 2D array, "
+                       "table[x][0] is label, table[x][1] is inner id",
+                       IndexDetailDataType::TYPE_2DArray_INT64);
+    return infos;
 }
 
 void
@@ -624,6 +633,35 @@ InnerIndexInterface::analyze_quantizer(JsonType& stats,
         stats["quantization_inversion_count_rate"].SetFloat(inversion_count_rate /
                                                             static_cast<float>(sample_data_size));
     }
+}
+
+DetailDataPtr
+InnerIndexInterface::GetDetailDataByName(const std::string& name, IndexDetailInfo& info) const {
+    auto infos = this->GetIndexDetailInfos();
+    for (const auto& detail_info : infos) {
+        if (detail_info.name == name) {
+            info = detail_info;
+            return this->get_detail_data_by_info(detail_info);
+        }
+    }
+    throw VsagException(ErrorType::INVALID_ARGUMENT,
+                        "Index doesn't have detail data name: " + name);
+}
+
+DetailDataPtr
+InnerIndexInterface::get_detail_data_by_info(const IndexDetailInfo& info) const {
+    const std::string& name = info.name;
+    auto data = std::make_shared<DetailDataImpl>();
+    if (name == INDEX_DETAIL_NAME_NUM_ELEMENTS) {
+        data->SetDataScalarInt64(this->GetNumElements());
+    } else if (name == INDEX_DETAIL_NAME_LABEL_TABLE) {
+        std::vector<std::vector<int64_t>> label_tables;
+        for (const auto& [key, value] : this->label_table_->label_remap_) {
+            label_tables.emplace_back(std::vector<int64_t>{key, value});
+        }
+        data->SetData2DArrayInt64(label_tables);
+    }
+    return data;
 }
 
 }  // namespace vsag

--- a/src/algorithm/inner_index_interface.h
+++ b/src/algorithm/inner_index_interface.h
@@ -164,6 +164,9 @@ public:
     virtual std::vector<IndexDetailInfo>
     GetIndexDetailInfos() const;
 
+    virtual DetailDataPtr
+    GetDetailDataByName(const std::string& name, IndexDetailInfo& info) const;
+
     [[nodiscard]] virtual int64_t
     GetEstimateBuildMemory(const int64_t num_elements) const {
         throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
@@ -394,6 +397,9 @@ protected:
                       uint64_t sample_data_size,
                       int64_t topk,
                       const std::string& search_param) const;
+
+    virtual DetailDataPtr
+    get_detail_data_by_info(const IndexDetailInfo& info) const;
 
 public:
     LabelTablePtr label_table_{nullptr};

--- a/src/algorithm/inner_index_interface_test.cpp
+++ b/src/algorithm/inner_index_interface_test.cpp
@@ -177,4 +177,6 @@ TEST_CASE("InnerIndexInterface NOT Implemented", "[ut][InnerIndexInterface]") {
 
     SearchParam param(true, "", nullptr, nullptr);
     REQUIRE_THROWS(empty_index->KnnSearch(nullptr, 0, param));
+
+    REQUIRE_NOTHROW(empty_index->GetIndexDetailInfos());
 }

--- a/src/index/index_impl.h
+++ b/src/index/index_impl.h
@@ -185,6 +185,11 @@ public:
         SAFE_CALL(return this->inner_index_->GetIndexDetailInfos());
     }
 
+    tl::expected<DetailDataPtr, Error>
+    GetDetailDataByName(const std::string& name, IndexDetailInfo& info) const override {
+        SAFE_CALL(return this->inner_index_->GetDetailDataByName(name, info));
+    }
+
     [[nodiscard]] int64_t
     GetEstimateBuildMemory(const int64_t num_elements) const override {
         return this->inner_index_->GetEstimateBuildMemory(num_elements);

--- a/src/index_detail_data.h
+++ b/src/index_detail_data.h
@@ -1,0 +1,123 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <vsag/index_detail_info.h>
+
+#include <variant>
+#include <vector>
+
+namespace vsag {
+
+class DetailDataImpl : public DetailData {
+public:
+    using Data1DArrayInt64 = std::vector<int64_t>;
+    using Data2DArrayInt64 = std::vector<std::vector<int64_t>>;
+    using DataScalarInt64 = int64_t;
+    using DataScalarDouble = double;
+    using DataScalarString = std::string;
+    using DataScalarBool = bool;
+
+    explicit DetailDataImpl() : DetailData(){};
+
+    virtual ~DetailDataImpl() = default;
+
+    std::vector<int64_t>
+    GetData1DArrayInt64() override {
+        return std::get<Data1DArrayInt64>(data_);
+    }
+
+    const std::vector<int64_t>&
+    GetData1DArrayInt64() const override {
+        return std::get<Data1DArrayInt64>(data_);
+    }
+
+    std::vector<std::vector<int64_t>>
+    GetData2DArrayInt64() override {
+        return std::get<Data2DArrayInt64>(data_);
+    }
+
+    const std::vector<std::vector<int64_t>>&
+    GetData2DArrayInt64() const override {
+        return std::get<Data2DArrayInt64>(data_);
+    }
+
+    std::string
+    GetDataScalarString() override {
+        return std::get<DataScalarString>(data_);
+    }
+
+    const std::string&
+    GetDataScalarString() const override {
+        return std::get<DataScalarString>(data_);
+    }
+
+    bool
+    GetDataScalarBool() override {
+        return std::get<DataScalarBool>(data_);
+    }
+
+    int64_t
+    GetDataScalarInt64() override {
+        return std::get<DataScalarInt64>(data_);
+    }
+
+    double
+    GetDataScalarDouble() override {
+        return std::get<DataScalarDouble>(data_);
+    }
+
+public:
+    void
+    SetData1DArrayInt64(const Data1DArrayInt64& data) {
+        data_ = data;
+    }
+
+    void
+    SetData2DArrayInt64(const Data2DArrayInt64& data) {
+        data_ = data;
+    }
+
+    void
+    SetDataScalarInt64(const DataScalarInt64& data) {
+        data_ = data;
+    }
+
+    void
+    SetDataScalarDouble(const DataScalarDouble& data) {
+        data_ = data;
+    }
+
+    void
+    SetDataScalarString(const DataScalarString& data) {
+        data_ = data;
+    }
+
+    void
+    SetDataScalarBool(const DataScalarBool& data) {
+        data_ = data;
+    }
+
+private:
+    std::variant<Data1DArrayInt64,
+                 Data2DArrayInt64,
+                 DataScalarInt64,
+                 DataScalarDouble,
+                 DataScalarString,
+                 DataScalarBool>
+        data_;
+};
+}  // namespace vsag

--- a/src/index_detail_data_test.cpp
+++ b/src/index_detail_data_test.cpp
@@ -1,0 +1,43 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "index_detail_data.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+using namespace vsag;
+
+TEST_CASE("DetailDataImpl Test", "[DetailDataImpl][ut]") {
+    DetailDataImpl data;
+    DetailData* detail_data = &data;
+    data.SetData1DArrayInt64({1, 2, 3});
+    REQUIRE(detail_data->GetData1DArrayInt64() == std::vector<int64_t>({1, 2, 3}));
+
+    data.SetData2DArrayInt64({{1, 2}, {3, 4}});
+    REQUIRE(detail_data->GetData2DArrayInt64() ==
+            std::vector<std::vector<int64_t>>({{1, 2}, {3, 4}}));
+
+    data.SetDataScalarInt64(100);
+    REQUIRE(detail_data->GetDataScalarInt64() == 100);
+
+    data.SetDataScalarDouble(3.14);
+    REQUIRE(detail_data->GetDataScalarDouble() == 3.14);
+
+    data.SetDataScalarString("hello");
+    REQUIRE(detail_data->GetDataScalarString() == "hello");
+
+    data.SetDataScalarBool(true);
+    REQUIRE(detail_data->GetDataScalarBool() == true);
+}

--- a/src/index_detail_info.cpp
+++ b/src/index_detail_info.cpp
@@ -1,0 +1,23 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <vsag/index_detail_info.h>
+
+namespace vsag {
+
+const char* INDEX_DETAIL_NAME_NUM_ELEMENTS = "num_elements";
+const char* INDEX_DETAIL_NAME_LABEL_TABLE = "label_table";
+
+}  // namespace vsag

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -522,6 +522,7 @@ TestHGraphBuildAndContinueAdd(const fixtures::HGraphTestIndexPtr& test_index,
                     dim, resource->base_count, metric_type);
                 TestIndex::TestContinueAdd(index, dataset, true);
                 HGraphTestIndex::TestGeneral(index, dataset, search_param, recall);
+                TestIndex::TestIndexDetailData(index);
                 vsag::Options::Instance().set_block_size_limit(origin_size);
             }
         }

--- a/tests/test_index.cpp
+++ b/tests/test_index.cpp
@@ -2535,4 +2535,37 @@ TestIndex::TestConcurrentAddSearchRemove(const TestIndex::IndexPtr& index,
     }
 }
 
+void
+TestIndex::TestIndexDetailData(const IndexPtr& index) {
+    auto infos = index->GetIndexDetailInfos();
+    REQUIRE(infos.has_value());
+    const auto& detail_infos = infos.value();
+    REQUIRE(detail_infos.size() > 0);
+    for (const auto& info : detail_infos) {
+        vsag::IndexDetailInfo r_info;
+        auto detail_data_value = index->GetDetailDataByName(info.name, r_info);
+        REQUIRE(info.name == r_info.name);
+        REQUIRE(info.type == r_info.type);
+        REQUIRE(info.description == r_info.description);
+
+        REQUIRE(detail_data_value.has_value());
+        auto detail_data = detail_data_value.value();
+        if (info.type == vsag::IndexDetailDataType::TYPE_SCALAR_INT64) {
+            REQUIRE_NOTHROW(detail_data->GetDataScalarInt64());
+        } else if (info.type == vsag::IndexDetailDataType::TYPE_SCALAR_DOUBLE) {
+            REQUIRE_NOTHROW(detail_data->GetDataScalarDouble());
+        } else if (info.type == vsag::IndexDetailDataType::TYPE_SCALAR_STRING) {
+            REQUIRE_NOTHROW(detail_data->GetDataScalarString());
+        } else if (info.type == vsag::IndexDetailDataType::TYPE_SCALAR_BOOL) {
+            REQUIRE_NOTHROW(detail_data->GetDataScalarBool());
+        } else if (info.type == vsag::IndexDetailDataType::TYPE_1DArray_INT64) {
+            REQUIRE_NOTHROW(detail_data->GetData1DArrayInt64());
+        } else if (info.type == vsag::IndexDetailDataType::TYPE_2DArray_INT64) {
+            REQUIRE_NOTHROW(detail_data->GetData2DArrayInt64());
+        } else {
+            REQUIRE(false);
+        }
+    }
+}
+
 }  // namespace fixtures

--- a/tests/test_index.h
+++ b/tests/test_index.h
@@ -315,6 +315,9 @@ public:
     static void
     TestIndexStatus(const IndexPtr& index);
 
+    static void
+    TestIndexDetailData(const IndexPtr& index);
+
     constexpr static float RECALL_THRESHOLD = 0.85F;
 };
 

--- a/tests/test_simple_index.cpp
+++ b/tests/test_simple_index.cpp
@@ -160,4 +160,8 @@ TEST_CASE("Test Simple Index", "[ft][simple_index]") {
     REQUIRE_THROWS(index->GetIndexType());
     REQUIRE_THROWS(index->GetIndexDetailInfos());
     REQUIRE_THROWS(index->Serialize(WriteFuncType(nullptr)));
+
+    IndexDetailInfo info;
+    std::string name = INDEX_DETAIL_NAME_NUM_ELEMENTS;
+    REQUIRE_THROWS(index->GetDetailDataByName(name, info));
 }


### PR DESCRIPTION
closed: #1293 
- only support label_table and num_element

## Summary by Sourcery

Add support for retrieving detailed index metadata, specifically element count and label table, by introducing new metadata descriptors and data access APIs and implementing them in the inner index.

New Features:
- Define IndexDetailInfo and IndexDetailDataType to describe available detail data.
- Introduce DetailData interface and variant-based DetailDataImpl for typed detail retrieval.
- Add GetIndexDetailInfos and GetDetailDataByName APIs to Index and InnerIndexInterface.

Enhancements:
- Implement inner index logic to return detail infos and populate ‘num_elements’ and ‘label_table’ items.
- Delegate detail data methods through IndexImpl to the inner index.

Tests:
- Add unit tests for DetailDataImpl getters and setters.
- Extend index tests to validate detail info listing, data retrieval, and unsupported behavior.