### PR TITLE
improvement(BruteForce): enhance brute_force

### DIFF
--- a/include/vsag/constants.h
+++ b/include/vsag/constants.h
@@ -181,9 +181,15 @@ extern const char* const STORE_RAW_VECTOR;
 extern const char* const RAW_VECTOR_IO_TYPE;
 extern const char* const RAW_VECTOR_FILE_PATH;
 
-extern const char* const BRUTE_FORCE_QUANTIZATION_TYPE;
-extern const char* const BRUTE_FORCE_IO_TYPE;
+extern const char* const BRUTE_FORCE_BASE_QUANTIZATION_TYPE;
+extern const char* const BRUTE_FORCE_BASE_IO_TYPE;
+extern const char* const BRUTE_FORCE_BASE_PQ_DIM;
+extern const char* const BRUTE_FORCE_BASE_FILE_PATH;
+extern const char* const BRUTE_FORCE_PRECISE_QUANTIZATION_TYPE;
+extern const char* const BRUTE_FORCE_PRECISE_IO_TYPE;
+extern const char* const BRUTE_FORCE_PRECISE_FILE_PATH;
 extern const char* const BRUTE_FORCE_THREAD_COUNT;
+extern const char* const BRUTE_FORCE_USE_RESIDUAL;
 
 extern const char* const IVF_USE_RESIDUAL;
 extern const char* const IVF_USE_REORDER;

--- a/src/algorithm/brute_force_parameter.h
+++ b/src/algorithm/brute_force_parameter.h
@@ -34,7 +34,7 @@ public:
     CheckCompatibility(const vsag::ParamPtr& other) const override;
 
 public:
-    FlattenDataCellParamPtr flatten_param;
+    FlattenInterfaceParamPtr base_codes_param{nullptr};
 };
 
 DEFINE_POINTER(BruteForceParameter);

--- a/src/algorithm/brute_force_parameter_test.cpp
+++ b/src/algorithm/brute_force_parameter_test.cpp
@@ -22,11 +22,14 @@
 TEST_CASE("BruteForce Parameters CheckCompatibility",
           "[ut][BruteForceParameter][CheckCompatibility]") {
     auto param_str = R"({
-        "io_params": {
-            "type": "block_memory_io"
-        },
-        "quantization_params": {
-            "type": "sq8"
+        "base_codes": {
+            "codes_type": "flatten_codes",
+            "io_params": {
+                "type": "block_memory_io"
+            },
+            "quantization_params": {
+                "type": "fp32"
+            }
         },
         "type": "brute_force",
         "use_attribute_filter": true

--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -1207,7 +1207,7 @@ HGraph::reorder(const void* query,
 static const std::string HGRAPH_PARAMS_TEMPLATE =
     R"(
     {
-        "type": "{INDEX_TYPE_HGRAPH}",
+        "{TYPE_KEY}": "{INDEX_TYPE_HGRAPH}",
         "{USE_REORDER_KEY}": false,
         "{HGRAPH_USE_ENV_OPTIMIZER}": false,
         "{HGRAPH_IGNORE_REORDER_KEY}": false,

--- a/src/algorithm/inner_index_interface.cpp
+++ b/src/algorithm/inner_index_interface.cpp
@@ -358,7 +358,7 @@ InnerIndexInterface::FastCreateIndex(const std::string& index_fast_str,
     if (strs[0] == INDEX_BRUTE_FORCE) {
         constexpr const char* build_string_temp = R"(
         {{
-            "quantization_type": "{}"
+            "base_quantization_type": "{}"
         }}
         )";
         JsonType json = JsonType::Parse(fmt::format(build_string_temp, strs[1]));

--- a/src/algorithm/ivf.cpp
+++ b/src/algorithm/ivf.cpp
@@ -37,7 +37,7 @@ namespace vsag {
 static constexpr const char* IVF_PARAMS_TEMPLATE =
     R"(
     {
-        "type": "{INDEX_TYPE_IVF}",
+        "{TYPE_KEY}": "{INDEX_TYPE_IVF}",
         "{IVF_TRAIN_TYPE_KEY}": "{IVF_TRAIN_TYPE_KMEANS}",
         "{USE_ATTRIBUTE_FILTER_KEY}": false,
         "{USE_REORDER_KEY}": false,

--- a/src/algorithm/ivf_partition/gno_imi_partition.cpp
+++ b/src/algorithm/ivf_partition/gno_imi_partition.cpp
@@ -76,13 +76,13 @@ GNOIMIPartition::GNOIMIPartition(const IndexCommonParam& common_param,
     precomputed_terms_st_.resize(static_cast<long>(bucket_count_s_) * bucket_count_t_);
 
     param_ptr_ = std::make_shared<BruteForceParameter>();
-    param_ptr_->flatten_param = std::make_shared<FlattenDataCellParameter>();
+    param_ptr_->base_codes_param = std::make_shared<FlattenDataCellParameter>();
     JsonType memory_json;
     memory_json["type"].SetString(IO_TYPE_VALUE_BLOCK_MEMORY_IO);
-    param_ptr_->flatten_param->io_parameter = IOParameter::GetIOParameterByJson(memory_json);
+    param_ptr_->base_codes_param->io_parameter = IOParameter::GetIOParameterByJson(memory_json);
     JsonType quantizer_json;
     quantizer_json["type"].SetString(QUANTIZATION_TYPE_VALUE_FP32);
-    param_ptr_->flatten_param->quantizer_parameter =
+    param_ptr_->base_codes_param->quantizer_parameter =
         QuantizerParameter::GetQuantizerParameterByJson(quantizer_json);
 }
 

--- a/src/algorithm/pyramid.cpp
+++ b/src/algorithm/pyramid.cpp
@@ -459,7 +459,7 @@ Pyramid::InitFeatures() {
 static const std::string HGRAPH_PARAMS_TEMPLATE =
     R"(
     {
-        "type": "{INDEX_TYPE_PYRAMID}",
+        "{TYPE_KEY}": "{INDEX_TYPE_PYRAMID}",
         "{USE_REORDER_KEY}": false,
         "{GRAPH_KEY}": {
             "{IO_PARAMS_KEY}": {

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -139,7 +139,6 @@ const char* const INDEX_TQ_CHAIN = "tq_chain";
 
 const char* const HGRAPH_SUPPORT_REMOVE = "support_remove";
 const char* const HGRAPH_REMOVE_FLAG_BIT = "remove_flag_bit";
-
 const char* const HGRAPH_USE_REORDER = USE_REORDER_KEY;
 const char* const HGRAPH_USE_ELP_OPTIMIZER = HGRAPH_USE_ELP_OPTIMIZER_KEY;
 const char* const HGRAPH_IGNORE_REORDER = "ignore_reorder";
@@ -169,9 +168,15 @@ const char* const STORE_RAW_VECTOR = "store_raw_vector";
 const char* const RAW_VECTOR_IO_TYPE = "raw_vector_io_type";
 const char* const RAW_VECTOR_FILE_PATH = "raw_vector_file_path";
 
-const char* const BRUTE_FORCE_QUANTIZATION_TYPE = "quantization_type";
-const char* const BRUTE_FORCE_IO_TYPE = "io_type";
+const char* const BRUTE_FORCE_BASE_QUANTIZATION_TYPE = "base_quantization_type";
+const char* const BRUTE_FORCE_BASE_IO_TYPE = "base_io_type";
+const char* const BRUTE_FORCE_BASE_PQ_DIM = "base_pq_dim";
+const char* const BRUTE_FORCE_BASE_FILE_PATH = "base_file_path";
+const char* const BRUTE_FORCE_PRECISE_QUANTIZATION_TYPE = "precise_quantization_type";
+const char* const BRUTE_FORCE_PRECISE_IO_TYPE = "precise_io_type";
+const char* const BRUTE_FORCE_PRECISE_FILE_PATH = "precise_file_path";
 const char* const BRUTE_FORCE_THREAD_COUNT = "thread_count";
+const char* const BRUTE_FORCE_USE_RESIDUAL = "use_residual";
 
 const char* const IVF_USE_RESIDUAL = "use_residual";
 const char* const IVF_USE_REORDER = "use_reorder";

--- a/src/inner_string_params.h
+++ b/src/inner_string_params.h
@@ -24,6 +24,7 @@ namespace vsag {
 // Index Type
 const char* const INDEX_TYPE_HGRAPH = "hgraph";
 const char* const INDEX_TYPE_IVF = "ivf";
+const char* const INDEX_TYPE_BRUTE_FORCE = "brute_force";
 const char* const INDEX_TYPE_GNO_IMI = "gno_imi";
 const char* const INDEX_TYPE_PYRAMID = "pyramid";
 

--- a/src/parameter.h
+++ b/src/parameter.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "common.h"
+#include "inner_string_params.h"
 #include "typing.h"
 #include "utils/pointer_define.h"
 namespace vsag {
@@ -26,8 +27,9 @@ class Parameter {
 public:
     static std::string
     TryToParseType(const JsonType& json) {
-        CHECK_ARGUMENT(json.Contains("type"), "params must have type");  // TODO(LHT): "type" rename
-        return json["type"].GetString();
+        CHECK_ARGUMENT(json.Contains(TYPE_KEY),
+                       "params must have type");  // TODO(LHT): "type" rename
+        return json[TYPE_KEY].GetString();
     }
 
 public:

--- a/tests/test_brute_force.cpp
+++ b/tests/test_brute_force.cpp
@@ -105,7 +105,7 @@ BruteForceTestIndex::GenerateBruteForceBuildParametersString(const std::string& 
         "metric_type": "{}",
         "dim": {},
         "index_param": {{
-            "quantization_type": "{}",
+            "base_quantization_type": "{}",
             "store_raw_vector": true,
             "use_attribute_filter": {}
         }}


### PR DESCRIPTION
- add reorder for BF
- align the config with other Index,like hgraph

## Summary by Sourcery

Align brute-force index configuration and parameters with other index types and support configurable base and precise code settings.

New Features:
- Introduce separate base and precise code configurations for the brute-force index, including IO, quantization, and PQ dimensions.
- Add a configuration option to enable residual-based reordering for the brute-force index via a use_residual flag.

Enhancements:
- Refactor brute-force parameters to use a generic base_codes_param and shared TYPE_KEY constant, improving consistency with other index implementations.
- Update JSON templates for brute-force, HGraph, IVF, and Pyramid indexes to use consistent TYPE_KEY-based schemas.
- Extend brute-force external parameter mapping to expose base and precise code options and thread count via dedicated config keys.

Tests:
- Adjust brute-force parameter and index tests to cover the new base_codes configuration structure.