### PR TITLE
perf(label_table): add TryGetIdByLabel to avoid exception overhead

### DIFF
--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -918,9 +918,10 @@ HGraph::CalDistanceById(const float* query,
     {
         std::shared_lock<std::shared_mutex> lock(this->label_lookup_mutex_);
         for (int64_t i = 0; i < count; ++i) {
-            try {
-                inner_ids[i] = this->label_table_->GetIdByLabel(ids[i]);
-            } catch (std::runtime_error& e) {
+            auto [success, inner_id] = this->label_table_->TryGetIdByLabel(ids[i]);
+            if (success) {
+                inner_ids[i] = inner_id;
+            } else {
                 logger::debug(fmt::format("failed to find id: {}", ids[i]));
                 invalid_id_loc.push_back(i);
             }

--- a/src/label_table.h
+++ b/src/label_table.h
@@ -79,19 +79,28 @@ public:
         return true;
     }
 
-    inline InnerIdType
-    GetIdByLabel(LabelType label) const {
+    inline std::pair<bool, InnerIdType>
+    TryGetIdByLabel(LabelType label) const noexcept {
         if (use_reverse_map_) {
             if (this->label_remap_.count(label) == 0) {
-                throw std::runtime_error(fmt::format("label {} is not exists", label));
+                return {false, 0};
             }
-            return this->label_remap_.at(label);
+            return {true, this->label_remap_.at(label)};
         }
         auto result = std::find(label_table_.begin(), label_table_.end(), label);
         if (result == label_table_.end()) {
+            return {false, 0};
+        }
+        return {true, static_cast<InnerIdType>(result - label_table_.begin())};
+    }
+
+    inline InnerIdType
+    GetIdByLabel(LabelType label) const {
+        auto [success, inner_id] = TryGetIdByLabel(label);
+        if (not success) {
             throw std::runtime_error(fmt::format("label {} is not exists", label));
         }
-        return result - label_table_.begin();
+        return inner_id;
     }
 
     inline bool


### PR DESCRIPTION
## Summary
- Cherry-pick of PR #1701 to 0.16 branch
- Add `TryGetIdByLabel` method to avoid exception overhead when checking label existence
- Refactored `GetIdByLabel` to use `TryGetIdByLabel` internally

## Changes
The 0.16 branch has a different `LabelTable` structure compared to main, so the changes were adapted accordingly:
- Added `TryGetIdByLabel` method that returns `std::pair<bool, InnerIdType>` instead of throwing exceptions
- The method is `noexcept` to avoid exception handling overhead
- `GetIdByLabel` now delegates to `TryGetIdByLabel` for code reuse

Original PR: #1701