### PR TITLE
feat: add more statistics for search process

### DIFF
--- a/src/algorithm/hgraph.h
+++ b/src/algorithm/hgraph.h
@@ -257,7 +257,8 @@ private:
                      const GraphInterfacePtr& graph,
                      const FlattenInterfacePtr& flatten,
                      InnerSearchParam& inner_search_param,
-                     const VisitedListPtr& vt = nullptr) const;
+                     const VisitedListPtr& vt,
+                     Statistics& stats) const;
 
     template <InnerSearchMode mode = InnerSearchMode::KNN_SEARCH>
     DistHeapPtr
@@ -265,7 +266,8 @@ private:
                      const GraphInterfacePtr& graph,
                      const FlattenInterfacePtr& flatten,
                      InnerSearchParam& inner_search_param,
-                     IteratorFilterContext* iter_ctx) const;
+                     IteratorFilterContext* iter_ctx,
+                     Statistics& stats) const;
 
 private:
     // since v0.15

--- a/src/algorithm/inner_index_interface.h
+++ b/src/algorithm/inner_index_interface.h
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <shared_mutex>
 #include <vector>
 
@@ -27,6 +28,7 @@
 #include "parameter.h"
 #include "storage/stream_reader.h"
 #include "storage/stream_writer.h"
+#include "typing.h"
 #include "utils/function_exists_check.h"
 #include "utils/pointer_define.h"
 #include "vsag/dataset.h"
@@ -39,6 +41,23 @@ DEFINE_POINTER(LabelTable);
 DEFINE_POINTER(IndexFeatureList);
 
 class IndexCommonParam;
+
+class Statistics {
+public:
+    [[nodiscard]] std::string
+    Dump() const {
+        JsonType j;
+        j["is_timeout"].SetBool(is_timeout.load(std::memory_order_relaxed));
+        j["dist_cmp"].SetInt(dist_cmp.load(std::memory_order_relaxed));
+        j["hops"].SetInt(hops.load(std::memory_order_relaxed));
+        return j.Dump();
+    }
+
+public:
+    std::atomic<bool> is_timeout{false};
+    std::atomic<uint32_t> dist_cmp{0};
+    std::atomic<uint32_t> hops{0};
+};
 
 class InnerIndexInterface {
 public:

--- a/src/algorithm/ivf.h
+++ b/src/algorithm/ivf.h
@@ -140,13 +140,14 @@ private:
 
     template <InnerSearchMode mode = KNN_SEARCH>
     DistHeapPtr
-    search(const DatasetPtr& query, const InnerSearchParam& param) const;
+    search(const DatasetPtr& query, const InnerSearchParam& param, Statistics& stats) const;
 
     DatasetPtr
     reorder(int64_t topk,
             DistHeapPtr& input,
             const float* query,
-            const InnerSearchParam& param) const;
+            const InnerSearchParam& param,
+            Statistics& stats) const;
 
     void
     merge_one_unit(const MergeUnit& unit);

--- a/src/algorithm/ivf_partition/gno_imi_partition.h
+++ b/src/algorithm/ivf_partition/gno_imi_partition.h
@@ -33,12 +33,16 @@ public:
     Train(const DatasetPtr dataset) override;
 
     Vector<BucketIdType>
-    ClassifyDatas(const void* datas, int64_t count, BucketIdType buckets_per_data) const override;
+    ClassifyDatas(const void* datas,
+                  int64_t count,
+                  BucketIdType buckets_per_data,
+                  Statistics& stats) const override;
 
     Vector<BucketIdType>
     ClassifyDatasForSearch(const void* datas,
                            int64_t count,
-                           const InnerSearchParam& param) override;
+                           const InnerSearchParam& param,
+                           Statistics& stats) override;
 
     void
     GetCentroid(BucketIdType bucket_id, Vector<float>& centroid) override;
@@ -70,7 +74,8 @@ private:
     inner_joint_classify_datas(const float* data,
                                int64_t count,
                                BucketIdType buckets_per_data,
-                               BucketIdType* result) const;
+                               BucketIdType* result,
+                               Statistics& stats) const;
 };
 
 }  // namespace vsag

--- a/src/algorithm/ivf_partition/gno_imi_partition_test.cpp
+++ b/src/algorithm/ivf_partition/gno_imi_partition_test.cpp
@@ -17,9 +17,11 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include "algorithm/inner_index_interface.h"
 #include "algorithm/ivf_parameter.h"
 #include "fixtures.h"
 #include "impl/allocator/safe_allocator.h"
+#include "impl/inner_search_param.h"
 #include "impl/searcher/basic_searcher.h"
 #include "storage/serialization_template_test.h"
 
@@ -51,7 +53,8 @@ TEST_CASE("GNO-IMI Partition Basic Test", "[ut][GNOIMIPartition]") {
     dataset->Float32Vectors(vec.data())->Dim(dim)->NumElements(data_count)->Owner(false);
 
     partition->Train(dataset);
-    auto class_result = partition->ClassifyDatas(vec.data(), data_count, 1);
+    Statistics stats;
+    auto class_result = partition->ClassifyDatas(vec.data(), data_count, 1, stats);
     REQUIRE(class_result.size() == data_count);
 
     param_str = R"(
@@ -72,7 +75,7 @@ TEST_CASE("GNO-IMI Partition Basic Test", "[ut][GNOIMIPartition]") {
         auto query = Dataset::Make();
         query->Dim(dim)->Float32Vectors(vec.data() + i * dim)->NumElements(1)->Owner(false);
         auto result =
-            partition->ClassifyDatasForSearch(vec.data() + i * dim, 1, inner_search_param);
+            partition->ClassifyDatasForSearch(vec.data() + i * dim, 1, inner_search_param, stats);
         auto id = result[0];
         if (id == class_result[i]) {
             match_count++;
@@ -86,7 +89,7 @@ TEST_CASE("GNO-IMI Partition Basic Test", "[ut][GNOIMIPartition]") {
         auto query = Dataset::Make();
         query->Dim(dim)->Float32Vectors(vec.data() + i * dim)->NumElements(1)->Owner(false);
         auto result =
-            partition->ClassifyDatasForSearch(vec.data() + i * dim, 1, inner_search_param);
+            partition->ClassifyDatasForSearch(vec.data() + i * dim, 1, inner_search_param, stats);
         auto id = result[0];
         if (id == class_result[i]) {
             match_count++;
@@ -100,7 +103,7 @@ TEST_CASE("GNO-IMI Partition Basic Test", "[ut][GNOIMIPartition]") {
         auto query = Dataset::Make();
         query->Dim(dim)->Float32Vectors(vec.data() + i * dim)->NumElements(1)->Owner(false);
         auto result =
-            partition->ClassifyDatasForSearch(vec.data() + i * dim, 1, inner_search_param);
+            partition->ClassifyDatasForSearch(vec.data() + i * dim, 1, inner_search_param, stats);
         auto id = result[0];
         // REQUIRE(id == class_result[i]);
         if (id == class_result[i]) {
@@ -137,7 +140,8 @@ TEST_CASE("GNO-IMI Partition Serialize Test", "[ut][GNOIMIPartition]") {
     dataset->Float32Vectors(vec.data())->Dim(dim)->NumElements(data_count)->Owner(false);
 
     partition->Train(dataset);
-    auto class_result = partition->ClassifyDatas(vec.data(), data_count, 1);
+    Statistics stats;
+    auto class_result = partition->ClassifyDatas(vec.data(), data_count, 1, stats);
     REQUIRE(class_result.size() == data_count);
 
     auto partition2 = std::make_unique<GNOIMIPartition>(param, strategy_param);
@@ -162,7 +166,7 @@ TEST_CASE("GNO-IMI Partition Serialize Test", "[ut][GNOIMIPartition]") {
         auto query = Dataset::Make();
         query->Dim(dim)->Float32Vectors(vec.data() + i * dim)->NumElements(1)->Owner(false);
         auto result =
-            partition2->ClassifyDatasForSearch(vec.data() + i * dim, 1, inner_search_param);
+            partition2->ClassifyDatasForSearch(vec.data() + i * dim, 1, inner_search_param, stats);
         auto id = result[0];
         if (id == class_result[i]) {
             match_count++;

--- a/src/algorithm/ivf_partition/ivf_nearest_partition.h
+++ b/src/algorithm/ivf_partition/ivf_nearest_partition.h
@@ -32,7 +32,10 @@ public:
     Train(const DatasetPtr dataset) override;
 
     Vector<BucketIdType>
-    ClassifyDatas(const void* datas, int64_t count, BucketIdType buckets_per_data) const override;
+    ClassifyDatas(const void* datas,
+                  int64_t count,
+                  BucketIdType buckets_per_data,
+                  Statistics& stats) const override;
 
     void
     GetCentroid(BucketIdType bucket_id, Vector<float>& centroid) override;

--- a/src/algorithm/ivf_partition/ivf_nearest_partition_test.cpp
+++ b/src/algorithm/ivf_partition/ivf_nearest_partition_test.cpp
@@ -17,8 +17,10 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include "algorithm/inner_index_interface.h"
 #include "fixtures.h"
 #include "impl/allocator/safe_allocator.h"
+#include "impl/inner_search_param.h"
 #include "impl/thread_pool/safe_thread_pool.h"
 #include "storage/serialization_template_test.h"
 
@@ -47,7 +49,8 @@ TEST_CASE("IVF Nearest Partition Basic Test", "[ut][IVFNearestPartition]") {
         dataset->Float32Vectors(vec.data())->Dim(dim)->NumElements(data_count)->Owner(false);
 
         partition->Train(dataset);
-        auto class_result = partition->ClassifyDatas(vec.data(), data_count, 1);
+        Statistics stats;
+        auto class_result = partition->ClassifyDatas(vec.data(), data_count, 1, stats);
         REQUIRE(class_result.size() == data_count);
 
         auto index = partition->route_index_ptr_;
@@ -87,7 +90,8 @@ TEST_CASE("IVF Nearest Partition Serialize Test", "[ut][IVFNearestPartition]") {
     dataset->Float32Vectors(vec.data())->Dim(dim)->NumElements(data_count)->Owner(false);
 
     partition->Train(dataset);
-    auto class_result = partition->ClassifyDatas(vec.data(), data_count, 1);
+    Statistics stats;
+    auto class_result = partition->ClassifyDatas(vec.data(), data_count, 1, stats);
     REQUIRE(class_result.size() == data_count);
 
     auto partition2 = std::make_unique<IVFNearestPartition>(bucket_count, param, strategy_param);

--- a/src/algorithm/ivf_partition/ivf_partition_strategy.h
+++ b/src/algorithm/ivf_partition/ivf_partition_strategy.h
@@ -18,6 +18,7 @@
 #include <iostream>
 #include <vector>
 
+#include "algorithm/inner_index_interface.h"
 #include "impl/searcher/basic_searcher.h"
 #include "ivf_partition_strategy_parameter.h"
 #include "storage/stream_reader.h"
@@ -55,11 +56,17 @@ public:
     Train(const DatasetPtr dataset) = 0;
 
     virtual Vector<BucketIdType>
-    ClassifyDatas(const void* datas, int64_t count, BucketIdType buckets_per_data) const = 0;
+    ClassifyDatas(const void* datas,
+                  int64_t count,
+                  BucketIdType buckets_per_data,
+                  Statistics& stats) const = 0;
 
     virtual Vector<BucketIdType>
-    ClassifyDatasForSearch(const void* datas, int64_t count, const InnerSearchParam& param) {
-        return std::move(ClassifyDatas(datas, count, param.scan_bucket_size));
+    ClassifyDatasForSearch(const void* datas,
+                           int64_t count,
+                           const InnerSearchParam& param,
+                           Statistics& stats) {
+        return std::move(ClassifyDatas(datas, count, param.scan_bucket_size, stats));
     }
 
     virtual void

--- a/src/datacell/bucket_datacell.h
+++ b/src/datacell/bucket_datacell.h
@@ -17,7 +17,9 @@
 
 #include <shared_mutex>
 
+#include "algorithm/inner_index_interface.h"
 #include "bucket_interface.h"
+#include "impl/inner_search_param.h"
 #include "io/io_array.h"
 #include "quantization/product_quantization/pq_fastscan_quantizer.h"
 #include "simd/fp32_simd.h"
@@ -297,7 +299,8 @@ BucketDataCell<QuantTmpl, IOTmpl>::Train(const void* data, uint64_t count) {
             data_ptr = train_data_buffer.data();
         }
         Vector<float> centroid(this->quantizer_->GetDim(), allocator_);
-        auto buckets = strategy_->ClassifyDatas(data_ptr, count, 1);
+        Statistics stats;
+        auto buckets = strategy_->ClassifyDatas(data_ptr, count, 1, stats);
         for (int i = 0; i < count; ++i) {
             strategy_->GetCentroid(buckets[i], centroid);
             for (int j = 0; j < dim; ++j) {

--- a/src/dataset_impl.cpp
+++ b/src/dataset_impl.cpp
@@ -275,7 +275,7 @@ DatasetImpl::Append(const DatasetPtr& other) {
 
 std::vector<std::string>
 DatasetImpl::GetStatistics(const std::vector<std::string>& stat_keys) const {
-    auto json = JsonType::Parse(this->statistics_);
+    auto json = JsonType::Parse(this->Statistics_);
     std::vector<std::string> result;
     for (const auto& key : stat_keys) {
         if (json.Contains(key)) {

--- a/src/dataset_impl.h
+++ b/src/dataset_impl.h
@@ -274,8 +274,8 @@ public:
     }
 
     DatasetPtr
-    Statistics(const std::string& statisticss) override {
-        this->statistics_ = statisticss;
+    Statistics(const std::string& Statisticss) override {
+        this->Statistics_ = Statisticss;
         return shared_from_this();
     }
 
@@ -284,7 +284,7 @@ public:
 
     std::string
     GetStatistics() const override {
-        return this->statistics_;
+        return this->Statistics_;
     }
 
     static DatasetPtr
@@ -295,7 +295,7 @@ private:
     std::unordered_map<std::string, var> data_;
     Allocator* allocator_ = nullptr;
 
-    std::string statistics_{"{}"};
+    std::string Statistics_{"{}"};
 };
 
 };  // namespace vsag

--- a/src/impl/inner_search_param.h
+++ b/src/impl/inner_search_param.h
@@ -15,6 +15,8 @@
 
 #pragma once
 
+#include <mutex>
+
 #include "typing.h"
 #include "utils/pointer_define.h"
 #include "utils/timer.h"
@@ -30,9 +32,7 @@ enum InnerSearchType { PURE = 1, WITH_FILTER = 2 };
 
 class InnerSearchParam {
 public:
-    InnerSearchParam() {
-        stats = std::make_shared<JsonType>();
-    }
+    InnerSearchParam() = default;
 
 public:
     int64_t topk{0};
@@ -61,8 +61,6 @@ public:
 
     // time record
     std::shared_ptr<Timer> time_cost{nullptr};
-
-    std::shared_ptr<JsonType> stats{nullptr};
 
     InnerSearchParam&
     operator=(const InnerSearchParam& other) {

--- a/src/impl/searcher/basic_searcher.h
+++ b/src/impl/searcher/basic_searcher.h
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include "algorithm/inner_index_interface.h"
 #include "attr/executor/executor.h"
 #include "datacell/flatten_interface.h"
 #include "datacell/graph_interface.h"
@@ -44,7 +45,8 @@ public:
            const VisitedListPtr& vl,
            const void* query,
            const InnerSearchParam& inner_search_param,
-           const LabelTablePtr& label_table = nullptr) const;
+           const LabelTablePtr& label_table,
+           Statistics& stats) const;
 
     virtual DistHeapPtr
     Search(const GraphInterfacePtr& graph,
@@ -52,7 +54,8 @@ public:
            const VisitedListPtr& vl,
            const void* query,
            const InnerSearchParam& inner_search_param,
-           IteratorFilterContext* iter_ctx) const;
+           IteratorFilterContext* iter_ctx,
+           Statistics& stats) const;
 
     virtual bool
     SetRuntimeParameters(const UnorderedMap<std::string, float>& new_params);
@@ -66,7 +69,7 @@ public:
                       const uint32_t n_trials = OPTIMIZE_SEARCHER_SAMPLE_SIZE);
 
     virtual double
-    MockRun() const;
+    MockRun(Statistics& stats) const;
 
     void
     SetMutexArray(MutexArrayPtr new_mutex_array);
@@ -91,7 +94,8 @@ private:
                 const VisitedListPtr& vl,
                 const void* query,
                 const InnerSearchParam& inner_search_param,
-                const LabelTablePtr& label_table) const;
+                const LabelTablePtr& label_table,
+                Statistics& stats) const;
 
     template <InnerSearchMode mode = KNN_SEARCH>
     DistHeapPtr
@@ -100,7 +104,8 @@ private:
                 const VisitedListPtr& vl,
                 const void* query,
                 const InnerSearchParam& inner_search_param,
-                IteratorFilterContext* iter_ctx) const;
+                IteratorFilterContext* iter_ctx,
+                Statistics& stats) const;
 
 private:
     Allocator* allocator_{nullptr};

--- a/src/impl/searcher/basic_searcher_test.cpp
+++ b/src/impl/searcher/basic_searcher_test.cpp
@@ -15,7 +15,9 @@
 
 #include "basic_searcher.h"
 
+#include "algorithm/inner_index_interface.h"
 #include "searcher_test.h"
+#include "utils/visited_list.h"
 
 using namespace vsag;
 
@@ -133,16 +135,18 @@ TEST_CASE("Search with HNSW", "[ut][BasicSearcher]") {
         {
             // search with empty graph_data_cell
             auto vl = pool->TakeOne();
-            auto failed_without_vector =
-                searcher->Search(graph_data_cell, nullptr, vl, base_vectors.data(), search_param);
+            Statistics stats;
+            auto failed_without_vector = searcher->Search(
+                graph_data_cell, nullptr, vl, base_vectors.data(), search_param, nullptr, stats);
             pool->ReturnOne(vl);
             REQUIRE(failed_without_vector->Size() == 0);
         }
         {
             // search with empty vector_data_cell
             auto vl = pool->TakeOne();
-            auto failed_without_graph =
-                searcher->Search(nullptr, vector_data_cell, vl, base_vectors.data(), search_param);
+            Statistics stats;
+            auto failed_without_graph = searcher->Search(
+                nullptr, vector_data_cell, vl, base_vectors.data(), search_param, nullptr, stats);
             pool->ReturnOne(vl);
             REQUIRE(failed_without_graph->Size() == 0);
         }
@@ -175,8 +179,14 @@ TEST_CASE("Search with HNSW", "[ut][BasicSearcher]") {
         for (int i = 0; i < query_size; i++) {
             std::unordered_set<InnerIdType> valid_set, set;
             auto vl = pool->TakeOne();
-            auto result = searcher->Search(
-                graph_data_cell, vector_data_cell, vl, base_vectors.data() + i * dim, search_param);
+            Statistics stats;
+            auto result = searcher->Search(graph_data_cell,
+                                           vector_data_cell,
+                                           vl,
+                                           base_vectors.data() + i * dim,
+                                           search_param,
+                                           (LabelTablePtr) nullptr,
+                                           stats);
             pool->ReturnOne(vl);
             auto result_size = result->Size();
             for (int j = 0; j < result_size; j++) {
@@ -302,11 +312,12 @@ TEST_CASE("Optimize SQ4", "[ut][BasicOptimizer]") {
 
     // searcher-optimizer
     searcher->SetMockParameters(graph_data_cell, vector_data_cell, pool, search_param, dim, 1000);
-    auto loss_before = searcher->MockRun();
+    Statistics stats;
+    auto loss_before = searcher->MockRun(stats);
     auto optimizer_searcher = std::make_shared<Optimizer<BasicSearcher>>(common);
     optimizer_searcher->RegisterParameter(RuntimeParameter(PREFETCH_DEPTH_CODE, 1, 3, 1));
     optimizer_searcher->RegisterParameter(RuntimeParameter(PREFETCH_STRIDE_CODE, 1, 3, 1));
     optimizer_searcher->RegisterParameter(RuntimeParameter(PREFETCH_STRIDE_VISIT, 1, 3, 1));
     float end2end_improvement = optimizer_searcher->Optimize(searcher);
-    auto loss_after = searcher->MockRun();
+    auto loss_after = searcher->MockRun(stats);
 }

--- a/src/simd/sq4_simd_test.cpp
+++ b/src/simd/sq4_simd_test.cpp
@@ -20,6 +20,7 @@
 
 #include "fixtures.h"
 #include "simd_status.h"
+
 using namespace vsag;
 
 #define TEST_ACCURACY(Func)                                        \


### PR DESCRIPTION
metrics added:
- number of distance calculations
- Hops in graph search

## Summary by Sourcery

Add comprehensive metrics collection for search processes by recording distance comparison counts and hop counts in BasicSearcher and brute-force search, extend partition strategy API to carry InnerSearchParam for metric aggregation, and update related calls and tests to support the new API.

New Features:
- Track distance comparisons and graph search hop counts in BasicSearcher
- Collect and report distance comparison metrics in brute-force search
- Extend partition strategies (IVFNearestPartition, GNOIMIPartition) and IVF routines to accept InnerSearchParam for aggregating comparison stats

Enhancements:
- Update ClassifyDatas API to include InnerSearchParam and propagate dummy parameters across IVF, ivf_partition_strategy, and bucket_datacell

Tests:
- Adjust partition unit tests to supply dummy InnerSearchParam to the updated ClassifyDatas API