### PR TITLE
fix: add missing namespaces for stream serialization helpers

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -33,7 +33,7 @@ Checks: >
     -readability-identifier-length,
     -readability-magic-numbers,
     -readability-function-cognitive-complexity, # enable after fix all
-    -readability-redundant-access-specifiers
+    -readability-redundant-access-specifiers, # keep repeated public:/protected:/private: as visual separators between method groups
 
 
 HeaderFilterRegex: ''

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,8 +20,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Install clang-tidy
-        run: sudo apt install clang-tidy-15 -y && sudo ln -s /usr/bin/clang-tidy-15 /usr/bin/clang-tidy
+      - name: Install clang-tidy 15
+        run: sudo apt install clang-tidy-15 -y
       - name: Load Cache
         uses: hendrikmuhs/ccache-action@v1.2
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,6 +99,28 @@ $ make fmt
 
 The format script will automatically verify you're using clang-format-15 and will fail if a different version is detected.
 
+### Run clang-tidy
+
+**Important**: VSAG requires **clang-tidy version 15 EXACTLY**. Do not use higher or lower versions as they may produce different diagnostics.
+
+Install clang-tidy-15:
+```shell
+# Ubuntu/Debian
+$ sudo apt-get install clang-tidy-15
+```
+
+To run lint checks:
+```shell
+$ make lint
+```
+
+To apply clang-tidy fixes in place:
+```shell
+$ make fix-lint
+```
+
+The lint wrapper will automatically verify you're using clang-tidy-15 and will fail if a different version is detected.
+
 ## Run tests with code coverage
 
 Before submitting your PR, make sure you have run unit test, and your code coverage rate is >= 90%.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -29,6 +29,7 @@ docker pull vsaglib/vsag:ubuntu
   - or Clang version 13.0.0 or later
 - Build Tools: 
   - CMake version 3.18.0 or later
+  - clang-tidy version 15 EXACTLY (not higher, not lower - required for consistent lint diagnostics)
   - clang-format version 15 EXACTLY (not higher, not lower - required for consistent formatting)
 - Additional Dependencies:
   - gfortran

--- a/Makefile
+++ b/Makefile
@@ -98,11 +98,11 @@ cov:                     ## Build unit tests with code coverage enabled.
 
 .PHONEY: lint
 lint:                    ## Check coding styles defined in `.clang-tidy`.
-	@./scripts/linters/run-clang-tidy.py -p build-release/ -use-color -source-filter '^.*vsag\/src.*(?<!_test)\.cpp$$' -j ${COMPILE_JOBS}
+	@./scripts/linters/run-clang-tidy-15.sh -p build-release/ -use-color -source-filter '^.*vsag\/src.*(?<!_test)\.cpp$$' -j ${COMPILE_JOBS}
 
 .PHONEY: fix-lint
 fix-lint:                ## Fix coding style issues in-place via clang-apply-replacements, use it be careful!!!
-	@./scripts/linters/run-clang-tidy.py -p build-release/ -use-color -source-filter '^.*vsag\/src.*(?<!_test)\.cpp$$' -j ${COMPILE_JOBS} -fix
+	@./scripts/linters/run-clang-tidy-15.sh -p build-release/ -use-color -source-filter '^.*vsag\/src.*(?<!_test)\.cpp$$' -j ${COMPILE_JOBS} -fix
 
 .PHONY: test_parallel
 test_parallel:           ## Run all tests parallel (used in CI).

--- a/scripts/linters/run-clang-tidy-15.sh
+++ b/scripts/linters/run-clang-tidy-15.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# VSAG requires clang-tidy version 15 EXACTLY
+# Higher or lower versions may produce different diagnostics
+
+set -euo pipefail
+
+REQUIRED_VERSION="15"
+
+if ! command -v clang-tidy-15 &> /dev/null; then
+    echo "ERROR: clang-tidy-15 is not installed!"
+    echo "Please install it with: sudo apt-get install clang-tidy-15"
+    exit 1
+fi
+
+ACTUAL_VERSION=$(clang-tidy-15 --version | grep -oP 'version \K[0-9]+' | head -1)
+if [ "$ACTUAL_VERSION" != "$REQUIRED_VERSION" ]; then
+    echo "ERROR: clang-tidy version mismatch!"
+    echo "Required: version $REQUIRED_VERSION"
+    echo "Found: version $ACTUAL_VERSION"
+    exit 1
+fi
+
+echo "Using clang-tidy version $ACTUAL_VERSION (required: $REQUIRED_VERSION)"
+
+if printf '%s\n' "$@" | grep -qx -- '-fix'; then
+    if ! command -v clang-apply-replacements-15 &> /dev/null; then
+        echo "ERROR: clang-apply-replacements-15 is not installed!"
+        echo "Please install it with: sudo apt-get install clang-tools-15"
+        exit 1
+    fi
+
+    exec ./scripts/linters/run-clang-tidy.py \
+        -clang-tidy-binary clang-tidy-15 \
+        -clang-apply-replacements-binary clang-apply-replacements-15 \
+        "$@"
+fi
+
+exec ./scripts/linters/run-clang-tidy.py -clang-tidy-binary clang-tidy-15 "$@"

--- a/src/algorithm/hnswlib/algorithm_interface.h
+++ b/src/algorithm/hnswlib/algorithm_interface.h
@@ -34,6 +34,9 @@ namespace hnswlib {
 
 using LabelType = vsag::LabelType;
 using InnerIdType = vsag::InnerIdType;
+using vsag::StreamReader;
+using vsag::StreamWriter;
+using vsag::WriteFuncStreamWriter;
 
 template <typename dist_t>
 class AlgorithmInterface {

--- a/src/algorithm/hnswlib/block_manager.h
+++ b/src/algorithm/hnswlib/block_manager.h
@@ -26,6 +26,10 @@
 
 namespace hnswlib {
 
+using vsag::IOStreamReader;
+using vsag::StreamReader;
+using vsag::StreamWriter;
+
 class BlockManager {
 public:
     BlockManager(uint64_t size_data_per_element,

--- a/src/algorithm/inner_index_interface_test.cpp
+++ b/src/algorithm/inner_index_interface_test.cpp
@@ -71,8 +71,7 @@ TEST_CASE("Fast Create Index", "[ut][InnerIndexInterface]") {
 
 class EmptyInnerIndex : public InnerIndexInterface {
 public:
-    EmptyInnerIndex() : InnerIndexInterface() {
-    }
+    EmptyInnerIndex() = default;
 
     std::string
     GetName() const override {
@@ -86,7 +85,6 @@ public:
 
     void
     InitFeatures() override {
-        return;
     }
 
     std::vector<int64_t>
@@ -113,12 +111,10 @@ public:
 
     void
     Serialize(StreamWriter& writer) const override {
-        return;
     }
 
     void
     Deserialize(StreamReader& reader) override {
-        return;
     }
 
     int64_t

--- a/src/impl/conjugate_graph_test.cpp
+++ b/src/impl/conjugate_graph_test.cpp
@@ -167,7 +167,7 @@ TEST_CASE("ConjugateGraph Serialize and Deserialize with Stream", "[ut][Conjugat
         in_stream.seekg(0, std::ios::end);
         REQUIRE(in_stream.tellg() == 60 + vsag::FOOTER_SIZE);
         in_stream.seekg(0, std::ios::beg);
-        IOStreamReader reader(in_stream);
+        vsag::IOStreamReader reader(in_stream);
         REQUIRE(conjugate_graph->Deserialize(reader).has_value());
         in_stream.close();
 
@@ -195,7 +195,7 @@ TEST_CASE("ConjugateGraph Serialize and Deserialize with Stream", "[ut][Conjugat
         out_stream.close();
 
         std::fstream in_stream(dir.path + "conjugate_graph.bin", std::ios::in | std::ios::binary);
-        IOStreamReader reader(in_stream);
+        vsag::IOStreamReader reader(in_stream);
         REQUIRE(conjugate_graph->Deserialize(reader).error().type == vsag::ErrorType::READ_ERROR);
         in_stream.close();
     }
@@ -218,7 +218,7 @@ TEST_CASE("ConjugateGraph Serialize and Deserialize with Stream", "[ut][Conjugat
         out_stream.close();
 
         std::fstream in_stream(dir.path + "conjugate_graph.bin", std::ios::in | std::ios::binary);
-        IOStreamReader reader(in_stream);
+        vsag::IOStreamReader reader(in_stream);
         REQUIRE(conjugate_graph->Deserialize(reader).error().type == vsag::ErrorType::READ_ERROR);
         in_stream.close();
     }
@@ -233,7 +233,7 @@ TEST_CASE("ConjugateGraph Serialize and Deserialize with Stream", "[ut][Conjugat
         std::filesystem::resize_file(dir.path + "conjugate_graph.bin", 55 + vsag::FOOTER_SIZE);
 
         std::fstream in_stream(dir.path + "conjugate_graph.bin", std::ios::in | std::ios::binary);
-        IOStreamReader reader(in_stream);
+        vsag::IOStreamReader reader(in_stream);
         REQUIRE(conjugate_graph->Deserialize(reader).error().type == vsag::ErrorType::READ_ERROR);
         in_stream.close();
     }
@@ -249,7 +249,7 @@ TEST_CASE("ConjugateGraph Serialize and Deserialize with Stream", "[ut][Conjugat
         out_stream.close();
 
         std::fstream in_stream(dir.path + "conjugate_graph.bin", std::ios::in | std::ios::binary);
-        IOStreamReader reader(in_stream);
+        vsag::IOStreamReader reader(in_stream);
         REQUIRE(conjugate_graph->Deserialize(reader).error().type == vsag::ErrorType::READ_ERROR);
         in_stream.close();
     }
@@ -264,7 +264,7 @@ TEST_CASE("ConjugateGraph Serialize and Deserialize with Stream", "[ut][Conjugat
         std::filesystem::resize_file(dir.path + "conjugate_graph.bin", 55 + vsag::FOOTER_SIZE);
 
         std::fstream in_stream(dir.path + "conjugate_graph.bin", std::ios::in | std::ios::binary);
-        IOStreamReader reader(in_stream);
+        vsag::IOStreamReader reader(in_stream);
         REQUIRE(conjugate_graph->Deserialize(reader).error().type == vsag::ErrorType::READ_ERROR);
         in_stream.close();
 
@@ -278,7 +278,7 @@ TEST_CASE("ConjugateGraph Serialize and Deserialize with Stream", "[ut][Conjugat
 
         std::fstream re_in_stream(dir.path + "conjugate_graph.bin",
                                   std::ios::in | std::ios::binary);
-        IOStreamReader re_reader(re_in_stream);
+        vsag::IOStreamReader re_reader(re_in_stream);
         REQUIRE(conjugate_graph->Deserialize(re_reader).has_value());
         REQUIRE(conjugate_graph->GetMemoryUsage() == 4 + vsag::FOOTER_SIZE);
         re_in_stream.close();

--- a/src/impl/label_table_test.cpp
+++ b/src/impl/label_table_test.cpp
@@ -271,12 +271,12 @@ TEST_CASE("LabelTable Serialize and Deserialize with Duplicates", "[ut][LabelTab
 
         // Serialize
         std::stringstream ss;
-        IOStreamWriter writer(ss);
+        vsag::IOStreamWriter writer(ss);
         label_table->Serialize(writer);
 
         // Deserialize into new label table
         auto new_label_table = std::make_shared<LabelTable>(allocator.get(), true, true);
-        IOStreamReader reader(ss);
+        vsag::IOStreamReader reader(ss);
         new_label_table->Deserialize(reader);
 
         // Verify labels are preserved
@@ -305,11 +305,11 @@ TEST_CASE("LabelTable Serialize and Deserialize with Duplicates", "[ut][LabelTab
         label_table->Insert(2, 300);
 
         std::stringstream ss;
-        IOStreamWriter writer(ss);
+        vsag::IOStreamWriter writer(ss);
         label_table->Serialize(writer);
 
         auto new_label_table = std::make_shared<LabelTable>(allocator.get(), true, true);
-        IOStreamReader reader(ss);
+        vsag::IOStreamReader reader(ss);
         new_label_table->Deserialize(reader);
 
         REQUIRE(new_label_table->GetLabelById(0) == 100);
@@ -331,11 +331,11 @@ TEST_CASE("LabelTable Serialize and Deserialize with Duplicates", "[ut][LabelTab
         auto count_before = label_table->GetTotalCount();
 
         std::stringstream ss;
-        IOStreamWriter writer(ss);
+        vsag::IOStreamWriter writer(ss);
         label_table->Serialize(writer);
 
         auto new_label_table = std::make_shared<LabelTable>(allocator.get(), true, true);
-        IOStreamReader reader(ss);
+        vsag::IOStreamReader reader(ss);
         new_label_table->Deserialize(reader);
 
         REQUIRE(new_label_table->GetTotalCount() == count_before);

--- a/src/index/hnsw_test.cpp
+++ b/src/index/hnsw_test.cpp
@@ -323,7 +323,7 @@ TEST_CASE("serialize empty index", "[ut][hnsw]") {
         REQUIRE(result.has_value());
         out_stream.close();
         std::fstream in_stream(dir.path + "empty_index.bin", std::ios::in | std::ios::binary);
-        IOStreamReader reader(in_stream);
+        vsag::IOStreamReader reader(in_stream);
         auto footer = Footer::Parse(reader);
         REQUIRE(footer->GetMetadata()->EmptyIndex());
     }

--- a/src/storage/footer_test.cpp
+++ b/src/storage/footer_test.cpp
@@ -33,7 +33,7 @@ TEST_CASE("Footer Basic Usage Test", "[ut][footer]") {
 
         std::stringstream in_ss(std::ios::in | std::ios::binary);
         in_ss.str(str);
-        IOStreamReader reader(in_ss);
+        vsag::IOStreamReader reader(in_ss);
         footer.Deserialize(reader);
         for (int i = 0; i < 10; i++) {
             REQUIRE(std::stoi(footer.GetMetadata(std::to_string(i))) == i);
@@ -56,7 +56,7 @@ TEST_CASE("Footer Basic Usage Test", "[ut][footer]") {
         std::string str = ss.str();
         str.resize(vsag::FOOTER_SIZE - 1);
         ss.str(str);
-        IOStreamReader reader(ss);
+        vsag::IOStreamReader reader(ss);
         REQUIRE_THROWS(footer.Deserialize(reader));
     }
 
@@ -71,7 +71,7 @@ TEST_CASE("Footer Basic Usage Test", "[ut][footer]") {
         std::stringstream in_ss(std::ios::in | std::ios::binary);
         str.resize(10);
         in_ss.str(str);
-        IOStreamReader reader(in_ss);
+        vsag::IOStreamReader reader(in_ss);
         REQUIRE_THROWS(footer.Deserialize(reader));
     }
 
@@ -91,7 +91,7 @@ TEST_CASE("Footer Basic Usage Test", "[ut][footer]") {
 
         std::stringstream in_ss(std::ios::in | std::ios::binary);
         in_ss.str(str);
-        IOStreamReader reader(in_ss);
+        vsag::IOStreamReader reader(in_ss);
         REQUIRE_THROWS(footer.Deserialize(reader));
     }
 
@@ -99,7 +99,7 @@ TEST_CASE("Footer Basic Usage Test", "[ut][footer]") {
         std::stringstream ss(std::ios::in | std::ios::out | std::ios::binary);
         uint32_t serialized_data_size = vsag::FOOTER_SIZE + 1;
         ss << serialized_data_size;
-        IOStreamReader reader(ss);
+        vsag::IOStreamReader reader(ss);
         REQUIRE_THROWS(footer.Deserialize(reader));
     }
 
@@ -108,7 +108,7 @@ TEST_CASE("Footer Basic Usage Test", "[ut][footer]") {
         std::string invalid_value = "abcd";
         footer.SetMetadata(vsag::SERIALIZE_MAGIC_NUM, invalid_value);
         footer.Serialize(ss);
-        IOStreamReader reader(ss);
+        vsag::IOStreamReader reader(ss);
         REQUIRE_THROWS(footer.Deserialize(reader));
     }
 
@@ -117,7 +117,7 @@ TEST_CASE("Footer Basic Usage Test", "[ut][footer]") {
         std::string invalid_value = "1.0";
         footer.SetMetadata(vsag::SERIALIZE_VERSION, invalid_value);
         footer.Serialize(ss);
-        IOStreamReader reader(ss);
+        vsag::IOStreamReader reader(ss);
         REQUIRE_THROWS(footer.Deserialize(reader));
     }
 }

--- a/src/storage/serialization_template_test.h
+++ b/src/storage/serialization_template_test.h
@@ -23,8 +23,8 @@ template <typename T>
 void
 test_serializion(T& old_instance, T& new_instance) {
     std::stringstream ss;
-    IOStreamWriter writer(ss);
+    vsag::IOStreamWriter writer(ss);
     old_instance.Serialize(writer);
-    IOStreamReader reader(ss);
+    vsag::IOStreamReader reader(ss);
     new_instance.Deserialize(reader);
 }

--- a/src/storage/stream_reader.cpp
+++ b/src/storage/stream_reader.cpp
@@ -26,6 +26,8 @@
 #include "vsag/options.h"
 #include "vsag_exception.h"
 
+namespace vsag {
+
 SliceStreamReader
 StreamReader::Slice(uint64_t begin, uint64_t length) {
     return {this, begin, length};
@@ -218,3 +220,5 @@ SliceStreamReader::SliceStreamReader(StreamReader* reader, uint64_t length)
     begin_ = reader->GetCursor();
     // vsag::logger::trace("SliceReader [{}, {})", begin_, begin_ + length_);
 }
+
+}  // namespace vsag

--- a/src/storage/stream_reader.h
+++ b/src/storage/stream_reader.h
@@ -23,6 +23,8 @@
 #include "../typing.h"
 #include "impl/logger/logger.h"
 
+namespace vsag {
+
 class SliceStreamReader;
 
 class StreamReader {
@@ -167,9 +169,7 @@ public:
     GetCursor() const override;
 
 public:
-    explicit BufferStreamReader(StreamReader* reader,
-                                uint64_t max_size,
-                                vsag::Allocator* allocator);
+    explicit BufferStreamReader(StreamReader* reader, uint64_t max_size, Allocator* allocator);
 
     ~BufferStreamReader();
 
@@ -209,3 +209,5 @@ private:
     uint64_t begin_{0};
     uint64_t cursor_{0};
 };
+
+}  // namespace vsag

--- a/src/storage/stream_reader_test.cpp
+++ b/src/storage/stream_reader_test.cpp
@@ -24,14 +24,14 @@
 // ['2' '2' ... repeats 1024 times]
 // ['3' '3' ... repeats 1024 times]
 // ['4' '4' ... repeats 1024 times]
-ReadFuncStreamReader
+vsag::ReadFuncStreamReader
 gen_4k_data_and_return_stream_reader(char* buffer) {
     memset(buffer, '1', 1024);
     memset(buffer + 1024, '2', 1024);
     memset(buffer + 2048, '3', 1024);
     memset(buffer + 3072, '4', 1024);
 
-    auto reader = ReadFuncStreamReader(
+    auto reader = vsag::ReadFuncStreamReader(
         /*read_func=*/[=](uint64_t offset,
                           uint64_t size,
                           void* dest) { memcpy(dest, buffer + offset, size); },

--- a/src/storage/stream_writer.cpp
+++ b/src/storage/stream_writer.cpp
@@ -18,6 +18,8 @@
 #include <cstring>
 #include <utility>
 
+namespace vsag {
+
 BufferStreamWriter::BufferStreamWriter(char* buffer) : buffer_(buffer) {
 }
 
@@ -48,3 +50,5 @@ WriteFuncStreamWriter::Write(const char* data, uint64_t size) {
     cursor_ += size;
     bytes_written_ += size;
 }
+
+}  // namespace vsag

--- a/src/storage/stream_writer.h
+++ b/src/storage/stream_writer.h
@@ -21,6 +21,8 @@
 
 #include "typing.h"
 
+namespace vsag {
+
 class StreamWriter {
 public:
     template <typename T>
@@ -107,7 +109,8 @@ public:
 
     std::function<void(uint64_t, uint64_t, void*)> writeFunc_;
 
-public:
     uint64_t cursor_{0};
     uint64_t written_bytes_{0};
 };
+
+}  // namespace vsag

--- a/src/storage/stream_writer_test.cpp
+++ b/src/storage/stream_writer_test.cpp
@@ -25,11 +25,11 @@
 
 TEST_CASE("BufferStreamWriter", "[ut][stream_reader]") {
     auto* buffer = new char[4096]{};
-    BufferStreamWriter writer(buffer);
+    vsag::BufferStreamWriter writer(buffer);
 
     SECTION("float") {
         float number = 1.234567;
-        StreamWriter::WriteObj(writer, number);
+        vsag::StreamWriter::WriteObj(writer, number);
         float number2 = 0.0F;
         memcpy(&number2, buffer, sizeof(float));
         REQUIRE(number == number2);
@@ -37,7 +37,7 @@ TEST_CASE("BufferStreamWriter", "[ut][stream_reader]") {
 
     SECTION("string") {
         std::string text{"hello world!"};
-        StreamWriter::WriteString(writer, text);
+        vsag::StreamWriter::WriteString(writer, text);
 
         struct {
             uint64_t size;
@@ -51,12 +51,12 @@ TEST_CASE("BufferStreamWriter", "[ut][stream_reader]") {
 
     SECTION("empty string") {
         std::string empty_text;
-        CHECK_NOTHROW(StreamWriter::WriteString(writer, empty_text));
+        CHECK_NOTHROW(vsag::StreamWriter::WriteString(writer, empty_text));
     }
 
     SECTION("std::vector") {
         std::vector<float> numbers{1.1, 2.2, 3.3, 4.4, 5.5};
-        StreamWriter::WriteVector(writer, numbers);
+        vsag::StreamWriter::WriteVector(writer, numbers);
 
         struct {
             uint64_t size;
@@ -74,7 +74,7 @@ TEST_CASE("BufferStreamWriter", "[ut][stream_reader]") {
 
     SECTION("empty std::vector") {
         std::vector<float> numbers{};
-        CHECK_NOTHROW(StreamWriter::WriteVector(writer, numbers));
+        CHECK_NOTHROW(vsag::StreamWriter::WriteVector(writer, numbers));
     }
 
     SECTION("vsag::Vector") {
@@ -84,7 +84,7 @@ TEST_CASE("BufferStreamWriter", "[ut][stream_reader]") {
         numbers[1] = 3;
         numbers[2] = 5;
         numbers[3] = 7;
-        StreamWriter::WriteVector(writer, numbers);
+        vsag::StreamWriter::WriteVector(writer, numbers);
 
         struct {
             uint64_t size;
@@ -101,7 +101,7 @@ TEST_CASE("BufferStreamWriter", "[ut][stream_reader]") {
 
     SECTION("empty vsag::Vector") {
         std::vector<float> numbers{};
-        CHECK_NOTHROW(StreamWriter::WriteVector(writer, numbers));
+        CHECK_NOTHROW(vsag::StreamWriter::WriteVector(writer, numbers));
     }
 
     delete[] buffer;


### PR DESCRIPTION
Wrap stream reader, stream writer, and IO read helper declarations in the vsag namespace, update affected callers, keep repeated access specifiers as visual separators per project style, and align clang-tidy configuration and tooling on version 15 with an exact-version wrapper like clang-format.