### PR TITLE
fix(ci): stabilize contributors readme updates

### DIFF
--- a/.github/scripts/update-contributors-readme.mjs
+++ b/.github/scripts/update-contributors-readme.mjs
@@ -1,0 +1,192 @@
+import { readFile, writeFile } from 'node:fs/promises';
+
+const CONTRIBUTORS_PER_ROW = 6;
+const START_MARKER = '<!-- readme: contributors -start -->';
+const END_MARKER = '<!-- readme: contributors -end -->';
+
+function parseArgs(argv) {
+    const args = {};
+
+    for (let index = 0; index < argv.length; index += 1) {
+        const token = argv[index];
+        const next = argv[index + 1];
+
+        if (!token.startsWith('--') || next === undefined) {
+            continue;
+        }
+
+        args[token.slice(2)] = next;
+        index += 1;
+    }
+
+    return args;
+}
+
+function escapeHtml(value) {
+    return value
+        .replaceAll('&', '&amp;')
+        .replaceAll('<', '&lt;')
+        .replaceAll('>', '&gt;')
+        .replaceAll('"', '&quot;')
+        .replaceAll("'", '&#39;');
+}
+
+async function githubRequest(path, token) {
+    const response = await fetch(`https://api.github.com${path}`, {
+        headers: {
+            Accept: 'application/vnd.github+json',
+            Authorization: `Bearer ${token}`,
+            'User-Agent': 'vsag-contributors-readme',
+            'X-GitHub-Api-Version': '2022-11-28'
+        }
+    });
+
+    if (!response.ok) {
+        throw new Error(`GitHub API request failed for ${path}: ${response.status}`);
+    }
+
+    return response.json();
+}
+
+async function listContributors(owner, repo, token) {
+    const contributors = [];
+
+    for (let page = 1; ; page += 1) {
+        const pageItems = await githubRequest(
+            `/repos/${owner}/${repo}/contributors?per_page=100&page=${page}`,
+            token
+        );
+
+        contributors.push(...pageItems);
+
+        if (pageItems.length < 100) {
+            return contributors;
+        }
+    }
+}
+
+function parseExistingNames(readmeContent) {
+    const namesByLogin = new Map();
+    const startIndex = readmeContent.indexOf(START_MARKER);
+    const endIndex = readmeContent.indexOf(END_MARKER);
+
+    if (startIndex === -1 || endIndex === -1 || endIndex <= startIndex) {
+        return namesByLogin;
+    }
+
+    const existingBlock = readmeContent.slice(startIndex, endIndex + END_MARKER.length);
+    const contributorCellPattern =
+        /<a href="https:\/\/github\.com\/([^\"]+)">[\s\S]*?<sub><b>([^<]+)<\/b><\/sub>/g;
+
+    let match = contributorCellPattern.exec(existingBlock);
+
+    while (match !== null) {
+        namesByLogin.set(match[1], match[2]);
+        match = contributorCellPattern.exec(existingBlock);
+    }
+
+    return namesByLogin;
+}
+
+async function resolveDisplayName(login, namesByLogin, token) {
+    const existingName = namesByLogin.get(login);
+
+    if (existingName) {
+        return existingName;
+    }
+
+    const user = await githubRequest(`/users/${encodeURIComponent(login)}`, token);
+    return user.name || login;
+}
+
+function renderContributorCell(contributor) {
+    const login = escapeHtml(contributor.login);
+    const avatarUrl = escapeHtml(contributor.avatar_url);
+    const displayName = escapeHtml(contributor.name);
+
+    return [
+        '            <td align="center">',
+        `                <a href="https://github.com/${login}">`,
+        `                    <img src="${avatarUrl}" width="100;" alt="${login}"/>`,
+        '                    <br />',
+        `                    <sub><b>${displayName}</b></sub>`,
+        '                </a>',
+        '            </td>'
+    ];
+}
+
+function renderContributorsTable(contributors) {
+    const lines = [START_MARKER, '<table>', '    <tbody>'];
+
+    for (let index = 0; index < contributors.length; index += CONTRIBUTORS_PER_ROW) {
+        lines.push('        <tr>');
+
+        for (const contributor of contributors.slice(index, index + CONTRIBUTORS_PER_ROW)) {
+            lines.push(...renderContributorCell(contributor));
+        }
+
+        lines.push('        </tr>');
+    }
+
+    lines.push('    </tbody>', '</table>', END_MARKER);
+
+    return `${lines.join('\n')}\n`;
+}
+
+async function main() {
+    const args = parseArgs(process.argv.slice(2));
+    const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+    const repository = args.repo || process.env.GITHUB_REPOSITORY;
+    const readmePath = args.readme || 'README.md';
+
+    if (!token) {
+        throw new Error('GITHUB_TOKEN or GH_TOKEN is required');
+    }
+
+    if (!repository || !repository.includes('/')) {
+        throw new Error('Repository must be provided via --repo or GITHUB_REPOSITORY');
+    }
+
+    const [owner, repo] = repository.split('/');
+    const readmeContent = await readFile(readmePath, 'utf8');
+    const startIndex = readmeContent.indexOf(START_MARKER);
+    const endIndex = readmeContent.indexOf(END_MARKER);
+
+    if (startIndex === -1 || endIndex === -1 || endIndex <= startIndex) {
+        throw new Error(`Could not find contributors markers in ${readmePath}`);
+    }
+
+    const existingNames = parseExistingNames(readmeContent);
+    const contributors = (await listContributors(owner, repo, token))
+        .filter(user => user.type !== 'Bot' && !user.login.includes('actions-user'))
+        .sort(
+            (left, right) =>
+                right.contributions - left.contributions || left.login.localeCompare(right.login)
+        );
+
+    const contributorsWithNames = [];
+
+    for (const contributor of contributors) {
+        contributorsWithNames.push({
+            ...contributor,
+            name: await resolveDisplayName(contributor.login, existingNames, token)
+        });
+    }
+
+    const updatedBlock = renderContributorsTable(contributorsWithNames);
+    const updatedReadme =
+        readmeContent.slice(0, startIndex) +
+        updatedBlock +
+        readmeContent.slice(endIndex + END_MARKER.length + 1);
+
+    if (updatedReadme === readmeContent) {
+        return;
+    }
+
+    await writeFile(readmePath, updatedReadme, 'utf8');
+}
+
+main().catch(error => {
+    console.error(error.message);
+    process.exitCode = 1;
+});

--- a/.github/scripts/update-contributors-readme.mjs
+++ b/.github/scripts/update-contributors-readme.mjs
@@ -31,6 +31,15 @@ function escapeHtml(value) {
         .replaceAll("'", '&#39;');
 }
 
+function unescapeHtml(value) {
+    return value
+        .replaceAll('&quot;', '"')
+        .replaceAll('&#39;', "'")
+        .replaceAll('&lt;', '<')
+        .replaceAll('&gt;', '>')
+        .replaceAll('&amp;', '&');
+}
+
 async function githubRequest(path, token) {
     const response = await fetch(`https://api.github.com${path}`, {
         headers: {
@@ -81,7 +90,7 @@ function parseExistingNames(readmeContent) {
     let match = contributorCellPattern.exec(existingBlock);
 
     while (match !== null) {
-        namesByLogin.set(match[1], match[2]);
+        namesByLogin.set(match[1], unescapeHtml(match[2]));
         match = contributorCellPattern.exec(existingBlock);
     }
 
@@ -107,7 +116,7 @@ function renderContributorCell(contributor) {
     return [
         '            <td align="center">',
         `                <a href="https://github.com/${login}">`,
-        `                    <img src="${avatarUrl}" width="100;" alt="${login}"/>`,
+        `                    <img src="${avatarUrl}" width="100" alt="${login}"/>`,
         '                    <br />',
         `                    <sub><b>${displayName}</b></sub>`,
         '                </a>',
@@ -131,6 +140,21 @@ function renderContributorsTable(contributors) {
     lines.push('    </tbody>', '</table>', END_MARKER);
 
     return `${lines.join('\n')}\n`;
+}
+
+function sliceTrailingContent(readmeContent, endIndex) {
+    const contentAfterEndMarkerIndex = endIndex + END_MARKER.length;
+    const contentAfterEndMarker = readmeContent.slice(contentAfterEndMarkerIndex);
+
+    if (contentAfterEndMarker.startsWith('\r\n')) {
+        return contentAfterEndMarker.slice(2);
+    }
+
+    if (contentAfterEndMarker.startsWith('\n')) {
+        return contentAfterEndMarker.slice(1);
+    }
+
+    return contentAfterEndMarker;
 }
 
 async function main() {
@@ -164,20 +188,18 @@ async function main() {
                 right.contributions - left.contributions || left.login.localeCompare(right.login)
         );
 
-    const contributorsWithNames = [];
-
-    for (const contributor of contributors) {
-        contributorsWithNames.push({
+    const contributorsWithNames = await Promise.all(
+        contributors.map(async contributor => ({
             ...contributor,
             name: await resolveDisplayName(contributor.login, existingNames, token)
-        });
-    }
+        }))
+    );
 
     const updatedBlock = renderContributorsTable(contributorsWithNames);
     const updatedReadme =
         readmeContent.slice(0, startIndex) +
         updatedBlock +
-        readmeContent.slice(endIndex + END_MARKER.length + 1);
+        sliceTrailingContent(readmeContent, endIndex);
 
     if (updatedReadme === readmeContent) {
         return;

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: update-contributors
+  cancel-in-progress: true
+
 jobs:
   contributors:
     runs-on: ubuntu-latest
@@ -15,7 +19,49 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
-      - name: Contribute List
-        uses: akhilmhdh/contributors-readme-action@v2.3.11
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Update contributors list
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node .github/scripts/update-contributors-readme.mjs
+
+      - name: Check for README changes
+        id: changes
+        run: |
+          if git diff --quiet -- README.md; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create or update contributors PR
+        if: steps.changes.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          branch="automation/contributors-readme"
+          title="docs(contributor): contributors readme action update"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git checkout -B "$branch"
+          git add README.md
+          git commit -m "docs(contributor): stable contributors readme update"
+          git push --force-with-lease origin "$branch"
+
+          pr_number="$(gh pr list --base main --head "$branch" --state open --json number --jq '.[0].number')"
+
+          if [ -z "$pr_number" ]; then
+            gh pr create --base main --head "$branch" --title "$title" --body ""
+            pr_number="$(gh pr list --base main --head "$branch" --state open --json number --jq '.[0].number')"
+          else
+            gh pr edit "$pr_number" --title "$title" --body ""
+          fi
+
+          gh pr edit "$pr_number" --add-label kind/documentation --add-label version/1.0

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -55,11 +55,10 @@ jobs:
           git commit -m "docs(contributor): stable contributors readme update"
           git push --force-with-lease origin "$branch"
 
-          pr_number="$(gh pr list --base main --head "$branch" --state open --json number --jq '.[0].number')"
+          pr_number="$(gh pr list --base main --head "$branch" --state open --json number --jq '.[0].number // empty')"
 
           if [ -z "$pr_number" ]; then
-            gh pr create --base main --head "$branch" --title "$title" --body ""
-            pr_number="$(gh pr list --base main --head "$branch" --state open --json number --jq '.[0].number')"
+            pr_number="$(gh pr create --base main --head "$branch" --title "$title" --body "" --json number --jq '.number')"
           else
             gh pr edit "$pr_number" --title "$title" --body ""
           fi

--- a/README.md
+++ b/README.md
@@ -292,42 +292,42 @@ VSAG referenced the following works during its implementation:
         <tr>
             <td align="center">
                 <a href="https://github.com/LHT129">
-                    <img src="https://avatars.githubusercontent.com/u/176897537?v=4" width="100;" alt="LHT129"/>
+                    <img src="https://avatars.githubusercontent.com/u/176897537?v=4" width="100" alt="LHT129"/>
                     <br />
                     <sub><b>LHT129</b></sub>
                 </a>
             </td>
             <td align="center">
                 <a href="https://github.com/inabao">
-                    <img src="https://avatars.githubusercontent.com/u/37021995?v=4" width="100;" alt="inabao"/>
+                    <img src="https://avatars.githubusercontent.com/u/37021995?v=4" width="100" alt="inabao"/>
                     <br />
                     <sub><b>inabao</b></sub>
                 </a>
             </td>
             <td align="center">
                 <a href="https://github.com/wxyucs">
-                    <img src="https://avatars.githubusercontent.com/u/12595343?v=4" width="100;" alt="wxyucs"/>
+                    <img src="https://avatars.githubusercontent.com/u/12595343?v=4" width="100" alt="wxyucs"/>
                     <br />
                     <sub><b>Xiangyu Wang</b></sub>
                 </a>
             </td>
             <td align="center">
                 <a href="https://github.com/ShawnShawnYou">
-                    <img src="https://avatars.githubusercontent.com/u/58975154?v=4" width="100;" alt="ShawnShawnYou"/>
+                    <img src="https://avatars.githubusercontent.com/u/58975154?v=4" width="100" alt="ShawnShawnYou"/>
                     <br />
                     <sub><b>ShawnShawnYou</b></sub>
                 </a>
             </td>
             <td align="center">
                 <a href="https://github.com/Coien-rr">
-                    <img src="https://avatars.githubusercontent.com/u/83146518?v=4" width="100;" alt="Coien-rr"/>
+                    <img src="https://avatars.githubusercontent.com/u/83146518?v=4" width="100" alt="Coien-rr"/>
                     <br />
                     <sub><b>Cooper</b></sub>
                 </a>
             </td>
             <td align="center">
                 <a href="https://github.com/Carrot-77">
-                    <img src="https://avatars.githubusercontent.com/u/61344086?v=4" width="100;" alt="Carrot-77"/>
+                    <img src="https://avatars.githubusercontent.com/u/61344086?v=4" width="100" alt="Carrot-77"/>
                     <br />
                     <sub><b>Carrot-77</b></sub>
                 </a>
@@ -336,42 +336,42 @@ VSAG referenced the following works during its implementation:
         <tr>
             <td align="center">
                 <a href="https://github.com/jac0626">
-                    <img src="https://avatars.githubusercontent.com/u/118544282?v=4" width="100;" alt="jac0626"/>
+                    <img src="https://avatars.githubusercontent.com/u/118544282?v=4" width="100" alt="jac0626"/>
                     <br />
                     <sub><b>jac</b></sub>
                 </a>
             </td>
             <td align="center">
                 <a href="https://github.com/nedchu">
-                    <img src="https://avatars.githubusercontent.com/u/11944144?v=4" width="100;" alt="nedchu"/>
+                    <img src="https://avatars.githubusercontent.com/u/11944144?v=4" width="100" alt="nedchu"/>
                     <br />
                     <sub><b>Deming Chu</b></sub>
                 </a>
             </td>
             <td align="center">
                 <a href="https://github.com/shadowao">
-                    <img src="https://avatars.githubusercontent.com/u/13804928?v=4" width="100;" alt="shadowao"/>
+                    <img src="https://avatars.githubusercontent.com/u/13804928?v=4" width="100" alt="shadowao"/>
                     <br />
                     <sub><b>azl</b></sub>
                 </a>
             </td>
             <td align="center">
                 <a href="https://github.com/yulijunzj">
-                    <img src="https://avatars.githubusercontent.com/u/22726506?v=4" width="100;" alt="yulijunzj"/>
+                    <img src="https://avatars.githubusercontent.com/u/22726506?v=4" width="100" alt="yulijunzj"/>
                     <br />
                     <sub><b>L J. Yun</b></sub>
                 </a>
             </td>
             <td align="center">
                 <a href="https://github.com/Roxanne0321">
-                    <img src="https://avatars.githubusercontent.com/u/188438858?v=4" width="100;" alt="Roxanne0321"/>
+                    <img src="https://avatars.githubusercontent.com/u/188438858?v=4" width="100" alt="Roxanne0321"/>
                     <br />
                     <sub><b>Roxanne</b></sub>
                 </a>
             </td>
             <td align="center">
                 <a href="https://github.com/jingyueob">
-                    <img src="https://avatars.githubusercontent.com/u/212298588?v=4" width="100;" alt="jingyueob"/>
+                    <img src="https://avatars.githubusercontent.com/u/212298588?v=4" width="100" alt="jingyueob"/>
                     <br />
                     <sub><b>jingyueob</b></sub>
                 </a>
@@ -380,42 +380,42 @@ VSAG referenced the following works during its implementation:
         <tr>
             <td align="center">
                 <a href="https://github.com/antfin-oss">
-                    <img src="https://avatars.githubusercontent.com/u/48939886?v=4" width="100;" alt="antfin-oss"/>
+                    <img src="https://avatars.githubusercontent.com/u/48939886?v=4" width="100" alt="antfin-oss"/>
                     <br />
                     <sub><b>Ant OSS</b></sub>
                 </a>
             </td>
             <td align="center">
                 <a href="https://github.com/misaka0714">
-                    <img src="https://avatars.githubusercontent.com/u/129934985?v=4" width="100;" alt="misaka0714"/>
+                    <img src="https://avatars.githubusercontent.com/u/129934985?v=4" width="100" alt="misaka0714"/>
                     <br />
                     <sub><b>baoyuan</b></sub>
                 </a>
             </td>
             <td align="center">
                 <a href="https://github.com/Danbaiwq">
-                    <img src="https://avatars.githubusercontent.com/u/212493818?v=4" width="100;" alt="Danbaiwq"/>
+                    <img src="https://avatars.githubusercontent.com/u/212493818?v=4" width="100" alt="Danbaiwq"/>
                     <br />
                     <sub><b>Danbaiwq</b></sub>
                 </a>
             </td>
             <td align="center">
                 <a href="https://github.com/HeHuMing">
-                    <img src="https://avatars.githubusercontent.com/u/223064905?v=4" width="100;" alt="HeHuMing"/>
+                    <img src="https://avatars.githubusercontent.com/u/223064905?v=4" width="100" alt="HeHuMing"/>
                     <br />
                     <sub><b>HuMing He</b></sub>
                 </a>
             </td>
             <td align="center">
                 <a href="https://github.com/jiacai2050">
-                    <img src="https://avatars.githubusercontent.com/u/3848910?v=4" width="100;" alt="jiacai2050"/>
+                    <img src="https://avatars.githubusercontent.com/u/3848910?v=4" width="100" alt="jiacai2050"/>
                     <br />
                     <sub><b>Jiacai Liu</b></sub>
                 </a>
             </td>
             <td align="center">
                 <a href="https://github.com/lyxiong0">
-                    <img src="https://avatars.githubusercontent.com/u/29161506?v=4" width="100;" alt="lyxiong0"/>
+                    <img src="https://avatars.githubusercontent.com/u/29161506?v=4" width="100" alt="lyxiong0"/>
                     <br />
                     <sub><b>Liyao Xiong</b></sub>
                 </a>
@@ -424,42 +424,42 @@ VSAG referenced the following works during its implementation:
         <tr>
             <td align="center">
                 <a href="https://github.com/mly5269">
-                    <img src="https://avatars.githubusercontent.com/u/130448862?v=4" width="100;" alt="mly5269"/>
+                    <img src="https://avatars.githubusercontent.com/u/130448862?v=4" width="100" alt="mly5269"/>
                     <br />
                     <sub><b>mly</b></sub>
                 </a>
             </td>
             <td align="center">
                 <a href="https://github.com/Ningsir">
-                    <img src="https://avatars.githubusercontent.com/u/34963409?v=4" width="100;" alt="Ningsir"/>
+                    <img src="https://avatars.githubusercontent.com/u/34963409?v=4" width="100" alt="Ningsir"/>
                     <br />
                     <sub><b>Xinger</b></sub>
                 </a>
             </td>
             <td align="center">
                 <a href="https://github.com/pkusunjy">
-                    <img src="https://avatars.githubusercontent.com/u/11880269?v=4" width="100;" alt="pkusunjy"/>
+                    <img src="https://avatars.githubusercontent.com/u/11880269?v=4" width="100" alt="pkusunjy"/>
                     <br />
                     <sub><b>Sun Jiayu</b></sub>
                 </a>
             </td>
             <td align="center">
                 <a href="https://github.com/cubicc">
-                    <img src="https://avatars.githubusercontent.com/u/51120671?v=4" width="100;" alt="cubicc"/>
+                    <img src="https://avatars.githubusercontent.com/u/51120671?v=4" width="100" alt="cubicc"/>
                     <br />
                     <sub><b>cubicc</b></sub>
                 </a>
             </td>
             <td align="center">
                 <a href="https://github.com/dasurax">
-                    <img src="https://avatars.githubusercontent.com/u/9841872?v=4" width="100;" alt="dasurax"/>
+                    <img src="https://avatars.githubusercontent.com/u/9841872?v=4" width="100" alt="dasurax"/>
                     <br />
                     <sub><b>dasurax</b></sub>
                 </a>
             </td>
             <td align="center">
                 <a href="https://github.com/hhy3">
-                    <img src="https://avatars.githubusercontent.com/u/44047980?v=4" width="100;" alt="hhy3"/>
+                    <img src="https://avatars.githubusercontent.com/u/44047980?v=4" width="100" alt="hhy3"/>
                     <br />
                     <sub><b>Zihao Wang</b></sub>
                 </a>
@@ -468,35 +468,35 @@ VSAG referenced the following works during its implementation:
         <tr>
             <td align="center">
                 <a href="https://github.com/jiaweizone">
-                    <img src="https://avatars.githubusercontent.com/u/251354?v=4" width="100;" alt="jiaweizone"/>
+                    <img src="https://avatars.githubusercontent.com/u/251354?v=4" width="100" alt="jiaweizone"/>
                     <br />
                     <sub><b>wei</b></sub>
                 </a>
             </td>
             <td align="center">
                 <a href="https://github.com/mingyu-hkustgz">
-                    <img src="https://avatars.githubusercontent.com/u/151442761?v=4" width="100;" alt="mingyu-hkustgz"/>
+                    <img src="https://avatars.githubusercontent.com/u/151442761?v=4" width="100" alt="mingyu-hkustgz"/>
                     <br />
                     <sub><b>Mingyu Yang</b></sub>
                 </a>
             </td>
             <td align="center">
                 <a href="https://github.com/skylhd">
-                    <img src="https://avatars.githubusercontent.com/u/13144296?v=4" width="100;" alt="skylhd"/>
+                    <img src="https://avatars.githubusercontent.com/u/13144296?v=4" width="100" alt="skylhd"/>
                     <br />
                     <sub><b>lhd</b></sub>
                 </a>
             </td>
             <td align="center">
                 <a href="https://github.com/stuBirdFly">
-                    <img src="https://avatars.githubusercontent.com/u/84010733?v=4" width="100;" alt="stuBirdFly"/>
+                    <img src="https://avatars.githubusercontent.com/u/84010733?v=4" width="100" alt="stuBirdFly"/>
                     <br />
                     <sub><b>stuBirdFly</b></sub>
                 </a>
             </td>
             <td align="center">
                 <a href="https://github.com/xfmeng17">
-                    <img src="https://avatars.githubusercontent.com/u/32661584?v=4" width="100;" alt="xfmeng17"/>
+                    <img src="https://avatars.githubusercontent.com/u/32661584?v=4" width="100" alt="xfmeng17"/>
                     <br />
                     <sub><b>XFMENG17</b></sub>
                 </a>

--- a/README.md
+++ b/README.md
@@ -288,8 +288,8 @@ VSAG referenced the following works during its implementation:
 <!-- markdownlint-disable -->
 <!-- readme: contributors -start -->
 <table>
-	<tbody>
-		<tr>
+    <tbody>
+        <tr>
             <td align="center">
                 <a href="https://github.com/LHT129">
                     <img src="https://avatars.githubusercontent.com/u/176897537?v=4" width="100;" alt="LHT129"/>
@@ -326,14 +326,14 @@ VSAG referenced the following works during its implementation:
                 </a>
             </td>
             <td align="center">
-                <a href="https://github.com/nedchu">
-                    <img src="https://avatars.githubusercontent.com/u/11944144?v=4" width="100;" alt="nedchu"/>
+                <a href="https://github.com/Carrot-77">
+                    <img src="https://avatars.githubusercontent.com/u/61344086?v=4" width="100;" alt="Carrot-77"/>
                     <br />
-                    <sub><b>Deming Chu</b></sub>
+                    <sub><b>Carrot-77</b></sub>
                 </a>
             </td>
-		</tr>
-		<tr>
+        </tr>
+        <tr>
             <td align="center">
                 <a href="https://github.com/jac0626">
                     <img src="https://avatars.githubusercontent.com/u/118544282?v=4" width="100;" alt="jac0626"/>
@@ -342,17 +342,17 @@ VSAG referenced the following works during its implementation:
                 </a>
             </td>
             <td align="center">
+                <a href="https://github.com/nedchu">
+                    <img src="https://avatars.githubusercontent.com/u/11944144?v=4" width="100;" alt="nedchu"/>
+                    <br />
+                    <sub><b>Deming Chu</b></sub>
+                </a>
+            </td>
+            <td align="center">
                 <a href="https://github.com/shadowao">
                     <img src="https://avatars.githubusercontent.com/u/13804928?v=4" width="100;" alt="shadowao"/>
                     <br />
                     <sub><b>azl</b></sub>
-                </a>
-            </td>
-            <td align="center">
-                <a href="https://github.com/Carrot-77">
-                    <img src="https://avatars.githubusercontent.com/u/61344086?v=4" width="100;" alt="Carrot-77"/>
-                    <br />
-                    <sub><b>Carrot-77</b></sub>
                 </a>
             </td>
             <td align="center">
@@ -376,8 +376,8 @@ VSAG referenced the following works during its implementation:
                     <sub><b>jingyueob</b></sub>
                 </a>
             </td>
-		</tr>
-		<tr>
+        </tr>
+        <tr>
             <td align="center">
                 <a href="https://github.com/antfin-oss">
                     <img src="https://avatars.githubusercontent.com/u/48939886?v=4" width="100;" alt="antfin-oss"/>
@@ -392,6 +392,36 @@ VSAG referenced the following works during its implementation:
                     <sub><b>baoyuan</b></sub>
                 </a>
             </td>
+            <td align="center">
+                <a href="https://github.com/Danbaiwq">
+                    <img src="https://avatars.githubusercontent.com/u/212493818?v=4" width="100;" alt="Danbaiwq"/>
+                    <br />
+                    <sub><b>Danbaiwq</b></sub>
+                </a>
+            </td>
+            <td align="center">
+                <a href="https://github.com/HeHuMing">
+                    <img src="https://avatars.githubusercontent.com/u/223064905?v=4" width="100;" alt="HeHuMing"/>
+                    <br />
+                    <sub><b>HuMing He</b></sub>
+                </a>
+            </td>
+            <td align="center">
+                <a href="https://github.com/jiacai2050">
+                    <img src="https://avatars.githubusercontent.com/u/3848910?v=4" width="100;" alt="jiacai2050"/>
+                    <br />
+                    <sub><b>Jiacai Liu</b></sub>
+                </a>
+            </td>
+            <td align="center">
+                <a href="https://github.com/lyxiong0">
+                    <img src="https://avatars.githubusercontent.com/u/29161506?v=4" width="100;" alt="lyxiong0"/>
+                    <br />
+                    <sub><b>Liyao Xiong</b></sub>
+                </a>
+            </td>
+        </tr>
+        <tr>
             <td align="center">
                 <a href="https://github.com/mly5269">
                     <img src="https://avatars.githubusercontent.com/u/130448862?v=4" width="100;" alt="mly5269"/>
@@ -414,59 +444,6 @@ VSAG referenced the following works during its implementation:
                 </a>
             </td>
             <td align="center">
-                <a href="https://github.com/lyxiong0">
-                    <img src="https://avatars.githubusercontent.com/u/29161506?v=4" width="100;" alt="lyxiong0"/>
-                    <br />
-                    <sub><b>Liyao Xiong</b></sub>
-                </a>
-            </td>
-		</tr>
-		<tr>
-            <td align="center">
-                <a href="https://github.com/jiacai2050">
-                    <img src="https://avatars.githubusercontent.com/u/3848910?v=4" width="100;" alt="jiacai2050"/>
-                    <br />
-                    <sub><b>Jiacai Liu</b></sub>
-                </a>
-            </td>
-            <td align="center">
-                <a href="https://github.com/HeHuMing">
-                    <img src="https://avatars.githubusercontent.com/u/223064905?v=4" width="100;" alt="HeHuMing"/>
-                    <br />
-                    <sub><b>HuMing He</b></sub>
-                </a>
-            </td>
-            <td align="center">
-                <a href="https://github.com/Danbaiwq">
-                    <img src="https://avatars.githubusercontent.com/u/212493818?v=4" width="100;" alt="Danbaiwq"/>
-                    <br />
-                    <sub><b>Danbaiwq</b></sub>
-                </a>
-            </td>
-            <td align="center">
-                <a href="https://github.com/mingyu-hkustgz">
-                    <img src="https://avatars.githubusercontent.com/u/151442761?v=4" width="100;" alt="mingyu-hkustgz"/>
-                    <br />
-                    <sub><b>Mingyu Yang</b></sub>
-                </a>
-            </td>
-            <td align="center">
-                <a href="https://github.com/xfmeng17">
-                    <img src="https://avatars.githubusercontent.com/u/32661584?v=4" width="100;" alt="xfmeng17"/>
-                    <br />
-                    <sub><b>XFMENG17</b></sub>
-                </a>
-            </td>
-            <td align="center">
-                <a href="https://github.com/hhy3">
-                    <img src="https://avatars.githubusercontent.com/u/44047980?v=4" width="100;" alt="hhy3"/>
-                    <br />
-                    <sub><b>Zihao Wang</b></sub>
-                </a>
-            </td>
-		</tr>
-		<tr>
-            <td align="center">
                 <a href="https://github.com/cubicc">
                     <img src="https://avatars.githubusercontent.com/u/51120671?v=4" width="100;" alt="cubicc"/>
                     <br />
@@ -478,6 +455,29 @@ VSAG referenced the following works during its implementation:
                     <img src="https://avatars.githubusercontent.com/u/9841872?v=4" width="100;" alt="dasurax"/>
                     <br />
                     <sub><b>dasurax</b></sub>
+                </a>
+            </td>
+            <td align="center">
+                <a href="https://github.com/hhy3">
+                    <img src="https://avatars.githubusercontent.com/u/44047980?v=4" width="100;" alt="hhy3"/>
+                    <br />
+                    <sub><b>Zihao Wang</b></sub>
+                </a>
+            </td>
+        </tr>
+        <tr>
+            <td align="center">
+                <a href="https://github.com/jiaweizone">
+                    <img src="https://avatars.githubusercontent.com/u/251354?v=4" width="100;" alt="jiaweizone"/>
+                    <br />
+                    <sub><b>wei</b></sub>
+                </a>
+            </td>
+            <td align="center">
+                <a href="https://github.com/mingyu-hkustgz">
+                    <img src="https://avatars.githubusercontent.com/u/151442761?v=4" width="100;" alt="mingyu-hkustgz"/>
+                    <br />
+                    <sub><b>Mingyu Yang</b></sub>
                 </a>
             </td>
             <td align="center">
@@ -495,14 +495,14 @@ VSAG referenced the following works during its implementation:
                 </a>
             </td>
             <td align="center">
-                <a href="https://github.com/jiaweizone">
-                    <img src="https://avatars.githubusercontent.com/u/251354?v=4" width="100;" alt="jiaweizone"/>
+                <a href="https://github.com/xfmeng17">
+                    <img src="https://avatars.githubusercontent.com/u/32661584?v=4" width="100;" alt="xfmeng17"/>
                     <br />
-                    <sub><b>wei</b></sub>
+                    <sub><b>XFMENG17</b></sub>
                 </a>
             </td>
-		</tr>
-	<tbody>
+        </tr>
+    </tbody>
 </table>
 <!-- readme: contributors -end -->
 <!-- markdownlint-restore -->


### PR DESCRIPTION
## Summary
- replace the third-party contributors README action with a repo-local updater that applies a stable `contributions desc, login asc` order
- keep contributor display names from the existing README while normalizing the generated table markup once
- update the workflow to reuse a single PR branch and apply required documentation/version labels