### PR TITLE
fix: fallback async_io param and warn when libaio is unavailable

### DIFF
--- a/src/io/async_io_test.cpp
+++ b/src/io/async_io_test.cpp
@@ -17,7 +17,9 @@
 
 #include <memory>
 
+#include "async_io_parameter.h"
 #include "basic_io_test.h"
+#include "buffer_io_parameter.h"
 #include "impl/allocator/safe_allocator.h"
 #include "unittest.h"
 
@@ -52,6 +54,13 @@ TEST_CASE("AsyncIO Parameter", "[ut][AsyncIO]") {
     )";
     auto json = JsonType::Parse(fmt::format(param_str, path));
     auto io_param = IOParameter::GetIOParameterByJson(json);
+#if HAVE_LIBAIO
+    REQUIRE(std::dynamic_pointer_cast<AsyncIOParameter>(io_param) != nullptr);
+    REQUIRE(io_param->ToJson()["type"].GetString() == "async_io");
+#else
+    REQUIRE(std::dynamic_pointer_cast<BufferIOParameter>(io_param) != nullptr);
+    REQUIRE(io_param->ToJson()["type"].GetString() == "buffer_io");
+#endif
     IndexCommonParam common_param;
     common_param.allocator_ = allocator;
     auto io = std::make_unique<AsyncIO>(io_param, common_param);

--- a/src/io/io_parameter.cpp
+++ b/src/io/io_parameter.cpp
@@ -15,8 +15,11 @@
 
 #include "io_parameter.h"
 
+#include <mutex>
+
 #include "async_io_parameter.h"
 #include "buffer_io_parameter.h"
+#include "impl/logger/logger.h"
 #include "inner_string_params.h"
 #include "memory_block_io_parameter.h"
 #include "memory_io_parameter.h"
@@ -24,6 +27,10 @@
 #include "reader_io_parameter.h"
 
 namespace vsag {
+
+namespace {
+std::once_flag async_io_fallback_warn_once;
+}  // namespace
 
 IOParamPtr
 IOParameter::GetIOParameterByJson(const JsonType& json) {
@@ -40,7 +47,14 @@ IOParameter::GetIOParameterByJson(const JsonType& json) {
             io_ptr = std::make_shared<BufferIOParameter>();
             io_ptr->FromJson(json);
         } else if (type_name == IO_TYPE_VALUE_ASYNC_IO) {
+#if HAVE_LIBAIO
             io_ptr = std::make_shared<AsyncIOParameter>();
+#else
+            std::call_once(async_io_fallback_warn_once, []() {
+                logger::warn("libaio is unavailable, async_io is falling back to buffer_io");
+            });
+            io_ptr = std::make_shared<BufferIOParameter>();
+#endif
             io_ptr->FromJson(json);
         } else if (type_name == IO_TYPE_VALUE_MMAP_IO) {
             io_ptr = std::make_shared<MMapIOParameter>();


### PR DESCRIPTION
## Summary
- fallback async_io parameter parsing to BufferIOParameter when libaio is unavailable
- add a one-time warning log to make the async_io -> buffer_io fallback visible
- add regression assertions to cover both HAVE_LIBAIO branches in AsyncIO parameter test

## Why
Without this, fallback behavior can be partially silent and confusing in environments that compile without libaio support.

Fixes #1931