### PR TITLE
feat(hgraph): support pqr in HGraph

### DIFF
--- a/include/vsag/constants.h
+++ b/include/vsag/constants.h
@@ -177,6 +177,7 @@ extern const char* const HGRAPH_EXTRA_INFO_SIZE;
 extern const char* const HGRAPH_SUPPORT_DUPLICATE;
 extern const char* const HGRAPH_SUPPORT_TOMBSTONE;
 extern const char* const HGRAPH_USE_EXTRA_INFO_FILTER;
+extern const char* const HGRAPH_REORDER_TYPE;
 extern const char* const STORE_RAW_VECTOR;
 extern const char* const RAW_VECTOR_IO_TYPE;
 extern const char* const RAW_VECTOR_FILE_PATH;

--- a/src/algorithm/hgraph.h
+++ b/src/algorithm/hgraph.h
@@ -293,10 +293,7 @@ private:
 
 private:
     void
-    reorder(const void* query,
-            const FlattenInterfacePtr& flatten,
-            DistHeapPtr& candidate_heap,
-            int64_t k) const;
+    reorder(const void* query, DistHeapPtr& candidate_heap, int64_t k) const;
 
     void
     elp_optimize();

--- a/src/algorithm/hgraph_parameter.cpp
+++ b/src/algorithm/hgraph_parameter.cpp
@@ -22,9 +22,9 @@
 #include "datacell/sparse_graph_datacell_parameter.h"
 #include "datacell/sparse_vector_datacell_parameter.h"
 #include "impl/odescent/odescent_graph_parameter.h"
+#include "impl/reorder/reorder_parameter.h"
 #include "inner_string_params.h"
 #include "vsag/constants.h"
-
 namespace vsag {
 
 HGraphParameter::HGraphParameter(const JsonType& json) : HGraphParameter() {
@@ -124,6 +124,8 @@ HGraphParameter::FromJson(const JsonType& json) {
     if (json.Contains(SUPPORT_TOMBSTONE)) {
         this->support_tombstone = json[SUPPORT_TOMBSTONE].GetBool();
     }
+
+    this->reorder_param = CreateReorderParam(json[REORDER_KEY]);
 }
 
 JsonType
@@ -137,6 +139,7 @@ HGraphParameter::ToJson() const {
     json[EF_CONSTRUCTION_KEY].SetInt(this->ef_construction);
     json[ALPHA_KEY].SetFloat(this->alpha);
     json[SUPPORT_DUPLICATE].SetBool(this->support_duplicate);
+    json[REORDER_KEY].SetJson(this->reorder_param->ToJson());
     return json;
 }
 
@@ -176,6 +179,11 @@ HGraphParameter::CheckCompatibility(const ParamPtr& other) const {
     }
     if (support_duplicate != hgraph_param->support_duplicate) {
         logger::error("HGraphParameter::CheckCompatibility: support_duplicate must be the same");
+        return false;
+    }
+    if (this->use_reorder and
+        not this->reorder_param->CheckCompatibility(hgraph_param->reorder_param)) {
+        logger::error("HGraphParameter::CheckCompatibility: reorder_param is not compatible");
         return false;
     }
     return true;

--- a/src/algorithm/hgraph_parameter.h
+++ b/src/algorithm/hgraph_parameter.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "data_type.h"
+#include "impl/reorder/reorder_parameter.h"
 #include "index_search_parameter.h"
 #include "inner_index_parameter.h"
 #include "utils/pointer_define.h"
@@ -48,6 +49,7 @@ public:
     FlattenInterfaceParamPtr base_codes_param{nullptr};
     GraphInterfaceParamPtr bottom_graph_param{nullptr};
     SparseGraphDatacellParamPtr hierarchical_graph_param{nullptr};
+    ReorderParameterPtr reorder_param{nullptr};
 
     ODescentParameterPtr odescent_param{nullptr};
 

--- a/src/algorithm/hgraph_parameter_test.cpp
+++ b/src/algorithm/hgraph_parameter_test.cpp
@@ -54,6 +54,7 @@ struct HGraphDefaultParam {
     bool use_attribute_filter = false;
     bool support_duplicate = false;
     bool use_reorder = true;
+    std::string reorder_type = "flatten_reorder";
 };
 
 std::string
@@ -107,7 +108,22 @@ generate_hgraph_param(const HGraphDefaultParam& param) {
         "type": "hgraph",
         "use_attribute_filter": {},
         "use_reorder": {},
-        "support_duplicate": {}
+        "support_duplicate": {},
+        "reorder": {{
+            "codes_type": "flatten",
+            "io_params": {{
+                "file_path": "./default_file_path",
+                "type": "block_memory_io"
+            }},
+            "quantization_params": {{
+                "hold_molds": false,
+                "pca_dim": 0,
+                "pq_dim": 1,
+                "sq4_uniform_trunc_rate": 0.05,
+                "type": "sq8"
+            }},
+            "reorder_type": "{}"
+        }}
     }})";
 
     return fmt::format(param_str,
@@ -122,7 +138,8 @@ generate_hgraph_param(const HGraphDefaultParam& param) {
                        param.precise_codes_quantization_type,
                        param.use_attribute_filter,
                        param.use_reorder,
-                       param.support_duplicate);
+                       param.support_duplicate,
+                       param.reorder_type);
 }
 
 TEST_CASE("HGraph Parameters CheckCompatibility", "[ut][HGraphParameter][CheckCompatibility]") {
@@ -158,4 +175,6 @@ TEST_CASE("HGraph Parameters CheckCompatibility", "[ut][HGraphParameter][CheckCo
     TEST_COMPATIBILITY_CASE(
         "different use attribute filter", use_attribute_filter, true, false, false)
     TEST_COMPATIBILITY_CASE("different support duplicate", support_duplicate, true, false, false)
+    TEST_COMPATIBILITY_CASE(
+        "different reorder type", reorder_type, "flatten_reorder", "pqr_reorder", false)
 }

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -164,6 +164,8 @@ const char* const HGRAPH_EXTRA_INFO_SIZE = "extra_info_size";
 const char* const HGRAPH_SUPPORT_DUPLICATE = "support_duplicate";
 const char* const HGRAPH_SUPPORT_TOMBSTONE = "support_tomb_stone";
 const char* const HGRAPH_USE_EXTRA_INFO_FILTER = "use_extra_info_filter";
+const char* const HGRAPH_REORDER_TYPE = "reorder_type";
+
 const char* const STORE_RAW_VECTOR = "store_raw_vector";
 const char* const RAW_VECTOR_IO_TYPE = "raw_vector_io_type";
 const char* const RAW_VECTOR_FILE_PATH = "raw_vector_file_path";

--- a/src/datacell/flatten_interface.h
+++ b/src/datacell/flatten_interface.h
@@ -64,6 +64,12 @@ public:
     };
 
     virtual void
+    CalResidual(const void* vector, void* residual, InnerIdType count) {
+        throw VsagException(ErrorType::INTERNAL_ERROR,
+                            "CalResidual not implemented in FlattenInterface");
+    };
+
+    virtual void
     BatchInsertVector(const void* vectors, InnerIdType count, InnerIdType* idx_vec = nullptr) = 0;
 
     virtual float

--- a/src/impl/reorder/CMakeLists.txt
+++ b/src/impl/reorder/CMakeLists.txt
@@ -15,9 +15,13 @@
 
 
 set (REORDER_SRC
+        pqr_reorder.cpp
+        pqr_reorder.h
         flatten_reorder.cpp
         flatten_reorder.h
         reorder.h
+        reorder_parameter.h
+        reorder_parameter.cpp
 )
 
 add_library (reorder OBJECT ${REORDER_SRC})

--- a/src/impl/reorder/flatten_reorder.cpp
+++ b/src/impl/reorder/flatten_reorder.cpp
@@ -21,7 +21,7 @@ DistHeapPtr
 FlattenReorder::Reorder(const DistHeapPtr& input,
                         const float* query,
                         int64_t topk,
-                        Allocator* allocator) {
+                        Allocator* allocator) const {
     if (allocator == nullptr) {
         allocator = allocator_;
     }

--- a/src/impl/reorder/flatten_reorder_parameter.h
+++ b/src/impl/reorder/flatten_reorder_parameter.h
@@ -15,28 +15,24 @@
 
 #pragma once
 
-#include <memory>
-
-#include "datacell/flatten_interface.h"
-#include "impl/heap/distance_heap.h"
-#include "impl/reorder/reorder.h"
+#include "inner_string_params.h"
+#include "reorder_parameter.h"
 #include "utils/pointer_define.h"
-
 namespace vsag {
-class FlattenReorder : public ReorderInterface {
+
+DEFINE_POINTER(FlattenReorderParameter);
+class FlattenReorderParameter : public ReorderParameter {
 public:
-    FlattenReorder(const FlattenInterfacePtr& flatten, Allocator* allocator)
-        : flatten_(flatten), allocator_(allocator) {
+    explicit FlattenReorderParameter() : ReorderParameter(std::move(FLATTEN_REORDER)) {
     }
-
-    DistHeapPtr
-    Reorder(const DistHeapPtr& input,
-            const float* query,
-            int64_t topk,
-            Allocator* allocator = nullptr) const override;
-
-private:
-    const FlattenInterfacePtr flatten_;
-    Allocator* allocator_{nullptr};
+    void
+    FromJson(const vsag::JsonType& json) override {
+    }
+    JsonType
+    ToJson() const override {
+        JsonType json;
+        json[REORDER_TYPE].SetString(this->name_);
+        return json;
+    }
 };
 }  // namespace vsag

--- a/src/impl/reorder/pqr_reorder.cpp
+++ b/src/impl/reorder/pqr_reorder.cpp
@@ -1,0 +1,118 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "impl/reorder/pqr_reorder.h"
+
+#include "simd/simd.h"
+#include "storage/stream_writer.h"
+namespace vsag {
+
+static const int64_t TRAIN_MAX_SIZE = 65535;
+
+DistHeapPtr
+PqrReorder::Reorder(const DistHeapPtr& input,
+                    const float* query,
+                    int64_t topk,
+                    Allocator* allocator) const {
+    auto reorder_heap = DistanceHeap::MakeInstanceBySize<true, true>(allocator, topk);
+    const auto* float_vector = reinterpret_cast<const float*>(query);
+    Vector<float> normalize_vector(dim_, allocator_);
+    if (metric_ == MetricType::METRIC_TYPE_COSINE) {
+        Normalize(float_vector, normalize_vector.data(), dim_);
+        float_vector = normalize_vector.data();
+    }
+    auto computer = reorder_code_->FactoryComputer(float_vector);
+    size_t candidate_size = input->Size();
+    const auto* candidate_result = input->GetData();
+    Vector<InnerIdType> ids(candidate_size, allocator);
+    Vector<float> dists(candidate_size, allocator);
+    for (int i = 0; i < candidate_size; ++i) {
+        ids[i] = candidate_result[i].second;
+    }
+    reorder_code_->Query(dists.data(), computer, ids.data(), candidate_size);
+    for (int i = 0; i < candidate_size; ++i) {
+        float final_dist = candidate_result[i].first;
+        dists[i] = 1 - dists[i];
+        if (metric_ == MetricType::METRIC_TYPE_L2SQR) {
+            final_dist += bias_[ids[i]];
+            dists[i] *= 2;
+        }
+        reorder_heap->Push(final_dist - dists[i], ids[i]);
+    }
+    return reorder_heap;
+}
+
+void
+PqrReorder::InsertVector(const void* vector, vsag::InnerIdType id) {
+    const auto* float_vector = reinterpret_cast<const float*>(vector);
+    Vector<float> normalize_vector(dim_, allocator_);
+    if (metric_ == MetricType::METRIC_TYPE_COSINE) {
+        Normalize(float_vector, normalize_vector.data(), dim_);
+        float_vector = normalize_vector.data();
+    }
+    bool need_release = false;
+    const auto* codes = flatten_->GetCodesById(id, need_release);
+    Vector<float> code_vector(dim_, allocator_);
+    Vector<float> residual_vector(dim_, allocator_);
+    flatten_->Decode(codes, code_vector.data());
+    FP32Sub(float_vector, code_vector.data(), residual_vector.data(), dim_);
+    reorder_code_->InsertVector(residual_vector.data(), id);
+    if (metric_ == MetricType::METRIC_TYPE_L2SQR) {
+        bias_[id] = 2 * FP32ComputeIP(residual_vector.data(), code_vector.data(), dim_) +
+                    FP32ComputeIP(residual_vector.data(), residual_vector.data(), dim_);
+    }
+    if (need_release) {
+        allocator_->Deallocate((void*)codes);
+    }
+}
+
+void
+PqrReorder::Train(const void* vector, uint64_t count) {
+    int64_t train_size = count > TRAIN_MAX_SIZE ? TRAIN_MAX_SIZE : static_cast<int64_t>(count);
+    const auto* float_vector = reinterpret_cast<const float*>(vector);
+    Vector<float> train_vectors(train_size * dim_, allocator_);
+    Vector<float> residual_vectors(train_size * dim_, allocator_);
+    if (metric_ == MetricType::METRIC_TYPE_COSINE) {
+        for (int64_t i = 0; i < train_size; ++i) {
+            Normalize(float_vector + i * dim_, train_vectors.data() + i * dim_, dim_);
+        }
+    } else {
+        std::memcpy(train_vectors.data(), float_vector, sizeof(float) * train_size * dim_);
+    }
+    this->flatten_->CalResidual(train_vectors.data(), residual_vectors.data(), train_size);
+    reorder_code_->Train(residual_vectors.data(), train_size);
+}
+
+void
+PqrReorder::Resize(uint64_t new_size) {
+    if (new_size <= this->size_) {
+        return;
+    }
+    reorder_code_->Resize(new_size);
+    bias_.resize(new_size);
+}
+
+void
+PqrReorder::Serialize(StreamWriter& writer) const {
+    reorder_code_->Serialize(writer);
+    StreamWriter::WriteVector(writer, bias_);
+}
+void
+PqrReorder::Deserialize(StreamReader& reader) {
+    reorder_code_->Deserialize(reader);
+    StreamReader::ReadVector(reader, bias_);
+}
+
+}  // namespace vsag

--- a/src/impl/reorder/pqr_reorder.h
+++ b/src/impl/reorder/pqr_reorder.h
@@ -1,0 +1,79 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+
+#include "datacell/flatten_interface.h"
+#include "impl/heap/distance_heap.h"
+#include "impl/reorder/reorder.h"
+#include "pqr_reorder_parameter.h"
+#include "quantization/product_quantization/product_quantizer_parameter.h"
+#include "utils/pointer_define.h"
+
+namespace vsag {
+class PqrReorder : public ReorderInterface {
+public:
+    PqrReorder(const FlattenInterfacePtr& flatten,
+               const IndexCommonParam& common_param,
+               const ReorderParameterPtr& reorder_param)
+        : flatten_(flatten),
+          allocator_(common_param.allocator_.get()),
+          bias_(common_param.allocator_.get()) {
+        auto inner_common = common_param;
+        metric_ = common_param.metric_;
+        dim_ = inner_common.dim_;
+        inner_common.metric_ = MetricType::METRIC_TYPE_IP;
+        auto pqr_reorder_param = std::dynamic_pointer_cast<PqrReorderParameter>(reorder_param);
+        if (pqr_reorder_param == nullptr) {
+            throw VsagException(ErrorType::INVALID_ARGUMENT,
+                                "Invalid reorder parameter type for PqrReorder");
+        }
+        reorder_code_ =
+            FlattenInterface::MakeInstance(pqr_reorder_param->residual_param_, inner_common);
+    }
+
+    DistHeapPtr
+    Reorder(const DistHeapPtr& input,
+            const float* query,
+            int64_t topk,
+            Allocator* allocator = nullptr) const override;
+
+    void
+    InsertVector(const void* vector, vsag::InnerIdType id) override;
+
+    void
+    Train(const void* vector, uint64_t count) override;
+
+    void
+    Resize(uint64_t new_size) override;
+
+    void
+    Serialize(StreamWriter& writer) const override;
+
+    void
+    Deserialize(StreamReader& reader) override;
+
+private:
+    const FlattenInterfacePtr flatten_;
+    FlattenInterfacePtr reorder_code_;
+
+    Allocator* allocator_{nullptr};
+    Vector<float> bias_;
+    int64_t dim_{0};
+    MetricType metric_{MetricType::METRIC_TYPE_IP};
+};
+}  // namespace vsag

--- a/src/impl/reorder/pqr_reorder_parameter.h
+++ b/src/impl/reorder/pqr_reorder_parameter.h
@@ -1,0 +1,58 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <fmt/format.h>
+
+#include "common.h"
+#include "datacell/flatten_interface_parameter.h"
+#include "inner_string_params.h"
+#include "reorder_parameter.h"
+#include "utils/pointer_define.h"
+namespace vsag {
+DEFINE_POINTER(PqrReorderParameter);
+
+class PqrReorderParameter : public ReorderParameter {
+public:
+    explicit PqrReorderParameter() : ReorderParameter(PQR_REORDER) {
+    }
+
+    void
+    FromJson(const vsag::JsonType& json) override {
+        residual_param_ = CreateFlattenParam(json);
+    }
+
+    JsonType
+    ToJson() const override {
+        JsonType json = residual_param_->ToJson();
+        json[REORDER_TYPE].SetString(this->name_);
+        return json;
+    }
+
+    bool
+    CheckCompatibility(const vsag::ParamPtr& other) const override {
+        auto dynamic_other = std::dynamic_pointer_cast<PqrReorderParameter>(other);
+        if (!dynamic_other) {
+            return false;
+        }
+        return this->residual_param_->CheckCompatibility(dynamic_other->residual_param_);
+    }
+
+public:
+    FlattenInterfaceParamPtr residual_param_;  // used to quantize residual
+};
+
+}  // namespace vsag

--- a/src/impl/reorder/reorder.h
+++ b/src/impl/reorder/reorder.h
@@ -28,7 +28,35 @@ public:
     Reorder(const DistHeapPtr& input,
             const float* query,
             int64_t topk,
-            Allocator* allocator = nullptr) = 0;
+            Allocator* allocator = nullptr) const = 0;
+
+    virtual void
+    InsertVector(const void* vector, vsag::InnerIdType id) {
+        // do nothing
+    }
+
+    virtual void
+    Train(const void* vector, uint64_t count) {
+        // do nothing
+    }
+
+    virtual void
+    Resize(uint64_t new_size) {
+        // do nothing
+    }
+
+    virtual void
+    Serialize(StreamWriter& writer) const {
+        // do nothing
+    }
+
+    virtual void
+    Deserialize(StreamReader& reader) {
+        // do nothing
+    }
+
+protected:
+    uint64_t size_{0};
 };
 
 }  // namespace vsag

--- a/src/impl/reorder/reorder_parameter.cpp
+++ b/src/impl/reorder/reorder_parameter.cpp
@@ -1,0 +1,43 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "reorder_parameter.h"
+
+#include <fmt/format.h>
+
+#include "flatten_reorder_parameter.h"
+#include "inner_string_params.h"
+#include "pqr_reorder_parameter.h"
+namespace vsag {
+
+ReorderParameterPtr
+CreateReorderParam(const JsonType& json) {
+    std::string reorder_type = FLATTEN_REORDER;
+    if (json.Contains(REORDER_TYPE)) {
+        reorder_type = json[REORDER_TYPE].GetString();
+    }
+    ReorderParameterPtr param = nullptr;
+    if (reorder_type == PQR_REORDER) {
+        param = std::make_shared<PqrReorderParameter>();
+    } else if (reorder_type == FLATTEN_REORDER) {
+        param = std::make_shared<FlattenReorderParameter>();
+    } else {
+        throw VsagException(ErrorType::INVALID_ARGUMENT, "unknown reorder type: " + reorder_type);
+    }
+    param->FromJson(json);
+    return param;
+}
+
+}  // namespace vsag

--- a/src/impl/reorder/reorder_parameter.h
+++ b/src/impl/reorder/reorder_parameter.h
@@ -15,28 +15,21 @@
 
 #pragma once
 
-#include <memory>
-
-#include "datacell/flatten_interface.h"
-#include "impl/heap/distance_heap.h"
-#include "impl/reorder/reorder.h"
+#include "parameter.h"
 #include "utils/pointer_define.h"
-
 namespace vsag {
-class FlattenReorder : public ReorderInterface {
-public:
-    FlattenReorder(const FlattenInterfacePtr& flatten, Allocator* allocator)
-        : flatten_(flatten), allocator_(allocator) {
+DEFINE_POINTER(ReorderParameter);
+
+class ReorderParameter : public Parameter {
+protected:
+    explicit ReorderParameter(std::string name) : name_(std::move(name)) {
     }
 
-    DistHeapPtr
-    Reorder(const DistHeapPtr& input,
-            const float* query,
-            int64_t topk,
-            Allocator* allocator = nullptr) const override;
-
-private:
-    const FlattenInterfacePtr flatten_;
-    Allocator* allocator_{nullptr};
+public:
+    std::string name_{};
 };
+
+ReorderParameterPtr
+CreateReorderParam(const JsonType& json);
+
 }  // namespace vsag

--- a/src/inner_string_params.h
+++ b/src/inner_string_params.h
@@ -141,6 +141,16 @@ const char* const GNO_IMI_SEARCH_PARAM_FIRST_ORDER_SCAN_RATIO = "first_order_sca
 const char* const FLATTEN_DATA_CELL = "flatten_data_cell";
 const char* const SPARSE_VECTOR_DATA_CELL = "sparse_vector_data_cell";
 
+const char* const PQR_REORDER = "pqr_reorder";
+const char* const FLATTEN_REORDER = "flatten_reorder";
+const char* const REORDER_TYPE = "reorder_type";
+const char* const REORDER_KEY = "reorder";
+const char* const REORDER_CODES_KEY = "reorder_codes";
+const char* const REORDER_CODES_IO_TYPE = "reorder_codes_io_type";
+const char* const REORDER_CODES_IO_FILE = "reorder_codes_io_file";
+const char* const REORDER_CODES_TYPE = "reorder_codes_type";
+const char* const REORDER_CODES_QUANTIZATION_TYPE = "reorder_codes_quantization_type";
+
 // for pyramid index
 const char* const NO_BUILD_LEVELS = "no_build_levels";
 
@@ -244,6 +254,13 @@ const std::unordered_map<std::string, std::string> DEFAULT_MAP = {
     {"RABITQ_QUANTIZATION_BITS_PER_DIM_QUERY_KEY", RABITQ_QUANTIZATION_BITS_PER_DIM_QUERY_KEY},
     {"TQ_CHAIN_KEY", TQ_CHAIN_KEY},
     {"NO_BUILD_LEVELS", NO_BUILD_LEVELS},
-    {"GRAPH_TYPE_KEY", GRAPH_TYPE_KEY}};
+    {"GRAPH_TYPE_KEY", GRAPH_TYPE_KEY},
+    {"REORDER_KEY", REORDER_KEY},
+    {"REORDER_CODES_KEY", REORDER_CODES_KEY},
+    {"REORDER_CODES_IO_TYPE", REORDER_CODES_IO_TYPE},
+    {"REORDER_CODES_IO_FILE", REORDER_CODES_IO_FILE},
+    {"REORDER_CODES_TYPE", REORDER_CODES_TYPE},
+    {"REORDER_CODES_QUANTIZATION_TYPE", REORDER_CODES_QUANTIZATION_TYPE},
+    {"REORDER_TYPE", REORDER_TYPE}};
 
 }  // namespace vsag


### PR DESCRIPTION
#1252

## Summary by Sourcery

Enable HGraph to support a PQR reordering stage by adding a PqrReorder implementation, wiring it into the HGraph lifecycle, exposing configurable reorder parameters, and covering it with new tests

New Features:
- Introduce PQR-based reorder strategy (PqrReorder) for HGraph to refine search using product quantization residuals

Enhancements:
- Extend ReorderInterface with Train/InsertVector/Resize/(De)Serialize methods and add CalResidual to FlattenInterface/FlattenDataCell
- Enhance HGraph to select and use the configured reorder strategy (flatten or PQR) through constructor, training, search, insertion, resizing, and serialization
- Extend HGraphParameter and JSON templates with reorder configuration options

Build:
- Include new reorder sources (pqr_reorder, reorder_parameter, flatten_reorder_parameter) in impl/reorder CMakeLists

Tests:
- Add PQR reorder functional tests in test_hgraph.cpp for both PR and daily pipelines