### PR TITLE
docs: document non-fp32 input types for HGraph

### DIFF
--- a/docs/docs/en/src/indexes/hgraph.md
+++ b/docs/docs/en/src/indexes/hgraph.md
@@ -81,6 +81,119 @@ and `docs/hgraph.md` in the repository.
 | `base_file_path` / `precise_file_path` | string | — | File path; required when the corresponding `*_io_type` is disk-backed (`buffer_io`, `async_io`, `mmap_io`) |
 | `hgraph_init_capacity` | int | `100` | Initial capacity hint (doesn't cap the final size) |
 
+## Supported input data types
+
+The `dtype` field in the top-level build config selects how `Dataset` interprets the raw vector
+bytes. HGraph supports four input types; the `dtype` value, the corresponding `Dataset` setter,
+and the example demonstrating each combination are summarised below.
+
+| `dtype`     | Element type | `Dataset` setter         | Example                                                                                                |
+|-------------|--------------|--------------------------|--------------------------------------------------------------------------------------------------------|
+| `float32`   | `float`      | `Float32Vectors`         | [`103_index_hgraph.cpp`](https://github.com/antgroup/vsag/blob/main/examples/cpp/103_index_hgraph.cpp) |
+| `int8`      | `int8_t`     | `Int8Vectors`            | [`316_index_int8_hgraph.cpp`](https://github.com/antgroup/vsag/blob/main/examples/cpp/316_index_int8_hgraph.cpp) |
+| `float16`   | `uint16_t` (IEEE 754 binary16, bit-pattern packed) | `Float16Vectors` | [`321_index_fp16_hgraph.cpp`](https://github.com/antgroup/vsag/blob/main/examples/cpp/321_index_fp16_hgraph.cpp) |
+| `bfloat16`  | `uint16_t` (Brain Float, bit-pattern packed) | `Float16Vectors` (shared with FP16) | adapt `321_index_fp16_hgraph.cpp` per the notes below                                                  |
+
+The `dim` value is the logical vector dimensionality (number of elements), not the byte length, so
+the same `dim` is reused across all four data types.
+
+### `int8` input
+
+Quantized `int8` vectors are passed directly via `Int8Vectors`:
+
+```cpp
+std::vector<int8_t> data(num_vectors * dim);  // populate with int8 elements
+auto base = vsag::Dataset::Make();
+base->NumElements(num_vectors)->Dim(dim)->Ids(ids)
+    ->Int8Vectors(data.data())->Owner(false);
+```
+
+Build config (note `dtype: "int8"`):
+
+```json
+{
+    "dtype": "int8",
+    "metric_type": "l2",
+    "dim": 128,
+    "index_param": {
+        "base_quantization_type": "pq",
+        "max_degree": 26,
+        "ef_construction": 100,
+        "alpha": 1.2
+    }
+}
+```
+
+Queries use the same `Int8Vectors` setter and the same `dtype`. A runnable example is
+[`316_index_int8_hgraph.cpp`](https://github.com/antgroup/vsag/blob/main/examples/cpp/316_index_int8_hgraph.cpp).
+
+### `float16` / `bfloat16` input
+
+FP16 and BF16 vectors are both passed through `Float16Vectors`, which takes a `const uint16_t*`
+that points at the 16-bit storage of each element. Conversion from `float` is up to the caller;
+inside the VSAG source tree there are convenience helpers (`vsag::generic::FloatToFP16` in
+[`src/simd/fp16_simd.h`](https://github.com/antgroup/vsag/blob/main/src/simd/fp16_simd.h)
+and `vsag::generic::FloatToBF16` in
+[`src/simd/bf16_simd.h`](https://github.com/antgroup/vsag/blob/main/src/simd/bf16_simd.h)),
+but these are **internal headers** that are not installed under `include/vsag/`. Application code
+linking against an installed VSAG library should provide its own conversion (for example, copy
+the small helper, use `_cvtss_sh` / F16C intrinsics, or any FP16 library of choice). The snippet
+below uses the in-tree helper for brevity:
+
+```cpp
+// The fp16/bf16 helpers below live in src/simd/ and are not part of the public
+// installed headers. Replace with your own float -> uint16_t conversion when
+// linking against an installed VSAG.
+#include "simd/fp16_simd.h"  // FloatToFP16 (for BF16, use simd/bf16_simd.h / FloatToBF16)
+
+std::vector<uint16_t> data(num_vectors * dim);
+for (size_t i = 0; i < data.size(); ++i) {
+    data[i] = vsag::generic::FloatToFP16(some_float_source());
+}
+auto base = vsag::Dataset::Make();
+base->NumElements(num_vectors)->Dim(dim)->Ids(ids)
+    ->Float16Vectors(data.data())->Owner(false);
+```
+
+Build config:
+
+```json
+{
+    "dtype": "float16",
+    "metric_type": "l2",
+    "dim": 128,
+    "index_param": {
+        "base_quantization_type": "pq",
+        "max_degree": 26,
+        "ef_construction": 100,
+        "alpha": 1.2
+    }
+}
+```
+
+To switch the example to BF16, change `dtype` to `"bfloat16"` and replace `FloatToFP16` with
+`FloatToBF16`; the `Float16Vectors` setter and the rest of the build/search flow stay the same.
+A runnable FP16 example is
+[`321_index_fp16_hgraph.cpp`](https://github.com/antgroup/vsag/blob/main/examples/cpp/321_index_fp16_hgraph.cpp).
+
+> **Note.** The header comment at the top of `321_index_fp16_hgraph.cpp` currently mentions a
+> `BFloat16Vectors()` setter, but no such setter exists — `Float16Vectors` is the single entry
+> point for both FP16 and BF16. Use it for both `dtype: "float16"` and `dtype: "bfloat16"`.
+
+### Choosing an input type
+
+- Pick `float32` when accuracy matters most and memory budget allows; this is the default.
+- Pick `float16` / `bfloat16` to halve the input storage. FP16 has a smaller exponent range; BF16
+  has fewer mantissa bits but the same exponent range as FP32, which is often preferable for
+  embedding-style vectors.
+- Pick `int8` when your data is already integer-quantised (e.g. produced by an upstream quantiser
+  or by a model with int8 outputs). With `int8` input you typically still combine a coarse
+  quantizer such as `pq` / `sq8` for the in-index storage.
+
+The chosen `dtype` only constrains the **input** representation. The on-disk / in-memory storage is
+still controlled by `base_quantization_type` (and optionally `precise_quantization_type` when
+`use_reorder: true`), so e.g. `dtype: "float16"` + `base_quantization_type: "sq8"` is valid.
+
 ## Search parameters
 
 Search-time parameters live under the `hgraph` sub-object:

--- a/docs/docs/zh/src/indexes/hgraph.md
+++ b/docs/docs/zh/src/indexes/hgraph.md
@@ -74,6 +74,112 @@ auto result = index->KnnSearch(
 | `base_file_path` / `precise_file_path` | string | — | 磁盘后端时的文件路径（使用 `mmap_io` / `async_io` / `buffer_io` 时必填） |
 | `hgraph_init_capacity` | int | `100` | 初始容量提示（不会限制最终规模） |
 
+## 支持的输入数据类型
+
+顶层构建配置中的 `dtype` 字段决定 `Dataset` 如何解释原始向量字节。HGraph 支持四种输入类型，
+`dtype` 值、对应的 `Dataset` setter 与演示示例见下表。
+
+| `dtype`     | 元素类型 | `Dataset` setter         | 示例                                                                                                  |
+|-------------|----------|--------------------------|-------------------------------------------------------------------------------------------------------|
+| `float32`   | `float`  | `Float32Vectors`         | [`103_index_hgraph.cpp`](https://github.com/antgroup/vsag/blob/main/examples/cpp/103_index_hgraph.cpp) |
+| `int8`      | `int8_t` | `Int8Vectors`            | [`316_index_int8_hgraph.cpp`](https://github.com/antgroup/vsag/blob/main/examples/cpp/316_index_int8_hgraph.cpp) |
+| `float16`   | `uint16_t`（按 IEEE 754 binary16 位模式打包） | `Float16Vectors` | [`321_index_fp16_hgraph.cpp`](https://github.com/antgroup/vsag/blob/main/examples/cpp/321_index_fp16_hgraph.cpp) |
+| `bfloat16`  | `uint16_t`（按 Brain Float 位模式打包） | `Float16Vectors`（与 FP16 共用） | 在 `321_index_fp16_hgraph.cpp` 基础上按下文调整                                                       |
+
+`dim` 始终表示逻辑维度（元素数量），与字节长度无关，因此四种数据类型下 `dim` 取值相同。
+
+### `int8` 输入
+
+量化好的 `int8` 向量直接通过 `Int8Vectors` 传入：
+
+```cpp
+std::vector<int8_t> data(num_vectors * dim);  // 填入 int8 元素
+auto base = vsag::Dataset::Make();
+base->NumElements(num_vectors)->Dim(dim)->Ids(ids)
+    ->Int8Vectors(data.data())->Owner(false);
+```
+
+对应构建配置（注意 `dtype: "int8"`）：
+
+```json
+{
+    "dtype": "int8",
+    "metric_type": "l2",
+    "dim": 128,
+    "index_param": {
+        "base_quantization_type": "pq",
+        "max_degree": 26,
+        "ef_construction": 100,
+        "alpha": 1.2
+    }
+}
+```
+
+查询时同样使用 `Int8Vectors` 和相同的 `dtype`。可运行示例：
+[`316_index_int8_hgraph.cpp`](https://github.com/antgroup/vsag/blob/main/examples/cpp/316_index_int8_hgraph.cpp)。
+
+### `float16` / `bfloat16` 输入
+
+FP16 与 BF16 都通过 `Float16Vectors` 传入，参数类型为 `const uint16_t*`，指向各元素的 16 位
+存储。从 `float` 到 16 位格式的转换由调用方负责。VSAG 源码树内提供了便捷辅助函数
+（`vsag::generic::FloatToFP16` 位于
+[`src/simd/fp16_simd.h`](https://github.com/antgroup/vsag/blob/main/src/simd/fp16_simd.h)，
+`vsag::generic::FloatToBF16` 位于
+[`src/simd/bf16_simd.h`](https://github.com/antgroup/vsag/blob/main/src/simd/bf16_simd.h)），
+但它们是**内部头文件**，并未通过 `include/vsag/` 对外安装。链接已安装版 VSAG 库的应用需要自行
+完成转换（例如复制这段小工具函数、使用 `_cvtss_sh` / F16C 内置指令，或调用任意 FP16 库）。下面
+的示例代码为了简洁直接使用了源码树内的辅助函数：
+
+```cpp
+// 下面的 fp16/bf16 辅助函数位于 src/simd/，并未随 VSAG 一并安装。
+// 链接已安装版 VSAG 时，请替换为自行实现的 float -> uint16_t 转换。
+#include "simd/fp16_simd.h"  // FloatToFP16（BF16 场景改为 simd/bf16_simd.h / FloatToBF16）
+
+std::vector<uint16_t> data(num_vectors * dim);
+for (size_t i = 0; i < data.size(); ++i) {
+    data[i] = vsag::generic::FloatToFP16(some_float_source());
+}
+auto base = vsag::Dataset::Make();
+base->NumElements(num_vectors)->Dim(dim)->Ids(ids)
+    ->Float16Vectors(data.data())->Owner(false);
+```
+
+构建配置：
+
+```json
+{
+    "dtype": "float16",
+    "metric_type": "l2",
+    "dim": 128,
+    "index_param": {
+        "base_quantization_type": "pq",
+        "max_degree": 26,
+        "ef_construction": 100,
+        "alpha": 1.2
+    }
+}
+```
+
+切换到 BF16 时，将 `dtype` 改为 `"bfloat16"`、把 `FloatToFP16` 替换为 `FloatToBF16` 即可；
+`Float16Vectors` setter 与构建/检索流程不变。可运行 FP16 示例：
+[`321_index_fp16_hgraph.cpp`](https://github.com/antgroup/vsag/blob/main/examples/cpp/321_index_fp16_hgraph.cpp)。
+
+> **注意。** `321_index_fp16_hgraph.cpp` 文件头注释提到 `BFloat16Vectors()`，但该 setter 并不
+> 存在 —— FP16 与 BF16 都通过 `Float16Vectors` 传入。无论 `dtype` 是 `"float16"` 还是
+> `"bfloat16"`，都使用同一个 setter。
+
+### 输入类型选择建议
+
+- 对精度要求最高、且内存预算充裕时，选 `float32`（默认）。
+- 想把输入存储减半，选 `float16` / `bfloat16`。FP16 指数范围更小，BF16 尾数位更少但指数范围
+  与 FP32 一致，对 embedding 类向量通常更友好。
+- 数据本身已是整数量化结果（来自上游量化器或 int8 输出的模型）时，选 `int8`。此时通常仍配合
+  `pq` / `sq8` 之类的索引内量化器使用。
+
+`dtype` 仅约束**输入**表示；索引内的实际存储仍由 `base_quantization_type`（以及
+`use_reorder: true` 下的 `precise_quantization_type`）决定，因此
+`dtype: "float16"` + `base_quantization_type: "sq8"` 这样的组合是允许的。
+
 ## 检索参数
 
 检索参数放在 `hgraph` 子对象下：


### PR DESCRIPTION
## Summary

- Document the `int8` / `float16` / `bfloat16` input options for HGraph that are demonstrated by
  `examples/cpp/316_index_int8_hgraph.cpp` and `examples/cpp/321_index_fp16_hgraph.cpp` but were
  missing from the website's HGraph page (it only covered the `float32` case).
- Add a new **Supported input data types** section to `docs/docs/{en,zh}/src/indexes/hgraph.md`
  that lists the `dtype` value, the matching `Dataset` setter, the `FloatToFP16` / `FloatToBF16`
  helpers, example build configs for `int8` and `float16`/`bfloat16`, and short guidance on
  choosing between the four input types.

## Why

`dtype` selects how `Dataset` interprets raw vector bytes, but the HGraph guide showed only
`Float32Vectors` + `dtype: "float32"`. New users running the `316`/`321` examples had to derive
the `Int8Vectors` / `Float16Vectors` mapping from the example source, and the BF16 case (which
shares the `Float16Vectors` setter with FP16, distinguished only by `dtype` and the
`FloatToBF16` helper) was undocumented entirely.

## Notes for reviewers

- Verified against `include/vsag/dataset.h` (`Int8Vectors` at line 237, `Float16Vectors` at
  line 271 — there is no separate `BFloat16Vectors` setter; FP16 and BF16 share the same
  `const uint16_t*` setter and are distinguished by `dtype`).
- Verified the helper namespaces against `src/simd/fp16_simd.h:35` (`FloatToFP16`) and
  `src/simd/bf16_simd.h:36` (`FloatToBF16`).
- No SUMMARY changes are needed — the section is appended to the existing `indexes/hgraph.md`
  page.