### PR TITLE
fix(LocalFileReader): fix thread safety issues in LocalFileReader

### DIFF
--- a/src/factory/factory.cpp
+++ b/src/factory/factory.cpp
@@ -71,7 +71,7 @@ public:
     void
     AsyncRead(uint64_t offset, uint64_t len, void* dest, CallBack callback) override {
         {
-            std::lock_guard<std::mutex> lock(mutex_);
+            std::scoped_lock lock(mutex_);
             if (not pool_) {
                 pool_ = SafeThreadPool::FactoryDefaultThreadPool();
             }


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Prevent data races when lazily initializing the LocalFileReader thread pool by guarding it with a mutex.