### PR TITLE
docs: add Quantization chapter with per-quantizer reference pages

### DIFF
--- a/docs/docs/en/src/SUMMARY.md
+++ b/docs/docs/en/src/SUMMARY.md
@@ -19,6 +19,18 @@
 - [Pyramid](indexes/pyramid.md)
 - [BruteForce](indexes/brute_force.md)
 
+# Quantization
+
+- [Overview](quantization/README.md)
+- [FP32 (Baseline)](quantization/fp32.md)
+- [Half-Precision (FP16 / BF16)](quantization/fp16_bf16.md)
+- [Scalar Quantization (SQ4 / SQ8)](quantization/sq.md)
+- [Scalar Uniform (SQ4 / SQ8 Uniform)](quantization/sq_uniform.md)
+- [Product Quantization (PQ)](quantization/pq.md)
+- [PQ FastScan](quantization/pqfs.md)
+- [RaBitQ](quantization/rabitq.md)
+- [Transform Quantizer (TQ)](advanced/quantization_transform.md)
+
 # Developer Guide
 
 - [Code Structure](development/code_structure.md)
@@ -42,7 +54,6 @@
 - [Hybrid Memory-Disk Index](advanced/hybrid_index.md)
 - [Extra Info](advanced/extra_info.md)
 - [Index Lifecycle Management](advanced/index_lifecycle.md)
-- [Quantization Transform](advanced/quantization_transform.md)
 
 # Performance and Tuning
 

--- a/docs/docs/en/src/figures/quantization/fp-bitlayout.svg
+++ b/docs/docs/en/src/figures/quantization/fp-bitlayout.svg
@@ -1,0 +1,58 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 300" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="13">
+  <title>fp32 vs fp16 vs bf16: IEEE 754 field widths</title>
+  <desc>Bit-level layout comparison of the three floating-point quantizers VSAG uses for storage: fp32 has 1 sign + 8 exponent + 23 mantissa bits, fp16 has 1 + 5 + 10, bf16 has 1 + 8 + 7.</desc>
+  <style>
+    .sign { fill: #3e3a39; stroke: #1a1614; stroke-width: 0.8; }
+    .exp  { fill: #f4bd37; stroke: #b88a16; stroke-width: 0.8; }
+    .mant { fill: #fce897; stroke: #b88a16; stroke-width: 0.8; }
+    .lbl { fill: #1a1614; }
+    .lbl-muted { fill: #6e6a66; }
+    .lbl-light { fill: #ffffff; }
+  </style>
+
+  <text class="lbl" x="20" y="24">IEEE 754 / bf16 field widths</text>
+
+  <!-- legend -->
+  <g transform="translate(440,12)">
+    <rect class="sign" x="0" y="0" width="14" height="14"/><text class="lbl-muted" x="20" y="12">sign</text>
+    <rect class="exp"  x="70" y="0" width="14" height="14"/><text class="lbl-muted" x="90" y="12">exponent</text>
+    <rect class="mant" x="170" y="0" width="14" height="14"/><text class="lbl-muted" x="190" y="12">mantissa</text>
+  </g>
+
+  <!-- scale: 1 bit = 18 px for exp+mant; sign block widened to 28 px for legibility -->
+  <!-- fp32 row -->
+  <g transform="translate(60,60)">
+    <text class="lbl" x="-50" y="22" font-weight="700">fp32</text>
+    <rect class="sign" x="0"   y="0" width="28" height="34"/>
+    <rect class="exp"  x="28"  y="0" width="144" height="34"/>
+    <rect class="mant" x="172" y="0" width="414" height="34"/>
+    <text class="lbl-light" x="10" y="22">s</text>
+    <text class="lbl" x="74" y="22">8 bits</text>
+    <text class="lbl" x="324" y="22">23 bits</text>
+    <text class="lbl-muted" x="-20" y="52">range &#x00B1;3.4&#xD7;10&#x00B3;&#x2078;  &#xB7;  precision &#x2248; 7 decimal digits  &#xB7;  4 bytes</text>
+  </g>
+
+  <!-- fp16 row -->
+  <g transform="translate(60,140)">
+    <text class="lbl" x="-50" y="22" font-weight="700">fp16</text>
+    <rect class="sign" x="0"   y="0" width="28" height="34"/>
+    <rect class="exp"  x="28"  y="0" width="90" height="34"/>
+    <rect class="mant" x="118" y="0" width="180" height="34"/>
+    <text class="lbl-light" x="10" y="22">s</text>
+    <text class="lbl" x="40" y="22">5 bits</text>
+    <text class="lbl" x="170" y="22">10 bits</text>
+    <text class="lbl-muted" x="-20" y="52">range &#x00B1;6.5&#xD7;10&#x2074;  &#xB7;  precision &#x2248; 3 decimal digits  &#xB7;  2 bytes</text>
+  </g>
+
+  <!-- bf16 row -->
+  <g transform="translate(60,220)">
+    <text class="lbl" x="-50" y="22" font-weight="700">bf16</text>
+    <rect class="sign" x="0"   y="0" width="28" height="34"/>
+    <rect class="exp"  x="28"  y="0" width="144" height="34"/>
+    <rect class="mant" x="172" y="0" width="126" height="34"/>
+    <text class="lbl-light" x="10" y="22">s</text>
+    <text class="lbl" x="74" y="22">8 bits</text>
+    <text class="lbl" x="200" y="22">7 bits</text>
+    <text class="lbl-muted" x="-20" y="52">range &#x00B1;3.4&#xD7;10&#x00B3;&#x2078;  &#xB7;  precision &#x2248; 2-3 decimal digits  &#xB7;  2 bytes</text>
+  </g>
+</svg>

--- a/docs/docs/en/src/figures/quantization/pq-codebook.svg
+++ b/docs/docs/en/src/figures/quantization/pq-codebook.svg
@@ -1,0 +1,134 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 280" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="13">
+  <title>Product Quantization: sub-vector split and codebook lookup</title>
+  <desc>A vector of dim D is split into M sub-vectors. Each sub-vector is mapped to the nearest centroid in a per-sub-space codebook of 2^nbits entries, producing M code IDs.</desc>
+  <style>
+    .vec { fill: #fff7d6; stroke: #f4bd37; stroke-width: 1.2; }
+    .sub { fill: #fce897; stroke: #b88a16; stroke-width: 1; }
+    .cb { fill: #fafafa; stroke: #3e3a39; stroke-width: 1; }
+    .row { fill: #ffffff; stroke: #cfcbc7; stroke-width: 0.8; }
+    .row-hit { fill: #fce897; stroke: #b88a16; stroke-width: 1.2; }
+    .lbl { fill: #1a1614; }
+    .lbl-muted { fill: #6e6a66; }
+    .arr { stroke: #3e3a39; stroke-width: 1.2; fill: none; }
+    .code { fill: #3e3a39; stroke: none; }
+  </style>
+
+  <!-- Top: original vector x of dim D -->
+  <text class="lbl" x="20" y="28">x &#x2208; &#8477;&#x1D49;  (D = M &#xB7; d&#x209B;)</text>
+  <g>
+    <rect class="vec" x="20" y="38" width="320" height="28" rx="3"/>
+    <!-- M=4 split markers -->
+    <line class="arr" x1="100" y1="38" x2="100" y2="66"/>
+    <line class="arr" x1="180" y1="38" x2="180" y2="66"/>
+    <line class="arr" x1="260" y1="38" x2="260" y2="66"/>
+    <text class="lbl-muted" x="50" y="57">x&#x2081;</text>
+    <text class="lbl-muted" x="130" y="57">x&#x2082;</text>
+    <text class="lbl-muted" x="210" y="57">x&#x2083;</text>
+    <text class="lbl-muted" x="290" y="57">x&#x2098;</text>
+  </g>
+  <text class="lbl-muted" x="20" y="84">split into M sub-vectors of dim d&#x209B; = D/M</text>
+
+  <!-- Arrow down to codebooks -->
+  <path class="arr" d="M170 96 L170 120" marker-end="url(#arrow)"/>
+
+  <!-- Codebooks row -->
+  <g transform="translate(20,128)">
+    <!-- codebook 1 -->
+    <text class="lbl" x="0" y="0">codebook C&#x2081;</text>
+    <g>
+      <rect class="cb" x="0" y="8" width="70" height="120"/>
+      <rect class="row" x="0" y="8" width="70" height="20"/>
+      <rect class="row" x="0" y="28" width="70" height="20"/>
+      <rect class="row-hit" x="0" y="48" width="70" height="20"/>
+      <rect class="row" x="0" y="68" width="70" height="20"/>
+      <rect class="row" x="0" y="88" width="70" height="20"/>
+      <rect class="row" x="0" y="108" width="70" height="20"/>
+      <text class="lbl-muted" x="6" y="22">000</text>
+      <text class="lbl-muted" x="6" y="42">001</text>
+      <text class="code" x="6" y="62">010 &#x2190;</text>
+      <text class="lbl-muted" x="6" y="82">011</text>
+      <text class="lbl-muted" x="6" y="102">...</text>
+      <text class="lbl-muted" x="6" y="122">2&#x1D4F;&#x2212;1</text>
+    </g>
+
+    <!-- codebook 2 -->
+    <g transform="translate(110,0)">
+      <text class="lbl" x="0" y="0">codebook C&#x2082;</text>
+      <rect class="cb" x="0" y="8" width="70" height="120"/>
+      <rect class="row-hit" x="0" y="8" width="70" height="20"/>
+      <rect class="row" x="0" y="28" width="70" height="20"/>
+      <rect class="row" x="0" y="48" width="70" height="20"/>
+      <rect class="row" x="0" y="68" width="70" height="20"/>
+      <rect class="row" x="0" y="88" width="70" height="20"/>
+      <rect class="row" x="0" y="108" width="70" height="20"/>
+      <text class="code" x="6" y="22">000 &#x2190;</text>
+      <text class="lbl-muted" x="6" y="42">001</text>
+      <text class="lbl-muted" x="6" y="62">010</text>
+      <text class="lbl-muted" x="6" y="82">011</text>
+      <text class="lbl-muted" x="6" y="102">...</text>
+      <text class="lbl-muted" x="6" y="122">2&#x1D4F;&#x2212;1</text>
+    </g>
+
+    <!-- codebook 3 -->
+    <g transform="translate(220,0)">
+      <text class="lbl" x="0" y="0">codebook C&#x2083;</text>
+      <rect class="cb" x="0" y="8" width="70" height="120"/>
+      <rect class="row" x="0" y="8" width="70" height="20"/>
+      <rect class="row" x="0" y="28" width="70" height="20"/>
+      <rect class="row" x="0" y="48" width="70" height="20"/>
+      <rect class="row-hit" x="0" y="68" width="70" height="20"/>
+      <rect class="row" x="0" y="88" width="70" height="20"/>
+      <rect class="row" x="0" y="108" width="70" height="20"/>
+      <text class="lbl-muted" x="6" y="22">000</text>
+      <text class="lbl-muted" x="6" y="42">001</text>
+      <text class="lbl-muted" x="6" y="62">010</text>
+      <text class="code" x="6" y="82">011 &#x2190;</text>
+      <text class="lbl-muted" x="6" y="102">...</text>
+      <text class="lbl-muted" x="6" y="122">2&#x1D4F;&#x2212;1</text>
+    </g>
+
+    <!-- codebook M -->
+    <g transform="translate(330,0)">
+      <text class="lbl" x="0" y="0">codebook C&#x2098;</text>
+      <rect class="cb" x="0" y="8" width="70" height="120"/>
+      <rect class="row" x="0" y="8" width="70" height="20"/>
+      <rect class="row-hit" x="0" y="28" width="70" height="20"/>
+      <rect class="row" x="0" y="48" width="70" height="20"/>
+      <rect class="row" x="0" y="68" width="70" height="20"/>
+      <rect class="row" x="0" y="88" width="70" height="20"/>
+      <rect class="row" x="0" y="108" width="70" height="20"/>
+      <text class="lbl-muted" x="6" y="22">000</text>
+      <text class="code" x="6" y="42">001 &#x2190;</text>
+      <text class="lbl-muted" x="6" y="62">010</text>
+      <text class="lbl-muted" x="6" y="82">011</text>
+      <text class="lbl-muted" x="6" y="102">...</text>
+      <text class="lbl-muted" x="6" y="122">2&#x1D4F;&#x2212;1</text>
+    </g>
+
+    <!-- arrow right to output -->
+    <path class="arr" d="M410 70 L440 70" marker-end="url(#arrow)"/>
+
+    <!-- output codes -->
+    <g transform="translate(450,40)">
+      <text class="lbl" x="0" y="0">PQ code  (M &#xB7; nbits)</text>
+      <g>
+        <rect class="sub" x="0" y="8" width="50" height="28"/>
+        <rect class="sub" x="50" y="8" width="50" height="28"/>
+        <rect class="sub" x="100" y="8" width="50" height="28"/>
+        <rect class="sub" x="150" y="8" width="50" height="28"/>
+      </g>
+      <text class="code" x="14" y="27">010</text>
+      <text class="code" x="64" y="27">000</text>
+      <text class="code" x="114" y="27">011</text>
+      <text class="code" x="164" y="27">001</text>
+      <text class="lbl-muted" x="0" y="56">M &#xB7; nbits bits / vec</text>
+      <text class="lbl-muted" x="0" y="74">e.g. M=64, b=8 &#x2192; 64 B</text>
+    </g>
+  </g>
+
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#3e3a39"/>
+    </marker>
+  </defs>
+</svg>

--- a/docs/docs/en/src/figures/quantization/pqfs-block.svg
+++ b/docs/docs/en/src/figures/quantization/pqfs-block.svg
@@ -1,0 +1,126 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 380" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="13">
+  <title>PQ FastScan block layout and SIMD lookup</title>
+  <desc>FastScan stores 4-bit PQ codes for 16 vectors interleaved per sub-space so a single 128-bit SIMD register holds one column of 16 codes and a pshufb-style lookup decodes 16 partial distances in one instruction.</desc>
+  <style>
+    .blk { fill: #ffffff; stroke: #cfcbc7; stroke-width: 1; }
+    .cell { fill: #fce897; stroke: #b88a16; stroke-width: 0.8; }
+    .cell-col { fill: #f4bd37; stroke: #b88a16; stroke-width: 1.2; }
+    .lut { fill: #ffffff; stroke: #3e3a39; stroke-width: 1; }
+    .lut-cell { fill: #ffffff; stroke: #cfcbc7; }
+    .lbl { fill: #1a1614; }
+    .lbl-muted { fill: #6e6a66; }
+    .arr { stroke: #3e3a39; stroke-width: 1.2; fill: none; }
+  </style>
+  <defs>
+    <marker id="arr" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#3e3a39"/>
+    </marker>
+  </defs>
+
+  <text class="lbl" x="20" y="24">FastScan block &#x2014; 16 vectors &#xD7; M sub-spaces, 4-bit codes interleaved</text>
+
+  <!-- block of 16x8 cells (M=8 shown) -->
+  <g transform="translate(40,50)">
+    <rect class="blk" x="-4" y="-4" width="408" height="248"/>
+    <text class="lbl-muted" x="-30" y="14">v&#x2080;</text>
+    <text class="lbl-muted" x="-30" y="29">v&#x2081;</text>
+    <text class="lbl-muted" x="-30" y="44">v&#x2082;</text>
+    <text class="lbl-muted" x="-30" y="59">...</text>
+    <text class="lbl-muted" x="-30" y="224">v&#x2081;&#x2085;</text>
+
+    <text class="lbl-muted" x="0" y="-12">m=0</text>
+    <text class="lbl-muted" x="50" y="-12">m=1</text>
+    <text class="lbl-muted" x="100" y="-12">m=2</text>
+    <text class="lbl-muted" x="150" y="-12">m=3</text>
+    <text class="lbl-muted" x="350" y="-12">m=M&#x2212;1</text>
+
+    <!-- grid: 8 cols x 16 rows -->
+    <g>
+      <!-- column m=2 highlighted -->
+      <g>
+        <rect class="cell-col" x="100" y="0" width="50" height="240"/>
+      </g>
+      <!-- cells filling -->
+      <g fill="#fce897" stroke="#b88a16" stroke-width="0.6">
+        <!-- 16 rows x 8 cols -->
+        <g transform="translate(0,0)">
+          <rect class="cell" x="0"   y="0" width="50" height="15"/>
+          <rect class="cell" x="50"  y="0" width="50" height="15"/>
+          <rect class="cell-col" x="100" y="0" width="50" height="15"/>
+          <rect class="cell" x="150" y="0" width="50" height="15"/>
+          <rect class="cell" x="200" y="0" width="50" height="15"/>
+          <rect class="cell" x="250" y="0" width="50" height="15"/>
+          <rect class="cell" x="300" y="0" width="50" height="15"/>
+          <rect class="cell" x="350" y="0" width="50" height="15"/>
+        </g>
+        <g transform="translate(0,15)">
+          <rect class="cell" x="0"   y="0" width="50" height="15"/>
+          <rect class="cell" x="50"  y="0" width="50" height="15"/>
+          <rect class="cell-col" x="100" y="0" width="50" height="15"/>
+          <rect class="cell" x="150" y="0" width="50" height="15"/>
+          <rect class="cell" x="200" y="0" width="50" height="15"/>
+          <rect class="cell" x="250" y="0" width="50" height="15"/>
+          <rect class="cell" x="300" y="0" width="50" height="15"/>
+          <rect class="cell" x="350" y="0" width="50" height="15"/>
+        </g>
+        <g transform="translate(0,30)">
+          <rect class="cell" x="0"   y="0" width="50" height="15"/>
+          <rect class="cell" x="50"  y="0" width="50" height="15"/>
+          <rect class="cell-col" x="100" y="0" width="50" height="15"/>
+          <rect class="cell" x="150" y="0" width="50" height="15"/>
+          <rect class="cell" x="200" y="0" width="50" height="15"/>
+          <rect class="cell" x="250" y="0" width="50" height="15"/>
+          <rect class="cell" x="300" y="0" width="50" height="15"/>
+          <rect class="cell" x="350" y="0" width="50" height="15"/>
+        </g>
+        <g transform="translate(0,45)" opacity="0.55">
+          <rect class="cell" x="0"   y="0" width="50" height="15"/>
+          <rect class="cell" x="50"  y="0" width="50" height="15"/>
+          <rect class="cell-col" x="100" y="0" width="50" height="15"/>
+          <rect class="cell" x="150" y="0" width="50" height="15"/>
+          <rect class="cell" x="200" y="0" width="50" height="15"/>
+          <rect class="cell" x="250" y="0" width="50" height="15"/>
+          <rect class="cell" x="300" y="0" width="50" height="15"/>
+          <rect class="cell" x="350" y="0" width="50" height="15"/>
+        </g>
+        <!-- skip middle rows visually -->
+        <g transform="translate(0,225)">
+          <rect class="cell" x="0"   y="0" width="50" height="15"/>
+          <rect class="cell" x="50"  y="0" width="50" height="15"/>
+          <rect class="cell-col" x="100" y="0" width="50" height="15"/>
+          <rect class="cell" x="150" y="0" width="50" height="15"/>
+          <rect class="cell" x="200" y="0" width="50" height="15"/>
+          <rect class="cell" x="250" y="0" width="50" height="15"/>
+          <rect class="cell" x="300" y="0" width="50" height="15"/>
+          <rect class="cell" x="350" y="0" width="50" height="15"/>
+        </g>
+      </g>
+      <text class="lbl-muted" x="180" y="130">&#x22EE; &#x22EE; &#x22EE; &#x22EE;</text>
+    </g>
+
+    <!-- one column annotated as a SIMD register -->
+    <text class="lbl" x="160" y="270">column m=2: 16 codes &#xD7; 4 bits = 64 bits</text>
+    <text class="lbl-muted" x="160" y="288">(half a 128-bit SIMD register)</text>
+  </g>
+
+  <!-- arrow to LUT -->
+  <path class="arr" d="M455 170 L515 170" marker-end="url(#arr)"/>
+  <text class="lbl" x="465" y="158">pshufb</text>
+
+  <!-- LUT 16 entries -->
+  <g transform="translate(525,50)">
+    <text class="lbl" x="0" y="14">LUT (per query, per m)</text>
+    <rect class="lut" x="0" y="22" width="80" height="240"/>
+    <g font-size="11" fill="#3e3a39">
+      <rect class="lut-cell" x="0" y="22" width="80" height="15"/><text x="6" y="33">d&#x2080;</text>
+      <rect class="lut-cell" x="0" y="37" width="80" height="15"/><text x="6" y="48">d&#x2081;</text>
+      <rect class="lut-cell" x="0" y="52" width="80" height="15"/><text x="6" y="63">d&#x2082;</text>
+      <rect class="lut-cell" x="0" y="67" width="80" height="15"/><text x="6" y="78">d&#x2083;</text>
+      <rect class="lut-cell" x="0" y="82" width="80" height="15"/><text x="6" y="93">...</text>
+      <rect class="lut-cell" x="0" y="247" width="80" height="15"/><text x="6" y="258">d&#x2081;&#x2085;</text>
+    </g>
+    <text class="lbl-muted" x="0" y="282">2&#x2074; = 16 entries</text>
+    <text class="lbl-muted" x="0" y="298">one shuffle &#x2192;</text>
+    <text class="lbl-muted" x="0" y="314">16 partial dists</text>
+  </g>
+</svg>

--- a/docs/docs/en/src/figures/quantization/quantization-overview.svg
+++ b/docs/docs/en/src/figures/quantization/quantization-overview.svg
@@ -1,0 +1,118 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 480" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="13">
+  <title>Quantizer selection decision tree</title>
+  <desc>Decision tree that helps pick a base quantizer in VSAG based on memory budget, vector dimension and reorder needs.</desc>
+  <style>
+    .node { fill: #fff7d6; stroke: #b88a16; stroke-width: 1.2; }
+    .leaf { fill: #f4bd37; stroke: #b88a16; stroke-width: 1.4; }
+    .leaf-dark { fill: #3e3a39; stroke: #1a1614; stroke-width: 1.4; }
+    .branch { stroke: #3e3a39; stroke-width: 1.2; fill: none; }
+    .lbl { fill: #1a1614; }
+    .lbl-light { fill: #ffffff; }
+    .lbl-muted { fill: #6e6a66; }
+  </style>
+
+  <text class="lbl" x="20" y="24">Picking a base quantizer</text>
+
+  <!-- root -->
+  <g transform="translate(280,50)">
+    <rect class="node" x="0" y="0" width="160" height="46" rx="6"/>
+    <text class="lbl" x="14" y="20">memory budget?</text>
+    <text class="lbl-muted" x="14" y="38">(vs accuracy)</text>
+  </g>
+
+  <!-- branches from root -->
+  <path class="branch" d="M320 96 L130 150"/>
+  <path class="branch" d="M360 96 L360 150"/>
+  <path class="branch" d="M400 96 L590 150"/>
+
+  <!-- branch labels -->
+  <text class="lbl-muted" x="170" y="125">strict</text>
+  <text class="lbl-muted" x="340" y="125">balanced</text>
+  <text class="lbl-muted" x="540" y="125">loose</text>
+
+  <!-- level 2: three boxes -->
+  <!-- strict: high compression -->
+  <g transform="translate(30,150)">
+    <rect class="node" x="0" y="0" width="200" height="46" rx="6"/>
+    <text class="lbl" x="14" y="20">need ~64&#xD7; compression?</text>
+    <text class="lbl-muted" x="14" y="38">dim &#x2265; 128 typical</text>
+  </g>
+  <!-- balanced -->
+  <g transform="translate(260,150)">
+    <rect class="node" x="0" y="0" width="200" height="46" rx="6"/>
+    <text class="lbl" x="14" y="20">8 bytes per coord ok?</text>
+    <text class="lbl-muted" x="14" y="38">4&#xD7; vs fp32</text>
+  </g>
+  <!-- loose -->
+  <g transform="translate(490,150)">
+    <rect class="node" x="0" y="0" width="200" height="46" rx="6"/>
+    <text class="lbl" x="14" y="20">need exact distances?</text>
+    <text class="lbl-muted" x="14" y="38">training data?</text>
+  </g>
+
+  <!-- branches from strict -->
+  <path class="branch" d="M97  196 L70  250"/>
+  <path class="branch" d="M163 196 L195 250"/>
+  <text class="lbl-muted" x="55"  y="222">yes</text>
+  <text class="lbl-muted" x="175" y="222">no</text>
+
+  <!-- branches from balanced -->
+  <path class="branch" d="M327 196 L345 250"/>
+  <path class="branch" d="M393 196 L515 250"/>
+  <text class="lbl-muted" x="310" y="222">yes</text>
+  <text class="lbl-muted" x="405" y="222">no</text>
+
+  <!-- branches from loose -->
+  <path class="branch" d="M557 196 L515 250"/>
+  <path class="branch" d="M623 196 L650 250"/>
+  <text class="lbl-muted" x="540" y="222">no</text>
+  <text class="lbl-muted" x="635" y="222">yes</text>
+
+  <!-- leaves -->
+  <g transform="translate(20,250)">
+    <!-- rabitq -->
+    <g transform="translate(0,0)">
+      <rect class="leaf" x="0" y="0" width="100" height="40" rx="6"/>
+      <text class="lbl" x="14" y="18">rabitq</text>
+      <text class="lbl-muted" x="14" y="34">~1 bit/dim</text>
+    </g>
+    <!-- pq / pqfs -->
+    <g transform="translate(120,0)">
+      <rect class="leaf" x="0" y="0" width="110" height="40" rx="6"/>
+      <text class="lbl" x="14" y="18">pq / pqfs</text>
+      <text class="lbl-muted" x="14" y="34">4-8 b/dim</text>
+    </g>
+    <!-- sq family -->
+    <g transform="translate(240,0)">
+      <rect class="leaf" x="0" y="0" width="170" height="40" rx="6"/>
+      <text class="lbl" x="14" y="18">sq* family</text>
+      <text class="lbl-muted" x="14" y="34">4-8 b/dim</text>
+    </g>
+    <!-- fp16 / bf16 -->
+    <g transform="translate(430,0)">
+      <rect class="leaf" x="0" y="0" width="130" height="40" rx="6"/>
+      <text class="lbl" x="14" y="18">fp16 / bf16</text>
+      <text class="lbl-muted" x="14" y="34">16 b/dim</text>
+    </g>
+    <!-- fp32 -->
+    <g transform="translate(580,0)">
+      <rect class="leaf-dark" x="0" y="0" width="100" height="40" rx="6"/>
+      <text class="lbl-light" x="14" y="18">fp32</text>
+      <text class="lbl-light" x="14" y="34">no loss</text>
+    </g>
+  </g>
+
+  <!-- reorder hint band -->
+  <g transform="translate(40,330)">
+    <rect class="node" x="0" y="0" width="660" height="50" rx="6"/>
+    <text class="lbl" x="14" y="20">tight memory + good recall?  pair a small base quantizer with</text>
+    <text class="lbl" x="14" y="38">use_reorder=true and precise_quantization_type=&quot;fp16&quot; or &quot;fp32&quot;</text>
+  </g>
+
+  <!-- bottom row of caveats -->
+  <g transform="translate(40,400)">
+    <text class="lbl-muted" x="0" y="14">&#x2022; pq / pqfs need training: sample &#x2265; 256 &#xB7; 2^pq_bits per sub-space</text>
+    <text class="lbl-muted" x="0" y="32">&#x2022; sq*_uniform fit one global [min, max] (smaller meta, less robust)</text>
+    <text class="lbl-muted" x="0" y="50">&#x2022; rabitq + reorder is the standard recipe for recall-critical search</text>
+  </g>
+</svg>

--- a/docs/docs/en/src/figures/quantization/rabitq-hyperplane.svg
+++ b/docs/docs/en/src/figures/quantization/rabitq-hyperplane.svg
@@ -1,0 +1,91 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 340" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="13">
+  <title>RaBitQ: 1-bit signed code via random hyperplane</title>
+  <desc>RaBitQ normalises each vector, then encodes each dimension by the sign of its inner product against a random orthonormal basis. The stored code is one bit per dim plus a small per-vector residual norm; reorder against a precise copy recovers full recall.</desc>
+  <style>
+    .sphere { fill: #fff7d6; stroke: #b88a16; stroke-width: 1.2; }
+    .axis { stroke: #cfcbc7; stroke-width: 1; }
+    .hp { stroke: #3e3a39; stroke-width: 1.5; stroke-dasharray: 6 4; }
+    .pt-plus { fill: #f4bd37; stroke: #b88a16; stroke-width: 1; }
+    .pt-minus { fill: #3e3a39; stroke: #1a1614; stroke-width: 1; }
+    .lbl { fill: #1a1614; }
+    .lbl-muted { fill: #6e6a66; }
+    .arr { stroke: #3e3a39; stroke-width: 1.2; fill: none; }
+    .codebox { fill: #fce897; stroke: #b88a16; stroke-width: 1; }
+  </style>
+  <defs>
+    <marker id="arr" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#3e3a39"/>
+    </marker>
+  </defs>
+
+  <text class="lbl" x="20" y="24">RaBitQ &#x2014; sign(&#x27E8;x, p&#x1D62;&#x27E9;) gives one bit per dim</text>
+
+  <!-- sphere with hyperplane -->
+  <g transform="translate(160,180)">
+    <circle class="sphere" cx="0" cy="0" r="110"/>
+    <line class="axis" x1="-110" y1="0" x2="110" y2="0"/>
+    <line class="axis" x1="0" y1="-110" x2="0" y2="110"/>
+    <!-- hyperplane perpendicular to p_i (direction ~ (cos30, sin30)) -->
+    <line class="hp" x1="-100" y1="-58" x2="100" y2="58"/>
+    <text class="lbl-muted" x="78" y="62">p&#x1D62;</text>
+    <!-- arrow showing p_i direction -->
+    <line class="arr" x1="0" y1="0" x2="60" y2="-35" marker-end="url(#arr)"/>
+
+    <!-- + side points -->
+    <circle class="pt-plus" cx="55" cy="-65" r="5"/>
+    <circle class="pt-plus" cx="85" cy="-15" r="5"/>
+    <circle class="pt-plus" cx="35" cy="-40" r="5"/>
+    <circle class="pt-plus" cx="70" cy="-90" r="5"/>
+    <circle class="pt-plus" cx="20" cy="-95" r="5"/>
+
+    <!-- - side points -->
+    <circle class="pt-minus" cx="-50" cy="40" r="5"/>
+    <circle class="pt-minus" cx="-85" cy="10" r="5"/>
+    <circle class="pt-minus" cx="-30" cy="65" r="5"/>
+    <circle class="pt-minus" cx="-70" cy="-15" r="5"/>
+    <circle class="pt-minus" cx="-15" cy="85" r="5"/>
+
+    <text class="lbl" x="75" y="-95">b&#x1D62; = 1</text>
+    <text class="lbl" x="-100" y="100">b&#x1D62; = 0</text>
+  </g>
+
+  <!-- arrow to bit string -->
+  <path class="arr" d="M310 180 L370 180" marker-end="url(#arr)"/>
+
+  <!-- right side: bit string + reorder -->
+  <g transform="translate(385,80)">
+    <text class="lbl" x="0" y="0">stored code per vector</text>
+    <g>
+      <rect class="codebox" x="0" y="12" width="22" height="22"/>
+      <rect class="codebox" x="22" y="12" width="22" height="22"/>
+      <rect class="codebox" x="44" y="12" width="22" height="22"/>
+      <rect class="codebox" x="66" y="12" width="22" height="22"/>
+      <rect class="codebox" x="88" y="12" width="22" height="22"/>
+      <rect class="codebox" x="110" y="12" width="22" height="22"/>
+      <rect class="codebox" x="132" y="12" width="22" height="22"/>
+      <rect class="codebox" x="154" y="12" width="22" height="22"/>
+      <rect class="codebox" x="176" y="12" width="22" height="22"/>
+      <rect class="codebox" x="198" y="12" width="22" height="22"/>
+      <text class="lbl" x="6" y="28">1</text>
+      <text class="lbl" x="28" y="28">0</text>
+      <text class="lbl" x="50" y="28">1</text>
+      <text class="lbl" x="72" y="28">1</text>
+      <text class="lbl" x="94" y="28">0</text>
+      <text class="lbl" x="116" y="28">0</text>
+      <text class="lbl" x="138" y="28">1</text>
+      <text class="lbl" x="160" y="28">0</text>
+      <text class="lbl" x="182" y="28">1</text>
+      <text class="lbl" x="204" y="28">1</text>
+    </g>
+    <text class="lbl-muted" x="0" y="56">d bits + 1 fp16 residual norm</text>
+    <text class="lbl-muted" x="0" y="74">&#x2192; ~ d/8 + 2 bytes per vector</text>
+
+    <text class="lbl" x="0" y="120">distance:</text>
+    <text class="lbl-muted" x="0" y="140">popcount(q_code XOR x_code)</text>
+    <text class="lbl-muted" x="0" y="158">scaled by residual norms</text>
+
+    <text class="lbl" x="0" y="200">accuracy boost:</text>
+    <text class="lbl-muted" x="0" y="220">use_reorder=true + fp16</text>
+    <text class="lbl-muted" x="0" y="238">re-rank top-k against precise copy</text>
+  </g>
+</svg>

--- a/docs/docs/en/src/figures/quantization/sq-axis.svg
+++ b/docs/docs/en/src/figures/quantization/sq-axis.svg
@@ -1,0 +1,77 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 220" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="13">
+  <title>Scalar Quantization: float range mapped to integer bins</title>
+  <desc>The float range [v_min, v_max] is split into 2^bits equal-width bins. Each float value lands in one bin and is stored as the bin index. The decoded value is the bin centre.</desc>
+  <style>
+    .axis { stroke: #3e3a39; stroke-width: 1.4; fill: none; }
+    .tick { stroke: #3e3a39; stroke-width: 1; }
+    .bin  { fill: #fce897; stroke: #b88a16; stroke-width: 1; }
+    .bin-hit { fill: #f4bd37; stroke: #b88a16; stroke-width: 1.4; }
+    .lbl { fill: #1a1614; }
+    .lbl-muted { fill: #6e6a66; }
+    .pt { fill: #3e3a39; }
+    .arr { stroke: #3e3a39; stroke-width: 1.2; fill: none; }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#3e3a39"/>
+    </marker>
+  </defs>
+
+  <!-- title -->
+  <text class="lbl" x="20" y="26">float range &#x2192; 2&#x1D4F; bins  (here b = 3, 8 bins)</text>
+
+  <!-- bins -->
+  <g transform="translate(60,60)">
+    <rect class="bin"     x="0"   y="0" width="70" height="32"/>
+    <rect class="bin"     x="70"  y="0" width="70" height="32"/>
+    <rect class="bin-hit" x="140" y="0" width="70" height="32"/>
+    <rect class="bin"     x="210" y="0" width="70" height="32"/>
+    <rect class="bin"     x="280" y="0" width="70" height="32"/>
+    <rect class="bin"     x="350" y="0" width="70" height="32"/>
+    <rect class="bin"     x="420" y="0" width="70" height="32"/>
+    <rect class="bin"     x="490" y="0" width="70" height="32"/>
+
+    <text class="lbl" x="28" y="20">000</text>
+    <text class="lbl" x="98" y="20">001</text>
+    <text class="lbl" x="168" y="20">010</text>
+    <text class="lbl" x="238" y="20">011</text>
+    <text class="lbl" x="308" y="20">100</text>
+    <text class="lbl" x="378" y="20">101</text>
+    <text class="lbl" x="448" y="20">110</text>
+    <text class="lbl" x="518" y="20">111</text>
+  </g>
+
+  <!-- axis below -->
+  <g transform="translate(60,110)">
+    <line class="axis" x1="0" y1="0" x2="560" y2="0" marker-end="url(#arrow)"/>
+    <line class="tick" x1="0" y1="-5" x2="0" y2="5"/>
+    <line class="tick" x1="70" y1="-4" x2="70" y2="4"/>
+    <line class="tick" x1="140" y1="-4" x2="140" y2="4"/>
+    <line class="tick" x1="210" y1="-4" x2="210" y2="4"/>
+    <line class="tick" x1="280" y1="-4" x2="280" y2="4"/>
+    <line class="tick" x1="350" y1="-4" x2="350" y2="4"/>
+    <line class="tick" x1="420" y1="-4" x2="420" y2="4"/>
+    <line class="tick" x1="490" y1="-4" x2="490" y2="4"/>
+    <line class="tick" x1="560" y1="-5" x2="560" y2="5"/>
+
+    <text class="lbl-muted" x="-18" y="22">v_min</text>
+    <text class="lbl-muted" x="540" y="22">v_max</text>
+
+    <!-- sample data point lands in bin "010" -->
+    <circle class="pt" cx="170" cy="0" r="4"/>
+    <text class="lbl" x="155" y="-12">x</text>
+  </g>
+
+  <!-- arrow from bin to code -->
+  <path class="arr" d="M230 96 L230 140" marker-end="url(#arrow)"/>
+  <text class="lbl" x="240" y="125">store the bin index</text>
+
+  <!-- output -->
+  <g transform="translate(120,160)">
+    <rect class="bin-hit" x="0" y="0" width="70" height="28"/>
+    <text class="lbl" x="22" y="20">010</text>
+    <text class="lbl-muted" x="80" y="20">b bits per dim &#x2192;  d &#xB7; b  bits per vector</text>
+  </g>
+
+  <text class="lbl-muted" x="20" y="208">decode: x&#x0302; = v_min + (idx + &#xBD;) &#xB7; (v_max &#x2212; v_min) / 2&#x1D4F;</text>
+</svg>

--- a/docs/docs/en/src/figures/quantization/sq-uniform-vs-perdim.svg
+++ b/docs/docs/en/src/figures/quantization/sq-uniform-vs-perdim.svg
@@ -1,0 +1,118 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 320" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="13">
+  <title>Uniform SQ vs per-dim SQ: range estimation</title>
+  <desc>Uniform SQ uses one global [min, max] shared by every dimension; per-dim SQ stores a separate [min_i, max_i] for each dimension. Per-dim handles skewed dimensions better but stores 2D extra floats.</desc>
+  <style>
+    .panel { fill: #ffffff; stroke: #cfcbc7; stroke-width: 1; }
+    .axis  { stroke: #3e3a39; stroke-width: 1; fill: none; }
+    .range { stroke: #f4bd37; stroke-width: 4; stroke-linecap: round; }
+    .range-narrow { stroke: #b88a16; stroke-width: 4; stroke-linecap: round; }
+    .range-wide { stroke: #f4bd37; stroke-width: 4; stroke-linecap: round; }
+    .pt { fill: #3e3a39; }
+    .lbl { fill: #1a1614; }
+    .lbl-muted { fill: #6e6a66; }
+    .global { stroke: #b88a16; stroke-width: 1.5; stroke-dasharray: 4 4; }
+  </style>
+
+  <!-- Left panel: uniform -->
+  <g transform="translate(20,20)">
+    <rect class="panel" x="0" y="0" width="330" height="280"/>
+    <text class="lbl" x="14" y="22">uniform SQ &#x2014; one shared [min, max]</text>
+
+    <!-- 4 dim rows -->
+    <g transform="translate(40,50)">
+      <!-- dim 1 -->
+      <text class="lbl-muted" x="-30" y="20">d&#x2081;</text>
+      <line class="axis" x1="0" y1="20" x2="260" y2="20"/>
+      <line class="global" x1="20" y1="10" x2="240" y2="10"/>
+      <line class="global" x1="20" y1="30" x2="240" y2="30"/>
+      <line class="range" x1="40" y1="20" x2="120" y2="20"/>
+      <circle class="pt" cx="60" cy="20" r="3"/>
+      <circle class="pt" cx="80" cy="20" r="3"/>
+      <circle class="pt" cx="100" cy="20" r="3"/>
+
+      <!-- dim 2 -->
+      <text class="lbl-muted" x="-30" y="70">d&#x2082;</text>
+      <line class="axis" x1="0" y1="70" x2="260" y2="70"/>
+      <line class="global" x1="20" y1="60" x2="240" y2="60"/>
+      <line class="global" x1="20" y1="80" x2="240" y2="80"/>
+      <line class="range" x1="160" y1="70" x2="230" y2="70"/>
+      <circle class="pt" cx="180" cy="70" r="3"/>
+      <circle class="pt" cx="200" cy="70" r="3"/>
+      <circle class="pt" cx="220" cy="70" r="3"/>
+
+      <!-- dim 3 -->
+      <text class="lbl-muted" x="-30" y="120">d&#x2083;</text>
+      <line class="axis" x1="0" y1="120" x2="260" y2="120"/>
+      <line class="global" x1="20" y1="110" x2="240" y2="110"/>
+      <line class="global" x1="20" y1="130" x2="240" y2="130"/>
+      <line class="range" x1="90" y1="120" x2="170" y2="120"/>
+      <circle class="pt" cx="110" cy="120" r="3"/>
+      <circle class="pt" cx="130" cy="120" r="3"/>
+      <circle class="pt" cx="150" cy="120" r="3"/>
+
+      <!-- dim 4 -->
+      <text class="lbl-muted" x="-30" y="170">d&#x2084;</text>
+      <line class="axis" x1="0" y1="170" x2="260" y2="170"/>
+      <line class="global" x1="20" y1="160" x2="240" y2="160"/>
+      <line class="global" x1="20" y1="180" x2="240" y2="180"/>
+      <line class="range" x1="40" y1="170" x2="230" y2="170"/>
+      <circle class="pt" cx="60" cy="170" r="3"/>
+      <circle class="pt" cx="140" cy="170" r="3"/>
+      <circle class="pt" cx="220" cy="170" r="3"/>
+    </g>
+
+    <text class="lbl-muted" x="14" y="252">shared range wastes bins on quiet dims</text>
+    <text class="lbl-muted" x="14" y="268">storage overhead: 2 floats total</text>
+  </g>
+
+  <!-- Right panel: per-dim -->
+  <g transform="translate(370,20)">
+    <rect class="panel" x="0" y="0" width="330" height="280"/>
+    <text class="lbl" x="14" y="22">per-dim SQ &#x2014; [min_i, max_i] per dim</text>
+
+    <g transform="translate(40,50)">
+      <!-- dim 1: tight -->
+      <text class="lbl-muted" x="-30" y="20">d&#x2081;</text>
+      <line class="axis" x1="0" y1="20" x2="260" y2="20"/>
+      <line class="global" x1="40" y1="10" x2="120" y2="10"/>
+      <line class="global" x1="40" y1="30" x2="120" y2="30"/>
+      <line class="range-narrow" x1="40" y1="20" x2="120" y2="20"/>
+      <circle class="pt" cx="60" cy="20" r="3"/>
+      <circle class="pt" cx="80" cy="20" r="3"/>
+      <circle class="pt" cx="100" cy="20" r="3"/>
+
+      <!-- dim 2: tight, shifted -->
+      <text class="lbl-muted" x="-30" y="70">d&#x2082;</text>
+      <line class="axis" x1="0" y1="70" x2="260" y2="70"/>
+      <line class="global" x1="160" y1="60" x2="230" y2="60"/>
+      <line class="global" x1="160" y1="80" x2="230" y2="80"/>
+      <line class="range-narrow" x1="160" y1="70" x2="230" y2="70"/>
+      <circle class="pt" cx="180" cy="70" r="3"/>
+      <circle class="pt" cx="200" cy="70" r="3"/>
+      <circle class="pt" cx="220" cy="70" r="3"/>
+
+      <!-- dim 3: medium -->
+      <text class="lbl-muted" x="-30" y="120">d&#x2083;</text>
+      <line class="axis" x1="0" y1="120" x2="260" y2="120"/>
+      <line class="global" x1="90" y1="110" x2="170" y2="110"/>
+      <line class="global" x1="90" y1="130" x2="170" y2="130"/>
+      <line class="range-narrow" x1="90" y1="120" x2="170" y2="120"/>
+      <circle class="pt" cx="110" cy="120" r="3"/>
+      <circle class="pt" cx="130" cy="120" r="3"/>
+      <circle class="pt" cx="150" cy="120" r="3"/>
+
+      <!-- dim 4: wide -->
+      <text class="lbl-muted" x="-30" y="170">d&#x2084;</text>
+      <line class="axis" x1="0" y1="170" x2="260" y2="170"/>
+      <line class="global" x1="40" y1="160" x2="230" y2="160"/>
+      <line class="global" x1="40" y1="180" x2="230" y2="180"/>
+      <line class="range-wide" x1="40" y1="170" x2="230" y2="170"/>
+      <circle class="pt" cx="60" cy="170" r="3"/>
+      <circle class="pt" cx="140" cy="170" r="3"/>
+      <circle class="pt" cx="220" cy="170" r="3"/>
+    </g>
+
+    <text class="lbl-muted" x="14" y="252">every dim uses its full bin budget</text>
+    <text class="lbl-muted" x="14" y="268">storage overhead: 2&#xB7;d floats</text>
+  </g>
+</svg>

--- a/docs/docs/en/src/indexes/brute_force.md
+++ b/docs/docs/en/src/indexes/brute_force.md
@@ -61,7 +61,7 @@ Advanced users can pass an `index_param` object to enable quantization or storag
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `base_quantization_type` | string | `"fp32"` | `fp32`, `fp16`, `bf16`, `sq8`, `sq8_uniform`, `sq4_uniform`, `pq`, `pqfs`, `rabitq` |
+| `base_quantization_type` | string | `"fp32"` | `fp32`, `fp16`, `bf16`, `sq8`, `sq4`, `sq8_uniform`, `sq4_uniform`, `pq`, `pqfs`, `rabitq` — see the [Quantization chapter](../quantization/README.md) for per-quantizer details |
 | `use_attribute_filter` | bool | `false` | Enable attribute-based filtering (see [Attribute Filter](../advanced/attribute_filter.md)) |
 
 > **Note on `store_raw_vector`.** The `store_raw_vector` flag is parsed by the shared
@@ -131,7 +131,7 @@ BruteForce advertises the following capability flags (see `BruteForce::InitFeatu
 | `SUPPORT_CHECK_ID_EXIST` / `SUPPORT_CLONE` / `SUPPORT_ESTIMATE_MEMORY` / `SUPPORT_GET_MEMORY_USAGE` | Standard introspection and lifecycle. |
 | `SUPPORT_SERIALIZE_BINARY_SET` / `SUPPORT_SERIALIZE_FILE` / `SUPPORT_SERIALIZE_WRITE_FUNC` | Full save surface. |
 | `SUPPORT_DESERIALIZE_BINARY_SET` / `SUPPORT_DESERIALIZE_FILE` / `SUPPORT_DESERIALIZE_READER_SET` | Full load surface. (There is no `DESERIALIZE_WRITE_FUNC` counterpart — read paths use `READER_SET` instead.) |
-| `NEED_TRAIN` | Set when `base_quantization_type` is one of `sq8`, `sq8_uniform`, `sq4_uniform`, `pq`, `pqfs`, `rabitq`. |
+| `NEED_TRAIN` | Set when `base_quantization_type` is one of `sq8`, `sq4`, `sq8_uniform`, `sq4_uniform`, `pq`, `pqfs`, `rabitq`. |
 
 Notably **not** supported by BruteForce: `SUPPORT_UPDATE_VECTOR_CONCURRENT`,
 `SUPPORT_UPDATE_ID_CONCURRENT`, and `SUPPORT_EXPORT_MODEL`.

--- a/docs/docs/en/src/indexes/hgraph.md
+++ b/docs/docs/en/src/indexes/hgraph.md
@@ -20,8 +20,8 @@ default.
    either NSW-style insertion (`graph_type: "nsw"`, the default) or ODescent
    (`graph_type: "odescent"`).
 2. **Quantization.** The base storage is compressed with a configurable quantizer
-   (`base_quantization_type` — `fp32`, `fp16`, `bf16`, `sq8`, `sq8_uniform`, `sq4_uniform`,
-   `pq`, `pqfs`, `rabitq`). Optionally, a second high-precision copy is kept
+   (`base_quantization_type` — `fp32`, `fp16`, `bf16`, `sq8`, `sq4`, `sq8_uniform`, `sq4_uniform`,
+   `pq`, `pqfs`, `rabitq`, `tq`). Optionally, a second high-precision copy is kept
    (`use_reorder: true` with `precise_quantization_type`) and used to re-rank the
    candidates returned by the coarse search.
 3. **Search.** Greedy beam search traverses the graph top-down, expanding the current
@@ -65,7 +65,7 @@ and `docs/hgraph.md` in the repository.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `base_quantization_type` | string | — (required) | `fp32`, `fp16`, `bf16`, `sq8`, `sq8_uniform`, `sq4_uniform`, `pq`, `pqfs`, `rabitq` |
+| `base_quantization_type` | string | — (required) | `fp32`, `fp16`, `bf16`, `sq8`, `sq4`, `sq8_uniform`, `sq4_uniform`, `pq`, `pqfs`, `rabitq`, `tq` — see the [Quantization chapter](../quantization/README.md) for per-quantizer details |
 | `max_degree` | int | `64` | Maximum out-degree per graph node |
 | `ef_construction` | int | `400` | Candidate list size during build (higher = better recall, slower build) |
 | `graph_type` | string | `"nsw"` | Graph algorithm: `nsw` or `odescent` |

--- a/docs/docs/en/src/indexes/ivf.md
+++ b/docs/docs/en/src/indexes/ivf.md
@@ -75,7 +75,7 @@ repository for the exhaustive list.
 | `first_order_buckets_count` | int | `10` | First-level count (effective for `gno_imi`) |
 | `second_order_buckets_count` | int | `10` | Second-level count (effective for `gno_imi`) |
 | `ivf_train_type` | string | `"kmeans"` | Centroid training: `kmeans` or `random` |
-| `base_quantization_type` | string | `"fp32"` | `fp32`, `fp16`, `bf16`, `sq8`, `sq8_uniform`, `sq4_uniform`, `pq`, `pqfs`, `rabitq` |
+| `base_quantization_type` | string | `"fp32"` | `fp32`, `fp16`, `bf16`, `sq8`, `sq4`, `sq8_uniform`, `sq4_uniform`, `pq`, `pqfs`, `rabitq` — see the [Quantization chapter](../quantization/README.md) for per-quantizer details |
 | `base_pq_dim` | int | `1` | PQ subspaces (required with `pq` / `pqfs`) |
 | `use_reorder` | bool | `false` | Keep a high-precision copy and re-rank after the coarse scan |
 | `precise_quantization_type` | string | `"fp32"` | Quantizer used for reordering (with `use_reorder: true`) |

--- a/docs/docs/en/src/indexes/pyramid.md
+++ b/docs/docs/en/src/indexes/pyramid.md
@@ -81,7 +81,7 @@ Build-time parameters live under `index_param`.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `base_quantization_type` | string | — | Coarse storage quantizer (`fp32`, `fp16`, `bf16`, `sq8`, `sq8_uniform`, `sq4_uniform`, `pq`, `pqfs`, `rabitq`). |
+| `base_quantization_type` | string | — | Coarse storage quantizer (`fp32`, `fp16`, `bf16`, `sq8`, `sq4`, `sq8_uniform`, `sq4_uniform`, `pq`, `pqfs`, `rabitq`). See the [Quantization chapter](../quantization/README.md) for per-quantizer details. |
 | `max_degree` | int | `64` | Maximum out-degree per node within a sub-graph. |
 | `graph_type` | string | `"nsw"` | `nsw` or `odescent`. |
 | `ef_construction` | int | `400` | Candidate list size for `nsw` builds. |

--- a/docs/docs/en/src/quantization/README.md
+++ b/docs/docs/en/src/quantization/README.md
@@ -1,0 +1,155 @@
+# Quantization
+
+Vector quantization is the central memory/recall lever in VSAG. Every index
+type stores vectors through a **base quantizer** (configured by
+`base_quantization_type`), and may keep a second **precise quantizer** for
+re-ranking (`precise_quantization_type` + `use_reorder: true`). This chapter
+documents each supported quantizer: what it does, what JSON parameters it
+takes, when it needs training, which metrics it supports, and when to choose
+it.
+
+![Quantization decision tree: pick a quantizer by memory budget](../figures/quantization/quantization-overview.svg)
+
+## Storage and search pipeline
+
+```
+                 +---------------------+
+   raw vector -->|  optional transform |   (TQ chain: pca / rom / fht / mrle)
+                 +----------+----------+
+                            |
+                            v
+                 +---------------------+
+                 |   base quantizer    |   fp32 / fp16 / bf16 /
+                 |                     |   sq8 / sq4 / sq8_uniform /
+                 |                     |   sq4_uniform / pq / pqfs /
+                 |                     |   rabitq
+                 +----------+----------+
+                            |
+                            v
+                  +-------------------+
+                  |   index storage   |   (HGraph / IVF / Pyramid /
+                  |                   |    BruteForce / SINDI)
+                  +---------+---------+
+                            |
+                            v
+                   graph / list walk
+                            |
+            +---------------+-----------------+
+            |                                 |
+   use_reorder: false                use_reorder: true
+            |                                 |
+            v                                 v
+       top-K result               +---------------------+
+                                  | precise quantizer   |  re-rank
+                                  | (fp32 default;      |
+                                  |  fp16/bf16/sq8 OK)  |
+                                  +----------+----------+
+                                             |
+                                             v
+                                        top-K result
+```
+
+`use_reorder` and `precise_quantization_type` are not specific to any single
+quantizer — they apply whenever the index supports reordering (see
+[HGraph](../indexes/hgraph.md), [IVF](../indexes/ivf.md),
+[Pyramid](../indexes/pyramid.md)).
+
+## Supported quantizers at a glance
+
+The factory in `src/datacell/flatten_interface.cpp` dispatches to
+the concrete quantizer based on the JSON `type` field.
+
+| `base_quantization_type` | Bits / dim (approx.) | Needs training | Lossless | Typical use |
+| --- | --- | --- | --- | --- |
+| `fp32` | 32 | no | yes | Reference / precise reorder store |
+| `fp16` | 16 | no | near-lossless | Half-precision storage; good default for high-dim float vectors |
+| `bf16` | 16 | no | near-lossless | Same memory as `fp16`, wider dynamic range |
+| `sq8` | 8 | **yes** | no | General memory-saving baseline |
+| `sq4` | 4 | **yes** | no | Aggressive memory saving, expect recall drop without reorder |
+| `sq8_uniform` | 8 | **yes** | no | SIMD-friendly SQ8 with global min/max |
+| `sq4_uniform` | 4 | **yes** | no | SIMD-friendly SQ4; supports `sq4_uniform_trunc_rate` |
+| `pq` | ~`pq_bits` × `pq_dim` / `dim` | **yes** | no | Codebook-based, very compact |
+| `pqfs` | 4 × `pq_dim` / `dim` | **yes** | no | PQ FastScan — SIMD-accelerated PQ |
+| `rabitq` | 1 (+ optional 7) | **yes** | no | 1-bit / 1+7-bit binary quantization, strongest compression |
+| `tq` | depends on chain | depends on terminal quantizer | no | [Transform Quantizer](../advanced/quantization_transform.md): prepend rotations / PCA before another quantizer |
+
+`int8` and `sparse` are not exposed as general-purpose
+`base_quantization_type` values:
+
+- `int8` is selected automatically when `dtype: "int8"` is used; it is not a
+  compression mode.
+- `sparse` backs the inverted lists of [SINDI](../indexes/sindi.md) and is
+  not selectable on dense indexes.
+
+## Training requirement
+
+Quantizers marked **yes** above implement the `NEED_TRAIN` flag and require
+either `Build` (which trains internally on the input vectors) or an explicit
+`Train` call before `Add`. See [Build and Train](../advanced/build_and_train.md)
+for the full lifecycle.
+
+For HGraph the training data is the base vectors passed to `Build`; for IVF
+the centroids are trained first and the residuals fed to the configured
+base quantizer.
+
+## Metric compatibility
+
+All quantizers documented here support the three dense metrics
+(`l2` / `ip` / `cosine`). For `cosine`, the index normalizes vectors before
+quantization, so the underlying quantizer never sees the original magnitude.
+A few practical notes:
+
+- `pq` / `pqfs` perform their distance lookup tables per subspace; very low
+  `pq_dim` (≤ 4) on `ip` / `cosine` is more sensitive to anisotropy than `l2`.
+- `rabitq` works best when input vectors are decorrelated — either turn on
+  `rabitq_use_fht` / `rabitq_pca_dim`, or wrap with a `tq` chain like
+  `"pca, rom, rabitq"`.
+
+## Choosing a quantizer
+
+A pragmatic decision tree:
+
+1. **Need exact distances or a precise reorder store?** Use `fp32`.
+2. **Just want to halve memory with negligible recall loss?** Use `fp16`
+   (or `bf16` if the data has a wide dynamic range, e.g. unnormalized
+   embeddings).
+3. **Want ~4× memory saving and willing to enable reorder?** Use `sq8` (or
+   `sq8_uniform` for better SIMD throughput on `l2` / `ip`).
+4. **Memory-tight and willing to lose more recall before reorder?** Use
+   `sq4_uniform`.
+5. **High-dim vectors, want strong compression with codebooks?** Use `pq`,
+   or `pqfs` when the platform supports the SIMD path.
+6. **Maximum compression (1-bit) and willing to pay reorder cost?** Use
+   `rabitq`, ideally with `rabitq_use_fht: true` or a `tq` chain.
+
+For every lossy quantizer above, enabling `use_reorder: true` with
+`precise_quantization_type: "fp32"` is the standard way to recover recall at
+the cost of extra memory; see the [HGraph parameter table](../indexes/hgraph.md#parameters)
+for the exact behavior.
+
+## Where quantization is exposed
+
+Not every index exposes every parameter as an external key. As of today:
+
+- **HGraph** exposes the richest set: `base_quantization_type`,
+  `precise_quantization_type`, `use_reorder`, `base_pq_dim`,
+  `rabitq_pca_dim`, `rabitq_bits_per_dim_query`,
+  `rabitq_bits_per_dim_base`, `rabitq_version`, `rabitq_error_rate`,
+  `rabitq_use_fht`, `sq4_uniform_trunc_rate`, `tq_chain`
+  (see `src/algorithm/hgraph.cpp`).
+- **IVF**, **Pyramid**, **BruteForce** expose `base_quantization_type` and
+  the common reorder keys; some tunables (e.g. `tq_chain`) are wired
+  internally but not exposed as external keys today.
+
+Refer to each index page for its full parameter list.
+
+## In this chapter
+
+- [FP32 (Baseline)](fp32.md)
+- [Half-Precision (FP16 / BF16)](fp16_bf16.md)
+- [Scalar Quantization (SQ4 / SQ8)](sq.md)
+- [Scalar Uniform (SQ4 / SQ8 Uniform)](sq_uniform.md)
+- [Product Quantization (PQ)](pq.md)
+- [PQ FastScan](pqfs.md)
+- [RaBitQ](rabitq.md)
+- [Transform Quantizer (TQ)](../advanced/quantization_transform.md)

--- a/docs/docs/en/src/quantization/fp16_bf16.md
+++ b/docs/docs/en/src/quantization/fp16_bf16.md
@@ -1,0 +1,87 @@
+# Half-Precision (FP16 / BF16)
+
+`fp16` and `bf16` store each coordinate in 16 bits instead of 32, cutting
+code memory in half with **near-lossless** accuracy. They have no
+quantizer-specific JSON parameters; the only difference is the bit layout
+of the float format itself.
+
+![FP32 vs FP16 vs BF16 bit layout: sign / exponent / mantissa widths](../figures/quantization/fp-bitlayout.svg)
+
+> Implementation: `src/quantization/scalar_quantization/half_precision_quantizer.cpp`
+> with the type traits at `half_precision_traits.h`.
+> Runnable example: `examples/cpp/321_index_fp16_hgraph.cpp`.
+
+## FP16 vs BF16 at a glance
+
+| Format | Sign | Exponent | Mantissa | Effective range | Precision |
+| --- | --- | --- | --- | --- | --- |
+| `fp16` | 1 | 5 | 10 | ~±6.55e4 | ~3 decimal digits |
+| `bf16` | 1 | 8 | 7 | same as `fp32` (~±3.4e38) | ~2 decimal digits |
+
+Practical implications:
+
+- **`fp16`** keeps more mantissa bits — better precision for normalized
+  embeddings whose values lie roughly in `[-1, 1]`. Standard choice for
+  cosine-normalized vectors.
+- **`bf16`** keeps the full `fp32` exponent range — safer for raw,
+  un-normalized features (e.g. weighted sums, accumulator-like
+  embeddings). Loses some precision compared to `fp16` on values close to
+  zero.
+
+If you do not know which one to pick, start with `fp16` for normalized
+embeddings and `bf16` for unnormalized or wide-range data.
+
+## When to use it
+
+- Default "drop-in" memory saving on top of an `fp32` baseline. Recall
+  loss is typically below 1% on standard benchmarks (SIFT, GIST,
+  Glove, sentence embeddings).
+- As a **precise reorder store** that is half the size of fp32:
+  `precise_quantization_type: "fp16"` or `"bf16"` with
+  `use_reorder: true`.
+- High-dim float vectors where 32-bit storage is the bottleneck.
+
+## Memory cost
+
+`2 × dim` bytes per vector for the codes alone.
+
+## Parameters
+
+Neither `fp16` nor `bf16` has quantizer-specific JSON parameters.
+
+```json
+{
+    "dtype": "float32",
+    "metric_type": "l2",
+    "dim": 768,
+    "index_param": {
+        "base_quantization_type": "fp16",
+        "max_degree": 32,
+        "ef_construction": 300
+    }
+}
+```
+
+Swap `"fp16"` for `"bf16"` to switch formats. The input `dtype` stays
+`"float32"`: the quantizer converts on the fly.
+
+## Training
+
+Not required. Neither `fp16` nor `bf16` sets `NEED_TRAIN`.
+
+## Metric compatibility
+
+`l2`, `ip`, `cosine` — all supported. `cosine` is implemented by
+normalizing inputs before storing them at 16-bit precision.
+
+## When **not** to use it
+
+- When you also need a memory-aggressive *base* quantizer such as `sq8` or
+  `pq` — those already pull the storage well below 2 bytes/dim.
+- When you need exact distances (use `fp32`).
+
+## Related pages
+
+- [Quantization overview](README.md)
+- [HGraph index](../indexes/hgraph.md) — `precise_quantization_type` table
+- [Memory Management](../advanced/memory.md)

--- a/docs/docs/en/src/quantization/fp32.md
+++ b/docs/docs/en/src/quantization/fp32.md
@@ -1,0 +1,61 @@
+# FP32 (Baseline)
+
+`fp32` stores every coordinate as a 32-bit IEEE-754 float — the same layout
+as the input vectors. It is the **only fully lossless** option in VSAG and
+serves as the reference baseline that all other quantizers are compared
+against.
+
+> Implementation: `src/quantization/fp32_quantizer.cpp`, parameter file
+> `fp32_quantizer_parameter.cpp`.
+
+## When to use it
+
+- **Reorder / precise store.** `precise_quantization_type: "fp32"` is the
+  default precise store when `use_reorder: true`; the graph walk uses a
+  cheap base quantizer and the top-K candidates are re-scored exactly
+  against the fp32 copy.
+- **Reference / ground truth.** Building an index with
+  `base_quantization_type: "fp32"` gives the highest possible recall for
+  that index type and is the standard baseline for benchmarking other
+  quantizers (`docs/docs/en/src/resources/eval.md`).
+- **Small datasets** where memory is not the bottleneck.
+- **BruteForce with raw-vector retrieval.** `SUPPORT_GET_RAW_VECTOR_BY_IDS`
+  is only advertised when `base_quantization_type` is `fp32` and the metric
+  allows it (`src/index/brute_force.cpp`).
+
+## Memory cost
+
+`4 × dim` bytes per vector for the codes alone. When `fp32` is used as a
+precise store on top of a base quantizer, the per-vector cost is
+**base codes + 4 × dim**.
+
+## Parameters
+
+`fp32` has no quantizer-specific JSON parameters.
+
+```json
+{
+    "dtype": "float32",
+    "metric_type": "l2",
+    "dim": 128,
+    "index_param": {
+        "base_quantization_type": "fp32",
+        "max_degree": 32,
+        "ef_construction": 300
+    }
+}
+```
+
+## Training
+
+Not required. `fp32` does **not** set `NEED_TRAIN`.
+
+## Metric compatibility
+
+`l2`, `ip`, `cosine` — all supported with no special handling.
+
+## Related pages
+
+- [Quantization overview](README.md)
+- [HGraph index](../indexes/hgraph.md) — see `precise_quantization_type`
+- [Memory Management](../advanced/memory.md)

--- a/docs/docs/en/src/quantization/pq.md
+++ b/docs/docs/en/src/quantization/pq.md
@@ -1,0 +1,90 @@
+# Product Quantization (PQ)
+
+Product Quantization splits a vector into `pq_dim` equal-sized **subvectors**
+and quantizes each one independently against a small learned codebook of
+`2^pq_bits` centroids. The stored code is then `pq_dim × pq_bits` bits per
+vector — orders of magnitude smaller than `fp32`. Distance computations
+use precomputed lookup tables (LUT) per query.
+
+![Product Quantization: sub-vector split and codebook lookup](../figures/quantization/pq-codebook.svg)
+
+> Implementation: `src/quantization/product_quantization/product_quantizer.cpp`,
+> parameter file `product_quantizer_parameter.cpp`.
+
+## When to use it
+
+- **High-dim float vectors (≥ 256 dim)** where `sq8` is still too large.
+- **Memory-tight, accuracy-acceptable** workloads where ~16× compression
+  vs fp32 is required.
+- Combined with `use_reorder: true` and a small `fp16`/`fp32` precise
+  store, PQ is the standard "compressed graph index" recipe at large
+  scale.
+
+For wider SIMD throughput at `pq_bits = 4`, see [PQ FastScan](pqfs.md).
+
+## Memory cost (codes only)
+
+`ceil(pq_dim × pq_bits / 8)` bytes per vector for the codes, plus a small
+codebook stored once (`pq_dim × 2^pq_bits × subspace_dim × 4` bytes).
+For typical settings (`pq_dim = 32`, `pq_bits = 8`, `dim = 128`):
+
+- code size = `32 × 8 / 8 = 32` bytes per vector (vs `128 × 4 = 512` for
+  fp32 → 16× smaller).
+
+## Parameters
+
+| Key | Type | Default | Meaning |
+| --- | --- | --- | --- |
+| `pq_dim` | int | `1` | Number of subvectors. Must divide `dim`. Larger values give finer quantization at the cost of more codebooks and larger codes (`product_quantizer_parameter.h:38`). |
+| `pq_bits` | int | `8` | Bits per subvector (1–8). With `8`, each subvector is one byte. Most reliable with `8`; see [PQ FastScan](pqfs.md) for the 4-bit SIMD variant. |
+
+On HGraph these are exposed as the top-level keys `base_pq_dim` and
+`pq_bits` (`src/algorithm/hgraph.cpp:465-472`).
+
+```json
+{
+    "dtype": "float32",
+    "metric_type": "l2",
+    "dim": 128,
+    "index_param": {
+        "base_quantization_type": "pq",
+        "base_pq_dim": 32,
+        "max_degree": 32,
+        "ef_construction": 300,
+        "use_reorder": true,
+        "precise_quantization_type": "fp16"
+    }
+}
+```
+
+## Training
+
+`NEED_TRAIN` is set. Training runs k-means per subspace to learn the
+`2^pq_bits` centroids; this is typically the most expensive training step
+of any built-in quantizer. Use a training sample of at least `256 ×
+2^pq_bits` vectors per subspace for stable codebooks; `Build(base)`
+samples from the input automatically.
+
+## Metric compatibility
+
+`l2`, `ip`, `cosine` — all supported. Query-time distance is computed via
+a per-subspace LUT: for `l2` it is squared L2 between the query subvector
+and each centroid; for `ip` it is the dot product. Cosine reduces to `ip`
+on pre-normalized vectors.
+
+## Tips
+
+- `pq_dim` should divide `dim` evenly. Common ratios are `dim/4` or
+  `dim/8`.
+- Very small `pq_dim` (e.g. `dim/16`) produces very compact codes but
+  loses recall fast; combine with reorder.
+- For anisotropic data, a rotation transformer in front improves PQ
+  recall noticeably: use [Transform Quantizer](../advanced/quantization_transform.md)
+  with a chain like `"rom, pq"`.
+
+## Related pages
+
+- [PQ FastScan](pqfs.md)
+- [Transform Quantizer](../advanced/quantization_transform.md)
+- [HGraph index](../indexes/hgraph.md)
+- [Quantization overview](README.md)

--- a/docs/docs/en/src/quantization/pqfs.md
+++ b/docs/docs/en/src/quantization/pqfs.md
@@ -1,0 +1,81 @@
+# PQ FastScan
+
+`pqfs` is a SIMD-accelerated variant of [Product Quantization](pq.md) that
+fixes `pq_bits = 4` and uses a memory layout designed for the AVX-2 /
+AVX-512 "FastScan" lookup-table kernel. At the cost of being 4-bit only,
+it delivers significantly higher distance-computation throughput.
+
+![PQ FastScan: 16-vector 4-bit interleaved block and SIMD LUT lookup](../figures/quantization/pqfs-block.svg)
+
+> Implementation: `src/quantization/product_quantization/pq_fastscan_quantizer.cpp`,
+> parameter file `pq_fastscan_quantizer_parameter.cpp`.
+
+## When to use it
+
+- The platform has AVX-2 (and ideally AVX-512); the FastScan kernel is
+  the main reason to choose `pqfs` over `pq`.
+- Search throughput, not just memory, matters.
+- 4-bit subspace codebooks (16 centroids per subvector) are sufficient
+  for your recall target — typically yes when combined with reorder.
+
+If your platform does not advertise the required SIMD width, fall back to
+plain [`pq`](pq.md).
+
+## Memory cost (codes only)
+
+`ceil(pq_dim / 2) = (pq_dim + 1) / 2` bytes per vector — both even and odd
+`pq_dim` are supported (`src/quantization/product_quantization/pq_fastscan_quantizer.cpp:41`).
+Codebooks: `pq_dim × 16 × subspace_dim × 4` bytes — significantly smaller
+than 8-bit `pq` because the codebook has only 16 centroids per subspace.
+
+## Parameters
+
+| Key | Type | Default | Meaning |
+| --- | --- | --- | --- |
+| `pq_dim` | int | `1` | Number of subvectors. Must divide `dim`. `pq_bits` is **fixed to 4** internally and not configurable (`pq_fastscan_quantizer_parameter.cpp:28-33`). |
+
+Exposed on HGraph as `base_pq_dim` (`src/algorithm/hgraph.cpp:465-472`).
+
+```json
+{
+    "dtype": "float32",
+    "metric_type": "l2",
+    "dim": 128,
+    "index_param": {
+        "base_quantization_type": "pqfs",
+        "base_pq_dim": 32,
+        "max_degree": 32,
+        "ef_construction": 300,
+        "use_reorder": true,
+        "precise_quantization_type": "fp16"
+    }
+}
+```
+
+## Training
+
+`NEED_TRAIN` is set. Trains 16-centroid codebooks per subspace; cheaper
+than the 256-centroid training in `pq`.
+
+## Metric compatibility
+
+`l2`, `ip`, `cosine` — same coverage as `pq`. The LUT layout is metric-
+specific but transparently handled by the quantizer.
+
+## Tips
+
+- `pq_dim` should be a multiple of the SIMD-batch width the kernel
+  expects (the implementation uses 32 internally on AVX-512). When in
+  doubt, choose `pq_dim ∈ {32, 64, 96, 128}`.
+- The benefit over `pq` is **throughput at the same recall**, not memory
+  (4-bit codes are inherently smaller, but `pq` with `pq_bits = 4` would
+  match).
+- For maximum recall recovery, pair with `use_reorder: true` and an
+  `fp16` or `fp32` precise store.
+
+## Related pages
+
+- [Product Quantization (PQ)](pq.md)
+- [HGraph index](../indexes/hgraph.md)
+- [Transform Quantizer](../advanced/quantization_transform.md)
+- [Quantization overview](README.md)

--- a/docs/docs/en/src/quantization/rabitq.md
+++ b/docs/docs/en/src/quantization/rabitq.md
@@ -1,0 +1,125 @@
+# RaBitQ
+
+`rabitq` is VSAG's binary / low-bit quantizer. In its default mode each
+coordinate is encoded with **1 bit**, giving the highest compression ratio
+of any built-in quantizer. A second mode (`rabitq_version =
+"split_1bit_7bit"`) splits the representation into a 1-bit base and a
+7-bit refinement to recover much of the accuracy at ~8 bits/dim, while
+preserving the 1-bit fast distance kernel.
+
+![RaBitQ: encode each coordinate by its sign relative to a random hyperplane](../figures/quantization/rabitq-hyperplane.svg)
+
+> Implementation: `src/quantization/rabitq_quantization/rabitq_quantizer.cpp`,
+> parameter file `rabitq_quantizer_parameter.cpp`.
+> Design notes: `docs/rabitq_1xbit_new_repo_guide.md`,
+> `docs/rabitq_split_1bit_7bit.md`.
+
+## When to use it
+
+- **Maximum compression.** 1-bit codes are the smallest possible storage
+  for dense vectors.
+- **High-dim embeddings** where rotation + binarization preserves enough
+  geometry for nearest-neighbor search.
+- Combined with a precise reorder store (`fp16` / `fp32`) — the standard
+  recipe is "RaBitQ + reorder", because the binary distance is noisy on
+  its own.
+
+For best accuracy, also enable `rabitq_use_fht: true` or wrap with a
+[Transform Quantizer](../advanced/quantization_transform.md) chain such
+as `"pca, rom, rabitq"`.
+
+## Memory cost (codes only)
+
+- `rabitq_bits_per_dim_base = 1`: `ceil(dim / 8)` bytes per vector. With
+  `dim = 768` that is 96 bytes (vs 3072 for fp32 → 32× smaller).
+- `rabitq_bits_per_dim_base = 8` (split-1+7 mode stores additional bits):
+  ~`dim` bytes per vector.
+
+## Parameters
+
+| Key | Type | Default | Meaning |
+| --- | --- | --- | --- |
+| `pca_dim` | int | `0` (= input dim) | Optional PCA preprocessing dimension applied inside RaBitQ. `0` means no PCA reduction (`rabitq_quantizer_parameter.cpp:30-32`). |
+| `rabitq_bits_per_dim_query` | int | `32` | Bits per dimension used to encode the **query** during search. Allowed values: `4` or `32` (`rabitq_quantizer_parameter.cpp:38-43`). |
+| `rabitq_bits_per_dim_base` | int | `1` | Bits per dimension for the **base** (stored) codes. Allowed range `[1, 8]` (`rabitq_quantizer_parameter.cpp:45-54`). Use `1` for pure 1-bit RaBitQ. |
+| `rabitq_version` | string | `"standard"` | One of `"standard"` (1-bit) or `"split_1bit_7bit"`. The split version requires `rabitq_bits_per_dim_query = 32` (`rabitq_quantizer_parameter.cpp:55-67`). |
+| `rabitq_error_rate` | float | `1.9` | Controls the error budget of the encoder; must be finite and positive (`rabitq_quantizer_parameter.cpp:68-75`). |
+| `use_fht` | bool | `false` | If `true`, applies a Fast Hadamard Transform rotation before binarization. Improves accuracy on anisotropic data with cheap O(dim log dim) cost (`rabitq_quantizer_parameter.cpp:76-78`). |
+
+On HGraph these are exposed as the top-level keys `rabitq_pca_dim`,
+`rabitq_bits_per_dim_query`, `rabitq_bits_per_dim_base`, `rabitq_version`,
+`rabitq_error_rate`, and `rabitq_use_fht` — the last one is the HGraph
+alias for the quantizer's `use_fht` key and is rewritten by the index
+layer (`src/algorithm/hgraph.cpp:473-480`, names defined in
+`src/constants.cpp:142-148`). Pyramid exposes the same `rabitq_*` keys
+(`src/algorithm/pyramid.cpp:698-699`).
+
+```json
+{
+    "dtype": "float32",
+    "metric_type": "l2",
+    "dim": 768,
+    "index_param": {
+        "base_quantization_type": "rabitq",
+        "rabitq_use_fht": true,
+        "rabitq_pca_dim": 0,
+        "rabitq_bits_per_dim_base": 1,
+        "rabitq_bits_per_dim_query": 32,
+        "max_degree": 32,
+        "ef_construction": 300,
+        "use_reorder": true,
+        "precise_quantization_type": "fp32"
+    }
+}
+```
+
+Swap to the higher-accuracy split mode. The split layout is selected by a
+combination of two keys — `rabitq_version: "split_1bit_7bit"` selects the
+1+7 RaBitQ encoding, and `base_codes_type: "rabitq_split"` switches the
+storage datacell. Setting `rabitq_version` alone does **not** activate the
+split datacell path; both keys must be set together (see
+`docs/rabitq_split_1bit_7bit.md`):
+
+```json
+{
+    "base_quantization_type": "rabitq",
+    "base_codes_type": "rabitq_split",
+    "rabitq_version": "split_1bit_7bit",
+    "rabitq_bits_per_dim_base": 8,
+    "rabitq_bits_per_dim_query": 32,
+    "rabitq_use_fht": true
+}
+```
+
+## Training
+
+`NEED_TRAIN` is set. Training learns the rotation and per-dimension
+statistics that make the 1-bit encoding well-balanced. The optional FHT
+rotation is fixed (not learned), so it adds no extra training cost; PCA
+preprocessing (when `pca_dim > 0`) trains a projection matrix.
+
+## Metric compatibility
+
+`l2`, `ip`, `cosine` — all supported. The binary distance kernel is a
+popcount over XORed code words; for `ip` / `cosine` the implementation
+also tracks a residual norm so the inner-product estimate is unbiased.
+
+## Tips
+
+- **Always enable reorder** unless you have validated that 1-bit recall
+  is acceptable on your data. `use_reorder: true` +
+  `precise_quantization_type: "fp32"` is the safe default.
+- **Rotate first.** For un-normalized data, set `rabitq_use_fht: true` or
+  use a `tq` chain that includes `rom` / `fht`.
+- **Split mode for accuracy.** `rabitq_version: "split_1bit_7bit"` keeps
+  the 1-bit fast path for graph traversal and adds a 7-bit refinement
+  for re-ranking; expect significantly higher recall at ~8× the code
+  size of pure 1-bit.
+
+## Related pages
+
+- [Transform Quantizer](../advanced/quantization_transform.md)
+- [HGraph index](../indexes/hgraph.md)
+- Design notes: `docs/rabitq_1xbit_new_repo_guide.md`,
+  `docs/rabitq_split_1bit_7bit.md`
+- [Quantization overview](README.md)

--- a/docs/docs/en/src/quantization/sq.md
+++ b/docs/docs/en/src/quantization/sq.md
@@ -1,0 +1,87 @@
+# Scalar Quantization (SQ4 / SQ8)
+
+`sq8` and `sq4` are **per-dimension scalar quantizers**: each coordinate is
+mapped from `float32` to an 8-bit (`sq8`) or 4-bit (`sq4`) integer using a
+per-dimension `[min, max]` range learned during training. They share the
+same implementation, parameterized by bit width, in
+`src/quantization/scalar_quantization/scalar_quantizer.cpp` and
+`scalar_quantizer_parameter.h`.
+
+For SIMD-friendlier variants with a **global** `[min, max]`, see
+[Scalar Uniform](sq_uniform.md).
+
+![Scalar Quantization: map a coordinate into one of 2^b bins on its per-dim range](../figures/quantization/sq-axis.svg)
+
+## SQ4 vs SQ8 at a glance
+
+| Type | Bits / dim | Memory vs fp32 | Typical accuracy | Notes |
+| --- | --- | --- | --- | --- |
+| `sq8` | 8 | ~1/4 | minor recall loss | General memory-saving baseline |
+| `sq4` | 4 | ~1/8 | noticeable loss without reorder | Aggressive compression; pair with `use_reorder: true` |
+
+The training is per-dimension `min`/`max`, so heavy-tailed coordinates can
+waste code bits. If your data is anisotropic, consider either
+[Scalar Uniform](sq_uniform.md) or a [Transform Quantizer](../advanced/quantization_transform.md)
+chain like `"rom, sq8_uniform"` to rotate first.
+
+## Memory cost (codes only)
+
+- `sq8`: `dim` bytes per vector.
+- `sq4`: `ceil(dim / 2)` bytes per vector.
+
+There is also a small per-dimension range table (`8 × dim` bytes,
+amortized across all vectors).
+
+## Parameters
+
+Neither `sq8` nor `sq4` has quantizer-specific JSON parameters today
+(`scalar_quantizer_parameter.h:36-58`). The bit width is selected by the
+`type` string alone.
+
+```json
+{
+    "dtype": "float32",
+    "metric_type": "l2",
+    "dim": 128,
+    "index_param": {
+        "base_quantization_type": "sq8",
+        "max_degree": 32,
+        "ef_construction": 300,
+        "use_reorder": true,
+        "precise_quantization_type": "fp32"
+    }
+}
+```
+
+Replace `"sq8"` with `"sq4"` for 4-bit codes.
+
+## Training
+
+`NEED_TRAIN` is set. Training collects per-dimension `min` / `max` from a
+sample of the input vectors. Calling `Build(base)` trains internally; on
+indexes that require an explicit `Train` (some IVF flows), call it before
+`Add`. See [Build and Train](../advanced/build_and_train.md).
+
+## Metric compatibility
+
+`l2`, `ip`, `cosine` — all supported. Distances are computed by decoding
+the integer codes back to per-dimension scaled floats.
+
+## When to choose `sq8` vs `sq4`
+
+- **`sq8`**: default memory-saving choice for graph indexes (HGraph,
+  Pyramid) when ~4× memory reduction is the target. Recall loss is small
+  enough that `use_reorder` is often optional, but enabling it with
+  `precise_quantization_type: "fp32"` is the safest setup.
+- **`sq4`**: choose when memory is tight and you can afford a precise
+  reorder store. Almost always pair with `use_reorder: true`.
+- Pick `sq*_uniform` instead when the data is roughly homogeneous across
+  dimensions; the uniform variants have higher SIMD throughput.
+- For heavy-tailed / anisotropic data, prefer a [Transform Quantizer](../advanced/quantization_transform.md)
+  chain that rotates before quantization.
+
+## Related pages
+
+- [Scalar Uniform (SQ4 / SQ8 Uniform)](sq_uniform.md)
+- [Transform Quantizer](../advanced/quantization_transform.md)
+- [Quantization overview](README.md)

--- a/docs/docs/en/src/quantization/sq_uniform.md
+++ b/docs/docs/en/src/quantization/sq_uniform.md
@@ -1,0 +1,119 @@
+# Scalar Quantization Uniform (SQ4 / SQ8 Uniform)
+
+`sq8_uniform` and `sq4_uniform` are scalar quantizers like
+[`sq8` / `sq4`](sq.md), except they learn a **single global** `[min, max]`
+range that applies to every dimension. This trade-off — slightly less
+adaptive per dimension, but a much simpler decode path — unlocks SIMD code
+that runs significantly faster on `l2` and `ip` distance kernels and
+keeps the code layout tighter.
+
+![Uniform (global range) vs per-dimension Scalar Quantization](../figures/quantization/sq-uniform-vs-perdim.svg)
+
+> Implementation: `src/quantization/scalar_quantization/sq8_uniform_quantizer.cpp`,
+> `src/quantization/scalar_quantization/sq4_uniform_quantizer.cpp`.
+
+## Why it is fast: distances stay in the integer domain
+
+This is the core reason to prefer `sq*_uniform` over `sq*` whenever it
+applies. Because every dimension shares one `(min, max)` pair, the affine
+decode `x = min + code · (max - min) / (2^b - 1)` has the **same scale and
+offset for every coordinate**. That has three consequences in the hot path:
+
+- The query is encoded **once** with the same global `(min, max)` into a
+  uint8 (or packed nibble) buffer, in `ProcessQueryImpl`
+  (`src/quantization/scalar_quantization/sq8_uniform_quantizer.cpp:179`).
+- Each base vector code is **never decoded back to fp32**. The kernel
+  `SQ8UniformComputeCodesIP(uint8_t* q, uint8_t* x, dim)` /
+  `SQ4UniformComputeCodesIP(...)` reads both operands as raw integer codes
+  and does the dot product on uint8 / packed nibble lanes using AVX-512 /
+  AMX (or NEON on ARM), one cache-line at a time. There is no per-element
+  fp dequantization in the inner loop.
+- The single shared scale factor and offset are applied **once per
+  pair**, after the integer reduction, to recover the fp distance. Some
+  metric-specific corrections (a per-vector norm or sum) are also added
+  outside the loop; see the trailing metadata noted in
+  `sq8_uniform_quantizer.cpp:200` and the
+  `SQ8UniformComputeCodesIPBatch` batch kernel.
+
+In the per-dimension `sq*` quantizers, each coordinate has its own
+`(min_i, max_i)` so the kernel either has to multiply by a per-dim scale
+table inside the loop or decode at least one operand back to fp first.
+Skipping that work is what makes uniform variants significantly faster at
+the same recall.
+
+## When to use it
+
+- **HGraph / IVF / Pyramid hot paths.** When the bottleneck is the
+  base-quantizer distance computation, `sq8_uniform` / `sq4_uniform` are
+  almost always faster than their non-uniform counterparts at comparable
+  recall.
+- **Data with similar coordinate ranges across dimensions.** Normalized
+  embeddings (cosine), or vectors that have already been rotated (e.g.
+  through a [Transform Quantizer](../advanced/quantization_transform.md)
+  chain like `"rom, sq8_uniform"` or `"fht, sq8_uniform"`) are the ideal
+  inputs.
+- **As the terminal quantizer of a `tq` chain.** The most common chain is
+  `"pca, rom, sq8_uniform"`, see example 501.
+
+## SQ4 uniform vs SQ8 uniform
+
+| Type | Bits / dim | Memory vs fp32 | Typical accuracy |
+| --- | --- | --- | --- |
+| `sq8_uniform` | 8 | ~1/4 | minor recall loss |
+| `sq4_uniform` | 4 | ~1/8 | needs reorder for high recall |
+
+## Parameters
+
+| Key | Type | Default | Applies to | Meaning |
+| --- | --- | --- | --- | --- |
+| `sq4_uniform_trunc_rate` | float | `0.05` | `sq4_uniform` only | Symmetric truncation rate for outliers (`src/quantization/scalar_quantization/sq4_uniform_quantizer_parameter.h:39`). Higher values clip more extreme coordinates, reducing range loss for the bulk of the data at the cost of clipping the tails. |
+
+`sq8_uniform` has no quantizer-specific JSON parameters.
+
+When using HGraph, `sq4_uniform_trunc_rate` is exposed as a top-level key
+and mapped into the nested quantization params
+(`src/algorithm/hgraph.cpp:409-416`).
+
+```json
+{
+    "dtype": "float32",
+    "metric_type": "l2",
+    "dim": 128,
+    "index_param": {
+        "base_quantization_type": "sq4_uniform",
+        "sq4_uniform_trunc_rate": 0.05,
+        "max_degree": 32,
+        "ef_construction": 300,
+        "use_reorder": true,
+        "precise_quantization_type": "fp32"
+    }
+}
+```
+
+Set `"base_quantization_type": "sq8_uniform"` and drop the `trunc_rate`
+key for the 8-bit variant.
+
+## Training
+
+`NEED_TRAIN` is set. Training estimates one global `[min, max]` across all
+dimensions (with optional truncation for `sq4_uniform`). `Build` will
+perform training internally.
+
+## Metric compatibility
+
+`l2`, `ip`, `cosine` — all supported. `cosine` normalizes before quantizing,
+which is also what makes uniform scaling close to optimal for that metric.
+
+## Choosing between uniform and non-uniform
+
+- Data is normalized (`cosine` or pre-normalized `l2`) → **uniform**.
+- Data has very heterogeneous per-dimension ranges (e.g. mixed feature
+  blocks) → start with non-uniform [`sq*`](sq.md), or use uniform behind a
+  rotation transformer (`"rom, sq*_uniform"`).
+- Throughput matters more than the last bit of recall → **uniform**.
+
+## Related pages
+
+- [Scalar Quantization (SQ4 / SQ8)](sq.md)
+- [Transform Quantizer](../advanced/quantization_transform.md)
+- [Quantization overview](README.md)

--- a/docs/docs/en/src/resources/index_parameters.md
+++ b/docs/docs/en/src/resources/index_parameters.md
@@ -69,7 +69,7 @@ HGraph places its build parameters under the generic `index_param` key (see
 |-------|---------|-------------|
 | `max_degree` | 16–48 | Maximum out-degree per node |
 | `ef_construction` | 200–500 | Candidate set size during build; larger = higher recall, slower build |
-| `base_quantization_type` | `fp32` / `fp16` / `bf16` / `sq8` / `sq4` / `pq` | Quantization of the base storage |
+| `base_quantization_type` | `fp32` / `fp16` / `bf16` / `sq8` / `sq4` / `pq` | Quantization of the base storage — see the [Quantization chapter](../quantization/README.md) for all supported values |
 
 At search time:
 

--- a/docs/docs/zh/src/SUMMARY.md
+++ b/docs/docs/zh/src/SUMMARY.md
@@ -19,6 +19,18 @@
 - [Pyramid](indexes/pyramid.md)
 - [BruteForce](indexes/brute_force.md)
 
+# 量化
+
+- [总览](quantization/README.md)
+- [FP32（基线）](quantization/fp32.md)
+- [半精度浮点（FP16 / BF16）](quantization/fp16_bf16.md)
+- [标量量化（SQ4 / SQ8）](quantization/sq.md)
+- [Uniform 标量量化（SQ4 / SQ8 Uniform）](quantization/sq_uniform.md)
+- [乘积量化（PQ）](quantization/pq.md)
+- [PQ FastScan](quantization/pqfs.md)
+- [RaBitQ](quantization/rabitq.md)
+- [量化变换（TQ）](advanced/quantization_transform.md)
+
 # 开发者指南
 
 - [代码目录结构](development/code_structure.md)
@@ -42,7 +54,6 @@
 - [内存-磁盘混合索引](advanced/hybrid_index.md)
 - [Extra Info（附加信息）](advanced/extra_info.md)
 - [索引生命周期管理](advanced/index_lifecycle.md)
-- [量化变换](advanced/quantization_transform.md)
 
 # 性能与调优
 

--- a/docs/docs/zh/src/figures/quantization/fp-bitlayout.svg
+++ b/docs/docs/zh/src/figures/quantization/fp-bitlayout.svg
@@ -1,0 +1,58 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 300" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="13">
+  <title>fp32 vs fp16 vs bf16: IEEE 754 field widths</title>
+  <desc>Bit-level layout comparison of the three floating-point quantizers VSAG uses for storage: fp32 has 1 sign + 8 exponent + 23 mantissa bits, fp16 has 1 + 5 + 10, bf16 has 1 + 8 + 7.</desc>
+  <style>
+    .sign { fill: #3e3a39; stroke: #1a1614; stroke-width: 0.8; }
+    .exp  { fill: #f4bd37; stroke: #b88a16; stroke-width: 0.8; }
+    .mant { fill: #fce897; stroke: #b88a16; stroke-width: 0.8; }
+    .lbl { fill: #1a1614; }
+    .lbl-muted { fill: #6e6a66; }
+    .lbl-light { fill: #ffffff; }
+  </style>
+
+  <text class="lbl" x="20" y="24">IEEE 754 / bf16 位宽布局</text>
+
+  <!-- legend -->
+  <g transform="translate(440,12)">
+    <rect class="sign" x="0" y="0" width="14" height="14"/><text class="lbl-muted" x="20" y="12">符号位</text>
+    <rect class="exp"  x="70" y="0" width="14" height="14"/><text class="lbl-muted" x="90" y="12">指数位</text>
+    <rect class="mant" x="170" y="0" width="14" height="14"/><text class="lbl-muted" x="190" y="12">尾数位</text>
+  </g>
+
+  <!-- scale: 1 bit = 18 px for exp+mant; sign block widened to 28 px for legibility -->
+  <!-- fp32 row -->
+  <g transform="translate(60,60)">
+    <text class="lbl" x="-50" y="22" font-weight="700">fp32</text>
+    <rect class="sign" x="0"   y="0" width="28" height="34"/>
+    <rect class="exp"  x="28"  y="0" width="144" height="34"/>
+    <rect class="mant" x="172" y="0" width="414" height="34"/>
+    <text class="lbl-light" x="10" y="22">s</text>
+    <text class="lbl" x="74" y="22">8 bits</text>
+    <text class="lbl" x="324" y="22">23 bits</text>
+    <text class="lbl-muted" x="-20" y="52">范围 &#x00B1;3.4&#xD7;10&#x00B3;&#x2078;  &#xB7;  精度 &#x2248; 7 位十进制  &#xB7;  4 字节</text>
+  </g>
+
+  <!-- fp16 row -->
+  <g transform="translate(60,140)">
+    <text class="lbl" x="-50" y="22" font-weight="700">fp16</text>
+    <rect class="sign" x="0"   y="0" width="28" height="34"/>
+    <rect class="exp"  x="28"  y="0" width="90" height="34"/>
+    <rect class="mant" x="118" y="0" width="180" height="34"/>
+    <text class="lbl-light" x="10" y="22">s</text>
+    <text class="lbl" x="40" y="22">5 bits</text>
+    <text class="lbl" x="170" y="22">10 bits</text>
+    <text class="lbl-muted" x="-20" y="52">范围 &#x00B1;6.5&#xD7;10&#x2074;  &#xB7;  精度 &#x2248; 3 位十进制  &#xB7;  2 字节</text>
+  </g>
+
+  <!-- bf16 row -->
+  <g transform="translate(60,220)">
+    <text class="lbl" x="-50" y="22" font-weight="700">bf16</text>
+    <rect class="sign" x="0"   y="0" width="28" height="34"/>
+    <rect class="exp"  x="28"  y="0" width="144" height="34"/>
+    <rect class="mant" x="172" y="0" width="126" height="34"/>
+    <text class="lbl-light" x="10" y="22">s</text>
+    <text class="lbl" x="74" y="22">8 bits</text>
+    <text class="lbl" x="200" y="22">7 bits</text>
+    <text class="lbl-muted" x="-20" y="52">范围 &#x00B1;3.4&#xD7;10&#x00B3;&#x2078;  &#xB7;  精度 &#x2248; 2-3 位十进制  &#xB7;  2 字节</text>
+  </g>
+</svg>

--- a/docs/docs/zh/src/figures/quantization/pq-codebook.svg
+++ b/docs/docs/zh/src/figures/quantization/pq-codebook.svg
@@ -1,0 +1,134 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 280" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="13">
+  <title>Product Quantization: sub-vector split and codebook lookup</title>
+  <desc>A vector of dim D is split into M sub-vectors. Each sub-vector is mapped to the nearest centroid in a per-sub-space codebook of 2^nbits entries, producing M code IDs.</desc>
+  <style>
+    .vec { fill: #fff7d6; stroke: #f4bd37; stroke-width: 1.2; }
+    .sub { fill: #fce897; stroke: #b88a16; stroke-width: 1; }
+    .cb { fill: #fafafa; stroke: #3e3a39; stroke-width: 1; }
+    .row { fill: #ffffff; stroke: #cfcbc7; stroke-width: 0.8; }
+    .row-hit { fill: #fce897; stroke: #b88a16; stroke-width: 1.2; }
+    .lbl { fill: #1a1614; }
+    .lbl-muted { fill: #6e6a66; }
+    .arr { stroke: #3e3a39; stroke-width: 1.2; fill: none; }
+    .code { fill: #3e3a39; stroke: none; }
+  </style>
+
+  <!-- Top: original vector x of dim D -->
+  <text class="lbl" x="20" y="28">x &#x2208; &#8477;&#x1D49;  (D = M &#xB7; d&#x209B;)</text>
+  <g>
+    <rect class="vec" x="20" y="38" width="320" height="28" rx="3"/>
+    <!-- M=4 split markers -->
+    <line class="arr" x1="100" y1="38" x2="100" y2="66"/>
+    <line class="arr" x1="180" y1="38" x2="180" y2="66"/>
+    <line class="arr" x1="260" y1="38" x2="260" y2="66"/>
+    <text class="lbl-muted" x="50" y="57">x&#x2081;</text>
+    <text class="lbl-muted" x="130" y="57">x&#x2082;</text>
+    <text class="lbl-muted" x="210" y="57">x&#x2083;</text>
+    <text class="lbl-muted" x="290" y="57">x&#x2098;</text>
+  </g>
+  <text class="lbl-muted" x="20" y="84">切分为 M 个维度为 d&#x209B; = D/M 的子向量</text>
+
+  <!-- Arrow down to codebooks -->
+  <path class="arr" d="M170 96 L170 120" marker-end="url(#arrow)"/>
+
+  <!-- Codebooks row -->
+  <g transform="translate(20,128)">
+    <!-- codebook 1 -->
+    <text class="lbl" x="0" y="0">码本 C&#x2081;</text>
+    <g>
+      <rect class="cb" x="0" y="8" width="70" height="120"/>
+      <rect class="row" x="0" y="8" width="70" height="20"/>
+      <rect class="row" x="0" y="28" width="70" height="20"/>
+      <rect class="row-hit" x="0" y="48" width="70" height="20"/>
+      <rect class="row" x="0" y="68" width="70" height="20"/>
+      <rect class="row" x="0" y="88" width="70" height="20"/>
+      <rect class="row" x="0" y="108" width="70" height="20"/>
+      <text class="lbl-muted" x="6" y="22">000</text>
+      <text class="lbl-muted" x="6" y="42">001</text>
+      <text class="code" x="6" y="62">010 &#x2190;</text>
+      <text class="lbl-muted" x="6" y="82">011</text>
+      <text class="lbl-muted" x="6" y="102">...</text>
+      <text class="lbl-muted" x="6" y="122">2&#x1D4F;&#x2212;1</text>
+    </g>
+
+    <!-- codebook 2 -->
+    <g transform="translate(110,0)">
+      <text class="lbl" x="0" y="0">码本 C&#x2082;</text>
+      <rect class="cb" x="0" y="8" width="70" height="120"/>
+      <rect class="row-hit" x="0" y="8" width="70" height="20"/>
+      <rect class="row" x="0" y="28" width="70" height="20"/>
+      <rect class="row" x="0" y="48" width="70" height="20"/>
+      <rect class="row" x="0" y="68" width="70" height="20"/>
+      <rect class="row" x="0" y="88" width="70" height="20"/>
+      <rect class="row" x="0" y="108" width="70" height="20"/>
+      <text class="code" x="6" y="22">000 &#x2190;</text>
+      <text class="lbl-muted" x="6" y="42">001</text>
+      <text class="lbl-muted" x="6" y="62">010</text>
+      <text class="lbl-muted" x="6" y="82">011</text>
+      <text class="lbl-muted" x="6" y="102">...</text>
+      <text class="lbl-muted" x="6" y="122">2&#x1D4F;&#x2212;1</text>
+    </g>
+
+    <!-- codebook 3 -->
+    <g transform="translate(220,0)">
+      <text class="lbl" x="0" y="0">码本 C&#x2083;</text>
+      <rect class="cb" x="0" y="8" width="70" height="120"/>
+      <rect class="row" x="0" y="8" width="70" height="20"/>
+      <rect class="row" x="0" y="28" width="70" height="20"/>
+      <rect class="row" x="0" y="48" width="70" height="20"/>
+      <rect class="row-hit" x="0" y="68" width="70" height="20"/>
+      <rect class="row" x="0" y="88" width="70" height="20"/>
+      <rect class="row" x="0" y="108" width="70" height="20"/>
+      <text class="lbl-muted" x="6" y="22">000</text>
+      <text class="lbl-muted" x="6" y="42">001</text>
+      <text class="lbl-muted" x="6" y="62">010</text>
+      <text class="code" x="6" y="82">011 &#x2190;</text>
+      <text class="lbl-muted" x="6" y="102">...</text>
+      <text class="lbl-muted" x="6" y="122">2&#x1D4F;&#x2212;1</text>
+    </g>
+
+    <!-- codebook M -->
+    <g transform="translate(330,0)">
+      <text class="lbl" x="0" y="0">码本 C&#x2098;</text>
+      <rect class="cb" x="0" y="8" width="70" height="120"/>
+      <rect class="row" x="0" y="8" width="70" height="20"/>
+      <rect class="row-hit" x="0" y="28" width="70" height="20"/>
+      <rect class="row" x="0" y="48" width="70" height="20"/>
+      <rect class="row" x="0" y="68" width="70" height="20"/>
+      <rect class="row" x="0" y="88" width="70" height="20"/>
+      <rect class="row" x="0" y="108" width="70" height="20"/>
+      <text class="lbl-muted" x="6" y="22">000</text>
+      <text class="code" x="6" y="42">001 &#x2190;</text>
+      <text class="lbl-muted" x="6" y="62">010</text>
+      <text class="lbl-muted" x="6" y="82">011</text>
+      <text class="lbl-muted" x="6" y="102">...</text>
+      <text class="lbl-muted" x="6" y="122">2&#x1D4F;&#x2212;1</text>
+    </g>
+
+    <!-- arrow right to output -->
+    <path class="arr" d="M410 70 L440 70" marker-end="url(#arrow)"/>
+
+    <!-- output codes -->
+    <g transform="translate(450,40)">
+      <text class="lbl" x="0" y="0">PQ code（M &#xB7; nbits）</text>
+      <g>
+        <rect class="sub" x="0" y="8" width="50" height="28"/>
+        <rect class="sub" x="50" y="8" width="50" height="28"/>
+        <rect class="sub" x="100" y="8" width="50" height="28"/>
+        <rect class="sub" x="150" y="8" width="50" height="28"/>
+      </g>
+      <text class="code" x="14" y="27">010</text>
+      <text class="code" x="64" y="27">000</text>
+      <text class="code" x="114" y="27">011</text>
+      <text class="code" x="164" y="27">001</text>
+      <text class="lbl-muted" x="0" y="56">每向量 M &#xB7; nbits bits</text>
+      <text class="lbl-muted" x="0" y="74">例：M=64, b=8 &#x2192; 64 B</text>
+    </g>
+  </g>
+
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#3e3a39"/>
+    </marker>
+  </defs>
+</svg>

--- a/docs/docs/zh/src/figures/quantization/pqfs-block.svg
+++ b/docs/docs/zh/src/figures/quantization/pqfs-block.svg
@@ -1,0 +1,126 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 380" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="13">
+  <title>PQ FastScan block layout and SIMD lookup</title>
+  <desc>FastScan stores 4-bit PQ codes for 16 vectors interleaved per sub-space so a single 128-bit SIMD register holds one column of 16 codes and a pshufb-style lookup decodes 16 partial distances in one instruction.</desc>
+  <style>
+    .blk { fill: #ffffff; stroke: #cfcbc7; stroke-width: 1; }
+    .cell { fill: #fce897; stroke: #b88a16; stroke-width: 0.8; }
+    .cell-col { fill: #f4bd37; stroke: #b88a16; stroke-width: 1.2; }
+    .lut { fill: #ffffff; stroke: #3e3a39; stroke-width: 1; }
+    .lut-cell { fill: #ffffff; stroke: #cfcbc7; }
+    .lbl { fill: #1a1614; }
+    .lbl-muted { fill: #6e6a66; }
+    .arr { stroke: #3e3a39; stroke-width: 1.2; fill: none; }
+  </style>
+  <defs>
+    <marker id="arr" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#3e3a39"/>
+    </marker>
+  </defs>
+
+  <text class="lbl" x="20" y="24">FastScan block &#x2014; 16 个向量 &#xD7; M 个子空间，4-bit code 交错排布</text>
+
+  <!-- block of 16x8 cells (M=8 shown) -->
+  <g transform="translate(40,50)">
+    <rect class="blk" x="-4" y="-4" width="408" height="248"/>
+    <text class="lbl-muted" x="-30" y="14">v&#x2080;</text>
+    <text class="lbl-muted" x="-30" y="29">v&#x2081;</text>
+    <text class="lbl-muted" x="-30" y="44">v&#x2082;</text>
+    <text class="lbl-muted" x="-30" y="59">...</text>
+    <text class="lbl-muted" x="-30" y="224">v&#x2081;&#x2085;</text>
+
+    <text class="lbl-muted" x="0" y="-12">m=0</text>
+    <text class="lbl-muted" x="50" y="-12">m=1</text>
+    <text class="lbl-muted" x="100" y="-12">m=2</text>
+    <text class="lbl-muted" x="150" y="-12">m=3</text>
+    <text class="lbl-muted" x="350" y="-12">m=M&#x2212;1</text>
+
+    <!-- grid: 8 cols x 16 rows -->
+    <g>
+      <!-- column m=2 highlighted -->
+      <g>
+        <rect class="cell-col" x="100" y="0" width="50" height="240"/>
+      </g>
+      <!-- cells filling -->
+      <g fill="#fce897" stroke="#b88a16" stroke-width="0.6">
+        <!-- 16 rows x 8 cols -->
+        <g transform="translate(0,0)">
+          <rect class="cell" x="0"   y="0" width="50" height="15"/>
+          <rect class="cell" x="50"  y="0" width="50" height="15"/>
+          <rect class="cell-col" x="100" y="0" width="50" height="15"/>
+          <rect class="cell" x="150" y="0" width="50" height="15"/>
+          <rect class="cell" x="200" y="0" width="50" height="15"/>
+          <rect class="cell" x="250" y="0" width="50" height="15"/>
+          <rect class="cell" x="300" y="0" width="50" height="15"/>
+          <rect class="cell" x="350" y="0" width="50" height="15"/>
+        </g>
+        <g transform="translate(0,15)">
+          <rect class="cell" x="0"   y="0" width="50" height="15"/>
+          <rect class="cell" x="50"  y="0" width="50" height="15"/>
+          <rect class="cell-col" x="100" y="0" width="50" height="15"/>
+          <rect class="cell" x="150" y="0" width="50" height="15"/>
+          <rect class="cell" x="200" y="0" width="50" height="15"/>
+          <rect class="cell" x="250" y="0" width="50" height="15"/>
+          <rect class="cell" x="300" y="0" width="50" height="15"/>
+          <rect class="cell" x="350" y="0" width="50" height="15"/>
+        </g>
+        <g transform="translate(0,30)">
+          <rect class="cell" x="0"   y="0" width="50" height="15"/>
+          <rect class="cell" x="50"  y="0" width="50" height="15"/>
+          <rect class="cell-col" x="100" y="0" width="50" height="15"/>
+          <rect class="cell" x="150" y="0" width="50" height="15"/>
+          <rect class="cell" x="200" y="0" width="50" height="15"/>
+          <rect class="cell" x="250" y="0" width="50" height="15"/>
+          <rect class="cell" x="300" y="0" width="50" height="15"/>
+          <rect class="cell" x="350" y="0" width="50" height="15"/>
+        </g>
+        <g transform="translate(0,45)" opacity="0.55">
+          <rect class="cell" x="0"   y="0" width="50" height="15"/>
+          <rect class="cell" x="50"  y="0" width="50" height="15"/>
+          <rect class="cell-col" x="100" y="0" width="50" height="15"/>
+          <rect class="cell" x="150" y="0" width="50" height="15"/>
+          <rect class="cell" x="200" y="0" width="50" height="15"/>
+          <rect class="cell" x="250" y="0" width="50" height="15"/>
+          <rect class="cell" x="300" y="0" width="50" height="15"/>
+          <rect class="cell" x="350" y="0" width="50" height="15"/>
+        </g>
+        <!-- skip middle rows visually -->
+        <g transform="translate(0,225)">
+          <rect class="cell" x="0"   y="0" width="50" height="15"/>
+          <rect class="cell" x="50"  y="0" width="50" height="15"/>
+          <rect class="cell-col" x="100" y="0" width="50" height="15"/>
+          <rect class="cell" x="150" y="0" width="50" height="15"/>
+          <rect class="cell" x="200" y="0" width="50" height="15"/>
+          <rect class="cell" x="250" y="0" width="50" height="15"/>
+          <rect class="cell" x="300" y="0" width="50" height="15"/>
+          <rect class="cell" x="350" y="0" width="50" height="15"/>
+        </g>
+      </g>
+      <text class="lbl-muted" x="180" y="130">&#x22EE; &#x22EE; &#x22EE; &#x22EE;</text>
+    </g>
+
+    <!-- one column annotated as a SIMD register -->
+    <text class="lbl" x="160" y="270">列 m=2：16 个 code &#xD7; 4 bits = 64 bits</text>
+    <text class="lbl-muted" x="160" y="288">（128-bit SIMD 寄存器的一半）</text>
+  </g>
+
+  <!-- arrow to LUT -->
+  <path class="arr" d="M455 170 L515 170" marker-end="url(#arr)"/>
+  <text class="lbl" x="465" y="158">pshufb</text>
+
+  <!-- LUT 16 entries -->
+  <g transform="translate(525,50)">
+    <text class="lbl" x="0" y="14">LUT（每 query / 每 m）</text>
+    <rect class="lut" x="0" y="22" width="80" height="240"/>
+    <g font-size="11" fill="#3e3a39">
+      <rect class="lut-cell" x="0" y="22" width="80" height="15"/><text x="6" y="33">d&#x2080;</text>
+      <rect class="lut-cell" x="0" y="37" width="80" height="15"/><text x="6" y="48">d&#x2081;</text>
+      <rect class="lut-cell" x="0" y="52" width="80" height="15"/><text x="6" y="63">d&#x2082;</text>
+      <rect class="lut-cell" x="0" y="67" width="80" height="15"/><text x="6" y="78">d&#x2083;</text>
+      <rect class="lut-cell" x="0" y="82" width="80" height="15"/><text x="6" y="93">...</text>
+      <rect class="lut-cell" x="0" y="247" width="80" height="15"/><text x="6" y="258">d&#x2081;&#x2085;</text>
+    </g>
+    <text class="lbl-muted" x="0" y="282">2&#x2074; = 16 项</text>
+    <text class="lbl-muted" x="0" y="298">一次 shuffle &#x2192;</text>
+    <text class="lbl-muted" x="0" y="314">16 个部分距离</text>
+  </g>
+</svg>

--- a/docs/docs/zh/src/figures/quantization/quantization-overview.svg
+++ b/docs/docs/zh/src/figures/quantization/quantization-overview.svg
@@ -1,0 +1,118 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 480" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="13">
+  <title>Quantizer selection decision tree</title>
+  <desc>Decision tree that helps pick a base quantizer in VSAG based on memory budget, vector dimension and reorder needs.</desc>
+  <style>
+    .node { fill: #fff7d6; stroke: #b88a16; stroke-width: 1.2; }
+    .leaf { fill: #f4bd37; stroke: #b88a16; stroke-width: 1.4; }
+    .leaf-dark { fill: #3e3a39; stroke: #1a1614; stroke-width: 1.4; }
+    .branch { stroke: #3e3a39; stroke-width: 1.2; fill: none; }
+    .lbl { fill: #1a1614; }
+    .lbl-light { fill: #ffffff; }
+    .lbl-muted { fill: #6e6a66; }
+  </style>
+
+  <text class="lbl" x="20" y="24">如何选择基础量化器</text>
+
+  <!-- root -->
+  <g transform="translate(280,50)">
+    <rect class="node" x="0" y="0" width="160" height="46" rx="6"/>
+    <text class="lbl" x="14" y="20">内存预算？</text>
+    <text class="lbl-muted" x="14" y="38">（相对精度）</text>
+  </g>
+
+  <!-- branches from root -->
+  <path class="branch" d="M320 96 L130 150"/>
+  <path class="branch" d="M360 96 L360 150"/>
+  <path class="branch" d="M400 96 L590 150"/>
+
+  <!-- branch labels -->
+  <text class="lbl-muted" x="170" y="125">紧</text>
+  <text class="lbl-muted" x="340" y="125">均衡</text>
+  <text class="lbl-muted" x="540" y="125">宽松</text>
+
+  <!-- level 2: three boxes -->
+  <!-- strict: high compression -->
+  <g transform="translate(30,150)">
+    <rect class="node" x="0" y="0" width="200" height="46" rx="6"/>
+    <text class="lbl" x="14" y="20">需 ~64&#xD7; 压缩？</text>
+    <text class="lbl-muted" x="14" y="38">典型 dim &#x2265; 128</text>
+  </g>
+  <!-- balanced -->
+  <g transform="translate(260,150)">
+    <rect class="node" x="0" y="0" width="200" height="46" rx="6"/>
+    <text class="lbl" x="14" y="20">每维 8 字节可接受？</text>
+    <text class="lbl-muted" x="14" y="38">相对 fp32 压 4&#xD7;</text>
+  </g>
+  <!-- loose -->
+  <g transform="translate(490,150)">
+    <rect class="node" x="0" y="0" width="200" height="46" rx="6"/>
+    <text class="lbl" x="14" y="20">需要精确距离？</text>
+    <text class="lbl-muted" x="14" y="38">是否有训练数据？</text>
+  </g>
+
+  <!-- branches from strict -->
+  <path class="branch" d="M97  196 L70  250"/>
+  <path class="branch" d="M163 196 L195 250"/>
+  <text class="lbl-muted" x="55"  y="222">是</text>
+  <text class="lbl-muted" x="175" y="222">否</text>
+
+  <!-- branches from balanced -->
+  <path class="branch" d="M327 196 L345 250"/>
+  <path class="branch" d="M393 196 L515 250"/>
+  <text class="lbl-muted" x="310" y="222">是</text>
+  <text class="lbl-muted" x="405" y="222">否</text>
+
+  <!-- branches from loose -->
+  <path class="branch" d="M557 196 L515 250"/>
+  <path class="branch" d="M623 196 L650 250"/>
+  <text class="lbl-muted" x="540" y="222">否</text>
+  <text class="lbl-muted" x="635" y="222">是</text>
+
+  <!-- leaves -->
+  <g transform="translate(20,250)">
+    <!-- rabitq -->
+    <g transform="translate(0,0)">
+      <rect class="leaf" x="0" y="0" width="100" height="40" rx="6"/>
+      <text class="lbl" x="14" y="18">rabitq</text>
+      <text class="lbl-muted" x="14" y="34">~1 bit/维</text>
+    </g>
+    <!-- pq / pqfs -->
+    <g transform="translate(120,0)">
+      <rect class="leaf" x="0" y="0" width="110" height="40" rx="6"/>
+      <text class="lbl" x="14" y="18">pq / pqfs</text>
+      <text class="lbl-muted" x="14" y="34">4-8 bits/维</text>
+    </g>
+    <!-- sq family -->
+    <g transform="translate(240,0)">
+      <rect class="leaf" x="0" y="0" width="170" height="40" rx="6"/>
+      <text class="lbl" x="14" y="18">sq* 家族</text>
+      <text class="lbl-muted" x="14" y="34">4-8 bits/维</text>
+    </g>
+    <!-- fp16 / bf16 -->
+    <g transform="translate(430,0)">
+      <rect class="leaf" x="0" y="0" width="130" height="40" rx="6"/>
+      <text class="lbl" x="14" y="18">fp16 / bf16</text>
+      <text class="lbl-muted" x="14" y="34">16 bits/维</text>
+    </g>
+    <!-- fp32 -->
+    <g transform="translate(580,0)">
+      <rect class="leaf-dark" x="0" y="0" width="100" height="40" rx="6"/>
+      <text class="lbl-light" x="14" y="18">fp32</text>
+      <text class="lbl-light" x="14" y="34">无损</text>
+    </g>
+  </g>
+
+  <!-- reorder hint band -->
+  <g transform="translate(40,330)">
+    <rect class="node" x="0" y="0" width="660" height="50" rx="6"/>
+    <text class="lbl" x="14" y="20">既要省内存又要高召回？把小的基础量化器与下面配合使用</text>
+    <text class="lbl" x="14" y="38">use_reorder=true 且 precise_quantization_type=&quot;fp16&quot; 或 &quot;fp32&quot;</text>
+  </g>
+
+  <!-- bottom row of caveats -->
+  <g transform="translate(40,400)">
+    <text class="lbl-muted" x="0" y="14">&#x2022; pq / pqfs 需要训练：每个子空间采样 &#x2265; 256 &#xB7; 2^pq_bits</text>
+    <text class="lbl-muted" x="0" y="32">&#x2022; sq*_uniform 拟合单一全局 [min, max]（元数据更小，鲁棒性略低）</text>
+    <text class="lbl-muted" x="0" y="50">&#x2022; rabitq + reorder 是召回敏感场景的标准方案</text>
+  </g>
+</svg>

--- a/docs/docs/zh/src/figures/quantization/rabitq-hyperplane.svg
+++ b/docs/docs/zh/src/figures/quantization/rabitq-hyperplane.svg
@@ -1,0 +1,91 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 340" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="13">
+  <title>RaBitQ: 1-bit signed code via random hyperplane</title>
+  <desc>RaBitQ normalises each vector, then encodes each dimension by the sign of its inner product against a random orthonormal basis. The stored code is one bit per dim plus a small per-vector residual norm; reorder against a precise copy recovers full recall.</desc>
+  <style>
+    .sphere { fill: #fff7d6; stroke: #b88a16; stroke-width: 1.2; }
+    .axis { stroke: #cfcbc7; stroke-width: 1; }
+    .hp { stroke: #3e3a39; stroke-width: 1.5; stroke-dasharray: 6 4; }
+    .pt-plus { fill: #f4bd37; stroke: #b88a16; stroke-width: 1; }
+    .pt-minus { fill: #3e3a39; stroke: #1a1614; stroke-width: 1; }
+    .lbl { fill: #1a1614; }
+    .lbl-muted { fill: #6e6a66; }
+    .arr { stroke: #3e3a39; stroke-width: 1.2; fill: none; }
+    .codebox { fill: #fce897; stroke: #b88a16; stroke-width: 1; }
+  </style>
+  <defs>
+    <marker id="arr" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#3e3a39"/>
+    </marker>
+  </defs>
+
+  <text class="lbl" x="20" y="24">RaBitQ &#x2014; sign(&#x27E8;x, p&#x1D62;&#x27E9;) 给出每维 1 bit</text>
+
+  <!-- sphere with hyperplane -->
+  <g transform="translate(160,180)">
+    <circle class="sphere" cx="0" cy="0" r="110"/>
+    <line class="axis" x1="-110" y1="0" x2="110" y2="0"/>
+    <line class="axis" x1="0" y1="-110" x2="0" y2="110"/>
+    <!-- hyperplane perpendicular to p_i (direction ~ (cos30, sin30)) -->
+    <line class="hp" x1="-100" y1="-58" x2="100" y2="58"/>
+    <text class="lbl-muted" x="78" y="62">p&#x1D62;</text>
+    <!-- arrow showing p_i direction -->
+    <line class="arr" x1="0" y1="0" x2="60" y2="-35" marker-end="url(#arr)"/>
+
+    <!-- + side points -->
+    <circle class="pt-plus" cx="55" cy="-65" r="5"/>
+    <circle class="pt-plus" cx="85" cy="-15" r="5"/>
+    <circle class="pt-plus" cx="35" cy="-40" r="5"/>
+    <circle class="pt-plus" cx="70" cy="-90" r="5"/>
+    <circle class="pt-plus" cx="20" cy="-95" r="5"/>
+
+    <!-- - side points -->
+    <circle class="pt-minus" cx="-50" cy="40" r="5"/>
+    <circle class="pt-minus" cx="-85" cy="10" r="5"/>
+    <circle class="pt-minus" cx="-30" cy="65" r="5"/>
+    <circle class="pt-minus" cx="-70" cy="-15" r="5"/>
+    <circle class="pt-minus" cx="-15" cy="85" r="5"/>
+
+    <text class="lbl" x="75" y="-95">b&#x1D62; = 1</text>
+    <text class="lbl" x="-100" y="100">b&#x1D62; = 0</text>
+  </g>
+
+  <!-- arrow to bit string -->
+  <path class="arr" d="M310 180 L370 180" marker-end="url(#arr)"/>
+
+  <!-- right side: bit string + reorder -->
+  <g transform="translate(385,80)">
+    <text class="lbl" x="0" y="0">每向量的存储 code</text>
+    <g>
+      <rect class="codebox" x="0" y="12" width="22" height="22"/>
+      <rect class="codebox" x="22" y="12" width="22" height="22"/>
+      <rect class="codebox" x="44" y="12" width="22" height="22"/>
+      <rect class="codebox" x="66" y="12" width="22" height="22"/>
+      <rect class="codebox" x="88" y="12" width="22" height="22"/>
+      <rect class="codebox" x="110" y="12" width="22" height="22"/>
+      <rect class="codebox" x="132" y="12" width="22" height="22"/>
+      <rect class="codebox" x="154" y="12" width="22" height="22"/>
+      <rect class="codebox" x="176" y="12" width="22" height="22"/>
+      <rect class="codebox" x="198" y="12" width="22" height="22"/>
+      <text class="lbl" x="6" y="28">1</text>
+      <text class="lbl" x="28" y="28">0</text>
+      <text class="lbl" x="50" y="28">1</text>
+      <text class="lbl" x="72" y="28">1</text>
+      <text class="lbl" x="94" y="28">0</text>
+      <text class="lbl" x="116" y="28">0</text>
+      <text class="lbl" x="138" y="28">1</text>
+      <text class="lbl" x="160" y="28">0</text>
+      <text class="lbl" x="182" y="28">1</text>
+      <text class="lbl" x="204" y="28">1</text>
+    </g>
+    <text class="lbl-muted" x="0" y="56">d bits + 1 个 fp16 残差范数</text>
+    <text class="lbl-muted" x="0" y="74">&#x2192; 每向量 &#x2248; d/8 + 2 字节</text>
+
+    <text class="lbl" x="0" y="120">距离：</text>
+    <text class="lbl-muted" x="0" y="140">popcount(q_code XOR x_code)</text>
+    <text class="lbl-muted" x="0" y="158">按残差范数缩放</text>
+
+    <text class="lbl" x="0" y="200">提升精度：</text>
+    <text class="lbl-muted" x="0" y="220">use_reorder=true + fp16</text>
+    <text class="lbl-muted" x="0" y="238">对 top-k 用精确副本重排</text>
+  </g>
+</svg>

--- a/docs/docs/zh/src/figures/quantization/sq-axis.svg
+++ b/docs/docs/zh/src/figures/quantization/sq-axis.svg
@@ -1,0 +1,77 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 220" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="13">
+  <title>Scalar Quantization: float range mapped to integer bins</title>
+  <desc>The float range [v_min, v_max] is split into 2^bits equal-width bins. Each float value lands in one bin and is stored as the bin index. The decoded value is the bin centre.</desc>
+  <style>
+    .axis { stroke: #3e3a39; stroke-width: 1.4; fill: none; }
+    .tick { stroke: #3e3a39; stroke-width: 1; }
+    .bin  { fill: #fce897; stroke: #b88a16; stroke-width: 1; }
+    .bin-hit { fill: #f4bd37; stroke: #b88a16; stroke-width: 1.4; }
+    .lbl { fill: #1a1614; }
+    .lbl-muted { fill: #6e6a66; }
+    .pt { fill: #3e3a39; }
+    .arr { stroke: #3e3a39; stroke-width: 1.2; fill: none; }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#3e3a39"/>
+    </marker>
+  </defs>
+
+  <!-- title -->
+  <text class="lbl" x="20" y="26">float 范围 &#x2192; 2&#x1D4F; 个 bin（此处 b = 3，共 8 个 bin）</text>
+
+  <!-- bins -->
+  <g transform="translate(60,60)">
+    <rect class="bin"     x="0"   y="0" width="70" height="32"/>
+    <rect class="bin"     x="70"  y="0" width="70" height="32"/>
+    <rect class="bin-hit" x="140" y="0" width="70" height="32"/>
+    <rect class="bin"     x="210" y="0" width="70" height="32"/>
+    <rect class="bin"     x="280" y="0" width="70" height="32"/>
+    <rect class="bin"     x="350" y="0" width="70" height="32"/>
+    <rect class="bin"     x="420" y="0" width="70" height="32"/>
+    <rect class="bin"     x="490" y="0" width="70" height="32"/>
+
+    <text class="lbl" x="28" y="20">000</text>
+    <text class="lbl" x="98" y="20">001</text>
+    <text class="lbl" x="168" y="20">010</text>
+    <text class="lbl" x="238" y="20">011</text>
+    <text class="lbl" x="308" y="20">100</text>
+    <text class="lbl" x="378" y="20">101</text>
+    <text class="lbl" x="448" y="20">110</text>
+    <text class="lbl" x="518" y="20">111</text>
+  </g>
+
+  <!-- axis below -->
+  <g transform="translate(60,110)">
+    <line class="axis" x1="0" y1="0" x2="560" y2="0" marker-end="url(#arrow)"/>
+    <line class="tick" x1="0" y1="-5" x2="0" y2="5"/>
+    <line class="tick" x1="70" y1="-4" x2="70" y2="4"/>
+    <line class="tick" x1="140" y1="-4" x2="140" y2="4"/>
+    <line class="tick" x1="210" y1="-4" x2="210" y2="4"/>
+    <line class="tick" x1="280" y1="-4" x2="280" y2="4"/>
+    <line class="tick" x1="350" y1="-4" x2="350" y2="4"/>
+    <line class="tick" x1="420" y1="-4" x2="420" y2="4"/>
+    <line class="tick" x1="490" y1="-4" x2="490" y2="4"/>
+    <line class="tick" x1="560" y1="-5" x2="560" y2="5"/>
+
+    <text class="lbl-muted" x="-18" y="22">v_min</text>
+    <text class="lbl-muted" x="540" y="22">v_max</text>
+
+    <!-- sample data point lands in bin "010" -->
+    <circle class="pt" cx="170" cy="0" r="4"/>
+    <text class="lbl" x="155" y="-12">x</text>
+  </g>
+
+  <!-- arrow from bin to code -->
+  <path class="arr" d="M230 96 L230 140" marker-end="url(#arrow)"/>
+  <text class="lbl" x="240" y="125">存储 bin 索引</text>
+
+  <!-- output -->
+  <g transform="translate(120,160)">
+    <rect class="bin-hit" x="0" y="0" width="70" height="28"/>
+    <text class="lbl" x="22" y="20">010</text>
+    <text class="lbl-muted" x="80" y="20">每维 b bits &#x2192;  每向量 d &#xB7; b bits</text>
+  </g>
+
+  <text class="lbl-muted" x="20" y="208">解码：x&#x0302; = v_min + (idx + &#xBD;) &#xB7; (v_max &#x2212; v_min) / 2&#x1D4F;</text>
+</svg>

--- a/docs/docs/zh/src/figures/quantization/sq-uniform-vs-perdim.svg
+++ b/docs/docs/zh/src/figures/quantization/sq-uniform-vs-perdim.svg
@@ -1,0 +1,118 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 320" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="13">
+  <title>Uniform SQ vs per-dim SQ: range estimation</title>
+  <desc>Uniform SQ uses one global [min, max] shared by every dimension; per-dim SQ stores a separate [min_i, max_i] for each dimension. Per-dim handles skewed dimensions better but stores 2D extra floats.</desc>
+  <style>
+    .panel { fill: #ffffff; stroke: #cfcbc7; stroke-width: 1; }
+    .axis  { stroke: #3e3a39; stroke-width: 1; fill: none; }
+    .range { stroke: #f4bd37; stroke-width: 4; stroke-linecap: round; }
+    .range-narrow { stroke: #b88a16; stroke-width: 4; stroke-linecap: round; }
+    .range-wide { stroke: #f4bd37; stroke-width: 4; stroke-linecap: round; }
+    .pt { fill: #3e3a39; }
+    .lbl { fill: #1a1614; }
+    .lbl-muted { fill: #6e6a66; }
+    .global { stroke: #b88a16; stroke-width: 1.5; stroke-dasharray: 4 4; }
+  </style>
+
+  <!-- Left panel: uniform -->
+  <g transform="translate(20,20)">
+    <rect class="panel" x="0" y="0" width="330" height="280"/>
+    <text class="lbl" x="14" y="22">uniform SQ &#x2014; 全局共享 [min, max]</text>
+
+    <!-- 4 dim rows -->
+    <g transform="translate(40,50)">
+      <!-- dim 1 -->
+      <text class="lbl-muted" x="-30" y="20">d&#x2081;</text>
+      <line class="axis" x1="0" y1="20" x2="260" y2="20"/>
+      <line class="global" x1="20" y1="10" x2="240" y2="10"/>
+      <line class="global" x1="20" y1="30" x2="240" y2="30"/>
+      <line class="range" x1="40" y1="20" x2="120" y2="20"/>
+      <circle class="pt" cx="60" cy="20" r="3"/>
+      <circle class="pt" cx="80" cy="20" r="3"/>
+      <circle class="pt" cx="100" cy="20" r="3"/>
+
+      <!-- dim 2 -->
+      <text class="lbl-muted" x="-30" y="70">d&#x2082;</text>
+      <line class="axis" x1="0" y1="70" x2="260" y2="70"/>
+      <line class="global" x1="20" y1="60" x2="240" y2="60"/>
+      <line class="global" x1="20" y1="80" x2="240" y2="80"/>
+      <line class="range" x1="160" y1="70" x2="230" y2="70"/>
+      <circle class="pt" cx="180" cy="70" r="3"/>
+      <circle class="pt" cx="200" cy="70" r="3"/>
+      <circle class="pt" cx="220" cy="70" r="3"/>
+
+      <!-- dim 3 -->
+      <text class="lbl-muted" x="-30" y="120">d&#x2083;</text>
+      <line class="axis" x1="0" y1="120" x2="260" y2="120"/>
+      <line class="global" x1="20" y1="110" x2="240" y2="110"/>
+      <line class="global" x1="20" y1="130" x2="240" y2="130"/>
+      <line class="range" x1="90" y1="120" x2="170" y2="120"/>
+      <circle class="pt" cx="110" cy="120" r="3"/>
+      <circle class="pt" cx="130" cy="120" r="3"/>
+      <circle class="pt" cx="150" cy="120" r="3"/>
+
+      <!-- dim 4 -->
+      <text class="lbl-muted" x="-30" y="170">d&#x2084;</text>
+      <line class="axis" x1="0" y1="170" x2="260" y2="170"/>
+      <line class="global" x1="20" y1="160" x2="240" y2="160"/>
+      <line class="global" x1="20" y1="180" x2="240" y2="180"/>
+      <line class="range" x1="40" y1="170" x2="230" y2="170"/>
+      <circle class="pt" cx="60" cy="170" r="3"/>
+      <circle class="pt" cx="140" cy="170" r="3"/>
+      <circle class="pt" cx="220" cy="170" r="3"/>
+    </g>
+
+    <text class="lbl-muted" x="14" y="252">共享范围会让窄分布的维度浪费 bin</text>
+    <text class="lbl-muted" x="14" y="268">存储开销：合计 2 个 float</text>
+  </g>
+
+  <!-- Right panel: per-dim -->
+  <g transform="translate(370,20)">
+    <rect class="panel" x="0" y="0" width="330" height="280"/>
+    <text class="lbl" x="14" y="22">per-dim SQ &#x2014; 每维独立 [min_i, max_i]</text>
+
+    <g transform="translate(40,50)">
+      <!-- dim 1: tight -->
+      <text class="lbl-muted" x="-30" y="20">d&#x2081;</text>
+      <line class="axis" x1="0" y1="20" x2="260" y2="20"/>
+      <line class="global" x1="40" y1="10" x2="120" y2="10"/>
+      <line class="global" x1="40" y1="30" x2="120" y2="30"/>
+      <line class="range-narrow" x1="40" y1="20" x2="120" y2="20"/>
+      <circle class="pt" cx="60" cy="20" r="3"/>
+      <circle class="pt" cx="80" cy="20" r="3"/>
+      <circle class="pt" cx="100" cy="20" r="3"/>
+
+      <!-- dim 2: tight, shifted -->
+      <text class="lbl-muted" x="-30" y="70">d&#x2082;</text>
+      <line class="axis" x1="0" y1="70" x2="260" y2="70"/>
+      <line class="global" x1="160" y1="60" x2="230" y2="60"/>
+      <line class="global" x1="160" y1="80" x2="230" y2="80"/>
+      <line class="range-narrow" x1="160" y1="70" x2="230" y2="70"/>
+      <circle class="pt" cx="180" cy="70" r="3"/>
+      <circle class="pt" cx="200" cy="70" r="3"/>
+      <circle class="pt" cx="220" cy="70" r="3"/>
+
+      <!-- dim 3: medium -->
+      <text class="lbl-muted" x="-30" y="120">d&#x2083;</text>
+      <line class="axis" x1="0" y1="120" x2="260" y2="120"/>
+      <line class="global" x1="90" y1="110" x2="170" y2="110"/>
+      <line class="global" x1="90" y1="130" x2="170" y2="130"/>
+      <line class="range-narrow" x1="90" y1="120" x2="170" y2="120"/>
+      <circle class="pt" cx="110" cy="120" r="3"/>
+      <circle class="pt" cx="130" cy="120" r="3"/>
+      <circle class="pt" cx="150" cy="120" r="3"/>
+
+      <!-- dim 4: wide -->
+      <text class="lbl-muted" x="-30" y="170">d&#x2084;</text>
+      <line class="axis" x1="0" y1="170" x2="260" y2="170"/>
+      <line class="global" x1="40" y1="160" x2="230" y2="160"/>
+      <line class="global" x1="40" y1="180" x2="230" y2="180"/>
+      <line class="range-wide" x1="40" y1="170" x2="230" y2="170"/>
+      <circle class="pt" cx="60" cy="170" r="3"/>
+      <circle class="pt" cx="140" cy="170" r="3"/>
+      <circle class="pt" cx="220" cy="170" r="3"/>
+    </g>
+
+    <text class="lbl-muted" x="14" y="252">每个维度都能用满 bin 预算</text>
+    <text class="lbl-muted" x="14" y="268">存储开销：2&#xB7;d 个 float</text>
+  </g>
+</svg>

--- a/docs/docs/zh/src/indexes/brute_force.md
+++ b/docs/docs/zh/src/indexes/brute_force.md
@@ -57,7 +57,7 @@ auto result = index->KnnSearch(query, /*topk=*/10, "{}").value();
 
 | 参数 | 类型 | 默认值 | 说明 |
 |------|------|--------|------|
-| `base_quantization_type` | string | `"fp32"` | `fp32`、`fp16`、`bf16`、`sq8`、`sq8_uniform`、`sq4_uniform`、`pq`、`pqfs`、`rabitq` |
+| `base_quantization_type` | string | `"fp32"` | `fp32`、`fp16`、`bf16`、`sq8`、`sq4`、`sq8_uniform`、`sq4_uniform`、`pq`、`pqfs`、`rabitq` —— 各量化器细节见[量化章节](../quantization/README.md) |
 | `use_attribute_filter` | bool | `false` | 启用属性过滤（参见 [属性过滤](../advanced/attribute_filter.md)） |
 
 > **关于 `store_raw_vector` 的说明。** `store_raw_vector` 字段会被共用的
@@ -81,7 +81,7 @@ auto result = index->KnnSearch(query, /*topk=*/10, "{}").value();
 }
 ```
 
-当 `base_quantization_type` 选择了需要训练的量化器（`sq8`、`sq8_uniform`、`sq4_uniform`、
+当 `base_quantization_type` 选择了需要训练的量化器（`sq8`、`sq4`、`sq8_uniform`、`sq4_uniform`、
 `pq`、`pqfs`、`rabitq`）时，`Build` 会先用传入的数据集训练量化器，此时召回率不再保证
 100%。只有 `fp32`、`fp16`、`bf16` 不需要训练，能保持精确距离（仅受浮点数值精度影响）。
 
@@ -124,7 +124,7 @@ BruteForce 声明的能力标志如下（参见 `BruteForce::InitFeatures`，
 | `SUPPORT_CHECK_ID_EXIST` / `SUPPORT_CLONE` / `SUPPORT_ESTIMATE_MEMORY` / `SUPPORT_GET_MEMORY_USAGE` | 标准的内省与生命周期接口。 |
 | `SUPPORT_SERIALIZE_BINARY_SET` / `SUPPORT_SERIALIZE_FILE` / `SUPPORT_SERIALIZE_WRITE_FUNC` | 完整的保存能力。 |
 | `SUPPORT_DESERIALIZE_BINARY_SET` / `SUPPORT_DESERIALIZE_FILE` / `SUPPORT_DESERIALIZE_READER_SET` | 完整的加载能力。（没有对应的 `DESERIALIZE_WRITE_FUNC`，读路径使用 `READER_SET` 形式。） |
-| `NEED_TRAIN` | 当 `base_quantization_type` 是 `sq8`、`sq8_uniform`、`sq4_uniform`、`pq`、`pqfs`、`rabitq` 之一时声明。 |
+| `NEED_TRAIN` | 当 `base_quantization_type` 是 `sq8`、`sq4`、`sq8_uniform`、`sq4_uniform`、`pq`、`pqfs`、`rabitq` 之一时声明。 |
 
 BruteForce **不支持** 的能力包括：`SUPPORT_UPDATE_VECTOR_CONCURRENT`、
 `SUPPORT_UPDATE_ID_CONCURRENT`、`SUPPORT_EXPORT_MODEL`。

--- a/docs/docs/zh/src/indexes/hgraph.md
+++ b/docs/docs/zh/src/indexes/hgraph.md
@@ -16,7 +16,7 @@ HGraph 都是推荐的默认索引。
    `max_degree` 预算内的最近邻。构图算法可以是 NSW 风格插入（`graph_type: "nsw"`，默认）
    或 ODescent（`graph_type: "odescent"`）。
 2. **量化。** 底层存储使用可配置的量化器进行压缩（`base_quantization_type` —
-   `fp32`、`fp16`、`bf16`、`sq8`、`sq8_uniform`、`sq4_uniform`、`pq`、`pqfs`、`rabitq`）。
+   `fp32`、`fp16`、`bf16`、`sq8`、`sq4`、`sq8_uniform`、`sq4_uniform`、`pq`、`pqfs`、`rabitq`、`tq`）。
    可选地再保留一份高精度副本（`use_reorder: true` 搭配 `precise_quantization_type`），
    用于对粗排结果进行重打分。
 3. **搜索。** 自顶向下在图上做贪心 beam search，扩展候选集到 `ef_search` 个节点；如启用精排，
@@ -58,7 +58,7 @@ auto result = index->KnnSearch(
 
 | 参数 | 类型 | 默认值 | 说明 |
 |------|------|--------|------|
-| `base_quantization_type` | string | —（必填） | `fp32`、`fp16`、`bf16`、`sq8`、`sq8_uniform`、`sq4_uniform`、`pq`、`pqfs`、`rabitq` |
+| `base_quantization_type` | string | —（必填） | `fp32`、`fp16`、`bf16`、`sq8`、`sq4`、`sq8_uniform`、`sq4_uniform`、`pq`、`pqfs`、`rabitq`、`tq` —— 各量化器细节见[量化章节](../quantization/README.md) |
 | `max_degree` | int | `64` | 图节点最大出度 |
 | `ef_construction` | int | `400` | 构建阶段的候选集大小（越大召回越高，构建越慢） |
 | `graph_type` | string | `"nsw"` | 构图算法：`nsw` 或 `odescent` |

--- a/docs/docs/zh/src/indexes/ivf.md
+++ b/docs/docs/zh/src/indexes/ivf.md
@@ -69,7 +69,7 @@ auto result = index->KnnSearch(
 | `first_order_buckets_count` | int | `10` | 第一级桶数（`gno_imi` 策略下生效） |
 | `second_order_buckets_count` | int | `10` | 第二级桶数（`gno_imi` 策略下生效） |
 | `ivf_train_type` | string | `"kmeans"` | 中心训练方式：`kmeans` 或 `random` |
-| `base_quantization_type` | string | `"fp32"` | `fp32`、`fp16`、`bf16`、`sq8`、`sq8_uniform`、`sq4_uniform`、`pq`、`pqfs`、`rabitq` |
+| `base_quantization_type` | string | `"fp32"` | `fp32`、`fp16`、`bf16`、`sq8`、`sq4`、`sq8_uniform`、`sq4_uniform`、`pq`、`pqfs`、`rabitq` —— 各量化器细节见[量化章节](../quantization/README.md) |
 | `base_pq_dim` | int | `1` | PQ 子空间数（`pq` / `pqfs` 时必填） |
 | `use_reorder` | bool | `false` | 是否保留高精度副本用于精排 |
 | `precise_quantization_type` | string | `"fp32"` | 精排量化类型（`use_reorder: true` 时使用） |

--- a/docs/docs/zh/src/indexes/pyramid.md
+++ b/docs/docs/zh/src/indexes/pyramid.md
@@ -76,7 +76,7 @@ auto result = index->KnnSearch(
 
 | 参数 | 类型 | 默认值 | 说明 |
 |------|------|--------|------|
-| `base_quantization_type` | string | — | 底层量化类型（`fp32`、`fp16`、`bf16`、`sq8`、`sq8_uniform`、`sq4_uniform`、`pq`、`pqfs`、`rabitq`） |
+| `base_quantization_type` | string | — | 底层量化类型（`fp32`、`fp16`、`bf16`、`sq8`、`sq4`、`sq8_uniform`、`sq4_uniform`、`pq`、`pqfs`、`rabitq`）。各量化器细节见[量化章节](../quantization/README.md)。 |
 | `max_degree` | int | `64` | 子图内节点的最大出度 |
 | `graph_type` | string | `"nsw"` | `nsw` 或 `odescent` |
 | `ef_construction` | int | `400` | `nsw` 构图时的候选集大小 |

--- a/docs/docs/zh/src/quantization/README.md
+++ b/docs/docs/zh/src/quantization/README.md
@@ -1,0 +1,145 @@
+# 量化
+
+向量量化是 VSAG 中权衡内存与召回的核心手段。每种索引类型都通过一个
+**基础量化器**（由 `base_quantization_type` 配置）存储向量，并可以额外保留
+一个**精确量化器**用于重排（`precise_quantization_type` + `use_reorder:
+true`）。本章介绍每一种受支持的量化器：它做什么、接受哪些 JSON 参数、是否
+需要训练、支持哪些度量、以及何时选用它。
+
+![量化器选择决策树：按内存预算挑选量化器](../figures/quantization/quantization-overview.svg)
+
+## 存储与搜索流水线
+
+```
+                  +---------------------+
+   原始向量 ----->|  可选变换           |   (TQ 链：pca / rom / fht / mrle)
+                  +----------+----------+
+                             |
+                             v
+                  +---------------------+
+                  |   基础量化器        |   fp32 / fp16 / bf16 /
+                  |                     |   sq8 / sq4 / sq8_uniform /
+                  |                     |   sq4_uniform / pq / pqfs /
+                  |                     |   rabitq
+                  +----------+----------+
+                             |
+                             v
+                   +-------------------+
+                   |   索引存储        |   (HGraph / IVF / Pyramid /
+                   |                   |    BruteForce / SINDI)
+                   +---------+---------+
+                             |
+                             v
+                    图 / 倒排链路游走
+                             |
+             +---------------+-----------------+
+             |                                 |
+    use_reorder: false                use_reorder: true
+             |                                 |
+             v                                 v
+        top-K 结果                  +---------------------+
+                                    | 精确量化器          |  重排
+                                    | (默认 fp32；        |
+                                    |  fp16/bf16/sq8 可)  |
+                                    +----------+----------+
+                                               |
+                                               v
+                                          top-K 结果
+```
+
+`use_reorder` 与 `precise_quantization_type` 并非某一具体量化器专属——只要
+索引支持重排，它们就生效（见
+[HGraph](../indexes/hgraph.md)、[IVF](../indexes/ivf.md)、
+[Pyramid](../indexes/pyramid.md)）。
+
+## 支持的量化器一览
+
+`src/datacell/flatten_interface.cpp` 的工厂会根据 JSON 中的 `type`
+字段分派到具体量化器。
+
+| `base_quantization_type` | 每维位数（约） | 需要训练 | 是否无损 | 典型场景 |
+| --- | --- | --- | --- | --- |
+| `fp32` | 32 | 否 | 是 | 参考基线 / 精确重排存储 |
+| `fp16` | 16 | 否 | 近似无损 | 半精度存储；高维 float 向量的良好默认 |
+| `bf16` | 16 | 否 | 近似无损 | 与 `fp16` 同样大小，动态范围更宽 |
+| `sq8` | 8 | **是** | 否 | 通用的省内存基线 |
+| `sq4` | 4 | **是** | 否 | 激进压缩，不重排时召回会下降 |
+| `sq8_uniform` | 8 | **是** | 否 | 全局 min/max，SIMD 友好的 SQ8 |
+| `sq4_uniform` | 4 | **是** | 否 | SIMD 友好的 SQ4；支持 `sq4_uniform_trunc_rate` |
+| `pq` | ~`pq_bits` × `pq_dim` / `dim` | **是** | 否 | 基于码本，非常紧凑 |
+| `pqfs` | 4 × `pq_dim` / `dim` | **是** | 否 | PQ FastScan——SIMD 加速版 PQ |
+| `rabitq` | 1（可选额外 7） | **是** | 否 | 1 比特 / 1+7 比特二值量化，最强压缩 |
+| `tq` | 取决于链路 | 取决于末端量化器 | 否 | [量化变换](../advanced/quantization_transform.md)：在另一个量化器之前串接旋转 / PCA |
+
+`int8` 与 `sparse` 不作为通用的 `base_quantization_type` 暴露：
+
+- `int8` 在使用 `dtype: "int8"` 时被自动选用，并非一种压缩模式。
+- `sparse` 为 [SINDI](../indexes/sindi.md) 的倒排链表服务，密集索引不可
+  直接选择。
+
+## 训练需求
+
+上表中标记为**是**的量化器实现了 `NEED_TRAIN` 标志，必须先调用 `Build`
+（在输入向量上内部完成训练）或显式 `Train` 之后再 `Add`。完整生命周期见
+[索引构建与训练](../advanced/build_and_train.md)。
+
+对 HGraph 而言，训练数据就是传给 `Build` 的基础向量；对 IVF 而言，先训练
+聚类中心，再把残差喂给所配置的基础量化器。
+
+## 度量兼容性
+
+本章所列量化器全部支持三种稠密度量（`l2` / `ip` / `cosine`）。对 `cosine`，
+索引会在量化前对向量做归一化，因此底层量化器看不到原始模长。一些实践
+要点：
+
+- `pq` / `pqfs` 在每个子空间上做距离查表；当 `pq_dim` 非常小（≤ 4），
+  在 `ip` / `cosine` 上比 `l2` 更容易受各向异性影响。
+- `rabitq` 在输入向量去相关的情况下效果最好——要么开启
+  `rabitq_use_fht` / `rabitq_pca_dim`，要么用 `tq` 链路如
+  `"pca, rom, rabitq"` 包一层。
+
+## 量化器选择
+
+一份实用的决策树：
+
+1. **需要精确距离或精确重排存储？** 用 `fp32`。
+2. **只想内存减半且召回基本无损？** 用 `fp16`（若数据动态范围大，例如未
+   归一化的嵌入，则用 `bf16`）。
+3. **想要约 4× 的内存节省并愿意启用重排？** 用 `sq8`（在 `l2` / `ip` 上
+   想要更高 SIMD 吞吐可用 `sq8_uniform`）。
+4. **内存紧张、可在重排前承受更大召回损失？** 用 `sq4_uniform`。
+5. **高维向量，希望基于码本做强压缩？** 用 `pq`，平台支持 SIMD 路径时用
+   `pqfs`。
+6. **追求最强压缩（1 比特）并能承担重排代价？** 用 `rabitq`，最好搭配
+   `rabitq_use_fht: true` 或 `tq` 链路。
+
+对上述任何一种有损量化器，将 `use_reorder: true` 配合
+`precise_quantization_type: "fp32"` 是恢复召回的标准做法，代价是额外内存；
+具体行为参考 [HGraph 参数表](../indexes/hgraph.md#parameters)。
+
+## 量化在何处暴露
+
+并非每种索引都将所有参数都暴露为外部 key。当前情况：
+
+- **HGraph** 暴露最完整的集合：`base_quantization_type`、
+  `precise_quantization_type`、`use_reorder`、`base_pq_dim`、
+  `rabitq_pca_dim`、`rabitq_bits_per_dim_query`、
+  `rabitq_bits_per_dim_base`、`rabitq_version`、`rabitq_error_rate`、
+  `rabitq_use_fht`、`sq4_uniform_trunc_rate`、`tq_chain`
+  （见 `src/algorithm/hgraph.cpp`）。
+- **IVF**、**Pyramid**、**BruteForce** 暴露 `base_quantization_type`
+  与通用的重排相关 key；部分可调项（如 `tq_chain`）目前在内部接好但未作
+  为外部 key 暴露。
+
+每种索引的完整参数列表见对应索引页。
+
+## 本章内容
+
+- [FP32（基线）](fp32.md)
+- [半精度浮点（FP16 / BF16）](fp16_bf16.md)
+- [标量量化（SQ4 / SQ8）](sq.md)
+- [Uniform 标量量化（SQ4 / SQ8 Uniform）](sq_uniform.md)
+- [乘积量化（PQ）](pq.md)
+- [PQ FastScan](pqfs.md)
+- [RaBitQ](rabitq.md)
+- [量化变换（TQ）](../advanced/quantization_transform.md)

--- a/docs/docs/zh/src/quantization/fp16_bf16.md
+++ b/docs/docs/zh/src/quantization/fp16_bf16.md
@@ -1,0 +1,81 @@
+# 半精度浮点（FP16 / BF16）
+
+`fp16` 与 `bf16` 把每个坐标用 16 位而非 32 位存储，把码内存减半且**近似
+无损**。它们没有量化器专属的 JSON 参数；二者的唯一差异是浮点格式自身的
+位布局。
+
+![FP32 / FP16 / BF16 位布局：符号位 / 指数位 / 尾数位宽度](../figures/quantization/fp-bitlayout.svg)
+
+> 实现：`src/quantization/scalar_quantization/half_precision_quantizer.cpp`，
+> 类型特征在 `half_precision_traits.h`。
+> 可运行示例：`examples/cpp/321_index_fp16_hgraph.cpp`。
+
+## FP16 与 BF16 一览
+
+| 格式 | 符号位 | 指数位 | 尾数位 | 有效范围 | 精度 |
+| --- | --- | --- | --- | --- | --- |
+| `fp16` | 1 | 5 | 10 | ~±6.55e4 | 约 3 位十进制 |
+| `bf16` | 1 | 8 | 7 | 与 `fp32` 相同（~±3.4e38） | 约 2 位十进制 |
+
+实践含义：
+
+- **`fp16`** 保留更多尾数位——对取值大致在 `[-1, 1]` 的归一化嵌入精度更
+  好。是 cosine 归一化向量的标准选择。
+- **`bf16`** 保留与 `fp32` 一致的指数范围——对原始、未归一化的特征（如
+  加权和、累加器式嵌入）更安全。相对 `fp16`，在接近零的取值上损失一些
+  精度。
+
+不确定时：归一化嵌入选 `fp16`，未归一化或范围较宽的数据选 `bf16`。
+
+## 何时使用
+
+- 在 `fp32` 基线之上作为"即插即用"的内存优化。在标准基准（SIFT、GIST、
+  Glove、句向量）上召回损失通常低于 1%。
+- 作为**精确重排存储**，体积仅为 fp32 的一半：
+  `precise_quantization_type: "fp16"` 或 `"bf16"` 配合 `use_reorder: true`。
+- 高维浮点向量，32 位存储成为瓶颈时。
+
+## 内存代价
+
+仅码本身每向量 `2 × dim` 字节。
+
+## 参数
+
+`fp16` 与 `bf16` 均没有量化器专属 JSON 参数。
+
+```json
+{
+    "dtype": "float32",
+    "metric_type": "l2",
+    "dim": 768,
+    "index_param": {
+        "base_quantization_type": "fp16",
+        "max_degree": 32,
+        "ef_construction": 300
+    }
+}
+```
+
+将 `"fp16"` 替换为 `"bf16"` 即可切换格式。输入 `dtype` 仍是 `"float32"`：
+量化器会在运行时转换。
+
+## 训练
+
+不需要。`fp16` 与 `bf16` 均不设置 `NEED_TRAIN`。
+
+## 度量兼容性
+
+`l2`、`ip`、`cosine`——全部支持。`cosine` 通过先归一化输入再以 16 位精度
+存储实现。
+
+## 何时**不要**使用
+
+- 当你还需要一个内存更激进的*基础*量化器（如 `sq8` 或 `pq`）——它们已经
+  把存储压到远低于 2 字节/维。
+- 当你需要精确距离（用 `fp32`）。
+
+## 相关页面
+
+- [量化总览](README.md)
+- [HGraph 索引](../indexes/hgraph.md) —— `precise_quantization_type` 表
+- [内存管理](../advanced/memory.md)

--- a/docs/docs/zh/src/quantization/fp32.md
+++ b/docs/docs/zh/src/quantization/fp32.md
@@ -1,0 +1,56 @@
+# FP32（基线）
+
+`fp32` 把每个坐标按 32 位 IEEE-754 浮点存储——与输入向量布局一致。它是
+VSAG 中**唯一完全无损**的选项，作为所有其他量化器对比的参考基线。
+
+> 实现：`src/quantization/fp32_quantizer.cpp`，参数文件
+> `fp32_quantizer_parameter.cpp`。
+
+## 何时使用
+
+- **重排 / 精确存储。** 当 `use_reorder: true` 时，
+  `precise_quantization_type: "fp32"` 是默认的精确存储；图上游走使用便宜
+  的基础量化器，对 top-K 候选再用 fp32 精确重打分。
+- **参考 / 基准真值。** 用 `base_quantization_type: "fp32"` 构建索引能拿
+  到该索引类型可达的最高召回，是其他量化器对比的标准基线
+  （`docs/docs/en/src/resources/eval.md`）。
+- **小规模数据集**，内存不是瓶颈时。
+- **BruteForce 原始向量取回。** 仅当 `base_quantization_type` 为 `fp32`
+  且度量允许时，`SUPPORT_GET_RAW_VECTOR_BY_IDS` 才会被广播
+  （`src/index/brute_force.cpp`）。
+
+## 内存代价
+
+仅码本身的开销为每向量 `4 × dim` 字节。当 `fp32` 作为某个基础量化器之上的
+精确存储时，每向量代价为 **base 码 + 4 × dim**。
+
+## 参数
+
+`fp32` 没有量化器专属的 JSON 参数。
+
+```json
+{
+    "dtype": "float32",
+    "metric_type": "l2",
+    "dim": 128,
+    "index_param": {
+        "base_quantization_type": "fp32",
+        "max_degree": 32,
+        "ef_construction": 300
+    }
+}
+```
+
+## 训练
+
+不需要。`fp32` **不**设置 `NEED_TRAIN`。
+
+## 度量兼容性
+
+`l2`、`ip`、`cosine`——全部支持，无特殊处理。
+
+## 相关页面
+
+- [量化总览](README.md)
+- [HGraph 索引](../indexes/hgraph.md) —— 见 `precise_quantization_type`
+- [内存管理](../advanced/memory.md)

--- a/docs/docs/zh/src/quantization/pq.md
+++ b/docs/docs/zh/src/quantization/pq.md
@@ -1,0 +1,83 @@
+# 乘积量化（PQ）
+
+乘积量化把一个向量切成 `pq_dim` 个等长的**子向量**，每个子向量独立地按
+含 `2^pq_bits` 个中心的小型码本进行量化。最终存储的码为每向量
+`pq_dim × pq_bits` 比特——比 `fp32` 小数量级。查询时的距离计算通过每查询
+预先计算的查找表（LUT）完成。
+
+![乘积量化：子向量切分与码本查表](../figures/quantization/pq-codebook.svg)
+
+> 实现：`src/quantization/product_quantization/product_quantizer.cpp`，
+> 参数文件 `product_quantizer_parameter.cpp`。
+
+## 何时使用
+
+- **高维浮点向量（≥ 256 维）**，且 `sq8` 仍嫌过大。
+- **内存紧张、精度可接受**的工作负载，需要相对 fp32 约 16× 压缩。
+- 配合 `use_reorder: true` 与一个小型 `fp16`/`fp32` 精确存储，PQ 是大规模
+  场景下"压缩图索引"的标准配方。
+
+如需在 `pq_bits = 4` 时获得更高的 SIMD 吞吐，见 [PQ FastScan](pqfs.md)。
+
+## 内存代价（仅码）
+
+每向量 `ceil(pq_dim × pq_bits / 8)` 字节，外加一份只存一次的小型码本
+（`pq_dim × 2^pq_bits × subspace_dim × 4` 字节）。以典型配置
+（`pq_dim = 32`、`pq_bits = 8`、`dim = 128`）为例：
+
+- 码大小 = `32 × 8 / 8 = 32` 字节/向量（对比 fp32 的 `128 × 4 = 512`
+  → 小 16×）。
+
+## 参数
+
+| Key | 类型 | 默认 | 含义 |
+| --- | --- | --- | --- |
+| `pq_dim` | int | `1` | 子向量数量。必须整除 `dim`。取值越大，量化越细，但码本数量与码大小也会变大（`product_quantizer_parameter.h:38`）。 |
+| `pq_bits` | int | `8` | 每个子向量的位数（1–8）。取 `8` 时每个子向量一字节。`8` 最稳；4 位 SIMD 变种见 [PQ FastScan](pqfs.md)。 |
+
+在 HGraph 上，这些以顶层 key `base_pq_dim` 与 `pq_bits` 暴露
+（`src/algorithm/hgraph.cpp:465-472`）。
+
+```json
+{
+    "dtype": "float32",
+    "metric_type": "l2",
+    "dim": 128,
+    "index_param": {
+        "base_quantization_type": "pq",
+        "base_pq_dim": 32,
+        "max_degree": 32,
+        "ef_construction": 300,
+        "use_reorder": true,
+        "precise_quantization_type": "fp16"
+    }
+}
+```
+
+## 训练
+
+设置了 `NEED_TRAIN`。训练在每个子空间上跑 k-means 来学习 `2^pq_bits` 个
+中心；这通常是所有内建量化器中最贵的训练步骤。每个子空间使用至少
+`256 × 2^pq_bits` 个训练样本，码本会更稳定；`Build(base)` 会自动从输入
+采样。
+
+## 度量兼容性
+
+`l2`、`ip`、`cosine`——全部支持。查询时距离通过每子空间的 LUT 计算：
+`l2` 使用查询子向量与每个中心的 L2 平方；`ip` 使用点积。`cosine` 在预
+归一化向量上等价于 `ip`。
+
+## 实践要点
+
+- `pq_dim` 应整除 `dim`。常用比例是 `dim/4` 或 `dim/8`。
+- 极小的 `pq_dim`（如 `dim/16`）能得到非常紧凑的码，但召回会迅速下降；
+  务必配合重排。
+- 对各向异性数据，在 PQ 前接一层旋转变换能显著提升召回：用
+  [量化变换](../advanced/quantization_transform.md) 链路如 `"rom, pq"`。
+
+## 相关页面
+
+- [PQ FastScan](pqfs.md)
+- [量化变换](../advanced/quantization_transform.md)
+- [HGraph 索引](../indexes/hgraph.md)
+- [量化总览](README.md)

--- a/docs/docs/zh/src/quantization/pqfs.md
+++ b/docs/docs/zh/src/quantization/pqfs.md
@@ -1,0 +1,77 @@
+# PQ FastScan
+
+`pqfs` 是 [乘积量化](pq.md) 的一个 SIMD 加速变种：将 `pq_bits` 固定为 4，
+并采用专为 AVX-2 / AVX-512 "FastScan" 查表内核设计的内存布局。代价是仅
+支持 4 位，但能带来显著更高的距离计算吞吐。
+
+![PQ FastScan：16 向量 4 位交错块与 SIMD LUT 查表](../figures/quantization/pqfs-block.svg)
+
+> 实现：`src/quantization/product_quantization/pq_fastscan_quantizer.cpp`，
+> 参数文件 `pq_fastscan_quantizer_parameter.cpp`。
+
+## 何时使用
+
+- 平台有 AVX-2（最好还有 AVX-512）；FastScan 内核正是选用 `pqfs` 而非
+  `pq` 的主要理由。
+- 关注的不只是内存，还有搜索吞吐。
+- 4 位子空间码本（每子向量 16 个中心）能满足召回目标——通常配合重排即
+  可。
+
+如果平台不具备所需的 SIMD 宽度，请回退到普通 [`pq`](pq.md)。
+
+## 内存代价（仅码）
+
+每向量 `ceil(pq_dim / 2) = (pq_dim + 1) / 2` 字节——奇数和偶数 `pq_dim`
+都支持（`src/quantization/product_quantization/pq_fastscan_quantizer.cpp:41`）。
+码本：`pq_dim × 16 × subspace_dim × 4` 字节——因为每子空间只有 16 个中心，
+比 8 位 `pq` 的码本小很多。
+
+## 参数
+
+| Key | 类型 | 默认 | 含义 |
+| --- | --- | --- | --- |
+| `pq_dim` | int | `1` | 子向量数量。必须整除 `dim`。`pq_bits` 在内部**固定为 4** 且不可配（`pq_fastscan_quantizer_parameter.cpp:28-33`）。 |
+
+在 HGraph 上以 `base_pq_dim` 暴露（`src/algorithm/hgraph.cpp:465-472`）。
+
+```json
+{
+    "dtype": "float32",
+    "metric_type": "l2",
+    "dim": 128,
+    "index_param": {
+        "base_quantization_type": "pqfs",
+        "base_pq_dim": 32,
+        "max_degree": 32,
+        "ef_construction": 300,
+        "use_reorder": true,
+        "precise_quantization_type": "fp16"
+    }
+}
+```
+
+## 训练
+
+设置了 `NEED_TRAIN`。在每子空间训练 16 中心码本；比 `pq` 的 256 中心训练
+更便宜。
+
+## 度量兼容性
+
+`l2`、`ip`、`cosine`——覆盖与 `pq` 一致。LUT 布局因度量而异，但由量化器
+透明处理。
+
+## 实践要点
+
+- `pq_dim` 最好是内核预期 SIMD 批宽的倍数（实现在 AVX-512 上内部使用
+  32）。拿不准时，选 `pq_dim ∈ {32, 64, 96, 128}`。
+- 相对 `pq` 的优势是**相同召回下的吞吐**，而非内存（4 位码本身就小，但
+  `pq` 设 `pq_bits = 4` 同样能匹配大小）。
+- 想最大化召回恢复，配合 `use_reorder: true` 与 `fp16` 或 `fp32` 精确
+  存储。
+
+## 相关页面
+
+- [乘积量化（PQ）](pq.md)
+- [HGraph 索引](../indexes/hgraph.md)
+- [量化变换](../advanced/quantization_transform.md)
+- [量化总览](README.md)

--- a/docs/docs/zh/src/quantization/rabitq.md
+++ b/docs/docs/zh/src/quantization/rabitq.md
@@ -1,0 +1,114 @@
+# RaBitQ
+
+`rabitq` 是 VSAG 的二值 / 低比特量化器。默认模式下每个坐标用 **1 比特**
+编码，给出所有内建量化器中最高的压缩率。另一种模式
+（`rabitq_version = "split_1bit_7bit"`）把表示拆分为 1 比特基础 + 7 比特
+精化，在保留 1 比特快速距离内核的同时，以约 8 比特/维换回大部分精度。
+
+![RaBitQ：按坐标相对随机超平面的符号进行编码](../figures/quantization/rabitq-hyperplane.svg)
+
+> 实现：`src/quantization/rabitq_quantization/rabitq_quantizer.cpp`，
+> 参数文件 `rabitq_quantizer_parameter.cpp`。
+> 设计说明：`docs/rabitq_1xbit_new_repo_guide.md`、
+> `docs/rabitq_split_1bit_7bit.md`。
+
+## 何时使用
+
+- **最强压缩。** 1 比特码是稠密向量可能的最小存储。
+- **高维嵌入**——旋转 + 二值化后仍能保留足够近邻搜索所需的几何信息。
+- 配合精确重排存储（`fp16` / `fp32`）——标准做法就是 "RaBitQ + 重排"，
+  因为 1 比特距离本身噪声较大。
+
+为获得最佳精度，请同时启用 `rabitq_use_fht: true`，或者用
+[量化变换](../advanced/quantization_transform.md) 链路如
+`"pca, rom, rabitq"` 包一层。
+
+## 内存代价（仅码）
+
+- `rabitq_bits_per_dim_base = 1`：每向量 `ceil(dim / 8)` 字节。`dim = 768`
+  时为 96 字节（对比 fp32 的 3072 → 小 32×）。
+- `rabitq_bits_per_dim_base = 8`（split 1+7 模式存储更多比特）：每向量
+  约 `dim` 字节。
+
+## 参数
+
+| Key | 类型 | 默认 | 含义 |
+| --- | --- | --- | --- |
+| `pca_dim` | int | `0`（= 输入维度） | RaBitQ 内部可选的 PCA 预处理维度。`0` 表示不做 PCA 降维（`rabitq_quantizer_parameter.cpp:30-32`）。 |
+| `rabitq_bits_per_dim_query` | int | `32` | 搜索时**查询**的每维位数。允许值：`4` 或 `32`（`rabitq_quantizer_parameter.cpp:38-43`）。 |
+| `rabitq_bits_per_dim_base` | int | `1` | **底库**（存储）码的每维位数。范围 `[1, 8]`（`rabitq_quantizer_parameter.cpp:45-54`）。纯 1 比特 RaBitQ 取 `1`。 |
+| `rabitq_version` | string | `"standard"` | 取值：`"standard"`（1 比特）或 `"split_1bit_7bit"`。split 模式要求 `rabitq_bits_per_dim_query = 32`（`rabitq_quantizer_parameter.cpp:55-67`）。 |
+| `rabitq_error_rate` | float | `1.9` | 控制编码器误差预算；必须为有限正数（`rabitq_quantizer_parameter.cpp:68-75`）。 |
+| `use_fht` | bool | `false` | `true` 时在二值化前应用快速 Hadamard 变换旋转。以 O(dim log dim) 的廉价代价提升各向异性数据上的精度（`rabitq_quantizer_parameter.cpp:76-78`）。 |
+
+在 HGraph 上，这些以顶层 key 暴露：`rabitq_pca_dim`、
+`rabitq_bits_per_dim_query`、`rabitq_bits_per_dim_base`、`rabitq_version`、
+`rabitq_error_rate`、`rabitq_use_fht`。其中 `rabitq_use_fht` 是 HGraph
+对量化器内部 `use_fht` key 的别名，由索引层重写（`src/algorithm/hgraph.cpp:473-480`，
+名称定义见 `src/constants.cpp:142-148`）。Pyramid 同样暴露相应的 `rabitq_*` key
+（`src/algorithm/pyramid.cpp:698-699`）。
+
+```json
+{
+    "dtype": "float32",
+    "metric_type": "l2",
+    "dim": 768,
+    "index_param": {
+        "base_quantization_type": "rabitq",
+        "rabitq_use_fht": true,
+        "rabitq_pca_dim": 0,
+        "rabitq_bits_per_dim_base": 1,
+        "rabitq_bits_per_dim_query": 32,
+        "max_degree": 32,
+        "ef_construction": 300,
+        "use_reorder": true,
+        "precise_quantization_type": "fp32"
+    }
+}
+```
+
+切换到高精度的 split 模式。split 布局由两个 key 共同决定：
+`rabitq_version: "split_1bit_7bit"` 选择 1+7 RaBitQ 编码，
+`base_codes_type: "rabitq_split"` 切换存储 datacell。仅设置
+`rabitq_version` **不会**走 split datacell 路径，二者必须同时设置（详见
+`docs/rabitq_split_1bit_7bit.md`）：
+
+```json
+{
+    "base_quantization_type": "rabitq",
+    "base_codes_type": "rabitq_split",
+    "rabitq_version": "split_1bit_7bit",
+    "rabitq_bits_per_dim_base": 8,
+    "rabitq_bits_per_dim_query": 32,
+    "rabitq_use_fht": true
+}
+```
+
+## 训练
+
+设置了 `NEED_TRAIN`。训练学习让 1 比特编码均衡的旋转与逐维统计。可选的
+FHT 旋转是固定的（无需学习），因此不增加训练代价；PCA 预处理（`pca_dim
+> 0`）会训练一个投影矩阵。
+
+## 度量兼容性
+
+`l2`、`ip`、`cosine`——全部支持。二值距离内核是对 XOR 后的码字做 popcount；
+对 `ip` / `cosine`，实现还会追踪一份残差范数，使内积估计无偏。
+
+## 实践要点
+
+- **始终启用重排**，除非你已经验证 1 比特召回在你的数据上可接受。
+  `use_reorder: true` + `precise_quantization_type: "fp32"` 是稳妥默认。
+- **先旋转。** 对未归一化数据，设 `rabitq_use_fht: true`，或在 `tq` 链路
+  中包含 `rom` / `fht`。
+- **精度优先时用 split 模式。** `rabitq_version: "split_1bit_7bit"` 保留
+  图遍历的 1 比特快速路径，再添加 7 比特精化用于重排；相对纯 1 比特，
+  代价约为 8× 码大小，召回明显更高。
+
+## 相关页面
+
+- [量化变换](../advanced/quantization_transform.md)
+- [HGraph 索引](../indexes/hgraph.md)
+- 设计说明：`docs/rabitq_1xbit_new_repo_guide.md`、
+  `docs/rabitq_split_1bit_7bit.md`
+- [量化总览](README.md)

--- a/docs/docs/zh/src/quantization/sq.md
+++ b/docs/docs/zh/src/quantization/sq.md
@@ -1,0 +1,83 @@
+# 标量量化（SQ4 / SQ8）
+
+`sq8` 与 `sq4` 是**逐维标量量化器**：每个坐标按训练得到的逐维 `[min, max]`
+范围，从 `float32` 映射到 8 位（`sq8`）或 4 位（`sq4`）整数。它们共享同
+一份实现，仅以位宽参数化，位于
+`src/quantization/scalar_quantization/scalar_quantizer.cpp` 与
+`scalar_quantizer_parameter.h`。
+
+如果想要 SIMD 更友好、使用**全局** `[min, max]` 的变种，见
+[Uniform 标量量化](sq_uniform.md)。
+
+![标量量化：按逐维 [min, max] 范围将坐标映射到 2^b 个 bin 之一](../figures/quantization/sq-axis.svg)
+
+## SQ4 与 SQ8 一览
+
+| 类型 | 每维位数 | 相对 fp32 内存 | 典型精度 | 备注 |
+| --- | --- | --- | --- | --- |
+| `sq8` | 8 | ~1/4 | 轻微召回下降 | 通用省内存基线 |
+| `sq4` | 4 | ~1/8 | 不重排时下降明显 | 激进压缩；配合 `use_reorder: true` |
+
+训练得到的是逐维 `min`/`max`，重尾分布的坐标可能浪费码位。如果数据各
+向异性强，可考虑改用 [Uniform 标量量化](sq_uniform.md) 或先旋转的
+[量化变换](../advanced/quantization_transform.md) 链路，例如
+`"rom, sq8_uniform"`。
+
+## 内存代价（仅码）
+
+- `sq8`：每向量 `dim` 字节。
+- `sq4`：每向量 `ceil(dim / 2)` 字节。
+
+此外还有一份小型逐维范围表（`8 × dim` 字节，所有向量摊销）。
+
+## 参数
+
+目前 `sq8` 与 `sq4` 均无量化器专属 JSON 参数
+（`scalar_quantizer_parameter.h:36-58`）。位宽仅由 `type` 字符串决定。
+
+```json
+{
+    "dtype": "float32",
+    "metric_type": "l2",
+    "dim": 128,
+    "index_param": {
+        "base_quantization_type": "sq8",
+        "max_degree": 32,
+        "ef_construction": 300,
+        "use_reorder": true,
+        "precise_quantization_type": "fp32"
+    }
+}
+```
+
+将 `"sq8"` 替换为 `"sq4"` 即得到 4 位码。
+
+## 训练
+
+设置了 `NEED_TRAIN`。训练从输入向量样本中收集逐维 `min` / `max`。
+`Build(base)` 会内部完成训练；对需要显式 `Train` 的索引（如部分 IVF 流程），
+请在 `Add` 之前调用。详见
+[索引构建与训练](../advanced/build_and_train.md)。
+
+## 度量兼容性
+
+`l2`、`ip`、`cosine`——全部支持。距离通过把整数码解码回逐维缩放浮点后
+计算。
+
+## `sq8` 与 `sq4` 如何选
+
+- **`sq8`**：图索引（HGraph、Pyramid）追求约 4× 内存压缩时的默认选择。
+  召回损失通常很小，`use_reorder` 经常可选，但搭配
+  `precise_quantization_type: "fp32"` 启用重排是最稳妥的配置。
+- **`sq4`**：内存紧张且能承担精确重排存储时选用。几乎总是要配合
+  `use_reorder: true`。
+- 如果数据大致维度同质，改选 `sq*_uniform`；uniform 变种具有更高的 SIMD
+  吞吐。
+- 对重尾 / 各向异性数据，更推荐前置旋转的
+  [量化变换](../advanced/quantization_transform.md) 链路。
+
+## 相关页面
+
+- [Uniform 标量量化（SQ4 / SQ8 Uniform）](sq_uniform.md)
+- [量化变换](../advanced/quantization_transform.md)
+- [量化总览](README.md)

--- a/docs/docs/zh/src/quantization/sq_uniform.md
+++ b/docs/docs/zh/src/quantization/sq_uniform.md
@@ -1,0 +1,108 @@
+# 标量量化 Uniform（Scalar Quantization Uniform：SQ4 / SQ8 Uniform）
+
+`sq8_uniform` 与 `sq4_uniform` 与 [`sq8` / `sq4`](sq.md) 类似，是标量量化
+器，但它们学习的是**全局唯一**的 `[min, max]` 范围，对所有维度都使用同一
+份缩放参数。这一权衡——逐维自适应能力略弱，但解码路径更简单——换来了
+显著更快的 SIMD 距离计算（`l2` 与 `ip`），并保持更紧凑的码布局。
+
+![Uniform（全局范围）与逐维标量量化对比](../figures/quantization/sq-uniform-vs-perdim.svg)
+
+> 实现：`src/quantization/scalar_quantization/sq8_uniform_quantizer.cpp`、
+> `src/quantization/scalar_quantization/sq4_uniform_quantizer.cpp`。
+
+## 为什么快：距离计算停留在整数域
+
+这是在条件允许时优先选用 `sq*_uniform` 而非 `sq*` 的核心原因。由于每个
+维度共享同一对 `(min, max)`，仿射解码
+`x = min + code · (max - min) / (2^b - 1)` 对**所有坐标都使用相同的
+scale 与 offset**。这在热路径上带来三点收益：
+
+- query 用同一份全局 `(min, max)` **只编码一次**，存入 uint8（或打包的
+  半字节）缓冲，见 `ProcessQueryImpl`
+  （`src/quantization/scalar_quantization/sq8_uniform_quantizer.cpp:179`）。
+- base 向量的 code **从不解码回 fp32**。kernel
+  `SQ8UniformComputeCodesIP(uint8_t* q, uint8_t* x, dim)` /
+  `SQ4UniformComputeCodesIP(...)` 把两个操作数都按原始整数 code 读入，
+  在 uint8 / 打包半字节通道上直接用 AVX-512 / AMX（ARM 上为 NEON）做
+  点积，一次处理一个 cache line。内层循环里没有任何逐元素的 fp 反量化。
+- 共享的 scale 与 offset 在整数累加完成之后**对每对向量只补偿一次**，
+  即可还原 fp 距离。某些度量需要的额外项（每向量的 norm 或 sum）也在
+  循环外加上，参见
+  `sq8_uniform_quantizer.cpp:200` 的 trailing metadata 说明以及
+  `SQ8UniformComputeCodesIPBatch` 批量 kernel。
+
+而在逐维的 `sq*` 量化器里，每个坐标都有自己的 `(min_i, max_i)`，kernel
+要么在循环内乘以逐维 scale 表，要么先把至少一边的操作数解码回 fp。
+省掉这一步，就是 uniform 变种在同等召回下显著更快的根本原因。
+
+## 何时使用
+
+- **HGraph / IVF / Pyramid 的热路径。** 当瓶颈在基础量化器距离计算时，
+  在相近召回下，`sq8_uniform` / `sq4_uniform` 几乎总是比对应的非 uniform
+  变种更快。
+- **维度间取值范围相近的数据。** 归一化嵌入（cosine），或已通过
+  [量化变换](../advanced/quantization_transform.md) 链路（如
+  `"rom, sq8_uniform"` 或 `"fht, sq8_uniform"`）旋转过的向量，都是理想
+  输入。
+- **作为 `tq` 链路的末端量化器。** 最常见的链路是
+  `"pca, rom, sq8_uniform"`，参考示例 501。
+
+## SQ4 uniform 与 SQ8 uniform 对比
+
+| 类型 | 每维位数 | 相对 fp32 内存 | 典型精度 |
+| --- | --- | --- | --- |
+| `sq8_uniform` | 8 | ~1/4 | 轻微召回下降 |
+| `sq4_uniform` | 4 | ~1/8 | 需重排以保持高召回 |
+
+## 参数
+
+| Key | 类型 | 默认 | 适用 | 含义 |
+| --- | --- | --- | --- | --- |
+| `sq4_uniform_trunc_rate` | float | `0.05` | 仅 `sq4_uniform` | 对离群值的对称截断比例（`src/quantization/scalar_quantization/sq4_uniform_quantizer_parameter.h:39`）。值越大，越多极端坐标被截断，从而减少主体数据的范围浪费，代价是尾部被裁掉。 |
+
+`sq8_uniform` 没有量化器专属的 JSON 参数。
+
+在 HGraph 上，`sq4_uniform_trunc_rate` 作为顶层 key 暴露，并被映射到
+嵌套的量化参数中（`src/algorithm/hgraph.cpp:409-416`）。
+
+```json
+{
+    "dtype": "float32",
+    "metric_type": "l2",
+    "dim": 128,
+    "index_param": {
+        "base_quantization_type": "sq4_uniform",
+        "sq4_uniform_trunc_rate": 0.05,
+        "max_degree": 32,
+        "ef_construction": 300,
+        "use_reorder": true,
+        "precise_quantization_type": "fp32"
+    }
+}
+```
+
+若需 8 位变种，把 `"base_quantization_type"` 设为 `"sq8_uniform"` 并去掉
+`trunc_rate` key 即可。
+
+## 训练
+
+设置了 `NEED_TRAIN`。训练在所有维度上估计单一的 `[min, max]`
+（`sq4_uniform` 时可附加截断）。`Build` 会内部完成训练。
+
+## 度量兼容性
+
+`l2`、`ip`、`cosine`——全部支持。`cosine` 会先归一化再量化，这也使得 uniform
+缩放在该度量下接近最优。
+
+## uniform 与非 uniform 之间如何选
+
+- 数据已归一化（`cosine` 或预归一化 `l2`）→ 选 **uniform**。
+- 数据各维度取值范围差异极大（如混合特征块）→ 先尝试非 uniform 的
+  [`sq*`](sq.md)，或在旋转变换后再用 uniform（`"rom, sq*_uniform"`）。
+- 吞吐比最后一点点召回更重要 → **uniform**。
+
+## 相关页面
+
+- [标量量化（SQ4 / SQ8）](sq.md)
+- [量化变换](../advanced/quantization_transform.md)
+- [量化总览](README.md)

--- a/docs/docs/zh/src/resources/index_parameters.md
+++ b/docs/docs/zh/src/resources/index_parameters.md
@@ -67,7 +67,7 @@ HGraph 的构建参数使用通用的 `index_param` 键（参见 `examples/cpp/1
 |------|-------|------|
 | `max_degree` | 16~48 | 每节点最大出边数 |
 | `ef_construction` | 200~500 | 构建阶段候选集大小，越大召回越高、构建越慢 |
-| `base_quantization_type` | `fp32` / `fp16` / `bf16` / `sq8` / `sq4` / `pq` | 主存储的量化策略 |
+| `base_quantization_type` | `fp32` / `fp16` / `bf16` / `sq8` / `sq4` / `pq` | 主存储的量化策略 —— 支持的全部取值见[量化章节](../quantization/README.md) |
 
 搜索时：
 


### PR DESCRIPTION
## Summary

- Adds a dedicated **Quantization** chapter in both English and Chinese
  docs (`docs/docs/{en,zh}/src/quantization/`) with one page per
  quantizer: `fp32`, `fp16` / `bf16`, `sq4` / `sq8`, `sq*_uniform`, `pq`,
  `pqfs`, `rabitq`, plus an overview with a storage/search pipeline
  diagram and a selection decision tree.
- Each page documents the actual JSON parameters, defaults and
  validation rules taken from the quantizer parameter sources (e.g.
  `src/quantization/product_quantization/*_parameter.cpp`,
  `src/quantization/rabitq_quantization/rabitq_quantizer_parameter.cpp`,
  `src/quantization/scalar_quantization/*_parameter.{h,cpp}`), plus
  training requirements, metric compatibility and memory cost.
- Cross-links the new chapter from every `base_quantization_type` row in
  the index parameter tables: HGraph, IVF, Pyramid, BruteForce and the
  shared Index Parameters reference (EN + ZH).
- Relocates the existing **Transform Quantizer (TQ)** page from
  *Advanced Features* to the new *Quantization* chapter in both
  SUMMARYs so all quantization material lives in one place. mdbook does
  not allow a file to appear twice in `SUMMARY.md`, so the entry was
  moved rather than duplicated; the page content itself is unchanged.

## Verification

- `mdbook build` succeeds in both `docs/docs/en` and `docs/docs/zh` with
  no errors or warnings.
- No source code changes; tests / coverage requirements do not apply.

## Notes for reviewers

- Naming convention chosen for symmetry: `fp32.md`, `fp16_bf16.md`,
  `sq.md` (covers sq4 + sq8), `sq_uniform.md`, `pq.md`, `pqfs.md`,
  `rabitq.md`. Half-precision and per-bit-width scalar quantizers share
  the same implementation template, so combining them avoids
  near-duplicate pages.
- ASCII pipeline diagrams are used instead of Mermaid because the
  current `book.toml` does not enable a Mermaid renderer.
- `int8` (dtype, not a compression mode) and `sparse` (SINDI-only) are
  mentioned in the overview but intentionally do not get their own
  pages.