### PR TITLE
feat(api): add reasoning support to SearchRequest, Dataset and QueryContext

### DIFF
--- a/include/vsag/dataset.h
+++ b/include/vsag/dataset.h
@@ -371,6 +371,23 @@ public:
      */
     virtual std::vector<std::string>
     GetStatistics(const std::vector<std::string>& stat_keys) const = 0;
+
+    /**
+     * @brief Sets the Reasoning report for the dataset.
+     *
+     * @param reasoning_json The Reasoning report as a JSON string.
+     * @return DatasetPtr A shared pointer to the dataset with updated Reasoning.
+     */
+    virtual DatasetPtr
+    Reasoning(const std::string& reasoning_json) = 0;
+
+    /**
+     * @brief Retrieves the Reasoning report of the dataset.
+     *
+     * @return const std::string& The Reasoning report JSON string.
+     */
+    virtual const std::string&
+    GetReasoning() const = 0;
 };
 
 };  // namespace vsag

--- a/include/vsag/search_request.h
+++ b/include/vsag/search_request.h
@@ -16,6 +16,7 @@
 
 #include <cstdint>
 #include <string>
+#include <vector>
 
 #include "vsag/bitset.h"
 #include "vsag/dataset.h"
@@ -169,9 +170,18 @@ public:
 
     /**
      * @brief Flag indicating this is the final search in an iterator sequence
-     * @details When set to true, signals that no more results are expected from this iterator.ß
+     * @details When set to true, signals that no more results are expected from this iterator.
      */
     bool is_last_search_{false};
+
+    /**
+     * @brief Expected labels for reasoning analysis
+     * @details List of expected vector IDs that should be returned in the search result.
+     *          When non-empty, enables reasoning mechanism to analyze why these target
+     *          vectors were not recalled. Used for debugging and optimization purposes.
+     *          Default is empty (no reasoning enabled).
+     */
+    std::vector<int64_t> expected_labels_{};
 };
 
 }  // namespace vsag

--- a/src/dataset_impl.h
+++ b/src/dataset_impl.h
@@ -258,6 +258,17 @@ public:
         return this->Statistics_;
     }
 
+    DatasetPtr
+    Reasoning(const std::string& reasoning_json) override {
+        this->Reasoning_ = reasoning_json;
+        return shared_from_this();
+    }
+
+    const std::string&
+    GetReasoning() const override {
+        return this->Reasoning_;
+    }
+
     static DatasetPtr
     MakeEmptyDataset();
 
@@ -267,6 +278,7 @@ private:
     Allocator* allocator_ = nullptr;
 
     std::string Statistics_{"{}"};
+    std::string Reasoning_{"{}"};
 };
 
 };  // namespace vsag

--- a/src/query_context.h
+++ b/src/query_context.h
@@ -24,10 +24,12 @@
 namespace vsag {
 
 class SearchStatistics;
+class ReasoningContext;
 
 struct QueryContext {
     Allocator* alloc = nullptr;
     SearchStatistics* stats = nullptr;
+    ReasoningContext* reasoning_ctx = nullptr;
 };
 
 class SearchStatistics {


### PR DESCRIPTION
## Summary
Add reasoning support to API layer, enabling analysis of why expected vectors were not recalled in search results.

## Changes
- Add `expected_labels_` field to `SearchRequest` for specifying target vectors
- Add `Reasoning()` getter/setter to `Dataset` for carrying reasoning reports
- Add `reasoning_ctx` pointer to `QueryContext` for passing reasoning context

This is the foundation for reasoning mechanism, subsequent ReasoningContext implementation and index integration will depend on this task.

## Files Changed
- `include/vsag/search_request.h`: Add `expected_labels_` field with documentation
- `include/vsag/dataset.h`: Add `Reasoning()` and `GetReasoning()` virtual methods
- `src/dataset_impl.h`: Implement Reasoning getter/setter with `Reasoning_` member
- `src/query_context.h`: Add `reasoning_ctx` pointer and forward declaration

## Testing
- Build verified with `make release`
- Code formatted with `clang-format-15`

## Related Issues
- Fixes #1832
- Related to #1829 (parent issue)

## Checklist
- [x] Code follows VSAG coding style
- [x] Build passes
- [x] Code formatted