### PR TITLE
fix(analyzer): add nullptr check in HGraphAnalyzer and copy query vectors

### DIFF
--- a/src/analyzer/hgraph_analyzer.cpp
+++ b/src/analyzer/hgraph_analyzer.cpp
@@ -249,6 +249,14 @@ HGraphAnalyzer::SetQuery(const DatasetPtr& query) {
     query_sample_ids_.resize(query_sample_size_);
     query_sample_datas_.resize(static_cast<std::vector<float>::size_type>(query_sample_size_) *
                                static_cast<std::vector<float>::size_type>(dim_));
+    if (query->GetFloat32Vectors() != nullptr) {
+        std::memcpy(query_sample_datas_.data(),
+                    query->GetFloat32Vectors(),
+                    query_sample_size_ * dim_ * sizeof(float));
+    } else {
+        logger::error("Query dataset is empty or not float32");
+        return false;
+    }
     std::iota(query_sample_ids_.begin(), query_sample_ids_.end(), 0);
     return true;
 }


### PR DESCRIPTION
This pull request adds error handling to the `SetQuery` method in `HGraphAnalyzer` to ensure that the query dataset contains valid float32 vectors before proceeding. If the dataset is empty or not in the expected format, the method now logs an error and returns `false` instead of continuing.

Error handling improvements:

* Added a check in `HGraphAnalyzer::SetQuery` to verify that the query dataset contains valid float32 vectors before copying data; logs an error and returns `false` if the dataset is empty or not float32.