### PR TITLE
feat(index): add "is_timeout" stat for search result

### DIFF
--- a/include/vsag/dataset.h
+++ b/include/vsag/dataset.h
@@ -276,6 +276,32 @@ public:
      */
     virtual int64_t
     GetExtraInfoSize() const = 0;
+
+    /*
+     * @brief Sets the Statistics for the dataset.
+     *
+     * @param Statistics The Statistics string.
+     * @return DatasetPtr A shared pointer to the dataset with updated Statistics.
+     */
+    virtual DatasetPtr
+    Statistics(const std::string& Statistics) = 0;
+
+    /**
+     * @brief Retrieves the all Statistics of the dataset.
+     *
+     * @return std::string The Statistics string.
+     */
+    virtual std::string
+    GetStatistics() const = 0;
+
+    /**
+     * @brief Retrieves the Statistics of the dataset.
+     *
+     * @param stat_keys The vector of stat keys.
+     * @return std::vector<std::string> The vector of stat values.
+     */
+    virtual std::vector<std::string>
+    GetStatistics(const std::vector<std::string>& stat_keys) const = 0;
 };
 
 };  // namespace vsag

--- a/mockimpl/CMakeLists.txt
+++ b/mockimpl/CMakeLists.txt
@@ -23,6 +23,7 @@ set (MOCK_SRCS
   ../src/impl/bitset/fast_bitset.cpp
   ../src/constants.cpp
   ../src/dataset_impl.cpp
+  ../src/json_wrapper.cpp
 )
 
 add_library (vsag_mockimpl SHARED ${MOCK_SRCS})

--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -1003,12 +1003,11 @@ HGraph::add_one_point(const void* data, int level, InnerIdType inner_id) {
 bool
 HGraph::graph_add_one(const void* data, int level, InnerIdType inner_id) {
     DistHeapPtr result = nullptr;
-    InnerSearchParam param{
-        .topk = 1,
-        .ep = this->entry_point_id_,
-        .ef = 1,
-        .is_inner_id_allowed = nullptr,
-    };
+    InnerSearchParam param;
+    param.topk = 1;
+    param.ep = this->entry_point_id_;
+    param.ef = 1;
+    param.is_inner_id_allowed = nullptr;
 
     LockGuard cur_lock(neighbors_mutex_, inner_id);
     auto flatten_codes = basic_flatten_codes_;
@@ -1880,6 +1879,7 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
     search_param.search_alloc = search_allocator;
 
     auto vt = this->pool_->TakeOne();
+
     const auto* raw_query = get_data(query);
     for (auto i = static_cast<int64_t>(this->route_graphs_.size() - 1); i >= 0; --i) {
         auto result = this->search_one_graph(
@@ -1915,6 +1915,7 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
     if (params.enable_time_record) {
         search_param.time_cost = std::make_shared<Timer>();
         search_param.time_cost->SetThreshold(params.timeout_ms);
+        (*search_param.stats)["is_timeout"].SetBool(false);
     }
 
     auto search_result = this->search_one_graph(
@@ -1932,7 +1933,9 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
 
     // return an empty dataset directly if searcher returns nothing
     if (search_result->Empty()) {
-        return DatasetImpl::MakeEmptyDataset();
+        auto dataset_result = DatasetImpl::MakeEmptyDataset();
+        dataset_result->Statistics(search_param.stats->Dump());
+        return dataset_result;
     }
     auto count = static_cast<const int64_t>(search_result->Size());
     auto [dataset_results, dists, ids] = create_fast_dataset(count, search_allocator);
@@ -1950,6 +1953,7 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
         }
         search_result->Pop();
     }
+    dataset_results->Statistics(search_param.stats->Dump());
     return std::move(dataset_results);
 }
 

--- a/src/algorithm/ivf.h
+++ b/src/algorithm/ivf.h
@@ -143,7 +143,10 @@ private:
     search(const DatasetPtr& query, const InnerSearchParam& param) const;
 
     DatasetPtr
-    reorder(int64_t topk, DistHeapPtr& input, const float* query) const;
+    reorder(int64_t topk,
+            DistHeapPtr& input,
+            const float* query,
+            const InnerSearchParam& param) const;
 
     void
     merge_one_unit(const MergeUnit& unit);

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -109,7 +109,7 @@ const char* const INDEX_PARAM = "index_param";
 
 const char PART_SLASH = '/';
 
-// statstic key
+// statistics key
 const char* const STATSTIC_MEMORY = "memory";
 const char* const STATSTIC_INDEX_NAME = "index_name";
 const char* const STATSTIC_DATA_NUM = "data_num";

--- a/src/dataset_impl.cpp
+++ b/src/dataset_impl.cpp
@@ -17,6 +17,7 @@
 
 #include <cstring>
 
+#include "typing.h"
 #include "vsag_exception.h"
 
 namespace vsag {
@@ -270,6 +271,20 @@ DatasetImpl::Append(const DatasetPtr& other) {
         }
     }
     return shared_from_this();
+}
+
+std::vector<std::string>
+DatasetImpl::GetStatistics(const std::vector<std::string>& stat_keys) const {
+    auto json = JsonType::Parse(this->statistics_);
+    std::vector<std::string> result;
+    for (const auto& key : stat_keys) {
+        if (json.Contains(key)) {
+            result.emplace_back(json[key].Dump());
+        } else {
+            result.emplace_back("");
+        }
+    }
+    return result;
 }
 
 };  // namespace vsag

--- a/src/dataset_impl.h
+++ b/src/dataset_impl.h
@@ -273,6 +273,20 @@ public:
         return 0;
     }
 
+    DatasetPtr
+    Statistics(const std::string& statisticss) override {
+        this->statistics_ = statisticss;
+        return shared_from_this();
+    }
+
+    std::vector<std::string>
+    GetStatistics(const std::vector<std::string>& stat_keys) const override;
+
+    std::string
+    GetStatistics() const override {
+        return this->statistics_;
+    }
+
     static DatasetPtr
     MakeEmptyDataset();
 
@@ -280,6 +294,8 @@ private:
     bool owner_{true};
     std::unordered_map<std::string, var> data_;
     Allocator* allocator_ = nullptr;
+
+    std::string statistics_{"{}"};
 };
 
 };  // namespace vsag

--- a/src/impl/inner_search_param.h
+++ b/src/impl/inner_search_param.h
@@ -30,6 +30,11 @@ enum InnerSearchType { PURE = 1, WITH_FILTER = 2 };
 
 class InnerSearchParam {
 public:
+    InnerSearchParam() {
+        stats = std::make_shared<JsonType>();
+    }
+
+public:
     int64_t topk{0};
     float radius{0.0F};
     InnerIdType ep{0};
@@ -56,6 +61,8 @@ public:
 
     // time record
     std::shared_ptr<Timer> time_cost{nullptr};
+
+    std::shared_ptr<JsonType> stats{nullptr};
 
     InnerSearchParam&
     operator=(const InnerSearchParam& other) {

--- a/src/impl/searcher/basic_searcher.cpp
+++ b/src/impl/searcher/basic_searcher.cpp
@@ -300,6 +300,7 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
 
         if (inner_search_param.time_cost != nullptr and
             inner_search_param.time_cost->CheckOvertime()) {
+            (*inner_search_param.stats)["is_timeout"].SetBool(true);
             break;
         }
 

--- a/tests/test_index.cpp
+++ b/tests/test_index.cpp
@@ -2325,6 +2325,12 @@ TestIndex::TestSearchOvertime(const IndexPtr& index,
             ->Owner(false);
         auto res = index->KnnSearch(query, 10, search_param);
         REQUIRE(res.has_value());
+        auto result = res.value();
+        REQUIRE(result->GetStatistics() != "{}");
+        auto stats = result->GetStatistics({"is_timeout"});
+        REQUIRE(stats.size() == 1);
+        bool has_timeout_result = (stats[0] == "true" or stats[0] == "false");
+        REQUIRE(has_timeout_result);
     }
 }
 


### PR DESCRIPTION
closed: #1326 

## Summary by Sourcery

Introduce a JSON-based statistics mechanism for search results, track timeout events, and expose these stats through the Dataset API

New Features:
- Add Dataset::Statstics and GetStatstics methods to set and retrieve JSON-encoded statistics

Enhancements:
- Initialize and update is_timeout flag in InnerSearchParam and record it in HGraph, IVF, and BasicSearcher search flows
- Attach statistics JSON to returned Dataset instances in both empty and non-empty search results

Build:
- Include json_wrapper.cpp in mockimpl CMakeLists to support JSON parsing for statistics

Tests:
- Add unit test to verify retrieval of the is_timeout statistic from search results