### PR TITLE
docs: correct 'last updated' date in contributors list

### DIFF
--- a/docs/docs/zh/src/misc/contributors.md
+++ b/docs/docs/zh/src/misc/contributors.md
@@ -1,6 +1,6 @@
 # 贡献者列表
 
-以下是 VSAG 项目的贡献者（更新于 2025-11-11），按照第一次贡献时间排序：
+以下是 VSAG 项目的贡献者（更新于 2025-11-20），按照第一次贡献时间排序：
 
 - 2024-07-26 Xiangyu Wang ([wxyucs](https://github.com/wxyucs/)) from AntGroup
 - 2024-08-21 Jiabao Jin ([inabao](https://github.com/inabao)) from AntGroup


### PR DESCRIPTION
## Summary

The header in `docs/docs/zh/src/misc/contributors.md` says the list was updated on `2025-11-11`, but the list itself contains an entry dated `2025-11-20`, which predates the claimed update date. Update the header to `2025-11-20` to match the newest entry.

## Diff

```diff
-以下是 VSAG 项目的贡献者（更新于 2025-11-11），按照第一次贡献时间排序：
+以下是 VSAG 项目的贡献者（更新于 2025-11-20），按照第一次贡献时间排序：
```

## Note

This PR also exercises the docs sync pipeline end-to-end (`antgroup/vsag` → `vsag-io/vsag-io.github.io` sync branch → review → deploy). No `[skip ci]` on purpose.

Signed-off-by: Xiangyu Wang <wxyucs@gmail.com>
Signed-off-by: OpenCode (claude-opus-4.7) <noreply@opencode.ai>