### PR TITLE
fix: make filtered graph search deterministic

### DIFF
--- a/include/vsag/constants.h
+++ b/include/vsag/constants.h
@@ -96,6 +96,7 @@ extern const char* const HNSW_PARAMETER_CONSTRUCTION;
 extern const char* const HNSW_PARAMETER_USE_STATIC;
 extern const char* const HNSW_PARAMETER_REVERSED_EDGES;
 extern const char* const HNSW_PARAMETER_SKIP_RATIO;
+extern const char* const HNSW_PARAMETER_SKIP_STRATEGY;
 
 extern const char* const PYRAMID_PARAMETER_BASE_CODES;
 

--- a/src/algorithm/hnswlib/algorithm_interface.h
+++ b/src/algorithm/hnswlib/algorithm_interface.h
@@ -25,6 +25,7 @@
 #include "space_interface.h"
 #include "storage/stream_reader.h"
 #include "typing.h"
+#include "utils/filter_search_skip_strategy.h"
 #include "vsag/dataset.h"
 #include "vsag/errors.h"
 #include "vsag/expected.hpp"
@@ -47,6 +48,8 @@ public:
               size_t ef,
               const vsag::FilterPtr is_id_allowed = nullptr,
               float skip_ratio = 0.9f,
+              vsag::FilterSearchSkipStrategyType skip_strategy_type =
+                  vsag::FilterSearchSkipStrategyType::DETERMINISTIC_ACCUMULATIVE,
               vsag::Allocator* allocator = nullptr,
               vsag::IteratorFilterContext* iter_ctx = nullptr,
               bool is_last_filter = false) const = 0;

--- a/src/algorithm/hnswlib/hnswalg.cpp
+++ b/src/algorithm/hnswlib/hnswalg.cpp
@@ -20,7 +20,7 @@
 #include "data_cell/graph_interface.h"
 #include "impl/basic_searcher.h"
 #include "prefetch.h"
-#include "utils/linear_congruential_generator.h"
+#include "utils/filter_search_skip_strategy.h"
 
 namespace hnswlib {
 
@@ -487,9 +487,9 @@ HierarchicalNSW::searchBaseLayerST(InnerIdType ep_id,
                                    size_t ef,
                                    const vsag::FilterPtr is_id_allowed,
                                    const float skip_ratio,
+                                   vsag::FilterSearchSkipStrategyType skip_strategy_type,
                                    vsag::Allocator* allocator,
                                    vsag::IteratorFilterContext* iter_ctx) const {
-    vsag::LinearCongruentialGenerator generator;
     VisitedListPtr vl = visited_list_pool_->getFreeVisitedList();
     vl_type* visited_array = vl->mass;
     vl_type visited_array_tag = vl->curV;
@@ -499,7 +499,8 @@ HierarchicalNSW::searchBaseLayerST(InnerIdType ep_id,
     MaxHeap candidate_set(search_allocator);
 
     float valid_ratio = is_id_allowed ? is_id_allowed->ValidRatio() : 1.0F;
-    float skip_threshold = valid_ratio == 1.0F ? 0 : (1 - ((1 - valid_ratio) * skip_ratio));
+    auto skip_strategy =
+        vsag::create_filter_search_skip_strategy(skip_strategy_type, valid_ratio, skip_ratio);
 
     float lower_bound;
     if (iter_ctx != nullptr && !iter_ctx->IsFirstUsed()) {
@@ -571,10 +572,13 @@ HierarchicalNSW::searchBaseLayerST(InnerIdType ep_id,
             }
             if (visited_array[candidate_id] != visited_array_tag) {
                 visited_array[candidate_id] = visited_array_tag;
+                bool candidate_valid_checked = false;
                 if (is_id_allowed && not candidate_set.empty() &&
-                    generator.NextFloat() < skip_threshold &&
-                    not is_id_allowed->CheckValid(getExternalLabel(candidate_id))) {
-                    continue;
+                    not skip_strategy->ShouldSkipFilterCheck()) {
+                    candidate_valid_checked = true;
+                    if (not is_id_allowed->CheckValid(getExternalLabel(candidate_id))) {
+                        continue;
+                    }
                 }
                 float dist = 0;
                 char* currObj1 = getDataByInternalId(candidate_id);
@@ -588,7 +592,7 @@ HierarchicalNSW::searchBaseLayerST(InnerIdType ep_id,
 #endif
 
                     if ((!has_deletions || !isMarkedDeleted(candidate_id)) &&
-                        ((!is_id_allowed) ||
+                        ((!is_id_allowed) || candidate_valid_checked ||
                          is_id_allowed->CheckValid(getExternalLabel(candidate_id)))) {
                         if (iter_ctx != nullptr && !iter_ctx->CheckPoint(candidate_id)) {
                             continue;
@@ -1600,6 +1604,7 @@ HierarchicalNSW::searchKnn(const void* query_data,
                            uint64_t ef,
                            const vsag::FilterPtr is_id_allowed,
                            const float skip_ratio,
+                           vsag::FilterSearchSkipStrategyType skip_strategy_type,
                            vsag::Allocator* allocator,
                            vsag::IteratorFilterContext* iter_ctx,
                            bool is_last_filter) const {
@@ -1629,6 +1634,7 @@ HierarchicalNSW::searchKnn(const void* query_data,
                                                         std::max(ef, k),
                                                         is_id_allowed,
                                                         skip_ratio,
+                                                        skip_strategy_type,
                                                         allocator,
                                                         iter_ctx);
     } else {
@@ -1677,6 +1683,7 @@ HierarchicalNSW::searchKnn(const void* query_data,
                                                             std::max(ef, k),
                                                             is_id_allowed,
                                                             skip_ratio,
+                                                            skip_strategy_type,
                                                             allocator,
                                                             iter_ctx);
         } else {
@@ -1685,6 +1692,7 @@ HierarchicalNSW::searchKnn(const void* query_data,
                                                            std::max(ef, k),
                                                            is_id_allowed,
                                                            skip_ratio,
+                                                           skip_strategy_type,
                                                            allocator,
                                                            iter_ctx);
         }
@@ -1809,8 +1817,9 @@ HierarchicalNSW::searchBaseLayerST<false, false>(
     size_t ef,
     const vsag::FilterPtr is_id_allowed,
     const float skip_ratio,
+    vsag::FilterSearchSkipStrategyType skip_strategy_type,
     vsag::Allocator* allocator,
-    vsag::IteratorFilterContext* iter_ctx = nullptr) const;
+    vsag::IteratorFilterContext* iter_ctx) const;
 
 template MaxHeap
 HierarchicalNSW::searchBaseLayerST<false, false>(InnerIdType ep_id,

--- a/src/algorithm/hnswlib/hnswalg.h
+++ b/src/algorithm/hnswlib/hnswalg.h
@@ -270,6 +270,8 @@ public:
                       size_t ef,
                       const vsag::FilterPtr is_id_allowed = nullptr,
                       const float skip_ratio = 0.9f,
+                      vsag::FilterSearchSkipStrategyType skip_strategy_type =
+                          vsag::FilterSearchSkipStrategyType::DETERMINISTIC_ACCUMULATIVE,
                       vsag::Allocator* allocator = nullptr,
                       vsag::IteratorFilterContext* iter_ctx = nullptr) const;
 
@@ -436,6 +438,8 @@ public:
               uint64_t ef,
               const vsag::FilterPtr is_id_allowed = nullptr,
               const float skip_ratio = 0.9f,
+              vsag::FilterSearchSkipStrategyType skip_strategy_type =
+                  vsag::FilterSearchSkipStrategyType::DETERMINISTIC_ACCUMULATIVE,
               vsag::Allocator* allocator = nullptr,
               vsag::IteratorFilterContext* iter_ctx = nullptr,
               bool is_last_filter = false) const override;

--- a/src/algorithm/hnswlib/hnswalg_static.h
+++ b/src/algorithm/hnswlib/hnswalg_static.h
@@ -1408,6 +1408,8 @@ public:
               uint64_t ef,
               const vsag::FilterPtr is_id_allowed = nullptr,
               const float skip_ratio = 0.9f,
+              vsag::FilterSearchSkipStrategyType skip_strategy_type =
+                  vsag::FilterSearchSkipStrategyType::DETERMINISTIC_ACCUMULATIVE,
               vsag::Allocator* allocator = nullptr,
               vsag::IteratorFilterContext* iter_ctx = nullptr,
               bool is_last_filter = false) const override {

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -101,6 +101,7 @@ const char* const HNSW_PARAMETER_CONSTRUCTION = "ef_construction";
 const char* const HNSW_PARAMETER_USE_STATIC = "use_static";
 const char* const HNSW_PARAMETER_REVERSED_EDGES = "use_reversed_edges";
 const char* const HNSW_PARAMETER_SKIP_RATIO = "skip_ratio";
+const char* const HNSW_PARAMETER_SKIP_STRATEGY = "skip_strategy";
 
 const char* const PYRAMID_PARAMETER_BASE_CODES = "base_codes";
 

--- a/src/impl/basic_searcher.cpp
+++ b/src/impl/basic_searcher.cpp
@@ -17,9 +17,22 @@
 
 #include <limits>
 
-#include "utils/linear_congruential_generator.h"
 #include "utils/standard_heap.h"
 namespace vsag {
+
+namespace {
+
+FilterSearchSkipStrategyPtr
+create_filter_search_skip_strategy(const InnerSearchParam& inner_search_param) {
+    return create_filter_search_skip_strategy(
+        inner_search_param.skip_strategy_type,
+        inner_search_param.is_inner_id_allowed != nullptr
+            ? inner_search_param.is_inner_id_allowed->ValidRatio()
+            : 1.0F,
+        inner_search_param.skip_ratio);
+}
+
+}  // namespace
 
 BasicSearcher::BasicSearcher(const IndexCommonParam& common_param, MutexArrayPtr mutex_array)
     : allocator_(common_param.allocator_.get()), mutex_array_(std::move(mutex_array)) {
@@ -30,11 +43,10 @@ BasicSearcher::visit(const GraphInterfacePtr& graph,
                      const VisitedListPtr& vl,
                      const std::pair<float, uint64_t>& current_node_pair,
                      const FilterPtr& filter,
-                     float skip_ratio,
+                     FilterSearchSkipStrategy* skip_strategy,
                      Vector<InnerIdType>& to_be_visited_rid,
                      Vector<InnerIdType>& to_be_visited_id,
                      Vector<InnerIdType>& neighbors) const {
-    LinearCongruentialGenerator generator;
     uint32_t count_no_visited = 0;
 
     if (this->mutex_array_ != nullptr) {
@@ -44,17 +56,13 @@ BasicSearcher::visit(const GraphInterfacePtr& graph,
         graph->GetNeighbors(current_node_pair.second, neighbors);
     }
 
-    float skip_threshold =
-        (filter != nullptr
-             ? (filter->ValidRatio() == 1.0F ? 0 : (1 - ((1 - filter->ValidRatio()) * skip_ratio)))
-             : 0.0F);
-
     for (uint32_t i = 0; i < neighbors.size(); i++) {
         if (i + prefetch_stride_visit_ < neighbors.size()) {
             vl->Prefetch(neighbors[i + prefetch_stride_visit_]);
         }
         if (not vl->Get(neighbors[i])) {
-            if (not filter || count_no_visited == 0 || generator.NextFloat() > skip_threshold ||
+            auto skip_filter_check = filter != nullptr && skip_strategy->ShouldSkipFilterCheck();
+            if (not filter || count_no_visited == 0 || skip_filter_check ||
                 filter->CheckValid(neighbors[i])) {
                 to_be_visited_rid[count_no_visited] = i;
                 to_be_visited_id[count_no_visited] = neighbors[i];
@@ -122,6 +130,7 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
     Vector<InnerIdType> to_be_visited_id(graph->MaximumDegree(), alloc);
     Vector<InnerIdType> neighbors(graph->MaximumDegree(), alloc);
     Vector<float> line_dists(graph->MaximumDegree(), alloc);
+    auto skip_strategy = create_filter_search_skip_strategy(inner_search_param);
 
     if (!iter_ctx->IsFirstUsed()) {
         if (iter_ctx->Empty()) {
@@ -173,7 +182,7 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
                                  vl,
                                  current_node_pair,
                                  inner_search_param.is_inner_id_allowed,
-                                 inner_search_param.skip_ratio,
+                                 skip_strategy.get(),
                                  to_be_visited_rid,
                                  to_be_visited_id,
                                  neighbors);
@@ -258,6 +267,7 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
     Vector<InnerIdType> to_be_visited_id(graph->MaximumDegree(), alloc);
     Vector<InnerIdType> neighbors(graph->MaximumDegree(), alloc);
     Vector<float> line_dists(graph->MaximumDegree(), alloc);
+    auto skip_strategy = create_filter_search_skip_strategy(inner_search_param);
 
     flatten->Query(&dist, computer, &ep, 1, alloc);
     if (not is_id_allowed || is_id_allowed->CheckValid(ep)) {
@@ -291,7 +301,7 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
                                  vl,
                                  current_node_pair,
                                  inner_search_param.is_inner_id_allowed,
-                                 inner_search_param.skip_ratio,
+                                 skip_strategy.get(),
                                  to_be_visited_rid,
                                  to_be_visited_id,
                                  neighbors);

--- a/src/impl/basic_searcher.h
+++ b/src/impl/basic_searcher.h
@@ -28,7 +28,7 @@
 #include "lock_strategy.h"
 #include "runtime_parameter.h"
 #include "utils/distance_heap.h"
-#include "utils/linear_congruential_generator.h"
+#include "utils/filter_search_skip_strategy.h"
 #include "utils/visited_list.h"
 
 namespace vsag {
@@ -45,6 +45,8 @@ public:
     uint64_t ef{10};
     FilterPtr is_inner_id_allowed{nullptr};
     float skip_ratio{0.8F};
+    FilterSearchSkipStrategyType skip_strategy_type{
+        FilterSearchSkipStrategyType::DETERMINISTIC_ACCUMULATIVE};
     InnerSearchMode search_mode{KNN_SEARCH};
     int range_search_limit_size{-1};
 
@@ -63,6 +65,7 @@ public:
             ep = other.ep;
             ef = other.ef;
             skip_ratio = other.skip_ratio;
+            skip_strategy_type = other.skip_strategy_type;
             search_mode = other.search_mode;
             range_search_limit_size = other.range_search_limit_size;
             is_inner_id_allowed = other.is_inner_id_allowed;
@@ -121,7 +124,7 @@ private:
           const VisitedListPtr& vl,
           const std::pair<float, uint64_t>& current_node_pair,
           const FilterPtr& filter,
-          float skip_ratio,
+          FilterSearchSkipStrategy* skip_strategy,
           Vector<InnerIdType>& to_be_visited_rid,
           Vector<InnerIdType>& to_be_visited_id,
           Vector<InnerIdType>& neighbors) const;

--- a/src/index/hnsw.cpp
+++ b/src/index/hnsw.cpp
@@ -293,6 +293,7 @@ HNSW::knn_search(const DatasetPtr& query,
                                            std::max(params.ef_search, k),
                                            filter_ptr,
                                            params.skip_ratio,
+                                           params.skip_strategy_type,
                                            allocator,
                                            iter_filter_ctx,
                                            is_last_filter);

--- a/src/index/hnsw_zparameters.cpp
+++ b/src/index/hnsw_zparameters.cpp
@@ -117,6 +117,14 @@ HnswSearchParameters::FromJson(const std::string& json_string) {
     if (params[index_name].contains(HNSW_PARAMETER_SKIP_RATIO)) {
         obj.skip_ratio = params[index_name][HNSW_PARAMETER_SKIP_RATIO];
     }
+    if (params[index_name].contains(HNSW_PARAMETER_SKIP_STRATEGY)) {
+        CHECK_ARGUMENT(params[index_name][HNSW_PARAMETER_SKIP_STRATEGY].is_string(),
+                       fmt::format("parameters[{}][{}] must be string type",
+                                   index_name,
+                                   HNSW_PARAMETER_SKIP_STRATEGY));
+        obj.skip_strategy_type = parse_filter_search_skip_strategy_type(
+            params[index_name][HNSW_PARAMETER_SKIP_STRATEGY]);
+    }
 
     return obj;
 }

--- a/src/index/hnsw_zparameters.h
+++ b/src/index/hnsw_zparameters.h
@@ -21,6 +21,7 @@
 #include "../algorithm/hnswlib/hnswlib.h"
 #include "../data_type.h"
 #include "index_common_param.h"
+#include "utils/filter_search_skip_strategy.h"
 
 namespace vsag {
 
@@ -62,6 +63,8 @@ public:
     // required vars
     int64_t ef_search;
     float skip_ratio{0.9};
+    FilterSearchSkipStrategyType skip_strategy_type{
+        FilterSearchSkipStrategyType::DETERMINISTIC_ACCUMULATIVE};
     bool use_conjugate_graph_search;
 
 private:

--- a/src/index/hnsw_zparameters_test.cpp
+++ b/src/index/hnsw_zparameters_test.cpp
@@ -71,3 +71,49 @@ TEST_CASE("create hnsw with wrong parameter", "[ut][hnsw]") {
         vsag::HnswParameters::FromJson(correct_parsed_params, common_param);
     }
 }
+
+TEST_CASE("parse hnsw search skip strategy", "[ut][hnsw]") {
+    SECTION("default deterministic accumulative strategy") {
+        auto params = vsag::HnswSearchParameters::FromJson(R"(
+        {
+            "hnsw": {
+                "ef_search": 100,
+                "skip_ratio": 0.3
+            }
+        })");
+        REQUIRE(params.skip_strategy_type ==
+                vsag::FilterSearchSkipStrategyType::DETERMINISTIC_ACCUMULATIVE);
+    }
+
+    SECTION("explicit random strategy") {
+        auto params = vsag::HnswSearchParameters::FromJson(R"(
+        {
+            "hnsw": {
+                "ef_search": 100,
+                "skip_ratio": 0.3,
+                "skip_strategy": "random"
+            }
+        })");
+        REQUIRE(params.skip_strategy_type == vsag::FilterSearchSkipStrategyType::RANDOM);
+    }
+
+    SECTION("invalid strategy") {
+        REQUIRE_THROWS(vsag::HnswSearchParameters::FromJson(R"(
+        {
+            "hnsw": {
+                "ef_search": 100,
+                "skip_strategy": "invalid"
+            }
+        })"));
+    }
+
+    SECTION("non-string strategy") {
+        REQUIRE_THROWS(vsag::HnswSearchParameters::FromJson(R"(
+        {
+            "hnsw": {
+                "ef_search": 100,
+                "skip_strategy": 1
+            }
+        })"));
+    }
+}

--- a/src/utils/filter_search_skip_strategy.cpp
+++ b/src/utils/filter_search_skip_strategy.cpp
@@ -1,0 +1,122 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "filter_search_skip_strategy.h"
+
+#include <algorithm>
+#include <cmath>
+
+#include "linear_congruential_generator.h"
+#include "vsag_exception.h"
+
+namespace vsag {
+namespace {
+
+constexpr const char* RANDOM_SKIP_STRATEGY = "random";
+constexpr const char* DETERMINISTIC_ACCUMULATIVE_SKIP_STRATEGY = "deterministic_accumulative";
+
+double
+get_skip_check_probability(float valid_ratio, float skip_ratio) {
+    if (valid_ratio == 1.0F) {
+        return 1.0;
+    }
+    auto skip_check_probability =
+        static_cast<double>(1.0F - valid_ratio) * static_cast<double>(skip_ratio);
+    return std::clamp(skip_check_probability, 0.0, 1.0);
+}
+
+class RandomFilterSearchSkipStrategy : public FilterSearchSkipStrategy {
+public:
+    explicit RandomFilterSearchSkipStrategy(double retain_ratio)
+        : skip_threshold_(1.0 - retain_ratio) {
+    }
+
+    bool
+    ShouldSkipFilterCheck() override {
+        if (skip_threshold_ <= 0.0) {
+            return true;
+        }
+        if (skip_threshold_ >= 1.0) {
+            return false;
+        }
+        return generator_.NextFloat() > skip_threshold_;
+    }
+
+private:
+    LinearCongruentialGenerator generator_;
+    double skip_threshold_{0.0};
+};
+
+class AccumulativeFilterSearchSkipStrategy : public FilterSearchSkipStrategy {
+public:
+    explicit AccumulativeFilterSearchSkipStrategy(double retain_ratio)
+        : retain_ratio_(retain_ratio) {
+    }
+
+    bool
+    ShouldSkipFilterCheck() override {
+        accumulative_alpha_ += retain_ratio_;
+        if (accumulative_alpha_ >= 1.0) {
+            accumulative_alpha_ = std::fmod(accumulative_alpha_, 1.0);
+            return true;
+        }
+        return false;
+    }
+
+private:
+    double retain_ratio_{1.0};
+    double accumulative_alpha_{0.0};
+};
+
+}  // namespace
+
+FilterSearchSkipStrategyPtr
+create_filter_search_skip_strategy(FilterSearchSkipStrategyType type,
+                                   float valid_ratio,
+                                   float skip_ratio) {
+    auto retain_ratio = get_skip_check_probability(valid_ratio, skip_ratio);
+    switch (type) {
+        case FilterSearchSkipStrategyType::RANDOM:
+            return std::make_unique<RandomFilterSearchSkipStrategy>(retain_ratio);
+        case FilterSearchSkipStrategyType::DETERMINISTIC_ACCUMULATIVE:
+            return std::make_unique<AccumulativeFilterSearchSkipStrategy>(retain_ratio);
+    }
+    throw VsagException(ErrorType::INVALID_ARGUMENT, "Unknown FilterSearchSkipStrategyType");
+}
+
+FilterSearchSkipStrategyType
+parse_filter_search_skip_strategy_type(const std::string& strategy_name) {
+    if (strategy_name == RANDOM_SKIP_STRATEGY) {
+        return FilterSearchSkipStrategyType::RANDOM;
+    }
+    if (strategy_name == DETERMINISTIC_ACCUMULATIVE_SKIP_STRATEGY) {
+        return FilterSearchSkipStrategyType::DETERMINISTIC_ACCUMULATIVE;
+    }
+    throw VsagException(ErrorType::INVALID_ARGUMENT,
+                        "invalid filter search skip strategy '" + strategy_name +
+                            "', valid values are 'random' and 'deterministic_accumulative'");
+}
+
+const char*
+filter_search_skip_strategy_type_to_string(FilterSearchSkipStrategyType type) {
+    switch (type) {
+        case FilterSearchSkipStrategyType::RANDOM:
+            return RANDOM_SKIP_STRATEGY;
+        case FilterSearchSkipStrategyType::DETERMINISTIC_ACCUMULATIVE:
+            return DETERMINISTIC_ACCUMULATIVE_SKIP_STRATEGY;
+    }
+    throw VsagException(ErrorType::INVALID_ARGUMENT, "Unknown FilterSearchSkipStrategyType");
+}
+
+}  // namespace vsag

--- a/src/utils/filter_search_skip_strategy.cpp
+++ b/src/utils/filter_search_skip_strategy.cpp
@@ -15,7 +15,6 @@
 #include "filter_search_skip_strategy.h"
 
 #include <algorithm>
-#include <cmath>
 
 #include "linear_congruential_generator.h"
 #include "vsag_exception.h"
@@ -38,8 +37,8 @@ get_skip_check_probability(float valid_ratio, float skip_ratio) {
 
 class RandomFilterSearchSkipStrategy : public FilterSearchSkipStrategy {
 public:
-    explicit RandomFilterSearchSkipStrategy(double retain_ratio)
-        : skip_threshold_(1.0 - retain_ratio) {
+    explicit RandomFilterSearchSkipStrategy(double skip_probability)
+        : skip_threshold_(1.0 - skip_probability) {
     }
 
     bool
@@ -60,22 +59,22 @@ private:
 
 class AccumulativeFilterSearchSkipStrategy : public FilterSearchSkipStrategy {
 public:
-    explicit AccumulativeFilterSearchSkipStrategy(double retain_ratio)
-        : retain_ratio_(retain_ratio) {
+    explicit AccumulativeFilterSearchSkipStrategy(double skip_probability)
+        : skip_probability_(skip_probability) {
     }
 
     bool
     ShouldSkipFilterCheck() override {
-        accumulative_alpha_ += retain_ratio_;
+        accumulative_alpha_ += skip_probability_;
         if (accumulative_alpha_ >= 1.0) {
-            accumulative_alpha_ = std::fmod(accumulative_alpha_, 1.0);
+            accumulative_alpha_ -= 1.0;
             return true;
         }
         return false;
     }
 
 private:
-    double retain_ratio_{1.0};
+    double skip_probability_{1.0};
     double accumulative_alpha_{0.0};
 };
 
@@ -85,12 +84,12 @@ FilterSearchSkipStrategyPtr
 create_filter_search_skip_strategy(FilterSearchSkipStrategyType type,
                                    float valid_ratio,
                                    float skip_ratio) {
-    auto retain_ratio = get_skip_check_probability(valid_ratio, skip_ratio);
+    auto skip_probability = get_skip_check_probability(valid_ratio, skip_ratio);
     switch (type) {
         case FilterSearchSkipStrategyType::RANDOM:
-            return std::make_unique<RandomFilterSearchSkipStrategy>(retain_ratio);
+            return std::make_unique<RandomFilterSearchSkipStrategy>(skip_probability);
         case FilterSearchSkipStrategyType::DETERMINISTIC_ACCUMULATIVE:
-            return std::make_unique<AccumulativeFilterSearchSkipStrategy>(retain_ratio);
+            return std::make_unique<AccumulativeFilterSearchSkipStrategy>(skip_probability);
     }
     throw VsagException(ErrorType::INVALID_ARGUMENT, "Unknown FilterSearchSkipStrategyType");
 }

--- a/src/utils/filter_search_skip_strategy.h
+++ b/src/utils/filter_search_skip_strategy.h
@@ -1,0 +1,48 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+namespace vsag {
+
+enum class FilterSearchSkipStrategyType {
+    RANDOM,
+    DETERMINISTIC_ACCUMULATIVE,
+};
+
+class FilterSearchSkipStrategy {
+public:
+    virtual ~FilterSearchSkipStrategy() = default;
+
+    virtual bool
+    ShouldSkipFilterCheck() = 0;
+};
+
+using FilterSearchSkipStrategyPtr = std::unique_ptr<FilterSearchSkipStrategy>;
+
+FilterSearchSkipStrategyPtr
+create_filter_search_skip_strategy(FilterSearchSkipStrategyType type,
+                                   float valid_ratio,
+                                   float skip_ratio);
+
+FilterSearchSkipStrategyType
+parse_filter_search_skip_strategy_type(const std::string& strategy_name);
+
+const char*
+filter_search_skip_strategy_type_to_string(FilterSearchSkipStrategyType type);
+
+}  // namespace vsag

--- a/src/utils/filter_search_skip_strategy_test.cpp
+++ b/src/utils/filter_search_skip_strategy_test.cpp
@@ -1,0 +1,85 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "filter_search_skip_strategy.h"
+
+#include <algorithm>
+#include <catch2/catch_test_macros.hpp>
+#include <vector>
+
+using namespace vsag;
+
+TEST_CASE("Filter search skip strategy parse", "[ut][filter_search_skip_strategy]") {
+    REQUIRE(parse_filter_search_skip_strategy_type("random") ==
+            FilterSearchSkipStrategyType::RANDOM);
+    REQUIRE(parse_filter_search_skip_strategy_type("deterministic_accumulative") ==
+            FilterSearchSkipStrategyType::DETERMINISTIC_ACCUMULATIVE);
+    REQUIRE(std::string(filter_search_skip_strategy_type_to_string(
+                FilterSearchSkipStrategyType::DETERMINISTIC_ACCUMULATIVE)) ==
+            "deterministic_accumulative");
+    REQUIRE(std::string(filter_search_skip_strategy_type_to_string(
+                FilterSearchSkipStrategyType::RANDOM)) == "random");
+    REQUIRE_THROWS(parse_filter_search_skip_strategy_type("unknown"));
+}
+
+TEST_CASE("Accumulative filter search skip strategy is deterministic",
+          "[ut][filter_search_skip_strategy]") {
+    constexpr float valid_ratio = 0.5F;
+    constexpr float skip_ratio = 0.8F;
+    std::vector<bool> first_sequence;
+    std::vector<bool> second_sequence;
+
+    auto first_strategy = create_filter_search_skip_strategy(
+        FilterSearchSkipStrategyType::DETERMINISTIC_ACCUMULATIVE, valid_ratio, skip_ratio);
+    auto second_strategy = create_filter_search_skip_strategy(
+        FilterSearchSkipStrategyType::DETERMINISTIC_ACCUMULATIVE, valid_ratio, skip_ratio);
+
+    for (uint64_t i = 0; i < 20; ++i) {
+        first_sequence.emplace_back(first_strategy->ShouldSkipFilterCheck());
+        second_sequence.emplace_back(second_strategy->ShouldSkipFilterCheck());
+    }
+
+    REQUIRE(first_sequence == second_sequence);
+    REQUIRE(std::count(first_sequence.begin(), first_sequence.end(), true) == 8);
+}
+
+TEST_CASE("Accumulative filter search skip strategy edge cases",
+          "[ut][filter_search_skip_strategy]") {
+    SECTION("valid ratio one skips filter checks") {
+        auto strategy = create_filter_search_skip_strategy(
+            FilterSearchSkipStrategyType::DETERMINISTIC_ACCUMULATIVE, 1.0F, 0.8F);
+        for (uint64_t i = 0; i < 10; ++i) {
+            REQUIRE(strategy->ShouldSkipFilterCheck());
+        }
+    }
+
+    SECTION("skip ratio zero skips invalid candidates") {
+        auto strategy = create_filter_search_skip_strategy(
+            FilterSearchSkipStrategyType::DETERMINISTIC_ACCUMULATIVE, 0.5F, 0.0F);
+        for (uint64_t i = 0; i < 10; ++i) {
+            REQUIRE_FALSE(strategy->ShouldSkipFilterCheck());
+        }
+    }
+
+    SECTION("ratio inputs are clamped") {
+        auto always_skip_strategy = create_filter_search_skip_strategy(
+            FilterSearchSkipStrategyType::DETERMINISTIC_ACCUMULATIVE, -1.0F, 2.0F);
+        auto never_skip_strategy = create_filter_search_skip_strategy(
+            FilterSearchSkipStrategyType::DETERMINISTIC_ACCUMULATIVE, 0.5F, -1.0F);
+        for (uint64_t i = 0; i < 10; ++i) {
+            REQUIRE(always_skip_strategy->ShouldSkipFilterCheck());
+            REQUIRE_FALSE(never_skip_strategy->ShouldSkipFilterCheck());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add configurable filter search skip strategies with deterministic accumulative behavior as the default.
- Replace random pre-filter skip decisions in HNSW/basic graph search while keeping final filter checks intact.
- Add HNSW `skip_strategy` parsing and unit coverage for strategy behavior and parameter parsing.

## Tests
- `cmake --build build --target unittests -j32`
- `./build/tests/unittests "[ut][filter_search_skip_strategy]"`
- `./build/tests/unittests "parse hnsw search skip strategy"`
- `git diff --check`

# Issue
fixes: #1942 