### PR TITLE
fix(hnsw): synchronize parallel add graph updates

### DIFF
--- a/src/algorithm/hnswlib/hnswalg.cpp
+++ b/src/algorithm/hnswlib/hnswalg.cpp
@@ -304,6 +304,14 @@ HierarchicalNSW::setBatchNeigohbors(InnerIdType internal_id,
                                     const InnerIdType* neighbors,
                                     uint64_t neigbor_count) {
     vsag::LockGuard lock(points_locks_, internal_id);
+    setBatchNeigohborsNoLock(internal_id, level, neighbors, neigbor_count);
+}
+
+void
+HierarchicalNSW::setBatchNeigohborsNoLock(InnerIdType internal_id,
+                                          int level,
+                                          const InnerIdType* neighbors,
+                                          uint64_t neigbor_count) {
     linklistsizeint* ll_cur = getLinklistAtLevel(internal_id, level);
     for (int i = 1; i <= neigbor_count; ++i) {
         ll_cur[i] = neighbors[i - 1];
@@ -318,6 +326,14 @@ HierarchicalNSW::appendNeigohbor(InnerIdType internal_id,
                                  InnerIdType neighbor,
                                  uint64_t max_degree) {
     vsag::LockGuard lock(points_locks_, internal_id);
+    appendNeigohborNoLock(internal_id, level, neighbor, max_degree);
+}
+
+void
+HierarchicalNSW::appendNeigohborNoLock(InnerIdType internal_id,
+                                       int level,
+                                       InnerIdType neighbor,
+                                       uint64_t max_degree) {
     linklistsizeint* ll_cur = getLinklistAtLevel(internal_id, level);
     uint64_t neigbor_count = getListCount(ll_cur) + 1;
     if (neigbor_count <= max_degree) {
@@ -331,8 +347,19 @@ HierarchicalNSW::updateConnections(InnerIdType internal_id,
                                    const vsag::Vector<InnerIdType>& cand_neighbors,
                                    int level,
                                    bool is_update) {
+    vsag::LockGuard lock(points_locks_, internal_id);
+    updateConnectionsNoLock(internal_id, cand_neighbors, level, is_update);
+}
+
+void
+HierarchicalNSW::updateConnectionsNoLock(InnerIdType internal_id,
+                                         const vsag::Vector<InnerIdType>& cand_neighbors,
+                                         int level,
+                                         bool is_update) {
     std::shared_ptr<char[]> link_data = std::shared_ptr<char[]>(new char[size_links_level0_]);
-    getLinklistAtLevel(internal_id, level, link_data.get());
+    auto* src = reinterpret_cast<char*>(getLinklistAtLevel(internal_id, level));
+    auto link_size = level == 0 ? size_links_level0_ : size_links_per_element_;
+    std::memcpy(link_data.get(), src, link_size);
     linklistsizeint* ll_cur = (linklistsizeint*)link_data.get();
 
     auto cur_size = getListCount(ll_cur);
@@ -353,7 +380,7 @@ HierarchicalNSW::updateConnections(InnerIdType internal_id,
             in_edges.insert(internal_id);
         }
     }
-    setBatchNeigohbors(internal_id, level, cand_neighbors.data(), cand_neighbors.size());
+    setBatchNeigohborsNoLock(internal_id, level, cand_neighbors.data(), cand_neighbors.size());
 }
 
 bool
@@ -417,6 +444,7 @@ HierarchicalNSW::bruteForce(const void* data_point,
 int
 HierarchicalNSW::getRandomLevel(double reverse_size) {
     std::uniform_real_distribution<double> distribution(0.0, 1.0);
+    std::lock_guard<std::mutex> lock(level_generator_mutex_);
     double r = -log(distribution(level_generator_)) * reverse_size;
     return (int)r;
 }
@@ -781,11 +809,18 @@ HierarchicalNSW::mutuallyConnectNewElement(InnerIdType cur_c,
 
     InnerIdType next_closest_entry_point = selectedNeighbors.back();
 
-    updateConnections(cur_c, selectedNeighbors, level, isUpdate);
+    if (isUpdate) {
+        updateConnections(cur_c, selectedNeighbors, level, isUpdate);
+    } else {
+        updateConnectionsNoLock(cur_c, selectedNeighbors, level, isUpdate);
+    }
 
     std::shared_ptr<char[]> ll_other_data = std::shared_ptr<char[]>(new char[size_links_level0_]);
     for (unsigned int selectedNeighbor : selectedNeighbors) {
-        getLinklistAtLevel(selectedNeighbor, level, ll_other_data.get());
+        vsag::LockGuard lock(points_locks_, selectedNeighbor);
+        auto* src = reinterpret_cast<char*>(getLinklistAtLevel(selectedNeighbor, level));
+        auto link_size = level == 0 ? size_links_level0_ : size_links_per_element_;
+        std::memcpy(ll_other_data.get(), src, link_size);
         linklistsizeint* ll_other = (linklistsizeint*)ll_other_data.get();
 
         uint64_t sz_link_list_other = getListCount(ll_other);
@@ -812,7 +847,7 @@ HierarchicalNSW::mutuallyConnectNewElement(InnerIdType cur_c,
         // If cur_c is already present in the neighboring connections of `selectedNeighbors[idx]` then no need to modify any connections or run the heuristics.
         if (!is_cur_c_present) {
             if (sz_link_list_other < m_curmax) {
-                appendNeigohbor(selectedNeighbor, level, cur_c, m_curmax);
+                appendNeigohborNoLock(selectedNeighbor, level, cur_c, m_curmax);
                 if (use_reversed_edges_) {
                     auto& cur_in_edges = getEdges(cur_c, level);
                     cur_in_edges.insert(selectedNeighbor);
@@ -840,7 +875,7 @@ HierarchicalNSW::mutuallyConnectNewElement(InnerIdType cur_c,
                     cand_neighbors.push_back(candidates.top().second);
                     candidates.pop();
                 }
-                updateConnections(selectedNeighbor, cand_neighbors, level, true);
+                updateConnectionsNoLock(selectedNeighbor, cand_neighbors, level, true);
                 // Nearest K:
                 /*int indx = -1;
                     for (int j = 0; j < sz_link_list_other; j++) {
@@ -1552,10 +1587,14 @@ HierarchicalNSW::addPoint(const void* data_point, LabelType label, int level) {
     std::shared_lock resize_lock(resize_mutex_);
     std::unique_lock lock(max_level_mutex_);
     int maxlevelcopy = max_level_;
-    if (curlevel <= maxlevelcopy)
-        lock.unlock();
     int64_t currObj = enterpoint_node_;
     int64_t enterpoint_copy = enterpoint_node_;
+    if (curlevel <= maxlevelcopy)
+        lock.unlock();
+
+    // Take the per-point lock after the global max-level lock to keep a consistent lock order.
+    // This still keeps the new point invisible before any neighbor starts pointing to it.
+    vsag::LockGuard point_lock(points_locks_, cur_c);
 
     if (curlevel) {
         auto new_link_lists = (char*)allocator_->Reallocate(link_lists_[cur_c],

--- a/src/algorithm/hnswlib/hnswalg.h
+++ b/src/algorithm/hnswlib/hnswalg.h
@@ -87,7 +87,6 @@ private:
         points_locks_;  // Ensures access safety for the link list and label of a specific point.
     mutable std::shared_mutex
         label_lookup_lock_{};  // Ensures access safety for the global label lookup table.
-
     InnerIdType enterpoint_node_{0};
 
     uint64_t size_links_level0_{0};
@@ -117,6 +116,7 @@ private:
     vsag::PGUnorderedMap<LabelType, InnerIdType> label_lookup_;
 
     std::default_random_engine level_generator_{2021};
+    mutable std::mutex level_generator_mutex_;
     mutable std::default_random_engine update_probability_generator_;
 
     vsag::Allocator* allocator_{nullptr};
@@ -233,6 +233,12 @@ public:
                       int level,
                       bool is_update);
 
+    void
+    updateConnectionsNoLock(InnerIdType internal_id,
+                            const vsag::Vector<InnerIdType>& cand_neighbors,
+                            int level,
+                            bool is_update);
+
     bool
     checkReverseConnection();
 
@@ -300,7 +306,19 @@ public:
                        uint64_t neigbor_count);
 
     void
+    setBatchNeigohborsNoLock(InnerIdType internal_id,
+                             int level,
+                             const InnerIdType* neighbors,
+                             uint64_t neigbor_count);
+
+    void
     appendNeigohbor(InnerIdType internal_id, int level, InnerIdType neighbor, uint64_t max_degree);
+
+    void
+    appendNeigohborNoLock(InnerIdType internal_id,
+                          int level,
+                          InnerIdType neighbor,
+                          uint64_t max_degree);
 
     linklistsizeint*
     getLinklist0(InnerIdType internal_id) const {


### PR DESCRIPTION
## Summary
- make neighbor-side updates in `HierarchicalNSW::mutuallyConnectNewElement()` atomic so concurrent inserts do not overwrite each other from stale snapshots
- keep a newly inserted point hidden until its link lists are initialized, and serialize `getRandomLevel()` access to avoid shared RNG races
- align `addPoint()` lock ordering with other read paths so TSAN no longer reports a lock-order inversion with `max_level_mutex_`

## Test Plan
- `make fmt`
- `./build-release/examples/cpp/322_feature_hnsw_concurrent_add_recall`
- `TSAN_OPTIONS="halt_on_error=1 second_deadlock_stack=1 history_size=7" ./build/examples/cpp/322_feature_hnsw_concurrent_add_recall`

Closes #1801
