### PR TITLE
fix: skip missing sparse term lists

### DIFF
--- a/src/datacell/sparse_term_datacell.cpp
+++ b/src/datacell/sparse_term_datacell.cpp
@@ -144,14 +144,16 @@ SparseTermDataCell::InsertHeapByTermLists(float* dists,
     while (computer->HasNextTerm()) {
         auto it = computer->NextTermIter();
         auto term = computer->GetTerm(it);
-        if (term >= term_ids_.size()) {
+        if (term >= term_ids_.size() || term >= term_sizes_.size() || term_sizes_[term] == 0 ||
+            term_ids_[term] == nullptr) {
             continue;
         }
 
         uint32_t i = 0;
+        auto& one_term_ids = *term_ids_[term];
         auto term_size = static_cast<uint32_t>(static_cast<float>(term_sizes_[term]) *
                                                computer->term_retain_ratio_);
-        auto& one_term_ids = *term_ids_[term];
+        term_size = std::min<uint32_t>(term_size, one_term_ids.size());
         if constexpr (mode == InnerSearchMode::KNN_SEARCH) {
             if (heap.size() < n_candidate) {
                 for (; i < term_size; i++) {

--- a/src/datacell/sparse_term_datacell.cpp
+++ b/src/datacell/sparse_term_datacell.cpp
@@ -154,8 +154,9 @@ SparseTermDataCell::InsertHeapByTermLists(float* dists,
         auto& one_term_ids = *term_ids_[term];
         auto term_size = static_cast<uint32_t>(static_cast<float>(term_sizes_[term]) *
                                                computer->term_retain_ratio_);
-        auto max_term_size = static_cast<uint32_t>(std::min(
-            one_term_ids.size(), static_cast<size_t>(std::numeric_limits<uint32_t>::max())));
+        auto max_term_size = static_cast<uint32_t>(
+            std::min<size_t>(static_cast<size_t>(one_term_ids.size()),
+                             static_cast<size_t>(std::numeric_limits<uint32_t>::max())));
         term_size = std::min(term_size, max_term_size);
         if constexpr (mode == InnerSearchMode::KNN_SEARCH) {
             if (heap.size() < n_candidate) {

--- a/src/datacell/sparse_term_datacell.cpp
+++ b/src/datacell/sparse_term_datacell.cpp
@@ -154,8 +154,8 @@ SparseTermDataCell::InsertHeapByTermLists(float* dists,
         auto& one_term_ids = *term_ids_[term];
         auto term_size = static_cast<uint32_t>(static_cast<float>(term_sizes_[term]) *
                                                computer->term_retain_ratio_);
-        auto max_term_size = static_cast<uint32_t>(
-            std::min<uint64_t>(one_term_ids.size(), std::numeric_limits<uint32_t>::max()));
+        auto max_term_size = static_cast<uint32_t>(std::min(
+            one_term_ids.size(), static_cast<size_t>(std::numeric_limits<uint32_t>::max())));
         term_size = std::min(term_size, max_term_size);
         if constexpr (mode == InnerSearchMode::KNN_SEARCH) {
             if (heap.size() < n_candidate) {

--- a/src/datacell/sparse_term_datacell.cpp
+++ b/src/datacell/sparse_term_datacell.cpp
@@ -152,12 +152,16 @@ SparseTermDataCell::InsertHeapByTermLists(float* dists,
 
         uint32_t i = 0;
         auto& one_term_ids = *term_ids_[term];
-        auto term_size = static_cast<uint32_t>(static_cast<float>(term_sizes_[term]) *
-                                               computer->term_retain_ratio_);
         auto max_term_size = static_cast<uint32_t>(
             std::min<size_t>(static_cast<size_t>(one_term_ids.size()),
                              static_cast<size_t>(std::numeric_limits<uint32_t>::max())));
-        term_size = std::min(term_size, max_term_size);
+        auto retained_term_size =
+            static_cast<double>(term_sizes_[term]) * computer->term_retain_ratio_;
+        uint32_t term_size = 0;
+        if (retained_term_size > 0.0) {
+            term_size = static_cast<uint32_t>(
+                std::min(retained_term_size, static_cast<double>(max_term_size)));
+        }
         if constexpr (mode == InnerSearchMode::KNN_SEARCH) {
             if (heap.size() < n_candidate) {
                 for (; i < term_size; i++) {

--- a/src/datacell/sparse_term_datacell.cpp
+++ b/src/datacell/sparse_term_datacell.cpp
@@ -152,16 +152,13 @@ SparseTermDataCell::InsertHeapByTermLists(float* dists,
 
         uint32_t i = 0;
         auto& one_term_ids = *term_ids_[term];
-        auto max_term_size = static_cast<uint32_t>(
-            std::min<size_t>(static_cast<size_t>(one_term_ids.size()),
-                             static_cast<size_t>(std::numeric_limits<uint32_t>::max())));
+        auto max_term_size = static_cast<uint32_t>(std::min<uint64_t>(
+            one_term_ids.size(), static_cast<uint64_t>(std::numeric_limits<uint32_t>::max())));
         auto retained_term_size =
             static_cast<double>(term_sizes_[term]) * computer->term_retain_ratio_;
-        uint32_t term_size = 0;
-        if (retained_term_size > 0.0) {
-            term_size = static_cast<uint32_t>(
-                std::min(retained_term_size, static_cast<double>(max_term_size)));
-        }
+        auto clamped_term_size =
+            std::clamp(retained_term_size, 0.0, static_cast<double>(max_term_size));
+        auto term_size = static_cast<uint32_t>(clamped_term_size);
         if constexpr (mode == InnerSearchMode::KNN_SEARCH) {
             if (heap.size() < n_candidate) {
                 for (; i < term_size; i++) {

--- a/src/datacell/sparse_term_datacell.cpp
+++ b/src/datacell/sparse_term_datacell.cpp
@@ -17,6 +17,7 @@
 
 #include <algorithm>
 #include <cstring>
+#include <limits>
 
 #include "simd/fp16_simd.h"
 #include "utils/util_functions.h"
@@ -153,7 +154,9 @@ SparseTermDataCell::InsertHeapByTermLists(float* dists,
         auto& one_term_ids = *term_ids_[term];
         auto term_size = static_cast<uint32_t>(static_cast<float>(term_sizes_[term]) *
                                                computer->term_retain_ratio_);
-        term_size = std::min<uint32_t>(term_size, one_term_ids.size());
+        auto max_term_size = static_cast<uint32_t>(
+            std::min<uint64_t>(one_term_ids.size(), std::numeric_limits<uint32_t>::max()));
+        term_size = std::min(term_size, max_term_size);
         if constexpr (mode == InnerSearchMode::KNN_SEARCH) {
             if (heap.size() < n_candidate) {
                 for (; i < term_size; i++) {

--- a/src/datacell/sparse_term_datacell_test.cpp
+++ b/src/datacell/sparse_term_datacell_test.cpp
@@ -439,16 +439,16 @@ TEST_CASE("SparseTermDatacell handles missing term lists", "[ut][SparseTermDatac
 
     std::vector<uint32_t> query_ids = {1};
     std::vector<float> query_vals = {1.0F};
-    SparseVector query;
+    SparseVector query{};
     query.len_ = static_cast<uint32_t>(query_ids.size());
     query.ids_ = query_ids.data();
     query.vals_ = query_vals.data();
 
-    SINDISearchParameter search_params;
+    SINDISearchParameter search_params{};
     search_params.term_prune_ratio = 0;
     search_params.query_prune_ratio = 0;
 
-    InnerSearchParam inner_param;
+    InnerSearchParam inner_param{};
     inner_param.ef = 2;
 
     SECTION("null term list is skipped") {

--- a/src/datacell/sparse_term_datacell_test.cpp
+++ b/src/datacell/sparse_term_datacell_test.cpp
@@ -451,15 +451,21 @@ TEST_CASE("SparseTermDatacell handles missing term lists", "[ut][SparseTermDatac
     InnerSearchParam inner_param{};
     inner_param.ef = 2;
 
-    SECTION("null term list is skipped") {
-        data_cell->term_ids_[1].reset();
-        data_cell->term_sizes_[1] = 1;
+    auto search = [&]() {
         auto computer = std::make_shared<SparseTermComputer>(query, search_params, allocator.get());
         std::vector<float> dists(1, -1.0F);
         MaxHeap heap(allocator.get());
 
         data_cell->InsertHeapByTermLists<KNN_SEARCH, PURE>(
             dists.data(), computer, heap, inner_param, 0);
+
+        return heap;
+    };
+
+    SECTION("null term list is skipped") {
+        data_cell->term_ids_[1].reset();
+        data_cell->term_sizes_[1] = 1;
+        auto heap = search();
 
         REQUIRE(heap.empty());
     }
@@ -468,12 +474,7 @@ TEST_CASE("SparseTermDatacell handles missing term lists", "[ut][SparseTermDatac
         data_cell->term_ids_[1] = std::make_unique<Vector<uint16_t>>(allocator.get());
         data_cell->term_ids_[1]->push_back(0);
         data_cell->term_sizes_[1] = 2;
-        auto computer = std::make_shared<SparseTermComputer>(query, search_params, allocator.get());
-        std::vector<float> dists(1, -1.0F);
-        MaxHeap heap(allocator.get());
-
-        data_cell->InsertHeapByTermLists<KNN_SEARCH, PURE>(
-            dists.data(), computer, heap, inner_param, 0);
+        auto heap = search();
 
         REQUIRE(heap.size() == 1);
         REQUIRE(heap.top().second == 0);

--- a/src/datacell/sparse_term_datacell_test.cpp
+++ b/src/datacell/sparse_term_datacell_test.cpp
@@ -452,6 +452,7 @@ TEST_CASE("SparseTermDatacell handles missing term lists", "[ut][SparseTermDatac
     inner_param.ef = 2;
 
     SECTION("null term list is skipped") {
+        data_cell->term_ids_[1].reset();
         data_cell->term_sizes_[1] = 1;
         auto computer = std::make_shared<SparseTermComputer>(query, search_params, allocator.get());
         std::vector<float> dists(1, -1.0F);

--- a/src/datacell/sparse_term_datacell_test.cpp
+++ b/src/datacell/sparse_term_datacell_test.cpp
@@ -431,6 +431,54 @@ TEST_CASE("SparseTermDatacell Deserialize Clears Stale Posting Lists", "[ut][Spa
     REQUIRE(stale.term_ids_.size() == 2);
 }
 
+TEST_CASE("SparseTermDatacell handles missing term lists", "[ut][SparseTermDatacell]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    auto data_cell = std::make_shared<SparseTermDataCell>(
+        1.0F, DEFAULT_TERM_ID_LIMIT, allocator.get(), SparseValueQuantizationType::FP32, nullptr);
+    data_cell->ResizeTermList(2);
+
+    std::vector<uint32_t> query_ids = {1};
+    std::vector<float> query_vals = {1.0F};
+    SparseVector query;
+    query.len_ = static_cast<uint32_t>(query_ids.size());
+    query.ids_ = query_ids.data();
+    query.vals_ = query_vals.data();
+
+    SINDISearchParameter search_params;
+    search_params.term_prune_ratio = 0;
+    search_params.query_prune_ratio = 0;
+
+    InnerSearchParam inner_param;
+    inner_param.ef = 2;
+
+    SECTION("null term list is skipped") {
+        data_cell->term_sizes_[1] = 1;
+        auto computer = std::make_shared<SparseTermComputer>(query, search_params, allocator.get());
+        std::vector<float> dists(1, -1.0F);
+        MaxHeap heap(allocator.get());
+
+        data_cell->InsertHeapByTermLists<KNN_SEARCH, PURE>(
+            dists.data(), computer, heap, inner_param, 0);
+
+        REQUIRE(heap.empty());
+    }
+
+    SECTION("oversized term size is clamped to the term list") {
+        data_cell->term_ids_[1] = std::make_unique<Vector<uint16_t>>(allocator.get());
+        data_cell->term_ids_[1]->push_back(0);
+        data_cell->term_sizes_[1] = 2;
+        auto computer = std::make_shared<SparseTermComputer>(query, search_params, allocator.get());
+        std::vector<float> dists(1, -1.0F);
+        MaxHeap heap(allocator.get());
+
+        data_cell->InsertHeapByTermLists<KNN_SEARCH, PURE>(
+            dists.data(), computer, heap, inner_param, 0);
+
+        REQUIRE(heap.size() == 1);
+        REQUIRE(heap.top().second == 0);
+    }
+}
+
 TEST_CASE("SparseTermDatacell Last Term Test", "[ut][SparseTermDatacell]") {
     auto allocator = SafeAllocator::FactoryDefaultAllocator();
 


### PR DESCRIPTION
## Summary

Skip missing sparse-term posting lists in `SparseTermDataCell::InsertHeapByTermLists`.

The search path now ignores terms whose posting-list pointer is absent and clamps retained term size to the actual posting-list length before indexing. Regression coverage exercises both a null term list and an oversized recorded term size.

Fixes #1965.
Part of #1960.

## Validation

- `git diff --check`
- Fork PR CI: https://github.com/jac0626/vsag/actions/runs/25477108783
- Log scan: target `sparse_term_datacell.cpp` runtime error is gone in this branch.

## Known CI State

The fork PR CI run failed in `Test X86 Functests` on an unrelated HNSW recall assertion:

`tests/test_index.cpp:535: REQUIRE( cur_recall > expected_recall * query_count * RECALL_THRESHOLD )`, with `nanf > 72.25f`.

The same log still contains existing non-target runtime errors from `fast_bitset.cpp` and `inner_index_interface.cpp`, which are handled by separate PRs.

## Notes

Local macOS rebuild was blocked by the existing CMake configuration error: `gcc does not support using libc++`.
