### PR TITLE
Refactor: Extract factory methods from GraphInterface and FlattenInterface

### DIFF
--- a/src/algorithm/brute_force.cpp
+++ b/src/algorithm/brute_force.cpp
@@ -23,6 +23,7 @@
 #include "attr/executor/executor.h"
 #include "datacell/attribute_inverted_interface.h"
 #include "datacell/flatten_datacell.h"
+#include "datacell/flatten_factory.h"
 #include "datacell/flatten_interface.h"
 #include "fmt/chrono.h"
 #include "impl/heap/standard_heap.h"
@@ -37,7 +38,7 @@ namespace vsag {
 
 BruteForce::BruteForce(const BruteForceParameterPtr& param, const IndexCommonParam& common_param)
     : InnerIndexInterface(param, common_param) {
-    inner_codes_ = FlattenInterface::MakeInstance(param->base_codes_param, common_param);
+    inner_codes_ = FlattenInterfaceFactory::MakeInstance(param->base_codes_param, common_param);
     auto code_size = this->inner_codes_->code_size_;
     auto increase_count = Options::Instance().block_size_limit() / code_size;
     this->resize_increase_count_bit_ = std::max(

--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -26,7 +26,9 @@
 #include "analyzer/analyzer.h"
 #include "attr/argparse.h"
 #include "common.h"
+#include "datacell/flatten_factory.h"
 #include "datacell/flatten_interface.h"
+#include "datacell/graph_factory.h"
 #include "datacell/sparse_graph_datacell.h"
 #include "dataset_impl.h"
 #include "impl/filter/filter_headers.h"
@@ -71,15 +73,15 @@ HGraph::HGraph(const HGraphParameterPtr& hgraph_param, const vsag::IndexCommonPa
     this->support_duplicate_ = hgraph_param->support_duplicate;
     neighbors_mutex_ = std::make_shared<PointsMutex>(0, common_param.allocator_.get());
     this->basic_flatten_codes_ =
-        FlattenInterface::MakeInstance(hgraph_param->base_codes_param, common_param);
+        FlattenInterfaceFactory::MakeInstance(hgraph_param->base_codes_param, common_param);
     if (use_reorder_) {
         this->high_precise_codes_ =
-            FlattenInterface::MakeInstance(hgraph_param->precise_codes_param, common_param);
+            FlattenInterfaceFactory::MakeInstance(hgraph_param->precise_codes_param, common_param);
     }
     this->searcher_ = std::make_shared<BasicSearcher>(common_param, neighbors_mutex_);
 
     this->bottom_graph_ =
-        GraphInterface::MakeInstance(hgraph_param->bottom_graph_param, common_param);
+        GraphInterfaceFactory::MakeInstance(hgraph_param->bottom_graph_param, common_param);
     if (this->support_duplicate_) {
         this->label_table_->SetDuplicateTracker(this->bottom_graph_->GetDuplicateTracker());
     }
@@ -560,11 +562,11 @@ HGraph::Tune(const std::string& parameters, bool disable_future_tuning) {
     // init new_basic_code obj
     auto common_param = this->basic_flatten_codes_->ExportCommonParam();
     auto new_basic_code =
-        FlattenInterface::MakeInstance(hgraph_parameter->base_codes_param, common_param);
+        FlattenInterfaceFactory::MakeInstance(hgraph_parameter->base_codes_param, common_param);
     FlattenInterfacePtr new_precise_code;
     if (inner_parameter->use_reorder) {
-        new_precise_code =
-            FlattenInterface::MakeInstance(hgraph_parameter->precise_codes_param, common_param);
+        new_precise_code = FlattenInterfaceFactory::MakeInstance(
+            hgraph_parameter->precise_codes_param, common_param);
     }
 
     std::scoped_lock lock(this->add_mutex_);
@@ -2475,7 +2477,7 @@ HGraph::check_and_init_raw_vector(const FlattenInterfaceParamPtr& raw_vector_par
     }
 
     if (is_create_new) {
-        raw_vector_ = FlattenInterface::MakeInstance(raw_vector_param, common_param);
+        raw_vector_ = FlattenInterfaceFactory::MakeInstance(raw_vector_param, common_param);
     }
 
     if (basic_flatten_codes_->GetQuantizerName() != QUANTIZATION_TYPE_VALUE_FP32 and

--- a/src/algorithm/ivf.cpp
+++ b/src/algorithm/ivf.cpp
@@ -22,6 +22,7 @@
 #include "algorithm/inner_index_interface.h"
 #include "attr/argparse.h"
 #include "attr/executor/executor.h"
+#include "datacell/flatten_factory.h"
 #include "datacell/flatten_interface.h"
 #include "impl/heap/standard_heap.h"
 #include "impl/inner_search_param.h"
@@ -259,7 +260,7 @@ IVF::IVF(const IVFParameterPtr& param, const IndexCommonParam& common_param)
     }
     if (this->use_reorder_) {
         this->reorder_codes_ =
-            FlattenInterface::MakeInstance(param->precise_codes_param, common_param);
+            FlattenInterfaceFactory::MakeInstance(param->precise_codes_param, common_param);
         reorder_ = std::make_shared<FlattenReorder>(this->reorder_codes_, allocator_);
     }
     if (param->bucket_param->use_residual_) {

--- a/src/algorithm/pyramid.h
+++ b/src/algorithm/pyramid.h
@@ -18,6 +18,7 @@
 #include <memory>
 #include <utility>
 
+#include "datacell/flatten_factory.h"
 #include "datacell/graph_interface.h"
 #include "impl/allocator/safe_allocator.h"
 #include "impl/filter/filter_headers.h"
@@ -108,7 +109,8 @@ public:
           index_min_size_(pyramid_param->index_min_size),
           graph_type_(pyramid_param->graph_type),
           support_duplicate_(pyramid_param->support_duplicate) {
-        base_codes_ = FlattenInterface::MakeInstance(pyramid_param->base_codes_param, common_param);
+        base_codes_ =
+            FlattenInterfaceFactory::MakeInstance(pyramid_param->base_codes_param, common_param);
         root_ =
             std::make_unique<IndexNode>(allocator_, pyramid_param->graph_param, index_min_size_);
         points_mutex_ = std::make_shared<PointsMutex>(max_capacity_, allocator_);
@@ -116,8 +118,8 @@ public:
         no_build_levels_.assign(pyramid_param->no_build_levels.begin(),
                                 pyramid_param->no_build_levels.end());
         if (use_reorder_) {
-            precise_codes_ =
-                FlattenInterface::MakeInstance(pyramid_param->precise_codes_param, common_param);
+            precise_codes_ = FlattenInterfaceFactory::MakeInstance(
+                pyramid_param->precise_codes_param, common_param);
             reorder_ = std::make_shared<FlattenReorder>(precise_codes_, allocator_);
         }
     }

--- a/src/algorithm/warp.cpp
+++ b/src/algorithm/warp.cpp
@@ -25,6 +25,7 @@
 #include "datacell/attribute_inverted_interface.h"
 #include "datacell/flatten_datacell.h"
 #include "datacell/flatten_datacell_parameter.h"
+#include "datacell/flatten_factory.h"
 #include "datacell/flatten_interface.h"
 #include "fmt/chrono.h"
 #include "impl/heap/distance_heap.h"
@@ -40,7 +41,7 @@ namespace vsag {
 
 WARP::WARP(const WarpParameterPtr& param, const IndexCommonParam& common_param)
     : InnerIndexInterface(param, common_param), doc_offsets_(allocator_) {
-    inner_codes_ = FlattenInterface::MakeInstance(param->base_codes_param, common_param);
+    inner_codes_ = FlattenInterfaceFactory::MakeInstance(param->base_codes_param, common_param);
     auto code_size = this->inner_codes_->code_size_;
     auto increase_count = Options::Instance().block_size_limit() / code_size;
     this->resize_increase_count_bit_ = std::max(

--- a/src/datacell/compressed_graph_datacell_test.cpp
+++ b/src/datacell/compressed_graph_datacell_test.cpp
@@ -29,9 +29,9 @@ TestCompressedGraphDataCell(const GraphInterfaceParamPtr& param,
     auto count = GENERATE(1000, 2000);
     auto max_id = 10000;
 
-    auto graph = GraphInterface::MakeInstance(param, common_param);
+    auto graph = GraphInterfaceFactory::MakeInstance(param, common_param);
     GraphInterfaceTest test(graph, true);
-    auto other = GraphInterface::MakeInstance(param, common_param);
+    auto other = GraphInterfaceFactory::MakeInstance(param, common_param);
     test.BasicTest(max_id, count, other, false);
 }
 
@@ -71,12 +71,12 @@ TEST_CASE("CompressedGraphDataCell duplicate tracker follows parameter",
     common_param.allocator_ = allocator;
 
     auto disabled_param = std::make_shared<CompressedGraphDatacellParameter>();
-    auto disabled_graph = GraphInterface::MakeInstance(disabled_param, common_param);
+    auto disabled_graph = GraphInterfaceFactory::MakeInstance(disabled_param, common_param);
     REQUIRE(disabled_graph->GetDuplicateTracker() == nullptr);
 
     auto enabled_param = std::make_shared<CompressedGraphDatacellParameter>();
     enabled_param->support_duplicate_ = true;
-    auto enabled_graph = GraphInterface::MakeInstance(enabled_param, common_param);
+    auto enabled_graph = GraphInterfaceFactory::MakeInstance(enabled_param, common_param);
     REQUIRE(enabled_graph->GetDuplicateTracker() != nullptr);
 
     enabled_graph->SetDuplicateId(0, 1);

--- a/src/datacell/flatten_datacell_test.cpp
+++ b/src/datacell/flatten_datacell_test.cpp
@@ -30,11 +30,11 @@ TestFlattenDataCell(FlattenDataCellParamPtr& param,
                     IndexCommonParam& common_param,
                     float error = 1e-3) {
     auto count = GENERATE(100, 1000);
-    auto flatten = FlattenInterface::MakeInstance(param, common_param);
+    auto flatten = FlattenInterfaceFactory::MakeInstance(param, common_param);
 
     FlattenInterfaceTest test(flatten, common_param.metric_);
     test.BasicTest(common_param.dim_, count, error);
-    auto other = FlattenInterface::MakeInstance(param, common_param);
+    auto other = FlattenInterfaceFactory::MakeInstance(param, common_param);
     test.TestSerializeAndDeserialize(common_param.dim_, other, error);
 }
 

--- a/src/datacell/flatten_factory.cpp
+++ b/src/datacell/flatten_factory.cpp
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "flatten_interface.h"
+#include "flatten_factory.h"
 
 #include "flatten_datacell.h"
+#include "flatten_interface.h"
 #include "inner_string_params.h"
 #include "io/io_headers.h"
 #include "quantization/int8_quantizer.h"
@@ -184,6 +185,31 @@ make_instance(const FlattenInterfaceParamPtr& param, const IndexCommonParam& com
     }
     if (metric == MetricType::METRIC_TYPE_COSINE) {
         return make_instance<MetricType::METRIC_TYPE_COSINE, IOTemp>(param, common_param);
+    }
+    return nullptr;
+}
+
+FlattenInterfacePtr
+FlattenInterfaceFactory::MakeInstance(const FlattenInterfaceParamPtr& param,
+                                      const IndexCommonParam& common_param) {
+    auto io_type_name = param->io_parameter->GetTypeName();
+    if (io_type_name == IO_TYPE_VALUE_BLOCK_MEMORY_IO) {
+        return make_instance<MemoryBlockIO>(param, common_param);
+    }
+    if (io_type_name == IO_TYPE_VALUE_MEMORY_IO) {
+        return make_instance<MemoryIO>(param, common_param);
+    }
+    if (io_type_name == IO_TYPE_VALUE_BUFFER_IO) {
+        return make_instance<BufferIO>(param, common_param);
+    }
+    if (io_type_name == IO_TYPE_VALUE_ASYNC_IO) {
+        return make_instance<AsyncIO>(param, common_param);
+    }
+    if (io_type_name == IO_TYPE_VALUE_MMAP_IO) {
+        return make_instance<MMapIO>(param, common_param);
+    }
+    if (io_type_name == IO_TYPE_VALUE_READER_IO) {
+        return make_instance<ReaderIO>(param, common_param);
     }
     return nullptr;
 }

--- a/src/datacell/flatten_factory.h
+++ b/src/datacell/flatten_factory.h
@@ -1,0 +1,32 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "flatten_interface_parameter.h"
+#include "index_common_param.h"
+#include "typing.h"
+#include "utils/pointer_define.h"
+
+namespace vsag {
+class FlattenInterface;
+DEFINE_POINTER(FlattenInterface);
+
+class FlattenInterfaceFactory {
+public:
+    static FlattenInterfacePtr
+    MakeInstance(const FlattenInterfaceParamPtr& param, const IndexCommonParam& common_param);
+};
+
+}  // namespace vsag

--- a/src/datacell/flatten_interface.h
+++ b/src/datacell/flatten_interface.h
@@ -39,9 +39,6 @@ class FlattenInterface {
 public:
     FlattenInterface() = default;
 
-    static FlattenInterfacePtr
-    MakeInstance(const FlattenInterfaceParamPtr& param, const IndexCommonParam& common_param);
-
 public:
     virtual void
     Query(float* result_dists,

--- a/src/datacell/graph_datacell_test.cpp
+++ b/src/datacell/graph_datacell_test.cpp
@@ -31,9 +31,9 @@ TestGraphDataCell(const GraphInterfaceParamPtr& param,
     auto count = GENERATE(1000, 2000);
     auto max_id = 10000;
 
-    auto graph = GraphInterface::MakeInstance(param, common_param);
+    auto graph = GraphInterfaceFactory::MakeInstance(param, common_param);
     GraphInterfaceTest test(graph);
-    auto other = GraphInterface::MakeInstance(param, common_param);
+    auto other = GraphInterfaceFactory::MakeInstance(param, common_param);
     test.BasicTest(max_id, count, other, test_delete);
 }
 
@@ -124,9 +124,9 @@ TEST_CASE("GraphDataCell Merge", "[ut][GraphDataCell]") {
     auto graph_param = GraphInterfaceParameter::GetGraphParameterByJson(
         GraphStorageTypes::GRAPH_STORAGE_TYPE_VALUE_FLAT, param_json);
 
-    auto graph = GraphInterface::MakeInstance(graph_param, common_param);
+    auto graph = GraphInterfaceFactory::MakeInstance(graph_param, common_param);
     GraphInterfaceTest test(graph);
-    auto other = GraphInterface::MakeInstance(graph_param, common_param);
+    auto other = GraphInterfaceFactory::MakeInstance(graph_param, common_param);
     test.MergeTest(other, 1000);
 }
 
@@ -139,14 +139,14 @@ TEST_CASE("GraphDataCell duplicate tracker follows parameter", "[ut][GraphDataCe
     auto disabled_param = std::make_shared<GraphDataCellParameter>();
     disabled_param->io_parameter_ = std::make_shared<MemoryIOParameter>();
     disabled_param->support_duplicate_ = false;
-    auto disabled_graph = GraphInterface::MakeInstance(disabled_param, common_param);
+    auto disabled_graph = GraphInterfaceFactory::MakeInstance(disabled_param, common_param);
     REQUIRE(disabled_graph->GetDuplicateTracker() == nullptr);
     REQUIRE(disabled_graph->GetDuplicateIds(0).empty());
 
     auto enabled_param = std::make_shared<GraphDataCellParameter>();
     enabled_param->io_parameter_ = std::make_shared<MemoryIOParameter>();
     enabled_param->support_duplicate_ = true;
-    auto enabled_graph = GraphInterface::MakeInstance(enabled_param, common_param);
+    auto enabled_graph = GraphInterfaceFactory::MakeInstance(enabled_param, common_param);
     REQUIRE(enabled_graph->GetDuplicateTracker() != nullptr);
 
     enabled_graph->Resize(4);
@@ -182,7 +182,7 @@ TEST_CASE("GraphDataCell Reverse Edges", "[ut][GraphDataCell]") {
     auto graph_param = GraphInterfaceParameter::GetGraphParameterByJson(
         GraphStorageTypes::GRAPH_STORAGE_TYPE_VALUE_FLAT, param_json);
 
-    auto graph = GraphInterface::MakeInstance(graph_param, common_param);
+    auto graph = GraphInterfaceFactory::MakeInstance(graph_param, common_param);
     GraphInterfaceTest test(graph);
     test.ReverseEdgeTest(100);
 }
@@ -213,7 +213,7 @@ TEST_CASE("GraphDataCell Move", "[ut][GraphDataCell]") {
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = 1024 * 1024 * 2ULL;
     vsag::Options::Instance().set_block_size_limit(size);
-    auto graph = GraphInterface::MakeInstance(graph_param, common_param);
+    auto graph = GraphInterfaceFactory::MakeInstance(graph_param, common_param);
     GraphInterfaceTest test(graph);
     test.MoveTest(100);
     vsag::Options::Instance().set_block_size_limit(origin_size);
@@ -242,7 +242,7 @@ TEST_CASE("GraphDataCell Move same id keeps neighbors", "[ut][GraphDataCell]") {
     auto graph_param = GraphInterfaceParameter::GetGraphParameterByJson(
         GraphStorageTypes::GRAPH_STORAGE_TYPE_VALUE_FLAT, param_json);
 
-    auto graph = GraphInterface::MakeInstance(graph_param, common_param);
+    auto graph = GraphInterfaceFactory::MakeInstance(graph_param, common_param);
     graph->Resize(4);
 
     Vector<InnerIdType> empty(allocator.get());

--- a/src/datacell/graph_factory.cpp
+++ b/src/datacell/graph_factory.cpp
@@ -1,0 +1,58 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "graph_factory.h"
+
+#include "compressed_graph_datacell.h"
+#include "graph_datacell.h"
+#include "graph_interface.h"
+#include "io/io_headers.h"
+#include "sparse_graph_datacell.h"
+
+namespace vsag {
+
+GraphInterfacePtr
+GraphInterfaceFactory::MakeInstance(const GraphInterfaceParamPtr& graph_param,
+                                    const IndexCommonParam& common_param) {
+    switch (graph_param->graph_storage_type_) {
+        case GraphStorageTypes::GRAPH_STORAGE_TYPE_SPARSE:
+            return std::make_shared<SparseGraphDataCell>(graph_param, common_param);
+        case GraphStorageTypes::GRAPH_STORAGE_TYPE_VALUE_COMPRESSED:
+            return std::make_shared<CompressedGraphDataCell>(graph_param, common_param);
+        case GraphStorageTypes::GRAPH_STORAGE_TYPE_VALUE_FLAT:
+            auto io_string = std::dynamic_pointer_cast<GraphDataCellParameter>(graph_param)
+                                 ->io_parameter_->GetTypeName();
+            if (io_string == IO_TYPE_VALUE_BLOCK_MEMORY_IO) {
+                return std::make_shared<GraphDataCell<MemoryBlockIO>>(graph_param, common_param);
+            }
+            if (io_string == IO_TYPE_VALUE_MEMORY_IO) {
+                return std::make_shared<GraphDataCell<MemoryIO>>(graph_param, common_param);
+            }
+            if (io_string == IO_TYPE_VALUE_MMAP_IO) {
+                return std::make_shared<GraphDataCell<MMapIO>>(graph_param, common_param);
+            }
+            if (io_string == IO_TYPE_VALUE_BUFFER_IO) {
+                return std::make_shared<GraphDataCell<BufferIO>>(graph_param, common_param);
+            }
+            if (io_string == IO_TYPE_VALUE_ASYNC_IO) {
+                return std::make_shared<GraphDataCell<AsyncIO>>(graph_param, common_param);
+            }
+            if (io_string == IO_TYPE_VALUE_READER_IO) {
+                return std::make_shared<GraphDataCell<ReaderIO>>(graph_param, common_param);
+            }
+    }
+    return nullptr;
+}
+
+}  // namespace vsag

--- a/src/datacell/graph_factory.h
+++ b/src/datacell/graph_factory.h
@@ -1,0 +1,33 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "graph_interface_parameter.h"
+#include "index_common_param.h"
+#include "typing.h"
+#include "utils/pointer_define.h"
+
+namespace vsag {
+
+class GraphInterface;
+DEFINE_POINTER(GraphInterface);
+
+class GraphInterfaceFactory {
+public:
+    static GraphInterfacePtr
+    MakeInstance(const GraphInterfaceParamPtr& graph_param, const IndexCommonParam& common_param);
+};
+
+}  // namespace vsag

--- a/src/datacell/graph_interface.cpp
+++ b/src/datacell/graph_interface.cpp
@@ -48,37 +48,4 @@ GraphInterface::UpdateReverseEdges(InnerIdType id,
     }
 }
 
-GraphInterfacePtr
-GraphInterface::MakeInstance(const GraphInterfaceParamPtr& graph_param,
-                             const IndexCommonParam& common_param) {
-    switch (graph_param->graph_storage_type_) {
-        case GraphStorageTypes::GRAPH_STORAGE_TYPE_SPARSE:
-            return std::make_shared<SparseGraphDataCell>(graph_param, common_param);
-        case GraphStorageTypes::GRAPH_STORAGE_TYPE_VALUE_COMPRESSED:
-            return std::make_shared<CompressedGraphDataCell>(graph_param, common_param);
-        case GraphStorageTypes::GRAPH_STORAGE_TYPE_VALUE_FLAT:
-            auto io_string = std::dynamic_pointer_cast<GraphDataCellParameter>(graph_param)
-                                 ->io_parameter_->GetTypeName();
-            if (io_string == IO_TYPE_VALUE_BLOCK_MEMORY_IO) {
-                return std::make_shared<GraphDataCell<MemoryBlockIO>>(graph_param, common_param);
-            }
-            if (io_string == IO_TYPE_VALUE_MEMORY_IO) {
-                return std::make_shared<GraphDataCell<MemoryIO>>(graph_param, common_param);
-            }
-            if (io_string == IO_TYPE_VALUE_MMAP_IO) {
-                return std::make_shared<GraphDataCell<MMapIO>>(graph_param, common_param);
-            }
-            if (io_string == IO_TYPE_VALUE_BUFFER_IO) {
-                return std::make_shared<GraphDataCell<BufferIO>>(graph_param, common_param);
-            }
-            if (io_string == IO_TYPE_VALUE_ASYNC_IO) {
-                return std::make_shared<GraphDataCell<AsyncIO>>(graph_param, common_param);
-            }
-            if (io_string == IO_TYPE_VALUE_READER_IO) {
-                return std::make_shared<GraphDataCell<ReaderIO>>(graph_param, common_param);
-            }
-            return nullptr;
-    }
-    return nullptr;
-}
 }  // namespace vsag

--- a/src/datacell/graph_interface.h
+++ b/src/datacell/graph_interface.h
@@ -42,9 +42,6 @@ public:
 
     virtual ~GraphInterface() = default;
 
-    static GraphInterfacePtr
-    MakeInstance(const GraphInterfaceParamPtr& graph_param, const IndexCommonParam& common_param);
-
 public:
     virtual void
     InsertNeighborsById(InnerIdType id, const Vector<InnerIdType>& neighbor_ids) = 0;

--- a/src/datacell/sparse_graph_datacell_test.cpp
+++ b/src/datacell/sparse_graph_datacell_test.cpp
@@ -30,9 +30,9 @@ TestSparseGraphDataCell(const GraphInterfaceParamPtr& param,
     auto count = GENERATE(1000, 2000);
     auto max_id = 10000;
 
-    auto graph = GraphInterface::MakeInstance(param, common_param);
+    auto graph = GraphInterfaceFactory::MakeInstance(param, common_param);
     GraphInterfaceTest test(graph);
-    auto other = GraphInterface::MakeInstance(param, common_param);
+    auto other = GraphInterfaceFactory::MakeInstance(param, common_param);
     test.BasicTest(max_id, count, other, test_delete);
 }
 
@@ -82,9 +82,9 @@ TEST_CASE("SparseGraphDataCell Merge Test", "[ut][SparseGraphDataCell]") {
     graph_param->max_degree_ = max_degree;
     graph_param->support_delete_ = is_support_delete;
 
-    auto graph = GraphInterface::MakeInstance(graph_param, common_param);
+    auto graph = GraphInterfaceFactory::MakeInstance(graph_param, common_param);
     GraphInterfaceTest test(graph);
-    auto other = GraphInterface::MakeInstance(graph_param, common_param);
+    auto other = GraphInterfaceFactory::MakeInstance(graph_param, common_param);
     test.MergeTest(other, count);
 }
 
@@ -100,7 +100,7 @@ TEST_CASE("SparseGraphDataCell Reverse Edges", "[ut][SparseGraphDataCell]") {
     graph_param->max_degree_ = max_degree;
     graph_param->use_reverse_edges_ = true;
 
-    auto graph = GraphInterface::MakeInstance(graph_param, common_param);
+    auto graph = GraphInterfaceFactory::MakeInstance(graph_param, common_param);
     GraphInterfaceTest test(graph);
     test.ReverseEdgeTest(100);
 }
@@ -117,7 +117,7 @@ TEST_CASE("SparseGraphDataCell Move", "[ut][SparseGraphDataCell]") {
     graph_param->max_degree_ = max_degree;
     graph_param->use_reverse_edges_ = true;
 
-    auto graph = GraphInterface::MakeInstance(graph_param, common_param);
+    auto graph = GraphInterfaceFactory::MakeInstance(graph_param, common_param);
     GraphInterfaceTest test(graph);
     test.MoveTest(100);
 }
@@ -132,7 +132,7 @@ TEST_CASE("SparseGraphDataCell Move same id keeps neighbors", "[ut][SparseGraphD
     graph_param->max_degree_ = 8;
     graph_param->use_reverse_edges_ = true;
 
-    auto graph = GraphInterface::MakeInstance(graph_param, common_param);
+    auto graph = GraphInterfaceFactory::MakeInstance(graph_param, common_param);
 
     Vector<InnerIdType> empty(allocator.get());
     Vector<InnerIdType> neighbors(allocator.get());
@@ -170,7 +170,7 @@ TEST_CASE("SparseGraphDataCell decodes stored neighbors for reverse-edge updates
     graph_param->remove_flag_bit_ = 4;
     graph_param->use_reverse_edges_ = true;
 
-    auto graph = GraphInterface::MakeInstance(graph_param, common_param);
+    auto graph = GraphInterfaceFactory::MakeInstance(graph_param, common_param);
 
     Vector<InnerIdType> empty(allocator.get());
     Vector<InnerIdType> to_two(allocator.get());

--- a/src/datacell/sparse_vector_datacell_test.cpp
+++ b/src/datacell/sparse_vector_datacell_test.cpp
@@ -45,7 +45,7 @@ TEST_CASE("SparseDataCell Basic Test", "[ut][SparseDataCell] ") {
     index_common_param.allocator_ = SafeAllocator::FactoryDefaultAllocator();
     index_common_param.metric_ = MetricType::METRIC_TYPE_IP;
     index_common_param.dim_ = max_dim;
-    auto data_cell = FlattenInterface::MakeInstance(param, index_common_param);
+    auto data_cell = FlattenInterfaceFactory::MakeInstance(param, index_common_param);
     REQUIRE(data_cell->GetQuantizerName() == QUANTIZATION_TYPE_VALUE_SPARSE);
     REQUIRE(data_cell->GetMetricType() == MetricType::METRIC_TYPE_IP);
 
@@ -82,7 +82,7 @@ TEST_CASE("SparseDataCell Basic Test", "[ut][SparseDataCell] ") {
         }
     }
     SECTION("serialize and deserialize") {
-        auto new_data_cell = FlattenInterface::MakeInstance(param, index_common_param);
+        auto new_data_cell = FlattenInterfaceFactory::MakeInstance(param, index_common_param);
         test_serializion(*data_cell, *new_data_cell);
         auto computer = new_data_cell->FactoryComputer(query_sparse_vectors.data());
         std::vector<float> dist(base_count);
@@ -126,7 +126,7 @@ TEST_CASE("SparseDataCell Concurrent Test", "[ut][SparseDataCell][concurrent] ")
     index_common_param.allocator_ = SafeAllocator::FactoryDefaultAllocator();
     index_common_param.metric_ = MetricType::METRIC_TYPE_IP;
     index_common_param.dim_ = max_dim;
-    auto data_cell = FlattenInterface::MakeInstance(param, index_common_param);
+    auto data_cell = FlattenInterfaceFactory::MakeInstance(param, index_common_param);
     REQUIRE(data_cell->GetQuantizerName() == QUANTIZATION_TYPE_VALUE_SPARSE);
     REQUIRE(data_cell->GetMetricType() == MetricType::METRIC_TYPE_IP);
 

--- a/src/impl/pruning_strategy_test.cpp
+++ b/src/impl/pruning_strategy_test.cpp
@@ -51,7 +51,7 @@ TEST_CASE("Pruning Strategy Select Edges With Heuristic", "[ut][pruning_strategy
     common_param.dim_ = 128;
 
     // Create flatten interface instance with configured parameters
-    auto flatten = FlattenInterface::MakeInstance(flatten_param, common_param);
+    auto flatten = FlattenInterfaceFactory::MakeInstance(flatten_param, common_param);
     REQUIRE(flatten != nullptr);
 
     float vectors[5][128] = {0};
@@ -175,7 +175,7 @@ TEST_CASE("Pruning Strategy Select Edges With Heuristic", "[ut][pruning_strategy
         auto graph_param = std::make_shared<GraphDataCellParameter>();
         graph_param->io_parameter_ = std::make_shared<MemoryIOParameter>();
         graph_param->max_degree_ = 4;
-        auto graph = GraphInterface::MakeInstance(graph_param, common_param);
+        auto graph = GraphInterfaceFactory::MakeInstance(graph_param, common_param);
 
         auto candidates = std::make_shared<StandardHeap<true, false>>(allocator.get(), -1);
         candidates->Push(d01, 1);

--- a/src/index/diskann.cpp
+++ b/src/index/diskann.cpp
@@ -29,6 +29,7 @@
 #include <vector>
 
 #include "datacell/flatten_datacell.h"
+#include "datacell/flatten_factory.h"
 #include "dataset_impl.h"
 #include "impl/odescent/odescent_graph_builder.h"
 #include "io/memory_io_parameter.h"
@@ -323,7 +324,7 @@ DiskANN::build(const DatasetPtr& base) {
             flatten_param->quantizer_parameter = std::make_shared<FP32QuantizerParameter>();
             flatten_param->io_parameter = std::make_shared<MemoryIOParameter>();
             vsag::FlattenInterfacePtr flatten_interface_ptr =
-                vsag::FlattenInterface::MakeInstance(flatten_param, this->common_param_);
+                vsag::FlattenInterfaceFactory::MakeInstance(flatten_param, this->common_param_);
             flatten_interface_ptr->Train(vectors, data_num);
             flatten_interface_ptr->BatchInsertVector(vectors, data_num);
             auto param = std::make_shared<ODescentParameter>();

--- a/src/index/hnsw.cpp
+++ b/src/index/hnsw.cpp
@@ -27,7 +27,9 @@
 #include "algorithm/hnswlib/hnswlib.h"
 #include "common.h"
 #include "datacell/flatten_datacell.h"
+#include "datacell/flatten_factory.h"
 #include "datacell/graph_datacell_parameter.h"
+#include "datacell/graph_factory.h"
 #include "impl/allocator/safe_allocator.h"
 #include "impl/odescent/odescent_graph_builder.h"
 #include "index/hnsw_zparameters.h"
@@ -1173,9 +1175,9 @@ HNSW::merge(const std::vector<MergeUnit>& merge_units) {
     graph_param_ptr->max_degree_ = max_degree_ * 2;
 
     FlattenInterfacePtr flatten_interface =
-        FlattenInterface::MakeInstance(param, index_common_param_);
+        FlattenInterfaceFactory::MakeInstance(param, index_common_param_);
     GraphInterfacePtr graph_interface =
-        GraphInterface::MakeInstance(graph_param_ptr, index_common_param_);
+        GraphInterfaceFactory::MakeInstance(graph_param_ptr, index_common_param_);
     Vector<LabelType> ids(allocator_.get());
     // extract data and graph
     IdMapFunction id_map = [](int64_t id) -> std::tuple<bool, int64_t> {

--- a/src/index/hnsw_test.cpp
+++ b/src/index/hnsw_test.cpp
@@ -996,8 +996,10 @@ TEST_CASE("extract/set data and graph", "[ut][hnsw]") {
     vsag::GraphDataCellParamPtr graph_param_ptr = std::make_shared<vsag::GraphDataCellParameter>();
     graph_param_ptr->io_parameter_ = std::make_shared<vsag::MemoryIOParameter>();
 
-    FlattenInterfacePtr flatten_interface = FlattenInterface::MakeInstance(param, common_param);
-    GraphInterfacePtr graph_interface = GraphInterface::MakeInstance(graph_param_ptr, common_param);
+    FlattenInterfacePtr flatten_interface =
+        FlattenInterfaceFactory::MakeInstance(param, common_param);
+    GraphInterfacePtr graph_interface =
+        GraphInterfaceFactory::MakeInstance(graph_param_ptr, common_param);
     Vector<LabelType> ids_vector(allocator.get());
 
     IdMapFunction id_map = [](int64_t id) -> std::tuple<bool, int64_t> {


### PR DESCRIPTION
## Summary

This PR extracts factory methods from core interface classes to improve code organization and reduce coupling.

**Changes:**
- Create GraphInterfaceFactory and FlattenInterfaceFactory classes
- Move MakeInstance static methods from interface classes to factory classes
- Update all call sites to use factory classes instead of interface classes

**Benefits:**
1. Decouples factory responsibilities from core interface headers
2. Reduces compilation dependencies when interface changes occur
3. Follows single responsibility principle - interfaces define behavior, factories create instances

**Testing:**
- Compilation: Successfully compiled with make release
- Code formatting: Applied make fmt