### PR TITLE
fix: propagate iterator filter init failures in hnsw

### DIFF
--- a/src/index/hnsw.cpp
+++ b/src/index/hnsw.cpp
@@ -294,9 +294,15 @@ HNSW::knn_search(const DatasetPtr& query,
 
         std::shared_lock lock_global(rw_mutex_);
         if (iter_ctx != nullptr && *iter_ctx == nullptr) {
-            auto* filter_context = new IteratorFilterContext();
-            filter_context->init(alg_hnsw_->getMaxElements(), params.ef_search, search_allocator);
-            *iter_ctx = filter_context;
+            auto filter_context = std::make_unique<IteratorFilterContext>();
+            if (auto ret = filter_context->init(
+                    alg_hnsw_->getMaxElements(), params.ef_search, search_allocator);
+                not ret.has_value()) {
+                auto err = ret.error();
+                logger::error("failed to init IteratorFilterContext: {}", err.message);
+                return tl::unexpected(err);
+            }
+            *iter_ctx = filter_context.release();
         }
         IteratorFilterContext* iter_filter_ctx = nullptr;
         if (iter_ctx != nullptr) {

--- a/src/index/hnsw.cpp
+++ b/src/index/hnsw.cpp
@@ -298,9 +298,7 @@ HNSW::knn_search(const DatasetPtr& query,
             if (auto ret = filter_context->init(
                     alg_hnsw_->getMaxElements(), params.ef_search, search_allocator);
                 not ret.has_value()) {
-                auto err = ret.error();
-                logger::error("failed to init IteratorFilterContext: {}", err.message);
-                return tl::unexpected(err);
+                return tl::unexpected(std::move(ret).error());
             }
             *iter_ctx = filter_context.release();
         }

--- a/src/index/hnsw_test.cpp
+++ b/src/index/hnsw_test.cpp
@@ -16,6 +16,7 @@
 #include "hnsw.h"
 
 #include <catch2/catch_test_macros.hpp>
+#include <cstdlib>
 #include <memory>
 #include <nlohmann/json.hpp>
 #include <vector>
@@ -193,6 +194,82 @@ TEST_CASE("knn_search", "[ut][hnsw]") {
         REQUIRE_FALSE(result.has_value());
         REQUIRE(result.error().type == ErrorType::INVALID_ARGUMENT);
     }
+}
+
+TEST_CASE("iterator filter init allocation failure", "[ut][hnsw]") {
+    logger::set_level(logger::level::debug);
+
+    class FailingAllocator : public Allocator {
+    public:
+        std::string
+        Name() override {
+            return "failing-allocator";
+        }
+
+        void*
+        Allocate(uint64_t size) override {
+            if (size == failed_size_) {
+                throw std::bad_alloc();
+            }
+            return std::malloc(size);
+        }
+
+        void
+        Deallocate(void* p) override {
+            std::free(p);
+        }
+
+        void*
+        Reallocate(void* p, uint64_t size) override {
+            if (size == failed_size_) {
+                throw std::bad_alloc();
+            }
+            return std::realloc(p, size);
+        }
+
+        uint64_t failed_size_{0};
+    };
+
+    const int64_t dim = 128;
+    const int64_t num_elements = 10;
+    IndexCommonParam common_param;
+    common_param.dim_ = dim;
+    common_param.data_type_ = DataTypes::DATA_TYPE_FLOAT;
+    common_param.metric_ = MetricType::METRIC_TYPE_L2SQR;
+    common_param.allocator_ = SafeAllocator::FactoryDefaultAllocator();
+
+    HnswParameters hnsw_obj = parse_hnsw_params(common_param);
+    hnsw_obj.max_degree = 12;
+    hnsw_obj.ef_construction = 100;
+    auto index = std::make_shared<HNSW>(hnsw_obj, common_param);
+    index->InitMemorySpace();
+
+    auto [ids, vectors] = fixtures::generate_ids_and_vectors(num_elements, dim);
+
+    auto dataset = Dataset::Make();
+    dataset->Dim(dim)
+        ->NumElements(num_elements)
+        ->Ids(ids.data())
+        ->Float32Vectors(vectors.data())
+        ->Owner(false);
+    REQUIRE(index->Build(dataset).has_value());
+
+    auto query = Dataset::Make();
+    query->NumElements(1)->Dim(dim)->Float32Vectors(vectors.data())->Owner(false);
+
+    JsonType params;
+    params["hnsw"]["ef_search"].SetInt(100);
+    auto search_parameters = params.Dump();
+
+    FailingAllocator allocator;
+    allocator.failed_size_ = 2;
+    IteratorContext* iter_ctx = nullptr;
+    SearchParam search_param(true, search_parameters, nullptr, &allocator, iter_ctx, false);
+
+    auto result = index->KnnSearch(query, 10, search_param);
+    REQUIRE_FALSE(result.has_value());
+    REQUIRE(result.error().type == ErrorType::NO_ENOUGH_MEMORY);
+    REQUIRE(search_param.iter_ctx == nullptr);
 }
 
 TEST_CASE("range_search", "[ut][hnsw]") {

--- a/src/index/hnsw_test.cpp
+++ b/src/index/hnsw_test.cpp
@@ -18,6 +18,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <cstdlib>
 #include <memory>
+#include <new>
 #include <nlohmann/json.hpp>
 #include <vector>
 
@@ -208,10 +209,14 @@ TEST_CASE("iterator filter init allocation failure", "[ut][hnsw]") {
 
         void*
         Allocate(uint64_t size) override {
-            if (size == failed_size_) {
+            if (++allocate_count_ == fail_on_allocate_) {
                 throw std::bad_alloc();
             }
-            return std::malloc(size);
+            auto* ptr = std::malloc(size);
+            if (ptr == nullptr) {
+                throw std::bad_alloc();
+            }
+            return ptr;
         }
 
         void
@@ -221,13 +226,20 @@ TEST_CASE("iterator filter init allocation failure", "[ut][hnsw]") {
 
         void*
         Reallocate(void* p, uint64_t size) override {
-            if (size == failed_size_) {
+            if (++reallocate_count_ == fail_on_reallocate_) {
                 throw std::bad_alloc();
             }
-            return std::realloc(p, size);
+            auto* ptr = std::realloc(p, size);
+            if (ptr == nullptr) {
+                throw std::bad_alloc();
+            }
+            return ptr;
         }
 
-        uint64_t failed_size_{0};
+        uint64_t fail_on_allocate_{std::numeric_limits<uint64_t>::max()};
+        uint64_t fail_on_reallocate_{std::numeric_limits<uint64_t>::max()};
+        uint64_t allocate_count_{0};
+        uint64_t reallocate_count_{0};
     };
 
     const int64_t dim = 128;
@@ -262,7 +274,7 @@ TEST_CASE("iterator filter init allocation failure", "[ut][hnsw]") {
     auto search_parameters = params.Dump();
 
     FailingAllocator allocator;
-    allocator.failed_size_ = 2;
+    allocator.fail_on_allocate_ = 1;
     IteratorContext* iter_ctx = nullptr;
     SearchParam search_param(true, search_parameters, nullptr, &allocator, iter_ctx, false);
 


### PR DESCRIPTION
## Summary
- handle `IteratorFilterContext::init()` failures in `HNSW::knn_search()` instead of continuing with a null context
- use RAII for the temporary iterator context during initialization and preserve the original allocation error
- add a targeted regression test that forces iterator filter initialization to fail and verifies `NO_ENOUGH_MEMORY` is returned

## Testing
- `./build/tests/unittests \"iterator filter init allocation failure\"`

#1842 