### PR TITLE
fix: reduce PGUnorderedMap overhead in label indexes

### DIFF
--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -1244,6 +1244,8 @@ HGraph::deserialize_basic_info_v0_14(StreamReader& reader) {
 
     uint64_t size;
     StreamReader::ReadObj(reader, size);
+    this->label_table_->label_remap_.clear();
+    this->label_table_->label_remap_.reserve(size);
     for (uint64_t i = 0; i < size; ++i) {
         LabelType key;
         StreamReader::ReadObj(reader, key);
@@ -1350,6 +1352,8 @@ HGraph::deserialize_label_info(StreamReader& reader) const {
     StreamReader::ReadVector(reader, this->label_table_->label_table_);
     uint64_t size;
     StreamReader::ReadObj(reader, size);
+    this->label_table_->label_remap_.clear();
+    this->label_table_->label_remap_.reserve(size);
     for (uint64_t i = 0; i < size; ++i) {
         LabelType key;
         StreamReader::ReadObj(reader, key);

--- a/src/algorithm/hnswlib/algorithm_interface.h
+++ b/src/algorithm/hnswlib/algorithm_interface.h
@@ -118,8 +118,8 @@ public:
     virtual uint64_t
     getDeletedCount() = 0;
 
-    virtual vsag::PGUnorderedMap<LabelType, InnerIdType>
-    getDeletedElements() = 0;
+    virtual const vsag::PGUnorderedMap<LabelType, InnerIdType>&
+    getDeletedElements() const = 0;
 
     virtual bool
     isValidLabel(LabelType label) = 0;

--- a/src/algorithm/hnswlib/hnswalg.cpp
+++ b/src/algorithm/hnswlib/hnswalg.cpp
@@ -45,6 +45,8 @@ HierarchicalNSW::HierarchicalNSW(SpaceInterface* s,
       normalize_(normalize),
       label_lookup_(allocator),
       deleted_elements_(allocator) {
+    label_lookup_.max_load_factor(0.75F);
+    deleted_elements_.max_load_factor(0.75F);
     max_elements_ = max_elements;
     num_deleted_ = 0;
     data_size_ = s->get_data_size();
@@ -1122,6 +1124,8 @@ HierarchicalNSW::DeserializeImpl(StreamReader& reader, SpaceInterface* s, uint64
     this->points_locks_->Resize(max_elements);
 
     rev_size_ = 1.0 / mult_;
+    label_lookup_.clear();
+    label_lookup_.reserve(cur_element_count_);
     for (uint64_t i = 0; i < cur_element_count_; i++) {
         label_lookup_[getExternalLabel(i)] = i;
         unsigned int link_list_size;
@@ -1160,6 +1164,8 @@ HierarchicalNSW::DeserializeImpl(StreamReader& reader, SpaceInterface* s, uint64
         }
     }
 
+    num_deleted_ = 0;
+    deleted_elements_.clear();
     for (uint64_t i = 0; i < cur_element_count_; i++) {
         if (isMarkedDeleted(i)) {
             num_deleted_ += 1;

--- a/src/algorithm/hnswlib/hnswalg.h
+++ b/src/algorithm/hnswlib/hnswalg.h
@@ -270,8 +270,8 @@ public:
         return num_deleted_;
     }
 
-    vsag::PGUnorderedMap<LabelType, InnerIdType>
-    getDeletedElements() override {
+    const vsag::PGUnorderedMap<LabelType, InnerIdType>&
+    getDeletedElements() const override {
         return deleted_elements_;
     }
 

--- a/src/impl/label_table.cpp
+++ b/src/impl/label_table.cpp
@@ -42,6 +42,7 @@ LabelTable::LabelTable(Allocator* allocator, bool use_reverse_map, bool compress
       deleted_ids_(allocator),
       hole_list_(0, allocator) {
     (void)compress_redundant_data;
+    label_remap_.max_load_factor(0.75F);
     deleted_ids_filter_ = std::make_shared<RemoveListFilter>(deleted_ids_, delete_ids_mutex_);
 }
 
@@ -149,6 +150,8 @@ void
 LabelTable::Deserialize(StreamReader& reader) {
     StreamReader::ReadVector(reader, label_table_);
     if (use_reverse_map_) {
+        this->label_remap_.clear();
+        this->label_remap_.reserve(label_table_.size());
         for (InnerIdType id = 0; id < label_table_.size(); ++id) {
             this->label_remap_[label_table_[id]] = id;
         }
@@ -169,12 +172,24 @@ LabelTable::Deserialize(StreamReader& reader) {
 void
 LabelTable::MergeOther(const LabelTablePtr& other, const IdMapFunction& id_map) {
     auto other_size = other->GetTotalCount();
-    this->label_table_.resize(total_count_ + other_size);
-    for (int64_t i = 0; i < other_size; ++i) {
-        auto new_label = std::get<1>(id_map(other->label_table_[i]));
-        this->label_table_[i + total_count_] = new_label;
-        this->label_remap_[new_label] = i + total_count_;
+    auto current_total_count = total_count_.load();
+    auto other_size_u = static_cast<uint64_t>(other_size);
+    auto current_total_count_u = static_cast<uint64_t>(current_total_count);
+    this->label_table_.resize(current_total_count_u + other_size_u);
+    if (use_reverse_map_) {
+        this->label_remap_.reserve(this->label_remap_.size() + other_size_u);
+        for (uint64_t i = 0; i < other_size_u; ++i) {
+            auto new_label = std::get<1>(id_map(other->label_table_[i]));
+            auto new_inner_id = static_cast<InnerIdType>(i + current_total_count_u);
+            this->label_table_[i + current_total_count_u] = new_label;
+            this->label_remap_[new_label] = new_inner_id;
+        }
+    } else {
+        for (uint64_t i = 0; i < other_size_u; ++i) {
+            auto new_label = std::get<1>(id_map(other->label_table_[i]));
+            this->label_table_[i + current_total_count_u] = new_label;
+        }
     }
-    total_count_ += other_size;
+    total_count_ += static_cast<int64_t>(other_size_u);
 }
 }  // namespace vsag

--- a/src/impl/label_table.h
+++ b/src/impl/label_table.h
@@ -58,6 +58,7 @@ public:
     SetImmutable() {
         this->use_reverse_map_ = false;
         PGUnorderedMap<LabelType, InnerIdType> empty_remap(allocator_);
+        empty_remap.max_load_factor(0.75F);
         this->label_remap_.swap(empty_remap);
     }
 
@@ -212,6 +213,8 @@ public:
     Deserialize(lvalue_or_rvalue<StreamReader> reader) {
         StreamReader::ReadVector(reader, label_table_);
         if (use_reverse_map_) {
+            this->label_remap_.clear();
+            this->label_remap_.reserve(label_table_.size());
             for (InnerIdType id = 0; id < label_table_.size(); ++id) {
                 this->label_remap_[label_table_[id]] = id;
             }

--- a/src/index/hnsw_test.cpp
+++ b/src/index/hnsw_test.cpp
@@ -1057,7 +1057,8 @@ TEST_CASE("update mark-deleted vector", "[ut][hnsw]") {
     for (auto i = 0; i < delete_size; i++) {
         REQUIRE(alg_hnsw->getCurrentElementCount() == base_size);
         REQUIRE(alg_hnsw->getDeletedCount() == i);
-        REQUIRE(alg_hnsw->getDeletedElements().size() == i);
+        const auto& deleted_elements = alg_hnsw->getDeletedElements();
+        REQUIRE(deleted_elements.size() == i);
 
         alg_hnsw->markDelete(base_ids[i]);
 
@@ -1071,9 +1072,10 @@ TEST_CASE("update mark-deleted vector", "[ut][hnsw]") {
         bool is_deleted = alg_hnsw->isMarkedDeleted(old_label);
         alg_hnsw->updateLabel(old_label, new_label);
         if (is_deleted) {
-            REQUIRE(alg_hnsw->getDeletedElements().count(old_label) == 0);
-            REQUIRE(alg_hnsw->getDeletedElements().count(new_label) != 0);
-            REQUIRE(alg_hnsw->getDeletedElements()[new_label] == old_label);
+            const auto& deleted_elements = alg_hnsw->getDeletedElements();
+            REQUIRE(deleted_elements.count(old_label) == 0);
+            REQUIRE(deleted_elements.count(new_label) != 0);
+            REQUIRE(deleted_elements.at(new_label) == old_label);
         } else {
             REQUIRE(not alg_hnsw->isValidLabel(old_label));
             REQUIRE(alg_hnsw->isValidLabel(new_label));


### PR DESCRIPTION
## Summary
- tune `PGUnorderedMap` load factors for HNSW label maps and `LabelTable` reverse maps
- reserve capacity before rebuilding reverse maps during deserialize and merge paths
- return deleted-element maps by const reference to avoid whole-map copies on read-only access

## Testing
- `cmake -S . -B build-release -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build-release --target vsag -j4`
- `cmake -S . -B build-test -DCMAKE_BUILD_TYPE=Release -DENABLE_TESTS=ON`
- `cmake --build build-test --target unittests -j4`
- `build-test/tests/unittests "update mark-deleted vector"`
- `build-test/tests/unittests "[hnsw][ut]"`

Closes #1939
