### PR TITLE
chore: replace all-contributors with contributors-readme-action

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -13,6 +13,8 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
       - name: Contribute List
         uses: akhilmhdh/contributors-readme-action@v2.3.11
         env:

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -1,0 +1,19 @@
+name: Update Contributors
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  contributors:
+    runs-on: ubuntu-latest
+    name: Update contributors in README
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Contribute List
+        uses: akhilmhdh/contributors-readme-action@v2.3.11
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -167,8 +167,12 @@ VSAG referenced the following works during its implementation:
 
 ## Contributors
 
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
 <!-- readme: contributors -start -->
 <!-- readme: contributors -end -->
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
 
 ## Star History
 

--- a/README.md
+++ b/README.md
@@ -167,14 +167,8 @@ VSAG referenced the following works during its implementation:
 
 ## Contributors
 
-<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
-<!-- prettier-ignore-start -->
-<!-- markdownlint-disable -->
-
-<!-- markdownlint-restore -->
-<!-- prettier-ignore-end -->
-
-<!-- ALL-CONTRIBUTORS-LIST:END -->
+<!-- readme: contributors -start -->
+<!-- readme: contributors -end -->
 
 ## Star History
 


### PR DESCRIPTION
## Summary

- Replace the non-functional all-contributors bot markers in README.md with `akhilmhdh/contributors-readme-action` markers
- Add `.github/workflows/contributors.yml` that automatically updates the contributors list on each push to `main`
- No manual `@all-contributors add` needed — the action fetches contributors from GitHub API automatically