### PR TITLE
fix: avoid memcmp on dataset path strings

### DIFF
--- a/src/dataset_impl_test.cpp
+++ b/src/dataset_impl_test.cpp
@@ -250,6 +250,21 @@ AreAllPointersDifferent(T* original, T* copy, uint64_t num_elements) {
     return true;
 }
 
+bool
+ArePathArraysDeepCopied(const std::string* original,
+                        const std::string* copy,
+                        uint64_t num_elements) {
+    if (original == copy) {
+        return false;
+    }
+    for (uint64_t i = 0; i < num_elements; ++i) {
+        if (original[i] != copy[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+
 TEST_CASE("Dataset Copy and Append Test", "[ut][Dataset]") {
     std::random_device rd;
     std::mt19937 gen(rd());
@@ -277,7 +292,7 @@ TEST_CASE("Dataset Copy and Append Test", "[ut][Dataset]") {
         REQUIRE(AreAllPointersDifferent(
             original->GetAttributeSets(), copy->GetAttributeSets(), num_elements));
 
-        REQUIRE(AreAllPointersDifferent(original->GetPaths(), copy->GetPaths(), num_elements));
+        REQUIRE(ArePathArraysDeepCopied(original->GetPaths(), copy->GetPaths(), num_elements));
     }
     SECTION("Append") {
         auto copy = original->DeepCopy();

--- a/src/dataset_impl_test.cpp
+++ b/src/dataset_impl_test.cpp
@@ -254,7 +254,10 @@ bool
 ArePathArraysDeepCopied(const std::string* original,
                         const std::string* copy,
                         uint64_t num_elements) {
-    if (original == copy) {
+    if (num_elements == 0) {
+        return true;
+    }
+    if (original == nullptr || copy == nullptr || original == copy) {
         return false;
     }
     for (uint64_t i = 0; i < num_elements; ++i) {


### PR DESCRIPTION
## Summary

Fixes #1951. Part of #1950.

This keeps the Dataset DeepCopy fix test-only. The previous assertion used `memcmp` on `std::string` objects to infer whether `Paths` had been deep-copied. That compares implementation-specific object bytes, which can be identical for equal short strings on macOS/libc++, causing a false failure.

The updated assertion checks the intended semantics directly: the copied path array must be a different array pointer, and every copied string value must match the original.

## Validation

- `/opt/homebrew/opt/llvm@15/bin/clang-format -i src/dataset_impl_test.cpp`
- `git diff --check`
- `./build/tests/unittests "Dataset Copy and Append Test"`

Note: rebuilding from a clean `upstream/main` checkout on local macOS is blocked by the existing AppleClang/libc++ configuration issue being addressed separately in PR #1930, so the local executable run used the available build artifact. Full PR CI should validate the change on the current supported Linux path; macOS CI validation depends on the macOS support PR.