### PR TITLE
fix(sparse): fix core dump when get vector with invalid id

### DIFF
--- a/src/algorithm/inner_index_interface.cpp
+++ b/src/algorithm/inner_index_interface.cpp
@@ -382,9 +382,7 @@ InnerIndexInterface::GetVectorByIds(const int64_t* ids, int64_t count) const {
             throw VsagException(ErrorType::NO_ENOUGH_MEMORY,
                                 "failed to allocate memory for vectors");
         }
-        for (int i = 0; i < count; i++) {
-            new (&sparse_vectors[i]) SparseVector();
-        }
+        std::uninitialized_default_construct_n(sparse_vectors, count);
         vectors->NumElements(count)->SparseVectors(sparse_vectors)->Owner(true, allocator_);
         for (int i = 0; i < count; ++i) {
             InnerIdType inner_id = this->label_table_->GetIdByLabel(ids[i]);

--- a/src/algorithm/inner_index_interface.cpp
+++ b/src/algorithm/inner_index_interface.cpp
@@ -382,6 +382,9 @@ InnerIndexInterface::GetVectorByIds(const int64_t* ids, int64_t count) const {
             throw VsagException(ErrorType::NO_ENOUGH_MEMORY,
                                 "failed to allocate memory for vectors");
         }
+        for (int i = 0; i < count; i++) {
+            new (&sparse_vectors[i]) SparseVector();
+        }
         vectors->NumElements(count)->SparseVectors(sparse_vectors)->Owner(true, allocator_);
         for (int i = 0; i < count; ++i) {
             InnerIdType inner_id = this->label_table_->GetIdByLabel(ids[i]);

--- a/src/dataset_impl.h
+++ b/src/dataset_impl.h
@@ -52,13 +52,13 @@ public:
             allocator_->Deallocate((void*)(DatasetImpl::GetFloat32Vectors()));
             allocator_->Deallocate((void*)(DatasetImpl::GetExtraInfos()));
 
-            if (DatasetImpl::GetSparseVectors() != nullptr) {
+            if (const auto* sparse_vectors = GetSparseVectors(); sparse_vectors != nullptr) {
                 for (int i = 0; i < DatasetImpl::GetNumElements(); i++) {
-                    if ((void*)DatasetImpl::GetSparseVectors()[i].ids_ != nullptr) {
-                        allocator_->Deallocate((void*)DatasetImpl::GetSparseVectors()[i].ids_);
+                    if (sparse_vectors[i].ids_ != nullptr) {
+                        allocator_->Deallocate((void*)sparse_vectors[i].ids_);
                     }
-                    if ((void*)DatasetImpl::GetSparseVectors()[i].vals_ != nullptr) {
-                        allocator_->Deallocate((void*)DatasetImpl::GetSparseVectors()[i].vals_);
+                    if (sparse_vectors[i].vals_ != nullptr) {
+                        allocator_->Deallocate((void*)sparse_vectors[i].vals_);
                     }
                 }
                 allocator_->Deallocate((void*)DatasetImpl::GetSparseVectors());

--- a/src/dataset_impl.h
+++ b/src/dataset_impl.h
@@ -54,8 +54,12 @@ public:
 
             if (DatasetImpl::GetSparseVectors() != nullptr) {
                 for (int i = 0; i < DatasetImpl::GetNumElements(); i++) {
-                    allocator_->Deallocate((void*)DatasetImpl::GetSparseVectors()[i].ids_);
-                    allocator_->Deallocate((void*)DatasetImpl::GetSparseVectors()[i].vals_);
+                    if ((void*)DatasetImpl::GetSparseVectors()[i].ids_ != nullptr) {
+                        allocator_->Deallocate((void*)DatasetImpl::GetSparseVectors()[i].ids_);
+                    }
+                    if ((void*)DatasetImpl::GetSparseVectors()[i].vals_ != nullptr) {
+                        allocator_->Deallocate((void*)DatasetImpl::GetSparseVectors()[i].vals_);
+                    }
                 }
                 allocator_->Deallocate((void*)DatasetImpl::GetSparseVectors());
             }

--- a/tests/test_index.cpp
+++ b/tests/test_index.cpp
@@ -2171,6 +2171,11 @@ TestIndex::TestGetRawVectorByIds(const IndexPtr& index,
     if (not index->CheckFeature(vsag::SUPPORT_GET_RAW_VECTOR_BY_IDS)) {
         return;
     }
+
+    int64_t non_exist_id = -9999999;
+    auto failed_res = index->GetRawVectorByIds(&non_exist_id, 1);
+    REQUIRE(not failed_res.has_value());
+
     int64_t count = dataset->count_;
     auto vectors = index->GetRawVectorByIds(dataset->base_->GetIds(), count);
     REQUIRE(vectors.has_value());


### PR DESCRIPTION
close #1399

## Summary by Sourcery

Fix handling of invalid sparse vector IDs to prevent crashes when retrieving or deallocating vectors.

Bug Fixes:
- Guard sparse vector deallocation against null ids_/vals_ pointers to avoid core dumps.
- Ensure sparse vector array elements are default-constructed before use so invalid IDs do not lead to undefined behavior.
- Verify GetRawVectorByIds returns no value for non-existent IDs and add a regression test for this scenario.

Tests:
- Extend index retrieval tests to cover GetRawVectorByIds with non-existent IDs and validate it fails gracefully.