### PR TITLE
feat: support Pyramid ExportModel

### DIFF
--- a/src/algorithm/pyramid.cpp
+++ b/src/algorithm/pyramid.cpp
@@ -460,6 +460,25 @@ Pyramid::Deserialize(StreamReader& reader) {
     this->current_memory_usage_ = static_cast<int64_t>(this->CalSerializeSize());
 }
 
+InnerIndexPtr
+Pyramid::ExportModel(const IndexCommonParam& param) const {
+    auto index = std::make_shared<Pyramid>(this->create_param_ptr_, param);
+    if (index->use_reorder_ != this->use_reorder_) {
+        throw VsagException(ErrorType::INTERNAL_ERROR,
+                            "Export model's pyramid reorder config mismatched");
+    }
+    this->base_codes_->ExportModel(index->base_codes_);
+    if (use_reorder_) {
+        if (index->precise_codes_ == nullptr) {
+            throw VsagException(ErrorType::INTERNAL_ERROR,
+                                "Export model's pyramid precise codes is empty");
+        }
+        this->precise_codes_->ExportModel(index->precise_codes_);
+    }
+    index->current_memory_usage_ = static_cast<int64_t>(index->CalSerializeSize());
+    return index;
+}
+
 std::vector<int64_t>
 Pyramid::Add(const DatasetPtr& base, AddMode mode) {
     const auto* path = base->GetPaths();
@@ -599,6 +618,7 @@ Pyramid::InitFeatures() {
     // other
     this->index_feature_list_->SetFeatures({
         IndexFeature::SUPPORT_CLONE,
+        IndexFeature::SUPPORT_EXPORT_MODEL,
         IndexFeature::SUPPORT_GET_MEMORY_USAGE,
     });
 }

--- a/src/algorithm/pyramid.h
+++ b/src/algorithm/pyramid.h
@@ -148,6 +148,9 @@ public:
     Deserialize(StreamReader& reader) override;
 
     [[nodiscard]] InnerIndexPtr
+    ExportModel(const IndexCommonParam& param) const override;
+
+    [[nodiscard]] InnerIndexPtr
     Fork(const IndexCommonParam& param) override {
         return std::make_shared<Pyramid>(this->create_param_ptr_, param);
     }

--- a/tests/test_pyramid.cpp
+++ b/tests/test_pyramid.cpp
@@ -170,6 +170,28 @@ RequireDistancesNearZero(const vsag::DatasetPtr& result, const std::set<int64_t>
     }
 }
 
+class BlockSizeLimitGuard {
+public:
+    explicit BlockSizeLimitGuard(uint64_t block_size_limit)
+        : origin_size_(vsag::Options::Instance().block_size_limit()) {
+        vsag::Options::Instance().set_block_size_limit(block_size_limit);
+    }
+
+    BlockSizeLimitGuard(const BlockSizeLimitGuard&) = delete;
+    BlockSizeLimitGuard&
+    operator=(const BlockSizeLimitGuard&) = delete;
+    BlockSizeLimitGuard(BlockSizeLimitGuard&&) = delete;
+    BlockSizeLimitGuard&
+    operator=(BlockSizeLimitGuard&&) = delete;
+
+    ~BlockSizeLimitGuard() {
+        vsag::Options::Instance().set_block_size_limit(origin_size_);
+    }
+
+private:
+    uint64_t origin_size_;
+};
+
 }  // namespace
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
@@ -498,6 +520,33 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex, "Pyramid Clone", "[ft][
         TestClone(index, dataset, search_param);
     }
     vsag::Options::Instance().set_block_size_limit(origin_size);
+}
+
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
+                             "Pyramid Export Model",
+                             "[ft][export][pyramid]") {
+    auto size = GENERATE(1024 * 1024 * 2);
+    BlockSizeLimitGuard block_size_limit_guard(size);
+    auto metric_type = GENERATE("l2");
+    auto use_reorder = GENERATE(true, false);
+    PyramidParam pyramid_param;
+    pyramid_param.no_build_levels = {0, 1, 2};
+    pyramid_param.use_reorder = use_reorder;
+    if (use_reorder) {
+        pyramid_param.base_quantization_type = "rabitq";
+        pyramid_param.precise_quantization_type = "fp32";
+    }
+    const std::string name = "pyramid";
+    auto search_param = GeneratePyramidSearchParametersString(100);
+    for (auto& dim : dims) {
+        INFO(fmt::format("metric_type={}, dim={}, use_reorder={}", metric_type, dim, use_reorder));
+        auto param = GeneratePyramidBuildParametersString(metric_type, dim, pyramid_param);
+        auto index = TestFactory(name, param, true);
+        auto index2 = TestFactory(name, param, true);
+        auto dataset = pool.GetDatasetAndCreate(dim, base_count, metric_type, /*with_path=*/true);
+        TestBuildIndex(index, dataset, true);
+        TestExportModel(index, index2, dataset, search_param);
+    }
 }
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,


### PR DESCRIPTION
## Summary
- Add `Pyramid::ExportModel()` to export an empty Pyramid index with trained code models copied from the source index.
- Advertise `SUPPORT_EXPORT_MODEL` for Pyramid.
- Add Pyramid export-model functional coverage for both reorder and non-reorder configurations.

## Tests
- `make debug VSAG_ENABLE_TESTS=ON VSAG_ENABLE_MOCKIMPL=ON COMPILE_JOBS=64`
- `./build/tests/functests -d yes "[ft][export][pyramid]" --allow-running-no-tests`

Fixes #1973