### PR TITLE
fix(hnsw): fix concurrent access to max_level_ in HNSW search operations

### DIFF
--- a/src/algorithm/hnswlib/hnswalg.cpp
+++ b/src/algorithm/hnswlib/hnswalg.cpp
@@ -1658,9 +1658,11 @@ HierarchicalNSW::searchKnn(const void* query_data,
                                                         iter_ctx);
     } else {
         int64_t currObj;
+        int max_level_copy;
         {
             std::shared_lock data_loc(max_level_mutex_);
             currObj = enterpoint_node_;
+            max_level_copy = max_level_;
         }
         if (currObj > cur_element_count_) {
             return result;
@@ -1668,7 +1670,7 @@ HierarchicalNSW::searchKnn(const void* query_data,
 
         float curdist = fstdistfunc_(query_data, getDataByInternalId(currObj), dist_func_param_);
         std::shared_ptr<char[]> link_data = std::shared_ptr<char[]>(new char[size_links_level0_]);
-        for (int level = max_level_; level > 0; level--) {
+        for (int level = max_level_copy; level > 0; level--) {
             bool changed = true;
             while (changed) {
                 changed = false;
@@ -1747,14 +1749,16 @@ HierarchicalNSW::searchRange(const void* query_data,
     std::shared_ptr<float[]> normalize_query;
     normalizeVector(query_data, normalize_query);
     int64_t currObj;
+    int max_level_copy;
     {
         std::shared_lock data_loc(max_level_mutex_);
         currObj = enterpoint_node_;
+        max_level_copy = max_level_;
     }
     float curdist = fstdistfunc_(query_data, getDataByInternalId(currObj), dist_func_param_);
 
     std::shared_ptr<char[]> link_data = std::shared_ptr<char[]>(new char[size_links_level0_]);
-    for (int level = max_level_; level > 0; level--) {
+    for (int level = max_level_copy; level > 0; level--) {
         bool changed = true;
         while (changed) {
             changed = false;


### PR DESCRIPTION
Fixed race condition where max_level_ was accessed outside the protection of max_level_mutex_ in searchKnn() and searchRange() functions.

The issue occurred when:
1. A search thread reads max_level_ without holding the lock
2. An add thread concurrently increases max_level_ and adds new nodes
3. The search thread may traverse uninitialized or invalid node IDs, causing 'cand error' exceptions

Changes:
- In searchKnn(): Read max_level_ inside the lock scope into a local copy
- In searchRange(): Read max_level_ inside the lock scope into a local copy

This ensures both enterpoint_node_ and max_level_ are read atomically under the same lock protection, preventing inconsistent state.

Fixes: cand error in concurrent add/search scenarios