### PR TITLE
feat(hgraph): support deduplication under different quantization

### DIFF
--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -1049,6 +1049,9 @@ HGraph::graph_add_one(const void* data, int level, InnerIdType inner_id) {
 
     param.ef = this->ef_construct_;
     param.topk = static_cast<int64_t>(ef_construct_);
+    if (this->label_table_->CompressDuplicateData()) {
+        param.query_id = inner_id;
+    }
 
     if (bottom_graph_->TotalCount() != 0) {
         result = search_one_graph(data,

--- a/src/datacell/flatten_datacell.h
+++ b/src/datacell/flatten_datacell.h
@@ -119,6 +119,9 @@ public:
     [[nodiscard]] const uint8_t*
     GetCodesById(InnerIdType id, bool& need_release) const override;
 
+    void
+    Release(const uint8_t* data) const override;
+
     [[nodiscard]] bool
     InMemory() const override;
 
@@ -171,6 +174,13 @@ private:
         return computer;
     }
 };
+
+template <typename QuantTmpl, typename IOTmpl>
+void
+FlattenDataCell<QuantTmpl, IOTmpl>::Release(const uint8_t* data) const {
+    this->io_->Release(data);
+}
+
 template <typename QuantTmpl, typename IOTmpl>
 bool
 FlattenDataCell<QuantTmpl, IOTmpl>::HoldMolds() const {

--- a/src/datacell/flatten_interface.h
+++ b/src/datacell/flatten_interface.h
@@ -69,6 +69,21 @@ public:
     virtual float
     ComputePairVectors(InnerIdType id1, InnerIdType id2) = 0;
 
+    bool
+    CompareVectors(InnerIdType id1, InnerIdType id2) {
+        bool release1, release2;
+        const auto* codes1 = this->GetCodesById(id1, release1);
+        const auto* codes2 = this->GetCodesById(id2, release2);
+        bool result = (std::memcmp(codes1, codes2, this->code_size_) == 0);
+        if (release1) {
+            this->Release(codes1);
+        }
+        if (release2) {
+            this->Release(codes2);
+        }
+        return result;
+    }
+
     virtual void
     Prefetch(InnerIdType id) = 0;
 
@@ -114,6 +129,9 @@ public:
 
     [[nodiscard]] virtual const uint8_t*
     GetCodesById(InnerIdType id, bool& need_release) const = 0;
+
+    virtual void
+    Release(const uint8_t* data) const = 0;
 
     virtual bool
     GetCodesById(InnerIdType id, uint8_t* codes) const = 0;

--- a/src/datacell/sparse_vector_datacell.h
+++ b/src/datacell/sparse_vector_datacell.h
@@ -105,6 +105,9 @@ public:
     [[nodiscard]] const uint8_t*
     GetCodesById(InnerIdType id, bool& need_release) const override;
 
+    void
+    Release(const uint8_t* data) const override;
+
     [[nodiscard]] bool
     InMemory() const override;
 

--- a/src/datacell/sparse_vector_datacell.inl
+++ b/src/datacell/sparse_vector_datacell.inl
@@ -126,6 +126,12 @@ SparseVectorDataCell<QuantTmpl, IOTmpl>::GetCodesById(InnerIdType id, bool& need
 }
 
 template <typename QuantTmpl, typename IOTmpl>
+void
+SparseVectorDataCell<QuantTmpl, IOTmpl>::Release(const uint8_t* data) const {
+    io_->Release(data);
+}
+
+template <typename QuantTmpl, typename IOTmpl>
 MetricType
 SparseVectorDataCell<QuantTmpl, IOTmpl>::GetMetricType() {
     return this->quantizer_->Metric();

--- a/src/impl/inner_search_param.h
+++ b/src/impl/inner_search_param.h
@@ -56,7 +56,12 @@ public:
     float first_order_scan_ratio{1.0F};
     Allocator* search_alloc{nullptr};
     std::vector<ExecutorPtr> executors;
+
+    // deal with duplicate ids
     mutable int64_t duplicate_id{-1};
+    int64_t query_id{-1};
+
+    // use in search process with duplicate ids
     bool consider_duplicate{false};
 
     // time record

--- a/src/impl/searcher/basic_searcher.cpp
+++ b/src/impl/searcher/basic_searcher.cpp
@@ -380,18 +380,16 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
 
     // set duplicate id for query vector
     if (inner_search_param.query_id != -1) {
-        auto data = top_candidates->GetData();
-        auto min_distance = std::numeric_limits<float>::max();
-        auto min_index = -1;
-        for (uint32_t i = 0; i < top_candidates->Size(); ++i) {
+        const auto* data = top_candidates->GetData();
+        auto min_distance = data[0].first;
+        auto min_index = data[0].second;
+        for (uint32_t i = 1; i < top_candidates->Size(); ++i) {
             if (data[i].first < min_distance) {
                 min_distance = data[i].first;
                 min_index = data[i].second;
             }
         }
-        auto quantization_min_distance =
-            flatten->ComputePairVectors(min_index, inner_search_param.query_id);
-        if (quantization_min_distance <= THRESHOLD_ERROR) {
+        if (flatten->CompareVectors(min_index, inner_search_param.query_id)) {
             inner_search_param.duplicate_id = min_index;
         }
     }

--- a/src/impl/searcher/basic_searcher.cpp
+++ b/src/impl/searcher/basic_searcher.cpp
@@ -195,9 +195,6 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
 
         for (uint32_t i = 0; i < count_no_visited; i++) {
             dist = line_dists[i];
-            if (dist < THRESHOLD_ERROR) {
-                inner_search_param.duplicate_id = to_be_visited_id[i];
-            }
             if (top_candidates->Size() < ef || lower_bound > dist ||
                 (mode == RANGE_SEARCH && dist <= inner_search_param.radius)) {
                 if (!iter_ctx->CheckPoint(to_be_visited_id[i])) {
@@ -296,9 +293,6 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
             top_candidates->Pop();
         }
     }
-    if (dist < THRESHOLD_ERROR) {
-        inner_search_param.duplicate_id = ep;
-    }
     candidate_set->Push(-dist, ep);
     vl->Set(ep);
 
@@ -338,9 +332,6 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
 
         for (uint32_t i = 0; i < count_no_visited; i++) {
             dist = line_dists[i];
-            if (dist < THRESHOLD_ERROR) {
-                inner_search_param.duplicate_id = to_be_visited_id[i];
-            }
             if (top_candidates->Size() < ef || lower_bound > dist ||
                 (mode == RANGE_SEARCH && dist <= inner_search_param.radius)) {
                 candidate_set->Push(-dist, to_be_visited_id[i]);
@@ -384,6 +375,24 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
         while (not top_candidates->Empty() &&
                top_candidates->Top().first > inner_search_param.radius + THRESHOLD_ERROR) {
             top_candidates->Pop();
+        }
+    }
+
+    // set duplicate id for query vector
+    if (inner_search_param.query_id != -1) {
+        auto data = top_candidates->GetData();
+        auto min_distance = std::numeric_limits<float>::max();
+        auto min_index = -1;
+        for (uint32_t i = 0; i < top_candidates->Size(); ++i) {
+            if (data[i].first < min_distance) {
+                min_distance = data[i].first;
+                min_index = data[i].second;
+            }
+        }
+        auto quantization_min_distance =
+            flatten->ComputePairVectors(min_index, inner_search_param.query_id);
+        if (quantization_min_distance <= THRESHOLD_ERROR) {
+            inner_search_param.duplicate_id = min_index;
         }
     }
 

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -1176,18 +1176,13 @@ TestHGraphDuplicate(const fixtures::HGraphTestIndexPtr& test_index,
     auto search_param = fmt::format(fixtures::search_param_tmp, 200, false);
     std::unordered_map<std::string, float> ratios{
         {"prefix", 0.9}, {"suffix", 0.9}, {"middle", 1.0}};
-    const std::vector<std::pair<std::string, float>> all_test_cases =
-        fixtures::RandomSelect<std::pair<std::string, float>>(
-            {
-                {"fp32", 0.99},
-                {"rabitq,fp32", 0.3},
-                {"pq,fp32", 0.95},
-                {"sq8_uniform,fp32", 0.98},
-            },
-            2);
     for (auto metric_type : resource->metric_types) {
         for (auto dim : resource->dims) {
-            for (auto& [base_quantization_str, recall] : all_test_cases) {
+            for (auto& [base_quantization_str, recall] : resource->test_cases) {
+                if (base_quantization_str.find("bf16") != std::string::npos and
+                    (metric_type == "ip" or metric_type == "cosine")) {
+                    continue;
+                }
                 INFO(
                     fmt::format("metric_type: {}, dim: {}, base_quantization_str: {}, recall: {}, "
                                 "duplicate_pos: {}",

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -1179,10 +1179,6 @@ TestHGraphDuplicate(const fixtures::HGraphTestIndexPtr& test_index,
     for (auto metric_type : resource->metric_types) {
         for (auto dim : resource->dims) {
             for (auto& [base_quantization_str, recall] : resource->test_cases) {
-                if (base_quantization_str.find("bf16") != std::string::npos and
-                    (metric_type == "ip" or metric_type == "cosine")) {
-                    continue;
-                }
                 INFO(
                     fmt::format("metric_type: {}, dim: {}, base_quantization_str: {}, recall: {}, "
                                 "duplicate_pos: {}",

--- a/tests/test_pyramid.cpp
+++ b/tests/test_pyramid.cpp
@@ -316,7 +316,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex, "Pyramid OverTime Test"
         auto dataset = pool.GetDatasetAndCreate(dim, base_count, metric_type, /*with_path=*/true);
         TestContinueAdd(index, dataset, true);
         TestSearchOvertime(index, dataset, search_param);
-        auto timeout_search_param = GeneratePyramidSearchParametersString(100, 0.1);
+        auto timeout_search_param = GeneratePyramidSearchParametersString(100, 0.0F);
 
         auto query = vsag::Dataset::Make();
         query->NumElements(1)


### PR DESCRIPTION
## Summary by Sourcery

Refine duplicate vector handling in HGraph search to correctly detect duplicates when using different quantization schemes and align tests with the new behavior.

Enhancements:
- Change duplicate-id detection to compare the query against the nearest candidate via quantized distance instead of relying on raw distance thresholds during traversal.
- Extend inner search parameters to carry the query id when duplicate compression is enabled so search can resolve duplicates consistently across quantizations.

Tests:
- Update HGraph duplicate tests to use shared quantization test cases and skip unsupported bf16 configurations for inner-product and cosine metrics.