### PR TITLE
feat(sparse): support get raw vector

### DIFF
--- a/include/vsag/index.h
+++ b/include/vsag/index.h
@@ -74,7 +74,7 @@ public:
      * @return IndexType
      */
     virtual IndexType
-    GetIndexType() {
+    GetIndexType() const {
         throw std::runtime_error("Index not support GetIndexType");
     }
 

--- a/src/algorithm/brute_force.h
+++ b/src/algorithm/brute_force.h
@@ -67,7 +67,7 @@ public:
     GetAttributeSetByInnerId(InnerIdType inner_id, AttributeSet* attr) const override;
 
     [[nodiscard]] IndexType
-    GetIndexType() override {
+    GetIndexType() const override {
         return IndexType::BRUTEFORCE;
     }
 

--- a/src/algorithm/hgraph.h
+++ b/src/algorithm/hgraph.h
@@ -121,11 +121,8 @@ public:
     void
     GetVectorByInnerId(InnerIdType inner_id, float* data) const override;
 
-    DatasetPtr
-    GetVectorByIds(const int64_t* ids, int64_t count) const;
-
     IndexType
-    GetIndexType() override {
+    GetIndexType() const override {
         return IndexType::HGRAPH;
     }
 

--- a/src/algorithm/inner_index_interface.cpp
+++ b/src/algorithm/inner_index_interface.cpp
@@ -385,22 +385,18 @@ InnerIndexInterface::GetVectorByIds(const int64_t* ids, int64_t count) const {
             this->GetSparseVectorByInnerId(inner_id, sparse_vectors + i);
         }
         return vectors;
-    } else {
-        auto* float_vectors = (float*)allocator_->Allocate(sizeof(float) * count * dim_);
-        if (float_vectors == nullptr) {
-            throw VsagException(ErrorType::NO_ENOUGH_MEMORY,
-                                "failed to allocate memory for vectors");
-        }
-        vectors->NumElements(count)
-            ->Dim(dim_)
-            ->Float32Vectors(float_vectors)
-            ->Owner(true, allocator_);
-        for (int i = 0; i < count; ++i) {
-            InnerIdType inner_id = this->label_table_->GetIdByLabel(ids[i]);
-            this->GetVectorByInnerId(inner_id, float_vectors + i * dim_);
-        }
-        return vectors;
     }
+
+    auto* float_vectors = (float*)allocator_->Allocate(sizeof(float) * count * dim_);
+    if (float_vectors == nullptr) {
+        throw VsagException(ErrorType::NO_ENOUGH_MEMORY, "failed to allocate memory for vectors");
+    }
+    vectors->NumElements(count)->Dim(dim_)->Float32Vectors(float_vectors)->Owner(true, allocator_);
+    for (int i = 0; i < count; ++i) {
+        InnerIdType inner_id = this->label_table_->GetIdByLabel(ids[i]);
+        this->GetVectorByInnerId(inner_id, float_vectors + i * dim_);
+    }
+    return vectors;
 }
 
 DatasetPtr

--- a/src/algorithm/inner_index_interface.cpp
+++ b/src/algorithm/inner_index_interface.cpp
@@ -372,16 +372,35 @@ InnerIndexInterface::FastCreateIndex(const std::string& index_fast_str,
 DatasetPtr
 InnerIndexInterface::GetVectorByIds(const int64_t* ids, int64_t count) const {
     DatasetPtr vectors = Dataset::Make();
-    auto* float_vectors = (float*)allocator_->Allocate(sizeof(float) * count * dim_);
-    if (float_vectors == nullptr) {
-        throw VsagException(ErrorType::NO_ENOUGH_MEMORY, "failed to allocate memory for vectors");
+
+    if (GetIndexType() == IndexType::SINDI or GetIndexType() == IndexType::SPARSE) {
+        auto* sparse_vectors = (SparseVector*)allocator_->Allocate(sizeof(SparseVector) * count);
+        if (sparse_vectors == nullptr) {
+            throw VsagException(ErrorType::NO_ENOUGH_MEMORY,
+                                "failed to allocate memory for vectors");
+        }
+        vectors->NumElements(count)->SparseVectors(sparse_vectors)->Owner(true, allocator_);
+        for (int i = 0; i < count; ++i) {
+            InnerIdType inner_id = this->label_table_->GetIdByLabel(ids[i]);
+            this->GetSparseVectorByInnerId(inner_id, sparse_vectors + i);
+        }
+        return vectors;
+    } else {
+        auto* float_vectors = (float*)allocator_->Allocate(sizeof(float) * count * dim_);
+        if (float_vectors == nullptr) {
+            throw VsagException(ErrorType::NO_ENOUGH_MEMORY,
+                                "failed to allocate memory for vectors");
+        }
+        vectors->NumElements(count)
+            ->Dim(dim_)
+            ->Float32Vectors(float_vectors)
+            ->Owner(true, allocator_);
+        for (int i = 0; i < count; ++i) {
+            InnerIdType inner_id = this->label_table_->GetIdByLabel(ids[i]);
+            this->GetVectorByInnerId(inner_id, float_vectors + i * dim_);
+        }
+        return vectors;
     }
-    vectors->NumElements(count)->Dim(dim_)->Float32Vectors(float_vectors)->Owner(true, allocator_);
-    for (int i = 0; i < count; ++i) {
-        InnerIdType inner_id = this->label_table_->GetIdByLabel(ids[i]);
-        this->GetVectorByInnerId(inner_id, float_vectors + i * dim_);
-    }
-    return vectors;
 }
 
 DatasetPtr

--- a/src/algorithm/inner_index_interface.h
+++ b/src/algorithm/inner_index_interface.h
@@ -174,7 +174,7 @@ public:
     GetExtraInfoByIds(const int64_t* ids, int64_t count, char* extra_infos) const;
 
     [[nodiscard]] virtual IndexType
-    GetIndexType() = 0;
+    GetIndexType() const = 0;
 
     [[nodiscard]] virtual int64_t
     GetMemoryUsage() const {
@@ -218,7 +218,13 @@ public:
                             "Index doesn't support GetVectorByInnerId");
     }
 
-    DatasetPtr
+    virtual void
+    GetSparseVectorByInnerId(InnerIdType inner_id, SparseVector* data) const {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "Index doesn't support GetSparseVectorByInnerId");
+    }
+
+    virtual DatasetPtr
     GetVectorByIds(const int64_t* ids, int64_t count) const;
 
     virtual void

--- a/src/algorithm/inner_index_interface_test.cpp
+++ b/src/algorithm/inner_index_interface_test.cpp
@@ -80,7 +80,7 @@ public:
     }
 
     IndexType
-    GetIndexType() override {
+    GetIndexType() const override {
         throw std::runtime_error("Index not support GetIndexType");
     }
 

--- a/src/algorithm/ivf.h
+++ b/src/algorithm/ivf.h
@@ -80,7 +80,7 @@ public:
     GetCodeByInnerId(InnerIdType inner_id, uint8_t* data) const override;
 
     [[nodiscard]] IndexType
-    GetIndexType() override {
+    GetIndexType() const override {
         return IndexType::IVF;
     }
 

--- a/src/algorithm/pyramid.h
+++ b/src/algorithm/pyramid.h
@@ -113,7 +113,7 @@ public:
     }
 
     IndexType
-    GetIndexType() override {
+    GetIndexType() const override {
         return IndexType::PYRAMID;
     }
 

--- a/src/algorithm/sindi/sindi.h
+++ b/src/algorithm/sindi/sindi.h
@@ -84,8 +84,11 @@ public:
     void
     Deserialize(StreamReader& reader) override;
 
+    void
+    GetSparseVectorByInnerId(InnerIdType inner_id, SparseVector* data) const override;
+
     IndexType
-    GetIndexType() override {
+    GetIndexType() const override {
         return IndexType::SINDI;
     }
 

--- a/src/algorithm/sparse_index.cpp
+++ b/src/algorithm/sparse_index.cpp
@@ -239,6 +239,16 @@ SparseIndex::CalcDistanceById(const DatasetPtr& vector, int64_t id) const {
     return CalDistanceByIdUnsafe(sorted_ids, sorted_vals, inner_id);
 }
 
+void
+SparseIndex::GetSparseVectorByInnerId(InnerIdType inner_id, SparseVector* data) const {
+    data->len_ = datas_[inner_id][0];
+    data->ids_ = (uint32_t*)allocator_->Allocate(sizeof(uint32_t) * data->len_);
+    data->vals_ = (float*)allocator_->Allocate(sizeof(float) * data->len_);
+
+    memcpy(data->ids_, datas_[inner_id] + 1, data->len_ * sizeof(uint32_t));
+    memcpy(data->vals_, datas_[inner_id] + 1 + datas_[inner_id][0], data->len_ * sizeof(float));
+}
+
 DatasetPtr
 SparseIndex::CalDistanceById(const DatasetPtr& query, const int64_t* ids, int64_t count) const {
     // prepare result
@@ -290,6 +300,7 @@ SparseIndex::InitFeatures() {
 
     // info
     this->index_feature_list_->SetFeature(IndexFeature::SUPPORT_CAL_DISTANCE_BY_ID);
+    this->index_feature_list_->SetFeature(IndexFeature::SUPPORT_GET_RAW_VECTOR_BY_IDS);
 
     // metric
     this->index_feature_list_->SetFeature(IndexFeature::SUPPORT_METRIC_TYPE_INNER_PRODUCT);

--- a/src/algorithm/sparse_index.h
+++ b/src/algorithm/sparse_index.h
@@ -52,8 +52,11 @@ public:
         return std::make_shared<SparseIndex>(this->create_param_ptr_, param);
     }
 
+    void
+    GetSparseVectorByInnerId(InnerIdType inner_id, SparseVector* data) const override;
+
     IndexType
-    GetIndexType() override {
+    GetIndexType() const override {
         return IndexType::SPARSE;
     }
 

--- a/src/datacell/sparse_term_datacell.cpp
+++ b/src/datacell/sparse_term_datacell.cpp
@@ -225,6 +225,28 @@ SparseTermDataCell::CalcDistanceByInnerId(const SparseTermComputerPtr& computer,
 }
 
 void
+SparseTermDataCell::GetSparseVector(uint32_t base_id, SparseVector* data) {
+    Vector<uint32_t> ids(allocator_);
+    Vector<float> vals(allocator_);
+
+    for (auto term = 0; term < term_ids_.size(); term++) {
+        for (auto i = 0; i < term_sizes_[term]; i++) {
+            if (term_ids_[term][i] == base_id) {
+                ids.push_back(term);
+                vals.push_back(term_datas_[term][i]);
+            }
+        }
+    }
+
+    data->len_ = ids.size();
+    data->ids_ = (uint32_t*)allocator_->Allocate(sizeof(uint32_t) * data->len_);
+    data->vals_ = (float*)allocator_->Allocate(sizeof(float) * data->len_);
+
+    memcpy(data->ids_, ids.data(), data->len_ * sizeof(uint32_t));
+    memcpy(data->vals_, vals.data(), data->len_ * sizeof(float));
+}
+
+void
 SparseTermDataCell::Serialize(StreamWriter& writer) const {
     StreamWriter::WriteObj(writer, term_capacity_);
     for (auto i = 0; i < term_capacity_; i++) {

--- a/src/datacell/sparse_term_datacell.h
+++ b/src/datacell/sparse_term_datacell.h
@@ -68,6 +68,9 @@ public:
     float
     CalcDistanceByInnerId(const SparseTermComputerPtr& computer, uint32_t base_id);
 
+    void
+    GetSparseVector(uint32_t base_id, SparseVector* data);
+
 public:
     uint32_t term_id_limit_{0};
 

--- a/src/index/diskann.h
+++ b/src/index/diskann.h
@@ -72,7 +72,7 @@ public:
     }
 
     IndexType
-    GetIndexType() override {
+    GetIndexType() const override {
         return IndexType::DISKANN;
     }
 

--- a/src/index/hnsw.h
+++ b/src/index/hnsw.h
@@ -82,7 +82,7 @@ public:
     }
 
     IndexType
-    GetIndexType() override {
+    GetIndexType() const override {
         return IndexType::HNSW;
     }
 

--- a/src/index/index_impl.h
+++ b/src/index/index_impl.h
@@ -196,7 +196,7 @@ public:
     };
 
     IndexType
-    GetIndexType() override {
+    GetIndexType() const override {
         return this->inner_index_->GetIndexType();
     }
 

--- a/tests/test_sindi.cpp
+++ b/tests/test_sindi.cpp
@@ -165,6 +165,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex, "SINDI Build and Search",
     auto dataset = pool.GetSparseDatasetAndCreate(base_count, 128, 0.8);
     REQUIRE(index->GetIndexType() == vsag::IndexType::SINDI);
     TestContinueAdd(index, dataset, true);
+    TestGetRawVectorByIds(index, dataset, true);
     TestKnnSearch(index, dataset, search_param, 0.99, true);
     TestSearchAllocator(index, dataset, search_param, 0.99, true);
     TestRangeSearch(index, dataset, search_param, 0.99, 10, true);

--- a/tests/test_sparse_index.cpp
+++ b/tests/test_sparse_index.cpp
@@ -51,6 +51,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::SparseTestIndex,
     auto dataset = pool.GetSparseDatasetAndCreate(base_count, 128, 0.8);
     REQUIRE(index->GetIndexType() == vsag::IndexType::SPARSE);
     TestContinueAdd(index, dataset, true);
+    TestGetRawVectorByIds(index, dataset, true);
     TestKnnSearch(index, dataset, search_param, 0.99, true);
     TestRangeSearch(index, dataset, search_param, 0.99, 10, true);
     TestRangeSearch(index, dataset, search_param, 0.49, 5, true);


### PR DESCRIPTION
close #1348 

## Summary by Sourcery

Implement raw vector retrieval for sparse indices, extend the index interface for sparse vector support, and update tests to validate this feature

New Features:
- Add support for retrieving raw sparse vectors by IDs via GetVectorByIds for SPARSE and SINDI indices

Enhancements:
- Extend InnerIndexInterface with GetSparseVectorByInnerId and update GetIndexType to be a const method across implementations
- Enable SUPPORT_GET_RAW_VECTOR_BY_IDS feature for SINDI and SparseIndex

Tests:
- Add TestGetRawVectorByIds to SINDI and SparseIndex test suites and update TestIndex to validate sparse vector retrieval and distance consistency