### PR TITLE
docs(site): add Google Analytics (gtag.js) to vsag.io

### DIFF
--- a/docs/blog/en/theme/head.hbs
+++ b/docs/blog/en/theme/head.hbs
@@ -1,3 +1,14 @@
+<!-- Google tag (gtag.js) -->
+<!-- Shared across docs/{en,zh} and blog/{en,zh}. Keep these four copies in sync. -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-WL7YCF91WW"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-WL7YCF91WW');
+</script>
+
 <!-- Language toggle button injected into mdBook's top menu bar. -->
 <!-- Shared across docs/{en,zh} and blog/{en,zh}. Keep these four copies in sync. -->
 <style>

--- a/docs/blog/en/theme/head.hbs
+++ b/docs/blog/en/theme/head.hbs
@@ -1,12 +1,14 @@
 <!-- Google tag (gtag.js) -->
-<!-- Shared across docs/{en,zh} and blog/{en,zh}. Keep these four copies in sync. -->
+<!-- Shared with docs/{docs,blog}/{en,zh}/theme/head.hbs and docs/landing/index.html. Keep these five copies in sync. -->
+<!-- Hostname-gated so local mdBook previews and fork deploys do not pollute the production GA4 property. -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-WL7YCF91WW"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
-
-  gtag('config', 'G-WL7YCF91WW');
+  if (location.hostname === 'vsag.io') {
+    gtag('config', 'G-WL7YCF91WW');
+  }
 </script>
 
 <!-- Language toggle button injected into mdBook's top menu bar. -->

--- a/docs/blog/zh/theme/head.hbs
+++ b/docs/blog/zh/theme/head.hbs
@@ -1,3 +1,14 @@
+<!-- Google tag (gtag.js) -->
+<!-- Shared across docs/{en,zh} and blog/{en,zh}. Keep these four copies in sync. -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-WL7YCF91WW"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-WL7YCF91WW');
+</script>
+
 <!-- Language toggle button injected into mdBook's top menu bar. -->
 <!-- Shared across docs/{en,zh} and blog/{en,zh}. Keep these four copies in sync. -->
 <style>

--- a/docs/blog/zh/theme/head.hbs
+++ b/docs/blog/zh/theme/head.hbs
@@ -1,12 +1,14 @@
 <!-- Google tag (gtag.js) -->
-<!-- Shared across docs/{en,zh} and blog/{en,zh}. Keep these four copies in sync. -->
+<!-- Shared with docs/{docs,blog}/{en,zh}/theme/head.hbs and docs/landing/index.html. Keep these five copies in sync. -->
+<!-- Hostname-gated so local mdBook previews and fork deploys do not pollute the production GA4 property. -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-WL7YCF91WW"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
-
-  gtag('config', 'G-WL7YCF91WW');
+  if (location.hostname === 'vsag.io') {
+    gtag('config', 'G-WL7YCF91WW');
+  }
 </script>
 
 <!-- Language toggle button injected into mdBook's top menu bar. -->

--- a/docs/docs/en/theme/head.hbs
+++ b/docs/docs/en/theme/head.hbs
@@ -1,3 +1,14 @@
+<!-- Google tag (gtag.js) -->
+<!-- Shared across docs/{en,zh} and blog/{en,zh}. Keep these four copies in sync. -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-WL7YCF91WW"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-WL7YCF91WW');
+</script>
+
 <!-- Language toggle button injected into mdBook's top menu bar. -->
 <!-- Shared across docs/{en,zh} and blog/{en,zh}. Keep these four copies in sync. -->
 <style>

--- a/docs/docs/en/theme/head.hbs
+++ b/docs/docs/en/theme/head.hbs
@@ -1,12 +1,14 @@
 <!-- Google tag (gtag.js) -->
-<!-- Shared across docs/{en,zh} and blog/{en,zh}. Keep these four copies in sync. -->
+<!-- Shared with docs/{docs,blog}/{en,zh}/theme/head.hbs and docs/landing/index.html. Keep these five copies in sync. -->
+<!-- Hostname-gated so local mdBook previews and fork deploys do not pollute the production GA4 property. -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-WL7YCF91WW"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
-
-  gtag('config', 'G-WL7YCF91WW');
+  if (location.hostname === 'vsag.io') {
+    gtag('config', 'G-WL7YCF91WW');
+  }
 </script>
 
 <!-- Language toggle button injected into mdBook's top menu bar. -->

--- a/docs/docs/zh/theme/head.hbs
+++ b/docs/docs/zh/theme/head.hbs
@@ -1,3 +1,14 @@
+<!-- Google tag (gtag.js) -->
+<!-- Shared across docs/{en,zh} and blog/{en,zh}. Keep these four copies in sync. -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-WL7YCF91WW"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-WL7YCF91WW');
+</script>
+
 <!-- Language toggle button injected into mdBook's top menu bar. -->
 <!-- Shared across docs/{en,zh} and blog/{en,zh}. Keep these four copies in sync. -->
 <style>

--- a/docs/docs/zh/theme/head.hbs
+++ b/docs/docs/zh/theme/head.hbs
@@ -1,12 +1,14 @@
 <!-- Google tag (gtag.js) -->
-<!-- Shared across docs/{en,zh} and blog/{en,zh}. Keep these four copies in sync. -->
+<!-- Shared with docs/{docs,blog}/{en,zh}/theme/head.hbs and docs/landing/index.html. Keep these five copies in sync. -->
+<!-- Hostname-gated so local mdBook previews and fork deploys do not pollute the production GA4 property. -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-WL7YCF91WW"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
-
-  gtag('config', 'G-WL7YCF91WW');
+  if (location.hostname === 'vsag.io') {
+    gtag('config', 'G-WL7YCF91WW');
+  }
 </script>
 
 <!-- Language toggle button injected into mdBook's top menu bar. -->

--- a/docs/landing/index.html
+++ b/docs/landing/index.html
@@ -17,6 +17,16 @@
     <meta property="og:url" content="https://vsag.io/" />
     <link rel="icon" href="favicon.svg" type="image/svg+xml" />
     <link rel="stylesheet" href="style.css" />
+
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-WL7YCF91WW"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-WL7YCF91WW');
+    </script>
   </head>
   <body>
     <a class="skip" href="#main">Skip to content</a>

--- a/docs/landing/index.html
+++ b/docs/landing/index.html
@@ -2,6 +2,20 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+
+    <!-- Google tag (gtag.js) -->
+    <!-- Shared with docs/{docs,blog}/{en,zh}/theme/head.hbs. Keep these five copies in sync. -->
+    <!-- Hostname-gated so local previews and fork deploys do not pollute the production GA4 property. -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-WL7YCF91WW"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      if (location.hostname === 'vsag.io') {
+        gtag('config', 'G-WL7YCF91WW');
+      }
+    </script>
+
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>VSAG — High-performance vector indexing library</title>
     <meta
@@ -17,16 +31,6 @@
     <meta property="og:url" content="https://vsag.io/" />
     <link rel="icon" href="favicon.svg" type="image/svg+xml" />
     <link rel="stylesheet" href="style.css" />
-
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-WL7YCF91WW"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'G-WL7YCF91WW');
-    </script>
   </head>
   <body>
     <a class="skip" href="#main">Skip to content</a>


### PR DESCRIPTION
## Summary

- Add the Google Analytics 4 `gtag.js` snippet (measurement ID `G-WL7YCF91WW`) so we can track usage on https://vsag.io.
- Cover the whole site by injecting the snippet in two places:
  - `docs/landing/index.html` — the static landing page served at `vsag.io/`.
  - `docs/{docs,blog}/{en,zh}/theme/head.hbs` — picked up by mdBook and emitted into every generated page under `vsag.io/docs/{en,zh}/` and `vsag.io/blogs/{en,zh}/`.
- All four `head.hbs` files are kept byte-identical, matching the existing "Keep these four copies in sync" convention used by the language-toggle script.

## Test plan

- Build the site locally / via the existing publish workflow and confirm `gtag/js?id=G-WL7YCF91WW` appears in `<head>` on the landing page and on docs/blog pages in both languages.
- Verify in GA4 Realtime that pageviews are received from `vsag.io`.

## Labels

Please add the required labels before merging:
- `kind/documentation`
- `version/*` (target release)