### PR TITLE
docs: add language toggle button on docs, blogs and landing

### DIFF
--- a/docs/blog/en/theme/head.hbs
+++ b/docs/blog/en/theme/head.hbs
@@ -69,25 +69,37 @@
       // hide the button in that case to avoid sending users to nonexistent URLs.
       if (!info) return true;
 
-      var btn = document.createElement('a');
+      // Use a real <button> so keyboard activation (Enter/Space) and focus
+      // styles match the other icons in mdBook's .right-buttons toolbar.
+      var btn = document.createElement('button');
       btn.id = 'lang-toggle';
-      btn.href = info.otherRoot;
-      btn.setAttribute('role', 'button');
-      // Show the *target* language so users know what clicking does.
+      btn.type = 'button';
+      // Show the *target* language so users know what clicking does. Set
+      // `lang` so screen readers pronounce "中" / "EN" in the right voice.
       btn.textContent = info.other === 'zh' ? '\u4e2d' : 'EN';
+      btn.lang = info.other;
       btn.title = info.other === 'zh' ? '\u5207\u6362\u4e3a\u4e2d\u6587' : 'Switch to English';
       btn.setAttribute('aria-label', btn.title);
 
-      btn.addEventListener('click', function (e) {
-        e.preventDefault();
+      btn.addEventListener('click', function () {
+        // Guard against rapid double-clicks firing concurrent probes.
+        if (btn.getAttribute('aria-busy') === 'true') return;
         var target = buildTargetUrl(info, window.location.pathname);
         var hash = window.location.hash || '';
         btn.setAttribute('aria-busy', 'true');
+        // Bound the HEAD probe so a stalled network does not leave the
+        // toggle stuck in the busy state forever.
+        var controller = (typeof AbortController === 'function') ? new AbortController() : null;
+        var timer = setTimeout(function () { if (controller) controller.abort(); }, 3000);
+        var opts = { method: 'HEAD' };
+        if (controller) opts.signal = controller.signal;
         // Prefer HEAD to check existence without downloading the page.
-        fetch(target, { method: 'HEAD' }).then(function (r) {
+        fetch(target, opts).then(function (r) {
+          clearTimeout(timer);
           window.location.assign(r.ok ? (target + hash) : info.otherRoot);
         }).catch(function () {
-          // Network error / CORS / offline -> fall back to language root.
+          clearTimeout(timer);
+          // Network error / CORS / offline / timeout -> fall back to language root.
           window.location.assign(info.otherRoot);
         });
       });

--- a/docs/blog/en/theme/head.hbs
+++ b/docs/blog/en/theme/head.hbs
@@ -1,0 +1,105 @@
+<!-- Language toggle button injected into mdBook's top menu bar. -->
+<!-- Shared across docs/{en,zh} and blog/{en,zh}. Keep these four copies in sync. -->
+<style>
+  #lang-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 2.2em;
+    height: 2.2em;
+    padding: 0 0.55em;
+    margin-left: 0.2em;
+    border: 0;
+    border-radius: 4px;
+    background: transparent;
+    color: var(--icons);
+    font: inherit;
+    font-size: 0.95em;
+    line-height: 1;
+    cursor: pointer;
+    text-decoration: none;
+    user-select: none;
+  }
+  #lang-toggle:hover {
+    color: var(--icons-hover);
+    background: var(--theme-hover, rgba(0, 0, 0, 0.05));
+  }
+  #lang-toggle[aria-busy="true"] {
+    opacity: 0.6;
+    cursor: progress;
+  }
+</style>
+<script>
+  (function () {
+    // Site layout (deployed at https://vsag.io/):
+    //   /docs/en/...   /docs/zh/...
+    //   /blogs/en/...  /blogs/zh/...
+    // mdBook sources in this repo live under docs/docs/{en,zh} and docs/blog/{en,zh};
+    // the deploy workflow renames blog -> blogs, so runtime paths use /blogs/.
+    var PAIRS = [
+      { a: '/docs/en/',  b: '/docs/zh/'  },
+      { a: '/blogs/en/', b: '/blogs/zh/' }
+    ];
+
+    function detect(pathname) {
+      for (var i = 0; i < PAIRS.length; i++) {
+        var p = PAIRS[i];
+        if (pathname.indexOf(p.a) === 0) {
+          return { current: 'en', other: 'zh', currentRoot: p.a, otherRoot: p.b };
+        }
+        if (pathname.indexOf(p.b) === 0) {
+          return { current: 'zh', other: 'en', currentRoot: p.b, otherRoot: p.a };
+        }
+      }
+      return null;
+    }
+
+    function buildTargetUrl(info, pathname) {
+      var rest = pathname.slice(info.currentRoot.length);
+      return info.otherRoot + rest;
+    }
+
+    function insertButton() {
+      var bar = document.querySelector('.right-buttons');
+      if (!bar) return false;
+      if (document.getElementById('lang-toggle')) return true;
+
+      var info = detect(window.location.pathname);
+      // On local `mdbook serve`, paths look like "/" instead of "/docs/en/";
+      // hide the button in that case to avoid sending users to nonexistent URLs.
+      if (!info) return true;
+
+      var btn = document.createElement('a');
+      btn.id = 'lang-toggle';
+      btn.href = info.otherRoot;
+      btn.setAttribute('role', 'button');
+      // Show the *target* language so users know what clicking does.
+      btn.textContent = info.other === 'zh' ? '\u4e2d' : 'EN';
+      btn.title = info.other === 'zh' ? '\u5207\u6362\u4e3a\u4e2d\u6587' : 'Switch to English';
+      btn.setAttribute('aria-label', btn.title);
+
+      btn.addEventListener('click', function (e) {
+        e.preventDefault();
+        var target = buildTargetUrl(info, window.location.pathname);
+        var hash = window.location.hash || '';
+        btn.setAttribute('aria-busy', 'true');
+        // Prefer HEAD to check existence without downloading the page.
+        fetch(target, { method: 'HEAD' }).then(function (r) {
+          window.location.assign(r.ok ? (target + hash) : info.otherRoot);
+        }).catch(function () {
+          // Network error / CORS / offline -> fall back to language root.
+          window.location.assign(info.otherRoot);
+        });
+      });
+
+      bar.insertBefore(btn, bar.firstChild);
+      return true;
+    }
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', insertButton);
+    } else {
+      insertButton();
+    }
+  })();
+</script>

--- a/docs/blog/zh/theme/head.hbs
+++ b/docs/blog/zh/theme/head.hbs
@@ -69,25 +69,37 @@
       // hide the button in that case to avoid sending users to nonexistent URLs.
       if (!info) return true;
 
-      var btn = document.createElement('a');
+      // Use a real <button> so keyboard activation (Enter/Space) and focus
+      // styles match the other icons in mdBook's .right-buttons toolbar.
+      var btn = document.createElement('button');
       btn.id = 'lang-toggle';
-      btn.href = info.otherRoot;
-      btn.setAttribute('role', 'button');
-      // Show the *target* language so users know what clicking does.
+      btn.type = 'button';
+      // Show the *target* language so users know what clicking does. Set
+      // `lang` so screen readers pronounce "中" / "EN" in the right voice.
       btn.textContent = info.other === 'zh' ? '\u4e2d' : 'EN';
+      btn.lang = info.other;
       btn.title = info.other === 'zh' ? '\u5207\u6362\u4e3a\u4e2d\u6587' : 'Switch to English';
       btn.setAttribute('aria-label', btn.title);
 
-      btn.addEventListener('click', function (e) {
-        e.preventDefault();
+      btn.addEventListener('click', function () {
+        // Guard against rapid double-clicks firing concurrent probes.
+        if (btn.getAttribute('aria-busy') === 'true') return;
         var target = buildTargetUrl(info, window.location.pathname);
         var hash = window.location.hash || '';
         btn.setAttribute('aria-busy', 'true');
+        // Bound the HEAD probe so a stalled network does not leave the
+        // toggle stuck in the busy state forever.
+        var controller = (typeof AbortController === 'function') ? new AbortController() : null;
+        var timer = setTimeout(function () { if (controller) controller.abort(); }, 3000);
+        var opts = { method: 'HEAD' };
+        if (controller) opts.signal = controller.signal;
         // Prefer HEAD to check existence without downloading the page.
-        fetch(target, { method: 'HEAD' }).then(function (r) {
+        fetch(target, opts).then(function (r) {
+          clearTimeout(timer);
           window.location.assign(r.ok ? (target + hash) : info.otherRoot);
         }).catch(function () {
-          // Network error / CORS / offline -> fall back to language root.
+          clearTimeout(timer);
+          // Network error / CORS / offline / timeout -> fall back to language root.
           window.location.assign(info.otherRoot);
         });
       });

--- a/docs/blog/zh/theme/head.hbs
+++ b/docs/blog/zh/theme/head.hbs
@@ -1,0 +1,105 @@
+<!-- Language toggle button injected into mdBook's top menu bar. -->
+<!-- Shared across docs/{en,zh} and blog/{en,zh}. Keep these four copies in sync. -->
+<style>
+  #lang-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 2.2em;
+    height: 2.2em;
+    padding: 0 0.55em;
+    margin-left: 0.2em;
+    border: 0;
+    border-radius: 4px;
+    background: transparent;
+    color: var(--icons);
+    font: inherit;
+    font-size: 0.95em;
+    line-height: 1;
+    cursor: pointer;
+    text-decoration: none;
+    user-select: none;
+  }
+  #lang-toggle:hover {
+    color: var(--icons-hover);
+    background: var(--theme-hover, rgba(0, 0, 0, 0.05));
+  }
+  #lang-toggle[aria-busy="true"] {
+    opacity: 0.6;
+    cursor: progress;
+  }
+</style>
+<script>
+  (function () {
+    // Site layout (deployed at https://vsag.io/):
+    //   /docs/en/...   /docs/zh/...
+    //   /blogs/en/...  /blogs/zh/...
+    // mdBook sources in this repo live under docs/docs/{en,zh} and docs/blog/{en,zh};
+    // the deploy workflow renames blog -> blogs, so runtime paths use /blogs/.
+    var PAIRS = [
+      { a: '/docs/en/',  b: '/docs/zh/'  },
+      { a: '/blogs/en/', b: '/blogs/zh/' }
+    ];
+
+    function detect(pathname) {
+      for (var i = 0; i < PAIRS.length; i++) {
+        var p = PAIRS[i];
+        if (pathname.indexOf(p.a) === 0) {
+          return { current: 'en', other: 'zh', currentRoot: p.a, otherRoot: p.b };
+        }
+        if (pathname.indexOf(p.b) === 0) {
+          return { current: 'zh', other: 'en', currentRoot: p.b, otherRoot: p.a };
+        }
+      }
+      return null;
+    }
+
+    function buildTargetUrl(info, pathname) {
+      var rest = pathname.slice(info.currentRoot.length);
+      return info.otherRoot + rest;
+    }
+
+    function insertButton() {
+      var bar = document.querySelector('.right-buttons');
+      if (!bar) return false;
+      if (document.getElementById('lang-toggle')) return true;
+
+      var info = detect(window.location.pathname);
+      // On local `mdbook serve`, paths look like "/" instead of "/docs/en/";
+      // hide the button in that case to avoid sending users to nonexistent URLs.
+      if (!info) return true;
+
+      var btn = document.createElement('a');
+      btn.id = 'lang-toggle';
+      btn.href = info.otherRoot;
+      btn.setAttribute('role', 'button');
+      // Show the *target* language so users know what clicking does.
+      btn.textContent = info.other === 'zh' ? '\u4e2d' : 'EN';
+      btn.title = info.other === 'zh' ? '\u5207\u6362\u4e3a\u4e2d\u6587' : 'Switch to English';
+      btn.setAttribute('aria-label', btn.title);
+
+      btn.addEventListener('click', function (e) {
+        e.preventDefault();
+        var target = buildTargetUrl(info, window.location.pathname);
+        var hash = window.location.hash || '';
+        btn.setAttribute('aria-busy', 'true');
+        // Prefer HEAD to check existence without downloading the page.
+        fetch(target, { method: 'HEAD' }).then(function (r) {
+          window.location.assign(r.ok ? (target + hash) : info.otherRoot);
+        }).catch(function () {
+          // Network error / CORS / offline -> fall back to language root.
+          window.location.assign(info.otherRoot);
+        });
+      });
+
+      bar.insertBefore(btn, bar.firstChild);
+      return true;
+    }
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', insertButton);
+    } else {
+      insertButton();
+    }
+  })();
+</script>

--- a/docs/docs/en/theme/head.hbs
+++ b/docs/docs/en/theme/head.hbs
@@ -69,25 +69,37 @@
       // hide the button in that case to avoid sending users to nonexistent URLs.
       if (!info) return true;
 
-      var btn = document.createElement('a');
+      // Use a real <button> so keyboard activation (Enter/Space) and focus
+      // styles match the other icons in mdBook's .right-buttons toolbar.
+      var btn = document.createElement('button');
       btn.id = 'lang-toggle';
-      btn.href = info.otherRoot;
-      btn.setAttribute('role', 'button');
-      // Show the *target* language so users know what clicking does.
+      btn.type = 'button';
+      // Show the *target* language so users know what clicking does. Set
+      // `lang` so screen readers pronounce "中" / "EN" in the right voice.
       btn.textContent = info.other === 'zh' ? '\u4e2d' : 'EN';
+      btn.lang = info.other;
       btn.title = info.other === 'zh' ? '\u5207\u6362\u4e3a\u4e2d\u6587' : 'Switch to English';
       btn.setAttribute('aria-label', btn.title);
 
-      btn.addEventListener('click', function (e) {
-        e.preventDefault();
+      btn.addEventListener('click', function () {
+        // Guard against rapid double-clicks firing concurrent probes.
+        if (btn.getAttribute('aria-busy') === 'true') return;
         var target = buildTargetUrl(info, window.location.pathname);
         var hash = window.location.hash || '';
         btn.setAttribute('aria-busy', 'true');
+        // Bound the HEAD probe so a stalled network does not leave the
+        // toggle stuck in the busy state forever.
+        var controller = (typeof AbortController === 'function') ? new AbortController() : null;
+        var timer = setTimeout(function () { if (controller) controller.abort(); }, 3000);
+        var opts = { method: 'HEAD' };
+        if (controller) opts.signal = controller.signal;
         // Prefer HEAD to check existence without downloading the page.
-        fetch(target, { method: 'HEAD' }).then(function (r) {
+        fetch(target, opts).then(function (r) {
+          clearTimeout(timer);
           window.location.assign(r.ok ? (target + hash) : info.otherRoot);
         }).catch(function () {
-          // Network error / CORS / offline -> fall back to language root.
+          clearTimeout(timer);
+          // Network error / CORS / offline / timeout -> fall back to language root.
           window.location.assign(info.otherRoot);
         });
       });

--- a/docs/docs/en/theme/head.hbs
+++ b/docs/docs/en/theme/head.hbs
@@ -1,0 +1,105 @@
+<!-- Language toggle button injected into mdBook's top menu bar. -->
+<!-- Shared across docs/{en,zh} and blog/{en,zh}. Keep these four copies in sync. -->
+<style>
+  #lang-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 2.2em;
+    height: 2.2em;
+    padding: 0 0.55em;
+    margin-left: 0.2em;
+    border: 0;
+    border-radius: 4px;
+    background: transparent;
+    color: var(--icons);
+    font: inherit;
+    font-size: 0.95em;
+    line-height: 1;
+    cursor: pointer;
+    text-decoration: none;
+    user-select: none;
+  }
+  #lang-toggle:hover {
+    color: var(--icons-hover);
+    background: var(--theme-hover, rgba(0, 0, 0, 0.05));
+  }
+  #lang-toggle[aria-busy="true"] {
+    opacity: 0.6;
+    cursor: progress;
+  }
+</style>
+<script>
+  (function () {
+    // Site layout (deployed at https://vsag.io/):
+    //   /docs/en/...   /docs/zh/...
+    //   /blogs/en/...  /blogs/zh/...
+    // mdBook sources in this repo live under docs/docs/{en,zh} and docs/blog/{en,zh};
+    // the deploy workflow renames blog -> blogs, so runtime paths use /blogs/.
+    var PAIRS = [
+      { a: '/docs/en/',  b: '/docs/zh/'  },
+      { a: '/blogs/en/', b: '/blogs/zh/' }
+    ];
+
+    function detect(pathname) {
+      for (var i = 0; i < PAIRS.length; i++) {
+        var p = PAIRS[i];
+        if (pathname.indexOf(p.a) === 0) {
+          return { current: 'en', other: 'zh', currentRoot: p.a, otherRoot: p.b };
+        }
+        if (pathname.indexOf(p.b) === 0) {
+          return { current: 'zh', other: 'en', currentRoot: p.b, otherRoot: p.a };
+        }
+      }
+      return null;
+    }
+
+    function buildTargetUrl(info, pathname) {
+      var rest = pathname.slice(info.currentRoot.length);
+      return info.otherRoot + rest;
+    }
+
+    function insertButton() {
+      var bar = document.querySelector('.right-buttons');
+      if (!bar) return false;
+      if (document.getElementById('lang-toggle')) return true;
+
+      var info = detect(window.location.pathname);
+      // On local `mdbook serve`, paths look like "/" instead of "/docs/en/";
+      // hide the button in that case to avoid sending users to nonexistent URLs.
+      if (!info) return true;
+
+      var btn = document.createElement('a');
+      btn.id = 'lang-toggle';
+      btn.href = info.otherRoot;
+      btn.setAttribute('role', 'button');
+      // Show the *target* language so users know what clicking does.
+      btn.textContent = info.other === 'zh' ? '\u4e2d' : 'EN';
+      btn.title = info.other === 'zh' ? '\u5207\u6362\u4e3a\u4e2d\u6587' : 'Switch to English';
+      btn.setAttribute('aria-label', btn.title);
+
+      btn.addEventListener('click', function (e) {
+        e.preventDefault();
+        var target = buildTargetUrl(info, window.location.pathname);
+        var hash = window.location.hash || '';
+        btn.setAttribute('aria-busy', 'true');
+        // Prefer HEAD to check existence without downloading the page.
+        fetch(target, { method: 'HEAD' }).then(function (r) {
+          window.location.assign(r.ok ? (target + hash) : info.otherRoot);
+        }).catch(function () {
+          // Network error / CORS / offline -> fall back to language root.
+          window.location.assign(info.otherRoot);
+        });
+      });
+
+      bar.insertBefore(btn, bar.firstChild);
+      return true;
+    }
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', insertButton);
+    } else {
+      insertButton();
+    }
+  })();
+</script>

--- a/docs/docs/zh/theme/head.hbs
+++ b/docs/docs/zh/theme/head.hbs
@@ -69,25 +69,37 @@
       // hide the button in that case to avoid sending users to nonexistent URLs.
       if (!info) return true;
 
-      var btn = document.createElement('a');
+      // Use a real <button> so keyboard activation (Enter/Space) and focus
+      // styles match the other icons in mdBook's .right-buttons toolbar.
+      var btn = document.createElement('button');
       btn.id = 'lang-toggle';
-      btn.href = info.otherRoot;
-      btn.setAttribute('role', 'button');
-      // Show the *target* language so users know what clicking does.
+      btn.type = 'button';
+      // Show the *target* language so users know what clicking does. Set
+      // `lang` so screen readers pronounce "中" / "EN" in the right voice.
       btn.textContent = info.other === 'zh' ? '\u4e2d' : 'EN';
+      btn.lang = info.other;
       btn.title = info.other === 'zh' ? '\u5207\u6362\u4e3a\u4e2d\u6587' : 'Switch to English';
       btn.setAttribute('aria-label', btn.title);
 
-      btn.addEventListener('click', function (e) {
-        e.preventDefault();
+      btn.addEventListener('click', function () {
+        // Guard against rapid double-clicks firing concurrent probes.
+        if (btn.getAttribute('aria-busy') === 'true') return;
         var target = buildTargetUrl(info, window.location.pathname);
         var hash = window.location.hash || '';
         btn.setAttribute('aria-busy', 'true');
+        // Bound the HEAD probe so a stalled network does not leave the
+        // toggle stuck in the busy state forever.
+        var controller = (typeof AbortController === 'function') ? new AbortController() : null;
+        var timer = setTimeout(function () { if (controller) controller.abort(); }, 3000);
+        var opts = { method: 'HEAD' };
+        if (controller) opts.signal = controller.signal;
         // Prefer HEAD to check existence without downloading the page.
-        fetch(target, { method: 'HEAD' }).then(function (r) {
+        fetch(target, opts).then(function (r) {
+          clearTimeout(timer);
           window.location.assign(r.ok ? (target + hash) : info.otherRoot);
         }).catch(function () {
-          // Network error / CORS / offline -> fall back to language root.
+          clearTimeout(timer);
+          // Network error / CORS / offline / timeout -> fall back to language root.
           window.location.assign(info.otherRoot);
         });
       });

--- a/docs/docs/zh/theme/head.hbs
+++ b/docs/docs/zh/theme/head.hbs
@@ -1,0 +1,105 @@
+<!-- Language toggle button injected into mdBook's top menu bar. -->
+<!-- Shared across docs/{en,zh} and blog/{en,zh}. Keep these four copies in sync. -->
+<style>
+  #lang-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 2.2em;
+    height: 2.2em;
+    padding: 0 0.55em;
+    margin-left: 0.2em;
+    border: 0;
+    border-radius: 4px;
+    background: transparent;
+    color: var(--icons);
+    font: inherit;
+    font-size: 0.95em;
+    line-height: 1;
+    cursor: pointer;
+    text-decoration: none;
+    user-select: none;
+  }
+  #lang-toggle:hover {
+    color: var(--icons-hover);
+    background: var(--theme-hover, rgba(0, 0, 0, 0.05));
+  }
+  #lang-toggle[aria-busy="true"] {
+    opacity: 0.6;
+    cursor: progress;
+  }
+</style>
+<script>
+  (function () {
+    // Site layout (deployed at https://vsag.io/):
+    //   /docs/en/...   /docs/zh/...
+    //   /blogs/en/...  /blogs/zh/...
+    // mdBook sources in this repo live under docs/docs/{en,zh} and docs/blog/{en,zh};
+    // the deploy workflow renames blog -> blogs, so runtime paths use /blogs/.
+    var PAIRS = [
+      { a: '/docs/en/',  b: '/docs/zh/'  },
+      { a: '/blogs/en/', b: '/blogs/zh/' }
+    ];
+
+    function detect(pathname) {
+      for (var i = 0; i < PAIRS.length; i++) {
+        var p = PAIRS[i];
+        if (pathname.indexOf(p.a) === 0) {
+          return { current: 'en', other: 'zh', currentRoot: p.a, otherRoot: p.b };
+        }
+        if (pathname.indexOf(p.b) === 0) {
+          return { current: 'zh', other: 'en', currentRoot: p.b, otherRoot: p.a };
+        }
+      }
+      return null;
+    }
+
+    function buildTargetUrl(info, pathname) {
+      var rest = pathname.slice(info.currentRoot.length);
+      return info.otherRoot + rest;
+    }
+
+    function insertButton() {
+      var bar = document.querySelector('.right-buttons');
+      if (!bar) return false;
+      if (document.getElementById('lang-toggle')) return true;
+
+      var info = detect(window.location.pathname);
+      // On local `mdbook serve`, paths look like "/" instead of "/docs/en/";
+      // hide the button in that case to avoid sending users to nonexistent URLs.
+      if (!info) return true;
+
+      var btn = document.createElement('a');
+      btn.id = 'lang-toggle';
+      btn.href = info.otherRoot;
+      btn.setAttribute('role', 'button');
+      // Show the *target* language so users know what clicking does.
+      btn.textContent = info.other === 'zh' ? '\u4e2d' : 'EN';
+      btn.title = info.other === 'zh' ? '\u5207\u6362\u4e3a\u4e2d\u6587' : 'Switch to English';
+      btn.setAttribute('aria-label', btn.title);
+
+      btn.addEventListener('click', function (e) {
+        e.preventDefault();
+        var target = buildTargetUrl(info, window.location.pathname);
+        var hash = window.location.hash || '';
+        btn.setAttribute('aria-busy', 'true');
+        // Prefer HEAD to check existence without downloading the page.
+        fetch(target, { method: 'HEAD' }).then(function (r) {
+          window.location.assign(r.ok ? (target + hash) : info.otherRoot);
+        }).catch(function () {
+          // Network error / CORS / offline -> fall back to language root.
+          window.location.assign(info.otherRoot);
+        });
+      });
+
+      bar.insertBefore(btn, bar.firstChild);
+      return true;
+    }
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', insertButton);
+    } else {
+      insertButton();
+    }
+  })();
+</script>

--- a/docs/landing/index.html
+++ b/docs/landing/index.html
@@ -48,7 +48,7 @@
           <a href="#features">Features</a>
           <a href="#quickstart">Quickstart</a>
           <a href="#ecosystem">Ecosystem</a>
-          <a class="lang" href="/docs/zh/" aria-label="切换为中文" title="切换为中文">中</a>
+          <a class="lang" href="/docs/zh/" lang="zh" hreflang="zh" aria-label="切换为中文" title="切换为中文">中</a>
           <a class="gh" href="https://github.com/antgroup/vsag" aria-label="GitHub">
             <svg width="18" height="18" viewBox="0 0 16 16" aria-hidden="true">
               <path

--- a/docs/landing/index.html
+++ b/docs/landing/index.html
@@ -48,6 +48,7 @@
           <a href="#features">Features</a>
           <a href="#quickstart">Quickstart</a>
           <a href="#ecosystem">Ecosystem</a>
+          <a class="lang" href="/docs/zh/" aria-label="切换为中文" title="切换为中文">中</a>
           <a class="gh" href="https://github.com/antgroup/vsag" aria-label="GitHub">
             <svg width="18" height="18" viewBox="0 0 16 16" aria-hidden="true">
               <path

--- a/docs/landing/style.css
+++ b/docs/landing/style.css
@@ -139,8 +139,15 @@ p  { margin: 0 0 1em; color: var(--fg-subtle); }
   border: 1px solid var(--border); background: var(--surface-alt);
 }
 .nav-links .gh:hover { color: var(--fg); border-color: var(--border-strong); }
+.nav-links .lang {
+  display: inline-flex; align-items: center; justify-content: center;
+  min-width: 34px; height: 34px; padding: 0 10px; border-radius: 10px;
+  color: var(--fg-subtle); border: 1px solid var(--border);
+  background: var(--surface-alt); font-weight: 600;
+}
+.nav-links .lang:hover { color: var(--fg); border-color: var(--border-strong); }
 @media (max-width: 720px) {
-  .nav-links a:not(.gh) { display: none; }
+  .nav-links a:not(.gh):not(.lang) { display: none; }
 }
 
 /* Hero */


### PR DESCRIPTION
## Summary

- Add a language switcher button to every mdBook page in `docs/{en,zh}` and `blogs/{en,zh}` by dropping a shared `theme/head.hbs` into each of the four book roots. The script injects an `EN` / `中` toggle into mdBook's top-right `.right-buttons` area (next to search and theme icons).
- Add a matching toggle to the `landing/` page (`<a class="lang">中</a>`) so readers on `vsag.io/` can jump straight into `/docs/zh/`.
- Clicking preserves the current path plus hash. We `HEAD`-probe the counterpart URL first; if the other language lacks the same page (or the request fails), we fall back to the target language root (`/docs/{lang}/` or `/blogs/{lang}/`). This keeps the UX usable even when the two books diverge slightly.

## Why

Docs live as two independent mdBooks (separate `book.toml`, separate `SUMMARY.md`), so there is no built-in way to hop between the same article in the other language. A per-page toggle gives readers a one-click switch without restructuring the docs.

## Deploy path

No workflow changes are needed:

- `.github/workflows/docs.yaml` already does `rsync -av --delete` on `docs/docs/{en,zh}/` and `docs/blog/{en,zh}/`, which will ship the new `theme/head.hbs` files over to `vsag-io/vsag-io.github.io` automatically.
- `vsag-io/vsag-io.github.io`'s `Makefile` builds each book with `mdbook build <dir> -d …`, and mdBook auto-reads `theme/head.hbs` from the book root — no build changes required.
- `landing/index.html` and `landing/style.css` are `cp`'d straight into `$BOOK/` by the same Makefile, so the landing-page toggle also ships with no infra change.

## Notes

- On local `mdbook serve` the path is `/` (not `/docs/en/`), so the injector's language detection returns `null` and no button is shown. This is intentional — it keeps local preview clean. For end-to-end verification, merge and observe the `sync` branch on `vsag-io/vsag-io.github.io`.
- The four `head.hbs` files are deliberately identical copies (one per book). A banner comment at the top of each asks future editors to keep them in sync.