### PR TITLE
[Backport 0.18] fix(ci): publish pyvsag wheels on release

### DIFF
--- a/.github/workflows/build_release_wheel.yml
+++ b/.github/workflows/build_release_wheel.yml
@@ -11,6 +11,9 @@ on:
         description: 'Architecture to build (x86_64 or aarch64). If empty, builds all.'
         required: false
         type: string
+  release:
+    types:
+      - published
 
 jobs:
   setup-matrix:
@@ -153,9 +156,7 @@ jobs:
     name: Publish packages
     needs: [build_wheels_modern, build_wheels_py36]
     runs-on: ubuntu-latest
-    # The `if: always()` ensures this job runs even if one of the build jobs is skipped
-    # because its matrix was empty. We check for files later.
-    if: always() && (github.event_name == 'release' || (github.event_name == 'push' && github.ref == 'refs/heads/main'))
+    if: always() && github.event_name == 'release' && github.event.action == 'published'
     steps:
       - uses: actions/download-artifact@v5
         with:
@@ -174,25 +175,15 @@ jobs:
             echo "should_publish=true" >> $GITHUB_OUTPUT
           fi
 
-      - name: Publish to TestPyPI
-        if: steps.list_files.outputs.should_publish == 'true' && github.event_name == 'push'
-        uses: pypa/gh-action-pypi-publish@v1
-        with:
-          repository-url: https://test.pypi.org/legacy/
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-          skip-existing: true
-          verbose: true
-
       - name: Publish to PyPI
-        if: steps.list_files.outputs.should_publish == 'true' && github.event_name == 'release' && github.event.action == 'published'
+        if: steps.list_files.outputs.should_publish == 'true'
         uses: pypa/gh-action-pypi-publish@v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
           verbose: true
 
       - name: Upload to GitHub Release
-        if: steps.list_files.outputs.should_publish == 'true' && github.event_name == 'release' && github.event.action == 'published'
+        if: steps.list_files.outputs.should_publish == 'true'
         uses: softprops/action-gh-release@v2
         with:
           files: dist/*.whl
-

--- a/.github/workflows/build_release_wheel.yml
+++ b/.github/workflows/build_release_wheel.yml
@@ -156,7 +156,7 @@ jobs:
     name: Publish packages
     needs: [build_wheels_modern, build_wheels_py36]
     runs-on: ubuntu-latest
-    if: always() && github.event_name == 'release' && github.event.action == 'published'
+    if: ${{ github.event_name == 'release' && github.event.action == 'published' && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
     steps:
       - uses: actions/download-artifact@v5
         with:


### PR DESCRIPTION
## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement/Refactor
- [ ] Documentation
- [x] CI/Build/Infra

## Linked Issue

- Issue: #1887

## What Changed

- add a `release.published` trigger to `.github/workflows/build_release_wheel.yml` on the `0.18` release line
- restrict the publish job so manual `workflow_dispatch` runs only build wheels
- remove push/TestPyPI publishing so Python package publishing only happens for published GitHub releases
- align the current `0.18` maintenance branch with the same release-publish behavior proposed for `main`

## Test Evidence

- [ ] `make fmt`
- [ ] `make lint`
- [ ] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [x] Other (describe below)

Test details:

```text
ruby -e 'require "yaml"; YAML.load_file(".github/workflows/build_release_wheel.yml")'
git diff --check
```

## Compatibility Impact

- API/ABI compatibility: none
- Behavior changes: manual dispatch now builds only; publishing happens only on `release.published`

## Performance and Concurrency Impact

- Performance impact: none
- Concurrency/thread-safety impact: none

## Documentation Impact

- [x] No docs update needed
- [ ] Updated docs:
  - [ ] `README.md`
  - [ ] `DEVELOPMENT.md`
  - [ ] `CONTRIBUTING.md`
  - [ ] Other: <!-- path -->

## Risk and Rollback

- Risk level: low
- Rollback plan: revert this workflow change to restore the previous manual-only publish flow on `0.18`

## Checklist

- [x] I have linked the relevant issue (or explained why not applicable)
- [ ] I have added/updated tests for new behavior or bug fixes
- [x] I have considered API compatibility impact
- [x] I have updated docs if behavior/workflow changed
- [x] My commit messages follow project conventions (Conventional Commits, optional `[skip ci]` prefix)
