### PR TITLE
style(cmake): format CMakeLists for clearer diffs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,39 +14,43 @@
 # limitations under the License.
 
 
-cmake_minimum_required (VERSION 3.18)
+cmake_minimum_required(VERSION 3.18)
+
+# Newer CMake policies for optional behavior
 if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
-    cmake_policy (SET CMP0135 NEW)
-endif ()
+    cmake_policy(SET CMP0135 NEW)
+endif()
+
 if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.30.0")
-    cmake_policy (SET CMP0169 OLD)
-endif ()
+    cmake_policy(SET CMP0169 OLD)
+endif()
 
-project (VSAG
-        LANGUAGES C CXX
-)
+# Project declaration
+project(VSAG LANGUAGES C CXX)
 
-include (cmake/ColorizeMessage.cmake)
+# Utilities
+include(cmake/ColorizeMessage.cmake)
 
-message (STATUS "CPU ARCH: ${Yellow}${CMAKE_HOST_SYSTEM_PROCESSOR}${CR}")
+message(STATUS "CPU ARCH: ${Yellow}${CMAKE_HOST_SYSTEM_PROCESSOR}${CR}")
 
-macro (vsag_add_exe_linker_flag flag)
-    set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${flag}")
-endmacro ()
+# Helper macros to accumulate linker flags
+macro(vsag_add_exe_linker_flag flag)
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${flag}")
+endmacro()
 
-macro (vsag_add_shared_linker_flag flag)
-    set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${flag}")
-endmacro ()
+macro(vsag_add_shared_linker_flag flag)
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${flag}")
+endmacro()
 
-macro (maybe_add_dependencies depender)
+macro(maybe_add_dependencies depender)
     if (TARGET ${depender})
         foreach (dependee ${ARGN})
             if (TARGET ${dependee})
-                add_dependencies (${depender} ${dependee})
-            endif ()
-        endforeach ()
-    endif ()
-endmacro ()
+                add_dependencies(${depender} ${dependee})
+            endif()
+        endforeach()
+    endif()
+endmacro()
 
 # options
 option (ENABLE_JEMALLOC "Whether to link jemalloc to all executables" OFF)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,47 +13,67 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+add_subdirectory(simd)
+add_subdirectory(io)
+add_subdirectory(quantization)
+add_subdirectory(impl)
+add_subdirectory(storage)
+add_subdirectory(attr)
+add_subdirectory(datacell)
+add_subdirectory(algorithm)
+add_subdirectory(utils)
+add_subdirectory(factory)
+add_subdirectory(analyzer)
 
-add_subdirectory (simd)
-add_subdirectory (io)
-add_subdirectory (quantization)
-add_subdirectory (impl)
-add_subdirectory (storage)
-add_subdirectory (attr)
-add_subdirectory (datacell)
-add_subdirectory (algorithm)
-add_subdirectory (utils)
-add_subdirectory (factory)
-add_subdirectory (analyzer)
+file(GLOB CPP_SRCS "*.cpp")
+list(FILTER CPP_SRCS EXCLUDE REGEX "_test.cpp")
 
-file (GLOB CPP_SRCS "*.cpp")
-list (FILTER CPP_SRCS EXCLUDE REGEX "_test.cpp")
+file(GLOB CPP_INDEX_SRCS "index/*.cpp")
+list(FILTER CPP_INDEX_SRCS EXCLUDE REGEX "_test.cpp")
 
-file (GLOB CPP_INDEX_SRCS "index/*.cpp")
-list (FILTER CPP_INDEX_SRCS EXCLUDE REGEX "_test.cpp")
+set(VSAG_SRCS ${CPP_SRCS} ${CPP_INDEX_SRCS})
 
-set (VSAG_SRCS ${CPP_SRCS} ${CPP_INDEX_SRCS})
+add_library(vsag SHARED ${VSAG_SRCS})
+add_library(vsag_static STATIC ${VSAG_SRCS})
 
-add_library (vsag SHARED ${VSAG_SRCS})
-add_library (vsag_static STATIC ${VSAG_SRCS})
+set(VSAG_DEP_LIBS
+    antlr4-autogen
+    antlr4-runtime
+    diskann
+    simd
+    io
+    quantizer
+    storage
+    utils
+    factory
+    analyzer
+    datacell
+    ${IMPL_LIBS}
+    ${ALGORITHM_LIBS}
+    attr
+    pthread
+    m
+    dl
+    fmt::fmt
+    nlohmann_json::nlohmann_json
+    roaring
+    ${BLAS_LIBRARIES}
+)
 
-set (VSAG_DEP_LIBS antlr4-autogen antlr4-runtime diskann simd io quantizer storage utils factory analyzer
-      datacell ${IMPL_LIBS} ${ALGORITHM_LIBS} attr pthread m dl fmt::fmt nlohmann_json::nlohmann_json roaring ${BLAS_LIBRARIES})
+target_link_libraries(vsag ${VSAG_DEP_LIBS} coverage_config)
+target_link_libraries(vsag_static ${VSAG_DEP_LIBS} coverage_config)
 
-target_link_libraries (vsag ${VSAG_DEP_LIBS} coverage_config)
-target_link_libraries (vsag_static ${VSAG_DEP_LIBS} coverage_config)
+add_dependencies(vsag spdlog)
+add_dependencies(vsag_static spdlog)
 
-add_dependencies (vsag spdlog)
-add_dependencies (vsag_static spdlog)
-
-maybe_add_dependencies (vsag antlr4 spdlog roaring openblas boost mkl)
-maybe_add_dependencies (vsag_static antlr4 spdlog roaring openblas boost mkl)
+maybe_add_dependencies(vsag antlr4 spdlog roaring openblas boost mkl)
+maybe_add_dependencies(vsag_static antlr4 spdlog roaring openblas boost mkl)
 
 if (ENABLE_TESTS)
-    file (GLOB VSAG_TESTS "*_test.cpp")
-    file (GLOB INDEX_TESTS "index/*_test.cpp")
-    list (APPEND VSAG_TESTS ${INDEX_TESTS})
-    add_library (vsag_test STATIC ${VSAG_TESTS})
-    target_link_libraries (vsag_test PRIVATE Catch2::Catch2 vsag)
-    add_dependencies (vsag_test spdlog Catch2)
-endif ()
+    file(GLOB VSAG_TESTS "*_test.cpp")
+    file(GLOB INDEX_TESTS "index/*_test.cpp")
+    list(APPEND VSAG_TESTS ${INDEX_TESTS})
+    add_library(vsag_test STATIC ${VSAG_TESTS})
+    target_link_libraries(vsag_test PRIVATE Catch2::Catch2 vsag)
+    add_dependencies(vsag_test spdlog Catch2)
+endif()

--- a/src/algorithm/CMakeLists.txt
+++ b/src/algorithm/CMakeLists.txt
@@ -14,28 +14,29 @@
 # limitations under the License.
 
 
-add_subdirectory (ivf_partition)
-add_subdirectory (hnswlib)
-add_subdirectory (sindi)
+add_subdirectory(ivf_partition)
+add_subdirectory(hnswlib)
+add_subdirectory(sindi)
 
-file (GLOB ALGORITHM_SRCS "*.cpp")
-list (FILTER ALGORITHM_SRCS EXCLUDE REGEX "_test.cpp")
+file(GLOB ALGORITHM_SRCS "*.cpp")
+list(FILTER ALGORITHM_SRCS EXCLUDE REGEX "_test.cpp")
 
 add_library(algorithm OBJECT ${ALGORITHM_SRCS})
-target_link_libraries (algorithm PUBLIC coverage_config)
+target_link_libraries(algorithm PUBLIC coverage_config)
 maybe_add_dependencies(algorithm spdlog fmt::fmt antlr4)
 
-
-set (ALGORITHM_LIBS
-        algorithm
-        hnswlib
-        ivf_partition
-        sindi
-        PARENT_SCOPE)
+set(
+    ALGORITHM_LIBS
+    algorithm
+    hnswlib
+    ivf_partition
+    sindi
+    PARENT_SCOPE
+)
 
 if (ENABLE_TESTS)
-    file (GLOB_RECURSE ALGORITHM_TESTS "*_test.cpp")
-    add_library (algorithm_test STATIC ${ALGORITHM_TESTS})
-    target_link_libraries (algorithm_test PRIVATE Catch2::Catch2 vsag)
-    add_dependencies (algorithm_test spdlog Catch2 antlr4)
-endif ()
+    file(GLOB_RECURSE ALGORITHM_TESTS "*_test.cpp")
+    add_library(algorithm_test STATIC ${ALGORITHM_TESTS})
+    target_link_libraries(algorithm_test PRIVATE Catch2::Catch2 vsag)
+    add_dependencies(algorithm_test spdlog Catch2 antlr4)
+endif()

--- a/src/algorithm/hnswlib/CMakeLists.txt
+++ b/src/algorithm/hnswlib/CMakeLists.txt
@@ -1,10 +1,10 @@
 
-set (HNSWLIB_SRCS
-        block_manager.cpp
-        algorithm_interface.cpp
-        hnswalg.cpp
+set(HNSWLIB_SRCS
+    block_manager.cpp
+    algorithm_interface.cpp
+    hnswalg.cpp
 )
 
-add_library (hnswlib OBJECT ${HNSWLIB_SRCS})
-target_link_libraries (hnswlib PUBLIC coverage_config)
-add_dependencies (hnswlib spdlog fmt::fmt)
+add_library(hnswlib OBJECT ${HNSWLIB_SRCS})
+target_link_libraries(hnswlib PUBLIC coverage_config)
+add_dependencies(hnswlib spdlog fmt::fmt)

--- a/src/impl/CMakeLists.txt
+++ b/src/impl/CMakeLists.txt
@@ -14,33 +14,64 @@
 # limitations under the License.
 
 
-add_subdirectory (thread_pool)
-add_subdirectory (allocator)
-add_subdirectory (filter)
-add_subdirectory (heap)
-add_subdirectory (transform)
-add_subdirectory (bitset)
-add_subdirectory (cluster)
-add_subdirectory (logger)
-add_subdirectory (searcher)
-add_subdirectory (odescent)
-add_subdirectory (reorder)
-add_subdirectory (blas)
+add_subdirectory(thread_pool)
+add_subdirectory(allocator)
+add_subdirectory(filter)
+add_subdirectory(heap)
+add_subdirectory(transform)
+add_subdirectory(bitset)
+add_subdirectory(cluster)
+add_subdirectory(logger)
+add_subdirectory(searcher)
+add_subdirectory(odescent)
+add_subdirectory(reorder)
+add_subdirectory(blas)
 
-file (GLOB IMPL_SRCS "*.cpp")
-list (FILTER IMPL_SRCS EXCLUDE REGEX "_test.cpp")
+file(GLOB IMPL_SRCS "*.cpp")
+list(FILTER IMPL_SRCS EXCLUDE REGEX "_test.cpp")
 
-add_library (impl OBJECT ${IMPL_SRCS})
-target_link_libraries (impl PUBLIC transform thread_pool allocator heap vsag_blas
-    bitset logger filter cluster searcher odescent reorder fmt::fmt coverage_config)
-maybe_add_dependencies (impl spdlog)
+add_library(impl OBJECT ${IMPL_SRCS})
+target_link_libraries(
+    impl
+    PUBLIC
+    transform
+    thread_pool
+    allocator
+    heap
+    vsag_blas
+    bitset
+    logger
+    filter
+    cluster
+    searcher
+    odescent
+    reorder
+    fmt::fmt
+    coverage_config
+)
+maybe_add_dependencies(impl spdlog)
 
-set (IMPL_LIBS transform thread_pool allocator heap bitset vsag_blas
-    logger filter impl cluster searcher odescent reorder PARENT_SCOPE)
+set(
+    IMPL_LIBS
+    transform
+    thread_pool
+    allocator
+    heap
+    bitset
+    vsag_blas
+    logger
+    filter
+    impl
+    cluster
+    searcher
+    odescent
+    reorder
+    PARENT_SCOPE
+)
 
 if (ENABLE_TESTS)
-    file (GLOB_RECURSE IMPL_TESTS "*_test.cpp")
-    add_library (impl_test STATIC ${IMPL_TESTS})
-    target_link_libraries (impl_test PRIVATE Catch2::Catch2 vsag)
-    add_dependencies (impl_test spdlog Catch2)
-endif ()
+    file(GLOB_RECURSE IMPL_TESTS "*_test.cpp")
+    add_library(impl_test STATIC ${IMPL_TESTS})
+    target_link_libraries(impl_test PRIVATE Catch2::Catch2 vsag)
+    add_dependencies(impl_test spdlog Catch2)
+endif()

--- a/src/impl/thread_pool/CMakeLists.txt
+++ b/src/impl/thread_pool/CMakeLists.txt
@@ -14,12 +14,12 @@
 # limitations under the License.
 
 
-set (THREAD_POOL_SRC
+set(THREAD_POOL_SRC
     default_thread_pool.cpp
     default_thread_pool.h
     safe_thread_pool.h
 )
 
-add_library (thread_pool OBJECT ${THREAD_POOL_SRC})
-target_link_libraries (thread_pool PRIVATE fmt::fmt coverage_config)
-maybe_add_dependencies (thread_pool spdlog)
+add_library(thread_pool OBJECT ${THREAD_POOL_SRC})
+target_link_libraries(thread_pool PRIVATE fmt::fmt coverage_config)
+maybe_add_dependencies(thread_pool spdlog)

--- a/src/io/CMakeLists.txt
+++ b/src/io/CMakeLists.txt
@@ -14,38 +14,39 @@
 # limitations under the License.
 
 
-set (IO_SRC
-        io_parameter.cpp
-        memory_io.cpp
-        memory_io_parameter.cpp
-        memory_block_io_parameter.cpp
-        buffer_io_parameter.cpp
-        buffer_io.cpp
-        async_io_parameter.cpp
-        async_io.cpp
-        mmap_io_parameter.cpp
-        mmap_io.cpp
-        memory_block_io.cpp
-        reader_io.cpp
-        reader_io_parameter.cpp
+set(IO_SRC
+    io_parameter.cpp
+    memory_io.cpp
+    memory_io_parameter.cpp
+    memory_block_io_parameter.cpp
+    buffer_io_parameter.cpp
+    buffer_io.cpp
+    async_io_parameter.cpp
+    async_io.cpp
+    mmap_io_parameter.cpp
+    mmap_io.cpp
+    memory_block_io.cpp
+    reader_io.cpp
+    reader_io_parameter.cpp
 )
 
-add_library (io OBJECT ${IO_SRC})
-if (HAVE_LIBAIO)
-    target_compile_definitions (io PUBLIC -DHAVE_LIBAIO=1)
-    target_link_libraries (io PUBLIC fmt::fmt aio coverage_config)
-    message (STATUS "io module: linking with libaio")
-else ()
-    target_compile_definitions (io PUBLIC -DHAVE_LIBAIO=0)
-    target_link_libraries (io PUBLIC fmt::fmt coverage_config)
-    message (STATUS "io module: libaio not available, async I/O disabled")
-endif ()
+add_library(io OBJECT ${IO_SRC})
 
-maybe_add_dependencies (io spdlog)
+if (HAVE_LIBAIO)
+    target_compile_definitions(io PUBLIC -DHAVE_LIBAIO=1)
+    target_link_libraries(io PUBLIC fmt::fmt aio coverage_config)
+    message(STATUS "io module: linking with libaio")
+else()
+    target_compile_definitions(io PUBLIC -DHAVE_LIBAIO=0)
+    target_link_libraries(io PUBLIC fmt::fmt coverage_config)
+    message(STATUS "io module: libaio not available, async I/O disabled")
+endif()
+
+maybe_add_dependencies(io spdlog)
 
 if (ENABLE_TESTS)
-    file (GLOB_RECURSE IO_TESTS "*_test.cpp")
-    add_library (io_test STATIC ${IO_TESTS})
-    target_link_libraries (io_test PRIVATE Catch2::Catch2 vsag)
-    add_dependencies (io_test spdlog Catch2)
-endif ()
+    file(GLOB_RECURSE IO_TESTS "*_test.cpp")
+    add_library(io_test STATIC ${IO_TESTS})
+    target_link_libraries(io_test PRIVATE Catch2::Catch2 vsag)
+    add_dependencies(io_test spdlog Catch2)
+endif()

--- a/src/quantization/CMakeLists.txt
+++ b/src/quantization/CMakeLists.txt
@@ -14,40 +14,40 @@
 # limitations under the License.
 
 
-set (QUANTIZER_SRC
-        quantizer_adapter.cpp
-        fp32_quantizer.cpp
-        int8_quantizer.cpp
-        scalar_quantization/scalar_quantizer.cpp
-        scalar_quantization/bf16_quantizer.cpp
-        scalar_quantization/fp16_quantizer.cpp
-        scalar_quantization/sq4_uniform_quantizer.cpp
-        scalar_quantization/sq8_uniform_quantizer.cpp
-        product_quantization/pq_fastscan_quantizer.cpp
-        product_quantization/product_quantizer.cpp
-        rabitq_quantization/rabitq_quantizer.cpp
-        quantizer_parameter.cpp
-        fp32_quantizer_parameter.cpp
-        int8_quantizer_parameter.cpp
-        scalar_quantization/sq8_uniform_quantizer_parameter.cpp
-        scalar_quantization/sq4_uniform_quantizer_parameter.cpp
-        scalar_quantization/bf16_quantizer_parameter.cpp
-        scalar_quantization/scalar_quantization_trainer.cpp
-        scalar_quantization/fp16_quantizer_parameter.cpp
-        rabitq_quantization/rabitq_quantizer_parameter.cpp
-        product_quantization/product_quantizer_parameter.cpp
-        product_quantization/pq_fastscan_quantizer_parameter.cpp
-        transform_quantization/transform_quantizer_parameter.cpp
+set(QUANTIZER_SRC
+    quantizer_adapter.cpp
+    fp32_quantizer.cpp
+    int8_quantizer.cpp
+    scalar_quantization/scalar_quantizer.cpp
+    scalar_quantization/bf16_quantizer.cpp
+    scalar_quantization/fp16_quantizer.cpp
+    scalar_quantization/sq4_uniform_quantizer.cpp
+    scalar_quantization/sq8_uniform_quantizer.cpp
+    product_quantization/pq_fastscan_quantizer.cpp
+    product_quantization/product_quantizer.cpp
+    rabitq_quantization/rabitq_quantizer.cpp
+    quantizer_parameter.cpp
+    fp32_quantizer_parameter.cpp
+    int8_quantizer_parameter.cpp
+    scalar_quantization/sq8_uniform_quantizer_parameter.cpp
+    scalar_quantization/sq4_uniform_quantizer_parameter.cpp
+    scalar_quantization/bf16_quantizer_parameter.cpp
+    scalar_quantization/scalar_quantization_trainer.cpp
+    scalar_quantization/fp16_quantizer_parameter.cpp
+    rabitq_quantization/rabitq_quantizer_parameter.cpp
+    product_quantization/product_quantizer_parameter.cpp
+    product_quantization/pq_fastscan_quantizer_parameter.cpp
+    transform_quantization/transform_quantizer_parameter.cpp
 )
 
-add_library (quantizer OBJECT ${QUANTIZER_SRC})
+add_library(quantizer OBJECT ${QUANTIZER_SRC})
 target_link_libraries(quantizer PUBLIC fmt::fmt coverage_config)
 
-maybe_add_dependencies (quantizer spdlog)
+maybe_add_dependencies(quantizer spdlog)
 
 if (ENABLE_TESTS)
-    file (GLOB_RECURSE QUANTIZER_TESTS "*_test.cpp")
-    add_library (quantizer_test STATIC ${QUANTIZER_TESTS})
-    target_link_libraries (quantizer_test PRIVATE Catch2::Catch2 vsag)
-    add_dependencies (quantizer_test spdlog Catch2)
-endif ()
+    file(GLOB_RECURSE QUANTIZER_TESTS "*_test.cpp")
+    add_library(quantizer_test STATIC ${QUANTIZER_TESTS})
+    target_link_libraries(quantizer_test PRIVATE Catch2::Catch2 vsag)
+    add_dependencies(quantizer_test spdlog Catch2)
+endif()

--- a/src/simd/CMakeLists.txt
+++ b/src/simd/CMakeLists.txt
@@ -14,121 +14,130 @@
 # limitations under the License.
 
 
-set (SIMD_SRCS
-        generic.cpp
-        sse.cpp
-        avx.cpp
-        avx2.cpp
-        avx512.cpp
-        avx512vpopcntdq.cpp
-        neon.cpp
-        sve.cpp
-        simd.cpp
-        simd_status.cpp
-        basic_func.cpp
-        bit_simd.cpp
-        fp32_simd.cpp
-        fp16_simd.cpp
-        int8_simd.cpp
-        bf16_simd.cpp
-        pqfs_simd.cpp
-        sq8_simd.cpp
-        sq4_simd.cpp
-        sq4_uniform_simd.cpp
-        sq8_uniform_simd.cpp
-        rabitq_simd.cpp
-        normalize.cpp
+set(SIMD_SRCS
+    generic.cpp
+    sse.cpp
+    avx.cpp
+    avx2.cpp
+    avx512.cpp
+    avx512vpopcntdq.cpp
+    neon.cpp
+    sve.cpp
+    simd.cpp
+    simd_status.cpp
+    basic_func.cpp
+    bit_simd.cpp
+    fp32_simd.cpp
+    fp16_simd.cpp
+    int8_simd.cpp
+    bf16_simd.cpp
+    pqfs_simd.cpp
+    sq8_simd.cpp
+    sq4_simd.cpp
+    sq4_uniform_simd.cpp
+    sq8_uniform_simd.cpp
+    rabitq_simd.cpp
+    normalize.cpp
 )
+
 if (DIST_CONTAINS_SSE)
-    set_source_files_properties (
-            sse.cpp
-            PROPERTIES COMPILE_FLAGS
-            "-msse -msse2 -msse3 -mssse3 -msse4 -msse4a -msse4.1 -msse4.2")
-endif ()
+    set_source_files_properties(
+        sse.cpp
+        PROPERTIES COMPILE_FLAGS
+        "-msse -msse2 -msse3 -mssse3 -msse4 -msse4a -msse4.1 -msse4.2"
+    )
+endif()
+
 if (DIST_CONTAINS_AVX)
-    set_source_files_properties (avx.cpp PROPERTIES COMPILE_FLAGS "-mavx -mf16c")
-endif ()
+    set_source_files_properties(avx.cpp PROPERTIES COMPILE_FLAGS "-mavx -mf16c")
+endif()
+
 if (DIST_CONTAINS_AVX2)
-    set_source_files_properties (avx2.cpp PROPERTIES COMPILE_FLAGS "-mavx2 -mfma -mf16c")
-endif ()
+    set_source_files_properties(avx2.cpp PROPERTIES COMPILE_FLAGS "-mavx2 -mfma -mf16c")
+endif()
+
 if (DIST_CONTAINS_AVX512)
-    set_source_files_properties (
-            avx512.cpp
-            PROPERTIES
-            COMPILE_FLAGS
-            "-mavx512f -mavx512pf -mavx512er -mavx512cd -mavx512vl -mavx512bw -mavx512dq -mavx512ifma -mavx512vbmi"
+    set_source_files_properties(
+        avx512.cpp
+        PROPERTIES
+        COMPILE_FLAGS
+        "-mavx512f -mavx512pf -mavx512er -mavx512cd -mavx512vl -mavx512bw -mavx512dq -mavx512ifma -mavx512vbmi"
     )
-endif ()
+endif()
+
 if (DIST_CONTAINS_AVX512VPOPCNTDQ)
-    set_source_files_properties (
-            avx512vpopcntdq.cpp
-            PROPERTIES
-            COMPILE_FLAGS
-            "-mavx512f -mavx512pf -mavx512er -mavx512cd -mavx512vl -mavx512bw -mavx512dq -mavx512ifma -mavx512vbmi -mavx512vpopcntdq"
+    set_source_files_properties(
+        avx512vpopcntdq.cpp
+        PROPERTIES
+        COMPILE_FLAGS
+        "-mavx512f -mavx512pf -mavx512er -mavx512cd -mavx512vl -mavx512bw -mavx512dq -mavx512ifma -mavx512vbmi -mavx512vpopcntdq"
     )
-endif ()
+endif()
+
 if (DIST_CONTAINS_NEON)
-    set_source_files_properties (neon.cpp PROPERTIES COMPILE_FLAGS "-march=armv8-a")
-endif ()
+    set_source_files_properties(neon.cpp PROPERTIES COMPILE_FLAGS "-march=armv8-a")
+endif()
+
 if (DIST_CONTAINS_SVE)
-    set_source_files_properties (sve.cpp PROPERTIES COMPILE_FLAGS "-march=armv8-a+sve")
-endif ()
+    set_source_files_properties(sve.cpp PROPERTIES COMPILE_FLAGS "-march=armv8-a+sve")
+endif()
 
 
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3")
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ftree-vectorize")
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-builtin-malloc")
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-builtin-calloc")
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-builtin-realloc")
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-builtin-free")
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fopenmp -fopenmp-simd")
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -funroll-loops")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ftree-vectorize")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-builtin-malloc")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-builtin-calloc")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-builtin-realloc")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-builtin-free")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fopenmp -fopenmp-simd")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -funroll-loops")
 
-add_library (simd STATIC ${SIMD_SRCS})
+add_library(simd STATIC ${SIMD_SRCS})
 
-macro (simd_add_definitions flag1 flag2)
+macro(simd_add_definitions flag1 flag2)
     if (${flag1})
-        target_compile_definitions (simd PUBLIC ${flag2})
-    endif ()
-endmacro ()
+        target_compile_definitions(simd PUBLIC ${flag2})
+    endif()
+endmacro()
 
-simd_add_definitions (DIST_CONTAINS_SSE -DENABLE_SSE=1)
-simd_add_definitions (DIST_CONTAINS_AVX -DENABLE_AVX=1)
-simd_add_definitions (DIST_CONTAINS_AVX2 -DENABLE_AVX2=1)
-simd_add_definitions (DIST_CONTAINS_AVX512 -DENABLE_AVX512=1)
-simd_add_definitions (DIST_CONTAINS_AVX512VPOPCNTDQ -DENABLE_AVX512VPOPCNTDQ=1)
-simd_add_definitions (DIST_CONTAINS_NEON -DENABLE_NEON=1)
-simd_add_definitions (DIST_CONTAINS_SVE -DENABLE_SVE=1)
+simd_add_definitions(DIST_CONTAINS_SSE -DENABLE_SSE=1)
+simd_add_definitions(DIST_CONTAINS_AVX -DENABLE_AVX=1)
+simd_add_definitions(DIST_CONTAINS_AVX2 -DENABLE_AVX2=1)
+simd_add_definitions(DIST_CONTAINS_AVX512 -DENABLE_AVX512=1)
+simd_add_definitions(DIST_CONTAINS_AVX512VPOPCNTDQ -DENABLE_AVX512VPOPCNTDQ=1)
+simd_add_definitions(DIST_CONTAINS_NEON -DENABLE_NEON=1)
+simd_add_definitions(DIST_CONTAINS_SVE -DENABLE_SVE=1)
 
-target_link_libraries (simd
-  PRIVATE cpuinfo
-  INTERFACE coverage_config
-  )
-add_dependencies (simd cpuinfo)
-install (TARGETS simd ARCHIVE DESTINATION lib)
+target_link_libraries(
+    simd
+    PRIVATE cpuinfo
+    INTERFACE coverage_config
+)
+add_dependencies(simd cpuinfo)
+install(TARGETS simd ARCHIVE DESTINATION lib)
 
 if (ENABLE_TESTS)
-    file (GLOB_RECURSE SIMD_TESTS "*_test.cpp")
-    add_library (simd_test STATIC ${SIMD_TESTS})
+    file(GLOB_RECURSE SIMD_TESTS "*_test.cpp")
+    add_library(simd_test STATIC ${SIMD_TESTS})
 
     if (DIST_CONTAINS_SSE)
-        target_compile_definitions (simd_test PRIVATE ENABLE_SSE=1)
-    endif ()
+        target_compile_definitions(simd_test PRIVATE ENABLE_SSE=1)
+    endif()
     if (DIST_CONTAINS_AVX)
-        target_compile_definitions (simd_test PRIVATE ENABLE_AVX=1)
-    endif ()
+        target_compile_definitions(simd_test PRIVATE ENABLE_AVX=1)
+    endif()
     if (DIST_CONTAINS_AVX2)
-        target_compile_definitions (simd_test PRIVATE ENABLE_AVX2=1)    
-    endif ()
+        target_compile_definitions(simd_test PRIVATE ENABLE_AVX2=1)
+    endif()
     if (DIST_CONTAINS_AVX512)
-        target_compile_definitions (simd_test PRIVATE ENABLE_AVX512=1)
-    endif ()
+        target_compile_definitions(simd_test PRIVATE ENABLE_AVX512=1)
+    endif()
     if (DIST_CONTAINS_AVX512VPOPCNTDQ)
-        target_compile_definitions (simd_test PRIVATE ENABLE_AVX512VPOPCNTDQ=1)
-    endif ()
+        target_compile_definitions(simd_test PRIVATE ENABLE_AVX512VPOPCNTDQ=1)
+    endif()
     if (DIST_CONTAINS_NEON)
-        target_compile_definitions (simd_test PRIVATE ENABLE_NEON=1)
-    endif ()
-    target_link_libraries (simd_test PRIVATE Catch2::Catch2 vsag simd)
-    add_dependencies (simd_test spdlog Catch2)
+        target_compile_definitions(simd_test PRIVATE ENABLE_NEON=1)
+    endif()
+    target_link_libraries(simd_test PRIVATE Catch2::Catch2 vsag simd)
+    add_dependencies(simd_test spdlog Catch2)
 endif()

--- a/src/storage/CMakeLists.txt
+++ b/src/storage/CMakeLists.txt
@@ -14,20 +14,20 @@
 # limitations under the License.
 
 
-set (STORAGE_SRC
-  footer.cpp
-  serialization.cpp
-  stream_reader.cpp
-  stream_writer.cpp
+set(STORAGE_SRC
+    footer.cpp
+    serialization.cpp
+    stream_reader.cpp
+    stream_writer.cpp
 )
 
-add_library (storage OBJECT ${STORAGE_SRC})
-target_link_libraries (storage PUBLIC fmt::fmt coverage_config)
-add_dependencies (storage spdlog)
+add_library(storage OBJECT ${STORAGE_SRC})
+target_link_libraries(storage PUBLIC fmt::fmt coverage_config)
+add_dependencies(storage spdlog)
 
 if (ENABLE_TESTS)
-    file (GLOB_RECURSE STORAGE_TESTS "*_test.cpp")
-    add_library (storage_test STATIC ${STORAGE_TESTS})
-    target_link_libraries (storage_test PRIVATE Catch2::Catch2 vsag)
-    add_dependencies (storage_test spdlog Catch2)
-endif ()
+    file(GLOB_RECURSE STORAGE_TESTS "*_test.cpp")
+    add_library(storage_test STATIC ${STORAGE_TESTS})
+    target_link_libraries(storage_test PRIVATE Catch2::Catch2 vsag)
+    add_dependencies(storage_test spdlog Catch2)
+endif()

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -14,25 +14,25 @@
 # limitations under the License.
 
 
-set (UTILS_SRC
-        util_functions.cpp
-        linear_congruential_generator.cpp
-        visited_list.cpp
-        slow_task_timer.cpp
-        timer.cpp
-        window_result_queue.cpp
-        sparse_vector_transform.cpp
-        prefetch.cpp
-        lock_strategy.cpp
+set(UTILS_SRC
+    util_functions.cpp
+    linear_congruential_generator.cpp
+    visited_list.cpp
+    slow_task_timer.cpp
+    timer.cpp
+    window_result_queue.cpp
+    sparse_vector_transform.cpp
+    prefetch.cpp
+    lock_strategy.cpp
 )
 
-add_library (utils OBJECT ${UTILS_SRC})
-target_link_libraries (utils PUBLIC coverage_config)
-add_dependencies (utils spdlog fmt::fmt)
+add_library(utils OBJECT ${UTILS_SRC})
+target_link_libraries(utils PUBLIC coverage_config)
+add_dependencies(utils spdlog fmt::fmt)
 
 if (ENABLE_TESTS)
-    file (GLOB_RECURSE UTILS_TESTS "*_test.cpp")
-    add_library (utils_test STATIC ${UTILS_TESTS})
-    target_link_libraries (utils_test PRIVATE Catch2::Catch2 vsag)
-    add_dependencies (utils_test spdlog Catch2)
-endif ()
+    file(GLOB_RECURSE UTILS_TESTS "*_test.cpp")
+    add_library(utils_test STATIC ${UTILS_TESTS})
+    target_link_libraries(utils_test PRIVATE Catch2::Catch2 vsag)
+    add_dependencies(utils_test spdlog Catch2)
+endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,22 +15,36 @@
 
 
 #  unittests
-add_executable (unittests
-        test_main.cpp
-        fixtures/fixtures.cpp
-        fixtures/test_logger.cpp
+add_executable(
+    unittests
+    test_main.cpp
+    fixtures/fixtures.cpp
+    fixtures/test_logger.cpp
 )
 
 if (APPLE)
-        target_link_libraries (unittests
-                        PRIVATE
-                        Catch2::Catch2 
-                        simd_test vsag_test algorithm_test factory_test attr_test
-                        datacell_test quantizer_test storage_test io_test utils_test impl_test
-                        vsag
-        )
-        # Ensure static test libraries are not dead-stripped on macOS.
-        target_link_options (unittests PRIVATE
+    target_link_libraries(
+        unittests
+        PRIVATE
+        Catch2::Catch2
+        simd_test
+        vsag_test
+        algorithm_test
+        factory_test
+        attr_test
+        datacell_test
+        quantizer_test
+        storage_test
+        io_test
+        utils_test
+        impl_test
+        vsag
+    )
+
+    # Ensure static test libraries are not dead-stripped on macOS.
+    target_link_options(
+        unittests
+        PRIVATE
         "-Wl,-force_load,$<TARGET_FILE:simd_test>"
         "-Wl,-force_load,$<TARGET_FILE:vsag_test>"
         "-Wl,-force_load,$<TARGET_FILE:algorithm_test>"
@@ -42,20 +56,30 @@ if (APPLE)
         "-Wl,-force_load,$<TARGET_FILE:io_test>"
         "-Wl,-force_load,$<TARGET_FILE:utils_test>"
         "-Wl,-force_load,$<TARGET_FILE:impl_test>"
-        )
+    )
 else()
-        target_link_libraries (unittests
-                        PRIVATE
-                        Catch2::Catch2 
-                        "-Wl,--whole-archive"
-                        simd_test vsag_test algorithm_test factory_test attr_test
-                        datacell_test quantizer_test storage_test io_test utils_test impl_test
-                        "-Wl,--no-whole-archive"
-                        vsag
-        )
+    target_link_libraries(
+        unittests
+        PRIVATE
+        Catch2::Catch2
+        "-Wl,--whole-archive"
+        simd_test
+        vsag_test
+        algorithm_test
+        factory_test
+        attr_test
+        datacell_test
+        quantizer_test
+        storage_test
+        io_test
+        utils_test
+        impl_test
+        "-Wl,--no-whole-archive"
+        vsag
+    )
 endif()
 
-add_dependencies (unittests spdlog Catch2 vsag)
+add_dependencies(unittests spdlog Catch2 vsag)
 
 # function tests
 file (GLOB FUNCTION_TESTS "test_*.cpp")

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -14,6 +14,6 @@
 # limitations under the License.
 
 
-add_subdirectory (eval)
-add_subdirectory (check_compatibility)
-add_subdirectory (analyze_index)
+add_subdirectory(eval)
+add_subdirectory(check_compatibility)
+add_subdirectory(analyze_index)

--- a/tools/analyze_index/CMakeLists.txt
+++ b/tools/analyze_index/CMakeLists.txt
@@ -14,11 +14,11 @@
 # limitations under the License.
 
 
-add_executable (analyze_index analyze_index.cpp)
-target_link_libraries (analyze_index
-        PRIVATE
-        argparse::argparse
-        vsag
+add_executable(analyze_index analyze_index.cpp)
+target_link_libraries(
+    analyze_index
+    PRIVATE
+    argparse::argparse
+    vsag
 )
-
 

--- a/tools/check_compatibility/CMakeLists.txt
+++ b/tools/check_compatibility/CMakeLists.txt
@@ -14,10 +14,10 @@
 # limitations under the License.
 
 
-add_executable (check_compatibility check_compatibility.cpp)
-target_link_libraries (check_compatibility
-        PRIVATE
-        vsag
+add_executable(check_compatibility check_compatibility.cpp)
+target_link_libraries(
+    check_compatibility
+    PRIVATE
+    vsag
 )
-
 

--- a/tools/eval/CMakeLists.txt
+++ b/tools/eval/CMakeLists.txt
@@ -14,40 +14,42 @@
 # limitations under the License.
 
 
-set (eval_srcs
-        case/eval_case.cpp
-        case/search_eval_case.cpp
-        case/build_eval_case.cpp
+set(eval_srcs
+    case/eval_case.cpp
+    case/search_eval_case.cpp
+    case/build_eval_case.cpp
 
-        exporter/exporter.cpp
-        exporter/formatter.cpp
+    exporter/exporter.cpp
+    exporter/formatter.cpp
 
-        monitor/monitor.cpp
-        monitor/latency_monitor.cpp
-        monitor/recall_monitor.cpp
-        monitor/memory_peak_monitor.cpp
-        monitor/duration_monitor.cpp
+    monitor/monitor.cpp
+    monitor/latency_monitor.cpp
+    monitor/recall_monitor.cpp
+    monitor/memory_peak_monitor.cpp
+    monitor/duration_monitor.cpp
 
-        eval_config.cpp
-        eval_dataset.cpp
-        eval_job.cpp
-        )
-add_library (eval_obj OBJECT ${eval_srcs})
-target_compile_options (eval_obj PRIVATE -fopenmp)
-target_link_libraries (eval_obj PRIVATE cpr)
-add_dependencies (eval_obj hdf5 spdlog yaml-cpp tabulate cpr)
+    eval_config.cpp
+    eval_dataset.cpp
+    eval_job.cpp
+)
 
-add_executable (eval_performance main.cpp)
-target_compile_options (eval_performance PRIVATE -fopenmp)
-target_link_libraries (eval_performance
-  PRIVATE
-  vsag
-  eval_obj
-  yaml-cpp
-  argparse::argparse
-  tabulate
-  simd
-  libhdf5_cpp.a
-  libhdf5.a
-  z
+add_library(eval_obj OBJECT ${eval_srcs})
+target_compile_options(eval_obj PRIVATE -fopenmp)
+target_link_libraries(eval_obj PRIVATE cpr)
+add_dependencies(eval_obj hdf5 spdlog yaml-cpp tabulate cpr)
+
+add_executable(eval_performance main.cpp)
+target_compile_options(eval_performance PRIVATE -fopenmp)
+target_link_libraries(
+    eval_performance
+    PRIVATE
+    vsag
+    eval_obj
+    yaml-cpp
+    argparse::argparse
+    tabulate
+    simd
+    libhdf5_cpp.a
+    libhdf5.a
+    z
 )


### PR DESCRIPTION
Normalize CMake files to improve readability and make git diffs more trackable. Changes include:
- Standardize command spacing: cmd(arg) instead of cmd (arg)
- Use endif()/endmacro() style without space before parentheses
- Split long lists (dependencies, sources, libraries) into one item per line to make additions/deletions obvious in diffs
- Normalize multi-line blocks for target_link_libraries and add_executable
- Add brief comments before key sections (project, policies, utilities)

This is a pure formatting change with no functional modifications to the build system.