### PR TITLE
chore: enforce kind and version labels on PRs via Mergify

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -225,7 +225,7 @@ namespace vsag {
 
 Every pull request **must** have both of the following labels before it can be merged:
 
-- A **`kind/*`** label indicating the type of change (e.g. `kind/feature`, `kind/bug`, `kind/chore`, `kind/docs`).
+- A **`kind/*`** label indicating the type of change: `kind/bug` (bug fix), `kind/feature` (new feature), `kind/improvement` (refactor, chore, or minor improvement), or `kind/documentation` (documentation change).
 - A **`version/*`** label indicating the target version (e.g. `version/1.0`, `version/0.18`).
 
 Mergify enforces these labels via check runs. When creating a PR, always add the appropriate `kind/*` and `version/*` labels.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -221,6 +221,15 @@ namespace vsag {
 4. **Document**: Update relevant documentation and examples
 5. **Review Coverage**: Ensure test coverage remains >= 90%
 
+## Pull Request Labels
+
+Every pull request **must** have both of the following labels before it can be merged:
+
+- A **`kind/*`** label indicating the type of change (e.g. `kind/feature`, `kind/bug`, `kind/chore`, `kind/docs`).
+- A **`version/*`** label indicating the version impact (e.g. `version/major`, `version/minor`, `version/patch`).
+
+Mergify enforces these labels via check runs. When creating a PR, always add the appropriate `kind/*` and `version/*` labels.
+
 ## Common Gotchas
 
 - Don't use `.cc` extension; use `.cpp`

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -226,7 +226,7 @@ namespace vsag {
 Every pull request **must** have both of the following labels before it can be merged:
 
 - A **`kind/*`** label indicating the type of change (e.g. `kind/feature`, `kind/bug`, `kind/chore`, `kind/docs`).
-- A **`version/*`** label indicating the version impact (e.g. `version/major`, `version/minor`, `version/patch`).
+- A **`version/*`** label indicating the target version (e.g. `version/1.0`, `version/0.18`).
 
 Mergify enforces these labels via check runs. When creating a PR, always add the appropriate `kind/*` and `version/*` labels.
 

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -107,23 +107,15 @@ pull_request_rules:
       label:
         add:
           - module/testing
-  - name: require kind label
-    conditions:
-      - -label~=^kind/
-    actions:
-      post_check:
-        title: kind label missing
-        summary: PR must have a `kind/*` label (e.g. kind/feature, kind/bug, kind/chore, kind/docs).
-        conclusion: failure
+merge_protections:
+  - name: Require kind label
+    if:
+      - base=main
+    success_conditions:
+      - label~=^kind/
 
-  - name: require version label
-    conditions:
-      - -label~=^version/
-    actions:
-      post_check:
-        title: version label missing
-        summary: PR must have a `version/*` label (e.g. version/major, version/minor, version/patch).
-        conclusion: failure
-
-merge_protections_settings:
-  reporting_method: check-runs
+  - name: Require version label
+    if:
+      - base=main
+    success_conditions:
+      - label~=^version/

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -107,5 +107,21 @@ pull_request_rules:
       label:
         add:
           - module/testing
+  - name: require kind label
+    conditions:
+      - -label~=^kind/
+    actions:
+      post_check:
+        title: kind label missing
+        summary: PR must have a `kind/*` label (e.g. kind/feature, kind/bug, kind/chore).
+
+  - name: require version label
+    conditions:
+      - -label~=^version/
+    actions:
+      post_check:
+        title: version label missing
+        summary: PR must have a `version/*` label (e.g. version/minor, version/patch).
+
 merge_protections_settings:
   reporting_method: check-runs

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -113,7 +113,8 @@ pull_request_rules:
     actions:
       post_check:
         title: kind label missing
-        summary: PR must have a `kind/*` label (e.g. kind/feature, kind/bug, kind/chore).
+        summary: PR must have a `kind/*` label (e.g. kind/feature, kind/bug, kind/chore, kind/docs).
+        conclusion: failure
 
   - name: require version label
     conditions:
@@ -121,7 +122,8 @@ pull_request_rules:
     actions:
       post_check:
         title: version label missing
-        summary: PR must have a `version/*` label (e.g. version/minor, version/patch).
+        summary: PR must have a `version/*` label (e.g. version/major, version/minor, version/patch).
+        conclusion: failure
 
 merge_protections_settings:
   reporting_method: check-runs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,7 +119,7 @@ Update relevant docs when behavior changes:
 Every pull request **must** have two labels before it can be merged:
 
 - A `kind/*` label for the type of change (e.g. `kind/feature`, `kind/bug`, `kind/chore`, `kind/docs`).
-- A `version/*` label for the version impact (e.g. `version/major`, `version/minor`, `version/patch`).
+- A `version/*` label for the target version (e.g. `version/1.0`, `version/0.18`).
 
 Mergify enforces these via check runs. Always add both labels when creating a PR.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,7 +118,7 @@ Update relevant docs when behavior changes:
 
 Every pull request **must** have two labels before it can be merged:
 
-- A `kind/*` label for the type of change (e.g. `kind/feature`, `kind/bug`, `kind/chore`, `kind/docs`).
+- A `kind/*` label for the type of change: `kind/bug` (bug fix), `kind/feature` (new feature), `kind/improvement` (refactor, chore, or minor improvement), or `kind/documentation` (documentation change).
 - A `version/*` label for the target version (e.g. `version/1.0`, `version/0.18`).
 
 Mergify enforces these via check runs. Always add both labels when creating a PR.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,15 @@ Update relevant docs when behavior changes:
 - When using skip-CI commit messages, follow the repository convention and place `[skip ci]` at the
   beginning of the subject line.
 
+## Pull Request Labels
+
+Every pull request **must** have two labels before it can be merged:
+
+- A `kind/*` label for the type of change (e.g. `kind/feature`, `kind/bug`, `kind/chore`, `kind/docs`).
+- A `version/*` label for the version impact (e.g. `version/major`, `version/minor`, `version/patch`).
+
+Mergify enforces these via check runs. Always add both labels when creating a PR.
+
 ## References
 
 - `README.md`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,7 +144,7 @@ $ bash scripts/coverage/collect_cpp_coverage.sh
 
 Every pull request **must** have the following two labels before it can be merged:
 
--   A **`kind/*`** label indicating the type of change, e.g. `kind/feature`, `kind/bug`, `kind/chore`, `kind/docs`.
+-   A **`kind/*`** label indicating the type of change: `kind/bug` (bug fix), `kind/feature` (new feature), `kind/improvement` (refactor, chore, or minor improvement), or `kind/documentation` (documentation change).
 -   A **`version/*`** label indicating the target version, e.g. `version/1.0`, `version/0.18`.
 
 Mergify enforces these labels via check runs. The PR merge will be blocked until both labels are present.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,7 +145,7 @@ $ bash scripts/coverage/collect_cpp_coverage.sh
 Every pull request **must** have the following two labels before it can be merged:
 
 -   A **`kind/*`** label indicating the type of change, e.g. `kind/feature`, `kind/bug`, `kind/chore`, `kind/docs`.
--   A **`version/*`** label indicating the version impact, e.g. `version/major`, `version/minor`, `version/patch`.
+-   A **`version/*`** label indicating the target version, e.g. `version/1.0`, `version/0.18`.
 
 Mergify enforces these labels via check runs. The PR merge will be blocked until both labels are present.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,6 +140,15 @@ $ bash scripts/testing/test_parallel_bg.sh
 $ bash scripts/coverage/collect_cpp_coverage.sh
 ```
 
+## Pull Request Labels
+
+Every pull request **must** have the following two labels before it can be merged:
+
+-   A **`kind/*`** label indicating the type of change, e.g. `kind/feature`, `kind/bug`, `kind/chore`, `kind/docs`.
+-   A **`version/*`** label indicating the version impact, e.g. `version/major`, `version/minor`, `version/patch`.
+
+Mergify enforces these labels via check runs. The PR merge will be blocked until both labels are present.
+
 ## Commit message and skip CI
 
 -   Follow Conventional Commits in the subject line, such as `feat:`, `fix:`, `docs:`, or `chore:`.


### PR DESCRIPTION
## Summary

- Add Mergify merge protections to block PR merges when `kind/*` or `version/*` labels are missing.
- Document the label requirement in `CONTRIBUTING.md`, `.github/copilot-instructions.md`, and `CLAUDE.md` so that both human contributors and AI agents are aware of the policy.