### PR TITLE
fix(datacell): update max_capacity after io operation completes in 0.18

### DIFF
--- a/src/datacell/extra_info_datacell.h
+++ b/src/datacell/extra_info_datacell.h
@@ -51,12 +51,12 @@ public:
         if (new_capacity <= this->max_capacity_) {
             return;
         }
-        this->max_capacity_ = new_capacity;
         uint64_t io_size =
             static_cast<uint64_t>(new_capacity) * static_cast<uint64_t>(extra_info_size_);
         uint8_t end_flag =
             127;  // the value is meaningless, only to occupy the position for io allocate
         this->io_->Write(&end_flag, 1, io_size);
+        this->max_capacity_ = new_capacity;
     }
 
     void

--- a/src/datacell/flatten_datacell.h
+++ b/src/datacell/flatten_datacell.h
@@ -90,11 +90,11 @@ public:
         if (new_capacity <= this->max_capacity_) {
             return;
         }
-        this->max_capacity_ = new_capacity;
         uint64_t io_size = static_cast<uint64_t>(new_capacity) * static_cast<uint64_t>(code_size_);
         uint8_t end_flag =
             127;  // the value is meaningless, only to occupy the position for io allocate
         this->io_->Write(&end_flag, 1, io_size);
+        this->max_capacity_ = new_capacity;
     }
 
     void

--- a/src/datacell/graph_datacell.h
+++ b/src/datacell/graph_datacell.h
@@ -262,11 +262,11 @@ GraphDataCell<IOTmpl>::Resize(InnerIdType new_size) {
         }
         node_versions_.resize(new_size);
     }
-    this->max_capacity_ = new_size;
     uint64_t io_size = static_cast<uint64_t>(new_size) * static_cast<uint64_t>(code_line_size_);
     uint8_t end_flag =
         127;  // the value is meaningless, only to occupy the position for io allocate
     this->io_->Write(&end_flag, 1, io_size);
+    this->max_capacity_ = new_size;
 }
 
 template <typename IOTmpl>

--- a/src/datacell/sparse_vector_datacell.h
+++ b/src/datacell/sparse_vector_datacell.h
@@ -79,11 +79,11 @@ public:
             return;
         }
         size_t io_size = (new_capacity - total_count_) * max_code_size_ + current_offset_;
-        this->max_capacity_ = new_capacity;
         uint8_t end_flag =
             127;  // the value is meaingless, only to occupy the position for io allocate
         this->io_->Write(&end_flag, 1, io_size);
         this->offset_io_->Write(&end_flag, 1, new_capacity * sizeof(uint32_t));
+        this->max_capacity_ = new_capacity;
     }
 
     void


### PR DESCRIPTION
cp #1642 to 0.15
link: #1643

Move max_capacity assignment after io->Write() to ensure data is persisted before updating capacity.

This fixes the same resize issue as in 0.17 branch.