### PR TITLE
fix(quantization): add null pointer check in Computer destructor

### DIFF
--- a/src/quantization/computer.h
+++ b/src/quantization/computer.h
@@ -42,7 +42,9 @@ public:
         : quantizer_(quantizer), allocator_(allocator), raw_query_(allocator){};
 
     ~Computer() override {
-        quantizer_->ReleaseComputer(*this);
+        if (quantizer_) {
+            quantizer_->ReleaseComputer(*this);
+        }
     }
 
     void
@@ -92,7 +94,9 @@ public:
     }
 
     ~Computer() override {
-        quantizer_->ReleaseComputer(*this);
+        if (quantizer_) {
+            quantizer_->ReleaseComputer(*this);
+        }
         delete inner_computer_;
     }
 


### PR DESCRIPTION
## Summary
This PR fixes a critical null pointer dereference bug in the `Computer` class destructor. The destructor was calling `quantizer_->ReleaseComputer(*this)` without checking if `quantizer_` is null, which could cause a segmentation fault when an exception is thrown during object construction.

## Changes
- Add null pointer check before calling `ReleaseComputer` in main template destructor (`src/quantization/computer.h:44-49`)
- Add null pointer check in `TransformQuantizer` specialized template destructor (`src/quantization/computer.h:95-100`)
- Ensure exception safety by preventing null pointer dereference in destructors

## Technical Details
The `quantizer_` member is initialized to `nullptr` in the class declaration. If an exception occurs during construction (e.g., when `inner_computer_ = new Computer<QuantImpl>(...)` throws), the destructor will still be called, but `quantizer_` may still be `nullptr`. The fix adds a simple null check to prevent the crash.

## Testing
- [x] Release build passes
- [x] Code style check passes (clang-format)
- [ ] Unit tests (skipped for this small fix)

## Files Changed
- `src/quantization/computer.h`

## Related Issues
Fixes #1661

## Checklist
- [x] Code follows VSAG coding style
- [x] All builds pass
- [x] PR description is clear
- [x] Commit messages follow conventional commits format