### PR TITLE
chore(ci): remove pull_request trigger from coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,8 +3,6 @@ name: Coverage
 on:
   push:
     branches: [ "main", "0.*" ]
-  pull_request:
-    branches: [ "main", "0.*" ]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
Remove the pull_request trigger from the coverage workflow to reduce unnecessary CI runs. Coverage will only run when PRs are merged to the main branch or can be manually triggered.

## Changes
- Removed `pull_request` trigger from `.github/workflows/coverage.yml`
- Kept `push` trigger for main and 0.* branches (coverage runs on PR merge)
- Kept `workflow_dispatch` trigger for manual coverage runs

## Files Changed
- `.github/workflows/coverage.yml`

## Testing
This is a configuration change to GitHub Actions workflow. The YAML syntax has been validated.

## Related Issues
Fixes #1674

## Checklist
- [x] Code follows VSAG coding style
- [x] PR description is clear
- [x] Related issue is referenced