### PR TITLE
refactor(io): replace C-style cast with C++ style cast

### DIFF
--- a/src/io/reader_io.cpp
+++ b/src/io/reader_io.cpp
@@ -67,7 +67,7 @@ ReaderIO::DirectReadImpl(uint64_t size, uint64_t offset, bool& need_release) con
 
 void
 ReaderIO::ReleaseImpl(const uint8_t* data) const {
-    allocator_->Deallocate((void*)data);
+    allocator_->Deallocate(const_cast<void*>(static_cast<const void*>(data)));
 }
 
 bool


### PR DESCRIPTION
## Summary
Replace C-style cast (void*) with C++ style const_cast in reader_io.cpp

## Changes
- Line 70: Changed (void*)data to const_cast<void*>(static_cast<const void*>(data))

## Related
Closes #1639