### PR TITLE
fix: avoid OOM in release packaging

### DIFF
--- a/docs/docs/en/src/development/building.md
+++ b/docs/docs/en/src/development/building.md
@@ -96,3 +96,21 @@ make dist-libcxx          # libc++ (Clang)
 ```
 
 The produced tarballs contain headers, static/shared libraries, and version metadata.
+
+## Release Publishing
+
+To publish a new GitHub Release, use the `Build and Publish Release` workflow in the GitHub
+Actions tab and run it manually with:
+
+- `branch`: the branch, tag, or commit SHA to release from
+- `tag_name`: the new release tag, such as `v1.0.0`
+- `prerelease`: whether to mark the release as a prerelease
+
+For a local dry run of the same packaging script, run:
+
+```bash
+COMPILE_JOBS=6 bash ./scripts/release/dist.sh
+```
+
+You can increase `COMPILE_JOBS` if your machine has enough memory, but the default is conservative
+to avoid out-of-memory failures in CI runners.

--- a/docs/docs/zh/src/development/building.md
+++ b/docs/docs/zh/src/development/building.md
@@ -138,3 +138,19 @@ make pyvsag-all
 - `VSAG_ENABLE_INTEL_MKL`：是否启用 Intel MKL 作为 BLAS 后端，默认 `OFF`；关闭时使用 OpenBLAS；
 - `VSAG_ENABLE_LIBAIO`：是否启用 `libaio`，默认 `ON`。
 
+## 发布流程
+
+如果要在 GitHub 上手动发布 Release，请到 GitHub Actions 页面运行 `Build and Publish Release` 工作流，并填写以下参数：
+
+- `branch`：要发布的分支、tag 或 commit SHA
+- `tag_name`：新的发布标签，例如 `v1.0.0`
+- `prerelease`：是否标记为预发布版本
+
+如果你想在本地手动执行同样的打包流程，可以运行：
+
+```bash
+COMPILE_JOBS=6 bash ./scripts/release/dist.sh
+```
+
+如果机器内存足够，可以适当调大 `COMPILE_JOBS`；默认值会比较保守，以避免 CI 里再次触发
+内存不足。

--- a/scripts/release/dist.sh
+++ b/scripts/release/dist.sh
@@ -10,12 +10,17 @@ build() {
     local dockerfile=$2
     local makefile_target=$3
     local dist_name_suffix=$4
+    local compile_jobs=${COMPILE_JOBS:-6}
+
+    if ! [[ "$compile_jobs" =~ ^[0-9]+$ ]]; then
+        compile_jobs=6
+    fi
 
     docker build -t $image_name -f $dockerfile .
 
     docker run -u $CURRENT_UID:$CURRENT_GID --rm -v $(pwd):/work $image_name \
            bash -c "\
-           export COMPILE_JOBS=48 && \
+           export COMPILE_JOBS=\"$compile_jobs\" && \
            export CMAKE_INSTALL_PREFIX=/tmp/vsag && \
            make clean-release && make $makefile_target && make run-dist-tests && make install && \
            mkdir -p ./dist && \
@@ -43,7 +48,7 @@ build "vsag-builder-cxx11" \
 # libcxx version
 # docker run -u $CURRENT_UID:$CURRENT_GID --rm -v $(pwd):/work vsag-builder \
 #        bash -c "\
-#        export COMPILE_JOBS=48 && \
+#        export COMPILE_JOBS=6 && \
 #        export CMAKE_INSTALL_PREFIX=/tmp/vsag && \
 #        make clean-release && make dist-libcxx && make install && \
 #        mkdir -p ./dist && \


### PR DESCRIPTION
## Summary
- Lower the default release packaging parallelism in `scripts/release/dist.sh` from 48 to a conservative default, with `COMPILE_JOBS` now configurable.
- Add English and Chinese build docs for manual GitHub Actions release publishing and local packaging.
- Keep the release workflow behavior unchanged except for the safer packaging default.

## Verification
- `bash -n scripts/release/dist.sh`
- `git diff --check -- scripts/release/dist.sh docs/docs/en/src/development/building.md docs/docs/zh/src/development/building.md`