### PR TITLE
fix(ut): illegal instruction (sve) occurred on Apple Silicon

### DIFF
--- a/src/simd/sq4_simd_test.cpp
+++ b/src/simd/sq4_simd_test.cpp
@@ -15,56 +15,71 @@
 
 #include "sq4_simd.h"
 
+#include <cpuinfo.h>
+
 #include <catch2/benchmark/catch_benchmark.hpp>
 #include <catch2/catch_test_macros.hpp>
 
 #include "fixtures.h"
 #include "simd_status.h"
+
 using namespace vsag;
 
-#define TEST_ACCURACY(Func)                                        \
-    {                                                              \
-        auto gt = generic::Func(codes1.data() + i * code_size,     \
-                                codes2.data() + i * code_size,     \
-                                lb.data(),                         \
-                                diff.data(),                       \
-                                dim);                              \
-        auto sse = sse::Func(codes1.data() + i * code_size,        \
-                             codes2.data() + i * code_size,        \
-                             lb.data(),                            \
-                             diff.data(),                          \
-                             dim);                                 \
-        auto avx = avx::Func(codes1.data() + i * code_size,        \
-                             codes2.data() + i * code_size,        \
-                             lb.data(),                            \
-                             diff.data(),                          \
-                             dim);                                 \
-        auto avx2 = avx2::Func(codes1.data() + i * code_size,      \
-                               codes2.data() + i * code_size,      \
-                               lb.data(),                          \
-                               diff.data(),                        \
-                               dim);                               \
-        auto avx512 = avx512::Func(codes1.data() + i * code_size,  \
-                                   codes2.data() + i * code_size,  \
-                                   lb.data(),                      \
-                                   diff.data(),                    \
-                                   dim);                           \
-        auto neon = neon::Func(codes1.data() + i * code_size,      \
-                               codes2.data() + i * code_size,      \
-                               lb.data(),                          \
-                               diff.data(),                        \
-                               dim);                               \
-        auto sve = sve::Func(codes1.data() + i * code_size,        \
-                             codes2.data() + i * code_size,        \
-                             lb.data(),                            \
-                             diff.data(),                          \
-                             dim);                                 \
-        REQUIRE(fixtures::dist_t(gt) == fixtures::dist_t(sse));    \
-        REQUIRE(fixtures::dist_t(gt) == fixtures::dist_t(avx));    \
-        REQUIRE(fixtures::dist_t(gt) == fixtures::dist_t(avx2));   \
-        REQUIRE(fixtures::dist_t(gt) == fixtures::dist_t(avx512)); \
-        REQUIRE(fixtures::dist_t(gt) == fixtures::dist_t(neon));   \
-        REQUIRE(fixtures::dist_t(gt) == fixtures::dist_t(sve));    \
+#define TEST_ACCURACY(Func)                                            \
+    {                                                                  \
+        auto gt = generic::Func(codes1.data() + i * code_size,         \
+                                codes2.data() + i * code_size,         \
+                                lb.data(),                             \
+                                diff.data(),                           \
+                                dim);                                  \
+        if (SimdStatus::SupportSSE()) {                                \
+            auto sse = sse::Func(codes1.data() + i * code_size,        \
+                                 codes2.data() + i * code_size,        \
+                                 lb.data(),                            \
+                                 diff.data(),                          \
+                                 dim);                                 \
+            REQUIRE(fixtures::dist_t(gt) == fixtures::dist_t(sse));    \
+        }                                                              \
+        if (SimdStatus::SupportAVX()) {                                \
+            auto avx = avx::Func(codes1.data() + i * code_size,        \
+                                 codes2.data() + i * code_size,        \
+                                 lb.data(),                            \
+                                 diff.data(),                          \
+                                 dim);                                 \
+            REQUIRE(fixtures::dist_t(gt) == fixtures::dist_t(avx));    \
+        }                                                              \
+        if (SimdStatus::SupportAVX2()) {                               \
+            auto avx2 = avx2::Func(codes1.data() + i * code_size,      \
+                                   codes2.data() + i * code_size,      \
+                                   lb.data(),                          \
+                                   diff.data(),                        \
+                                   dim);                               \
+            REQUIRE(fixtures::dist_t(gt) == fixtures::dist_t(avx2));   \
+        }                                                              \
+        if (SimdStatus::SupportAVX512()) {                             \
+            auto avx512 = avx512::Func(codes1.data() + i * code_size,  \
+                                       codes2.data() + i * code_size,  \
+                                       lb.data(),                      \
+                                       diff.data(),                    \
+                                       dim);                           \
+            REQUIRE(fixtures::dist_t(gt) == fixtures::dist_t(avx512)); \
+        }                                                              \
+        if (SimdStatus::SupportNEON()) {                               \
+            auto neon = neon::Func(codes1.data() + i * code_size,      \
+                                   codes2.data() + i * code_size,      \
+                                   lb.data(),                          \
+                                   diff.data(),                        \
+                                   dim);                               \
+            REQUIRE(fixtures::dist_t(gt) == fixtures::dist_t(neon));   \
+        }                                                              \
+        if (SimdStatus::SupportSVE()) {                                \
+            auto sve = sve::Func(codes1.data() + i * code_size,        \
+                                 codes2.data() + i * code_size,        \
+                                 lb.data(),                            \
+                                 diff.data(),                          \
+                                 dim);                                 \
+            REQUIRE(fixtures::dist_t(gt) == fixtures::dist_t(sve));    \
+        }                                                              \
     }
 
 TEST_CASE("SQ4 SIMD Compute Codes", "[ut][simd]") {


### PR DESCRIPTION
fixes: #1367

add an instruction set check before running simd distance function tests

## Summary by Sourcery

Guard SIMD distance function tests with runtime CPU feature checks to avoid executing unsupported instruction sets.

Bug Fixes:
- Prevent illegal instruction crashes on platforms lacking specific SIMD extensions such as SVE by skipping unsupported variants in tests.

Tests:
- Update SQ4 SIMD accuracy tests to conditionally run SSE, AVX, AVX2, AVX-512, NEON, and SVE implementations only when the corresponding CPU features are available.