### PR TITLE
fix(diskann): normalize data for COSINE metric in PQ quantization (cherry-pick to 0.18)

### DIFF
--- a/extern/diskann/DiskANN/include/pq.h
+++ b/extern/diskann/DiskANN/include/pq.h
@@ -155,7 +155,7 @@ int generate_pq_data_from_pivots(std::stringstream &base_reader, uint32_t num_ce
 template <typename T>
 int generate_pq_data_from_pivots(const T* data, size_t num_points, size_t dim, const std::vector<size_t>& skip_locs, uint32_t num_centers, uint32_t num_pq_chunks,
                                  std::stringstream &pq_pivots_stream, std::stringstream &compressed_file_writer,
-                                 bool use_opq = false, std::shared_ptr<float[]> rotmat_tr = nullptr, bool use_bsa = false);
+                                 bool use_opq = false, std::shared_ptr<float[]> rotmat_tr = nullptr, bool use_bsa = false, bool should_normalize = false);
 
 template <typename T>
 void generate_disk_quantized_data(const std::string &data_file_to_use, const std::string &disk_pq_pivots_path,

--- a/extern/diskann/DiskANN/src/pq.cpp
+++ b/extern/diskann/DiskANN/src/pq.cpp
@@ -1700,7 +1700,7 @@ int generate_pq_data_from_pivots(std::stringstream &base_reader, uint32_t num_ce
 template <typename T>
 int generate_pq_data_from_pivots(const T* data, size_t num_points, size_t dim, const std::vector<size_t>& skip_locs, uint32_t num_centers, uint32_t num_pq_chunks,
                                  std::stringstream &pq_pivots_stream, std::stringstream &compressed_file_writer,
-                                 bool use_opq, std::shared_ptr<float[]> rotmat_tr, bool use_bsa)
+                                 bool use_opq, std::shared_ptr<float[]> rotmat_tr, bool use_bsa, bool should_normalize)
 {
     size_t read_blk_size = 64 * 1024 * 1024;
     std::unique_ptr<float[]> full_pivot_data;
@@ -1756,6 +1756,9 @@ int generate_pq_data_from_pivots(const T* data, size_t num_points, size_t dim, c
             {
                 block_data_tmp[p * dim + d] -= centroid[d];
                 block_data_float[p * dim + d] = block_data_tmp[p * dim + d];
+            }
+            if (should_normalize) {
+                normalize(block_data_float.get() + p * dim, dim);
             }
         }
 
@@ -1940,13 +1943,13 @@ void generate_disk_quantized_data(const T* train_data, size_t train_size, size_t
         generate_pq_pivots((const float*)sample_data, sample_size, (uint32_t)train_dim, 256, (uint32_t)disk_pq_dims, NUM_KMEANS_REPS_PQ,
                            disk_pq_pivots, false);
     }
-
+    bool should_normalize = (compare_metric == diskann::Metric::COSINE);
     if (compare_metric == diskann::Metric::INNER_PRODUCT)
         generate_pq_data_from_pivots<float>((const float*)train_data, train_size, train_dim, skip_locs, 256, (uint32_t)disk_pq_dims, disk_pq_pivots,
-                                            disk_pq_compressed_vectors, use_opq, rotate, use_bsa);
+                                            disk_pq_compressed_vectors, use_opq, rotate, use_bsa, should_normalize);
     else
         generate_pq_data_from_pivots<T>(train_data, train_size, train_dim, skip_locs, 256, (uint32_t)disk_pq_dims, disk_pq_pivots,
-                                        disk_pq_compressed_vectors, use_opq, rotate, use_bsa);
+                                        disk_pq_compressed_vectors, use_opq, rotate, use_bsa, should_normalize);
 }
 
 
@@ -2022,15 +2025,15 @@ template DISKANN_DLLEXPORT int generate_pq_data_from_pivots<float>(std::stringst
 
 template DISKANN_DLLEXPORT int generate_pq_data_from_pivots<float>(const float* data, size_t num_points, size_t dim, const std::vector<size_t>& skip_locs, uint32_t num_centers, uint32_t num_pq_chunks,
                                                                    std::stringstream &pq_pivots_stream, std::stringstream &compressed_file_writer,
-                                                                   bool use_opq, std::shared_ptr<float[]> rotmat_tr, bool use_bsa = false);
+                                                                   bool use_opq, std::shared_ptr<float[]> rotmat_tr, bool use_bsa = false, bool should_normalize = false);
 
 template DISKANN_DLLEXPORT int generate_pq_data_from_pivots<uint8_t>(const uint8_t* data, size_t num_points, size_t dim, const std::vector<size_t>& skip_locs, uint32_t num_centers, uint32_t num_pq_chunks,
                                                             std::stringstream &pq_pivots_stream, std::stringstream &compressed_file_writer,
-                                                            bool use_opq, std::shared_ptr<float[]> rotmat_tr, bool use_bsa = false);
+                                                            bool use_opq, std::shared_ptr<float[]> rotmat_tr, bool use_bsa = false, bool should_normalize = false);
 
 template DISKANN_DLLEXPORT int generate_pq_data_from_pivots<int8_t>(const int8_t* data, size_t num_points, size_t dim, const std::vector<size_t>& skip_locs, uint32_t num_centers, uint32_t num_pq_chunks,
                                                             std::stringstream &pq_pivots_stream, std::stringstream &compressed_file_writer,
-                                                            bool use_opq, std::shared_ptr<float[]> rotmat_tr, bool use_bsa = false);
+                                                            bool use_opq, std::shared_ptr<float[]> rotmat_tr, bool use_bsa = false, bool should_normalize = false);
 
 template DISKANN_DLLEXPORT void generate_disk_quantized_data<int8_t>(const std::string &data_file_to_use,
                                                                      const std::string &disk_pq_pivots_path,

--- a/tests/test_diskann.cpp
+++ b/tests/test_diskann.cpp
@@ -76,7 +76,7 @@ DiskANNTestIndex::GenerateDiskANNBuildParametersString(const std::string& metric
 }  // namespace fixtures
 TEST_CASE_METHOD(fixtures::DiskANNTestIndex, "diskann build test", "[ft][index][diskann]") {
     auto dims = fixtures::get_common_used_dims(3);
-    auto metric_type = GENERATE("l2", "ip");
+    auto metric_type = GENERATE("l2", "ip", "cosine");
     const std::string name = "diskann";
     for (auto dim : dims) {
         auto param = GenerateDiskANNBuildParametersString(metric_type, dim);
@@ -89,7 +89,7 @@ TEST_CASE_METHOD(fixtures::DiskANNTestIndex, "diskann build test", "[ft][index][
 
 TEST_CASE_METHOD(fixtures::DiskANNTestIndex, "diskann pq_dim test", "[ft][index][diskann]") {
     const std::vector<int> dims = {736, 1536, 2048, 2560, 3072};
-    auto metric_type = GENERATE("l2", "ip");
+    auto metric_type = GENERATE("l2", "ip", "cosine");
     const std::string name = "diskann";
     constexpr auto build_parameter_json = R"(
         {{
@@ -135,7 +135,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::DiskANNTestIndex,
                              "[ft][index][diskann]") {
     vsag::Options::Instance().logger()->SetLevel(vsag::Logger::Level::kDEBUG);
     auto dims = fixtures::get_common_used_dims(1);
-    auto metric_type = GENERATE("l2", "ip");
+    auto metric_type = GENERATE("l2", "ip", "cosine");
     auto graph_type = GENERATE("vamana", "odescent");
     const std::string name = "diskann";
 
@@ -214,7 +214,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::DiskANNTestIndex,
                              "[ft][diskann][serialization]") {
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
-    auto metric_type = GENERATE("l2", "ip");
+    auto metric_type = GENERATE("l2", "ip", "cosine");
     const std::string name = "diskann";
     auto dim = 128;
     vsag::Options::Instance().set_block_size_limit(size);


### PR DESCRIPTION
## Summary

Cherry-pick PR #1745 to 0.18 branch.

Add should_normalize parameter to generate_pq_data_from_pivots to normalize data during PQ code generation when using COSINE metric.

## Changes

- Modified extern/diskann/DiskANN/include/pq.h:
  - Added should_normalize parameter to generate_pq_data_from_pivots function

- Modified extern/diskann/DiskANN/src/pq.cpp:
  - Added should_normalize parameter to generate_pq_data_from_pivots function
  - Added normalization logic in generate_pq_data_from_pivots for COSINE metric
  - Modified generate_disk_quantized_data to pass should_normalize parameter
  - Updated template instantiations for float, uint8_t, int8_t types

- Modified tests/test_diskann.cpp:
  - Added "cosine" metric to test cases in diskann pq_dim test, build and search test, and serialization test