### PR TITLE
refactor(tests): migrate Python tests to pytest framework

### DIFF
--- a/.github/workflows/build_release_wheel.yml
+++ b/.github/workflows/build_release_wheel.yml
@@ -106,7 +106,21 @@ jobs:
         env:
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_BUILD: ${{ matrix.cibw-build-id }}
-          CIBW_TEST_COMMAND: "pip install numpy && ls -alF /project/ && python /project/tests/python/run_test.py"
+          CIBW_TEST_COMMAND: |
+            pip install numpy pytest && \
+            echo "=== Running VSAG Python Tests ===" && \
+            python -m pytest /project/tests/python -v --tb=short 2>&1 | tee /tmp/test-output.log && \
+            if grep -q "FAILED\|ERROR" /tmp/test-output.log; then \
+              echo "❌ Tests failed!" && \
+              grep -A 5 "FAILED\|ERROR" /tmp/test-output.log && \
+              exit 1; \
+            elif grep -q "passed" /tmp/test-output.log; then \
+              echo "✅ All tests passed!" && \
+              exit 0; \
+            else \
+              echo "⚠️ Test results unclear" && \
+              exit 1; \
+            fi
 
       - uses: actions/upload-artifact@v5
         with:
@@ -141,7 +155,21 @@ jobs:
         env:
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_BUILD: "cp36-*"
-          CIBW_TEST_COMMAND: "pip install numpy && ls -alF /project/ && python /project/tests/python/run_test.py"
+          CIBW_TEST_COMMAND: |
+            pip install numpy pytest && \
+            echo "=== Running VSAG Python Tests ===" && \
+            python -m pytest /project/tests/python -v --tb=short 2>&1 | tee /tmp/test-output.log && \
+            if grep -q "FAILED\|ERROR" /tmp/test-output.log; then \
+              echo "❌ Tests failed!" && \
+              grep -A 5 "FAILED\|ERROR" /tmp/test-output.log && \
+              exit 1; \
+            elif grep -q "passed" /tmp/test-output.log; then \
+              echo "✅ All tests passed!" && \
+              exit 0; \
+            else \
+              echo "⚠️ Test results unclear" && \
+              exit 1; \
+            fi
 
       - uses: actions/upload-artifact@v5
         with:

--- a/.github/workflows/python_build_and_test.yml
+++ b/.github/workflows/python_build_and_test.yml
@@ -96,11 +96,42 @@ jobs:
         run: |
             pip3 uninstall pyvsag -y
             pip3 install ./wheelhouse/*.whl
-            pip3 install numpy pyjson
+            pip3 install numpy pyjson pytest
+      
       - name: Run Python Test
         run: |
             cd ./tests/python/
-            python3 run_test.py
+            echo "=== Running pytest with detailed output ==="
+            python3 -m pytest . -v --tb=short 2>&1 | tee test-output.log
+            echo "=== Test execution completed ==="
+        continue-on-error: true
+      
+      - name: Analyze Test Results
+        run: |
+            cd ./tests/python/
+            echo "=== Analyzing test results ==="
+            if grep -q "FAILED\|ERROR" test-output.log; then
+              echo "❌ Some tests failed!"
+              echo "=== Failed tests summary ==="
+              grep -A 5 "FAILED\|ERROR" test-output.log || true
+              exit 1
+            elif grep -q "passed" test-output.log && ! grep -q "FAILED" test-output.log; then
+              PASSED=$(grep -oP '\d+(?= passed)' test-output.log || echo "0")
+              echo "✅ All tests passed! ($PASSED tests)"
+            else
+              echo "⚠️ Could not determine test results"
+              cat test-output.log
+              exit 1
+            fi
+      
+      - name: Upload Test Logs
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: pytest-logs-x86-${{ github.run_id }}
+          path: ./tests/python/test-output.log
+          retention-days: 30
+          if-no-files-found: ignore
 
   test_python_aarch64:
     name: Test Python Aarch64
@@ -124,11 +155,42 @@ jobs:
         run: |
           pip3 uninstall pyvsag -y
           pip3 install ./wheelhouse/*.whl
-          pip3 install numpy pyjson
+          pip3 install numpy pyjson pytest
+      
       - name: Run Python Test
         run: |
             cd ./tests/python/
-            python3 run_test.py
+            echo "=== Running pytest with detailed output ==="
+            python3 -m pytest . -v --tb=short 2>&1 | tee test-output.log
+            echo "=== Test execution completed ==="
+        continue-on-error: true
+      
+      - name: Analyze Test Results
+        run: |
+            cd ./tests/python/
+            echo "=== Analyzing test results ==="
+            if grep -q "FAILED\|ERROR" test-output.log; then
+              echo "❌ Some tests failed!"
+              echo "=== Failed tests summary ==="
+              grep -A 5 "FAILED\|ERROR" test-output.log || true
+              exit 1
+            elif grep -q "passed" test-output.log && ! grep -q "FAILED" test-output.log; then
+              PASSED=$(grep -oP '\d+(?= passed)' test-output.log || echo "0")
+              echo "✅ All tests passed! ($PASSED tests)"
+            else
+              echo "⚠️ Could not determine test results"
+              cat test-output.log
+              exit 1
+            fi
+      
+      - name: Upload Test Logs
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: pytest-logs-aarch64-${{ github.run_id }}
+          path: ./tests/python/test-output.log
+          retention-days: 30
+          if-no-files-found: ignore
         
   clean_up:
     name: Clean Up

--- a/scripts/python/local_build_wheel.sh
+++ b/scripts/python/local_build_wheel.sh
@@ -90,7 +90,7 @@ run_build() {
     echo "🛠️  Starting cibuildwheel... "
     CIBW_BUILD="${cibw_build_pattern}" \
     CIBW_ARCHS="${ARCH}" \
-    CIBW_TEST_COMMAND="pip install numpy && ls -alF /project/ && python /project/tests/python/run_test.py" \
+    CIBW_TEST_COMMAND="pip install numpy pytest && bash /project/tests/python/test_runner.sh" \
     cibuildwheel --platform linux --output-dir wheelhouse python
   else 
     echo "🛠️  Starting build..."
@@ -107,8 +107,9 @@ run_build() {
     echo "   - Installing wheel: ${LATEST_WHEEL}"
     pip install "${LATEST_WHEEL}" --force-reinstall
     echo "   - Running tests..."
-    pip install numpy
-    python examples/python/example_hnsw.py
+    pip install numpy pytest
+    cd tests/python && python -m pytest . -v --tb=short 2>&1 | tee test-output.log || (cat test-output.log && exit 1)
+    cd ../..
   fi
 
   cleanup

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -1,0 +1,166 @@
+# Copyright 2024-present the vsag project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pytest fixtures and utilities for VSAG index tests"""
+
+import json
+import numpy as np
+import pyvsag
+import pytest
+import os
+from pathlib import Path
+
+
+class TestDataset:
+    """Test dataset class for VSAG index tests"""
+
+    def __init__(self, num_vectors=200, dim=128, seed=42, topk=10, metric="l2"):
+        self.num_vectors = num_vectors
+        self.dim = dim
+        self.seed = seed
+        self.query_vectors_count = 10
+        self.base_vectors, self.query_vectors, self.ids, self.num_elements, self.dim = (
+            TestDataset.create_test_dataset(num_vectors, dim, seed)
+        )
+        self.gt_ids, self.gt_dists = self.cal_gt_knn_results(
+            self.base_vectors, self.query_vectors, k=topk, metric=metric
+        )
+
+    @staticmethod
+    def generate_random_vectors(num_vectors, dim, seed=49):
+        """Generate random float32 vectors for testing"""
+        np.random.seed(seed)
+        return np.random.randn(num_vectors * dim).astype(np.float32)
+
+    @staticmethod
+    def generate_sequential_ids(num_vectors):
+        """Generate sequential IDs for testing"""
+        return np.arange(num_vectors, dtype=np.int64)
+
+    @staticmethod
+    def create_test_dataset(num_vectors=100, dim=128, seed=49):
+        """Create a standard test dataset"""
+        vectors = TestDataset.generate_random_vectors(num_vectors, dim, seed)
+        ids = TestDataset.generate_sequential_ids(num_vectors)
+        query_vectors = TestDataset.generate_random_vectors(10, dim, seed * 2)
+        return vectors, query_vectors, ids, num_vectors, dim
+
+    def cal_gt_knn_results(
+        self, vectors: np.ndarray, query_vectors: np.ndarray, k=10, metric="l2"
+    ):
+        """Calculate ground truth KNN results for verification"""
+        new_vectors = vectors.reshape(-1, self.dim)
+        new_query_vectors = query_vectors.reshape(-1, self.dim)
+        result_ids = []
+        result_dists = []
+        for query_vector in new_query_vectors:
+            if metric == "l2":
+                dists = np.linalg.norm(new_vectors - query_vector, axis=1)
+            elif metric == "ip":
+                dists = -np.dot(new_vectors, query_vector)
+            elif metric == "cosine":
+                dists = 1 - (
+                    np.dot(new_vectors, query_vector)
+                    / (
+                        np.linalg.norm(new_vectors, axis=1)
+                        * np.linalg.norm(query_vector)
+                    )
+                )
+            else:
+                raise ValueError(f"Unsupported metric: {metric}")
+            sorted_indices = np.argsort(dists)
+            result_ids.append(sorted_indices[:k])
+            result_dists.append(dists[sorted_indices[:k]])
+        return np.array(result_ids), np.array(result_dists)
+
+
+# Fixtures
+
+@pytest.fixture
+def dataset():
+    """Default test dataset (128 dim, 200 vectors, l2 metric)"""
+    return TestDataset(num_vectors=200, dim=128, seed=42, topk=10, metric="l2")
+
+
+@pytest.fixture
+def dataset_factory():
+    """Factory fixture for creating datasets with custom parameters"""
+    def _create(num_vectors=200, dim=128, seed=42, topk=10, metric="l2"):
+        return TestDataset(
+            num_vectors=num_vectors, dim=dim, seed=seed, topk=topk, metric=metric
+        )
+    return _create
+
+
+@pytest.fixture
+def generate_random_filepath():
+    """Generate random file path for testing"""
+    def _generate():
+        random_id = np.random.randint(0, 1000000)
+        filename = f"test_index_{random_id}.vsag"
+        while os.path.exists(filename):
+            random_id = np.random.randint(0, 1000000)
+            filename = f"test_index_{random_id}.vsag"
+        return filename
+    return _generate
+
+
+# Helper functions
+
+def create_index(index_type: str, index_param: str) -> pyvsag.Index:
+    """Factory function to create index for testing"""
+    return pyvsag.Index(index_type, index_param)
+
+
+def build_index(index: pyvsag.Index, dataset: TestDataset):
+    """Build index for testing"""
+    index.build(
+        dataset.base_vectors, dataset.ids, dataset.num_elements, dataset.dim
+    )
+
+
+def save_index(index: pyvsag.Index, file_path: str):
+    """Serialize index for testing"""
+    index.save(file_path)
+
+
+def load_index(index: pyvsag.Index, file_path: str):
+    """Load index for testing"""
+    index.load(file_path)
+
+
+def calculate_recall(results: np.ndarray, gt_ids: np.ndarray, topk: int = 10) -> float:
+    """Calculate recall for testing"""
+    recall = np.isin(results[:topk], gt_ids[:topk]).sum(axis=0)
+    return recall / topk
+
+
+def verify_knn_search(
+    index: pyvsag.Index,
+    dataset: TestDataset,
+    search_param: str,
+    topk: int = 10,
+    expect_recall: float = 0.9,
+):
+    """Test knn_search method for testing"""
+    query_count = dataset.query_vectors_count
+    query_vectors = dataset.query_vectors.reshape(query_count, dataset.dim)
+    recall = 0
+    for i in range(query_count):
+        query = query_vectors[i]
+        ids, _ = index.knn_search(vector=query, k=topk, parameters=search_param)
+        assert len(ids) == topk
+        recall += calculate_recall(ids, dataset.gt_ids, topk)
+    print(f"recall: {recall / query_count}")
+    assert recall >= expect_recall * query_count

--- a/tests/python/run_test.py
+++ b/tests/python/run_test.py
@@ -12,18 +12,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from test_ivf import run_ivf_test
-from test_hnsw import run_hnsw_test
-from test_hgraph import run_hgraph_test
-from test_bruteforce import run_bruteforce_test
+"""Test runner - now uses pytest under the hood"""
+
+import os
+import pytest
+import sys
 
 
 def run():
-    run_ivf_test()
-    run_hnsw_test()
-    run_hgraph_test()
-    run_bruteforce_test()
+    """Run all tests using pytest"""
+    # Get the directory where this script is located
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    args = [
+        "-v",
+        os.path.join(script_dir, "test_ivf.py"),
+        os.path.join(script_dir, "test_hnsw.py"),
+        os.path.join(script_dir, "test_hgraph.py"),
+        os.path.join(script_dir, "test_bruteforce.py"),
+    ]
+    return pytest.main(args)
 
 
 if __name__ == "__main__":
-    run()
+    sys.exit(run())

--- a/tests/python/test_base.py
+++ b/tests/python/test_base.py
@@ -12,44 +12,50 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from test_dataset import TestDataset
+"""Test base module - re-exported from conftest for backward compatibility"""
+
 import pyvsag
-import json
 import numpy as np
 import os
+from conftest import (
+    TestDataset,
+    create_index,
+    build_index,
+    save_index,
+    load_index,
+    calculate_recall,
+)
+
+__all__ = ["TestBase", "TestDataset"]
 
 
 class TestBase:
-    """Test base class for VSAG index tests"""
+    """Test base class for VSAG index tests - backward compatibility wrapper"""
 
     @staticmethod
     def FactoryIndex(index_type: str, index_param: str) -> pyvsag.Index:
         """Factory method to create index for testing"""
-        return pyvsag.Index(index_type, index_param)
+        return create_index(index_type, index_param)
 
     @staticmethod
     def BuildIndex(index: pyvsag.Index, dataset: TestDataset):
         """Build index for testing"""
-        index.build(
-            dataset.base_vectors, dataset.ids, dataset.num_elements, dataset.dim
-        )
+        build_index(index, dataset)
 
     @staticmethod
     def SaveIndex(index: pyvsag.Index, file_path: str):
         """Serialize index for testing"""
-        index.save(file_path)
+        save_index(index, file_path)
 
     @staticmethod
     def LoadIndex(index: pyvsag.Index, file_path: str):
         """Load index for testing"""
-        index.load(file_path)
+        load_index(index, file_path)
 
     @staticmethod
     def CalRecall(results: np.ndarray, gt_ids: np.ndarray, topk: int = 10) -> float:
         """Calculate recall for testing"""
-        # too many indices for array: array is 1-dimensional, but 2 were indexed
-        recall = np.isin(results[:topk], gt_ids[:topk]).sum(axis=0)
-        return recall / topk
+        return calculate_recall(results, gt_ids, topk)
 
     @staticmethod
     def GenerateRandomFilePath() -> str:
@@ -70,28 +76,5 @@ class TestBase:
         expect_recall: float = 0.9,
     ):
         """Test knn_search method for testing"""
-        query_count = dataset.query_vectors_count
-        query_vectors = dataset.query_vectors.reshape(query_count, dataset.dim)
-        recall = 0
-        for i in range(query_count):
-            query = query_vectors[i]
-            ids, _ = index.knn_search(vector=query, k=topk, parameters=search_param)
-            assert len(ids) == topk
-            recall += TestBase.CalRecall(ids, dataset.gt_ids, topk)
-        print(f"recall: {recall / query_count}")
-        assert recall >= expect_recall * query_count
-
-
-if __name__ == "__main__":
-    dataset = TestDataset()
-    index_params = json.dumps(
-        {
-            "dtype": "float32",
-            "metric_type": "l2",
-            "dim": 128,
-            "hnsw": {"max_degree": 16, "ef_construction": 100},
-        }
-    )
-    index = TestBase.FactoryIndex("hnsw", index_params)
-    TestBase.BuildIndex(index, dataset)
-    TestBase.TestKnnSearch(index, dataset, json.dumps({"hnsw": {"ef_search": 100}}))
+        from conftest import verify_knn_search
+        verify_knn_search(index, dataset, search_param, topk, expect_recall)

--- a/tests/python/test_bruteforce.py
+++ b/tests/python/test_bruteforce.py
@@ -12,94 +12,76 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from test_base import TestBase
-from test_dataset import TestDataset
+"""Pytest tests for Bruteforce index"""
+
 import json
-import os
 import pyvsag
+import pytest
+from conftest import create_index, build_index, save_index, load_index, verify_knn_search
 
 
-class TestBruteforce(TestBase):
-    """Test Bruteforce index"""
-
-    type_name: str = "brute_force"
-
-    def __init__(
-        self,
-        dim: int = 128,
-        num_vectors: int = 1000,
-        metric: str = "l2",
-        expect_recall: float = 0.9,
-        quantization_type: str = "sq8",
-    ):
-        self.dim = dim
-        self.num_vectors = num_vectors
-        self.metric = metric
-        self.dataset = TestDataset(dim=dim, num_vectors=num_vectors, metric=metric)
-        qs = quantization_type.split(",")
-        self.base_quantization_type = qs[0]
-        self.precise_quantization_type = "fp32"
-        if len(qs) > 1:
-            self.precise_quantization_type = qs[1]
-            self.use_reorder = True
-        else:
-            self.use_reorder = False
-
-        self.index_params = json.dumps(
-            {
-                "dtype": "float32",
-                "metric_type": self.metric,
-                "dim": self.dim,
-                "index_param": {
-                    "base_quantization_type": self.base_quantization_type,
-                    "precise_quantization_type": self.precise_quantization_type,
-                },
-            }
-        )
-
-    def init_index(self) -> pyvsag.Index:
-        """Initialize Bruteforce index"""
-        return TestBase.FactoryIndex(self.type_name, self.index_params)
-
-    def general_test_search(self):
-        """Test search index"""
-        search_params = json.dumps({})
-        TestBase.TestKnnSearch(self.index, self.dataset, search_params)
-
-    def test_build(self):
-        """Test build index"""
-        self.index = self.init_index()
-        TestBase.BuildIndex(self.index, self.dataset)
-        self.general_test_search()
-
-    def test_load_save(self):
-        """Test load and save index"""
-        filename = TestBase.GenerateRandomFilePath()
-        TestBase.SaveIndex(self.index, filename)
-        self.index = self.init_index()
-        TestBase.LoadIndex(self.index, filename)
-        os.remove(filename)
-        self.general_test_search()
+TYPE_NAME = "brute_force"
 
 
-def run_bruteforce_test():
-    """Run Bruteforce index tests"""
-    metric_types = ["ip"]
-    dims = [128, 256, 1024]
-    quantizer_recalls = [
-        ("sq8", 0.9),
-        ("fp16", 0.98),
-        ("fp32", 0.9999),
-    ]
-    for metric in metric_types:
-        for dim in dims:
-            for qt, recall in quantizer_recalls:
-                test_brute_force = TestBruteforce(
-                    dim=dim, metric=metric, expect_recall=recall, quantization_type=qt
-                )
-                test_brute_force.test_build()
-                test_brute_force.test_load_save()
+def _create_index_params(dim: int, metric: str, quantization_type: str) -> str:
+    """Create index parameters for Bruteforce"""
+    qs = quantization_type.split(",")
+    base_quantization_type = qs[0]
+    precise_quantization_type = "fp32"
+    if len(qs) > 1:
+        precise_quantization_type = qs[1]
+    
+    return json.dumps(
+        {
+            "dtype": "float32",
+            "metric_type": metric,
+            "dim": dim,
+            "index_param": {
+                "base_quantization_type": base_quantization_type,
+                "precise_quantization_type": precise_quantization_type,
+            },
+        }
+    )
 
 
-if __name__ == "__main__":
-    run_bruteforce_test()
+@pytest.mark.parametrize("metric", ["ip"])
+@pytest.mark.parametrize("dim", [128, 256, 1024])
+@pytest.mark.parametrize("quantization_type,expect_recall", [
+    ("sq8", 0.9),
+    ("fp16", 0.98),
+    ("fp32", 0.9999),
+])
+def test_bruteforce_build(dim, metric, quantization_type, expect_recall, dataset_factory):
+    """Test building Bruteforce index"""
+    dataset = dataset_factory(dim=dim, num_vectors=1000, metric=metric)
+    index_params = _create_index_params(dim, metric, quantization_type)
+    index = create_index(TYPE_NAME, index_params)
+    build_index(index, dataset)
+    
+    search_params = json.dumps({})
+    verify_knn_search(index, dataset, search_params, expect_recall=expect_recall)
+
+
+@pytest.mark.parametrize("metric", ["ip"])
+@pytest.mark.parametrize("dim", [128, 256, 1024])
+@pytest.mark.parametrize("quantization_type,expect_recall", [
+    ("sq8", 0.9),
+    ("fp16", 0.98),
+    ("fp32", 0.9999),
+])
+def test_bruteforce_load_save(dim, metric, quantization_type, expect_recall, dataset_factory, tmp_path):
+    """Test loading and saving Bruteforce index"""
+    dataset = dataset_factory(dim=dim, num_vectors=1000, metric=metric)
+    index_params = _create_index_params(dim, metric, quantization_type)
+    
+    # Build and save
+    index = create_index(TYPE_NAME, index_params)
+    build_index(index, dataset)
+    filename = tmp_path / f"test_bruteforce_{dim}_{metric}_{quantization_type.replace(',', '_')}.vsag"
+    save_index(index, str(filename))
+    
+    # Load and test
+    index = create_index(TYPE_NAME, index_params)
+    load_index(index, str(filename))
+    search_params = json.dumps({})
+    verify_knn_search(index, dataset, search_params, expect_recall=expect_recall)

--- a/tests/python/test_dataset.py
+++ b/tests/python/test_dataset.py
@@ -12,73 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
+"""Test dataset module - re-exported from conftest for backward compatibility"""
 
+# Re-export from conftest for backward compatibility
+from conftest import TestDataset
 
-class TestDataset:
-    """Test dataset class for VSAG index tests"""
-
-    def __init__(self, num_vectors=200, dim=128, seed=42, topk=10, metric="l2"):
-        self.num_vectors = num_vectors
-        self.dim = dim
-        self.seed = seed
-        self.query_vectors_count = 10
-        self.base_vectors, self.query_vectors, self.ids, self.num_elements, self.dim = (
-            TestDataset.create_test_dataset(num_vectors, dim, seed)
-        )
-        self.gt_ids, self.gt_dists = self.cal_gt_knn_results(
-            self.base_vectors, self.query_vectors, k=topk, metric=metric
-        )
-
-    @staticmethod
-    def generate_random_vectors(num_vectors, dim, seed=49):
-        """Generate random float32 vectors for testing"""
-        np.random.seed(seed)
-        return np.random.randn(num_vectors * dim).astype(np.float32)
-
-    @staticmethod
-    def generate_sequential_ids(num_vectors):
-        """Generate sequential IDs for testing"""
-        return np.arange(num_vectors, dtype=np.int64)
-
-    @staticmethod
-    def create_test_dataset(num_vectors=100, dim=128, seed=49):
-        """Create a standard test dataset"""
-        vectors = TestDataset.generate_random_vectors(num_vectors, dim, seed)
-        ids = TestDataset.generate_sequential_ids(num_vectors)
-        query_vectors = TestDataset.generate_random_vectors(10, dim, seed * 2)
-        return vectors, query_vectors, ids, num_vectors, dim
-
-    def cal_gt_knn_results(
-        self, vectors: np.ndarray, query_vectors: np.ndarray, k=10, metric="l2"
-    ):
-        """Calculate ground truth KNN results for verification"""
-        new_vectors = vectors.reshape(-1, self.dim)
-        new_query_vectors = query_vectors.reshape(-1, self.dim)
-        result_ids = []
-        result_dists = []
-        for query_vector in new_query_vectors:
-            if metric == "l2":
-                dists = np.linalg.norm(new_vectors - query_vector, axis=1)
-            elif metric == "ip":
-                dists = -np.dot(new_vectors, query_vector)
-            elif metric == "cosine":
-                dists = 1 - (
-                    np.dot(new_vectors, query_vector)
-                    / (
-                        np.linalg.norm(new_vectors, axis=1)
-                        * np.linalg.norm(query_vector)
-                    )
-                )
-            else:
-                raise ValueError(f"Unsupported metric: {metric}")
-            sorted_indices = np.argsort(dists)
-            result_ids.append(sorted_indices[:k])
-            result_dists.append(dists[sorted_indices[:k]])
-        return np.array(result_ids), np.array(result_dists)
-
-
-if __name__ == "__main__":
-    test_dataset = TestDataset(num_vectors=1000, dim=128, seed=49, metric="ip")
-    print(test_dataset.gt_ids)
-    print(test_dataset.gt_dists)
+__all__ = ["TestDataset"]

--- a/tests/python/test_hgraph.py
+++ b/tests/python/test_hgraph.py
@@ -12,102 +12,87 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from test_base import TestBase
-from test_dataset import TestDataset
+"""Pytest tests for HGraph index"""
+
 import json
-import os
 import pyvsag
+import pytest
+from conftest import create_index, build_index, save_index, load_index, verify_knn_search
 
 
-class TestHGraph(TestBase):
-    """Test HGraph index"""
-
-    type_name: str = "hgraph"
-
-    def __init__(
-        self,
-        dim: int = 128,
-        num_vectors: int = 1000,
-        metric: str = "l2",
-        expect_recall: float = 0.9,
-        quantization_type: str = "sq8",
-    ):
-        self.dim = dim
-        self.num_vectors = num_vectors
-        self.metric = metric
-        self.dataset = TestDataset(dim=dim, num_vectors=num_vectors, metric=metric)
-        self.max_degree = int(dim / 4)
-        self.ef_construction = max(200, self.max_degree)
-        qs = quantization_type.split(",")
-        self.base_quantization_type = qs[0]
-        self.precise_quantization_type = "fp32"
-        if len(qs) > 1:
-            self.precise_quantization_type = qs[1]
-            self.use_reorder = True
-        else:
-            self.use_reorder = False
-
-        self.index_params = json.dumps(
-            {
-                "dtype": "float32",
-                "metric_type": self.metric,
-                "dim": self.dim,
-                "index_param": {
-                    "max_degree": self.max_degree,
-                    "ef_construction": self.ef_construction,
-                    "base_quantization_type": self.base_quantization_type,
-                    "precise_quantization_type": self.precise_quantization_type,
-                    "use_reorder": self.use_reorder,
-                },
-            }
-        )
-
-    def init_index(self) -> pyvsag.Index:
-        """Initialize HGraph index"""
-
-        return TestBase.FactoryIndex(self.type_name, self.index_params)
-
-    def general_test_search(self):
-        """Test search index"""
-        search_params = json.dumps({"hgraph": {"ef_search": 100}})
-        TestBase.TestKnnSearch(self.index, self.dataset, search_params)
-
-    def test_build(self):
-        """Test build index"""
-        self.index = self.init_index()
-        TestBase.BuildIndex(self.index, self.dataset)
-        self.general_test_search()
-
-    def test_load_save(self):
-        """Test load and save index"""
-        filename = TestBase.GenerateRandomFilePath()
-        TestBase.SaveIndex(self.index, filename)
-        self.index = self.init_index()
-        TestBase.LoadIndex(self.index, filename)
-        os.remove(filename)
-        self.general_test_search()
+TYPE_NAME = "hgraph"
 
 
-def run_hgraph_test():
-    """Run HNSW index tests"""
-    metric_types = ["ip"]
-    dims = [128, 256, 1024]
-    quantizer_recalls = [
-        ("sq8", 0.9),
-        ("fp16", 0.92),
-        ("fp32", 0.93),
-        ("sq8,fp16", 0.92),
-        ("sq8_uniform,fp32", 0.9),
-    ]
-    for metric in metric_types:
-        for dim in dims:
-            for qt, recall in quantizer_recalls:
-                test_hgraph = TestHGraph(
-                    dim=dim, metric=metric, expect_recall=recall, quantization_type=qt
-                )
-                test_hgraph.test_build()
-                test_hgraph.test_load_save()
+def _create_index_params(dim: int, metric: str, quantization_type: str) -> str:
+    """Create index parameters for HGraph"""
+    max_degree = int(dim / 4)
+    ef_construction = max(200, max_degree)
+    qs = quantization_type.split(",")
+    base_quantization_type = qs[0]
+    precise_quantization_type = "fp32"
+    use_reorder = False
+    if len(qs) > 1:
+        precise_quantization_type = qs[1]
+        use_reorder = True
+    
+    return json.dumps(
+        {
+            "dtype": "float32",
+            "metric_type": metric,
+            "dim": dim,
+            "index_param": {
+                "max_degree": max_degree,
+                "ef_construction": ef_construction,
+                "base_quantization_type": base_quantization_type,
+                "precise_quantization_type": precise_quantization_type,
+                "use_reorder": use_reorder,
+            },
+        }
+    )
 
 
-if __name__ == "__main__":
-    run_hgraph_test()
+@pytest.mark.parametrize("metric", ["ip"])
+@pytest.mark.parametrize("dim", [128, 256, 1024])
+@pytest.mark.parametrize("quantization_type,expect_recall", [
+    ("sq8", 0.9),
+    ("fp16", 0.92),
+    ("fp32", 0.93),
+    ("sq8,fp16", 0.92),
+    ("sq8_uniform,fp32", 0.9),
+])
+def test_hgraph_build(dim, metric, quantization_type, expect_recall, dataset_factory):
+    """Test building HGraph index"""
+    dataset = dataset_factory(dim=dim, num_vectors=1000, metric=metric)
+    index_params = _create_index_params(dim, metric, quantization_type)
+    index = create_index(TYPE_NAME, index_params)
+    build_index(index, dataset)
+    
+    search_params = json.dumps({"hgraph": {"ef_search": 100}})
+    verify_knn_search(index, dataset, search_params, expect_recall=expect_recall)
+
+
+@pytest.mark.parametrize("metric", ["ip"])
+@pytest.mark.parametrize("dim", [128, 256, 1024])
+@pytest.mark.parametrize("quantization_type,expect_recall", [
+    ("sq8", 0.9),
+    ("fp16", 0.92),
+    ("fp32", 0.93),
+    ("sq8,fp16", 0.92),
+    ("sq8_uniform,fp32", 0.9),
+])
+def test_hgraph_load_save(dim, metric, quantization_type, expect_recall, dataset_factory, tmp_path):
+    """Test loading and saving HGraph index"""
+    dataset = dataset_factory(dim=dim, num_vectors=1000, metric=metric)
+    index_params = _create_index_params(dim, metric, quantization_type)
+    
+    # Build and save
+    index = create_index(TYPE_NAME, index_params)
+    build_index(index, dataset)
+    filename = tmp_path / f"test_hgraph_{dim}_{metric}_{quantization_type.replace(',', '_')}.vsag"
+    save_index(index, str(filename))
+    
+    # Load and test
+    index = create_index(TYPE_NAME, index_params)
+    load_index(index, str(filename))
+    search_params = json.dumps({"hgraph": {"ef_search": 100}})
+    verify_knn_search(index, dataset, search_params, expect_recall=expect_recall)

--- a/tests/python/test_hnsw.py
+++ b/tests/python/test_hnsw.py
@@ -12,79 +12,62 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from test_base import TestBase
-from test_dataset import TestDataset
+"""Pytest tests for HNSW index"""
+
 import json
-import os
 import pyvsag
+import pytest
+from conftest import create_index, build_index, save_index, load_index, verify_knn_search
 
 
-class TestHNSW(TestBase):
-    """Test HNSW index"""
-
-    type_name: str = "hnsw"
-
-    def __init__(
-        self,
-        dim: int = 128,
-        num_vectors: int = 1000,
-        metric: str = "l2",
-        expect_recall: float = 0.9,
-    ):
-        self.dim = dim
-        self.num_vectors = num_vectors
-        self.metric = metric
-        self.dataset = TestDataset(dim=dim, num_vectors=num_vectors, metric=metric)
-        self.max_degree = int(dim / 4)
-        self.ef_construction = max(200, self.max_degree)
-        self.index_params = json.dumps(
-            {
-                "dtype": "float32",
-                "metric_type": self.metric,
-                "dim": self.dim,
-                "hnsw": {
-                    "max_degree": self.max_degree,
-                    "ef_construction": self.ef_construction,
-                },
-            }
-        )
-
-    def init_index(self) -> pyvsag.Index:
-        """Initialize HNSW index"""
-
-        return TestBase.FactoryIndex(self.type_name, self.index_params)
-
-    def general_test_search(self):
-        """Test search index"""
-        search_params = json.dumps({"hnsw": {"ef_search": 40}})
-        TestBase.TestKnnSearch(self.index, self.dataset, search_params)
-
-    def test_build(self):
-        """Test build index"""
-        self.index = self.init_index()
-        TestBase.BuildIndex(self.index, self.dataset)
-        self.general_test_search()
-
-    def test_load_save(self):
-        """Test load and save index"""
-        filename = TestBase.GenerateRandomFilePath()
-        TestBase.SaveIndex(self.index, filename)
-        self.index = self.init_index()
-        TestBase.LoadIndex(self.index, filename)
-        os.remove(filename)
-        self.general_test_search()
+TYPE_NAME = "hnsw"
 
 
-def run_hnsw_test():
-    """Run HNSW index tests"""
-    metric_types = ["ip"]
-    dims = [128, 256, 1024]
-    for metric in metric_types:
-        for dim in dims:
-            test_hnsw = TestHNSW(dim=dim, metric=metric)
-            test_hnsw.test_build()
-            test_hnsw.test_load_save()
+def _create_index_params(dim: int, metric: str) -> str:
+    """Create index parameters for HNSW"""
+    max_degree = int(dim / 4)
+    ef_construction = max(200, max_degree)
+    return json.dumps(
+        {
+            "dtype": "float32",
+            "metric_type": metric,
+            "dim": dim,
+            "hnsw": {
+                "max_degree": max_degree,
+                "ef_construction": ef_construction,
+            },
+        }
+    )
 
 
-if __name__ == "__main__":
-    run_hnsw_test()
+@pytest.mark.parametrize("metric", ["ip"])
+@pytest.mark.parametrize("dim", [128, 256, 1024])
+def test_hnsw_build(dim, metric, dataset_factory):
+    """Test building HNSW index"""
+    dataset = dataset_factory(dim=dim, num_vectors=1000, metric=metric)
+    index_params = _create_index_params(dim, metric)
+    index = create_index(TYPE_NAME, index_params)
+    build_index(index, dataset)
+    
+    search_params = json.dumps({"hnsw": {"ef_search": 40}})
+    verify_knn_search(index, dataset, search_params)
+
+
+@pytest.mark.parametrize("metric", ["ip"])
+@pytest.mark.parametrize("dim", [128, 256, 1024])
+def test_hnsw_load_save(dim, metric, dataset_factory, tmp_path):
+    """Test loading and saving HNSW index"""
+    dataset = dataset_factory(dim=dim, num_vectors=1000, metric=metric)
+    index_params = _create_index_params(dim, metric)
+    
+    # Build and save
+    index = create_index(TYPE_NAME, index_params)
+    build_index(index, dataset)
+    filename = tmp_path / f"test_hnsw_{dim}_{metric}.vsag"
+    save_index(index, str(filename))
+    
+    # Load and test
+    index = create_index(TYPE_NAME, index_params)
+    load_index(index, str(filename))
+    search_params = json.dumps({"hnsw": {"ef_search": 40}})
+    verify_knn_search(index, dataset, search_params)

--- a/tests/python/test_ivf.py
+++ b/tests/python/test_ivf.py
@@ -12,101 +12,86 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from test_base import TestBase
-from test_dataset import TestDataset
+"""Pytest tests for IVF index"""
+
 import json
-import os
 import pyvsag
-
-class TestIVF(TestBase):
-    """Test IVF index"""
-
-    type_name: str = "ivf"
-
-    def __init__(
-        self,
-        dim: int = 128,
-        num_vectors: int = 1000,
-        metric: str = "l2",
-        expect_recall: float = 0.9,
-        quantization_type: str = "sq8",
-    ):
-        self.dim = dim
-        self.num_vectors = num_vectors
-        self.metric = metric
-        self.dataset = TestDataset(dim=dim, num_vectors=num_vectors, metric=metric)
-        self.buckets_count = 50
-        qs = quantization_type.split(",")
-        self.base_quantization_type = qs[0]
-        self.precise_quantization_type = "fp32"
-        if len(qs) > 1:
-            self.precise_quantization_type = qs[1]
-            self.use_reorder = True
-        else:
-            self.use_reorder = False
-
-        self.index_params = json.dumps(
-            {
-                "dtype": "float32",
-                "metric_type": self.metric,
-                "dim": self.dim,
-                "index_param": {
-                    "buckets_count": 50,
-                    "partition_strategy_type": "ivf",
-                    "ivf_train_type": "kmeans",
-                    "base_quantization_type": self.base_quantization_type,
-                    "precise_quantization_type": self.precise_quantization_type,
-                    "use_reorder": self.use_reorder
-                },
-            }
-        )
-
-    def init_index(self) -> pyvsag.Index:
-        """Initialize IVF index"""
-
-        return TestBase.FactoryIndex(self.type_name, self.index_params)
-
-    def general_test_search(self):
-        """Test search index"""
-        search_params = json.dumps({"ivf": {"scan_buckets_count": 50, "factor": 4.0}})
-        TestBase.TestKnnSearch(self.index, self.dataset, search_params)
-
-    def test_build(self):
-        """Test build index"""
-        self.index = self.init_index()
-        TestBase.BuildIndex(self.index, self.dataset)
-        self.general_test_search()
-
-    def test_load_save(self):
-        """Test load and save index"""
-        filename = TestBase.GenerateRandomFilePath()
-        TestBase.SaveIndex(self.index, filename)
-        self.index = self.init_index()
-        TestBase.LoadIndex(self.index, filename)
-        os.remove(filename)
-        self.general_test_search()
+import pytest
+from conftest import create_index, build_index, save_index, load_index, verify_knn_search
 
 
-def run_ivf_test():
-    """Run HNSW index tests"""
-    metric_types = ["ip"]
-    dims = [128, 256, 1024]
-    quantizer_recalls = [
-        ("sq8", 0.9),
-        ("fp16", 0.92),
-        ("fp32", 0.93),
-        ("sq8,fp16", 0.92),
-        ("sq8_uniform,fp32", 0.9),
-    ]
-    for metric in metric_types:
-        for dim in dims:
-            for qt, recall in quantizer_recalls:
-                test_ivf = TestIVF(
-                    dim=dim, metric=metric, expect_recall=recall, quantization_type=qt
-                )
-                test_ivf.test_build()
-                test_ivf.test_load_save()
+TYPE_NAME = "ivf"
 
 
-if __name__ == "__main__":
-    run_ivf_test()
+def _create_index_params(dim: int, metric: str, quantization_type: str) -> str:
+    """Create index parameters for IVF"""
+    qs = quantization_type.split(",")
+    base_quantization_type = qs[0]
+    precise_quantization_type = "fp32"
+    use_reorder = False
+    if len(qs) > 1:
+        precise_quantization_type = qs[1]
+        use_reorder = True
+    
+    return json.dumps(
+        {
+            "dtype": "float32",
+            "metric_type": metric,
+            "dim": dim,
+            "index_param": {
+                "buckets_count": 50,
+                "partition_strategy_type": "ivf",
+                "ivf_train_type": "kmeans",
+                "base_quantization_type": base_quantization_type,
+                "precise_quantization_type": precise_quantization_type,
+                "use_reorder": use_reorder,
+            },
+        }
+    )
+
+
+@pytest.mark.parametrize("metric", ["ip"])
+@pytest.mark.parametrize("dim", [128, 256, 1024])
+@pytest.mark.parametrize("quantization_type,expect_recall", [
+    ("sq8", 0.9),
+    ("fp16", 0.92),
+    ("fp32", 0.93),
+    ("sq8,fp16", 0.92),
+    ("sq8_uniform,fp32", 0.9),
+])
+def test_ivf_build(dim, metric, quantization_type, expect_recall, dataset_factory):
+    """Test building IVF index"""
+    dataset = dataset_factory(dim=dim, num_vectors=1000, metric=metric)
+    index_params = _create_index_params(dim, metric, quantization_type)
+    index = create_index(TYPE_NAME, index_params)
+    build_index(index, dataset)
+    
+    search_params = json.dumps({"ivf": {"scan_buckets_count": 50}})
+    verify_knn_search(index, dataset, search_params, expect_recall=expect_recall)
+
+
+@pytest.mark.parametrize("metric", ["ip"])
+@pytest.mark.parametrize("dim", [128, 256, 1024])
+@pytest.mark.parametrize("quantization_type,expect_recall", [
+    ("sq8", 0.9),
+    ("fp16", 0.92),
+    ("fp32", 0.93),
+    ("sq8,fp16", 0.92),
+    ("sq8_uniform,fp32", 0.9),
+])
+def test_ivf_load_save(dim, metric, quantization_type, expect_recall, dataset_factory, tmp_path):
+    """Test loading and saving IVF index"""
+    dataset = dataset_factory(dim=dim, num_vectors=1000, metric=metric)
+    index_params = _create_index_params(dim, metric, quantization_type)
+    
+    # Build and save
+    index = create_index(TYPE_NAME, index_params)
+    build_index(index, dataset)
+    filename = tmp_path / f"test_ivf_{dim}_{metric}_{quantization_type.replace(',', '_')}.vsag"
+    save_index(index, str(filename))
+    
+    # Load and test
+    index = create_index(TYPE_NAME, index_params)
+    load_index(index, str(filename))
+    search_params = json.dumps({"ivf": {"scan_buckets_count": 50}})
+    verify_knn_search(index, dataset, search_params, expect_recall=expect_recall)

--- a/tests/python/test_runner.sh
+++ b/tests/python/test_runner.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Test runner script for cibuildwheel
+# This script runs pytest and analyzes results
+
+set -e
+
+echo "=== Running VSAG Python Tests ==="
+
+# Run pytest with detailed output
+python -m pytest /project/tests/python -v --tb=short 2>&1 | tee /tmp/test-output.log
+
+# Analyze results
+if grep -q 'FAILED\|ERROR' /tmp/test-output.log; then
+    echo "❌ Tests failed!"
+    grep -A 5 'FAILED\|ERROR' /tmp/test-output.log || true
+    exit 1
+elif grep -q 'passed' /tmp/test-output.log; then
+    PASSED=$(grep -oP '\d+(?= passed)' /tmp/test-output.log || echo "0")
+    echo "✅ All tests passed! ($PASSED tests)"
+    exit 0
+else
+    echo "⚠️  Test results unclear"
+    cat /tmp/test-output.log
+    exit 1
+fi


### PR DESCRIPTION
Convert class-based test structure to pytest functional approach:
- Replace unittest.TestCase classes with pytest functions
- Add pytest fixtures for test data and index management
- Use @pytest.mark.parametrize for configuration variants
- Update CI workflows to run pytest with detailed output
- Add test_runner.sh for cibuildwheel integration
- Maintain backward compatibility via conftest.py exports

Benefits:
- Cleaner, more maintainable test code
- Better test isolation with fixtures
- Easier to add new test cases
- Improved test failure reporting

Files changed:
- tests/python/*.py: Convert to pytest format
- tests/python/conftest.py: Add shared fixtures
- tests/python/test_runner.sh: New test runner script
- .github/workflows/*: Update to use pytest
- scripts/python/local_build_wheel.sh: Use pytest in build