### PR TITLE
feat(dataset): add "is_timeout" stat for search result (#1316)

### DIFF
--- a/include/vsag/dataset.h
+++ b/include/vsag/dataset.h
@@ -276,6 +276,32 @@ public:
      */
     virtual int64_t
     GetExtraInfoSize() const = 0;
+
+    /*
+     * @brief Sets the Statistics for the dataset.
+     *
+     * @param Statistics The Statistics string.
+     * @return DatasetPtr A shared pointer to the dataset with updated Statistics.
+     */
+    virtual DatasetPtr
+    Statistics(const std::string& Statistics) = 0;
+
+    /**
+     * @brief Retrieves the all Statistics of the dataset.
+     *
+     * @return std::string The Statistics string.
+     */
+    virtual std::string
+    GetStatistics() const = 0;
+
+    /**
+     * @brief Retrieves the Statistics of the dataset.
+     *
+     * @param stat_keys The vector of stat keys.
+     * @return std::vector<std::string> The vector of stat values.
+     */
+    virtual std::vector<std::string>
+    GetStatistics(const std::vector<std::string>& stat_keys) const = 0;
 };
 
 };  // namespace vsag

--- a/mockimpl/CMakeLists.txt
+++ b/mockimpl/CMakeLists.txt
@@ -23,6 +23,7 @@ set (MOCK_SRCS
   ../src/impl/bitset/fast_bitset.cpp
   ../src/constants.cpp
   ../src/dataset_impl.cpp
+  ../src/json_wrapper.cpp
 )
 
 add_library (vsag_mockimpl SHARED ${MOCK_SRCS})

--- a/src/algorithm/ivf.cpp
+++ b/src/algorithm/ivf.cpp
@@ -464,7 +464,7 @@ IVF::KnnSearch(const DatasetPtr& query,
     }
     auto search_result = this->search<KNN_SEARCH>(query, param);
     if (use_reorder_) {
-        return reorder(k, search_result, query->GetFloat32Vectors());
+        return reorder(k, search_result, query->GetFloat32Vectors(), param);
     }
     auto count = static_cast<const int64_t>(search_result->Size());
     auto [dataset_results, dists, labels] = create_fast_dataset(count, allocator_);
@@ -473,6 +473,7 @@ IVF::KnnSearch(const DatasetPtr& query,
         labels[j] = label_table_->GetLabelById(search_result->Top().second);
         search_result->Pop();
     }
+    dataset_results->Statistics(param.stats->Dump());
     return std::move(dataset_results);
 }
 
@@ -493,7 +494,7 @@ IVF::RangeSearch(const DatasetPtr& query,
     auto search_result = this->search<RANGE_SEARCH>(query, param);
     if (use_reorder_) {
         int64_t k = (limited_size > 0) ? limited_size : static_cast<int64_t>(search_result->Size());
-        return reorder(k, search_result, query->GetFloat32Vectors());
+        return reorder(k, search_result, query->GetFloat32Vectors(), param);
     }
     auto count = static_cast<const int64_t>(search_result->Size());
     auto [dataset_results, dists, labels] = create_fast_dataset(count, allocator_);
@@ -686,12 +687,16 @@ IVF::create_search_param(const std::string& parameters, const FilterPtr& filter)
     if (search_param.enable_time_record) {
         param.time_cost = std::make_shared<Timer>();
         param.time_cost->SetThreshold(search_param.timeout_ms);
+        (*param.stats)["is_timeout"].SetBool(false);
     }
     return param;
 }
 
 DatasetPtr
-IVF::reorder(int64_t topk, DistHeapPtr& input, const float* query) const {
+IVF::reorder(int64_t topk,
+             DistHeapPtr& input,
+             const float* query,
+             const InnerSearchParam& param) const {
     auto [dataset_results, dists, labels] = create_fast_dataset(topk, allocator_);
     auto reorder_heap = Reorder::ReorderByFlatten(input, reorder_codes_, query, allocator_, topk);
     auto size = static_cast<int64_t>(reorder_heap->Size());
@@ -700,6 +705,7 @@ IVF::reorder(int64_t topk, DistHeapPtr& input, const float* query) const {
         labels[j] = label_table_->GetLabelById(reorder_heap->Top().second);
         reorder_heap->Pop();
     }
+    dataset_results->Statistics(param.stats->Dump());
     return std::move(dataset_results);
 }
 
@@ -762,6 +768,7 @@ IVF::search(const DatasetPtr& query, const InnerSearchParam& param) const {
         Vector<float> dist(allocator_);
         for (uint64_t i = 0; i < bucket_count; ++i) {
             if (param.time_cost != nullptr and param.time_cost->CheckOvertime()) {
+                (*param.stats)["is_timeout"].SetBool(true);
                 break;
             }
             if (i % search_thread_count != thread_id) {
@@ -961,7 +968,7 @@ IVF::SearchWithRequest(const SearchRequest& request) const {
     }
     auto search_result = this->search<KNN_SEARCH>(query, param);
     if (use_reorder_) {
-        return reorder(request.topk_, search_result, query->GetFloat32Vectors());
+        return reorder(request.topk_, search_result, query->GetFloat32Vectors(), param);
     }
     auto count = static_cast<const int64_t>(search_result->Size());
     auto [dataset_results, dists, labels] = create_fast_dataset(count, allocator_);
@@ -970,6 +977,7 @@ IVF::SearchWithRequest(const SearchRequest& request) const {
         labels[j] = label_table_->GetLabelById(search_result->Top().second);
         search_result->Pop();
     }
+    dataset_results->Statistics(param.stats->Dump());
     return std::move(dataset_results);
 }
 

--- a/src/algorithm/ivf.h
+++ b/src/algorithm/ivf.h
@@ -142,7 +142,10 @@ private:
     search(const DatasetPtr& query, const InnerSearchParam& param) const;
 
     DatasetPtr
-    reorder(int64_t topk, DistHeapPtr& input, const float* query) const;
+    reorder(int64_t topk,
+            DistHeapPtr& input,
+            const float* query,
+            const InnerSearchParam& param) const;
 
     void
     merge_one_unit(const MergeUnit& unit);

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -109,7 +109,7 @@ const char* const INDEX_PARAM = "index_param";
 
 const char PART_SLASH = '/';
 
-// statstic key
+// statistics key
 const char* const STATSTIC_MEMORY = "memory";
 const char* const STATSTIC_INDEX_NAME = "index_name";
 const char* const STATSTIC_DATA_NUM = "data_num";

--- a/src/dataset_impl.cpp
+++ b/src/dataset_impl.cpp
@@ -17,6 +17,7 @@
 
 #include <cstring>
 
+#include "typing.h"
 #include "vsag_exception.h"
 
 namespace vsag {
@@ -270,6 +271,20 @@ DatasetImpl::Append(const DatasetPtr& other) {
         }
     }
     return shared_from_this();
+}
+
+std::vector<std::string>
+DatasetImpl::GetStatistics(const std::vector<std::string>& stat_keys) const {
+    auto json = JsonType::Parse(this->statistics_);
+    std::vector<std::string> result;
+    for (const auto& key : stat_keys) {
+        if (json.Contains(key)) {
+            result.emplace_back(json[key].Dump());
+        } else {
+            result.emplace_back("");
+        }
+    }
+    return result;
 }
 
 };  // namespace vsag

--- a/src/dataset_impl.h
+++ b/src/dataset_impl.h
@@ -273,6 +273,20 @@ public:
         return 0;
     }
 
+    DatasetPtr
+    Statistics(const std::string& statisticss) override {
+        this->statistics_ = statisticss;
+        return shared_from_this();
+    }
+
+    std::vector<std::string>
+    GetStatistics(const std::vector<std::string>& stat_keys) const override;
+
+    std::string
+    GetStatistics() const override {
+        return this->statistics_;
+    }
+
     static DatasetPtr
     MakeEmptyDataset();
 
@@ -280,6 +294,8 @@ private:
     bool owner_{true};
     std::unordered_map<std::string, var> data_;
     Allocator* allocator_ = nullptr;
+
+    std::string statistics_{"{}"};
 };
 
 };  // namespace vsag

--- a/src/impl/inner_search_param.h
+++ b/src/impl/inner_search_param.h
@@ -30,6 +30,11 @@ enum InnerSearchType { PURE = 1, WITH_FILTER = 2 };
 
 class InnerSearchParam {
 public:
+    InnerSearchParam() {
+        stats = std::make_shared<JsonType>();
+    }
+
+public:
     int64_t topk{0};
     float radius{0.0F};
     InnerIdType ep{0};
@@ -56,6 +61,8 @@ public:
 
     // time record
     std::shared_ptr<Timer> time_cost{nullptr};
+
+    std::shared_ptr<JsonType> stats{nullptr};
 
     InnerSearchParam&
     operator=(const InnerSearchParam& other) {

--- a/src/impl/searcher/basic_searcher.cpp
+++ b/src/impl/searcher/basic_searcher.cpp
@@ -300,6 +300,7 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
 
         if (inner_search_param.time_cost != nullptr and
             inner_search_param.time_cost->CheckOvertime()) {
+            (*inner_search_param.stats)["is_timeout"].SetBool(true);
             break;
         }
 

--- a/tests/test_index.cpp
+++ b/tests/test_index.cpp
@@ -2275,6 +2275,12 @@ TestIndex::TestSearchOvertime(const IndexPtr& index,
             ->Owner(false);
         auto res = index->KnnSearch(query, 10, search_param);
         REQUIRE(res.has_value());
+        auto result = res.value();
+        REQUIRE(result->GetStatistics() != "{}");
+        auto stats = result->GetStatistics({"is_timeout"});
+        REQUIRE(stats.size() == 1);
+        bool has_timeout_result = (stats[0] == "true" or stats[0] == "false");
+        REQUIRE(has_timeout_result);
     }
 }
 


### PR DESCRIPTION
## Summary by Sourcery

Add a statistics feature to dataset search results by tracking and exposing an "is_timeout" field in a JSON stats object, wiring it through search parameters, query execution, and result datasets.

New Features:
- Introduce Statistics setter and getter methods on Dataset interface and implementation
- Record and propagate JSON-based search statistics including an "is_timeout" flag
- Initialize and carry a stats JSON object through InnerSearchParam and search routines

Enhancements:
- Update IVF reorder functions to accept search parameters and attach statistics to reordered results

Tests:
- Add unit test to verify that "is_timeout" statistic is present and boolean in search outcomes

Chores:
- Include JSON wrapper in mock implementation build and correct a comment typo in constants