### PR TITLE
fix: keep HGraph count consistent after add OOM

### DIFF
--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -671,15 +671,25 @@ HGraph::build_by_odescent(const DatasetPtr& data) {
     const auto* vectors = data->GetFloat32Vectors();
     const auto* extra_infos = data->GetExtraInfos();
     auto inner_ids = this->get_unique_inner_ids(total);
-    Vector<Vector<InnerIdType>> route_graph_ids(allocator_);
-    InnerIdType cur_size = 0;
+    Vector<InnerIdType> valid_inner_ids(allocator_);
     for (int64_t i = 0; i < total; ++i) {
         auto label = labels[i];
         if (this->label_table_->CheckLabel(label)) {
             failed_ids.emplace_back(label);
             continue;
         }
-        InnerIdType inner_id = inner_ids.at(cur_size);
+        valid_inner_ids.emplace_back(inner_ids[valid_inner_ids.size()]);
+    }
+    this->resize(total_count_.load() + valid_inner_ids.size());
+    this->total_count_ += valid_inner_ids.size();
+    Vector<Vector<InnerIdType>> route_graph_ids(allocator_);
+    InnerIdType cur_size = 0;
+    for (int64_t i = 0; i < total; ++i) {
+        auto label = labels[i];
+        if (this->label_table_->CheckLabel(label)) {
+            continue;
+        }
+        InnerIdType inner_id = valid_inner_ids.at(cur_size);
         cur_size++;
         this->label_table_->Insert(inner_id, label);
         this->basic_flatten_codes_->InsertVector(vectors + dim_ * i, inner_id);
@@ -702,7 +712,6 @@ HGraph::build_by_odescent(const DatasetPtr& data) {
             }
         }
     }
-    this->resize(total_count_);
     auto build_data = (use_reorder_ and not build_by_base_) ? this->high_precise_codes_
                                                             : this->basic_flatten_codes_;
     {
@@ -777,8 +786,10 @@ HGraph::Add(const DatasetPtr& data, AddMode mode) {
         {
             std::scoped_lock lock(this->add_mutex_);
             inner_id = this->get_unique_inner_ids(1).at(0);
-            uint64_t new_count = total_count_;
-            this->resize(new_count);
+            if (inner_id >= total_count_) {
+                this->resize(total_count_.load() + 1);
+                ++total_count_;
+            }
         }
 
         {
@@ -2243,6 +2254,10 @@ HGraph::GetVectorByInnerId(InnerIdType inner_id, float* data) const {
     codes = (create_new_raw_vector_) ? raw_vector_ : codes;
     bool release;
     const auto* buffer = codes->GetCodesById(inner_id, release);
+    if (buffer == nullptr) {
+        throw VsagException(ErrorType::INTERNAL_ERROR,
+                            fmt::format("failed to get vector by inner id {}", inner_id));
+    }
     codes->Decode(buffer, data);
     if (release) {
         codes->Release(buffer);

--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -670,27 +670,32 @@ HGraph::build_by_odescent(const DatasetPtr& data) {
     const auto* labels = data->GetIds();
     const auto* vectors = data->GetFloat32Vectors();
     const auto* extra_infos = data->GetExtraInfos();
-    auto inner_ids = this->get_unique_inner_ids(total);
-    Vector<InnerIdType> valid_inner_ids(allocator_);
+    Vector<int64_t> valid_indices(allocator_);
+    UnorderedSet<LabelType> seen_labels(allocator_);
     for (int64_t i = 0; i < total; ++i) {
         auto label = labels[i];
-        if (this->label_table_->CheckLabel(label)) {
+        if (this->label_table_->CheckLabel(label) or seen_labels.find(label) != seen_labels.end()) {
             failed_ids.emplace_back(label);
             continue;
         }
-        valid_inner_ids.emplace_back(inner_ids[valid_inner_ids.size()]);
+        seen_labels.insert(label);
+        valid_indices.emplace_back(i);
     }
-    this->resize(total_count_.load() + valid_inner_ids.size());
-    this->total_count_ += valid_inner_ids.size();
-    Vector<Vector<InnerIdType>> route_graph_ids(allocator_);
-    InnerIdType cur_size = 0;
-    for (int64_t i = 0; i < total; ++i) {
-        auto label = labels[i];
-        if (this->label_table_->CheckLabel(label)) {
-            continue;
+    auto inner_ids = this->get_unique_inner_ids(static_cast<InnerIdType>(valid_indices.size()));
+    auto current_count = total_count_.load();
+    uint64_t new_ids_count = 0;
+    for (auto inner_id : inner_ids) {
+        if (inner_id >= current_count) {
+            ++new_ids_count;
         }
-        InnerIdType inner_id = valid_inner_ids.at(cur_size);
-        cur_size++;
+    }
+    this->resize(current_count + new_ids_count);
+    this->total_count_ += new_ids_count;
+    Vector<Vector<InnerIdType>> route_graph_ids(allocator_);
+    for (InnerIdType cur_size = 0; cur_size < valid_indices.size(); ++cur_size) {
+        auto i = valid_indices[cur_size];
+        auto label = labels[i];
+        InnerIdType inner_id = inner_ids.at(cur_size);
         this->label_table_->Insert(inner_id, label);
         this->basic_flatten_codes_->InsertVector(vectors + dim_ * i, inner_id);
         if (use_reorder_) {

--- a/src/algorithm/hgraph.h
+++ b/src/algorithm/hgraph.h
@@ -237,12 +237,13 @@ public:
         if (ret.size() != count) {
             throw VsagException(ErrorType::NO_ENOUGH_MEMORY, "allocate memory failed");
         }
+        auto next_id = static_cast<InnerIdType>(this->total_count_.load());
         for (InnerIdType i = 0; i < count; ++i) {
             auto [success, id] = this->label_table_->PopHole();
             if (success) {
                 ret[i] = id;
             } else {
-                ret[i] = static_cast<InnerIdType>(this->total_count_++);
+                ret[i] = next_id++;
             }
         }
         return ret;

--- a/src/algorithm/hgraph.h
+++ b/src/algorithm/hgraph.h
@@ -233,6 +233,7 @@ public:
 
     Vector<InnerIdType>
     get_unique_inner_ids(InnerIdType count) {
+        // Callers commit total_count_ only after resize succeeds.
         Vector<InnerIdType> ret(count, this->allocator_);
         if (ret.size() != count) {
             throw VsagException(ErrorType::NO_ENOUGH_MEMORY, "allocate memory failed");

--- a/tests/test_regression.cpp
+++ b/tests/test_regression.cpp
@@ -15,11 +15,15 @@
 
 #include <vsag/vsag.h>
 #include <vsag/vsag_ext.h>
+#include <vsag/options.h>
 
 #include <catch2/catch_test_macros.hpp>
+#include <cstdlib>
 #include <new>
 #include <nlohmann/json.hpp>
+#include <numeric>
 #include <string>
+#include <unordered_map>
 
 #include "algorithm/hnswlib/visited_list_pool.h"
 
@@ -95,4 +99,139 @@ TEST_CASE("gh#369", "[ft][github]") {
 
     auto search_result = hgraph->KnnSearch(query, 10, search_parameters.dump(), filter);
     REQUIRE(search_result.has_value());
+}
+
+// https://github.com/antgroup/vsag/issues/1974
+TEST_CASE("gh#1974", "[ft][github]") {
+    using namespace nlohmann;
+
+    class LimitedAllocator : public Allocator {
+    public:
+        std::string
+        Name() override {
+            return "LimitedAllocator";
+        }
+
+        void*
+        Allocate(uint64_t size) override {
+            if (used_ + size > limit_) {
+                return nullptr;
+            }
+            auto* ptr = std::malloc(size);
+            if (ptr != nullptr) {
+                sizes_[ptr] = size;
+                used_ += size;
+            }
+            return ptr;
+        }
+
+        void
+        Deallocate(void* p) override {
+            auto iter = sizes_.find(p);
+            if (iter != sizes_.end()) {
+                used_ -= iter->second;
+                sizes_.erase(iter);
+            }
+            std::free(p);
+        }
+
+        void*
+        Reallocate(void* p, uint64_t size) override {
+            auto old_size = uint64_t{0};
+            auto iter = sizes_.find(p);
+            if (iter != sizes_.end()) {
+                old_size = iter->second;
+            }
+            if (used_ - old_size + size > limit_) {
+                return nullptr;
+            }
+            auto* new_ptr = std::realloc(p, size);
+            if (new_ptr != nullptr) {
+                if (iter != sizes_.end()) {
+                    sizes_.erase(iter);
+                }
+                sizes_[new_ptr] = size;
+                used_ = used_ - old_size + size;
+            }
+            return new_ptr;
+        }
+
+        void
+        SetLimit(uint64_t limit) {
+            limit_ = limit;
+        }
+
+        uint64_t
+        Used() const {
+            return used_;
+        }
+
+    private:
+        uint64_t limit_{std::numeric_limits<uint64_t>::max()};
+        uint64_t used_{0};
+        std::unordered_map<void*, uint64_t> sizes_;
+    };
+
+    auto origin_size = vsag::Options::Instance().block_size_limit();
+    vsag::Options::Instance().set_block_size_limit(512ULL * 1024ULL);
+
+    constexpr int64_t dim = 32;
+    constexpr int64_t base_count = 4096;
+    constexpr int64_t add_count = 1;
+    std::vector<int64_t> base_ids(base_count);
+    std::vector<float> base_vectors(base_count * dim, 0.0F);
+    std::vector<int64_t> add_ids(add_count);
+    std::vector<float> add_vectors(add_count * dim, 1.0F);
+    std::iota(base_ids.begin(), base_ids.end(), 0);
+    std::iota(add_ids.begin(), add_ids.end(), base_count);
+
+    json base_param{{"base_quantization_type", "sq8"},
+                    {"max_degree", 8},
+                    {"ef_construction", 100},
+                    {"build_thread_count", 1},
+                    {"store_raw_vector", true}};
+    json tuned_param = base_param;
+    tuned_param["base_quantization_type"] = "bf16";
+    json index_param{{"dtype", "float32"},
+                     {"metric_type", "l2"},
+                     {"dim", dim},
+                     {"index_param", base_param}};
+    json tune_param{{"dtype", "float32"},
+                    {"metric_type", "l2"},
+                    {"dim", dim},
+                    {"index_param", tuned_param}};
+
+    LimitedAllocator allocator;
+    auto create_result = vsag::Factory::CreateIndex("hgraph", index_param.dump(), &allocator);
+    REQUIRE(create_result.has_value());
+    auto hgraph = create_result.value();
+
+    auto base = Dataset::Make();
+    base->Dim(dim)
+        ->NumElements(base_count)
+        ->Ids(base_ids.data())
+        ->Float32Vectors(base_vectors.data())
+        ->Owner(false);
+    auto build_result = hgraph->Build(base);
+    REQUIRE(build_result.has_value());
+    REQUIRE(hgraph->GetNumElements() == base_count);
+
+    allocator.SetLimit(allocator.Used());
+    auto add = Dataset::Make();
+    add->Dim(dim)
+        ->NumElements(add_count)
+        ->Ids(add_ids.data())
+        ->Float32Vectors(add_vectors.data())
+        ->Owner(false);
+    auto add_result = hgraph->Add(add);
+    REQUIRE_FALSE(add_result.has_value());
+    REQUIRE(add_result.error().type == ErrorType::NO_ENOUGH_MEMORY);
+    REQUIRE(hgraph->GetNumElements() == base_count);
+
+    allocator.SetLimit(std::numeric_limits<uint64_t>::max());
+    auto tune_result = hgraph->Tune(tune_param.dump());
+    REQUIRE(tune_result.has_value());
+    REQUIRE(tune_result.value());
+
+    vsag::Options::Instance().set_block_size_limit(origin_size);
 }

--- a/tests/test_regression.cpp
+++ b/tests/test_regression.cpp
@@ -13,12 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <vsag/options.h>
 #include <vsag/vsag.h>
 #include <vsag/vsag_ext.h>
-#include <vsag/options.h>
 
 #include <catch2/catch_test_macros.hpp>
 #include <cstdlib>
+#include <limits>
 #include <new>
 #include <nlohmann/json.hpp>
 #include <numeric>
@@ -105,6 +106,21 @@ TEST_CASE("gh#369", "[ft][github]") {
 TEST_CASE("gh#1974", "[ft][github]") {
     using namespace nlohmann;
 
+    class BlockSizeLimitGuard {
+    public:
+        explicit BlockSizeLimitGuard(uint64_t block_size_limit)
+            : origin_size_(vsag::Options::Instance().block_size_limit()) {
+            vsag::Options::Instance().set_block_size_limit(block_size_limit);
+        }
+
+        ~BlockSizeLimitGuard() {
+            vsag::Options::Instance().set_block_size_limit(origin_size_);
+        }
+
+    private:
+        uint64_t origin_size_;
+    };
+
     class LimitedAllocator : public Allocator {
     public:
         std::string
@@ -172,8 +188,7 @@ TEST_CASE("gh#1974", "[ft][github]") {
         std::unordered_map<void*, uint64_t> sizes_;
     };
 
-    auto origin_size = vsag::Options::Instance().block_size_limit();
-    vsag::Options::Instance().set_block_size_limit(512ULL * 1024ULL);
+    BlockSizeLimitGuard block_size_limit_guard(512ULL * 1024ULL);
 
     constexpr int64_t dim = 32;
     constexpr int64_t base_count = 4096;
@@ -192,14 +207,10 @@ TEST_CASE("gh#1974", "[ft][github]") {
                     {"store_raw_vector", true}};
     json tuned_param = base_param;
     tuned_param["base_quantization_type"] = "bf16";
-    json index_param{{"dtype", "float32"},
-                     {"metric_type", "l2"},
-                     {"dim", dim},
-                     {"index_param", base_param}};
-    json tune_param{{"dtype", "float32"},
-                    {"metric_type", "l2"},
-                    {"dim", dim},
-                    {"index_param", tuned_param}};
+    json index_param{
+        {"dtype", "float32"}, {"metric_type", "l2"}, {"dim", dim}, {"index_param", base_param}};
+    json tune_param{
+        {"dtype", "float32"}, {"metric_type", "l2"}, {"dim", dim}, {"index_param", tuned_param}};
 
     LimitedAllocator allocator;
     auto create_result = vsag::Factory::CreateIndex("hgraph", index_param.dump(), &allocator);
@@ -232,6 +243,4 @@ TEST_CASE("gh#1974", "[ft][github]") {
     auto tune_result = hgraph->Tune(tune_param.dump());
     REQUIRE(tune_result.has_value());
     REQUIRE(tune_result.value());
-
-    vsag::Options::Instance().set_block_size_limit(origin_size);
 }


### PR DESCRIPTION
## Summary
- Delay HGraph element-count updates until add/build resize succeeds.
- Add a guard for missing vector data before decoding by inner id.
- Add regression coverage for #1974 to ensure failed Add does not corrupt Tune.

## Tests
- `cmake --build \"./build/\" --target functests --parallel 96`
- `./build/tests/functests -d yes \"gh#1974\" --allow-running-no-tests`