### PR TITLE
docs(landing): add copy buttons, refine indexes table, update ecosystem

### DIFF
--- a/docs/landing/index.html
+++ b/docs/landing/index.html
@@ -6,12 +6,12 @@
     <title>VSAG — High-performance vector indexing library</title>
     <meta
       name="description"
-      content="VSAG is a high-performance C++ vector indexing library for similarity search, with Python bindings (pyvsag) and ready-to-use indexes such as HGraph, HNSW, DiskANN, IVF, Pyramid and SINDI."
+      content="VSAG is a high-performance C++ vector indexing library for similarity search, with Python bindings (pyvsag) and ready-to-use indexes such as HGraph, IVF, SINDI, Pyramid and brute force."
     />
     <meta property="og:title" content="VSAG — High-performance vector indexing library" />
     <meta
       property="og:description"
-      content="High-performance C++ library for approximate nearest neighbor search. HGraph, HNSW, DiskANN, IVF, Pyramid, SINDI."
+      content="High-performance C++ library for approximate nearest neighbor search. HGraph, IVF, SINDI, Pyramid, brute force."
     />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://vsag.io/" />
@@ -71,7 +71,7 @@
           </h1>
           <p class="lede">
             VSAG is a C++ library for approximate nearest-neighbor search. It
-            ships production-ready HGraph, HNSW, DiskANN, IVF, Pyramid and SINDI
+            ships production-ready HGraph, IVF, SINDI, Pyramid and brute-force
             indexes with SIMD-accelerated distance kernels, quantization, and a
             unified builder API — with first-class Python bindings via
             <code>pyvsag</code>.
@@ -142,8 +142,9 @@
               </div>
               <h3>A family of indexes</h3>
               <p>
-                HGraph, HNSW, DiskANN, IVF, Pyramid, SINDI and brute force — one
-                builder-style API, one serialization format, one set of ops.
+                HGraph, IVF, SINDI, Pyramid and brute force — one builder-style
+                API, one serialization format, one set of ops. Legacy HNSW and
+                DiskANN remain available.
               </p>
             </article>
             <article class="card">
@@ -236,8 +237,13 @@
           <div class="qs-grid">
             <div class="qs-panel">
               <h3>Python (pyvsag)</h3>
-              <pre><code><span class="c">pip install pyvsag</span></code></pre>
-              <pre><code><span class="k">import</span> pyvsag, numpy <span class="k">as</span> np
+              <div class="code-block">
+                <button class="copy-btn" type="button" aria-label="Copy code">Copy</button>
+                <pre><code><span class="c">pip install numpy pyvsag</span></code></pre>
+              </div>
+              <div class="code-block">
+                <button class="copy-btn" type="button" aria-label="Copy code">Copy</button>
+                <pre><code><span class="k">import</span> pyvsag, numpy <span class="k">as</span> np
 
 index = pyvsag.Index(<span class="s">"hgraph"</span>, <span class="s">"""</span>
 <span class="s">{</span>
@@ -252,12 +258,18 @@ vecs = np.random.rand(10000, 128).astype(<span class="s">"float32"</span>)
 index.build(vectors=vecs, ids=ids, num_elements=10000, dim=128)
 
 q = np.random.rand(128).astype(<span class="s">"float32"</span>)
-I, D = index.knn_search(vector=q, k=10, parameters=<span class="s">'{"hgraph":{"ef_search":100}}'</span>)</code></pre>
+I, D = index.knn_search(vector=q, k=10, parameters=<span class="s">'{"hgraph":{"ef_search":100}}'</span>)
+<span class="k">print</span>(<span class="s">"ids:"</span>, I)
+<span class="k">print</span>(<span class="s">"distances:"</span>, D)</code></pre>
+              </div>
             </div>
             <div class="qs-panel">
               <h3>C++</h3>
-              <pre><code><span class="c">// link against libvsag, C++17</span>
+              <div class="code-block">
+                <button class="copy-btn" type="button" aria-label="Copy code">Copy</button>
+                <pre><code><span class="c">// link against libvsag, C++17</span>
 <span class="pp">#include</span> <span class="s">&lt;vsag/vsag.h&gt;</span>
+<span class="pp">#include</span> <span class="s">&lt;iostream&gt;</span>
 
 <span class="k">auto</span> result = vsag::Factory::CreateIndex(<span class="s">"hgraph"</span>, R<span class="s">"({
   "dtype": "float32", "metric_type": "l2", "dim": 128,
@@ -271,7 +283,12 @@ index-&gt;Build(dataset);
 
 <span class="k">auto</span> q = vsag::Dataset::Make();
 q-&gt;Dim(128)-&gt;NumElements(1)-&gt;Float32Vectors(query)-&gt;Owner(<span class="k">false</span>);
-<span class="k">auto</span> r = index-&gt;KnnSearch(q, <span class="n">10</span>, R<span class="s">"({"hgraph":{"ef_search":100}})"</span>);</code></pre>
+<span class="k">auto</span> r = index-&gt;KnnSearch(q, <span class="n">10</span>, R<span class="s">"({"hgraph":{"ef_search":100}})"</span>);
+<span class="k">auto</span> res = r.value();
+<span class="k">for</span> (int64_t i = <span class="n">0</span>; i &lt; res-&gt;GetDim(); ++i) {
+  std::cout &lt;&lt; res-&gt;GetIds()[i] &lt;&lt; <span class="s">" "</span> &lt;&lt; res-&gt;GetDistances()[i] &lt;&lt; <span class="s">"\n"</span>;
+}</code></pre>
+              </div>
             </div>
           </div>
           <p class="qs-foot">
@@ -301,6 +318,13 @@ q-&gt;Dim(128)-&gt;NumElements(1)-&gt;Float32Vectors(query)-&gt;Owner(<span clas
               </thead>
               <tbody>
                 <tr>
+                  <th scope="row"><code>brute_force</code></th>
+                  <td>Exact ground-truth baseline, small datasets</td>
+                  <td>High</td>
+                  <td>Instant</td>
+                  <td>Slow</td>
+                </tr>
+                <tr>
                   <th scope="row"><code>hgraph</code></th>
                   <td>General-purpose, high recall, quantized graph</td>
                   <td>Medium</td>
@@ -308,30 +332,9 @@ q-&gt;Dim(128)-&gt;NumElements(1)-&gt;Float32Vectors(query)-&gt;Owner(<span clas
                   <td>Very fast</td>
                 </tr>
                 <tr>
-                  <th scope="row"><code>hnsw</code></th>
-                  <td>Classic hierarchical navigable small world</td>
-                  <td>High</td>
-                  <td>Medium</td>
-                  <td>Fast</td>
-                </tr>
-                <tr>
-                  <th scope="row"><code>diskann</code></th>
-                  <td>Billion-scale corpora on SSD</td>
-                  <td>Low (RAM)</td>
-                  <td>Medium</td>
-                  <td>Fast (I/O bound)</td>
-                </tr>
-                <tr>
                   <th scope="row"><code>ivf</code></th>
                   <td>High-throughput batch search, GPU-friendly training</td>
                   <td>Low–Medium</td>
-                  <td>Fast</td>
-                  <td>Fast</td>
-                </tr>
-                <tr>
-                  <th scope="row"><code>pyramid</code></th>
-                  <td>Multi-tenant / partitioned corpora</td>
-                  <td>Medium</td>
                   <td>Fast</td>
                   <td>Fast</td>
                 </tr>
@@ -343,11 +346,25 @@ q-&gt;Dim(128)-&gt;NumElements(1)-&gt;Float32Vectors(query)-&gt;Owner(<span clas
                   <td>Very fast</td>
                 </tr>
                 <tr>
-                  <th scope="row"><code>brute_force</code></th>
-                  <td>Exact ground-truth baseline, small datasets</td>
+                  <th scope="row"><code>pyramid</code></th>
+                  <td>Multi-tenant / partitioned corpora</td>
+                  <td>Medium</td>
+                  <td>Fast</td>
+                  <td>Fast</td>
+                </tr>
+                <tr class="deprecated">
+                  <th scope="row"><code>hnsw</code> <span class="badge-deprecated">Deprecated</span></th>
+                  <td>Classic hierarchical navigable small world</td>
                   <td>High</td>
-                  <td>Instant</td>
-                  <td>Slow</td>
+                  <td>Medium</td>
+                  <td>Fast</td>
+                </tr>
+                <tr class="deprecated">
+                  <th scope="row"><code>diskann</code> <span class="badge-deprecated">Deprecated</span></th>
+                  <td>Billion-scale corpora on SSD</td>
+                  <td>Low (RAM)</td>
+                  <td>Medium</td>
+                  <td>Fast (I/O bound)</td>
                 </tr>
               </tbody>
             </table>
@@ -363,9 +380,15 @@ q-&gt;Dim(128)-&gt;NumElements(1)-&gt;Float32Vectors(query)-&gt;Owner(<span clas
             <article class="card">
               <h3>Databases &amp; search engines</h3>
               <p>
-                VSAG powers vector search in production systems including
-                OceanBase, TuGraph and internal services at Ant Group.
+                VSAG powers vector search in production systems including:
               </p>
+              <ul class="users-list">
+                <li><a href="https://github.com/oceanbase/oceanbase">OceanBase</a></li>
+                <li><a href="https://github.com/TuGraph-family/tugraph-db">TuGraph</a></li>
+                <li><a href="https://github.com/GreptimeTeam/greptimedb">GreptimeDB</a></li>
+                <li><a href="https://www.alibabacloud.com/product/hologres">Hologres</a></li>
+                <li><a href="https://www.alibabacloud.com/product/polardb">PolarDB</a></li>
+              </ul>
             </article>
             <article class="card">
               <h3>Language bindings</h3>
@@ -459,5 +482,46 @@ q-&gt;Dim(128)-&gt;NumElements(1)-&gt;Float32Vectors(query)-&gt;Owner(<span clas
         <small>© VSAG contributors. Built with care at Ant Group and by the community.</small>
       </div>
     </footer>
+    <script>
+      (function () {
+        document.querySelectorAll('.code-block').forEach(function (block) {
+          var btn = block.querySelector('.copy-btn');
+          var code = block.querySelector('pre code');
+          if (!btn || !code) return;
+          btn.addEventListener('click', function () {
+            var text = code.innerText;
+            var done = function () {
+              var original = btn.textContent;
+              btn.textContent = 'Copied';
+              btn.classList.add('copied');
+              setTimeout(function () {
+                btn.textContent = original || 'Copy';
+                btn.classList.remove('copied');
+              }, 1600);
+            };
+            if (navigator.clipboard && navigator.clipboard.writeText) {
+              navigator.clipboard.writeText(text).then(done, function () {
+                fallback(text);
+                done();
+              });
+            } else {
+              fallback(text);
+              done();
+            }
+          });
+        });
+        function fallback(text) {
+          var ta = document.createElement('textarea');
+          ta.value = text;
+          ta.setAttribute('readonly', '');
+          ta.style.position = 'absolute';
+          ta.style.left = '-9999px';
+          document.body.appendChild(ta);
+          ta.select();
+          try { document.execCommand('copy'); } catch (e) {}
+          document.body.removeChild(ta);
+        }
+      })();
+    </script>
   </body>
 </html>

--- a/docs/landing/index.html
+++ b/docs/landing/index.html
@@ -6,12 +6,12 @@
     <title>VSAG — High-performance vector indexing library</title>
     <meta
       name="description"
-      content="VSAG is a high-performance C++ vector indexing library for similarity search, with Python bindings (pyvsag) and ready-to-use indexes such as HGraph, IVF, SINDI, Pyramid and brute force."
+      content="VSAG is a high-performance C++ vector indexing library for similarity search, with Python bindings (pyvsag) and ready-to-use indexes such as HGraph, IVF, SINDI, Pyramid and BruteForce."
     />
     <meta property="og:title" content="VSAG — High-performance vector indexing library" />
     <meta
       property="og:description"
-      content="High-performance C++ library for approximate nearest neighbor search. HGraph, IVF, SINDI, Pyramid, brute force."
+      content="High-performance C++ library for approximate nearest neighbor search. HGraph, IVF, SINDI, Pyramid, BruteForce."
     />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://vsag.io/" />
@@ -71,7 +71,7 @@
           </h1>
           <p class="lede">
             VSAG is a C++ library for approximate nearest-neighbor search. It
-            ships production-ready HGraph, IVF, SINDI, Pyramid and brute force
+            ships production-ready HGraph, IVF, SINDI, Pyramid and BruteForce
             indexes with SIMD-accelerated distance kernels, quantization, and a
             unified builder API — with first-class Python bindings via
             <code>pyvsag</code>.
@@ -142,7 +142,7 @@
               </div>
               <h3>A family of indexes</h3>
               <p>
-                HGraph, IVF, SINDI, Pyramid and brute force — one builder-style
+                HGraph, IVF, SINDI, Pyramid and BruteForce — one builder-style
                 API, one serialization format, one set of ops. Legacy HNSW and
                 DiskANN remain available.
               </p>

--- a/docs/landing/index.html
+++ b/docs/landing/index.html
@@ -71,7 +71,7 @@
           </h1>
           <p class="lede">
             VSAG is a C++ library for approximate nearest-neighbor search. It
-            ships production-ready HGraph, IVF, SINDI, Pyramid and brute-force
+            ships production-ready HGraph, IVF, SINDI, Pyramid and brute force
             indexes with SIMD-accelerated distance kernels, quantization, and a
             unified builder API — with first-class Python bindings via
             <code>pyvsag</code>.
@@ -284,6 +284,7 @@ index-&gt;Build(dataset);
 <span class="k">auto</span> q = vsag::Dataset::Make();
 q-&gt;Dim(128)-&gt;NumElements(1)-&gt;Float32Vectors(query)-&gt;Owner(<span class="k">false</span>);
 <span class="k">auto</span> r = index-&gt;KnnSearch(q, <span class="n">10</span>, R<span class="s">"({"hgraph":{"ef_search":100}})"</span>);
+<span class="k">if</span> (!r.has_value()) { std::cerr &lt;&lt; r.error().message &lt;&lt; <span class="s">"\n"</span>; <span class="k">return</span> <span class="n">1</span>; }
 <span class="k">auto</span> res = r.value();
 <span class="k">for</span> (int64_t i = <span class="n">0</span>; i &lt; res-&gt;GetDim(); ++i) {
   std::cout &lt;&lt; res-&gt;GetIds()[i] &lt;&lt; <span class="s">" "</span> &lt;&lt; res-&gt;GetDistances()[i] &lt;&lt; <span class="s">"\n"</span>;
@@ -482,44 +483,71 @@ q-&gt;Dim(128)-&gt;NumElements(1)-&gt;Float32Vectors(query)-&gt;Owner(<span clas
         <small>© VSAG contributors. Built with care at Ant Group and by the community.</small>
       </div>
     </footer>
+    <div id="copy-status" class="sr-only" role="status" aria-live="polite"></div>
     <script>
       (function () {
+        var status = document.getElementById('copy-status');
+        function announce(msg) {
+          if (!status) return;
+          // Toggle content to ensure AT picks up repeated announcements.
+          status.textContent = '';
+          setTimeout(function () { status.textContent = msg; }, 30);
+        }
         document.querySelectorAll('.code-block').forEach(function (block) {
           var btn = block.querySelector('.copy-btn');
           var code = block.querySelector('pre code');
           if (!btn || !code) return;
+          var original = btn.textContent || 'Copy';
+          var timer = null;
+          btn.setAttribute('data-label', original);
+          function reset() {
+            btn.textContent = original;
+            btn.classList.remove('copied', 'failed');
+            btn.setAttribute('aria-label', 'Copy code');
+          }
+          function flash(state, label, announcement) {
+            if (timer) { clearTimeout(timer); timer = null; }
+            btn.textContent = label;
+            btn.classList.remove('copied', 'failed');
+            btn.classList.add(state);
+            btn.setAttribute('aria-label', announcement);
+            announce(announcement);
+            timer = setTimeout(reset, 1600);
+          }
           btn.addEventListener('click', function () {
             var text = code.innerText;
-            var done = function () {
-              var original = btn.textContent;
-              btn.textContent = 'Copied';
-              btn.classList.add('copied');
-              setTimeout(function () {
-                btn.textContent = original || 'Copy';
-                btn.classList.remove('copied');
-              }, 1600);
-            };
             if (navigator.clipboard && navigator.clipboard.writeText) {
-              navigator.clipboard.writeText(text).then(done, function () {
-                fallback(text);
-                done();
-              });
+              navigator.clipboard.writeText(text).then(
+                function () { flash('copied', 'Copied', 'Code copied to clipboard'); },
+                function () {
+                  if (fallback(text)) {
+                    flash('copied', 'Copied', 'Code copied to clipboard');
+                  } else {
+                    flash('failed', 'Copy failed', 'Copy failed');
+                  }
+                }
+              );
             } else {
-              fallback(text);
-              done();
+              if (fallback(text)) {
+                flash('copied', 'Copied', 'Code copied to clipboard');
+              } else {
+                flash('failed', 'Copy failed', 'Copy failed');
+              }
             }
           });
         });
         function fallback(text) {
           var ta = document.createElement('textarea');
+          var copied = false;
           ta.value = text;
           ta.setAttribute('readonly', '');
           ta.style.position = 'absolute';
           ta.style.left = '-9999px';
           document.body.appendChild(ta);
           ta.select();
-          try { document.execCommand('copy'); } catch (e) {}
+          try { copied = document.execCommand('copy'); } catch (e) { copied = false; }
           document.body.removeChild(ta);
+          return copied;
         }
       })();
     </script>

--- a/docs/landing/style.css
+++ b/docs/landing/style.css
@@ -283,6 +283,35 @@ p  { margin: 0 0 1em; color: var(--fg-subtle); }
   background: transparent;
 }
 .qs-panel pre + pre { border-top: 1px dashed rgba(255, 244, 220, 0.08); }
+.qs-panel .code-block + .code-block { border-top: 1px dashed rgba(255, 244, 220, 0.08); }
+.qs-panel .code-block { position: relative; }
+.qs-panel .code-block pre { padding-right: 76px; }
+.copy-btn {
+  position: absolute; top: 10px; right: 10px;
+  font-family: var(--sans); font-size: 0.74rem; font-weight: 600;
+  letter-spacing: 0.06em; text-transform: uppercase;
+  color: #e9e4da;
+  background: rgba(255, 244, 220, 0.08);
+  border: 1px solid rgba(255, 244, 220, 0.18);
+  border-radius: 8px;
+  padding: 5px 10px;
+  cursor: pointer;
+  opacity: 0.7;
+  transition: opacity 0.15s ease, background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+.qs-panel .code-block:hover .copy-btn,
+.copy-btn:focus-visible { opacity: 1; }
+.copy-btn:hover {
+  background: rgba(244, 189, 55, 0.18);
+  border-color: rgba(244, 189, 55, 0.4);
+  color: var(--gold-100);
+}
+.copy-btn.copied {
+  background: rgba(244, 189, 55, 0.28);
+  border-color: rgba(244, 189, 55, 0.55);
+  color: var(--gold-100);
+  opacity: 1;
+}
 .qs-panel code { background: transparent; border: 0; padding: 0; color: inherit; font-size: inherit; }
 .qs-panel .k  { color: #f4bd37; }
 .qs-panel .s  { color: #fce897; }
@@ -306,6 +335,53 @@ p  { margin: 0 0 1em; color: var(--fg-subtle); }
   color: var(--fg-muted); background: var(--surface-alt);
 }
 .matrix tbody tr:last-child th, .matrix tbody tr:last-child td { border-bottom: 0; }
+.matrix tbody tr.deprecated th,
+.matrix tbody tr.deprecated td { color: var(--fg-muted); }
+.matrix tbody tr.deprecated th code {
+  background: var(--surface-alt);
+  border-color: var(--border);
+  color: var(--fg-muted);
+}
+.badge-deprecated {
+  display: inline-block; margin-left: 6px;
+  padding: 2px 8px; font-size: 0.68rem; font-weight: 600;
+  letter-spacing: 0.06em; text-transform: uppercase;
+  color: var(--fg-muted);
+  background: var(--surface-alt);
+  border: 1px solid var(--border-strong);
+  border-radius: 999px;
+  vertical-align: middle;
+}
+
+.users-list {
+  list-style: none; padding: 0; margin: 10px 0 0;
+  display: flex; flex-wrap: wrap; gap: 8px;
+}
+.users-list li {
+  font-size: 0.9rem;
+}
+.users-list a {
+  display: inline-block;
+  padding: 5px 12px;
+  color: var(--fg);
+  background: var(--surface-alt);
+  border: 1px solid var(--border-strong);
+  border-radius: 999px;
+  font-weight: 550;
+  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+.users-list a:hover {
+  text-decoration: none;
+  background: linear-gradient(135deg, rgba(252, 232, 151, 0.4), rgba(244, 189, 55, 0.15));
+  border-color: rgba(244, 189, 55, 0.45);
+  color: var(--gold-700);
+}
+@media (prefers-color-scheme: dark) {
+  .users-list a:hover {
+    background: linear-gradient(135deg, rgba(244, 189, 55, 0.22), rgba(244, 189, 55, 0.06));
+    color: var(--gold-100);
+  }
+}
 .matrix tbody th code {
   background: linear-gradient(135deg, rgba(252, 232, 151, 0.45), rgba(244, 189, 55, 0.1));
   border-color: rgba(244, 189, 55, 0.35); color: var(--gold-700);

--- a/docs/landing/style.css
+++ b/docs/landing/style.css
@@ -312,6 +312,12 @@ p  { margin: 0 0 1em; color: var(--fg-subtle); }
   color: var(--gold-100);
   opacity: 1;
 }
+.copy-btn.failed {
+  background: rgba(220, 80, 80, 0.22);
+  border-color: rgba(220, 80, 80, 0.5);
+  color: #ffd6d0;
+  opacity: 1;
+}
 .qs-panel code { background: transparent; border: 0; padding: 0; color: inherit; font-size: inherit; }
 .qs-panel .k  { color: #f4bd37; }
 .qs-panel .s  { color: #fce897; }


### PR DESCRIPTION
## Summary

Refinements to the `docs/landing/` page (vsag.io homepage) based on feedback:

- **Quickstart**: add a `Copy` button to each code block (clipboard API + `execCommand` fallback); install `numpy` alongside `pyvsag`; print the `knn_search` results in both the Python and C++ snippets so users can see the output shape.
- **Indexes table**: reorder the table to lead with the actively developed indexes — `brute_force`, `hgraph`, `ivf`, `sindi`, `pyramid` — and move `hnsw` and `diskann` to the bottom with a dimmed row style and a `Deprecated` pill.
- **Ecosystem**: replace the free-text ''Databases & search engines'' blurb with a chip-style linked list of the downstream projects currently using VSAG: OceanBase, TuGraph, GreptimeDB, Hologres, PolarDB.
- Hero lede, ''family of indexes'' card, and meta description tweaked to match the new ordering (lead with HGraph/IVF/SINDI/Pyramid/brute force; HNSW + DiskANN mentioned as legacy).

## Testing

Static HTML/CSS/JS changes only; opened `docs/landing/index.html` in a browser to confirm the copy button states (idle / hover / `Copied`), the deprecated row styling, and the ecosystem chip list render correctly in both light and dark modes.