### PR TITLE
feat: allow selecting inner index label remap map (cherry-pick #1981 to 0.18)

### DIFF
--- a/include/vsag/constants.h
+++ b/include/vsag/constants.h
@@ -187,6 +187,7 @@ extern const char* const HGRAPH_PARAMETER_HOPS_LIMIT;
 extern const char* const HGRAPH_EXTRA_INFO_SIZE;
 extern const char* const HGRAPH_SUPPORT_DUPLICATE;
 extern const char* const HGRAPH_SUPPORT_TOMBSTONE;
+extern const char* const HGRAPH_LABEL_REMAP_TYPE;
 extern const char* const HGRAPH_USE_EXTRA_INFO_FILTER;
 extern const char* const STORE_RAW_VECTOR;
 extern const char* const RAW_VECTOR_IO_TYPE;

--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -422,6 +422,12 @@ HGraph::map_hgraph_param(const JsonType& hgraph_json) {
             {
                 SUPPORT_TOMBSTONE,
             },
+        },
+        {
+            HGRAPH_LABEL_REMAP_TYPE,
+            {
+                LABEL_REMAP_TYPE_KEY,
+            },
         }};
     const std::string hgraph_params_template =
         R"(
@@ -504,6 +510,7 @@ HGraph::map_hgraph_param(const JsonType& hgraph_json) {
         },
         "{HGRAPH_SUPPORT_DUPLICATE}": false,
         "{HGRAPH_SUPPORT_TOMBSTONE}": false,
+        "{HGRAPH_LABEL_REMAP_TYPE}": "{LABEL_REMAP_TYPE_VALUE_PG}",
         "{EF_CONSTRUCTION_KEY}": 400
     })";
 
@@ -1193,13 +1200,12 @@ HGraph::serialize_basic_info_v0_14(StreamWriter& writer) const {
     StreamWriter::WriteObj(writer, capacity);
     StreamWriter::WriteVector(writer, this->label_table_->label_table_);
 
-    uint64_t size = this->label_table_->label_remap_.size();
+    uint64_t size = this->label_table_->GetRemapSize();
     StreamWriter::WriteObj(writer, size);
-    for (const auto& pair : this->label_table_->label_remap_) {
-        auto key = pair.first;
+    this->label_table_->ForEachRemap([&](LabelType key, InnerIdType value) {
         StreamWriter::WriteObj(writer, key);
-        StreamWriter::WriteObj(writer, pair.second);
-    }
+        StreamWriter::WriteObj(writer, value);
+    });
 }
 
 void
@@ -1224,15 +1230,15 @@ HGraph::deserialize_basic_info_v0_14(StreamReader& reader) {
                                                       nullptr);
         this->label_table_->duplicate_count_ = 0;
     }
-
     uint64_t size;
     StreamReader::ReadObj(reader, size);
+    this->label_table_->ResetRemap(size);
     for (uint64_t i = 0; i < size; ++i) {
         LabelType key;
         StreamReader::ReadObj(reader, key);
         InnerIdType value;
         StreamReader::ReadObj(reader, value);
-        this->label_table_->label_remap_.emplace(key, value);
+        this->label_table_->InsertRemap(key, value);
     }
     // Restore total_count from label_remap size
     this->label_table_->total_count_.store(static_cast<int64_t>(size));
@@ -1313,13 +1319,12 @@ HGraph::serialize_label_info(StreamWriter& writer) const {
         return;
     }
     StreamWriter::WriteVector(writer, this->label_table_->label_table_);
-    uint64_t size = this->label_table_->label_remap_.size();
+    uint64_t size = this->label_table_->GetRemapSize();
     StreamWriter::WriteObj(writer, size);
-    for (const auto& pair : this->label_table_->label_remap_) {
-        auto key = pair.first;
+    this->label_table_->ForEachRemap([&](LabelType key, InnerIdType value) {
         StreamWriter::WriteObj(writer, key);
-        StreamWriter::WriteObj(writer, pair.second);
-    }
+        StreamWriter::WriteObj(writer, value);
+    });
 }
 
 void
@@ -1331,12 +1336,13 @@ HGraph::deserialize_label_info(StreamReader& reader) const {
     StreamReader::ReadVector(reader, this->label_table_->label_table_);
     uint64_t size;
     StreamReader::ReadObj(reader, size);
+    this->label_table_->ResetRemap(size);
     for (uint64_t i = 0; i < size; ++i) {
         LabelType key;
         StreamReader::ReadObj(reader, key);
         InnerIdType value;
         StreamReader::ReadObj(reader, value);
-        this->label_table_->label_remap_.emplace(key, value);
+        this->label_table_->InsertRemap(key, value);
     }
     // Restore total_count from label_remap size (same as number of valid elements)
     this->label_table_->total_count_.store(static_cast<int64_t>(size));

--- a/src/algorithm/hgraph_parameter.cpp
+++ b/src/algorithm/hgraph_parameter.cpp
@@ -179,6 +179,10 @@ HGraphParameter::CheckCompatibility(const ParamPtr& other) const {
         logger::error("HGraphParameter::CheckCompatibility: support_duplicate must be the same");
         return false;
     }
+    if (label_remap_type != hgraph_param->label_remap_type) {
+        logger::error("HGraphParameter::CheckCompatibility: label_remap_type must be the same");
+        return false;
+    }
     return true;
 }
 

--- a/src/algorithm/hgraph_parameter_test.cpp
+++ b/src/algorithm/hgraph_parameter_test.cpp
@@ -19,6 +19,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include "hgraph.h"
 #include "parameter_test.h"
 
 #define TEST_COMPATIBILITY_CASE(section_name, param_member, val1, val2, expect_compatible) \
@@ -54,6 +55,7 @@ struct HGraphDefaultParam {
     bool use_attribute_filter = false;
     bool support_duplicate = false;
     bool use_reorder = true;
+    std::string label_remap_type = "pg";
 };
 
 std::string
@@ -107,7 +109,8 @@ generate_hgraph_param(const HGraphDefaultParam& param) {
         "type": "hgraph",
         "use_attribute_filter": {},
         "use_reorder": {},
-        "support_duplicate": {}
+        "support_duplicate": {},
+        "label_remap_type": "{}"
     }})";
 
     return fmt::format(param_str,
@@ -122,40 +125,63 @@ generate_hgraph_param(const HGraphDefaultParam& param) {
                        param.precise_codes_quantization_type,
                        param.use_attribute_filter,
                        param.use_reorder,
-                       param.support_duplicate);
+                       param.support_duplicate,
+                       param.label_remap_type);
 }
 
-TEST_CASE("HGraph Parameters CheckCompatibility", "[ut][HGraphParameter][CheckCompatibility]") {
-    SECTION("wrong parameter type") {
-        HGraphDefaultParam default_param;
-        auto param_str = generate_hgraph_param(default_param);
-        auto param = std::make_shared<vsag::HGraphParameter>();
-        param->FromString(param_str);
-        REQUIRE(param->CheckCompatibility(param));
-        REQUIRE_FALSE(param->CheckCompatibility(std::make_shared<vsag::EmptyParameter>()));
-    }
+TEST_CASE("HGraph Parameters CheckCompatibility", "[ut][HGraphParameter][CheckCompatibility]"){
+    SECTION("wrong parameter type"){HGraphDefaultParam default_param;
+auto param_str = generate_hgraph_param(default_param);
+auto param = std::make_shared<vsag::HGraphParameter>();
+param->FromString(param_str);
+REQUIRE(param->CheckCompatibility(param));
+REQUIRE_FALSE(param->CheckCompatibility(std::make_shared<vsag::EmptyParameter>()));
+}
 
-    TEST_COMPATIBILITY_CASE(
-        "different base codes io type", base_codes_io_type, "memory_io", "block_memory_io", true)
-    TEST_COMPATIBILITY_CASE("different pq dim", base_codes_pq_dim, 8, 16, false)
-    TEST_COMPATIBILITY_CASE(
-        "different base codes quantization type", base_codes_quantization_type, "sq4", "sq8", false)
-    TEST_COMPATIBILITY_CASE("different graph type", graph_storage_type, "flat", "compressed", false)
-    TEST_COMPATIBILITY_CASE("different max degree", max_degree, 26, 30, false)
-    TEST_COMPATIBILITY_CASE("different support remove", support_remove, true, false, false)
-    TEST_COMPATIBILITY_CASE("different remove flag bit", remove_flag_bit, 8, 16, false)
-    TEST_COMPATIBILITY_CASE("different use reorder", use_reorder, true, false, false)
-    TEST_COMPATIBILITY_CASE("different precise codes io type",
-                            precise_codes_io_type,
-                            "memory_io",
-                            "block_memory_io",
-                            true)
-    TEST_COMPATIBILITY_CASE("different precise codes quantization type",
-                            precise_codes_quantization_type,
-                            "fp32",
-                            "sq8",
-                            false)
-    TEST_COMPATIBILITY_CASE(
-        "different use attribute filter", use_attribute_filter, true, false, false)
-    TEST_COMPATIBILITY_CASE("different support duplicate", support_duplicate, true, false, false)
+TEST_COMPATIBILITY_CASE(
+    "different base codes io type", base_codes_io_type, "memory_io", "block_memory_io", true)
+TEST_COMPATIBILITY_CASE("different pq dim", base_codes_pq_dim, 8, 16, false)
+TEST_COMPATIBILITY_CASE(
+    "different base codes quantization type", base_codes_quantization_type, "sq4", "sq8", false)
+TEST_COMPATIBILITY_CASE("different graph type", graph_storage_type, "flat", "compressed", false)
+TEST_COMPATIBILITY_CASE("different max degree", max_degree, 26, 30, false)
+TEST_COMPATIBILITY_CASE("different support remove", support_remove, true, false, false)
+TEST_COMPATIBILITY_CASE("different remove flag bit", remove_flag_bit, 8, 16, false)
+TEST_COMPATIBILITY_CASE("different use reorder", use_reorder, true, false, false)
+TEST_COMPATIBILITY_CASE(
+    "different precise codes io type", precise_codes_io_type, "memory_io", "block_memory_io", true)
+TEST_COMPATIBILITY_CASE("different precise codes quantization type",
+                        precise_codes_quantization_type,
+                        "fp32",
+                        "sq8",
+                        false)
+TEST_COMPATIBILITY_CASE("different use attribute filter", use_attribute_filter, true, false, false)
+TEST_COMPATIBILITY_CASE("different support duplicate", support_duplicate, true, false, false)
+TEST_COMPATIBILITY_CASE("different label remap type", label_remap_type, "pg", "robin", false)
+}
+
+TEST_CASE("HGraph maps label_remap_type to inner index parameter", "[ut][HGraphParameter]") {
+    auto param = vsag::JsonType::Parse(R"({
+        "base_quantization_type": "fp32",
+        "base_io_type": "block_memory_io",
+        "precise_quantization_type": "fp32",
+        "precise_io_type": "block_memory_io",
+        "graph_io_type": "block_memory_io",
+        "graph_storage_type": "flat",
+        "graph_type": "nsw",
+        "max_degree": 32,
+        "ef_construction": 100,
+        "label_remap_type": "robin",
+        "use_reorder": true
+    })");
+
+    vsag::IndexCommonParam common_param;
+    common_param.dim_ = 128;
+    common_param.data_type_ = vsag::DataTypes::DATA_TYPE_FLOAT;
+    auto hgraph_param = vsag::HGraph::CheckAndMappingExternalParam(param, common_param);
+    auto typed_param = std::dynamic_pointer_cast<vsag::HGraphParameter>(hgraph_param);
+
+    REQUIRE(typed_param != nullptr);
+    REQUIRE(typed_param->bottom_graph_param != nullptr);
+    REQUIRE(typed_param->label_remap_type == vsag::LabelRemapType::ROBIN);
 }

--- a/src/algorithm/hnswlib/algorithm_interface.h
+++ b/src/algorithm/hnswlib/algorithm_interface.h
@@ -118,8 +118,8 @@ public:
     virtual size_t
     getDeletedCount() = 0;
 
-    virtual vsag::PGUnorderedMap<LabelType, InnerIdType>
-    getDeletedElements() = 0;
+    virtual const vsag::UnorderedMap<LabelType, InnerIdType>&
+    getDeletedElements() const = 0;
 
     virtual bool
     isValidLabel(LabelType label) = 0;

--- a/src/algorithm/hnswlib/hnswalg.h
+++ b/src/algorithm/hnswlib/hnswalg.h
@@ -113,7 +113,7 @@ private:
     DISTFUNC fstdistfunc_{nullptr};
     void* dist_func_param_{nullptr};
 
-    vsag::PGUnorderedMap<LabelType, InnerIdType> label_lookup_;
+    vsag::UnorderedMap<LabelType, InnerIdType> label_lookup_;
 
     std::default_random_engine level_generator_{2021};
     mutable std::mutex level_generator_mutex_;
@@ -130,7 +130,7 @@ private:
     bool allow_replace_deleted_{false};
 
     std::mutex deleted_elements_lock_{};  // lock for deleted_elements_
-    vsag::PGUnorderedMap<LabelType, InnerIdType>
+    vsag::UnorderedMap<LabelType, InnerIdType>
         deleted_elements_;  // contains labels and internal ids of deleted elements
 
     bool immutable_{false};
@@ -270,8 +270,8 @@ public:
         return num_deleted_;
     }
 
-    vsag::PGUnorderedMap<LabelType, InnerIdType>
-    getDeletedElements() override {
+    const vsag::UnorderedMap<LabelType, InnerIdType>&
+    getDeletedElements() const override {
         return deleted_elements_;
     }
 

--- a/src/algorithm/hnswlib/hnswalg_static.h
+++ b/src/algorithm/hnswlib/hnswalg_static.h
@@ -248,8 +248,8 @@ public:
         return num_deleted_;
     }
 
-    vsag::PGUnorderedMap<LabelType, InnerIdType>
-    getDeletedElements() override {
+    const vsag::UnorderedMap<LabelType, InnerIdType>&
+    getDeletedElements() const override {
         throw std::runtime_error("Static HNSW doesn't support delete");
     };
 

--- a/src/algorithm/inner_index_interface.cpp
+++ b/src/algorithm/inner_index_interface.cpp
@@ -43,7 +43,8 @@ InnerIndexInterface::InnerIndexInterface(const InnerIndexParameterPtr& index_par
       use_attribute_filter_(index_param->use_attribute_filter),
       train_sample_count_(index_param->train_sample_count),
       use_reorder_(index_param->use_reorder) {
-    this->label_table_ = std::make_shared<LabelTable>(allocator_);
+    this->label_table_ =
+        std::make_shared<LabelTable>(allocator_, true, false, index_param->label_remap_type);
     this->tomb_label_table_ = std::make_shared<LabelTable>(allocator_);
     this->index_feature_list_ = std::make_unique<IndexFeatureList>();
     this->index_feature_list_->SetFeature(SUPPORT_EXPORT_IDS);
@@ -691,9 +692,9 @@ InnerIndexInterface::get_detail_data_by_info(const IndexDetailInfo& info) const 
         data->SetDataScalarInt64(this->GetNumElements());
     } else if (name == INDEX_DETAIL_NAME_LABEL_TABLE) {
         std::vector<std::vector<int64_t>> label_tables;
-        for (const auto& [key, value] : this->label_table_->label_remap_) {
+        this->label_table_->ForEachRemap([&](LabelType key, InnerIdType value) {
             label_tables.emplace_back(std::vector<int64_t>{key, value});
-        }
+        });
         data->SetData2DArrayInt64(label_tables);
     } else if (name == INDEX_DETAIL_DATA_TYPE) {
         data->SetDataScalarString(ToString(data_type_));

--- a/src/algorithm/inner_index_parameter.cpp
+++ b/src/algorithm/inner_index_parameter.cpp
@@ -25,6 +25,28 @@
 
 namespace vsag {
 
+namespace {
+
+auto
+parse_label_remap_type(const std::string& remap_type) -> LabelRemapType {
+    if (remap_type == LABEL_REMAP_TYPE_VALUE_PG) {
+        return LabelRemapType::PG;
+    }
+    if (remap_type == LABEL_REMAP_TYPE_VALUE_ROBIN) {
+        return LabelRemapType::ROBIN;
+    }
+    throw VsagException(ErrorType::INVALID_ARGUMENT,
+                        fmt::format("invalid label_remap_type: {}", remap_type));
+}
+
+auto
+dump_label_remap_type(LabelRemapType remap_type) -> const char* {
+    return remap_type == LabelRemapType::ROBIN ? LABEL_REMAP_TYPE_VALUE_ROBIN
+                                               : LABEL_REMAP_TYPE_VALUE_PG;
+}
+
+}  // namespace
+
 void
 InnerIndexParameter::FromJson(const JsonType& json) {
     if (json.Contains(USE_REORDER_KEY)) {
@@ -45,6 +67,10 @@ InnerIndexParameter::FromJson(const JsonType& json) {
 
     if (json.Contains(BUILD_THREAD_COUNT_KEY)) {
         this->build_thread_count = json[BUILD_THREAD_COUNT_KEY].GetInt();
+    }
+
+    if (json.Contains(LABEL_REMAP_TYPE_KEY)) {
+        this->label_remap_type = parse_label_remap_type(json[LABEL_REMAP_TYPE_KEY].GetString());
     }
 
     if (this->use_reorder) {
@@ -85,6 +111,7 @@ InnerIndexParameter::ToJson() const {
     JsonType json;
     json[USE_REORDER_KEY].SetBool(this->use_reorder);
     json[BUILD_THREAD_COUNT_KEY].SetInt(this->build_thread_count);
+    json[LABEL_REMAP_TYPE_KEY].SetString(dump_label_remap_type(this->label_remap_type));
     json[USE_ATTRIBUTE_FILTER_KEY].SetBool(this->use_attribute_filter);
     if (use_reorder) {
         json[PRECISE_CODES_KEY].SetJson(this->precise_codes_param->ToJson());
@@ -127,6 +154,11 @@ InnerIndexParameter::CheckCompatibility(const ParamPtr& other) const {
 
     if (this->use_attribute_filter != inner_index_param->use_attribute_filter) {
         logger::error("InnerIndexParameter::CheckCompatibility: use_attribute_filter mismatch");
+        return false;
+    }
+
+    if (this->label_remap_type != inner_index_param->label_remap_type) {
+        logger::error("InnerIndexParameter::CheckCompatibility: label_remap_type mismatch");
         return false;
     }
 

--- a/src/algorithm/inner_index_parameter.h
+++ b/src/algorithm/inner_index_parameter.h
@@ -48,6 +48,8 @@ public:
 
     uint64_t build_thread_count{1};
 
+    LabelRemapType label_remap_type{LabelRemapType::PG};
+
     int64_t train_sample_count{MAX_TRAIN_COUNT};
 
     bool store_raw_vector{false};

--- a/src/algorithm/inner_index_parameter_test.cpp
+++ b/src/algorithm/inner_index_parameter_test.cpp
@@ -87,3 +87,26 @@ TEST_CASE("Sampling Logic Test", "[ut][InnerIndexParameter][sampling]") {
         REQUIRE(param->train_sample_count != 65536L);
     }
 }
+
+TEST_CASE("Label remap type parameter test", "[ut][InnerIndexParameter][label_remap_type]") {
+    auto param = std::make_shared<vsag::InnerIndexParameter>();
+    auto json_obj = vsag::JsonType::Parse(R"({})");
+
+    SECTION("default is pg") {
+        param->FromJson(json_obj);
+        REQUIRE(param->label_remap_type == vsag::LabelRemapType::PG);
+        REQUIRE(param->ToJson()["label_remap_type"].GetString() == "pg");
+    }
+
+    SECTION("parse robin") {
+        json_obj["label_remap_type"].SetString("robin");
+        param->FromJson(json_obj);
+        REQUIRE(param->label_remap_type == vsag::LabelRemapType::ROBIN);
+        REQUIRE(param->ToJson()["label_remap_type"].GetString() == "robin");
+    }
+
+    SECTION("reject invalid value") {
+        json_obj["label_remap_type"].SetString("invalid");
+        REQUIRE_THROWS_AS(param->FromJson(json_obj), vsag::VsagException);
+    }
+}

--- a/src/algorithm/pyramid.cpp
+++ b/src/algorithm/pyramid.cpp
@@ -880,12 +880,10 @@ Pyramid::SetImmutable() {
     if (this->immutable_) {
         return;
     }
-    label_table_->use_reverse_map_ = false;
+    label_table_->SetImmutable();
     this->points_mutex_.reset();
     this->points_mutex_ = std::make_shared<EmptyMutex>();
     this->searcher_->SetMutexArray(this->points_mutex_);
-    PGUnorderedMap<LabelType, InnerIdType> empty_remap(allocator_);
-    this->label_table_->label_remap_.swap(empty_remap);
     immutable_ = true;
 }
 

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -167,6 +167,7 @@ const char* const HGRAPH_PARAMETER_HOPS_LIMIT = "hops_limit";
 const char* const HGRAPH_EXTRA_INFO_SIZE = "extra_info_size";
 const char* const HGRAPH_SUPPORT_DUPLICATE = "support_duplicate";
 const char* const HGRAPH_SUPPORT_TOMBSTONE = "support_tomb_stone";
+const char* const HGRAPH_LABEL_REMAP_TYPE = "label_remap_type";
 const char* const HGRAPH_USE_EXTRA_INFO_FILTER = "use_extra_info_filter";
 const char* const STORE_RAW_VECTOR = "store_raw_vector";
 const char* const RAW_VECTOR_IO_TYPE = "raw_vector_io_type";

--- a/src/impl/label_table.cpp
+++ b/src/impl/label_table.cpp
@@ -17,6 +17,94 @@
 
 namespace vsag {
 
+LabelTable::LabelRemap::LabelRemap(Allocator* allocator, LabelRemapType remap_type)
+    : allocator_(allocator), remap_type_(remap_type) {
+    Reset();
+}
+
+void
+LabelTable::LabelRemap::Reset() {
+    if (remap_type_ == LabelRemapType::ROBIN) {
+        robin_map_ = std::make_unique<UnorderedMap<LabelType, InnerIdType>>(0, allocator_);
+        robin_map_->max_load_factor(0.75F);
+        pg_map_.reset();
+        return;
+    }
+    pg_map_ = std::make_unique<PGUnorderedMap<LabelType, InnerIdType>>(0, allocator_);
+    pg_map_->max_load_factor(0.75F);
+    robin_map_.reset();
+}
+
+void
+LabelTable::LabelRemap::Clear() {
+    if (pg_map_ != nullptr) {
+        pg_map_->clear();
+        return;
+    }
+    robin_map_->clear();
+}
+
+void
+LabelTable::LabelRemap::Reserve(uint64_t size) {
+    if (pg_map_ != nullptr) {
+        pg_map_->reserve(size);
+        return;
+    }
+    robin_map_->reserve(size);
+}
+
+uint64_t
+LabelTable::LabelRemap::Size() const {
+    if (pg_map_ != nullptr) {
+        return pg_map_->size();
+    }
+    return robin_map_->size();
+}
+
+void
+LabelTable::LabelRemap::InsertOrAssign(LabelType label, InnerIdType inner_id) {
+    if (pg_map_ != nullptr) {
+        (*pg_map_)[label] = inner_id;
+        return;
+    }
+    (*robin_map_)[label] = inner_id;
+}
+
+void
+LabelTable::LabelRemap::Emplace(LabelType label, InnerIdType inner_id) {
+    if (pg_map_ != nullptr) {
+        pg_map_->emplace(label, inner_id);
+        return;
+    }
+    robin_map_->emplace(label, inner_id);
+}
+
+bool
+LabelTable::LabelRemap::Erase(LabelType label) {
+    if (pg_map_ != nullptr) {
+        return pg_map_->erase(label) > 0;
+    }
+    return robin_map_->erase(label) > 0;
+}
+
+bool
+LabelTable::LabelRemap::Find(LabelType label, InnerIdType& inner_id) const {
+    if (pg_map_ != nullptr) {
+        auto iter = pg_map_->find(label);
+        if (iter == pg_map_->end()) {
+            return false;
+        }
+        inner_id = iter->second;
+        return true;
+    }
+    auto iter = robin_map_->find(label);
+    if (iter == robin_map_->end()) {
+        return false;
+    }
+    inner_id = iter->second;
+    return true;
+}
+
 void
 LabelTable::MergeOther(const LabelTablePtr& other, const IdMapFunction& id_map) {
     auto other_size = other->GetTotalCount();
@@ -24,7 +112,7 @@ LabelTable::MergeOther(const LabelTablePtr& other, const IdMapFunction& id_map) 
     for (int64_t i = 0; i < other_size; ++i) {
         auto new_label = std::get<1>(id_map(other->label_table_[i]));
         this->label_table_[i + total_count_] = new_label;
-        this->label_remap_[new_label] = i + total_count_;
+        this->label_remap_.InsertOrAssign(new_label, i + total_count_);
     }
     total_count_ += other_size;
 }

--- a/src/impl/label_table.h
+++ b/src/impl/label_table.h
@@ -17,7 +17,14 @@
 
 #include <fmt/format.h>
 
+#include <algorithm>
 #include <atomic>
+#include <functional>
+#include <limits>
+#include <memory>
+#include <mutex>
+#include <tuple>
+#include <utility>
 
 #include "storage/stream_reader.h"
 #include "storage/stream_writer.h"
@@ -40,12 +47,67 @@ struct DuplicateRecord {
 
 class LabelTable {
 public:
+    class LabelRemap {
+    public:
+        explicit LabelRemap(Allocator* allocator, LabelRemapType remap_type = LabelRemapType::PG);
+
+        void
+        Clear();
+
+        void
+        Reset();
+
+        void
+        Reserve(uint64_t size);
+
+        uint64_t
+        Size() const;
+
+        void
+        InsertOrAssign(LabelType label, InnerIdType inner_id);
+
+        void
+        Emplace(LabelType label, InnerIdType inner_id);
+
+        bool
+        Erase(LabelType label);
+
+        bool
+        Find(LabelType label, InnerIdType& inner_id) const;
+
+        template <typename Func>
+        void
+        ForEach(Func&& func) const {
+            if (pg_map_ != nullptr) {
+                for (const auto& [label, inner_id] : *pg_map_) {
+                    func(label, inner_id);
+                }
+                return;
+            }
+            for (const auto& [label, inner_id] : *robin_map_) {
+                func(label, inner_id);
+            }
+        }
+
+        [[nodiscard]] LabelRemapType
+        GetType() const {
+            return remap_type_;
+        }
+
+    private:
+        Allocator* allocator_{nullptr};
+        LabelRemapType remap_type_{LabelRemapType::PG};
+        std::unique_ptr<UnorderedMap<LabelType, InnerIdType>> robin_map_{};
+        std::unique_ptr<PGUnorderedMap<LabelType, InnerIdType>> pg_map_{};
+    };
+
     explicit LabelTable(Allocator* allocator,
                         bool use_reverse_map = true,
-                        bool compress_redundant_data = false)
+                        bool compress_redundant_data = false,
+                        LabelRemapType label_remap_type = LabelRemapType::PG)
         : allocator_(allocator),
           label_table_(0, allocator),
-          label_remap_(0, allocator),
+          label_remap_(allocator, label_remap_type),
           use_reverse_map_(use_reverse_map),
           deleted_ids_(allocator),
           compress_duplicate_data_(compress_redundant_data),
@@ -60,7 +122,7 @@ public:
     inline void
     Insert(InnerIdType id, LabelType label) {
         if (use_reverse_map_) {
-            label_remap_[label] = id;
+            label_remap_.InsertOrAssign(label, id);
         }
         if (id + 1 > label_table_.size()) {
             label_table_.resize(id + 1);
@@ -74,12 +136,13 @@ public:
         if (not use_reverse_map_) {
             return true;
         }
-        auto iter = label_remap_.find(label);
-        if (iter == label_remap_.end() or iter->second == std::numeric_limits<InnerIdType>::max()) {
+        InnerIdType inner_id;
+        if (not label_remap_.Find(label, inner_id) or
+            inner_id == std::numeric_limits<InnerIdType>::max()) {
             return false;
         }
-        deleted_ids_.insert(iter->second);
-        label_remap_[label] = std::numeric_limits<InnerIdType>::max();
+        deleted_ids_.insert(inner_id);
+        label_remap_.InsertOrAssign(label, std::numeric_limits<InnerIdType>::max());
         return true;
     }
 
@@ -89,17 +152,18 @@ public:
         if (not use_reverse_map_) {
             return false;
         }
-        auto iter = label_remap_.find(label);
-        if (iter == label_remap_.end() or iter->second != std::numeric_limits<InnerIdType>::max()) {
+        InnerIdType inner_id;
+        if (not label_remap_.Find(label, inner_id) or
+            inner_id != std::numeric_limits<InnerIdType>::max()) {
             return false;
         }
 
         // 2. find inner_id
-        auto inner_id = GetIdByLabel(label, true);
+        inner_id = GetIdByLabel(label, true);
 
         // 3. recover
         deleted_ids_.erase(inner_id);
-        label_remap_[label] = inner_id;
+        label_remap_.InsertOrAssign(label, inner_id);
         return true;
     }
 
@@ -108,9 +172,9 @@ public:
         if (not use_reverse_map_) {
             return false;
         }
-        auto iter = label_remap_.find(label);
-        return (iter != label_remap_.end() and
-                iter->second == std::numeric_limits<InnerIdType>::max());
+        InnerIdType inner_id;
+        return label_remap_.Find(label, inner_id) and
+               inner_id == std::numeric_limits<InnerIdType>::max();
     }
 
     inline bool
@@ -131,12 +195,12 @@ public:
     inline std::pair<bool, InnerIdType>
     TryGetIdByLabel(LabelType label, bool return_even_removed = false) const noexcept {
         if (use_reverse_map_ and not return_even_removed) {
-            auto iter = this->label_remap_.find(label);
-            if (iter == this->label_remap_.end()) {
+            InnerIdType inner_id;
+            if (not this->label_remap_.Find(label, inner_id)) {
                 return {false, 0};
             }
-            if (iter->second != std::numeric_limits<InnerIdType>::max()) {
-                return {true, iter->second};
+            if (inner_id != std::numeric_limits<InnerIdType>::max()) {
+                return {true, inner_id};
             } else {
                 return {false, 0};
             }
@@ -152,9 +216,9 @@ public:
     CheckLabel(LabelType label) const {
         // return true when label exists and not been deleted
         if (use_reverse_map_) {
-            auto iter = label_remap_.find(label);
-            return iter != label_remap_.end() and
-                   iter->second != std::numeric_limits<InnerIdType>::max();
+            InnerIdType inner_id;
+            return label_remap_.Find(label, inner_id) and
+                   inner_id != std::numeric_limits<InnerIdType>::max();
         }
         auto result = std::find(label_table_.begin(), label_table_.end(), label);
         return result != label_table_.end();
@@ -185,11 +249,20 @@ public:
         // 3. update label_remap_
         if (use_reverse_map_) {
             // note that currently, old_label must exist
-            auto iter_old = label_remap_.find(old_label);
-            auto internal_id = iter_old->second;
-            label_remap_.erase(iter_old);
-            label_remap_[new_label] = internal_id;
+            InnerIdType internal_id;
+            if (not label_remap_.Find(old_label, internal_id)) {
+                throw VsagException(ErrorType::INTERNAL_ERROR,
+                                    fmt::format("old label {} does not exist", old_label));
+            }
+            label_remap_.Erase(old_label);
+            label_remap_.InsertOrAssign(new_label, internal_id);
         }
+    }
+
+    void
+    SetImmutable() {
+        this->use_reverse_map_ = false;
+        this->label_remap_.Reset();
     }
 
     inline LabelType
@@ -232,8 +305,10 @@ public:
     Deserialize(lvalue_or_rvalue<StreamReader> reader) {
         StreamReader::ReadVector(reader, label_table_);
         if (use_reverse_map_) {
+            this->label_remap_.Clear();
+            this->label_remap_.Reserve(label_table_.size());
             for (InnerIdType id = 0; id < label_table_.size(); ++id) {
-                this->label_remap_[label_table_[id]] = id;
+                this->label_remap_.InsertOrAssign(label_table_[id], id);
             }
         }
         if (compress_duplicate_data_) {
@@ -272,6 +347,30 @@ public:
         return total_count_;
     }
 
+    uint64_t
+    GetRemapSize() const {
+        return label_remap_.Size();
+    }
+
+    template <typename Visitor>
+    void
+    ForEachRemap(Visitor&& visitor) const {
+        label_remap_.ForEach(std::forward<Visitor>(visitor));
+    }
+
+    void
+    ResetRemap(uint64_t size = 0) {
+        label_remap_.Clear();
+        if (size > 0) {
+            label_remap_.Reserve(size);
+        }
+    }
+
+    void
+    InsertRemap(LabelType label, InnerIdType inner_id) {
+        label_remap_.Emplace(label, inner_id);
+    }
+
     inline bool
     CompressDuplicateData() const {
         return compress_duplicate_data_;
@@ -303,7 +402,7 @@ public:
     int64_t
     GetMemoryUsage() {
         return sizeof(LabelTable) + label_table_.size() * sizeof(LabelType) +
-               label_remap_.size() * (sizeof(LabelType) + sizeof(InnerIdType)) +
+               label_remap_.Size() * (sizeof(LabelType) + sizeof(InnerIdType)) +
                deleted_ids_.size() * sizeof(InnerIdType) +
                duplicate_records_.size() * (sizeof(DuplicateRecord*) + sizeof(DuplicateRecord));
     }
@@ -313,7 +412,7 @@ public:
     // Whether to use reverse map to speed up GetIdByLabel.
     bool use_reverse_map_{true};
     // Reverse map from label to id.
-    PGUnorderedMap<LabelType, InnerIdType> label_remap_;
+    LabelRemap label_remap_;
     UnorderedSet<InnerIdType> deleted_ids_;
 
     bool compress_duplicate_data_{true};

--- a/src/impl/label_table_test.cpp
+++ b/src/impl/label_table_test.cpp
@@ -1,0 +1,29 @@
+#include "label_table.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "impl/allocator/default_allocator.h"
+
+using namespace vsag;
+
+TEST_CASE("LabelTable Supports Configurable Remap Implementation", "[ut][LabelTable]") {
+    auto allocator = std::make_shared<DefaultAllocator>();
+
+    SECTION("robin remap works") {
+        LabelTable label_table(allocator.get(), true, false, LabelRemapType::ROBIN);
+        label_table.Insert(0, 100);
+        label_table.Insert(1, 200);
+
+        REQUIRE(label_table.GetRemapSize() == 2);
+        REQUIRE(label_table.GetIdByLabel(100) == 0);
+        REQUIRE(label_table.GetIdByLabel(200) == 1);
+    }
+
+    SECTION("pg remap remains default") {
+        LabelTable label_table(allocator.get(), true, false, LabelRemapType::PG);
+        label_table.Insert(0, 100);
+
+        REQUIRE(label_table.GetRemapSize() == 1);
+        REQUIRE(label_table.GetIdByLabel(100) == 0);
+    }
+}

--- a/src/index/hnsw_test.cpp
+++ b/src/index/hnsw_test.cpp
@@ -1185,7 +1185,7 @@ TEST_CASE("update mark-deleted vector", "[ut][hnsw]") {
         if (is_deleted) {
             REQUIRE(alg_hnsw->getDeletedElements().count(old_label) == 0);
             REQUIRE(alg_hnsw->getDeletedElements().count(new_label) != 0);
-            REQUIRE(alg_hnsw->getDeletedElements()[new_label] == old_label);
+            REQUIRE(alg_hnsw->getDeletedElements().at(new_label) == old_label);
         } else {
             REQUIRE(not alg_hnsw->isValidLabel(old_label));
             REQUIRE(alg_hnsw->isValidLabel(new_label));

--- a/src/inner_string_params.h
+++ b/src/inner_string_params.h
@@ -34,6 +34,7 @@ const char* const USE_QUANTIZATION = "use_quantization";
 const char* const EXTRA_INFO_KEY = "extra_info";
 const char* const USE_ATTRIBUTE_FILTER_KEY = "use_attribute_filter";
 const char* const BUILD_THREAD_COUNT_KEY = "build_thread_count";
+const char* const LABEL_REMAP_TYPE_KEY = "label_remap_type";
 const char* const BASE_CODES_KEY = "base_codes";
 const char* const PRECISE_CODES_KEY = "precise_codes";
 const char* const STORE_RAW_VECTOR_KEY = "store_raw_vector";
@@ -45,6 +46,9 @@ const char* const ATTR_PARAMS_KEY = "attr_params";
 const char* const HGRAPH_USE_ELP_OPTIMIZER_KEY = "use_elp_optimizer";
 const char* const HGRAPH_IGNORE_REORDER_KEY = "ignore_reorder";
 const char* const HGRAPH_BUILD_BY_BASE_QUANTIZATION_KEY = "build_by_base";
+const char* const HGRAPH_USE_REVERSE_EDGES_KEY = "use_reverse_edges";
+const char* const LABEL_REMAP_TYPE_VALUE_ROBIN = "robin";
+const char* const LABEL_REMAP_TYPE_VALUE_PG = "pg";
 const char* const GRAPH_KEY = "graph";
 const char* const ALPHA_KEY = "alpha";
 
@@ -188,6 +192,7 @@ const std::unordered_map<std::string, std::string> DEFAULT_MAP = {
     {"BASE_CODES_KEY", BASE_CODES_KEY},
     {"PRECISE_CODES_KEY", PRECISE_CODES_KEY},
     {"HGRAPH_SUPPORT_DUPLICATE", HGRAPH_SUPPORT_DUPLICATE},
+    {"HGRAPH_LABEL_REMAP_TYPE", HGRAPH_LABEL_REMAP_TYPE},
     {"IO_TYPE_VALUE_MEMORY_IO", IO_TYPE_VALUE_MEMORY_IO},
     {"IO_TYPE_VALUE_BLOCK_MEMORY_IO", IO_TYPE_VALUE_BLOCK_MEMORY_IO},
     {"IO_TYPE_VALUE_BUFFER_IO", IO_TYPE_VALUE_BUFFER_IO},
@@ -243,6 +248,9 @@ const std::unordered_map<std::string, std::string> DEFAULT_MAP = {
     {"IVF_PARTITION_STRATEGY_TYPE_NEAREST", IVF_PARTITION_STRATEGY_TYPE_NEAREST},
     {"IVF_TRAIN_TYPE_KMEANS", IVF_TRAIN_TYPE_KMEANS},
     {"BUILD_THREAD_COUNT_KEY", BUILD_THREAD_COUNT_KEY},
+    {"LABEL_REMAP_TYPE_KEY", LABEL_REMAP_TYPE_KEY},
+    {"LABEL_REMAP_TYPE_VALUE_ROBIN", LABEL_REMAP_TYPE_VALUE_ROBIN},
+    {"LABEL_REMAP_TYPE_VALUE_PG", LABEL_REMAP_TYPE_VALUE_PG},
     {"SEARCH_PARALLELISM", SEARCH_PARALLELISM},
     {"GRAPH_SUPPORT_REMOVE", GRAPH_SUPPORT_REMOVE},
     {"REMOVE_FLAG_BIT", REMOVE_FLAG_BIT},

--- a/src/typing.h
+++ b/src/typing.h
@@ -30,6 +30,8 @@ namespace vsag {
 using InnerIdType = uint32_t;  // inner id's type; index's vector count may less than 2^31 - 1
 using LabelType = int64_t;     // external id's type
 
+enum class LabelRemapType : uint8_t { ROBIN, PG };
+
 using JsonType = JsonWrapper;  // alias for nlohmann::json type
 using BucketIdType = int32_t;
 


### PR DESCRIPTION
## Summary
This is a cherry-pick of PR #1981 to branch 0.18.

Original PR: https://github.com/antgroup/vsag/pull/1981

### Changes from original PR:
- Add an inner-index label_remap_type parameter and expose it on the HGraph build parameter surface
- Encapsulate label remap storage inside LabelTable so inner indexes can switch between robin_map and robin_pg_map
- Add unit coverage for parameter parsing, HGraph mapping, and configurable remap behavior

### Cherry-pick adaptations:
- Resolved conflicts in multiple files to adapt to 0.18 branch context
- Preserved all functionality from original PR
- Added necessary conflict resolution adjustments

Closes #1986 (original issue)