### PR TITLE
fix(quantizer): prevent division by zero in ScalarQuantizer::EncodeOneImpl

### DIFF
--- a/src/quantization/scalar_quantization/scalar_quantizer.cpp
+++ b/src/quantization/scalar_quantization/scalar_quantizer.cpp
@@ -95,7 +95,11 @@ ScalarQuantizer<metric, bit>::EncodeOneImpl(const DataType* data, uint8_t* codes
     }
     memset(codes, 0, this->code_size_);
     for (uint64_t d = 0; d < this->dim_; d++) {
-        delta = 1.0F * (cur[d] - lower_bound_[d]) / diff_[d];
+        if (diff_[d] < std::numeric_limits<float>::epsilon()) {
+            delta = 1.0F;
+        } else {
+            delta = 1.0F * (cur[d] - lower_bound_[d]) / diff_[d];
+        }
         if (delta < 0.0F) {
             delta = 0;
         } else if (delta > 0.999F) {


### PR DESCRIPTION
## Summary
Fix potential division by zero error in `ScalarQuantizer::EncodeOneImpl` when encoding data with identical values in any dimension.

## Changes
- Added epsilon check for `diff_[d]` before division operation
- When `diff_[d]` is near zero (below `std::numeric_limits<float>::epsilon()`), set `delta` to `1.0F` to avoid numerical overflow
- This handles the edge case where all data values in a dimension are identical

## Commits
- fix(quantizer): prevent division by zero in ScalarQuantizer::EncodeOneImpl

## Files Changed
- `src/quantization/scalar_quantization/scalar_quantizer.cpp`

## Testing
- Build: Release build completed successfully
- Unit tests: SQ4Quantizer and SQ8Quantizer tests passed
- Lint: Code style check passed

## Related Issues
- Fixes #1665

## Checklist
- [x] Code follows VSAG coding style
- [x] All tests pass
- [x] PR description is clear