### PR TITLE
feat(python): add doc/test for pyvsag

### DIFF
--- a/.github/workflows/build_release_wheel.yml
+++ b/.github/workflows/build_release_wheel.yml
@@ -106,7 +106,7 @@ jobs:
         env:
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_BUILD: ${{ matrix.cibw-build-id }}
-          CIBW_TEST_COMMAND: "pip install numpy && ls -alF /project/ && python /project/examples/python/example_hnsw.py"
+          CIBW_TEST_COMMAND: "pip install numpy && ls -alF /project/ && python /project/tests/python/run_test.py"
 
       - uses: actions/upload-artifact@v5
         with:
@@ -141,7 +141,7 @@ jobs:
         env:
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_BUILD: "cp36-*"
-          CIBW_TEST_COMMAND: "pip install numpy && ls -alF /project/ && python /project/examples/python/example_hnsw.py"
+          CIBW_TEST_COMMAND: "pip install numpy && ls -alF /project/ && python /project/tests/python/run_test.py"
 
       - uses: actions/upload-artifact@v5
         with:

--- a/.github/workflows/python_build_and_test.yml
+++ b/.github/workflows/python_build_and_test.yml
@@ -1,0 +1,154 @@
+name: Python Build & Test
+
+on:
+  push:
+    branches: [ "main", "0.*" ]
+  pull_request:
+    branches: [ "main", "0.*" ]
+
+jobs:
+  build_python_wheel_x86:
+    name: Python Wheel Build X86
+    runs-on: ubuntu-22.04
+    concurrency:
+      group: python_build_x86-${{ github.event.pull_request.number }}
+      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+    steps:
+      - name: Free Disk Space
+        run: rm -rf /useless/hostedtoolcache
+    
+      - uses: actions/checkout@v4
+      - name: Prepare Env
+        run: sudo bash ./scripts/deps/install_deps_ubuntu.sh
+      - name: Load Cache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          max-size: "2G"
+          save: ${{ github.event_name != 'pull_request' }}
+          key: build-${{ hashFiles('./CMakeLists.txt') }}-${{ hashFiles('./.circleci/fresh_ci_cache.commit') }}
+      - name: Make Python Wheel
+        run: |
+            sudo apt update
+            sudo apt install -y python3-venv
+            export CMAKE_GENERATOR="Ninja"; make pyvsag
+      - name: Save Wheel
+        uses: actions/upload-artifact@v5
+        with:
+          path: ./wheelhouse
+          name: wheelhouse_x86-${{ github.run_id }}
+          compression-level: 1
+          retention-days: 1
+          overwrite: 'true'
+
+  build_python_wheel_aarch64:
+    name: Python Wheel Build Aarch64
+    runs-on: ubuntu-22.04-arm
+    concurrency:
+      group: python_build_aarch-${{ github.event.pull_request.number }}
+      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+    steps:
+      - name: Free Disk Space
+        run: rm -rf /opt/hostedtoolcache
+      - uses: actions/checkout@v4
+      - name: Prepare Env
+        run: sudo bash ./scripts/deps/install_deps_ubuntu.sh
+      - name: Load Cache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          max-size: "2G"
+          save: ${{ github.event_name != 'pull_request' }}
+          key: build-aarch-${{ hashFiles('./CMakeLists.txt') }}-${{ hashFiles('./.circleci/fresh_ci_cache.commit') }}
+      - name: Make Python Wheel
+        run: |
+            sudo apt update
+            sudo apt install -y python3-venv
+            export CMAKE_GENERATOR="Ninja"; make pyvsag
+      - name: Save Wheel
+        uses: actions/upload-artifact@v5
+        with:
+          path: ./wheelhouse
+          name: wheelhouse_aarch64-${{ github.run_id }}
+          compression-level: 1
+          retention-days: 1
+          overwrite: 'true'
+
+  test_python_x86:
+    name: Test Python X86
+    needs: build_python_wheel_x86
+    runs-on: ubuntu-22.04
+    concurrency:
+      group: test_python_x86-${{ github.event.pull_request.number }}
+      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+    steps:
+      - name: Free Disk Space
+        run: rm -rf /opt/hostedtoolcache
+      - uses: actions/checkout@v4
+    
+      - name: Prepare Env
+        run: sudo bash ./scripts/deps/install_deps_ubuntu.sh
+      - name: Download Test
+        uses: actions/download-artifact@v5
+        with:
+          name: wheelhouse_x86-${{ github.run_id }}
+          path: ./wheelhouse
+      - name: Install Python Wheel
+        run: |
+            pip3 uninstall pyvsag -y
+            pip3 install ./wheelhouse/*.whl
+            pip3 install numpy pyjson
+      - name: Run Python Test
+        run: |
+            cd ./tests/python/
+            python3 run_test.py
+
+  test_python_aarch64:
+    name: Test Python Aarch64
+    needs: build_python_wheel_aarch64
+    runs-on: ubuntu-22.04-arm
+    concurrency:
+      group: test_python_aarch64-${{ github.event.pull_request.number }}
+      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+    steps:
+      - name: Free Disk Space
+        run: rm -rf /opt/hostedtoolcache
+      - uses: actions/checkout@v4
+      - name: Prepare Env
+        run: sudo bash ./scripts/deps/install_deps_ubuntu.sh
+      - name: Download Test
+        uses: actions/download-artifact@v5
+        with:
+          name: wheelhouse_aarch64-${{ github.run_id }}
+          path: ./wheelhouse
+      - name: Install Python Wheel  
+        run: |
+          pip3 uninstall pyvsag -y
+          pip3 install ./wheelhouse/*.whl
+          pip3 install numpy pyjson
+      - name: Run Python Test
+        run: |
+            cd ./tests/python/
+            python3 run_test.py
+        
+  clean_up:
+    name: Clean Up
+    needs: [ test_python_x86, test_python_aarch64 ]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Create Empty File
+        run: touch /tmp/clean_up
+      - name: Overwrite Test Artifact X86
+        uses: actions/upload-artifact@v5
+        with:
+          path: /tmp/clean_up
+          name: wheelhouse_x86-${{ github.run_id }}
+          compression-level: 1
+          retention-days: 1
+          overwrite: 'true'
+      - name: Overwrite Test Artifact Aarch64
+        uses: actions/upload-artifact@v5
+        with:
+          path: /tmp/clean_up
+          name: wheelhouse_aarch64-${{ github.run_id }}
+          compression-level: 1
+          retention-days: 1
+          overwrite: 'true'

--- a/scripts/python/build_cpp_for_cibw.sh
+++ b/scripts/python/build_cpp_for_cibw.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -eo pipefail
 
+MKL_STATIC_LINK=ON
+if [ $1 == false ]; then
+    MKL_STATIC_LINK=OFF
+fi
+
 CMAKE_BUILD_DIR="./build-release/"
 PYTHON_EXECUTABLE="${PYTHON:-$(which python3 || which python)}"
 if [ ! -x "$PYTHON_EXECUTABLE" ]; then
@@ -32,7 +37,7 @@ cmake -S. -B$CMAKE_BUILD_DIR \
     -DPython3_EXECUTABLE="$PYTHON_EXECUTABLE" \
     -DPython3_ROOT_DIR="$(dirname $(dirname $PYTHON_EXECUTABLE))" \
     -DPython3_FIND_STRATEGY=LOCATION \
-    -DMKL_STATIC_LINK=OFF
+    -DMKL_STATIC_LINK=$MKL_STATIC_LINK
 
 echo "=== Building project ==="
 cmake --build $CMAKE_BUILD_DIR --parallel $(nproc || sysctl -n hw.ncpu)

--- a/scripts/python/local_build_wheel.sh
+++ b/scripts/python/local_build_wheel.sh
@@ -90,11 +90,12 @@ run_build() {
     echo "🛠️  Starting cibuildwheel... "
     CIBW_BUILD="${cibw_build_pattern}" \
     CIBW_ARCHS="${ARCH}" \
-    CIBW_TEST_COMMAND="pip install numpy && ls -alF /project/ && python /project/examples/python/example_hnsw.py" \
+    CIBW_TEST_COMMAND="pip install numpy && ls -alF /project/ && python /project/tests/python/run_test.py" \
     cibuildwheel --platform linux --output-dir wheelhouse python
   else 
     echo "🛠️  Starting build..."
-    bash scripts/python/build_cpp_for_cibw.sh
+    ENABLE_MKL_STATIC_LINK=$HAVE_DOCKER
+    bash scripts/python/build_cpp_for_cibw.sh $ENABLE_MKL_STATIC_LINK
     python -m build --wheel --outdir wheelhouse python
     echo "✅ Build complete. Starting test..."
     # Find the most recently created wheel

--- a/tests/python/run_test.py
+++ b/tests/python/run_test.py
@@ -1,4 +1,3 @@
-
 # Copyright 2024-present the vsag project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,15 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import sys
+from test_ivf import run_ivf_test
+from test_hnsw import run_hnsw_test
+from test_hgraph import run_hgraph_test
+from test_bruteforce import run_bruteforce_test
 
-_cur_file_dir = os.path.dirname(os.path.realpath(__file__))
-sys.path.append(_cur_file_dir)
 
-from _pyvsag import *
-from ._version import __version__
+def run():
+    run_ivf_test()
+    run_hnsw_test()
+    run_hgraph_test()
+    run_bruteforce_test()
 
-import _pyvsag
-__doc__ = _pyvsag.__doc__
 
+if __name__ == "__main__":
+    run()

--- a/tests/python/test_base.py
+++ b/tests/python/test_base.py
@@ -1,0 +1,97 @@
+# Copyright 2024-present the vsag project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from test_dataset import TestDataset
+import pyvsag
+import json
+import numpy as np
+import os
+
+
+class TestBase:
+    """Test base class for VSAG index tests"""
+
+    @staticmethod
+    def FactoryIndex(index_type: str, index_param: str) -> pyvsag.Index:
+        """Factory method to create index for testing"""
+        return pyvsag.Index(index_type, index_param)
+
+    @staticmethod
+    def BuildIndex(index: pyvsag.Index, dataset: TestDataset):
+        """Build index for testing"""
+        index.build(
+            dataset.base_vectors, dataset.ids, dataset.num_elements, dataset.dim
+        )
+
+    @staticmethod
+    def SaveIndex(index: pyvsag.Index, file_path: str):
+        """Serialize index for testing"""
+        index.save(file_path)
+
+    @staticmethod
+    def LoadIndex(index: pyvsag.Index, file_path: str):
+        """Load index for testing"""
+        index.load(file_path)
+
+    @staticmethod
+    def CalRecall(results: np.ndarray, gt_ids: np.ndarray, topk: int = 10) -> float:
+        """Calculate recall for testing"""
+        # too many indices for array: array is 1-dimensional, but 2 were indexed
+        recall = np.isin(results[:topk], gt_ids[:topk]).sum(axis=0)
+        return recall / topk
+
+    @staticmethod
+    def GenerateRandomFilePath() -> str:
+        """Generate empty file path for testing"""
+        random_id = np.random.randint(0, 1000000)
+        filename = f"test_index_{random_id}.vsag"
+        while os.path.exists(filename):
+            random_id = np.random.randint(0, 1000000)
+            filename = f"test_index_{random_id}.vsag"
+        return filename
+
+    @staticmethod
+    def TestKnnSearch(
+        index: pyvsag.Index,
+        dataset: TestDataset,
+        search_param: str,
+        topk: int = 10,
+        expect_recall: float = 0.9,
+    ):
+        """Test knn_search method for testing"""
+        query_count = dataset.query_vectors_count
+        query_vectors = dataset.query_vectors.reshape(query_count, dataset.dim)
+        recall = 0
+        for i in range(query_count):
+            query = query_vectors[i]
+            ids, _ = index.knn_search(vector=query, k=topk, parameters=search_param)
+            assert len(ids) == topk
+            recall += TestBase.CalRecall(ids, dataset.gt_ids, topk)
+        print(f"recall: {recall / query_count}")
+        assert recall >= expect_recall * query_count
+
+
+if __name__ == "__main__":
+    dataset = TestDataset()
+    index_params = json.dumps(
+        {
+            "dtype": "float32",
+            "metric_type": "l2",
+            "dim": 128,
+            "hnsw": {"max_degree": 16, "ef_construction": 100},
+        }
+    )
+    index = TestBase.FactoryIndex("hnsw", index_params)
+    TestBase.BuildIndex(index, dataset)
+    TestBase.TestKnnSearch(index, dataset, json.dumps({"hnsw": {"ef_search": 100}}))

--- a/tests/python/test_bruteforce.py
+++ b/tests/python/test_bruteforce.py
@@ -1,0 +1,105 @@
+# Copyright 2024-present the vsag project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from test_base import TestBase
+from test_dataset import TestDataset
+import json
+import os
+import pyvsag
+
+
+class TestBruteforce(TestBase):
+    """Test Bruteforce index"""
+
+    type_name: str = "brute_force"
+
+    def __init__(
+        self,
+        dim: int = 128,
+        num_vectors: int = 1000,
+        metric: str = "l2",
+        expect_recall: float = 0.9,
+        quantization_type: str = "sq8",
+    ):
+        self.dim = dim
+        self.num_vectors = num_vectors
+        self.metric = metric
+        self.dataset = TestDataset(dim=dim, num_vectors=num_vectors, metric=metric)
+        qs = quantization_type.split(",")
+        self.base_quantization_type = qs[0]
+        self.precise_quantization_type = "fp32"
+        if len(qs) > 1:
+            self.precise_quantization_type = qs[1]
+            self.use_reorder = True
+        else:
+            self.use_reorder = False
+
+        self.index_params = json.dumps(
+            {
+                "dtype": "float32",
+                "metric_type": self.metric,
+                "dim": self.dim,
+                "index_param": {
+                    "base_quantization_type": self.base_quantization_type,
+                    "precise_quantization_type": self.precise_quantization_type,
+                },
+            }
+        )
+
+    def init_index(self) -> pyvsag.Index:
+        """Initialize Bruteforce index"""
+        return TestBase.FactoryIndex(self.type_name, self.index_params)
+
+    def general_test_search(self):
+        """Test search index"""
+        search_params = json.dumps({})
+        TestBase.TestKnnSearch(self.index, self.dataset, search_params)
+
+    def test_build(self):
+        """Test build index"""
+        self.index = self.init_index()
+        TestBase.BuildIndex(self.index, self.dataset)
+        self.general_test_search()
+
+    def test_load_save(self):
+        """Test load and save index"""
+        filename = TestBase.GenerateRandomFilePath()
+        TestBase.SaveIndex(self.index, filename)
+        self.index = self.init_index()
+        TestBase.LoadIndex(self.index, filename)
+        os.remove(filename)
+        self.general_test_search()
+
+
+def run_bruteforce_test():
+    """Run Bruteforce index tests"""
+    metric_types = ["ip"]
+    dims = [128, 256, 1024]
+    quantizer_recalls = [
+        ("sq8", 0.9),
+        ("fp16", 0.98),
+        ("fp32", 0.9999),
+    ]
+    for metric in metric_types:
+        for dim in dims:
+            for qt, recall in quantizer_recalls:
+                test_brute_force = TestBruteforce(
+                    dim=dim, metric=metric, expect_recall=recall, quantization_type=qt
+                )
+                test_brute_force.test_build()
+                test_brute_force.test_load_save()
+
+
+if __name__ == "__main__":
+    run_bruteforce_test()

--- a/tests/python/test_dataset.py
+++ b/tests/python/test_dataset.py
@@ -1,0 +1,84 @@
+# Copyright 2024-present the vsag project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+
+
+class TestDataset:
+    """Test dataset class for VSAG index tests"""
+
+    def __init__(self, num_vectors=200, dim=128, seed=42, topk=10, metric="l2"):
+        self.num_vectors = num_vectors
+        self.dim = dim
+        self.seed = seed
+        self.query_vectors_count = 10
+        self.base_vectors, self.query_vectors, self.ids, self.num_elements, self.dim = (
+            TestDataset.create_test_dataset(num_vectors, dim, seed)
+        )
+        self.gt_ids, self.gt_dists = self.cal_gt_knn_results(
+            self.base_vectors, self.query_vectors, k=topk, metric=metric
+        )
+
+    @staticmethod
+    def generate_random_vectors(num_vectors, dim, seed=49):
+        """Generate random float32 vectors for testing"""
+        np.random.seed(seed)
+        return np.random.randn(num_vectors * dim).astype(np.float32)
+
+    @staticmethod
+    def generate_sequential_ids(num_vectors):
+        """Generate sequential IDs for testing"""
+        return np.arange(num_vectors, dtype=np.int64)
+
+    @staticmethod
+    def create_test_dataset(num_vectors=100, dim=128, seed=49):
+        """Create a standard test dataset"""
+        vectors = TestDataset.generate_random_vectors(num_vectors, dim, seed)
+        ids = TestDataset.generate_sequential_ids(num_vectors)
+        query_vectors = TestDataset.generate_random_vectors(10, dim, seed * 2)
+        return vectors, query_vectors, ids, num_vectors, dim
+
+    def cal_gt_knn_results(
+        self, vectors: np.ndarray, query_vectors: np.ndarray, k=10, metric="l2"
+    ):
+        """Calculate ground truth KNN results for verification"""
+        new_vectors = vectors.reshape(-1, self.dim)
+        new_query_vectors = query_vectors.reshape(-1, self.dim)
+        result_ids = []
+        result_dists = []
+        for query_vector in new_query_vectors:
+            if metric == "l2":
+                dists = np.linalg.norm(new_vectors - query_vector, axis=1)
+            elif metric == "ip":
+                dists = -np.dot(new_vectors, query_vector)
+            elif metric == "cosine":
+                dists = 1 - (
+                    np.dot(new_vectors, query_vector)
+                    / (
+                        np.linalg.norm(new_vectors, axis=1)
+                        * np.linalg.norm(query_vector)
+                    )
+                )
+            else:
+                raise ValueError(f"Unsupported metric: {metric}")
+            sorted_indices = np.argsort(dists)
+            result_ids.append(sorted_indices[:k])
+            result_dists.append(dists[sorted_indices[:k]])
+        return np.array(result_ids), np.array(result_dists)
+
+
+if __name__ == "__main__":
+    test_dataset = TestDataset(num_vectors=1000, dim=128, seed=49, metric="ip")
+    print(test_dataset.gt_ids)
+    print(test_dataset.gt_dists)

--- a/tests/python/test_hgraph.py
+++ b/tests/python/test_hgraph.py
@@ -1,0 +1,113 @@
+# Copyright 2024-present the vsag project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from test_base import TestBase
+from test_dataset import TestDataset
+import json
+import os
+import pyvsag
+
+
+class TestHGraph(TestBase):
+    """Test HGraph index"""
+
+    type_name: str = "hgraph"
+
+    def __init__(
+        self,
+        dim: int = 128,
+        num_vectors: int = 1000,
+        metric: str = "l2",
+        expect_recall: float = 0.9,
+        quantization_type: str = "sq8",
+    ):
+        self.dim = dim
+        self.num_vectors = num_vectors
+        self.metric = metric
+        self.dataset = TestDataset(dim=dim, num_vectors=num_vectors, metric=metric)
+        self.max_degree = int(dim / 4)
+        self.ef_construction = max(200, self.max_degree)
+        qs = quantization_type.split(",")
+        self.base_quantization_type = qs[0]
+        self.precise_quantization_type = "fp32"
+        if len(qs) > 1:
+            self.precise_quantization_type = qs[1]
+            self.use_reorder = True
+        else:
+            self.use_reorder = False
+
+        self.index_params = json.dumps(
+            {
+                "dtype": "float32",
+                "metric_type": self.metric,
+                "dim": self.dim,
+                "index_param": {
+                    "max_degree": self.max_degree,
+                    "ef_construction": self.ef_construction,
+                    "base_quantization_type": self.base_quantization_type,
+                    "precise_quantization_type": self.precise_quantization_type,
+                    "use_reorder": self.use_reorder,
+                },
+            }
+        )
+
+    def init_index(self) -> pyvsag.Index:
+        """Initialize HGraph index"""
+
+        return TestBase.FactoryIndex(self.type_name, self.index_params)
+
+    def general_test_search(self):
+        """Test search index"""
+        search_params = json.dumps({"hgraph": {"ef_search": 100}})
+        TestBase.TestKnnSearch(self.index, self.dataset, search_params)
+
+    def test_build(self):
+        """Test build index"""
+        self.index = self.init_index()
+        TestBase.BuildIndex(self.index, self.dataset)
+        self.general_test_search()
+
+    def test_load_save(self):
+        """Test load and save index"""
+        filename = TestBase.GenerateRandomFilePath()
+        TestBase.SaveIndex(self.index, filename)
+        self.index = self.init_index()
+        TestBase.LoadIndex(self.index, filename)
+        os.remove(filename)
+        self.general_test_search()
+
+
+def run_hgraph_test():
+    """Run HNSW index tests"""
+    metric_types = ["ip"]
+    dims = [128, 256, 1024]
+    quantizer_recalls = [
+        ("sq8", 0.9),
+        ("fp16", 0.92),
+        ("fp32", 0.93),
+        ("sq8,fp16", 0.92),
+        ("sq8_uniform,fp32", 0.9),
+    ]
+    for metric in metric_types:
+        for dim in dims:
+            for qt, recall in quantizer_recalls:
+                test_hgraph = TestHGraph(
+                    dim=dim, metric=metric, expect_recall=recall, quantization_type=qt
+                )
+                test_hgraph.test_build()
+                test_hgraph.test_load_save()
+
+
+if __name__ == "__main__":
+    run_hgraph_test()

--- a/tests/python/test_hnsw.py
+++ b/tests/python/test_hnsw.py
@@ -1,0 +1,90 @@
+# Copyright 2024-present the vsag project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from test_base import TestBase
+from test_dataset import TestDataset
+import json
+import os
+import pyvsag
+
+
+class TestHNSW(TestBase):
+    """Test HNSW index"""
+
+    type_name: str = "hnsw"
+
+    def __init__(
+        self,
+        dim: int = 128,
+        num_vectors: int = 1000,
+        metric: str = "l2",
+        expect_recall: float = 0.9,
+    ):
+        self.dim = dim
+        self.num_vectors = num_vectors
+        self.metric = metric
+        self.dataset = TestDataset(dim=dim, num_vectors=num_vectors, metric=metric)
+        self.max_degree = int(dim / 4)
+        self.ef_construction = max(200, self.max_degree)
+        self.index_params = json.dumps(
+            {
+                "dtype": "float32",
+                "metric_type": self.metric,
+                "dim": self.dim,
+                "hnsw": {
+                    "max_degree": self.max_degree,
+                    "ef_construction": self.ef_construction,
+                },
+            }
+        )
+
+    def init_index(self) -> pyvsag.Index:
+        """Initialize HNSW index"""
+
+        return TestBase.FactoryIndex(self.type_name, self.index_params)
+
+    def general_test_search(self):
+        """Test search index"""
+        search_params = json.dumps({"hnsw": {"ef_search": 40}})
+        TestBase.TestKnnSearch(self.index, self.dataset, search_params)
+
+    def test_build(self):
+        """Test build index"""
+        self.index = self.init_index()
+        TestBase.BuildIndex(self.index, self.dataset)
+        self.general_test_search()
+
+    def test_load_save(self):
+        """Test load and save index"""
+        filename = TestBase.GenerateRandomFilePath()
+        TestBase.SaveIndex(self.index, filename)
+        self.index = self.init_index()
+        TestBase.LoadIndex(self.index, filename)
+        os.remove(filename)
+        self.general_test_search()
+
+
+def run_hnsw_test():
+    """Run HNSW index tests"""
+    metric_types = ["ip"]
+    dims = [128, 256, 1024]
+    for metric in metric_types:
+        for dim in dims:
+            test_hnsw = TestHNSW(dim=dim, metric=metric)
+            test_hnsw.test_build()
+            test_hnsw.test_load_save()
+
+
+if __name__ == "__main__":
+    run_hnsw_test()

--- a/tests/python/test_ivf.py
+++ b/tests/python/test_ivf.py
@@ -1,0 +1,112 @@
+# Copyright 2024-present the vsag project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from test_base import TestBase
+from test_dataset import TestDataset
+import json
+import os
+import pyvsag
+
+class TestIVF(TestBase):
+    """Test IVF index"""
+
+    type_name: str = "ivf"
+
+    def __init__(
+        self,
+        dim: int = 128,
+        num_vectors: int = 1000,
+        metric: str = "l2",
+        expect_recall: float = 0.9,
+        quantization_type: str = "sq8",
+    ):
+        self.dim = dim
+        self.num_vectors = num_vectors
+        self.metric = metric
+        self.dataset = TestDataset(dim=dim, num_vectors=num_vectors, metric=metric)
+        self.buckets_count = 50
+        qs = quantization_type.split(",")
+        self.base_quantization_type = qs[0]
+        self.precise_quantization_type = "fp32"
+        if len(qs) > 1:
+            self.precise_quantization_type = qs[1]
+            self.use_reorder = True
+        else:
+            self.use_reorder = False
+
+        self.index_params = json.dumps(
+            {
+                "dtype": "float32",
+                "metric_type": self.metric,
+                "dim": self.dim,
+                "index_param": {
+                    "buckets_count": 50,
+                    "partition_strategy_type": "ivf",
+                    "ivf_train_type": "kmeans",
+                    "base_quantization_type": self.base_quantization_type,
+                    "precise_quantization_type": self.precise_quantization_type,
+                    "use_reorder": self.use_reorder,
+                },
+            }
+        )
+
+    def init_index(self) -> pyvsag.Index:
+        """Initialize IVF index"""
+
+        return TestBase.FactoryIndex(self.type_name, self.index_params)
+
+    def general_test_search(self):
+        """Test search index"""
+        search_params = json.dumps({"ivf": {"scan_buckets_count": 50}})
+        TestBase.TestKnnSearch(self.index, self.dataset, search_params)
+
+    def test_build(self):
+        """Test build index"""
+        self.index = self.init_index()
+        TestBase.BuildIndex(self.index, self.dataset)
+        self.general_test_search()
+
+    def test_load_save(self):
+        """Test load and save index"""
+        filename = TestBase.GenerateRandomFilePath()
+        TestBase.SaveIndex(self.index, filename)
+        self.index = self.init_index()
+        TestBase.LoadIndex(self.index, filename)
+        os.remove(filename)
+        self.general_test_search()
+
+
+def run_ivf_test():
+    """Run HNSW index tests"""
+    metric_types = ["ip"]
+    dims = [128, 256, 1024]
+    quantizer_recalls = [
+        ("sq8", 0.9),
+        ("fp16", 0.92),
+        ("fp32", 0.93),
+        ("sq8,fp16", 0.92),
+        ("sq8_uniform,fp32", 0.9),
+    ]
+    for metric in metric_types:
+        for dim in dims:
+            for qt, recall in quantizer_recalls:
+                test_ivf = TestIVF(
+                    dim=dim, metric=metric, expect_recall=recall, quantization_type=qt
+                )
+                test_ivf.test_build()
+                test_ivf.test_load_save()
+
+
+if __name__ == "__main__":
+    run_ivf_test()


### PR DESCRIPTION
closed: #1412 

- add pydoc for pyvsag's api
- add some pytest for pyvsag
- enable pytest on CI

## Summary by Sourcery

Add Python binding documentation and tests for the VSAG index API and integrate Python wheel build-and-test into CI.

New Features:
- Expose rich docstrings for the pyvsag module and Index class methods to describe vector indexing and search behavior from Python.
- Introduce a Python test suite covering multiple index types (HNSW, HGraph, IVF, and brute-force) including build, search, and save/load flows.

Enhancements:
- Propagate the compiled module docstring to the pyvsag package-level __doc__ for better Python help/introspection support.

CI:
- Add a GitHub Actions workflow to build pyvsag wheels for x86 and AArch64, run the Python tests against the built wheels, and clean up test artifacts.

Tests:
- Add reusable Python test utilities and datasets plus index-specific tests to validate correctness and recall for different VSAG index types via the pyvsag API.