### PR TITLE
chore(ci): migrate compatibility indexes from git branch to GitHub Releases (0.16)

### DIFF
--- a/.github/workflows/check_compatibility.yml
+++ b/.github/workflows/check_compatibility.yml
@@ -12,15 +12,31 @@ jobs:
     name: Check Compatibility
     runs-on: ubuntu-latest
     concurrency:
-      group: compatibility-${{ github.event.pull_request.number }}
+      group: compatibility-${{ github.event.pull_request.number || github.sha }}
       cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     container:
       image: vsaglib/vsag:ci-x86
     steps:
-      - name: Prepare Data
+      - name: Install GitHub CLI
         run: |
-          git clone -b old_version_index https://github.com/antgroup/vsag.git
-          cp -r ./vsag/* /tmp/
+          (type -p wget >/dev/null || (apt update && apt-get install wget -y)) \
+          && mkdir -p -m 755 /etc/apt/keyrings \
+          && wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg | tee /etc/apt/keyrings/githubcli.gpg >/dev/null \
+          && chmod go+r /etc/apt/keyrings/githubcli.gpg \
+          && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list >/dev/null \
+          && apt update \
+          && apt install gh -y
+      - name: Download Compatibility Indexes from Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release download compatibility-indexes \
+            --repo antgroup/vsag \
+            --dir /tmp \
+            --pattern "*.index" \
+            --pattern "*.bin" \
+            --pattern "*.json" \
+            || echo "Warning: Failed to download compatibility indexes"
       - uses: actions/checkout@v4
       - name: Compile Check Compatibility Tools
         run: export CMAKE_GENERATOR="Ninja"; make release

--- a/.github/workflows/generate_old_version_index.yml
+++ b/.github/workflows/generate_old_version_index.yml
@@ -17,7 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      pull-requests: write
     container:
       image: vsaglib/vsag:ci-x86
     steps:
@@ -36,13 +35,23 @@ jobs:
           fi
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
           cd ${GITHUB_WORKSPACE}
-      - name: Fetch Index Branch
-        uses: actions/checkout@v4
-        with:
-          ref: old_version_index
-          path: vsag_index
-          fetch-tags: 'true'
-          fetch-depth: '0'
+      - name: Install GitHub CLI
+        run: |
+          (type -p wget >/dev/null || (apt update && apt-get install wget -y)) \
+          && mkdir -p -m 755 /etc/apt/keyrings \
+          && wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg | tee /etc/apt/keyrings/githubcli.gpg >/dev/null \
+          && chmod go+r /etc/apt/keyrings/githubcli.gpg \
+          && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list >/dev/null \
+          && apt update \
+          && apt install gh -y
+      - name: Download Test Dataset from Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release download compatibility-indexes \
+            --repo antgroup/vsag \
+            --pattern "random_512d_10K.bin" \
+            || echo "Test dataset not found in release, will be generated"
       - name: Fetch Tag Branch
         uses: actions/checkout@v4
         with:
@@ -54,18 +63,58 @@ jobs:
         run: |
           echo ${{ steps.set-version.outputs.version }}
           cd vsag_tag
-          cp ../vsag_index/create_old_version_index.cpp tools/
-          cat ../vsag_index/CMakeLists.txt >> tools/CMakeLists.txt
+          cp ../random_512d_10K.bin . || true
           make release
-      - name: Generate Index And Move
+      - name: Generate Index
         run: |
           cd ${GITHUB_WORKSPACE}/vsag_tag
           ./build-release/tools/create_old_version_index ${{ steps.set-version.outputs.version }}
-          cd ../vsag_index
-      - name: Config Git And Push
-        uses: peter-evans/create-pull-request@v7
-        with:
-          path: vsag_index
-          base: old_version_index
-          signoff: 'true'
-          title: 'Update tag index ${{ steps.set-version.outputs.version }}'
+      - name: Upload to Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.set-version.outputs.version }}
+        run: |
+          cd ${GITHUB_WORKSPACE}/vsag_tag
+          
+          files=()
+          for algo in hgraph hnsw; do
+            for ext in index build.json search.json; do
+              file="${VERSION}_${algo}_${ext}"
+              if [ -f "$file" ]; then
+                files+=("$file")
+              fi
+            done
+          done
+          
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "No index files found to upload"
+            exit 0
+          fi
+          
+          echo "Files to upload: ${files[*]}"
+          
+          release_error=$(gh release view compatibility-indexes --repo antgroup/vsag 2>&1)
+          if [ $? -eq 0 ]; then
+            echo "Uploading to existing release..."
+            if ! gh release upload compatibility-indexes "${files[@]}" --repo antgroup/vsag --clobber; then
+              echo "Error: Failed to upload files to release"
+              exit 1
+            fi
+          else
+            if echo "$release_error" | grep -qi "404\|not found\|notfound"; then
+              echo "Creating new release..."
+              if ! gh release create compatibility-indexes "${files[@]}" \
+                --repo antgroup/vsag \
+                --title "VSAG Compatibility Test Indexes" \
+                --notes "Index files for backward compatibility testing" \
+                --prerelease; then
+                echo "Error: Failed to create release"
+                exit 1
+              fi
+            else
+              echo "Error checking release existence: $release_error"
+              exit 1
+            fi
+          fi
+          
+          echo "Successfully uploaded ${#files[@]} file(s)"


### PR DESCRIPTION
## Summary
Backport of #1692 and #1708 to 0.16 branch.

Migrate compatibility test index files from the `old_version_index` git branch to GitHub Releases for improved CI performance and maintainability.

## Changes
- Modified `generate_old_version_index.yml` to upload indexes to Release instead of creating PR
- Modified `check_compatibility.yml` to download indexes from Release instead of git clone
- Removed git clone of `old_version_index` branch (961 MB)
- Added `gh release download/upload` commands for faster CI execution
- Add `--prerelease` flag when creating new release
- Improved shell script safety with bash arrays

## Expected Improvements
| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| CI time | 6-10 min | 3.5-6.5 min | 40-50% faster |
| Clone size | 961 MB | ~300 MB | 70% smaller |
| Repository growth | Continuous | None | Eliminated |

## Related Issues
- Fixes #1691
- Backport of #1692 and #1708