### PR TITLE
test: cover vsag_c_api edge paths

### DIFF
--- a/src/vsag_c_api_test.cpp
+++ b/src/vsag_c_api_test.cpp
@@ -47,6 +47,7 @@ static constexpr const char* hgraph_search_parameters = R"(
 
 static constexpr int64_t num_vectors = 500;
 static constexpr int64_t dim = 128;
+thread_local std::string deserialize_read_func_path;
 
 class VsagTestCase {
 public:
@@ -137,8 +138,10 @@ TEST_CASE("vsag_c_api basic test", "[vsag_c_api][ut]") {
         using ReadFuncType = void (*)(OffsetType offset, SizeType size, void* data);
         ReadFuncType read_func = [](OffsetType offset, SizeType size, void* data) {
             std::ifstream ifile(path.data(), std::ios::binary);
+            REQUIRE(ifile.is_open());
             ifile.seekg(offset);
             ifile.read(reinterpret_cast<char*>(data), size);
+            REQUIRE(ifile.gcount() == static_cast<std::streamsize>(size));
             ifile.close();
         };
         vsag_index_t index2 = vsag_index_factory(index_name, index_param);
@@ -415,5 +418,220 @@ TEST_CASE("vsag_c_api update operations and get vector by ids", "[vsag_c_api][ut
         }
     }
 
+    vsag_index_destroy(index);
+}
+
+TEST_CASE("vsag_c_api null handle paths", "[vsag_c_api][ut]") {
+    VsagTestCase test_case;
+    SearchResult_t result{};
+    std::vector<int64_t> ids(3, 0);
+    std::vector<float> dists(3, 0.0F);
+    std::vector<float> vectors(3 * dim, 0.0F);
+    result.ids = ids.data();
+    result.dists = dists.data();
+
+    REQUIRE(vsag_index_destroy(nullptr).code == VSAG_SUCCESS);
+    REQUIRE(
+        vsag_index_build(nullptr, test_case.datas.data(), test_case.ids.data(), dim, num_vectors)
+            .code == VSAG_INTERNAL_ERROR);
+    REQUIRE(vsag_index_add(nullptr, test_case.datas.data(), test_case.ids.data(), dim, num_vectors)
+                .code == VSAG_SUCCESS);
+    REQUIRE(
+        vsag_index_train(nullptr, test_case.datas.data(), test_case.ids.data(), dim, num_vectors)
+            .code == VSAG_SUCCESS);
+    REQUIRE(vsag_index_knn_search(
+                nullptr, test_case.datas.data(), dim, 3, hgraph_search_parameters, &result)
+                .code == VSAG_SUCCESS);
+    REQUIRE(vsag_index_knn_search_with_filter(
+                nullptr, test_case.datas.data(), dim, 3, hgraph_search_parameters, nullptr, &result)
+                .code == VSAG_SUCCESS);
+    REQUIRE(vsag_index_range_search(
+                nullptr, test_case.datas.data(), dim, 1.0F, hgraph_search_parameters, &result)
+                .code == VSAG_SUCCESS);
+    REQUIRE(
+        vsag_index_range_search_with_filter(
+            nullptr, test_case.datas.data(), dim, 1.0F, hgraph_search_parameters, nullptr, &result)
+            .code == VSAG_SUCCESS);
+
+    vsag_index_t clone_index = nullptr;
+    REQUIRE(vsag_index_clone(nullptr, &clone_index).code == VSAG_INTERNAL_ERROR);
+    REQUIRE(clone_index == nullptr);
+
+    vsag_index_t model_index = nullptr;
+    REQUIRE(vsag_index_export_model(nullptr, &model_index).code == VSAG_INTERNAL_ERROR);
+    REQUIRE(model_index == nullptr);
+
+    REQUIRE(
+        vsag_index_calculate_distance_by_ids(
+            nullptr, test_case.datas.data(), dim, test_case.ids.data(), ids.size(), dists.data())
+            .code == VSAG_INTERNAL_ERROR);
+    REQUIRE(vsag_index_update_ids(nullptr, ids.data(), ids.data(), dim, ids.size()).code ==
+            VSAG_INTERNAL_ERROR);
+    REQUIRE(vsag_index_update_vector(nullptr, 0, test_case.datas.data(), dim).code ==
+            VSAG_INTERNAL_ERROR);
+    REQUIRE(vsag_index_update_vector_force(nullptr, 0, test_case.datas.data(), dim).code ==
+            VSAG_INTERNAL_ERROR);
+    REQUIRE(vsag_index_get_vector_by_ids(nullptr, ids.data(), ids.size(), vectors.data()).code ==
+            VSAG_INTERNAL_ERROR);
+    auto dir = fixtures::TempDir("vsag_c_api_null_test");
+    auto null_path = dir.GenerateRandomFile();
+    REQUIRE(vsag_serialize_file(nullptr, null_path.data()).code == VSAG_INTERNAL_ERROR);
+    REQUIRE(vsag_deserialize_file(nullptr, null_path.data()).code == VSAG_INTERNAL_ERROR);
+    REQUIRE(vsag_serialize_write_func(nullptr, nullptr).code == VSAG_INTERNAL_ERROR);
+    REQUIRE(vsag_deserialize_read_func(nullptr, nullptr, nullptr).code == VSAG_INTERNAL_ERROR);
+}
+
+TEST_CASE("vsag_c_api failure paths on valid index", "[vsag_c_api][ut]") {
+    auto index = vsag_index_factory(index_name, index_param);
+    REQUIRE(index != nullptr);
+
+    VsagTestCase test_case;
+    auto ret =
+        vsag_index_build(index, test_case.datas.data(), test_case.ids.data(), dim, num_vectors);
+    REQUIRE(ret.code == VSAG_SUCCESS);
+
+    std::vector<float> vectors(dim, 0.0F);
+    int64_t missing_id = 999999;
+    ret = vsag_index_get_vector_by_ids(index, &missing_id, 1, vectors.data());
+    REQUIRE(ret.code != VSAG_SUCCESS);
+
+    float dist = 0.0F;
+    ret = vsag_index_calculate_distance_by_ids(
+        index, test_case.datas.data(), dim, &missing_id, 1, &dist);
+    REQUIRE(ret.code == VSAG_SUCCESS);
+
+    int64_t existing_old_id = 3;
+    int64_t occupied_new_id = 4;
+    ret = vsag_index_update_ids(index, &existing_old_id, &occupied_new_id, dim, 1);
+    REQUIRE(ret.code != VSAG_SUCCESS);
+
+    ret = vsag_index_update_ids(index, &missing_id, &occupied_new_id, dim, 1);
+    REQUIRE(ret.code != VSAG_SUCCESS);
+
+    std::vector<float> new_vector(dim, 0.0F);
+    for (int64_t i = 0; i < dim; ++i) {
+        new_vector[i] = test_case.datas[i];
+    }
+    ret = vsag_index_update_vector(index, missing_id, new_vector.data(), dim);
+    REQUIRE(ret.code != VSAG_SUCCESS);
+    ret = vsag_index_update_vector_force(index, missing_id, new_vector.data(), dim);
+    REQUIRE(ret.code != VSAG_SUCCESS);
+
+    auto dir = fixtures::TempDir("vsag_c_api_error");
+    auto missing_path = dir.GenerateRandomFile();
+    auto index2 = vsag_index_factory(index_name, index_param);
+    REQUIRE(index2 != nullptr);
+    ret = vsag_deserialize_file(index2, missing_path.data());
+    REQUIRE(ret.code != VSAG_SUCCESS);
+    ret = vsag_deserialize_read_func(index2, nullptr, nullptr);
+    REQUIRE(ret.code != VSAG_SUCCESS);
+
+    vsag_index_destroy(index2);
+    vsag_index_destroy(index);
+}
+
+TEST_CASE("vsag_c_api search error paths", "[vsag_c_api][ut]") {
+    auto index = vsag_index_factory(index_name, index_param);
+    REQUIRE(index != nullptr);
+
+    VsagTestCase test_case;
+    auto ret =
+        vsag_index_build(index, test_case.datas.data(), test_case.ids.data(), dim, num_vectors);
+    REQUIRE(ret.code == VSAG_SUCCESS);
+
+    int64_t topk = 10;
+    std::vector<int64_t> ids(topk, -1);
+    std::vector<float> dists(topk, 0.0F);
+    SearchResult_t result{};
+    result.ids = ids.data();
+    result.dists = dists.data();
+
+    auto filter_func = [](int64_t id) -> bool { return id >= 0; };
+
+    constexpr const char* invalid_search_parameters = "not-json";
+    ret = vsag_index_knn_search(
+        index, test_case.datas.data(), dim, topk, invalid_search_parameters, &result);
+    REQUIRE(ret.code != VSAG_SUCCESS);
+
+    ret = vsag_index_knn_search_with_filter(
+        index, test_case.datas.data(), dim, topk, invalid_search_parameters, filter_func, &result);
+    REQUIRE(ret.code != VSAG_SUCCESS);
+
+    ret = vsag_index_range_search(
+        index, test_case.datas.data(), dim, 10.0F, invalid_search_parameters, &result);
+    REQUIRE(ret.code != VSAG_SUCCESS);
+
+    ret = vsag_index_range_search_with_filter(
+        index, test_case.datas.data(), dim, 10.0F, invalid_search_parameters, filter_func, &result);
+    REQUIRE(ret.code != VSAG_SUCCESS);
+
+    ret = vsag_index_knn_search(
+        index, test_case.datas.data(), dim - 1, topk, hgraph_search_parameters, &result);
+    REQUIRE(ret.code != VSAG_SUCCESS);
+
+    ret = vsag_index_range_search(
+        index, test_case.datas.data(), dim - 1, 10.0F, hgraph_search_parameters, &result);
+    REQUIRE(ret.code != VSAG_SUCCESS);
+
+    vsag_index_destroy(index);
+}
+
+TEST_CASE("vsag_c_api serialize and update edge paths", "[vsag_c_api][ut]") {
+    auto index = vsag_index_factory(index_name, index_param);
+    REQUIRE(index != nullptr);
+
+    VsagTestCase test_case;
+    auto ret =
+        vsag_index_build(index, test_case.datas.data(), test_case.ids.data(), dim, num_vectors);
+    REQUIRE(ret.code == VSAG_SUCCESS);
+
+    int64_t same_id = 42;
+    ret = vsag_index_update_ids(index, &same_id, &same_id, dim, 1);
+    REQUIRE(ret.code == VSAG_SUCCESS);
+
+    std::vector<float> vector(dim, 0.0F);
+    ret = vsag_index_get_vector_by_ids(index, &same_id, 1, vector.data());
+    REQUIRE(ret.code == VSAG_SUCCESS);
+    for (int64_t i = 0; i < dim; ++i) {
+        REQUIRE(vector[i] == test_case.datas[same_id * dim + i]);
+    }
+
+    auto dir = fixtures::TempDir("vsag_c_api_serialize_edge");
+    auto path = dir.GenerateRandomFile();
+    ret = vsag_serialize_file(index, path.data());
+    REQUIRE(ret.code == VSAG_SUCCESS);
+
+    auto non_empty_index = vsag_index_factory(index_name, index_param);
+    REQUIRE(non_empty_index != nullptr);
+    ret = vsag_index_build(
+        non_empty_index, test_case.datas.data(), test_case.ids.data(), dim, num_vectors);
+    REQUIRE(ret.code == VSAG_SUCCESS);
+
+    ret = vsag_deserialize_file(non_empty_index, path.data());
+    REQUIRE(ret.code != VSAG_SUCCESS);
+
+    deserialize_read_func_path = path;
+
+    using SizeFuncType = SizeType (*)();
+    SizeFuncType size_func = []() -> SizeType {
+        struct stat st;
+        stat(deserialize_read_func_path.data(), &st);
+        return static_cast<SizeType>(st.st_size);
+    };
+
+    using ReadFuncType = void (*)(OffsetType offset, SizeType size, void* data);
+    ReadFuncType read_func = [](OffsetType offset, SizeType size, void* data) {
+        std::ifstream ifile(deserialize_read_func_path.data(), std::ios::binary);
+        REQUIRE(ifile.is_open());
+        ifile.seekg(offset);
+        ifile.read(reinterpret_cast<char*>(data), size);
+        REQUIRE(ifile.gcount() == static_cast<std::streamsize>(size));
+        ifile.close();
+    };
+
+    ret = vsag_deserialize_read_func(non_empty_index, read_func, size_func);
+    REQUIRE(ret.code != VSAG_SUCCESS);
+
+    vsag_index_destroy(non_empty_index);
     vsag_index_destroy(index);
 }


### PR DESCRIPTION
## Summary
- add C API tests for null-handle wrapper behavior across build, search, clone, update, and serialize APIs
- add failure-path tests for invalid search parameters, missing ids, update edge cases, and deserialize-on-non-empty-index behavior
- keep production code unchanged and validate the new cases with make test CASE=[vsag_c_api]