### PR TITLE
docs: update eval_performance tool documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,20 @@
 VSAG is a high-performance vector indexing library for similarity search, written primarily in C++
 with Python bindings provided by `pyvsag`.
 
+## Where To Learn About The Project
+
+Before making non-trivial changes, consult the project documentation:
+
+- The official documentation site: <https://vsag.io/docs> (English and Chinese versions are
+  available, including index parameters, best practices, performance references, and the
+  `eval_performance` tool guide).
+- The in-repo `docs/` directory, which mirrors the website source under `docs/docs/{en,zh}/src/`
+  and also contains design notes (e.g. `docs/hgraph.md`, `docs/ivf.md`, `docs/sindi.md`,
+  `docs/eval_performance.md`, `docs/dataset_format.md`).
+
+When updating user-facing behavior, keep both the website docs and any related in-repo READMEs
+(`tools/eval/README.md`, `tools/eval/README_zh.md`, etc.) in sync.
+
 ## What To Optimize For
 
 - Preserve API compatibility unless a breaking change is explicitly intended.

--- a/docs/docs/en/src/resources/eval.md
+++ b/docs/docs/en/src/resources/eval.md
@@ -37,14 +37,47 @@ HDF5 must be installed on the system (Ubuntu: `apt install libhdf5-dev`; CentOS:
     --topk 10
 ```
 
+Useful flags include `--search_mode` (`knn` / `range` / `knn_filter` / `range_filter`),
+`--search-query-count`, `--delete-index-after-search`, and the various `--disable_*` switches that
+turn off individual metrics. See `tools/eval/README.md` for the full list.
+
 ### 2. Config-file mode (batch comparisons)
 
+The YAML file is passed directly as a positional argument (no `--config` flag):
+
 ```bash
-./build-release/tools/eval/eval_performance --config my_eval.yaml
+./build-release/tools/eval/eval_performance my_eval.yaml
 ```
 
-See the template `tools/eval/eval_template.yaml`. A single configuration can define multiple
-`eval_caseN` entries, each with its own parameter set.
+A reference template is available at `tools/eval/eval_template.yaml`. A single configuration can
+define multiple named cases, plus an optional `global` section that holds shared settings such as
+thread counts, exporters, and an embedded HTTP monitor.
+
+A minimal example:
+
+```yaml
+global:
+  num_threads_building: 8
+  num_threads_searching: 16
+  exporters:
+    print-directly:
+      to: stdout
+      format: table
+    save-to-file:
+      to: "file:///tmp/eval_results.json"
+      format: json
+
+eval_case1:
+  datapath: /tmp/sift-128-euclidean.hdf5
+  type: search
+  index_name: hgraph
+  create_params: '{"dim":128,"dtype":"float32","metric_type":"l2","index_param":{"base_quantization_type":"fp32","max_degree":32,"ef_construction":300}}'
+  search_params: '{"hgraph":{"ef_search":60}}'
+  index_path: /tmp/vsag_eval/hgraph_fp32
+  topk: 10
+```
+
+Note: under `global.exporters`, each entry is a **named** exporter (a YAML map), not a list item.
 
 ## Supported Dimensions
 
@@ -57,12 +90,32 @@ See the template `tools/eval/eval_template.yaml`. A single configuration can def
 
 `search_mode` accepts `knn`, `range`, `knn_filter`, and `range_filter`.
 
-## Output Formats
+## Output Formats and Destinations
 
-- `table` — to stdout or a file.
-- `json` — for downstream automation.
-- `line_protocol` — directly to InfluxDB (supports token auth).
-- `markdown` — handy when posting into an issue or document.
+Each exporter combines a `format` with a `to` destination.
+
+- Formats: `table` (or its alias `text`), `json`, `line_protocol` (for InfluxDB).
+- Destinations:
+    - `stdout` — print to standard output.
+    - `file://<path>` — write (overwrite) to a file.
+    - `appendfile://<path>` — append to a file.
+    - `influxdb://<host>:<port>/<path>?<query>` — POST to an InfluxDB v2 endpoint. Use
+      `format: line_protocol` and pass an authentication token via `vars.token`.
+
+If no exporter is configured, results are printed to stdout in `table` format by default.
+
+## HTTP Monitor (optional)
+
+When configured, the tool starts an embedded HTTP server for the duration of a batch run and
+exposes live progress (current case, total cases, completion %) plus the latest metrics. This is
+helpful for long-running evaluations.
+
+```yaml
+global:
+  http_server:
+    enabled: true
+    port: 8080
+```
 
 ## Datasets
 
@@ -72,5 +125,5 @@ Any HDF5 dataset from [ann-benchmarks](https://github.com/erikbern/ann-benchmark
 ## References
 
 - Source: `tools/eval/`
-- English README: `tools/eval/README.md`
+- Detailed README: `tools/eval/README.md`
 - Reference numbers on standard hardware: [Reference Performance](performance.md).

--- a/docs/docs/en/src/resources/eval.md
+++ b/docs/docs/en/src/resources/eval.md
@@ -98,9 +98,9 @@ Each exporter combines a `format` with a `to` destination.
 - Destinations:
     - `stdout` — print to standard output.
     - `file://<path>` — write (overwrite) to a file.
-    - `appendfile://<path>` — append to a file.
     - `influxdb://<host>:<port>/<path>?<query>` — POST to an InfluxDB v2 endpoint. Use
-      `format: line_protocol` and pass an authentication token via `vars.token`.
+      `format: line_protocol` and pass an authentication token via `vars.token` (the value must
+      include the `Token ` prefix, e.g. `Token <your-influxdb-token>`).
 
 If no exporter is configured, results are printed to stdout in `table` format by default.
 

--- a/docs/docs/zh/src/resources/eval.md
+++ b/docs/docs/zh/src/resources/eval.md
@@ -94,9 +94,9 @@ eval_case1:
 - 目标：
     - `stdout` — 输出到标准输出。
     - `file://<path>` — 写入文件（覆盖）。
-    - `appendfile://<path>` — 追加写入文件。
     - `influxdb://<host>:<port>/<path>?<query>` — POST 到 InfluxDB v2 接口；
-      需要使用 `format: line_protocol`，并通过 `vars.token` 传入鉴权令牌。
+      需要使用 `format: line_protocol`，并通过 `vars.token` 传入鉴权令牌
+      （值需包含 `Token ` 前缀，例如 `Token <your-influxdb-token>`）。
 
 如未配置任何导出器，结果默认以 `table` 格式打印到 stdout。
 

--- a/docs/docs/zh/src/resources/eval.md
+++ b/docs/docs/zh/src/resources/eval.md
@@ -34,13 +34,46 @@ cmake --build build-release -j
     --topk 10
 ```
 
+常用参数还包括 `--search_mode`（`knn` / `range` / `knn_filter` / `range_filter`）、
+`--search-query-count`、`--delete-index-after-search`，以及一系列用于关闭单项指标的
+`--disable_*` 开关。完整参数列表见 `tools/eval/README.md`。
+
 ### 2. 配置文件模式（适合批量对比）
 
+YAML 文件作为位置参数直接传入（不需要 `--config` 标志）：
+
 ```bash
-./build-release/tools/eval/eval_performance --config my_eval.yaml
+./build-release/tools/eval/eval_performance my_eval.yaml
 ```
 
-参考模板 `tools/eval/eval_template.yaml`，一份配置可包含多个 `eval_caseN` 并分别使用不同参数。
+参考模板 `tools/eval/eval_template.yaml`。一份配置可以包含多个具名 case，并通过可选的
+`global` 段配置共享参数，例如线程数、导出器以及内嵌的 HTTP 监控服务。
+
+最小示例：
+
+```yaml
+global:
+  num_threads_building: 8
+  num_threads_searching: 16
+  exporters:
+    print-directly:
+      to: stdout
+      format: table
+    save-to-file:
+      to: "file:///tmp/eval_results.json"
+      format: json
+
+eval_case1:
+  datapath: /tmp/sift-128-euclidean.hdf5
+  type: search
+  index_name: hgraph
+  create_params: '{"dim":128,"dtype":"float32","metric_type":"l2","index_param":{"base_quantization_type":"fp32","max_degree":32,"ef_construction":300}}'
+  search_params: '{"hgraph":{"ef_search":60}}'
+  index_path: /tmp/vsag_eval/hgraph_fp32
+  topk: 10
+```
+
+注意：`global.exporters` 下每一项都是**具名**的导出器（即 YAML map），并不是数组。
 
 ## 支持的评估维度
 
@@ -53,12 +86,31 @@ cmake --build build-release -j
 
 `search_mode` 支持 `knn`、`range`、`knn_filter`、`range_filter` 四种。
 
-## 结果导出
+## 输出格式与导出目标
 
-- `table`：输出到 stdout 或文件；
-- `json`：便于自动化处理；
-- `line_protocol`：直接写入 InfluxDB（支持 token 认证）；
-- `markdown`：便于贴到 issue / 文档。
+每个导出器同时指定一种 `format` 与一个 `to` 目标。
+
+- 格式：`table`（或别名 `text`）、`json`、`line_protocol`（用于 InfluxDB）。
+- 目标：
+    - `stdout` — 输出到标准输出。
+    - `file://<path>` — 写入文件（覆盖）。
+    - `appendfile://<path>` — 追加写入文件。
+    - `influxdb://<host>:<port>/<path>?<query>` — POST 到 InfluxDB v2 接口；
+      需要使用 `format: line_protocol`，并通过 `vars.token` 传入鉴权令牌。
+
+如未配置任何导出器，结果默认以 `table` 格式打印到 stdout。
+
+## HTTP 监控（可选）
+
+启用后，工具会在批量评估运行期间启动一个内嵌 HTTP 服务，实时暴露当前进度（当前案例、
+总案例数、完成百分比）和最新指标，便于长时间任务的状态观察。
+
+```yaml
+global:
+  http_server:
+    enabled: true
+    port: 8080
+```
 
 ## 数据集
 
@@ -68,5 +120,5 @@ cmake --build build-release -j
 ## 参考
 
 - 源码：`tools/eval/`
-- 英文说明：`tools/eval/README.md`
+- 详细说明：`tools/eval/README.md`
 - 标准机型的基准结果见 [标准环境性能参考](performance.md)。

--- a/tools/eval/README.md
+++ b/tools/eval/README.md
@@ -17,23 +17,30 @@ This is a powerful command-line tool for comprehensive performance benchmarking 
     - **Latency**: Average Latency, Percentile Latency (P50, P95, P99, etc.)
     - **Resources**: Peak Memory Usage
 - **Flexible Configuration**: Supports configuring all test parameters via either command-line arguments or a YAML file.
-- **Powerful Result Export**: Supports formatting test results as a table, JSON, or Markdown, and exporting them to standard output (stdout) or a file.
+- **Multiple Export Targets**: Results can be sent to stdout, written to a file (overwrite or append), or pushed to InfluxDB.
+- **Multiple Output Formats**: `table` / `text`, `json`, and `line_protocol` (for InfluxDB).
+- **Built-in HTTP Monitor (optional)**: Expose live progress and metrics via an embedded HTTP server while a batch is running.
 
 ## Build and Installation
 
-Before building, ensure you have a C++17 compiler, CMake, and the HDF5 library installed.
+The `tools/` directory is not built by default. Enable it explicitly. Before building, ensure you have a C++17 compiler, CMake, and the HDF5 library installed.
 
 ```bash
-# 1. Clone the repository (assuming this tool is in a subdirectory of the vsag project)
+# 1. Clone the repository
 git clone https://github.com/antgroup/vsag.git
 cd vsag
 
-# 2. Create a build directory and compile
-make release
+# 2. Build with tools enabled
+VSAG_ENABLE_TOOLS=ON make release
+# or directly via CMake:
+# cmake -S . -B build-release -DCMAKE_BUILD_TYPE=Release -DENABLE_TOOLS=ON
+# cmake --build build-release -j
 
-# 3. After compilation, the executable is located in the build-release/tools/eval/ directory
+# 3. After compilation, the executable is located at:
 #    ./build-release/tools/eval/eval_performance
 ```
+
+On Ubuntu install HDF5 with `apt install libhdf5-dev`; on CentOS use `yum install hdf5-devel`.
 
 ## Usage
 
@@ -49,54 +56,56 @@ This mode is suitable for running quick tests on a single index configuration. A
 
 - `-d, --datapath` (required): The path to the HDF5 dataset file for evaluation.
 - `-t, --type` (required): The evaluation method, choose from `build` or `search`.
-- `-n, --index_name` (required): The name of the index to create (e.g., `hnsw`, `ivf-flat`).
-- `-c, --create_params` (required): The parameters for creating the index, in JSON string format (e.g., `'{"M":32,"ef_construction":200}'`).
+- `-n, --index_name` (required): The name of the index to create (e.g., `hgraph`, `hnsw`, `ivf`).
+- `-c, --create_params` (required): The parameters for creating the index, in JSON string format (e.g., `'{"dim":128,"dtype":"float32","metric_type":"l2","index_param":{"base_quantization_type":"fp32","max_degree":32,"ef_construction":300}}'`).
 - `-i, --index_path`: The path to save or load the index (default: `/tmp/performance/index`).
 
 **Search-Related Parameters**
 
-- `-s, --search_params`: The parameters for searching, in JSON string format (e.g., `'{"ef_search":100}'`). This is required when `--type` is `search`.
+- `-s, --search_params`: The parameters for searching, in JSON string format (e.g., `'{"hgraph":{"ef_search":100}}'`). This is required when `--type` is `search`.
 - `--search_mode`: The search mode, choose from `knn`, `range`, `knn_filter`, `range_filter` (default: `knn`).
-- `--topk`: The K value for KNN search (default: 10).
-- `--range`: The radius for Range search (default: 0.5).
-- `--search-query-count`: The number of queries to run for search performance evaluation (default: 100000).
-- `--delete-index-after-search`: Delete the index after the search is complete (default: false).
+- `--topk`: The K value for KNN search (default: `10`).
+- `--range`: The radius for Range search (default: `0.5`).
+- `--search-query-count`: The number of queries to run for the search performance evaluation. Queries from the dataset are reused/cycled to reach this count (default: `100000`).
+- `--delete-index-after-search`: Delete the on-disk index after the search is complete to free up storage space (default: `false`).
 
 **Metric Control Parameters (for disabling certain calculations)**
 
 - `--disable_recall`: Disable average recall evaluation.
-- `--disable_percent_recall`: Disable percentile recall evaluation.
+- `--disable_percent_recall`: Disable percentile recall evaluation (P0, P10, P30, P50, P70, P90).
 - `--disable_qps`: Disable QPS evaluation.
 - `--disable_tps`: Disable TPS evaluation.
-- `--disable_memory`: Disable memory usage evaluation.
+- `--disable_memory`: Disable peak memory usage evaluation.
 - `--disable_latency`: Disable average latency evaluation.
-- `--disable_percent_latency`: Disable percentile latency evaluation.
+- `--disable_percent_latency`: Disable percentile latency evaluation (P50, P80, P90, P95, P99).
 
 #### Examples
 
 1.  **Build an Index**
-    Build an HNSW index and save it to the specified path.
+
+    Build an HGraph index and save it to the specified path.
 
     ```bash
     ./eval_performance \
         --type build \
-        --datapath /path/to/sift-1m.hdf5 \
-        --index_name hnsw \
-        --create_params '{"M":32,"ef_construction":200}' \
+        --datapath /path/to/sift-128-euclidean.hdf5 \
+        --index_name hgraph \
+        --create_params '{"dim":128,"dtype":"float32","metric_type":"l2","index_param":{"base_quantization_type":"fp32","max_degree":32,"ef_construction":300}}' \
         --index_path /tmp/my_sift_index
     ```
 
 2.  **Search Vectors**
-    Load a pre-built index and perform a KNN search with `ef_search=100`.
+
+    Load a pre-built index and perform a KNN search.
 
     ```bash
     ./eval_performance \
         --type search \
-        --datapath /path/to/sift-1m.hdf5 \
-        --index_name hnsw \
-        --create_params '{"M":32,"ef_construction":200}' \
+        --datapath /path/to/sift-128-euclidean.hdf5 \
+        --index_name hgraph \
+        --create_params '{"dim":128,"dtype":"float32","metric_type":"l2","index_param":{"base_quantization_type":"fp32","max_degree":32,"ef_construction":300}}' \
         --index_path /tmp/my_sift_index \
-        --search_params '{"ef_search":100}' \
+        --search_params '{"hgraph":{"ef_search":100}}' \
         --topk 10
     ```
 
@@ -106,66 +115,107 @@ This mode is more powerful, allowing you to define and run multiple test cases i
 
 #### How to Run
 
+The YAML file path is passed directly as a positional argument (no `--config` flag):
+
 ```bash
 ./eval_performance /path/to/your/config.yaml
 ```
 
+A reference template is available at [`tools/eval/eval_template.yaml`](eval_template.yaml).
+
 #### YAML File Structure
 
-The YAML file consists of an optional `global` section and multiple test cases.
+A YAML file consists of an optional `global` section and one or more named test cases. Every top-level key other than `global` is treated as an independent test case; the case name is user-defined (e.g., `hnsw_m16_ef200`).
 
-- **`global`**: Defines global configurations.
-    - `num_threads_building`: Number of threads to use for building the index.
-    - `num_threads_searching`: Number of threads to use for searching.
-    - `exporters`: Defines how to export results. This is a list that can contain multiple exporters.
-        - `to`: The export destination, choose from `stdout` or `file`.
-        - `format`: The export format, choose from `table` (default), `json`, `markdown`.
-        - `vars`: Additional variables required by the exporter. For example, when `to` is `file`, the `path` variable is required to specify the file path.
+##### Global section
 
-- **Test Cases**: Every top-level key other than `global` represents an independent test case. The case name is user-defined (e.g., `hnsw_m16_ef200`). The parameters under each case are mostly identical to the command-line arguments.
+```yaml
+global:
+  num_threads_building: 8        # threads used for building indexes
+  num_threads_searching: 16      # threads used for searching
+  exporters:                     # map of named exporters (NOT a list)
+    <exporter_name>:
+      to: <destination>
+      format: <format>
+      vars:                      # optional, depends on exporter
+        <key>: <value>
+  http_server:                   # optional HTTP monitor
+    enabled: true
+    port: 8080
+```
+
+###### `exporters`
+
+`exporters` is a **map** of named exporters (each key is just a label). For each exporter you specify:
+
+- `to`: the export destination, one of:
+    - `stdout` — print to standard output.
+    - `file://<path>` — write (overwrite) to the given file path.
+    - `appendfile://<path>` — append to the given file path.
+    - `influxdb://<host>:<port>/<path>?<query>` — POST to an InfluxDB v2 endpoint. The `influxdb://` prefix is internally rewritten to `http://`. Requires `format: line_protocol` and a `token` entry in `vars`.
+- `format`: the result format, one of `table` (or `text`, equivalent), `json`, `line_protocol`.
+- `vars` (optional): additional variables required by the exporter, e.g. `token` for InfluxDB.
+
+If no `exporters` are configured, results are printed to stdout in `table` format by default.
+
+###### `http_server`
+
+When `http_server.enabled` is `true`, an embedded HTTP server is started on `0.0.0.0:<port>` (default `8080`) for the duration of the run. It exposes live progress (current case, total cases, completion %) and the latest metrics, which is useful for long-running batch evaluations.
+
+##### Test cases
+
+Each named case accepts the same fields as the command-line parameters. Common fields:
+
+- `datapath` (required), `type` (required: `build` or `search`), `index_name` (required), `create_params` (required)
+- `search_params` (required when `type: search`), `search_mode`, `index_path`, `topk`, `range`
+- `search_query_count`, `delete_index_after_search`
+- `num_threads_building`, `num_threads_searching` (override the `global` values for this case)
+- `disable_recall`, `disable_percent_recall`, `disable_qps`, `disable_tps`, `disable_memory`, `disable_latency`, `disable_percent_latency`
 
 #### YAML Example
 
-Below is an example `config.yaml` that defines two different search test cases and exports the results to the screen as a table, and to files in Markdown and JSON formats.
+The example below defines two search test cases. Results are printed as a table to stdout, also written to a JSON file, and finally pushed to InfluxDB in line-protocol format.
 
 ```yaml
-# Global configuration
 global:
   num_threads_building: 8
   num_threads_searching: 16
   exporters:
-    # Exporter 1: Print results as a table to standard output
-    - to: stdout
+    print-directly:
+      to: stdout
       format: table
-    # Exporter 2: Save results as a Markdown file
-    - to: file
-      format: markdown
-      vars:
-        path: "./results.md"
-    # Exporter 3: Save results as a JSON file
-    - to: file
+    save-to-file:
+      to: "file:///tmp/eval_results.json"
       format: json
+    send-to-influxdb:
+      to: "influxdb://127.0.0.1:8086/api/v2/write?org=vsag&bucket=eval&precision=ns"
+      format: line_protocol
       vars:
-        path: "./results.json"
+        token: "Token <your-influxdb-token>"
+  http_server:
+    enabled: true
+    port: 8080
 
-# Test Case 1: HNSW index, M=16, ef_search=100
-hnsw_m16_ef100:
-  datapath: /path/to/sift-1m.hdf5
+# Test Case 1: HGraph index
+hgraph_fp32_d32_ef300:
+  datapath: /path/to/sift-128-euclidean.hdf5
   type: search
-  index_name: hnsw
-  create_params: '{"M":16,"ef_construction":200}'
-  search_params: '{"ef_search":100}'
-  index_path: /tmp/vsag_eval/hnsw_m16
+  index_name: hgraph
+  create_params: '{"dim":128,"dtype":"float32","metric_type":"l2","index_param":{"base_quantization_type":"fp32","max_degree":32,"ef_construction":300}}'
+  search_params: '{"hgraph":{"ef_search":60}}'
+  index_path: /tmp/vsag_eval/hgraph_fp32
+  search_mode: knn
   topk: 10
+  delete_index_after_search: false
 
-# Test Case 2: IVF-FLAT index, nlist=128, nprobe=8
-ivf_nlist128_nprobe8:
-  datapath: /path/to/sift-1m.hdf5
+# Test Case 2: HGraph with sq8_uniform quantization
+hgraph_sq8_d32_ef400:
+  datapath: /path/to/sift-128-euclidean.hdf5
   type: search
-  index_name: ivf-flat
-  create_params: '{"nlist":128}'
-  search_params: '{"nprobe":8}'
-  index_path: /tmp/vsag_eval/ivf_128
+  index_name: hgraph
+  create_params: '{"dim":128,"dtype":"float32","metric_type":"l2","index_param":{"base_quantization_type":"sq8_uniform","max_degree":32,"ef_construction":400}}'
+  search_params: '{"hgraph":{"ef_search":100}}'
+  index_path: /tmp/vsag_eval/hgraph_sq8
   topk: 10
 ```
 

--- a/tools/eval/README.md
+++ b/tools/eval/README.md
@@ -17,7 +17,7 @@ This is a powerful command-line tool for comprehensive performance benchmarking 
     - **Latency**: Average Latency, Percentile Latency (P50, P95, P99, etc.)
     - **Resources**: Peak Memory Usage
 - **Flexible Configuration**: Supports configuring all test parameters via either command-line arguments or a YAML file.
-- **Multiple Export Targets**: Results can be sent to stdout, written to a file (overwrite or append), or pushed to InfluxDB.
+- **Multiple Export Targets**: Results can be sent to stdout, written to a file, or pushed to InfluxDB.
 - **Multiple Output Formats**: `table` / `text`, `json`, and `line_protocol` (for InfluxDB).
 - **Built-in HTTP Monitor (optional)**: Expose live progress and metrics via an embedded HTTP server while a batch is running.
 
@@ -151,8 +151,7 @@ global:
 - `to`: the export destination, one of:
     - `stdout` — print to standard output.
     - `file://<path>` — write (overwrite) to the given file path.
-    - `appendfile://<path>` — append to the given file path.
-    - `influxdb://<host>:<port>/<path>?<query>` — POST to an InfluxDB v2 endpoint. The `influxdb://` prefix is internally rewritten to `http://`. Requires `format: line_protocol` and a `token` entry in `vars`.
+    - `influxdb://<host>:<port>/<path>?<query>` — POST to an InfluxDB v2 endpoint. The `influxdb://` prefix is internally rewritten to `http://`. Requires `format: line_protocol` and a `token` entry in `vars` (the value must include the `Token ` prefix, e.g. `Token <your-influxdb-token>`).
 - `format`: the result format, one of `table` (or `text`, equivalent), `json`, `line_protocol`.
 - `vars` (optional): additional variables required by the exporter, e.g. `token` for InfluxDB.
 

--- a/tools/eval/README_zh.md
+++ b/tools/eval/README_zh.md
@@ -17,7 +17,7 @@
     - **延迟**：平均延迟, 不同百分位的延迟 (P50, P95, P99 等)
     - **资源**：峰值内存使用
 - **灵活的配置**：支持通过命令行或 YAML 文件配置所有测试参数。
-- **多种导出目标**：结果可输出到 stdout、写入文件（覆盖或追加）或推送到 InfluxDB。
+- **多种导出目标**：结果可输出到 stdout、写入文件或推送到 InfluxDB。
 - **多种输出格式**：`table` / `text`、`json`、以及用于 InfluxDB 的 `line_protocol`。
 - **可选的内置 HTTP 监控**：在批量评估运行期间，通过内嵌 HTTP 服务实时查看进度和指标。
 
@@ -151,8 +151,7 @@ global:
 - `to`: 导出目标，可选：
     - `stdout` — 输出到标准输出。
     - `file://<path>` — 写入到指定文件（覆盖）。
-    - `appendfile://<path>` — 追加到指定文件。
-    - `influxdb://<host>:<port>/<path>?<query>` — POST 到 InfluxDB v2 接口。`influxdb://` 前缀会被内部重写为 `http://`。需要 `format: line_protocol`，并在 `vars` 中提供 `token`。
+    - `influxdb://<host>:<port>/<path>?<query>` — POST 到 InfluxDB v2 接口。`influxdb://` 前缀会被内部重写为 `http://`。需要 `format: line_protocol`，并在 `vars` 中提供 `token`（值需包含 `Token ` 前缀，例如 `Token <your-influxdb-token>`）。
 - `format`: 导出格式，可选 `table`（或等价的 `text`）、`json`、`line_protocol`。
 - `vars`（可选）: 导出器所需的额外变量，例如 InfluxDB 的 `token`。
 

--- a/tools/eval/README_zh.md
+++ b/tools/eval/README_zh.md
@@ -17,23 +17,30 @@
     - **延迟**：平均延迟, 不同百分位的延迟 (P50, P95, P99 等)
     - **资源**：峰值内存使用
 - **灵活的配置**：支持通过命令行或 YAML 文件配置所有测试参数。
-- **强大的结果导出**：支持将测试结果格式化为表格 (Table)、JSON 或 Markdown，并导出到标准输出 (stdout) 或文件。
+- **多种导出目标**：结果可输出到 stdout、写入文件（覆盖或追加）或推送到 InfluxDB。
+- **多种输出格式**：`table` / `text`、`json`、以及用于 InfluxDB 的 `line_protocol`。
+- **可选的内置 HTTP 监控**：在批量评估运行期间，通过内嵌 HTTP 服务实时查看进度和指标。
 
 ## 编译与安装
 
-在编译之前，请确保您已安装 C++17 编译器、CMake 和 HDF5 库。
+`tools/` 默认不会被编译，需要显式开启。在编译之前，请确保您已安装 C++17 编译器、CMake 和 HDF5 库。
 
 ```bash
-# 1. 克隆仓库 (假设此工具在 vsag 项目的子目录中)
+# 1. 克隆仓库
 git clone https://github.com/antgroup/vsag.git
 cd vsag
 
-# 2. 创建构建目录并编译
-make release
+# 2. 开启 tools 选项编译
+VSAG_ENABLE_TOOLS=ON make release
+# 或者直接通过 CMake：
+# cmake -S . -B build-release -DCMAKE_BUILD_TYPE=Release -DENABLE_TOOLS=ON
+# cmake --build build-release -j
 
-# 3. 编译完成后，可执行文件位于 build-release/tools/eval/ 目录下
+# 3. 编译完成后，可执行文件位于：
 #    ./build-release/tools/eval/eval_performance
 ```
+
+Ubuntu 安装 HDF5：`apt install libhdf5-dev`；CentOS：`yum install hdf5-devel`。
 
 ## 使用方法
 
@@ -49,54 +56,56 @@ make release
 
 - `-d, --datapath` (必需): 用于评估的 HDF5 数据集文件路径。
 - `-t, --type` (必需): 评估方法，可选 `build` 或 `search`。
-- `-n, --index_name` (必需): 要创建的索引名称 (例如, `hnsw`, `ivf-flat`)。
-- `-c, --create_params` (必需): 创建索引所需的参数，格式为 JSON 字符串 (例如, `'{"M":32,"ef_construction":200}'`)。
+- `-n, --index_name` (必需): 要创建的索引名称 (例如 `hgraph`、`hnsw`、`ivf`)。
+- `-c, --create_params` (必需): 创建索引所需的参数，格式为 JSON 字符串 (例如 `'{"dim":128,"dtype":"float32","metric_type":"l2","index_param":{"base_quantization_type":"fp32","max_degree":32,"ef_construction":300}}'`)。
 - `-i, --index_path`: 索引的保存或加载路径 (默认: `/tmp/performance/index`)。
 
 **搜索相关参数**
 
-- `-s, --search_params`: 搜索时所需的参数，格式为 JSON 字符串 (例如, `'{"ef_search":100}'`)。当 `--type` 为 `search` 时此项为必需。
-- `--search_mode`: 搜索模式，可选 `knn`, `range`, `knn_filter`, `range_filter` (默认: `knn`)。
-- `--topk`: KNN 搜索的 K 值 (默认: 10)。
-- `--range`: Range 搜索的半径 (默认: 0.5)。
-- `--search-query-count`: 用于搜索性能评估的查询数量 (默认: 100000)。
-- `--delete-index-after-search`: 搜索完成后删除索引 (默认: false)。
+- `-s, --search_params`: 搜索时所需的参数，格式为 JSON 字符串 (例如 `'{"hgraph":{"ef_search":100}}'`)。当 `--type` 为 `search` 时此项为必需。
+- `--search_mode`: 搜索模式，可选 `knn`、`range`、`knn_filter`、`range_filter` (默认: `knn`)。
+- `--topk`: KNN 搜索的 K 值 (默认: `10`)。
+- `--range`: Range 搜索的半径 (默认: `0.5`)。
+- `--search-query-count`: 用于搜索性能评估的查询次数。当数据集查询数不足时会循环复用 (默认: `100000`)。
+- `--delete-index-after-search`: 搜索完成后删除磁盘上的索引以释放存储空间 (默认: `false`)。
 
 **指标控制参数 (用于禁用某些计算)**
 
 - `--disable_recall`: 禁用平均召回率评估。
-- `--disable_percent_recall`: 禁用百分位召回率评估。
+- `--disable_percent_recall`: 禁用百分位召回率评估 (P0, P10, P30, P50, P70, P90)。
 - `--disable_qps`: 禁用 QPS 评估。
 - `--disable_tps`: 禁用 TPS 评估。
-- `--disable_memory`: 禁用内存使用评估。
+- `--disable_memory`: 禁用峰值内存使用评估。
 - `--disable_latency`: 禁用平均延迟评估。
-- `--disable_percent_latency`: 禁用百分位延迟评估。
+- `--disable_percent_latency`: 禁用百分位延迟评估 (P50, P80, P90, P95, P99)。
 
 #### 示例
 
 1.  **构建索引**
-    构建一个 HNSW 索引并将它保存到指定路径。
+
+    构建一个 HGraph 索引并保存到指定路径。
 
     ```bash
     ./eval_performance \
         --type build \
-        --datapath /path/to/sift-1m.hdf5 \
-        --index_name hnsw \
-        --create_params '{"M":32,"ef_construction":200}' \
+        --datapath /path/to/sift-128-euclidean.hdf5 \
+        --index_name hgraph \
+        --create_params '{"dim":128,"dtype":"float32","metric_type":"l2","index_param":{"base_quantization_type":"fp32","max_degree":32,"ef_construction":300}}' \
         --index_path /tmp/my_sift_index
     ```
 
 2.  **搜索向量**
-    加载已构建的索引，并使用 `ef_search=100` 的参数进行 KNN 搜索。
+
+    加载已构建的索引并执行 KNN 搜索。
 
     ```bash
     ./eval_performance \
         --type search \
-        --datapath /path/to/sift-1m.hdf5 \
-        --index_name hnsw \
-        --create_params '{"M":32,"ef_construction":200}' \
+        --datapath /path/to/sift-128-euclidean.hdf5 \
+        --index_name hgraph \
+        --create_params '{"dim":128,"dtype":"float32","metric_type":"l2","index_param":{"base_quantization_type":"fp32","max_degree":32,"ef_construction":300}}' \
         --index_path /tmp/my_sift_index \
-        --search_params '{"ef_search":100}' \
+        --search_params '{"hgraph":{"ef_search":100}}' \
         --topk 10
     ```
 
@@ -106,66 +115,107 @@ make release
 
 #### 运行方式
 
+YAML 文件作为位置参数直接传入（不需要 `--config` 标志）：
+
 ```bash
 ./eval_performance /path/to/your/config.yaml
 ```
 
+可参考模板 [`tools/eval/eval_template.yaml`](eval_template.yaml)。
+
 #### YAML 文件结构
 
-YAML 文件由一个可选的 `global` 部分和多个测试案例 (case) 组成。
+YAML 文件由一个可选的 `global` 部分和一个或多个具名的测试案例组成。除 `global` 外，每个顶级键都被视为一个独立的测试案例，案例名称可以自定义（例如 `hnsw_m16_ef200`）。
 
-- **`global`**: 用于定义全局配置。
-    - `num_threads_building`: 构建索引时使用的线程数。
-    - `num_threads_searching`: 搜索时使用的线程数。
-    - `exporters`: 定义结果如何导出。这是一个列表，可以配置多个导出器。
-        - `to`: 导出目标，可选 `stdout` (屏幕) 或 `file`。
-        - `format`: 导出格式，可选 `table` (默认), `json`, `markdown`。
-        - `vars`: 导出器所需的额外变量。例如，当 `to` 是 `file` 时，需要提供 `path` 变量指定文件路径。
+##### `global` 部分
 
-- **测试案例**: 除了 `global` 之外的每个顶级键都代表一个独立的测试案例。案例名称可以自定义（例如 `hnsw_m16_ef200`）。其下的参数与命令行参数基本一致。
+```yaml
+global:
+  num_threads_building: 8        # 构建索引时使用的线程数
+  num_threads_searching: 16      # 搜索时使用的线程数
+  exporters:                     # 具名导出器组成的 map (注意不是数组)
+    <exporter_name>:
+      to: <destination>
+      format: <format>
+      vars:                      # 可选，依导出器类型而定
+        <key>: <value>
+  http_server:                   # 可选的 HTTP 监控服务
+    enabled: true
+    port: 8080
+```
+
+###### `exporters`
+
+`exporters` 是一个**具名导出器的 map**（每个键只是一个标签）。每个导出器需要指定：
+
+- `to`: 导出目标，可选：
+    - `stdout` — 输出到标准输出。
+    - `file://<path>` — 写入到指定文件（覆盖）。
+    - `appendfile://<path>` — 追加到指定文件。
+    - `influxdb://<host>:<port>/<path>?<query>` — POST 到 InfluxDB v2 接口。`influxdb://` 前缀会被内部重写为 `http://`。需要 `format: line_protocol`，并在 `vars` 中提供 `token`。
+- `format`: 导出格式，可选 `table`（或等价的 `text`）、`json`、`line_protocol`。
+- `vars`（可选）: 导出器所需的额外变量，例如 InfluxDB 的 `token`。
+
+如果没有配置任何 `exporters`，结果将默认以 `table` 格式打印到 stdout。
+
+###### `http_server`
+
+当 `http_server.enabled` 为 `true` 时，运行期间会在 `0.0.0.0:<port>`（默认 `8080`）上启动一个内嵌的 HTTP 服务，实时暴露当前进度（当前案例、总案例数、完成百分比）和最新指标，便于长时间批量评估时的状态观察。
+
+##### 测试案例
+
+每个具名案例支持的字段与命令行参数一致。常用字段：
+
+- `datapath`（必需）、`type`（必需，`build` 或 `search`）、`index_name`（必需）、`create_params`（必需）
+- `search_params`（当 `type: search` 时必需）、`search_mode`、`index_path`、`topk`、`range`
+- `search_query_count`、`delete_index_after_search`
+- `num_threads_building`、`num_threads_searching`（覆盖 `global` 中针对此案例的值）
+- `disable_recall`、`disable_percent_recall`、`disable_qps`、`disable_tps`、`disable_memory`、`disable_latency`、`disable_percent_latency`
 
 #### YAML 示例
 
-下面是一个示例 `config.yaml`，它定义了两个不同的搜索测试案例，并将结果同时以表格形式打印到屏幕、以 Markdown 和 JSON 格式保存到文件。
+下面的示例定义了两个搜索测试案例，并将结果同时以表格形式打印到 stdout、写入到 JSON 文件，以及以 line_protocol 格式推送到 InfluxDB。
 
 ```yaml
-# 全局配置
 global:
   num_threads_building: 8
   num_threads_searching: 16
   exporters:
-    # 导出器1: 在屏幕上打印表格
-    - to: stdout
+    print-directly:
+      to: stdout
       format: table
-    # 导出器2: 将结果保存为 Markdown 文件
-    - to: file
-      format: markdown
-      vars:
-        path: "./results.md"
-    # 导出器3: 将结果保存为 JSON 文件
-    - to: file
+    save-to-file:
+      to: "file:///tmp/eval_results.json"
       format: json
+    send-to-influxdb:
+      to: "influxdb://127.0.0.1:8086/api/v2/write?org=vsag&bucket=eval&precision=ns"
+      format: line_protocol
       vars:
-        path: "./results.json"
+        token: "Token <your-influxdb-token>"
+  http_server:
+    enabled: true
+    port: 8080
 
-# 测试案例 1: HNSW 索引, M=16, ef_search=100
-hnsw_m16_ef100:
-  datapath: /path/to/sift-1m.hdf5
+# 测试案例 1: HGraph 索引
+hgraph_fp32_d32_ef300:
+  datapath: /path/to/sift-128-euclidean.hdf5
   type: search
-  index_name: hnsw
-  create_params: '{"M":16,"ef_construction":200}'
-  search_params: '{"ef_search":100}'
-  index_path: /tmp/vsag_eval/hnsw_m16
+  index_name: hgraph
+  create_params: '{"dim":128,"dtype":"float32","metric_type":"l2","index_param":{"base_quantization_type":"fp32","max_degree":32,"ef_construction":300}}'
+  search_params: '{"hgraph":{"ef_search":60}}'
+  index_path: /tmp/vsag_eval/hgraph_fp32
+  search_mode: knn
   topk: 10
+  delete_index_after_search: false
 
-# 测试案例 2: IVF-FLAT 索引, nlist=128, nprobe=8
-ivf_nlist128_nprobe8:
-  datapath: /path/to/sift-1m.hdf5
+# 测试案例 2: 使用 sq8_uniform 量化的 HGraph
+hgraph_sq8_d32_ef400:
+  datapath: /path/to/sift-128-euclidean.hdf5
   type: search
-  index_name: ivf-flat
-  create_params: '{"nlist":128}'
-  search_params: '{"nprobe":8}'
-  index_path: /tmp/vsag_eval/ivf_128
+  index_name: hgraph
+  create_params: '{"dim":128,"dtype":"float32","metric_type":"l2","index_param":{"base_quantization_type":"sq8_uniform","max_degree":32,"ef_construction":400}}'
+  search_params: '{"hgraph":{"ef_search":100}}'
+  index_path: /tmp/vsag_eval/hgraph_sq8
   topk: 10
 ```
 


### PR DESCRIPTION
## Summary

Sync the `eval_performance` documentation (both `tools/eval/README{,_zh}.md` and the website pages under `docs/docs/{en,zh}/src/resources/eval.md`) with the actual implementation in `tools/eval/`.

### Corrections (the previous docs were factually wrong)

- **Output formats**: removed `markdown` (not supported); the real list is `table` / `text` / `json` / `line_protocol` (`tools/eval/exporter/formatter.cpp`).
- **Export destinations**: documented the URL-scheme based `to` values that the code actually parses — `stdout`, `file://<path>`, `influxdb://<host>:<port>/<path>?<query>`. Old docs claimed `to: file` with a `path` var, which doesn't work.
- **`exporters` is a YAML map, not a list** — `tools/eval/main.cpp` requires `IsMap()` and iterates with named keys.
- **Config-file invocation**: `eval_performance my.yaml` (positional). Removed the incorrect `--config` flag mentioned on the website.
- **Build instructions**: clarified that the tool requires `VSAG_ENABLE_TOOLS=ON` / `-DENABLE_TOOLS=ON`.
- **InfluxDB token**: noted that `vars.token` must include the `Token ` prefix because the value is sent verbatim as the `Authorization` header (`tools/eval/exporter/exporter_influxdb.h`).

### Newly documented features

- `http_server` block in `global` (embedded HTTP monitor for live progress / metrics).
- `influxdb://` exporter (with `vars.token` for InfluxDB auth).
- `--search-query-count` and `--delete-index-after-search` CLI flags.
- `num_threads_building` / `num_threads_searching`, available both globally and per-case.
- Per-case `disable_*` keys in YAML.

### Intentionally NOT documented: `appendfile://`

The codebase contains an `AppendfileExporter` registered under the `appendfile://` scheme (`tools/eval/exporter/exporter.cpp`), but the constructor strips only 6 characters (`file_path.substr(6)` in `tools/eval/exporter/exporter_appendfile.h:44`), the same as the `file://` exporter. Since `appendfile://` is 13 characters long, an input like `appendfile:///tmp/x` is parsed as `file:///tmp/x`, which is incorrect.

To avoid advertising a broken feature, this PR deliberately does not surface `appendfile://` in user-facing documentation. Once the prefix-stripping bug in `AppendfileExporter` is fixed (and ideally covered by a test), a follow-up change can re-introduce the documentation for `appendfile://<path>`.

## Test Plan

Documentation-only change. Verified the documented behavior against the source under `tools/eval/` (`main.cpp`, `eval_config.cpp`, `exporter/exporter.cpp`, `exporter/formatter.cpp`, `exporter/exporter_influxdb.h`, `exporter/exporter_appendfile.h`, `monitor/http_server_monitor.h`, `eval_template.yaml`).