### PR TITLE
ci: correctly skip tsan for markdown-only pull requests

### DIFF
--- a/.github/workflows/tsan_build_and_test.yml
+++ b/.github/workflows/tsan_build_and_test.yml
@@ -20,10 +20,14 @@ jobs:
       - uses: dorny/paths-filter@v3
         id: changes
         with:
+          # 'every' is REQUIRED here: with the default 'some' quantifier, the broad '**'
+          # pattern would always match and the negation patterns ('!docs/**', '!**/*.md')
+          # would have no effect, causing docs-only PRs to incorrectly trigger TSan.
+          predicate-quantifier: 'every'
           filters: |
             non_markdown:
               - '**'
-              - '!*.md'
+              - '!docs/**'
               - '!**/*.md'
 
   build_tsan:


### PR DESCRIPTION
## Change Type
- Improvement (CI)

## Linked Issue / Context
- Follow-up to #1972, which intended to skip the TSan workflow for Markdown-only PRs.
- Observed regression: docs-only PR #1998 still triggered TSan (run [25533936656](https://github.com/antgroup/vsag/actions/runs/25533936656/job/74946238652?pr=1998)).

## Root Cause
`dorny/paths-filter@v3` defaults to the `some` predicate quantifier: a file is counted as matching the filter if **any** pattern matches. With

```yaml
non_markdown:
  - '**'
  - '!*.md'
  - '!**/*.md'
```

the broad `**` always matches, so the negation patterns never get a chance to exclude `*.md` files. Every PR — including docs-only ones — ended up with `non_markdown=true`, which kept the `build_tsan` / `test_tsan` jobs gated by that output running.

## What Changed
- `.github/workflows/tsan_build_and_test.yml`:
  - Set `predicate-quantifier: 'every'` so a file must satisfy **all** patterns to be counted.
  - Replace `'!*.md'` with `'!docs/**'` to align PR filtering with the existing `push` trigger's `paths-ignore: ['docs/**']`, while keeping `'!**/*.md'` to cover Markdown files outside `docs/` (e.g. `README.md`, `CONTRIBUTING.md`).

Net effect: pull requests that only modify `docs/**` and/or any `*.md` file no longer trigger the TSan build/test jobs, matching the original intent of #1972.

## Test Evidence
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/tsan_build_and_test.yml"); puts "YAML OK"'` → `YAML OK`.
- Behavior will be verified on this PR itself: since this PR only touches a workflow file (not Markdown), TSan should still run here, while subsequent docs-only PRs should skip it.