### PR TITLE
fix: normalize missing CalcDistanceById results

### DIFF
--- a/src/algorithm/ivf.cpp
+++ b/src/algorithm/ivf.cpp
@@ -1054,15 +1054,17 @@ IVF::CalDistanceById(const float* query,
 
 float
 IVF::CalcDistanceById(const float* query, int64_t id, bool calculate_precise_distance) const {
+    auto [success, inner_id] = this->label_table_->TryGetIdByLabel(id);
+    if (not success) {
+        return -1.0F;
+    }
     if (this->use_reorder_ && calculate_precise_distance) {
         float dist = 0.0F;
         auto computer = this->reorder_codes_->FactoryComputer(query);
-        auto inner_id = this->label_table_->GetIdByLabel(id);
         this->reorder_codes_->Query(&dist, computer, &inner_id, 1);
         return dist;
     }
     auto computer = this->bucket_->FactoryComputer(query);
-    auto inner_id = this->label_table_->GetIdByLabel(id);
     auto location = this->get_location(inner_id);
     return this->bucket_->QueryOneById(computer, location.first, location.second);
 }

--- a/src/algorithm/ivf.cpp
+++ b/src/algorithm/ivf.cpp
@@ -1054,6 +1054,7 @@ IVF::CalDistanceById(const float* query,
 
 float
 IVF::CalcDistanceById(const float* query, int64_t id, bool calculate_precise_distance) const {
+    std::shared_lock<std::shared_mutex> lock(this->label_lookup_mutex_);
     auto [success, inner_id] = this->label_table_->TryGetIdByLabel(id);
     if (not success) {
         return -1.0F;

--- a/src/algorithm/sparse_index.cpp
+++ b/src/algorithm/sparse_index.cpp
@@ -237,7 +237,10 @@ SparseIndex::CalcDistanceById(const DatasetPtr& vector,
                               int64_t id,
                               bool calculate_precise_distance) const {
     const auto* sparse_vectors = vector->GetSparseVectors();
-    uint32_t inner_id = this->label_table_->GetIdByLabel(id);
+    auto [success, inner_id] = this->label_table_->TryGetIdByLabel(id);
+    if (not success) {
+        return -1.0F;
+    }
     auto [sorted_ids, sorted_vals] = sort_sparse_vector(sparse_vectors[0]);
     return CalDistanceByIdUnsafe(sorted_ids, sorted_vals, inner_id);
 }

--- a/tests/test_index.cpp
+++ b/tests/test_index.cpp
@@ -61,6 +61,17 @@ get_one_query(const vsag::DatasetPtr& queries, int i) {
     return query;
 }
 
+int64_t
+get_missing_id(const vsag::DatasetPtr& base) {
+    std::unordered_set<int64_t> existing_ids(base->GetIds(),
+                                             base->GetIds() + base->GetNumElements());
+    int64_t missing_id = 0;
+    while (existing_ids.count(missing_id) != 0) {
+        ++missing_id;
+    }
+    return missing_id;
+}
+
 void
 TestIndex::TestBuildIndex(const IndexPtr& index,
                           const TestDatasetPtr& dataset,

--- a/tests/test_index.h
+++ b/tests/test_index.h
@@ -35,6 +35,9 @@
 #include "vsag/vsag.h"
 
 namespace fixtures {
+vsag::DatasetPtr
+get_one_query(const vsag::DatasetPtr& queries, int i);
+
 class TestIndex {
 public:
     using IndexPtr = vsag::IndexPtr;

--- a/tests/test_index.h
+++ b/tests/test_index.h
@@ -38,6 +38,9 @@ namespace fixtures {
 vsag::DatasetPtr
 get_one_query(const vsag::DatasetPtr& queries, int i);
 
+int64_t
+get_missing_id(const vsag::DatasetPtr& base);
+
 class TestIndex {
 public:
     using IndexPtr = vsag::IndexPtr;

--- a/tests/test_ivf.cpp
+++ b/tests/test_ivf.cpp
@@ -293,6 +293,17 @@ IVFTestIndex::TestGeneral(const TestIndex::IndexPtr& index,
 
 namespace {
 
+int64_t
+GetMissingId(const vsag::DatasetPtr& base) {
+    std::unordered_set<int64_t> existing_ids(base->GetIds(),
+                                             base->GetIds() + base->GetNumElements());
+    int64_t missing_id = 0;
+    while (existing_ids.count(missing_id) != 0) {
+        ++missing_id;
+    }
+    return missing_id;
+}
+
 template <typename Fn>
 void
 RunWithGeneratedBlockSizeLimit(Fn&& fn) {
@@ -596,6 +607,36 @@ TestIVFBuild(const fixtures::IVFResourcePtr& resource) {
 }
 
 IVF_PR_DAILY_CASE("IVF Build", "[ft][build][ivf]", TestIVFBuild)
+
+static void
+TestIVFCalcDistanceByIdMissingId(const fixtures::IVFResourcePtr& resource) {
+    using namespace fixtures;
+    const auto base_count = resource->base_count;
+    ForEachIVFCase(
+        resource,
+        resource->test_cases,
+        [base_count](const auto& metric_type,
+                     auto dim,
+                     const auto& train_type,
+                     const auto& base_quantization_str,
+                     auto recall) {
+            const auto build_param = IVFTestIndex::GenerateIVFBuildParametersString(
+                metric_type, dim, base_quantization_str, 210, train_type);
+            auto index = TestIndex::TestFactory(IVFTestIndex::name, build_param, true);
+            auto dataset = IVFTestIndex::pool.GetDatasetAndCreate(dim, base_count, metric_type);
+            TestIndex::TestBuildIndex(index, dataset, true);
+
+            auto query = get_one_query(dataset->query_, 0);
+            const auto missing_id = GetMissingId(dataset->base_);
+            auto distance = index->CalcDistanceById(query->GetFloat32Vectors(), missing_id);
+
+            REQUIRE(distance.has_value());
+            REQUIRE(distance.value() == -1.0F);
+        });
+}
+IVF_PR_DAILY_CASE("IVF CalcDistanceById missing id returns -1",
+                  "[ft][distance][ivf]",
+                  TestIVFCalcDistanceByIdMissingId)
 
 static void
 TestIVFSearchOvertime(const fixtures::IVFResourcePtr& resource) {

--- a/tests/test_ivf.cpp
+++ b/tests/test_ivf.cpp
@@ -291,19 +291,6 @@ IVFTestIndex::TestGeneral(const TestIndex::IndexPtr& index,
 }
 }  // namespace fixtures
 
-namespace {
-
-int64_t
-GetMissingId(const vsag::DatasetPtr& base) {
-    std::unordered_set<int64_t> existing_ids(base->GetIds(),
-                                             base->GetIds() + base->GetNumElements());
-    int64_t missing_id = 0;
-    while (existing_ids.count(missing_id) != 0) {
-        ++missing_id;
-    }
-    return missing_id;
-}
-
 template <typename Fn>
 void
 RunWithGeneratedBlockSizeLimit(Fn&& fn) {
@@ -370,8 +357,6 @@ ForEachIVFCase(const fixtures::IVFResourcePtr& resource, const Cases& test_cases
         auto resource = fixtures::IVFTestIndex::GetResource(false); \
         helper(resource);                                           \
     }
-
-}  // namespace
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::IVFTestIndex,
                              "IVF Factory Test With Exceptions",
@@ -627,7 +612,7 @@ TestIVFCalcDistanceByIdMissingId(const fixtures::IVFResourcePtr& resource) {
             TestIndex::TestBuildIndex(index, dataset, true);
 
             auto query = get_one_query(dataset->query_, 0);
-            const auto missing_id = GetMissingId(dataset->base_);
+            const auto missing_id = fixtures::get_missing_id(dataset->base_);
             auto distance = index->CalcDistanceById(query->GetFloat32Vectors(), missing_id);
 
             REQUIRE(distance.has_value());

--- a/tests/test_sparse_index.cpp
+++ b/tests/test_sparse_index.cpp
@@ -44,21 +44,6 @@ TestDatasetPool SparseTestIndex::pool{};
 
 }  // namespace fixtures
 
-namespace {
-
-int64_t
-GetMissingId(const vsag::DatasetPtr& base) {
-    std::unordered_set<int64_t> existing_ids(base->GetIds(),
-                                             base->GetIds() + base->GetNumElements());
-    int64_t missing_id = 0;
-    while (existing_ids.count(missing_id) != 0) {
-        ++missing_id;
-    }
-    return missing_id;
-}
-
-}  // namespace
-
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::SparseTestIndex,
                              "SparseIndex Build and Search",
                              "[ft][build][search][sparse_index]") {
@@ -83,7 +68,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::SparseTestIndex,
     TestBuildIndex(index, dataset, true);
 
     auto query = fixtures::get_one_query(dataset->query_, 0);
-    const auto missing_id = GetMissingId(dataset->base_);
+    const auto missing_id = fixtures::get_missing_id(dataset->base_);
     auto distance = index->CalcDistanceById(query, missing_id);
 
     REQUIRE(distance.has_value());

--- a/tests/test_sparse_index.cpp
+++ b/tests/test_sparse_index.cpp
@@ -44,6 +44,21 @@ TestDatasetPool SparseTestIndex::pool{};
 
 }  // namespace fixtures
 
+namespace {
+
+int64_t
+GetMissingId(const vsag::DatasetPtr& base) {
+    std::unordered_set<int64_t> existing_ids(base->GetIds(),
+                                             base->GetIds() + base->GetNumElements());
+    int64_t missing_id = 0;
+    while (existing_ids.count(missing_id) != 0) {
+        ++missing_id;
+    }
+    return missing_id;
+}
+
+}  // namespace
+
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::SparseTestIndex,
                              "SparseIndex Build and Search",
                              "[ft][build][search][sparse_index]") {
@@ -58,6 +73,21 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::SparseTestIndex,
     TestFilterSearch(index, dataset, search_param, 0.99, true);
     TestCalcDistanceById(index, dataset, 1e-4, true, true);
     TestBatchCalcDistanceById(index, dataset, 1e-4, true, true);
+}
+
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::SparseTestIndex,
+                             "SparseIndex returns -1 for missing id",
+                             "[ft][distance][sparse_index]") {
+    auto index = TestFactory("sparse_index", build_param, true);
+    auto dataset = pool.GetSparseDatasetAndCreate(base_count, 128, 0.8);
+    TestBuildIndex(index, dataset, true);
+
+    auto query = fixtures::get_one_query(dataset->query_, 0);
+    const auto missing_id = GetMissingId(dataset->base_);
+    auto distance = index->CalcDistanceById(query, missing_id);
+
+    REQUIRE(distance.has_value());
+    REQUIRE(distance.value() == -1.0F);
 }
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::SparseTestIndex,


### PR DESCRIPTION
## Summary
- return -1 instead of throwing when IVF::CalcDistanceById or SparseIndex::CalcDistanceById is called with a missing label
- add functional coverage for missing-ID lookups in IVF and SparseIndex
- expose the shared get_one_query test helper through test_index.h for the new coverage

## Linked issue
- Closes #2045

## Testing
- make fmt
- make test CASE='[ft][distance][sparse_index],[ft][distance][ivf]'