### PR TITLE
docs: reorganize agent guidance

### DIFF
--- a/.github/ISSUE_TEMPLATE/ISSUE_GUIDE.md
+++ b/.github/ISSUE_TEMPLATE/ISSUE_GUIDE.md
@@ -59,7 +59,7 @@ new feature
 ## Labels
 
 The issue templates pre-apply a `kind/*` label that mirrors the PR
-[`kind/*`](../../AGENTS.md#pull-request-labels) policy, so triage and release
+[`kind/*`](../../docs/agents/contribution-workflow.md#pull-request-labels) policy, so triage and release
 notes stay consistent. The one exception is `question.yml`, which applies the
 plain `question` label — usage questions do not normally produce a PR and so
 do not need a `kind/*` value.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,176 +1,98 @@
 # AGENTS.md
 
+> **Read me first.** This file is the entry point for AI coding agents
+> working on VSAG. It is intentionally short. The bullets under
+> *Hard Constraints* must hold for every change; the *Documentation Index*
+> points at the detailed rules for each topic.
+
 ## Project Overview
 
-VSAG is a high-performance vector indexing library for similarity search, written primarily in C++
-with Python bindings provided by `pyvsag`.
+VSAG is a high-performance vector indexing library for similarity search,
+written primarily in C++ with Python bindings provided by `pyvsag` and
+Node.js/TypeScript bindings provided by `vsag`.
 
-## Where To Learn About The Project
+## Hard Constraints (must hold every change)
+
+- **Tool versions are fixed:** `clang-format` and `clang-tidy` **must be
+  version 15 exactly**. Newer versions are not acceptable; CI enforces this.
+- **Formatting:** 4-space indentation, 100-character line limit, `.cpp`
+  (not `.cc`) suffix, every committed text file ends with a trailing newline.
+- **Layout:** public APIs live in `include/vsag/`; implementation lives in
+  `src/`; keep code in the `vsag` namespace unless the file clearly requires
+  otherwise.
+- **Prefer `uint64_t` over `size_t`** in code changes to avoid macOS compile
+  issues.
+- **Do not modify `extern/`** unless the task explicitly requires third-party
+  dependency changes.
+- **Tests:** new features need tests; bug fixes need regression coverage; the
+  C++ library (`src/` + `include/`) must maintain **≥ 90 % unit-test
+  coverage**.
+- **Commits:** use Conventional Commits (`feat:`, `fix:`, `docs:`,
+  `chore:`, …) and DCO sign-off. **AI agents must NOT add their own
+  `Signed-off-by:`** — only humans can certify the DCO. **AI agents must
+  also NOT invoke `git commit -s`**, because `-s` appends `Signed-off-by:`
+  at the end of the message (with a blank line separating it from earlier
+  trailers) and breaks the required ordering. Instead, write both trailers
+  directly in the commit message body: derive the human identity from
+  `git config user.name` / `user.email`, place `Signed-off-by:` first, and
+  follow it immediately (no blank line) with
+  `Assisted-by: <AgentName>:<ModelVersion>` (e.g.
+  `Assisted-by: OpenCode:claude-opus-4.7`). For `[skip ci]`, place it at
+  the **start** of the subject line.
+- **Pull requests need two labels:** one `kind/*` (`kind/bug`,
+  `kind/feature`, `kind/improvement`, `kind/documentation`) and one
+  `version/*` (e.g. `version/1.0`). Mergify enforces both.
+- **Issues do NOT carry `Signed-off-by:`** — DCO only applies to commits.
+
+## Quick Command Reference
+
+```bash
+make debug        # debug build
+make test         # build and run unit + functional tests (no coverage instrumentation)
+make fmt          # run clang-format
+make lint         # run clang-tidy
+make fix-lint     # apply clang-tidy fixes where safe
+make cov          # build with coverage instrumentation; run the test binaries and
+                  # scripts/coverage/collect_cpp_coverage.sh to produce a report
+make release      # optimized build
+make pyvsag       # build the Python wheel
+```
+
+Full build and environment details: [`docs/agents/build-and-test.md`](docs/agents/build-and-test.md).
+
+## Documentation Index (read the relevant file before non-trivial work)
+
+| Topic | Document |
+| --- | --- |
+| Build / test / dev environment / tool versions | [`docs/agents/build-and-test.md`](docs/agents/build-and-test.md) |
+| C++ style, layout, common patterns, testing | [`docs/agents/coding-standards.md`](docs/agents/coding-standards.md) |
+| Branching, commits, DCO, `Assisted-by`, PR labels, doc sync | [`docs/agents/contribution-workflow.md`](docs/agents/contribution-workflow.md) |
+| Drafting & submitting GitHub issues (`/create-issue`) | [`docs/agents/filing-issues.md`](docs/agents/filing-issues.md) |
+| Repository / docs map | [`docs/agents/docs-map.md`](docs/agents/docs-map.md) |
+
+## How To Research The Project
 
 Before making non-trivial changes, consult the project documentation:
 
-- The official documentation site: <https://vsag.io/docs> (English and Chinese versions are
-  available, including index parameters, best practices, performance references, and the
-  `eval_performance` tool guide).
-- The in-repo `docs/` directory, which mirrors the website source under `docs/docs/{en,zh}/src/`
-  and also contains design notes (e.g. `docs/hgraph.md`, `docs/ivf.md`, `docs/sindi.md`,
-  `docs/eval_performance.md`, `docs/dataset_format.md`).
+- Official documentation site: <https://vsag.io/docs> (English and Chinese;
+  index parameters, best practices, performance references, and the
+  `eval_performance` tool guide all live there).
+- In-repo sources mirror the site under `docs/docs/{en,zh}/src/`. Top-level
+  `docs/*.md` (e.g. `docs/hgraph.md`, `docs/ivf.md`, `docs/sindi.md`,
+  `docs/eval_performance.md`, `docs/dataset_format.md`) historically contain
+  design-leaning notes and may overlap with the website; treat the website
+  source as preferred and consult [`docs/agents/docs-map.md`](docs/agents/docs-map.md)
+  for the full layout.
 
-When updating user-facing behavior, keep both the website docs and any related in-repo READMEs
-(`tools/eval/README.md`, `tools/eval/README_zh.md`, etc.) in sync.
-
-## What To Optimize For
-
-- Preserve API compatibility unless a breaking change is explicitly intended.
-- Keep performance in mind for hot paths, memory layout, and parallel code.
-- Follow existing project structure and naming before introducing new patterns.
-- Prefer minimal, targeted changes over broad refactors.
-
-## Repository Structure
-
-- `include/`: public headers
-- `src/`: core implementation and unit tests
-- `tests/`: functional tests
-- `examples/cpp/`: C++ examples
-- `examples/python/`: Python examples
-- `python/`: `pyvsag` packaging and Python-side code
-- `python_bindings/`: pybind11 bindings
-- `docs/`: design and user-facing documentation
-- `tools/`: utility and analysis tools
-
-## Build And Test
-
-Preferred commands:
-
-```bash
-make debug
-make test
-make fmt
-make lint
-make fix-lint
-make cov
-make release
-make pyvsag
-```
-
-## Development Environment
-
-- Recommended: use the published Docker development image.
-- Supported local environments include Ubuntu 20.04+ and CentOS 7+.
-- Compiler baseline: GCC 9.4.0+ or Clang 13.0.0+.
-- Build baseline: CMake 3.18.0+.
-
-## Required Tool Versions
-
-- `clang-format` must be version 15 exactly.
-- `clang-tidy` must be version 15 exactly.
-
-Do not assume newer versions are acceptable; the repository enforces these versions for consistent
-formatting and diagnostics.
-
-## Coding Standards
-
-Follow the Google C++ Style Guide with project-specific rules:
-
-- 4-space indentation
-- use `.cpp` instead of `.cc`
-- 100-character line limit
-- ensure committed text files end with a trailing newline
-
-Additional expectations:
-
-- Keep public APIs in `include/vsag/`.
-- Keep implementation in `src/`.
-- Place tests near the code they validate when appropriate.
-- Add or update Doxygen comments for public APIs.
-
-## Testing Expectations
-
-- New features should include tests.
-- Bug fixes should include regression coverage.
-- Contributions are expected to maintain at least 90% code coverage on the C++ library code
-  (sources under `src/` and public headers under `include/`), as measured by the coverage job
-  invoked via `make test` and the corresponding CI coverage workflow. This threshold is based on
-  the unit-test suite; functional tests under `tests/` and Python code are not currently included
-  in the coverage metric unless explicitly documented otherwise.
-
-## Common Code Patterns
-
-- Builder-style chained APIs are common.
-- `std::shared_ptr<T>` is used widely in public interfaces.
-- Prefer existing error-handling/result patterns used in the surrounding code.
-- Keep code in the `vsag` namespace unless the file clearly requires otherwise.
-
-## Documentation Expectations
-
-Update relevant docs when behavior changes:
-
-- `README.md` for user-facing features or examples
-- `DEVELOPMENT.md` for build or environment changes
-- `CONTRIBUTING.md` for workflow or contribution policy changes
-
-## Contribution Notes
-
-- Before modifying code, create and switch to a working branch from an up-to-date `main`.
-- Keep changes scoped and reviewable.
-- Be careful with performance-sensitive code and cross-platform behavior.
-- Prefer `uint64_t` over `size_t` in code changes to avoid potential macOS compile issues.
-- Avoid changing files under `extern/` unless the task explicitly requires third-party dependency changes.
-- If changing build logic or dependencies, document the rationale clearly.
-- Commit messages should follow Conventional Commits, such as `feat:`, `fix:`, `docs:`, or
-  `chore:`.
-- Commits in this project are expected to use DCO sign-off (`git commit -s`).
-- Only humans can legally certify the DCO; AI coding agents **must not** add their own
-  `Signed-off-by` trailer. The human submitter is responsible for reviewing AI-generated
-  changes, ensuring license compliance, and taking full responsibility for the contribution.
-- For changes produced with AI assistance, attribute the agent with an `Assisted-by:` trailer
-  in the form `Assisted-by: AgentName:ModelVersion` (see the
-  [Linux kernel AI Coding Assistants policy](https://docs.kernel.org/process/coding-assistants.html)).
-  Determine `AgentName` and `ModelVersion` at execution time from the active agent name and
-  model name (e.g. `Assisted-by: OpenCode:claude-opus-4.7`).
-- Trailer order: place the human `Signed-off-by:` first, followed by the `Assisted-by:` line
-  for the AI agent.
-- When using skip-CI commit messages, follow the repository convention and place `[skip ci]` at the
-  beginning of the subject line.
-
-## Pull Request Labels
-
-Every pull request **must** have two labels before it can be merged:
-
-- A `kind/*` label for the type of change: `kind/bug` (bug fix), `kind/feature` (new feature), `kind/improvement` (refactor, chore, or minor improvement), or `kind/documentation` (documentation change).
-- A `version/*` label for the target version (e.g. `version/1.0`, `version/0.18`).
-
-Mergify enforces these via check runs. Always add both labels when creating a PR.
-
-## Filing Issues With An Agent
-
-Agents are also expected to help users file high-quality issues. The shared
-workflow lives in `.github/agent-prompts/create-issue.md` and the writing
-rules live in `.github/ISSUE_TEMPLATE/ISSUE_GUIDE.md`. Both Claude Code,
-OpenCode and Codex expose this workflow as a `/create-issue` slash command
-(see `.claude/commands/`, `.opencode/command/`, `.codex/prompts/`).
-
-When drafting an issue:
-
-- Map every required field of the chosen YAML template under
-  `.github/ISSUE_TEMPLATE/`. Use `// TODO` for genuinely unknown values.
-- Cite sources as `path:line` for repo references and full URLs for
-  `vsag.io/docs` pages.
-- Run `gh issue list --repo antgroup/vsag --search ... --state all --limit 5`
-  and append the matches under a `## Related issues` section. Do not block
-  creation on duplicates; the maintainers will close as needed.
-- Append a footer of the form
-  `_Drafted with AI assistant: <AgentName>:<ModelVersion>_` for transparency.
-  Do **not** add `Signed-off-by:` to issues — DCO applies only to commits.
-- Show a dry-run preview and only call `gh issue create` after the user
-  confirms. On failure, fall back to `gh issue create --web`.
-
-A shell wrapper is provided at `tools/issue-helper/new-issue.sh` for users
-who prefer not to drive the agent's slash command directly.
+When updating user-facing behavior, keep both the website docs and any
+related in-repo READMEs (`tools/eval/README.md`, `tools/eval/README_zh.md`,
+etc.) in sync. See
+[`docs/agents/contribution-workflow.md`](docs/agents/contribution-workflow.md#documentation-expectations).
 
 ## References
 
-- `README.md`
-- `CONTRIBUTING.md`
-- `DEVELOPMENT.md`
-- `.github/ISSUE_TEMPLATE/ISSUE_GUIDE.md`
+- [`README.md`](README.md)
+- [`CONTRIBUTING.md`](CONTRIBUTING.md)
+- [`DEVELOPMENT.md`](DEVELOPMENT.md)
+- [`.github/ISSUE_TEMPLATE/ISSUE_GUIDE.md`](.github/ISSUE_TEMPLATE/ISSUE_GUIDE.md)
+- [`docs/agents/`](docs/agents/) — detailed agent operating docs

--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
+<!-- agent-hints
+canonical: README.md
+purpose: VSAG project landing page (intro, performance, Quickstart, links)
+key-facts:
+  - VSAG is a C++ vector indexing library with pyvsag (Python) and vsag (Node.js/TS) bindings
+  - SINDI (sparse) and HGraph (dense) are the headline indexes
+  - Quickstart blocks exist for C++, Python, and TypeScript
+related:
+  - AGENTS.md
+  - DEVELOPMENT.md
+  - docs/docs/en/src/guide/installation.md
+last-reviewed: 2026-05-12
+-->
 <div align="center">
   <h1><img alt="vsag-pages" src="docs/banner.svg" width=500/></h1>
 

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -1,0 +1,36 @@
+<!-- agent-hints
+canonical: docs/agents/README.md
+purpose: Index of agent-facing operating docs split out of AGENTS.md
+key-facts:
+  - AGENTS.md is the entry point; this directory holds the full rules
+  - Read the relevant sub-doc before non-trivial changes
+  - Sub-docs are the single source of truth for their topic
+related:
+  - ../../AGENTS.md
+last-reviewed: 2026-05-12
+-->
+
+# Agent Operating Docs
+
+This directory holds the detailed operating rules referenced from
+[`AGENTS.md`](../../AGENTS.md). `AGENTS.md` itself is intentionally short and
+acts as an index plus a list of hard constraints; everything below provides
+the full context for a given topic.
+
+| Document | Purpose |
+| --- | --- |
+| [`build-and-test.md`](build-and-test.md) | Build / test commands, development environment, required tool versions. |
+| [`coding-standards.md`](coding-standards.md) | C++ style, layout rules, common code patterns, testing expectations. |
+| [`contribution-workflow.md`](contribution-workflow.md) | Branching, commit messages, DCO, `Assisted-by`, PR labels, docs sync. |
+| [`filing-issues.md`](filing-issues.md) | How agents draft and submit GitHub issues for VSAG. |
+| [`docs-map.md`](docs-map.md) | Map of the repository's markdown documentation and how the pieces relate. |
+
+## How to use these docs as an agent
+
+1. Always read [`AGENTS.md`](../../AGENTS.md) first — it lists the
+   non-negotiable hard constraints.
+2. Open the sub-doc that matches the current task (build issue, code style
+   question, PR prep, issue filing, doc navigation).
+3. When updating behavior that any of these docs describe, update the
+   sub-doc in the same change. `AGENTS.md` only needs an update when a
+   hard constraint or top-level pointer changes.

--- a/docs/agents/build-and-test.md
+++ b/docs/agents/build-and-test.md
@@ -1,0 +1,63 @@
+<!-- agent-hints
+canonical: docs/agents/build-and-test.md
+purpose: Build, test, and development environment rules for VSAG
+key-facts:
+  - clang-format and clang-tidy must be version 15 exactly
+  - Preferred build path is the published Docker image
+  - Use the make targets listed below instead of raw cmake
+related:
+  - ../../DEVELOPMENT.md
+  - ../docs/en/src/development/building.md
+last-reviewed: 2026-05-12
+-->
+
+# Build And Test
+
+## Preferred commands
+
+```bash
+make debug
+make test
+make fmt
+make lint
+make fix-lint
+make cov
+make release
+make pyvsag
+```
+
+Prefer these targets over invoking `cmake` directly so behavior matches CI.
+
+## Development environment
+
+- Recommended: use the published Docker development image
+  (`vsaglib/vsag:ubuntu`).
+- Supported local environments include Ubuntu 20.04+ and CentOS 7+.
+- Compiler baseline: GCC 9.4.0+ or Clang 13.0.0+.
+- Build baseline: CMake 3.18.0+.
+
+See [`DEVELOPMENT.md`](../../DEVELOPMENT.md) for the full setup walkthrough.
+
+## Required tool versions
+
+- `clang-format` must be version **15** exactly.
+- `clang-tidy` must be version **15** exactly.
+
+Do not assume newer versions are acceptable; the repository enforces these
+versions for consistent formatting and diagnostics. CI will fail otherwise.
+
+## Testing expectations
+
+- New features should include tests.
+- Bug fixes should include regression coverage.
+- Contributions are expected to maintain at least **90% code coverage** on the
+  C++ library code (sources under `src/` and public headers under `include/`).
+  `make test` builds and runs the unit + functional suite but does **not**
+  enable coverage instrumentation. To produce the coverage report locally use
+  the `make cov` flow (which configures the build with `ENABLE_COVERAGE=ON`)
+  followed by running the test binaries and
+  `scripts/coverage/collect_cpp_coverage.sh`; the equivalent CI coverage
+  workflow enforces the 90% threshold. This threshold is based on the
+  unit-test suite; functional tests under `tests/` and Python code are not
+  currently included in the coverage metric unless explicitly documented
+  otherwise.

--- a/docs/agents/coding-standards.md
+++ b/docs/agents/coding-standards.md
@@ -1,0 +1,53 @@
+<!-- agent-hints
+canonical: docs/agents/coding-standards.md
+purpose: C++ coding standards and common patterns enforced in VSAG
+key-facts:
+  - 4-space indent, 100-col limit, .cpp suffix, trailing newline required
+  - Public APIs live in include/vsag/; implementation in src/
+  - Prefer uint64_t over size_t for macOS compatibility
+related:
+  - ../../CONTRIBUTING.md
+  - ../docs/en/src/development/code_structure.md
+last-reviewed: 2026-05-12
+-->
+
+# Coding Standards
+
+Follow the Google C++ Style Guide with the project-specific rules below.
+
+## Formatting
+
+- 4-space indentation
+- Use `.cpp` instead of `.cc`
+- 100-character line limit
+- Ensure committed text files end with a trailing newline
+
+## Code layout
+
+- Keep public APIs in `include/vsag/`.
+- Keep implementation in `src/`.
+- Place tests near the code they validate when appropriate.
+- Add or update Doxygen comments for public APIs.
+- Keep code in the `vsag` namespace unless the file clearly requires otherwise.
+
+## What to optimize for
+
+- Preserve API compatibility unless a breaking change is explicitly intended.
+- Keep performance in mind for hot paths, memory layout, and parallel code.
+- Follow existing project structure and naming before introducing new patterns.
+- Prefer minimal, targeted changes over broad refactors.
+
+## Common code patterns
+
+- Builder-style chained APIs are common.
+- `std::shared_ptr<T>` is used widely in public interfaces.
+- Prefer existing error-handling/result patterns used in the surrounding code.
+- Prefer `uint64_t` over `size_t` in code changes to avoid potential macOS
+  compile issues.
+
+## Things to avoid
+
+- Avoid changing files under `extern/` unless the task explicitly requires
+  third-party dependency changes.
+- Be careful with performance-sensitive code and cross-platform behavior.
+- If changing build logic or dependencies, document the rationale clearly.

--- a/docs/agents/contribution-workflow.md
+++ b/docs/agents/contribution-workflow.md
@@ -1,0 +1,83 @@
+<!-- agent-hints
+canonical: docs/agents/contribution-workflow.md
+purpose: Branching, commits, DCO, Assisted-by, PR labels, doc sync rules
+key-facts:
+  - Use Conventional Commits with DCO sign-off; AI agents must NOT self-sign
+  - AI agents: do NOT use `git commit -s` (it appends Signed-off-by last, with a blank line before it). Write both trailers manually in the commit body, deriving the human Signed-off-by from `git config user.name`/`user.email`
+  - Trailer order: Signed-off-by first, Assisted-by immediately after, no blank line between them
+  - Every PR needs both a kind/* and a version/* label
+related:
+  - ../../CONTRIBUTING.md
+  - ../../.github/pull_request_template.md
+last-reviewed: 2026-05-12
+-->
+
+# Contribution Workflow
+
+## Branching
+
+- Before modifying code, create and switch to a working branch from an
+  up-to-date `main`.
+- Keep changes scoped and reviewable.
+
+## Commit messages
+
+- Follow Conventional Commits: `feat:`, `fix:`, `docs:`, `chore:`,
+  `refactor:`, etc.
+- Commits in this project are expected to carry a DCO `Signed-off-by:`
+  trailer.
+- **Only humans can legally certify the DCO; AI coding agents must not add
+  their own `Signed-off-by` trailer.** The human submitter is responsible for
+  reviewing AI-generated changes, ensuring license compliance, and taking
+  full responsibility for the contribution.
+- **AI agents must NOT invoke `git commit -s`.** `-s` appends a
+  `Signed-off-by:` trailer at the very end of the message and inserts a
+  blank line before it if other trailers are present, which separates the
+  human sign-off from the `Assisted-by:` line and reverses the required
+  order. Instead, write both trailers directly in the commit message body.
+  Derive the human identity from the active git configuration
+  (`git config user.name` and `git config user.email`) and format it as
+  `Signed-off-by: <Name> <email>`.
+- For changes produced with AI assistance, attribute the agent with an
+  `Assisted-by:` trailer in the form `Assisted-by: AgentName:ModelVersion`
+  (see the [Linux kernel AI Coding Assistants policy](https://docs.kernel.org/process/coding-assistants.html)).
+  Determine `AgentName` and `ModelVersion` at execution time from the active
+  agent name and model name (for example
+  `Assisted-by: OpenCode:claude-opus-4.7`).
+- **Trailer order and spacing**: a single blank line separates the subject
+  (and optional body) from the trailer block. Inside the trailer block,
+  place the human `Signed-off-by:` first and the `Assisted-by:` line
+  immediately after, with **no blank line between them**. Example:
+
+  ```
+  docs: reorganize agent guidance
+
+  Signed-off-by: Jane Doe <jane@example.com>
+  Assisted-by: OpenCode:claude-opus-4.7
+  ```
+- When using skip-CI commit messages, follow the repository convention and
+  place `[skip ci]` at the **beginning** of the subject line.
+
+## Pull request labels
+
+Every pull request **must** have two labels before it can be merged:
+
+- A `kind/*` label for the type of change: `kind/bug` (bug fix),
+  `kind/feature` (new feature), `kind/improvement` (refactor, chore, or minor
+  improvement), or `kind/documentation` (documentation change).
+- A `version/*` label for the target version (e.g. `version/1.0`,
+  `version/0.18`).
+
+Mergify enforces these via check runs. Always add both labels when creating
+a PR.
+
+## Documentation expectations
+
+Update relevant docs when behavior changes:
+
+- `README.md` for user-facing features or examples.
+- `DEVELOPMENT.md` for build or environment changes.
+- `CONTRIBUTING.md` for workflow or contribution policy changes.
+- Website docs under `docs/docs/{en,zh}/src/` together with any related
+  in-repo READMEs (`tools/eval/README.md`, `tools/eval/README_zh.md`, etc.).
+  Keep English and Chinese versions in sync.

--- a/docs/agents/docs-map.md
+++ b/docs/agents/docs-map.md
@@ -1,0 +1,110 @@
+<!-- agent-hints
+canonical: docs/agents/docs-map.md
+purpose: Map of VSAG markdown docs and where to look for what
+key-facts:
+  - Website source mirrors are docs/docs/{en,zh}/src/
+  - Top-level docs/*.md may overlap with website docs (being reconciled separately)
+  - Tool-level READMEs live alongside the tool under tools/<name>/
+related:
+  - https://vsag.io/docs
+  - ../../README.md
+last-reviewed: 2026-05-12
+-->
+
+# Documentation Map
+
+This page is a navigation aid for agents. Before making non-trivial changes,
+locate the right document below first.
+
+## Repository structure (high level)
+
+- `include/`: public headers (canonical for public APIs)
+- `src/`: core implementation and unit tests
+- `tests/`: functional tests
+- `examples/cpp/`, `examples/python/`, `examples/typescript/`: example programs
+- `python/`: `pyvsag` packaging and Python-side code
+- `python_bindings/`: pybind11 bindings
+- `docs/`: design and user-facing documentation (see below)
+- `tools/`: utility and analysis tools
+
+## Where docs live
+
+### Agent-facing rules
+
+- [`AGENTS.md`](../../AGENTS.md) — index + hard constraints (entry point).
+- [`docs/agents/`](.) — detailed agent operating docs (this directory).
+- [`.github/agent-prompts/`](../../.github/agent-prompts/) — shared agent
+  workflows (e.g. `/create-issue`).
+
+### User-facing project docs
+
+- [`README.md`](../../README.md) — landing page, performance highlights,
+  multi-language Quickstart.
+- [`DEVELOPMENT.md`](../../DEVELOPMENT.md) — developer onboarding.
+- [`CONTRIBUTING.md`](../../CONTRIBUTING.md) — contribution policy.
+- [`CODE_OF_CONDUCT.md`](../../CODE_OF_CONDUCT.md).
+
+### Website source (English & Chinese)
+
+The official documentation site at <https://vsag.io/docs> is rendered from:
+
+- `docs/docs/en/src/` — English source.
+- `docs/docs/zh/src/` — Chinese source (kept in a parallel directory so
+  Chinese pages share the website URL path structure).
+
+Common sub-areas (mirrored in both languages):
+
+- `guide/` — getting started (installation, knn search, pyvsag, create index).
+- `indexes/` — per-index user docs (`hgraph`, `ivf`, `sindi`, `pyramid`).
+- `advanced/` — advanced features (filtered search, range search, memory,
+  optimizer, serialization, attribute filter, extra info, etc.).
+- `development/` — building, testing, code structure, contributing.
+- `resources/` — index parameters, best practices, performance numbers,
+  dataset format, `eval_performance` guide, release notes, papers.
+
+### Top-level `docs/*.md`
+
+These files (`docs/hgraph.md`, `docs/ivf.md`, `docs/sindi.md`,
+`docs/brute_force.md`, `docs/dataset_format.md`, `docs/eval_performance.md`,
+`docs/get_memory_usage_en.md`) historically contained design notes that
+partially overlap with the website docs above. They are being reconciled in
+a separate track; treat the website docs (`docs/docs/{en,zh}/src/`) as the
+preferred source when content differs, and consult both if the topic
+requires deeper background.
+
+### Tool READMEs
+
+- [`tools/README.md`](../../tools/README.md)
+- [`tools/eval/README.md`](../../tools/eval/README.md) /
+  [`tools/eval/README_zh.md`](../../tools/eval/README_zh.md)
+- [`tools/analyze_index/README.md`](../../tools/analyze_index/README.md) /
+  [`tools/analyze_index/README_zh.md`](../../tools/analyze_index/README_zh.md)
+- [`tools/check_compatibility/README.md`](../../tools/check_compatibility/README.md) /
+  [`tools/check_compatibility/README_zh.md`](../../tools/check_compatibility/README_zh.md)
+- [`tools/issue-helper/README.md`](../../tools/issue-helper/README.md)
+- [`benchs/README.md`](../../benchs/README.md)
+- [`scripts/csv_extract/README.md`](../../scripts/csv_extract/README.md)
+
+Chinese versions use the `_zh.md` suffix convention here (kept as-is to
+preserve published URLs and user expectations).
+
+### Blog
+
+- `docs/blog/{en,zh}/src/` — long-form articles.
+
+## When to update which doc
+
+| Change | Update |
+| --- | --- |
+| New user-facing feature | `README.md`, relevant page under `docs/docs/{en,zh}/src/`. |
+| New build flag or dependency | `DEVELOPMENT.md`, `docs/agents/build-and-test.md`. |
+| Workflow / policy change | `CONTRIBUTING.md`, the matching file under `docs/agents/`. |
+| New index parameter | `docs/docs/{en,zh}/src/resources/index_parameters.md` and the per-index page. |
+| Behavior change in `eval_performance` | `tools/eval/README{,_zh}.md` and `docs/docs/{en,zh}/src/resources/eval.md`. |
+
+## Pending follow-ups
+
+- Long top-level design notes (`docs/hgraph.md`, `docs/sindi.md`, etc.,
+  >200 lines) should gain `<!-- agent-hints -->` blocks once the reconciliation
+  track decides whether to keep them; do not edit those files preemptively
+  here.

--- a/docs/agents/filing-issues.md
+++ b/docs/agents/filing-issues.md
@@ -1,0 +1,48 @@
+<!-- agent-hints
+canonical: .github/agent-prompts/create-issue.md
+purpose: Pointer to the canonical /create-issue workflow shared by all agents
+key-facts:
+  - Canonical workflow lives at .github/agent-prompts/create-issue.md
+  - Writing rules live at .github/ISSUE_TEMPLATE/ISSUE_GUIDE.md
+  - Issues do NOT carry Signed-off-by; only commits do
+related:
+  - ../../.github/agent-prompts/create-issue.md
+  - ../../.github/ISSUE_TEMPLATE/ISSUE_GUIDE.md
+  - ../../tools/issue-helper/README.md
+last-reviewed: 2026-05-12
+-->
+
+# Filing Issues With An Agent
+
+Agents are expected to help users file high-quality issues. The full
+step-by-step workflow is **not** duplicated here — it lives in a single
+canonical file shared across Claude Code, OpenCode, and Codex:
+
+> **Canonical workflow:** [`.github/agent-prompts/create-issue.md`](../../.github/agent-prompts/create-issue.md)
+>
+> **Writing rules / template guide:** [`.github/ISSUE_TEMPLATE/ISSUE_GUIDE.md`](../../.github/ISSUE_TEMPLATE/ISSUE_GUIDE.md)
+
+The per-agent slash-command wrappers point at the canonical file:
+
+- `.claude/commands/create-issue.md`
+- `.opencode/command/create-issue.md`
+- `.codex/prompts/create-issue.md`
+
+A shell wrapper is provided at [`tools/issue-helper/new-issue.sh`](../../tools/issue-helper/new-issue.sh)
+for users who prefer not to drive the agent's slash command directly.
+
+## Quick rules (must hold regardless of agent)
+
+- Map every required field of the chosen YAML template under
+  `.github/ISSUE_TEMPLATE/`. Use `// TODO` for genuinely unknown values.
+- Cite sources as `path:line` for repo references and full URLs for
+  `vsag.io/docs` pages.
+- Run
+  `gh issue list --repo antgroup/vsag --search ... --state all --limit 5`
+  and append the matches under a `## Related issues` section. Do not block
+  creation on duplicates; the maintainers will close as needed.
+- Append a footer of the form
+  `_Drafted with AI assistant: <AgentName>:<ModelVersion>_` for transparency.
+  **Do not** add `Signed-off-by:` to issues — DCO applies only to commits.
+- Show a dry-run preview and only call `gh issue create` after the user
+  confirms. On failure, fall back to `gh issue create --web`.

--- a/tools/eval/README.md
+++ b/tools/eval/README.md
@@ -1,3 +1,16 @@
+<!-- agent-hints
+canonical: tools/eval/README.md
+purpose: Usage guide for the eval_performance tool (build, run, datasets, metrics)
+key-facts:
+  - Binary built with ENABLE_TOOLS=ON; lives at build-release/tools/eval/eval_performance
+  - Consumes HDF5 datasets in the ann-benchmarks layout (see docs/dataset_format.md)
+  - Reports throughput, latency, and recall across indexes/params
+related:
+  - README_zh.md
+  - ../../docs/docs/en/src/resources/eval.md
+  - ../../docs/eval_performance.md
+last-reviewed: 2026-05-12
+-->
 # VSAG Performance Evaluation Tool
 
 [\[中文\]](README_zh.md)


### PR DESCRIPTION
## Summary
- Refactor `AGENTS.md` into a short entry point with hard constraints and a documentation index.
- Add `docs/agents/` topic-specific guidance for build/test, coding standards, contribution workflow, issue filing, and documentation mapping.
- Add agent hints to long markdown entry points and update the stale PR label policy link.

## Testing
- Not run; documentation-only change.

## Notes
- This commit was created without a DCO `Signed-off-by:` trailer because AI agents must not self-certify DCO in this repository. A human maintainer will need to sign off or recreate/amend the commit before merge.