### PR TITLE
ci: skip heavy builds on docs-only changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,85 +1,25 @@
 version: 2.1
 
+# This is the setup workflow. It uses the path-filtering orb to decide
+# whether the real CI pipeline (continue_config.yml) should run, based on
+# which files changed in the commit.
+#
+# Changes confined to documentation (docs/**) do not affect the C++ build
+# or tests, so we skip the main pipeline for docs-only changes.
+
+setup: true
+
+orbs:
+  path-filtering: circleci/path-filtering@1.3.0
+
 workflows:
-  pull-request-workflow:
+  setup-workflow:
     jobs:
-      - pull-request-check:
-          filters:
-            branches:
-              ignore:
-                - main
-                - ^0\.\d+
-
-  main-branch-workflow:
-    jobs:
-      - main-branch-check:
-          filters:
-            branches:
-              only:
-                - main
-                - ^0\.\d+
-
-jobs:
-  pull-request-check:
-    machine:
-      image: ubuntu-2204:2025.09.1
-    resource_class: large
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - fork-cache-{{ checksum "CMakeLists.txt" }}-{{ checksum ".circleci/fresh_ci_cache.commit" }}
-      - run:
-          name: prepare_env_and_create_swap_file
-          command: |
-            sudo apt update
-            sudo apt install -y gfortran python3-dev libomp-15-dev gcc make cmake g++ lcov libaio-dev libcurl4-openssl-dev ninja-build 
-            sudo apt-get install -y libopenblas-dev
-            sudo dd if=/dev/zero of=.swapfile bs=2M count=2048
-            sudo chmod 600 .swapfile
-            sudo mkswap .swapfile
-            sudo swapon .swapfile
-      - run:
-          command: export CMAKE_GENERATOR="Ninja" && export VSAG_ENABLE_INTEL_MKL=OFF && export COMPILE_JOBS=4 && make test_parallel
-          no_output_timeout: 50m
-      - run:
-          name: remove_swap_file
-          command: |
-            sudo swapoff .swapfile
-            sudo rm .swapfile
-      - save_cache:
-          key: fork-cache-{{ checksum "CMakeLists.txt" }}-{{ checksum ".circleci/fresh_ci_cache.commit" }}
-          paths:
-            - ./build
-
-  main-branch-check:
-    machine:
-      image: ubuntu-2204:2025.09.1
-    resource_class: large
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - main-cache-{{ checksum "CMakeLists.txt" }}-{{ checksum ".circleci/fresh_ci_cache.commit" }}
-      - run:
-          name: prepare_env_and_create_swap_file
-          command: |
-            sudo apt update
-            sudo apt install -y gfortran python3-dev libomp-15-dev gcc make cmake g++ lcov libaio-dev libcurl4-openssl-dev ninja-build 
-            sudo apt-get install -y libopenblas-dev
-            sudo dd if=/dev/zero of=.swapfile bs=2M count=2048
-            sudo chmod 600 .swapfile
-            sudo mkswap .swapfile
-            sudo swapon .swapfile
-      - run:
-          command: export CMAKE_GENERATOR="Ninja" && export VSAG_ENABLE_INTEL_MKL=OFF && export COMPILE_JOBS=4 && make test_parallel
-          no_output_timeout: 50m
-      - run:
-          name: remove_swap_file
-          command: |
-            sudo swapoff .swapfile
-            sudo rm .swapfile
-      - save_cache:
-          key: main-cache-{{ checksum "CMakeLists.txt" }}-{{ checksum ".circleci/fresh_ci_cache.commit" }}
-          paths:
-            - ./build
+      - path-filtering/filter:
+          base-revision: main
+          config-path: .circleci/continue_config.yml
+          # For each regex that matches a changed path, set the mapped
+          # pipeline parameter to the given value. `run-build` stays false
+          # unless at least one non-docs file changed.
+          mapping: |
+            ^(?!docs/).* run-build true

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -1,0 +1,97 @@
+version: 2.1
+
+# This is the continuation config invoked by .circleci/config.yml (the setup
+# pipeline). The setup pipeline uses the path-filtering orb to decide whether
+# `run-build` should be true. When a change only touches documentation
+# (docs/**), `run-build` stays false and the workflows below are skipped.
+
+parameters:
+  run-build:
+    type: boolean
+    default: false
+
+workflows:
+  pull-request-workflow:
+    when: << pipeline.parameters.run-build >>
+    jobs:
+      - pull-request-check:
+          filters:
+            branches:
+              ignore:
+                - main
+                - ^0\.\d+
+
+  main-branch-workflow:
+    when: << pipeline.parameters.run-build >>
+    jobs:
+      - main-branch-check:
+          filters:
+            branches:
+              only:
+                - main
+                - ^0\.\d+
+
+jobs:
+  pull-request-check:
+    machine:
+      image: ubuntu-2204:2025.09.1
+    resource_class: large
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - fork-cache-{{ checksum "CMakeLists.txt" }}-{{ checksum ".circleci/fresh_ci_cache.commit" }}
+      - run:
+          name: prepare_env_and_create_swap_file
+          command: |
+            sudo apt update
+            sudo apt install -y gfortran python3-dev libomp-15-dev gcc make cmake g++ lcov libaio-dev libcurl4-openssl-dev ninja-build 
+            sudo apt-get install -y libopenblas-dev
+            sudo dd if=/dev/zero of=.swapfile bs=2M count=2048
+            sudo chmod 600 .swapfile
+            sudo mkswap .swapfile
+            sudo swapon .swapfile
+      - run:
+          command: export CMAKE_GENERATOR="Ninja" && export VSAG_ENABLE_INTEL_MKL=OFF && export COMPILE_JOBS=4 && make test_parallel
+          no_output_timeout: 50m
+      - run:
+          name: remove_swap_file
+          command: |
+            sudo swapoff .swapfile
+            sudo rm .swapfile
+      - save_cache:
+          key: fork-cache-{{ checksum "CMakeLists.txt" }}-{{ checksum ".circleci/fresh_ci_cache.commit" }}
+          paths:
+            - ./build
+
+  main-branch-check:
+    machine:
+      image: ubuntu-2204:2025.09.1
+    resource_class: large
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - main-cache-{{ checksum "CMakeLists.txt" }}-{{ checksum ".circleci/fresh_ci_cache.commit" }}
+      - run:
+          name: prepare_env_and_create_swap_file
+          command: |
+            sudo apt update
+            sudo apt install -y gfortran python3-dev libomp-15-dev gcc make cmake g++ lcov libaio-dev libcurl4-openssl-dev ninja-build 
+            sudo apt-get install -y libopenblas-dev
+            sudo dd if=/dev/zero of=.swapfile bs=2M count=2048
+            sudo chmod 600 .swapfile
+            sudo mkswap .swapfile
+            sudo swapon .swapfile
+      - run:
+          command: export CMAKE_GENERATOR="Ninja" && export VSAG_ENABLE_INTEL_MKL=OFF && export COMPILE_JOBS=4 && make test_parallel
+          no_output_timeout: 50m
+      - run:
+          name: remove_swap_file
+          command: |
+            sudo swapoff .swapfile
+            sudo rm .swapfile
+      - save_cache:
+          key: main-cache-{{ checksum "CMakeLists.txt" }}-{{ checksum ".circleci/fresh_ci_cache.commit" }}
+          paths:
+            - ./build

--- a/.github/workflows/tsan_build_and_test.yml
+++ b/.github/workflows/tsan_build_and_test.yml
@@ -3,8 +3,12 @@ name: Tsan Build & Test Parallel
 on:
   push:
     branches: [ "main", "0.*" ]
+    paths-ignore:
+      - 'docs/**'
   pull_request:
     branches: [ "main", "0.*" ]
+    paths-ignore:
+      - 'docs/**'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary

Documentation-only changes (under `docs/**`) do not affect the C++ library or its tests, yet currently trigger the full tsan GitHub Actions workflow and the CircleCI build/test pipeline. This PR makes both CI systems skip such changes.

## Changes

- **`.github/workflows/tsan_build_and_test.yml`**: add `paths-ignore: ['docs/**']` to both `push` and `pull_request` triggers.
- **CircleCI**: convert the pipeline to a setup workflow using the `circleci/path-filtering@1.3.0` orb.
  - `.circleci/config.yml` becomes a small setup pipeline. A `mapping` rule matches any changed file whose path does not start with `docs/` and sets the `run-build` pipeline parameter to `true`.
  - `.circleci/continue_config.yml` (new) contains the original `pull-request-check` / `main-branch-check` jobs and workflows, now gated on `<< pipeline.parameters.run-build >>`. Branch filters and job steps are unchanged.

For non-docs changes, CI behaviour is identical to before (same jobs, same filters, same caches). For docs-only changes, both the tsan workflow and the CircleCI workflows are skipped.

## Action required before merge

CircleCI dynamic config must be enabled for this to work. In the CircleCI project settings for `antgroup/vsag`, toggle on:

> **Enable dynamic config using setup workflows**

Without this switch, CircleCI will ignore `setup: true` and the filter job.

## Testing

- YAML syntactically validated locally.
- This PR itself changes files outside `docs/**`, so the mapping should set `run-build=true` and CI should run normally, exercising the new `continue_config.yml` path end-to-end.

Signed-off-by: Xiangyu Wang <wxyucs@gmail.com>
Signed-off-by: OpenCode (claude-opus-4.7) <noreply@opencode.ai>