### PR TITLE
feat(c_api): add functional serialzie method for C api

### DIFF
--- a/include/vsag/vsag_c_api.h
+++ b/include/vsag/vsag_c_api.h
@@ -64,4 +64,16 @@ vsag_serialize_file(vsag_index_t index, const char* file_path);
 
 Error_t
 vsag_deserialize_file(vsag_index_t index, const char* file_path);
+
+typedef uint64_t OffsetType;
+typedef uint64_t SizeType;
+
+Error_t
+vsag_serialize_write_func(vsag_index_t index,
+                          void (*write_func)(OffsetType offset, SizeType size, const void* data));
+
+Error_t
+vsag_deserialize_read_func(vsag_index_t index,
+                           void (*read_func)(OffsetType offset, SizeType size, void* data),
+                           SizeType (*size_func)());
 }

--- a/src/impl/cluster/kmeans_cluster.cpp
+++ b/src/impl/cluster/kmeans_cluster.cpp
@@ -85,11 +85,6 @@ KMeansCluster::Run(uint32_t k,
     }
 
     for (int it = 0; it < iter; ++it) {
-        logger::trace("[{}] KMeansCluster::Run iter: {}/{}, cur loss is {}",
-                      get_current_time(),
-                      it,
-                      iter,
-                      total_err);
         if (k < THRESHOLD_FOR_HGRAPH) {
             total_err = this->find_nearest_one_with_blas(datas, count, k, y_sqr, distances, labels);
         } else {
@@ -125,11 +120,6 @@ KMeansCluster::Run(uint32_t k,
         }
         futures.clear();
 
-        if (it > 0 && use_mse_for_convergence &&
-            std::fabs(last_err - total_err) / static_cast<double>(count) < threshold) {
-            break;
-        }
-
         for (int j = 0; j < k; ++j) {
             if (counts[j] > 0) {
                 cblas_sscal(dim_,
@@ -146,6 +136,17 @@ KMeansCluster::Run(uint32_t k,
                 }
             }
         }
+
+        logger::trace("[{}] KMeansCluster::Run iter: {}/{} finished, cur loss is {}",
+                      get_current_time(),
+                      static_cast<int>(it),
+                      static_cast<int>(iter),
+                      static_cast<double>(total_err));
+        if (it > 0 && use_mse_for_convergence &&
+            std::fabs(last_err - total_err) / static_cast<double>(count) < threshold) {
+            break;
+        }
+
         last_err = total_err;
     }
     if (err != nullptr) {


### PR DESCRIPTION
closed: #1295

## Summary by Sourcery

Introduce new functional serialization and deserialization methods to the C API, enabling clients to supply custom write and read callbacks for flexible IO, backed by a RandomAccessStreamBuf implementation and verified by updated unit tests.

New Features:
- Add vsag_serialize_write_func to serialize an index using a user-provided write callback
- Add vsag_deserialize_read_func to deserialize an index from user-provided read and size callbacks

Enhancements:
- Introduce RandomAccessStreamBuf to support random-access reading from callbacks
- Define OffsetType and SizeType in the C API header

Tests:
- Extend C API unit tests to validate custom callback-based serialization and deserialization