### PR TITLE
fix(diskann): normalize data in PQ quantization

### DIFF
--- a/extern/diskann/DiskANN/include/pq.h
+++ b/extern/diskann/DiskANN/include/pq.h
@@ -155,7 +155,8 @@ int generate_pq_data_from_pivots(std::stringstream &base_reader, uint32_t num_ce
 template <typename T>
 int generate_pq_data_from_pivots(const T* data, size_t num_points, size_t dim, const std::vector<size_t>& skip_locs, uint32_t num_centers, uint32_t num_pq_chunks,
                                  std::stringstream &pq_pivots_stream, std::stringstream &compressed_file_writer,
-                                 bool use_opq = false, std::shared_ptr<float[]> rotmat_tr = nullptr, bool use_bsa = false);
+                                 bool use_opq = false, std::shared_ptr<float[]> rotmat_tr = nullptr,
+                                 bool use_bsa = false, bool should_normalize = false);
 
 template <typename T>
 void generate_disk_quantized_data(const std::string &data_file_to_use, const std::string &disk_pq_pivots_path,

--- a/extern/diskann/DiskANN/src/pq.cpp
+++ b/extern/diskann/DiskANN/src/pq.cpp
@@ -1700,7 +1700,7 @@ int generate_pq_data_from_pivots(std::stringstream &base_reader, uint32_t num_ce
 template <typename T>
 int generate_pq_data_from_pivots(const T* data, size_t num_points, size_t dim, const std::vector<size_t>& skip_locs, uint32_t num_centers, uint32_t num_pq_chunks,
                                  std::stringstream &pq_pivots_stream, std::stringstream &compressed_file_writer,
-                                 bool use_opq, std::shared_ptr<float[]> rotmat_tr, bool use_bsa)
+                                 bool use_opq, std::shared_ptr<float[]> rotmat_tr, bool use_bsa, bool should_normalize)
 {
     size_t read_blk_size = 64 * 1024 * 1024;
     std::unique_ptr<float[]> full_pivot_data;
@@ -1756,6 +1756,9 @@ int generate_pq_data_from_pivots(const T* data, size_t num_points, size_t dim, c
             {
                 block_data_tmp[p * dim + d] -= centroid[d];
                 block_data_float[p * dim + d] = block_data_tmp[p * dim + d];
+            }
+            if (should_normalize) {
+                normalize(block_data_float.get() + p * dim, dim);
             }
         }
 
@@ -1941,12 +1944,15 @@ void generate_disk_quantized_data(const T* train_data, size_t train_size, size_t
                            disk_pq_pivots, false);
     }
 
+    bool should_normalize = (compare_metric == diskann::Metric::COSINE);
     if (compare_metric == diskann::Metric::INNER_PRODUCT)
-        generate_pq_data_from_pivots<float>((const float*)train_data, train_size, train_dim, skip_locs, 256, (uint32_t)disk_pq_dims, disk_pq_pivots,
-                                            disk_pq_compressed_vectors, use_opq, rotate, use_bsa);
+        generate_pq_data_from_pivots<float>((const float *)train_data, train_size, train_dim, skip_locs, 256,
+                                            (uint32_t)disk_pq_dims, disk_pq_pivots, disk_pq_compressed_vectors, use_opq,
+                                            rotate, use_bsa, should_normalize);
     else
-        generate_pq_data_from_pivots<T>(train_data, train_size, train_dim, skip_locs, 256, (uint32_t)disk_pq_dims, disk_pq_pivots,
-                                        disk_pq_compressed_vectors, use_opq, rotate, use_bsa);
+        generate_pq_data_from_pivots<T>(train_data, train_size, train_dim, skip_locs, 256, (uint32_t)disk_pq_dims,
+                                        disk_pq_pivots, disk_pq_compressed_vectors, use_opq, rotate, use_bsa,
+                                        should_normalize);
 }
 
 
@@ -2022,15 +2028,15 @@ template DISKANN_DLLEXPORT int generate_pq_data_from_pivots<float>(std::stringst
 
 template DISKANN_DLLEXPORT int generate_pq_data_from_pivots<float>(const float* data, size_t num_points, size_t dim, const std::vector<size_t>& skip_locs, uint32_t num_centers, uint32_t num_pq_chunks,
                                                                    std::stringstream &pq_pivots_stream, std::stringstream &compressed_file_writer,
-                                                                   bool use_opq, std::shared_ptr<float[]> rotmat_tr, bool use_bsa = false);
+                                                                   bool use_opq, std::shared_ptr<float[]> rotmat_tr, bool use_bsa = false, bool should_normalize);
 
 template DISKANN_DLLEXPORT int generate_pq_data_from_pivots<uint8_t>(const uint8_t* data, size_t num_points, size_t dim, const std::vector<size_t>& skip_locs, uint32_t num_centers, uint32_t num_pq_chunks,
                                                             std::stringstream &pq_pivots_stream, std::stringstream &compressed_file_writer,
-                                                            bool use_opq, std::shared_ptr<float[]> rotmat_tr, bool use_bsa = false);
+                                                            bool use_opq, std::shared_ptr<float[]> rotmat_tr, bool use_bsa = false, bool should_normalize);
 
 template DISKANN_DLLEXPORT int generate_pq_data_from_pivots<int8_t>(const int8_t* data, size_t num_points, size_t dim, const std::vector<size_t>& skip_locs, uint32_t num_centers, uint32_t num_pq_chunks,
                                                             std::stringstream &pq_pivots_stream, std::stringstream &compressed_file_writer,
-                                                            bool use_opq, std::shared_ptr<float[]> rotmat_tr, bool use_bsa = false);
+                                                            bool use_opq, std::shared_ptr<float[]> rotmat_tr, bool use_bsa = false, bool should_normalize);
 
 template DISKANN_DLLEXPORT void generate_disk_quantized_data<int8_t>(const std::string &data_file_to_use,
                                                                      const std::string &disk_pq_pivots_path,

--- a/extern/diskann/DiskANN/src/pq_flash_index.cpp
+++ b/extern/diskann/DiskANN/src/pq_flash_index.cpp
@@ -2238,6 +2238,10 @@ void PQFlashIndex<T, LabelT>::cal_distance_by_ids(const float *query, const int6
     {
         aligned_query_T[i] = (float) query[i];
     }
+    
+    if (metric == diskann::Metric::COSINE) {
+        normalize(aligned_query_T.get(), this->data_dim);
+    }
 
     pq_table.preprocess_query(aligned_query_T.get());
     auto pq_dists = std::shared_ptr<float[]>(new float[NUM_CENTROID * this->n_chunks]);

--- a/tests/test_diskann.cpp
+++ b/tests/test_diskann.cpp
@@ -136,7 +136,7 @@ TEST_CASE_METHOD(fixtures::DiskANNTestIndex, "diskann build test", "[ft][index][
 
 TEST_CASE_METHOD(fixtures::DiskANNTestIndex, "diskann cal distance by id", "[ft][index][diskann]") {
     auto dims = fixtures::get_common_used_dims(3);
-    auto metric_type = GENERATE("l2", "ip");
+    auto metric_type = GENERATE("l2", "ip", "cosine");
     const std::string name = "diskann";
     constexpr auto search_param_template = R"(
         {{
@@ -191,7 +191,7 @@ TEST_CASE_METHOD(fixtures::DiskANNTestIndex, "diskann cal distance by id", "[ft]
 TEST_CASE_METHOD(fixtures::DiskANNTestIndex, "diskann pq_dim test", "[ft][index][diskann]") {
     const std::vector<int> dims = {736, 1536, 2048, 2560, 3072};
     const std::vector<int> max_degrees = {16, 32, 48, 64, 96};
-    auto metric_type = GENERATE("l2", "ip");
+    auto metric_type = GENERATE("l2", "ip", "cosine");
     const std::string name = "diskann";
     constexpr auto build_parameter_json = R"(
         {{
@@ -245,7 +245,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::DiskANNTestIndex,
                              "[ft][index][diskann]") {
     vsag::Options::Instance().logger()->SetLevel(vsag::Logger::Level::kDEBUG);
     auto dims = fixtures::get_common_used_dims(1);
-    auto metric_type = GENERATE("l2", "ip");
+    auto metric_type = GENERATE("l2", "ip", "cosine");
     auto graph_type = GENERATE("vamana", "odescent");
     const std::string name = "diskann";
 
@@ -324,7 +324,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::DiskANNTestIndex,
                              "[ft][diskann][serialization]") {
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
-    auto metric_type = GENERATE("l2", "ip");
+    auto metric_type = GENERATE("l2", "ip", "cosine");
     const std::string name = "diskann";
     auto dim = 128;
     vsag::Options::Instance().set_block_size_limit(size);


### PR DESCRIPTION


- Add should_normalize parameter to generate_pq_data_from_pivots to normalize data during PQ code generation when using COSINE metric
- Normalize query vectors in cal_distance_by_ids for COSINE metric to ensure correct distance calculation against normalized base vectors
- Add cosine metric to DiskANN test cases
