### PR TITLE
fix(hgraph): refactor label remap handling in SetImmutable

### DIFF
--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -1272,9 +1272,7 @@ HGraph::deserialize_label_info(StreamReader& reader) const {
         StreamReader::ReadObj(reader, key);
         InnerIdType value;
         StreamReader::ReadObj(reader, value);
-        if (not this->immutable_) {
-            this->label_table_->label_remap_.emplace(key, value);
-        }
+        this->label_table_->label_remap_.emplace(key, value);
     }
 }
 
@@ -2006,9 +2004,6 @@ HGraph::SetImmutable() {
     this->neighbors_mutex_.reset();
     this->neighbors_mutex_ = std::make_shared<EmptyMutex>();
     this->searcher_->SetMutexArray(this->neighbors_mutex_);
-    this->label_table_->use_reverse_map_ = false;
-    STLUnorderedMap<LabelType, InnerIdType> empty_remap(allocator_);
-    this->label_table_->label_remap_.swap(empty_remap);
     this->immutable_ = true;
 }
 


### PR DESCRIPTION
close #1555 

This pull request makes targeted changes to the `HGraph` class in `hgraph.cpp`, specifically around how label remapping and immutability are handled. The updates ensure that label remapping is consistently managed, even after the graph is set to immutable, and remove unnecessary cleanup logic.

Label remapping and immutability handling:

* Removed the check for `immutable_` before updating `label_remap_` in `deserialize_label_info`, allowing label remapping to occur regardless of immutability status.
* Stopped clearing and disabling `label_remap_` and `use_reverse_map_` in `SetImmutable()`, so label remapping data is now preserved when the graph becomes immutable.