### PR TITLE
feat(io): add Resize API for efficient storage allocation

### DIFF
--- a/src/datacell/extra_info_datacell.h
+++ b/src/datacell/extra_info_datacell.h
@@ -54,9 +54,7 @@ public:
         this->max_capacity_ = new_capacity;
         uint64_t io_size =
             static_cast<uint64_t>(new_capacity) * static_cast<uint64_t>(extra_info_size_);
-        uint8_t end_flag =
-            127;  // the value is meaningless, only to occupy the position for io allocate
-        this->io_->Write(&end_flag, 1, io_size);
+        this->io_->Resize(io_size);
     }
 
     void

--- a/src/datacell/flatten_datacell.h
+++ b/src/datacell/flatten_datacell.h
@@ -92,9 +92,7 @@ public:
         }
         this->max_capacity_ = new_capacity;
         uint64_t io_size = static_cast<uint64_t>(new_capacity) * static_cast<uint64_t>(code_size_);
-        uint8_t end_flag =
-            127;  // the value is meaningless, only to occupy the position for io allocate
-        this->io_->Write(&end_flag, 1, io_size);
+        this->io_->Resize(io_size);
     }
 
     void

--- a/src/datacell/graph_datacell.h
+++ b/src/datacell/graph_datacell.h
@@ -264,9 +264,7 @@ GraphDataCell<IOTmpl>::Resize(InnerIdType new_size) {
     }
     this->max_capacity_ = new_size;
     uint64_t io_size = static_cast<uint64_t>(new_size) * static_cast<uint64_t>(code_line_size_);
-    uint8_t end_flag =
-        127;  // the value is meaningless, only to occupy the position for io allocate
-    this->io_->Write(&end_flag, 1, io_size);
+    this->io_->Resize(io_size);
 }
 
 template <typename IOTmpl>

--- a/src/datacell/sparse_vector_datacell.h
+++ b/src/datacell/sparse_vector_datacell.h
@@ -80,10 +80,8 @@ public:
         }
         uint64_t io_size = (new_capacity - total_count_) * max_code_size_ + current_offset_;
         this->max_capacity_ = new_capacity;
-        uint8_t end_flag =
-            127;  // the value is meaingless, only to occupy the position for io allocate
-        this->io_->Write(&end_flag, 1, io_size);
-        this->offset_io_->Write(&end_flag, 1, new_capacity * sizeof(uint32_t));
+        this->io_->Resize(io_size);
+        this->offset_io_->Resize(static_cast<uint64_t>(new_capacity) * sizeof(uint32_t));
     }
 
     void

--- a/src/io/async_io.cpp
+++ b/src/io/async_io.cpp
@@ -81,6 +81,19 @@ AsyncIO::WriteImpl(const uint8_t* data, uint64_t size, uint64_t offset) {
     fsync(wfd_);
 }
 
+void
+AsyncIO::ResizeImpl(uint64_t size) {
+#ifdef __APPLE__
+    auto ret = ftruncate(this->wfd_, static_cast<off_t>(size));
+#else
+    auto ret = ftruncate64(this->wfd_, static_cast<int64_t>(size));
+#endif
+    if (ret == -1) {
+        throw VsagException(ErrorType::INTERNAL_ERROR, "ftruncate failed");
+    }
+    this->size_ = size;
+}
+
 bool
 AsyncIO::ReadImpl(uint64_t size, uint64_t offset, uint8_t* data) const {
     bool need_release = true;

--- a/src/io/async_io.h
+++ b/src/io/async_io.h
@@ -40,6 +40,9 @@ public:
     void
     WriteImpl(const uint8_t* data, uint64_t size, uint64_t offset);
 
+    void
+    ResizeImpl(uint64_t size);
+
     bool
     ReadImpl(uint64_t size, uint64_t offset, uint8_t* data) const;
 

--- a/src/io/basic_io.h
+++ b/src/io/basic_io.h
@@ -218,6 +218,24 @@ public:
         }
     }
 
+    inline void
+    Resize(uint64_t size) {
+        if constexpr (has_ResizeImpl<IOTmpl>::value) {
+            return cast().ResizeImpl(size);
+        } else {
+            if (size <= this->size_) {
+                return;
+            }
+            ByteBuffer buffer(SERIALIZE_BUFFER_SIZE, this->allocator_);
+            uint64_t offset = this->size_;
+            while (offset < size) {
+                auto cur_size = std::min(SERIALIZE_BUFFER_SIZE, size - offset);
+                this->Write(buffer.data, cur_size, offset);
+                offset += cur_size;
+            }
+        }
+    }
+
     inline int64_t
     GetMemoryUsage() const {
         return this->size_;
@@ -314,5 +332,6 @@ private:
                                  std::declval<uint64_t>())
     GENERATE_HAS_MEMBER_FUNCTION(ReleaseImpl, void, std::declval<const uint8_t*>())
     GENERATE_HAS_MEMBER_FUNCTION(InitIOImpl, void, std::declval<const IOParamPtr&>())
+    GENERATE_HAS_MEMBER_FUNCTION(ResizeImpl, void, std::declval<uint64_t>())
 };
 }  // namespace vsag

--- a/src/io/buffer_io.cpp
+++ b/src/io/buffer_io.cpp
@@ -58,6 +58,19 @@ BufferIO::WriteImpl(const uint8_t* data, uint64_t size, uint64_t offset) {
     }
 }
 
+void
+BufferIO::ResizeImpl(uint64_t size) {
+#ifdef __APPLE__
+    auto ret = ftruncate(this->fd_, static_cast<off_t>(size));
+#else
+    auto ret = ftruncate64(this->fd_, static_cast<int64_t>(size));
+#endif
+    if (ret == -1) {
+        throw VsagException(ErrorType::INTERNAL_ERROR, "ftruncate failed");
+    }
+    this->size_ = size;
+}
+
 bool
 BufferIO::ReadImpl(uint64_t size, uint64_t offset, uint8_t* data) const {
     if (size == 0) {

--- a/src/io/buffer_io.h
+++ b/src/io/buffer_io.h
@@ -48,6 +48,9 @@ public:
     void
     WriteImpl(const uint8_t* data, uint64_t size, uint64_t offset);
 
+    void
+    ResizeImpl(uint64_t size);
+
     bool
     ReadImpl(uint64_t size, uint64_t offset, uint8_t* data) const;
 

--- a/src/io/memory_block_io.h
+++ b/src/io/memory_block_io.h
@@ -39,6 +39,9 @@ public:
     void
     WriteImpl(const uint8_t* data, uint64_t size, uint64_t offset);
 
+    void
+    ResizeImpl(uint64_t size);
+
     bool
     ReadImpl(uint64_t size, uint64_t offset, uint8_t* data) const;
 

--- a/src/io/memory_io.cpp
+++ b/src/io/memory_io.cpp
@@ -23,6 +23,16 @@ MemoryIO::WriteImpl(const uint8_t* data, uint64_t size, uint64_t offset) {
     memcpy(start_ + offset, data, size);
 }
 
+void
+MemoryIO::ResizeImpl(uint64_t size) {
+    if (size <= this->size_) {
+        this->size_ = size;
+        return;
+    }
+    check_and_realloc(size);
+    this->size_ = size;
+}
+
 bool
 MemoryIO::ReadImpl(uint64_t size, uint64_t offset, uint8_t* data) const {
     bool ret = check_valid_offset(size + offset);

--- a/src/io/memory_io.h
+++ b/src/io/memory_io.h
@@ -49,6 +49,9 @@ public:
     void
     WriteImpl(const uint8_t* data, uint64_t size, uint64_t offset);
 
+    void
+    ResizeImpl(uint64_t size);
+
     bool
     ReadImpl(uint64_t size, uint64_t offset, uint8_t* data) const;
 

--- a/src/io/mmap_io.h
+++ b/src/io/mmap_io.h
@@ -40,6 +40,9 @@ public:
     void
     WriteImpl(const uint8_t* data, uint64_t size, uint64_t offset);
 
+    void
+    ResizeImpl(uint64_t size);
+
     bool
     ReadImpl(uint64_t size, uint64_t offset, uint8_t* data) const;
 


### PR DESCRIPTION
- Add Resize() method to basic_io.h with ResizeImpl support via SFINAE
- Implement ResizeImpl for async_io, buffer_io, and memory_block_io
- Replace Write-based expansion hack with Resize in datacell classes
- Add null pointer check for memory_block_io allocation