### PR TITLE
fix: narrowing conversion warnings

### DIFF
--- a/examples/cpp/101_index_hnsw.cpp
+++ b/examples/cpp/101_index_hnsw.cpp
@@ -27,7 +27,7 @@ main(int argc, char** argv) {
 
     std::mt19937 rng;
     rng.seed(47);
-    std::uniform_real_distribution<> distrib_real;
+    std::uniform_real_distribution<float> distrib_real;
     for (int64_t i = 0; i < num_vectors; ++i) {
         ids[i] = i;
     }

--- a/examples/cpp/102_index_diskann.cpp
+++ b/examples/cpp/102_index_diskann.cpp
@@ -30,7 +30,7 @@ main(int argc, char** argv) {
 
     std::mt19937 rng;
     rng.seed(47);
-    std::uniform_real_distribution<> distrib_real;
+    std::uniform_real_distribution<float> distrib_real;
     for (int64_t i = 0; i < num_vectors; ++i) {
         ids[i] = i;
     }

--- a/examples/cpp/104_index_fresh_hnsw.cpp
+++ b/examples/cpp/104_index_fresh_hnsw.cpp
@@ -27,7 +27,7 @@ main(int argc, char** argv) {
 
     std::mt19937 rng;
     rng.seed(47);
-    std::uniform_real_distribution<> distrib_real;
+    std::uniform_real_distribution<float> distrib_real;
     for (int64_t i = 0; i < num_vectors; ++i) {
         ids[i] = i;
     }

--- a/examples/cpp/107_index_pyramid.cpp
+++ b/examples/cpp/107_index_pyramid.cpp
@@ -66,7 +66,7 @@ main(int argc, char** argv) {
 
     std::mt19937 rng;
     rng.seed(47);
-    std::uniform_real_distribution<> distrib_real;
+    std::uniform_real_distribution<float> distrib_real;
     for (int64_t i = 0; i < num_vectors; ++i) {
         ids[i] = i;
     }

--- a/examples/cpp/201_custom_allocator.cpp
+++ b/examples/cpp/201_custom_allocator.cpp
@@ -91,7 +91,7 @@ main() {
 
     std::mt19937 rng;
     rng.seed(47);
-    std::uniform_real_distribution<> distrib_real;
+    std::uniform_real_distribution<float> distrib_real;
     for (int64_t i = 0; i < num_vectors; ++i) {
         ids[i] = i;
     }

--- a/examples/cpp/203_custom_thread_pool.cpp
+++ b/examples/cpp/203_custom_thread_pool.cpp
@@ -41,7 +41,7 @@ main() {
 
     std::mt19937 rng;
     rng.seed(47);
-    std::uniform_real_distribution<> distrib_real;
+    std::uniform_real_distribution<float> distrib_real;
     for (int64_t i = 0; i < num_vectors; ++i) {
         ids[i] = i;
     }

--- a/examples/cpp/302_feature_range_search.cpp
+++ b/examples/cpp/302_feature_range_search.cpp
@@ -27,7 +27,7 @@ main(int argc, char** argv) {
 
     std::mt19937 rng;
     rng.seed(47);
-    std::uniform_real_distribution<> distrib_real;
+    std::uniform_real_distribution<float> distrib_real;
     for (int64_t i = 0; i < num_vectors; ++i) {
         ids[i] = i;
     }

--- a/examples/cpp/304_feature_enhance_graph.cpp
+++ b/examples/cpp/304_feature_enhance_graph.cpp
@@ -31,7 +31,7 @@ main(int argc, char** argv) {
     std::shared_ptr<float[]> base_data(new float[dim * base_elements]);
     std::mt19937 rng;
     rng.seed(47);
-    std::uniform_real_distribution<> distribution_real(-1, 1);
+    std::uniform_real_distribution<float> distribution_real(-1, 1);
     for (int i = 0; i < base_elements; i++) {
         base_ids[i] = i;
 

--- a/examples/cpp/309_feature_clone.cpp
+++ b/examples/cpp/309_feature_clone.cpp
@@ -27,7 +27,7 @@ main(int argc, char** argv) {
 
     std::mt19937 rng;
     rng.seed(47);
-    std::uniform_real_distribution<> distrib_real;
+    std::uniform_real_distribution<float> distrib_real;
     for (int64_t i = 0; i < num_vectors; ++i) {
         ids[i] = i;
     }

--- a/examples/cpp/310_feature_export_model.cpp
+++ b/examples/cpp/310_feature_export_model.cpp
@@ -27,7 +27,7 @@ main(int argc, char** argv) {
 
     std::mt19937 rng;
     rng.seed(47);
-    std::uniform_real_distribution<> distrib_real;
+    std::uniform_real_distribution<float> distrib_real;
     for (int64_t i = 0; i < num_vectors; ++i) {
         ids[i] = i;
     }

--- a/examples/cpp/311_feature_train.cpp
+++ b/examples/cpp/311_feature_train.cpp
@@ -27,7 +27,7 @@ main(int argc, char** argv) {
 
     std::mt19937 rng;
     rng.seed(47);
-    std::uniform_real_distribution<> distrib_real;
+    std::uniform_real_distribution<float> distrib_real;
     for (int64_t i = 0; i < num_vectors; ++i) {
         ids[i] = i;
     }

--- a/examples/cpp/313_feature_search_allocator.cpp
+++ b/examples/cpp/313_feature_search_allocator.cpp
@@ -98,7 +98,7 @@ main() {
 
     std::mt19937 rng;
     rng.seed(47);
-    std::uniform_real_distribution<> distrib_real;
+    std::uniform_real_distribution<float> distrib_real;
     for (int64_t i = 0; i < num_vectors; ++i) {
         ids[i] = i;
     }

--- a/examples/cpp/318_feature_tune.cpp
+++ b/examples/cpp/318_feature_tune.cpp
@@ -28,7 +28,7 @@ main(int argc, char** argv) {
 
     std::mt19937 rng;
     rng.seed(47);
-    std::uniform_real_distribution<> distrib_real;
+    std::uniform_real_distribution<float> distrib_real;
     for (int64_t i = 0; i < num_vectors; ++i) {
         ids[i] = i;
     }

--- a/examples/cpp/401_persistent_kv.cpp
+++ b/examples/cpp/401_persistent_kv.cpp
@@ -118,7 +118,7 @@ main(int32_t argc, char** argv) {
 
     std::mt19937 rng;
     rng.seed(47);
-    std::uniform_real_distribution<> distrib_real;
+    std::uniform_real_distribution<float> distrib_real;
     for (uint32_t i = 0; i < num_vectors; ++i) {
         ids[i] = i;
     }

--- a/examples/cpp/402_persistent_streaming.cpp
+++ b/examples/cpp/402_persistent_streaming.cpp
@@ -36,7 +36,7 @@ main(int32_t argc, char** argv) {
 
     std::mt19937 rng;
     rng.seed(47);
-    std::uniform_real_distribution<> distrib_real;
+    std::uniform_real_distribution<float> distrib_real;
     for (uint32_t i = 0; i < num_vectors; ++i) {
         ids[i] = i;
     }

--- a/extern/diskann/DiskANN/src/math_utils.cpp
+++ b/extern/diskann/DiskANN/src/math_utils.cpp
@@ -30,7 +30,7 @@ float calc_distance(float *vec_1, float *vec_2, uint64_t dim)
 // to be pre-allocated
 void compute_vecs_l2sq(float *vecs_l2sq, float *data, const uint64_t num_points, const uint64_t dim)
 {
-//#pragma omp parallel for schedule(static, 8192)
+    // #pragma omp parallel for schedule(static, 8192)
     for (int64_t n_iter = 0; n_iter < (int64_t)num_points; n_iter++)
     {
         vecs_l2sq[n_iter] = cblas_snrm2((vsag_blasint)dim, (data + (n_iter * dim)), 1);
@@ -49,8 +49,8 @@ void rotate_data_randomly(float *data, uint64_t num_points, uint64_t dim, float 
     }
     // diskann::cout << "done Rotating data with random matrix.." << std::flush;
 
-    cblas_sgemm(CblasRowMajor, CblasNoTrans, transpose, (vsag_blasint)num_points, (vsag_blasint)dim, (vsag_blasint)dim, 1.0, data,
-                (vsag_blasint)dim, rot_mat, (vsag_blasint)dim, 0, new_mat, (vsag_blasint)dim);
+    cblas_sgemm(CblasRowMajor, CblasNoTrans, transpose, (vsag_blasint)num_points, (vsag_blasint)dim, (vsag_blasint)dim,
+                1.0, data, (vsag_blasint)dim, rot_mat, (vsag_blasint)dim, 0, new_mat, (vsag_blasint)dim);
 
     // diskann::cout << "done." << std::endl;
 }
@@ -88,18 +88,21 @@ void compute_closest_centers_in_block(const float *const data, const uint64_t nu
         ones_b[i] = 1.0;
     }
 
-    cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasTrans, (vsag_blasint)num_points, (vsag_blasint)num_centers, (vsag_blasint)1, 1.0f,
-                docs_l2sq, (vsag_blasint)1, ones_a, (vsag_blasint)1, 0.0f, dist_matrix, (vsag_blasint)num_centers);
+    cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasTrans, (vsag_blasint)num_points, (vsag_blasint)num_centers,
+                (vsag_blasint)1, 1.0f, docs_l2sq, (vsag_blasint)1, ones_a, (vsag_blasint)1, 0.0f, dist_matrix,
+                (vsag_blasint)num_centers);
 
-    cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasTrans, (vsag_blasint)num_points, (vsag_blasint)num_centers, (vsag_blasint)1, 1.0f,
-                ones_b, (vsag_blasint)1, centers_l2sq, (vsag_blasint)1, 1.0f, dist_matrix, (vsag_blasint)num_centers);
+    cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasTrans, (vsag_blasint)num_points, (vsag_blasint)num_centers,
+                (vsag_blasint)1, 1.0f, ones_b, (vsag_blasint)1, centers_l2sq, (vsag_blasint)1, 1.0f, dist_matrix,
+                (vsag_blasint)num_centers);
 
-    cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasTrans, (vsag_blasint)num_points, (vsag_blasint)num_centers, (vsag_blasint)dim, -2.0f,
-                data, (vsag_blasint)dim, centers, (vsag_blasint)dim, 1.0f, dist_matrix, (vsag_blasint)num_centers);
+    cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasTrans, (vsag_blasint)num_points, (vsag_blasint)num_centers,
+                (vsag_blasint)dim, -2.0f, data, (vsag_blasint)dim, centers, (vsag_blasint)dim, 1.0f, dist_matrix,
+                (vsag_blasint)num_centers);
 
     if (k == 1)
     {
-//#pragma omp parallel for schedule(static, 8192)
+        // #pragma omp parallel for schedule(static, 8192)
         for (int64_t i = 0; i < (int64_t)num_points; i++)
         {
             float min = std::numeric_limits<float>::max();
@@ -116,7 +119,7 @@ void compute_closest_centers_in_block(const float *const data, const uint64_t nu
     }
     else
     {
-//#pragma omp parallel for schedule(static, 8192)
+        // #pragma omp parallel for schedule(static, 8192)
         for (int64_t i = 0; i < (int64_t)num_points; i++)
         {
             std::priority_queue<PivotContainer> top_k_queue;
@@ -184,7 +187,7 @@ void compute_closest_centers(float *data, uint64_t num_points, uint64_t dim, flo
                                                      pts_norms_blk, pivs_norms_squared, closest_centers,
                                                      distance_matrix, k);
 
-//#pragma omp parallel for schedule(static, 1)
+        // #pragma omp parallel for schedule(static, 1)
         for (int64_t j = cur_blk * PAR_BLOCK_SIZE;
              j < std::min((int64_t)num_points, (int64_t)((cur_blk + 1) * PAR_BLOCK_SIZE)); j++)
         {
@@ -194,7 +197,7 @@ void compute_closest_centers(float *data, uint64_t num_points, uint64_t dim, flo
                 closest_centers_ivf[j * k + l] = (uint32_t)this_center_id;
                 if (inverted_index != NULL)
                 {
-//#pragma omp critical
+                    // #pragma omp critical
                     inverted_index[this_center_id].push_back(j);
                 }
             }
@@ -243,8 +246,8 @@ namespace kmeans
 // closest_centers == NULL, will allocate memory and return. Similarly, if
 // closest_docs == NULL, will allocate memory and return.
 
-float lloyds_iter(float *data, uint64_t num_points, uint64_t dim, float *centers, uint64_t num_centers, float *docs_l2sq,
-                  std::vector<uint64_t> *closest_docs, uint32_t *&closest_center)
+float lloyds_iter(float *data, uint64_t num_points, uint64_t dim, float *centers, uint64_t num_centers,
+                  float *docs_l2sq, std::vector<uint64_t> *closest_docs, uint32_t *&closest_center)
 {
     bool compute_residual = true;
     // Timer timer;
@@ -261,7 +264,7 @@ float lloyds_iter(float *data, uint64_t num_points, uint64_t dim, float *centers
                                         docs_l2sq);
 
     memset(centers, 0, sizeof(float) * (uint64_t)num_centers * (uint64_t)dim);
-//#pragma omp parallel for schedule(static, 1)
+    // #pragma omp parallel for schedule(static, 1)
     for (int64_t c = 0; c < (int64_t)num_centers; ++c)
     {
         float *center = centers + (uint64_t)c * (uint64_t)dim;
@@ -278,7 +281,8 @@ float lloyds_iter(float *data, uint64_t num_points, uint64_t dim, float *centers
         }
         if (closest_docs[c].size() > 0)
         {
-            for (uint64_t i = 0; i < dim; i++) {
+            for (uint64_t i = 0; i < dim; i++)
+            {
                 center[i] = (float)(cluster_sum[i] / ((double)closest_docs[c].size()));
             }
         }
@@ -293,11 +297,12 @@ float lloyds_iter(float *data, uint64_t num_points, uint64_t dim, float *centers
         uint64_t nchunks = num_points / CHUNK_SIZE + (num_points % CHUNK_SIZE == 0 ? 0 : 1);
         std::vector<float> residuals(nchunks * BUF_PAD, 0.0);
 
-//#pragma omp parallel for schedule(static, 32)
+        // #pragma omp parallel for schedule(static, 32)
         for (int64_t chunk = 0; chunk < (int64_t)nchunks; ++chunk)
-            for (uint64_t d = chunk * CHUNK_SIZE; d < num_points && d < (chunk + 1) * CHUNK_SIZE; ++d) {
-                residuals[chunk * BUF_PAD] +=
-                    math_utils::calc_distance(data + (d * dim), centers + (uint64_t)closest_center[d] * (uint64_t)dim, dim);
+            for (uint64_t d = chunk * CHUNK_SIZE; d < num_points && d < (chunk + 1) * CHUNK_SIZE; ++d)
+            {
+                residuals[chunk * BUF_PAD] += math_utils::calc_distance(
+                    data + (d * dim), centers + (uint64_t)closest_center[d] * (uint64_t)dim, dim);
             }
 
         for (uint64_t chunk = 0; chunk < nchunks; ++chunk)
@@ -398,7 +403,7 @@ void kmeanspp_selecting_pivots(float *data, uint64_t num_points, uint64_t dim, f
     std::vector<uint64_t> picked;
     std::random_device rd;
     auto x = rd();
-    std::mt19937 generator(x);
+    std::mt19937_64 generator(x);
     std::uniform_real_distribution<> distribution(0, 1);
     std::uniform_int_distribution<uint64_t> int_dist(0, num_points - 1);
     uint64_t init_id = int_dist(generator);
@@ -409,7 +414,7 @@ void kmeanspp_selecting_pivots(float *data, uint64_t num_points, uint64_t dim, f
 
     float *dist = new float[num_points];
 
-//#pragma omp parallel for schedule(static, 8192)
+    // #pragma omp parallel for schedule(static, 8192)
     for (int64_t i = 0; i < (int64_t)num_points; i++)
     {
         dist[i] = math_utils::calc_distance(data + i * dim, data + init_id * dim, dim);
@@ -450,7 +455,7 @@ void kmeanspp_selecting_pivots(float *data, uint64_t num_points, uint64_t dim, f
         picked.push_back(tmp_pivot);
         std::memcpy(pivot_data + num_picked * dim, data + tmp_pivot * dim, dim * sizeof(float));
 
-//#pragma omp parallel for schedule(static, 8192)
+        // #pragma omp parallel for schedule(static, 8192)
         for (int64_t i = 0; i < (int64_t)num_points; i++)
         {
             dist[i] = (std::min)(dist[i], math_utils::calc_distance(data + i * dim, data + tmp_pivot * dim, dim));

--- a/src/simd/simd_test.cpp
+++ b/src/simd/simd_test.cpp
@@ -57,7 +57,7 @@ TEST_CASE("Test InnerProduct Instructions", "[ut][simd]") {
     std::random_device rd;
     std::mt19937 rng(rd());
     for (uint64_t dim = 1; dim < 1026; dim++) {
-        std::uniform_real_distribution<> distrib_real;
+        std::uniform_real_distribution<float> distrib_real;
         float vector1[dim];
         float vector2[dim];
         for (int j = 0; j < dim; j++) {
@@ -74,7 +74,7 @@ TEST_CASE("Test L2 Instructions", "[ut][simd]") {
     std::random_device rd;
     std::mt19937 rng(rd());
     for (uint64_t dim = 1; dim < 1026; dim++) {
-        std::uniform_real_distribution<> distrib_real;
+        std::uniform_real_distribution<float> distrib_real;
         float vector1[dim];
         float vector2[dim];
         for (int j = 0; j < dim; j++) {

--- a/tests/fixtures/fixtures.h
+++ b/tests/fixtures/fixtures.h
@@ -107,8 +107,7 @@ GenerateVectors(uint64_t count,
 template <typename T, typename RT = typename std::enable_if<std::is_floating_point_v<T>, T>::type>
 std::vector<RT>
 GenerateVectors(uint64_t count, uint32_t dim, int seed = 47, bool need_normalize = true) {
-    using EngineType =
-        typename std::conditional<(sizeof(T) > 4), std::mt19937_64, std::mt19937>::type;
+    using EngineType = std::conditional_t<(sizeof(T) > 4), std::mt19937_64, std::mt19937>;
     EngineType rng(seed);
     std::uniform_real_distribution<T> distrib_real(0.1, 0.9);
     std::vector<T> vectors(dim * count);

--- a/tests/fixtures/fixtures.h
+++ b/tests/fixtures/fixtures.h
@@ -21,6 +21,7 @@
 #include <memory>
 #include <random>
 #include <tuple>
+#include <type_traits>
 #include <vector>
 
 #include "common.h"
@@ -106,7 +107,9 @@ GenerateVectors(uint64_t count,
 template <typename T, typename RT = typename std::enable_if<std::is_floating_point_v<T>, T>::type>
 std::vector<RT>
 GenerateVectors(uint64_t count, uint32_t dim, int seed = 47, bool need_normalize = true) {
-    std::mt19937 rng(seed);
+    using EngineType =
+        typename std::conditional<(sizeof(T) > 4), std::mt19937_64, std::mt19937>::type;
+    EngineType rng(seed);
     std::uniform_real_distribution<T> distrib_real(0.1, 0.9);
     std::vector<T> vectors(dim * count);
     for (int64_t i = 0; i < dim * count; ++i) {

--- a/tests/test_diskann.cpp
+++ b/tests/test_diskann.cpp
@@ -421,7 +421,7 @@ TEST_CASE("DiskAnn Filter Test", "[ft][diskann]") {
     // Generate random data
     std::mt19937 rng;
     rng.seed(47);
-    std::uniform_real_distribution<> distrib_real;
+    std::uniform_real_distribution<float> distrib_real;
     std::uniform_int_distribution<> ids_random(0, max_elements - 1);
 
     for (int64_t i = 0; i < max_elements; i++) {
@@ -566,7 +566,7 @@ TEST_CASE("DiskAnn Random Id", "[ft][diskann]") {
 
     // Generate random data
     std::mt19937 rng;
-    std::uniform_real_distribution<> distrib_real;
+    std::uniform_real_distribution<float> distrib_real;
     std::uniform_int_distribution<> ids_rand(0, max_elements - 1);
     for (int i = 0; i < max_elements; i++) {
         ids[i] = ids_rand(rng);
@@ -653,7 +653,7 @@ TEST_CASE("DiskANN small dimension", "[ft][diskann]") {
     // Generate random data
     std::mt19937 rng;
     rng.seed(47);
-    std::uniform_real_distribution<> distrib_real;
+    std::uniform_real_distribution<float> distrib_real;
     int64_t* ids = new int64_t[max_elements];
     float* data = new float[dim * max_elements];
     for (int i = 0; i < max_elements; i++) {
@@ -718,7 +718,7 @@ TEST_CASE("split building process", "[ft][diskann]") {
     // Generate random data
     std::mt19937 rng;
     rng.seed(47);
-    std::uniform_real_distribution<> distrib_real;
+    std::uniform_real_distribution<float> distrib_real;
     int64_t* ids = new int64_t[max_elements];
     float* data = new float[dim * max_elements];
     for (int i = 0; i < max_elements; i++) {

--- a/tests/test_factory.cpp
+++ b/tests/test_factory.cpp
@@ -44,7 +44,7 @@ TEST_CASE("Test Factory", "[ft][factory]") {
     // Generate random data
     std::mt19937 rng;
     rng.seed(47);
-    std::uniform_real_distribution<> distrib_real;
+    std::uniform_real_distribution<float> distrib_real;
     int64_t* ids = new int64_t[max_elements];
     float* data = new float[dim * max_elements];
     for (int i = 0; i < max_elements; i++) {

--- a/tests/test_index_old.cpp
+++ b/tests/test_index_old.cpp
@@ -1515,7 +1515,7 @@ TEST_CASE("hnsw with pretrained by conjugate graph", "[ft][index][hnsw]") {
     std::shared_ptr<float[]> base_data(new float[dim * base_elements]);
     std::mt19937 rng;
     rng.seed(47);
-    std::uniform_real_distribution<> distribution_real(-1, 1);
+    std::uniform_real_distribution<float> distribution_real(-1, 1);
     for (int i = 0; i < base_elements; i++) {
         base_ids[i] = i;
 
@@ -1642,7 +1642,7 @@ TEST_CASE("HNSW filtered search", "[ft][index][hnsw]") {
 
     // Generate random data
     std::mt19937 rng(47);
-    std::uniform_real_distribution<> distrib_real;
+    std::uniform_real_distribution<float> distrib_real;
     int64_t* ids = new int64_t[max_elements];
     float* data = new float[dim * max_elements];
 
@@ -1828,7 +1828,7 @@ TEST_CASE("DiskAnn filtered knn search", "[ft][index][diskann]") {
     // Generate random data
     std::mt19937 rng;
     rng.seed(47);
-    std::uniform_real_distribution<> distrib_real;
+    std::uniform_real_distribution<float> distrib_real;
     std::uniform_int_distribution<> ids_random(0, max_elements - 1);
     int64_t* ids = new int64_t[max_elements];
     float* data = new float[dim * max_elements];

--- a/tests/test_multi_thread.cpp
+++ b/tests/test_multi_thread.cpp
@@ -74,7 +74,7 @@ TEST_CASE("Test DiskAnn Multi-threading", "[ft][diskann]") {
     // Generate random data
     std::mt19937 rng;
     rng.seed(47);
-    std::uniform_real_distribution<> distrib_real;
+    std::uniform_real_distribution<float> distrib_real;
     for (int i = 0; i < max_elements; i++) ids[i] = i;
     for (int i = 0; i < dim * max_elements; i++) data[i] = distrib_real(rng);
 
@@ -138,7 +138,7 @@ TEST_CASE("Test HNSW Multi-threading", "[ft][hnsw][concurrent]") {
     // Generate random data
     std::mt19937 rng;
     rng.seed(47);
-    std::uniform_real_distribution<> distrib_real;
+    std::uniform_real_distribution<float> distrib_real;
     for (int i = 0; i < max_elements; i++) ids[i] = i;
     for (int i = 0; i < dim * max_elements; i++) data[i] = distrib_real(rng);
 
@@ -212,7 +212,7 @@ TEST_CASE("Test HNSW Multi-threading Read and Write", "[ft][hnsw][concurrent]") 
     // Generate random data
     std::mt19937 rng;
     rng.seed(47);
-    std::uniform_real_distribution<> distrib_real;
+    std::uniform_real_distribution<float> distrib_real;
     for (int i = 0; i < max_elements; i++) ids[i] = i;
     for (int i = 0; i < dim * max_elements; i++) data[i] = distrib_real(rng);
     nlohmann::json parameters{
@@ -282,7 +282,7 @@ TEST_CASE("Test HNSW Multi-threading read-write with Feedback and Pretrain",
 
     // Generate random data
     std::mt19937 rng;
-    std::uniform_real_distribution<> distrib_real(-128, 127);
+    std::uniform_real_distribution<float> distrib_real(-128, 127);
     for (int i = 0; i < max_elements; i++) ids[i] = i;
     for (int i = 0; i < dim * max_elements; i++) data[i] = (int8_t)distrib_real(rng);
     nlohmann::json parameters{

--- a/tests/test_random_index.cpp
+++ b/tests/test_random_index.cpp
@@ -89,7 +89,7 @@ TEST_CASE("Test Random Index", "[ft][random]") {
         {"hnsw", {{"ef_search", ef_search}}}};
 
     // Generate random data
-    std::uniform_real_distribution<> distrib_real;
+    std::uniform_real_distribution<float> distrib_real;
     int64_t* ids = new int64_t[max_elements];
     float* data = new float[dim * max_elements];
     for (int i = 0; i < max_elements; i++) {


### PR DESCRIPTION
## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement/Refactor
- [ ] Documentation
- [ ] CI/Build/Infra

## Linked Issue

- Issue: <!-- e.g. #1234 -->

## What Changed

- <!-- Briefly describe the key changes -->

## Test Evidence

- [ ] `make fmt`
- [ ] `make lint`
- [ ] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [ ] Other (describe below)

Test details:

```text
<!-- Paste commands and key output here -->
```

## Compatibility Impact

- API/ABI compatibility: <!-- none / describe -->
- Behavior changes: <!-- none / describe -->

## Performance and Concurrency Impact

- Performance impact: <!-- none / improved / regressed / unknown -->
- Concurrency/thread-safety impact: <!-- none / describe -->

## Documentation Impact

- [ ] No docs update needed
- [ ] Updated docs:
  - [ ] `README.md`
  - [ ] `DEVELOPMENT.md`
  - [ ] `CONTRIBUTING.md`
  - [ ] Other: <!-- path -->

## Risk and Rollback

- Risk level: <!-- low / medium / high -->
- Rollback plan: <!-- how to revert safely -->

## Checklist

- [ ] I have linked the relevant issue (or explained why not applicable)
- [ ] I have added/updated tests for new behavior or bug fixes
- [ ] I have considered API compatibility impact
- [ ] I have updated docs if behavior/workflow changed
- [x] My commit messages follow project conventions (Conventional Commits, optional `[skip ci]` prefix)
