### PR TITLE
fix: correct GetStats unsupported error message

### DIFF
--- a/include/vsag/index.h
+++ b/include/vsag/index.h
@@ -885,7 +885,7 @@ public:
       */
     [[nodiscard]] virtual std::string
     GetStats() const {
-        throw std::runtime_error("Index not support range search");
+        throw std::runtime_error("Index not support GetStats");
     }
 
     /**

--- a/tests/test_simple_index.cpp
+++ b/tests/test_simple_index.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_exception.hpp>
 #include <fstream>
 
 #include "fixtures/fixtures.h"
@@ -116,12 +117,9 @@ TEST_CASE("Test Simple Index", "[ft][simple_index]") {
     REQUIRE_THROWS(index->EstimateMemory(1000));
     REQUIRE_THROWS(index->GetEstimateBuildMemory(1000));
     REQUIRE_THROWS(index->Feedback(dataset->query_, 10, ""));
-    try {
-        index->GetStats();
-        FAIL("Expected GetStats to throw");
-    } catch (const std::runtime_error& e) {
-        REQUIRE(std::string(e.what()) == "Index not support GetStats");
-    }
+    REQUIRE_THROWS_MATCHES(index->GetStats(),
+                           std::runtime_error,
+                           Catch::Matchers::Message("Index not support GetStats"));
     REQUIRE_THROWS(index->UpdateId(0, 1));
     REQUIRE_THROWS(index->UpdateVector(0, dataset->query_));
     REQUIRE_THROWS(index->ContinueBuild(dataset->base_, binary));

--- a/tests/test_simple_index.cpp
+++ b/tests/test_simple_index.cpp
@@ -116,7 +116,12 @@ TEST_CASE("Test Simple Index", "[ft][simple_index]") {
     REQUIRE_THROWS(index->EstimateMemory(1000));
     REQUIRE_THROWS(index->GetEstimateBuildMemory(1000));
     REQUIRE_THROWS(index->Feedback(dataset->query_, 10, ""));
-    REQUIRE_THROWS(index->GetStats());
+    try {
+        index->GetStats();
+        FAIL("Expected GetStats to throw");
+    } catch (const std::runtime_error& e) {
+        REQUIRE(std::string(e.what()) == "Index not support GetStats");
+    }
     REQUIRE_THROWS(index->UpdateId(0, 1));
     REQUIRE_THROWS(index->UpdateVector(0, dataset->query_));
     REQUIRE_THROWS(index->ContinueBuild(dataset->base_, binary));


### PR DESCRIPTION
## Summary
- Correct the default `Index::GetStats()` exception message in `include/vsag/index.h` so it reports unsupported `GetStats` instead of range search.
- Add a regression assertion in `tests/test_simple_index.cpp` to validate the thrown runtime error message.
- This avoids misleading diagnostics when callers invoke unsupported stats APIs.