### PR TITLE
feat: allow selecting inner index label remap map

### DIFF
--- a/include/vsag/constants.h
+++ b/include/vsag/constants.h
@@ -193,6 +193,7 @@ extern const char* const HGRAPH_PARAMETER_HOPS_LIMIT;
 extern const char* const HGRAPH_EXTRA_INFO_SIZE;
 extern const char* const HGRAPH_SUPPORT_DUPLICATE;
 extern const char* const HGRAPH_SUPPORT_TOMBSTONE;
+extern const char* const HGRAPH_LABEL_REMAP_TYPE;
 extern const char* const HGRAPH_USE_EXTRA_INFO_FILTER;
 extern const char* const STORE_RAW_VECTOR;
 extern const char* const RAW_VECTOR_IO_TYPE;

--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -440,6 +440,12 @@ HGraph::map_hgraph_param(const JsonType& hgraph_json) {
             {
                 SUPPORT_TOMBSTONE,
             },
+        },
+        {
+            HGRAPH_LABEL_REMAP_TYPE,
+            {
+                LABEL_REMAP_TYPE_KEY,
+            },
         }};
     const std::string hgraph_params_template =
         R"(
@@ -501,6 +507,7 @@ HGraph::map_hgraph_param(const JsonType& hgraph_json) {
             }
         },
         "{STORE_RAW_VECTOR_KEY}": false,
+        "{LABEL_REMAP_TYPE_KEY}": "{LABEL_REMAP_TYPE_VALUE_PG}",
         "{RAW_VECTOR_KEY}": {
             "{IO_PARAMS_KEY}": {
                 "{TYPE_KEY}": "{IO_TYPE_VALUE_BLOCK_MEMORY_IO}",
@@ -1215,13 +1222,12 @@ HGraph::serialize_basic_info_v0_14(StreamWriter& writer) const {
     StreamWriter::WriteObj(writer, capacity);
     StreamWriter::WriteVector(writer, this->label_table_->label_table_);
 
-    uint64_t size = this->label_table_->label_remap_.size();
+    uint64_t size = this->label_table_->GetRemapSize();
     StreamWriter::WriteObj(writer, size);
-    for (const auto& pair : this->label_table_->label_remap_) {
-        auto key = pair.first;
+    this->label_table_->ForEachRemap([&writer](LabelType key, InnerIdType value) {
         StreamWriter::WriteObj(writer, key);
-        StreamWriter::WriteObj(writer, pair.second);
-    }
+        StreamWriter::WriteObj(writer, value);
+    });
 }
 
 void
@@ -1244,14 +1250,13 @@ HGraph::deserialize_basic_info_v0_14(StreamReader& reader) {
 
     uint64_t size;
     StreamReader::ReadObj(reader, size);
-    this->label_table_->label_remap_.clear();
-    this->label_table_->label_remap_.reserve(size);
+    this->label_table_->ResetRemap(size);
     for (uint64_t i = 0; i < size; ++i) {
         LabelType key;
         StreamReader::ReadObj(reader, key);
         InnerIdType value;
         StreamReader::ReadObj(reader, value);
-        this->label_table_->label_remap_.emplace(key, value);
+        this->label_table_->InsertRemap(key, value);
     }
     // Restore total_count from label_remap size
     this->label_table_->total_count_.store(static_cast<int64_t>(size));
@@ -1333,13 +1338,12 @@ HGraph::serialize_label_info(StreamWriter& writer) const {
     }
 
     StreamWriter::WriteVector(writer, this->label_table_->label_table_);
-    uint64_t size = this->label_table_->label_remap_.size();
+    uint64_t size = this->label_table_->GetRemapSize();
     StreamWriter::WriteObj(writer, size);
-    for (const auto& pair : this->label_table_->label_remap_) {
-        auto key = pair.first;
+    this->label_table_->ForEachRemap([&writer](LabelType key, InnerIdType value) {
         StreamWriter::WriteObj(writer, key);
-        StreamWriter::WriteObj(writer, pair.second);
-    }
+        StreamWriter::WriteObj(writer, value);
+    });
 }
 
 void
@@ -1352,14 +1356,13 @@ HGraph::deserialize_label_info(StreamReader& reader) const {
     StreamReader::ReadVector(reader, this->label_table_->label_table_);
     uint64_t size;
     StreamReader::ReadObj(reader, size);
-    this->label_table_->label_remap_.clear();
-    this->label_table_->label_remap_.reserve(size);
+    this->label_table_->ResetRemap(size);
     for (uint64_t i = 0; i < size; ++i) {
         LabelType key;
         StreamReader::ReadObj(reader, key);
         InnerIdType value;
         StreamReader::ReadObj(reader, value);
-        this->label_table_->label_remap_.emplace(key, value);
+        this->label_table_->InsertRemap(key, value);
     }
     this->label_table_->total_count_.store(static_cast<int64_t>(size));
 }

--- a/src/algorithm/hgraph_parameter_test.cpp
+++ b/src/algorithm/hgraph_parameter_test.cpp
@@ -190,3 +190,29 @@ TEST_CASE("HGraph maps support_duplicate to graph parameter", "[ut][HGraphParame
     REQUIRE(typed_param->support_duplicate);
     REQUIRE(typed_param->bottom_graph_param->support_duplicate_);
 }
+
+TEST_CASE("HGraph maps label_remap_type to inner index parameter", "[ut][HGraphParameter]") {
+    auto param = vsag::JsonType::Parse(R"({
+        "base_quantization_type": "fp32",
+        "base_io_type": "block_memory_io",
+        "precise_quantization_type": "fp32",
+        "precise_io_type": "block_memory_io",
+        "graph_io_type": "block_memory_io",
+        "graph_storage_type": "flat",
+        "graph_type": "nsw",
+        "max_degree": 32,
+        "ef_construction": 100,
+        "label_remap_type": "robin",
+        "use_reorder": true
+    })");
+
+    vsag::IndexCommonParam common_param;
+    common_param.dim_ = 128;
+    common_param.data_type_ = vsag::DataTypes::DATA_TYPE_FLOAT;
+    auto hgraph_param = vsag::HGraph::CheckAndMappingExternalParam(param, common_param);
+    auto typed_param = std::dynamic_pointer_cast<vsag::HGraphParameter>(hgraph_param);
+
+    REQUIRE(typed_param != nullptr);
+    REQUIRE(typed_param->bottom_graph_param != nullptr);
+    REQUIRE(typed_param->label_remap_type == vsag::LabelRemapType::ROBIN);
+}

--- a/src/algorithm/hnswlib/algorithm_interface.h
+++ b/src/algorithm/hnswlib/algorithm_interface.h
@@ -121,7 +121,7 @@ public:
     virtual uint64_t
     getDeletedCount() = 0;
 
-    virtual const vsag::PGUnorderedMap<LabelType, InnerIdType>&
+    virtual const vsag::UnorderedMap<LabelType, InnerIdType>&
     getDeletedElements() const = 0;
 
     virtual bool

--- a/src/algorithm/hnswlib/hnswalg.h
+++ b/src/algorithm/hnswlib/hnswalg.h
@@ -113,7 +113,7 @@ private:
     DISTFUNC fstdistfunc_{nullptr};
     void* dist_func_param_{nullptr};
 
-    vsag::PGUnorderedMap<LabelType, InnerIdType> label_lookup_;
+    vsag::UnorderedMap<LabelType, InnerIdType> label_lookup_;
 
     std::default_random_engine level_generator_{2021};
     mutable std::mutex level_generator_mutex_;
@@ -130,7 +130,7 @@ private:
     bool allow_replace_deleted_{false};
 
     std::mutex deleted_elements_lock_{};  // lock for deleted_elements_
-    vsag::PGUnorderedMap<LabelType, InnerIdType>
+    vsag::UnorderedMap<LabelType, InnerIdType>
         deleted_elements_;  // contains labels and internal ids of deleted elements
 
     bool immutable_{false};
@@ -270,7 +270,7 @@ public:
         return num_deleted_;
     }
 
-    const vsag::PGUnorderedMap<LabelType, InnerIdType>&
+    const vsag::UnorderedMap<LabelType, InnerIdType>&
     getDeletedElements() const override {
         return deleted_elements_;
     }

--- a/src/algorithm/inner_index_interface.cpp
+++ b/src/algorithm/inner_index_interface.cpp
@@ -43,7 +43,8 @@ InnerIndexInterface::InnerIndexInterface(const InnerIndexParameterPtr& index_par
       use_attribute_filter_(index_param->use_attribute_filter),
       train_sample_count_(index_param->train_sample_count),
       use_reorder_(index_param->use_reorder) {
-    this->label_table_ = std::make_shared<LabelTable>(allocator_);
+    this->label_table_ =
+        std::make_shared<LabelTable>(allocator_, true, false, index_param->label_remap_type);
     this->index_feature_list_ = std::make_unique<IndexFeatureList>();
     this->index_feature_list_->SetFeature(SUPPORT_EXPORT_IDS);
     this->extra_info_size_ = common_param.extra_info_size_;
@@ -694,9 +695,9 @@ InnerIndexInterface::get_detail_data_by_info(const IndexDetailInfo& info) const 
         data->SetDataScalarInt64(this->GetNumElements());
     } else if (name == INDEX_DETAIL_NAME_LABEL_TABLE) {
         std::vector<std::vector<int64_t>> label_tables;
-        for (const auto& [key, value] : this->label_table_->label_remap_) {
+        this->label_table_->ForEachRemap([&label_tables](LabelType key, InnerIdType value) {
             label_tables.emplace_back(std::vector<int64_t>{key, value});
-        }
+        });
         data->SetData2DArrayInt64(label_tables);
     } else if (name == INDEX_DETAIL_DATA_TYPE) {
         data->SetDataScalarString(ToString(data_type_));

--- a/src/algorithm/inner_index_parameter.cpp
+++ b/src/algorithm/inner_index_parameter.cpp
@@ -25,6 +25,28 @@
 
 namespace vsag {
 
+namespace {
+
+auto
+parse_label_remap_type(const std::string& remap_type) -> LabelRemapType {
+    if (remap_type == LABEL_REMAP_TYPE_VALUE_PG) {
+        return LabelRemapType::PG;
+    }
+    if (remap_type == LABEL_REMAP_TYPE_VALUE_ROBIN) {
+        return LabelRemapType::ROBIN;
+    }
+    throw VsagException(ErrorType::INVALID_ARGUMENT,
+                        fmt::format("invalid label_remap_type: {}", remap_type));
+}
+
+auto
+dump_label_remap_type(LabelRemapType remap_type) -> const char* {
+    return remap_type == LabelRemapType::ROBIN ? LABEL_REMAP_TYPE_VALUE_ROBIN
+                                               : LABEL_REMAP_TYPE_VALUE_PG;
+}
+
+}  // namespace
+
 void
 InnerIndexParameter::FromJson(const JsonType& json) {
     if (json.Contains(USE_REORDER_KEY)) {
@@ -45,6 +67,10 @@ InnerIndexParameter::FromJson(const JsonType& json) {
 
     if (json.Contains(BUILD_THREAD_COUNT_KEY)) {
         this->build_thread_count = json[BUILD_THREAD_COUNT_KEY].GetInt();
+    }
+
+    if (json.Contains(LABEL_REMAP_TYPE_KEY)) {
+        this->label_remap_type = parse_label_remap_type(json[LABEL_REMAP_TYPE_KEY].GetString());
     }
 
     if (this->use_reorder) {
@@ -85,6 +111,7 @@ InnerIndexParameter::ToJson() const {
     JsonType json;
     json[USE_REORDER_KEY].SetBool(this->use_reorder);
     json[BUILD_THREAD_COUNT_KEY].SetInt(this->build_thread_count);
+    json[LABEL_REMAP_TYPE_KEY].SetString(dump_label_remap_type(this->label_remap_type));
     json[USE_ATTRIBUTE_FILTER_KEY].SetBool(this->use_attribute_filter);
     if (use_reorder) {
         json[PRECISE_CODES_KEY].SetJson(this->precise_codes_param->ToJson());
@@ -127,6 +154,11 @@ InnerIndexParameter::CheckCompatibility(const ParamPtr& other) const {
 
     if (this->use_attribute_filter != inner_index_param->use_attribute_filter) {
         logger::error("InnerIndexParameter::CheckCompatibility: use_attribute_filter mismatch");
+        return false;
+    }
+
+    if (this->label_remap_type != inner_index_param->label_remap_type) {
+        logger::error("InnerIndexParameter::CheckCompatibility: label_remap_type mismatch");
         return false;
     }
 

--- a/src/algorithm/inner_index_parameter.h
+++ b/src/algorithm/inner_index_parameter.h
@@ -48,6 +48,8 @@ public:
 
     uint64_t build_thread_count{1};
 
+    LabelRemapType label_remap_type{LabelRemapType::PG};
+
     int64_t train_sample_count{MAX_TRAIN_COUNT};
 
     bool store_raw_vector{false};

--- a/src/algorithm/inner_index_parameter_test.cpp
+++ b/src/algorithm/inner_index_parameter_test.cpp
@@ -88,3 +88,26 @@ TEST_CASE("Sampling Logic Test", "[ut][InnerIndexParameter][sampling]") {
         REQUIRE(param->train_sample_count != 65536L);
     }
 }
+
+TEST_CASE("Label remap type parameter test", "[ut][InnerIndexParameter][label_remap_type]") {
+    auto param = std::make_shared<vsag::InnerIndexParameter>();
+    auto json_obj = vsag::JsonType::Parse(R"({})");
+
+    SECTION("default is pg") {
+        param->FromJson(json_obj);
+        REQUIRE(param->label_remap_type == vsag::LabelRemapType::PG);
+        REQUIRE(param->ToJson()["label_remap_type"].GetString() == "pg");
+    }
+
+    SECTION("parse robin") {
+        json_obj["label_remap_type"].SetString("robin");
+        param->FromJson(json_obj);
+        REQUIRE(param->label_remap_type == vsag::LabelRemapType::ROBIN);
+        REQUIRE(param->ToJson()["label_remap_type"].GetString() == "robin");
+    }
+
+    SECTION("reject invalid value") {
+        json_obj["label_remap_type"].SetString("invalid");
+        REQUIRE_THROWS_AS(param->FromJson(json_obj), vsag::VsagException);
+    }
+}

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -173,6 +173,7 @@ const char* const HGRAPH_PARAMETER_HOPS_LIMIT = "hops_limit";
 const char* const HGRAPH_EXTRA_INFO_SIZE = "extra_info_size";
 const char* const HGRAPH_SUPPORT_DUPLICATE = "support_duplicate";
 const char* const HGRAPH_SUPPORT_TOMBSTONE = "support_tomb_stone";
+const char* const HGRAPH_LABEL_REMAP_TYPE = "label_remap_type";
 const char* const HGRAPH_USE_EXTRA_INFO_FILTER = "use_extra_info_filter";
 const char* const STORE_RAW_VECTOR = "store_raw_vector";
 const char* const RAW_VECTOR_IO_TYPE = "raw_vector_io_type";

--- a/src/impl/label_table.cpp
+++ b/src/impl/label_table.cpp
@@ -21,7 +21,8 @@ class RemoveListFilter : public Filter {
 public:
     explicit RemoveListFilter(const UnorderedSet<InnerIdType>& remove_ids,
                               std::shared_mutex& delete_ids_mutex)
-        : Filter(), remove_ids_(remove_ids), delete_ids_mutex_(delete_ids_mutex){};
+        : Filter(), remove_ids_(remove_ids), delete_ids_mutex_(delete_ids_mutex) {
+    }
 
     [[nodiscard]] bool
     CheckValid(int64_t inner_id) const override {
@@ -34,29 +35,123 @@ private:
     std::shared_mutex& delete_ids_mutex_;
 };
 
-LabelTable::LabelTable(Allocator* allocator, bool use_reverse_map, bool compress_redundant_data)
-    : allocator_(allocator),
-      label_table_(0, allocator),
-      label_remap_(0, allocator),
+LabelTable::LabelRemap::LabelRemap(Allocator* allocator, LabelRemapType remap_type)
+    : allocator_(allocator), remap_type_(remap_type) {
+    if (remap_type_ == LabelRemapType::ROBIN) {
+        robin_map_ = std::make_unique<UnorderedMap<LabelType, InnerIdType>>(0, allocator);
+        robin_map_->max_load_factor(0.75F);
+    } else {
+        pg_map_ = std::make_unique<PGUnorderedMap<LabelType, InnerIdType>>(0, allocator);
+        pg_map_->max_load_factor(0.75F);
+    }
+}
+
+void
+LabelTable::LabelRemap::Reset() {
+    if (remap_type_ == LabelRemapType::ROBIN) {
+        robin_map_ = std::make_unique<UnorderedMap<LabelType, InnerIdType>>(0, allocator_);
+        robin_map_->max_load_factor(0.75F);
+        return;
+    }
+
+    pg_map_ = std::make_unique<PGUnorderedMap<LabelType, InnerIdType>>(0, allocator_);
+    pg_map_->max_load_factor(0.75F);
+}
+
+void
+LabelTable::LabelRemap::Clear() {
+    if (pg_map_ != nullptr) {
+        pg_map_->clear();
+        return;
+    }
+    robin_map_->clear();
+}
+
+void
+LabelTable::LabelRemap::Reserve(uint64_t size) {
+    if (pg_map_ != nullptr) {
+        pg_map_->reserve(size);
+        return;
+    }
+    robin_map_->reserve(size);
+}
+
+uint64_t
+LabelTable::LabelRemap::Size() const {
+    if (pg_map_ != nullptr) {
+        return pg_map_->size();
+    }
+    return robin_map_->size();
+}
+
+void
+LabelTable::LabelRemap::InsertOrAssign(LabelType label, InnerIdType inner_id) {
+    if (pg_map_ != nullptr) {
+        (*pg_map_)[label] = inner_id;
+        return;
+    }
+    (*robin_map_)[label] = inner_id;
+}
+
+void
+LabelTable::LabelRemap::Emplace(LabelType label, InnerIdType inner_id) {
+    if (pg_map_ != nullptr) {
+        pg_map_->emplace(label, inner_id);
+        return;
+    }
+    robin_map_->emplace(label, inner_id);
+}
+
+bool
+LabelTable::LabelRemap::Erase(LabelType label) {
+    if (pg_map_ != nullptr) {
+        return pg_map_->erase(label) > 0;
+    }
+    return robin_map_->erase(label) > 0;
+}
+
+bool
+LabelTable::LabelRemap::Find(LabelType label, InnerIdType& inner_id) const {
+    if (pg_map_ != nullptr) {
+        const auto iter = pg_map_->find(label);
+        if (iter == pg_map_->end()) {
+            return false;
+        }
+        inner_id = iter->second;
+        return true;
+    }
+
+    const auto iter = robin_map_->find(label);
+    if (iter == robin_map_->end()) {
+        return false;
+    }
+    inner_id = iter->second;
+    return true;
+}
+
+LabelTable::LabelTable(Allocator* allocator,
+                       bool use_reverse_map,
+                       bool compress_redundant_data,
+                       LabelRemapType label_remap_type)
+    : label_table_(0, allocator),
       use_reverse_map_(use_reverse_map),
+      label_remap_(allocator, label_remap_type),
+      allocator_(allocator),
       deleted_ids_(allocator),
       hole_list_(0, allocator) {
     (void)compress_redundant_data;
-    label_remap_.max_load_factor(0.75F);
     deleted_ids_filter_ = std::make_shared<RemoveListFilter>(deleted_ids_, delete_ids_mutex_);
 }
 
 bool
 LabelTable::CheckLabel(LabelType label) const {
     bool is_exist = false;
-    InnerIdType inner_id;
+    InnerIdType inner_id = INVALID_ID;
     if (use_reverse_map_) {
-        auto iter = label_remap_.find(label);
-        is_exist = iter != label_remap_.end();
+        is_exist = label_remap_.Find(label, inner_id);
         if (not is_exist) {
             return false;
         }
-        inner_id = iter->second;
     } else {
         auto result = std::find(label_table_.begin(), label_table_.end(), label);
         is_exist = (result != label_table_.end());
@@ -76,11 +171,11 @@ LabelTable::CheckLabel(LabelType label) const {
 
 InnerIdType
 LabelTable::get_id_by_label_with_reverse_map(LabelType label) const noexcept {
-    const auto iter = this->label_remap_.find(label);
-    if (iter == this->label_remap_.end()) {
+    InnerIdType inner_id = INVALID_ID;
+    if (not this->label_remap_.Find(label, inner_id)) {
         return INVALID_ID;
     }
-    return iter->second;
+    return inner_id;
 }
 
 InnerIdType
@@ -150,10 +245,10 @@ void
 LabelTable::Deserialize(StreamReader& reader) {
     StreamReader::ReadVector(reader, label_table_);
     if (use_reverse_map_) {
-        this->label_remap_.clear();
-        this->label_remap_.reserve(label_table_.size());
+        this->label_remap_.Clear();
+        this->label_remap_.Reserve(label_table_.size());
         for (InnerIdType id = 0; id < label_table_.size(); ++id) {
-            this->label_remap_[label_table_[id]] = id;
+            this->label_remap_.InsertOrAssign(label_table_[id], id);
         }
     }
 
@@ -177,12 +272,12 @@ LabelTable::MergeOther(const LabelTablePtr& other, const IdMapFunction& id_map) 
     auto current_total_count_u = static_cast<uint64_t>(current_total_count);
     this->label_table_.resize(current_total_count_u + other_size_u);
     if (use_reverse_map_) {
-        this->label_remap_.reserve(this->label_remap_.size() + other_size_u);
+        this->label_remap_.Reserve(this->label_remap_.Size() + other_size_u);
         for (uint64_t i = 0; i < other_size_u; ++i) {
             auto new_label = std::get<1>(id_map(other->label_table_[i]));
             auto new_inner_id = static_cast<InnerIdType>(i + current_total_count_u);
             this->label_table_[i + current_total_count_u] = new_label;
-            this->label_remap_[new_label] = new_inner_id;
+            this->label_remap_.InsertOrAssign(new_label, new_inner_id);
         }
     } else {
         for (uint64_t i = 0; i < other_size_u; ++i) {

--- a/src/impl/label_table.h
+++ b/src/impl/label_table.h
@@ -19,8 +19,12 @@
 #include <vsag/filter.h>
 
 #include <atomic>
+#include <functional>
+#include <memory>
 #include <shared_mutex>
+#include <tuple>
 
+#include "common.h"
 #include "datacell/duplicate_interface.h"
 #include "storage/stream_reader.h"
 #include "storage/stream_writer.h"
@@ -36,16 +40,71 @@ using IdMapFunction = std::function<std::tuple<bool, int64_t>(int64_t)>;
 
 class LabelTable {
 public:
+    class LabelRemap {
+    public:
+        explicit LabelRemap(Allocator* allocator, LabelRemapType remap_type = LabelRemapType::PG);
+
+        void
+        Clear();
+
+        void
+        Reset();
+
+        void
+        Reserve(uint64_t size);
+
+        uint64_t
+        Size() const;
+
+        void
+        InsertOrAssign(LabelType label, InnerIdType inner_id);
+
+        void
+        Emplace(LabelType label, InnerIdType inner_id);
+
+        bool
+        Erase(LabelType label);
+
+        bool
+        Find(LabelType label, InnerIdType& inner_id) const;
+
+        template <typename Func>
+        void
+        ForEach(Func&& func) const {
+            if (pg_map_ != nullptr) {
+                for (const auto& [label, inner_id] : *pg_map_) {
+                    func(label, inner_id);
+                }
+                return;
+            }
+            for (const auto& [label, inner_id] : *robin_map_) {
+                func(label, inner_id);
+            }
+        }
+
+        [[nodiscard]] LabelRemapType
+        GetType() const {
+            return remap_type_;
+        }
+
+    private:
+        Allocator* allocator_{nullptr};
+        LabelRemapType remap_type_{LabelRemapType::PG};
+        std::unique_ptr<UnorderedMap<LabelType, InnerIdType>> robin_map_{};
+        std::unique_ptr<PGUnorderedMap<LabelType, InnerIdType>> pg_map_{};
+    };
+
     explicit LabelTable(Allocator* allocator,
                         bool use_reverse_map = true,
-                        bool compress_redundant_data = false);
+                        bool compress_redundant_data = false,
+                        LabelRemapType label_remap_type = LabelRemapType::PG);
 
     static constexpr InnerIdType INVALID_ID = std::numeric_limits<InnerIdType>::max();
 
     void
     Insert(InnerIdType id, LabelType label) {
         if (use_reverse_map_) {
-            label_remap_[label] = id;
+            label_remap_.InsertOrAssign(label, id);
         }
         if (id + 1 > label_table_.size()) {
             label_table_.resize(id + 1);
@@ -57,9 +116,7 @@ public:
     void
     SetImmutable() {
         this->use_reverse_map_ = false;
-        PGUnorderedMap<LabelType, InnerIdType> empty_remap(allocator_);
-        empty_remap.max_load_factor(0.75F);
-        this->label_remap_.swap(empty_remap);
+        this->label_remap_.Reset();
     }
 
     /**
@@ -86,17 +143,17 @@ public:
         if (not use_reverse_map_) {
             return false;
         }
-        auto iter = label_remap_.find(label);
-        if (iter == label_remap_.end() or iter->second != std::numeric_limits<InnerIdType>::max()) {
+        InnerIdType inner_id = INVALID_ID;
+        if (not label_remap_.Find(label, inner_id) or inner_id != INVALID_ID) {
             return false;
         }
 
         // 2. find inner_id
-        auto inner_id = GetIdByLabel(label, true);
+        inner_id = GetIdByLabel(label, true);
 
         // 3. recover
         deleted_ids_.erase(inner_id);
-        label_remap_[label] = inner_id;
+        label_remap_.InsertOrAssign(label, inner_id);
         return true;
     }
 
@@ -105,9 +162,11 @@ public:
         if (not use_reverse_map_) {
             return false;
         }
-        auto iter = label_remap_.find(label);
-        return (iter != label_remap_.end() and
-                iter->second == std::numeric_limits<InnerIdType>::max());
+        InnerIdType inner_id = INVALID_ID;
+        if (not label_remap_.Find(label, inner_id)) {
+            return false;
+        }
+        return inner_id == INVALID_ID;
     }
 
     /**
@@ -179,10 +238,12 @@ public:
         // 3. update label_remap_
         if (use_reverse_map_) {
             // note that currently, old_label must exist
-            auto iter_old = label_remap_.find(old_label);
-            auto internal_id = iter_old->second;
-            label_remap_.erase(iter_old);
-            label_remap_[new_label] = internal_id;
+            InnerIdType internal_id = INVALID_ID;
+            bool remap_found = label_remap_.Find(old_label, internal_id);
+            CHECK_ARGUMENT(remap_found,
+                           fmt::format("old label {} does not exist in remap", old_label));
+            label_remap_.Erase(old_label);
+            label_remap_.InsertOrAssign(new_label, internal_id);
         }
     }
 
@@ -213,10 +274,10 @@ public:
     Deserialize(lvalue_or_rvalue<StreamReader> reader) {
         StreamReader::ReadVector(reader, label_table_);
         if (use_reverse_map_) {
-            this->label_remap_.clear();
-            this->label_remap_.reserve(label_table_.size());
+            this->label_remap_.Clear();
+            this->label_remap_.Reserve(label_table_.size());
             for (InnerIdType id = 0; id < label_table_.size(); ++id) {
-                this->label_remap_[label_table_[id]] = id;
+                this->label_remap_.InsertOrAssign(label_table_[id], id);
             }
         }
         if (support_tombstone_) {
@@ -257,8 +318,32 @@ public:
     int64_t
     GetMemoryUsage() {
         return sizeof(LabelTable) + label_table_.size() * sizeof(LabelType) +
-               label_remap_.size() * (sizeof(LabelType) + sizeof(InnerIdType)) +
+               label_remap_.Size() * (sizeof(LabelType) + sizeof(InnerIdType)) +
                deleted_ids_.size() * sizeof(InnerIdType) + hole_list_.size() * sizeof(InnerIdType);
+    }
+
+    uint64_t
+    GetRemapSize() const {
+        return label_remap_.Size();
+    }
+
+    template <typename Visitor>
+    void
+    ForEachRemap(Visitor&& visitor) const {
+        label_remap_.ForEach(visitor);
+    }
+
+    void
+    ResetRemap(uint64_t size = 0) {
+        label_remap_.Clear();
+        if (size > 0) {
+            label_remap_.Reserve(size);
+        }
+    }
+
+    void
+    InsertRemap(LabelType label, InnerIdType inner_id) {
+        label_remap_.Emplace(label, inner_id);
     }
 
     /**
@@ -308,7 +393,7 @@ public:
     // Whether to use reverse map to speed up GetIdByLabel.
     bool use_reverse_map_{true};
     // Reverse map from label to id.
-    PGUnorderedMap<LabelType, InnerIdType> label_remap_;
+    LabelRemap label_remap_;
 
     bool support_tombstone_{false};
     DuplicateTrackerPtr duplicate_tracker_{nullptr};
@@ -363,11 +448,11 @@ public:
         }
 
         if (use_reverse_map_) {
-            label_remap_.erase(label_table_[to]);
+            label_remap_.Erase(label_table_[to]);
         }
         label_table_[to] = label_table_[from];
         if (use_reverse_map_) {
-            label_remap_[label_table_[to]] = to;
+            label_remap_.InsertOrAssign(label_table_[to], to);
         }
     }
 

--- a/src/impl/label_table_test.cpp
+++ b/src/impl/label_table_test.cpp
@@ -159,6 +159,28 @@ TEST_CASE("LabelTable Without Reverse Map", "[ut][LabelTable]") {
     }
 }
 
+TEST_CASE("LabelTable Supports Configurable Remap Implementation", "[ut][LabelTable]") {
+    auto allocator = std::make_shared<DefaultAllocator>();
+
+    SECTION("robin remap works") {
+        LabelTable label_table(allocator.get(), true, false, LabelRemapType::ROBIN);
+        label_table.Insert(0, 100);
+        label_table.Insert(1, 200);
+
+        REQUIRE(label_table.GetRemapSize() == 2);
+        REQUIRE(label_table.GetIdByLabel(100) == 0);
+        REQUIRE(label_table.GetIdByLabel(200) == 1);
+    }
+
+    SECTION("pg remap remains default") {
+        LabelTable label_table(allocator.get(), true, false, LabelRemapType::PG);
+        label_table.Insert(0, 100);
+
+        REQUIRE(label_table.GetRemapSize() == 1);
+        REQUIRE(label_table.GetIdByLabel(100) == 0);
+    }
+}
+
 TEST_CASE("LabelTable Memory Management", "[ut][LabelTable]") {
     auto allocator = std::make_shared<DefaultAllocator>();
     LabelTable label_table(allocator.get());

--- a/src/inner_string_params.h
+++ b/src/inner_string_params.h
@@ -34,6 +34,7 @@ const char* const USE_QUANTIZATION = "use_quantization";
 const char* const EXTRA_INFO_KEY = "extra_info";
 const char* const USE_ATTRIBUTE_FILTER_KEY = "use_attribute_filter";
 const char* const BUILD_THREAD_COUNT_KEY = "build_thread_count";
+const char* const LABEL_REMAP_TYPE_KEY = "label_remap_type";
 const char* const BASE_CODES_KEY = "base_codes";
 const char* const PRECISE_CODES_KEY = "precise_codes";
 const char* const STORE_RAW_VECTOR_KEY = "store_raw_vector";
@@ -46,6 +47,8 @@ const char* const HGRAPH_USE_ELP_OPTIMIZER_KEY = "use_elp_optimizer";
 const char* const HGRAPH_IGNORE_REORDER_KEY = "ignore_reorder";
 const char* const HGRAPH_BUILD_BY_BASE_QUANTIZATION_KEY = "build_by_base";
 const char* const HGRAPH_USE_REVERSE_EDGES_KEY = "use_reverse_edges";
+const char* const LABEL_REMAP_TYPE_VALUE_ROBIN = "robin";
+const char* const LABEL_REMAP_TYPE_VALUE_PG = "pg";
 const char* const GRAPH_KEY = "graph";
 const char* const ALPHA_KEY = "alpha";
 
@@ -247,6 +250,9 @@ const std::unordered_map<std::string, std::string> DEFAULT_MAP = {
     {"IVF_PARTITION_STRATEGY_TYPE_NEAREST", IVF_PARTITION_STRATEGY_TYPE_NEAREST},
     {"IVF_TRAIN_TYPE_KMEANS", IVF_TRAIN_TYPE_KMEANS},
     {"BUILD_THREAD_COUNT_KEY", BUILD_THREAD_COUNT_KEY},
+    {"LABEL_REMAP_TYPE_KEY", LABEL_REMAP_TYPE_KEY},
+    {"LABEL_REMAP_TYPE_VALUE_ROBIN", LABEL_REMAP_TYPE_VALUE_ROBIN},
+    {"LABEL_REMAP_TYPE_VALUE_PG", LABEL_REMAP_TYPE_VALUE_PG},
     {"SEARCH_PARALLELISM", SEARCH_PARALLELISM},
     {"GRAPH_SUPPORT_REMOVE", GRAPH_SUPPORT_REMOVE},
     {"REMOVE_FLAG_BIT", REMOVE_FLAG_BIT},

--- a/src/typing.h
+++ b/src/typing.h
@@ -31,6 +31,8 @@ namespace vsag {
 using InnerIdType = uint32_t;  // inner id's type; index's vector count may less than 2^31 - 1
 using LabelType = int64_t;     // external id's type
 
+enum class LabelRemapType : uint8_t { ROBIN, PG };
+
 using JsonType = JsonWrapper;  // alias for nlohmann::json type
 using BucketIdType = int32_t;
 


### PR DESCRIPTION
## Summary
- add an inner-index label_remap_type parameter and expose it on the HGraph build parameter surface
- encapsulate label remap storage inside LabelTable so inner indexes can switch between robin_map and robin_pg_map
- add unit coverage for parameter parsing, HGraph mapping, and configurable remap behavior

## Testing
- make debug
- make test (unit test phase passed; functests timed out in existing long-running HGraph functests)
- ./build/tests/unittests Label remap type parameter test
- ./build/tests/unittests LabelTable Supports Configurable Remap Implementation
- ./build/tests/unittests HGraph maps label_remap_type to inner index parameter

Closes #1986