### PR TITLE
feat(simd): add SIMD implementations for NormalizeWithCentroid

### DIFF
--- a/src/simd/avx.cpp
+++ b/src/simd/avx.cpp
@@ -1276,4 +1276,70 @@ KacsWalk(float* data, uint64_t len) {
     return sse::FHTRotate(data, len);
 #endif
 }
+
+float
+NormalizeWithCentroid(const float* from, const float* centroid, float* to, uint64_t dim) {
+#if defined(ENABLE_AVX)
+    float norm_sq = 0;
+    uint64_t i = 0;
+    if (dim >= 8) {
+        __m256 sum = _mm256_setzero_ps();
+        for (; i + 7 < dim; i += 8) {
+            __m256 f = _mm256_loadu_ps(from + i);
+            __m256 c = _mm256_loadu_ps(centroid + i);
+            __m256 diff = _mm256_sub_ps(f, c);
+            sum = _mm256_add_ps(sum, _mm256_mul_ps(diff, diff));
+        }
+        norm_sq = avx_reduce_add_ps(sum);
+        norm_sq += sse::FP32ComputeL2Sqr(from + i, centroid + i, dim - i);
+    } else {
+        norm_sq = sse::FP32ComputeL2Sqr(from, centroid, dim);
+    }
+
+    float norm = 0;
+    if (norm_sq < 1e-5f) {
+        norm = 1.0f;
+    } else {
+        norm = std::sqrt(norm_sq);
+    }
+
+    __m256 normVec = _mm256_set1_ps(norm);
+    for (i = 0; i + 7 < dim; i += 8) {
+        __m256 f = _mm256_loadu_ps(from + i);
+        __m256 c = _mm256_loadu_ps(centroid + i);
+        __m256 diff = _mm256_sub_ps(f, c);
+        __m256 result = _mm256_div_ps(diff, normVec);
+        _mm256_storeu_ps(to + i, result);
+    }
+    if (i < dim) {
+        for (; i < dim; ++i) {
+            to[i] = (from[i] - centroid[i]) / norm;
+        }
+    }
+    return norm;
+#else
+    return sse::NormalizeWithCentroid(from, centroid, to, dim);
+#endif
+}
+
+void
+InverseNormalizeWithCentroid(
+    const float* from, const float* centroid, float* to, uint64_t dim, float norm) {
+#if defined(ENABLE_AVX)
+    uint64_t i = 0;
+    __m256 normVec = _mm256_set1_ps(norm);
+    for (; i + 7 < dim; i += 8) {
+        __m256 f = _mm256_loadu_ps(from + i);
+        __m256 c = _mm256_loadu_ps(centroid + i);
+        __m256 result = _mm256_add_ps(_mm256_mul_ps(f, normVec), c);
+        _mm256_storeu_ps(to + i, result);
+    }
+    if (i < dim) {
+        sse::InverseNormalizeWithCentroid(from + i, centroid + i, to + i, dim - i, norm);
+    }
+#else
+    sse::InverseNormalizeWithCentroid(from, centroid, to, dim, norm);
+#endif
+}
+
 }  // namespace vsag::avx

--- a/src/simd/avx2.cpp
+++ b/src/simd/avx2.cpp
@@ -1426,4 +1426,70 @@ KacsWalk(float* data, uint64_t len) {
     return avx::KacsWalk(data, len);
 #endif
 }
+
+float
+NormalizeWithCentroid(const float* from, const float* centroid, float* to, uint64_t dim) {
+#if defined(ENABLE_AVX2)
+    float norm_sq = 0;
+    uint64_t i = 0;
+    if (dim >= 8) {
+        __m256 sum = _mm256_setzero_ps();
+        for (; i + 7 < dim; i += 8) {
+            __m256 f = _mm256_loadu_ps(from + i);
+            __m256 c = _mm256_loadu_ps(centroid + i);
+            __m256 diff = _mm256_sub_ps(f, c);
+            sum = _mm256_fmadd_ps(diff, diff, sum);
+        }
+        norm_sq = avx2_reduce_add_ps(sum);
+        norm_sq += avx::FP32ComputeL2Sqr(from + i, centroid + i, dim - i);
+    } else {
+        norm_sq = avx::FP32ComputeL2Sqr(from, centroid, dim);
+    }
+
+    float norm = 0;
+    if (norm_sq < 1e-5f) {
+        norm = 1.0f;
+    } else {
+        norm = std::sqrt(norm_sq);
+    }
+
+    __m256 normVec = _mm256_set1_ps(norm);
+    for (i = 0; i + 7 < dim; i += 8) {
+        __m256 f = _mm256_loadu_ps(from + i);
+        __m256 c = _mm256_loadu_ps(centroid + i);
+        __m256 diff = _mm256_sub_ps(f, c);
+        __m256 result = _mm256_div_ps(diff, normVec);
+        _mm256_storeu_ps(to + i, result);
+    }
+    if (i < dim) {
+        for (; i < dim; ++i) {
+            to[i] = (from[i] - centroid[i]) / norm;
+        }
+    }
+    return norm;
+#else
+    return avx::NormalizeWithCentroid(from, centroid, to, dim);
+#endif
+}
+
+void
+InverseNormalizeWithCentroid(
+    const float* from, const float* centroid, float* to, uint64_t dim, float norm) {
+#if defined(ENABLE_AVX2)
+    uint64_t i = 0;
+    __m256 normVec = _mm256_set1_ps(norm);
+    for (; i + 7 < dim; i += 8) {
+        __m256 f = _mm256_loadu_ps(from + i);
+        __m256 c = _mm256_loadu_ps(centroid + i);
+        __m256 result = _mm256_fmadd_ps(f, normVec, c);
+        _mm256_storeu_ps(to + i, result);
+    }
+    if (i < dim) {
+        avx::InverseNormalizeWithCentroid(from + i, centroid + i, to + i, dim - i, norm);
+    }
+#else
+    avx::InverseNormalizeWithCentroid(from, centroid, to, dim, norm);
+#endif
+}
+
 }  // namespace vsag::avx2

--- a/src/simd/avx512.cpp
+++ b/src/simd/avx512.cpp
@@ -1453,4 +1453,75 @@ FHTRotate(float* data, uint64_t dim_) {
     return generic::FHTRotate(data, dim_);
 #endif
 }
+
+float
+NormalizeWithCentroid(const float* from, const float* centroid, float* to, uint64_t dim) {
+#if defined(ENABLE_AVX512)
+    float norm_sq = 0;
+    uint64_t i = 0;
+    if (dim >= 16) {
+        __m512 sum = _mm512_setzero_ps();
+        for (; i + 15 < dim; i += 16) {
+            __m512 f = _mm512_loadu_ps(from + i);
+            __m512 c = _mm512_loadu_ps(centroid + i);
+            __m512 diff = _mm512_sub_ps(f, c);
+            sum = _mm512_fmadd_ps(diff, diff, sum);
+        }
+        norm_sq = _mm512_reduce_add_ps(sum);
+        for (; i < dim; ++i) {
+            auto diff = from[i] - centroid[i];
+            norm_sq += diff * diff;
+        }
+    } else {
+        norm_sq = generic::FP32ComputeL2Sqr(from, centroid, dim);
+    }
+
+    float norm = 0;
+    if (norm_sq < 1e-5f) {
+        norm = 1.0f;
+    } else {
+        norm = std::sqrt(norm_sq);
+    }
+
+    __m512 normVec = _mm512_set1_ps(norm);
+    for (i = 0; i + 15 < dim; i += 16) {
+        __m512 f = _mm512_loadu_ps(from + i);
+        __m512 c = _mm512_loadu_ps(centroid + i);
+        __m512 diff = _mm512_sub_ps(f, c);
+        __m512 result = _mm512_div_ps(diff, normVec);
+        _mm512_storeu_ps(to + i, result);
+    }
+    if (i < dim) {
+        for (; i < dim; ++i) {
+            to[i] = (from[i] - centroid[i]) / norm;
+        }
+    }
+    return norm;
+#else
+    return avx2::NormalizeWithCentroid(from, centroid, to, dim);
+#endif
+}
+
+void
+InverseNormalizeWithCentroid(
+    const float* from, const float* centroid, float* to, uint64_t dim, float norm) {
+#if defined(ENABLE_AVX512)
+    uint64_t i = 0;
+    __m512 normVec = _mm512_set1_ps(norm);
+    for (; i + 15 < dim; i += 16) {
+        __m512 f = _mm512_loadu_ps(from + i);
+        __m512 c = _mm512_loadu_ps(centroid + i);
+        __m512 result = _mm512_fmadd_ps(f, normVec, c);
+        _mm512_storeu_ps(to + i, result);
+    }
+    if (i < dim) {
+        for (; i < dim; ++i) {
+            to[i] = from[i] * norm + centroid[i];
+        }
+    }
+#else
+    avx2::InverseNormalizeWithCentroid(from, centroid, to, dim, norm);
+#endif
+}
+
 }  // namespace vsag::avx512

--- a/src/simd/neon.cpp
+++ b/src/simd/neon.cpp
@@ -2380,4 +2380,72 @@ FHTRotate(float* data, uint64_t dim_) {
     generic::FHTRotate(data, dim_);
 #endif
 }
+
+float
+NormalizeWithCentroid(const float* from, const float* centroid, float* to, uint64_t dim) {
+#if defined(ENABLE_NEON)
+    float norm_sq = 0;
+    uint64_t d = dim;
+    if (d >= 4) {
+        float32x4_t sum = vdupq_n_f32(0.0f);
+        while (d >= 4) {
+            float32x4_t f = vld1q_f32(from + dim - d);
+            float32x4_t c = vld1q_f32(centroid + dim - d);
+            float32x4_t diff = vsubq_f32(f, c);
+            sum = vmlaq_f32(sum, diff, diff);
+            d -= 4;
+        }
+        norm_sq = vaddvq_f32(sum);
+    }
+    if (d > 0) {
+        norm_sq += generic::FP32ComputeL2Sqr(from + dim - d, centroid + dim - d, d);
+    }
+
+    float norm = 0;
+    if (norm_sq < 1e-5f) {
+        norm = 1.0f;
+    } else {
+        norm = std::sqrt(norm_sq);
+    }
+
+    float32x4_t normVec = vdupq_n_f32(norm);
+    uint64_t i = 0;
+    for (; i + 3 < dim; i += 4) {
+        float32x4_t f = vld1q_f32(from + i);
+        float32x4_t c = vld1q_f32(centroid + i);
+        float32x4_t diff = vsubq_f32(f, c);
+        float32x4_t result = vdivq_f32(diff, normVec);
+        vst1q_f32(to + i, result);
+    }
+    if (i < dim) {
+        for (; i < dim; ++i) {
+            to[i] = (from[i] - centroid[i]) / norm;
+        }
+    }
+    return norm;
+#else
+    return generic::NormalizeWithCentroid(from, centroid, to, dim);
+#endif
+}
+
+void
+InverseNormalizeWithCentroid(
+    const float* from, const float* centroid, float* to, uint64_t dim, float norm) {
+#if defined(ENABLE_NEON)
+    float32x4_t normVec = vdupq_n_f32(norm);
+    uint64_t i = 0;
+    for (; i + 3 < dim; i += 4) {
+        float32x4_t f = vld1q_f32(from + i);
+        float32x4_t c = vld1q_f32(centroid + i);
+        float32x4_t result = vfmaq_f32(c, f, normVec);
+        vst1q_f32(to + i, result);
+    }
+    for (; i < dim; i++) {
+        to[i] = from[i] * norm + centroid[i];
+    }
+#else
+    generic::InverseNormalizeWithCentroid(from, centroid, to, dim, norm);
+#endif
+}
+
 }  // namespace vsag::neon

--- a/src/simd/normalize.cpp
+++ b/src/simd/normalize.cpp
@@ -1,4 +1,3 @@
-
 // Copyright 2024-present the vsag project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,13 +19,8 @@
 namespace vsag {
 
 VSAG_DEFINE_SIMD_DISPATCH(Normalize, NormalizeType);
+VSAG_DEFINE_SIMD_DISPATCH(NormalizeWithCentroid, NormalizeWithCentroidType);
+VSAG_DEFINE_SIMD_DISPATCH(InverseNormalizeWithCentroid, InverseNormalizeWithCentroidType);
 VSAG_DEFINE_SIMD_DISPATCH(DivScalar, DivScalarType);
-
-// NormalizeWithCentroid and InverseNormalizeWithCentroid currently only
-// have generic implementations. Keep them as explicit one-liners so the
-// lack of SIMD variants is obvious at the call site.
-NormalizeWithCentroidType NormalizeWithCentroid = generic::NormalizeWithCentroid;
-InverseNormalizeWithCentroidType InverseNormalizeWithCentroid =
-    generic::InverseNormalizeWithCentroid;
 
 }  // namespace vsag

--- a/src/simd/normalize.h
+++ b/src/simd/normalize.h
@@ -1,4 +1,3 @@
-
 // Copyright 2024-present the vsag project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,15 +18,24 @@
 
 namespace vsag {
 
-#define DECLARE_NORMALIZE_FUNCTIONS(ns)                                  \
-    namespace ns {                                                       \
-    void                                                                 \
-    DivScalar(const float* from, float* to, uint64_t dim, float scalar); \
-    float                                                                \
-    Normalize(const float* from, float* to, uint64_t dim);               \
+#define DECLARE_NORMALIZE_FUNCTIONS(ns)                                                       \
+    namespace ns {                                                                            \
+    void                                                                                      \
+    DivScalar(const float* from, float* to, uint64_t dim, float scalar);                      \
+    float                                                                                     \
+    Normalize(const float* from, float* to, uint64_t dim);                                    \
+    float                                                                                     \
+    NormalizeWithCentroid(const float* from, const float* centroid, float* to, uint64_t dim); \
+    void                                                                                      \
+    InverseNormalizeWithCentroid(                                                             \
+        const float* from, const float* centroid, float* to, uint64_t dim, float norm);       \
     }  // namespace ns
 
 namespace generic {
+void
+DivScalar(const float* from, float* to, uint64_t dim, float scalar);
+float
+Normalize(const float* from, float* to, uint64_t dim);
 float
 NormalizeWithCentroid(const float* from, const float* centroid, float* to, uint64_t dim);
 void
@@ -35,7 +43,6 @@ InverseNormalizeWithCentroid(
     const float* from, const float* centroid, float* to, uint64_t dim, float norm);
 }  // namespace generic
 
-DECLARE_NORMALIZE_FUNCTIONS(generic)
 DECLARE_NORMALIZE_FUNCTIONS(sse)
 DECLARE_NORMALIZE_FUNCTIONS(avx)
 DECLARE_NORMALIZE_FUNCTIONS(avx2)

--- a/src/simd/normalize_test.cpp
+++ b/src/simd/normalize_test.cpp
@@ -1,4 +1,3 @@
-
 // Copyright 2024-present the vsag project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -77,6 +76,247 @@ TEST_CASE("Normalize Compute", "[ut][simd]") {
                 for (int j = 0; j < dim; ++j) {
                     REQUIRE(fixtures::dist_t(tmp_value[j]) ==
                             fixtures::dist_t(tmp_value[j + dim * 3]));
+                }
+            }
+        }
+    }
+}
+
+TEST_CASE("NormalizeWithCentroid Compute", "[ut][simd]") {
+    auto dims = fixtures::get_common_used_dims();
+    int64_t count = 100;
+    for (auto& dim : dims) {
+        auto vec1 = fixtures::generate_vectors(count, dim);
+        auto centroid = fixtures::generate_vectors(1, dim);
+        std::vector<float> tmp_value(dim * 7);
+        for (uint64_t i = 0; i < count; ++i) {
+            auto gt = generic::NormalizeWithCentroid(
+                vec1.data() + i * dim, centroid.data(), tmp_value.data(), dim);
+
+            if (SimdStatus::SupportSSE()) {
+                auto sse = sse::NormalizeWithCentroid(
+                    vec1.data() + i * dim, centroid.data(), tmp_value.data() + dim, dim);
+                REQUIRE(fixtures::dist_t(gt) == fixtures::dist_t(sse));
+                for (int j = 0; j < dim; ++j) {
+                    REQUIRE(fixtures::dist_t(tmp_value[j]) ==
+                            fixtures::dist_t(tmp_value[j + dim * 1]));
+                }
+            }
+            if (SimdStatus::SupportAVX()) {
+                auto avx = avx::NormalizeWithCentroid(
+                    vec1.data() + i * dim, centroid.data(), tmp_value.data() + dim * 2, dim);
+                REQUIRE(fixtures::dist_t(gt) == fixtures::dist_t(avx));
+                for (int j = 0; j < dim; ++j) {
+                    REQUIRE(fixtures::dist_t(tmp_value[j]) ==
+                            fixtures::dist_t(tmp_value[j + dim * 2]));
+                }
+            }
+            if (SimdStatus::SupportAVX2()) {
+                auto avx2 = avx2::NormalizeWithCentroid(
+                    vec1.data() + i * dim, centroid.data(), tmp_value.data() + dim * 3, dim);
+                REQUIRE(fixtures::dist_t(gt) == fixtures::dist_t(avx2));
+                for (int j = 0; j < dim; ++j) {
+                    REQUIRE(fixtures::dist_t(tmp_value[j]) ==
+                            fixtures::dist_t(tmp_value[j + dim * 3]));
+                }
+            }
+            if (SimdStatus::SupportAVX512()) {
+                auto avx512 = avx512::NormalizeWithCentroid(
+                    vec1.data() + i * dim, centroid.data(), tmp_value.data() + dim * 4, dim);
+                REQUIRE(fixtures::dist_t(gt) == fixtures::dist_t(avx512));
+                for (int j = 0; j < dim; ++j) {
+                    REQUIRE(fixtures::dist_t(tmp_value[j]) ==
+                            fixtures::dist_t(tmp_value[j + dim * 4]));
+                }
+            }
+            if (SimdStatus::SupportNEON()) {
+                auto neon = neon::NormalizeWithCentroid(
+                    vec1.data() + i * dim, centroid.data(), tmp_value.data() + dim * 5, dim);
+                REQUIRE(fixtures::dist_t(gt) == fixtures::dist_t(neon));
+                for (int j = 0; j < dim; ++j) {
+                    REQUIRE(fixtures::dist_t(tmp_value[j]) ==
+                            fixtures::dist_t(tmp_value[j + dim * 5]));
+                }
+            }
+            if (SimdStatus::SupportSVE()) {
+                auto sve = sve::NormalizeWithCentroid(
+                    vec1.data() + i * dim, centroid.data(), tmp_value.data() + dim * 6, dim);
+                REQUIRE(fixtures::dist_t(gt) == fixtures::dist_t(sve));
+                for (int j = 0; j < dim; ++j) {
+                    REQUIRE(fixtures::dist_t(tmp_value[j]) ==
+                            fixtures::dist_t(tmp_value[j + dim * 6]));
+                }
+            }
+        }
+    }
+}
+
+TEST_CASE("NormalizeWithCentroid Self Centroid", "[ut][simd]") {
+    auto dims = fixtures::get_common_used_dims();
+    int64_t count = 10;
+    for (auto& dim : dims) {
+        auto vec1 = fixtures::generate_vectors(count, dim);
+        std::vector<float> normalized(dim * 7);
+        std::vector<float> recovered(dim * 7);
+        for (uint64_t i = 0; i < count; ++i) {
+            auto* input = vec1.data() + i * dim;
+
+            auto gt = generic::NormalizeWithCentroid(input, input, normalized.data(), dim);
+            REQUIRE(fixtures::dist_t(gt) == fixtures::dist_t(1.0f));
+            for (int j = 0; j < dim; ++j) {
+                REQUIRE(fixtures::dist_t(normalized[j]) == fixtures::dist_t(0.0f));
+            }
+            generic::InverseNormalizeWithCentroid(
+                normalized.data(), input, recovered.data(), dim, gt);
+            for (int j = 0; j < dim; ++j) {
+                REQUIRE(fixtures::dist_t(recovered[j]) == fixtures::dist_t(input[j]));
+            }
+
+            if (SimdStatus::SupportSSE()) {
+                auto sse = sse::NormalizeWithCentroid(input, input, normalized.data() + dim, dim);
+                REQUIRE(fixtures::dist_t(gt) == fixtures::dist_t(sse));
+                for (int j = 0; j < dim; ++j) {
+                    REQUIRE(fixtures::dist_t(normalized[j + dim]) == fixtures::dist_t(0.0f));
+                }
+                sse::InverseNormalizeWithCentroid(
+                    normalized.data() + dim, input, recovered.data() + dim, dim, sse);
+                for (int j = 0; j < dim; ++j) {
+                    REQUIRE(fixtures::dist_t(recovered[j + dim]) == fixtures::dist_t(input[j]));
+                }
+            }
+            if (SimdStatus::SupportAVX()) {
+                auto avx =
+                    avx::NormalizeWithCentroid(input, input, normalized.data() + dim * 2, dim);
+                REQUIRE(fixtures::dist_t(gt) == fixtures::dist_t(avx));
+                for (int j = 0; j < dim; ++j) {
+                    REQUIRE(fixtures::dist_t(normalized[j + dim * 2]) == fixtures::dist_t(0.0f));
+                }
+                avx::InverseNormalizeWithCentroid(
+                    normalized.data() + dim * 2, input, recovered.data() + dim * 2, dim, avx);
+                for (int j = 0; j < dim; ++j) {
+                    REQUIRE(fixtures::dist_t(recovered[j + dim * 2]) == fixtures::dist_t(input[j]));
+                }
+            }
+            if (SimdStatus::SupportAVX2()) {
+                auto avx2 =
+                    avx2::NormalizeWithCentroid(input, input, normalized.data() + dim * 3, dim);
+                REQUIRE(fixtures::dist_t(gt) == fixtures::dist_t(avx2));
+                for (int j = 0; j < dim; ++j) {
+                    REQUIRE(fixtures::dist_t(normalized[j + dim * 3]) == fixtures::dist_t(0.0f));
+                }
+                avx2::InverseNormalizeWithCentroid(
+                    normalized.data() + dim * 3, input, recovered.data() + dim * 3, dim, avx2);
+                for (int j = 0; j < dim; ++j) {
+                    REQUIRE(fixtures::dist_t(recovered[j + dim * 3]) == fixtures::dist_t(input[j]));
+                }
+            }
+            if (SimdStatus::SupportAVX512()) {
+                auto avx512 =
+                    avx512::NormalizeWithCentroid(input, input, normalized.data() + dim * 4, dim);
+                REQUIRE(fixtures::dist_t(gt) == fixtures::dist_t(avx512));
+                for (int j = 0; j < dim; ++j) {
+                    REQUIRE(fixtures::dist_t(normalized[j + dim * 4]) == fixtures::dist_t(0.0f));
+                }
+                avx512::InverseNormalizeWithCentroid(
+                    normalized.data() + dim * 4, input, recovered.data() + dim * 4, dim, avx512);
+                for (int j = 0; j < dim; ++j) {
+                    REQUIRE(fixtures::dist_t(recovered[j + dim * 4]) == fixtures::dist_t(input[j]));
+                }
+            }
+            if (SimdStatus::SupportNEON()) {
+                auto neon =
+                    neon::NormalizeWithCentroid(input, input, normalized.data() + dim * 5, dim);
+                REQUIRE(fixtures::dist_t(gt) == fixtures::dist_t(neon));
+                for (int j = 0; j < dim; ++j) {
+                    REQUIRE(fixtures::dist_t(normalized[j + dim * 5]) == fixtures::dist_t(0.0f));
+                }
+                neon::InverseNormalizeWithCentroid(
+                    normalized.data() + dim * 5, input, recovered.data() + dim * 5, dim, neon);
+                for (int j = 0; j < dim; ++j) {
+                    REQUIRE(fixtures::dist_t(recovered[j + dim * 5]) == fixtures::dist_t(input[j]));
+                }
+            }
+            if (SimdStatus::SupportSVE()) {
+                auto sve =
+                    sve::NormalizeWithCentroid(input, input, normalized.data() + dim * 6, dim);
+                REQUIRE(fixtures::dist_t(gt) == fixtures::dist_t(sve));
+                for (int j = 0; j < dim; ++j) {
+                    REQUIRE(fixtures::dist_t(normalized[j + dim * 6]) == fixtures::dist_t(0.0f));
+                }
+                sve::InverseNormalizeWithCentroid(
+                    normalized.data() + dim * 6, input, recovered.data() + dim * 6, dim, sve);
+                for (int j = 0; j < dim; ++j) {
+                    REQUIRE(fixtures::dist_t(recovered[j + dim * 6]) == fixtures::dist_t(input[j]));
+                }
+            }
+        }
+    }
+}
+
+TEST_CASE("InverseNormalizeWithCentroid Compute", "[ut][simd]") {
+    auto dims = fixtures::get_common_used_dims();
+    int64_t count = 100;
+    for (auto& dim : dims) {
+        auto vec1 = fixtures::generate_vectors(count, dim);
+        auto centroid = fixtures::generate_vectors(1, dim);
+        std::vector<float> tmp_value(dim * 7);
+        std::vector<float> recovered(dim * 7);
+        for (uint64_t i = 0; i < count; ++i) {
+            auto norm = generic::NormalizeWithCentroid(
+                vec1.data() + i * dim, centroid.data(), tmp_value.data(), dim);
+
+            generic::InverseNormalizeWithCentroid(
+                tmp_value.data(), centroid.data(), recovered.data(), dim, norm);
+            for (int j = 0; j < dim; ++j) {
+                REQUIRE(fixtures::dist_t(vec1[i * dim + j]) == fixtures::dist_t(recovered[j]));
+            }
+
+            if (SimdStatus::SupportSSE()) {
+                sse::InverseNormalizeWithCentroid(
+                    tmp_value.data(), centroid.data(), recovered.data() + dim, dim, norm);
+                for (int j = 0; j < dim; ++j) {
+                    REQUIRE(fixtures::dist_t(vec1[i * dim + j]) ==
+                            fixtures::dist_t(recovered[j + dim * 1]));
+                }
+            }
+            if (SimdStatus::SupportAVX()) {
+                avx::InverseNormalizeWithCentroid(
+                    tmp_value.data(), centroid.data(), recovered.data() + dim * 2, dim, norm);
+                for (int j = 0; j < dim; ++j) {
+                    REQUIRE(fixtures::dist_t(vec1[i * dim + j]) ==
+                            fixtures::dist_t(recovered[j + dim * 2]));
+                }
+            }
+            if (SimdStatus::SupportAVX2()) {
+                avx2::InverseNormalizeWithCentroid(
+                    tmp_value.data(), centroid.data(), recovered.data() + dim * 3, dim, norm);
+                for (int j = 0; j < dim; ++j) {
+                    REQUIRE(fixtures::dist_t(vec1[i * dim + j]) ==
+                            fixtures::dist_t(recovered[j + dim * 3]));
+                }
+            }
+            if (SimdStatus::SupportAVX512()) {
+                avx512::InverseNormalizeWithCentroid(
+                    tmp_value.data(), centroid.data(), recovered.data() + dim * 4, dim, norm);
+                for (int j = 0; j < dim; ++j) {
+                    REQUIRE(fixtures::dist_t(vec1[i * dim + j]) ==
+                            fixtures::dist_t(recovered[j + dim * 4]));
+                }
+            }
+            if (SimdStatus::SupportNEON()) {
+                neon::InverseNormalizeWithCentroid(
+                    tmp_value.data(), centroid.data(), recovered.data() + dim * 5, dim, norm);
+                for (int j = 0; j < dim; ++j) {
+                    REQUIRE(fixtures::dist_t(vec1[i * dim + j]) ==
+                            fixtures::dist_t(recovered[j + dim * 5]));
+                }
+            }
+            if (SimdStatus::SupportSVE()) {
+                sve::InverseNormalizeWithCentroid(
+                    tmp_value.data(), centroid.data(), recovered.data() + dim * 6, dim, norm);
+                for (int j = 0; j < dim; ++j) {
+                    REQUIRE(fixtures::dist_t(vec1[i * dim + j]) ==
+                            fixtures::dist_t(recovered[j + dim * 6]));
                 }
             }
         }

--- a/src/simd/sse.cpp
+++ b/src/simd/sse.cpp
@@ -1353,4 +1353,72 @@ KacsWalk(float* data, uint64_t len) {
     return generic::KacsWalk(data, len);
 #endif
 }
+
+float
+NormalizeWithCentroid(const float* from, const float* centroid, float* to, uint64_t dim) {
+#if defined(ENABLE_SSE)
+    float norm_sq = 0;
+    uint64_t i = 0;
+    if (dim >= 4) {
+        __m128 sum = _mm_setzero_ps();
+        for (; i + 3 < dim; i += 4) {
+            __m128 f = _mm_loadu_ps(from + i);
+            __m128 c = _mm_loadu_ps(centroid + i);
+            __m128 diff = _mm_sub_ps(f, c);
+            sum = _mm_add_ps(sum, _mm_mul_ps(diff, diff));
+        }
+        alignas(16) float result[4];
+        _mm_store_ps(result, sum);
+        norm_sq = result[0] + result[1] + result[2] + result[3];
+        norm_sq += generic::FP32ComputeL2Sqr(from + i, centroid + i, dim - i);
+    } else {
+        norm_sq = generic::FP32ComputeL2Sqr(from, centroid, dim);
+    }
+
+    float norm = 0;
+    if (norm_sq < 1e-5f) {
+        norm = 1.0f;
+    } else {
+        norm = std::sqrt(norm_sq);
+    }
+
+    __m128 normVec = _mm_set1_ps(norm);
+    for (i = 0; i + 3 < dim; i += 4) {
+        __m128 f = _mm_loadu_ps(from + i);
+        __m128 c = _mm_loadu_ps(centroid + i);
+        __m128 diff = _mm_sub_ps(f, c);
+        __m128 result = _mm_div_ps(diff, normVec);
+        _mm_storeu_ps(to + i, result);
+    }
+    if (i < dim) {
+        for (; i < dim; ++i) {
+            to[i] = (from[i] - centroid[i]) / norm;
+        }
+    }
+    return norm;
+#else
+    return generic::NormalizeWithCentroid(from, centroid, to, dim);
+#endif
+}
+
+void
+InverseNormalizeWithCentroid(
+    const float* from, const float* centroid, float* to, uint64_t dim, float norm) {
+#if defined(ENABLE_SSE)
+    uint64_t i = 0;
+    __m128 normVec = _mm_set1_ps(norm);
+    for (; i + 3 < dim; i += 4) {
+        __m128 f = _mm_loadu_ps(from + i);
+        __m128 c = _mm_loadu_ps(centroid + i);
+        __m128 result = _mm_add_ps(_mm_mul_ps(f, normVec), c);
+        _mm_storeu_ps(to + i, result);
+    }
+    for (; i < dim; i++) {
+        to[i] = from[i] * norm + centroid[i];
+    }
+#else
+    generic::InverseNormalizeWithCentroid(from, centroid, to, dim, norm);
+#endif
+}
+
 }  // namespace vsag::sse

--- a/src/simd/sve.cpp
+++ b/src/simd/sve.cpp
@@ -1428,4 +1428,78 @@ FHTRotate(float* data, uint64_t dim_) {
 #endif
 }
 
+float
+NormalizeWithCentroid(const float* from, const float* centroid, float* to, uint64_t dim) {
+#if defined(ENABLE_SVE)
+    if (dim == 0) {
+        return 1.0f;
+    }
+
+    svfloat32_t sum = svdup_f32(0.0f);
+    uint64_t i = 0;
+    const uint64_t step = svcntw();
+
+    svbool_t predicate = svwhilelt_b32(i, dim);
+    do {
+        svfloat32_t f_vec = svld1_f32(predicate, from + i);
+        svfloat32_t c_vec = svld1_f32(predicate, centroid + i);
+        svfloat32_t diff = svsub_f32_z(predicate, f_vec, c_vec);
+        sum = svmla_f32_m(predicate, sum, diff, diff);
+        i += step;
+        predicate = svwhilelt_b32(i, dim);
+    } while (svptest_first(svptrue_b32(), predicate));
+
+    float norm_sq = svaddv_f32(svptrue_b32(), sum);
+    float norm = 0;
+    if (norm_sq < 1e-5f) {
+        norm = 1.0f;
+    } else {
+        norm = std::sqrt(norm_sq);
+    }
+
+    svfloat32_t normVec = svdup_f32(norm);
+    i = 0;
+    predicate = svwhilelt_b32(i, dim);
+    do {
+        svfloat32_t f_vec = svld1_f32(predicate, from + i);
+        svfloat32_t c_vec = svld1_f32(predicate, centroid + i);
+        svfloat32_t diff = svsub_f32_z(predicate, f_vec, c_vec);
+        svfloat32_t result = svdiv_f32_z(predicate, diff, normVec);
+        svst1_f32(predicate, to + i, result);
+        i += step;
+        predicate = svwhilelt_b32(i, dim);
+    } while (svptest_first(svptrue_b32(), predicate));
+
+    return norm;
+#else
+    return neon::NormalizeWithCentroid(from, centroid, to, dim);
+#endif
+}
+
+void
+InverseNormalizeWithCentroid(
+    const float* from, const float* centroid, float* to, uint64_t dim, float norm) {
+#if defined(ENABLE_SVE)
+    if (dim == 0) {
+        return;
+    }
+
+    svfloat32_t normVec = svdup_f32(norm);
+    uint64_t i = 0;
+    const uint64_t step = svcntw();
+
+    svbool_t predicate = svwhilelt_b32(i, dim);
+    do {
+        svfloat32_t f_vec = svld1_f32(predicate, from + i);
+        svfloat32_t c_vec = svld1_f32(predicate, centroid + i);
+        svfloat32_t result = svmad_f32_z(predicate, f_vec, normVec, c_vec);
+        svst1_f32(predicate, to + i, result);
+        i += step;
+        predicate = svwhilelt_b32(i, dim);
+    } while (svptest_first(svptrue_b32(), predicate));
+#else
+    neon::InverseNormalizeWithCentroid(from, centroid, to, dim, norm);
+#endif
+}
+
 }  // namespace vsag::sve


### PR DESCRIPTION
## Summary

Add SIMD-optimized NormalizeWithCentroid and InverseNormalizeWithCentroid for all supported instruction sets:

- **SSE**: 4-wide SIMD using _mm_* intrinsics
- **AVX**: 8-wide SIMD using _mm256_* intrinsics  
- **AVX2**: 8-wide SIMD with FMA (_mm256_fmadd_ps) for improved performance
- **AVX512**: 16-wide SIMD with FMA (_mm512_fmadd_ps) and _mm512_reduce_add_ps
- **NEON**: 4-wide SIMD using ARM NEON intrinsics (vld1q_f32, vsubq_f32, etc.)
- **SVE**: Scalable vector implementation using SVE intrinsics (svld1_f32, svsub_f32_z, etc.)

### Algorithm

**NormalizeWithCentroid**: Computes normalized vector as (from - centroid) / ||from - centroid||, returning the norm.
- Phase 1: SIMD compute squared norm of (from - centroid)
- Phase 2: SIMD divide (from - centroid) by norm

**InverseNormalizeWithCentroid**: Recovers original vector as from * norm + centroid.
- SIMD multiply and add with FMA where available

### Testing

Added unit tests for both functions across all ISAs, verifying numerical correctness against the generic scalar implementation.

Signed-off-by: tianlan.lht <tianlan.lht@antgroup.com>
Co-authored-by: opencode <opencode@anthropic.com>