### PR TITLE
fix(sindi): bypass buffered reads for footerless deserialize

### DIFF
--- a/src/algorithm/sindi/sindi.cpp
+++ b/src/algorithm/sindi/sindi.cpp
@@ -337,7 +337,7 @@ SINDI::Deserialize(StreamReader& reader) {
 
     BufferStreamReader buffer_reader(
         &reader, std::numeric_limits<uint64_t>::max(), this->allocator_);
-    if (not deserialize_without_buffer_) {
+    if (not deserialize_without_buffer_ and not deserialize_without_footer_) {
         reader_ptr = &buffer_reader;
     }
     auto& reader_ref = *reader_ptr;

--- a/tests/test_sindi.cpp
+++ b/tests/test_sindi.cpp
@@ -232,6 +232,26 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex, "SINDI Serialize File", "
 }
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex,
+                             "SINDI Deserialize Without Footer Defaults To NonBuffered Read",
+                             "[ft][sindi]") {
+    fixtures::SINDIParam writer_param;
+    writer_param.deserialize_without_footer = true;
+    writer_param.deserialize_without_buffer = true;
+    auto writer_build_param = fixtures::SINDITestIndex::GenerateBuildParameter(writer_param);
+
+    fixtures::SINDIParam reader_param;
+    reader_param.deserialize_without_footer = true;
+    reader_param.deserialize_without_buffer = false;
+    auto reader_build_param = fixtures::SINDITestIndex::GenerateBuildParameter(reader_param);
+
+    auto index = TestFactory("sindi", writer_build_param, true);
+    auto index2 = TestFactory("sindi", reader_build_param, true);
+    auto dataset = pool.GetSparseDatasetAndCreate(base_count, 128, 0.8);
+    TestBuildIndex(index, dataset, true);
+    TestSerializeFile(index, index2, dataset, fixtures::SINDITestIndex::search_param, true);
+}
+
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex,
                              "SINDI Search Unreleated Param",
                              "[ft][sindi]") {
     fixtures::SINDIParam param;


### PR DESCRIPTION
## Summary
- bypass `BufferStreamReader` when SINDI deserializes legacy footerless data
- add a regression test covering `deserialize_without_footer=true` with the default buffer setting

## Testing
- `./tests/functests \"*SINDI Serialize File*\"`
- `./tests/functests \"*SINDI Deserialize Without Footer Defaults To NonBuffered Read*\"`