### PR TITLE
test: normalize functest tag system

### DIFF
--- a/tests/test_brute_force.cpp
+++ b/tests/test_brute_force.cpp
@@ -135,7 +135,7 @@ BruteForceTestIndex::TestGeneral(const IndexPtr& index,
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::BruteForceTestIndex,
                              "BruteForce Factory Test With Exceptions",
-                             "[ft][bruteforce]") {
+                             "[ft][factory][bruteforce]") {
     auto name = "brute_force";
     SECTION("Empty parameters") {
         auto param = "{}";
@@ -233,12 +233,12 @@ TestBruteForceBuildAndContinueAdd(const fixtures::BruteForceResourcePtr& resourc
     vsag::Options::Instance().set_block_size_limit(origin_size);
 }
 
-TEST_CASE("(PR) BruteForce Build & ContinueAdd Test", "[ft][BruteForce][pr]") {
+TEST_CASE("(PR) BruteForce Build & ContinueAdd Test", "[ft][build][bruteforce][pr]") {
     auto resource = fixtures::BruteForceTestIndex::GetResource(true);
     TestBruteForceBuildAndContinueAdd(resource);
 }
 
-TEST_CASE("(Daily) BruteForce Build & ContinueAdd Test", "[ft][BruteForce][daily]") {
+TEST_CASE("(Daily) BruteForce Build & ContinueAdd Test", "[ft][build][bruteforce][daily]") {
     auto resource = fixtures::BruteForceTestIndex::GetResource(false);
     TestBruteForceBuildAndContinueAdd(resource);
 }
@@ -273,12 +273,12 @@ TestBruteForceBuild(const fixtures::BruteForceResourcePtr& resource) {
     }
 }
 
-TEST_CASE("(PR) BruteForce Build Test", "[ft][BruteForce][pr]") {
+TEST_CASE("(PR) BruteForce Build Test", "[ft][build][bruteforce][pr]") {
     auto resource = fixtures::BruteForceTestIndex::GetResource(true);
     TestBruteForceBuild(resource);
 }
 
-TEST_CASE("(Daily) BruteForce Build Test", "[ft][BruteForce][daily]") {
+TEST_CASE("(Daily) BruteForce Build Test", "[ft][build][bruteforce][daily]") {
     auto resource = fixtures::BruteForceTestIndex::GetResource(false);
     TestBruteForceBuild(resource);
 }
@@ -307,12 +307,12 @@ TestBruteForceAdd(const fixtures::BruteForceResourcePtr& resource) {
     }
 }
 
-TEST_CASE("(PR) BruteForce Add Test", "[ft][BruteForce][pr]") {
+TEST_CASE("(PR) BruteForce Add Test", "[ft][build][bruteforce][pr]") {
     auto resource = fixtures::BruteForceTestIndex::GetResource(true);
     TestBruteForceAdd(resource);
 }
 
-TEST_CASE("(Daily) BruteForce Add Test", "[ft][BruteForce][daily]") {
+TEST_CASE("(Daily) BruteForce Add Test", "[ft][build][bruteforce][daily]") {
     auto resource = fixtures::BruteForceTestIndex::GetResource(false);
     TestBruteForceAdd(resource);
 }
@@ -341,12 +341,12 @@ TestBruteForceConcurrentAdd(const fixtures::BruteForceResourcePtr& resource) {
     }
 }
 
-TEST_CASE("(PR) BruteForce Concurrent Add Test", "[ft][BruteForce][pr][concurrent]") {
+TEST_CASE("(PR) BruteForce Concurrent Add Test", "[ft][build][bruteforce][concurrent][pr]") {
     auto resource = fixtures::BruteForceTestIndex::GetResource(true);
     TestBruteForceConcurrentAdd(resource);
 }
 
-TEST_CASE("(Daily) BruteForce Concurrent Add Test", "[ft][BruteForce][daily][concurrent]") {
+TEST_CASE("(Daily) BruteForce Concurrent Add Test", "[ft][build][bruteforce][concurrent][daily]") {
     auto resource = fixtures::BruteForceTestIndex::GetResource(false);
     TestBruteForceConcurrentAdd(resource);
 }
@@ -380,12 +380,12 @@ TestBruteForceSerializeFile(const fixtures::BruteForceResourcePtr& resource) {
     }
 }
 
-TEST_CASE("(PR) BruteForce Serialize File Test", "[ft][BruteForce][pr][serialization]") {
+TEST_CASE("(PR) BruteForce Serialize File Test", "[ft][serialize][bruteforce][pr]") {
     auto resource = fixtures::BruteForceTestIndex::GetResource(true);
     TestBruteForceSerializeFile(resource);
 }
 
-TEST_CASE("(Daily) BruteForce Serialize File Test", "[ft][BruteForce][daily][serialization]") {
+TEST_CASE("(Daily) BruteForce Serialize File Test", "[ft][serialize][bruteforce][daily]") {
     auto resource = fixtures::BruteForceTestIndex::GetResource(false);
     TestBruteForceSerializeFile(resource);
 }
@@ -413,12 +413,12 @@ TestBruteForceClone(const fixtures::BruteForceResourcePtr& resource) {
     }
 }
 
-TEST_CASE("(PR) BruteForce Clone Test", "[ft][BruteForce][pr]") {
+TEST_CASE("(PR) BruteForce Clone Test", "[ft][clone][bruteforce][pr]") {
     auto resource = fixtures::BruteForceTestIndex::GetResource(true);
     TestBruteForceClone(resource);
 }
 
-TEST_CASE("(Daily) BruteForce Clone Test", "[ft][BruteForce][daily]") {
+TEST_CASE("(Daily) BruteForce Clone Test", "[ft][clone][bruteforce][daily]") {
     auto resource = fixtures::BruteForceTestIndex::GetResource(false);
     TestBruteForceClone(resource);
 }
@@ -450,13 +450,13 @@ TestBruteForceRandomAllocator(const fixtures::BruteForceResourcePtr& resource) {
 }
 
 TEST_CASE("(PR) BruteForce Build & ContinueAdd Test With Random Allocator",
-          "[ft][BruteForce][pr]") {
+          "[ft][build][bruteforce][pr]") {
     auto resource = fixtures::BruteForceTestIndex::GetResource(true);
     TestBruteForceRandomAllocator(resource);
 }
 
 TEST_CASE("(Daily) BruteForce Build & ContinueAdd Test With Random Allocator",
-          "[ft][BruteForce][daily]") {
+          "[ft][build][bruteforce][daily]") {
     auto resource = fixtures::BruteForceTestIndex::GetResource(false);
     TestBruteForceRandomAllocator(resource);
 }
@@ -483,12 +483,12 @@ TestBruteForceCalcDistanceById(const fixtures::BruteForceResourcePtr& resource) 
     }
 }
 
-TEST_CASE("(PR) BruteForce GetDistance By ID Test", "[ft][BruteForce][pr]") {
+TEST_CASE("(PR) BruteForce GetDistance By ID Test", "[ft][distance][bruteforce][pr]") {
     auto resource = fixtures::BruteForceTestIndex::GetResource(true);
     TestBruteForceCalcDistanceById(resource);
 }
 
-TEST_CASE("(Daily) BruteForce GetDistance By ID Test", "[ft][BruteForce][daily]") {
+TEST_CASE("(Daily) BruteForce GetDistance By ID Test", "[ft][distance][bruteforce][daily]") {
     auto resource = fixtures::BruteForceTestIndex::GetResource(false);
     TestBruteForceCalcDistanceById(resource);
 }
@@ -515,12 +515,12 @@ TestBruteForceDuplicateBuild(const fixtures::BruteForceResourcePtr& resource) {
     }
 }
 
-TEST_CASE("(PR) BruteForce Duplicate Build Test", "[ft][BruteForce][pr]") {
+TEST_CASE("(PR) BruteForce Duplicate Build Test", "[ft][build][duplicate][bruteforce][pr]") {
     auto resource = fixtures::BruteForceTestIndex::GetResource(true);
     TestBruteForceDuplicateBuild(resource);
 }
 
-TEST_CASE("(Daily) BruteForce Duplicate Build Test", "[ft][BruteForce][daily]") {
+TEST_CASE("(Daily) BruteForce Duplicate Build Test", "[ft][build][duplicate][bruteforce][daily]") {
     auto resource = fixtures::BruteForceTestIndex::GetResource(false);
     TestBruteForceDuplicateBuild(resource);
 }
@@ -553,12 +553,13 @@ TestBruteForceWithAttrFilter(const fixtures::BruteForceResourcePtr& resource) {
     }
 }
 
-TEST_CASE("(PR) BruteForce With Attribute Filter Test", "[ft][BruteForce][pr]") {
+TEST_CASE("(PR) BruteForce With Attribute Filter Test", "[ft][filter_search][bruteforce][pr]") {
     auto resource = fixtures::BruteForceTestIndex::GetResource(true);
     TestBruteForceWithAttrFilter(resource);
 }
 
-TEST_CASE("(Daily) BruteForce With Attribute Filter Test", "[ft][BruteForce][daily]") {
+TEST_CASE("(Daily) BruteForce With Attribute Filter Test",
+          "[ft][filter_search][bruteforce][daily]") {
     auto resource = fixtures::BruteForceTestIndex::GetResource(false);
     TestBruteForceWithAttrFilter(resource);
 }
@@ -585,13 +586,13 @@ TestBruteForceMarkRemove(const fixtures::BruteForceResourcePtr& resource) {
     }
 }
 
-TEST_CASE("(PR) BruteForce Mark Remove", "[ft][BruteForce][pr]") {
+TEST_CASE("(PR) BruteForce Mark Remove", "[ft][remove][bruteforce][pr]") {
     auto test_index = std::make_shared<fixtures::BruteForceTestIndex>();
     auto resource = test_index->GetResource(true);
     TestBruteForceMarkRemove(resource);
 }
 
-TEST_CASE("(Daily) BruteForce Mark Remove", "[ft][BruteForce][daily]") {
+TEST_CASE("(Daily) BruteForce Mark Remove", "[ft][remove][bruteforce][daily]") {
     auto test_index = std::make_shared<fixtures::BruteForceTestIndex>();
     auto resource = test_index->GetResource(false);
     TestBruteForceMarkRemove(resource);
@@ -628,12 +629,12 @@ TestBruteForceRemoveById(const fixtures::BruteForceResourcePtr& resource) {
     }
 }
 
-TEST_CASE("(PR) BruteForce Remove By ID Test", "[ft][BruteForce][pr]") {
+TEST_CASE("(PR) BruteForce Remove By ID Test", "[ft][remove][bruteforce][pr]") {
     auto resource = fixtures::BruteForceTestIndex::GetResource(true);
     TestBruteForceRemoveById(resource);
 }
 
-TEST_CASE("(Daily) BruteForce Remove By ID Test", "[ft][BruteForce][daily]") {
+TEST_CASE("(Daily) BruteForce Remove By ID Test", "[ft][remove][bruteforce][daily]") {
     auto resource = fixtures::BruteForceTestIndex::GetResource(false);
     TestBruteForceRemoveById(resource);
 }
@@ -659,12 +660,12 @@ TestBruteForceEstimateMemory(const fixtures::BruteForceResourcePtr& resource) {
     }
 }
 
-TEST_CASE("(PR) BruteForce BruteForce Estimate Memory Test", "[ft][BruteForce][pr]") {
+TEST_CASE("(PR) BruteForce BruteForce Estimate Memory Test", "[ft][memory][bruteforce][pr]") {
     auto resource = fixtures::BruteForceTestIndex::GetResource(true);
     TestBruteForceEstimateMemory(resource);
 }
 
-TEST_CASE("(Daily) BruteForce BruteForce Estimate Memory Test", "[ft][BruteForce][daily]") {
+TEST_CASE("(Daily) BruteForce BruteForce Estimate Memory Test", "[ft][memory][bruteforce][daily]") {
     auto resource = fixtures::BruteForceTestIndex::GetResource(false);
     TestBruteForceEstimateMemory(resource);
 }

--- a/tests/test_diskann.cpp
+++ b/tests/test_diskann.cpp
@@ -77,7 +77,7 @@ DiskANNTestIndex::GenerateDiskANNBuildParametersString(const std::string& metric
     return build_parameters_str;
 }
 }  // namespace fixtures
-TEST_CASE_METHOD(fixtures::DiskANNTestIndex, "diskann build test", "[ft][index][diskann]") {
+TEST_CASE_METHOD(fixtures::DiskANNTestIndex, "diskann build test", "[ft][build][diskann]") {
     auto dims = fixtures::get_common_used_dims(3);
     auto metric_type = GENERATE("l2", "ip");
     const std::string name = "diskann";
@@ -90,7 +90,9 @@ TEST_CASE_METHOD(fixtures::DiskANNTestIndex, "diskann build test", "[ft][index][
     }
 }
 
-TEST_CASE_METHOD(fixtures::DiskANNTestIndex, "diskann cal distance by id", "[ft][index][diskann]") {
+TEST_CASE_METHOD(fixtures::DiskANNTestIndex,
+                 "diskann cal distance by id",
+                 "[ft][distance][diskann]") {
     auto dims = fixtures::get_common_used_dims(3);
     auto metric_type = GENERATE("l2", "ip", "cosine");
     const std::string name = "diskann";
@@ -144,7 +146,7 @@ TEST_CASE_METHOD(fixtures::DiskANNTestIndex, "diskann cal distance by id", "[ft]
     }
 }
 
-TEST_CASE_METHOD(fixtures::DiskANNTestIndex, "diskann pq_dim test", "[ft][index][diskann]") {
+TEST_CASE_METHOD(fixtures::DiskANNTestIndex, "diskann pq_dim test", "[ft][diskann]") {
     const std::vector<int> dims = {736, 1536, 2048, 2560, 3072};
     auto metric_type = GENERATE("l2", "ip", "cosine");
     const std::string name = "diskann";
@@ -189,7 +191,7 @@ TEST_CASE_METHOD(fixtures::DiskANNTestIndex, "diskann pq_dim test", "[ft][index]
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::DiskANNTestIndex,
                              "diskann build and search",
-                             "[ft][index][diskann]") {
+                             "[ft][build][search][diskann]") {
     vsag::Options::Instance().logger()->SetLevel(vsag::Logger::Level::kDEBUG);
     auto dims = fixtures::get_common_used_dims(1);
     auto metric_type = GENERATE("l2", "ip", "cosine");
@@ -228,7 +230,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::DiskANNTestIndex,
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::DiskANNTestIndex,
                              "diskann async_io test",
-                             "[ft][index][diskann]") {
+                             "[ft][io][diskann]") {
     vsag::Options::Instance().logger()->SetLevel(vsag::Logger::Level::kDEBUG);
     auto dims = fixtures::get_common_used_dims(1);
     auto metric_type = GENERATE("l2");
@@ -248,7 +250,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::DiskANNTestIndex,
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::DiskANNTestIndex,
                              "diskann beam_with test",
-                             "[ft][index][diskann]") {
+                             "[ft][diskann]") {
     vsag::Options::Instance().logger()->SetLevel(vsag::Logger::Level::kDEBUG);
     auto dims = fixtures::get_common_used_dims(1);
     auto metric_type = GENERATE("l2");
@@ -268,7 +270,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::DiskANNTestIndex,
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::DiskANNTestIndex,
                              "DiskANN Serialize File",
-                             "[ft][diskann][serialization]") {
+                             "[ft][serialize][diskann]") {
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
     auto metric_type = GENERATE("l2", "ip", "cosine");
@@ -294,7 +296,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::DiskANNTestIndex,
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::DiskANNTestIndex,
                              "DiskANN Search with Dirty Vector",
-                             "[ft][diskann]") {
+                             "[ft][search][diskann]") {
     // bug issue #360
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
@@ -313,7 +315,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::DiskANNTestIndex,
 }
 
 /* FIXME: segmentation fault on some platform
-TEST_CASE("DiskAnn OPQ", "[ft][diskann]") {
+TEST_CASE("DiskAnn OPQ", "[ft][search][diskann]") {
     int dim = 128;            // Dimension of the elements
     int max_elements = 1000;  // Maximum number of elements, should be known beforehand
     int max_degree = 16;      // Tightly connected with internal dimensionality of the data
@@ -383,7 +385,7 @@ TEST_CASE("DiskAnn OPQ", "[ft][diskann]") {
 }
 */
 
-TEST_CASE("DiskAnn Filter Test", "[ft][diskann]") {
+TEST_CASE("DiskAnn Filter Test", "[ft][filter_search][diskann]") {
     int dim = 65;             // Dimension of the elements
     int max_elements = 1000;  // Maximum number of elements, should be known beforehand
     int label_num = 100;      // Total number of labels
@@ -623,7 +625,7 @@ TEST_CASE("DiskAnn Random Id", "[ft][diskann]") {
     REQUIRE(recall >= 0.99);
 }
 
-TEST_CASE("DiskANN small dimension", "[ft][diskann]") {
+TEST_CASE("DiskANN small dimension", "[ft][build][diskann]") {
     int dim = 3;
     int max_elements = 1000;
     int max_degree = 16;
@@ -692,7 +694,7 @@ TEST_CASE("DiskANN small dimension", "[ft][diskann]") {
     REQUIRE(recall > 0.85);
 }
 
-TEST_CASE("split building process", "[ft][diskann]") {
+TEST_CASE("split building process", "[ft][build][diskann]") {
     int64_t dim = 128;
     int64_t ef_construction = 100;
     int64_t max_degree = 12;

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -546,13 +546,13 @@ TestHGraphBuildAndContinueAdd(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("(PR) HGraph Build & ContinueAdd Test", "[ft][hgraph][pr]") {
+TEST_CASE("(PR) HGraph Build & ContinueAdd Test", "[ft][build][hgraph][pr]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(true);
     TestHGraphBuildAndContinueAdd(test_index, resource);
 }
 
-TEST_CASE("(Daily) HGraph Build & ContinueAdd Test", "[ft][hgraph][daily]") {
+TEST_CASE("(Daily) HGraph Build & ContinueAdd Test", "[ft][build][hgraph][daily]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(false);
     TestHGraphBuildAndContinueAdd(test_index, resource);
@@ -603,7 +603,7 @@ TestHGraphFactor(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("HGraph Factor Test", "[ft][hgraph][pr]") {
+TEST_CASE("HGraph Factor Test", "[ft][factory][hgraph][pr]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(true);
     TestHGraphFactor(test_index, resource);
@@ -643,13 +643,13 @@ TestHGraphTrainAndAddTest(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("(PR) HGraph Train & Add Test", "[ft][hgraph][pr]") {
+TEST_CASE("(PR) HGraph Train & Add Test", "[ft][build][hgraph][pr]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(true);
     TestHGraphTrainAndAddTest(test_index, resource);
 }
 
-TEST_CASE("(Daily) HGraph Train & Add Test", "[ft][hgraph][daily]") {
+TEST_CASE("(Daily) HGraph Train & Add Test", "[ft][build][hgraph][daily]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(false);
     TestHGraphTrainAndAddTest(test_index, resource);
@@ -742,13 +742,13 @@ TestHGraphBuild(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("(PR) HGraph Build Test", "[ft][hgraph][pr]") {
+TEST_CASE("(PR) HGraph Build Test", "[ft][build][hgraph][pr]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(true);
     TestHGraphBuild(test_index, resource);
 }
 
-TEST_CASE("(Daily) HGraph Build Test", "[ft][hgraph][daily]") {
+TEST_CASE("(Daily) HGraph Build Test", "[ft][build][hgraph][daily]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(false);
     TestHGraphBuild(test_index, resource);
@@ -809,13 +809,13 @@ TestHGraphWithAttr(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("(PR) HGraph With Attr", "[ft][hgraph][pr]") {
+TEST_CASE("(PR) HGraph With Attr", "[ft][filter_search][hgraph][pr]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(true);
     TestHGraphWithAttr(test_index, resource);
 }
 
-TEST_CASE("(Daily) HGraph With Attr", "[ft][hgraph][daily]") {
+TEST_CASE("(Daily) HGraph With Attr", "[ft][filter_search][hgraph][daily]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(false);
     TestHGraphWithAttr(test_index, resource);
@@ -870,13 +870,13 @@ TestHGraphGetRawVector(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("(PR) HGraph Support Get Raw Vector", "[ft][hgraph][pr]") {
+TEST_CASE("(PR) HGraph Support Get Raw Vector", "[ft][update][hgraph][pr]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(true);
     TestHGraphGetRawVector(test_index, resource);
 }
 
-TEST_CASE("(Daily) HGraph Support Get Raw Vector", "[ft][hgraph][daily]") {
+TEST_CASE("(Daily) HGraph Support Get Raw Vector", "[ft][update][hgraph][daily]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(false);
     TestHGraphGetRawVector(test_index, resource);
@@ -980,19 +980,19 @@ TestHGraphTune(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("(PR) HGraph Tune", "[ft][hgraph][pr]") {
+TEST_CASE("(PR) HGraph Tune", "[ft][search][hgraph][pr]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(true);
     TestHGraphTune(test_index, resource);
 }
 
-TEST_CASE("(Daily) HGraph Tune", "[ft][hgraph][daily]") {
+TEST_CASE("(Daily) HGraph Tune", "[ft][search][hgraph][daily]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(false);
     TestHGraphTune(test_index, resource);
 }
 
-TEST_CASE("(PR) HGraph Tune with ignore_reorder", "[ft][hgraph][pr]") {
+TEST_CASE("(PR) HGraph Tune with ignore_reorder", "[ft][search][hgraph][pr]") {
     using namespace fixtures;
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = 1024 * 1024 * 2;
@@ -1107,13 +1107,13 @@ TestHGraphODescentBuild(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("(PR) HGraph ODescent Build", "[ft][hgraph][pr]") {
+TEST_CASE("(PR) HGraph ODescent Build", "[ft][build][hgraph][pr]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(true);
     TestHGraphODescentBuild(test_index, resource);
 }
 
-TEST_CASE("(Daily) HGraph ODescent Build", "[ft][hgraph][daily]") {
+TEST_CASE("(Daily) HGraph ODescent Build", "[ft][build][hgraph][daily]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(false);
     TestHGraphODescentBuild(test_index, resource);
@@ -1154,13 +1154,13 @@ TestHGraphMarkRemove(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("(PR) HGraph Mark Remove", "[ft][hgraph][pr]") {
+TEST_CASE("(PR) HGraph Mark Remove", "[ft][remove][hgraph][pr]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(true);
     TestHGraphMarkRemove(test_index, resource);
 }
 
-TEST_CASE("(Daily) HGraph Mark Remove", "[ft][hgraph][daily]") {
+TEST_CASE("(Daily) HGraph Mark Remove", "[ft][remove][hgraph][daily]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(false);
     TestHGraphMarkRemove(test_index, resource);
@@ -1200,13 +1200,13 @@ TestHGraphShrink(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("(PR) HGraph Shrink", "[ft][hgraph][pr]") {
+TEST_CASE("(PR) HGraph Shrink", "[ft][build][hgraph][pr]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(true);
     TestHGraphShrink(test_index, resource);
 }
 
-TEST_CASE("(Daily) HGraph Shrink", "[ft][hgraph][daily]") {
+TEST_CASE("(Daily) HGraph Shrink", "[ft][build][hgraph][daily]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(false);
     TestHGraphShrink(test_index, resource);
@@ -1248,13 +1248,13 @@ TestHGraphCompressedBuild(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("(PR) HGraph Compressed Graph Build", "[ft][hgraph][pr]") {
+TEST_CASE("(PR) HGraph Compressed Graph Build", "[ft][build][hgraph][pr]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(true);
     TestHGraphCompressedBuild(test_index, resource);
 }
 
-TEST_CASE("(Daily) HGraph Compressed Graph Build", "[ft][hgraph][daily]") {
+TEST_CASE("(Daily) HGraph Compressed Graph Build", "[ft][build][hgraph][daily]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(false);
     TestHGraphCompressedBuild(test_index, resource);
@@ -1297,13 +1297,13 @@ TestHGraphMerge(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("(PR) HGraph Merge", "[ft][hgraph][pr]") {
+TEST_CASE("(PR) HGraph Merge", "[ft][merge][hgraph][pr]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(true);
     TestHGraphMerge(test_index, resource);
 }
 
-TEST_CASE("(Daily) HGraph Merge", "[ft][hgraph][daily]") {
+TEST_CASE("(Daily) HGraph Merge", "[ft][merge][hgraph][daily]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(false);
     TestHGraphMerge(test_index, resource);
@@ -1346,13 +1346,13 @@ TestHGraphAdd(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("(PR) HGraph Add", "[ft][hgraph][pr]") {
+TEST_CASE("(PR) HGraph Add", "[ft][build][hgraph][pr]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(true);
     TestHGraphAdd(test_index, resource);
 }
 
-TEST_CASE("(Daily) HGraph Add", "[ft][hgraph][daily]") {
+TEST_CASE("(Daily) HGraph Add", "[ft][build][hgraph][daily]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(false);
     TestHGraphAdd(test_index, resource);
@@ -1395,7 +1395,7 @@ TestHGraphNonstandardID(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("HGraph Test NonstandardID", "[ft][hgraph][pr]") {
+TEST_CASE("HGraph Test NonstandardID", "[ft][build][hgraph][pr]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(true);
     TestHGraphNonstandardID(test_index, resource);
@@ -1482,19 +1482,20 @@ TestHGraphDuplicateSerializeCompressed(const fixtures::HGraphTestIndexPtr& test_
     RunHGraphDuplicateChecks(test_index, resource, "compressed", false, true);
 }
 
-TEST_CASE("(PR) HGraph Duplicate", "[ft][hgraph][pr]") {
+TEST_CASE("(PR) HGraph Duplicate", "[ft][build][hgraph][duplicate][pr]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(true);
     TestHGraphDuplicate(test_index, resource);
 }
 
-TEST_CASE("(Daily) HGraph Duplicate", "[ft][hgraph][daily]") {
+TEST_CASE("(Daily) HGraph Duplicate", "[ft][build][hgraph][duplicate][daily]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(false);
     TestHGraphDuplicate(test_index, resource);
 }
 
-TEST_CASE("(PR) HGraph Duplicate Serialize Compressed", "[ft][hgraph][serialization][pr]") {
+TEST_CASE("(PR) HGraph Duplicate Serialize Compressed",
+          "[ft][build][duplicate][serialize][hgraph][pr]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(true);
     TestHGraphDuplicateSerializeCompressed(test_index, resource);
@@ -1533,13 +1534,13 @@ TestHGraphSearchWithDirtyVector(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("(PR) HGraph Search with Dirty Vector", "[ft][hgraph][pr]") {
+TEST_CASE("(PR) HGraph Search with Dirty Vector", "[ft][search][hgraph][pr]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(true);
     TestHGraphSearchWithDirtyVector(test_index, resource);
 }
 
-TEST_CASE("(Daily) HGraph Search with Dirty Vector", "[ft][hgraph][daily]") {
+TEST_CASE("(Daily) HGraph Search with Dirty Vector", "[ft][search][hgraph][daily]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(false);
     TestHGraphSearchWithDirtyVector(test_index, resource);
@@ -1547,7 +1548,7 @@ TEST_CASE("(Daily) HGraph Search with Dirty Vector", "[ft][hgraph][daily]") {
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::HGraphTestIndex,
                              "HGraph Search with Sparse Vector",
-                             "[ft][hgraph][concurrent]") {
+                             "[ft][concurrent][hgraph]") {
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
     auto metric_type = "ip";
@@ -1612,13 +1613,13 @@ TestHGraphConcurrentAdd(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("(PR) HGraph Concurrent Add", "[ft][hgraph][pr][concurrent]") {
+TEST_CASE("(PR) HGraph Concurrent Add", "[ft][build][concurrent][hgraph][pr]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(true);
     TestHGraphConcurrentAdd(test_index, resource);
 }
 
-TEST_CASE("(Daily) HGraph Concurrent Add", "[ft][hgraph][daily][concurrent]") {
+TEST_CASE("(Daily) HGraph Concurrent Add", "[ft][build][concurrent][hgraph][daily]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(false);
     TestHGraphConcurrentAdd(test_index, resource);
@@ -1665,13 +1666,13 @@ TestHGraphConcurrentAddSearchRemove(const fixtures::HGraphTestIndexPtr& test_ind
     }
 }
 
-TEST_CASE("(PR) HGraph Concurrent Add Search Remove", "[ft][hgraph][pr][concurrent]") {
+TEST_CASE("(PR) HGraph Concurrent Add Search Remove", "[ft][build][concurrent][hgraph][pr]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(true);
     TestHGraphConcurrentAddSearchRemove(test_index, resource);
 }
 
-TEST_CASE("(Daily) HGraph Concurrent Add Search Remove", "[ft][hgraph][daily][concurrent]") {
+TEST_CASE("(Daily) HGraph Concurrent Add Search Remove", "[ft][build][concurrent][hgraph][daily]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(false);
     TestHGraphConcurrentAddSearchRemove(test_index, resource);
@@ -1726,13 +1727,13 @@ TestHGraphSerialize(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("(PR) HGraph Serialize File", "[ft][hgraph][serialization][pr]") {
+TEST_CASE("(PR) HGraph Serialize File", "[ft][serialize][hgraph][serialization][pr]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(true);
     TestHGraphSerialize(test_index, resource);
 }
 
-TEST_CASE("(Daily) HGraph Serialize File", "[ft][hgraph][serialization][daily]") {
+TEST_CASE("(Daily) HGraph Serialize File", "[ft][serialize][hgraph][serialization][daily]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(false);
     TestHGraphSerialize(test_index, resource);
@@ -1787,13 +1788,13 @@ TestHGraphReaderIO(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("(PR) HGraph Reader IO", "[ft][hgraph][serialization][pr]") {
+TEST_CASE("(PR) HGraph Reader IO", "[ft][serialize][hgraph][pr]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(true);
     TestHGraphReaderIO(test_index, resource);
 }
 
-TEST_CASE("(Daily) HGraph Reader IO", "[ft][hgraph][serialization][daily]") {
+TEST_CASE("(Daily) HGraph Reader IO", "[ft][serialize][hgraph][daily]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(false);
     TestHGraphReaderIO(test_index, resource);
@@ -1840,13 +1841,13 @@ TestHGraphClone(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("(PR) HGraph Clone", "[ft][hgraph][pr]") {
+TEST_CASE("(PR) HGraph Clone", "[ft][clone][hgraph][pr]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(true);
     TestHGraphClone(test_index, resource);
 }
 
-TEST_CASE("(Daily) HGraph Clone", "[ft][hgraph][daily]") {
+TEST_CASE("(Daily) HGraph Clone", "[ft][clone][hgraph][daily]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(false);
     TestHGraphClone(test_index, resource);
@@ -1894,13 +1895,13 @@ TestHGraphExportModel(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("(PR) HGraph Export Model", "[ft][hgraph][pr]") {
+TEST_CASE("(PR) HGraph Export Model", "[ft][export][hgraph][pr]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(true);
     TestHGraphExportModel(test_index, resource);
 }
 
-TEST_CASE("(Daily) HGraph Export Model", "[ft][hgraph][daily]") {
+TEST_CASE("(Daily) HGraph Export Model", "[ft][export][hgraph][daily]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(false);
     TestHGraphExportModel(test_index, resource);
@@ -1947,13 +1948,14 @@ TestHGraphRandomAllocator(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("(PR) HGraph Build & ContinueAdd Test With Random Allocator", "[ft][hgraph][pr]") {
+TEST_CASE("(PR) HGraph Build & ContinueAdd Test With Random Allocator", "[ft][build][hgraph][pr]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(true);
     TestHGraphRandomAllocator(test_index, resource);
 }
 
-TEST_CASE("(Daily) HGraph Build & ContinueAdd Test With Random Allocator", "[ft][hgraph][daily]") {
+TEST_CASE("(Daily) HGraph Build & ContinueAdd Test With Random Allocator",
+          "[ft][build][hgraph][daily]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(false);
     TestHGraphRandomAllocator(test_index, resource);
@@ -1999,13 +2001,13 @@ TestHGraphDuplicateBuild(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("(PR) HGraph Duplicate Build", "[ft][hgraph][pr]") {
+TEST_CASE("(PR) HGraph Duplicate Build", "[ft][build][duplicate][hgraph][pr]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(true);
     TestHGraphDuplicateBuild(test_index, resource);
 }
 
-TEST_CASE("(Daily) HGraph Duplicate Build", "[ft][hgraph][daily]") {
+TEST_CASE("(Daily) HGraph Duplicate Build", "[ft][build][duplicate][hgraph][daily]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(false);
     TestHGraphDuplicateBuild(test_index, resource);
@@ -2053,19 +2055,21 @@ TestHGraphEstimateMemoryAndGetMemoryUsage(const fixtures::HGraphTestIndexPtr& te
     }
 }
 
-TEST_CASE("(PR) HGraph Estimate Memory And Get Memory Usage", "[ft][hgraph][pr]") {
+TEST_CASE("(PR) HGraph Estimate Memory And Get Memory Usage", "[ft][memory][hgraph][pr]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(true);
     TestHGraphEstimateMemoryAndGetMemoryUsage(test_index, resource);
 }
 
-TEST_CASE("(Daily) HGraph Estimate Memory", "[ft][hgraph][daily]") {
+TEST_CASE("(Daily) HGraph Estimate Memory", "[ft][memory][hgraph][daily]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(false);
     TestHGraphEstimateMemoryAndGetMemoryUsage(test_index, resource);
 }
 
-TEST_CASE_PERSISTENT_FIXTURE(fixtures::HGraphTestIndex, "HGraph ELP Optimizer", "[ft][hgraph]") {
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::HGraphTestIndex,
+                             "HGraph ELP Optimizer",
+                             "[ft][build][hgraph]") {
     fixtures::logger::LoggerReplacer _;
     vsag::Options::Instance().logger()->SetLevel(vsag::Logger::Level::kDEBUG);
 
@@ -2142,13 +2146,13 @@ TestHGraphIgnoreReorder(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("(PR) HGraph Ignore Reorder", "[ft][hgraph][pr]") {
+TEST_CASE("(PR) HGraph Ignore Reorder", "[ft][search][hgraph][pr]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(true);
     TestHGraphIgnoreReorder(test_index, resource);
 }
 
-TEST_CASE("(Daily) HGraph Ignore Reorder", "[ft][hgraph][daily]") {
+TEST_CASE("(Daily) HGraph Ignore Reorder", "[ft][search][hgraph][daily]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(false);
     TestHGraphIgnoreReorder(test_index, resource);
@@ -2206,13 +2210,13 @@ TestHGraphWithExtraInfo(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("(PR) HGraph With Extra Info", "[ft][hgraph][pr]") {
+TEST_CASE("(PR) HGraph With Extra Info", "[ft][search][hgraph][pr]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(true);
     TestHGraphWithExtraInfo(test_index, resource);
 }
 
-TEST_CASE("(Daily) HGraph With Extra Info", "[ft][hgraph][daily]") {
+TEST_CASE("(Daily) HGraph With Extra Info", "[ft][search][hgraph][daily]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(false);
     TestHGraphWithExtraInfo(test_index, resource);
@@ -2257,13 +2261,13 @@ TestHGraphSearchOverTime(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("(PR) HGraph Search Over Time", "[ft][hgraph][pr]") {
+TEST_CASE("(PR) HGraph Search Over Time", "[ft][search][hgraph][pr]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(true);
     TestHGraphSearchOverTime(test_index, resource);
 }
 
-TEST_CASE("(Daily) HGraph Search Over Time", "[ft][hgraph][daily]") {
+TEST_CASE("(Daily) HGraph Search Over Time", "[ft][search][hgraph][daily]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(false);
     TestHGraphSearchOverTime(test_index, resource);
@@ -2319,19 +2323,19 @@ TestHGraphDiskIOType(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("(PR) HGraph Disk IO Type Index", "[ft][hgraph][serialization][pr]") {
+TEST_CASE("(PR) HGraph Disk IO Type Index", "[ft][serialize][hgraph][pr]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(true);
     TestHGraphDiskIOType(test_index, resource);
 }
 
-TEST_CASE("(Daily) HGraph Disk IO Type Index", "[ft][hgraph][serialization][daily]") {
+TEST_CASE("(Daily) HGraph Disk IO Type Index", "[ft][serialize][hgraph][daily]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(false);
     TestHGraphDiskIOType(test_index, resource);
 }
 
-TEST_CASE("HGraph Concurrent Read Write", "[ft][hgraph][concurrent]") {
+TEST_CASE("HGraph Concurrent Read Write", "[ft][concurrent][hgraph]") {
     uint32_t op_num = 10000;
     uint32_t dim = 128;
     uint32_t top_k = 5;
@@ -2533,13 +2537,13 @@ TestHGraphHopsLimit(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("(PR) HGraph Hops Limit", "[ft][hgraph][pr]") {
+TEST_CASE("(PR) HGraph Hops Limit", "[ft][search][hgraph][pr]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(true);
     TestHGraphHopsLimit(test_index, resource);
 }
 
-TEST_CASE("(Daily) HGraph Hops Limit", "[ft][hgraph][daily]") {
+TEST_CASE("(Daily) HGraph Hops Limit", "[ft][search][hgraph][daily]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(false);
     TestHGraphHopsLimit(test_index, resource);
@@ -2622,13 +2626,13 @@ TestHGraphReverseEdges(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("(PR) HGraph Reverse Edges", "[ft][hgraph][pr]") {
+TEST_CASE("(PR) HGraph Reverse Edges", "[ft][build][hgraph][pr]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(true);
     TestHGraphReverseEdges(test_index, resource);
 }
 
-TEST_CASE("(Daily) HGraph Reverse Edges", "[ft][hgraph][daily]") {
+TEST_CASE("(Daily) HGraph Reverse Edges", "[ft][build][hgraph][daily]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(false);
     TestHGraphReverseEdges(test_index, resource);

--- a/tests/test_hnsw.cpp
+++ b/tests/test_hnsw.cpp
@@ -100,7 +100,7 @@ HNSWTestIndex::TestGeneral(const TestIndex::IndexPtr& index,
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex,
                              "HNSW Factory Test With Exceptions",
-                             "[ft][hnsw]") {
+                             "[ft][factory][hnsw]") {
     auto name = "hnsw";
     SECTION("Empty parameters") {
         auto param = "{}";
@@ -226,7 +226,9 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex,
     }
 }
 
-TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Estimate Memory", "[ft][hnsw]") {
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex,
+                             "HNSW Estimate Memory",
+                             "[ft][memory][hnsw]") {
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
     auto metric_type = GENERATE("l2", "cosine");
@@ -250,7 +252,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Estimate Memory", "[
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex,
                              "HNSW Build & ContinueAdd Test",
-                             "[ft][hnsw]") {
+                             "[ft][build][hnsw]") {
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
     auto metric_type = GENERATE("l2", "ip", "cosine");
@@ -313,7 +315,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Test non-standard ID
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex,
                              "HNSW Continue Destruct V.S. All Test",
-                             "[ft][hnsw]") {
+                             "[ft][build][hnsw]") {
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
     auto metric_type = GENERATE("l2");
@@ -335,7 +337,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex,
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex,
                              "HNSW Search with Dirty Vector",
-                             "[ft][hnsw]") {
+                             "[ft][search][hnsw]") {
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
     auto metric_type = GENERATE("l2", "ip", "cosine");
@@ -352,7 +354,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex,
     vsag::Options::Instance().set_block_size_limit(origin_size);
 }
 
-TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Build", "[ft][hnsw]") {
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Build", "[ft][build][hnsw]") {
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
     auto metric_type = GENERATE("l2", "ip", "cosine");
@@ -377,7 +379,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Build", "[ft][hnsw]"
     vsag::Options::Instance().set_block_size_limit(origin_size);
 }
 
-TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Merge", "[ft][hnsw]") {
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Merge", "[ft][merge][hnsw]") {
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
     auto metric_type = GENERATE("l2");
@@ -398,7 +400,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Merge", "[ft][hnsw]"
     vsag::Options::Instance().set_block_size_limit(origin_size);
 }
 
-TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Filter", "[ft][hnsw]") {
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Filter", "[ft][filter_search][hnsw]") {
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
     auto metric_type = GENERATE("l2");
@@ -420,7 +422,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Filter", "[ft][hnsw]
     vsag::Options::Instance().set_block_size_limit(origin_size);
 }
 
-TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Add", "[ft][hnsw]") {
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Add", "[ft][build][hnsw]") {
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
     auto metric_type = GENERATE("l2", "ip", "cosine");
@@ -446,7 +448,9 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Add", "[ft][hnsw]") 
     }
 }
 
-TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Concurrent Add", "[ft][hnsw]") {
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex,
+                             "HNSW Concurrent Add",
+                             "[ft][build][hnsw][concurrent][build]") {
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
     auto metric_type = GENERATE("l2", "ip", "cosine");
@@ -472,7 +476,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Concurrent Add", "[f
     }
 }
 
-TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Remove", "[ft][hnsw]") {
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Remove", "[ft][remove][hnsw]") {
     auto test_recovery = GENERATE(true, false);
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
@@ -498,7 +502,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Remove", "[ft][hnsw]
     }
 }
 
-TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Update Id", "[ft][hnsw]") {
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Update Id", "[ft][update][hnsw]") {
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
     auto metric_type = GENERATE("l2", "ip", "cosine");
@@ -515,7 +519,9 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Update Id", "[ft][hn
     }
 }
 
-TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Batch Calc Dis Id", "[ft][hnsw]") {
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex,
+                             "HNSW Batch Calc Dis Id",
+                             "[ft][distance][hnsw]") {
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
     auto metric_type = GENERATE("l2", "ip", "cosine");
@@ -532,7 +538,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Batch Calc Dis Id", 
     }
 }
 
-TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Get Min Max ID", "[ft][hnsw]") {
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Get Min Max ID", "[ft][search][hnsw]") {
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
     auto metric_type = GENERATE("l2");
@@ -548,7 +554,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Get Min Max ID", "[f
     vsag::Options::Instance().set_block_size_limit(origin_size);
 }
 
-TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Get Raw Vector", "[ft][hnsw]") {
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Get Raw Vector", "[ft][update][hnsw]") {
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
     auto dtype = GENERATE("float32", "int8");
@@ -568,7 +574,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Get Raw Vector", "[f
     }
 }
 
-TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Update Vector", "[ft][hnsw]") {
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Update Vector", "[ft][update][hnsw]") {
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
     auto metric_type = GENERATE("l2");
@@ -587,7 +593,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Update Vector", "[ft
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex,
                              "HNSW Serialize File",
-                             "[ft][hnsw][serialization]") {
+                             "[ft][serialize][hnsw][serialization]") {
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
     auto metric_type = GENERATE("l2", "ip", "cosine");
@@ -610,7 +616,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex,
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex,
                              "HNSW Build & ContinueAdd Test With Random Allocator",
-                             "[ft][hnsw]") {
+                             "[ft][build][hnsw]") {
     auto allocator = std::make_shared<fixtures::RandomAllocator>();
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
@@ -631,7 +637,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex,
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex,
                              "HNSW Duplicate Add",
-                             "[ft][hnsw][concurrent]") {
+                             "[ft][build][hnsw][concurrent]") {
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
     auto metric_type = GENERATE("l2", "ip", "cosine");
@@ -656,7 +662,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex,
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex,
                              "HNSW Set Immutable",
-                             "[ft][hnsw][immutable]") {
+                             "[ft][immutable][hnsw]") {
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
     auto metric_type = "l2";

--- a/tests/test_index_old.cpp
+++ b/tests/test_index_old.cpp
@@ -17,7 +17,7 @@
 #include "simd/simd.h"
 #include "test_index.h"
 
-TEST_CASE("hnsw int8 recall", "[ft][index][hnsw]") {
+TEST_CASE("hnsw int8 recall", "[ft][search][hnsw]") {
     vsag::Options::Instance().logger()->SetLevel(vsag::Logger::Level::kDEBUG);
 
     int64_t num_vectors = 1000;
@@ -81,7 +81,7 @@ TEST_CASE("hnsw int8 recall", "[ft][index][hnsw]") {
     }
 }
 
-TEST_CASE("index search distance", "[ft][index]") {
+TEST_CASE("index search distance", "[ft][search][distance][hnsw][diskann]") {
     vsag::Options::Instance().logger()->SetLevel(vsag::Logger::Level::kDEBUG);
 
     uint64_t num_vectors = 1000;
@@ -233,7 +233,7 @@ TEST_CASE("index search distance", "[ft][index]") {
     }
 }
 
-TEST_CASE("create two hnsw index in the same time", "[ft][index][hnsw]") {
+TEST_CASE("create two hnsw index in the same time", "[ft][build][hnsw]") {
     vsag::Options::Instance().logger()->SetLevel(vsag::Logger::Level::kDEBUG);
 
     int64_t num_vectors = 1000;
@@ -291,7 +291,7 @@ TEST_CASE("create two hnsw index in the same time", "[ft][index][hnsw]") {
 // index->serialize/deserialize
 /////////////////////////////////////////////////////////
 
-TEST_CASE("serialize/deserialize with file stream", "[ft][index]") {
+TEST_CASE("serialize/deserialize with file stream", "[ft][serialize][hnsw]") {
     vsag::Options::Instance().logger()->SetLevel(vsag::Logger::Level::kDEBUG);
 
     int64_t num_vectors = 1000;
@@ -391,7 +391,7 @@ TEST_CASE("serialize/deserialize with file stream", "[ft][index]") {
     // }
 }
 
-TEST_CASE("search on a deserialized empty index", "[ft][index]") {
+TEST_CASE("search on a deserialized empty index", "[ft][search][serialize][hnsw][diskann]") {
     vsag::Options::Instance().logger()->SetLevel(vsag::Logger::Level::kDEBUG);
 
     int64_t num_vectors = 1000;
@@ -452,7 +452,7 @@ TEST_CASE("search on a deserialized empty index", "[ft][index]") {
     REQUIRE(rangesearch.value()->GetDim() == 0);
 }
 
-TEST_CASE("remove vectors from the index", "[ft][index]") {
+TEST_CASE("remove vectors from the index", "[ft][remove][hnsw][diskann]") {
     vsag::Options::Instance().logger()->SetLevel(vsag::Logger::Level::kDEBUG);
     int64_t num_vectors = 1000;
     int64_t dim = 64;
@@ -569,7 +569,7 @@ TEST_CASE("remove vectors from the index", "[ft][index]") {
     }
 }
 
-TEST_CASE("index with bsa", "[ft][index]") {
+TEST_CASE("index with bsa", "[ft][diskann]") {
     vsag::Options::Instance().logger()->SetLevel(vsag::Logger::Level::kDEBUG);
     int64_t num_vectors = 1000;
     int64_t dim = 128;
@@ -625,7 +625,7 @@ TEST_CASE("index with bsa", "[ft][index]") {
     REQUIRE(recall > 0.99);
 }
 
-TEST_CASE("io for diskann", "[ft][index]") {
+TEST_CASE("io for diskann", "[ft][io][diskann]") {
     vsag::Options::Instance().logger()->SetLevel(vsag::Logger::Level::kDEBUG);
     int64_t num_vectors = 1000;
     int64_t dim = 128;
@@ -685,7 +685,7 @@ TEST_CASE("io for diskann", "[ft][index]") {
     REQUIRE(recall > 0.99);
 }
 
-TEST_CASE("different parameter of io_limit", "[ft][index]") {
+TEST_CASE("different parameter of io_limit", "[ft][io][diskann]") {
     vsag::Options::Instance().logger()->SetLevel(vsag::Logger::Level::kDEBUG);
     int64_t num_vectors = 1000;
     int64_t dim = 128;
@@ -750,7 +750,7 @@ TEST_CASE("different parameter of io_limit", "[ft][index]") {
 // utility functions
 /////////////////////////////////////////////////////////
 
-TEST_CASE("check correct build parameters", "[ft][index]") {
+TEST_CASE("check correct build parameters", "[ft][factory]") {
     vsag::Options::Instance().logger()->SetLevel(vsag::Logger::Level::kDEBUG);
 
     auto json_string = R"(
@@ -774,7 +774,7 @@ TEST_CASE("check correct build parameters", "[ft][index]") {
     REQUIRE(res.has_value());
 }
 
-TEST_CASE("check incorrect build parameters", "[ft][index]") {
+TEST_CASE("check incorrect build parameters", "[ft][factory]") {
     vsag::Options::Instance().logger()->SetLevel(vsag::Logger::Level::kDEBUG);
 
     auto json_string = R"(
@@ -798,7 +798,7 @@ TEST_CASE("check incorrect build parameters", "[ft][index]") {
     REQUIRE(res.error().type == vsag::ErrorType::INVALID_ARGUMENT);
 }
 
-TEST_CASE("check correct search parameters", "[ft][index]") {
+TEST_CASE("check correct search parameters", "[ft][factory]") {
     vsag::Options::Instance().logger()->SetLevel(vsag::Logger::Level::kDEBUG);
 
     auto json_string = R"(
@@ -818,7 +818,7 @@ TEST_CASE("check correct search parameters", "[ft][index]") {
     REQUIRE(res.has_value());
 }
 
-TEST_CASE("check incorrect search parameters", "[ft][index]") {
+TEST_CASE("check incorrect search parameters", "[ft][factory]") {
     vsag::Options::Instance().logger()->SetLevel(vsag::Logger::Level::kDEBUG);
 
     auto json_string = R"(
@@ -839,7 +839,7 @@ TEST_CASE("check incorrect search parameters", "[ft][index]") {
     REQUIRE(res.error().type == vsag::ErrorType::INVALID_ARGUMENT);
 }
 
-TEST_CASE("generate build parameters", "[ft][index]") {
+TEST_CASE("generate build parameters", "[ft][factory]") {
     vsag::Options::Instance().logger()->SetLevel(vsag::Logger::Level::kDEBUG);
 
     auto metric_type = GENERATE("l2", "IP");
@@ -864,7 +864,7 @@ TEST_CASE("generate build parameters", "[ft][index]") {
     REQUIRE(json["diskann"]["pq_dims"].GetInt() == dim / 4);
 }
 
-TEST_CASE("estimate search cost", "[ft][index]") {
+TEST_CASE("estimate search cost", "[ft][factory]") {
     vsag::Options::Instance().logger()->SetLevel(vsag::Logger::Level::kDEBUG);
 
     constexpr auto search_parameters_json = R"(
@@ -913,7 +913,7 @@ TEST_CASE("estimate search cost", "[ft][index]") {
     }
 }
 
-TEST_CASE("generate build parameters with invalid num_elements", "[ft][index]") {
+TEST_CASE("generate build parameters with invalid num_elements", "[ft][factory]") {
     vsag::Options::Instance().logger()->SetLevel(vsag::Logger::Level::kDEBUG);
 
     auto metric_type = GENERATE("l2", "IP");
@@ -926,7 +926,7 @@ TEST_CASE("generate build parameters with invalid num_elements", "[ft][index]") 
     REQUIRE(parameters.error().type == vsag::ErrorType::INVALID_ARGUMENT);
 }
 
-TEST_CASE("generate build parameters with invalid dim", "[ft][index]") {
+TEST_CASE("generate build parameters with invalid dim", "[ft][factory]") {
     vsag::Options::Instance().logger()->SetLevel(vsag::Logger::Level::kDEBUG);
 
     auto metric_type = GENERATE("l2", "IP");
@@ -939,7 +939,7 @@ TEST_CASE("generate build parameters with invalid dim", "[ft][index]") {
     REQUIRE(parameters.error().type == vsag::ErrorType::INVALID_ARGUMENT);
 }
 
-TEST_CASE("build index with generated_build_parameters", "[ft][index]") {
+TEST_CASE("build index with generated_build_parameters", "[ft][factory][hnsw]") {
     vsag::Options::Instance().logger()->SetLevel(vsag::Logger::Level::kDEBUG);
 
     int64_t num_vectors = 1000;
@@ -991,7 +991,7 @@ TEST_CASE("build index with generated_build_parameters", "[ft][index]") {
     REQUIRE(recall > 0.95);
 }
 
-TEST_CASE("int8 + freshhnsw + feedback + update", "[ft][index][hnsw]") {
+TEST_CASE("int8 + freshhnsw + feedback + update", "[ft][feedback][update][hnsw]") {
     auto logger = vsag::Options::Instance().logger();
     logger->SetLevel(vsag::Logger::Level::kDEBUG);
 
@@ -1110,7 +1110,7 @@ TEST_CASE("int8 + freshhnsw + feedback + update", "[ft][index][hnsw]") {
     REQUIRE(fixtures::time_t(recall[1]) == fixtures::time_t(1.0f));
 }
 
-TEST_CASE("hnsw + feedback with global optimum id + remove", "[ft][index][hnsw]") {
+TEST_CASE("hnsw + feedback with global optimum id + remove", "[ft][feedback][remove][hnsw]") {
     auto logger = vsag::Options::Instance().logger();
     logger->SetLevel(vsag::Logger::Level::kDEBUG);
 
@@ -1235,7 +1235,7 @@ TEST_CASE("hnsw + feedback with global optimum id + remove", "[ft][index][hnsw]"
     }
 }
 
-TEST_CASE("using indexes that do not support conjugate graph", "[ft][index]") {
+TEST_CASE("using indexes that do not support conjugate graph", "[ft][diskann]") {
     vsag::Options::Instance().logger()->SetLevel(vsag::Logger::Level::kDEBUG);
     int64_t num_vectors = 1000;
     int64_t dim = 64;
@@ -1266,7 +1266,7 @@ TEST_CASE("using indexes that do not support conjugate graph", "[ft][index]") {
     REQUIRE_THROWS(index->Pretrain(base_tag_ids, k, search_parameters));
 }
 
-TEST_CASE("hnsw with pretrained by conjugate graph", "[ft][index][hnsw]") {
+TEST_CASE("hnsw with pretrained by conjugate graph", "[ft][feedback][hnsw]") {
     auto logger = vsag::Options::Instance().logger();
     logger->SetLevel(vsag::Logger::Level::kDEBUG);
 
@@ -1394,7 +1394,7 @@ TEST_CASE("hnsw with pretrained by conjugate graph", "[ft][index][hnsw]") {
     }
 }
 
-TEST_CASE("HNSW filtered search", "[ft][index][hnsw]") {
+TEST_CASE("HNSW filtered search", "[ft][filter_search][hnsw]") {
     auto logger = vsag::Options::Instance().logger();
     logger->SetLevel(vsag::Logger::Level::kDEBUG);
 
@@ -1568,7 +1568,7 @@ TEST_CASE("HNSW filtered search", "[ft][index][hnsw]") {
     }
 }
 
-TEST_CASE("DiskAnn filtered knn search", "[ft][index][diskann]") {
+TEST_CASE("DiskAnn filtered knn search", "[ft][filter_search][diskann]") {
     auto logger = vsag::Options::Instance().logger();
     logger->SetLevel(vsag::Logger::Level::kDEBUG);
 

--- a/tests/test_ivf.cpp
+++ b/tests/test_ivf.cpp
@@ -459,13 +459,13 @@ TestIVFBuildAndContinueAdd(const fixtures::IVFResourcePtr& resource) {
     }
 }
 
-TEST_CASE("(PR) IVF Build & ContinueAdd Test", "[ft][ivf][pr][concurrent]") {
+TEST_CASE("(PR) IVF Build & ContinueAdd Test", "[ft][build][concurrent][ivf][pr]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(true);
     TestIVFBuildAndContinueAdd(resource);
 }
 
-TEST_CASE("(Daily) IVF Build & ContinueAdd Test", "[ft][ivf][daily][concurrent]") {
+TEST_CASE("(Daily) IVF Build & ContinueAdd Test", "[ft][build][concurrent][ivf][daily]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(false);
     TestIVFBuildAndContinueAdd(resource);
@@ -522,13 +522,13 @@ TestIVFBuildWithResidual(const fixtures::IVFResourcePtr& resource) {
     }
 }
 
-TEST_CASE("(PR) IVF Build with Residual", "[ft][ivf][pr]") {
+TEST_CASE("(PR) IVF Build with Residual", "[ft][build][ivf][pr]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(true);
     TestIVFBuildWithResidual(resource);
 }
 
-TEST_CASE("(Daily) IVF Build with Residual", "[ft][ivf][daily]") {
+TEST_CASE("(Daily) IVF Build with Residual", "[ft][build][ivf][daily]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(false);
     TestIVFBuildWithResidual(resource);
@@ -598,13 +598,13 @@ TestIVFBuild(const fixtures::IVFResourcePtr& resource) {
     }
 }
 
-TEST_CASE("(PR) IVF Build", "[ft][ivf][pr]") {
+TEST_CASE("(PR) IVF Build", "[ft][build][ivf][pr]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(true);
     TestIVFBuild(resource);
 }
 
-TEST_CASE("(Daily) IVF Build", "[ft][ivf][daily]") {
+TEST_CASE("(Daily) IVF Build", "[ft][build][ivf][daily]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(false);
     TestIVFBuild(resource);
@@ -667,13 +667,13 @@ TestIVFSearchOvertime(const fixtures::IVFResourcePtr& resource) {
     }
 }
 
-TEST_CASE("(PR) IVF Search Overtime", "[ft][ivf][pr]") {
+TEST_CASE("(PR) IVF Search Overtime", "[ft][search][ivf][pr]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(true);
     TestIVFSearchOvertime(resource);
 }
 
-TEST_CASE("(Daily) IVF Search Overtime", "[ft][ivf][daily]") {
+TEST_CASE("(Daily) IVF Search Overtime", "[ft][search][ivf][daily]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(false);
     TestIVFSearchOvertime(resource);
@@ -720,13 +720,13 @@ TestIVFBuildWithLargeK(const fixtures::IVFResourcePtr& resource) {
     }
 }
 
-TEST_CASE("(PR) IVF Build With Large K", "[ft][ivf][pr]") {
+TEST_CASE("(PR) IVF Build With Large K", "[ft][build][ivf][pr]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(true);
     TestIVFBuildWithLargeK(resource);
 }
 
-TEST_CASE("(Daily) IVF Build With Large K", "[ft][ivf][daily]") {
+TEST_CASE("(Daily) IVF Build With Large K", "[ft][build][ivf][daily]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(false);
     TestIVFBuildWithLargeK(resource);
@@ -773,13 +773,13 @@ TestIVFMarkRemove(const fixtures::IVFResourcePtr& resource) {
     }
 }
 
-TEST_CASE("(PR) IVF Mark Remove", "[ft][ivf][pr]") {
+TEST_CASE("(PR) IVF Mark Remove", "[ft][remove][ivf][pr]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(true);
     TestIVFMarkRemove(resource);
 }
 
-TEST_CASE("(Daily) IVF Mark Remove", "[ft][ivf][daily]") {
+TEST_CASE("(Daily) IVF Mark Remove", "[ft][remove][ivf][daily]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(false);
     TestIVFMarkRemove(resource);
@@ -849,13 +849,13 @@ TestIVFWithAttr(const fixtures::IVFResourcePtr& resource) {
     }
 }
 
-TEST_CASE("(PR) IVF Build With Attribute", "[ft][ivf][pr]") {
+TEST_CASE("(PR) IVF Build With Attribute", "[ft][filter_search][ivf][build][pr]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(true);
     TestIVFWithAttr(resource);
 }
 
-TEST_CASE("(Daily) IVF Build With Attribute", "[ft][ivf][daily]") {
+TEST_CASE("(Daily) IVF Build With Attribute", "[ft][filter_search][ivf][build][daily]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(false);
     TestIVFWithAttr(resource);
@@ -902,13 +902,13 @@ TestIVFExportModel(const fixtures::IVFResourcePtr& resource) {
     }
 }
 
-TEST_CASE("(PR) IVF Export Model", "[ft][ivf][pr]") {
+TEST_CASE("(PR) IVF Export Model", "[ft][export][ivf][pr]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(true);
     TestIVFExportModel(resource);
 }
 
-TEST_CASE("(Daily) IVF IVF Export Model", "[ft][ivf][daily]") {
+TEST_CASE("(Daily) IVF IVF Export Model", "[ft][export][ivf][daily]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(false);
     TestIVFExportModel(resource);
@@ -954,13 +954,13 @@ TestIVFAdd(const fixtures::IVFResourcePtr& resource) {
     }
 }
 
-TEST_CASE("(PR) IVF Add", "[ft][ivf][pr]") {
+TEST_CASE("(PR) IVF Add", "[ft][build][ivf][pr]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(true);
     TestIVFAdd(resource);
 }
 
-TEST_CASE("(Daily) IVF Add", "[ft][ivf][daily]") {
+TEST_CASE("(Daily) IVF Add", "[ft][build][ivf][daily]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(false);
     TestIVFAdd(resource);
@@ -1012,13 +1012,13 @@ TestIVFMerge(const fixtures::IVFResourcePtr& resource) {
     }
 }
 
-TEST_CASE("(PR) IVF Merge", "[ft][ivf][pr]") {
+TEST_CASE("(PR) IVF Merge", "[ft][merge][ivf][pr]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(true);
     TestIVFMerge(resource);
 }
 
-TEST_CASE("(Daily) IVF Merge", "[ft][ivf][daily]") {
+TEST_CASE("(Daily) IVF Merge", "[ft][merge][ivf][daily]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(false);
     TestIVFMerge(resource);
@@ -1070,13 +1070,13 @@ TestIVFConcurrentAdd(const fixtures::IVFResourcePtr& resource) {
     }
 }
 
-TEST_CASE("(PR) IVF Concurrent Add", "[ft][ivf][pr]") {
+TEST_CASE("(PR) IVF Concurrent Add", "[ft][build][concurrent][ivf][pr]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(true);
     TestIVFConcurrentAdd(resource);
 }
 
-TEST_CASE("(Daily) IVF Concurrent Add", "[ft][ivf][daily]") {
+TEST_CASE("(Daily) IVF Concurrent Add", "[ft][build][concurrent][ivf][daily]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(false);
     TestIVFConcurrentAdd(resource);
@@ -1149,13 +1149,13 @@ TestIVFSerialize(const fixtures::IVFResourcePtr& resource) {
     }
 }
 
-TEST_CASE("(PR) IVF Serialize File", "[ft][ivf][serialization][pr]") {
+TEST_CASE("(PR) IVF Serialize File", "[ft][serialize][ivf][pr]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(true);
     TestIVFSerialize(resource);
 }
 
-TEST_CASE("(Daily) IVF Serialize File", "[ft][ivf][serialization][daily]") {
+TEST_CASE("(Daily) IVF Serialize File", "[ft][serialize][ivf][daily]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(false);
     TestIVFSerialize(resource);
@@ -1200,13 +1200,13 @@ TestIVFClone(const fixtures::IVFResourcePtr& resource) {
     }
 }
 
-TEST_CASE("(PR) IVF Clone", "[ft][ivf][pr]") {
+TEST_CASE("(PR) IVF Clone", "[ft][clone][ivf][pr]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(true);
     TestIVFClone(resource);
 }
 
-TEST_CASE("(Daily) IVF Clone", "[ft][ivf][daily]") {
+TEST_CASE("(Daily) IVF Clone", "[ft][clone][ivf][daily]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(false);
     TestIVFClone(resource);
@@ -1254,13 +1254,15 @@ TestIVFRandomAllocator(const fixtures::IVFResourcePtr& resource) {
     }
 }
 
-TEST_CASE("(PR) IVF Build & ContinueAdd Test With Random Allocator", "[ft][ivf][pr]") {
+TEST_CASE("(PR) IVF Build & ContinueAdd Test With Random Allocator",
+          "[ft][build][concurrent][ivf][pr]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(true);
     TestIVFRandomAllocator(resource);
 }
 
-TEST_CASE("(Daily) IVF Build & ContinueAdd Test With Random Allocator", "[ft][ivf][daily]") {
+TEST_CASE("(Daily) IVF Build & ContinueAdd Test With Random Allocator",
+          "[ft][build][concurrent][ivf][daily]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(false);
     TestIVFRandomAllocator(resource);
@@ -1305,13 +1307,13 @@ TestIVFEstimateMemoryAndGetMemoryUsage(const fixtures::IVFResourcePtr& resource)
     }
 }
 
-TEST_CASE("(PR) IVF Estimate Memory And Get Memory Usage", "[ft][ivf][pr]") {
+TEST_CASE("(PR) IVF Estimate Memory And Get Memory Usage", "[ft][memory][ivf][pr]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(true);
     TestIVFEstimateMemoryAndGetMemoryUsage(resource);
 }
 
-TEST_CASE("(Daily) IVF Estimate Memory", "[ft][ivf][daily]") {
+TEST_CASE("(Daily) IVF Estimate Memory", "[ft][memory][ivf][daily]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(false);
     TestIVFEstimateMemoryAndGetMemoryUsage(resource);
@@ -1360,13 +1362,13 @@ TestIVFBuildMultiBucketsPerData(const fixtures::IVFResourcePtr& resource) {
     }
 }
 
-TEST_CASE("(PR) IVF Build Multi Buckets Per Data", "[ft][ivf][pr]") {
+TEST_CASE("(PR) IVF Build Multi Buckets Per Data", "[ft][build][ivf][pr]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(true);
     TestIVFBuildMultiBucketsPerData(resource);
 }
 
-TEST_CASE("(Daily) IVF Build Multi Buckets Per Data", "[ft][ivf][daily]") {
+TEST_CASE("(Daily) IVF Build Multi Buckets Per Data", "[ft][build][ivf][daily]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(false);
     TestIVFBuildMultiBucketsPerData(resource);
@@ -1412,13 +1414,13 @@ TestIVFGNOIMIBuild(const fixtures::IVFResourcePtr& resource) {
     }
 }
 
-TEST_CASE("(PR) IVF GNO-IMI Build", "[ft][ivf][pr]") {
+TEST_CASE("(PR) IVF GNO-IMI Build", "[ft][build][ivf][pr]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(true);
     TestIVFGNOIMIBuild(resource);
 }
 
-TEST_CASE("(Daily) IVF GNO-IMI Build", "[ft][ivf][daily]") {
+TEST_CASE("(Daily) IVF GNO-IMI Build", "[ft][build][ivf][daily]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(false);
     TestIVFGNOIMIBuild(resource);
@@ -1471,13 +1473,13 @@ TestIVFGNOIMIBuildWithResidual(const fixtures::IVFResourcePtr& resource) {
     }
 }
 
-TEST_CASE("(PR) IVF GNO-IMI Build with Residual", "[ft][ivf][pr]") {
+TEST_CASE("(PR) IVF GNO-IMI Build with Residual", "[ft][build][ivf][pr]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(true);
     TestIVFGNOIMIBuildWithResidual(resource);
 }
 
-TEST_CASE("(Daily) IVF GNO-IMI Build with Residual", "[ft][ivf][daily]") {
+TEST_CASE("(Daily) IVF GNO-IMI Build with Residual", "[ft][build][ivf][daily]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(false);
     TestIVFGNOIMIBuildWithResidual(resource);

--- a/tests/test_pyramid.cpp
+++ b/tests/test_pyramid.cpp
@@ -174,7 +174,7 @@ RequireDistancesNearZero(const vsag::DatasetPtr& result, const std::set<int64_t>
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
                              "Pyramid Build & ContinueAdd Test",
-                             "[ft][pyramid]") {
+                             "[ft][build][pyramid]") {
     auto metric_type = GENERATE("l2", "ip", "cosine");
     auto use_reorder = GENERATE(true, false);
     auto immutable = GENERATE(true, false);
@@ -211,7 +211,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
                              "Pyramid Duplicate Path Semantics Same Path",
-                             "[ft][pyramid]") {
+                             "[ft][build][pyramid]") {
     PyramidParam pyramid_param;
     pyramid_param.no_build_levels = {0, 1, 2};
     pyramid_param.support_duplicate = true;
@@ -240,7 +240,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
                              "Pyramid Duplicate Path Semantics Prefix Descendant",
-                             "[ft][pyramid]") {
+                             "[ft][build][pyramid]") {
     PyramidParam pyramid_param;
     pyramid_param.no_build_levels = {0, 1, 2};
     pyramid_param.support_duplicate = true;
@@ -279,7 +279,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
                              "Pyramid Duplicate Path Semantics Shared Prefix Visibility",
-                             "[ft][pyramid]") {
+                             "[ft][build][pyramid]") {
     PyramidParam pyramid_param;
     pyramid_param.no_build_levels = {0, 1, 2};
     pyramid_param.support_duplicate = true;
@@ -324,7 +324,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
                              "Pyramid Duplicate Path Semantics Negative Control",
-                             "[ft][pyramid]") {
+                             "[ft][build][pyramid]") {
     PyramidParam pyramid_param;
     pyramid_param.no_build_levels = {0, 1, 2};
     pyramid_param.support_duplicate = true;
@@ -351,7 +351,9 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
     REQUIRE(ids_a.count(402) == 0);
 }
 
-TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex, "Pyramid Add Test", "[ft][pyramid]") {
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
+                             "Pyramid Add Test",
+                             "[ft][build][pyramid]") {
     auto metric_type = GENERATE("l2");
     std::string base_quantization_str = GENERATE("fp32");
     PyramidParam pyramid_param;
@@ -374,7 +376,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex, "Pyramid Add Test", "[f
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
                              "Pyramid Multi-Levels Test",
-                             "[ft][pyramid]") {
+                             "[ft][build][pyramid]") {
     auto metric_type = GENERATE("l2");
     std::string base_quantization_str = GENERATE("fp32");
     const std::string name = "pyramid";
@@ -400,7 +402,9 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
     }
 }
 
-TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex, "Pyramid No Path Test", "[ft][pyramid]") {
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
+                             "Pyramid No Path Test",
+                             "[ft][build][pyramid]") {
     auto metric_type = GENERATE("l2");
     std::string base_quantization_str = GENERATE("fp32");
     const std::string name = "pyramid";
@@ -432,7 +436,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex, "Pyramid No Path Test",
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
                              "Pyramid Serialize File",
-                             "[ft][pyramid][serialization]") {
+                             "[ft][pyramid][serialization][serialize]") {
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
     auto metric_type = GENERATE("l2");
@@ -476,7 +480,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
     vsag::Options::Instance().set_block_size_limit(origin_size);
 }
 
-TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex, "Pyramid Clone", "[ft][pyramid]") {
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex, "Pyramid Clone", "[ft][clone][pyramid]") {
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
     auto metric_type = GENERATE("l2");
@@ -498,7 +502,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex, "Pyramid Clone", "[ft][
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
                              "Pyramid Build Test With Random Allocator",
-                             "[ft][pyramid]") {
+                             "[ft][build][pyramid]") {
     auto allocator = std::make_shared<fixtures::RandomAllocator>();
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
@@ -521,7 +525,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
 }
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
                              "Pyramid Concurrent Test",
-                             "[ft][pyramid][concurrent]") {
+                             "[ft][concurrent][pyramid][build]") {
     auto metric_type = GENERATE("l2");
     PyramidParam pyramid_param;
     pyramid_param.no_build_levels = {0, 1};
@@ -543,7 +547,9 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
     }
 }
 
-TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex, "Pyramid OverTime Test", "[ft][pyramid]") {
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
+                             "Pyramid OverTime Test",
+                             "[ft][search][pyramid]") {
     auto metric_type = GENERATE("l2");
     PyramidParam pyramid_param;
     pyramid_param.no_build_levels = {0, 1};
@@ -577,7 +583,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex, "Pyramid OverTime Test"
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
                              "Pyramid Duplicate Test",
-                             "[ft][pyramid][concurrent]") {
+                             "[ft][concurrent][pyramid][build][duplicate]") {
     using namespace fixtures;
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto metric_type = GENERATE("l2", "cosine");
@@ -626,7 +632,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
                              "Pyramid Duplicate ID Test",
-                             "[ft][pyramid]") {
+                             "[ft][build][pyramid][duplicate]") {
     auto metric_type = GENERATE("l2");
     PyramidParam pyramid_param;
     pyramid_param.no_build_levels = {0, 1};
@@ -642,7 +648,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
                              "Pyramid Analyzer Test",
-                             "[ft][pyramid][analyzer]") {
+                             "[ft][pyramid][analyzer][build]") {
     auto metric_type = GENERATE("l2");
     PyramidParam pyramid_param;
     pyramid_param.no_build_levels = {0, 1, 2};

--- a/tests/test_sindi.cpp
+++ b/tests/test_sindi.cpp
@@ -93,7 +93,7 @@ TestDatasetPool SINDITestIndex::pool{};
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex,
                              "Invalid Build and Search Parameter",
-                             "[ft][sindi]") {
+                             "[ft][build][search][sindi]") {
     SECTION("invalid doc_prune_ratio") {
         fixtures::SINDIParam param;
         param.doc_prune_ratio = 0.99;
@@ -178,7 +178,9 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex,
     REQUIRE_FALSE(search_result.has_value());
 }
 
-TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex, "SINDI Build and Search", "[ft][sindi]") {
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex,
+                             "SINDI Build and Search",
+                             "[ft][build][search][sindi]") {
     fixtures::SINDIParam param;
     param.use_reorder = GENERATE(true, false);
     auto build_param = fixtures::SINDITestIndex::GenerateBuildParameter(param);
@@ -202,7 +204,9 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex, "SINDI Build and Search",
     TestIndexStatus(index);
 }
 
-TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex, "SINDI Concurrent", "[ft][sindi]") {
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex,
+                             "SINDI Concurrent",
+                             "[ft][concurrent][sindi]") {
     fixtures::SINDIParam param;
     param.use_reorder = GENERATE(true, false);
     auto build_param = fixtures::SINDITestIndex::GenerateBuildParameter(param);
@@ -212,7 +216,9 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex, "SINDI Concurrent", "[ft]
     TestConcurrentAddSearch(index, dataset, search_param, 0.99, true);
 }
 
-TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex, "SINDI Serialize File", "[ft][sindi]") {
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex,
+                             "SINDI Serialize File",
+                             "[ft][serialize][sindi]") {
     fixtures::SINDIParam param;
     param.deserialize_without_footer = GENERATE(true, false);
     param.deserialize_without_buffer = true;
@@ -251,7 +257,9 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex, "SINDI Serialize File", "
     vsag::Options::Instance().set_block_size_limit(origin_size);
 }
 
-TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex, "Sindi Duplicate ID Test", "[ft][sindi]") {
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex,
+                             "Sindi Duplicate ID Test",
+                             "[ft][build][duplicate][sindi]") {
     fixtures::SINDIParam param;
     param.use_reorder = GENERATE(true, false);
     auto build_param = fixtures::SINDITestIndex::GenerateBuildParameter(param);

--- a/tests/test_sparse_index.cpp
+++ b/tests/test_sparse_index.cpp
@@ -46,7 +46,7 @@ TestDatasetPool SparseTestIndex::pool{};
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::SparseTestIndex,
                              "SparseIndex Build and Search",
-                             "[ft][sparse_index]") {
+                             "[ft][build][search][sparse_index]") {
     auto index = TestFactory("sparse_index", build_param, true);
     auto dataset = pool.GetSparseDatasetAndCreate(base_count, 128, 0.8);
     REQUIRE(index->GetIndexType() == vsag::IndexType::SPARSE);
@@ -62,7 +62,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::SparseTestIndex,
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::SparseTestIndex,
                              "Sparse Index Serialize File",
-                             "[ft][sparse_index]") {
+                             "[ft][serialize][sparse_index]") {
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
     auto metric_type = GENERATE("l2");


### PR DESCRIPTION
## Summary

- Fix `[BruteForce]` tag casing to `[bruteforce]` for consistency
- Remove generic `[index]` tag that does not provide useful filtering
- Add feature tags to all functest cases: `[build]`, `[search]`, `[serialize]`, `[clone]`, `[merge]`, `[remove]`, `[update]`, `[distance]`, `[duplicate]`, `[filter_search]`, `[memory]`, `[factory]`, `[export]`, `[concurrent]`, `[io]`, `[feedback]`, `[immutable]`
- Rename `[serialization]` tag to `[serialize]` for consistency
- Standardize tag ordering: `[ft][feature][index_type][level]`

## Impact

- 9 test files modified, 193 lines changed (plus 1 fixture file formatting fix)
- Enables precise test filtering by feature (e.g., `[pr][serialize]`, `[daily][build][hgraph]`)
- Lays foundation for future test refactoring (Phase 1-4 of functest-refactor-plan.md)
