### PR TITLE
fix: avoid empty fast bitset memcpy

### DIFF
--- a/src/impl/bitset/fast_bitset.cpp
+++ b/src/impl/bitset/fast_bitset.cpp
@@ -17,6 +17,7 @@
 
 #include <limits>
 #include <memory>
+#include <string>
 
 #include "simd/bit_simd.h"
 #include "vsag_exception.h"
@@ -24,6 +25,7 @@
 namespace vsag {
 
 static constexpr uint64_t FILL_ONE = 0xFFFFFFFFFFFFFFFF;
+// The high bit of capacity_ stores fill_bit, so serialized word count must fit in 31 bits.
 static constexpr uint64_t MAX_FAST_BITSET_WORDS = std::numeric_limits<uint32_t>::max() >> 1;
 
 void
@@ -222,10 +224,19 @@ FastBitset::Deserialize(StreamReader& reader) {
     uint64_t size;
     StreamReader::ReadObj(reader, size);
     if (size > MAX_FAST_BITSET_WORDS) {
-        throw VsagException(ErrorType::READ_ERROR, "bitset size too large");
+        throw VsagException(ErrorType::READ_ERROR,
+                            "bitset word size too large: ",
+                            std::to_string(size),
+                            ", max: ",
+                            std::to_string(MAX_FAST_BITSET_WORDS));
     }
-    if (size > std::numeric_limits<size_t>::max() / sizeof(uint64_t)) {
-        throw VsagException(ErrorType::READ_ERROR, "bitset byte size too large");
+    const auto max_byte_words = std::numeric_limits<size_t>::max() / sizeof(uint64_t);
+    if (size > max_byte_words) {
+        throw VsagException(ErrorType::READ_ERROR,
+                            "bitset byte size too large, words: ",
+                            std::to_string(size),
+                            ", max words: ",
+                            std::to_string(max_byte_words));
     }
 
     std::unique_ptr<uint64_t[]> new_data;

--- a/src/impl/bitset/fast_bitset.cpp
+++ b/src/impl/bitset/fast_bitset.cpp
@@ -225,30 +225,27 @@ FastBitset::Deserialize(StreamReader& reader) {
     StreamReader::ReadObj(reader, size);
     if (size > MAX_FAST_BITSET_WORDS) {
         throw VsagException(ErrorType::READ_ERROR,
-                            "bitset word size too large: ",
-                            std::to_string(size),
-                            ", max: ",
-                            std::to_string(MAX_FAST_BITSET_WORDS));
+                            "bitset word size too large: " + std::to_string(size) +
+                                ", max: " + std::to_string(MAX_FAST_BITSET_WORDS));
     }
     const auto max_byte_words = std::numeric_limits<size_t>::max() / sizeof(uint64_t);
     if (size > max_byte_words) {
         throw VsagException(ErrorType::READ_ERROR,
-                            "bitset byte size too large, words: ",
-                            std::to_string(size),
-                            ", max words: ",
-                            std::to_string(max_byte_words));
+                            "bitset byte size too large, words: " + std::to_string(size) +
+                                ", max words: " + std::to_string(max_byte_words));
     }
 
     std::unique_ptr<uint64_t[]> new_data;
     if (size > 0) {
-        new_data = std::make_unique<uint64_t[]>(size);
+        new_data.reset(new uint64_t[size]);
         reader.Read(reinterpret_cast<char*>(new_data.get()), size * sizeof(uint64_t));
     }
 
+    const auto size32 = static_cast<uint32_t>(size);
     delete[] data_;
     data_ = new_data.release();
-    this->size_ = static_cast<uint32_t>(size);
-    this->set_capacity(static_cast<uint32_t>(size));
+    this->size_ = size32;
+    this->set_capacity(size32);
     this->set_fill_bit(fill_bit);
 }
 

--- a/src/impl/bitset/fast_bitset.cpp
+++ b/src/impl/bitset/fast_bitset.cpp
@@ -15,6 +15,7 @@
 
 #include "fast_bitset.h"
 
+#include <limits>
 #include <memory>
 
 #include "simd/bit_simd.h"
@@ -23,7 +24,7 @@
 namespace vsag {
 
 static constexpr uint64_t FILL_ONE = 0xFFFFFFFFFFFFFFFF;
-static constexpr uint64_t MAX_FAST_BITSET_WORDS = 0x7FFFFFFF;
+static constexpr uint64_t MAX_FAST_BITSET_WORDS = std::numeric_limits<uint32_t>::max() >> 1;
 
 void
 FastBitset::Set(int64_t pos, bool value) {
@@ -221,7 +222,10 @@ FastBitset::Deserialize(StreamReader& reader) {
     uint64_t size;
     StreamReader::ReadObj(reader, size);
     if (size > MAX_FAST_BITSET_WORDS) {
-        throw VsagException(ErrorType::INTERNAL_ERROR, "bitset size too large");
+        throw VsagException(ErrorType::READ_ERROR, "bitset size too large");
+    }
+    if (size > std::numeric_limits<size_t>::max() / sizeof(uint64_t)) {
+        throw VsagException(ErrorType::READ_ERROR, "bitset byte size too large");
     }
 
     std::unique_ptr<uint64_t[]> new_data;

--- a/src/impl/bitset/fast_bitset.cpp
+++ b/src/impl/bitset/fast_bitset.cpp
@@ -217,8 +217,12 @@ FastBitset::Deserialize(StreamReader& reader) {
     StreamReader::ReadObj(reader, fill_bit);
     uint64_t size;
     StreamReader::ReadObj(reader, size);
-    data_ = new uint64_t[size];
-    reader.Read(reinterpret_cast<char*>(data_), size * sizeof(uint64_t));
+    delete[] data_;
+    data_ = nullptr;
+    if (size > 0) {
+        data_ = new uint64_t[size];
+        reader.Read(reinterpret_cast<char*>(data_), size * sizeof(uint64_t));
+    }
     this->size_ = size;
     this->set_capacity(size);
     this->set_fill_bit(fill_bit);
@@ -234,7 +238,9 @@ void
 FastBitset::resize(uint32_t new_size, uint64_t fill) {
     if (new_size > this->get_capacity()) {
         auto* tmp = new uint64_t[new_size];
-        std::memcpy(tmp, data_, size_ * sizeof(uint64_t));
+        if (size_ > 0) {
+            std::memcpy(tmp, data_, size_ * sizeof(uint64_t));
+        }
         delete[] data_;
         this->data_ = tmp;
         this->set_capacity(new_size);

--- a/src/impl/bitset/fast_bitset.cpp
+++ b/src/impl/bitset/fast_bitset.cpp
@@ -15,12 +15,15 @@
 
 #include "fast_bitset.h"
 
+#include <memory>
+
 #include "simd/bit_simd.h"
 #include "vsag_exception.h"
 
 namespace vsag {
 
 static constexpr uint64_t FILL_ONE = 0xFFFFFFFFFFFFFFFF;
+static constexpr uint64_t MAX_FAST_BITSET_WORDS = 0x7FFFFFFF;
 
 void
 FastBitset::Set(int64_t pos, bool value) {
@@ -217,14 +220,20 @@ FastBitset::Deserialize(StreamReader& reader) {
     StreamReader::ReadObj(reader, fill_bit);
     uint64_t size;
     StreamReader::ReadObj(reader, size);
-    delete[] data_;
-    data_ = nullptr;
-    if (size > 0) {
-        data_ = new uint64_t[size];
-        reader.Read(reinterpret_cast<char*>(data_), size * sizeof(uint64_t));
+    if (size > MAX_FAST_BITSET_WORDS) {
+        throw VsagException(ErrorType::INTERNAL_ERROR, "bitset size too large");
     }
-    this->size_ = size;
-    this->set_capacity(size);
+
+    std::unique_ptr<uint64_t[]> new_data;
+    if (size > 0) {
+        new_data = std::make_unique<uint64_t[]>(size);
+        reader.Read(reinterpret_cast<char*>(new_data.get()), size * sizeof(uint64_t));
+    }
+
+    delete[] data_;
+    data_ = new_data.release();
+    this->size_ = static_cast<uint32_t>(size);
+    this->set_capacity(static_cast<uint32_t>(size));
     this->set_fill_bit(fill_bit);
 }
 

--- a/src/impl/bitset/fast_bitset_test.cpp
+++ b/src/impl/bitset/fast_bitset_test.cpp
@@ -16,6 +16,7 @@
 #include "fast_bitset.h"
 
 #include <catch2/matchers/catch_matchers.hpp>
+#include <limits>
 #include <sstream>
 
 #include "impl/allocator/safe_allocator.h"
@@ -229,7 +230,7 @@ TEST_CASE("FastBitset rejects oversized deserialize size", "[ut][FastBitset]") {
     std::stringstream stream(std::ios::in | std::ios::out | std::ios::binary);
     IOStreamWriter writer(stream);
     const bool fill_bit = false;
-    const uint64_t oversized_size = 0x80000000ULL;
+    const uint64_t oversized_size = (std::numeric_limits<uint32_t>::max() >> 1) + 1ULL;
     StreamWriter::WriteObj(writer, fill_bit);
     StreamWriter::WriteObj(writer, oversized_size);
     stream.seekg(0);

--- a/src/impl/bitset/fast_bitset_test.cpp
+++ b/src/impl/bitset/fast_bitset_test.cpp
@@ -21,6 +21,7 @@
 #include "impl/allocator/safe_allocator.h"
 #include "unittest.h"
 #include "utils/util_functions.h"
+#include "vsag_exception.h"
 using namespace vsag;
 
 std::pair<FastBitsetPtr, std::vector<int>>
@@ -222,6 +223,26 @@ TEST_CASE("FastBitset empty resize and deserialize", "[ut][FastBitset]") {
     restored.Set(7, true);
     REQUIRE(restored.Test(7));
     REQUIRE(restored.Count() == 1);
+}
+
+TEST_CASE("FastBitset rejects oversized deserialize size", "[ut][FastBitset]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+
+    FastBitset bitset(allocator.get());
+    bitset.Set(3, true);
+
+    std::stringstream stream(std::ios::in | std::ios::out | std::ios::binary);
+    IOStreamWriter writer(stream);
+    const bool fill_bit = false;
+    const uint64_t oversized_size = 0x80000000ULL;
+    StreamWriter::WriteObj(writer, fill_bit);
+    StreamWriter::WriteObj(writer, oversized_size);
+    stream.seekg(0);
+
+    IOStreamReader reader(stream);
+    REQUIRE_THROWS_AS(bitset.Deserialize(reader), vsag::VsagException);
+    REQUIRE(bitset.Test(3));
+    REQUIRE(bitset.Count() == 1);
 }
 
 std::unordered_set<int>

--- a/src/impl/bitset/fast_bitset_test.cpp
+++ b/src/impl/bitset/fast_bitset_test.cpp
@@ -204,11 +204,6 @@ GetUnion(const std::vector<int>& values1, const std::vector<int>& values2) {
 TEST_CASE("FastBitset empty resize and deserialize", "[ut][FastBitset]") {
     auto allocator = SafeAllocator::FactoryDefaultAllocator();
 
-    FastBitset bitset(allocator.get());
-    bitset.Set(3, true);
-    REQUIRE(bitset.Test(3));
-    REQUIRE(bitset.Count() == 1);
-
     FastBitset empty(allocator.get());
     std::stringstream stream(std::ios::in | std::ios::out | std::ios::binary);
     IOStreamWriter writer(stream);

--- a/src/impl/bitset/fast_bitset_test.cpp
+++ b/src/impl/bitset/fast_bitset_test.cpp
@@ -16,6 +16,7 @@
 #include "fast_bitset.h"
 
 #include <catch2/matchers/catch_matchers.hpp>
+#include <sstream>
 
 #include "impl/allocator/safe_allocator.h"
 #include "unittest.h"
@@ -197,6 +198,30 @@ GetUnion(const std::vector<int>& values1, const std::vector<int>& values2) {
         result.insert(value);
     }
     return result;
+}
+
+TEST_CASE("FastBitset empty resize and deserialize", "[ut][FastBitset]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+
+    FastBitset bitset(allocator.get());
+    bitset.Set(3, true);
+    REQUIRE(bitset.Test(3));
+    REQUIRE(bitset.Count() == 1);
+
+    FastBitset empty(allocator.get());
+    std::stringstream stream(std::ios::in | std::ios::out | std::ios::binary);
+    IOStreamWriter writer(stream);
+    empty.Serialize(writer);
+    stream.seekg(0);
+
+    FastBitset restored(allocator.get());
+    IOStreamReader reader(stream);
+    restored.Deserialize(reader);
+    REQUIRE(restored.Count() == 0);
+
+    restored.Set(7, true);
+    REQUIRE(restored.Test(7));
+    REQUIRE(restored.Count() == 1);
 }
 
 std::unordered_set<int>


### PR DESCRIPTION
## Summary

Fix `FastBitset` zero-length serialization edge cases that can pass null pointers to `memcpy` under UBSan.

The deserialize path now keeps empty bitsets represented without allocating data, and resize only copies existing words when the previous size is non-zero. A regression test covers resizing from an empty bitset and deserializing an empty bitset.

Fixes #1963.
Part of #1960.

## Validation

- `git diff --check`
- Fork PR CI: https://github.com/jac0626/vsag/actions/runs/25476854514
- Log scan: target `fast_bitset.cpp` runtime error is gone in this branch; remaining runtime errors are existing issues tracked separately (`inner_index_interface.cpp`, `sparse_term_datacell.cpp`, `hnswalg.*`).

## Notes

Local macOS rebuild was blocked by the existing CMake configuration error: `gcc does not support using libc++`.
