### PR TITLE
perf(build): skip boost library compilation, only copy headers

### DIFF
--- a/extern/boost/boost.cmake
+++ b/extern/boost/boost.cmake
@@ -38,22 +38,12 @@ ExternalProject_Add (
         env PATH=/usr/lib/ccache:$ENV{PATH}
         ./bootstrap.sh
             --without-icu
-            --without-libraries=python,test,stacktrace,mpi,log,graph,graph_parallel
+            --without-libraries=python,test,stacktrace,mpi,log,graph,graph_parallel,math,wave,serialization,wserialization,random,regex,locale,iostreams,chrono,timer,container,exception,date_time,thread,context,contract,coroutine,fiber,filesystem,atomic,signals,program_options,type_erasure
             --prefix=${install_dir}
     BUILD_COMMAND
-        env PATH=/usr/lib/ccache:$ENV{PATH}
-        ./b2 install
-            -d0
-            -j${NUM_BUILDING_JOBS}
-            --prefix=${install_dir}
-            --disable-icu
-            include=${install_dir}/include
-            linkflags=-L${install_dir}/lib
-            "cxxflags=-fPIC ${VSAG_THIRDPARTY_CXX_FLAGS}"
-            runtime-link=static
-            link=static
-            variant=release
-            toolset=${BOOST_TOOLSET}
+        ${CMAKE_COMMAND} -E make_directory ${install_dir}/include
+    COMMAND
+        ${CMAKE_COMMAND} -E copy_directory boost ${install_dir}/include/boost
     BUILD_IN_SOURCE 1
     INSTALL_COMMAND ""
     LOG_CONFIGURE TRUE
@@ -63,15 +53,6 @@ ExternalProject_Add (
     INACTIVITY_TIMEOUT 5
     # filesize ~= 90MiB
     TIMEOUT 90
-)
-
-ExternalProject_Add_Step (${name} setup-compiler
-    DEPENDEES configure
-    DEPENDERS build
-    COMMAND
-        echo "using gcc : : ${CMAKE_CXX_COMPILER} $<SEMICOLON>"
-            > ${source_dir}/tools/build/src/user-config.jam
-    WORKING_DIRECTORY ${source_dir}
 )
 
 ExternalProject_Add_Step (${name} clean

--- a/extern/boost/boost.cmake
+++ b/extern/boost/boost.cmake
@@ -34,15 +34,7 @@ ExternalProject_Add (
     DOWNLOAD_DIR ${DOWNLOAD_DIR}
     SOURCE_DIR ${source_dir}
     CONFIGURE_COMMAND ""
-    CONFIGURE_COMMAND
-        env PATH=/usr/lib/ccache:$ENV{PATH}
-        ./bootstrap.sh
-            --without-icu
-            --without-libraries=python,test,stacktrace,mpi,log,graph,graph_parallel,math,wave,serialization,wserialization,random,regex,locale,iostreams,chrono,timer,container,exception,date_time,thread,context,contract,coroutine,fiber,filesystem,atomic,signals,program_options,type_erasure
-            --prefix=${install_dir}
     BUILD_COMMAND
-        ${CMAKE_COMMAND} -E make_directory ${install_dir}/include
-    COMMAND
         ${CMAKE_COMMAND} -E copy_directory boost ${install_dir}/include/boost
     BUILD_IN_SOURCE 1
     INSTALL_COMMAND ""

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -44,15 +44,15 @@ if (APPLE)
         "-Wl,-force_load,$<TARGET_FILE:impl_test>"
         )
 else()
-        target_link_libraries (unittests
-                        PRIVATE
-                        Catch2::Catch2 
-                        "-Wl,--whole-archive"
-                        simd_test vsag_test algorithm_test factory_test attr_test
-                        datacell_test quantizer_test storage_test io_test utils_test impl_test
-                        "-Wl,--no-whole-archive"
-                        vsag
-        )
+	target_link_libraries (unittests
+					PRIVATE
+					Catch2::Catch2
+					"-Wl,--whole-archive"
+					simd_test vsag_test algorithm_test factory_test attr_test
+					datacell_test quantizer_test storage_test io_test utils_test impl_test
+					"-Wl,--no-whole-archive"
+					vsag roaring
+	)
 endif()
 
 add_dependencies (unittests Catch2 vsag)

--- a/tools/eval/CMakeLists.txt
+++ b/tools/eval/CMakeLists.txt
@@ -56,5 +56,5 @@ target_link_libraries (eval_performance PRIVATE
     vsag_eval_common
     ${HDF5_CPP_STATIC_LIBRARY}
     ${HDF5_C_STATIC_LIBRARY}
-    z)
+    z dl)
 add_dependencies (eval_performance hdf5)


### PR DESCRIPTION
VSAG only uses boost::dynamic_bitset which is header-only. DiskANN core library uses dynamic_bitset, apps directory is not built. All boost libraries are unnecessary for compilation.

This reduces boost build time from 10-30 minutes to seconds.
