### PR TITLE
fix: avoid OOM in release packaging (backport #2042 to 0.18)

### DIFF
--- a/scripts/release/dist.sh
+++ b/scripts/release/dist.sh
@@ -10,12 +10,17 @@ build() {
     local dockerfile=$2
     local makefile_target=$3
     local dist_name_suffix=$4
+    local compile_jobs=${COMPILE_JOBS:-6}
+
+    if ! [[ "$compile_jobs" =~ ^[1-9][0-9]*$ ]]; then
+        compile_jobs=6
+    fi
 
     docker build -t $image_name -f $dockerfile .
 
     docker run -u $CURRENT_UID:$CURRENT_GID --rm -v $(pwd):/work $image_name \
            bash -c "\
-           export COMPILE_JOBS=48 && \
+           export COMPILE_JOBS=\"$compile_jobs\" && \
            export CMAKE_INSTALL_PREFIX=/tmp/vsag && \
            make clean-release && make $makefile_target && make run-dist-tests && make install && \
            mkdir -p ./dist && \
@@ -43,7 +48,7 @@ build "vsag-builder-cxx11" \
 # libcxx version
 # docker run -u $CURRENT_UID:$CURRENT_GID --rm -v $(pwd):/work vsag-builder \
 #        bash -c "\
-#        export COMPILE_JOBS=48 && \
+#        export COMPILE_JOBS=6 && \
 #        export CMAKE_INSTALL_PREFIX=/tmp/vsag && \
 #        make clean-release && make dist-libcxx && make install && \
 #        mkdir -p ./dist && \


### PR DESCRIPTION
## Summary
Backport of #2042 to the `0.18` release branch. The failed release run https://github.com/antgroup/vsag/actions/runs/25839521861 was dispatched against `0.18` and OOM-killed during `Package release assets` because this branch still had the hard-coded `COMPILE_JOBS=48`.

The release packaging script hard-coded `COMPILE_JOBS=48`, which on the GitHub Actions `ubuntu-22.04` runner caused the C++ compile step inside `Package release assets` to be killed by the OOM killer (exit 137). This makes the parallelism configurable via the `COMPILE_JOBS` environment variable, defaults to 6 (matching the project `Makefile` default), and falls back to 6 if the supplied value is not a positive integer. The variable is also quoted when exported inside the `docker run` bash command to avoid word-splitting.

Docs changes from #2042 are intentionally omitted: `docs/docs/{en,zh}/src/development/building.md` only exists on `main`.

## Linked issue
Fixes #2062

(Note: #2062 tracks the same bug across all of 0.15\u20130.18; please reopen it after this PR merges so the remaining backports stay linked.)

## Verification
- `bash -n scripts/release/dist.sh`
- Diff matches the relevant hunk of #2042 (`scripts/release/dist.sh` only), with the regex tightened to `^[1-9][0-9]*$` per review.