### PR TITLE
refactor(quantizer): deduplicate batch methods in CRTP base class

### DIFF
--- a/src/quantization/product_quantization/product_quantizer.cpp
+++ b/src/quantization/product_quantization/product_quantizer.cpp
@@ -122,24 +122,6 @@ ProductQuantizer<metric>::EncodeOneImpl(const DataType* data, uint8_t* codes) {
 
 template <MetricType metric>
 bool
-ProductQuantizer<metric>::EncodeBatchImpl(const DataType* data, uint8_t* codes, uint64_t count) {
-    for (uint64_t i = 0; i < count; ++i) {
-        this->EncodeOneImpl(data + i * this->dim_, codes + i * this->code_size_);
-    }
-    return true;
-}
-
-template <MetricType metric>
-bool
-ProductQuantizer<metric>::DecodeBatchImpl(const uint8_t* codes, DataType* data, uint64_t count) {
-    for (uint64_t i = 0; i < count; ++i) {
-        this->DecodeOneImpl(codes + i * this->code_size_, data + i * this->dim_);
-    }
-    return true;
-}
-
-template <MetricType metric>
-bool
 ProductQuantizer<metric>::DecodeOneImpl(const uint8_t* codes, DataType* data) {
     for (int i = 0; i < pq_dim_; ++i) {
         auto idx = codes[i];
@@ -274,18 +256,6 @@ ProductQuantizer<metric>::ComputeDistsBatch4Impl(Computer<ProductQuantizer<metri
 
 template <MetricType metric>
 void
-ProductQuantizer<metric>::ScanBatchDistImpl(Computer<ProductQuantizer<metric>>& computer,
-                                            uint64_t count,
-                                            const uint8_t* codes,
-                                            float* dists) const {
-    // TODO(LHT): Optimize batch for simd
-    for (uint64_t i = 0; i < count; ++i) {
-        this->ComputeDistImpl(computer, codes + i * this->code_size_, dists + i);
-    }
-}
-
-template <MetricType metric>
-void
 ProductQuantizer<metric>::SerializeImpl(StreamWriter& writer) {
     StreamWriter::WriteObj(writer, this->pq_dim_);
     StreamWriter::WriteObj(writer, this->subspace_dim_);
@@ -299,12 +269,6 @@ ProductQuantizer<metric>::DeserializeImpl(StreamReader& reader) {
     StreamReader::ReadObj(reader, this->subspace_dim_);
     StreamReader::ReadVector(reader, this->codebooks_);
     this->transpose_codebooks();
-}
-
-template <MetricType metric>
-void
-ProductQuantizer<metric>::ReleaseComputerImpl(Computer<ProductQuantizer<metric>>& computer) const {
-    this->allocator_->Deallocate(computer.buf_);
 }
 
 template <MetricType metric>

--- a/src/quantization/product_quantization/product_quantizer.h
+++ b/src/quantization/product_quantization/product_quantizer.h
@@ -40,13 +40,7 @@ public:
     EncodeOneImpl(const DataType* data, uint8_t* codes);
 
     bool
-    EncodeBatchImpl(const DataType* data, uint8_t* codes, uint64_t count);
-
-    bool
     DecodeOneImpl(const uint8_t* codes, DataType* data);
-
-    bool
-    DecodeBatchImpl(const uint8_t* codes, DataType* data, uint64_t count);
 
     float
     ComputeImpl(const uint8_t* codes1, const uint8_t* codes2);
@@ -56,12 +50,6 @@ public:
 
     void
     ComputeDistImpl(Computer<ProductQuantizer>& computer, const uint8_t* codes, float* dists) const;
-
-    void
-    ScanBatchDistImpl(Computer<ProductQuantizer<metric>>& computer,
-                      uint64_t count,
-                      const uint8_t* codes,
-                      float* dists) const;
 
     void
     ComputeDistsBatch4Impl(Computer<ProductQuantizer<metric>>& computer,
@@ -79,9 +67,6 @@ public:
 
     void
     DeserializeImpl(StreamReader& reader);
-
-    void
-    ReleaseComputerImpl(Computer<ProductQuantizer<metric>>& computer) const;
 
     [[nodiscard]] std::string
     NameImpl() const {

--- a/src/quantization/quantizer.h
+++ b/src/quantization/quantizer.h
@@ -94,6 +94,20 @@ public:
     }
 
     /**
+     * @brief Default implementation of EncodeBatchImpl using loop.
+     * Subclasses can override for optimized batch encoding.
+     */
+    bool
+    EncodeBatchImpl(const DataType* data, uint8_t* codes, uint64_t count) {
+        for (uint64_t i = 0; i < count; ++i) {
+            if (!cast().EncodeOneImpl(data + i * dim_, codes + i * code_size_)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
      * @brief Decodes an encoded code back into its original data representation.
      *
      * @param codes Pointer to the encoded code.
@@ -116,6 +130,20 @@ public:
     bool
     DecodeBatch(const uint8_t* codes, DataType* data, uint64_t count) {
         return cast().DecodeBatchImpl(codes, data, count);
+    }
+
+    /**
+     * @brief Default implementation of DecodeBatchImpl using loop.
+     * Subclasses can override for optimized batch decoding.
+     */
+    bool
+    DecodeBatchImpl(const uint8_t* codes, DataType* data, uint64_t count) {
+        for (uint64_t i = 0; i < count; ++i) {
+            if (!cast().DecodeOneImpl(codes + i * code_size_, data + i * dim_)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**
@@ -203,6 +231,29 @@ public:
     inline void
     ReleaseComputer(Computer<QuantT>& computer) const {
         cast().ReleaseComputerImpl(computer);
+    }
+
+    /**
+     * @brief Default implementation of ReleaseComputerImpl.
+     * Subclasses can override for custom release logic.
+     */
+    void
+    ReleaseComputerImpl(Computer<QuantT>& computer) const {
+        allocator_->Deallocate(computer.buf_);
+    }
+
+    /**
+     * @brief Default implementation of ScanBatchDistImpl using loop.
+     * Subclasses can override for optimized batch distance computation.
+     */
+    void
+    ScanBatchDistImpl(Computer<QuantT>& computer,
+                      uint64_t count,
+                      const uint8_t* codes,
+                      float* dists) const {
+        for (uint64_t i = 0; i < count; ++i) {
+            cast().ComputeDistImpl(computer, codes + i * code_size_, dists + i);
+        }
     }
 
     [[nodiscard]] virtual std::string

--- a/src/quantization/scalar_quantization/bf16_quantizer.cpp
+++ b/src/quantization/scalar_quantization/bf16_quantizer.cpp
@@ -68,29 +68,11 @@ BF16Quantizer<metric>::EncodeOneImpl(const DataType* data, uint8_t* codes) const
 
 template <MetricType metric>
 bool
-BF16Quantizer<metric>::EncodeBatchImpl(const DataType* data, uint8_t* codes, uint64_t count) {
-    for (uint64_t i = 0; i < count; ++i) {
-        this->EncodeOneImpl(data + i * this->dim_, codes + i * this->code_size_);
-    }
-    return true;
-}
-
-template <MetricType metric>
-bool
 BF16Quantizer<metric>::DecodeOneImpl(const uint8_t* codes, DataType* data) {
     const auto* codes_bf16 = reinterpret_cast<const uint16_t*>(codes);
 
     for (uint64_t d = 0; d < this->dim_; d++) {
         data[d] = generic::BF16ToFloat(codes_bf16[d]);
-    }
-    return true;
-}
-
-template <MetricType metric>
-bool
-BF16Quantizer<metric>::DecodeBatchImpl(const uint8_t* codes, DataType* data, uint64_t count) {
-    for (uint64_t i = 0; i < count; ++i) {
-        this->DecodeOneImpl(codes + i * this->code_size_, data + i * this->dim_);
     }
     return true;
 }
@@ -138,24 +120,6 @@ BF16Quantizer<metric>::ComputeDistImpl(Computer<BF16Quantizer>& computer,
         logger::error("unsupported metric type");
         dists[0] = 0;
     }
-}
-
-template <MetricType metric>
-void
-BF16Quantizer<metric>::ScanBatchDistImpl(Computer<BF16Quantizer<metric>>& computer,
-                                         uint64_t count,
-                                         const uint8_t* codes,
-                                         float* dists) const {
-    // TODO(LHT): Optimize batch for simd
-    for (uint64_t i = 0; i < count; ++i) {
-        this->ComputeDistImpl(computer, codes + i * this->code_size_, dists + i);
-    }
-}
-
-template <MetricType metric>
-void
-BF16Quantizer<metric>::ReleaseComputerImpl(Computer<BF16Quantizer<metric>>& computer) const {
-    this->allocator_->Deallocate(computer.buf_);
 }
 
 TEMPLATE_QUANTIZER(BF16Quantizer)

--- a/src/quantization/scalar_quantization/bf16_quantizer.h
+++ b/src/quantization/scalar_quantization/bf16_quantizer.h
@@ -39,13 +39,7 @@ public:
     EncodeOneImpl(const DataType* data, uint8_t* codes) const;
 
     bool
-    EncodeBatchImpl(const DataType* data, uint8_t* codes, uint64_t count);
-
-    bool
     DecodeOneImpl(const uint8_t* codes, DataType* data);
-
-    bool
-    DecodeBatchImpl(const uint8_t* codes, DataType* data, uint64_t count);
 
     float
     ComputeImpl(const uint8_t* codes1, const uint8_t* codes2);
@@ -55,15 +49,6 @@ public:
 
     void
     ComputeDistImpl(Computer<BF16Quantizer>& computer, const uint8_t* codes, float* dists) const;
-
-    void
-    ScanBatchDistImpl(Computer<BF16Quantizer<metric>>& computer,
-                      uint64_t count,
-                      const uint8_t* codes,
-                      float* dists) const;
-
-    void
-    ReleaseComputerImpl(Computer<BF16Quantizer<metric>>& computer) const;
 
     void
     SerializeImpl(StreamWriter& writer){};

--- a/src/quantization/scalar_quantization/fp16_quantizer.cpp
+++ b/src/quantization/scalar_quantization/fp16_quantizer.cpp
@@ -68,29 +68,11 @@ FP16Quantizer<metric>::EncodeOneImpl(const DataType* data, uint8_t* codes) const
 
 template <MetricType metric>
 bool
-FP16Quantizer<metric>::EncodeBatchImpl(const DataType* data, uint8_t* codes, uint64_t count) {
-    for (uint64_t i = 0; i < count; ++i) {
-        this->EncodeOneImpl(data + i * this->dim_, codes + i * this->code_size_);
-    }
-    return true;
-}
-
-template <MetricType metric>
-bool
 FP16Quantizer<metric>::DecodeOneImpl(const uint8_t* codes, DataType* data) {
     const auto* codes_fp16 = reinterpret_cast<const uint16_t*>(codes);
 
     for (uint64_t d = 0; d < this->dim_; d++) {
         data[d] = generic::FP16ToFloat(codes_fp16[d]);
-    }
-    return true;
-}
-
-template <MetricType metric>
-bool
-FP16Quantizer<metric>::DecodeBatchImpl(const uint8_t* codes, DataType* data, uint64_t count) {
-    for (uint64_t i = 0; i < count; ++i) {
-        this->DecodeOneImpl(codes + i * this->code_size_, data + i * this->dim_);
     }
     return true;
 }
@@ -138,24 +120,6 @@ FP16Quantizer<metric>::ComputeDistImpl(Computer<FP16Quantizer>& computer,
     } else {
         throw VsagException(ErrorType::INTERNAL_ERROR, "unsupported metric type");
     }
-}
-
-template <MetricType metric>
-void
-FP16Quantizer<metric>::ScanBatchDistImpl(Computer<FP16Quantizer<metric>>& computer,
-                                         uint64_t count,
-                                         const uint8_t* codes,
-                                         float* dists) const {
-    // TODO(LHT): Optimize batch for simd
-    for (uint64_t i = 0; i < count; ++i) {
-        this->ComputeDistImpl(computer, codes + i * this->code_size_, dists + i);
-    }
-}
-
-template <MetricType metric>
-void
-FP16Quantizer<metric>::ReleaseComputerImpl(Computer<FP16Quantizer<metric>>& computer) const {
-    this->allocator_->Deallocate(computer.buf_);
 }
 
 TEMPLATE_QUANTIZER(FP16Quantizer)

--- a/src/quantization/scalar_quantization/fp16_quantizer.h
+++ b/src/quantization/scalar_quantization/fp16_quantizer.h
@@ -39,13 +39,7 @@ public:
     EncodeOneImpl(const DataType* data, uint8_t* codes) const;
 
     bool
-    EncodeBatchImpl(const DataType* data, uint8_t* codes, uint64_t count);
-
-    bool
     DecodeOneImpl(const uint8_t* codes, DataType* data);
-
-    bool
-    DecodeBatchImpl(const uint8_t* codes, DataType* data, uint64_t count);
 
     float
     ComputeImpl(const uint8_t* codes1, const uint8_t* codes2);
@@ -55,15 +49,6 @@ public:
 
     void
     ComputeDistImpl(Computer<FP16Quantizer>& computer, const uint8_t* codes, float* dists) const;
-
-    void
-    ScanBatchDistImpl(Computer<FP16Quantizer<metric>>& computer,
-                      uint64_t count,
-                      const uint8_t* codes,
-                      float* dists) const;
-
-    void
-    ReleaseComputerImpl(Computer<FP16Quantizer<metric>>& computer) const;
 
     void
     SerializeImpl(StreamWriter& writer){};

--- a/src/quantization/scalar_quantization/scalar_quantizer.cpp
+++ b/src/quantization/scalar_quantization/scalar_quantizer.cpp
@@ -110,17 +110,6 @@ ScalarQuantizer<metric, bit>::EncodeOneImpl(const DataType* data, uint8_t* codes
 
 template <MetricType metric, int bit>
 bool
-ScalarQuantizer<metric, bit>::EncodeBatchImpl(const DataType* data,
-                                              uint8_t* codes,
-                                              uint64_t count) {
-    for (uint64_t i = 0; i < count; ++i) {
-        this->EncodeOneImpl(data + i * this->dim_, codes + i * this->code_size_);
-    }
-    return true;
-}
-
-template <MetricType metric, int bit>
-bool
 ScalarQuantizer<metric, bit>::DecodeOneImpl(const uint8_t* codes, DataType* data) {
     for (uint64_t d = 0; d < this->dim_; d++) {
         auto idx = (d * BIT_PER_DIM) / 8;
@@ -130,17 +119,6 @@ ScalarQuantizer<metric, bit>::DecodeOneImpl(const uint8_t* codes, DataType* data
                   lower_bound_[d];
     }
 
-    return true;
-}
-
-template <MetricType metric, int bit>
-bool
-ScalarQuantizer<metric, bit>::DecodeBatchImpl(const uint8_t* codes,
-                                              DataType* data,
-                                              uint64_t count) {
-    for (uint64_t i = 0; i < count; ++i) {
-        this->DecodeOneImpl(codes + i * this->code_size_, data + i * this->dim_);
-    }
     return true;
 }
 
@@ -215,25 +193,6 @@ ScalarQuantizer<metric, bit>::ComputeDistImpl(Computer<ScalarQuantizer>& compute
         logger::error("unsupported metric type");
         dists[0] = 0;
     }
-}
-
-template <MetricType metric, int bit>
-void
-ScalarQuantizer<metric, bit>::ScanBatchDistImpl(Computer<ScalarQuantizer<metric, bit>>& computer,
-                                                uint64_t count,
-                                                const uint8_t* codes,
-                                                float* dists) const {
-    // TODO(LHT): Optimize batch for simd
-    for (uint64_t i = 0; i < count; ++i) {
-        this->ComputeDistImpl(computer, codes + i * this->code_size_, dists + i);
-    }
-}
-
-template <MetricType metric, int bit>
-void
-ScalarQuantizer<metric, bit>::ReleaseComputerImpl(
-    Computer<ScalarQuantizer<metric, bit>>& computer) const {
-    this->allocator_->Deallocate(computer.buf_);
 }
 
 template <MetricType metric, int bit>

--- a/src/quantization/scalar_quantization/scalar_quantizer.h
+++ b/src/quantization/scalar_quantization/scalar_quantizer.h
@@ -39,13 +39,7 @@ public:
     EncodeOneImpl(const float* data, uint8_t* codes) const;
 
     bool
-    EncodeBatchImpl(const float* data, uint8_t* codes, uint64_t count);
-
-    bool
     DecodeOneImpl(const uint8_t* codes, float* data);
-
-    bool
-    DecodeBatchImpl(const uint8_t* codes, float* data, uint64_t count);
 
     float
     ComputeImpl(const uint8_t* codes1, const uint8_t* codes2);
@@ -55,15 +49,6 @@ public:
 
     void
     ComputeDistImpl(Computer<ScalarQuantizer>& computer, const uint8_t* codes, float* dists) const;
-
-    void
-    ScanBatchDistImpl(Computer<ScalarQuantizer<metric, bit>>& computer,
-                      uint64_t count,
-                      const uint8_t* codes,
-                      float* dists) const;
-
-    void
-    ReleaseComputerImpl(Computer<ScalarQuantizer<metric, bit>>& computer) const;
 
     void
     SerializeImpl(StreamWriter& writer);

--- a/src/quantization/scalar_quantization/sq4_uniform_quantizer.cpp
+++ b/src/quantization/scalar_quantization/sq4_uniform_quantizer.cpp
@@ -157,15 +157,6 @@ SQ4UniformQuantizer<metric>::EncodeOneImpl(const DataType* data, uint8_t* codes)
 
 template <MetricType metric>
 bool
-SQ4UniformQuantizer<metric>::EncodeBatchImpl(const DataType* data, uint8_t* codes, uint64_t count) {
-    for (uint64_t i = 0; i < count; ++i) {
-        this->EncodeOneImpl(data + i * this->dim_, codes + i * this->code_size_);
-    }
-    return true;
-}
-
-template <MetricType metric>
-bool
 SQ4UniformQuantizer<metric>::DecodeOneImpl(const uint8_t* codes, DataType* data) {
     for (uint64_t d = 0; d < this->dim_; d++) {
         if ((d & 1) != 0U) {
@@ -175,15 +166,6 @@ SQ4UniformQuantizer<metric>::DecodeOneImpl(const uint8_t* codes, DataType* data)
         }
     }
 
-    return true;
-}
-
-template <MetricType metric>
-bool
-SQ4UniformQuantizer<metric>::DecodeBatchImpl(const uint8_t* codes, DataType* data, uint64_t count) {
-    for (uint64_t i = 0; i < count; ++i) {
-        this->DecodeOneImpl(codes + i * this->code_size_, data + i * this->dim_);
-    }
     return true;
 }
 
@@ -235,25 +217,6 @@ SQ4UniformQuantizer<metric>::ComputeDistImpl(Computer<SQ4UniformQuantizer>& comp
                                              const uint8_t* codes,
                                              float* dists) const {
     dists[0] = this->ComputeImpl(computer.buf_, codes);
-}
-
-template <MetricType metric>
-void
-SQ4UniformQuantizer<metric>::ScanBatchDistImpl(Computer<SQ4UniformQuantizer<metric>>& computer,
-                                               uint64_t count,
-                                               const uint8_t* codes,
-                                               float* dists) const {
-    // TODO(LHT): Optimize batch for simd
-    for (uint64_t i = 0; i < count; ++i) {
-        this->ComputeDistImpl(computer, codes + i * this->code_size_, dists + i);
-    }
-}
-
-template <MetricType metric>
-void
-SQ4UniformQuantizer<metric>::ReleaseComputerImpl(
-    Computer<SQ4UniformQuantizer<metric>>& computer) const {
-    this->allocator_->Deallocate(computer.buf_);
 }
 
 template <MetricType metric>

--- a/src/quantization/scalar_quantization/sq4_uniform_quantizer.h
+++ b/src/quantization/scalar_quantization/sq4_uniform_quantizer.h
@@ -46,13 +46,7 @@ public:
     EncodeOneImpl(const DataType* data, uint8_t* codes) const;
 
     bool
-    EncodeBatchImpl(const DataType* data, uint8_t* codes, uint64_t count);
-
-    bool
     DecodeOneImpl(const uint8_t* codes, DataType* data);
-
-    bool
-    DecodeBatchImpl(const uint8_t* codes, DataType* data, uint64_t count);
 
     float
     ComputeImpl(const uint8_t* codes1, const uint8_t* codes2) const;
@@ -64,15 +58,6 @@ public:
     ComputeDistImpl(Computer<SQ4UniformQuantizer>& computer,
                     const uint8_t* codes,
                     float* dists) const;
-
-    void
-    ScanBatchDistImpl(Computer<SQ4UniformQuantizer<metric>>& computer,
-                      uint64_t count,
-                      const uint8_t* codes,
-                      float* dists) const;
-
-    void
-    ReleaseComputerImpl(Computer<SQ4UniformQuantizer<metric>>& computer) const;
 
     void
     SerializeImpl(StreamWriter& writer);

--- a/src/quantization/scalar_quantization/sq8_uniform_quantizer.cpp
+++ b/src/quantization/scalar_quantization/sq8_uniform_quantizer.cpp
@@ -138,27 +138,9 @@ SQ8UniformQuantizer<metric>::EncodeOneImpl(const DataType* data, uint8_t* codes)
 
 template <MetricType metric>
 bool
-SQ8UniformQuantizer<metric>::EncodeBatchImpl(const DataType* data, uint8_t* codes, uint64_t count) {
-    for (uint64_t i = 0; i < count; ++i) {
-        this->EncodeOneImpl(data + i * this->dim_, codes + i * this->code_size_);
-    }
-    return true;
-}
-
-template <MetricType metric>
-bool
 SQ8UniformQuantizer<metric>::DecodeOneImpl(const uint8_t* codes, DataType* data) {
     for (uint64_t d = 0; d < this->dim_; d++) {
         data[d] = codes[d] / 255.0 * diff_ + lower_bound_;
-    }
-    return true;
-}
-
-template <MetricType metric>
-bool
-SQ8UniformQuantizer<metric>::DecodeBatchImpl(const uint8_t* codes, DataType* data, uint64_t count) {
-    for (uint64_t i = 0; i < count; ++i) {
-        this->DecodeOneImpl(codes + i * this->code_size_, data + i * this->dim_);
     }
     return true;
 }
@@ -214,25 +196,6 @@ SQ8UniformQuantizer<metric>::ComputeDistImpl(Computer<SQ8UniformQuantizer>& comp
                                              const uint8_t* codes,
                                              float* dists) const {
     dists[0] = this->ComputeImpl(computer.buf_, codes);
-}
-
-template <MetricType metric>
-void
-SQ8UniformQuantizer<metric>::ScanBatchDistImpl(Computer<SQ8UniformQuantizer<metric>>& computer,
-                                               uint64_t count,
-                                               const uint8_t* codes,
-                                               float* dists) const {
-    // TODO(LHT): Optimize batch for simd
-    for (uint64_t i = 0; i < count; ++i) {
-        this->ComputeDistImpl(computer, codes + i * this->code_size_, dists + i);
-    }
-}
-
-template <MetricType metric>
-void
-SQ8UniformQuantizer<metric>::ReleaseComputerImpl(
-    Computer<SQ8UniformQuantizer<metric>>& computer) const {
-    this->allocator_->Deallocate(computer.buf_);
 }
 
 template <MetricType metric>

--- a/src/quantization/scalar_quantization/sq8_uniform_quantizer.h
+++ b/src/quantization/scalar_quantization/sq8_uniform_quantizer.h
@@ -43,13 +43,7 @@ public:
     EncodeOneImpl(const DataType* data, uint8_t* codes) const;
 
     bool
-    EncodeBatchImpl(const DataType* data, uint8_t* codes, uint64_t count);
-
-    bool
     DecodeOneImpl(const uint8_t* codes, DataType* data);
-
-    bool
-    DecodeBatchImpl(const uint8_t* codes, DataType* data, uint64_t count);
 
     float
     ComputeImpl(const uint8_t* codes1, const uint8_t* codes2) const;
@@ -63,19 +57,10 @@ public:
                     float* dists) const;
 
     void
-    ScanBatchDistImpl(Computer<SQ8UniformQuantizer<metric>>& computer,
-                      uint64_t count,
-                      const uint8_t* codes,
-                      float* dists) const;
-
-    void
     SerializeImpl(StreamWriter& writer);
 
     void
     DeserializeImpl(StreamReader& reader);
-
-    void
-    ReleaseComputerImpl(Computer<SQ8UniformQuantizer<metric>>& computer) const;
 
     [[nodiscard]] std::string
     NameImpl() const {


### PR DESCRIPTION
Move repeated EncodeBatchImpl, DecodeBatchImpl, ScanBatchDistImpl, and ReleaseComputerImpl implementations from subclasses to Quantizer base class. Subclasses can override these methods for optimized batch processing.

Removed ~265 lines of duplicate code across 6 quantizer types:
- ScalarQuantizer, SQ4UniformQuantizer, SQ8UniformQuantizer
- BF16Quantizer, FP16Quantizer, ProductQuantizer