### PR TITLE
refactor(blas): collect all blas dependance to one

### DIFF
--- a/src/algorithm/ivf_partition/CMakeLists.txt
+++ b/src/algorithm/ivf_partition/CMakeLists.txt
@@ -24,4 +24,4 @@ set (IVF_PARTITION_SRCS
 
 add_library (ivf_partition OBJECT ${IVF_PARTITION_SRCS})
 target_link_libraries (ivf_partition PUBLIC coverage_config)
-maybe_add_dependencies (ivf_partition spdlog fmt::fmt mkl openblas)
+maybe_add_dependencies (ivf_partition spdlog fmt::fmt)

--- a/src/algorithm/ivf_partition/gno_imi_partition.cpp
+++ b/src/algorithm/ivf_partition/gno_imi_partition.cpp
@@ -15,7 +15,6 @@
 
 #include "gno_imi_partition.h"
 
-#include <cblas.h>
 #include <fmt/format.h>
 
 #include <atomic>
@@ -25,6 +24,7 @@
 
 #include "algorithm/inner_index_interface.h"
 #include "impl/allocator/safe_allocator.h"
+#include "impl/blas/blas_function.h"
 #include "impl/cluster/kmeans_cluster.h"
 #include "inner_string_params.h"
 #include "utils/util_functions.h"
@@ -42,20 +42,20 @@ static constexpr const char* SEARCH_PARAM_TEMPLATE_STR = R"(
 // C = A * B^T
 void
 matmul(const float* A, const float* B, float* C, int64_t M, int64_t N, int64_t K) {
-    cblas_sgemm(CblasColMajor,
-                CblasTrans,
-                CblasNoTrans,
-                static_cast<blasint>(N),
-                static_cast<blasint>(M),
-                static_cast<blasint>(K),
-                1.0F,
-                B,
-                static_cast<blasint>(K),
-                A,
-                static_cast<blasint>(K),
-                0.0F,
-                C,
-                static_cast<blasint>(N));
+    BlasFunction::Sgemm(BlasFunction::ColMajor,
+                        BlasFunction::Trans,
+                        BlasFunction::NoTrans,
+                        static_cast<int32_t>(N),
+                        static_cast<int32_t>(M),
+                        static_cast<int32_t>(K),
+                        1.0F,
+                        B,
+                        static_cast<int32_t>(K),
+                        A,
+                        static_cast<int32_t>(K),
+                        0.0F,
+                        C,
+                        static_cast<int32_t>(N));
 }
 
 GNOIMIPartition::GNOIMIPartition(const IndexCommonParam& common_param,

--- a/src/algorithm/ivf_partition/ivf_partition_strategy.cpp
+++ b/src/algorithm/ivf_partition/ivf_partition_strategy.cpp
@@ -15,7 +15,7 @@
 
 #include "ivf_partition_strategy.h"
 
-#include <cblas.h>
+#include "impl/blas/blas_function.h"
 
 namespace vsag {
 
@@ -26,8 +26,12 @@ IVFPartitionStrategy::GetResidual(
     memcpy(residuals, x, sizeof(float) * n * dim_);
     for (size_t i = 0; i < n; ++i) {
         BucketIdType bucket_id = assign[i];
-        cblas_saxpy(
-            static_cast<int>(dim_), -1.0, centroids + bucket_id * dim_, 1, residuals + i * dim_, 1);
+        BlasFunction::Saxpy(static_cast<int32_t>(dim_),
+                            -1.0,
+                            centroids + bucket_id * dim_,
+                            1,
+                            residuals + i * dim_,
+                            1);
     }
 }
 

--- a/src/impl/CMakeLists.txt
+++ b/src/impl/CMakeLists.txt
@@ -25,17 +25,18 @@ add_subdirectory (logger)
 add_subdirectory (searcher)
 add_subdirectory (odescent)
 add_subdirectory (reorder)
+add_subdirectory (blas)
 
 file (GLOB IMPL_SRCS "*.cpp")
 list (FILTER IMPL_SRCS EXCLUDE REGEX "_test.cpp")
 list (FILTER IMPL_SRCS EXCLUDE REGEX kmeans_cluster.cpp)
 
 add_library (impl OBJECT ${IMPL_SRCS})
-target_link_libraries (impl PUBLIC transform thread_pool allocator heap 
+target_link_libraries (impl PUBLIC transform thread_pool allocator heap vsag_blas
     bitset logger filter cluster searcher odescent reorder fmt::fmt coverage_config)
 maybe_add_dependencies (impl spdlog)
 
-set (IMPL_LIBS transform thread_pool allocator heap bitset 
+set (IMPL_LIBS transform thread_pool allocator heap bitset vsag_blas
     logger filter impl cluster searcher odescent reorder PARENT_SCOPE)
 
 if (ENABLE_TESTS)

--- a/src/impl/blas/CMakeLists.txt
+++ b/src/impl/blas/CMakeLists.txt
@@ -14,11 +14,6 @@
 # limitations under the License.
 
 
-set (SINDI_SRCS
-        sindi.cpp
-        sindi_parameter.cpp
-)
+add_library (vsag_blas OBJECT blas_function.cpp)
+maybe_add_dependencies (vsag_blas openblas mkl)
 
-add_library (sindi OBJECT ${SINDI_SRCS})
-target_link_libraries (sindi PUBLIC coverage_config)
-maybe_add_dependencies (sindi spdlog fmt::fmt)

--- a/src/impl/blas/blas_function.cpp
+++ b/src/impl/blas/blas_function.cpp
@@ -1,0 +1,134 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "blas_function.h"
+
+#include <cblas.h>
+#include <lapacke.h>
+
+namespace vsag {
+
+void
+BlasFunction::Saxpy(int32_t n, float alpha, const float* x, int32_t incx, float* y, int32_t incy) {
+    cblas_saxpy(n, alpha, x, incx, y, incy);
+}
+
+void
+BlasFunction::Sscal(int32_t n, float alpha, float* x, int32_t incx) {
+    cblas_sscal(n, alpha, x, incx);
+}
+
+void
+BlasFunction::Sgemv(int32_t order,
+                    int32_t trans,
+                    int32_t m,
+                    int32_t n,
+                    float alpha,
+                    const float* a,
+                    int32_t lda,
+                    const float* x,
+                    int32_t incx,
+                    float beta,
+                    float* y,
+                    int32_t incy) {
+    cblas_sgemv(static_cast<CBLAS_ORDER>(order),
+                static_cast<CBLAS_TRANSPOSE>(trans),
+                m,
+                n,
+                alpha,
+                a,
+                lda,
+                x,
+                incx,
+                beta,
+                y,
+                incy);
+}
+
+void
+BlasFunction::Sgemm(int32_t order,
+                    int32_t transa,
+                    int32_t transb,
+                    int32_t m,
+                    int32_t n,
+                    int32_t k,
+                    float alpha,
+                    const float* a,
+                    int32_t lda,
+                    const float* b,
+                    int32_t ldb,
+                    float beta,
+                    float* c,
+                    int32_t ldc) {
+    cblas_sgemm(static_cast<CBLAS_ORDER>(order),
+                static_cast<CBLAS_TRANSPOSE>(transa),
+                static_cast<CBLAS_TRANSPOSE>(transb),
+                m,
+                n,
+                k,
+                alpha,
+                a,
+                lda,
+                b,
+                ldb,
+                beta,
+                c,
+                ldc);
+}
+
+int32_t
+BlasFunction::Sgeqrf(int32_t order, int32_t m, int32_t n, float* a, int32_t lda, float* tau) {
+    return LAPACKE_sgeqrf(static_cast<lapack_int>(order),
+                          static_cast<lapack_int>(m),
+                          static_cast<lapack_int>(n),
+                          a,
+                          static_cast<lapack_int>(lda),
+                          tau);
+}
+
+int32_t
+BlasFunction::Sorgqr(
+    int32_t order, int32_t m, int32_t n, int32_t k, float* a, int32_t lda, const float* tau) {
+    return LAPACKE_sorgqr(static_cast<lapack_int>(order),
+                          static_cast<lapack_int>(m),
+                          static_cast<lapack_int>(n),
+                          static_cast<lapack_int>(k),
+                          a,
+                          static_cast<lapack_int>(lda),
+                          tau);
+}
+
+int32_t
+BlasFunction::Sgetrf(int32_t order, int32_t m, int32_t n, float* a, int32_t lda, int32_t* ipiv) {
+    return LAPACKE_sgetrf(static_cast<lapack_int>(order),
+                          static_cast<lapack_int>(m),
+                          static_cast<lapack_int>(n),
+                          a,
+                          static_cast<lapack_int>(lda),
+                          reinterpret_cast<lapack_int*>(ipiv));
+}
+
+int32_t
+BlasFunction::Ssyev(
+    int32_t order, char jobz, char uplo, int32_t n, float* a, int32_t lda, float* w) {
+    return LAPACKE_ssyev(static_cast<lapack_int>(order),
+                         jobz,
+                         uplo,
+                         static_cast<lapack_int>(n),
+                         a,
+                         static_cast<lapack_int>(lda),
+                         w);
+}
+
+}  // namespace vsag

--- a/src/impl/blas/blas_function.h
+++ b/src/impl/blas/blas_function.h
@@ -1,0 +1,184 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+
+namespace vsag {
+
+class BlasFunction {
+public:
+    /**
+     * @brief Perform the operation y := alpha * x + y.
+     * 
+     * @param n Number of elements in vector x and y.
+     * @param alpha Scaling factor for vector x.
+     * @param x Pointer to the input vector x.
+     * @param incx Stride of vector x (use 1 for contiguous storage).
+     * @param y Pointer to the input/output vector y.
+     * @param incy Stride of vector y (use 1 for contiguous storage).
+     */
+    static void
+    Saxpy(int32_t n, float alpha, const float* x, int32_t incx, float* y, int32_t incy);
+
+    /**
+     * @brief Scale vector x by alpha.
+     * 
+     * @param n Number of elements in vector x.
+     * @param alpha Scaling factor.
+     * @param x Pointer to the input/output vector x.
+     * @param incx Stride of vector x (use 1 for contiguous storage).
+     */
+    static void
+    Sscal(int32_t n, float alpha, float* x, int32_t incx);
+
+    /**
+     * @brief Perform the matrix-vector operation y := alpha * A * x + beta * y.
+     * 
+     * @param order Specifies the matrix storage layout (RowMajor or ColMajor).
+     * @param trans Specifies the operation (NoTrans, Trans, or ConjTrans).
+     * @param m Number of rows in matrix A.
+     * @param n Number of columns in matrix A.
+     * @param alpha Scaling factor for matrix A.
+     * @param a Pointer to the input matrix A.
+     * @param lda Leading dimension of matrix A (use m for RowMajor, use n for ColMajor).
+     * @param x Pointer to the input vector x.
+     * @param incx Stride of vector x (use 1 for contiguous storage).
+     * @param beta Scaling factor for vector y.
+     * @param y Pointer to the input/output vector y.
+     * @param incy Stride of vector y (use 1 for contiguous storage).
+     */
+    static void
+    Sgemv(int32_t order,
+          int32_t trans,
+          int32_t m,
+          int32_t n,
+          float alpha,
+          const float* a,
+          int32_t lda,
+          const float* x,
+          int32_t incx,
+          float beta,
+          float* y,
+          int32_t incy);
+
+    /**
+     * @brief Perform the matrix-matrix operation C := alpha * A * B + beta * C.
+     * 
+     * @param order Specifies the matrix storage layout (RowMajor or ColMajor).
+     * @param transa Specifies the operation for matrix A (NoTrans, Trans, or ConjTrans).
+     * @param transb Specifies the operation for matrix B (NoTrans, Trans, or ConjTrans).
+     * @param m Number of rows in matrix A.
+     * @param n Number of columns in matrix B.
+     * @param k Number of columns in matrix A (if transa == NoTrans, else number of rows in A).
+     * @param alpha Scaling factor for matrices A and B.
+     * @param a Pointer to the input matrix A.
+     * @param lda Leading dimension of matrix A (use m for RowMajor, use k for ColMajor).
+     * @param b Pointer to the input matrix B.
+     * @param ldb Leading dimension of matrix B (use n for RowMajor, use k for ColMajor).
+     * @param beta Scaling factor for matrix C.
+     * @param c Pointer to the input/output matrix C.
+     * @param ldc Leading dimension of matrix C (use m for RowMajor, use n for ColMajor).
+     */
+    static void
+    Sgemm(int32_t order,
+          int32_t transa,
+          int32_t transb,
+          int32_t m,
+          int32_t n,
+          int32_t k,
+          float alpha,
+          const float* a,
+          int32_t lda,
+          const float* b,
+          int32_t ldb,
+          float beta,
+          float* c,
+          int32_t ldc);
+
+    /**
+     * @brief Compute the QR factorization of a matrix A using the Gram-Schmidt process.
+     * 
+     * @param order Specifies the matrix storage layout (RowMajor or ColMajor).
+     * @param m Number of rows in matrix A.
+     * @param n Number of columns in matrix A.
+     * @param a Pointer to the input/output matrix A.
+     * @param lda Leading dimension of matrix A (use m for RowMajor, use n for ColMajor).
+     * @param tau Pointer to the output array tau of size min(m, n).
+     * @return int32_t Error code (0 for success).
+     */
+    static int32_t
+    Sgeqrf(int32_t order, int32_t m, int32_t n, float* a, int32_t lda, float* tau);
+
+    /**
+     * @brief Compute the orthogonal matrix Q from the QR factorization computed by Sgeqrf.
+     * 
+     * @param order Specifies the matrix storage layout (RowMajor or ColMajor).
+     * @param m Number of rows in matrix A.
+     * @param n Number of columns in matrix A.
+     * @param k Number of columns in matrix A (if transa == NoTrans, else number of rows in A).
+     * @param a Pointer to the input/output matrix A.
+     * @param lda Leading dimension of matrix A (use m for RowMajor, use n for ColMajor).
+     * @param tau Pointer to the input array tau of size min(m, n).
+     * @return int32_t Error code (0 for success).
+     */
+    static int32_t
+    Sorgqr(int32_t order, int32_t m, int32_t n, int32_t k, float* a, int32_t lda, const float* tau);
+
+    /**
+     * @brief Compute the LU factorization of a matrix A using partial pivoting.
+     * 
+     * @param order Specifies the matrix storage layout (RowMajor or ColMajor).
+     * @param m Number of rows in matrix A.
+     * @param n Number of columns in matrix A.
+     * @param a Pointer to the input/output matrix A.
+     * @param lda Leading dimension of matrix A (use m for RowMajor, use n for ColMajor).
+     * @param ipiv Pointer to the output array ipiv of size max(m, n).
+     * @return int32_t Error code (0 for success).
+     */
+    static int32_t
+    Sgetrf(int32_t order, int32_t m, int32_t n, float* a, int32_t lda, int32_t* ipiv);
+
+    /**
+     * @brief Compute the eigenvalues and, optionally, the eigenvectors of a symmetric matrix A.
+     * 
+     * @param order Specifies the matrix storage layout (RowMajor or ColMajor).
+     * @param jobz Specifies whether to compute eigenvalues only (N) or eigenvalues and eigenvectors (V).
+     * @param uplo Specifies whether the upper or lower triangle of A is stored (U or L).
+     * @param n Number of rows and columns in matrix A.
+     * @param a Pointer to the input/output matrix A.
+     * @param lda Leading dimension of matrix A (use n for RowMajor, use n for ColMajor).
+     * @param w Pointer to the output array w of size n.
+     * @return int32_t Error code (0 for success).
+     */
+    static int32_t
+    Ssyev(int32_t order, char jobz, char uplo, int32_t n, float* a, int32_t lda, float* w);
+
+    // Constants for BLAS operations
+    static constexpr int32_t RowMajor = 101;   // Row-major storage
+    static constexpr int32_t ColMajor = 102;   // Column-major storage
+    static constexpr int32_t NoTrans = 111;    // No transpose
+    static constexpr int32_t Trans = 112;      // Transpose
+    static constexpr int32_t ConjTrans = 113;  // Conjugate transpose
+
+    // LAPACK specific constants
+    static constexpr char JobV = 'V';   // Compute eigenvectors
+    static constexpr char JobN = 'N';   // Do not compute eigenvectors
+    static constexpr char Upper = 'U';  // Upper triangular
+    static constexpr char Lower = 'L';  // Lower triangular
+};
+
+}  // namespace vsag

--- a/src/impl/cluster/CMakeLists.txt
+++ b/src/impl/cluster/CMakeLists.txt
@@ -16,5 +16,5 @@
 
 add_library (cluster OBJECT kmeans_cluster.cpp)
 target_link_libraries (cluster PRIVATE fmt::fmt)
-maybe_add_dependencies (cluster spdlog openblas mkl)
+maybe_add_dependencies (cluster spdlog)
 

--- a/src/impl/transform/CMakeLists.txt
+++ b/src/impl/transform/CMakeLists.txt
@@ -28,4 +28,4 @@ set (TRANSFORM_SRC
 )
 add_library (transform OBJECT ${TRANSFORM_SRC})
 target_link_libraries (transform PUBLIC fmt::fmt coverage_config)
-maybe_add_dependencies (transform spdlog openblas mkl)
+maybe_add_dependencies (transform spdlog)

--- a/src/impl/transform/random_orthogonal_transformer_test.cpp
+++ b/src/impl/transform/random_orthogonal_transformer_test.cpp
@@ -15,12 +15,11 @@
 
 #include "random_orthogonal_transformer.h"
 
-#include <cblas.h>
-
 #include <catch2/catch_test_macros.hpp>
 
 #include "fixtures.h"
 #include "impl/allocator/safe_allocator.h"
+#include "impl/blas/blas_function.h"
 #include "storage/serialization_template_test.h"
 
 using namespace vsag;
@@ -71,20 +70,20 @@ TestOrthogonality(RandomOrthogonalMatrix& rom, uint64_t dim) {
 
     // compute Q ^ T * Q
     std::vector<float> result(dim * dim, 0.0);
-    cblas_sgemm(CblasRowMajor,
-                CblasTrans,
-                CblasNoTrans,
-                dim,
-                dim,
-                dim,
-                1.0f,
-                Q.data(),
-                dim,
-                Q.data(),
-                dim,
-                0.0f,
-                result.data(),
-                dim);
+    BlasFunction::Sgemm(BlasFunction::RowMajor,
+                        BlasFunction::Trans,
+                        BlasFunction::NoTrans,
+                        dim,
+                        dim,
+                        dim,
+                        1.0F,
+                        Q.data(),
+                        dim,
+                        Q.data(),
+                        dim,
+                        0.0F,
+                        result.data(),
+                        dim);
 
     // constructing unit matrices
     std::vector<float> identity(dim * dim, 0.0);

--- a/src/quantization/CMakeLists.txt
+++ b/src/quantization/CMakeLists.txt
@@ -43,7 +43,7 @@ set (QUANTIZER_SRC
 add_library (quantizer OBJECT ${QUANTIZER_SRC})
 target_link_libraries(quantizer PUBLIC fmt::fmt coverage_config)
 
-maybe_add_dependencies (quantizer spdlog openblas mkl)
+maybe_add_dependencies (quantizer spdlog)
 
 if (ENABLE_TESTS)
     file (GLOB_RECURSE QUANTIZER_TESTS "*_test.cpp")

--- a/src/quantization/product_quantization/pq_fastscan_quantizer.cpp
+++ b/src/quantization/product_quantization/pq_fastscan_quantizer.cpp
@@ -15,8 +15,7 @@
 
 #include "pq_fastscan_quantizer.h"
 
-#include <cblas.h>
-
+#include "impl/blas/blas_function.h"
 #include "impl/cluster/kmeans_cluster.h"
 #include "index_common_param.h"
 #include "pq_fastscan_quantizer_parameter.h"
@@ -324,18 +323,18 @@ PQFastScanQuantizer<metric>::ProcessQueryImpl(const DataType* query,
             auto* per_result = lookup_table.data() + i * CENTROIDS_PER_SUBSPACE;
             if constexpr (metric == MetricType::METRIC_TYPE_IP or
                           metric == MetricType::METRIC_TYPE_COSINE) {
-                cblas_sgemv(CblasRowMajor,
-                            CblasNoTrans,
-                            CENTROIDS_PER_SUBSPACE,
-                            subspace_dim_,
-                            1.0F,
-                            per_code_book,
-                            subspace_dim_,
-                            per_query,
-                            1,
-                            0.0F,
-                            per_result,
-                            1);
+                BlasFunction::Sgemv(BlasFunction::RowMajor,
+                                    BlasFunction::NoTrans,
+                                    CENTROIDS_PER_SUBSPACE,
+                                    subspace_dim_,
+                                    1.0F,
+                                    per_code_book,
+                                    subspace_dim_,
+                                    per_query,
+                                    1,
+                                    0.0F,
+                                    per_result,
+                                    1);
             } else if constexpr (metric == MetricType::METRIC_TYPE_L2SQR) {
                 // TODO(LHT): use blas opt
                 for (int64_t j = 0; j < CENTROIDS_PER_SUBSPACE; ++j) {

--- a/src/quantization/product_quantization/product_quantizer.cpp
+++ b/src/quantization/product_quantization/product_quantizer.cpp
@@ -15,8 +15,7 @@
 
 #include "product_quantizer.h"
 
-#include <cblas.h>
-
+#include "impl/blas/blas_function.h"
 #include "impl/cluster/kmeans_cluster.h"
 #include "simd/fp32_simd.h"
 #include "simd/normalize.h"
@@ -345,18 +344,18 @@ ProductQuantizer<metric>::ProcessQueryImpl(const DataType* query,
             auto* per_result = lookup_table + i * CENTROIDS_PER_SUBSPACE;
             if constexpr (metric == MetricType::METRIC_TYPE_IP or
                           metric == MetricType::METRIC_TYPE_COSINE) {
-                cblas_sgemv(CblasRowMajor,
-                            CblasNoTrans,
-                            CENTROIDS_PER_SUBSPACE,
-                            subspace_dim_,
-                            1.0F,
-                            per_code_book,
-                            subspace_dim_,
-                            per_query,
-                            1,
-                            0.0F,
-                            per_result,
-                            1);
+                BlasFunction::Sgemv(BlasFunction::RowMajor,
+                                    BlasFunction::NoTrans,
+                                    CENTROIDS_PER_SUBSPACE,
+                                    subspace_dim_,
+                                    1.0F,
+                                    per_code_book,
+                                    subspace_dim_,
+                                    per_query,
+                                    1,
+                                    0.0F,
+                                    per_result,
+                                    1);
             } else if constexpr (metric == MetricType::METRIC_TYPE_L2SQR) {
                 // TODO(LHT): use blas opt
                 for (int64_t j = 0; j < CENTROIDS_PER_SUBSPACE; ++j) {


### PR DESCRIPTION
- add BlasFunction to hold all blas dependance

## Summary by Sourcery

Centralize BLAS and LAPACK usage behind a new wrapper and update callers to depend on a shared BLAS abstraction.

Enhancements:
- Introduce a BlasFunction utility class encapsulating common BLAS and LAPACK operations used across the project.
- Refactor transform, clustering, IVF partition, and quantization components (and related tests) to call BlasFunction instead of directly invoking cblas/LAPACKE.
- Add a dedicated vsag_blas library target and link the impl library against it to consolidate BLAS-related code and dependencies.

Build:
- Add a new impl/blas CMake target for the BLAS wrapper and wire it into the impl build.
- Simplify other CMake targets by removing direct OpenBLAS/MKL dependencies in favor of the shared BLAS wrapper target.