### PR TITLE
fix(lint): exclude clang-diagnostic-error for GCC-only Sanitize flag

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -20,6 +20,7 @@ Checks:
     - "clang-analyzer-*"
     - "-clang-analyzer-deadcode.DeadStores" # value stored but never read
     - "clang-diagnostic-*"
+    - "-clang-diagnostic-error"
     - "-clang-diagnostic-deprecated-builtins"
     - "modernize-*"
     - "-modernize-use-trailing-return-type"


### PR DESCRIPTION
## Summary
- exclude `clang-diagnostic-error` from `.clang-tidy` checks
- avoid clang-tidy failures triggered by the GCC-only `-fno-var-tracking-assignments` flag in Sanitize builds
- keep ASan lint aligned with the current GCC-specific build configuration