### PR TITLE
docs: add Index Lifecycle Management page

### DIFF
--- a/docs/docs/en/src/SUMMARY.md
+++ b/docs/docs/en/src/SUMMARY.md
@@ -35,6 +35,7 @@
 - [Graph Enhancement](advanced/enhance_graph.md)
 - [Hybrid Memory-Disk Index](advanced/hybrid_index.md)
 - [Extra Info](advanced/extra_info.md)
+- [Index Lifecycle Management](advanced/index_lifecycle.md)
 
 # Performance and Tuning
 

--- a/docs/docs/en/src/advanced/index_lifecycle.md
+++ b/docs/docs/en/src/advanced/index_lifecycle.md
@@ -1,0 +1,190 @@
+# Index Lifecycle Management
+
+After an index is built, VSAG provides several operations that mutate the index in place or
+produce a new index derived from it. This page documents the full lifecycle surface:
+
+- `Remove` — delete vectors by id.
+- `UpdateVector` / `UpdateId` — modify an existing vector or rename its id.
+- `Clone` — produce a deep copy of an existing index.
+- `ExportModel` — extract the trained model as an empty index for reuse.
+
+Each operation is optional and is exposed only when the underlying index advertises the matching
+capability flag via `index->CheckFeature(...)`.
+
+## Capability Flags
+
+| Operation         | Capability Flag                          | HGraph | IVF | SINDI |
+|-------------------|------------------------------------------|:------:|:---:|:-----:|
+| `Remove`          | _(no dedicated flag — see below)_        |   Yes  |  —  |   —   |
+| `UpdateVector`    | `SUPPORT_UPDATE_VECTOR_CONCURRENT`       |   Yes  |  —  |  Yes  |
+| `UpdateId`        | `SUPPORT_UPDATE_ID_CONCURRENT`           |   Yes  |  —  |  Yes  |
+| `Clone`           | `SUPPORT_CLONE`                          |   Yes  | Yes |   —   |
+| `ExportModel`     | `SUPPORT_EXPORT_MODEL`                   |   Yes  | Yes |   —   |
+
+For the flag-gated operations, check at runtime with `index->CheckFeature(vsag::SUPPORT_*)` before
+calling; unsupported indexes return `UNSUPPORTED_INDEX_OPERATION`. `Remove` does not currently
+have a dedicated capability flag — see the next section for how to determine whether your index
+supports it and which mode it supports.
+
+## Removing Vectors
+
+`Remove` deletes vectors by id. HGraph supports two deletion modes with different requirements:
+
+- `RemoveMode::MARK_REMOVE` (the default) only writes a tombstone via the label table and works
+  regardless of `support_remove`. The id is filtered out of subsequent searches, but the underlying
+  graph node and vector storage are kept.
+- `RemoveMode::FORCE_REMOVE` physically rewrites the graph and reclaims the slot. This mode is
+  only available when the index was built with `support_remove: true` in `index_param` (which
+  causes the graph data cell to allocate the delete-tracking metadata). Calling `FORCE_REMOVE` on
+  an index built without `support_remove: true` will fail.
+
+```json
+{
+    "dtype": "float32",
+    "metric_type": "l2",
+    "dim": 128,
+    "index_param": {
+        "base_quantization_type": "sq8",
+        "max_degree": 16,
+        "ef_construction": 100,
+        "support_remove": true
+    }
+}
+```
+
+The JSON snippet above is only required if you intend to use `FORCE_REMOVE`. For `MARK_REMOVE`
+alone you can omit the `support_remove` flag.
+
+```json
+{
+    "dtype": "float32",
+    "metric_type": "l2",
+    "dim": 128,
+    "index_param": {
+        "base_quantization_type": "sq8",
+        "max_degree": 16,
+        "ef_construction": 100,
+        "support_remove": true
+    }
+}
+```
+
+```cpp
+// Single-id and batch overloads are available.
+index->Remove(id);
+index->Remove(std::vector<int64_t>{id1, id2, id3});
+```
+
+### Remove Modes
+
+The optional `RemoveMode` argument selects the deletion strategy:
+
+| Mode                          | Behavior                                                          |
+|-------------------------------|-------------------------------------------------------------------|
+| `RemoveMode::MARK_REMOVE` (default) | Tombstones the id; fast, no shrink or graph repair. Subsequent searches skip the id. Does not require `support_remove: true`. |
+| `RemoveMode::FORCE_REMOVE`    | Physically removes the vector and repairs the graph. Heavier. Requires the index to be built with `support_remove: true`. |
+
+`Remove` returns the number of ids that were successfully removed. Ids that did not exist are
+silently skipped and not counted.
+
+A runnable example is available at `examples/cpp/303_feature_remove.cpp`.
+
+## Updating Vectors and Ids
+
+### `UpdateVector`
+
+`UpdateVector(id, new_base, force_update = false)` replaces the vector data of an existing id in
+place. The default `force_update = false` mode performs a connectivity check: if the new vector
+is far from the original (which would degrade graph quality), the update is **rejected** and the
+caller is expected to fall back to `Remove` + `Add`.
+
+```cpp
+std::vector<float> new_vec(dim);  // populate with the replacement vector
+auto upd = vsag::Dataset::Make();
+upd->NumElements(1)->Dim(dim)->Ids(&id)->Float32Vectors(new_vec.data())->Owner(false);
+
+auto status = index->UpdateVector(id, upd, /*force_update=*/false);
+if (status.has_value() && *status) {
+    // updated in place
+} else if (status.has_value() && not *status) {
+    // rejected: new vector is too far from the old one — fall back to remove + add
+    index->Remove(id);
+    index->Add(upd);
+}
+```
+
+Setting `force_update = true` skips the check and always applies the update; use with caution as
+it may degrade recall.
+
+### `UpdateId`
+
+`UpdateId(old_id, new_id)` renames an existing id without touching the underlying vector.
+Returns `true` on success, `false` if `old_id` was not found or `new_id` already exists.
+
+```cpp
+index->UpdateId(123, 456);
+```
+
+A runnable example combining `UpdateVector`, `Remove`, and `Add` is available at
+`examples/cpp/305_feature_update.cpp`.
+
+## Cloning an Index
+
+`Clone()` produces a deep copy of the entire index — vectors, graph, quantizer state, and
+metadata — as an independent `IndexPtr`. The clone can be searched, mutated, or serialized
+independently of the source.
+
+```cpp
+auto cloned = index->Clone().value();
+
+// Both indexes return identical search results immediately after cloning.
+auto r1 = index->KnnSearch(query, k, params).value();
+auto r2 = cloned->KnnSearch(query, k, params).value();
+```
+
+`Clone` optionally accepts a custom `Allocator` so that the cloned index uses a different memory
+region than the source — useful for handing an index off to a thread or component that owns its
+own allocator. See [Memory Management](memory.md) for allocator details.
+
+A runnable example is available at `examples/cpp/309_feature_clone.cpp`.
+
+## Exporting the Trained Model
+
+`ExportModel()` returns an empty index that retains all trained state (quantization codebooks,
+centroids, hyperparameters) of the source but contains no vectors. It is the canonical way to
+share a pre-trained model across shards, processes, or hosts without re-running training.
+
+```cpp
+auto exported = index->ExportModel();
+if (not exported.has_value()) {
+    // index does not support ExportModel — handle the error
+    return;
+}
+auto model = *exported;
+
+// Populate the empty model with a new (potentially different) vector set.
+for (int64_t i = 0; i < num_vectors; ++i) {
+    auto one = vsag::Dataset::Make();
+    one->NumElements(1)->Dim(dim)->Ids(ids + i)
+       ->Float32Vectors(vectors + i * dim)->Owner(false);
+    model->Add(one);
+}
+```
+
+The returned index behaves identically to one freshly created via `Factory::CreateIndex(...)` and
+trained on the source data — only the per-vector storage is empty. This pattern is particularly
+useful for IVF-style indexes where training (k-means on centroids) is the dominant cost.
+
+A runnable example is available at `examples/cpp/310_feature_export_model.cpp`.
+
+## Notes and Limitations
+
+- `Remove`, `UpdateVector`, and `UpdateId` are concurrent-safe on HGraph when the matching
+  `*_CONCURRENT` capability flag is set. The flag set also gates safe combinations with
+  concurrent search and add (e.g. `SUPPORT_ADD_SEARCH_DELETE_CONCURRENT`).
+- `MARK_REMOVE` does not free memory; use `FORCE_REMOVE` or rebuild periodically if you need to
+  reclaim space.
+- `Clone` cost scales linearly with index size. For large indexes prefer serialization +
+  deserialization with a dedicated reader if you only need a snapshot on disk.
+- `ExportModel` preserves training but **not** any inserted vectors. The exported model can be
+  freely serialized and shipped before any vectors are added.

--- a/docs/docs/zh/src/SUMMARY.md
+++ b/docs/docs/zh/src/SUMMARY.md
@@ -35,6 +35,7 @@
 - [图索引增强](advanced/enhance_graph.md)
 - [内存-磁盘混合索引](advanced/hybrid_index.md)
 - [Extra Info（附加信息）](advanced/extra_info.md)
+- [索引生命周期管理](advanced/index_lifecycle.md)
 
 # 性能与调优
 

--- a/docs/docs/zh/src/advanced/index_lifecycle.md
+++ b/docs/docs/zh/src/advanced/index_lifecycle.md
@@ -1,0 +1,177 @@
+# 索引生命周期管理
+
+索引构建完成后，VSAG 提供一组用于原地修改索引或从已有索引派生新索引的操作。本页文档化完整的
+生命周期接口：
+
+- `Remove` —— 按 id 删除向量。
+- `UpdateVector` / `UpdateId` —— 修改已有向量或重命名其 id。
+- `Clone` —— 对已有索引进行深拷贝。
+- `ExportModel` —— 将训练好的模型导出为空索引以复用。
+
+每个操作均为可选项，仅当底层索引通过 `index->CheckFeature(...)` 公布对应能力标志时才可用。
+
+## 能力标志
+
+| 操作              | 能力标志                                  | HGraph | IVF | SINDI |
+|-------------------|------------------------------------------|:------:|:---:|:-----:|
+| `Remove`          | _（暂无专用标志，参见下文）_              |   是   |  —  |   —   |
+| `UpdateVector`    | `SUPPORT_UPDATE_VECTOR_CONCURRENT`       |   是   |  —  |  是   |
+| `UpdateId`        | `SUPPORT_UPDATE_ID_CONCURRENT`           |   是   |  —  |  是   |
+| `Clone`           | `SUPPORT_CLONE`                          |   是   | 是  |   —   |
+| `ExportModel`     | `SUPPORT_EXPORT_MODEL`                   |   是   | 是  |   —   |
+
+对于带能力标志的操作，请在调用前通过 `index->CheckFeature(vsag::SUPPORT_*)` 在运行时进行检查；
+不支持的索引会返回 `UNSUPPORTED_INDEX_OPERATION`。`Remove` 目前未提供专用能力标志，是否可用
+（以及支持哪种模式）参见下一节。
+
+## 删除向量
+
+`Remove` 按 id 删除向量。HGraph 支持两种删除模式，要求不同：
+
+- `RemoveMode::MARK_REMOVE`（默认）：仅通过 label table 写入墓碑标记，**不依赖** `support_remove`
+  即可调用。该 id 会在后续搜索中被过滤掉，但底层图节点与向量存储仍然保留。
+- `RemoveMode::FORCE_REMOVE`：物理重写图并回收存储槽。该模式仅在索引以
+  `index_param` 中 `support_remove: true` 构建时可用（这会让图 datacell 分配删除追踪元数据）。
+  若索引未带 `support_remove: true` 构建，调用 `FORCE_REMOVE` 会失败。
+
+```json
+{
+    "dtype": "float32",
+    "metric_type": "l2",
+    "dim": 128,
+    "index_param": {
+        "base_quantization_type": "sq8",
+        "max_degree": 16,
+        "ef_construction": 100,
+        "support_remove": true
+    }
+}
+```
+
+上述 JSON 仅在打算使用 `FORCE_REMOVE` 时是必需的。若只用 `MARK_REMOVE`，可以省略
+`support_remove` 字段。
+
+```json
+{
+    "dtype": "float32",
+    "metric_type": "l2",
+    "dim": 128,
+    "index_param": {
+        "base_quantization_type": "sq8",
+        "max_degree": 16,
+        "ef_construction": 100,
+        "support_remove": true
+    }
+}
+```
+
+```cpp
+// 提供单 id 与批量两种重载。
+index->Remove(id);
+index->Remove(std::vector<int64_t>{id1, id2, id3});
+```
+
+### 删除模式
+
+可选的 `RemoveMode` 参数用于选择删除策略：
+
+| 模式                                | 行为                                                                |
+|-------------------------------------|---------------------------------------------------------------------|
+| `RemoveMode::MARK_REMOVE`（默认）   | 对 id 打墓碑标记；速度快，不收缩、不修图。后续搜索会跳过该 id。不要求 `support_remove: true`。 |
+| `RemoveMode::FORCE_REMOVE`          | 物理删除向量并修复图结构。开销较大。要求索引以 `support_remove: true` 构建。 |
+
+`Remove` 返回成功删除的 id 数量。原本不存在的 id 会被静默跳过，不计入返回值。
+
+可运行示例：`examples/cpp/303_feature_remove.cpp`。
+
+## 更新向量与 id
+
+### `UpdateVector`
+
+`UpdateVector(id, new_base, force_update = false)` 在原地替换已有 id 对应的向量数据。默认的
+`force_update = false` 模式会做连通性检查：若新向量距离原向量较远（这会破坏图质量），更新会被
+**拒绝**，调用方应当退回到 `Remove` + `Add` 方案。
+
+```cpp
+std::vector<float> new_vec(dim);  // 填入替换向量
+auto upd = vsag::Dataset::Make();
+upd->NumElements(1)->Dim(dim)->Ids(&id)->Float32Vectors(new_vec.data())->Owner(false);
+
+auto status = index->UpdateVector(id, upd, /*force_update=*/false);
+if (status.has_value() && *status) {
+    // 已原地更新
+} else if (status.has_value() && not *status) {
+    // 被拒绝：新向量距离原向量太远 —— 退回到 remove + add
+    index->Remove(id);
+    index->Add(upd);
+}
+```
+
+将 `force_update` 置为 `true` 会跳过检查并强制更新；请谨慎使用，可能损失召回率。
+
+### `UpdateId`
+
+`UpdateId(old_id, new_id)` 重命名已有 id 而不动底层向量。成功返回 `true`，若 `old_id` 不存在
+或 `new_id` 已被占用则返回 `false`。
+
+```cpp
+index->UpdateId(123, 456);
+```
+
+结合 `UpdateVector`、`Remove`、`Add` 的可运行示例：`examples/cpp/305_feature_update.cpp`。
+
+## 克隆索引
+
+`Clone()` 对整个索引做深拷贝 —— 包括向量、图、量化器状态与元数据 —— 返回一个独立的
+`IndexPtr`。该克隆体可独立于源索引进行搜索、修改或序列化。
+
+```cpp
+auto cloned = index->Clone().value();
+
+// 克隆完成后，两个索引返回的搜索结果完全一致。
+auto r1 = index->KnnSearch(query, k, params).value();
+auto r2 = cloned->KnnSearch(query, k, params).value();
+```
+
+`Clone` 还可选传入自定义 `Allocator`，使克隆索引使用与源不同的内存区 —— 便于把索引交给拥有
+自己内存分配器的线程或组件。分配器细节参见 [内存管理](memory.md)。
+
+可运行示例：`examples/cpp/309_feature_clone.cpp`。
+
+## 导出训练模型
+
+`ExportModel()` 返回一个保留了源索引全部训练状态（量化码本、聚类中心、超参数）但**不含**任何
+向量的空索引。这是在多个分片、进程或主机之间共享预训练模型而无需重新训练的标准做法。
+
+```cpp
+auto exported = index->ExportModel();
+if (not exported.has_value()) {
+    // 索引不支持 ExportModel —— 处理错误
+    return;
+}
+auto model = *exported;
+
+// 向空模型注入一批新的（可与源不同的）向量。
+for (int64_t i = 0; i < num_vectors; ++i) {
+    auto one = vsag::Dataset::Make();
+    one->NumElements(1)->Dim(dim)->Ids(ids + i)
+       ->Float32Vectors(vectors + i * dim)->Owner(false);
+    model->Add(one);
+}
+```
+
+返回的索引行为上等同于一个通过 `Factory::CreateIndex(...)` 新建并在源数据上完成训练的索引 ——
+仅每条向量的存储为空。该模式对训练（中心点 k-means）开销占主导的 IVF 类索引尤其有用。
+
+可运行示例：`examples/cpp/310_feature_export_model.cpp`。
+
+## 注意事项与限制
+
+- 当对应的 `*_CONCURRENT` 能力标志被置位时，HGraph 上的 `Remove`、`UpdateVector`、`UpdateId`
+  是并发安全的。该标志组还约束与并发搜索、增加之间的安全组合（如
+  `SUPPORT_ADD_SEARCH_DELETE_CONCURRENT`）。
+- `MARK_REMOVE` 不会释放内存；如需回收空间请使用 `FORCE_REMOVE` 或定期重建索引。
+- `Clone` 的开销与索引规模线性相关。如果只需要磁盘快照，对大索引来说更适合采用「序列化 + 由
+  专用 reader 反序列化」的方案。
+- `ExportModel` 保留训练状态，但**不**保留任何已插入的向量。导出的模型可以在尚未添加任何向量
+  之前自由序列化、分发。


### PR DESCRIPTION
## Summary

Adds an **Index Lifecycle Management** page under Advanced Features that documents the `Remove`,
`UpdateVector` / `UpdateId`, `Clone`, and `ExportModel` operations. These APIs are exercised by
existing examples (`303_feature_remove.cpp`, `305_feature_update.cpp`, `309_feature_clone.cpp`,
`310_feature_export_model.cpp`) but had no counterpart on the website.

## What's covered

- Capability-flag matrix per index (HGraph / IVF / SINDI) for each operation.
- `RemoveMode::MARK_REMOVE` vs `RemoveMode::FORCE_REMOVE` semantics, plus the HGraph
  `support_remove` build parameter.
- `UpdateVector(..., force_update)` rejection semantics and the recommended `Remove` + `Add`
  fall-back pattern.
- `Clone` (with optional custom allocator) and `ExportModel` (training state without vectors)
  usage and runnable example pointers.

## Documentation set sync

- `docs/docs/en/src/advanced/index_lifecycle.md` (new)
- `docs/docs/zh/src/advanced/index_lifecycle.md` (new)
- `docs/docs/en/src/SUMMARY.md` (one navigation entry)
- `docs/docs/zh/src/SUMMARY.md` (one navigation entry)

No source or test changes; documentation-only PR.