### PR TITLE
fix: avoid NaN recall in HGraph duplicate range-search functest

### DIFF
--- a/tests/test_index.cpp
+++ b/tests/test_index.cpp
@@ -518,11 +518,17 @@ TestIndex::TestRangeSearch(const IndexPtr& index,
         if (limited_size > 0) {
             REQUIRE(res.value()->GetDim() <= limited_size);
         }
+        auto res_dim = res.value()->GetDim();
         auto result = res.value()->GetIds();
         auto gt = gts->GetIds() + gt_topK * i;
-        auto val = Intersection(gt, gt_topK - 1, result, res.value()->GetDim());
-        cur_recall += static_cast<float>(val) /
-                      static_cast<float>(std::min(gt_topK - 1, res.value()->GetDim()));
+        auto gt_count = std::max<int64_t>(0, gt_topK - 1);
+        auto val = Intersection(gt, gt_count, result, res_dim);
+        auto denominator = std::min(gt_count, res_dim);
+        // Skip recall calculation if denominator is 0 to avoid NaN when RangeSearch returns
+        // empty result.
+        if (denominator > 0) {
+            cur_recall += static_cast<float>(val) / static_cast<float>(denominator);
+        }
     }
     if (cur_recall <= expected_recall * query_count) {
         WARN(fmt::format("cur_result({}) <= expected_recall * query_count({})",


### PR DESCRIPTION
## Summary
Fix flaky (PR) HGraph Duplicate failures where range-search recall in test code can become NaN.

## Reproduction
In TestIndex::TestRangeSearch, recall was accumulated as:
- numerator: intersection count
- denominator: min(gt_topK - 1, res_dim)

When RangeSearch returned empty result (res_dim = 0), denominator became 0, producing 0/0 -> NaN, and the assertion failed as NaN > threshold is false.

## Root Cause
The test did not guard against zero denominator for empty range-search results.

## Fix
In tests/test_index.cpp, compute denominator first and only accumulate per-query recall when denominator > 0.

## Validation
- Local minimal reproduction confirmed original formula yields 0/0 -> NaN.
- Full project test build in this container is currently blocked by unrelated OpenBLAS build error in make debug.

Closes #1996
