### PR TITLE
fix(memory_usage): conditionally call cal_memory_usage only on actual capacity changes

### DIFF
--- a/src/algorithm/brute_force.cpp
+++ b/src/algorithm/brute_force.cpp
@@ -621,8 +621,8 @@ BruteForce::resize(uint64_t new_size) {
     if (cur_size < new_size_power_2) {
         this->inner_codes_->Resize(new_size_power_2);
         this->max_capacity_.store(new_size_power_2);
+        this->cal_memory_usage();
     }
-    this->cal_memory_usage();
 }
 
 void

--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -1634,8 +1634,8 @@ HGraph::resize(uint64_t new_size) {
             this->extra_infos_->Resize(new_size_power_2);
         }
         this->max_capacity_.store(new_size_power_2);
+        this->cal_memory_usage();
     }
-    this->cal_memory_usage();
 }
 void
 HGraph::InitFeatures() {

--- a/src/algorithm/sindi/sindi.cpp
+++ b/src/algorithm/sindi/sindi.cpp
@@ -87,12 +87,14 @@ SINDI::Add(const DatasetPtr& base, AddMode mode) {
 
     // adjust window
     int64_t final_add_window = align_up(cur_element_count_ + data_num, window_size_) / window_size_;
+    bool window_changed = false;
     while (window_term_list_.size() < final_add_window) {
         window_term_list_.emplace_back(std::make_shared<SparseTermDataCell>(doc_retain_ratio_,
                                                                             term_id_limit_,
                                                                             allocator_,
                                                                             use_quantization_,
                                                                             quantization_params_));
+        window_changed = true;
     }
 
     // add process
@@ -144,7 +146,9 @@ SINDI::Add(const DatasetPtr& base, AddMode mode) {
             rerank_flat_index_->Add(single_base);
         }
     }
-    this->cal_memory_usage();
+    if (window_changed) {
+        this->cal_memory_usage();
+    }
     return failed_ids;
 }
 


### PR DESCRIPTION
fixes: #1582 

Previously cal_memory_usage() was called unconditionally in resize() and Add() methods, even when no actual capacity or window changes occurred. This caused unnecessary memory usage recalculations. Now it's only invoked when:
- resize() actually increases capacity (brute_force, hgraph)
- Add() actually creates new windows (sindi)