### PR TITLE
fix(ci): fetch remote branch before force-with-lease push

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -50,15 +50,34 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          # Fetch the remote automation branch (if any) so --force-with-lease
-          # has an up-to-date lease ref and does not fail with "stale info".
-          git fetch origin "$branch":"refs/remotes/origin/$branch" || true
+          # Probe the remote for the automation branch. git ls-remote
+          # --exit-code returns 0 when the ref exists, 2 when it does not,
+          # and other codes on real errors (auth/network/etc.) that must
+          # not be silently ignored.
+          set +e
+          git ls-remote --exit-code --heads origin "$branch" >/dev/null
+          ls_remote_rc=$?
+          set -e
+          if [ "$ls_remote_rc" -eq 0 ]; then
+            remote_branch_exists=1
+          elif [ "$ls_remote_rc" -eq 2 ]; then
+            remote_branch_exists=0
+          else
+            echo "git ls-remote failed with exit code $ls_remote_rc" >&2
+            exit "$ls_remote_rc"
+          fi
+
+          if [ "$remote_branch_exists" -eq 1 ]; then
+            # Populate a remote-tracking ref so --force-with-lease has an
+            # up-to-date lease and does not fail with "stale info".
+            git fetch origin "$branch":"refs/remotes/origin/$branch"
+          fi
 
           git checkout -B "$branch"
           git add README.md
           git commit -m "docs(contributor): stable contributors readme update"
 
-          if git rev-parse --verify --quiet "refs/remotes/origin/$branch" >/dev/null; then
+          if [ "$remote_branch_exists" -eq 1 ]; then
             lease_sha="$(git rev-parse "refs/remotes/origin/$branch")"
             git push --force-with-lease="$branch:$lease_sha" origin "$branch"
           else

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -50,10 +50,20 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+          # Fetch the remote automation branch (if any) so --force-with-lease
+          # has an up-to-date lease ref and does not fail with "stale info".
+          git fetch origin "$branch":"refs/remotes/origin/$branch" || true
+
           git checkout -B "$branch"
           git add README.md
           git commit -m "docs(contributor): stable contributors readme update"
-          git push --force-with-lease origin "$branch"
+
+          if git rev-parse --verify --quiet "refs/remotes/origin/$branch" >/dev/null; then
+            lease_sha="$(git rev-parse "refs/remotes/origin/$branch")"
+            git push --force-with-lease="$branch:$lease_sha" origin "$branch"
+          else
+            git push origin "$branch"
+          fi
 
           pr_number="$(gh pr list --base main --head "$branch" --state open --json number --jq '.[0].number // empty')"
 


### PR DESCRIPTION
## Summary
- The contributors workflow failed on main with `! [rejected] automation/contributors-readme -> automation/contributors-readme (stale info)` (see [failed run](https://github.com/antgroup/vsag/actions/runs/24826706635/job/72664433327)).
- Root cause: `actions/checkout@v4` only fetches `main`, so there is no remote-tracking ref for `automation/contributors-readme`. Without a lease ref, `git push --force-with-lease` refuses to push to avoid overwriting unknown remote state. The previous run happened to succeed only because that remote branch did not exist yet; once it exists and diverges from `main`, every subsequent run fails.
- Fix: fetch the remote branch (if any) into `refs/remotes/origin/<branch>`, then use `--force-with-lease=<branch>:<sha>` with the fetched SHA so the push is accepted while still guarding against concurrent updates. Fall back to a plain push when the remote branch does not exist yet.

## Test Plan
Reproduced locally against a temporary bare repo with an isolated `HOME`/`GIT_CONFIG_GLOBAL`:

- Old logic against a divergent remote branch: `! [rejected] ... (stale info)` (matches CI).
- New logic, scenario 1 (remote branch exists and diverged from `main`): fetch + `--force-with-lease=<branch>:<sha>` succeeds; `origin` ends up with the new README.
- New logic, scenario 2 (remote branch does not exist): falls through to plain `git push origin <branch>` and creates it.