### PR TITLE
ci: skip coverage workflow for markdown-only pushes

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,13 +3,33 @@ name: Coverage
 on:
   push:
     branches: [ "main", "0.*" ]
-    paths-ignore:
-      - 'docs/**'
   workflow_dispatch:
 
 jobs:
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      non_markdown: ${{ steps.changes.outputs.non_markdown }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          # 'every' is REQUIRED here: with the default 'some' quantifier, the broad '**'
+          # pattern would always match and the negation patterns ('!docs/**', '!**/*.md')
+          # would have no effect, causing docs-only pushes to incorrectly trigger Coverage.
+          predicate-quantifier: 'every'
+          filters: |
+            non_markdown:
+              - '**'
+              - '!docs/**'
+              - '!**/*.md'
+
   coverage:
     name: Test Coverage
+    needs: changes
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.non_markdown == 'true'
     runs-on: ubuntu-latest
     concurrency:
       group: coverage-${{ github.event.pull_request.number || github.sha }}


### PR DESCRIPTION
## Summary

- The current `paths-ignore: docs/**` in `.github/workflows/coverage.yml` only filters the `docs/` directory. Markdown files elsewhere in the repo (top-level `*.md`, `tools/**/README*.md`, etc.) still trigger the coverage job on pushes to `main` / `0.*`, which is wasted CI for doc-only changes.
- Replace it with the same `dorny/paths-filter@v3` pattern already used by `.github/workflows/tsan_build_and_test.yml`: a `changes` job computes a `non_markdown` output using `predicate-quantifier: 'every'` with `'**'`, `'!docs/**'`, `'!**/*.md'`. The `coverage` job runs only when `non_markdown == 'true'` (or when triggered manually via `workflow_dispatch`).

## Behavior

- Push containing only markdown changes (anywhere in the tree) -> coverage skipped.
- Push touching any non-markdown / non-`docs/` file -> coverage runs as before.
- `workflow_dispatch` -> always runs.

## Notes

- `predicate-quantifier: 'every'` is required so the negation patterns actually take effect (matches the existing comment in `tsan_build_and_test.yml`).