### PR TITLE
test(fixtures): use fixed seed for reproducible test data generation

### DIFF
--- a/tests/fixtures/core/random.h
+++ b/tests/fixtures/core/random.h
@@ -28,18 +28,42 @@ namespace fixtures {
 
 template <typename T>
 typename std::enable_if<std::is_floating_point<T>::value, T>::type
-RandomValue(const T& min, const T& max) {
-    thread_local std::random_device rd;
-    thread_local std::mt19937 gen(rd());
+RandomValue(const T& min, const T& max, int seed = -1) {
+    thread_local std::mt19937 gen;
+    thread_local int current_seed = -1;
+    if (seed >= 0) {
+        if (seed != current_seed) {
+            gen.seed(seed);
+            current_seed = seed;
+        }
+    } else {
+        if (current_seed != -2) {
+            std::random_device rd;
+            gen.seed(rd());
+            current_seed = -2;
+        }
+    }
     std::uniform_real_distribution<T> dis(min, max);
     return dis(gen);
 }
 
 template <typename T>
 typename std::enable_if<std::is_integral<T>::value, T>::type
-RandomValue(const T& min, const T& max) {
-    thread_local std::random_device rd;
-    thread_local std::mt19937 gen(rd());
+RandomValue(const T& min, const T& max, int seed = -1) {
+    thread_local std::mt19937 gen;
+    thread_local int current_seed = -1;
+    if (seed >= 0) {
+        if (seed != current_seed) {
+            gen.seed(seed);
+            current_seed = seed;
+        }
+    } else {
+        if (current_seed != -2) {
+            std::random_device rd;
+            gen.seed(rd());
+            current_seed = -2;
+        }
+    }
     std::uniform_int_distribution<T> dis(min, max);
     return dis(gen);
 }

--- a/tests/fixtures/data/vector_generator.cpp
+++ b/tests/fixtures/data/vector_generator.cpp
@@ -121,6 +121,24 @@ generate_vectors(uint64_t count, uint32_t dim, bool need_normalize, int seed) {
     return std::move(GenerateVectors<float>(count, dim, seed, need_normalize));
 }
 
+std::vector<float>
+generate_normal_vectors(
+    uint64_t count, uint32_t dim, bool need_normalize, int seed, float mean, float stddev) {
+    std::mt19937 rng(seed);
+
+    std::normal_distribution<float> distrib(mean, stddev);
+    std::vector<float> vectors(dim * count);
+    for (int64_t i = 0; i < dim * count; ++i) {
+        vectors[i] = distrib(rng);
+    }
+    if (need_normalize) {
+        for (int64_t i = 0; i < count; ++i) {
+            vsag::Normalize(vectors.data() + i * dim, vectors.data() + i * dim, dim);
+        }
+    }
+    return vectors;
+}
+
 std::vector<int8_t>
 generate_int8_codes(uint64_t count, uint32_t dim, int seed) {
     return GenerateVectors<int8_t>(count, dim, seed);

--- a/tests/fixtures/data/vector_generator.h
+++ b/tests/fixtures/data/vector_generator.h
@@ -91,6 +91,14 @@ GenerateBinaryVectorsAndCodes(uint32_t count, uint32_t dim, int seed = 47);
 std::vector<float>
 generate_vectors(uint64_t count, uint32_t dim, bool need_normalize = true, int seed = 47);
 
+std::vector<float>
+generate_normal_vectors(uint64_t count,
+                        uint32_t dim,
+                        bool need_normalize = true,
+                        int seed = 47,
+                        float mean = 0.0f,
+                        float stddev = 1.0f);
+
 std::vector<uint8_t>
 generate_int4_codes(uint64_t count, uint32_t dim, int seed = 47);
 

--- a/tests/fixtures/framework/test_dataset.cpp
+++ b/tests/fixtures/framework/test_dataset.cpp
@@ -1,4 +1,3 @@
-
 // Copyright 2024-present the vsag project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -44,12 +43,12 @@ GenerateRandomDataset(uint64_t dim,
                       uint64_t extra_info_size = 0,
                       std::string vector_type = "dense",
                       bool has_duplicate = false,
-                      int64_t id_shift = 16) {
+                      int64_t id_shift = 16,
+                      int seed = 47) {
     auto base = vsag::Dataset::Make();
     bool need_normalize = (metric_str != "cosine");
-    auto vecs =
-        fixtures::generate_vectors(count, dim, need_normalize, fixtures::RandomValue(0, 564));
-    auto vecs_int8 = fixtures::generate_int8_codes(count, dim, fixtures::RandomValue(0, 564));
+    auto vecs = fixtures::generate_vectors(count, dim, need_normalize, seed);
+    auto vecs_int8 = fixtures::generate_int8_codes(count, dim, seed);
     auto attr_sets = fixtures::generate_attributes(count);
     auto paths = new std::string[count];
     for (int i = 0; i < count; ++i) {
@@ -91,11 +90,10 @@ GenerateNanRandomDataset(uint64_t dim, uint64_t count, std::string metric_str = 
     auto base = vsag::Dataset::Make();
     bool need_normalize = (metric_str != "cosine");
 
-    std::vector<float> vecs =
-        fixtures::generate_vectors(count, dim, need_normalize, fixtures::RandomValue(0, 564));
-    std::random_device rd;
-    std::mt19937 g(rd());
-    std::uniform_real_distribution real;
+    constexpr int nan_seed = 47;
+    std::vector<float> vecs = fixtures::generate_vectors(count, dim, need_normalize, nan_seed);
+    std::mt19937 g(nan_seed + 1);
+    std::uniform_real_distribution<float> real(0.0f, 1.0f);
     for (int i = 0; i < count; ++i) {
         float r = real(g);
         if (r < 0.001) {
@@ -257,7 +255,11 @@ TestDataset::CreateTestDataset(uint64_t dim,
                                std::string vector_type,
                                uint64_t extra_info_size,
                                bool has_duplicate,
-                               int64_t id_shift) {
+                               int64_t id_shift,
+                               bool use_fixed_seed) {
+    constexpr int fixed_seed = 47;
+    int seed = use_fixed_seed ? fixed_seed : fixtures::RandomValue(0, 564);
+
     TestDatasetPtr dataset = std::shared_ptr<TestDataset>(new TestDataset);
     dataset->dim_ = dim;
     dataset->id_shift = id_shift;
@@ -269,10 +271,18 @@ TestDataset::CreateTestDataset(uint64_t dim,
                                            extra_info_size,
                                            vector_type,
                                            has_duplicate,
-                                           dataset->id_shift);
+                                           dataset->id_shift,
+                                           seed);
     constexpr uint64_t query_count = 100;
-    dataset->query_ =
-        GenerateRandomDataset(dim, query_count, metric_str, true, extra_info_size, vector_type);
+    dataset->query_ = GenerateRandomDataset(dim,
+                                            query_count,
+                                            metric_str,
+                                            true,
+                                            extra_info_size,
+                                            vector_type,
+                                            false,
+                                            dataset->id_shift,
+                                            seed + 1);
     dataset->filter_query_ = dataset->query_;
     dataset->range_query_ = dataset->query_;
     dataset->valid_ratio_ = valid_ratio;

--- a/tests/fixtures/framework/test_dataset.h
+++ b/tests/fixtures/framework/test_dataset.h
@@ -1,4 +1,3 @@
-
 // Copyright 2024-present the vsag project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -48,6 +47,7 @@ public:
      * @param extra_info_size Size of extra info per vector.
      * @param has_duplicate Whether to include duplicate vectors.
      * @param id_shift Offset for generated IDs.
+     * @param use_fixed_seed Whether to use a fixed seed for reproducible data generation.
      * @return Shared pointer to the created TestDataset.
      */
     static std::shared_ptr<TestDataset>
@@ -59,7 +59,8 @@ public:
                       std::string vector_type = "dense",
                       uint64_t extra_info_size = 0,
                       bool has_duplicate = false,
-                      int64_t id_shift = 16);
+                      int64_t id_shift = 16,
+                      bool use_fixed_seed = true);
 
     /**
      * @brief Creates a test dataset with NaN values.


### PR DESCRIPTION
## Summary

- Add generate_normal_vectors function for normal distribution test data with fixed seed
- Add optional seed parameter to RandomValue functions for reproducible random values  
- Modify GenerateRandomDataset to use fixed seed (47) by default instead of RandomValue(0, 564)
- Add use_fixed_seed parameter to CreateTestDataset (default true for CI stability)
- Fix GenerateNanRandomDataset to use fixed seed instead of std::random_device

## Background

CI flaky failures occur due to random test data generation using std::random_device. Each test run produces different data distribution, causing recall rate fluctuations that sometimes fall below thresholds even when algorithm implementation is correct.

## Changes

| File | Change |
|------|--------|
| tests/fixtures/core/random.h | Add optional seed parameter to RandomValue (default -1 for backward compatibility) |
| tests/fixtures/data/vector_generator.h | Add generate_normal_vectors function declaration |
| tests/fixtures/data/vector_generator.cpp | Add generate_normal_vectors implementation using std::normal_distribution |
| tests/fixtures/framework/test_dataset.h | Add use_fixed_seed parameter to CreateTestDataset |
| tests/fixtures/framework/test_dataset.cpp | Use fixed seed (47) for reproducible test data

## Expected Effects

1. CI stability: Fixed seed eliminates data randomness, recall fluctuations minimized
2. Reproducible tests: Local development can reproduce CI failure scenarios
3. Better data distribution: Normal distribution more closely resembles real embedding scenarios
4. Backward compatible: use_fixed_seed=false allows random data when needed

Fixes #1877