### PR TITLE
feat(hgraph): add remove support for graph indexes

### DIFF
--- a/include/vsag/index.h
+++ b/include/vsag/index.h
@@ -69,10 +69,16 @@ enum class RemoveMode {
         * this mode is fast */
     MARK_REMOVE = 0,
 
-    /** remove the vector from index and repair the index, but not shrink the index, 
-        * this mode is heavy */
-    REMOVE_AND_REPAIR = 1,
+    /** remove the vector from index and repair the index, this mode is heavy */
+    FORCE_REMOVE = 1,
+
+    /** backward-compatible alias kept for existing public API users */
+    REMOVE_AND_REPAIR = FORCE_REMOVE,
+
+    /** backward-compatible alias for the mixed-style enumerator introduced earlier */
+    ForceRemove = FORCE_REMOVE,
 };
+
 class Index {
 public:
     /**

--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -727,6 +727,7 @@ HGraph::build_by_odescent(const DatasetPtr& data) {
 
 std::vector<int64_t>
 HGraph::Add(const DatasetPtr& data, AddMode mode) {
+    std::shared_lock force_remove_rlock(this->force_remove_mutex_);
     std::vector<int64_t> failed_ids;
     auto base_dim = data->GetDim();
     if (data_type_ != DataTypes::DATA_TYPE_SPARSE) {
@@ -867,6 +868,7 @@ HGraph::KnnSearch(const DatasetPtr& query,
         (1 <= params.ef_search) and (params.ef_search <= ef_search_threshold),
         fmt::format("ef_search({}) must in range[1, {}]", params.ef_search, ef_search_threshold));
 
+    std::shared_lock force_remove_rlock(this->force_remove_mutex_);
     std::shared_lock shared_lock(this->global_mutex_);
     // check k
     CHECK_ARGUMENT(k > 0, fmt::format("k({}) must be greater than 0", k));
@@ -1125,6 +1127,7 @@ HGraph::RangeSearch(const DatasetPtr& query,
     CHECK_ARGUMENT(limited_size != 0,
                    fmt::format("limited_size({}) must not be equal to 0", limited_size));
 
+    std::shared_lock force_remove_rlock(this->force_remove_mutex_);
     std::shared_lock shared_lock(this->global_mutex_);
 
     InnerSearchParam search_param;
@@ -1912,46 +1915,168 @@ HGraph::Remove(const std::vector<int64_t>& ids, RemoveMode mode) {
         delete_count_ += delete_count;
         return delete_count;
     }
-    for (const auto& id : ids) {
-        InnerIdType inner_id;
-        {
-            std::shared_lock lock(this->label_lookup_mutex_);
-            inner_id = this->label_table_->GetIdByLabel(id);
+
+    if (mode == RemoveMode::FORCE_REMOVE) {
+        std::unique_lock<std::shared_mutex> wlock(this->force_remove_mutex_);
+        for (const auto& id : ids) {
+            delete_count += this->force_remove_one(id);
         }
-        if (inner_id == this->entry_point_id_) {
-            bool find_new_ep = false;
-            while (not route_graphs_.empty()) {
-                auto& upper_graph = route_graphs_.back();
-                Vector<InnerIdType> neighbors(allocator_);
-                upper_graph->GetNeighbors(this->entry_point_id_, neighbors);
-                for (const auto& nb_id : neighbors) {
-                    if (inner_id == nb_id) {
-                        continue;
-                    }
-                    this->entry_point_id_ = nb_id;
-                    find_new_ep = true;
-                    break;
-                }
-                if (find_new_ep) {
-                    break;
-                }
-                route_graphs_.pop_back();
-            }
+        if (delete_count != 0) {
+            this->shrink_to_fit();
         }
-        {
-            {
-                std::scoped_lock<std::shared_mutex> wlock(this->global_mutex_);
-                for (int level = static_cast<int>(route_graphs_.size()) - 1; level >= 0; --level) {
-                    this->route_graphs_[level]->DeleteNeighborsById(inner_id);
-                }
-                this->bottom_graph_->DeleteNeighborsById(inner_id);
+        return delete_count;
+    }
+
+    throw VsagException(ErrorType::INVALID_ARGUMENT, "RemoveMode not supported");
+}
+
+void
+HGraph::find_new_entry_point() {
+    bool find_new_ep = false;
+    auto inner_id = this->entry_point_id_;
+    while (not route_graphs_.empty()) {
+        auto& upper_graph = route_graphs_.back();
+        Vector<InnerIdType> neighbors(allocator_);
+        upper_graph->GetNeighbors(this->entry_point_id_, neighbors);
+        for (const auto& nb_id : neighbors) {
+            if (inner_id == nb_id) {
+                continue;
             }
-            std::scoped_lock label_lock(this->label_lookup_mutex_);
-            this->label_table_->MarkRemove(id);
-            delete_count++;
+            this->entry_point_id_ = nb_id;
+            find_new_ep = true;
+            break;
+        }
+        if (find_new_ep) {
+            break;
+        }
+        route_graphs_.pop_back();
+    }
+}
+
+void
+HGraph::graph_force_remove_one(const InnerIdType& inner_id,
+                               const FlattenInterfacePtr& flatten,
+                               const GraphInterfacePtr& graph) {
+    Vector<InnerIdType> forward_neighbors(allocator_);
+    graph->GetNeighbors(inner_id, forward_neighbors);
+    Vector<InnerIdType> reverse_neighbors(allocator_);
+    graph->GetIncomingNeighbors(inner_id, reverse_neighbors);
+    if (forward_neighbors.empty() && reverse_neighbors.empty()) {
+        return;
+    }
+
+    UnorderedSet<InnerIdType> affected_nodes(allocator_);
+    auto current_count = this->total_count_.load();
+    for (const auto& n : forward_neighbors) {
+        if (n < current_count) {
+            affected_nodes.insert(n);
         }
     }
-    return delete_count;
+    for (const auto& n : reverse_neighbors) {
+        if (n < current_count) {
+            affected_nodes.insert(n);
+        }
+    }
+
+    auto max_degree = graph->MaximumDegree();
+
+    for (const auto& neighbor : affected_nodes) {
+        LockGuard lock(neighbors_mutex_, neighbor);
+
+        Vector<InnerIdType> neighbors_of_neighbor(allocator_);
+        graph->GetNeighbors(neighbor, neighbors_of_neighbor);
+
+        UnorderedSet<InnerIdType> candidate_set(allocator_);
+        for (const auto& nb : neighbors_of_neighbor) {
+            if (nb != inner_id) {
+                candidate_set.insert(nb);
+            }
+        }
+        for (const auto& nb : forward_neighbors) {
+            if (nb != inner_id && nb != neighbor) {
+                candidate_set.insert(nb);
+            }
+        }
+
+        Vector<InnerIdType> candidate_list(allocator_);
+        auto current_count = this->total_count_.load();
+        for (const auto& candidate : candidate_set) {
+            if (candidate < current_count) {
+                candidate_list.emplace_back(candidate);
+            }
+        }
+
+        select_edges_by_heuristic(
+            candidate_list, neighbor, max_degree, flatten, allocator_, alpha_);
+
+        graph->InsertNeighborsById(neighbor, candidate_list);
+    }
+
+    Vector<InnerIdType> empty_neighbor(allocator_);
+    graph->InsertNeighborsById(inner_id, empty_neighbor);
+}
+
+void
+HGraph::move_id(InnerIdType from, InnerIdType to) {
+    basic_flatten_codes_->Move(from, to);
+    if (high_precise_codes_) {
+        high_precise_codes_->Move(from, to);
+    }
+
+    if (extra_infos_) {
+        extra_infos_->Move(from, to);
+    }
+
+    bottom_graph_->Move(from, to);
+    for (const auto& route_graph : route_graphs_) {
+        route_graph->Move(from, to);
+    }
+
+    label_table_->Move(from, to);
+
+    if (entry_point_id_ == from) {
+        entry_point_id_ = to;
+    }
+}
+
+uint32_t
+HGraph::force_remove_one(int64_t label) {
+    InnerIdType inner_id;
+    {
+        std::shared_lock lock(this->label_lookup_mutex_);
+        inner_id = this->label_table_->GetIdByLabel(label);
+    }
+    if (inner_id == this->entry_point_id_) {
+        this->find_new_entry_point();
+    }
+
+    graph_force_remove_one(inner_id, basic_flatten_codes_, bottom_graph_);
+
+    for (const auto& route_graph : route_graphs_) {
+        graph_force_remove_one(inner_id, basic_flatten_codes_, route_graph);
+    }
+    InnerIdType swap_id = this->total_count_.load() - 1;
+
+    if (swap_id != inner_id) {
+        this->move_id(swap_id, inner_id);
+    }
+    this->total_count_--;
+    return 1;
+}
+
+void
+HGraph::shrink_to_fit() {
+    auto total_count = this->total_count_.load();
+
+    basic_flatten_codes_->ShrinkToFit(total_count);
+    if (high_precise_codes_) {
+        high_precise_codes_->ShrinkToFit(total_count);
+    }
+    bottom_graph_->ShrinkToFit(total_count);
+    for (const auto& route_graph : route_graphs_) {
+        route_graph->ShrinkToFit(total_count);
+    }
+    label_table_->ShrinkToFit(total_count);
 }
 
 void
@@ -2173,6 +2298,7 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
         (1 <= params.ef_search) and (params.ef_search <= ef_search_threshold),
         fmt::format("ef_search({}) must in range[1, {}]", params.ef_search, ef_search_threshold));
 
+    std::shared_lock force_remove_rlock(this->force_remove_mutex_);
     std::shared_lock shared_lock(this->global_mutex_);
     // check k
     CHECK_ARGUMENT(k > 0, fmt::format("k({}) must be greater than 0", k));

--- a/src/algorithm/hgraph.h
+++ b/src/algorithm/hgraph.h
@@ -324,6 +324,23 @@ private:
     void
     deserialize_basic_info_v0_14(StreamReader& reader);
 
+    uint32_t
+    force_remove_one(int64_t label);
+
+    void
+    find_new_entry_point();
+
+    void
+    graph_force_remove_one(const InnerIdType& inner_id,
+                           const FlattenInterfacePtr& flatten,
+                           const GraphInterfacePtr& graph);
+
+    void
+    move_id(InnerIdType from, InnerIdType to);
+
+    void
+    shrink_to_fit();
+
 private:
     void
     reorder(const void* query,
@@ -390,6 +407,7 @@ private:
     mutable std::shared_mutex global_mutex_;
     mutable MutexArrayPtr neighbors_mutex_;
     mutable std::shared_mutex add_mutex_;
+    mutable std::shared_mutex force_remove_mutex_;
 
     std::atomic<InnerIdType> max_capacity_{0};
 

--- a/src/algorithm/hgraph_parameter.cpp
+++ b/src/algorithm/hgraph_parameter.cpp
@@ -91,6 +91,7 @@ HGraphParameter::FromJson(const JsonType& json) {
         if (graph_param != nullptr) {
             hierarchical_graph_param->remove_flag_bit_ = graph_param->remove_flag_bit_;
             hierarchical_graph_param->support_delete_ = graph_param->support_remove_;
+            hierarchical_graph_param->use_reverse_edges_ = graph_param->use_reverse_edges_;
         } else {
             hierarchical_graph_param->support_delete_ = false;
         }

--- a/src/datacell/compressed_graph_datacell.cpp
+++ b/src/datacell/compressed_graph_datacell.cpp
@@ -34,6 +34,10 @@ CompressedGraphDataCell::CompressedGraphDataCell(const CompressedGraphDatacellPa
     if (graph_param->support_duplicate_) {
         this->InitDuplicateTracker();
     }
+    if (graph_param->use_reverse_edges_) {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "CompressedGraphDataCell does not support reverse edges");
+    }
 }
 
 CompressedGraphDataCell::~CompressedGraphDataCell() {

--- a/src/datacell/compressed_graph_datacell_parameter.h
+++ b/src/datacell/compressed_graph_datacell_parameter.h
@@ -36,6 +36,9 @@ public:
         if (json.Contains(SUPPORT_DUPLICATE)) {
             this->support_duplicate_ = json[SUPPORT_DUPLICATE].GetBool();
         }
+        if (json.Contains(HGRAPH_USE_REVERSE_EDGES_KEY)) {
+            this->use_reverse_edges_ = json[HGRAPH_USE_REVERSE_EDGES_KEY].GetBool();
+        }
     }
 
     JsonType
@@ -44,6 +47,7 @@ public:
         json[GRAPH_PARAM_MAX_DEGREE_KEY].SetInt(this->max_degree_);
         json[GRAPH_STORAGE_TYPE_KEY].SetString(GRAPH_STORAGE_TYPE_VALUE_COMPRESSED);
         json[SUPPORT_DUPLICATE].SetBool(this->support_duplicate_);
+        json[HGRAPH_USE_REVERSE_EDGES_KEY].SetBool(this->use_reverse_edges_);
         return json;
     }
 
@@ -70,6 +74,14 @@ public:
                 "support_duplicate_ mismatch: {} vs {}",
                 support_duplicate_,
                 graph_param->support_duplicate_);
+            return false;
+        }
+        if (use_reverse_edges_ != graph_param->use_reverse_edges_) {
+            logger::error(
+                "CompressedGraphDatacellParameter::CheckCompatibility: "
+                "use_reverse_edges_ mismatch: {} vs {}",
+                use_reverse_edges_,
+                graph_param->use_reverse_edges_);
             return false;
         }
         return true;

--- a/src/datacell/extra_info_datacell.h
+++ b/src/datacell/extra_info_datacell.h
@@ -83,6 +83,9 @@ public:
     int64_t
     GetMemoryUsage() const override;
 
+    void
+    Move(InnerIdType from, InnerIdType to) override;
+
     inline void
     SetIO(std::shared_ptr<BasicIO<IOTmpl>> io) {
         this->io_ = io;
@@ -180,5 +183,18 @@ ExtraInfoDataCell<IOTmpl>::GetMemoryUsage() const {
         memory += this->io_->GetMemoryUsage();
     }
     return memory;
+}
+
+template <typename IOTmpl>
+void
+ExtraInfoDataCell<IOTmpl>::Move(InnerIdType from, InnerIdType to) {
+    bool need_release = false;
+    const char* extra_info = this->GetExtraInfoById(from, need_release);
+    this->io_->Write(reinterpret_cast<const uint8_t*>(extra_info),
+                     extra_info_size_,
+                     static_cast<uint64_t>(to) * static_cast<uint64_t>(extra_info_size_));
+    if (need_release) {
+        this->io_->Release(reinterpret_cast<const uint8_t*>(extra_info));
+    }
 }
 }  // namespace vsag

--- a/src/datacell/extra_info_interface.h
+++ b/src/datacell/extra_info_interface.h
@@ -114,6 +114,12 @@ public:
     virtual void
     DisableForceInMemory(){};
 
+    virtual void
+    Move(InnerIdType from, InnerIdType to) {
+        throw VsagException(ErrorType::INTERNAL_ERROR,
+                            "Move not implemented in ExtraInfoInterface");
+    }
+
 public:
     InnerIdType total_count_{0};
     InnerIdType max_capacity_{0};

--- a/src/datacell/flatten_datacell.h
+++ b/src/datacell/flatten_datacell.h
@@ -118,6 +118,16 @@ public:
     void
     MergeOther(const FlattenInterfacePtr& other, InnerIdType bias) override;
 
+    void
+    Move(InnerIdType from, InnerIdType to) override;
+
+    void
+    ShrinkToFit(InnerIdType capacity) override {
+        uint64_t io_size = static_cast<uint64_t>(capacity) * static_cast<uint64_t>(code_size_);
+        this->io_->Shrink(io_size);
+        this->max_capacity_ = capacity;
+    }
+
     [[nodiscard]] std::string
     GetQuantizerName() override;
 
@@ -498,6 +508,18 @@ FlattenDataCell<QuantTmpl, IOTmpl>::GetMemoryUsage() const {
     }
     memory += sizeof(QuantTmpl);
     return memory;
+}
+
+template <typename QuantTmpl, typename IOTmpl>
+void
+FlattenDataCell<QuantTmpl, IOTmpl>::Move(InnerIdType from, InnerIdType to) {
+    bool need_release = false;
+    const uint8_t* codes = this->GetCodesById(from, need_release);
+    this->io_->Write(
+        codes, code_size_, static_cast<uint64_t>(to) * static_cast<uint64_t>(code_size_));
+    if (need_release) {
+        this->io_->Release(codes);
+    }
 }
 
 }  // namespace vsag

--- a/src/datacell/flatten_interface.h
+++ b/src/datacell/flatten_interface.h
@@ -193,6 +193,15 @@ public:
         throw VsagException(ErrorType::INTERNAL_ERROR, "MergeOther not implemented");
     }
 
+    virtual void
+    Move(InnerIdType from, InnerIdType to) {
+        throw VsagException(ErrorType::INTERNAL_ERROR, "Move not implemented in FlattenInterface");
+    }
+
+    virtual void
+    ShrinkToFit(InnerIdType capacity) {
+    }
+
 public:
     mutable std::shared_mutex mutex_;
 

--- a/src/datacell/graph_datacell.h
+++ b/src/datacell/graph_datacell.h
@@ -133,10 +133,21 @@ public:
         return std::make_shared<DenseDuplicateTracker>(allocator_);
     }
 
-private:
-    std::shared_ptr<BasicIO<IOTmpl>> io_{nullptr};
+    void
+    Move(InnerIdType from, InnerIdType to) override;
 
-    std::unique_ptr<ReverseEdge> reverse_edges_{nullptr};
+    void
+    ShrinkToFit(InnerIdType capacity) override {
+        uint64_t io_size = static_cast<uint64_t>(capacity) * static_cast<uint64_t>(code_line_size_);
+        this->io_->Shrink(io_size);
+        if (is_support_delete_) {
+            node_versions_.resize(capacity);
+        }
+        this->max_capacity_ = capacity;
+    }
+
+protected:
+    std::shared_ptr<BasicIO<IOTmpl>> io_{nullptr};
 
     Vector<uint8_t> node_versions_;
 
@@ -219,30 +230,11 @@ GraphDataCell<IOTmpl>::InsertNeighborsById(InnerIdType id,
     }
 
     // Update reverse edges if enabled
-    if (reverse_edges_) {
-        Vector<InnerIdType> old_neighbors(allocator_);
-        if (id < this->total_count_) {
-            this->GetNeighbors(id, old_neighbors);
-        }
-        UnorderedSet<InnerIdType> old_set(allocator_);
-        UnorderedSet<InnerIdType> new_set(allocator_);
-        for (const auto& n : old_neighbors) {
-            old_set.insert(n);
-        }
-        for (const auto& n : neighbor_ids) {
-            new_set.insert(n);
-        }
-        for (const auto& old_n : old_neighbors) {
-            if (new_set.find(old_n) == new_set.end()) {
-                reverse_edges_->RemoveReverseEdge(id, old_n);
-            }
-        }
-        for (const auto& new_n : neighbor_ids) {
-            if (old_set.find(new_n) == old_set.end()) {
-                reverse_edges_->AddReverseEdge(id, new_n);
-            }
-        }
+    Vector<InnerIdType> old_neighbors(allocator_);
+    if (reverse_edges_ && id < this->total_count_) {
+        this->GetNeighbors(id, old_neighbors);
     }
+    UpdateReverseEdges(id, old_neighbors, neighbor_ids);
 
     InnerIdType current = total_count_.load();
     while (current < id + 1 && !total_count_.compare_exchange_weak(current, id + 1)) {
@@ -391,6 +383,49 @@ GraphDataCell<IOTmpl>::RecoverDeleteNeighborsById(vsag::InnerIdType id) {
     } else {
         throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
                             "disable delete in graph datacell");
+    }
+}
+
+template <typename IOTmpl>
+void
+GraphDataCell<IOTmpl>::Move(InnerIdType from, InnerIdType to) {
+    if (from == to) {
+        return;
+    }
+
+    Vector<InnerIdType> reverse_neighbors(allocator_);
+    this->GetIncomingNeighbors(from, reverse_neighbors);
+
+    Vector<InnerIdType> neighbors(allocator_);
+    this->InsertNeighborsById(to, neighbors);
+    for (const auto& reverse_nb : reverse_neighbors) {
+        this->GetNeighbors(reverse_nb, neighbors);
+        Vector<InnerIdType> new_neighbors(allocator_);
+        bool has_to = false;
+        for (const auto& nb : neighbors) {
+            if (nb != from) {
+                new_neighbors.emplace_back(nb);
+            }
+            if (nb == to) {
+                has_to = true;
+            }
+        }
+        if (not has_to) {
+            new_neighbors.emplace_back(to);
+        }
+        this->InsertNeighborsById(reverse_nb, new_neighbors);
+        neighbors.clear();
+    }
+
+    Vector<InnerIdType> from_neighbors(allocator_);
+    this->GetNeighbors(from, from_neighbors);
+    this->InsertNeighborsById(to, from_neighbors);
+
+    from_neighbors.clear();
+    this->InsertNeighborsById(from, from_neighbors);
+
+    if (is_support_delete_) {
+        node_versions_[to] = node_versions_[from];
     }
 }
 

--- a/src/datacell/graph_datacell.h
+++ b/src/datacell/graph_datacell.h
@@ -133,10 +133,21 @@ public:
         return std::make_shared<DenseDuplicateTracker>(allocator_);
     }
 
-private:
-    std::shared_ptr<BasicIO<IOTmpl>> io_{nullptr};
+    void
+    Move(InnerIdType from, InnerIdType to) override;
 
-    std::unique_ptr<ReverseEdge> reverse_edges_{nullptr};
+    void
+    ShrinkToFit(InnerIdType capacity) override {
+        uint64_t io_size = static_cast<uint64_t>(capacity) * static_cast<uint64_t>(code_line_size_);
+        this->io_->Shrink(io_size);
+        if (is_support_delete_) {
+            node_versions_.resize(capacity);
+        }
+        this->max_capacity_ = capacity;
+    }
+
+protected:
+    std::shared_ptr<BasicIO<IOTmpl>> io_{nullptr};
 
     Vector<uint8_t> node_versions_;
 
@@ -219,30 +230,11 @@ GraphDataCell<IOTmpl>::InsertNeighborsById(InnerIdType id,
     }
 
     // Update reverse edges if enabled
-    if (reverse_edges_) {
-        Vector<InnerIdType> old_neighbors(allocator_);
-        if (id < this->total_count_) {
-            this->GetNeighbors(id, old_neighbors);
-        }
-        UnorderedSet<InnerIdType> old_set(allocator_);
-        UnorderedSet<InnerIdType> new_set(allocator_);
-        for (const auto& n : old_neighbors) {
-            old_set.insert(n);
-        }
-        for (const auto& n : neighbor_ids) {
-            new_set.insert(n);
-        }
-        for (const auto& old_n : old_neighbors) {
-            if (new_set.find(old_n) == new_set.end()) {
-                reverse_edges_->RemoveReverseEdge(id, old_n);
-            }
-        }
-        for (const auto& new_n : neighbor_ids) {
-            if (old_set.find(new_n) == old_set.end()) {
-                reverse_edges_->AddReverseEdge(id, new_n);
-            }
-        }
+    Vector<InnerIdType> old_neighbors(allocator_);
+    if (reverse_edges_ && id < this->total_count_) {
+        this->GetNeighbors(id, old_neighbors);
     }
+    UpdateReverseEdges(id, old_neighbors, neighbor_ids);
 
     InnerIdType current = total_count_.load();
     while (current < id + 1 && !total_count_.compare_exchange_weak(current, id + 1)) {
@@ -285,6 +277,10 @@ GraphDataCell<IOTmpl>::GetNeighbors(InnerIdType id, Vector<InnerIdType>& neighbo
     auto start = static_cast<uint64_t>(id) * static_cast<uint64_t>(this->code_line_size_);
     uint32_t neighbor_count = 0;
     this->io_->Read(sizeof(neighbor_count), start, (uint8_t*)(&neighbor_count));
+    if (neighbor_count > this->maximum_degree_) {
+        neighbor_ids.clear();
+        return;
+    }
     if (is_support_delete_) {
         neighbor_count &= remove_flag_mask_;
         start += sizeof(neighbor_count);
@@ -391,6 +387,49 @@ GraphDataCell<IOTmpl>::RecoverDeleteNeighborsById(vsag::InnerIdType id) {
     } else {
         throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
                             "disable delete in graph datacell");
+    }
+}
+
+template <typename IOTmpl>
+void
+GraphDataCell<IOTmpl>::Move(InnerIdType from, InnerIdType to) {
+    if (from == to) {
+        return;
+    }
+
+    Vector<InnerIdType> reverse_neighbors(allocator_);
+    this->GetIncomingNeighbors(from, reverse_neighbors);
+
+    Vector<InnerIdType> neighbors(allocator_);
+    this->InsertNeighborsById(to, neighbors);
+    for (const auto& reverse_nb : reverse_neighbors) {
+        this->GetNeighbors(reverse_nb, neighbors);
+        Vector<InnerIdType> new_neighbors(allocator_);
+        bool has_to = false;
+        for (const auto& nb : neighbors) {
+            if (nb != from) {
+                new_neighbors.emplace_back(nb);
+            }
+            if (nb == to) {
+                has_to = true;
+            }
+        }
+        if (not has_to) {
+            new_neighbors.emplace_back(to);
+        }
+        this->InsertNeighborsById(reverse_nb, new_neighbors);
+        neighbors.clear();
+    }
+
+    Vector<InnerIdType> from_neighbors(allocator_);
+    this->GetNeighbors(from, from_neighbors);
+    this->InsertNeighborsById(to, from_neighbors);
+
+    from_neighbors.clear();
+    this->InsertNeighborsById(from, from_neighbors);
+
+    if (is_support_delete_) {
+        node_versions_[to] = node_versions_[from];
     }
 }
 

--- a/src/datacell/graph_datacell_test.cpp
+++ b/src/datacell/graph_datacell_test.cpp
@@ -157,3 +157,113 @@ TEST_CASE("GraphDataCell duplicate tracker follows parameter", "[ut][GraphDataCe
     REQUIRE(enabled_graph->GetDuplicateIds(0) == std::vector<InnerIdType>{1});
     REQUIRE(enabled_graph->GetDuplicateIds(1) == std::vector<InnerIdType>{0});
 }
+
+TEST_CASE("GraphDataCell Reverse Edges", "[ut][GraphDataCell]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    auto dim = 32;
+    auto max_degree = 16;
+    auto io_type = "block_memory_io";
+    constexpr const char* graph_param_temp =
+        R"(
+        {{
+            "io_params": {{
+                "type": "{}"
+            }},
+            "max_degree": {},
+            "use_reverse_edges": true
+        }}
+        )";
+
+    IndexCommonParam common_param;
+    common_param.dim_ = dim;
+    common_param.allocator_ = allocator;
+    auto param_str = fmt::format(graph_param_temp, io_type, max_degree);
+    auto param_json = JsonType::Parse(param_str);
+    auto graph_param = GraphInterfaceParameter::GetGraphParameterByJson(
+        GraphStorageTypes::GRAPH_STORAGE_TYPE_VALUE_FLAT, param_json);
+
+    auto graph = GraphInterface::MakeInstance(graph_param, common_param);
+    GraphInterfaceTest test(graph);
+    test.ReverseEdgeTest(100);
+}
+
+TEST_CASE("GraphDataCell Move", "[ut][GraphDataCell]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    auto dim = 8;
+    auto max_degree = 8;
+    auto io_type = "block_memory_io";
+    constexpr const char* graph_param_temp =
+        R"(
+        {{
+            "io_params": {{
+                "type": "{}"
+            }},
+            "max_degree": {},
+            "use_reverse_edges": true
+        }}
+        )";
+
+    IndexCommonParam common_param;
+    common_param.dim_ = dim;
+    common_param.allocator_ = allocator;
+    auto param_str = fmt::format(graph_param_temp, io_type, max_degree);
+    auto param_json = JsonType::Parse(param_str);
+    auto graph_param = GraphInterfaceParameter::GetGraphParameterByJson(
+        GraphStorageTypes::GRAPH_STORAGE_TYPE_VALUE_FLAT, param_json);
+    auto origin_size = vsag::Options::Instance().block_size_limit();
+    auto size = 1024 * 1024 * 2ULL;
+    vsag::Options::Instance().set_block_size_limit(size);
+    auto graph = GraphInterface::MakeInstance(graph_param, common_param);
+    GraphInterfaceTest test(graph);
+    test.MoveTest(100);
+    vsag::Options::Instance().set_block_size_limit(origin_size);
+}
+
+TEST_CASE("GraphDataCell Move same id keeps neighbors", "[ut][GraphDataCell]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    constexpr int dim = 32;
+    constexpr int max_degree = 8;
+    constexpr const char* graph_param_temp =
+        R"(
+        {{
+            "io_params": {{
+                "type": "block_memory_io"
+            }},
+            "max_degree": {},
+            "use_reverse_edges": true
+        }}
+        )";
+
+    IndexCommonParam common_param;
+    common_param.dim_ = dim;
+    common_param.allocator_ = allocator;
+    auto param_str = fmt::format(graph_param_temp, max_degree);
+    auto param_json = JsonType::Parse(param_str);
+    auto graph_param = GraphInterfaceParameter::GetGraphParameterByJson(
+        GraphStorageTypes::GRAPH_STORAGE_TYPE_VALUE_FLAT, param_json);
+
+    auto graph = GraphInterface::MakeInstance(graph_param, common_param);
+    graph->Resize(4);
+
+    Vector<InnerIdType> empty(allocator.get());
+    Vector<InnerIdType> neighbors(allocator.get());
+    neighbors.emplace_back(1);
+    neighbors.emplace_back(2);
+
+    graph->InsertNeighborsById(0, neighbors);
+    graph->InsertNeighborsById(1, empty);
+    graph->InsertNeighborsById(2, empty);
+
+    graph->Move(0, 0);
+
+    Vector<InnerIdType> moved_neighbors(allocator.get());
+    graph->GetNeighbors(0, moved_neighbors);
+    REQUIRE(moved_neighbors.size() == 2);
+    REQUIRE(moved_neighbors[0] == 1);
+    REQUIRE(moved_neighbors[1] == 2);
+
+    Vector<InnerIdType> incoming(allocator.get());
+    graph->GetIncomingNeighbors(1, incoming);
+    REQUIRE(incoming.size() == 1);
+    REQUIRE(incoming[0] == 0);
+}

--- a/src/datacell/graph_datacell_test.cpp
+++ b/src/datacell/graph_datacell_test.cpp
@@ -159,3 +159,110 @@ TEST_CASE("GraphDataCell duplicate tracker follows parameter", "[ut][GraphDataCe
     REQUIRE(enabled_graph->GetDuplicateIds(0) == std::vector<InnerIdType>{1});
     REQUIRE(enabled_graph->GetDuplicateIds(1) == std::vector<InnerIdType>{0});
 }
+
+TEST_CASE("GraphDataCell Reverse Edges", "[ut][GraphDataCell]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    auto dim = 32;
+    auto max_degree = 32;
+    auto io_type = "block_memory_io";
+    constexpr const char* graph_param_temp =
+        R"(
+        {{
+            "io_params": {{
+                "type": "{}"
+            }},
+            "max_degree": {},
+            "use_reverse_edges": true
+        }}
+        )";
+
+    IndexCommonParam common_param;
+    common_param.dim_ = dim;
+    common_param.allocator_ = allocator;
+    auto param_str = fmt::format(graph_param_temp, io_type, max_degree);
+    auto param_json = JsonType::Parse(param_str);
+    auto graph_param = GraphInterfaceParameter::GetGraphParameterByJson(
+        GraphStorageTypes::GRAPH_STORAGE_TYPE_VALUE_FLAT, param_json);
+
+    auto graph = GraphInterface::MakeInstance(graph_param, common_param);
+    GraphInterfaceTest test(graph);
+    test.ReverseEdgeTest(100);
+}
+
+TEST_CASE("GraphDataCell Move", "[ut][GraphDataCell]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    auto dim = 32;
+    auto max_degree = 32;
+    auto io_type = "block_memory_io";
+    constexpr const char* graph_param_temp =
+        R"(
+        {{
+            "io_params": {{
+                "type": "{}"
+            }},
+            "max_degree": {},
+            "use_reverse_edges": true
+        }}
+        )";
+
+    IndexCommonParam common_param;
+    common_param.dim_ = dim;
+    common_param.allocator_ = allocator;
+    auto param_str = fmt::format(graph_param_temp, io_type, max_degree);
+    auto param_json = JsonType::Parse(param_str);
+    auto graph_param = GraphInterfaceParameter::GetGraphParameterByJson(
+        GraphStorageTypes::GRAPH_STORAGE_TYPE_VALUE_FLAT, param_json);
+
+    auto graph = GraphInterface::MakeInstance(graph_param, common_param);
+    GraphInterfaceTest test(graph);
+    test.MoveTest(100);
+}
+
+TEST_CASE("GraphDataCell Move same id keeps neighbors", "[ut][GraphDataCell]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    constexpr int dim = 32;
+    constexpr int max_degree = 8;
+    constexpr const char* graph_param_temp =
+        R"(
+        {{
+            "io_params": {{
+                "type": "block_memory_io"
+            }},
+            "max_degree": {},
+            "use_reverse_edges": true
+        }}
+        )";
+
+    IndexCommonParam common_param;
+    common_param.dim_ = dim;
+    common_param.allocator_ = allocator;
+    auto param_str = fmt::format(graph_param_temp, max_degree);
+    auto param_json = JsonType::Parse(param_str);
+    auto graph_param = GraphInterfaceParameter::GetGraphParameterByJson(
+        GraphStorageTypes::GRAPH_STORAGE_TYPE_VALUE_FLAT, param_json);
+
+    auto graph = GraphInterface::MakeInstance(graph_param, common_param);
+    graph->Resize(4);
+
+    Vector<InnerIdType> empty(allocator.get());
+    Vector<InnerIdType> neighbors(allocator.get());
+    neighbors.emplace_back(1);
+    neighbors.emplace_back(2);
+
+    graph->InsertNeighborsById(0, neighbors);
+    graph->InsertNeighborsById(1, empty);
+    graph->InsertNeighborsById(2, empty);
+
+    graph->Move(0, 0);
+
+    Vector<InnerIdType> moved_neighbors(allocator.get());
+    graph->GetNeighbors(0, moved_neighbors);
+    REQUIRE(moved_neighbors.size() == 2);
+    REQUIRE(moved_neighbors[0] == 1);
+    REQUIRE(moved_neighbors[1] == 2);
+
+    Vector<InnerIdType> incoming(allocator.get());
+    graph->GetIncomingNeighbors(1, incoming);
+    REQUIRE(incoming.size() == 1);
+    REQUIRE(incoming[0] == 0);
+}

--- a/src/datacell/graph_interface.cpp
+++ b/src/datacell/graph_interface.cpp
@@ -22,6 +22,32 @@
 
 namespace vsag {
 
+void
+GraphInterface::UpdateReverseEdges(InnerIdType id,
+                                   const Vector<InnerIdType>& old_neighbors,
+                                   const Vector<InnerIdType>& new_neighbors) {
+    if (reverse_edges_) {
+        UnorderedSet<InnerIdType> old_set(allocator_);
+        UnorderedSet<InnerIdType> new_set(allocator_);
+        for (const auto& n : old_neighbors) {
+            old_set.insert(n);
+        }
+        for (const auto& n : new_neighbors) {
+            new_set.insert(n);
+        }
+        for (const auto& old_n : old_neighbors) {
+            if (new_set.find(old_n) == new_set.end()) {
+                reverse_edges_->RemoveReverseEdge(id, old_n);
+            }
+        }
+        for (const auto& new_n : new_neighbors) {
+            if (old_set.find(new_n) == old_set.end()) {
+                reverse_edges_->AddReverseEdge(id, new_n);
+            }
+        }
+    }
+}
+
 GraphInterfacePtr
 GraphInterface::MakeInstance(const GraphInterfaceParamPtr& graph_param,
                              const IndexCommonParam& common_param) {

--- a/src/datacell/graph_interface.h
+++ b/src/datacell/graph_interface.h
@@ -22,6 +22,7 @@
 
 #include "duplicate_interface.h"
 #include "graph_interface_parameter.h"
+#include "impl/reverse_edge.h"
 #include "index_common_param.h"
 #include "inner_string_params.h"
 #include "io/io_parameter.h"
@@ -93,10 +94,22 @@ public:
 
     virtual void
     GetIncomingNeighbors(InnerIdType id, Vector<InnerIdType>& neighbors) const {
-        neighbors.clear();
+        if (reverse_edges_) {
+            reverse_edges_->GetIncomingNeighbors(id, neighbors);
+        } else {
+            neighbors.clear();
+        }
     }
 
-public:
+    virtual void
+    Move(InnerIdType from, InnerIdType to) {
+        throw VsagException(ErrorType::INTERNAL_ERROR, "Move not implemented in GraphInterface");
+    }
+
+    virtual void
+    ShrinkToFit(InnerIdType capacity) {
+    }
+
     virtual void
     Serialize(StreamWriter& writer) {
         StreamWriter::WriteObj(writer, this->total_count_);
@@ -166,6 +179,12 @@ public:
     InitIO(const IOParamPtr& io_param) {
     }
 
+protected:
+    void
+    UpdateReverseEdges(InnerIdType id,
+                       const Vector<InnerIdType>& old_neighbors,
+                       const Vector<InnerIdType>& new_neighbors);
+
 public:
     virtual DuplicateTrackerPtr
     CreateDuplicateTracker() {
@@ -222,6 +241,7 @@ public:
 
 protected:
     DuplicateTrackerPtr duplicate_tracker_{nullptr};
+    std::unique_ptr<ReverseEdge> reverse_edges_{nullptr};
 };
 
 }  // namespace vsag

--- a/src/datacell/graph_interface_test.cpp
+++ b/src/datacell/graph_interface_test.cpp
@@ -1,4 +1,3 @@
-
 // Copyright 2024-present the vsag project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,6 +14,7 @@
 
 #include "graph_interface_test.h"
 
+#include <algorithm>
 #include <fstream>
 #include <random>
 
@@ -184,20 +184,26 @@ GraphInterfaceTest::BasicTest(uint64_t max_id,
     }
 }
 
-std::unordered_map<InnerIdType, std::shared_ptr<Vector<InnerIdType>>>
+static std::unordered_map<InnerIdType, std::shared_ptr<Vector<InnerIdType>>>
 generate_graph(int count, int max_degree, Allocator* allocator) {
     std::unordered_map<InnerIdType, std::shared_ptr<Vector<InnerIdType>>> maps;
+    std::mt19937 rng(std::random_device{}());
+
     for (int i = 0; i < count; ++i) {
-        std::unordered_set<InnerIdType> unique_ids;
-        unique_ids.insert(i);
         maps[i] = std::make_shared<Vector<InnerIdType>>(allocator);
-        while (unique_ids.size() < max_degree + 1) {
-            InnerIdType new_neighbor = random() % count;
-            auto iter = unique_ids.insert(new_neighbor);
-            if (iter.second) {
-                maps[i]->push_back(new_neighbor);
+
+        std::vector<InnerIdType> candidates;
+        candidates.reserve(count - 1);
+        for (int j = 0; j < count; ++j) {
+            if (j != i) {
+                candidates.push_back(static_cast<InnerIdType>(j));
             }
         }
+
+        int k = std::min(max_degree, count - 1);
+        std::shuffle(candidates.begin(), candidates.begin() + k, rng);
+
+        maps[i]->insert(maps[i]->end(), candidates.begin(), candidates.begin() + k);
     }
     return maps;
 }
@@ -250,4 +256,121 @@ GraphInterfaceTest::MergeTest(GraphInterfacePtr& other, int count) {
                     0);
         }
     }
+}
+
+void
+GraphInterfaceTest::ReverseEdgeTest(int count) {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    auto max_degree = this->graph_->MaximumDegree();
+    this->graph_->Resize(count);
+
+    std::unordered_map<InnerIdType, std::shared_ptr<Vector<InnerIdType>>> maps =
+        generate_graph(count, max_degree, allocator.get());
+
+    for (auto& [key, value] : maps) {
+        this->graph_->InsertNeighborsById(key, *value);
+    }
+
+    auto test_func = [&]() {
+        std::unordered_map<InnerIdType, std::vector<InnerIdType>> expected_reverse(count);
+        for (int i = 0; i < count; ++i) {
+            Vector<InnerIdType> neighs(allocator.get());
+            this->graph_->GetNeighbors(i, neighs);
+            for (auto nei : neighs) {
+                expected_reverse[nei].emplace_back(i);
+            }
+        }
+
+        for (int i = 0; i < count; ++i) {
+            Vector<InnerIdType> incoming(allocator.get());
+            this->graph_->GetIncomingNeighbors(i, incoming);
+            auto it = expected_reverse.find(i);
+            if (it != expected_reverse.end()) {
+                std::sort(incoming.begin(), incoming.end());
+                auto expected = it->second;
+                std::sort(expected.begin(), expected.end());
+                REQUIRE(incoming.size() == expected.size());
+                REQUIRE(memcmp(incoming.data(),
+                               expected.data(),
+                               incoming.size() * sizeof(InnerIdType)) == 0);
+            } else {
+                REQUIRE(incoming.empty());
+            }
+        }
+    };
+
+    SECTION("Test GetIncomingNeighbors") {
+        test_func();
+    }
+
+    SECTION("Test Update Reverse Edges") {
+        InnerIdType test_id = 0;
+        Vector<InnerIdType> old_neighbors(allocator.get());
+        this->graph_->GetNeighbors(test_id, old_neighbors);
+
+        Vector<InnerIdType> new_neighbors(allocator.get());
+        for (int i = 0; i < max_degree && i < count - 1; ++i) {
+            new_neighbors.push_back(i + 10);
+        }
+        this->graph_->InsertNeighborsById(test_id, new_neighbors);
+        Vector<InnerIdType> get_neighbors(allocator.get());
+        this->graph_->GetNeighbors(test_id, get_neighbors);
+        REQUIRE(memcmp(get_neighbors.data(),
+                       new_neighbors.data(),
+                       get_neighbors.size() * sizeof(InnerIdType)) == 0);
+        test_func();
+    }
+}
+
+void
+GraphInterfaceTest::MoveTest(int count) {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    auto max_degree = this->graph_->MaximumDegree();
+    this->graph_->Resize(count * 2);
+
+    std::unordered_map<InnerIdType, std::shared_ptr<Vector<InnerIdType>>> maps =
+        generate_graph(count, max_degree, allocator.get());
+
+    for (auto& [key, value] : maps) {
+        this->graph_->InsertNeighborsById(key, *value);
+    }
+    constexpr int move_count = 20;
+    for (int ii = 0; ii < move_count; ++ii) {
+        InnerIdType from = count - 1 - ii;
+        InnerIdType to = ii;
+
+        this->graph_->Move(from, to);
+    }
+    count -= move_count;
+
+    auto test_func = [&]() {
+        std::unordered_map<InnerIdType, std::vector<InnerIdType>> expected_reverse(count);
+        for (int i = 0; i < count; ++i) {
+            Vector<InnerIdType> neighs(allocator.get());
+            this->graph_->GetNeighbors(i, neighs);
+            for (auto nei : neighs) {
+                REQUIRE(nei < count);
+                expected_reverse[nei].emplace_back(i);
+            }
+        }
+
+        for (int i = 0; i < count; ++i) {
+            Vector<InnerIdType> incoming(allocator.get());
+            this->graph_->GetIncomingNeighbors(i, incoming);
+            auto it = expected_reverse.find(i);
+            if (it != expected_reverse.end()) {
+                std::sort(incoming.begin(), incoming.end());
+                auto expected = it->second;
+                std::sort(expected.begin(), expected.end());
+                REQUIRE(incoming.size() == expected.size());
+                REQUIRE(memcmp(incoming.data(),
+                               expected.data(),
+                               incoming.size() * sizeof(InnerIdType)) == 0);
+            } else {
+                REQUIRE(incoming.empty());
+            }
+        }
+    };
+
+    test_func();
 }

--- a/src/datacell/graph_interface_test.cpp
+++ b/src/datacell/graph_interface_test.cpp
@@ -1,4 +1,3 @@
-
 // Copyright 2024-present the vsag project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -251,4 +250,121 @@ GraphInterfaceTest::MergeTest(GraphInterfacePtr& other, int count) {
                     0);
         }
     }
+}
+
+void
+GraphInterfaceTest::ReverseEdgeTest(int count) {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    auto max_degree = this->graph_->MaximumDegree();
+    this->graph_->Resize(count);
+
+    std::unordered_map<InnerIdType, std::shared_ptr<Vector<InnerIdType>>> maps =
+        generate_graph(count, max_degree, allocator.get());
+
+    for (auto& [key, value] : maps) {
+        this->graph_->InsertNeighborsById(key, *value);
+    }
+
+    auto test_func = [&]() {
+        std::unordered_map<InnerIdType, std::vector<InnerIdType>> expected_reverse(count);
+        for (int i = 0; i < count; ++i) {
+            Vector<InnerIdType> neighs(allocator.get());
+            this->graph_->GetNeighbors(i, neighs);
+            for (auto nei : neighs) {
+                expected_reverse[nei].emplace_back(i);
+            }
+        }
+
+        for (int i = 0; i < count; ++i) {
+            Vector<InnerIdType> incoming(allocator.get());
+            this->graph_->GetIncomingNeighbors(i, incoming);
+            auto it = expected_reverse.find(i);
+            if (it != expected_reverse.end()) {
+                std::sort(incoming.begin(), incoming.end());
+                auto expected = it->second;
+                std::sort(expected.begin(), expected.end());
+                REQUIRE(incoming.size() == expected.size());
+                REQUIRE(memcmp(incoming.data(),
+                               expected.data(),
+                               incoming.size() * sizeof(InnerIdType)) == 0);
+            } else {
+                REQUIRE(incoming.empty());
+            }
+        }
+    };
+
+    SECTION("Test GetIncomingNeighbors") {
+        test_func();
+    }
+
+    SECTION("Test Update Reverse Edges") {
+        InnerIdType test_id = 0;
+        Vector<InnerIdType> old_neighbors(allocator.get());
+        this->graph_->GetNeighbors(test_id, old_neighbors);
+
+        Vector<InnerIdType> new_neighbors(allocator.get());
+        for (int i = 0; i < max_degree && i < count - 1; ++i) {
+            new_neighbors.push_back(i + 10);
+        }
+        this->graph_->InsertNeighborsById(test_id, new_neighbors);
+        Vector<InnerIdType> get_neighbors(allocator.get());
+        this->graph_->GetNeighbors(test_id, get_neighbors);
+        REQUIRE(memcmp(get_neighbors.data(),
+                       new_neighbors.data(),
+                       get_neighbors.size() * sizeof(InnerIdType)) == 0);
+        test_func();
+    }
+}
+
+void
+GraphInterfaceTest::MoveTest(int count) {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    auto max_degree = this->graph_->MaximumDegree();
+    this->graph_->Resize(count * 2);
+
+    std::unordered_map<InnerIdType, std::shared_ptr<Vector<InnerIdType>>> maps =
+        generate_graph(count, max_degree, allocator.get());
+
+    for (auto& [key, value] : maps) {
+        this->graph_->InsertNeighborsById(key, *value);
+    }
+    constexpr int move_count = 20;
+    for (int ii = 0; ii < move_count; ++ii) {
+        InnerIdType from = count - 1 - ii;
+        InnerIdType to = ii;
+
+        this->graph_->Move(from, to);
+    }
+    count -= move_count;
+
+    auto test_func = [&]() {
+        std::unordered_map<InnerIdType, std::vector<InnerIdType>> expected_reverse(count);
+        for (int i = 0; i < count; ++i) {
+            Vector<InnerIdType> neighs(allocator.get());
+            this->graph_->GetNeighbors(i, neighs);
+            for (auto nei : neighs) {
+                REQUIRE(nei < count);
+                expected_reverse[nei].emplace_back(i);
+            }
+        }
+
+        for (int i = 0; i < count; ++i) {
+            Vector<InnerIdType> incoming(allocator.get());
+            this->graph_->GetIncomingNeighbors(i, incoming);
+            auto it = expected_reverse.find(i);
+            if (it != expected_reverse.end()) {
+                std::sort(incoming.begin(), incoming.end());
+                auto expected = it->second;
+                std::sort(expected.begin(), expected.end());
+                REQUIRE(incoming.size() == expected.size());
+                REQUIRE(memcmp(incoming.data(),
+                               expected.data(),
+                               incoming.size() * sizeof(InnerIdType)) == 0);
+            } else {
+                REQUIRE(incoming.empty());
+            }
+        }
+    };
+
+    test_func();
 }

--- a/src/datacell/graph_interface_test.h
+++ b/src/datacell/graph_interface_test.h
@@ -33,6 +33,12 @@ public:
     void
     MergeTest(GraphInterfacePtr& other, int count);
 
+    void
+    ReverseEdgeTest(int count);
+
+    void
+    MoveTest(int count);
+
 public:
     GraphInterfacePtr graph_{nullptr};
     bool require_sorted_{false};

--- a/src/datacell/sparse_graph_datacell.cpp
+++ b/src/datacell/sparse_graph_datacell.cpp
@@ -33,6 +33,9 @@ SparseGraphDataCell::SparseGraphDataCell(const SparseGraphDatacellParamPtr& grap
     if (graph_param->support_duplicate_) {
         this->InitDuplicateTracker();
     }
+    if (graph_param->use_reverse_edges_) {
+        this->reverse_edges_ = std::make_unique<ReverseEdge>(allocator);
+    }
 }
 
 SparseGraphDataCell::SparseGraphDataCell(const SparseGraphDatacellParamPtr& graph_param,
@@ -55,6 +58,8 @@ SparseGraphDataCell::InsertNeighborsById(InnerIdType id, const Vector<InnerIdTyp
     auto size = std::min(this->maximum_degree_, (uint32_t)(neighbor_ids.size()));
     std::unique_lock<std::shared_mutex> wlock(this->neighbors_map_mutex_);
     this->max_capacity_ = std::max(this->max_capacity_, id + 1);
+
+    Vector<InnerIdType> old_neighbors(allocator_);
     auto iter = this->neighbors_.find(id);
     if (iter == this->neighbors_.end()) {
         iter =
@@ -63,7 +68,23 @@ SparseGraphDataCell::InsertNeighborsById(InnerIdType id, const Vector<InnerIdTyp
         if (is_support_delete_) {
             node_version_[id] = 0;
         }
+    } else {
+        old_neighbors.reserve(iter->second->size());
+        for (const auto& old_neighbor : *iter->second) {
+            old_neighbors.emplace_back(is_support_delete_ ? (old_neighbor & remove_flag_mask_)
+                                                          : old_neighbor);
+        }
     }
+
+    wlock.unlock();
+    UpdateReverseEdges(id, old_neighbors, neighbor_ids);
+    wlock.lock();
+    iter = this->neighbors_.find(id);
+    if (iter == this->neighbors_.end()) {
+        iter =
+            this->neighbors_.emplace(id, std::make_unique<Vector<InnerIdType>>(allocator_)).first;
+    }
+
     if (is_support_delete_) {
         iter->second->resize(size);
         for (int i = 0; i < size; ++i) {
@@ -248,7 +269,67 @@ SparseGraphDataCell::GetMemoryUsage() const {
     memory += neighbors_.size() * (sizeof(InnerIdType) + maximum_degree_ * sizeof(InnerIdType) +
                                    sizeof(std::nullptr_t));
     memory += node_version_.size() * (sizeof(uint8_t) + sizeof(InnerIdType));
+    if (reverse_edges_) {
+        memory += reverse_edges_->GetMemoryUsage();
+    }
     return static_cast<int64_t>(memory);
+}
+
+void
+SparseGraphDataCell::GetIncomingNeighbors(InnerIdType id, Vector<InnerIdType>& neighbors) const {
+    if (reverse_edges_) {
+        reverse_edges_->GetIncomingNeighbors(id, neighbors);
+    } else {
+        neighbors.clear();
+    }
+}
+
+void
+SparseGraphDataCell::Move(InnerIdType from, InnerIdType to) {
+    if (from == to) {
+        return;
+    }
+
+    {
+        std::shared_lock<std::shared_mutex> rlock(this->neighbors_map_mutex_);
+        if (neighbors_.count(from) == 0) {
+            return;
+        }
+    }
+
+    Vector<InnerIdType> reverse_neighbors(allocator_);
+    this->GetIncomingNeighbors(from, reverse_neighbors);
+
+    Vector<InnerIdType> neighbors(allocator_);
+    this->InsertNeighborsById(to, neighbors);
+    for (const auto& reverse_nb : reverse_neighbors) {
+        this->GetNeighbors(reverse_nb, neighbors);
+        Vector<InnerIdType> new_neighbors(allocator_);
+        bool has_to = false;
+        for (const auto& nb : neighbors) {
+            if (nb != from) {
+                new_neighbors.emplace_back(nb);
+            }
+            if (nb == to) {
+                has_to = true;
+            }
+        }
+        if (not has_to) {
+            new_neighbors.emplace_back(to);
+        }
+        this->InsertNeighborsById(reverse_nb, new_neighbors);
+        neighbors.clear();
+    }
+
+    Vector<InnerIdType> from_neighbors(allocator_);
+    this->GetNeighbors(from, from_neighbors);
+    this->InsertNeighborsById(to, from_neighbors);
+
+    from_neighbors.clear();
+    this->InsertNeighborsById(from, from_neighbors);
+
+    std::unique_lock<std::shared_mutex> wlock(this->neighbors_map_mutex_);
+    this->neighbors_.erase(from);
 }
 
 }  // namespace vsag

--- a/src/datacell/sparse_graph_datacell.h
+++ b/src/datacell/sparse_graph_datacell.h
@@ -85,6 +85,16 @@ public:
         return std::make_shared<SparseDuplicateTracker>(allocator_);
     }
 
+    void
+    GetIncomingNeighbors(InnerIdType id, Vector<InnerIdType>& neighbors) const override;
+
+    void
+    Move(InnerIdType from, InnerIdType to) override;
+
+    void
+    ShrinkToFit(InnerIdType capacity) override {
+    }
+
 private:
     uint32_t code_line_size_{0};
     Allocator* const allocator_{nullptr};

--- a/src/datacell/sparse_graph_datacell_parameter.cpp
+++ b/src/datacell/sparse_graph_datacell_parameter.cpp
@@ -36,6 +36,9 @@ SparseGraphDatacellParameter::FromJson(const JsonType& json) {
     if (json.Contains(SUPPORT_DUPLICATE)) {
         this->support_duplicate_ = json[SUPPORT_DUPLICATE].GetBool();
     }
+    if (json.Contains(HGRAPH_USE_REVERSE_EDGES_KEY)) {
+        this->use_reverse_edges_ = json[HGRAPH_USE_REVERSE_EDGES_KEY].GetBool();
+    }
 }
 
 JsonType
@@ -45,6 +48,7 @@ SparseGraphDatacellParameter::ToJson() const {
     json[GRAPH_SUPPORT_REMOVE].SetBool(this->support_delete_);
     json[REMOVE_FLAG_BIT].SetInt(this->remove_flag_bit_);
     json[SUPPORT_DUPLICATE].SetBool(this->support_duplicate_);
+    json[HGRAPH_USE_REVERSE_EDGES_KEY].SetBool(this->use_reverse_edges_);
     return json;
 }
 
@@ -84,6 +88,14 @@ SparseGraphDatacellParameter::CheckCompatibility(const ParamPtr& other) const {
             "{}",
             support_duplicate_,
             graph_param->support_duplicate_);
+        return false;
+    }
+    if (use_reverse_edges_ != graph_param->use_reverse_edges_) {
+        logger::error(
+            "SparseGraphDatacellParameter::CheckCompatibility: use_reverse_edges_ mismatch: {} "
+            "vs {}",
+            use_reverse_edges_,
+            graph_param->use_reverse_edges_);
         return false;
     }
     return true;

--- a/src/datacell/sparse_graph_datacell_test.cpp
+++ b/src/datacell/sparse_graph_datacell_test.cpp
@@ -87,3 +87,113 @@ TEST_CASE("SparseGraphDataCell Merge Test", "[ut][SparseGraphDataCell]") {
     auto other = GraphInterface::MakeInstance(graph_param, common_param);
     test.MergeTest(other, count);
 }
+
+TEST_CASE("SparseGraphDataCell Reverse Edges", "[ut][SparseGraphDataCell]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    auto dim = 32;
+    auto max_degree = 32;
+
+    IndexCommonParam common_param;
+    common_param.dim_ = dim;
+    common_param.allocator_ = allocator;
+    auto graph_param = std::make_shared<SparseGraphDatacellParameter>();
+    graph_param->max_degree_ = max_degree;
+    graph_param->use_reverse_edges_ = true;
+
+    auto graph = GraphInterface::MakeInstance(graph_param, common_param);
+    GraphInterfaceTest test(graph);
+    test.ReverseEdgeTest(100);
+}
+
+TEST_CASE("SparseGraphDataCell Move", "[ut][SparseGraphDataCell]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    auto dim = 32;
+    auto max_degree = 32;
+
+    IndexCommonParam common_param;
+    common_param.dim_ = dim;
+    common_param.allocator_ = allocator;
+    auto graph_param = std::make_shared<SparseGraphDatacellParameter>();
+    graph_param->max_degree_ = max_degree;
+    graph_param->use_reverse_edges_ = true;
+
+    auto graph = GraphInterface::MakeInstance(graph_param, common_param);
+    GraphInterfaceTest test(graph);
+    test.MoveTest(100);
+}
+
+TEST_CASE("SparseGraphDataCell Move same id keeps neighbors", "[ut][SparseGraphDataCell]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+
+    IndexCommonParam common_param;
+    common_param.dim_ = 32;
+    common_param.allocator_ = allocator;
+    auto graph_param = std::make_shared<SparseGraphDatacellParameter>();
+    graph_param->max_degree_ = 8;
+    graph_param->use_reverse_edges_ = true;
+
+    auto graph = GraphInterface::MakeInstance(graph_param, common_param);
+
+    Vector<InnerIdType> empty(allocator.get());
+    Vector<InnerIdType> neighbors(allocator.get());
+    neighbors.emplace_back(1);
+    neighbors.emplace_back(2);
+
+    graph->InsertNeighborsById(0, neighbors);
+    graph->InsertNeighborsById(1, empty);
+    graph->InsertNeighborsById(2, empty);
+
+    graph->Move(0, 0);
+
+    Vector<InnerIdType> moved_neighbors(allocator.get());
+    graph->GetNeighbors(0, moved_neighbors);
+    REQUIRE(moved_neighbors.size() == 2);
+    REQUIRE(moved_neighbors[0] == 1);
+    REQUIRE(moved_neighbors[1] == 2);
+
+    Vector<InnerIdType> incoming(allocator.get());
+    graph->GetIncomingNeighbors(1, incoming);
+    REQUIRE(incoming.size() == 1);
+    REQUIRE(incoming[0] == 0);
+}
+
+TEST_CASE("SparseGraphDataCell decodes stored neighbors for reverse-edge updates",
+          "[ut][SparseGraphDataCell]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+
+    IndexCommonParam common_param;
+    common_param.dim_ = 32;
+    common_param.allocator_ = allocator;
+    auto graph_param = std::make_shared<SparseGraphDatacellParameter>();
+    graph_param->max_degree_ = 8;
+    graph_param->support_delete_ = true;
+    graph_param->remove_flag_bit_ = 4;
+    graph_param->use_reverse_edges_ = true;
+
+    auto graph = GraphInterface::MakeInstance(graph_param, common_param);
+
+    Vector<InnerIdType> empty(allocator.get());
+    Vector<InnerIdType> to_two(allocator.get());
+    Vector<InnerIdType> to_three(allocator.get());
+    to_two.emplace_back(2);
+    to_three.emplace_back(3);
+
+    graph->InsertNeighborsById(2, empty);
+    graph->InsertNeighborsById(3, empty);
+    graph->DeleteNeighborsById(2);
+    graph->InsertNeighborsById(1, to_two);
+
+    Vector<InnerIdType> incoming(allocator.get());
+    graph->GetIncomingNeighbors(2, incoming);
+    REQUIRE(incoming.size() == 1);
+    REQUIRE(incoming[0] == 1);
+
+    graph->InsertNeighborsById(1, to_three);
+
+    graph->GetIncomingNeighbors(2, incoming);
+    REQUIRE(incoming.empty());
+
+    graph->GetIncomingNeighbors(3, incoming);
+    REQUIRE(incoming.size() == 1);
+    REQUIRE(incoming[0] == 1);
+}

--- a/src/datacell/sparse_graph_datacell_test.cpp
+++ b/src/datacell/sparse_graph_datacell_test.cpp
@@ -89,3 +89,113 @@ TEST_CASE("SparseGraphDataCell Merge Test", "[ut][SparseGraphDataCell]") {
     auto other = GraphInterface::MakeInstance(graph_param, common_param);
     test.MergeTest(other, count);
 }
+
+TEST_CASE("SparseGraphDataCell Reverse Edges", "[ut][SparseGraphDataCell]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    auto dim = 32;
+    auto max_degree = 32;
+
+    IndexCommonParam common_param;
+    common_param.dim_ = dim;
+    common_param.allocator_ = allocator;
+    auto graph_param = std::make_shared<SparseGraphDatacellParameter>();
+    graph_param->max_degree_ = max_degree;
+    graph_param->use_reverse_edges_ = true;
+
+    auto graph = GraphInterface::MakeInstance(graph_param, common_param);
+    GraphInterfaceTest test(graph);
+    test.ReverseEdgeTest(100);
+}
+
+TEST_CASE("SparseGraphDataCell Move", "[ut][SparseGraphDataCell]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    auto dim = 32;
+    auto max_degree = 32;
+
+    IndexCommonParam common_param;
+    common_param.dim_ = dim;
+    common_param.allocator_ = allocator;
+    auto graph_param = std::make_shared<SparseGraphDatacellParameter>();
+    graph_param->max_degree_ = max_degree;
+    graph_param->use_reverse_edges_ = true;
+
+    auto graph = GraphInterface::MakeInstance(graph_param, common_param);
+    GraphInterfaceTest test(graph);
+    test.MoveTest(100);
+}
+
+TEST_CASE("SparseGraphDataCell Move same id keeps neighbors", "[ut][SparseGraphDataCell]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+
+    IndexCommonParam common_param;
+    common_param.dim_ = 32;
+    common_param.allocator_ = allocator;
+    auto graph_param = std::make_shared<SparseGraphDatacellParameter>();
+    graph_param->max_degree_ = 8;
+    graph_param->use_reverse_edges_ = true;
+
+    auto graph = GraphInterface::MakeInstance(graph_param, common_param);
+
+    Vector<InnerIdType> empty(allocator.get());
+    Vector<InnerIdType> neighbors(allocator.get());
+    neighbors.emplace_back(1);
+    neighbors.emplace_back(2);
+
+    graph->InsertNeighborsById(0, neighbors);
+    graph->InsertNeighborsById(1, empty);
+    graph->InsertNeighborsById(2, empty);
+
+    graph->Move(0, 0);
+
+    Vector<InnerIdType> moved_neighbors(allocator.get());
+    graph->GetNeighbors(0, moved_neighbors);
+    REQUIRE(moved_neighbors.size() == 2);
+    REQUIRE(moved_neighbors[0] == 1);
+    REQUIRE(moved_neighbors[1] == 2);
+
+    Vector<InnerIdType> incoming(allocator.get());
+    graph->GetIncomingNeighbors(1, incoming);
+    REQUIRE(incoming.size() == 1);
+    REQUIRE(incoming[0] == 0);
+}
+
+TEST_CASE("SparseGraphDataCell decodes stored neighbors for reverse-edge updates",
+          "[ut][SparseGraphDataCell]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+
+    IndexCommonParam common_param;
+    common_param.dim_ = 32;
+    common_param.allocator_ = allocator;
+    auto graph_param = std::make_shared<SparseGraphDatacellParameter>();
+    graph_param->max_degree_ = 8;
+    graph_param->support_delete_ = true;
+    graph_param->remove_flag_bit_ = 4;
+    graph_param->use_reverse_edges_ = true;
+
+    auto graph = GraphInterface::MakeInstance(graph_param, common_param);
+
+    Vector<InnerIdType> empty(allocator.get());
+    Vector<InnerIdType> to_two(allocator.get());
+    Vector<InnerIdType> to_three(allocator.get());
+    to_two.emplace_back(2);
+    to_three.emplace_back(3);
+
+    graph->InsertNeighborsById(2, empty);
+    graph->InsertNeighborsById(3, empty);
+    graph->DeleteNeighborsById(2);
+    graph->InsertNeighborsById(1, to_two);
+
+    Vector<InnerIdType> incoming(allocator.get());
+    graph->GetIncomingNeighbors(2, incoming);
+    REQUIRE(incoming.size() == 1);
+    REQUIRE(incoming[0] == 1);
+
+    graph->InsertNeighborsById(1, to_three);
+
+    graph->GetIncomingNeighbors(2, incoming);
+    REQUIRE(incoming.empty());
+
+    graph->GetIncomingNeighbors(3, incoming);
+    REQUIRE(incoming.size() == 1);
+    REQUIRE(incoming[0] == 1);
+}

--- a/src/impl/label_table.h
+++ b/src/impl/label_table.h
@@ -353,6 +353,29 @@ public:
         return false;
     }
 
+    void
+    Move(InnerIdType from, InnerIdType to) {
+        if (from == to) {
+            return;
+        }
+
+        if (use_reverse_map_) {
+            label_remap_.erase(label_table_[to]);
+        }
+        label_table_[to] = label_table_[from];
+        if (use_reverse_map_) {
+            label_remap_[label_table_[to]] = to;
+        }
+    }
+
+    void
+    ShrinkToFit(InnerIdType capacity) {
+        label_table_.resize(capacity);
+        if (duplicate_tracker_ != nullptr) {
+            duplicate_tracker_->Resize(capacity);
+        }
+    }
+
 private:
     UnorderedSet<InnerIdType> deleted_ids_;       // Record deleted ids.
     FilterPtr deleted_ids_filter_{nullptr};       // Filter to filter out deleted ids.

--- a/src/impl/label_table_test.cpp
+++ b/src/impl/label_table_test.cpp
@@ -385,3 +385,54 @@ TEST_CASE("LabelTable Hole List Serialization", "[ut][LabelTable]") {
         REQUIRE(s1 == false);
     }
 }
+
+TEST_CASE("LabelTable Move", "[ut][LabelTable]") {
+    auto allocator = std::make_shared<DefaultAllocator>();
+
+    SECTION("Move with reverse map") {
+        LabelTable label_table(allocator.get(), true);
+        label_table.Resize(5);
+        label_table.Insert(0, 100);
+        label_table.Insert(1, 200);
+        label_table.Insert(2, 300);
+
+        label_table.Move(0, 3);
+
+        REQUIRE(label_table.GetLabelById(3) == 100);
+        REQUIRE(label_table.GetIdByLabel(100) == 3);
+    }
+
+    SECTION("Move without reverse map") {
+        LabelTable label_table(allocator.get(), false);
+        label_table.Resize(5);
+        label_table.Insert(0, 100);
+        label_table.Insert(1, 200);
+
+        label_table.Move(0, 2);
+
+        REQUIRE(label_table.GetLabelById(2) == 100);
+    }
+
+    SECTION("Move updates reverse map correctly") {
+        LabelTable label_table(allocator.get(), true);
+        label_table.Resize(10);
+        label_table.Insert(0, 100);
+        label_table.Insert(1, 200);
+
+        label_table.Move(0, 5);
+
+        REQUIRE(label_table.GetIdByLabel(100) == 5);
+        REQUIRE(label_table.GetLabelById(5) == 100);
+    }
+
+    SECTION("Move to same id is no-op") {
+        LabelTable label_table(allocator.get(), true);
+        label_table.Resize(5);
+        label_table.Insert(0, 100);
+
+        label_table.Move(0, 0);
+
+        REQUIRE(label_table.GetLabelById(0) == 100);
+        REQUIRE(label_table.GetIdByLabel(100) == 0);
+    }
+}

--- a/src/impl/pruning_strategy.cpp
+++ b/src/impl/pruning_strategy.cpp
@@ -22,6 +22,28 @@
 namespace vsag {
 
 void
+select_edges_by_heuristic(Vector<InnerIdType>& neighbors,
+                          InnerIdType node_id,
+                          uint64_t max_size,
+                          const FlattenInterfacePtr& flatten,
+                          Allocator* allocator,
+                          float alpha) {
+    auto edges = std::make_shared<StandardHeap<true, false>>(allocator, -1);
+    for (const auto& neighbor : neighbors) {
+        float dist = flatten->ComputePairVectors(node_id, neighbor);
+        edges->Push(dist, neighbor);
+    }
+
+    select_edges_by_heuristic(edges, max_size, flatten, allocator, alpha);
+
+    neighbors.clear();
+    while (not edges->Empty()) {
+        neighbors.emplace_back(edges->Top().second);
+        edges->Pop();
+    }
+}
+
+void
 select_edges_by_heuristic(const DistHeapPtr& edges,
                           uint64_t max_size,
                           const FlattenInterfacePtr& flatten,

--- a/src/impl/pruning_strategy.h
+++ b/src/impl/pruning_strategy.h
@@ -25,6 +25,21 @@ DEFINE_POINTER(FlattenInterface);
 DEFINE_POINTER(GraphInterface);
 DEFINE_POINTER(MutexArray);
 
+/**
+ * @brief Selects edges using heuristic pruning on a distance heap.
+ *
+ * This function applies a diversity-based heuristic to select up to max_size edges
+ * from the given heap. It prefers edges that are both close to the query point and
+ * well-distributed in the vector space, avoiding redundant neighbors.
+ *
+ * @param edges Distance heap containing candidate edges (distance, id pairs).
+ *              Modified in-place to contain selected edges.
+ * @param max_size Maximum number of edges to select.
+ * @param flatten Flatten interface for computing pairwise vector distances.
+ * @param allocator Allocator for memory management.
+ * @param alpha Diversity parameter controlling the trade-off between proximity
+ *              and diversity. Higher values allow more diverse neighbors.
+ */
 void
 select_edges_by_heuristic(const DistHeapPtr& edges,
                           uint64_t max_size,
@@ -32,6 +47,48 @@ select_edges_by_heuristic(const DistHeapPtr& edges,
                           Allocator* allocator,
                           float alpha = 1.0F);
 
+/**
+ * @brief Selects edges using heuristic pruning on a neighbor vector.
+ *
+ * This overload computes distances from node_id to each neighbor and applies
+ * the same diversity-based heuristic as the heap version. Selected neighbors
+ * are stored back into the neighbors vector.
+ *
+ * @param neighbors Vector of neighbor IDs to be filtered. Modified in-place
+ *                  to contain only the selected neighbors.
+ * @param node_id The reference node ID for computing distances to neighbors.
+ * @param max_size Maximum number of neighbors to select.
+ * @param flatten Flatten interface for computing pairwise vector distances.
+ * @param allocator Allocator for memory management.
+ * @param alpha Diversity parameter controlling the trade-off between proximity
+ *              and diversity. Higher values allow more diverse neighbors.
+ */
+void
+select_edges_by_heuristic(Vector<InnerIdType>& neighbors,
+                          InnerIdType node_id,
+                          uint64_t max_size,
+                          const FlattenInterfacePtr& flatten,
+                          Allocator* allocator,
+                          float alpha = 1.0F);
+
+/**
+ * @brief Connects a new element to the graph using mutual edge selection.
+ *
+ * This function inserts a new element into the graph by selecting its neighbors
+ * using the heuristic edge selection, and then updating all selected neighbors
+ * to maintain bidirectional connections. If a neighbor's degree exceeds max_size,
+ * it triggers re-selection of that neighbor's edges.
+ *
+ * @param cur_c The ID of the new element to be connected.
+ * @param top_candidates Distance heap containing candidate neighbors for cur_c.
+ * @param graph Graph interface for storing and retrieving neighbor connections.
+ * @param flatten Flatten interface for computing pairwise vector distances.
+ * @param neighbors_mutexes Mutex array for thread-safe neighbor updates.
+ * @param allocator Allocator for memory management.
+ * @param alpha Diversity parameter for heuristic edge selection.
+ * @return InnerIdType The ID of the farthest selected neighbor, typically used
+ *                     as an entry point for subsequent operations.
+ */
 InnerIdType
 mutually_connect_new_element(InnerIdType cur_c,
                              const DistHeapPtr& top_candidates,

--- a/src/io/basic_io.h
+++ b/src/io/basic_io.h
@@ -236,6 +236,17 @@ public:
         }
     }
 
+    inline void
+    Shrink(uint64_t size) {
+        if constexpr (has_ShrinkImpl<IOTmpl>::value) {
+            return cast().ShrinkImpl(size);
+        } else {
+            if (size <= this->size_) {
+                this->size_ = size;
+            }
+        }
+    }
+
     inline int64_t
     GetMemoryUsage() const {
         return this->size_;
@@ -333,5 +344,6 @@ private:
     GENERATE_HAS_MEMBER_FUNCTION(ReleaseImpl, void, std::declval<const uint8_t*>())
     GENERATE_HAS_MEMBER_FUNCTION(InitIOImpl, void, std::declval<const IOParamPtr&>())
     GENERATE_HAS_MEMBER_FUNCTION(ResizeImpl, void, std::declval<uint64_t>())
+    GENERATE_HAS_MEMBER_FUNCTION(ShrinkImpl, void, std::declval<uint64_t>())
 };
 }  // namespace vsag

--- a/src/io/memory_block_io.cpp
+++ b/src/io/memory_block_io.cpp
@@ -148,6 +148,20 @@ MemoryBlockIO::ResizeImpl(uint64_t size) {
     this->size_ = size;
 }
 
+void
+MemoryBlockIO::ShrinkImpl(uint64_t size) {
+    if (size >= this->size_) {
+        return;
+    }
+    uint64_t new_block_count = (size + this->block_size_ - 1) >> this->block_bit_;
+    while (this->blocks_.size() > new_block_count) {
+        auto* block = this->blocks_.back();
+        this->allocator_->Deallocate(block);
+        this->blocks_.pop_back();
+    }
+    this->size_ = size;
+}
+
 static int
 countr_zero(uint64_t x) {
     if (x == 0) {

--- a/src/io/memory_block_io.h
+++ b/src/io/memory_block_io.h
@@ -140,6 +140,9 @@ public:
     void
     PrefetchImpl(uint64_t offset, uint64_t cache_line = 64);
 
+    void
+    ShrinkImpl(uint64_t size);
+
 private:
     /**
      * @brief Updates internal parameters after block size change.

--- a/src/io/memory_block_io_test.cpp
+++ b/src/io/memory_block_io_test.cpp
@@ -41,3 +41,26 @@ TEST_CASE("MemoryBlockIO Serialize and Deserialize Test", "[ut][MemoryBlockIO]")
         TestSerializeAndDeserialize(*wio, *rio);
     }
 }
+
+TEST_CASE("MemoryBlockIO Shrink Test", "[ut][MemoryBlockIO]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    auto block_size = 4096;
+    auto io = std::make_unique<MemoryBlockIO>(block_size, allocator.get());
+
+    std::vector<uint8_t> data(10000, 0xAB);
+    io->Write(data.data(), data.size(), 0);
+    REQUIRE(io->size_ == data.size());
+
+    io->Shrink(5000);
+    REQUIRE(io->size_ == 5000);
+
+    std::vector<uint8_t> read_data(5000);
+    io->Read(5000, 0, read_data.data());
+    REQUIRE(memcmp(read_data.data(), data.data(), 5000) == 0);
+
+    io->Shrink(1000);
+    REQUIRE(io->size_ == 1000);
+
+    io->Shrink(2000);
+    REQUIRE(io->size_ == 1000);
+}

--- a/tests/test_hgraph_remove.cpp
+++ b/tests/test_hgraph_remove.cpp
@@ -1,0 +1,321 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <atomic>
+#include <catch2/catch_test_macros.hpp>
+#include <future>
+#include <mutex>
+#include <nlohmann/json.hpp>
+#include <thread>
+#include <unordered_set>
+
+#include "fixtures/functest.h"
+#include "test_index.h"
+#include "vsag/options.h"
+#include "vsag/vsag.h"
+
+namespace {
+
+constexpr int64_t DIM = 16;
+constexpr int64_t NUM_ELEMENTS = 50;
+constexpr int64_t MAX_DEGREE = 8;
+constexpr int64_t EF_CONSTRUCTION = 30;
+constexpr int64_t EF_SEARCH = 20;
+constexpr int64_t THREAD_COUNT = 4;
+
+vsag::IndexPtr
+CreateHGraphIndex() {
+    auto origin_size = vsag::Options::Instance().block_size_limit();
+    vsag::Options::Instance().set_block_size_limit(1024 * 1024 * 2);
+
+    nlohmann::json index_param;
+    index_param["base_quantization_type"] = "fp32";
+    index_param["max_degree"] = MAX_DEGREE;
+    index_param["ef_construction"] = EF_CONSTRUCTION;
+    index_param["build_thread_count"] = 0;
+    index_param["use_reverse_edges"] = true;
+
+    nlohmann::json param;
+    param["dtype"] = "float32";
+    param["metric_type"] = "l2";
+    param["dim"] = DIM;
+    param["index_param"] = index_param;
+
+    auto index = vsag::Factory::CreateIndex("hgraph", param.dump());
+    REQUIRE(index.has_value());
+
+    vsag::Options::Instance().set_block_size_limit(origin_size);
+    return index.value();
+}
+
+}  // namespace
+
+TEST_CASE("HGraph Sequential Add and ForceRemove", "[ft][hgraph]") {
+    fixtures::logger::LoggerReplacer _;
+
+    auto index = CreateHGraphIndex();
+
+    std::vector<int64_t> ids(NUM_ELEMENTS);
+    std::vector<float> vectors(DIM * NUM_ELEMENTS);
+    std::mt19937 rng(47);
+    std::uniform_real_distribution<float> distrib(0.1, 0.9);
+    for (int64_t i = 0; i < NUM_ELEMENTS; ++i) {
+        ids[i] = i;
+    }
+    for (int64_t i = 0; i < DIM * NUM_ELEMENTS; ++i) {
+        vectors[i] = distrib(rng);
+    }
+
+    std::string search_param = nlohmann::json{{"hgraph", {{"ef_search", EF_SEARCH}}}}.dump();
+
+    for (int64_t i = 0; i < NUM_ELEMENTS; ++i) {
+        auto dataset = vsag::Dataset::Make();
+        dataset->Dim(DIM)
+            ->NumElements(1)
+            ->Ids(&ids[i])
+            ->Float32Vectors(&vectors[i * DIM])
+            ->Owner(false);
+        auto result = index->Add(dataset);
+        REQUIRE(result.has_value());
+    }
+
+    REQUIRE(index->GetNumElements() == NUM_ELEMENTS);
+
+    for (int64_t i = 0; i < NUM_ELEMENTS / 2; ++i) {
+        auto result = index->Remove(ids[i], vsag::RemoveMode::ForceRemove);
+        REQUIRE(result.has_value());
+    }
+
+    REQUIRE(index->GetNumElements() == NUM_ELEMENTS / 2);
+
+    for (int64_t i = NUM_ELEMENTS / 2; i < NUM_ELEMENTS; ++i) {
+        auto query = vsag::Dataset::Make();
+        query->Dim(DIM)->NumElements(1)->Float32Vectors(&vectors[i * DIM])->Owner(false);
+        auto result = index->KnnSearch(query, 10, search_param);
+        REQUIRE(result.has_value());
+    }
+}
+
+TEST_CASE("HGraph Concurrent Add and ForceRemove", "[ft][hgraph][concurrent]") {
+    fixtures::logger::LoggerReplacer _;
+
+    auto index = CreateHGraphIndex();
+
+    std::vector<int64_t> ids(NUM_ELEMENTS);
+    std::vector<float> vectors(DIM * NUM_ELEMENTS);
+    std::mt19937 rng(47);
+    std::uniform_real_distribution<float> distrib(0.1, 0.9);
+    for (int64_t i = 0; i < NUM_ELEMENTS; ++i) {
+        ids[i] = i;
+    }
+    for (int64_t i = 0; i < DIM * NUM_ELEMENTS; ++i) {
+        vectors[i] = distrib(rng);
+    }
+
+    fixtures::ThreadPool pool(THREAD_COUNT);
+    std::vector<std::future<bool>> futures;
+
+    std::atomic<int64_t> add_success{0};
+    std::atomic<int64_t> remove_success{0};
+
+    auto add_func = [&](int64_t i) -> bool {
+        auto dataset = vsag::Dataset::Make();
+        dataset->Dim(DIM)
+            ->NumElements(1)
+            ->Ids(&ids[i])
+            ->Float32Vectors(&vectors[i * DIM])
+            ->Owner(false);
+
+        auto add_result = index->Add(dataset);
+        if (add_result.has_value()) {
+            add_success++;
+            return true;
+        }
+        return false;
+    };
+
+    auto remove_func = [&](int64_t i) -> bool {
+        auto remove_result = index->Remove(ids[i], vsag::RemoveMode::ForceRemove);
+        if (remove_result.has_value()) {
+            remove_success++;
+            return true;
+        }
+        return false;
+    };
+
+    for (int64_t i = 0; i < NUM_ELEMENTS; ++i) {
+        futures.emplace_back(pool.enqueue(add_func, i));
+    }
+
+    for (auto& future : futures) {
+        REQUIRE(future.get());
+    }
+
+    REQUIRE(index->GetNumElements() == NUM_ELEMENTS);
+    futures.clear();
+
+    for (int64_t i = 0; i < NUM_ELEMENTS / 2; ++i) {
+        futures.emplace_back(pool.enqueue(remove_func, i));
+    }
+
+    for (auto& future : futures) {
+        REQUIRE(future.get());
+    }
+
+    REQUIRE(index->GetNumElements() == NUM_ELEMENTS / 2);
+    REQUIRE(add_success == NUM_ELEMENTS);
+    REQUIRE(remove_success == NUM_ELEMENTS / 2);
+}
+
+TEST_CASE("HGraph Sequential Add Remove ReAdd", "[ft][hgraph]") {
+    fixtures::logger::LoggerReplacer _;
+
+    auto index = CreateHGraphIndex();
+
+    std::vector<int64_t> ids(NUM_ELEMENTS);
+    std::vector<float> vectors(DIM * NUM_ELEMENTS);
+    std::mt19937 rng(47);
+    std::uniform_real_distribution<float> distrib(0.1, 0.9);
+    for (int64_t i = 0; i < NUM_ELEMENTS; ++i) {
+        ids[i] = i;
+    }
+    for (int64_t i = 0; i < DIM * NUM_ELEMENTS; ++i) {
+        vectors[i] = distrib(rng);
+    }
+
+    std::string search_param = nlohmann::json{{"hgraph", {{"ef_search", EF_SEARCH}}}}.dump();
+
+    for (int64_t i = 0; i < NUM_ELEMENTS; ++i) {
+        auto dataset = vsag::Dataset::Make();
+        dataset->Dim(DIM)
+            ->NumElements(1)
+            ->Ids(&ids[i])
+            ->Float32Vectors(&vectors[i * DIM])
+            ->Owner(false);
+        auto result = index->Add(dataset);
+        REQUIRE(result.has_value());
+    }
+
+    REQUIRE(index->GetNumElements() == NUM_ELEMENTS);
+
+    for (int64_t i = 0; i < NUM_ELEMENTS / 2; ++i) {
+        auto result = index->Remove(ids[i], vsag::RemoveMode::ForceRemove);
+        REQUIRE(result.has_value());
+    }
+
+    REQUIRE(index->GetNumElements() == NUM_ELEMENTS / 2);
+
+    for (int64_t i = 0; i < NUM_ELEMENTS / 2; ++i) {
+        auto dataset = vsag::Dataset::Make();
+        dataset->Dim(DIM)
+            ->NumElements(1)
+            ->Ids(&ids[i])
+            ->Float32Vectors(&vectors[i * DIM])
+            ->Owner(false);
+        auto result = index->Add(dataset);
+        REQUIRE(result.has_value());
+    }
+
+    REQUIRE(index->GetNumElements() == NUM_ELEMENTS);
+
+    for (int64_t i = 0; i < NUM_ELEMENTS; ++i) {
+        auto query = vsag::Dataset::Make();
+        query->Dim(DIM)->NumElements(1)->Float32Vectors(&vectors[i * DIM])->Owner(false);
+        auto result = index->KnnSearch(query, 10, search_param);
+        REQUIRE(result.has_value());
+    }
+}
+
+TEST_CASE("HGraph ForceRemove All Elements", "[ft][hgraph]") {
+    fixtures::logger::LoggerReplacer _;
+
+    auto index = CreateHGraphIndex();
+
+    std::vector<int64_t> ids(NUM_ELEMENTS);
+    std::vector<float> vectors(DIM * NUM_ELEMENTS);
+    std::mt19937 rng(47);
+    std::uniform_real_distribution<float> distrib(0.1, 0.9);
+    for (int64_t i = 0; i < NUM_ELEMENTS; ++i) {
+        ids[i] = i;
+    }
+    for (int64_t i = 0; i < DIM * NUM_ELEMENTS; ++i) {
+        vectors[i] = distrib(rng);
+    }
+
+    std::string search_param = nlohmann::json{{"hgraph", {{"ef_search", EF_SEARCH}}}}.dump();
+
+    auto base_dataset = vsag::Dataset::Make();
+    base_dataset->Dim(DIM)
+        ->NumElements(NUM_ELEMENTS)
+        ->Ids(ids.data())
+        ->Float32Vectors(vectors.data())
+        ->Owner(false);
+    auto build_result = index->Build(base_dataset);
+    REQUIRE(build_result.has_value());
+    REQUIRE(index->GetNumElements() == NUM_ELEMENTS);
+
+    for (int64_t i = 0; i < NUM_ELEMENTS; ++i) {
+        auto query = vsag::Dataset::Make();
+        query->Dim(DIM)->NumElements(1)->Float32Vectors(&vectors[i * DIM])->Owner(false);
+        auto result = index->KnnSearch(query, 10, search_param);
+        REQUIRE(result.has_value());
+        REQUIRE(result.value()->GetDim() > 0);
+    }
+
+    for (int64_t i = 0; i < NUM_ELEMENTS; ++i) {
+        auto remove_result = index->Remove(ids[i], vsag::RemoveMode::ForceRemove);
+        REQUIRE(remove_result.has_value());
+        REQUIRE(remove_result.value() > 0);
+    }
+
+    REQUIRE(index->GetNumElements() == 0);
+
+    auto empty_query = vsag::Dataset::Make();
+    empty_query->Dim(DIM)->NumElements(1)->Float32Vectors(vectors.data())->Owner(false);
+    auto empty_result = index->KnnSearch(empty_query, 10, search_param);
+    REQUIRE(empty_result.has_value());
+    REQUIRE(empty_result.value()->GetDim() == 0);
+}
+
+TEST_CASE("HGraph Batch ForceRemove supports legacy remove alias", "[ft][hgraph]") {
+    fixtures::logger::LoggerReplacer _;
+
+    auto index = CreateHGraphIndex();
+
+    std::vector<int64_t> ids(NUM_ELEMENTS);
+    std::vector<float> vectors(DIM * NUM_ELEMENTS);
+    std::mt19937 rng(47);
+    std::uniform_real_distribution<float> distrib(0.1, 0.9);
+    for (int64_t i = 0; i < NUM_ELEMENTS; ++i) {
+        ids[i] = i;
+    }
+    for (int64_t i = 0; i < DIM * NUM_ELEMENTS; ++i) {
+        vectors[i] = distrib(rng);
+    }
+
+    auto base_dataset = vsag::Dataset::Make();
+    base_dataset->Dim(DIM)
+        ->NumElements(NUM_ELEMENTS)
+        ->Ids(ids.data())
+        ->Float32Vectors(vectors.data())
+        ->Owner(false);
+    auto build_result = index->Build(base_dataset);
+    REQUIRE(build_result.has_value());
+
+    std::vector<int64_t> remove_ids(ids.begin(), ids.begin() + 5);
+    auto remove_result = index->Remove(remove_ids, vsag::RemoveMode::REMOVE_AND_REPAIR);
+    REQUIRE(remove_result.has_value());
+    REQUIRE(remove_result.value() == remove_ids.size());
+    REQUIRE(index->GetNumElements() == NUM_ELEMENTS - remove_ids.size());
+}

--- a/tests/test_hgraph_remove.cpp
+++ b/tests/test_hgraph_remove.cpp
@@ -1,0 +1,324 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <atomic>
+#include <catch2/catch_test_macros.hpp>
+#include <future>
+#include <mutex>
+#include <nlohmann/json.hpp>
+#include <thread>
+#include <unordered_set>
+
+#include "fixtures/fixtures.h"
+#include "fixtures/test_dataset_pool.h"
+#include "fixtures/test_logger.h"
+#include "fixtures/thread_pool.h"
+#include "test_index.h"
+#include "vsag/options.h"
+#include "vsag/vsag.h"
+
+namespace {
+
+constexpr int64_t DIM = 16;
+constexpr int64_t NUM_ELEMENTS = 100;
+constexpr int64_t MAX_DEGREE = 8;
+constexpr int64_t EF_CONSTRUCTION = 50;
+constexpr int64_t EF_SEARCH = 20;
+constexpr int64_t THREAD_COUNT = 4;
+
+vsag::IndexPtr
+CreateHGraphIndex() {
+    auto origin_size = vsag::Options::Instance().block_size_limit();
+    vsag::Options::Instance().set_block_size_limit(1024 * 1024 * 2);
+
+    nlohmann::json index_param;
+    index_param["base_quantization_type"] = "fp32";
+    index_param["max_degree"] = MAX_DEGREE;
+    index_param["ef_construction"] = EF_CONSTRUCTION;
+    index_param["build_thread_count"] = 0;
+    index_param["use_reverse_edges"] = true;
+
+    nlohmann::json param;
+    param["dtype"] = "float32";
+    param["metric_type"] = "l2";
+    param["dim"] = DIM;
+    param["index_param"] = index_param;
+
+    auto index = vsag::Factory::CreateIndex("hgraph", param.dump());
+    REQUIRE(index.has_value());
+
+    vsag::Options::Instance().set_block_size_limit(origin_size);
+    return index.value();
+}
+
+}  // namespace
+
+TEST_CASE("HGraph Sequential Add and ForceRemove", "[ft][hgraph]") {
+    fixtures::logger::LoggerReplacer _;
+
+    auto index = CreateHGraphIndex();
+
+    std::vector<int64_t> ids(NUM_ELEMENTS);
+    std::vector<float> vectors(DIM * NUM_ELEMENTS);
+    std::mt19937 rng(47);
+    std::uniform_real_distribution<float> distrib(0.1, 0.9);
+    for (int64_t i = 0; i < NUM_ELEMENTS; ++i) {
+        ids[i] = i;
+    }
+    for (int64_t i = 0; i < DIM * NUM_ELEMENTS; ++i) {
+        vectors[i] = distrib(rng);
+    }
+
+    std::string search_param = nlohmann::json{{"hgraph", {{"ef_search", EF_SEARCH}}}}.dump();
+
+    for (int64_t i = 0; i < NUM_ELEMENTS; ++i) {
+        auto dataset = vsag::Dataset::Make();
+        dataset->Dim(DIM)
+            ->NumElements(1)
+            ->Ids(&ids[i])
+            ->Float32Vectors(&vectors[i * DIM])
+            ->Owner(false);
+        auto result = index->Add(dataset);
+        REQUIRE(result.has_value());
+    }
+
+    REQUIRE(index->GetNumElements() == NUM_ELEMENTS);
+
+    for (int64_t i = 0; i < NUM_ELEMENTS / 2; ++i) {
+        auto result = index->Remove(ids[i], vsag::RemoveMode::ForceRemove);
+        REQUIRE(result.has_value());
+    }
+
+    REQUIRE(index->GetNumElements() == NUM_ELEMENTS / 2);
+
+    for (int64_t i = NUM_ELEMENTS / 2; i < NUM_ELEMENTS; ++i) {
+        auto query = vsag::Dataset::Make();
+        query->Dim(DIM)->NumElements(1)->Float32Vectors(&vectors[i * DIM])->Owner(false);
+        auto result = index->KnnSearch(query, 10, search_param);
+        REQUIRE(result.has_value());
+    }
+}
+
+TEST_CASE("HGraph Concurrent Add and ForceRemove", "[ft][hgraph][concurrent]") {
+    fixtures::logger::LoggerReplacer _;
+
+    auto index = CreateHGraphIndex();
+
+    std::vector<int64_t> ids(NUM_ELEMENTS);
+    std::vector<float> vectors(DIM * NUM_ELEMENTS);
+    std::mt19937 rng(47);
+    std::uniform_real_distribution<float> distrib(0.1, 0.9);
+    for (int64_t i = 0; i < NUM_ELEMENTS; ++i) {
+        ids[i] = i;
+    }
+    for (int64_t i = 0; i < DIM * NUM_ELEMENTS; ++i) {
+        vectors[i] = distrib(rng);
+    }
+
+    fixtures::ThreadPool pool(THREAD_COUNT);
+    std::vector<std::future<bool>> futures;
+
+    std::atomic<int64_t> add_success{0};
+    std::atomic<int64_t> remove_success{0};
+
+    auto add_func = [&](int64_t i) -> bool {
+        auto dataset = vsag::Dataset::Make();
+        dataset->Dim(DIM)
+            ->NumElements(1)
+            ->Ids(&ids[i])
+            ->Float32Vectors(&vectors[i * DIM])
+            ->Owner(false);
+
+        auto add_result = index->Add(dataset);
+        if (add_result.has_value()) {
+            add_success++;
+            return true;
+        }
+        return false;
+    };
+
+    auto remove_func = [&](int64_t i) -> bool {
+        auto remove_result = index->Remove(ids[i], vsag::RemoveMode::ForceRemove);
+        if (remove_result.has_value()) {
+            remove_success++;
+            return true;
+        }
+        return false;
+    };
+
+    for (int64_t i = 0; i < NUM_ELEMENTS; ++i) {
+        futures.emplace_back(pool.enqueue(add_func, i));
+    }
+
+    for (auto& future : futures) {
+        REQUIRE(future.get());
+    }
+
+    REQUIRE(index->GetNumElements() == NUM_ELEMENTS);
+    futures.clear();
+
+    for (int64_t i = 0; i < NUM_ELEMENTS / 2; ++i) {
+        futures.emplace_back(pool.enqueue(remove_func, i));
+    }
+
+    for (auto& future : futures) {
+        REQUIRE(future.get());
+    }
+
+    REQUIRE(index->GetNumElements() == NUM_ELEMENTS / 2);
+    REQUIRE(add_success == NUM_ELEMENTS);
+    REQUIRE(remove_success == NUM_ELEMENTS / 2);
+}
+
+TEST_CASE("HGraph Sequential Add Remove ReAdd", "[ft][hgraph]") {
+    fixtures::logger::LoggerReplacer _;
+
+    auto index = CreateHGraphIndex();
+
+    std::vector<int64_t> ids(NUM_ELEMENTS);
+    std::vector<float> vectors(DIM * NUM_ELEMENTS);
+    std::mt19937 rng(47);
+    std::uniform_real_distribution<float> distrib(0.1, 0.9);
+    for (int64_t i = 0; i < NUM_ELEMENTS; ++i) {
+        ids[i] = i;
+    }
+    for (int64_t i = 0; i < DIM * NUM_ELEMENTS; ++i) {
+        vectors[i] = distrib(rng);
+    }
+
+    std::string search_param = nlohmann::json{{"hgraph", {{"ef_search", EF_SEARCH}}}}.dump();
+
+    for (int64_t i = 0; i < NUM_ELEMENTS; ++i) {
+        auto dataset = vsag::Dataset::Make();
+        dataset->Dim(DIM)
+            ->NumElements(1)
+            ->Ids(&ids[i])
+            ->Float32Vectors(&vectors[i * DIM])
+            ->Owner(false);
+        auto result = index->Add(dataset);
+        REQUIRE(result.has_value());
+    }
+
+    REQUIRE(index->GetNumElements() == NUM_ELEMENTS);
+
+    for (int64_t i = 0; i < NUM_ELEMENTS / 2; ++i) {
+        auto result = index->Remove(ids[i], vsag::RemoveMode::ForceRemove);
+        REQUIRE(result.has_value());
+    }
+
+    REQUIRE(index->GetNumElements() == NUM_ELEMENTS / 2);
+
+    for (int64_t i = 0; i < NUM_ELEMENTS / 2; ++i) {
+        auto dataset = vsag::Dataset::Make();
+        dataset->Dim(DIM)
+            ->NumElements(1)
+            ->Ids(&ids[i])
+            ->Float32Vectors(&vectors[i * DIM])
+            ->Owner(false);
+        auto result = index->Add(dataset);
+        REQUIRE(result.has_value());
+    }
+
+    REQUIRE(index->GetNumElements() == NUM_ELEMENTS);
+
+    for (int64_t i = 0; i < NUM_ELEMENTS; ++i) {
+        auto query = vsag::Dataset::Make();
+        query->Dim(DIM)->NumElements(1)->Float32Vectors(&vectors[i * DIM])->Owner(false);
+        auto result = index->KnnSearch(query, 10, search_param);
+        REQUIRE(result.has_value());
+    }
+}
+
+TEST_CASE("HGraph ForceRemove All Elements", "[ft][hgraph]") {
+    fixtures::logger::LoggerReplacer _;
+
+    auto index = CreateHGraphIndex();
+
+    std::vector<int64_t> ids(NUM_ELEMENTS);
+    std::vector<float> vectors(DIM * NUM_ELEMENTS);
+    std::mt19937 rng(47);
+    std::uniform_real_distribution<float> distrib(0.1, 0.9);
+    for (int64_t i = 0; i < NUM_ELEMENTS; ++i) {
+        ids[i] = i;
+    }
+    for (int64_t i = 0; i < DIM * NUM_ELEMENTS; ++i) {
+        vectors[i] = distrib(rng);
+    }
+
+    std::string search_param = nlohmann::json{{"hgraph", {{"ef_search", EF_SEARCH}}}}.dump();
+
+    auto base_dataset = vsag::Dataset::Make();
+    base_dataset->Dim(DIM)
+        ->NumElements(NUM_ELEMENTS)
+        ->Ids(ids.data())
+        ->Float32Vectors(vectors.data())
+        ->Owner(false);
+    auto build_result = index->Build(base_dataset);
+    REQUIRE(build_result.has_value());
+    REQUIRE(index->GetNumElements() == NUM_ELEMENTS);
+
+    for (int64_t i = 0; i < NUM_ELEMENTS; ++i) {
+        auto query = vsag::Dataset::Make();
+        query->Dim(DIM)->NumElements(1)->Float32Vectors(&vectors[i * DIM])->Owner(false);
+        auto result = index->KnnSearch(query, 10, search_param);
+        REQUIRE(result.has_value());
+        REQUIRE(result.value()->GetDim() > 0);
+    }
+
+    for (int64_t i = 0; i < NUM_ELEMENTS; ++i) {
+        auto remove_result = index->Remove(ids[i], vsag::RemoveMode::ForceRemove);
+        REQUIRE(remove_result.has_value());
+        REQUIRE(remove_result.value() > 0);
+    }
+
+    REQUIRE(index->GetNumElements() == 0);
+
+    auto empty_query = vsag::Dataset::Make();
+    empty_query->Dim(DIM)->NumElements(1)->Float32Vectors(vectors.data())->Owner(false);
+    auto empty_result = index->KnnSearch(empty_query, 10, search_param);
+    REQUIRE(empty_result.has_value());
+    REQUIRE(empty_result.value()->GetDim() == 0);
+}
+
+TEST_CASE("HGraph Batch ForceRemove supports legacy remove alias", "[ft][hgraph]") {
+    fixtures::logger::LoggerReplacer _;
+
+    auto index = CreateHGraphIndex();
+
+    std::vector<int64_t> ids(NUM_ELEMENTS);
+    std::vector<float> vectors(DIM * NUM_ELEMENTS);
+    std::mt19937 rng(47);
+    std::uniform_real_distribution<float> distrib(0.1, 0.9);
+    for (int64_t i = 0; i < NUM_ELEMENTS; ++i) {
+        ids[i] = i;
+    }
+    for (int64_t i = 0; i < DIM * NUM_ELEMENTS; ++i) {
+        vectors[i] = distrib(rng);
+    }
+
+    auto base_dataset = vsag::Dataset::Make();
+    base_dataset->Dim(DIM)
+        ->NumElements(NUM_ELEMENTS)
+        ->Ids(ids.data())
+        ->Float32Vectors(vectors.data())
+        ->Owner(false);
+    auto build_result = index->Build(base_dataset);
+    REQUIRE(build_result.has_value());
+
+    std::vector<int64_t> remove_ids(ids.begin(), ids.begin() + 5);
+    auto remove_result = index->Remove(remove_ids, vsag::RemoveMode::REMOVE_AND_REPAIR);
+    REQUIRE(remove_result.has_value());
+    REQUIRE(remove_result.value() == remove_ids.size());
+    REQUIRE(index->GetNumElements() == NUM_ELEMENTS - remove_ids.size());
+}


### PR DESCRIPTION
## Summary
- enable vector removal in HGraph while keeping graph state consistent
- persist sparse graph removal metadata across datacell and IO paths
- add regression tests for graph remove behavior and related interfaces