### PR TITLE
fix(hnsw): fix the OOM issue caused by large IDs

### DIFF
--- a/src/algorithm/hnswlib/algorithm_interface.h
+++ b/src/algorithm/hnswlib/algorithm_interface.h
@@ -115,7 +115,7 @@ public:
     virtual size_t
     getDeletedCount() = 0;
 
-    virtual vsag::UnorderedMap<LabelType, InnerIdType>
+    virtual vsag::STLUnorderedMap<LabelType, InnerIdType>
     getDeletedElements() = 0;
 
     virtual bool

--- a/src/algorithm/hnswlib/hnswalg.h
+++ b/src/algorithm/hnswlib/hnswalg.h
@@ -114,7 +114,7 @@ private:
     DISTFUNC fstdistfunc_{nullptr};
     void* dist_func_param_{nullptr};
 
-    vsag::UnorderedMap<LabelType, InnerIdType> label_lookup_;
+    vsag::STLUnorderedMap<LabelType, InnerIdType> label_lookup_;
 
     std::default_random_engine level_generator_{2021};
     mutable std::default_random_engine update_probability_generator_;
@@ -130,7 +130,7 @@ private:
     bool allow_replace_deleted_{false};
 
     std::mutex deleted_elements_lock_{};  // lock for deleted_elements_
-    vsag::UnorderedMap<LabelType, InnerIdType>
+    vsag::STLUnorderedMap<LabelType, InnerIdType>
         deleted_elements_;  // contains labels and internal ids of deleted elements
 
     bool immutable_{false};
@@ -264,7 +264,7 @@ public:
         return num_deleted_;
     }
 
-    vsag::UnorderedMap<LabelType, InnerIdType>
+    vsag::STLUnorderedMap<LabelType, InnerIdType>
     getDeletedElements() override {
         return deleted_elements_;
     }

--- a/src/algorithm/hnswlib/hnswalg_static.h
+++ b/src/algorithm/hnswlib/hnswalg_static.h
@@ -248,7 +248,7 @@ public:
         return num_deleted_;
     }
 
-    vsag::UnorderedMap<LabelType, InnerIdType>
+    vsag::STLUnorderedMap<LabelType, InnerIdType>
     getDeletedElements() override {
         throw std::runtime_error("Static HNSW doesn't support delete");
     };

--- a/src/impl/label_table.h
+++ b/src/impl/label_table.h
@@ -276,7 +276,7 @@ public:
 
 public:
     Vector<LabelType> label_table_;
-    UnorderedMap<LabelType, InnerIdType> label_remap_;
+    STLUnorderedMap<LabelType, InnerIdType> label_remap_;
     UnorderedSet<InnerIdType> deleted_ids_;
 
     bool compress_duplicate_data_{true};

--- a/src/typing.h
+++ b/src/typing.h
@@ -49,6 +49,14 @@ using UnorderedMap = tsl::robin_map<KeyType,
                                     std::equal_to<KeyType>,
                                     vsag::AllocatorWrapper<std::pair<const KeyType, ValType>>>;
 
+template <typename KeyType, typename ValType>
+using STLUnorderedMap =
+    std::unordered_map<KeyType,
+                       ValType,
+                       std::hash<KeyType>,
+                       std::equal_to<KeyType>,
+                       vsag::AllocatorWrapper<std::pair<const KeyType, ValType>>>;
+
 template <typename T, typename... Args>
 inline auto
 AllocateShared(Allocator* allocator, Args&&... args) {

--- a/tests/fixtures/test_dataset.cpp
+++ b/tests/fixtures/test_dataset.cpp
@@ -48,7 +48,8 @@ GenerateRandomDataset(uint64_t dim,
                       bool is_query = false,
                       uint64_t extra_info_size = 0,
                       std::string vector_type = "dense",
-                      bool has_duplicate = false) {
+                      bool has_duplicate = false,
+                      int64_t id_shift = 16) {
     auto base = vsag::Dataset::Make();
     bool need_normalize = (metric_str != "cosine");
     auto vecs =
@@ -60,7 +61,9 @@ GenerateRandomDataset(uint64_t dim,
         paths[i] = create_random_string(!is_query);
     }
     std::vector<int64_t> ids(count);
-    std::iota(ids.begin(), ids.end(), TestDataset::ID_BIAS);
+    for (int64_t i = 0; i < count; ++i) {
+        ids[i] = (i << id_shift);
+    }
     base->Dim(dim)
         ->Ids(CopyVector(ids))
         ->Paths(paths)
@@ -110,7 +113,7 @@ GenerateNanRandomDataset(uint64_t dim, uint64_t count, std::string metric_str = 
     }
 
     std::vector<int64_t> ids(count);
-    std::iota(ids.begin(), ids.end(), 10086);
+    std::iota(ids.begin(), ids.end(), 16);
     base->Dim(dim)
         ->Ids(CopyVector(ids))
         ->Float32Vectors(CopyVector(vecs))
@@ -279,7 +282,8 @@ CalGroundTruthWithPath(const std::pair<float*, int64_t*>& result,
                        uint64_t top_k,
                        const vsag::DatasetPtr base,
                        const vsag::DatasetPtr query,
-                       std::function<bool(int64_t)> filter = nullptr) {
+                       std::function<bool(int64_t)> filter = nullptr,
+                       int64_t id_shift = 16) {
     auto base_count = base->GetNumElements();
     auto query_count = query->GetNumElements();
     auto base_paths = base->GetPaths();
@@ -292,7 +296,7 @@ CalGroundTruthWithPath(const std::pair<float*, int64_t*>& result,
         for (int j = 0; j < top_k; ++j) {
             while (start < base_count) {
                 auto base_id = result.second[i * base_count + start];
-                if (is_path_belong_to(query_paths[i], base_paths[base_id - TestDataset::ID_BIAS]) &&
+                if (is_path_belong_to(query_paths[i], base_paths[base_id >> id_shift]) &&
                     (not filter || not filter(base_id))) {
                     ids[i * top_k + j] = base_id;
                     dists[i * top_k + j] = result.first[i * base_count + start];
@@ -315,12 +319,20 @@ TestDataset::CreateTestDataset(uint64_t dim,
                                float valid_ratio,
                                std::string vector_type,
                                uint64_t extra_info_size,
-                               bool has_duplicate) {
+                               bool has_duplicate,
+                               int64_t id_shift) {
     TestDatasetPtr dataset = std::shared_ptr<TestDataset>(new TestDataset);
     dataset->dim_ = dim;
+    dataset->id_shift = id_shift;
     dataset->count_ = count;
-    dataset->base_ = GenerateRandomDataset(
-        dim, count, metric_str, false /*is_query*/, extra_info_size, vector_type, has_duplicate);
+    dataset->base_ = GenerateRandomDataset(dim,
+                                           count,
+                                           metric_str,
+                                           false /*is_query*/,
+                                           extra_info_size,
+                                           vector_type,
+                                           has_duplicate,
+                                           dataset->id_shift);
     constexpr uint64_t query_count = 100;
     dataset->query_ =
         GenerateRandomDataset(dim, query_count, metric_str, true, extra_info_size, vector_type);
@@ -332,8 +344,9 @@ TestDataset::CreateTestDataset(uint64_t dim,
             CalDistanceFloatMetrix(dataset->query_, dataset->base_, metric_str, vector_type);
         dataset->top_k = 10;
 
-        dataset->filter_function_ = [valid_ratio, count](int64_t id) -> bool {
-            return id - ID_BIAS > valid_ratio * count;
+        dataset->filter_function_ =
+            [valid_ratio, count, shift = dataset->id_shift](int64_t id) -> bool {
+            return (id >> shift) > valid_ratio * count;
         };
 
         dataset->ex_filter_function_ = [valid_ratio, count](const char* data) -> bool {
@@ -344,12 +357,24 @@ TestDataset::CreateTestDataset(uint64_t dim,
             dataset->query_, dataset->base_, metric_str, dataset->ex_filter_function_, vector_type);
 
         if (with_path) {
-            dataset->ground_truth_ =
-                CalGroundTruthWithPath(result, dataset->top_k, dataset->base_, dataset->query_);
-            dataset->filter_ground_truth_ = CalGroundTruthWithPath(
-                result, dataset->top_k, dataset->base_, dataset->query_, dataset->filter_function_);
-            dataset->ex_filter_ground_truth_ =
-                CalGroundTruthWithPath(ex_result, dataset->top_k, dataset->base_, dataset->query_);
+            dataset->ground_truth_ = CalGroundTruthWithPath(result,
+                                                            dataset->top_k,
+                                                            dataset->base_,
+                                                            dataset->query_,
+                                                            nullptr,
+                                                            dataset->id_shift);
+            dataset->filter_ground_truth_ = CalGroundTruthWithPath(result,
+                                                                   dataset->top_k,
+                                                                   dataset->base_,
+                                                                   dataset->query_,
+                                                                   dataset->filter_function_,
+                                                                   dataset->id_shift);
+            dataset->ex_filter_ground_truth_ = CalGroundTruthWithPath(ex_result,
+                                                                      dataset->top_k,
+                                                                      dataset->base_,
+                                                                      dataset->query_,
+                                                                      nullptr,
+                                                                      dataset->id_shift);
         } else {
             dataset->ground_truth_ = CalTopKGroundTruth(result, dataset->top_k, count, query_count);
             dataset->filter_ground_truth_ = CalFilterGroundTruth(

--- a/tests/fixtures/test_dataset.h
+++ b/tests/fixtures/test_dataset.h
@@ -25,7 +25,7 @@ class TestDataset {
 public:
     using DatasetPtr = vsag::DatasetPtr;
 
-    const static int ID_BIAS = 10086;
+    int64_t id_shift = 16;
 
     static std::shared_ptr<TestDataset>
     CreateTestDataset(uint64_t dim,
@@ -35,7 +35,8 @@ public:
                       float valid_ratio = 0.8,
                       std::string vector_type = "dense",
                       uint64_t extra_info_size = 0,
-                      bool has_duplicate = false);
+                      bool has_duplicate = false,
+                      int64_t id_shift = 16);
 
     static std::shared_ptr<TestDataset>
     CreateNanDataset(const std::string& metric_str);

--- a/tests/fixtures/test_dataset_pool.cpp
+++ b/tests/fixtures/test_dataset_pool.cpp
@@ -11,12 +11,20 @@ TestDatasetPool::GetDatasetAndCreate(uint64_t dim,
                                      const std::string& metric_str,
                                      bool with_path,
                                      float valid_ratio,
-                                     uint64_t extra_info_size) {
-    auto key = key_gen(dim, count, metric_str, with_path, valid_ratio, extra_info_size);
+                                     uint64_t extra_info_size,
+                                     int64_t id_shift) {
+    auto key = key_gen(dim, count, metric_str, with_path, valid_ratio, extra_info_size, id_shift);
     if (this->pool_.find(key) == this->pool_.end()) {
         this->dim_counts_.emplace_back(dim, count);
-        this->pool_[key] = TestDataset::CreateTestDataset(
-            dim, count, metric_str, with_path, valid_ratio, "dense", extra_info_size);
+        this->pool_[key] = TestDataset::CreateTestDataset(dim,
+                                                          count,
+                                                          metric_str,
+                                                          with_path,
+                                                          valid_ratio,
+                                                          "dense",
+                                                          extra_info_size,
+                                                          false,
+                                                          id_shift);
     }
     return this->pool_.at(key);
 }
@@ -26,10 +34,11 @@ TestDatasetPool::key_gen(int64_t dim,
                          const std::string& metric_str,
                          bool with_path,
                          float filter_ratio,
-                         uint64_t extra_info_size) {
+                         uint64_t extra_info_size,
+                         int64_t id_shift) {
     return std::to_string(dim) + "_" + std::to_string(count) + "_" + metric_str + "_" +
            std::to_string(with_path) + "_" + std::to_string(filter_ratio) +
-           std::to_string(extra_info_size);
+           std::to_string(extra_info_size) + "_" + std::to_string(id_shift);
 }
 
 TestDatasetPtr

--- a/tests/fixtures/test_dataset_pool.h
+++ b/tests/fixtures/test_dataset_pool.h
@@ -32,7 +32,8 @@ public:
                         const std::string& metric_str = "l2",
                         bool with_path = false,
                         float valid_ratio = 0.8,
-                        uint64_t extra_info_size = 0);
+                        uint64_t extra_info_size = 0,
+                        int64_t id_shift = 16);
 
     TestDatasetPtr
     GetDuplicateDataset(uint64_t dim,
@@ -55,7 +56,8 @@ private:
             const std::string& metric_str = "l2",
             bool with_path = false,
             float filter_ratio = 0.8,
-            uint64_t extra_info_size = 0);
+            uint64_t extra_info_size = 0,
+            int64_t id_shift = 16);
 
 private:
     std::unordered_map<std::string, TestDatasetPtr> pool_;

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -1123,6 +1123,49 @@ TEST_CASE("(Daily) HGraph Add", "[ft][hgraph][daily]") {
 }
 
 static void
+TestHGraphNonstandardID(const fixtures::HGraphTestIndexPtr& test_index,
+                        const fixtures::HGraphResourcePtr& resource) {
+    using namespace fixtures;
+    auto origin_size = vsag::Options::Instance().block_size_limit();
+    auto size = GENERATE(1024 * 1024 * 2);
+    auto search_param = fmt::format(fixtures::search_param_tmp, 200, false);
+
+    for (auto metric_type : resource->metric_types) {
+        for (auto dim : resource->dims) {
+            for (auto& [base_quantization_str, recall] : resource->test_cases) {
+                INFO(fmt::format("metric_type: {}, dim: {}, base_quantization_str: {}, recall: {}",
+                                 metric_type,
+                                 dim,
+                                 base_quantization_str,
+                                 recall));
+                if (HGraphTestIndex::IsRaBitQ(base_quantization_str) &&
+                    dim < fixtures::RABITQ_MIN_RACALL_DIM) {
+                    continue;  // Skip invalid RaBitQ configurations
+                }
+                vsag::Options::Instance().set_block_size_limit(size);
+                HGraphTestIndex::HGraphBuildParam build_param(
+                    metric_type, dim, base_quantization_str);
+                auto param = HGraphTestIndex::GenerateHGraphBuildParametersString(build_param);
+                auto index = TestIndex::TestFactory(test_index->name, param, true);
+                auto dataset = HGraphTestIndex::pool.GetDatasetAndCreate(
+                    dim, 10000, metric_type, false, 0.8, 0, 48);
+                TestIndex::TestAddIndex(index, dataset, true);
+                if (index->CheckFeature(vsag::SUPPORT_ADD_FROM_EMPTY)) {
+                    HGraphTestIndex::TestGeneral(index, dataset, search_param, recall);
+                }
+                vsag::Options::Instance().set_block_size_limit(origin_size);
+            }
+        }
+    }
+}
+
+TEST_CASE("HGraph Test NonstandardID", "[ft][hgraph][pr]") {
+    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
+    auto resource = test_index->GetResource(true);
+    TestHGraphNonstandardID(test_index, resource);
+}
+
+static void
 TestHGraphDuplicate(const fixtures::HGraphTestIndexPtr& test_index,
                     const fixtures::HGraphResourcePtr& resource) {
     using namespace fixtures;

--- a/tests/test_hnsw.cpp
+++ b/tests/test_hnsw.cpp
@@ -227,7 +227,6 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex,
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
     auto metric_type = GENERATE("l2", "ip", "cosine");
-    std::string base_quantization_str = GENERATE("sq8", "fp32");
     const std::string name = "hnsw";
     auto search_param = fmt::format(search_param_tmp, 100);
     for (auto& dim : dims) {
@@ -248,13 +247,38 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex,
     vsag::Options::Instance().set_block_size_limit(origin_size);
 }
 
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Test non-standard IDs", "[ft][hnsw]") {
+    auto origin_size = vsag::Options::Instance().block_size_limit();
+    auto size = GENERATE(1024 * 1024 * 2);
+    auto metric_type = GENERATE("l2");
+
+    const std::string name = "hnsw";
+    auto search_param = fmt::format(search_param_tmp, 100);
+    auto id_shift = 48;
+    for (auto& dim : dims) {
+        vsag::Options::Instance().set_block_size_limit(size);
+        auto param = GenerateHNSWBuildParametersString(metric_type, dim);
+        auto index = TestFactory(name, param, true);
+        REQUIRE(index->GetIndexType() == vsag::IndexType::HNSW);
+        auto dataset = pool.GetDatasetAndCreate(dim, 10000, metric_type, false, 0.8, 0, id_shift);
+        TestContinueAdd(index, dataset, true);
+        TestKnnSearch(index, dataset, search_param, 0.99, true);
+        TestKnnSearchIter(index, dataset, search_param, 0.99, true);
+        TestConcurrentKnnSearch(index, dataset, search_param, 0.99, true);
+        TestRangeSearch(index, dataset, search_param, 0.99, 10, true);
+        TestRangeSearch(index, dataset, search_param, 0.49, 5, true);
+        TestFilterSearch(index, dataset, search_param, 0.99, true);
+        TestSearchAllocator(index, dataset, search_param, 0.99, true);
+    }
+    vsag::Options::Instance().set_block_size_limit(origin_size);
+}
+
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex,
                              "HNSW Continue Destruct V.S. All Test",
                              "[ft][hnsw]") {
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
     auto metric_type = GENERATE("l2");
-    std::string base_quantization_str = GENERATE("fp32");
     const std::string name = "hnsw";
     auto search_param = fmt::format(search_param_tmp, 100);
 

--- a/tests/test_hnsw.cpp
+++ b/tests/test_hnsw.cpp
@@ -253,11 +253,23 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Test non-standard ID
     auto metric_type = GENERATE("l2");
 
     const std::string name = "hnsw";
-    auto search_param = fmt::format(search_param_tmp, 100);
+    auto search_param = fmt::format(search_param_tmp, 200);
     auto id_shift = 48;
+    constexpr auto parameter_temp = R"(
+    {{
+        "dtype": "float32",
+        "metric_type": "{}",
+        "dim": {},
+        "hnsw": {{
+            "max_degree": 64,
+            "ef_construction": 200,
+            "use_static": {}
+        }}
+    }}
+    )";
     for (auto& dim : dims) {
         vsag::Options::Instance().set_block_size_limit(size);
-        auto param = GenerateHNSWBuildParametersString(metric_type, dim);
+        auto param = fmt::format(parameter_temp, metric_type, dim, false);
         auto index = TestFactory(name, param, true);
         REQUIRE(index->GetIndexType() == vsag::IndexType::HNSW);
         auto dataset = pool.GetDatasetAndCreate(dim, 10000, metric_type, false, 0.8, 0, id_shift);

--- a/tests/test_index.cpp
+++ b/tests/test_index.cpp
@@ -1684,10 +1684,10 @@ TestIndex::TestGetExtraInfoById(const TestIndex::IndexPtr& index,
     auto result = index->GetExtraInfoByIds(ids.data(), count, extra_infos.data());
     REQUIRE(result.has_value());
     for (int64_t i = 0; i < count; ++i) {
-        REQUIRE(
-            memcmp(extra_infos.data() + i * extra_info_size,
-                   dataset->base_->GetExtraInfos() + (ids[i] - dataset->ID_BIAS) * extra_info_size,
-                   extra_info_size) == 0);
+        REQUIRE(memcmp(extra_infos.data() + i * extra_info_size,
+                       dataset->base_->GetExtraInfos() +
+                           (ids[i] >> dataset->id_shift) * extra_info_size,
+                       extra_info_size) == 0);
     }
 }
 

--- a/tests/test_index.cpp
+++ b/tests/test_index.cpp
@@ -1911,9 +1911,10 @@ TestIndex::TestRemoveIndex(const TestIndex::IndexPtr& index,
     auto base_dim = dataset->base_->GetDim();
     for (int64_t i = 0; i < base_num; ++i) {
         auto new_data = vsag::Dataset::Make();
+        int64_t id = base_num + i;
         new_data->NumElements(1)
             ->Dim(base_dim)
-            ->Ids(&i)
+            ->Ids(&id)
             ->Float32Vectors(dataset->base_->GetFloat32Vectors() + i * base_dim)
             ->Owner(false);
         auto add_results = index->Add(new_data);
@@ -1928,10 +1929,10 @@ TestIndex::TestRemoveIndex(const TestIndex::IndexPtr& index,
             ->Owner(false);
         auto add_results = index->Add(new_data);
         REQUIRE(add_results.has_value());
-        auto remove_results = index->Remove(i);
+        auto remove_results = index->Remove(i + base_num);
         REQUIRE(index->GetNumberRemoved() == i + 1);
         REQUIRE(remove_results.has_value());
-        remove_results = index->Remove(i);
+        remove_results = index->Remove(i + base_num);
         REQUIRE_FALSE(remove_results.has_value());
         REQUIRE(index->GetNumElements() == dataset->base_->GetNumElements());
     }


### PR DESCRIPTION
close: #1307

## Summary by Sourcery

Enable handling of large, bit-shifted IDs across dataset generation, ground-truth computation, and index internals to prevent OOM and ensure correct ID lookups.

New Features:
- Introduce id_shift parameter in test dataset generation and ground-truth functions to support large IDs
- Add end-to-end tests for nonstandard ID scenarios in HGraph and HNSW modules

Bug Fixes:
- Prevent OOM and incorrect lookups by shifting external IDs before internal indexing

Enhancements:
- Include id_shift in TestDatasetPool cache key
- Replace vsag::UnorderedMap with new STLUnorderedMap alias for internal label and delete maps in HNSW implementation

Tests:
- Add TestHGraphNonstandardID and HNSW nonstandard ID test suites to validate large ID handling

Chores:
- Define STLUnorderedMap alias in typing.h