### PR TITLE
fix: CalDistanceById batch interface returns -1 for invalid IDs

### DIFF
--- a/src/algorithm/inner_index_interface.cpp
+++ b/src/algorithm/inner_index_interface.cpp
@@ -329,8 +329,8 @@ InnerIndexInterface::CalDistanceById(const DatasetPtr& query,
     result->Distances(distances);
     for (int64_t i = 0; i < count; ++i) {
         try {
-            distances[i] = this->CalcDistanceById(query, ids[i], calculate_precise_distance);
-        } catch (const std::exception&) {
+            distances[i] = this->CalcDistanceById(query, ids[i]);
+        } catch (std::runtime_error& e) {
             logger::debug(fmt::format("failed to find id: {}", ids[i]));
             distances[i] = -1;
         }

--- a/src/algorithm/inner_index_interface.cpp
+++ b/src/algorithm/inner_index_interface.cpp
@@ -303,7 +303,17 @@ InnerIndexInterface::CalDistanceById(const float* query,
     auto* distances = static_cast<float*>(allocator_->Allocate(sizeof(float) * count));
     result->Distances(distances);
     for (int64_t i = 0; i < count; ++i) {
-        distances[i] = this->CalcDistanceById(query, ids[i]);
+        bool exists = false;
+        {
+            std::shared_lock<std::shared_mutex> lock(this->label_lookup_mutex_);
+            exists = this->label_table_->TryGetIdByLabel(ids[i]).first;
+        }
+        if (exists) {
+            distances[i] = this->CalcDistanceById(query, ids[i], calculate_precise_distance);
+        } else {
+            logger::debug(fmt::format("failed to find id: {}", ids[i]));
+            distances[i] = -1;
+        }
     }
     return result;
 }
@@ -319,8 +329,8 @@ InnerIndexInterface::CalDistanceById(const DatasetPtr& query,
     result->Distances(distances);
     for (int64_t i = 0; i < count; ++i) {
         try {
-            distances[i] = this->CalcDistanceById(query, ids[i]);
-        } catch (std::runtime_error& e) {
+            distances[i] = this->CalcDistanceById(query, ids[i], calculate_precise_distance);
+        } catch (const std::exception&) {
             logger::debug(fmt::format("failed to find id: {}", ids[i]));
             distances[i] = -1;
         }

--- a/src/algorithm/ivf.cpp
+++ b/src/algorithm/ivf.cpp
@@ -1027,27 +1027,31 @@ IVF::CalDistanceById(const float* query,
                      const int64_t* ids,
                      int64_t count,
                      bool calculate_precise_distance) const {
+    if (this->use_reorder_ && calculate_precise_distance) {
+        return this->cal_distance_by_id(query, ids, count, this->reorder_codes_);
+    }
     auto result = Dataset::Make();
     result->Owner(true, allocator_);
     auto* distances = static_cast<float*>(allocator_->Allocate(sizeof(float) * count));
     result->Distances(distances);
-    if (this->use_reorder_ && calculate_precise_distance) {
-        auto computer = this->reorder_codes_->FactoryComputer(query);
-        Vector<InnerIdType> inner_ids(count, allocator_);
-        for (int64_t i = 0; i < count; ++i) {
-            inner_ids[i] = this->label_table_->GetIdByLabel(ids[i]);
-        }
-        this->reorder_codes_->Query(distances, computer, inner_ids.data(), count);
-        return result;
-    }
     auto computer = this->bucket_->FactoryComputer(query);
     for (int64_t i = 0; i < count; ++i) {
-        auto inner_id = this->label_table_->GetIdByLabel(ids[i]);
+        bool success = false;
+        InnerIdType inner_id = 0;
+        {
+            std::shared_lock<std::shared_mutex> lock(this->label_lookup_mutex_);
+            std::tie(success, inner_id) = this->label_table_->TryGetIdByLabel(ids[i]);
+        }
+        if (not success) {
+            distances[i] = -1;
+            continue;
+        }
         auto location = this->get_location(inner_id);
         distances[i] = this->bucket_->QueryOneById(computer, location.first, location.second);
     }
     return result;
 }
+
 float
 IVF::CalcDistanceById(const float* query, int64_t id, bool calculate_precise_distance) const {
     if (this->use_reorder_ && calculate_precise_distance) {


### PR DESCRIPTION
**Problem**

The CalDistanceById(float*, ids, count) batch interface has inconsistent handling of invalid IDs across different Index implementations.

**Changes**

1. **inner_index_interface.cpp**: Use TryGetIdByLabel instead of try-catch for better performance
2. **ivf.cpp**: Use cal_distance_by_id helper for reorder branch to fix bug where invalid IDs were overwritten
3. **brute_force.cpp/.h**: Remove redundant implementation, use base class implementation instead

**Related Issue**

Fixes #2005

**Testing**

- Existing test in test_index.cpp already covers invalid ID scenario
- All modified files compile successfully
- Debug build completed successfully