### PR TITLE
feat: add allocator parameter to GetRawVectorByIds

### DIFF
--- a/include/vsag/index.h
+++ b/include/vsag/index.h
@@ -492,6 +492,7 @@ public:
      *
      * @param ids Array of vector IDs for which raw data is requested.
      * @param count Number of IDs in the 'ids' array.
+     * @param specified_allocator Optional Allocator for memory management (default is nullptr).
      * @return tl::expected<DatasetPtr, Error>
      *         - On success: A DatasetPtr containing the raw vector data
      *           (format depends on implementation, but typically includes vector arrays).
@@ -510,7 +511,9 @@ public:
      * inserted ones, even if the IDs match.
      */
     virtual tl::expected<DatasetPtr, Error>
-    GetRawVectorByIds(const int64_t* ids, int64_t count) const {
+    GetRawVectorByIds(const int64_t* ids,
+                      int64_t count,
+                      Allocator* specified_allocator = nullptr) const {
         throw std::runtime_error("Index doesn't support GetRawVectorByIds");
     };
 

--- a/src/algorithm/inner_index_interface.h
+++ b/src/algorithm/inner_index_interface.h
@@ -241,13 +241,15 @@ public:
     }
 
     virtual void
-    GetSparseVectorByInnerId(InnerIdType inner_id, SparseVector* data) const {
+    GetSparseVectorByInnerId(InnerIdType inner_id,
+                             SparseVector* data,
+                             Allocator* specified_allocator) const {
         throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
                             "Index doesn't support GetSparseVectorByInnerId");
     }
 
     virtual DatasetPtr
-    GetVectorByIds(const int64_t* ids, int64_t count) const;
+    GetVectorByIds(const int64_t* ids, int64_t count, Allocator* specified_allocator) const;
 
     virtual void
     InitFeatures() = 0;

--- a/src/algorithm/sindi/sindi.cpp
+++ b/src/algorithm/sindi/sindi.cpp
@@ -19,6 +19,7 @@
 #include "index_feature_list.h"
 #include "storage/serialization.h"
 #include "utils/util_functions.h"
+#include "vsag/allocator.h"
 
 namespace vsag {
 ParamPtr
@@ -427,18 +428,21 @@ SINDI::EstimateMemory(uint64_t num_elements) const {
 }
 
 void
-SINDI::GetSparseVectorByInnerId(InnerIdType inner_id, SparseVector* data) const {
+SINDI::GetSparseVectorByInnerId(InnerIdType inner_id,
+                                SparseVector* data,
+                                Allocator* specified_allocator) const {
     std::shared_lock rlock(this->global_mutex_);
 
     if (use_reorder_) {
-        return this->rerank_flat_index_->GetSparseVectorByInnerId(inner_id, data);
+        return this->rerank_flat_index_->GetSparseVectorByInnerId(
+            inner_id, data, specified_allocator);
     }
 
     auto cur_window = inner_id / window_size_;
     auto window_start_id = cur_window * window_size_;
     auto term_list = this->window_term_list_[cur_window];
 
-    term_list->GetSparseVector(inner_id - window_start_id, data);
+    term_list->GetSparseVector(inner_id - window_start_id, data, specified_allocator);
 }
 
 float

--- a/src/algorithm/sindi/sindi.h
+++ b/src/algorithm/sindi/sindi.h
@@ -18,6 +18,7 @@
 #include "algorithm/inner_index_interface.h"
 #include "algorithm/sparse_index.h"
 #include "datacell/sparse_term_datacell.h"
+#include "vsag/allocator.h"
 
 namespace vsag {
 
@@ -85,7 +86,9 @@ public:
     Deserialize(StreamReader& reader) override;
 
     void
-    GetSparseVectorByInnerId(InnerIdType inner_id, SparseVector* data) const override;
+    GetSparseVectorByInnerId(InnerIdType inner_id,
+                             SparseVector* data,
+                             Allocator* specified_allocator) const override;
 
     IndexType
     GetIndexType() const override {

--- a/src/algorithm/sparse_index.cpp
+++ b/src/algorithm/sparse_index.cpp
@@ -21,6 +21,7 @@
 #include "impl/label_table.h"
 #include "index_feature_list.h"
 #include "utils/util_functions.h"
+#include "vsag/allocator.h"
 namespace vsag {
 
 static float
@@ -240,10 +241,14 @@ SparseIndex::CalcDistanceById(const DatasetPtr& vector, int64_t id) const {
 }
 
 void
-SparseIndex::GetSparseVectorByInnerId(InnerIdType inner_id, SparseVector* data) const {
+SparseIndex::GetSparseVectorByInnerId(InnerIdType inner_id,
+                                      SparseVector* data,
+                                      Allocator* specified_allocator) const {
+    Allocator* allocator = specified_allocator != nullptr ? specified_allocator : allocator_;
+
     data->len_ = datas_[inner_id][0];
-    data->ids_ = (uint32_t*)allocator_->Allocate(sizeof(uint32_t) * data->len_);
-    data->vals_ = (float*)allocator_->Allocate(sizeof(float) * data->len_);
+    data->ids_ = (uint32_t*)allocator->Allocate(sizeof(uint32_t) * data->len_);
+    data->vals_ = (float*)allocator->Allocate(sizeof(float) * data->len_);
 
     memcpy(data->ids_, datas_[inner_id] + 1, data->len_ * sizeof(uint32_t));
     memcpy(data->vals_, datas_[inner_id] + 1 + datas_[inner_id][0], data->len_ * sizeof(float));

--- a/src/algorithm/sparse_index.h
+++ b/src/algorithm/sparse_index.h
@@ -53,7 +53,9 @@ public:
     }
 
     void
-    GetSparseVectorByInnerId(InnerIdType inner_id, SparseVector* data) const override;
+    GetSparseVectorByInnerId(InnerIdType inner_id,
+                             SparseVector* data,
+                             Allocator* specified_allocator) const override;
 
     IndexType
     GetIndexType() const override {

--- a/src/datacell/sparse_term_datacell.cpp
+++ b/src/datacell/sparse_term_datacell.cpp
@@ -15,6 +15,8 @@
 
 #include "sparse_term_datacell.h"
 
+#include "vsag/allocator.h"
+
 namespace vsag {
 
 void
@@ -244,9 +246,13 @@ SparseTermDataCell::CalcDistanceByInnerId(const SparseTermComputerPtr& computer,
 }
 
 void
-SparseTermDataCell::GetSparseVector(uint32_t base_id, SparseVector* data) {
-    Vector<uint32_t> ids(allocator_);
-    Vector<float> vals(allocator_);
+SparseTermDataCell::GetSparseVector(uint32_t base_id,
+                                    SparseVector* data,
+                                    Allocator* specified_allocator) {
+    Allocator* allocator = specified_allocator != nullptr ? specified_allocator : allocator_;
+
+    Vector<uint32_t> ids(allocator);
+    Vector<float> vals(allocator);
 
     for (auto term = 0; term < term_ids_.size(); term++) {
         for (auto i = 0; i < term_sizes_[term]; i++) {
@@ -258,8 +264,8 @@ SparseTermDataCell::GetSparseVector(uint32_t base_id, SparseVector* data) {
     }
 
     data->len_ = ids.size();
-    data->ids_ = (uint32_t*)allocator_->Allocate(sizeof(uint32_t) * data->len_);
-    data->vals_ = (float*)allocator_->Allocate(sizeof(float) * data->len_);
+    data->ids_ = (uint32_t*)allocator->Allocate(sizeof(uint32_t) * data->len_);
+    data->vals_ = (float*)allocator->Allocate(sizeof(float) * data->len_);
 
     memcpy(data->ids_, ids.data(), data->len_ * sizeof(uint32_t));
     memcpy(data->vals_, vals.data(), data->len_ * sizeof(float));

--- a/src/datacell/sparse_term_datacell.h
+++ b/src/datacell/sparse_term_datacell.h
@@ -21,6 +21,7 @@
 #include "storage/stream_reader.h"
 #include "storage/stream_writer.h"
 #include "utils/pointer_define.h"
+#include "vsag/allocator.h"
 #include "vsag/dataset.h"
 
 namespace vsag {
@@ -69,7 +70,7 @@ public:
     CalcDistanceByInnerId(const SparseTermComputerPtr& computer, uint32_t base_id);
 
     void
-    GetSparseVector(uint32_t base_id, SparseVector* data);
+    GetSparseVector(uint32_t base_id, SparseVector* data, Allocator* specified_allocator);
 
 public:
     uint32_t term_id_limit_{0};

--- a/src/impl/allocator/default_allocator.cpp
+++ b/src/impl/allocator/default_allocator.cpp
@@ -23,7 +23,9 @@ namespace vsag {
 #ifndef NDEBUG
 DefaultAllocator::~DefaultAllocator() {
     if (not allocated_ptrs_.empty()) {
-        logger::error(fmt::format("There is a memory leak in {}.", DefaultAllocator::Name()));
+        logger::error(fmt::format("There is a memory leak in {}, size: {}",
+                                  DefaultAllocator::Name(),
+                                  allocated_ptrs_.size()));
         abort();
     }
 }

--- a/src/index/index_impl.h
+++ b/src/index/index_impl.h
@@ -233,13 +233,15 @@ public:
         return this->inner_index_->GetNumberRemoved();
     }
 
-    virtual tl::expected<DatasetPtr, Error>
-    GetRawVectorByIds(const int64_t* ids, int64_t count) const override {
+    tl::expected<DatasetPtr, Error>
+    GetRawVectorByIds(const int64_t* ids,
+                      int64_t count,
+                      Allocator* specified_allocator) const override {
         if (not CheckFeature(IndexFeature::SUPPORT_GET_RAW_VECTOR_BY_IDS)) {
             return tl::unexpected(Error(ErrorType::UNSUPPORTED_INDEX_OPERATION,
                                         "index no support to get raw vector by ids"));
         }
-        SAFE_CALL(return this->inner_index_->GetVectorByIds(ids, count));
+        SAFE_CALL(return this->inner_index_->GetVectorByIds(ids, count, specified_allocator));
     };
 
     [[nodiscard]] std::string

--- a/tests/test_index.cpp
+++ b/tests/test_index.cpp
@@ -19,6 +19,7 @@
 #include "fixtures/test_logger.h"
 #include "fixtures/test_reader.h"
 #include "fixtures/thread_pool.h"
+#include "impl/allocator/default_allocator.h"
 #include "index/hnsw.h"
 #include "simd/fp32_simd.h"
 #include "vsag/engine.h"
@@ -2235,11 +2236,49 @@ TestIndex::TestGetRawVectorByIds(const IndexPtr& index,
         return;
     }
 
-    int64_t non_exist_id = -9999999;
-    auto failed_res = index->GetRawVectorByIds(&non_exist_id, 1);
-    REQUIRE(not failed_res.has_value());
+    // get with not existed id
+    {
+        int64_t non_exist_id = -9999999;
+        auto failed_res = index->GetRawVectorByIds(&non_exist_id, 1);
+        REQUIRE(not failed_res.has_value());
+    }
 
-    int64_t count = dataset->count_;
+    auto count = static_cast<int64_t>(dataset->count_);
+
+    // get with specifed memory allocator
+    {
+        vsag::DefaultAllocator allocator;
+        void* mem = nullptr;
+        {
+            auto res =
+                index->GetRawVectorByIds(dataset->base_->GetIds(), count, &allocator).value();
+
+            if (index->GetIndexType() == vsag::IndexType::SINDI or
+                index->GetIndexType() == vsag::IndexType::SPARSE) {
+                mem = (void*)res->GetSparseVectors();
+            } else {
+                mem = (void*)res->GetFloat32Vectors();
+            }
+        }
+
+        // free the vector memory after the dataset released
+        if (index->GetIndexType() == vsag::IndexType::SINDI or
+            index->GetIndexType() == vsag::IndexType::SPARSE) {
+            auto* sparse_vectors = (vsag::SparseVector*)mem;
+            for (int64_t i = 0; i < count; ++i) {
+                allocator.Deallocate(sparse_vectors[i].ids_);
+                sparse_vectors[i].ids_ = nullptr;
+                allocator.Deallocate(sparse_vectors[i].vals_);
+                sparse_vectors[i].vals_ = nullptr;
+            }
+            allocator.Deallocate(sparse_vectors);
+        } else {
+            auto* vectors = (float*)mem;
+            allocator.Deallocate(vectors);
+        }
+    }
+
+    // common case
     auto vectors = index->GetRawVectorByIds(dataset->base_->GetIds(), count);
     REQUIRE(vectors.has_value());
     if (index->GetIndexType() == vsag::IndexType::SINDI or


### PR DESCRIPTION
introduce an `allocator` parameter to the `GetRawVectorByIds` method, allowing callers to specify a custom memory allocator when retrieving raw vectors from the index.

closed: #1433