### PR TITLE
test: stabilize hnsw feedback functest

### DIFF
--- a/tests/test_index_old.cpp
+++ b/tests/test_index_old.cpp
@@ -1105,8 +1105,12 @@ TEST_CASE("int8 + freshhnsw + feedback + update", "[ft][feedback][update][hnsw]"
     logger->Debug("====summary====");
     logger->Debug(fmt::format(R"(Error fix: {})", error_fix));
 
-    REQUIRE(error_fix > 0);
-    REQUIRE(recall[0] < recall[1]);
+    const bool initial_recall_is_perfect = fixtures::time_t(recall[0]) == fixtures::time_t(1.0f);
+    if (not initial_recall_is_perfect) {
+        REQUIRE(error_fix > 0);
+        REQUIRE(recall[0] < recall[1]);
+    }
+    REQUIRE(recall[1] >= recall[0]);
     REQUIRE(fixtures::time_t(recall[1]) == fixtures::time_t(1.0f));
 }
 
@@ -1228,9 +1232,15 @@ TEST_CASE("hnsw + feedback with global optimum id + remove", "[ft][feedback][rem
     logger->Debug("====summary====");
     logger->Debug(fmt::format(R"(Error fix: {})", error_fix));
 
-    REQUIRE(error_fix > 0);
+    const bool initial_recall_is_perfect = fixtures::time_t(recall[0]) == fixtures::time_t(1.0f);
+    if (not initial_recall_is_perfect) {
+        REQUIRE(error_fix > 0);
+    }
     if (not is_remove) {
-        REQUIRE(recall[0] < recall[1]);
+        if (not initial_recall_is_perfect) {
+            REQUIRE(recall[0] < recall[1]);
+        }
+        REQUIRE(recall[1] >= recall[0]);
         REQUIRE(fixtures::time_t(recall[1]) == fixtures::time_t(1.0f));
     }
 }

--- a/tests/test_index_old.cpp
+++ b/tests/test_index_old.cpp
@@ -1105,13 +1105,14 @@ TEST_CASE("int8 + freshhnsw + feedback + update", "[ft][feedback][update][hnsw]"
     logger->Debug("====summary====");
     logger->Debug(fmt::format(R"(Error fix: {})", error_fix));
 
-    const bool initial_recall_is_perfect = fixtures::time_t(recall[0]) == fixtures::time_t(1.0f);
+    const bool initial_recall_is_perfect =
+        fixtures::recall_t(recall[0]) == fixtures::recall_t(1.0f);
     if (not initial_recall_is_perfect) {
         REQUIRE(error_fix > 0);
         REQUIRE(recall[0] < recall[1]);
     }
     REQUIRE(recall[1] >= recall[0]);
-    REQUIRE(fixtures::time_t(recall[1]) == fixtures::time_t(1.0f));
+    REQUIRE(fixtures::recall_t(recall[1]) == fixtures::recall_t(1.0f));
 }
 
 TEST_CASE("hnsw + feedback with global optimum id + remove", "[ft][feedback][remove][hnsw]") {
@@ -1232,7 +1233,8 @@ TEST_CASE("hnsw + feedback with global optimum id + remove", "[ft][feedback][rem
     logger->Debug("====summary====");
     logger->Debug(fmt::format(R"(Error fix: {})", error_fix));
 
-    const bool initial_recall_is_perfect = fixtures::time_t(recall[0]) == fixtures::time_t(1.0f);
+    const bool initial_recall_is_perfect =
+        fixtures::recall_t(recall[0]) == fixtures::recall_t(1.0f);
     if (not initial_recall_is_perfect) {
         REQUIRE(error_fix > 0);
     }
@@ -1241,7 +1243,7 @@ TEST_CASE("hnsw + feedback with global optimum id + remove", "[ft][feedback][rem
             REQUIRE(recall[0] < recall[1]);
         }
         REQUIRE(recall[1] >= recall[0]);
-        REQUIRE(fixtures::time_t(recall[1]) == fixtures::time_t(1.0f));
+        REQUIRE(fixtures::recall_t(recall[1]) == fixtures::recall_t(1.0f));
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #1953. Part of #1950.

The HNSW feedback functests assumed the first search round must produce at least one wrong result, then required `error_fix > 0` and strict recall improvement. On macOS/arm64/ASan the first round can already reach perfect recall, so there is no error to fix and the test fails even though correctness did not regress.

This updates the assertions to keep the intended feedback coverage when initial recall is imperfect, while allowing the already-perfect case to pass. The final non-remove path still requires perfect recall, and the second round must not regress from the first round. The same stable assertion pattern is applied to the related remove/non-remove feedback test in the same file.

## Validation

- `/opt/homebrew/opt/llvm@15/bin/clang-format -i tests/test_index_old.cpp`
- `git diff --check`

Local macOS execution is blocked from a clean `upstream/main` checkout by existing compiler/toolchain configuration issues: system AppleClang hits the AppleClang/libc++ detection issue addressed in PR #1930, while Homebrew LLVM 15 fails C compiler detection locally because it cannot link `libSystem`. Full runtime validation should come from PR CI.