### PR TITLE
feat(pyramid): implement more fine-grained locks in pyramid

### DIFF
--- a/extern/diskann/diskann.cmake
+++ b/extern/diskann/diskann.cmake
@@ -35,7 +35,7 @@ set(DISKANN_SOURCES
 #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mavx2 -mfma -msse2 -ftree-vectorize -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free -fopenmp -fopenmp-simd -funroll-loops -Wfatal-errors -DUSE_AVX2")
 
 add_library(diskann STATIC ${DISKANN_SOURCES})
-target_compile_options(diskann PRIVATE -ftree-vectorize -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free -fopenmp -fopenmp-simd -funroll-loops -Wfatal-errors -DENABLE_CUSTOM_LOGGER=1)
+target_compile_options(diskann PRIVATE -ftree-vectorize -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free -fopenmp -fopenmp-simd -funroll-loops -Wno-error -DENABLE_CUSTOM_LOGGER=1)
 set_property(TARGET diskann PROPERTY CXX_STANDARD 17)
 add_dependencies(diskann boost openblas)
 

--- a/extern/diskann/diskann.cmake
+++ b/extern/diskann/diskann.cmake
@@ -35,7 +35,7 @@ set(DISKANN_SOURCES
 #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mavx2 -mfma -msse2 -ftree-vectorize -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free -fopenmp -fopenmp-simd -funroll-loops -Wfatal-errors -DUSE_AVX2")
 
 add_library(diskann STATIC ${DISKANN_SOURCES})
-target_compile_options(diskann PRIVATE -ftree-vectorize -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free -fopenmp -fopenmp-simd -funroll-loops -Wno-error -DENABLE_CUSTOM_LOGGER=1)
+target_compile_options(diskann PRIVATE -ftree-vectorize -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free -fopenmp -fopenmp-simd -funroll-loops -Wfatal-errors -DENABLE_CUSTOM_LOGGER=1)
 set_property(TARGET diskann PROPERTY CXX_STANDARD 17)
 add_dependencies(diskann boost openblas)
 

--- a/src/algorithm/pyramid.cpp
+++ b/src/algorithm/pyramid.cpp
@@ -395,10 +395,11 @@ Pyramid::Add(const DatasetPtr& base) {
                     std::scoped_lock<std::mutex> entry_point_lock(entry_point_mutex_);
                     update_entry_point = is_update_entry_point(node->graph_->TotalCount());
                 }
+                search_param.ep = node->entry_point_;
                 if (not update_entry_point) {
                     graph_lock.unlock();
                 }
-                search_param.ep = node->entry_point_;
+
                 auto vl = pool_->TakeOne();
                 auto results = searcher_->Search(
                     node->graph_, base_codes_, vl, data_vectors + dim_ * i, search_param);

--- a/src/algorithm/pyramid.cpp
+++ b/src/algorithm/pyramid.cpp
@@ -150,7 +150,7 @@ IndexNode::InitGraph() {
 }
 
 DistHeapPtr
-IndexNode::SearchGraph(const SearchFunc& search_func, VisitedListPtr vl) const {
+IndexNode::SearchGraph(const SearchFunc& search_func, const VisitedListPtr& vl) const {
     if (graph_ != nullptr && graph_->TotalCount() > 0) {
         return search_func(this, vl);
     }
@@ -215,7 +215,7 @@ Pyramid::KnnSearch(const DatasetPtr& query,
         search_param.is_inner_id_allowed =
             std::make_shared<InnerIdWrapperFilter>(filter, *label_table_);
     }
-    SearchFunc search_func = [&](const IndexNode* node, VisitedListPtr vl) {
+    SearchFunc search_func = [&](const IndexNode* node, const VisitedListPtr& vl) {
         std::shared_lock lock(node->mutex_);
         search_param.ep = node->entry_point_;
         auto results = searcher_->Search(
@@ -240,7 +240,7 @@ Pyramid::RangeSearch(const DatasetPtr& query,
         search_param.is_inner_id_allowed =
             std::make_shared<InnerIdWrapperFilter>(filter, *label_table_);
     }
-    SearchFunc search_func = [&](const IndexNode* node, VisitedListPtr vl) {
+    SearchFunc search_func = [&](const IndexNode* node, const VisitedListPtr& vl) {
         std::shared_lock lock(node->mutex_);
         search_param.ep = node->entry_point_;
         auto results = searcher_->Search(
@@ -366,7 +366,7 @@ Pyramid::Add(const DatasetPtr& base) {
         auto path_slices = split(current_path, PART_SLASH);
         std::shared_ptr<IndexNode> node = root_;
         auto inner_id = static_cast<InnerIdType>(i + local_cur_element_count);
-        auto vector = data_vectors + dim_ * i;
+        const auto* vector = data_vectors + dim_ * i;
         int no_build_level_index = 0;
         for (int j = 0; j <= path_slices.size(); ++j) {
             std::shared_ptr<IndexNode> new_node = nullptr;
@@ -560,7 +560,9 @@ Pyramid::Build(const DatasetPtr& base) {
 }
 
 void
-Pyramid::add_one_point(std::shared_ptr<IndexNode> node, InnerIdType inner_id, const float* vector) {
+Pyramid::add_one_point(const std::shared_ptr<IndexNode>& node,
+                       InnerIdType inner_id,
+                       const float* vector) {
     std::unique_lock graph_lock(node->mutex_);
     InnerSearchParam search_param;
     search_param.ef = pyramid_param_->ef_construction;

--- a/src/algorithm/pyramid.cpp
+++ b/src/algorithm/pyramid.cpp
@@ -62,7 +62,7 @@ IndexNode::IndexNode(IndexCommonParam* common_param, GraphInterfaceParamPtr grap
 
 void
 IndexNode::BuildGraph(ODescent& odescent) {
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::unique_lock lock(mutex_);
     // Build an index when the level corresponding to the current node requires indexing
     if (has_index_ && not ids_.empty()) {
         InitGraph();
@@ -85,7 +85,7 @@ IndexNode::AddChild(const std::string& key) {
 
 std::shared_ptr<IndexNode>
 IndexNode::GetChild(const std::string& key, bool need_init) {
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::unique_lock lock(mutex_);
     auto result = children_.find(key);
     if (result != children_.end()) {
         return result->second;
@@ -150,14 +150,15 @@ IndexNode::InitGraph() {
 }
 
 DistHeapPtr
-IndexNode::SearchGraph(const SearchFunc& search_func) const {
+IndexNode::SearchGraph(const SearchFunc& search_func, VisitedListPtr vl) const {
     if (graph_ != nullptr && graph_->TotalCount() > 0) {
-        return search_func(this);
+        return search_func(this, vl);
     }
     auto search_result =
         std::make_shared<StandardHeap<true, false>>(common_param_->allocator_.get(), -1);
+
     for (const auto& [key, node] : children_) {
-        DistHeapPtr child_search_result = node->SearchGraph(search_func);
+        DistHeapPtr child_search_result = node->SearchGraph(search_func, vl);
         while (not child_search_result->Empty()) {
             auto result = child_search_result->Top();
             child_search_result->Pop();
@@ -214,13 +215,11 @@ Pyramid::KnnSearch(const DatasetPtr& query,
         search_param.is_inner_id_allowed =
             std::make_shared<InnerIdWrapperFilter>(filter, *label_table_);
     }
-    SearchFunc search_func = [&](const IndexNode* node) {
+    SearchFunc search_func = [&](const IndexNode* node, VisitedListPtr vl) {
+        std::shared_lock lock(node->mutex_);
         search_param.ep = node->entry_point_;
-        std::lock_guard<std::mutex> lock(node->mutex_);
-        auto vl = pool_->TakeOne();
         auto results = searcher_->Search(
             node->graph_, base_codes_, vl, query->GetFloat32Vectors(), search_param);
-        pool_->ReturnOne(vl);
         return results;
     };
     return this->search_impl(query, k, search_func);
@@ -241,13 +240,11 @@ Pyramid::RangeSearch(const DatasetPtr& query,
         search_param.is_inner_id_allowed =
             std::make_shared<InnerIdWrapperFilter>(filter, *label_table_);
     }
-    SearchFunc search_func = [&](const IndexNode* node) {
+    SearchFunc search_func = [&](const IndexNode* node, VisitedListPtr vl) {
+        std::shared_lock lock(node->mutex_);
         search_param.ep = node->entry_point_;
-        std::lock_guard<std::mutex> lock(node->mutex_);
-        auto vl = pool_->TakeOne();
         auto results = searcher_->Search(
             node->graph_, base_codes_, vl, query->GetFloat32Vectors(), search_param);
-        pool_->ReturnOne(vl);
         return results;
     };
     int64_t final_limit = limited_size == -1 ? std::numeric_limits<int64_t>::max() : limited_size;
@@ -268,7 +265,11 @@ Pyramid::search_impl(const DatasetPtr& query, int64_t limit, const SearchFunc& s
             return DatasetImpl::MakeEmptyDataset();
         }
     }
-    auto search_result = node->SearchGraph(search_func);
+
+    auto vl = pool_->TakeOne();
+    auto search_result = node->SearchGraph(search_func, vl);
+    pool_->ReturnOne(vl);
+
     while (search_result->Size() > limit) {
         search_result->Pop();
     }
@@ -363,7 +364,6 @@ Pyramid::Add(const DatasetPtr& base) {
     search_param.ef = pyramid_param_->ef_construction;
     search_param.topk = pyramid_param_->max_degree;
     search_param.search_mode = KNN_SEARCH;
-    auto empty_mutex = std::make_shared<EmptyMutex>();
     for (auto i = 0; i < data_num; ++i) {
         std::string current_path = path[i];
         auto path_slices = split(current_path, PART_SLASH);
@@ -381,7 +381,7 @@ Pyramid::Add(const DatasetPtr& base) {
                 no_build_level_index++;
                 continue;
             }
-            std::lock_guard<std::mutex> graph_lock(node->mutex_);
+            std::unique_lock graph_lock(node->mutex_);
             // add one point
             if (node->graph_ == nullptr) {
                 node->InitGraph();
@@ -395,13 +395,21 @@ Pyramid::Add(const DatasetPtr& base) {
                     std::scoped_lock<std::mutex> entry_point_lock(entry_point_mutex_);
                     update_entry_point = is_update_entry_point(node->graph_->TotalCount());
                 }
+                if (not update_entry_point) {
+                    graph_lock.unlock();
+                }
                 search_param.ep = node->entry_point_;
                 auto vl = pool_->TakeOne();
                 auto results = searcher_->Search(
                     node->graph_, base_codes_, vl, data_vectors + dim_ * i, search_param);
                 pool_->ReturnOne(vl);
-                mutually_connect_new_element(
-                    inner_id, results, node->graph_, base_codes_, empty_mutex, allocator_, alpha_);
+                mutually_connect_new_element(inner_id,
+                                             results,
+                                             node->graph_,
+                                             base_codes_,
+                                             points_mutex_,
+                                             allocator_,
+                                             alpha_);
                 if (update_entry_point) {
                     node->entry_point_ = inner_id;
                 }
@@ -421,6 +429,7 @@ Pyramid::resize(int64_t new_max_capacity) {
     pool_ = std::make_unique<VisitedListPool>(1, allocator_, new_max_capacity, allocator_);
     label_table_->label_table_.resize(new_max_capacity);
     base_codes_->Resize(new_max_capacity);
+    points_mutex_->Resize(new_max_capacity);
     max_capacity_ = new_max_capacity;
 }
 
@@ -442,10 +451,9 @@ Pyramid::InitFeatures() {
     });
 
     // concurrency
-    this->index_feature_list_->SetFeatures({
-        IndexFeature::SUPPORT_SEARCH_CONCURRENT,
-        IndexFeature::SUPPORT_ADD_CONCURRENT,
-    });
+    this->index_feature_list_->SetFeatures({IndexFeature::SUPPORT_SEARCH_CONCURRENT,
+                                            IndexFeature::SUPPORT_ADD_CONCURRENT,
+                                            IndexFeature::SUPPORT_ADD_SEARCH_CONCURRENT});
 
     // serialize
     this->index_feature_list_->SetFeatures({

--- a/src/algorithm/pyramid.cpp
+++ b/src/algorithm/pyramid.cpp
@@ -328,6 +328,7 @@ Pyramid::Deserialize(StreamReader& reader) {
     base_codes_->Deserialize(buffer_reader);
     root_->Deserialize(buffer_reader);
     pool_ = std::make_unique<VisitedListPool>(1, allocator_, base_codes_->TotalCount(), allocator_);
+    resize(base_codes_->TotalCount());
 }
 
 std::vector<int64_t>
@@ -383,7 +384,7 @@ Pyramid::Add(const DatasetPtr& base) {
         }
     };
 
-    Vector<std::future<void>> futures;
+    Vector<std::future<void>> futures(allocator_);
     for (auto i = 0; i < data_num; ++i) {
         if (this->build_pool_ != nullptr) {
             futures.push_back(this->build_pool_->GeneralEnqueue(add_func, i));

--- a/src/algorithm/pyramid.h
+++ b/src/algorithm/pyramid.h
@@ -28,11 +28,12 @@
 #include "io/memory_io_parameter.h"
 #include "pyramid_zparameters.h"
 #include "quantization/fp32_quantizer_parameter.h"
+#include "utils/lock_strategy.h"
 
 namespace vsag {
 
 class IndexNode;
-using SearchFunc = std::function<DistHeapPtr(const IndexNode* node)>;
+using SearchFunc = std::function<DistHeapPtr(const IndexNode* node, VisitedListPtr vl)>;
 
 class IndexNode {
 public:
@@ -45,7 +46,7 @@ public:
     InitGraph();
 
     DistHeapPtr
-    SearchGraph(const SearchFunc& search_func) const;
+    SearchGraph(const SearchFunc& search_func, VisitedListPtr vl) const;
 
     void
     AddChild(const std::string& key);
@@ -63,7 +64,7 @@ public:
     GraphInterfacePtr graph_{nullptr};
     InnerIdType entry_point_{0};
     uint32_t level_{0};
-    mutable std::mutex mutex_;
+    mutable std::shared_mutex mutex_;
 
     Vector<InnerIdType> ids_;
     bool has_index_{false};
@@ -87,10 +88,11 @@ public:
           pyramid_param_(pyramid_param),
           common_param_(common_param),
           alpha_(pyramid_param->alpha) {
-        searcher_ = std::make_unique<BasicSearcher>(common_param_);
         base_codes_ =
             FlattenInterface::MakeInstance(pyramid_param_->base_codes_param, common_param_);
         root_ = std::make_shared<IndexNode>(&common_param_, pyramid_param_->graph_param);
+        points_mutex_ = std::make_shared<PointsMutex>(max_capacity_, allocator_);
+        searcher_ = std::make_unique<BasicSearcher>(common_param_, points_mutex_);
     }
 
     explicit Pyramid(const ParamPtr& param, const IndexCommonParam& common_param)
@@ -181,6 +183,8 @@ private:
 
     std::mutex entry_point_mutex_;
     std::default_random_engine level_generator_{2021};
+
+    MutexArrayPtr points_mutex_{nullptr};
 };
 
 }  // namespace vsag

--- a/src/algorithm/pyramid.h
+++ b/src/algorithm/pyramid.h
@@ -33,7 +33,7 @@
 namespace vsag {
 
 class IndexNode;
-using SearchFunc = std::function<DistHeapPtr(const IndexNode* node, VisitedListPtr vl)>;
+using SearchFunc = std::function<DistHeapPtr(const IndexNode* node, const VisitedListPtr& vl)>;
 
 class IndexNode {
 public:

--- a/src/algorithm/pyramid.h
+++ b/src/algorithm/pyramid.h
@@ -166,6 +166,9 @@ private:
     std::vector<int64_t>
     build_by_odescent(const DatasetPtr& base);
 
+    void
+    add_one_point(std::shared_ptr<IndexNode> node, InnerIdType inner_id, const float* vector);
+
 private:
     IndexCommonParam common_param_;
     PyramidParamPtr pyramid_param_{nullptr};

--- a/src/algorithm/pyramid.h
+++ b/src/algorithm/pyramid.h
@@ -46,7 +46,7 @@ public:
     InitGraph();
 
     DistHeapPtr
-    SearchGraph(const SearchFunc& search_func, VisitedListPtr vl) const;
+    SearchGraph(const SearchFunc& search_func, const VisitedListPtr& vl) const;
 
     void
     AddChild(const std::string& key);
@@ -167,7 +167,9 @@ private:
     build_by_odescent(const DatasetPtr& base);
 
     void
-    add_one_point(std::shared_ptr<IndexNode> node, InnerIdType inner_id, const float* vector);
+    add_one_point(const std::shared_ptr<IndexNode>& node,
+                  InnerIdType inner_id,
+                  const float* vector);
 
 private:
     IndexCommonParam common_param_;

--- a/src/algorithm/pyramid.h
+++ b/src/algorithm/pyramid.h
@@ -172,6 +172,8 @@ private:
     std::shared_ptr<IndexNode> root_{nullptr};
     FlattenInterfacePtr base_codes_{nullptr};
     std::unique_ptr<VisitedListPool> pool_ = nullptr;
+
+    MutexArrayPtr points_mutex_{nullptr};
     std::unique_ptr<BasicSearcher> searcher_ = nullptr;
     int64_t max_capacity_{0};
     int64_t cur_element_count_{0};
@@ -183,8 +185,6 @@ private:
 
     std::mutex entry_point_mutex_;
     std::default_random_engine level_generator_{2021};
-
-    MutexArrayPtr points_mutex_{nullptr};
 };
 
 }  // namespace vsag

--- a/src/datacell/flatten_interface.h
+++ b/src/datacell/flatten_interface.h
@@ -120,6 +120,7 @@ public:
 
     [[nodiscard]] virtual InnerIdType
     TotalCount() const {
+        std::shared_lock lock(mutex_);
         return this->total_count_;
     }
 
@@ -161,7 +162,7 @@ public:
     }
 
 public:
-    std::shared_mutex mutex_;
+    mutable std::shared_mutex mutex_;
 
     InnerIdType total_count_{0};
     InnerIdType max_capacity_{800};

--- a/tests/test_pyramid.cpp
+++ b/tests/test_pyramid.cpp
@@ -229,7 +229,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
                              "[ft][pyramid][concurrent]") {
     auto metric_type = GENERATE("l2");
     PyramidParam pyramid_param;
-    pyramid_param.no_build_levels = {0, 1, 2};
+    pyramid_param.no_build_levels = {0, 1};
     const std::string name = "pyramid";
     auto search_param = fmt::format(search_param_tmp, 20);
     for (auto& dim : dims) {
@@ -238,5 +238,11 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
         auto dataset = pool.GetDatasetAndCreate(dim, base_count, metric_type, /*with_path=*/true);
         TestConcurrentAdd(index, dataset, true);
         TestConcurrentKnnSearch(index, dataset, search_param, 0.99, true);
+    }
+    for (auto& dim : dims) {
+        auto param = GeneratePyramidBuildParametersString(metric_type, dim, pyramid_param);
+        auto index = TestFactory(name, param, true);
+        auto dataset = pool.GetDatasetAndCreate(dim, base_count, metric_type, /*with_path=*/true);
+        TestConcurrentAddSearch(index, dataset, search_param, 0.99, true);
     }
 }


### PR DESCRIPTION
close: #1336

## Summary by Sourcery

Enhance pyramid index concurrency by introducing fine-grained locking strategies and extending search interfaces to support concurrent add and search operations.

New Features:
- Add per-point locking via PointsMutex to enable concurrent additions and searches
- Extend SearchFunc and SearchGraph to accept a VisitedListPtr for improved resource management
- Introduce SUPPORT_ADD_SEARCH_CONCURRENT feature flag for pyramid index

Enhancements:
- Replace node-level std::mutex with std::shared_mutex and use shared_lock for reads and unique_lock for writes
- Refactor locking in build, search, and add routines to reduce contention and unlock early when possible
- Move VisitedListPool allocation outside recursive SearchGraph calls to streamline lock usage
- Resize points_mutex_ array to match capacity changes

Tests:
- Add TestConcurrentAddSearch for combined concurrent add and search scenarios
- Adjust no_build_levels in pyramid concurrency tests