### PR TITLE
fix: unify virtual/override keyword usage in destructors

### DIFF
--- a/src/algorithm/pyramid.h
+++ b/src/algorithm/pyramid.h
@@ -123,7 +123,7 @@ public:
     explicit Pyramid(const ParamPtr& param, const IndexCommonParam& common_param)
         : Pyramid(std::dynamic_pointer_cast<PyramidParameters>(param), common_param){};
 
-    ~Pyramid() = default;
+    ~Pyramid() override = default;
 
     std::vector<int64_t>
     Add(const DatasetPtr& base, AddMode mode = AddMode::DEFAULT) override;

--- a/src/algorithm/sindi/sindi.h
+++ b/src/algorithm/sindi/sindi.h
@@ -33,7 +33,7 @@ public:
     SINDI(const ParamPtr& param, const IndexCommonParam& common_param)
         : SINDI(std::dynamic_pointer_cast<SINDIParameter>(param), common_param){};
 
-    ~SINDI() = default;
+    ~SINDI() override = default;
 
     std::string
     GetName() const override {

--- a/src/impl/transform/mrle_transformer.h
+++ b/src/impl/transform/mrle_transformer.h
@@ -31,7 +31,7 @@ public:
         this->type_ = VectorTransformerType::MRLE;
     }
 
-    virtual ~MRLETransformer() override = default;
+    ~MRLETransformer() override = default;
 
     TransformerMetaPtr
     Transform(const float* original_vec, float* transformed_vec) const override {

--- a/src/impl/transform/random_orthogonal_transformer.h
+++ b/src/impl/transform/random_orthogonal_transformer.h
@@ -27,7 +27,7 @@ public:
                                     int64_t dim,
                                     uint64_t retries = MAX_RETRIES);
 
-    virtual ~RandomOrthogonalMatrix() override = default;
+    ~RandomOrthogonalMatrix() override = default;
 
     TransformerMetaPtr
     Transform(const float* original_vec, float* transformed_vec) const override;

--- a/src/index/diskann.h
+++ b/src/index/diskann.h
@@ -64,7 +64,7 @@ public:
 
     DiskANN(DiskannParameters& diskann_params, const IndexCommonParam& index_common_param);
 
-    ~DiskANN() = default;
+    ~DiskANN() override = default;
 
     tl::expected<std::vector<int64_t>, Error>
     Build(const DatasetPtr& base) override {

--- a/src/quantization/fp32_quantizer.h
+++ b/src/quantization/fp32_quantizer.h
@@ -43,7 +43,7 @@ public:
 
     FP32Quantizer(const QuantizerParamPtr& param, const IndexCommonParam& common_param);
 
-    ~FP32Quantizer() = default;
+    ~FP32Quantizer() override = default;
 
     bool
     TrainImpl(const DataType* data, uint64_t count);

--- a/src/quantization/int8_quantizer.h
+++ b/src/quantization/int8_quantizer.h
@@ -47,7 +47,7 @@ public:
 
     INT8Quantizer(const QuantizerParamPtr& param, const IndexCommonParam& common_param);
 
-    ~INT8Quantizer() = default;
+    ~INT8Quantizer() override = default;
 
     bool
     TrainImpl(const DataType* data, uint64_t count);


### PR DESCRIPTION
## Summary
Unify virtual/override keyword usage in destructors following C++ Core Guidelines C.128.

## Changes
- Add `override` to destructors in `DiskANN`, `FP32Quantizer`, `INT8Quantizer`, `SINDI`, `Pyramid`
- Remove redundant `virtual` keyword in `MRLETransformer`, `RandomOrthogonalMatrix`

## Files Changed
- src/index/diskann.h
- src/quantization/fp32_quantizer.h
- src/quantization/int8_quantizer.h
- src/algorithm/sindi/sindi.h
- src/algorithm/pyramid.h
- src/impl/transform/mrle_transformer.h
- src/impl/transform/random_orthogonal_transformer.h

## Testing
- Build: `make release` passed
- Tests: Functional and unit tests passed

## Checklist
- [x] Code follows VSAG coding style
- [x] All tests pass
- [x] PR description is clear