### PR TITLE
refactor(inner_index): change ErrorType to NO_ENOUGH_MEMORY for bad_alloc

### DIFF
--- a/src/algorithm/inner_index_interface.cpp
+++ b/src/algorithm/inner_index_interface.cpp
@@ -208,7 +208,7 @@ InnerIndexInterface::Deserialize(const ReaderSet& reader_set) {
         this->SetIO(index_reader);
         return;
     } catch (const std::bad_alloc& e) {
-        throw VsagException(ErrorType::READ_ERROR, "failed to Deserialize: ", e.what());
+        throw VsagException(ErrorType::NO_ENOUGH_MEMORY, "failed to Deserialize: ", e.what());
     }
 }
 

--- a/src/quantization/scalar_quantization/fp16_quantizer.cpp
+++ b/src/quantization/scalar_quantization/fp16_quantizer.cpp
@@ -115,7 +115,7 @@ FP16Quantizer<metric>::ProcessQueryImpl(const DataType* query,
         this->EncodeOneImpl(query, computer.buf_);
     } catch (std::bad_alloc& e) {
         throw VsagException(
-            ErrorType::INTERNAL_ERROR, "bad alloc when init computer buf", e.what());
+            ErrorType::NO_ENOUGH_MEMORY, "bad alloc when init computer buf", e.what());
     }
 }
 


### PR DESCRIPTION
## Summary
Cherry-pick of PR #1558 to 0.16 branch.

### Changes
- Change `READ_ERROR` to `NO_ENOUGH_MEMORY` in `InnerIndexInterface::Deserialize` methods when catching `std::bad_alloc`
- Change `INTERNAL_ERROR` to `NO_ENOUGH_MEMORY` in `FP16Quantizer::ProcessQueryImpl`

### Note
The thread pool creation logic changes from PR #1558 are already present in 0.16 branch:
- `hgraph.cpp` (line 96-99): already checks `build_thread_count_ > 1` before creating default thread pool
- `ivf.cpp` (line 235-238): already checks `thread_count > 1` before creating default thread pool
- `brute_force.cpp`: the `SearchWithRequest` parallel search code does not exist in 0.16 branch

Original PR: #1558