### PR TITLE
ci: require linked issue for kind/bug and kind/feature PRs

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -126,7 +126,9 @@ merge_protections:
     # refuses to merge `kind/feature` / `kind/bug` PRs whose description
     # does not reference an issue via a GitHub auto-closing keyword.
     if:
-      - base=main
+      - or:
+          - base=main
+          - base~=^0\.
       - or:
           - label=kind/feature
           - label=kind/bug

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -119,5 +119,19 @@ merge_protections:
       - base=main
     success_conditions:
       - label~=^version/
+
+  - name: Require linked issue for feature/bug PRs
+    # Defense-in-depth fallback for the `PR Issue Link Check` GitHub
+    # Action. If the Action is ever disabled or skipped, Mergify still
+    # refuses to merge `kind/feature` / `kind/bug` PRs whose description
+    # does not reference an issue via a GitHub auto-closing keyword.
+    if:
+      - base=main
+      - or:
+          - label=kind/feature
+          - label=kind/bug
+    success_conditions:
+      - >-
+        body~=(?im)(?:^|[\s\-\*])(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?\s+(?:#\d+|[\w.\-]+/[\w.\-]+#\d+|https?://github\.com/[\w.\-]+/[\w.\-]+/issues/\d+)
 merge_protections_settings:
   reporting_method: check-runs

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,20 @@
 
 ## Linked Issue
 
-- Issue: <!-- e.g. #1234 -->
+<!--
+REQUIRED for `kind/bug` and `kind/feature` PRs. Use a GitHub-recognized
+auto-closing keyword so the linked issue is closed when this PR merges:
+
+  Fixes: #1234
+  Closes: #1234
+  Resolves: #1234
+
+Cross-repo references (`owner/repo#1234`) and full issue URLs are also
+accepted. `kind/improvement` and `kind/documentation` PRs may leave this
+blank (delete the line below or keep it empty).
+-->
+
+- Fixes: <!-- #1234 -->
 
 ## What Changed
 
@@ -54,7 +67,7 @@ Test details:
 
 ## Checklist
 
-- [ ] I have linked the relevant issue (or explained why not applicable)
+- [ ] I have linked the relevant issue (required for `kind/bug` and `kind/feature`; see "Linked Issue" above)
 - [ ] I have added/updated tests for new behavior or bug fixes
 - [ ] I have considered API compatibility impact
 - [ ] I have updated docs if behavior/workflow changed

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,16 +12,16 @@
 REQUIRED for `kind/bug` and `kind/feature` PRs. Use a GitHub-recognized
 auto-closing keyword so the linked issue is closed when this PR merges:
 
-  Fixes: #1234
-  Closes: #1234
-  Resolves: #1234
+  Fixes: #<number>
+  Closes: #<number>
+  Resolves: #<number>
 
-Cross-repo references (`owner/repo#1234`) and full issue URLs are also
-accepted. `kind/improvement` and `kind/documentation` PRs may leave this
-blank (delete the line below or keep it empty).
+Cross-repo references (`owner/repo#<number>`) and full issue URLs are
+also accepted. `kind/improvement` and `kind/documentation` PRs may leave
+this blank (delete the line below or keep it empty).
 -->
 
-- Fixes: <!-- #1234 -->
+- Fixes: <!-- #<number> -->
 
 ## What Changed
 

--- a/.github/workflows/pr-issue-link.yml
+++ b/.github/workflows/pr-issue-link.yml
@@ -1,0 +1,99 @@
+name: PR Issue Link Check
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize, labeled, unlabeled]
+    branches:
+      - main
+      - "0.*"
+
+permissions:
+  pull-requests: read
+
+concurrency:
+  group: pr-issue-link-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  check-issue-link:
+    name: Require linked issue for feature/bug PRs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR description references an issue
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import re
+          import sys
+
+          body = os.environ.get("PR_BODY") or ""
+          try:
+              labels = json.loads(os.environ.get("PR_LABELS") or "[]")
+          except json.JSONDecodeError:
+              labels = []
+
+          requires_link = any(label in ("kind/feature", "kind/bug") for label in labels)
+
+          if not requires_link:
+              # kind/improvement, kind/documentation, or no kind/* yet
+              # (the latter is already blocked by the existing
+              # "Require kind label" Mergify protection, so we don't
+              # need to fail here too).
+              print(
+                  "PR is not labeled `kind/feature` or `kind/bug`; "
+                  "issue link is optional. Skipping check."
+              )
+              sys.exit(0)
+
+          # Accept GitHub auto-closing keywords (close/closes/closed,
+          # fix/fixes/fixed, resolve/resolves/resolved), case-insensitive,
+          # optionally followed by a colon, then a reference to either:
+          #   - #1234
+          #   - owner/repo#1234
+          #   - https://github.com/owner/repo/issues/1234
+          pattern = re.compile(
+              r"(?im)"
+              r"(?:^|[\s\-\*])"
+              r"(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)"
+              r"\s*:?\s+"
+              r"(?:"
+              r"#\d+"
+              r"|[\w.\-]+/[\w.\-]+#\d+"
+              r"|https?://github\.com/[\w.\-]+/[\w.\-]+/issues/\d+"
+              r")"
+          )
+
+          # Strip HTML comments so the placeholder in the PR template
+          # (e.g. "<!-- e.g. #1234 -->") does not count as a real link.
+          body_no_comments = re.sub(r"<!--.*?-->", "", body, flags=re.DOTALL)
+
+          match = pattern.search(body_no_comments)
+          if match:
+              print(
+                  "Found linked issue reference: "
+                  f"`{match.group(0).strip()}`. Check passed."
+              )
+              sys.exit(0)
+
+          print("::error::PR is labeled `kind/feature` or `kind/bug` but the "
+                "description does not link an issue.")
+          print("")
+          print("Please edit the PR description to include one of the "
+                "following (GitHub-recognized auto-closing keywords):")
+          print("")
+          print("    Fixes: #1234")
+          print("    Closes: #1234")
+          print("    Resolves: #1234")
+          print("")
+          print("Cross-repo references (`owner/repo#1234`) and full issue "
+                "URLs are also accepted.")
+          print("")
+          print("See .github/pull_request_template.md and CONTRIBUTING.md "
+                "for details.")
+          sys.exit(1)
+          PY

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,11 @@ Node.js/TypeScript bindings provided by `vsag`.
 - **Pull requests need two labels:** one `kind/*` (`kind/bug`,
   `kind/feature`, `kind/improvement`, `kind/documentation`) and one
   `version/*` (e.g. `version/1.0`). Mergify enforces both.
+- **`kind/bug` / `kind/feature` PRs must link an issue** in the
+  description using a GitHub auto-closing keyword (`Fixes: #N`,
+  `Closes: #N`, `Resolves: #N`; cross-repo or full issue URL also OK).
+  `kind/improvement` and `kind/documentation` PRs are exempt. Enforced
+  by the `PR Issue Link Check` Action and a Mergify protection.
 - **Issues do NOT carry `Signed-off-by:`** — DCO only applies to commits.
 
 ## Quick Command Reference

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,6 +149,31 @@ Every pull request **must** have the following two labels before it can be merge
 
 Mergify enforces these labels via check runs. The PR merge will be blocked until both labels are present.
 
+## Linking an Issue
+
+PRs labeled **`kind/bug`** or **`kind/feature`** must reference an existing
+issue in the PR description using a GitHub-recognized auto-closing keyword,
+so the issue closes automatically when the PR merges:
+
+```text
+Fixes: #1234
+Closes: #1234
+Resolves: #1234
+```
+
+Cross-repo references (`owner/repo#1234`) and full issue URLs are also
+accepted. PRs labeled `kind/improvement` or `kind/documentation` are
+exempt from this requirement.
+
+This rule is enforced by:
+
+1.  The `PR Issue Link Check` GitHub Action (a required status check on
+    `main` and `0.*` branches), and
+2.  A Mergify `merge_protections` rule as a defense-in-depth fallback.
+
+If the check fails, edit the PR description to add the required keyword
+and the check will re-run automatically.
+
 ## Commit message and skip CI
 
 -   Follow Conventional Commits in the subject line, such as `feat:`, `fix:`, `docs:`, or `chore:`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,8 +167,10 @@ exempt from this requirement.
 
 This rule is enforced by:
 
-1.  The `PR Issue Link Check` GitHub Action (a required status check on
-    `main` and `0.*` branches), and
+1.  The `PR Issue Link Check` GitHub Action, which runs on every PR
+    targeting `main` or `0.*` branches. Repo administrators are expected
+    to add it to the **required status checks** for those branches so
+    that a failed check actually blocks merge.
 2.  A Mergify `merge_protections` rule as a defense-in-depth fallback.
 
 If the check fails, edit the PR description to add the required keyword

--- a/docs/agents/contribution-workflow.md
+++ b/docs/agents/contribution-workflow.md
@@ -96,7 +96,9 @@ reference.
 Enforcement happens in two places:
 
 1. The `PR Issue Link Check` GitHub Action runs on every PR open / edit /
-   sync and is a required status check on `main` and `0.*` branches.
+   sync targeting `main` or `0.*` branches. Repo administrators are
+   expected to add it to the **required status checks** on those
+   branches so a failed check actually blocks merge.
 2. A Mergify `merge_protections` rule (`Require linked issue for
    feature/bug PRs`) blocks merge as a defense-in-depth fallback.
 

--- a/docs/agents/contribution-workflow.md
+++ b/docs/agents/contribution-workflow.md
@@ -6,6 +6,7 @@ key-facts:
   - AI agents: do NOT use `git commit -s` (it appends Signed-off-by last, with a blank line before it). Write both trailers manually in the commit body, deriving the human Signed-off-by from `git config user.name`/`user.email`
   - Trailer order: Signed-off-by first, Assisted-by immediately after, no blank line between them
   - Every PR needs both a kind/* and a version/* label
+  - PRs labeled kind/bug or kind/feature must link an issue with Fixes:/Closes:/Resolves: #N (or owner/repo#N / issue URL)
 related:
   - ../../CONTRIBUTING.md
   - ../../.github/pull_request_template.md
@@ -70,6 +71,34 @@ Every pull request **must** have two labels before it can be merged:
 
 Mergify enforces these via check runs. Always add both labels when creating
 a PR.
+
+## Linking an issue
+
+PRs labeled `kind/bug` or `kind/feature` **must** reference an existing
+issue in the PR description using a GitHub-recognized auto-closing keyword
+(`close[sd]?`, `fix(e[sd])?`, `resolve[sd]?`, case-insensitive, optionally
+with a colon), followed by `#N`, `owner/repo#N`, or a full issue URL.
+Examples:
+
+```text
+Fixes: #1234
+Closes #1234
+Resolves: antgroup/vsag#999
+Closes: https://github.com/antgroup/vsag/issues/100
+```
+
+`kind/improvement` and `kind/documentation` PRs are exempt — link an issue
+only if it helps reviewers. The placeholder line in
+`.github/pull_request_template.md` lives inside an HTML comment and does
+**not** satisfy the rule on its own; you must replace it with a real
+reference.
+
+Enforcement happens in two places:
+
+1. The `PR Issue Link Check` GitHub Action runs on every PR open / edit /
+   sync and is a required status check on `main` and `0.*` branches.
+2. A Mergify `merge_protections` rule (`Require linked issue for
+   feature/bug PRs`) blocks merge as a defense-in-depth fallback.
 
 ## Documentation expectations
 


### PR DESCRIPTION
## Change Type

- [x] CI/Build/Infra

## Linked Issue

<!-- This PR is kind/improvement; an issue link is not required. -->

N/A — this PR is a workflow/infra improvement and is labeled `kind/improvement`. Per the rule introduced in this PR, only `kind/bug` and `kind/feature` PRs need a linked issue.

## What Changed

- Add a new GitHub Action `.github/workflows/pr-issue-link.yml` (`PR Issue Link Check`) that fails when a PR labeled `kind/feature` or `kind/bug` does not reference an issue in its description using a GitHub auto-closing keyword (`Fixes: #N` / `Closes: #N` / `Resolves: #N`; cross-repo `owner/repo#N` and full issue URLs are also accepted).
- Add a `Require linked issue for feature/bug PRs` entry to `.github/mergify.yml` as a defense-in-depth fallback so Mergify also refuses the merge if the Action is somehow bypassed.
- Update `.github/pull_request_template.md` so the rule is visible to authors before they open the PR.
- Update `CONTRIBUTING.md`, `AGENTS.md`, and `docs/agents/contribution-workflow.md` to document the requirement for both humans and AI agents.

`kind/improvement` and `kind/documentation` PRs are **exempt** — they may still link an issue, but it is not required.

## Test Evidence

YAML files parse successfully and the issue-link regex was validated locally against representative PR bodies (placeholder in PR template, valid `Fixes: #N`, cross-repo, URL, comment-only, PR-reference, etc.). End-to-end shell simulation reproduces the exact Action logic and all expected cases pass:

```text
feature_no_link        : rc=1 expected=1 PASS
feature_with_fixes     : rc=0 expected=0 PASS
bug_no_link            : rc=1 expected=1 PASS
bug_closes_url         : rc=0 expected=0 PASS
improvement_no_link    : rc=0 expected=0 PASS
documentation_no_link  : rc=0 expected=0 PASS
no_kind_label          : rc=0 expected=0 PASS
feature_only_in_comment: rc=1 expected=1 PASS
```

Once this PR runs in CI, the `PR Issue Link Check` workflow will exercise itself against this very PR (which carries `kind/improvement`) and should pass.

## Compatibility Impact

- API/ABI compatibility: none
- Behavior changes: starting from when this PR merges, future PRs labeled `kind/bug` or `kind/feature` must include an issue link in the description or CI will fail. Existing open PRs are unaffected until they are updated/rebased.

## Performance and Concurrency Impact

- Performance impact: none (small Python check, runs on `ubuntu-latest`)
- Concurrency/thread-safety impact: none

## Documentation Impact

- [x] Updated docs:
  - [x] `CONTRIBUTING.md`
  - [x] `AGENTS.md`
  - [x] `docs/agents/contribution-workflow.md`
  - [x] `.github/pull_request_template.md`

## Risk and Rollback

- Risk level: low — additive workflow + one extra Mergify protection. No existing rules removed.
- Rollback plan: revert this commit. The new Action and Mergify protection disappear, behavior returns to current state.

## Follow-up (after merge)

- Repo admin: add the `PR Issue Link Check` job to **required status checks** on `main` and `0.*` branches so the check actually blocks merges.
- Part 2 (Mergify per-`kind/*` auto-merge) will be proposed in a separate PR; see the planning docs.

## Checklist

- [x] I have linked the relevant issue (N/A — `kind/improvement`)
- [x] I have added/updated tests for new behavior or bug fixes (regex validated locally; the Action runs on every PR)
- [x] I have considered API compatibility impact
- [x] I have updated docs
- [x] My commit messages follow project conventions (Conventional Commits, DCO sign-off, `Assisted-by` trailer)