### PR TITLE
fix: backport JsonWrapper copy constructor fix to 0.18

### DIFF
--- a/src/json_wrapper.cpp
+++ b/src/json_wrapper.cpp
@@ -30,12 +30,7 @@ JsonWrapper::~JsonWrapper() {
     }
 }
 
-JsonWrapper::JsonWrapper(const JsonWrapper& other) {
-    if (owns_json_) {
-        delete json_;
-    }
-    json_ = new nlohmann::json();
-    owns_json_ = true;
+JsonWrapper::JsonWrapper(const JsonWrapper& other) : json_(new nlohmann::json()), owns_json_(true) {
     if (other.json_ != nullptr) {
         *json_ = *other.json_;
     }

--- a/src/json_wrapper_test.cpp
+++ b/src/json_wrapper_test.cpp
@@ -1,3 +1,17 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "json_wrapper.h"
 
 #include <catch2/catch_test_macros.hpp>
@@ -6,8 +20,7 @@ TEST_CASE("JsonWrapper copy constructor preserves valid strings", "[ut][json]") 
     vsag::JsonWrapper param;
     param["index_param"].SetString("{\n    \"window_size\": 20000\n}");
 
-    vsag::JsonWrapper basic_info;
-    basic_info.SetJson(param);
+    vsag::JsonWrapper basic_info = param;
 
     REQUIRE_NOTHROW(basic_info.Dump());
     REQUIRE(basic_info["index_param"].GetString() == "{\n    \"window_size\": 20000\n}");

--- a/src/json_wrapper_test.cpp
+++ b/src/json_wrapper_test.cpp
@@ -1,0 +1,14 @@
+#include "json_wrapper.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+TEST_CASE("JsonWrapper copy constructor preserves valid strings", "[ut][json]") {
+    vsag::JsonWrapper param;
+    param["index_param"].SetString("{\n    \"window_size\": 20000\n}");
+
+    vsag::JsonWrapper basic_info;
+    basic_info.SetJson(param);
+
+    REQUIRE_NOTHROW(basic_info.Dump());
+    REQUIRE(basic_info["index_param"].GetString() == "{\n    \"window_size\": 20000\n}");
+}


### PR DESCRIPTION
## Summary
- backport the `JsonWrapper` copy-constructor fix to `0.18` to avoid undefined behavior during metadata JSON serialization
- add a regression test covering `JsonWrapper` copy and JSON dumping with string content
- fix the SINDI serialization failure reported in #1860 without changing the public API

fixes: #1860