### PR TITLE
refactor(string): unify same string defination

### DIFF
--- a/src/algorithm/brute_force.cpp
+++ b/src/algorithm/brute_force.cpp
@@ -438,10 +438,10 @@ static const std::string BRUTE_FORCE_PARAMS_TEMPLATE =
     {
         "type": "{INDEX_BRUTE_FORCE}",
         "{IO_PARAMS_KEY}": {
-            "{IO_TYPE_KEY}": "{IO_TYPE_VALUE_MEMORY_IO}"
+            "{TYPE_KEY}": "{IO_TYPE_VALUE_MEMORY_IO}"
         },
         "{QUANTIZATION_PARAMS_KEY}": {
-            "{QUANTIZATION_TYPE_KEY}": "{QUANTIZATION_TYPE_VALUE_FP32}",
+            "{TYPE_KEY}": "{QUANTIZATION_TYPE_VALUE_FP32}",
             "subspace": 64,
             "nbits": 8,
             "{HOLD_MOLDS}": false
@@ -461,14 +461,14 @@ BruteForce::CheckAndMappingExternalParam(const JsonType& external_param,
             BRUTE_FORCE_QUANTIZATION_TYPE,
             {
                 QUANTIZATION_PARAMS_KEY,
-                QUANTIZATION_TYPE_KEY,
+                TYPE_KEY,
             },
         },
         {
             BRUTE_FORCE_IO_TYPE,
             {
                 IO_PARAMS_KEY,
-                IO_TYPE_KEY,
+                TYPE_KEY,
             },
         },
         {

--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -113,7 +113,7 @@ HGraph::Build(const DatasetPtr& data) {
     CHECK_ARGUMENT(GetNumElements() == 0, "index is not empty");
     this->Train(data);
     std::vector<int64_t> ret;
-    if (graph_type_ == GRAPH_TYPE_NSW) {
+    if (graph_type_ == GRAPH_TYPE_VALUE_NSW) {
         ret = this->Add(data);
     } else {
         ret = this->build_by_odescent(data);
@@ -1215,69 +1215,69 @@ static const std::string HGRAPH_PARAMS_TEMPLATE =
         "{HGRAPH_USE_ATTRIBUTE_FILTER_KEY}": false,
         "{HGRAPH_GRAPH_KEY}": {
             "{IO_PARAMS_KEY}": {
-                "{IO_TYPE_KEY}": "{IO_TYPE_VALUE_BLOCK_MEMORY_IO}",
-                "{IO_FILE_PATH}": "{DEFAULT_FILE_PATH_VALUE}"
+                "{TYPE_KEY}": "{IO_TYPE_VALUE_BLOCK_MEMORY_IO}",
+                "{IO_FILE_PATH_KEY}": "{DEFAULT_FILE_PATH_VALUE}"
             },
-            "{GRAPH_TYPE_KEY}": "{GRAPH_TYPE_NSW}",
-            "{GRAPH_STORAGE_TYPE_KEY}": "{GRAPH_STORAGE_TYPE_FLAT}",
+            "{GRAPH_TYPE_KEY}": "{GRAPH_TYPE_VALUE_NSW}",
+            "{GRAPH_STORAGE_TYPE_KEY}": "{GRAPH_STORAGE_TYPE_VALUE_FLAT}",
             "{ODESCENT_PARAMETER_BUILD_BLOCK_SIZE}": 10000,
             "{ODESCENT_PARAMETER_MIN_IN_DEGREE}": 1,
             "{ODESCENT_PARAMETER_ALPHA}": 1.2,
             "{ODESCENT_PARAMETER_GRAPH_ITER_TURN}": 30,
             "{ODESCENT_PARAMETER_NEIGHBOR_SAMPLE_RATE}": 0.2,
-            "{GRAPH_PARAM_MAX_DEGREE}": 64,
-            "{GRAPH_PARAM_INIT_MAX_CAPACITY}": 100,
+            "{GRAPH_PARAM_MAX_DEGREE_KEY}": 64,
+            "{GRAPH_PARAM_INIT_MAX_CAPACITY_KEY}": 100,
             "{GRAPH_SUPPORT_REMOVE}": false,
             "{REMOVE_FLAG_BIT}": 8
         },
-        "{HGRAPH_BASE_CODES_KEY}": {
+        "{BASE_CODES_KEY}": {
             "{IO_PARAMS_KEY}": {
-                "{IO_TYPE_KEY}": "{IO_TYPE_VALUE_BLOCK_MEMORY_IO}",
-                "{IO_FILE_PATH}": "{DEFAULT_FILE_PATH_VALUE}"
+                "{TYPE_KEY}": "{IO_TYPE_VALUE_BLOCK_MEMORY_IO}",
+                "{IO_FILE_PATH_KEY}": "{DEFAULT_FILE_PATH_VALUE}"
             },
             "{CODES_TYPE_KEY}": "flatten",
             "{QUANTIZATION_PARAMS_KEY}": {
-                "{QUANTIZATION_TYPE_KEY}": "{QUANTIZATION_TYPE_VALUE_FP32}",
-                "{SQ4_UNIFORM_QUANTIZATION_TRUNC_RATE}": 0.05,
-                "{PCA_DIM}": 0,
-                "{RABITQ_QUANTIZATION_BITS_PER_DIM_QUERY}": 32,
-                "{TQ_CHAIN}": "",
+                "{TYPE_KEY}": "{QUANTIZATION_TYPE_VALUE_FP32}",
+                "{SQ4_UNIFORM_QUANTIZATION_TRUNC_RATE_KEY}": 0.05,
+                "{PCA_DIM_KEY}": 0,
+                "{RABITQ_QUANTIZATION_BITS_PER_DIM_QUERY_KEY}": 32,
+                "{TQ_CHAIN_KEY}": "",
                 "nbits": 8,
-                "{PRODUCT_QUANTIZATION_DIM}": 1,
+                "{PRODUCT_QUANTIZATION_DIM_KEY}": 1,
                 "{HOLD_MOLDS}": false
             }
         },
         "{PRECISE_CODES_KEY}": {
             "{IO_PARAMS_KEY}": {
-                "{IO_TYPE_KEY}": "{IO_TYPE_VALUE_BLOCK_MEMORY_IO}",
-                "{IO_FILE_PATH}": "{DEFAULT_FILE_PATH_VALUE}"
+                "{TYPE_KEY}": "{IO_TYPE_VALUE_BLOCK_MEMORY_IO}",
+                "{IO_FILE_PATH_KEY}": "{DEFAULT_FILE_PATH_VALUE}"
             },
             "{CODES_TYPE_KEY}": "flatten",
             "{QUANTIZATION_PARAMS_KEY}": {
-                "{QUANTIZATION_TYPE_KEY}": "{QUANTIZATION_TYPE_VALUE_FP32}",
-                "{SQ4_UNIFORM_QUANTIZATION_TRUNC_RATE}": 0.05,
-                "{PCA_DIM}": 0,
-                "{PRODUCT_QUANTIZATION_DIM}": 1,
+                "{TYPE_KEY}": "{QUANTIZATION_TYPE_VALUE_FP32}",
+                "{SQ4_UNIFORM_QUANTIZATION_TRUNC_RATE_KEY}": 0.05,
+                "{PCA_DIM_KEY}": 0,
+                "{PRODUCT_QUANTIZATION_DIM_KEY}": 1,
                 "{HOLD_MOLDS}": false
             }
         },
         "{STORE_RAW_VECTOR_KEY}": false,
         "{RAW_VECTOR_KEY}": {
             "{IO_PARAMS_KEY}": {
-                "{IO_TYPE_KEY}": "{IO_TYPE_VALUE_BLOCK_MEMORY_IO}",
-                "{IO_FILE_PATH}": "{DEFAULT_FILE_PATH_VALUE}"
+                "{TYPE_KEY}": "{IO_TYPE_VALUE_BLOCK_MEMORY_IO}",
+                "{IO_FILE_PATH_KEY}": "{DEFAULT_FILE_PATH_VALUE}"
             },
             "{CODES_TYPE_KEY}": "flatten",
             "{QUANTIZATION_PARAMS_KEY}": {
-                "{QUANTIZATION_TYPE_KEY}": "{QUANTIZATION_TYPE_VALUE_FP32}",
+                "{TYPE_KEY}": "{QUANTIZATION_TYPE_VALUE_FP32}",
                 "{HOLD_MOLDS}": true
             }
         },
         "{BUILD_THREAD_COUNT_KEY}": 100,
         "{EXTRA_INFO_KEY}": {
             "{IO_PARAMS_KEY}": {
-                "{IO_TYPE_KEY}": "{IO_TYPE_VALUE_BLOCK_MEMORY_IO}",
-                "{IO_FILE_PATH}": "{DEFAULT_FILE_PATH_VALUE}"
+                "{TYPE_KEY}": "{IO_TYPE_VALUE_BLOCK_MEMORY_IO}",
+                "{IO_FILE_PATH_KEY}": "{DEFAULT_FILE_PATH_VALUE}"
             }
         },
         "{ATTR_PARAMS_KEY}": {
@@ -1324,15 +1324,15 @@ HGraph::CheckAndMappingExternalParam(const JsonType& external_param,
                                             {
                                                 HGRAPH_BASE_QUANTIZATION_TYPE,
                                                 {
-                                                    HGRAPH_BASE_CODES_KEY,
+                                                    BASE_CODES_KEY,
                                                     QUANTIZATION_PARAMS_KEY,
-                                                    QUANTIZATION_TYPE_KEY,
+                                                    TYPE_KEY,
                                                 },
                                             },
                                             {
                                                 STORE_RAW_VECTOR,
                                                 {
-                                                    HGRAPH_BASE_CODES_KEY,
+                                                    BASE_CODES_KEY,
                                                     QUANTIZATION_PARAMS_KEY,
                                                     HOLD_MOLDS,
                                                 },
@@ -1340,9 +1340,9 @@ HGraph::CheckAndMappingExternalParam(const JsonType& external_param,
                                             {
                                                 HGRAPH_BASE_IO_TYPE,
                                                 {
-                                                    HGRAPH_BASE_CODES_KEY,
+                                                    BASE_CODES_KEY,
                                                     IO_PARAMS_KEY,
-                                                    IO_TYPE_KEY,
+                                                    TYPE_KEY,
                                                 },
                                             },
                                             {
@@ -1350,15 +1350,15 @@ HGraph::CheckAndMappingExternalParam(const JsonType& external_param,
                                                 {
                                                     PRECISE_CODES_KEY,
                                                     IO_PARAMS_KEY,
-                                                    IO_TYPE_KEY,
+                                                    TYPE_KEY,
                                                 },
                                             },
                                             {
                                                 HGRAPH_BASE_FILE_PATH,
                                                 {
-                                                    HGRAPH_BASE_CODES_KEY,
+                                                    BASE_CODES_KEY,
                                                     IO_PARAMS_KEY,
-                                                    IO_FILE_PATH,
+                                                    IO_FILE_PATH_KEY,
                                                 },
                                             },
                                             {
@@ -1366,7 +1366,7 @@ HGraph::CheckAndMappingExternalParam(const JsonType& external_param,
                                                 {
                                                     PRECISE_CODES_KEY,
                                                     IO_PARAMS_KEY,
-                                                    IO_FILE_PATH,
+                                                    IO_FILE_PATH_KEY,
                                                 },
                                             },
                                             {
@@ -1374,7 +1374,7 @@ HGraph::CheckAndMappingExternalParam(const JsonType& external_param,
                                                 {
                                                     PRECISE_CODES_KEY,
                                                     QUANTIZATION_PARAMS_KEY,
-                                                    QUANTIZATION_TYPE_KEY,
+                                                    TYPE_KEY,
                                                 },
                                             },
                                             {
@@ -1382,7 +1382,7 @@ HGraph::CheckAndMappingExternalParam(const JsonType& external_param,
                                                 {
                                                     HGRAPH_GRAPH_KEY,
                                                     IO_PARAMS_KEY,
-                                                    IO_TYPE_KEY,
+                                                    TYPE_KEY,
                                                 },
                                             },
                                             {
@@ -1390,7 +1390,7 @@ HGraph::CheckAndMappingExternalParam(const JsonType& external_param,
                                                 {
                                                     HGRAPH_GRAPH_KEY,
                                                     IO_PARAMS_KEY,
-                                                    IO_FILE_PATH,
+                                                    IO_FILE_PATH_KEY,
                                                 },
                                             },
                                             {
@@ -1412,7 +1412,7 @@ HGraph::CheckAndMappingExternalParam(const JsonType& external_param,
                                                 {
                                                     RAW_VECTOR_KEY,
                                                     IO_PARAMS_KEY,
-                                                    IO_TYPE_KEY,
+                                                    TYPE_KEY,
                                                 },
                                             },
                                             {
@@ -1420,14 +1420,14 @@ HGraph::CheckAndMappingExternalParam(const JsonType& external_param,
                                                 {
                                                     RAW_VECTOR_KEY,
                                                     IO_PARAMS_KEY,
-                                                    IO_FILE_PATH,
+                                                    IO_FILE_PATH_KEY,
                                                 },
                                             },
                                             {
                                                 HGRAPH_GRAPH_MAX_DEGREE,
                                                 {
                                                     HGRAPH_GRAPH_KEY,
-                                                    GRAPH_PARAM_MAX_DEGREE,
+                                                    GRAPH_PARAM_MAX_DEGREE_KEY,
                                                 },
                                             },
                                             {
@@ -1446,7 +1446,7 @@ HGraph::CheckAndMappingExternalParam(const JsonType& external_param,
                                                 HGRAPH_INIT_CAPACITY,
                                                 {
                                                     HGRAPH_GRAPH_KEY,
-                                                    GRAPH_PARAM_INIT_MAX_CAPACITY,
+                                                    GRAPH_PARAM_INIT_MAX_CAPACITY_KEY,
                                                 },
                                             },
                                             {
@@ -1507,49 +1507,49 @@ HGraph::CheckAndMappingExternalParam(const JsonType& external_param,
                                             {
                                                 SQ4_UNIFORM_TRUNC_RATE,
                                                 {
-                                                    HGRAPH_BASE_CODES_KEY,
+                                                    BASE_CODES_KEY,
                                                     QUANTIZATION_PARAMS_KEY,
-                                                    SQ4_UNIFORM_QUANTIZATION_TRUNC_RATE,
+                                                    SQ4_UNIFORM_QUANTIZATION_TRUNC_RATE_KEY,
                                                 },
                                             },
                                             {
                                                 RABITQ_PCA_DIM,
                                                 {
-                                                    HGRAPH_BASE_CODES_KEY,
+                                                    BASE_CODES_KEY,
                                                     QUANTIZATION_PARAMS_KEY,
-                                                    PCA_DIM,
+                                                    PCA_DIM_KEY,
                                                 },
                                             },
                                             {
                                                 INDEX_TQ_CHAIN,
                                                 {
-                                                    HGRAPH_BASE_CODES_KEY,
+                                                    BASE_CODES_KEY,
                                                     QUANTIZATION_PARAMS_KEY,
-                                                    TQ_CHAIN,
+                                                    TQ_CHAIN_KEY,
                                                 },
                                             },
                                             {
                                                 RABITQ_BITS_PER_DIM_QUERY,
                                                 {
-                                                    HGRAPH_BASE_CODES_KEY,
+                                                    BASE_CODES_KEY,
                                                     QUANTIZATION_PARAMS_KEY,
-                                                    RABITQ_QUANTIZATION_BITS_PER_DIM_QUERY,
+                                                    RABITQ_QUANTIZATION_BITS_PER_DIM_QUERY_KEY,
                                                 },
                                             },
                                             {
                                                 HGRAPH_BASE_PQ_DIM,
                                                 {
-                                                    HGRAPH_BASE_CODES_KEY,
+                                                    BASE_CODES_KEY,
                                                     QUANTIZATION_PARAMS_KEY,
-                                                    PRODUCT_QUANTIZATION_DIM,
+                                                    PRODUCT_QUANTIZATION_DIM_KEY,
                                                 },
                                             },
                                             {
                                                 RABITQ_USE_FHT,
                                                 {
-                                                    HGRAPH_BASE_CODES_KEY,
+                                                    BASE_CODES_KEY,
                                                     QUANTIZATION_PARAMS_KEY,
-                                                    USE_FHT,
+                                                    USE_FHT_KEY,
                                                 },
                                             },
                                             {
@@ -1577,7 +1577,7 @@ HGraph::CheckAndMappingExternalParam(const JsonType& external_param,
     auto inner_json = JsonType::Parse(str);
     mapping_external_param_to_inner(external_param, external_mapping, inner_json);
     if (common_param.data_type_ == DataTypes::DATA_TYPE_SPARSE) {
-        inner_json[HGRAPH_BASE_CODES_KEY][CODES_TYPE_KEY].SetString(SPARSE_CODES);
+        inner_json[BASE_CODES_KEY][CODES_TYPE_KEY].SetString(SPARSE_CODES);
         inner_json[PRECISE_CODES_KEY][CODES_TYPE_KEY].SetString(SPARSE_CODES);
         inner_json[RAW_VECTOR_KEY][CODES_TYPE_KEY].SetString(SPARSE_CODES);
     }

--- a/src/algorithm/hgraph.h
+++ b/src/algorithm/hgraph.h
@@ -346,7 +346,7 @@ private:
     InnerIdType entry_point_id_{std::numeric_limits<InnerIdType>::max()};
 
     ODescentParameterPtr odescent_param_{nullptr};
-    std::string graph_type_{GRAPH_TYPE_NSW};
+    std::string graph_type_{GRAPH_TYPE_VALUE_NSW};
 
     uint64_t ef_construct_{400};
     float alpha_{1.0};

--- a/src/algorithm/hgraph_parameter.cpp
+++ b/src/algorithm/hgraph_parameter.cpp
@@ -50,9 +50,9 @@ HGraphParameter::FromJson(const JsonType& json) {
         this->build_by_base = json[HGRAPH_BUILD_BY_BASE_QUANTIZATION_KEY].GetBool();
     }
 
-    CHECK_ARGUMENT(json.Contains(HGRAPH_BASE_CODES_KEY),
-                   fmt::format("hgraph parameters must contains {}", HGRAPH_BASE_CODES_KEY));
-    const auto& base_codes_json = json[HGRAPH_BASE_CODES_KEY];
+    CHECK_ARGUMENT(json.Contains(BASE_CODES_KEY),
+                   fmt::format("hgraph parameters must contains {}", BASE_CODES_KEY));
+    const auto& base_codes_json = json[BASE_CODES_KEY];
     this->base_codes_param = CreateFlattenParam(base_codes_json);
 
     if (use_reorder) {
@@ -66,15 +66,15 @@ HGraphParameter::FromJson(const JsonType& json) {
                    fmt::format("hgraph parameters must contains {}", HGRAPH_GRAPH_KEY));
     const auto& graph_json = json[HGRAPH_GRAPH_KEY];
 
-    GraphStorageTypes graph_storage_type = GraphStorageTypes::GRAPH_STORAGE_TYPE_FLAT;
+    GraphStorageTypes graph_storage_type = GraphStorageTypes::GRAPH_STORAGE_TYPE_VALUE_FLAT;
     if (graph_json.Contains(GRAPH_STORAGE_TYPE_KEY)) {
         const auto graph_storage_type_str = graph_json[GRAPH_STORAGE_TYPE_KEY].GetString();
-        if (graph_storage_type_str == GRAPH_STORAGE_TYPE_COMPRESSED) {
-            graph_storage_type = GraphStorageTypes::GRAPH_STORAGE_TYPE_COMPRESSED;
+        if (graph_storage_type_str == GRAPH_STORAGE_TYPE_VALUE_COMPRESSED) {
+            graph_storage_type = GraphStorageTypes::GRAPH_STORAGE_TYPE_VALUE_COMPRESSED;
         }
 
-        if (graph_storage_type_str != GRAPH_STORAGE_TYPE_COMPRESSED &&
-            graph_storage_type_str != GRAPH_STORAGE_TYPE_FLAT) {
+        if (graph_storage_type_str != GRAPH_STORAGE_TYPE_VALUE_COMPRESSED &&
+            graph_storage_type_str != GRAPH_STORAGE_TYPE_VALUE_FLAT) {
             throw VsagException(
                 ErrorType::INVALID_ARGUMENT,
                 fmt::format("invalid graph_storage_type: {}", graph_storage_type_str));
@@ -85,7 +85,7 @@ HGraphParameter::FromJson(const JsonType& json) {
 
     hierarchical_graph_param = std::make_shared<SparseGraphDatacellParameter>();
     hierarchical_graph_param->max_degree_ = this->bottom_graph_param->max_degree_ / 2;
-    if (graph_storage_type == GraphStorageTypes::GRAPH_STORAGE_TYPE_FLAT) {
+    if (graph_storage_type == GraphStorageTypes::GRAPH_STORAGE_TYPE_VALUE_FLAT) {
         auto graph_param =
             std::dynamic_pointer_cast<GraphDataCellParameter>(this->bottom_graph_param);
         if (graph_param != nullptr) {
@@ -112,7 +112,7 @@ HGraphParameter::FromJson(const JsonType& json) {
 
     if (graph_json.Contains(GRAPH_TYPE_KEY)) {
         graph_type = graph_json[GRAPH_TYPE_KEY].GetString();
-        if (graph_type == GRAPH_TYPE_ODESCENT) {
+        if (graph_type == GRAPH_TYPE_VALUE_ODESCENT) {
             odescent_param = std::make_shared<ODescentParameter>();
             odescent_param->FromJson(graph_json);
         }
@@ -132,7 +132,7 @@ HGraphParameter::ToJson() const {
     json[TYPE_KEY].SetString(INDEX_TYPE_HGRAPH);
 
     json[HGRAPH_USE_ELP_OPTIMIZER_KEY].SetBool(this->use_elp_optimizer);
-    json[HGRAPH_BASE_CODES_KEY].SetJson(this->base_codes_param->ToJson());
+    json[BASE_CODES_KEY].SetJson(this->base_codes_param->ToJson());
     json[HGRAPH_GRAPH_KEY].SetJson(this->bottom_graph_param->ToJson());
     json[HGRAPH_EF_CONSTRUCTION_KEY].SetInt(this->ef_construction);
     json[HGRAPH_ALPHA_KEY].SetFloat(this->alpha);

--- a/src/algorithm/hgraph_parameter.h
+++ b/src/algorithm/hgraph_parameter.h
@@ -51,7 +51,7 @@ public:
 
     ODescentParameterPtr odescent_param{nullptr};
 
-    std::string graph_type{GRAPH_TYPE_NSW};
+    std::string graph_type{GRAPH_TYPE_VALUE_NSW};
 
     bool use_elp_optimizer{false};
     bool ignore_reorder{false};

--- a/src/algorithm/ivf.cpp
+++ b/src/algorithm/ivf.cpp
@@ -44,18 +44,18 @@ static constexpr const char* IVF_PARAMS_TEMPLATE =
         "{BUILD_THREAD_COUNT_KEY}": 1,
         "{BUCKET_PARAMS_KEY}": {
             "{IO_PARAMS_KEY}": {
-                "{IO_TYPE_KEY}": "{IO_TYPE_VALUE_MEMORY_IO}",
-                "{IO_FILE_PATH}": "{DEFAULT_FILE_PATH_VALUE}"
+                "{TYPE_KEY}": "{IO_TYPE_VALUE_MEMORY_IO}",
+                "{IO_FILE_PATH_KEY}": "{DEFAULT_FILE_PATH_VALUE}"
             },
             "{QUANTIZATION_PARAMS_KEY}": {
-                "{QUANTIZATION_TYPE_KEY}": "{QUANTIZATION_TYPE_VALUE_FP32}",
-                "{SQ4_UNIFORM_QUANTIZATION_TRUNC_RATE}": 0.05,
-                "{PCA_DIM}": 0,
-                "{RABITQ_QUANTIZATION_BITS_PER_DIM_QUERY}": 32,
-                "{PRODUCT_QUANTIZATION_DIM}": 1
+                "{TYPE_KEY}": "{QUANTIZATION_TYPE_VALUE_FP32}",
+                "{SQ4_UNIFORM_QUANTIZATION_TRUNC_RATE_KEY}": 0.05,
+                "{PCA_DIM_KEY}": 0,
+                "{RABITQ_QUANTIZATION_BITS_PER_DIM_QUERY_KEY}": 32,
+                "{PRODUCT_QUANTIZATION_DIM_KEY}": 1
             },
             "{BUCKETS_COUNT_KEY}": 10,
-            "{BUCKET_USE_RESIDUAL}": false
+            "{BUCKET_USE_RESIDUAL_KEY}": false
         },
         "{IVF_PARTITION_STRATEGY_PARAMS_KEY}": {
             "{IVF_PARTITION_STRATEGY_TYPE_KEY}": "{IVF_PARTITION_STRATEGY_TYPE_NEAREST}",
@@ -69,13 +69,13 @@ static constexpr const char* IVF_PARAMS_TEMPLATE =
         "{USE_REORDER_KEY}": false,
         "{PRECISE_CODES_KEY}": {
             "{IO_PARAMS_KEY}": {
-                "{IO_TYPE_KEY}": "{IO_TYPE_VALUE_BLOCK_MEMORY_IO}",
-                "{IO_FILE_PATH}": "{DEFAULT_FILE_PATH_VALUE}"
+                "{TYPE_KEY}": "{IO_TYPE_VALUE_BLOCK_MEMORY_IO}",
+                "{IO_FILE_PATH_KEY}": "{DEFAULT_FILE_PATH_VALUE}"
             },
             "codes_type": "flatten_codes",
             "{QUANTIZATION_PARAMS_KEY}": {
-                "{QUANTIZATION_TYPE_KEY}": "{QUANTIZATION_TYPE_VALUE_FP32}",
-                "{PRODUCT_QUANTIZATION_DIM}": 0
+                "{TYPE_KEY}": "{QUANTIZATION_TYPE_VALUE_FP32}",
+                "{PRODUCT_QUANTIZATION_DIM_KEY}": 0
             }
         },
         "{ATTR_PARAMS_KEY}": {
@@ -92,7 +92,7 @@ IVF::CheckAndMappingExternalParam(const JsonType& external_param,
             {
                 BUCKET_PARAMS_KEY,
                 QUANTIZATION_PARAMS_KEY,
-                QUANTIZATION_TYPE_KEY,
+                TYPE_KEY,
             },
         },
         {
@@ -100,7 +100,7 @@ IVF::CheckAndMappingExternalParam(const JsonType& external_param,
             {
                 BUCKET_PARAMS_KEY,
                 IO_PARAMS_KEY,
-                IO_TYPE_KEY,
+                TYPE_KEY,
             },
         },
         {
@@ -108,7 +108,7 @@ IVF::CheckAndMappingExternalParam(const JsonType& external_param,
             {
                 BUCKET_PARAMS_KEY,
                 IO_PARAMS_KEY,
-                IO_FILE_PATH,
+                IO_FILE_PATH_KEY,
             },
         },
         {
@@ -116,7 +116,7 @@ IVF::CheckAndMappingExternalParam(const JsonType& external_param,
             {
                 PRECISE_CODES_KEY,
                 QUANTIZATION_PARAMS_KEY,
-                QUANTIZATION_TYPE_KEY,
+                TYPE_KEY,
             },
         },
         {
@@ -124,7 +124,7 @@ IVF::CheckAndMappingExternalParam(const JsonType& external_param,
             {
                 PRECISE_CODES_KEY,
                 IO_PARAMS_KEY,
-                IO_TYPE_KEY,
+                TYPE_KEY,
             },
         },
         {
@@ -132,7 +132,7 @@ IVF::CheckAndMappingExternalParam(const JsonType& external_param,
             {
                 PRECISE_CODES_KEY,
                 IO_PARAMS_KEY,
-                IO_FILE_PATH,
+                IO_FILE_PATH_KEY,
             },
         },
         {
@@ -188,7 +188,7 @@ IVF::CheckAndMappingExternalParam(const JsonType& external_param,
             IVF_USE_RESIDUAL,
             {
                 BUCKET_PARAMS_KEY,
-                BUCKET_USE_RESIDUAL,
+                BUCKET_USE_RESIDUAL_KEY,
             },
         },
         {
@@ -202,7 +202,7 @@ IVF::CheckAndMappingExternalParam(const JsonType& external_param,
             {
                 BUCKET_PARAMS_KEY,
                 QUANTIZATION_PARAMS_KEY,
-                PRODUCT_QUANTIZATION_DIM,
+                PRODUCT_QUANTIZATION_DIM_KEY,
             },
         },
         {

--- a/src/algorithm/sindi/sindi_parameter.cpp
+++ b/src/algorithm/sindi/sindi_parameter.cpp
@@ -39,8 +39,8 @@ SINDIParameter::FromJson(const JsonType& json) {
         doc_prune_ratio = DEFAULT_DOC_PRUNE_RATIO;
     }
 
-    if (json.Contains(SPARSE_USE_REORDER)) {
-        use_reorder = json[SPARSE_USE_REORDER].GetBool();
+    if (json.Contains(USE_REORDER_KEY)) {
+        use_reorder = json[USE_REORDER_KEY].GetBool();
     } else {
         use_reorder = DEFAULT_USE_REORDER;
     }
@@ -64,7 +64,7 @@ SINDIParameter::ToJson() const {
     JsonType json;
     json[SPARSE_TERM_ID_LIMIT].SetInt(term_id_limit);
     json[SPARSE_DOC_PRUNE_RATIO].SetFloat(doc_prune_ratio);
-    json[SPARSE_USE_REORDER].SetBool(use_reorder);
+    json[USE_REORDER_KEY].SetBool(use_reorder);
     json[SPARSE_WINDOW_SIZE].SetInt(window_size);
     return json;
 }

--- a/src/algorithm/sindi/sindi_parameter_test.cpp
+++ b/src/algorithm/sindi/sindi_parameter_test.cpp
@@ -51,7 +51,7 @@ struct SINDIDefaultParam {
 std::string
 generate_sindi_param(const SINDIDefaultParam& param) {
     vsag::JsonType json;
-    json[SPARSE_USE_REORDER].SetBool(param.use_reorder);
+    json[USE_REORDER_KEY].SetBool(param.use_reorder);
     json[SPARSE_DOC_PRUNE_RATIO].SetFloat(param.doc_prune_ratio);
     json[SPARSE_WINDOW_SIZE].SetInt(param.window_size);
     json[SPARSE_TERM_ID_LIMIT].SetInt(param.term_id_limit);

--- a/src/datacell/bucket_datacell_parameter.cpp
+++ b/src/datacell/bucket_datacell_parameter.cpp
@@ -39,8 +39,8 @@ BucketDataCellParameter::FromJson(const JsonType& json) {
         this->buckets_count = json[BUCKETS_COUNT_KEY].GetInt();
     }
 
-    if (json.Contains(BUCKET_USE_RESIDUAL)) {
-        this->use_residual_ = json[BUCKET_USE_RESIDUAL].GetBool();
+    if (json.Contains(BUCKET_USE_RESIDUAL_KEY)) {
+        this->use_residual_ = json[BUCKET_USE_RESIDUAL_KEY].GetBool();
     }
 }
 
@@ -48,7 +48,7 @@ JsonType
 BucketDataCellParameter::ToJson() const {
     JsonType json;
     json[IO_PARAMS_KEY].SetJson(this->io_parameter->ToJson());
-    json[BUCKET_USE_RESIDUAL].SetBool(this->use_residual_);
+    json[BUCKET_USE_RESIDUAL_KEY].SetBool(this->use_residual_);
     json[QUANTIZATION_PARAMS_KEY].SetJson(this->quantizer_parameter->ToJson());
     json[BUCKETS_COUNT_KEY].SetInt(this->buckets_count);
     return json;

--- a/src/datacell/compressed_graph_datacell_parameter.h
+++ b/src/datacell/compressed_graph_datacell_parameter.h
@@ -24,21 +24,21 @@ DEFINE_POINTER2(CompressedGraphDatacellParam, CompressedGraphDatacellParameter);
 class CompressedGraphDatacellParameter : public GraphInterfaceParameter {
 public:
     CompressedGraphDatacellParameter()
-        : GraphInterfaceParameter(GraphStorageTypes::GRAPH_STORAGE_TYPE_COMPRESSED) {
+        : GraphInterfaceParameter(GraphStorageTypes::GRAPH_STORAGE_TYPE_VALUE_COMPRESSED) {
     }
 
     void
     FromJson(const JsonType& json) override {
-        if (json.Contains(GRAPH_PARAM_MAX_DEGREE)) {
-            this->max_degree_ = json[GRAPH_PARAM_MAX_DEGREE].GetInt();
+        if (json.Contains(GRAPH_PARAM_MAX_DEGREE_KEY)) {
+            this->max_degree_ = json[GRAPH_PARAM_MAX_DEGREE_KEY].GetInt();
         }
     }
 
     JsonType
     ToJson() const override {
         JsonType json;
-        json[GRAPH_PARAM_MAX_DEGREE].SetInt(this->max_degree_);
-        json[GRAPH_STORAGE_TYPE_KEY].SetString(GRAPH_STORAGE_TYPE_COMPRESSED);
+        json[GRAPH_PARAM_MAX_DEGREE_KEY].SetInt(this->max_degree_);
+        json[GRAPH_STORAGE_TYPE_KEY].SetString(GRAPH_STORAGE_TYPE_VALUE_COMPRESSED);
         return json;
     }
 };

--- a/src/datacell/compressed_graph_datacell_test.cpp
+++ b/src/datacell/compressed_graph_datacell_test.cpp
@@ -56,10 +56,11 @@ TEST_CASE("CompressedGraphDataCell Basic Test", "[ut][CompressedGraphDataCell]")
         }}
         )";
 
-    auto param_str = fmt::format(graph_param_temp, max_degree, GRAPH_STORAGE_TYPE_COMPRESSED);
+    auto param_str = fmt::format(graph_param_temp, max_degree, GRAPH_STORAGE_TYPE_VALUE_COMPRESSED);
     auto param_json = JsonType::Parse(param_str);
     auto graph_param = std::make_shared<CompressedGraphDatacellParameter>();
     graph_param->FromJson(param_json);
-    REQUIRE(graph_param->graph_storage_type_ == GraphStorageTypes::GRAPH_STORAGE_TYPE_COMPRESSED);
+    REQUIRE(graph_param->graph_storage_type_ ==
+            GraphStorageTypes::GRAPH_STORAGE_TYPE_VALUE_COMPRESSED);
     TestCompressedGraphDataCell(graph_param, common_param);
 }

--- a/src/datacell/graph_datacell_parameter.cpp
+++ b/src/datacell/graph_datacell_parameter.cpp
@@ -27,11 +27,11 @@ GraphDataCellParameter::FromJson(const JsonType& json) {
     CHECK_ARGUMENT(json.Contains(IO_PARAMS_KEY),
                    fmt::format("graph interface parameters must contains {}", IO_PARAMS_KEY));
     this->io_parameter_ = IOParameter::GetIOParameterByJson(json[IO_PARAMS_KEY]);
-    if (json.Contains(GRAPH_PARAM_MAX_DEGREE)) {
-        this->max_degree_ = json[GRAPH_PARAM_MAX_DEGREE].GetInt();
+    if (json.Contains(GRAPH_PARAM_MAX_DEGREE_KEY)) {
+        this->max_degree_ = json[GRAPH_PARAM_MAX_DEGREE_KEY].GetInt();
     }
-    if (json.Contains(GRAPH_PARAM_INIT_MAX_CAPACITY)) {
-        this->init_max_capacity_ = json[GRAPH_PARAM_INIT_MAX_CAPACITY].GetInt();
+    if (json.Contains(GRAPH_PARAM_INIT_MAX_CAPACITY_KEY)) {
+        this->init_max_capacity_ = json[GRAPH_PARAM_INIT_MAX_CAPACITY_KEY].GetInt();
     }
     if (json.Contains(GRAPH_SUPPORT_REMOVE)) {
         this->support_remove_ = json[GRAPH_SUPPORT_REMOVE].GetBool();
@@ -45,8 +45,8 @@ JsonType
 GraphDataCellParameter::ToJson() const {
     JsonType json;
     json[IO_PARAMS_KEY].SetJson(this->io_parameter_->ToJson());
-    json[GRAPH_PARAM_MAX_DEGREE].SetInt(this->max_degree_);
-    json[GRAPH_PARAM_INIT_MAX_CAPACITY].SetInt(this->init_max_capacity_);
+    json[GRAPH_PARAM_MAX_DEGREE_KEY].SetInt(this->max_degree_);
+    json[GRAPH_PARAM_INIT_MAX_CAPACITY_KEY].SetInt(this->init_max_capacity_);
     json[GRAPH_SUPPORT_REMOVE].SetBool(this->support_remove_);
     json[REMOVE_FLAG_BIT].SetInt(this->remove_flag_bit_);
     return json;

--- a/src/datacell/graph_datacell_parameter.h
+++ b/src/datacell/graph_datacell_parameter.h
@@ -23,7 +23,8 @@ namespace vsag {
 DEFINE_POINTER2(GraphDataCellParam, GraphDataCellParameter);
 class GraphDataCellParameter : public GraphInterfaceParameter {
 public:
-    GraphDataCellParameter() : GraphInterfaceParameter(GraphStorageTypes::GRAPH_STORAGE_TYPE_FLAT) {
+    GraphDataCellParameter()
+        : GraphInterfaceParameter(GraphStorageTypes::GRAPH_STORAGE_TYPE_VALUE_FLAT) {
     }
 
     void

--- a/src/datacell/graph_datacell_test.cpp
+++ b/src/datacell/graph_datacell_test.cpp
@@ -63,7 +63,7 @@ TEST_CASE("GraphDataCell Basic Test", "[ut][GraphDataCell]") {
         fmt::format(graph_param_temp, io_type, max_degree, max_capacity, is_support_delete);
     auto param_json = JsonType::Parse(param_str);
     auto graph_param = GraphInterfaceParameter::GetGraphParameterByJson(
-        GraphStorageTypes::GRAPH_STORAGE_TYPE_FLAT, param_json);
+        GraphStorageTypes::GRAPH_STORAGE_TYPE_VALUE_FLAT, param_json);
     TestGraphDataCell(graph_param, common_param, is_support_delete);
 }
 
@@ -92,7 +92,7 @@ TEST_CASE("GraphDataCell Remove Test", "[ut][GraphDataCell]") {
     auto param_str = fmt::format(graph_param_temp, io_type, max_degree, remove_flag_bit);
     auto param_json = JsonType::Parse(param_str);
     auto graph_param = GraphInterfaceParameter::GetGraphParameterByJson(
-        GraphStorageTypes::GRAPH_STORAGE_TYPE_FLAT, param_json);
+        GraphStorageTypes::GRAPH_STORAGE_TYPE_VALUE_FLAT, param_json);
     TestGraphDataCell(graph_param, common_param, is_support_delete);
 }
 
@@ -122,7 +122,7 @@ TEST_CASE("GraphDataCell Merge", "[ut][GraphDataCell]") {
         fmt::format(graph_param_temp, io_type, max_degree, max_capacity, is_support_delete);
     auto param_json = JsonType::Parse(param_str);
     auto graph_param = GraphInterfaceParameter::GetGraphParameterByJson(
-        GraphStorageTypes::GRAPH_STORAGE_TYPE_FLAT, param_json);
+        GraphStorageTypes::GRAPH_STORAGE_TYPE_VALUE_FLAT, param_json);
 
     auto graph = GraphInterface::MakeInstance(graph_param, common_param);
     GraphInterfaceTest test(graph);

--- a/src/datacell/graph_interface.cpp
+++ b/src/datacell/graph_interface.cpp
@@ -28,9 +28,9 @@ GraphInterface::MakeInstance(const GraphInterfaceParamPtr& graph_param,
     switch (graph_param->graph_storage_type_) {
         case GraphStorageTypes::GRAPH_STORAGE_TYPE_SPARSE:
             return std::make_shared<SparseGraphDataCell>(graph_param, common_param);
-        case GraphStorageTypes::GRAPH_STORAGE_TYPE_COMPRESSED:
+        case GraphStorageTypes::GRAPH_STORAGE_TYPE_VALUE_COMPRESSED:
             return std::make_shared<CompressedGraphDataCell>(graph_param, common_param);
-        case GraphStorageTypes::GRAPH_STORAGE_TYPE_FLAT:
+        case GraphStorageTypes::GRAPH_STORAGE_TYPE_VALUE_FLAT:
             auto io_string = std::dynamic_pointer_cast<GraphDataCellParameter>(graph_param)
                                  ->io_parameter_->GetTypeName();
             if (io_string == IO_TYPE_VALUE_BLOCK_MEMORY_IO) {

--- a/src/datacell/graph_interface_parameter.cpp
+++ b/src/datacell/graph_interface_parameter.cpp
@@ -25,10 +25,10 @@ GraphInterfaceParameter::GetGraphParameterByJson(GraphStorageTypes graph_type,
                                                  const JsonType& json) {
     GraphInterfaceParamPtr param{nullptr};
     switch (graph_type) {
-        case GraphStorageTypes::GRAPH_STORAGE_TYPE_FLAT:
+        case GraphStorageTypes::GRAPH_STORAGE_TYPE_VALUE_FLAT:
             param = std::make_shared<GraphDataCellParameter>();
             break;
-        case GraphStorageTypes::GRAPH_STORAGE_TYPE_COMPRESSED:
+        case GraphStorageTypes::GRAPH_STORAGE_TYPE_VALUE_COMPRESSED:
             param = std::make_shared<CompressedGraphDatacellParameter>();
             break;
         case GraphStorageTypes::GRAPH_STORAGE_TYPE_SPARSE:

--- a/src/datacell/graph_interface_parameter.h
+++ b/src/datacell/graph_interface_parameter.h
@@ -21,8 +21,8 @@ namespace vsag {
 DEFINE_POINTER2(GraphInterfaceParam, GraphInterfaceParameter);
 
 enum class GraphStorageTypes {
-    GRAPH_STORAGE_TYPE_FLAT = 0,
-    GRAPH_STORAGE_TYPE_COMPRESSED = 1,
+    GRAPH_STORAGE_TYPE_VALUE_FLAT = 0,
+    GRAPH_STORAGE_TYPE_VALUE_COMPRESSED = 1,
     GRAPH_STORAGE_TYPE_SPARSE = 2
 };
 
@@ -32,7 +32,7 @@ public:
     GetGraphParameterByJson(GraphStorageTypes graph_type, const JsonType& json);
 
 public:
-    GraphStorageTypes graph_storage_type_{GraphStorageTypes::GRAPH_STORAGE_TYPE_FLAT};
+    GraphStorageTypes graph_storage_type_{GraphStorageTypes::GRAPH_STORAGE_TYPE_VALUE_FLAT};
 
     uint64_t max_degree_{64};
 

--- a/src/datacell/sparse_graph_datacell_parameter.cpp
+++ b/src/datacell/sparse_graph_datacell_parameter.cpp
@@ -24,8 +24,8 @@ SparseGraphDatacellParameter::SparseGraphDatacellParameter()
 
 void
 SparseGraphDatacellParameter::FromJson(const JsonType& json) {
-    if (json.Contains(GRAPH_PARAM_MAX_DEGREE)) {
-        this->max_degree_ = json[GRAPH_PARAM_MAX_DEGREE].GetInt();
+    if (json.Contains(GRAPH_PARAM_MAX_DEGREE_KEY)) {
+        this->max_degree_ = json[GRAPH_PARAM_MAX_DEGREE_KEY].GetInt();
     }
     if (json.Contains(GRAPH_SUPPORT_REMOVE)) {
         this->support_delete_ = json[GRAPH_SUPPORT_REMOVE].GetBool();
@@ -38,7 +38,7 @@ SparseGraphDatacellParameter::FromJson(const JsonType& json) {
 JsonType
 SparseGraphDatacellParameter::ToJson() const {
     JsonType json;
-    json[GRAPH_PARAM_MAX_DEGREE].SetInt(this->max_degree_);
+    json[GRAPH_PARAM_MAX_DEGREE_KEY].SetInt(this->max_degree_);
     json[GRAPH_SUPPORT_REMOVE].SetBool(this->support_delete_);
     json[REMOVE_FLAG_BIT].SetInt(this->remove_flag_bit_);
     return json;

--- a/src/impl/odescent/odescent_graph_builder_test.cpp
+++ b/src/impl/odescent/odescent_graph_builder_test.cpp
@@ -95,7 +95,7 @@ TEST_CASE("ODescent Build Test", "[ut][ODescent]") {
 
     // prepare graph param
     auto graph_type = partial_data ? vsag::GraphStorageTypes::GRAPH_STORAGE_TYPE_SPARSE
-                                   : vsag::GraphStorageTypes::GRAPH_STORAGE_TYPE_FLAT;
+                                   : vsag::GraphStorageTypes::GRAPH_STORAGE_TYPE_VALUE_FLAT;
     vsag::GraphInterfaceParamPtr graph_param_ptr =
         vsag::GraphInterfaceParameter::GetGraphParameterByJson(graph_type, graph_param_json);
     // build graph

--- a/src/impl/transform/vector_transformer_parameter.cpp
+++ b/src/impl/transform/vector_transformer_parameter.cpp
@@ -21,20 +21,20 @@ namespace vsag {
 
 void
 VectorTransformerParameter::FromJson(const JsonType& json) {
-    if (json.Contains(INPUT_DIM)) {
-        input_dim_ = json[INPUT_DIM].GetInt();
+    if (json.Contains(INPUT_DIM_KEY)) {
+        input_dim_ = json[INPUT_DIM_KEY].GetInt();
     }
 
-    if (json.Contains(PCA_DIM)) {
-        pca_dim_ = json[PCA_DIM].GetInt();
+    if (json.Contains(PCA_DIM_KEY)) {
+        pca_dim_ = json[PCA_DIM_KEY].GetInt();
     }
 }
 
 JsonType
 VectorTransformerParameter::ToJson() const {
     JsonType json;
-    json[PCA_DIM].SetInt(pca_dim_);
-    json[INPUT_DIM].SetInt(input_dim_);
+    json[PCA_DIM_KEY].SetInt(pca_dim_);
+    json[INPUT_DIM_KEY].SetInt(input_dim_);
     return json;
 }
 

--- a/src/inner_string_params.h
+++ b/src/inner_string_params.h
@@ -31,6 +31,7 @@ const char* const USE_REORDER_KEY = "use_reorder";
 const char* const EXTRA_INFO_KEY = "extra_info";
 const char* const USE_ATTRIBUTE_FILTER_KEY = "use_attribute_filter";
 const char* const BUILD_THREAD_COUNT_KEY = "build_thread_count";
+const char* const BASE_CODES_KEY = "base_codes";
 const char* const PRECISE_CODES_KEY = "precise_codes";
 const char* const STORE_RAW_VECTOR_KEY = "store_raw_vector";
 const char* const RAW_VECTOR_KEY = "raw_vector";
@@ -42,14 +43,11 @@ const char* const HGRAPH_USE_ELP_OPTIMIZER_KEY = "use_elp_optimizer";
 const char* const HGRAPH_IGNORE_REORDER_KEY = "ignore_reorder";
 const char* const HGRAPH_BUILD_BY_BASE_QUANTIZATION_KEY = "build_by_base";
 const char* const HGRAPH_GRAPH_KEY = "graph";
-const char* const HGRAPH_BASE_CODES_KEY = "base_codes";
 const char* const HGRAPH_EF_CONSTRUCTION_KEY = "ef_construction";
 const char* const HGRAPH_ALPHA_KEY = "alpha";
 
 // IO param key
 const char* const IO_PARAMS_KEY = "io_params";
-// IO type
-const char* const IO_TYPE_KEY = "type";
 const char* const IO_TYPE_VALUE_MEMORY_IO = "memory_io";
 const char* const IO_TYPE_VALUE_BUFFER_IO = "buffer_io";
 const char* const IO_TYPE_VALUE_MMAP_IO = "mmap_io";
@@ -57,13 +55,14 @@ const char* const IO_TYPE_VALUE_READER_IO = "reader_io";
 const char* const IO_TYPE_VALUE_ASYNC_IO = "async_io";
 const char* const IO_TYPE_VALUE_BLOCK_MEMORY_IO = "block_memory_io";
 const char* const BLOCK_IO_BLOCK_SIZE_KEY = "block_size";
-const char* const IO_FILE_PATH = "file_path";
+
+// IO param for file
+const char* const IO_FILE_PATH_KEY = "file_path";
 const char* const DEFAULT_FILE_PATH_VALUE = "./default_file_path";
 
 // quantization params key
 const char* const QUANTIZATION_PARAMS_KEY = "quantization_params";
 // quantization type
-const char* const QUANTIZATION_TYPE_KEY = "type";
 const char* const QUANTIZATION_TYPE_VALUE_SQ8 = "sq8";
 const char* const QUANTIZATION_TYPE_VALUE_SQ8_UNIFORM = "sq8_uniform";
 const char* const QUANTIZATION_TYPE_VALUE_SQ4 = "sq4";
@@ -86,16 +85,16 @@ const char* const TRANSFORMER_TYPE_VALUE_RESIDUAL = "residual";
 const char* const TRANSFORMER_TYPE_VALUE_NORMALIZE = "normalize";
 
 // vector transformer param
-const char* const INPUT_DIM = "input_dim";
-const char* const PCA_DIM = "pca_dim";
-const char* const USE_FHT = "use_fht";
+const char* const INPUT_DIM_KEY = "input_dim";
+const char* const PCA_DIM_KEY = "pca_dim";
+const char* const USE_FHT_KEY = "use_fht";
 
 // quantization param
-const char* const TQ_CHAIN = "tq_chain";
-const char* const RABITQ_QUANTIZATION_BITS_PER_DIM_QUERY = "rabitq_bits_per_dim_query";
-const char* const SQ4_UNIFORM_QUANTIZATION_TRUNC_RATE = "sq4_uniform_trunc_rate";
-const char* const PRODUCT_QUANTIZATION_DIM = "pq_dim";
-const char* const PRODUCT_QUANTIZATION_BITS = "pq_bits";
+const char* const TQ_CHAIN_KEY = "tq_chain";
+const char* const RABITQ_QUANTIZATION_BITS_PER_DIM_QUERY_KEY = "rabitq_bits_per_dim_query";
+const char* const SQ4_UNIFORM_QUANTIZATION_TRUNC_RATE_KEY = "sq4_uniform_trunc_rate";
+const char* const PRODUCT_QUANTIZATION_DIM_KEY = "pq_dim";
+const char* const PRODUCT_QUANTIZATION_BITS_KEY = "pq_bits";
 
 // sparse index param
 const char* const SPARSE_NEED_SORT = "need_sort";
@@ -104,30 +103,25 @@ const char* const SPARSE_DOC_PRUNE_RATIO = "doc_prune_ratio";
 const char* const SPARSE_TERM_PRUNE_RATIO = "term_prune_ratio";
 const char* const SPARSE_TERM_ID_LIMIT = "term_id_limit";
 const char* const SPARSE_WINDOW_SIZE = "window_size";
-const char* const SPARSE_USE_REORDER = "use_reorder";
-const char* const SPARSE_N_CANDIDATE = "n_candidate";
 const char* const SPARSE_DESERIALIZE_WITHOUT_FOOTER = "deserialize_without_footer";
 
 // graph param value
-const char* const GRAPH_PARAM_MAX_DEGREE = "max_degree";
-const char* const GRAPH_PARAM_INIT_MAX_CAPACITY = "init_capacity";
+const char* const GRAPH_PARAM_MAX_DEGREE_KEY = "max_degree";
+const char* const GRAPH_PARAM_INIT_MAX_CAPACITY_KEY = "init_capacity";
 
 const char* const GRAPH_TYPE_KEY = "graph_type";
+const char* const GRAPH_TYPE_VALUE_ODESCENT = "odescent";
+const char* const GRAPH_TYPE_VALUE_NSW = "nsw";
 
 const char* const GRAPH_STORAGE_TYPE_KEY = "graph_storage_type";
-const char* const GRAPH_STORAGE_TYPE_COMPRESSED = "compressed";
-const char* const GRAPH_STORAGE_TYPE_FLAT = "flat";
+const char* const GRAPH_STORAGE_TYPE_VALUE_COMPRESSED = "compressed";
+const char* const GRAPH_STORAGE_TYPE_VALUE_FLAT = "flat";
 
+// bucket params for IVF index
 const char* const BUCKET_PARAMS_KEY = "buckets_params";
 const char* const BUCKET_PER_DATA_KEY = "buckets_per_data";
-const char* const NO_BUILD_LEVELS = "no_build_levels";
-
 const char* const BUCKETS_COUNT_KEY = "buckets_count";
-const char* const BUCKET_USE_RESIDUAL = "use_residual";
-const char* const IVF_SEARCH_PARAM_SCAN_BUCKETS_COUNT = "scan_buckets_count";
-const char* const SEARCH_PARAM_FACTOR = "factor";
-const char* const SEARCH_PARALLELISM = "parallelism";
-const char* const SEARCH_MAX_TIME_COST_MS = "timeout_ms";
+const char* const BUCKET_USE_RESIDUAL_KEY = "use_residual";
 
 const char* const IVF_TRAIN_TYPE_KEY = "ivf_train_type";
 const char* const IVF_TRAIN_TYPE_RANDOM = "random";
@@ -145,6 +139,9 @@ const char* const GNO_IMI_SEARCH_PARAM_FIRST_ORDER_SCAN_RATIO = "first_order_sca
 const char* const FLATTEN_DATA_CELL = "flatten_data_cell";
 const char* const SPARSE_VECTOR_DATA_CELL = "sparse_vector_data_cell";
 
+// for pyramid index
+const char* const NO_BUILD_LEVELS = "no_build_levels";
+
 const char* const GRAPH_SUPPORT_REMOVE = "support_remove";
 const char* const REMOVE_FLAG_BIT = "remove_flag_bit";
 const char* const HOLD_MOLDS = "hold_molds";
@@ -154,57 +151,65 @@ const char* const SUPPORT_TOMBSTONE = "support_tombstone";
 const char* const DATACELL_OFFSETS = "datacell_offsets";
 const char* const DATACELL_SIZES = "datacell_sizes";
 const char* const BASIC_INFO = "basic_info";
-const char* const INDEX_TYPE = "type";
 
 const char* const CODES_TYPE_KEY = "codes_type";
 const char* const FLATTEN_CODES = "flatten";
 const char* const SPARSE_CODES = "sparse";
 
+const char* const IVF_SEARCH_PARAM_SCAN_BUCKETS_COUNT = "scan_buckets_count";
+const char* const SEARCH_PARAM_FACTOR = "factor";
+const char* const SEARCH_PARALLELISM = "parallelism";
+const char* const SEARCH_MAX_TIME_COST_MS = "timeout_ms";
+const char* const SPARSE_N_CANDIDATE = "n_candidate";
+
 const std::unordered_map<std::string, std::string> DEFAULT_MAP = {
     {"INDEX_TYPE_HGRAPH", INDEX_TYPE_HGRAPH},
     {"INDEX_TYPE_IVF", INDEX_TYPE_IVF},
     {"INDEX_TYPE_GNO_IMI", INDEX_TYPE_GNO_IMI},
+    {"TYPE_KEY", TYPE_KEY},
     {"HGRAPH_USE_ELP_OPTIMIZER_KEY", HGRAPH_USE_ELP_OPTIMIZER_KEY},
     {"HGRAPH_IGNORE_REORDER_KEY", HGRAPH_IGNORE_REORDER_KEY},
     {"HGRAPH_BUILD_BY_BASE_QUANTIZATION_KEY", HGRAPH_BUILD_BY_BASE_QUANTIZATION_KEY},
     {"HGRAPH_GRAPH_KEY", HGRAPH_GRAPH_KEY},
-    {"HGRAPH_BASE_CODES_KEY", HGRAPH_BASE_CODES_KEY},
+    {"BASE_CODES_KEY", BASE_CODES_KEY},
     {"PRECISE_CODES_KEY", PRECISE_CODES_KEY},
     {"HGRAPH_SUPPORT_DUPLICATE", HGRAPH_SUPPORT_DUPLICATE},
-    {"IO_TYPE_KEY", IO_TYPE_KEY},
     {"IO_TYPE_VALUE_MEMORY_IO", IO_TYPE_VALUE_MEMORY_IO},
     {"IO_TYPE_VALUE_BLOCK_MEMORY_IO", IO_TYPE_VALUE_BLOCK_MEMORY_IO},
     {"IO_TYPE_VALUE_BUFFER_IO", IO_TYPE_VALUE_BUFFER_IO},
     {"IO_PARAMS_KEY", IO_PARAMS_KEY},
     {"BLOCK_IO_BLOCK_SIZE_KEY", BLOCK_IO_BLOCK_SIZE_KEY},
-    {"QUANTIZATION_TYPE_KEY", QUANTIZATION_TYPE_KEY},
     {"QUANTIZATION_TYPE_VALUE_SQ8", QUANTIZATION_TYPE_VALUE_SQ8},
+    {"QUANTIZATION_TYPE_VALUE_SQ8_UNIFORM", QUANTIZATION_TYPE_VALUE_SQ8_UNIFORM},
+    {"QUANTIZATION_TYPE_VALUE_SQ4", QUANTIZATION_TYPE_VALUE_SQ4},
+    {"QUANTIZATION_TYPE_VALUE_SQ4_UNIFORM", QUANTIZATION_TYPE_VALUE_SQ4_UNIFORM},
     {"QUANTIZATION_TYPE_VALUE_FP32", QUANTIZATION_TYPE_VALUE_FP32},
     {"QUANTIZATION_TYPE_VALUE_PQ", QUANTIZATION_TYPE_VALUE_PQ},
     {"QUANTIZATION_TYPE_VALUE_PQFS", QUANTIZATION_TYPE_VALUE_PQFS},
     {"QUANTIZATION_TYPE_VALUE_FP16", QUANTIZATION_TYPE_VALUE_FP16},
     {"QUANTIZATION_TYPE_VALUE_BF16", QUANTIZATION_TYPE_VALUE_BF16},
     {"QUANTIZATION_TYPE_VALUE_RABITQ", QUANTIZATION_TYPE_VALUE_RABITQ},
-    {"PRODUCT_QUANTIZATION_DIM", PRODUCT_QUANTIZATION_DIM},
-    {"PRODUCT_QUANTIZATION_BITS", PRODUCT_QUANTIZATION_BITS},
-    {"GRAPH_TYPE_NSW", GRAPH_TYPE_NSW},
+    {"PRODUCT_QUANTIZATION_DIM_KEY", PRODUCT_QUANTIZATION_DIM_KEY},
+    {"PRODUCT_QUANTIZATION_BITS_KEY", PRODUCT_QUANTIZATION_BITS_KEY},
+    {"GRAPH_TYPE_VALUE_NSW", GRAPH_TYPE_VALUE_NSW},
+    {"GRAPH_TYPE_VALUE_ODESCENT", GRAPH_TYPE_VALUE_ODESCENT},
     {"GRAPH_STORAGE_TYPE_KEY", GRAPH_STORAGE_TYPE_KEY},
-    {"GRAPH_STORAGE_TYPE_FLAT", GRAPH_STORAGE_TYPE_FLAT},
-    {"GRAPH_STORAGE_TYPE_COMPRESSED", GRAPH_STORAGE_TYPE_COMPRESSED},
+    {"GRAPH_STORAGE_TYPE_VALUE_FLAT", GRAPH_STORAGE_TYPE_VALUE_FLAT},
+    {"GRAPH_STORAGE_TYPE_VALUE_COMPRESSED", GRAPH_STORAGE_TYPE_VALUE_COMPRESSED},
     {"QUANTIZATION_PARAMS_KEY", QUANTIZATION_PARAMS_KEY},
-    {"GRAPH_PARAM_MAX_DEGREE", GRAPH_PARAM_MAX_DEGREE},
-    {"GRAPH_PARAM_INIT_MAX_CAPACITY", GRAPH_PARAM_INIT_MAX_CAPACITY},
+    {"GRAPH_PARAM_MAX_DEGREE_KEY", GRAPH_PARAM_MAX_DEGREE_KEY},
+    {"GRAPH_PARAM_INIT_MAX_CAPACITY_KEY", GRAPH_PARAM_INIT_MAX_CAPACITY_KEY},
     {"HGRAPH_EF_CONSTRUCTION_KEY", HGRAPH_EF_CONSTRUCTION_KEY},
     {"HGRAPH_ALPHA_KEY", HGRAPH_ALPHA_KEY},
     {"BUCKETS_COUNT_KEY", BUCKETS_COUNT_KEY},
     {"BUCKET_PARAMS_KEY", BUCKET_PARAMS_KEY},
-    {"IO_FILE_PATH", IO_FILE_PATH},
+    {"IO_FILE_PATH_KEY", IO_FILE_PATH_KEY},
     {"DEFAULT_FILE_PATH_VALUE", DEFAULT_FILE_PATH_VALUE},
     {"PRECISE_CODES_KEY", PRECISE_CODES_KEY},
     {"USE_REORDER_KEY", USE_REORDER_KEY},
     {"USE_ATTRIBUTE_FILTER_KEY", USE_ATTRIBUTE_FILTER_KEY},
-    {"SQ4_UNIFORM_QUANTIZATION_TRUNC_RATE", SQ4_UNIFORM_QUANTIZATION_TRUNC_RATE},
-    {"PCA_DIM", PCA_DIM},
+    {"SQ4_UNIFORM_QUANTIZATION_TRUNC_RATE_KEY", SQ4_UNIFORM_QUANTIZATION_TRUNC_RATE_KEY},
+    {"PCA_DIM_KEY", PCA_DIM_KEY},
     {"IVF_SEARCH_PARAM_SCAN_BUCKETS_COUNT", IVF_SEARCH_PARAM_SCAN_BUCKETS_COUNT},
     {"GNO_IMI_FIRST_ORDER_BUCKETS_COUNT_KEY", GNO_IMI_FIRST_ORDER_BUCKETS_COUNT_KEY},
     {"GNO_IMI_SECOND_ORDER_BUCKETS_COUNT_KEY", GNO_IMI_SECOND_ORDER_BUCKETS_COUNT_KEY},
@@ -215,6 +220,7 @@ const std::unordered_map<std::string, std::string> DEFAULT_MAP = {
     {"ODESCENT_PARAMETER_GRAPH_ITER_TURN", ODESCENT_PARAMETER_GRAPH_ITER_TURN},
     {"ODESCENT_PARAMETER_NEIGHBOR_SAMPLE_RATE", ODESCENT_PARAMETER_NEIGHBOR_SAMPLE_RATE},
     {"EXTRA_INFO_KEY", EXTRA_INFO_KEY},
+    {"CODES_TYPE_KEY", CODES_TYPE_KEY},
     {"SEARCH_PARAM_FACTOR", SEARCH_PARAM_FACTOR},
     {"BUCKET_PER_DATA_KEY", BUCKET_PER_DATA_KEY},
     {"IVF_PARTITION_STRATEGY_PARAMS_KEY", IVF_PARTITION_STRATEGY_PARAMS_KEY},
@@ -231,7 +237,7 @@ const std::unordered_map<std::string, std::string> DEFAULT_MAP = {
     {"RAW_VECTOR_KEY", RAW_VECTOR_KEY},
     {"ATTR_HAS_BUCKETS_KEY", ATTR_HAS_BUCKETS_KEY},
     {"ATTR_PARAMS_KEY", ATTR_PARAMS_KEY},
-    {"RABITQ_QUANTIZATION_BITS_PER_DIM_QUERY", RABITQ_QUANTIZATION_BITS_PER_DIM_QUERY},
-    {"TQ_CHAIN", TQ_CHAIN}};
+    {"RABITQ_QUANTIZATION_BITS_PER_DIM_QUERY_KEY", RABITQ_QUANTIZATION_BITS_PER_DIM_QUERY_KEY},
+    {"TQ_CHAIN_KEY", TQ_CHAIN_KEY}};
 
 }  // namespace vsag

--- a/src/io/async_io_parameter.cpp
+++ b/src/io/async_io_parameter.cpp
@@ -29,15 +29,15 @@ AsyncIOParameter::AsyncIOParameter(const vsag::JsonType& json)
 
 void
 AsyncIOParameter::FromJson(const JsonType& json) {
-    CHECK_ARGUMENT(json.Contains(IO_FILE_PATH), "miss file_path param in async io type");
-    this->path_ = json[IO_FILE_PATH].GetString();
+    CHECK_ARGUMENT(json.Contains(IO_FILE_PATH_KEY), "miss file_path param in async io type");
+    this->path_ = json[IO_FILE_PATH_KEY].GetString();
 }
 
 JsonType
 AsyncIOParameter::ToJson() const {
     JsonType json;
-    json[IO_TYPE_KEY].SetString(IO_TYPE_VALUE_ASYNC_IO);
-    json[IO_FILE_PATH].SetString(this->path_);
+    json[TYPE_KEY].SetString(IO_TYPE_VALUE_ASYNC_IO);
+    json[IO_FILE_PATH_KEY].SetString(this->path_);
     return json;
 }
 }  // namespace vsag

--- a/src/io/buffer_io_parameter.cpp
+++ b/src/io/buffer_io_parameter.cpp
@@ -29,15 +29,15 @@ BufferIOParameter::BufferIOParameter(const vsag::JsonType& json)
 
 void
 BufferIOParameter::FromJson(const JsonType& json) {
-    CHECK_ARGUMENT(json.Contains(IO_FILE_PATH), "miss file_path param in buffer io type");
-    this->path_ = json[IO_FILE_PATH].GetString();
+    CHECK_ARGUMENT(json.Contains(IO_FILE_PATH_KEY), "miss file_path param in buffer io type");
+    this->path_ = json[IO_FILE_PATH_KEY].GetString();
 }
 
 JsonType
 BufferIOParameter::ToJson() const {
     JsonType json;
-    json[IO_TYPE_KEY].SetString(IO_TYPE_VALUE_BUFFER_IO);
-    json[IO_FILE_PATH].SetString(this->path_);
+    json[TYPE_KEY].SetString(IO_TYPE_VALUE_BUFFER_IO);
+    json[IO_FILE_PATH_KEY].SetString(this->path_);
     return json;
 }
 }  // namespace vsag

--- a/src/io/memory_block_io_parameter.cpp
+++ b/src/io/memory_block_io_parameter.cpp
@@ -37,7 +37,7 @@ MemoryBlockIOParameter::FromJson(const JsonType& json) {
 JsonType
 MemoryBlockIOParameter::ToJson() const {
     JsonType json;
-    json[IO_TYPE_KEY].SetString(IO_TYPE_VALUE_BLOCK_MEMORY_IO);
+    json[TYPE_KEY].SetString(IO_TYPE_VALUE_BLOCK_MEMORY_IO);
     return json;
 }
 

--- a/src/io/memory_io_parameter.cpp
+++ b/src/io/memory_io_parameter.cpp
@@ -34,7 +34,7 @@ MemoryIOParameter::FromJson(const JsonType& json) {
 JsonType
 MemoryIOParameter::ToJson() const {
     JsonType json;
-    json[IO_TYPE_KEY].SetString(IO_TYPE_VALUE_MEMORY_IO);
+    json[TYPE_KEY].SetString(IO_TYPE_VALUE_MEMORY_IO);
     return json;
 }
 }  // namespace vsag

--- a/src/io/mmap_io_parameter.cpp
+++ b/src/io/mmap_io_parameter.cpp
@@ -28,15 +28,15 @@ MMapIOParameter::MMapIOParameter(const vsag::JsonType& json) : IOParameter(IO_TY
 
 void
 MMapIOParameter::FromJson(const JsonType& json) {
-    CHECK_ARGUMENT(json.Contains(IO_FILE_PATH), "miss file_path param in mmap io type");
-    this->path_ = json[IO_FILE_PATH].GetString();
+    CHECK_ARGUMENT(json.Contains(IO_FILE_PATH_KEY), "miss file_path param in mmap io type");
+    this->path_ = json[IO_FILE_PATH_KEY].GetString();
 }
 
 JsonType
 MMapIOParameter::ToJson() const {
     JsonType json;
-    json[IO_TYPE_KEY].SetString(IO_TYPE_VALUE_MMAP_IO);
-    json[IO_FILE_PATH].SetString(this->path_);
+    json[TYPE_KEY].SetString(IO_TYPE_VALUE_MMAP_IO);
+    json[IO_FILE_PATH_KEY].SetString(this->path_);
     return json;
 }
 }  // namespace vsag

--- a/src/quantization/fp32_quantizer_parameter.cpp
+++ b/src/quantization/fp32_quantizer_parameter.cpp
@@ -32,7 +32,7 @@ FP32QuantizerParameter::FromJson(const JsonType& json) {
 JsonType
 FP32QuantizerParameter::ToJson() const {
     JsonType json;
-    json[QUANTIZATION_TYPE_KEY].SetString(QUANTIZATION_TYPE_VALUE_FP32);
+    json[TYPE_KEY].SetString(QUANTIZATION_TYPE_VALUE_FP32);
     return json;
 }
 }  // namespace vsag

--- a/src/quantization/int8_quantizer_parameter.cpp
+++ b/src/quantization/int8_quantizer_parameter.cpp
@@ -32,7 +32,7 @@ INT8QuantizerParameter::FromJson(const JsonType& json) {
 JsonType
 INT8QuantizerParameter::ToJson() const {
     JsonType json;
-    json[QUANTIZATION_TYPE_KEY].SetString(QUANTIZATION_TYPE_VALUE_INT8);
+    json[TYPE_KEY].SetString(QUANTIZATION_TYPE_VALUE_INT8);
     return json;
 }
 }  // namespace vsag

--- a/src/quantization/product_quantization/pq_fastscan_quantizer_parameter.cpp
+++ b/src/quantization/product_quantization/pq_fastscan_quantizer_parameter.cpp
@@ -26,17 +26,17 @@ PQFastScanQuantizerParameter::PQFastScanQuantizerParameter()
 
 void
 PQFastScanQuantizerParameter::FromJson(const JsonType& json) {
-    if (json.Contains(PRODUCT_QUANTIZATION_DIM) &&
-        json[PRODUCT_QUANTIZATION_DIM].IsNumberInteger()) {
-        this->pq_dim_ = json[PRODUCT_QUANTIZATION_DIM].GetInt();
+    if (json.Contains(PRODUCT_QUANTIZATION_DIM_KEY) &&
+        json[PRODUCT_QUANTIZATION_DIM_KEY].IsNumberInteger()) {
+        this->pq_dim_ = json[PRODUCT_QUANTIZATION_DIM_KEY].GetInt();
     }
 }
 
 JsonType
 PQFastScanQuantizerParameter::ToJson() const {
     JsonType json;
-    json[QUANTIZATION_TYPE_KEY].SetString(QUANTIZATION_TYPE_VALUE_PQFS);
-    json[PRODUCT_QUANTIZATION_DIM].SetInt(this->pq_dim_);
+    json[TYPE_KEY].SetString(QUANTIZATION_TYPE_VALUE_PQFS);
+    json[PRODUCT_QUANTIZATION_DIM_KEY].SetInt(this->pq_dim_);
     return json;
 }
 

--- a/src/quantization/product_quantization/product_quantizer_parameter.cpp
+++ b/src/quantization/product_quantization/product_quantizer_parameter.cpp
@@ -26,23 +26,23 @@ ProductQuantizerParameter::ProductQuantizerParameter()
 
 void
 ProductQuantizerParameter::FromJson(const JsonType& json) {
-    if (json.Contains(PRODUCT_QUANTIZATION_DIM) &&
-        json[PRODUCT_QUANTIZATION_DIM].IsNumberInteger()) {
-        this->pq_dim_ = json[PRODUCT_QUANTIZATION_DIM].GetInt();
+    if (json.Contains(PRODUCT_QUANTIZATION_DIM_KEY) &&
+        json[PRODUCT_QUANTIZATION_DIM_KEY].IsNumberInteger()) {
+        this->pq_dim_ = json[PRODUCT_QUANTIZATION_DIM_KEY].GetInt();
     }
 
-    if (json.Contains(PRODUCT_QUANTIZATION_BITS) &&
-        json[PRODUCT_QUANTIZATION_BITS].IsNumberInteger()) {
-        this->pq_bits_ = json[PRODUCT_QUANTIZATION_BITS].GetInt();
+    if (json.Contains(PRODUCT_QUANTIZATION_BITS_KEY) &&
+        json[PRODUCT_QUANTIZATION_BITS_KEY].IsNumberInteger()) {
+        this->pq_bits_ = json[PRODUCT_QUANTIZATION_BITS_KEY].GetInt();
     }
 }
 
 JsonType
 ProductQuantizerParameter::ToJson() const {
     JsonType json;
-    json[QUANTIZATION_TYPE_KEY].SetString(QUANTIZATION_TYPE_VALUE_PQ);
-    json[PRODUCT_QUANTIZATION_DIM].SetInt(this->pq_dim_);
-    json[PRODUCT_QUANTIZATION_BITS].SetInt(this->pq_bits_);
+    json[TYPE_KEY].SetString(QUANTIZATION_TYPE_VALUE_PQ);
+    json[PRODUCT_QUANTIZATION_DIM_KEY].SetInt(this->pq_dim_);
+    json[PRODUCT_QUANTIZATION_BITS_KEY].SetInt(this->pq_bits_);
     return json;
 }
 

--- a/src/quantization/quantizer_adapter_test.cpp
+++ b/src/quantization/quantizer_adapter_test.cpp
@@ -72,7 +72,7 @@ CreateQuantizerParam(const QuantizerType& quantization_type, uint64_t dim) {
     switch (quantization_type) {
         case QuantizerType::QUANTIZER_TYPE_PQ: {
             JsonType params;
-            params[PRODUCT_QUANTIZATION_DIM].SetInt(dim);
+            params[PRODUCT_QUANTIZATION_DIM_KEY].SetInt(dim);
             auto pq_param = std::make_shared<ProductQuantizerParameter>();
             pq_param->FromJson(params);
             return pq_param;

--- a/src/quantization/rabitq_quantization/rabitq_quantizer_parameter.cpp
+++ b/src/quantization/rabitq_quantization/rabitq_quantizer_parameter.cpp
@@ -26,24 +26,24 @@ RaBitQuantizerParameter::RaBitQuantizerParameter()
 
 void
 RaBitQuantizerParameter::FromJson(const JsonType& json) {
-    if (json.Contains(PCA_DIM)) {
-        this->pca_dim_ = json[PCA_DIM].GetInt();
+    if (json.Contains(PCA_DIM_KEY)) {
+        this->pca_dim_ = json[PCA_DIM_KEY].GetInt();
     }
-    if (json.Contains(RABITQ_QUANTIZATION_BITS_PER_DIM_QUERY)) {
-        this->num_bits_per_dim_query_ = json[RABITQ_QUANTIZATION_BITS_PER_DIM_QUERY].GetInt();
+    if (json.Contains(RABITQ_QUANTIZATION_BITS_PER_DIM_QUERY_KEY)) {
+        this->num_bits_per_dim_query_ = json[RABITQ_QUANTIZATION_BITS_PER_DIM_QUERY_KEY].GetInt();
     }
-    if (json.Contains(USE_FHT)) {
-        this->use_fht_ = json[USE_FHT].GetBool();
+    if (json.Contains(USE_FHT_KEY)) {
+        this->use_fht_ = json[USE_FHT_KEY].GetBool();
     }
 }
 
 JsonType
 RaBitQuantizerParameter::ToJson() const {
     JsonType json;
-    json[QUANTIZATION_TYPE_KEY].SetString(QUANTIZATION_TYPE_VALUE_RABITQ);
-    json[PCA_DIM].SetInt(this->pca_dim_);
-    json[RABITQ_QUANTIZATION_BITS_PER_DIM_QUERY].SetInt(this->num_bits_per_dim_query_);
-    json[USE_FHT].SetBool(this->use_fht_);
+    json[TYPE_KEY].SetString(QUANTIZATION_TYPE_VALUE_RABITQ);
+    json[PCA_DIM_KEY].SetInt(this->pca_dim_);
+    json[RABITQ_QUANTIZATION_BITS_PER_DIM_QUERY_KEY].SetInt(this->num_bits_per_dim_query_);
+    json[USE_FHT_KEY].SetBool(this->use_fht_);
     return json;
 }
 

--- a/src/quantization/scalar_quantization/bf16_quantizer_parameter.cpp
+++ b/src/quantization/scalar_quantization/bf16_quantizer_parameter.cpp
@@ -30,7 +30,7 @@ BF16QuantizerParameter::FromJson(const JsonType& json) {
 JsonType
 BF16QuantizerParameter::ToJson() const {
     JsonType json;
-    json[QUANTIZATION_TYPE_KEY].SetString(QUANTIZATION_TYPE_VALUE_BF16);
+    json[TYPE_KEY].SetString(QUANTIZATION_TYPE_VALUE_BF16);
     return json;
 }
 }  // namespace vsag

--- a/src/quantization/scalar_quantization/fp16_quantizer_parameter.cpp
+++ b/src/quantization/scalar_quantization/fp16_quantizer_parameter.cpp
@@ -30,7 +30,7 @@ FP16QuantizerParameter::FromJson(const JsonType& json) {
 JsonType
 FP16QuantizerParameter::ToJson() const {
     JsonType json;
-    json[QUANTIZATION_TYPE_KEY].SetString(QUANTIZATION_TYPE_VALUE_FP16);
+    json[TYPE_KEY].SetString(QUANTIZATION_TYPE_VALUE_FP16);
     return json;
 }
 }  // namespace vsag

--- a/src/quantization/scalar_quantization/scalar_quantizer_parameter.h
+++ b/src/quantization/scalar_quantization/scalar_quantizer_parameter.h
@@ -53,7 +53,7 @@ template <int bit>
 JsonType
 ScalarQuantizerParameter<bit>::ToJson() const {
     JsonType json;
-    json[QUANTIZATION_TYPE_KEY].SetString(this->GetTypeName());
+    json[TYPE_KEY].SetString(this->GetTypeName());
     return json;
 }
 

--- a/src/quantization/scalar_quantization/sq4_uniform_quantizer_parameter.cpp
+++ b/src/quantization/scalar_quantization/sq4_uniform_quantizer_parameter.cpp
@@ -25,17 +25,17 @@ SQ4UniformQuantizerParameter::SQ4UniformQuantizerParameter()
 
 void
 SQ4UniformQuantizerParameter::FromJson(const JsonType& json) {
-    if (json.Contains(SQ4_UNIFORM_QUANTIZATION_TRUNC_RATE)) {
+    if (json.Contains(SQ4_UNIFORM_QUANTIZATION_TRUNC_RATE_KEY)) {
         this->trunc_rate_ =
-            json[SQ4_UNIFORM_QUANTIZATION_TRUNC_RATE].GetFloat();  // TODO(LHT): Check value
+            json[SQ4_UNIFORM_QUANTIZATION_TRUNC_RATE_KEY].GetFloat();  // TODO(LHT): Check value
     }
 }
 
 JsonType
 SQ4UniformQuantizerParameter::ToJson() const {
     JsonType json;
-    json[QUANTIZATION_TYPE_KEY].SetString(QUANTIZATION_TYPE_VALUE_SQ4_UNIFORM);
-    json[SQ4_UNIFORM_QUANTIZATION_TRUNC_RATE].SetFloat(this->trunc_rate_);
+    json[TYPE_KEY].SetString(QUANTIZATION_TYPE_VALUE_SQ4_UNIFORM);
+    json[SQ4_UNIFORM_QUANTIZATION_TRUNC_RATE_KEY].SetFloat(this->trunc_rate_);
     return json;
 }
 bool

--- a/src/quantization/scalar_quantization/sq8_uniform_quantizer_parameter.cpp
+++ b/src/quantization/scalar_quantization/sq8_uniform_quantizer_parameter.cpp
@@ -29,7 +29,7 @@ SQ8UniformQuantizerParameter::FromJson(const JsonType& json) {
 JsonType
 SQ8UniformQuantizerParameter::ToJson() const {
     JsonType json;
-    json[QUANTIZATION_TYPE_KEY].SetString(QUANTIZATION_TYPE_VALUE_SQ8_UNIFORM);
+    json[TYPE_KEY].SetString(QUANTIZATION_TYPE_VALUE_SQ8_UNIFORM);
     return json;
 }
 }  // namespace vsag

--- a/src/quantization/sparse_quantization/sparse_quantizer_parameter.h
+++ b/src/quantization/sparse_quantization/sparse_quantizer_parameter.h
@@ -35,7 +35,7 @@ public:
     JsonType
     ToJson() const override {
         JsonType json;
-        json[QUANTIZATION_TYPE_KEY].SetString(this->GetTypeName());
+        json[TYPE_KEY].SetString(this->GetTypeName());
         return json;
     }
 };

--- a/src/quantization/transform_quantization/transform_quantizer_parameter.cpp
+++ b/src/quantization/transform_quantization/transform_quantizer_parameter.cpp
@@ -26,8 +26,8 @@ TransformQuantizerParameter::TransformQuantizerParameter()
 void
 TransformQuantizerParameter::FromJson(const JsonType& json) {
     std::string chain_str;
-    if (json.Contains(TQ_CHAIN)) {
-        chain_str = json[TQ_CHAIN].GetString();
+    if (json.Contains(TQ_CHAIN_KEY)) {
+        chain_str = json[TQ_CHAIN_KEY].GetString();
         this->tq_chain_ = SplitString(chain_str);
     }
     if (this->tq_chain_.size() <= 1) {
@@ -45,7 +45,7 @@ TransformQuantizerParameter::FromJson(const JsonType& json) {
     }
 
     base_quantizer_json_ = json;
-    base_quantizer_json_[QUANTIZATION_TYPE_KEY].SetString(quantizer_type);
+    base_quantizer_json_[TYPE_KEY].SetString(quantizer_type);
     tq_chain_.pop_back();
 }
 
@@ -89,9 +89,9 @@ JsonType
 TransformQuantizerParameter::ToJson() const {
     JsonType json = base_quantizer_json_;
     auto tmp_tq_chain = tq_chain_;
-    tmp_tq_chain.emplace_back(json[QUANTIZATION_TYPE_KEY].GetString());
-    json[TQ_CHAIN].SetString(MergeStrings(tmp_tq_chain));
-    json[QUANTIZATION_TYPE_KEY].SetString(QUANTIZATION_TYPE_VALUE_TQ);
+    tmp_tq_chain.emplace_back(json[TYPE_KEY].GetString());
+    json[TQ_CHAIN_KEY].SetString(MergeStrings(tmp_tq_chain));
+    json[TYPE_KEY].SetString(QUANTIZATION_TYPE_VALUE_TQ);
     return json;
 }
 
@@ -112,7 +112,7 @@ TransformQuantizerParameter::CheckCompatibility(const ParamPtr& other) const {
             return false;
         }
     }
-    return this->base_quantizer_json_[QUANTIZATION_TYPE_KEY].GetString() ==
-           tq_param->base_quantizer_json_[QUANTIZATION_TYPE_KEY].GetString();
+    return this->base_quantizer_json_[TYPE_KEY].GetString() ==
+           tq_param->base_quantizer_json_[TYPE_KEY].GetString();
 }
 }  // namespace vsag

--- a/src/quantization/transform_quantization/transform_quantizer_parameter.h
+++ b/src/quantization/transform_quantization/transform_quantizer_parameter.h
@@ -44,7 +44,7 @@ public:
 
     std::string
     GetBottomQuantizationName() const {
-        return base_quantizer_json_[QUANTIZATION_TYPE_KEY].GetString();
+        return base_quantizer_json_[TYPE_KEY].GetString();
     }
 
 public:

--- a/src/quantization/transform_quantization/transform_quantizer_parameter_test.cpp
+++ b/src/quantization/transform_quantization/transform_quantizer_parameter_test.cpp
@@ -76,7 +76,7 @@ TEST_CASE("TQ Parameter ToJson Test", "[ut][TransformQuantizerParameter]") {
     )";
     auto param = std::make_shared<TransformQuantizerParameter>();
     param->FromJson(JsonType::Parse(param_str));
-    REQUIRE(param->base_quantizer_json_[QUANTIZATION_TYPE_KEY].GetString() == "rabitq");
+    REQUIRE(param->base_quantizer_json_[TYPE_KEY].GetString() == "rabitq");
     REQUIRE(param->tq_chain_.size() == 2);
     ParameterTest::TestToJson(param);
 }

--- a/tools/analyze_index/analyze_index.cpp
+++ b/tools/analyze_index/analyze_index.cpp
@@ -178,7 +178,7 @@ private:
         metric_type_ = static_cast<MetricType>(basic_info["metric"].GetInt());
         std::string inner_param = basic_info[INDEX_PARAM].GetString();
         index_param_ = JsonType::Parse(inner_param);
-        index_name_ = index_param_[INDEX_TYPE].GetString();
+        index_name_ = index_param_[TYPE_KEY].GetString();
         logger::info("index name: {}", index_name_);
         logger::info("index dim: {}", dim_);
         logger::info("index data type: {}", DataTypesToString(data_type_));


### PR DESCRIPTION
- split key/value for inner strings
- make internal/external string more clear. After mapping, all external param will not be used, but internal string instead
- unify string defination with same values

## Summary by Sourcery

Unify and consolidate string key definitions across the codebase by renaming and centralizing duplicate constants, clarifying internal vs external parameter mappings, and updating templates, parsing logic and tests to use the new unified names.

Enhancements:
- Rename numerous string constants to use a consistent KEY suffix and VALUE_ prefixes (e.g., TYPE_KEY, IO_FILE_PATH_KEY, GRAPH_TYPE_VALUE_NSW, GRAPH_STORAGE_TYPE_VALUE_FLAT).
- Consolidate duplicate key definitions into inner_string_params.h and remove obsolete external variants.
- Refactor parameter mapping functions and JSON templates to reference the unified internal keys only and simplify external‐to‐internal mapping logic.

Tests:
- Update unit tests and test cases to use renamed constants and updated enum values (e.g., GRAPH_STORAGE_TYPE_VALUE_FLAT, TYPE_KEY).