### PR TITLE
feat(hgraph): add hops_limit search parameter

### DIFF
--- a/include/vsag/constants.h
+++ b/include/vsag/constants.h
@@ -178,6 +178,7 @@ extern const char* const HGRAPH_BASE_FILE_PATH;
 extern const char* const HGRAPH_PRECISE_IO_TYPE;
 extern const char* const HGRAPH_PRECISE_FILE_PATH;
 extern const char* const HGRAPH_PARAMETER_EF_RUNTIME;
+extern const char* const HGRAPH_PARAMETER_HOPS_LIMIT;
 extern const char* const HGRAPH_EXTRA_INFO_SIZE;
 extern const char* const HGRAPH_SUPPORT_DUPLICATE;
 extern const char* const HGRAPH_SUPPORT_TOMBSTONE;

--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -2151,6 +2151,19 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
     }
     search_param.parallel_search_thread_count = params.parallel_search_thread_count;
 
+    // hops_limit only takes effect when it's greater than ef_search
+    if (params.hops_limit <= static_cast<uint32_t>(params.ef_search)) {
+        search_param.hops_limit = std::numeric_limits<uint32_t>::max();
+        if (params.hops_limit != std::numeric_limits<uint32_t>::max()) {
+            logger::warn(
+                fmt::format("hops_limit({}) is not greater than ef_search({}), ignoring hops_limit",
+                            params.hops_limit,
+                            params.ef_search));
+        }
+    } else {
+        search_param.hops_limit = params.hops_limit;
+    }
+
     auto search_result = this->search_one_graph(
         raw_query, this->bottom_graph_, this->basic_flatten_codes_, search_param, vt, &ctx);
 

--- a/src/algorithm/hgraph_parameter.cpp
+++ b/src/algorithm/hgraph_parameter.cpp
@@ -199,6 +199,9 @@ HGraphSearchParameters::FromJson(const std::string& json_string) {
         fmt::format(
             "parameters[{}] must contains {}", INDEX_TYPE_HGRAPH, HGRAPH_PARAMETER_EF_RUNTIME));
     obj.ef_search = params[INDEX_TYPE_HGRAPH][HGRAPH_PARAMETER_EF_RUNTIME].GetInt();
+    if (params[INDEX_TYPE_HGRAPH].Contains(HGRAPH_PARAMETER_HOPS_LIMIT)) {
+        obj.hops_limit = params[INDEX_TYPE_HGRAPH][HGRAPH_PARAMETER_HOPS_LIMIT].GetInt();
+    }
     if (params[INDEX_TYPE_HGRAPH].Contains(HGRAPH_USE_EXTRA_INFO_FILTER)) {
         obj.use_extra_info_filter =
             params[INDEX_TYPE_HGRAPH][HGRAPH_USE_EXTRA_INFO_FILTER].GetBool();

--- a/src/algorithm/hgraph_parameter.h
+++ b/src/algorithm/hgraph_parameter.h
@@ -15,6 +15,8 @@
 
 #pragma once
 
+#include <limits>
+
 #include "data_type.h"
 #include "index_search_parameter.h"
 #include "inner_index_parameter.h"
@@ -75,6 +77,7 @@ public:
 
 public:
     int64_t ef_search{30};
+    uint32_t hops_limit{std::numeric_limits<uint32_t>::max()};
     bool use_reorder{false};
     bool use_extra_info_filter{false};
 

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -162,6 +162,7 @@ const char* const HGRAPH_BASE_FILE_PATH = "base_file_path";
 const char* const HGRAPH_PRECISE_IO_TYPE = "precise_io_type";
 const char* const HGRAPH_PRECISE_FILE_PATH = "precise_file_path";
 const char* const HGRAPH_PARAMETER_EF_RUNTIME = "ef_search";
+const char* const HGRAPH_PARAMETER_HOPS_LIMIT = "hops_limit";
 const char* const HGRAPH_EXTRA_INFO_SIZE = "extra_info_size";
 const char* const HGRAPH_SUPPORT_DUPLICATE = "support_duplicate";
 const char* const HGRAPH_SUPPORT_TOMBSTONE = "support_tomb_stone";

--- a/src/impl/inner_search_param.h
+++ b/src/impl/inner_search_param.h
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include <limits>
 #include <mutex>
 
 #include "typing.h"
@@ -39,6 +40,7 @@ public:
     float radius{0.0F};
     InnerIdType ep{0};
     uint64_t ef{10};
+    uint32_t hops_limit{std::numeric_limits<uint32_t>::max()};
     FilterPtr is_inner_id_allowed{nullptr};
     float skip_ratio{0.8F};
     InnerSearchMode search_mode{KNN_SEARCH};

--- a/src/impl/searcher/basic_searcher.cpp
+++ b/src/impl/searcher/basic_searcher.cpp
@@ -169,6 +169,9 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
 
     while (not candidate_set->Empty()) {
         hops++;
+        if (hops >= inner_search_param.hops_limit) {
+            break;
+        }
         auto current_node_pair = candidate_set->Top();
 
         if constexpr (mode == InnerSearchMode::KNN_SEARCH) {
@@ -301,6 +304,9 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
 
     while (not candidate_set->Empty()) {
         ++hops;
+        if (hops >= inner_search_param.hops_limit) {
+            break;
+        }
         auto current_node_pair = candidate_set->Top();
 
         if (inner_search_param.time_cost != nullptr and

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -2319,3 +2319,87 @@ TEST_CASE("HGraph Concurrent Read Write", "[ft][hgraph][concurrent]") {
         thread.join();
     }
 }
+
+// Tests for hops_limit search parameter
+static void
+TestHGraphHopsLimit(const fixtures::HGraphTestIndexPtr& test_index,
+                    const fixtures::HGraphResourcePtr& resource) {
+    using namespace fixtures;
+    auto origin_size = vsag::Options::Instance().block_size_limit();
+    auto size = GENERATE(1024 * 1024 * 2);
+
+    // Test with valid hops_limit (> ef_search)
+    constexpr static const char* search_param_with_hops_limit = R"({
+        "hgraph": {
+            "ef_search": 30,
+            "hops_limit": 100
+        }
+    })";
+
+    // Test with invalid hops_limit (<= ef_search) - should warn and ignore
+    constexpr static const char* search_param_invalid_hops_limit = R"({
+        "hgraph": {
+            "ef_search": 100,
+            "hops_limit": 50
+        }
+    })";
+
+    // Test without hops_limit (default behavior)
+    constexpr static const char* search_param_without_hops_limit = R"({
+        "hgraph": {
+            "ef_search": 30
+        }
+    })";
+
+    for (auto metric_type : resource->metric_types) {
+        for (auto dim : resource->dims) {
+            for (auto& [base_quantization_str, recall] : resource->test_cases) {
+                INFO(fmt::format("metric_type: {}, dim: {}, base_quantization_str: {}, recall: {}",
+                                 metric_type,
+                                 dim,
+                                 base_quantization_str,
+                                 recall));
+                if (HGraphTestIndex::IsRaBitQ(base_quantization_str) &&
+                    dim < fixtures::RABITQ_MIN_RACALL_DIM) {
+                    dim = fixtures::RABITQ_MIN_RACALL_DIM;
+                }
+
+                vsag::Options::Instance().set_block_size_limit(size);
+                HGraphTestIndex::HGraphBuildParam build_param(
+                    metric_type, dim, base_quantization_str);
+                auto param = HGraphTestIndex::GenerateHGraphBuildParametersString(build_param);
+                auto index = TestIndex::TestFactory(test_index->name, param, true);
+                auto dataset = HGraphTestIndex::pool.GetDatasetAndCreate(
+                    dim, resource->base_count, metric_type);
+
+                TestIndex::TestBuildIndex(index, dataset, true);
+
+                // Test with valid hops_limit - should work normally
+                TestIndex::TestKnnSearch(
+                    index, dataset, search_param_with_hops_limit, recall * 0.9, true);
+
+                // Test without hops_limit - should work normally
+                TestIndex::TestKnnSearch(
+                    index, dataset, search_param_without_hops_limit, recall, true);
+
+                // Test with invalid hops_limit - should warn but still work
+                TestIndex::TestKnnSearch(
+                    index, dataset, search_param_invalid_hops_limit, recall, true);
+
+                vsag::Options::Instance().set_block_size_limit(origin_size);
+            }
+        }
+    }
+}
+
+TEST_CASE("(PR) HGraph Hops Limit", "[ft][hgraph][pr]") {
+    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
+    auto resource = test_index->GetResource(true);
+    TestHGraphHopsLimit(test_index, resource);
+}
+
+TEST_CASE("(Daily) HGraph Hops Limit", "[ft][hgraph][daily]") {
+    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
+    auto resource = test_index->GetResource(false);
+    TestHGraphHopsLimit(test_index, resource);
+}


### PR DESCRIPTION
Add hops_limit parameter to control the maximum number of hops during graph search.

- Add hops_limit to InnerSearchParam and HGraphSearchParameters

- Implement hops limit check in BasicSearcher

- Add parsing support for hops_limit in search parameters

- Add functional tests for hops_limit feature