### PR TITLE
ci(macos): add macOS ASAN build/test jobs and deps installer

### DIFF
--- a/.github/workflows/asan_build_and_test.yml
+++ b/.github/workflows/asan_build_and_test.yml
@@ -75,6 +75,31 @@ jobs:
           retention-days: 3
           overwrite: 'true'
 
+  build_asan_macos:
+    name: Asan Build macOS
+    runs-on: macos-latest
+    concurrency:
+      group: asan_build_macos-${{ github.event.pull_request.number || github.sha }}
+      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+    steps:
+      - name: Free Disk Space
+        run: rm -rf /Users/runner/hostedtoolcache || true
+      - uses: actions/checkout@v4
+      - name: Prepare Env
+        run: bash ./scripts/deps/install_deps_macos.sh
+      - name: Make Asan
+        run: export CMAKE_GENERATOR="Ninja"; make asan
+      - name: Clean
+        run: find ./build -type f -name "*.o" -exec rm -f {} +
+      - name: Save Test
+        uses: actions/upload-artifact@v5
+        with:
+          path: ./build/
+          name: test_macos-${{ github.run_id }}
+          compression-level: 1
+          retention-days: 3
+          overwrite: 'true'
+
   test_asan_x86:
     name: Test X86
     needs: build_asan_x86
@@ -222,9 +247,100 @@ jobs:
             fi
           done
 
+  test_asan_macos:
+    name: Test macOS
+    needs: build_asan_macos
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        test_type: [ unittests, functests ]
+    concurrency:
+      group: test_asan_macos-${{ matrix.test_type }}-${{ github.event.pull_request.number || github.sha }}
+      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+    steps:
+      - name: Free Disk Space
+        run: rm -rf /Users/runner/hostedtoolcache || true
+      - uses: actions/checkout@v4
+      - name: Clean Build
+        run: rm -rf ./build
+      - name: Download Test
+        uses: actions/download-artifact@v5
+        with:
+          name: test_macos-${{ github.run_id }}
+          path: ./build
+      - name: Do Asan Test In ${{ matrix.test_type }}
+        run: |
+          echo leak:libomp.dylib > omp.supp
+          export LSAN_OPTIONS=suppressions=omp.supp || true
+          chmod +x ./build/tests/${{ matrix.test_type }}
+          ./scripts/testing/test_parallel_by_name.sh ${{ matrix.test_type }}
+      - name: Upload Log
+        uses: actions/upload-artifact@v5
+        with:
+          path: ./log
+          name: log-macos-${{ matrix.test_type }}-${{ github.run_id }}
+          compression-level: 1
+          retention-days: 3
+          overwrite: 'true'
+
+  test_example_macos:
+    name: Test Example macOS
+    needs: build_asan_macos
+    runs-on: macos-latest
+    concurrency:
+      group: test_example_macos-${{ github.event.pull_request.number || github.sha }}
+      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+    steps:
+      - name: Free Disk Space
+        run: rm -rf /Users/runner/hostedtoolcache || true
+      - uses: actions/checkout@v4
+      - name: Clean Env
+        run: rm -rf ./build
+      - name: Download Test
+        uses: actions/download-artifact@v5
+        with:
+          name: test_macos-${{ github.run_id }}
+          path: ./build
+      - name: Do Test In example
+        run: |
+          cd ./build/examples/cpp
+          echo "leak:libgomp.so" > lsan.supp || true
+          echo "leak:libgomp.so.1" >> lsan.supp || true
+          export LSAN_OPTIONS=suppressions=$(pwd)/lsan.supp || true
+          for example in ./*; do
+            filename=$(basename "$example")
+            if [[ $filename =~ ^[0-9]{3} ]]; then
+              chmod +x $example
+              echo "Run $example"
+              $example
+            fi
+          done
+      - uses: actions/checkout@v4
+      - name: Clean Env
+        run: rm -rf ./build
+      - name: Download Test
+        uses: actions/download-artifact@v5
+        with:
+          name: test_aarch64-${{ github.run_id }}
+          path: ./build
+      - name: Do Test In example
+        run: |
+          cd ./build/examples/cpp
+          echo "leak:libgomp.so" > lsan.supp
+          echo "leak:libgomp.so.1" >> lsan.supp
+          export LSAN_OPTIONS=suppressions=$(pwd)/lsan.supp
+          for example in ./*; do
+            filename=$(basename "$example")
+            if [[ $filename =~ ^[0-9]{3} ]]; then
+              chmod +x $example
+              echo "Run $example"
+              $example
+            fi
+          done
+
   clean_up:
     name: Clean Up
-    needs: [ test_asan_x86, test_asan_aarch64 ]
+    needs: [ test_asan_x86, test_asan_aarch64, test_asan_macos ]
     runs-on: ubuntu-22.04
     steps:
       - name: Create Empty File
@@ -242,6 +358,14 @@ jobs:
         with:
           path: /tmp/clean_up
           name: test_aarch64-${{ github.run_id }}
+          compression-level: 1
+          retention-days: 3
+          overwrite: 'true'
+      - name: Overwrite Test Artifact macOS
+        uses: actions/upload-artifact@v5
+        with:
+          path: /tmp/clean_up
+          name: test_macos-${{ github.run_id }}
           compression-level: 1
           retention-days: 3
           overwrite: 'true'

--- a/.github/workflows/daily_test.yml
+++ b/.github/workflows/daily_test.yml
@@ -74,6 +74,39 @@ jobs:
           retention-days: 3
           overwrite: 'true'
 
+  daily_build_asan_macos:
+    name: Asan Build macOS
+    runs-on: macos-latest
+    concurrency:
+      group: daily_build_macos
+      cancel-in-progress: true
+    steps:
+      - name: Free Disk Space
+        run: rm -rf /Users/runner/hostedtoolcache || true
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+      - name: Prepare Env
+        run: bash ./scripts/deps/install_deps_macos.sh
+      - name: Load Cache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          max-size: "2G"
+          save: false
+          key: build-macos-${{ hashFiles('./CMakeLists.txt') }}-${{ hashFiles('./.circleci/fresh_ci_cache.commit') }}
+      - name: Make Asan
+        run: export CMAKE_GENERATOR="Ninja"; make asan
+      - name: Clean
+        run: find ./build -type f -name "*.o" -exec rm -f {} +
+      - name: Save Test
+        uses: actions/upload-artifact@v5
+        with:
+          path: ./build/
+          name: test_macos-${{ github.run_id }}
+          compression-level: 1
+          retention-days: 3
+          overwrite: 'true'
+
   daily_test_asan_x86:
     name: Test X86
     needs: daily_build_asan_x86
@@ -112,6 +145,44 @@ jobs:
         with:
           path: ./log
           name: log-x86-${{ matrix.test_type }}-${{ github.run_id }}
+          compression-level: 1
+          retention-days: 3
+          overwrite: 'true'
+
+  daily_test_asan_macos:
+    name: Test macOS
+    needs: daily_build_asan_macos
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        test_type: [ unittests, functests ]
+    concurrency:
+      group: daily_test_macos-${{ matrix.test_type }}
+      cancel-in-progress: true
+    steps:
+      - name: Free Disk Space
+        run: rm -rf /Users/runner/hostedtoolcache || true
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+      - name: Clean Env
+        run: rm -rf ./build
+      - name: Download Test
+        uses: actions/download-artifact@v5
+        with:
+          name: test_macos-${{ github.run_id }}
+          path: ./build
+      - name: Do Asan Test In ${{ matrix.test_type }}
+        run: |
+          echo leak:libomp.dylib > omp.supp
+          export LSAN_OPTIONS=suppressions=omp.supp || true
+          chmod +x ./build/tests/${{ matrix.test_type }}
+          ./scripts/testing/test_parallel_by_name.sh ${{ matrix.test_type }} ~[pr]
+      - name: Upload Log
+        uses: actions/upload-artifact@v5
+        with:
+          path: ./log
+          name: log-macos-${{ matrix.test_type }}-${{ github.run_id }}
           compression-level: 1
           retention-days: 3
           overwrite: 'true'
@@ -158,7 +229,7 @@ jobs:
 
   asan_test_clean_up:
     name: Clean Up
-    needs: [ daily_test_asan_x86, daily_test_asan_aarch64 ]
+    needs: [ daily_test_asan_x86, daily_test_asan_aarch64, daily_test_asan_macos ]
     runs-on: ubuntu-22.04
     steps:
       - name: Create Empty File
@@ -176,6 +247,14 @@ jobs:
         with:
           path: /tmp/clean_up
           name: test_aarch64-${{ github.run_id }}
+          compression-level: 1
+          retention-days: 3
+          overwrite: 'true'
+      - name: Overwrite Test Artifact macOS
+        uses: actions/upload-artifact@v5
+        with:
+          path: /tmp/clean_up
+          name: test_macos-${{ github.run_id }}
           compression-level: 1
           retention-days: 3
           overwrite: 'true'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,34 +22,311 @@ if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.30.0")
     cmake_policy (SET CMP0169 OLD)
 endif ()
 
-project (VSAG LANGUAGES C CXX)
+project (VSAG
+        LANGUAGES C CXX
+)
 
-include (GNUInstallDirs)               # Standard install directory variables.
-include (cmake/ColorizeMessage.cmake)  # Colored status output helpers.
-include (cmake/VSAGHelpers.cmake)      # Shared helper functions.
-include (cmake/VSAGOptions.cmake)      # Cache options and build defaults.
+include (cmake/ColorizeMessage.cmake)
 
-set (VSAG_TARGET_PROCESSOR "${CMAKE_SYSTEM_PROCESSOR}")
-if (NOT VSAG_TARGET_PROCESSOR)
-    set (VSAG_TARGET_PROCESSOR "${CMAKE_HOST_SYSTEM_PROCESSOR}")
+message (STATUS "CPU ARCH: ${Yellow}${CMAKE_HOST_SYSTEM_PROCESSOR}${CR}")
+
+macro (vsag_add_exe_linker_flag flag)
+    set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${flag}")
+endmacro ()
+
+macro (vsag_add_shared_linker_flag flag)
+    set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${flag}")
+endmacro ()
+
+macro (maybe_add_dependencies depender)
+    if (TARGET ${depender})
+        foreach (dependee ${ARGN})
+            if (TARGET ${dependee})
+                add_dependencies (${depender} ${dependee})
+            endif ()
+        endforeach ()
+    endif ()
+endmacro ()
+
+# options
+option (ENABLE_JEMALLOC "Whether to link jemalloc to all executables" OFF)
+option (ENABLE_ASAN "Whether to turn AddressSanitizer ON or OFF" OFF)
+option (ENABLE_COVERAGE "Whether to turn unit test coverage ON or OFF" OFF)
+option (ENABLE_FUZZ_TEST "Whether to turn Fuzz Test ON or OFF" OFF)
+option (ENABLE_WERROR "Whether to error on warnings" ON)
+option (ENABLE_TSAN "Whether to turn Thread Sanitizer ON or OFF" OFF)
+option (ENABLE_FRAME_POINTER "Whether to build with -fno-omit-frame-pointer" ON)
+option (ENABLE_THIN_LTO "Whether to build with thin lto -flto=thin" OFF)
+option (ENABLE_CCACHE "Whether to open ccache" OFF)
+option (ENABLE_INTEL_MKL "Enable intel-mkl (x86 platform only)" ON)
+option (ENABLE_CXX11_ABI "Use CXX11 ABI" ON)
+option (ENABLE_LIBCXX "Use libc++ instead of libstdc++" OFF) # only support in clang
+option (ENABLE_TOOLS "Whether compile vsag tools" OFF)
+option (ENABLE_EXAMPLES "Whether compile examples" ON)
+option (ENABLE_TESTS "Whether compile vsag tests" ON)
+option (DISABLE_SSE_FORCE "Force disable sse and higher instructions" OFF)
+option (DISABLE_AVX_FORCE "Force disable avx and higher instructions" OFF)
+option (DISABLE_AVX2_FORCE "Force disable avx2 and higher instructions" OFF)
+option (DISABLE_AVX512_FORCE "Force disable avx512 instructions" OFF)
+option (DISABLE_AVX512VPOPCNTDQ_FORCE "Force disable avx512vpopcntdq instructions" OFF)
+option (DISABLE_NEON_FORCE "Force disable neon instructions" OFF)
+option (DISABLE_SVE_FORCE "Force disable sve instructions" OFF)
+# AIO library configuration
+option (ENABLE_LIBAIO "Whether to enable libaio support" ON)
+if (NOT APPLE)
+    if (ENABLE_CXX11_ABI)
+        add_definitions (-D_GLIBCXX_USE_CXX11_ABI=1)
+        message (STATUS "Using libstdc++ with ${Yellow}C++11 ABI${CR}")
+    else ()
+        add_definitions (-D_GLIBCXX_USE_CXX11_ABI=0)
+        message (STATUS "Using libstdc++ with ${Yellow}pre-C++11 ABI${CR}")
+
+        # for avoiding symbol conflict: _Rep::_S_create
+        vsag_add_shared_linker_flag(-fvisibility-inlines-hidden)
+    endif ()
 endif ()
 
-message (STATUS "CPU ARCH: ${Yellow}${VSAG_TARGET_PROCESSOR}${CR}")
+if (ENABLE_WERROR)
+    add_compile_options (-Werror)
+endif ()
 
-include (cmake/VSAGCompilerConfig.cmake)        # Compiler, ABI, sanitizer, and linker setup.
-include (cmake/VSAGSystemDeps.cmake)            # System dependency discovery.
-include (cmake/DarwinDep.cmake)                 # macOS-specific dependency handling.
-include (cmake/VSAGExternalProjectConfig.cmake) # Shared ExternalProject flags and env.
-include (cmake/VSAGThirdParty.cmake)            # Third-party dependency declarations.
-include (cmake/VSAGDependencyTargets.cmake)     # Shared interface/header dependency targets.
+# On Apple platforms, use the system's libc++ instead of static linking libstdc++
+if (NOT APPLE)
+    vsag_add_exe_linker_flag (-static-libstdc++)
+    vsag_add_shared_linker_flag (-static-libstdc++)
+endif ()
+vsag_add_shared_linker_flag (-fvisibility=hidden)
 
-include_directories (${PROJECT_SOURCE_DIR}/include)
-include_directories (${PROJECT_SOURCE_DIR}/src)
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -gdwarf-4")
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -gdwarf-4")
 
+    if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 15.0.0)
+        set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-builtins")
+        message (STATUS "Clang >=15 detected: -Wno-deprecated-builtins enabled")
+    endif ()
+else ()
+    if (ENABLE_LIBCXX)
+        message (FATAL_ERROR "gcc does not support using libc++")
+    endif ()
+endif ()
+
+if (ENABLE_LIBCXX OR APPLE)
+    message (STATUS "Using libc++ with C++11 ABI")
+    if (APPLE)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++")
+        set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -stdlib=libc++")
+    else()
+        set (LIBCXX_SEARCH_PATH /opt/alibaba-cloud-compiler/lib64)
+        find_library (LIBCXX_STATIC libc++.a PATHS ${LIBCXX_SEARCH_PATH})
+        find_library (LIBCXXABI_STATIC libc++abi.a PATHS ${LIBCXX_SEARCH_PATH})
+        if (LIBCXX_STATIC AND LIBCXXABI_STATIC)
+            get_filename_component (LIBCXX_DIR "${LIBCXX_STATIC}" DIRECTORY)
+            message (STATUS "Found libc++ at ${LIBCXX_STATIC}")
+            message (STATUS "Found libc++abi at ${LIBCXXABI_STATIC}")
+            set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+
+            vsag_add_shared_linker_flag ("-fuse-ld=lld")
+            vsag_add_shared_linker_flag ("-Wl,-rpath,${LIBCXX_DIR}")
+            vsag_add_exe_linker_flag ("-fuse-ld=lld")
+            vsag_add_exe_linker_flag ("-Wl,-rpath,${LIBCXX_DIR}")
+            set (CMAKE_CXX_STANDARD_LIBRARIES "${CMAKE_CXX_STANDARD_LIBRARIES} ${LIBCXX_STATIC} ${LIBCXXABI_STATIC}")
+        else ()
+            message (FATAL_ERROR "libc++ or libc++abi not found")
+        endif ()
+    endif ()
+else ()
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+        set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libstdc++")
+    endif ()
+endif ()
+
+# AIO library detection
+if (ENABLE_LIBAIO)
+    find_library (AIO_LIBRARY aio)
+    if (AIO_LIBRARY)
+        message (STATUS "Found libaio: ${AIO_LIBRARY}")
+        set (HAVE_LIBAIO 1)
+        add_definitions (-DHAVE_LIBAIO=1)
+    else ()
+        message (WARNING "libaio not found, disabling async I/O support")
+        set (HAVE_LIBAIO 0)
+        add_definitions (-DHAVE_LIBAIO=0)
+        add_definitions (-DNO_LIBAIO=1)
+    endif ()
+else ()
+    message (STATUS "libaio support disabled by user")
+    set (HAVE_LIBAIO 0)
+    add_definitions (-DHAVE_LIBAIO=0)
+    add_definitions (-DNO_LIBAIO=1)
+endif ()
+
+# ccache
+find_program (CCACHE_FOUND ccache)
+if (CCACHE_FOUND AND ENABLE_CCACHE)
+    message (STATUS "Compiling with ccache")
+    set_property (GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
+    set_property (GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
+endif ()
+
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
+set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
+
+set (ld_flags
+        "-L${CMAKE_INSTALL_PREFIX}/lib"
+        "-L${CMAKE_INSTALL_PREFIX}/lib64"
+)
+if (EXISTS "/usr/lib/${CMAKE_LIBRARY_ARCHITECTURE}")
+    set (ld_flags
+            "${ld_flags}"
+            "-L/usr/lib/${CMAKE_LIBRARY_ARCHITECTURE}"
+    )
+endif ()
+if (EXISTS "/usr/lib64/${CMAKE_LIBRARY_ARCHITECTURE}")
+    set (ld_flags
+            "${ld_flags}"
+            "-L/usr/lib64/${CMAKE_LIBRARY_ARCHITECTURE}"
+    )
+endif ()
+if (EXISTS "/opt/alibaba-cloud-compiler/lib64/")
+    set (ld_flags
+            "${ld_flags}"
+            "-L/opt/alibaba-cloud-compiler/lib64/"
+    )
+endif ()
+string (JOIN " " ld_flags ${ld_flags})
+
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
+set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
+
+set (common_cmake_args
+        "-DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}"
+        "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}"
+        "-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}"
+        "-DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer -fPIC -gdwarf-4 "
+        "-DCMAKE_C_FLAGS=${CMAKE_C_FLAGS} -fno-omit-frame-pointer -fPIC -gdwarf-4 "
+        "-DCMAKE_EXE_LINKER_FLAGS=${extra_link_libs}"
+        "-DCMAKE_SHARED_LINKER_FLAGS=${extra_link_libs}"
+        "-DCMAKE_INCLUDE_PATH=${CMAKE_INSTALL_PREFIX}/include"
+        "-DCMAKE_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/lib:/opt/alibaba-cloud-compiler/lib64"
+)
+include (cmake/DarwinDep.cmake)
+set(common_configure_envs
+    "env"
+    "CC=${CMAKE_C_COMPILER}"
+    "CXX=${CMAKE_CXX_COMPILER}"
+    "CFLAGS=${CMAKE_C_FLAGS} -fno-omit-frame-pointer -fPIC -O2 -D_DEFAULT_SOURCE -D_GNU_SOURCE -gdwarf-4"
+    "CXXFLAGS=${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer -fPIC -O2 -D_DEFAULT_SOURCE -D_GNU_SOURCE -gdwarf-4"
+    "CPPFLAGS=-isystem ${CMAKE_INSTALL_PREFIX}/include"
+    "LDFLAGS=${ld_flags_workaround} ${ld_flags}"  # Use the workaround for LDFLAGS
+    "PATH=${BUILDING_PATH}:$ENV{PATH}"
+    "ACLOCAL_PATH=${ACLOCAL_PATH}"
+)
+
+# set the default compilation parallelism of thirdparties
+if (NOT NUM_BUILDING_JOBS)
+    set (NUM_BUILDING_JOBS 4)
+endif ()
+
+# thirdparties of lib
+include (cmake/CheckSIMDCompilerFlag.cmake)
+include (ExternalProject)
+include (extern/json/json.cmake)
+include (extern/antlr4/antlr4.cmake)
+include (extern/boost/boost.cmake)
+include (extern/openblas/openblas.cmake)
+include (extern/mkl/mkl.cmake)
+include (extern/diskann/diskann.cmake)
+include (extern/spdlog/spdlog.cmake)
+include (extern/catch2/catch2.cmake)
+include (extern/cpuinfo/cpuinfo.cmake)
+include (extern/fmt/fmt.cmake)
+include (extern/thread_pool/thread_pool.cmake)
+include (extern/tsl/tsl.cmake)
+include (extern/roaringbitmap/roaringbitmap.cmake)
+
+include_directories (${CMAKE_CURRENT_BINARY_DIR}/spdlog/install/include)
+include_directories (include)
+include_directories (src)
+
+# thirdparties of tools, cannot compile with _GLIBCXX_USE_CXX11_ABI=0
+if (ENABLE_TOOLS AND ENABLE_CXX11_ABI)
+    include (extern/hdf5/hdf5.cmake)
+    include (extern/argparse/argparse.cmake)
+    include (extern/yaml-cpp/yaml-cpp.cmake)
+    include (extern/tabulate/tabulate.cmake)
+    include (extern/cpr/cpr.cmake)
+endif ()
+
+set (CMAKE_CXX_STANDARD 17)
+set (CMAKE_CXX_STANDARD_REQUIRED ON)
+
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    if (CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL 17 OR CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 17)
+        set (CMAKE_CXX_STANDARD 20)
+    endif ()
+endif ()
+
+# debug or release or sanitize
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -Werror=suggest-override")
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -O0")
+elseif (CMAKE_BUILD_TYPE STREQUAL "Release")
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -Ofast")
+elseif (CMAKE_BUILD_TYPE STREQUAL "Sanitize")
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -O2")
+endif ()
+
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-incompatible-pointer-types-discards-qualifiers")
+endif ()
+
+# code coverage configuration
+add_library (coverage_config INTERFACE)
+if (ENABLE_COVERAGE AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang" AND NOT WIN32 AND NOT APPLE)
+    target_compile_options (coverage_config INTERFACE
+        -O0
+        -g
+        --coverage
+        -fprofile-update=atomic
+    )
+    target_link_options (coverage_config INTERFACE --coverage)
+endif ()
+
+# asan
+if (ENABLE_ASAN)
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.0))
+        message (STATUS "Compiling with AddressSanitizer and UndefinedBehaviorSanitizer")
+        set (ASAN_FLAGS "-g -fsanitize=address,undefined -fno-omit-frame-pointer -fno-optimize-sibling-calls -fsanitize-recover=address -fno-sanitize=vptr")
+    else ()
+        message (STATUS "Compiling with AddressSanitizer")
+        set (ASAN_FLAGS "-g -fsanitize=address -fno-omit-frame-pointer -static-libasan")
+    endif ()
+
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${ASAN_FLAGS}")
+    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${ASAN_FLAGS}")
+    set (CMAKE_LD_FLAGS "${CMAKE_LD_FLAGS} ${ASAN_FLAGS}")
+endif ()
+
+# tsan
+if (ENABLE_TSAN)
+    if (ENABLE_ASAN)
+        message (FATAL_ERROR "ENABLE_TSAN cannot be combined with ENABLE_ASAN")
+    endif ()
+    set (CMAKE_REQUIRED_FLAGS "-fsanitize=thread")
+    set (ENV{TSAN_OPTIONS} "report_atomic_races=0")
+    add_compile_options (-fsanitize=thread)
+    add_compile_options (-g)
+    set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=thread")
+endif ()
+
+# tests
 if (ENABLE_TESTS)
-    include_directories (${PROJECT_SOURCE_DIR}/tests/fixtures)
+    include_directories(tests/fixtures/)
 endif ()
 
+# sources
 add_subdirectory (src)
 if (NOT APPLE)
     add_subdirectory (mockimpl)
@@ -57,14 +334,62 @@ endif ()
 if (ENABLE_EXAMPLES)
     add_subdirectory (examples/cpp)
 endif ()
+
 if (ENABLE_TOOLS AND ENABLE_CXX11_ABI)
     add_subdirectory (tools)
 endif ()
+
 if (ENABLE_TESTS)
     add_subdirectory (tests)
-    target_compile_definitions (vsag PRIVATE ENABLE_TESTS)
+    target_compile_definitions(vsag PRIVATE ENABLE_TESTS)
 endif ()
 
-include (cmake/VSAGPythonBindings.cmake)  # Optional Python bindings.
-include (cmake/VSAGInstall.cmake)         # Install rules.
-include (cmake/VSAGVersion.cmake)         # Generated version header target.
+# pybinds
+if (ENABLE_PYBINDS)
+    # find_package(Python3) will find the python interpreter.
+    # To use a specific python, set the CMake variable Python3_EXECUTABLE.
+    # For example: cmake -DPython3_EXECUTABLE=/usr/bin/python3 ...
+    
+    find_package (Python3 REQUIRED COMPONENTS Interpreter Development.Module)
+    
+    message(STATUS "Python3 found:")
+    message(STATUS "  Executable: ${Python3_EXECUTABLE}")
+    message(STATUS "  Version: ${Python3_VERSION}")
+    message(STATUS "  Include dirs: ${Python3_INCLUDE_DIRS}")
+    message(STATUS "  Module suffix: ${Python3_SOABI}")
+    
+  
+    include (extern/pybind11/pybind11.cmake)
+    
+    pybind11_add_module (_pyvsag python_bindings/binding.cpp)
+    target_compile_options (_pyvsag PRIVATE -fopenmp)
+    target_link_libraries (_pyvsag PRIVATE pybind11::module vsag)
+    if (NOT APPLE)
+        target_link_options(_pyvsag PRIVATE -static-libstdc++ -static-libgcc)
+    endif ()
+
+    message(STATUS "Building _pyvsag for Python ${Python3_VERSION}")
+    message(STATUS "Expected output: _pyvsag${Python3_SOABI}${CMAKE_SHARED_MODULE_SUFFIX}")
+endif ()
+
+# install
+install (DIRECTORY include/
+        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+install (TARGETS vsag
+        LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+install (TARGETS vsag_static
+        LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+if (ENABLE_TESTS AND USE_CXX11_ABI)
+    install (TARGETS test_performance
+            LIBRARY DESTINATION "${CMAKE_INSTALL_BINDIR}")
+endif ()
+
+# version
+find_package (Git)
+add_custom_target (version
+        ${CMAKE_COMMAND} -D SRC=${CMAKE_CURRENT_SOURCE_DIR}/src/version.h.in
+        -D DST=${CMAKE_CURRENT_SOURCE_DIR}/src/version.h
+        -D GIT_EXECUTABLE=${GIT_EXECUTABLE}
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/GenerateVersionHeader.cmake
+)
+add_dependencies (vsag version)

--- a/TASK.md
+++ b/TASK.md
@@ -1,0 +1,1 @@
+/home/tianlan.lht/code/workspace/agent-hive/tasks/in_progress/2026-02-05-添加-macos-asan-构建测试支持.md

--- a/cmake/DarwinDep.cmake
+++ b/cmake/DarwinDep.cmake
@@ -13,75 +13,127 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if (APPLE)
-    set (ld_flags_workaround "-Wl,-rpath,@loader_path")
+if(APPLE)
+    set(ld_flags_workaround "-Wl,-rpath,@loader_path")
     # Find OpenMP - will locate libomp on macOS
-    find_package (OpenMP REQUIRED)
+    # First try to find OpenMP normally
+    find_package(OpenMP)
+    # If not found, try to find it in common locations where libomp gets installed on macOS
+    if(NOT OpenMP_C_FOUND OR NOT OpenMP_CXX_FOUND)
+        # Common locations for libomp on macOS
+        find_path(OpenMP_C_INCLUDE_DIR
+            NAMES omp.h
+            HINTS ENV OpenMP_ROOT
+                  /opt/homebrew/opt/libomp
+                  /usr/local/opt/libomp
+            PATH_SUFFIXES include
+        )
+        
+        find_path(OpenMP_CXX_INCLUDE_DIR
+            NAMES omp.h
+            HINTS ENV OpenMP_ROOT
+                  /opt/homebrew/opt/libomp
+                  /usr/local/opt/libomp
+            PATH_SUFFIXES include
+        )
+        
+        find_library(OpenMP_C_LIBRARY
+            NAMES omp
+            HINTS ENV OpenMP_ROOT
+                  /opt/homebrew/opt/libomp
+                  /usr/local/opt/libomp
+            PATH_SUFFIXES lib
+        )
+        
+        find_library(OpenMP_CXX_LIBRARY
+            NAMES omp
+            HINTS ENV OpenMP_ROOT
+                  /opt/homebrew/opt/libomp
+                  /usr/local/opt/libomp
+            PATH_SUFFIXES lib
+        )
+        
+        if(OpenMP_C_INCLUDE_DIR AND OpenMP_CXX_INCLUDE_DIR AND OpenMP_C_LIBRARY AND OpenMP_CXX_LIBRARY)
+            set(OpenMP_C_FOUND TRUE)
+            set(OpenMP_CXX_FOUND TRUE)
+            set(OpenMP_FOUND TRUE)
+            set(OpenMP_C_FLAGS "-Xpreprocessor -fopenmp -I${OpenMP_C_INCLUDE_DIR}")
+            set(OpenMP_CXX_FLAGS "-Xpreprocessor -fopenmp -I${OpenMP_CXX_INCLUDE_DIR}")
+            set(OpenMP_C_LIB_NAMES ${OpenMP_C_LIBRARY})
+            set(OpenMP_CXX_LIB_NAMES ${OpenMP_CXX_LIBRARY})
+            set(OpenMP_LIBRARIES ${OpenMP_C_LIBRARY} ${OpenMP_CXX_LIBRARY})
+            
+            # Set the variables that CMake expects
+            set(OpenMP_C_INCLUDE_DIRS ${OpenMP_C_INCLUDE_DIR})
+            set(OpenMP_CXX_INCLUDE_DIRS ${OpenMP_CXX_INCLUDE_DIR})
+        endif()
+    endif()
+    
     if (OpenMP_CXX_FOUND)
-        message (STATUS "Found OpenMP: ${OpenMP_CXX_INCLUDE_DIRS}")
-        set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
-        set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-    endif ()
-
+        message(STATUS "Found OpenMP: ${OpenMP_CXX_INCLUDE_DIRS}")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+    else()
+        message(WARNING "OpenMP not found on macOS. Install with 'brew install libomp' for OpenMP support.")
+    endif()
+    
     # Find LAPACK - will automatically use Accelerate framework on macOS
-    find_package (LAPACK)
+    find_package(LAPACK)
     if (LAPACK_FOUND)
-        message (STATUS "Found LAPACK (using Accelerate framework on macOS)")
+        message(STATUS "Found LAPACK (using Accelerate framework on macOS)")
         # LAPACK libraries are in LAPACK_LIBRARIES variable
-    else ()
-        message (WARNING "LAPACK not found")
-    endif ()
+    else()
+        message(WARNING "LAPACK not found")
+    endif()
 
     # Find gfortran and its library path for OpenBLAS
-    find_program (GFORTRAN_EXECUTABLE NAMES gfortran)
-    if (GFORTRAN_EXECUTABLE)
-        execute_process (
+    find_program(GFORTRAN_EXECUTABLE NAMES gfortran)
+    if(GFORTRAN_EXECUTABLE)
+        execute_process(
             COMMAND ${GFORTRAN_EXECUTABLE} -print-file-name=libgfortran.dylib
             OUTPUT_VARIABLE GFORTRAN_LIB
             OUTPUT_STRIP_TRAILING_WHITESPACE
         )
-        if (EXISTS "${GFORTRAN_LIB}" AND NOT IS_DIRECTORY "${GFORTRAN_LIB}")
-            get_filename_component (GFORTRAN_LIB_DIR "${GFORTRAN_LIB}" DIRECTORY)
-            list (APPEND CMAKE_INSTALL_RPATH "${GFORTRAN_LIB_DIR}")
-        else ()
-            unset (GFORTRAN_LIB)
-            message (WARNING
-                     "gfortran found but libgfortran.dylib not found via -print-file-name; "
-                     "OpenBLAS link may fail")
-        endif ()
-    else ()
-        message (WARNING "gfortran not found; OpenBLAS/LAPACKE features may not link on macOS")
-    endif ()
+        if(EXISTS "${GFORTRAN_LIB}" AND NOT IS_DIRECTORY "${GFORTRAN_LIB}")
+            get_filename_component(GFORTRAN_LIB_DIR "${GFORTRAN_LIB}" DIRECTORY)
+            list(APPEND CMAKE_INSTALL_RPATH "${GFORTRAN_LIB_DIR}")
+        else()
+            unset(GFORTRAN_LIB)
+            message(WARNING "gfortran found but libgfortran.dylib not found via -print-file-name; OpenBLAS link may fail")
+        endif()
+    else()
+        message(WARNING "gfortran not found; OpenBLAS/LAPACKE features may not link on macOS")
+    endif()
 
     # Fixup: some scripts (e.g. OpenBLAS fallback) set BLAS_LIBRARIES/LAPACK_LIBRARIES to include
     # a bare `gfortran` token (expands to -lgfortran). On macOS libgfortran is often not in the
     # default linker search paths, causing: `ld: library 'gfortran' not found`.
-    function (vsag_darwin_fixup_blas_lapack_libs)
+    function(vsag_darwin_fixup_blas_lapack_libs)
         if (NOT APPLE)
-            return ()
-        endif ()
+            return()
+        endif()
         if (NOT DEFINED GFORTRAN_LIB OR NOT EXISTS "${GFORTRAN_LIB}")
-            return ()
-        endif ()
+            return()
+        endif()
 
-        foreach (_var BLAS_LIBRARIES LAPACK_LIBRARIES)
-            if (DEFINED ${_var})
-                set (_new_list "")
-                foreach (_item IN LISTS ${_var})
-                    if (_item STREQUAL "gfortran")
-                        list (APPEND _new_list "${GFORTRAN_LIB}")
-                    else ()
-                        list (APPEND _new_list "${_item}")
-                    endif ()
-                endforeach ()
+        foreach(_var BLAS_LIBRARIES LAPACK_LIBRARIES)
+            if(DEFINED ${_var})
+                set(_new_list "")
+                foreach(_item IN LISTS ${_var})
+                    if(_item STREQUAL "gfortran")
+                        list(APPEND _new_list "${GFORTRAN_LIB}")
+                    else()
+                        list(APPEND _new_list "${_item}")
+                    endif()
+                endforeach()
                 # Keep cache in sync so downstream includes/targets see the rewritten list.
-                set (${_var} "${_new_list}" CACHE STRING "" FORCE)
-            endif ()
-        endforeach ()
-    endfunction ()
+                set(${_var} "${_new_list}" CACHE STRING "" FORCE)
+            endif()
+        endforeach()
+    endfunction()
 
     # Run after the whole top-level configure has defined BLAS/LAPACK variables (order independent).
-    cmake_language (DEFER CALL vsag_darwin_fixup_blas_lapack_libs)
-else ()
-    set (ld_flags_workaround "-Wl,-rpath=\\$\\$ORIGIN")
-endif ()
+    cmake_language(DEFER CALL vsag_darwin_fixup_blas_lapack_libs)
+else()
+    set(ld_flags_workaround "-Wl,-rpath=\\$\\$ORIGIN")
+endif()

--- a/extern/yaml-cpp/yaml-cpp.cmake
+++ b/extern/yaml-cpp/yaml-cpp.cmake
@@ -1,25 +1,17 @@
 include (FetchContent)
 
-set (YAML_CPP_BUILD_CONTRIB OFF CACHE BOOL "Disable yaml-cpp contrib targets" FORCE)
-set (YAML_CPP_BUILD_TOOLS OFF CACHE BOOL "Disable yaml-cpp utility targets" FORCE)
-set (YAML_CPP_BUILD_TESTS OFF CACHE BOOL "Disable yaml-cpp tests" FORCE)
-
-set (yaml_cpp_urls
-    https://github.com/jbeder/yaml-cpp/archive/refs/tags/yaml-cpp-0.9.0.tar.gz
-    # this url is maintained by the vsag project, if it's broken, please try
-    #  the latest commit or contact the vsag project
-    https://vsagcache.oss-rg-china-mainland.aliyuncs.com/yaml-cpp/yaml-cpp-0.9.0.tar.gz
-)
-if (DEFINED ENV{VSAG_THIRDPARTY_YAML_CPP})
-    message (STATUS "Using local path for yaml-cpp: $ENV{VSAG_THIRDPARTY_YAML_CPP}")
-    list (PREPEND yaml_cpp_urls "$ENV{VSAG_THIRDPARTY_YAML_CPP}")
-endif ()
 FetchContent_Declare (
-    yaml-cpp
-    URL ${yaml_cpp_urls}
-    URL_HASH MD5=7d17de1b2a4b1d2776181f67c940bcdf
-    DOWNLOAD_NO_PROGRESS 1
-    INACTIVITY_TIMEOUT 5
-    TIMEOUT 30)
+        yaml-cpp
+        URL https://github.com/jbeder/yaml-cpp/archive/refs/tags/0.8.0.tar.gz
+        # this url is maintained by the vsag project, if it's broken, please try
+        #  the latest commit or contact the vsag project
+        http://vsagcache.oss-rg-china-mainland.aliyuncs.com/yaml-cpp/0.8.0.tar.gz
+        URL_HASH MD5=1d2c7975edba60e995abe3c4af6480e5
+        DOWNLOAD_NO_PROGRESS 1
+        INACTIVITY_TIMEOUT 5
+        TIMEOUT 30
+        CMAKE_ARGS -DCMAKE_POLICY_DEFAULT_CMP0048=NEW
+)
 
 FetchContent_MakeAvailable (yaml-cpp)
+include_directories (${yaml-cpp_SOURCE_DIR}/include)

--- a/scripts/deps/install_deps_macos.sh
+++ b/scripts/deps/install_deps_macos.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[install_deps_macos] Starting macOS dependency installation..."
+
+# Ensure Homebrew exists
+if ! command -v brew >/dev/null 2>&1; then
+  echo "Homebrew not found. Installing Homebrew..."
+  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+  # Attempt to add brew to PATH for both Intel and Apple Silicon
+  if [ -d "/opt/homebrew/bin" ]; then
+    eval "$(/opt/homebrew/bin/brew shellenv)" || true
+  elif [ -d "/usr/local/bin" ]; then
+    eval "$(/usr/local/bin/brew shellenv)" || true
+  fi
+fi
+
+brew update || true
+
+# Packages required for building and running tests on macOS
+# Add gcc (for gfortran), openblas (BLAS/LAPACK), lcov (coverage), hdf5, curl
+packages=(cmake ninja libomp pkg-config gcc openblas lcov hdf5 curl)
+for pkg in "${packages[@]}"; do
+  if brew list "$pkg" >/dev/null 2>&1; then
+    echo "[install_deps_macos] $pkg already installed"
+  else
+    echo "[install_deps_macos] Installing $pkg"
+    brew install "$pkg" || true
+  fi
+done
+
+# Optional: ensure cmake and ninja are on PATH (they should be via Homebrew)
+command -v cmake >/dev/null 2>&1 || { echo "cmake not found after install"; }
+command -v ninja >/dev/null 2>&1 || { echo "ninja not found after install"; }
+
+echo "[install_deps_macos] Done."


### PR DESCRIPTION
- Add scripts/deps/install_deps_macos.sh to install macOS dependencies via Homebrew (cmake, ninja, libomp, pkg-config, gcc/gfortran, openblas, lcov, hdf5, curl).
- Update .github/workflows/asan_build_and_test.yml and .github/workflows/daily_test.yml:
  - Add build_asan_macos, test_asan_macos, test_example_macos jobs; call installer script; upload test_macos artifact; include macOS in cleanup.
  - Add daily_build_asan_macos and daily_test_asan_macos to daily workflow.
- Note: macOS runners may be Intel or Apple Silicon; ASAN behavior differs on macOS and may require suppression or other adjustments.