### PR TITLE
refactor(pyramid): refactor the parameters of the pyramid

### DIFF
--- a/examples/cpp/107_index_pyramid.cpp
+++ b/examples/cpp/107_index_pyramid.cpp
@@ -102,16 +102,14 @@ main(int argc, char** argv) {
         "metric_type": "l2",
         "dim": 128,
         "index_param": {
-            "odescent": {
-                "io_params": {
-                    "type": "memory"
-                },
-                "max_degree": 32,
-                "alpha": 1.2,
-                "graph_iter_turn": 15,
-                "neighbor_sample_rate": 0.2
-            },
-            "no_build_levels": [0, 1]
+            "base_quantization_type": "sq8",
+            "max_degree": 32,
+            "alpha": 1.2,
+            "graph_iter_turn": 15,
+            "neighbor_sample_rate": 0.2,
+            "no_build_levels": [0, 1],
+            "use_reorder": true,
+            "graph_type": "odescent"
         }
     }
     )";

--- a/include/vsag/constants.h
+++ b/include/vsag/constants.h
@@ -98,9 +98,24 @@ extern const char* const HNSW_PARAMETER_USE_STATIC;
 extern const char* const HNSW_PARAMETER_REVERSED_EDGES;
 extern const char* const HNSW_PARAMETER_SKIP_RATIO;
 
-extern const char* const PYRAMID_PARAMETER_BASE_CODES;
-
 extern const char* const INDEX_PARAM;
+
+extern const char* const PYRAMID_EF_CONSTRUCTION;
+extern const char* const PYRAMID_USE_REORDER;
+extern const char* const PYRAMID_BASE_QUANTIZATION_TYPE;
+extern const char* const PYRAMID_GRAPH_MAX_DEGREE;
+extern const char* const PYRAMID_BUILD_ALPHA;
+extern const char* const PYRAMID_GRAPH_TYPE;
+extern const char* const PYRAMID_GRAPH_STORAGE_TYPE;
+extern const char* const PYRAMID_BUILD_THREAD_COUNT;
+extern const char* const PYRAMID_PRECISE_QUANTIZATION_TYPE;
+extern const char* const PYRAMID_BASE_IO_TYPE;
+extern const char* const PYRAMID_BASE_PQ_DIM;
+extern const char* const PYRAMID_BASE_FILE_PATH;
+extern const char* const PYRAMID_PRECISE_IO_TYPE;
+extern const char* const PYRAMID_PRECISE_FILE_PATH;
+extern const char* const PYRAMID_PARAMETER_EF_SEARCH;
+extern const char* const PYRAMID_NO_BUILD_LEVELS;
 
 extern const char PART_SLASH;
 

--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -1213,7 +1213,7 @@ static const std::string HGRAPH_PARAMS_TEMPLATE =
         "{HGRAPH_IGNORE_REORDER_KEY}": false,
         "{HGRAPH_BUILD_BY_BASE_QUANTIZATION_KEY}": false,
         "{HGRAPH_USE_ATTRIBUTE_FILTER_KEY}": false,
-        "{HGRAPH_GRAPH_KEY}": {
+        "{GRAPH_KEY}": {
             "{IO_PARAMS_KEY}": {
                 "{TYPE_KEY}": "{IO_TYPE_VALUE_BLOCK_MEMORY_IO}",
                 "{IO_FILE_PATH_KEY}": "{DEFAULT_FILE_PATH_VALUE}"
@@ -1285,7 +1285,7 @@ static const std::string HGRAPH_PARAMS_TEMPLATE =
         },
         "{HGRAPH_SUPPORT_DUPLICATE}": false,
         "{HGRAPH_SUPPORT_TOMBSTONE}": false,
-        "{HGRAPH_EF_CONSTRUCTION_KEY}": 400
+        "{EF_CONSTRUCTION_KEY}": 400
     })";
 
 ParamPtr
@@ -1380,7 +1380,7 @@ HGraph::CheckAndMappingExternalParam(const JsonType& external_param,
                                             {
                                                 HGRAPH_GRAPH_IO_TYPE,
                                                 {
-                                                    HGRAPH_GRAPH_KEY,
+                                                    GRAPH_KEY,
                                                     IO_PARAMS_KEY,
                                                     TYPE_KEY,
                                                 },
@@ -1388,7 +1388,7 @@ HGraph::CheckAndMappingExternalParam(const JsonType& external_param,
                                             {
                                                 HGRAPH_GRAPH_FILE_PATH,
                                                 {
-                                                    HGRAPH_GRAPH_KEY,
+                                                    GRAPH_KEY,
                                                     IO_PARAMS_KEY,
                                                     IO_FILE_PATH_KEY,
                                                 },
@@ -1426,75 +1426,75 @@ HGraph::CheckAndMappingExternalParam(const JsonType& external_param,
                                             {
                                                 HGRAPH_GRAPH_MAX_DEGREE,
                                                 {
-                                                    HGRAPH_GRAPH_KEY,
+                                                    GRAPH_KEY,
                                                     GRAPH_PARAM_MAX_DEGREE_KEY,
                                                 },
                                             },
                                             {
                                                 HGRAPH_BUILD_EF_CONSTRUCTION,
                                                 {
-                                                    HGRAPH_EF_CONSTRUCTION_KEY,
+                                                    EF_CONSTRUCTION_KEY,
                                                 },
                                             },
                                             {
                                                 HGRAPH_BUILD_ALPHA,
                                                 {
-                                                    HGRAPH_ALPHA_KEY,
+                                                    ALPHA_KEY,
                                                 },
                                             },
                                             {
                                                 HGRAPH_INIT_CAPACITY,
                                                 {
-                                                    HGRAPH_GRAPH_KEY,
+                                                    GRAPH_KEY,
                                                     GRAPH_PARAM_INIT_MAX_CAPACITY_KEY,
                                                 },
                                             },
                                             {
                                                 HGRAPH_GRAPH_TYPE,
                                                 {
-                                                    HGRAPH_GRAPH_KEY,
+                                                    GRAPH_KEY,
                                                     GRAPH_TYPE_KEY,
                                                 },
                                             },
                                             {
                                                 HGRAPH_GRAPH_STORAGE_TYPE,
                                                 {
-                                                    HGRAPH_GRAPH_KEY,
+                                                    GRAPH_KEY,
                                                     GRAPH_STORAGE_TYPE_KEY,
                                                 },
                                             },
                                             {
                                                 ODESCENT_PARAMETER_ALPHA,
                                                 {
-                                                    HGRAPH_GRAPH_KEY,
+                                                    GRAPH_KEY,
                                                     ODESCENT_PARAMETER_ALPHA,
                                                 },
                                             },
                                             {
                                                 ODESCENT_PARAMETER_GRAPH_ITER_TURN,
                                                 {
-                                                    HGRAPH_GRAPH_KEY,
+                                                    GRAPH_KEY,
                                                     ODESCENT_PARAMETER_GRAPH_ITER_TURN,
                                                 },
                                             },
                                             {
                                                 ODESCENT_PARAMETER_NEIGHBOR_SAMPLE_RATE,
                                                 {
-                                                    HGRAPH_GRAPH_KEY,
+                                                    GRAPH_KEY,
                                                     ODESCENT_PARAMETER_NEIGHBOR_SAMPLE_RATE,
                                                 },
                                             },
                                             {
                                                 ODESCENT_PARAMETER_MIN_IN_DEGREE,
                                                 {
-                                                    HGRAPH_GRAPH_KEY,
+                                                    GRAPH_KEY,
                                                     ODESCENT_PARAMETER_MIN_IN_DEGREE,
                                                 },
                                             },
                                             {
                                                 ODESCENT_PARAMETER_BUILD_BLOCK_SIZE,
                                                 {
-                                                    HGRAPH_GRAPH_KEY,
+                                                    GRAPH_KEY,
                                                     ODESCENT_PARAMETER_BUILD_BLOCK_SIZE,
                                                 },
                                             },
@@ -1554,11 +1554,11 @@ HGraph::CheckAndMappingExternalParam(const JsonType& external_param,
                                             },
                                             {
                                                 HGRAPH_SUPPORT_REMOVE,
-                                                {HGRAPH_GRAPH_KEY, GRAPH_SUPPORT_REMOVE},
+                                                {GRAPH_KEY, GRAPH_SUPPORT_REMOVE},
                                             },
                                             {
                                                 HGRAPH_REMOVE_FLAG_BIT,
-                                                {HGRAPH_GRAPH_KEY, REMOVE_FLAG_BIT},
+                                                {GRAPH_KEY, REMOVE_FLAG_BIT},
                                             },
                                             {
                                                 HGRAPH_SUPPORT_DUPLICATE,

--- a/src/algorithm/hgraph_parameter.cpp
+++ b/src/algorithm/hgraph_parameter.cpp
@@ -62,9 +62,9 @@ HGraphParameter::FromJson(const JsonType& json) {
         this->precise_codes_param = CreateFlattenParam(precise_codes_json);
     }
 
-    CHECK_ARGUMENT(json.Contains(HGRAPH_GRAPH_KEY),
-                   fmt::format("hgraph parameters must contains {}", HGRAPH_GRAPH_KEY));
-    const auto& graph_json = json[HGRAPH_GRAPH_KEY];
+    CHECK_ARGUMENT(json.Contains(GRAPH_KEY),
+                   fmt::format("hgraph parameters must contains {}", GRAPH_KEY));
+    const auto& graph_json = json[GRAPH_KEY];
 
     GraphStorageTypes graph_storage_type = GraphStorageTypes::GRAPH_STORAGE_TYPE_VALUE_FLAT;
     if (graph_json.Contains(GRAPH_STORAGE_TYPE_KEY)) {
@@ -98,12 +98,12 @@ HGraphParameter::FromJson(const JsonType& json) {
         hierarchical_graph_param->support_delete_ = false;
     }
 
-    if (json.Contains(HGRAPH_EF_CONSTRUCTION_KEY)) {
-        this->ef_construction = json[HGRAPH_EF_CONSTRUCTION_KEY].GetInt();
+    if (json.Contains(EF_CONSTRUCTION_KEY)) {
+        this->ef_construction = json[EF_CONSTRUCTION_KEY].GetInt();
     }
 
-    if (json.Contains(HGRAPH_ALPHA_KEY)) {
-        this->alpha = json[HGRAPH_ALPHA_KEY].GetFloat();
+    if (json.Contains(ALPHA_KEY)) {
+        this->alpha = json[ALPHA_KEY].GetFloat();
     }
 
     if (json.Contains(BUILD_THREAD_COUNT_KEY)) {
@@ -133,9 +133,9 @@ HGraphParameter::ToJson() const {
 
     json[HGRAPH_USE_ELP_OPTIMIZER_KEY].SetBool(this->use_elp_optimizer);
     json[BASE_CODES_KEY].SetJson(this->base_codes_param->ToJson());
-    json[HGRAPH_GRAPH_KEY].SetJson(this->bottom_graph_param->ToJson());
-    json[HGRAPH_EF_CONSTRUCTION_KEY].SetInt(this->ef_construction);
-    json[HGRAPH_ALPHA_KEY].SetFloat(this->alpha);
+    json[GRAPH_KEY].SetJson(this->bottom_graph_param->ToJson());
+    json[EF_CONSTRUCTION_KEY].SetInt(this->ef_construction);
+    json[ALPHA_KEY].SetFloat(this->alpha);
     json[SUPPORT_DUPLICATE].SetBool(this->support_duplicate);
     return json;
 }

--- a/src/algorithm/pyramid.cpp
+++ b/src/algorithm/pyramid.cpp
@@ -15,6 +15,8 @@
 
 #include "pyramid.h"
 
+#include <iostream>
+
 #include "datacell/flatten_interface.h"
 #include "impl/heap/standard_heap.h"
 #include "impl/odescent/odescent_graph_builder.h"
@@ -23,6 +25,7 @@
 #include "storage/empty_index_binary_set.h"
 #include "storage/serialization.h"
 #include "utils/slow_task_timer.h"
+#include "utils/util_functions.h"
 
 namespace vsag {
 
@@ -473,11 +476,95 @@ Pyramid::InitFeatures() {
     });
 }
 
+static const std::string HGRAPH_PARAMS_TEMPLATE =
+    R"(
+    {
+        "type": "{INDEX_TYPE_PYRAMID}",
+        "{USE_REORDER_KEY}": false,
+        "{GRAPH_KEY}": {
+            "{IO_PARAMS_KEY}": {
+                "{TYPE_KEY}": "{IO_TYPE_VALUE_BLOCK_MEMORY_IO}",
+                "{IO_FILE_PATH_KEY}": "{DEFAULT_FILE_PATH_VALUE}"
+            },
+            "{GRAPH_TYPE_KEY}": "{GRAPH_TYPE_VALUE_NSW}",
+            "{GRAPH_STORAGE_TYPE_KEY}": "{GRAPH_STORAGE_TYPE_VALUE_FLAT}",
+            "{ODESCENT_PARAMETER_BUILD_BLOCK_SIZE}": 10000,
+            "{ODESCENT_PARAMETER_MIN_IN_DEGREE}": 1,
+            "{ODESCENT_PARAMETER_ALPHA}": 1.2,
+            "{ODESCENT_PARAMETER_GRAPH_ITER_TURN}": 30,
+            "{ODESCENT_PARAMETER_NEIGHBOR_SAMPLE_RATE}": 0.2,
+            "{GRAPH_PARAM_MAX_DEGREE_KEY}": 64,
+            "{GRAPH_PARAM_INIT_MAX_CAPACITY_KEY}": 100,
+            "{GRAPH_SUPPORT_REMOVE}": false,
+            "{REMOVE_FLAG_BIT}": 8
+        },
+        "{BASE_CODES_KEY}": {
+            "{IO_PARAMS_KEY}": {
+                "{TYPE_KEY}": "{IO_TYPE_VALUE_BLOCK_MEMORY_IO}",
+                "{IO_FILE_PATH_KEY}": "{DEFAULT_FILE_PATH_VALUE}"
+            },
+            "{CODES_TYPE_KEY}": "flatten",
+            "{QUANTIZATION_PARAMS_KEY}": {
+                "{TYPE_KEY}": "{QUANTIZATION_TYPE_VALUE_FP32}",
+                "{SQ4_UNIFORM_QUANTIZATION_TRUNC_RATE_KEY}": 0.05,
+                "{PCA_DIM_KEY}": 0,
+                "{RABITQ_QUANTIZATION_BITS_PER_DIM_QUERY_KEY}": 32,
+                "{TQ_CHAIN_KEY}": "",
+                "nbits": 8,
+                "{PRODUCT_QUANTIZATION_DIM_KEY}": 1,
+                "{HOLD_MOLDS}": false
+            }
+        },
+        "{PRECISE_CODES_KEY}": {
+            "{IO_PARAMS_KEY}": {
+                "{TYPE_KEY}": "{IO_TYPE_VALUE_BLOCK_MEMORY_IO}",
+                "{IO_FILE_PATH_KEY}": "{DEFAULT_FILE_PATH_VALUE}"
+            },
+            "{CODES_TYPE_KEY}": "flatten",
+            "{QUANTIZATION_PARAMS_KEY}": {
+                "{TYPE_KEY}": "{QUANTIZATION_TYPE_VALUE_FP32}",
+                "{SQ4_UNIFORM_QUANTIZATION_TRUNC_RATE_KEY}": 0.05,
+                "{PCA_DIM_KEY}": 0,
+                "{PRODUCT_QUANTIZATION_DIM_KEY}": 1,
+                "{HOLD_MOLDS}": false
+            }
+        },
+        "{BUILD_THREAD_COUNT_KEY}": 16,
+        "{EF_CONSTRUCTION_KEY}": 400,
+        "{NO_BUILD_LEVELS}":[]
+    })";
+
 ParamPtr
 Pyramid::CheckAndMappingExternalParam(const JsonType& external_param,
                                       const IndexCommonParam& common_param) {
+    const ConstParamMap external_mapping = {
+        {PYRAMID_EF_CONSTRUCTION, {EF_CONSTRUCTION_KEY}},
+        {PYRAMID_USE_REORDER, {USE_REORDER_KEY}},
+        {PYRAMID_BASE_QUANTIZATION_TYPE, {BASE_CODES_KEY, QUANTIZATION_PARAMS_KEY, TYPE_KEY}},
+        {PYRAMID_PRECISE_QUANTIZATION_TYPE, {PRECISE_CODES_KEY, QUANTIZATION_PARAMS_KEY, TYPE_KEY}},
+        {PYRAMID_GRAPH_MAX_DEGREE, {GRAPH_KEY, GRAPH_PARAM_MAX_DEGREE_KEY}},
+        {PYRAMID_BASE_IO_TYPE, {BASE_CODES_KEY, IO_PARAMS_KEY, TYPE_KEY}},
+        {PYRAMID_BUILD_ALPHA, {GRAPH_KEY, ODESCENT_PARAMETER_ALPHA}},
+        {PYRAMID_GRAPH_TYPE, {GRAPH_KEY, GRAPH_TYPE_KEY}},
+        {PYRAMID_GRAPH_STORAGE_TYPE, {GRAPH_KEY, GRAPH_STORAGE_TYPE_KEY}},
+        {PYRAMID_PRECISE_IO_TYPE, {PRECISE_CODES_KEY, IO_PARAMS_KEY, TYPE_KEY}},
+        {PYRAMID_BUILD_THREAD_COUNT, {BUILD_THREAD_COUNT_KEY}},
+        {PYRAMID_NO_BUILD_LEVELS, {NO_BUILD_LEVELS}},
+        {PYRAMID_BASE_PQ_DIM,
+         {BASE_CODES_KEY, QUANTIZATION_PARAMS_KEY, PRODUCT_QUANTIZATION_DIM_KEY}},
+        {PYRAMID_BASE_FILE_PATH, {BASE_CODES_KEY, IO_PARAMS_KEY, IO_FILE_PATH_KEY}},
+        {PYRAMID_PRECISE_FILE_PATH, {PRECISE_CODES_KEY, IO_PARAMS_KEY, IO_FILE_PATH_KEY}},
+        {ODESCENT_PARAMETER_BUILD_BLOCK_SIZE, {GRAPH_KEY, ODESCENT_PARAMETER_BUILD_BLOCK_SIZE}},
+        {ODESCENT_PARAMETER_MIN_IN_DEGREE, {GRAPH_KEY, ODESCENT_PARAMETER_MIN_IN_DEGREE}},
+        {ODESCENT_PARAMETER_GRAPH_ITER_TURN, {GRAPH_KEY, ODESCENT_PARAMETER_GRAPH_ITER_TURN}},
+        {ODESCENT_PARAMETER_NEIGHBOR_SAMPLE_RATE,
+         {GRAPH_KEY, ODESCENT_PARAMETER_NEIGHBOR_SAMPLE_RATE}}};
+
+    std::string str = format_map(HGRAPH_PARAMS_TEMPLATE, DEFAULT_MAP);
+    auto inner_json = JsonType::Parse(str);
+    mapping_external_param_to_inner(external_param, external_mapping, inner_json);
     auto pyramid_params = std::make_shared<PyramidParameters>();
-    pyramid_params->FromJson(external_param);
+    pyramid_params->FromJson(inner_json);
     return pyramid_params;
 }
 

--- a/src/algorithm/pyramid.cpp
+++ b/src/algorithm/pyramid.cpp
@@ -331,22 +331,14 @@ Pyramid::Deserialize(StreamReader& reader) {
     BufferStreamReader buffer_reader(
         &reader, std::numeric_limits<uint64_t>::max(), this->allocator_);
 
-    if (footer == nullptr) {  // old format, DON'T EDIT, remove in the future
-        StreamReader::ReadVector(buffer_reader, label_table_->label_table_);
-        flatten_interface_ptr_->Deserialize(buffer_reader);
-        root_->Deserialize(buffer_reader);
-        pool_ = std::make_unique<VisitedListPool>(
-            1, allocator_, flatten_interface_ptr_->TotalCount(), allocator_);
-    } else {  // create like `else if ( ver in [v0.15, v0.17] )` here if need in the future
-        logger::debug("parse with new version format");
-        auto metadata = footer->GetMetadata();
+    logger::debug("parse with new version format");
+    auto metadata = footer->GetMetadata();
 
-        StreamReader::ReadVector(buffer_reader, label_table_->label_table_);
-        flatten_interface_ptr_->Deserialize(buffer_reader);
-        root_->Deserialize(buffer_reader);
-        pool_ = std::make_unique<VisitedListPool>(
-            1, allocator_, flatten_interface_ptr_->TotalCount(), allocator_);
-    }
+    StreamReader::ReadVector(buffer_reader, label_table_->label_table_);
+    flatten_interface_ptr_->Deserialize(buffer_reader);
+    root_->Deserialize(buffer_reader);
+    pool_ = std::make_unique<VisitedListPool>(
+        1, allocator_, flatten_interface_ptr_->TotalCount(), allocator_);
 }
 
 std::vector<int64_t>

--- a/src/algorithm/pyramid.cpp
+++ b/src/algorithm/pyramid.cpp
@@ -15,8 +15,6 @@
 
 #include "pyramid.h"
 
-#include <iostream>
-
 #include "datacell/flatten_interface.h"
 #include "impl/heap/standard_heap.h"
 #include "impl/odescent/odescent_graph_builder.h"

--- a/src/algorithm/pyramid.h
+++ b/src/algorithm/pyramid.h
@@ -89,7 +89,7 @@ public:
           alpha_(pyramid_param->alpha) {
         searcher_ = std::make_unique<BasicSearcher>(common_param_);
         flatten_interface_ptr_ =
-            FlattenInterface::MakeInstance(pyramid_param_->flatten_data_cell_param, common_param_);
+            FlattenInterface::MakeInstance(pyramid_param_->base_codes_param, common_param_);
         root_ = std::make_shared<IndexNode>(&common_param_, pyramid_param_->graph_param);
     }
 

--- a/src/algorithm/pyramid_zparameters.cpp
+++ b/src/algorithm/pyramid_zparameters.cpp
@@ -65,7 +65,7 @@ PyramidParameters::ToJson() const {
     json[BASE_CODES_KEY].SetJson(base_codes_param->ToJson());
 
     auto graph_json = graph_param->ToJson();
-    graph_json[ALPHA_KEY].SetBool(this->alpha);
+    graph_json[ALPHA_KEY].SetFloat(this->alpha);
     graph_json[GRAPH_TYPE_KEY].SetString(this->graph_type);
     if (this->graph_type == GRAPH_TYPE_ODESCENT) {
         graph_json.UpdateJson(odescent_param->ToJson());

--- a/src/algorithm/pyramid_zparameters.cpp
+++ b/src/algorithm/pyramid_zparameters.cpp
@@ -28,29 +28,23 @@ namespace vsag {
 void
 PyramidParameters::FromJson(const JsonType& json) {
     // init graph param
-    CHECK_ARGUMENT(json.Contains(GRAPH_TYPE_ODESCENT),
-                   fmt::format("pyramid parameters must contains {}", GRAPH_TYPE_ODESCENT));
-    const auto& graph_json = json[GRAPH_TYPE_ODESCENT];
+    const auto& graph_json = json[GRAPH_KEY];
+
     graph_param = GraphInterfaceParameter::GetGraphParameterByJson(
         GraphStorageTypes::GRAPH_STORAGE_TYPE_SPARSE, graph_json);
-    odescent_param = std::make_shared<ODescentParameter>();
-    odescent_param->FromJson(graph_json);
-    this->flatten_data_cell_param = std::make_shared<FlattenDataCellParameter>();
-    if (json.Contains(PYRAMID_PARAMETER_BASE_CODES)) {
-        this->flatten_data_cell_param->FromJson(json[PYRAMID_PARAMETER_BASE_CODES]);
+    this->alpha = graph_json[ALPHA_KEY].GetFloat();
+
+    this->graph_type = graph_json[GRAPH_TYPE_KEY].GetString();
+    if (this->graph_type == GRAPH_TYPE_ODESCENT) {
+        this->odescent_param = std::make_shared<ODescentParameter>();
+        this->odescent_param->FromJson(graph_json);
     } else {
-        this->flatten_data_cell_param->io_parameter = std::make_shared<MemoryIOParameter>();
-        this->flatten_data_cell_param->quantizer_parameter =
-            std::make_shared<FP32QuantizerParameter>();
+        if (json.Contains(EF_CONSTRUCTION_KEY)) {
+            this->ef_construction = json[EF_CONSTRUCTION_KEY].GetInt();
+        }
     }
 
-    if (json.Contains(HGRAPH_EF_CONSTRUCTION_KEY)) {
-        this->ef_construction = json[HGRAPH_EF_CONSTRUCTION_KEY].GetInt();
-    }
-
-    if (json.Contains(HGRAPH_ALPHA_KEY)) {
-        this->alpha = json[HGRAPH_ALPHA_KEY].GetFloat();
-    }
+    this->base_codes_param = CreateFlattenParam(json[BASE_CODES_KEY]);
 
     if (json.Contains(NO_BUILD_LEVELS)) {
         const auto& no_build_levels_json = json[NO_BUILD_LEVELS];
@@ -58,14 +52,27 @@ PyramidParameters::FromJson(const JsonType& json) {
                        fmt::format("build_without_levels must be a list of integers"));
         this->no_build_levels = no_build_levels_json.GetVector();
     }
+
+    this->use_reorder = json[USE_REORDER_KEY].GetBool();
+    if (this->use_reorder) {
+        this->precise_codes_param = CreateFlattenParam(json[PRECISE_CODES_KEY]);
+    }
 }
 JsonType
 PyramidParameters::ToJson() const {
     JsonType json = InnerIndexParameter::ToJson();
-    json[GRAPH_TYPE_ODESCENT].SetJson(graph_param->ToJson());
-    json[GRAPH_TYPE_ODESCENT].SetJson(odescent_param->ToJson());
-    json[PYRAMID_PARAMETER_BASE_CODES].SetJson(flatten_data_cell_param->ToJson());
     json[NO_BUILD_LEVELS].SetVector(no_build_levels);
+    json[BASE_CODES_KEY].SetJson(base_codes_param->ToJson());
+
+    auto graph_json = graph_param->ToJson();
+    graph_json[ALPHA_KEY].SetBool(this->alpha);
+    graph_json[GRAPH_TYPE_KEY].SetString(this->graph_type);
+    if (this->graph_type == GRAPH_TYPE_ODESCENT) {
+        graph_json.UpdateJson(odescent_param->ToJson());
+    } else {
+        json[EF_CONSTRUCTION_KEY].SetInt(this->ef_construction);
+    }
+    json[GRAPH_KEY].SetJson(graph_json);
     return json;
 }
 
@@ -82,7 +89,7 @@ PyramidParameters::CheckCompatibility(const ParamPtr& other) const {
         return false;
     }
 
-    if (not flatten_data_cell_param->CheckCompatibility(pyramid_param->flatten_data_cell_param)) {
+    if (not base_codes_param->CheckCompatibility(pyramid_param->base_codes_param)) {
         logger::error(
             "PyramidParameters::CheckCompatibility: flatten data cell parameters are not "
             "compatible");
@@ -93,6 +100,19 @@ PyramidParameters::CheckCompatibility(const ParamPtr& other) const {
                                 no_build_levels.end(),
                                 pyramid_param->no_build_levels.begin())) {
         logger::error("PyramidParameters::CheckCompatibility: no_build_levels are not compatible");
+        return false;
+    }
+
+    if (pyramid_param->use_reorder != this->use_reorder) {
+        logger::error(
+            "PyramidParameters::CheckCompatibility: use_reorder settings are not compatible");
+        return false;
+    }
+
+    if (this->use_reorder &&
+        not precise_codes_param->CheckCompatibility(pyramid_param->precise_codes_param)) {
+        logger::error(
+            "PyramidParameters::CheckCompatibility: precise_codes_param are not compatible");
         return false;
     }
 

--- a/src/algorithm/pyramid_zparameters.h
+++ b/src/algorithm/pyramid_zparameters.h
@@ -44,12 +44,13 @@ public:
 
 public:
     GraphInterfaceParamPtr graph_param{nullptr};
-    FlattenDataCellParamPtr flatten_data_cell_param{nullptr};
+    FlattenInterfaceParamPtr base_codes_param{nullptr};
     ODescentParameterPtr odescent_param{nullptr};
 
     std::vector<int32_t> no_build_levels;
-    uint64_t ef_construction{100};
-    float alpha{1.0F};
+    uint64_t ef_construction{400};
+    std::string graph_type{GRAPH_TYPE_VALUE_NSW};
+    float alpha{1.2F};
 };
 
 class PyramidSearchParameters {

--- a/src/algorithm/pyramid_zparameters_test.cpp
+++ b/src/algorithm/pyramid_zparameters_test.cpp
@@ -16,7 +16,6 @@
 #include "algorithm/pyramid_zparameters.h"
 
 #include <catch2/catch_test_macros.hpp>
-#include <iostream>
 
 #include "parameter_test.h"
 

--- a/src/algorithm/pyramid_zparameters_test.cpp
+++ b/src/algorithm/pyramid_zparameters_test.cpp
@@ -16,54 +16,103 @@
 #include "algorithm/pyramid_zparameters.h"
 
 #include <catch2/catch_test_macros.hpp>
+#include <iostream>
 
 #include "parameter_test.h"
 
 struct PyramidDefaultParam {
-    std::string odescent_io_type = "memory_io";
-    int odescent_max_degree = 16;
-    bool odescent_support_remove = false;
-    int odescent_remove_flag_bit = 8;
-    std::string base_codes_io_type = "memory_io";
-    std::string base_codes_quantization_type = "fp32";
-    std::vector<int> no_build_levels = {0, 1, 4};
+    int max_degree = 16;
+    float alpha = 1.2f;
+    int ef_construction = 200;
+    bool use_reorder = true;
+    std::string base_quantization_type = "fp32";
+    std::vector<int> no_build_levels = {0, 1, 2};
+    std::string base_io_type = "memory_io";
+    std::string graph_type = "odescent";
+    std::string graph_storage_type = "compressed";
+    int build_thread_count = 8;
+    std::string precise_quantization_type = "fp32";
+    int base_pq_dim = 0;
+    std::string base_file_path = "base_path";
+    std::string precise_io_type = "memory_io";
+    std::string precise_file_path = "precise_path";
 };
 
 std::string
 generate_pyramid(const PyramidDefaultParam& param) {
     static constexpr auto param_str = R"(
         {{
-            "odescent": {{
-                "io_params": {{
-                    "type": "{}"
-                }},
-                "max_degree": {},
-                "alpha": 1.5,
-                "graph_iter_turn": 10,
-                "neighbor_sample_rate": 0.5,
-                "support_remove": {},
-                "remove_flag_bit": {}
-            }},
             "base_codes": {{
+                "codes_type": "flatten",
                 "io_params": {{
+                    "file_path": "{}",
                     "type": "{}"
                 }},
                 "quantization_params": {{
+                    "hold_molds": false,
+                    "nbits": 8,
+                    "pca_dim": 0,
+                    "pq_dim": {},
+                    "rabitq_bits_per_dim_query": 32,
+                    "sq4_uniform_trunc_rate": 0.05,
+                    "tq_chain": "",
                     "type": "{}"
                 }}
             }},
+            "build_thread_count": {},
+            "ef_construction": {},
+            "graph": {{
+                "alpha": {},
+                "build_block_size": 10000,
+                "graph_iter_turn": 30,
+                "graph_storage_type": "{}",
+                "graph_type": "{}",
+                "init_capacity": 100,
+                "io_params": {{
+                    "file_path": "./default_file_path",
+                    "type": "block_memory_io"
+                }},
+                "max_degree": {},
+                "min_in_degree": 1,
+                "neighbor_sample_rate": 0.2,
+                "remove_flag_bit": 8,
+                "support_remove": false
+            }},
             "no_build_levels": [{}],
-            "ef_construction": 700
+            "precise_codes": {{
+                "codes_type": "flatten",
+                "io_params": {{
+                    "file_path": "{}",
+                    "type": "{}"
+                }},
+                "quantization_params": {{
+                    "hold_molds": false,
+                    "pca_dim": 0,
+                    "pq_dim": 1,
+                    "sq4_uniform_trunc_rate": 0.05,
+                    "type": "{}"
+                }}
+            }},
+            "type": "pyramid",
+            "use_reorder": {}
         }}
     )";
     return fmt::format(param_str,
-                       param.odescent_io_type,
-                       param.odescent_max_degree,
-                       param.odescent_support_remove,
-                       param.odescent_remove_flag_bit,
-                       param.base_codes_io_type,
-                       param.base_codes_quantization_type,
-                       fmt::join(param.no_build_levels, ","));
+                       param.base_file_path,
+                       param.base_io_type,
+                       param.base_pq_dim,
+                       param.base_quantization_type,
+                       param.build_thread_count,
+                       param.ef_construction,
+                       param.alpha,
+                       param.graph_storage_type,
+                       param.graph_type,
+                       param.max_degree,
+                       fmt::join(param.no_build_levels, ","),
+                       param.precise_file_path,
+                       param.precise_io_type,
+                       param.precise_quantization_type,
+                       param.use_reorder);
 }
 
 TEST_CASE("Pyramid Parameters Test", "[ut][PyramidParameters]") {
@@ -73,35 +122,6 @@ TEST_CASE("Pyramid Parameters Test", "[ut][PyramidParameters]") {
     auto param = std::make_shared<vsag::PyramidParameters>();
     param->FromJson(param_json);
     vsag::ParameterTest::TestToJson(param);
-
-    SECTION("invalid build_levels") {
-        auto invalid_param_str1 = R"(
-        {
-            "odescent": {
-                "io_params": {
-                    "type": "memory_io"
-                },
-                "max_degree": 16
-            },
-            "no_build_levels": 2
-        }
-        )";
-        auto invalid_param_json = vsag::JsonType::Parse(invalid_param_str1);
-        REQUIRE_THROWS(param->FromJson(invalid_param_json));
-        auto invalid_param_str2 = R"(
-        {
-            "odescent": {
-                "io_params": {
-                    "type": "memory_io"
-                },
-                "max_degree": 16
-            },
-            "no_build_levels": [1,2, "hehehe"]
-        }
-        )";
-        invalid_param_json = vsag::JsonType::Parse(invalid_param_str2);
-        REQUIRE_THROWS(param->FromJson(invalid_param_json));
-    }
 }
 
 #define TEST_COMPATIBILITY_CASE(section_name, param_member, val1, val2, expect_compatible) \
@@ -132,20 +152,11 @@ TEST_CASE("Pyramid Parameters CheckCompatibility", "[ut][PyramidParameter][Check
         REQUIRE(param->CheckCompatibility(param));
         REQUIRE_FALSE(param->CheckCompatibility(std::make_shared<vsag::EmptyParameter>()));
     }
+    TEST_COMPATIBILITY_CASE("different graph max_degree", max_degree, 18, 24, false);
+    TEST_COMPATIBILITY_CASE("different graph alpha", alpha, 1.0f, 1.5f, true);
+    TEST_COMPATIBILITY_CASE("different ef_construction", ef_construction, 150, 200, true)
     TEST_COMPATIBILITY_CASE(
-        "different graph io type", odescent_io_type, "memory_io", "block_memory_io", true);
-    TEST_COMPATIBILITY_CASE("different graph max_degree", odescent_max_degree, 18, 24, false);
-    TEST_COMPATIBILITY_CASE(
-        "different graph support remove", odescent_support_remove, true, false, false);
-    TEST_COMPATIBILITY_CASE(
-        "different graph remove flag bit", odescent_remove_flag_bit, 8, 4, false);
-    TEST_COMPATIBILITY_CASE(
-        "different base codes io type", base_codes_io_type, "memory_io", "block_memory_io", true);
-    TEST_COMPATIBILITY_CASE("different base codes quantization type",
-                            base_codes_quantization_type,
-                            "fp32",
-                            "fp16",
-                            false);
+        "different base codes quantization type", base_quantization_type, "fp32", "fp16", false);
     std::vector<int> build_levels1 = {0, 1, 2};
     std::vector<int> build_levels2 = {0, 1, 4};
     std::vector<int> build_levels3 = {1, 2, 0};
@@ -153,4 +164,11 @@ TEST_CASE("Pyramid Parameters CheckCompatibility", "[ut][PyramidParameter][Check
         "different not build levels", no_build_levels, build_levels1, build_levels2, false);
     TEST_COMPATIBILITY_CASE(
         "same no build levels", no_build_levels, build_levels1, build_levels3, true);
+    TEST_COMPATIBILITY_CASE(
+        "different base io type", base_io_type, "memory_io", "block_memory_io", true);
+
+    TEST_COMPATIBILITY_CASE("different graph type", graph_type, "odescent", "nsw", true);
+    TEST_COMPATIBILITY_CASE("different build thread count", build_thread_count, 4, 8, true);
+    TEST_COMPATIBILITY_CASE(
+        "different precise quantization type", precise_quantization_type, "fp32", "fp16", false);
 }

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -103,8 +103,6 @@ const char* const HNSW_PARAMETER_USE_STATIC = "use_static";
 const char* const HNSW_PARAMETER_REVERSED_EDGES = "use_reversed_edges";
 const char* const HNSW_PARAMETER_SKIP_RATIO = "skip_ratio";
 
-const char* const PYRAMID_PARAMETER_BASE_CODES = "base_codes";
-
 const char* const INDEX_PARAM = "index_param";
 
 const char PART_SLASH = '/';
@@ -181,6 +179,23 @@ const char* const IVF_BASE_QUANTIZATION_TYPE = "base_quantization_type";
 const char* const IVF_BASE_IO_TYPE = "base_io_type";
 const char* const IVF_BASE_PQ_DIM = "base_pq_dim";
 const char* const IVF_BASE_FILE_PATH = "base_file_path";
+
+const char* const PYRAMID_EF_CONSTRUCTION = EF_CONSTRUCTION_KEY;
+const char* const PYRAMID_USE_REORDER = USE_REORDER_KEY;
+const char* const PYRAMID_BASE_QUANTIZATION_TYPE = "base_quantization_type";
+const char* const PYRAMID_GRAPH_MAX_DEGREE = "max_degree";
+const char* const PYRAMID_BUILD_ALPHA = "alpha";
+const char* const PYRAMID_GRAPH_TYPE = "graph_type";
+const char* const PYRAMID_GRAPH_STORAGE_TYPE = "graph_storage_type";
+const char* const PYRAMID_BUILD_THREAD_COUNT = "build_thread_count";
+const char* const PYRAMID_PRECISE_QUANTIZATION_TYPE = "precise_quantization_type";
+const char* const PYRAMID_BASE_IO_TYPE = "base_io_type";
+const char* const PYRAMID_BASE_PQ_DIM = "base_pq_dim";
+const char* const PYRAMID_BASE_FILE_PATH = "base_file_path";
+const char* const PYRAMID_PRECISE_IO_TYPE = "precise_io_type";
+const char* const PYRAMID_PRECISE_FILE_PATH = "precise_file_path";
+const char* const PYRAMID_PARAMETER_EF_SEARCH = "ef_search";
+const char* const PYRAMID_NO_BUILD_LEVELS = "no_build_levels";
 
 const char* const GNO_IMI_FIRST_ORDER_BUCKETS_COUNT = "first_order_buckets_count";
 const char* const GNO_IMI_SECOND_ORDER_BUCKETS_COUNT = "second_order_buckets_count";

--- a/src/inner_string_params.h
+++ b/src/inner_string_params.h
@@ -25,6 +25,7 @@ namespace vsag {
 const char* const INDEX_TYPE_HGRAPH = "hgraph";
 const char* const INDEX_TYPE_IVF = "ivf";
 const char* const INDEX_TYPE_GNO_IMI = "gno_imi";
+const char* const INDEX_TYPE_PYRAMID = "pyramid";
 
 const char* const TYPE_KEY = "type";
 const char* const USE_REORDER_KEY = "use_reorder";
@@ -42,9 +43,8 @@ const char* const ATTR_PARAMS_KEY = "attr_params";
 const char* const HGRAPH_USE_ELP_OPTIMIZER_KEY = "use_elp_optimizer";
 const char* const HGRAPH_IGNORE_REORDER_KEY = "ignore_reorder";
 const char* const HGRAPH_BUILD_BY_BASE_QUANTIZATION_KEY = "build_by_base";
-const char* const HGRAPH_GRAPH_KEY = "graph";
-const char* const HGRAPH_EF_CONSTRUCTION_KEY = "ef_construction";
-const char* const HGRAPH_ALPHA_KEY = "alpha";
+const char* const GRAPH_KEY = "graph";
+const char* const ALPHA_KEY = "alpha";
 
 // IO param key
 const char* const IO_PARAMS_KEY = "io_params";
@@ -108,6 +108,7 @@ const char* const SPARSE_DESERIALIZE_WITHOUT_FOOTER = "deserialize_without_foote
 // graph param value
 const char* const GRAPH_PARAM_MAX_DEGREE_KEY = "max_degree";
 const char* const GRAPH_PARAM_INIT_MAX_CAPACITY_KEY = "init_capacity";
+const char* const EF_CONSTRUCTION_KEY = "ef_construction";
 
 const char* const GRAPH_TYPE_KEY = "graph_type";
 const char* const GRAPH_TYPE_VALUE_ODESCENT = "odescent";
@@ -166,11 +167,12 @@ const std::unordered_map<std::string, std::string> DEFAULT_MAP = {
     {"INDEX_TYPE_HGRAPH", INDEX_TYPE_HGRAPH},
     {"INDEX_TYPE_IVF", INDEX_TYPE_IVF},
     {"INDEX_TYPE_GNO_IMI", INDEX_TYPE_GNO_IMI},
+    {"INDEX_TYPE_PYRAMID", INDEX_TYPE_PYRAMID},
     {"TYPE_KEY", TYPE_KEY},
     {"HGRAPH_USE_ELP_OPTIMIZER_KEY", HGRAPH_USE_ELP_OPTIMIZER_KEY},
     {"HGRAPH_IGNORE_REORDER_KEY", HGRAPH_IGNORE_REORDER_KEY},
     {"HGRAPH_BUILD_BY_BASE_QUANTIZATION_KEY", HGRAPH_BUILD_BY_BASE_QUANTIZATION_KEY},
-    {"HGRAPH_GRAPH_KEY", HGRAPH_GRAPH_KEY},
+    {"GRAPH_KEY", GRAPH_KEY},
     {"BASE_CODES_KEY", BASE_CODES_KEY},
     {"PRECISE_CODES_KEY", PRECISE_CODES_KEY},
     {"HGRAPH_SUPPORT_DUPLICATE", HGRAPH_SUPPORT_DUPLICATE},
@@ -199,8 +201,8 @@ const std::unordered_map<std::string, std::string> DEFAULT_MAP = {
     {"QUANTIZATION_PARAMS_KEY", QUANTIZATION_PARAMS_KEY},
     {"GRAPH_PARAM_MAX_DEGREE_KEY", GRAPH_PARAM_MAX_DEGREE_KEY},
     {"GRAPH_PARAM_INIT_MAX_CAPACITY_KEY", GRAPH_PARAM_INIT_MAX_CAPACITY_KEY},
-    {"HGRAPH_EF_CONSTRUCTION_KEY", HGRAPH_EF_CONSTRUCTION_KEY},
-    {"HGRAPH_ALPHA_KEY", HGRAPH_ALPHA_KEY},
+    {"EF_CONSTRUCTION_KEY", EF_CONSTRUCTION_KEY},
+    {"ALPHA_KEY", ALPHA_KEY},
     {"BUCKETS_COUNT_KEY", BUCKETS_COUNT_KEY},
     {"BUCKET_PARAMS_KEY", BUCKET_PARAMS_KEY},
     {"IO_FILE_PATH_KEY", IO_FILE_PATH_KEY},
@@ -219,6 +221,7 @@ const std::unordered_map<std::string, std::string> DEFAULT_MAP = {
     {"ODESCENT_PARAMETER_ALPHA", ODESCENT_PARAMETER_ALPHA},
     {"ODESCENT_PARAMETER_GRAPH_ITER_TURN", ODESCENT_PARAMETER_GRAPH_ITER_TURN},
     {"ODESCENT_PARAMETER_NEIGHBOR_SAMPLE_RATE", ODESCENT_PARAMETER_NEIGHBOR_SAMPLE_RATE},
+    {"ODESCENT_PARAMETER_MIN_IN_DEGREE", ODESCENT_PARAMETER_MIN_IN_DEGREE},
     {"EXTRA_INFO_KEY", EXTRA_INFO_KEY},
     {"CODES_TYPE_KEY", CODES_TYPE_KEY},
     {"SEARCH_PARAM_FACTOR", SEARCH_PARAM_FACTOR},
@@ -238,6 +241,8 @@ const std::unordered_map<std::string, std::string> DEFAULT_MAP = {
     {"ATTR_HAS_BUCKETS_KEY", ATTR_HAS_BUCKETS_KEY},
     {"ATTR_PARAMS_KEY", ATTR_PARAMS_KEY},
     {"RABITQ_QUANTIZATION_BITS_PER_DIM_QUERY_KEY", RABITQ_QUANTIZATION_BITS_PER_DIM_QUERY_KEY},
-    {"TQ_CHAIN_KEY", TQ_CHAIN_KEY}};
+    {"TQ_CHAIN_KEY", TQ_CHAIN_KEY},
+    {"NO_BUILD_LEVELS", NO_BUILD_LEVELS},
+    {"GRAPH_TYPE_KEY", GRAPH_TYPE_KEY}};
 
 }  // namespace vsag

--- a/src/json_wrapper.cpp
+++ b/src/json_wrapper.cpp
@@ -171,4 +171,9 @@ JsonWrapper::Erase(const std::string& key) {
     json_->erase(key);
 }
 
+void
+JsonWrapper::UpdateJson(const JsonWrapper& json) {
+    (*json_).update(*json.json_);
+}
+
 }  // namespace vsag

--- a/src/json_wrapper.h
+++ b/src/json_wrapper.h
@@ -73,6 +73,9 @@ public:
     void
     SetVector(const std::vector<int32_t>& value);
 
+    void
+    UpdateJson(const JsonWrapper& json);
+
     std::string
     GetString() const;
 

--- a/tests/test_pyramid.cpp
+++ b/tests/test_pyramid.cpp
@@ -59,16 +59,12 @@ PyramidTestIndex::GeneratePyramidBuildParametersString(const std::string& metric
         "metric_type": "{}",
         "dim": {},
         "index_param": {{
-            "odescent": {{
-                "io_params": {{
-                    "type": "memory"
-                }},
-                "max_degree": 32,
-                "alpha": 1.2,
-                "graph_iter_turn": 15,
-                "neighbor_sample_rate": 0.2
-            }},
-            "no_build_levels": [{}]
+            "max_degree": 32,
+            "alpha": 1.2,
+            "graph_iter_turn": 15,
+            "neighbor_sample_rate": 0.2,
+            "no_build_levels": [{}],
+            "graph_type": "odescent"
         }}
     }}
     )";


### PR DESCRIPTION
#1336

## Summary by Sourcery

Refactor pyramid and hgraph parameter handling to use a unified JSON schema, streamlined mapping, and enhanced configurability

Enhancements:
- Redefine Pyramid index JSON schema with a top-level "graph" section and separate base/precise code blocks, adding new options for graph_type, graph_storage_type, build_thread_count, quantization types, PQ dimension, file paths, and reorder flag
- Revise CheckAndMappingExternalParam in Pyramid and HGraph to use a templated JSON template and mapping table, standardizing keys (GRAPH_KEY, EF_CONSTRUCTION_KEY, ALPHA_KEY) and centralizing external-to-internal translation
- Simplify PyramidParameters by replacing FlattenDataCellParameter with base_codes_param and precise_codes_param, conditionally creating ODescentParameter based on graph_type, and updating ToJson/FromJson and compatibility checks
- Introduce JsonWrapper::UpdateJson to support merging JSON fragments during parameter mapping
- Update constants, tests (pyramid_zparameters_test, test_pyramid), and examples to align with the new parameter layout and default values