### PR TITLE
chore(ci): skip docs-only changes on push-triggered workflows

### DIFF
--- a/.github/workflows/asan_build_and_test.yml
+++ b/.github/workflows/asan_build_and_test.yml
@@ -3,6 +3,8 @@ name: Asan Build & Test Parallel
 on:
   push:
     branches: [ "main", "0.*" ]
+    paths-ignore:
+      - 'docs/**'
   workflow_dispatch:
 jobs:
   build_asan_x86:

--- a/.github/workflows/check_compatibility.yml
+++ b/.github/workflows/check_compatibility.yml
@@ -3,6 +3,8 @@ name: Check Compatibility
 on:
   push:
     branches: [ "main", "0.*" ]
+    paths-ignore:
+      - 'docs/**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,6 +3,8 @@ name: Coverage
 on:
   push:
     branches: [ "main", "0.*" ]
+    paths-ignore:
+      - 'docs/**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch:
   push:
     branches: [ "main", "0.*" ]
+    paths-ignore:
+      - 'docs/**'
 
 jobs:
   clang-format-check:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,6 +3,8 @@ name: Lint
 on:
   push:
     branches: [ "main", "0.*" ]
+    paths-ignore:
+      - 'docs/**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/python_build_and_test.yml
+++ b/.github/workflows/python_build_and_test.yml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch:
   push:
     branches: [ "main", "0.*" ]
+    paths-ignore:
+      - 'docs/**'
 
 jobs:
   build_python_wheel_x86:


### PR DESCRIPTION
## Summary
- Add `paths-ignore: docs/**` to the remaining push-triggered workflows so that docs-only changes merged to `main` no longer spin up heavy build/test/lint/coverage jobs.
- Align with the precedent set by `tsan_build_and_test.yml` in #1885.

## Workflows updated
- `asan_build_and_test.yml`
- `check_compatibility.yml`
- `coverage.yml`
- `format.yml`
- `lint.yml`
- `python_build_and_test.yml`

## Left unchanged on purpose
- `contributors.yml`: we still want to refresh the contributors list when a docs-only PR is merged.
- `tsan_build_and_test.yml`, `asan_with_simd_option.yml`, `docs.yaml`, `update-ci-image.yml`: already scoped via `paths` / `paths-ignore`.
- `pr-ci.yml`: already uses `dorny/paths-filter` to gate jobs by change type.
- Schedule/dispatch/tag-only workflows (`daily_test.yml`, `performance.yml`, `build_release_wheel.yml`, `release.yml`, `generate_old_version_index.yml`): not affected by docs changes.

## Result
After this change, every workflow only runs in its minimally justified scenario. A docs-only PR merged to `main` now only triggers `docs.yaml` (sync) and `contributors.yml` (list refresh).

## Test Plan
- Merge and observe on the next docs-only PR that the listed workflows are skipped on `push` while `docs.yaml` still runs.
- Non-docs pushes should continue to trigger all updated workflows unchanged.