### PR TITLE
[WIP] fix(pyramid): fix error in Pyramid CI

### DIFF
--- a/.github/workflows/asan_build_and_test.yml
+++ b/.github/workflows/asan_build_and_test.yml
@@ -109,6 +109,8 @@ jobs:
           export LSAN_OPTIONS=suppressions=omp.supp
           chmod +x ./build/tests/${{ matrix.test_type }}
           ./scripts/testing/test_parallel_by_name.sh ${{ matrix.test_type }}
+      - name: Debug with SSH
+        uses: mxschmitt/action-tmate@v3
       - name: Upload Log
         uses: actions/upload-artifact@v5
         with:

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# 配置参数
+CONCURRENCY=4  # 同时并发的进程数
+
+# 模式1：批次式并行（每次启动N个进程，全部完成后开始下一批）
+batch_parallel() {
+    while true; do
+        echo "启动 $CONCURRENCY 个并行测试进程..."
+        for ((i=1; i<=$CONCURRENCY; i++)); do
+            ./build-release/tests/functests "Pyramid Serialize File" &
+        done
+        wait  # 等待本批次所有进程完成
+    done
+}
+
+# 模式2：持续并行（始终保持N个进程在运行）
+persistent_parallel() {
+    while true; do
+        jobs_count=$(jobs -p | wc -l)
+        if [ $jobs_count -lt $CONCURRENCY ]; then
+            ./build-release/tests/functests "Pyramid Serialize File" &
+        else
+            sleep 0.1  # 避免CPU占用过高
+        fi
+    done
+}
+
+# 选择执行模式（取消注释其中一个）
+batch_parallel   # 批次式并行
+# persistent_parallel  # 持续并行

--- a/tests/test_index.cpp
+++ b/tests/test_index.cpp
@@ -986,8 +986,26 @@ TestIndex::TestSerializeBinarySet(const IndexPtr& index_from,
         REQUIRE(res_from.has_value());
         REQUIRE(res_to.has_value());
         REQUIRE(res_from.value()->GetDim() == res_to.value()->GetDim());
+        bool pr = false;
         for (auto j = 0; j < topk; ++j) {
-            REQUIRE(res_to.value()->GetIds()[j] == res_from.value()->GetIds()[j]);
+            if (res_to.value()->GetIds()[j] != res_from.value()->GetIds()[j]) {
+                pr = true;
+            }
+        }
+        if (pr) {
+            auto query_path = dataset->query_->GetPaths()[i];
+            std::cout << "query path: " << query_path << std::endl;
+            for (auto j = 0; j < topk; ++j) {
+                auto from_id = res_from.value()->GetIds()[j] >> 16;
+                auto to_id = res_to.value()->GetIds()[j] >> 16;
+                auto from_path = dataset->base_->GetPaths()[from_id];
+                auto to_path = dataset->base_->GetPaths()[to_id];
+                auto from_distance = res_from.value()->GetDistances()[j];
+                auto to_distance =  res_to.value()->GetDistances()[j];
+                std::cout << fmt::format("rank {}: from_id {}, from_path {}, from_distance {:.6f} | to_id {}, to_path {}, to_distance {:.6f}",
+                                         j, from_id, from_path, from_distance, to_id, to_path, to_distance) << std::endl;
+            }
+            std::cout << std::endl;
         }
     }
 }

--- a/tests/test_index.cpp
+++ b/tests/test_index.cpp
@@ -900,8 +900,35 @@ TestIndex::TestSerializeFile(const IndexPtr& index_from,
         REQUIRE(res_from.has_value());
         REQUIRE(res_to.has_value());
         REQUIRE(res_from.value()->GetDim() == res_to.value()->GetDim());
+        bool pr = false;
         for (auto j = 0; j < topk; ++j) {
-            REQUIRE(res_to.value()->GetIds()[j] == res_from.value()->GetIds()[j]);
+            if (res_to.value()->GetIds()[j] != res_from.value()->GetIds()[j]) {
+                pr = true;
+            }
+        }
+        if (pr) {
+            auto query_path = dataset->query_->GetPaths()[i];
+            std::cout << "query path: " << query_path << std::endl;
+            for (auto j = 0; j < topk; ++j) {
+                auto from_id = res_from.value()->GetIds()[j] >> 16;
+                auto to_id = res_to.value()->GetIds()[j] >> 16;
+                auto from_path = dataset->base_->GetPaths()[from_id];
+                auto to_path = dataset->base_->GetPaths()[to_id];
+                auto from_distance = res_from.value()->GetDistances()[j];
+                auto to_distance = res_to.value()->GetDistances()[j];
+                std::cout << fmt::format(
+                                 "rank {}: from_id {}, from_path {}, from_distance {:.6f} | to_id "
+                                 "{}, to_path {}, to_distance {:.6f}",
+                                 j,
+                                 from_id,
+                                 from_path,
+                                 from_distance,
+                                 to_id,
+                                 to_path,
+                                 to_distance)
+                          << std::endl;
+            }
+            std::cout << std::endl;
         }
     }
 }
@@ -1001,9 +1028,18 @@ TestIndex::TestSerializeBinarySet(const IndexPtr& index_from,
                 auto from_path = dataset->base_->GetPaths()[from_id];
                 auto to_path = dataset->base_->GetPaths()[to_id];
                 auto from_distance = res_from.value()->GetDistances()[j];
-                auto to_distance =  res_to.value()->GetDistances()[j];
-                std::cout << fmt::format("rank {}: from_id {}, from_path {}, from_distance {:.6f} | to_id {}, to_path {}, to_distance {:.6f}",
-                                         j, from_id, from_path, from_distance, to_id, to_path, to_distance) << std::endl;
+                auto to_distance = res_to.value()->GetDistances()[j];
+                std::cout << fmt::format(
+                                 "rank {}: from_id {}, from_path {}, from_distance {:.6f} | to_id "
+                                 "{}, to_path {}, to_distance {:.6f}",
+                                 j,
+                                 from_id,
+                                 from_path,
+                                 from_distance,
+                                 to_id,
+                                 to_path,
+                                 to_distance)
+                          << std::endl;
             }
             std::cout << std::endl;
         }
@@ -1046,8 +1082,35 @@ TestIndex::TestSerializeReaderSet(const IndexPtr& index_from,
         REQUIRE(res_from.has_value());
         REQUIRE(res_to.has_value());
         REQUIRE(res_from.value()->GetDim() == res_to.value()->GetDim());
+        bool pr = false;
         for (auto j = 0; j < topk; ++j) {
-            REQUIRE(res_to.value()->GetIds()[j] == res_from.value()->GetIds()[j]);
+            if (res_to.value()->GetIds()[j] != res_from.value()->GetIds()[j]) {
+                pr = true;
+            }
+        }
+        if (pr) {
+            auto query_path = dataset->query_->GetPaths()[i];
+            std::cout << "query path: " << query_path << std::endl;
+            for (auto j = 0; j < topk; ++j) {
+                auto from_id = res_from.value()->GetIds()[j] >> 16;
+                auto to_id = res_to.value()->GetIds()[j] >> 16;
+                auto from_path = dataset->base_->GetPaths()[from_id];
+                auto to_path = dataset->base_->GetPaths()[to_id];
+                auto from_distance = res_from.value()->GetDistances()[j];
+                auto to_distance = res_to.value()->GetDistances()[j];
+                std::cout << fmt::format(
+                                 "rank {}: from_id {}, from_path {}, from_distance {:.6f} | to_id "
+                                 "{}, to_path {}, to_distance {:.6f}",
+                                 j,
+                                 from_id,
+                                 from_path,
+                                 from_distance,
+                                 to_id,
+                                 to_path,
+                                 to_distance)
+                          << std::endl;
+            }
+            std::cout << std::endl;
         }
     }
 }

--- a/tests/test_index.cpp
+++ b/tests/test_index.cpp
@@ -930,6 +930,10 @@ TestIndex::TestSerializeFile(const IndexPtr& index_from,
             }
             std::cout << std::endl;
         }
+
+        for (auto j = 0; j < topk; ++j) {
+            REQUIRE(res_to.value()->GetIds()[j] == res_from.value()->GetIds()[j]);
+        }
     }
 }
 void
@@ -1043,6 +1047,9 @@ TestIndex::TestSerializeBinarySet(const IndexPtr& index_from,
             }
             std::cout << std::endl;
         }
+        for (auto j = 0; j < topk; ++j) {
+            REQUIRE(res_to.value()->GetIds()[j] == res_from.value()->GetIds()[j]);
+        }
     }
 }
 
@@ -1111,6 +1118,9 @@ TestIndex::TestSerializeReaderSet(const IndexPtr& index_from,
                           << std::endl;
             }
             std::cout << std::endl;
+        }
+        for (auto j = 0; j < topk; ++j) {
+            REQUIRE(res_to.value()->GetIds()[j] == res_from.value()->GetIds()[j]);
         }
     }
 }


### PR DESCRIPTION
## Summary by Sourcery

Relax strict result equality in the Pyramid serialization test and add a helper script for stress-running the Pyramid functional tests in parallel.

Tests:
- Adjust the Pyramid serialization binary set test to log detailed mismatches instead of failing immediately on differing result IDs.

Chores:
- Add a shell script to repeatedly run the Pyramid functional test suite in parallel for debugging and stress testing.