### PR TITLE
fix(quantization): add null check in TransformQuantizer Computer destructor

### DIFF
--- a/src/quantization/computer.h
+++ b/src/quantization/computer.h
@@ -92,7 +92,9 @@ public:
     }
 
     ~Computer() override {
-        quantizer_->ReleaseComputer(*this);
+        if (quantizer_) {
+            quantizer_->ReleaseComputer(*this);
+        }
         delete inner_computer_;
     }
 


### PR DESCRIPTION
## Summary
Add null pointer check in TransformQuantizer Computer destructor to prevent potential crashes when `quantizer_` is null.

## Changes
- Added null check for `quantizer_` before calling `ReleaseComputer()` in destructor
- Defensive programming to handle edge cases where Computer object might be in invalid state

## Commits
- fix(quantization): add null check in TransformQuantizer Computer destructor

## Files Changed
- src/quantization/computer.h

## Testing
- Build: Release build passed
- Tests: Unit tests passed
- Lint: Code style check passed
- Format: Code formatting passed

## Related Issues
- Fixes #1663

## Details
### Original Code
```cpp
~Computer() override {
    quantizer_->ReleaseComputer(*this);
    delete inner_computer_;
}
```

### Fixed Code
```cpp
~Computer() override {
    if (quantizer_) {
        quantizer_->ReleaseComputer(*this);
    }
    delete inner_computer_;
}
```

Note: `delete inner_computer_` is safe with nullptr in C++ standard, so no additional check is needed.

## Checklist
- [x] Code follows VSAG coding style
- [x] All tests pass
- [x] Documentation updated (if needed)
- [x] PR description is clear