### PR TITLE
refactor(io): use std::filesystem::path for file paths

### DIFF
--- a/src/io/async_io.cpp
+++ b/src/io/async_io.cpp
@@ -22,7 +22,9 @@
 
 #include <filesystem>
 
+#include "async_io_parameter.h"
 #include "direct_io_object.h"
+#include "index_common_param.h"
 #include "io_context.h"
 
 namespace vsag {
@@ -30,22 +32,24 @@ namespace vsag {
 std::unique_ptr<IOContextPool> AsyncIO::io_context_pool =
     std::make_unique<IOContextPool>(10, nullptr);
 
-AsyncIO::AsyncIO(std::string filename, Allocator* allocator)
-    : BasicIO<AsyncIO>(allocator), filepath_(std::move(filename)) {
+AsyncIO::AsyncIO(std::filesystem::path filepath, Allocator* allocator)
+    : BasicIO<AsyncIO>(allocator), filepath_(std::move(filepath)) {
     this->exist_file_ = std::filesystem::exists(this->filepath_);
     if (std::filesystem::is_directory(this->filepath_)) {
         throw VsagException(ErrorType::INTERNAL_ERROR,
-                            fmt::format("{} is a directory", this->filepath_));
+                            fmt::format("{} is a directory", this->filepath_.string()));
     }
-    this->rfd_ = open(filepath_.c_str(), O_CREAT | O_RDWR | O_DIRECT, 0644);
+    this->rfd_ = open(this->filepath_.c_str(), O_CREAT | O_RDWR | O_DIRECT, 0644);
     if (this->rfd_ < 0) {
-        throw VsagException(ErrorType::INTERNAL_ERROR,
-                            fmt::format("open file {} error {}", this->filepath_, strerror(errno)));
+        throw VsagException(
+            ErrorType::INTERNAL_ERROR,
+            fmt::format("open file {} error {}", this->filepath_.string(), strerror(errno)));
     }
-    this->wfd_ = open(filepath_.c_str(), O_CREAT | O_RDWR, 0644);
+    this->wfd_ = open(this->filepath_.c_str(), O_CREAT | O_RDWR, 0644);
     if (this->wfd_ < 0) {
-        throw VsagException(ErrorType::INTERNAL_ERROR,
-                            fmt::format("open file {} error {}", this->filepath_, strerror(errno)));
+        throw VsagException(
+            ErrorType::INTERNAL_ERROR,
+            fmt::format("open file {} error {}", this->filepath_.string(), strerror(errno)));
     }
 }
 
@@ -125,7 +129,7 @@ AsyncIO::DirectReadImpl(uint64_t size, uint64_t offset, bool& need_release) cons
 }
 
 void
-AsyncIO::ReleaseImpl(const uint8_t* data) {
+AsyncIO::ReleaseImpl(const uint8_t* data) const {
     auto* ptr = const_cast<uint8_t*>(data);
     uint64_t align_bit = Options::Instance().direct_IO_object_align_bit();
     auto raw = reinterpret_cast<uintptr_t>(ptr);

--- a/src/io/async_io.h
+++ b/src/io/async_io.h
@@ -15,20 +15,27 @@
 
 #pragma once
 
-#if HAVE_LIBAIO
-#include "async_io_parameter.h"
+#include <filesystem>
+
 #include "basic_io.h"
-#include "index_common_param.h"
 #include "io_context.h"
+
 namespace vsag {
 
+class AsyncIOParameter;
+class IndexCommonParam;
+class Allocator;
+
+using AsyncIOParameterPtr = std::shared_ptr<AsyncIOParameter>;
+
+#if HAVE_LIBAIO
 class AsyncIO : public BasicIO<AsyncIO> {
 public:
     static constexpr bool InMemory = false;
     static constexpr bool SkipDeserialize = false;
 
 public:
-    explicit AsyncIO(std::string filename, Allocator* allocator);
+    explicit AsyncIO(std::filesystem::path filepath, Allocator* allocator);
 
     explicit AsyncIO(const AsyncIOParameterPtr& io_param, const IndexCommonParam& common_param);
 
@@ -36,7 +43,6 @@ public:
 
     ~AsyncIO() override;
 
-public:
     void
     WriteImpl(const uint8_t* data, uint64_t size, uint64_t offset);
 
@@ -49,28 +55,26 @@ public:
     [[nodiscard]] const uint8_t*
     DirectReadImpl(uint64_t size, uint64_t offset, bool& need_release) const;
 
-    static void
-    ReleaseImpl(const uint8_t* data);
+    void
+    ReleaseImpl(const uint8_t* data) const;
 
     bool
     MultiReadImpl(uint8_t* datas, uint64_t* sizes, uint64_t* offsets, uint64_t count) const;
 
-public:
-    static std::unique_ptr<IOContextPool> io_context_pool;
-
 private:
-    std::string filepath_{};
+    std::filesystem::path filepath_;
 
     int rfd_{-1};
 
     int wfd_{-1};
 
     bool exist_file_{false};
+
+    static std::unique_ptr<IOContextPool> io_context_pool;
 };
 
-}  // namespace vsag
-
 #else
-#include "buffer_io.h"
 #define AsyncIO BufferIO
-#endif  // HAVE_LIBAIO
+#endif
+
+}  // namespace vsag

--- a/src/io/async_io_test.cpp
+++ b/src/io/async_io_test.cpp
@@ -20,6 +20,7 @@
 
 #include "basic_io_test.h"
 #include "impl/allocator/safe_allocator.h"
+#include "index_common_param.h"
 
 using namespace vsag;
 

--- a/src/io/buffer_io.cpp
+++ b/src/io/buffer_io.cpp
@@ -20,19 +20,23 @@
 
 #include <filesystem>
 
+#include "buffer_io_parameter.h"
+#include "index_common_param.h"
+
 namespace vsag {
 
-BufferIO::BufferIO(std::string filename, Allocator* allocator)
-    : BasicIO<BufferIO>(allocator), filepath_(std::move(filename)) {
+BufferIO::BufferIO(std::filesystem::path filepath, Allocator* allocator)
+    : BasicIO<BufferIO>(allocator), filepath_(std::move(filepath)) {
     this->exist_file_ = std::filesystem::exists(this->filepath_);
     if (std::filesystem::is_directory(this->filepath_)) {
         throw VsagException(ErrorType::INTERNAL_ERROR,
-                            fmt::format("{} is a directory", this->filepath_));
+                            fmt::format("{} is a directory", this->filepath_.string()));
     }
-    this->fd_ = open(filepath_.c_str(), O_CREAT | O_RDWR, 0644);
+    this->fd_ = open(this->filepath_.c_str(), O_CREAT | O_RDWR, 0644);
     if (this->fd_ < 0) {
-        throw VsagException(ErrorType::INTERNAL_ERROR,
-                            fmt::format("open file {} error {}", this->filepath_, strerror(errno)));
+        throw VsagException(
+            ErrorType::INTERNAL_ERROR,
+            fmt::format("open file {} error {}", this->filepath_.string(), strerror(errno)));
     }
 }
 
@@ -41,6 +45,13 @@ BufferIO::BufferIO(const BufferIOParameterPtr& io_param, const IndexCommonParam&
 
 BufferIO::BufferIO(const IOParamPtr& param, const IndexCommonParam& common_param)
     : BufferIO(std::dynamic_pointer_cast<BufferIOParameter>(param), common_param){};
+
+BufferIO::~BufferIO() {
+    close(this->fd_);
+    if (not this->exist_file_) {
+        std::filesystem::remove(this->filepath_);
+    }
+}
 
 void
 BufferIO::WriteImpl(const uint8_t* data, uint64_t size, uint64_t offset) {

--- a/src/io/buffer_io.h
+++ b/src/io/buffer_io.h
@@ -15,15 +15,15 @@
 
 #pragma once
 
-#include <unistd.h>
-
 #include <filesystem>
 
 #include "basic_io.h"
 #include "buffer_io_parameter.h"
-#include "index_common_param.h"
 
 namespace vsag {
+
+class IndexCommonParam;
+class Allocator;
 
 class BufferIO : public BasicIO<BufferIO> {
 public:
@@ -31,19 +31,13 @@ public:
     static constexpr bool SkipDeserialize = false;
 
 public:
-    BufferIO(std::string filename, Allocator* allocator);
+    explicit BufferIO(std::filesystem::path filepath, Allocator* allocator);
 
     explicit BufferIO(const BufferIOParameterPtr& io_param, const IndexCommonParam& common_param);
 
     explicit BufferIO(const IOParamPtr& param, const IndexCommonParam& common_param);
 
-    ~BufferIO() override {
-        close(this->fd_);
-        // remove file
-        if (not this->exist_file_) {
-            std::filesystem::remove(this->filepath_);
-        }
-    }
+    ~BufferIO() override;
 
     void
     WriteImpl(const uint8_t* data, uint64_t size, uint64_t offset);
@@ -64,10 +58,11 @@ public:
     MultiReadImpl(uint8_t* datas, uint64_t* sizes, uint64_t* offsets, uint64_t count) const;
 
 private:
-    std::string filepath_{};
+    std::filesystem::path filepath_;
 
     int fd_{-1};
 
     bool exist_file_{false};
 };
+
 }  // namespace vsag

--- a/src/io/buffer_io_test.cpp
+++ b/src/io/buffer_io_test.cpp
@@ -20,6 +20,7 @@
 
 #include "basic_io_test.h"
 #include "impl/allocator/safe_allocator.h"
+#include "index_common_param.h"
 
 using namespace vsag;
 

--- a/src/io/mmap_io.cpp
+++ b/src/io/mmap_io.cpp
@@ -23,21 +23,23 @@
 #include <utility>
 
 #include "index_common_param.h"
+#include "mmap_io_parameter.h"
 
 namespace vsag {
 
-MMapIO::MMapIO(std::string filename, Allocator* allocator)
-    : BasicIO<MMapIO>(allocator), filepath_(std::move(filename)) {
+MMapIO::MMapIO(std::filesystem::path filepath, Allocator* allocator)
+    : BasicIO<MMapIO>(allocator), filepath_(std::move(filepath)) {
     this->exist_file_ = std::filesystem::exists(this->filepath_);
     if (std::filesystem::is_directory(this->filepath_)) {
         throw VsagException(ErrorType::INTERNAL_ERROR,
-                            fmt::format("{} is a directory", this->filepath_));
+                            fmt::format("{} is a directory", this->filepath_.string()));
     }
 
-    this->fd_ = open(filepath_.c_str(), O_CREAT | O_RDWR, 0644);
+    this->fd_ = open(this->filepath_.c_str(), O_CREAT | O_RDWR, 0644);
     if (this->fd_ < 0) {
-        throw VsagException(ErrorType::INTERNAL_ERROR,
-                            fmt::format("open file {} error {}", this->filepath_, strerror(errno)));
+        throw VsagException(
+            ErrorType::INTERNAL_ERROR,
+            fmt::format("open file {} error {}", this->filepath_.string(), strerror(errno)));
     }
     auto mmap_size = this->size_;
     if (this->size_ == 0) {

--- a/src/io/mmap_io.h
+++ b/src/io/mmap_io.h
@@ -15,6 +15,8 @@
 
 #pragma once
 
+#include <filesystem>
+
 #include "basic_io.h"
 #include "mmap_io_parameter.h"
 
@@ -29,7 +31,7 @@ public:
     static constexpr bool SkipDeserialize = false;
 
 public:
-    MMapIO(std::string filename, Allocator* allocator);
+    explicit MMapIO(std::filesystem::path filepath, Allocator* allocator);
 
     explicit MMapIO(const MMapIOParamPtr& io_param, const IndexCommonParam& common_param);
 
@@ -55,7 +57,7 @@ public:
     static constexpr int64_t DEFAULT_INIT_MMAP_SIZE = 4096;
 
 private:
-    std::string filepath_{};
+    std::filesystem::path filepath_;
 
     int fd_{-1};
 
@@ -63,4 +65,5 @@ private:
 
     bool exist_file_{false};
 };
+
 }  // namespace vsag


### PR DESCRIPTION
- Replace std::string with std::filesystem::path in BufferIO, AsyncIO, MMapIO
- Improve cross-platform compatibility
- Use .string() for error messages, .c_str() for system calls
- Add explicit keyword to single-argument constructors