### PR TITLE
fix(leak): vt pool leak on concurrent search

### DIFF
--- a/src/utils/resource_object.h
+++ b/src/utils/resource_object.h
@@ -15,6 +15,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace vsag {
 
 class ResourceObject {
@@ -34,6 +36,14 @@ public:
      */
     virtual void
     Reset() = 0;
+
+    /**
+     * @brief The ID of the sub-pool this resource object belongs to.
+     *
+     * This is used to ensure an object is returned to the same sub-pool it was
+     * taken from, preventing pool imbalance under concurrent access.
+     */
+    int64_t source_pool_id_{0};
 };
 
 }  // namespace vsag


### PR DESCRIPTION
closed: #1376 

- for Hgraph index, concurrent search may lead imbalance of the vt pool. Try to balance it by "unify take/return to one subpool"

## Summary by Sourcery

Balance resource object sub-pools to prevent leaks during concurrent access by tracking each object's originating pool.

Bug Fixes:
- Fix resource object pool imbalance and potential leaks under concurrent access by binding take/return operations to a specific sub-pool.

Enhancements:
- Track and store the originating sub-pool identifier on resource objects to enable deterministic return to the same pool.