### PR TITLE
fix(build): make clean targets remove hidden files in build directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ test_tsan: tsan          ## Run unit tests with ThreadSanitizer option.
 
 .PHONY: clean
 clean:                   ## Clear build/ directory.
-	rm -rf ${DEBUG_BUILD_DIR}/*
+	rm -rf ${DEBUG_BUILD_DIR} && mkdir -p ${DEBUG_BUILD_DIR}
 
 ##
 ## ================ integration ================
@@ -168,7 +168,7 @@ pyvsag-all:              ## Build wheels for all supported versions. Usage: make
 
 .PHONY: clean-release
 clean-release:           ## Clear build-release/ directory.
-	rm -rf ${RELEASE_BUILD_DIR}/*
+	rm -rf ${RELEASE_BUILD_DIR} && mkdir -p ${RELEASE_BUILD_DIR}
 
 .PHONY: install
 install:                 ## Build and install the release version of vsag.


### PR DESCRIPTION
## Summary
Fix the Makefile `clean` and `clean-release` targets to properly remove hidden files (like `.ninja_deps`, `.ninja_log`) from build directories.

## Changes
- Modified `clean` target at `Makefile:86`: change `rm -rf ${DEBUG_BUILD_DIR}/*` to `rm -rf ${DEBUG_BUILD_DIR} && mkdir -p ${DEBUG_BUILD_DIR}`
- Modified `clean-release` target at `Makefile:171`: change `rm -rf ${RELEASE_BUILD_DIR}/*` to `rm -rf ${RELEASE_BUILD_DIR} && mkdir -p ${RELEASE_BUILD_DIR}`

## Problem
Shell glob `*` does not match dotfiles by default, causing hidden files generated by Ninja (`.ninja_deps`, `.ninja_log`) to remain after `make clean`.

## Solution
Remove entire directories and recreate them as empty directories. This ensures complete cleanup without glob matching issues.

## Testing
Verified by:
1. Creating build directories with hidden files
2. Running `make clean` and `make clean-release`
3. Confirming directories are empty after clean

## Related Issues
- Fixes #1779