### PR TITLE
fix(hnsw): fix the OOM issue caused by large IDs

### DIFF
--- a/src/algorithm/hnswlib/algorithm_interface.h
+++ b/src/algorithm/hnswlib/algorithm_interface.h
@@ -105,7 +105,7 @@ public:
     virtual size_t
     getDeletedCount() = 0;
 
-    virtual vsag::UnorderedMap<LabelType, InnerIdType>
+    virtual vsag::STLUnorderedMap<LabelType, InnerIdType>
     getDeletedElements() = 0;
 
     virtual bool

--- a/src/algorithm/hnswlib/hnswalg.h
+++ b/src/algorithm/hnswlib/hnswalg.h
@@ -114,7 +114,7 @@ private:
     DISTFUNC fstdistfunc_{nullptr};
     void* dist_func_param_{nullptr};
 
-    vsag::UnorderedMap<LabelType, InnerIdType> label_lookup_;
+    vsag::STLUnorderedMap<LabelType, InnerIdType> label_lookup_;
 
     std::default_random_engine level_generator_{2021};
     mutable std::default_random_engine update_probability_generator_;
@@ -130,7 +130,7 @@ private:
     bool allow_replace_deleted_{false};
 
     std::mutex deleted_elements_lock_{};  // lock for deleted_elements_
-    vsag::UnorderedMap<LabelType, InnerIdType>
+    vsag::STLUnorderedMap<LabelType, InnerIdType>
         deleted_elements_;  // contains labels and internal ids of deleted elements
 
     bool immutable_{false};
@@ -249,7 +249,7 @@ public:
         return num_deleted_;
     }
 
-    vsag::UnorderedMap<LabelType, InnerIdType>
+    vsag::STLUnorderedMap<LabelType, InnerIdType>
     getDeletedElements() override {
         return deleted_elements_;
     }

--- a/src/algorithm/hnswlib/hnswalg_static.h
+++ b/src/algorithm/hnswlib/hnswalg_static.h
@@ -248,7 +248,7 @@ public:
         return num_deleted_;
     }
 
-    vsag::UnorderedMap<LabelType, InnerIdType>
+    vsag::STLUnorderedMap<LabelType, InnerIdType>
     getDeletedElements() override {
         throw std::runtime_error("Static HNSW doesn't support delete");
     };

--- a/src/label_table.h
+++ b/src/label_table.h
@@ -192,7 +192,7 @@ public:
 
 public:
     Vector<LabelType> label_table_;
-    UnorderedMap<LabelType, InnerIdType> label_remap_;
+    STLUnorderedMap<LabelType, InnerIdType> label_remap_;
 
     bool compress_duplicate_data_{true};
 

--- a/src/typing.h
+++ b/src/typing.h
@@ -49,6 +49,14 @@ using UnorderedMap = tsl::robin_map<KeyType,
                                     std::equal_to<KeyType>,
                                     vsag::AllocatorWrapper<std::pair<const KeyType, ValType>>>;
 
+template <typename KeyType, typename ValType>
+using STLUnorderedMap =
+    std::unordered_map<KeyType,
+                       ValType,
+                       std::hash<KeyType>,
+                       std::equal_to<KeyType>,
+                       vsag::AllocatorWrapper<std::pair<const KeyType, ValType>>>;
+
 template <typename T, typename... Args>
 inline auto
 AllocateShared(Allocator* allocator, Args&&... args) {

--- a/tests/fixtures/test_dataset.h
+++ b/tests/fixtures/test_dataset.h
@@ -25,7 +25,7 @@ class TestDataset {
 public:
     using DatasetPtr = vsag::DatasetPtr;
 
-    const static int ID_BIAS = 10086;
+    int64_t id_shift = 16;
 
     static std::shared_ptr<TestDataset>
     CreateTestDataset(uint64_t dim,
@@ -35,7 +35,8 @@ public:
                       float valid_ratio = 0.8,
                       std::string vector_type = "dense",
                       uint64_t extra_info_size = 0,
-                      bool has_duplicate = false);
+                      bool has_duplicate = false,
+                      int64_t id_shift = 16);
 
     static std::shared_ptr<TestDataset>
     CreateNanDataset(const std::string& metric_str);

--- a/tests/fixtures/test_dataset_pool.cpp
+++ b/tests/fixtures/test_dataset_pool.cpp
@@ -11,12 +11,20 @@ TestDatasetPool::GetDatasetAndCreate(uint64_t dim,
                                      const std::string& metric_str,
                                      bool with_path,
                                      float valid_ratio,
-                                     uint64_t extra_info_size) {
-    auto key = key_gen(dim, count, metric_str, with_path, valid_ratio, extra_info_size);
+                                     uint64_t extra_info_size,
+                                     int64_t id_shift) {
+    auto key = key_gen(dim, count, metric_str, with_path, valid_ratio, extra_info_size, id_shift);
     if (this->pool_.find(key) == this->pool_.end()) {
         this->dim_counts_.emplace_back(dim, count);
-        this->pool_[key] = TestDataset::CreateTestDataset(
-            dim, count, metric_str, with_path, valid_ratio, "dense", extra_info_size);
+        this->pool_[key] = TestDataset::CreateTestDataset(dim,
+                                                          count,
+                                                          metric_str,
+                                                          with_path,
+                                                          valid_ratio,
+                                                          "dense",
+                                                          extra_info_size,
+                                                          false,
+                                                          id_shift);
     }
     return this->pool_.at(key);
 }
@@ -26,10 +34,11 @@ TestDatasetPool::key_gen(int64_t dim,
                          const std::string& metric_str,
                          bool with_path,
                          float filter_ratio,
-                         uint64_t extra_info_size) {
+                         uint64_t extra_info_size,
+                         int64_t id_shift) {
     return std::to_string(dim) + "_" + std::to_string(count) + "_" + metric_str + "_" +
            std::to_string(with_path) + "_" + std::to_string(filter_ratio) +
-           std::to_string(extra_info_size);
+           std::to_string(extra_info_size) + "_" + std::to_string(id_shift);
 }
 
 TestDatasetPtr

--- a/tests/fixtures/test_dataset_pool.h
+++ b/tests/fixtures/test_dataset_pool.h
@@ -32,7 +32,8 @@ public:
                         const std::string& metric_str = "l2",
                         bool with_path = false,
                         float valid_ratio = 0.8,
-                        uint64_t extra_info_size = 0);
+                        uint64_t extra_info_size = 0,
+                        int64_t id_shift = 16);
 
     TestDatasetPtr
     GetDuplicateDataset(uint64_t dim,
@@ -55,7 +56,8 @@ private:
             const std::string& metric_str = "l2",
             bool with_path = false,
             float filter_ratio = 0.8,
-            uint64_t extra_info_size = 0);
+            uint64_t extra_info_size = 0,
+            int64_t id_shift = 16);
 
 private:
     std::unordered_map<std::string, TestDatasetPtr> pool_;

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -1016,6 +1016,49 @@ TEST_CASE("[Daily] HGraph Add", "[ft][hgraph][daily]") {
 }
 
 static void
+TestHGraphNonstandardID(const fixtures::HGraphTestIndexPtr& test_index,
+                        const fixtures::HGraphResourcePtr& resource) {
+    using namespace fixtures;
+    auto origin_size = vsag::Options::Instance().block_size_limit();
+    auto size = GENERATE(1024 * 1024 * 2);
+    auto search_param = fmt::format(fixtures::search_param_tmp, 200, false);
+
+    for (auto metric_type : resource->metric_types) {
+        for (auto dim : resource->dims) {
+            for (auto& [base_quantization_str, recall] : resource->test_cases) {
+                INFO(fmt::format("metric_type: {}, dim: {}, base_quantization_str: {}, recall: {}",
+                                 metric_type,
+                                 dim,
+                                 base_quantization_str,
+                                 recall));
+                if (HGraphTestIndex::IsRaBitQ(base_quantization_str) &&
+                    dim < fixtures::RABITQ_MIN_RACALL_DIM) {
+                    continue;  // Skip invalid RaBitQ configurations
+                }
+                vsag::Options::Instance().set_block_size_limit(size);
+                HGraphTestIndex::HGraphBuildParam build_param(
+                    metric_type, dim, base_quantization_str);
+                auto param = HGraphTestIndex::GenerateHGraphBuildParametersString(build_param);
+                auto index = TestIndex::TestFactory(test_index->name, param, true);
+                auto dataset = HGraphTestIndex::pool.GetDatasetAndCreate(
+                    dim, 10000, metric_type, false, 0.8, 0, 48);
+                TestIndex::TestAddIndex(index, dataset, true);
+                if (index->CheckFeature(vsag::SUPPORT_ADD_FROM_EMPTY)) {
+                    HGraphTestIndex::TestGeneral(index, dataset, search_param, recall);
+                }
+                vsag::Options::Instance().set_block_size_limit(origin_size);
+            }
+        }
+    }
+}
+
+TEST_CASE("HGraph Test NonstandardID", "[ft][hgraph][pr]") {
+    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
+    auto resource = test_index->GetResource(true);
+    TestHGraphNonstandardID(test_index, resource);
+}
+
+static void
 TestHGraphDuplicate(const fixtures::HGraphTestIndexPtr& test_index,
                     const fixtures::HGraphResourcePtr& resource) {
     using namespace fixtures;

--- a/tests/test_hnsw.cpp
+++ b/tests/test_hnsw.cpp
@@ -229,7 +229,6 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex,
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
     auto metric_type = GENERATE("l2", "ip", "cosine");
-    std::string base_quantization_str = GENERATE("sq8", "fp32");
     const std::string name = "hnsw";
     auto search_param = fmt::format(search_param_tmp, 100);
     for (auto& dim : dims) {
@@ -250,13 +249,50 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex,
     vsag::Options::Instance().set_block_size_limit(origin_size);
 }
 
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Test non-standard IDs", "[ft][hnsw]") {
+    auto origin_size = vsag::Options::Instance().block_size_limit();
+    auto size = GENERATE(1024 * 1024 * 2);
+    auto metric_type = GENERATE("l2");
+
+    const std::string name = "hnsw";
+    auto search_param = fmt::format(search_param_tmp, 200);
+    auto id_shift = 48;
+    constexpr auto parameter_temp = R"(
+    {{
+        "dtype": "float32",
+        "metric_type": "{}",
+        "dim": {},
+        "hnsw": {{
+            "max_degree": 64,
+            "ef_construction": 200,
+            "use_static": {}
+        }}
+    }}
+    )";
+    for (auto& dim : dims) {
+        vsag::Options::Instance().set_block_size_limit(size);
+        auto param = fmt::format(parameter_temp, metric_type, dim, false);
+        auto index = TestFactory(name, param, true);
+        REQUIRE(index->GetIndexType() == vsag::IndexType::HNSW);
+        auto dataset = pool.GetDatasetAndCreate(dim, 10000, metric_type, false, 0.8, 0, id_shift);
+        TestContinueAdd(index, dataset, true);
+        TestKnnSearch(index, dataset, search_param, 0.99, true);
+        TestKnnSearchIter(index, dataset, search_param, 0.99, true);
+        TestConcurrentKnnSearch(index, dataset, search_param, 0.99, true);
+        TestRangeSearch(index, dataset, search_param, 0.99, 10, true);
+        TestRangeSearch(index, dataset, search_param, 0.49, 5, true);
+        TestFilterSearch(index, dataset, search_param, 0.99, true);
+        TestSearchAllocator(index, dataset, search_param, 0.99, true);
+    }
+    vsag::Options::Instance().set_block_size_limit(origin_size);
+}
+
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex,
                              "HNSW Continue Destruct V.S. All Test",
                              "[ft][hnsw]") {
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
     auto metric_type = GENERATE("l2");
-    std::string base_quantization_str = GENERATE("fp32");
     const std::string name = "hnsw";
     auto search_param = fmt::format(search_param_tmp, 100);
 

--- a/tests/test_index.cpp
+++ b/tests/test_index.cpp
@@ -1589,10 +1589,10 @@ TestIndex::TestGetExtraInfoById(const TestIndex::IndexPtr& index,
     auto result = index->GetExtraInfoByIds(ids.data(), count, extra_infos.data());
     REQUIRE(result.has_value());
     for (int64_t i = 0; i < count; ++i) {
-        REQUIRE(
-            memcmp(extra_infos.data() + i * extra_info_size,
-                   dataset->base_->GetExtraInfos() + (ids[i] - dataset->ID_BIAS) * extra_info_size,
-                   extra_info_size) == 0);
+        REQUIRE(memcmp(extra_infos.data() + i * extra_info_size,
+                       dataset->base_->GetExtraInfos() +
+                           (ids[i] >> dataset->id_shift) * extra_info_size,
+                       extra_info_size) == 0);
     }
 }
 
@@ -1813,9 +1813,10 @@ TestIndex::TestRemoveIndex(const TestIndex::IndexPtr& index,
     auto base_dim = dataset->base_->GetDim();
     for (int64_t i = 0; i < base_num; ++i) {
         auto new_data = vsag::Dataset::Make();
+        int64_t id = base_num + i;
         new_data->NumElements(1)
             ->Dim(base_dim)
-            ->Ids(&i)
+            ->Ids(&id)
             ->Float32Vectors(dataset->base_->GetFloat32Vectors() + i * base_dim)
             ->Owner(false);
         auto add_results = index->Add(new_data);
@@ -1830,10 +1831,10 @@ TestIndex::TestRemoveIndex(const TestIndex::IndexPtr& index,
             ->Owner(false);
         auto add_results = index->Add(new_data);
         REQUIRE(add_results.has_value());
-        auto remove_results = index->Remove(i);
+        auto remove_results = index->Remove(i + base_num);
         REQUIRE(index->GetNumberRemoved() == i + 1);
         REQUIRE(remove_results.has_value());
-        remove_results = index->Remove(i);
+        remove_results = index->Remove(i + base_num);
         REQUIRE_FALSE(remove_results.has_value());
         REQUIRE(index->GetNumElements() == dataset->base_->GetNumElements());
     }


### PR DESCRIPTION
cp (#1313) to 0.16

## Summary by Sourcery

Enable handling of large non-standard IDs and reduce memory overhead to prevent OOM in HNSW.

New Features:
- Add id_shift parameter to dataset generation and filtering to support arbitrary large IDs.

Bug Fixes:
- Replace robin_map-based UnorderedMap with STLUnorderedMap in HNSW to lower memory usage and prevent OOM on large ID spaces.

Enhancements:
- Refactor TestDataset, TestDatasetPool, and TestIndex to use bit-shifted IDs instead of fixed ID_BIAS.

Tests:
- Add HGraph and HNSW test cases for non-standard large IDs to validate addition, search, and deletion operations.