### PR TITLE
fix(hgraph): restore total_count after deserialization

### DIFF
--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -1200,7 +1200,7 @@ HGraph::deserialize_basic_info_v0_14(StreamReader& reader) {
         this->label_table_->label_remap_.emplace(key, value);
     }
     // Restore total_count from label_remap size
-    this->label_table_->total_count_.store(size);
+    this->label_table_->total_count_.store(static_cast<int64_t>(size));
 }
 
 #define TO_JSON_BASE64(json_obj, var) json_obj[#var].SetString(base64_encode_obj(this->var##_));
@@ -1304,7 +1304,7 @@ HGraph::deserialize_label_info(StreamReader& reader) const {
         this->label_table_->label_remap_.emplace(key, value);
     }
     // Restore total_count from label_remap size (same as number of valid elements)
-    this->label_table_->total_count_.store(size);
+    this->label_table_->total_count_.store(static_cast<int64_t>(size));
 }
 
 void


### PR DESCRIPTION
close: #1637
close: #1645

Fix the issue where ExportIDs returns 0 elements after deserialization. The total_count_ was not restored after deserializing label_table_, causing GetTotalCount() to return 0.

Restore total_count from label_remap size after deserialization in both v0.14 and new version format paths.