### PR TITLE
feat(pyramid): move topk_factor to IndexSearchParameter base class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,4 @@ data/
 /dist/
 opencode.json
 _codeql_detected_source_root
+wheelhouse/

--- a/extern/mkl/mkl.cmake
+++ b/extern/mkl/mkl.cmake
@@ -111,9 +111,7 @@ if (CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64" AND ENABLE_INTEL_MKL)
 
        
         set(BLAS_LIBRARIES
-            "${MKL_PATH}/libmkl_intel_lp64.so"
-            "${MKL_PATH}/libmkl_intel_thread.so"
-            "${MKL_PATH}/libmkl_core.so"
+            "${MKL_PATH}/libmkl_rt.so"
             "${OMP_PATH}/libiomp5.so"
         )
 

--- a/scripts/python/build_cpp_for_cibw.sh
+++ b/scripts/python/build_cpp_for_cibw.sh
@@ -31,7 +31,7 @@ rm -rf python/pyvsag/*.so python/pyvsag/*.so.*
 echo "=== Configuring CMake ==="
 cmake -S. -B$CMAKE_BUILD_DIR \
     -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_CXX_FLAGS_RELEASE="-O3 -DNDEBUG -s" \
+    -DCMAKE_CXX_FLAGS_RELEASE="-O3 -DNDEBUG" \
     -DENABLE_PYBINDS=ON \
     -DENABLE_TESTS=OFF \
     -DPython3_EXECUTABLE="$PYTHON_EXECUTABLE" \

--- a/scripts/python/local_build_wheel.sh
+++ b/scripts/python/local_build_wheel.sh
@@ -53,7 +53,7 @@ echo "✅ Detected local architecture: $ARCH"
 cleanup() {
   echo "🧹 Cleaning up and restoring files..."
   # Use git to restore the patched files, which is safer than using .bak files
-  git restore python/pyproject.toml python/setup.py
+  git checkout -- python/pyproject.toml python/setup.py
   rm -f python/pyvsag/_version.py
   echo "✅ Cleanup complete."
 }

--- a/src/algorithm/hgraph_parameter.cpp
+++ b/src/algorithm/hgraph_parameter.cpp
@@ -204,10 +204,6 @@ HGraphSearchParameters::FromJson(const std::string& json_string) {
             params[INDEX_TYPE_HGRAPH][HGRAPH_USE_EXTRA_INFO_FILTER].GetBool();
     }
 
-    if (params[INDEX_TYPE_HGRAPH].Contains(SEARCH_PARAM_FACTOR)) {
-        obj.topk_factor = params[INDEX_TYPE_HGRAPH][SEARCH_PARAM_FACTOR].GetFloat();
-    }
-
     return obj;
 }
 }  // namespace vsag

--- a/src/algorithm/hgraph_parameter.h
+++ b/src/algorithm/hgraph_parameter.h
@@ -75,7 +75,6 @@ public:
 
 public:
     int64_t ef_search{30};
-    float topk_factor{0.0F};
     bool use_reorder{false};
     bool use_extra_info_filter{false};
 

--- a/src/algorithm/index_search_parameter.h
+++ b/src/algorithm/index_search_parameter.h
@@ -37,6 +37,10 @@ public:
             timeout_ms = json[SEARCH_MAX_TIME_COST_MS].GetInt();
             enable_time_record = true;
         }
+
+        if (json.Contains(SEARCH_PARAM_FACTOR)) {
+            topk_factor = json[SEARCH_PARAM_FACTOR].GetFloat();
+        }
     }
 
 public:
@@ -45,5 +49,8 @@ public:
     // for timeout
     double timeout_ms{std::numeric_limits<double>::max()};
     bool enable_time_record{false};
+
+    // for reorder, controls the number of candidates to reorder
+    float topk_factor{0.0F};
 };
 }  // namespace vsag

--- a/src/algorithm/ivf.cpp
+++ b/src/algorithm/ivf.cpp
@@ -467,6 +467,9 @@ IVF::KnnSearch(const DatasetPtr& query,
     param.search_mode = KNN_SEARCH;
     param.topk = k;
     if (use_reorder_) {
+        CHECK_ARGUMENT(
+            param.factor > 0.0F,
+            fmt::format("factor must be positive when use_reorder is true, got {}", param.factor));
         param.topk = static_cast<int64_t>(param.factor * static_cast<float>(k));
     }
     auto search_result = this->search<KNN_SEARCH>(query, param, ctx);
@@ -500,6 +503,9 @@ IVF::RangeSearch(const DatasetPtr& query,
     param.radius = radius;
     param.range_search_limit_size = static_cast<int>(limited_size);
     if (use_reorder_ and limited_size > 0) {
+        CHECK_ARGUMENT(
+            param.factor > 0.0F,
+            fmt::format("factor must be positive when use_reorder is true, got {}", param.factor));
         param.range_search_limit_size =
             static_cast<int>(param.factor * static_cast<float>(limited_size));
     }
@@ -960,6 +966,9 @@ IVF::SearchWithRequest(const SearchRequest& request) const {
     param.search_mode = KNN_SEARCH;
     param.topk = request.topk_;
     if (use_reorder_) {
+        CHECK_ARGUMENT(
+            param.factor > 0.0F,
+            fmt::format("factor must be positive when use_reorder is true, got {}", param.factor));
         param.topk = static_cast<int64_t>(param.factor * static_cast<float>(request.topk_));
     }
     auto query = request.query_;

--- a/src/algorithm/ivf_parameter.cpp
+++ b/src/algorithm/ivf_parameter.cpp
@@ -113,6 +113,7 @@ IVFSearchParameters::FromJson(const std::string& json_string) {
         obj.first_order_scan_ratio =
             params[INDEX_TYPE_IVF][GNO_IMI_SEARCH_PARAM_FIRST_ORDER_SCAN_RATIO].GetFloat();
     }
+
     return obj;
 }
 }  // namespace vsag

--- a/src/algorithm/ivf_parameter.cpp
+++ b/src/algorithm/ivf_parameter.cpp
@@ -108,11 +108,6 @@ IVFSearchParameters::FromJson(const std::string& json_string) {
                                IVF_SEARCH_PARAM_SCAN_BUCKETS_COUNT));
     obj.scan_buckets_count = params[INDEX_TYPE_IVF][IVF_SEARCH_PARAM_SCAN_BUCKETS_COUNT].GetInt();
 
-    // set obj.topk_factor
-    if (params[INDEX_TYPE_IVF].Contains(SEARCH_PARAM_FACTOR)) {
-        obj.topk_factor = params[INDEX_TYPE_IVF][SEARCH_PARAM_FACTOR].GetFloat();
-    }
-
     // set obj.first_order_scan_ratio
     if (params[INDEX_TYPE_IVF].Contains(GNO_IMI_SEARCH_PARAM_FIRST_ORDER_SCAN_RATIO)) {
         obj.first_order_scan_ratio =

--- a/src/algorithm/ivf_parameter.h
+++ b/src/algorithm/ivf_parameter.h
@@ -56,7 +56,6 @@ public:
 
 public:
     int64_t scan_buckets_count{30};
-    float topk_factor{2.0F};
     float first_order_scan_ratio{1.0F};
 
 private:

--- a/src/algorithm/ivf_parameter.h
+++ b/src/algorithm/ivf_parameter.h
@@ -59,7 +59,9 @@ public:
     float first_order_scan_ratio{1.0F};
 
 private:
-    IVFSearchParameters() = default;
+    IVFSearchParameters() {
+        topk_factor = 2.0F;  // IVF default factor is 2.0
+    }
 };
 
 }  // namespace vsag

--- a/tests/python/test_ivf.py
+++ b/tests/python/test_ivf.py
@@ -56,8 +56,7 @@ class TestIVF(TestBase):
                     "ivf_train_type": "kmeans",
                     "base_quantization_type": self.base_quantization_type,
                     "precise_quantization_type": self.precise_quantization_type,
-                    "use_reorder": self.use_reorder,
-                    "factor": 2
+                    "use_reorder": self.use_reorder
                 },
             }
         )
@@ -69,7 +68,7 @@ class TestIVF(TestBase):
 
     def general_test_search(self):
         """Test search index"""
-        search_params = json.dumps({"ivf": {"scan_buckets_count": 50}})
+        search_params = json.dumps({"ivf": {"scan_buckets_count": 50, "factor": 4.0}})
         TestBase.TestKnnSearch(self.index, self.dataset, search_params)
 
     def test_build(self):

--- a/tests/python/test_ivf.py
+++ b/tests/python/test_ivf.py
@@ -57,6 +57,7 @@ class TestIVF(TestBase):
                     "base_quantization_type": self.base_quantization_type,
                     "precise_quantization_type": self.precise_quantization_type,
                     "use_reorder": self.use_reorder,
+                    "factor": 2
                 },
             }
         )


### PR DESCRIPTION
- Extract topk_factor from HGraphSearchParameters and IVFSearchParameters
- Add topk_factor to IndexSearchParameter for inheritance by all search parameters
- Implement topk_factor support in Pyramid search to control reorder ratio
- When topk_factor > 1.0, reorder_limit = limit * topk_factor