### PR TITLE
feat(pyramid): support reordering and timeout checks

### DIFF
--- a/src/algorithm/pyramid.cpp
+++ b/src/algorithm/pyramid.cpp
@@ -168,9 +168,13 @@ Pyramid::build_by_odescent(const DatasetPtr& base) {
     std::memcpy(label_table_->label_table_.data(), data_ids, sizeof(LabelType) * data_num);
 
     base_codes_->BatchInsertVector(data_vectors, data_num);
+    if (use_reorder_) {
+        precise_codes_->BatchInsertVector(data_vectors, data_num);
+    }
+    auto codes = use_reorder_ ? precise_codes_ : base_codes_;
 
     ODescent graph_builder(
-        pyramid_param_->odescent_param, base_codes_, allocator_, common_param_.thread_pool_.get());
+        pyramid_param_->odescent_param, codes, allocator_, common_param_.thread_pool_.get());
     for (int i = 0; i < data_num; ++i) {
         std::string current_path = path[i];
         auto path_slices = split(current_path, PART_SLASH);
@@ -185,6 +189,7 @@ Pyramid::build_by_odescent(const DatasetPtr& base) {
     }
     root_->BuildGraph(graph_builder);
     cur_element_count_ = data_num;
+    max_capacity_ = data_num;
     return {};
 }
 
@@ -203,11 +208,12 @@ Pyramid::KnnSearch(const DatasetPtr& query,
             std::make_shared<InnerIdWrapperFilter>(filter, *label_table_);
     }
     Statistics stats;
+    auto codes = use_reorder_ ? precise_codes_ : base_codes_;
     SearchFunc search_func = [&](const IndexNode* node, const VisitedListPtr& vl) {
         std::shared_lock lock(node->mutex_);
         search_param.ep = node->entry_point_;
         auto results = searcher_->Search(node->graph_,
-                                         base_codes_,
+                                         codes,
                                          vl,
                                          query->GetFloat32Vectors(),
                                          search_param,
@@ -237,11 +243,12 @@ Pyramid::RangeSearch(const DatasetPtr& query,
             std::make_shared<InnerIdWrapperFilter>(filter, *label_table_);
     }
     Statistics stats;
+    auto codes = use_reorder_ ? precise_codes_ : base_codes_;
     SearchFunc search_func = [&](const IndexNode* node, const VisitedListPtr& vl) {
         std::shared_lock lock(node->mutex_);
         search_param.ep = node->entry_point_;
         auto results = searcher_->Search(node->graph_,
-                                         base_codes_,
+                                         codes,
                                          vl,
                                          query->GetFloat32Vectors(),
                                          search_param,
@@ -330,10 +337,16 @@ void
 Pyramid::Serialize(StreamWriter& writer) const {
     StreamWriter::WriteVector(writer, label_table_->label_table_);
     base_codes_->Serialize(writer);
+    if (use_reorder_) {
+        precise_codes_->Serialize(writer);
+    }
     root_->Serialize(writer);
 
     // serialize footer (introduced since v0.15)
+    JsonType basic_info;
+    basic_info["max_capacity"].SetInt(max_capacity_);
     auto metadata = std::make_shared<Metadata>();
+    metadata->Set(BASIC_INFO, basic_info);
     auto footer = std::make_shared<Footer>(metadata);
     footer->Write(writer);
 }
@@ -342,18 +355,22 @@ void
 Pyramid::Deserialize(StreamReader& reader) {
     // try to deserialize footer (only in new version)
     auto footer = Footer::Parse(reader);
+    auto metadata = footer->GetMetadata();
+    auto basic_info = metadata->Get(BASIC_INFO);
+    auto max_capacity = basic_info["max_capacity"].GetInt();
 
     BufferStreamReader buffer_reader(
         &reader, std::numeric_limits<uint64_t>::max(), this->allocator_);
 
-    logger::debug("parse with new version format");
-    auto metadata = footer->GetMetadata();
-
     StreamReader::ReadVector(buffer_reader, label_table_->label_table_);
     base_codes_->Deserialize(buffer_reader);
+    if (use_reorder_) {
+        precise_codes_->Deserialize(buffer_reader);
+    }
+    cur_element_count_ = base_codes_->TotalCount();
     root_->Deserialize(buffer_reader);
-    pool_ = std::make_unique<VisitedListPool>(1, allocator_, base_codes_->TotalCount(), allocator_);
-    resize(base_codes_->TotalCount());
+    pool_ = std::make_unique<VisitedListPool>(1, allocator_, cur_element_count_, allocator_);
+    resize(max_capacity);
 }
 
 std::vector<int64_t>
@@ -379,6 +396,9 @@ Pyramid::Add(const DatasetPtr& base) {
         }
         cur_element_count_ += data_num;
         base_codes_->BatchInsertVector(data_vectors, data_num);
+        if (use_reorder_) {
+            precise_codes_->BatchInsertVector(data_vectors, data_num);
+        }
     }
     std::shared_lock<std::shared_mutex> lock(resize_mutex_);
 
@@ -434,6 +454,9 @@ Pyramid::resize(int64_t new_max_capacity) {
     pool_ = std::make_unique<VisitedListPool>(1, allocator_, new_max_capacity, allocator_);
     label_table_->label_table_.resize(new_max_capacity);
     base_codes_->Resize(new_max_capacity);
+    if (use_reorder_) {
+        precise_codes_->Resize(new_max_capacity);
+    }
     points_mutex_->Resize(new_max_capacity);
     max_capacity_ = new_max_capacity;
 }
@@ -570,6 +593,9 @@ Pyramid::CheckAndMappingExternalParam(const JsonType& external_param,
 void
 Pyramid::Train(const DatasetPtr& base) {
     this->base_codes_->Train(base->GetFloat32Vectors(), base->GetNumElements());
+    if (use_reorder_) {
+        this->precise_codes_->Train(base->GetFloat32Vectors(), base->GetNumElements());
+    }
 }
 std::vector<int64_t>
 Pyramid::Build(const DatasetPtr& base) {
@@ -593,6 +619,8 @@ Pyramid::add_one_point(const std::shared_ptr<IndexNode>& node,
     search_param.ef = pyramid_param_->ef_construction;
     search_param.topk = pyramid_param_->max_degree;
     search_param.search_mode = KNN_SEARCH;
+
+    auto codes = use_reorder_ ? precise_codes_ : base_codes_;
     // add one point
     if (node->graph_ == nullptr) {
         node->InitGraph();
@@ -614,7 +642,7 @@ Pyramid::add_one_point(const std::shared_ptr<IndexNode>& node,
         auto vl = pool_->TakeOne();
         Statistics discard_stats;
         auto results = searcher_->Search(node->graph_,
-                                         base_codes_,
+                                         codes,
                                          vl,
                                          vector,
                                          search_param,
@@ -622,7 +650,7 @@ Pyramid::add_one_point(const std::shared_ptr<IndexNode>& node,
                                          discard_stats);
         pool_->ReturnOne(vl);
         mutually_connect_new_element(
-            inner_id, results, node->graph_, base_codes_, points_mutex_, allocator_, alpha_);
+            inner_id, results, node->graph_, codes, points_mutex_, allocator_, alpha_);
         if (update_entry_point) {
             node->entry_point_ = inner_id;
         }

--- a/src/algorithm/pyramid.cpp
+++ b/src/algorithm/pyramid.cpp
@@ -652,13 +652,8 @@ Pyramid::add_one_point(const std::shared_ptr<IndexNode>& node,
 
         auto vl = pool_->TakeOne();
         Statistics discard_stats;
-        auto results = searcher_->Search(node->graph_,
-                                         codes,
-                                         vl,
-                                         vector,
-                                         search_param,
-                                         (LabelTablePtr) nullptr,
-                                         discard_stats);
+        auto results = searcher_->Search(
+            node->graph_, codes, vl, vector, search_param, (LabelTablePtr) nullptr, discard_stats);
         pool_->ReturnOne(vl);
         mutually_connect_new_element(
             inner_id, results, node->graph_, codes, points_mutex_, allocator_, alpha_);

--- a/src/algorithm/pyramid.cpp
+++ b/src/algorithm/pyramid.cpp
@@ -203,6 +203,12 @@ Pyramid::KnnSearch(const DatasetPtr& query,
     search_param.ef = parsed_param.ef_search;
     search_param.topk = k;
     search_param.search_mode = KNN_SEARCH;
+
+    if (parsed_param.enable_time_record) {
+        search_param.time_cost = std::make_shared<Timer>();
+        search_param.time_cost->SetThreshold(parsed_param.timeout_ms);
+    }
+
     if (filter != nullptr) {
         search_param.is_inner_id_allowed =
             std::make_shared<InnerIdWrapperFilter>(filter, *label_table_);
@@ -238,6 +244,12 @@ Pyramid::RangeSearch(const DatasetPtr& query,
     search_param.ef = parsed_param.ef_search;
     search_param.radius = radius;
     search_param.search_mode = RANGE_SEARCH;
+
+    if (parsed_param.enable_time_record) {
+        search_param.time_cost = std::make_shared<Timer>();
+        search_param.time_cost->SetThreshold(parsed_param.timeout_ms);
+    }
+
     if (filter != nullptr) {
         search_param.is_inner_id_allowed =
             std::make_shared<InnerIdWrapperFilter>(filter, *label_table_);

--- a/src/algorithm/pyramid.cpp
+++ b/src/algorithm/pyramid.cpp
@@ -381,7 +381,6 @@ Pyramid::Deserialize(StreamReader& reader) {
     }
     cur_element_count_ = base_codes_->TotalCount();
     root_->Deserialize(buffer_reader);
-    pool_ = std::make_unique<VisitedListPool>(1, allocator_, cur_element_count_, allocator_);
     resize(max_capacity);
 }
 

--- a/src/algorithm/pyramid.h
+++ b/src/algorithm/pyramid.h
@@ -22,6 +22,7 @@
 #include "impl/filter/filter_headers.h"
 #include "impl/heap/distance_heap.h"
 #include "impl/odescent/odescent_graph_builder.h"
+#include "impl/reorder/flatten_reorder.h"
 #include "impl/searcher/basic_searcher.h"
 #include "index_feature_list.h"
 #include "inner_index_interface.h"
@@ -99,6 +100,11 @@ public:
         root_ = std::make_shared<IndexNode>(&common_param_, pyramid_param_->graph_param);
         points_mutex_ = std::make_shared<PointsMutex>(max_capacity_, allocator_);
         searcher_ = std::make_unique<BasicSearcher>(common_param_, points_mutex_);
+        if (use_reorder_) {
+            precise_codes_ =
+                FlattenInterface::MakeInstance(pyramid_param_->precise_codes_param, common_param_);
+            reorder_ = std::make_shared<FlattenReorder>(precise_codes_, allocator_);
+        }
     }
 
     explicit Pyramid(const ParamPtr& param, const IndexCommonParam& common_param)
@@ -188,6 +194,7 @@ private:
     PyramidParamPtr pyramid_param_{nullptr};
     std::shared_ptr<IndexNode> root_{nullptr};
     FlattenInterfacePtr base_codes_{nullptr};
+    FlattenInterfacePtr precise_codes_{nullptr};
     std::unique_ptr<VisitedListPool> pool_ = nullptr;
 
     MutexArrayPtr points_mutex_{nullptr};
@@ -202,6 +209,7 @@ private:
 
     std::mutex entry_point_mutex_;
     std::default_random_engine level_generator_{2021};
+    ReorderInterfacePtr reorder_{nullptr};
 };
 
 }  // namespace vsag

--- a/src/algorithm/pyramid_zparameters.cpp
+++ b/src/algorithm/pyramid_zparameters.cpp
@@ -130,6 +130,7 @@ PyramidSearchParameters::FromJson(const std::string& json_string) {
     // set obj.ef_search
     CHECK_ARGUMENT(params.Contains(INDEX_PYRAMID),
                    fmt::format("parameters must contains {}", INDEX_PYRAMID));
+    obj.IndexSearchParameter::FromJson(params[INDEX_PYRAMID]);
 
     CHECK_ARGUMENT(
         params[INDEX_PYRAMID].Contains(HNSW_PARAMETER_EF_RUNTIME),

--- a/src/algorithm/pyramid_zparameters.h
+++ b/src/algorithm/pyramid_zparameters.h
@@ -18,6 +18,7 @@
 #include <functional>
 
 #include "algorithm/hgraph_parameter.h"
+#include "algorithm/index_search_parameter.h"
 #include "datacell/flatten_interface.h"
 #include "datacell/graph_datacell_parameter.h"
 #include "datacell/graph_interface.h"
@@ -54,7 +55,7 @@ public:
     float alpha{1.2F};
 };
 
-class PyramidSearchParameters {
+class PyramidSearchParameters : public IndexSearchParameter {
 public:
     static PyramidSearchParameters
     FromJson(const std::string& json_string);

--- a/tests/test_pyramid.cpp
+++ b/tests/test_pyramid.cpp
@@ -37,6 +37,9 @@ public:
                                          int64_t dim,
                                          const PyramidParam& param);
 
+    static std::string
+    GeneratePyramidSearchParametersString(int64_t ef_search, double timeout_ms = 100);
+
     static TestDatasetPool pool;
 
     static std::vector<int> dims;
@@ -48,7 +51,8 @@ public:
     constexpr static const char* search_param_tmp = R"(
         {{
             "pyramid": {{
-                "ef_search": 100
+                "ef_search": {},
+                "timeout_ms": {}
             }}
         }})";
 };
@@ -88,6 +92,12 @@ PyramidTestIndex::GeneratePyramidBuildParametersString(const std::string& metric
                                             param.use_reorder);
     return build_parameters_str;
 }
+
+std::string
+PyramidTestIndex::GeneratePyramidSearchParametersString(int64_t ef_search, double timeout_ms) {
+    return fmt::format(search_param_tmp, ef_search, timeout_ms);
+}
+
 }  // namespace fixtures
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
@@ -103,7 +113,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
         pyramid_param.precise_quantization_type = "fp32";
     }
     const std::string name = "pyramid";
-    auto search_param = fmt::format(search_param_tmp, 20);
+    auto search_param = GeneratePyramidSearchParametersString(100);
     for (auto& dim : dims) {
         auto param = GeneratePyramidBuildParametersString(metric_type, dim, pyramid_param);
         auto index = TestFactory(name, param, true);
@@ -123,7 +133,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex, "Pyramid Add Test", "[f
     PyramidParam pyramid_param;
     pyramid_param.no_build_levels = {0, 1, 2};
     const std::string name = "pyramid";
-    auto search_param = fmt::format(search_param_tmp, 20);
+    auto search_param = GeneratePyramidSearchParametersString(100);
     for (auto& dim : dims) {
         auto param = GeneratePyramidBuildParametersString(metric_type, dim, pyramid_param);
         auto index = TestFactory(name, param, true);
@@ -142,7 +152,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
     auto metric_type = GENERATE("l2");
     std::string base_quantization_str = GENERATE("fp32");
     const std::string name = "pyramid";
-    auto search_param = fmt::format(search_param_tmp, 100);
+    auto search_param = GeneratePyramidSearchParametersString(100);
     PyramidParam pyramid_param;
     for (auto& dim : dims) {
         for (const auto& level : levels) {
@@ -163,7 +173,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex, "Pyramid No Path Test",
     auto metric_type = GENERATE("l2");
     std::string base_quantization_str = GENERATE("fp32");
     const std::string name = "pyramid";
-    auto search_param = fmt::format(search_param_tmp, 100);
+    auto search_param = GeneratePyramidSearchParametersString(100);
     PyramidParam pyramid_param;
     std::vector<std::vector<int>> tmp_levels = {{1, 2}, {0, 1, 2}};
     for (auto& dim : dims) {
@@ -199,8 +209,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
         pyramid_param.precise_quantization_type = "fp32";
     }
     const std::string name = "pyramid";
-    auto search_param = fmt::format(search_param_tmp, 20);
-
+    auto search_param = GeneratePyramidSearchParametersString(100);
     for (auto& dim : dims) {
         vsag::Options::Instance().set_block_size_limit(size);
         auto param = GeneratePyramidBuildParametersString(metric_type, dim, pyramid_param);
@@ -237,8 +246,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex, "Pyramid Clone", "[ft][
     PyramidParam pyramid_param;
     pyramid_param.no_build_levels = {0, 1, 2};
     const std::string name = "pyramid";
-    auto search_param = fmt::format(search_param_tmp, 20);
-
+    auto search_param = GeneratePyramidSearchParametersString(100);
     for (auto& dim : dims) {
         vsag::Options::Instance().set_block_size_limit(size);
         auto param = GeneratePyramidBuildParametersString(metric_type, dim, pyramid_param);
@@ -279,7 +287,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
     PyramidParam pyramid_param;
     pyramid_param.no_build_levels = {0, 1};
     const std::string name = "pyramid";
-    auto search_param = fmt::format(search_param_tmp, 20);
+    auto search_param = GeneratePyramidSearchParametersString(100);
     for (auto& dim : dims) {
         auto param = GeneratePyramidBuildParametersString(metric_type, dim, pyramid_param);
         auto index = TestFactory(name, param, true);
@@ -292,5 +300,36 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
         auto index = TestFactory(name, param, true);
         auto dataset = pool.GetDatasetAndCreate(dim, base_count, metric_type, /*with_path=*/true);
         TestConcurrentAddSearch(index, dataset, search_param, 0.99, true);
+    }
+}
+
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex, "Pyramid OverTime Test", "[ft][pyramid]") {
+    auto metric_type = GENERATE("l2");
+    PyramidParam pyramid_param;
+    pyramid_param.no_build_levels = {0, 1};
+    const std::string name = "pyramid";
+    auto search_param = GeneratePyramidSearchParametersString(100, 20);
+    for (auto& dim : dims) {
+        auto param = GeneratePyramidBuildParametersString(metric_type, dim, pyramid_param);
+        auto index = TestFactory(name, param, true);
+        auto dataset = pool.GetDatasetAndCreate(dim, base_count, metric_type, /*with_path=*/true);
+        TestContinueAdd(index, dataset, true);
+        TestSearchOvertime(index, dataset, search_param);
+        auto timeout_search_param = GeneratePyramidSearchParametersString(100, 0.1);
+
+        auto query = vsag::Dataset::Make();
+        query->NumElements(1)
+            ->Dim(dim)
+            ->Float32Vectors(dataset->query_->GetFloat32Vectors())
+            ->Paths(dataset->query_->GetPaths())
+            ->Owner(false);
+        auto res = index->KnnSearch(query, 10, timeout_search_param);
+        REQUIRE(res.has_value());
+        auto result = res.value();
+        REQUIRE(result->GetStatistics() != "{}");
+        auto stats = result->GetStatistics({"is_timeout"});
+        REQUIRE(stats.size() == 1);
+        bool is_timeout = stats[0] == "true";
+        REQUIRE(is_timeout);
     }
 }


### PR DESCRIPTION
#1336

## Summary by Sourcery

Add support for reorder-aware pyramid indexing and timeout-aware search, and extend tests accordingly.

New Features:
- Support optional reorder using precise quantization codes throughout pyramid build, add, resize, train, and search flows.
- Expose search timeout configuration and timeout statistics via pyramid search parameters and propagate them through KnnSearch and RangeSearch results.
- Persist and restore pyramid index capacity metadata, including max capacity, across serialization.

Enhancements:
- Extend pyramid tests to cover reorder configurations, configurable search parameters, and search timeout behavior, including statistics validation.