### PR TITLE
[Backport 0.18] feat(analyzer): implement duplicate detection in GetDuplicate (#1705)

### DIFF
--- a/src/analyzer/hgraph_analyzer.cpp
+++ b/src/analyzer/hgraph_analyzer.cpp
@@ -156,7 +156,63 @@ HGraphAnalyzer::GetDuplicateRatio() {
         }
         return static_cast<float>(duplicate_num) / static_cast<float>(this->total_count_);
     }
-    return 0.0F;
+
+    // Sieve method: progressively filter candidate duplicate groups
+    calculate_base_groundtruth();
+    auto codes = hgraph_->reorder_ ? hgraph_->high_precise_codes_ : hgraph_->basic_flatten_codes_;
+    constexpr float epsilon = 2e-6F;
+
+    // Initialize with all vectors as a single group
+    Vector<Vector<InnerIdType>> groups(allocator_);
+    groups.emplace_back(total_count_, allocator_);
+    std::iota(groups[0].begin(), groups[0].end(), 0);
+
+    // Process each query to sieve groups
+    for (uint64_t q = 0; q < base_sample_size_ && !groups.empty(); ++q) {
+        Vector<Vector<InnerIdType>> new_groups(allocator_);
+        auto comp = codes->FactoryComputer(base_sample_datas_.data() + q * dim_);
+
+        for (auto& group : groups) {
+            Vector<float> dists(group.size(), allocator_);
+            codes->Query(dists.data(), comp, group.data(), group.size());
+
+            Vector<std::pair<float, InnerIdType>> sorted(group.size(), allocator_);
+            for (size_t i = 0; i < group.size(); ++i) {
+                sorted[i] = {dists[i], group[i]};
+            }
+            std::sort(sorted.begin(), sorted.end());
+
+            Vector<InnerIdType> sub(allocator_);
+            sub.push_back(sorted[0].second);
+            float first_dist = sorted[0].first;
+            for (size_t i = 1; i < sorted.size(); ++i) {
+                if (sorted[i].first - first_dist <= epsilon) {
+                    sub.push_back(sorted[i].second);
+                } else {
+                    if (sub.size() > 1) {
+                        new_groups.push_back(std::move(sub));
+                    }
+                    sub.clear();
+                    sub.push_back(sorted[i].second);
+                    first_dist = sorted[i].first;
+                }
+            }
+            if (sub.size() > 1) {
+                new_groups.push_back(std::move(sub));
+            }
+        }
+        groups = std::move(new_groups);
+    }
+
+    // Count duplicates
+    uint64_t duplicate_count = 0;
+    for (const auto& group : groups) {
+        duplicate_count += group.size() - 1;
+        for (size_t i = 1; i < group.size(); ++i) {
+            is_duplicate_ids_[group[i]] = true;
+        }
+    }
+    return static_cast<float>(duplicate_count) / static_cast<float>(total_count_);
 }
 
 float
@@ -269,8 +325,6 @@ HGraphAnalyzer::calculate_groundtruth(const Vector<float>& sample_datas,
     if (not ground_truth.empty()) {
         return;
     }
-    // calculate duplicate ratio while calculating groundtruth
-    uint32_t duplicate_count = 0;
     Vector<float> distances_array(this->total_count_, allocator_);
     Vector<InnerIdType> ids_array(this->total_count_, allocator_);
     std::iota(ids_array.begin(), ids_array.end(), 0);
@@ -422,9 +476,6 @@ HGraphAnalyzer::GetStats() {
     stats["connect_components"].SetInt(components.size());
     stats["maximal_component_size"].SetInt(*std::max_element(components.begin(), components.end()));
     stats["deleted_count"].SetInt(hgraph_->delete_count_);
-    if (hgraph_->label_table_->CompressDuplicateData()) {
-        stats["duplicate_ratio"].SetFloat(GetDuplicateRatio());
-    }
     const auto& [count_in_degree, count_out_degree, avg_degree] = GetDegreeDistribution();
     stats["in_degree_distribution"].SetVector<uint32_t>(count_in_degree);
     stats["out_degree_distribution"].SetVector<uint32_t>(count_out_degree);


### PR DESCRIPTION
Backport PR #1705 to 0.18 release branch

Original PR: #1705

Add duplicate detection logic when CompressDuplicateData() is false using
a sieve method that progressively filters candidate duplicate groups:
- Initialize with all vectors as a single group
- For each sample query, compute distances and group by proximity
- Groups with identical distances across all queries are duplicates
- Uses EPSILON=2e-6f for floating-point distance comparison

Changes adapted for 0.18 branch:
- Uses duplicate_records_ structure instead of duplicate_ids_
- CalDistanceById signature remains 3 parameters (no boolean param)
- Removed duplicate duplicate_ratio entry in GetStats

Signed-off-by: jinjiabao.jjb <jinjiabao.jjb@antgroup.com>