### PR TITLE
fix: guard inner index binary deserialization

### DIFF
--- a/src/algorithm/inner_index_interface.cpp
+++ b/src/algorithm/inner_index_interface.cpp
@@ -18,6 +18,7 @@
 #include <fmt/format.h>
 
 #include <cstring>
+#include <limits>
 
 #include "algorithm/bruteforce/bruteforce.h"
 #include "algorithm/hgraph/hgraph.h"
@@ -221,7 +222,14 @@ InnerIndexInterface::Deserialize(const BinarySet& binary_set) {
             throw VsagException(
                 ErrorType::READ_ERROR, "binary read out of range for index: ", this->GetName());
         }
-        std::memcpy(dest, b.data.get() + offset, len);
+        if (offset > std::numeric_limits<size_t>::max() ||
+            len > std::numeric_limits<size_t>::max()) {
+            throw VsagException(
+                ErrorType::READ_ERROR, "binary read too large for index: ", this->GetName());
+        }
+        const auto copy_offset = static_cast<size_t>(offset);
+        const auto copy_len = static_cast<size_t>(len);
+        std::memcpy(dest, b.data.get() + copy_offset, copy_len);
     };
 
     try {

--- a/src/algorithm/inner_index_interface.cpp
+++ b/src/algorithm/inner_index_interface.cpp
@@ -224,22 +224,21 @@ InnerIndexInterface::Deserialize(const BinarySet& binary_set) {
             throw VsagException(
                 ErrorType::READ_ERROR, "binary read out of range for index: ", this->GetName());
         }
-        if (offset > std::numeric_limits<size_t>::max() ||
-            len > std::numeric_limits<size_t>::max()) {
+        if (len > std::numeric_limits<size_t>::max()) {
             throw VsagException(
                 ErrorType::READ_ERROR, "binary read too large for index: ", this->GetName());
         }
-        const auto copy_offset = static_cast<size_t>(offset);
         const auto copy_len = static_cast<size_t>(len);
         using PointerDiffLimit = std::make_unsigned_t<std::ptrdiff_t>;
-        if (offset > static_cast<PointerDiffLimit>(std::numeric_limits<std::ptrdiff_t>::max()) ||
-            len > static_cast<PointerDiffLimit>(std::numeric_limits<std::ptrdiff_t>::max()) ||
-            len > static_cast<PointerDiffLimit>(std::numeric_limits<std::ptrdiff_t>::max()) -
-                      offset) {
+        const auto max_pointer_offset =
+            static_cast<PointerDiffLimit>(std::numeric_limits<std::ptrdiff_t>::max());
+        if (offset > max_pointer_offset || len > max_pointer_offset ||
+            len > max_pointer_offset - offset) {
             throw VsagException(
                 ErrorType::READ_ERROR, "binary read offset too large for index: ", this->GetName());
         }
-        std::memcpy(dest, b.data.get() + static_cast<std::ptrdiff_t>(offset), copy_len);
+        const auto copy_offset = static_cast<std::ptrdiff_t>(offset);
+        std::memcpy(dest, b.data.get() + copy_offset, copy_len);
     };
 
     try {

--- a/src/algorithm/inner_index_interface.cpp
+++ b/src/algorithm/inner_index_interface.cpp
@@ -211,6 +211,11 @@ InnerIndexInterface::Deserialize(const BinarySet& binary_set) {
         throw VsagException(ErrorType::READ_ERROR, "null binary data for index: ", index_name);
     }
 
+    const auto* binary_data = b.data.get();
+    using PointerDiffLimit = std::make_unsigned_t<std::ptrdiff_t>;
+    const auto max_pointer_offset =
+        static_cast<PointerDiffLimit>(std::numeric_limits<std::ptrdiff_t>::max());
+
     auto func = [&](uint64_t offset, uint64_t len, void* dest) -> void {
         // logger::debug("read offset {} len {}", offset, len);
         if (len == 0) {
@@ -229,16 +234,14 @@ InnerIndexInterface::Deserialize(const BinarySet& binary_set) {
                 ErrorType::READ_ERROR, "binary read too large for index: ", index_name);
         }
         const auto copy_len = static_cast<size_t>(len);
-        using PointerDiffLimit = std::make_unsigned_t<std::ptrdiff_t>;
-        const auto max_pointer_offset =
-            static_cast<PointerDiffLimit>(std::numeric_limits<std::ptrdiff_t>::max());
+        // Pointer arithmetic uses ptrdiff_t offsets, so validate representability first.
         if (offset > max_pointer_offset || len > max_pointer_offset ||
             len > max_pointer_offset - offset) {
             throw VsagException(
                 ErrorType::READ_ERROR, "binary read offset too large for index: ", index_name);
         }
         const auto copy_offset = static_cast<std::ptrdiff_t>(offset);
-        std::memcpy(dest, b.data.get() + copy_offset, copy_len);
+        std::memcpy(dest, binary_data + copy_offset, copy_len);
     };
 
     try {

--- a/src/algorithm/inner_index_interface.cpp
+++ b/src/algorithm/inner_index_interface.cpp
@@ -17,8 +17,10 @@
 
 #include <fmt/format.h>
 
+#include <cstddef>
 #include <cstring>
 #include <limits>
+#include <type_traits>
 
 #include "algorithm/bruteforce/bruteforce.h"
 #include "algorithm/hgraph/hgraph.h"
@@ -229,7 +231,15 @@ InnerIndexInterface::Deserialize(const BinarySet& binary_set) {
         }
         const auto copy_offset = static_cast<size_t>(offset);
         const auto copy_len = static_cast<size_t>(len);
-        std::memcpy(dest, b.data.get() + copy_offset, copy_len);
+        using PointerDiffLimit = std::make_unsigned_t<std::ptrdiff_t>;
+        if (offset > static_cast<PointerDiffLimit>(std::numeric_limits<std::ptrdiff_t>::max()) ||
+            len > static_cast<PointerDiffLimit>(std::numeric_limits<std::ptrdiff_t>::max()) ||
+            len > static_cast<PointerDiffLimit>(std::numeric_limits<std::ptrdiff_t>::max()) -
+                      offset) {
+            throw VsagException(
+                ErrorType::READ_ERROR, "binary read offset too large for index: ", this->GetName());
+        }
+        std::memcpy(dest, b.data.get() + static_cast<std::ptrdiff_t>(offset), copy_len);
     };
 
     try {

--- a/src/algorithm/inner_index_interface.cpp
+++ b/src/algorithm/inner_index_interface.cpp
@@ -201,14 +201,14 @@ InnerIndexInterface::Deserialize(const BinarySet& binary_set) {
         }
     }
 
-    if (not binary_set.Contains(this->GetName())) {
-        throw VsagException(
-            ErrorType::READ_ERROR, "missing binary data for index: ", this->GetName());
+    const auto index_name = this->GetName();
+    if (not binary_set.Contains(index_name)) {
+        throw VsagException(ErrorType::READ_ERROR, "missing binary data for index: ", index_name);
     }
 
-    Binary b = binary_set.Get(this->GetName());
+    Binary b = binary_set.Get(index_name);
     if (b.size > 0 && b.data == nullptr) {
-        throw VsagException(ErrorType::READ_ERROR, "null binary data for index: ", this->GetName());
+        throw VsagException(ErrorType::READ_ERROR, "null binary data for index: ", index_name);
     }
 
     auto func = [&](uint64_t offset, uint64_t len, void* dest) -> void {
@@ -218,15 +218,15 @@ InnerIndexInterface::Deserialize(const BinarySet& binary_set) {
         }
         if (dest == nullptr) {
             throw VsagException(
-                ErrorType::READ_ERROR, "null read destination for index: ", this->GetName());
+                ErrorType::READ_ERROR, "null read destination for index: ", index_name);
         }
         if (b.data == nullptr || offset > b.size || len > b.size - offset) {
             throw VsagException(
-                ErrorType::READ_ERROR, "binary read out of range for index: ", this->GetName());
+                ErrorType::READ_ERROR, "binary read out of range for index: ", index_name);
         }
         if (len > std::numeric_limits<size_t>::max()) {
             throw VsagException(
-                ErrorType::READ_ERROR, "binary read too large for index: ", this->GetName());
+                ErrorType::READ_ERROR, "binary read too large for index: ", index_name);
         }
         const auto copy_len = static_cast<size_t>(len);
         using PointerDiffLimit = std::make_unsigned_t<std::ptrdiff_t>;
@@ -235,7 +235,7 @@ InnerIndexInterface::Deserialize(const BinarySet& binary_set) {
         if (offset > max_pointer_offset || len > max_pointer_offset ||
             len > max_pointer_offset - offset) {
             throw VsagException(
-                ErrorType::READ_ERROR, "binary read offset too large for index: ", this->GetName());
+                ErrorType::READ_ERROR, "binary read offset too large for index: ", index_name);
         }
         const auto copy_offset = static_cast<std::ptrdiff_t>(offset);
         std::memcpy(dest, b.data.get() + copy_offset, copy_len);

--- a/src/algorithm/inner_index_interface.cpp
+++ b/src/algorithm/inner_index_interface.cpp
@@ -17,6 +17,8 @@
 
 #include <fmt/format.h>
 
+#include <cstring>
+
 #include "algorithm/bruteforce/bruteforce.h"
 #include "algorithm/hgraph/hgraph.h"
 #include "impl/filter/filter_headers.h"
@@ -196,9 +198,29 @@ InnerIndexInterface::Deserialize(const BinarySet& binary_set) {
         }
     }
 
+    if (not binary_set.Contains(this->GetName())) {
+        throw VsagException(
+            ErrorType::READ_ERROR, "missing binary data for index: ", this->GetName());
+    }
+
     Binary b = binary_set.Get(this->GetName());
+    if (b.size > 0 && b.data == nullptr) {
+        throw VsagException(ErrorType::READ_ERROR, "null binary data for index: ", this->GetName());
+    }
+
     auto func = [&](uint64_t offset, uint64_t len, void* dest) -> void {
         // logger::debug("read offset {} len {}", offset, len);
+        if (len == 0) {
+            return;
+        }
+        if (dest == nullptr) {
+            throw VsagException(
+                ErrorType::READ_ERROR, "null read destination for index: ", this->GetName());
+        }
+        if (b.data == nullptr || offset > b.size || len > b.size - offset) {
+            throw VsagException(
+                ErrorType::READ_ERROR, "binary read out of range for index: ", this->GetName());
+        }
         std::memcpy(dest, b.data.get() + offset, len);
     };
 

--- a/src/algorithm/inner_index_interface_test.cpp
+++ b/src/algorithm/inner_index_interface_test.cpp
@@ -168,6 +168,14 @@ public:
     }
 };
 
+Binary
+MakeBinary(const std::shared_ptr<int8_t[]>& data, uint64_t size) {
+    Binary binary;
+    binary.data = data;
+    binary.size = size;
+    return binary;
+}
+
 template <typename Func>
 void
 RequireReadError(Func&& func) {
@@ -177,6 +185,10 @@ RequireReadError(Func&& func) {
     } catch (const VsagException& e) {
         got_read_error = true;
         REQUIRE(e.error_.type == ErrorType::READ_ERROR);
+    } catch (const std::exception& e) {
+        FAIL("Expected READ_ERROR VsagException, got std::exception: " << e.what());
+    } catch (...) {
+        FAIL("Expected READ_ERROR VsagException, got non-standard exception");
     }
     REQUIRE(got_read_error);
 }
@@ -246,7 +258,7 @@ TEST_CASE("InnerIndexInterface rejects malformed binary set", "[ut][InnerIndexIn
 
     SECTION("null non-empty index binary") {
         BinarySet binary;
-        binary.Set(index->GetName(), Binary{.data = nullptr, .size = sizeof(uint64_t)});
+        binary.Set(index->GetName(), MakeBinary(std::shared_ptr<int8_t[]>(), sizeof(uint64_t)));
 
         RequireReadError([&index, &binary]() { index->Deserialize(binary); });
     }
@@ -254,7 +266,7 @@ TEST_CASE("InnerIndexInterface rejects malformed binary set", "[ut][InnerIndexIn
     SECTION("truncated index binary") {
         auto data = std::shared_ptr<int8_t[]>(new int8_t[1]);
         BinarySet binary;
-        binary.Set(index->GetName(), Binary{.data = data, .size = 1});
+        binary.Set(index->GetName(), MakeBinary(data, 1));
 
         RequireReadError([&index, &binary]() { index->Deserialize(binary); });
     }
@@ -263,7 +275,7 @@ TEST_CASE("InnerIndexInterface rejects malformed binary set", "[ut][InnerIndexIn
         index = std::make_shared<NullDestinationInnerIndex>();
         auto data = std::shared_ptr<int8_t[]>(new int8_t[1]);
         BinarySet binary;
-        binary.Set(index->GetName(), Binary{.data = data, .size = 1});
+        binary.Set(index->GetName(), MakeBinary(data, 1));
 
         RequireReadError([&index, &binary]() { index->Deserialize(binary); });
     }
@@ -272,7 +284,7 @@ TEST_CASE("InnerIndexInterface rejects malformed binary set", "[ut][InnerIndexIn
         index = std::make_shared<SeekOutOfRangeInnerIndex>();
         auto data = std::shared_ptr<int8_t[]>(new int8_t[1]);
         BinarySet binary;
-        binary.Set(index->GetName(), Binary{.data = data, .size = 1});
+        binary.Set(index->GetName(), MakeBinary(data, 1));
 
         RequireReadError([&index, &binary]() { index->Deserialize(binary); });
     }

--- a/src/algorithm/inner_index_interface_test.cpp
+++ b/src/algorithm/inner_index_interface_test.cpp
@@ -15,9 +15,9 @@
 
 #include "inner_index_interface.h"
 
-#include <functional>
 #include <memory>
 #include <sstream>
+#include <utility>
 
 #include "algorithm/bruteforce/bruteforce.h"
 #include "algorithm/hgraph/hgraph.h"
@@ -140,11 +140,40 @@ public:
     }
 };
 
+class NullDestinationInnerIndex : public EmptyInnerIndex {
+public:
+    std::string
+    GetName() const override {
+        return "NullDestinationInnerIndex";
+    }
+
+    void
+    Deserialize(StreamReader& reader) override {
+        reader.Read(nullptr, 1);
+    }
+};
+
+class SeekOutOfRangeInnerIndex : public EmptyInnerIndex {
+public:
+    std::string
+    GetName() const override {
+        return "SeekOutOfRangeInnerIndex";
+    }
+
+    void
+    Deserialize(StreamReader& reader) override {
+        reader.Seek(2);
+        uint8_t value = 0;
+        reader.Read(reinterpret_cast<char*>(&value), 1);
+    }
+};
+
+template <typename Func>
 void
-RequireReadError(const std::function<void()>& func) {
+RequireReadError(Func&& func) {
     bool got_read_error = false;
     try {
-        func();
+        std::forward<Func>(func)();
     } catch (const VsagException& e) {
         got_read_error = true;
         REQUIRE(e.error_.type == ErrorType::READ_ERROR);
@@ -223,6 +252,24 @@ TEST_CASE("InnerIndexInterface rejects malformed binary set", "[ut][InnerIndexIn
     }
 
     SECTION("truncated index binary") {
+        auto data = std::shared_ptr<int8_t[]>(new int8_t[1]);
+        BinarySet binary;
+        binary.Set(index->GetName(), Binary{.data = data, .size = 1});
+
+        RequireReadError([&index, &binary]() { index->Deserialize(binary); });
+    }
+
+    SECTION("null read destination") {
+        index = std::make_shared<NullDestinationInnerIndex>();
+        auto data = std::shared_ptr<int8_t[]>(new int8_t[1]);
+        BinarySet binary;
+        binary.Set(index->GetName(), Binary{.data = data, .size = 1});
+
+        RequireReadError([&index, &binary]() { index->Deserialize(binary); });
+    }
+
+    SECTION("seek out of range") {
+        index = std::make_shared<SeekOutOfRangeInnerIndex>();
         auto data = std::shared_ptr<int8_t[]>(new int8_t[1]);
         BinarySet binary;
         binary.Set(index->GetName(), Binary{.data = data, .size = 1});

--- a/src/algorithm/inner_index_interface_test.cpp
+++ b/src/algorithm/inner_index_interface_test.cpp
@@ -15,6 +15,7 @@
 
 #include "inner_index_interface.h"
 
+#include <functional>
 #include <memory>
 #include <sstream>
 
@@ -23,6 +24,7 @@
 #include "impl/allocator/safe_allocator.h"
 #include "index_common_param.h"
 #include "unittest.h"
+#include "vsag_exception.h"
 
 using namespace vsag;
 
@@ -124,6 +126,32 @@ public:
     }
 };
 
+class ReadingInnerIndex : public EmptyInnerIndex {
+public:
+    std::string
+    GetName() const override {
+        return "ReadingInnerIndex";
+    }
+
+    void
+    Deserialize(StreamReader& reader) override {
+        uint64_t value = 0;
+        StreamReader::ReadObj(reader, value);
+    }
+};
+
+void
+RequireReadError(const std::function<void()>& func) {
+    bool got_read_error = false;
+    try {
+        func();
+    } catch (const VsagException& e) {
+        got_read_error = true;
+        REQUIRE(e.error_.type == ErrorType::READ_ERROR);
+    }
+    REQUIRE(got_read_error);
+}
+
 TEST_CASE("InnerIndexInterface NOT Implemented", "[ut][InnerIndexInterface]") {
     InnerIndexPtr empty_index = std::make_shared<EmptyInnerIndex>();
     IndexCommonParam common_param;
@@ -176,4 +204,29 @@ TEST_CASE("InnerIndexInterface NOT Implemented", "[ut][InnerIndexInterface]") {
     REQUIRE_THROWS(empty_index->KnnSearch(nullptr, 0, param));
 
     REQUIRE_NOTHROW(empty_index->GetIndexDetailInfos());
+}
+
+TEST_CASE("InnerIndexInterface rejects malformed binary set", "[ut][InnerIndexInterface]") {
+    InnerIndexPtr index = std::make_shared<ReadingInnerIndex>();
+
+    SECTION("missing index binary") {
+        BinarySet binary;
+
+        RequireReadError([&index, &binary]() { index->Deserialize(binary); });
+    }
+
+    SECTION("null non-empty index binary") {
+        BinarySet binary;
+        binary.Set(index->GetName(), Binary{.data = nullptr, .size = sizeof(uint64_t)});
+
+        RequireReadError([&index, &binary]() { index->Deserialize(binary); });
+    }
+
+    SECTION("truncated index binary") {
+        auto data = std::shared_ptr<int8_t[]>(new int8_t[1]);
+        BinarySet binary;
+        binary.Set(index->GetName(), Binary{.data = data, .size = 1});
+
+        RequireReadError([&index, &binary]() { index->Deserialize(binary); });
+    }
 }

--- a/src/algorithm/inner_index_interface_test.cpp
+++ b/src/algorithm/inner_index_interface_test.cpp
@@ -264,7 +264,7 @@ TEST_CASE("InnerIndexInterface rejects malformed binary set", "[ut][InnerIndexIn
     }
 
     SECTION("truncated index binary") {
-        auto data = std::shared_ptr<int8_t[]>(new int8_t[1]);
+        auto data = std::shared_ptr<int8_t[]>(new int8_t[1]{});
         BinarySet binary;
         binary.Set(index->GetName(), MakeBinary(data, 1));
 
@@ -273,7 +273,7 @@ TEST_CASE("InnerIndexInterface rejects malformed binary set", "[ut][InnerIndexIn
 
     SECTION("null read destination") {
         index = std::make_shared<NullDestinationInnerIndex>();
-        auto data = std::shared_ptr<int8_t[]>(new int8_t[1]);
+        auto data = std::shared_ptr<int8_t[]>(new int8_t[1]{});
         BinarySet binary;
         binary.Set(index->GetName(), MakeBinary(data, 1));
 
@@ -282,7 +282,7 @@ TEST_CASE("InnerIndexInterface rejects malformed binary set", "[ut][InnerIndexIn
 
     SECTION("seek out of range") {
         index = std::make_shared<SeekOutOfRangeInnerIndex>();
-        auto data = std::shared_ptr<int8_t[]>(new int8_t[1]);
+        auto data = std::shared_ptr<int8_t[]>(new int8_t[1]{});
         BinarySet binary;
         binary.Set(index->GetName(), MakeBinary(data, 1));
 


### PR DESCRIPTION
## Summary

Guard `InnerIndexInterface::Deserialize(const BinarySet&)` against malformed binary input before constructing the read callback.

The binary-set path now reports `READ_ERROR` for missing index data, null non-empty data, null read destinations, and out-of-range reads. Regression coverage exercises missing, null, and truncated index binary entries.

Fixes #1964.
Part of #1960.

## Validation

- `git diff --check`
- Fork PR CI: https://github.com/jac0626/vsag/actions/runs/25477024729
- Log scan: target `inner_index_interface.cpp` runtime error is gone in this branch; remaining runtime errors are existing issues tracked separately (`fast_bitset.cpp`, `sparse_term_datacell.cpp`, `hnswalg.*`).

## Notes

Local macOS rebuild was blocked by the existing CMake configuration error: `gcc does not support using libc++`.
