### PR TITLE
chore(ci): allow manual dispatch for docs sync workflow

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -7,6 +7,7 @@ on:
       - main
     paths:
       - 'docs/**'
+  workflow_dispatch:
 
 jobs:
   sync:


### PR DESCRIPTION
## Summary
- Add \`workflow_dispatch\` trigger to \`.github/workflows/docs.yaml\` so the Sync Docs workflow can be re-run manually from the Actions tab / \`gh workflow run\`.

## Motivation
The workflow is currently only triggered by \`push\` to \`main\` with changes under \`docs/**\`. If a merge commit contains \`[skip ci]\` (as happened with #1886), or a docs-only change somehow bypasses the path filter, there is no way to re-trigger the sync without pushing another commit. Adding \`workflow_dispatch\` provides a safe manual recovery path.

## Test Plan
After merge, run \`gh workflow run docs.yaml --ref main\` (or use the Actions UI) to verify the workflow runs and syncs to \`vsag-io/vsag-io.github.io\`.