### PR TITLE
fix(io): add MAP_FAILED error check for mmap

### DIFF
--- a/src/io/mmap_io.cpp
+++ b/src/io/mmap_io.cpp
@@ -52,6 +52,10 @@ MMapIO::MMapIO(std::string filename, Allocator* allocator)
         }
     }
     void* addr = mmap(nullptr, mmap_size, PROT_READ | PROT_WRITE, MAP_SHARED, this->fd_, 0);
+    if (addr == MAP_FAILED) {
+        throw VsagException(ErrorType::INTERNAL_ERROR,
+                            fmt::format("mmap failed: {}", strerror(errno)));
+    }
     this->start_ = static_cast<uint8_t*>(addr);
 }
 


### PR DESCRIPTION
## Summary

Add `MAP_FAILED` error check for `mmap()` call in `MMapIO` constructor to prevent potential memory access issues when memory mapping fails.

## Changes

- Add `MAP_FAILED` check after `mmap()` call in `src/io/mmap_io.cpp`
- Throw `VsagException` with errno information when mmap fails

## Commits

- fix(io): add MAP_FAILED error check for mmap

## Files Changed

- src/io/mmap_io.cpp

## Testing

- All MMapIO related unit tests pass (3 test cases, 16803 assertions)
- Release build completed successfully (1050 targets)
- Code style check passed

## Related Issues

- Fixes #1656 

## Checklist

- [x] Code follows VSAG coding style
- [x] All tests pass
- [x] PR description is clear
