### PR TITLE
refactor(safe_call): add exception handling for bad_alloc

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -19,18 +19,18 @@
 
 #include "vsag_exception.h"
 
-#define SAFE_CALL(stmt)                                                                     \
-    try {                                                                                   \
-        stmt;                                                                               \
-        return {};                                                                          \
-    } catch (const vsag::VsagException& e) {                                                \
-        LOG_ERROR_AND_RETURNS(e.error_.type, e.error_.message);                             \
-    } catch (const std::bad_alloc& e) {                                                     \
+#define SAFE_CALL(stmt)                                                                      \
+    try {                                                                                    \
+        stmt;                                                                                \
+        return {};                                                                           \
+    } catch (const vsag::VsagException& e) {                                                 \
+        LOG_ERROR_AND_RETURNS(e.error_.type, e.error_.message);                              \
+    } catch (const std::bad_alloc& e) {                                                      \
         LOG_ERROR_AND_RETURNS(ErrorType::NO_ENOUGH_MEMORY, "not enough memory: ", e.what()); \
-    } catch (const std::exception& e) {                                                     \
-        LOG_ERROR_AND_RETURNS(ErrorType::UNKNOWN_ERROR, "unknownError: ", e.what());        \
-    } catch (...) {                                                                         \
-        LOG_ERROR_AND_RETURNS(ErrorType::UNKNOWN_ERROR, "unknown error");                   \
+    } catch (const std::exception& e) {                                                      \
+        LOG_ERROR_AND_RETURNS(ErrorType::UNKNOWN_ERROR, "unknownError: ", e.what());         \
+    } catch (...) {                                                                          \
+        LOG_ERROR_AND_RETURNS(ErrorType::UNKNOWN_ERROR, "unknown error");                    \
     }
 
 #define CHECK_ARGUMENT(expr, message)                                        \


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Introduce a catch block for std::bad_alloc in SAFE_CALL macro to return NO_ENOUGH_MEMORY instead of UNKNOWN_ERROR.