### PR TITLE
docs(quantization): add layout diagrams for all quantizer types

### DIFF
--- a/src/quantization/fp32_quantizer.h
+++ b/src/quantization/fp32_quantizer.h
@@ -22,6 +22,18 @@
 
 namespace vsag {
 
+/***
+ * @brief FP32 Quantizer stores vectors in 32-bit floating-point format.
+ *
+ * code layout:
+ * +----------------+----------------+
+ * | float32-code   | mold (opt)     |
+ * | [dim * 4B]     | [4B]           |
+ * +----------------+----------------+
+ *
+ * - float32-code: original vector data (required)
+ * - mold: sqrt(sum(vec^2)) for cosine similarity (optional, cosine with hold_molds)
+ */
 template <MetricType metric = MetricType::METRIC_TYPE_L2SQR>
 class FP32Quantizer : public Quantizer<FP32Quantizer<metric>> {
 public:

--- a/src/quantization/int8_quantizer.h
+++ b/src/quantization/int8_quantizer.h
@@ -25,6 +25,19 @@
 #include "quantizer.h"
 
 namespace vsag {
+
+/***
+ * @brief INT8 Quantizer stores vectors in 8-bit integer format.
+ *
+ * code layout:
+ * +----------------+----------------+
+ * | int8-code      | mold (opt)     |
+ * | [dim * 1B]     | [4B]           |
+ * +----------------+----------------+
+ *
+ * - int8-code: quantized 8-bit integer values (required)
+ * - mold: sqrt(sum(vec^2)) for normalization (optional, cosine only)
+ */
 template <MetricType metric = MetricType::METRIC_TYPE_L2SQR>
 class INT8Quantizer : public Quantizer<INT8Quantizer<metric>> {
 public:

--- a/src/quantization/product_quantization/pq_fastscan_quantizer.h
+++ b/src/quantization/product_quantization/pq_fastscan_quantizer.h
@@ -22,6 +22,25 @@
 
 namespace vsag {
 
+/***
+ * @brief PQ FastScan Quantizer uses 4-bit packed storage for optimized distance computation.
+ *
+ * code layout (32 vectors packed):
+ * +--------+--------+-----+--------+
+ * | sub0   | sub1   | ... | subN   |
+ * | [32*4b]| [32*4b]|     | [32*4b]|
+ * +--------+--------+-----+--------+
+ *
+ * query layout:
+ * +------------------+--------+--------+
+ * | lookup-table     | diff   | lower  |
+ * | [pq_dim*16*4B]   | [4B]   | [4B]   |
+ * +------------------+--------+--------+
+ *
+ * - pqfs-code: 4 bits per subspace, packed for 32 vectors at once
+ * - Each subspace has 16 centroids (2^4 = 16 possible indices)
+ * - Optimized for SIMD batch distance computation
+ */
 template <MetricType metric = MetricType::METRIC_TYPE_L2SQR>
 class PQFastScanQuantizer : public Quantizer<PQFastScanQuantizer<metric>> {
 public:

--- a/src/quantization/product_quantization/product_quantizer.h
+++ b/src/quantization/product_quantization/product_quantizer.h
@@ -22,6 +22,26 @@
 
 namespace vsag {
 
+/***
+ * @brief Product Quantizer divides vectors into subspaces and quantizes each subspace.
+ *
+ * code layout:
+ * +------+------+------+------+
+ * | sub0 | sub1 | ...  | subN |
+ * | [1B] | [1B] |      | [1B] |
+ * +------+------+------+------+
+ *
+ * query layout (lookup table):
+ * +------------------+------------------+          +------------------+
+ * | lut[0][0..255]   | lut[1][0..255]   |   ...    | lut[N][0..255]   |
+ * | [256 floats]     | [256 floats]     |          | [256 floats]     |
+ * +------------------+------------------+          +------------------+
+ *
+ * - pq-code: 1 byte per subspace, index into codebook (required)
+ * - pq_dim: number of subspaces
+ * - Each subspace has 256 centroids (2^8 = 256 possible indices)
+ * - Lookup table: precomputed distances for query to all centroids
+ */
 template <MetricType metric = MetricType::METRIC_TYPE_L2SQR>
 class ProductQuantizer : public Quantizer<ProductQuantizer<metric>> {
 public:

--- a/src/quantization/scalar_quantization/bf16_quantizer.h
+++ b/src/quantization/scalar_quantization/bf16_quantizer.h
@@ -22,6 +22,19 @@
 
 namespace vsag {
 
+/***
+ * @brief BF16 Quantizer stores vectors in 16-bit bfloat16 floating-point format.
+ *
+ * code layout:
+ * +------------------------+
+ * | bf16-code              |
+ * | [dim * 2B]             |
+ * +------------------------+
+ *
+ * - bf16-code: bfloat16 (Brain Float) values (required)
+ * - 1 sign bit, 8 exponent bits, 7 mantissa bits
+ * - Same exponent range as FP32, less precision
+ */
 template <MetricType metric = MetricType::METRIC_TYPE_L2SQR>
 class BF16Quantizer : public Quantizer<BF16Quantizer<metric>> {
 public:

--- a/src/quantization/scalar_quantization/fp16_quantizer.h
+++ b/src/quantization/scalar_quantization/fp16_quantizer.h
@@ -22,6 +22,18 @@
 
 namespace vsag {
 
+/***
+ * @brief FP16 Quantizer stores vectors in 16-bit half-precision floating-point format.
+ *
+ * code layout:
+ * +------------------------+
+ * | fp16-code              |
+ * | [dim * 2B]             |
+ * +------------------------+
+ *
+ * - fp16-code: IEEE 754 half-precision floats (required)
+ * - 1 sign bit, 5 exponent bits, 10 mantissa bits
+ */
 template <MetricType metric = MetricType::METRIC_TYPE_L2SQR>
 class FP16Quantizer : public Quantizer<FP16Quantizer<metric>> {
 public:

--- a/src/quantization/scalar_quantization/scalar_quantizer.h
+++ b/src/quantization/scalar_quantization/scalar_quantizer.h
@@ -22,6 +22,25 @@
 
 namespace vsag {
 
+/***
+ * @brief Scalar Quantizer stores vectors in 4-bit or 8-bit quantized format.
+ *
+ * code layout (SQ8):
+ * +------------------------+
+ * | sq8-code               |
+ * | [dim * 1B]             |
+ * +------------------------+
+ *
+ * code layout (SQ4):
+ * +------------------------+
+ * | sq4-code               |
+ * | [dim * 0.5B, packed]   |
+ * +------------------------+
+ *
+ * - sq-code: quantized values per dimension (required)
+ * - SQ8: 8 bits per dimension, range [0, 255]
+ * - SQ4: 4 bits per dimension, packed 2 values per byte, range [0, 15]
+ */
 template <MetricType metric = MetricType::METRIC_TYPE_L2SQR, int bit = 8>
 class ScalarQuantizer : public Quantizer<ScalarQuantizer<metric, bit>> {
 public:

--- a/src/quantization/sparse_quantization/sparse_quantizer.h
+++ b/src/quantization/sparse_quantization/sparse_quantizer.h
@@ -29,6 +29,21 @@ struct BufferEntry {
     float val;
 };
 
+/***
+ * @brief Sparse Quantizer stores sparse vectors with only non-zero elements.
+ *
+ * code layout:
+ * +----------+------------------+------------------+-----+------------------+
+ * | len      | entry[0]         | entry[1]         | ... | entry[len-1]     |
+ * | [4B]     | id[4B] + val[4B] | id[4B] + val[4B] |     | id[4B] + val[4B] |
+ * +----------+------------------+------------------+-----+------------------+
+ *
+ * - len: number of non-zero elements (uint32)
+ * - entry[i]: sorted by id in ascending order
+ *   - id: dimension index (uint32)
+ *   - val: value at this dimension (float)
+ * - Only supports METRIC_TYPE_IP (inner product)
+ */
 template <MetricType metric = MetricType::METRIC_TYPE_IP>
 class SparseQuantizer : public Quantizer<SparseQuantizer<metric>> {
 public:

--- a/src/quantization/transform_quantization/transform_quantizer.h
+++ b/src/quantization/transform_quantization/transform_quantizer.h
@@ -26,6 +26,26 @@
 
 namespace vsag {
 
+/***
+ * @brief Transform Quantizer applies transformation chain before base quantization.
+ *
+ * code layout:
+ * +----------------+----------+----------+-----+----------+
+ * | base-code      | meta[0]  | meta[1]  | ... | meta[N]  |
+ * | [aligned size] | [var]    | [var]    |     | [var]    |
+ * +----------------+----------+----------+-----+----------+
+ *
+ * query layout:
+ * +----------------+----------+----------+-----+----------+
+ * | base-code      | meta[0]  | meta[1]  | ... | meta[N]  |
+ * | [aligned size] | [var]    | [var]    |     | [var]    |
+ * +----------------+----------+----------+-----+----------+
+ *
+ * - base-code: quantized code from inner quantizer (aligned)
+ * - meta[i]: metadata from i-th transformer in chain
+ * - Transformers: PCA, FHT, ROM, MRLE
+ * - Distance is recovered through chain of transformers
+ */
 template <typename QuantTmpl, MetricType metric = MetricType::METRIC_TYPE_L2SQR>
 class TransformQuantizer : public Quantizer<TransformQuantizer<QuantTmpl, metric>> {
 public:


### PR DESCRIPTION
## Summary
Add layout diagram comments for all quantizer types in `src/quantization/` directory. Each quantizer now has ASCII art diagrams showing the memory layout of code and query data structures.

## Changes
- **FP32Quantizer**: Add layout diagram showing float32-code + mold (optional for cosine)
- **INT8Quantizer**: Add layout diagram showing int8-code + mold (optional for cosine)
- **ScalarQuantizer**: Add layout diagrams for SQ4 and SQ8 formats
- **FP16Quantizer**: Add layout diagram showing fp16-code storage
- **BF16Quantizer**: Add layout diagram showing bf16-code storage
- **ProductQuantizer**: Add code and query (lookup table) layout diagrams
- **PQFastScanQuantizer**: Add packed 4-bit layout diagrams for fast scan
- **SparseQuantizer**: Add layout diagram showing variable-length sparse entry format
- **TransformQuantizer**: Add layout diagram showing base-code + transform-metas chain

## Layout Diagram Format
Each quantizer includes:
- ASCII art diagram showing memory structure
- Field names and byte sizes
- Field descriptions (required/optional, usage)
- Query layout where applicable (lookup tables, etc.)

## Testing
- [x] Release build successful
- [x] All unit tests pass
- [x] Code style check pass
- [x] Code format check pass

## Related Issues
- Fixes #1687

## Example
```
code layout (ProductQuantizer):
+------+------+------+------+
| sub0 | sub1 | ...  | subN |
| [1B] | [1B] |      | [1B] |
+------+------+------+------+
```

## Checklist
- [x] Code follows VSAG coding style
- [x] All tests pass
- [x] PR description is clear