### PR TITLE
chore: make fmt and lint compatible with macOS (Homebrew llvm@15)

### DIFF
--- a/scripts/format/format-cpp.sh
+++ b/scripts/format/format-cpp.sh
@@ -5,15 +5,35 @@
 
 REQUIRED_VERSION="15"
 
-# Check if clang-format-15 is available
-if ! command -v clang-format-15 &> /dev/null; then
-    echo "ERROR: clang-format-15 is not installed!"
-    echo "Please install it with: sudo apt-get install clang-format-15"
+# Find clang-format-15 binary: check the suffixed name first, then use
+# 'brew --prefix' for dynamic resolution on macOS, and finally fall back
+# to stable Homebrew opt symlinks.
+CLANG_FORMAT=""
+if command -v clang-format-15 &> /dev/null; then
+    CLANG_FORMAT="clang-format-15"
+elif command -v brew &> /dev/null; then
+    BREW_LLVM_PREFIX=$(brew --prefix llvm@15 2>/dev/null || true)
+    if [ -n "$BREW_LLVM_PREFIX" ] && [ -x "$BREW_LLVM_PREFIX/bin/clang-format" ]; then
+        CLANG_FORMAT="$BREW_LLVM_PREFIX/bin/clang-format"
+    fi
+fi
+if [ -z "$CLANG_FORMAT" ] && [ -x "/opt/homebrew/opt/llvm@15/bin/clang-format" ]; then
+    CLANG_FORMAT="/opt/homebrew/opt/llvm@15/bin/clang-format"
+elif [ -z "$CLANG_FORMAT" ] && [ -x "/usr/local/opt/llvm@15/bin/clang-format" ]; then
+    CLANG_FORMAT="/usr/local/opt/llvm@15/bin/clang-format"
+elif [ -z "$CLANG_FORMAT" ] && command -v clang-format &> /dev/null; then
+    CLANG_FORMAT="clang-format"
+fi
+
+if [ -z "$CLANG_FORMAT" ]; then
+    echo "ERROR: clang-format (version 15) is not installed!"
+    echo "  Linux:  sudo apt-get install clang-format-15"
+    echo "  macOS:  brew install llvm@15"
     exit 1
 fi
 
-# Verify we're using the correct version
-ACTUAL_VERSION=$(clang-format-15 --version | grep -oP 'version \K[0-9]+' | head -1)
+# Verify we're using the correct version (portable - no grep -P)
+ACTUAL_VERSION=$("$CLANG_FORMAT" --version | sed -n 's/.*version \([0-9]*\).*/\1/p' | head -1)
 if [ "$ACTUAL_VERSION" != "$REQUIRED_VERSION" ]; then
     echo "ERROR: clang-format version mismatch!"
     echo "Required: version $REQUIRED_VERSION"
@@ -23,13 +43,13 @@ fi
 
 echo "Using clang-format version $ACTUAL_VERSION (required: $REQUIRED_VERSION)"
 
-# Format code using clang-format-15
-find include/ -iname "*.h" -o -iname "*.cpp" | xargs clang-format-15 -i
-find src/ -iname "*.h" -o -iname "*.cpp" | xargs clang-format-15 -i
-find python_bindings/ -iname "*.h" -o -iname "*.cpp" | xargs clang-format-15 -i
-find examples/cpp/ -iname "*.h" -o -iname "*.cpp" | xargs clang-format-15 -i
-find mockimpl/ -iname "*.h" -o -iname "*.cpp" | xargs clang-format-15 -i
-find tests/ -iname "*.h" -o -iname "*.cpp" | xargs clang-format-15 -i
-find tools/ -iname "*.h" -o -iname "*.cpp" | xargs clang-format-15 -i
+# Format code using the resolved clang-format binary.
+find include/ -iname "*.h" -o -iname "*.cpp" | xargs "$CLANG_FORMAT" -i
+find src/ -iname "*.h" -o -iname "*.cpp" | xargs "$CLANG_FORMAT" -i
+find python_bindings/ -iname "*.h" -o -iname "*.cpp" | xargs "$CLANG_FORMAT" -i
+find examples/cpp/ -iname "*.h" -o -iname "*.cpp" | xargs "$CLANG_FORMAT" -i
+find mockimpl/ -iname "*.h" -o -iname "*.cpp" | xargs "$CLANG_FORMAT" -i
+find tests/ -iname "*.h" -o -iname "*.cpp" | xargs "$CLANG_FORMAT" -i
+find tools/ -iname "*.h" -o -iname "*.cpp" | xargs "$CLANG_FORMAT" -i
 
-echo "Code formatting completed with clang-format-15"
+echo "Code formatting completed with $CLANG_FORMAT"

--- a/scripts/linters/run-clang-tidy-15.sh
+++ b/scripts/linters/run-clang-tidy-15.sh
@@ -7,13 +7,36 @@ set -euo pipefail
 
 REQUIRED_VERSION="15"
 
-if ! command -v clang-tidy-15 &> /dev/null; then
-    echo "ERROR: clang-tidy-15 is not installed!"
-    echo "Please install it with: sudo apt-get install clang-tidy-15"
+# Find clang-tidy-15 binary: check the suffixed name first, then use
+# 'brew --prefix' for dynamic resolution on macOS, and finally fall back
+# to stable Homebrew opt symlinks.
+CLANG_TIDY=""
+CLANG_APPLY=""
+if command -v clang-tidy-15 &> /dev/null; then
+    CLANG_TIDY="clang-tidy-15"
+elif command -v brew &> /dev/null; then
+    BREW_LLVM_PREFIX=$(brew --prefix llvm@15 2>/dev/null || true)
+    if [ -n "$BREW_LLVM_PREFIX" ] && [ -x "$BREW_LLVM_PREFIX/bin/clang-tidy" ]; then
+        CLANG_TIDY="$BREW_LLVM_PREFIX/bin/clang-tidy"
+    fi
+fi
+if [ -z "$CLANG_TIDY" ] && [ -x "/opt/homebrew/opt/llvm@15/bin/clang-tidy" ]; then
+    CLANG_TIDY="/opt/homebrew/opt/llvm@15/bin/clang-tidy"
+elif [ -z "$CLANG_TIDY" ] && [ -x "/usr/local/opt/llvm@15/bin/clang-tidy" ]; then
+    CLANG_TIDY="/usr/local/opt/llvm@15/bin/clang-tidy"
+elif [ -z "$CLANG_TIDY" ] && command -v clang-tidy &> /dev/null; then
+    CLANG_TIDY="clang-tidy"
+fi
+
+if [ -z "$CLANG_TIDY" ]; then
+    echo "ERROR: clang-tidy (version 15) is not installed!"
+    echo "  Linux:  sudo apt-get install clang-tidy-15"
+    echo "  macOS:  brew install llvm@15"
     exit 1
 fi
 
-ACTUAL_VERSION=$(clang-tidy-15 --version | grep -oP 'version \K[0-9]+' | head -1)
+# Verify we're using the correct version (portable - no grep -P)
+ACTUAL_VERSION=$("$CLANG_TIDY" --version | sed -n 's/.*version \([0-9]*\).*/\1/p' | head -1)
 if [ "$ACTUAL_VERSION" != "$REQUIRED_VERSION" ]; then
     echo "ERROR: clang-tidy version mismatch!"
     echo "Required: version $REQUIRED_VERSION"
@@ -24,16 +47,34 @@ fi
 echo "Using clang-tidy version $ACTUAL_VERSION (required: $REQUIRED_VERSION)"
 
 if printf '%s\n' "$@" | grep -qx -- '-fix'; then
-    if ! command -v clang-apply-replacements-15 &> /dev/null; then
-        echo "ERROR: clang-apply-replacements-15 is not installed!"
-        echo "Please install it with: sudo apt-get install clang-tools-15"
+    # Find clang-apply-replacements-15 binary
+    if command -v clang-apply-replacements-15 &> /dev/null; then
+        CLANG_APPLY="clang-apply-replacements-15"
+    elif command -v brew &> /dev/null; then
+        BREW_LLVM_PREFIX=$(brew --prefix llvm@15 2>/dev/null || true)
+        if [ -n "$BREW_LLVM_PREFIX" ] && [ -x "$BREW_LLVM_PREFIX/bin/clang-apply-replacements" ]; then
+            CLANG_APPLY="$BREW_LLVM_PREFIX/bin/clang-apply-replacements"
+        fi
+    fi
+    if [ -z "$CLANG_APPLY" ] && [ -x "/opt/homebrew/opt/llvm@15/bin/clang-apply-replacements" ]; then
+        CLANG_APPLY="/opt/homebrew/opt/llvm@15/bin/clang-apply-replacements"
+    elif [ -z "$CLANG_APPLY" ] && [ -x "/usr/local/opt/llvm@15/bin/clang-apply-replacements" ]; then
+        CLANG_APPLY="/usr/local/opt/llvm@15/bin/clang-apply-replacements"
+    elif [ -z "$CLANG_APPLY" ] && command -v clang-apply-replacements &> /dev/null; then
+        CLANG_APPLY="clang-apply-replacements"
+    fi
+
+    if [ -z "$CLANG_APPLY" ]; then
+        echo "ERROR: clang-apply-replacements (version 15) is not installed!"
+        echo "  Linux:  sudo apt-get install clang-tools-15"
+        echo "  macOS:  brew install llvm@15"
         exit 1
     fi
 
     exec ./scripts/linters/run-clang-tidy.py \
-        -clang-tidy-binary clang-tidy-15 \
-        -clang-apply-replacements-binary clang-apply-replacements-15 \
+        -clang-tidy-binary "$CLANG_TIDY" \
+        -clang-apply-replacements-binary "$CLANG_APPLY" \
         "$@"
 fi
 
-exec ./scripts/linters/run-clang-tidy.py -clang-tidy-binary clang-tidy-15 "$@"
+exec ./scripts/linters/run-clang-tidy.py -clang-tidy-binary "$CLANG_TIDY" "$@"

--- a/src/impl/label_table.h
+++ b/src/impl/label_table.h
@@ -277,7 +277,7 @@ public:
         if (deleted_ids_.empty()) {
             return {};
         }
-        auto size = std::min(static_cast<uint64_t>(max_count), deleted_ids_.size());
+        auto size = std::min<uint64_t>(static_cast<uint64_t>(max_count), deleted_ids_.size());
         return std::vector<InnerIdType>(deleted_ids_.begin(),
                                         std::next(deleted_ids_.begin(), size));
     }


### PR DESCRIPTION
## What

Fix `make fmt` and `make lint` failures on macOS caused by three separate issues.

Closes #1905

## Why

### 1. Toolchain binary naming
Homebrew `llvm@15` installs binaries **without** a version suffix (`clang-format`, not `clang-format-15`). The scripts only looked for the suffixed names (Linux `apt` convention), causing immediate `command not found` errors on macOS.

### 2. `grep -oP` incompatibility
Both scripts used `grep -oP` (Perl-compatible regex) for version extraction. macOS ships BSD grep which does not support `-P`.

### 3. `std::min` type deduction failure on macOS ARM
On Apple Silicon, `uint64_t` resolves to `unsigned long long` while container `size_type` is `unsigned long`. `std::min` cannot deduce a common type, producing a `clang-diagnostic-error` in `label_table.h`.

## How

| File | Change |
|------|--------|
| `scripts/format/format-cpp.sh` | Add Homebrew fallback paths for Apple Silicon (`/opt/homebrew`) and Intel (`/usr/local/opt`); replace `grep -oP` with portable `sed` |
| `scripts/linters/run-clang-tidy-15.sh` | Same fixes for `clang-tidy` and `clang-apply-replacements` |
| `src/impl/label_table.h` | `std::min` → `std::min<uint64_t>` (explicit template arg, consistent with all other call sites) |

## Test

Verified `make fmt` and `make lint` pass on macOS 14 (Apple Silicon, Homebrew llvm@15).