### PR TITLE
feat(hgraph): add reverse edge support for HGraph index

### DIFF
--- a/include/vsag/constants.h
+++ b/include/vsag/constants.h
@@ -163,6 +163,7 @@ extern const char* const HGRAPH_REMOVE_FLAG_BIT;
 // hgraph params
 extern const char* const HGRAPH_USE_REORDER;
 extern const char* const HGRAPH_USE_ELP_OPTIMIZER;
+extern const char* const HGRAPH_USE_REVERSE_EDGES;
 extern const char* const HGRAPH_IGNORE_REORDER;
 extern const char* const HGRAPH_BUILD_BY_BASE_QUANTIZATION;
 extern const char* const HGRAPH_BASE_QUANTIZATION_TYPE;

--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -67,7 +67,8 @@ HGraph::HGraph(const HGraphParameterPtr& hgraph_param, const vsag::IndexCommonPa
       odescent_param_(hgraph_param->odescent_param),
       graph_type_(hgraph_param->graph_type),
       hierarchical_datacell_param_(hgraph_param->hierarchical_graph_param),
-      use_old_serial_format_(common_param.use_old_serial_format_) {
+      use_old_serial_format_(common_param.use_old_serial_format_),
+      use_reverse_edges_(hgraph_param->use_reverse_edges) {
     this->label_table_->compress_duplicate_data_ = hgraph_param->support_duplicate;
     this->label_table_->support_tombstone_ = hgraph_param->support_tombstone;
     neighbors_mutex_ = std::make_shared<PointsMutex>(0, common_param.allocator_.get());
@@ -98,6 +99,10 @@ HGraph::HGraph(const HGraphParameterPtr& hgraph_param, const vsag::IndexCommonPa
     }
     check_and_init_raw_vector(hgraph_param->raw_vector_param, common_param);
     resize(bottom_graph_->max_capacity_);
+
+    if (use_reverse_edges_) {
+        reverse_edges_ = std::make_unique<ReverseEdge>(this->allocator_);
+    }
 }
 void
 HGraph::Train(const DatasetPtr& base) {
@@ -146,6 +151,12 @@ HGraph::map_hgraph_param(const JsonType& hgraph_json) {
             HGRAPH_USE_ELP_OPTIMIZER,
             {
                 HGRAPH_USE_ELP_OPTIMIZER_KEY,
+            },
+        },
+        {
+            HGRAPH_USE_REVERSE_EDGES,
+            {
+                HGRAPH_USE_REVERSE_EDGES_KEY,
             },
         },
         {
@@ -1451,6 +1462,10 @@ HGraph::Deserialize(StreamReader& reader) {
     }
     this->cal_memory_usage();
 
+    if (use_reverse_edges_ && reverse_edges_) {
+        this->rebuild_reverse_edges();
+    }
+
     // post serialize procedure
     if (use_elp_optimizer_) {
         elp_optimize();
@@ -1613,7 +1628,8 @@ HGraph::graph_add_one(const void* data, int level, InnerIdType inner_id) {
                                      flatten_codes,
                                      neighbors_mutex_,
                                      allocator_,
-                                     alpha_);
+                                     alpha_,
+                                     reverse_edges_.get());
     } else {
         LockGuard cur_lock(neighbors_mutex_, inner_id);
         bottom_graph_->InsertNeighborsById(inner_id, Vector<InnerIdType>(allocator_));
@@ -1643,7 +1659,8 @@ HGraph::graph_add_one(const void* data, int level, InnerIdType inner_id) {
                                          flatten_codes,
                                          neighbors_mutex_,
                                          allocator_,
-                                         alpha_);
+                                         alpha_,
+                                         nullptr);
         } else {
             LockGuard cur_lock(neighbors_mutex_, inner_id);
             route_graphs_[j]->InsertNeighborsById(inner_id, Vector<InnerIdType>(allocator_));
@@ -2439,8 +2456,28 @@ HGraph::cal_memory_usage() {
         memory += raw_vector_->GetMemoryUsage();
     }
 
+    if (reverse_edges_) {
+        memory += reverse_edges_->GetMemoryUsage();
+    }
+
     std::unique_lock lock(this->memory_usage_mutex_);
     this->current_memory_usage_.store(static_cast<int64_t>(memory));
+}
+
+void
+HGraph::rebuild_reverse_edges() {
+    if (!reverse_edges_) {
+        return;
+    }
+    reverse_edges_->Clear();
+    auto total_count = this->total_count_.load();
+    for (InnerIdType id = 0; id < total_count; ++id) {
+        Vector<InnerIdType> neighbors(allocator_);
+        this->bottom_graph_->GetNeighbors(id, neighbors);
+        for (const auto& neighbor : neighbors) {
+            reverse_edges_->AddReverseEdge(id, neighbor);
+        }
+    }
 }
 
 }  // namespace vsag

--- a/src/algorithm/hgraph.h
+++ b/src/algorithm/hgraph.h
@@ -35,6 +35,7 @@
 #include "index_common_param.h"
 #include "index_feature_list.h"
 #include "inner_index_interface.h"
+#include "reverse_edge.h"
 #include "typing.h"
 #include "utils/lock_strategy.h"
 #include "utils/util_functions.h"
@@ -354,6 +355,9 @@ private:
     void
     cal_memory_usage();
 
+    void
+    rebuild_reverse_edges();
+
 private:
     FlattenInterfacePtr basic_flatten_codes_{nullptr};
     FlattenInterfacePtr high_precise_codes_{nullptr};
@@ -361,6 +365,9 @@ private:
     Vector<GraphInterfacePtr> route_graphs_;
     GraphInterfacePtr bottom_graph_{nullptr};
     SparseGraphDatacellParamPtr hierarchical_datacell_param_{nullptr};
+
+    std::unique_ptr<ReverseEdge> reverse_edges_{nullptr};
+    bool use_reverse_edges_{false};
 
     bool use_elp_optimizer_{false};
     bool ignore_reorder_{false};

--- a/src/algorithm/hgraph_parameter.cpp
+++ b/src/algorithm/hgraph_parameter.cpp
@@ -50,6 +50,10 @@ HGraphParameter::FromJson(const JsonType& json) {
         this->build_by_base = json[HGRAPH_BUILD_BY_BASE_QUANTIZATION_KEY].GetBool();
     }
 
+    if (json.Contains(HGRAPH_USE_REVERSE_EDGES_KEY)) {
+        this->use_reverse_edges = json[HGRAPH_USE_REVERSE_EDGES_KEY].GetBool();
+    }
+
     CHECK_ARGUMENT(json.Contains(BASE_CODES_KEY),
                    fmt::format("hgraph parameters must contains {}", BASE_CODES_KEY));
     const auto& base_codes_json = json[BASE_CODES_KEY];
@@ -133,6 +137,7 @@ HGraphParameter::ToJson() const {
 
     json[HGRAPH_USE_ELP_OPTIMIZER_KEY].SetBool(this->use_elp_optimizer);
     json[HGRAPH_IGNORE_REORDER_KEY].SetBool(this->ignore_reorder);
+    json[HGRAPH_USE_REVERSE_EDGES_KEY].SetBool(this->use_reverse_edges);
     json[BASE_CODES_KEY].SetJson(this->base_codes_param->ToJson());
     json[GRAPH_KEY].SetJson(this->bottom_graph_param->ToJson());
     json[EF_CONSTRUCTION_KEY].SetInt(this->ef_construction);
@@ -178,6 +183,10 @@ HGraphParameter::CheckCompatibility(const ParamPtr& other) const {
     }
     if (support_duplicate != hgraph_param->support_duplicate) {
         logger::error("HGraphParameter::CheckCompatibility: support_duplicate must be the same");
+        return false;
+    }
+    if (use_reverse_edges != hgraph_param->use_reverse_edges) {
+        logger::error("HGraphParameter::CheckCompatibility: use_reverse_edges must be the same");
         return false;
     }
     return true;

--- a/src/algorithm/hgraph_parameter.h
+++ b/src/algorithm/hgraph_parameter.h
@@ -58,6 +58,7 @@ public:
     bool use_elp_optimizer{false};
     bool ignore_reorder{false};
     bool build_by_base{false};
+    bool use_reverse_edges{false};
 
     uint64_t ef_construction{400};
     float alpha{1.0F};

--- a/src/algorithm/pyramid.cpp
+++ b/src/algorithm/pyramid.cpp
@@ -786,7 +786,7 @@ Pyramid::add_one_point(IndexNode* node, InnerIdType inner_id, const float* vecto
             return;
         }
         mutually_connect_new_element(
-            inner_id, results, node->graph_, codes, points_mutex_, allocator_, alpha_);
+            inner_id, results, node->graph_, codes, points_mutex_, allocator_, alpha_, nullptr);
         if (update_entry_point) {
             node->entry_point_ = inner_id;
         }

--- a/src/algorithm/reverse_edge.h
+++ b/src/algorithm/reverse_edge.h
@@ -1,0 +1,115 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mutex>
+#include <shared_mutex>
+
+#include "typing.h"
+#include "vsag/allocator.h"
+
+namespace vsag {
+
+class ReverseEdge {
+public:
+    explicit ReverseEdge(Allocator* allocator) : allocator_(allocator), reverse_edges_(allocator) {
+    }
+
+    void
+    AddReverseEdge(InnerIdType from, InnerIdType to) {
+        std::unique_lock<std::shared_mutex> wlock(mutex_);
+        auto [it, inserted] =
+            reverse_edges_.emplace(to, std::make_unique<Vector<InnerIdType>>(allocator_));
+        auto& incoming = it->second;
+        for (const auto& id : *incoming) {
+            if (id == from) {
+                return;
+            }
+        }
+        incoming->push_back(from);
+    }
+
+    void
+    RemoveReverseEdge(InnerIdType from, InnerIdType to) {
+        std::unique_lock<std::shared_mutex> wlock(mutex_);
+        auto it = reverse_edges_.find(to);
+        if (it == reverse_edges_.end()) {
+            return;
+        }
+        auto& incoming = it->second;
+        for (auto iter = incoming->begin(); iter != incoming->end(); ++iter) {
+            if (*iter == from) {
+                incoming->erase(iter);
+                return;
+            }
+        }
+    }
+
+    void
+    GetIncomingNeighbors(InnerIdType id, Vector<InnerIdType>& neighbors) const {
+        std::shared_lock<std::shared_mutex> rlock(mutex_);
+        auto it = reverse_edges_.find(id);
+        if (it == reverse_edges_.end()) {
+            neighbors.clear();
+            return;
+        }
+        neighbors.assign(it->second->begin(), it->second->end());
+    }
+
+    void
+    ClearIncomingNeighbors(InnerIdType id) {
+        std::unique_lock<std::shared_mutex> wlock(mutex_);
+        auto it = reverse_edges_.find(id);
+        if (it != reverse_edges_.end()) {
+            it->second->clear();
+        }
+    }
+
+    void
+    Clear() {
+        std::unique_lock<std::shared_mutex> wlock(mutex_);
+        reverse_edges_.clear();
+    }
+
+    // Resize is intentionally a no-op because ReverseEdge uses a sparse hash map
+    // keyed by target node ID. Pre-allocating capacity for specific node IDs
+    // wouldn't provide meaningful benefits, as the underlying hash map handles
+    // its own memory allocation dynamically.
+    void
+    Resize(InnerIdType /*new_size*/) {
+    }
+
+    int64_t
+    GetMemoryUsage() const {
+        std::shared_lock<std::shared_mutex> rlock(mutex_);
+        int64_t usage = sizeof(ReverseEdge);
+        for (const auto& [id, neighbors] : reverse_edges_) {
+            usage += sizeof(id);
+            usage += sizeof(std::unique_ptr<Vector<InnerIdType>>);
+            if (neighbors) {
+                usage += sizeof(*neighbors);
+                usage += neighbors->capacity() * sizeof(InnerIdType);
+            }
+        }
+        return usage;
+    }
+
+private:
+    Allocator* const allocator_;
+    UnorderedMap<InnerIdType, std::unique_ptr<Vector<InnerIdType>>> reverse_edges_;
+    mutable std::shared_mutex mutex_{};
+};
+
+}  // namespace vsag

--- a/src/algorithm/reverse_edge_test.cpp
+++ b/src/algorithm/reverse_edge_test.cpp
@@ -1,0 +1,200 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "algorithm/reverse_edge.h"
+
+#include <algorithm>
+#include <catch2/catch_test_macros.hpp>
+#include <thread>
+#include <vector>
+
+#include "impl/allocator/safe_allocator.h"
+
+namespace vsag {
+
+TEST_CASE("ReverseEdge Basic Operations", "[ut][ReverseEdge]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    ReverseEdge reverse_edge(allocator.get());
+
+    SECTION("Add and Get Reverse Edge") {
+        reverse_edge.AddReverseEdge(1, 2);
+        reverse_edge.AddReverseEdge(3, 2);
+
+        Vector<InnerIdType> neighbors(allocator.get());
+        reverse_edge.GetIncomingNeighbors(2, neighbors);
+
+        REQUIRE(neighbors.size() == 2);
+        REQUIRE(std::find(neighbors.begin(), neighbors.end(), 1) != neighbors.end());
+        REQUIRE(std::find(neighbors.begin(), neighbors.end(), 3) != neighbors.end());
+    }
+
+    SECTION("Duplicate Add Should Be Idempotent") {
+        reverse_edge.AddReverseEdge(1, 2);
+        reverse_edge.AddReverseEdge(1, 2);
+        reverse_edge.AddReverseEdge(1, 2);
+
+        Vector<InnerIdType> neighbors(allocator.get());
+        reverse_edge.GetIncomingNeighbors(2, neighbors);
+
+        REQUIRE(neighbors.size() == 1);
+        REQUIRE(neighbors[0] == 1);
+    }
+
+    SECTION("Remove Reverse Edge") {
+        reverse_edge.AddReverseEdge(1, 2);
+        reverse_edge.AddReverseEdge(3, 2);
+
+        reverse_edge.RemoveReverseEdge(1, 2);
+
+        Vector<InnerIdType> neighbors(allocator.get());
+        reverse_edge.GetIncomingNeighbors(2, neighbors);
+
+        REQUIRE(neighbors.size() == 1);
+        REQUIRE(neighbors[0] == 3);
+    }
+
+    SECTION("Remove Non-Existent Edge Should Not Crash") {
+        reverse_edge.AddReverseEdge(1, 2);
+        reverse_edge.RemoveReverseEdge(3, 2);
+        reverse_edge.RemoveReverseEdge(1, 3);
+
+        Vector<InnerIdType> neighbors(allocator.get());
+        reverse_edge.GetIncomingNeighbors(2, neighbors);
+
+        REQUIRE(neighbors.size() == 1);
+        REQUIRE(neighbors[0] == 1);
+    }
+
+    SECTION("Get Incoming Neighbors for Non-Existent Node") {
+        Vector<InnerIdType> neighbors(allocator.get());
+        reverse_edge.GetIncomingNeighbors(999, neighbors);
+
+        REQUIRE(neighbors.empty());
+    }
+
+    SECTION("Clear Incoming Neighbors") {
+        reverse_edge.AddReverseEdge(1, 2);
+        reverse_edge.AddReverseEdge(3, 2);
+        reverse_edge.AddReverseEdge(4, 5);
+
+        reverse_edge.ClearIncomingNeighbors(2);
+
+        Vector<InnerIdType> neighbors(allocator.get());
+        reverse_edge.GetIncomingNeighbors(2, neighbors);
+        REQUIRE(neighbors.empty());
+
+        reverse_edge.GetIncomingNeighbors(5, neighbors);
+        REQUIRE(neighbors.size() == 1);
+        REQUIRE(neighbors[0] == 4);
+    }
+
+    SECTION("Clear All") {
+        reverse_edge.AddReverseEdge(1, 2);
+        reverse_edge.AddReverseEdge(3, 2);
+        reverse_edge.AddReverseEdge(4, 5);
+
+        reverse_edge.Clear();
+
+        Vector<InnerIdType> neighbors(allocator.get());
+        reverse_edge.GetIncomingNeighbors(2, neighbors);
+        REQUIRE(neighbors.empty());
+
+        reverse_edge.GetIncomingNeighbors(5, neighbors);
+        REQUIRE(neighbors.empty());
+    }
+
+    SECTION("Multiple Edges") {
+        reverse_edge.AddReverseEdge(1, 2);
+        reverse_edge.AddReverseEdge(3, 2);
+        reverse_edge.AddReverseEdge(5, 2);
+
+        reverse_edge.AddReverseEdge(1, 4);
+        reverse_edge.AddReverseEdge(3, 4);
+
+        Vector<InnerIdType> neighbors_2(allocator.get());
+        reverse_edge.GetIncomingNeighbors(2, neighbors_2);
+        REQUIRE(neighbors_2.size() == 3);
+
+        Vector<InnerIdType> neighbors_4(allocator.get());
+        reverse_edge.GetIncomingNeighbors(4, neighbors_4);
+        REQUIRE(neighbors_4.size() == 2);
+
+        reverse_edge.RemoveReverseEdge(1, 2);
+        reverse_edge.GetIncomingNeighbors(2, neighbors_2);
+        REQUIRE(neighbors_2.size() == 2);
+    }
+
+    SECTION("Get Memory Usage") {
+        reverse_edge.AddReverseEdge(1, 2);
+        reverse_edge.AddReverseEdge(3, 2);
+
+        int64_t usage = reverse_edge.GetMemoryUsage();
+        REQUIRE(usage > 0);
+        REQUIRE(usage > sizeof(ReverseEdge));
+    }
+}
+
+TEST_CASE("ReverseEdge Thread Safety", "[ut][ReverseEdge]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    ReverseEdge reverse_edge(allocator.get());
+
+    const int num_threads = 4;
+    const int num_iterations = 100;
+
+    SECTION("Concurrent Add and Get") {
+        std::vector<std::thread> threads;
+
+        for (int t = 0; t < num_threads; ++t) {
+            threads.emplace_back([&reverse_edge, t, num_iterations]() {
+                for (int i = 0; i < num_iterations; ++i) {
+                    reverse_edge.AddReverseEdge(t * num_iterations + i, 0);
+                }
+            });
+        }
+
+        for (auto& thread : threads) {
+            thread.join();
+        }
+
+        Vector<InnerIdType> neighbors(allocator.get());
+        reverse_edge.GetIncomingNeighbors(0, neighbors);
+        REQUIRE(neighbors.size() == static_cast<size_t>(num_threads * num_iterations));
+    }
+
+    SECTION("Concurrent Add and Remove") {
+        std::vector<std::thread> threads;
+
+        for (int t = 0; t < num_threads; ++t) {
+            threads.emplace_back([&reverse_edge, t, num_iterations]() {
+                for (int i = 0; i < num_iterations; ++i) {
+                    int id = t * num_iterations + i;
+                    reverse_edge.AddReverseEdge(id, 0);
+                    if (i % 2 == 0) {
+                        reverse_edge.RemoveReverseEdge(id, 0);
+                    }
+                }
+            });
+        }
+
+        for (auto& thread : threads) {
+            thread.join();
+        }
+
+        Vector<InnerIdType> neighbors(allocator.get());
+        reverse_edge.GetIncomingNeighbors(0, neighbors);
+        REQUIRE(neighbors.size() <= static_cast<size_t>(num_threads * num_iterations));
+    }
+}
+
+}  // namespace vsag

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -143,6 +143,7 @@ const char* const HGRAPH_SUPPORT_REMOVE = "support_remove";
 const char* const HGRAPH_REMOVE_FLAG_BIT = "remove_flag_bit";
 const char* const HGRAPH_USE_REORDER = USE_REORDER_KEY;
 const char* const HGRAPH_USE_ELP_OPTIMIZER = HGRAPH_USE_ELP_OPTIMIZER_KEY;
+const char* const HGRAPH_USE_REVERSE_EDGES = HGRAPH_USE_REVERSE_EDGES_KEY;
 const char* const HGRAPH_IGNORE_REORDER = "ignore_reorder";
 const char* const HGRAPH_BUILD_BY_BASE_QUANTIZATION = "build_by_base";
 const char* const HGRAPH_BASE_QUANTIZATION_TYPE = "base_quantization_type";

--- a/src/impl/pruning_strategy.cpp
+++ b/src/impl/pruning_strategy.cpp
@@ -15,6 +15,7 @@
 
 #include "pruning_strategy.h"
 
+#include "algorithm/reverse_edge.h"
 #include "datacell/flatten_datacell.h"
 #include "datacell/graph_interface.h"
 #include "impl/heap/standard_heap.h"
@@ -71,7 +72,8 @@ mutually_connect_new_element(InnerIdType cur_c,
                              const FlattenInterfacePtr& flatten,
                              const MutexArrayPtr& neighbors_mutexes,
                              Allocator* allocator,
-                             float alpha) {
+                             float alpha,
+                             ReverseEdge* reverse_edges) {
     const uint64_t max_size = graph->MaximumDegree();
     select_edges_by_heuristic(top_candidates, max_size, flatten, allocator, alpha);
     if (top_candidates->Size() > max_size) {
@@ -130,9 +132,71 @@ mutually_connect_new_element(InnerIdType cur_c,
                 cand_neighbors.emplace_back(candidates->Top().second);
                 candidates->Pop();
             }
+
             graph->InsertNeighborsById(selected_neighbor, cand_neighbors);
         }
     }
+
+    // Update reverse edges after releasing node locks to avoid deadlock
+    if (reverse_edges != nullptr) {
+        for (auto selected_neighbor : selected_neighbors) {
+            if (selected_neighbor == cur_c) {
+                continue;
+            }
+
+            Vector<InnerIdType> neighbors(allocator);
+            graph->GetNeighbors(selected_neighbor, neighbors);
+
+            uint64_t sz_link_list_other = neighbors.size();
+            uint64_t max_size = graph->MaximumDegree();
+
+            if (sz_link_list_other < max_size) {
+                reverse_edges->AddReverseEdge(cur_c, selected_neighbor);
+                reverse_edges->AddReverseEdge(selected_neighbor, cur_c);
+            } else {
+                // For pruning case, compute the new neighbor set
+                float d_max = flatten->ComputePairVectors(cur_c, selected_neighbor);
+
+                auto candidates = std::make_shared<StandardHeap<true, false>>(allocator, -1);
+                candidates->Push(d_max, cur_c);
+
+                for (uint64_t j = 0; j < sz_link_list_other; j++) {
+                    candidates->Push(flatten->ComputePairVectors(neighbors[j], selected_neighbor),
+                                     neighbors[j]);
+                }
+
+                select_edges_by_heuristic(candidates, max_size, flatten, allocator, alpha);
+
+                Vector<InnerIdType> cand_neighbors(allocator);
+                while (not candidates->Empty()) {
+                    cand_neighbors.emplace_back(candidates->Top().second);
+                    candidates->Pop();
+                }
+
+                reverse_edges->AddReverseEdge(cur_c, selected_neighbor);
+
+                UnorderedSet<InnerIdType> old_neighbor_set(allocator);
+                UnorderedSet<InnerIdType> new_neighbor_set(allocator);
+                for (const auto& n : neighbors) {
+                    old_neighbor_set.insert(n);
+                }
+                for (const auto& n : cand_neighbors) {
+                    new_neighbor_set.insert(n);
+                }
+                for (const auto& new_neighbor : cand_neighbors) {
+                    if (old_neighbor_set.find(new_neighbor) == old_neighbor_set.end()) {
+                        reverse_edges->AddReverseEdge(selected_neighbor, new_neighbor);
+                    }
+                }
+                for (const auto& old_neighbor : neighbors) {
+                    if (new_neighbor_set.find(old_neighbor) == new_neighbor_set.end()) {
+                        reverse_edges->RemoveReverseEdge(selected_neighbor, old_neighbor);
+                    }
+                }
+            }
+        }
+    }
+
     return next_closest_entry_point;
 }
 

--- a/src/impl/pruning_strategy.h
+++ b/src/impl/pruning_strategy.h
@@ -19,6 +19,9 @@
 #include "utils/pointer_define.h"
 
 namespace vsag {
+
+class ReverseEdge;
+
 DEFINE_POINTER2(DistHeap, DistanceHeap);
 DEFINE_POINTER(FlattenInterface);
 DEFINE_POINTER(GraphInterface);
@@ -38,6 +41,7 @@ mutually_connect_new_element(InnerIdType cur_c,
                              const FlattenInterfacePtr& flatten,
                              const MutexArrayPtr& neighbors_mutexes,
                              Allocator* allocator,
-                             float alpha = 1.0F);
+                             float alpha = 1.0F,
+                             ReverseEdge* reverse_edges = nullptr);
 
 }  // namespace vsag

--- a/src/impl/pruning_strategy_test.cpp
+++ b/src/impl/pruning_strategy_test.cpp
@@ -185,8 +185,8 @@ TEST_CASE("Pruning Strategy Select Edges With Heuristic", "[ut][pruning_strategy
 
         auto mutexes = std::make_shared<EmptyMutex>();
         MutexArrayPtr mutex_array = std::make_shared<EmptyMutex>();
-        auto entry_point =
-            mutually_connect_new_element(0, candidates, graph, flatten, mutexes, allocator.get());
+        auto entry_point = mutually_connect_new_element(
+            0, candidates, graph, flatten, mutexes, allocator.get(), 1.0F, nullptr);
 
         REQUIRE(entry_point == 1);
 

--- a/src/inner_string_params.h
+++ b/src/inner_string_params.h
@@ -45,6 +45,7 @@ const char* const ATTR_PARAMS_KEY = "attr_params";
 const char* const HGRAPH_USE_ELP_OPTIMIZER_KEY = "use_elp_optimizer";
 const char* const HGRAPH_IGNORE_REORDER_KEY = "ignore_reorder";
 const char* const HGRAPH_BUILD_BY_BASE_QUANTIZATION_KEY = "build_by_base";
+const char* const HGRAPH_USE_REVERSE_EDGES_KEY = "use_reverse_edges";
 const char* const GRAPH_KEY = "graph";
 const char* const ALPHA_KEY = "alpha";
 

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -2449,3 +2449,92 @@ TEST_CASE("(Daily) HGraph Hops Limit", "[ft][hgraph][daily]") {
     auto resource = test_index->GetResource(false);
     TestHGraphHopsLimit(test_index, resource);
 }
+
+static void
+TestHGraphReverseEdges(const fixtures::HGraphTestIndexPtr& test_index,
+                       const fixtures::HGraphResourcePtr& resource) {
+    using namespace fixtures;
+    auto search_param = fmt::format(search_param_tmp, 100, false);
+
+    for (auto metric_type : resource->metric_types) {
+        for (auto dim : resource->dims) {
+            for (auto& [base_quantization_str, recall] : resource->test_cases) {
+                INFO(fmt::format("metric_type: {}, dim: {}, base_quantization_str: {}",
+                                 metric_type,
+                                 dim,
+                                 base_quantization_str));
+
+                if (HGraphTestIndex::IsRaBitQ(base_quantization_str) &&
+                    dim < fixtures::RABITQ_MIN_RACALL_DIM) {
+                    dim = fixtures::RABITQ_MIN_RACALL_DIM;
+                }
+
+                HGraphTestIndex::HGraphBuildParam build_param(
+                    metric_type, dim, base_quantization_str);
+                build_param.thread_count = 1;
+                auto param = HGraphTestIndex::GenerateHGraphBuildParametersString(build_param);
+
+                SECTION("Build with use_reverse_edges enabled") {
+                    auto param_with_reverse = param;
+                    uint64_t pos =
+                        static_cast<uint64_t>(param_with_reverse.find("\"index_param\": {{"));
+                    if (pos != static_cast<uint64_t>(std::string::npos)) {
+                        param_with_reverse.insert(static_cast<size_t>(pos) + 17,
+                                                  "\"use_reverse_edges\": true, ");
+                    }
+
+                    auto index = TestIndex::TestFactory(test_index->name, param_with_reverse, true);
+                    auto dataset = HGraphTestIndex::pool.GetDatasetAndCreate(
+                        dim, resource->base_count, metric_type);
+
+                    TestIndex::TestBuildIndex(index, dataset, true);
+                    TestIndex::TestKnnSearch(index, dataset, search_param, recall, true);
+                }
+
+                SECTION("Serialize and Deserialize with reverse edges") {
+                    auto param_with_reverse = param;
+                    uint64_t pos =
+                        static_cast<uint64_t>(param_with_reverse.find("\"index_param\": {{"));
+                    if (pos != static_cast<uint64_t>(std::string::npos)) {
+                        param_with_reverse.insert(static_cast<size_t>(pos) + 17,
+                                                  "\"use_reverse_edges\": true, ");
+                    }
+
+                    auto index = TestIndex::TestFactory(test_index->name, param_with_reverse, true);
+                    auto dataset = HGraphTestIndex::pool.GetDatasetAndCreate(
+                        dim, resource->base_count, metric_type);
+
+                    TestIndex::TestBuildIndex(index, dataset, true);
+
+                    fixtures::TempDir dir("hgraph_reverse_edge");
+                    std::string path = dir.GenerateRandomFile();
+
+                    std::ofstream out_file(path, std::ios::binary);
+                    index->Serialize(out_file);
+                    out_file.close();
+
+                    std::ifstream in_file(path, std::ios::binary);
+                    auto deserialized_index =
+                        TestIndex::TestFactory(test_index->name, param_with_reverse, true);
+                    deserialized_index->Deserialize(in_file);
+                    in_file.close();
+
+                    TestIndex::TestKnnSearch(
+                        deserialized_index, dataset, search_param, recall, true);
+                }
+            }
+        }
+    }
+}
+
+TEST_CASE("(PR) HGraph Reverse Edges", "[ft][hgraph][pr]") {
+    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
+    auto resource = test_index->GetResource(true);
+    TestHGraphReverseEdges(test_index, resource);
+}
+
+TEST_CASE("(Daily) HGraph Reverse Edges", "[ft][hgraph][daily]") {
+    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
+    auto resource = test_index->GetResource(false);
+    TestHGraphReverseEdges(test_index, resource);
+}


### PR DESCRIPTION
## Summary
Add reverse edge tracking capability to the HGraph index, enabling O(1) lookup of incoming neighbors for each node.

## Changes
- Add `ReverseEdge` class for tracking incoming neighbors with thread-safe operations
- Add `use_reverse_edges` parameter to `HGraphParameter` (default: false)
- Integrate reverse edge updates in `mutually_connect_new_element`
- Support serialize/deserialize for reverse edges
- Update `pyramid.cpp` and `pruning_strategy` for new interface

## Files Changed
- `src/algorithm/reverse_edge.h` (new)
- `src/algorithm/hgraph.h`
- `src/algorithm/hgraph.cpp`
- `src/algorithm/hgraph_parameter.h`
- `src/algorithm/hgraph_parameter.cpp`
- `src/algorithm/pyramid.cpp`
- `src/impl/pruning_strategy.h`
- `src/impl/pruning_strategy.cpp`
- `src/impl/pruning_strategy_test.cpp`
- `src/inner_string_params.h`

## Testing
- All unit tests pass (299 test cases)
- Build succeeds without errors
- Code formatted with `make fmt`

## Related Issues
- Fixes #1746

## Notes
- Default: disabled (`use_reverse_edges=false`)
- Memory overhead: ~2x edge storage when enabled
- Use case: graph analysis, node deletion optimization, bidirectional search