### PR TITLE
fix: guard scalar quantizer NaN encoding

### DIFF
--- a/src/quantization/scalar_quantization/scalar_quantization_utils.h
+++ b/src/quantization/scalar_quantization/scalar_quantization_utils.h
@@ -16,12 +16,14 @@
 
 namespace vsag {
 
-static inline float
+inline constexpr float kScalarQuantizationUpperClamp = 0.999F;
+
+inline float
 ClampScalarQuantizationDelta(float delta) {
     if (!(delta >= 0.0F)) {
         return 0.0F;
     }
-    if (delta > 0.999F) {
+    if (delta > kScalarQuantizationUpperClamp) {
         return 1.0F;
     }
     return delta;

--- a/src/quantization/scalar_quantization/scalar_quantization_utils.h
+++ b/src/quantization/scalar_quantization/scalar_quantization_utils.h
@@ -1,0 +1,30 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace vsag {
+
+static inline float
+ClampScalarQuantizationDelta(float delta) {
+    if (!(delta >= 0.0F)) {
+        return 0.0F;
+    }
+    if (delta > 0.999F) {
+        return 1.0F;
+    }
+    return delta;
+}
+
+}  // namespace vsag

--- a/src/quantization/scalar_quantization/scalar_quantizer.cpp
+++ b/src/quantization/scalar_quantization/scalar_quantizer.cpp
@@ -15,6 +15,8 @@
 
 #include "scalar_quantizer.h"
 
+#include <cmath>
+
 #include "scalar_quantization_trainer.h"
 #include "simd/normalize.h"
 #include "simd/sq4_simd.h"
@@ -104,6 +106,8 @@ ScalarQuantizer<metric, bit>::EncodeOneImpl(const float* data, uint8_t* codes) c
             delta = 0;
         } else if (delta > 0.999F) {
             delta = 1;
+        } else if (std::isnan(delta)) {
+            delta = 0;
         }
         scaled = static_cast<uint8_t>(static_cast<float>(MAX_CODE_PER_DIM - 1) * delta);
         fill_codes(codes, scaled, BIT_PER_DIM, d);

--- a/src/quantization/scalar_quantization/scalar_quantizer.cpp
+++ b/src/quantization/scalar_quantization/scalar_quantizer.cpp
@@ -16,6 +16,7 @@
 #include "scalar_quantizer.h"
 
 #include "scalar_quantization_trainer.h"
+#include "scalar_quantization_utils.h"
 #include "simd/normalize.h"
 #include "simd/sq4_simd.h"
 #include "simd/sq8_simd.h"
@@ -100,12 +101,7 @@ ScalarQuantizer<metric, bit>::EncodeOneImpl(const float* data, uint8_t* codes) c
         } else {
             delta = 1.0F * (cur[d] - lower_bound_[d]) / diff_[d];
         }
-        // The negated comparison is true for NaN, preventing it from reaching the uint8_t cast.
-        if (!(delta >= 0.0F)) {
-            delta = 0;
-        } else if (delta > 0.999F) {
-            delta = 1;
-        }
+        delta = ClampScalarQuantizationDelta(delta);
         scaled = static_cast<uint8_t>(static_cast<float>(MAX_CODE_PER_DIM - 1) * delta);
         fill_codes(codes, scaled, BIT_PER_DIM, d);
     }

--- a/src/quantization/scalar_quantization/scalar_quantizer.cpp
+++ b/src/quantization/scalar_quantization/scalar_quantizer.cpp
@@ -100,6 +100,7 @@ ScalarQuantizer<metric, bit>::EncodeOneImpl(const float* data, uint8_t* codes) c
         } else {
             delta = 1.0F * (cur[d] - lower_bound_[d]) / diff_[d];
         }
+        // This also clamps NaN, preventing it from reaching the uint8_t cast below.
         if (!(delta > 0.0F)) {
             delta = 0;
         } else if (delta > 0.999F) {

--- a/src/quantization/scalar_quantization/scalar_quantizer.cpp
+++ b/src/quantization/scalar_quantization/scalar_quantizer.cpp
@@ -15,8 +15,6 @@
 
 #include "scalar_quantizer.h"
 
-#include <cmath>
-
 #include "scalar_quantization_trainer.h"
 #include "simd/normalize.h"
 #include "simd/sq4_simd.h"
@@ -102,12 +100,10 @@ ScalarQuantizer<metric, bit>::EncodeOneImpl(const float* data, uint8_t* codes) c
         } else {
             delta = 1.0F * (cur[d] - lower_bound_[d]) / diff_[d];
         }
-        if (delta < 0.0F) {
+        if (!(delta > 0.0F)) {
             delta = 0;
         } else if (delta > 0.999F) {
             delta = 1;
-        } else if (std::isnan(delta)) {
-            delta = 0;
         }
         scaled = static_cast<uint8_t>(static_cast<float>(MAX_CODE_PER_DIM - 1) * delta);
         fill_codes(codes, scaled, BIT_PER_DIM, d);

--- a/src/quantization/scalar_quantization/scalar_quantizer.cpp
+++ b/src/quantization/scalar_quantization/scalar_quantizer.cpp
@@ -100,8 +100,8 @@ ScalarQuantizer<metric, bit>::EncodeOneImpl(const float* data, uint8_t* codes) c
         } else {
             delta = 1.0F * (cur[d] - lower_bound_[d]) / diff_[d];
         }
-        // This also clamps NaN, preventing it from reaching the uint8_t cast below.
-        if (!(delta > 0.0F)) {
+        // The negated comparison is true for NaN, preventing it from reaching the uint8_t cast.
+        if (!(delta >= 0.0F)) {
             delta = 0;
         } else if (delta > 0.999F) {
             delta = 1;

--- a/src/quantization/scalar_quantization/scalar_quantizer_test.cpp
+++ b/src/quantization/scalar_quantization/scalar_quantizer_test.cpp
@@ -15,6 +15,8 @@
 
 #include "scalar_quantizer.h"
 
+#include <cmath>
+#include <limits>
 #include <vector>
 
 #include "impl/allocator/default_allocator.h"
@@ -95,6 +97,20 @@ TEST_CASE("SQ4 Serialize and Deserialize", "[ut][SQ4Quantizer]") {
             TestSerializeAndDeserializeMetricSQ4<metrics[2]>(dim, count, error);
         }
     }
+}
+
+TEST_CASE("SQ8 Encode handles NaN delta before uint8 cast", "[ut][SQ8Quantizer]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    SQ8Quantizer<MetricType::METRIC_TYPE_L2SQR> quantizer(2, allocator.get());
+    std::vector<float> train = {0.0F, 0.0F, 1.0F, 1.0F};
+    std::vector<float> query = {std::numeric_limits<float>::quiet_NaN(), 0.5F};
+    std::vector<uint8_t> codes(quantizer.GetCodeSize());
+    std::vector<float> decoded(2);
+
+    REQUIRE(quantizer.Train(train.data(), 2));
+    REQUIRE(quantizer.EncodeOne(query.data(), codes.data()));
+    REQUIRE(quantizer.DecodeOne(codes.data(), decoded.data()));
+    REQUIRE(std::isfinite(decoded[0]));
 }
 
 template <MetricType metric>

--- a/src/quantization/scalar_quantization/scalar_quantizer_test.cpp
+++ b/src/quantization/scalar_quantization/scalar_quantizer_test.cpp
@@ -19,7 +19,6 @@
 #include <limits>
 #include <vector>
 
-#include "impl/allocator/default_allocator.h"
 #include "impl/allocator/safe_allocator.h"
 #include "quantization/quantizer_test.h"
 #include "unittest.h"

--- a/src/quantization/scalar_quantization/scalar_quantizer_test.cpp
+++ b/src/quantization/scalar_quantization/scalar_quantizer_test.cpp
@@ -114,6 +114,22 @@ TEST_CASE("SQ8 Encode handles NaN delta before uint8 cast", "[ut][SQ8Quantizer]"
     REQUIRE(std::abs(decoded[0]) <= 1e-6F);
 }
 
+TEST_CASE("SQ4 Encode handles NaN delta before uint8 cast", "[ut][SQ4Quantizer]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    SQ4Quantizer<MetricType::METRIC_TYPE_L2SQR> quantizer(2, allocator.get());
+    std::vector<float> train = {0.0F, 0.0F, 1.0F, 1.0F};
+    std::vector<float> query = {std::numeric_limits<float>::quiet_NaN(), 0.5F};
+    std::vector<uint8_t> codes(quantizer.GetCodeSize());
+    std::vector<float> decoded(2);
+
+    REQUIRE(quantizer.Train(train.data(), 2));
+    REQUIRE(quantizer.EncodeOne(query.data(), codes.data()));
+    REQUIRE(quantizer.DecodeOne(codes.data(), decoded.data()));
+    REQUIRE((codes[0] & 0x0F) == 0);
+    REQUIRE(std::isfinite(decoded[0]));
+    REQUIRE(std::abs(decoded[0]) <= 1e-6F);
+}
+
 template <MetricType metric>
 void
 TestQuantizerEncodeDecodeMetricSQ8(uint64_t dim,

--- a/src/quantization/scalar_quantization/scalar_quantizer_test.cpp
+++ b/src/quantization/scalar_quantization/scalar_quantizer_test.cpp
@@ -110,8 +110,10 @@ TEST_CASE("SQ8 Encode handles NaN delta before uint8 cast", "[ut][SQ8Quantizer]"
     REQUIRE(quantizer.EncodeOne(query.data(), codes.data()));
     REQUIRE(quantizer.DecodeOne(codes.data(), decoded.data()));
     REQUIRE(codes[0] == 0);
+    REQUIRE(codes[1] == static_cast<uint8_t>(255.0F * 0.5F));
     REQUIRE(std::isfinite(decoded[0]));
     REQUIRE(std::abs(decoded[0]) <= 1e-6F);
+    REQUIRE(std::abs(decoded[1] - 127.0F / 255.0F) <= 1e-6F);
 }
 
 TEST_CASE("SQ4 Encode handles NaN delta before uint8 cast", "[ut][SQ4Quantizer]") {
@@ -126,8 +128,10 @@ TEST_CASE("SQ4 Encode handles NaN delta before uint8 cast", "[ut][SQ4Quantizer]"
     REQUIRE(quantizer.EncodeOne(query.data(), codes.data()));
     REQUIRE(quantizer.DecodeOne(codes.data(), decoded.data()));
     REQUIRE((codes[0] & 0x0F) == 0);
+    REQUIRE(((codes[0] >> 4) & 0x0F) == static_cast<uint8_t>(15.0F * 0.5F));
     REQUIRE(std::isfinite(decoded[0]));
     REQUIRE(std::abs(decoded[0]) <= 1e-6F);
+    REQUIRE(std::abs(decoded[1] - 7.0F / 15.0F) <= 1e-6F);
 }
 
 template <MetricType metric>

--- a/src/quantization/scalar_quantization/scalar_quantizer_test.cpp
+++ b/src/quantization/scalar_quantization/scalar_quantizer_test.cpp
@@ -112,7 +112,7 @@ TEST_CASE("SQ8 Encode handles NaN delta before uint8 cast", "[ut][SQ8Quantizer]"
     REQUIRE(quantizer.DecodeOne(codes.data(), decoded.data()));
     REQUIRE(codes[0] == 0);
     REQUIRE(std::isfinite(decoded[0]));
-    REQUIRE(decoded[0] == 0.0F);
+    REQUIRE(std::abs(decoded[0]) <= 1e-6F);
 }
 
 template <MetricType metric>

--- a/src/quantization/scalar_quantization/scalar_quantizer_test.cpp
+++ b/src/quantization/scalar_quantization/scalar_quantizer_test.cpp
@@ -110,7 +110,9 @@ TEST_CASE("SQ8 Encode handles NaN delta before uint8 cast", "[ut][SQ8Quantizer]"
     REQUIRE(quantizer.Train(train.data(), 2));
     REQUIRE(quantizer.EncodeOne(query.data(), codes.data()));
     REQUIRE(quantizer.DecodeOne(codes.data(), decoded.data()));
+    REQUIRE(codes[0] == 0);
     REQUIRE(std::isfinite(decoded[0]));
+    REQUIRE(decoded[0] == 0.0F);
 }
 
 template <MetricType metric>

--- a/src/quantization/scalar_quantization/scalar_quantizer_test_utils.h
+++ b/src/quantization/scalar_quantization/scalar_quantizer_test_utils.h
@@ -1,0 +1,43 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cmath>
+#include <vector>
+
+#include "unittest.h"
+
+namespace vsag {
+
+template <typename QuantizerT>
+void
+TestUniformZeroRangeEncodesToZero(QuantizerT& quantizer, uint64_t dim, uint64_t encoded_code_size) {
+    std::vector<float> train(dim * 3, 3.0F);
+    std::vector<float> query(dim, 4.0F);
+    std::vector<uint8_t> codes(quantizer.GetCodeSize());
+    std::vector<float> decoded(dim);
+
+    REQUIRE(quantizer.Train(train.data(), 3));
+    REQUIRE(quantizer.EncodeOne(query.data(), codes.data()));
+    for (uint64_t i = 0; i < encoded_code_size; ++i) {
+        REQUIRE(codes[i] == 0);
+    }
+    REQUIRE(quantizer.DecodeOne(codes.data(), decoded.data()));
+    for (auto value : decoded) {
+        REQUIRE(std::abs(value - 3.0F) <= 1e-6F);
+    }
+}
+
+}  // namespace vsag

--- a/src/quantization/scalar_quantization/scalar_quantizer_test_utils.h
+++ b/src/quantization/scalar_quantization/scalar_quantizer_test_utils.h
@@ -23,7 +23,11 @@ namespace vsag {
 
 template <typename QuantizerT>
 void
-TestUniformZeroRangeEncodesToZero(QuantizerT& quantizer, uint64_t dim, uint64_t encoded_code_size) {
+TestUniformZeroRangeEncodesToZero(QuantizerT& quantizer,
+                                  uint64_t dim,
+                                  uint64_t encoded_code_size,
+                                  uint64_t code_offset = 0,
+                                  float tolerance = 1e-5F) {
     std::vector<float> train(dim * 3, 3.0F);
     std::vector<float> query(dim, 4.0F);
     std::vector<uint8_t> codes(quantizer.GetCodeSize());
@@ -32,11 +36,11 @@ TestUniformZeroRangeEncodesToZero(QuantizerT& quantizer, uint64_t dim, uint64_t 
     REQUIRE(quantizer.Train(train.data(), 3));
     REQUIRE(quantizer.EncodeOne(query.data(), codes.data()));
     for (uint64_t i = 0; i < encoded_code_size; ++i) {
-        REQUIRE(codes[i] == 0);
+        REQUIRE(codes[code_offset + i] == 0);
     }
     REQUIRE(quantizer.DecodeOne(codes.data(), decoded.data()));
     for (auto value : decoded) {
-        REQUIRE(std::abs(value - 3.0F) <= 1e-6F);
+        REQUIRE(std::abs(value - 3.0F) <= tolerance);
     }
 }
 

--- a/src/quantization/scalar_quantization/sq4_uniform_quantizer.cpp
+++ b/src/quantization/scalar_quantization/sq4_uniform_quantizer.cpp
@@ -19,6 +19,7 @@
 
 #include "index_common_param.h"
 #include "scalar_quantization_trainer.h"
+#include "scalar_quantization_utils.h"
 #include "simd/normalize.h"
 #include "simd/sq4_uniform_simd.h"
 #include "sq4_uniform_quantizer_parameter.h"
@@ -125,12 +126,7 @@ SQ4UniformQuantizer<metric>::EncodeOneImpl(const float* data, uint8_t* codes) co
     float inv_diff = diff_ == 0.0F ? 0.0F : 1.0F / diff_;
     for (uint64_t d = 0; d < this->dim_; d++) {
         delta = (data[d] - lower_bound_) * inv_diff;
-        // The negated comparison is true for NaN, preventing it from reaching the uint8_t cast.
-        if (!(delta >= 0.0F)) {
-            delta = 0.0F;
-        } else if (delta > 0.999F) {
-            delta = 1.0F;
-        }
+        delta = ClampScalarQuantizationDelta(delta);
         scaled = static_cast<uint8_t>(15.0F * delta);
 
         if ((d & 1) != 0U) {

--- a/src/quantization/scalar_quantization/sq4_uniform_quantizer.cpp
+++ b/src/quantization/scalar_quantization/sq4_uniform_quantizer.cpp
@@ -125,6 +125,7 @@ SQ4UniformQuantizer<metric>::EncodeOneImpl(const float* data, uint8_t* codes) co
     float inv_diff = diff_ == 0.0F ? 0.0F : 1.0F / diff_;
     for (uint64_t d = 0; d < this->dim_; d++) {
         delta = (data[d] - lower_bound_) * inv_diff;
+        // This also clamps NaN, preventing it from reaching the uint8_t cast below.
         if (!(delta > 0.0F)) {
             delta = 0.0F;
         } else if (delta > 0.999F) {

--- a/src/quantization/scalar_quantization/sq4_uniform_quantizer.cpp
+++ b/src/quantization/scalar_quantization/sq4_uniform_quantizer.cpp
@@ -125,8 +125,8 @@ SQ4UniformQuantizer<metric>::EncodeOneImpl(const float* data, uint8_t* codes) co
     float inv_diff = diff_ == 0.0F ? 0.0F : 1.0F / diff_;
     for (uint64_t d = 0; d < this->dim_; d++) {
         delta = (data[d] - lower_bound_) * inv_diff;
-        // This also clamps NaN, preventing it from reaching the uint8_t cast below.
-        if (!(delta > 0.0F)) {
+        // The negated comparison is true for NaN, preventing it from reaching the uint8_t cast.
+        if (!(delta >= 0.0F)) {
             delta = 0.0F;
         } else if (delta > 0.999F) {
             delta = 1.0F;

--- a/src/quantization/scalar_quantization/sq4_uniform_quantizer.cpp
+++ b/src/quantization/scalar_quantization/sq4_uniform_quantizer.cpp
@@ -15,7 +15,6 @@
 
 #include "sq4_uniform_quantizer.h"
 
-#include <cmath>
 #include <cstddef>
 
 #include "index_common_param.h"
@@ -123,14 +122,13 @@ SQ4UniformQuantizer<metric>::EncodeOneImpl(const float* data, uint8_t* codes) co
         data = norm_data.data();
     }
 
+    float inv_diff = diff_ == 0.0F ? 0.0F : 1.0F / diff_;
     for (uint64_t d = 0; d < this->dim_; d++) {
-        delta = diff_ == 0.0F ? 0.0F : 1.0F * (data[d] - lower_bound_) / diff_;
-        if (delta < 0.0F) {
+        delta = (data[d] - lower_bound_) * inv_diff;
+        if (!(delta > 0.0F)) {
             delta = 0.0F;
         } else if (delta > 0.999F) {
             delta = 1.0F;
-        } else if (std::isnan(delta)) {
-            delta = 0.0F;
         }
         scaled = static_cast<uint8_t>(15.0F * delta);
 

--- a/src/quantization/scalar_quantization/sq4_uniform_quantizer.cpp
+++ b/src/quantization/scalar_quantization/sq4_uniform_quantizer.cpp
@@ -15,6 +15,7 @@
 
 #include "sq4_uniform_quantizer.h"
 
+#include <cmath>
 #include <cstddef>
 
 #include "index_common_param.h"
@@ -123,11 +124,13 @@ SQ4UniformQuantizer<metric>::EncodeOneImpl(const float* data, uint8_t* codes) co
     }
 
     for (uint64_t d = 0; d < this->dim_; d++) {
-        delta = 1.0F * (data[d] - lower_bound_) / diff_;
+        delta = diff_ == 0.0F ? 0.0F : 1.0F * (data[d] - lower_bound_) / diff_;
         if (delta < 0.0F) {
             delta = 0.0F;
         } else if (delta > 0.999F) {
             delta = 1.0F;
+        } else if (std::isnan(delta)) {
+            delta = 0.0F;
         }
         scaled = static_cast<uint8_t>(15.0F * delta);
 

--- a/src/quantization/scalar_quantization/sq4_uniform_quantizer_test.cpp
+++ b/src/quantization/scalar_quantization/sq4_uniform_quantizer_test.cpp
@@ -15,11 +15,9 @@
 
 #include "sq4_uniform_quantizer.h"
 
-#include <cmath>
-#include <vector>
-
 #include "impl/allocator/safe_allocator.h"
 #include "quantization/quantizer_test.h"
+#include "scalar_quantizer_test_utils.h"
 #include "unittest.h"
 using namespace vsag;
 
@@ -52,21 +50,9 @@ TEST_CASE("SQ4 Uniform Encode and Decode", "[ut][SQ4UniformQuantizer]") {
 
 TEST_CASE("SQ4 Uniform encodes zero range to zero", "[ut][SQ4UniformQuantizer]") {
     auto allocator = SafeAllocator::FactoryDefaultAllocator();
-    SQ4UniformQuantizer<MetricType::METRIC_TYPE_L2SQR> quantizer(4, allocator.get());
-    std::vector<float> train(12, 3.0F);
-    std::vector<float> query(4, 4.0F);
-    std::vector<uint8_t> codes(quantizer.GetCodeSize());
-    std::vector<float> decoded(4);
-
-    REQUIRE(quantizer.Train(train.data(), 3));
-    REQUIRE(quantizer.EncodeOne(query.data(), codes.data()));
-    for (uint64_t i = 0; i < query.size() / 2; ++i) {
-        REQUIRE(codes[i] == 0);
-    }
-    REQUIRE(quantizer.DecodeOne(codes.data(), decoded.data()));
-    for (auto value : decoded) {
-        REQUIRE(std::abs(value - 3.0F) <= 1e-6F);
-    }
+    constexpr uint64_t dim = 4;
+    SQ4UniformQuantizer<MetricType::METRIC_TYPE_L2SQR> quantizer(dim, allocator.get());
+    TestUniformZeroRangeEncodesToZero(quantizer, dim, dim / 2);
 }
 
 template <MetricType metric>

--- a/src/quantization/scalar_quantization/sq4_uniform_quantizer_test.cpp
+++ b/src/quantization/scalar_quantization/sq4_uniform_quantizer_test.cpp
@@ -15,6 +15,7 @@
 
 #include "sq4_uniform_quantizer.h"
 
+#include <cmath>
 #include <vector>
 
 #include "impl/allocator/safe_allocator.h"
@@ -64,7 +65,7 @@ TEST_CASE("SQ4 Uniform encodes zero range to zero", "[ut][SQ4UniformQuantizer]")
     }
     REQUIRE(quantizer.DecodeOne(codes.data(), decoded.data()));
     for (auto value : decoded) {
-        REQUIRE(value == 3.0F);
+        REQUIRE(std::abs(value - 3.0F) <= 1e-6F);
     }
 }
 

--- a/src/quantization/scalar_quantization/sq4_uniform_quantizer_test.cpp
+++ b/src/quantization/scalar_quantization/sq4_uniform_quantizer_test.cpp
@@ -52,15 +52,15 @@ TEST_CASE("SQ4 Uniform Encode and Decode", "[ut][SQ4UniformQuantizer]") {
 
 TEST_CASE("SQ4 Uniform encodes zero range to zero", "[ut][SQ4UniformQuantizer]") {
     auto allocator = SafeAllocator::FactoryDefaultAllocator();
-    SQ4UniformQuantizer<MetricType::METRIC_TYPE_L2SQR> quantizer(5, allocator.get());
-    std::vector<float> train(15, 3.0F);
-    std::vector<float> query(5, 4.0F);
+    SQ4UniformQuantizer<MetricType::METRIC_TYPE_L2SQR> quantizer(4, allocator.get());
+    std::vector<float> train(12, 3.0F);
+    std::vector<float> query(4, 4.0F);
     std::vector<uint8_t> codes(quantizer.GetCodeSize());
-    std::vector<float> decoded(5);
+    std::vector<float> decoded(4);
 
     REQUIRE(quantizer.Train(train.data(), 3));
     REQUIRE(quantizer.EncodeOne(query.data(), codes.data()));
-    for (uint64_t i = 0; i < (query.size() + 1) / 2; ++i) {
+    for (uint64_t i = 0; i < query.size() / 2; ++i) {
         REQUIRE(codes[i] == 0);
     }
     REQUIRE(quantizer.DecodeOne(codes.data(), decoded.data()));

--- a/src/quantization/scalar_quantization/sq4_uniform_quantizer_test.cpp
+++ b/src/quantization/scalar_quantization/sq4_uniform_quantizer_test.cpp
@@ -59,6 +59,9 @@ TEST_CASE("SQ4 Uniform encodes zero range to zero", "[ut][SQ4UniformQuantizer]")
 
     REQUIRE(quantizer.Train(train.data(), 3));
     REQUIRE(quantizer.EncodeOne(query.data(), codes.data()));
+    for (uint64_t i = 0; i < (query.size() + 1) / 2; ++i) {
+        REQUIRE(codes[i] == 0);
+    }
     REQUIRE(quantizer.DecodeOne(codes.data(), decoded.data()));
     for (auto value : decoded) {
         REQUIRE(value == 3.0F);

--- a/src/quantization/scalar_quantization/sq4_uniform_quantizer_test.cpp
+++ b/src/quantization/scalar_quantization/sq4_uniform_quantizer_test.cpp
@@ -49,6 +49,22 @@ TEST_CASE("SQ4 Uniform Encode and Decode", "[ut][SQ4UniformQuantizer]") {
     }
 }
 
+TEST_CASE("SQ4 Uniform encodes zero range to zero", "[ut][SQ4UniformQuantizer]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    SQ4UniformQuantizer<MetricType::METRIC_TYPE_L2SQR> quantizer(5, allocator.get());
+    std::vector<float> train(15, 3.0F);
+    std::vector<float> query(5, 4.0F);
+    std::vector<uint8_t> codes(quantizer.GetCodeSize());
+    std::vector<float> decoded(5);
+
+    REQUIRE(quantizer.Train(train.data(), 3));
+    REQUIRE(quantizer.EncodeOne(query.data(), codes.data()));
+    REQUIRE(quantizer.DecodeOne(codes.data(), decoded.data()));
+    for (auto value : decoded) {
+        REQUIRE(value == 3.0F);
+    }
+}
+
 template <MetricType metric>
 void
 TestComputeMetricSQ4Uniform(uint64_t dim, int count, float error = 1e-5) {

--- a/src/quantization/scalar_quantization/sq8_uniform_quantizer.cpp
+++ b/src/quantization/scalar_quantization/sq8_uniform_quantizer.cpp
@@ -18,6 +18,7 @@
 #include <cstddef>
 
 #include "scalar_quantization_trainer.h"
+#include "scalar_quantization_utils.h"
 #include "simd/normalize.h"
 #include "simd/sq8_uniform_simd.h"
 #include "typing.h"
@@ -113,12 +114,7 @@ SQ8UniformQuantizer<metric>::EncodeOneImpl(const float* data, uint8_t* codes) co
     float inv_diff = diff_ == 0.0F ? 0.0F : 1.0F / diff_;
     for (uint64_t d = 0; d < this->dim_; d++) {
         delta = (data[d] - lower_bound_) * inv_diff;
-        // The negated comparison is true for NaN, preventing it from reaching the uint8_t cast.
-        if (!(delta >= 0.0F)) {
-            delta = 0;
-        } else if (delta > 0.999F) {
-            delta = 1;
-        }
+        delta = ClampScalarQuantizationDelta(delta);
         scaled = static_cast<uint8_t>(255.0F * delta);
         codes[offset_code_ + d] = scaled;
 

--- a/src/quantization/scalar_quantization/sq8_uniform_quantizer.cpp
+++ b/src/quantization/scalar_quantization/sq8_uniform_quantizer.cpp
@@ -15,6 +15,7 @@
 
 #include "sq8_uniform_quantizer.h"
 
+#include <cmath>
 #include <cstddef>
 
 #include "scalar_quantization_trainer.h"
@@ -111,11 +112,13 @@ SQ8UniformQuantizer<metric>::EncodeOneImpl(const float* data, uint8_t* codes) co
     }
 
     for (uint64_t d = 0; d < this->dim_; d++) {
-        delta = 1.0F * (data[d] - lower_bound_) / diff_;
+        delta = diff_ == 0.0F ? 0.0F : 1.0F * (data[d] - lower_bound_) / diff_;
         if (delta < 0.0F) {
             delta = 0;
         } else if (delta > 0.999F) {
             delta = 1;
+        } else if (std::isnan(delta)) {
+            delta = 0;
         }
         scaled = static_cast<uint8_t>(255.0F * delta);
         codes[offset_code_ + d] = scaled;

--- a/src/quantization/scalar_quantization/sq8_uniform_quantizer.cpp
+++ b/src/quantization/scalar_quantization/sq8_uniform_quantizer.cpp
@@ -15,7 +15,6 @@
 
 #include "sq8_uniform_quantizer.h"
 
-#include <cmath>
 #include <cstddef>
 
 #include "scalar_quantization_trainer.h"
@@ -111,14 +110,13 @@ SQ8UniformQuantizer<metric>::EncodeOneImpl(const float* data, uint8_t* codes) co
         data = norm_data.data();
     }
 
+    float inv_diff = diff_ == 0.0F ? 0.0F : 1.0F / diff_;
     for (uint64_t d = 0; d < this->dim_; d++) {
-        delta = diff_ == 0.0F ? 0.0F : 1.0F * (data[d] - lower_bound_) / diff_;
-        if (delta < 0.0F) {
+        delta = (data[d] - lower_bound_) * inv_diff;
+        if (!(delta > 0.0F)) {
             delta = 0;
         } else if (delta > 0.999F) {
             delta = 1;
-        } else if (std::isnan(delta)) {
-            delta = 0;
         }
         scaled = static_cast<uint8_t>(255.0F * delta);
         codes[offset_code_ + d] = scaled;

--- a/src/quantization/scalar_quantization/sq8_uniform_quantizer.cpp
+++ b/src/quantization/scalar_quantization/sq8_uniform_quantizer.cpp
@@ -113,8 +113,8 @@ SQ8UniformQuantizer<metric>::EncodeOneImpl(const float* data, uint8_t* codes) co
     float inv_diff = diff_ == 0.0F ? 0.0F : 1.0F / diff_;
     for (uint64_t d = 0; d < this->dim_; d++) {
         delta = (data[d] - lower_bound_) * inv_diff;
-        // This also clamps NaN, preventing it from reaching the uint8_t cast below.
-        if (!(delta > 0.0F)) {
+        // The negated comparison is true for NaN, preventing it from reaching the uint8_t cast.
+        if (!(delta >= 0.0F)) {
             delta = 0;
         } else if (delta > 0.999F) {
             delta = 1;

--- a/src/quantization/scalar_quantization/sq8_uniform_quantizer.cpp
+++ b/src/quantization/scalar_quantization/sq8_uniform_quantizer.cpp
@@ -113,6 +113,7 @@ SQ8UniformQuantizer<metric>::EncodeOneImpl(const float* data, uint8_t* codes) co
     float inv_diff = diff_ == 0.0F ? 0.0F : 1.0F / diff_;
     for (uint64_t d = 0; d < this->dim_; d++) {
         delta = (data[d] - lower_bound_) * inv_diff;
+        // This also clamps NaN, preventing it from reaching the uint8_t cast below.
         if (!(delta > 0.0F)) {
             delta = 0;
         } else if (delta > 0.999F) {

--- a/src/quantization/scalar_quantization/sq8_uniform_quantizer_test.cpp
+++ b/src/quantization/scalar_quantization/sq8_uniform_quantizer_test.cpp
@@ -15,11 +15,9 @@
 
 #include "sq8_uniform_quantizer.h"
 
-#include <cmath>
-#include <vector>
-
 #include "impl/allocator/safe_allocator.h"
 #include "quantization/quantizer_test.h"
+#include "scalar_quantizer_test_utils.h"
 #include "unittest.h"
 using namespace vsag;
 
@@ -52,21 +50,9 @@ TEST_CASE("SQ8 Uniform Encode and Decode", "[ut][SQ8UniformQuantizer]") {
 
 TEST_CASE("SQ8 Uniform encodes zero range to zero", "[ut][SQ8UniformQuantizer]") {
     auto allocator = SafeAllocator::FactoryDefaultAllocator();
-    SQ8UniformQuantizer<MetricType::METRIC_TYPE_L2SQR> quantizer(4, allocator.get());
-    std::vector<float> train(12, 3.0F);
-    std::vector<float> query(4, 4.0F);
-    std::vector<uint8_t> codes(quantizer.GetCodeSize());
-    std::vector<float> decoded(4);
-
-    REQUIRE(quantizer.Train(train.data(), 3));
-    REQUIRE(quantizer.EncodeOne(query.data(), codes.data()));
-    for (uint64_t i = 0; i < query.size(); ++i) {
-        REQUIRE(codes[i] == 0);
-    }
-    REQUIRE(quantizer.DecodeOne(codes.data(), decoded.data()));
-    for (auto value : decoded) {
-        REQUIRE(std::abs(value - 3.0F) <= 1e-6F);
-    }
+    constexpr uint64_t dim = 4;
+    SQ8UniformQuantizer<MetricType::METRIC_TYPE_L2SQR> quantizer(dim, allocator.get());
+    TestUniformZeroRangeEncodesToZero(quantizer, dim, dim);
 }
 
 template <MetricType metric>

--- a/src/quantization/scalar_quantization/sq8_uniform_quantizer_test.cpp
+++ b/src/quantization/scalar_quantization/sq8_uniform_quantizer_test.cpp
@@ -49,6 +49,22 @@ TEST_CASE("SQ8 Uniform Encode and Decode", "[ut][SQ8UniformQuantizer]") {
     }
 }
 
+TEST_CASE("SQ8 Uniform encodes zero range to zero", "[ut][SQ8UniformQuantizer]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    SQ8UniformQuantizer<MetricType::METRIC_TYPE_L2SQR> quantizer(4, allocator.get());
+    std::vector<float> train(12, 3.0F);
+    std::vector<float> query(4, 4.0F);
+    std::vector<uint8_t> codes(quantizer.GetCodeSize());
+    std::vector<float> decoded(4);
+
+    REQUIRE(quantizer.Train(train.data(), 3));
+    REQUIRE(quantizer.EncodeOne(query.data(), codes.data()));
+    REQUIRE(quantizer.DecodeOne(codes.data(), decoded.data()));
+    for (auto value : decoded) {
+        REQUIRE(value == 3.0F);
+    }
+}
+
 template <MetricType metric>
 void
 TestComputeMetricSQ8Uniform(uint64_t dim, int count, float error = 1e-5) {

--- a/src/quantization/scalar_quantization/sq8_uniform_quantizer_test.cpp
+++ b/src/quantization/scalar_quantization/sq8_uniform_quantizer_test.cpp
@@ -15,6 +15,7 @@
 
 #include "sq8_uniform_quantizer.h"
 
+#include <cmath>
 #include <vector>
 
 #include "impl/allocator/safe_allocator.h"
@@ -64,7 +65,7 @@ TEST_CASE("SQ8 Uniform encodes zero range to zero", "[ut][SQ8UniformQuantizer]")
     }
     REQUIRE(quantizer.DecodeOne(codes.data(), decoded.data()));
     for (auto value : decoded) {
-        REQUIRE(value == 3.0F);
+        REQUIRE(std::abs(value - 3.0F) <= 1e-6F);
     }
 }
 

--- a/src/quantization/scalar_quantization/sq8_uniform_quantizer_test.cpp
+++ b/src/quantization/scalar_quantization/sq8_uniform_quantizer_test.cpp
@@ -59,6 +59,9 @@ TEST_CASE("SQ8 Uniform encodes zero range to zero", "[ut][SQ8UniformQuantizer]")
 
     REQUIRE(quantizer.Train(train.data(), 3));
     REQUIRE(quantizer.EncodeOne(query.data(), codes.data()));
+    for (uint64_t i = 0; i < query.size(); ++i) {
+        REQUIRE(codes[i] == 0);
+    }
     REQUIRE(quantizer.DecodeOne(codes.data(), decoded.data()));
     for (auto value : decoded) {
         REQUIRE(value == 3.0F);


### PR DESCRIPTION
## What changed

Fixes #1966.

- Guard scalar quantizer encoding so `NaN` deltas are clamped before casting to `uint8_t`.
- Define zero-range SQ4/SQ8 uniform encoding as code `0`, avoiding division by zero before the cast.
- Add regression coverage for ordinary SQ NaN-delta encoding and SQ4/SQ8 uniform zero-range encoding.

## Why

UBSan reported `nan is outside the range of representable values of type 'unsigned char'` in scalar quantizer encoding. Existing `< 0` / `> 0.999` clamping does not catch `NaN`, and SQ4/SQ8 uniform quantizers could also divide by zero when trained on a zero-range dataset.

## Validation

- `/opt/homebrew/opt/llvm@15/bin/clang-format -i ... && git diff --check`
- `clang++ -fsyntax-only` for the six changed translation units using the existing compile commands

Full local `unittests` were not completed on this macOS checkout because upstream/main's current macOS build path is blocked by local toolchain/third-party configuration issues; PR CI should provide the full Linux sanitizer validation.
