### PR TITLE
feat(index): add ShrinkAndRepair API with timeout

### DIFF
--- a/include/vsag/index.h
+++ b/include/vsag/index.h
@@ -175,9 +175,10 @@ public:
      * @brief 
      *  1. Shrink the index to release memory occupied by soft deleted vectors.
      *  2. Repair the index which is corrupted by soft delete.
+     * @param timeout_ms is the timeout in milliseconds for the shrink and repair operation
      */
-    virtual void
-    ShrinkAndRepair() {
+    virtual tl::expected<void, Error>
+    ShrinkAndRepair(double timeout_ms = std::numeric_limits<double>::max()) {
         throw std::runtime_error("Index not support ShrinkAndRepair");
     }
 

--- a/src/algorithm/hgraph.h
+++ b/src/algorithm/hgraph.h
@@ -178,6 +178,9 @@ public:
     Remove(const std::vector<int64_t>& ids, RemoveMode mode = RemoveMode::MARK_REMOVE) override;
 
     void
+    ShrinkAndRepair(double timeout_ms = std::numeric_limits<double>::max()) override{};
+
+    void
     Serialize(StreamWriter& writer) const override;
 
     void

--- a/src/algorithm/inner_index_interface.h
+++ b/src/algorithm/inner_index_interface.h
@@ -356,6 +356,12 @@ public:
         return this->Remove(std::vector<int64_t>({id}), mode);
     }
 
+    virtual void
+    ShrinkAndRepair(double timeout_ms = std::numeric_limits<double>::max()) {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "Index doesn't support ShrinkAndRepair");
+    }
+
     [[nodiscard]] virtual DatasetPtr
     SearchWithRequest(const SearchRequest& request) const {
         throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,

--- a/src/index/index_impl.h
+++ b/src/index/index_impl.h
@@ -408,6 +408,12 @@ public:
         SAFE_CALL(return this->inner_index_->Remove(ids, mode));
     }
 
+    tl::expected<void, Error>
+    ShrinkAndRepair(double timeout_ms = std::numeric_limits<double>::max()) override {
+        CHECK_IMMUTABLE_INDEX("shrink and repair");
+        SAFE_CALL(this->inner_index_->ShrinkAndRepair(timeout_ms));
+    }
+
     [[nodiscard]] tl::expected<BinarySet, Error>
     Serialize() const override {
         SAFE_CALL(return this->inner_index_->Serialize());


### PR DESCRIPTION
Introduce ShrinkAndRepair(double timeout_ms = ...) to the public index API and switch the return to tl::expected<void, Error> for structured error handling.