### PR TITLE
fix(quantization): add missing quantization types to IsValidQuantizationType

### DIFF
--- a/src/quantization/quantizer_parameter.cpp
+++ b/src/quantization/quantizer_parameter.cpp
@@ -94,7 +94,9 @@ QuantizerParameter::IsValidQuantizationType(const std::string& type_name) {
                                                                 QUANTIZATION_TYPE_VALUE_FP16,
                                                                 QUANTIZATION_TYPE_VALUE_RABITQ,
                                                                 QUANTIZATION_TYPE_VALUE_SPARSE,
-                                                                QUANTIZATION_TYPE_VALUE_PQFS};
+                                                                QUANTIZATION_TYPE_VALUE_PQFS,
+                                                                QUANTIZATION_TYPE_VALUE_TQ,
+                                                                QUANTIZATION_TYPE_VALUE_INT8};
 
     return valid_types.find(type_name) != valid_types.end();
 }


### PR DESCRIPTION
## Summary
This PR adds two missing quantization types (`QUANTIZATION_TYPE_VALUE_TQ` and `QUANTIZATION_TYPE_VALUE_INT8`) to the `valid_types` set in the `IsValidQuantizationType` function, ensuring consistency with the `GetQuantizerParameterByJson` function.

## Background
The `IsValidQuantizationType` function was missing validation for two quantization types that were already properly handled in `GetQuantizerParameterByJson`. This inconsistency could lead to false negatives when validating these quantization types.

## Changes
- Add `QUANTIZATION_TYPE_VALUE_TQ` to the `valid_types` set in `IsValidQuantizationType`
- Add `QUANTIZATION_TYPE_VALUE_INT8` to the `valid_types` set in `IsValidQuantizationType`

## Commits
- fix(quantization): add missing quantization types to IsValidQuantizationType

## Files Changed
- `src/quantization/quantizer_parameter.cpp`

## Testing
- [x] Release build successful
- [x] Unit tests passing
- [x] Lint checks passing
- [x] Code formatted correctly

## Related Issues
- Fixes #1667

## Checklist
- [x] Code follows VSAG coding style
- [x] All tests pass
- [x] PR description is clear