### PR TITLE
Add SINDI analyze support

### DIFF
--- a/docs/docs/en/src/resources/analyze_index.md
+++ b/docs/docs/en/src/resources/analyze_index.md
@@ -17,9 +17,9 @@ AnalyzeIndexBySearch(const SearchRequest& request);
 
 - **Input**: a `SearchRequest` (query dataset + `topk` + search parameter JSON).
 - **Output**: a JSON-formatted string containing dynamic, query-driven metrics.
-- **Supported indexes**: currently `HGraph` and `IVF`. `Pyramid` only supports static analysis
-  through `GetStats()` — it does not yet override `AnalyzeIndexBySearch`. Indexes that do not
-  implement this API will throw an exception when called.
+- **Supported indexes**: currently `HGraph`, `IVF`, and `SINDI`. `Pyramid` only supports static
+  analysis through `GetStats()` — it does not yet override `AnalyzeIndexBySearch`. Indexes that do
+  not implement this API will throw an exception when called.
 
 It is complementary to `Index::GetStats()`, which reports static structural properties of the
 index without needing query data. For graph-based indexes, additional graph-health details such
@@ -28,28 +28,87 @@ exposed through `GetStats()` rather than through `AnalyzeIndexBySearch`.
 
 ### Static metrics from `GetStats()`
 
+#### HGraph metrics
+
 | Metric | Meaning |
 | --- | --- |
 | `total_count` | Total number of vectors in the index |
 | `deleted_count` | Vectors marked for deletion |
 | `connect_components` | Connected components in the proximity graph |
+| `maximal_component_size` | Size of the largest connected component |
+| `in_degree_distribution` | Histogram of graph in-degrees |
+| `out_degree_distribution` | Histogram of graph out-degrees |
+| `average_degree` | Average graph degree over valid nodes |
 | `duplicate_ratio` | Proportion of duplicate vectors in the dataset |
-| `avg_distance_base` | Average pairwise distance on a sample of base vectors |
-| `recall_base` | Self-recall on a sample of base vectors (sanity check) |
-| `proximity_recall_neighbor` | Recall of neighbor lists vs. the true nearest neighbors |
-| `quantization_bias_ratio` | Bias introduced by quantized distance vs. exact distance |
+| `avg_distance_base` | Average distance on sampled base vectors |
+| `recall_base` | Self-recall on sampled base vectors |
+| `time_cost_query` | Average latency when sampled base vectors are searched as queries |
+| `proximity_recall_neighbor` | Recall of graph neighbor lists against true nearest neighbors |
+| `quantization_bias_ratio` | Quantized-distance bias against exact distance |
 | `quantization_inversion_count_rate` | Rate of distance-order inversions caused by quantization |
+
+#### SINDI metrics
+
+| Metric | Meaning |
+| --- | --- |
+| `total_count` | Total number of sparse vectors in the index |
+| `window_count` | Number of SINDI windows |
+| `active_term_count.mean` / `min` / `max` | Per-window ratio of non-empty terms to term capacity |
+| `active_term_count.avg_count` | Average count of non-empty terms per window |
+| `posting_length_distribution.mean` / `max` / `p95` / `p99` | Distribution of non-empty posting-list lengths |
+| `posting_length_distribution.long_tail_threshold` | P99 posting-list length used as the long-tail threshold |
+| `posting_length_distribution.long_tail_mean` | Ratio of posting lists longer than the P99 threshold |
+| `mean_doc_retained.mean` | Average ratio of retained terms after document pruning |
+| `recall_base` | Self-recall using sampled base vectors as queries and exact sparse ground truth |
+| `doc_prune_recall` | Candidate recall from the doc-pruned index with query pruning disabled |
+| `doc_prune_bias_mean` | Average relative distance bias between doc-pruned distance and exact sparse distance |
+| `doc_prune_inversion_count_rate` | Candidate-pair order inversion rate introduced by document pruning |
+| `quantization_range.min_val` / `max_val` / `diff` | SQ8 quantization range, emitted only when quantization is enabled |
+| `quantization_recall` | Candidate recall from quantized coarse scoring, emitted only when quantization is enabled |
+| `quantization_bias_ratio` | Average relative distance bias between quantized distance and decoded doc-pruned distance |
+| `quantization_inversion_count_rate` | Candidate-pair order inversion rate introduced by quantization |
+
+Metrics that require original base vectors output a `skipped_reason` object when the data is not
+available. Original vectors are available inside the index when `use_reorder=true`; otherwise pass
+SINDI `base_path` through the analyze parameters or the command-line option described below.
 
 ### Dynamic metrics from `AnalyzeIndexBySearch`
 
-Common query-driven metrics produced by HGraph (IVF currently does **not** emit these recall /
-distance / latency fields — see below):
+#### HGraph metrics
 
 | Metric | Meaning |
 | --- | --- |
 | `recall_query` | Recall on the supplied query set against true nearest neighbors |
 | `avg_distance_query` | Average distance between query vectors and retrieved neighbors |
-| `time_cost_query` | Average per-query latency (milliseconds) |
+| `time_cost_query` | Average per-query latency in milliseconds |
+| `quantization_bias_ratio_query` | Quantization bias observed during query search |
+| `quantization_inversion_count_rate_query` | Query-time ordering errors introduced by quantization |
+
+#### SINDI metrics
+
+| Metric | Meaning |
+| --- | --- |
+| `recall_query` | Search-result recall against supplied or generated sparse ground truth |
+| `mean_latency_ms` | Average per-query latency measured while running `KnnSearch` |
+| `time_cost_query` | Alias of `mean_latency_ms`, kept consistent with other analyzers |
+| `postings_scanned.query_term_count_after_prune_mean` | Average number of query terms left after query pruning |
+| `postings_scanned.query_term_with_posting_mean` | Average number of retained query terms that hit at least one non-empty posting list |
+| `postings_scanned.posting_hit_mean` | Average hit ratio of retained query terms against non-empty posting lists |
+| `doc_prune_recall` | Recall of doc-pruned pre-rerank candidates against sparse ground truth with query pruning disabled |
+| `doc_prune_bias_mean` | Average relative distance bias between doc-pruned distance and exact sparse distance on sampled queries |
+| `doc_prune_inversion_count_rate` | Candidate-pair order inversion rate introduced by document pruning on sampled queries |
+| `quantization_recall` | Recall of quantized pre-rerank candidates, emitted only when quantization is enabled |
+| `quantization_bias_ratio` | Average relative distance bias between quantized distance and decoded doc-pruned distance |
+| `quantization_inversion_count_rate` | Candidate-pair order inversion rate introduced by quantization |
+| `reorder_recall.before_reorder_recall_k_at_k` | Recall of coarse top-k candidates before precise reorder |
+| `reorder_recall.after_reorder_recall_k_at_k` | Recall of final top-k candidates after precise reorder |
+| `last_topk_rank_in_heap.mean` / `p95` / `p99` / `max` | Rank distribution of final top-k results inside the pre-rerank candidate heap |
+
+SINDI dynamic recall and distance-quality metrics need ground truth. Pass `groundtruth_path` to
+reuse an existing `.dev.gt` file, or pass `base_path` so the analyzer can generate exact sparse
+ground truth. `save_groundtruth_path` can persist generated ground truth for later runs. Without
+ground truth, those fields return `skipped_reason`; `postings_scanned` still runs because it only
+needs the query and index postings.
 
 Quantization-related fields differ by index type — they are not unified across implementations:
 
@@ -91,11 +150,22 @@ cmake --build build-release -j
 | `--index_path` | `-i` | **Yes** | Path to the serialized VSAG index file. |
 | `--build_parameter` | `-bp` | No | Build parameters (JSON) used when reloading the index. Defaults to the parameters embedded in the index file. |
 | `--query_path` | `-qp` | No | Binary query dataset path. If omitted, only static analysis is performed. |
+| `--query_data_type` | | No | Query dataset type: `auto`, `dense`, or `sparse`. `auto` uses sparse loading for SINDI. |
+| `--base_path` | | No | Optional sparse CSR base dataset for SINDI analysis and ground-truth generation. |
+| `--groundtruth_path` | | No | Optional SINDI `.dev.gt` ground-truth file. If present, it is reused. |
+| `--save_groundtruth_path` | | No | Optional path for saving generated SINDI ground truth. |
 | `--search_parameter` | `-sp` | No | Search parameters (JSON) used during dynamic analysis. |
 | `--topk` | `-k` | No | Top-K for dynamic analysis (default `100`). |
 
 The query file format is the simple binary `(uint32 rows, uint32 cols, float32 data...)` layout
 consumed by `load_query()` in `tools/analyze_index/analyze_index.cpp`.
+
+For SINDI, query and base datasets use CSR sparse binary layout:
+`int64 nrow, int64 ncol, int64 nnz`, followed by `int64 indptr[nrow + 1]`,
+`int32 indices[nnz]`, and `float32 data[nnz]`. SINDI ground truth uses `.dev.gt` layout:
+`uint32 query_count, uint32 topk`, followed by flattened `int32 ids` and `float32 distances`.
+If `--groundtruth_path` is not provided but `--base_path` is available, SINDI analysis generates
+ground truth from the original sparse base vectors and can save it through `--save_groundtruth_path`.
 
 ### Two analysis modes
 
@@ -120,6 +190,9 @@ Reports the index name, dimension, data type, metric, build parameters, and `Get
 
 In addition to the static section, prints a `Search Analyze: { ... }` JSON block produced by
 `AnalyzeIndexBySearch`.
+
+When a serialized index only embeds `index_param`, `analyze_index` can still reload it without
+`--build_parameter`; missing metadata fields are filled with analyzer defaults where possible.
 
 ## Typical Use Cases
 

--- a/docs/docs/zh/src/resources/analyze_index.md
+++ b/docs/docs/zh/src/resources/analyze_index.md
@@ -16,8 +16,8 @@ AnalyzeIndexBySearch(const SearchRequest& request);
 
 - **输入**：`SearchRequest`（查询数据集 + `topk` + 搜索参数 JSON）。
 - **输出**：JSON 字符串，包含基于查询的动态指标。
-- **支持的索引类型**：当前支持 `HGraph` 与 `IVF`。`Pyramid` 仅通过 `GetStats()` 提供静态分析，
-  尚未 override `AnalyzeIndexBySearch`。未实现该接口的索引在调用时会抛出异常。
+- **支持的索引类型**：当前支持 `HGraph`、`IVF` 与 `SINDI`。`Pyramid` 仅通过 `GetStats()` 提供
+  静态分析，尚未 override `AnalyzeIndexBySearch`。未实现该接口的索引在调用时会抛出异常。
 
 该接口与 `Index::GetStats()` 互为补充：后者无需查询数据，只输出索引的静态结构指标。
 对于基于图的索引，度分布、入口点质量、子索引召回率以及低召回热点节点等图健康度信息，
@@ -25,27 +25,86 @@ AnalyzeIndexBySearch(const SearchRequest& request);
 
 ### `GetStats()` 输出的静态指标
 
+#### HGraph 指标
+
 | 指标 | 含义 |
 | --- | --- |
 | `total_count` | 索引中向量总数 |
 | `deleted_count` | 被标记为删除的向量数 |
 | `connect_components` | 邻近图中的连通分量数 |
+| `maximal_component_size` | 最大连通分量大小 |
+| `in_degree_distribution` | 图入度分布直方图 |
+| `out_degree_distribution` | 图出度分布直方图 |
+| `average_degree` | 有效节点的平均图度数 |
 | `duplicate_ratio` | 数据集中重复向量比例 |
 | `avg_distance_base` | 基础数据集采样向量的平均距离 |
-| `recall_base` | 基础数据集采样向量的自召回率（健康度自检） |
+| `recall_base` | 基础数据集采样向量的自召回率 |
+| `time_cost_query` | 使用采样 base 向量作为查询时的平均耗时 |
 | `proximity_recall_neighbor` | 邻居列表相对真实最近邻的召回率 |
 | `quantization_bias_ratio` | 量化距离相对精确距离的偏差比率 |
 | `quantization_inversion_count_rate` | 量化导致的距离顺序倒置比率 |
 
+#### SINDI 指标
+
+| 指标 | 含义 |
+| --- | --- |
+| `total_count` | 稀疏索引中的向量总数 |
+| `window_count` | SINDI window 数量 |
+| `active_term_count.mean` / `min` / `max` | 每个 window 中非空 term 数占 term capacity 的比例统计 |
+| `active_term_count.avg_count` | 每个 window 的平均非空 term 数 |
+| `posting_length_distribution.mean` / `max` / `p95` / `p99` | 非空 posting list 长度分布 |
+| `posting_length_distribution.long_tail_threshold` | 作为长尾阈值的 P99 posting list 长度 |
+| `posting_length_distribution.long_tail_mean` | 长度超过 P99 阈值的 posting list 比例 |
+| `mean_doc_retained.mean` | doc prune 后每个文档平均保留的 term 比例 |
+| `recall_base` | 使用采样 base 向量作为 query、基于精确 sparse 真值集计算的自召回 |
+| `doc_prune_recall` | 禁用 query prune 时，doc-pruned 索引返回候选相对真值 top-k 的召回 |
+| `doc_prune_bias_mean` | doc-pruned 距离相对原始精确 sparse 距离的平均相对偏差 |
+| `doc_prune_inversion_count_rate` | doc prune 在候选集合内导致的距离顺序倒置比例 |
+| `quantization_range.min_val` / `max_val` / `diff` | SQ8 量化范围，仅在开启量化时输出 |
+| `quantization_recall` | 量化粗筛候选相对真值 top-k 的召回，仅在开启量化时输出 |
+| `quantization_bias_ratio` | 量化距离相对解码后 doc-pruned 距离的平均相对偏差 |
+| `quantization_inversion_count_rate` | 量化在候选集合内导致的距离顺序倒置比例 |
+
+依赖原始 base 向量的 SINDI 指标在数据不可用时会输出 `skipped_reason`。当
+`use_reorder=true` 时，索引内可读取原始向量；否则需要通过 analyze 参数或下方命令行参数
+传入 SINDI `base_path`。
+
 ### `AnalyzeIndexBySearch` 输出的动态指标
 
-HGraph 输出的通用查询指标（**IVF 当前不输出** 以下召回 / 距离 / 时延字段，详见下方说明）：
+#### HGraph 指标
 
 | 指标 | 含义 |
 | --- | --- |
 | `recall_query` | 用户查询集相对真实最近邻的召回率 |
 | `avg_distance_query` | 查询向量与检索结果之间的平均距离 |
-| `time_cost_query` | 平均单次查询耗时（毫秒） |
+| `time_cost_query` | 平均单次查询耗时，单位毫秒 |
+| `quantization_bias_ratio_query` | 查询阶段观察到的量化距离偏差 |
+| `quantization_inversion_count_rate_query` | 查询阶段量化导致的距离顺序倒置率 |
+
+#### SINDI 指标
+
+| 指标 | 含义 |
+| --- | --- |
+| `recall_query` | 搜索结果相对用户提供或自动生成 sparse 真值集的召回率 |
+| `mean_latency_ms` | 调用 `KnnSearch` 时测得的平均单 query 耗时 |
+| `time_cost_query` | `mean_latency_ms` 的别名，用于和其他 analyzer 保持输出习惯一致 |
+| `postings_scanned.query_term_count_after_prune_mean` | query prune 后平均剩余 query term 数 |
+| `postings_scanned.query_term_with_posting_mean` | 剩余 query term 中平均有多少 term 命中至少一个非空 posting list |
+| `postings_scanned.posting_hit_mean` | 剩余 query term 命中非空 posting list 的平均比例 |
+| `doc_prune_recall` | 禁用 query prune 时，doc-pruned 粗筛候选相对 sparse 真值集的召回 |
+| `doc_prune_bias_mean` | 抽样 query 上 doc-pruned 距离相对原始精确 sparse 距离的平均相对偏差 |
+| `doc_prune_inversion_count_rate` | 抽样 query 上 doc prune 在候选集合内导致的顺序倒置比例 |
+| `quantization_recall` | 量化粗筛候选召回，仅在开启量化时输出 |
+| `quantization_bias_ratio` | 量化距离相对解码后 doc-pruned 距离的平均相对偏差 |
+| `quantization_inversion_count_rate` | 量化在候选集合内导致的顺序倒置比例 |
+| `reorder_recall.before_reorder_recall_k_at_k` | 精排前粗筛 top-k 候选相对真值 top-k 的召回 |
+| `reorder_recall.after_reorder_recall_k_at_k` | 精排后最终 top-k 相对真值 top-k 的召回 |
+| `last_topk_rank_in_heap.mean` / `p95` / `p99` / `max` | 最终 top-k 结果在精排前候选堆中的最差名次分布 |
+
+SINDI 动态召回和距离质量指标需要真值集。可通过 `groundtruth_path` 复用已有 `.dev.gt`，
+也可通过 `base_path` 让 analyzer 基于原始 sparse base 生成精确真值集；`save_groundtruth_path`
+可保存生成结果便于后续复用。没有可用真值集时，这些字段会输出 `skipped_reason`；
+`postings_scanned` 只依赖 query 和索引 posting，仍可正常输出。
 
 量化相关字段在不同索引下命名不一致：
 
@@ -85,11 +144,21 @@ cmake --build build-release -j
 | `--index_path` | `-i` | **是** | 待分析的 VSAG 索引文件路径。 |
 | `--build_parameter` | `-bp` | 否 | 加载索引时使用的构建参数（JSON）。默认使用索引文件内嵌的原始参数。 |
 | `--query_path` | `-qp` | 否 | 查询数据集路径。如果未提供，则只进行静态分析。 |
+| `--query_data_type` | | 否 | 查询数据类型：`auto`、`dense` 或 `sparse`。`auto` 会对 SINDI 使用 sparse 加载。 |
+| `--base_path` | | 否 | SINDI 分析可选的 sparse CSR 原始 base 数据集路径。 |
+| `--groundtruth_path` | | 否 | SINDI 可选的 `.dev.gt` 真值集路径；提供后直接复用。 |
+| `--save_groundtruth_path` | | 否 | SINDI 自动生成真值集时的可选保存路径。 |
 | `--search_parameter` | `-sp` | 否 | 动态分析时使用的搜索参数（JSON）。 |
 | `--topk` | `-k` | 否 | 动态分析的 top-K（默认 `100`）。 |
 
 查询文件格式为 `tools/analyze_index/analyze_index.cpp` 中 `load_query()` 所读取的简单二进制
 布局：`(uint32 rows, uint32 cols, float32 data...)`。
+
+SINDI 的 query/base 数据使用 CSR sparse 二进制布局：`int64 nrow, int64 ncol, int64 nnz`，
+随后是 `int64 indptr[nrow + 1]`、`int32 indices[nnz]` 和 `float32 data[nnz]`。SINDI 真值集
+使用 `.dev.gt` 布局：`uint32 query_count, uint32 topk`，随后是展开后的 `int32 ids` 与
+`float32 distances`。如果没有提供 `--groundtruth_path` 但提供了 `--base_path`，SINDI 分析会
+基于原始 sparse base 生成真值集，并可通过 `--save_groundtruth_path` 保存复用。
 
 ### 两种分析模式
 
@@ -113,6 +182,9 @@ cmake --build build-release -j
 ```
 
 除静态信息外，还会额外打印由 `AnalyzeIndexBySearch` 产出的 `Search Analyze: { ... }` JSON 块。
+
+当序列化索引只内嵌 `index_param` 时，`analyze_index` 也可以在不提供 `--build_parameter` 的情况下
+加载；缺失的 metadata 字段会尽可能使用 analyzer 默认值补齐。
 
 ## 典型使用场景
 

--- a/src/algorithm/sindi/sindi.cpp
+++ b/src/algorithm/sindi/sindi.cpp
@@ -15,6 +15,7 @@
 
 #include "sindi.h"
 
+#include "analyzer/analyzer.h"
 #include "impl/heap/standard_heap.h"
 #include "index_feature_list.h"
 #include "storage/serialization.h"
@@ -53,6 +54,35 @@ SINDI::SINDI(const SINDIParameterPtr& param, const IndexCommonParam& common_para
         rerank_param->need_sort = true;
         rerank_flat_index_ = std::make_shared<SparseIndex>(rerank_param, common_param);
     }
+}
+
+constexpr int64_t K_ANALYZE_DEFAULT_TOPK = 10;
+constexpr uint64_t K_ANALYZE_BASE_SAMPLE_SIZE = 10;
+
+std::string
+SINDI::GetStats() const {
+    AnalyzerParam analyzer_param(allocator_);
+    analyzer_param.topk = K_ANALYZE_DEFAULT_TOPK;
+    analyzer_param.base_sample_size =
+        std::min<uint64_t>(K_ANALYZE_BASE_SAMPLE_SIZE, cur_element_count_);
+    analyzer_param.search_params =
+        R"({"sindi": {"query_prune_ratio": 0, "term_prune_ratio": 0, "n_candidate": 500, "use_term_lists_heap_insert": true}})";
+    auto analyzer = CreateAnalyzer(this, analyzer_param);
+    JsonType stats = analyzer->GetStats();
+    return stats.Dump(4);
+}
+
+std::string
+SINDI::AnalyzeIndexBySearch(const SearchRequest& request) {
+    AnalyzerParam analyzer_param(allocator_);
+    analyzer_param.topk = request.topk_;
+    analyzer_param.base_sample_size =
+        std::min<uint64_t>(K_ANALYZE_BASE_SAMPLE_SIZE, cur_element_count_);
+    analyzer_param.search_params = request.params_str_;
+    auto analyzer = CreateAnalyzer(this, analyzer_param);
+    JsonType stats =
+        request.query_ == nullptr ? analyzer->GetStats() : analyzer->AnalyzeIndexBySearch(request);
+    return stats.Dump(4);
 }
 
 std::vector<int64_t>

--- a/src/algorithm/sindi/sindi.h
+++ b/src/algorithm/sindi/sindi.h
@@ -29,6 +29,8 @@ public:
     CheckAndMappingExternalParam(const JsonType& external_param,
                                  const IndexCommonParam& common_param);
 
+    friend class SINDIAnalyzer;
+
     explicit SINDI(const SINDIParameterPtr& param, const IndexCommonParam& common_param);
 
     SINDI(const ParamPtr& param, const IndexCommonParam& common_param)
@@ -48,6 +50,12 @@ public:
     GetMemoryUsageDetail() const override {
         return "";
     }
+
+    std::string
+    GetStats() const override;
+
+    std::string
+    AnalyzeIndexBySearch(const SearchRequest& request) override;
 
     std::vector<int64_t>
     Add(const DatasetPtr& base, AddMode mode = AddMode::DEFAULT) override;

--- a/src/analyzer/CMakeLists.txt
+++ b/src/analyzer/CMakeLists.txt
@@ -19,6 +19,8 @@ set (ANALYZER_SRC
         hgraph_analyzer.h
         pyramid_analyzer.cpp
         pyramid_analyzer.h
+        sindi_analyzer.cpp
+        sindi_analyzer.h
         analyzer.cpp
         analyzer.h
 )

--- a/src/analyzer/analyzer.cpp
+++ b/src/analyzer/analyzer.cpp
@@ -17,6 +17,7 @@
 
 #include "hgraph_analyzer.h"
 #include "pyramid_analyzer.h"
+#include "sindi_analyzer.h"
 
 namespace vsag {
 
@@ -34,6 +35,10 @@ CreateAnalyzer(const InnerIndexInterface* index, const AnalyzerParam& param) {
     if (dynamic_cast<Pyramid*>(index_no_const) != nullptr) {
         auto* pyramid = dynamic_cast<Pyramid*>(index_no_const);
         return std::make_shared<PyramidAnalyzer>(pyramid, param);
+    }
+    if (dynamic_cast<SINDI*>(index_no_const) != nullptr) {
+        auto* sindi = dynamic_cast<SINDI*>(index_no_const);
+        return std::make_shared<SINDIAnalyzer>(sindi, param);
     }
     throw VsagException(
         ErrorType::UNSUPPORTED_INDEX_OPERATION,

--- a/src/analyzer/sindi_analyzer.cpp
+++ b/src/analyzer/sindi_analyzer.cpp
@@ -1,0 +1,1352 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "sindi_analyzer.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <fstream>
+#include <limits>
+#include <numeric>
+#include <queue>
+#include <random>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "utils/sparse_vector_transform.h"
+
+namespace vsag {
+namespace {
+
+constexpr int64_t K_ANALYZE_DEFAULT_TOPK = 10;
+constexpr uint64_t K_ANALYZE_BASE_SAMPLE_LIMIT = 10;
+constexpr uint64_t K_ANALYZE_DOC_SAMPLE_LIMIT = 100000;
+constexpr float K_ANALYZE_EPSILON = 1e-6F;
+
+struct analyze_options {
+    std::string base_path;
+    std::string groundtruth_path;
+    std::string save_groundtruth_path;
+};
+
+JsonType
+make_skip_json(const std::string& reason) {
+    JsonType json;
+    json["skipped_reason"].SetString(reason);
+    return json;
+}
+
+float
+calculate_percentile(const std::vector<float>& sorted_values, float percentile) {
+    if (sorted_values.empty()) {
+        return 0.0F;
+    }
+    float index = percentile * static_cast<float>(sorted_values.size() - 1);
+    auto lower = static_cast<size_t>(std::floor(index));
+    auto upper = static_cast<size_t>(std::ceil(index));
+    if (lower == upper) {
+        return sorted_values[lower];
+    }
+    float weight = index - static_cast<float>(lower);
+    return sorted_values[lower] * (1.0F - weight) + sorted_values[upper] * weight;
+}
+
+JsonType
+make_distribution_stats_from_sorted(const std::vector<float>& sorted_values) {
+    JsonType json;
+    if (sorted_values.empty()) {
+        json["mean"].SetFloat(0.0F);
+        json["max"].SetFloat(0.0F);
+        json["p95"].SetFloat(0.0F);
+        json["p99"].SetFloat(0.0F);
+        return json;
+    }
+
+    float sum = std::accumulate(sorted_values.begin(), sorted_values.end(), 0.0F);
+    json["mean"].SetFloat(sum / static_cast<float>(sorted_values.size()));
+    json["max"].SetFloat(sorted_values.back());
+    json["p95"].SetFloat(calculate_percentile(sorted_values, 0.95F));
+    json["p99"].SetFloat(calculate_percentile(sorted_values, 0.99F));
+    return json;
+}
+
+JsonType
+make_distribution_stats(const std::vector<float>& values) {
+    auto sorted_values = values;
+    std::sort(sorted_values.begin(), sorted_values.end());
+    return make_distribution_stats_from_sorted(sorted_values);
+}
+
+std::streamsize
+to_stream_size(size_t bytes) {
+    return static_cast<std::streamsize>(bytes);
+}
+
+void
+release_sparse_vector(Allocator* allocator, SparseVector* vector) {
+    if (vector == nullptr || allocator == nullptr) {
+        return;
+    }
+    if (vector->ids_ != nullptr) {
+        allocator->Deallocate(vector->ids_);
+        vector->ids_ = nullptr;
+    }
+    if (vector->vals_ != nullptr) {
+        allocator->Deallocate(vector->vals_);
+        vector->vals_ = nullptr;
+    }
+    vector->len_ = 0;
+}
+
+void
+copy_sparse_vector(const SparseVector& source, SparseVector* target, Allocator* allocator) {
+    target->len_ = source.len_;
+    target->ids_ = nullptr;
+    target->vals_ = nullptr;
+    if (source.len_ == 0 || allocator == nullptr) {
+        return;
+    }
+    auto bytes = sizeof(uint32_t) * static_cast<size_t>(source.len_);
+    target->ids_ = static_cast<uint32_t*>(allocator->Allocate(bytes));
+    std::copy(source.ids_, source.ids_ + source.len_, target->ids_);
+    target->vals_ =
+        static_cast<float*>(allocator->Allocate(sizeof(float) * static_cast<size_t>(source.len_)));
+    std::copy(source.vals_, source.vals_ + source.len_, target->vals_);
+}
+
+float
+get_sparse_distance(const SparseVector& query, const SparseVector& base) {
+    float dot = 0.0F;
+    uint32_t query_idx = 0;
+    uint32_t base_idx = 0;
+    while (query_idx < query.len_ && base_idx < base.len_) {
+        if (query.ids_[query_idx] < base.ids_[base_idx]) {
+            ++query_idx;
+        } else if (query.ids_[query_idx] > base.ids_[base_idx]) {
+            ++base_idx;
+        } else {
+            dot += query.vals_[query_idx] * base.vals_[base_idx];
+            ++query_idx;
+            ++base_idx;
+        }
+    }
+    return 1.0F - dot;
+}
+
+DatasetPtr
+make_single_query_dataset(const SparseVector* query) {
+    auto dataset = Dataset::Make();
+    dataset->NumElements(1)->SparseVectors(query)->Owner(false);
+    return dataset;
+}
+
+void
+set_skip_metrics(JsonType& stats, const std::string& reason) {
+    stats["recall_base"].SetJson(make_skip_json(reason));
+    stats["doc_prune_bias_mean"].SetJson(make_skip_json(reason));
+    stats["doc_prune_inversion_count_rate"].SetJson(make_skip_json(reason));
+    stats["doc_prune_recall"].SetJson(make_skip_json(reason));
+    stats["quantization_bias_ratio"].SetJson(make_skip_json(reason));
+    stats["quantization_inversion_count_rate"].SetJson(make_skip_json(reason));
+    stats["quantization_recall"].SetJson(make_skip_json(reason));
+}
+
+int64_t
+resolve_candidate_count(const SINDISearchParameter& search_param, int64_t topk) {
+    return std::max<int64_t>(search_param.n_candidate, topk);
+}
+
+}  // namespace
+
+void
+SINDIAnalyzer::get_pruned_sparse_vector_by_inner_id(InnerIdType inner_id,
+                                                    SparseVector* data,
+                                                    Allocator* specified_allocator) const {
+    std::shared_lock rlock(sindi_->global_mutex_);
+    Allocator* allocator =
+        specified_allocator != nullptr ? specified_allocator : sindi_->allocator_;
+    auto cur_window = inner_id / sindi_->window_size_;
+    auto window_start_id = cur_window * sindi_->window_size_;
+    auto term_list = sindi_->window_term_list_[cur_window];
+    term_list->GetSparseVector(inner_id - window_start_id, data, allocator);
+    if (sindi_->remap_term_ids_ && sindi_->term_id_mapper_) {
+        for (uint32_t i = 0; i < data->len_; ++i) {
+            data->ids_[i] = sindi_->term_id_mapper_->ReverseMap(data->ids_[i]);
+        }
+    }
+}
+
+std::vector<std::pair<float, int64_t>>
+SINDIAnalyzer::collect_coarse_candidates(const SparseVector& query,
+                                         const SINDISearchParameter& search_param,
+                                         int64_t candidate_count) const {
+    std::shared_lock rlock(sindi_->global_mutex_);
+    std::vector<std::pair<float, int64_t>> coarse_candidates;
+    if (candidate_count <= 0 || query.len_ == 0) {
+        return coarse_candidates;
+    }
+
+    SparseVector effective_query = query;
+    Vector<uint32_t> tmp_ids(sindi_->allocator_);
+    Vector<float> tmp_vals(sindi_->allocator_);
+    if (sindi_->remap_term_ids_) {
+        effective_query = sindi_->remap_sparse_vector_for_query(query, tmp_ids, tmp_vals);
+        if (effective_query.len_ == 0) {
+            return coarse_candidates;
+        }
+    }
+
+    InnerSearchParam inner_param;
+    inner_param.ef = candidate_count;
+    inner_param.topk = candidate_count;
+    MaxHeap heap(sindi_->allocator_);
+    auto computer =
+        std::make_shared<SparseTermComputer>(effective_query, search_param, sindi_->allocator_);
+
+    Vector<float> dists(sindi_->window_size_, 0.0F, sindi_->allocator_);
+    for (int64_t cur = 0; cur < static_cast<int64_t>(sindi_->window_term_list_.size()); ++cur) {
+        auto window_start_id = static_cast<uint32_t>(cur * sindi_->window_size_);
+        auto term_list = sindi_->window_term_list_[cur];
+        term_list->Query(dists.data(), computer);
+        if (search_param.use_term_lists_heap_insert) {
+            term_list->InsertHeapByTermLists<KNN_SEARCH, PURE>(
+                dists.data(), computer, heap, inner_param, window_start_id);
+        } else {
+            term_list->InsertHeapByDists<KNN_SEARCH, PURE>(
+                dists.data(), dists.size(), heap, inner_param, window_start_id);
+        }
+    }
+
+    coarse_candidates.resize(heap.size());
+    for (int64_t idx = static_cast<int64_t>(heap.size()) - 1; idx >= 0; --idx) {
+        coarse_candidates[idx] = {1.0F + heap.top().first,
+                                  sindi_->label_table_->GetLabelById(heap.top().second)};
+        heap.pop();
+    }
+    return coarse_candidates;
+}
+
+std::vector<std::pair<float, int64_t>>
+SINDIAnalyzer::collect_doc_prune_candidates(const SparseVector& query,
+                                            const SINDISearchParameter& search_param,
+                                            int64_t candidate_count) const {
+    std::shared_lock rlock(sindi_->global_mutex_);
+    std::vector<std::pair<float, int64_t>> doc_prune_candidates;
+    if (candidate_count <= 0 || query.len_ == 0) {
+        return doc_prune_candidates;
+    }
+
+    SparseVector effective_query = query;
+    Vector<uint32_t> tmp_ids(sindi_->allocator_);
+    Vector<float> tmp_vals(sindi_->allocator_);
+    if (sindi_->remap_term_ids_) {
+        effective_query = sindi_->remap_sparse_vector_for_query(query, tmp_ids, tmp_vals);
+        if (effective_query.len_ == 0) {
+            return doc_prune_candidates;
+        }
+    }
+
+    InnerSearchParam inner_param;
+    inner_param.ef = candidate_count;
+    inner_param.topk = candidate_count;
+    MaxHeap heap(sindi_->allocator_);
+    auto computer =
+        std::make_shared<SparseTermComputer>(effective_query, search_param, sindi_->allocator_);
+
+    Vector<float> dists(sindi_->window_size_, 0.0F, sindi_->allocator_);
+    Vector<float> decoded_values(sindi_->allocator_);
+
+    for (int64_t cur = 0; cur < static_cast<int64_t>(sindi_->window_term_list_.size()); ++cur) {
+        auto window_start_id = static_cast<uint32_t>(cur * sindi_->window_size_);
+        auto term_list = sindi_->window_term_list_[cur];
+        if (term_list == nullptr) {
+            continue;
+        }
+        std::fill(dists.begin(), dists.end(), 0.0F);
+
+        while (computer->HasNextTerm()) {
+            auto term_idx = computer->NextTermIter();
+            auto term = computer->GetTerm(term_idx);
+            if (term >= term_list->term_sizes_.size() || term_list->term_sizes_[term] == 0) {
+                continue;
+            }
+            auto term_size = static_cast<uint32_t>(
+                static_cast<float>(term_list->term_sizes_[term]) * computer->term_retain_ratio_);
+            if (term_size == 0) {
+                continue;
+            }
+
+            if (term_list->use_quantization_) {
+                decoded_values.resize(term_size);
+                term_list->Decode(
+                    term_list->term_datas_[term]->data(), term_size, decoded_values.data());
+                computer->ScanForAccumulate(term_idx,
+                                            term_list->term_ids_[term]->data(),
+                                            decoded_values.data(),
+                                            term_size,
+                                            dists.data());
+            } else {
+                computer->ScanForAccumulate(
+                    term_idx,
+                    term_list->term_ids_[term]->data(),
+                    reinterpret_cast<const float*>(term_list->term_datas_[term]->data()),
+                    term_size,
+                    dists.data());
+            }
+        }
+        computer->ResetTerm();
+
+        if (search_param.use_term_lists_heap_insert) {
+            term_list->InsertHeapByTermLists<KNN_SEARCH, PURE>(
+                dists.data(), computer, heap, inner_param, window_start_id);
+        } else {
+            term_list->InsertHeapByDists<KNN_SEARCH, PURE>(
+                dists.data(), dists.size(), heap, inner_param, window_start_id);
+        }
+    }
+
+    doc_prune_candidates.resize(heap.size());
+    for (int64_t idx = static_cast<int64_t>(heap.size()) - 1; idx >= 0; --idx) {
+        doc_prune_candidates[idx] = {1.0F + heap.top().first,
+                                     sindi_->label_table_->GetLabelById(heap.top().second)};
+        heap.pop();
+    }
+    return doc_prune_candidates;
+}
+
+std::vector<std::pair<float, int64_t>>
+SINDIAnalyzer::rerank_candidates(const SparseVector& query,
+                                 const std::vector<std::pair<float, int64_t>>& coarse_candidates,
+                                 int64_t topk) const {
+    std::vector<std::pair<float, int64_t>> reranked;
+    if (not sindi_->use_reorder_ || coarse_candidates.empty() || topk <= 0) {
+        return reranked;
+    }
+    reranked.reserve(coarse_candidates.size());
+    for (const auto& coarse : coarse_candidates) {
+        auto exact_dist = calculate_exact_distance_by_label(query, coarse.second);
+        reranked.emplace_back(exact_dist, coarse.second);
+    }
+    std::sort(reranked.begin(), reranked.end(), [](const auto& left, const auto& right) {
+        if (std::abs(left.first - right.first) > K_ANALYZE_EPSILON) {
+            return left.first < right.first;
+        }
+        return left.second < right.second;
+    });
+    if (static_cast<int64_t>(reranked.size()) > topk) {
+        reranked.resize(static_cast<size_t>(topk));
+    }
+    return reranked;
+}
+
+bool
+SINDIAnalyzer::get_original_sparse_vector_by_inner_id(InnerIdType inner_id,
+                                                      SparseVector* data,
+                                                      Allocator* specified_allocator,
+                                                      const DatasetPtr& base_dataset) const {
+    Allocator* allocator =
+        specified_allocator != nullptr ? specified_allocator : sindi_->allocator_;
+    if (allocator == nullptr) {
+        return false;
+    }
+    if (sindi_->use_reorder_) {
+        sindi_->GetSparseVectorByInnerId(inner_id, data, allocator);
+        return true;
+    }
+    if (base_dataset == nullptr || base_dataset->GetSparseVectors() == nullptr ||
+        inner_id >= base_dataset->GetNumElements()) {
+        return false;
+    }
+    copy_sparse_vector(base_dataset->GetSparseVectors()[inner_id], data, allocator);
+    return true;
+}
+
+float
+SINDIAnalyzer::calculate_exact_distance_by_label(const SparseVector& query,
+                                                 int64_t label,
+                                                 const DatasetPtr& base_dataset) const {
+    auto inner_id = sindi_->label_table_->GetIdByLabel(label);
+    SparseVector original{};
+    if (not get_original_sparse_vector_by_inner_id(
+            inner_id, &original, sindi_->allocator_, base_dataset)) {
+        return std::numeric_limits<float>::max();
+    }
+    auto distance = get_sparse_distance(query, original);
+    release_sparse_vector(sindi_->allocator_, &original);
+    return distance;
+}
+
+float
+SINDIAnalyzer::calculate_pruned_distance_by_label(const SparseVector& query, int64_t label) const {
+    auto inner_id = sindi_->label_table_->GetIdByLabel(label);
+    SparseVector pruned{};
+    get_pruned_sparse_vector_by_inner_id(inner_id, &pruned, sindi_->allocator_);
+    auto distance = get_sparse_distance(query, pruned);
+    release_sparse_vector(sindi_->allocator_, &pruned);
+    return distance;
+}
+
+DatasetPtr
+SINDIAnalyzer::calculate_ground_truth(const DatasetPtr& query_dataset,
+                                      int64_t topk,
+                                      const DatasetPtr& base_dataset) const {
+    if (query_dataset == nullptr || query_dataset->GetSparseVectors() == nullptr || topk <= 0) {
+        return nullptr;
+    }
+    if (not sindi_->use_reorder_ &&
+        (base_dataset == nullptr || base_dataset->GetSparseVectors() == nullptr)) {
+        return nullptr;
+    }
+
+    auto query_count = query_dataset->GetNumElements();
+    auto base_count =
+        base_dataset == nullptr ? sindi_->cur_element_count_ : base_dataset->GetNumElements();
+    auto effective_topk = std::min<int64_t>(topk, base_count);
+    if (effective_topk <= 0) {
+        return nullptr;
+    }
+
+    auto* ids = static_cast<int64_t*>(sindi_->allocator_->Allocate(
+        sizeof(int64_t) * static_cast<size_t>(query_count) * effective_topk));
+    auto* distances = static_cast<float*>(sindi_->allocator_->Allocate(
+        sizeof(float) * static_cast<size_t>(query_count) * effective_topk));
+
+    for (int64_t query_idx = 0; query_idx < query_count; ++query_idx) {
+        std::priority_queue<std::pair<float, int64_t>> heap;
+        const auto& query = query_dataset->GetSparseVectors()[query_idx];
+        for (int64_t base_idx = 0; base_idx < base_count; ++base_idx) {
+            SparseVector original{};
+            const SparseVector* base_vector = nullptr;
+            if (base_dataset != nullptr && base_dataset->GetSparseVectors() != nullptr) {
+                base_vector = base_dataset->GetSparseVectors() + base_idx;
+            } else {
+                sindi_->GetSparseVectorByInnerId(base_idx, &original, sindi_->allocator_);
+                base_vector = &original;
+            }
+
+            auto label = base_dataset != nullptr && base_dataset->GetIds() != nullptr
+                             ? base_dataset->GetIds()[base_idx]
+                             : sindi_->label_table_->GetLabelById(base_idx);
+            heap.emplace(get_sparse_distance(query, *base_vector), label);
+            if (static_cast<int64_t>(heap.size()) > effective_topk) {
+                heap.pop();
+            }
+            release_sparse_vector(sindi_->allocator_, &original);
+        }
+
+        for (int64_t rank = effective_topk - 1; rank >= 0; --rank) {
+            auto offset = static_cast<size_t>(query_idx) * effective_topk + rank;
+            ids[offset] = heap.top().second;
+            distances[offset] = heap.top().first;
+            heap.pop();
+        }
+    }
+
+    auto ground_truth = Dataset::Make();
+    ground_truth->NumElements(query_count)
+        ->Dim(effective_topk)
+        ->Ids(ids)
+        ->Distances(distances)
+        ->Owner(true, sindi_->allocator_);
+    return ground_truth;
+}
+
+namespace {
+
+JsonType
+parse_sindi_search_json(const std::string& params_str) {
+    JsonType json;
+    if (params_str.empty() || params_str == "default") {
+        json[INDEX_SINDI].SetJson(JsonType());
+        return json;
+    }
+    json = JsonType::Parse(params_str);
+    if (not json.Contains(INDEX_SINDI)) {
+        json[INDEX_SINDI].SetJson(JsonType());
+    }
+    return json;
+}
+
+analyze_options
+parse_analyze_options(const JsonType& json) {
+    analyze_options options;
+    if (not json.Contains("analyze")) {
+        return options;
+    }
+    auto analyze = json["analyze"];
+    if (analyze.Contains("base_path")) {
+        options.base_path = analyze["base_path"].GetString();
+    }
+    if (analyze.Contains("groundtruth_path")) {
+        options.groundtruth_path = analyze["groundtruth_path"].GetString();
+    }
+    if (analyze.Contains("save_groundtruth_path")) {
+        options.save_groundtruth_path = analyze["save_groundtruth_path"].GetString();
+    }
+    return options;
+}
+
+DatasetPtr
+load_sparse_dataset(const std::string& file_path) {
+    std::fstream in_stream(file_path, std::ios::binary | std::ios::in);
+    if (not in_stream.is_open()) {
+        logger::warn("Failed to open sparse dataset file: {}", file_path);
+        return nullptr;
+    }
+
+    int64_t rows = 0;
+    int64_t cols = 0;
+    int64_t nnz = 0;
+    in_stream.read(reinterpret_cast<char*>(&rows), sizeof(rows));
+    in_stream.read(reinterpret_cast<char*>(&cols), sizeof(cols));
+    in_stream.read(reinterpret_cast<char*>(&nnz), sizeof(nnz));
+    if (rows < 0 || cols < 0 || nnz < 0) {
+        logger::warn("Invalid sparse dataset header in file: {}", file_path);
+        return nullptr;
+    }
+
+    std::vector<int64_t> indptr(static_cast<size_t>(rows) + 1);
+    std::vector<int32_t> indices(static_cast<size_t>(nnz));
+    std::vector<float> values(static_cast<size_t>(nnz));
+
+    in_stream.read(reinterpret_cast<char*>(indptr.data()),
+                   to_stream_size(sizeof(int64_t) * (static_cast<size_t>(rows) + 1)));
+    in_stream.read(reinterpret_cast<char*>(indices.data()),
+                   to_stream_size(sizeof(int32_t) * static_cast<size_t>(nnz)));
+    in_stream.read(reinterpret_cast<char*>(values.data()),
+                   to_stream_size(sizeof(float) * static_cast<size_t>(nnz)));
+    if (not in_stream.good()) {
+        logger::warn("Failed to read sparse dataset CSR arrays from file: {}", file_path);
+        return nullptr;
+    }
+
+    if (indptr[0] != 0 || indptr[static_cast<size_t>(rows)] != nnz) {
+        logger::warn("Invalid sparse dataset indptr bounds in file: {}", file_path);
+        return nullptr;
+    }
+    for (int64_t row = 0; row < rows; ++row) {
+        if (indptr[static_cast<size_t>(row)] > indptr[static_cast<size_t>(row + 1)] ||
+            indptr[static_cast<size_t>(row)] < 0 || indptr[static_cast<size_t>(row + 1)] > nnz) {
+            logger::warn("Invalid sparse dataset indptr monotonicity in file: {}", file_path);
+            return nullptr;
+        }
+    }
+    for (int64_t offset = 0; offset < nnz; ++offset) {
+        if (indices[static_cast<size_t>(offset)] < 0 ||
+            indices[static_cast<size_t>(offset)] >= cols) {
+            logger::warn("Invalid sparse dataset column index in file: {}", file_path);
+            return nullptr;
+        }
+    }
+
+    auto* sparse_vectors = new SparseVector[static_cast<size_t>(rows)];
+
+    for (int64_t row = 0; row < rows; ++row) {
+        auto begin = indptr[static_cast<size_t>(row)];
+        auto end = indptr[static_cast<size_t>(row + 1)];
+        auto len = end - begin;
+        sparse_vectors[row].len_ = static_cast<uint32_t>(len);
+        sparse_vectors[row].ids_ = new uint32_t[static_cast<size_t>(len)];
+        sparse_vectors[row].vals_ = new float[static_cast<size_t>(len)];
+        for (int64_t offset = 0; offset < len; ++offset) {
+            auto value_offset = static_cast<size_t>(begin + offset);
+            sparse_vectors[row].ids_[offset] = static_cast<uint32_t>(indices[value_offset]);
+            sparse_vectors[row].vals_[offset] = values[value_offset];
+        }
+    }
+
+    auto dataset = Dataset::Make();
+    dataset->SparseVectors(sparse_vectors)->Owner(true)->NumElements(rows)->Dim(cols);
+    return dataset;
+}
+
+void
+check_base_dataset_for_analyze(const DatasetPtr& base_dataset, int64_t expected_count) {
+    CHECK_ARGUMENT(base_dataset != nullptr, "SINDI analyze requires valid sparse base dataset");
+    CHECK_ARGUMENT(base_dataset->GetSparseVectors() != nullptr,
+                   "SINDI analyze requires valid sparse base dataset");
+    CHECK_ARGUMENT(base_dataset->GetNumElements() == expected_count,
+                   "SINDI analyze base dataset count mismatch with index element count");
+}
+
+DatasetPtr
+load_ground_truth(const std::string& file_path) {
+    std::fstream in_stream(file_path, std::ios::binary | std::ios::in);
+    if (not in_stream.is_open()) {
+        logger::warn("Failed to open ground truth file: {}", file_path);
+        return nullptr;
+    }
+
+    uint32_t rows = 0;
+    uint32_t dim = 0;
+    in_stream.read(reinterpret_cast<char*>(&rows), sizeof(rows));
+    in_stream.read(reinterpret_cast<char*>(&dim), sizeof(dim));
+    if (not in_stream.good()) {
+        logger::warn("Failed to read ground truth header from file: {}", file_path);
+        return nullptr;
+    }
+    if (dim != 0 && rows > std::numeric_limits<size_t>::max() / dim) {
+        logger::warn("Invalid ground truth shape in file: {}", file_path);
+        return nullptr;
+    }
+    auto total = static_cast<size_t>(rows) * dim;
+    std::vector<int32_t> ids32(total);
+    std::vector<float> distance_buffer(total);
+    in_stream.read(reinterpret_cast<char*>(ids32.data()), to_stream_size(sizeof(int32_t) * total));
+    in_stream.read(reinterpret_cast<char*>(distance_buffer.data()),
+                   to_stream_size(sizeof(float) * total));
+    if (not in_stream.good()) {
+        logger::warn("Failed to read ground truth payload from file: {}", file_path);
+        return nullptr;
+    }
+
+    auto* ids64 = new int64_t[total];
+    auto* distances = new float[total];
+    for (size_t i = 0; i < total; ++i) {
+        ids64[i] = ids32[i];
+        distances[i] = distance_buffer[i];
+    }
+
+    auto dataset = Dataset::Make();
+    dataset->NumElements(rows)->Dim(dim)->Ids(ids64)->Distances(distances)->Owner(true);
+    return dataset;
+}
+
+bool
+save_ground_truth(const std::string& file_path, const DatasetPtr& ground_truth) {
+    if (file_path.empty() || ground_truth == nullptr) {
+        return false;
+    }
+    std::fstream out_stream(file_path, std::ios::binary | std::ios::out | std::ios::trunc);
+    if (not out_stream.is_open()) {
+        logger::warn("Failed to write ground truth file: {}", file_path);
+        return false;
+    }
+    if (ground_truth->GetNumElements() < 0 || ground_truth->GetDim() < 0 ||
+        ground_truth->GetNumElements() > std::numeric_limits<uint32_t>::max() ||
+        ground_truth->GetDim() > std::numeric_limits<uint32_t>::max()) {
+        logger::warn("Ground truth shape exceeds file format limits for file: {}", file_path);
+        return false;
+    }
+    auto rows = static_cast<uint32_t>(ground_truth->GetNumElements());
+    auto dim = static_cast<uint32_t>(ground_truth->GetDim());
+    auto total = static_cast<size_t>(rows) * dim;
+    if (ground_truth->GetIds() == nullptr || ground_truth->GetDistances() == nullptr) {
+        logger::warn("Invalid ground truth dataset for file: {}", file_path);
+        return false;
+    }
+    std::vector<int32_t> ids(total);
+    for (size_t i = 0; i < total; ++i) {
+        if (ground_truth->GetIds()[i] < std::numeric_limits<int32_t>::min() ||
+            ground_truth->GetIds()[i] > std::numeric_limits<int32_t>::max()) {
+            logger::warn("Ground truth id exceeds int32 range for file: {}", file_path);
+            return false;
+        }
+        ids[i] = static_cast<int32_t>(ground_truth->GetIds()[i]);
+    }
+    out_stream.write(reinterpret_cast<const char*>(&rows), sizeof(rows));
+    out_stream.write(reinterpret_cast<const char*>(&dim), sizeof(dim));
+    out_stream.write(reinterpret_cast<const char*>(ids.data()),
+                     to_stream_size(sizeof(int32_t) * total));
+    out_stream.write(reinterpret_cast<const char*>(ground_truth->GetDistances()),
+                     to_stream_size(sizeof(float) * total));
+    return out_stream.good();
+}
+
+float
+calculate_recall(const int64_t* result_ids,
+                 int64_t result_dim,
+                 const int64_t* gt_ids,
+                 int64_t topk) {
+    if (topk == 0) {
+        return 0.0F;
+    }
+    std::unordered_set<int64_t> gt_set;
+    gt_set.reserve(static_cast<size_t>(topk));
+    for (int64_t i = 0; i < topk; ++i) {
+        gt_set.insert(gt_ids[i]);
+    }
+    int64_t hit_count = 0;
+    for (int64_t i = 0; i < result_dim; ++i) {
+        if (gt_set.count(result_ids[i]) != 0) {
+            ++hit_count;
+        }
+    }
+    return static_cast<float>(hit_count) / static_cast<float>(topk);
+}
+
+float
+calculate_candidate_recall(const std::vector<std::pair<float, int64_t>>& candidates,
+                           const int64_t* gt_ids,
+                           int64_t topk,
+                           int64_t candidate_limit) {
+    auto count = static_cast<int64_t>(candidates.size());
+    if (candidate_limit >= 0) {
+        count = std::min(count, candidate_limit);
+    }
+    std::vector<int64_t> candidate_ids;
+    candidate_ids.reserve(static_cast<size_t>(count));
+    for (int64_t idx = 0; idx < count; ++idx) {
+        candidate_ids.push_back(candidates[idx].second);
+    }
+    return calculate_recall(candidate_ids.data(), count, gt_ids, topk);
+}
+
+}  // namespace
+
+JsonType
+SINDIAnalyzer::get_active_term_count_stats() const {
+    std::vector<float> active_means;
+    std::vector<float> active_counts;
+    active_means.reserve(sindi_->window_term_list_.size());
+    active_counts.reserve(sindi_->window_term_list_.size());
+
+    for (const auto& window : sindi_->window_term_list_) {
+        if (window == nullptr) {
+            continue;
+        }
+        float active_count = 0.0F;
+        for (uint32_t term_size : window->term_sizes_) {
+            if (term_size > 0) {
+                active_count += 1.0F;
+            }
+        }
+        active_counts.push_back(active_count);
+        auto denominator = static_cast<float>(std::max(1U, window->term_capacity_));
+        active_means.push_back(active_count / denominator);
+    }
+
+    JsonType stats;
+    if (active_means.empty()) {
+        stats["mean"].SetFloat(0.0F);
+        stats["min"].SetFloat(0.0F);
+        stats["max"].SetFloat(0.0F);
+        stats["avg_count"].SetFloat(0.0F);
+        return stats;
+    }
+
+    float ratio_sum = std::accumulate(active_means.begin(), active_means.end(), 0.0F);
+    float count_sum = std::accumulate(active_counts.begin(), active_counts.end(), 0.0F);
+    stats["mean"].SetFloat(ratio_sum / static_cast<float>(active_means.size()));
+    stats["min"].SetFloat(*std::min_element(active_means.begin(), active_means.end()));
+    stats["max"].SetFloat(*std::max_element(active_means.begin(), active_means.end()));
+    stats["avg_count"].SetFloat(count_sum / static_cast<float>(active_counts.size()));
+    return stats;
+}
+
+JsonType
+SINDIAnalyzer::calculate_recall_stats(const DatasetPtr& query_dataset,
+                                      const DatasetPtr& ground_truth,
+                                      const SINDISearchParameter& search_param,
+                                      int64_t topk) const {
+    JsonType stats;
+    if (query_dataset == nullptr || query_dataset->GetSparseVectors() == nullptr ||
+        ground_truth == nullptr || ground_truth->GetIds() == nullptr || topk <= 0) {
+        auto skip = make_skip_json("ground truth unavailable");
+        stats["recall_query"].SetJson(skip);
+        stats["mean_latency_ms"].SetJson(skip);
+        stats["doc_prune_recall"].SetJson(skip);
+        stats["quantization_recall"].SetJson(skip);
+        return stats;
+    }
+
+    auto query_count = query_dataset->GetNumElements();
+    float recall_sum = 0.0F;
+    float doc_prune_recall_sum = 0.0F;
+    float quantization_recall_sum = 0.0F;
+    double total_latency_ms = 0.0;
+    auto search_param_str = search_param.ToJson().Dump();
+    SINDISearchParameter no_query_prune_param = search_param;
+    no_query_prune_param.query_prune_ratio = 0.0F;
+
+    for (int64_t query_idx = 0; query_idx < query_count; ++query_idx) {
+        auto single_query =
+            make_single_query_dataset(query_dataset->GetSparseVectors() + query_idx);
+        auto start = std::chrono::high_resolution_clock::now();
+        auto search_result = sindi_->KnnSearch(single_query, topk, search_param_str, nullptr);
+        auto end = std::chrono::high_resolution_clock::now();
+        total_latency_ms += std::chrono::duration<double, std::milli>(end - start).count();
+        recall_sum += calculate_recall(search_result->GetIds(),
+                                       search_result->GetDim(),
+                                       ground_truth->GetIds() + query_idx * ground_truth->GetDim(),
+                                       topk);
+
+        const auto& query = query_dataset->GetSparseVectors()[query_idx];
+        auto candidate_count = resolve_candidate_count(no_query_prune_param, topk);
+        auto doc_prune_candidates =
+            collect_doc_prune_candidates(query, no_query_prune_param, candidate_count);
+        auto doc_prune_recall =
+            calculate_candidate_recall(doc_prune_candidates,
+                                       ground_truth->GetIds() + query_idx * ground_truth->GetDim(),
+                                       topk,
+                                       -1);
+        doc_prune_recall_sum += doc_prune_recall;
+        if (sindi_->use_quantization_) {
+            auto quantization_candidates =
+                collect_coarse_candidates(query, no_query_prune_param, candidate_count);
+            quantization_recall_sum += calculate_candidate_recall(
+                quantization_candidates,
+                ground_truth->GetIds() + query_idx * ground_truth->GetDim(),
+                topk,
+                -1);
+        }
+    }
+
+    auto denominator = static_cast<float>(std::max<int64_t>(1, query_count));
+    stats["recall_query"].SetFloat(recall_sum / denominator);
+    stats["doc_prune_recall"].SetFloat(doc_prune_recall_sum / denominator);
+    if (sindi_->use_quantization_) {
+        stats["quantization_recall"].SetFloat(quantization_recall_sum / denominator);
+    } else {
+        stats["quantization_recall"].SetJson(make_skip_json("quantization disabled"));
+    }
+    stats["mean_latency_ms"].SetFloat(static_cast<float>(total_latency_ms) / denominator);
+    return stats;
+}
+
+JsonType
+SINDIAnalyzer::calculate_postings_scanned_stats(const DatasetPtr& query_dataset,
+                                                const SINDISearchParameter& search_param) const {
+    if (query_dataset == nullptr || query_dataset->GetSparseVectors() == nullptr) {
+        return make_skip_json("query dataset unavailable");
+    }
+
+    float pruned_term_sum = 0.0F;
+    float term_hit_sum = 0.0F;
+    float posting_hit_mean_sum = 0.0F;
+    for (int64_t query_idx = 0; query_idx < query_dataset->GetNumElements(); ++query_idx) {
+        const auto& query = query_dataset->GetSparseVectors()[query_idx];
+        Vector<std::pair<uint32_t, float>> sorted_terms(sindi_->allocator_);
+        sort_sparse_vector(query, sorted_terms);
+        auto pruned_len = static_cast<uint32_t>((1.0F - search_param.query_prune_ratio) *
+                                                static_cast<float>(query.len_));
+        if (pruned_len == 0 && query.len_ > 0) {
+            pruned_len = 1;
+        }
+        pruned_term_sum += static_cast<float>(pruned_len);
+
+        uint32_t hit_term_count = 0;
+        for (uint32_t term_idx = 0; term_idx < pruned_len && term_idx < sorted_terms.size();
+             ++term_idx) {
+            auto term = sorted_terms[term_idx].first;
+            if (sindi_->remap_term_ids_) {
+                auto compact = sindi_->term_id_mapper_->TryMap(term);
+                if (not compact.has_value()) {
+                    continue;
+                }
+                term = compact.value();
+            }
+            bool has_posting = false;
+            for (const auto& window : sindi_->window_term_list_) {
+                if (window != nullptr && term < window->term_sizes_.size() &&
+                    window->term_sizes_[term] > 0) {
+                    has_posting = true;
+                    break;
+                }
+            }
+            if (has_posting) {
+                ++hit_term_count;
+            }
+        }
+        term_hit_sum += static_cast<float>(hit_term_count);
+        posting_hit_mean_sum +=
+            pruned_len == 0 ? 0.0F
+                            : static_cast<float>(hit_term_count) / static_cast<float>(pruned_len);
+    }
+
+    JsonType stats;
+    auto denominator = static_cast<float>(std::max<int64_t>(1, query_dataset->GetNumElements()));
+    stats["query_term_count_after_prune_mean"].SetFloat(pruned_term_sum / denominator);
+    stats["query_term_with_posting_mean"].SetFloat(term_hit_sum / denominator);
+    stats["posting_hit_mean"].SetFloat(posting_hit_mean_sum / denominator);
+    return stats;
+}
+
+JsonType
+SINDIAnalyzer::get_base_search_stats(const std::string& search_param,
+                                     const DatasetPtr& base_dataset) const {
+    JsonType stats;
+    if (not sindi_->use_reorder_ &&
+        (base_dataset == nullptr || base_dataset->GetSparseVectors() == nullptr)) {
+        set_skip_metrics(
+            stats,
+            "requires original base vectors; provide --base_path or rebuild with use_reorder=true");
+        return stats;
+    }
+
+    std::vector<InnerIdType> sample_ids(static_cast<size_t>(sindi_->cur_element_count_));
+    std::iota(sample_ids.begin(), sample_ids.end(), 0);
+    std::random_device rd;
+    std::mt19937 rng(rd());
+    std::shuffle(sample_ids.begin(), sample_ids.end(), rng);
+
+    auto sample_count = std::min<uint64_t>(sample_ids.size(), K_ANALYZE_BASE_SAMPLE_LIMIT);
+    if (sample_count == 0) {
+        set_skip_metrics(stats, "empty index");
+        return stats;
+    }
+
+    auto* queries = static_cast<SparseVector*>(
+        sindi_->allocator_->Allocate(sizeof(SparseVector) * sample_count));
+    for (uint64_t idx = 0; idx < sample_count; ++idx) {
+        new (queries + idx) SparseVector{};
+        get_original_sparse_vector_by_inner_id(
+            sample_ids[idx], queries + idx, sindi_->allocator_, base_dataset);
+    }
+    auto query_dataset = Dataset::Make();
+    query_dataset->SparseVectors(queries)
+        ->NumElements(static_cast<int64_t>(sample_count))
+        ->Owner(true, sindi_->allocator_)
+        ->Dim(sindi_->dim_);
+
+    auto search_json = parse_sindi_search_json(search_param);
+    SINDISearchParameter parsed_search_param;
+    parsed_search_param.FromJson(search_json);
+    auto ground_truth = calculate_ground_truth(query_dataset, K_ANALYZE_DEFAULT_TOPK, base_dataset);
+    auto recall_stats = calculate_recall_stats(
+        query_dataset, ground_truth, parsed_search_param, K_ANALYZE_DEFAULT_TOPK);
+    if (recall_stats.Contains("recall_query")) {
+        stats["recall_base"].SetJson(recall_stats["recall_query"]);
+    }
+    if (recall_stats.Contains("doc_prune_recall")) {
+        stats["doc_prune_recall"].SetJson(recall_stats["doc_prune_recall"]);
+    }
+    if (recall_stats.Contains("quantization_recall")) {
+        stats["quantization_recall"].SetJson(recall_stats["quantization_recall"]);
+    }
+
+    auto quality_stats = calculate_distance_quality_stats(
+        query_dataset, parsed_search_param, base_dataset, K_ANALYZE_DEFAULT_TOPK);
+    for (const auto& key : {"doc_prune_bias_mean",
+                            "doc_prune_inversion_count_rate",
+                            "quantization_bias_ratio",
+                            "quantization_inversion_count_rate"}) {
+        if (quality_stats.Contains(key)) {
+            stats[key].SetJson(quality_stats[key]);
+        }
+    }
+    return stats;
+}
+
+JsonType
+SINDIAnalyzer::get_posting_length_distribution_stats() const {
+    std::vector<float> posting_lengths;
+    for (const auto& window : sindi_->window_term_list_) {
+        if (window == nullptr) {
+            continue;
+        }
+        for (uint32_t term_size : window->term_sizes_) {
+            if (term_size > 0) {
+                posting_lengths.push_back(static_cast<float>(term_size));
+            }
+        }
+    }
+
+    if (posting_lengths.empty()) {
+        return make_skip_json("no non-empty posting lists");
+    }
+
+    std::sort(posting_lengths.begin(), posting_lengths.end());
+    JsonType posting_stats = make_distribution_stats_from_sorted(posting_lengths);
+    float threshold = calculate_percentile(posting_lengths, 0.99F);
+    auto long_tail_count = std::count_if(posting_lengths.begin(),
+                                         posting_lengths.end(),
+                                         [&](float value) { return value > threshold; });
+    posting_stats["long_tail_threshold"].SetFloat(threshold);
+    posting_stats["long_tail_mean"].SetFloat(static_cast<float>(long_tail_count) /
+                                             static_cast<float>(posting_lengths.size()));
+    return posting_stats;
+}
+
+JsonType
+SINDIAnalyzer::get_quantization_range_stats() const {
+    if (not sindi_->use_quantization_) {
+        return make_skip_json("quantization disabled");
+    }
+    JsonType stats;
+    stats["min_val"].SetFloat(sindi_->quantization_params_->min_val);
+    stats["max_val"].SetFloat(sindi_->quantization_params_->max_val);
+    stats["diff"].SetFloat(sindi_->quantization_params_->diff);
+    return stats;
+}
+
+JsonType
+SINDIAnalyzer::get_mean_doc_retained(const DatasetPtr& base_dataset) const {
+    if (not sindi_->use_reorder_ &&
+        (base_dataset == nullptr || base_dataset->GetSparseVectors() == nullptr)) {
+        return make_skip_json(
+            "requires original base vectors; provide --base_path or rebuild with use_reorder=true");
+    }
+
+    std::vector<int64_t> sample_ids(static_cast<size_t>(sindi_->cur_element_count_));
+    std::iota(sample_ids.begin(), sample_ids.end(), 0);
+    std::mt19937 rng(47);
+    std::shuffle(sample_ids.begin(), sample_ids.end(), rng);
+
+    auto retained_sample_count = std::min<uint64_t>(sample_ids.size(), K_ANALYZE_DOC_SAMPLE_LIMIT);
+    float retained_ratio_sum = 0.0F;
+    uint64_t valid_count = 0;
+    for (uint64_t idx = 0; idx < retained_sample_count; ++idx) {
+        SparseVector original{};
+        SparseVector pruned{};
+        if (not get_original_sparse_vector_by_inner_id(
+                sample_ids[idx], &original, sindi_->allocator_, base_dataset)) {
+            continue;
+        }
+        get_pruned_sparse_vector_by_inner_id(sample_ids[idx], &pruned, sindi_->allocator_);
+        if (original.len_ > 0) {
+            retained_ratio_sum +=
+                static_cast<float>(pruned.len_) / static_cast<float>(original.len_);
+            ++valid_count;
+        }
+        release_sparse_vector(sindi_->allocator_, &original);
+        release_sparse_vector(sindi_->allocator_, &pruned);
+    }
+
+    JsonType stats;
+    stats["mean"].SetFloat(valid_count == 0 ? 0.0F
+                                            : retained_ratio_sum / static_cast<float>(valid_count));
+    return stats;
+}
+
+JsonType
+SINDIAnalyzer::calculate_distance_quality_stats(const DatasetPtr& query_dataset,
+                                                const SINDISearchParameter& search_param,
+                                                const DatasetPtr& base_dataset,
+                                                int64_t topk) const {
+    JsonType stats;
+    if (query_dataset == nullptr || query_dataset->GetSparseVectors() == nullptr || topk <= 0) {
+        auto skip = make_skip_json("query dataset unavailable");
+        stats["doc_prune_bias_mean"].SetJson(skip);
+        stats["doc_prune_inversion_count_rate"].SetJson(skip);
+        if (sindi_->use_quantization_) {
+            stats["quantization_bias_ratio"].SetJson(skip);
+            stats["quantization_inversion_count_rate"].SetJson(skip);
+        }
+        return stats;
+    }
+    if (not sindi_->use_reorder_ &&
+        (base_dataset == nullptr || base_dataset->GetSparseVectors() == nullptr)) {
+        auto skip = make_skip_json(
+            "requires original base vectors; provide --base_path or rebuild with use_reorder=true");
+        stats["doc_prune_bias_mean"].SetJson(skip);
+        stats["doc_prune_inversion_count_rate"].SetJson(skip);
+        if (sindi_->use_quantization_) {
+            stats["quantization_bias_ratio"].SetJson(skip);
+            stats["quantization_inversion_count_rate"].SetJson(skip);
+        }
+        return stats;
+    }
+
+    float doc_bias_sum = 0.0F;
+    float doc_inversion_rate_sum = 0.0F;
+    float quant_bias_sum = 0.0F;
+    float quant_inversion_rate_sum = 0.0F;
+    auto query_count = query_dataset->GetNumElements();
+    auto sampled_query_count = std::min<int64_t>(
+        query_count, std::max<int64_t>(1, static_cast<int64_t>(base_sample_size_)));
+    SINDISearchParameter no_query_prune_param = search_param;
+    no_query_prune_param.query_prune_ratio = 0.0F;
+    auto candidate_count = resolve_candidate_count(no_query_prune_param, topk);
+    int64_t valid_doc_query_count = 0;
+    int64_t valid_quant_query_count = 0;
+
+    for (int64_t query_idx = 0; query_idx < sampled_query_count; ++query_idx) {
+        const auto& query = query_dataset->GetSparseVectors()[query_idx];
+        auto doc_candidates =
+            collect_doc_prune_candidates(query, no_query_prune_param, candidate_count);
+        auto doc_count = static_cast<int64_t>(doc_candidates.size());
+        if (doc_count > 0) {
+            ++valid_doc_query_count;
+            std::vector<float> exact_distances(static_cast<size_t>(doc_count));
+            std::vector<float> pruned_distances(static_cast<size_t>(doc_count));
+            float query_doc_bias = 0.0F;
+            for (int64_t rank = 0; rank < doc_count; ++rank) {
+                exact_distances[rank] = calculate_exact_distance_by_label(
+                    query, doc_candidates[rank].second, base_dataset);
+                pruned_distances[rank] =
+                    calculate_pruned_distance_by_label(query, doc_candidates[rank].second);
+                query_doc_bias += std::abs(pruned_distances[rank] - exact_distances[rank]) /
+                                  std::max(std::abs(exact_distances[rank]), K_ANALYZE_EPSILON);
+            }
+            doc_bias_sum += query_doc_bias / static_cast<float>(doc_count);
+
+            int64_t doc_pair_count = 0;
+            int64_t doc_inversion_count = 0;
+            for (int64_t left = 0; left < doc_count; ++left) {
+                for (int64_t right = left + 1; right < doc_count; ++right) {
+                    auto exact_diff = exact_distances[left] - exact_distances[right];
+                    auto pruned_diff = pruned_distances[left] - pruned_distances[right];
+                    if (std::abs(exact_diff) > K_ANALYZE_EPSILON &&
+                        std::abs(pruned_diff) > K_ANALYZE_EPSILON) {
+                        ++doc_pair_count;
+                        if ((exact_diff < 0.0F) != (pruned_diff < 0.0F)) {
+                            ++doc_inversion_count;
+                        }
+                    }
+                }
+            }
+            doc_inversion_rate_sum +=
+                doc_pair_count == 0
+                    ? 0.0F
+                    : static_cast<float>(doc_inversion_count) / static_cast<float>(doc_pair_count);
+        }
+
+        if (not sindi_->use_quantization_) {
+            continue;
+        }
+        auto quant_candidates =
+            collect_coarse_candidates(query, no_query_prune_param, candidate_count);
+        auto quant_count = static_cast<int64_t>(quant_candidates.size());
+        if (quant_count <= 0) {
+            continue;
+        }
+        ++valid_quant_query_count;
+        std::vector<float> pruned_distances(static_cast<size_t>(quant_count));
+        std::vector<float> quantized_distances(static_cast<size_t>(quant_count));
+        float query_quant_bias = 0.0F;
+        for (int64_t rank = 0; rank < quant_count; ++rank) {
+            pruned_distances[rank] =
+                calculate_pruned_distance_by_label(query, quant_candidates[rank].second);
+            quantized_distances[rank] = quant_candidates[rank].first;
+            query_quant_bias += std::abs(quantized_distances[rank] - pruned_distances[rank]) /
+                                std::max(std::abs(pruned_distances[rank]), K_ANALYZE_EPSILON);
+        }
+        quant_bias_sum += query_quant_bias / static_cast<float>(quant_count);
+
+        int64_t quant_pair_count = 0;
+        int64_t quant_inversion_count = 0;
+        for (int64_t left = 0; left < quant_count; ++left) {
+            for (int64_t right = left + 1; right < quant_count; ++right) {
+                auto pruned_diff = pruned_distances[left] - pruned_distances[right];
+                auto quant_diff = quantized_distances[left] - quantized_distances[right];
+                if (std::abs(pruned_diff) > K_ANALYZE_EPSILON &&
+                    std::abs(quant_diff) > K_ANALYZE_EPSILON) {
+                    ++quant_pair_count;
+                    if ((pruned_diff < 0.0F) != (quant_diff < 0.0F)) {
+                        ++quant_inversion_count;
+                    }
+                }
+            }
+        }
+        quant_inversion_rate_sum +=
+            quant_pair_count == 0
+                ? 0.0F
+                : static_cast<float>(quant_inversion_count) / static_cast<float>(quant_pair_count);
+    }
+
+    auto doc_denominator = static_cast<float>(std::max<int64_t>(1, valid_doc_query_count));
+    stats["doc_prune_bias_mean"].SetFloat(doc_bias_sum / doc_denominator);
+    stats["doc_prune_inversion_count_rate"].SetFloat(doc_inversion_rate_sum / doc_denominator);
+    if (sindi_->use_quantization_) {
+        auto quant_denominator = static_cast<float>(std::max<int64_t>(1, valid_quant_query_count));
+        stats["quantization_bias_ratio"].SetFloat(quant_bias_sum / quant_denominator);
+        stats["quantization_inversion_count_rate"].SetFloat(quant_inversion_rate_sum /
+                                                            quant_denominator);
+    }
+    return stats;
+}
+
+JsonType
+SINDIAnalyzer::GetStats() {
+    auto search_json = parse_sindi_search_json(search_params_);
+    auto analyze_options = parse_analyze_options(search_json);
+    DatasetPtr base_dataset = nullptr;
+    if (not analyze_options.base_path.empty()) {
+        base_dataset = load_sparse_dataset(analyze_options.base_path);
+        check_base_dataset_for_analyze(base_dataset, sindi_->cur_element_count_);
+    }
+
+    JsonType stats;
+    stats["total_count"].SetInt(static_cast<uint64_t>(sindi_->cur_element_count_));
+    stats["window_count"].SetInt(static_cast<uint64_t>(sindi_->window_term_list_.size()));
+    stats["active_term_count"].SetJson(get_active_term_count_stats());
+    stats["posting_length_distribution"].SetJson(get_posting_length_distribution_stats());
+    if (sindi_->use_quantization_) {
+        stats["quantization_range"].SetJson(get_quantization_range_stats());
+    }
+    stats["mean_doc_retained"].SetJson(get_mean_doc_retained(base_dataset));
+
+    auto default_search_json = parse_sindi_search_json("default");
+    default_search_json[INDEX_SINDI][SPARSE_QUERY_PRUNE_RATIO].SetFloat(0.0F);
+    default_search_json[INDEX_SINDI][SPARSE_TERM_PRUNE_RATIO].SetFloat(0.0F);
+    default_search_json[INDEX_SINDI][SPARSE_N_CANDIDATE].SetInt(500);
+    default_search_json[INDEX_SINDI][SPARSE_USE_TERM_LISTS_HEAP_INSERT].SetBool(true);
+    auto default_search_param = default_search_json.Dump();
+
+    auto base_search_stats = get_base_search_stats(default_search_param, base_dataset);
+    for (const auto& key : {"recall_base",
+                            "doc_prune_recall",
+                            "quantization_recall",
+                            "doc_prune_bias_mean",
+                            "doc_prune_inversion_count_rate",
+                            "quantization_bias_ratio",
+                            "quantization_inversion_count_rate"}) {
+        if (base_search_stats.Contains(key)) {
+            stats[key].SetJson(base_search_stats[key]);
+        }
+    }
+
+    return stats;
+}
+
+JsonType
+SINDIAnalyzer::AnalyzeIndexBySearch(const SearchRequest& request) {
+    JsonType stats;
+    auto search_json = parse_sindi_search_json(request.params_str_);
+    auto analyze_options = parse_analyze_options(search_json);
+    SINDISearchParameter search_param;
+    search_param.FromJson(search_json);
+
+    auto query_dataset = request.query_;
+    CHECK_ARGUMENT(query_dataset != nullptr, "query dataset is null");
+    CHECK_ARGUMENT(query_dataset->GetSparseVectors() != nullptr,
+                   "SINDI analyze requires sparse query dataset");
+
+    auto effective_topk = std::min<int64_t>(request.topk_, sindi_->cur_element_count_);
+    if (effective_topk <= 0) {
+        return stats;
+    }
+
+    DatasetPtr base_dataset = nullptr;
+    if (not analyze_options.base_path.empty()) {
+        base_dataset = load_sparse_dataset(analyze_options.base_path);
+        check_base_dataset_for_analyze(base_dataset, sindi_->cur_element_count_);
+    }
+
+    DatasetPtr ground_truth = nullptr;
+    bool has_explicit_groundtruth = not analyze_options.groundtruth_path.empty();
+    std::string ground_truth_skip_reason =
+        "ground truth unavailable; provide --groundtruth_path or --base_path";
+    if (has_explicit_groundtruth) {
+        ground_truth = load_ground_truth(analyze_options.groundtruth_path);
+    }
+    if (ground_truth == nullptr && not has_explicit_groundtruth) {
+        ground_truth = calculate_ground_truth(query_dataset, effective_topk, base_dataset);
+        if (ground_truth == nullptr && not sindi_->use_reorder_ &&
+            (base_dataset == nullptr || base_dataset->GetSparseVectors() == nullptr)) {
+            ground_truth_skip_reason =
+                "ground truth auto-generation skipped because original base vectors are "
+                "unavailable; provide --base_path or --groundtruth_path or rebuild with "
+                "use_reorder=true";
+        }
+        if (ground_truth != nullptr) {
+            save_ground_truth(analyze_options.save_groundtruth_path, ground_truth);
+        }
+    }
+
+    bool has_ground_truth = ground_truth != nullptr &&
+                            ground_truth->GetNumElements() == query_dataset->GetNumElements() &&
+                            ground_truth->GetDim() >= effective_topk;
+    if (not has_ground_truth) {
+        ground_truth = nullptr;
+    }
+
+    float coarse_recall_sum = 0.0F;
+    float rerank_recall_sum = 0.0F;
+    std::vector<float> last_topk_ranks;
+
+    if (has_ground_truth) {
+        auto recall_stats =
+            calculate_recall_stats(query_dataset, ground_truth, search_param, effective_topk);
+        for (const auto& key :
+             {"recall_query", "doc_prune_recall", "quantization_recall", "mean_latency_ms"}) {
+            if (recall_stats.Contains(key)) {
+                stats[key].SetJson(recall_stats[key]);
+            }
+        }
+        stats["time_cost_query"].SetJson(recall_stats["mean_latency_ms"]);
+
+        auto quality_stats = calculate_distance_quality_stats(
+            query_dataset, search_param, base_dataset, effective_topk);
+        for (const auto& key : {"doc_prune_bias_mean",
+                                "doc_prune_inversion_count_rate",
+                                "quantization_bias_ratio",
+                                "quantization_inversion_count_rate"}) {
+            if (quality_stats.Contains(key)) {
+                stats[key].SetJson(quality_stats[key]);
+            }
+        }
+
+        for (int64_t query_idx = 0; query_idx < query_dataset->GetNumElements(); ++query_idx) {
+            const auto& query = query_dataset->GetSparseVectors()[query_idx];
+            auto candidate_count = resolve_candidate_count(search_param, effective_topk);
+            auto coarse_candidates =
+                collect_coarse_candidates(query, search_param, candidate_count);
+            if (not coarse_candidates.empty()) {
+                coarse_recall_sum += calculate_candidate_recall(
+                    coarse_candidates,
+                    ground_truth->GetIds() + query_idx * ground_truth->GetDim(),
+                    effective_topk,
+                    effective_topk);
+                auto reranked = rerank_candidates(query, coarse_candidates, effective_topk);
+                std::vector<int64_t> reranked_ids;
+                reranked_ids.reserve(reranked.size());
+                std::unordered_map<int64_t, int64_t> coarse_rank;
+                for (size_t rank = 0; rank < coarse_candidates.size(); ++rank) {
+                    coarse_rank[coarse_candidates[rank].second] = static_cast<int64_t>(rank) + 1;
+                }
+                int64_t last_rank = 0;
+                for (const auto& item : reranked) {
+                    reranked_ids.push_back(item.second);
+                    last_rank = std::max(last_rank, coarse_rank[item.second]);
+                }
+                rerank_recall_sum +=
+                    calculate_recall(reranked_ids.data(),
+                                     static_cast<int64_t>(reranked_ids.size()),
+                                     ground_truth->GetIds() + query_idx * ground_truth->GetDim(),
+                                     effective_topk);
+                last_topk_ranks.push_back(static_cast<float>(last_rank));
+            }
+        }
+    } else {
+        auto skip = make_skip_json(ground_truth_skip_reason);
+        stats["recall_query"].SetJson(skip);
+        stats["mean_latency_ms"].SetJson(skip);
+        stats["time_cost_query"].SetJson(skip);
+        stats["doc_prune_recall"].SetJson(skip);
+        stats["quantization_recall"].SetJson(skip);
+        stats["doc_prune_bias_mean"].SetJson(skip);
+        stats["doc_prune_inversion_count_rate"].SetJson(skip);
+        if (sindi_->use_quantization_) {
+            stats["quantization_bias_ratio"].SetJson(skip);
+            stats["quantization_inversion_count_rate"].SetJson(skip);
+        }
+    }
+
+    stats["postings_scanned"].SetJson(
+        calculate_postings_scanned_stats(query_dataset, search_param));
+
+    if (sindi_->use_reorder_ && has_ground_truth && not last_topk_ranks.empty()) {
+        JsonType reorder_recall;
+        reorder_recall["before_reorder_recall_k_at_k"].SetFloat(
+            coarse_recall_sum / static_cast<float>(last_topk_ranks.size()));
+        reorder_recall["after_reorder_recall_k_at_k"].SetFloat(
+            rerank_recall_sum / static_cast<float>(last_topk_ranks.size()));
+        stats["reorder_recall"].SetJson(reorder_recall);
+        stats["last_topk_rank_in_heap"].SetJson(make_distribution_stats(last_topk_ranks));
+    } else if (sindi_->use_reorder_) {
+        stats["reorder_recall"].SetJson(
+            make_skip_json("ground truth unavailable for reorder analysis"));
+        stats["last_topk_rank_in_heap"].SetJson(
+            make_skip_json("ground truth unavailable for reorder analysis"));
+    }
+
+    return stats;
+}
+
+}  // namespace vsag

--- a/src/analyzer/sindi_analyzer.h
+++ b/src/analyzer/sindi_analyzer.h
@@ -1,0 +1,119 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <vector>
+
+#include "algorithm/sindi/sindi.h"
+#include "analyzer.h"
+
+namespace vsag {
+
+class SINDIAnalyzer : public AnalyzerBase {
+public:
+    SINDIAnalyzer(SINDI* sindi, const AnalyzerParam& param)
+        : AnalyzerBase(sindi->allocator_, static_cast<uint32_t>(sindi->GetNumElements())),
+          sindi_(sindi),
+          topk_(param.topk),
+          base_sample_size_(param.base_sample_size),
+          search_params_(param.search_params) {
+    }
+
+    JsonType
+    GetStats() override;
+
+    JsonType
+    AnalyzeIndexBySearch(const SearchRequest& request) override;
+
+private:
+    void
+    get_pruned_sparse_vector_by_inner_id(InnerIdType inner_id,
+                                         SparseVector* data,
+                                         Allocator* specified_allocator) const;
+
+    std::vector<std::pair<float, int64_t>>
+    collect_coarse_candidates(const SparseVector& query,
+                              const SINDISearchParameter& search_param,
+                              int64_t candidate_count) const;
+
+    std::vector<std::pair<float, int64_t>>
+    collect_doc_prune_candidates(const SparseVector& query,
+                                 const SINDISearchParameter& search_param,
+                                 int64_t candidate_count) const;
+
+    std::vector<std::pair<float, int64_t>>
+    rerank_candidates(const SparseVector& query,
+                      const std::vector<std::pair<float, int64_t>>& coarse_candidates,
+                      int64_t topk) const;
+
+    float
+    calculate_exact_distance_by_label(const SparseVector& query,
+                                      int64_t label,
+                                      const DatasetPtr& base_dataset = nullptr) const;
+
+    bool
+    get_original_sparse_vector_by_inner_id(InnerIdType inner_id,
+                                           SparseVector* data,
+                                           Allocator* specified_allocator,
+                                           const DatasetPtr& base_dataset = nullptr) const;
+
+    float
+    calculate_pruned_distance_by_label(const SparseVector& query, int64_t label) const;
+
+    DatasetPtr
+    calculate_ground_truth(const DatasetPtr& query_dataset,
+                           int64_t topk,
+                           const DatasetPtr& base_dataset = nullptr) const;
+
+    JsonType
+    get_active_term_count_stats() const;
+
+    JsonType
+    get_posting_length_distribution_stats() const;
+
+    JsonType
+    get_quantization_range_stats() const;
+
+    JsonType
+    get_mean_doc_retained(const DatasetPtr& base_dataset = nullptr) const;
+
+    JsonType
+    calculate_distance_quality_stats(const DatasetPtr& query_dataset,
+                                     const SINDISearchParameter& search_param,
+                                     const DatasetPtr& base_dataset,
+                                     int64_t topk) const;
+
+    JsonType
+    calculate_recall_stats(const DatasetPtr& query_dataset,
+                           const DatasetPtr& ground_truth,
+                           const SINDISearchParameter& search_param,
+                           int64_t topk) const;
+
+    JsonType
+    calculate_postings_scanned_stats(const DatasetPtr& query_dataset,
+                                     const SINDISearchParameter& search_param) const;
+
+    JsonType
+    get_base_search_stats(const std::string& search_param,
+                          const DatasetPtr& base_dataset = nullptr) const;
+
+private:
+    SINDI* sindi_{nullptr};
+    int64_t topk_{10};
+    uint64_t base_sample_size_{10};
+    std::string search_params_;
+};
+
+}  // namespace vsag

--- a/src/datacell/sparse_term_datacell.cpp
+++ b/src/datacell/sparse_term_datacell.cpp
@@ -307,11 +307,10 @@ SparseTermDataCell::CalcDistanceByInnerId(const SparseTermComputerPtr& computer,
         if (computer->HasNextTerm()) {
             auto next_it = it + 1;
             auto next_term = computer->GetTerm(next_it);
-            if (next_term >= term_ids_.size()) {
-                continue;
+            if (next_term < term_ids_.size() && term_sizes_[next_term] != 0) {
+                __builtin_prefetch(term_ids_[next_term]->data(), 0, 3);
+                __builtin_prefetch(term_datas_[next_term]->data(), 0, 3);
             }
-            __builtin_prefetch(term_ids_[next_term]->data(), 0, 3);
-            __builtin_prefetch(term_datas_[next_term]->data(), 0, 3);
         }
         // Fix: Check term_sizes_[term] == 0 to avoid null pointer dereference
         if (term >= term_ids_.size() || term_sizes_[term] == 0) {

--- a/tests/test_sindi.cpp
+++ b/tests/test_sindi.cpp
@@ -207,6 +207,42 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex,
     TestIndexStatus(index);
 }
 
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex, "SINDI Analyze", "[ft][analyze][sindi]") {
+    fixtures::SINDIParam param;
+    param.use_reorder = GENERATE(true, false);
+    param.use_quantization = GENERATE(true, false);
+    auto build_param = fixtures::SINDITestIndex::GenerateBuildParameter(param);
+    auto index = TestFactory("sindi", build_param, true);
+    auto dataset = pool.GetSparseDatasetAndCreate(base_count, 128, 0.8);
+    REQUIRE(index->GetIndexType() == vsag::IndexType::SINDI);
+    TestBuildIndex(index, dataset, true);
+
+    auto stats = vsag::JsonType::Parse(index->GetStats());
+    REQUIRE(stats.Contains("total_count"));
+    REQUIRE(stats.Contains("window_count"));
+    REQUIRE(stats.Contains("active_term_count"));
+    REQUIRE(stats.Contains("posting_length_distribution"));
+    REQUIRE(stats.Contains("mean_doc_retained"));
+    REQUIRE(stats.Contains("recall_base"));
+
+    vsag::SearchRequest request;
+    request.topk_ = 10;
+    request.params_str_ = fixtures::SINDITestIndex::GenerateSearchParameter(true);
+    request.query_ = dataset->query_;
+    auto raw_query_count = dataset->query_->GetNumElements();
+    dataset->query_->NumElements(5);
+    auto analyze = vsag::JsonType::Parse(index->AnalyzeIndexBySearch(request));
+    dataset->query_->NumElements(raw_query_count);
+
+    REQUIRE(analyze.Contains("recall_query"));
+    REQUIRE(analyze.Contains("time_cost_query"));
+    REQUIRE(analyze.Contains("postings_scanned"));
+    REQUIRE(analyze.Contains("doc_prune_recall"));
+    if (param.use_quantization) {
+        REQUIRE(analyze.Contains("quantization_recall"));
+    }
+}
+
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex,
                              "SINDI Concurrent",
                              "[ft][concurrent][sindi]") {

--- a/tools/analyze_index/analyze_index.cpp
+++ b/tools/analyze_index/analyze_index.cpp
@@ -16,13 +16,17 @@
 #include <vsag/vsag.h>
 
 #include <argparse/argparse.hpp>
+#include <cstdint>
 #include <fstream>
 #include <iostream>
+#include <memory>
 
 #include "algorithm/hgraph.h"
 #include "algorithm/ivf.h"
 #include "algorithm/pyramid.h"
 #include "algorithm/pyramid_zparameters.h"
+#include "algorithm/sindi/sindi.h"
+#include "algorithm/sindi/sindi_parameter.h"
 #include "index/index_impl.h"
 #include "inner_string_params.h"
 #include "storage/serialization.h"
@@ -33,6 +37,48 @@ using namespace vsag;
 constexpr static const char* DEFAULT_BUILD_PARAM = "default";
 constexpr static const char* DEFAULT_SEARCH_PARAM = "default";
 constexpr static const char* EMPTY_QUERY_PATH = "empty";
+constexpr static const char* EMPTY_OPTIONAL_PATH = "";
+constexpr static const char* QUERY_DATA_TYPE_AUTO = "auto";
+
+std::streamsize
+to_stream_size(size_t bytes) {
+    return static_cast<std::streamsize>(bytes);
+}
+
+bool
+is_sparse_build_param(const JsonType& params) {
+    return params.Contains("dtype") && params["dtype"].GetString() == "sparse";
+}
+
+bool
+is_sindi_inner_param(const JsonType& params) {
+    return params.Contains(SPARSE_TERM_ID_LIMIT) || params.Contains(SPARSE_DOC_PRUNE_RATIO) ||
+           params.Contains(USE_QUANTIZATION) || params.Contains(SPARSE_REMAP_TERM_IDS);
+}
+
+std::string
+infer_index_name_from_build_param(const JsonType& params) {
+    if (params.Contains(TYPE_KEY)) {
+        return params[TYPE_KEY].GetString();
+    }
+    if (is_sparse_build_param(params)) {
+        return INDEX_SINDI;
+    }
+    if (params.Contains(INDEX_PARAM)) {
+        auto index_param = params[INDEX_PARAM];
+        if (index_param.Contains(TYPE_KEY)) {
+            return index_param[TYPE_KEY].GetString();
+        }
+        if (index_param.Contains("base_quantization_type") ||
+            index_param.Contains("index_min_size")) {
+            return INDEX_PYRAMID;
+        }
+        if (is_sindi_inner_param(index_param)) {
+            return INDEX_SINDI;
+        }
+    }
+    return "";
+}
 
 inline const std::string
 MetricTypeToString(MetricType type) {
@@ -80,6 +126,22 @@ parse_args(argparse::ArgumentParser& parser, int argc, char** argv) {
         .default_value(EMPTY_QUERY_PATH)
         .help("The query dataset path, if not set, will not do query analysis");
 
+    parser.add_argument<std::string>("--query_data_type")
+        .default_value(std::string(QUERY_DATA_TYPE_AUTO))
+        .help("Query dataset type: auto, dense, sparse");
+
+    parser.add_argument<std::string>("--base_path")
+        .default_value(std::string(EMPTY_OPTIONAL_PATH))
+        .help("Optional sparse base dataset path for SINDI analyze");
+
+    parser.add_argument<std::string>("--groundtruth_path")
+        .default_value(std::string(EMPTY_OPTIONAL_PATH))
+        .help("Optional ground truth path for analyze");
+
+    parser.add_argument<std::string>("--save_groundtruth_path")
+        .default_value(std::string(EMPTY_OPTIONAL_PATH))
+        .help("Optional output path for generated ground truth");
+
     parser.add_argument<std::string>("--search_parameter", "-sp")
         .default_value(DEFAULT_SEARCH_PARAM)
         .help("The parameter for search, if not set, will use default parameter");
@@ -98,8 +160,8 @@ parse_args(argparse::ArgumentParser& parser, int argc, char** argv) {
 }
 
 DatasetPtr
-load_query(const std::string& query_path) {
-    std::fstream in_stream(query_path);
+load_dense_query(const std::string& query_path) {
+    std::fstream in_stream(query_path, std::ios::binary | std::ios::in);
     if (not in_stream.is_open()) {
         logger::error("Failed to open query file: {}", query_path);
         return nullptr;
@@ -115,6 +177,97 @@ load_query(const std::string& query_path) {
     return dataset;
 }
 
+DatasetPtr
+load_sparse_query(const std::string& query_path) {
+    std::fstream in_stream(query_path, std::ios::binary | std::ios::in);
+    if (not in_stream.is_open()) {
+        logger::error("Failed to open sparse query file: {}", query_path);
+        return nullptr;
+    }
+
+    int64_t rows = 0;
+    int64_t cols = 0;
+    int64_t nnz = 0;
+    in_stream.read(reinterpret_cast<char*>(&rows), sizeof(rows));
+    in_stream.read(reinterpret_cast<char*>(&cols), sizeof(cols));
+    in_stream.read(reinterpret_cast<char*>(&nnz), sizeof(nnz));
+    if (rows < 0 || cols < 0 || nnz < 0) {
+        logger::error("Invalid sparse query header in file: {}", query_path);
+        return nullptr;
+    }
+
+    std::vector<int64_t> indptr(static_cast<size_t>(rows) + 1);
+    std::vector<int32_t> indices(static_cast<size_t>(nnz));
+    std::vector<float> values(static_cast<size_t>(nnz));
+    auto* sparse_vectors = new SparseVector[static_cast<size_t>(rows)];
+
+    in_stream.read(reinterpret_cast<char*>(indptr.data()),
+                   to_stream_size(sizeof(int64_t) * (static_cast<size_t>(rows) + 1)));
+    in_stream.read(reinterpret_cast<char*>(indices.data()),
+                   to_stream_size(sizeof(int32_t) * static_cast<size_t>(nnz)));
+    in_stream.read(reinterpret_cast<char*>(values.data()),
+                   to_stream_size(sizeof(float) * static_cast<size_t>(nnz)));
+    if (not in_stream.good()) {
+        logger::error("Failed to read sparse query CSR arrays from file: {}", query_path);
+        delete[] sparse_vectors;
+        return nullptr;
+    }
+
+    if (indptr[0] != 0 || indptr[static_cast<size_t>(rows)] != nnz) {
+        logger::error("Invalid sparse query indptr bounds in file: {}", query_path);
+        delete[] sparse_vectors;
+        return nullptr;
+    }
+    for (int64_t row = 0; row < rows; ++row) {
+        if (indptr[static_cast<size_t>(row)] > indptr[static_cast<size_t>(row + 1)] ||
+            indptr[static_cast<size_t>(row)] < 0 || indptr[static_cast<size_t>(row + 1)] > nnz) {
+            logger::error("Invalid sparse query indptr monotonicity in file: {}", query_path);
+            delete[] sparse_vectors;
+            return nullptr;
+        }
+    }
+    for (int64_t offset = 0; offset < nnz; ++offset) {
+        if (indices[static_cast<size_t>(offset)] < 0 ||
+            indices[static_cast<size_t>(offset)] >= cols) {
+            logger::error("Invalid sparse query column index in file: {}", query_path);
+            delete[] sparse_vectors;
+            return nullptr;
+        }
+    }
+
+    for (int64_t row = 0; row < rows; ++row) {
+        auto begin = indptr[static_cast<size_t>(row)];
+        auto end = indptr[static_cast<size_t>(row + 1)];
+        auto len = end - begin;
+        sparse_vectors[row].len_ = static_cast<uint32_t>(len);
+        sparse_vectors[row].ids_ = new uint32_t[static_cast<size_t>(len)];
+        sparse_vectors[row].vals_ = new float[static_cast<size_t>(len)];
+        for (int64_t offset = 0; offset < len; ++offset) {
+            auto value_offset = static_cast<size_t>(begin + offset);
+            sparse_vectors[row].ids_[offset] = static_cast<uint32_t>(indices[value_offset]);
+            sparse_vectors[row].vals_[offset] = values[value_offset];
+        }
+    }
+
+    auto dataset = Dataset::Make();
+    dataset->SparseVectors(sparse_vectors)->Owner(true)->NumElements(rows)->Dim(cols);
+    return dataset;
+}
+
+DatasetPtr
+load_query(const std::string& query_path, DataTypes data_type, const std::string& query_data_type) {
+    if (query_data_type == "dense") {
+        return load_dense_query(query_path);
+    }
+    if (query_data_type == "sparse") {
+        return load_sparse_query(query_path);
+    }
+    if (data_type == DataTypes::DATA_TYPE_SPARSE) {
+        return load_sparse_query(query_path);
+    }
+    return load_dense_query(query_path);
+}
+
 class AnalyzedIndex {
 public:
     AnalyzedIndex(const std::string& build_param) : build_param_(build_param) {
@@ -123,13 +276,13 @@ public:
     bool
     LoadIndex(const std::string& index_path) {
         index_path_ = index_path;
-        std::fstream in_stream(index_path);
+        std::fstream in_stream(index_path, std::ios::binary | std::ios::in);
         IOStreamReader reader(in_stream);
         if (not parse_reader(reader)) {
             return false;
         }
         if (build_param_ != DEFAULT_BUILD_PARAM) {
-            std::fstream new_stream(index_path_);
+            std::fstream new_stream(index_path_, std::ios::binary | std::ios::in);
             if (not create_index_with_param(index_name_, new_stream)) {
                 return false;
             }
@@ -139,7 +292,12 @@ public:
     }
 
     void
-    AnalyzeQuery(const DatasetPtr& query_dataset, int64_t topk, const std::string& search_param) {
+    AnalyzeQuery(const DatasetPtr& query_dataset,
+                 int64_t topk,
+                 const std::string& search_param,
+                 const std::string& base_path,
+                 const std::string& groundtruth_path,
+                 const std::string& save_groundtruth_path) {
         if (not index_) {
             logger::error("Index not loaded");
             return;
@@ -151,14 +309,46 @@ public:
         SearchRequest query_request;
         query_request.query_ = query_dataset;
         query_request.topk_ = topk;
-        query_request.params_str_ = search_param;
+        if (base_path.empty() && groundtruth_path.empty() && save_groundtruth_path.empty()) {
+            query_request.params_str_ = search_param;
+        } else {
+            JsonType params =
+                search_param == DEFAULT_SEARCH_PARAM ? JsonType() : JsonType::Parse(search_param);
+            params["analyze"].SetJson(JsonType());
+            if (not base_path.empty()) {
+                params["analyze"]["base_path"].SetString(base_path);
+            }
+            if (not groundtruth_path.empty()) {
+                params["analyze"]["groundtruth_path"].SetString(groundtruth_path);
+            }
+            if (not save_groundtruth_path.empty()) {
+                params["analyze"]["save_groundtruth_path"].SetString(save_groundtruth_path);
+            }
+            query_request.params_str_ = params.Dump();
+        }
         auto search_result = index_->AnalyzeIndexBySearch(query_request);
         logger::info("Search Analyze: {}", search_result);
     }
 
     void
-    ShowIndexProperty() const {
-        logger::info("index inner property: {}", index_->GetStats());
+    ShowIndexProperty(const std::string& search_param, const std::string& base_path) const {
+        if (base_path.empty() || index_name_ != INDEX_SINDI) {
+            logger::info("index inner property: {}", index_->GetStats());
+            return;
+        }
+        SearchRequest stats_request;
+        stats_request.topk_ = 0;
+        JsonType params =
+            search_param == DEFAULT_SEARCH_PARAM ? JsonType() : JsonType::Parse(search_param);
+        params["analyze"].SetJson(JsonType());
+        params["analyze"]["base_path"].SetString(base_path);
+        stats_request.params_str_ = params.Dump();
+        logger::info("index inner property: {}", index_->AnalyzeIndexBySearch(stats_request));
+    }
+
+    DataTypes
+    GetDataType() const {
+        return data_type_;
     }
 
 private:
@@ -176,57 +366,61 @@ private:
         auto basic_info = meta_data->Get(BASIC_INFO);
         logger::info("[parse_reader] Got basic_info");
 
-        logger::info("[parse_reader] build_param_ = {}", build_param_);
-        logger::info("[parse_reader] Checking if INDEX_PARAM exists in basic_info");
+        if (build_param_ != DEFAULT_BUILD_PARAM) {
+            auto parsed = JsonType::Parse(build_param_);
+            index_name_ = infer_index_name_from_build_param(parsed);
+            if (is_sparse_build_param(parsed)) {
+                dim_ = parsed.Contains(DIM) ? parsed[DIM].GetInt() : 0;
+                extra_info_size_ = 0;
+                data_type_ = DataTypes::DATA_TYPE_SPARSE;
+                metric_type_ = MetricType::METRIC_TYPE_IP;
+            }
+
+            if (not index_name_.empty()) {
+                logger::info("index name (from explicit build_param): {}", index_name_);
+                return true;
+            }
+            logger::error("Failed to infer index type from explicit build_param");
+            return false;
+        }
 
         if (not basic_info.Contains(INDEX_PARAM)) {
-            logger::info("[parse_reader] INDEX_PARAM not found in basic_info");
-            if (build_param_ == DEFAULT_BUILD_PARAM) {
-                logger::error("Index parameter not found in metadata and no build_param provided");
-                return false;
-            }
-            logger::info("[parse_reader] Parsing build_param_ to get index_name");
-            auto parsed = JsonType::Parse(build_param_);
-            logger::info("[parse_reader] Parsed build_param_, dump: {}", parsed.Dump(4));
-            if (parsed.Contains(TYPE_KEY)) {
-                index_name_ = parsed[TYPE_KEY].GetString();
-                logger::info("[parse_reader] index_name_ from TYPE_KEY: {}", index_name_);
-            } else if (parsed.Contains(INDEX_PARAM)) {
-                auto index_param = parsed[INDEX_PARAM];
-                logger::info("[parse_reader] INDEX_PARAM in build_param: {}", index_param.Dump(4));
-                if (index_param.Contains(TYPE_KEY)) {
-                    index_name_ = index_param[TYPE_KEY].GetString();
-                    logger::info("[parse_reader] index_name_ from INDEX_PARAM.TYPE_KEY: {}",
-                                 index_name_);
-                } else if (index_param.Contains("base_quantization_type") ||
-                           index_param.Contains("index_min_size")) {
-                    index_name_ = INDEX_PYRAMID;
-                    logger::info("[parse_reader] Detected pyramid params, using index_name: {}",
-                                 index_name_);
-                } else {
-                    logger::error("[parse_reader] TYPE_KEY not found in INDEX_PARAM");
-                    return false;
-                }
-            } else {
-                logger::error("[parse_reader] TYPE_KEY not found in build_param");
-                return false;
-            }
-            logger::info("index name (from build_param): {}", index_name_);
-            dim_ = 0;
-            extra_info_size_ = 0;
-            data_type_ = DataTypes::DATA_TYPE_FLOAT;
-            metric_type_ = MetricType::METRIC_TYPE_L2SQR;
-            return true;
+            logger::error("Index parameter not found in metadata and no build_param provided");
+            return false;
         }
+
         logger::info("[parse_reader] INDEX_PARAM found in basic_info");
         // parse basic info
-        dim_ = basic_info[DIM].GetInt();
-        extra_info_size_ = basic_info["extra_info_size"].GetInt();
-        data_type_ = static_cast<DataTypes>(basic_info["data_type"].GetInt());
-        metric_type_ = static_cast<MetricType>(basic_info["metric"].GetInt());
         std::string inner_param = basic_info[INDEX_PARAM].GetString();
         index_param_ = JsonType::Parse(inner_param);
-        index_name_ = index_param_[TYPE_KEY].GetString();
+        index_name_ = infer_index_name_from_build_param(index_param_);
+        if (index_name_.empty()) {
+            index_name_ = infer_index_name_from_build_param(basic_info);
+        }
+        if (index_name_.empty()) {
+            logger::error("Failed to infer index type from metadata");
+            return false;
+        }
+
+        dim_ = basic_info.Contains(DIM) ? basic_info[DIM].GetInt() : 0;
+        extra_info_size_ =
+            basic_info.Contains("extra_info_size") ? basic_info["extra_info_size"].GetInt() : 0;
+        if (basic_info.Contains("data_type")) {
+            data_type_ = static_cast<DataTypes>(basic_info["data_type"].GetInt());
+        } else {
+            data_type_ = index_name_ == INDEX_SINDI ? DataTypes::DATA_TYPE_SPARSE
+                                                    : DataTypes::DATA_TYPE_FLOAT;
+        }
+        if (basic_info.Contains("metric")) {
+            metric_type_ = static_cast<MetricType>(basic_info["metric"].GetInt());
+        } else {
+            metric_type_ = index_name_ == INDEX_SINDI ? MetricType::METRIC_TYPE_IP
+                                                      : MetricType::METRIC_TYPE_L2SQR;
+        }
+        if (not basic_info.Contains(DIM) || not basic_info.Contains("extra_info_size") ||
+            not basic_info.Contains("data_type") || not basic_info.Contains("metric")) {
+            logger::warn("Index metadata is incomplete; missing fields will use analyzer defaults");
+        }
         logger::info("index name: {}", index_name_);
         logger::info("index dim: {}", dim_);
         logger::info("index data type: {}", DataTypesToString(data_type_));
@@ -286,6 +480,13 @@ private:
             inner_index->Deserialize(reader);
             index_ = std::make_shared<IndexImpl<Pyramid>>(inner_index, index_common_params);
             return true;
+        } else if (index_name_ == INDEX_SINDI) {
+            auto sindi_parameter = std::make_shared<SINDIParameter>();
+            sindi_parameter->FromJson(index_param_);
+            auto inner_index = std::make_shared<SINDI>(sindi_parameter, index_common_params);
+            inner_index->Deserialize(reader);
+            index_ = std::make_shared<IndexImpl<SINDI>>(inner_index, index_common_params);
+            return true;
         } else {
             logger::error("Index type {} not supported", index_name_);
             return false;
@@ -296,10 +497,10 @@ private:
     IndexPtr index_{nullptr};
     std::string build_param_;
     std::string index_path_;
-    int64_t dim_;
-    int64_t extra_info_size_;
-    DataTypes data_type_;
-    MetricType metric_type_;
+    int64_t dim_{0};
+    int64_t extra_info_size_{0};
+    DataTypes data_type_{DataTypes::DATA_TYPE_FLOAT};
+    MetricType metric_type_{MetricType::METRIC_TYPE_L2SQR};
     std::string index_name_;
     std::string inner_param_;
     JsonType index_param_;
@@ -311,17 +512,25 @@ main(int argc, char** argv) {
     parse_args(parser, argc, argv);
     std::string index_path = parser.get<std::string>("--index_path");
     std::string build_param = parser.get<std::string>("--build_parameter");
+    std::string search_param = parser.get<std::string>("--search_parameter");
+    std::string base_path = parser.get<std::string>("--base_path");
     // parse index
     AnalyzedIndex index(build_param);
-    index.LoadIndex(index_path);
+    if (not index.LoadIndex(index_path)) {
+        logger::error("Failed to load index from {}", index_path);
+        return -1;
+    }
     // get index property
-    index.ShowIndexProperty();
+    index.ShowIndexProperty(search_param, base_path);
     // analyze query
     std::string query_path = parser.get<std::string>("--query_path");
-    std::string search_param = parser.get<std::string>("--search_parameter");
+    std::string query_data_type = parser.get<std::string>("--query_data_type");
+    std::string groundtruth_path = parser.get<std::string>("--groundtruth_path");
+    std::string save_groundtruth_path = parser.get<std::string>("--save_groundtruth_path");
     int64_t topk = parser.get<int>("--topk");
     if (query_path != EMPTY_QUERY_PATH) {
-        auto querys = load_query(query_path);
-        index.AnalyzeQuery(querys, topk, search_param);
+        auto querys = load_query(query_path, index.GetDataType(), query_data_type);
+        index.AnalyzeQuery(
+            querys, topk, search_param, base_path, groundtruth_path, save_groundtruth_path);
     }
 }


### PR DESCRIPTION
## Summary
- add SINDI analyzer support for static and search-based analysis
- wire SINDI into analyzer factory, index APIs, and analyze_index sparse CLI loading
- document HGraph/SINDI analyze metrics and add SINDI functional coverage
- guard sparse term prefetch against empty term lists during distance calculation

## Tests
- `cmake --build build-release --target analyze_index -j2`
- `cmake --build build-release --target functests -j2`
- `./build-release/tests/functests "SINDI Analyze"`

## Notes
- Excludes local SINDI testing scripts/YAML and `benchs/indexes/sindi_base_1m_build.yaml` as requested.