### PR TITLE
fix(test): fix compile of memleak in clang

### DIFF
--- a/.github/workflows/asan_build_and_test.yml
+++ b/.github/workflows/asan_build_and_test.yml
@@ -33,6 +33,7 @@ jobs:
       - name: Clean
         run: |
           find ./build -type f -name "*.o" -exec rm -f {} +
+          find ./build -type f -name "*.cpp" -exec rm -f {} +
           rm -rf ./build/tools
       - name: Save Test
         uses: actions/upload-artifact@v5


### PR DESCRIPTION

close: #1407 
## Summary by Sourcery

Fix memleak test configuration and ASAN workflow cleanup to restore successful compilation and execution.

Bug Fixes:
- Adjust memleak test index setup to generate build parameters dynamically, resolving compilation issues with formatted JSON strings.

Enhancements:
- Simplify memleak test index configuration by introducing a helper to generate index build parameters from base quantization types.

CI:
- Extend ASAN workflow cleanup to remove generated .cpp files from the build directory before saving test artifacts.