### PR TITLE
fix(tsan): fix the tsan error on CI

### DIFF
--- a/.github/workflows/tsan_build_and_test.yml
+++ b/.github/workflows/tsan_build_and_test.yml
@@ -61,7 +61,7 @@ jobs:
         run: |
           echo race:libomp.so > omp.supp
           echo race:libomp.so.5 >> omp.supp
-          echo 'race:fmt::v10::detail::format_decimal' >> omp.supp
+          echo race:fmt::v10::detail::format_decimal >> omp.supp
           export TSAN_OPTIONS=suppressions=omp.supp
           chmod +x ./build/tests/functests
           ./build/tests/functests "[concurrent]~[daily]"


### PR DESCRIPTION
#1329
## Summary by Sourcery

CI:
- Adjust TSAN suppression file entries in the CI workflow to match current OpenMP and fmt symbol names.