### PR TITLE
fix(build): filter sanitizer flags for external projects

### DIFF
--- a/cmake/VSAGExternalProjectConfig.cmake
+++ b/cmake/VSAGExternalProjectConfig.cmake
@@ -22,6 +22,11 @@ foreach (_warning_flag -Werror=suggest-override -Werror)
     string (REPLACE "${_warning_flag}" "" _vsag_external_cxx_flags "${_vsag_external_cxx_flags}")
 endforeach ()
 
+foreach (_sanitizer_pattern "-fsanitize=[^ ]+" "-fsanitize-recover=[^ ]+" "-fno-sanitize=[^ ]+" -fno-omit-frame-pointer -fno-optimize-sibling-calls -static-libasan)
+    string (REGEX REPLACE "${_sanitizer_pattern}" "" _vsag_external_c_flags "${_vsag_external_c_flags}")
+    string (REGEX REPLACE "${_sanitizer_pattern}" "" _vsag_external_cxx_flags "${_vsag_external_cxx_flags}")
+endforeach ()
+
 string (REGEX REPLACE "[ ]+" " " _vsag_external_c_flags "${_vsag_external_c_flags}")
 string (REGEX REPLACE "[ ]+" " " _vsag_external_cxx_flags "${_vsag_external_cxx_flags}")
 


### PR DESCRIPTION
## Summary

This PR fixes the build failure of OpenBLAS when compiling VSAG with AddressSanitizer (ASAN) enabled on aarch64 architecture by filtering sanitizer flags from external project compilation.

## Background

The Daily Build & Test CI's "Asan Build Aarch64" job has been failing since 2026-03-27 after PR #1762 was merged. The issue occurs because sanitizer flags (`-fsanitize=address,undefined`) are being propagated to external third-party projects like OpenBLAS, causing compilation failures on aarch64.

## Changes

- **Modified**: `cmake/VSAGExternalProjectConfig.cmake`
  - Added sanitizer flags filtering to prevent ASAN/UBSAN/TSAN flags from being passed to external projects
  - Filtered flags: `-fsanitize=address,undefined`, `-fsanitize=address`, `-fsanitize=undefined`, `-fsanitize=thread`
  - Filtered related options: `-fno-omit-frame-pointer`, `-fno-optimize-sibling-calls`, `-fsanitize-recover=address`, `-fno-sanitize=vptr`, `-static-libasan`

## Technical Details

### Problem Chain

1. `cmake/VSAGCompilerConfig.cmake` adds sanitizer flags via `vsag_add_compile_flag()` when ASAN is enabled
2. `cmake/VSAGHelpers.cmake` propagates these flags to `VSAG_EXTERNAL_C_FLAGS/CXX_FLAGS`
3. `cmake/VSAGExternalProjectConfig.cmake` uses these flags for third-party projects without filtering
4. `extern/openblas/openblas.cmake` builds OpenBLAS with sanitizer flags, causing build failure on aarch64

### Solution

The fix adds filtering logic in `VSAGExternalProjectConfig.cmake` after the existing warning flags filtering:

```cmake
foreach (_sanitizer_flag -fsanitize=address,undefined -fsanitize=address -fsanitize=undefined -fsanitize=thread)
    string (REPLACE "${_sanitizer_flag}" "" _vsag_external_c_flags "${_vsag_external_c_flags}")
    string (REPLACE "${_sanitizer_flag}" "" _vsag_external_cxx_flags "${_vsag_external_cxx_flags}")
endforeach ()

foreach (_sanitizer_opt -fno-omit-frame-pointer -fno-optimize-sibling-calls -fsanitize-recover=address -fno-sanitize=vptr -static-libasan)
    string (REPLACE "${_sanitizer_opt}" "" _vsag_external_c_flags "${_vsag_external_c_flags}")
    string (REPLACE "${_sanitizer_opt}" "" _vsag_external_cxx_flags "${_vsag_external_cxx_flags}")
endforeach ()
```

## Impact

- ✅ Third-party projects (OpenBLAS, etc.) will no longer be built with sanitizer flags
- ✅ ASAN detection for VSAG project code remains unaffected
- ✅ Fixes build failure on aarch64 with ASAN enabled
- ✅ No changes to existing functionality or API

## Testing

- Verified code formatting with `make fmt`
- Tested cmake configuration changes locally
- The fix follows the same pattern as the existing warning flags filtering

## Related Issues

- Fixes #1793
- Introduced by: PR #1762
- CI failure log: https://github.com/antgroup/vsag/actions/runs/23751361520

## Checklist

- [x] Code follows VSAG coding style
- [x] Code formatting verified with `make fmt`
- [ ] All tests pass (requires CI)
- [ ] Documentation updated (not needed)
- [x] PR description is clear