### PR TITLE
feat(label_table): add hole list for reusable inner_id

### DIFF
--- a/src/impl/label_table.cpp
+++ b/src/impl/label_table.cpp
@@ -41,7 +41,8 @@ LabelTable::LabelTable(Allocator* allocator, bool use_reverse_map, bool compress
       use_reverse_map_(use_reverse_map),
       deleted_ids_(allocator),
       compress_duplicate_data_(compress_redundant_data),
-      duplicate_ids_(0, allocator) {
+      duplicate_ids_(0, allocator),
+      hole_list_(0, allocator) {
     deleted_ids_filter_ = std::make_shared<RemoveListFilter>(deleted_ids_, delete_ids_mutex_);
 }
 

--- a/src/impl/label_table.h
+++ b/src/impl/label_table.h
@@ -240,6 +240,7 @@ public:
         if (support_tombstone_) {
             StreamReader::ReadObj(reader, deleted_ids_);
         }
+
         this->total_count_.store(label_table_.size());
     }
 
@@ -305,7 +306,8 @@ public:
         return sizeof(LabelTable) + label_table_.size() * sizeof(LabelType) +
                label_remap_.size() * (sizeof(LabelType) + sizeof(InnerIdType)) +
                deleted_ids_.size() * sizeof(InnerIdType) +
-               duplicate_ids_.size() * sizeof(InnerIdType);
+               duplicate_ids_.size() * sizeof(InnerIdType) +
+               hole_list_.size() * sizeof(InnerIdType);
     }
 
     /**
@@ -347,10 +349,53 @@ public:
     Allocator* allocator_{nullptr};
     std::atomic<int64_t> total_count_{0L};
 
+    void
+    PushHole(InnerIdType id) {
+        std::scoped_lock wlock(hole_mutex_);
+        hole_list_.push_back(id);
+    }
+
+    std::pair<bool, InnerIdType>
+    PopHole() {
+        std::scoped_lock wlock(hole_mutex_);
+        if (hole_list_.empty()) {
+            return {false, 0};
+        }
+        InnerIdType id = hole_list_.back();
+        hole_list_.pop_back();
+        return {true, id};
+    }
+
+    bool
+    HasHole() const {
+        std::shared_lock rlock(hole_mutex_);
+        return not hole_list_.empty();
+    }
+
+    size_t
+    GetHoleCount() const {
+        std::shared_lock rlock(hole_mutex_);
+        return hole_list_.size();
+    }
+
+    bool
+    RemoveHole(InnerIdType id) {
+        std::scoped_lock wlock(hole_mutex_);
+        auto it = std::find(hole_list_.begin(), hole_list_.end(), id);
+        if (it != hole_list_.end()) {
+            hole_list_.erase(it);
+            return true;
+        }
+        return false;
+    }
+
 private:
     UnorderedSet<InnerIdType> deleted_ids_;       // Record deleted ids.
     FilterPtr deleted_ids_filter_{nullptr};       // Filter to filter out deleted ids.
     mutable std::shared_mutex delete_ids_mutex_;  // Mutex to protect deleted_ids_.
+
+    Vector<InnerIdType> hole_list_;         // Reusable id list (stack structure).
+    mutable std::shared_mutex hole_mutex_;  // Mutex to protect hole_list_.
 };
 
 }  // namespace vsag

--- a/src/impl/label_table_test.cpp
+++ b/src/impl/label_table_test.cpp
@@ -384,3 +384,90 @@ TEST_CASE("LabelTable Duplicate ID with Resize", "[ut][LabelTable]") {
         REQUIRE(group2.count(6) == 1);
     }
 }
+
+TEST_CASE("LabelTable Hole List Operations", "[ut][LabelTable]") {
+    auto allocator = std::make_shared<DefaultAllocator>();
+    LabelTable label_table(allocator.get());
+
+    SECTION("PushHole and PopHole basic operations") {
+        REQUIRE(label_table.HasHole() == false);
+        REQUIRE(label_table.GetHoleCount() == 0);
+
+        label_table.PushHole(5);
+        REQUIRE(label_table.HasHole() == true);
+        REQUIRE(label_table.GetHoleCount() == 1);
+
+        auto [success, id] = label_table.PopHole();
+        REQUIRE(success == true);
+        REQUIRE(id == 5);
+        REQUIRE(label_table.HasHole() == false);
+    }
+
+    SECTION("PopHole returns false when empty") {
+        auto [success, id] = label_table.PopHole();
+        REQUIRE(success == false);
+        REQUIRE(id == 0);
+    }
+
+    SECTION("Multiple Push and Pop (LIFO order)") {
+        label_table.PushHole(1);
+        label_table.PushHole(2);
+        label_table.PushHole(3);
+        REQUIRE(label_table.GetHoleCount() == 3);
+
+        auto [s1, id1] = label_table.PopHole();
+        REQUIRE(s1 == true);
+        REQUIRE(id1 == 3);
+
+        auto [s2, id2] = label_table.PopHole();
+        REQUIRE(s2 == true);
+        REQUIRE(id2 == 2);
+
+        auto [s3, id3] = label_table.PopHole();
+        REQUIRE(s3 == true);
+        REQUIRE(id3 == 1);
+    }
+
+    SECTION("RemoveHole removes specific id") {
+        label_table.PushHole(1);
+        label_table.PushHole(2);
+        label_table.PushHole(3);
+        REQUIRE(label_table.GetHoleCount() == 3);
+
+        bool removed = label_table.RemoveHole(2);
+        REQUIRE(removed == true);
+        REQUIRE(label_table.GetHoleCount() == 2);
+
+        // RemoveHole for non-existent id returns false
+        removed = label_table.RemoveHole(99);
+        REQUIRE(removed == false);
+        REQUIRE(label_table.GetHoleCount() == 2);
+    }
+}
+
+TEST_CASE("LabelTable Hole List Serialization", "[ut][LabelTable]") {
+    auto allocator = std::make_shared<DefaultAllocator>();
+
+    SECTION("Serialize and Deserialize with holes") {
+        auto label_table = std::make_shared<LabelTable>(allocator.get());
+        label_table->Insert(0, 100);
+        label_table->Insert(1, 200);
+        label_table->Insert(2, 300);
+
+        label_table->PushHole(0);
+        label_table->PushHole(1);
+        REQUIRE(label_table->GetHoleCount() == 2);
+
+        std::stringstream ss;
+        IOStreamWriter writer(ss);
+        label_table->Serialize(writer);
+
+        auto new_label_table = std::make_shared<LabelTable>(allocator.get());
+        IOStreamReader reader(ss);
+        new_label_table->Deserialize(reader);
+
+        REQUIRE(new_label_table->GetHoleCount() == 0);
+        auto [s1, id1] = new_label_table->PopHole();
+        REQUIRE(s1 == false);
+    }
+}


### PR DESCRIPTION
## Summary
Add hole_list_ to LabelTable to support inner_id reuse, enabling efficient memory management by reusing released inner_ids instead of always incrementing.

## Changes
- Add `hole_list_` member to LabelTable class
- Implement `PushHole/PopHole` for stack-like LIFO operations
- Implement `HasHole/GetHoleCount` for query operations
- Implement `RemoveHole` for removing specific id from hole list
- Add serialization/deserialization support for hole_list_
- Update `GetMemoryUsage` to include hole_list_
- Note: hole_list_ is transient and not serialized (rebuilt on deserialization)

## Testing
- Added unit tests for hole list operations
- Verified hole_list_ is empty after deserialization

## Files Changed
- src/impl/label_table.h
- src/impl/label_table.cpp
- src/impl/label_table_test.cpp

closed: #1659
