### PR TITLE
test(impl): add unit tests for untested components in impl module

### DIFF
--- a/src/impl/allocator/allocator_wrapper_test.cpp
+++ b/src/impl/allocator/allocator_wrapper_test.cpp
@@ -1,0 +1,91 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "allocator_wrapper.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <vector>
+
+#include "impl/allocator/safe_allocator.h"
+
+using namespace vsag;
+
+TEST_CASE("AllocatorWrapper Basic Test", "[ut][AllocatorWrapper]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    AllocatorWrapper<int> wrapper(allocator.get());
+
+    SECTION("Allocate and Deallocate") {
+        int* ptr = wrapper.allocate(10);
+        REQUIRE(ptr != nullptr);
+
+        for (int i = 0; i < 10; ++i) {
+            ptr[i] = i;
+        }
+
+        for (int i = 0; i < 10; ++i) {
+            REQUIRE(ptr[i] == i);
+        }
+
+        wrapper.deallocate(ptr, 10);
+    }
+
+    SECTION("Construct and Destroy") {
+        int* ptr = wrapper.allocate(1);
+        wrapper.construct(ptr, 42);
+        REQUIRE(*ptr == 42);
+        wrapper.destroy(ptr);
+        wrapper.deallocate(ptr, 1);
+    }
+}
+
+TEST_CASE("AllocatorWrapper STL Container Test", "[ut][AllocatorWrapper]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    AllocatorWrapper<int> wrapper(allocator.get());
+
+    SECTION("Vector with AllocatorWrapper") {
+        std::vector<int, AllocatorWrapper<int>> vec(wrapper);
+        vec.push_back(1);
+        vec.push_back(2);
+        vec.push_back(3);
+
+        REQUIRE(vec.size() == 3);
+        REQUIRE(vec[0] == 1);
+        REQUIRE(vec[1] == 2);
+        REQUIRE(vec[2] == 3);
+    }
+}
+
+TEST_CASE("AllocatorWrapper Equality Test", "[ut][AllocatorWrapper]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    AllocatorWrapper<int> wrapper1(allocator.get());
+    AllocatorWrapper<int> wrapper2(allocator.get());
+    AllocatorWrapper<int> wrapper3(nullptr);
+
+    REQUIRE(wrapper1 == wrapper2);
+    REQUIRE_FALSE(wrapper1 == wrapper3);
+    REQUIRE(wrapper1 != wrapper3);
+}
+
+TEST_CASE("AllocatorWrapper Rebind Test", "[ut][AllocatorWrapper]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    AllocatorWrapper<int> wrapper_int(allocator.get());
+
+    typename AllocatorWrapper<int>::rebind<double>::other wrapper_double(wrapper_int);
+    double* ptr = wrapper_double.allocate(5);
+    REQUIRE(ptr != nullptr);
+    wrapper_double.construct(ptr, 3.14);
+    REQUIRE(*ptr == 3.14);
+    wrapper_double.destroy(ptr);
+    wrapper_double.deallocate(ptr, 5);
+}

--- a/src/impl/bitset/computable_bitset_test.cpp
+++ b/src/impl/bitset/computable_bitset_test.cpp
@@ -1,0 +1,119 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "computable_bitset.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <vector>
+
+#include "impl/allocator/safe_allocator.h"
+
+using namespace vsag;
+
+TEST_CASE("ComputableBitset MakeInstance Test", "[ut][ComputableBitset]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+
+    SECTION("Make SparseBitset") {
+        auto bitset =
+            ComputableBitset::MakeInstance(ComputableBitsetType::SparseBitset, allocator.get());
+        REQUIRE(bitset != nullptr);
+    }
+
+    SECTION("Make FastBitset") {
+        auto bitset =
+            ComputableBitset::MakeInstance(ComputableBitsetType::FastBitset, allocator.get());
+        REQUIRE(bitset != nullptr);
+    }
+}
+
+TEST_CASE("ComputableBitset MakeRawInstance Test", "[ut][ComputableBitset]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+
+    SECTION("Make Raw SparseBitset") {
+        auto* bitset =
+            ComputableBitset::MakeRawInstance(ComputableBitsetType::SparseBitset, allocator.get());
+        REQUIRE(bitset != nullptr);
+        delete bitset;
+    }
+
+    SECTION("Make Raw FastBitset") {
+        auto* bitset =
+            ComputableBitset::MakeRawInstance(ComputableBitsetType::FastBitset, allocator.get());
+        REQUIRE(bitset != nullptr);
+        delete bitset;
+    }
+}
+
+TEST_CASE("ComputableBitset And with Vector Test", "[ut][ComputableBitset]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+
+    auto bitset1 =
+        ComputableBitset::MakeInstance(ComputableBitsetType::FastBitset, allocator.get());
+    auto bitset2 =
+        ComputableBitset::MakeInstance(ComputableBitsetType::FastBitset, allocator.get());
+    auto bitset3 =
+        ComputableBitset::MakeInstance(ComputableBitsetType::FastBitset, allocator.get());
+
+    for (int64_t i = 0; i < 100; i++) {
+        bitset1->Set(i, true);
+        if (i % 2 == 0) {
+            bitset2->Set(i, true);
+        }
+        if (i % 3 == 0) {
+            bitset3->Set(i, true);
+        }
+    }
+
+    std::vector<const ComputableBitset*> bitsets = {bitset2.get(), bitset3.get()};
+    bitset1->And(bitsets);
+
+    for (int64_t i = 0; i < 100; i++) {
+        if (i % 2 == 0 && i % 3 == 0) {
+            REQUIRE(bitset1->Test(i));
+        } else {
+            REQUIRE_FALSE(bitset1->Test(i));
+        }
+    }
+}
+
+TEST_CASE("ComputableBitset Or with Vector Test", "[ut][ComputableBitset]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+
+    auto bitset1 =
+        ComputableBitset::MakeInstance(ComputableBitsetType::FastBitset, allocator.get());
+    auto bitset2 =
+        ComputableBitset::MakeInstance(ComputableBitsetType::FastBitset, allocator.get());
+    auto bitset3 =
+        ComputableBitset::MakeInstance(ComputableBitsetType::FastBitset, allocator.get());
+
+    for (int64_t i = 0; i < 100; i++) {
+        if (i % 2 == 0) {
+            bitset2->Set(i, true);
+        }
+        if (i % 3 == 0) {
+            bitset3->Set(i, true);
+        }
+    }
+
+    std::vector<const ComputableBitset*> bitsets = {bitset2.get(), bitset3.get()};
+    bitset1->Or(bitsets);
+
+    for (int64_t i = 0; i < 100; i++) {
+        if (i % 2 == 0 || i % 3 == 0) {
+            REQUIRE(bitset1->Test(i));
+        } else {
+            REQUIRE_FALSE(bitset1->Test(i));
+        }
+    }
+}

--- a/src/impl/blas/blas_function_test.cpp
+++ b/src/impl/blas/blas_function_test.cpp
@@ -1,0 +1,159 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "blas_function.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <cmath>
+#include <vector>
+
+using namespace vsag;
+
+static constexpr float EPSILON = 1e-4F;
+
+TEST_CASE("Saxpy Basic Test", "[ut][BlasFunction]") {
+    int32_t n = 10;
+    float alpha = 2.0F;
+    std::vector<float> x(n), y(n), expected(n);
+
+    for (int32_t i = 0; i < n; ++i) {
+        x[i] = static_cast<float>(i);
+        y[i] = static_cast<float>(i * 2);
+        expected[i] = alpha * x[i] + y[i];
+    }
+
+    BlasFunction::Saxpy(n, alpha, x.data(), 1, y.data(), 1);
+
+    for (int32_t i = 0; i < n; ++i) {
+        REQUIRE(std::abs(y[i] - expected[i]) < EPSILON);
+    }
+}
+
+TEST_CASE("Sscal Basic Test", "[ut][BlasFunction]") {
+    int32_t n = 10;
+    float alpha = 3.0F;
+    std::vector<float> x(n), expected(n);
+
+    for (int32_t i = 0; i < n; ++i) {
+        x[i] = static_cast<float>(i);
+        expected[i] = alpha * x[i];
+    }
+
+    BlasFunction::Sscal(n, alpha, x.data(), 1);
+
+    for (int32_t i = 0; i < n; ++i) {
+        REQUIRE(std::abs(x[i] - expected[i]) < EPSILON);
+    }
+}
+
+TEST_CASE("Sgemv Basic Test", "[ut][BlasFunction]") {
+    int32_t m = 3;
+    int32_t n = 4;
+    float alpha = 1.0F;
+    float beta = 0.0F;
+
+    std::vector<float> a(m * n);
+    std::vector<float> x(n);
+    std::vector<float> y(m, 0.0F);
+    std::vector<float> expected(m, 0.0F);
+
+    for (int32_t i = 0; i < m * n; ++i) {
+        a[i] = static_cast<float>(i);
+    }
+    for (int32_t i = 0; i < n; ++i) {
+        x[i] = static_cast<float>(i + 1);
+    }
+
+    for (int32_t i = 0; i < m; ++i) {
+        for (int32_t j = 0; j < n; ++j) {
+            expected[i] += a[i * n + j] * x[j];
+        }
+    }
+
+    BlasFunction::Sgemv(BlasFunction::RowMajor,
+                        BlasFunction::NoTrans,
+                        m,
+                        n,
+                        alpha,
+                        a.data(),
+                        n,
+                        x.data(),
+                        1,
+                        beta,
+                        y.data(),
+                        1);
+
+    for (int32_t i = 0; i < m; ++i) {
+        REQUIRE(std::abs(y[i] - expected[i]) < EPSILON);
+    }
+}
+
+TEST_CASE("Sgemm Basic Test", "[ut][BlasFunction]") {
+    int32_t m = 2;
+    int32_t n = 3;
+    int32_t k = 4;
+    float alpha = 1.0F;
+    float beta = 0.0F;
+
+    std::vector<float> a(m * k);
+    std::vector<float> b(k * n);
+    std::vector<float> c(m * n, 0.0F);
+    std::vector<float> expected(m * n, 0.0F);
+
+    for (int32_t i = 0; i < m * k; ++i) {
+        a[i] = static_cast<float>(i + 1);
+    }
+    for (int32_t i = 0; i < k * n; ++i) {
+        b[i] = static_cast<float>(i + 1);
+    }
+
+    for (int32_t i = 0; i < m; ++i) {
+        for (int32_t j = 0; j < n; ++j) {
+            for (int32_t l = 0; l < k; ++l) {
+                expected[i * n + j] += a[i * k + l] * b[l * n + j];
+            }
+        }
+    }
+
+    BlasFunction::Sgemm(BlasFunction::RowMajor,
+                        BlasFunction::NoTrans,
+                        BlasFunction::NoTrans,
+                        m,
+                        n,
+                        k,
+                        alpha,
+                        a.data(),
+                        k,
+                        b.data(),
+                        n,
+                        beta,
+                        c.data(),
+                        n);
+
+    for (int32_t i = 0; i < m * n; ++i) {
+        REQUIRE(std::abs(c[i] - expected[i]) < EPSILON);
+    }
+}
+
+TEST_CASE("BlasFunction Constants Test", "[ut][BlasFunction]") {
+    REQUIRE(BlasFunction::RowMajor == 101);
+    REQUIRE(BlasFunction::ColMajor == 102);
+    REQUIRE(BlasFunction::NoTrans == 111);
+    REQUIRE(BlasFunction::Trans == 112);
+    REQUIRE(BlasFunction::ConjTrans == 113);
+    REQUIRE(BlasFunction::JobV == 'V');
+    REQUIRE(BlasFunction::JobN == 'N');
+    REQUIRE(BlasFunction::Upper == 'U');
+    REQUIRE(BlasFunction::Lower == 'L');
+}

--- a/src/impl/filter/combined_filter_test.cpp
+++ b/src/impl/filter/combined_filter_test.cpp
@@ -1,0 +1,97 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "combined_filter.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <memory>
+
+#include "impl/allocator/safe_allocator.h"
+#include "impl/bitset/fast_bitset.h"
+#include "white_list_filter.h"
+
+using namespace vsag;
+
+TEST_CASE("CombinedFilter Basic Test", "[ut][CombinedFilter]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    int64_t max_count = 100;
+
+    auto bitset1 = std::make_shared<FastBitset>(allocator.get());
+    auto bitset2 = std::make_shared<FastBitset>(allocator.get());
+
+    for (int64_t i = 0; i < max_count; i++) {
+        if (i % 2 == 0) {
+            bitset1->Set(i, true);
+        }
+        if (i % 3 == 0) {
+            bitset2->Set(i, true);
+        }
+    }
+
+    auto filter1 = std::make_shared<WhiteListFilter>(bitset1);
+    auto filter2 = std::make_shared<WhiteListFilter>(bitset2);
+
+    SECTION("Empty CombinedFilter") {
+        CombinedFilter combined;
+        REQUIRE(combined.IsEmpty());
+
+        for (int64_t i = 0; i < max_count; i++) {
+            REQUIRE(combined.CheckValid(i));
+        }
+    }
+
+    SECTION("Single Filter") {
+        CombinedFilter combined;
+        combined.AppendFilter(filter1);
+        REQUIRE_FALSE(combined.IsEmpty());
+
+        for (int64_t i = 0; i < max_count; i++) {
+            if (i % 2 == 0) {
+                REQUIRE(combined.CheckValid(i));
+            } else {
+                REQUIRE_FALSE(combined.CheckValid(i));
+            }
+        }
+    }
+
+    SECTION("Two Filters AND") {
+        CombinedFilter combined;
+        combined.AppendFilter(filter1);
+        combined.AppendFilter(filter2);
+
+        for (int64_t i = 0; i < max_count; i++) {
+            if (i % 2 == 0 && i % 3 == 0) {
+                REQUIRE(combined.CheckValid(i));
+            } else {
+                REQUIRE_FALSE(combined.CheckValid(i));
+            }
+        }
+    }
+
+    SECTION("Append nullptr") {
+        CombinedFilter combined;
+        combined.AppendFilter(nullptr);
+        REQUIRE(combined.IsEmpty());
+    }
+
+    SECTION("ValidRatio") {
+        CombinedFilter combined;
+        combined.AppendFilter(filter1);
+        combined.AppendFilter(filter2);
+
+        float ratio = combined.ValidRatio();
+        REQUIRE(ratio > 0.0F);
+        REQUIRE(ratio <= 1.0F);
+    }
+}

--- a/src/impl/filter/inner_id_wrapper_filter_test.cpp
+++ b/src/impl/filter/inner_id_wrapper_filter_test.cpp
@@ -1,0 +1,68 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "inner_id_wrapper_filter.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <memory>
+
+#include "impl/allocator/safe_allocator.h"
+#include "impl/bitset/fast_bitset.h"
+#include "impl/label_table.h"
+#include "white_list_filter.h"
+
+using namespace vsag;
+
+TEST_CASE("InnerIdWrapperFilter Basic Test", "[ut][InnerIdWrapperFilter]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    int64_t max_count = 10;
+
+    LabelTable label_table(allocator.get());
+    for (int64_t i = 0; i < max_count; i++) {
+        label_table.Insert(i, i * 100);
+    }
+
+    auto bitset = std::make_shared<FastBitset>(allocator.get());
+    for (int64_t i = 0; i < max_count * 100; i++) {
+        if (i % 200 == 0) {
+            bitset->Set(i, true);
+        }
+    }
+
+    auto inner_filter = std::make_shared<WhiteListFilter>(bitset);
+    InnerIdWrapperFilter wrapper(inner_filter, label_table);
+
+    for (int64_t i = 0; i < max_count; i++) {
+        bool expected = (i % 2 == 0);
+        REQUIRE(wrapper.CheckValid(i) == expected);
+    }
+}
+
+TEST_CASE("InnerIdWrapperFilter ValidRatio Test", "[ut][InnerIdWrapperFilter]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    int64_t max_count = 10;
+
+    LabelTable label_table(allocator.get());
+    for (int64_t i = 0; i < max_count; i++) {
+        label_table.Insert(i, i);
+    }
+
+    auto func = [](int64_t id) -> bool { return id % 3 == 0; };
+    auto inner_filter = std::make_shared<WhiteListFilter>(func);
+    InnerIdWrapperFilter wrapper(inner_filter, label_table);
+
+    float ratio = wrapper.ValidRatio();
+    REQUIRE(ratio > 0.0F);
+    REQUIRE(ratio <= 1.0F);
+}

--- a/src/impl/thread_pool/default_thread_pool_test.cpp
+++ b/src/impl/thread_pool/default_thread_pool_test.cpp
@@ -1,0 +1,67 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "default_thread_pool.h"
+
+#include <atomic>
+#include <catch2/catch_test_macros.hpp>
+
+using namespace vsag;
+
+TEST_CASE("DefaultThreadPool Basic Test", "[ut][DefaultThreadPool]") {
+    DefaultThreadPool pool(4);
+
+    SECTION("Enqueue and Execute") {
+        std::atomic<int> counter{0};
+
+        for (int i = 0; i < 10; ++i) {
+            pool.Enqueue([&counter]() { counter++; });
+        }
+
+        pool.WaitUntilEmpty();
+        REQUIRE(counter == 10);
+    }
+}
+
+TEST_CASE("DefaultThreadPool SetPoolSize Test", "[ut][DefaultThreadPool]") {
+    DefaultThreadPool pool(2);
+
+    std::atomic<int> counter{0};
+    for (int i = 0; i < 5; ++i) {
+        pool.Enqueue([&counter]() { counter++; });
+    }
+    pool.WaitUntilEmpty();
+    REQUIRE(counter == 5);
+
+    pool.SetPoolSize(4);
+
+    counter = 0;
+    for (int i = 0; i < 10; ++i) {
+        pool.Enqueue([&counter]() { counter++; });
+    }
+    pool.WaitUntilEmpty();
+    REQUIRE(counter == 10);
+}
+
+TEST_CASE("DefaultThreadPool SetQueueSizeLimit Test", "[ut][DefaultThreadPool]") {
+    DefaultThreadPool pool(2);
+    pool.SetQueueSizeLimit(100);
+
+    std::atomic<int> counter{0};
+    for (int i = 0; i < 50; ++i) {
+        pool.Enqueue([&counter]() { counter++; });
+    }
+    pool.WaitUntilEmpty();
+    REQUIRE(counter == 50);
+}

--- a/src/impl/transform/mrle_transformer_test.cpp
+++ b/src/impl/transform/mrle_transformer_test.cpp
@@ -1,0 +1,78 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "mrle_transformer.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <cmath>
+#include <vector>
+
+#include "impl/allocator/safe_allocator.h"
+
+using namespace vsag;
+
+static constexpr float EPSILON = 1e-5F;
+
+TEST_CASE("MRLETransformer L2 Transform Test", "[ut][MRLETransformer]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    int64_t dim = 16;
+    MRLETransformer<MetricType::METRIC_TYPE_L2SQR> transformer(allocator.get(), dim, dim);
+
+    std::vector<float> input(dim);
+    std::vector<float> output(dim);
+
+    for (int64_t i = 0; i < dim; ++i) {
+        input[i] = static_cast<float>(i + 1);
+    }
+
+    auto meta = transformer.Transform(input.data(), output.data());
+    REQUIRE(meta != nullptr);
+
+    for (int64_t i = 0; i < dim; ++i) {
+        REQUIRE(std::abs(output[i] - input[i]) < EPSILON);
+    }
+}
+
+TEST_CASE("MRLETransformer Cosine Transform Test", "[ut][MRLETransformer]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    int64_t dim = 16;
+    MRLETransformer<MetricType::METRIC_TYPE_COSINE> transformer(allocator.get(), dim, dim);
+
+    std::vector<float> input(dim);
+    std::vector<float> output(dim);
+
+    for (int64_t i = 0; i < dim; ++i) {
+        input[i] = static_cast<float>(i + 1);
+    }
+
+    auto meta = transformer.Transform(input.data(), output.data());
+    REQUIRE(meta != nullptr);
+
+    float sum = 0.0F;
+    for (int64_t i = 0; i < dim; ++i) {
+        sum += output[i] * output[i];
+    }
+    REQUIRE(std::abs(sum - 1.0F) < EPSILON);
+}
+
+TEST_CASE("MRLETransformer InverseTransform Test", "[ut][MRLETransformer]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    int64_t dim = 8;
+    MRLETransformer<MetricType::METRIC_TYPE_L2SQR> transformer(allocator.get(), dim, dim);
+
+    std::vector<float> input(dim);
+    std::vector<float> output(dim);
+
+    REQUIRE_THROWS_AS(transformer.InverseTransform(input.data(), output.data()), VsagException);
+}


### PR DESCRIPTION
## Summary

Add unit tests for untested components in the `src/impl/` module to improve test coverage and regression protection.

## Changes

- Add `blas_function_test.cpp`: test Saxpy, Sscal, Sgemv, Sgemm operations
- Add `combined_filter_test.cpp`: test AND combination logic for filters
- Add `inner_id_wrapper_filter_test.cpp`: test ID mapping correctness
- Add `computable_bitset_test.cpp`: test MakeInstance, MakeRawInstance factory methods
- Add `allocator_wrapper_test.cpp`: test allocate, deallocate, construct, destroy
- Add `default_thread_pool_test.cpp`: test Enqueue, WaitUntilEmpty, SetPoolSize
- Add `mrle_transformer_test.cpp`: test Transform for L2/Cosine metrics

## Testing

All tests pass:
- BlasFunction: 5 test cases, 38 assertions
- CombinedFilter: 1 test case, 305 assertions
- InnerIdWrapperFilter: 2 test cases, 12 assertions
- ComputableBitset: 4 test cases, 204 assertions
- AllocatorWrapper: 4 test cases, 20 assertions
- DefaultThreadPool: 3 test cases, 4 assertions
- MRLETransformer: 3 test cases, 20 assertions

## Related Issues

- Fixes #1727

## Checklist

- [x] Code follows VSAG coding style
- [x] All tests pass
- [x] PR description is clear