### PR TITLE
fix: backport VsagException inheritance fix to 0.18

### DIFF
--- a/src/factory/engine.cpp
+++ b/src/factory/engine.cpp
@@ -158,11 +158,11 @@ Engine::CreateIndex(const std::string& origin_name, const std::string& parameter
     } catch (const std::bad_alloc& e) {
         LOG_ERROR_AND_RETURNS(
             ErrorType::NO_ENOUGH_MEMORY, "failed to create index(not enough memory): ", e.what());
+    } catch (const vsag::VsagException& e) {
+        LOG_ERROR_AND_RETURNS(e.error_.type, "failed to create index: " + e.error_.message);
     } catch (const std::exception& e) {
         LOG_ERROR_AND_RETURNS(
             ErrorType::UNSUPPORTED_INDEX, "failed to create index(unknown error): ", e.what());
-    } catch (const vsag::VsagException& e) {
-        LOG_ERROR_AND_RETURNS(e.error_.type, "failed to create index: " + e.error_.message);
     }
 }
 

--- a/src/vsag_exception.h
+++ b/src/vsag_exception.h
@@ -20,7 +20,7 @@
 #include "vsag/errors.h"
 
 namespace vsag {
-class VsagException : std::exception {
+class VsagException : public std::exception {
 public:
     explicit VsagException(Error& error) : error_(error){};
 


### PR DESCRIPTION
## Summary
- backport PR #1776 to release branch `0.18`
- make `VsagException` publicly inherit from `std::exception` so it can be caught by standard exception handlers
- reorder catch blocks in `engine.cpp` to keep the derived exception handler before `std::exception`

## Verification
- `cmake -S . -B /tmp/vsag-pr1776-build -DENABLE_TESTS=OFF -DENABLE_EXAMPLES=OFF -DENABLE_TOOLS=OFF`
- `cmake --build /tmp/vsag-pr1776-build --target vsag -j4`