### PR TITLE
fix: correct allocator used to allocate neighbors_mutex

### DIFF
--- a/src/utils/lock_strategy.cpp
+++ b/src/utils/lock_strategy.cpp
@@ -22,7 +22,7 @@ PointsMutex::PointsMutex(uint32_t element_num, Allocator* allocator)
       neighbors_mutex_(element_num, nullptr, allocator),
       element_num_(element_num) {
     for (int i = 0; i < element_num_; ++i) {
-        neighbors_mutex_[i] = std::make_shared<std::shared_mutex>();
+        neighbors_mutex_[i] = AllocateShared<std::shared_mutex>(allocator_);
     }
 }
 

--- a/src/utils/util_functions.cpp
+++ b/src/utils/util_functions.cpp
@@ -48,6 +48,7 @@ mapping_external_param_to_inner(const JsonType& external_json,
     for (const auto& [key, value] : external_raw_json->items()) {
         auto ranges = param_map.equal_range(key);
         if (ranges.first == ranges.second) {
+            // key not found in param_map
             throw VsagException(ErrorType::INVALID_ARGUMENT,
                                 fmt::format("invalid config param: {}", key));
         }

--- a/tests/test_memleak.cpp
+++ b/tests/test_memleak.cpp
@@ -1,0 +1,210 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <cassert>
+#include <catch2/catch_test_macros.hpp>
+#include <cstdint>
+#include <iostream>
+#include <unordered_map>
+
+#include "fixtures.h"
+#include "fmt/format.h"
+#include "vsag/allocator.h"
+#include "vsag/options.h"
+#include "vsag/vsag.h"
+
+using namespace vsag;
+
+class MyAllocator : public vsag::Allocator {
+public:
+    MyAllocator() = default;
+
+    uint64_t
+    UsedMemory() const {
+        uint64_t used = 0;
+        for (const auto& [_, size] : addrs_) {
+            used += size;
+        }
+        return used;
+    }
+
+public:
+    std::string
+    Name() override {
+        return "my_allocator";
+    }
+
+    void*
+    Allocate(size_t size) override {
+        std::scoped_lock lock(mutex_);
+        auto* ptr = malloc(size);
+        if (ptr != nullptr) {
+            addrs_[ptr] = size;
+        }
+        return ptr;
+    }
+
+    void
+    Deallocate(void* p) override {
+        std::scoped_lock lock(mutex_);
+        if (addrs_.erase(p) != 0) {
+            free(p);
+        }
+    }
+
+    void*
+    Reallocate(void* p, size_t size) override {
+        std::scoped_lock lock(mutex_);
+        if (p == nullptr) {
+            return Allocate(size);
+        }
+        if (addrs_.find(p) == addrs_.end()) {
+            return nullptr;
+        }
+        auto* new_ptr = realloc(p, size);
+        if (new_ptr != nullptr) {
+            addrs_.erase(p);
+            addrs_[new_ptr] = size;
+        } else if (size == 0) {
+            // realloc(p, 0) may have freed p. We must untrack it.
+            addrs_.erase(p);
+        }
+        return new_ptr;
+    }
+
+private:
+    std::mutex mutex_;
+    std::unordered_map<void*, uint64_t> addrs_;
+};
+
+class ScopedIndex {
+public:
+    explicit ScopedIndex(const std::string& name,
+                         const std::string& parameter,
+                         int64_t num_vectors,
+                         int64_t dim,
+                         Allocator* allocator) {
+        resource_ = std::make_unique<vsag::Resource>(allocator, nullptr);
+        engine_ = std::make_unique<vsag::Engine>(resource_.get());
+        std::string build_parameters = fmt::format(parameter, dim);
+
+        index_ = engine_->CreateIndex(name, build_parameters).value();
+
+        auto [ids, vecs] = fixtures::generate_ids_and_vectors(num_vectors, dim);
+        auto base = vsag::Dataset::Make();
+        base->NumElements(num_vectors)
+            ->Dim(dim)
+            ->Ids(ids.data())
+            ->Float32Vectors(vecs.data())
+            ->Owner(false);
+
+        index_->Build(base).value();
+    }
+
+    ~ScopedIndex() {
+        index_ = nullptr;
+        engine_->Shutdown();
+        engine_ = nullptr;
+        resource_ = nullptr;
+    }
+
+public:
+    std::shared_ptr<vsag::Index>&
+    GetIndex() {
+        return index_;
+    }
+
+private:
+    std::unique_ptr<vsag::Resource> resource_;
+    std::unique_ptr<vsag::Engine> engine_;
+    std::shared_ptr<vsag::Index> index_;
+};
+
+const std::tuple<std::string, std::string, std::string, int64_t, int64_t> INDEX_PARAMS[] = {
+    {"hgraph",
+     R"({{
+                    "dtype": "float32",
+                    "metric_type": "l2",
+                    "dim": {},
+                    "index_param": {{
+                        "base_quantization_type": "fp32",
+                        "max_degree": 48,
+                        "ef_construction": 100
+                    }}
+                }})",
+     R"({"hgraph": {"ef_search": 100}})",
+     10000,
+     128},
+
+    {"hgraph",
+     R"({{
+                    "dtype": "float32",
+                    "metric_type": "l2",
+                    "dim": {},
+                    "index_param": {{
+                        "base_quantization_type": "sq8_uniform",
+                        "max_degree": 48,
+                        "ef_construction": 100
+                    }}
+                }})",
+     R"({"hgraph": {"ef_search": 100}})",
+     10000,
+     128},
+
+    {"ivf",
+     R"({{
+                    "dtype": "float32",
+                    "metric_type": "l2",
+                    "dim": {},
+                    "index_param": {{
+                        "buckets_count": 50,
+                        "base_quantization_type": "fp32",
+                        "partition_strategy_type": "ivf",
+                        "ivf_train_type": "kmeans",
+                        "ivf_train_sample_count": 1000
+                    }}
+                }})",
+     R"({"ivf": {"scan_buckets_count": 10}})",
+     10000,
+     128},
+};
+
+TEST_CASE("Test Classic Index Memory Leak", "[ft][memleak]") {
+    Options::Instance().set_block_size_limit(4ULL * 1024 * 1024);
+    auto* allocator = new MyAllocator();
+    REQUIRE(allocator->UsedMemory() == 0);
+    for (const auto& [index_name, index_parameter, search_parameter, num_vectors, dim] :
+         INDEX_PARAMS) {
+        ScopedIndex scoped_index(index_name, index_parameter, num_vectors, dim, allocator);
+
+        const int64_t num_queries = 1'000;
+        auto query_vector = fixtures::generate_vectors(num_queries, dim);
+        auto query = vsag::Dataset::Make();
+
+        for (uint64_t i = 0; i < num_queries; ++i) {
+            query->NumElements(1)
+                ->Dim(dim)
+                ->Float32Vectors(query_vector.data() + i * dim)
+                ->Owner(false);
+
+            scoped_index.GetIndex()->KnnSearch(query, 10, search_parameter).value();
+        }
+    }
+    REQUIRE(allocator->UsedMemory() == 0);
+    delete allocator;
+}


### PR DESCRIPTION
fixes: https://github.com/antgroup/vsag/issues/1389

- correct the allocator in PointsMutex constructor
- add a memoryleak test case

## Summary by Sourcery

Tests:
- Introduce a memory-leak test that builds an index using a custom tracking allocator and asserts no memory remains allocated after index teardown.