### PR TITLE
feat(python): unify FP16/BF16 dense binding interfaces

### DIFF
--- a/examples/python/104_index_hgraph_fp16_bf16.py
+++ b/examples/python/104_index_hgraph_fp16_bf16.py
@@ -1,0 +1,141 @@
+#  Copyright 2024-present the vsag project
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import json
+
+import numpy as np
+import pyvsag
+
+
+def float32_to_bfloat16_bits(f32_array):
+    """Convert float32 numpy array to raw bfloat16 bits (uint16)."""
+    f32_view = f32_array.view(np.uint32)
+    return (f32_view >> 16).astype(np.uint16)
+
+
+def fp16_example():
+    dim = 128
+    num_elements = 10000
+    query_elements = 1
+
+    ids = np.arange(num_elements, dtype=np.int64)
+    data_f32 = np.random.random((num_elements, dim)).astype(np.float32)
+    data_fp16 = data_f32.astype(np.float16)
+    data_fp16_flat = data_fp16.reshape(-1)
+
+    query_f32 = np.random.random((query_elements, dim)).astype(np.float32)
+    query_fp16 = query_f32.astype(np.float16)
+
+    index_params = json.dumps(
+        {
+            "dtype": "float16",
+            "metric_type": "l2",
+            "dim": dim,
+            "index_param": {
+                "base_quantization_type": "fp16",
+                "max_degree": 26,
+                "ef_construction": 100,
+                "alpha": 1.2,
+            },
+        }
+    )
+
+    print("[FP16] Create hgraph index")
+    index = pyvsag.Index("hgraph", index_params)
+
+    print("[FP16] Build hgraph index")
+    index.build(vectors=data_fp16_flat, ids=ids, num_elements=num_elements, dim=dim)
+
+    print("[FP16] KNN search hgraph index")
+    search_params = json.dumps({"hgraph": {"ef_search": 100}})
+    for q in query_fp16:
+        result_ids, result_dists = index.knn_search(vector=q, k=10, parameters=search_params)
+        print("result_ids:", result_ids)
+        print("result_dists:", result_dists)
+
+    print("[FP16] Range search hgraph index")
+    for q in query_fp16:
+        result_ids, result_dists = index.range_search(
+            point=q, threshold=0.5, parameters=search_params
+        )
+        print("result_ids:", result_ids)
+        print("result_dists:", result_dists)
+
+    print("[FP16] Add vectors to hgraph index")
+    add_ids = np.arange(num_elements, num_elements + 100, dtype=np.int64)
+    add_data_f32 = np.random.random((100, dim)).astype(np.float32)
+    add_data_fp16 = add_data_f32.astype(np.float16).reshape(-1)
+    index.add(vectors=add_data_fp16, ids=add_ids, num_elements=100, dim=dim)
+    print(f"[FP16] Index now has {index.get_num_elements()} elements")
+
+
+def bf16_example():
+    dim = 128
+    num_elements = 10000
+    query_elements = 1
+
+    ids = np.arange(num_elements, dtype=np.int64)
+    data_f32 = np.random.random((num_elements, dim)).astype(np.float32)
+    data_bf16 = float32_to_bfloat16_bits(data_f32.reshape(-1))
+
+    query_f32 = np.random.random((query_elements, dim)).astype(np.float32)
+    query_bf16 = float32_to_bfloat16_bits(query_f32.reshape(-1)).reshape(query_elements, dim)
+
+    index_params = json.dumps(
+        {
+            "dtype": "bfloat16",
+            "metric_type": "l2",
+            "dim": dim,
+            "index_param": {
+                "base_quantization_type": "bf16",
+                "max_degree": 26,
+                "ef_construction": 100,
+                "alpha": 1.2,
+            },
+        }
+    )
+
+    print("[BF16] Create hgraph index")
+    index = pyvsag.Index("hgraph", index_params)
+
+    print("[BF16] Build hgraph index")
+    index.build(vectors=data_bf16, ids=ids, num_elements=num_elements, dim=dim)
+
+    print("[BF16] KNN search hgraph index")
+    search_params = json.dumps({"hgraph": {"ef_search": 100}})
+    for q in query_bf16:
+        result_ids, result_dists = index.knn_search(vector=q, k=10, parameters=search_params)
+        print("result_ids:", result_ids)
+        print("result_dists:", result_dists)
+
+    print("[BF16] Range search hgraph index")
+    for q in query_bf16:
+        result_ids, result_dists = index.range_search(
+            point=q, threshold=0.5, parameters=search_params
+        )
+        print("result_ids:", result_ids)
+        print("result_dists:", result_dists)
+
+    print("[BF16] Add vectors to hgraph index")
+    add_ids = np.arange(num_elements, num_elements + 100, dtype=np.int64)
+    add_data_f32 = np.random.random((100, dim)).astype(np.float32)
+    add_data_bf16 = float32_to_bfloat16_bits(add_data_f32.reshape(-1))
+    index.add(vectors=add_data_bf16, ids=add_ids, num_elements=100, dim=dim)
+    print(f"[BF16] Index now has {index.get_num_elements()} elements")
+
+
+if __name__ == "__main__":
+    fp16_example()
+    print()
+    bf16_example()

--- a/python_bindings/index_binding.cpp
+++ b/python_bindings/index_binding.cpp
@@ -16,10 +16,12 @@
 #include <pybind11/stl.h>
 
 #include <fstream>
+#include <nlohmann/json.hpp>
 #include <vector>
 
 #include "binding.h"
 #include "fmt/format.h"
+#include "vsag/constants.h"
 #include "vsag/dataset.h"
 #include "vsag/vsag.h"
 
@@ -28,6 +30,149 @@ namespace {
 int64_t
 to_int64(uint64_t value) {
     return static_cast<int64_t>(value);
+}
+
+enum class DenseVectorKind { FLOAT32, FLOAT16, BFLOAT16, UNSUPPORTED };
+
+DenseVectorKind
+parse_dense_vector_kind(const std::string& parameters) {
+    const auto json = nlohmann::json::parse(parameters);
+    const auto dtype = json.find(vsag::PARAMETER_DTYPE);
+    if (dtype == json.end() || !dtype->is_string()) {
+        return DenseVectorKind::FLOAT32;
+    }
+
+    const auto dtype_name = dtype->get<std::string>();
+    if (dtype_name == vsag::DATATYPE_FLOAT32) {
+        return DenseVectorKind::FLOAT32;
+    }
+    if (dtype_name == vsag::DATATYPE_FLOAT16) {
+        return DenseVectorKind::FLOAT16;
+    }
+    if (dtype_name == vsag::DATATYPE_BFLOAT16) {
+        return DenseVectorKind::BFLOAT16;
+    }
+    return DenseVectorKind::UNSUPPORTED;
+}
+
+const char*
+expected_numpy_dtype(DenseVectorKind kind) {
+    switch (kind) {
+        case DenseVectorKind::FLOAT32:
+            return "numpy.float32";
+        case DenseVectorKind::FLOAT16:
+            return "numpy.float16";
+        case DenseVectorKind::BFLOAT16:
+            return "numpy.uint16 (raw bfloat16 bits)";
+        case DenseVectorKind::UNSUPPORTED:
+            return "unsupported";
+    }
+    return "unsupported";
+}
+
+const char*
+expected_numpy_dtype_name(DenseVectorKind kind) {
+    switch (kind) {
+        case DenseVectorKind::FLOAT32:
+            return "float32";
+        case DenseVectorKind::FLOAT16:
+            return "float16";
+        case DenseVectorKind::BFLOAT16:
+            return "uint16";
+        case DenseVectorKind::UNSUPPORTED:
+            return "";
+    }
+    return "";
+}
+
+void
+validate_dense_index_kind(DenseVectorKind kind, const char* operation_name) {
+    if (kind == DenseVectorKind::UNSUPPORTED) {
+        throw std::invalid_argument(
+            fmt::format("{} only supports indexes with dtype in [{}, {}, {}]",
+                        operation_name,
+                        vsag::DATATYPE_FLOAT32,
+                        vsag::DATATYPE_FLOAT16,
+                        vsag::DATATYPE_BFLOAT16));
+    }
+}
+
+py::buffer_info
+validate_dense_array(const py::array& array,
+                     DenseVectorKind kind,
+                     const char* arg_name,
+                     uint64_t expected_size = 0,
+                     uint64_t expected_dim = 0) {
+    auto buf = array.request();
+    const auto dtype_name = py::str(array.attr("dtype")).cast<std::string>();
+    if (dtype_name != expected_numpy_dtype_name(kind)) {
+        throw std::invalid_argument(
+            fmt::format("{} must be {} array", arg_name, expected_numpy_dtype(kind)));
+    }
+    if (expected_size == 0) {
+        if (buf.ndim != 1) {
+            throw std::invalid_argument(fmt::format("{} must be 1-dimensional", arg_name));
+        }
+        if (buf.strides[0] != buf.itemsize) {
+            throw std::invalid_argument(fmt::format("{} must be contiguous", arg_name));
+        }
+        return buf;
+    }
+
+    uint64_t actual_size = 0;
+    if (buf.ndim == 1) {
+        if (buf.strides[0] != buf.itemsize) {
+            throw std::invalid_argument(fmt::format("{} must be contiguous", arg_name));
+        }
+        actual_size = static_cast<uint64_t>(buf.shape[0]);
+    } else if (buf.ndim == 2) {
+        if (buf.strides[1] != buf.itemsize || buf.strides[0] != buf.itemsize * buf.shape[1]) {
+            throw std::invalid_argument(
+                fmt::format("{} must be contiguous in row-major order", arg_name));
+        }
+        if (expected_dim != 0 && static_cast<uint64_t>(buf.shape[1]) != expected_dim) {
+            throw std::invalid_argument(fmt::format("{} second dimension ({}) must equal dim ({})",
+                                                    arg_name,
+                                                    buf.shape[1],
+                                                    expected_dim));
+        }
+        actual_size = static_cast<uint64_t>(buf.shape[0]) * static_cast<uint64_t>(buf.shape[1]);
+    } else {
+        throw std::invalid_argument(fmt::format(
+            "{} must be a 1-dimensional array or a 2-dimensional contiguous matrix", arg_name));
+    }
+
+    if (actual_size != expected_size) {
+        throw std::invalid_argument(
+            fmt::format("{} size ({}) must equal {}", arg_name, actual_size, expected_size));
+    }
+    return buf;
+}
+
+void
+validate_ids(const py::array_t<int64_t>& ids, uint64_t expected_size) {
+    auto buf = ids.request();
+    if (buf.ndim != 1) {
+        throw std::invalid_argument("ids must be 1-dimensional");
+    }
+    if (buf.strides[0] != buf.itemsize) {
+        throw std::invalid_argument("ids must be contiguous");
+    }
+    if (static_cast<uint64_t>(buf.shape[0]) != expected_size) {
+        throw std::invalid_argument(fmt::format(
+            "ids length ({}) must equal num_elements ({})", buf.shape[0], expected_size));
+    }
+}
+
+void
+set_dense_vectors(const vsag::DatasetPtr& dataset,
+                  const py::buffer_info& buf,
+                  DenseVectorKind kind) {
+    if (kind == DenseVectorKind::FLOAT32) {
+        dataset->Float32Vectors(static_cast<const float*>(buf.ptr));
+        return;
+    }
+    dataset->Float16Vectors(static_cast<const uint16_t*>(buf.ptr));
 }
 
 struct SparseVectors {  // NOLINT(readability-identifier-naming)
@@ -121,20 +266,27 @@ public:
                     throw std::runtime_error("error type: unexpectedError");
             }
         }
+        dense_vector_kind_ = parse_dense_vector_kind(parameters);
     }
 
     void
-    Build(py::array_t<float> vectors,
-          py::array_t<int64_t> ids,
-          uint64_t num_elements,
-          uint64_t dim) {
+    Build(py::array vectors, py::array_t<int64_t> ids, uint64_t num_elements, uint64_t dim) {
+        validate_dense_index_kind(dense_vector_kind_, "build");
+        auto buf =
+            validate_dense_array(vectors, dense_vector_kind_, "vectors", num_elements * dim, dim);
+        validate_ids(ids, num_elements);
+
         auto dataset = vsag::Dataset::Make();
         dataset->Owner(false)
             ->Dim(to_int64(dim))
             ->NumElements(to_int64(num_elements))
-            ->Ids(ids.mutable_data())
-            ->Float32Vectors(vectors.mutable_data());
-        index_->Build(dataset);
+            ->Ids(ids.data());
+        set_dense_vectors(dataset, buf, dense_vector_kind_);
+
+        auto build_result = index_->Build(dataset);
+        if (!build_result.has_value()) {
+            throw std::runtime_error(fmt::format("build failed: {}", build_result.error().message));
+        }
     }
 
     void
@@ -165,12 +317,13 @@ public:
     }
 
     py::object
-    KnnSearch(py::array_t<float> vector, uint64_t k, std::string& parameters) {
+    KnnSearch(py::array vector, uint64_t k, std::string& parameters) {
+        validate_dense_index_kind(dense_vector_kind_, "knn_search");
+        auto buf = validate_dense_array(vector, dense_vector_kind_, "vector");
+
         auto query = vsag::Dataset::Make();
-        query->NumElements(1)
-            ->Dim(to_int64(vector.size()))
-            ->Float32Vectors(vector.mutable_data())
-            ->Owner(false);
+        query->NumElements(1)->Dim(to_int64(static_cast<uint64_t>(buf.shape[0])))->Owner(false);
+        set_dense_vectors(query, buf, dense_vector_kind_);
 
         uint64_t ids_shape[1]{k};
         uint64_t ids_strides[1]{sizeof(int64_t)};
@@ -179,13 +332,18 @@ public:
 
         auto ids = py::array_t<int64_t>(ids_shape, ids_strides);
         auto dists = py::array_t<float>(dists_shape, dists_strides);
-        if (auto result = index_->KnnSearch(query, to_int64(k), parameters); result.has_value()) {
-            auto ids_view = ids.mutable_unchecked<1>();
-            auto dists_view = dists.mutable_unchecked<1>();
+        auto ids_view = ids.mutable_unchecked<1>();
+        auto dists_view = dists.mutable_unchecked<1>();
+        for (uint64_t i = 0; i < k; ++i) {
+            ids_view(i) = -1;
+            dists_view(i) = -1.0f;
+        }
 
+        if (auto result = index_->KnnSearch(query, to_int64(k), parameters); result.has_value()) {
             const auto* vsag_ids = result.value()->GetIds();
             const auto* vsag_distances = result.value()->GetDistances();
-            for (uint32_t i = 0; i < k; ++i) {
+            const auto count = static_cast<uint64_t>(result.value()->GetDim());
+            for (uint64_t i = 0; i < k && i < count; ++i) {
                 ids_view(i) = vsag_ids[i];
                 dists_view(i) = vsag_distances[i];
             }
@@ -228,12 +386,13 @@ public:
     }
 
     py::object
-    RangeSearch(py::array_t<float> point, float threshold, std::string& parameters) {
+    RangeSearch(py::array point, float threshold, std::string& parameters) {
+        validate_dense_index_kind(dense_vector_kind_, "range_search");
+        auto buf = validate_dense_array(point, dense_vector_kind_, "point");
+
         auto query = vsag::Dataset::Make();
-        query->NumElements(1)
-            ->Dim(to_int64(point.size()))
-            ->Float32Vectors(point.mutable_data())
-            ->Owner(false);
+        query->NumElements(1)->Dim(to_int64(static_cast<uint64_t>(buf.shape[0])))->Owner(false);
+        set_dense_vectors(query, buf, dense_vector_kind_);
 
         py::array_t<int64_t> labels;
         py::array_t<float> dists;
@@ -280,17 +439,22 @@ public:
     }
 
     void
-    Add(py::array_t<float> vectors, py::array_t<int64_t> ids, uint64_t num_elements, uint64_t dim) {
+    Add(py::array vectors, py::array_t<int64_t> ids, uint64_t num_elements, uint64_t dim) {
+        validate_dense_index_kind(dense_vector_kind_, "add");
+        auto buf =
+            validate_dense_array(vectors, dense_vector_kind_, "vectors", num_elements * dim, dim);
+        validate_ids(ids, num_elements);
+
         auto dataset = vsag::Dataset::Make();
         dataset->Owner(false)
             ->Dim(to_int64(dim))
             ->NumElements(to_int64(num_elements))
-            ->Ids(ids.mutable_data())
-            ->Float32Vectors(vectors.mutable_data());
+            ->Ids(ids.data());
+        set_dense_vectors(dataset, buf, dense_vector_kind_);
 
         auto result = index_->Add(dataset);
         if (!result.has_value()) {
-            throw std::runtime_error("Failed to add vectors to index");
+            throw std::runtime_error(fmt::format("add failed: {}", result.error().message));
         }
     }
 
@@ -353,6 +517,7 @@ public:
     }
 
 private:
+    DenseVectorKind dense_vector_kind_{DenseVectorKind::FLOAT32};
     std::shared_ptr<vsag::Index> index_;
 };
 
@@ -366,6 +531,11 @@ bind_index(py::module_& module) {
         This class supports both dense and sparse vector indexing and searching.
         It provides methods for building indexes, performing k-NN and range searches,
         and saving/loading indexes to/from disk.
+
+        Supported dense input types:
+        - float32 indexes accept numpy.float32 vectors
+        - float16 indexes accept numpy.float16 vectors
+        - bfloat16 indexes accept numpy.uint16 arrays containing raw bfloat16 bits
     )pbdoc")
         .def(py::init<const std::string&, const std::string&>(),
              py::arg("name"),
@@ -385,16 +555,20 @@ bind_index(py::module_& module) {
              py::arg("num_elements"),
              py::arg("dim"),
              R"pbdoc(
-         Build index from dense float32 vectors.
+         Build index from dense vectors.
 
          Args:
-             vectors (numpy.ndarray): 1D array of float32 values with total size num_elements * dim
+              vectors (numpy.ndarray): Dense vector buffer with shape (num_elements * dim,) or
+                  a row-major contiguous matrix with shape (num_elements, dim)
              ids (numpy.ndarray): 1D array of int64 values with shape (num_elements,)
              num_elements (int): Number of vectors in the dataset
              dim (int): Dimensionality of each vector
 
          Note:
-             - The vectors array should contain num_elements * dim consecutive float32 values
+              - The index parameters determine the VSAG dtype
+              - Accepted dense inputs are numpy.float32 for float32 indexes, numpy.float16 for float16 indexes,
+                and numpy.uint16 raw-bit buffers for bfloat16 indexes
+              - Dense build inputs may be passed as either a flat array or a contiguous 2D matrix
          )pbdoc")
         .def("build",
              &Index::SparseBuild,
@@ -426,18 +600,18 @@ bind_index(py::module_& module) {
          Perform k-nearest neighbors search on a single dense query vector.
 
          Args:
-             vector (numpy.ndarray): 1D array of float32 values representing the query vector
+             vector (numpy.ndarray): 1D dense query vector buffer
              k (int): Number of nearest neighbors to retrieve
              parameters (str): JSON-formatted string containing search-specific parameters
 
          Returns:
-             tuple: (distances, ids) where:
-                 - distances: numpy.ndarray of float32 with shape (k,) containing distances to neighbors
+             tuple: (ids, distances) where:
                  - ids: numpy.ndarray of int64 with shape (k,) containing neighbor IDs
+                 - distances: numpy.ndarray of float32 with shape (k,) containing distances to neighbors
 
          Note:
-             - Distance metric depends on the index configuration (typically L2 or inner product)
-             - Results are sorted by distance (closest first)
+             - The query dtype must match the index dtype declared in the index parameters
+             - Use numpy.uint16 raw-bit buffers for bfloat16 queries
          )pbdoc")
         .def("knn_search",
              &Index::SparseKnnSearch,
@@ -457,7 +631,7 @@ bind_index(py::module_& module) {
              parameters (str): JSON-formatted string containing search-specific parameters
 
          Returns:
-             tuple: (distances, ids) with the same format as dense knn_search
+             tuple: (ids, distances) with the same format as dense knn_search
 
          )pbdoc")
         .def("range_search",
@@ -469,18 +643,18 @@ bind_index(py::module_& module) {
          Perform range search to find all vectors within a specified distance threshold.
 
          Args:
-             point (numpy.ndarray): 1D array of float32 values representing the query vector
+             point (numpy.ndarray): 1D dense query vector buffer
              threshold (float): Maximum distance threshold for inclusion in results
              parameters (str): JSON-formatted string containing search-specific parameters
 
          Returns:
-             tuple: (distances, ids) where:
-                 - distances: numpy.ndarray of float32 containing distances to all qualifying vectors
+             tuple: (ids, distances) where:
                  - ids: numpy.ndarray of int64 containing corresponding IDs
+                 - distances: numpy.ndarray of float32 containing distances to all qualifying vectors
 
          Note:
-             - The number of returned results varies based on data distribution and threshold
-             - Results are not guaranteed to be sorted by distance
+             - The query dtype must match the index dtype declared in the index parameters
+             - Use numpy.uint16 raw-bit buffers for bfloat16 queries
          )pbdoc")
         .def("save",
              &Index::Save,
@@ -555,17 +729,23 @@ bind_index(py::module_& module) {
              py::arg("num_elements"),
              py::arg("dim"),
              R"pbdoc(
-         Add new vectors to the index dynamically.
+         Add new dense vectors to the index dynamically.
 
          Args:
-             vectors (numpy.ndarray): 1D array of float32 values with total size num_elements * dim
+              vectors (numpy.ndarray): Dense vector buffer with shape (num_elements * dim,) or
+                  a row-major contiguous matrix with shape (num_elements, dim)
              ids (numpy.ndarray): 1D array of int64 values with shape (num_elements,)
              num_elements (int): Number of vectors to add
              dim (int): Dimensionality of each vector
 
          Raises:
              RuntimeError: If the add operation fails.
-         )pbdoc")
+
+         Note:
+              - The vector dtype must match the index dtype declared in the index parameters
+              - Use numpy.uint16 raw-bit buffers for bfloat16 additions
+              - Dense add inputs may be passed as either a flat array or a contiguous 2D matrix
+          )pbdoc")
         .def("remove",
              &Index::Remove,
              py::arg("ids"),

--- a/tests/python/test_index_operations.py
+++ b/tests/python/test_index_operations.py
@@ -25,6 +25,30 @@ from conftest import (
 )
 
 
+def _create_dense_dispatch_index(dtype: str, dim: int) -> pyvsag.Index:
+    quantization = "fp16" if dtype == "float16" else "bf16"
+    return create_index(
+        "hgraph",
+        f"""
+        {{
+            "dtype": "{dtype}",
+            "metric_type": "l2",
+            "dim": {dim},
+            "index_param": {{
+                "base_quantization_type": "{quantization}",
+                "max_degree": 16,
+                "ef_construction": 50,
+                "alpha": 1.2
+            }}
+        }}
+        """,
+    )
+
+
+def _float32_to_bfloat16_bits(array: np.ndarray) -> np.ndarray:
+    return (array.astype(np.float32).view(np.uint32) >> 16).astype(np.uint16)
+
+
 class TestGetNumElements:
     """Tests for get_num_elements method"""
 
@@ -243,6 +267,168 @@ class TestAddVectors:
         ids_2 = dataset.ids[half:]
         index.add(vectors_2, ids_2, dataset.num_elements - half, dataset.dim)
         assert index.get_num_elements() == dataset.num_elements
+
+
+class TestDenseDtypeDispatch:
+    """Tests for dense dtype-aware build/search/add bindings"""
+
+    def test_build_accepts_2d_float16_matrix(self, dataset_factory):
+        dataset = dataset_factory(num_vectors=64, dim=32)
+        index = _create_dense_dispatch_index("float16", dataset.dim)
+
+        vectors = dataset.base_vectors.reshape(dataset.num_elements, dataset.dim).astype(np.float16)
+        index.build(vectors, dataset.ids, dataset.num_elements, dataset.dim)
+
+        assert index.get_num_elements() == dataset.num_elements
+
+    def test_add_accepts_2d_bfloat16_matrix(self, dataset_factory):
+        dataset = dataset_factory(num_vectors=32, dim=16)
+        index = _create_dense_dispatch_index("bfloat16", dataset.dim)
+
+        vectors = _float32_to_bfloat16_bits(dataset.base_vectors).reshape(
+            dataset.num_elements, dataset.dim
+        )
+        index.add(vectors, dataset.ids, dataset.num_elements, dataset.dim)
+
+        assert index.get_num_elements() == dataset.num_elements
+
+    def test_knn_search_accepts_float16_query(self, dataset_factory):
+        dataset = dataset_factory(num_vectors=64, dim=32)
+        index = _create_dense_dispatch_index("float16", dataset.dim)
+        index.build(dataset.base_vectors.astype(np.float16), dataset.ids, dataset.num_elements, dataset.dim)
+
+        query = dataset.query_vectors[: dataset.dim].astype(np.float16)
+        ids, distances = index.knn_search(query, 5, '{"hgraph": {"ef_search": 20}}')
+
+        assert ids.shape == (5,)
+        assert distances.shape == (5,)
+
+    def test_knn_search_accepts_bfloat16_query(self, dataset_factory):
+        dataset = dataset_factory(num_vectors=64, dim=32)
+        index = _create_dense_dispatch_index("bfloat16", dataset.dim)
+        index.build(
+            _float32_to_bfloat16_bits(dataset.base_vectors),
+            dataset.ids,
+            dataset.num_elements,
+            dataset.dim,
+        )
+
+        query = _float32_to_bfloat16_bits(dataset.query_vectors[: dataset.dim])
+        ids, distances = index.knn_search(query, 5, '{"hgraph": {"ef_search": 20}}')
+
+        assert ids.shape == (5,)
+        assert distances.shape == (5,)
+
+    def test_range_search_accepts_float16_query(self, dataset_factory):
+        dataset = dataset_factory(num_vectors=64, dim=32)
+        index = _create_dense_dispatch_index("float16", dataset.dim)
+        index.build(dataset.base_vectors.astype(np.float16), dataset.ids, dataset.num_elements, dataset.dim)
+
+        query = dataset.query_vectors[: dataset.dim].astype(np.float16)
+        ids, distances = index.range_search(query, 1e9, '{"hgraph": {"ef_search": 20}}')
+
+        assert ids.ndim == 1
+        assert distances.ndim == 1
+        assert ids.shape == distances.shape
+
+    def test_range_search_accepts_bfloat16_query(self, dataset_factory):
+        dataset = dataset_factory(num_vectors=64, dim=32)
+        index = _create_dense_dispatch_index("bfloat16", dataset.dim)
+        index.build(
+            _float32_to_bfloat16_bits(dataset.base_vectors),
+            dataset.ids,
+            dataset.num_elements,
+            dataset.dim,
+        )
+
+        query = _float32_to_bfloat16_bits(dataset.query_vectors[: dataset.dim])
+        ids, distances = index.range_search(query, 1e9, '{"hgraph": {"ef_search": 20}}')
+
+        assert ids.ndim == 1
+        assert distances.ndim == 1
+        assert ids.shape == distances.shape
+
+    @pytest.mark.parametrize(
+        ("dtype", "vectors", "expected_error"),
+        [
+            ("float16", lambda dataset: dataset.base_vectors.astype(np.float32), "vectors must be numpy.float16 array"),
+            (
+                "bfloat16",
+                lambda dataset: dataset.base_vectors.astype(np.float16),
+                r"vectors must be numpy.uint16 \(raw bfloat16 bits\) array",
+            ),
+        ],
+    )
+    def test_add_rejects_wrong_dense_dtype(self, dataset_factory, dtype, vectors, expected_error):
+        dataset = dataset_factory(num_vectors=16, dim=8)
+        index = _create_dense_dispatch_index(dtype, dataset.dim)
+
+        with pytest.raises(ValueError, match=expected_error):
+            index.add(vectors(dataset), dataset.ids, dataset.num_elements, dataset.dim)
+
+    @pytest.mark.parametrize(
+        ("dtype", "vectors", "expected_error"),
+        [
+            ("float16", lambda dataset: dataset.base_vectors.astype(np.float32), "vectors must be numpy.float16 array"),
+            (
+                "bfloat16",
+                lambda dataset: dataset.base_vectors.astype(np.float16),
+                r"vectors must be numpy.uint16 \(raw bfloat16 bits\) array",
+            ),
+        ],
+    )
+    def test_build_rejects_wrong_dense_dtype(self, dataset_factory, dtype, vectors, expected_error):
+        dataset = dataset_factory(num_vectors=16, dim=8)
+        index = _create_dense_dispatch_index(dtype, dataset.dim)
+
+        with pytest.raises(ValueError, match=expected_error):
+            index.build(vectors(dataset), dataset.ids, dataset.num_elements, dataset.dim)
+
+    @pytest.mark.parametrize(
+        ("dtype", "query", "expected_error"),
+        [
+            ("float16", lambda dim: np.ones(dim, dtype=np.float32), "vector must be numpy.float16 array"),
+            (
+                "bfloat16",
+                lambda dim: np.ones(dim, dtype=np.float16),
+                r"vector must be numpy.uint16 \(raw bfloat16 bits\) array",
+            ),
+        ],
+    )
+    def test_knn_search_rejects_wrong_dense_dtype(self, dataset_factory, dtype, query, expected_error):
+        dataset = dataset_factory(num_vectors=16, dim=8)
+        index = _create_dense_dispatch_index(dtype, dataset.dim)
+
+        build_vectors = dataset.base_vectors.astype(np.float16)
+        if dtype == "bfloat16":
+            build_vectors = _float32_to_bfloat16_bits(dataset.base_vectors)
+        index.build(build_vectors, dataset.ids, dataset.num_elements, dataset.dim)
+
+        with pytest.raises(ValueError, match=expected_error):
+            index.knn_search(query(dataset.dim), 3, '{"hgraph": {"ef_search": 20}}')
+
+    @pytest.mark.parametrize(
+        ("dtype", "query", "expected_error"),
+        [
+            ("float16", lambda dim: np.ones(dim, dtype=np.float32), "point must be numpy.float16 array"),
+            (
+                "bfloat16",
+                lambda dim: np.ones(dim, dtype=np.float16),
+                r"point must be numpy.uint16 \(raw bfloat16 bits\) array",
+            ),
+        ],
+    )
+    def test_range_search_rejects_wrong_dense_dtype(self, dataset_factory, dtype, query, expected_error):
+        dataset = dataset_factory(num_vectors=16, dim=8)
+        index = _create_dense_dispatch_index(dtype, dataset.dim)
+
+        build_vectors = dataset.base_vectors.astype(np.float16)
+        if dtype == "bfloat16":
+            build_vectors = _float32_to_bfloat16_bits(dataset.base_vectors)
+        index.build(build_vectors, dataset.ids, dataset.num_elements, dataset.dim)
+
+        with pytest.raises(ValueError, match=expected_error):
+            index.range_search(query(dataset.dim), 1.0, '{"hgraph": {"ef_search": 20}}')
 
 
 class TestRemoveVectors:


### PR DESCRIPTION
## Summary

- unify dense Python bindings under the existing `build`, `knn_search`, `range_search`, and `add` methods instead of adding separate `*_fp16` / `*_bf16` entrypoints
- dispatch dense inputs by the index `dtype` from constructor parameters: `numpy.float32` for `float32`, `numpy.float16` for `float16`, and raw-bit `numpy.uint16` for `bfloat16`
- keep sparse overloads unchanged and update the FP16/BF16 example to use the unified API

## Notes

- VSAG still uses `Dataset::Float16Vectors()` for both FP16 and BF16 payload storage; the semantic distinction comes from the index `dtype`
- BF16 still has to be passed from Python as `numpy.uint16` because NumPy has no native bfloat16 dtype here
- the binding validates dtype, 1-D shape, contiguous layout, and exact buffer length before passing raw pointers into VSAG

## Validation

- `clang-format -i python_bindings/index_binding.cpp`
- `python3 -m py_compile examples/python/104_index_hgraph_fp16_bf16.py`
- `git diff --check`

CI on the PR will cover the remaining build/test verification.
