### PR TITLE
docs: expand memory page and add Index Introspection page

### DIFF
--- a/docs/docs/en/src/SUMMARY.md
+++ b/docs/docs/en/src/SUMMARY.md
@@ -32,6 +32,7 @@
 - [Attribute Filter (Hybrid Search)](advanced/attribute_filter.md)
 - [Serialization](advanced/serialization.md)
 - [Memory Management](advanced/memory.md)
+- [Index Introspection](advanced/introspection.md)
 - [Graph Enhancement](advanced/enhance_graph.md)
 - [Hybrid Memory-Disk Index](advanced/hybrid_index.md)
 - [Extra Info](advanced/extra_info.md)

--- a/docs/docs/en/src/advanced/introspection.md
+++ b/docs/docs/en/src/advanced/introspection.md
@@ -1,0 +1,134 @@
+# Index Introspection
+
+VSAG indexes expose three families of introspection APIs that let callers discover what an index
+can do, compute distances against existing vectors, and read back structured information about
+the built index without re-running a search:
+
+- **`CheckFeature(IndexFeature)`** — runtime capability discovery.
+- **`CalDistanceById(...)`** — distance from a query to specific stored ids.
+- **`GetIndexDetailInfos()` / `GetDetailDataByName(...)`** — structured per-index detail data.
+
+These APIs are read-only and safe to call concurrently with search.
+
+## Capability Discovery — `CheckFeature`
+
+`index->CheckFeature(vsag::SUPPORT_*)` returns `true` when the underlying index implementation
+advertises the given feature. Use it whenever a code path takes an `IndexPtr` of unknown concrete
+type (e.g. user-supplied configuration, polymorphic store):
+
+```cpp
+if (index->CheckFeature(vsag::SUPPORT_ESTIMATE_MEMORY)) {
+    uint64_t est = index->EstimateMemory(100'000);
+}
+
+if (not index->CheckFeature(vsag::SUPPORT_DELETE_BY_ID)) {
+    // Skip / fall back to remove + re-add via a different index.
+}
+```
+
+Feature flags cover almost every optional surface in the library: build / add /
+serialize variants, concurrent combinations, metric types, attribute and extra-info filters,
+`Clone`, `ExportModel`, `Tune`, and more. See `include/vsag/index_features.h` for the full
+enumeration.
+
+A runnable example is available at `examples/cpp/307_feature_check_features.cpp`.
+
+## Distances to Existing Ids — `CalDistanceById`
+
+`CalDistanceById` computes the distance between a query and one or more vectors that are
+**already stored in the index**, without running a search. This is useful for re-ranking, A/B
+evaluation, ground-truth checks, or computing pairwise distances to a known shortlist.
+
+Two overloads are provided:
+
+```cpp
+// Dense vector indexes (HGraph, BruteForce, IVF, DiskANN, HNSW)
+auto r = index->CalDistanceById(query_ptr, ids, count, /*calculate_precise_distance=*/true);
+
+// Sparse vector indexes (SINDI, SparseIndex) — wrap the query in a Dataset
+auto query_ds = vsag::Dataset::Make();
+query_ds->NumElements(1)->SparseVectors(/* ... */);
+auto r = index->CalDistanceById(query_ds, ids, count, /*calculate_precise_distance=*/true);
+```
+
+The result `Dataset` holds `count` distances in `GetDistances()`. A value of `-1.0F` means the
+corresponding id was invalid (not present in the index).
+
+### `calculate_precise_distance`
+
+The trailing `bool` argument trades precision for latency:
+
+| Value | Behavior                                                                                                  |
+|-------|-----------------------------------------------------------------------------------------------------------|
+| `true` (default) | Use the full-precision vector representation. May incur disk I/O on hybrid memory-disk indexes. |
+| `false`          | Use the quantized / approximate representation cached for search. Faster, no I/O.               |
+
+A runnable example is available at `examples/cpp/306_feature_calculate_distance_by_id.cpp`.
+
+## Detail Data — `GetIndexDetailInfos` / `GetDetailDataByName`
+
+`GetIndexDetailInfos()` returns a list of `IndexDetailInfo` records that describe every named
+piece of structured data the index can expose. Each record carries a `name`, a `description`, and
+a `type` enum that selects the right typed accessor on `DetailData`.
+
+Support is index-dependent — there is no dedicated `SUPPORT_*` flag for these two APIs. The
+`Index` base class throws `std::runtime_error("Index doesn't support ...")` by default
+(`GetIndexDetailInfos` and `GetDetailDataByName` in `include/vsag/index.h:658,674`);
+HGraph / IVF / BruteForce / Pyramid / SINDI / WARP implement them through
+`InnerIndexInterface`, while `HNSW` only overrides `GetDetailDataByName` and DiskANN does not
+override either. Always handle the `tl::expected` error path when calling these APIs.
+
+```cpp
+auto infos = index->GetIndexDetailInfos().value();
+for (const auto& info : infos) {
+    std::cout << info.name << " : " << info.description << '\n';
+}
+```
+
+Once you know which entries are available, call `GetDetailDataByName(name, info)` to retrieve the
+typed payload:
+
+```cpp
+vsag::IndexDetailInfo info;
+auto detail = index->GetDetailDataByName(vsag::INDEX_DETAIL_NAME_NUM_ELEMENTS, info).value();
+int64_t n = detail->GetDataScalarInt64();
+
+detail = index->GetDetailDataByName(vsag::INDEX_DETAIL_NAME_LABEL_TABLE, info).value();
+auto table = detail->GetData2DArrayInt64();   // [row][col] int64 matrix
+
+detail = index->GetDetailDataByName(vsag::INDEX_DETAIL_DATA_TYPE, info).value();
+std::string dt = detail->GetDataScalarString();
+```
+
+### Data Types
+
+`info.type` selects which accessor on `DetailData` is valid:
+
+| `IndexDetailDataType`     | Accessor                              |
+|---------------------------|---------------------------------------|
+| `TYPE_SCALAR_INT64`       | `GetDataScalarInt64()`                |
+| `TYPE_SCALAR_DOUBLE`      | `GetDataScalarDouble()`               |
+| `TYPE_SCALAR_BOOL`        | `GetDataScalarBool()`                 |
+| `TYPE_SCALAR_STRING`      | `GetDataScalarString()`               |
+| `TYPE_1DArray_INT64`      | `GetData1DArrayInt64()`               |
+| `TYPE_2DArray_INT64`      | `GetData2DArrayInt64()`               |
+
+Standard detail names exposed as constants in `include/vsag/index_detail_info.h`:
+
+| Constant                            | Typical type           | Meaning                                  |
+|-------------------------------------|------------------------|------------------------------------------|
+| `INDEX_DETAIL_NAME_NUM_ELEMENTS`    | `TYPE_SCALAR_INT64`    | Number of vectors currently in the index. |
+| `INDEX_DETAIL_NAME_LABEL_TABLE`     | `TYPE_2DArray_INT64`   | Per-vector label table (e.g. internal-to-user id mapping). |
+| `INDEX_DETAIL_DATA_TYPE`            | `TYPE_SCALAR_STRING`   | Underlying vector data type (e.g. `"float32"`). |
+
+Individual indexes may expose additional names; iterate `GetIndexDetailInfos()` to discover them
+at runtime. A runnable example is available at `examples/cpp/317_feature_get_detail_data.cpp`.
+
+## Notes and Limitations
+
+- `CheckFeature` is constant-time. Prefer it over `try` / `catch` around an unsupported call.
+- `CalDistanceById` requires the underlying index to retain enough information to recompute the
+  distance. For purely quantized indexes (no raw vectors retained), `calculate_precise_distance =
+  true` may return the quantized distance instead.
+- `GetIndexDetailInfos` and `GetDetailDataByName` are read-only snapshots. The values returned
+  reflect the index state at the moment of the call; concurrent mutations may invalidate them.

--- a/docs/docs/en/src/advanced/memory.md
+++ b/docs/docs/en/src/advanced/memory.md
@@ -43,10 +43,58 @@ See `examples/cpp/313_feature_search_allocator.cpp` and
 
 ## Estimating and Querying Memory
 
-- `Index::EstimateMemory(data_num)` — estimate memory usage before building
-  (`examples/cpp/308_feature_estimate_memory.cpp`).
-- `Index::GetMemoryUsage()` — query the current memory footprint
-  (`examples/cpp/319_feature_get_memory_usage.cpp`).
+### `EstimateMemory(data_num)`
+
+`Index::EstimateMemory(data_num)` returns a byte-level estimate of the memory the index will
+occupy once `data_num` vectors have been inserted. It is computed from the build parameters
+(dimension, quantization, `max_degree`, etc.) without allocating any vector storage, so it is
+safe to call on an empty index and is the recommended way to size a node before ingest:
+
+```cpp
+if (index->CheckFeature(vsag::SUPPORT_ESTIMATE_MEMORY)) {
+    uint64_t estimated = index->EstimateMemory(1'000'000);  // bytes
+}
+```
+
+See `examples/cpp/308_feature_estimate_memory.cpp` for a full run.
+
+### `GetMemoryUsage()`
+
+`Index::GetMemoryUsage()` returns the **current** memory footprint of an index in bytes:
+
+```cpp
+int64_t bytes = index->GetMemoryUsage();
+```
+
+Properties:
+
+- Implemented by every index type, but only indexes that advertise
+  `vsag::SUPPORT_GET_MEMORY_USAGE` via `CheckFeature` are formally guaranteed to return a
+  meaningful value. HGraph, IVF, BruteForce, Pyramid and WARP set the flag
+  (see `src/algorithm/{hgraph,ivf,brute_force,pyramid,warp}.cpp`); SINDI implements the call
+  (since the method is pure-virtual on `Index`) but does not currently set the feature flag, so
+  treat its value as informational only.
+- Thread-safe; can be polled concurrently with searches.
+- Latency is on the order of microseconds — suitable for production-grade real-time
+  monitoring loops.
+- Reports memory attributable to the index itself (vectors, graph, quantizer state). The number
+  is typically smaller than the resident set size observed at the OS level, which also includes
+  allocator overhead, scratch buffers, and any data held outside the index (e.g. user-owned input
+  vectors). For SINDI in particular, call `GetMemoryUsage()` **after** the build completes to get
+  a representative value.
+
+See `examples/cpp/319_feature_get_memory_usage.cpp` for a runnable example, including a helper
+that compares the interface value with the process resident size.
+
+### Capability Flags
+
+| Flag                          | Meaning                                          |
+|-------------------------------|--------------------------------------------------|
+| `vsag::SUPPORT_ESTIMATE_MEMORY` | `EstimateMemory(data_num)` is available.       |
+| `vsag::SUPPORT_GET_MEMORY_USAGE` | `GetMemoryUsage()` is available.              |
+
+Both flags can be checked via `index->CheckFeature(...)` — see
+[Index Introspection](introspection.md).
 
 ## Thread Pool
 

--- a/docs/docs/zh/src/SUMMARY.md
+++ b/docs/docs/zh/src/SUMMARY.md
@@ -32,6 +32,7 @@
 - [属性过滤（混合搜索）](advanced/attribute_filter.md)
 - [序列化格式](advanced/serialization.md)
 - [内存管理](advanced/memory.md)
+- [索引自省](advanced/introspection.md)
 - [图索引增强](advanced/enhance_graph.md)
 - [内存-磁盘混合索引](advanced/hybrid_index.md)
 - [Extra Info（附加信息）](advanced/extra_info.md)

--- a/docs/docs/zh/src/advanced/introspection.md
+++ b/docs/docs/zh/src/advanced/introspection.md
@@ -1,0 +1,128 @@
+# 索引自省
+
+VSAG 提供三类自省 API，让调用方可以发现某个索引的能力、对已有向量计算距离，以及读出关于已构建
+索引的结构化信息，而无需重新执行一次搜索：
+
+- **`CheckFeature(IndexFeature)`** —— 运行时能力探测。
+- **`CalDistanceById(...)`** —— 计算 query 到已存入向量 id 的距离。
+- **`GetIndexDetailInfos()` / `GetDetailDataByName(...)`** —— 读取索引各项结构化详情数据。
+
+这些 API 均为只读操作，可与搜索并发调用。
+
+## 能力探测 —— `CheckFeature`
+
+当底层索引实现公布了某项能力时，`index->CheckFeature(vsag::SUPPORT_*)` 返回 `true`。当代码路径
+持有一个具体类型未知的 `IndexPtr`（例如用户配置注入、多态存储）时，应使用此 API：
+
+```cpp
+if (index->CheckFeature(vsag::SUPPORT_ESTIMATE_MEMORY)) {
+    uint64_t est = index->EstimateMemory(100'000);
+}
+
+if (not index->CheckFeature(vsag::SUPPORT_DELETE_BY_ID)) {
+    // 跳过 / 通过另一个索引以 remove + re-add 方式回退。
+}
+```
+
+能力标志几乎覆盖了库中所有可选接口：build / add / 序列化变体、各种并发组合、度量类型、属性
+过滤、extra-info 过滤、`Clone`、`ExportModel`、`Tune` 等。完整枚举见
+`include/vsag/index_features.h`。
+
+可运行示例：`examples/cpp/307_feature_check_features.cpp`。
+
+## 到已有 id 的距离 —— `CalDistanceById`
+
+`CalDistanceById` 计算 query 与索引中**已存在**的一个或多个向量之间的距离，**无需**执行一次
+搜索。它适用于 re-rank、A/B 评估、ground-truth 校验，或对已知候选集合做成对距离计算。
+
+提供两个重载：
+
+```cpp
+// 稠密向量索引（HGraph、BruteForce、IVF、DiskANN、HNSW）
+auto r = index->CalDistanceById(query_ptr, ids, count, /*calculate_precise_distance=*/true);
+
+// 稀疏向量索引（SINDI、SparseIndex）—— 用 Dataset 封装查询
+auto query_ds = vsag::Dataset::Make();
+query_ds->NumElements(1)->SparseVectors(/* ... */);
+auto r = index->CalDistanceById(query_ds, ids, count, /*calculate_precise_distance=*/true);
+```
+
+结果 `Dataset` 中 `GetDistances()` 持有 `count` 个距离。若某个 id 无效（不在索引中），对应位置
+返回 `-1.0F`。
+
+### `calculate_precise_distance`
+
+末尾的 `bool` 参数在精度与延迟之间做取舍：
+
+| 取值              | 行为                                                                      |
+|-------------------|---------------------------------------------------------------------------|
+| `true`（默认）    | 使用全精度向量表征。在内存-磁盘混合索引上可能引发磁盘 I/O。              |
+| `false`           | 使用搜索路径缓存的量化 / 近似表征。更快、无 I/O。                         |
+
+可运行示例：`examples/cpp/306_feature_calculate_distance_by_id.cpp`。
+
+## 详情数据 —— `GetIndexDetailInfos` / `GetDetailDataByName`
+
+`GetIndexDetailInfos()` 返回一组 `IndexDetailInfo` 记录，描述索引可对外暴露的每一项命名结构化
+数据。每条记录包含 `name`、`description` 和一个 `type` 枚举，后者用于选择 `DetailData` 上的
+合适访问器。
+
+是否支持取决于索引类型 —— 这两个 API 没有专门的 `SUPPORT_*` flag。`Index` 基类默认抛
+`std::runtime_error("Index doesn't support ...")`（`GetIndexDetailInfos` 与
+`GetDetailDataByName`，见 `include/vsag/index.h:658,674`）；HGraph / IVF / BruteForce /
+Pyramid / SINDI / WARP 通过 `InnerIndexInterface` 提供了实现，而 `HNSW` 仅 override 了
+`GetDetailDataByName`，DiskANN 两者都没有 override。调用时请始终处理 `tl::expected`
+的 error 分支。
+
+```cpp
+auto infos = index->GetIndexDetailInfos().value();
+for (const auto& info : infos) {
+    std::cout << info.name << " : " << info.description << '\n';
+}
+```
+
+知道哪些项可用后，调用 `GetDetailDataByName(name, info)` 获取对应类型的数据：
+
+```cpp
+vsag::IndexDetailInfo info;
+auto detail = index->GetDetailDataByName(vsag::INDEX_DETAIL_NAME_NUM_ELEMENTS, info).value();
+int64_t n = detail->GetDataScalarInt64();
+
+detail = index->GetDetailDataByName(vsag::INDEX_DETAIL_NAME_LABEL_TABLE, info).value();
+auto table = detail->GetData2DArrayInt64();   // [row][col] int64 矩阵
+
+detail = index->GetDetailDataByName(vsag::INDEX_DETAIL_DATA_TYPE, info).value();
+std::string dt = detail->GetDataScalarString();
+```
+
+### 数据类型
+
+`info.type` 决定 `DetailData` 上哪一个访问器有效：
+
+| `IndexDetailDataType`     | 访问器                                |
+|---------------------------|---------------------------------------|
+| `TYPE_SCALAR_INT64`       | `GetDataScalarInt64()`                |
+| `TYPE_SCALAR_DOUBLE`      | `GetDataScalarDouble()`               |
+| `TYPE_SCALAR_BOOL`        | `GetDataScalarBool()`                 |
+| `TYPE_SCALAR_STRING`      | `GetDataScalarString()`               |
+| `TYPE_1DArray_INT64`      | `GetData1DArrayInt64()`               |
+| `TYPE_2DArray_INT64`      | `GetData2DArrayInt64()`               |
+
+`include/vsag/index_detail_info.h` 中以常量形式给出的标准详情名：
+
+| 常量                                | 典型类型                | 含义                                          |
+|-------------------------------------|-------------------------|-----------------------------------------------|
+| `INDEX_DETAIL_NAME_NUM_ELEMENTS`    | `TYPE_SCALAR_INT64`     | 索引当前包含的向量数。                          |
+| `INDEX_DETAIL_NAME_LABEL_TABLE`     | `TYPE_2DArray_INT64`    | 逐向量的 label 表（如内部 id ↔ 用户 id 映射）。 |
+| `INDEX_DETAIL_DATA_TYPE`            | `TYPE_SCALAR_STRING`    | 底层向量数据类型（如 `"float32"`）。           |
+
+具体索引可能额外暴露其他名称；运行期通过 `GetIndexDetailInfos()` 遍历即可发现。可运行示例：
+`examples/cpp/317_feature_get_detail_data.cpp`。
+
+## 注意事项与限制
+
+- `CheckFeature` 是常数时间复杂度。相比对不支持的调用做 `try` / `catch`，应优先使用它。
+- `CalDistanceById` 要求底层索引保留足够信息以重新计算距离。对于纯量化索引（不保留原始向量），
+  即使传入 `calculate_precise_distance = true`，也可能返回量化距离。
+- `GetIndexDetailInfos` 与 `GetDetailDataByName` 是只读快照。返回的数值反映调用瞬间的索引状态，
+  并发修改可能使其失效。

--- a/docs/docs/zh/src/advanced/memory.md
+++ b/docs/docs/zh/src/advanced/memory.md
@@ -42,8 +42,53 @@ auto result = index->KnnSearch(query, k, search_param);
 
 ## 估算与查询内存占用
 
-- `Index::EstimateMemory(data_num)`：在构建前估算索引将占用的内存（示例：`examples/cpp/308_feature_estimate_memory.cpp`）。
-- `Index::GetMemoryUsage()`：查询当前实际占用的字节数（示例：`examples/cpp/319_feature_get_memory_usage.cpp`）。
+### `EstimateMemory(data_num)`
+
+`Index::EstimateMemory(data_num)` 返回索引在插入 `data_num` 条向量后预期占用的字节数。它仅基于
+构建参数（dim、量化方式、`max_degree` 等）推算，不会分配任何向量存储，因此可以在空索引上安全
+调用，是入库前评估节点规格的推荐方式：
+
+```cpp
+if (index->CheckFeature(vsag::SUPPORT_ESTIMATE_MEMORY)) {
+    uint64_t estimated = index->EstimateMemory(1'000'000);  // 字节
+}
+```
+
+完整示例：`examples/cpp/308_feature_estimate_memory.cpp`。
+
+### `GetMemoryUsage()`
+
+`Index::GetMemoryUsage()` 返回索引**当前**占用的字节数：
+
+```cpp
+int64_t bytes = index->GetMemoryUsage();
+```
+
+特性：
+
+- 所有索引类型均实现了该方法，但只有通过 `CheckFeature` 公布 `vsag::SUPPORT_GET_MEMORY_USAGE`
+  的索引才保证返回有意义的数值。HGraph、IVF、BruteForce、Pyramid、WARP 均声明了该能力
+  （见 `src/algorithm/{hgraph,ivf,brute_force,pyramid,warp}.cpp`）；SINDI 出于
+  接口纯虚函数的要求实现了该方法，但当前未设置该 feature flag，请仅把返回值视为参考信息。
+- 线程安全；可与搜索并发轮询。
+- 延迟在微秒量级 —— 适合生产环境的实时内存监控。
+- 统计的是索引自身占用的内存（向量、图、量化器状态）。该值通常小于操作系统层面观察到的 RSS：
+  RSS 还包含 allocator 的开销、临时 scratch buffer、以及索引外部持有的数据（例如用户自有的输入
+  向量缓冲）。SINDI 索引尤其建议在构建完成**之后**调用 `GetMemoryUsage()` 才能拿到具有代表性的
+  数值。
+
+可运行示例：`examples/cpp/319_feature_get_memory_usage.cpp`，其中包含一个辅助函数将接口值与进程
+驻留内存进行对照。
+
+### 能力标志
+
+| 标志                              | 含义                                  |
+|-----------------------------------|---------------------------------------|
+| `vsag::SUPPORT_ESTIMATE_MEMORY`   | 支持 `EstimateMemory(data_num)`。     |
+| `vsag::SUPPORT_GET_MEMORY_USAGE`  | 支持 `GetMemoryUsage()`。             |
+
+两个标志均可通过 `index->CheckFeature(...)` 查询 —— 参见
+[索引自省](introspection.md)。
 
 ## 线程池
 


### PR DESCRIPTION
## Summary

- **Expands** `advanced/memory.md` to fully document `EstimateMemory` and `GetMemoryUsage`:
  per-index support matrix, byte-level semantics, thread-safety and latency notes, and the
  matching capability flags. Absorbs the previously stand-alone `docs/get_memory_usage_en.md`
  notes that were not surfaced on the website.
- **Adds** `advanced/introspection.md`, a new page in Advanced Features that documents the three
  read-only introspection APIs exercised by examples 307 / 306 / 317:
  - `CheckFeature(IndexFeature)` — runtime capability discovery.
  - `CalDistanceById(...)` — dense and sparse overloads, with `calculate_precise_distance`
    semantics.
  - `GetIndexDetailInfos()` / `GetDetailDataByName(...)` — typed accessors on `DetailData` and
    the standard detail-name constants.

## Documentation set sync

- `docs/docs/en/src/advanced/memory.md` (expanded)
- `docs/docs/zh/src/advanced/memory.md` (expanded)
- `docs/docs/en/src/advanced/introspection.md` (new)
- `docs/docs/zh/src/advanced/introspection.md` (new)
- `docs/docs/en/src/SUMMARY.md` (one navigation entry)
- `docs/docs/zh/src/SUMMARY.md` (one navigation entry)

No source or test changes; documentation-only PR.