### PR TITLE
fix(ci): use pr url to obtain contributors PR number

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -58,7 +58,8 @@ jobs:
           pr_number="$(gh pr list --base main --head "$branch" --state open --json number --jq '.[0].number // empty')"
 
           if [ -z "$pr_number" ]; then
-            pr_number="$(gh pr create --base main --head "$branch" --title "$title" --body "" --json number --jq '.number')"
+            pr_url="$(gh pr create --base main --head "$branch" --title "$title" --body "")"
+            pr_number="${pr_url##*/}"
           else
             gh pr edit "$pr_number" --title "$title" --body ""
           fi


### PR DESCRIPTION
## Summary
- `gh pr create` does not support `--json`/`--jq`, so the contributors workflow added in #1913 failed with `unknown flag: --json` (see [failed run](https://github.com/antgroup/vsag/actions/runs/24814784703/job/72626801795)).
- Capture the PR URL printed by `gh pr create` (its real, documented output) and parse the trailing PR number from it.

## Test Plan
- Locally simulated both branches of the workflow shell with a mock `gh`:
  - new-PR path: `gh pr list` returns empty → `gh pr create` URL parsed to `9999`.
  - existing-PR path: `gh pr list` returns `1234` → `gh pr edit` invoked with `1234` and labels applied.