### PR TITLE
fix(datacell): add virtual destructor to ExtraInfoInterface

### DIFF
--- a/src/datacell/extra_info_interface.h
+++ b/src/datacell/extra_info_interface.h
@@ -32,6 +32,8 @@ class ExtraInfoInterface {
 public:
     ExtraInfoInterface() = default;
 
+    virtual ~ExtraInfoInterface() = default;
+
     static ExtraInfoInterfacePtr
     MakeInstance(const ExtraInfoDataCellParamPtr& param, const IndexCommonParam& common_param);
 


### PR DESCRIPTION
## Summary

Add virtual destructor to `ExtraInfoInterface` class to ensure proper cleanup when deleting derived objects through base class pointer.

## Changes

- Add `virtual ~ExtraInfoInterface() = default;` to the interface class
- Follows C++ Core Guidelines C.35 for polymorphic base classes
- Consistent with `GraphInterface` implementation in the same module

## Testing

- Code compiles successfully with release build
- No behavioral changes, purely defensive fix

## Related Issues

Fixes #1716

## Checklist

- [x] Code follows VSAG coding style
- [x] All tests pass
- [x] PR description is clear