### PR TITLE
feat(hgraph): support reader_io in base quantizer and graph

### DIFF
--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -1834,11 +1834,13 @@ HGraph::SetImmutable() {
 
 void
 HGraph::SetIO(const std::shared_ptr<Reader> reader) {
+    auto reader_param = std::make_shared<ReaderIOParameter>();
+    reader_param->reader = reader;
     if (use_reorder_) {
-        auto reader_param = std::make_shared<ReaderIOParameter>();
-        reader_param->reader = reader;
         high_precise_codes_->InitIO(reader_param);
     }
+    basic_flatten_codes_->InitIO(reader_param);
+    bottom_graph_->InitIO(reader_param);
 }
 
 [[nodiscard]] DatasetPtr

--- a/src/datacell/graph_datacell.h
+++ b/src/datacell/graph_datacell.h
@@ -70,6 +70,11 @@ public:
         this->io_ = io;
     }
 
+    virtual void
+    InitIO(const IOParamPtr& io_param) override {
+        this->io_->InitIO(io_param);
+    }
+
     /****
      * prefetch neighbors of a base point with id
      * @param id of base point

--- a/src/datacell/graph_interface.h
+++ b/src/datacell/graph_interface.h
@@ -23,6 +23,7 @@
 #include "graph_interface_parameter.h"
 #include "index_common_param.h"
 #include "inner_string_params.h"
+#include "io/io_parameter.h"
 #include "storage/stream_reader.h"
 #include "storage/stream_writer.h"
 #include "typing.h"
@@ -136,6 +137,10 @@ public:
     SetMaxCapacity(InnerIdType capacity) {
         this->max_capacity_ = std::max(capacity, this->total_count_.load());
     };
+
+    virtual void
+    InitIO(const IOParamPtr& io_param) {
+    }
 
 public:
     InnerIdType max_capacity_{100};


### PR DESCRIPTION
## Summary by Sourcery

Add IO initialization support across graph components to propagate reader-based IO parameters through the hgraph quantizer and graph layers.

New Features:
- Allow HGraph to initialize IO parameters for base flatten codes and bottom graph using a shared Reader-based IO parameter.
- Expose an InitIO hook on GraphInterface and implement it in GraphDataCell to forward IO initialization to the underlying IO object.

Enhancements:
- Include IO parameter definitions in graph interface headers to enable consistent IO initialization across graph implementations.