### PR TITLE
docs: add extensibility guide for advanced features

### DIFF
--- a/docs/docs/en/src/SUMMARY.md
+++ b/docs/docs/en/src/SUMMARY.md
@@ -35,6 +35,7 @@
 - [Serialization](advanced/serialization.md)
 - [Memory Management](advanced/memory.md)
 - [Index Introspection](advanced/introspection.md)
+- [Extensibility](advanced/extensibility.md)
 - [Graph Enhancement](advanced/enhance_graph.md)
 - [Hybrid Memory-Disk Index](advanced/hybrid_index.md)
 - [Extra Info](advanced/extra_info.md)

--- a/docs/docs/en/src/advanced/extensibility.md
+++ b/docs/docs/en/src/advanced/extensibility.md
@@ -1,0 +1,152 @@
+# Extensibility
+
+VSAG exposes a small set of stable C++ extension points so applications can plug
+in their own infrastructure without forking the library. This page summarizes
+**what is extensible** and **what is not**, and links to runnable examples.
+
+## Public extension points
+
+| Extension point | Header | Purpose |
+|---|---|---|
+| `vsag::Allocator` | `vsag/allocator.h` | Custom memory allocation strategy. |
+| `vsag::Logger` | `vsag/logger.h` | Redirect VSAG logs to your logging stack. |
+| `vsag::ThreadPool` | `vsag/thread_pool.h` | Reuse an external worker pool for builds and IO. |
+| `vsag::Filter` | `vsag/filter.h` | Custom pre-filter for `KnnSearch` / `RangeSearch`. |
+| `vsag::Reader` (+ `ReaderSet`) | `vsag/readerset.h` | Custom IO backend for deserialization. |
+
+All five are abstract base classes. Each declares at least one pure-virtual method that you
+must implement; some also declare non-pure-virtual methods with sensible defaults (for example,
+`Filter::CheckValid(const char*)`, `Filter::ValidRatio()`, `Filter::FilterDistribution()`,
+`Filter::GetValidIds()`, and `Reader::MultiRead()`) that you can override only when you need
+custom behaviour. Implement the required methods, wrap your instance in a `std::shared_ptr`
+(or pass a raw pointer where the API requires it), and hand it to VSAG.
+
+## Wiring extensions into an index
+
+There are two main entry points.
+
+### 1. Per-index resources via `Engine`
+
+`vsag::Engine` (`vsag/engine.h`) is the recommended way to bind a custom
+`Allocator` and `ThreadPool` to every index it creates:
+
+```cpp
+auto allocator   = std::make_shared<MyAllocator>();
+auto thread_pool = std::make_shared<MyThreadPool>();
+vsag::Resource resource(allocator, thread_pool);
+vsag::Engine engine(&resource);
+
+auto index = engine.CreateIndex("hgraph", parameters).value();
+// ... use index ...
+engine.Shutdown();
+```
+
+`Engine(Resource*)` takes a non-owning pointer — the caller is responsible for
+keeping the `Resource` alive for at least as long as the engine and every index
+it produced (until `Shutdown()` returns / those indexes are destroyed). The
+`Resource` itself owns the `Allocator` / `ThreadPool` shared pointers. See
+[Memory Management](memory.md) for the full ownership model, and
+[Per-Search Allocator](search_allocator.md) for scoping an allocator to a
+single search call.
+
+For quick prototypes, `Engine::CreateDefaultAllocator()` and
+`Engine::CreateThreadPool(num_threads)` return ready-to-use implementations.
+
+### 2. `Factory::CreateIndex` with a raw allocator
+
+`vsag::Factory::CreateIndex(name, params, allocator)`
+(`vsag/factory.h`) accepts an optional `Allocator*`. This path does not take a
+thread pool; new code should prefer `Engine`.
+
+## Filter
+
+Implement `vsag::Filter` and pass a `FilterPtr` through `SearchRequest::filter_`
+**and** set `SearchRequest::enable_filter_ = true` (the filter is ignored when
+the flag is off). The legacy `SearchParam::filter` path remains supported.
+Only `CheckValid(int64_t id)` is required; the other hooks are optional
+optimizations:
+
+- `CheckValid(const char* data)` — filter on per-vector extra info.
+- `ValidRatio()` — hint the planner about selectivity.
+- `FilterDistribution()` — hint about the spatial distribution of the valid
+  ids: `NONE` (default) means no hint, `RELATED_TO_VECTOR` means the valid ids
+  are correlated with vector position. See `vsag/filter.h`.
+- `GetValidIds(...)` — expose a precomputed valid-id list for very selective
+  filters.
+
+Runnable example: `examples/cpp/301_feature_filter.cpp`. The
+[Filtered Search](filtered_search.md) page describes filter integration in
+detail.
+
+## Reader / ReaderSet
+
+`Index::Deserialize(const ReaderSet&)` lets you stream an index from any storage
+backend (local file, object storage, remote FS, …) by providing a `Reader` per
+named binary stream. Implement `Read`, `AsyncRead`, and `Size` at minimum;
+`MultiRead` is optional and improves throughput when the backend supports
+batched IO. `vsag::Factory::CreateLocalFileReader` is a reference
+implementation for local files.
+
+Runnable example: `examples/cpp/102_index_diskann.cpp` (DiskANN deserialization
+uses `ReaderSet`). See [Serialization](serialization.md) for the full
+serialize / deserialize matrix.
+
+## Logger
+
+VSAG uses a single global logger configured through the `Options` singleton:
+
+```cpp
+class MyLogger : public vsag::Logger { /* implement Trace/Debug/Info/... */ };
+static MyLogger my_logger;
+vsag::Options::Instance().set_logger(&my_logger);
+```
+
+The logger pointer is **not** owned by VSAG — keep it alive for the duration of
+any VSAG call. Pass `nullptr` to fall back to the built-in logger.
+
+Runnable example: `examples/cpp/202_custom_logger.cpp`.
+
+## Global tuning via `Options`
+
+`vsag::Options::Instance()` (`vsag/options.h`) is a process-wide singleton for
+settings that do not belong to a specific index:
+
+| Setter | Default | Notes |
+|---|---|---|
+| `set_num_threads_io(n)` | `8` | Threads used for disk-index IO during search. Must be in `[1, 200]`. |
+| `set_num_threads_building(n)` | `4` | Threads used while building disk indexes. |
+| `set_block_size_limit(bytes)` | `128 MiB` | Maximum size of a single allocation block. Must be `≥ 256 KiB` (`src/options.cpp:53-57`). |
+| `set_direct_IO_object_align_bit(bits)` | `9` | Direct-IO alignment, in bits. Must be `≤ 21` (alignment size up to 2 MiB; `src/options.cpp:40-46`). |
+| `set_logger(Logger*)` | built-in | See [Logger](#logger). |
+
+These options affect every index in the process; set them once at startup. They
+do **not** override per-index parameters such as HGraph's `build_thread_count`.
+
+## What is *not* publicly extensible
+
+VSAG does not currently provide stable public interfaces for the following:
+
+- **Quantizers.** Concrete quantizer types (SQ8, PQ, RaBitQ, …) are selected
+  via index parameters; subclassing them from user code is not supported.
+- **Distance computers / metric types.** Distance metrics are fixed to
+  `l2`, `ip`, and `cosine` per index.
+- **DataCell / IO / storage backends inside an index.** These are
+  implementation details. Use the `Reader` interface for custom IO at the
+  deserialization boundary.
+
+If you need one of these, please open an issue describing the use case.
+
+## A note on `vsag::ext`
+
+The `vsag/vsag_ext.h` header defines a thin handle-based API (`IndexHandler`,
+`DatasetHandler`, `BitsetHandler`, …) intended for **language bindings and FFI**. It is not a
+user-facing extension surface; prefer the standard `vsag::Index` API for C++
+applications.
+
+## Related examples
+
+- `examples/cpp/201_custom_allocator.cpp`
+- `examples/cpp/202_custom_logger.cpp`
+- `examples/cpp/203_custom_thread_pool.cpp`
+- `examples/cpp/301_feature_filter.cpp`
+- `examples/cpp/102_index_diskann.cpp`

--- a/docs/docs/zh/src/SUMMARY.md
+++ b/docs/docs/zh/src/SUMMARY.md
@@ -35,6 +35,7 @@
 - [序列化格式](advanced/serialization.md)
 - [内存管理](advanced/memory.md)
 - [索引自省](advanced/introspection.md)
+- [可扩展性](advanced/extensibility.md)
 - [图索引增强](advanced/enhance_graph.md)
 - [内存-磁盘混合索引](advanced/hybrid_index.md)
 - [Extra Info（附加信息）](advanced/extra_info.md)

--- a/docs/docs/zh/src/advanced/extensibility.md
+++ b/docs/docs/zh/src/advanced/extensibility.md
@@ -1,0 +1,144 @@
+# 可扩展性
+
+VSAG 暴露了一组稳定的 C++ 扩展点，方便应用接入自有基础设施而无需 fork 库本身。
+本页梳理 **哪些可以扩展**、**哪些不可以**，并给出可运行示例的链接。
+
+## 公开扩展点
+
+| 扩展点 | 头文件 | 用途 |
+|---|---|---|
+| `vsag::Allocator` | `vsag/allocator.h` | 自定义内存分配策略。 |
+| `vsag::Logger` | `vsag/logger.h` | 把 VSAG 日志重定向到你的日志体系。 |
+| `vsag::ThreadPool` | `vsag/thread_pool.h` | 复用外部线程池执行 build 和 IO。 |
+| `vsag::Filter` | `vsag/filter.h` | 为 `KnnSearch` / `RangeSearch` 提供自定义预过滤器。 |
+| `vsag::Reader`（含 `ReaderSet`） | `vsag/readerset.h` | 自定义反序列化的 IO 后端。 |
+
+这五个都是抽象基类。每个至少声明一个必须实现的纯虚方法；部分还声明了带默认实现的非纯虚方法
+（例如 `Filter::CheckValid(const char*)`、`Filter::ValidRatio()`、
+`Filter::FilterDistribution()`、`Filter::GetValidIds()`，以及 `Reader::MultiRead()`），只在需
+要自定义行为时才需要 override。实现必须的方法、用 `std::shared_ptr` 包装（或在 API 要求时
+直接传裸指针），然后交给 VSAG 即可。
+
+## 把扩展接入索引
+
+主要有两条接入路径。
+
+### 1. 通过 `Engine` 注入按索引生效的资源
+
+`vsag::Engine`（`vsag/engine.h`）是绑定自定义 `Allocator` 与 `ThreadPool` 的
+推荐方式，绑定后由它创建的每个索引都会共享这些资源：
+
+```cpp
+auto allocator   = std::make_shared<MyAllocator>();
+auto thread_pool = std::make_shared<MyThreadPool>();
+vsag::Resource resource(allocator, thread_pool);
+vsag::Engine engine(&resource);
+
+auto index = engine.CreateIndex("hgraph", parameters).value();
+// ... 使用索引 ...
+engine.Shutdown();
+```
+
+`Engine(Resource*)` 接收的是 **non-owning** 裸指针（见
+`include/vsag/engine.h:38-42`）：调用者必须保证 `Resource`（连同它持有的
+allocator 与 thread pool）的生命周期长于 engine 以及 engine 创建的所有索引。
+`Engine::Shutdown()` 释放 engine 内部资源，但不会销毁外部的 `Resource`。
+`Resource` 提供两个构造器（`include/vsag/resource.h:45,59-60`）：既可以传裸
+`Allocator*` / `ThreadPool*`（生命周期由调用者管理），也可以传 `shared_ptr`
+重载，让 `Resource` 共享所有权。完整的所有权模型见 [内存管理](memory.md)，
+把 allocator 收敛到单次搜索调用的用法见 [搜索路径 Allocator](search_allocator.md)。
+
+如果只是想快速跑通，`Engine::CreateDefaultAllocator()` 与
+`Engine::CreateThreadPool(num_threads)` 会返回开箱即用的实现。
+
+### 2. 通过 `Factory::CreateIndex` 传裸 allocator
+
+`vsag::Factory::CreateIndex(name, params, allocator)`（`vsag/factory.h`）接受
+一个可选的 `Allocator*`。这条路径不接受线程池，新代码建议改用 `Engine`。
+
+## Filter
+
+实现 `vsag::Filter`，通过 `SearchRequest::filter_`（或已弃用的
+`SearchParam::filter`）传入 `FilterPtr` 即可。使用 `SearchRequest` 时，必须
+同时把 `enable_filter_` 设为 `true`，filter 才会真正生效
+（见 `include/vsag/search_request.h:113,123`）。只有 `CheckValid(int64_t id)`
+是必须实现的，其他都是可选的优化钩子：
+
+- `CheckValid(const char* data)`：基于向量 extra info 过滤。
+- `ValidRatio()`：向规划器提示选择度。
+- `FilterDistribution()`：返回 `NONE`（默认）或 `RELATED_TO_VECTOR`，声明有效
+  id 的分布是否与向量在底层存储中的位置相关
+  （见 `include/vsag/filter.h:27-30`）。
+- `GetValidIds(...)`：对于选择度极低的过滤器，提供预先计算好的有效 id 列表。
+
+可运行示例：`examples/cpp/301_feature_filter.cpp`。过滤接入的细节见
+[过滤搜索](filtered_search.md)。
+
+## Reader / ReaderSet
+
+`Index::Deserialize(const ReaderSet&)`（`include/vsag/index.h:810`）允许通过
+per-stream 的 `Reader` 从任意存储后端（本地文件、对象存储、远程文件系统…）
+反序列化索引。至少实现 `Read`、`AsyncRead`、`Size` 三个方法；`MultiRead` 是
+可选的，当底层支持批量 IO 时能显著提升吞吐。`vsag::Factory::CreateLocalFileReader`
+是本地文件的参考实现。
+
+可运行示例：`examples/cpp/102_index_diskann.cpp`（DiskANN 的反序列化基于
+`ReaderSet`）。完整的序列化/反序列化矩阵见 [序列化](serialization.md)。
+
+## Logger
+
+VSAG 使用全局唯一的 logger，通过 `Options` 单例配置：
+
+```cpp
+class MyLogger : public vsag::Logger { /* 实现 Trace/Debug/Info/... */ };
+static MyLogger my_logger;
+vsag::Options::Instance().set_logger(&my_logger);
+```
+
+logger 指针的所有权 **不** 归 VSAG —— 必须在所有 VSAG 调用期间保持其存活。
+传入 `nullptr` 则回退到内置 logger。
+
+可运行示例：`examples/cpp/202_custom_logger.cpp`。
+
+## 通过 `Options` 进行全局调参
+
+`vsag::Options::Instance()`（`vsag/options.h`）是进程级单例，承载与具体索引
+无关的设置：
+
+| 接口 | 默认值 | 备注 |
+|---|---|---|
+| `set_num_threads_io(n)` | `8` | 搜索时磁盘索引的 IO 线程数，取值范围 `[1, 200]`。 |
+| `set_num_threads_building(n)` | `4` | 构建磁盘索引使用的线程数。 |
+| `set_block_size_limit(bytes)` | `128 MiB` | 单次分配 block 的最大值，必须 ≥ 256 KiB（见 `src/options.cpp:53-57`）。 |
+| `set_direct_IO_object_align_bit(bits)` | `9` | Direct-IO 对齐位数，必须 ≤ 21（见 `src/options.cpp:40-46`）。 |
+| `set_logger(Logger*)` | 内置 | 见上文 [Logger](#logger)。 |
+
+这些 option 对进程内所有索引生效，建议启动时设置一次。它们 **不会** 覆盖
+HGraph 的 `build_thread_count` 等具体索引参数。
+
+## 哪些 *不* 提供公开扩展接口
+
+以下能力目前 **没有** 稳定的公开扩展接口：
+
+- **量化器（Quantizer）。** 具体量化类型（SQ8、PQ、RaBitQ…）通过索引参数选择，
+  不支持用户代码继承扩展。
+- **距离计算器 / 距离类型。** 每个索引的可选 metric 固定为 `l2`、`ip`、
+  `cosine`。
+- **索引内部的 DataCell / IO / 存储后端。** 这些都是实现细节。若需要自定义
+  IO，请在反序列化边界使用 `Reader` 接口。
+
+如果你的场景需要上述任一能力，请提 issue 描述使用场景。
+
+## 关于 `vsag::ext`
+
+`vsag/vsag_ext.h` 提供了一组基于 handle 的精简 API（`IndexHandler`、
+`DatasetHandler`、`BitsetHandler` ……），用于 **语言绑定 / FFI**，并不是面向最终用户的扩展层。
+C++ 应用应直接使用标准的 `vsag::Index` API。
+
+## 相关示例
+
+- `examples/cpp/201_custom_allocator.cpp`
+- `examples/cpp/202_custom_logger.cpp`
+- `examples/cpp/203_custom_thread_pool.cpp`
+- `examples/cpp/301_feature_filter.cpp`
+- `examples/cpp/102_index_diskann.cpp`


### PR DESCRIPTION
## Summary

Adds a new **Extensibility** page (en + zh) under Advanced Features that
consolidates VSAG's public C++ extension points and links to the matching
runnable examples under `examples/cpp/`.

## What's covered

- Public extension interfaces: `Allocator`, `Logger`, `ThreadPool`, `Filter`,
  `Reader` / `ReaderSet`.
- Two wiring paths: `Engine` + `Resource` (recommended) and
  `Factory::CreateIndex` with a raw `Allocator*`. Cross-links
  `advanced/memory.md` for the ownership model rather than repeating it.
- Process-wide tuning via the `Options` singleton (`num_threads_io`,
  `num_threads_building`, `block_size_limit`, `direct_IO_object_align_bit`,
  `set_logger`).
- Explicit list of **non-extensible** surfaces (quantizers, distance
  computers, internal DataCell/IO/storage) to set correct expectations.
- Clarifies that `vsag::ext` is a handle-based FFI layer for language
  bindings, not a user-facing extension API.

## SUMMARY placement

Inserted between **Memory Management** and **Graph Enhancement** in both
language SUMMARY files.

## Notes for reviewers

- No source-code changes; documentation only.
- Examples referenced: 102, 201, 202, 203, 301.
- Follow-up (not in this PR): extend `serialization.md` to cover `Clone`,
  `ExportModel`, and fix the `WriteFuncType` callback signature documented
  there.

---

_Drafted with AI assistant: OpenCode:claude-opus-4.7_