### PR TITLE
feat(python): add sparse HDF5 dataset helpers for pyvsag

### DIFF
--- a/docs/dataset_format.md
+++ b/docs/dataset_format.md
@@ -1,6 +1,32 @@
 # HDF5 Dataset Structure Documentation
 
-## Mandatory Datasets
+This document covers two on-disk variants used by the `eval_performance` tool:
+
+- **Dense vectors** (default; backwards-compatible with public datasets).
+- **Sparse vectors** (selected via the file-level `type` attribute).
+
+The variant is identified by the file-level `type` attribute (see
+[Vector type](#vector-type) below). When the attribute is absent, the
+file is interpreted as **dense** for compatibility with existing public
+benchmark datasets.
+
+---
+
+## Vector type
+
+### `type` (file-level attribute)
+- **Type**: String (ASCII), optional
+- **Values**:
+    - `"dense"` (or attribute missing): `/train` and `/test` are
+      `(N, D)` matrices, see [Dense layout](#dense-layout).
+    - `"sparse"`: `/train` and `/test` are one-dimensional byte streams,
+      see [Sparse layout](#sparse-layout).
+
+---
+
+## Dense layout
+
+### Mandatory Datasets
 
 ### `/train` (Training Data)
 - **Type**: `INT8` or `FLOAT32`
@@ -77,3 +103,73 @@
     - Row-major storage for all matrices
     - Feature vectors stored contiguously:
         - `/train` size = `N × D × data_size` (1 or 4 bytes/element)
+
+---
+
+## Sparse layout
+
+When the file-level `type` attribute equals `"sparse"`, the `/train` and
+`/test` datasets do **not** follow the `(N, D)` dense matrix layout.
+Instead they are stored as a one-dimensional `INT8` (`H5T_INTEGER` of
+size 1) dataset whose payload is a raw byte stream of packed sparse
+vectors. The `int8` storage class is a transport detail only; the bytes
+are not int8 vector elements.
+
+### `/train`, `/test` (sparse byte stream)
+- **HDF5 type**: `H5T_INTEGER`, size 1 (`INT8`)
+- **HDF5 shape**: 1-D, total length = sum of per-vector record sizes
+- **Endianness**: little-endian
+- **Content**: a contiguous sequence of records, one per sparse vector,
+  in order. Each record has the layout:
+
+  | Field      | Type        | Size            | Description                              |
+  |------------|-------------|-----------------|------------------------------------------|
+  | `len`      | `uint32`    | 4 bytes         | Number of non-zero entries in the vector |
+  | `ids[len]` | `uint32[]`  | `4 * len` bytes | Feature indices (column ids)             |
+  | `vals[len]`| `float32[]` | `4 * len` bytes | Values associated with `ids`             |
+
+  Records are concatenated back-to-back with no padding or separators.
+  A `len == 0` record is allowed and occupies only the 4-byte length
+  field.
+
+- **Key ordering**: on load, the eval tool sorts each vector's `ids` in
+  ascending order (and reorders `vals` accordingly). Writers may emit
+  unordered keys, but readers should not depend on that.
+
+### Distance metric
+
+- **`distance` attribute**: only `"ip"` (inner product) is supported by
+  the C++ eval tool for sparse datasets. The recorded ground-truth
+  distance is `1 - <q1, q2>`.
+
+### Ground truth
+
+`/neighbors` and `/distances` follow the same shape/type rules as in the
+[Dense layout](#dense-layout):
+
+- `/neighbors`: `INT64`, shape `(Q, K)`
+- `/distances`: `FLOAT32`, shape `(Q, K)`
+
+### Python helper
+
+The Python package `pyvsag` ships a decoder in `pyvsag.sparse`:
+
+```python
+from pyvsag.sparse import load_sparse_hdf5
+
+data = load_sparse_hdf5("sparse.hdf5")
+# data["type"]     -> "sparse"
+# data["distance"] -> "ip"
+# data["train"]    -> list[dict[int, float]]   one dict per sparse vector
+# data["test"]     -> list[dict[int, float]]
+# data["neighbors"], data["distances"] -> numpy arrays
+```
+
+Use `pyvsag.sparse.decode_sparse_bytes(buffer)` directly if you already
+have the raw bytes from another source.
+
+### Reference implementation
+
+The byte-stream encoder/decoder lives in C++ at
+`tools/eval/eval_dataset.cpp` (see `parse_sparse_vectors` and
+`serialize_sparse_vectors`).

--- a/docs/docs/en/src/resources/dataset_format.md
+++ b/docs/docs/en/src/resources/dataset_format.md
@@ -110,6 +110,65 @@ formulas below.
     - Feature vectors stored contiguously:
         - `/train` total size = `N × D × element_size` (1 or 4 bytes per element).
 
+## Sparse layout
+
+When the global attribute `type` equals `"sparse"`, `/train` and `/test` do **not** follow
+the `(N, D)` dense matrix layout. They are instead stored as one-dimensional `INT8`
+(`H5T_INTEGER`, size 1) datasets whose payload is a raw byte stream of packed sparse
+vectors. The `int8` storage class is a transport detail only; the bytes are not int8
+vector elements.
+
+### `/train`, `/test` (sparse byte stream)
+
+- **HDF5 type**: `H5T_INTEGER`, size 1 (`INT8`)
+- **HDF5 shape**: 1-D; total length equals the sum of per-vector record sizes
+- **Endianness**: little-endian
+- **Content**: a contiguous sequence of records, one per sparse vector, in order. Each
+  record has the following fields, concatenated with no padding or separators:
+
+  | Field        | Type        | Size            | Description                              |
+  |--------------|-------------|-----------------|------------------------------------------|
+  | `len`        | `uint32`    | 4 bytes         | Number of non-zero entries in the vector |
+  | `ids[len]`   | `uint32[]`  | `4 * len` bytes | Feature indices (column ids)             |
+  | `vals[len]`  | `float32[]` | `4 * len` bytes | Values associated with `ids`             |
+
+  A `len == 0` record is allowed and occupies only the 4-byte length field.
+
+- **Key ordering**: on load, the eval tool sorts each vector's `ids` in ascending order
+  (and reorders `vals` accordingly). Writers may emit unordered keys, but readers should
+  not rely on that.
+
+### Ground truth and metric
+
+`/neighbors` and `/distances` follow the same shape and type rules as in the dense
+layout above. Only `"ip"` (sparse inner-product distance, `1 - sparse_inner_product`)
+is supported via the `distance` attribute.
+
+### Python helper
+
+The Python package `pyvsag` ships a decoder in [`pyvsag.sparse`](https://github.com/antgroup/vsag/blob/main/python/pyvsag/sparse.py):
+
+```python
+from pyvsag.sparse import load_sparse_hdf5
+
+data = load_sparse_hdf5("sparse.hdf5")
+# data["type"]      -> "sparse"
+# data["distance"]  -> "ip"
+# data["train"]     -> list[dict[int, float]]   one dict per sparse vector, keys ascending
+# data["test"]      -> list[dict[int, float]]
+# data["neighbors"] -> numpy.ndarray  shape (Q, K) int64
+# data["distances"] -> numpy.ndarray  shape (Q, K) float32
+```
+
+`pyvsag.sparse.decode_sparse_bytes(buffer)` is also exposed for callers that already
+hold the raw byte stream.
+
+### Reference implementation
+
+The byte-stream encoder/decoder lives at
+[`tools/eval/eval_dataset.cpp`](https://github.com/antgroup/vsag/blob/main/tools/eval/eval_dataset.cpp)
+(see `parse_sparse_vectors` and `serialize_sparse_vectors`).
+
 ## References
 
 - Public benchmark datasets compatible with this layout are available from

--- a/docs/docs/zh/src/resources/dataset_format.md
+++ b/docs/docs/zh/src/resources/dataset_format.md
@@ -105,6 +105,61 @@ VSAG 的评测与基准工具（尤其是 [`eval_performance`](eval.md)）使用
     - 向量元素连续存放：
         - `/train` 总大小 = `N × D × element_size`（每元素 1 或 4 字节）。
 
+## Sparse 布局
+
+当全局属性 `type` 取值为 `"sparse"` 时，`/train` 与 `/test` **不再**遵循 `(N, D)` 的
+稠密矩阵布局，而是以 1 维 `INT8`（`H5T_INTEGER`，size 1）数据集存储原始字节流。
+此处的 `int8` 仅是传输形式，**字节本身并不是 int8 向量元素**。
+
+### `/train`、`/test`（稀疏字节流）
+
+- **HDF5 类型**：`H5T_INTEGER`，size 1（`INT8`）
+- **HDF5 形状**：1 维；总长度等于所有向量记录大小之和
+- **字节序**：小端（little-endian）
+- **内容**：按向量顺序首尾相接的记录序列，每条记录包含以下字段，紧密拼接，
+  无填充、无分隔符：
+
+  | 字段        | 类型        | 大小            | 说明                              |
+  |-------------|-------------|-----------------|-----------------------------------|
+  | `len`       | `uint32`    | 4 字节          | 该向量的非零项个数                |
+  | `ids[len]`  | `uint32[]`  | `4 * len` 字节  | 非零项的特征下标（column ids）    |
+  | `vals[len]` | `float32[]` | `4 * len` 字节  | 与 `ids` 对应的取值               |
+
+  允许 `len == 0` 的记录，此时仅占 4 字节的长度字段。
+
+- **键的顺序**：eval 工具在读取时会对每条向量按 `ids` 升序排序（`vals` 同步重排）。
+  写入侧可以输出无序键，但读取侧不应假设无序。
+
+### 真值与距离
+
+`/neighbors` 与 `/distances` 的形状与类型规则与上文稠密布局相同。`distance` 属性
+对稀疏向量仅支持 `"ip"`（稀疏内积距离，`1 - 稀疏内积`）。
+
+### Python 辅助函数
+
+Python 包 `pyvsag` 在 [`pyvsag.sparse`](https://github.com/antgroup/vsag/blob/main/python/pyvsag/sparse.py)
+中提供解码工具：
+
+```python
+from pyvsag.sparse import load_sparse_hdf5
+
+data = load_sparse_hdf5("sparse.hdf5")
+# data["type"]      -> "sparse"
+# data["distance"]  -> "ip"
+# data["train"]     -> list[dict[int, float]]   每条稀疏向量一个字典，键升序
+# data["test"]      -> list[dict[int, float]]
+# data["neighbors"] -> numpy.ndarray  shape (Q, K) int64
+# data["distances"] -> numpy.ndarray  shape (Q, K) float32
+```
+
+如果已经拿到原始字节流，可以直接调用 `pyvsag.sparse.decode_sparse_bytes(buffer)`。
+
+### 参考实现
+
+字节流的编码/解码逻辑位于
+[`tools/eval/eval_dataset.cpp`](https://github.com/antgroup/vsag/blob/main/tools/eval/eval_dataset.cpp)
+（参见 `parse_sparse_vectors` 与 `serialize_sparse_vectors`）。
+
 ## 参考
 
 - 与该格式兼容的公开基准数据集可在

--- a/python/pyvsag/sparse.py
+++ b/python/pyvsag/sparse.py
@@ -1,0 +1,224 @@
+# Copyright 2024-present the vsag project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Helpers for reading sparse-vector HDF5 datasets produced by the
+``eval_performance`` C++ tool.
+
+The eval tool stores sparse vectors in a custom layout that does **not**
+match the typical ``(N, D)`` HDF5 dense matrix layout. This module decodes
+that layout into Python-friendly structures.
+
+On-disk layout (see ``tools/eval/eval_dataset.cpp`` for the reference
+implementation):
+
+* File-level attribute ``type``:
+    - ``"dense"`` (or attribute missing, for compatibility with public
+      datasets): ``/train`` and ``/test`` are ``(N, D)`` matrices of
+      ``INT8`` or ``FLOAT32``.
+    - ``"sparse"``: ``/train`` and ``/test`` are one-dimensional
+      ``INT8`` (``H5T_INTEGER`` of size 1) datasets that hold a raw byte
+      stream. The stored ``int8`` dtype is a transport detail; the bytes
+      are actually a packed sequence of records:
+
+        ``uint32 len | uint32 ids[len] | float32 vals[len]``
+
+      concatenated back-to-back, one record per vector. ``len == 0`` is
+      allowed and occupies only the 4-byte length field.
+
+* File-level attribute ``distance``: for sparse datasets only ``"ip"`` is
+  supported by the C++ eval tool; the value here is returned as-is.
+
+The decoder verifies that the byte stream is fully consumed; a malformed
+file raises :class:`ValueError`.
+"""
+
+from __future__ import annotations
+
+import struct
+from typing import Any, Dict, List, Optional, Sequence
+
+import numpy as np
+
+__all__ = [
+    "load_sparse_hdf5",
+    "decode_sparse_bytes",
+]
+
+# Each record header is a single little-endian uint32 storing the number
+# of non-zero entries in the vector.
+_LEN_STRUCT = struct.Struct("<I")
+_LEN_SIZE = _LEN_STRUCT.size  # 4
+
+
+def decode_sparse_bytes(buffer: bytes) -> List[Dict[int, float]]:
+    """Decode a raw eval-format sparse byte stream into a list of dicts.
+
+    Args:
+        buffer: Bytes read from a sparse ``/train`` or ``/test`` dataset.
+
+    Returns:
+        A list where each element is ``{feature_index: value}`` for one
+        sparse vector. Keys are returned in ascending order (the eval
+        tool also stores them ordered after parsing).
+
+    Raises:
+        ValueError: If the byte stream is truncated or has trailing bytes
+            that cannot be parsed as a complete record.
+    """
+    view = memoryview(buffer)
+    total = len(view)
+    pos = 0
+    result: List[Dict[int, float]] = []
+
+    while pos < total:
+        if pos + _LEN_SIZE > total:
+            raise ValueError(
+                f"sparse stream truncated at offset {pos}: expected 4-byte length header"
+            )
+        (length,) = _LEN_STRUCT.unpack_from(view, pos)
+        pos += _LEN_SIZE
+
+        if length == 0:
+            result.append({})
+            continue
+
+        ids_size = length * 4
+        vals_size = length * 4
+        if pos + ids_size + vals_size > total:
+            raise ValueError(
+                f"sparse stream truncated at offset {pos}: "
+                f"expected {ids_size + vals_size} bytes for len={length}"
+            )
+
+        ids = np.frombuffer(view, dtype=np.uint32, count=length, offset=pos)
+        pos += ids_size
+        vals = np.frombuffer(view, dtype=np.float32, count=length, offset=pos)
+        pos += vals_size
+
+        # Build dict; sorting by key keeps the output stable regardless
+        # of input order (the C++ side also sorts on load).
+        is_sorted = length <= 1 or bool(np.all(ids[:-1] <= ids[1:]))
+        if is_sorted:
+            result.append({int(k): float(v) for k, v in zip(ids, vals)})
+        else:
+            order = np.argsort(ids, kind="stable")
+            result.append({int(ids[i]): float(vals[i]) for i in order})
+
+    return result
+
+
+def load_sparse_hdf5(
+    path: str,
+    splits: Sequence[str] = ("train", "test"),
+    *,
+    require_sparse: bool = True,
+) -> Dict[str, Any]:
+    """Load an eval-format HDF5 file containing sparse vectors.
+
+    Args:
+        path: Path to the ``.hdf5`` file produced by the eval tool.
+        splits: Which sparse splits to decode. Defaults to both
+            ``"train"`` and ``"test"``. Pass e.g. ``("test",)`` to skip
+            decoding the (usually much larger) base set.
+        require_sparse: If ``True`` (default), raise :class:`ValueError`
+            when the file is not marked as sparse. Set to ``False`` to
+            allow loading dense files (in which case the requested
+            ``splits`` are returned as numpy arrays instead of dict
+            lists).
+
+    Returns:
+        A dict with the following keys:
+
+        * ``"type"``: ``"sparse"`` or ``"dense"`` (the value of the file's
+          ``type`` attribute; ``"dense"`` is also returned when the
+          attribute is absent, for backwards compatibility).
+        * ``"distance"``: value of the ``distance`` attribute, or
+          ``None`` if missing.
+        * For each requested split (e.g. ``"train"``, ``"test"``): a
+          ``list[dict[int, float]]`` for sparse files, or a
+          ``numpy.ndarray`` for dense files (when
+          ``require_sparse=False``).
+        * ``"neighbors"``: ``numpy.ndarray`` of shape ``(Q, K)``,
+          ``int64``, if the dataset exists.
+        * ``"distances"``: ``numpy.ndarray`` of shape ``(Q, K)``,
+          ``float32``, if the dataset exists.
+
+    Raises:
+        ImportError: If ``h5py`` is not installed.
+        ValueError: If the file is not sparse and ``require_sparse`` is
+            ``True``, or if a sparse byte stream is malformed.
+
+    Example:
+        >>> from pyvsag.sparse import load_sparse_hdf5
+        >>> data = load_sparse_hdf5("sparse.hdf5")
+        >>> data["type"]
+        'sparse'
+        >>> data["train"][0]
+        {0: 1.0, 3: 2.0}
+    """
+    try:
+        import h5py
+    except ImportError as exc:  # pragma: no cover - import-time guard
+        raise ImportError(
+            "load_sparse_hdf5 requires the 'h5py' package; "
+            "install it with `pip install h5py`."
+        ) from exc
+
+    out: Dict[str, Any] = {}
+    with h5py.File(path, "r") as f:
+        # ``type`` attribute. Older public datasets omit it and are
+        # implicitly dense.
+        vec_type = _read_str_attr(f, "type")
+        if vec_type is None:
+            vec_type = "dense"
+        out["type"] = vec_type
+        out["distance"] = _read_str_attr(f, "distance")
+
+        if vec_type != "sparse" and require_sparse:
+            raise ValueError(
+                f"{path!r} is not a sparse dataset (type={vec_type!r}); "
+                "pass require_sparse=False to load dense files."
+            )
+
+        for split in splits:
+            if split not in f:
+                continue
+            dset = f[split]
+            if vec_type == "sparse":
+                # Sparse splits are 1-D INT8 byte streams.
+                raw = dset[()]
+                if isinstance(raw, np.ndarray):
+                    buf = raw.tobytes()
+                else:  # pragma: no cover - defensive
+                    buf = bytes(raw)
+                out[split] = decode_sparse_bytes(buf)
+            else:
+                out[split] = dset[()]
+
+        for name in ("neighbors", "distances"):
+            if name in f:
+                out[name] = f[name][()]
+
+    return out
+
+
+def _read_str_attr(h5obj, name: str) -> Optional[str]:
+    """Read a string attribute, handling both ``bytes`` and ``str`` h5py
+    return types."""
+    if name not in h5obj.attrs:
+        return None
+    value = h5obj.attrs[name]
+    if isinstance(value, bytes):
+        return value.decode("utf-8")
+    return str(value)

--- a/python/pyvsag/sparse.py
+++ b/python/pyvsag/sparse.py
@@ -65,10 +65,11 @@ def decode_sparse_bytes(buffer: Any) -> List[Dict[int, float]]:
     """Decode a raw eval-format sparse byte stream into a list of dicts.
 
     Args:
-        buffer: Any object that supports the buffer protocol (``bytes``,
-            ``bytearray``, ``memoryview``, or a 1-D ``numpy.ndarray`` of
-            ``int8`` / ``uint8``). The buffer is wrapped in a
-            ``memoryview`` and read without copying.
+        buffer: Any object that supports the buffer protocol and exposes
+            a contiguous byte view (``bytes``, ``bytearray``,
+            ``memoryview``, or a contiguous 1-D ``numpy.ndarray``). The
+            buffer is reinterpreted as raw bytes via
+            ``memoryview(...).cast("B")`` and read without copying.
 
     Returns:
         A list where each element is ``{feature_index: value}`` for one
@@ -77,10 +78,21 @@ def decode_sparse_bytes(buffer: Any) -> List[Dict[int, float]]:
 
     Raises:
         ValueError: If the byte stream is truncated or has trailing bytes
-            that cannot be parsed as a complete record.
+            that cannot be parsed as a complete record, or if ``buffer``
+            cannot be cast to a contiguous byte view.
     """
-    view = memoryview(buffer)
-    total = len(view)
+    try:
+        # Force a byte-granular view: for ndarrays / typed memoryviews
+        # whose ``itemsize`` is > 1, ``len(view)`` would otherwise be an
+        # element count rather than a byte count, which would mis-parse
+        # the stream.
+        view = memoryview(buffer).cast("B")
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            "decode_sparse_bytes requires a contiguous byte buffer "
+            "(bytes, bytearray, or a contiguous int8/uint8 ndarray)"
+        ) from exc
+    total = view.nbytes
     pos = 0
     result: List[Dict[int, float]] = []
 
@@ -207,9 +219,10 @@ def load_sparse_hdf5(
                 continue
             dset = f[split]
             if vec_type == "sparse":
-                # Sparse splits are 1-D INT8 byte streams. Pass the
-                # ndarray straight through; decode_sparse_bytes wraps it
-                # in a memoryview and reads it without copying.
+                # Sparse splits are 1-D INT8 byte streams. ``dset[()]``
+                # materializes the dataset as a numpy ndarray (one copy
+                # out of HDF5); decode_sparse_bytes then reinterprets
+                # that buffer as bytes without an additional copy.
                 out[split] = decode_sparse_bytes(dset[()])
             else:
                 out[split] = dset[()]

--- a/python/pyvsag/sparse.py
+++ b/python/pyvsag/sparse.py
@@ -104,9 +104,12 @@ def decode_sparse_bytes(buffer: Any) -> List[Dict[int, float]]:
                 f"expected {ids_size + vals_size} bytes for len={length}"
             )
 
-        ids = np.frombuffer(view, dtype=np.uint32, count=length, offset=pos)
+        # Use explicit little-endian dtypes so the decode is correct on
+        # big-endian hosts (``np.uint32`` / ``np.float32`` are native-
+        # endian, while the on-disk layout is always little-endian).
+        ids = np.frombuffer(view, dtype="<u4", count=length, offset=pos)
         pos += ids_size
-        vals = np.frombuffer(view, dtype=np.float32, count=length, offset=pos)
+        vals = np.frombuffer(view, dtype="<f4", count=length, offset=pos)
         pos += vals_size
 
         # Build dict; sorting by key keeps the output stable regardless
@@ -185,6 +188,11 @@ def load_sparse_hdf5(
         vec_type = _read_str_attr(f, "type")
         if vec_type is None:
             vec_type = "dense"
+        elif vec_type not in ("dense", "sparse"):
+            raise ValueError(
+                f"{path!r} has unknown type attribute {vec_type!r}; "
+                "expected 'dense' or 'sparse'."
+            )
         out["type"] = vec_type
         out["distance"] = _read_str_attr(f, "distance")
 
@@ -214,15 +222,22 @@ def load_sparse_hdf5(
 
 
 def _read_str_attr(h5obj, name: str) -> Optional[str]:
-    """Read a string attribute, handling both Python ``str`` and any
-    bytes-like value (``bytes``, ``numpy.bytes_``) that h5py may return
-    depending on the on-disk string type."""
+    """Read a string attribute, normalizing the various forms h5py may
+    return (``str``, ``bytes``, ``numpy.bytes_``, ``numpy.str_``, 0-d
+    arrays, or 1-element arrays) into a plain Python ``str``."""
     if name not in h5obj.attrs:
         return None
     value = h5obj.attrs[name]
-    # ``hasattr('decode')`` catches both ``bytes`` and ``numpy.bytes_``
-    # (the latter is a ``bytes`` subclass on numpy 2.x but not on 1.x),
-    # while plain ``str`` / ``numpy.str_`` falls through to ``str(value)``.
-    if hasattr(value, "decode"):
+    # Unwrap 0-d / single-element numpy arrays first; ``.item()`` yields
+    # a Python ``str`` or ``bytes`` (numpy scalars also support it).
+    if isinstance(value, np.ndarray):
+        if value.size != 1:
+            raise ValueError(
+                f"attribute {name!r} is not a scalar string (shape={value.shape})"
+            )
+        value = value.item()
+    elif isinstance(value, np.generic):
+        value = value.item()
+    if isinstance(value, bytes):
         return value.decode("utf-8")
     return str(value)

--- a/python/pyvsag/sparse.py
+++ b/python/pyvsag/sparse.py
@@ -61,11 +61,14 @@ _LEN_STRUCT = struct.Struct("<I")
 _LEN_SIZE = _LEN_STRUCT.size  # 4
 
 
-def decode_sparse_bytes(buffer: bytes) -> List[Dict[int, float]]:
+def decode_sparse_bytes(buffer: Any) -> List[Dict[int, float]]:
     """Decode a raw eval-format sparse byte stream into a list of dicts.
 
     Args:
-        buffer: Bytes read from a sparse ``/train`` or ``/test`` dataset.
+        buffer: Any object that supports the buffer protocol (``bytes``,
+            ``bytearray``, ``memoryview``, or a 1-D ``numpy.ndarray`` of
+            ``int8`` / ``uint8``). The buffer is wrapped in a
+            ``memoryview`` and read without copying.
 
     Returns:
         A list where each element is ``{feature_index: value}`` for one
@@ -196,13 +199,10 @@ def load_sparse_hdf5(
                 continue
             dset = f[split]
             if vec_type == "sparse":
-                # Sparse splits are 1-D INT8 byte streams.
-                raw = dset[()]
-                if isinstance(raw, np.ndarray):
-                    buf = raw.tobytes()
-                else:  # pragma: no cover - defensive
-                    buf = bytes(raw)
-                out[split] = decode_sparse_bytes(buf)
+                # Sparse splits are 1-D INT8 byte streams. Pass the
+                # ndarray straight through; decode_sparse_bytes wraps it
+                # in a memoryview and reads it without copying.
+                out[split] = decode_sparse_bytes(dset[()])
             else:
                 out[split] = dset[()]
 
@@ -214,11 +214,15 @@ def load_sparse_hdf5(
 
 
 def _read_str_attr(h5obj, name: str) -> Optional[str]:
-    """Read a string attribute, handling both ``bytes`` and ``str`` h5py
-    return types."""
+    """Read a string attribute, handling both Python ``str`` and any
+    bytes-like value (``bytes``, ``numpy.bytes_``) that h5py may return
+    depending on the on-disk string type."""
     if name not in h5obj.attrs:
         return None
     value = h5obj.attrs[name]
-    if isinstance(value, bytes):
+    # ``hasattr('decode')`` catches both ``bytes`` and ``numpy.bytes_``
+    # (the latter is a ``bytes`` subclass on numpy 2.x but not on 1.x),
+    # while plain ``str`` / ``numpy.str_`` falls through to ``str(value)``.
+    if hasattr(value, "decode"):
         return value.decode("utf-8")
     return str(value)


### PR DESCRIPTION
## Summary

- Add `pyvsag.sparse` with `load_sparse_hdf5` and `decode_sparse_bytes` so Python users can read the `eval_performance` tool's sparse-vector HDF5 layout without re-deriving the byte format.
- Decode the packed `(uint32 len, uint32 ids[len], float32 vals[len])` records into `list[dict[int, float]]`, and surface the file-level `type` / `distance` attributes plus `neighbors` / `distances` ground truth as numpy arrays.
- Document the sparse on-disk layout in `docs/dataset_format.md` (new "Sparse layout" section) and reorganize the existing content under an explicit "Dense layout" heading.

## Why

The eval tool stores sparse vectors as a 1-D `INT8` HDF5 dataset whose bytes are actually a packed record stream — not int8 vector elements. Today there is no helper on the Python side, so users have to read `tools/eval/eval_dataset.cpp` to figure out how to load these files. This change closes that gap and aligns the docs with the C++ reference implementation.

## API

```python
from pyvsag.sparse import load_sparse_hdf5

data = load_sparse_hdf5("sparse.hdf5")
# data["type"]      -> "sparse"
# data["distance"]  -> "ip"
# data["train"]     -> list[dict[int, float]]   one dict per sparse vector, keys ascending
# data["test"]      -> list[dict[int, float]]
# data["neighbors"] -> numpy.ndarray  shape (Q, K) int64
# data["distances"] -> numpy.ndarray  shape (Q, K) float32
```

`decode_sparse_bytes(buffer)` is also exposed for callers that already have the raw byte stream.

`h5py` is imported lazily inside `load_sparse_hdf5` with a friendly error message, so importing `pyvsag.sparse` does not pull in a new hard dependency.

## Testing

- Local smoke test in a temp venv (`numpy`, `h5py`): round-trips a hand-crafted sparse HDF5 file matching the C++ `serialize_sparse_vectors` byte layout, verifies key ordering (incl. unordered input), `splits` filtering, `require_sparse=True` rejection of dense files, and three classes of malformed byte streams (truncated header, truncated body, trailing bytes). All assertions pass.

## Docs

- `docs/dataset_format.md`: introduce a "Vector type" section, group the existing fields under "Dense layout", and add a "Sparse layout" section covering the byte-stream record format, key-ordering convention, supported `ip` distance, the new Python helper, and a pointer to the C++ reference in `tools/eval/eval_dataset.cpp`.