### PR TITLE
refactor: deduplicate hgraph and ivf functests

### DIFF
--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -306,6 +306,54 @@ HGraphTestIndex::TestMemoryUsageDetail(const IndexPtr& index) {
 }
 }  // namespace fixtures
 
+namespace {
+
+template <typename Fn>
+void
+RunWithGeneratedBlockSizeLimit(Fn&& fn) {
+    const auto origin_size = vsag::Options::Instance().block_size_limit();
+    const auto size = GENERATE(1024 * 1024 * 2);
+    vsag::Options::Instance().set_block_size_limit(size);
+    fn();
+    vsag::Options::Instance().set_block_size_limit(origin_size);
+}
+
+template <typename Cases, typename Fn>
+void
+ForEachHGraphCase(const fixtures::HGraphResourcePtr& resource, const Cases& test_cases, Fn&& fn) {
+    for (const auto& metric_type : resource->metric_types) {
+        for (auto raw_dim : resource->dims) {
+            for (const auto& [base_quantization_str, recall] : test_cases) {
+                auto dim = raw_dim;
+                INFO(fmt::format("metric_type: {}, dim: {}, base_quantization_str: {}, recall: {}",
+                                 metric_type,
+                                 dim,
+                                 base_quantization_str,
+                                 recall));
+                if (fixtures::HGraphTestIndex::IsRaBitQ(base_quantization_str) &&
+                    dim < fixtures::RABITQ_MIN_RACALL_DIM) {
+                    dim = fixtures::RABITQ_MIN_RACALL_DIM;
+                }
+                fn(metric_type, dim, base_quantization_str, recall);
+            }
+        }
+    }
+}
+
+#define HGRAPH_PR_DAILY_CASE(title, tags, helper)                        \
+    TEST_CASE("(PR) " title, tags "[pr]") {                              \
+        auto test_index = std::make_shared<fixtures::HGraphTestIndex>(); \
+        auto resource = test_index->GetResource(true);                   \
+        helper(test_index, resource);                                    \
+    }                                                                    \
+    TEST_CASE("(Daily) " title, tags "[daily]") {                        \
+        auto test_index = std::make_shared<fixtures::HGraphTestIndex>(); \
+        auto resource = test_index->GetResource(false);                  \
+        helper(test_index, resource);                                    \
+    }
+
+}  // namespace
+
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::HGraphTestIndex,
                              "HGraph Factory Test With Exceptions",
                              "[ft][hgraph]") {
@@ -515,22 +563,12 @@ static void
 TestHGraphBuildAndContinueAdd(const fixtures::HGraphTestIndexPtr& test_index,
                               const fixtures::HGraphResourcePtr& resource) {
     using namespace fixtures;
-    auto origin_size = vsag::Options::Instance().block_size_limit();
-    auto size = GENERATE(1024 * 1024 * 2);
     auto search_param = fmt::format(fixtures::search_param_tmp, 200, false);
-    for (auto metric_type : resource->metric_types) {
-        for (auto dim : resource->dims) {
-            for (auto& [base_quantization_str, recall] : resource->test_cases) {
-                INFO(fmt::format("metric_type: {}, dim: {}, base_quantization_str: {}, recall: {}",
-                                 metric_type,
-                                 dim,
-                                 base_quantization_str,
-                                 recall));
-                if (HGraphTestIndex::IsRaBitQ(base_quantization_str) &&
-                    dim < fixtures::RABITQ_MIN_RACALL_DIM) {
-                    dim = fixtures::RABITQ_MIN_RACALL_DIM;
-                }
-                vsag::Options::Instance().set_block_size_limit(size);
+    ForEachHGraphCase(
+        resource,
+        resource->test_cases,
+        [&](const auto& metric_type, int64_t dim, const auto& base_quantization_str, float recall) {
+            RunWithGeneratedBlockSizeLimit([&] {
                 HGraphTestIndex::HGraphBuildParam build_param(
                     metric_type, dim, base_quantization_str);
                 auto param = HGraphTestIndex::GenerateHGraphBuildParametersString(build_param);
@@ -540,23 +578,13 @@ TestHGraphBuildAndContinueAdd(const fixtures::HGraphTestIndexPtr& test_index,
                 TestIndex::TestContinueAdd(index, dataset, true);
                 HGraphTestIndex::TestGeneral(index, dataset, search_param, recall);
                 TestIndex::TestIndexDetailData(index);
-                vsag::Options::Instance().set_block_size_limit(origin_size);
-            }
-        }
-    }
+            });
+        });
 }
 
-TEST_CASE("(PR) HGraph Build & ContinueAdd Test", "[ft][build][hgraph][pr]") {
-    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
-    auto resource = test_index->GetResource(true);
-    TestHGraphBuildAndContinueAdd(test_index, resource);
-}
-
-TEST_CASE("(Daily) HGraph Build & ContinueAdd Test", "[ft][build][hgraph][daily]") {
-    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
-    auto resource = test_index->GetResource(false);
-    TestHGraphBuildAndContinueAdd(test_index, resource);
-}
+HGRAPH_PR_DAILY_CASE("HGraph Build & ContinueAdd Test",
+                     "[ft][build][hgraph]",
+                     TestHGraphBuildAndContinueAdd)
 
 static void
 TestHGraphFactor(const fixtures::HGraphTestIndexPtr& test_index,
@@ -613,22 +641,12 @@ void
 TestHGraphTrainAndAddTest(const fixtures::HGraphTestIndexPtr& test_index,
                           const fixtures::HGraphResourcePtr& resource) {
     using namespace fixtures;
-    auto origin_size = vsag::Options::Instance().block_size_limit();
-    auto size = GENERATE(1024 * 1024 * 2);
     auto search_param = fmt::format(fixtures::search_param_tmp, 200, false);
-    for (auto metric_type : resource->metric_types) {
-        for (auto dim : resource->dims) {
-            for (auto& [base_quantization_str, recall] : resource->test_cases) {
-                INFO(fmt::format("metric_type: {}, dim: {}, base_quantization_str: {}, recall: {}",
-                                 metric_type,
-                                 dim,
-                                 base_quantization_str,
-                                 recall));
-                if (HGraphTestIndex::IsRaBitQ(base_quantization_str) &&
-                    dim < fixtures::RABITQ_MIN_RACALL_DIM) {
-                    dim = fixtures::RABITQ_MIN_RACALL_DIM;
-                }
-                vsag::Options::Instance().set_block_size_limit(size);
+    ForEachHGraphCase(
+        resource,
+        resource->test_cases,
+        [&](const auto& metric_type, int64_t dim, const auto& base_quantization_str, float recall) {
+            RunWithGeneratedBlockSizeLimit([&] {
                 HGraphTestIndex::HGraphBuildParam build_param(
                     metric_type, dim, base_quantization_str);
                 auto param = HGraphTestIndex::GenerateHGraphBuildParametersString(build_param);
@@ -637,23 +655,11 @@ TestHGraphTrainAndAddTest(const fixtures::HGraphTestIndexPtr& test_index,
                     dim, resource->base_count, metric_type);
                 TestIndex::TestTrainAndAdd(index, dataset, true);
                 HGraphTestIndex::TestGeneral(index, dataset, search_param, recall);
-                vsag::Options::Instance().set_block_size_limit(origin_size);
-            }
-        }
-    }
+            });
+        });
 }
 
-TEST_CASE("(PR) HGraph Train & Add Test", "[ft][build][hgraph][pr]") {
-    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
-    auto resource = test_index->GetResource(true);
-    TestHGraphTrainAndAddTest(test_index, resource);
-}
-
-TEST_CASE("(Daily) HGraph Train & Add Test", "[ft][build][hgraph][daily]") {
-    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
-    auto resource = test_index->GetResource(false);
-    TestHGraphTrainAndAddTest(test_index, resource);
-}
+HGRAPH_PR_DAILY_CASE("HGraph Train & Add Test", "[ft][build][hgraph]", TestHGraphTrainAndAddTest)
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::HGraphTestIndex,
                              "HGraph Search Empty Index",
@@ -705,25 +711,13 @@ static void
 TestHGraphBuild(const fixtures::HGraphTestIndexPtr& test_index,
                 const fixtures::HGraphResourcePtr& resource) {
     using namespace fixtures;
-    auto origin_size = vsag::Options::Instance().block_size_limit();
-    auto size = GENERATE(1024 * 1024 * 2);
     auto search_param = fmt::format(fixtures::search_param_tmp, 200, false);
 
-    for (auto metric_type : resource->metric_types) {
-        for (auto dim : resource->dims) {
-            for (auto& [base_quantization_str, recall] : resource->test_cases) {
-                INFO(fmt::format("metric_type: {}, dim: {}, base_quantization_str: {}, recall: {}",
-                                 metric_type,
-                                 dim,
-                                 base_quantization_str,
-                                 recall));
-                if (HGraphTestIndex::IsRaBitQ(base_quantization_str) &&
-                    dim < fixtures::RABITQ_MIN_RACALL_DIM) {
-                    dim = fixtures::RABITQ_MIN_RACALL_DIM;
-                }
-
-                vsag::Options::Instance().set_block_size_limit(size);
-
+    ForEachHGraphCase(
+        resource,
+        resource->test_cases,
+        [&](const auto& metric_type, int64_t dim, const auto& base_quantization_str, float recall) {
+            RunWithGeneratedBlockSizeLimit([&] {
                 HGraphTestIndex::HGraphBuildParam build_param(
                     metric_type, dim, base_quantization_str);
                 auto param = HGraphTestIndex::GenerateHGraphBuildParametersString(build_param);
@@ -735,24 +729,11 @@ TestHGraphBuild(const fixtures::HGraphTestIndexPtr& test_index,
                 TestIndex::TestBuildIndex(index, dataset, true);
                 TestIndex::TestExportIDs(index, dataset);
                 HGraphTestIndex::TestGeneral(index, dataset, search_param, recall);
-
-                vsag::Options::Instance().set_block_size_limit(origin_size);
-            }
-        }
-    }
+            });
+        });
 }
 
-TEST_CASE("(PR) HGraph Build Test", "[ft][build][hgraph][pr]") {
-    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
-    auto resource = test_index->GetResource(true);
-    TestHGraphBuild(test_index, resource);
-}
-
-TEST_CASE("(Daily) HGraph Build Test", "[ft][build][hgraph][daily]") {
-    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
-    auto resource = test_index->GetResource(false);
-    TestHGraphBuild(test_index, resource);
-}
+HGRAPH_PR_DAILY_CASE("HGraph Build Test", "[ft][build][hgraph]", TestHGraphBuild)
 static void
 TestHGraphWithAttr(const fixtures::HGraphTestIndexPtr& test_index,
                    const fixtures::HGraphResourcePtr& resource) {
@@ -809,17 +790,7 @@ TestHGraphWithAttr(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("(PR) HGraph With Attr", "[ft][filter_search][hgraph][pr]") {
-    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
-    auto resource = test_index->GetResource(true);
-    TestHGraphWithAttr(test_index, resource);
-}
-
-TEST_CASE("(Daily) HGraph With Attr", "[ft][filter_search][hgraph][daily]") {
-    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
-    auto resource = test_index->GetResource(false);
-    TestHGraphWithAttr(test_index, resource);
-}
+HGRAPH_PR_DAILY_CASE("HGraph With Attr", "[ft][filter_search][hgraph]", TestHGraphWithAttr)
 
 static void
 TestHGraphGetRawVector(const fixtures::HGraphTestIndexPtr& test_index,
@@ -870,17 +841,9 @@ TestHGraphGetRawVector(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("(PR) HGraph Support Get Raw Vector", "[ft][update][hgraph][pr]") {
-    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
-    auto resource = test_index->GetResource(true);
-    TestHGraphGetRawVector(test_index, resource);
-}
-
-TEST_CASE("(Daily) HGraph Support Get Raw Vector", "[ft][update][hgraph][daily]") {
-    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
-    auto resource = test_index->GetResource(false);
-    TestHGraphGetRawVector(test_index, resource);
-}
+HGRAPH_PR_DAILY_CASE("HGraph Support Get Raw Vector",
+                     "[ft][update][hgraph]",
+                     TestHGraphGetRawVector)
 
 static void
 TestHGraphTune(const fixtures::HGraphTestIndexPtr& test_index,
@@ -980,17 +943,7 @@ TestHGraphTune(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("(PR) HGraph Tune", "[ft][search][hgraph][pr]") {
-    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
-    auto resource = test_index->GetResource(true);
-    TestHGraphTune(test_index, resource);
-}
-
-TEST_CASE("(Daily) HGraph Tune", "[ft][search][hgraph][daily]") {
-    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
-    auto resource = test_index->GetResource(false);
-    TestHGraphTune(test_index, resource);
-}
+HGRAPH_PR_DAILY_CASE("HGraph Tune", "[ft][search][hgraph]", TestHGraphTune)
 
 TEST_CASE("(PR) HGraph Tune with ignore_reorder", "[ft][search][hgraph][pr]") {
     using namespace fixtures;
@@ -1107,38 +1060,18 @@ TestHGraphODescentBuild(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("(PR) HGraph ODescent Build", "[ft][build][hgraph][pr]") {
-    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
-    auto resource = test_index->GetResource(true);
-    TestHGraphODescentBuild(test_index, resource);
-}
-
-TEST_CASE("(Daily) HGraph ODescent Build", "[ft][build][hgraph][daily]") {
-    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
-    auto resource = test_index->GetResource(false);
-    TestHGraphODescentBuild(test_index, resource);
-}
+HGRAPH_PR_DAILY_CASE("HGraph ODescent Build", "[ft][build][hgraph]", TestHGraphODescentBuild)
 
 static void
 TestHGraphMarkRemove(const fixtures::HGraphTestIndexPtr& test_index,
                      const fixtures::HGraphResourcePtr& resource) {
     using namespace fixtures;
-    auto origin_size = vsag::Options::Instance().block_size_limit();
-    auto size = GENERATE(1024 * 1024 * 2);
     auto search_param = fmt::format(fixtures::search_param_tmp, 200, false);
-    for (auto metric_type : resource->metric_types) {
-        for (auto dim : resource->dims) {
-            for (auto& [base_quantization_str, recall] : resource->test_cases) {
-                INFO(fmt::format("metric_type: {}, dim: {}, base_quantization_str: {}, recall: {}",
-                                 metric_type,
-                                 dim,
-                                 base_quantization_str,
-                                 recall));
-                if (HGraphTestIndex::IsRaBitQ(base_quantization_str) &&
-                    dim < fixtures::RABITQ_MIN_RACALL_DIM) {
-                    dim = fixtures::RABITQ_MIN_RACALL_DIM;
-                }
-                vsag::Options::Instance().set_block_size_limit(size);
+    ForEachHGraphCase(
+        resource,
+        resource->test_cases,
+        [&](const auto& metric_type, int64_t dim, const auto& base_quantization_str, float recall) {
+            RunWithGeneratedBlockSizeLimit([&] {
                 HGraphTestIndex::HGraphBuildParam build_param(
                     metric_type, dim, base_quantization_str);
                 build_param.support_remove = true;
@@ -1148,45 +1081,23 @@ TestHGraphMarkRemove(const fixtures::HGraphTestIndexPtr& test_index,
                     dim, resource->base_count, metric_type);
                 TestIndex::TestMarkRemoveIndex(index, dataset, search_param, true);
                 HGraphTestIndex::TestGeneral(index, dataset, search_param, recall);
-                vsag::Options::Instance().set_block_size_limit(origin_size);
-            }
-        }
-    }
+            });
+        });
 }
 
-TEST_CASE("(PR) HGraph Mark Remove", "[ft][remove][hgraph][pr]") {
-    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
-    auto resource = test_index->GetResource(true);
-    TestHGraphMarkRemove(test_index, resource);
-}
-
-TEST_CASE("(Daily) HGraph Mark Remove", "[ft][remove][hgraph][daily]") {
-    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
-    auto resource = test_index->GetResource(false);
-    TestHGraphMarkRemove(test_index, resource);
-}
+HGRAPH_PR_DAILY_CASE("HGraph Mark Remove", "[ft][remove][hgraph]", TestHGraphMarkRemove)
 
 static void
 TestHGraphCompressedBuild(const fixtures::HGraphTestIndexPtr& test_index,
                           const fixtures::HGraphResourcePtr& resource) {
     using namespace fixtures;
-    auto origin_size = vsag::Options::Instance().block_size_limit();
-    auto size = GENERATE(1024 * 1024 * 2);
     auto search_param = fmt::format(fixtures::search_param_tmp, 200, false);
 
-    for (auto metric_type : resource->metric_types) {
-        for (auto dim : resource->dims) {
-            for (auto& [base_quantization_str, recall] : resource->test_cases) {
-                INFO(fmt::format("metric_type: {}, dim: {}, base_quantization_str: {}, recall: {}",
-                                 metric_type,
-                                 dim,
-                                 base_quantization_str,
-                                 recall));
-                if (HGraphTestIndex::IsRaBitQ(base_quantization_str) &&
-                    dim < fixtures::RABITQ_MIN_RACALL_DIM) {
-                    dim = fixtures::RABITQ_MIN_RACALL_DIM;
-                }
-                vsag::Options::Instance().set_block_size_limit(size);
+    ForEachHGraphCase(
+        resource,
+        resource->test_cases,
+        [&](const auto& metric_type, int64_t dim, const auto& base_quantization_str, float recall) {
+            RunWithGeneratedBlockSizeLimit([&] {
                 HGraphTestIndex::HGraphBuildParam build_param(
                     metric_type, dim, base_quantization_str);
                 build_param.graph_storage = "compressed";
@@ -1196,23 +1107,13 @@ TestHGraphCompressedBuild(const fixtures::HGraphTestIndexPtr& test_index,
                     dim, resource->base_count, metric_type);
                 TestIndex::TestBuildIndex(index, dataset, true);
                 HGraphTestIndex::TestGeneral(index, dataset, search_param, recall);
-                vsag::Options::Instance().set_block_size_limit(origin_size);
-            }
-        }
-    }
+            });
+        });
 }
 
-TEST_CASE("(PR) HGraph Compressed Graph Build", "[ft][build][hgraph][pr]") {
-    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
-    auto resource = test_index->GetResource(true);
-    TestHGraphCompressedBuild(test_index, resource);
-}
-
-TEST_CASE("(Daily) HGraph Compressed Graph Build", "[ft][build][hgraph][daily]") {
-    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
-    auto resource = test_index->GetResource(false);
-    TestHGraphCompressedBuild(test_index, resource);
-}
+HGRAPH_PR_DAILY_CASE("HGraph Compressed Graph Build",
+                     "[ft][build][hgraph]",
+                     TestHGraphCompressedBuild)
 
 static void
 TestHGraphMerge(const fixtures::HGraphTestIndexPtr& test_index,
@@ -1251,17 +1152,7 @@ TestHGraphMerge(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("(PR) HGraph Merge", "[ft][merge][hgraph][pr]") {
-    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
-    auto resource = test_index->GetResource(true);
-    TestHGraphMerge(test_index, resource);
-}
-
-TEST_CASE("(Daily) HGraph Merge", "[ft][merge][hgraph][daily]") {
-    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
-    auto resource = test_index->GetResource(false);
-    TestHGraphMerge(test_index, resource);
-}
+HGRAPH_PR_DAILY_CASE("HGraph Merge", "[ft][merge][hgraph]", TestHGraphMerge)
 
 static void
 TestHGraphAdd(const fixtures::HGraphTestIndexPtr& test_index,
@@ -1300,17 +1191,7 @@ TestHGraphAdd(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("(PR) HGraph Add", "[ft][build][hgraph][pr]") {
-    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
-    auto resource = test_index->GetResource(true);
-    TestHGraphAdd(test_index, resource);
-}
-
-TEST_CASE("(Daily) HGraph Add", "[ft][build][hgraph][daily]") {
-    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
-    auto resource = test_index->GetResource(false);
-    TestHGraphAdd(test_index, resource);
-}
+HGRAPH_PR_DAILY_CASE("HGraph Add", "[ft][build][hgraph]", TestHGraphAdd)
 
 static void
 TestHGraphNonstandardID(const fixtures::HGraphTestIndexPtr& test_index,
@@ -1436,17 +1317,7 @@ TestHGraphDuplicateSerializeCompressed(const fixtures::HGraphTestIndexPtr& test_
     RunHGraphDuplicateChecks(test_index, resource, "compressed", false, true);
 }
 
-TEST_CASE("(PR) HGraph Duplicate", "[ft][build][hgraph][duplicate][pr]") {
-    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
-    auto resource = test_index->GetResource(true);
-    TestHGraphDuplicate(test_index, resource);
-}
-
-TEST_CASE("(Daily) HGraph Duplicate", "[ft][build][hgraph][duplicate][daily]") {
-    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
-    auto resource = test_index->GetResource(false);
-    TestHGraphDuplicate(test_index, resource);
-}
+HGRAPH_PR_DAILY_CASE("HGraph Duplicate", "[ft][build][hgraph][duplicate]", TestHGraphDuplicate)
 
 TEST_CASE("(PR) HGraph Duplicate Serialize Compressed",
           "[ft][build][duplicate][serialize][hgraph][pr]") {
@@ -1488,17 +1359,9 @@ TestHGraphSearchWithDirtyVector(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("(PR) HGraph Search with Dirty Vector", "[ft][search][hgraph][pr]") {
-    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
-    auto resource = test_index->GetResource(true);
-    TestHGraphSearchWithDirtyVector(test_index, resource);
-}
-
-TEST_CASE("(Daily) HGraph Search with Dirty Vector", "[ft][search][hgraph][daily]") {
-    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
-    auto resource = test_index->GetResource(false);
-    TestHGraphSearchWithDirtyVector(test_index, resource);
-}
+HGRAPH_PR_DAILY_CASE("HGraph Search with Dirty Vector",
+                     "[ft][search][hgraph]",
+                     TestHGraphSearchWithDirtyVector)
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::HGraphTestIndex,
                              "HGraph Search with Sparse Vector",
@@ -1567,17 +1430,9 @@ TestHGraphConcurrentAdd(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("(PR) HGraph Concurrent Add", "[ft][build][concurrent][hgraph][pr]") {
-    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
-    auto resource = test_index->GetResource(true);
-    TestHGraphConcurrentAdd(test_index, resource);
-}
-
-TEST_CASE("(Daily) HGraph Concurrent Add", "[ft][build][concurrent][hgraph][daily]") {
-    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
-    auto resource = test_index->GetResource(false);
-    TestHGraphConcurrentAdd(test_index, resource);
-}
+HGRAPH_PR_DAILY_CASE("HGraph Concurrent Add",
+                     "[ft][build][concurrent][hgraph]",
+                     TestHGraphConcurrentAdd)
 
 static void
 TestHGraphConcurrentAddSearchRemove(const fixtures::HGraphTestIndexPtr& test_index,
@@ -1620,17 +1475,9 @@ TestHGraphConcurrentAddSearchRemove(const fixtures::HGraphTestIndexPtr& test_ind
     }
 }
 
-TEST_CASE("(PR) HGraph Concurrent Add Search Remove", "[ft][build][concurrent][hgraph][pr]") {
-    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
-    auto resource = test_index->GetResource(true);
-    TestHGraphConcurrentAddSearchRemove(test_index, resource);
-}
-
-TEST_CASE("(Daily) HGraph Concurrent Add Search Remove", "[ft][build][concurrent][hgraph][daily]") {
-    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
-    auto resource = test_index->GetResource(false);
-    TestHGraphConcurrentAddSearchRemove(test_index, resource);
-}
+HGRAPH_PR_DAILY_CASE("HGraph Concurrent Add Search Remove",
+                     "[ft][build][concurrent][hgraph]",
+                     TestHGraphConcurrentAddSearchRemove)
 
 static void
 TestHGraphSerialize(const fixtures::HGraphTestIndexPtr& test_index,
@@ -1681,17 +1528,9 @@ TestHGraphSerialize(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("(PR) HGraph Serialize File", "[ft][serialize][hgraph][serialization][pr]") {
-    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
-    auto resource = test_index->GetResource(true);
-    TestHGraphSerialize(test_index, resource);
-}
-
-TEST_CASE("(Daily) HGraph Serialize File", "[ft][serialize][hgraph][serialization][daily]") {
-    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
-    auto resource = test_index->GetResource(false);
-    TestHGraphSerialize(test_index, resource);
-}
+HGRAPH_PR_DAILY_CASE("HGraph Serialize File",
+                     "[ft][serialize][hgraph][serialization]",
+                     TestHGraphSerialize)
 
 static void
 TestHGraphReaderIO(const fixtures::HGraphTestIndexPtr& test_index,
@@ -1742,17 +1581,7 @@ TestHGraphReaderIO(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("(PR) HGraph Reader IO", "[ft][serialize][hgraph][pr]") {
-    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
-    auto resource = test_index->GetResource(true);
-    TestHGraphReaderIO(test_index, resource);
-}
-
-TEST_CASE("(Daily) HGraph Reader IO", "[ft][serialize][hgraph][daily]") {
-    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
-    auto resource = test_index->GetResource(false);
-    TestHGraphReaderIO(test_index, resource);
-}
+HGRAPH_PR_DAILY_CASE("HGraph Reader IO", "[ft][serialize][hgraph]", TestHGraphReaderIO)
 
 static void
 TestHGraphClone(const fixtures::HGraphTestIndexPtr& test_index,
@@ -1795,17 +1624,7 @@ TestHGraphClone(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("(PR) HGraph Clone", "[ft][clone][hgraph][pr]") {
-    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
-    auto resource = test_index->GetResource(true);
-    TestHGraphClone(test_index, resource);
-}
-
-TEST_CASE("(Daily) HGraph Clone", "[ft][clone][hgraph][daily]") {
-    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
-    auto resource = test_index->GetResource(false);
-    TestHGraphClone(test_index, resource);
-}
+HGRAPH_PR_DAILY_CASE("HGraph Clone", "[ft][clone][hgraph]", TestHGraphClone)
 
 static void
 TestHGraphExportModel(const fixtures::HGraphTestIndexPtr& test_index,
@@ -1849,17 +1668,7 @@ TestHGraphExportModel(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("(PR) HGraph Export Model", "[ft][export][hgraph][pr]") {
-    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
-    auto resource = test_index->GetResource(true);
-    TestHGraphExportModel(test_index, resource);
-}
-
-TEST_CASE("(Daily) HGraph Export Model", "[ft][export][hgraph][daily]") {
-    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
-    auto resource = test_index->GetResource(false);
-    TestHGraphExportModel(test_index, resource);
-}
+HGRAPH_PR_DAILY_CASE("HGraph Export Model", "[ft][export][hgraph]", TestHGraphExportModel)
 
 static void
 TestHGraphRandomAllocator(const fixtures::HGraphTestIndexPtr& test_index,
@@ -1902,18 +1711,9 @@ TestHGraphRandomAllocator(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("(PR) HGraph Build & ContinueAdd Test With Random Allocator", "[ft][build][hgraph][pr]") {
-    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
-    auto resource = test_index->GetResource(true);
-    TestHGraphRandomAllocator(test_index, resource);
-}
-
-TEST_CASE("(Daily) HGraph Build & ContinueAdd Test With Random Allocator",
-          "[ft][build][hgraph][daily]") {
-    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
-    auto resource = test_index->GetResource(false);
-    TestHGraphRandomAllocator(test_index, resource);
-}
+HGRAPH_PR_DAILY_CASE("HGraph Build & ContinueAdd Test With Random Allocator",
+                     "[ft][build][hgraph]",
+                     TestHGraphRandomAllocator)
 
 static void
 TestHGraphDuplicateBuild(const fixtures::HGraphTestIndexPtr& test_index,
@@ -1955,17 +1755,9 @@ TestHGraphDuplicateBuild(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("(PR) HGraph Duplicate Build", "[ft][build][duplicate][hgraph][pr]") {
-    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
-    auto resource = test_index->GetResource(true);
-    TestHGraphDuplicateBuild(test_index, resource);
-}
-
-TEST_CASE("(Daily) HGraph Duplicate Build", "[ft][build][duplicate][hgraph][daily]") {
-    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
-    auto resource = test_index->GetResource(false);
-    TestHGraphDuplicateBuild(test_index, resource);
-}
+HGRAPH_PR_DAILY_CASE("HGraph Duplicate Build",
+                     "[ft][build][duplicate][hgraph]",
+                     TestHGraphDuplicateBuild)
 
 static void
 TestHGraphEstimateMemoryAndGetMemoryUsage(const fixtures::HGraphTestIndexPtr& test_index,
@@ -2009,17 +1801,9 @@ TestHGraphEstimateMemoryAndGetMemoryUsage(const fixtures::HGraphTestIndexPtr& te
     }
 }
 
-TEST_CASE("(PR) HGraph Estimate Memory And Get Memory Usage", "[ft][memory][hgraph][pr]") {
-    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
-    auto resource = test_index->GetResource(true);
-    TestHGraphEstimateMemoryAndGetMemoryUsage(test_index, resource);
-}
-
-TEST_CASE("(Daily) HGraph Estimate Memory", "[ft][memory][hgraph][daily]") {
-    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
-    auto resource = test_index->GetResource(false);
-    TestHGraphEstimateMemoryAndGetMemoryUsage(test_index, resource);
-}
+HGRAPH_PR_DAILY_CASE("HGraph Estimate Memory And Get Memory Usage",
+                     "[ft][memory][hgraph]",
+                     TestHGraphEstimateMemoryAndGetMemoryUsage)
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::HGraphTestIndex,
                              "HGraph ELP Optimizer",
@@ -2100,17 +1884,7 @@ TestHGraphIgnoreReorder(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("(PR) HGraph Ignore Reorder", "[ft][search][hgraph][pr]") {
-    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
-    auto resource = test_index->GetResource(true);
-    TestHGraphIgnoreReorder(test_index, resource);
-}
-
-TEST_CASE("(Daily) HGraph Ignore Reorder", "[ft][search][hgraph][daily]") {
-    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
-    auto resource = test_index->GetResource(false);
-    TestHGraphIgnoreReorder(test_index, resource);
-}
+HGRAPH_PR_DAILY_CASE("HGraph Ignore Reorder", "[ft][search][hgraph]", TestHGraphIgnoreReorder)
 
 static void
 TestHGraphWithExtraInfo(const fixtures::HGraphTestIndexPtr& test_index,
@@ -2164,17 +1938,7 @@ TestHGraphWithExtraInfo(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("(PR) HGraph With Extra Info", "[ft][search][hgraph][pr]") {
-    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
-    auto resource = test_index->GetResource(true);
-    TestHGraphWithExtraInfo(test_index, resource);
-}
-
-TEST_CASE("(Daily) HGraph With Extra Info", "[ft][search][hgraph][daily]") {
-    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
-    auto resource = test_index->GetResource(false);
-    TestHGraphWithExtraInfo(test_index, resource);
-}
+HGRAPH_PR_DAILY_CASE("HGraph With Extra Info", "[ft][search][hgraph]", TestHGraphWithExtraInfo)
 
 static void
 TestHGraphSearchOverTime(const fixtures::HGraphTestIndexPtr& test_index,
@@ -2215,17 +1979,7 @@ TestHGraphSearchOverTime(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("(PR) HGraph Search Over Time", "[ft][search][hgraph][pr]") {
-    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
-    auto resource = test_index->GetResource(true);
-    TestHGraphSearchOverTime(test_index, resource);
-}
-
-TEST_CASE("(Daily) HGraph Search Over Time", "[ft][search][hgraph][daily]") {
-    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
-    auto resource = test_index->GetResource(false);
-    TestHGraphSearchOverTime(test_index, resource);
-}
+HGRAPH_PR_DAILY_CASE("HGraph Search Over Time", "[ft][search][hgraph]", TestHGraphSearchOverTime)
 
 static void
 TestHGraphDiskIOType(const fixtures::HGraphTestIndexPtr& test_index,
@@ -2277,17 +2031,7 @@ TestHGraphDiskIOType(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("(PR) HGraph Disk IO Type Index", "[ft][serialize][hgraph][pr]") {
-    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
-    auto resource = test_index->GetResource(true);
-    TestHGraphDiskIOType(test_index, resource);
-}
-
-TEST_CASE("(Daily) HGraph Disk IO Type Index", "[ft][serialize][hgraph][daily]") {
-    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
-    auto resource = test_index->GetResource(false);
-    TestHGraphDiskIOType(test_index, resource);
-}
+HGRAPH_PR_DAILY_CASE("HGraph Disk IO Type Index", "[ft][serialize][hgraph]", TestHGraphDiskIOType)
 
 TEST_CASE("HGraph Concurrent Read Write", "[ft][concurrent][hgraph]") {
     uint32_t op_num = 10000;
@@ -2491,17 +2235,7 @@ TestHGraphHopsLimit(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("(PR) HGraph Hops Limit", "[ft][search][hgraph][pr]") {
-    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
-    auto resource = test_index->GetResource(true);
-    TestHGraphHopsLimit(test_index, resource);
-}
-
-TEST_CASE("(Daily) HGraph Hops Limit", "[ft][search][hgraph][daily]") {
-    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
-    auto resource = test_index->GetResource(false);
-    TestHGraphHopsLimit(test_index, resource);
-}
+HGRAPH_PR_DAILY_CASE("HGraph Hops Limit", "[ft][search][hgraph]", TestHGraphHopsLimit)
 
 static void
 TestHGraphReverseEdges(const fixtures::HGraphTestIndexPtr& test_index,
@@ -2580,14 +2314,4 @@ TestHGraphReverseEdges(const fixtures::HGraphTestIndexPtr& test_index,
     }
 }
 
-TEST_CASE("(PR) HGraph Reverse Edges", "[ft][build][hgraph][pr]") {
-    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
-    auto resource = test_index->GetResource(true);
-    TestHGraphReverseEdges(test_index, resource);
-}
-
-TEST_CASE("(Daily) HGraph Reverse Edges", "[ft][build][hgraph][daily]") {
-    auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
-    auto resource = test_index->GetResource(false);
-    TestHGraphReverseEdges(test_index, resource);
-}
+HGRAPH_PR_DAILY_CASE("HGraph Reverse Edges", "[ft][build][hgraph]", TestHGraphReverseEdges)

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -738,42 +738,27 @@ static void
 TestHGraphWithAttr(const fixtures::HGraphTestIndexPtr& test_index,
                    const fixtures::HGraphResourcePtr& resource) {
     using namespace fixtures;
-    auto origin_size = vsag::Options::Instance().block_size_limit();
     auto search_param = fmt::format(fixtures::search_param_tmp, 200, false);
 
-    auto size = GENERATE(1024 * 1024 * 2);
     std::vector<std::pair<std::string, float>> tmp_test_cases = {
         {"fp32", 0.75},
     };
-    for (auto metric_type : resource->metric_types) {
-        for (auto dim : resource->dims) {
-            for (auto& [base_quantization_str, recall] : tmp_test_cases) {
-                INFO(fmt::format("metric_type: {}, dim: {}, base_quantization_str: {}, recall: {}",
-                                 metric_type,
-                                 dim,
-                                 base_quantization_str,
-                                 recall));
-                if (HGraphTestIndex::IsRaBitQ(base_quantization_str) &&
-                    dim < fixtures::RABITQ_MIN_RACALL_DIM) {
-                    dim = fixtures::RABITQ_MIN_RACALL_DIM;
-                }
-
-                // Set block size limit for current test iteration
-                vsag::Options::Instance().set_block_size_limit(size);
-
-                // Generate index parameters with attribute support enabled
+    ForEachHGraphCase(
+        resource,
+        tmp_test_cases,
+        [&](const auto& metric_type, int64_t dim, const auto& base_quantization_str, float recall) {
+            RunWithGeneratedBlockSizeLimit([&] {
                 HGraphTestIndex::HGraphBuildParam build_param(
                     metric_type, dim, base_quantization_str);
                 build_param.use_attr_filter = true;
                 auto param = HGraphTestIndex::GenerateHGraphBuildParametersString(build_param);
 
-                // Create index and dataset
                 auto index = TestIndex::TestFactory(test_index->name, param, true);
                 auto dataset = HGraphTestIndex::pool.GetDatasetAndCreate(
                     dim, resource->base_count, metric_type);
 
                 if (not index->CheckFeature(vsag::SUPPORT_BUILD)) {
-                    continue;
+                    return;
                 }
                 auto build_result = index->Build(dataset->base_);
                 REQUIRE(build_result.has_value());
@@ -782,12 +767,8 @@ TestHGraphWithAttr(const fixtures::HGraphTestIndexPtr& test_index,
 
                 REQUIRE_NOTHROW(test_serializion_file(*index, *index2, "serialize_hgraph"));
                 TestIndex::TestWithAttr(index2, dataset, search_param, true);
-
-                // Restore original block size limit
-                vsag::Options::Instance().set_block_size_limit(origin_size);
-            }
-        }
-    }
+            });
+        });
 }
 
 HGRAPH_PR_DAILY_CASE("HGraph With Attr", "[ft][filter_search][hgraph]", TestHGraphWithAttr)
@@ -796,49 +777,27 @@ static void
 TestHGraphGetRawVector(const fixtures::HGraphTestIndexPtr& test_index,
                        const fixtures::HGraphResourcePtr& resource) {
     using namespace fixtures;
-    auto origin_size = vsag::Options::Instance().block_size_limit();
-    auto size = GENERATE(1024 * 1024 * 2);
     const std::vector<std::pair<std::string, float>> test_cases = {
         {"fp32", 0.99}, {"sq8", 0.99}, {"sq4_uniform,fp32", 0.95}};
     auto search_param = fmt::format(fixtures::search_param_tmp, 200, false);
-    for (auto metric_type : resource->metric_types) {
-        for (auto dim : resource->dims) {
-            for (auto& [base_quantization_str, recall] : test_cases) {
-                INFO(fmt::format("metric_type: {}, dim: {}, base_quantization_str: {}, recall: {}",
-                                 metric_type,
-                                 dim,
-                                 base_quantization_str,
-                                 recall));
-                if (HGraphTestIndex::IsRaBitQ(base_quantization_str) &&
-                    dim < fixtures::RABITQ_MIN_RACALL_DIM) {
-                    dim = fixtures::RABITQ_MIN_RACALL_DIM;
-                }
-
-                // Set block size limit for current test iteration
-                vsag::Options::Instance().set_block_size_limit(size);
-
-                // Generate index parameters with attribute support enabled
+    ForEachHGraphCase(
+        resource,
+        test_cases,
+        [&](const auto& metric_type, int64_t dim, const auto& base_quantization_str, float recall) {
+            RunWithGeneratedBlockSizeLimit([&] {
                 HGraphTestIndex::HGraphBuildParam build_param(
                     metric_type, dim, base_quantization_str);
                 build_param.store_raw_vector = true;
                 auto param = HGraphTestIndex::GenerateHGraphBuildParametersString(build_param);
 
-                // Create index and dataset
                 auto index = TestIndex::TestFactory(test_index->name, param, true);
-
                 auto dataset = HGraphTestIndex::pool.GetDatasetAndCreate(
                     dim, resource->base_count, metric_type);
 
                 TestIndex::TestBuildIndex(index, dataset, true);
-
-                // Execute attribute-aware build test
                 HGraphTestIndex::TestGeneral(index, dataset, search_param, recall);
-
-                // Restore original block size limit
-                vsag::Options::Instance().set_block_size_limit(origin_size);
-            }
-        }
-    }
+            });
+        });
 }
 
 HGRAPH_PR_DAILY_CASE("HGraph Support Get Raw Vector",

--- a/tests/test_ivf.cpp
+++ b/tests/test_ivf.cpp
@@ -291,6 +291,70 @@ IVFTestIndex::TestGeneral(const TestIndex::IndexPtr& index,
 }
 }  // namespace fixtures
 
+namespace {
+
+template <typename Fn>
+void
+RunWithGeneratedBlockSizeLimit(Fn&& fn) {
+    const auto origin_size = vsag::Options::Instance().block_size_limit();
+    const auto size = GENERATE(1024 * 1024 * 2);
+    vsag::Options::Instance().set_block_size_limit(size);
+    fn();
+    vsag::Options::Instance().set_block_size_limit(origin_size);
+}
+
+inline float
+AdjustIVFRecall(float recall,
+                const std::string& train_type,
+                const std::string& base_quantization_str,
+                int64_t dim) {
+    if (train_type == "kmeans") {
+        recall *= 0.8F;
+    }
+    if (base_quantization_str == "fp16") {
+        recall *= (1 - dim / 8192.0F);
+    }
+    return recall;
+}
+
+template <typename Cases, typename Fn>
+void
+ForEachIVFCase(const fixtures::IVFResourcePtr& resource, const Cases& test_cases, Fn&& fn) {
+    for (const auto& metric_type : resource->metric_types) {
+        for (auto dim : resource->dims) {
+            for (const auto& train_type : resource->train_types) {
+                for (const auto& [base_quantization_str, base_recall] : test_cases) {
+                    const auto recall =
+                        AdjustIVFRecall(base_recall, train_type, base_quantization_str, dim);
+                    INFO(
+                        fmt::format("metric_type: {}, dim: {}, base_quantization_str: {}, "
+                                    "train_type: {}, recall: {}",
+                                    metric_type,
+                                    dim,
+                                    base_quantization_str,
+                                    train_type,
+                                    recall));
+                    fn(metric_type, dim, train_type, base_quantization_str, recall);
+                }
+            }
+        }
+    }
+}
+
+#define IVF_PR_DAILY_CASE(title, tags, helper)                        \
+    TEST_CASE("(PR) " title, tags "[pr]") {                           \
+        auto test_index = std::make_shared<fixtures::IVFTestIndex>(); \
+        auto resource = test_index->GetResource(true);                \
+        helper(resource);                                             \
+    }                                                                 \
+    TEST_CASE("(Daily) " title, tags "[daily]") {                     \
+        auto test_index = std::make_shared<fixtures::IVFTestIndex>(); \
+        auto resource = test_index->GetResource(false);               \
+        helper(resource);                                             \
+    }
+
+}  // namespace
+
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::IVFTestIndex,
                              "IVF Factory Test With Exceptions",
                              "[ft][ivf]") {
@@ -418,64 +482,38 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::IVFTestIndex,
 static void
 TestIVFBuildAndContinueAdd(const fixtures::IVFResourcePtr& resource) {
     using namespace fixtures;
-    auto origin_size = vsag::Options::Instance().block_size_limit();
-    auto size = GENERATE(1024 * 1024 * 2);
-    for (auto metric_type : resource->metric_types) {
-        for (auto dim : resource->dims) {
-            for (auto train_type : resource->train_types) {
-                for (auto [base_quantization_str, recall] : resource->test_cases) {
-                    if (train_type == "kmeans") {
-                        recall *= 0.8F;  // Kmeans may not achieve high recall in random datasets
-                    }
-                    if (base_quantization_str == "fp16") {
-                        recall *= (1 - dim / 8192.0F);
-                    }
-                    auto count = std::min(300, static_cast<int32_t>(dim / 4));
-                    auto search_param =
-                        fmt::format(fixtures::search_param_tmp, std::max(250, count));
-                    INFO(
-                        fmt::format("metric_type: {}, dim: {}, base_quantization_str: {}, "
-                                    "train_type: {}, recall: {}",
-                                    metric_type,
-                                    dim,
-                                    base_quantization_str,
-                                    train_type,
-                                    recall));
-                    vsag::Options::Instance().set_block_size_limit(size);
-                    auto param = IVFTestIndex::GenerateIVFBuildParametersString(
-                        metric_type, dim, base_quantization_str, 300, train_type);
-                    auto index = TestIndex::TestFactory(IVFTestIndex::name, param, true);
-                    auto dataset = IVFTestIndex::pool.GetDatasetAndCreate(
-                        dim, resource->base_count, metric_type);
-                    TestIndex::TestContinueAdd(index, dataset, true);
-                    if (index->CheckFeature(vsag::SUPPORT_ADD_AFTER_BUILD)) {
-                        IVFTestIndex::TestGeneral(index, dataset, search_param, recall);
-                        TestIndex::TestExportIDs(index, dataset);
-                    }
-                    vsag::Options::Instance().set_block_size_limit(origin_size);
-                }
-            }
-        }
-    }
+    ForEachIVFCase(resource,
+                   resource->test_cases,
+                   [&](const auto& metric_type,
+                       int64_t dim,
+                       const auto& train_type,
+                       const auto& base_quantization_str,
+                       float recall) {
+                       RunWithGeneratedBlockSizeLimit([&] {
+                           const auto count = std::min(300, static_cast<int32_t>(dim / 4));
+                           const auto search_param =
+                               fmt::format(fixtures::search_param_tmp, std::max(250, count));
+                           auto param = IVFTestIndex::GenerateIVFBuildParametersString(
+                               metric_type, dim, base_quantization_str, 300, train_type);
+                           auto index = TestIndex::TestFactory(IVFTestIndex::name, param, true);
+                           auto dataset = IVFTestIndex::pool.GetDatasetAndCreate(
+                               dim, resource->base_count, metric_type);
+                           TestIndex::TestContinueAdd(index, dataset, true);
+                           if (index->CheckFeature(vsag::SUPPORT_ADD_AFTER_BUILD)) {
+                               IVFTestIndex::TestGeneral(index, dataset, search_param, recall);
+                               TestIndex::TestExportIDs(index, dataset);
+                           }
+                       });
+                   });
 }
 
-TEST_CASE("(PR) IVF Build & ContinueAdd Test", "[ft][build][concurrent][ivf][pr]") {
-    auto test_index = std::make_shared<fixtures::IVFTestIndex>();
-    auto resource = test_index->GetResource(true);
-    TestIVFBuildAndContinueAdd(resource);
-}
-
-TEST_CASE("(Daily) IVF Build & ContinueAdd Test", "[ft][build][concurrent][ivf][daily]") {
-    auto test_index = std::make_shared<fixtures::IVFTestIndex>();
-    auto resource = test_index->GetResource(false);
-    TestIVFBuildAndContinueAdd(resource);
-}
+IVF_PR_DAILY_CASE("IVF Build & ContinueAdd Test",
+                  "[ft][build][concurrent][ivf]",
+                  TestIVFBuildAndContinueAdd)
 
 static void
 TestIVFBuildWithResidual(const fixtures::IVFResourcePtr& resource) {
     using namespace fixtures;
-    auto origin_size = vsag::Options::Instance().block_size_limit();
-    auto size = GENERATE(1024 * 1024 * 2);
     std::vector<std::pair<std::string, float>> tmp_test_cases = {
         {"fp32", 0.90},
         {"bf16", 0.88},
@@ -484,61 +522,35 @@ TestIVFBuildWithResidual(const fixtures::IVFResourcePtr& resource) {
         {"pq,fp32", 0.82},
         {"pqfs,fp32", 0.82},
     };
-    for (auto metric_type : resource->metric_types) {
-        for (auto dim : resource->dims) {
-            for (auto train_type : resource->train_types) {
-                for (auto [base_quantization_str, recall] : tmp_test_cases) {
-                    auto count = std::min(300, static_cast<int32_t>(dim / 4));
-                    if (train_type == "kmeans") {
-                        recall *= 0.8F;  // Kmeans may not achieve high recall in random datasets
-                    }
-                    if (base_quantization_str == "fp16") {
-                        recall *= (1 - dim / 8192.0F);
-                    }
-                    auto search_param =
-                        fmt::format(fixtures::search_param_tmp, std::max(250, count));
-                    INFO(
-                        fmt::format("metric_type: {}, dim: {}, base_quantization_str: {}, "
-                                    "train_type: {}, recall: {}",
-                                    metric_type,
-                                    dim,
-                                    base_quantization_str,
-                                    train_type,
-                                    recall));
-                    vsag::Options::Instance().set_block_size_limit(size);
-                    auto param = IVFTestIndex::GenerateIVFBuildParametersString(
-                        metric_type, dim, base_quantization_str, 300, train_type, true);
-                    auto index = IVFTestIndex::TestFactory(IVFTestIndex::name, param, true);
-                    auto dataset = IVFTestIndex::pool.GetDatasetAndCreate(
-                        dim, resource->base_count, metric_type);
-                    IVFTestIndex::TestContinueAdd(index, dataset, true);
-                    if (index->CheckFeature(vsag::SUPPORT_ADD_AFTER_BUILD)) {
-                        IVFTestIndex::TestGeneral(index, dataset, search_param, recall);
-                    }
-                    vsag::Options::Instance().set_block_size_limit(origin_size);
-                }
-            }
-        }
-    }
+    ForEachIVFCase(resource,
+                   tmp_test_cases,
+                   [&](const auto& metric_type,
+                       int64_t dim,
+                       const auto& train_type,
+                       const auto& base_quantization_str,
+                       float recall) {
+                       RunWithGeneratedBlockSizeLimit([&] {
+                           const auto count = std::min(300, static_cast<int32_t>(dim / 4));
+                           const auto search_param =
+                               fmt::format(fixtures::search_param_tmp, std::max(250, count));
+                           auto param = IVFTestIndex::GenerateIVFBuildParametersString(
+                               metric_type, dim, base_quantization_str, 300, train_type, true);
+                           auto index = IVFTestIndex::TestFactory(IVFTestIndex::name, param, true);
+                           auto dataset = IVFTestIndex::pool.GetDatasetAndCreate(
+                               dim, resource->base_count, metric_type);
+                           IVFTestIndex::TestContinueAdd(index, dataset, true);
+                           if (index->CheckFeature(vsag::SUPPORT_ADD_AFTER_BUILD)) {
+                               IVFTestIndex::TestGeneral(index, dataset, search_param, recall);
+                           }
+                       });
+                   });
 }
 
-TEST_CASE("(PR) IVF Build with Residual", "[ft][build][ivf][pr]") {
-    auto test_index = std::make_shared<fixtures::IVFTestIndex>();
-    auto resource = test_index->GetResource(true);
-    TestIVFBuildWithResidual(resource);
-}
-
-TEST_CASE("(Daily) IVF Build with Residual", "[ft][build][ivf][daily]") {
-    auto test_index = std::make_shared<fixtures::IVFTestIndex>();
-    auto resource = test_index->GetResource(false);
-    TestIVFBuildWithResidual(resource);
-}
+IVF_PR_DAILY_CASE("IVF Build with Residual", "[ft][build][ivf]", TestIVFBuildWithResidual)
 
 static void
 TestIVFBuild(const fixtures::IVFResourcePtr& resource) {
     using namespace fixtures;
-    auto origin_size = vsag::Options::Instance().block_size_limit();
-    auto size = GENERATE(1024 * 1024 * 2);
     std::vector<int32_t> search_threads_counts{1, 3};
     constexpr static const char* search_param_tmp2 = R"(
         {{
@@ -549,66 +561,34 @@ TestIVFBuild(const fixtures::IVFResourcePtr& resource) {
                 "parallelism": {}
             }}
         }})";
-    for (auto metric_type : resource->metric_types) {
-        for (auto dim : resource->dims) {
-            for (auto train_type : resource->train_types) {
-                for (auto [base_quantization_str, recall] : resource->test_cases) {
-                    auto count = std::min(300, static_cast<int32_t>(dim / 4));
-                    if (train_type == "kmeans") {
-                        recall *= 0.8F;  // Kmeans may not achieve high recall in random datasets
+    ForEachIVFCase(
+        resource,
+        resource->test_cases,
+        [&](const auto& metric_type,
+            int64_t dim,
+            const auto& train_type,
+            const auto& base_quantization_str,
+            float recall) {
+            RunWithGeneratedBlockSizeLimit([&] {
+                const auto count = std::min(300, static_cast<int32_t>(dim / 4));
+                auto param = IVFTestIndex::GenerateIVFBuildParametersString(
+                    metric_type, dim, base_quantization_str, 300, train_type, false, 1, false, 3);
+                auto index = IVFTestIndex::TestFactory(IVFTestIndex::name, param, true);
+                auto dataset =
+                    IVFTestIndex::pool.GetDatasetAndCreate(dim, resource->base_count, metric_type);
+                IVFTestIndex::TestBuildIndex(index, dataset, true);
+                if (index->CheckFeature(vsag::SUPPORT_BUILD)) {
+                    for (auto search_thread_count : search_threads_counts) {
+                        auto search_param = fmt::format(
+                            search_param_tmp2, std::max(200, count), search_thread_count);
+                        IVFTestIndex::TestGeneral(index, dataset, search_param, recall);
                     }
-                    if (base_quantization_str == "fp16") {
-                        recall *= (1 - dim / 8192.0F);
-                    }
-
-                    INFO(
-                        fmt::format("metric_type: {}, dim: {}, base_quantization_str: {}, "
-                                    "train_type: {}, recall: {}",
-                                    metric_type,
-                                    dim,
-                                    base_quantization_str,
-                                    train_type,
-                                    recall));
-                    vsag::Options::Instance().set_block_size_limit(size);
-                    auto param =
-                        IVFTestIndex::GenerateIVFBuildParametersString(metric_type,
-                                                                       dim,
-                                                                       base_quantization_str,
-                                                                       300,
-                                                                       train_type,
-                                                                       false,
-                                                                       1,
-                                                                       false,
-                                                                       3);
-                    auto index = IVFTestIndex::TestFactory(IVFTestIndex::name, param, true);
-                    auto dataset = IVFTestIndex::pool.GetDatasetAndCreate(
-                        dim, resource->base_count, metric_type);
-                    IVFTestIndex::TestBuildIndex(index, dataset, true);
-                    if (index->CheckFeature(vsag::SUPPORT_BUILD)) {
-                        for (auto search_thread_count : search_threads_counts) {
-                            auto search_param = fmt::format(
-                                search_param_tmp2, std::max(200, count), search_thread_count);
-                            IVFTestIndex::TestGeneral(index, dataset, search_param, recall);
-                        }
-                    }
-                    vsag::Options::Instance().set_block_size_limit(origin_size);
                 }
-            }
-        }
-    }
+            });
+        });
 }
 
-TEST_CASE("(PR) IVF Build", "[ft][build][ivf][pr]") {
-    auto test_index = std::make_shared<fixtures::IVFTestIndex>();
-    auto resource = test_index->GetResource(true);
-    TestIVFBuild(resource);
-}
-
-TEST_CASE("(Daily) IVF Build", "[ft][build][ivf][daily]") {
-    auto test_index = std::make_shared<fixtures::IVFTestIndex>();
-    auto resource = test_index->GetResource(false);
-    TestIVFBuild(resource);
-}
+IVF_PR_DAILY_CASE("IVF Build", "[ft][build][ivf]", TestIVFBuild)
 
 static void
 TestIVFSearchOvertime(const fixtures::IVFResourcePtr& resource) {
@@ -667,17 +647,7 @@ TestIVFSearchOvertime(const fixtures::IVFResourcePtr& resource) {
     }
 }
 
-TEST_CASE("(PR) IVF Search Overtime", "[ft][search][ivf][pr]") {
-    auto test_index = std::make_shared<fixtures::IVFTestIndex>();
-    auto resource = test_index->GetResource(true);
-    TestIVFSearchOvertime(resource);
-}
-
-TEST_CASE("(Daily) IVF Search Overtime", "[ft][search][ivf][daily]") {
-    auto test_index = std::make_shared<fixtures::IVFTestIndex>();
-    auto resource = test_index->GetResource(false);
-    TestIVFSearchOvertime(resource);
-}
+IVF_PR_DAILY_CASE("IVF Search Overtime", "[ft][search][ivf]", TestIVFSearchOvertime)
 
 static void
 TestIVFBuildWithLargeK(const fixtures::IVFResourcePtr& resource) {
@@ -720,70 +690,34 @@ TestIVFBuildWithLargeK(const fixtures::IVFResourcePtr& resource) {
     }
 }
 
-TEST_CASE("(PR) IVF Build With Large K", "[ft][build][ivf][pr]") {
-    auto test_index = std::make_shared<fixtures::IVFTestIndex>();
-    auto resource = test_index->GetResource(true);
-    TestIVFBuildWithLargeK(resource);
-}
-
-TEST_CASE("(Daily) IVF Build With Large K", "[ft][build][ivf][daily]") {
-    auto test_index = std::make_shared<fixtures::IVFTestIndex>();
-    auto resource = test_index->GetResource(false);
-    TestIVFBuildWithLargeK(resource);
-}
+IVF_PR_DAILY_CASE("IVF Build With Large K", "[ft][build][ivf]", TestIVFBuildWithLargeK)
 
 static void
 TestIVFMarkRemove(const fixtures::IVFResourcePtr& resource) {
     using namespace fixtures;
-    auto origin_size = vsag::Options::Instance().block_size_limit();
-    auto size = GENERATE(1024 * 1024 * 2);
-    for (auto metric_type : resource->metric_types) {
-        for (auto dim : resource->dims) {
-            for (auto train_type : resource->train_types) {
-                for (auto [base_quantization_str, recall] : resource->test_cases) {
-                    if (train_type == "kmeans") {
-                        recall *= 0.8F;  // Kmeans may not achieve high recall in random datasets
-                    }
-                    if (base_quantization_str == "fp16") {
-                        recall *= (1 - dim / 8192.0F);
-                    }
-                    auto count = std::min(300, static_cast<int32_t>(dim / 4));
-                    auto search_param =
-                        fmt::format(fixtures::search_param_tmp, std::max(250, count));
-                    INFO(
-                        fmt::format("metric_type: {}, dim: {}, base_quantization_str: {}, "
-                                    "train_type: {}, recall: {}",
-                                    metric_type,
-                                    dim,
-                                    base_quantization_str,
-                                    train_type,
-                                    recall));
-                    vsag::Options::Instance().set_block_size_limit(size);
-                    auto param = IVFTestIndex::GenerateIVFBuildParametersString(
-                        metric_type, dim, base_quantization_str, 300, train_type);
-                    auto index = TestIndex::TestFactory(IVFTestIndex::name, param, true);
-                    auto dataset = IVFTestIndex::pool.GetDatasetAndCreate(
-                        dim, resource->base_count, metric_type);
-                    TestIndex::TestMarkRemoveIndex(index, dataset, search_param, true);
-                    IVFTestIndex::TestGeneral(index, dataset, search_param, recall);
-                    vsag::Options::Instance().set_block_size_limit(origin_size);
-                }
-            }
-        }
-    }
+    ForEachIVFCase(resource,
+                   resource->test_cases,
+                   [&](const auto& metric_type,
+                       int64_t dim,
+                       const auto& train_type,
+                       const auto& base_quantization_str,
+                       float recall) {
+                       RunWithGeneratedBlockSizeLimit([&] {
+                           const auto count = std::min(300, static_cast<int32_t>(dim / 4));
+                           const auto search_param =
+                               fmt::format(fixtures::search_param_tmp, std::max(250, count));
+                           auto param = IVFTestIndex::GenerateIVFBuildParametersString(
+                               metric_type, dim, base_quantization_str, 300, train_type);
+                           auto index = TestIndex::TestFactory(IVFTestIndex::name, param, true);
+                           auto dataset = IVFTestIndex::pool.GetDatasetAndCreate(
+                               dim, resource->base_count, metric_type);
+                           TestIndex::TestMarkRemoveIndex(index, dataset, search_param, true);
+                           IVFTestIndex::TestGeneral(index, dataset, search_param, recall);
+                       });
+                   });
 }
 
-TEST_CASE("(PR) IVF Mark Remove", "[ft][remove][ivf][pr]") {
-    auto test_index = std::make_shared<fixtures::IVFTestIndex>();
-    auto resource = test_index->GetResource(true);
-    TestIVFMarkRemove(resource);
-}
-
-TEST_CASE("(Daily) IVF Mark Remove", "[ft][remove][ivf][daily]") {
-    auto test_index = std::make_shared<fixtures::IVFTestIndex>();
-    auto resource = test_index->GetResource(false);
-    TestIVFMarkRemove(resource);
-}
+IVF_PR_DAILY_CASE("IVF Mark Remove", "[ft][remove][ivf]", TestIVFMarkRemove)
 
 static void
 TestIVFWithAttr(const fixtures::IVFResourcePtr& resource) {
@@ -849,17 +783,7 @@ TestIVFWithAttr(const fixtures::IVFResourcePtr& resource) {
     }
 }
 
-TEST_CASE("(PR) IVF Build With Attribute", "[ft][filter_search][ivf][build][pr]") {
-    auto test_index = std::make_shared<fixtures::IVFTestIndex>();
-    auto resource = test_index->GetResource(true);
-    TestIVFWithAttr(resource);
-}
-
-TEST_CASE("(Daily) IVF Build With Attribute", "[ft][filter_search][ivf][build][daily]") {
-    auto test_index = std::make_shared<fixtures::IVFTestIndex>();
-    auto resource = test_index->GetResource(false);
-    TestIVFWithAttr(resource);
-}
+IVF_PR_DAILY_CASE("IVF Build With Attribute", "[ft][filter_search][ivf][build]", TestIVFWithAttr)
 
 static void
 TestIVFExportModel(const fixtures::IVFResourcePtr& resource) {
@@ -917,112 +841,64 @@ TEST_CASE("(Daily) IVF IVF Export Model", "[ft][export][ivf][daily]") {
 static void
 TestIVFAdd(const fixtures::IVFResourcePtr& resource) {
     using namespace fixtures;
-    auto origin_size = vsag::Options::Instance().block_size_limit();
-    auto size = GENERATE(1024 * 1024 * 2);
-    for (auto metric_type : resource->metric_types) {
-        for (auto dim : resource->dims) {
-            for (auto train_type : resource->train_types) {
-                for (auto [base_quantization_str, recall] : resource->test_cases) {
-                    if (train_type == "kmeans") {
-                        recall *= 0.8F;  // Kmeans may not achieve high recall in random datasets
-                    }
-                    auto count = std::min(300, static_cast<int32_t>(dim / 4));
-                    auto search_param =
-                        fmt::format(fixtures::search_param_tmp, std::max(200, count));
-                    INFO(
-                        fmt::format("metric_type: {}, dim: {}, base_quantization_str: {}, "
-                                    "train_type: {}, recall: {}",
-                                    metric_type,
-                                    dim,
-                                    base_quantization_str,
-                                    train_type,
-                                    recall));
-                    vsag::Options::Instance().set_block_size_limit(size);
-                    auto param = IVFTestIndex::GenerateIVFBuildParametersString(
-                        metric_type, dim, base_quantization_str, 300, train_type);
-                    auto index = IVFTestIndex::TestFactory(IVFTestIndex::name, param, true);
-                    auto dataset = IVFTestIndex::pool.GetDatasetAndCreate(
-                        dim, resource->base_count, metric_type);
-                    IVFTestIndex::TestAddIndex(index, dataset, true);
-                    if (index->CheckFeature(vsag::SUPPORT_ADD_FROM_EMPTY)) {
-                        IVFTestIndex::TestGeneral(index, dataset, search_param, recall);
-                    }
-                    vsag::Options::Instance().set_block_size_limit(origin_size);
-                }
-            }
-        }
-    }
+    ForEachIVFCase(resource,
+                   resource->test_cases,
+                   [&](const auto& metric_type,
+                       int64_t dim,
+                       const auto& train_type,
+                       const auto& base_quantization_str,
+                       float recall) {
+                       RunWithGeneratedBlockSizeLimit([&] {
+                           const auto count = std::min(300, static_cast<int32_t>(dim / 4));
+                           const auto search_param =
+                               fmt::format(fixtures::search_param_tmp, std::max(200, count));
+                           auto param = IVFTestIndex::GenerateIVFBuildParametersString(
+                               metric_type, dim, base_quantization_str, 300, train_type);
+                           auto index = IVFTestIndex::TestFactory(IVFTestIndex::name, param, true);
+                           auto dataset = IVFTestIndex::pool.GetDatasetAndCreate(
+                               dim, resource->base_count, metric_type);
+                           IVFTestIndex::TestAddIndex(index, dataset, true);
+                           if (index->CheckFeature(vsag::SUPPORT_ADD_FROM_EMPTY)) {
+                               IVFTestIndex::TestGeneral(index, dataset, search_param, recall);
+                           }
+                       });
+                   });
 }
 
-TEST_CASE("(PR) IVF Add", "[ft][build][ivf][pr]") {
-    auto test_index = std::make_shared<fixtures::IVFTestIndex>();
-    auto resource = test_index->GetResource(true);
-    TestIVFAdd(resource);
-}
-
-TEST_CASE("(Daily) IVF Add", "[ft][build][ivf][daily]") {
-    auto test_index = std::make_shared<fixtures::IVFTestIndex>();
-    auto resource = test_index->GetResource(false);
-    TestIVFAdd(resource);
-}
+IVF_PR_DAILY_CASE("IVF Add", "[ft][build][ivf]", TestIVFAdd)
 
 static void
 TestIVFMerge(const fixtures::IVFResourcePtr& resource) {
     using namespace fixtures;
-    auto origin_size = vsag::Options::Instance().block_size_limit();
-    auto size = GENERATE(1024 * 1024 * 2);
-    for (auto metric_type : resource->metric_types) {
-        for (auto dim : resource->dims) {
-            for (auto train_type : resource->train_types) {
-                for (auto [base_quantization_str, recall] : resource->test_cases) {
-                    if (train_type == "kmeans") {
-                        recall *= 0.8F;  // Kmeans may not achieve high recall in random datasets
-                    }
-                    if (base_quantization_str == "fp16") {
-                        recall *= (1 - dim / 8192.0F);
-                    }
-                    auto count = std::min(300, static_cast<int32_t>(dim / 4));
-                    auto search_param =
-                        fmt::format(fixtures::search_param_tmp, std::max(200, count));
-                    INFO(
-                        fmt::format("metric_type: {}, dim: {}, base_quantization_str: {}, "
-                                    "train_type: {}, recall: {}",
-                                    metric_type,
-                                    dim,
-                                    base_quantization_str,
-                                    train_type,
-                                    recall));
-                    vsag::Options::Instance().set_block_size_limit(size);
-                    auto param = IVFTestIndex::GenerateIVFBuildParametersString(
-                        metric_type, dim, base_quantization_str, 300, train_type);
-                    auto model = IVFTestIndex::TestFactory(IVFTestIndex::name, param, true);
-                    auto dataset = IVFTestIndex::pool.GetDatasetAndCreate(
-                        dim, resource->base_count, metric_type);
-                    auto ret = model->Train(dataset->base_);
-                    REQUIRE(ret.has_value() == true);
-                    auto merge_index =
-                        IVFTestIndex::TestMergeIndexWithSameModel(model, dataset, 5, true);
-                    if (model->CheckFeature(vsag::SUPPORT_MERGE_INDEX)) {
-                        IVFTestIndex::TestGeneral(merge_index, dataset, search_param, recall);
-                    }
-                    vsag::Options::Instance().set_block_size_limit(origin_size);
+    ForEachIVFCase(
+        resource,
+        resource->test_cases,
+        [&](const auto& metric_type,
+            int64_t dim,
+            const auto& train_type,
+            const auto& base_quantization_str,
+            float recall) {
+            RunWithGeneratedBlockSizeLimit([&] {
+                const auto count = std::min(300, static_cast<int32_t>(dim / 4));
+                const auto search_param =
+                    fmt::format(fixtures::search_param_tmp, std::max(200, count));
+                auto param = IVFTestIndex::GenerateIVFBuildParametersString(
+                    metric_type, dim, base_quantization_str, 300, train_type);
+                auto model = IVFTestIndex::TestFactory(IVFTestIndex::name, param, true);
+                auto dataset =
+                    IVFTestIndex::pool.GetDatasetAndCreate(dim, resource->base_count, metric_type);
+                auto ret = model->Train(dataset->base_);
+                REQUIRE(ret.has_value() == true);
+                auto merge_index =
+                    IVFTestIndex::TestMergeIndexWithSameModel(model, dataset, 5, true);
+                if (model->CheckFeature(vsag::SUPPORT_MERGE_INDEX)) {
+                    IVFTestIndex::TestGeneral(merge_index, dataset, search_param, recall);
                 }
-            }
-        }
-    }
+            });
+        });
 }
 
-TEST_CASE("(PR) IVF Merge", "[ft][merge][ivf][pr]") {
-    auto test_index = std::make_shared<fixtures::IVFTestIndex>();
-    auto resource = test_index->GetResource(true);
-    TestIVFMerge(resource);
-}
-
-TEST_CASE("(Daily) IVF Merge", "[ft][merge][ivf][daily]") {
-    auto test_index = std::make_shared<fixtures::IVFTestIndex>();
-    auto resource = test_index->GetResource(false);
-    TestIVFMerge(resource);
-}
+IVF_PR_DAILY_CASE("IVF Merge", "[ft][merge][ivf]", TestIVFMerge)
 
 static void
 TestIVFConcurrentAdd(const fixtures::IVFResourcePtr& resource) {
@@ -1070,17 +946,7 @@ TestIVFConcurrentAdd(const fixtures::IVFResourcePtr& resource) {
     }
 }
 
-TEST_CASE("(PR) IVF Concurrent Add", "[ft][build][concurrent][ivf][pr]") {
-    auto test_index = std::make_shared<fixtures::IVFTestIndex>();
-    auto resource = test_index->GetResource(true);
-    TestIVFConcurrentAdd(resource);
-}
-
-TEST_CASE("(Daily) IVF Concurrent Add", "[ft][build][concurrent][ivf][daily]") {
-    auto test_index = std::make_shared<fixtures::IVFTestIndex>();
-    auto resource = test_index->GetResource(false);
-    TestIVFConcurrentAdd(resource);
-}
+IVF_PR_DAILY_CASE("IVF Concurrent Add", "[ft][build][concurrent][ivf]", TestIVFConcurrentAdd)
 
 static void
 TestIVFSerialize(const fixtures::IVFResourcePtr& resource) {
@@ -1149,17 +1015,7 @@ TestIVFSerialize(const fixtures::IVFResourcePtr& resource) {
     }
 }
 
-TEST_CASE("(PR) IVF Serialize File", "[ft][serialize][ivf][pr]") {
-    auto test_index = std::make_shared<fixtures::IVFTestIndex>();
-    auto resource = test_index->GetResource(true);
-    TestIVFSerialize(resource);
-}
-
-TEST_CASE("(Daily) IVF Serialize File", "[ft][serialize][ivf][daily]") {
-    auto test_index = std::make_shared<fixtures::IVFTestIndex>();
-    auto resource = test_index->GetResource(false);
-    TestIVFSerialize(resource);
-}
+IVF_PR_DAILY_CASE("IVF Serialize File", "[ft][serialize][ivf]", TestIVFSerialize)
 
 static void
 TestIVFClone(const fixtures::IVFResourcePtr& resource) {
@@ -1200,17 +1056,7 @@ TestIVFClone(const fixtures::IVFResourcePtr& resource) {
     }
 }
 
-TEST_CASE("(PR) IVF Clone", "[ft][clone][ivf][pr]") {
-    auto test_index = std::make_shared<fixtures::IVFTestIndex>();
-    auto resource = test_index->GetResource(true);
-    TestIVFClone(resource);
-}
-
-TEST_CASE("(Daily) IVF Clone", "[ft][clone][ivf][daily]") {
-    auto test_index = std::make_shared<fixtures::IVFTestIndex>();
-    auto resource = test_index->GetResource(false);
-    TestIVFClone(resource);
-}
+IVF_PR_DAILY_CASE("IVF Clone", "[ft][clone][ivf]", TestIVFClone)
 
 static void
 TestIVFRandomAllocator(const fixtures::IVFResourcePtr& resource) {
@@ -1254,19 +1100,9 @@ TestIVFRandomAllocator(const fixtures::IVFResourcePtr& resource) {
     }
 }
 
-TEST_CASE("(PR) IVF Build & ContinueAdd Test With Random Allocator",
-          "[ft][build][concurrent][ivf][pr]") {
-    auto test_index = std::make_shared<fixtures::IVFTestIndex>();
-    auto resource = test_index->GetResource(true);
-    TestIVFRandomAllocator(resource);
-}
-
-TEST_CASE("(Daily) IVF Build & ContinueAdd Test With Random Allocator",
-          "[ft][build][concurrent][ivf][daily]") {
-    auto test_index = std::make_shared<fixtures::IVFTestIndex>();
-    auto resource = test_index->GetResource(false);
-    TestIVFRandomAllocator(resource);
-}
+IVF_PR_DAILY_CASE("IVF Build & ContinueAdd Test With Random Allocator",
+                  "[ft][build][concurrent][ivf]",
+                  TestIVFRandomAllocator)
 
 static void
 TestIVFEstimateMemoryAndGetMemoryUsage(const fixtures::IVFResourcePtr& resource) {
@@ -1362,17 +1198,9 @@ TestIVFBuildMultiBucketsPerData(const fixtures::IVFResourcePtr& resource) {
     }
 }
 
-TEST_CASE("(PR) IVF Build Multi Buckets Per Data", "[ft][build][ivf][pr]") {
-    auto test_index = std::make_shared<fixtures::IVFTestIndex>();
-    auto resource = test_index->GetResource(true);
-    TestIVFBuildMultiBucketsPerData(resource);
-}
-
-TEST_CASE("(Daily) IVF Build Multi Buckets Per Data", "[ft][build][ivf][daily]") {
-    auto test_index = std::make_shared<fixtures::IVFTestIndex>();
-    auto resource = test_index->GetResource(false);
-    TestIVFBuildMultiBucketsPerData(resource);
-}
+IVF_PR_DAILY_CASE("IVF Build Multi Buckets Per Data",
+                  "[ft][build][ivf]",
+                  TestIVFBuildMultiBucketsPerData)
 
 static void
 TestIVFGNOIMIBuild(const fixtures::IVFResourcePtr& resource) {
@@ -1414,17 +1242,7 @@ TestIVFGNOIMIBuild(const fixtures::IVFResourcePtr& resource) {
     }
 }
 
-TEST_CASE("(PR) IVF GNO-IMI Build", "[ft][build][ivf][pr]") {
-    auto test_index = std::make_shared<fixtures::IVFTestIndex>();
-    auto resource = test_index->GetResource(true);
-    TestIVFGNOIMIBuild(resource);
-}
-
-TEST_CASE("(Daily) IVF GNO-IMI Build", "[ft][build][ivf][daily]") {
-    auto test_index = std::make_shared<fixtures::IVFTestIndex>();
-    auto resource = test_index->GetResource(false);
-    TestIVFGNOIMIBuild(resource);
-}
+IVF_PR_DAILY_CASE("IVF GNO-IMI Build", "[ft][build][ivf]", TestIVFGNOIMIBuild)
 
 static void
 TestIVFGNOIMIBuildWithResidual(const fixtures::IVFResourcePtr& resource) {
@@ -1473,14 +1291,6 @@ TestIVFGNOIMIBuildWithResidual(const fixtures::IVFResourcePtr& resource) {
     }
 }
 
-TEST_CASE("(PR) IVF GNO-IMI Build with Residual", "[ft][build][ivf][pr]") {
-    auto test_index = std::make_shared<fixtures::IVFTestIndex>();
-    auto resource = test_index->GetResource(true);
-    TestIVFGNOIMIBuildWithResidual(resource);
-}
-
-TEST_CASE("(Daily) IVF GNO-IMI Build with Residual", "[ft][build][ivf][daily]") {
-    auto test_index = std::make_shared<fixtures::IVFTestIndex>();
-    auto resource = test_index->GetResource(false);
-    TestIVFGNOIMIBuildWithResidual(resource);
-}
+IVF_PR_DAILY_CASE("IVF GNO-IMI Build with Residual",
+                  "[ft][build][ivf]",
+                  TestIVFGNOIMIBuildWithResidual)

--- a/tests/test_ivf.cpp
+++ b/tests/test_ivf.cpp
@@ -312,20 +312,23 @@ AdjustIVFRecall(float recall,
         recall *= 0.8F;
     }
     if (base_quantization_str == "fp16") {
-        recall *= (1 - dim / 8192.0F);
+        recall *= (dim < 8192 ? (1.0F - static_cast<float>(dim) / 8192.0F) : 0.0F);
     }
     return recall;
 }
 
-template <typename Cases, typename Fn>
+template <typename Cases, typename RecallFn, typename Fn>
 void
-ForEachIVFCase(const fixtures::IVFResourcePtr& resource, const Cases& test_cases, Fn&& fn) {
+ForEachIVFCase(const fixtures::IVFResourcePtr& resource,
+               const Cases& test_cases,
+               RecallFn&& recall_fn,
+               Fn&& fn) {
     for (const auto& metric_type : resource->metric_types) {
         for (auto dim : resource->dims) {
             for (const auto& train_type : resource->train_types) {
                 for (const auto& [base_quantization_str, base_recall] : test_cases) {
                     const auto recall =
-                        AdjustIVFRecall(base_recall, train_type, base_quantization_str, dim);
+                        recall_fn(base_recall, train_type, base_quantization_str, dim);
                     INFO(
                         fmt::format("metric_type: {}, dim: {}, base_quantization_str: {}, "
                                     "train_type: {}, recall: {}",
@@ -341,16 +344,20 @@ ForEachIVFCase(const fixtures::IVFResourcePtr& resource, const Cases& test_cases
     }
 }
 
-#define IVF_PR_DAILY_CASE(title, tags, helper)                        \
-    TEST_CASE("(PR) " title, tags "[pr]") {                           \
-        auto test_index = std::make_shared<fixtures::IVFTestIndex>(); \
-        auto resource = test_index->GetResource(true);                \
-        helper(resource);                                             \
-    }                                                                 \
-    TEST_CASE("(Daily) " title, tags "[daily]") {                     \
-        auto test_index = std::make_shared<fixtures::IVFTestIndex>(); \
-        auto resource = test_index->GetResource(false);               \
-        helper(resource);                                             \
+template <typename Cases, typename Fn>
+void
+ForEachIVFCase(const fixtures::IVFResourcePtr& resource, const Cases& test_cases, Fn&& fn) {
+    ForEachIVFCase(resource, test_cases, AdjustIVFRecall, std::forward<Fn>(fn));
+}
+
+#define IVF_PR_DAILY_CASE(title, tags, helper)                      \
+    TEST_CASE("(PR) " title, tags "[pr]") {                         \
+        auto resource = fixtures::IVFTestIndex::GetResource(true);  \
+        helper(resource);                                           \
+    }                                                               \
+    TEST_CASE("(Daily) " title, tags "[daily]") {                   \
+        auto resource = fixtures::IVFTestIndex::GetResource(false); \
+        helper(resource);                                           \
     }
 
 }  // namespace
@@ -903,47 +910,32 @@ IVF_PR_DAILY_CASE("IVF Merge", "[ft][merge][ivf]", TestIVFMerge)
 static void
 TestIVFConcurrentAdd(const fixtures::IVFResourcePtr& resource) {
     using namespace fixtures;
-    auto origin_size = vsag::Options::Instance().block_size_limit();
-    auto size = GENERATE(1024 * 1024 * 2);
-    for (auto metric_type : resource->metric_types) {
-        for (auto dim : resource->dims) {
-            for (auto train_type : resource->train_types) {
-                for (auto [base_quantization_str, recall] : resource->test_cases) {
-                    if (train_type == "kmeans") {
-                        recall *= 0.8F;  // Kmeans may not achieve high recall in random datasets
-                    }
-                    if (base_quantization_str == "pqfs,fp16") {
-                        continue;
-                    }
-                    if (base_quantization_str == "fp16") {
-                        recall *= (1 - dim / 8192.0F);
-                    }
-                    auto count = std::min(300, static_cast<int32_t>(dim / 4));
-                    auto search_param =
-                        fmt::format(fixtures::search_param_tmp, std::max(200, count));
-                    INFO(
-                        fmt::format("metric_type: {}, dim: {}, base_quantization_str: {}, "
-                                    "train_type: {}, recall: {}",
-                                    metric_type,
-                                    dim,
-                                    base_quantization_str,
-                                    train_type,
-                                    recall));
-                    vsag::Options::Instance().set_block_size_limit(size);
-                    auto param = IVFTestIndex::GenerateIVFBuildParametersString(
-                        metric_type, dim, base_quantization_str, 300, train_type);
-                    auto index = IVFTestIndex::TestFactory(IVFTestIndex::name, param, true);
-                    auto dataset = IVFTestIndex::pool.GetDatasetAndCreate(
-                        dim, resource->base_count, metric_type);
-                    IVFTestIndex::TestConcurrentAdd(index, dataset, true);
-                    if (index->CheckFeature(vsag::SUPPORT_ADD_CONCURRENT)) {
-                        IVFTestIndex::TestGeneral(index, dataset, search_param, recall);
-                    }
-                    vsag::Options::Instance().set_block_size_limit(origin_size);
-                }
-            }
-        }
-    }
+    ForEachIVFCase(resource,
+                   resource->test_cases,
+                   AdjustIVFRecall,
+                   [&](const auto& metric_type,
+                       int64_t dim,
+                       const auto& train_type,
+                       const auto& base_quantization_str,
+                       float recall) {
+                       if (base_quantization_str == "pqfs,fp16") {
+                           return;
+                       }
+                       RunWithGeneratedBlockSizeLimit([&] {
+                           const auto count = std::min(300, static_cast<int32_t>(dim / 4));
+                           const auto search_param =
+                               fmt::format(fixtures::search_param_tmp, std::max(200, count));
+                           auto param = IVFTestIndex::GenerateIVFBuildParametersString(
+                               metric_type, dim, base_quantization_str, 300, train_type);
+                           auto index = IVFTestIndex::TestFactory(IVFTestIndex::name, param, true);
+                           auto dataset = IVFTestIndex::pool.GetDatasetAndCreate(
+                               dim, resource->base_count, metric_type);
+                           IVFTestIndex::TestConcurrentAdd(index, dataset, true);
+                           if (index->CheckFeature(vsag::SUPPORT_ADD_CONCURRENT)) {
+                               IVFTestIndex::TestGeneral(index, dataset, search_param, recall);
+                           }
+                       });
+                   });
 }
 
 IVF_PR_DAILY_CASE("IVF Concurrent Add", "[ft][build][concurrent][ivf]", TestIVFConcurrentAdd)
@@ -951,68 +943,59 @@ IVF_PR_DAILY_CASE("IVF Concurrent Add", "[ft][build][concurrent][ivf]", TestIVFC
 static void
 TestIVFSerialize(const fixtures::IVFResourcePtr& resource) {
     using namespace fixtures;
-    auto origin_size = vsag::Options::Instance().block_size_limit();
-    auto size = GENERATE(1024 * 1024 * 2);
-    for (auto metric_type : resource->metric_types) {
-        for (auto dim : resource->dims) {
-            for (auto train_type : resource->train_types) {
-                for (auto [base_quantization_str, recall] : resource->test_cases) {
-                    if (train_type == "kmeans") {
-                        recall *= 0.8F;  // Kmeans may not achieve high recall in random datasets
-                    }
-                    auto count = std::min(300, static_cast<int32_t>(dim / 4));
-                    auto search_param =
-                        fmt::format(fixtures::search_param_tmp, std::max(200, count));
-                    INFO(
-                        fmt::format("metric_type: {}, dim: {}, base_quantization_str: {}, "
-                                    "train_type: {}, recall: {}",
-                                    metric_type,
-                                    dim,
-                                    base_quantization_str,
-                                    train_type,
-                                    recall));
-                    vsag::Options::Instance().set_block_size_limit(size);
-                    auto param = IVFTestIndex::GenerateIVFBuildParametersString(
-                        metric_type, dim, base_quantization_str, 300, train_type);
-                    auto index = IVFTestIndex::TestFactory(IVFTestIndex::name, param, true);
-
-                    if (index->CheckFeature(vsag::SUPPORT_BUILD)) {
-                        auto dataset = IVFTestIndex::pool.GetDatasetAndCreate(
-                            dim, resource->base_count, metric_type);
-                        IVFTestIndex::TestBuildIndex(index, dataset, true);
-                        if (index->CheckFeature(vsag::SUPPORT_SERIALIZE_FILE) and
-                            index->CheckFeature(vsag::SUPPORT_DESERIALIZE_FILE)) {
-                            auto index2 =
-                                IVFTestIndex::TestFactory(IVFTestIndex::name, param, true);
-                            IVFTestIndex::TestSerializeFile(
-                                index, index2, dataset, search_param, true);
-                        }
-                        if (index->CheckFeature(vsag::SUPPORT_SERIALIZE_BINARY_SET) and
-                            index->CheckFeature(vsag::SUPPORT_DESERIALIZE_BINARY_SET)) {
-                            auto index2 =
-                                IVFTestIndex::TestFactory(IVFTestIndex::name, param, true);
-                            IVFTestIndex::TestSerializeBinarySet(
-                                index, index2, dataset, search_param, true);
-                        }
-                        if (index->CheckFeature(vsag::SUPPORT_SERIALIZE_FILE) and
-                            index->CheckFeature(vsag::SUPPORT_DESERIALIZE_READER_SET)) {
-                            auto index2 =
-                                IVFTestIndex::TestFactory(IVFTestIndex::name, param, true);
-                            IVFTestIndex::TestSerializeReaderSet(
-                                index, index2, dataset, search_param, IVFTestIndex::name, true);
-                        }
-                        if (index->CheckFeature(vsag::SUPPORT_SERIALIZE_WRITE_FUNC)) {
-                            auto index2 =
-                                IVFTestIndex::TestFactory(IVFTestIndex::name, param, true);
-                            IVFTestIndex::TestSerializeWriteFunc(
-                                index, index2, dataset, search_param, true);
-                        }
-                    }
-                    vsag::Options::Instance().set_block_size_limit(origin_size);
-                }
+    auto adjust_serialize_recall =
+        [](float recall, const std::string& train_type, const std::string&, int64_t) {
+            if (train_type == "kmeans") {
+                recall *= 0.8F;
             }
-        }
-    }
+            return recall;
+        };
+    ForEachIVFCase(
+        resource,
+        resource->test_cases,
+        adjust_serialize_recall,
+        [&](const auto& metric_type,
+            int64_t dim,
+            const auto& train_type,
+            const auto& base_quantization_str,
+            float recall) {
+            RunWithGeneratedBlockSizeLimit([&] {
+                const auto count = std::min(300, static_cast<int32_t>(dim / 4));
+                const auto search_param =
+                    fmt::format(fixtures::search_param_tmp, std::max(200, count));
+                auto param = IVFTestIndex::GenerateIVFBuildParametersString(
+                    metric_type, dim, base_quantization_str, 300, train_type);
+                auto index = IVFTestIndex::TestFactory(IVFTestIndex::name, param, true);
+
+                if (index->CheckFeature(vsag::SUPPORT_BUILD)) {
+                    auto dataset = IVFTestIndex::pool.GetDatasetAndCreate(
+                        dim, resource->base_count, metric_type);
+                    IVFTestIndex::TestBuildIndex(index, dataset, true);
+                    if (index->CheckFeature(vsag::SUPPORT_SERIALIZE_FILE) and
+                        index->CheckFeature(vsag::SUPPORT_DESERIALIZE_FILE)) {
+                        auto index2 = IVFTestIndex::TestFactory(IVFTestIndex::name, param, true);
+                        IVFTestIndex::TestSerializeFile(index, index2, dataset, search_param, true);
+                    }
+                    if (index->CheckFeature(vsag::SUPPORT_SERIALIZE_BINARY_SET) and
+                        index->CheckFeature(vsag::SUPPORT_DESERIALIZE_BINARY_SET)) {
+                        auto index2 = IVFTestIndex::TestFactory(IVFTestIndex::name, param, true);
+                        IVFTestIndex::TestSerializeBinarySet(
+                            index, index2, dataset, search_param, true);
+                    }
+                    if (index->CheckFeature(vsag::SUPPORT_SERIALIZE_FILE) and
+                        index->CheckFeature(vsag::SUPPORT_DESERIALIZE_READER_SET)) {
+                        auto index2 = IVFTestIndex::TestFactory(IVFTestIndex::name, param, true);
+                        IVFTestIndex::TestSerializeReaderSet(
+                            index, index2, dataset, search_param, IVFTestIndex::name, true);
+                    }
+                    if (index->CheckFeature(vsag::SUPPORT_SERIALIZE_WRITE_FUNC)) {
+                        auto index2 = IVFTestIndex::TestFactory(IVFTestIndex::name, param, true);
+                        IVFTestIndex::TestSerializeWriteFunc(
+                            index, index2, dataset, search_param, true);
+                    }
+                }
+            });
+        });
 }
 
 IVF_PR_DAILY_CASE("IVF Serialize File", "[ft][serialize][ivf]", TestIVFSerialize)


### PR DESCRIPTION
## Summary
- deduplicate repeated PR/Daily functest wrappers in `tests/test_hgraph.cpp` and `tests/test_ivf.cpp`
- extract shared test-case iteration helpers for the most repetitive HGraph and IVF setup flows
- keep the existing PR-only and historical test names that CI already relies on

## Testing
- `/usr/bin/clang-format-15 -i tests/test_hgraph.cpp tests/test_ivf.cpp`
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DENABLE_ASAN=OFF -DENABLE_CCACHE=ON -DENABLE_TESTS=ON -DENABLE_MOCKIMPL=ON -DENABLE_PYBINDS=OFF -DENABLE_TOOLS=OFF -DENABLE_EXAMPLES=OFF -DENABLE_INTEL_MKL=OFF -DENABLE_LIBAIO=ON`
- `cmake --build build --target functests --parallel 6`
- `build/tests/functests -d yes "[pr][ivf]" --allow-running-no-tests`
- `build/tests/functests -d yes "\"(PR) HGraph Reverse Edges\"" --allow-running-no-tests`
- `build/tests/functests -d yes "[pr][hgraph],[pr][ivf]" --allow-running-no-tests` (timed out after covering the HGraph PR suite through the final case; no failures before timeout)