### PR TITLE
fix(datacell): fix resize logic to update size after expansion

### DIFF
--- a/src/datacell/extra_info_datacell.h
+++ b/src/datacell/extra_info_datacell.h
@@ -51,10 +51,10 @@ public:
         if (new_capacity <= this->max_capacity_) {
             return;
         }
-        this->max_capacity_ = new_capacity;
         uint64_t io_size =
             static_cast<uint64_t>(new_capacity) * static_cast<uint64_t>(extra_info_size_);
         this->io_->Resize(io_size);
+        this->max_capacity_ = new_capacity;
     }
 
     void

--- a/src/datacell/flatten_datacell.h
+++ b/src/datacell/flatten_datacell.h
@@ -90,9 +90,9 @@ public:
         if (new_capacity <= this->max_capacity_) {
             return;
         }
-        this->max_capacity_ = new_capacity;
         uint64_t io_size = static_cast<uint64_t>(new_capacity) * static_cast<uint64_t>(code_size_);
         this->io_->Resize(io_size);
+        this->max_capacity_ = new_capacity;
     }
 
     void

--- a/src/datacell/graph_datacell.h
+++ b/src/datacell/graph_datacell.h
@@ -262,9 +262,9 @@ GraphDataCell<IOTmpl>::Resize(InnerIdType new_size) {
         }
         node_versions_.resize(new_size);
     }
-    this->max_capacity_ = new_size;
     uint64_t io_size = static_cast<uint64_t>(new_size) * static_cast<uint64_t>(code_line_size_);
     this->io_->Resize(io_size);
+    this->max_capacity_ = new_size;
 }
 
 template <typename IOTmpl>

--- a/src/datacell/sparse_vector_datacell.h
+++ b/src/datacell/sparse_vector_datacell.h
@@ -79,9 +79,9 @@ public:
             return;
         }
         uint64_t io_size = (new_capacity - total_count_) * max_code_size_ + current_offset_;
-        this->max_capacity_ = new_capacity;
         this->io_->Resize(io_size);
         this->offset_io_->Resize(static_cast<uint64_t>(new_capacity) * sizeof(uint32_t));
+        this->max_capacity_ = new_capacity;
     }
 
     void


### PR DESCRIPTION
close: #1643

Fix resize order in datacell components to prevent incorrect state when resize fails:

- graph_datacell.h: update max_capacity_ after io_->Resize()

- flatten_datacell.h: update max_capacity_ after io_->Resize()

- extra_info_datacell.h: update max_capacity_ after io_->Resize()

- sparse_vector_datacell.h: update max_capacity_ after io_->Resize() and offset_io_->Resize()

This ensures that if any resize operation fails, the size/capacity

values remain at their previous valid values, preventing data corruption.