### PR TITLE
docs: add HDF5 dataset format page to Resources

### DIFF
--- a/docs/docs/en/src/SUMMARY.md
+++ b/docs/docs/en/src/SUMMARY.md
@@ -42,6 +42,7 @@
 - [Optimizer (Tune)](advanced/optimizer.md)
 - [Benchmarks](resources/performance.md)
 - [Evaluation Tool](resources/eval.md)
+- [HDF5 Dataset Format](resources/dataset_format.md)
 - [Index Analysis Tool](resources/analyze_index.md)
 
 # Resources

--- a/docs/docs/en/src/resources/dataset_format.md
+++ b/docs/docs/en/src/resources/dataset_format.md
@@ -1,0 +1,118 @@
+# HDF5 Dataset Format
+
+VSAG's evaluation and benchmark tooling (most notably
+[`eval_performance`](eval.md)) consumes datasets in the HDF5 format used by
+[ann-benchmarks](https://github.com/erikbern/ann-benchmarks). This page
+documents the exact layout VSAG expects so you can prepare custom datasets or
+debug failing evaluations.
+
+The dataset layout described below is the **dense** layout (selected by the global
+attribute `type="dense"`, or by omitting the attribute). For **sparse** datasets
+(`type="sparse"`), `/train` and `/test` are 1-D `INT8` byte streams produced by VSAG's
+sparse-vector serialization (decoded by `parse_sparse_vectors` in
+`tools/eval/eval_dataset.cpp`); all other datasets and attributes below still apply.
+
+## Mandatory Datasets
+
+### `/train` (base vectors)
+
+- **Type**: `INT8` or `FLOAT32`
+- **Shape**: `(N, D)`
+    - `N` — number of base vectors (`number_of_base`)
+    - `D` — feature dimensionality (`dim`)
+- **Notes**: the element type is inferred from HDF5:
+    - `H5T_INTEGER` (1-byte) → `INT8`
+    - `H5T_FLOAT` (4-byte) → `FLOAT32`
+
+### `/test` (query vectors)
+
+- **Type**: must match `/train`
+- **Shape**: `(Q, D)`
+    - `Q` — number of query vectors (`number_of_query`)
+    - `D` — must equal `/train`'s `D`
+
+### `/neighbors` (ground-truth indices)
+
+- **Type**: `INT64`
+- **Shape**: `(Q, K)`
+    - `K` — number of ground-truth neighbors per query
+- **Content**: precomputed top-`K` indices into `/train`.
+
+### `/distances` (ground-truth distances)
+
+- **Type**: `FLOAT32`
+- **Shape**: `(Q, K)` (identical to `/neighbors`)
+- **Note**: each entry must align with the same position in `/neighbors`.
+
+## Global Attributes
+
+### `type` (vector type)
+
+- **Type**: ASCII string
+- **Required**: no (defaults to `"dense"` if the attribute is missing)
+- **Allowed values**:
+    - `"dense"` — dense vectors stored as standard matrices in `/train` and `/test`
+    - `"sparse"` — sparse vectors stored in the serialized format produced by VSAG's
+      sparse-vector helpers
+
+### `distance` (metric definition)
+
+The evaluation tool treats `distance` values as **distances** (smaller is better) when
+comparing against the ground truth in `/distances`. Prepare ground-truth distances using the
+formulas below.
+
+- **Type**: ASCII string
+- **Required**: yes
+- **Allowed values for dense vectors**:
+    - `"euclidean"` — L2 distance, computed as `sqrt(L2Sqr)`
+    - `"ip"` — inner-product distance (`1 - inner_product`); data type auto-detected
+    - `"angular"` — cosine distance (`1 - cosine_similarity`)
+- **Allowed values for sparse vectors**:
+    - `"ip"` — sparse inner-product distance (`1 - sparse_inner_product`); other metrics
+      are not supported for sparse vectors
+
+## Optional Datasets
+
+### `/train_labels` and `/test_labels`
+
+- **Type**: `INT64`
+- **Shapes**:
+    - `/train_labels`: `(N,)`
+    - `/test_labels`: `(Q,)`
+- **Requirement**: if labels are present, both datasets must exist.
+
+### `/valid_ratios`
+
+- **Type**: `FLOAT32`
+- **Shape**: `(L,)`
+- **Usage**: stores per-class validation ratios. The evaluation tool indexes this array
+  with the **raw label value** (`valid_ratio_[label]`, see
+  `tools/eval/eval_dataset.h:71`), so labels must be non-negative integers and `L` must
+  be strictly greater than the maximum label value (typically `L > max(label)` with valid
+  indices `0..L-1`). It is the dataset author's responsibility to keep the array large
+  enough to cover every label that appears in `/train_labels` and `/test_labels`.
+
+## Structural Requirements
+
+1. **Dimensional compatibility**
+    - `train_shape[1] == test_shape[1]` (same `D`)
+    - `neighbors.shape == distances.shape`
+2. **Type mapping**
+
+   | HDF5 Specification     | Internal Type | Size    | Used In                                          |
+   |------------------------|---------------|---------|--------------------------------------------------|
+   | `H5T_INTEGER` (size=1) | `INT8`        | 1 byte  | `/train`, `/test`                                |
+   | `H5T_FLOAT` (size=4)   | `FLOAT32`     | 4 bytes | `/train`, `/test`, `/distances`, `/valid_ratios` |
+   | `H5T_INTEGER` (size=8) | `INT64`       | 8 bytes | `/neighbors`, `/train_labels`, `/test_labels`    |
+
+3. **Memory organization**
+    - Row-major storage for all matrices.
+    - Feature vectors stored contiguously:
+        - `/train` total size = `N × D × element_size` (1 or 4 bytes per element).
+
+## References
+
+- Public benchmark datasets compatible with this layout are available from
+  [ann-benchmarks](https://github.com/erikbern/ann-benchmarks)
+  (e.g. `sift-128-euclidean.hdf5`, `gist-960-euclidean.hdf5`).
+- See [Evaluation Tool](eval.md) for how datasets in this format are consumed.

--- a/docs/docs/zh/src/SUMMARY.md
+++ b/docs/docs/zh/src/SUMMARY.md
@@ -42,6 +42,7 @@
 - [优化器](advanced/optimizer.md)
 - [标准环境性能参考](resources/performance.md)
 - [性能评估工具](resources/eval.md)
+- [HDF5 数据集格式](resources/dataset_format.md)
 - [索引分析工具](resources/analyze_index.md)
 
 # 资源

--- a/docs/docs/zh/src/resources/dataset_format.md
+++ b/docs/docs/zh/src/resources/dataset_format.md
@@ -1,0 +1,113 @@
+# HDF5 数据集格式
+
+VSAG 的评测与基准工具（尤其是 [`eval_performance`](eval.md)）使用与
+[ann-benchmarks](https://github.com/erikbern/ann-benchmarks) 一致的 HDF5
+数据集格式。本页说明 VSAG 期望的具体布局，便于你准备自定义数据集或排查评测
+失败的问题。
+
+下文描述的是 **dense（稠密）** 布局（对应全局属性 `type="dense"`，或省略该属性）。
+对于 **sparse（稀疏）** 数据集（`type="sparse"`），`/train` 与 `/test` 是 1 维
+`INT8` 字节流，由 VSAG 的稀疏向量序列化接口生成（由
+`tools/eval/eval_dataset.cpp` 中的 `parse_sparse_vectors` 解析）；其余数据集与
+全局属性的约束仍然适用。
+
+## 必选数据集
+
+### `/train`（底库向量）
+
+- **类型**：`INT8` 或 `FLOAT32`
+- **形状**：`(N, D)`
+    - `N` —— 底库向量数量（`number_of_base`）
+    - `D` —— 向量维度（`dim`）
+- **说明**：元素类型由 HDF5 自动推断：
+    - `H5T_INTEGER`（1 字节）→ `INT8`
+    - `H5T_FLOAT`（4 字节）→ `FLOAT32`
+
+### `/test`（查询向量）
+
+- **类型**：必须与 `/train` 一致
+- **形状**：`(Q, D)`
+    - `Q` —— 查询向量数量（`number_of_query`）
+    - `D` —— 必须等于 `/train` 的 `D`
+
+### `/neighbors`（真实近邻索引）
+
+- **类型**：`INT64`
+- **形状**：`(Q, K)`
+    - `K` —— 每个查询的真实近邻个数
+- **内容**：预先计算好的 Top-`K` 索引，指向 `/train` 中的向量。
+
+### `/distances`（真实近邻距离）
+
+- **类型**：`FLOAT32`
+- **形状**：`(Q, K)`，与 `/neighbors` 相同
+- **要求**：与 `/neighbors` 中对应位置的近邻一一对齐。
+
+## 全局属性
+
+### `type`（向量类型）
+
+- **类型**：ASCII 字符串
+- **必填**：否（缺失时默认为 `"dense"`）
+- **可选值**：
+    - `"dense"` —— 稠密向量，按标准矩阵布局存放在 `/train` 与 `/test`
+    - `"sparse"` —— 稀疏向量，使用 VSAG 稀疏向量辅助接口的序列化格式
+
+### `distance`（距离度量）
+
+评测工具会将 `distance` 视为**距离**（数值越小越好），并与 `/distances` 中的真值进行
+对比。请按下方公式准备真值距离。
+
+- **类型**：ASCII 字符串
+- **必填**：是
+- **稠密向量可选值**：
+    - `"euclidean"` —— L2 距离，以 `sqrt(L2Sqr)` 计算
+    - `"ip"` —— 内积距离（`1 - 内积`），自动识别数据类型
+    - `"angular"` —— 余弦距离（`1 - 余弦相似度`）
+- **稀疏向量可选值**：
+    - `"ip"` —— 稀疏内积距离（`1 - 稀疏内积`），稀疏向量暂不支持其他度量
+
+## 可选数据集
+
+### `/train_labels` 与 `/test_labels`
+
+- **类型**：`INT64`
+- **形状**：
+    - `/train_labels`：`(N,)`
+    - `/test_labels`：`(Q,)`
+- **要求**：若使用标签，两个数据集必须同时存在。
+
+### `/valid_ratios`
+
+- **类型**：`FLOAT32`
+- **形状**：`(L,)`
+- **用途**：保存每个类别的验证比例。评测工具会以**原始 label 值**作为下标
+  （`valid_ratio_[label]`，见 `tools/eval/eval_dataset.h:71`），因此 label 必须为
+  非负整数，且 `L` 必须严格大于最大 label 值（通常为 `L > max(label)`，下标范围
+  `0..L-1`）。数据集作者需自行保证该数组足够大，能覆盖 `/train_labels` 与
+  `/test_labels` 中出现的所有 label。
+
+## 结构性要求
+
+1. **维度一致性**
+    - `train_shape[1] == test_shape[1]`（`D` 相同）
+    - `neighbors.shape == distances.shape`
+2. **类型映射**
+
+   | HDF5 规格              | 内部类型      | 大小    | 出现于                                              |
+   |------------------------|---------------|---------|-----------------------------------------------------|
+   | `H5T_INTEGER`（size=1）| `INT8`        | 1 字节  | `/train`、`/test`                                   |
+   | `H5T_FLOAT`（size=4）  | `FLOAT32`     | 4 字节  | `/train`、`/test`、`/distances`、`/valid_ratios`    |
+   | `H5T_INTEGER`（size=8）| `INT64`       | 8 字节  | `/neighbors`、`/train_labels`、`/test_labels`       |
+
+3. **内存布局**
+    - 所有矩阵按行优先（row-major）存储。
+    - 向量元素连续存放：
+        - `/train` 总大小 = `N × D × element_size`（每元素 1 或 4 字节）。
+
+## 参考
+
+- 与该格式兼容的公开基准数据集可在
+  [ann-benchmarks](https://github.com/erikbern/ann-benchmarks)
+  获取（如 `sift-128-euclidean.hdf5`、`gist-960-euclidean.hdf5`）。
+- 关于该格式如何被消费，参见 [性能评估工具](eval.md)。


### PR DESCRIPTION
## Summary

- Promote the orphan dataset-format note into a first-class **Resources** page on both the English and Chinese vsag.io sites.
- Link the new page from `SUMMARY.md` next to the existing Evaluation Tool entry.
- Documents the HDF5 layout consumed by `eval_performance` and `ann-benchmarks`-compatible datasets (mandatory/optional datasets, attributes, type mapping, structural requirements).

## Context

This is **Step 1** of a multi-step documentation completion plan that fills gaps between `examples/cpp/` and the published vsag.io docs. The plan tackles each gap in a small, focused PR; subsequent steps will cover index lifecycle, memory/introspection, quantization, extensibility, and persistence pages.

## Files

- `docs/docs/en/src/resources/dataset_format.md` (new)
- `docs/docs/zh/src/resources/dataset_format.md` (new)
- `docs/docs/en/src/SUMMARY.md`, `docs/docs/zh/src/SUMMARY.md` — add the new entry under *Performance and Tuning*.

## Notes

- No source code changes; docs-only.
- Existing repo-level note at `docs/dataset_format.md` is kept as a design note per `AGENTS.md` convention.

_Drafted with AI assistant: OpenCode:claude-opus-4.7_