### PR TITLE
fix(resize): ensure size is updated after successful expansion

### DIFF
--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -1056,7 +1056,6 @@ HGraph::resize(uint64_t new_size) {
         pool_ = std::make_shared<VisitedListPool>(1, allocator_, new_size_power_2, allocator_);
         this->label_table_->Resize(new_size_power_2);
         bottom_graph_->Resize(new_size_power_2);
-        this->max_capacity_.store(new_size_power_2);
         this->basic_flatten_codes_->Resize(new_size_power_2);
         if (use_reorder_) {
             this->high_precise_codes_->Resize(new_size_power_2);
@@ -1064,6 +1063,7 @@ HGraph::resize(uint64_t new_size) {
         if (this->extra_infos_ != nullptr) {
             this->extra_infos_->Resize(new_size_power_2);
         }
+        this->max_capacity_.store(new_size_power_2);
     }
 }
 void

--- a/src/data_cell/extra_info_datacell.h
+++ b/src/data_cell/extra_info_datacell.h
@@ -51,12 +51,12 @@ public:
         if (new_capacity <= this->max_capacity_) {
             return;
         }
-        this->max_capacity_ = new_capacity;
         uint64_t io_size =
             static_cast<uint64_t>(new_capacity) * static_cast<uint64_t>(extra_info_size_);
         uint8_t end_flag =
             127;  // the value is meaningless, only to occupy the position for io allocate
         this->io_->Write(&end_flag, 1, io_size);
+        this->max_capacity_ = new_capacity;
     }
 
     void

--- a/src/data_cell/flatten_datacell.h
+++ b/src/data_cell/flatten_datacell.h
@@ -76,11 +76,11 @@ public:
         if (new_capacity <= this->max_capacity_) {
             return;
         }
-        this->max_capacity_ = new_capacity;
         uint64_t io_size = static_cast<uint64_t>(new_capacity) * static_cast<uint64_t>(code_size_);
         uint8_t end_flag =
             127;  // the value is meaningless, only to occupy the position for io allocate
         this->io_->Write(&end_flag, 1, io_size);
+        this->max_capacity_ = new_capacity;
     }
 
     void

--- a/src/data_cell/graph_datacell.h
+++ b/src/data_cell/graph_datacell.h
@@ -246,11 +246,11 @@ GraphDataCell<IOTmpl>::Resize(InnerIdType new_size) {
         }
         node_versions_.resize(new_size);
     }
-    this->max_capacity_ = new_size;
     uint64_t io_size = static_cast<uint64_t>(new_size) * static_cast<uint64_t>(code_line_size_);
     uint8_t end_flag =
         127;  // the value is meaningless, only to occupy the position for io allocate
     this->io_->Write(&end_flag, 1, io_size);
+    this->max_capacity_ = new_size;
 }
 
 template <typename IOTmpl>

--- a/src/data_cell/sparse_vector_datacell.h
+++ b/src/data_cell/sparse_vector_datacell.h
@@ -71,11 +71,11 @@ public:
             return;
         }
         size_t io_size = (new_capacity - total_count_) * max_code_size_ + current_offset_;
-        this->max_capacity_ = new_capacity;
         uint8_t end_flag =
             127;  // the value is meaingless, only to occupy the position for io allocate
         this->io_->Write(&end_flag, 1, io_size);
         this->offset_io_->Write(&end_flag, 1, new_capacity * sizeof(uint32_t));
+        this->max_capacity_ = new_capacity;
     }
 
     void


### PR DESCRIPTION
cp #1642 to 0.16
link: #1643
Move max_capacity_ update to after all expansion operations complete. This prevents inconsistent state where size is updated but memory allocation failed in subsequent resize operations.

Fixes resize ordering in:
- HGraph::resize
- GraphDataCell::Resize
- FlattenDataCell::Resize
- ExtraInfoDataCell::Resize
- SparseVectorDataCell::Resize