### PR TITLE
fix(hgraph): serialize ignore_reorder field in ToJson()

### DIFF
--- a/src/algorithm/hgraph_parameter.cpp
+++ b/src/algorithm/hgraph_parameter.cpp
@@ -132,6 +132,7 @@ HGraphParameter::ToJson() const {
     json[TYPE_KEY].SetString(INDEX_TYPE_HGRAPH);
 
     json[HGRAPH_USE_ELP_OPTIMIZER_KEY].SetBool(this->use_elp_optimizer);
+    json[HGRAPH_IGNORE_REORDER_KEY].SetBool(this->ignore_reorder);
     json[BASE_CODES_KEY].SetJson(this->base_codes_param->ToJson());
     json[GRAPH_KEY].SetJson(this->bottom_graph_param->ToJson());
     json[EF_CONSTRUCTION_KEY].SetInt(this->ef_construction);


### PR DESCRIPTION
## Summary

Fix serialization/deserialization compatibility issue when using `ignore_reorder: true` configuration in HGraph index.

## Problem

When building a HGraph index with `ignore_reorder: true`, the serialization and deserialization process fails with:
```
HGraphParameter::CheckCompatibility: use_reorder and ignore_reorder must be the same
```

## Root Cause

The `ignore_reorder` field was not serialized in `HGraphParameter::ToJson()`, causing:
1. Serialized index has `ignore_reorder=true` in runtime but not saved in `index_param`
2. During deserialization, `ignore_reorder` defaults to `false`
3. Compatibility check fails because `have_reorder` differs

## Fix

Add `ignore_reorder` serialization in `HGraphParameter::ToJson()`:
```cpp
json[HGRAPH_IGNORE_REORDER_KEY].SetBool(this->ignore_reorder);
```

## Changes

- `src/algorithm/hgraph_parameter.cpp`: Add `ignore_reorder` field serialization

## Testing

- Verified with example program that serialization/deserialization now works correctly
- All existing HGraph tests pass, including `TestHGraphIgnoreReorder`

## Related Issues

Fixes #1710