### PR TITLE
feat: add MultiVector dataset support and migrate WARP to MultiVectors API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -199,3 +199,6 @@ data/
 opencode.json
 _codeql_detected_source_root
 wheelhouse/
+
+# claude-code
+.claude/

--- a/examples/cpp/110_index_warp.cpp
+++ b/examples/cpp/110_index_warp.cpp
@@ -34,7 +34,7 @@ main(int argc, char** argv) {
     std::uniform_int_distribution<int> vec_count_dist(5, 10);
 
     // Generate MultiVector array: each document owns its own vectors buffer
-    std::vector<vsag::MultiVector> multi_vectors(num_elements);
+    vsag::MultiVector* multi_vectors = new vsag::MultiVector[num_elements];
     uint64_t total_vectors = 0;
     for (int64_t i = 0; i < num_elements; ++i) {
         ids[i] = i;
@@ -47,14 +47,14 @@ main(int argc, char** argv) {
         total_vectors += len;
     }
 
-    // Create dataset with MultiVectors API
+    // Create dataset with MultiVectors API (Owner(true) transfers memory ownership to Dataset)
     vsag::DatasetPtr base = vsag::Dataset::Make();
     base->NumElements(num_elements)
         ->Dim(dim)
         ->Ids(ids.data())
-        ->MultiVectors(multi_vectors.data())
+        ->MultiVectors(multi_vectors)
         ->MultiVectorDim(dim)
-        ->Owner(false);
+        ->Owner(true);
 
     std::cout << "Created multi-vector dataset with " << num_elements << " elements (documents)"
               << std::endl;
@@ -70,7 +70,8 @@ main(int argc, char** argv) {
         "dim": 128
     }
     )";
-    std::shared_ptr<vsag::Index> index = vsag::Factory::CreateIndex("warp", warp_build_parameters).value();
+    std::shared_ptr<vsag::Index> index =
+        vsag::Factory::CreateIndex("warp", warp_build_parameters).value();
 
     /******************* Build WARP Index *****************/
     if (auto build_result = index->Build(base); build_result.has_value()) {
@@ -114,11 +115,6 @@ main(int argc, char** argv) {
     for (int64_t i = 0; i < result->GetDim(); ++i) {
         std::cout << "  Document " << result->GetIds()[i]
                   << ": score = " << result->GetDistances()[i] << std::endl;
-    }
-
-    // Cleanup multi-vector buffers
-    for (int64_t i = 0; i < num_elements; ++i) {
-        delete[] multi_vectors[i].vectors_;
     }
 
     return 0;

--- a/examples/cpp/110_index_warp.cpp
+++ b/examples/cpp/110_index_warp.cpp
@@ -23,44 +23,43 @@ main(int argc, char** argv) {
     vsag::init();
 
     /******************* Prepare Multi-Vector Base Dataset *****************/
-    // In ColBERT-style retrieval, each document has multiple vectors (one per token)
-    // We'll create 100 documents, each with variable number of vectors (5-10)
-    int64_t num_docs = 100;
+    // In ColBERT-style retrieval, each element (document) has multiple vectors (one per token)
+    // We'll create 100 elements (documents), each with variable number of vectors (5-10)
+    int64_t num_elements = 100;
     int64_t dim = 128;
 
-    std::vector<int64_t> ids(num_docs);
-    std::vector<uint32_t> vector_counts(num_docs);
-    std::vector<float> datas;
+    std::vector<int64_t> ids(num_elements);
     std::mt19937 rng(47);
     std::uniform_real_distribution<float> distrib_real;
     std::uniform_int_distribution<int> vec_count_dist(5, 10);
 
-    // Generate document IDs and variable vector counts
+    // Generate MultiVector array: each document owns its own vectors buffer
+    std::vector<vsag::MultiVector> multi_vectors(num_elements);
     uint64_t total_vectors = 0;
-    for (int64_t i = 0; i < num_docs; ++i) {
+    for (int64_t i = 0; i < num_elements; ++i) {
         ids[i] = i;
-        vector_counts[i] = vec_count_dist(rng);
-        total_vectors += vector_counts[i];
+        uint32_t len = vec_count_dist(rng);
+        multi_vectors[i].len_ = len;
+        multi_vectors[i].vectors_ = new float[len * dim];
+        for (uint32_t j = 0; j < len * dim; ++j) {
+            multi_vectors[i].vectors_[j] = distrib_real(rng);
+        }
+        total_vectors += len;
     }
 
-    // Generate all vectors
-    datas.reserve(total_vectors * dim);
-    for (uint64_t i = 0; i < total_vectors * dim; ++i) {
-        datas.push_back(distrib_real(rng));
-    }
-
-    // Create dataset with VectorCounts for multi-vector support
-    auto base = vsag::Dataset::Make();
-    base->NumElements(num_docs)
+    // Create dataset with MultiVectors API
+    vsag::DatasetPtr base = vsag::Dataset::Make();
+    base->NumElements(num_elements)
         ->Dim(dim)
         ->Ids(ids.data())
-        ->Float32Vectors(datas.data())
-        ->VectorCounts(vector_counts.data())  // Specify number of vectors per document
+        ->MultiVectors(multi_vectors.data())
+        ->MultiVectorDim(dim)
         ->Owner(false);
 
-    std::cout << "Created multi-vector dataset with " << num_docs << " documents" << std::endl;
-    std::cout << "Total vectors: " << total_vectors << " (avg " << (double)total_vectors / num_docs
-              << " vectors per doc)" << std::endl;
+    std::cout << "Created multi-vector dataset with " << num_elements << " elements (documents)"
+              << std::endl;
+    std::cout << "Total vectors: " << total_vectors << " (avg "
+              << (double)total_vectors / num_elements << " vectors per element)" << std::endl;
 
     /******************* Create WARP Index *****************/
     // WARP index for ColBERT-style maxsin similarity
@@ -71,12 +70,12 @@ main(int argc, char** argv) {
         "dim": 128
     }
     )";
-    auto index = vsag::Factory::CreateIndex("warp", warp_build_parameters).value();
+    std::shared_ptr<vsag::Index> index = vsag::Factory::CreateIndex("warp", warp_build_parameters).value();
 
     /******************* Build WARP Index *****************/
     if (auto build_result = index->Build(base); build_result.has_value()) {
         std::cout << "After Build(), Index WARP contains: " << index->GetNumElements()
-                  << " documents" << std::endl;
+                  << " elements (documents)" << std::endl;
     } else {
         std::cerr << "Failed to build index: " << build_result.error().message << std::endl;
         exit(-1);
@@ -90,11 +89,15 @@ main(int argc, char** argv) {
         query_vectors[i] = distrib_real(rng);
     }
 
-    auto query = vsag::Dataset::Make();
+    vsag::MultiVector query_multi_vectors;
+    query_multi_vectors.len_ = query_vec_count;
+    query_multi_vectors.vectors_ = query_vectors.data();
+
+    vsag::DatasetPtr query = vsag::Dataset::Make();
     query->NumElements(1)
         ->Dim(dim)
-        ->Float32Vectors(query_vectors.data())
-        ->VectorCounts(&query_vec_count)  // Specify query has multiple vectors
+        ->MultiVectors(&query_multi_vectors)
+        ->MultiVectorDim(dim)
         ->Owner(false);
 
     std::cout << "Query has " << query_vec_count << " vectors" << std::endl;
@@ -102,15 +105,20 @@ main(int argc, char** argv) {
     /******************* KnnSearch For WARP Index *****************/
     // WARP performs maxsin similarity: for each query vector, find max similarity
     // with any document vector, sum across query vectors
-    auto warp_search_parameters = R"({})";
+    std::string warp_search_parameters = R"({})";
     int64_t topk = 5;
-    auto result = index->KnnSearch(query, topk, warp_search_parameters).value();
+    vsag::DatasetPtr result = index->KnnSearch(query, topk, warp_search_parameters).value();
 
     /******************* Print Search Result *****************/
     std::cout << "Top-" << topk << " results (maxsin similarity): " << std::endl;
     for (int64_t i = 0; i < result->GetDim(); ++i) {
         std::cout << "  Document " << result->GetIds()[i]
                   << ": score = " << result->GetDistances()[i] << std::endl;
+    }
+
+    // Cleanup multi-vector buffers
+    for (int64_t i = 0; i < num_elements; ++i) {
+        delete[] multi_vectors[i].vectors_;
     }
 
     return 0;

--- a/include/vsag/constants.h
+++ b/include/vsag/constants.h
@@ -39,6 +39,8 @@ extern const char* const DATASET_PATHS;
 extern const char* const EXTRA_INFOS;
 extern const char* const EXTRA_INFO_SIZE;
 extern const char* const VECTOR_COUNTS;
+extern const char* const MULTI_VECTORS;
+extern const char* const MULTI_VECTOR_DIM;
 
 extern const char* const HNSW_DATA;
 extern const char* const CONJUGATE_GRAPH_DATA;

--- a/include/vsag/dataset.h
+++ b/include/vsag/dataset.h
@@ -35,6 +35,23 @@ struct SparseVector {
     float* vals_ = nullptr;    // contains vals with size of len_
 };
 
+/**
+ * @brief Represents one document's multi-vector data.
+ *
+ * @details
+ * Each document may contain a variable number of dense sub-vectors.
+ * The sub-vector dimensionality is defined at the Dataset level via
+ * MultiVectorDim(), not per-element.
+ *
+ * @note When Owner(true) is set on the Dataset, each element's vectors_
+ * pointer must be independently allocated (not an offset into a shared
+ * buffer), because the Dataset destructor will free each vectors_ separately.
+ */
+struct MultiVector {
+    uint32_t len_ = 0;          // number of sub-vectors in this document
+    float* vectors_ = nullptr;  // flat array of len_ * MultiVectorDim floats
+};
+
 class Dataset;
 using DatasetPtr = std::shared_ptr<Dataset>;
 

--- a/include/vsag/dataset.h
+++ b/include/vsag/dataset.h
@@ -422,6 +422,52 @@ public:
      */
     virtual const uint32_t*
     GetVectorCounts() const = 0;
+
+    /**
+     * @brief Sets the multi-vector array for the dataset.
+     *
+     * @details
+     * Each element in the array represents one document's multi-vector data.
+     * The sub-vector dimensionality is defined by MultiVectorDim().
+     *
+     * @note When Owner(true) is set, each MultiVector element's vectors_ pointer
+     * must be independently allocated (not an offset into a shared buffer),
+     * because the destructor will free each vectors_ separately.
+     *
+     * @param multi_vectors Pointer to the array of MultiVector structs (length = NumElements).
+     * @return DatasetPtr A shared pointer to the dataset with updated multi-vectors.
+     */
+    virtual DatasetPtr
+    MultiVectors(const MultiVector* multi_vectors) = 0;
+
+    /**
+     * @brief Retrieves the multi-vector array of the dataset.
+     *
+     * @return const MultiVector* Pointer to the array of MultiVector structs, or nullptr if not set.
+     */
+    virtual const MultiVector*
+    GetMultiVectors() const = 0;
+
+    /**
+     * @brief Sets the sub-vector dimensionality for multi-vector data.
+     *
+     * @details
+     * This defines the number of floats per sub-vector in each MultiVector element.
+     * It is independent of Dim(), which describes the dense single-vector dimensionality.
+     *
+     * @param dim The sub-vector dimensionality (must be > 0 when MultiVectors is used).
+     * @return DatasetPtr A shared pointer to the dataset with updated multi-vector dim.
+     */
+    virtual DatasetPtr
+    MultiVectorDim(int64_t dim) = 0;
+
+    /**
+     * @brief Retrieves the sub-vector dimensionality for multi-vector data.
+     *
+     * @return int64_t The sub-vector dimensionality, or 0 if not set.
+     */
+    virtual int64_t
+    GetMultiVectorDim() const = 0;
 };
 
 };  // namespace vsag

--- a/src/algorithm/warp.cpp
+++ b/src/algorithm/warp.cpp
@@ -16,6 +16,7 @@
 #include "warp.h"
 
 #include <atomic>
+#include <limits>
 #include <mutex>
 #include <numeric>
 #include <optional>
@@ -37,6 +38,11 @@
 #include "utils/slow_task_timer.h"
 #include "utils/util_functions.h"
 namespace vsag {
+
+namespace {
+constexpr InnerIdType MIN_PARALLEL_SEARCH_DOC_COUNT = 1000;
+constexpr float INITIAL_BEST_VECTOR_DISTANCE = std::numeric_limits<float>::infinity();
+}  // namespace
 
 WARP::WARP(const WarpParameterPtr& param, const IndexCommonParam& common_param)
     : InnerIndexInterface(param, common_param), doc_offsets_(allocator_) {
@@ -213,17 +219,17 @@ WARP::compute_maxsin_similarity(const float* query_vectors,
     Vector<float> dists(doc_vec_count, allocator_);
     std::iota(vec_indices.begin(), vec_indices.end(), doc_start_vec_idx);
 
-    // For each query vector, find max similarity with any document vector
+    // FactoryComputer returns distances; keep the best document-vector distance per query vector.
     for (uint32_t q = 0; q < query_vec_count; ++q) {
         const float* query_vec = query_vectors + q * dim_;
         auto computer = this->inner_codes_->FactoryComputer(query_vec);
 
-        float min_sim = std::numeric_limits<float>::max();
+        float best_dist = INITIAL_BEST_VECTOR_DISTANCE;
         this->inner_codes_->Query(dists.data(), computer, vec_indices.data(), doc_vec_count);
-        for (const auto& sim : dists) {
-            min_sim = std::min(min_sim, sim);
+        for (const float dist : dists) {
+            best_dist = std::min(best_dist, dist);
         }
-        total_score += min_sim;
+        total_score += best_dist;
     }
     return total_score;
 }
@@ -299,7 +305,8 @@ WARP::SearchWithRequest(const SearchRequest& request) const {
 
     DistHeapPtr heap = nullptr;
 
-    if (parallel_count == 1 || this->thread_pool_ == nullptr || total_count_ < 1000) {
+    if (parallel_count == 1 || this->thread_pool_ == nullptr ||
+        total_count_ < MIN_PARALLEL_SEARCH_DOC_COUNT) {
         heap = search_func(0, total_count_);
     } else {
         std::vector<std::future<DistHeapPtr>> futures;
@@ -375,7 +382,8 @@ WARP::RangeSearch(const vsag::DatasetPtr& query,
     auto parallel_count = warp_params.parallel_search_thread_count;
 
     // Use serial version if no thread pool or small dataset
-    if (parallel_count == 1 || this->thread_pool_ == nullptr || total_count_ < 1000) {
+    if (parallel_count == 1 || this->thread_pool_ == nullptr ||
+        total_count_ < MIN_PARALLEL_SEARCH_DOC_COUNT) {
         auto heap = std::make_shared<StandardHeap<true, true>>(this->allocator_, limited_size);
 
         for (InnerIdType doc_id = 0; doc_id < total_count_; ++doc_id) {

--- a/src/algorithm/warp.cpp
+++ b/src/algorithm/warp.cpp
@@ -16,6 +16,7 @@
 #include "warp.h"
 
 #include <atomic>
+#include <cstring>
 #include <limits>
 #include <mutex>
 #include <numeric>
@@ -67,32 +68,47 @@ WARP::EstimateMemory(uint64_t num_elements) const {
 std::vector<int64_t>
 WARP::Build(const vsag::DatasetPtr& data) {
     this->Train(data);
-    return this->Add(data);
+    std::vector<int64_t> failed_ids = this->Add(data);
+    return failed_ids;
 }
 
 void
 WARP::Train(const DatasetPtr& data) {
-    const float* vectors = data->GetFloat32Vectors();
-    const uint32_t* vector_counts = data->GetVectorCounts();
-    uint64_t train_count = data->GetNumElements();
-    if (vector_counts != nullptr) {
-        train_count = std::accumulate(
-            vector_counts, vector_counts + data->GetNumElements(), static_cast<uint64_t>(0));
+    const MultiVector* multi_vectors = data->GetMultiVectors();
+    CHECK_ARGUMENT(multi_vectors != nullptr, "data.multi_vectors is nullptr");
+
+    int64_t mv_dim = data->GetMultiVectorDim();
+    CHECK_ARGUMENT(mv_dim == dim_,
+                   fmt::format("data.multi_vector_dim({}) must be equal to index.dim({})",
+                               mv_dim,
+                               dim_));
+
+    int64_t num_elements = data->GetNumElements();
+    uint64_t total_vectors = 0;
+    for (int64_t i = 0; i < num_elements; ++i) {
+        total_vectors += multi_vectors[i].len_;
     }
-    this->inner_codes_->Train(vectors, train_count);
+    Vector<float> buffer(total_vectors * mv_dim, allocator_);
+    uint64_t offset = 0;
+    for (int64_t i = 0; i < num_elements; ++i) {
+        uint64_t num_floats = static_cast<uint64_t>(multi_vectors[i].len_) * mv_dim;
+        std::memcpy(buffer.data() + offset, multi_vectors[i].vectors_, num_floats * sizeof(float));
+        offset += num_floats;
+    }
+    this->inner_codes_->Train(buffer.data(), total_vectors);
 }
 
 std::vector<int64_t>
 WARP::Add(const DatasetPtr& data, AddMode mode) {
     std::vector<int64_t> failed_ids;
-    auto base_dim = data->GetDim();
-    CHECK_ARGUMENT(base_dim == dim_,
-                   fmt::format("base.dim({}) must be equal to index.dim({})", base_dim, dim_));
-    CHECK_ARGUMENT(data->GetFloat32Vectors() != nullptr, "base.float_vector is nullptr");
+    const MultiVector* multi_vectors = data->GetMultiVectors();
+    CHECK_ARGUMENT(multi_vectors != nullptr, "data.multi_vectors is nullptr");
 
-    // For multi-vector support, vector counts per document is required
-    const uint32_t* vector_counts = data->GetVectorCounts();
-    CHECK_ARGUMENT(vector_counts != nullptr, "base.vector_counts is nullptr");
+    int64_t mv_dim = data->GetMultiVectorDim();
+    CHECK_ARGUMENT(mv_dim == dim_,
+                   fmt::format("data.multi_vector_dim({}) must be equal to index.dim({})",
+                               mv_dim,
+                               dim_));
 
     {
         std::lock_guard lock(this->add_mutex_);
@@ -101,21 +117,19 @@ WARP::Add(const DatasetPtr& data, AddMode mode) {
         }
     }
 
-    // Multi-vector document handling
-    const auto total = data->GetNumElements();
-    const auto* labels = data->GetIds();
-    const auto* vectors = data->GetFloat32Vectors();
-    const auto* attrs = data->GetAttributeSets();
-    const auto* extra_info = data->GetExtraInfos();
-    const auto extra_info_size = data->GetExtraInfoSize();
+    const int64_t num_elements = data->GetNumElements();
+    const int64_t* labels = data->GetIds();
+    const AttributeSet* attrs = data->GetAttributeSets();
+    const char* extra_info = data->GetExtraInfos();
+    const int64_t extra_info_size = data->GetExtraInfoSize();
 
     // Pre-calculate total vectors and reserve capacity once
     uint64_t total_vectors_to_add = 0;
-    for (int64_t j = 0; j < total; ++j) {
-        total_vectors_to_add += vector_counts[j];
+    for (int64_t i = 0; i < num_elements; ++i) {
+        total_vectors_to_add += multi_vectors[i].len_;
     }
     uint64_t required_vec_capacity = this->inner_codes_->TotalCount() + total_vectors_to_add;
-    auto cur_vec_capacity = this->max_vector_capacity_.load();
+    uint64_t cur_vec_capacity = this->max_vector_capacity_.load();
     if (cur_vec_capacity < required_vec_capacity) {
         std::lock_guard lock(this->global_mutex_);
         cur_vec_capacity = this->max_vector_capacity_.load();
@@ -153,17 +167,16 @@ WARP::Add(const DatasetPtr& data, AddMode mode) {
     };
 
     std::vector<std::future<std::optional<int64_t>>> futures;
-    uint64_t vec_offset = 0;
 
-    for (int64_t j = 0; j < total; ++j) {
-        const auto label = labels[j];
-        uint32_t doc_vec_count = vector_counts[j];
+    for (int64_t i = 0; i < num_elements; ++i) {
+        const int64_t label = labels[i];
+        uint32_t doc_vec_count = multi_vectors[i].len_;
+        const float* doc_vectors = multi_vectors[i].vectors_;
 
         {
             std::lock_guard label_lock(this->label_lookup_mutex_);
             if (this->label_table_->CheckLabel(label)) {
                 failed_ids.emplace_back(label);
-                vec_offset += doc_vec_count;
                 continue;
             }
         }
@@ -171,25 +184,23 @@ WARP::Add(const DatasetPtr& data, AddMode mode) {
         if (this->thread_pool_ != nullptr) {
             auto future = this->thread_pool_->GeneralEnqueue(
                 add_func,
-                vectors + vec_offset * dim_,
+                doc_vectors,
                 doc_vec_count,
                 label,
-                attrs == nullptr ? nullptr : attrs + j,
-                extra_info == nullptr ? nullptr : extra_info + j * extra_info_size);
+                attrs == nullptr ? nullptr : attrs + i,
+                extra_info == nullptr ? nullptr : extra_info + i * extra_info_size);
             futures.emplace_back(std::move(future));
         } else {
             if (auto add_res =
-                    add_func(vectors + vec_offset * dim_,
+                    add_func(doc_vectors,
                              doc_vec_count,
                              label,
-                             attrs == nullptr ? nullptr : attrs + j,
-                             extra_info == nullptr ? nullptr : extra_info + j * extra_info_size);
+                             attrs == nullptr ? nullptr : attrs + i,
+                             extra_info == nullptr ? nullptr : extra_info + i * extra_info_size);
                 add_res.has_value()) {
                 failed_ids.emplace_back(add_res.value());
             }
         }
-
-        vec_offset += doc_vec_count;
     }
 
     if (this->thread_pool_ != nullptr) {
@@ -253,12 +264,12 @@ DatasetPtr
 WARP::SearchWithRequest(const SearchRequest& request) const {
     std::shared_lock read_lock(this->global_mutex_);
 
-    // Get query information
-    const float* query_vectors = request.query_->GetFloat32Vectors();
-    const uint32_t* query_vec_counts = request.query_->GetVectorCounts();
-    CHECK_ARGUMENT(query_vec_counts != nullptr, "query.vector_counts is nullptr");
+    // Get query information from MultiVectors
+    const MultiVector* query_multi_vectors = request.query_->GetMultiVectors();
+    CHECK_ARGUMENT(query_multi_vectors != nullptr, "query.multi_vectors is nullptr");
 
-    uint32_t query_vec_count = query_vec_counts[0];
+    const float* query_vectors = query_multi_vectors[0].vectors_;
+    uint32_t query_vec_count = query_multi_vectors[0].len_;
 
     FilterPtr ft = nullptr;
     auto combined_filter = std::make_shared<CombinedFilter>();
@@ -366,12 +377,12 @@ WARP::RangeSearch(const vsag::DatasetPtr& query,
                   int64_t limited_size) const {
     std::shared_lock read_lock(this->global_mutex_);
 
-    // Get query information
-    const float* query_vectors = query->GetFloat32Vectors();
-    const uint32_t* query_vec_counts = query->GetVectorCounts();
-    CHECK_ARGUMENT(query_vec_counts != nullptr, "query.vector_counts is nullptr");
+    // Get query information from MultiVectors
+    const MultiVector* query_multi_vectors = query->GetMultiVectors();
+    CHECK_ARGUMENT(query_multi_vectors != nullptr, "query.multi_vectors is nullptr");
 
-    uint32_t query_vec_count = query_vec_counts[0];
+    const float* query_vectors = query_multi_vectors[0].vectors_;
+    uint32_t query_vec_count = query_multi_vectors[0].len_;
 
     if (limited_size < 0) {
         limited_size = std::numeric_limits<int64_t>::max();

--- a/src/algorithm/warp.cpp
+++ b/src/algorithm/warp.cpp
@@ -78,10 +78,9 @@ WARP::Train(const DatasetPtr& data) {
     CHECK_ARGUMENT(multi_vectors != nullptr, "data.multi_vectors is nullptr");
 
     int64_t mv_dim = data->GetMultiVectorDim();
-    CHECK_ARGUMENT(mv_dim == dim_,
-                   fmt::format("data.multi_vector_dim({}) must be equal to index.dim({})",
-                               mv_dim,
-                               dim_));
+    CHECK_ARGUMENT(
+        mv_dim == dim_,
+        fmt::format("data.multi_vector_dim({}) must be equal to index.dim({})", mv_dim, dim_));
 
     int64_t num_elements = data->GetNumElements();
     uint64_t total_vectors = 0;
@@ -105,10 +104,9 @@ WARP::Add(const DatasetPtr& data, AddMode mode) {
     CHECK_ARGUMENT(multi_vectors != nullptr, "data.multi_vectors is nullptr");
 
     int64_t mv_dim = data->GetMultiVectorDim();
-    CHECK_ARGUMENT(mv_dim == dim_,
-                   fmt::format("data.multi_vector_dim({}) must be equal to index.dim({})",
-                               mv_dim,
-                               dim_));
+    CHECK_ARGUMENT(
+        mv_dim == dim_,
+        fmt::format("data.multi_vector_dim({}) must be equal to index.dim({})", mv_dim, dim_));
 
     {
         std::lock_guard lock(this->add_mutex_);

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -43,6 +43,8 @@ const char* const DATASET_PATHS = "paths";
 const char* const EXTRA_INFOS = "extra_infos";
 const char* const EXTRA_INFO_SIZE = "extra_info_size";
 const char* const VECTOR_COUNTS = "vector_counts";
+const char* const MULTI_VECTORS = "multi_vectors";
+const char* const MULTI_VECTOR_DIM = "multi_vector_dim";
 
 const char* const HNSW_DATA = "hnsw_data";
 const char* const CONJUGATE_GRAPH_DATA = "conjugate_graph_data";

--- a/src/dataset_impl.cpp
+++ b/src/dataset_impl.cpp
@@ -437,7 +437,7 @@ DatasetImpl::Append(const DatasetPtr& other) {
     // append multi-vectors
     if (auto iter = this->data_.find(MULTI_VECTORS); iter != this->data_.end()) {
         int64_t mv_dim = this->GetMultiVectorDim();
-        MultiVector* ptr = const_cast<MultiVector*>(std::get<const MultiVector*>(iter->second));
+        auto* ptr = const_cast<MultiVector*>(std::get<const MultiVector*>(iter->second));
         this->MultiVectors(allocate_and_copy_multi_vectors(other->GetMultiVectors(),
                                                            new_num_elements,
                                                            mv_dim,

--- a/src/dataset_impl.cpp
+++ b/src/dataset_impl.cpp
@@ -385,9 +385,8 @@ DatasetImpl::Append(const DatasetPtr& other) {
         }
         int64_t mv_dim = this->GetMultiVectorDim();
         if (mv_dim <= 0 || other->GetMultiVectorDim() != mv_dim) {
-            throw VsagException(
-                ErrorType::INVALID_ARGUMENT,
-                "Cannot append datasets with different multi vector dimensions");
+            throw VsagException(ErrorType::INVALID_ARGUMENT,
+                                "Cannot append datasets with different multi vector dimensions");
         }
     }
 
@@ -439,8 +438,12 @@ DatasetImpl::Append(const DatasetPtr& other) {
     if (auto iter = this->data_.find(MULTI_VECTORS); iter != this->data_.end()) {
         int64_t mv_dim = this->GetMultiVectorDim();
         MultiVector* ptr = const_cast<MultiVector*>(std::get<const MultiVector*>(iter->second));
-        this->MultiVectors(allocate_and_copy_multi_vectors(
-            other->GetMultiVectors(), new_num_elements, mv_dim, this->allocator_, ptr, old_num_elements));
+        this->MultiVectors(allocate_and_copy_multi_vectors(other->GetMultiVectors(),
+                                                           new_num_elements,
+                                                           mv_dim,
+                                                           this->allocator_,
+                                                           ptr,
+                                                           old_num_elements));
     }
 
     // append attribute-sets

--- a/src/dataset_impl.cpp
+++ b/src/dataset_impl.cpp
@@ -362,8 +362,47 @@ DatasetImpl::Append(const DatasetPtr& other) {
     auto new_num_elements = other->GetNumElements();
     auto dim = this->GetDim();
 
+    // check paths
+    if (this->data_.find(DATASET_PATHS) != this->data_.end() && other->GetPaths() == nullptr) {
+        throw VsagException(ErrorType::INVALID_ARGUMENT,
+                            "Cannot append dataset without paths to dataset with paths");
+    }
+
+    // check sparse-vectors
+    if (this->data_.find(SPARSE_VECTORS) != this->data_.end() &&
+        other->GetSparseVectors() == nullptr) {
+        throw VsagException(
+            ErrorType::INVALID_ARGUMENT,
+            "Cannot append dataset without sparse vectors to dataset with sparse vectors");
+    }
+
+    // check multi-vectors
+    if (this->data_.find(MULTI_VECTORS) != this->data_.end()) {
+        if (other->GetMultiVectors() == nullptr) {
+            throw VsagException(
+                ErrorType::INVALID_ARGUMENT,
+                "Cannot append dataset without multi vectors to dataset with multi vectors");
+        }
+        int64_t mv_dim = this->GetMultiVectorDim();
+        if (mv_dim <= 0 || other->GetMultiVectorDim() != mv_dim) {
+            throw VsagException(
+                ErrorType::INVALID_ARGUMENT,
+                "Cannot append datasets with different multi vector dimensions");
+        }
+    }
+
+    // check attribute-sets
+    if (this->data_.find(ATTRIBUTE_SETS) != this->data_.end() &&
+        other->GetAttributeSets() == nullptr) {
+        throw VsagException(
+            ErrorType::INVALID_ARGUMENT,
+            "Cannot append dataset without attribute sets to dataset with attribute sets");
+    }
+
+    // all validation passed; safe to mutate state (destructor relies on NumElements for cleanup)
     this->NumElements(old_num_elements + new_num_elements);
 
+    // append contiguous arrays via realloc-and-copy
     APPEND_DATA(IDS, int64_t*, Ids, 1);
     APPEND_DATA(DISTS, float*, Distances, dim);
     APPEND_DATA(INT8_VECTORS, int8_t*, Int8Vectors, dim);
@@ -376,16 +415,12 @@ DatasetImpl::Append(const DatasetPtr& other) {
 
     // append paths
     if (auto iter = this->data_.find(DATASET_PATHS); iter != this->data_.end()) {
-        if (other->GetPaths() == nullptr) {
-            throw VsagException(ErrorType::INVALID_ARGUMENT,
-                                "Cannot append dataset without paths to dataset with paths");
-        }
         auto* ptr = const_cast<std::string*>(std::get<const std::string*>(iter->second));
         auto* paths_copy = new std::string[old_num_elements + new_num_elements];
         for (int i = 0; i < old_num_elements; ++i) {
             paths_copy[i] += ptr[i];
         }
-        delete[] ptr;  // Free the old memory if it was allocated with new[]
+        delete[] ptr;
         ptr = nullptr;
         for (int i = 0; i < new_num_elements; ++i) {
             paths_copy[old_num_elements + i] += other->GetPaths()[i];
@@ -393,43 +428,23 @@ DatasetImpl::Append(const DatasetPtr& other) {
         this->Paths(paths_copy);
     }
 
-    // append sparse vectors
+    // append sparse-vectors
     if (auto iter = this->data_.find(SPARSE_VECTORS); iter != this->data_.end()) {
-        if (other->GetSparseVectors() == nullptr) {
-            throw VsagException(
-                ErrorType::INVALID_ARGUMENT,
-                "Cannot append dataset without sparse vectors to dataset with sparse vectors");
-        }
         auto* ptr = const_cast<SparseVector*>(std::get<const SparseVector*>(iter->second));
         this->SparseVectors(allocate_and_copy_sparse_vectors(
             other->GetSparseVectors(), new_num_elements, this->allocator_, ptr, old_num_elements));
     }
 
-    // append multi vectors
+    // append multi-vectors
     if (auto iter = this->data_.find(MULTI_VECTORS); iter != this->data_.end()) {
-        if (other->GetMultiVectors() == nullptr) {
-            throw VsagException(
-                ErrorType::INVALID_ARGUMENT,
-                "Cannot append dataset without multi vectors to dataset with multi vectors");
-        }
         int64_t mv_dim = this->GetMultiVectorDim();
-        if (mv_dim <= 0 || other->GetMultiVectorDim() != mv_dim) {
-            throw VsagException(
-                ErrorType::INVALID_ARGUMENT,
-                "Cannot append datasets with different multi vector dimensions");
-        }
         MultiVector* ptr = const_cast<MultiVector*>(std::get<const MultiVector*>(iter->second));
         this->MultiVectors(allocate_and_copy_multi_vectors(
             other->GetMultiVectors(), new_num_elements, mv_dim, this->allocator_, ptr, old_num_elements));
     }
 
-    // append attribute sets
+    // append attribute-sets
     if (auto iter = this->data_.find(ATTRIBUTE_SETS); iter != this->data_.end()) {
-        if (other->GetAttributeSets() == nullptr) {
-            throw VsagException(
-                ErrorType::INVALID_ARGUMENT,
-                "Cannot append dataset without attribute sets to dataset with attribute sets");
-        }
         auto* ptr = const_cast<AttributeSet*>(std::get<const AttributeSet*>(iter->second));
         auto* attrsets_copy = new AttributeSet[new_num_elements + old_num_elements];
         this->AttributeSets(attrsets_copy);
@@ -447,6 +462,7 @@ DatasetImpl::Append(const DatasetPtr& other) {
             }
         }
     }
+
     return shared_from_this();
 }
 

--- a/src/dataset_impl.cpp
+++ b/src/dataset_impl.cpp
@@ -163,6 +163,15 @@ DatasetImpl::~DatasetImpl() {  // NOLINT
             }
             allocator_->Deallocate(void_ptr(DatasetImpl::GetSparseVectors()));
         }
+        const MultiVector* multi_vectors = DatasetImpl::GetMultiVectors();
+        if (multi_vectors != nullptr) {
+            for (int64_t i = 0; i < DatasetImpl::GetNumElements(); i++) {
+                if (multi_vectors[i].vectors_ != nullptr) {
+                    allocator_->Deallocate(void_ptr(multi_vectors[i].vectors_));
+                }
+            }
+            allocator_->Deallocate(void_ptr(DatasetImpl::GetMultiVectors()));
+        }
 
     } else {
         delete[] DatasetImpl::GetIds();
@@ -179,6 +188,13 @@ DatasetImpl::~DatasetImpl() {  // NOLINT
                 delete[] DatasetImpl::GetSparseVectors()[i].vals_;
             }
             delete[] DatasetImpl::GetSparseVectors();
+        }
+
+        if (DatasetImpl::GetMultiVectors() != nullptr) {
+            for (int64_t i = 0; i < DatasetImpl::GetNumElements(); i++) {
+                delete[] DatasetImpl::GetMultiVectors()[i].vectors_;
+            }
+            delete[] DatasetImpl::GetMultiVectors();
         }
     }
     delete[] DatasetImpl::GetPaths();

--- a/src/dataset_impl.cpp
+++ b/src/dataset_impl.cpp
@@ -405,6 +405,24 @@ DatasetImpl::Append(const DatasetPtr& other) {
             other->GetSparseVectors(), new_num_elements, this->allocator_, ptr, old_num_elements));
     }
 
+    // append multi vectors
+    if (auto iter = this->data_.find(MULTI_VECTORS); iter != this->data_.end()) {
+        if (other->GetMultiVectors() == nullptr) {
+            throw VsagException(
+                ErrorType::INVALID_ARGUMENT,
+                "Cannot append dataset without multi vectors to dataset with multi vectors");
+        }
+        int64_t mv_dim = this->GetMultiVectorDim();
+        if (mv_dim <= 0 || other->GetMultiVectorDim() != mv_dim) {
+            throw VsagException(
+                ErrorType::INVALID_ARGUMENT,
+                "Cannot append datasets with different multi vector dimensions");
+        }
+        MultiVector* ptr = const_cast<MultiVector*>(std::get<const MultiVector*>(iter->second));
+        this->MultiVectors(allocate_and_copy_multi_vectors(
+            other->GetMultiVectors(), new_num_elements, mv_dim, this->allocator_, ptr, old_num_elements));
+    }
+
     // append attribute sets
     if (auto iter = this->data_.find(ATTRIBUTE_SETS); iter != this->data_.end()) {
         if (other->GetAttributeSets() == nullptr) {

--- a/src/dataset_impl.cpp
+++ b/src/dataset_impl.cpp
@@ -99,6 +99,52 @@ copy_sparse_vector(const SparseVector& src, SparseVector* dest, Allocator* alloc
     std::memcpy(dest->vals_, src.vals_, len * sizeof(float));
 }
 
+static void
+copy_multi_vector(const MultiVector& src,
+                  MultiVector* dest,
+                  int64_t multi_vector_dim,
+                  Allocator* allocator) {
+    dest->len_ = src.len_;
+    if (src.len_ == 0) {
+        dest->vectors_ = nullptr;
+        return;
+    }
+    uint64_t num_floats = static_cast<uint64_t>(src.len_) * multi_vector_dim;
+    if (allocator != nullptr) {
+        dest->vectors_ = static_cast<float*>(allocator->Allocate(num_floats * sizeof(float)));
+    } else {
+        dest->vectors_ = new float[num_floats];
+    }
+    std::memcpy(dest->vectors_, src.vectors_, num_floats * sizeof(float));
+}
+
+static MultiVector*
+allocate_and_copy_multi_vectors(const MultiVector* src,
+                                uint64_t count,
+                                int64_t multi_vector_dim,
+                                Allocator* allocator,
+                                MultiVector* old_dest = nullptr,
+                                uint64_t old_count = 0) {
+    if (src == nullptr || count == 0) {
+        return old_dest;
+    }
+
+    uint64_t new_total = old_count + count;
+    MultiVector* dest = nullptr;
+
+    if (allocator != nullptr) {
+        dest = allocator_element<MultiVector>(allocator, old_dest, new_total * sizeof(MultiVector));
+    } else {
+        dest = new_element<MultiVector>(old_dest, old_count, new_total);
+    }
+
+    for (uint64_t i = old_count; i < new_total; ++i) {
+        const MultiVector& src_vec = src[i - old_count];
+        copy_multi_vector(src_vec, &dest[i], multi_vector_dim, allocator);
+    }
+    return dest;
+}
+
 static SparseVector*
 allocate_and_copy_sparse_vectors(const SparseVector* src,
                                  uint64_t count,
@@ -253,6 +299,12 @@ DatasetImpl::DeepCopy(Allocator* allocator) const {
     if (this->GetSparseVectors() != nullptr) {
         copy_dataset->SparseVectors(allocate_and_copy_sparse_vectors(
             this->GetSparseVectors(), num_elements, allocator_ref));
+    }
+    if (this->GetMultiVectors() != nullptr) {
+        int64_t mv_dim = this->GetMultiVectorDim();
+        copy_dataset->MultiVectorDim(mv_dim);
+        copy_dataset->MultiVectors(allocate_and_copy_multi_vectors(
+            this->GetMultiVectors(), num_elements, mv_dim, allocator_ref));
     }
     if (this->GetPaths() != nullptr) {
         auto* paths = new std::string[num_elements];

--- a/src/dataset_impl.h
+++ b/src/dataset_impl.h
@@ -37,7 +37,8 @@ class DatasetImpl : public Dataset {
                              const std::string*,
                              const SparseVector*,
                              const AttributeSet*,
-                             const uint32_t*>;
+                             const uint32_t*,
+                             const MultiVector*>;
 
 public:
     DatasetImpl() = default;
@@ -282,6 +283,34 @@ public:
             return std::get<const uint32_t*>(iter->second);
         }
         return nullptr;
+    }
+
+    DatasetPtr
+    MultiVectors(const MultiVector* multi_vectors) override {
+        this->data_[MULTI_VECTORS] = multi_vectors;
+        return shared_from_this();
+    }
+
+    const MultiVector*
+    GetMultiVectors() const override {
+        if (auto iter = this->data_.find(MULTI_VECTORS); iter != this->data_.end()) {
+            return std::get<const MultiVector*>(iter->second);
+        }
+        return nullptr;
+    }
+
+    DatasetPtr
+    MultiVectorDim(int64_t dim) override {
+        this->data_[MULTI_VECTOR_DIM] = dim;
+        return shared_from_this();
+    }
+
+    int64_t
+    GetMultiVectorDim() const override {
+        if (auto iter = this->data_.find(MULTI_VECTOR_DIM); iter != this->data_.end()) {
+            return std::get<int64_t>(iter->second);
+        }
+        return 0;
     }
 
     static DatasetPtr

--- a/src/dataset_impl_test.cpp
+++ b/src/dataset_impl_test.cpp
@@ -342,6 +342,237 @@ TEST_CASE("Dataset Copy and Append Test", "[ut][Dataset]") {
     }
 }
 
+TEST_CASE("Dataset MultiVector Basic Test", "[ut][dataset]") {
+    SECTION("MultiVectorDim default is 0") {
+        auto dataset = vsag::Dataset::Make();
+        REQUIRE(dataset->GetMultiVectorDim() == 0);
+    }
+
+    SECTION("MultiVectorDim setter/getter round-trip") {
+        auto dataset = vsag::Dataset::Make();
+        dataset->MultiVectorDim(128);
+        REQUIRE(dataset->GetMultiVectorDim() == 128);
+    }
+
+    SECTION("MultiVectors getter returns nullptr by default") {
+        auto dataset = vsag::Dataset::Make();
+        REQUIRE(dataset->GetMultiVectors() == nullptr);
+    }
+
+    SECTION("MultiVectors setter/getter round-trip") {
+        constexpr int64_t num_elements = 10;
+        constexpr int64_t mv_dim = 16;
+
+        auto* multi_vectors = new vsag::MultiVector[num_elements];
+        for (int64_t i = 0; i < num_elements; ++i) {
+            multi_vectors[i].len_ = 3;
+            multi_vectors[i].vectors_ = new float[3 * mv_dim];
+            for (int j = 0; j < 3 * mv_dim; ++j) {
+                multi_vectors[i].vectors_[j] = static_cast<float>(i * 100 + j);
+            }
+        }
+
+        auto dataset = vsag::Dataset::Make();
+        dataset->NumElements(num_elements)->MultiVectorDim(mv_dim)->MultiVectors(multi_vectors);
+
+        REQUIRE(dataset->GetMultiVectors() == multi_vectors);
+        REQUIRE(dataset->GetMultiVectors()[0].len_ == 3);
+        REQUIRE(dataset->GetMultiVectors()[0].vectors_[0] == 0.0f);
+        REQUIRE(dataset->GetMultiVectors()[1].vectors_[0] == 100.0f);
+
+        dataset->Owner(true, nullptr);
+    }
+
+    SECTION("Owner(true) destructor releases MultiVector without crash") {
+        constexpr int64_t num_elements = 5;
+        constexpr int64_t mv_dim = 8;
+
+        auto* multi_vectors = new vsag::MultiVector[num_elements];
+        for (int64_t i = 0; i < num_elements; ++i) {
+            multi_vectors[i].len_ = 2;
+            multi_vectors[i].vectors_ = new float[2 * mv_dim];
+        }
+        multi_vectors[2].len_ = 0;
+        delete[] multi_vectors[2].vectors_;
+        multi_vectors[2].vectors_ = nullptr;
+
+        auto dataset = vsag::Dataset::Make();
+        dataset->NumElements(num_elements)
+            ->MultiVectorDim(mv_dim)
+            ->MultiVectors(multi_vectors)
+            ->Owner(true, nullptr);
+    }
+
+    SECTION("Owner(true) with allocator releases MultiVector without crash") {
+        vsag::DefaultAllocator allocator;
+        constexpr int64_t num_elements = 5;
+        constexpr int64_t mv_dim = 8;
+
+        auto* multi_vectors = static_cast<vsag::MultiVector*>(
+            allocator.Allocate(num_elements * sizeof(vsag::MultiVector)));
+        for (int64_t i = 0; i < num_elements; ++i) {
+            multi_vectors[i].len_ = 2;
+            multi_vectors[i].vectors_ =
+                static_cast<float*>(allocator.Allocate(2 * mv_dim * sizeof(float)));
+        }
+
+        auto dataset = vsag::Dataset::Make();
+        dataset->NumElements(num_elements)
+            ->MultiVectorDim(mv_dim)
+            ->MultiVectors(multi_vectors)
+            ->Owner(true, &allocator);
+    }
+}
+
+TEST_CASE("Dataset MultiVector Append Test", "[ut][dataset]") {
+    constexpr int64_t mv_dim = 16;
+
+    auto use_allocator = GENERATE(true, false);
+    std::shared_ptr<vsag::Allocator> allocator =
+        use_allocator ? vsag::Engine::CreateDefaultAllocator() : nullptr;
+
+    auto make_multi_vector_dataset = [&](int64_t num_elements, uint32_t len_per_doc) {
+        vsag::MultiVector* multi_vectors = nullptr;
+        if (allocator) {
+            multi_vectors = static_cast<vsag::MultiVector*>(
+                allocator->Allocate(num_elements * sizeof(vsag::MultiVector)));
+        } else {
+            multi_vectors = new vsag::MultiVector[num_elements];
+        }
+        for (int64_t i = 0; i < num_elements; ++i) {
+            multi_vectors[i].len_ = len_per_doc;
+            uint64_t num_floats = static_cast<uint64_t>(len_per_doc) * mv_dim;
+            if (allocator) {
+                multi_vectors[i].vectors_ =
+                    static_cast<float*>(allocator->Allocate(num_floats * sizeof(float)));
+            } else {
+                multi_vectors[i].vectors_ = new float[num_floats];
+            }
+            for (uint64_t j = 0; j < num_floats; ++j) {
+                multi_vectors[i].vectors_[j] = static_cast<float>(i * 1000 + j);
+            }
+        }
+        auto dataset = vsag::Dataset::Make();
+        dataset->NumElements(num_elements)
+            ->Dim(mv_dim)
+            ->MultiVectorDim(mv_dim)
+            ->MultiVectors(multi_vectors)
+            ->Owner(true, allocator.get());
+        return dataset;
+    };
+
+    SECTION("Append preserves data") {
+        constexpr int64_t n1 = 10;
+        constexpr int64_t n2 = 7;
+        constexpr uint32_t len = 3;
+
+        auto ds1 = make_multi_vector_dataset(n1, len);
+        auto ds2 = make_multi_vector_dataset(n2, len);
+
+        const vsag::MultiVector* mv2_before = ds2->GetMultiVectors();
+        std::vector<float> mv2_first_vec(mv_dim * len);
+        std::memcpy(mv2_first_vec.data(), mv2_before[0].vectors_, mv_dim * len * sizeof(float));
+
+        ds1->Append(ds2);
+
+        REQUIRE(ds1->GetNumElements() == n1 + n2);
+        REQUIRE(ds1->GetMultiVectors() != nullptr);
+
+        const vsag::MultiVector* result_mv = ds1->GetMultiVectors();
+        for (int64_t i = 0; i < n1; ++i) {
+            REQUIRE(result_mv[i].len_ == len);
+            REQUIRE(result_mv[i].vectors_[0] == static_cast<float>(i * 1000));
+        }
+        for (int64_t i = 0; i < n2; ++i) {
+            REQUIRE(result_mv[n1 + i].len_ == len);
+            REQUIRE(std::memcmp(result_mv[n1 + i].vectors_,
+                                mv2_before[i].vectors_,
+                                len * mv_dim * sizeof(float)) == 0);
+        }
+    }
+
+    SECTION("Append with variable-length MultiVectors") {
+        constexpr int64_t n1 = 5;
+        constexpr int64_t n2 = 3;
+
+        auto make_varlen_dataset = [&](int64_t num_elements, int seed) {
+            std::mt19937 gen(seed);
+            std::uniform_int_distribution<uint32_t> len_dist(1, 6);
+
+            vsag::MultiVector* multi_vectors = nullptr;
+            if (allocator) {
+                multi_vectors = static_cast<vsag::MultiVector*>(
+                    allocator->Allocate(num_elements * sizeof(vsag::MultiVector)));
+            } else {
+                multi_vectors = new vsag::MultiVector[num_elements];
+            }
+            for (int64_t i = 0; i < num_elements; ++i) {
+                uint32_t len = len_dist(gen);
+                multi_vectors[i].len_ = len;
+                uint64_t num_floats = static_cast<uint64_t>(len) * mv_dim;
+                if (allocator) {
+                    multi_vectors[i].vectors_ =
+                        static_cast<float*>(allocator->Allocate(num_floats * sizeof(float)));
+                } else {
+                    multi_vectors[i].vectors_ = new float[num_floats];
+                }
+                for (uint64_t j = 0; j < num_floats; ++j) {
+                    multi_vectors[i].vectors_[j] = static_cast<float>(seed * 10000 + i * 100 + j);
+                }
+            }
+            auto dataset = vsag::Dataset::Make();
+            dataset->NumElements(num_elements)
+                ->Dim(mv_dim)
+                ->MultiVectorDim(mv_dim)
+                ->MultiVectors(multi_vectors)
+                ->Owner(true, allocator.get());
+            return dataset;
+        };
+
+        auto ds1 = make_varlen_dataset(n1, 42);
+        auto ds2 = make_varlen_dataset(n2, 99);
+
+        std::vector<uint32_t> expected_lens(n1 + n2);
+        for (int64_t i = 0; i < n1; ++i) {
+            expected_lens[i] = ds1->GetMultiVectors()[i].len_;
+        }
+        for (int64_t i = 0; i < n2; ++i) {
+            expected_lens[n1 + i] = ds2->GetMultiVectors()[i].len_;
+        }
+
+        ds1->Append(ds2);
+
+        REQUIRE(ds1->GetNumElements() == n1 + n2);
+        const vsag::MultiVector* result_mv = ds1->GetMultiVectors();
+        for (int64_t i = 0; i < n1 + n2; ++i) {
+            REQUIRE(result_mv[i].len_ == expected_lens[i]);
+            REQUIRE(result_mv[i].vectors_ != nullptr);
+        }
+    }
+
+    SECTION("Append mismatch MultiVectorDim throws") {
+        auto ds1 = make_multi_vector_dataset(5, 2);
+
+        auto* mv2 = new vsag::MultiVector[3];
+        for (int i = 0; i < 3; ++i) {
+            mv2[i].len_ = 2;
+            mv2[i].vectors_ = new float[2 * 32];
+        }
+        auto ds2 = vsag::Dataset::Make();
+        ds2->NumElements(3)->Dim(mv_dim)->MultiVectorDim(32)->MultiVectors(mv2)->Owner(true, nullptr);
+
+        REQUIRE_THROWS(ds1->Append(ds2));
+    }
+
+    SECTION("Append this has MultiVectors but other does not throws") {
+        auto ds1 = make_multi_vector_dataset(5, 2);
+        auto ds2 = vsag::Dataset::Make();
+        ds2->NumElements(3)->Dim(mv_dim)->Owner(false);
+
+        REQUIRE_THROWS(ds1->Append(ds2));
+    }
+}
+
 TEST_CASE("Dataset MultiVector DeepCopy Test", "[ut][dataset]") {
     constexpr int64_t num_elements = 50;
     constexpr int64_t mv_dim = 32;

--- a/src/dataset_impl_test.cpp
+++ b/src/dataset_impl_test.cpp
@@ -559,7 +559,8 @@ TEST_CASE("Dataset MultiVector Append Test", "[ut][dataset]") {
             mv2[i].vectors_ = new float[2 * 32];
         }
         auto ds2 = vsag::Dataset::Make();
-        ds2->NumElements(3)->Dim(mv_dim)->MultiVectorDim(32)->MultiVectors(mv2)->Owner(true, nullptr);
+        ds2->NumElements(3)->Dim(mv_dim)->MultiVectorDim(32)->MultiVectors(mv2)->Owner(true,
+                                                                                       nullptr);
 
         REQUIRE_THROWS(ds1->Append(ds2));
     }
@@ -633,8 +634,8 @@ TEST_CASE("Dataset MultiVector DeepCopy Test", "[ut][dataset]") {
             REQUIRE(dst_mv[i].len_ == src_mv[i].len_);
             REQUIRE(dst_mv[i].vectors_ != src_mv[i].vectors_);
             uint64_t num_floats = static_cast<uint64_t>(src_mv[i].len_) * mv_dim;
-            REQUIRE(std::memcmp(dst_mv[i].vectors_, src_mv[i].vectors_, num_floats * sizeof(float)) ==
-                    0);
+            REQUIRE(std::memcmp(
+                        dst_mv[i].vectors_, src_mv[i].vectors_, num_floats * sizeof(float)) == 0);
         }
     }
 

--- a/src/dataset_impl_test.cpp
+++ b/src/dataset_impl_test.cpp
@@ -341,3 +341,85 @@ TEST_CASE("Dataset Copy and Append Test", "[ut][Dataset]") {
         REQUIRE(EqualDataset(sub_original, append_dataset));
     }
 }
+
+TEST_CASE("Dataset MultiVector DeepCopy Test", "[ut][dataset]") {
+    constexpr int64_t num_elements = 50;
+    constexpr int64_t mv_dim = 32;
+
+    bool use_allocator = GENERATE(true, false);
+    std::shared_ptr<vsag::Allocator> allocator =
+        use_allocator ? vsag::Engine::CreateDefaultAllocator() : nullptr;
+
+    std::mt19937 gen(42);
+    std::uniform_int_distribution<uint32_t> len_dist(1, 8);
+    std::uniform_real_distribution<float> val_dist(-1.0f, 1.0f);
+
+    vsag::MultiVector* multi_vectors = nullptr;
+    if (allocator) {
+        multi_vectors = static_cast<vsag::MultiVector*>(
+            allocator->Allocate(num_elements * sizeof(vsag::MultiVector)));
+    } else {
+        multi_vectors = new vsag::MultiVector[num_elements];
+    }
+
+    for (int64_t i = 0; i < num_elements; ++i) {
+        uint32_t len = len_dist(gen);
+        multi_vectors[i].len_ = len;
+        uint64_t num_floats = static_cast<uint64_t>(len) * mv_dim;
+        if (allocator) {
+            multi_vectors[i].vectors_ =
+                static_cast<float*>(allocator->Allocate(num_floats * sizeof(float)));
+        } else {
+            multi_vectors[i].vectors_ = new float[num_floats];
+        }
+        for (uint64_t j = 0; j < num_floats; ++j) {
+            multi_vectors[i].vectors_[j] = val_dist(gen);
+        }
+    }
+
+    vsag::DatasetPtr dataset = vsag::Dataset::Make();
+    dataset->NumElements(num_elements)
+        ->Dim(mv_dim)
+        ->MultiVectorDim(mv_dim)
+        ->MultiVectors(multi_vectors)
+        ->Owner(true, allocator.get());
+
+    SECTION("DeepCopy preserves data") {
+        bool use_copy_allocator = GENERATE(true, false);
+        std::shared_ptr<vsag::Allocator> copy_allocator =
+            use_copy_allocator ? vsag::Engine::CreateDefaultAllocator() : nullptr;
+
+        vsag::DatasetPtr copy = dataset->DeepCopy(copy_allocator.get());
+
+        REQUIRE(copy->GetNumElements() == num_elements);
+        REQUIRE(copy->GetMultiVectorDim() == mv_dim);
+        REQUIRE(copy->GetMultiVectors() != nullptr);
+        REQUIRE(copy->GetMultiVectors() != dataset->GetMultiVectors());
+
+        const vsag::MultiVector* src_mv = dataset->GetMultiVectors();
+        const vsag::MultiVector* dst_mv = copy->GetMultiVectors();
+        for (int64_t i = 0; i < num_elements; ++i) {
+            REQUIRE(dst_mv[i].len_ == src_mv[i].len_);
+            REQUIRE(dst_mv[i].vectors_ != src_mv[i].vectors_);
+            uint64_t num_floats = static_cast<uint64_t>(src_mv[i].len_) * mv_dim;
+            REQUIRE(std::memcmp(dst_mv[i].vectors_, src_mv[i].vectors_, num_floats * sizeof(float)) ==
+                    0);
+        }
+    }
+
+    SECTION("DeepCopy with zero-length MultiVector element") {
+        multi_vectors[0].len_ = 0;
+        if (allocator) {
+            allocator->Deallocate(multi_vectors[0].vectors_);
+        } else {
+            delete[] multi_vectors[0].vectors_;
+        }
+        multi_vectors[0].vectors_ = nullptr;
+
+        vsag::DatasetPtr copy = dataset->DeepCopy(nullptr);
+        const vsag::MultiVector* dst_mv = copy->GetMultiVectors();
+        REQUIRE(dst_mv[0].len_ == 0);
+        REQUIRE(dst_mv[0].vectors_ == nullptr);
+        REQUIRE(dst_mv[1].len_ == dataset->GetMultiVectors()[1].len_);
+    }
+}

--- a/tests/fixtures/framework/test_dataset.cpp
+++ b/tests/fixtures/framework/test_dataset.cpp
@@ -90,8 +90,7 @@ CalMultiVectorDistance(const vsag::DatasetPtr query,
     for (uint32_t qv = 0; qv < q_mv.len_; ++qv) {
         float min_dist = std::numeric_limits<float>::max();
         for (uint32_t bv = 0; bv < b_mv.len_; ++bv) {
-            float dist = dist_func(
-                q_mv.vectors_ + qv * dim, b_mv.vectors_ + bv * dim, dim);
+            float dist = dist_func(q_mv.vectors_ + qv * dim, b_mv.vectors_ + bv * dim, dim);
             if (dist < min_dist) {
                 min_dist = dist;
             }

--- a/tests/fixtures/framework/test_dataset.cpp
+++ b/tests/fixtures/framework/test_dataset.cpp
@@ -57,17 +57,17 @@ using MaxHeap = std::priority_queue<std::pair<float, int64_t>,
                                     CompareByFirst>;
 
 static std::pair<std::vector<uint32_t>, uint64_t>
-GenerateVectorCounts(uint64_t count, int seed, uint32_t min_count = 1, uint32_t max_count = 5) {
+GenerateMultiVectorLens(uint64_t count, int seed, uint32_t min_len = 1, uint32_t max_len = 5) {
     std::mt19937 gen(seed);
-    std::uniform_int_distribution<uint32_t> dist(min_count, max_count);
+    std::uniform_int_distribution<uint32_t> dist(min_len, max_len);
 
-    std::vector<uint32_t> vector_counts(count);
-    uint64_t total_vectors = 0;
+    std::vector<uint32_t> vector_lens(count);
+    uint64_t total_vector_len = 0;
     for (uint64_t i = 0; i < count; ++i) {
-        vector_counts[i] = dist(gen);
-        total_vectors += vector_counts[i];
+        vector_lens[i] = dist(gen);
+        total_vector_len += vector_lens[i];
     }
-    return {vector_counts, total_vectors};
+    return {vector_lens, total_vector_len};
 }
 
 // Calculate distance between two multi-vector documents using MaxSim similarity
@@ -77,30 +77,21 @@ CalMultiVectorDistance(const vsag::DatasetPtr query,
                        uint64_t query_idx,
                        const vsag::DatasetPtr base,
                        uint64_t base_idx) {
-    auto dim = base->GetDim();
-    auto* query_counts = query->GetVectorCounts();
-    auto* base_counts = base->GetVectorCounts();
-    auto* query_vecs = query->GetFloat32Vectors();
-    auto* base_vecs = base->GetFloat32Vectors();
+    int64_t dim = base->GetMultiVectorDim();
+    const vsag::MultiVector* query_mvs = query->GetMultiVectors();
+    const vsag::MultiVector* base_mvs = base->GetMultiVectors();
     auto dist_func = get_distance_func("ip");
 
-    // Calculate vector start offsets
-    uint32_t q_vec_start = 0;
-    for (uint64_t i = 0; i < query_idx; ++i) {
-        q_vec_start += query_counts[i];
-    }
-    uint32_t b_vec_start = 0;
-    for (uint64_t i = 0; i < base_idx; ++i) {
-        b_vec_start += base_counts[i];
-    }
+    const vsag::MultiVector& q_mv = query_mvs[query_idx];
+    const vsag::MultiVector& b_mv = base_mvs[base_idx];
 
     // MaxSim: for each query vector, find min distance (max similarity), then sum
     float total_score = 0.0F;
-    for (uint32_t qv = 0; qv < query_counts[query_idx]; ++qv) {
+    for (uint32_t qv = 0; qv < q_mv.len_; ++qv) {
         float min_dist = std::numeric_limits<float>::max();
-        for (uint32_t bv = 0; bv < base_counts[base_idx]; ++bv) {
+        for (uint32_t bv = 0; bv < b_mv.len_; ++bv) {
             float dist = dist_func(
-                query_vecs + (q_vec_start + qv) * dim, base_vecs + (b_vec_start + bv) * dim, dim);
+                q_mv.vectors_ + qv * dim, b_mv.vectors_ + bv * dim, dim);
             if (dist < min_dist) {
                 min_dist = dist;
             }
@@ -147,28 +138,17 @@ GenerateRandomDataset(uint64_t dim,
                       std::string vector_type = "dense",
                       bool has_duplicate = false,
                       int64_t id_shift = 16,
-                      int seed = 47,
-                      bool is_multi_vector = false) {
+                      int seed = 47) {
     auto base = vsag::Dataset::Make();
     bool need_normalize = (metric_str != "cosine");
 
-    std::vector<uint32_t> vector_counts;
-    uint64_t num_vectors = count;
-    if (is_multi_vector) {
-        uint64_t total_vectors;
-        std::tie(vector_counts, total_vectors) = GenerateVectorCounts(count, seed + 2);
-        num_vectors = total_vectors;
-    }
-
-    auto vecs = fixtures::generate_vectors(num_vectors, dim, need_normalize, seed);
-    auto vecs_int8 = fixtures::generate_int8_codes(num_vectors, dim, seed);
     auto attr_sets = fixtures::generate_attributes(count);
     auto paths = new std::string[count];
-    for (int i = 0; i < count; ++i) {
+    for (uint64_t i = 0; i < count; ++i) {
         paths[i] = create_random_string(!is_query);
     }
     std::vector<int64_t> ids(count);
-    for (int64_t i = 0; i < count; ++i) {
+    for (int64_t i = 0; i < static_cast<int64_t>(count); ++i) {
         ids[i] = (i << id_shift);
     }
     base->Dim(dim)
@@ -177,26 +157,49 @@ GenerateRandomDataset(uint64_t dim,
         ->AttributeSets(attr_sets)
         ->NumElements(count)
         ->Owner(true);
-    if (not has_duplicate) {
-        base->Float32Vectors(CopyVector(vecs))->Int8Vectors(CopyVector(vecs_int8));
-    } else {
-        base->Float32Vectors(DuplicateCopyVector(vecs))
-            ->Int8Vectors(DuplicateCopyVector(vecs_int8));
-    }
+
     if (vector_type == "sparse") {
+        auto vecs = fixtures::generate_vectors(count, dim, need_normalize, seed);
+        auto vecs_int8 = fixtures::generate_int8_codes(count, dim, seed);
         if (not has_duplicate) {
+            base->Float32Vectors(CopyVector(vecs))->Int8Vectors(CopyVector(vecs_int8));
             base->SparseVectors(CopyVector(GenerateSparseVectors(count, dim)));
         } else {
+            base->Float32Vectors(DuplicateCopyVector(vecs))
+                ->Int8Vectors(DuplicateCopyVector(vecs_int8));
             base->SparseVectors(DuplicateCopyVector(GenerateSparseVectors(count, dim)));
         }
+    } else if (vector_type == "multi") {
+        auto [vector_lens, total_vector_len] = GenerateMultiVectorLens(count, seed + 2);
+        auto vecs = fixtures::generate_vectors(total_vector_len, dim, need_normalize, seed);
+        auto* multi_vectors = new vsag::MultiVector[count];
+        uint64_t vec_offset = 0;
+        for (uint64_t i = 0; i < count; ++i) {
+            uint32_t len = vector_lens[i];
+            multi_vectors[i].len_ = len;
+            uint64_t num_floats = static_cast<uint64_t>(len) * dim;
+            multi_vectors[i].vectors_ = new float[num_floats];
+            std::memcpy(multi_vectors[i].vectors_,
+                        vecs.data() + vec_offset * dim,
+                        num_floats * sizeof(float));
+            vec_offset += len;
+        }
+        base->MultiVectorDim(dim)->MultiVectors(multi_vectors);
+    } else {
+        auto vecs = fixtures::generate_vectors(count, dim, need_normalize, seed);
+        auto vecs_int8 = fixtures::generate_int8_codes(count, dim, seed);
+        if (not has_duplicate) {
+            base->Float32Vectors(CopyVector(vecs))->Int8Vectors(CopyVector(vecs_int8));
+        } else {
+            base->Float32Vectors(DuplicateCopyVector(vecs))
+                ->Int8Vectors(DuplicateCopyVector(vecs_int8));
+        }
     }
+
     if (extra_info_size != 0) {
         auto extra_infos = fixtures::generate_extra_infos(count, extra_info_size);
         base->ExtraInfos(CopyVector(extra_infos));
         base->ExtraInfoSize(extra_info_size);
-    }
-    if (is_multi_vector) {
-        base->VectorCounts(CopyVector(vector_counts));
     }
     return base;
 }
@@ -359,8 +362,7 @@ TestDataset::CreateTestDataset(uint64_t dim,
                                uint64_t extra_info_size,
                                bool has_duplicate,
                                int64_t id_shift,
-                               bool use_fixed_seed,
-                               bool is_multi_vector) {
+                               bool use_fixed_seed) {
     constexpr int fixed_seed = 47;
     int seed = use_fixed_seed ? fixed_seed : fixtures::RandomValue(0, 564);
 
@@ -376,8 +378,7 @@ TestDataset::CreateTestDataset(uint64_t dim,
                                            vector_type,
                                            has_duplicate,
                                            dataset->id_shift,
-                                           seed,
-                                           is_multi_vector);
+                                           seed);
     constexpr uint64_t query_count = 100;
     dataset->query_ = GenerateRandomDataset(dim,
                                             query_count,
@@ -387,8 +388,7 @@ TestDataset::CreateTestDataset(uint64_t dim,
                                             vector_type,
                                             false,
                                             dataset->id_shift,
-                                            seed + 1,
-                                            is_multi_vector);
+                                            seed + 1);
     dataset->filter_query_ = dataset->query_;
     dataset->range_query_ = dataset->query_;
     dataset->valid_ratio_ = valid_ratio;
@@ -413,7 +413,7 @@ TestDataset::CreateTestDataset(uint64_t dim,
         };
 
         std::pair<float*, int64_t*> result;
-        if (is_multi_vector) {
+        if (vector_type == "multi") {
             result = CalMultiVectorDistanceMatrix(dataset->query_, dataset->base_);
         } else {
             result =

--- a/tests/fixtures/framework/test_dataset.h
+++ b/tests/fixtures/framework/test_dataset.h
@@ -43,12 +43,11 @@ public:
      * @param metric_str Distance metric type ("l2", "ip", etc.).
      * @param with_path Whether to include path information.
      * @param valid_ratio Ratio of valid vectors.
-     * @param vector_type Type of vectors ("dense", "sparse", etc.).
+     * @param vector_type Type of vectors ("dense", "sparse", "multi").
      * @param extra_info_size Size of extra info per vector.
      * @param has_duplicate Whether to include duplicate vectors.
      * @param id_shift Offset for generated IDs.
      * @param use_fixed_seed Whether to use a fixed seed for reproducible data generation.
-     * @param is_multi_vector Whether to generate multi-vector documents.
      * @return Shared pointer to the created TestDataset.
      */
     static std::shared_ptr<TestDataset>
@@ -61,8 +60,7 @@ public:
                       uint64_t extra_info_size = 0,
                       bool has_duplicate = false,
                       int64_t id_shift = 16,
-                      bool use_fixed_seed = true,
-                      bool is_multi_vector = false);
+                      bool use_fixed_seed = true);
 
     /**
      * @brief Creates a test dataset with NaN values.

--- a/tests/fixtures/framework/test_dataset_pool.cpp
+++ b/tests/fixtures/framework/test_dataset_pool.cpp
@@ -14,8 +14,8 @@ TestDatasetPool::GetDatasetAndCreate(uint64_t dim,
                                      uint64_t extra_info_size,
                                      int64_t id_shift,
                                      const std::string& vector_type) {
-    auto key =
-        key_gen(dim, count, metric_str, with_path, valid_ratio, extra_info_size, id_shift, vector_type);
+    auto key = key_gen(
+        dim, count, metric_str, with_path, valid_ratio, extra_info_size, id_shift, vector_type);
     if (this->pool_.find(key) == this->pool_.end()) {
         this->dim_counts_.emplace_back(dim, count);
         this->pool_[key] = TestDataset::CreateTestDataset(dim,

--- a/tests/fixtures/framework/test_dataset_pool.cpp
+++ b/tests/fixtures/framework/test_dataset_pool.cpp
@@ -13,9 +13,9 @@ TestDatasetPool::GetDatasetAndCreate(uint64_t dim,
                                      float valid_ratio,
                                      uint64_t extra_info_size,
                                      int64_t id_shift,
-                                     bool is_multi_vector) {
-    auto key = key_gen(
-        dim, count, metric_str, with_path, valid_ratio, extra_info_size, id_shift, is_multi_vector);
+                                     const std::string& vector_type) {
+    auto key =
+        key_gen(dim, count, metric_str, with_path, valid_ratio, extra_info_size, id_shift, vector_type);
     if (this->pool_.find(key) == this->pool_.end()) {
         this->dim_counts_.emplace_back(dim, count);
         this->pool_[key] = TestDataset::CreateTestDataset(dim,
@@ -23,12 +23,11 @@ TestDatasetPool::GetDatasetAndCreate(uint64_t dim,
                                                           metric_str,
                                                           with_path,
                                                           valid_ratio,
-                                                          "dense",
+                                                          vector_type,
                                                           extra_info_size,
                                                           false,
                                                           id_shift,
-                                                          true,
-                                                          is_multi_vector);
+                                                          true);
     }
     return this->pool_.at(key);
 }
@@ -40,11 +39,10 @@ TestDatasetPool::key_gen(int64_t dim,
                          float filter_ratio,
                          uint64_t extra_info_size,
                          int64_t id_shift,
-                         bool is_multi_vector) {
+                         const std::string& vector_type) {
     return std::to_string(dim) + "_" + std::to_string(count) + "_" + metric_str + "_" +
            std::to_string(with_path) + "_" + std::to_string(filter_ratio) +
-           std::to_string(extra_info_size) + "_" + std::to_string(id_shift) + "_" +
-           std::to_string(is_multi_vector);
+           std::to_string(extra_info_size) + "_" + std::to_string(id_shift) + "_" + vector_type;
 }
 
 TestDatasetPtr

--- a/tests/fixtures/framework/test_dataset_pool.h
+++ b/tests/fixtures/framework/test_dataset_pool.h
@@ -45,7 +45,7 @@ public:
      * @param valid_ratio Ratio of valid vectors.
      * @param extra_info_size Size of extra info per vector.
      * @param id_shift Offset for generated IDs.
-     * @param is_multi_vector Whether to generate multi-vector documents.
+     * @param vector_type Type of vectors ("dense", "sparse", "multi").
      * @return Shared pointer to the TestDataset.
      */
     TestDatasetPtr
@@ -56,7 +56,7 @@ public:
                         float valid_ratio = 0.8,
                         uint64_t extra_info_size = 0,
                         int64_t id_shift = 16,
-                        bool is_multi_vector = false);
+                        const std::string& vector_type = "dense");
 
     /**
      * @brief Gets a test dataset with duplicate vectors.
@@ -104,7 +104,7 @@ private:
      * @param filter_ratio Ratio of valid vectors.
      * @param extra_info_size Size of extra info per vector.
      * @param id_shift Offset for generated IDs.
-     * @param is_multi_vector Whether to include multi-vector mode in the key.
+     * @param vector_type Type of vectors ("dense", "sparse", "multi").
      * @return Unique string key for the dataset.
      */
     static std::string
@@ -115,7 +115,7 @@ private:
             float filter_ratio = 0.8,
             uint64_t extra_info_size = 0,
             int64_t id_shift = 16,
-            bool is_multi_vector = false);
+            const std::string& vector_type = "dense");
 
 private:
     std::unordered_map<std::string, TestDatasetPtr> pool_;   // Cache of TestDataset objects.

--- a/tests/test_index.cpp
+++ b/tests/test_index.cpp
@@ -39,22 +39,19 @@ Intersection(const int64_t* x, int64_t x_count, const int64_t* y, int64_t y_coun
 
 vsag::DatasetPtr
 get_one_query(const vsag::DatasetPtr& queries, int i) {
-    auto query = vsag::Dataset::Make();
-    query->NumElements(1)
-        ->Dim(queries->GetDim())
-        ->SparseVectors(queries->GetSparseVectors() + i)
-        ->Owner(false);
+    vsag::DatasetPtr query = vsag::Dataset::Make();
+    query->NumElements(1)->Dim(queries->GetDim())->Owner(false);
 
-    // Support multi-vector query - calculate correct vector offset
-    const auto* vector_counts = queries->GetVectorCounts();
-    if (vector_counts != nullptr) {
-        uint32_t vec_offset = 0;
-        for (int j = 0; j < i; ++j) {
-            vec_offset += vector_counts[j];
-        }
-        query->Float32Vectors(queries->GetFloat32Vectors() + vec_offset * queries->GetDim());
-        query->VectorCounts(vector_counts + i);
-    } else {
+    if (queries->GetSparseVectors() != nullptr) {
+        query->SparseVectors(queries->GetSparseVectors() + i);
+    }
+
+    if (queries->GetMultiVectors() != nullptr) {
+        query->MultiVectors(queries->GetMultiVectors() + i);
+        query->MultiVectorDim(queries->GetMultiVectorDim());
+    }
+
+    if (queries->GetFloat32Vectors() != nullptr) {
         query->Float32Vectors(queries->GetFloat32Vectors() + i * queries->GetDim());
     }
 

--- a/tests/test_warp.cpp
+++ b/tests/test_warp.cpp
@@ -111,7 +111,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::WarpTestIndex, "Warp Add Test", "[ft][war
         auto index = TestFactory(name, param, true);
         REQUIRE(index->GetIndexType() == vsag::IndexType::WARP);
         auto dataset =
-            pool.GetDatasetAndCreate(dim, base_count, metric_type, false, 0.8, 0, 16, true);
+            pool.GetDatasetAndCreate(dim, base_count, metric_type, false, 0.8, 0, 16, "multi");
         TestAddIndex(index, dataset, true);
         TestKnnSearch(index, dataset, search_param, 0.99, true);
         TestRangeSearch(index, dataset, search_param, 0.99, 10, true);
@@ -142,7 +142,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::WarpTestIndex,
             REQUIRE(deserialize_index.has_value());
         }
         auto dataset =
-            pool.GetDatasetAndCreate(dim, base_count, metric_type, false, 0.8, 0, 16, true);
+            pool.GetDatasetAndCreate(dim, base_count, metric_type, false, 0.8, 0, 16, "multi");
         TestBuildIndex(index, dataset, true);
         SECTION("serialize/deserialize by binary") {
             auto index2 = TestFactory(name, param, true);


### PR DESCRIPTION
## Summary

- Introduce `MultiVector` struct and associated constants for per-document variable-length dense sub-vectors
- Add MultiVector virtual interfaces to `Dataset` and implement them in `DatasetImpl` (setter/getter, DeepCopy, Append, destructor)
- Migrate WARP index to exclusively consume `MultiVectors`, removing the legacy `VectorCounts` path
- Adapt tests and `110_index_warp` example to use the MultiVectors dataset API
- Fix a bug in `DatasetImpl::Append` where validation was hoisted before state mutation to prevent OOB access

## Test plan

- [x] Unit tests pass: `make test`
- [x] Functional tests pass for WARP index
- [x] Coverage threshold maintained (>= 90%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)