### PR TITLE
improvment(cmake): Support compile without libaio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,8 @@ option (DISABLE_AVX512_FORCE "Force disable avx512 instructions" OFF)
 option (DISABLE_AVX512VPOPCNTDQ_FORCE "Force disable avx512vpopcntdq instructions" OFF)
 option (DISABLE_NEON_FORCE "Force disable neon instructions" OFF)
 option (DISABLE_SVE_FORCE "Force disable sve instructions" OFF)
-
+# AIO library configuration
+option (ENABLE_LIBAIO "Whether to enable libaio support" ON)
 
 if (ENABLE_CXX11_ABI)
     add_definitions (-D_GLIBCXX_USE_CXX11_ABI=1)
@@ -130,6 +131,26 @@ else ()
     if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
         set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libstdc++")
     endif ()
+endif ()
+
+# AIO library detection
+if (ENABLE_LIBAIO)
+    find_library (AIO_LIBRARY aio)
+    if (AIO_LIBRARY)
+        message (STATUS "Found libaio: ${AIO_LIBRARY}")
+        set (HAVE_LIBAIO 1)
+        add_definitions (-DHAVE_LIBAIO=1)
+    else ()
+        message (WARNING "libaio not found, disabling async I/O support")
+        set (HAVE_LIBAIO 0)
+        add_definitions (-DHAVE_LIBAIO=0)
+        add_definitions (-DNO_LIBAIO=1)
+    endif ()
+else ()
+    message (STATUS "libaio support disabled by user")
+    set (HAVE_LIBAIO 0)
+    add_definitions (-DHAVE_LIBAIO=0)
+    add_definitions (-DNO_LIBAIO=1)
 endif ()
 
 # ccache

--- a/src/io/CMakeLists.txt
+++ b/src/io/CMakeLists.txt
@@ -31,7 +31,16 @@ set (IO_SRC
 )
 
 add_library (io STATIC ${IO_SRC})
-target_link_libraries (io PUBLIC fmt::fmt aio coverage_config)
+if (HAVE_LIBAIO)
+    target_compile_definitions (io PUBLIC -DHAVE_LIBAIO=1)
+    target_link_libraries (io PUBLIC fmt::fmt aio coverage_config)
+    message (STATUS "io module: linking with libaio")
+else ()
+    target_compile_definitions (io PUBLIC -DHAVE_LIBAIO=0)
+    target_link_libraries (io PUBLIC fmt::fmt coverage_config)
+    message (STATUS "io module: libaio not available, async I/O disabled")
+endif ()
+
 maybe_add_dependencies (io spdlog)
 
 if (ENABLE_TESTS)

--- a/src/io/async_io.cpp
+++ b/src/io/async_io.cpp
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if HAVE_LIBAIO
+
 #include "async_io.h"
 
 #include <fcntl.h>
@@ -24,6 +26,7 @@
 #include "io_context.h"
 
 namespace vsag {
+
 std::unique_ptr<IOContextPool> AsyncIO::io_context_pool =
     std::make_unique<IOContextPool>(10, nullptr);
 
@@ -164,3 +167,5 @@ AsyncIO::MultiReadImpl(uint8_t* datas, uint64_t* sizes, uint64_t* offsets, uint6
 }
 
 }  // namespace vsag
+
+#endif  // HAVE_LIBAIO

--- a/src/io/async_io.h
+++ b/src/io/async_io.h
@@ -15,11 +15,11 @@
 
 #pragma once
 
+#if HAVE_LIBAIO
 #include "async_io_parameter.h"
 #include "basic_io.h"
 #include "index_common_param.h"
 #include "io_context.h"
-
 namespace vsag {
 
 class AsyncIO : public BasicIO<AsyncIO> {
@@ -64,4 +64,10 @@ private:
 
     bool exist_file_{false};
 };
+
 }  // namespace vsag
+
+#else
+#include "buffer_io.h"
+#define AsyncIO BufferIO
+#endif  // HAVE_LIBAIO

--- a/src/io/io_context.h
+++ b/src/io/io_context.h
@@ -15,6 +15,8 @@
 
 #pragma once
 
+#if HAVE_LIBAIO
+
 #include "libaio.h"
 #include "utils/resource_object.h"
 #include "utils/resource_object_pool.h"
@@ -53,3 +55,5 @@ public:
 using IOContextPool = ResourceObjectPool<IOContext>;
 
 }  // namespace vsag
+
+#endif  // HAVE_LIBAIO


### PR DESCRIPTION
closed: #644 

- and ENABLE_LIBAIO config and env's aio check
- if no libaio, the AsyncIO is the same as BufferIO

## Summary by Sourcery

Add configurable libaio support so the project can be built with or without asynchronous I/O, falling back to buffered I/O when libaio is unavailable or disabled.

New Features:
- Introduce an ENABLE_LIBAIO CMake option to toggle libaio usage at configure time.

Enhancements:
- Detect libaio availability at configure time and define compile-time flags to enable or disable async I/O integration.
- Adjust the io library to conditionally link against libaio and expose the HAVE_LIBAIO definition to dependent code.
- Fallback AsyncIO implementation to BufferIO when libaio support is not present, ensuring builds still succeed without libaio.