### PR TITLE
docs: add Quantization Transform advanced page

### DIFF
--- a/docs/docs/en/src/SUMMARY.md
+++ b/docs/docs/en/src/SUMMARY.md
@@ -39,6 +39,7 @@
 - [Hybrid Memory-Disk Index](advanced/hybrid_index.md)
 - [Extra Info](advanced/extra_info.md)
 - [Index Lifecycle Management](advanced/index_lifecycle.md)
+- [Quantization Transform](advanced/quantization_transform.md)
 
 # Performance and Tuning
 

--- a/docs/docs/en/src/advanced/quantization_transform.md
+++ b/docs/docs/en/src/advanced/quantization_transform.md
@@ -1,0 +1,199 @@
+# Quantization Transform
+
+The **Transform Quantizer** (`base_quantization_type: "tq"`) chains one or more vector
+transformations in front of a final quantizer. Transformations reshape vectors so a downstream
+quantizer can encode them more accurately or compactly — for example, rotate vectors so their
+energy is spread across dimensions (RaBitQ / SQ benefit greatly), or reduce dimensionality with
+PCA before storing them.
+
+> Runnable example: `examples/cpp/501_quantization_transform.cpp`.
+
+## Why a transform layer
+
+A pure quantizer compresses vectors directly. With low-bit quantizers (e.g. `sq4`,
+`sq*_uniform`, `rabitq`) accuracy depends heavily on the **distribution** of vector
+coordinates: heavy-tailed or anisotropic dimensions waste code bits. A transform layer
+mitigates this:
+
+- **Random rotations** (`rom`, `fht`) decorrelate coordinates so a uniform/scalar quantizer
+  works better on each axis.
+- **PCA** (`pca`) reduces dimensions while keeping most of the variance — code size shrinks
+  proportionally.
+- **MRLE** (`mrle`) is a metric-recoverable low-rank encoding tailored to L2/IP search.
+
+The transform output then feeds a standard quantizer (`fp32`, `sq8`, `sq8_uniform`, `rabitq`,
+…), which actually stores the codes. The whole chain is referred to as **`tq` (Transform
+Quantizer)**.
+
+## Quick start
+
+`tq` is currently exposed as a **public, externally configurable** quantization type only by
+**HGraph**. HGraph maps the top-level keys `tq_chain` and `rabitq_pca_dim` into the nested
+`base_codes.quantization_params` JSON via its external-parameter mapping
+(`src/algorithm/hgraph.cpp:370-385`). IVF, BruteForce, Pyramid and WARP all internally render
+a `tq_chain` field into their inner JSON template, but none of them expose `tq_chain` (or any
+other TQ parameter) in their external mapping today. `CheckAndMappingExternalParam` rejects
+unknown external keys with `invalid config param`
+(`src/utils/util_functions.cpp:50-53`), so passing `tq_chain` in the `index_param` JSON of
+those indexes will fail at index construction. Configuring TQ on non-HGraph indexes
+therefore requires code-side changes to add the external mapping.
+
+```cpp
+std::string params = R"({
+    "dtype": "float32",
+    "metric_type": "l2",
+    "dim": 128,
+    "index_param": {
+        "base_quantization_type": "tq",
+        "tq_chain": "pca, rom, sq8_uniform",
+        "rabitq_pca_dim": 64,
+        "max_degree": 32,
+        "ef_construction": 300,
+        "use_reorder": true,
+        "precise_quantization_type": "fp32"
+    }
+})";
+
+vsag::Resource resource(vsag::Engine::CreateDefaultAllocator(), nullptr);
+vsag::Engine engine(&resource);
+auto index = engine.CreateIndex("hgraph", params).value();
+index->Build(base);
+auto result = index->KnnSearch(query, topk, search_params).value();
+```
+
+In the example above, base vectors are first projected from 128 to 64 dimensions (`pca`),
+randomly rotated (`rom`), then quantized with `sq8_uniform`. Reordering is enabled, so HGraph
+keeps an `fp32` precise copy and re-ranks the top candidates returned by the graph search
+(`include/vsag/index.h`; see [Memory Management](memory.md) for the storage implications).
+
+## `tq_chain` syntax
+
+`tq_chain` is a **comma-separated string**: one or more transformer names followed by exactly
+one final quantizer name. Whitespace around tokens is trimmed
+(`src/quantization/transform_quantization/transform_quantizer_parameter.cpp:53-74`).
+
+```
+"<transform1>, <transform2>, ..., <quantizer>"
+```
+
+Examples:
+
+| Chain | Effect |
+|---|---|
+| `"rom, fp32"` | Random rotation, then store as fp32 (used for tests / sanity baselines). |
+| `"fht, sq8_uniform"` | Fast Hadamard rotation, then 8-bit uniform scalar quantization. |
+| `"pca, rom, sq8_uniform"` | PCA reduction, random rotation, then 8-bit uniform — the example chain. |
+| `"pca, rom, rabitq"` | PCA + rotation feeding the RaBitQ binary quantizer. |
+| `"mrle, fp32"` | MRLE projection then store as fp32 (MRLE must be first). |
+
+Constraints (`transform_quantizer_parameter.cpp:33-45`):
+
+- The chain must contain **at least one transformer + one quantizer** (length ≥ 2). An empty
+  or single-token chain raises `INVALID_ARGUMENT`.
+- The **last token must be a quantizer that the TQ flatten path can dispatch**: one of
+  `fp32`, `sq8`, `sq8_uniform`, `sq4`, `sq4_uniform`, `bf16`, `fp16`, `pq`, `pqfs`, `rabitq`
+  (`src/datacell/flatten_interface.cpp:126-164`). `TransformQuantizerParameter` parses a
+  slightly wider set of names (it also accepts `sparse`, `int8`, `tq`), but the flatten
+  factory does not have a dispatch branch for `int8`/`tq` and explicitly rejects `sparse`
+  when `is_transform_quantizer` is true (`src/datacell/flatten_interface.cpp:166`), so using
+  any of those three as the terminal quantizer fails at index construction with an
+  "unsupported quantization type" error.
+- Any unrecognized transformer name raises `INVALID_ARGUMENT: invalid transformer name`
+  (`transform_quantizer.h:225-227`).
+
+## Supported transformers
+
+The factory at `src/quantization/transform_quantization/transform_quantizer.h:192-227`
+recognizes four transformer names today:
+
+| Name | Output dim | Description | Implementation |
+|---|---|---|---|
+| `pca` | `pca_dim` if set, else input dim | Principal-Component-Analysis projection; reduces dim while keeping variance. | `src/impl/transform/pca_transformer.h` |
+| `rom` | input dim | Random Orthogonal Matrix; rotates vectors to decorrelate dimensions. | `src/impl/transform/random_orthogonal_transformer.h` |
+| `fht` | input dim | Fast Hadamard / KAC random rotation; cheaper variant of `rom`. | `src/impl/transform/fht_kac_rotate_transformer.h` |
+| `mrle` | `mrle_dim` (≤ input dim) | Metric-Recoverable Low-rank Encoding; **must be the first transformer in the chain**. | `src/impl/transform/mrle_transformer.h` |
+
+Notes:
+
+- `mrle` placement is enforced at `transform_quantizer.h:155-159` and `mrle_dim ≤ input_dim`
+  at `transform_quantizer.h:217-220`.
+- Other strings declared in headers (`residual`, `normalize`) are **not** wired into the
+  factory and will be rejected.
+
+## Transformer parameters
+
+The transformer JSON is read by `VectorTransformerParameter::FromJson`
+(`src/impl/transform/vector_transformer_parameter.cpp:22-35`):
+
+| Key | Type | Default | Meaning |
+|---|---|---|---|
+| `pca_dim` | int | `0` (= input dim) | Output dim of the `pca` transformer. |
+| `mrle_dim` | int | `0` (= input dim) | Output dim of the `mrle` transformer. |
+| `input_dim` | int | auto | Auto-populated by the chain — do not set manually. |
+
+### HGraph external mapping
+
+When using HGraph, two top-level shortcuts are mapped into the nested quantizer params
+(`src/algorithm/hgraph.cpp:370-385`):
+
+- `tq_chain` → `base_codes.quantization_params.tq_chain`
+- `rabitq_pca_dim` → `base_codes.quantization_params.pca_dim`
+
+The name `rabitq_pca_dim` predates Transform Quantizer; when the chain includes `pca`, it
+drives the **`pca` transformer's output dim** (it is not RaBitQ-specific). When the chain
+ends in `rabitq` without `pca`, the same key configures RaBitQ's own PCA preprocessing
+(`src/quantization/rabitq_quantization/rabitq_quantizer_parameter.cpp:30`).
+
+## Reordering and the precise codes store
+
+Transform chains lose some information by design (rotation is lossless, but `pca` /
+`sq*_uniform` / `rabitq` are not). Combining `tq` with **reorder** — keep a precise (typically
+`fp32`) copy of every vector and re-rank the top candidates — restores accuracy with a
+modest memory cost:
+
+- `use_reorder: true` makes HGraph keep a second flatten store, the **precise codes store**
+  (`src/algorithm/hgraph.cpp:76-79`).
+- `precise_quantization_type` selects its quantizer (`fp32` default; can be `fp16` / `bf16` /
+  `sq8` if you want to trade memory for accuracy).
+- At search time the graph walk uses the cheap `tq` base codes, then the top-K are re-scored
+  against the precise codes (`hgraph.cpp:978-981` and surrounding sites).
+
+`use_reorder` and `precise_quantization_type` are not specific to `tq` — they also apply when
+`base_quantization_type` is `sq8`, `pq`, `rabitq`, etc. See the table in
+[HGraph index](../indexes/hgraph.md) for the full per-index parameter list.
+
+## Choosing a chain
+
+A pragmatic rule of thumb:
+
+| Goal | Suggested chain | Notes |
+|---|---|---|
+| Memory-aggressive, accuracy-restored | `"pca, rom, sq8_uniform"` + `use_reorder: true`, `precise_quantization_type: "fp32"` | Example 501 baseline. |
+| Maximum compression | `"pca, rom, rabitq"` + reorder | 1-bit quantization with rotation cleanup; expect noticeable accuracy loss without reorder. |
+| Anisotropic data, no dim reduction | `"rom, sq8_uniform"` or `"fht, sq8_uniform"` | Use `fht` for lower build cost on high dim. |
+| Distance-preserving low-rank | `"mrle, fp32"` | Metric-aware reduction, no further quantization. |
+
+Always benchmark on your own data — the right tradeoff between `tq` aggressiveness and
+`use_reorder` depends on dataset distribution, target recall, and memory budget.
+
+## Compatibility and merge
+
+Two `tq` configurations are considered compatible only when the chain length, every
+transformer name, and the final quantizer all match
+(`src/quantization/transform_quantization/transform_quantizer_parameter.cpp:99-117`). This
+matters for serialization round-trips and for any future merge / clone operations across
+indexes — keep the chain string stable across builds you intend to combine.
+
+> **Chain string equality is necessary but not sufficient.** The `tq_chain` token list does
+> not encode transformer parameters such as `pca_dim` / `mrle_dim` (read as separate sibling
+> JSON keys at `src/quantization/transform_quantization/transform_quantizer.h:200-216`) or the
+> internal parameters of the terminal quantizer (e.g. `pq` subspace count, `rabitq` rotation
+> seed). These parameters change the effective code dimension and layout, so for two builds
+> to be practically merge-/clone-compatible you must keep the **entire** transform + quantizer
+> parameter set consistent, not just the chain string.
+
+## Related pages
+
+- [HGraph index](../indexes/hgraph.md) — parameter reference for `base_quantization_type`,
+  `use_reorder`, `precise_quantization_type`.
+- [Memory Management](memory.md) — memory cost of base + precise stores.

--- a/docs/docs/zh/src/SUMMARY.md
+++ b/docs/docs/zh/src/SUMMARY.md
@@ -39,6 +39,7 @@
 - [内存-磁盘混合索引](advanced/hybrid_index.md)
 - [Extra Info（附加信息）](advanced/extra_info.md)
 - [索引生命周期管理](advanced/index_lifecycle.md)
+- [量化变换](advanced/quantization_transform.md)
 
 # 性能与调优
 

--- a/docs/docs/zh/src/advanced/quantization_transform.md
+++ b/docs/docs/zh/src/advanced/quantization_transform.md
@@ -1,0 +1,183 @@
+# 量化变换（Quantization Transform）
+
+**变换量化器**（`base_quantization_type: "tq"`）在最终量化器之前串联一个或多个向量变换。
+变换会重塑向量分布，让后续量化器能更准确、更紧凑地编码 —— 例如把向量旋转一下，让能量分散
+到各个维度（RaBitQ / SQ 受益最大），或者先用 PCA 降维再存储。
+
+> 可运行示例：`examples/cpp/501_quantization_transform.cpp`。
+
+## 为什么需要变换层
+
+纯量化器直接压缩向量。对低比特量化器（如 `sq4`、`sq*_uniform`、`rabitq`），编码精度严重
+依赖向量坐标的**分布**：长尾或各向异性的维度会浪费 code bit。变换层可以缓解这个问题：
+
+- **随机旋转**（`rom`、`fht`）让坐标去相关，均匀/标量量化器在每个轴上工作得更好。
+- **PCA**（`pca`）在保留主要方差的同时降低维度 —— code 大小按比例缩小。
+- **MRLE**（`mrle`）是为 L2/IP 搜索设计的距离可恢复低秩编码。
+
+变换后的输出再喂给一个标准量化器（`fp32`、`sq8`、`sq8_uniform`、`rabitq` ……），由后者
+真正存储 code。整条链被称为 **`tq`（Transform Quantizer）**。
+
+## 快速上手
+
+`tq` 目前作为**对外可配置**的量化类型，只有 **HGraph** 真正暴露了它。HGraph 通过外部参数映射把
+顶层键 `tq_chain` 和 `rabitq_pca_dim` 写到嵌套的 `base_codes.quantization_params`
+（`src/algorithm/hgraph.cpp:370-385`）。IVF、BruteForce、Pyramid、WARP 虽然在内部 JSON 模板中
+也会渲染 `tq_chain` 字段，但它们的外部参数映射里**都没有** `tq_chain`（或其它 TQ 参数）。
+`CheckAndMappingExternalParam` 遇到未映射的外部键会直接抛 `invalid config param`
+（`src/utils/util_functions.cpp:50-53`），因此在这些索引的 `index_param` JSON 中传 `tq_chain`
+会在构建时报错。在非 HGraph 索引上启用 TQ 目前需要在代码侧补一条外部映射。
+
+```cpp
+std::string params = R"({
+    "dtype": "float32",
+    "metric_type": "l2",
+    "dim": 128,
+    "index_param": {
+        "base_quantization_type": "tq",
+        "tq_chain": "pca, rom, sq8_uniform",
+        "rabitq_pca_dim": 64,
+        "max_degree": 32,
+        "ef_construction": 300,
+        "use_reorder": true,
+        "precise_quantization_type": "fp32"
+    }
+})";
+
+vsag::Resource resource(vsag::Engine::CreateDefaultAllocator(), nullptr);
+vsag::Engine engine(&resource);
+auto index = engine.CreateIndex("hgraph", params).value();
+index->Build(base);
+auto result = index->KnnSearch(query, topk, search_params).value();
+```
+
+上面的例子里，base 向量先从 128 维降到 64 维（`pca`），随后做随机旋转（`rom`），最后用
+`sq8_uniform` 量化。开启了 reorder，HGraph 同时保留一份 `fp32` 精确副本，对图搜索返回的
+top 候选做精排（`include/vsag/index.h`；存储影响见 [内存管理](memory.md)）。
+
+## `tq_chain` 语法
+
+`tq_chain` 是一个**以逗号分隔的字符串**：一个或多个变换名，最后跟一个**唯一的**量化器名。
+token 两侧的空白会被自动 trim
+（`src/quantization/transform_quantization/transform_quantizer_parameter.cpp:53-74`）。
+
+```
+"<变换1>, <变换2>, ..., <量化器>"
+```
+
+示例：
+
+| 链 | 作用 |
+|---|---|
+| `"rom, fp32"` | 随机旋转后以 fp32 存储（多用于基线/sanity）。 |
+| `"fht, sq8_uniform"` | 快速 Hadamard 旋转 + 8 位均匀标量量化。 |
+| `"pca, rom, sq8_uniform"` | 先 PCA 降维，再随机旋转，再 8 位均匀量化 —— 即示例 501。 |
+| `"pca, rom, rabitq"` | PCA + 旋转后喂给 RaBitQ 二值量化器。 |
+| `"mrle, fp32"` | MRLE 投影再以 fp32 存储（MRLE 必须放在最前）。 |
+
+约束（`transform_quantizer_parameter.cpp:33-45`）：
+
+- 链至少包含 **1 个变换 + 1 个量化器**（长度 ≥ 2）。空串或单 token 会抛
+  `INVALID_ARGUMENT`。
+- **最后一个 token 必须是 TQ flatten 路径能够 dispatch 的量化器** —— `fp32`、`sq8`、
+  `sq8_uniform`、`sq4`、`sq4_uniform`、`bf16`、`fp16`、`pq`、`pqfs`、`rabitq` 之一
+  （`src/datacell/flatten_interface.cpp:126-164`）。`TransformQuantizerParameter` 解析层会
+  额外接受 `sparse`、`int8`、`tq`，但 flatten 工厂没有针对 `int8`/`tq` 的分发分支，并且当
+  `is_transform_quantizer=true` 时显式拒绝 `sparse`
+  （`src/datacell/flatten_interface.cpp:166`），因此这三个不能用作 TQ 末端，否则会在构建索引时
+  以 "unsupported quantization type" 失败。
+- 未识别的变换名会抛 `INVALID_ARGUMENT: invalid transformer name`
+  （`transform_quantizer.h:225-227`）。
+
+## 支持的变换
+
+`src/quantization/transform_quantization/transform_quantizer.h:192-227` 的工厂当前识别
+4 个变换名：
+
+| 名称 | 输出维度 | 描述 | 实现 |
+|---|---|---|---|
+| `pca` | 设置了 `pca_dim` 则取该值，否则同输入 | 主成分分析投影；在保留方差的前提下降维。 | `src/impl/transform/pca_transformer.h` |
+| `rom` | 同输入 | 随机正交矩阵；旋转向量以让各维去相关。 | `src/impl/transform/random_orthogonal_transformer.h` |
+| `fht` | 同输入 | 快速 Hadamard / KAC 随机旋转；`rom` 的低开销变体。 | `src/impl/transform/fht_kac_rotate_transformer.h` |
+| `mrle` | `mrle_dim`（≤ 输入维） | 距离可恢复低秩编码；**必须是链中第一个变换**。 | `src/impl/transform/mrle_transformer.h` |
+
+说明：
+
+- `mrle` 必须位于首位由 `transform_quantizer.h:155-159` 强制；`mrle_dim ≤ input_dim`
+  由 `transform_quantizer.h:217-220` 强制。
+- header 中声明的其它字符串（`residual`、`normalize`）**未**接入工厂，会被拒绝。
+
+## 变换参数
+
+变换 JSON 由 `VectorTransformerParameter::FromJson` 解析
+（`src/impl/transform/vector_transformer_parameter.cpp:22-35`）：
+
+| 键 | 类型 | 默认 | 含义 |
+|---|---|---|---|
+| `pca_dim` | int | `0`（= 输入维） | `pca` 变换的输出维。 |
+| `mrle_dim` | int | `0`（= 输入维） | `mrle` 变换的输出维。 |
+| `input_dim` | int | 自动 | 由链自动填充 —— 不要手动设置。 |
+
+### HGraph 顶层映射
+
+使用 HGraph 时，两个顶层快捷键会被映射到嵌套的量化器参数中
+（`src/algorithm/hgraph.cpp:370-385`）：
+
+- `tq_chain` → `base_codes.quantization_params.tq_chain`
+- `rabitq_pca_dim` → `base_codes.quantization_params.pca_dim`
+
+`rabitq_pca_dim` 这个名字早于 Transform Quantizer 引入；当链中包含 `pca` 时，它实际
+驱动的是 **`pca` 变换的输出维**（与 RaBitQ 无关）。如果链以 `rabitq` 结尾且未使用
+`pca`，则同一个键会配置 RaBitQ 自身的 PCA 预处理
+（`src/quantization/rabitq_quantization/rabitq_quantizer_parameter.cpp:30`）。
+
+## Reorder 与精确码存储
+
+变换链在设计上一定有信息损失（旋转无损，但 `pca` / `sq*_uniform` / `rabitq` 有损）。
+把 `tq` 与 **reorder** 组合使用 —— 即额外保留一份精确（通常是 `fp32`）副本，对 top 候选
+做精排 —— 可以以较小的内存成本恢复精度：
+
+- `use_reorder: true` 会让 HGraph 额外维护一份 flatten 存储，称为**精确码存储**
+  （`src/algorithm/hgraph.cpp:76-79`）。
+- `precise_quantization_type` 决定精确码使用的量化器（默认 `fp32`；若想用内存换精度，
+  也可以设为 `fp16` / `bf16` / `sq8`）。
+- 搜索时先用低成本的 `tq` base codes 走图，得到的 top-K 候选再用精确码重新打分
+  （`hgraph.cpp:978-981` 及附近调用）。
+
+`use_reorder` 与 `precise_quantization_type` 并非 `tq` 专属 —— 当
+`base_quantization_type` 是 `sq8`、`pq`、`rabitq` 等时同样适用。完整的逐索引参数表见
+[HGraph 索引](../indexes/hgraph.md)。
+
+## 链该怎么选
+
+经验法则：
+
+| 目标 | 建议链 | 备注 |
+|---|---|---|
+| 激进压缩 + 精度恢复 | `"pca, rom, sq8_uniform"` + `use_reorder: true`、`precise_quantization_type: "fp32"` | 示例 501 的基线。 |
+| 最大压缩 | `"pca, rom, rabitq"` + reorder | 1 bit 量化 + 旋转校正；不开 reorder 精度损失明显。 |
+| 各向异性数据、不降维 | `"rom, sq8_uniform"` 或 `"fht, sq8_uniform"` | 高维下用 `fht` 构建成本更低。 |
+| 距离保持的低秩 | `"mrle, fp32"` | 度量感知降维，不再量化。 |
+
+请在自有数据上 benchmark —— `tq` 的激进程度与 `use_reorder` 的取舍最终取决于数据分布、
+目标召回率以及内存预算。
+
+## 兼容性与合并
+
+两个 `tq` 配置只有在链长度、每一步变换名、最终量化器都完全一致时才被视为兼容
+（`src/quantization/transform_quantization/transform_quantizer_parameter.cpp:99-117`）。
+这一点对序列化往返以及未来的合并/克隆操作至关重要 —— 准备合在一起的索引，应保持 chain
+字符串稳定。
+
+> **chain 字符串一致只是必要条件，并不充分。** `tq_chain` token 列表并不编码变换器参数
+> （例如 `pca_dim` / `mrle_dim`，它们作为兄弟 JSON 键单独读取，见
+> `src/quantization/transform_quantization/transform_quantizer.h:200-216`），也不编码末端量化器
+> 的内部参数（例如 `pq` 子空间数、`rabitq` 旋转种子等）。这些参数会改变实际 code 的维度与
+> 布局，因此两个构建要真正可合并/可克隆，必须保持**整套** transform + quantizer 参数一致，
+> 不能只对齐 chain 字符串。
+
+## 相关页面
+
+- [HGraph 索引](../indexes/hgraph.md) —— `base_quantization_type`、`use_reorder`、
+  `precise_quantization_type` 等参数说明。
+- [内存管理](memory.md) —— base + precise 存储的内存开销。


### PR DESCRIPTION
## Summary

Adds a new **Quantization Transform** page (en + zh) under Advanced Features, documenting the `base_quantization_type: "tq"` feature exercised by `examples/cpp/501_quantization_transform.cpp`. This closes a docs gap where users had no website reference for the TQ chain syntax other than reading the example source.

## Contents

- `tq_chain` syntax (comma-separated, trim rules, ordering constraints).
- The four supported transformers: `pca`, `rom`, `fht`, `mrle` — with parameters and constraints (e.g. `mrle` must be first; `mrle_dim <= input_dim`).
- The list of legal terminal quantizers accepted by the chain.
- The `rabitq_pca_dim` <-> `pca_dim` mapping gotcha (`src/algorithm/hgraph.cpp:370-385`): in chains containing `pca`, `rabitq_pca_dim` actually drives the PCA output dimension and is unrelated to RaBitQ.
- Interaction with `use_reorder` and `precise_quantization_type`.
- Index-type support note (first-class on HGraph; other indexes via nested JSON).
- Practical chain-selection guidance.
- Source references under `src/quantization/transform_quantization/*` for traceability.

## Labels

- kind/documentation
- version/1.0