### PR TITLE
remove n_candidate check in sindi

### DIFF
--- a/src/algorithm/sindi/sindi.cpp
+++ b/src/algorithm/sindi/sindi.cpp
@@ -130,11 +130,6 @@ SINDI::KnnSearch(const DatasetPtr& query,
     // search parameter
     SINDISearchParameter search_param;
     search_param.FromJson(JsonType::parse(parameters));
-    CHECK_ARGUMENT(search_param.n_candidate <= AMPLIFICATION_FACTOR * k,
-                   fmt::format("n_candidate ({}) should be less than {} * k ({})",
-                               search_param.n_candidate,
-                               AMPLIFICATION_FACTOR,
-                               k));
     InnerSearchParam inner_param;
     inner_param.ef = std::max(static_cast<int64_t>(search_param.n_candidate), k);
     inner_param.topk = k;

--- a/tests/test_sindi.cpp
+++ b/tests/test_sindi.cpp
@@ -101,14 +101,6 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex,
     TestBuildIndex(index, dataset, true);
     {
         auto invalid_search_param = R"({
-            "sindi": {
-                "n_candidate": -1,
-                "query_prune_ratio": 0.0,
-                "term_prune_ratio": 0.0
-            }
-        })";
-        TestKnnSearch(index, dataset, invalid_search_param, 0.99, false);
-        invalid_search_param = R"({
             "sindi":{
                 "n_candidate": 10,
                 "query_prune_ratio": 1.2,


### PR DESCRIPTION
Remove the check because the BIGANN test necessitates a large n_candidate

## Summary by Sourcery

Enhancements:
- Remove the CHECK_ARGUMENT enforcing n_candidate <= AMPLIFICATION_FACTOR * k in SINDI::KnnSearch