### PR TITLE
refactor(deserialize): increase time of deserialization per IO operation

### DIFF
--- a/tests/fixtures/test_reader.h
+++ b/tests/fixtures/test_reader.h
@@ -20,6 +20,9 @@
 #include "vsag/binaryset.h"
 #include "vsag/readerset.h"
 
+#include <thread>
+#include <chrono>
+
 namespace fixtures {
 
 class TestReader : public vsag::Reader {
@@ -29,6 +32,7 @@ public:
 
     void
     Read(uint64_t offset, uint64_t len, void* dest) override {
+        std::this_thread::sleep_for(std::chrono::milliseconds(30));
         memcpy((char*)dest, binary_.data.get() + offset, len);
     }
 

--- a/tests/fixtures/test_reader.h
+++ b/tests/fixtures/test_reader.h
@@ -17,11 +17,11 @@
 
 #include <string.h>
 
+#include <chrono>
+#include <thread>
+
 #include "vsag/binaryset.h"
 #include "vsag/readerset.h"
-
-#include <thread>
-#include <chrono>
 
 namespace fixtures {
 


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Introduce a 30ms sleep in the TestReader fixture’s Read method to simulate slower I/O during deserialization tests.