### PR TITLE
refactor(smart_pointer): replace shared_ptr with unique_ptr for better performance

### DIFF
--- a/src/algorithm/pyramid.h
+++ b/src/algorithm/pyramid.h
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include <memory>
 #include <utility>
 
 #include "datacell/graph_interface.h"
@@ -62,7 +63,7 @@ public:
     void
     AddChild(const std::string& key);
 
-    std::shared_ptr<IndexNode>
+    IndexNode*
     GetChild(const std::string& key, bool need_init = false);
 
     void
@@ -82,7 +83,7 @@ public:
     Status status_{Status::NO_INDEX};
 
 private:
-    UnorderedMap<std::string, std::shared_ptr<IndexNode>> children_;
+    UnorderedMap<std::string, std::unique_ptr<IndexNode>> children_;
     Allocator* allocator_{nullptr};
     GraphInterfaceParamPtr graph_param_{nullptr};
 };
@@ -107,7 +108,7 @@ public:
         label_table_->compress_duplicate_data_ = pyramid_param->support_duplicate;
         base_codes_ = FlattenInterface::MakeInstance(pyramid_param->base_codes_param, common_param);
         root_ =
-            std::make_shared<IndexNode>(allocator_, pyramid_param->graph_param, index_min_size_);
+            std::make_unique<IndexNode>(allocator_, pyramid_param->graph_param, index_min_size_);
         points_mutex_ = std::make_shared<PointsMutex>(max_capacity_, allocator_);
         searcher_ = std::make_unique<BasicSearcher>(common_param, points_mutex_);
         no_build_levels_.assign(pyramid_param->no_build_levels.begin(),
@@ -209,9 +210,7 @@ private:
     build_by_odescent(const DatasetPtr& base);
 
     void
-    add_one_point(const std::shared_ptr<IndexNode>& node,
-                  InnerIdType inner_id,
-                  const float* vector);
+    add_one_point(IndexNode* node, InnerIdType inner_id, const float* vector);
 
     static std::vector<std::vector<std::string>>
     parse_path(const std::string& path);
@@ -230,7 +229,7 @@ private:
     Vector<int32_t> no_build_levels_;
     uint64_t ef_construction_{400};
     int64_t max_degree_{64};
-    std::shared_ptr<IndexNode> root_{nullptr};
+    std::unique_ptr<IndexNode> root_{nullptr};
     FlattenInterfacePtr base_codes_{nullptr};
     FlattenInterfacePtr precise_codes_{nullptr};
     std::unique_ptr<VisitedListPool> pool_ = nullptr;

--- a/src/datacell/sparse_vector_datacell_test.cpp
+++ b/src/datacell/sparse_vector_datacell_test.cpp
@@ -75,9 +75,9 @@ TEST_CASE("SparseDataCell Basic Test", "[ut][SparseDataCell] ") {
     auto query_sparse_vectors = fixtures::GenerateSparseVectors(1, 100);
     SECTION("accuracy") {
         auto computer = data_cell->FactoryComputer(query_sparse_vectors.data());
-        std::shared_ptr<float[]> dist = std::shared_ptr<float[]>(new float[base_count]);
-        data_cell->Query(dist.get(), computer, idx.data(), 1);
-        data_cell->Query(dist.get() + 1, computer, idx.data() + 1, base_count - 1);
+        std::vector<float> dist(base_count);
+        data_cell->Query(dist.data(), computer, idx.data(), 1);
+        data_cell->Query(dist.data() + 1, computer, idx.data() + 1, base_count - 1);
         for (int i = 0; i < base_count; ++i) {
             fixtures::dist_t distance =
                 fixtures::GetSparseDistance(query_sparse_vectors[0], sparse_vectors[i]);
@@ -88,9 +88,9 @@ TEST_CASE("SparseDataCell Basic Test", "[ut][SparseDataCell] ") {
         auto new_data_cell = FlattenInterface::MakeInstance(param, index_common_param);
         test_serializion(*data_cell, *new_data_cell);
         auto computer = new_data_cell->FactoryComputer(query_sparse_vectors.data());
-        std::shared_ptr<float[]> dist = std::shared_ptr<float[]>(new float[base_count]);
-        new_data_cell->Query(dist.get(), computer, idx.data(), 1);
-        new_data_cell->Query(dist.get() + 1, computer, idx.data() + 1, base_count - 1);
+        std::vector<float> dist(base_count);
+        new_data_cell->Query(dist.data(), computer, idx.data(), 1);
+        new_data_cell->Query(dist.data() + 1, computer, idx.data() + 1, base_count - 1);
         for (int i = 0; i < base_count; ++i) {
             fixtures::dist_t distance =
                 fixtures::GetSparseDistance(query_sparse_vectors[0], sparse_vectors[i]);
@@ -160,9 +160,9 @@ TEST_CASE("SparseDataCell Concurrent Test", "[ut][SparseDataCell][concurrent] ")
     auto query_sparse_vectors = fixtures::GenerateSparseVectors(1, 100);
     SECTION("accuracy") {
         auto computer = data_cell->FactoryComputer(query_sparse_vectors.data());
-        std::shared_ptr<float[]> dist = std::shared_ptr<float[]>(new float[base_count]);
-        data_cell->Query(dist.get(), computer, idx.data(), 1);
-        data_cell->Query(dist.get() + 1, computer, idx.data() + 1, base_count - 1);
+        std::vector<float> dist(base_count);
+        data_cell->Query(dist.data(), computer, idx.data(), 1);
+        data_cell->Query(dist.data() + 1, computer, idx.data() + 1, base_count - 1);
         for (int i = 0; i < base_count; ++i) {
             fixtures::dist_t distance =
                 fixtures::GetSparseDistance(query_sparse_vectors[0], sparse_vectors[i]);

--- a/src/index/hnsw.cpp
+++ b/src/index/hnsw.cpp
@@ -1019,10 +1019,10 @@ HNSW::pretrain(const std::vector<int64_t>& base_tag_ids,
     } else {
         data_size = dim_ * 4;
     }
-    std::shared_ptr<int8_t[]> base_data(new int8_t[data_size]);
-    std::shared_ptr<int8_t[]> topk_data(new int8_t[data_size]);
+    std::unique_ptr<int8_t[]> base_data(new int8_t[data_size]);
+    std::unique_ptr<int8_t[]> topk_data(new int8_t[data_size]);
 
-    std::shared_ptr<int8_t[]> generated_data(new int8_t[data_size]);
+    std::unique_ptr<int8_t[]> generated_data(new int8_t[data_size]);
     set_dataset(type_, dim_, generated_query, generated_data.get(), 1);
 
     for (const int64_t& base_tag_id : base_tag_ids) {

--- a/src/index/hnsw_test.cpp
+++ b/src/index/hnsw_test.cpp
@@ -949,13 +949,13 @@ TEST_CASE("get data by label", "[ut][hnsw]") {
     SECTION("hnsw test") {
         DefaultAllocator allocator;
         auto* alg_hnsw = new hnswlib::HierarchicalNSW(&space, 100, &allocator);
-        std::shared_ptr<int8_t[]> base_data(new int8_t[dim * sizeof(float)]);
+        std::vector<int8_t> base_data(dim * sizeof(float));
         alg_hnsw->init_memory_space();
         alg_hnsw->addPoint(base_vectors.data(), 0);
         fixtures::dist_t distance = alg_hnsw->getDistanceByLabel(0, alg_hnsw->getDataByLabel(0));
 
-        alg_hnsw->copyDataByLabel(0, base_data.get());
-        fixtures::dist_t distance_validate = alg_hnsw->getDistanceByLabel(0, base_data.get());
+        alg_hnsw->copyDataByLabel(0, base_data.data());
+        fixtures::dist_t distance_validate = alg_hnsw->getDistanceByLabel(0, base_data.data());
 
         REQUIRE(distance == 0);
         REQUIRE(distance == distance_validate);
@@ -966,15 +966,15 @@ TEST_CASE("get data by label", "[ut][hnsw]") {
     SECTION("static hnsw test") {
         DefaultAllocator allocator;
         auto* alg_hnsw_static = new hnswlib::StaticHierarchicalNSW(&space, 100, &allocator);
-        std::shared_ptr<int8_t[]> base_data(new int8_t[dim * sizeof(float)]);
+        std::vector<int8_t> base_data(dim * sizeof(float));
         alg_hnsw_static->init_memory_space();
         alg_hnsw_static->addPoint(base_vectors.data(), 0);
         fixtures::dist_t distance =
             alg_hnsw_static->getDistanceByLabel(0, alg_hnsw_static->getDataByLabel(0));
 
-        alg_hnsw_static->copyDataByLabel(0, base_data.get());
+        alg_hnsw_static->copyDataByLabel(0, base_data.data());
         fixtures::dist_t distance_validate =
-            alg_hnsw_static->getDistanceByLabel(0, base_data.get());
+            alg_hnsw_static->getDistanceByLabel(0, base_data.data());
 
         REQUIRE(distance == 0);
         REQUIRE(distance == distance_validate);


### PR DESCRIPTION
- Convert IndexNode children storage from shared_ptr to unique_ptr in pyramid
- Change root_ from shared_ptr to unique_ptr in Pyramid class
- Update GetChild and add_one_point methods to use raw pointers
- Replace shared_ptr<int8_t[]> with unique_ptr<int8_t[]> in hnsw.cpp
- Replace shared_ptr<float[]> with vector<float> in sparse_vector_datacell_test.cpp

This refactoring eliminates unnecessary reference counting overhead and improves memory efficiency. The ownership semantics remain clear with unique_ptr providing exclusive ownership.