### PR TITLE
fix: prevent memory leak when MemoryIO reallocate fails

### DIFF
--- a/src/impl/allocator/default_allocator.cpp
+++ b/src/impl/allocator/default_allocator.cpp
@@ -73,11 +73,13 @@ DefaultAllocator::Reallocate(void* p, uint64_t size) {
             ErrorType::INTERNAL_ERROR,
             fmt::format("reallocate: address {} is not allocated by {}", p, Name()));
     }
-    allocated_ptrs_.erase(p);
 #endif
     auto* ptr = realloc(p, size);
 #ifndef NDEBUG
-    allocated_ptrs_.insert(ptr);
+    if (ptr != nullptr) {
+        allocated_ptrs_.erase(p);
+        allocated_ptrs_.insert(ptr);
+    }
 #endif
     return ptr;
 }

--- a/src/impl/allocator/default_allocator_test.cpp
+++ b/src/impl/allocator/default_allocator_test.cpp
@@ -16,6 +16,13 @@
 #include "default_allocator.h"
 
 #include "unittest.h"
+
+#if defined(__has_feature)
+#define VSAG_HAS_ADDRESS_SANITIZER __has_feature(address_sanitizer)
+#else
+#define VSAG_HAS_ADDRESS_SANITIZER 0
+#endif
+
 TEST_CASE("DefaultAllocator Basic Test", "[ut][DefaultAllocator]") {
     vsag::DefaultAllocator allocator;
     int number = 69278;
@@ -44,3 +51,22 @@ TEST_CASE("DefaultAllocator Mismatch of Malloc and Free", "[ut][DefaultAllocator
     allocator.Deallocate(nullptr);
 #endif
 }
+
+TEST_CASE("DefaultAllocator Reallocate Failure Keeps Tracking", "[ut][DefaultAllocator]") {
+#ifndef NDEBUG
+#if defined(__SANITIZE_ADDRESS__) || VSAG_HAS_ADDRESS_SANITIZER
+    SKIP("ASan aborts oversize realloc before DefaultAllocator can observe a nullptr result");
+#else
+    vsag::DefaultAllocator allocator;
+    auto* p = allocator.Allocate(1ULL << 20);
+    REQUIRE(p != nullptr);
+
+    auto* ret = allocator.Reallocate(p, UINT64_MAX);
+    REQUIRE(ret == nullptr);
+
+    REQUIRE_NOTHROW(allocator.Deallocate(p));
+#endif
+#endif
+}
+
+#undef VSAG_HAS_ADDRESS_SANITIZER

--- a/src/io/memory_io.cpp
+++ b/src/io/memory_io.cpp
@@ -20,7 +20,7 @@ namespace vsag {
 void
 MemoryIO::WriteImpl(const uint8_t* data, uint64_t size, uint64_t offset) {
     check_and_realloc(size + offset);
-    memcpy(start_ + offset, data, size);
+    memcpy(buffer_ + offset, data, size);
 }
 
 void
@@ -37,7 +37,7 @@ bool
 MemoryIO::ReadImpl(uint64_t size, uint64_t offset, uint8_t* data) const {
     bool ret = check_valid_offset(size + offset);
     if (ret) {
-        memcpy(data, start_ + offset, size);
+        memcpy(data, buffer_ + offset, size);
     }
     return ret;
 }
@@ -46,7 +46,7 @@ const uint8_t*
 MemoryIO::DirectReadImpl(uint64_t size, uint64_t offset, bool& need_release) const {
     need_release = false;
     if (check_valid_offset(size + offset)) {
-        return start_ + offset;
+        return buffer_ + offset;
     }
     return nullptr;
 }
@@ -61,6 +61,6 @@ MemoryIO::MultiReadImpl(uint8_t* datas, uint64_t* sizes, uint64_t* offsets, uint
 }
 void
 MemoryIO::PrefetchImpl(uint64_t offset, uint64_t cache_line) {
-    PrefetchLines(this->start_ + offset, cache_line);
+    PrefetchLines(this->buffer_ + offset, cache_line);
 }
 }  // namespace vsag

--- a/src/io/memory_io.h
+++ b/src/io/memory_io.h
@@ -1,4 +1,3 @@
-
 // Copyright 2024-present the vsag project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,6 +20,7 @@
 #include "index_common_param.h"
 #include "memory_io_parameter.h"
 #include "utils/prefetch.h"
+#include "vsag_exception.h"
 
 namespace vsag {
 
@@ -48,7 +48,11 @@ public:
      * @param allocator A pointer to the Allocator for memory management.
      */
     explicit MemoryIO(Allocator* allocator) : BasicIO<MemoryIO>(allocator) {
-        start_ = static_cast<uint8_t*>(allocator->Allocate(1));
+        buffer_ = static_cast<uint8_t*>(allocator->Allocate(1));
+        if (buffer_ == nullptr) {
+            throw VsagException(ErrorType::NO_ENOUGH_MEMORY,
+                                "failed to allocate initial buffer in MemoryIO");
+        }
     }
 
     /**
@@ -75,7 +79,7 @@ public:
      * @brief Destructor that deallocates the memory buffer.
      */
     ~MemoryIO() override {
-        this->allocator_->Deallocate(start_);
+        this->allocator_->Deallocate(buffer_);
     }
 
     /**
@@ -146,6 +150,10 @@ private:
     /**
      * @brief Checks the required size and reallocates the buffer if needed.
      *
+     * Uses a temporary pointer for Reallocate result to prevent memory leak
+     * on allocation failure. The original buffer pointer is only updated
+     * after successful reallocation.
+     *
      * @param size The required size for the buffer.
      */
     void
@@ -153,12 +161,18 @@ private:
         if (size <= this->size_) {
             return;
         }
-        start_ = reinterpret_cast<uint8_t*>(this->allocator_->Reallocate(start_, size));
+        uint8_t* new_buffer = static_cast<uint8_t*>(this->allocator_->Reallocate(buffer_, size));
+        if (new_buffer == nullptr) {
+            throw VsagException(ErrorType::NO_ENOUGH_MEMORY,
+                                "failed to reallocate memory in MemoryIO, requested size: ",
+                                size);
+        }
+        buffer_ = new_buffer;
         this->size_ = size;
     }
 
 private:
     /// Pointer to the start of the allocated memory buffer.
-    uint8_t* start_{nullptr};
+    uint8_t* buffer_{nullptr};
 };
 }  // namespace vsag

--- a/src/io/memory_io_test.cpp
+++ b/src/io/memory_io_test.cpp
@@ -1,4 +1,3 @@
-
 // Copyright 2024-present the vsag project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,6 +14,7 @@
 
 #include "memory_io.h"
 
+#include <cstdlib>
 #include <memory>
 
 #include "basic_io_test.h"
@@ -34,4 +34,113 @@ TEST_CASE("MemoryIO Serialize and Deserialize", "[ut][MemoryIO]") {
     auto wio = std::make_unique<MemoryIO>(allocator.get());
     auto rio = std::make_unique<MemoryIO>(allocator.get());
     TestSerializeAndDeserialize(*wio, *rio);
+}
+
+class FailAllocator : public Allocator {
+public:
+    std::string
+    Name() override {
+        return "FailAllocator";
+    }
+
+    void*
+    Allocate(uint64_t size) override {
+        if (fail_on_allocate_) {
+            return nullptr;
+        }
+        return std::malloc(size);
+    }
+
+    void
+    Deallocate(void* p) override {
+        std::free(p);
+    }
+
+    void*
+    Reallocate(void* p, uint64_t size) override {
+        if (reallocate_allowed_count_ > 0) {
+            --reallocate_allowed_count_;
+            return std::realloc(p, size);
+        }
+        if (fail_on_reallocate_) {
+            return nullptr;
+        }
+        return std::realloc(p, size);
+    }
+
+    void
+    SetFailOnReallocate(bool fail) {
+        fail_on_reallocate_ = fail;
+    }
+    void
+    SetFailOnAllocate(bool fail) {
+        fail_on_allocate_ = fail;
+    }
+    void
+    SetReallocateAllowedCount(int count) {
+        reallocate_allowed_count_ = count;
+    }
+
+private:
+    bool fail_on_allocate_ = false;
+    bool fail_on_reallocate_ = false;
+    int reallocate_allowed_count_ = 0;
+};
+
+TEST_CASE("MemoryIO Allocation Failure", "[ut][MemoryIO]") {
+    FailAllocator fail_allocator;
+    fail_allocator.SetFailOnAllocate(true);
+
+    REQUIRE_THROWS_AS(std::make_unique<MemoryIO>(&fail_allocator), VsagException);
+}
+
+TEST_CASE("MemoryIO Allocation Failure Error Type", "[ut][MemoryIO]") {
+    FailAllocator fail_allocator;
+    fail_allocator.SetFailOnAllocate(true);
+
+    try {
+        std::make_unique<MemoryIO>(&fail_allocator);
+        FAIL("Expected VsagException to be thrown");
+    } catch (const VsagException& e) {
+        REQUIRE(e.error_.type == ErrorType::NO_ENOUGH_MEMORY);
+    }
+}
+
+TEST_CASE("MemoryIO Reallocate Failure", "[ut][MemoryIO]") {
+    FailAllocator fail_allocator;
+    fail_allocator.SetFailOnAllocate(false);
+    fail_allocator.SetReallocateAllowedCount(1);
+    fail_allocator.SetFailOnReallocate(true);
+
+    auto io = std::make_unique<MemoryIO>(&fail_allocator);
+
+    const char* test_data = "initial data";
+    io->Write(reinterpret_cast<const uint8_t*>(test_data), strlen(test_data), 0);
+
+    REQUIRE_THROWS_AS(
+        io->Write(reinterpret_cast<const uint8_t*>("more data"), strlen("more data"), 1000),
+        VsagException);
+
+    std::vector<uint8_t> read_buffer(strlen(test_data));
+    REQUIRE(io->Read(strlen(test_data), 0, read_buffer.data()));
+    REQUIRE(std::string(reinterpret_cast<char*>(read_buffer.data()), strlen(test_data)) ==
+            test_data);
+}
+
+TEST_CASE("MemoryIO Reallocate Failure Error Type", "[ut][MemoryIO]") {
+    FailAllocator fail_allocator;
+    fail_allocator.SetFailOnAllocate(false);
+    fail_allocator.SetReallocateAllowedCount(1);
+    fail_allocator.SetFailOnReallocate(true);
+
+    auto io = std::make_unique<MemoryIO>(&fail_allocator);
+
+    io->Write(reinterpret_cast<const uint8_t*>("initial"), 7, 0);
+
+    try {
+        io->Write(reinterpret_cast<const uint8_t*>("large"), 5, 1000);
+        FAIL("Expected VsagException to be thrown");
+    } catch (const VsagException& e) {
+        REQUIRE(e.error_.type == ErrorType::NO_ENOUGH_MEMORY);
+    }
 }


### PR DESCRIPTION
When Reallocate returns nullptr in MemoryIO::check_and_realloc, the original pointer was being overwritten, causing a memory leak. 

This PR fixes the issue by:
1. Saving the Reallocate return value to a temporary variable
2. Checking if the return value is nullptr
3. Throwing VsagException with ErrorType::NO_ENOUGH_MEMORY if allocation fails
4. Adding a unit test to verify the exception handling

Changes:
- Modified src/io/memory_io.h to check Reallocate result before updating pointer
- Added test case in src/io/memory_io_test.cpp for allocation failure scenario