### PR TITLE
fix: add INVALID_ENTRY_POINT guard to iterative KnnSearch and RangeSearch

### DIFF
--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -42,10 +42,7 @@ namespace vsag {
 
 static DatasetPtr
 make_empty_dataset_with_stats() {
-    SearchStatistics stats;
-    auto dataset_result = DatasetImpl::MakeEmptyDataset();
-    dataset_result->Statistics(stats.Dump());
-    return dataset_result;
+    return DatasetImpl::MakeEmptyDataset();
 }
 
 HGraph::HGraph(const HGraphParameterPtr& hgraph_param, const vsag::IndexCommonParam& common_param)

--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -40,6 +40,14 @@
 
 namespace vsag {
 
+static DatasetPtr
+make_empty_dataset_with_stats() {
+    SearchStatistics stats;
+    auto dataset_result = DatasetImpl::MakeEmptyDataset();
+    dataset_result->Statistics(stats.Dump());
+    return dataset_result;
+}
+
 HGraph::HGraph(const HGraphParameterPtr& hgraph_param, const vsag::IndexCommonParam& common_param)
     : InnerIndexInterface(hgraph_param, common_param),
       route_graphs_(common_param.allocator_.get()),
@@ -347,8 +355,7 @@ HGraph::KnnSearch(const DatasetPtr& query,
         auto cur_count = this->bottom_graph_->TotalCount();
 
         if (cur_count == 0) {
-            auto dataset_result = DatasetImpl::MakeEmptyDataset();
-            return dataset_result;
+            return make_empty_dataset_with_stats();
         }
         auto* new_ctx = new IteratorFilterContext();
         if (auto ret = new_ctx->init(cur_count, params.ef_search, search_allocator);
@@ -376,6 +383,9 @@ HGraph::KnnSearch(const DatasetPtr& query,
         search_param.ef = 1;
         search_param.is_inner_id_allowed = nullptr;
         search_param.search_alloc = search_allocator;
+        if (search_param.ep == INVALID_ENTRY_POINT) {
+            return make_empty_dataset_with_stats();
+        }
         if (iter_filter_ctx->IsFirstUsed()) {
             for (auto i = static_cast<int64_t>(this->route_graphs_.size() - 1); i >= 0; --i) {
                 auto result = this->search_one_graph(
@@ -541,6 +551,11 @@ HGraph::RangeSearch(const DatasetPtr& query,
     search_param.ep = this->entry_point_id_;
     search_param.topk = 1;
     search_param.ef = 1;
+
+    if (search_param.ep == INVALID_ENTRY_POINT) {
+        return make_empty_dataset_with_stats();
+    }
+
     const auto* raw_query = get_data(query);
     for (auto i = static_cast<int64_t>(this->route_graphs_.size() - 1); i >= 0; --i) {
         auto result = this->search_one_graph(
@@ -1702,8 +1717,7 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
     search_param.search_alloc = search_allocator;
 
     if (search_param.ep == INVALID_ENTRY_POINT) {
-        auto dataset_result = DatasetImpl::MakeEmptyDataset();
-        return dataset_result;
+        return make_empty_dataset_with_stats();
     }
 
     const auto* raw_query = get_data(query);


### PR DESCRIPTION
## Summary
- add a shared empty dataset helper that preserves search statistics
- guard iterative KnnSearch and RangeSearch when the entry point is invalid on empty indexes
- backport the fix from #1742 to branch 0.16

## Related
- Original PR: #1742
- Issue: #1739