### PR TITLE
feat: replace CPR with cpp-httplib and add HTTP monitor server

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,7 +256,7 @@ if (ENABLE_TOOLS AND ENABLE_CXX11_ABI)
     include (extern/argparse/argparse.cmake)
     include (extern/yaml-cpp/yaml-cpp.cmake)
     include (extern/tabulate/tabulate.cmake)
-    include (extern/cpr/cpr.cmake)
+    include (extern/httplib/httplib.cmake)
 endif ()
 
 set (CMAKE_CXX_STANDARD 17)

--- a/extern/httplib/httplib.cmake
+++ b/extern/httplib/httplib.cmake
@@ -1,0 +1,44 @@
+
+# Copyright 2024-present the vsag project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include(FetchContent)
+
+# cpp-httplib is a header-only library, we only need the main header
+set(httplib_urls
+    https://github.com/yhirose/cpp-httplib/archive/refs/tags/v0.35.0.tar.gz
+    https://vsagcache.oss-rg-china-mainland.aliyuncs.com/cpp-httplib/v0.35.0.tar.gz
+)
+
+if(DEFINED ENV{VSAG_THIRDPARTY_HTTPLIB})
+  message(STATUS "Using local path for httplib: $ENV{VSAG_THIRDPARTY_HTTPLIB}")
+  list(PREPEND httplib_urls "$ENV{VSAG_THIRDPARTY_HTTPLIB}")
+endif()
+
+FetchContent_Declare(
+    httplib
+    URL ${httplib_urls}
+    URL_HASH MD5=564fdf8b1acbc780fadb2e55fe6a0db6
+    DOWNLOAD_NO_PROGRESS 1
+    INACTIVITY_TIMEOUT 5
+    TIMEOUT 30
+)
+
+FetchContent_MakeAvailable(httplib)
+
+# httplib is header-only, just add include directory
+include_directories(${httplib_SOURCE_DIR})
+
+# Define macro to indicate httplib is available
+add_definitions(-DCPP_HTTPLIB_OPENSSL_SUPPORT)

--- a/tools/eval/CMakeLists.txt
+++ b/tools/eval/CMakeLists.txt
@@ -27,6 +27,7 @@ set (eval_srcs
         monitor/recall_monitor.cpp
         monitor/memory_peak_monitor.cpp
         monitor/duration_monitor.cpp
+        monitor/http_server_monitor.cpp
 
         eval_config.cpp
         eval_dataset.cpp
@@ -34,8 +35,8 @@ set (eval_srcs
         )
 add_library (eval_obj OBJECT ${eval_srcs})
 target_compile_options (eval_obj PRIVATE -fopenmp)
-target_link_libraries (eval_obj PRIVATE cpr)
-add_dependencies (eval_obj hdf5 spdlog yaml-cpp tabulate cpr)
+target_link_libraries (eval_obj PRIVATE pthread)
+add_dependencies (eval_obj hdf5 spdlog yaml-cpp tabulate)
 
 add_executable (eval_performance main.cpp)
 target_compile_options (eval_performance PRIVATE -fopenmp)

--- a/tools/eval/case/eval_case.h
+++ b/tools/eval/case/eval_case.h
@@ -17,6 +17,7 @@
 
 #include "../eval_config.h"
 #include "../eval_dataset.h"
+#include "../monitor/http_server_monitor.h"
 #include "nlohmann/json.hpp"
 #include "vsag/index.h"
 #include "vsag/logger.h"
@@ -44,6 +45,46 @@ public:
         std::cout << result.dump(4) << std::endl;
     }
 
+    // HTTP Monitor integration
+    static void
+    SetHttpMonitor(HttpServerMonitor* monitor) {
+        http_monitor_ = monitor;
+    }
+
+    static void
+    SetCurrentCaseName(const std::string& name) {
+        current_case_name_ = name;
+        if (http_monitor_) {
+            http_monitor_->SetCurrentCase(name);
+        }
+    }
+
+    static void
+    UpdateMonitorProgress(float percent) {
+        if (http_monitor_) {
+            http_monitor_->UpdateProgress(percent);
+        }
+    }
+
+    static void
+    UpdateMonitorMetrics(const JsonType& metrics) {
+        if (http_monitor_) {
+            http_monitor_->UpdateMetrics(metrics);
+        }
+    }
+
+    static void
+    MarkCaseCompleted() {
+        if (http_monitor_) {
+            http_monitor_->MarkCaseCompleted();
+        }
+    }
+
+    static HttpServerMonitor*
+    GetMonitor() {
+        return http_monitor_;
+    }
+
 public:
     explicit EvalCase(std::string dataset_path, std::string index_path, vsag::IndexPtr index);
 
@@ -65,6 +106,10 @@ protected:
     Logger logger_{nullptr};
 
     JsonType basic_info_{};
+
+    // Static members for HTTP monitor
+    inline static HttpServerMonitor* http_monitor_ = nullptr;
+    inline static std::string current_case_name_{};
 };
 
 }  // namespace vsag::eval

--- a/tools/eval/eval_job.h
+++ b/tools/eval/eval_job.h
@@ -32,6 +32,12 @@ struct exporter {
     std::unordered_map<std::string, std::string> vars;  // environment variables, like cookies
 };
 
+// http_server config for monitoring
+struct HttpServer {
+    bool enabled = false;
+    int port = 8080;  // default port
+};
+
 // a eval_job contains multiple eval cases
 struct eval_job {
     using eval_case = YAML::Node;
@@ -43,6 +49,7 @@ struct eval_job {
     std::vector<exporter> exporters;
     std::optional<int32_t> num_threads_building;
     std::optional<int32_t> num_threads_searching;
+    std::optional<HttpServer> http_server;
 };
 
 }  // namespace vsag::eval

--- a/tools/eval/exporter/exporter_influxdb.h
+++ b/tools/eval/exporter/exporter_influxdb.h
@@ -15,7 +15,7 @@
 
 #pragma once
 
-#include <cpr/cpr.h>
+#include <httplib.h>
 
 #include <iostream>
 #include <string>
@@ -36,15 +36,21 @@ class InfluxdbExporter : public Exporter {
 public:
     bool
     Export(const std::string& formatted_result) override {
-        cpr::Header header1 = cpr::Header{{"Authorization", token_},
-                                          {"Content-Type", "text/plain; charset=utf-8"},
-                                          {"Accept", "application/json"}};
-        cpr::Response r = cpr::Post(cpr::Url{endpoint_}, header1, cpr::Body{formatted_result});
-        if (r.status_code == 204) {
+        httplib::Client client(host_.c_str());
+        client.set_default_headers({{"Authorization", token_},
+                                    {"Content-Type", "text/plain; charset=utf-8"},
+                                    {"Accept", "application/json"}});
+
+        auto res = client.Post(path_.c_str(), formatted_result, "text/plain");
+        if (res && res->status == 204) {
             return true;
         }
         // TODO(wxyu): use vsag logger
-        std::cerr << r.text << std::endl;
+        if (res) {
+            std::cerr << "HTTP Error: " << res->status << " - " << res->body << std::endl;
+        } else {
+            std::cerr << "HTTP Request failed" << std::endl;
+        }
 
         return false;
     }
@@ -52,13 +58,40 @@ public:
 public:
     InfluxdbExporter(const std::string& endpoint,
                      const std::unordered_map<std::string, std::string>& vars) {
-        endpoint_ = replace_string(endpoint, "influxdb", "http");
+        // Parse endpoint from "http://host:port/path?query" to host and path
+        // e.g., "http://127.0.0.1:8086/api/v2/write?org=vsag&bucket=example&precision=ns"
+        std::string full_url = replace_string(endpoint, "influxdb", "http");
+        ParseEndpoint(full_url);
         token_ = vars.at("token");
     }
 
 private:
-    // e.g., "http://127.0.0.1:8086/api/v2/write?org=vsag&bucket=example&precision=ns"
-    std::string endpoint_{};
+    void
+    ParseEndpoint(const std::string& full_url) {
+        // Find the path separator after host:port
+        // Format: http://host:port/path or http://host/path
+        size_t protocol_end = full_url.find("://");
+        if (protocol_end == std::string::npos) {
+            host_ = full_url;
+            path_ = "/";
+            return;
+        }
+
+        size_t path_start = full_url.find('/', protocol_end + 3);
+        if (path_start == std::string::npos) {
+            host_ = full_url;
+            path_ = "/";
+        } else {
+            host_ = full_url.substr(0, path_start);
+            path_ = full_url.substr(path_start);
+        }
+    }
+
+private:
+    // Host part, e.g., "http://127.0.0.1:8086"
+    std::string host_{};
+    // Path part, e.g., "/api/v2/write?org=vsag&bucket=example&precision=ns"
+    std::string path_{};
     // e.g., "Token mlIiP-zVfcooHhMbGG9Yk-KfrkHyDc2h-rphnIBda8UMe_6Qocy8tNmV323yxOPEAsC8uIs6_nb-XUSMEAO76A=="
     std::string token_{};
 };

--- a/tools/eval/monitor/http_server_monitor.cpp
+++ b/tools/eval/monitor/http_server_monitor.cpp
@@ -1,0 +1,450 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "http_server_monitor.h"
+
+#include <fstream>
+#include <iostream>
+#include <sstream>
+
+namespace vsag::eval {
+
+HttpServerMonitor::HttpServerMonitor(int port) : port_(port) {
+    server_ = std::make_unique<httplib::Server>();
+    start_time_ = std::chrono::steady_clock::now();
+    setup_routes();
+}
+
+HttpServerMonitor::~HttpServerMonitor() {
+    Stop();
+}
+
+void
+HttpServerMonitor::Start() {
+    if (running_) {
+        return;
+    }
+    running_ = true;
+    server_thread_ = std::thread(&HttpServerMonitor::run_server, this);
+}
+
+void
+HttpServerMonitor::Stop() {
+    if (!running_) {
+        return;
+    }
+    running_ = false;
+    server_->stop();
+    if (server_thread_.joinable()) {
+        server_thread_.join();
+    }
+}
+
+void
+HttpServerMonitor::run_server() {
+    std::cout << "[HTTP Monitor] Starting server on port " << port_ << std::endl;
+    if (!server_->listen("0.0.0.0", port_)) {
+        std::cerr << "[HTTP Monitor] Failed to start server on port " << port_ << std::endl;
+    }
+}
+
+void
+HttpServerMonitor::setup_routes() {
+    // API endpoints
+    server_->Get("/api/status", [this](const httplib::Request&, httplib::Response& res) {
+        res.set_content(get_status_json().dump(), "application/json");
+    });
+
+    server_->Get("/api/metrics", [this](const httplib::Request&, httplib::Response& res) {
+        std::lock_guard<std::mutex> lock(state_mutex_);
+        res.set_content(current_metrics_.dump(), "application/json");
+    });
+
+    server_->Get("/api/history", [this](const httplib::Request&, httplib::Response& res) {
+        std::lock_guard<std::mutex> lock(state_mutex_);
+        JsonType history_json = JsonType::array();
+        for (const auto& h : case_history_) {
+            history_json.push_back(h);
+        }
+        res.set_content(history_json.dump(), "application/json");
+    });
+
+    // Main page
+    server_->Get("/", [this](const httplib::Request&, httplib::Response& res) {
+        res.set_content(get_index_html(), "text/html");
+    });
+
+    // Static files (if web_root is set)
+    if (!web_root_.empty()) {
+        server_->set_base_dir(web_root_);
+    }
+
+    // CORS support
+    server_->set_post_routing_handler([](const httplib::Request&, httplib::Response& res) {
+        res.set_header("Access-Control-Allow-Origin", "*");
+    });
+}
+
+JsonType
+HttpServerMonitor::get_status_json() const {
+    std::lock_guard<std::mutex> lock(state_mutex_);
+    JsonType status;
+    status["total_cases"] = total_cases_;
+    status["completed_cases"] = completed_cases_;
+    status["current_case"] = current_case_;
+    status["case_status"] = case_status_;
+    status["progress"] = current_progress_;
+    status["running"] = running_.load();
+
+    auto now = std::chrono::steady_clock::now();
+    auto total_elapsed =
+        std::chrono::duration_cast<std::chrono::seconds>(now - start_time_).count();
+    status["total_elapsed_seconds"] = total_elapsed;
+
+    if (case_status_ == "running") {
+        auto case_elapsed =
+            std::chrono::duration_cast<std::chrono::seconds>(now - case_start_time_).count();
+        status["case_elapsed_seconds"] = case_elapsed;
+    }
+
+    return status;
+}
+
+void
+HttpServerMonitor::SetTotalCases(int total) {
+    std::lock_guard<std::mutex> lock(state_mutex_);
+    total_cases_ = total;
+}
+
+void
+HttpServerMonitor::SetCurrentCase(const std::string& name) {
+    std::lock_guard<std::mutex> lock(state_mutex_);
+    // Save current case to history if completed
+    if (!current_case_.empty() && case_status_ == "completed") {
+        JsonType history_entry;
+        history_entry["name"] = current_case_;
+        history_entry["metrics"] = current_metrics_;
+        case_history_.push_back(history_entry);
+    }
+    current_case_ = name;
+    case_status_ = "running";
+    current_progress_ = 0.0F;
+    case_start_time_ = std::chrono::steady_clock::now();
+}
+
+void
+HttpServerMonitor::SetCaseStatus(const std::string& status) {
+    std::lock_guard<std::mutex> lock(state_mutex_);
+    case_status_ = status;
+}
+
+void
+HttpServerMonitor::MarkCaseCompleted() {
+    std::lock_guard<std::mutex> lock(state_mutex_);
+    case_status_ = "completed";
+    completed_cases_++;
+    current_progress_ = 100.0F;
+
+    // Save to history
+    if (!current_case_.empty()) {
+        JsonType history_entry;
+        history_entry["name"] = current_case_;
+        history_entry["metrics"] = current_metrics_;
+        case_history_.push_back(history_entry);
+    }
+}
+
+void
+HttpServerMonitor::UpdateMetrics(const JsonType& metrics) {
+    std::lock_guard<std::mutex> lock(state_mutex_);
+    current_metrics_ = metrics;
+}
+
+void
+HttpServerMonitor::UpdateProgress(float percent_complete) {
+    std::lock_guard<std::mutex> lock(state_mutex_);
+    current_progress_ = std::max(0.0F, std::min(100.0F, percent_complete));
+}
+
+void
+HttpServerMonitor::SetWebRoot(const std::string& path) {
+    web_root_ = path;
+}
+
+std::string
+HttpServerMonitor::get_index_html() const {
+    std::string html = R"(<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>VSAG Performance Monitor</title>
+    <style>
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            background: #f5f5f5;
+            padding: 20px;
+        }
+        .container { max-width: 1200px; margin: 0 auto; }
+        header {
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+            padding: 30px;
+            border-radius: 10px;
+            margin-bottom: 20px;
+        }
+        header h1 { font-size: 28px; margin-bottom: 10px; }
+        header p { opacity: 0.9; }
+        .card {
+            background: white;
+            border-radius: 10px;
+            padding: 24px;
+            margin-bottom: 20px;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+        }
+        .card h2 {
+            font-size: 18px;
+            margin-bottom: 20px;
+            color: #333;
+            border-bottom: 2px solid #667eea;
+            padding-bottom: 10px;
+        }
+        .progress-bar {
+            background: #e0e0e0;
+            border-radius: 10px;
+            height: 30px;
+            overflow: hidden;
+            margin: 15px 0;
+        }
+        .progress-fill {
+            background: linear-gradient(90deg, #667eea 0%, #764ba2 100%);
+            height: 100%;
+            transition: width 0.5s ease;
+            display: flex;
+            align-items: center;
+            justify-content: flex-end;
+            padding-right: 10px;
+            color: white;
+            font-weight: bold;
+        }
+        .stats-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            gap: 20px;
+            margin-top: 20px;
+        }
+        .stat-box {
+            background: #f8f9fa;
+            padding: 20px;
+            border-radius: 8px;
+            border-left: 4px solid #667eea;
+        }
+        .stat-box label {
+            display: block;
+            font-size: 12px;
+            color: #666;
+            text-transform: uppercase;
+            margin-bottom: 5px;
+        }
+        .stat-box value {
+            display: block;
+            font-size: 24px;
+            font-weight: bold;
+            color: #333;
+        }
+        .status-running { color: #28a745; }
+        .status-completed { color: #007bff; }
+        .status-failed { color: #dc3545; }
+        .metrics-table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-top: 15px;
+        }
+        .metrics-table th, .metrics-table td {
+            padding: 12px;
+            text-align: left;
+            border-bottom: 1px solid #eee;
+        }
+        .metrics-table th {
+            background: #f8f9fa;
+            font-weight: 600;
+        }
+        #metrics-content {
+            font-family: 'Monaco', 'Menlo', monospace;
+            font-size: 14px;
+            white-space: pre-wrap;
+            background: #f8f9fa;
+            padding: 20px;
+            border-radius: 8px;
+            overflow-x: auto;
+        }
+        .refresh-indicator {
+            display: inline-block;
+            width: 10px;
+            height: 10px;
+            border-radius: 50%;
+            background: #28a745;
+            margin-left: 10px;
+            animation: pulse 2s infinite;
+        }
+        @keyframes pulse {
+            0% { opacity: 1; }
+            50% { opacity: 0.5; }
+            100% { opacity: 1; }
+        }
+        .case-item {
+            padding: 10px;
+            margin: 5px 0;
+            background: #f8f9fa;
+            border-radius: 5px;
+            border-left: 3px solid #ddd;
+        }
+        .case-item.completed { border-color: #28a745; }
+        .case-item.running { border-color: #007bff; }
+        .case-item.failed { border-color: #dc3545; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <header>
+            <h1>VSAG Performance Monitor</h1>
+            <p>Real-time benchmark progress and metrics</p>
+        </header>
+
+        <div class="card">
+            <h2>
+                Overall Progress
+                <span class="refresh-indicator"></span>
+            </h2>
+            <div class="progress-bar">
+                <div class="progress-fill" id="progress-bar" style="width: 0%">0%</div>
+            </div>
+            <div class="stats-grid">
+                <div class="stat-box">
+                    <label>Current Case</label>
+                    <value id="current-case">-</value>
+                </div>
+                <div class="stat-box">
+                    <label>Cases</label>
+                    <value id="case-count">0/0</value>
+                </div>
+                <div class="stat-box">
+                    <label>Status</label>
+                    <value id="status">Idle</value>
+                </div>
+                <div class="stat-box">
+                    <label>Elapsed Time</label>
+                    <value id="elapsed">00:00</value>
+                </div>
+            </div>
+        </div>
+
+        <div class="card">
+            <h2>Current Metrics</h2>
+            <div id="metrics-content">No metrics available</div>
+        </div>
+
+        <div class="card">
+            <h2>Completed Cases</h2>
+            <div id="history-list">No completed cases yet</div>
+        </div>
+    </div>
+
+    <script>
+        async function fetchStatus() {
+            try {
+                const [statusRes, metricsRes] = await Promise.all([
+                    fetch('/api/status'),
+                    fetch('/api/metrics')
+                ]);
+                const status = await statusRes.json();
+                const metrics = await metricsRes.json();
+                updateUI(status, metrics);
+            } catch (e) {
+                console.error('Failed to fetch status:', e);
+            }
+        }
+
+        function updateUI(status, metrics) {
+            // Update progress bar
+            const totalProgress = status.total_cases > 0
+                ? ((status.completed_cases + status.progress/100) / status.total_cases * 100)
+                : 0;
+            const bar = document.getElementById('progress-bar');
+            bar.style.width = totalProgress + '%';
+            bar.textContent = Math.round(totalProgress) + '%';
+
+            // Update stats
+            document.getElementById('current-case').textContent = status.current_case || '-';
+            document.getElementById('case-count').textContent =
+                `${status.completed_cases}/${status.total_cases}`;
+
+            const statusEl = document.getElementById('status');
+            statusEl.textContent = status.case_status;
+            statusEl.className = 'status-' + status.case_status;
+
+            // Format elapsed time
+            const minutes = Math.floor(status.total_elapsed_seconds / 60);
+            const seconds = status.total_elapsed_seconds % 60;
+            document.getElementById('elapsed').textContent =
+                `${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
+
+            // Update metrics
+            document.getElementById('metrics-content').textContent =
+                JSON.stringify(metrics, null, 2);
+        }
+
+        async function fetchHistory() {
+            try {
+                const res = await fetch('/api/history');
+                const history = await res.json();
+                updateHistory(history);
+            } catch (e) {
+                console.error('Failed to fetch history:', e);
+            }
+        }
+
+        function updateHistory(history) {
+            const container = document.getElementById('history-list');
+            if (history.length === 0) {
+                container.innerHTML = 'No completed cases yet';
+                return;
+            }
+            container.innerHTML = history.map(h =>
+                `<div class="case-item completed">
+                    <strong>${h.name}</strong>
+                    <pre>${JSON.stringify(h.metrics, null, 2)}</pre>
+                 </div>`
+            ).join('');
+        }
+
+        // Poll every 1 second
+        setInterval(() => {
+            fetchStatus();
+            fetchHistory();
+        }, 1000);
+
+        // Initial fetch
+        fetchStatus();
+        fetchHistory();
+    </script>
+</body>
+</html>)";
+
+    return html;
+}
+
+}  // namespace vsag::eval

--- a/tools/eval/monitor/http_server_monitor.h
+++ b/tools/eval/monitor/http_server_monitor.h
@@ -1,0 +1,113 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <httplib.h>
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "../common.h"
+
+namespace vsag::eval {
+
+class HttpServerMonitor {
+public:
+    using TimePoint = std::chrono::steady_clock::time_point;
+
+    explicit HttpServerMonitor(int port = 8080);
+    ~HttpServerMonitor();
+
+    // Server control
+    void
+    Start();
+
+    void
+    Stop();
+
+    bool
+    IsRunning() const {
+        return running_;
+    }
+    int
+    GetPort() const {
+        return port_;
+    }
+
+    // Progress tracking
+    void
+    SetTotalCases(int total);
+
+    void
+    SetCurrentCase(const std::string& name);
+
+    void
+    SetCaseStatus(const std::string& status);  // "pending", "running", "completed", "failed"
+
+    void
+    MarkCaseCompleted();
+
+    // Metrics update - called by EvalCase during execution
+    void
+    UpdateMetrics(const JsonType& metrics);
+
+    void
+    UpdateProgress(float percent_complete);  // 0.0 - 100.0
+
+    // Static files
+    void
+    SetWebRoot(const std::string& path);
+
+private:
+    void
+    setup_routes();
+
+    void
+    run_server();
+
+    JsonType
+    get_status_json() const;
+
+    std::string
+    get_index_html() const;
+
+private:
+    // HTTP server
+    std::unique_ptr<httplib::Server> server_;
+    std::thread server_thread_;
+    int port_;
+    std::atomic<bool> running_{false};
+    std::string web_root_;
+
+    // State data (protected by mutex)
+    mutable std::mutex state_mutex_;
+    int total_cases_{0};
+    int completed_cases_{0};
+    std::string current_case_;
+    std::string case_status_{"idle"};  // idle, running, completed, failed
+    float current_progress_{0.0F};     // 0.0 - 100.0
+    JsonType current_metrics_;
+    TimePoint start_time_;
+    TimePoint case_start_time_;
+    std::vector<JsonType> case_history_;  // Completed cases data
+};
+
+}  // namespace vsag::eval


### PR DESCRIPTION
Replace CPR (HTTP client library) with cpp-httplib to:
- Eliminate nested dependency on libcurl (CPR -> curl chain)
- Reduce download size from ~4MB to ~0.3MB (85% reduction)
- Speed up build by reducing network downloads from 2 to 1

Add HTTP server monitor for eval_performance tool:
- Add HttpServerMonitor class for real-time progress tracking
- Provide Web UI (embedded HTML/CSS/JS) for viewing metrics
- Add REST API endpoints (/api/status, /api/metrics, /api/history)
- Support YAML configuration for http_server (enabled, port)
- Expose static methods in EvalCase for progress reporting

Changes:
- extern/httplib/httplib.cmake: new httplib fetch config
- tools/eval/monitor/http_server_monitor.h/cpp: new HTTP server
- tools/eval/exporter/exporter_influxdb.h: migrate from cpr to httplib
- tools/eval/case/eval_case.h: add monitor integration hooks
- tools/eval/main.cpp: start/stop HTTP server with job execution
- tools/eval/eval_job.h: add http_server config structure
- CMakeLists.txt: replace cpr.cmake with httplib.cmake
- tools/eval/CMakeLists.txt: add new source file, remove cpr dep