### PR TITLE
fix: avoid unaligned hnsw link access

### DIFF
--- a/src/algorithm/hnswlib/hnswalg.cpp
+++ b/src/algorithm/hnswlib/hnswalg.cpp
@@ -316,7 +316,7 @@ HierarchicalNSW::setBatchNeigohborsNoLock(InnerIdType internal_id,
                                           const InnerIdType* neighbors,
                                           uint64_t neigbor_count) {
     linklistsizeint* ll_cur = getLinklistAtLevel(internal_id, level);
-    for (int i = 1; i <= neigbor_count; ++i) {
+    for (uint64_t i = 1; i <= neigbor_count; ++i) {
         setLinkAt(ll_cur, i, neighbors[i - 1]);
     }
 
@@ -1553,7 +1553,8 @@ HierarchicalNSW::removePoint(LabelType label) {
         }
 
         for (int i = 0; i < size_cur; ++i) {
-            getEdges(getLinkAt(data_cur, i + 1), level).erase(cur_c);
+            auto neighbor = getLinkAt(data_cur, i + 1);
+            getEdges(neighbor, level).erase(cur_c);
         }
     }
 }

--- a/src/algorithm/hnswlib/hnswalg.cpp
+++ b/src/algorithm/hnswlib/hnswalg.cpp
@@ -1381,16 +1381,16 @@ HierarchicalNSW::dealNoInEdge(InnerIdType id, int level, int m_curmax, int skip_
     int alone_size = getListCount(alone_data);
     auto& in_edges = getEdges(id, level);
     for (int j = 0; j < alone_size; ++j) {
-        auto alone_link = getLinkAt(alone_data, j + 1);
-        if (alone_link == skip_c) {
+        auto neighbor_id = getLinkAt(alone_data, j + 1);
+        if (neighbor_id == skip_c) {
             continue;
         }
-        auto to_edge_data_cur = getLinklistAtLevel(alone_link, level);
+        auto to_edge_data_cur = getLinklistAtLevel(neighbor_id, level);
         int to_edge_size_cur = getListCount(to_edge_data_cur);
         if (to_edge_size_cur < m_curmax) {
             setLinkAt(to_edge_data_cur, to_edge_size_cur + 1, id);
             setListCount(to_edge_data_cur, to_edge_size_cur + 1);
-            in_edges.insert(alone_link);
+            in_edges.insert(neighbor_id);
         }
     }
 }

--- a/src/algorithm/hnswlib/hnswalg.cpp
+++ b/src/algorithm/hnswlib/hnswalg.cpp
@@ -232,11 +232,11 @@ HierarchicalNSW::getNeighborsInternalId(uint32_t internal_id,
                                         vsag::Vector<InnerIdType>& neighbor_ids) {
     vsag::Vector<uint32_t> neighbors_id(allocator_);
 
-    int* data = (int*)get_linklist0(internal_id);
-    uint32_t size = getListCount((hnswlib::linklistsizeint*)data);
+    auto* data = get_linklist0(internal_id);
+    uint32_t size = getListCount(data);
     neighbor_ids.resize(size);
     for (uint32_t i = 0; i < size; i++) {
-        neighbor_ids[i] = *(data + i + 1);
+        neighbor_ids[i] = getLinkAt(data, i + 1);
     }
 }
 
@@ -317,7 +317,7 @@ HierarchicalNSW::setBatchNeigohborsNoLock(InnerIdType internal_id,
                                           uint64_t neigbor_count) {
     linklistsizeint* ll_cur = getLinklistAtLevel(internal_id, level);
     for (int i = 1; i <= neigbor_count; ++i) {
-        ll_cur[i] = neighbors[i - 1];
+        setLinkAt(ll_cur, i, neighbors[i - 1]);
     }
 
     setListCount(ll_cur, neigbor_count);
@@ -340,7 +340,7 @@ HierarchicalNSW::appendNeigohborNoLock(InnerIdType internal_id,
     linklistsizeint* ll_cur = getLinklistAtLevel(internal_id, level);
     uint64_t neigbor_count = getListCount(ll_cur) + 1;
     if (neigbor_count <= max_degree) {
-        ll_cur[neigbor_count] = neighbor;
+        setLinkAt(ll_cur, neigbor_count, neighbor);
         setListCount(ll_cur, neigbor_count);
     }
 }
@@ -1095,15 +1095,15 @@ HierarchicalNSW::DeserializeImpl(StreamReader& reader, SpaceInterface* s, uint64
 
     // step 1, try to parse/read with the newer serial format
     reader.Read(raw_buffer, newer_format_size);
-    enterpoint_node_ = *(InnerIdType*)(raw_buffer);
-    maxM_ = *(uint64_t*)(raw_buffer + sizeof(InnerIdType));
+    enterpoint_node_ = readUnaligned<InnerIdType>(raw_buffer);
+    maxM_ = readUnaligned<uint64_t>(raw_buffer + sizeof(InnerIdType));
     bool is_newer_format = (M_ == maxM_);
 
     // step 2, try to read with the older serial format
     if (not is_newer_format) {
         reader.Read(raw_buffer + newer_format_size, buffer_size - newer_format_size);
-        enterpoint_node_ = *(int64_t*)(raw_buffer);
-        maxM_ = *(uint64_t*)(raw_buffer + sizeof(int64_t));
+        enterpoint_node_ = static_cast<InnerIdType>(readUnaligned<int64_t>(raw_buffer));
+        maxM_ = readUnaligned<uint64_t>(raw_buffer + sizeof(int64_t));
         if (M_ != maxM_) {
             // this condition will be true only when the parameter used in create_index is not equal
             // to the parameter of the serialized index
@@ -1298,10 +1298,9 @@ HierarchicalNSW::modifyOutEdge(InnerIdType old_internal_id, InnerIdType new_inte
         for (const auto& in_node : edges) {
             auto data = getLinklistAtLevel(in_node, level);
             uint64_t link_size = getListCount(data);
-            auto* links = (InnerIdType*)(data + 1);
             for (int i = 0; i < link_size; ++i) {
-                if (links[i] == old_internal_id) {
-                    links[i] = new_internal_id;
+                if (getLinkAt(data, i + 1) == old_internal_id) {
+                    setLinkAt(data, i + 1, new_internal_id);
                     break;
                 }
             }
@@ -1316,9 +1315,8 @@ HierarchicalNSW::modifyInEdges(InnerIdType right_internal_id,
     for (int level = 0; level <= element_levels_[right_internal_id]; ++level) {
         auto data = getLinklistAtLevel(right_internal_id, level);
         uint64_t link_size = getListCount(data);
-        auto* links = (InnerIdType*)(data + 1);
         for (int i = 0; i < link_size; ++i) {
-            auto& in_edges = getEdges(links[i], level);
+            auto& in_edges = getEdges(getLinkAt(data, i + 1), level);
             if (is_erase) {
                 in_edges.erase(wrong_internal_id);
             } else {
@@ -1381,19 +1379,18 @@ HierarchicalNSW::dealNoInEdge(InnerIdType id, int level, int m_curmax, int skip_
     // Establish edges from the neighbors of the id pointing to the id.
     auto alone_data = getLinklistAtLevel(id, level);
     int alone_size = getListCount(alone_data);
-    auto alone_link = (unsigned int*)(alone_data + 1);
     auto& in_edges = getEdges(id, level);
     for (int j = 0; j < alone_size; ++j) {
-        if (alone_link[j] == skip_c) {
+        auto alone_link = getLinkAt(alone_data, j + 1);
+        if (alone_link == skip_c) {
             continue;
         }
-        auto to_edge_data_cur = (unsigned int*)getLinklistAtLevel(alone_link[j], level);
+        auto to_edge_data_cur = getLinklistAtLevel(alone_link, level);
         int to_edge_size_cur = getListCount(to_edge_data_cur);
-        auto to_edge_data_link_cur = (unsigned int*)(to_edge_data_cur + 1);
         if (to_edge_size_cur < m_curmax) {
-            to_edge_data_link_cur[to_edge_size_cur] = id;
+            setLinkAt(to_edge_data_cur, to_edge_size_cur + 1, id);
             setListCount(to_edge_data_cur, to_edge_size_cur + 1);
-            in_edges.insert(alone_link[j]);
+            in_edges.insert(alone_link);
         }
     }
 }
@@ -1488,11 +1485,11 @@ HierarchicalNSW::removePoint(LabelType label) {
     // If the node to be deleted is an entry node, find another top-level node.
     if (cur_c == enterpoint_node_) {
         for (int level = max_level_; level >= 0; level--) {
-            auto data = (unsigned int*)getLinklistAtLevel(enterpoint_node_, level);
+            auto data = getLinklistAtLevel(enterpoint_node_, level);
             int size = getListCount(data);
             if (size != 0) {
                 max_level_ = level;
-                enterpoint_node_ = *(data + 1);
+                enterpoint_node_ = getLinkAt(data, 1);
                 break;
             }
         }
@@ -1505,7 +1502,6 @@ HierarchicalNSW::removePoint(LabelType label) {
         const auto in_edges_cur = getEdges(cur_c, level);
         auto data_cur = getLinklistAtLevel(cur_c, level);
         int size_cur = getListCount(data_cur);
-        auto data_link_cur = (unsigned int*)(data_cur + 1);
 
         for (const auto in_edge : in_edges_cur) {
             MaxHeap candidates(allocator_);
@@ -1513,30 +1509,30 @@ HierarchicalNSW::removePoint(LabelType label) {
 
             // Add the original neighbors of the indegree node to the candidate queue.
             for (int i = 0; i < size_cur; ++i) {
-                if (data_link_cur[i] == cur_c || data_link_cur[i] == in_edge) {
+                auto neighbor = getLinkAt(data_cur, i + 1);
+                if (neighbor == cur_c || neighbor == in_edge) {
                     continue;
                 }
-                unique_ids.insert(data_link_cur[i]);
-                candidates.emplace(fstdistfunc_(getDataByInternalId(data_link_cur[i]),
+                unique_ids.insert(neighbor);
+                candidates.emplace(fstdistfunc_(getDataByInternalId(neighbor),
                                                 getDataByInternalId(in_edge),
                                                 dist_func_param_),
-                                   data_link_cur[i]);
+                                   neighbor);
             }
 
             // Add the neighbors of the node to be deleted to the candidate queue.
-            auto in_edge_data_cur = (unsigned int*)getLinklistAtLevel(in_edge, level);
+            auto in_edge_data_cur = getLinklistAtLevel(in_edge, level);
             int in_edge_size_cur = getListCount(in_edge_data_cur);
-            auto in_edge_data_link_cur = (unsigned int*)(in_edge_data_cur + 1);
             for (int i = 0; i < in_edge_size_cur; ++i) {
-                if (in_edge_data_link_cur[i] == cur_c ||
-                    unique_ids.find(in_edge_data_link_cur[i]) != unique_ids.end()) {
+                auto neighbor = getLinkAt(in_edge_data_cur, i + 1);
+                if (neighbor == cur_c || unique_ids.find(neighbor) != unique_ids.end()) {
                     continue;
                 }
-                unique_ids.insert(in_edge_data_link_cur[i]);
-                candidates.emplace(fstdistfunc_(getDataByInternalId(in_edge_data_link_cur[i]),
+                unique_ids.insert(neighbor);
+                candidates.emplace(fstdistfunc_(getDataByInternalId(neighbor),
                                                 getDataByInternalId(in_edge),
                                                 dist_func_param_),
-                                   in_edge_data_link_cur[i]);
+                                   neighbor);
             }
 
             if (candidates.empty()) {
@@ -1557,7 +1553,7 @@ HierarchicalNSW::removePoint(LabelType label) {
         }
 
         for (int i = 0; i < size_cur; ++i) {
-            getEdges(data_link_cur[i], level).erase(cur_c);
+            getEdges(getLinkAt(data_cur, i + 1), level).erase(cur_c);
         }
     }
 }

--- a/src/algorithm/hnswlib/hnswalg.h
+++ b/src/algorithm/hnswlib/hnswalg.h
@@ -422,14 +422,48 @@ public:
         return *ll_cur & DELETE_MARK;
     }
 
+    template <typename T>
+    static inline T
+    readUnaligned(const void* ptr) {
+        T value;
+        std::memcpy(&value, ptr, sizeof(T));
+        return value;
+    }
+
+    template <typename T>
+    static inline void
+    writeUnaligned(void* ptr, T value) {
+        std::memcpy(ptr, &value, sizeof(T));
+    }
+
+    static inline const char*
+    linkWordPtr(const linklistsizeint* ptr, uint64_t index) {
+        return reinterpret_cast<const char*>(ptr) + index * sizeof(linklistsizeint);
+    }
+
+    static inline char*
+    linkWordPtr(linklistsizeint* ptr, uint64_t index) {
+        return reinterpret_cast<char*>(ptr) + index * sizeof(linklistsizeint);
+    }
+
     static inline unsigned short int
     getListCount(const linklistsizeint* ptr) {
-        return *((unsigned short int*)ptr);
+        return readUnaligned<unsigned short int>(ptr);
     }
 
     static inline void
     setListCount(linklistsizeint* ptr, unsigned short int size) {
-        *((unsigned short int*)(ptr)) = size;
+        writeUnaligned<unsigned short int>(ptr, size);
+    }
+
+    static inline InnerIdType
+    getLinkAt(const linklistsizeint* ptr, uint64_t index) {
+        return readUnaligned<InnerIdType>(linkWordPtr(ptr, index));
+    }
+
+    static inline void
+    setLinkAt(linklistsizeint* ptr, uint64_t index, InnerIdType value) {
+        writeUnaligned<InnerIdType>(linkWordPtr(ptr, index), value);
     }
 
     /*

--- a/src/algorithm/hnswlib/hnswalg.h
+++ b/src/algorithm/hnswlib/hnswalg.h
@@ -29,6 +29,7 @@
 #include <random>
 #include <shared_mutex>
 #include <stdexcept>
+#include <type_traits>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -425,6 +426,7 @@ public:
     template <typename T>
     static inline T
     readUnaligned(const void* ptr) {
+        static_assert(std::is_trivially_copyable<T>::value, "T must be trivially copyable");
         T value;
         std::memcpy(&value, ptr, sizeof(T));
         return value;
@@ -433,8 +435,12 @@ public:
     template <typename T>
     static inline void
     writeUnaligned(void* ptr, T value) {
+        static_assert(std::is_trivially_copyable<T>::value, "T must be trivially copyable");
         std::memcpy(ptr, &value, sizeof(T));
     }
+
+    static_assert(sizeof(InnerIdType) == sizeof(linklistsizeint),
+                  "HNSW link-list storage uses linklistsizeint-sized neighbor words");
 
     static inline const char*
     linkWordPtr(const linklistsizeint* ptr, uint64_t index) {

--- a/src/index/hnsw_test.cpp
+++ b/src/index/hnsw_test.cpp
@@ -15,7 +15,9 @@
 
 #include "hnsw.h"
 
+#include <array>
 #include <cstdlib>
+#include <cstdint>
 #include <memory>
 #include <new>
 #include <nlohmann/json.hpp>
@@ -116,6 +118,19 @@ TEST_CASE("build with allocator", "[ut][hnsw]") {
         ->Owner(false);
     auto result = index->Build(dataset);
     REQUIRE(result.has_value());
+}
+
+TEST_CASE("hnsw unaligned link helpers", "[ut][hnsw]") {
+    std::array<uint8_t, sizeof(uint64_t) + 1> buffer{};
+    auto* unaligned_ptr = buffer.data() + 1;
+
+    constexpr uint64_t encoded_value = 0x0102030405060708ULL;
+    hnswlib::HierarchicalNSW::writeUnaligned<uint64_t>(unaligned_ptr, encoded_value);
+    REQUIRE(hnswlib::HierarchicalNSW::readUnaligned<uint64_t>(unaligned_ptr) == encoded_value);
+
+    constexpr InnerIdType neighbor_id = 12345;
+    hnswlib::HierarchicalNSW::writeUnaligned<InnerIdType>(unaligned_ptr, neighbor_id);
+    REQUIRE(hnswlib::HierarchicalNSW::readUnaligned<InnerIdType>(unaligned_ptr) == neighbor_id);
 }
 
 TEST_CASE("knn_search", "[ut][hnsw]") {

--- a/src/index/hnsw_test.cpp
+++ b/src/index/hnsw_test.cpp
@@ -16,8 +16,8 @@
 #include "hnsw.h"
 
 #include <array>
-#include <cstdlib>
 #include <cstdint>
+#include <cstdlib>
 #include <memory>
 #include <new>
 #include <nlohmann/json.hpp>


### PR DESCRIPTION
## Summary

Fixes #1962.

This PR removes undefined behavior from HNSW packed link-list access by replacing direct typed loads/stores on potentially unaligned graph memory with small inline `std::memcpy` accessors.

## Root Cause

HNSW stores link-list counts and neighbor ids in a packed byte layout. Some access paths cast those byte addresses to `linklistsizeint*`, `unsigned short*`, or integer pointers and dereference them directly. UBSan reports this as misaligned load/store even when the code happens to work on x86 hardware.

## Changes

- Use inline unaligned scalar load/store helpers for list count access.
- Use the same helpers for direct neighbor id reads/writes on packed link-list memory.
- Parse serialized HNSW header fields from `char` buffers via `std::memcpy` instead of typed pointer casts.
- Preserve the existing in-memory and serialized layout.

## Validation

- Ran `clang-format` 15 on the changed HNSW files.
- Ran `git diff --check`.
- Did not add new tests; the existing ASan/UBSan functest path already exposes this issue, so CI should validate that the HNSW unaligned runtime errors disappear.
