### PR TITLE
docs: update Google Analytics tracking tag

### DIFF
--- a/docs/blog/en/theme/head.hbs
+++ b/docs/blog/en/theme/head.hbs
@@ -1,13 +1,13 @@
 <!-- Google tag (gtag.js) -->
 <!-- Shared with docs/{docs,blog}/{en,zh}/theme/head.hbs and docs/landing/index.html. Keep these five copies in sync. -->
 <!-- Hostname-gated so local mdBook previews and fork deploys do not pollute the production GA4 property. -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-WL7YCF91WW"></script>
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-2VKGDGDEQV"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
   if (location.hostname === 'vsag.io') {
-    gtag('config', 'G-WL7YCF91WW');
+    gtag('config', 'G-2VKGDGDEQV');
   }
 </script>
 

--- a/docs/blog/zh/theme/head.hbs
+++ b/docs/blog/zh/theme/head.hbs
@@ -1,13 +1,13 @@
 <!-- Google tag (gtag.js) -->
 <!-- Shared with docs/{docs,blog}/{en,zh}/theme/head.hbs and docs/landing/index.html. Keep these five copies in sync. -->
 <!-- Hostname-gated so local mdBook previews and fork deploys do not pollute the production GA4 property. -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-WL7YCF91WW"></script>
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-2VKGDGDEQV"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
   if (location.hostname === 'vsag.io') {
-    gtag('config', 'G-WL7YCF91WW');
+    gtag('config', 'G-2VKGDGDEQV');
   }
 </script>
 

--- a/docs/docs/en/theme/head.hbs
+++ b/docs/docs/en/theme/head.hbs
@@ -1,13 +1,13 @@
 <!-- Google tag (gtag.js) -->
 <!-- Shared with docs/{docs,blog}/{en,zh}/theme/head.hbs and docs/landing/index.html. Keep these five copies in sync. -->
 <!-- Hostname-gated so local mdBook previews and fork deploys do not pollute the production GA4 property. -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-WL7YCF91WW"></script>
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-2VKGDGDEQV"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
   if (location.hostname === 'vsag.io') {
-    gtag('config', 'G-WL7YCF91WW');
+    gtag('config', 'G-2VKGDGDEQV');
   }
 </script>
 

--- a/docs/docs/zh/theme/head.hbs
+++ b/docs/docs/zh/theme/head.hbs
@@ -1,13 +1,13 @@
 <!-- Google tag (gtag.js) -->
 <!-- Shared with docs/{docs,blog}/{en,zh}/theme/head.hbs and docs/landing/index.html. Keep these five copies in sync. -->
 <!-- Hostname-gated so local mdBook previews and fork deploys do not pollute the production GA4 property. -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-WL7YCF91WW"></script>
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-2VKGDGDEQV"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
   if (location.hostname === 'vsag.io') {
-    gtag('config', 'G-WL7YCF91WW');
+    gtag('config', 'G-2VKGDGDEQV');
   }
 </script>
 

--- a/docs/landing/index.html
+++ b/docs/landing/index.html
@@ -6,13 +6,13 @@
     <!-- Google tag (gtag.js) -->
     <!-- Shared with docs/{docs,blog}/{en,zh}/theme/head.hbs. Keep these five copies in sync. -->
     <!-- Hostname-gated so local previews and fork deploys do not pollute the production GA4 property. -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-WL7YCF91WW"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-2VKGDGDEQV"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
       if (location.hostname === 'vsag.io') {
-        gtag('config', 'G-WL7YCF91WW');
+        gtag('config', 'G-2VKGDGDEQV');
       }
     </script>
 


### PR DESCRIPTION
## Summary

- Replace the outdated Google Analytics measurement ID `G-WL7YCF91WW` with the new `G-2VKGDGDEQV` across the docs site, blog, and landing page.
- Affected files: `docs/landing/index.html`, `docs/docs/{en,zh}/theme/head.hbs`, `docs/blog/{en,zh}/theme/head.hbs`.

## Motivation

The previous GA tag was configured incorrectly. Updating it ensures vsag.io traffic is reported to the correct GA4 property after the next docs sync to `vsag-io/vsag-io.github.io`.