### PR TITLE
fix(sindi): bypass buffered reads for footerless deserialize

### DIFF
--- a/src/algorithm/sindi/sindi.cpp
+++ b/src/algorithm/sindi/sindi.cpp
@@ -372,7 +372,7 @@ SINDI::Deserialize(StreamReader& reader) {
 
     BufferStreamReader buffer_reader(
         &reader, std::numeric_limits<uint64_t>::max(), this->allocator_);
-    if (not deserialize_without_buffer_) {
+    if (not deserialize_without_buffer_ and not deserialize_without_footer_) {
         reader_ptr = &buffer_reader;
     }
     auto& reader_ref = *reader_ptr;


### PR DESCRIPTION
## Summary
- bypass `BufferStreamReader` when SINDI deserializes legacy footerless data
- avoid read-size mismatches when callers set `deserialize_without_footer=true` without also disabling buffered reads

## Testing
- `./tests/functests \"*SINDI Serialize File*\"`
- `./tests/functests \"*SINDI Deserialize Without Footer Defaults To NonBuffered Read*\"`