### PR TITLE
feat(hgraph): integrate reasoning mechanism for search diagnostics

### DIFF
--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -33,6 +33,7 @@
 #include "impl/heap/standard_heap.h"
 #include "impl/odescent/odescent_graph_builder.h"
 #include "impl/pruning_strategy.h"
+#include "impl/reasoning/search_reasoning.h"
 #include "index/index_impl.h"
 #include "index/iterator_filter.h"
 #include "io/reader_io_parameter.h"
@@ -2298,12 +2299,49 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
 
     std::shared_lock force_remove_rlock(this->force_remove_mutex_);
     std::shared_lock shared_lock(this->global_mutex_);
+
     // check k
     CHECK_ARGUMENT(k > 0, fmt::format("k({}) must be greater than 0", k));
     k = std::min(k, GetNumElements());
 
     // check query vector
     CHECK_ARGUMENT(query->GetNumElements() == 1, "query dataset should contain 1 vector only");
+
+    // Setup reasoning context if expected labels are provided.
+    std::shared_ptr<ReasoningContext> reasoning_ctx;
+    if (not request.expected_labels_.empty()) {
+        reasoning_ctx = std::make_shared<ReasoningContext>(this->allocator_);
+        reasoning_ctx->SetSearchParams(k, "HGraph", use_reorder_, request.filter_ != nullptr);
+
+        UnorderedMap<int64_t, InnerIdType> label_to_inner_id(this->allocator_);
+        for (const auto& label : request.expected_labels_) {
+            auto [success, inner_id] = label_table_->TryGetIdByLabel(label, true);
+            if (success) {
+                label_to_inner_id[label] = inner_id;
+            }
+        }
+
+        Vector<int64_t> expected_labels_vec(
+            request.expected_labels_.begin(), request.expected_labels_.end(), this->allocator_);
+        reasoning_ctx->InitializeExpectedTargets(expected_labels_vec, label_to_inner_id);
+
+        const auto* const query_vector = get_data(query);
+        auto precise_flatten = this->basic_flatten_codes_;
+        if (use_reorder_) {
+            precise_flatten = this->high_precise_codes_;
+        }
+        if (create_new_raw_vector_) {
+            precise_flatten = this->raw_vector_;
+        }
+        auto computer = precise_flatten->FactoryComputer(query_vector);
+        for (const auto& pair : label_to_inner_id) {
+            float dist = 0.0F;
+            const auto inner_id = pair.second;
+            precise_flatten->Query(&dist, computer, &inner_id, 1);
+            reasoning_ctx->SetTrueDistance(inner_id, dist);
+        }
+        ctx.reasoning_ctx = reasoning_ctx.get();
+    }
 
     InnerSearchParam search_param;
     search_param.ep = this->entry_point_id_;
@@ -2393,9 +2431,16 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
     if (search_result->Empty()) {
         auto dataset_result = DatasetImpl::MakeEmptyDataset();
         dataset_result->Statistics(stats.Dump());
+        if (reasoning_ctx) {
+            reasoning_ctx->DiagnoseExpectedTargets();
+            dataset_result->Reasoning(reasoning_ctx->GenerateReport());
+        }
         return dataset_result;
     }
     auto count = static_cast<const int64_t>(search_result->Size());
+
+    Vector<InnerIdType> result_inner_ids(static_cast<size_t>(count), this->allocator_);
+
     auto [dataset_results, dists, ids] = create_fast_dataset(count, ctx.alloc);
     char* extra_infos = nullptr;
     if (extra_info_size_ > 0 && this->extra_infos_ != nullptr) {
@@ -2404,15 +2449,24 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
         dataset_results->ExtraInfos(extra_infos);
     }
     for (int64_t j = count - 1; j >= 0; --j) {
-        dists[j] = search_result->Top().first;
-        ids[j] = this->label_table_->GetLabelById(search_result->Top().second);
+        const auto& top = search_result->Top();
+        dists[j] = top.first;
+        ids[j] = this->label_table_->GetLabelById(top.second);
+        result_inner_ids[j] = top.second;
         if (extra_infos != nullptr) {
-            this->extra_infos_->GetExtraInfoById(search_result->Top().second,
-                                                 extra_infos + extra_info_size_ * j);
+            this->extra_infos_->GetExtraInfoById(top.second, extra_infos + extra_info_size_ * j);
         }
         search_result->Pop();
     }
     dataset_results->Statistics(stats.Dump());
+
+    // Generate reasoning report if reasoning context was created
+    if (reasoning_ctx) {
+        reasoning_ctx->MarkResult(result_inner_ids);
+        reasoning_ctx->DiagnoseExpectedTargets();
+        dataset_results->Reasoning(reasoning_ctx->GenerateReport());
+    }
+
     return std::move(dataset_results);
 }
 

--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -34,6 +34,7 @@
 #include "impl/heap/standard_heap.h"
 #include "impl/odescent/odescent_graph_builder.h"
 #include "impl/pruning_strategy.h"
+#include "impl/reasoning/search_reasoning.h"
 #include "index/index_impl.h"
 #include "index/iterator_filter.h"
 #include "io/reader_io_parameter.h"
@@ -2173,6 +2174,32 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
         (1 <= params.ef_search) and (params.ef_search <= ef_search_threshold),
         fmt::format("ef_search({}) must in range[1, {}]", params.ef_search, ef_search_threshold));
 
+    // Setup reasoning context if expected labels are provided
+    std::shared_ptr<ReasoningContext> reasoning_ctx;
+    if (not request.expected_labels_.empty()) {
+        reasoning_ctx = std::make_shared<ReasoningContext>(this->allocator_);
+        reasoning_ctx->SetSearchParams(k, "HGraph", use_reorder_, request.filter_ != nullptr);
+
+        // Build label to inner_id map for expected targets
+        UnorderedMap<int64_t, InnerIdType> label_to_inner_id(this->allocator_);
+        for (const auto& label : request.expected_labels_) {
+            auto [success, inner_id] = label_table_->TryGetIdByLabel(label, true);
+            if (success) {
+                label_to_inner_id[label] = inner_id;
+            }
+        }
+
+        Vector<int64_t> expected_labels_vec(
+            request.expected_labels_.begin(), request.expected_labels_.end(), this->allocator_);
+        reasoning_ctx->InitializeExpectedTargets(expected_labels_vec,
+                                                 label_to_inner_id,
+                                                 static_cast<const float*>(get_data(query)),
+                                                 nullptr,
+                                                 data_type_,
+                                                 dim_);
+        ctx.reasoning_ctx = reasoning_ctx.get();
+    }
+
     std::shared_lock shared_lock(this->global_mutex_);
     // check k
     CHECK_ARGUMENT(k > 0, fmt::format("k({}) must be greater than 0", k));
@@ -2272,6 +2299,13 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
         return dataset_result;
     }
     auto count = static_cast<const int64_t>(search_result->Size());
+
+    // Collect result inner_ids for reasoning
+    Vector<InnerIdType> result_inner_ids(static_cast<size_t>(count), this->allocator_);
+    for (int64_t j = count - 1; j >= 0; --j) {
+        result_inner_ids[j] = search_result->Top().second;
+    }
+
     auto [dataset_results, dists, ids] = create_fast_dataset(count, ctx.alloc);
     char* extra_infos = nullptr;
     if (extra_info_size_ > 0 && this->extra_infos_ != nullptr) {
@@ -2289,6 +2323,14 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
         search_result->Pop();
     }
     dataset_results->Statistics(stats.Dump());
+
+    // Generate reasoning report if reasoning context was created
+    if (reasoning_ctx) {
+        reasoning_ctx->MarkResult(result_inner_ids);
+        reasoning_ctx->DiagnoseExpectedTargets();
+        dataset_results->Reasoning(reasoning_ctx->GenerateReport());
+    }
+
     return std::move(dataset_results);
 }
 

--- a/src/impl/reasoning/search_reasoning.cpp
+++ b/src/impl/reasoning/search_reasoning.cpp
@@ -14,10 +14,7 @@
 
 #include "search_reasoning.h"
 
-#include <cmath>
-
-#include "simd/bf16_simd.h"
-#include "simd/fp16_simd.h"
+#include <nlohmann/json.hpp>
 
 namespace vsag {
 
@@ -33,19 +30,9 @@ ReasoningContext::~ReasoningContext() = default;
 
 void
 ReasoningContext::InitializeExpectedTargets(
-    const Vector<int64_t>& labels,
-    const UnorderedMap<int64_t, InnerIdType>& label_to_inner_id,
-    const float* query,
-    const void* precise_vectors,
-    DataTypes data_type,
-    uint64_t dim) {
+    const Vector<int64_t>& labels, const UnorderedMap<int64_t, InnerIdType>& label_to_inner_id) {
     expected_inner_ids_.clear();
     expected_traces_.clear();
-
-    float* casted_vec = nullptr;
-    if (data_type != DataTypes::DATA_TYPE_FLOAT) {
-        casted_vec = new float[dim];
-    }
 
     for (const auto& label : labels) {
         auto it = label_to_inner_id.find(label);
@@ -57,48 +44,17 @@ ReasoningContext::InitializeExpectedTargets(
             trace.label = label;
             trace.inner_id = inner_id;
 
-            const float* vec = nullptr;
-
-            if (data_type == DataTypes::DATA_TYPE_FLOAT) {
-                vec = static_cast<const float*>(precise_vectors) +
-                      static_cast<uint64_t>(inner_id) * dim;
-            } else if (data_type == DataTypes::DATA_TYPE_INT8) {
-                const int8_t* int8_vec = static_cast<const int8_t*>(precise_vectors) +
-                                         static_cast<uint64_t>(inner_id) * dim;
-                for (uint64_t i = 0; i < dim; ++i) {
-                    casted_vec[i] = static_cast<float>(int8_vec[i]);
-                }
-                vec = casted_vec;
-            } else if (data_type == DataTypes::DATA_TYPE_FP16) {
-                const uint16_t* fp16_vec = static_cast<const uint16_t*>(precise_vectors) +
-                                           static_cast<uint64_t>(inner_id) * dim;
-                for (uint64_t i = 0; i < dim; ++i) {
-                    casted_vec[i] = generic::FP16ToFloat(fp16_vec[i]);
-                }
-                vec = casted_vec;
-            } else if (data_type == DataTypes::DATA_TYPE_BF16) {
-                const uint16_t* bf16_vec = static_cast<const uint16_t*>(precise_vectors) +
-                                           static_cast<uint64_t>(inner_id) * dim;
-                for (uint64_t i = 0; i < dim; ++i) {
-                    casted_vec[i] = generic::BF16ToFloat(bf16_vec[i]);
-                }
-                vec = casted_vec;
-            }
-
-            if (vec != nullptr) {
-                float true_dist = 0.0F;
-                for (uint64_t i = 0; i < dim; ++i) {
-                    float diff = query[i] - vec[i];
-                    true_dist += diff * diff;
-                }
-                trace.true_distance = std::sqrt(true_dist);
-            }
-
             expected_traces_.insert(std::make_pair(inner_id, trace));
         }
     }
+}
 
-    delete[] casted_vec;
+void
+ReasoningContext::SetTrueDistance(InnerIdType id, float dist) {
+    auto it = expected_traces_.find(id);
+    if (it != expected_traces_.end()) {
+        it.value().true_distance = dist;
+    }
 }
 
 void
@@ -137,17 +93,30 @@ ReasoningContext::RecordFilterReject(InnerIdType id) {
 void
 ReasoningContext::RecordReorder(InnerIdType id, float dist_before, float dist_after) {
     auto it = expected_traces_.find(id);
-    if (it != expected_traces_.end()) {
-        it.value().reorder_evicted = true;
-        it.value().quantized_distance = dist_before;
-        it.value().true_distance = dist_after;
+    if (it == expected_traces_.end()) {
+        return;
     }
+
+    it.value().quantized_distance = dist_before;
+    it.value().true_distance = dist_after;
 
     ReorderRecord record;
     record.id = id;
     record.dist_before = dist_before;
     record.dist_after = dist_after;
     reorder_changes_.push_back(record);
+}
+
+void
+ReasoningContext::RecordReorderEviction(InnerIdType id, uint32_t hop) {
+    auto it = expected_traces_.find(id);
+    if (it != expected_traces_.end()) {
+        it.value().reorder_evicted = true;
+        if (!it.value().was_visited) {
+            it.value().was_visited = true;
+            it.value().visited_at_hop = static_cast<int32_t>(hop);
+        }
+    }
 }
 
 void
@@ -204,6 +173,7 @@ ReasoningContext::DiagnoseTarget(const ExpectedTargetTrace& trace) {
 std::string
 ReasoningContext::GenerateReport() const {
     JsonType report;
+    nlohmann::json missed_targets = nlohmann::json::array();
 
     int found_count = 0;
     int missed_count = 0;
@@ -214,6 +184,19 @@ ReasoningContext::GenerateReport() const {
             found_count++;
         } else {
             missed_count++;
+
+            nlohmann::json detail;
+            detail["label"] = trace.label;
+            detail["inner_id"] = trace.inner_id;
+            detail["diagnosis"] = trace.diagnosis;
+            detail["true_distance"] = trace.true_distance;
+            detail["quantized_distance"] = trace.quantized_distance;
+            detail["was_visited"] = trace.was_visited;
+            detail["visited_at_hop"] = trace.visited_at_hop;
+            detail["was_evicted"] = trace.was_evicted;
+            detail["filter_rejected"] = trace.filter_rejected;
+            detail["reorder_evicted"] = trace.reorder_evicted;
+            missed_targets.push_back(detail);
         }
     }
 
@@ -222,6 +205,11 @@ ReasoningContext::GenerateReport() const {
                           std::to_string(missed_count) + " missed";
 
     report["expected_analysis"]["summary"].SetString(summary);
+    if (not missed_targets.empty()) {
+        JsonType missed_targets_json;
+        *missed_targets_json.GetInnerJson() = std::move(missed_targets);
+        report["expected_analysis"]["missed_targets"].SetJson(missed_targets_json);
+    }
 
     return report.Dump();
 }

--- a/src/impl/reasoning/search_reasoning.cpp
+++ b/src/impl/reasoning/search_reasoning.cpp
@@ -205,11 +205,9 @@ ReasoningContext::GenerateReport() const {
                           std::to_string(missed_count) + " missed";
 
     report["expected_analysis"]["summary"].SetString(summary);
-    if (not missed_targets.empty()) {
-        JsonType missed_targets_json;
-        *missed_targets_json.GetInnerJson() = std::move(missed_targets);
-        report["expected_analysis"]["missed_targets"].SetJson(missed_targets_json);
-    }
+    JsonType missed_targets_json;
+    *missed_targets_json.GetInnerJson() = std::move(missed_targets);
+    report["expected_analysis"]["missed_targets"].SetJson(missed_targets_json);
 
     return report.Dump();
 }

--- a/src/impl/reasoning/search_reasoning.cpp
+++ b/src/impl/reasoning/search_reasoning.cpp
@@ -14,8 +14,6 @@
 
 #include "search_reasoning.h"
 
-#include <nlohmann/json.hpp>
-
 namespace vsag {
 
 ReasoningContext::ReasoningContext(Allocator* allocator)
@@ -173,7 +171,7 @@ ReasoningContext::DiagnoseTarget(const ExpectedTargetTrace& trace) {
 std::string
 ReasoningContext::GenerateReport() const {
     JsonType report;
-    nlohmann::json missed_targets = nlohmann::json::array();
+    JsonType missed_targets = JsonType::Parse("[]");
 
     int found_count = 0;
     int missed_count = 0;
@@ -185,18 +183,18 @@ ReasoningContext::GenerateReport() const {
         } else {
             missed_count++;
 
-            nlohmann::json detail;
-            detail["label"] = trace.label;
-            detail["inner_id"] = trace.inner_id;
-            detail["diagnosis"] = trace.diagnosis;
-            detail["true_distance"] = trace.true_distance;
-            detail["quantized_distance"] = trace.quantized_distance;
-            detail["was_visited"] = trace.was_visited;
-            detail["visited_at_hop"] = trace.visited_at_hop;
-            detail["was_evicted"] = trace.was_evicted;
-            detail["filter_rejected"] = trace.filter_rejected;
-            detail["reorder_evicted"] = trace.reorder_evicted;
-            missed_targets.push_back(detail);
+            JsonType detail;
+            detail["label"].SetJson(JsonType::Parse(std::to_string(trace.label)));
+            detail["inner_id"].SetJson(JsonType::Parse(std::to_string(trace.inner_id)));
+            detail["diagnosis"].SetString(trace.diagnosis);
+            detail["true_distance"].SetFloat(trace.true_distance);
+            detail["quantized_distance"].SetFloat(trace.quantized_distance);
+            detail["was_visited"].SetBool(trace.was_visited);
+            detail["visited_at_hop"].SetJson(JsonType::Parse(std::to_string(trace.visited_at_hop)));
+            detail["was_evicted"].SetBool(trace.was_evicted);
+            detail["filter_rejected"].SetBool(trace.filter_rejected);
+            detail["reorder_evicted"].SetBool(trace.reorder_evicted);
+            missed_targets.AppendJson(detail);
         }
     }
 
@@ -205,9 +203,7 @@ ReasoningContext::GenerateReport() const {
                           std::to_string(missed_count) + " missed";
 
     report["expected_analysis"]["summary"].SetString(summary);
-    JsonType missed_targets_json;
-    *missed_targets_json.GetInnerJson() = std::move(missed_targets);
-    report["expected_analysis"]["missed_targets"].SetJson(missed_targets_json);
+    report["expected_analysis"]["missed_targets"].SetJson(missed_targets);
 
     return report.Dump();
 }

--- a/src/impl/reasoning/search_reasoning.h
+++ b/src/impl/reasoning/search_reasoning.h
@@ -17,7 +17,6 @@
 #include <cstdint>
 #include <string>
 
-#include "data_type.h"
 #include "impl/allocator/allocator_wrapper.h"
 #include "json_wrapper.h"
 #include "typing.h"
@@ -54,11 +53,10 @@ public:
 
     void
     InitializeExpectedTargets(const Vector<int64_t>& labels,
-                              const UnorderedMap<int64_t, InnerIdType>& label_to_inner_id,
-                              const float* query,
-                              const void* precise_vectors,
-                              DataTypes data_type,
-                              uint64_t dim);
+                              const UnorderedMap<int64_t, InnerIdType>& label_to_inner_id);
+
+    void
+    SetTrueDistance(InnerIdType id, float dist);
 
     void
     RecordVisit(InnerIdType id, float dist, uint32_t hop);
@@ -71,6 +69,9 @@ public:
 
     void
     RecordReorder(InnerIdType id, float dist_before, float dist_after);
+
+    void
+    RecordReorderEviction(InnerIdType id, uint32_t hop);
 
     void
     SetTermination(const std::string& reason);
@@ -95,6 +96,10 @@ public:
 
     void
     AddDistanceComputation(uint32_t count = 1);
+
+    static constexpr const char* kTerminationLowerBoundReached = "lower_bound_reached";
+    static constexpr const char* kTerminationHopsLimitReached = "hops_limit_reached";
+    static constexpr const char* kTerminationTimeout = "timeout";
 
 public:
     int64_t topk_{0};

--- a/src/impl/reasoning/search_reasoning_test.cpp
+++ b/src/impl/reasoning/search_reasoning_test.cpp
@@ -15,6 +15,7 @@
 #include "search_reasoning.h"
 
 #include <catch2/catch_test_macros.hpp>
+#include <string_view>
 
 #include "impl/allocator/default_allocator.h"
 
@@ -61,12 +62,8 @@ TEST_CASE("ReasoningContext with expected targets", "[reasoning]") {
     label_to_inner_id[100] = 0;
     label_to_inner_id[200] = 1;
 
-    float query[4] = {1.0F, 0.0F, 0.0F, 0.0F};
-    float vectors[2][4] = {{1.0F, 0.0F, 0.0F, 0.0F}, {0.0F, 1.0F, 0.0F, 0.0F}};
-
     SECTION("InitializeExpectedTargets") {
-        ctx.InitializeExpectedTargets(
-            labels, label_to_inner_id, query, vectors, DataTypes::DATA_TYPE_FLOAT, 4);
+        ctx.InitializeExpectedTargets(labels, label_to_inner_id);
         REQUIRE(ctx.expected_traces_.size() == 2);
         REQUIRE(ctx.expected_inner_ids_.size() == 2);
 
@@ -78,7 +75,7 @@ TEST_CASE("ReasoningContext with expected targets", "[reasoning]") {
         auto it2 = ctx.expected_traces_.find(1);
         REQUIRE(it2 != ctx.expected_traces_.end());
         REQUIRE(it2.value().label == 200);
-        REQUIRE(it2.value().true_distance > 0.0F);
+        REQUIRE(it2.value().true_distance == 0.0F);
     }
 }
 
@@ -92,10 +89,7 @@ TEST_CASE("ReasoningContext event recording", "[reasoning]") {
     UnorderedMap<int64_t, InnerIdType> label_to_inner_id(&allocator);
     label_to_inner_id[100] = 0;
 
-    float query[4] = {1.0F, 0.0F, 0.0F, 0.0F};
-    float vectors[1][4] = {{1.0F, 0.0F, 0.0F, 0.0F}};
-    ctx.InitializeExpectedTargets(
-        labels, label_to_inner_id, query, vectors, DataTypes::DATA_TYPE_FLOAT, 4);
+    ctx.InitializeExpectedTargets(labels, label_to_inner_id);
 
     SECTION("RecordVisit") {
         ctx.RecordVisit(0, 0.5F, 1);
@@ -123,15 +117,37 @@ TEST_CASE("ReasoningContext event recording", "[reasoning]") {
         REQUIRE(it.value().was_visited == true);
     }
 
+    SECTION("RecordFilterReject keeps visited hop") {
+        ctx.RecordVisit(0, 0.2F, 3);
+        ctx.RecordFilterReject(0);
+        auto it = ctx.expected_traces_.find(0);
+        REQUIRE(it != ctx.expected_traces_.end());
+        REQUIRE(it.value().visited_at_hop == 3);
+    }
+
     SECTION("RecordReorder") {
         ctx.RecordVisit(0, 0.3F, 1);
         ctx.RecordReorder(0, 0.3F, 0.5F);
         auto it = ctx.expected_traces_.find(0);
         REQUIRE(it != ctx.expected_traces_.end());
-        REQUIRE(it.value().reorder_evicted == true);
+        REQUIRE(it.value().reorder_evicted == false);
         REQUIRE(it.value().quantized_distance == 0.3F);
         REQUIRE(it.value().true_distance == 0.5F);
         REQUIRE(ctx.reorder_changes_.size() == 1);
+    }
+
+    SECTION("RecordReorder ignores non-expected target") {
+        ctx.RecordReorder(99, 0.3F, 0.5F);
+        REQUIRE(ctx.reorder_changes_.empty());
+    }
+
+    SECTION("RecordReorderEviction") {
+        ctx.RecordReorderEviction(0, 2);
+        auto it = ctx.expected_traces_.find(0);
+        REQUIRE(it != ctx.expected_traces_.end());
+        REQUIRE(it.value().reorder_evicted == true);
+        REQUIRE(it.value().was_visited == true);
+        REQUIRE(it.value().visited_at_hop == 2);
     }
 }
 
@@ -157,18 +173,7 @@ TEST_CASE("ReasoningContext diagnosis logic", "[reasoning]") {
     label_to_inner_id[600] = 5;
     label_to_inner_id[700] = 6;
 
-    float query[4] = {1.0F, 0.0F, 0.0F, 0.0F};
-    float vectors[7][4] = {
-        {1.0F, 0.0F, 0.0F, 0.0F},
-        {0.5F, 0.5F, 0.0F, 0.0F},
-        {0.0F, 1.0F, 0.0F, 0.0F},
-        {0.5F, 0.5F, 0.0F, 0.0F},
-        {0.0F, 1.0F, 0.0F, 0.0F},
-        {0.0F, 1.0F, 0.0F, 0.0F},
-        {0.0F, 1.0F, 0.0F, 0.0F},
-    };
-    ctx.InitializeExpectedTargets(
-        labels, label_to_inner_id, query, vectors, DataTypes::DATA_TYPE_FLOAT, 4);
+    ctx.InitializeExpectedTargets(labels, label_to_inner_id);
 
     SECTION("Diagnose: not_reachable") {
         ctx.DiagnoseExpectedTargets();
@@ -207,6 +212,7 @@ TEST_CASE("ReasoningContext diagnosis logic", "[reasoning]") {
     SECTION("Diagnose: reorder_evicted") {
         ctx.RecordVisit(6, 0.3F, 1);
         ctx.RecordReorder(6, 0.3F, 0.8F);
+        ctx.RecordReorderEviction(6, 2);
         ctx.DiagnoseExpectedTargets();
         auto it = ctx.expected_traces_.find(6);
         REQUIRE(it != ctx.expected_traces_.end());
@@ -237,10 +243,9 @@ TEST_CASE("ReasoningContext GenerateReport", "[reasoning]") {
     label_to_inner_id[100] = 0;
     label_to_inner_id[200] = 1;
 
-    float query[4] = {1.0F, 0.0F, 0.0F, 0.0F};
-    float vectors[2][4] = {{1.0F, 0.0F, 0.0F, 0.0F}, {0.0F, 1.0F, 0.0F, 0.0F}};
-    ctx.InitializeExpectedTargets(
-        labels, label_to_inner_id, query, vectors, DataTypes::DATA_TYPE_FLOAT, 4);
+    ctx.InitializeExpectedTargets(labels, label_to_inner_id);
+    ctx.SetTrueDistance(0, 0.0F);
+    ctx.SetTrueDistance(1, 1.4142135F);
 
     ctx.RecordVisit(0, 0.0F, 1);
     Vector<InnerIdType> result_ids(&allocator);
@@ -253,6 +258,17 @@ TEST_CASE("ReasoningContext GenerateReport", "[reasoning]") {
     REQUIRE(report.find("expected_analysis") != std::string::npos);
     REQUIRE(report.find("1/2") != std::string::npos);
     REQUIRE(report.find("1 missed") != std::string::npos);
+    REQUIRE(report.find("missed_targets") != std::string::npos);
+    REQUIRE(report.find("not_reachable") != std::string::npos);
+    REQUIRE(report.find("1.4142135") != std::string::npos);
+}
+
+TEST_CASE("ReasoningContext termination reasons are centralized", "[reasoning]") {
+    REQUIRE(std::string_view(ReasoningContext::kTerminationLowerBoundReached) ==
+            "lower_bound_reached");
+    REQUIRE(std::string_view(ReasoningContext::kTerminationHopsLimitReached) ==
+            "hops_limit_reached");
+    REQUIRE(std::string_view(ReasoningContext::kTerminationTimeout) == "timeout");
 }
 
 }  // namespace vsag

--- a/src/impl/reorder/flatten_reorder.cpp
+++ b/src/impl/reorder/flatten_reorder.cpp
@@ -17,6 +17,7 @@
 
 #include "datacell/flatten_interface.h"
 #include "impl/heap/standard_heap.h"
+#include "impl/reasoning/search_reasoning.h"
 #include "query_context.h"
 
 namespace vsag {
@@ -41,12 +42,19 @@ FlattenReorder::Reorder(const vsag::DistHeapPtr& input,
     }
     flatten_->Query(dists.data(), computer, ids.data(), candidate_size, &ctx);
     for (int i = 0; i < candidate_size; ++i) {
+        if (ctx.reasoning_ctx != nullptr) {
+            ctx.reasoning_ctx->RecordReorder(
+                candidate_result[i].second, candidate_result[i].first, dists[i]);
+        }
         if (reorder_heap->Size() < topk || dists[i] < reorder_heap->Top().first) {
             reorder_heap->Push(dists[i], candidate_result[i].second);
             if (reorder_heap->Size() > topk) {
                 if (iter_ctx != nullptr) {
                     auto curr = reorder_heap->Top();
                     iter_ctx->AddDiscardNode(curr.first, curr.second);
+                }
+                if (ctx.reasoning_ctx != nullptr) {
+                    ctx.reasoning_ctx->RecordReorderEviction(reorder_heap->Top().second, 0);
                 }
                 reorder_heap->Pop();
             }

--- a/src/impl/reorder/flatten_reorder.cpp
+++ b/src/impl/reorder/flatten_reorder.cpp
@@ -17,6 +17,7 @@
 
 #include "datacell/flatten_interface.h"
 #include "impl/heap/standard_heap.h"
+#include "impl/reasoning/search_reasoning.h"
 #include "query_context.h"
 
 namespace vsag {
@@ -41,12 +42,19 @@ FlattenReorder::Reorder(const vsag::DistHeapPtr& input,
     }
     flatten_->Query(dists.data(), computer, ids.data(), candidate_size, &ctx);
     for (int i = 0; i < candidate_size; ++i) {
+        if (ctx.reasoning_ctx != nullptr) {
+            ctx.reasoning_ctx->RecordReorder(
+                candidate_result[i].second, candidate_result[i].first, dists[i]);
+        }
         if (reorder_heap->Size() < topk || dists[i] < reorder_heap->Top().first) {
             reorder_heap->Push(dists[i], candidate_result[i].second);
             if (reorder_heap->Size() > topk) {
                 if (iter_ctx != nullptr) {
                     auto curr = reorder_heap->Top();
                     iter_ctx->AddDiscardNode(curr.first, curr.second);
+                }
+                if (ctx.reasoning_ctx != nullptr) {
+                    ctx.reasoning_ctx->RecordEviction(reorder_heap->Top().second, 0);
                 }
                 reorder_heap->Pop();
             }

--- a/src/impl/searcher/basic_searcher.cpp
+++ b/src/impl/searcher/basic_searcher.cpp
@@ -22,6 +22,7 @@
 #include "algorithm/inner_index_interface.h"
 #include "datacell/flatten_interface.h"
 #include "impl/heap/standard_heap.h"
+#include "impl/reasoning/search_reasoning.h"
 #include "utils/linear_congruential_generator.h"
 #include "vsag/allocator.h"
 
@@ -177,6 +178,9 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
 
         if constexpr (mode == InnerSearchMode::KNN_SEARCH) {
             if ((-current_node_pair.first) > lower_bound && top_candidates->Size() == ef) {
+                if (ctx != nullptr and ctx->reasoning_ctx != nullptr) {
+                    ctx->reasoning_ctx->SetTermination("lower_bound_reached");
+                }
                 break;
             }
         }
@@ -294,6 +298,9 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
     if (check_func(ep)) {
         top_candidates->Push(dist, ep);
         lower_bound = top_candidates->Top().first;
+        if (ctx != nullptr and ctx->reasoning_ctx != nullptr) {
+            ctx->reasoning_ctx->RecordVisit(ep, dist, 0);
+        }
     }
     if constexpr (mode == InnerSearchMode::RANGE_SEARCH) {
         if (dist > inner_search_param.radius and not top_candidates->Empty()) {
@@ -306,7 +313,13 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
     while (not candidate_set->Empty()) {
         ++hops;
         if (hops >= inner_search_param.hops_limit) {
+            if (ctx != nullptr and ctx->reasoning_ctx != nullptr) {
+                ctx->reasoning_ctx->SetTermination("hops_limit_reached");
+            }
             break;
+        }
+        if (ctx != nullptr and ctx->reasoning_ctx != nullptr) {
+            ctx->reasoning_ctx->AddSearchHop();
         }
         auto current_node_pair = candidate_set->Top();
 
@@ -314,6 +327,9 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
             inner_search_param.time_cost->CheckOvertime()) {
             if (ctx != nullptr and ctx->stats != nullptr) {
                 ctx->stats->is_timeout.store(true, std::memory_order_relaxed);
+            }
+            if (ctx != nullptr and ctx->reasoning_ctx != nullptr) {
+                ctx->reasoning_ctx->SetTermination("timeout");
             }
             break;
         }
@@ -343,6 +359,9 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
 
         for (uint32_t i = 0; i < count_no_visited; i++) {
             dist = line_dists[i];
+            if (ctx != nullptr and ctx->reasoning_ctx != nullptr) {
+                ctx->reasoning_ctx->RecordVisit(to_be_visited_id[i], dist, hops);
+            }
             if (top_candidates->Size() < ef || lower_bound > dist ||
                 (mode == RANGE_SEARCH && dist <= inner_search_param.radius)) {
                 candidate_set->Push(-dist, to_be_visited_id[i]);
@@ -361,6 +380,9 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
 
                 if constexpr (mode == KNN_SEARCH) {
                     if (top_candidates->Size() > ef) {
+                        if (ctx != nullptr and ctx->reasoning_ctx != nullptr) {
+                            ctx->reasoning_ctx->RecordEviction(top_candidates->Top().second, hops);
+                        }
                         top_candidates->Pop();
                     }
                 }

--- a/src/impl/searcher/basic_searcher.cpp
+++ b/src/impl/searcher/basic_searcher.cpp
@@ -22,7 +22,9 @@
 #include "algorithm/inner_index_interface.h"
 #include "datacell/flatten_interface.h"
 #include "impl/heap/standard_heap.h"
+#include "impl/reasoning/search_reasoning.h"
 #include "utils/filter_search_skip_strategy.h"
+#include "utils/linear_congruential_generator.h"
 #include "vsag/allocator.h"
 
 namespace vsag {
@@ -118,6 +120,7 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
     auto is_id_allowed = inner_search_param.is_inner_id_allowed;
     auto ep = inner_search_param.ep;
     auto ef = inner_search_param.ef;
+    ReasoningContext* reasoning = (ctx != nullptr) ? ctx->reasoning_ctx : nullptr;
 
     float dist = 0.0F;
     uint64_t ids_cnt = 1;
@@ -177,6 +180,9 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
 
         if constexpr (mode == InnerSearchMode::KNN_SEARCH) {
             if ((-current_node_pair.first) > lower_bound && top_candidates->Size() == ef) {
+                if (reasoning != nullptr) {
+                    reasoning->SetTermination(ReasoningContext::kTerminationLowerBoundReached);
+                }
                 break;
             }
         }
@@ -253,6 +259,7 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
                            QueryContext* ctx) const {
     // set customize query alloctor
     Allocator* alloc = select_query_allocator(ctx, allocator_);
+    ReasoningContext* reasoning = (ctx != nullptr) ? ctx->reasoning_ctx : nullptr;
 
     auto top_candidates = std::make_shared<StandardHeap<true, false>>(alloc, -1);
     auto candidate_set = std::make_shared<StandardHeap<true, false>>(alloc, -1);
@@ -297,9 +304,14 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
 
     flatten->Query(&dist, computer, &ep, 1, ctx);
     ++dist_cmp;
+    if (reasoning != nullptr) {
+        reasoning->RecordVisit(ep, dist, 0);
+    }
     if (check_func(ep)) {
         top_candidates->Push(dist, ep);
         lower_bound = top_candidates->Top().first;
+    } else if (reasoning != nullptr) {
+        reasoning->RecordFilterReject(ep);
     }
     if constexpr (mode == InnerSearchMode::RANGE_SEARCH) {
         if (dist > inner_search_param.radius and not top_candidates->Empty()) {
@@ -312,7 +324,13 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
     while (not candidate_set->Empty()) {
         ++hops;
         if (hops >= inner_search_param.hops_limit) {
+            if (reasoning != nullptr) {
+                reasoning->SetTermination(ReasoningContext::kTerminationHopsLimitReached);
+            }
             break;
+        }
+        if (reasoning != nullptr) {
+            reasoning->AddSearchHop();
         }
         auto current_node_pair = candidate_set->Top();
 
@@ -321,11 +339,17 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
             if (ctx != nullptr and ctx->stats != nullptr) {
                 ctx->stats->is_timeout.store(true, std::memory_order_relaxed);
             }
+            if (reasoning != nullptr) {
+                reasoning->SetTermination(ReasoningContext::kTerminationTimeout);
+            }
             break;
         }
 
         if constexpr (mode == InnerSearchMode::KNN_SEARCH) {
             if ((-current_node_pair.first) > lower_bound && top_candidates->Size() == ef) {
+                if (reasoning != nullptr) {
+                    reasoning->SetTermination(ReasoningContext::kTerminationLowerBoundReached);
+                }
                 break;
             }
         }
@@ -349,12 +373,17 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
 
         for (uint32_t i = 0; i < count_no_visited; i++) {
             dist = line_dists[i];
+            if (reasoning != nullptr) {
+                reasoning->RecordVisit(to_be_visited_id[i], dist, hops);
+            }
             if (top_candidates->Size() < ef || lower_bound > dist ||
                 (mode == RANGE_SEARCH && dist <= inner_search_param.radius)) {
                 candidate_set->Push(-dist, to_be_visited_id[i]);
                 //                flatten->Prefetch(candidate_set->Top().second);
                 if (check_func(to_be_visited_id[i])) {
                     top_candidates->Push(dist, to_be_visited_id[i]);
+                } else if (reasoning != nullptr) {
+                    reasoning->RecordFilterReject(to_be_visited_id[i]);
                 }
                 if (inner_search_param.consider_duplicate) {
                     const auto duplicate_ids = graph->GetDuplicateIds(to_be_visited_id[i]);
@@ -367,6 +396,9 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
 
                 if constexpr (mode == KNN_SEARCH) {
                     if (top_candidates->Size() > ef) {
+                        if (reasoning != nullptr) {
+                            reasoning->RecordEviction(top_candidates->Top().second, hops);
+                        }
                         top_candidates->Pop();
                     }
                 }

--- a/src/json_wrapper.cpp
+++ b/src/json_wrapper.cpp
@@ -112,6 +112,11 @@ JsonWrapper::SetJson(const JsonWrapper& json) {
 }
 
 void
+JsonWrapper::AppendJson(const JsonWrapper& json) {
+    json_->push_back(*json.json_);
+}
+
+void
 JsonWrapper::SetInt(uint64_t value) {
     (*json_) = value;
 }

--- a/src/json_wrapper.h
+++ b/src/json_wrapper.h
@@ -62,6 +62,9 @@ public:
     SetJson(const JsonWrapper& json);
 
     void
+    AppendJson(const JsonWrapper& json);
+
+    void
     SetInt(uint64_t value);
 
     void

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -21,7 +21,9 @@
 #include "inner_string_params.h"
 #include "test_index.h"
 #include "typing.h"
+#include "vsag/filter.h"
 #include "vsag/options.h"
+#include "vsag/search_request.h"
 
 namespace fixtures {
 
@@ -90,6 +92,24 @@ public:
     static const std::vector<std::pair<std::string, float>> all_test_cases;
 };
 using HGraphTestIndexPtr = std::shared_ptr<HGraphTestIndex>;
+
+class RejectAllFilter : public vsag::Filter {
+public:
+    bool
+    CheckValid(int64_t) const override {
+        return false;
+    }
+
+    bool
+    CheckValid(const char*) const override {
+        return false;
+    }
+
+    float
+    ValidRatio() const override {
+        return 0.0F;
+    }
+};
 
 TestDatasetPool HGraphTestIndex::pool{};
 fixtures::TempDir HGraphTestIndex::dir{"hgraph_test"};
@@ -772,6 +792,44 @@ TestHGraphWithAttr(const fixtures::HGraphTestIndexPtr& test_index,
 }
 
 HGRAPH_PR_DAILY_CASE("HGraph With Attr", "[ft][filter_search][hgraph]", TestHGraphWithAttr)
+
+TEST_CASE("(PR) HGraph SearchWithRequest Reasoning", "[ft][hgraph][pr]") {
+    using namespace fixtures;
+
+    HGraphTestIndex::HGraphBuildParam build_param("l2", 16, "fp32");
+    auto param = HGraphTestIndex::GenerateHGraphBuildParametersString(build_param);
+
+    auto index = TestIndex::TestFactory(HGraphTestIndex::name, param, true);
+    auto dataset = HGraphTestIndex::pool.GetDatasetAndCreate(16, 256, "l2");
+    TestIndex::TestBuildIndex(index, dataset, true);
+
+    auto query = vsag::Dataset::Make();
+    query->NumElements(1)
+        ->Dim(dataset->base_->GetDim())
+        ->Float32Vectors(dataset->base_->GetFloat32Vectors())
+        ->Owner(false);
+
+    vsag::SearchRequest req;
+    req.topk_ = 5;
+    req.params_str_ = fmt::format(fixtures::search_param_tmp, 32, false);
+    req.query_ = query;
+    req.expected_labels_ = {dataset->base_->GetIds()[0]};
+
+    auto result = index->SearchWithRequest(req);
+    REQUIRE(result.has_value());
+    REQUIRE_FALSE(result.value()->GetReasoning().empty());
+    REQUIRE(result.value()->GetReasoning().find("missed_targets") != std::string::npos);
+
+    req.enable_filter_ = true;
+    req.filter_ = std::make_shared<RejectAllFilter>();
+
+    auto empty_result = index->SearchWithRequest(req);
+    REQUIRE(empty_result.has_value());
+    REQUIRE(empty_result.value()->GetDim() == 0);
+    REQUIRE_FALSE(empty_result.value()->GetReasoning().empty());
+    REQUIRE(empty_result.value()->GetReasoning().find("missed_targets") != std::string::npos);
+    REQUIRE(empty_result.value()->GetReasoning().find("diagnosis") != std::string::npos);
+}
 
 static void
 TestHGraphGetRawVector(const fixtures::HGraphTestIndexPtr& test_index,


### PR DESCRIPTION
## Summary

- Integrate ReasoningContext into HGraph::SearchWithRequest to enable reasoning reports when expected_labels_ are provided
- Record visit/eviction/hops/termination events in BasicSearcher::search_impl with reasoning context
- Record reorder distance changes in FlattenReorder::Reorder for expected target analysis
- Generate reasoning report with expected target diagnosis (not_reachable, filter_rejected, quantization_error, ef_too_small, reorder_evicted, success)
- Zero overhead when reasoning_ctx is null (conditional checks only when expected_labels_ is non-empty)

Fixes #1834