### PR TITLE
[Backport 0.18] perf(label_table): add TryGetIdByLabel to avoid exception overhead (#1701)

### DIFF
--- a/src/algorithm/inner_index_interface.cpp
+++ b/src/algorithm/inner_index_interface.cpp
@@ -724,9 +724,10 @@ InnerIndexInterface::cal_distance_by_id(const float* query,
     {
         std::shared_lock<std::shared_mutex> lock(this->label_lookup_mutex_);
         for (int64_t i = 0; i < count; ++i) {
-            try {
-                inner_ids[i] = this->label_table_->GetIdByLabel(ids[i]);
-            } catch (VsagException& e) {
+            auto [success, inner_id] = this->label_table_->TryGetIdByLabel(ids[i]);
+            if (success) {
+                inner_ids[i] = inner_id;
+            } else {
                 logger::debug(fmt::format("failed to find id: {}", ids[i]));
                 invalid_id_loc.push_back(i);
             }

--- a/src/algorithm/sparse_index.cpp
+++ b/src/algorithm/sparse_index.cpp
@@ -268,10 +268,10 @@ SparseIndex::CalDistanceById(const DatasetPtr& query, const int64_t* ids, int64_
 
     // cal distances one by one
     for (int64_t i = 0; i < count; i++) {
-        try {
-            uint32_t inner_id = this->label_table_->GetIdByLabel(ids[i]);
+        auto [success, inner_id] = this->label_table_->TryGetIdByLabel(ids[i]);
+        if (success) {
             distances[i] = CalDistanceByIdUnsafe(sorted_ids, sorted_vals, inner_id);
-        } catch (VsagException& e) {
+        } else {
             distances[i] = -1;
         }
     }

--- a/src/impl/label_table.h
+++ b/src/impl/label_table.h
@@ -120,25 +120,32 @@ public:
 
     inline InnerIdType
     GetIdByLabel(LabelType label, bool return_even_removed = false) const {
+        auto [success, inner_id] = TryGetIdByLabel(label, return_even_removed);
+        if (not success) {
+            throw VsagException(ErrorType::INTERNAL_ERROR,
+                                fmt::format("label {} does not exist or is removed", label));
+        }
+        return inner_id;
+    }
+
+    inline std::pair<bool, InnerIdType>
+    TryGetIdByLabel(LabelType label, bool return_even_removed = false) const noexcept {
         if (use_reverse_map_ and not return_even_removed) {
-            if (this->label_remap_.count(label) == 0) {
-                throw VsagException(ErrorType::INTERNAL_ERROR,
-                                    fmt::format("label {} does not exist", label));
+            auto iter = this->label_remap_.find(label);
+            if (iter == this->label_remap_.end()) {
+                return {false, 0};
             }
-            auto id = this->label_remap_.at(label);
-            if (id != std::numeric_limits<InnerIdType>::max()) {
-                return id;
+            if (iter->second != std::numeric_limits<InnerIdType>::max()) {
+                return {true, iter->second};
             } else {
-                throw VsagException(ErrorType::INTERNAL_ERROR,
-                                    fmt::format("label {} is removed", label));
+                return {false, 0};
             }
         }
         auto result = std::find(label_table_.begin(), label_table_.end(), label);
         if (result == label_table_.end()) {
-            throw VsagException(ErrorType::INTERNAL_ERROR,
-                                fmt::format("label {} does not exist", label));
+            return {false, 0};
         }
-        return result - label_table_.begin();
+        return {true, result - label_table_.begin()};
     }
 
     inline bool


### PR DESCRIPTION
Backport PR #1701 to 0.18 release branch

Original PR: #1701

Add TryGetIdByLabel method that returns std::pair<bool, InnerIdType> instead
of throwing exceptions. This improves performance in hot paths by avoiding
the overhead of exception handling.

Changes:
- Add TryGetIdByLabel() method to LabelTable class
- Refactor GetIdByLabel() to use TryGetIdByLabel() internally
- Update cal_distance_by_id() to use TryGetIdByLabel() instead of try-catch
- Update SparseIndex::CalDistanceById() to use TryGetIdByLabel()

Note: 0.18 branch does not have label_table_test.cpp, so unit tests are not included.

Signed-off-by: jinjiabao.jjb <jinjiabao.jjb@antgroup.com>