### PR TITLE
fix: make public headers self-contained

### DIFF
--- a/include/vsag/allocator.h
+++ b/include/vsag/allocator.h
@@ -14,7 +14,11 @@
 
 #pragma once
 
+#include <cstdint>
+#include <exception>
+#include <new>
 #include <string>
+#include <utility>
 
 namespace vsag {
 

--- a/include/vsag/errors.h
+++ b/include/vsag/errors.h
@@ -18,6 +18,9 @@
 #include <string>
 #include <utility>
 
+#include "vsag/expected.hpp"
+#include "vsag/options.h"
+
 namespace vsag {
 
 enum class ErrorType {
@@ -65,10 +68,12 @@ _concatenate(std::stringstream& ss, const T& value, const Args&... args) {
     _concatenate(ss, args...);
 }
 
-#define LOG_ERROR_AND_RETURNS(t, ...) \
-    std::stringstream ss;             \
-    _concatenate(ss, __VA_ARGS__);    \
-    logger::error(ss.str());          \
+#define LOG_ERROR_AND_RETURNS(t, ...)                  \
+    std::stringstream ss;                              \
+    _concatenate(ss, __VA_ARGS__);                     \
+    if (auto* logger = Options::Instance().logger()) { \
+        logger->Error(ss.str());                       \
+    }                                                  \
     return tl::unexpected(Error(t, ss.str()));
 
 }  //namespace vsag

--- a/include/vsag/factory.h
+++ b/include/vsag/factory.h
@@ -14,13 +14,18 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
+#include <string>
 
 #include "vsag/allocator.h"
-#include "vsag/index.h"
-#include "vsag/readerset.h"
+#include "vsag/errors.h"
+#include "vsag/expected.hpp"
 
 namespace vsag {
+
+class Index;
+class Reader;
 
 class Factory {
 public:

--- a/include/vsag/filter.h
+++ b/include/vsag/filter.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
 
 namespace vsag {

--- a/include/vsag/index.h
+++ b/include/vsag/index.h
@@ -16,9 +16,17 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
+#include <iosfwd>
 #include <limits>
+#include <memory>
 #include <stdexcept>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
 
+#include "vsag/allocator.h"
 #include "vsag/binaryset.h"
 #include "vsag/bitset.h"
 #include "vsag/dataset.h"

--- a/include/vsag/search_request.h
+++ b/include/vsag/search_request.h
@@ -18,6 +18,7 @@
 #include <string>
 #include <vector>
 
+#include "vsag/allocator.h"
 #include "vsag/bitset.h"
 #include "vsag/dataset.h"
 #include "vsag/filter.h"


### PR DESCRIPTION
## Summary
- add direct standard and project includes to public headers that relied on transitive includes
- replace heavyweight includes in factory.h with forward declarations for Index and Reader
- keep public API behavior unchanged while making these headers safer to include in isolation
