### PR TITLE
fix(analyzer): add nullptr check and copy query vectors in HGraphAnalyzer

### DIFF
--- a/src/analyzer/hgraph_analyzer.cpp
+++ b/src/analyzer/hgraph_analyzer.cpp
@@ -249,6 +249,14 @@ HGraphAnalyzer::SetQuery(const DatasetPtr& query) {
     query_sample_ids_.resize(query_sample_size_);
     query_sample_datas_.resize(static_cast<std::vector<float>::size_type>(query_sample_size_) *
                                static_cast<std::vector<float>::size_type>(dim_));
+    if (query->GetFloat32Vectors() != nullptr) {
+        std::memcpy(query_sample_datas_.data(),
+                    query->GetFloat32Vectors(),
+                    query_sample_size_ * dim_ * sizeof(float));
+    } else {
+        logger::error("Query dataset is empty or not float32");
+        return false;
+    }
     std::iota(query_sample_ids_.begin(), query_sample_ids_.end(), 0);
     return true;
 }


### PR DESCRIPTION
This pull request adds error handling to the `SetQuery` method in `hgraph_analyzer.cpp` to ensure the query dataset contains valid float32 vectors before proceeding. If the dataset is invalid or empty, an error is logged and the function returns `false`.

Error handling improvements:

* Added a check to verify that `GetFloat32Vectors()` is not `nullptr` before copying data, and log an error and return `false` if the check fails. (`src/analyzer/hgraph_analyzer.cpp`)