### PR TITLE
docs: add Index Analysis page for AnalyzeIndexBySearch and analyze_index tool

### DIFF
--- a/docs/docs/en/src/SUMMARY.md
+++ b/docs/docs/en/src/SUMMARY.md
@@ -39,6 +39,7 @@
 - [Optimizer (Tune)](advanced/optimizer.md)
 - [Benchmarks](resources/performance.md)
 - [Evaluation Tool](resources/eval.md)
+- [Index Analysis Tool](resources/analyze_index.md)
 
 # Resources
 

--- a/docs/docs/en/src/resources/analyze_index.md
+++ b/docs/docs/en/src/resources/analyze_index.md
@@ -1,0 +1,129 @@
+# Index Analysis (`AnalyzeIndexBySearch` & `analyze_index`)
+
+VSAG ships an introspection capability for inspecting an index that has already been built or
+loaded, so you can diagnose recall regressions, quantization quality, graph health and search
+performance **without** rebuilding the index. This capability is exposed in two ways:
+
+- the C++ API `Index::AnalyzeIndexBySearch` (declared in `include/vsag/index.h`);
+- the command-line diagnostic tool `analyze_index`, located under `tools/analyze_index/`.
+
+## The `AnalyzeIndexBySearch` API
+
+```cpp
+// include/vsag/index.h
+virtual std::string
+AnalyzeIndexBySearch(const SearchRequest& request);
+```
+
+- **Input**: a `SearchRequest` (query dataset + `topk` + search parameter JSON).
+- **Output**: a JSON-formatted string containing dynamic, query-driven metrics.
+- **Supported indexes**: currently `HGraph`, `IVF`, and `Pyramid`. Other indexes throw
+  `std::runtime_error("Index not support analyze index by search")`.
+
+It is complementary to `Index::GetStats()`, which reports static structural properties of the
+index without needing query data.
+
+### Static metrics from `GetStats()`
+
+| Metric | Meaning |
+| --- | --- |
+| `total_count` | Total number of vectors in the index |
+| `deleted_count` | Vectors marked for deletion |
+| `connect_components` | Connected components in the proximity graph |
+| `duplicate_rate` | Proportion of duplicate vectors in the dataset |
+| `avg_distance_base` | Average pairwise distance on a sample of base vectors |
+| `recall_base` | Self-recall on a sample of base vectors (sanity check) |
+| `proximity_recall_neighbor` | Recall of neighbor lists vs. the true nearest neighbors |
+| `quantization_bias_ratio` | Bias introduced by quantized distance vs. exact distance |
+| `quantization_inversion_count_rate` | Rate of distance-order inversions caused by quantization |
+
+### Dynamic metrics from `AnalyzeIndexBySearch`
+
+| Metric | Meaning |
+| --- | --- |
+| `recall_query` | Recall on the supplied query set against true nearest neighbors |
+| `avg_distance_query` | Average distance between query vectors and retrieved neighbors |
+| `time_cost_query` | Average per-query latency (milliseconds) |
+| `quantization_bias_ratio` | Quantization bias observed during search |
+| `quantization_inversion_count_rate` | Quantization-induced ordering errors during search |
+
+For graph-based indexes (HGraph, Pyramid) the analyzer additionally inspects degree distribution,
+entry-point quality, sub-index recall, and low-recall hot-spots — these are surfaced through the
+JSON output where applicable.
+
+## The `analyze_index` Tool
+
+`analyze_index` is the user-facing wrapper around the analyzer APIs. It loads a serialized VSAG
+index from disk, prints its metadata and `GetStats()` output, and (optionally) runs
+`AnalyzeIndexBySearch` against a query file.
+
+### Building
+
+Tools are not built by default — enable them explicitly:
+
+```bash
+# via the project Makefile
+VSAG_ENABLE_TOOLS=ON make release
+
+# or directly through CMake
+cmake -S . -B build-release -DCMAKE_BUILD_TYPE=Release -DENABLE_TOOLS=ON
+cmake --build build-release -j
+# Output: ./build-release/tools/analyze_index/analyze_index
+```
+
+### Command-line arguments
+
+| Argument | Alias | Required | Description |
+| --- | --- | --- | --- |
+| `--index_path` | `-i` | **Yes** | Path to the serialized VSAG index file. |
+| `--build_parameter` | `-bp` | No | Build parameters (JSON) used when reloading the index. Defaults to the parameters embedded in the index file. |
+| `--query_path` | `-qp` | No | Binary query dataset path. If omitted, only static analysis is performed. |
+| `--search_parameter` | `-sp` | No | Search parameters (JSON) used during dynamic analysis. |
+| `--topk` | `-k` | No | Top-K for dynamic analysis (default `100`). |
+
+The query file format is the simple binary `(uint32 rows, uint32 cols, float32 data...)` layout
+consumed by `load_query()` in `tools/analyze_index/analyze_index.cpp`.
+
+### Two analysis modes
+
+**1. Static analysis (no query file)**
+
+```bash
+./build-release/tools/analyze_index/analyze_index \
+    --index_path /path/to/my_index.hgraph
+```
+
+Reports the index name, dimension, data type, metric, build parameters, and `GetStats()` JSON.
+
+**2. Static + dynamic analysis**
+
+```bash
+./build-release/tools/analyze_index/analyze_index \
+    --index_path /path/to/my_index.ivf \
+    --query_path /path/to/queries.bin \
+    --search_parameter '{"ivf":{"scan_buckets_count":16}}' \
+    --topk 50
+```
+
+In addition to the static section, prints a `Search Analyze: { ... }` JSON block produced by
+`AnalyzeIndexBySearch`.
+
+## Typical Use Cases
+
+- **Recall regression triage**: confirm whether a drop is caused by quantization
+  (`quantization_*` metrics), graph structure (`connect_components`,
+  `proximity_recall_neighbor`), or query-side parameters (`recall_query` vs. `recall_base`).
+- **Capacity / health checks**: detect duplicated data (`duplicate_rate`), disconnected
+  components, or excessive deletions.
+- **Parameter tuning**: re-run `AnalyzeIndexBySearch` with different `search_parameter` values to
+  pick an operating point that balances `recall_query` and `time_cost_query` — without rebuilding
+  the index.
+- **What-if experiments**: override `--build_parameter` on load to evaluate alternative settings
+  for indexes whose parameters are not embedded in the file.
+
+## References
+
+- API: `Index::AnalyzeIndexBySearch` in `include/vsag/index.h`
+- Implementations: `src/analyzer/{analyzer,hgraph_analyzer,pyramid_analyzer}.h`
+- Tool source: `tools/analyze_index/`
+- Tool README: `tools/analyze_index/README.md`

--- a/docs/docs/en/src/resources/analyze_index.md
+++ b/docs/docs/en/src/resources/analyze_index.md
@@ -17,11 +17,14 @@ AnalyzeIndexBySearch(const SearchRequest& request);
 
 - **Input**: a `SearchRequest` (query dataset + `topk` + search parameter JSON).
 - **Output**: a JSON-formatted string containing dynamic, query-driven metrics.
-- **Supported indexes**: currently `HGraph`, `IVF`, and `Pyramid`. Other indexes throw
-  `std::runtime_error("Index not support analyze index by search")`.
+- **Supported indexes**: currently `HGraph` and `IVF`. `Pyramid` only supports static analysis
+  through `GetStats()` — it does not yet override `AnalyzeIndexBySearch`. Indexes that do not
+  implement this API will throw an exception when called.
 
 It is complementary to `Index::GetStats()`, which reports static structural properties of the
-index without needing query data.
+index without needing query data. For graph-based indexes, additional graph-health details such
+as degree distribution, entry-point quality, sub-index recall and low-recall hot-spots are
+exposed through `GetStats()` rather than through `AnalyzeIndexBySearch`.
 
 ### Static metrics from `GetStats()`
 
@@ -30,7 +33,7 @@ index without needing query data.
 | `total_count` | Total number of vectors in the index |
 | `deleted_count` | Vectors marked for deletion |
 | `connect_components` | Connected components in the proximity graph |
-| `duplicate_rate` | Proportion of duplicate vectors in the dataset |
+| `duplicate_ratio` | Proportion of duplicate vectors in the dataset |
 | `avg_distance_base` | Average pairwise distance on a sample of base vectors |
 | `recall_base` | Self-recall on a sample of base vectors (sanity check) |
 | `proximity_recall_neighbor` | Recall of neighbor lists vs. the true nearest neighbors |
@@ -39,17 +42,27 @@ index without needing query data.
 
 ### Dynamic metrics from `AnalyzeIndexBySearch`
 
+Common query-driven metrics produced by HGraph (IVF currently does **not** emit these recall /
+distance / latency fields — see below):
+
 | Metric | Meaning |
 | --- | --- |
 | `recall_query` | Recall on the supplied query set against true nearest neighbors |
 | `avg_distance_query` | Average distance between query vectors and retrieved neighbors |
 | `time_cost_query` | Average per-query latency (milliseconds) |
-| `quantization_bias_ratio` | Quantization bias observed during search |
-| `quantization_inversion_count_rate` | Quantization-induced ordering errors during search |
 
-For graph-based indexes (HGraph, Pyramid) the analyzer additionally inspects degree distribution,
-entry-point quality, sub-index recall, and low-recall hot-spots — these are surfaced through the
-JSON output where applicable.
+Quantization-related fields differ by index type — they are not unified across implementations:
+
+| Index | Field | Meaning |
+| --- | --- | --- |
+| `HGraph` | `quantization_bias_ratio_query` | Quantization bias observed during search |
+| `HGraph` | `quantization_inversion_count_rate_query` | Quantization-induced ordering errors during search |
+| `IVF` | `quantization_bias_ratio` | Quantization bias observed during search (only when `use_reorder_` is enabled) |
+| `IVF` | `quantization_inversion_count_rate` | Quantization-induced ordering errors during search (only when `use_reorder_` is enabled) |
+
+If you also need degree distribution, entry-point analysis or sub-index quality breakdown, look
+in the `GetStats()` JSON instead — `AnalyzeIndexBySearch` focuses on dynamic, query-driven
+signals.
 
 ## The `analyze_index` Tool
 
@@ -113,7 +126,7 @@ In addition to the static section, prints a `Search Analyze: { ... }` JSON block
 - **Recall regression triage**: confirm whether a drop is caused by quantization
   (`quantization_*` metrics), graph structure (`connect_components`,
   `proximity_recall_neighbor`), or query-side parameters (`recall_query` vs. `recall_base`).
-- **Capacity / health checks**: detect duplicated data (`duplicate_rate`), disconnected
+- **Capacity / health checks**: detect duplicated data (`duplicate_ratio`), disconnected
   components, or excessive deletions.
 - **Parameter tuning**: re-run `AnalyzeIndexBySearch` with different `search_parameter` values to
   pick an operating point that balances `recall_query` and `time_cost_query` — without rebuilding

--- a/docs/docs/zh/src/SUMMARY.md
+++ b/docs/docs/zh/src/SUMMARY.md
@@ -39,6 +39,7 @@
 - [优化器](advanced/optimizer.md)
 - [标准环境性能参考](resources/performance.md)
 - [性能评估工具](resources/eval.md)
+- [索引分析工具](resources/analyze_index.md)
 
 # 资源
 

--- a/docs/docs/zh/src/resources/analyze_index.md
+++ b/docs/docs/zh/src/resources/analyze_index.md
@@ -16,10 +16,12 @@ AnalyzeIndexBySearch(const SearchRequest& request);
 
 - **输入**：`SearchRequest`（查询数据集 + `topk` + 搜索参数 JSON）。
 - **输出**：JSON 字符串，包含基于查询的动态指标。
-- **支持的索引类型**：当前支持 `HGraph`、`IVF`、`Pyramid`。其他索引会抛出
-  `std::runtime_error("Index not support analyze index by search")`。
+- **支持的索引类型**：当前支持 `HGraph` 与 `IVF`。`Pyramid` 仅通过 `GetStats()` 提供静态分析，
+  尚未 override `AnalyzeIndexBySearch`。未实现该接口的索引在调用时会抛出异常。
 
 该接口与 `Index::GetStats()` 互为补充：后者无需查询数据，只输出索引的静态结构指标。
+对于基于图的索引，度分布、入口点质量、子索引召回率以及低召回热点节点等图健康度信息，
+通过 `GetStats()` 而非 `AnalyzeIndexBySearch` 输出。
 
 ### `GetStats()` 输出的静态指标
 
@@ -28,7 +30,7 @@ AnalyzeIndexBySearch(const SearchRequest& request);
 | `total_count` | 索引中向量总数 |
 | `deleted_count` | 被标记为删除的向量数 |
 | `connect_components` | 邻近图中的连通分量数 |
-| `duplicate_rate` | 数据集中重复向量比例 |
+| `duplicate_ratio` | 数据集中重复向量比例 |
 | `avg_distance_base` | 基础数据集采样向量的平均距离 |
 | `recall_base` | 基础数据集采样向量的自召回率（健康度自检） |
 | `proximity_recall_neighbor` | 邻居列表相对真实最近邻的召回率 |
@@ -37,16 +39,25 @@ AnalyzeIndexBySearch(const SearchRequest& request);
 
 ### `AnalyzeIndexBySearch` 输出的动态指标
 
+HGraph 输出的通用查询指标（**IVF 当前不输出** 以下召回 / 距离 / 时延字段，详见下方说明）：
+
 | 指标 | 含义 |
 | --- | --- |
 | `recall_query` | 用户查询集相对真实最近邻的召回率 |
 | `avg_distance_query` | 查询向量与检索结果之间的平均距离 |
 | `time_cost_query` | 平均单次查询耗时（毫秒） |
-| `quantization_bias_ratio` | 搜索阶段观察到的量化偏差 |
-| `quantization_inversion_count_rate` | 搜索阶段量化引起的距离顺序倒置率 |
 
-对于基于图的索引（HGraph、Pyramid），分析器会额外检查度分布、入口点质量、子索引召回率以及
-低召回热点节点等信息，并在适用情况下通过 JSON 输出。
+量化相关字段在不同索引下命名不一致：
+
+| 索引 | 字段 | 含义 |
+| --- | --- | --- |
+| `HGraph` | `quantization_bias_ratio_query` | 搜索阶段观察到的量化偏差 |
+| `HGraph` | `quantization_inversion_count_rate_query` | 搜索阶段量化引起的距离顺序倒置率 |
+| `IVF` | `quantization_bias_ratio` | 搜索阶段观察到的量化偏差（仅在 `use_reorder_` 启用时输出） |
+| `IVF` | `quantization_inversion_count_rate` | 搜索阶段量化引起的距离顺序倒置率（仅在 `use_reorder_` 启用时输出） |
+
+如需度分布、入口点分析或子索引质量分布等图健康度信息，请查看 `GetStats()` 的 JSON 输出——
+`AnalyzeIndexBySearch` 仅关注查询驱动的动态信号。
 
 ## `analyze_index` 工具
 
@@ -108,7 +119,7 @@ cmake --build build-release -j
 - **召回率回归排查**：根据指标定位问题来源——是量化质量（`quantization_*`）、图结构
   （`connect_components`、`proximity_recall_neighbor`），还是查询端参数
   （对比 `recall_query` 与 `recall_base`）。
-- **数据健康度体检**：发现重复数据（`duplicate_rate`）、断连分量或过多删除等情况。
+- **数据健康度体检**：发现重复数据（`duplicate_ratio`）、断连分量或过多删除等情况。
 - **参数调优**：使用不同的 `search_parameter` 反复运行 `AnalyzeIndexBySearch`，
   在 `recall_query` 与 `time_cost_query` 之间选择合适的工作点，无需重建索引。
 - **假设性实验**：通过 `--build_parameter` 在加载时覆盖原始构建参数，对未在文件中嵌入参数的索引

--- a/docs/docs/zh/src/resources/analyze_index.md
+++ b/docs/docs/zh/src/resources/analyze_index.md
@@ -1,0 +1,122 @@
+# 索引分析（`AnalyzeIndexBySearch` 与 `analyze_index`）
+
+VSAG 提供了对**已构建或已加载索引**进行内省诊断的能力，可以在不重建索引的情况下排查召回率回归、
+量化质量、图结构健康度以及查询性能问题。该能力通过两种方式对外暴露：
+
+- C++ 接口 `Index::AnalyzeIndexBySearch`（声明在 `include/vsag/index.h`）；
+- 命令行诊断工具 `analyze_index`，位于 `tools/analyze_index/`。
+
+## `AnalyzeIndexBySearch` 接口
+
+```cpp
+// include/vsag/index.h
+virtual std::string
+AnalyzeIndexBySearch(const SearchRequest& request);
+```
+
+- **输入**：`SearchRequest`（查询数据集 + `topk` + 搜索参数 JSON）。
+- **输出**：JSON 字符串，包含基于查询的动态指标。
+- **支持的索引类型**：当前支持 `HGraph`、`IVF`、`Pyramid`。其他索引会抛出
+  `std::runtime_error("Index not support analyze index by search")`。
+
+该接口与 `Index::GetStats()` 互为补充：后者无需查询数据，只输出索引的静态结构指标。
+
+### `GetStats()` 输出的静态指标
+
+| 指标 | 含义 |
+| --- | --- |
+| `total_count` | 索引中向量总数 |
+| `deleted_count` | 被标记为删除的向量数 |
+| `connect_components` | 邻近图中的连通分量数 |
+| `duplicate_rate` | 数据集中重复向量比例 |
+| `avg_distance_base` | 基础数据集采样向量的平均距离 |
+| `recall_base` | 基础数据集采样向量的自召回率（健康度自检） |
+| `proximity_recall_neighbor` | 邻居列表相对真实最近邻的召回率 |
+| `quantization_bias_ratio` | 量化距离相对精确距离的偏差比率 |
+| `quantization_inversion_count_rate` | 量化导致的距离顺序倒置比率 |
+
+### `AnalyzeIndexBySearch` 输出的动态指标
+
+| 指标 | 含义 |
+| --- | --- |
+| `recall_query` | 用户查询集相对真实最近邻的召回率 |
+| `avg_distance_query` | 查询向量与检索结果之间的平均距离 |
+| `time_cost_query` | 平均单次查询耗时（毫秒） |
+| `quantization_bias_ratio` | 搜索阶段观察到的量化偏差 |
+| `quantization_inversion_count_rate` | 搜索阶段量化引起的距离顺序倒置率 |
+
+对于基于图的索引（HGraph、Pyramid），分析器会额外检查度分布、入口点质量、子索引召回率以及
+低召回热点节点等信息，并在适用情况下通过 JSON 输出。
+
+## `analyze_index` 工具
+
+`analyze_index` 是上述分析接口的命令行封装。它从磁盘加载一个已序列化的 VSAG 索引，
+打印元数据与 `GetStats()` 结果，并可选地针对查询文件运行 `AnalyzeIndexBySearch`。
+
+### 构建
+
+`tools/` 默认不会编译，需要显式开启：
+
+```bash
+# 通过项目 Makefile
+VSAG_ENABLE_TOOLS=ON make release
+
+# 也可直接通过 CMake
+cmake -S . -B build-release -DCMAKE_BUILD_TYPE=Release -DENABLE_TOOLS=ON
+cmake --build build-release -j
+# 产物：./build-release/tools/analyze_index/analyze_index
+```
+
+### 命令行参数
+
+| 参数 | 缩写 | 是否必需 | 描述 |
+| --- | --- | --- | --- |
+| `--index_path` | `-i` | **是** | 待分析的 VSAG 索引文件路径。 |
+| `--build_parameter` | `-bp` | 否 | 加载索引时使用的构建参数（JSON）。默认使用索引文件内嵌的原始参数。 |
+| `--query_path` | `-qp` | 否 | 查询数据集路径。如果未提供，则只进行静态分析。 |
+| `--search_parameter` | `-sp` | 否 | 动态分析时使用的搜索参数（JSON）。 |
+| `--topk` | `-k` | 否 | 动态分析的 top-K（默认 `100`）。 |
+
+查询文件格式为 `tools/analyze_index/analyze_index.cpp` 中 `load_query()` 所读取的简单二进制
+布局：`(uint32 rows, uint32 cols, float32 data...)`。
+
+### 两种分析模式
+
+**1. 仅静态分析（不提供查询文件）**
+
+```bash
+./build-release/tools/analyze_index/analyze_index \
+    --index_path /path/to/my_index.hgraph
+```
+
+输出索引名、维度、数据类型、距离度量、构建参数，以及 `GetStats()` 的 JSON。
+
+**2. 静态 + 动态分析**
+
+```bash
+./build-release/tools/analyze_index/analyze_index \
+    --index_path /path/to/my_index.ivf \
+    --query_path /path/to/queries.bin \
+    --search_parameter '{"ivf":{"scan_buckets_count":16}}' \
+    --topk 50
+```
+
+除静态信息外，还会额外打印由 `AnalyzeIndexBySearch` 产出的 `Search Analyze: { ... }` JSON 块。
+
+## 典型使用场景
+
+- **召回率回归排查**：根据指标定位问题来源——是量化质量（`quantization_*`）、图结构
+  （`connect_components`、`proximity_recall_neighbor`），还是查询端参数
+  （对比 `recall_query` 与 `recall_base`）。
+- **数据健康度体检**：发现重复数据（`duplicate_rate`）、断连分量或过多删除等情况。
+- **参数调优**：使用不同的 `search_parameter` 反复运行 `AnalyzeIndexBySearch`，
+  在 `recall_query` 与 `time_cost_query` 之间选择合适的工作点，无需重建索引。
+- **假设性实验**：通过 `--build_parameter` 在加载时覆盖原始构建参数，对未在文件中嵌入参数的索引
+  进行不同配置的评估。
+
+## 参考
+
+- 接口：`include/vsag/index.h` 中的 `Index::AnalyzeIndexBySearch`
+- 实现：`src/analyzer/{analyzer,hgraph_analyzer,pyramid_analyzer}.h`
+- 工具源码：`tools/analyze_index/`
+- 工具说明：`tools/analyze_index/README_zh.md`

--- a/tools/analyze_index/analyze_index.cpp
+++ b/tools/analyze_index/analyze_index.cpp
@@ -77,11 +77,11 @@ parse_args(argparse::ArgumentParser& parser, int argc, char** argv) {
             "if not set, will use default parameter in index file");
 
     parser.add_argument<std::string>("--query_path", "-qp")
-        .default_value(DEFAULT_SEARCH_PARAM)
+        .default_value(EMPTY_QUERY_PATH)
         .help("The query dataset path, if not set, will not do query analysis");
 
     parser.add_argument<std::string>("--search_parameter", "-sp")
-        .default_value(EMPTY_QUERY_PATH)
+        .default_value(DEFAULT_SEARCH_PARAM)
         .help("The parameter for search, if not set, will use default parameter");
 
     parser.add_argument("--topk", "-k")


### PR DESCRIPTION
## Summary

- Add a new documentation page describing the index introspection capability exposed via the `Index::AnalyzeIndexBySearch` C++ API (`include/vsag/index.h`) and the `analyze_index` CLI tool (`tools/analyze_index/`).
- Cover supported indexes (HGraph / IVF / Pyramid), static metrics from `GetStats()` vs. dynamic metrics from `AnalyzeIndexBySearch`, build instructions, command-line arguments, the two analysis modes (static-only and static+dynamic), and typical diagnosis scenarios (recall regression triage, health checks, parameter tuning, what-if experiments).
- Pages are provided in both English (`docs/docs/en/src/resources/analyze_index.md`) and Chinese (`docs/docs/zh/src/resources/analyze_index.md`), and registered under the *Performance and Tuning* / *性能与调优* section of each `SUMMARY.md`, next to the existing `eval.md` entry.

## Notes for reviewers

- Documentation-only change — no source code touched.
- Suggested labels: `kind/documentation` and the appropriate `version/*` label per the repo's PR-label policy.