### PR TITLE
feat(c_api): add more api for c-sdk

### DIFF
--- a/include/vsag/vsag_c_api.h
+++ b/include/vsag/vsag_c_api.h
@@ -37,28 +37,273 @@ extern "C" {
 typedef struct Error {
     int code;
     char message[1024];
-} Error_t;
+} Error_t; /** The error code. */
 
-typedef void* vsag_index_t;
+typedef void* vsag_index_t; /** The vsag index handle. */
+
+typedef bool (*FilterFunc_t)(int64_t id);
+typedef struct SearchResult {
+    float* dists;       /** The distances of the results. */
+    int64_t* ids;       /** The ids of the results. */
+    int64_t count;      /** The count of the results. */
+    void* other_result; /** The other result of the search. */
+} SearchResult_t;       /** The search result. */
+
+/**
+ * @brief Create a index factory object.
+ *
+ * @param index_name The name of the index.
+ * @param index_param The parameter of the index.
+ * @return vsag_index_t The vsag index handle.
+ */
 vsag_index_t
 vsag_index_factory(const char* index_name, const char* index_param);
 
+/**
+ * @brief Destroy the index factory object.
+ *
+ * @param index The vsag index handle.
+ * @return Error_t The error code.
+ */
 Error_t
 vsag_index_destroy(vsag_index_t index);
 
+/**
+ * @brief Build the index, include train and add.
+ *
+ * @param index The vsag index handle.
+ * @param data The data to build the index.
+ * @param ids The ids of the data.
+ * @param dim The dimension of the data.
+ * @param count The count of the data.
+ * @return Error_t The error code.
+ */
 Error_t
 vsag_index_build(
     vsag_index_t index, const float* data, const int64_t* ids, uint64_t dim, uint64_t count);
 
+/**
+ * @brief Add more data to the index, suppose the index is trained.
+ *
+ * @param index The vsag index handle.
+ * @param data The data to add to the index.
+ * @param ids The ids of the data.
+ * @param dim The dimension of the data.
+ * @param count The count of the data.
+ * @return Error_t The error code.
+ */
+Error_t
+vsag_index_add(vsag_index_t index,
+               const float* data,
+               const int64_t* ids,
+               const uint64_t dim,
+               const uint64_t count);
+
+/**
+ * @brief Train the index, no data is added to the index.
+ *
+ * @param index The vsag index handle.
+ * @param data The data to train the index.
+ * @param ids The ids of the data.
+ * @param dim The dimension of the data.
+ * @param count The count of the data.
+ * @return Error_t The error code.
+ */
+Error_t
+vsag_index_train(vsag_index_t index,
+                 const float* data,
+                 const int64_t* ids,
+                 const uint64_t dim,
+                 const uint64_t count);
+
+/**
+ * @brief Knn Search the index.
+ *
+ * @param index The vsag index handle.
+ * @param query The query data.
+ * @param dim The dimension of the query data.
+ * @param k The top k results.
+ * @param parameters The parameters of the search.
+ * @param result The result of the search.
+ * @return Error_t The error code.
+ */
 Error_t
 vsag_index_knn_search(vsag_index_t index,
                       const float* query,
                       uint64_t dim,
                       int64_t k,
                       const char* parameters,
-                      float* results,
-                      int64_t* ids);
+                      SearchResult_t* search_result);
 
+/**
+ * @brief Knn Search the index with filter.
+ *
+ * @param index The vsag index handle.
+ * @param query The query data.
+ * @param dim The dimension of the query data.
+ * @param k The top k results.
+ * @param parameters The parameters of the search.
+ * @param filter The filter function.
+ * @param result The result of the search.
+ * @return Error_t The error code.
+ */
+Error_t
+vsag_index_knn_search_with_filter(vsag_index_t index,
+                                  const float* query,
+                                  uint64_t dim,
+                                  int64_t k,
+                                  const char* parameters,
+                                  FilterFunc_t filter,
+                                  SearchResult_t* search_result);
+
+/**
+ * @brief Range Search the index.
+ *
+ * @param index The vsag index handle.
+ * @param query The query data.
+ * @param dim The dimension of the query data.
+ * @param radius The radius of the search.
+ * @param parameters The parameters of the search.
+ * @param result The result of the search.
+ * @return Error_t The error code.
+ */
+Error_t
+vsag_index_range_search(vsag_index_t index,
+                        const float* query,
+                        uint64_t dim,
+                        float radius,
+                        const char* parameters,
+                        SearchResult_t* search_result);
+
+/**
+ * @brief Range Search the index with filter.
+ *
+ * @param index The vsag index handle.
+ * @param query The query data.
+ * @param dim The dimension of the query data.
+ * @param radius The radius of the search.
+ * @param parameters The parameters of the search.
+ * @param filter The filter function.
+ * @param result The result of the search.
+ * @return Error_t The error code.
+ */
+Error_t
+vsag_index_range_search_with_filter(vsag_index_t index,
+                                    const float* query,
+                                    uint64_t dim,
+                                    float radius,
+                                    const char* parameters,
+                                    FilterFunc_t filter,
+                                    SearchResult_t* search_result);
+
+/**
+ * @brief Clone the index.
+ *
+ * @param index The vsag index handle.
+ * @param clone_index The output cloned vsag index handle's pointer.
+ * @return Error_t The error code.
+ */
+Error_t
+vsag_index_clone(const vsag_index_t index, vsag_index_t* clone_index);
+
+/**
+ * @brief Export the model index.
+ *
+ * @param index The vsag index handle.
+ * @param model_index The output vsag index handle's pointer(empty index as model).
+ * @return Error_t The error code.
+ */
+Error_t
+vsag_index_export_model(const vsag_index_t index, vsag_index_t* model_index);
+
+/**
+ * @brief Calculate the distance between query and ids.
+ *
+ * @param index The vsag index handle.
+ * @param query The query data.
+ * @param dim The dimension of the query data.
+ * @param ids The ids of the data.
+ * @param count The count of the ids.
+ * @param dists The output distances of the ids.
+ * @return Error_t The error code.
+ */
+Error_t
+vsag_index_calculate_distance_by_ids(const vsag_index_t index,
+                                     const float* query,
+                                     const uint64_t dim,
+                                     const int64_t* ids,
+                                     const uint64_t count,
+                                     float* dists);
+
+/**
+ * @brief Update the ids of the data.
+ *
+ * @param index The vsag index handle.
+ * @param old_ids The old ids of the data.
+ * @param new_ids The new ids of the data.
+ * @param dim The dimension of the data.
+ * @param count The count of the data.
+ * @return Error_t The error code.
+ */
+Error_t
+vsag_index_update_ids(vsag_index_t index,
+                      const int64_t* old_ids,
+                      const int64_t* new_ids,
+                      const uint64_t dim,
+                      const uint64_t count);
+/**
+ * @brief Update the vector of the data, replace the origin vector with new vector.
+ *        No suppose the origin and new vector are similar.
+ *
+ * @param index The vsag index handle.
+ * @param id The id of the data.
+ * @param new_data The new vector of the data.
+ * @param dim The dimension of the data.
+ * @return Error_t The error code.
+ */
+Error_t
+vsag_index_update_vector(vsag_index_t index,
+                         const int64_t id,
+                         const float* new_data,
+                         const uint64_t dim);
+
+/**
+ * @brief Update the vector of the data, force replace. 
+ * Suppose the origin and new vector are similar.
+ *
+ * @param index The vsag index handle.
+ * @param id The id of the data.
+ * @param new_data The new vector of the data.
+ * @param dim The dimension of the data.
+ * @return Error_t The error code.
+ */
+Error_t
+vsag_index_update_vector_force(vsag_index_t index,
+                               const int64_t id,
+                               const float* new_data,
+                               const uint64_t dim);
+/**
+ * @brief Get the vectors of the data by ids.
+ *
+ * @param index The vsag index handle.
+ * @param ids The ids of the data.
+ * @param count The count of the ids.
+ * @param vectors The output vectors of the data.
+ * @return Error_t The error code.
+ */
+Error_t
+vsag_index_get_vector_by_ids(vsag_index_t index,
+                             const int64_t* ids,
+                             const uint64_t count,
+                             float* vectors);
+
+/**
+ * @brief Serialize the index to a file.
+ *
+ * @param index The vsag index handle.
+ * @param file_path The file path to serialize the index.
+ * @return Error_t The error code.
+ */
 Error_t
 vsag_serialize_file(vsag_index_t index, const char* file_path);
 

--- a/src/vsag_c_api.cpp
+++ b/src/vsag_c_api.cpp
@@ -51,6 +51,23 @@ make_error(const std::exception& e) {
     return err;
 }
 
+static Error_t
+make_error(const std::string& msg) {
+    Error_t err;
+    err.code = VSAG_INTERNAL_ERROR;
+    snprintf(err.message, sizeof(err.message), "%s", msg.c_str());
+    return err;
+}
+
+#define VSAG_CHECK_RESULT(expr)                    \
+    do {                                           \
+        auto _vsag_result = (expr);                \
+        if ((_vsag_result).has_value()) {          \
+            return success;                        \
+        }                                          \
+        return make_error((_vsag_result).error()); \
+    } while (0)
+
 extern "C" {
 vsag_index_t
 vsag_index_factory(const char* index_name, const char* index_param) {
@@ -90,11 +107,55 @@ vsag_index_build(
                 ->Ids(ids)
                 ->Float32Vectors(data);
             auto build_result = vsag_index->index_->Build(dataset);
-            if (build_result.has_value()) {
-                return success;
-            }
+            VSAG_CHECK_RESULT(build_result);
+        }
+        return make_error("index is NULL");
+    } catch (const std::exception& e) {
+        return make_error(e);
+    }
+}
 
-            return make_error(build_result.error());
+Error_t
+vsag_index_add(vsag_index_t index,
+               const float* data,
+               const int64_t* ids,
+               const uint64_t dim,
+               const uint64_t count) {
+    try {
+        auto* vsag_index = static_cast<VsagIndex*>(index);
+        if (vsag_index != nullptr) {
+            auto dataset = vsag::Dataset::Make();
+            dataset->Owner(false)
+                ->Dim(static_cast<int64_t>(dim))
+                ->NumElements(static_cast<int64_t>(count))
+                ->Ids(ids)
+                ->Float32Vectors(data);
+            auto add_result = vsag_index->index_->Add(dataset);
+            VSAG_CHECK_RESULT(add_result);
+        }
+        return success;
+    } catch (const std::exception& e) {
+        return make_error(e);
+    }
+}
+
+Error_t
+vsag_index_train(vsag_index_t index,
+                 const float* data,
+                 const int64_t* ids,
+                 const uint64_t dim,
+                 const uint64_t count) {
+    try {
+        auto* vsag_index = static_cast<VsagIndex*>(index);
+        if (vsag_index != nullptr) {
+            auto dataset = vsag::Dataset::Make();
+            dataset->Owner(false)
+                ->Dim(static_cast<int64_t>(dim))
+                ->NumElements(static_cast<int64_t>(count))
+                ->Ids(ids)
+                ->Float32Vectors(data);
+            auto train_result = vsag_index->index_->Train(dataset);
+            VSAG_CHECK_RESULT(train_result);
         }
         return success;
     } catch (const std::exception& e) {
@@ -108,8 +169,7 @@ vsag_index_knn_search(vsag_index_t index,
                       uint64_t dim,
                       int64_t k,
                       const char* parameters,
-                      float* results,
-                      int64_t* ids) {
+                      SearchResult_t* search_result) {
     try {
         auto* vsag_index = static_cast<VsagIndex*>(index);
         if (vsag_index != nullptr) {
@@ -124,14 +184,307 @@ vsag_index_knn_search(vsag_index_t index,
                 const auto* dists_view = result.value()->GetDistances();
                 auto real_k = result.value()->GetDim();
                 for (int i = 0; i < real_k; ++i) {
-                    ids[i] = ids_view[i];
-                    results[i] = dists_view[i];
+                    search_result->ids[i] = ids_view[i];
+                    search_result->dists[i] = dists_view[i];
                 }
+                search_result->count = real_k;
             } else {
                 return make_error(result.error());
             }
         }
         return success;
+    } catch (const std::exception& e) {
+        return make_error(e);
+    }
+}
+
+class VsagFilterWrapper : public vsag::Filter {
+public:
+    VsagFilterWrapper(FilterFunc_t filter) : filter_(filter) {
+    }
+
+    [[nodiscard]] bool
+    CheckValid(int64_t id) const override {
+        return filter_(id);
+    }
+
+private:
+    FilterFunc_t filter_;
+};
+
+Error_t
+vsag_index_knn_search_with_filter(vsag_index_t index,
+                                  const float* query,
+                                  uint64_t dim,
+                                  int64_t k,
+                                  const char* parameters,
+                                  FilterFunc_t filter,
+                                  SearchResult_t* search_result) {
+    try {
+        auto* vsag_index = static_cast<VsagIndex*>(index);
+        if (vsag_index != nullptr) {
+            auto query_dataset = vsag::Dataset::Make();
+            query_dataset->Owner(false)
+                ->Dim(static_cast<int64_t>(dim))
+                ->NumElements(static_cast<int64_t>(1))
+                ->Float32Vectors(query);
+            auto vsag_filter = std::make_shared<VsagFilterWrapper>(filter);
+            auto result = vsag_index->index_->KnnSearch(query_dataset, k, parameters, vsag_filter);
+            if (result.has_value()) {
+                const auto* ids_view = result.value()->GetIds();
+                const auto* dists_view = result.value()->GetDistances();
+                auto real_k = result.value()->GetDim();
+                for (int i = 0; i < real_k; ++i) {
+                    search_result->ids[i] = ids_view[i];
+                    search_result->dists[i] = dists_view[i];
+                }
+                search_result->count = real_k;
+            } else {
+                return make_error(result.error());
+            }
+        }
+        return success;
+    } catch (const std::exception& e) {
+        return make_error(e);
+    }
+}
+
+Error_t
+vsag_index_range_search(vsag_index_t index,
+                        const float* query,
+                        uint64_t dim,
+                        float radius,
+                        const char* parameters,
+                        SearchResult_t* search_result) {
+    try {
+        auto* vsag_index = static_cast<VsagIndex*>(index);
+        if (vsag_index != nullptr) {
+            auto query_dataset = vsag::Dataset::Make();
+            query_dataset->Owner(false)
+                ->Dim(static_cast<int64_t>(dim))
+                ->NumElements(static_cast<int64_t>(1))
+                ->Float32Vectors(query);
+            auto result = vsag_index->index_->RangeSearch(query_dataset, radius, parameters);
+            if (result.has_value()) {
+                const auto* ids_view = result.value()->GetIds();
+                const auto* dists_view = result.value()->GetDistances();
+                auto real_k = result.value()->GetDim();
+                for (int i = 0; i < real_k; ++i) {
+                    search_result->ids[i] = ids_view[i];
+                    search_result->dists[i] = dists_view[i];
+                }
+                search_result->count = real_k;
+            } else {
+                return make_error(result.error());
+            }
+        }
+        return success;
+    } catch (const std::exception& e) {
+        return make_error(e);
+    }
+}
+
+Error_t
+vsag_index_range_search_with_filter(vsag_index_t index,
+                                    const float* query,
+                                    uint64_t dim,
+                                    float radius,
+                                    const char* parameters,
+                                    FilterFunc_t filter,
+                                    SearchResult_t* search_result) {
+    try {
+        auto* vsag_index = static_cast<VsagIndex*>(index);
+        if (vsag_index != nullptr) {
+            auto query_dataset = vsag::Dataset::Make();
+            query_dataset->Owner(false)
+                ->Dim(static_cast<int64_t>(dim))
+                ->NumElements(static_cast<int64_t>(1))
+                ->Float32Vectors(query);
+            auto vsag_filter = std::make_shared<VsagFilterWrapper>(filter);
+            auto result =
+                vsag_index->index_->RangeSearch(query_dataset, radius, parameters, vsag_filter);
+            if (result.has_value()) {
+                const auto* ids_view = result.value()->GetIds();
+                const auto* dists_view = result.value()->GetDistances();
+                auto real_k = result.value()->GetDim();
+                for (int i = 0; i < real_k; ++i) {
+                    search_result->ids[i] = ids_view[i];
+                    search_result->dists[i] = dists_view[i];
+                }
+                search_result->count = real_k;
+            } else {
+                return make_error(result.error());
+            }
+        }
+        return success;
+    } catch (const std::exception& e) {
+        return make_error(e);
+    }
+}
+
+Error_t
+vsag_index_clone(const vsag_index_t index, vsag_index_t* clone_index) {
+    try {
+        auto* vsag_index = static_cast<VsagIndex*>(index);
+        if (vsag_index != nullptr) {
+            auto clone_index2 = vsag_index->index_->Clone();
+            if (clone_index2.has_value()) {
+                *clone_index = new VsagIndex(clone_index2.value());
+                return success;
+            }
+            return make_error(clone_index2.error());
+        }
+        return make_error("index is NULL");
+    } catch (const std::exception& e) {
+        return make_error(e);
+    }
+}
+
+Error_t
+vsag_index_export_model(const vsag_index_t index, vsag_index_t* model_index) {
+    try {
+        auto* vsag_index = static_cast<VsagIndex*>(index);
+        if (vsag_index != nullptr) {
+            auto model_index2 = vsag_index->index_->ExportModel();
+            if (model_index2.has_value()) {
+                *model_index = new VsagIndex(model_index2.value());
+                return success;
+            }
+            return make_error(model_index2.error());
+        }
+        return make_error("index is NULL");
+    } catch (const std::exception& e) {
+        return make_error(e);
+    }
+}
+
+Error_t
+vsag_index_calculate_distance_by_ids(const vsag_index_t index,
+                                     const float* query,
+                                     const uint64_t dim,
+                                     const int64_t* ids,
+                                     const uint64_t count,
+                                     float* dists) {
+    try {
+        auto* vsag_index = static_cast<VsagIndex*>(index);
+        if (vsag_index != nullptr) {
+            auto dists2 =
+                vsag_index->index_->CalDistanceById(query, ids, static_cast<int64_t>(count));
+            if (dists2.has_value()) {
+                memcpy(dists, dists2.value()->GetDistances(), count * sizeof(float));
+                return success;
+            }
+            return make_error(dists2.error());
+        }
+        return make_error("index is NULL");
+    } catch (const std::exception& e) {
+        return make_error(e);
+    }
+}
+
+Error_t
+vsag_index_update_ids(vsag_index_t index,
+                      const int64_t* old_ids,
+                      const int64_t* new_ids,
+                      const uint64_t dim,
+                      const uint64_t count) {
+    try {
+        auto* vsag_index = static_cast<VsagIndex*>(index);
+        if (vsag_index != nullptr) {
+            for (uint64_t i = 0; i < count; ++i) {
+                auto update_result = vsag_index->index_->UpdateId(old_ids[i], new_ids[i]);
+                if (not update_result.has_value()) {
+                    return make_error(update_result.error());
+                }
+            }
+            return success;
+        }
+        return make_error("index is NULL");
+    } catch (const std::exception& e) {
+        return make_error(e);
+    }
+}
+
+Error_t
+vsag_index_update_vector(vsag_index_t index,
+                         const int64_t id,
+                         const float* new_data,
+                         const uint64_t dim) {
+    try {
+        auto* vsag_index = static_cast<VsagIndex*>(index);
+        if (vsag_index != nullptr) {
+            auto dataset = vsag::Dataset::Make();
+            dataset->Owner(false)
+                ->Dim(static_cast<int64_t>(dim))
+                ->NumElements(static_cast<int64_t>(1))
+                ->Ids(&id)
+                ->Float32Vectors(new_data);
+            auto update_result = vsag_index->index_->UpdateVector(id, dataset, false);
+            if (update_result.has_value()) {
+                if (update_result.value()) {
+                    return success;
+                }
+                return make_error("Failed to update vector");
+            }
+            return make_error(update_result.error());
+        }
+        return make_error("index is NULL");
+    } catch (const std::exception& e) {
+        return make_error(e);
+    }
+}
+
+Error_t
+vsag_index_update_vector_force(vsag_index_t index,
+                               const int64_t id,
+                               const float* new_data,
+                               const uint64_t dim) {
+    try {
+        auto* vsag_index = static_cast<VsagIndex*>(index);
+        if (vsag_index != nullptr) {
+            auto dataset = vsag::Dataset::Make();
+            dataset->Owner(false)
+                ->Dim(static_cast<int64_t>(dim))
+                ->NumElements(static_cast<int64_t>(1))
+                ->Ids(&id)
+                ->Float32Vectors(new_data);
+            auto update_result = vsag_index->index_->UpdateVector(id, dataset, true);
+            if (update_result.has_value()) {
+                if (update_result.value()) {
+                    return success;
+                }
+                return make_error("Failed to update vector");
+            }
+            return make_error(update_result.error());
+        }
+        return make_error("index is NULL");
+    } catch (const std::exception& e) {
+        return make_error(e);
+    }
+}
+
+Error_t
+vsag_index_get_vector_by_ids(vsag_index_t index,
+                             const int64_t* ids,
+                             const uint64_t count,
+                             float* vectors) {
+    try {
+        auto* vsag_index = static_cast<VsagIndex*>(index);
+        if (vsag_index != nullptr) {
+            auto dataset_result =
+                vsag_index->index_->GetRawVectorByIds(ids, static_cast<int64_t>(count));
+            if (dataset_result.has_value()) {
+                const auto* vectors_view = dataset_result.value()->GetFloat32Vectors();
+                if (vectors_view != nullptr) {
+                    uint64_t dim = dataset_result.value()->GetDim();
+                    memcpy(vectors, vectors_view, count * dim * sizeof(float));
+                    return success;
+                }
+                return make_error("Failed to get vector data");
+            }
+            return make_error(dataset_result.error());
+        }
+        return make_error("index is NULL");
     } catch (const std::exception& e) {
         return make_error(e);
     }
@@ -145,12 +498,9 @@ vsag_serialize_file(vsag_index_t index, const char* file_path) {
             std::ofstream file(file_path, std::ios::binary);
             auto serialize_result = vsag_index->index_->Serialize(file);
             file.close();
-            if (serialize_result.has_value()) {
-                return success;
-            }
-            return make_error(serialize_result.error());
+            VSAG_CHECK_RESULT(serialize_result);
         }
-        return success;
+        return make_error("index is NULL");
     } catch (const std::exception& e) {
         return make_error(e);
     }
@@ -162,10 +512,11 @@ vsag_deserialize_file(vsag_index_t index, const char* file_path) {
         auto* vsag_index = static_cast<VsagIndex*>(index);
         if (vsag_index != nullptr) {
             std::ifstream file(file_path, std::ios::binary);
-            vsag_index->index_->Deserialize(file);
+            auto deserialize_result = vsag_index->index_->Deserialize(file);
             file.close();
+            VSAG_CHECK_RESULT(deserialize_result);
         }
-        return success;
+        return make_error("index is NULL");
     } catch (const std::exception& e) {
         return make_error(e);
     }
@@ -177,12 +528,10 @@ vsag_serialize_write_func(vsag_index_t index,
     try {
         auto* vsag_index = static_cast<VsagIndex*>(index);
         if (vsag_index != nullptr) {
-            auto result = vsag_index->index_->Serialize(write_func);
-            if (not result.has_value()) {
-                return make_error(result.error());
-            }
+            auto serialize_result = vsag_index->index_->Serialize(write_func);
+            VSAG_CHECK_RESULT(serialize_result);
         }
-        return success;
+        return make_error("index is NULL");
     } catch (const std::exception& e) {
         return make_error(e);
     }
@@ -273,9 +622,10 @@ vsag_deserialize_read_func(vsag_index_t index,
         if (vsag_index != nullptr) {
             RandomAccessStreamBuf stream_buf(read_func, size_func);
             std::istream stream(&stream_buf);
-            vsag_index->index_->Deserialize(stream);
+            auto deserialize_result = vsag_index->index_->Deserialize(stream);
+            VSAG_CHECK_RESULT(deserialize_result);
         }
-        return success;
+        return make_error("index is NULL");
     } catch (const std::exception& e) {
         return make_error(e);
     }

--- a/src/vsag_c_api_test.cpp
+++ b/src/vsag_c_api_test.cpp
@@ -21,10 +21,9 @@
 #include <random>
 
 #include "fixtures.h"
+#include "simd/fp32_simd.h"
 
-TEST_CASE("vsag_c_api basic test", "[vsag_c_api][ut]") {
-    const char* index_name = "hgraph";
-    const char* index_param = R"(
+static constexpr const char* index_param = R"(
     {
         "dtype": "float32",
         "metric_type": "l2",
@@ -36,55 +35,71 @@ TEST_CASE("vsag_c_api basic test", "[vsag_c_api][ut]") {
             "alpha":1.2
         }
     }
-    )";
-    auto index = vsag_index_factory(index_name, index_param);
-    REQUIRE(index != nullptr);
+)";
 
-    int64_t num_vectors = 500;
-    int64_t dim = 128;
-    std::vector<int64_t> ids(num_vectors);
-    std::vector<float> datas(num_vectors * dim);
-    std::mt19937 rng(47);
-    std::uniform_real_distribution<float> distrib_real;
-    for (int64_t i = 0; i < num_vectors; ++i) {
-        ids[i] = i;
+static constexpr const char* index_name = "hgraph";
+
+static constexpr const char* hgraph_search_parameters = R"(
+    {
+        "hgraph": {
+            "ef_search": 200
+        }
     }
-    for (int64_t i = 0; i < dim * num_vectors; ++i) {
-        datas[i] = distrib_real(rng);
+)";
+
+static constexpr int64_t num_vectors = 500;
+static constexpr int64_t dim = 128;
+
+class VsagTestCase {
+public:
+    std::vector<int64_t> ids{};
+    std::vector<float> datas{};
+
+    VsagTestCase() {
+        std::mt19937 rng(47);
+        std::uniform_real_distribution<float> distrib_real;
+        ids.resize(num_vectors);
+        datas.resize(num_vectors * dim);
+        for (int64_t i = 0; i < num_vectors; ++i) {
+            ids[i] = i;
+        }
+        for (int64_t i = 0; i < dim * num_vectors; ++i) {
+            datas[i] = distrib_real(rng);
+        }
     }
-    Error_t ret = vsag_index_build(index, datas.data(), ids.data(), dim, num_vectors);
-    REQUIRE(ret.code == VSAG_SUCCESS);
-    auto func = [&](vsag_index_t index1) {
-        const char* hgraph_search_parameters = R"(
-            {
-                "hgraph": {
-                    "ef_search": 200
-                }
-            }
-            )";
+
+    void
+    CheckIndex(vsag_index_t index) {
         int64_t topk = 10;
+        std::vector<int64_t> results(topk);
+        std::vector<float> scores(topk);
+        SearchResult_t result;
+        result.dists = scores.data();
+        result.ids = results.data();
         for (int i = 0; i < num_vectors; ++i) {
-            std::vector<int64_t> results(topk);
-            std::vector<float> scores(topk);
-            ret = vsag_index_knn_search(index1,
-                                        datas.data() + i * dim,
-                                        dim,
-                                        topk,
-                                        hgraph_search_parameters,
-                                        scores.data(),
-                                        results.data());
+            auto ret = vsag_index_knn_search(
+                index, datas.data() + i * dim, dim, topk, hgraph_search_parameters, &result);
             REQUIRE(ret.code == VSAG_SUCCESS);
             bool in_results = false;
-            for (int64_t j = 0; j < topk; ++j) {
-                if (results[j] == i) {
+            for (int64_t j = 0; j < result.count; ++j) {
+                if (result.ids[j] == i) {
                     in_results = true;
                     break;
                 }
             }
             REQUIRE(in_results);
         }
-    };
-    func(index);
+    }
+};
+
+TEST_CASE("vsag_c_api basic test", "[vsag_c_api][ut]") {
+    auto index = vsag_index_factory(index_name, index_param);
+    REQUIRE(index != nullptr);
+    VsagTestCase test_case;
+    Error_t ret =
+        vsag_index_build(index, test_case.datas.data(), test_case.ids.data(), dim, num_vectors);
+    REQUIRE(ret.code == VSAG_SUCCESS);
+    test_case.CheckIndex(index);
     // for test serialize and deserialize file
     {
         auto dir = fixtures::TempDir("vsag_c_api");
@@ -95,6 +110,7 @@ TEST_CASE("vsag_c_api basic test", "[vsag_c_api][ut]") {
         ret = vsag_deserialize_file(index2, path.data());
         REQUIRE(ret.code == VSAG_SUCCESS);
         REQUIRE(index2 != nullptr);
+        test_case.CheckIndex(index2);
         vsag_index_destroy(index2);
     }
 
@@ -131,8 +147,274 @@ TEST_CASE("vsag_c_api basic test", "[vsag_c_api][ut]") {
         ret = vsag_deserialize_read_func(index2, read_func, size_func);
         REQUIRE(ret.code == VSAG_SUCCESS);
         REQUIRE(index2 != nullptr);
-        func(index2);
+        test_case.CheckIndex(index2);
         vsag_index_destroy(index2);
+    }
+
+    vsag_index_destroy(index);
+}
+
+TEST_CASE("vsag_c_api factory and destroy", "[vsag_c_api][ut]") {
+    // Test factory with valid parameters
+    auto index = vsag_index_factory(index_name, index_param);
+    REQUIRE(index != nullptr);
+
+    // Test factory with invalid parameters
+    auto invalid_index = vsag_index_factory("invalid_index", index_param);
+    REQUIRE(invalid_index == nullptr);
+
+    // Test destroy
+    Error_t ret = vsag_index_destroy(index);
+    REQUIRE(ret.code == VSAG_SUCCESS);
+}
+
+TEST_CASE("vsag_c_api build and add", "[vsag_c_api][ut]") {
+    auto index = vsag_index_factory(index_name, index_param);
+    REQUIRE(index != nullptr);
+
+    // Test build
+    VsagTestCase test_case;
+    int64_t add_num_vectors = 50;
+    Error_t ret = vsag_index_build(
+        index, test_case.datas.data(), test_case.ids.data(), dim, num_vectors - add_num_vectors);
+    REQUIRE(ret.code == VSAG_SUCCESS);
+
+    ret = vsag_index_add(index,
+                         test_case.datas.data() + (num_vectors - add_num_vectors) * dim,
+                         test_case.ids.data() + (num_vectors - add_num_vectors),
+                         dim,
+                         add_num_vectors);
+    REQUIRE(ret.code == VSAG_SUCCESS);
+
+    test_case.CheckIndex(index);
+
+    vsag_index_destroy(index);
+}
+
+TEST_CASE("vsag_c_api train", "[vsag_c_api][ut]") {
+    auto index = vsag_index_factory(index_name, index_param);
+    REQUIRE(index != nullptr);
+
+    VsagTestCase test_case;
+    // Test train
+    Error_t ret =
+        vsag_index_train(index, test_case.datas.data(), test_case.ids.data(), dim, num_vectors);
+    REQUIRE(ret.code == VSAG_SUCCESS);
+
+    ret = vsag_index_add(index, test_case.datas.data(), test_case.ids.data(), dim, num_vectors);
+    REQUIRE(ret.code == VSAG_SUCCESS);
+
+    test_case.CheckIndex(index);
+
+    vsag_index_destroy(index);
+}
+
+TEST_CASE("vsag_c_api knn search(with filter)", "[vsag_c_api][ut]") {
+    auto index = vsag_index_factory(index_name, index_param);
+    REQUIRE(index != nullptr);
+
+    VsagTestCase test_case;
+
+    Error_t ret =
+        vsag_index_build(index, test_case.datas.data(), test_case.ids.data(), dim, num_vectors);
+    REQUIRE(ret.code == VSAG_SUCCESS);
+
+    // Test knn search
+
+    int64_t topk = 10;
+    std::vector<int64_t> results(topk);
+    std::vector<float> scores(topk);
+    SearchResult_t result;
+    result.dists = scores.data();
+    result.ids = results.data();
+
+    // Test with filter
+    auto filter_func = [](int64_t id) -> bool {
+        return id % 2 == 0;  // Only accept even IDs
+    };
+
+    ret = vsag_index_knn_search_with_filter(
+        index, test_case.datas.data(), dim, topk, hgraph_search_parameters, filter_func, &result);
+    REQUIRE(ret.code == VSAG_SUCCESS);
+
+    // Verify that all returned IDs are even
+    for (int64_t i = 0; i < result.count; ++i) {
+        REQUIRE(result.ids[i] % 2 == 0);
+    }
+
+    vsag_index_destroy(index);
+}
+
+TEST_CASE("vsag_c_api range search", "[vsag_c_api][ut]") {
+    auto index = vsag_index_factory(index_name, index_param);
+    REQUIRE(index != nullptr);
+
+    VsagTestCase test_case;
+
+    Error_t ret =
+        vsag_index_build(index, test_case.datas.data(), test_case.ids.data(), dim, num_vectors);
+    REQUIRE(ret.code == VSAG_SUCCESS);
+
+    // Test range search
+
+    float radius = 10.0F;
+    std::vector<int64_t> results(500);  // Large enough buffer
+    std::vector<float> scores(500);
+    SearchResult_t result;
+    result.dists = scores.data();
+    result.ids = results.data();
+
+    auto idx = random() % num_vectors;
+    ret = vsag_index_range_search(
+        index, test_case.datas.data() + idx * dim, dim, radius, hgraph_search_parameters, &result);
+    REQUIRE(ret.code == VSAG_SUCCESS);
+
+    // Test range search with filter
+    auto filter_func = [](int64_t id) -> bool {
+        return id < 50;  // Only accept IDs less than 50
+    };
+
+    ret = vsag_index_range_search_with_filter(index,
+                                              test_case.datas.data() + idx * dim,
+                                              dim,
+                                              radius,
+                                              hgraph_search_parameters,
+                                              filter_func,
+                                              &result);
+    REQUIRE(ret.code == VSAG_SUCCESS);
+
+    // Verify that all returned IDs are less than 50
+    for (int64_t i = 0; i < result.count; ++i) {
+        REQUIRE(result.ids[i] < 50);
+    }
+
+    vsag_index_destroy(index);
+}
+
+TEST_CASE("vsag_c_api clone and export model", "[vsag_c_api][ut]") {
+    auto index = vsag_index_factory(index_name, index_param);
+    REQUIRE(index != nullptr);
+
+    VsagTestCase test_case;
+
+    Error_t ret =
+        vsag_index_build(index, test_case.datas.data(), test_case.ids.data(), dim, num_vectors);
+    REQUIRE(ret.code == VSAG_SUCCESS);
+
+    // Test clone
+    vsag_index_t cloned_index = nullptr;
+    ret = vsag_index_clone(index, &cloned_index);
+    REQUIRE(ret.code == VSAG_SUCCESS);
+    REQUIRE(cloned_index != nullptr);
+    test_case.CheckIndex(cloned_index);
+
+    // Test export model
+    vsag_index_t model_index = nullptr;
+    ret = vsag_index_export_model(index, &model_index);
+    REQUIRE(ret.code == VSAG_SUCCESS);
+    REQUIRE(model_index != nullptr);
+
+    ret =
+        vsag_index_add(model_index, test_case.datas.data(), test_case.ids.data(), dim, num_vectors);
+    REQUIRE(ret.code == VSAG_SUCCESS);
+    test_case.CheckIndex(model_index);
+
+    vsag_index_destroy(index);
+    vsag_index_destroy(cloned_index);
+    vsag_index_destroy(model_index);
+}
+
+TEST_CASE("vsag_c_api calculate distance by ids", "[vsag_c_api][ut]") {
+    auto index = vsag_index_factory(index_name, index_param);
+    REQUIRE(index != nullptr);
+
+    VsagTestCase test_case;
+
+    Error_t ret =
+        vsag_index_build(index, test_case.datas.data(), test_case.ids.data(), dim, num_vectors);
+    REQUIRE(ret.code == VSAG_SUCCESS);
+
+    // Test calculate distance by ids
+    std::vector<int64_t> query_ids = {0, 1, 2};
+    std::vector<float> distances(query_ids.size());
+
+    ret = vsag_index_calculate_distance_by_ids(index,
+                                               test_case.datas.data() + 5 * dim,
+                                               dim,
+                                               query_ids.data(),
+                                               query_ids.size(),
+                                               distances.data());
+    REQUIRE(ret.code == VSAG_SUCCESS);
+
+    // Verify distances are calculated (should be non-negative)
+    for (size_t i = 0; i < distances.size(); ++i) {
+        auto gt_dist = vsag::FP32ComputeL2Sqr(
+            test_case.datas.data() + 5 * dim, test_case.datas.data() + query_ids[i] * dim, dim);
+        REQUIRE(distances[i] == gt_dist);
+    }
+
+    vsag_index_destroy(index);
+}
+
+TEST_CASE("vsag_c_api update operations and get vector by ids", "[vsag_c_api][ut]") {
+    auto index = vsag_index_factory(index_name, index_param);
+    REQUIRE(index != nullptr);
+
+    VsagTestCase test_case;
+
+    Error_t ret =
+        vsag_index_build(index, test_case.datas.data(), test_case.ids.data(), dim, num_vectors);
+    REQUIRE(ret.code == VSAG_SUCCESS);
+
+    // Test get vector by ids
+    std::vector<int64_t> get_ids = {8, 9, 10};
+    std::vector<float> vectors(get_ids.size() * dim);
+    ret = vsag_index_get_vector_by_ids(index, get_ids.data(), get_ids.size(), vectors.data());
+    REQUIRE(ret.code == VSAG_SUCCESS);
+
+    for (size_t i = 0; i < get_ids.size(); ++i) {
+        auto* gt_vec = test_case.datas.data() + get_ids[i] * dim;
+        for (int64_t j = 0; j < dim; ++j) {
+            REQUIRE(vectors[i * dim + j] == gt_vec[j]);
+        }
+    }
+
+    // Test update ids
+    std::vector<int64_t> old_ids = {3, 4, 5};
+    std::vector<int64_t> new_ids = {3000, 4000, 5000};
+    ret = vsag_index_update_ids(index, old_ids.data(), new_ids.data(), dim, old_ids.size());
+    REQUIRE(ret.code == VSAG_SUCCESS);
+
+    ret = vsag_index_get_vector_by_ids(index, new_ids.data(), new_ids.size(), vectors.data());
+    REQUIRE(ret.code == VSAG_SUCCESS);
+
+    for (size_t i = 0; i < new_ids.size(); ++i) {
+        auto* gt_vec = test_case.datas.data() + old_ids[i] * dim;
+        for (int64_t j = 0; j < dim; ++j) {
+            REQUIRE(vectors[i * dim + j] == gt_vec[j]);
+        }
+    }
+
+    // Test update vector
+    std::vector<float> new_vector(dim);
+    for (int64_t i = 0; i < dim; ++i) {
+        new_vector[i] = test_case.datas[6 * dim + i];
+    }
+    ret = vsag_index_update_vector(index, 6, new_vector.data(), dim);
+    REQUIRE(ret.code == VSAG_SUCCESS);
+
+    // Test update vector force
+    ret = vsag_index_update_vector_force(index, 7, new_vector.data(), dim);
+    REQUIRE(ret.code == VSAG_SUCCESS);
+
+    std::vector<int64_t> update_ids = {6, 7};
+    ret = vsag_index_get_vector_by_ids(index, update_ids.data(), update_ids.size(), vectors.data());
+    REQUIRE(ret.code == VSAG_SUCCESS);
+
+    for (int64_t i = 0; i < update_ids.size(); ++i) {
+        for (int64_t j = 0; j < dim; ++j) {
+            REQUIRE(vectors[i * dim + j] == new_vector[j]);
+        }
     }
 
     vsag_index_destroy(index);


### PR DESCRIPTION
closed: #1369 

- try to align the c_api to c++'s Index interface

## Summary by Sourcery

Extend and align the C API with the C++ index interface, adding richer search and index management capabilities while improving error handling.

New Features:
- Introduce C API functions for adding and training data separately on an index.
- Add KNN and range search APIs that support structured search results and optional user-defined filters.
- Expose index clone and model export operations through the C API.
- Provide APIs to compute distances by IDs, update IDs and vectors, and fetch raw vectors by IDs from an index.

Enhancements:
- Unify result checking and error propagation in the C API using a common macro and helper overload.
- Clarify and expand C API documentation comments for all public functions and types.

Tests:
- Refactor C API tests into reusable fixtures and add comprehensive coverage for new C APIs, including build/add, train, filtered search, range search, clone/export, distance-by-IDs, updates, and serialization/deserialization paths.