### PR TITLE
feat(reasoning): implement ReasoningContext data collector

### DIFF
--- a/src/impl/CMakeLists.txt
+++ b/src/impl/CMakeLists.txt
@@ -26,16 +26,17 @@ add_subdirectory (searcher)
 add_subdirectory (odescent)
 add_subdirectory (reorder)
 add_subdirectory (blas)
+add_subdirectory (reasoning)
 
 file (GLOB IMPL_SRCS "*.cpp")
 list (FILTER IMPL_SRCS EXCLUDE REGEX "_test.cpp")
 
 add_library (impl OBJECT ${IMPL_SRCS})
 target_link_libraries (impl PRIVATE transform thread_pool allocator heap vsag_blas
-    bitset logger filter cluster searcher odescent reorder coverage_config vsag_src_common)
+    bitset logger filter cluster searcher odescent reorder reasoning coverage_config vsag_src_common)
 
 set (IMPL_LIBS transform thread_pool allocator heap bitset vsag_blas
-    logger filter impl cluster searcher odescent reorder PARENT_SCOPE)
+    logger filter impl cluster searcher odescent reorder reasoning PARENT_SCOPE)
 
 if (ENABLE_TESTS)
     file (GLOB_RECURSE IMPL_TESTS "*_test.cpp")

--- a/src/impl/reasoning/CMakeLists.txt
+++ b/src/impl/reasoning/CMakeLists.txt
@@ -1,0 +1,22 @@
+# Copyright 2024-present the vsag project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+set (REASONING_SRC
+        search_reasoning.cpp
+        search_reasoning.h
+)
+
+add_library (reasoning OBJECT ${REASONING_SRC})
+target_link_libraries (reasoning PRIVATE coverage_config vsag_src_common)

--- a/src/impl/reasoning/search_reasoning.cpp
+++ b/src/impl/reasoning/search_reasoning.cpp
@@ -1,0 +1,238 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "search_reasoning.h"
+
+#include <cmath>
+
+namespace vsag {
+
+ReasoningContext::ReasoningContext(Allocator* allocator)
+    : allocator_(allocator),
+      expected_inner_ids_(AllocatorWrapper<InnerIdType>(allocator)),
+      expected_traces_(
+          AllocatorWrapper<std::pair<const InnerIdType, ExpectedTargetTrace>>(allocator)),
+      reorder_changes_(AllocatorWrapper<ReorderRecord>(allocator)) {
+}
+
+ReasoningContext::~ReasoningContext() = default;
+
+void
+ReasoningContext::InitializeExpectedTargets(
+    const Vector<int64_t>& labels,
+    const UnorderedMap<int64_t, InnerIdType>& label_to_inner_id,
+    const float* query,
+    const void* precise_vectors,
+    DataTypes data_type,
+    uint64_t dim) {
+    expected_inner_ids_.clear();
+    expected_traces_.clear();
+
+    for (const auto& label : labels) {
+        auto it = label_to_inner_id.find(label);
+        if (it != label_to_inner_id.end()) {
+            InnerIdType inner_id = it->second;
+            expected_inner_ids_.insert(inner_id);
+
+            ExpectedTargetTrace trace;
+            trace.label = label;
+            trace.inner_id = inner_id;
+
+            const float* vec = nullptr;
+            float* casted_vec = nullptr;
+
+            if (data_type == DataTypes::DATA_TYPE_FLOAT) {
+                vec = static_cast<const float*>(precise_vectors) +
+                      static_cast<uint64_t>(inner_id) * dim;
+            } else if (data_type == DataTypes::DATA_TYPE_INT8) {
+                const int8_t* int8_vec = static_cast<const int8_t*>(precise_vectors) +
+                                         static_cast<uint64_t>(inner_id) * dim;
+                casted_vec = new float[dim];
+                for (uint64_t i = 0; i < dim; ++i) {
+                    casted_vec[i] = static_cast<float>(int8_vec[i]);
+                }
+                vec = casted_vec;
+            } else if (data_type == DataTypes::DATA_TYPE_FP16) {
+                const uint16_t* fp16_vec = static_cast<const uint16_t*>(precise_vectors) +
+                                           static_cast<uint64_t>(inner_id) * dim;
+                casted_vec = new float[dim];
+                for (uint64_t i = 0; i < dim; ++i) {
+                    casted_vec[i] = static_cast<float>(fp16_vec[i]) / 32768.0F;
+                }
+                vec = casted_vec;
+            }
+
+            if (vec != nullptr) {
+                float true_dist = 0.0F;
+                for (uint64_t i = 0; i < dim; ++i) {
+                    float diff = query[i] - vec[i];
+                    true_dist += diff * diff;
+                }
+                trace.true_distance = std::sqrt(true_dist);
+            }
+
+            delete[] casted_vec;
+
+            expected_traces_.insert(std::make_pair(inner_id, trace));
+        }
+    }
+}
+
+void
+ReasoningContext::RecordVisit(InnerIdType id, float dist, uint32_t hop) {
+    auto it = expected_traces_.find(id);
+    if (it != expected_traces_.end()) {
+        it.value().was_visited = true;
+        it.value().visited_at_hop = static_cast<int32_t>(hop);
+        if (it.value().quantized_distance == 0.0F) {
+            it.value().quantized_distance = dist;
+        }
+    }
+}
+
+void
+ReasoningContext::RecordEviction(InnerIdType id, uint32_t hop) {
+    auto it = expected_traces_.find(id);
+    if (it != expected_traces_.end()) {
+        it.value().was_evicted = true;
+        if (!it.value().was_visited) {
+            it.value().was_visited = true;
+            it.value().visited_at_hop = static_cast<int32_t>(hop);
+        }
+    }
+}
+
+void
+ReasoningContext::RecordFilterReject(InnerIdType id) {
+    auto it = expected_traces_.find(id);
+    if (it != expected_traces_.end()) {
+        it.value().filter_rejected = true;
+        it.value().was_visited = true;
+    }
+}
+
+void
+ReasoningContext::RecordReorder(InnerIdType id, float dist_before, float dist_after) {
+    auto it = expected_traces_.find(id);
+    if (it != expected_traces_.end()) {
+        it.value().reorder_evicted = true;
+        it.value().quantized_distance = dist_before;
+        it.value().true_distance = dist_after;
+    }
+
+    ReorderRecord record;
+    record.id = id;
+    record.dist_before = dist_before;
+    record.dist_after = dist_after;
+    reorder_changes_.push_back(record);
+}
+
+void
+ReasoningContext::SetTermination(const std::string& reason) {
+    termination_reason_ = reason;
+}
+
+void
+ReasoningContext::MarkResult(const Vector<InnerIdType>& result_ids) {
+    for (const auto& id : result_ids) {
+        auto it = expected_traces_.find(id);
+        if (it != expected_traces_.end()) {
+            it.value().was_in_result_set = true;
+        }
+    }
+}
+
+void
+ReasoningContext::DiagnoseExpectedTargets() {
+    for (auto it = expected_traces_.begin(); it != expected_traces_.end(); ++it) {
+        it.value().diagnosis = DiagnoseTarget(it.value());
+    }
+}
+
+std::string
+ReasoningContext::DiagnoseTarget(const ExpectedTargetTrace& trace) {
+    if (!trace.was_visited) {
+        return "not_reachable";
+    }
+
+    if (trace.filter_rejected) {
+        return "filter_rejected";
+    }
+
+    if (trace.quantized_distance > trace.true_distance * 1.5F && trace.true_distance > 0.0F) {
+        return "quantization_error";
+    }
+
+    if (trace.was_evicted && !trace.was_in_result_set) {
+        return "ef_too_small";
+    }
+
+    if (trace.reorder_evicted && !trace.was_in_result_set) {
+        return "reorder_evicted";
+    }
+
+    if (!trace.was_in_result_set) {
+        return "unknown";
+    }
+
+    return "success";
+}
+
+std::string
+ReasoningContext::GenerateReport() const {
+    JsonType report;
+
+    int found_count = 0;
+    int missed_count = 0;
+
+    for (const auto& pair : expected_traces_) {
+        const auto& trace = pair.second;
+        if (trace.was_in_result_set) {
+            found_count++;
+        } else {
+            missed_count++;
+        }
+    }
+
+    std::string summary = std::to_string(found_count) + "/" +
+                          std::to_string(expected_traces_.size()) + " expected labels found, " +
+                          std::to_string(missed_count) + " missed";
+
+    report["expected_analysis"]["summary"].SetString(summary);
+
+    return report.Dump();
+}
+
+void
+ReasoningContext::SetSearchParams(int64_t topk,
+                                  const std::string& index_type,
+                                  bool use_reorder,
+                                  bool filter_active) {
+    topk_ = topk;
+    index_type_ = index_type;
+    use_reorder_ = use_reorder;
+    filter_active_ = filter_active;
+}
+
+void
+ReasoningContext::AddSearchHop() {
+    total_hops_++;
+}
+
+void
+ReasoningContext::AddDistanceComputation(uint32_t count) {
+    total_dist_computations_ += count;
+}
+
+}  // namespace vsag

--- a/src/impl/reasoning/search_reasoning.h
+++ b/src/impl/reasoning/search_reasoning.h
@@ -1,0 +1,120 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+#include "data_type.h"
+#include "impl/allocator/allocator_wrapper.h"
+#include "json_wrapper.h"
+#include "typing.h"
+
+namespace vsag {
+
+struct ExpectedTargetTrace {
+    int64_t label{0};
+    InnerIdType inner_id{0};
+    float true_distance{0.0F};
+    float quantized_distance{0.0F};
+    bool was_visited{false};
+    int32_t visited_at_hop{-1};
+    bool was_in_result_set{false};
+    bool was_evicted{false};
+    bool filter_rejected{false};
+    bool reorder_evicted{false};
+    std::string diagnosis{};
+
+    ExpectedTargetTrace() = default;
+};
+
+struct ReorderRecord {
+    InnerIdType id{0};
+    float dist_before{0.0F};
+    float dist_after{0.0F};
+};
+
+class ReasoningContext {
+public:
+    ReasoningContext(Allocator* allocator);
+
+    ~ReasoningContext();
+
+    void
+    InitializeExpectedTargets(const Vector<int64_t>& labels,
+                              const UnorderedMap<int64_t, InnerIdType>& label_to_inner_id,
+                              const float* query,
+                              const void* precise_vectors,
+                              DataTypes data_type,
+                              uint64_t dim);
+
+    void
+    RecordVisit(InnerIdType id, float dist, uint32_t hop);
+
+    void
+    RecordEviction(InnerIdType id, uint32_t hop);
+
+    void
+    RecordFilterReject(InnerIdType id);
+
+    void
+    RecordReorder(InnerIdType id, float dist_before, float dist_after);
+
+    void
+    SetTermination(const std::string& reason);
+
+    void
+    MarkResult(const Vector<InnerIdType>& result_ids);
+
+    void
+    DiagnoseExpectedTargets();
+
+    std::string
+    GenerateReport() const;
+
+    void
+    SetSearchParams(int64_t topk,
+                    const std::string& index_type,
+                    bool use_reorder,
+                    bool filter_active);
+
+    void
+    AddSearchHop();
+
+    void
+    AddDistanceComputation(uint32_t count = 1);
+
+public:
+    int64_t topk_{0};
+    std::string index_type_{};
+    bool use_reorder_{false};
+    bool filter_active_{false};
+
+    uint32_t total_hops_{0};
+    uint32_t total_dist_computations_{0};
+    std::string termination_reason_{};
+
+    UnorderedSet<InnerIdType> expected_inner_ids_;
+    UnorderedMap<InnerIdType, ExpectedTargetTrace> expected_traces_;
+    Vector<ReorderRecord> reorder_changes_;
+
+private:
+    Allocator* allocator_{nullptr};
+
+    static std::string
+    DiagnoseTarget(const ExpectedTargetTrace& trace);
+};
+
+}  // namespace vsag

--- a/src/impl/reasoning/search_reasoning_test.cpp
+++ b/src/impl/reasoning/search_reasoning_test.cpp
@@ -1,0 +1,258 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "search_reasoning.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "impl/allocator/default_allocator.h"
+
+namespace vsag {
+
+TEST_CASE("ReasoningContext basic operations", "[reasoning]") {
+    DefaultAllocator allocator;
+    ReasoningContext ctx(&allocator);
+
+    SECTION("Initialization") {
+        REQUIRE(ctx.topk_ == 0);
+        REQUIRE(ctx.total_hops_ == 0);
+        REQUIRE(ctx.total_dist_computations_ == 0);
+    }
+
+    SECTION("SetSearchParams") {
+        ctx.SetSearchParams(10, "hgraph", true, false);
+        REQUIRE(ctx.topk_ == 10);
+        REQUIRE(ctx.index_type_ == "hgraph");
+        REQUIRE(ctx.use_reorder_ == true);
+        REQUIRE(ctx.filter_active_ == false);
+    }
+
+    SECTION("AddSearchHop and AddDistanceComputation") {
+        ctx.AddSearchHop();
+        ctx.AddSearchHop();
+        REQUIRE(ctx.total_hops_ == 2);
+
+        ctx.AddDistanceComputation(5);
+        ctx.AddDistanceComputation(3);
+        REQUIRE(ctx.total_dist_computations_ == 8);
+    }
+}
+
+TEST_CASE("ReasoningContext with expected targets", "[reasoning]") {
+    DefaultAllocator allocator;
+    ReasoningContext ctx(&allocator);
+
+    Vector<int64_t> labels(&allocator);
+    labels.push_back(100);
+    labels.push_back(200);
+
+    UnorderedMap<int64_t, InnerIdType> label_to_inner_id(&allocator);
+    label_to_inner_id[100] = 0;
+    label_to_inner_id[200] = 1;
+
+    float query[4] = {1.0F, 0.0F, 0.0F, 0.0F};
+    float vectors[2][4] = {{1.0F, 0.0F, 0.0F, 0.0F}, {0.0F, 1.0F, 0.0F, 0.0F}};
+
+    SECTION("InitializeExpectedTargets") {
+        ctx.InitializeExpectedTargets(
+            labels, label_to_inner_id, query, vectors, DataTypes::DATA_TYPE_FLOAT, 4);
+        REQUIRE(ctx.expected_traces_.size() == 2);
+        REQUIRE(ctx.expected_inner_ids_.size() == 2);
+
+        auto it1 = ctx.expected_traces_.find(0);
+        REQUIRE(it1 != ctx.expected_traces_.end());
+        REQUIRE(it1.value().label == 100);
+        REQUIRE(it1.value().true_distance == 0.0F);
+
+        auto it2 = ctx.expected_traces_.find(1);
+        REQUIRE(it2 != ctx.expected_traces_.end());
+        REQUIRE(it2.value().label == 200);
+        REQUIRE(it2.value().true_distance > 0.0F);
+    }
+}
+
+TEST_CASE("ReasoningContext event recording", "[reasoning]") {
+    DefaultAllocator allocator;
+    ReasoningContext ctx(&allocator);
+
+    Vector<int64_t> labels(&allocator);
+    labels.push_back(100);
+
+    UnorderedMap<int64_t, InnerIdType> label_to_inner_id(&allocator);
+    label_to_inner_id[100] = 0;
+
+    float query[4] = {1.0F, 0.0F, 0.0F, 0.0F};
+    float vectors[1][4] = {{1.0F, 0.0F, 0.0F, 0.0F}};
+    ctx.InitializeExpectedTargets(
+        labels, label_to_inner_id, query, vectors, DataTypes::DATA_TYPE_FLOAT, 4);
+
+    SECTION("RecordVisit") {
+        ctx.RecordVisit(0, 0.5F, 1);
+        auto it = ctx.expected_traces_.find(0);
+        REQUIRE(it != ctx.expected_traces_.end());
+        REQUIRE(it.value().was_visited == true);
+        REQUIRE(it.value().visited_at_hop == 1);
+        REQUIRE(it.value().quantized_distance == 0.5F);
+    }
+
+    SECTION("RecordEviction") {
+        ctx.RecordEviction(0, 2);
+        auto it = ctx.expected_traces_.find(0);
+        REQUIRE(it != ctx.expected_traces_.end());
+        REQUIRE(it.value().was_evicted == true);
+        REQUIRE(it.value().was_visited == true);
+        REQUIRE(it.value().visited_at_hop == 2);
+    }
+
+    SECTION("RecordFilterReject") {
+        ctx.RecordFilterReject(0);
+        auto it = ctx.expected_traces_.find(0);
+        REQUIRE(it != ctx.expected_traces_.end());
+        REQUIRE(it.value().filter_rejected == true);
+        REQUIRE(it.value().was_visited == true);
+    }
+
+    SECTION("RecordReorder") {
+        ctx.RecordVisit(0, 0.3F, 1);
+        ctx.RecordReorder(0, 0.3F, 0.5F);
+        auto it = ctx.expected_traces_.find(0);
+        REQUIRE(it != ctx.expected_traces_.end());
+        REQUIRE(it.value().reorder_evicted == true);
+        REQUIRE(it.value().quantized_distance == 0.3F);
+        REQUIRE(it.value().true_distance == 0.5F);
+        REQUIRE(ctx.reorder_changes_.size() == 1);
+    }
+}
+
+TEST_CASE("ReasoningContext diagnosis logic", "[reasoning]") {
+    DefaultAllocator allocator;
+    ReasoningContext ctx(&allocator);
+
+    Vector<int64_t> labels(&allocator);
+    labels.push_back(100);
+    labels.push_back(200);
+    labels.push_back(300);
+    labels.push_back(400);
+    labels.push_back(500);
+    labels.push_back(600);
+    labels.push_back(700);
+
+    UnorderedMap<int64_t, InnerIdType> label_to_inner_id(&allocator);
+    label_to_inner_id[100] = 0;
+    label_to_inner_id[200] = 1;
+    label_to_inner_id[300] = 2;
+    label_to_inner_id[400] = 3;
+    label_to_inner_id[500] = 4;
+    label_to_inner_id[600] = 5;
+    label_to_inner_id[700] = 6;
+
+    float query[4] = {1.0F, 0.0F, 0.0F, 0.0F};
+    float vectors[7][4] = {
+        {1.0F, 0.0F, 0.0F, 0.0F},
+        {0.5F, 0.5F, 0.0F, 0.0F},
+        {0.0F, 1.0F, 0.0F, 0.0F},
+        {0.5F, 0.5F, 0.0F, 0.0F},
+        {0.0F, 1.0F, 0.0F, 0.0F},
+        {0.0F, 1.0F, 0.0F, 0.0F},
+        {0.0F, 1.0F, 0.0F, 0.0F},
+    };
+    ctx.InitializeExpectedTargets(
+        labels, label_to_inner_id, query, vectors, DataTypes::DATA_TYPE_FLOAT, 4);
+
+    SECTION("Diagnose: not_reachable") {
+        ctx.DiagnoseExpectedTargets();
+        auto it = ctx.expected_traces_.find(4);
+        REQUIRE(it != ctx.expected_traces_.end());
+        REQUIRE(it.value().diagnosis == "not_reachable");
+    }
+
+    SECTION("Diagnose: filter_rejected") {
+        ctx.RecordFilterReject(2);
+        ctx.DiagnoseExpectedTargets();
+        auto it = ctx.expected_traces_.find(2);
+        REQUIRE(it != ctx.expected_traces_.end());
+        REQUIRE(it.value().diagnosis == "filter_rejected");
+    }
+
+    SECTION("Diagnose: ef_too_small") {
+        ctx.RecordVisit(3, 0.5F, 1);
+        ctx.RecordEviction(3, 3);
+        ctx.DiagnoseExpectedTargets();
+        auto it = ctx.expected_traces_.find(3);
+        REQUIRE(it != ctx.expected_traces_.end());
+        REQUIRE(it.value().diagnosis == "ef_too_small");
+    }
+
+    SECTION("Diagnose: quantization_error") {
+        auto it = ctx.expected_traces_.find(5);
+        REQUIRE(it != ctx.expected_traces_.end());
+        it.value().true_distance = 0.5F;
+        it.value().quantized_distance = 1.0F;
+        it.value().was_visited = true;
+        ctx.DiagnoseExpectedTargets();
+        REQUIRE(it.value().diagnosis == "quantization_error");
+    }
+
+    SECTION("Diagnose: reorder_evicted") {
+        ctx.RecordVisit(6, 0.3F, 1);
+        ctx.RecordReorder(6, 0.3F, 0.8F);
+        ctx.DiagnoseExpectedTargets();
+        auto it = ctx.expected_traces_.find(6);
+        REQUIRE(it != ctx.expected_traces_.end());
+        REQUIRE(it.value().diagnosis == "reorder_evicted");
+    }
+
+    SECTION("Diagnose: success") {
+        ctx.RecordVisit(0, 0.0F, 1);
+        Vector<InnerIdType> result_ids(&allocator);
+        result_ids.push_back(0);
+        ctx.MarkResult(result_ids);
+        ctx.DiagnoseExpectedTargets();
+        auto it = ctx.expected_traces_.find(0);
+        REQUIRE(it != ctx.expected_traces_.end());
+        REQUIRE(it.value().diagnosis == "success");
+    }
+}
+
+TEST_CASE("ReasoningContext GenerateReport", "[reasoning]") {
+    DefaultAllocator allocator;
+    ReasoningContext ctx(&allocator);
+
+    Vector<int64_t> labels(&allocator);
+    labels.push_back(100);
+    labels.push_back(200);
+
+    UnorderedMap<int64_t, InnerIdType> label_to_inner_id(&allocator);
+    label_to_inner_id[100] = 0;
+    label_to_inner_id[200] = 1;
+
+    float query[4] = {1.0F, 0.0F, 0.0F, 0.0F};
+    float vectors[2][4] = {{1.0F, 0.0F, 0.0F, 0.0F}, {0.0F, 1.0F, 0.0F, 0.0F}};
+    ctx.InitializeExpectedTargets(
+        labels, label_to_inner_id, query, vectors, DataTypes::DATA_TYPE_FLOAT, 4);
+
+    ctx.RecordVisit(0, 0.0F, 1);
+    Vector<InnerIdType> result_ids(&allocator);
+    result_ids.push_back(0);
+    ctx.MarkResult(result_ids);
+
+    ctx.DiagnoseExpectedTargets();
+
+    std::string report = ctx.GenerateReport();
+    REQUIRE(report.find("expected_analysis") != std::string::npos);
+    REQUIRE(report.find("1/2") != std::string::npos);
+    REQUIRE(report.find("1 missed") != std::string::npos);
+}
+
+}  // namespace vsag


### PR DESCRIPTION
## Summary
Implement ReasoningContext class for tracking expected targets during search, collecting visit/eviction events, and generating diagnostic reports.

## Changes
- Add ExpectedTargetTrace struct to track expected target state during search
- Implement ReasoningContext class with methods for:
  - InitializeExpectedTargets: Setup tracking for expected labels
  - RecordVisit/RecordEviction/RecordFilterReject: Record search events
  - RecordReorder: Track reorder changes
  - DiagnoseExpectedTargets: Generate diagnosis for missed targets
  - GenerateReport: Output JSON report
- Add diagnosis logic covering: not_reachable, filter_rejected, quantization_error, ef_too_small, reorder_evicted
- Add unit tests covering all core functionalities

## Files Changed
- src/impl/reasoning/search_reasoning.h (new)
- src/impl/reasoning/search_reasoning.cpp (new)
- src/impl/reasoning/search_reasoning_test.cpp (new)
- src/impl/reasoning/CMakeLists.txt (new)
- src/impl/CMakeLists.txt (modified)

## Testing
- All unit tests passed (44 assertions in 5 test cases)
- Build successful with make release

## Related Issues
- Related to https://github.com/antgroup/vsag/issues/1836
- Parent: https://github.com/antgroup/vsag/issues/1829
- Depends on: https://github.com/antgroup/vsag/issues/1832 (completed)

## Checklist
- [x] Code follows VSAG coding style
- [x] All tests pass
- [x] Documentation updated (header comments)
- [x] PR description is clear