### PR TITLE
fix(deserialize): fix HNSW in 0.14 cannot parse indexes in 0.16 (#1394)

### DIFF
--- a/src/index/diskann.cpp
+++ b/src/index/diskann.cpp
@@ -56,6 +56,7 @@ const static std::string BUILD_STATUS = "status";
 const static std::string BUILD_CURRENT_ROUND = "round";
 const static std::string BUILD_NODES = "builded_nodes";
 const static std::string BUILD_FAILED_LOC = "failed_loc";
+const static std::string EMPTY_DISKANN = "EMPTY_DISKANN";
 
 template <typename T>
 Binary
@@ -705,14 +706,8 @@ DiskANN::serialize() const {
     metadata->SetVersion("v0.15");
 
     if (status_ == IndexStatus::EMPTY) {
-        // TODO(wxyu): remove this if condition
-        // if (not Options::Instance().new_version()) {
-        //     // return a special binaryset means empty
-        //     return EmptyIndexBinarySet::Make("EMPTY_DISKANN");
-        // }
-
         metadata->SetEmptyIndex(true);
-        BinarySet bs;
+        BinarySet bs = EmptyIndexBinarySet::Make(EMPTY_DISKANN);
         bs.Set(SERIAL_META_KEY, metadata->ToBinary());
         return bs;
     }

--- a/src/index/hnsw.cpp
+++ b/src/index/hnsw.cpp
@@ -57,6 +57,8 @@ const static uint32_t GENERATE_SEARCH_L = 400;
 const static uint32_t UPDATE_CHECK_SEARCH_L = 100;
 const static float GENERATE_OMEGA = 0.51;
 
+static const std::string EMPTY_HNSW = "EMPTY_HNSW";
+
 HNSW::HNSW(HnswParameters hnsw_params, const IndexCommonParam& index_common_param)
     : space_(std::move(hnsw_params.space)),
       use_static_(hnsw_params.use_static),
@@ -488,14 +490,8 @@ HNSW::serialize() const {
     auto metadata = std::make_shared<Metadata>();
 
     if (GetNumElements() == 0) {
-        // TODO(wxyu): remove this if condition
-        // if (not Options::Instance().new_version()) {
-        //     // return a special binaryset means empty
-        //     return EmptyIndexBinarySet::Make("EMPTY_HNSW");
-        // }
-
         metadata->SetEmptyIndex(true);
-        BinarySet bs;
+        auto bs = EmptyIndexBinarySet::Make(EMPTY_HNSW);
         bs.Set(SERIAL_META_KEY, metadata->ToBinary());
         return bs;
     }


### PR DESCRIPTION
cp #1394 to 0.16

## Summary by Sourcery

Ensure HNSW and DiskANN indexes serialize empty indexes using the dedicated EmptyIndexBinarySet markers for compatibility across versions.

Bug Fixes:
- Fix deserialization compatibility for empty HNSW indexes between 0.14 and 0.16 by marking them with a specific empty-index binary set.
- Fix deserialization compatibility for empty DiskANN indexes by using a dedicated empty-index binary set when the index is empty.