### PR TITLE
fix(quantization): correct FP16/BF16 conversion in QuantizerAdapter::ProcessQueryImpl

### DIFF
--- a/src/quantization/quantizer_adapter.cpp
+++ b/src/quantization/quantizer_adapter.cpp
@@ -226,9 +226,9 @@ QuantizerAdapter<QuantT, DataT>::ProcessQueryImpl(
         Vector<DataType> vec(this->dim_, this->allocator_);
         for (int64_t i = 0; i < this->dim_; i++) {
             if (data_type_ == DataTypes::DATA_TYPE_FP16) {
-                vec[i] = FloatToFP16(query_int16[i]);
+                vec[i] = FP16ToFloat(query_int16[i]);
             } else {
-                vec[i] = FloatToBF16(query_int16[i]);
+                vec[i] = BF16ToFloat(query_int16[i]);
             }
         }
         this->inner_quantizer_->ProcessQueryImpl(vec.data(), inner_computer);

--- a/src/quantization/quantizer_adapter_test.cpp
+++ b/src/quantization/quantizer_adapter_test.cpp
@@ -24,6 +24,8 @@
 #include "metric_type.h"
 #include "quantization/product_quantization/product_quantizer.h"
 #include "quantization/quantizer_parameter.h"
+#include "quantization/scalar_quantization/half_precision_quantizer.h"
+#include "quantization/scalar_quantization/half_precision_quantizer_parameter.h"
 #include "quantizer_adapter_test.h"
 #include "typing.h"
 #include "unittest.h"
@@ -84,8 +86,12 @@ CreateQuantizerParam(const QuantizerType& quantization_type, uint64_t dim) {
         case QuantizerType::QUANTIZER_TYPE_SQ4:
         case QuantizerType::QUANTIZER_TYPE_SQ4_UNIFORM:
         case QuantizerType::QUANTIZER_TYPE_FP32:
-        case QuantizerType::QUANTIZER_TYPE_FP16:
-        case QuantizerType::QUANTIZER_TYPE_BF16:
+        case QuantizerType::QUANTIZER_TYPE_FP16: {
+            return std::make_shared<FP16QuantizerParameter>();
+        }
+        case QuantizerType::QUANTIZER_TYPE_BF16: {
+            return std::make_shared<BF16QuantizerParameter>();
+        }
         case QuantizerType::QUANTIZER_TYPE_INT8:
         case QuantizerType::QUANTIZER_TYPE_PQFS:
         case QuantizerType::QUANTIZER_TYPE_RABITQ:
@@ -100,7 +106,8 @@ CreateQuantizerParam(const QuantizerType& quantization_type, uint64_t dim) {
 IndexCommonParam
 CreateIndexCommonParam(uint64_t dim,
                        std::shared_ptr<Resource> res,
-                       MetricType metric_type = MetricType::METRIC_TYPE_L2SQR) {
+                       MetricType metric_type = MetricType::METRIC_TYPE_L2SQR,
+                       const std::string& dtype = DATATYPE_INT8) {
     std::string metric_str;
     switch (metric_type) {
         case MetricType::METRIC_TYPE_L2SQR:
@@ -118,7 +125,7 @@ CreateIndexCommonParam(uint64_t dim,
     }
 
     JsonType params;
-    params[PARAMETER_DTYPE].SetString(DATATYPE_INT8);
+    params[PARAMETER_DTYPE].SetString(dtype.c_str());
     params[PARAMETER_METRIC_TYPE].SetString(metric_str);
     params[PARAMETER_DIM].SetInt(dim);
     return IndexCommonParam::CheckAndCreate(params, res);
@@ -235,6 +242,172 @@ TEST_CASE("QuantizerAdapter Serialize AND Deserialize", "[ut][QuantizerAdapter][
                 TestAdapterSerializeAndDeserialize<ProductQuantizer<MetricType::METRIC_TYPE_L2SQR>,
                                                    MetricType::METRIC_TYPE_L2SQR>(
                     config.quantizer_type, dim, count, error);
+            }
+        }
+    }
+}
+
+// ==================== FP16/BF16 Data Type Tests ====================
+
+template <typename QuantT, MetricType metric>
+void
+TestQuantizerAdapterEncodeDecodeUInt16(QuantizerType quantizer_type,
+                                       uint64_t dim,
+                                       int count,
+                                       const std::string& dtype,
+                                       float error = 1e-5) {
+    vsag::Resource resource(vsag::Engine::CreateDefaultAllocator(), nullptr);
+    try {
+        const QuantizerParamPtr quantizer_param = CreateQuantizerParam(quantizer_type, dim);
+        if (quantizer_param == nullptr) {
+            return;
+        }
+        const IndexCommonParam common_param =
+            CreateIndexCommonParam(dim, std::make_shared<Resource>(resource), metric, dtype);
+        auto adapter =
+            std::make_shared<QuantizerAdapter<QuantT, uint16_t>>(quantizer_param, common_param);
+        TestQuantizerAdapterEncodeDecode<QuantizerAdapter<QuantT, uint16_t>, uint16_t>(
+            *adapter, dim, count, error, true, dtype);
+    } catch (const vsag::VsagException& e) {
+        std::cerr << "Exception: " << e.what() << std::endl;
+        throw;
+    }
+}
+
+template <typename QuantT, MetricType metric>
+void
+TestQuantizerAdapterComputeUInt16(QuantizerType quantizer_type,
+                                  uint64_t dim,
+                                  int count,
+                                  const std::string& dtype,
+                                  float error = 1e-5) {
+    vsag::Resource resource(vsag::Engine::CreateDefaultAllocator(), nullptr);
+    try {
+        const QuantizerParamPtr quantizer_param = CreateQuantizerParam(quantizer_type, dim);
+        if (quantizer_param == nullptr) {
+            return;
+        }
+        const IndexCommonParam common_param =
+            CreateIndexCommonParam(dim, std::make_shared<Resource>(resource), metric, dtype);
+        auto adapter =
+            std::make_shared<QuantizerAdapter<QuantT, uint16_t>>(quantizer_param, common_param);
+        TestQuantizerAdapterComputeCodes<QuantizerAdapter<QuantT, uint16_t>, metric, uint16_t>(
+            *adapter, dim, count, error, true, dtype);
+        TestQuantizerAdapterComputer<QuantizerAdapter<QuantT, uint16_t>, metric, uint16_t>(
+            *adapter, dim, count, error, 1.0f, true, 1.0f, 1.0f, dtype);
+    } catch (const vsag::VsagException& e) {
+        std::cerr << "Exception: " << e.what() << std::endl;
+        throw;
+    }
+}
+
+template <typename QuantT, MetricType metric>
+void
+TestAdapterSerializeAndDeserializeUInt16(QuantizerType quantizer_type,
+                                         uint64_t dim,
+                                         int count,
+                                         const std::string& dtype,
+                                         float error = 1e-5) {
+    vsag::Resource resource(vsag::Engine::CreateDefaultAllocator(), nullptr);
+    try {
+        const QuantizerParamPtr quantizer_param = CreateQuantizerParam(quantizer_type, dim);
+        if (quantizer_param == nullptr) {
+            return;
+        }
+        const IndexCommonParam common_param =
+            CreateIndexCommonParam(dim, std::make_shared<Resource>(resource), metric, dtype);
+        auto adapter1 =
+            std::make_shared<QuantizerAdapter<QuantT, uint16_t>>(quantizer_param, common_param);
+        auto adapter2 =
+            std::make_shared<QuantizerAdapter<QuantT, uint16_t>>(quantizer_param, common_param);
+        TestQuantizerAdapterSerializeAndDeserialize<QuantizerAdapter<QuantT, uint16_t>,
+                                                    metric,
+                                                    uint16_t>(
+            *adapter1, *adapter2, dim, count, error, 1.0f, 1.0f, 1.0f, true, dtype);
+    } catch (const vsag::VsagException& e) {
+        std::cerr << "Exception: " << e.what() << std::endl;
+        throw;
+    }
+}
+
+TEST_CASE("QuantizerAdapter FP16/BF16 Encode and Decode", "[ut][QuantizerAdapter][FP16][BF16]") {
+    for (const auto& config : quantizer_test_configs) {
+        if (config.quantizer_type != QuantizerType::QUANTIZER_TYPE_FP16 &&
+            config.quantizer_type != QuantizerType::QUANTIZER_TYPE_BF16) {
+            continue;
+        }
+        const std::string dtype = (config.quantizer_type == QuantizerType::QUANTIZER_TYPE_FP16)
+                                      ? DATATYPE_FLOAT16
+                                      : DATATYPE_BFLOAT16;
+        for (auto dim : config.dims) {
+            for (auto count : config.counts) {
+                float error = config.error_threshold * config.error_multiplier_encode_decode;
+                if (config.quantizer_type == QuantizerType::QUANTIZER_TYPE_FP16) {
+                    TestQuantizerAdapterEncodeDecodeUInt16<
+                        FP16Quantizer<MetricType::METRIC_TYPE_L2SQR>,
+                        MetricType::METRIC_TYPE_L2SQR>(
+                        config.quantizer_type, dim, count, dtype, error);
+                } else {
+                    TestQuantizerAdapterEncodeDecodeUInt16<
+                        BF16Quantizer<MetricType::METRIC_TYPE_L2SQR>,
+                        MetricType::METRIC_TYPE_L2SQR>(
+                        config.quantizer_type, dim, count, dtype, error);
+                }
+            }
+        }
+    }
+}
+
+TEST_CASE("QuantizerAdapter FP16/BF16 Compute", "[ut][QuantizerAdapter][FP16][BF16]") {
+    for (const auto& config : quantizer_test_configs) {
+        if (config.quantizer_type != QuantizerType::QUANTIZER_TYPE_FP16 &&
+            config.quantizer_type != QuantizerType::QUANTIZER_TYPE_BF16) {
+            continue;
+        }
+        const std::string dtype = (config.quantizer_type == QuantizerType::QUANTIZER_TYPE_FP16)
+                                      ? DATATYPE_FLOAT16
+                                      : DATATYPE_BFLOAT16;
+        for (auto dim : config.dims) {
+            for (auto count : config.counts) {
+                float error = config.error_threshold * config.error_multiplier_compute;
+                if (config.quantizer_type == QuantizerType::QUANTIZER_TYPE_FP16) {
+                    TestQuantizerAdapterComputeUInt16<FP16Quantizer<MetricType::METRIC_TYPE_L2SQR>,
+                                                      MetricType::METRIC_TYPE_L2SQR>(
+                        config.quantizer_type, dim, count, dtype, error);
+                } else {
+                    TestQuantizerAdapterComputeUInt16<BF16Quantizer<MetricType::METRIC_TYPE_L2SQR>,
+                                                      MetricType::METRIC_TYPE_L2SQR>(
+                        config.quantizer_type, dim, count, dtype, error);
+                }
+            }
+        }
+    }
+}
+
+TEST_CASE("QuantizerAdapter FP16/BF16 Serialize AND Deserialize",
+          "[ut][QuantizerAdapter][FP16][BF16]") {
+    for (const auto& config : quantizer_test_configs) {
+        if (config.quantizer_type != QuantizerType::QUANTIZER_TYPE_FP16 &&
+            config.quantizer_type != QuantizerType::QUANTIZER_TYPE_BF16) {
+            continue;
+        }
+        const std::string dtype = (config.quantizer_type == QuantizerType::QUANTIZER_TYPE_FP16)
+                                      ? DATATYPE_FLOAT16
+                                      : DATATYPE_BFLOAT16;
+        for (auto dim : config.dims) {
+            for (auto count : config.counts) {
+                float error = config.error_threshold * config.error_multiplier_serialize;
+                if (config.quantizer_type == QuantizerType::QUANTIZER_TYPE_FP16) {
+                    TestAdapterSerializeAndDeserializeUInt16<
+                        FP16Quantizer<MetricType::METRIC_TYPE_L2SQR>,
+                        MetricType::METRIC_TYPE_L2SQR>(
+                        config.quantizer_type, dim, count, dtype, error);
+                } else {
+                    TestAdapterSerializeAndDeserializeUInt16<
+                        BF16Quantizer<MetricType::METRIC_TYPE_L2SQR>,
+                        MetricType::METRIC_TYPE_L2SQR>(
+                        config.quantizer_type, dim, count, dtype, error);
+                }
             }
         }
     }

--- a/src/quantization/quantizer_adapter_test.h
+++ b/src/quantization/quantizer_adapter_test.h
@@ -1,4 +1,3 @@
-
 // Copyright 2024-present the vsag project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,11 +21,12 @@
 #include "quantization/computer.h"
 #include "quantizer.h"
 #include "simd/basic_func.h"
+#include "simd/bf16_simd.h"
+#include "simd/fp16_simd.h"
 #include "storage/serialization_template_test.h"
 #include "unittest.h"
 
 namespace vsag {
-// NOTE(Coien.rr): Just used in CreateQuantizerParam in tests, escalated if needed in the future.
 enum class QuantizerType {
     QUANTIZER_TYPE_SQ8 = 0,
     QUANTIZER_TYPE_SQ8_UNIFORM = 1,
@@ -48,20 +48,28 @@ using namespace vsag;
 
 template <typename T, typename DataT = float>
 void
-TestQuantizerAdapterEncodeDecode(
-    Quantizer<T>& quant, int64_t dim, int count, float error = 1e-5, bool retrain = true) {
+TestQuantizerAdapterEncodeDecode(Quantizer<T>& quant,
+                                 int64_t dim,
+                                 int count,
+                                 float error = 1e-5,
+                                 bool retrain = true,
+                                 const std::string& dtype = DATATYPE_FLOAT32) {
     std::vector<DataT> vecs;
     if constexpr (std::is_same<DataT, float>::value == true) {
         vecs = fixtures::generate_vectors(count, dim, true);
     } else if constexpr (std::is_same<DataT, int8_t>::value == true) {
         vecs = fixtures::generate_int8_codes(count, dim, true);
+    } else if constexpr (std::is_same<DataT, uint16_t>::value == true) {
+        auto [codes, floats] = (dtype == DATATYPE_FLOAT16)
+                                   ? fixtures::generate_fp16_codes_with_floats(count, dim, 42)
+                                   : fixtures::generate_bf16_codes_with_floats(count, dim, 42);
+        vecs = std::move(codes);
     } else {
         static_assert("Unsupported DataT type");
     }
     if (retrain) {
         quant.ReTrain(reinterpret_cast<DataType*>(vecs.data()), count);
     }
-    // Test EncodeOne & DecodeOne
     for (uint64_t i = 0; i < count; ++i) {
         std::vector<uint8_t> codes(quant.GetCodeSize());
         quant.EncodeOne(reinterpret_cast<DataType*>(vecs.data() + i * dim), codes.data());
@@ -69,13 +77,21 @@ TestQuantizerAdapterEncodeDecode(
         quant.DecodeOne(codes.data(), reinterpret_cast<DataType*>(out_vec.data()));
         float sum = 0.0F;
         for (int j = 0; j < dim; ++j) {
-            sum += std::abs(static_cast<DataType>(vecs[i * dim + j]) -
-                            static_cast<DataType>(out_vec[j]));
+            if constexpr (std::is_same<DataT, uint16_t>::value == true) {
+                float original = (dtype == DATATYPE_FLOAT16)
+                                     ? generic::FP16ToFloat(vecs[i * dim + j])
+                                     : generic::BF16ToFloat(vecs[i * dim + j]);
+                float decoded = (dtype == DATATYPE_FLOAT16) ? generic::FP16ToFloat(out_vec[j])
+                                                            : generic::BF16ToFloat(out_vec[j]);
+                sum += std::abs(original - decoded);
+            } else {
+                sum += std::abs(static_cast<DataType>(vecs[i * dim + j]) -
+                                static_cast<DataType>(out_vec[j]));
+            }
         }
         REQUIRE(sum < error * dim);
     }
 
-    // Test EncodeBatch & DecodeBatch
     std::vector<uint8_t> codes(quant.GetCodeSize() * count);
     quant.EncodeBatch(reinterpret_cast<DataType*>(vecs.data()), codes.data(), count);
     std::vector<DataT> out_vec(dim * count);
@@ -83,8 +99,18 @@ TestQuantizerAdapterEncodeDecode(
     for (int64_t i = 0; i < count; ++i) {
         float sum = 0.0F;
         for (int j = 0; j < dim; ++j) {
-            sum += std::abs(static_cast<DataType>(vecs[i * dim + j]) -
-                            static_cast<DataType>(out_vec[i * dim + j]));
+            if constexpr (std::is_same<DataT, uint16_t>::value == true) {
+                float original = (dtype == DATATYPE_FLOAT16)
+                                     ? generic::FP16ToFloat(vecs[i * dim + j])
+                                     : generic::BF16ToFloat(vecs[i * dim + j]);
+                float decoded = (dtype == DATATYPE_FLOAT16)
+                                    ? generic::FP16ToFloat(out_vec[i * dim + j])
+                                    : generic::BF16ToFloat(out_vec[i * dim + j]);
+                sum += std::abs(original - decoded);
+            } else {
+                sum += std::abs(static_cast<DataType>(vecs[i * dim + j]) -
+                                static_cast<DataType>(out_vec[i * dim + j]));
+            }
         }
         REQUIRE(sum < error * dim);
     }
@@ -96,12 +122,18 @@ TestQuantizerAdapterComputeCodes(Quantizer<T>& quantizer,
                                  uint64_t dim,
                                  uint32_t count,
                                  float error = 1e-4f,
-                                 bool retrain = true) {
+                                 bool retrain = true,
+                                 const std::string& dtype = DATATYPE_FLOAT32) {
     std::vector<DataT> vecs;
     if constexpr (std::is_same<DataT, float>::value == true) {
         vecs = fixtures::generate_vectors(count, dim, false);
     } else if constexpr (std::is_same<DataT, int8_t>::value == true) {
         vecs = fixtures::generate_int8_codes(count, dim, false);
+    } else if constexpr (std::is_same<DataT, uint16_t>::value == true) {
+        auto [codes, floats] = (dtype == DATATYPE_FLOAT16)
+                                   ? fixtures::generate_fp16_codes_with_floats(count, dim, 43)
+                                   : fixtures::generate_bf16_codes_with_floats(count, dim, 43);
+        vecs = std::move(codes);
     } else {
         static_assert("Unsupported DataT type");
     }
@@ -119,11 +151,42 @@ TestQuantizerAdapterComputeCodes(Quantizer<T>& quantizer,
         quantizer.EncodeOne(reinterpret_cast<DataType*>(vecs.data() + idx2 * dim), codes2.data());
         float gt = 0.0;
         float value = quantizer.Compute(codes1.data(), codes2.data());
-        if constexpr (metric == MetricType::METRIC_TYPE_IP ||
-                      metric == MetricType::METRIC_TYPE_COSINE) {
-            gt = 1 - INT8InnerProduct(vecs.data() + idx1 * dim, vecs.data() + idx2 * dim, &dim);
-        } else if constexpr (metric == MetricType::METRIC_TYPE_L2SQR) {
-            gt = INT8L2Sqr(vecs.data() + idx1 * dim, vecs.data() + idx2 * dim, &dim);
+        if constexpr (std::is_same<DataT, int8_t>::value == true) {
+            if constexpr (metric == MetricType::METRIC_TYPE_IP ||
+                          metric == MetricType::METRIC_TYPE_COSINE) {
+                gt = 1 - INT8InnerProduct(vecs.data() + idx1 * dim, vecs.data() + idx2 * dim, &dim);
+            } else if constexpr (metric == MetricType::METRIC_TYPE_L2SQR) {
+                gt = INT8L2Sqr(vecs.data() + idx1 * dim, vecs.data() + idx2 * dim, &dim);
+            }
+        } else if constexpr (std::is_same<DataT, uint16_t>::value == true) {
+            std::vector<float> float_vec1(dim), float_vec2(dim);
+            for (uint64_t d = 0; d < dim; ++d) {
+                if (dtype == DATATYPE_FLOAT16) {
+                    float_vec1[d] = generic::FP16ToFloat(vecs[idx1 * dim + d]);
+                    float_vec2[d] = generic::FP16ToFloat(vecs[idx2 * dim + d]);
+                } else {
+                    float_vec1[d] = generic::BF16ToFloat(vecs[idx1 * dim + d]);
+                    float_vec2[d] = generic::BF16ToFloat(vecs[idx2 * dim + d]);
+                }
+            }
+            if constexpr (metric == MetricType::METRIC_TYPE_IP ||
+                          metric == MetricType::METRIC_TYPE_COSINE) {
+                gt = 1 - InnerProduct(float_vec1.data(), float_vec2.data(), &dim);
+            } else if constexpr (metric == MetricType::METRIC_TYPE_L2SQR) {
+                gt = L2Sqr(float_vec1.data(), float_vec2.data(), &dim);
+            }
+        } else {
+            std::vector<float> float_vec1(dim), float_vec2(dim);
+            for (uint64_t d = 0; d < dim; ++d) {
+                float_vec1[d] = static_cast<float>(vecs[idx1 * dim + d]);
+                float_vec2[d] = static_cast<float>(vecs[idx2 * dim + d]);
+            }
+            if constexpr (metric == MetricType::METRIC_TYPE_IP ||
+                          metric == MetricType::METRIC_TYPE_COSINE) {
+                gt = 1 - InnerProduct(float_vec1.data(), float_vec2.data(), &dim);
+            } else if constexpr (metric == MetricType::METRIC_TYPE_L2SQR) {
+                gt = L2Sqr(float_vec1.data(), float_vec2.data(), &dim);
+            }
         }
         if (gt != 0.0) {
             REQUIRE(std::abs((gt - value) / gt) < error);
@@ -142,7 +205,8 @@ TestQuantizerAdapterComputer(Quantizer<T>& quant,
                              float related_error = 1.0f,
                              bool retrain = true,
                              float unbounded_numeric_error_rate = 1.0f,
-                             float unbounded_related_error_rate = 1.0f) {
+                             float unbounded_related_error_rate = 1.0f,
+                             const std::string& dtype = DATATYPE_FLOAT32) {
     auto query_count = 10;
     bool need_normalize = false;
     std::vector<DataT> vecs;
@@ -153,15 +217,25 @@ TestQuantizerAdapterComputer(Quantizer<T>& quant,
     } else if constexpr (std::is_same<DataT, int8_t>::value == true) {
         vecs = fixtures::generate_int8_codes(count, dim);
         queries = fixtures::generate_int8_codes(query_count, dim, 165);
+    } else if constexpr (std::is_same<DataT, uint16_t>::value == true) {
+        auto [codes_v, floats_v] = (dtype == DATATYPE_FLOAT16)
+                                       ? fixtures::generate_fp16_codes_with_floats(count, dim)
+                                       : fixtures::generate_bf16_codes_with_floats(count, dim);
+        vecs = std::move(codes_v);
+        auto [codes_q, floats_q] =
+            (dtype == DATATYPE_FLOAT16)
+                ? fixtures::generate_fp16_codes_with_floats(query_count, dim, 165)
+                : fixtures::generate_bf16_codes_with_floats(query_count, dim, 165);
+        queries = std::move(codes_q);
     } else {
         static_assert("Unsupported DataT type");
     }
 
     for (int d = 0; d < dim; d++) {
-        vecs[d] = 0.0f;
+        vecs[d] = 0;
     }
     for (int d = 0; d < dim; d++) {
-        queries[query_count * dim / 2 + d] = 0.0f;
+        queries[query_count * dim / 2 + d] = 0;
     }
 
     if (retrain) {
@@ -175,6 +249,18 @@ TestQuantizerAdapterComputer(Quantizer<T>& quant,
                 return 1 - INT8InnerProduct(vecs.data() + base_idx * dim,
                                             queries.data() + query_idx * dim,
                                             &dim);
+            } else if constexpr (std::is_same<DataT, uint16_t>::value == true) {
+                std::vector<float> float_base(dim), float_query(dim);
+                for (uint64_t d = 0; d < dim; ++d) {
+                    if (dtype == DATATYPE_FLOAT16) {
+                        float_base[d] = generic::FP16ToFloat(vecs[base_idx * dim + d]);
+                        float_query[d] = generic::FP16ToFloat(queries[query_idx * dim + d]);
+                    } else {
+                        float_base[d] = generic::BF16ToFloat(vecs[base_idx * dim + d]);
+                        float_query[d] = generic::BF16ToFloat(queries[query_idx * dim + d]);
+                    }
+                }
+                return 1 - InnerProduct(float_base.data(), float_query.data(), &dim);
             } else {
                 return 1 - InnerProduct(vecs.data() + base_idx * dim,
                                         queries.data() + query_idx * dim,
@@ -184,6 +270,18 @@ TestQuantizerAdapterComputer(Quantizer<T>& quant,
             if constexpr (std::is_same<DataT, int8_t>::value == true) {
                 return INT8L2Sqr(
                     vecs.data() + base_idx * dim, queries.data() + query_idx * dim, &dim);
+            } else if constexpr (std::is_same<DataT, uint16_t>::value == true) {
+                std::vector<float> float_base(dim), float_query(dim);
+                for (uint64_t d = 0; d < dim; ++d) {
+                    if (dtype == DATATYPE_FLOAT16) {
+                        float_base[d] = generic::FP16ToFloat(vecs[base_idx * dim + d]);
+                        float_query[d] = generic::FP16ToFloat(queries[query_idx * dim + d]);
+                    } else {
+                        float_base[d] = generic::BF16ToFloat(vecs[base_idx * dim + d]);
+                        float_query[d] = generic::BF16ToFloat(queries[query_idx * dim + d]);
+                    }
+                }
+                return L2Sqr(float_base.data(), float_query.data(), &dim);
             } else {
                 return L2Sqr(vecs.data() + base_idx * dim, queries.data() + query_idx * dim, &dim);
             }
@@ -195,7 +293,6 @@ TestQuantizerAdapterComputer(Quantizer<T>& quant,
         auto computer = quant.FactoryComputer();
         computer->SetQuery(reinterpret_cast<DataType*>(queries.data() + i * dim));
 
-        // Test Compute One Dist;
         std::vector<uint8_t> codes1(quant.GetCodeSize() * count, 0);
         std::vector<float> dists1(count);
         for (int j = 0; j < count; ++j) {
@@ -212,7 +309,6 @@ TestQuantizerAdapterComputer(Quantizer<T>& quant,
             }
         }
 
-        // Test Compute Batch
         std::vector<uint8_t> codes2(quant.GetCodeSize() * count);
         std::vector<float> dists2(count);
         quant.EncodeBatch(reinterpret_cast<DataType*>(vecs.data()), codes2.data(), count);
@@ -235,12 +331,18 @@ TestQuantizerAdapterSerializeAndDeserialize(Quantizer<QuantT>& quant1,
                                             float related_error = 1.0f,
                                             float unbounded_numeric_error_rate = 1.0f,
                                             float unbounded_related_error_rate = 1.0f,
-                                            bool retrain = true) {
+                                            bool retrain = true,
+                                            const std::string& dtype = DATATYPE_FLOAT32) {
     std::vector<DataT> vecs;
     if constexpr (std::is_same<DataT, float>::value == true) {
         vecs = fixtures::generate_vectors(count, dim, false);
     } else if constexpr (std::is_same<DataT, int8_t>::value == true) {
         vecs = fixtures::generate_int8_codes(count, dim, false);
+    } else if constexpr (std::is_same<DataT, uint16_t>::value == true) {
+        auto [codes, floats] = (dtype == DATATYPE_FLOAT16)
+                                   ? fixtures::generate_fp16_codes_with_floats(count, dim, 43)
+                                   : fixtures::generate_bf16_codes_with_floats(count, dim, 43);
+        vecs = std::move(codes);
     } else {
         static_assert("Unsupported DataT type");
     }
@@ -252,7 +354,15 @@ TestQuantizerAdapterSerializeAndDeserialize(Quantizer<QuantT>& quant1,
     REQUIRE(quant1.GetCodeSize() == quant2.GetCodeSize());
     REQUIRE(quant1.GetDim() == quant2.GetDim());
 
-    TestQuantizerAdapterEncodeDecode<QuantT, int8_t>(quant2, dim, count, error);
-    TestQuantizerAdapterComputeCodes<QuantT, metric, int8_t>(quant2, dim, count, error);
-    TestQuantizerAdapterComputer<QuantT, metric, int8_t>(quant2, dim, count, error);
+    TestQuantizerAdapterEncodeDecode<QuantT, DataT>(quant2, dim, count, error, true, dtype);
+    TestQuantizerAdapterComputeCodes<QuantT, metric, DataT>(quant2, dim, count, error, true, dtype);
+    TestQuantizerAdapterComputer<QuantT, metric, DataT>(quant2,
+                                                        dim,
+                                                        count,
+                                                        error,
+                                                        related_error,
+                                                        true,
+                                                        unbounded_numeric_error_rate,
+                                                        unbounded_related_error_rate,
+                                                        dtype);
 }

--- a/tests/fixtures/data/vector_generator.cpp
+++ b/tests/fixtures/data/vector_generator.cpp
@@ -25,6 +25,8 @@
 #include "core/common.h"
 #include "core/random.h"
 #include "fmt/format.h"
+#include "simd/bf16_simd.h"
+#include "simd/fp16_simd.h"
 #include "vsag/dataset.h"
 
 namespace fixtures {
@@ -118,7 +120,7 @@ GenerateBinaryVectorsAndCodes(uint32_t count, uint32_t dim, int seed) {
 
 std::vector<float>
 generate_vectors(uint64_t count, uint32_t dim, bool need_normalize, int seed) {
-    return std::move(GenerateVectors<float>(count, dim, seed, need_normalize));
+    return std::move(fixtures::GenerateVectors<float>(count, dim, seed, need_normalize));
 }
 
 std::vector<float>
@@ -399,3 +401,42 @@ GetSparseDistance(const vsag::SparseVector& vec1, const vsag::SparseVector& vec2
 }
 
 }  // namespace fixtures
+std::vector<uint16_t>
+generate_fp16_codes(uint64_t count, uint32_t dim, int seed) {
+    auto floats = fixtures::GenerateVectors<float>(count, dim, seed, false);
+    std::vector<uint16_t> codes(floats.size());
+    for (size_t i = 0; i < floats.size(); ++i) {
+        codes[i] = vsag::generic::FloatToFP16(floats[i]);
+    }
+    return codes;
+}
+
+std::vector<uint16_t>
+generate_bf16_codes(uint64_t count, uint32_t dim, int seed) {
+    auto floats = fixtures::GenerateVectors<float>(count, dim, seed, false);
+    std::vector<uint16_t> codes(floats.size());
+    for (size_t i = 0; i < floats.size(); ++i) {
+        codes[i] = vsag::generic::FloatToBF16(floats[i]);
+    }
+    return codes;
+}
+
+std::pair<std::vector<uint16_t>, std::vector<float>>
+fixtures::generate_fp16_codes_with_floats(uint64_t count, uint32_t dim, int seed) {
+    auto floats = fixtures::GenerateVectors<float>(count, dim, seed, false);
+    std::vector<uint16_t> codes(floats.size());
+    for (size_t i = 0; i < floats.size(); ++i) {
+        codes[i] = vsag::generic::FloatToFP16(floats[i]);
+    }
+    return {std::move(codes), std::move(floats)};
+}
+
+std::pair<std::vector<uint16_t>, std::vector<float>>
+fixtures::generate_bf16_codes_with_floats(uint64_t count, uint32_t dim, int seed) {
+    auto floats = fixtures::GenerateVectors<float>(count, dim, seed, false);
+    std::vector<uint16_t> codes(floats.size());
+    for (size_t i = 0; i < floats.size(); ++i) {
+        codes[i] = vsag::generic::FloatToBF16(floats[i]);
+    }
+    return {std::move(codes), std::move(floats)};
+}

--- a/tests/fixtures/data/vector_generator.h
+++ b/tests/fixtures/data/vector_generator.h
@@ -108,6 +108,19 @@ generate_int8_codes(uint64_t count, uint32_t dim, int seed = 47);
 std::vector<uint8_t>
 generate_uint8_codes(uint64_t count, uint32_t dim, int seed = 47);
 
+// Generate FP16/BF16 codes from float values in [0.1, 0.9] range
+std::vector<uint16_t>
+generate_fp16_codes(uint64_t count, uint32_t dim, int seed = 47);
+
+std::vector<uint16_t>
+generate_bf16_codes(uint64_t count, uint32_t dim, int seed = 47);
+
+std::pair<std::vector<uint16_t>, std::vector<float>>
+generate_fp16_codes_with_floats(uint64_t count, uint32_t dim, int seed = 47);
+
+std::pair<std::vector<uint16_t>, std::vector<float>>
+generate_bf16_codes_with_floats(uint64_t count, uint32_t dim, int seed = 47);
+
 std::tuple<std::vector<int64_t>, std::vector<float>>
 generate_ids_and_vectors(int64_t num_elements,
                          int64_t dim,


### PR DESCRIPTION
## Summary

- Fixed `QuantizerAdapter::ProcessQueryImpl` for FP16/BF16 dtypes: incorrectly called `FloatToFP16`/`FloatToBF16` on input query vectors that were already in FP16/BF16 format, when it should use `FP16ToFloat`/`BF16ToFloat` to convert to float32 for the inner quantizer
- Added unit tests for FP16/BF16 dtype paths in QuantizerAdapter (encode/decode, compute, serialize) which were previously untested

## Bug Details

In `src/quantization/quantizer_adapter.cpp`, the `ProcessQueryImpl` specialization for `uint16_t` (FP16/BF16) had inverted conversion logic:
- **Before**: incorrectly double-encoded already-quantized input as float
- **After**: correctly converts FP16/BF16 to float32

All other methods in the same file (TrainImpl, EncodeOneImpl, EncodeBatchImpl) already used the correct conversion.

## Tests Added

- `quantizer_adapter_test.cpp`: 3 new test cases for FP16/BF16 dtype paths (FP16Quantizer and BF16Quantizer)
- `vector_generator.h/cpp`: Added `generate_uint16_codes()` helper for generating FP16/BF16 test data
- `quantizer_adapter_test.h`: Extended test helper templates to support uint16_t DataT

Fixes #1900