### PR TITLE
perf(label_table): add TryGetIdByLabel to avoid exception overhead

### DIFF
--- a/src/algorithm/brute_force.cpp
+++ b/src/algorithm/brute_force.cpp
@@ -181,7 +181,10 @@ float
 BruteForce::CalcDistanceById(const float* vector, int64_t id) const {
     auto computer = this->inner_codes_->FactoryComputer(vector);
     float result = 0.0F;
-    InnerIdType inner_id = this->label_table_->GetIdByLabel(id);
+    auto [success, inner_id] = this->label_table_->TryGetIdByLabel(id);
+    if (not success) {
+        throw std::runtime_error(fmt::format("label {} is not exists", id));
+    }
     this->inner_codes_->Query(&result, computer, &inner_id, 1);
     return result;
 }

--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -952,7 +952,10 @@ HGraph::CalcDistanceById(const float* query, int64_t id) const {
     auto computer = flat->FactoryComputer(query);
     {
         std::shared_lock<std::shared_mutex> lock(this->label_lookup_mutex_);
-        auto new_id = this->label_table_->GetIdByLabel(id);
+        auto [success, new_id] = this->label_table_->TryGetIdByLabel(id);
+        if (not success) {
+            throw std::runtime_error(fmt::format("label {} is not exists", id));
+        }
         flat->Query(&result, computer, &new_id, 1);
         return result;
     }
@@ -974,9 +977,10 @@ HGraph::CalDistanceById(const float* query, const int64_t* ids, int64_t count) c
     {
         std::shared_lock<std::shared_mutex> lock(this->label_lookup_mutex_);
         for (int64_t i = 0; i < count; ++i) {
-            try {
-                inner_ids[i] = this->label_table_->GetIdByLabel(ids[i]);
-            } catch (std::runtime_error& e) {
+            auto [success, inner_id] = this->label_table_->TryGetIdByLabel(ids[i]);
+            if (success) {
+                inner_ids[i] = inner_id;
+            } else {
                 logger::debug(fmt::format("failed to find id: {}", ids[i]));
                 invalid_id_loc.push_back(i);
             }

--- a/src/label_table.h
+++ b/src/label_table.h
@@ -64,17 +64,27 @@ public:
 
     inline InnerIdType
     GetIdByLabel(LabelType label) const {
+        auto [success, inner_id] = TryGetIdByLabel(label);
+        if (not success) {
+            throw std::runtime_error(fmt::format("label {} is not exists", label));
+        }
+        return inner_id;
+    }
+
+    inline std::pair<bool, InnerIdType>
+    TryGetIdByLabel(LabelType label) const noexcept {
         if (use_reverse_map_) {
-            if (this->label_remap_.count(label) == 0) {
-                throw std::runtime_error(fmt::format("label {} is not exists", label));
+            auto iter = this->label_remap_.find(label);
+            if (iter == this->label_remap_.end()) {
+                return {false, 0};
             }
-            return this->label_remap_.at(label);
+            return {true, iter->second};
         }
         auto result = std::find(label_table_.begin(), label_table_.end(), label);
         if (result == label_table_.end()) {
-            throw std::runtime_error(fmt::format("label {} is not exists", label));
+            return {false, 0};
         }
-        return result - label_table_.begin();
+        return {true, static_cast<InnerIdType>(result - label_table_.begin())};
     }
 
     inline bool

--- a/src/label_table_test.cpp
+++ b/src/label_table_test.cpp
@@ -1,0 +1,53 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "label_table.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "default_allocator.h"
+
+using namespace vsag;
+
+TEST_CASE("LabelTable TryGetIdByLabel", "[ut][LabelTable]") {
+    auto allocator = std::make_shared<DefaultAllocator>();
+
+    SECTION("reverse map lookup") {
+        LabelTable label_table(allocator.get());
+        label_table.Insert(0, 100);
+        label_table.Insert(1, 200);
+
+        auto [ok1, id1] = label_table.TryGetIdByLabel(100);
+        auto [ok2, id2] = label_table.TryGetIdByLabel(999);
+
+        REQUIRE(ok1);
+        REQUIRE(id1 == 0);
+        REQUIRE(ok2 == false);
+        REQUIRE(id2 == 0);
+    }
+
+    SECTION("linear lookup without reverse map") {
+        LabelTable label_table(allocator.get(), false);
+        label_table.Insert(0, 100);
+        label_table.Insert(1, 200);
+
+        auto [ok1, id1] = label_table.TryGetIdByLabel(200);
+        auto [ok2, id2] = label_table.TryGetIdByLabel(999);
+
+        REQUIRE(ok1);
+        REQUIRE(id1 == 1);
+        REQUIRE(ok2 == false);
+        REQUIRE(id2 == 0);
+    }
+}


### PR DESCRIPTION
## Summary
- backport the non-throwing `LabelTable::TryGetIdByLabel` helper onto `0.15`
- keep the `0.15` branch shape intact by applying only the compatible portion of `cafb34b`
- add focused unit coverage for reverse-map and linear-scan lookup paths