### PR TITLE
fix(ci): improve index upload logic to compatibility-indexes release (0.17)

### DIFF
--- a/.github/workflows/generate_old_version_index.yml
+++ b/.github/workflows/generate_old_version_index.yml
@@ -62,6 +62,55 @@ jobs:
           cd ${GITHUB_WORKSPACE}/vsag_tag
           ./build-release/tools/create_old_version_index ${{ steps.set-version.outputs.version }}
           cd ../vsag_index
+      - name: Upload Index Files
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.set-version.outputs.version }}
+        run: |
+          cd ${GITHUB_WORKSPACE}/vsag_tag
+          
+          files=()
+          for algo in hgraph hnsw; do
+            for ext in index build.json search.json; do
+              file="${VERSION}_${algo}_${ext}"
+              if [ -f "$file" ]; then
+                files+=("$file")
+              fi
+            done
+          done
+          
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "No index files found to upload"
+            exit 0
+          fi
+          
+          echo "Files to upload: ${files[*]}"
+          
+          release_error=$(gh release view compatibility-indexes --repo antgroup/vsag 2>&1)
+          if [ $? -eq 0 ]; then
+            echo "Uploading to existing release..."
+            if ! gh release upload compatibility-indexes "${files[@]}" --repo antgroup/vsag --clobber; then
+              echo "Error: Failed to upload files to release"
+              exit 1
+            fi
+          else
+            if echo "$release_error" | grep -qi "404\|not found\|notfound"; then
+              echo "Creating new release..."
+              if ! gh release create compatibility-indexes "${files[@]}" \
+                --repo antgroup/vsag \
+                --title "VSAG Compatibility Test Indexes" \
+                --notes "Index files for backward compatibility testing" \
+                --prerelease; then
+                echo "Error: Failed to create release"
+                exit 1
+              fi
+            else
+              echo "Error checking release existence: $release_error"
+              exit 1
+            fi
+          fi
+          
+          echo "Successfully uploaded ${#files[@]} file(s)"
       - name: Config Git And Push
         uses: peter-evans/create-pull-request@v7
         with:

--- a/scripts/check_compatibility.sh
+++ b/scripts/check_compatibility.sh
@@ -1,32 +1,46 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
-old_version_indexes="v0.16.2_hgraph v0.16.2_hnsw \
-                     v0.16.1_hgraph v0.16.1_hnsw \
-                     v0.16.0_hgraph v0.16.0_hnsw \
-                     v0.15.0_hgraph v0.15.0_hnsw \
-                     v0.15.1_hgraph v0.15.1_hnsw \
-                     v0.14.0_hgraph v0.14.0_hnsw \
-                     v0.14.1_hgraph v0.14.1_hnsw \
-                     v0.14.2_hgraph v0.14.2_hnsw \
-                     v0.14.8_hgraph v0.14.8_hnsw \
-                     v0.13.4_hgraph v0.13.4_hnsw \
-                     v0.13.0_hnsw \
-                     v0.12.0_hnsw \
-                     v0.11.14_hnsw \
-                     v0.10.0_hnsw"
+old_version_indexes=(
+    "v0.16.2_hgraph"
+    "v0.16.2_hnsw"
+    "v0.16.1_hgraph"
+    "v0.16.1_hnsw"
+    "v0.16.0_hgraph"
+    "v0.16.0_hnsw"
+    "v0.15.0_hgraph"
+    "v0.15.0_hnsw"
+    "v0.15.1_hgraph"
+    "v0.15.1_hnsw"
+    "v0.14.0_hgraph"
+    "v0.14.0_hnsw"
+    "v0.14.1_hgraph"
+    "v0.14.1_hnsw"
+    "v0.14.2_hgraph"
+    "v0.14.2_hnsw"
+    "v0.14.8_hgraph"
+    "v0.14.8_hnsw"
+    "v0.13.4_hgraph"
+    "v0.13.4_hnsw"
+    "v0.13.0_hnsw"
+    "v0.12.0_hnsw"
+    "v0.11.14_hnsw"
+    "v0.10.0_hnsw"
+)
+
 all_success=true
 
-for version in ${old_version_indexes}
-do
-  ./build-release/tools/check_compatibility/check_compatibility ${version}
-  if [ $? -ne 0 ]; then
-    all_success=false
-    break
-  fi
+for version in "${old_version_indexes[@]}"; do
+    echo "Checking compatibility for: $version"
+    if ! ./build-release/tools/check_compatibility/check_compatibility "$version"; then
+        echo "Error: Compatibility check failed for $version"
+        all_success=false
+        break
+    fi
 done
 
 if [ "$all_success" = true ]; then
-  exit 0
+    echo "All compatibility checks passed"
+    exit 0
 else
-  exit 1
+    exit 1
 fi


### PR DESCRIPTION
## Summary
Backport of #1708 to 0.17 branch.

Fix the issue where index file upload fails when a new tag is released. The workflow now properly checks if a release exists before attempting to upload, and creates the release with `--prerelease` flag if needed.

## Changes
- **Better release existence check**: Use `gh release view` to check if release exists, and distinguish between "not found" errors and other errors (auth/rate-limit/network issues)
- **Prerelease flag**: Add `--prerelease` when creating the release to avoid it being marked as Latest
- **Improved error handling**: Capture stderr and fail fast on non-404 errors
- **Safe shell scripting**: Use bash arrays to avoid word splitting issues in file paths
- **Updated scripts/check_compatibility.sh**: Apply similar improvements for shell script safety and error handling
- **Portable shebang**: Use `#!/usr/bin/env bash` for better cross-platform compatibility

## Related Issues
- Fixes #1707
- Backport of #1708