### PR TITLE
feat: add HGraph duplicate distance threshold

### DIFF
--- a/docs/docs/en/src/indexes/hgraph.md
+++ b/docs/docs/en/src/indexes/hgraph.md
@@ -74,6 +74,7 @@ and `docs/hgraph.md` in the repository.
 | `base_pq_dim` | int | `1` | Number of PQ subspaces. When using `pq` / `pqfs`, set this explicitly instead of relying on the default. |
 | `build_thread_count` | int | `100` | Threads used to parallelise build |
 | `support_duplicate` | bool | `false` | Enable duplicate-ID detection on insert |
+| `duplicate_distance_threshold` | float | `0.0` | Duplicate-detection distance threshold. When greater than `0`, deduplicate by the nearest candidate distance; when `0`, fall back to the current code `memcmp` check |
 | `support_remove` | bool | `false` | Enable `Remove()` on the built index |
 | `store_raw_vector` | bool | `false` | Keep the raw vector in addition to the quantized copy (useful for `cosine`) |
 | `use_elp_optimizer` | bool | `false` | Auto-tune search parameters after build |

--- a/docs/docs/zh/src/indexes/hgraph.md
+++ b/docs/docs/zh/src/indexes/hgraph.md
@@ -67,6 +67,7 @@ auto result = index->KnnSearch(
 | `base_pq_dim` | int | `1` | PQ 子空间数（`pq` / `pqfs` 时必填） |
 | `build_thread_count` | int | `100` | 构建阶段并发线程数 |
 | `support_duplicate` | bool | `false` | 是否在插入时做重复 ID 检测 |
+| `duplicate_distance_threshold` | float | `0.0` | 重复判定距离阈值。大于 `0` 时按最近候选的距离判重；等于 `0` 时退化为当前编码 `memcmp` 判重 |
 | `support_remove` | bool | `false` | 是否支持 `Remove()` |
 | `store_raw_vector` | bool | `false` | 除量化副本外再保留原始向量（`cosine` 场景有用） |
 | `use_elp_optimizer` | bool | `false` | 构建完成后自动调优检索参数 |

--- a/include/vsag/constants.h
+++ b/include/vsag/constants.h
@@ -199,6 +199,7 @@ extern const char* const HGRAPH_PARAMETER_HOPS_LIMIT;
 extern const char* const HGRAPH_PARAMETER_RABITQ_ONE_BIT_SEARCH;
 extern const char* const HGRAPH_EXTRA_INFO_SIZE;
 extern const char* const HGRAPH_SUPPORT_DUPLICATE;
+extern const char* const HGRAPH_DUPLICATE_DISTANCE_THRESHOLD;
 extern const char* const HGRAPH_SUPPORT_TOMBSTONE;
 extern const char* const HGRAPH_LABEL_REMAP_TYPE;
 extern const char* const HGRAPH_USE_EXTRA_INFO_FILTER;

--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -97,6 +97,7 @@ HGraph::HGraph(const HGraphParameterPtr& hgraph_param, const vsag::IndexCommonPa
       reorder_by_base_(hgraph_param->reorder_source == HGRAPH_REORDER_SOURCE_BASE),
       ef_construct_(hgraph_param->ef_construction),
       alpha_(hgraph_param->alpha),
+      duplicate_distance_threshold_(hgraph_param->duplicate_distance_threshold),
       odescent_param_(hgraph_param->odescent_param),
       graph_type_(hgraph_param->graph_type),
       hierarchical_datacell_param_(hgraph_param->hierarchical_graph_param),
@@ -492,6 +493,12 @@ HGraph::map_hgraph_param(const JsonType& hgraph_json) {
             },
         },
         {
+            HGRAPH_DUPLICATE_DISTANCE_THRESHOLD,
+            {
+                DUPLICATE_DISTANCE_THRESHOLD,
+            },
+        },
+        {
             HGRAPH_SUPPORT_DUPLICATE,
             {
                 GRAPH_KEY,
@@ -596,6 +603,7 @@ HGraph::map_hgraph_param(const JsonType& hgraph_json) {
             "{ATTR_HAS_BUCKETS_KEY}": false
         },
         "{HGRAPH_SUPPORT_DUPLICATE}": false,
+        "{HGRAPH_DUPLICATE_DISTANCE_THRESHOLD}": 0.0,
         "{HGRAPH_SUPPORT_TOMBSTONE}": false,
         "{EF_CONSTRUCTION_KEY}": 400
     })";
@@ -1876,6 +1884,7 @@ HGraph::graph_add_one(const void* data, int level, InnerIdType inner_id) {
     param.topk = static_cast<int64_t>(ef_construct_);
     if (this->support_duplicate_) {
         param.find_duplicate = true;
+        param.duplicate_distance_threshold = this->duplicate_distance_threshold_;
     }
 
     if (bottom_graph_->TotalCount() != 0) {

--- a/src/algorithm/hgraph.h
+++ b/src/algorithm/hgraph.h
@@ -431,5 +431,6 @@ private:
     bool use_old_serial_format_{false};
 
     bool support_duplicate_{false};
+    float duplicate_distance_threshold_{0.0F};
 };
 }  // namespace vsag

--- a/src/algorithm/hgraph_parameter.cpp
+++ b/src/algorithm/hgraph_parameter.cpp
@@ -125,6 +125,9 @@ HGraphParameter::FromJson(const JsonType& json) {
             this->bottom_graph_param->support_duplicate_ = this->support_duplicate;
         }
     }
+    if (json.Contains(DUPLICATE_DISTANCE_THRESHOLD)) {
+        this->duplicate_distance_threshold = json[DUPLICATE_DISTANCE_THRESHOLD].GetFloat();
+    }
     if (json.Contains(SUPPORT_TOMBSTONE)) {
         this->support_tombstone = json[SUPPORT_TOMBSTONE].GetBool();
     }
@@ -143,6 +146,7 @@ HGraphParameter::ToJson() const {
     json[EF_CONSTRUCTION_KEY].SetInt(this->ef_construction);
     json[ALPHA_KEY].SetFloat(this->alpha);
     json[SUPPORT_DUPLICATE].SetBool(this->support_duplicate);
+    json[DUPLICATE_DISTANCE_THRESHOLD].SetFloat(this->duplicate_distance_threshold);
     json[TRAIN_SAMPLE_COUNT_KEY].SetInt(this->train_sample_count);
     return json;
 }
@@ -187,6 +191,11 @@ HGraphParameter::CheckCompatibility(const ParamPtr& other) const {
     }
     if (support_duplicate != hgraph_param->support_duplicate) {
         logger::error("HGraphParameter::CheckCompatibility: support_duplicate must be the same");
+        return false;
+    }
+    if (duplicate_distance_threshold != hgraph_param->duplicate_distance_threshold) {
+        logger::error(
+            "HGraphParameter::CheckCompatibility: duplicate_distance_threshold must be the same");
         return false;
     }
     return true;

--- a/src/algorithm/hgraph_parameter.h
+++ b/src/algorithm/hgraph_parameter.h
@@ -63,6 +63,7 @@ public:
     float alpha{1.0F};
 
     bool support_duplicate{false};
+    float duplicate_distance_threshold{0.0F};
     bool support_tombstone{false};
 
     DataTypes data_type{DataTypes::DATA_TYPE_FLOAT};

--- a/src/algorithm/hgraph_parameter_test.cpp
+++ b/src/algorithm/hgraph_parameter_test.cpp
@@ -54,6 +54,7 @@ struct HGraphDefaultParam {
     int remove_flag_bit = 8;
     bool use_attribute_filter = false;
     bool support_duplicate = false;
+    float duplicate_distance_threshold = 0.0F;
     bool use_reorder = true;
 };
 
@@ -108,7 +109,8 @@ generate_hgraph_param(const HGraphDefaultParam& param) {
         "type": "hgraph",
         "use_attribute_filter": {},
         "use_reorder": {},
-        "support_duplicate": {}
+        "support_duplicate": {},
+        "duplicate_distance_threshold": {}
     }})";
 
     return fmt::format(param_str,
@@ -123,7 +125,8 @@ generate_hgraph_param(const HGraphDefaultParam& param) {
                        param.precise_codes_quantization_type,
                        param.use_attribute_filter,
                        param.use_reorder,
-                       param.support_duplicate);
+                       param.support_duplicate,
+                       param.duplicate_distance_threshold);
 }
 
 // clang-format off
@@ -163,6 +166,11 @@ TEST_CASE("HGraph Parameters CheckCompatibility", "[ut][HGraphParameter][CheckCo
     TEST_COMPATIBILITY_CASE(
         "different use attribute filter", use_attribute_filter, true, false, false)
     TEST_COMPATIBILITY_CASE("different support duplicate", support_duplicate, true, false, false)
+    TEST_COMPATIBILITY_CASE("different duplicate distance threshold",
+                            duplicate_distance_threshold,
+                            0.0F,
+                            0.1F,
+                            false)
 }
 // clang-format on
 
@@ -178,6 +186,7 @@ TEST_CASE("HGraph maps support_duplicate to graph parameter", "[ut][HGraphParame
         "max_degree": 32,
         "ef_construction": 100,
         "support_duplicate": true,
+        "duplicate_distance_threshold": 0.25,
         "use_reorder": true
     })");
 
@@ -189,6 +198,7 @@ TEST_CASE("HGraph maps support_duplicate to graph parameter", "[ut][HGraphParame
 
     REQUIRE(typed_param != nullptr);
     REQUIRE(typed_param->support_duplicate);
+    REQUIRE(typed_param->duplicate_distance_threshold == 0.25F);
     REQUIRE(typed_param->bottom_graph_param->support_duplicate_);
 }
 

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -179,6 +179,7 @@ const char* const HGRAPH_PARAMETER_HOPS_LIMIT = "hops_limit";
 const char* const HGRAPH_PARAMETER_RABITQ_ONE_BIT_SEARCH = "rabitq_one_bit_search";
 const char* const HGRAPH_EXTRA_INFO_SIZE = "extra_info_size";
 const char* const HGRAPH_SUPPORT_DUPLICATE = "support_duplicate";
+const char* const HGRAPH_DUPLICATE_DISTANCE_THRESHOLD = "duplicate_distance_threshold";
 const char* const HGRAPH_SUPPORT_TOMBSTONE = "support_tomb_stone";
 const char* const HGRAPH_LABEL_REMAP_TYPE = "label_remap_type";
 const char* const HGRAPH_USE_EXTRA_INFO_FILTER = "use_extra_info_filter";

--- a/src/impl/inner_search_param.h
+++ b/src/impl/inner_search_param.h
@@ -60,6 +60,7 @@ public:
     // deal with duplicate ids
     mutable int64_t duplicate_id{-1};
     bool find_duplicate{false};
+    float duplicate_distance_threshold{0.0F};
 
     // use in search process with duplicate ids
     bool consider_duplicate{false};

--- a/src/impl/searcher/basic_searcher.cpp
+++ b/src/impl/searcher/basic_searcher.cpp
@@ -17,6 +17,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <cstring>
 #include <limits>
 
 #include "algorithm/inner_index_interface.h"
@@ -514,7 +515,7 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
     }
 
     // set duplicate id for query vector
-    if (inner_search_param.find_duplicate) {
+    if (inner_search_param.find_duplicate and not top_candidates->Empty()) {
         const auto* data = top_candidates->GetData();
         auto min_distance = data[0].first;
         auto min_index = data[0].second;
@@ -524,15 +525,21 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
                 min_index = data[i].second;
             }
         }
-        bool need_release;
-        const auto* codes = flatten->GetCodesById(min_index, need_release);
-        Vector<uint8_t> encoded_query(flatten->code_size_, allocator_);
-        flatten->Encode(static_cast<const float*>(query), encoded_query.data());
-        if (std::memcmp(codes, encoded_query.data(), flatten->code_size_) == 0) {
-            inner_search_param.duplicate_id = min_index;
-        }
-        if (need_release) {
-            flatten->Release(codes);
+        if (inner_search_param.duplicate_distance_threshold > 0.0F) {
+            if (min_distance <= inner_search_param.duplicate_distance_threshold) {
+                inner_search_param.duplicate_id = min_index;
+            }
+        } else {
+            bool need_release;
+            const auto* codes = flatten->GetCodesById(min_index, need_release);
+            Vector<uint8_t> encoded_query(flatten->code_size_, allocator_);
+            flatten->Encode(static_cast<const float*>(query), encoded_query.data());
+            if (std::memcmp(codes, encoded_query.data(), flatten->code_size_) == 0) {
+                inner_search_param.duplicate_id = min_index;
+            }
+            if (need_release) {
+                flatten->Release(codes);
+            }
         }
     }
 

--- a/src/impl/searcher/basic_searcher_test.cpp
+++ b/src/impl/searcher/basic_searcher_test.cpp
@@ -15,6 +15,8 @@
 
 #include "basic_searcher.h"
 
+#include <vector>
+
 #include "algorithm/inner_index_interface.h"
 #include "datacell/flatten_interface.h"
 #include "searcher_test.h"
@@ -321,4 +323,62 @@ TEST_CASE("Optimize SQ4", "[ut][BasicOptimizer]") {
     optimizer_searcher->RegisterParameter(RuntimeParameter(PREFETCH_STRIDE_VISIT, 1, 3, 1));
     float end2end_improvement = optimizer_searcher->Optimize(searcher);
     auto loss_after = searcher->MockRun(stats);
+}
+
+TEST_CASE("BasicSearcher duplicate threshold keeps nearest owner",
+          "[ut][BasicSearcher][duplicate]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    IndexCommonParam common;
+    common.dim_ = 2;
+    common.allocator_ = allocator;
+    common.metric_ = vsag::MetricType::METRIC_TYPE_L2SQR;
+
+    constexpr const char* param_temp = R"({{"type": "{}"}})";
+    auto quantizer_param = QuantizerParameter::GetQuantizerParameterByJson(
+        JsonType::Parse(fmt::format(param_temp, "fp32")));
+    auto io_param =
+        IOParameter::GetIOParameterByJson(JsonType::Parse(fmt::format(param_temp, "memory_io")));
+
+    auto vector_data_cell = std::make_shared<
+        FlattenDataCell<FP32Quantizer<vsag::MetricType::METRIC_TYPE_L2SQR>, MemoryIO>>(
+        quantizer_param, io_param, common);
+    vector_data_cell->SetQuantizer(
+        std::make_shared<FP32Quantizer<vsag::MetricType::METRIC_TYPE_L2SQR>>(2, allocator.get()));
+    vector_data_cell->SetIO(std::make_unique<MemoryIO>(allocator.get()));
+
+    std::vector<float> base_vectors = {0.0F, 0.0F, 0.3F, 0.0F};
+    std::vector<InnerIdType> ids = {0, 1};
+    vector_data_cell->Train(base_vectors.data(), ids.size());
+    vector_data_cell->BatchInsertVector(base_vectors.data(), ids.size(), ids.data());
+
+    auto graph_data_cell =
+        std::make_shared<MockGraphDataCell>(std::vector<std::vector<InnerIdType>>{{1}, {0}});
+    auto pool = std::make_shared<VisitedListPool>(
+        1, allocator.get(), vector_data_cell->TotalCount(), allocator.get());
+    auto searcher = std::make_shared<BasicSearcher>(common);
+
+    auto run_search = [&](const std::vector<float>& query, float threshold) {
+        InnerSearchParam search_param;
+        search_param.ep = 0;
+        search_param.ef = 2;
+        search_param.topk = 2;
+        search_param.find_duplicate = true;
+        search_param.duplicate_distance_threshold = threshold;
+        auto vl = pool->TakeOne();
+        QueryContext* ctx = nullptr;
+        auto result = searcher->Search(graph_data_cell,
+                                       vector_data_cell,
+                                       vl,
+                                       query.data(),
+                                       search_param,
+                                       LabelTablePtr{},
+                                       ctx);
+        REQUIRE(result->Size() == 2);
+        pool->ReturnOne(vl);
+        return search_param.duplicate_id;
+    };
+
+    REQUIRE(run_search({0.12F, 0.0F}, 0.01F) == -1);
+    REQUIRE(run_search({0.12F, 0.0F}, 0.02F) == 0);
+    REQUIRE(run_search({0.3F, 0.0F}, 0.0F) == 1);
 }

--- a/src/impl/searcher/searcher_test.h
+++ b/src/impl/searcher/searcher_test.h
@@ -15,8 +15,10 @@
 
 #pragma once
 
+#include <algorithm>
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
+#include <utility>
 
 #include "algorithm/hnswlib/hnswalg.h"
 #include "algorithm/hnswlib/space_l2.h"
@@ -31,6 +33,57 @@
 #include "utils/visited_list.h"
 
 namespace vsag {
+
+class MockGraphDataCell : public GraphInterface {
+public:
+    explicit MockGraphDataCell(std::vector<std::vector<InnerIdType>> neighbors)
+        : neighbors_(std::move(neighbors)) {
+        total_count_ = static_cast<InnerIdType>(neighbors_.size());
+        max_capacity_ = static_cast<InnerIdType>(neighbors_.size());
+        maximum_degree_ = 0;
+        for (const auto& ids : neighbors_) {
+            maximum_degree_ = std::max<uint32_t>(maximum_degree_, ids.size());
+        }
+    }
+
+    void
+    InsertNeighborsById(InnerIdType id, const Vector<InnerIdType>& neighbor_ids) override {
+        neighbors_[id].assign(neighbor_ids.begin(), neighbor_ids.end());
+        maximum_degree_ = std::max<uint32_t>(maximum_degree_, neighbor_ids.size());
+    }
+
+    void
+    Resize(InnerIdType new_size) override {
+        neighbors_.resize(new_size);
+        total_count_ = new_size;
+        max_capacity_ = new_size;
+    }
+
+    void
+    GetNeighbors(InnerIdType id, Vector<InnerIdType>& neighbor_ids) const override {
+        neighbor_ids.assign(neighbors_[id].begin(), neighbors_[id].end());
+    }
+
+    uint32_t
+    GetNeighborSize(InnerIdType id) const override {
+        return static_cast<uint32_t>(neighbors_[id].size());
+    }
+
+    [[nodiscard]] bool
+    CheckIdExists(InnerIdType id) const override {
+        return id >= 0 and id < static_cast<InnerIdType>(neighbors_.size());
+    }
+
+    void
+    Prefetch(InnerIdType id, uint32_t neighbor_i) override {
+        if (neighbor_i < neighbors_[id].size()) {
+            vsag::Prefetch(neighbors_[id].data() + neighbor_i);
+        }
+    }
+
+private:
+    std::vector<std::vector<InnerIdType>> neighbors_;
+};
 
 class AdaptGraphDataCell : public GraphInterface {
 public:

--- a/src/inner_string_params.h
+++ b/src/inner_string_params.h
@@ -167,6 +167,7 @@ const char* const GRAPH_SUPPORT_REMOVE = "support_remove";
 const char* const REMOVE_FLAG_BIT = "remove_flag_bit";
 const char* const HOLD_MOLDS = "hold_molds";
 const char* const SUPPORT_DUPLICATE = "support_duplicate";
+const char* const DUPLICATE_DISTANCE_THRESHOLD = "duplicate_distance_threshold";
 const char* const SUPPORT_TOMBSTONE = "support_tombstone";
 const char* const SUPPORT_AUTOTUNE = "support_autotune";
 
@@ -200,6 +201,7 @@ const std::unordered_map<std::string, std::string> DEFAULT_MAP = {
     {"BASE_CODES_KEY", BASE_CODES_KEY},
     {"PRECISE_CODES_KEY", PRECISE_CODES_KEY},
     {"HGRAPH_SUPPORT_DUPLICATE", HGRAPH_SUPPORT_DUPLICATE},
+    {"HGRAPH_DUPLICATE_DISTANCE_THRESHOLD", HGRAPH_DUPLICATE_DISTANCE_THRESHOLD},
     {"IO_TYPE_VALUE_MEMORY_IO", IO_TYPE_VALUE_MEMORY_IO},
     {"IO_TYPE_VALUE_BLOCK_MEMORY_IO", IO_TYPE_VALUE_BLOCK_MEMORY_IO},
     {"IO_TYPE_VALUE_BUFFER_IO", IO_TYPE_VALUE_BUFFER_IO},


### PR DESCRIPTION
## Summary
- add `duplicate_distance_threshold` as an HGraph build parameter and propagate it through the search insertion path
- keep duplicate ownership on the nearest candidate while allowing distance-threshold deduplication with `memcmp` fallback at zero
- add unit coverage for parameter mapping and Searcher duplicate-threshold behavior, plus docs updates

## Testing
- make fmt
- ./build/tests/unittests -d yes '[ut][HGraphParameter]' --allow-running-no-tests
- ./build/tests/unittests -d yes '[ut][BasicSearcher][duplicate]' --allow-running-no-tests