### PR TITLE
docs: reorganize documentation navigation

### DIFF
--- a/docs/docs/en/src/README.md
+++ b/docs/docs/en/src/README.md
@@ -17,10 +17,12 @@ Apache 2.0 license.
 
 ## How to Read This Documentation
 
-- **User Guide** — start here if you are new to VSAG.
-- **Developer Guide** — building from source, running tests, contributing.
-- **Advanced Features** — deep dives into specific capabilities.
-- **Resources** — release notes, community links, parameter reference, benchmarks.
+- **User Guide** — start here if you are new to VSAG: install, create an index, and run search.
+- **Indexes** — compare supported index types and look up their parameters.
+- **Advanced Features** — deep dives into specific search, serialization, memory, and hybrid-index capabilities.
+- **Performance and Tuning** — best practices, `Tune`, benchmarks, and evaluation tooling.
+- **Developer Guide** — building from source, running tests, and contributing.
+- **Resources** — release notes, roadmap, community links, related projects, papers, and contributors.
 
 The Chinese version of the same documentation is available under `docs/docs/zh/`.
 

--- a/docs/docs/en/src/SUMMARY.md
+++ b/docs/docs/en/src/SUMMARY.md
@@ -5,13 +5,14 @@
 # User Guide
 
 - [Installation](guide/installation.md)
-- [k-Nearest Neighbor Search](guide/knn_search.md)
 - [Creating an Index](guide/create_index.md)
+- [k-Nearest Neighbor Search](guide/knn_search.md)
 - [pyvsag](guide/pyvsag.md)
 
 # Indexes
 
 - [Overview](indexes/README.md)
+- [Index Parameters](resources/index_parameters.md)
 - [HGraph](indexes/hgraph.md)
 - [IVF](indexes/ivf.md)
 - [SINDI](indexes/sindi.md)
@@ -27,21 +28,23 @@
 # Advanced Features
 
 - [Range Search](advanced/range_search.md)
-- [Optimizer (Tune)](advanced/optimizer.md)
 - [Serialization](advanced/serialization.md)
 - [Memory Management](advanced/memory.md)
 - [Graph Enhancement](advanced/enhance_graph.md)
 - [Hybrid Memory-Disk Index](advanced/hybrid_index.md)
 
-# Resources
+# Performance and Tuning
 
-- [Release Notes](resources/release_notes.md)
-- [Community](resources/community.md)
-- [Related Projects](resources/related_projects.md)
 - [Best Practices](resources/best_practices.md)
-- [Index Parameters](resources/index_parameters.md)
+- [Optimizer (Tune)](advanced/optimizer.md)
 - [Benchmarks](resources/performance.md)
 - [Evaluation Tool](resources/eval.md)
 
------------
-[Contributors](misc/contributors.md)
+# Resources
+
+- [Release Notes](resources/release_notes.md)
+- [Roadmap](resources/roadmap_2025.md)
+- [Community](resources/community.md)
+- [Related Projects](resources/related_projects.md)
+- [Research Papers](resources/research_papers.md)
+- [Contributors](misc/contributors.md)

--- a/docs/docs/zh/src/README.md
+++ b/docs/docs/zh/src/README.md
@@ -17,6 +17,15 @@ VSAG 使用 C++ 编写，并提供：
 - **灵活的过滤与混合搜索**：支持 bitmap 与 callback 两种过滤方式，以及混合 `(data vector, attribute)` 查询；
 - **易于集成**：提供基于 CMake 的集成方式，详见 [README](https://github.com/antgroup/vsag/blob/main/README.md#integrate-with-cmake)。
 
+## 如何阅读本文档
+
+- **用户指南**：如果你是新用户，请从安装、创建索引和搜索开始。
+- **索引**：比较不同索引类型，并查询索引参数。
+- **高级功能**：深入了解搜索、序列化、内存管理和混合索引能力。
+- **性能与调优**：查看最佳实践、`Tune`、性能参考和评估工具。
+- **开发者指南**：了解源码构建、测试和贡献流程。
+- **资源**：查看版本日志、路线图、社区、关联项目、论文和贡献者信息。
+
 ## Contributing
 
 VSAG 是免费和开源的。你可以在 [GitHub](https://github.com/antgroup/vsag) 上获取到源代码，以及提交错误报告和功能请求到 [GitHub问题跟踪器](https://github.com/antgroup/vsag/issues) 上。VSAG 依靠社区来修复错误和增加功能：如果你想做出贡献，请阅读 [贡献指南](https://github.com/antgroup/vsag/blob/main/CONTRIBUTING.md) 并考虑 [创建合并请求](https://github.com/antgroup/vsag/pulls)。

--- a/docs/docs/zh/src/SUMMARY.md
+++ b/docs/docs/zh/src/SUMMARY.md
@@ -5,13 +5,14 @@
 # 用户指南
 
 - [安装](guide/installation.md)
-- [k-近邻搜索](guide/knn_search.md)
 - [创建索引](guide/create_index.md)
+- [k-近邻搜索](guide/knn_search.md)
 - [pyvsag](guide/pyvsag.md)
 
 # 索引
 
 - [总览](indexes/README.md)
+- [索引参数](resources/index_parameters.md)
 - [HGraph](indexes/hgraph.md)
 - [IVF](indexes/ivf.md)
 - [SINDI](indexes/sindi.md)
@@ -27,11 +28,17 @@
 # 高级功能
 
 - [范围搜索](advanced/range_search.md)
-- [优化器](advanced/optimizer.md)
 - [序列化格式](advanced/serialization.md)
 - [内存管理](advanced/memory.md)
 - [图索引增强](advanced/enhance_graph.md)
 - [内存-磁盘混合索引](advanced/hybrid_index.md)
+
+# 性能与调优
+
+- [最佳实践](resources/best_practices.md)
+- [优化器](advanced/optimizer.md)
+- [标准环境性能参考](resources/performance.md)
+- [性能评估工具](resources/eval.md)
 
 # 资源
 
@@ -40,10 +47,4 @@
 - [开源社区](resources/community.md)
 - [关联项目](resources/related_projects.md)
 - [科研论文](resources/research_papers.md)
-- [最佳实践](resources/best_practices.md)
-- [索引参数](resources/index_parameters.md)
-- [标准环境性能参考](resources/performance.md)
-- [性能评估工具](resources/eval.md)
-
------------
-[贡献者列表](misc/contributors.md)
+- [贡献者列表](misc/contributors.md)


### PR DESCRIPTION
## Summary
- reorder quick-start entries so index creation appears before search
- group parameter reference with index docs
- add a dedicated performance and tuning section and align English/Chinese resource entries

## Testing
- mdbook build docs/docs/zh -d /tmp/vsag-docs-zh
- mdbook build docs/docs/en -d /tmp/vsag-docs-en