### PR TITLE
feat(hgraph): ensure that the removing is thread-safe. (#1269)

### DIFF
--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -1096,6 +1096,8 @@ HGraph::InitFeatures() {
     // concurrency
     this->index_feature_list_->SetFeature(IndexFeature::SUPPORT_SEARCH_CONCURRENT);
     this->index_feature_list_->SetFeature(IndexFeature::SUPPORT_ADD_CONCURRENT);
+    this->index_feature_list_->SetFeature(IndexFeature::SUPPORT_ADD_SEARCH_CONCURRENT);
+    this->index_feature_list_->SetFeature(IndexFeature::SUPPORT_ADD_SEARCH_DELETE_CONCURRENT);
     // serialize
     this->index_feature_list_->SetFeatures({
         IndexFeature::SUPPORT_DESERIALIZE_BINARY_SET,
@@ -1608,8 +1610,11 @@ HGraph::GetCodeByInnerId(InnerIdType inner_id, uint8_t* data) const {
 
 bool
 HGraph::Remove(int64_t id) {
-    // TODO(inbao): support thread safe remove
-    auto inner_id = this->label_table_->GetIdByLabel(id);
+    InnerIdType inner_id;
+    {
+        std::shared_lock<std::shared_mutex> lock(this->label_lookup_mutex_);
+        inner_id = this->label_table_->GetIdByLabel(id);
+    }
     if (inner_id == this->entry_point_id_) {
         bool find_new_ep = false;
         while (not route_graphs_.empty()) {
@@ -1630,12 +1635,18 @@ HGraph::Remove(int64_t id) {
             route_graphs_.pop_back();
         }
     }
-    for (int level = static_cast<int>(route_graphs_.size()) - 1; level >= 0; --level) {
-        this->route_graphs_[level]->DeleteNeighborsById(inner_id);
+    {
+        {
+            std::scoped_lock<std::shared_mutex> wlock(this->global_mutex_);
+            for (int level = static_cast<int>(route_graphs_.size()) - 1; level >= 0; --level) {
+                this->route_graphs_[level]->DeleteNeighborsById(inner_id);
+            }
+            this->bottom_graph_->DeleteNeighborsById(inner_id);
+        }
+        std::scoped_lock label_lock(this->label_lookup_mutex_);
+        this->label_table_->Remove(id);
+        delete_count_++;
     }
-    this->bottom_graph_->DeleteNeighborsById(inner_id);
-    this->label_table_->Remove(id);
-    delete_count_++;
     return true;
 }
 
@@ -1836,6 +1847,7 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
         (1 <= params.ef_search) and (params.ef_search <= ef_search_threshold),
         fmt::format("ef_search({}) must in range[1, {}]", params.ef_search, ef_search_threshold));
 
+    std::shared_lock shared_lock(this->global_mutex_);
     // check k
     CHECK_ARGUMENT(k > 0, fmt::format("k({}) must be greater than 0", k));
     k = std::min(k, GetNumElements());
@@ -1945,7 +1957,7 @@ std::string
 HGraph::GetStats() const {
     JsonType stats;
     int64_t topk = DEFAULT_TOPK;
-    uint64_t sample_size = std::min(QUERY_SAMPLE_SIZE, this->total_count_);
+    uint64_t sample_size = std::min(QUERY_SAMPLE_SIZE, this->total_count_.load());
     Vector<float> sample_base_datas(dim_ * sample_size, 0.0F, allocator_);
     if (this->total_count_ == 0) {
         stats["total_count"].SetInt(0);

--- a/src/algorithm/hgraph.h
+++ b/src/algorithm/hgraph.h
@@ -347,7 +347,7 @@ private:
     uint64_t ef_construct_{400};
     float alpha_{1.0};
 
-    uint64_t total_count_{0};
+    std::atomic<uint64_t> total_count_{0};
 
     std::shared_ptr<VisitedListPool> pool_{nullptr};
 

--- a/tests/test_brute_force.cpp
+++ b/tests/test_brute_force.cpp
@@ -252,6 +252,11 @@ TestBruteForceBuild(const fixtures::BruteForceResourcePtr& resource) {
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
 
+    std::vector<int32_t> search_threads_counts{1, 3};
+    constexpr static const char* search_param_tmp2 = R"(
+    {{
+        "parallelism": {}
+    }})";
     for (const auto& metric_type : resource->metric_types) {
         for (auto dim : resource->dims) {
             for (const auto& [base_quantization_str, recall] : resource->test_cases) {

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -1363,6 +1363,59 @@ TEST_CASE("(Daily) HGraph Concurrent Add", "[ft][hgraph][daily][concurrent]") {
 }
 
 static void
+TestHGraphConcurrentAddSearchRemove(const fixtures::HGraphTestIndexPtr& test_index,
+                                    const fixtures::HGraphResourcePtr& resource) {
+    using namespace fixtures;
+    auto origin_size = vsag::Options::Instance().block_size_limit();
+    auto size = GENERATE(1024 * 1024 * 2);
+    auto search_param = fmt::format(fixtures::search_param_tmp, 200, false);
+
+    for (auto metric_type : resource->metric_types) {
+        for (auto dim : resource->dims) {
+            for (auto& [base_quantization_str, recall] : resource->test_cases) {
+                INFO(fmt::format("metric_type: {}, dim: {}, base_quantization_str: {}, recall: {}",
+                                 metric_type,
+                                 dim,
+                                 base_quantization_str,
+                                 recall));
+                if (HGraphTestIndex::IsRaBitQ(base_quantization_str) &&
+                    dim < fixtures::RABITQ_MIN_RACALL_DIM) {
+                    continue;  // Skip invalid RaBitQ configurations
+                }
+
+                // Set block size limit for current test iteration
+                vsag::Options::Instance().set_block_size_limit(size);
+
+                // Generate index parameters with attribute support enabled
+                HGraphTestIndex::HGraphBuildParam build_param(
+                    metric_type, dim, base_quantization_str);
+                build_param.support_remove = true;
+                auto param = HGraphTestIndex::GenerateHGraphBuildParametersString(build_param);
+                auto index = TestIndex::TestFactory(test_index->name, param, true);
+                auto dataset = HGraphTestIndex::pool.GetDatasetAndCreate(
+                    dim, resource->base_count, metric_type);
+                // Execute build test
+                TestIndex::TestConcurrentAddSearchRemove(index, dataset, search_param, true);
+                // Restore original block size limit
+                vsag::Options::Instance().set_block_size_limit(origin_size);
+            }
+        }
+    }
+}
+
+TEST_CASE("(PR) HGraph Concurrent Add Search Remove", "[ft][hgraph][pr][concurrent]") {
+    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
+    auto resource = test_index->GetResource(true);
+    TestHGraphConcurrentAddSearchRemove(test_index, resource);
+}
+
+TEST_CASE("(Daily) HGraph Concurrent Add Search Remove", "[ft][hgraph][daily][concurrent]") {
+    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
+    auto resource = test_index->GetResource(false);
+    TestHGraphConcurrentAddSearchRemove(test_index, resource);
+}
+
+static void
 TestHGraphSerialize(const fixtures::HGraphTestIndexPtr& test_index,
                     const fixtures::HGraphResourcePtr& resource) {
     using namespace fixtures;

--- a/tests/test_index.cpp
+++ b/tests/test_index.cpp
@@ -2408,4 +2408,54 @@ void
 TestIndex::TestGetDataByIdWithFlag(const IndexPtr& index, const TestDatasetPtr& dataset) {
 }
 
+void
+TestIndex::TestConcurrentAddSearchRemove(const TestIndex::IndexPtr& index,
+                                         const TestDatasetPtr& dataset,
+                                         const std::string& search_param,
+                                         bool expected_success) {
+    if (not index->CheckFeature(vsag::SUPPORT_ADD_SEARCH_DELETE_CONCURRENT)) {
+        return;
+    }
+    fixtures::logger::LoggerReplacer _;
+
+    auto base_count = dataset->base_->GetNumElements();
+    auto temp_count = static_cast<int64_t>(base_count * 0.8);
+    auto dim = dataset->base_->GetDim();
+    auto temp_dataset = vsag::Dataset::Make();
+    temp_dataset->Dim(dim)
+        ->Ids(dataset->base_->GetIds())
+        ->NumElements(temp_count)
+        ->Paths(dataset->base_->GetPaths())
+        ->Float32Vectors(dataset->base_->GetFloat32Vectors())
+        ->SparseVectors(dataset->base_->GetSparseVectors())
+        ->Owner(false);
+    index->Build(temp_dataset);
+    fixtures::ThreadPool pool(5);
+    std::vector<std::future<bool>> futures;
+
+    auto func = [&](uint64_t i) -> bool {
+        auto data_one = vsag::Dataset::Make();
+        data_one->Dim(dim)
+            ->Ids(dataset->base_->GetIds() + i)
+            ->NumElements(1)
+            ->Paths(dataset->base_->GetPaths() + i)
+            ->Float32Vectors(dataset->base_->GetFloat32Vectors() + i * dim)
+            ->SparseVectors(dataset->base_->GetSparseVectors() + i)
+            ->Owner(false);
+        auto add_index = index->Add(data_one);
+        auto search_index = index->KnnSearch(data_one, 1, search_param);
+        auto remove_index = index->Remove(*(dataset->base_->GetIds() + i));
+        return add_index.has_value() & search_index.has_value() & remove_index.has_value();
+    };
+
+    for (uint64_t j = temp_count; j < base_count; ++j) {
+        futures.emplace_back(pool.enqueue(func, j));
+    }
+
+    for (auto& res : futures) {
+        auto val = res.get();
+        REQUIRE(val);
+    }
+}
+
 }  // namespace fixtures

--- a/tests/test_index.h
+++ b/tests/test_index.h
@@ -228,6 +228,12 @@ public:
     TestConcurrentAdd(const IndexPtr& index,
                       const TestDatasetPtr& dataset,
                       bool expected_success = true);
+
+    static void
+    TestConcurrentAddSearchRemove(const IndexPtr& index,
+                                  const TestDatasetPtr& dataset,
+                                  const std::string& search_param,
+                                  bool expected_success = true);
     static void
     TestConcurrentAddSearch(const IndexPtr& index,
                             const TestDatasetPtr& dataset,


### PR DESCRIPTION
cp #1269 to 0.17

## Summary by Sourcery

Add thread-safe concurrent add/search/remove support to HGraph and extend tests to cover concurrent removal and related concurrency features.

New Features:
- Introduce concurrent add/search/remove capability in HGraph via new index feature flags and thread-safe removal logic.

Enhancements:
- Protect HGraph search and removal paths with shared/global mutexes and make total element count tracking atomic for safe concurrent access.

Tests:
- Add concurrent add-search-remove test scenarios for HGraph, including PR and daily suites, and a shared helper in the test index utilities.
- Adjust brute force test scaffolding to support varying search parallelism configuration.