### PR TITLE
[skip ci] docs: align AI sign-off rules with Linux kernel policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,11 +120,16 @@ Update relevant docs when behavior changes:
 - Commit messages should follow Conventional Commits, such as `feat:`, `fix:`, `docs:`, or
   `chore:`.
 - Commits in this project are expected to use DCO sign-off (`git commit -s`).
-- For co-developed changes, include a `Signed-off-by:` trailer for each contributor.
-- If dual sign-off is requested, include both the requester's identity and the current agent
-  identity in the `Signed-off-by:` trailers.
-- Determine the agent sign-off at execution time from the active agent name and model name, and use
-  the format `AgentName (ModelName)`.
+- Only humans can legally certify the DCO; AI coding agents **must not** add their own
+  `Signed-off-by` trailer. The human submitter is responsible for reviewing AI-generated
+  changes, ensuring license compliance, and taking full responsibility for the contribution.
+- For changes produced with AI assistance, attribute the agent with an `Assisted-by:` trailer
+  in the form `Assisted-by: AgentName:ModelVersion` (see the
+  [Linux kernel AI Coding Assistants policy](https://docs.kernel.org/process/coding-assistants.html)).
+  Determine `AgentName` and `ModelVersion` at execution time from the active agent name and
+  model name (e.g. `Assisted-by: OpenCode:claude-opus-4.7`).
+- Trailer order: place the human `Signed-off-by:` first, followed by the `Assisted-by:` line
+  for the AI agent.
 - When using skip-CI commit messages, follow the repository convention and place `[skip ci]` at the
   beginning of the subject line.
 

--- a/docs/docs/en/src/development/contributing.md
+++ b/docs/docs/en/src/development/contributing.md
@@ -75,13 +75,22 @@ Git provides a `-s` flag that appends the trailer automatically:
 git commit -s -m "This is my commit message"
 ```
 
-For contributions co-authored by a human developer and an AI coding agent (OpenCode, Claude Code,
-Codex, etc.), include a `Signed-off-by` trailer for **each** collaborator, for example:
+For contributions made with the help of an AI coding agent (OpenCode, Claude Code, Codex,
+etc.), only human contributors sign off on the DCO; the AI agent **must not** add its
+own `Signed-off-by` trailer, because only a human can legally certify the DCO. Each human
+contributor still adds their own `Signed-off-by:` trailer as usual. Instead of signing off,
+attribute the AI agent with an `Assisted-by:` trailer that follows the
+[Linux kernel AI Coding Assistants policy](https://docs.kernel.org/process/coding-assistants.html),
+in the form `Assisted-by: AgentName:ModelVersion`. Place the human `Signed-off-by:` line(s) first,
+followed by the `Assisted-by:` line, for example:
 
 ```text
 Signed-off-by: Random J Developer <random@developer.example.org>
-Signed-off-by: OpenCode (claude-sonnet-4.5) <noreply@opencode.ai>
+Assisted-by: OpenCode:claude-opus-4.7
 ```
+
+The human submitter is responsible for reviewing AI-generated changes, ensuring license
+compliance, and taking full responsibility for the contribution.
 
 ## Commit Messages and PR Labels
 

--- a/docs/docs/zh/src/development/contributing.md
+++ b/docs/docs/zh/src/development/contributing.md
@@ -67,12 +67,19 @@ Git 还有一个 `-s` 命令行选项，可以在提交时自动附加 Signed-of
 git commit -s -m "This is my commit message"
 ```
 
-对于由人类开发者和 AI Coding Agent（如 OpenCode、Claude Code、Codex 等）共同完成的贡献，请为**每一位协作者**各添加一行 `Signed-off-by` trailer，例如：
+对于借助 AI Coding Agent（如 OpenCode、Claude Code、Codex 等）完成的贡献，**仅由人类贡献者**
+签署 DCO；AI Agent **不得**添加自己的 `Signed-off-by` trailer，因为只有人类才能合法地证明
+DCO。每一位人类贡献者仍按常规各自添加自己的 `Signed-off-by:` trailer。除签名外，请按
+[Linux 内核 AI Coding Assistants 规范](https://docs.kernel.org/process/coding-assistants.html)
+使用 `Assisted-by:` trailer 标注 AI 协助，格式为 `Assisted-by: AgentName:ModelVersion`。
+在 trailer 顺序上，请将人类的 `Signed-off-by:` 放在前面，`Assisted-by:` 放在其后，例如：
 
 ```text
 Signed-off-by: Random J Developer <random@developer.example.org>
-Signed-off-by: OpenCode (claude-sonnet-4.5) <noreply@opencode.ai>
+Assisted-by: OpenCode:claude-opus-4.7
 ```
+
+人类提交者需对 AI 生成的修改进行审阅、确保许可证合规，并对该贡献承担全部责任。
 
 ### Commit 信息与 PR 标签
 


### PR DESCRIPTION
## Change Type
- Documentation

## Linked Issue / Context
- Aligns the project's AI contribution rules with the [Linux kernel AI Coding Assistants policy](https://docs.kernel.org/process/coding-assistants.html).
- Companion to #2000 (which already adopts the new trailer style in its commit message).

## What Changed
- `AGENTS.md`: rewrite the agent sign-off section.
  - State explicitly that AI agents **must not** add their own `Signed-off-by` (only humans can certify the DCO).
  - Replace the previous dual-`Signed-off-by` rule with an `Assisted-by: AgentName:ModelVersion` trailer for AI attribution.
  - Define trailer ordering: human `Signed-off-by:` first, `Assisted-by:` second.
- `docs/docs/en/src/development/contributing.md` and `docs/docs/zh/src/development/contributing.md`: update the English and Chinese contributing guides to match, with an updated example block.

## Test Evidence
- Documentation-only change. No source code or build behavior modified.
- The PR title uses `[skip ci]` per repository convention so CI workflows are skipped.