### PR TITLE
perf(build): reduce diskann static library size

### DIFF
--- a/extern/diskann/diskann.cmake
+++ b/extern/diskann/diskann.cmake
@@ -36,6 +36,8 @@ target_include_directories (vsag_diskann_headers INTERFACE
 add_library (diskann STATIC ${DISKANN_SOURCES})
 target_link_libraries (diskann PUBLIC vsag_diskann_headers)
 target_compile_options (diskann PRIVATE
+    -fdata-sections
+    -ffunction-sections
     -ftree-vectorize
     -fno-builtin-malloc
     -fno-builtin-calloc
@@ -46,6 +48,10 @@ target_compile_options (diskann PRIVATE
     -funroll-loops
     -Wfatal-errors)
 target_compile_definitions (diskann PRIVATE ENABLE_CUSTOM_LOGGER=1)
+target_link_options (diskann PRIVATE -Wl,--gc-sections)
+if (CMAKE_BUILD_TYPE STREQUAL "Release")
+    target_compile_options (diskann PRIVATE -g1)
+endif ()
 if (ENABLE_ASAN)
     target_compile_options (diskann PRIVATE -Wno-pass-failed)
 endif ()


### PR DESCRIPTION
## Summary

Add compilation and linker options to reduce diskann static library size, significantly reducing the final libvsag.so distribution size.

## Changes

- Added `-fdata-sections` and `-ffunction-sections` to separate each function and data into individual sections
- Added `-Wl,--gc-sections` linker option for garbage collection of unused sections
- Added `-g1` for minimal debug info in Release build mode

## Results

| Library | Before | After | Reduction |
|---------|--------|-------|-----------|
| libdiskann.a | 181 MB | 46 MB | **-74.6%** |
| libvsag.so | 335 MB | 284 MB | **-15%** |

## Testing

- Build: `make release` - Passed
- Tests: Pending verification

## Related Issues

- Related to #1791