### PR TITLE
fix: make VsagException public inherit from std::exception

### DIFF
--- a/src/factory/engine.cpp
+++ b/src/factory/engine.cpp
@@ -158,11 +158,11 @@ Engine::CreateIndex(const std::string& origin_name, const std::string& parameter
     } catch (const std::bad_alloc& e) {
         LOG_ERROR_AND_RETURNS(
             ErrorType::NO_ENOUGH_MEMORY, "failed to create index(not enough memory): ", e.what());
+    } catch (const vsag::VsagException& e) {
+        LOG_ERROR_AND_RETURNS(e.error_.type, "failed to create index: " + e.error_.message);
     } catch (const std::exception& e) {
         LOG_ERROR_AND_RETURNS(
             ErrorType::UNSUPPORTED_INDEX, "failed to create index(unknown error): ", e.what());
-    } catch (const vsag::VsagException& e) {
-        LOG_ERROR_AND_RETURNS(e.error_.type, "failed to create index: " + e.error_.message);
     }
 }
 

--- a/src/vsag_exception.h
+++ b/src/vsag_exception.h
@@ -20,7 +20,7 @@
 #include "vsag/errors.h"
 
 namespace vsag {
-class VsagException : std::exception {
+class VsagException : public std::exception {
 public:
     explicit VsagException(Error& error) : error_(error){};
 


### PR DESCRIPTION
## Summary

Cherry-pick of PR #1776 to branch 0.18

- Fix VsagException to use public inheritance from std::exception instead of private inheritance
- Reorder catch blocks in engine.cpp to ensure VsagException is caught before std::exception
- This allows VsagException to be caught by `catch (std::exception& e)` handlers, following standard C++ exception handling patterns

## Problem

The class was using private inheritance (default for class):
```cpp
class VsagException : std::exception {  // private inheritance
```

This prevented catching VsagException with std::exception handler, breaking standard exception handling.

## Solution

Changed to public inheritance:
```cpp
class VsagException : public std::exception {
```

And reordered catch blocks to ensure derived class (VsagException) is caught before base class (std::exception).

## Changes

1. `src/vsag_exception.h`: Changed to public inheritance
2. `src/factory/engine.cpp`: Reordered catch blocks (VsagException before std::exception)

## Impact

- No breaking changes - all existing code behavior unchanged
- Adds ability to catch VsagException via std::exception handler
- Follows C++ standard practice for exception classes