### PR TITLE
improvment(parallel search): optimize hgraph parallel search

### DIFF
--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -382,6 +382,8 @@ HGraph::KnnSearch(const DatasetPtr& query,
         search_param.ef = std::max(params.ef_search, k);
         search_param.is_inner_id_allowed = ft;
         search_param.topk = static_cast<int64_t>(search_param.ef);
+        search_param.parallel_search_thread_count = params.parallel_search_thread_count;
+
         search_result = this->search_one_graph(query_data,
                                                this->bottom_graph_,
                                                this->basic_flatten_codes_,
@@ -499,7 +501,7 @@ HGraph::search_one_graph(const void* query,
         visited_list->Reset();
     }
     DistHeapPtr result = nullptr;
-    if (inner_search_param.use_muti_threads_for_one_query && inner_search_param.level_0) {
+    if (inner_search_param.parallel_search_thread_count > 1) {
         result = this->parallel_searcher_->Search(
             graph, flatten, visited_list, query, inner_search_param);
     } else {
@@ -580,12 +582,15 @@ HGraph::RangeSearch(const DatasetPtr& query,
     search_param.search_mode = RANGE_SEARCH;
     search_param.consider_duplicate = true;
     search_param.range_search_limit_size = static_cast<int>(limited_size);
+    search_param.parallel_search_thread_count = params.parallel_search_thread_count;
+
     auto search_result = this->search_one_graph(raw_query,
                                                 this->bottom_graph_,
                                                 this->basic_flatten_codes_,
                                                 search_param,
                                                 (VisitedListPtr) nullptr,
                                                 stats);
+
     if (use_reorder_) {
         this->reorder(raw_query, this->high_precise_codes_, search_result, limited_size);
     }
@@ -1979,6 +1984,7 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
         search_param.time_cost->SetThreshold(params.timeout_ms);
         stats.is_timeout.store(false, std::memory_order_relaxed);
     }
+    search_param.parallel_search_thread_count = params.parallel_search_thread_count;
 
     auto search_result = this->search_one_graph(
         raw_query, this->bottom_graph_, this->basic_flatten_codes_, search_param, vt, stats);

--- a/src/impl/inner_search_param.h
+++ b/src/impl/inner_search_param.h
@@ -45,11 +45,6 @@ public:
     int range_search_limit_size{-1};
     int64_t parallel_search_thread_count{1};
 
-    //​​Multi-threaded search for a single query​
-    bool use_muti_threads_for_one_query{false};
-    uint64_t parallel_search_thread_count_per_query{4};
-    bool level_0{false};
-
     // for ivf
     int scan_bucket_size{1};
     float factor{2.0F};
@@ -81,9 +76,7 @@ public:
             scan_bucket_size = other.scan_bucket_size;
             factor = other.factor;
             first_order_scan_ratio = other.first_order_scan_ratio;
-            use_muti_threads_for_one_query = other.use_muti_threads_for_one_query;
-            parallel_search_thread_count_per_query = other.parallel_search_thread_count_per_query;
-            level_0 = other.level_0;
+            parallel_search_thread_count = other.parallel_search_thread_count;
         }
         return *this;
     }

--- a/src/utils/spsc_queue.h
+++ b/src/utils/spsc_queue.h
@@ -1,0 +1,69 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+
+namespace vsag {
+
+template <typename T, uint64_t N>
+class SPSCQueue {
+    static_assert(N && !(N & (N - 1)), "N must be power of 2");
+
+    alignas(64) std::atomic<uint64_t> write_idx{0};
+    alignas(64) std::atomic<uint64_t> read_idx{0};
+    alignas(64) T buffer[N];
+
+public:
+    inline bool
+    Push(const T& item) {
+        auto current_write = write_idx.load(std::memory_order_relaxed);
+        auto next_write = current_write + 1;
+        if (next_write - read_idx.load(std::memory_order_acquire) >= N) {
+            return false;  // full
+        }
+
+        buffer[current_write & (N - 1)] = item;
+        write_idx.store(next_write, std::memory_order_release);
+        return true;
+    }
+
+    inline bool
+    Push(T&& item) {
+        auto current_write = write_idx.load(std::memory_order_relaxed);
+        auto next_write = current_write + 1;
+        if (next_write - read_idx.load(std::memory_order_acquire) >= N) {
+            return false;  // full
+        }
+
+        buffer[current_write & (N - 1)] = std::move(item);
+        write_idx.store(next_write, std::memory_order_release);
+        return true;
+    }
+
+    inline bool
+    Pop(T& out) {
+        auto current_read = read_idx.load(std::memory_order_relaxed);
+        if (current_read == write_idx.load(std::memory_order_acquire)) {
+            return false;  // empty
+        }
+
+        out = buffer[current_read & (N - 1)];
+        read_idx.store(current_read + 1, std::memory_order_release);
+        return true;
+    }
+};
+}  // namespace vsag


### PR DESCRIPTION
closed: #1354 

non-parallel; CPU:100%
<img width="2698" height="160" alt="image" src="https://github.com/user-attachments/assets/46fcc526-b064-4874-bbb2-362ecd40ce62" />


parallel = 2; CPU:196%
<img width="2682" height="166" alt="image" src="https://github.com/user-attachments/assets/17eb3c43-b48c-43fb-8476-46937fa7b1ac" />

## Summary by Sourcery

Optimize the hgraph parallel search by introducing a lock-free SPSCQueue and persistent worker threads to streamline task dispatch and reduce threading overhead, leading to higher CPU utilization.

New Features:
- Add a reusable SPSCQueue utility for single-producer single-consumer communication

Enhancements:
- Refactor ParallelSearcher to use persistent worker threads and SPSCQueue for task distribution
- Replace per-iteration future-based parallelism with queue-driven processing to reduce overhead
- Improve workload distribution and synchronization for distance computations