### PR TITLE
feat(sindi): add built-in term ID remapping for sparse vocabularies

### DIFF
--- a/src/algorithm/sindi/CMakeLists.txt
+++ b/src/algorithm/sindi/CMakeLists.txt
@@ -17,6 +17,7 @@
 set (SINDI_SRCS
         sindi.cpp
         sindi_parameter.cpp
+        term_id_mapper.cpp
 )
 
 add_library (sindi OBJECT ${SINDI_SRCS})

--- a/src/algorithm/sindi/sindi.cpp
+++ b/src/algorithm/sindi/sindi.cpp
@@ -42,7 +42,12 @@ SINDI::SINDI(const SINDIParameterPtr& param, const IndexCommonParam& common_para
       deserialize_without_footer_(param->deserialize_without_footer),
       deserialize_without_buffer_(param->deserialize_without_buffer),
       quantization_params_(std::make_shared<QuantizationParams>()),
-      avg_doc_term_length_(param->avg_doc_term_length) {
+      avg_doc_term_length_(param->avg_doc_term_length),
+      remap_term_ids_(param->remap_term_ids) {
+    if (remap_term_ids_) {
+        term_id_mapper_ =
+            std::make_shared<TermIdMapper>(term_id_limit_, common_param.allocator_.get());
+    }
     if (use_reorder_) {
         SparseIndexParameterPtr rerank_param = std::make_shared<SparseIndexParameters>();
         rerank_param->need_sort = true;
@@ -118,7 +123,13 @@ SINDI::Add(const DatasetPtr& base, AddMode mode) {
         auto inner_id = static_cast<uint16_t>(cur_element_count_ - window_start_id);
 
         try {
-            window_term_list_[cur_window]->InsertVector(sparse_vector, inner_id);
+            if (remap_term_ids_) {
+                Vector<uint32_t> tmp_ids(allocator_);
+                auto remapped = remap_sparse_vector_for_build(sparse_vector, tmp_ids);
+                window_term_list_[cur_window]->InsertVector(remapped, inner_id);
+            } else {
+                window_term_list_[cur_window]->InsertVector(sparse_vector, inner_id);
+            }
         } catch (const std::runtime_error& e) {
             failed_ids.push_back(ids[i]);
             logger::warn("runtime error: {}", e.what());
@@ -237,7 +248,18 @@ SINDI::KnnSearch(const DatasetPtr& query,
     }
     inner_param.is_inner_id_allowed = ft;
 
-    auto computer = std::make_shared<SparseTermComputer>(sparse_query, search_param, allocator_);
+    SparseVector effective_query = sparse_query;
+    Vector<uint32_t> tmp_ids(allocator_);
+    Vector<float> tmp_vals(allocator_);
+    if (remap_term_ids_) {
+        effective_query = remap_sparse_vector_for_query(sparse_query, tmp_ids, tmp_vals);
+        if (effective_query.len_ == 0) {
+            auto [results, ret_dists, ret_ids] = create_fast_dataset(0, allocator);
+            return results;
+        }
+    }
+
+    auto computer = std::make_shared<SparseTermComputer>(effective_query, search_param, allocator_);
     return search_impl<KNN_SEARCH>(
         computer, inner_param, allocator, search_param.use_term_lists_heap_insert);
 }
@@ -385,7 +407,18 @@ SINDI::RangeSearch(const DatasetPtr& query,
     }
     inner_param.is_inner_id_allowed = ft;
 
-    auto computer = std::make_shared<SparseTermComputer>(sparse_query, search_param, allocator_);
+    SparseVector effective_query = sparse_query;
+    Vector<uint32_t> tmp_ids(allocator_);
+    Vector<float> tmp_vals(allocator_);
+    if (remap_term_ids_) {
+        effective_query = remap_sparse_vector_for_query(sparse_query, tmp_ids, tmp_vals);
+        if (effective_query.len_ == 0) {
+            auto [results, ret_dists, ret_ids] = create_fast_dataset(0, allocator_);
+            return results;
+        }
+    }
+
+    auto computer = std::make_shared<SparseTermComputer>(effective_query, search_param, allocator_);
     return search_impl<RANGE_SEARCH>(
         computer, inner_param, allocator_, search_param.use_term_lists_heap_insert);
 }
@@ -428,6 +461,10 @@ SINDI::Serialize(StreamWriter& writer) const {
 
     if (use_reorder_) {
         rerank_flat_index_->Serialize(writer);
+    }
+
+    if (remap_term_ids_ && term_id_mapper_) {
+        term_id_mapper_->Serialize(writer);
     }
 
     JsonType jsonify_basic_info;
@@ -491,6 +528,11 @@ SINDI::Deserialize(StreamReader& reader) {
     if (use_reorder_) {
         rerank_flat_index_->Deserialize(reader_ref);
     }
+
+    if (remap_term_ids_ && term_id_mapper_) {
+        term_id_mapper_->Deserialize(reader_ref);
+    }
+
     this->cal_memory_usage();
 }
 
@@ -534,6 +576,11 @@ SINDI::EstimateMemory(uint64_t num_elements) const {
     // size of term list
     mem += sizeof(std::vector<float>) * 2 * term_id_limit_;
 
+    // size of term id mapper (unordered_map ~50B per entry + vector 4B per entry)
+    if (remap_term_ids_) {
+        mem += static_cast<uint64_t>(term_id_limit_) * 54;
+    }
+
     return mem;
 }
 
@@ -553,6 +600,13 @@ SINDI::GetSparseVectorByInnerId(InnerIdType inner_id,
     auto term_list = this->window_term_list_[cur_window];
 
     term_list->GetSparseVector(inner_id - window_start_id, data, specified_allocator);
+
+    // Reverse map compact IDs back to original term IDs
+    if (remap_term_ids_ && term_id_mapper_) {
+        for (uint32_t i = 0; i < data->len_; ++i) {
+            data->ids_[i] = term_id_mapper_->ReverseMap(data->ids_[i]);
+        }
+    }
 }
 
 float
@@ -570,7 +624,12 @@ SINDI::CalcDistanceById(const DatasetPtr& vector,
     auto window_start_id = cur_window * window_size_;
     auto term_list = this->window_term_list_[cur_window];
 
-    const auto sparse_query = vector->GetSparseVectors()[0];
+    auto sparse_query = vector->GetSparseVectors()[0];
+    Vector<uint32_t> tmp_ids(allocator_);
+    Vector<float> tmp_vals(allocator_);
+    if (remap_term_ids_) {
+        sparse_query = remap_sparse_vector_for_query(sparse_query, tmp_ids, tmp_vals);
+    }
     SINDISearchParameter search_param;
     search_param.query_prune_ratio = 0;
     search_param.term_prune_ratio = 0;
@@ -703,6 +762,39 @@ SINDI::get_min_max_window_id(const FilterPtr& filter) const {
     }
 
     return {min_window_id, max_window_id};
+}
+
+SparseVector
+SINDI::remap_sparse_vector_for_query(const SparseVector& input,
+                                     Vector<uint32_t>& tmp_ids,
+                                     Vector<float>& tmp_vals) const {
+    tmp_ids.clear();
+    tmp_vals.clear();
+    for (uint32_t i = 0; i < input.len_; ++i) {
+        auto compact = term_id_mapper_->TryMap(input.ids_[i]);
+        if (compact.has_value()) {
+            tmp_ids.push_back(compact.value());
+            tmp_vals.push_back(input.vals_[i]);
+        }
+    }
+    SparseVector remapped;
+    remapped.len_ = static_cast<uint32_t>(tmp_ids.size());
+    remapped.ids_ = tmp_ids.data();
+    remapped.vals_ = tmp_vals.data();
+    return remapped;
+}
+
+SparseVector
+SINDI::remap_sparse_vector_for_build(const SparseVector& input, Vector<uint32_t>& tmp_ids) {
+    tmp_ids.resize(input.len_);
+    for (uint32_t i = 0; i < input.len_; ++i) {
+        tmp_ids[i] = term_id_mapper_->Map(input.ids_[i]);
+    }
+    SparseVector remapped;
+    remapped.len_ = input.len_;
+    remapped.ids_ = tmp_ids.data();
+    remapped.vals_ = input.vals_;
+    return remapped;
 }
 
 }  // namespace vsag

--- a/src/algorithm/sindi/sindi.cpp
+++ b/src/algorithm/sindi/sindi.cpp
@@ -260,8 +260,9 @@ SINDI::KnnSearch(const DatasetPtr& query,
     }
 
     auto computer = std::make_shared<SparseTermComputer>(effective_query, search_param, allocator_);
+    const SparseVector* rerank_query = (remap_term_ids_ && use_reorder_) ? &sparse_query : nullptr;
     return search_impl<KNN_SEARCH>(
-        computer, inner_param, allocator, search_param.use_term_lists_heap_insert);
+        computer, inner_param, allocator, search_param.use_term_lists_heap_insert, rerank_query);
 }
 
 template <InnerSearchMode mode>
@@ -269,7 +270,8 @@ DatasetPtr
 SINDI::search_impl(const SparseTermComputerPtr& computer,
                    const InnerSearchParam& inner_param,
                    Allocator* allocator,
-                   bool use_term_lists_heap_insert) const {
+                   bool use_term_lists_heap_insert,
+                   const SparseVector* original_query) const {
     // computer and heap
     MaxHeap heap(allocator);
     int64_t k = 0;
@@ -316,7 +318,8 @@ SINDI::search_impl(const SparseTermComputerPtr& computer,
         auto candidate_size = heap.size();
         auto high_precise_heap = std::make_shared<StandardHeap<true, false>>(allocator_, -1);
         auto [sorted_ids, sorted_vals] =
-            rerank_flat_index_->sort_sparse_vector(computer->raw_query_);
+            rerank_flat_index_->sort_sparse_vector(
+                original_query ? *original_query : computer->raw_query_);
         for (auto i = 0; i < candidate_size; i++) {
             auto inner_id = heap.top().second;
             auto high_precise_distance = rerank_flat_index_->CalDistanceByIdUnsafe(
@@ -419,8 +422,9 @@ SINDI::RangeSearch(const DatasetPtr& query,
     }
 
     auto computer = std::make_shared<SparseTermComputer>(effective_query, search_param, allocator_);
+    const SparseVector* rerank_query = (remap_term_ids_ && use_reorder_) ? &sparse_query : nullptr;
     return search_impl<RANGE_SEARCH>(
-        computer, inner_param, allocator_, search_param.use_term_lists_heap_insert);
+        computer, inner_param, allocator_, search_param.use_term_lists_heap_insert, rerank_query);
 }
 
 void

--- a/src/algorithm/sindi/sindi.cpp
+++ b/src/algorithm/sindi/sindi.cpp
@@ -104,6 +104,7 @@ SINDI::Add(const DatasetPtr& base, AddMode mode) {
     }
 
     // add process
+    Vector<uint32_t> tmp_ids(allocator_);
     for (uint32_t i = 0; i < data_num; ++i) {
         auto cur_window = cur_element_count_ / window_size_;
         auto window_start_id = cur_window * window_size_;
@@ -124,7 +125,6 @@ SINDI::Add(const DatasetPtr& base, AddMode mode) {
 
         try {
             if (remap_term_ids_) {
-                Vector<uint32_t> tmp_ids(allocator_);
                 auto remapped = remap_sparse_vector_for_build(sparse_vector, tmp_ids);
                 window_term_list_[cur_window]->InsertVector(remapped, inner_id);
             } else {
@@ -317,9 +317,8 @@ SINDI::search_impl(const SparseTermComputerPtr& computer,
         float cur_heap_top = std::numeric_limits<float>::max();
         auto candidate_size = heap.size();
         auto high_precise_heap = std::make_shared<StandardHeap<true, false>>(allocator_, -1);
-        auto [sorted_ids, sorted_vals] =
-            rerank_flat_index_->sort_sparse_vector(
-                original_query ? *original_query : computer->raw_query_);
+        auto [sorted_ids, sorted_vals] = rerank_flat_index_->sort_sparse_vector(
+            original_query ? *original_query : computer->raw_query_);
         for (auto i = 0; i < candidate_size; i++) {
             auto inner_id = heap.top().second;
             auto high_precise_distance = rerank_flat_index_->CalDistanceByIdUnsafe(
@@ -774,6 +773,8 @@ SINDI::remap_sparse_vector_for_query(const SparseVector& input,
                                      Vector<float>& tmp_vals) const {
     tmp_ids.clear();
     tmp_vals.clear();
+    tmp_ids.reserve(input.len_);
+    tmp_vals.reserve(input.len_);
     for (uint32_t i = 0; i < input.len_; ++i) {
         auto compact = term_id_mapper_->TryMap(input.ids_[i]);
         if (compact.has_value()) {

--- a/src/algorithm/sindi/sindi.h
+++ b/src/algorithm/sindi/sindi.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "algorithm/inner_index_interface.h"
+#include "algorithm/sindi/term_id_mapper.h"
 #include "algorithm/sparse_index.h"
 #include "datacell/sparse_term_datacell.h"
 #include "vsag/allocator.h"
@@ -137,6 +138,14 @@ private:
     void
     cal_memory_usage();
 
+    SparseVector
+    remap_sparse_vector_for_build(const SparseVector& input, Vector<uint32_t>& tmp_ids);
+
+    SparseVector
+    remap_sparse_vector_for_query(const SparseVector& input,
+                                  Vector<uint32_t>& tmp_ids,
+                                  Vector<float>& tmp_vals) const;
+
 private:
     mutable std::shared_mutex global_mutex_;
 
@@ -161,6 +170,9 @@ private:
 
     std::shared_ptr<QuantizationParams> quantization_params_;
     uint32_t avg_doc_term_length_{100};
+
+    bool remap_term_ids_{false};
+    std::shared_ptr<TermIdMapper> term_id_mapper_{nullptr};
 };
 
 }  // namespace vsag

--- a/src/algorithm/sindi/sindi.h
+++ b/src/algorithm/sindi/sindi.h
@@ -130,7 +130,8 @@ private:
     search_impl(const SparseTermComputerPtr& computer,
                 const InnerSearchParam& inner_param,
                 Allocator* allocator,
-                bool use_term_lists_heap_insert) const;
+                bool use_term_lists_heap_insert,
+                const SparseVector* original_query = nullptr) const;
 
     std::pair<int64_t, int64_t>
     get_min_max_window_id(const FilterPtr& filter) const;

--- a/src/algorithm/sindi/sindi_parameter.cpp
+++ b/src/algorithm/sindi/sindi_parameter.cpp
@@ -76,6 +76,10 @@ SINDIParameter::FromJson(const JsonType& json) {
     if (json.Contains(SPARSE_DESERIALIZE_WITHOUT_BUFFER)) {
         deserialize_without_buffer = json[SPARSE_DESERIALIZE_WITHOUT_BUFFER].GetBool();
     }
+
+    if (json.Contains(SPARSE_REMAP_TERM_IDS)) {
+        remap_term_ids = json[SPARSE_REMAP_TERM_IDS].GetBool();
+    }
 }
 
 JsonType
@@ -87,6 +91,7 @@ SINDIParameter::ToJson() const {
     json[USE_QUANTIZATION].SetBool(use_quantization);
     json[SPARSE_WINDOW_SIZE].SetInt(window_size);
     json[SPARSE_AVG_DOC_TERM_LENGTH].SetInt(avg_doc_term_length);
+    json[SPARSE_REMAP_TERM_IDS].SetBool(remap_term_ids);
     return json;
 }
 
@@ -112,6 +117,9 @@ SINDIParameter::CheckCompatibility(const vsag::ParamPtr& other) const {
         return false;
     }
     if (this->avg_doc_term_length != sindi_param->avg_doc_term_length) {
+        return false;
+    }
+    if (this->remap_term_ids != sindi_param->remap_term_ids) {
         return false;
     }
     return true;

--- a/src/algorithm/sindi/sindi_parameter.h
+++ b/src/algorithm/sindi/sindi_parameter.h
@@ -48,6 +48,8 @@ public:
 
     bool use_quantization{false};
 
+    bool remap_term_ids{false};
+
     // temporal parameter
     bool deserialize_without_footer{false};
     bool deserialize_without_buffer{false};

--- a/src/algorithm/sindi/sindi_parameter_test.cpp
+++ b/src/algorithm/sindi/sindi_parameter_test.cpp
@@ -46,6 +46,7 @@ struct SINDIDefaultParam {
     int window_size = 55555;
     int term_id_limit = 10000;
     int avg_doc_term_length = 100;
+    bool remap_term_ids = false;
 };
 
 std::string
@@ -57,6 +58,7 @@ generate_sindi_param(const SINDIDefaultParam& param) {
     json[SPARSE_WINDOW_SIZE].SetInt(param.window_size);
     json[SPARSE_TERM_ID_LIMIT].SetInt(param.term_id_limit);
     json[SPARSE_AVG_DOC_TERM_LENGTH].SetInt(param.avg_doc_term_length);
+    json[SPARSE_REMAP_TERM_IDS].SetBool(param.remap_term_ids);
     return json.Dump();
 }
 
@@ -72,6 +74,7 @@ TEST_CASE("SINDI Index Parameters Test", "[ut][SINDIParameter]") {
     REQUIRE(param->window_size == default_param.window_size);
     REQUIRE(param->term_id_limit == default_param.term_id_limit);
     REQUIRE(param->avg_doc_term_length == default_param.avg_doc_term_length);
+    REQUIRE(param->remap_term_ids == default_param.remap_term_ids);
 
     vsag::ParameterTest::TestToJson(param);
 
@@ -97,4 +100,45 @@ TEST_CASE("SINDI Index Parameters Compatibility Test", "[ut][SINDIParameter]") {
     TEST_COMPATIBILITY_CASE("term_id_limit compatibility", term_id_limit, 10000, 10001, false);
     TEST_COMPATIBILITY_CASE(
         "avg_doc_term_length compatibility", avg_doc_term_length, 100, 200, false);
+    TEST_COMPATIBILITY_CASE("remap_term_ids compatibility", remap_term_ids, false, true, false);
+}
+
+TEST_CASE("SINDI remap_term_ids Parameter", "[ut][SINDIParameter]") {
+    SECTION("default is false when not specified") {
+        auto param_str = R"({"term_id_limit": 1000, "window_size": 50000})";
+        auto param = std::make_shared<vsag::SINDIParameter>();
+        param->FromJson(vsag::JsonType::Parse(param_str));
+        REQUIRE(param->remap_term_ids == false);
+    }
+
+    SECTION("parse true") {
+        SINDIDefaultParam dp;
+        dp.remap_term_ids = true;
+        auto param_str = generate_sindi_param(dp);
+        auto param = std::make_shared<vsag::SINDIParameter>();
+        param->FromString(param_str);
+        REQUIRE(param->remap_term_ids == true);
+    }
+
+    SECTION("parse false") {
+        SINDIDefaultParam dp;
+        dp.remap_term_ids = false;
+        auto param_str = generate_sindi_param(dp);
+        auto param = std::make_shared<vsag::SINDIParameter>();
+        param->FromString(param_str);
+        REQUIRE(param->remap_term_ids == false);
+    }
+
+    SECTION("round-trip: FromJson -> ToJson -> FromJson") {
+        SINDIDefaultParam dp;
+        dp.remap_term_ids = true;
+        auto param_str = generate_sindi_param(dp);
+        auto param1 = std::make_shared<vsag::SINDIParameter>();
+        param1->FromString(param_str);
+
+        auto json2 = param1->ToJson();
+        auto param2 = std::make_shared<vsag::SINDIParameter>();
+        param2->FromJson(json2);
+        REQUIRE(param2->remap_term_ids == true);
+    }
 }

--- a/src/algorithm/sindi/sindi_test.cpp
+++ b/src/algorithm/sindi/sindi_test.cpp
@@ -15,6 +15,8 @@
 
 #include "sindi.h"
 
+#include <set>
+
 #include "impl/allocator/safe_allocator.h"
 #include "storage/serialization_template_test.h"
 #include "unittest.h"
@@ -330,6 +332,285 @@ TEST_CASE("SINDI Quantization Test", "[ut][SINDI]") {
 
     float recall = static_cast<float>(correct_count) / (num_query * k);
     REQUIRE(recall > 0.99);
+
+    for (auto& item : sv_base) {
+        delete[] item.vals_;
+        delete[] item.ids_;
+    }
+}
+
+TEST_CASE("SINDI Remap Basic Test", "[ut][SINDI]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    IndexCommonParam common_param;
+    common_param.allocator_ = allocator;
+
+    // Sparse term IDs in [0, 5000000] range, but only ~1000 unique terms
+    uint32_t num_base = 500;
+    uint32_t num_query = 50;
+    int64_t max_dim = 64;
+    int64_t max_id = 5000000;  // large sparse range
+    float min_val = 0;
+    float max_val = 10;
+    int seed_base = 42;
+    int64_t k = 10;
+
+    std::vector<int64_t> ids(num_base);
+    for (int64_t i = 0; i < num_base; ++i) {
+        ids[i] = i;
+    }
+
+    auto sv_base =
+        fixtures::GenerateSparseVectors(num_base, max_dim, max_id, min_val, max_val, seed_base);
+    auto base = vsag::Dataset::Make();
+    base->NumElements(num_base)->SparseVectors(sv_base.data())->Ids(ids.data())->Owner(false);
+
+    // Count unique terms to set term_id_limit
+    std::set<uint32_t> unique_terms;
+    for (uint32_t i = 0; i < num_base; ++i) {
+        for (uint32_t j = 0; j < sv_base[i].len_; ++j) {
+            unique_terms.insert(sv_base[i].ids_[j]);
+        }
+    }
+    uint32_t term_id_limit = static_cast<uint32_t>(unique_terms.size()) + 100;  // some headroom
+
+    auto param_str = fmt::format(R"({{
+        "use_reorder": false,
+        "use_quantization": false,
+        "doc_prune_ratio": 0.0,
+        "window_size": 10000,
+        "term_id_limit": {},
+        "remap_term_ids": true,
+        "avg_doc_term_length": 64
+    }})",
+                                 term_id_limit);
+
+    vsag::JsonType param_json = vsag::JsonType::Parse(param_str);
+    auto index_param = std::make_shared<vsag::SINDIParameter>();
+    index_param->FromJson(param_json);
+    auto index = std::make_unique<SINDI>(index_param, common_param);
+    auto another_index = std::make_unique<SINDI>(index_param, common_param);
+
+    // Build a brute-force index for ground truth
+    SparseIndexParameterPtr bf_param = std::make_shared<SparseIndexParameters>();
+    bf_param->need_sort = true;
+    auto bf_index = std::make_unique<SparseIndex>(bf_param, common_param);
+
+    // test build
+    bf_index->Build(base);
+    auto build_res = index->Build(base);
+    REQUIRE(build_res.size() == 0);
+    REQUIRE(index->GetNumElements() == num_base);
+
+    // test serialize/deserialize
+    test_serializion(*index, *another_index);
+    REQUIRE(another_index->GetNumElements() == num_base);
+
+    // test search
+    std::string search_param_str = R"(
+    {
+        "sindi": {
+            "query_prune_ratio": 0.0,
+            "term_prune_ratio": 0.0,
+            "n_candidate": 20,
+            "use_term_lists_heap_insert": false
+        }
+    }
+    )";
+
+    auto query = vsag::Dataset::Make();
+    for (int i = 0; i < num_query; ++i) {
+        query->NumElements(1)->SparseVectors(sv_base.data() + i)->Owner(false);
+
+        auto bf_result = bf_index->KnnSearch(query, k, search_param_str, nullptr);
+        auto result = index->KnnSearch(query, k, search_param_str, nullptr);
+
+        REQUIRE(result->GetDim() == bf_result->GetDim());
+        for (int j = 0; j < result->GetDim(); j++) {
+            REQUIRE(result->GetIds()[j] == bf_result->GetIds()[j]);
+            REQUIRE(std::abs(result->GetDistances()[j] - bf_result->GetDistances()[j]) < 1e-3);
+        }
+
+        // test serialized index gives same results
+        auto another_result = another_index->KnnSearch(query, k, search_param_str, nullptr);
+        for (int j = 0; j < another_result->GetDim(); j++) {
+            REQUIRE(result->GetIds()[j] == another_result->GetIds()[j]);
+        }
+    }
+
+    // test unknown query terms (terms not in the index)
+    {
+        SparseVector unknown_query;
+        uint32_t unknown_ids[] = {max_id + 100, max_id + 200};
+        float unknown_vals[] = {1.0f, 2.0f};
+        unknown_query.len_ = 2;
+        unknown_query.ids_ = unknown_ids;
+        unknown_query.vals_ = unknown_vals;
+        query->NumElements(1)->SparseVectors(&unknown_query)->Owner(false);
+        auto result = index->KnnSearch(query, k, search_param_str, nullptr);
+        REQUIRE(result->GetDim() == 0);  // no matches since all terms are unknown
+    }
+
+    // test incremental add with new terms
+    {
+        uint32_t num_add = 100;
+        std::vector<int64_t> add_ids(num_add);
+        for (uint32_t i = 0; i < num_add; ++i) {
+            add_ids[i] = num_base + i;
+        }
+        auto sv_add =
+            fixtures::GenerateSparseVectors(num_add, max_dim, max_id, min_val, max_val, 99);
+        auto add_data = vsag::Dataset::Make();
+        add_data->NumElements(num_add)
+            ->SparseVectors(sv_add.data())
+            ->Ids(add_ids.data())
+            ->Owner(false);
+        auto add_res = index->Add(add_data);
+        REQUIRE(index->GetNumElements() == num_base + num_add);
+
+        // search still works after incremental add
+        query->NumElements(1)->SparseVectors(sv_add.data())->Owner(false);
+        auto result = index->KnnSearch(query, k, search_param_str, nullptr);
+        REQUIRE(result->GetDim() == k);
+
+        for (auto& item : sv_add) {
+            delete[] item.vals_;
+            delete[] item.ids_;
+        }
+    }
+
+    for (auto& item : sv_base) {
+        delete[] item.vals_;
+        delete[] item.ids_;
+    }
+}
+
+TEST_CASE("SINDI Remap with Reorder Test", "[ut][SINDI]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    IndexCommonParam common_param;
+    common_param.allocator_ = allocator;
+
+    uint32_t num_base = 300;
+    uint32_t num_query = 30;
+    int64_t max_dim = 64;
+    int64_t max_id = 1000000;
+    float min_val = 0;
+    float max_val = 10;
+    int seed_base = 77;
+    int64_t k = 10;
+
+    std::vector<int64_t> ids(num_base);
+    for (int64_t i = 0; i < num_base; ++i) {
+        ids[i] = i;
+    }
+
+    auto sv_base =
+        fixtures::GenerateSparseVectors(num_base, max_dim, max_id, min_val, max_val, seed_base);
+    auto base = vsag::Dataset::Make();
+    base->NumElements(num_base)->SparseVectors(sv_base.data())->Ids(ids.data())->Owner(false);
+
+    std::set<uint32_t> unique_terms;
+    for (uint32_t i = 0; i < num_base; ++i) {
+        for (uint32_t j = 0; j < sv_base[i].len_; ++j) {
+            unique_terms.insert(sv_base[i].ids_[j]);
+        }
+    }
+    uint32_t term_id_limit = static_cast<uint32_t>(unique_terms.size()) + 100;
+
+    auto param_str = fmt::format(R"({{
+        "use_reorder": true,
+        "use_quantization": false,
+        "doc_prune_ratio": 0.0,
+        "window_size": 10000,
+        "term_id_limit": {},
+        "remap_term_ids": true,
+        "avg_doc_term_length": 64
+    }})",
+                                 term_id_limit);
+
+    vsag::JsonType param_json = vsag::JsonType::Parse(param_str);
+    auto index_param = std::make_shared<vsag::SINDIParameter>();
+    index_param->FromJson(param_json);
+    auto index = std::make_unique<SINDI>(index_param, common_param);
+
+    SparseIndexParameterPtr bf_param = std::make_shared<SparseIndexParameters>();
+    bf_param->need_sort = true;
+    auto bf_index = std::make_unique<SparseIndex>(bf_param, common_param);
+
+    bf_index->Build(base);
+    auto build_res = index->Build(base);
+    REQUIRE(build_res.size() == 0);
+
+    std::string search_param_str = R"(
+    {
+        "sindi": {
+            "query_prune_ratio": 0.0,
+            "term_prune_ratio": 0.0,
+            "n_candidate": 20,
+            "use_term_lists_heap_insert": false
+        }
+    }
+    )";
+
+    auto query = vsag::Dataset::Make();
+    for (int i = 0; i < num_query; ++i) {
+        query->NumElements(1)->SparseVectors(sv_base.data() + i)->Owner(false);
+
+        auto bf_result = bf_index->KnnSearch(query, k, search_param_str, nullptr);
+        auto result = index->KnnSearch(query, k, search_param_str, nullptr);
+
+        REQUIRE(result->GetDim() == bf_result->GetDim());
+        for (int j = 0; j < result->GetDim(); j++) {
+            REQUIRE(result->GetIds()[j] == bf_result->GetIds()[j]);
+            REQUIRE(std::abs(result->GetDistances()[j] - bf_result->GetDistances()[j]) < 1e-3);
+        }
+    }
+
+    for (auto& item : sv_base) {
+        delete[] item.vals_;
+        delete[] item.ids_;
+    }
+}
+
+TEST_CASE("SINDI Remap Term ID Limit Exceeded", "[ut][SINDI]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    IndexCommonParam common_param;
+    common_param.allocator_ = allocator;
+
+    // Create index with very small term_id_limit
+    auto param_str = R"({
+        "use_reorder": false,
+        "use_quantization": false,
+        "doc_prune_ratio": 0.0,
+        "window_size": 10000,
+        "term_id_limit": 5,
+        "remap_term_ids": true,
+        "avg_doc_term_length": 64
+    })";
+
+    vsag::JsonType param_json = vsag::JsonType::Parse(param_str);
+    auto index_param = std::make_shared<vsag::SINDIParameter>();
+    index_param->FromJson(param_json);
+    auto index = std::make_unique<SINDI>(index_param, common_param);
+
+    // Generate data with more than 5 unique terms
+    uint32_t num_base = 10;
+    int64_t max_dim = 10;
+    int64_t max_id = 1000;
+    auto sv_base = fixtures::GenerateSparseVectors(num_base, max_dim, max_id, 0, 10, 123);
+
+    std::vector<int64_t> ids(num_base);
+    for (int64_t i = 0; i < num_base; ++i) {
+        ids[i] = i;
+    }
+
+    auto base = vsag::Dataset::Make();
+    base->NumElements(num_base)->SparseVectors(sv_base.data())->Ids(ids.data())->Owner(false);
+
+    // Some docs should fail because term_id_limit=5 is too small
+    auto failed = index->Build(base);
+    REQUIRE(failed.size() > 0);  // at least some should fail
+    // But some should succeed (the first few docs with <= 5 unique terms total)
+    REQUIRE(index->GetNumElements() > 0);
 
     for (auto& item : sv_base) {
         delete[] item.vals_;

--- a/src/algorithm/sindi/sindi_test.cpp
+++ b/src/algorithm/sindi/sindi_test.cpp
@@ -344,11 +344,11 @@ TEST_CASE("SINDI Remap Basic Test", "[ut][SINDI]") {
     IndexCommonParam common_param;
     common_param.allocator_ = allocator;
 
-    // Sparse term IDs in [0, 5000000] range, but only ~1000 unique terms
-    uint32_t num_base = 500;
-    uint32_t num_query = 50;
-    int64_t max_dim = 64;
-    int64_t max_id = 5000000;  // large sparse range
+    // Same density as original SINDI test but with large sparse term IDs
+    uint32_t num_base = 1000;
+    uint32_t num_query = 100;
+    int64_t max_dim = 128;
+    int64_t max_id = 30000;  // same as original test for good overlap
     float min_val = 0;
     float max_val = 10;
     int seed_base = 42;
@@ -361,6 +361,16 @@ TEST_CASE("SINDI Remap Basic Test", "[ut][SINDI]") {
 
     auto sv_base =
         fixtures::GenerateSparseVectors(num_base, max_dim, max_id, min_val, max_val, seed_base);
+
+    // Shift all term IDs by a large offset to make them sparse in uint32 range
+    // This simulates real-world vocabulary IDs that are non-contiguous
+    constexpr uint32_t id_offset = 3000000;
+    for (uint32_t i = 0; i < num_base; ++i) {
+        for (uint32_t j = 0; j < sv_base[i].len_; ++j) {
+            sv_base[i].ids_[j] += id_offset;
+        }
+    }
+
     auto base = vsag::Dataset::Make();
     base->NumElements(num_base)->SparseVectors(sv_base.data())->Ids(ids.data())->Owner(false);
 
@@ -371,16 +381,16 @@ TEST_CASE("SINDI Remap Basic Test", "[ut][SINDI]") {
             unique_terms.insert(sv_base[i].ids_[j]);
         }
     }
-    uint32_t term_id_limit = static_cast<uint32_t>(unique_terms.size()) + 100;  // some headroom
+    uint32_t term_id_limit = static_cast<uint32_t>(unique_terms.size()) + 3000;
 
     auto param_str = fmt::format(R"({{
-        "use_reorder": false,
+        "use_reorder": true,
         "use_quantization": false,
         "doc_prune_ratio": 0.0,
         "window_size": 10000,
         "term_id_limit": {},
         "remap_term_ids": true,
-        "avg_doc_term_length": 64
+        "avg_doc_term_length": 100
     }})",
                                  term_id_limit);
 
@@ -390,12 +400,11 @@ TEST_CASE("SINDI Remap Basic Test", "[ut][SINDI]") {
     auto index = std::make_unique<SINDI>(index_param, common_param);
     auto another_index = std::make_unique<SINDI>(index_param, common_param);
 
-    // Build a brute-force index for ground truth
+    // Build a brute-force index for ground truth (uses original sparse IDs directly)
     SparseIndexParameterPtr bf_param = std::make_shared<SparseIndexParameters>();
     bf_param->need_sort = true;
     auto bf_index = std::make_unique<SparseIndex>(bf_param, common_param);
 
-    // test build
     bf_index->Build(base);
     auto build_res = index->Build(base);
     REQUIRE(build_res.size() == 0);
@@ -437,20 +446,20 @@ TEST_CASE("SINDI Remap Basic Test", "[ut][SINDI]") {
         }
     }
 
-    // test unknown query terms (terms not in the index)
+    // test unknown query terms
     {
         SparseVector unknown_query;
-        uint32_t unknown_ids[] = {max_id + 100, max_id + 200};
+        uint32_t unknown_ids[] = {1, 2};  // IDs not in [id_offset, id_offset+max_id]
         float unknown_vals[] = {1.0f, 2.0f};
         unknown_query.len_ = 2;
         unknown_query.ids_ = unknown_ids;
         unknown_query.vals_ = unknown_vals;
         query->NumElements(1)->SparseVectors(&unknown_query)->Owner(false);
         auto result = index->KnnSearch(query, k, search_param_str, nullptr);
-        REQUIRE(result->GetDim() == 0);  // no matches since all terms are unknown
+        REQUIRE(result->GetDim() == 0);
     }
 
-    // test incremental add with new terms
+    // test incremental add
     {
         uint32_t num_add = 100;
         std::vector<int64_t> add_ids(num_add);
@@ -459,6 +468,11 @@ TEST_CASE("SINDI Remap Basic Test", "[ut][SINDI]") {
         }
         auto sv_add =
             fixtures::GenerateSparseVectors(num_add, max_dim, max_id, min_val, max_val, 99);
+        for (uint32_t i = 0; i < num_add; ++i) {
+            for (uint32_t j = 0; j < sv_add[i].len_; ++j) {
+                sv_add[i].ids_[j] += id_offset;
+            }
+        }
         auto add_data = vsag::Dataset::Make();
         add_data->NumElements(num_add)
             ->SparseVectors(sv_add.data())
@@ -467,7 +481,6 @@ TEST_CASE("SINDI Remap Basic Test", "[ut][SINDI]") {
         auto add_res = index->Add(add_data);
         REQUIRE(index->GetNumElements() == num_base + num_add);
 
-        // search still works after incremental add
         query->NumElements(1)->SparseVectors(sv_add.data())->Owner(false);
         auto result = index->KnnSearch(query, k, search_param_str, nullptr);
         REQUIRE(result->GetDim() == k);
@@ -484,19 +497,21 @@ TEST_CASE("SINDI Remap Basic Test", "[ut][SINDI]") {
     }
 }
 
+
 TEST_CASE("SINDI Remap with Reorder Test", "[ut][SINDI]") {
     auto allocator = SafeAllocator::FactoryDefaultAllocator();
     IndexCommonParam common_param;
     common_param.allocator_ = allocator;
 
-    uint32_t num_base = 300;
-    uint32_t num_query = 30;
-    int64_t max_dim = 64;
-    int64_t max_id = 1000000;
+    uint32_t num_base = 1000;
+    uint32_t num_query = 100;
+    int64_t max_dim = 128;
+    int64_t max_id = 30000;
     float min_val = 0;
     float max_val = 10;
     int seed_base = 77;
     int64_t k = 10;
+    constexpr uint32_t id_offset = 2000000;
 
     std::vector<int64_t> ids(num_base);
     for (int64_t i = 0; i < num_base; ++i) {
@@ -505,6 +520,11 @@ TEST_CASE("SINDI Remap with Reorder Test", "[ut][SINDI]") {
 
     auto sv_base =
         fixtures::GenerateSparseVectors(num_base, max_dim, max_id, min_val, max_val, seed_base);
+    for (uint32_t i = 0; i < num_base; ++i) {
+        for (uint32_t j = 0; j < sv_base[i].len_; ++j) {
+            sv_base[i].ids_[j] += id_offset;
+        }
+    }
     auto base = vsag::Dataset::Make();
     base->NumElements(num_base)->SparseVectors(sv_base.data())->Ids(ids.data())->Owner(false);
 
@@ -523,7 +543,7 @@ TEST_CASE("SINDI Remap with Reorder Test", "[ut][SINDI]") {
         "window_size": 10000,
         "term_id_limit": {},
         "remap_term_ids": true,
-        "avg_doc_term_length": 64
+        "avg_doc_term_length": 100
     }})",
                                  term_id_limit);
 
@@ -576,41 +596,389 @@ TEST_CASE("SINDI Remap Term ID Limit Exceeded", "[ut][SINDI]") {
     IndexCommonParam common_param;
     common_param.allocator_ = allocator;
 
-    // Create index with very small term_id_limit
-    auto param_str = R"({
+    // Use small max_id so first doc has reasonable unique term count
+    auto sv_base = fixtures::GenerateSparseVectors(10, 10, 50, 0, 10, 123);
+
+    // Count unique terms in first doc to set a limit that allows first doc but not all
+    std::set<uint32_t> first_doc_terms;
+    for (uint32_t j = 0; j < sv_base[0].len_; ++j) {
+        first_doc_terms.insert(sv_base[0].ids_[j]);
+    }
+    uint32_t term_id_limit = static_cast<uint32_t>(first_doc_terms.size()) + 2;
+
+    auto param_str = fmt::format(R"({{
         "use_reorder": false,
         "use_quantization": false,
         "doc_prune_ratio": 0.0,
         "window_size": 10000,
-        "term_id_limit": 5,
+        "term_id_limit": {},
         "remap_term_ids": true,
-        "avg_doc_term_length": 64
-    })";
+        "avg_doc_term_length": 10
+    }})",
+                                 term_id_limit);
 
     vsag::JsonType param_json = vsag::JsonType::Parse(param_str);
     auto index_param = std::make_shared<vsag::SINDIParameter>();
     index_param->FromJson(param_json);
     auto index = std::make_unique<SINDI>(index_param, common_param);
 
-    // Generate data with more than 5 unique terms
-    uint32_t num_base = 10;
-    int64_t max_dim = 10;
-    int64_t max_id = 1000;
-    auto sv_base = fixtures::GenerateSparseVectors(num_base, max_dim, max_id, 0, 10, 123);
+    std::vector<int64_t> ids(10);
+    for (int64_t i = 0; i < 10; ++i) {
+        ids[i] = i;
+    }
+
+    auto base = vsag::Dataset::Make();
+    base->NumElements(10)->SparseVectors(sv_base.data())->Ids(ids.data())->Owner(false);
+
+    auto failed = index->Build(base);
+    REQUIRE(failed.size() > 0);
+    REQUIRE(index->GetNumElements() > 0);
+
+    for (auto& item : sv_base) {
+        delete[] item.vals_;
+        delete[] item.ids_;
+    }
+}
+
+TEST_CASE("SINDI Remap with Quantization Test", "[ut][SINDI]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    IndexCommonParam common_param;
+    common_param.allocator_ = allocator;
+
+    uint32_t num_base = 1000;
+    uint32_t num_query = 100;
+    int64_t max_dim = 128;
+    int64_t max_id = 30000;
+    float min_val = 0;
+    float max_val = 10;
+    int seed_base = 55;
+    int64_t k = 10;
+    constexpr uint32_t id_offset = 2000000;
 
     std::vector<int64_t> ids(num_base);
     for (int64_t i = 0; i < num_base; ++i) {
         ids[i] = i;
     }
 
+    auto sv_base =
+        fixtures::GenerateSparseVectors(num_base, max_dim, max_id, min_val, max_val, seed_base);
+    for (uint32_t i = 0; i < num_base; ++i) {
+        for (uint32_t j = 0; j < sv_base[i].len_; ++j) {
+            sv_base[i].ids_[j] += id_offset;
+        }
+    }
     auto base = vsag::Dataset::Make();
     base->NumElements(num_base)->SparseVectors(sv_base.data())->Ids(ids.data())->Owner(false);
 
-    // Some docs should fail because term_id_limit=5 is too small
-    auto failed = index->Build(base);
-    REQUIRE(failed.size() > 0);  // at least some should fail
-    // But some should succeed (the first few docs with <= 5 unique terms total)
-    REQUIRE(index->GetNumElements() > 0);
+    std::set<uint32_t> unique_terms;
+    for (uint32_t i = 0; i < num_base; ++i) {
+        for (uint32_t j = 0; j < sv_base[i].len_; ++j) {
+            unique_terms.insert(sv_base[i].ids_[j]);
+        }
+    }
+    uint32_t term_id_limit = static_cast<uint32_t>(unique_terms.size()) + 100;
+
+    auto param_str = fmt::format(R"({{
+        "use_reorder": true,
+        "use_quantization": true,
+        "doc_prune_ratio": 0.0,
+        "window_size": 10000,
+        "term_id_limit": {},
+        "remap_term_ids": true,
+        "avg_doc_term_length": 100
+    }})",
+                                 term_id_limit);
+
+    vsag::JsonType param_json = vsag::JsonType::Parse(param_str);
+    auto index_param = std::make_shared<vsag::SINDIParameter>();
+    index_param->FromJson(param_json);
+    auto index = std::make_unique<SINDI>(index_param, common_param);
+
+    SparseIndexParameterPtr bf_param = std::make_shared<SparseIndexParameters>();
+    bf_param->need_sort = true;
+    auto bf_index = std::make_unique<SparseIndex>(bf_param, common_param);
+
+    bf_index->Build(base);
+    auto build_res = index->Build(base);
+    REQUIRE(build_res.size() == 0);
+
+    std::string search_param_str = R"(
+    {
+        "sindi": {
+            "query_prune_ratio": 0.0,
+            "term_prune_ratio": 0.0,
+            "n_candidate": 20,
+            "use_term_lists_heap_insert": false
+        }
+    }
+    )";
+
+    auto query = vsag::Dataset::Make();
+    int64_t correct_count = 0;
+    for (int i = 0; i < num_query; ++i) {
+        query->NumElements(1)->SparseVectors(sv_base.data() + i)->Owner(false);
+
+        auto bf_result = bf_index->KnnSearch(query, k, search_param_str, nullptr);
+        auto result = index->KnnSearch(query, k, search_param_str, nullptr);
+
+        REQUIRE(result->GetDim() == bf_result->GetDim());
+
+        std::unordered_set<int64_t> gt_ids;
+        for (int j = 0; j < k; j++) {
+            gt_ids.insert(bf_result->GetIds()[j]);
+        }
+        for (int j = 0; j < k; j++) {
+            if (gt_ids.find(result->GetIds()[j]) != gt_ids.end()) {
+                correct_count++;
+            }
+        }
+    }
+
+    float recall = static_cast<float>(correct_count) / (num_query * k);
+    REQUIRE(recall > 0.95);
+
+    for (auto& item : sv_base) {
+        delete[] item.vals_;
+        delete[] item.ids_;
+    }
+}
+
+TEST_CASE("SINDI Remap with Filter Test", "[ut][SINDI]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    IndexCommonParam common_param;
+    common_param.allocator_ = allocator;
+
+    uint32_t num_base = 1000;
+    uint32_t num_query = 100;
+    int64_t max_dim = 128;
+    int64_t max_id = 30000;
+    float min_val = 0;
+    float max_val = 10;
+    int seed_base = 66;
+    int64_t k = 10;
+    constexpr uint32_t id_offset = 2000000;
+
+    std::vector<int64_t> ids(num_base);
+    for (int64_t i = 0; i < num_base; ++i) {
+        ids[i] = i;
+    }
+
+    auto sv_base =
+        fixtures::GenerateSparseVectors(num_base, max_dim, max_id, min_val, max_val, seed_base);
+    for (uint32_t i = 0; i < num_base; ++i) {
+        for (uint32_t j = 0; j < sv_base[i].len_; ++j) {
+            sv_base[i].ids_[j] += id_offset;
+        }
+    }
+    auto base = vsag::Dataset::Make();
+    base->NumElements(num_base)->SparseVectors(sv_base.data())->Ids(ids.data())->Owner(false);
+
+    std::set<uint32_t> unique_terms;
+    for (uint32_t i = 0; i < num_base; ++i) {
+        for (uint32_t j = 0; j < sv_base[i].len_; ++j) {
+            unique_terms.insert(sv_base[i].ids_[j]);
+        }
+    }
+    uint32_t term_id_limit = static_cast<uint32_t>(unique_terms.size()) + 100;
+
+    auto param_str = fmt::format(R"({{
+        "use_reorder": false,
+        "use_quantization": false,
+        "doc_prune_ratio": 0.0,
+        "window_size": 10000,
+        "term_id_limit": {},
+        "remap_term_ids": true,
+        "avg_doc_term_length": 100
+    }})",
+                                 term_id_limit);
+
+    vsag::JsonType param_json = vsag::JsonType::Parse(param_str);
+    auto index_param = std::make_shared<vsag::SINDIParameter>();
+    index_param->FromJson(param_json);
+    auto index = std::make_unique<SINDI>(index_param, common_param);
+
+    auto build_res = index->Build(base);
+    REQUIRE(build_res.size() == 0);
+
+    std::string search_param_str = R"(
+    {
+        "sindi": {
+            "query_prune_ratio": 0.0,
+            "term_prune_ratio": 0.0,
+            "n_candidate": 20,
+            "use_term_lists_heap_insert": false
+        }
+    }
+    )";
+
+    auto mock_filter = std::make_shared<MockFilter>();
+    auto query = vsag::Dataset::Make();
+
+    for (int i = 0; i < num_query; ++i) {
+        query->NumElements(1)->SparseVectors(sv_base.data() + i)->Owner(false);
+
+        auto result = index->KnnSearch(query, k, search_param_str, nullptr);
+        auto filter_result = index->KnnSearch(query, k, search_param_str, mock_filter);
+
+        REQUIRE(filter_result->GetDim() == k);
+        for (int j = 0; j < filter_result->GetDim(); j++) {
+            REQUIRE(mock_filter->CheckValid(filter_result->GetIds()[j]));
+        }
+
+        auto cur = 0;
+        for (int j = 0; j < k && cur < filter_result->GetDim(); j++) {
+            if (mock_filter->CheckValid(result->GetIds()[j])) {
+                REQUIRE(result->GetIds()[j] == filter_result->GetIds()[cur]);
+                cur++;
+            }
+        }
+    }
+
+    for (auto& item : sv_base) {
+        delete[] item.vals_;
+        delete[] item.ids_;
+    }
+}
+
+TEST_CASE("SINDI Remap GetSparseVectorByInnerId Reverse Mapping", "[ut][SINDI]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    IndexCommonParam common_param;
+    common_param.allocator_ = allocator;
+
+    uint32_t num_base = 50;
+    int64_t max_dim = 32;
+    int64_t max_id = 5000;
+    float min_val = 0;
+    float max_val = 10;
+    int seed_base = 88;
+    constexpr uint32_t id_offset = 4000000;
+
+    std::vector<int64_t> ids(num_base);
+    for (int64_t i = 0; i < num_base; ++i) {
+        ids[i] = i;
+    }
+
+    auto sv_base =
+        fixtures::GenerateSparseVectors(num_base, max_dim, max_id, min_val, max_val, seed_base);
+    for (uint32_t i = 0; i < num_base; ++i) {
+        for (uint32_t j = 0; j < sv_base[i].len_; ++j) {
+            sv_base[i].ids_[j] += id_offset;
+        }
+    }
+    auto base = vsag::Dataset::Make();
+    base->NumElements(num_base)->SparseVectors(sv_base.data())->Ids(ids.data())->Owner(false);
+
+    std::set<uint32_t> unique_terms;
+    for (uint32_t i = 0; i < num_base; ++i) {
+        for (uint32_t j = 0; j < sv_base[i].len_; ++j) {
+            unique_terms.insert(sv_base[i].ids_[j]);
+        }
+    }
+    uint32_t term_id_limit = static_cast<uint32_t>(unique_terms.size()) + 100;
+
+    auto param_str = fmt::format(R"({{
+        "use_reorder": false,
+        "use_quantization": false,
+        "doc_prune_ratio": 0.0,
+        "window_size": 10000,
+        "term_id_limit": {},
+        "remap_term_ids": true,
+        "avg_doc_term_length": 32
+    }})",
+                                 term_id_limit);
+
+    vsag::JsonType param_json = vsag::JsonType::Parse(param_str);
+    auto index_param = std::make_shared<vsag::SINDIParameter>();
+    index_param->FromJson(param_json);
+    auto index = std::make_unique<SINDI>(index_param, common_param);
+
+    auto build_res = index->Build(base);
+    REQUIRE(build_res.size() == 0);
+
+    for (uint32_t i = 0; i < num_base; ++i) {
+        SparseVector retrieved;
+        index->GetSparseVectorByInnerId(i, &retrieved, allocator.get());
+
+        std::set<uint32_t> original_ids;
+        for (uint32_t j = 0; j < sv_base[i].len_; ++j) {
+            original_ids.insert(sv_base[i].ids_[j]);
+        }
+
+        for (uint32_t j = 0; j < retrieved.len_; ++j) {
+            REQUIRE(original_ids.count(retrieved.ids_[j]) > 0);
+        }
+
+        allocator->Deallocate(retrieved.ids_);
+        allocator->Deallocate(retrieved.vals_);
+    }
+
+    for (auto& item : sv_base) {
+        delete[] item.vals_;
+        delete[] item.ids_;
+    }
+}
+
+TEST_CASE("SINDI Remap UpdateVector Compatibility", "[ut][SINDI]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    IndexCommonParam common_param;
+    common_param.allocator_ = allocator;
+
+    uint32_t num_base = 50;
+    int64_t max_dim = 32;
+    int64_t max_id = 5000;
+    float min_val = 0;
+    float max_val = 10;
+    int seed_base = 33;
+    constexpr uint32_t id_offset = 4000000;
+
+    std::vector<int64_t> ids(num_base);
+    for (int64_t i = 0; i < num_base; ++i) {
+        ids[i] = i;
+    }
+
+    auto sv_base =
+        fixtures::GenerateSparseVectors(num_base, max_dim, max_id, min_val, max_val, seed_base);
+    for (uint32_t i = 0; i < num_base; ++i) {
+        for (uint32_t j = 0; j < sv_base[i].len_; ++j) {
+            sv_base[i].ids_[j] += id_offset;
+        }
+    }
+    auto base = vsag::Dataset::Make();
+    base->NumElements(num_base)->SparseVectors(sv_base.data())->Ids(ids.data())->Owner(false);
+
+    std::set<uint32_t> unique_terms;
+    for (uint32_t i = 0; i < num_base; ++i) {
+        for (uint32_t j = 0; j < sv_base[i].len_; ++j) {
+            unique_terms.insert(sv_base[i].ids_[j]);
+        }
+    }
+    uint32_t term_id_limit = static_cast<uint32_t>(unique_terms.size()) + 100;
+
+    auto param_str = fmt::format(R"({{
+        "use_reorder": false,
+        "use_quantization": false,
+        "doc_prune_ratio": 0.0,
+        "window_size": 10000,
+        "term_id_limit": {},
+        "remap_term_ids": true,
+        "avg_doc_term_length": 32
+    }})",
+                                 term_id_limit);
+
+    vsag::JsonType param_json = vsag::JsonType::Parse(param_str);
+    auto index_param = std::make_shared<vsag::SINDIParameter>();
+    index_param->FromJson(param_json);
+    auto index = std::make_unique<SINDI>(index_param, common_param);
+
+    auto build_res = index->Build(base);
+    REQUIRE(build_res.size() == 0);
+
+    for (uint32_t i = 0; i < std::min(num_base, 10u); ++i) {
+        auto update_data = vsag::Dataset::Make();
+        update_data->NumElements(1)->SparseVectors(sv_base.data() + i)->Owner(false);
+        bool result = index->UpdateVector(ids[i], update_data);
+        REQUIRE(result == true);
+    }
 
     for (auto& item : sv_base) {
         delete[] item.vals_;

--- a/src/algorithm/sindi/sindi_test.cpp
+++ b/src/algorithm/sindi/sindi_test.cpp
@@ -497,7 +497,6 @@ TEST_CASE("SINDI Remap Basic Test", "[ut][SINDI]") {
     }
 }
 
-
 TEST_CASE("SINDI Remap with Reorder Test", "[ut][SINDI]") {
     auto allocator = SafeAllocator::FactoryDefaultAllocator();
     IndexCommonParam common_param;
@@ -979,6 +978,255 @@ TEST_CASE("SINDI Remap UpdateVector Compatibility", "[ut][SINDI]") {
         bool result = index->UpdateVector(ids[i], update_data);
         REQUIRE(result == true);
     }
+
+    for (auto& item : sv_base) {
+        delete[] item.vals_;
+        delete[] item.ids_;
+    }
+}
+
+TEST_CASE("SINDI Remap Memory Comparison", "[ut][SINDI]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    IndexCommonParam common_param;
+    common_param.allocator_ = allocator;
+
+    // Generate data with dense overlap but large sparse term IDs
+    uint32_t num_base = 500;
+    int64_t max_dim = 64;
+    int64_t max_id = 30000;
+    float min_val = 0;
+    float max_val = 10;
+    int seed_base = 42;
+    constexpr uint32_t id_offset = 5000000;  // shift IDs to simulate sparse vocab
+
+    std::vector<int64_t> ids(num_base);
+    for (int64_t i = 0; i < num_base; ++i) {
+        ids[i] = i;
+    }
+
+    auto sv_base =
+        fixtures::GenerateSparseVectors(num_base, max_dim, max_id, min_val, max_val, seed_base);
+
+    // Make a copy before shifting (for the no-remap index)
+    std::vector<SparseVector> sv_base_shifted(num_base);
+    for (uint32_t i = 0; i < num_base; ++i) {
+        sv_base_shifted[i].len_ = sv_base[i].len_;
+        sv_base_shifted[i].ids_ = new uint32_t[sv_base[i].len_];
+        sv_base_shifted[i].vals_ = new float[sv_base[i].len_];
+        for (uint32_t j = 0; j < sv_base[i].len_; ++j) {
+            sv_base_shifted[i].ids_[j] = sv_base[i].ids_[j] + id_offset;
+            sv_base_shifted[i].vals_[j] = sv_base[i].vals_[j];
+        }
+    }
+
+    // Count unique terms
+    std::set<uint32_t> unique_terms;
+    for (uint32_t i = 0; i < num_base; ++i) {
+        for (uint32_t j = 0; j < sv_base_shifted[i].len_; ++j) {
+            unique_terms.insert(sv_base_shifted[i].ids_[j]);
+        }
+    }
+    uint32_t unique_count = static_cast<uint32_t>(unique_terms.size());
+
+    // Index WITHOUT remap: needs term_id_limit >= max_shifted_id
+    uint32_t no_remap_limit = id_offset + max_id + 1;  // ~5030001
+    auto no_remap_param_str = fmt::format(R"({{
+        "use_reorder": false,
+        "use_quantization": false,
+        "doc_prune_ratio": 0.0,
+        "window_size": 10000,
+        "term_id_limit": {},
+        "remap_term_ids": false,
+        "avg_doc_term_length": 64
+    }})",
+                                          no_remap_limit);
+
+    auto no_remap_json = vsag::JsonType::Parse(no_remap_param_str);
+    auto no_remap_param = std::make_shared<vsag::SINDIParameter>();
+    no_remap_param->FromJson(no_remap_json);
+    auto no_remap_index = std::make_unique<SINDI>(no_remap_param, common_param);
+
+    auto base_no_remap = vsag::Dataset::Make();
+    base_no_remap->NumElements(num_base)
+        ->SparseVectors(sv_base_shifted.data())
+        ->Ids(ids.data())
+        ->Owner(false);
+    auto res1 = no_remap_index->Build(base_no_remap);
+    REQUIRE(res1.size() == 0);
+
+    // Index WITH remap: term_id_limit = unique terms + headroom
+    uint32_t remap_limit = unique_count + 100;
+    auto remap_param_str = fmt::format(R"({{
+        "use_reorder": false,
+        "use_quantization": false,
+        "doc_prune_ratio": 0.0,
+        "window_size": 10000,
+        "term_id_limit": {},
+        "remap_term_ids": true,
+        "avg_doc_term_length": 64
+    }})",
+                                       remap_limit);
+
+    auto remap_json = vsag::JsonType::Parse(remap_param_str);
+    auto remap_param = std::make_shared<vsag::SINDIParameter>();
+    remap_param->FromJson(remap_json);
+    auto remap_index = std::make_unique<SINDI>(remap_param, common_param);
+
+    auto base_remap = vsag::Dataset::Make();
+    base_remap->NumElements(num_base)
+        ->SparseVectors(sv_base_shifted.data())
+        ->Ids(ids.data())
+        ->Owner(false);
+    auto res2 = remap_index->Build(base_remap);
+    REQUIRE(res2.size() == 0);
+
+    // Compare memory usage
+    auto mem_no_remap = no_remap_index->EstimateMemory(num_base);
+    auto mem_remap = remap_index->EstimateMemory(num_base);
+
+    // Remap should use significantly less memory
+    // no_remap: ~5M slots × 20B = ~100MB overhead
+    // remap: ~30K slots × 20B + mapper = ~2MB overhead
+    REQUIRE(mem_remap < mem_no_remap);
+    float savings_ratio = 1.0f - static_cast<float>(mem_remap) / static_cast<float>(mem_no_remap);
+    WARN("Memory comparison: no_remap=" << mem_no_remap << " remap=" << mem_remap << " savings=" << savings_ratio << " unique_terms=" << unique_count);
+    REQUIRE(savings_ratio > 0.9f);  // at least 90% memory reduction
+
+    for (auto& item : sv_base) {
+        delete[] item.vals_;
+        delete[] item.ids_;
+    }
+    for (auto& item : sv_base_shifted) {
+        delete[] item.ids_;
+        delete[] item.vals_;
+    }
+}
+
+TEST_CASE("SINDI Remap Memory Comparison - MD5 Vocabulary", "[ut][SINDI]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    IndexCommonParam common_param;
+    common_param.allocator_ = allocator;
+
+    // Simulate MD5 hash-based tokenizer: term IDs scattered across uint32 range
+    // Actual unique terms ~5M, but raw IDs could be anywhere in [0, 2^32)
+    // Without remap: term_id_limit must be >= max_raw_id (impossible if > 10M)
+    // With remap: term_id_limit = 5M (fits within 10M limit)
+
+    // We can't actually test with 5M terms (too slow in QEMU), so we use
+    // a scaled-down version that demonstrates the same principle:
+    // 50K unique terms with raw IDs scattered in [0, 10M) range
+    uint32_t num_base = 500;
+    int64_t max_dim = 64;
+    int64_t max_id = 10000;  // base range for generation
+    float min_val = 0;
+    float max_val = 10;
+    int seed_base = 77;
+
+    std::vector<int64_t> ids(num_base);
+    for (int64_t i = 0; i < num_base; ++i) {
+        ids[i] = i;
+    }
+
+    auto sv_base =
+        fixtures::GenerateSparseVectors(num_base, max_dim, max_id, min_val, max_val, seed_base);
+
+    // Simulate MD5: scatter term IDs across a large range using a hash-like transform
+    std::mt19937 rng(12345);
+    std::unordered_map<uint32_t, uint32_t> id_scatter;
+    for (uint32_t i = 0; i < num_base; ++i) {
+        for (uint32_t j = 0; j < sv_base[i].len_; ++j) {
+            uint32_t orig = sv_base[i].ids_[j];
+            if (id_scatter.find(orig) == id_scatter.end()) {
+                // Map to a random ID in [0, 9999999] (simulating MD5 spread)
+                id_scatter[orig] = rng() % 10000000;
+            }
+            sv_base[i].ids_[j] = id_scatter[orig];
+        }
+    }
+
+    // Find max scattered ID
+    uint32_t max_scattered_id = 0;
+    std::set<uint32_t> unique_terms;
+    for (uint32_t i = 0; i < num_base; ++i) {
+        for (uint32_t j = 0; j < sv_base[i].len_; ++j) {
+            unique_terms.insert(sv_base[i].ids_[j]);
+            max_scattered_id = std::max(max_scattered_id, sv_base[i].ids_[j]);
+        }
+    }
+    uint32_t unique_count = static_cast<uint32_t>(unique_terms.size());
+
+    // Without remap: needs term_id_limit >= max_scattered_id + 1
+    uint32_t no_remap_limit = max_scattered_id + 1;
+
+    // With remap: only needs unique_count
+    uint32_t remap_limit = unique_count + 100;
+
+    auto base = vsag::Dataset::Make();
+    base->NumElements(num_base)->SparseVectors(sv_base.data())->Ids(ids.data())->Owner(false);
+
+    // Build without remap
+    auto no_remap_param_str = fmt::format(R"({{
+        "use_reorder": false,
+        "use_quantization": false,
+        "doc_prune_ratio": 0.0,
+        "window_size": 10000,
+        "term_id_limit": {},
+        "remap_term_ids": false,
+        "avg_doc_term_length": 64
+    }})",
+                                          no_remap_limit);
+
+    auto no_remap_json = vsag::JsonType::Parse(no_remap_param_str);
+    auto no_remap_param = std::make_shared<vsag::SINDIParameter>();
+    no_remap_param->FromJson(no_remap_json);
+    auto no_remap_index = std::make_unique<SINDI>(no_remap_param, common_param);
+    auto res1 = no_remap_index->Build(base);
+    REQUIRE(res1.size() == 0);
+
+    // Build with remap
+    auto remap_param_str = fmt::format(R"({{
+        "use_reorder": false,
+        "use_quantization": false,
+        "doc_prune_ratio": 0.0,
+        "window_size": 10000,
+        "term_id_limit": {},
+        "remap_term_ids": true,
+        "avg_doc_term_length": 64
+    }})",
+                                       remap_limit);
+
+    auto remap_json = vsag::JsonType::Parse(remap_param_str);
+    auto remap_param = std::make_shared<vsag::SINDIParameter>();
+    remap_param->FromJson(remap_json);
+    auto remap_index = std::make_unique<SINDI>(remap_param, common_param);
+    auto res2 = remap_index->Build(base);
+    REQUIRE(res2.size() == 0);
+
+    // Compare memory
+    auto mem_no_remap = no_remap_index->EstimateMemory(num_base);
+    auto mem_remap = remap_index->EstimateMemory(num_base);
+    float savings_ratio = 1.0f - static_cast<float>(mem_remap) / static_cast<float>(mem_no_remap);
+    WARN("MD5 vocab comparison: no_remap=" << mem_no_remap << " remap=" << mem_remap << " savings=" << savings_ratio << " unique_terms=" << unique_count << " max_id=" << max_scattered_id);
+
+    REQUIRE(mem_remap < mem_no_remap);
+    REQUIRE(savings_ratio > 0.9f);
+
+    // Verify search still works with remap
+    std::string search_param_str = R"(
+    {
+        "sindi": {
+            "query_prune_ratio": 0.0,
+            "term_prune_ratio": 0.0,
+            "n_candidate": 20,
+            "use_term_lists_heap_insert": false
+        }
+    }
+    )";
+
+    auto query = vsag::Dataset::Make();
+    query->NumElements(1)->SparseVectors(sv_base.data())->Owner(false);
+    auto result = remap_index->KnnSearch(query, 5, search_param_str, nullptr);
+    REQUIRE(result->GetDim() > 0);
 
     for (auto& item : sv_base) {
         delete[] item.vals_;

--- a/src/algorithm/sindi/sindi_test.cpp
+++ b/src/algorithm/sindi/sindi_test.cpp
@@ -1089,7 +1089,8 @@ TEST_CASE("SINDI Remap Memory Comparison", "[ut][SINDI]") {
     // remap: ~30K slots × 20B + mapper = ~2MB overhead
     REQUIRE(mem_remap < mem_no_remap);
     float savings_ratio = 1.0f - static_cast<float>(mem_remap) / static_cast<float>(mem_no_remap);
-    WARN("Memory comparison: no_remap=" << mem_no_remap << " remap=" << mem_remap << " savings=" << savings_ratio << " unique_terms=" << unique_count);
+    WARN("Memory comparison: no_remap=" << mem_no_remap << " remap=" << mem_remap << " savings="
+                                        << savings_ratio << " unique_terms=" << unique_count);
     REQUIRE(savings_ratio > 0.9f);  // at least 90% memory reduction
 
     for (auto& item : sv_base) {
@@ -1206,7 +1207,9 @@ TEST_CASE("SINDI Remap Memory Comparison - MD5 Vocabulary", "[ut][SINDI]") {
     auto mem_no_remap = no_remap_index->EstimateMemory(num_base);
     auto mem_remap = remap_index->EstimateMemory(num_base);
     float savings_ratio = 1.0f - static_cast<float>(mem_remap) / static_cast<float>(mem_no_remap);
-    WARN("MD5 vocab comparison: no_remap=" << mem_no_remap << " remap=" << mem_remap << " savings=" << savings_ratio << " unique_terms=" << unique_count << " max_id=" << max_scattered_id);
+    WARN("MD5 vocab comparison: no_remap=" << mem_no_remap << " remap=" << mem_remap << " savings="
+                                           << savings_ratio << " unique_terms=" << unique_count
+                                           << " max_id=" << max_scattered_id);
 
     REQUIRE(mem_remap < mem_no_remap);
     REQUIRE(savings_ratio > 0.9f);

--- a/src/algorithm/sindi/term_id_mapper.cpp
+++ b/src/algorithm/sindi/term_id_mapper.cpp
@@ -1,0 +1,89 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "term_id_mapper.h"
+
+#include <fmt/format.h>
+
+#include "vsag_exception.h"
+
+namespace vsag {
+
+TermIdMapper::TermIdMapper(uint32_t term_id_limit, Allocator* allocator)
+    : orig_to_compact_(allocator),
+      compact_to_orig_(allocator),
+      term_id_limit_(term_id_limit),
+      allocator_(allocator) {
+}
+
+uint32_t
+TermIdMapper::Map(uint32_t orig_id) {
+    auto it = orig_to_compact_.find(orig_id);
+    if (it != orig_to_compact_.end()) {
+        return it->second;
+    }
+    if (next_id_ >= term_id_limit_) {
+        throw VsagException(
+            ErrorType::INVALID_ARGUMENT,
+            fmt::format("term id mapper is full: next_id ({}) >= term_id_limit ({})",
+                        next_id_,
+                        term_id_limit_));
+    }
+    uint32_t compact_id = next_id_++;
+    orig_to_compact_[orig_id] = compact_id;
+    compact_to_orig_.push_back(orig_id);
+    return compact_id;
+}
+
+std::optional<uint32_t>
+TermIdMapper::TryMap(uint32_t orig_id) const {
+    auto it = orig_to_compact_.find(orig_id);
+    if (it != orig_to_compact_.end()) {
+        return it->second;
+    }
+    return std::nullopt;
+}
+
+uint32_t
+TermIdMapper::ReverseMap(uint32_t compact_id) const {
+    if (compact_id >= next_id_) {
+        throw VsagException(
+            ErrorType::INVALID_ARGUMENT,
+            fmt::format("compact_id ({}) >= mapper size ({})", compact_id, next_id_));
+    }
+    return compact_to_orig_[compact_id];
+}
+
+void
+TermIdMapper::Serialize(StreamWriter& writer) const {
+    StreamWriter::WriteObj(writer, next_id_);
+    StreamWriter::WriteObj(writer, term_id_limit_);
+    StreamWriter::WriteVector(writer, compact_to_orig_);
+}
+
+void
+TermIdMapper::Deserialize(StreamReader& reader) {
+    StreamReader::ReadObj(reader, next_id_);
+    StreamReader::ReadObj(reader, term_id_limit_);
+    StreamReader::ReadVector(reader, compact_to_orig_);
+
+    // Rebuild the forward map from the deserialized reverse map
+    orig_to_compact_.clear();
+    for (uint32_t i = 0; i < compact_to_orig_.size(); ++i) {
+        orig_to_compact_[compact_to_orig_[i]] = i;
+    }
+}
+
+}  // namespace vsag

--- a/src/algorithm/sindi/term_id_mapper.cpp
+++ b/src/algorithm/sindi/term_id_mapper.cpp
@@ -81,6 +81,7 @@ TermIdMapper::Deserialize(StreamReader& reader) {
 
     // Rebuild the forward map from the deserialized reverse map
     orig_to_compact_.clear();
+    orig_to_compact_.reserve(compact_to_orig_.size());
     for (uint32_t i = 0; i < compact_to_orig_.size(); ++i) {
         orig_to_compact_[compact_to_orig_[i]] = i;
     }

--- a/src/algorithm/sindi/term_id_mapper.h
+++ b/src/algorithm/sindi/term_id_mapper.h
@@ -1,0 +1,66 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+
+#include "storage/stream_reader.h"
+#include "storage/stream_writer.h"
+#include "typing.h"
+#include "vsag/allocator.h"
+
+namespace vsag {
+
+class TermIdMapper {
+public:
+    TermIdMapper(uint32_t term_id_limit, Allocator* allocator);
+
+    // Map an original term ID to a compact ID.
+    // First occurrence gets the next sequential ID.
+    // Throws VsagException if the compact ID space is exhausted.
+    uint32_t
+    Map(uint32_t orig_id);
+
+    // Try to map an original term ID to a compact ID.
+    // Returns nullopt if the term has not been seen before (does not allocate).
+    [[nodiscard]] std::optional<uint32_t>
+    TryMap(uint32_t orig_id) const;
+
+    // Reverse map a compact ID back to the original term ID.
+    [[nodiscard]] uint32_t
+    ReverseMap(uint32_t compact_id) const;
+
+    [[nodiscard]] uint32_t
+    Size() const {
+        return next_id_;
+    }
+
+    void
+    Serialize(StreamWriter& writer) const;
+
+    void
+    Deserialize(StreamReader& reader);
+
+private:
+    UnorderedMap<uint32_t, uint32_t> orig_to_compact_;
+    Vector<uint32_t> compact_to_orig_;
+    uint32_t next_id_{0};
+    uint32_t term_id_limit_{0};
+    Allocator* allocator_{nullptr};
+};
+
+}  // namespace vsag

--- a/src/algorithm/sindi/term_id_mapper_test.cpp
+++ b/src/algorithm/sindi/term_id_mapper_test.cpp
@@ -1,0 +1,206 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "term_id_mapper.h"
+
+#include <random>
+#include <set>
+
+#include "impl/allocator/safe_allocator.h"
+#include "storage/stream_reader.h"
+#include "storage/stream_writer.h"
+#include "unittest.h"
+#include "vsag_exception.h"
+
+using namespace vsag;
+
+TEST_CASE("TermIdMapper Basic Mapping", "[ut][TermIdMapper]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    TermIdMapper mapper(1000, allocator.get());
+
+    SECTION("first-come-first-served assignment") {
+        REQUIRE(mapper.Map(50000) == 0);
+        REQUIRE(mapper.Map(12) == 1);
+        REQUIRE(mapper.Map(999999) == 2);
+        REQUIRE(mapper.Map(42) == 3);
+        REQUIRE(mapper.Size() == 4);
+    }
+
+    SECTION("duplicate returns existing compact ID") {
+        REQUIRE(mapper.Map(50000) == 0);
+        REQUIRE(mapper.Map(12) == 1);
+        REQUIRE(mapper.Map(50000) == 0);  // duplicate
+        REQUIRE(mapper.Map(12) == 1);     // duplicate
+        REQUIRE(mapper.Size() == 2);
+    }
+
+    SECTION("sequential input maps to same IDs") {
+        REQUIRE(mapper.Map(0) == 0);
+        REQUIRE(mapper.Map(1) == 1);
+        REQUIRE(mapper.Map(2) == 2);
+        REQUIRE(mapper.Map(3) == 3);
+        REQUIRE(mapper.Size() == 4);
+    }
+}
+
+TEST_CASE("TermIdMapper Empty", "[ut][TermIdMapper]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    TermIdMapper mapper(100, allocator.get());
+    REQUIRE(mapper.Size() == 0);
+}
+
+TEST_CASE("TermIdMapper TryMap", "[ut][TermIdMapper]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    TermIdMapper mapper(100, allocator.get());
+
+    mapper.Map(100);
+    mapper.Map(200);
+
+    SECTION("known term returns compact ID") {
+        auto result = mapper.TryMap(100);
+        REQUIRE(result.has_value());
+        REQUIRE(result.value() == 0);
+
+        result = mapper.TryMap(200);
+        REQUIRE(result.has_value());
+        REQUIRE(result.value() == 1);
+    }
+
+    SECTION("unknown term returns nullopt") {
+        auto result = mapper.TryMap(999);
+        REQUIRE_FALSE(result.has_value());
+    }
+}
+
+TEST_CASE("TermIdMapper ReverseMap", "[ut][TermIdMapper]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    TermIdMapper mapper(100, allocator.get());
+
+    mapper.Map(50000);
+    mapper.Map(12);
+    mapper.Map(999999);
+
+    REQUIRE(mapper.ReverseMap(0) == 50000);
+    REQUIRE(mapper.ReverseMap(1) == 12);
+    REQUIRE(mapper.ReverseMap(2) == 999999);
+
+    REQUIRE_THROWS_AS(mapper.ReverseMap(3), VsagException);
+}
+
+TEST_CASE("TermIdMapper Limit Reached", "[ut][TermIdMapper]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    TermIdMapper mapper(3, allocator.get());
+
+    REQUIRE(mapper.Map(10) == 0);
+    REQUIRE(mapper.Map(20) == 1);
+    REQUIRE(mapper.Map(30) == 2);
+
+    // Limit reached, next new term should throw
+    REQUIRE_THROWS_AS(mapper.Map(40), VsagException);
+
+    // Existing terms still work
+    REQUIRE(mapper.Map(10) == 0);
+    REQUIRE(mapper.Map(20) == 1);
+    REQUIRE(mapper.Size() == 3);
+}
+
+TEST_CASE("TermIdMapper Serialize and Deserialize", "[ut][TermIdMapper]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+
+    // Build a mapper with some data
+    TermIdMapper mapper1(1000, allocator.get());
+    mapper1.Map(50000);
+    mapper1.Map(12);
+    mapper1.Map(999999);
+    mapper1.Map(42);
+
+    // Serialize to buffer
+    std::vector<char> buffer(1024 * 1024);
+    BufferStreamWriter writer(buffer.data());
+    mapper1.Serialize(writer);
+
+    // Deserialize into a new mapper
+    TermIdMapper mapper2(1000, allocator.get());
+    auto reader_func = [&buffer](uint64_t offset, uint64_t size, void* dest) {
+        memcpy(dest, buffer.data() + offset, size);
+    };
+    ReadFuncStreamReader reader(reader_func, 0, writer.GetCursor());
+    mapper2.Deserialize(reader);
+
+    REQUIRE(mapper2.Size() == mapper1.Size());
+    REQUIRE(mapper2.TryMap(50000).value() == 0);
+    REQUIRE(mapper2.TryMap(12).value() == 1);
+    REQUIRE(mapper2.TryMap(999999).value() == 2);
+    REQUIRE(mapper2.TryMap(42).value() == 3);
+    REQUIRE(mapper2.ReverseMap(0) == 50000);
+    REQUIRE(mapper2.ReverseMap(1) == 12);
+    REQUIRE(mapper2.ReverseMap(2) == 999999);
+    REQUIRE(mapper2.ReverseMap(3) == 42);
+}
+
+TEST_CASE("TermIdMapper Deserialize Then Continue Add", "[ut][TermIdMapper]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+
+    TermIdMapper mapper1(1000, allocator.get());
+    mapper1.Map(100);
+    mapper1.Map(200);
+
+    // Serialize
+    std::vector<char> buffer(1024 * 1024);
+    BufferStreamWriter writer(buffer.data());
+    mapper1.Serialize(writer);
+
+    // Deserialize
+    TermIdMapper mapper2(1000, allocator.get());
+    auto reader_func = [&buffer](uint64_t offset, uint64_t size, void* dest) {
+        memcpy(dest, buffer.data() + offset, size);
+    };
+    ReadFuncStreamReader reader(reader_func, 0, writer.GetCursor());
+    mapper2.Deserialize(reader);
+
+    // Continue adding new terms — should get next sequential IDs
+    REQUIRE(mapper2.Map(300) == 2);
+    REQUIRE(mapper2.Map(400) == 3);
+    REQUIRE(mapper2.Size() == 4);
+
+    // Old terms still work
+    REQUIRE(mapper2.Map(100) == 0);
+    REQUIRE(mapper2.Map(200) == 1);
+}
+
+TEST_CASE("TermIdMapper Large Scale", "[ut][TermIdMapper]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    TermIdMapper mapper(200000, allocator.get());
+
+    std::mt19937 rng(42);
+    std::uniform_int_distribution<uint32_t> dist(0, UINT32_MAX / 2);
+    std::set<uint32_t> unique_terms;
+
+    // Insert 100K random term IDs
+    for (int i = 0; i < 100000; ++i) {
+        uint32_t term = dist(rng);
+        unique_terms.insert(term);
+        mapper.Map(term);
+    }
+
+    REQUIRE(mapper.Size() == static_cast<uint32_t>(unique_terms.size()));
+
+    // Verify all mapped terms can be looked up
+    for (auto term : unique_terms) {
+        auto result = mapper.TryMap(term);
+        REQUIRE(result.has_value());
+        REQUIRE(mapper.ReverseMap(result.value()) == term);
+    }
+}

--- a/src/inner_string_params.h
+++ b/src/inner_string_params.h
@@ -113,6 +113,7 @@ const char* const SPARSE_DESERIALIZE_WITHOUT_FOOTER = "deserialize_without_foote
 const char* const SPARSE_DESERIALIZE_WITHOUT_BUFFER = "deserialize_without_buffer";
 const char* const SPARSE_USE_TERM_LISTS_HEAP_INSERT = "use_term_lists_heap_insert";
 const char* const SPARSE_AVG_DOC_TERM_LENGTH = "avg_doc_term_length";
+const char* const SPARSE_REMAP_TERM_IDS = "remap_term_ids";
 
 // graph param value
 const char* const GRAPH_PARAM_MAX_DEGREE_KEY = "max_degree";

--- a/tests/test_sindi.cpp
+++ b/tests/test_sindi.cpp
@@ -29,6 +29,7 @@ struct SINDIParam {
     bool deserialize_without_buffer = false;
     int term_id_limit = 2000;
     bool use_quantization = false;
+    bool remap_term_ids = false;
 };
 
 class SINDITestIndex : public fixtures::TestIndex {
@@ -59,7 +60,8 @@ public:
                 "term_id_limit": {},
                 "deserialize_without_footer": {},
                 "deserialize_without_buffer": {},
-                "use_quantization": {}
+                "use_quantization": {},
+                "remap_term_ids": {}
             }}
         }})";
         return fmt::format(build_param_template,
@@ -69,7 +71,8 @@ public:
                            param.term_id_limit,
                            param.deserialize_without_footer,
                            param.deserialize_without_buffer,
-                           param.use_quantization);
+                           param.use_quantization,
+                           param.remap_term_ids);
     }
 
     static std::string
@@ -209,6 +212,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex,
                              "[ft][concurrent][sindi]") {
     fixtures::SINDIParam param;
     param.use_reorder = GENERATE(true, false);
+    param.remap_term_ids = GENERATE(true, false);
     auto build_param = fixtures::SINDITestIndex::GenerateBuildParameter(param);
     auto index = TestFactory("sindi", build_param, true);
     auto dataset = pool.GetSparseDatasetAndCreate(base_count, 128, 0.8);
@@ -224,6 +228,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex,
     param.deserialize_without_buffer = true;
     param.use_reorder = GENERATE(true, false);
     param.use_quantization = GENERATE(true, false);
+    param.remap_term_ids = GENERATE(true, false);
     auto build_param = fixtures::SINDITestIndex::GenerateBuildParameter(param);
     auto search_param_with_heap_insert =
         fixtures::SINDITestIndex::GenerateSearchParameter(GENERATE(true, false));
@@ -262,8 +267,25 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex,
                              "[ft][build][duplicate][sindi]") {
     fixtures::SINDIParam param;
     param.use_reorder = GENERATE(true, false);
+    param.remap_term_ids = GENERATE(true, false);
     auto build_param = fixtures::SINDITestIndex::GenerateBuildParameter(param);
     auto index = TestFactory("sindi", build_param, true);
     auto dataset = pool.GetSparseDatasetAndCreate(base_count, 128, 0.8);
     TestDuplicateAdd(index, dataset);
+}
+
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex,
+                             "SINDI Remap Build and Search",
+                             "[ft][build][search][sindi]") {
+    fixtures::SINDIParam param;
+    param.use_reorder = GENERATE(true, false);
+    param.remap_term_ids = true;
+    auto build_param = fixtures::SINDITestIndex::GenerateBuildParameter(param);
+    auto index = TestFactory("sindi", build_param, true);
+    auto dataset = pool.GetSparseDatasetAndCreate(base_count, 128, 0.8);
+    REQUIRE(index->GetIndexType() == vsag::IndexType::SINDI);
+    TestBuildIndex(index, dataset, true);
+    TestKnnSearch(index, dataset, search_param, 0.99, true);
+    TestRangeSearch(index, dataset, search_param, 0.99, 10, true);
+    TestFilterSearch(index, dataset, search_param, 0.99, true);
 }


### PR DESCRIPTION
## Summary

- Add `remap_term_ids` parameter: when enabled, automatically maps arbitrary uint32 term IDs to dense compact internal IDs
- First-come-first-served assignment: first unseen term gets compact ID 0, next gets 1, etc.
- Query-time transparent remapping: unknown terms are skipped (no new terms added to mapper during search)
- Mapping table is serialized/deserialized alongside the index

Closes #1959

## Motivation

SINDI uses term IDs directly as array indices, so sparse term IDs (e.g. from hash-based tokenizers like MD5) cause massive memory waste or hit the `term_id_limit` cap. With remap enabled:
- 30K unique terms with max_id=5M: arrays shrink from 5M slots to 30K slots
- MD5/hash tokenizers: SINDI becomes usable at all (raw IDs span uint32 range, impossible without remap)

## Changes

| File | Change |
|------|--------|
| `term_id_mapper.h/cpp` | New `TermIdMapper` utility class (Map/TryMap/ReverseMap/Serialize/Deserialize) |
| `sindi_parameter.h/cpp` | Add `remap_term_ids` parameter |
| `sindi.h/cpp` | Integrate mapper: Add path remap, Search path remap (with rerank fix), Serialize/Deserialize, GetSparseVectorByInnerId reverse mapping, EstimateMemory |
| `inner_string_params.h` | Add JSON key constant |
| `sindi_test.cpp` | 9 remap test cases (basic, reorder, quantization, filter, reverse mapping, UpdateVector, term limit exceeded, 2 memory comparisons) |
| `test_sindi.cpp` | Functest parametrization with `remap_term_ids` |

## Key Design Decisions

- **Append-only mapper**: thread-safe with existing `global_mutex_` (write lock in Add, read lock in Search)
- **Query uses `TryMap` (not `Map`)**: unknown terms are skipped, no new mappings created during search
- **Rerank path**: uses original (non-remapped) query for `rerank_flat_index_` distance computation
- **`rerank_flat_index_`**: stores original sparse vectors, unaffected by remap
- **Backward compatible**: `remap_term_ids=false` (default) has zero overhead

## Memory Test Results

MD5 vocabulary scenario (IDs scattered across [0, 10M)):
- Without remap: **458 MB** (term_id_limit = 9,996,805)
- With remap: **1.1 MB** (unique_terms = 9,111)
- **Savings: 99.76%**

## Test Plan

- [x] TermIdMapper unit tests (8 cases, 200K+ assertions)
- [x] SINDIParameter parse/compatibility tests
- [x] SINDI Remap Basic Test (build, search correctness vs brute-force, serialize, unknown terms, incremental Add)
- [x] SINDI Remap with Reorder Test (remap + use_reorder=true)
- [x] SINDI Remap with Quantization Test (recall > 95%)
- [x] SINDI Remap with Filter Test (MockFilter even IDs)
- [x] SINDI Remap GetSparseVectorByInnerId Reverse Mapping
- [x] SINDI Remap UpdateVector Compatibility
- [x] SINDI Remap Term ID Limit Exceeded (graceful partial failure)
- [x] SINDI Remap Memory Comparison (>90% savings)
- [x] SINDI Remap Memory Comparison - MD5 Vocabulary (99.76% savings)
- [x] Functests with remap parametrization (Concurrent, Serialize, Duplicate, Build and Search)
- [x] All existing SINDI tests pass (no regression)

🤖 Generated with [Claude Code](https://claude.ai/code)