### PR TITLE
refactor(io): extract platform-specific syscalls to IOSyscall

### DIFF
--- a/src/io/async_io.cpp
+++ b/src/io/async_io.cpp
@@ -24,6 +24,7 @@
 
 #include "direct_io_object.h"
 #include "io_context.h"
+#include "io_syscall.h"
 
 namespace vsag {
 
@@ -66,12 +67,8 @@ AsyncIO::~AsyncIO() {
 
 void
 AsyncIO::WriteImpl(const uint8_t* data, uint64_t size, uint64_t offset) {
-#ifdef __APPLE__
-    auto ret = pwrite(this->wfd_, data, size, static_cast<off_t>(offset));
-#else
-    auto ret = pwrite64(this->wfd_, data, size, static_cast<int64_t>(offset));
-#endif
-    if (ret != size) {
+    auto ret = IOSyscall::PWrite(this->wfd_, data, size, offset);
+    if (ret != static_cast<ssize_t>(size)) {
         throw VsagException(ErrorType::INTERNAL_ERROR,
                             fmt::format("write bytes {} less than {}", ret, size));
     }
@@ -83,11 +80,7 @@ AsyncIO::WriteImpl(const uint8_t* data, uint64_t size, uint64_t offset) {
 
 void
 AsyncIO::ResizeImpl(uint64_t size) {
-#ifdef __APPLE__
-    auto ret = ftruncate(this->wfd_, static_cast<off_t>(size));
-#else
-    auto ret = ftruncate64(this->wfd_, static_cast<int64_t>(size));
-#endif
+    auto ret = IOSyscall::FTruncate(this->wfd_, size);
     if (ret == -1) {
         throw VsagException(ErrorType::INTERNAL_ERROR, "ftruncate failed");
     }
@@ -113,13 +106,9 @@ AsyncIO::DirectReadImpl(uint64_t size, uint64_t offset, bool& need_release) cons
         return nullptr;
     }
     DirectIOObject obj(size, offset);
-#ifdef __APPLE__
-    auto ret = pread(this->rfd_, obj.align_data, obj.size, static_cast<off_t>(obj.offset));
-#else
-    auto ret = pread64(this->rfd_, obj.align_data, obj.size, static_cast<int64_t>(obj.offset));
-#endif
+    auto ret = IOSyscall::PRead(this->rfd_, obj.align_data, obj.size, obj.offset);
     if (ret < 0) {
-        throw VsagException(ErrorType::INTERNAL_ERROR, fmt::format("pread64 error {}", ret));
+        throw VsagException(ErrorType::INTERNAL_ERROR, fmt::format("pread error {}", ret));
     }
     return obj.data;
 }

--- a/src/io/buffer_io.cpp
+++ b/src/io/buffer_io.cpp
@@ -20,6 +20,8 @@
 
 #include <filesystem>
 
+#include "io_syscall.h"
+
 namespace vsag {
 
 BufferIO::BufferIO(std::string filename, Allocator* allocator)
@@ -44,12 +46,8 @@ BufferIO::BufferIO(const IOParamPtr& param, const IndexCommonParam& common_param
 
 void
 BufferIO::WriteImpl(const uint8_t* data, uint64_t size, uint64_t offset) {
-#ifdef __APPLE__
-    auto ret = pwrite(this->fd_, data, size, static_cast<off_t>(offset));
-#else
-    auto ret = pwrite64(this->fd_, data, size, static_cast<int64_t>(offset));
-#endif
-    if (ret != size) {
+    auto ret = IOSyscall::PWrite(this->fd_, data, size, offset);
+    if (ret != static_cast<ssize_t>(size)) {
         throw VsagException(ErrorType::INTERNAL_ERROR,
                             fmt::format("write bytes {} less than {}", ret, size));
     }
@@ -60,11 +58,7 @@ BufferIO::WriteImpl(const uint8_t* data, uint64_t size, uint64_t offset) {
 
 void
 BufferIO::ResizeImpl(uint64_t size) {
-#ifdef __APPLE__
-    auto ret = ftruncate(this->fd_, static_cast<off_t>(size));
-#else
-    auto ret = ftruncate64(this->fd_, static_cast<int64_t>(size));
-#endif
+    auto ret = IOSyscall::FTruncate(this->fd_, size);
     if (ret == -1) {
         throw VsagException(ErrorType::INTERNAL_ERROR, "ftruncate failed");
     }
@@ -76,12 +70,8 @@ BufferIO::ReadImpl(uint64_t size, uint64_t offset, uint8_t* data) const {
     if (size == 0) {
         return true;
     }
-#ifdef __APPLE__
-    auto ret = pread(this->fd_, data, size, static_cast<off_t>(offset));
-#else
-    auto ret = pread64(this->fd_, data, size, static_cast<int64_t>(offset));
-#endif
-    if (ret != size) {
+    auto ret = IOSyscall::PRead(this->fd_, data, size, offset);
+    if (ret != static_cast<ssize_t>(size)) {
         throw VsagException(ErrorType::INTERNAL_ERROR,
                             fmt::format("read bytes {} less than {}", ret, size));
     }

--- a/src/io/io_syscall.h
+++ b/src/io/io_syscall.h
@@ -1,0 +1,62 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <cstdint>
+
+#ifdef _MSC_VER
+#define FORCEINLINE __forceinline
+#elif defined(__GNUC__) || defined(__clang__)
+#define FORCEINLINE inline __attribute__((always_inline))
+#else
+#define FORCEINLINE inline
+#endif
+
+namespace vsag {
+
+class IOSyscall {
+public:
+    static FORCEINLINE ssize_t
+    PRead(int fd, void* buf, size_t count, uint64_t offset) {
+#ifdef __APPLE__
+        return pread(fd, buf, count, static_cast<off_t>(offset));
+#else
+        return pread64(fd, buf, count, static_cast<int64_t>(offset));
+#endif
+    }
+
+    static FORCEINLINE ssize_t
+    PWrite(int fd, const void* buf, size_t count, uint64_t offset) {
+#ifdef __APPLE__
+        return pwrite(fd, buf, count, static_cast<off_t>(offset));
+#else
+        return pwrite64(fd, buf, count, static_cast<int64_t>(offset));
+#endif
+    }
+
+    static FORCEINLINE int
+    FTruncate(int fd, uint64_t length) {
+#ifdef __APPLE__
+        return ftruncate(fd, static_cast<off_t>(length));
+#else
+        return ftruncate64(fd, static_cast<int64_t>(length));
+#endif
+    }
+};
+
+}  // namespace vsag

--- a/src/io/mmap_io.cpp
+++ b/src/io/mmap_io.cpp
@@ -23,6 +23,7 @@
 #include <utility>
 
 #include "index_common_param.h"
+#include "io_syscall.h"
 
 namespace vsag {
 
@@ -42,11 +43,7 @@ MMapIO::MMapIO(std::string filename, Allocator* allocator)
     auto mmap_size = this->size_;
     if (this->size_ == 0) {
         mmap_size = DEFAULT_INIT_MMAP_SIZE;
-#ifdef __APPLE__
-        auto ret = ftruncate(this->fd_, static_cast<off_t>(mmap_size));
-#else
-        auto ret = ftruncate64(this->fd_, static_cast<int64_t>(mmap_size));
-#endif
+        auto ret = IOSyscall::FTruncate(this->fd_, mmap_size);
         if (ret == -1) {
             throw VsagException(ErrorType::INTERNAL_ERROR, "ftruncate failed");
         }
@@ -78,18 +75,12 @@ MMapIO::WriteImpl(const uint8_t* data, uint64_t size, uint64_t offset) {
         old_size = DEFAULT_INIT_MMAP_SIZE;
     }
     if (new_size > old_size) {
-        auto ret =
-#ifdef __APPLE__
-            ftruncate(this->fd_, static_cast<off_t>(new_size));
-#else
-            ftruncate64(this->fd_, static_cast<int64_t>(new_size));
-#endif
+        auto ret = IOSyscall::FTruncate(this->fd_, new_size);
         if (ret == -1) {
             throw VsagException(ErrorType::INTERNAL_ERROR, "ftruncate failed");
         }
 
 #ifdef __APPLE__
-        // macOS doesn't have mremap; unmap the old region first, then re-mmap.
         munmap(this->start_, old_size);
         void* addr = mmap(nullptr, new_size, PROT_READ | PROT_WRITE, MAP_SHARED, this->fd_, 0);
         if (addr == MAP_FAILED) {
@@ -113,12 +104,7 @@ MMapIO::ResizeImpl(uint64_t size) {
         old_size = DEFAULT_INIT_MMAP_SIZE;
     }
     if (new_size > old_size) {
-        auto ret =
-#ifdef __APPLE__
-            ftruncate(this->fd_, static_cast<off_t>(new_size));
-#else
-            ftruncate64(this->fd_, static_cast<int64_t>(new_size));
-#endif
+        auto ret = IOSyscall::FTruncate(this->fd_, new_size);
         if (ret == -1) {
             throw VsagException(ErrorType::INTERNAL_ERROR, "ftruncate failed");
         }
@@ -146,12 +132,7 @@ MMapIO::ResizeImpl(uint64_t size) {
         this->start_ =
             static_cast<uint8_t*>(mremap(this->start_, old_size, new_size, MREMAP_MAYMOVE));
 #endif
-        auto ret =
-#ifdef __APPLE__
-            ftruncate(this->fd_, static_cast<off_t>(new_size));
-#else
-            ftruncate64(this->fd_, static_cast<int64_t>(new_size));
-#endif
+        auto ret = IOSyscall::FTruncate(this->fd_, new_size);
         if (ret == -1) {
             throw VsagException(ErrorType::INTERNAL_ERROR, "ftruncate failed");
         }


### PR DESCRIPTION
- Add io_syscall.h with FORCEINLINE wrapper functions
- Eliminate duplicate platform checks (#ifdef __APPLE__) in BufferIO, MMapIO, AsyncIO
- Reduce ~30 lines of repetitive code
- Use __attribute__((always_inline)) for zero-overhead abstraction