### PR TITLE
refactor:is_subset_of_sparse_vector

### DIFF
--- a/src/utils/sparse_vector_transform.cpp
+++ b/src/utils/sparse_vector_transform.cpp
@@ -61,7 +61,7 @@ is_subset_of_sparse_vector(const SparseVector& sv1, const SparseVector& sv2) {
             return false;
         }
     }
-    return true;
+    return i == sv1.len_;
 }
 
 }  // namespace vsag

--- a/src/utils/sparse_vector_transform.cpp
+++ b/src/utils/sparse_vector_transform.cpp
@@ -41,20 +41,23 @@ is_subset_of_sparse_vector(const SparseVector& sv1, const SparseVector& sv2) {
         return false;
     }
 
-    std::unordered_map<uint32_t, float> sv2_map;
-    for (auto i = 0; i < sv2.len_; i++) {
-        sv2_map[sv2.ids_[i]] = sv2.vals_[i];
-    }
+    uint32_t i = 0;
+    uint32_t j = 0;
 
-    for (auto i = 0; i < sv1.len_; i++) {
-        auto search = sv2_map.find(sv1.ids_[i]);
-        if (search == sv2_map.end()) {
+    // sv1 and sv2 term IDs need to be sorted in ascending order
+    while (i < sv1.len_ && j < sv2.len_) {
+        if (sv1.ids_[i] == sv2.ids_[j]) {
+            if (std::abs(sv1.vals_[i] - sv2.vals_[j]) > 1e-3) {
+                // [case 3]: The term VALUE in the sv1 is not equal to that in the sv2
+                return false;
+            }
+            i++;
+            j++;
+        } else if (sv1.ids_[i] > sv2.ids_[j]) {
+            j++;
+        } else {
+            // sv1.ids_[i] < sv2.ids_[j]
             // [case 2]: The term ID in the sv1 does not exist in the sv2
-            return false;
-        }
-        float new_term_value = search->second;
-        if (std::abs(sv1.vals_[i] - new_term_value) > 1e-3) {
-            // [case 3]: The term VALUE in the sv1 is not equal to that in the sv2
             return false;
         }
     }


### PR DESCRIPTION
## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement/Refactor
- [ ] Documentation
- [ ] CI/Build/Infra

## Linked Issue



## What Changed

Since the term IDs are pre-sorted in ascending order, the subset check can be optimized to $O(M+N)$ time complexity with $O(1)$ auxiliary space, eliminating the need for additional memory allocation.

## Test Evidence

- [ ] `make fmt`
- [ ] `make lint`
- [ ] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [ ] Other (describe below)

Test details:

```text
<!-- Paste commands and key output here -->
```

## Compatibility Impact

- API/ABI compatibility: <!-- none / describe -->
- Behavior changes: <!-- none / describe -->

## Performance and Concurrency Impact

- Performance impact: <!-- none / improved / regressed / unknown -->
- Concurrency/thread-safety impact: <!-- none / describe -->

## Documentation Impact

- [ ] No docs update needed
- [ ] Updated docs:
  - [ ] `README.md`
  - [ ] `DEVELOPMENT.md`
  - [ ] `CONTRIBUTING.md`
  - [ ] Other: <!-- path -->

## Risk and Rollback

- Risk level: <!-- low / medium / high -->
- Rollback plan: <!-- how to revert safely -->

## Checklist

- [ ] I have linked the relevant issue (or explained why not applicable)
- [ ] I have added/updated tests for new behavior or bug fixes
- [ ] I have considered API compatibility impact
- [ ] I have updated docs if behavior/workflow changed
- [ ] My commit messages follow project conventions (Conventional Commits, optional `[skip ci]` prefix)
