### PR TITLE
fix: propagate iterator filter init failures in hnsw

### DIFF
--- a/src/index/hnsw.cpp
+++ b/src/index/hnsw.cpp
@@ -296,9 +296,13 @@ HNSW::knn_search(const DatasetPtr& query,
 
         std::shared_lock lock_global(rw_mutex_);
         if (iter_ctx != nullptr && *iter_ctx == nullptr) {
-            auto* filter_context = new IteratorFilterContext();
-            filter_context->init(alg_hnsw_->getMaxElements(), params.ef_search, search_allocator);
-            *iter_ctx = filter_context;
+            auto filter_context = std::make_unique<IteratorFilterContext>();
+            if (auto ret = filter_context->init(
+                    alg_hnsw_->getMaxElements(), params.ef_search, search_allocator);
+                not ret.has_value()) {
+                return tl::unexpected(std::move(ret).error());
+            }
+            *iter_ctx = filter_context.release();
         }
         IteratorFilterContext* iter_filter_ctx = nullptr;
         if (iter_ctx != nullptr) {

--- a/src/index/hnsw_test.cpp
+++ b/src/index/hnsw_test.cpp
@@ -16,7 +16,10 @@
 #include "hnsw.h"
 
 #include <catch2/catch_test_macros.hpp>
+#include <cstdlib>
+#include <limits>
 #include <memory>
+#include <new>
 #include <nlohmann/json.hpp>
 #include <vector>
 
@@ -193,6 +196,92 @@ TEST_CASE("knn_search", "[ut][hnsw]") {
         REQUIRE_FALSE(result.has_value());
         REQUIRE(result.error().type == ErrorType::INVALID_ARGUMENT);
     }
+}
+
+TEST_CASE("iterator filter init allocation failure", "[ut][hnsw]") {
+    logger::set_level(logger::level::debug);
+
+    class FailingAllocator : public Allocator {
+    public:
+        std::string
+        Name() override {
+            return "failing-allocator";
+        }
+
+        void*
+        Allocate(size_t size) override {
+            if (++allocate_count_ == fail_on_allocate_) {
+                throw std::bad_alloc();
+            }
+            auto* ptr = std::malloc(size);
+            if (ptr == nullptr) {
+                throw std::bad_alloc();
+            }
+            return ptr;
+        }
+
+        void
+        Deallocate(void* p) override {
+            std::free(p);
+        }
+
+        void*
+        Reallocate(void* p, size_t size) override {
+            if (++reallocate_count_ == fail_on_reallocate_) {
+                throw std::bad_alloc();
+            }
+            auto* ptr = std::realloc(p, size);
+            if (ptr == nullptr) {
+                throw std::bad_alloc();
+            }
+            return ptr;
+        }
+
+        size_t fail_on_allocate_{std::numeric_limits<size_t>::max()};
+        size_t fail_on_reallocate_{std::numeric_limits<size_t>::max()};
+        size_t allocate_count_{0};
+        size_t reallocate_count_{0};
+    };
+
+    const int64_t dim = 128;
+    const int64_t num_elements = 10;
+    IndexCommonParam common_param;
+    common_param.dim_ = dim;
+    common_param.data_type_ = DataTypes::DATA_TYPE_FLOAT;
+    common_param.metric_ = MetricType::METRIC_TYPE_L2SQR;
+    common_param.allocator_ = SafeAllocator::FactoryDefaultAllocator();
+
+    HnswParameters hnsw_obj = parse_hnsw_params(common_param);
+    hnsw_obj.max_degree = 12;
+    hnsw_obj.ef_construction = 100;
+    auto index = std::make_shared<HNSW>(hnsw_obj, common_param);
+    index->InitMemorySpace();
+
+    auto [ids, vectors] = fixtures::generate_ids_and_vectors(num_elements, dim);
+
+    auto dataset = Dataset::Make();
+    dataset->Dim(dim)
+        ->NumElements(num_elements)
+        ->Ids(ids.data())
+        ->Float32Vectors(vectors.data())
+        ->Owner(false);
+    REQUIRE(index->Build(dataset).has_value());
+
+    auto query = Dataset::Make();
+    query->NumElements(1)->Dim(dim)->Float32Vectors(vectors.data())->Owner(false);
+
+    JsonType params;
+    params["hnsw"]["ef_search"].SetInt(100);
+    auto search_parameters = params.Dump();
+
+    FailingAllocator allocator;
+    allocator.fail_on_allocate_ = 1;
+    SearchParam search_param(true, search_parameters, nullptr, &allocator, nullptr, false);
+
+    auto result = index->KnnSearch(query, 10, search_param);
+    REQUIRE_FALSE(result.has_value());
+    REQUIRE(result.error().type == ErrorType::NO_ENOUGH_MEMORY);
+    REQUIRE(search_param.iter_ctx == nullptr);
 }
 
 TEST_CASE("range_search", "[ut][hnsw]") {


### PR DESCRIPTION
## Summary
- propagate `IteratorFilterContext::init()` failures from `HNSW::knn_search()` on the 0.17 branch instead of continuing with an uninitialized iterator context
- keep iterator filter context initialization RAII-safe so failed setup does not leak or publish a partial context
- add a regression test that forces iterator filter allocation failure and verifies `NO_ENOUGH_MEMORY` is returned

## Testing
- `./build-min/tests/unittests \"iterator filter init allocation failure\"`

## Notes
- Investigation confirmed this bug is present on `0.15`, `0.16`, and `0.17`
- `0.18` and `main` already include the fix from #1844

Backport of #1844.