### PR TITLE
refactor: split datacell factory interfaces

### DIFF
--- a/src/algorithm/brute_force.cpp
+++ b/src/algorithm/brute_force.cpp
@@ -22,7 +22,7 @@
 #include "attr/argparse.h"
 #include "attr/executor/executor.h"
 #include "datacell/attribute_inverted_interface.h"
-#include "datacell/flatten_datacell.h"
+#include "datacell/flatten_factory.h"
 #include "datacell/flatten_interface.h"
 #include "fmt/chrono.h"
 #include "impl/heap/standard_heap.h"
@@ -37,7 +37,7 @@ namespace vsag {
 
 BruteForce::BruteForce(const BruteForceParameterPtr& param, const IndexCommonParam& common_param)
     : InnerIndexInterface(param, common_param) {
-    inner_codes_ = FlattenInterface::MakeInstance(param->base_codes_param, common_param);
+    inner_codes_ = MakeFlattenInstance(param->base_codes_param, common_param);
     auto code_size = this->inner_codes_->code_size_;
     auto increase_count = Options::Instance().block_size_limit() / code_size;
     this->resize_increase_count_bit_ = std::max(

--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -26,7 +26,9 @@
 #include "analyzer/analyzer.h"
 #include "attr/argparse.h"
 #include "common.h"
+#include "datacell/flatten_factory.h"
 #include "datacell/flatten_interface.h"
+#include "datacell/graph_factory.h"
 #include "datacell/sparse_graph_datacell.h"
 #include "dataset_impl.h"
 #include "impl/filter/filter_headers.h"
@@ -70,16 +72,14 @@ HGraph::HGraph(const HGraphParameterPtr& hgraph_param, const vsag::IndexCommonPa
     this->label_table_->support_tombstone_ = hgraph_param->support_tombstone;
     this->support_duplicate_ = hgraph_param->support_duplicate;
     neighbors_mutex_ = std::make_shared<PointsMutex>(0, common_param.allocator_.get());
-    this->basic_flatten_codes_ =
-        FlattenInterface::MakeInstance(hgraph_param->base_codes_param, common_param);
+    this->basic_flatten_codes_ = MakeFlattenInstance(hgraph_param->base_codes_param, common_param);
     if (use_reorder_) {
         this->high_precise_codes_ =
-            FlattenInterface::MakeInstance(hgraph_param->precise_codes_param, common_param);
+            MakeFlattenInstance(hgraph_param->precise_codes_param, common_param);
     }
     this->searcher_ = std::make_shared<BasicSearcher>(common_param, neighbors_mutex_);
 
-    this->bottom_graph_ =
-        GraphInterface::MakeInstance(hgraph_param->bottom_graph_param, common_param);
+    this->bottom_graph_ = MakeGraphInstance(hgraph_param->bottom_graph_param, common_param);
     if (this->support_duplicate_) {
         this->label_table_->SetDuplicateTracker(this->bottom_graph_->GetDuplicateTracker());
     }
@@ -559,12 +559,10 @@ HGraph::Tune(const std::string& parameters, bool disable_future_tuning) {
 
     // init new_basic_code obj
     auto common_param = this->basic_flatten_codes_->ExportCommonParam();
-    auto new_basic_code =
-        FlattenInterface::MakeInstance(hgraph_parameter->base_codes_param, common_param);
+    auto new_basic_code = MakeFlattenInstance(hgraph_parameter->base_codes_param, common_param);
     FlattenInterfacePtr new_precise_code;
     if (inner_parameter->use_reorder) {
-        new_precise_code =
-            FlattenInterface::MakeInstance(hgraph_parameter->precise_codes_param, common_param);
+        new_precise_code = MakeFlattenInstance(hgraph_parameter->precise_codes_param, common_param);
     }
 
     std::scoped_lock lock(this->add_mutex_);
@@ -2475,7 +2473,7 @@ HGraph::check_and_init_raw_vector(const FlattenInterfaceParamPtr& raw_vector_par
     }
 
     if (is_create_new) {
-        raw_vector_ = FlattenInterface::MakeInstance(raw_vector_param, common_param);
+        raw_vector_ = MakeFlattenInstance(raw_vector_param, common_param);
     }
 
     if (basic_flatten_codes_->GetQuantizerName() != QUANTIZATION_TYPE_VALUE_FP32 and

--- a/src/algorithm/inner_index_interface.h
+++ b/src/algorithm/inner_index_interface.h
@@ -23,7 +23,6 @@
 #include "datacell/attribute_inverted_interface.h"
 #include "datacell/extra_info_interface.h"
 #include "datacell/flatten_interface.h"
-#include "dataset_impl.h"
 #include "inner_index_parameter.h"
 #include "metric_type.h"
 #include "parameter.h"

--- a/src/algorithm/ivf.cpp
+++ b/src/algorithm/ivf.cpp
@@ -22,6 +22,7 @@
 #include "algorithm/inner_index_interface.h"
 #include "attr/argparse.h"
 #include "attr/executor/executor.h"
+#include "datacell/flatten_factory.h"
 #include "datacell/flatten_interface.h"
 #include "impl/heap/standard_heap.h"
 #include "impl/inner_search_param.h"
@@ -258,8 +259,7 @@ IVF::IVF(const IVFParameterPtr& param, const IndexCommonParam& common_param)
             common_param, param->ivf_partition_strategy_parameter);
     }
     if (this->use_reorder_) {
-        this->reorder_codes_ =
-            FlattenInterface::MakeInstance(param->precise_codes_param, common_param);
+        this->reorder_codes_ = MakeFlattenInstance(param->precise_codes_param, common_param);
         reorder_ = std::make_shared<FlattenReorder>(this->reorder_codes_, allocator_);
     }
     if (param->bucket_param->use_residual_) {

--- a/src/algorithm/ivf_partition/gno_imi_partition.cpp
+++ b/src/algorithm/ivf_partition/gno_imi_partition.cpp
@@ -22,9 +22,8 @@
 #include <numeric>
 #include <vector>
 
-#include "datacell/flatten_datacell_parameter.h"
-
 #include "algorithm/inner_index_interface.h"
+#include "datacell/flatten_datacell_parameter.h"
 #include "impl/allocator/safe_allocator.h"
 #include "impl/blas/blas_function.h"
 #include "impl/cluster/kmeans_cluster.h"

--- a/src/algorithm/ivf_partition/gno_imi_partition.cpp
+++ b/src/algorithm/ivf_partition/gno_imi_partition.cpp
@@ -22,6 +22,8 @@
 #include <numeric>
 #include <vector>
 
+#include "datacell/flatten_datacell_parameter.h"
+
 #include "algorithm/inner_index_interface.h"
 #include "impl/allocator/safe_allocator.h"
 #include "impl/blas/blas_function.h"

--- a/src/algorithm/pyramid.cpp
+++ b/src/algorithm/pyramid.cpp
@@ -18,6 +18,7 @@
 #include <chrono>
 
 #include "algorithm/inner_index_interface.h"
+#include "dataset_impl.h"
 #include "analyzer/analyzer.h"
 #include "datacell/flatten_interface.h"
 #include "impl/heap/standard_heap.h"

--- a/src/algorithm/pyramid.cpp
+++ b/src/algorithm/pyramid.cpp
@@ -18,9 +18,9 @@
 #include <chrono>
 
 #include "algorithm/inner_index_interface.h"
-#include "dataset_impl.h"
 #include "analyzer/analyzer.h"
 #include "datacell/flatten_interface.h"
+#include "dataset_impl.h"
 #include "impl/heap/standard_heap.h"
 #include "impl/odescent/odescent_graph_builder.h"
 #include "impl/pruning_strategy.h"

--- a/src/algorithm/pyramid.h
+++ b/src/algorithm/pyramid.h
@@ -18,6 +18,8 @@
 #include <memory>
 #include <utility>
 
+#include "datacell/flatten_factory.h"
+#include "datacell/graph_factory.h"
 #include "datacell/graph_interface.h"
 #include "impl/allocator/safe_allocator.h"
 #include "impl/filter/filter_headers.h"
@@ -108,7 +110,7 @@ public:
           index_min_size_(pyramid_param->index_min_size),
           graph_type_(pyramid_param->graph_type),
           support_duplicate_(pyramid_param->support_duplicate) {
-        base_codes_ = FlattenInterface::MakeInstance(pyramid_param->base_codes_param, common_param);
+        base_codes_ = MakeFlattenInstance(pyramid_param->base_codes_param, common_param);
         root_ =
             std::make_unique<IndexNode>(allocator_, pyramid_param->graph_param, index_min_size_);
         points_mutex_ = std::make_shared<PointsMutex>(max_capacity_, allocator_);
@@ -116,8 +118,7 @@ public:
         no_build_levels_.assign(pyramid_param->no_build_levels.begin(),
                                 pyramid_param->no_build_levels.end());
         if (use_reorder_) {
-            precise_codes_ =
-                FlattenInterface::MakeInstance(pyramid_param->precise_codes_param, common_param);
+            precise_codes_ = MakeFlattenInstance(pyramid_param->precise_codes_param, common_param);
             reorder_ = std::make_shared<FlattenReorder>(precise_codes_, allocator_);
         }
     }

--- a/src/algorithm/warp.cpp
+++ b/src/algorithm/warp.cpp
@@ -25,8 +25,8 @@
 #include "attr/argparse.h"
 #include "attr/executor/executor.h"
 #include "datacell/attribute_inverted_interface.h"
-#include "datacell/flatten_datacell.h"
 #include "datacell/flatten_datacell_parameter.h"
+#include "datacell/flatten_factory.h"
 #include "datacell/flatten_interface.h"
 #include "fmt/chrono.h"
 #include "impl/heap/distance_heap.h"
@@ -47,7 +47,7 @@ constexpr float INITIAL_BEST_VECTOR_DISTANCE = std::numeric_limits<float>::infin
 
 WARP::WARP(const WarpParameterPtr& param, const IndexCommonParam& common_param)
     : InnerIndexInterface(param, common_param), doc_offsets_(allocator_) {
-    inner_codes_ = FlattenInterface::MakeInstance(param->base_codes_param, common_param);
+    inner_codes_ = MakeFlattenInstance(param->base_codes_param, common_param);
     auto code_size = this->inner_codes_->code_size_;
     auto increase_count = Options::Instance().block_size_limit() / code_size;
     this->resize_increase_count_bit_ = std::max(

--- a/src/datacell/bucket_datacell_test.cpp
+++ b/src/datacell/bucket_datacell_test.cpp
@@ -14,13 +14,13 @@
 // limitations under the License.
 
 #include "bucket_datacell.h"
-#include "index_common_param.h"
 
 #include <algorithm>
 #include <utility>
 
 #include "impl/allocator/default_allocator.h"
 #include "impl/allocator/safe_allocator.h"
+#include "index_common_param.h"
 #include "simd/simd.h"
 #include "storage/serialization_template_test.h"
 #include "unittest.h"

--- a/src/datacell/bucket_datacell_test.cpp
+++ b/src/datacell/bucket_datacell_test.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 #include "bucket_datacell.h"
+#include "index_common_param.h"
 
 #include <algorithm>
 #include <utility>

--- a/src/datacell/bucket_interface.cpp
+++ b/src/datacell/bucket_interface.cpp
@@ -14,11 +14,11 @@
 // limitations under the License.
 
 #include "bucket_interface.h"
-#include "index_common_param.h"
 
 #include <fmt/format.h>
 
 #include "bucket_datacell.h"
+#include "index_common_param.h"
 #include "inner_string_params.h"
 #include "io/io_headers.h"
 #include "quantization/quantizer_headers.h"

--- a/src/datacell/bucket_interface.cpp
+++ b/src/datacell/bucket_interface.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 #include "bucket_interface.h"
+#include "index_common_param.h"
 
 #include <fmt/format.h>
 

--- a/src/datacell/compressed_graph_datacell.cpp
+++ b/src/datacell/compressed_graph_datacell.cpp
@@ -16,6 +16,7 @@
 #include "compressed_graph_datacell.h"
 
 #include "graph_datacell_parameter.h"
+#include "index_common_param.h"
 #include "vsag_exception.h"
 
 namespace vsag {

--- a/src/datacell/compressed_graph_datacell_test.cpp
+++ b/src/datacell/compressed_graph_datacell_test.cpp
@@ -14,7 +14,6 @@
 // limitations under the License.
 
 #include "compressed_graph_datacell.h"
-#include "index_common_param.h"
 
 #include <fmt/format.h>
 
@@ -22,6 +21,7 @@
 #include "graph_factory.h"
 #include "graph_interface_test.h"
 #include "impl/allocator/safe_allocator.h"
+#include "index_common_param.h"
 #include "unittest.h"
 using namespace vsag;
 

--- a/src/datacell/compressed_graph_datacell_test.cpp
+++ b/src/datacell/compressed_graph_datacell_test.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 #include "compressed_graph_datacell.h"
+#include "index_common_param.h"
 
 #include <fmt/format.h>
 

--- a/src/datacell/compressed_graph_datacell_test.cpp
+++ b/src/datacell/compressed_graph_datacell_test.cpp
@@ -18,6 +18,7 @@
 #include <fmt/format.h>
 
 #include "graph_datacell_parameter.h"
+#include "graph_factory.h"
 #include "graph_interface_test.h"
 #include "impl/allocator/safe_allocator.h"
 #include "unittest.h"
@@ -29,9 +30,9 @@ TestCompressedGraphDataCell(const GraphInterfaceParamPtr& param,
     auto count = GENERATE(1000, 2000);
     auto max_id = 10000;
 
-    auto graph = GraphInterface::MakeInstance(param, common_param);
+    auto graph = MakeGraphInstance(param, common_param);
     GraphInterfaceTest test(graph, true);
-    auto other = GraphInterface::MakeInstance(param, common_param);
+    auto other = MakeGraphInstance(param, common_param);
     test.BasicTest(max_id, count, other, false);
 }
 
@@ -71,12 +72,12 @@ TEST_CASE("CompressedGraphDataCell duplicate tracker follows parameter",
     common_param.allocator_ = allocator;
 
     auto disabled_param = std::make_shared<CompressedGraphDatacellParameter>();
-    auto disabled_graph = GraphInterface::MakeInstance(disabled_param, common_param);
+    auto disabled_graph = MakeGraphInstance(disabled_param, common_param);
     REQUIRE(disabled_graph->GetDuplicateTracker() == nullptr);
 
     auto enabled_param = std::make_shared<CompressedGraphDatacellParameter>();
     enabled_param->support_duplicate_ = true;
-    auto enabled_graph = GraphInterface::MakeInstance(enabled_param, common_param);
+    auto enabled_graph = MakeGraphInstance(enabled_param, common_param);
     REQUIRE(enabled_graph->GetDuplicateTracker() != nullptr);
 
     enabled_graph->SetDuplicateId(0, 1);

--- a/src/datacell/extra_info_datacell_test.cpp
+++ b/src/datacell/extra_info_datacell_test.cpp
@@ -14,7 +14,6 @@
 // limitations under the License.
 
 #include "extra_info_datacell.h"
-#include "index_common_param.h"
 
 #include <algorithm>
 #include <utility>
@@ -22,6 +21,7 @@
 #include "extra_info_interface_test.h"
 #include "impl/allocator/default_allocator.h"
 #include "impl/allocator/safe_allocator.h"
+#include "index_common_param.h"
 #include "parameter_test.h"
 #include "unittest.h"
 

--- a/src/datacell/extra_info_datacell_test.cpp
+++ b/src/datacell/extra_info_datacell_test.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 #include "extra_info_datacell.h"
+#include "index_common_param.h"
 
 #include <algorithm>
 #include <utility>

--- a/src/datacell/extra_info_interface.cpp
+++ b/src/datacell/extra_info_interface.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 #include "extra_info_interface.h"
+#include "index_common_param.h"
 
 #include <fmt/format.h>
 

--- a/src/datacell/extra_info_interface.cpp
+++ b/src/datacell/extra_info_interface.cpp
@@ -14,11 +14,11 @@
 // limitations under the License.
 
 #include "extra_info_interface.h"
-#include "index_common_param.h"
 
 #include <fmt/format.h>
 
 #include "extra_info_datacell.h"
+#include "index_common_param.h"
 #include "inner_string_params.h"
 #include "io/io_headers.h"
 #include "quantization/quantizer_headers.h"

--- a/src/datacell/flatten_datacell_test.cpp
+++ b/src/datacell/flatten_datacell_test.cpp
@@ -18,6 +18,7 @@
 #include <algorithm>
 #include <utility>
 
+#include "flatten_factory.h"
 #include "flatten_interface_test.h"
 #include "impl/allocator/default_allocator.h"
 #include "impl/allocator/safe_allocator.h"
@@ -30,11 +31,11 @@ TestFlattenDataCell(FlattenDataCellParamPtr& param,
                     IndexCommonParam& common_param,
                     float error = 1e-3) {
     auto count = GENERATE(100, 1000);
-    auto flatten = FlattenInterface::MakeInstance(param, common_param);
+    auto flatten = MakeFlattenInstance(param, common_param);
 
     FlattenInterfaceTest test(flatten, common_param.metric_);
     test.BasicTest(common_param.dim_, count, error);
-    auto other = FlattenInterface::MakeInstance(param, common_param);
+    auto other = MakeFlattenInstance(param, common_param);
     test.TestSerializeAndDeserialize(common_param.dim_, other, error);
 }
 

--- a/src/datacell/flatten_datacell_test.cpp
+++ b/src/datacell/flatten_datacell_test.cpp
@@ -14,6 +14,8 @@
 // limitations under the License.
 
 #include "flatten_datacell.h"
+#include "flatten_datacell_parameter.h"
+#include "index_common_param.h"
 
 #include <algorithm>
 #include <utility>

--- a/src/datacell/flatten_datacell_test.cpp
+++ b/src/datacell/flatten_datacell_test.cpp
@@ -14,16 +14,16 @@
 // limitations under the License.
 
 #include "flatten_datacell.h"
-#include "flatten_datacell_parameter.h"
-#include "index_common_param.h"
 
 #include <algorithm>
 #include <utility>
 
+#include "flatten_datacell_parameter.h"
 #include "flatten_factory.h"
 #include "flatten_interface_test.h"
 #include "impl/allocator/default_allocator.h"
 #include "impl/allocator/safe_allocator.h"
+#include "index_common_param.h"
 #include "unittest.h"
 
 using namespace vsag;

--- a/src/datacell/flatten_factory.cpp
+++ b/src/datacell/flatten_factory.cpp
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 #include "flatten_factory.h"
-#include "index_common_param.h"
 
 #include "flatten_datacell.h"
 #include "flatten_datacell_parameter.h"
+#include "index_common_param.h"
 #include "inner_string_params.h"
 #include "io/io_headers.h"
 #include "quantization/int8_quantizer.h"

--- a/src/datacell/flatten_factory.cpp
+++ b/src/datacell/flatten_factory.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "flatten_factory.h"
+#include "index_common_param.h"
 
 #include "flatten_datacell.h"
 #include "flatten_datacell_parameter.h"

--- a/src/datacell/flatten_factory.cpp
+++ b/src/datacell/flatten_factory.cpp
@@ -1,0 +1,211 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "flatten_factory.h"
+
+#include "flatten_datacell.h"
+#include "flatten_datacell_parameter.h"
+#include "inner_string_params.h"
+#include "io/io_headers.h"
+#include "quantization/int8_quantizer.h"
+#include "quantization/quantizer_adapter.h"
+#include "quantization/quantizer_headers.h"
+#include "quantization/sparse_quantization/sparse_quantizer.h"
+#include "quantization/transform_quantization/transform_quantizer_parameter.h"
+#include "sparse_vector_datacell.h"
+
+namespace vsag {
+template <typename QuantTemp, typename IOTemp>
+static FlattenInterfacePtr
+make_instance_flatten(const FlattenInterfaceParamPtr& param, const IndexCommonParam& common_param) {
+    auto& io_param = param->io_parameter;
+    auto& quantizer_param = param->quantizer_parameter;
+    if (param->name == FLATTEN_DATA_CELL) {
+        return std::make_shared<FlattenDataCell<QuantTemp, IOTemp>>(
+            quantizer_param, io_param, common_param);
+    }
+    throw VsagException(ErrorType::INVALID_ARGUMENT,
+                        fmt::format("Unknown flatten interface name: {}", param->name));
+}
+template <typename QuantTemp, typename IOTemp>
+static FlattenInterfacePtr
+make_instance_sparse(const FlattenInterfaceParamPtr& param, const IndexCommonParam& common_param) {
+    auto& io_param = param->io_parameter;
+    auto& quantizer_param = param->quantizer_parameter;
+
+    if (param->name == SPARSE_VECTOR_DATA_CELL) {
+        return std::make_shared<SparseVectorDataCell<QuantTemp, IOTemp>>(
+            quantizer_param, io_param, common_param);
+    }
+    throw VsagException(ErrorType::INVALID_ARGUMENT,
+                        fmt::format("Unknown flatten interface name: {}", param->name));
+}
+
+template <typename QuantizerType, typename IOTemp, MetricType metric>
+static FlattenInterfacePtr
+make_instance_with_tq(const FlattenInterfaceParamPtr& param,
+                      const IndexCommonParam& common_param,
+                      bool is_transform_quantizer) {
+    if (is_transform_quantizer) {
+        return make_instance_flatten<TransformQuantizer<QuantizerType, metric>, IOTemp>(
+            param, common_param);
+    }
+    return make_instance_flatten<QuantizerType, IOTemp>(param, common_param);
+}
+
+template <MetricType metric, typename IOTemp>
+static FlattenInterfacePtr
+make_instance(const FlattenInterfaceParamPtr& param, const IndexCommonParam& common_param) {
+    std::string quantization_string = param->quantizer_parameter->GetTypeName();
+
+    if (common_param.data_type_ == DataTypes::DATA_TYPE_INT8) {
+        if (quantization_string == QUANTIZATION_TYPE_VALUE_INT8) {
+            return make_instance_flatten<INT8Quantizer<metric>, IOTemp>(param, common_param);
+        }
+        if (quantization_string == QUANTIZATION_TYPE_VALUE_PQ) {
+            return make_instance_flatten<QuantizerAdapter<ProductQuantizer<metric>, int8_t>,
+                                         IOTemp>(param, common_param);
+        }
+        throw VsagException(
+            ErrorType::INVALID_ARGUMENT,
+            fmt::format("INT8 data type does not support {} quantization", quantization_string));
+    }
+
+    if (common_param.data_type_ == DataTypes::DATA_TYPE_FP16 ||
+        common_param.data_type_ == DataTypes::DATA_TYPE_BF16) {
+        if (quantization_string == QUANTIZATION_TYPE_VALUE_FP16) {
+            return make_instance_flatten<QuantizerAdapter<FP16Quantizer<metric>, uint16_t>, IOTemp>(
+                param, common_param);
+        }
+        if (quantization_string == QUANTIZATION_TYPE_VALUE_BF16) {
+            return make_instance_flatten<QuantizerAdapter<BF16Quantizer<metric>, uint16_t>, IOTemp>(
+                param, common_param);
+        }
+        if (quantization_string == QUANTIZATION_TYPE_VALUE_PQ) {
+            return make_instance_flatten<QuantizerAdapter<ProductQuantizer<metric>, uint16_t>,
+                                         IOTemp>(param, common_param);
+        }
+        throw VsagException(ErrorType::INVALID_ARGUMENT,
+                            fmt::format("FP16/BF16 data type does not support {} quantization",
+                                        quantization_string));
+    }
+
+    auto actual_quant_type = quantization_string;
+    bool is_transform_quantizer = (quantization_string == QUANTIZATION_TYPE_VALUE_TQ);
+
+    if (is_transform_quantizer) {
+        auto tq_param =
+            std::dynamic_pointer_cast<TransformQuantizerParameter>(param->quantizer_parameter);
+        if (not tq_param) {
+            throw VsagException(ErrorType::INVALID_ARGUMENT,
+                                "Expected TransformQuantizerParameter for TQ quantization");
+        }
+        actual_quant_type = tq_param->GetBottomQuantizationName();
+    }
+
+    if (actual_quant_type == QUANTIZATION_TYPE_VALUE_SQ8) {
+        return make_instance_with_tq<SQ8Quantizer<metric>, IOTemp, metric>(
+            param, common_param, is_transform_quantizer);
+    }
+    if (actual_quant_type == QUANTIZATION_TYPE_VALUE_FP32) {
+        return make_instance_with_tq<FP32Quantizer<metric>, IOTemp, metric>(
+            param, common_param, is_transform_quantizer);
+    }
+    if (actual_quant_type == QUANTIZATION_TYPE_VALUE_SQ4) {
+        return make_instance_with_tq<SQ4Quantizer<metric>, IOTemp, metric>(
+            param, common_param, is_transform_quantizer);
+    }
+    if (actual_quant_type == QUANTIZATION_TYPE_VALUE_SQ4_UNIFORM) {
+        return make_instance_with_tq<SQ4UniformQuantizer<metric>, IOTemp, metric>(
+            param, common_param, is_transform_quantizer);
+    }
+    if (actual_quant_type == QUANTIZATION_TYPE_VALUE_SQ8_UNIFORM) {
+        return make_instance_with_tq<SQ8UniformQuantizer<metric>, IOTemp, metric>(
+            param, common_param, is_transform_quantizer);
+    }
+    if (actual_quant_type == QUANTIZATION_TYPE_VALUE_BF16) {
+        return make_instance_with_tq<BF16Quantizer<metric>, IOTemp, metric>(
+            param, common_param, is_transform_quantizer);
+    }
+    if (actual_quant_type == QUANTIZATION_TYPE_VALUE_FP16) {
+        return make_instance_with_tq<FP16Quantizer<metric>, IOTemp, metric>(
+            param, common_param, is_transform_quantizer);
+    }
+    if (actual_quant_type == QUANTIZATION_TYPE_VALUE_PQ) {
+        return make_instance_with_tq<ProductQuantizer<metric>, IOTemp, metric>(
+            param, common_param, is_transform_quantizer);
+    }
+    if (actual_quant_type == QUANTIZATION_TYPE_VALUE_PQFS) {
+        return make_instance_with_tq<PQFastScanQuantizer<metric>, IOTemp, metric>(
+            param, common_param, is_transform_quantizer);
+    }
+    if (actual_quant_type == QUANTIZATION_TYPE_VALUE_RABITQ) {
+        return make_instance_with_tq<RaBitQuantizer<metric>, IOTemp, metric>(
+            param, common_param, is_transform_quantizer);
+    }
+    if (actual_quant_type == QUANTIZATION_TYPE_VALUE_SPARSE and not is_transform_quantizer) {
+        if constexpr (metric == MetricType::METRIC_TYPE_IP) {
+            return make_instance_sparse<SparseQuantizer<metric>, IOTemp>(param, common_param);
+        } else {
+            throw VsagException(ErrorType::INVALID_ARGUMENT,
+                                fmt::format("Sparse quantization only supports IP metric, got {}",
+                                            static_cast<int>(metric)));
+        }
+    }
+
+    throw VsagException(ErrorType::INVALID_ARGUMENT,
+                        fmt::format("Unsupported quantization type: {}", actual_quant_type));
+}
+
+template <typename IOTemp>
+static FlattenInterfacePtr
+make_instance(const FlattenInterfaceParamPtr& param, const IndexCommonParam& common_param) {
+    auto metric = common_param.metric_;
+    if (metric == MetricType::METRIC_TYPE_L2SQR) {
+        return make_instance<MetricType::METRIC_TYPE_L2SQR, IOTemp>(param, common_param);
+    }
+    if (metric == MetricType::METRIC_TYPE_IP) {
+        return make_instance<MetricType::METRIC_TYPE_IP, IOTemp>(param, common_param);
+    }
+    if (metric == MetricType::METRIC_TYPE_COSINE) {
+        return make_instance<MetricType::METRIC_TYPE_COSINE, IOTemp>(param, common_param);
+    }
+    return nullptr;
+}
+
+FlattenInterfacePtr
+MakeFlattenInstance(const FlattenInterfaceParamPtr& param, const IndexCommonParam& common_param) {
+    auto io_type_name = param->io_parameter->GetTypeName();
+    if (io_type_name == IO_TYPE_VALUE_BLOCK_MEMORY_IO) {
+        return make_instance<MemoryBlockIO>(param, common_param);
+    }
+    if (io_type_name == IO_TYPE_VALUE_MEMORY_IO) {
+        return make_instance<MemoryIO>(param, common_param);
+    }
+    if (io_type_name == IO_TYPE_VALUE_BUFFER_IO) {
+        return make_instance<BufferIO>(param, common_param);
+    }
+    if (io_type_name == IO_TYPE_VALUE_ASYNC_IO) {
+        return make_instance<AsyncIO>(param, common_param);
+    }
+    if (io_type_name == IO_TYPE_VALUE_MMAP_IO) {
+        return make_instance<MMapIO>(param, common_param);
+    }
+    if (io_type_name == IO_TYPE_VALUE_READER_IO) {
+        return make_instance<ReaderIO>(param, common_param);
+    }
+    return nullptr;
+}
+
+}  // namespace vsag

--- a/src/datacell/flatten_factory.h
+++ b/src/datacell/flatten_factory.h
@@ -12,4 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#pragma once
+
 #include "flatten_interface.h"
+#include "flatten_interface_parameter.h"
+#include "index_common_param.h"
+
+namespace vsag {
+
+FlattenInterfacePtr
+MakeFlattenInstance(const FlattenInterfaceParamPtr& param, const IndexCommonParam& common_param);
+
+}  // namespace vsag

--- a/src/datacell/flatten_interface.h
+++ b/src/datacell/flatten_interface.h
@@ -18,11 +18,8 @@
 #include <shared_mutex>
 #include <string>
 
-#include "flatten_datacell_parameter.h"
 #include "flatten_interface_parameter.h"
-#include "impl/runtime_parameter.h"
 #include "index_common_param.h"
-#include "io/reader_io.h"
 #include "quantization/computer.h"
 #include "query_context.h"
 #include "storage/stream_reader.h"
@@ -39,10 +36,6 @@ class FlattenInterface {
 public:
     FlattenInterface() = default;
 
-    static FlattenInterfacePtr
-    MakeInstance(const FlattenInterfaceParamPtr& param, const IndexCommonParam& common_param);
-
-public:
     virtual void
     Query(float* result_dists,
           const ComputerInterfacePtr& computer,

--- a/src/datacell/graph_datacell_test.cpp
+++ b/src/datacell/graph_datacell_test.cpp
@@ -16,6 +16,7 @@
 #include <fmt/format.h>
 
 #include "graph_datacell_parameter.h"
+#include "graph_factory.h"
 #include "graph_interface_parameter.h"
 #include "graph_interface_test.h"
 #include "impl/allocator/safe_allocator.h"
@@ -31,9 +32,9 @@ TestGraphDataCell(const GraphInterfaceParamPtr& param,
     auto count = GENERATE(1000, 2000);
     auto max_id = 10000;
 
-    auto graph = GraphInterface::MakeInstance(param, common_param);
+    auto graph = MakeGraphInstance(param, common_param);
     GraphInterfaceTest test(graph);
-    auto other = GraphInterface::MakeInstance(param, common_param);
+    auto other = MakeGraphInstance(param, common_param);
     test.BasicTest(max_id, count, other, test_delete);
 }
 
@@ -124,9 +125,9 @@ TEST_CASE("GraphDataCell Merge", "[ut][GraphDataCell]") {
     auto graph_param = GraphInterfaceParameter::GetGraphParameterByJson(
         GraphStorageTypes::GRAPH_STORAGE_TYPE_VALUE_FLAT, param_json);
 
-    auto graph = GraphInterface::MakeInstance(graph_param, common_param);
+    auto graph = MakeGraphInstance(graph_param, common_param);
     GraphInterfaceTest test(graph);
-    auto other = GraphInterface::MakeInstance(graph_param, common_param);
+    auto other = MakeGraphInstance(graph_param, common_param);
     test.MergeTest(other, 1000);
 }
 
@@ -139,14 +140,14 @@ TEST_CASE("GraphDataCell duplicate tracker follows parameter", "[ut][GraphDataCe
     auto disabled_param = std::make_shared<GraphDataCellParameter>();
     disabled_param->io_parameter_ = std::make_shared<MemoryIOParameter>();
     disabled_param->support_duplicate_ = false;
-    auto disabled_graph = GraphInterface::MakeInstance(disabled_param, common_param);
+    auto disabled_graph = MakeGraphInstance(disabled_param, common_param);
     REQUIRE(disabled_graph->GetDuplicateTracker() == nullptr);
     REQUIRE(disabled_graph->GetDuplicateIds(0).empty());
 
     auto enabled_param = std::make_shared<GraphDataCellParameter>();
     enabled_param->io_parameter_ = std::make_shared<MemoryIOParameter>();
     enabled_param->support_duplicate_ = true;
-    auto enabled_graph = GraphInterface::MakeInstance(enabled_param, common_param);
+    auto enabled_graph = MakeGraphInstance(enabled_param, common_param);
     REQUIRE(enabled_graph->GetDuplicateTracker() != nullptr);
 
     enabled_graph->Resize(4);
@@ -182,7 +183,7 @@ TEST_CASE("GraphDataCell Reverse Edges", "[ut][GraphDataCell]") {
     auto graph_param = GraphInterfaceParameter::GetGraphParameterByJson(
         GraphStorageTypes::GRAPH_STORAGE_TYPE_VALUE_FLAT, param_json);
 
-    auto graph = GraphInterface::MakeInstance(graph_param, common_param);
+    auto graph = MakeGraphInstance(graph_param, common_param);
     GraphInterfaceTest test(graph);
     test.ReverseEdgeTest(100);
 }
@@ -213,7 +214,7 @@ TEST_CASE("GraphDataCell Move", "[ut][GraphDataCell]") {
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = 1024 * 1024 * 2ULL;
     vsag::Options::Instance().set_block_size_limit(size);
-    auto graph = GraphInterface::MakeInstance(graph_param, common_param);
+    auto graph = MakeGraphInstance(graph_param, common_param);
     GraphInterfaceTest test(graph);
     test.MoveTest(100);
     vsag::Options::Instance().set_block_size_limit(origin_size);
@@ -242,7 +243,7 @@ TEST_CASE("GraphDataCell Move same id keeps neighbors", "[ut][GraphDataCell]") {
     auto graph_param = GraphInterfaceParameter::GetGraphParameterByJson(
         GraphStorageTypes::GRAPH_STORAGE_TYPE_VALUE_FLAT, param_json);
 
-    auto graph = GraphInterface::MakeInstance(graph_param, common_param);
+    auto graph = MakeGraphInstance(graph_param, common_param);
     graph->Resize(4);
 
     Vector<InnerIdType> empty(allocator.get());

--- a/src/datacell/graph_datacell_test.cpp
+++ b/src/datacell/graph_datacell_test.cpp
@@ -16,6 +16,7 @@
 #include <fmt/format.h>
 
 #include "graph_datacell_parameter.h"
+#include "index_common_param.h"
 #include "graph_factory.h"
 #include "graph_interface_parameter.h"
 #include "graph_interface_test.h"

--- a/src/datacell/graph_datacell_test.cpp
+++ b/src/datacell/graph_datacell_test.cpp
@@ -16,11 +16,11 @@
 #include <fmt/format.h>
 
 #include "graph_datacell_parameter.h"
-#include "index_common_param.h"
 #include "graph_factory.h"
 #include "graph_interface_parameter.h"
 #include "graph_interface_test.h"
 #include "impl/allocator/safe_allocator.h"
+#include "index_common_param.h"
 #include "io/memory_io_parameter.h"
 #include "unittest.h"
 

--- a/src/datacell/graph_factory.cpp
+++ b/src/datacell/graph_factory.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "graph_factory.h"
+#include "index_common_param.h"
 
 #include "compressed_graph_datacell.h"
 #include "graph_datacell.h"

--- a/src/datacell/graph_factory.cpp
+++ b/src/datacell/graph_factory.cpp
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 #include "graph_factory.h"
-#include "index_common_param.h"
 
 #include "compressed_graph_datacell.h"
 #include "graph_datacell.h"
 #include "graph_datacell_parameter.h"
+#include "index_common_param.h"
 #include "io/io_headers.h"
 #include "sparse_graph_datacell.h"
 

--- a/src/datacell/graph_factory.cpp
+++ b/src/datacell/graph_factory.cpp
@@ -1,0 +1,58 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "graph_factory.h"
+
+#include "compressed_graph_datacell.h"
+#include "graph_datacell.h"
+#include "graph_datacell_parameter.h"
+#include "io/io_headers.h"
+#include "sparse_graph_datacell.h"
+
+namespace vsag {
+
+GraphInterfacePtr
+MakeGraphInstance(const GraphInterfaceParamPtr& graph_param, const IndexCommonParam& common_param) {
+    switch (graph_param->graph_storage_type_) {
+        case GraphStorageTypes::GRAPH_STORAGE_TYPE_SPARSE:
+            return std::make_shared<SparseGraphDataCell>(graph_param, common_param);
+        case GraphStorageTypes::GRAPH_STORAGE_TYPE_VALUE_COMPRESSED:
+            return std::make_shared<CompressedGraphDataCell>(graph_param, common_param);
+        case GraphStorageTypes::GRAPH_STORAGE_TYPE_VALUE_FLAT:
+            auto io_string = std::dynamic_pointer_cast<GraphDataCellParameter>(graph_param)
+                                 ->io_parameter_->GetTypeName();
+            if (io_string == IO_TYPE_VALUE_BLOCK_MEMORY_IO) {
+                return std::make_shared<GraphDataCell<MemoryBlockIO>>(graph_param, common_param);
+            }
+            if (io_string == IO_TYPE_VALUE_MEMORY_IO) {
+                return std::make_shared<GraphDataCell<MemoryIO>>(graph_param, common_param);
+            }
+            if (io_string == IO_TYPE_VALUE_MMAP_IO) {
+                return std::make_shared<GraphDataCell<MMapIO>>(graph_param, common_param);
+            }
+            if (io_string == IO_TYPE_VALUE_BUFFER_IO) {
+                return std::make_shared<GraphDataCell<BufferIO>>(graph_param, common_param);
+            }
+            if (io_string == IO_TYPE_VALUE_ASYNC_IO) {
+                return std::make_shared<GraphDataCell<AsyncIO>>(graph_param, common_param);
+            }
+            if (io_string == IO_TYPE_VALUE_READER_IO) {
+                return std::make_shared<GraphDataCell<ReaderIO>>(graph_param, common_param);
+            }
+            return nullptr;
+    }
+    return nullptr;
+}
+
+}  // namespace vsag

--- a/src/datacell/graph_factory.h
+++ b/src/datacell/graph_factory.h
@@ -12,4 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "flatten_interface.h"
+#pragma once
+
+#include "graph_interface.h"
+#include "graph_interface_parameter.h"
+#include "index_common_param.h"
+
+namespace vsag {
+
+GraphInterfacePtr
+MakeGraphInstance(const GraphInterfaceParamPtr& graph_param, const IndexCommonParam& common_param);
+
+}  // namespace vsag

--- a/src/datacell/graph_interface.cpp
+++ b/src/datacell/graph_interface.cpp
@@ -15,11 +15,6 @@
 
 #include "graph_interface.h"
 
-#include "compressed_graph_datacell.h"
-#include "graph_datacell.h"
-#include "io/io_headers.h"
-#include "sparse_graph_datacell.h"
-
 namespace vsag {
 
 void
@@ -48,37 +43,4 @@ GraphInterface::UpdateReverseEdges(InnerIdType id,
     }
 }
 
-GraphInterfacePtr
-GraphInterface::MakeInstance(const GraphInterfaceParamPtr& graph_param,
-                             const IndexCommonParam& common_param) {
-    switch (graph_param->graph_storage_type_) {
-        case GraphStorageTypes::GRAPH_STORAGE_TYPE_SPARSE:
-            return std::make_shared<SparseGraphDataCell>(graph_param, common_param);
-        case GraphStorageTypes::GRAPH_STORAGE_TYPE_VALUE_COMPRESSED:
-            return std::make_shared<CompressedGraphDataCell>(graph_param, common_param);
-        case GraphStorageTypes::GRAPH_STORAGE_TYPE_VALUE_FLAT:
-            auto io_string = std::dynamic_pointer_cast<GraphDataCellParameter>(graph_param)
-                                 ->io_parameter_->GetTypeName();
-            if (io_string == IO_TYPE_VALUE_BLOCK_MEMORY_IO) {
-                return std::make_shared<GraphDataCell<MemoryBlockIO>>(graph_param, common_param);
-            }
-            if (io_string == IO_TYPE_VALUE_MEMORY_IO) {
-                return std::make_shared<GraphDataCell<MemoryIO>>(graph_param, common_param);
-            }
-            if (io_string == IO_TYPE_VALUE_MMAP_IO) {
-                return std::make_shared<GraphDataCell<MMapIO>>(graph_param, common_param);
-            }
-            if (io_string == IO_TYPE_VALUE_BUFFER_IO) {
-                return std::make_shared<GraphDataCell<BufferIO>>(graph_param, common_param);
-            }
-            if (io_string == IO_TYPE_VALUE_ASYNC_IO) {
-                return std::make_shared<GraphDataCell<AsyncIO>>(graph_param, common_param);
-            }
-            if (io_string == IO_TYPE_VALUE_READER_IO) {
-                return std::make_shared<GraphDataCell<ReaderIO>>(graph_param, common_param);
-            }
-            return nullptr;
-    }
-    return nullptr;
-}
 }  // namespace vsag

--- a/src/datacell/graph_interface.h
+++ b/src/datacell/graph_interface.h
@@ -16,15 +16,11 @@
 #pragma once
 
 #include <cstdint>
-#include <memory>
 #include <mutex>
 #include <vector>
 
 #include "duplicate_interface.h"
-#include "graph_interface_parameter.h"
 #include "impl/reverse_edge.h"
-#include "index_common_param.h"
-#include "inner_string_params.h"
 #include "io/io_parameter.h"
 #include "storage/stream_reader.h"
 #include "storage/stream_writer.h"
@@ -42,10 +38,6 @@ public:
 
     virtual ~GraphInterface() = default;
 
-    static GraphInterfacePtr
-    MakeInstance(const GraphInterfaceParamPtr& graph_param, const IndexCommonParam& common_param);
-
-public:
     virtual void
     InsertNeighborsById(InnerIdType id, const Vector<InnerIdType>& neighbor_ids) = 0;
 

--- a/src/datacell/sparse_graph_datacell.cpp
+++ b/src/datacell/sparse_graph_datacell.cpp
@@ -14,8 +14,8 @@
 // limitations under the License.
 
 #include "sparse_graph_datacell.h"
-#include "index_common_param.h"
 
+#include "index_common_param.h"
 #include "sparse_graph_datacell_parameter.h"
 #include "vsag_exception.h"
 

--- a/src/datacell/sparse_graph_datacell.cpp
+++ b/src/datacell/sparse_graph_datacell.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 #include "sparse_graph_datacell.h"
+#include "index_common_param.h"
 
 #include "sparse_graph_datacell_parameter.h"
 #include "vsag_exception.h"

--- a/src/datacell/sparse_graph_datacell_test.cpp
+++ b/src/datacell/sparse_graph_datacell_test.cpp
@@ -17,6 +17,7 @@
 
 #include <fmt/format.h>
 
+#include "graph_factory.h"
 #include "graph_interface_test.h"
 #include "impl/allocator/safe_allocator.h"
 #include "sparse_graph_datacell_parameter.h"
@@ -30,9 +31,9 @@ TestSparseGraphDataCell(const GraphInterfaceParamPtr& param,
     auto count = GENERATE(1000, 2000);
     auto max_id = 10000;
 
-    auto graph = GraphInterface::MakeInstance(param, common_param);
+    auto graph = MakeGraphInstance(param, common_param);
     GraphInterfaceTest test(graph);
-    auto other = GraphInterface::MakeInstance(param, common_param);
+    auto other = MakeGraphInstance(param, common_param);
     test.BasicTest(max_id, count, other, test_delete);
 }
 
@@ -82,9 +83,9 @@ TEST_CASE("SparseGraphDataCell Merge Test", "[ut][SparseGraphDataCell]") {
     graph_param->max_degree_ = max_degree;
     graph_param->support_delete_ = is_support_delete;
 
-    auto graph = GraphInterface::MakeInstance(graph_param, common_param);
+    auto graph = MakeGraphInstance(graph_param, common_param);
     GraphInterfaceTest test(graph);
-    auto other = GraphInterface::MakeInstance(graph_param, common_param);
+    auto other = MakeGraphInstance(graph_param, common_param);
     test.MergeTest(other, count);
 }
 
@@ -100,7 +101,7 @@ TEST_CASE("SparseGraphDataCell Reverse Edges", "[ut][SparseGraphDataCell]") {
     graph_param->max_degree_ = max_degree;
     graph_param->use_reverse_edges_ = true;
 
-    auto graph = GraphInterface::MakeInstance(graph_param, common_param);
+    auto graph = MakeGraphInstance(graph_param, common_param);
     GraphInterfaceTest test(graph);
     test.ReverseEdgeTest(100);
 }
@@ -117,7 +118,7 @@ TEST_CASE("SparseGraphDataCell Move", "[ut][SparseGraphDataCell]") {
     graph_param->max_degree_ = max_degree;
     graph_param->use_reverse_edges_ = true;
 
-    auto graph = GraphInterface::MakeInstance(graph_param, common_param);
+    auto graph = MakeGraphInstance(graph_param, common_param);
     GraphInterfaceTest test(graph);
     test.MoveTest(100);
 }
@@ -132,7 +133,7 @@ TEST_CASE("SparseGraphDataCell Move same id keeps neighbors", "[ut][SparseGraphD
     graph_param->max_degree_ = 8;
     graph_param->use_reverse_edges_ = true;
 
-    auto graph = GraphInterface::MakeInstance(graph_param, common_param);
+    auto graph = MakeGraphInstance(graph_param, common_param);
 
     Vector<InnerIdType> empty(allocator.get());
     Vector<InnerIdType> neighbors(allocator.get());
@@ -170,7 +171,7 @@ TEST_CASE("SparseGraphDataCell decodes stored neighbors for reverse-edge updates
     graph_param->remove_flag_bit_ = 4;
     graph_param->use_reverse_edges_ = true;
 
-    auto graph = GraphInterface::MakeInstance(graph_param, common_param);
+    auto graph = MakeGraphInstance(graph_param, common_param);
 
     Vector<InnerIdType> empty(allocator.get());
     Vector<InnerIdType> to_two(allocator.get());

--- a/src/datacell/sparse_graph_datacell_test.cpp
+++ b/src/datacell/sparse_graph_datacell_test.cpp
@@ -14,13 +14,13 @@
 // limitations under the License.
 
 #include "sparse_graph_datacell.h"
-#include "index_common_param.h"
 
 #include <fmt/format.h>
 
 #include "graph_factory.h"
 #include "graph_interface_test.h"
 #include "impl/allocator/safe_allocator.h"
+#include "index_common_param.h"
 #include "sparse_graph_datacell_parameter.h"
 #include "unittest.h"
 using namespace vsag;

--- a/src/datacell/sparse_graph_datacell_test.cpp
+++ b/src/datacell/sparse_graph_datacell_test.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 #include "sparse_graph_datacell.h"
+#include "index_common_param.h"
 
 #include <fmt/format.h>
 

--- a/src/datacell/sparse_vector_datacell_test.cpp
+++ b/src/datacell/sparse_vector_datacell_test.cpp
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "datacell/flatten_factory.h"
 #include "datacell/sparse_vector_datacell_parameter.h"
 #include "framework/test_thread_pool.h"
 #include "impl/allocator/safe_allocator.h"
@@ -45,7 +46,7 @@ TEST_CASE("SparseDataCell Basic Test", "[ut][SparseDataCell] ") {
     index_common_param.allocator_ = SafeAllocator::FactoryDefaultAllocator();
     index_common_param.metric_ = MetricType::METRIC_TYPE_IP;
     index_common_param.dim_ = max_dim;
-    auto data_cell = FlattenInterface::MakeInstance(param, index_common_param);
+    auto data_cell = MakeFlattenInstance(param, index_common_param);
     REQUIRE(data_cell->GetQuantizerName() == QUANTIZATION_TYPE_VALUE_SPARSE);
     REQUIRE(data_cell->GetMetricType() == MetricType::METRIC_TYPE_IP);
 
@@ -82,7 +83,7 @@ TEST_CASE("SparseDataCell Basic Test", "[ut][SparseDataCell] ") {
         }
     }
     SECTION("serialize and deserialize") {
-        auto new_data_cell = FlattenInterface::MakeInstance(param, index_common_param);
+        auto new_data_cell = MakeFlattenInstance(param, index_common_param);
         test_serializion(*data_cell, *new_data_cell);
         auto computer = new_data_cell->FactoryComputer(query_sparse_vectors.data());
         std::vector<float> dist(base_count);
@@ -126,7 +127,7 @@ TEST_CASE("SparseDataCell Concurrent Test", "[ut][SparseDataCell][concurrent] ")
     index_common_param.allocator_ = SafeAllocator::FactoryDefaultAllocator();
     index_common_param.metric_ = MetricType::METRIC_TYPE_IP;
     index_common_param.dim_ = max_dim;
-    auto data_cell = FlattenInterface::MakeInstance(param, index_common_param);
+    auto data_cell = MakeFlattenInstance(param, index_common_param);
     REQUIRE(data_cell->GetQuantizerName() == QUANTIZATION_TYPE_VALUE_SPARSE);
     REQUIRE(data_cell->GetMetricType() == MetricType::METRIC_TYPE_IP);
 

--- a/src/impl/odescent/odescent_graph_builder_test.cpp
+++ b/src/impl/odescent/odescent_graph_builder_test.cpp
@@ -19,6 +19,7 @@
 #include <set>
 
 #include "datacell/flatten_factory.h"
+#include "datacell/flatten_datacell_parameter.h"
 #include "datacell/graph_factory.h"
 #include "impl/allocator/safe_allocator.h"
 #include "io/memory_io_parameter.h"

--- a/src/impl/odescent/odescent_graph_builder_test.cpp
+++ b/src/impl/odescent/odescent_graph_builder_test.cpp
@@ -18,8 +18,8 @@
 #include <filesystem>
 #include <set>
 
-#include "datacell/flatten_factory.h"
 #include "datacell/flatten_datacell_parameter.h"
+#include "datacell/flatten_factory.h"
 #include "datacell/graph_factory.h"
 #include "impl/allocator/safe_allocator.h"
 #include "io/memory_io_parameter.h"

--- a/src/impl/odescent/odescent_graph_builder_test.cpp
+++ b/src/impl/odescent/odescent_graph_builder_test.cpp
@@ -18,8 +18,8 @@
 #include <filesystem>
 #include <set>
 
-#include "datacell/flatten_interface.h"
-#include "datacell/graph_interface.h"
+#include "datacell/flatten_factory.h"
+#include "datacell/graph_factory.h"
 #include "impl/allocator/safe_allocator.h"
 #include "io/memory_io_parameter.h"
 #include "quantization/fp32_quantizer_parameter.h"
@@ -86,7 +86,7 @@ TEST_CASE("ODescent Build Test", "[ut][ODescent]") {
     flatten_param->quantizer_parameter = std::make_shared<vsag::FP32QuantizerParameter>();
     flatten_param->io_parameter = std::make_shared<vsag::MemoryIOParameter>();
     vsag::FlattenInterfacePtr flatten_interface_ptr =
-        vsag::FlattenInterface::MakeInstance(flatten_param, param);
+        vsag::MakeFlattenInstance(flatten_param, param);
     flatten_interface_ptr->Train(vectors.data(), num_vectors);
     flatten_interface_ptr->BatchInsertVector(vectors.data(), num_vectors);
 
@@ -119,12 +119,10 @@ TEST_CASE("ODescent Build Test", "[ut][ODescent]") {
     auto id_map = [&](uint32_t id) -> uint32_t { return partial_data ? valid_ids[id] : id; };
 
     // check result
-    vsag::GraphInterfacePtr graph_interface =
-        vsag::GraphInterface::MakeInstance(graph_param_ptr, param);
-    vsag::GraphInterfacePtr half_graph_interface =
-        vsag::GraphInterface::MakeInstance(graph_param_ptr, param);
+    vsag::GraphInterfacePtr graph_interface = vsag::MakeGraphInstance(graph_param_ptr, param);
+    vsag::GraphInterfacePtr half_graph_interface = vsag::MakeGraphInstance(graph_param_ptr, param);
     vsag::GraphInterfacePtr merged_graph_interface =
-        vsag::GraphInterface::MakeInstance(graph_param_ptr, param);
+        vsag::MakeGraphInstance(graph_param_ptr, param);
     graph.Build(valid_ids);
     graph.SaveGraph(graph_interface);
 

--- a/src/impl/pruning_strategy_test.cpp
+++ b/src/impl/pruning_strategy_test.cpp
@@ -20,10 +20,10 @@
 #include <memory>
 #include <vector>
 
-#include "datacell/flatten_datacell.h"
 #include "datacell/flatten_datacell_parameter.h"
+#include "datacell/flatten_factory.h"
 #include "datacell/graph_datacell_parameter.h"
-#include "datacell/graph_interface.h"
+#include "datacell/graph_factory.h"
 #include "impl/allocator/safe_allocator.h"
 #include "impl/heap/standard_heap.h"
 #include "io/memory_io_parameter.h"
@@ -51,7 +51,7 @@ TEST_CASE("Pruning Strategy Select Edges With Heuristic", "[ut][pruning_strategy
     common_param.dim_ = 128;
 
     // Create flatten interface instance with configured parameters
-    auto flatten = FlattenInterface::MakeInstance(flatten_param, common_param);
+    auto flatten = MakeFlattenInstance(flatten_param, common_param);
     REQUIRE(flatten != nullptr);
 
     float vectors[5][128] = {0};
@@ -175,7 +175,7 @@ TEST_CASE("Pruning Strategy Select Edges With Heuristic", "[ut][pruning_strategy
         auto graph_param = std::make_shared<GraphDataCellParameter>();
         graph_param->io_parameter_ = std::make_shared<MemoryIOParameter>();
         graph_param->max_degree_ = 4;
-        auto graph = GraphInterface::MakeInstance(graph_param, common_param);
+        auto graph = MakeGraphInstance(graph_param, common_param);
 
         auto candidates = std::make_shared<StandardHeap<true, false>>(allocator.get(), -1);
         candidates->Push(d01, 1);

--- a/src/index/diskann.cpp
+++ b/src/index/diskann.cpp
@@ -28,7 +28,8 @@
 #include <utility>
 #include <vector>
 
-#include "datacell/flatten_datacell.h"
+#include "datacell/flatten_datacell_parameter.h"
+#include "datacell/flatten_factory.h"
 #include "dataset_impl.h"
 #include "impl/odescent/odescent_graph_builder.h"
 #include "io/memory_io_parameter.h"
@@ -323,7 +324,7 @@ DiskANN::build(const DatasetPtr& base) {
             flatten_param->quantizer_parameter = std::make_shared<FP32QuantizerParameter>();
             flatten_param->io_parameter = std::make_shared<MemoryIOParameter>();
             vsag::FlattenInterfacePtr flatten_interface_ptr =
-                vsag::FlattenInterface::MakeInstance(flatten_param, this->common_param_);
+                vsag::MakeFlattenInstance(flatten_param, this->common_param_);
             flatten_interface_ptr->Train(vectors, data_num);
             flatten_interface_ptr->BatchInsertVector(vectors, data_num);
             auto param = std::make_shared<ODescentParameter>();

--- a/src/index/hnsw.cpp
+++ b/src/index/hnsw.cpp
@@ -27,7 +27,10 @@
 #include "algorithm/hnswlib/hnswlib.h"
 #include "common.h"
 #include "datacell/flatten_datacell.h"
+#include "datacell/flatten_datacell_parameter.h"
+#include "datacell/flatten_factory.h"
 #include "datacell/graph_datacell_parameter.h"
+#include "datacell/graph_factory.h"
 #include "impl/allocator/safe_allocator.h"
 #include "impl/odescent/odescent_graph_builder.h"
 #include "index/hnsw_zparameters.h"
@@ -1172,10 +1175,8 @@ HNSW::merge(const std::vector<MergeUnit>& merge_units) {
     graph_param_ptr->io_parameter_ = std::make_shared<vsag::MemoryBlockIOParameter>();
     graph_param_ptr->max_degree_ = max_degree_ * 2;
 
-    FlattenInterfacePtr flatten_interface =
-        FlattenInterface::MakeInstance(param, index_common_param_);
-    GraphInterfacePtr graph_interface =
-        GraphInterface::MakeInstance(graph_param_ptr, index_common_param_);
+    FlattenInterfacePtr flatten_interface = MakeFlattenInstance(param, index_common_param_);
+    GraphInterfacePtr graph_interface = MakeGraphInstance(graph_param_ptr, index_common_param_);
     Vector<LabelType> ids(allocator_.get());
     // extract data and graph
     IdMapFunction id_map = [](int64_t id) -> std::tuple<bool, int64_t> {

--- a/src/index/hnsw.h
+++ b/src/index/hnsw.h
@@ -35,7 +35,6 @@
 #include "impl/allocator/safe_allocator.h"
 #include "impl/conjugate_graph.h"
 #include "impl/filter/filter_headers.h"
-#include "impl/logger/logger.h"
 #include "index_common_param.h"
 #include "index_feature_list.h"
 #include "index_impl.h"

--- a/src/index/hnsw_test.cpp
+++ b/src/index/hnsw_test.cpp
@@ -22,8 +22,8 @@
 #include <vector>
 
 #include "data_type.h"
-#include "datacell/flatten_factory.h"
 #include "datacell/flatten_datacell_parameter.h"
+#include "datacell/flatten_factory.h"
 #include "datacell/graph_datacell_parameter.h"
 #include "datacell/graph_factory.h"
 #include "impl/logger/logger.h"

--- a/src/index/hnsw_test.cpp
+++ b/src/index/hnsw_test.cpp
@@ -23,6 +23,7 @@
 
 #include "data_type.h"
 #include "datacell/flatten_factory.h"
+#include "datacell/flatten_datacell_parameter.h"
 #include "datacell/graph_datacell_parameter.h"
 #include "datacell/graph_factory.h"
 #include "impl/logger/logger.h"

--- a/src/index/hnsw_test.cpp
+++ b/src/index/hnsw_test.cpp
@@ -22,7 +22,9 @@
 #include <vector>
 
 #include "data_type.h"
+#include "datacell/flatten_factory.h"
 #include "datacell/graph_datacell_parameter.h"
+#include "datacell/graph_factory.h"
 #include "impl/logger/logger.h"
 #include "io/memory_io_parameter.h"
 #include "quantization/fp32_quantizer_parameter.h"
@@ -996,8 +998,8 @@ TEST_CASE("extract/set data and graph", "[ut][hnsw]") {
     vsag::GraphDataCellParamPtr graph_param_ptr = std::make_shared<vsag::GraphDataCellParameter>();
     graph_param_ptr->io_parameter_ = std::make_shared<vsag::MemoryIOParameter>();
 
-    FlattenInterfacePtr flatten_interface = FlattenInterface::MakeInstance(param, common_param);
-    GraphInterfacePtr graph_interface = GraphInterface::MakeInstance(graph_param_ptr, common_param);
+    FlattenInterfacePtr flatten_interface = MakeFlattenInstance(param, common_param);
+    GraphInterfacePtr graph_interface = MakeGraphInstance(graph_param_ptr, common_param);
     Vector<LabelType> ids_vector(allocator.get());
 
     IdMapFunction id_map = [](int64_t id) -> std::tuple<bool, int64_t> {

--- a/src/index/index_impl.h
+++ b/src/index/index_impl.h
@@ -17,6 +17,7 @@
 
 #include "algorithm/inner_index_interface.h"
 #include "common.h"
+#include "dataset_impl.h"
 #include "index_common_param.h"
 #include "vsag/index.h"
 namespace vsag {


### PR DESCRIPTION
## Summary
- move graph and flatten instance creation out of the core interface headers into dedicated factory headers and source files
- update all production and test call sites to use the new graph and flatten factory helpers
- reduce core header coupling by removing dataset_impl.h from inner_index_interface.h while keeping downstream behavior unchanged

## Testing
- make fmt
- targeted compilation via compile_commands.json entries for updated datacell, algorithm, and index translation units