### PR TITLE
fix(io): correct IO type name in AsyncIOParameter JSON constructor

### DIFF
--- a/src/io/async_io_parameter.cpp
+++ b/src/io/async_io_parameter.cpp
@@ -22,8 +22,7 @@ namespace vsag {
 AsyncIOParameter::AsyncIOParameter() : IOParameter(IO_TYPE_VALUE_ASYNC_IO) {
 }
 
-AsyncIOParameter::AsyncIOParameter(const vsag::JsonType& json)
-    : IOParameter(IO_TYPE_VALUE_BUFFER_IO) {
+AsyncIOParameter::AsyncIOParameter(const vsag::JsonType& json) : AsyncIOParameter() {
     this->FromJson(json);  // NOLINT(clang-analyzer-optin.cplusplus.VirtualCall)
 }
 


### PR DESCRIPTION
## Summary

Fix incorrect IO type name in `AsyncIOParameter` JSON constructor. The constructor was using `IO_TYPE_VALUE_BUFFER_IO` instead of `IO_TYPE_VALUE_ASYNC_IO`.

## Changes

- Changed `IO_TYPE_VALUE_BUFFER_IO` to `IO_TYPE_VALUE_ASYNC_IO` in the JSON constructor of `AsyncIOParameter` at `src/io/async_io_parameter.cpp:26`

## Background

The JSON constructor was incorrectly passing `IO_TYPE_VALUE_BUFFER_IO` to the base class, while the default constructor correctly uses `IO_TYPE_VALUE_ASYNC_IO`. This was a copy-paste error that could cause:
- Type identification issues when creating `AsyncIOParameter` from JSON configuration
- Inconsistent behavior in `ToJson()` serialization/deserialization

## Testing

- All AsyncIO related unit tests pass
- Build passes with `make release`

## Related Issues

Fixes #1722

## Checklist
- [x] Code follows VSAG coding style
- [x] All tests pass
- [x] PR description is clear