### PR TITLE
[WIP] Add FEATURE_IDS constant and implement Build Cache support

### DIFF
--- a/examples/cpp/322_feature_build_cache.cpp
+++ b/examples/cpp/322_feature_build_cache.cpp
@@ -1,0 +1,372 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file 322_feature_build_cache.cpp
+ * @brief Demonstrates the Build Cache feature for accelerated HGraph index rebuilding.
+ *
+ * Usage:
+ *   ./322_feature_build_cache <day1_data_dir> <day2_data_dir>
+ *
+ * Where each data_dir contains:
+ *   - id_map:  Text file, one FeatureID per line (e.g., "438b28dd3e02e8325f752dcf61e1d2d6_NEWS")
+ *   - label.bin: Binary file of int64_t labels (sequential 0,1,2,...)
+ *   - vector_data.bin: Binary file of float32 vectors (dim=768)
+ *
+ * The program:
+ *   1. Loads day1 data, builds an HGraph index (Phase 1)
+ *   2. Exports the Build Cache from the day1 index
+ *   3. Loads day2 data, uses the cache to warm-start a new index build (Phase 2)
+ *   4. Prints cache hit statistics
+ *   5. Performs a sample search to verify correctness
+ */
+
+#include <vsag/vsag.h>
+
+#include <chrono>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <random>
+#include <sstream>
+#include <string>
+#include <vector>
+
+// ============================================================================
+// Utility: Load data from disk
+// ============================================================================
+
+/**
+ * Load id_map file: one FeatureID string per line.
+ * Returns a vector of strings.
+ */
+static std::vector<std::string>
+load_id_map(const std::string& path) {
+    std::vector<std::string> result;
+    std::ifstream fin(path);
+    if (!fin.is_open()) {
+        std::cerr << "Cannot open id_map file: " << path << std::endl;
+        return result;
+    }
+    std::string line;
+    while (std::getline(fin, line)) {
+        if (!line.empty()) {
+            result.push_back(line);
+        }
+    }
+    return result;
+}
+
+/**
+ * Load label.bin file: array of int64_t.
+ * Returns a vector of int64_t labels.
+ */
+static std::vector<int64_t>
+load_labels(const std::string& path, int64_t expected_count) {
+    std::vector<int64_t> labels(expected_count);
+    std::ifstream fin(path, std::ios::binary);
+    if (!fin.is_open()) {
+        std::cerr << "Cannot open label.bin file: " << path << std::endl;
+        return {};
+    }
+    fin.read(reinterpret_cast<char*>(labels.data()), expected_count * sizeof(int64_t));
+    return labels;
+}
+
+/**
+ * Load vector_data.bin file: array of float32 vectors.
+ * Returns a vector of float values.
+ */
+static std::vector<float>
+load_vectors(const std::string& path, int64_t num_vectors, int64_t dim) {
+    std::vector<float> vectors(num_vectors * dim);
+    std::ifstream fin(path, std::ios::binary);
+    if (!fin.is_open()) {
+        std::cerr << "Cannot open vector_data.bin file: " << path << std::endl;
+        return {};
+    }
+    fin.read(reinterpret_cast<char*>(vectors.data()), num_vectors * dim * sizeof(float));
+    return vectors;
+}
+
+// ============================================================================
+// Utility: Create dataset for building
+// ============================================================================
+
+static vsag::DatasetPtr
+create_dataset(int64_t num_vectors,
+               int64_t dim,
+               const std::vector<int64_t>& ids,
+               const std::vector<float>& vectors,
+               const std::vector<std::string>* feature_ids = nullptr) {
+    auto dataset = vsag::Dataset::Make();
+    dataset->NumElements(num_vectors)->Dim(dim)->Ids(ids.data())->Float32Vectors(vectors.data());
+    if (feature_ids != nullptr) {
+        dataset->FeatureIds(feature_ids->data());
+    }
+    dataset->Owner(false);
+    return dataset;
+}
+
+// ============================================================================
+// Main
+// ============================================================================
+
+int
+main(int argc, char** argv) {
+    vsag::init();
+
+    // -------------------------------------------------------------------------
+    // Configuration (change these paths for your environment)
+    // -------------------------------------------------------------------------
+    std::string day1_dir = (argc > 1) ? argv[1] : "./whole-30m-768-euclidean-day1";
+    std::string day2_dir = (argc > 2) ? argv[2] : "./whole-30m-768-euclidean-day2";
+
+    // For quick testing, limit the number of vectors to load (-1 means all)
+    int64_t max_load = 10000;
+
+    int64_t dim = 768;
+
+    // -------------------------------------------------------------------------
+    // Phase 1: Build index with day1 data and export cache
+    // -------------------------------------------------------------------------
+    std::cout << "=== Phase 1: Building index with day1 data ===" << std::endl;
+
+    auto day1_ids = load_id_map(day1_dir + "/id_map");
+
+    // Determine actual data count from label.bin size.
+    // id_map may have more entries than label.bin/vector_data.bin, so we use the
+    // minimum of all three sources to ensure alignment.
+    int64_t label_count = static_cast<int64_t>(
+        std::filesystem::file_size(day1_dir + "/label.bin") / sizeof(int64_t));
+    int64_t vector_count = static_cast<int64_t>(
+        std::filesystem::file_size(day1_dir + "/vector_data.bin") / (dim * sizeof(float)));
+    int64_t id_count = static_cast<int64_t>(day1_ids.size());
+    int64_t day1_count = std::min({label_count, vector_count, id_count});
+
+    if (max_load > 0 && max_load < day1_count) {
+        day1_count = max_load;
+    }
+
+    auto day1_labels = load_labels(day1_dir + "/label.bin", day1_count);
+    auto day1_vectors = load_vectors(day1_dir + "/vector_data.bin", day1_count, dim);
+
+    if (day1_labels.empty() || day1_vectors.empty()) {
+        std::cerr << "Failed to load day1 data" << std::endl;
+        return 1;
+    }
+
+    // Limit feature ids to loaded count
+    if (static_cast<int64_t>(day1_ids.size()) > day1_count) {
+        day1_ids.resize(day1_count);
+    }
+
+    std::string hgraph_params = R"(
+    {
+        "dtype": "float32",
+        "metric_type": "l2",
+        "dim": 768,
+        "index_param": {
+            "base_quantization_type": "sq8",
+            "max_degree": 26,
+            "ef_construction": 100,
+            "alpha": 1.2
+        }
+    }
+    )";
+
+    vsag::Resource resource(vsag::Engine::CreateDefaultAllocator(), nullptr);
+    vsag::Engine engine(&resource);
+
+    auto day1_index = engine.CreateIndex("hgraph", hgraph_params).value();
+
+    auto day1_base =
+        create_dataset(day1_count, dim, day1_labels, day1_vectors, &day1_ids);
+
+    auto build_start = std::chrono::steady_clock::now();
+    auto build_result = day1_index->Build(day1_base);
+    auto build_end = std::chrono::steady_clock::now();
+
+    if (!build_result.has_value()) {
+        std::cerr << "Failed to build day1 index: " << build_result.error().message << std::endl;
+        return 1;
+    }
+    auto build_ms = std::chrono::duration_cast<std::chrono::milliseconds>(build_end - build_start).count();
+    std::cout << "Day1 index built in " << build_ms << " ms, "
+              << "num_elements=" << day1_index->GetNumElements() << std::endl;
+
+    // Check Build Cache support
+    std::cout << "SupportsBuildCache: " << (day1_index->SupportsBuildCache() ? "true" : "false")
+              << std::endl;
+
+    // Export Build Cache to file
+    std::string cache_file = "/tmp/vsag_build_cache.bin";
+    {
+        std::ofstream ofs(cache_file, std::ios::binary);
+        auto export_result = day1_index->ExportBuildCache(ofs);
+        if (!export_result.has_value()) {
+            std::cerr << "Failed to export build cache: " << export_result.error().message
+                      << std::endl;
+            return 1;
+        }
+        ofs.close();
+        std::cout << "Build cache exported to " << cache_file << std::endl;
+    }
+
+    // -------------------------------------------------------------------------
+    // Phase 2: Build index with day2 data using cache warm start
+    // -------------------------------------------------------------------------
+    std::cout << "\n=== Phase 2: Building index with day2 data (using cache) ===" << std::endl;
+
+    auto day2_ids = load_id_map(day2_dir + "/id_map");
+    int64_t label_count2 = static_cast<int64_t>(
+        std::filesystem::file_size(day2_dir + "/label.bin") / sizeof(int64_t));
+    int64_t vector_count2 = static_cast<int64_t>(
+        std::filesystem::file_size(day2_dir + "/vector_data.bin") / (dim * sizeof(float)));
+    int64_t id_count2 = static_cast<int64_t>(day2_ids.size());
+    int64_t day2_count = std::min({label_count2, vector_count2, id_count2});
+
+    if (max_load > 0 && max_load < day2_count) {
+        day2_count = max_load;
+    }
+
+    auto day2_labels = load_labels(day2_dir + "/label.bin", day2_count);
+    auto day2_vectors = load_vectors(day2_dir + "/vector_data.bin", day2_count, dim);
+
+    if (day2_labels.empty() || day2_vectors.empty()) {
+        std::cerr << "Failed to load day2 data" << std::endl;
+        return 1;
+    }
+
+    if (static_cast<int64_t>(day2_ids.size()) > day2_count) {
+        day2_ids.resize(day2_count);
+    }
+
+    auto day2_index = engine.CreateIndex("hgraph", hgraph_params).value();
+
+    auto day2_base =
+        create_dataset(day2_count, dim, day2_labels, day2_vectors, &day2_ids);
+
+    // Build with cache
+    vsag::BuildCacheOptions cache_options;
+    cache_options.enable_warm_start = true;
+    cache_options.hit_refine_rounds = 2;
+    cache_options.missed_refine_rounds = 4;
+    cache_options.drop_invalid_neighbors = true;
+
+    {
+        std::ifstream ifs(cache_file, std::ios::binary);
+        auto cache_build_start = std::chrono::steady_clock::now();
+        auto cache_build_result = day2_index->BuildWithCache(day2_base, ifs, cache_options);
+        auto cache_build_end = std::chrono::steady_clock::now();
+
+        if (!cache_build_result.has_value()) {
+            std::cerr << "BuildWithCache failed: " << cache_build_result.error().message
+                      << std::endl;
+            std::cerr << "Falling back to full Build..." << std::endl;
+
+            // Fallback to normal Build
+            auto fallback_index = engine.CreateIndex("hgraph", hgraph_params).value();
+            auto fb_result = fallback_index->Build(day2_base);
+            if (!fb_result.has_value()) {
+                std::cerr << "Fallback Build also failed: " << fb_result.error().message
+                          << std::endl;
+                return 1;
+            }
+            day2_index = fallback_index;
+        } else {
+            auto cache_build_ms =
+                std::chrono::duration_cast<std::chrono::milliseconds>(cache_build_end -
+                                                                       cache_build_start)
+                    .count();
+            std::cout << "Day2 index built with cache in " << cache_build_ms << " ms, "
+                      << "num_elements=" << day2_index->GetNumElements() << std::endl;
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Phase 3: Print Build Cache statistics
+    // -------------------------------------------------------------------------
+    auto stats_result = day2_index->GetBuildCacheStats();
+    if (stats_result.has_value()) {
+        const auto& stats = stats_result.value();
+        std::cout << "\n=== Build Cache Statistics ===" << std::endl;
+        std::cout << "  total_nodes:        " << stats.total_nodes << std::endl;
+        std::cout << "  cached_nodes:       " << stats.cached_nodes << std::endl;
+        std::cout << "  hit_nodes:          " << stats.hit_nodes << std::endl;
+        std::cout << "  missed_nodes:       " << stats.missed_nodes << std::endl;
+        std::cout << "  cache_hit_rate:     " << stats.cache_hit_rate << std::endl;
+        std::cout << "  dropped_neighbors:  " << stats.dropped_neighbors << std::endl;
+        std::cout << "  invalid_neighbors:  " << stats.invalid_neighbors << std::endl;
+        std::cout << "  hit_refine_rounds:  " << stats.hit_refine_rounds << std::endl;
+        std::cout << "  missed_refine_rounds: " << stats.missed_refine_rounds << std::endl;
+        std::cout << "  cache_load_us:      " << stats.cache_load_us << std::endl;
+        std::cout << "  warm_start_apply_us: " << stats.warm_start_apply_us << std::endl;
+        std::cout << "  hit_refine_us:      " << stats.hit_refine_us << std::endl;
+        std::cout << "  missed_refine_us:   " << stats.missed_refine_us << std::endl;
+    }
+
+    // -------------------------------------------------------------------------
+    // Phase 4: Verify search works
+    // -------------------------------------------------------------------------
+    std::cout << "\n=== Verification: KnnSearch ===" << std::endl;
+    std::vector<float> query_vec(dim);
+    std::mt19937 rng(47);
+    std::uniform_real_distribution<float> distrib_real;
+    for (int64_t i = 0; i < dim; ++i) {
+        query_vec[i] = distrib_real(rng);
+    }
+    auto query = vsag::Dataset::Make();
+    query->NumElements(1)->Dim(dim)->Float32Vectors(query_vec.data())->Owner(false);
+
+    std::string search_params = R"(
+    {
+        "hgraph": {
+            "ef_search": 100
+        }
+    }
+    )";
+
+    auto search_result = day2_index->KnnSearch(query, 10, search_params);
+    if (search_result.has_value()) {
+        std::cout << "Search returned " << search_result.value()->GetDim() << " results:" << std::endl;
+        for (int64_t i = 0; i < std::min(static_cast<int64_t>(5), search_result.value()->GetDim());
+             ++i) {
+            std::cout << "  id=" << search_result.value()->GetIds()[i]
+                      << " dist=" << search_result.value()->GetDistances()[i] << std::endl;
+        }
+    } else {
+        std::cerr << "Search failed: " << search_result.error().message << std::endl;
+    }
+
+    // -------------------------------------------------------------------------
+    // Phase 5: Export new cache for next cycle
+    // -------------------------------------------------------------------------
+    std::cout << "\n=== Phase 5: Exporting cache for next build cycle ===" << std::endl;
+    {
+        std::string cache_file_v2 = "/tmp/vsag_build_cache_v2.bin";
+        std::ofstream ofs(cache_file_v2, std::ios::binary);
+        auto export_result = day2_index->ExportBuildCache(ofs);
+        if (export_result.has_value()) {
+            std::cout << "New build cache exported to " << cache_file_v2 << std::endl;
+        } else {
+            std::cerr << "Failed to export new cache: " << export_result.error().message
+                      << std::endl;
+        }
+    }
+
+    engine.Shutdown();
+    return 0;
+}

--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -124,3 +124,6 @@ target_link_libraries (501_quantization_transform vsag)
 
 add_executable (321_index_fp16_hgraph 321_index_fp16_hgraph.cpp)
 target_link_libraries (321_index_fp16_hgraph vsag)
+
+add_executable(322_feature_build_cache 322_feature_build_cache.cpp)
+target_link_libraries(322_feature_build_cache vsag)

--- a/include/vsag/build_cache.h
+++ b/include/vsag/build_cache.h
@@ -1,0 +1,91 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+
+namespace vsag {
+
+/**
+ * @brief Options controlling Build Cache behavior.
+ *
+ * Build Cache uses the neighbor relationships from a previous index build
+ * to provide a warm start for the next build, reducing iteration rounds
+ * needed for graph convergence.
+ */
+struct BuildCacheOptions {
+    /** Whether to enable Warm Start. When false, BuildWithCache falls back to normal Build. */
+    bool enable_warm_start = true;
+
+    /** Number of Refine iterations for cache-hit nodes. Hit nodes already have
+     *  high-quality neighbors from the cache and converge quickly (1-2 rounds typically). */
+    uint32_t hit_refine_rounds = 2;
+
+    /** Number of Refine iterations for cache-miss nodes. Miss nodes start from
+     *  empty neighbors and need more iterations to integrate into the graph. */
+    uint32_t missed_refine_rounds = 4;
+
+    /** Whether to drop neighbors that map to deleted nodes (mapped to UINT32_MAX).
+     *  When true, invalid neighbors are removed from the neighbor list before injection. */
+    bool drop_invalid_neighbors = true;
+};
+
+/**
+ * @brief Statistics from the most recent BuildWithCache operation.
+ *
+ * These metrics are for observability only and do not influence build decisions.
+ */
+struct BuildCacheStats {
+    /** Total number of nodes in the new index. */
+    uint64_t total_nodes = 0;
+
+    /** Number of nodes present in the cache (old index size). */
+    uint64_t cached_nodes = 0;
+
+    /** Number of nodes that hit the cache (FeatureID exists in both old and new index). */
+    uint64_t hit_nodes = 0;
+
+    /** Number of nodes that missed the cache (new nodes or no record in cache). */
+    uint64_t missed_nodes = 0;
+
+    /** Total number of neighbors dropped because they mapped to deleted nodes. */
+    uint64_t dropped_neighbors = 0;
+
+    /** Total number of neighbors that mapped to deleted nodes (before drop filter). */
+    uint64_t invalid_neighbors = 0;
+
+    /** Actual Refine rounds executed for hit nodes. */
+    uint64_t hit_refine_rounds = 0;
+
+    /** Actual Refine rounds executed for missed nodes. */
+    uint64_t missed_refine_rounds = 0;
+
+    /** Cache loading time in microseconds. */
+    uint64_t cache_load_us = 0;
+
+    /** Warm Start neighbor injection time in microseconds. */
+    uint64_t warm_start_apply_us = 0;
+
+    /** Refine time for hit nodes in microseconds. */
+    uint64_t hit_refine_us = 0;
+
+    /** Refine time for missed nodes in microseconds. */
+    uint64_t missed_refine_us = 0;
+
+    /** Actual cache hit rate (hit_nodes / total_nodes). */
+    float cache_hit_rate = 0.0F;
+};
+
+}  // namespace vsag

--- a/include/vsag/constants.h
+++ b/include/vsag/constants.h
@@ -39,6 +39,7 @@ extern const char* const DATASET_PATHS;
 extern const char* const EXTRA_INFOS;
 extern const char* const EXTRA_INFO_SIZE;
 extern const char* const VECTOR_COUNTS;
+extern const char* const FEATURE_IDS;
 
 extern const char* const HNSW_DATA;
 extern const char* const CONJUGATE_GRAPH_DATA;

--- a/include/vsag/dataset.h
+++ b/include/vsag/dataset.h
@@ -405,6 +405,27 @@ public:
      */
     virtual const uint32_t*
     GetVectorCounts() const = 0;
+
+    /**
+     * @brief Sets the FeatureID array for the dataset.
+     *
+     * FeatureIDs are fixed-length strings used as cross-build-cycle stable identifiers
+     * for Build Cache warm start. Each FeatureID uniquely identifies a vector across
+     * different index build cycles, enabling neighbor cache mapping.
+     *
+     * @param feature_ids Pointer to the array of FeatureID strings.
+     * @return DatasetPtr A shared pointer to the dataset with FeatureIDs set.
+     */
+    virtual DatasetPtr
+    FeatureIds(const std::string* feature_ids) = 0;
+
+    /**
+     * @brief Retrieves the FeatureID array of the dataset.
+     *
+     * @return const std::string* Pointer to the array of FeatureID strings.
+     */
+    virtual const std::string*
+    GetFeatureIds() const = 0;
 };
 
 };  // namespace vsag

--- a/include/vsag/index.h
+++ b/include/vsag/index.h
@@ -21,6 +21,7 @@
 
 #include "vsag/binaryset.h"
 #include "vsag/bitset.h"
+#include "vsag/build_cache.h"
 #include "vsag/dataset.h"
 #include "vsag/errors.h"
 #include "vsag/expected.hpp"
@@ -745,6 +746,68 @@ public:
     virtual tl::expected<void, Error>
     SetImmutable() {
         throw std::runtime_error("Index doesn't support SetImmutable");
+    }
+
+public:
+    // [build cache methods]
+
+    /**
+     * @brief Check whether the index supports Build Cache functionality.
+     *
+     * Not all index types support Build Cache. Callers should probe this
+     * before calling ExportBuildCache / BuildWithCache.
+     *
+     * @return true if Build Cache is supported, false otherwise.
+     */
+    [[nodiscard]] virtual bool
+    SupportsBuildCache() const {
+        return false;
+    }
+
+    /**
+     * @brief Export the build cache from the current index to an output stream.
+     *
+     * The cache contains the bottom graph neighbor relationships and the
+     * FeatureID-to-inner_id mapping table. It should be called after a
+     * successful index build.
+     *
+     * @param out_stream Output stream to write the cache data to.
+     * @return void on success, or Error if export fails.
+     */
+    virtual tl::expected<void, Error>
+    ExportBuildCache(std::ostream& out_stream) const {
+        throw std::runtime_error("Index doesn't support ExportBuildCache");
+    }
+
+    /**
+     * @brief Build the index using a cache from a previous build for warm start.
+     *
+     * This is the core entry point for the Build Cache mechanism. It uses
+     * cached neighbor relationships to initialize the bottom graph with
+     * high-quality starting points, then performs differentiated Refine
+     * iterations based on cache hit/miss status.
+     *
+     * @param base The new dataset, containing dim, num_elements, ids, vectors,
+     *             and FeatureIds (fixed-length string field).
+     * @param in_stream Input stream from a previous ExportBuildCache call.
+     * @param options Behavior control options for warm start and refine.
+     * @return IDs that failed to insert, or Error if build fails.
+     */
+    virtual tl::expected<std::vector<int64_t>, Error>
+    BuildWithCache(const DatasetPtr& base,
+                   std::istream& in_stream,
+                   const BuildCacheOptions& options = BuildCacheOptions{}) {
+        throw std::runtime_error("Index doesn't support BuildWithCache");
+    }
+
+    /**
+     * @brief Get statistics from the most recent BuildWithCache operation.
+     *
+     * @return BuildCacheStats containing hit/miss counts, refine metrics, etc.
+     */
+    [[nodiscard]] virtual tl::expected<BuildCacheStats, Error>
+    GetBuildCacheStats() const {
+        throw std::runtime_error("Index doesn't support GetBuildCacheStats");
     }
 
 public:

--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -19,6 +19,7 @@
 #include <fmt/format.h>
 
 #include <atomic>
+#include <chrono>
 #include <memory>
 #include <stdexcept>
 
@@ -38,7 +39,9 @@
 #include "io/reader_io_parameter.h"
 #include "storage/serialization.h"
 #include "storage/stream_reader.h"
+#include "storage/stream_writer.h"
 #include "typing.h"
+#include "utils/open_addressing_hashmap.h"
 #include "utils/util_functions.h"
 #include "utils/visited_list.h"
 #include "vsag/options.h"
@@ -2612,6 +2615,678 @@ HGraph::cal_memory_usage() {
 
     std::unique_lock lock(this->memory_usage_mutex_);
     this->current_memory_usage_.store(static_cast<int64_t>(memory));
+}
+
+// ============================================================================
+// Build Cache implementation
+// ============================================================================
+
+// Cache file format constants
+static constexpr uint64_t BUILD_CACHE_MAGIC = 0x5653414743484500ULL;  // "VSAGCHE\0"
+static constexpr uint32_t BUILD_CACHE_VERSION = 1;
+static constexpr uint64_t BUILD_CACHE_HEADER_SIZE = 128;
+
+bool
+HGraph::SupportsBuildCache() const {
+    return true;
+}
+
+tl::expected<void, Error>
+HGraph::ExportBuildCache(std::ostream& out_stream) const {
+    try {
+        IOStreamWriter writer(out_stream);
+
+        // Section 0: Header (128 bytes)
+        // Write raw header fields in binary
+        uint64_t magic = BUILD_CACHE_MAGIC;
+        uint32_t version = BUILD_CACHE_VERSION;
+        uint64_t node_count = static_cast<uint64_t>(this->GetNumElements());
+        uint32_t max_degree = this->bottom_graph_->MaximumDegree();
+
+        // feature_id_len semantics:
+        //   0 = label-based cache (labels stored as int64)
+        //   0xFFFFFFFF = variable-length FeatureID cache (length-prefixed strings)
+        // Currently only label-based export is supported from the index itself.
+        uint32_t feature_id_len = 0;  // label-based
+
+        uint64_t build_param_hash = ComputeBuildParamHash();
+        uint64_t create_time = static_cast<uint64_t>(
+            std::chrono::duration_cast<std::chrono::seconds>(
+                std::chrono::system_clock::now().time_since_epoch())
+                .count());
+
+        StreamWriter::WriteObj(writer, magic);
+        StreamWriter::WriteObj(writer, version);
+        StreamWriter::WriteObj(writer, node_count);
+        StreamWriter::WriteObj(writer, max_degree);
+        StreamWriter::WriteObj(writer, feature_id_len);
+        StreamWriter::WriteObj(writer, build_param_hash);
+        StreamWriter::WriteObj(writer, create_time);
+
+        // Reserved bytes to fill up to 128 bytes
+        // Already written: 8+4+8+4+4+8+8 = 44 bytes
+        uint64_t reserved_size = BUILD_CACHE_HEADER_SIZE - 44;
+        std::vector<char> reserved(reserved_size, 0);
+        writer.Write(reserved.data(), reserved_size);
+
+        // Section 1: Label list (int64 for label-based cache)
+        // When feature_id_len == 0, each entry is sizeof(LabelType) = 8 bytes.
+        const auto& labels = this->label_table_->label_table_;
+        for (InnerIdType id = 0; id < static_cast<InnerIdType>(node_count); ++id) {
+            LabelType label = (id < labels.size()) ? labels[id] : LabelType(-1);
+            StreamWriter::WriteObj(writer, label);
+        }
+
+        // Section 2: Neighbor lists from bottom_graph_
+        ExportOldNeighbors(writer);
+
+        return {};
+    } catch (const std::exception& e) {
+        return tl::unexpected(Error(ErrorType::INTERNAL_ERROR,
+                                    fmt::format("ExportBuildCache failed: {}", e.what())));
+    }
+}
+
+tl::expected<std::vector<int64_t>, Error>
+HGraph::BuildWithCache(const DatasetPtr& base,
+                       std::istream& in_stream,
+                       const BuildCacheOptions& options) {
+    auto start_time = std::chrono::steady_clock::now();
+
+    // Reset stats
+    build_cache_stats_ = BuildCacheStats{};
+
+    if (!options.enable_warm_start) {
+        // Fallback to normal Build
+        return this->Build(base);
+    }
+
+    CHECK_ARGUMENT(GetNumElements() == 0, "index is not empty, cannot BuildWithCache");
+
+    try {
+        IOStreamReader reader(in_stream);
+
+        // Step 1: Read and validate header
+        uint64_t magic = 0;
+        StreamReader::ReadObj(reader, magic);
+        if (magic != BUILD_CACHE_MAGIC) {
+            return tl::unexpected(Error(
+                ErrorType::INVALID_BINARY,
+                fmt::format("Invalid cache file: magic mismatch, expected 0x{:016X}, got 0x{:016X}",
+                            BUILD_CACHE_MAGIC, magic)));
+        }
+
+        uint32_t version = 0;
+        StreamReader::ReadObj(reader, version);
+        if (version != BUILD_CACHE_VERSION) {
+            return tl::unexpected(Error(
+                ErrorType::INVALID_BINARY,
+                fmt::format("Cache version incompatible: expected v{}, got v{}",
+                            BUILD_CACHE_VERSION, version)));
+        }
+
+        uint64_t node_count = 0;
+        StreamReader::ReadObj(reader, node_count);
+
+        uint32_t cached_max_degree = 0;
+        StreamReader::ReadObj(reader, cached_max_degree);
+
+        uint32_t feature_id_len = 0;
+        StreamReader::ReadObj(reader, feature_id_len);
+
+        uint64_t cached_param_hash = 0;
+        StreamReader::ReadObj(reader, cached_param_hash);
+
+        uint64_t create_time = 0;
+        StreamReader::ReadObj(reader, create_time);
+        // Suppress unused warning
+        (void)create_time;
+
+        // Skip reserved bytes
+        uint64_t reserved_size = BUILD_CACHE_HEADER_SIZE - 44;
+        std::vector<char> reserved(reserved_size);
+        reader.Read(reserved.data(), reserved_size);
+
+        // Validate build_param_hash
+        uint64_t current_param_hash = ComputeBuildParamHash();
+        if (cached_param_hash != current_param_hash) {
+            return tl::unexpected(Error(
+                ErrorType::INVALID_BINARY,
+                fmt::format("Build params changed: old_hash=0x{:016X}, new_hash=0x{:016X}",
+                            cached_param_hash, current_param_hash)));
+        }
+
+        // Validate max_degree
+        if (cached_max_degree != this->bottom_graph_->MaximumDegree()) {
+            return tl::unexpected(Error(
+                ErrorType::INVALID_BINARY,
+                fmt::format("max_degree mismatch: cache={}, current={}",
+                            cached_max_degree, this->bottom_graph_->MaximumDegree())));
+        }
+
+        build_cache_stats_.cached_nodes = node_count;
+
+        auto cache_loaded_time = std::chrono::steady_clock::now();
+
+        // Determine feature_id_len: from dataset FeatureIds or default LabelType size
+        const std::string* dataset_feature_ids = base->GetFeatureIds();
+        int64_t num_elements = base->GetNumElements();
+        build_cache_stats_.total_nodes = static_cast<uint64_t>(num_elements);
+
+        // feature_id_len semantics from cache header:
+        //   0 = label-based cache (labels stored as int64)
+        //   0xFFFFFFFF = variable-length FeatureID cache (length-prefixed strings)
+        //   other = fixed-length FeatureID (legacy, treated as variable-length)
+        bool use_feature_ids = (dataset_feature_ids != nullptr &&
+                                feature_id_len != 0);
+
+        // Step 2: Build mapping table 1 (FeatureID -> new inner_id) from new dataset
+        OpenAddressingHashMap<uint32_t> fid_to_new_id(
+            static_cast<uint64_t>(num_elements));
+
+        // Also need to Train and prepare the index structures
+        this->Train(base);
+
+        // Assign inner_ids and build label_table_
+        std::vector<int64_t> failed_ids;
+        auto inner_ids = this->get_unique_inner_ids(static_cast<InnerIdType>(num_elements));
+        this->resize(static_cast<uint64_t>(num_elements));
+
+        const auto* labels = base->GetIds();
+        for (int64_t j = 0; j < num_elements; ++j) {
+            InnerIdType inner_id = inner_ids[static_cast<uint32_t>(j)];
+            this->label_table_->Insert(inner_id, labels[j]);
+        }
+
+        // Insert vector data into flatten codes (required for graph_add_one refine)
+        for (int64_t j = 0; j < num_elements; ++j) {
+            InnerIdType inner_id = inner_ids[static_cast<uint32_t>(j)];
+            const void* vec_data = this->get_data(base, j);
+            this->basic_flatten_codes_->InsertVector(vec_data, inner_id);
+            if (this->use_reorder_) {
+                this->high_precise_codes_->InsertVector(vec_data, inner_id);
+            }
+            if (this->create_new_raw_vector_) {
+                this->raw_vector_->InsertVector(vec_data, inner_id);
+            }
+        }
+
+        // Build FeatureID -> new inner_id mapping
+        if (use_feature_ids) {
+            for (int64_t j = 0; j < num_elements; ++j) {
+                InnerIdType inner_id = inner_ids[static_cast<uint32_t>(j)];
+                fid_to_new_id.Insert(std::string(dataset_feature_ids[j]), inner_id);
+            }
+        }
+
+        // Step 3: Load mapping table 2 (old inner_id -> FeatureID) and old neighbor lists
+        std::vector<std::string> old_feature_ids;
+        std::vector<uint32_t> old_to_new;
+
+        if (use_feature_ids && feature_id_len == 0xFFFFFFFF) {
+            // Variable-length FeatureID cache: each entry is [uint32_t len][char[len] data]
+            old_feature_ids.resize(node_count);
+            for (uint64_t i = 0; i < node_count; ++i) {
+                uint32_t fid_len = 0;
+                StreamReader::ReadObj(reader, fid_len);
+                old_feature_ids[i].resize(fid_len);
+                reader.Read(old_feature_ids[i].data(), fid_len);
+            }
+        } else if (use_feature_ids) {
+            // Fixed-length FeatureID cache (legacy): read feature_id_len bytes per entry
+            LoadOldFeatureIds(reader, old_feature_ids, node_count, feature_id_len);
+        } else {
+            // Label-based cache: load labels as int64
+            old_feature_ids.resize(node_count);
+            for (uint64_t i = 0; i < node_count; ++i) {
+                LabelType label;
+                StreamReader::ReadObj(reader, label);
+                old_feature_ids[i] = std::to_string(label);
+            }
+        }
+
+        // Step 4: Load old neighbor lists
+        std::vector<std::vector<uint32_t>> old_neighbors;
+        LoadOldNeighbors(reader, old_neighbors, node_count, cached_max_degree);
+
+        auto neighbor_loaded_time = std::chrono::steady_clock::now();
+
+        // Step 5: Build mapping table 3 (old inner_id -> new inner_id)
+        if (use_feature_ids) {
+            BuildOldToNewMapping(old_feature_ids, fid_to_new_id, old_to_new);
+        } else {
+            // For label-based cache: old label -> new inner_id via label_table_
+            old_to_new.resize(node_count, std::numeric_limits<uint32_t>::max());
+            for (uint64_t old_id = 0; old_id < node_count; ++old_id) {
+                LabelType old_label = std::stoll(old_feature_ids[old_id]);
+                auto [found, new_id] = this->label_table_->TryGetIdByLabel(old_label);
+                if (found && !this->label_table_->IsRemoved(new_id)) {
+                    old_to_new[old_id] = new_id;
+                }
+                // else: remains UINT32_MAX (deleted)
+            }
+        }
+
+        // Release mapping table 1 (fid_to_new_id) and mapping table 2 (old_feature_ids) to free memory
+        {
+            OpenAddressingHashMap<uint32_t> empty_map(1);
+            fid_to_new_id = std::move(empty_map);
+        }
+        {
+            std::vector<std::string>().swap(old_feature_ids);
+        }
+
+        auto mapping_built_time = std::chrono::steady_clock::now();
+
+        // Step 6: Count hit/miss nodes
+        for (uint64_t old_id = 0; old_id < old_to_new.size(); ++old_id) {
+            if (old_to_new[old_id] != std::numeric_limits<uint32_t>::max()) {
+                build_cache_stats_.hit_nodes++;
+            }
+        }
+        build_cache_stats_.missed_nodes =
+            build_cache_stats_.total_nodes - build_cache_stats_.hit_nodes;
+
+        // Step 7: Normalize mapped neighbors
+        NormalizeMappedNeighbors(old_neighbors, options);
+
+        auto warm_start_apply_start = std::chrono::steady_clock::now();
+
+        // Step 8: Apply warm start neighbors and refine
+        ApplyWarmStartNeighbors(old_to_new, old_neighbors, options);
+
+        // Release mapping table 3 and old_neighbors
+        {
+            std::vector<uint32_t>().swap(old_to_new);
+        }
+        {
+            std::vector<std::vector<uint32_t>>().swap(old_neighbors);
+        }
+
+        auto end_time = std::chrono::steady_clock::now();
+
+        // Step 9: Generate route graphs (no cache, build from scratch)
+        // Route graphs are built during add_one_point calls which are part of
+        // the refine above. However, we need to ensure entry_point is set.
+        if (this->bottom_graph_->TotalCount() > 0) {
+            // The entry_point has been set during the process
+        }
+
+        auto duration_us = [](auto start, auto end) -> uint64_t {
+            return static_cast<uint64_t>(
+                std::chrono::duration_cast<std::chrono::microseconds>(end - start).count());
+        };
+
+        build_cache_stats_.cache_load_us = duration_us(start_time, cache_loaded_time);
+        build_cache_stats_.warm_start_apply_us = duration_us(warm_start_apply_start, end_time);
+        build_cache_stats_.cache_hit_rate =
+            (build_cache_stats_.total_nodes > 0)
+                ? static_cast<float>(build_cache_stats_.hit_nodes) /
+                      static_cast<float>(build_cache_stats_.total_nodes)
+                : 0.0F;
+
+        return failed_ids;
+    } catch (const std::exception& e) {
+        return tl::unexpected(Error(ErrorType::INTERNAL_ERROR,
+                                    fmt::format("BuildWithCache failed: {}", e.what())));
+    }
+}
+
+tl::expected<BuildCacheStats, Error>
+HGraph::GetBuildCacheStats() const {
+    return build_cache_stats_;
+}
+
+JsonType
+HGraph::SerializeBuildCacheHeader() const {
+    JsonType header;
+    header["magic"].SetInt(static_cast<int64_t>(BUILD_CACHE_MAGIC));
+    header["version"].SetInt(BUILD_CACHE_VERSION);
+    header["node_count"].SetInt(static_cast<int64_t>(this->GetNumElements()));
+    header["max_degree"].SetInt(static_cast<int64_t>(this->bottom_graph_->MaximumDegree()));
+    header["build_param_hash"].SetInt(static_cast<int64_t>(ComputeBuildParamHash()));
+    return header;
+}
+
+tl::expected<void, Error>
+HGraph::ValidateBuildCacheHeader(const JsonType& header) const {
+    // Validate magic
+    if (!header.Contains("magic") ||
+        static_cast<uint64_t>(header["magic"].GetInt()) != BUILD_CACHE_MAGIC) {
+        return tl::unexpected(
+            Error(ErrorType::INVALID_BINARY,
+                  fmt::format("Invalid cache file: magic mismatch, expected 0x{:016X}",
+                              BUILD_CACHE_MAGIC)));
+    }
+
+    // Validate version
+    if (!header.Contains("version") ||
+        static_cast<uint32_t>(header["version"].GetInt()) != BUILD_CACHE_VERSION) {
+        return tl::unexpected(
+            Error(ErrorType::INVALID_BINARY,
+                  fmt::format("Cache version incompatible: expected v{}, got v{}",
+                              BUILD_CACHE_VERSION,
+                              header.Contains("version") ? header["version"].GetInt() : -1)));
+    }
+
+    // Validate build_param_hash
+    if (header.Contains("build_param_hash")) {
+        uint64_t cached_hash = static_cast<uint64_t>(header["build_param_hash"].GetInt());
+        uint64_t current_hash = ComputeBuildParamHash();
+        if (cached_hash != current_hash) {
+            return tl::unexpected(
+                Error(ErrorType::INVALID_BINARY,
+                      fmt::format("Build params changed: old_hash=0x{:016X}, new_hash=0x{:016X}",
+                                  cached_hash, current_hash)));
+        }
+    }
+
+    return {};
+}
+
+void
+HGraph::ExportOldFeatureIds(StreamWriter& writer) const {
+    // Export labels as the FeatureID representation
+    // In the standard path, each label is an int64_t
+    const auto& labels = this->label_table_->label_table_;
+    uint64_t node_count = static_cast<uint64_t>(this->GetNumElements());
+    for (uint64_t id = 0; id < node_count; ++id) {
+        LabelType label = (id < labels.size()) ? labels[id] : LabelType(-1);
+        StreamWriter::WriteObj(writer, label);
+    }
+}
+
+void
+HGraph::ExportOldNeighbors(StreamWriter& writer) const {
+    uint64_t node_count = static_cast<uint64_t>(this->GetNumElements());
+    uint32_t max_degree = this->bottom_graph_->MaximumDegree();
+
+    for (uint64_t id = 0; id < node_count; ++id) {
+        Vector<InnerIdType> neighbors(this->allocator_);
+        this->bottom_graph_->GetNeighbors(static_cast<InnerIdType>(id), neighbors);
+
+        uint16_t degree = static_cast<uint16_t>(neighbors.size());
+        StreamWriter::WriteObj(writer, degree);
+
+        for (uint32_t j = 0; j < max_degree; ++j) {
+            uint32_t neighbor_id = (j < degree) ? static_cast<uint32_t>(neighbors[j]) : 0U;
+            StreamWriter::WriteObj(writer, neighbor_id);
+        }
+    }
+}
+
+void
+HGraph::LoadOldFeatureIds(StreamReader& reader,
+                          std::vector<std::string>& feature_ids,
+                          uint64_t node_count,
+                          uint32_t feature_id_len) {
+    feature_ids.resize(node_count);
+    std::vector<char> buffer(feature_id_len);
+    for (uint64_t i = 0; i < node_count; ++i) {
+        reader.Read(buffer.data(), feature_id_len);
+        feature_ids[i] = std::string(buffer.data(), feature_id_len);
+    }
+}
+
+void
+HGraph::LoadOldNeighbors(StreamReader& reader,
+                         std::vector<std::vector<uint32_t>>& neighbors,
+                         uint64_t node_count,
+                         uint32_t max_degree) {
+    neighbors.resize(node_count);
+    for (uint64_t id = 0; id < node_count; ++id) {
+        uint16_t degree = 0;
+        StreamReader::ReadObj(reader, degree);
+        neighbors[id].resize(max_degree);
+        for (uint32_t j = 0; j < max_degree; ++j) {
+            uint32_t neighbor_id = 0;
+            StreamReader::ReadObj(reader, neighbor_id);
+            neighbors[id][j] = neighbor_id;
+        }
+        // Trim to actual degree
+        if (degree < max_degree) {
+            neighbors[id].resize(degree);
+        }
+    }
+}
+
+void
+HGraph::BuildFeatureIdToNewIdMap(const DatasetPtr& base,
+                                 OpenAddressingHashMap<uint32_t>& fid_to_new_id) {
+    const std::string* feature_ids = base->GetFeatureIds();
+    if (feature_ids == nullptr) {
+        throw VsagException(ErrorType::INVALID_ARGUMENT,
+                            "BuildWithCache requires FeatureIds in the dataset");
+    }
+    int64_t num_elements = base->GetNumElements();
+    const auto* labels = base->GetIds();
+
+    for (int64_t j = 0; j < num_elements; ++j) {
+        auto [success, id] = this->label_table_->TryGetIdByLabel(labels[j]);
+        if (success) {
+            fid_to_new_id.Insert(std::string(feature_ids[j]), id);
+        }
+    }
+}
+
+void
+HGraph::BuildOldToNewMapping(const std::vector<std::string>& old_feature_ids,
+                             const OpenAddressingHashMap<uint32_t>& fid_to_new_id,
+                             std::vector<uint32_t>& old_to_new) {
+    uint64_t node_count = old_feature_ids.size();
+    old_to_new.resize(node_count, std::numeric_limits<uint32_t>::max());
+
+    for (uint64_t old_id = 0; old_id < node_count; ++old_id) {
+        uint32_t new_id = 0;
+        if (fid_to_new_id.Lookup(old_feature_ids[old_id], new_id)) {
+            old_to_new[old_id] = new_id;
+        }
+        // else: remains UINT32_MAX (not found in new dataset)
+    }
+}
+
+void
+HGraph::NormalizeMappedNeighbors(std::vector<std::vector<uint32_t>>& neighbors,
+                                 const BuildCacheOptions& options) {
+    uint64_t node_count = neighbors.size();
+    uint32_t max_degree = this->bottom_graph_->MaximumDegree();
+    const uint32_t DELETED_MARKER = std::numeric_limits<uint32_t>::max();
+
+    for (uint64_t id = 0; id < node_count; ++id) {
+        auto& nbrs = neighbors[id];
+        uint32_t invalid_count = 0;
+        uint32_t write_pos = 0;
+
+        for (uint32_t read_pos = 0; read_pos < nbrs.size(); ++read_pos) {
+            uint32_t nbr = nbrs[read_pos];
+
+            // Skip deleted markers
+            if (nbr == DELETED_MARKER) {
+                invalid_count++;
+                continue;
+            }
+
+            // Skip self-loops
+            if (nbr == static_cast<uint32_t>(id)) {
+                continue;
+            }
+
+            // Skip duplicates (simple check within remaining elements)
+            bool is_dup = false;
+            for (uint32_t k = 0; k < write_pos; ++k) {
+                if (nbrs[k] == nbr) {
+                    is_dup = true;
+                    break;
+                }
+            }
+            if (is_dup) {
+                continue;
+            }
+
+            nbrs[write_pos++] = nbr;
+        }
+
+        // Trim to actual count
+        nbrs.resize(write_pos);
+
+        // Trim to max_degree
+        if (nbrs.size() > max_degree) {
+            nbrs.resize(max_degree);
+        }
+
+        build_cache_stats_.invalid_neighbors += invalid_count;
+        if (options.drop_invalid_neighbors) {
+            build_cache_stats_.dropped_neighbors += invalid_count;
+        }
+    }
+}
+
+void
+HGraph::ApplyWarmStartNeighbors(const std::vector<uint32_t>& old_to_new,
+                                const std::vector<std::vector<uint32_t>>& old_neighbors,
+                                const BuildCacheOptions& options) {
+    const uint32_t DELETED_MARKER = std::numeric_limits<uint32_t>::max();
+    uint64_t new_node_count = static_cast<uint64_t>(this->total_count_.load());
+    uint32_t max_degree = this->bottom_graph_->MaximumDegree();
+
+    auto warm_start_start = std::chrono::steady_clock::now();
+
+    // Phase 1: Warm start — inject cached neighbors or empty initialization
+    // First, insert all vectors into the flatten codes
+    // (This is already handled by the caller via Train + label setup)
+
+    // Create a mapping from new inner_id to whether it's a cache hit
+    std::vector<bool> is_hit(new_node_count, false);
+    std::vector<bool> is_valid_node(new_node_count, false);
+
+    // Mark valid nodes
+    for (uint64_t new_id = 0; new_id < new_node_count; ++new_id) {
+        if (new_id < this->label_table_->label_table_.size() &&
+            this->label_table_->label_table_[new_id] != std::numeric_limits<LabelType>::max()) {
+            is_valid_node[new_id] = true;
+        }
+    }
+
+    // Build reverse mapping: for each new inner_id, find old neighbors
+    // We need to know which new_id corresponds to which old_id
+    std::vector<uint32_t> new_to_old(new_node_count, DELETED_MARKER);
+    for (uint64_t old_id = 0; old_id < old_to_new.size(); ++old_id) {
+        uint32_t new_id = old_to_new[old_id];
+        if (new_id != DELETED_MARKER && new_id < new_node_count) {
+            new_to_old[new_id] = static_cast<uint32_t>(old_id);
+            is_hit[new_id] = true;
+        }
+    }
+
+    // Initialize bottom_graph_ with cached or empty neighbors
+    for (uint64_t new_id = 0; new_id < new_node_count; ++new_id) {
+        if (!is_valid_node[new_id]) {
+            continue;
+        }
+
+        Vector<InnerIdType> cached_nbrs(this->allocator_);
+        uint32_t old_id = new_to_old[new_id];
+
+        if (old_id != DELETED_MARKER && old_id < old_neighbors.size()) {
+            // Cache hit: use mapped neighbors (convert old inner_id -> new inner_id)
+            const auto& old_nbrs = old_neighbors[old_id];
+            for (uint32_t old_nbr : old_nbrs) {
+                if (old_nbr == DELETED_MARKER) {
+                    continue;
+                }
+                // Map old neighbor inner_id to new inner_id via old_to_new
+                if (old_nbr < old_to_new.size()) {
+                    uint32_t new_nbr = old_to_new[old_nbr];
+                    if (new_nbr != DELETED_MARKER) {
+                        cached_nbrs.push_back(static_cast<InnerIdType>(new_nbr));
+                    }
+                }
+            }
+        }
+        // else: cache miss, empty neighbors
+
+        this->bottom_graph_->InsertNeighborsById(static_cast<InnerIdType>(new_id), cached_nbrs);
+    }
+
+    // Set entry point
+    if (new_node_count > 0) {
+        this->entry_point_id_ = 0;
+    }
+
+    auto warm_start_end = std::chrono::steady_clock::now();
+
+    // Phase 2: Differentiated Refine
+    // Collect hit and missed node IDs
+    std::vector<InnerIdType> missed_nodes;
+    std::vector<InnerIdType> hit_nodes;
+    for (uint64_t new_id = 0; new_id < new_node_count; ++new_id) {
+        if (!is_valid_node[new_id]) {
+            continue;
+        }
+        if (is_hit[new_id]) {
+            hit_nodes.push_back(static_cast<InnerIdType>(new_id));
+        } else {
+            missed_nodes.push_back(static_cast<InnerIdType>(new_id));
+        }
+    }
+
+    auto flatten_codes = basic_flatten_codes_;
+    if (use_reorder_ && !build_by_base_) {
+        flatten_codes = high_precise_codes_;
+    }
+
+    // Refine missed nodes first (more iterations needed)
+    if (options.missed_refine_rounds > 0 && !missed_nodes.empty()) {
+        auto missed_start = std::chrono::steady_clock::now();
+        for (uint32_t round = 0; round < options.missed_refine_rounds; ++round) {
+            for (InnerIdType id : missed_nodes) {
+                // Get actual vector data for this node
+                Vector<float> vec_data(this->allocator_);
+                vec_data.resize(this->dim_);
+                this->GetVectorByInnerId(id, vec_data.data());
+                graph_add_one(vec_data.data(), 0, id);
+            }
+        }
+        auto missed_end = std::chrono::steady_clock::now();
+        build_cache_stats_.missed_refine_rounds = options.missed_refine_rounds;
+        build_cache_stats_.missed_refine_us = static_cast<uint64_t>(
+            std::chrono::duration_cast<std::chrono::microseconds>(missed_end - missed_start)
+                .count());
+    }
+
+    // Refine hit nodes (fewer iterations needed)
+    if (options.hit_refine_rounds > 0 && !hit_nodes.empty()) {
+        auto hit_start = std::chrono::steady_clock::now();
+        for (uint32_t round = 0; round < options.hit_refine_rounds; ++round) {
+            for (InnerIdType id : hit_nodes) {
+                Vector<float> vec_data(this->allocator_);
+                vec_data.resize(this->dim_);
+                this->GetVectorByInnerId(id, vec_data.data());
+                graph_add_one(vec_data.data(), 0, id);
+            }
+        }
+        auto hit_end = std::chrono::steady_clock::now();
+        build_cache_stats_.hit_refine_rounds = options.hit_refine_rounds;
+        build_cache_stats_.hit_refine_us = static_cast<uint64_t>(
+            std::chrono::duration_cast<std::chrono::microseconds>(hit_end - hit_start).count());
+    }
+
+    build_cache_stats_.warm_start_apply_us = static_cast<uint64_t>(
+        std::chrono::duration_cast<std::chrono::microseconds>(warm_start_end - warm_start_start)
+            .count());
+}
+
+uint64_t
+HGraph::ComputeBuildParamHash() const {
+    // Hash key build parameters that affect cache validity
+    uint64_t hash = 0;
+    hash ^= static_cast<uint64_t>(this->dim_) + 0x9e3779b97f4a7c15ULL + (hash << 6) + (hash >> 2);
+    hash ^= static_cast<uint64_t>(this->bottom_graph_->MaximumDegree()) + 0x9e3779b97f4a7c15ULL +
+            (hash << 6) + (hash >> 2);
+    hash ^= static_cast<uint64_t>(this->metric_) + 0x9e3779b97f4a7c15ULL + (hash << 6) + (hash >> 2);
+    hash ^= static_cast<uint64_t>(this->ef_construct_) + 0x9e3779b97f4a7c15ULL + (hash << 6) + (hash >> 2);
+    hash ^= static_cast<uint64_t>(this->data_type_) + 0x9e3779b97f4a7c15ULL + (hash << 6) + (hash >> 2);
+    return hash;
 }
 
 }  // namespace vsag

--- a/src/algorithm/hgraph.h
+++ b/src/algorithm/hgraph.h
@@ -37,8 +37,10 @@
 #include "inner_index_interface.h"
 #include "typing.h"
 #include "utils/lock_strategy.h"
+#include "utils/open_addressing_hashmap.h"
 #include "utils/util_functions.h"
 #include "utils/visited_list.h"
+#include "vsag/build_cache.h"
 #include "vsag/index.h"
 #include "vsag/index_features.h"
 
@@ -206,6 +208,24 @@ public:
                     const AttributeSet& new_attrs,
                     const AttributeSet& origin_attrs) override;
 
+    // --- Build Cache public interface ---
+
+    [[nodiscard]] bool
+    SupportsBuildCache() const override;
+
+    tl::expected<void, Error>
+    ExportBuildCache(std::ostream& out_stream) const override;
+
+    tl::expected<std::vector<int64_t>, Error>
+    BuildWithCache(const DatasetPtr& base,
+                   std::istream& in_stream,
+                   const BuildCacheOptions& options = BuildCacheOptions{}) override;
+
+    [[nodiscard]] tl::expected<BuildCacheStats, Error>
+    GetBuildCacheStats() const override;
+
+    // --- End Build Cache public interface ---
+
     static JsonType
     map_hgraph_param(const JsonType& hgraph_json);
 
@@ -354,6 +374,56 @@ private:
     void
     cal_memory_usage();
 
+    // --- Build Cache private helper methods ---
+
+    JsonType
+    SerializeBuildCacheHeader() const;
+
+    tl::expected<void, Error>
+    ValidateBuildCacheHeader(const JsonType& header) const;
+
+    void
+    ExportOldFeatureIds(StreamWriter& writer) const;
+
+    void
+    ExportOldNeighbors(StreamWriter& writer) const;
+
+    void
+    LoadOldFeatureIds(StreamReader& reader,
+                      std::vector<std::string>& feature_ids,
+                      uint64_t node_count,
+                      uint32_t feature_id_len);
+
+    void
+    LoadOldNeighbors(StreamReader& reader,
+                     std::vector<std::vector<uint32_t>>& neighbors,
+                     uint64_t node_count,
+                     uint32_t max_degree);
+
+    void
+    BuildFeatureIdToNewIdMap(
+        const DatasetPtr& base,
+        OpenAddressingHashMap<uint32_t>& fid_to_new_id);
+
+    void
+    BuildOldToNewMapping(const std::vector<std::string>& old_feature_ids,
+                         const OpenAddressingHashMap<uint32_t>& fid_to_new_id,
+                         std::vector<uint32_t>& old_to_new);
+
+    void
+    NormalizeMappedNeighbors(std::vector<std::vector<uint32_t>>& neighbors,
+                             const BuildCacheOptions& options);
+
+    void
+    ApplyWarmStartNeighbors(const std::vector<uint32_t>& old_to_new,
+                            const std::vector<std::vector<uint32_t>>& old_neighbors,
+                            const BuildCacheOptions& options);
+
+    uint64_t
+    ComputeBuildParamHash() const;
+
+    // --- End Build Cache private helper methods ---
+
 private:
     FlattenInterfacePtr basic_flatten_codes_{nullptr};
     FlattenInterfacePtr high_precise_codes_{nullptr};
@@ -408,5 +478,8 @@ private:
     bool use_old_serial_format_{false};
 
     bool support_duplicate_{false};
+
+    // Build Cache statistics, populated by BuildWithCache, returned by GetBuildCacheStats
+    BuildCacheStats build_cache_stats_{};
 };
 }  // namespace vsag

--- a/src/algorithm/inner_index_interface.h
+++ b/src/algorithm/inner_index_interface.h
@@ -57,6 +57,35 @@ public:
     static InnerIndexPtr
     FastCreateIndex(const std::string& index_fast_str, const IndexCommonParam& common_param);
 
+    // --- Build Cache virtual methods ---
+
+    [[nodiscard]] virtual bool
+    SupportsBuildCache() const {
+        return false;
+    }
+
+    virtual tl::expected<void, Error>
+    ExportBuildCache(std::ostream& out_stream) const {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "Index doesn't support ExportBuildCache");
+    }
+
+    virtual tl::expected<std::vector<int64_t>, Error>
+    BuildWithCache(const DatasetPtr& base,
+                   std::istream& in_stream,
+                   const BuildCacheOptions& options = BuildCacheOptions{}) {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "Index doesn't support BuildWithCache");
+    }
+
+    [[nodiscard]] virtual tl::expected<BuildCacheStats, Error>
+    GetBuildCacheStats() const {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "Index doesn't support GetBuildCacheStats");
+    }
+
+    // --- End Build Cache virtual methods ---
+
     virtual std::vector<int64_t>
     Add(const DatasetPtr& base, AddMode mode = AddMode::DEFAULT) = 0;
 

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -43,6 +43,7 @@ const char* const DATASET_PATHS = "paths";
 const char* const EXTRA_INFOS = "extra_infos";
 const char* const EXTRA_INFO_SIZE = "extra_info_size";
 const char* const VECTOR_COUNTS = "vector_counts";
+const char* const FEATURE_IDS = "feature_ids";
 
 const char* const HNSW_DATA = "hnsw_data";
 const char* const CONJUGATE_GRAPH_DATA = "conjugate_graph_data";

--- a/src/dataset_impl.h
+++ b/src/dataset_impl.h
@@ -284,6 +284,20 @@ public:
         return nullptr;
     }
 
+    DatasetPtr
+    FeatureIds(const std::string* feature_ids) override {
+        this->data_[FEATURE_IDS] = feature_ids;
+        return shared_from_this();
+    }
+
+    const std::string*
+    GetFeatureIds() const override {
+        if (auto iter = this->data_.find(FEATURE_IDS); iter != this->data_.end()) {
+            return std::get<const std::string*>(iter->second);
+        }
+        return nullptr;
+    }
+
     static DatasetPtr
     MakeEmptyDataset();
 

--- a/src/index/index_impl.h
+++ b/src/index/index_impl.h
@@ -481,6 +481,34 @@ public:
         SAFE_CALL(return this->inner_index_->UpdateVector(id, new_base, force_update));
     }
 
+    // --- Build Cache forwarding ---
+
+    [[nodiscard]] bool
+    SupportsBuildCache() const override {
+        return this->inner_index_->SupportsBuildCache();
+    }
+
+    tl::expected<void, Error>
+    ExportBuildCache(std::ostream& out_stream) const override {
+        SAFE_CALL(this->inner_index_->ExportBuildCache(out_stream));
+    }
+
+    tl::expected<std::vector<int64_t>, Error>
+    BuildWithCache(const DatasetPtr& base,
+                   std::istream& in_stream,
+                   const BuildCacheOptions& options = BuildCacheOptions{}) override {
+        CHECK_IMMUTABLE_INDEX("build with cache");
+        CHECK_NONEMPTY_DATASET(base);
+        SAFE_CALL(return this->inner_index_->BuildWithCache(base, in_stream, options));
+    }
+
+    [[nodiscard]] tl::expected<BuildCacheStats, Error>
+    GetBuildCacheStats() const override {
+        SAFE_CALL(return this->inner_index_->GetBuildCacheStats());
+    }
+
+    // --- End Build Cache forwarding ---
+
 public:
     [[nodiscard]] inline InnerIndexPtr
     GetInnerIndex() const {

--- a/src/utils/open_addressing_hashmap.h
+++ b/src/utils/open_addressing_hashmap.h
@@ -1,0 +1,181 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <string>
+#include <vector>
+
+namespace vsag {
+
+/**
+ * @brief Open-addressing HashMap optimized for Build Cache's FeatureID → inner_id mapping.
+ *
+ * Design choices:
+ * - Uses FNV-1a hash of std::string keys for fast lookup.
+ * - Supports variable-length FeatureID strings.
+ * - Slot layout: stores std::string key + ValueType value per slot.
+ * - Supports "write-once, read-many" access pattern typical of Build Cache.
+ * - Load factor of 0.5 by default to keep probe chains short.
+ */
+template <typename ValueType = uint32_t>
+class OpenAddressingHashMap {
+public:
+    /**
+     * @brief Construct a new Open Addressing HashMap.
+     *
+     * @param expected_count Expected number of entries (capacity will be ~2x this).
+     * @param feature_id_len Hint for average key length (unused in variable-length mode).
+     */
+    explicit OpenAddressingHashMap(uint64_t expected_count, uint32_t feature_id_len = 32) {
+        (void)feature_id_len;  // unused, kept for API compatibility
+        // Use load factor 0.5: capacity is 2x expected_count
+        uint64_t min_slots = expected_count * 2;
+        // Round up to next power of 2 for efficient modular arithmetic
+        slot_count_ = 1;
+        while (slot_count_ < min_slots) {
+            slot_count_ <<= 1;
+        }
+        slot_mask_ = slot_count_ - 1;
+        keys_.resize(slot_count_);
+        values_.resize(slot_count_);
+        occupied_.assign(slot_count_, false);
+        size_ = 0;
+    }
+
+    /**
+     * @brief Insert a key-value pair. Key must not already exist.
+     *
+     * @param feature_id Pointer to the FeatureID string data (must be null-terminated or
+     *                   have at least feature_id_len bytes).
+     * @param feature_id_len Length of the FeatureID string in bytes.
+     * @param value The value to associate with the key.
+     * @return true if inserted, false if the key already exists or table is full.
+     */
+    bool
+    Insert(const char* feature_id, uint32_t feature_id_len, ValueType value) {
+        std::string key(feature_id, feature_id_len);
+        return Insert(std::move(key), value);
+    }
+
+    /**
+     * @brief Insert a key-value pair using a std::string key.
+     */
+    bool
+    Insert(std::string key, ValueType value) {
+        uint64_t hash_val = HashString(key);
+        uint64_t slot_idx = hash_val & slot_mask_;
+
+        for (uint64_t probe = 0; probe < slot_count_; ++probe) {
+            uint64_t idx = (slot_idx + probe) & slot_mask_;
+            if (!occupied_[idx]) {
+                keys_[idx] = std::move(key);
+                values_[idx] = value;
+                occupied_[idx] = true;
+                ++size_;
+                return true;
+            }
+            if (keys_[idx] == key) {
+                // Key already exists
+                return false;
+            }
+        }
+        // Table is full
+        return false;
+    }
+
+    /**
+     * @brief Look up a key and return its associated value.
+     *
+     * @param feature_id Pointer to the FeatureID string data.
+     * @param feature_id_len Length of the FeatureID string in bytes.
+     * @param[out] value The found value is written here on success.
+     * @return true if key was found, false otherwise.
+     */
+    bool
+    Lookup(const char* feature_id, uint32_t feature_id_len, ValueType& value) const {
+        std::string key(feature_id, feature_id_len);
+        return Lookup(key, value);
+    }
+
+    /**
+     * @brief Look up a key using a std::string.
+     */
+    bool
+    Lookup(const std::string& key, ValueType& value) const {
+        uint64_t hash_val = HashString(key);
+        uint64_t slot_idx = hash_val & slot_mask_;
+
+        for (uint64_t probe = 0; probe < slot_count_; ++probe) {
+            uint64_t idx = (slot_idx + probe) & slot_mask_;
+            if (!occupied_[idx]) {
+                return false;
+            }
+            if (keys_[idx] == key) {
+                value = values_[idx];
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** @brief Current number of entries in the map. */
+    uint64_t
+    Size() const {
+        return size_;
+    }
+
+    /** @brief Total number of slots. */
+    uint64_t
+    Capacity() const {
+        return slot_count_;
+    }
+
+    /** @brief Memory usage in bytes. */
+    uint64_t
+    MemoryUsage() const {
+        uint64_t base = slot_count_ * (sizeof(ValueType) + sizeof(bool) + 32 /* avg string */);
+        uint64_t key_mem = 0;
+        for (uint64_t i = 0; i < slot_count_; ++i) {
+            if (occupied_[i]) {
+                key_mem += keys_[i].capacity();
+            }
+        }
+        return base + key_mem;
+    }
+
+private:
+    static uint64_t
+    HashString(const std::string& key) {
+        // FNV-1a hash for fast, good distribution
+        uint64_t hash = 14695981039346656037ULL;
+        for (char c : key) {
+            hash ^= static_cast<uint64_t>(static_cast<uint8_t>(c));
+            hash *= 1099511628211ULL;
+        }
+        return hash;
+    }
+
+    uint64_t slot_count_{0};
+    uint64_t slot_mask_{0};
+    uint64_t size_{0};
+    std::vector<std::string> keys_;
+    std::vector<ValueType> values_;
+    std::vector<bool> occupied_;
+};
+
+}  // namespace vsag


### PR DESCRIPTION
# Build Cache Feature for vsag HGraph Index

## Overview

This pull request introduces a new **Build Cache** feature to the vsag project, enabling accelerated HGraph index rebuilding by reusing neighbor relationships from previous builds.

The changes include:
- New APIs for exporting and importing build caches
- Support for stable FeatureIDs across build cycles
- An example demonstrating the full workflow

---

## Key Changes

### 🗄️ Build Cache Core Functionality

- **Added `BuildCacheOptions` and `BuildCacheStats` structs** in `include/vsag/build_cache.h`
  - Controls and observes Build Cache behavior
  - Includes warm start, refine rounds, and cache statistics

- **Extended the `Index` base class** in `include/vsag/index.h` with virtual methods for Build Cache support:
  - `SupportsBuildCache`
  - `ExportBuildCache`
  - `BuildWithCache`
  - `GetBuildCacheStats`
  - Allows index implementations to expose cache capabilities and statistics

- **Implemented the Build Cache interface in the HGraph index** (`src/algorithm/hgraph.h`)
  - Provides concrete support for exporting, importing, and using build caches during index construction

### 🔖 FeatureID Support for Dataset Stability

- **Extended the `Dataset` interface** in `include/vsag/dataset.h`
  - Supports setting and retrieving an array of FeatureIDs (fixed-length strings)
  - Acts as stable identifiers for vectors across build cycles
  - Enables correct neighbor mapping in the Build Cache

- **Added `FEATURE_IDS` constant** to `include/vsag/constants.h`
  - Provides consistent reference to FeatureID fields

### 🛠️ Demonstration and Build Integration

- **Added a comprehensive example** `examples/cpp/322_feature_build_cache.cpp`
  - Demonstrates the end-to-end Build Cache workflow:
    1. Loading data
    2. Building and exporting a cache
    3. Warm-starting a new build
    4. Printing cache statistics
    5. Verifying search correctness
    6. Exporting the next cache

- **Updated `examples/cpp/CMakeLists.txt`** to build and link the new example

---

## Change Type

- [x] New feature
- [ ] Improvement/Refactor
- [ ] Documentation
- [ ] CI/Build/Infra

---

## Linked Issue

- Issue: <!-- e.g. #1234 -->

---

## What Changed

<!-- Briefly describe the key changes -->

---

## Test Evidence

- [ ] `make fmt`
- [ ] `make lint`
- [ ] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [ ] Other (describe below)

**Test details:**

```text
<!-- Paste commands and key output here -->
```

---

## Compatibility Impact

| Dimension | Impact |
|-----------|--------|
| API/ABI compatibility | <!-- none / describe --> |
| Behavior changes | <!-- none / describe --> |

---

## Performance and Concurrency Impact

| Dimension | Impact |
|-----------|--------|
| Performance impact | <!-- none / improved / regressed / unknown --> |
| Concurrency/thread-safety impact | <!-- none / describe --> |

---

## Documentation Impact

- [ ] No docs update needed
- [ ] Updated docs:
  - [ ] `README.md`
  - [ ] `DEVELOPMENT.md`
  - [ ] `CONTRIBUTING.md`
  - [ ] Other: <!-- path -->

---

## Risk and Rollback

| Dimension | Details |
|-----------|---------|
| Risk level | <!-- low / medium / high --> |
| Rollback plan | <!-- how to revert safely --> |

---

## Checklist

- [ ] I have linked the relevant issue (or explained why not applicable)
- [ ] I have added/updated tests for new behavior or bug fixes
- [ ] I have considered API compatibility impact
- [ ] I have updated docs if behavior/workflow changed
- [ ] My commit messages follow project conventions (Conventional Commits, optional `[skip ci]` prefix)