### PR TITLE
fix: make VsagException public inherit from std::exception

### DIFF
--- a/src/factory/engine.cpp
+++ b/src/factory/engine.cpp
@@ -59,11 +59,11 @@ Engine::CreateIndex(const std::string& origin_name, const std::string& parameter
     } catch (const std::bad_alloc& e) {
         LOG_ERROR_AND_RETURNS(
             ErrorType::NO_ENOUGH_MEMORY, "failed to create index(not enough memory): ", e.what());
+    } catch (const vsag::VsagException& e) {
+        LOG_ERROR_AND_RETURNS(e.error_.type, "failed to create index: " + e.error_.message);
     } catch (const std::exception& e) {
         LOG_ERROR_AND_RETURNS(
             ErrorType::UNSUPPORTED_INDEX, "failed to create index(unknown error): ", e.what());
-    } catch (const vsag::VsagException& e) {
-        LOG_ERROR_AND_RETURNS(e.error_.type, "failed to create index: " + e.error_.message);
     }
 }
 

--- a/src/vsag_exception.h
+++ b/src/vsag_exception.h
@@ -20,7 +20,7 @@
 #include "vsag/errors.h"
 
 namespace vsag {
-class VsagException : std::exception {
+class VsagException : public std::exception {
 public:
     explicit VsagException(Error& error) : error_(error){};
 


### PR DESCRIPTION
## Summary

- Fix VsagException to use public inheritance from std::exception instead of private inheritance
- This allows VsagException to be caught by `catch (std::exception& e)` handlers, following standard C++ exception handling patterns

## Problem

The class was using private inheritance (default for class):
```cpp
class VsagException : std::exception {  // private inheritance
```

This prevented catching VsagException with std::exception handler, breaking standard exception handling.

## Solution

Changed to public inheritance:
```cpp
class VsagException : public std::exception {
```

## Impact

- No breaking changes - all existing code behavior unchanged
- Adds ability to catch VsagException via std::exception handler
- Follows C++ standard practice for exception classes

Fixes #1777