### PR TITLE
docs(clang-tidy): Switched from > to | in .clang-tidy to pr…

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -21,8 +21,6 @@ Checks:
     - "-clang-analyzer-deadcode.DeadStores" # value stored but never read
     - "clang-diagnostic-*"
     - "-clang-diagnostic-deprecated-builtins"
-    - "# google-*"
-    - "# misc-*"
     - "modernize-*"
     - "-modernize-use-trailing-return-type"
     - "-modernize-avoid-c-arrays"

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -13,26 +13,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-Checks: |
-    -*,
-    bugprone-*,
-    -bugprone-easily-swappable-parameters,
-    clang-analyzer-*,
-    -clang-analyzer-deadcode.DeadStores, # value stored but never read
-    clang-diagnostic-*,
-    -clang-diagnostic-deprecated-builtins,
-    # google-*,
-    # misc-*,
-    modernize-*,
-    -modernize-use-trailing-return-type,
-    -modernize-avoid-c-arrays,
-    openmp-*,
-    performance-*,
-    readability-*,
-    -readability-identifier-length,
-    -readability-magic-numbers,
-    -readability-function-cognitive-complexity, # enable after fix all
-    -readability-redundant-access-specifiers, # keep repeated public:/protected:/private: as visual separators between method groups
+Checks:
+    - "-*"
+    - "bugprone-*"
+    - "-bugprone-easily-swappable-parameters"
+    - "clang-analyzer-*"
+    - "-clang-analyzer-deadcode.DeadStores" # value stored but never read
+    - "clang-diagnostic-*"
+    - "-clang-diagnostic-deprecated-builtins"
+    - "# google-*"
+    - "# misc-*"
+    - "modernize-*"
+    - "-modernize-use-trailing-return-type"
+    - "-modernize-avoid-c-arrays"
+    - "openmp-*"
+    - "performance-*"
+    - "readability-*"
+    - "-readability-identifier-length"
+    - "-readability-magic-numbers"
+    - "-readability-function-cognitive-complexity" # enable after fix all
+    - "-readability-redundant-access-specifiers" # keep repeated public:/protected:/private: as visual separators between method groups
 
 
 HeaderFilterRegex: ''

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -13,8 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-Checks: >
+Checks: |
     -*,
     bugprone-*,
     -bugprone-easily-swappable-parameters,


### PR DESCRIPTION
…eserve line breaks, preventing comments from masking subsequent check rules.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement/Refactor
- [x] Documentation
- [ ] CI/Build/Infra

## Linked Issue

- Issue: <!-- e.g. #1234 -->

## What Changed

style: use literal block scalar for clang-tidy checks

Switched from `>` to `|` in .clang-tidy to preserve line breaks, 
preventing comments from masking subsequent check rules.

## Test Evidence

- [ ] `make fmt`
- [ ] `make lint`
- [ ] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [ ] Other (describe below)

Test details:

```text
<!-- Paste commands and key output here -->
```

## Compatibility Impact

- API/ABI compatibility: <!-- none / describe -->
- Behavior changes: <!-- none / describe -->

## Performance and Concurrency Impact

- Performance impact: <!-- none / improved / regressed / unknown -->
- Concurrency/thread-safety impact: <!-- none / describe -->

## Documentation Impact

- [ ] No docs update needed
- [ ] Updated docs:
  - [ ] `README.md`
  - [ ] `DEVELOPMENT.md`
  - [ ] `CONTRIBUTING.md`
  - [ ] Other: <!-- path -->

## Risk and Rollback

- Risk level: <!-- low / medium / high -->
- Rollback plan: <!-- how to revert safely -->

## Checklist

- [ ] I have linked the relevant issue (or explained why not applicable)
- [ ] I have added/updated tests for new behavior or bug fixes
- [ ] I have considered API compatibility impact
- [ ] I have updated docs if behavior/workflow changed
- [ ] My commit messages follow project conventions (Conventional Commits, optional `[skip ci]` prefix)
