### PR TITLE
feat: backport HGraph duplicate threshold to 0.18

### DIFF
--- a/docs/hgraph.md
+++ b/docs/hgraph.md
@@ -46,6 +46,7 @@ For examples, refer to [103_index_hgraph.cpp](https://github.com/antgroup/vsag/b
 | **Advanced** | ignore_reorder | bool | false | No | Skip precise quantization serialization |
 | **Advanced** | build_by_base | bool | false | No | Build index using base quantization |
 | **Features** | support_duplicate | bool | false | No | Enable duplicate data detection |
+| **Features** | duplicate_distance_threshold | float | 0.0 | No | Deduplicate by nearest-candidate distance when greater than 0; otherwise fall back to code memcmp |
 | **Features** | support_remove | bool | false | No | Enable deletion support |
 | **Features** | store_raw_vector | bool | false | No | Store raw vectors (cosine metric) |
 | **Features** | use_elp_optimizer | bool | false | No | Auto parameter optimization |
@@ -166,6 +167,12 @@ For examples, refer to [103_index_hgraph.cpp](https://github.com/antgroup/vsag/b
 - **Optional Values**: true, false
 - **Default Value**: false
 
+### duplicate_distance_threshold
+- **Parameter Type**: float
+- **Parameter Description**: Duplicate-detection distance threshold. When greater than 0, the nearest candidate is treated as the duplicate owner if its distance is within the threshold; when 0, duplicate detection falls back to code memcmp with the nearest candidate
+- **Optional Values**: Any non-negative float
+- **Default Value**: 0.0
+
 ### store_raw_vector
 - **Parameter Type**: bool
 - **Parameter Description**: Whether to store raw vectors in the index, useful for cosine metric
@@ -204,10 +211,11 @@ means that the index is built using SQ8 quantization, with a maximum degree of 3
     "ef_construction": 400,
     "build_thread_count": 50,
     "support_duplicate": true,
+    "duplicate_distance_threshold": 0.02,
     "support_remove": true
 }
 ```
-means that the index uses PQ quantization with 64 subspaces, enables reordering with FP16 precision, supports duplicate detection and deletion, with maximum degree 64 and ef_construction 400.
+means that the index uses PQ quantization with 64 subspaces, enables reordering with FP16 precision, deduplicates inserts within distance threshold 0.02, supports deletion, with maximum degree 64 and ef_construction 400.
 
 ## Detailed Explanation of Search Parameters
 

--- a/include/vsag/constants.h
+++ b/include/vsag/constants.h
@@ -186,6 +186,7 @@ extern const char* const HGRAPH_PARAMETER_EF_RUNTIME;
 extern const char* const HGRAPH_PARAMETER_HOPS_LIMIT;
 extern const char* const HGRAPH_EXTRA_INFO_SIZE;
 extern const char* const HGRAPH_SUPPORT_DUPLICATE;
+extern const char* const HGRAPH_DUPLICATE_DISTANCE_THRESHOLD;
 extern const char* const HGRAPH_SUPPORT_TOMBSTONE;
 extern const char* const HGRAPH_LABEL_REMAP_TYPE;
 extern const char* const HGRAPH_USE_EXTRA_INFO_FILTER;

--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -62,6 +62,7 @@ HGraph::HGraph(const HGraphParameterPtr& hgraph_param, const vsag::IndexCommonPa
       build_by_base_(hgraph_param->build_by_base),
       ef_construct_(hgraph_param->ef_construction),
       alpha_(hgraph_param->alpha),
+      duplicate_distance_threshold_(hgraph_param->duplicate_distance_threshold),
       odescent_param_(hgraph_param->odescent_param),
       graph_type_(hgraph_param->graph_type),
       hierarchical_datacell_param_(hgraph_param->hierarchical_graph_param),
@@ -418,6 +419,12 @@ HGraph::map_hgraph_param(const JsonType& hgraph_json) {
             },
         },
         {
+            HGRAPH_DUPLICATE_DISTANCE_THRESHOLD,
+            {
+                DUPLICATE_DISTANCE_THRESHOLD,
+            },
+        },
+        {
             HGRAPH_SUPPORT_TOMBSTONE,
             {
                 SUPPORT_TOMBSTONE,
@@ -509,6 +516,7 @@ HGraph::map_hgraph_param(const JsonType& hgraph_json) {
             "{ATTR_HAS_BUCKETS_KEY}": false
         },
         "{HGRAPH_SUPPORT_DUPLICATE}": false,
+        "{HGRAPH_DUPLICATE_DISTANCE_THRESHOLD}": 0.0,
         "{HGRAPH_SUPPORT_TOMBSTONE}": false,
         "{HGRAPH_LABEL_REMAP_TYPE}": "{LABEL_REMAP_TYPE_VALUE_PG}",
         "{EF_CONSTRUCTION_KEY}": 400
@@ -1608,6 +1616,8 @@ HGraph::graph_add_one(const void* data, int level, InnerIdType inner_id) {
     param.topk = static_cast<int64_t>(ef_construct_);
     if (this->label_table_->CompressDuplicateData()) {
         param.find_duplicate = true;
+        param.duplicate_query_id = inner_id;
+        param.duplicate_distance_threshold = this->duplicate_distance_threshold_;
     }
 
     if (bottom_graph_->TotalCount() != 0) {

--- a/src/algorithm/hgraph.h
+++ b/src/algorithm/hgraph.h
@@ -376,5 +376,7 @@ private:
     ReorderInterfacePtr reorder_{nullptr};
 
     bool use_old_serial_format_{false};
+
+    float duplicate_distance_threshold_{0.0F};
 };
 }  // namespace vsag

--- a/src/algorithm/hgraph_parameter.cpp
+++ b/src/algorithm/hgraph_parameter.cpp
@@ -121,6 +121,9 @@ HGraphParameter::FromJson(const JsonType& json) {
     if (json.Contains(SUPPORT_DUPLICATE)) {
         this->support_duplicate = json[SUPPORT_DUPLICATE].GetBool();
     }
+    if (json.Contains(DUPLICATE_DISTANCE_THRESHOLD)) {
+        this->duplicate_distance_threshold = json[DUPLICATE_DISTANCE_THRESHOLD].GetFloat();
+    }
     if (json.Contains(SUPPORT_TOMBSTONE)) {
         this->support_tombstone = json[SUPPORT_TOMBSTONE].GetBool();
     }
@@ -137,6 +140,7 @@ HGraphParameter::ToJson() const {
     json[EF_CONSTRUCTION_KEY].SetInt(this->ef_construction);
     json[ALPHA_KEY].SetFloat(this->alpha);
     json[SUPPORT_DUPLICATE].SetBool(this->support_duplicate);
+    json[DUPLICATE_DISTANCE_THRESHOLD].SetFloat(this->duplicate_distance_threshold);
     json[TRAIN_SAMPLE_COUNT_KEY].SetInt(this->train_sample_count);
     return json;
 }
@@ -177,6 +181,11 @@ HGraphParameter::CheckCompatibility(const ParamPtr& other) const {
     }
     if (support_duplicate != hgraph_param->support_duplicate) {
         logger::error("HGraphParameter::CheckCompatibility: support_duplicate must be the same");
+        return false;
+    }
+    if (duplicate_distance_threshold != hgraph_param->duplicate_distance_threshold) {
+        logger::error(
+            "HGraphParameter::CheckCompatibility: duplicate_distance_threshold must be the same");
         return false;
     }
     if (label_remap_type != hgraph_param->label_remap_type) {

--- a/src/algorithm/hgraph_parameter.h
+++ b/src/algorithm/hgraph_parameter.h
@@ -63,6 +63,7 @@ public:
     float alpha{1.0F};
 
     bool support_duplicate{false};
+    float duplicate_distance_threshold{0.0F};
     bool support_tombstone{false};
 
     DataTypes data_type{DataTypes::DATA_TYPE_FLOAT};

--- a/src/algorithm/hgraph_parameter_test.cpp
+++ b/src/algorithm/hgraph_parameter_test.cpp
@@ -1,4 +1,3 @@
-
 // Copyright 2024-present the vsag project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -54,6 +53,7 @@ struct HGraphDefaultParam {
     int remove_flag_bit = 8;
     bool use_attribute_filter = false;
     bool support_duplicate = false;
+    float duplicate_distance_threshold = 0.0F;
     bool use_reorder = true;
     std::string label_remap_type = "pg";
 };
@@ -110,6 +110,7 @@ generate_hgraph_param(const HGraphDefaultParam& param) {
         "use_attribute_filter": {},
         "use_reorder": {},
         "support_duplicate": {},
+        "duplicate_distance_threshold": {},
         "label_remap_type": "{}"
     }})";
 
@@ -126,38 +127,81 @@ generate_hgraph_param(const HGraphDefaultParam& param) {
                        param.use_attribute_filter,
                        param.use_reorder,
                        param.support_duplicate,
+                       param.duplicate_distance_threshold,
                        param.label_remap_type);
 }
 
-TEST_CASE("HGraph Parameters CheckCompatibility", "[ut][HGraphParameter][CheckCompatibility]"){
-    SECTION("wrong parameter type"){HGraphDefaultParam default_param;
-auto param_str = generate_hgraph_param(default_param);
-auto param = std::make_shared<vsag::HGraphParameter>();
-param->FromString(param_str);
-REQUIRE(param->CheckCompatibility(param));
-REQUIRE_FALSE(param->CheckCompatibility(std::make_shared<vsag::EmptyParameter>()));
-}
+// clang-format off
+TEST_CASE("HGraph Parameters CheckCompatibility", "[ut][HGraphParameter][CheckCompatibility]") {
+    SECTION("wrong parameter type") {
+        HGraphDefaultParam default_param;
+        auto param_str = generate_hgraph_param(default_param);
+        auto param = std::make_shared<vsag::HGraphParameter>();
+        param->FromString(param_str);
+        REQUIRE(param->CheckCompatibility(param));
+        REQUIRE_FALSE(param->CheckCompatibility(std::make_shared<vsag::EmptyParameter>()));
+    }
 
-TEST_COMPATIBILITY_CASE(
-    "different base codes io type", base_codes_io_type, "memory_io", "block_memory_io", true)
-TEST_COMPATIBILITY_CASE("different pq dim", base_codes_pq_dim, 8, 16, false)
-TEST_COMPATIBILITY_CASE(
-    "different base codes quantization type", base_codes_quantization_type, "sq4", "sq8", false)
-TEST_COMPATIBILITY_CASE("different graph type", graph_storage_type, "flat", "compressed", false)
-TEST_COMPATIBILITY_CASE("different max degree", max_degree, 26, 30, false)
-TEST_COMPATIBILITY_CASE("different support remove", support_remove, true, false, false)
-TEST_COMPATIBILITY_CASE("different remove flag bit", remove_flag_bit, 8, 16, false)
-TEST_COMPATIBILITY_CASE("different use reorder", use_reorder, true, false, false)
-TEST_COMPATIBILITY_CASE(
-    "different precise codes io type", precise_codes_io_type, "memory_io", "block_memory_io", true)
-TEST_COMPATIBILITY_CASE("different precise codes quantization type",
-                        precise_codes_quantization_type,
-                        "fp32",
-                        "sq8",
-                        false)
-TEST_COMPATIBILITY_CASE("different use attribute filter", use_attribute_filter, true, false, false)
-TEST_COMPATIBILITY_CASE("different support duplicate", support_duplicate, true, false, false)
-TEST_COMPATIBILITY_CASE("different label remap type", label_remap_type, "pg", "robin", false)
+    TEST_COMPATIBILITY_CASE(
+        "different base codes io type", base_codes_io_type, "memory_io", "block_memory_io", true)
+    TEST_COMPATIBILITY_CASE("different pq dim", base_codes_pq_dim, 8, 16, false)
+    TEST_COMPATIBILITY_CASE("different base codes quantization type",
+                            base_codes_quantization_type,
+                            "sq4",
+                            "sq8",
+                            false)
+    TEST_COMPATIBILITY_CASE("different graph type", graph_storage_type, "flat", "compressed", false)
+    TEST_COMPATIBILITY_CASE("different max degree", max_degree, 26, 30, false)
+    TEST_COMPATIBILITY_CASE("different support remove", support_remove, true, false, false)
+    TEST_COMPATIBILITY_CASE("different remove flag bit", remove_flag_bit, 8, 16, false)
+    TEST_COMPATIBILITY_CASE("different use reorder", use_reorder, true, false, false)
+    TEST_COMPATIBILITY_CASE("different precise codes io type",
+                            precise_codes_io_type,
+                            "memory_io",
+                            "block_memory_io",
+                            true)
+    TEST_COMPATIBILITY_CASE("different precise codes quantization type",
+                            precise_codes_quantization_type,
+                            "fp32",
+                            "sq8",
+                            false)
+    TEST_COMPATIBILITY_CASE(
+        "different use attribute filter", use_attribute_filter, true, false, false)
+    TEST_COMPATIBILITY_CASE("different support duplicate", support_duplicate, true, false, false)
+    TEST_COMPATIBILITY_CASE("different duplicate distance threshold",
+                            duplicate_distance_threshold,
+                            0.0F,
+                            0.1F,
+                            false)
+    TEST_COMPATIBILITY_CASE("different label remap type", label_remap_type, "pg", "robin", false)
+}
+// clang-format on
+
+TEST_CASE("HGraph maps support_duplicate to graph parameter", "[ut][HGraphParameter]") {
+    auto param = vsag::JsonType::Parse(R"({
+        "base_quantization_type": "fp32",
+        "base_io_type": "block_memory_io",
+        "precise_quantization_type": "fp32",
+        "precise_io_type": "block_memory_io",
+        "graph_io_type": "block_memory_io",
+        "graph_storage_type": "flat",
+        "graph_type": "nsw",
+        "max_degree": 32,
+        "ef_construction": 100,
+        "support_duplicate": true,
+        "duplicate_distance_threshold": 0.25,
+        "use_reorder": true
+    })");
+
+    vsag::IndexCommonParam common_param;
+    common_param.dim_ = 128;
+    common_param.data_type_ = vsag::DataTypes::DATA_TYPE_FLOAT;
+    auto hgraph_param = vsag::HGraph::CheckAndMappingExternalParam(param, common_param);
+    auto typed_param = std::dynamic_pointer_cast<vsag::HGraphParameter>(hgraph_param);
+
+    REQUIRE(typed_param != nullptr);
+    REQUIRE(typed_param->support_duplicate);
+    REQUIRE(typed_param->duplicate_distance_threshold == 0.25F);
 }
 
 TEST_CASE("HGraph maps label_remap_type to inner index parameter", "[ut][HGraphParameter]") {
@@ -182,6 +226,5 @@ TEST_CASE("HGraph maps label_remap_type to inner index parameter", "[ut][HGraphP
     auto typed_param = std::dynamic_pointer_cast<vsag::HGraphParameter>(hgraph_param);
 
     REQUIRE(typed_param != nullptr);
-    REQUIRE(typed_param->bottom_graph_param != nullptr);
     REQUIRE(typed_param->label_remap_type == vsag::LabelRemapType::ROBIN);
 }

--- a/src/algorithm/pyramid.cpp
+++ b/src/algorithm/pyramid.cpp
@@ -765,6 +765,7 @@ Pyramid::add_one_point(const std::shared_ptr<IndexNode>& node,
         search_param.search_mode = KNN_SEARCH;
         if (label_table_->CompressDuplicateData()) {
             search_param.find_duplicate = true;
+            search_param.duplicate_query_id = inner_id;
         }
         auto codes = use_reorder_ ? precise_codes_ : base_codes_;
         bool update_entry_point;

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -166,6 +166,7 @@ const char* const HGRAPH_PARAMETER_EF_RUNTIME = "ef_search";
 const char* const HGRAPH_PARAMETER_HOPS_LIMIT = "hops_limit";
 const char* const HGRAPH_EXTRA_INFO_SIZE = "extra_info_size";
 const char* const HGRAPH_SUPPORT_DUPLICATE = "support_duplicate";
+const char* const HGRAPH_DUPLICATE_DISTANCE_THRESHOLD = "duplicate_distance_threshold";
 const char* const HGRAPH_SUPPORT_TOMBSTONE = "support_tomb_stone";
 const char* const HGRAPH_LABEL_REMAP_TYPE = "label_remap_type";
 const char* const HGRAPH_USE_EXTRA_INFO_FILTER = "use_extra_info_filter";

--- a/src/impl/inner_search_param.h
+++ b/src/impl/inner_search_param.h
@@ -58,7 +58,9 @@ public:
 
     // deal with duplicate ids
     mutable int64_t duplicate_id{-1};
+    InnerIdType duplicate_query_id{std::numeric_limits<InnerIdType>::max()};
     bool find_duplicate{false};
+    float duplicate_distance_threshold{0.0F};
 
     // use in search process with duplicate ids
     bool consider_duplicate{false};

--- a/src/impl/searcher/basic_searcher.cpp
+++ b/src/impl/searcher/basic_searcher.cpp
@@ -16,6 +16,7 @@
 #include "basic_searcher.h"
 
 #include <atomic>
+#include <chrono>
 #include <limits>
 
 #include "algorithm/inner_index_interface.h"
@@ -449,7 +450,7 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
     }
 
     // set duplicate id for query vector
-    if (inner_search_param.find_duplicate) {
+    if (inner_search_param.find_duplicate and not top_candidates->Empty()) {
         const auto* data = top_candidates->GetData();
         auto min_distance = data[0].first;
         auto min_index = data[0].second;
@@ -459,15 +460,13 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
                 min_index = data[i].second;
             }
         }
-        bool need_release;
-        const auto* codes = flatten->GetCodesById(min_index, need_release);
-        Vector<uint8_t> encoded_query(flatten->code_size_, allocator_);
-        flatten->Encode(static_cast<const float*>(query), encoded_query.data());
-        if (std::memcmp(codes, encoded_query.data(), flatten->code_size_) == 0) {
+        if (inner_search_param.duplicate_distance_threshold > 0.0F) {
+            if (min_distance <= inner_search_param.duplicate_distance_threshold) {
+                inner_search_param.duplicate_id = min_index;
+            }
+        } else if (inner_search_param.duplicate_query_id < flatten->TotalCount() &&
+                   flatten->CompareVectors(inner_search_param.duplicate_query_id, min_index)) {
             inner_search_param.duplicate_id = min_index;
-        }
-        if (need_release) {
-            flatten->Release(codes);
         }
     }
 

--- a/src/impl/searcher/basic_searcher_test.cpp
+++ b/src/impl/searcher/basic_searcher_test.cpp
@@ -15,6 +15,8 @@
 
 #include "basic_searcher.h"
 
+#include <vector>
+
 #include "algorithm/inner_index_interface.h"
 #include "datacell/flatten_interface.h"
 #include "searcher_test.h"
@@ -321,4 +323,67 @@ TEST_CASE("Optimize SQ4", "[ut][BasicOptimizer]") {
     optimizer_searcher->RegisterParameter(RuntimeParameter(PREFETCH_STRIDE_VISIT, 1, 3, 1));
     float end2end_improvement = optimizer_searcher->Optimize(searcher);
     auto loss_after = searcher->MockRun(stats);
+}
+
+TEST_CASE("BasicSearcher duplicate threshold keeps nearest owner",
+          "[ut][BasicSearcher][duplicate]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    IndexCommonParam common;
+    common.dim_ = 2;
+    common.allocator_ = allocator;
+    common.metric_ = vsag::MetricType::METRIC_TYPE_L2SQR;
+
+    constexpr const char* param_temp = R"({{"type": "{}"}})";
+    auto quantizer_param = QuantizerParameter::GetQuantizerParameterByJson(
+        JsonType::Parse(fmt::format(param_temp, "fp32")));
+    auto io_param =
+        IOParameter::GetIOParameterByJson(JsonType::Parse(fmt::format(param_temp, "memory_io")));
+
+    auto vector_data_cell = std::make_shared<
+        FlattenDataCell<FP32Quantizer<vsag::MetricType::METRIC_TYPE_L2SQR>, MemoryIO>>(
+        quantizer_param, io_param, common);
+    vector_data_cell->SetQuantizer(
+        std::make_shared<FP32Quantizer<vsag::MetricType::METRIC_TYPE_L2SQR>>(2, allocator.get()));
+    vector_data_cell->SetIO(std::make_unique<MemoryIO>(allocator.get()));
+
+    std::vector<float> base_vectors = {0.0F, 0.0F, 0.3F, 0.0F};
+    std::vector<InnerIdType> ids = {0, 1};
+    vector_data_cell->Train(base_vectors.data(), ids.size());
+    vector_data_cell->BatchInsertVector(base_vectors.data(), ids.size(), ids.data());
+
+    auto graph_data_cell =
+        std::make_shared<MockGraphDataCell>(std::vector<std::vector<InnerIdType>>{{1}, {0}});
+    auto pool = std::make_shared<VisitedListPool>(
+        1, allocator.get(), vector_data_cell->TotalCount(), allocator.get());
+    auto searcher = std::make_shared<BasicSearcher>(common);
+
+    auto run_search = [&](const std::vector<float>& query,
+                          float threshold,
+                          InnerIdType duplicate_query_id =
+                              std::numeric_limits<InnerIdType>::max()) {
+        InnerSearchParam search_param;
+        search_param.ep = 0;
+        search_param.ef = 2;
+        search_param.topk = 2;
+        search_param.find_duplicate = true;
+        search_param.duplicate_query_id = duplicate_query_id;
+        search_param.duplicate_distance_threshold = threshold;
+        auto vl = pool->TakeOne();
+        QueryContext* ctx = nullptr;
+        auto result = searcher->Search(graph_data_cell,
+                                       vector_data_cell,
+                                       vl,
+                                       query.data(),
+                                       search_param,
+                                       LabelTablePtr{},
+                                       ctx);
+        REQUIRE(result->Size() == 2);
+        pool->ReturnOne(vl);
+        return search_param.duplicate_id;
+    };
+
+    REQUIRE(run_search({0.12F, 0.0F}, 0.01F) == -1);
+    REQUIRE(run_search({0.12F, 0.0F}, 0.02F) == 0);
+    REQUIRE(run_search({0.3F, 0.0F}, 0.0F, 1) == 1);
+    REQUIRE(run_search({0.12F, 0.0F}, 0.0F) == -1);
 }

--- a/src/impl/searcher/searcher_test.h
+++ b/src/impl/searcher/searcher_test.h
@@ -15,8 +15,10 @@
 
 #pragma once
 
+#include <algorithm>
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
+#include <utility>
 
 #include "algorithm/hnswlib/hnswalg.h"
 #include "algorithm/hnswlib/space_l2.h"
@@ -31,6 +33,52 @@
 #include "utils/visited_list.h"
 
 namespace vsag {
+
+class MockGraphDataCell : public GraphInterface {
+public:
+    explicit MockGraphDataCell(std::vector<std::vector<InnerIdType>> neighbors)
+        : neighbors_(std::move(neighbors)) {
+        total_count_ = static_cast<InnerIdType>(neighbors_.size());
+        max_capacity_ = static_cast<InnerIdType>(neighbors_.size());
+        maximum_degree_ = 0;
+        for (const auto& ids : neighbors_) {
+            maximum_degree_ = std::max<uint32_t>(maximum_degree_, ids.size());
+        }
+    }
+
+    void
+    InsertNeighborsById(InnerIdType id, const Vector<InnerIdType>& neighbor_ids) override {
+        neighbors_[id].assign(neighbor_ids.begin(), neighbor_ids.end());
+        maximum_degree_ = std::max<uint32_t>(maximum_degree_, neighbor_ids.size());
+    }
+
+    void
+    Resize(InnerIdType new_size) override {
+        neighbors_.resize(new_size);
+        total_count_ = new_size;
+        max_capacity_ = new_size;
+    }
+
+    void
+    GetNeighbors(InnerIdType id, Vector<InnerIdType>& neighbor_ids) const override {
+        neighbor_ids.assign(neighbors_[id].begin(), neighbors_[id].end());
+    }
+
+    uint32_t
+    GetNeighborSize(InnerIdType id) const override {
+        return static_cast<uint32_t>(neighbors_[id].size());
+    }
+
+    void
+    Prefetch(InnerIdType id, uint32_t neighbor_i) override {
+        if (neighbor_i < neighbors_[id].size()) {
+            vsag::Prefetch(neighbors_[id].data() + neighbor_i);
+        }
+    }
+
+private:
+    std::vector<std::vector<InnerIdType>> neighbors_;
+};
 
 class AdaptGraphDataCell : public GraphInterface {
 public:

--- a/src/inner_string_params.h
+++ b/src/inner_string_params.h
@@ -162,6 +162,7 @@ const char* const GRAPH_SUPPORT_REMOVE = "support_remove";
 const char* const REMOVE_FLAG_BIT = "remove_flag_bit";
 const char* const HOLD_MOLDS = "hold_molds";
 const char* const SUPPORT_DUPLICATE = "support_duplicate";
+const char* const DUPLICATE_DISTANCE_THRESHOLD = "duplicate_distance_threshold";
 const char* const SUPPORT_TOMBSTONE = "support_tombstone";
 const char* const SUPPORT_AUTOTUNE = "support_autotune";
 
@@ -192,6 +193,7 @@ const std::unordered_map<std::string, std::string> DEFAULT_MAP = {
     {"BASE_CODES_KEY", BASE_CODES_KEY},
     {"PRECISE_CODES_KEY", PRECISE_CODES_KEY},
     {"HGRAPH_SUPPORT_DUPLICATE", HGRAPH_SUPPORT_DUPLICATE},
+    {"HGRAPH_DUPLICATE_DISTANCE_THRESHOLD", HGRAPH_DUPLICATE_DISTANCE_THRESHOLD},
     {"HGRAPH_LABEL_REMAP_TYPE", HGRAPH_LABEL_REMAP_TYPE},
     {"IO_TYPE_VALUE_MEMORY_IO", IO_TYPE_VALUE_MEMORY_IO},
     {"IO_TYPE_VALUE_BLOCK_MEMORY_IO", IO_TYPE_VALUE_BLOCK_MEMORY_IO},


### PR DESCRIPTION
## Summary
- backport HGraph duplicate distance threshold support to the 0.18 branch
- keep duplicate ownership on the nearest candidate with the Searcher-side zero-threshold fallback fix
- backport the related HGraph parameter tests, BasicSearcher duplicate test, and in-repo HGraph docs update

## Testing
- make fmt
- cmake --build ./build --parallel 6 --target unittests
- ./build/tests/unittests -d yes '[ut][HGraphParameter]' --allow-running-no-tests
- ./build/tests/unittests -d yes '[ut][BasicSearcher][duplicate]' --allow-running-no-tests