### PR TITLE
fix  iter search and add concurency

### DIFF
--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -817,6 +817,7 @@ HGraph::KnnSearch(const DatasetPtr& query,
         (1 <= params.ef_search) and (params.ef_search <= ef_search_threshold),
         fmt::format("ef_search({}) must in range[1, {}]", params.ef_search, ef_search_threshold));
 
+    std::shared_lock shared_lock(this->global_mutex_);
     // check k
     CHECK_ARGUMENT(k > 0, fmt::format("k({}) must be greater than 0", k));
     k = std::min(k, GetNumElements());


### PR DESCRIPTION
Hgraph iterative filtering KnnSearch does not lock global_mutex like normal KnnSearch. This results in memory issues when resizing concurrently modifying the VisitedListPool.

<img width="3544" height="746" alt="image" src="https://github.com/user-attachments/assets/22d43151-148d-420d-a6cd-78f76bc73ce8" />
