### PR TITLE
feat(BruteForce): enable thread_count config

### DIFF
--- a/include/vsag/constants.h
+++ b/include/vsag/constants.h
@@ -183,6 +183,7 @@ extern const char* const RAW_VECTOR_FILE_PATH;
 
 extern const char* const BRUTE_FORCE_QUANTIZATION_TYPE;
 extern const char* const BRUTE_FORCE_IO_TYPE;
+extern const char* const BRUTE_FORCE_THREAD_COUNT;
 
 extern const char* const IVF_USE_RESIDUAL;
 extern const char* const IVF_USE_REORDER;

--- a/src/algorithm/brute_force.cpp
+++ b/src/algorithm/brute_force.cpp
@@ -39,10 +39,6 @@ BruteForce::BruteForce(const BruteForceParameterPtr& param, const IndexCommonPar
     auto increase_count = Options::Instance().block_size_limit() / code_size;
     this->resize_increase_count_bit_ = std::max(
         DEFAULT_RESIZE_BIT, static_cast<uint64_t>(log2(static_cast<double>(increase_count))));
-    this->build_pool_ = common_param.thread_pool_;
-    if (this->build_pool_ == nullptr) {
-        this->build_pool_ = SafeThreadPool::FactoryDefaultThreadPool();
-    }
     this->use_attribute_filter_ = param->use_attribute_filter;
     this->has_raw_vector_ = true;
 }
@@ -446,7 +442,7 @@ static const std::string BRUTE_FORCE_PARAMS_TEMPLATE =
             "nbits": 8,
             "{HOLD_MOLDS}": false
         },
-        "{BUILD_THREAD_COUNT_KEY}": 10,
+        "{BUILD_THREAD_COUNT_KEY}": 1,
         "{USE_ATTRIBUTE_FILTER_KEY}": false,
         "{ATTR_PARAMS_KEY}": {
             "{ATTR_HAS_BUCKETS_KEY}": true
@@ -469,6 +465,12 @@ BruteForce::CheckAndMappingExternalParam(const JsonType& external_param,
             {
                 IO_PARAMS_KEY,
                 TYPE_KEY,
+            },
+        },
+        {
+            BRUTE_FORCE_THREAD_COUNT,
+            {
+                BUILD_THREAD_COUNT_KEY,
             },
         },
         {

--- a/src/algorithm/inner_index_interface.cpp
+++ b/src/algorithm/inner_index_interface.cpp
@@ -51,8 +51,10 @@ InnerIndexInterface::InnerIndexInterface(const InnerIndexParameterPtr& index_par
     }
 
     this->build_pool_ = common_param.thread_pool_;
-    if (this->build_thread_count_ > 1 && this->build_pool_ == nullptr) {
+    if (this->build_pool_ == nullptr) {
         this->build_pool_ = SafeThreadPool::FactoryDefaultThreadPool();
+    }
+    if (this->build_thread_count_ > 1) {
         this->build_pool_->SetPoolSize(build_thread_count_);
     }
 

--- a/src/algorithm/inner_index_interface.h
+++ b/src/algorithm/inner_index_interface.h
@@ -423,7 +423,7 @@ protected:
     uint64_t extra_info_size_{0};
     ExtraInfoInterfacePtr extra_infos_{nullptr};
 
-    uint64_t build_thread_count_{100};
+    uint64_t build_thread_count_{1};
 
     std::shared_ptr<SafeThreadPool> build_pool_{nullptr};
 

--- a/src/algorithm/inner_index_parameter.h
+++ b/src/algorithm/inner_index_parameter.h
@@ -46,7 +46,7 @@ public:
 
     bool use_attribute_filter{false};
 
-    uint64_t build_thread_count{100};
+    uint64_t build_thread_count{1};
 
     bool store_raw_vector{false};
     FlattenInterfaceParamPtr raw_vector_param{nullptr};

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -170,6 +170,7 @@ const char* const RAW_VECTOR_FILE_PATH = "raw_vector_file_path";
 
 const char* const BRUTE_FORCE_QUANTIZATION_TYPE = "quantization_type";
 const char* const BRUTE_FORCE_IO_TYPE = "io_type";
+const char* const BRUTE_FORCE_THREAD_COUNT = "thread_count";
 
 const char* const IVF_USE_RESIDUAL = "use_residual";
 const char* const IVF_USE_REORDER = "use_reorder";


### PR DESCRIPTION
## Summary by Sourcery

Enable thread count configuration for BruteForce and InnerIndex and update defaults and configuration mappings accordingly.

New Features:
- Add configurable 'thread_count' parameter to BruteForce and InnerIndex interfaces

Enhancements:
- Change default build_thread_count from 10/100 to 1 in code and JSON templates
- Refactor thread pool initialization to create default pool if missing and set its size based on build_thread_count
- Introduce BRUTE_FORCE_THREAD_COUNT constant and map it in external parameter handling