### PR TITLE
optimize: avoid repeated align param calculation in DirectIOObject.Set

### DIFF
--- a/src/io/direct_io_object.h
+++ b/src/io/direct_io_object.h
@@ -16,23 +16,26 @@
 #pragma once
 
 #include <cstdint>
-#include <string>
+#include <cstdlib>
+
+#include "vsag/options.h"
 
 namespace vsag {
 
 class DirectIOObject {
 public:
-    DirectIOObject() = default;
+    DirectIOObject() {
+        this->align_bit = Options::Instance().direct_IO_object_align_bit();
+        this->align_size = 1 << align_bit;
+        this->align_mask = (1 << align_bit) - 1;
+    }
 
-    DirectIOObject(uint64_t size, uint64_t offset) {
+    DirectIOObject(uint64_t size, uint64_t offset) : DirectIOObject() {
         this->Set(size, offset);
     }
 
     void
     Set(uint64_t size1, uint64_t offset1) {
-        this->align_bit = Options::Instance().direct_IO_object_align_bit();
-        this->align_size = 1 << align_bit;
-        this->align_mask = (1 << align_bit) - 1;
         this->size = size1;
         this->offset = offset1;
         if (align_data) {


### PR DESCRIPTION
This change optimizes the DirectIOObject class by moving the computation of align_bit, align_size, and align_mask from the Set() method to the constructors. Previously, these values were recalculated every time Set() was called, which is unnecessary since they only depend on a configuration value that doesn't change during the object's lifetime.

## Changes
- Added header include for vsag/options.h
- Modified default constructor to initialize alignment parameters
- Modified parameterized constructor to delegate to default constructor
- Removed redundant alignment parameter calculations from Set() method

## Related Issue
Fixes #1636