### PR TITLE
feat: add MultiVectorDataCell for ColBERT-style multi-vector storage

### DIFF
--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -2108,12 +2108,8 @@ HGraph::reorder(const void* query,
     if (reorder_impl == nullptr) {
         reorder_impl = std::make_shared<FlattenReorder>(flatten, allocator_);
     }
-    auto reorder_heap = reorder_impl->Reorder(candidate_heap,
-                                              static_cast<const float*>(query),
-                                              k,
-                                              ctx,
-                                              iter_ctx,
-                                              rabitq_lower_bound_candidates);
+    auto reorder_heap = reorder_impl->Reorder(
+        candidate_heap, query, k, ctx, iter_ctx, rabitq_lower_bound_candidates);
     candidate_heap = reorder_heap;
 }
 

--- a/src/datacell/flatten_interface.cpp
+++ b/src/datacell/flatten_interface.cpp
@@ -18,6 +18,7 @@
 #include "index_common_param.h"
 #include "inner_string_params.h"
 #include "io/io_headers.h"
+#include "multi_vector_datacell.h"
 #include "quantization/int8_quantizer.h"
 #include "quantization/quantizer_adapter.h"
 #include "quantization/quantizer_headers.h"
@@ -44,6 +45,21 @@ make_instance_flatten(const FlattenInterfaceParamPtr& param, const IndexCommonPa
     throw VsagException(ErrorType::INVALID_ARGUMENT,
                         fmt::format("Unknown flatten interface name: {}", param->name));
 }
+template <typename QuantTemp, typename IOTemp>
+static FlattenInterfacePtr
+make_instance_multi_vector(const FlattenInterfaceParamPtr& param,
+                           const IndexCommonParam& common_param) {
+    auto& io_param = param->io_parameter;
+    auto& quantizer_param = param->quantizer_parameter;
+
+    if (param->name == MULTI_VECTOR_DATA_CELL) {
+        return std::make_shared<MultiVectorDataCell<QuantTemp, IOTemp>>(
+            quantizer_param, io_param, common_param);
+    }
+    throw VsagException(ErrorType::INVALID_ARGUMENT,
+                        fmt::format("Unknown flatten interface name: {}", param->name));
+}
+
 template <typename QuantTemp, typename IOTemp>
 static FlattenInterfacePtr
 make_instance_sparse(const FlattenInterfaceParamPtr& param, const IndexCommonParam& common_param) {
@@ -73,6 +89,10 @@ make_instance_with_tq(const FlattenInterfaceParamPtr& param,
 template <MetricType metric, typename IOTemp>
 static FlattenInterfacePtr
 make_instance(const FlattenInterfaceParamPtr& param, const IndexCommonParam& common_param) {
+    if (param->name == MULTI_VECTOR_DATA_CELL) {
+        return make_instance_multi_vector<FP32Quantizer<metric>, IOTemp>(param, common_param);
+    }
+
     std::string quantization_string = param->quantizer_parameter->GetTypeName();
 
     // Handle INT8 data type specially

--- a/src/datacell/flatten_interface_parameter.cpp
+++ b/src/datacell/flatten_interface_parameter.cpp
@@ -17,6 +17,7 @@
 
 #include "flatten_datacell_parameter.h"
 #include "inner_string_params.h"
+#include "multi_vector_datacell_parameter.h"
 #include "sparse_vector_datacell_parameter.h"
 
 namespace vsag {
@@ -26,6 +27,9 @@ CreateFlattenParam(const JsonType& json) {
     FlattenInterfaceParamPtr param = nullptr;
     if (json.Contains(CODES_TYPE_KEY) && json[CODES_TYPE_KEY].GetString() == SPARSE_CODES) {
         param = std::make_shared<SparseVectorDataCellParameter>();
+    } else if (json.Contains(CODES_TYPE_KEY) &&
+               json[CODES_TYPE_KEY].GetString() == MULTI_VECTOR_CODES) {
+        param = std::make_shared<MultiVectorDataCellParameter>();
     } else {
         param = std::make_shared<FlattenDataCellParameter>();
     }

--- a/src/datacell/multi_vector_datacell.h
+++ b/src/datacell/multi_vector_datacell.h
@@ -1,0 +1,130 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "flatten_interface.h"
+#include "io/basic_io.h"
+#include "io/memory_block_io.h"
+#include "quantization/multi_vector_computer.h"
+#include "vsag/dataset.h"
+
+namespace vsag {
+
+template <typename QuantTmpl, typename IOTmpl>
+class MultiVectorDataCell : public FlattenInterface {
+public:
+    MultiVectorDataCell() = default;
+
+    MultiVectorDataCell(const QuantizerParamPtr& quantization_param,
+                        const IOParamPtr& io_param,
+                        const IndexCommonParam& common_param);
+
+    void
+    Query(float* result_dists,
+          const ComputerInterfacePtr& computer,
+          const InnerIdType* idx,
+          InnerIdType id_count,
+          QueryContext* ctx = nullptr) override;
+
+    ComputerInterfacePtr
+    FactoryComputer(const void* query) override;
+
+    bool
+    Decode(const uint8_t* codes, float* vector) override {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "Decode is not supported for MultiVectorDataCell");
+    }
+
+    bool
+    Encode(const float* vector, uint8_t* codes) override {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "Encode is not supported for MultiVectorDataCell");
+    }
+
+    float
+    ComputePairVectors(InnerIdType id1, InnerIdType id2) override {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "ComputePairVectors is not supported for MultiVectorDataCell");
+    }
+
+    void
+    Train(const void* data, uint64_t count) override;
+
+    void
+    InsertVector(const void* vector, InnerIdType idx) override;
+
+    void
+    BatchInsertVector(const void* vectors, InnerIdType count, InnerIdType* idx_vec) override;
+
+    void
+    Resize(InnerIdType new_capacity) override;
+
+    void
+    Prefetch(InnerIdType id) override {
+    }
+
+    void
+    ExportModel(const FlattenInterfacePtr& other) const override {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "ExportModel is not supported for MultiVectorDataCell");
+    }
+
+    [[nodiscard]] std::string
+    GetQuantizerName() override;
+
+    [[nodiscard]] MetricType
+    GetMetricType() override;
+
+    [[nodiscard]] const uint8_t*
+    GetCodesById(InnerIdType id, bool& need_release) const override;
+
+    void
+    Release(const uint8_t* data) const override;
+
+    [[nodiscard]] bool
+    InMemory() const override;
+
+    bool
+    GetCodesById(InnerIdType id, uint8_t* codes) const override {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "fixed-length GetCodesById is not supported for MultiVectorDataCell");
+    }
+
+    void
+    Serialize(StreamWriter& writer) override;
+
+    void
+    Deserialize(lvalue_or_rvalue<StreamReader> reader) override;
+
+    int64_t
+    GetMemoryUsage() const override;
+
+private:
+    std::shared_ptr<Quantizer<QuantTmpl>> quantizer_{nullptr};
+    std::shared_ptr<BasicIO<IOTmpl>> io_{nullptr};
+
+    Allocator* const allocator_{nullptr};
+    std::shared_ptr<MemoryBlockIO> offset_io_{nullptr};
+    uint64_t current_offset_{0};
+    std::mutex current_offset_mutex_;
+
+    uint32_t multi_vector_dim_{0};
+    MetricType metric_{MetricType::METRIC_TYPE_L2SQR};
+};
+
+}  // namespace vsag
+
+#include "multi_vector_datacell.inl"

--- a/src/datacell/multi_vector_datacell.inl
+++ b/src/datacell/multi_vector_datacell.inl
@@ -174,8 +174,14 @@ MultiVectorDataCell<QuantTmpl, IOTmpl>::Deserialize(lvalue_or_rvalue<StreamReade
 template <typename QuantTmpl, typename IOTmpl>
 ComputerInterfacePtr
 MultiVectorDataCell<QuantTmpl, IOTmpl>::FactoryComputer(const void* query) {
-    throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                        "FactoryComputer is not yet implemented for MultiVectorDataCell");
+    CHECK_ARGUMENT(query != nullptr, "query is nullptr");
+    const MultiVector* multi_vector = static_cast<const MultiVector*>(query);
+    CHECK_ARGUMENT(multi_vector->len_ > 0, "query token count must be greater than 0");
+    CHECK_ARGUMENT(multi_vector->vectors_ != nullptr, "query vectors are nullptr");
+
+    auto computer = std::make_shared<MultiVectorComputer>(multi_vector_dim_, metric_, allocator_);
+    computer->SetQuery(multi_vector->vectors_, multi_vector->len_);
+    return computer;
 }
 
 template <typename QuantTmpl, typename IOTmpl>
@@ -185,8 +191,22 @@ MultiVectorDataCell<QuantTmpl, IOTmpl>::Query(float* result_dists,
                                               const InnerIdType* idx,
                                               InnerIdType id_count,
                                               QueryContext* ctx) {
-    throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                        "Query is not yet implemented for MultiVectorDataCell");
+    auto* mv_computer = dynamic_cast<MultiVectorComputer*>(computer.get());
+    CHECK_ARGUMENT(mv_computer != nullptr, "computer is not a MultiVectorComputer");
+
+    for (InnerIdType i = 0; i < id_count; ++i) {
+        bool need_release = false;
+        const uint8_t* codes = this->GetCodesById(idx[i], need_release);
+
+        uint32_t token_count = 0;
+        std::memcpy(&token_count, codes, sizeof(uint32_t));
+
+        mv_computer->ComputeDist(codes + sizeof(uint32_t), token_count, result_dists + i);
+
+        if (need_release) {
+            this->Release(codes);
+        }
+    }
 }
 
 template <typename QuantTmpl, typename IOTmpl>

--- a/src/datacell/multi_vector_datacell.inl
+++ b/src/datacell/multi_vector_datacell.inl
@@ -133,8 +133,16 @@ MultiVectorDataCell<QuantTmpl, IOTmpl>::GetMetricType() {
 template <typename QuantTmpl, typename IOTmpl>
 const uint8_t*
 MultiVectorDataCell<QuantTmpl, IOTmpl>::GetCodesById(InnerIdType id, bool& need_release) const {
-    throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                        "GetCodesById is not yet implemented for MultiVectorDataCell");
+    uint64_t offset = 0;
+    offset_io_->Read(sizeof(offset), static_cast<uint64_t>(id) * sizeof(offset), (uint8_t*)&offset);
+    uint32_t len = 0;
+    io_->Read(sizeof(len), offset, (uint8_t*)&len);
+    uint64_t read_size =
+        sizeof(uint32_t) + static_cast<uint64_t>(len) * multi_vector_dim_ * sizeof(float);
+    auto* codes = static_cast<uint8_t*>(allocator_->Allocate(read_size));
+    io_->Read(read_size, offset, codes);
+    need_release = true;
+    return codes;
 }
 
 template <typename QuantTmpl, typename IOTmpl>

--- a/src/datacell/multi_vector_datacell.inl
+++ b/src/datacell/multi_vector_datacell.inl
@@ -1,0 +1,146 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "multi_vector_datacell.h"
+#include "vsag/options.h"
+
+namespace vsag {
+
+template <typename QuantTmpl, typename IOTmpl>
+MultiVectorDataCell<QuantTmpl, IOTmpl>::MultiVectorDataCell(
+    const QuantizerParamPtr& quantization_param,
+    const IOParamPtr& io_param,
+    const IndexCommonParam& common_param)
+    : allocator_(common_param.allocator_.get()),
+      multi_vector_dim_(static_cast<uint32_t>(common_param.dim_)),
+      metric_(common_param.metric_) {
+    this->quantizer_ = std::make_shared<QuantTmpl>(quantization_param, common_param);
+    this->io_ = std::make_shared<IOTmpl>(io_param, common_param);
+    this->offset_io_ =
+        std::make_shared<MemoryBlockIO>(Options::Instance().block_size_limit(), allocator_);
+    this->max_capacity_ = 0;
+    this->code_size_ = 0;
+}
+
+template <typename QuantTmpl, typename IOTmpl>
+void
+MultiVectorDataCell<QuantTmpl, IOTmpl>::Train(const void* data, uint64_t count) {
+    this->quantizer_->Train(static_cast<const float*>(data), count);
+}
+
+template <typename QuantTmpl, typename IOTmpl>
+void
+MultiVectorDataCell<QuantTmpl, IOTmpl>::InsertVector(const void* vector, InnerIdType idx) {
+    throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                        "InsertVector is not yet implemented for MultiVectorDataCell");
+}
+
+template <typename QuantTmpl, typename IOTmpl>
+void
+MultiVectorDataCell<QuantTmpl, IOTmpl>::BatchInsertVector(const void* vectors,
+                                                          InnerIdType count,
+                                                          InnerIdType* idx_vec) {
+    throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                        "BatchInsertVector is not yet implemented for MultiVectorDataCell");
+}
+
+template <typename QuantTmpl, typename IOTmpl>
+void
+MultiVectorDataCell<QuantTmpl, IOTmpl>::Resize(InnerIdType new_capacity) {
+    if (new_capacity <= this->max_capacity_) {
+        return;
+    }
+    this->offset_io_->Resize(static_cast<uint64_t>(new_capacity) * sizeof(uint64_t));
+    this->max_capacity_ = new_capacity;
+}
+
+template <typename QuantTmpl, typename IOTmpl>
+std::string
+MultiVectorDataCell<QuantTmpl, IOTmpl>::GetQuantizerName() {
+    return this->quantizer_->Name();
+}
+
+template <typename QuantTmpl, typename IOTmpl>
+MetricType
+MultiVectorDataCell<QuantTmpl, IOTmpl>::GetMetricType() {
+    return this->metric_;
+}
+
+template <typename QuantTmpl, typename IOTmpl>
+const uint8_t*
+MultiVectorDataCell<QuantTmpl, IOTmpl>::GetCodesById(InnerIdType id, bool& need_release) const {
+    throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                        "GetCodesById is not yet implemented for MultiVectorDataCell");
+}
+
+template <typename QuantTmpl, typename IOTmpl>
+void
+MultiVectorDataCell<QuantTmpl, IOTmpl>::Release(const uint8_t* data) const {
+    allocator_->Deallocate(const_cast<uint8_t*>(data));
+}
+
+template <typename QuantTmpl, typename IOTmpl>
+bool
+MultiVectorDataCell<QuantTmpl, IOTmpl>::InMemory() const {
+    return FlattenInterface::InMemory();
+}
+
+template <typename QuantTmpl, typename IOTmpl>
+void
+MultiVectorDataCell<QuantTmpl, IOTmpl>::Serialize(StreamWriter& writer) {
+    throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                        "Serialize is not yet implemented for MultiVectorDataCell");
+}
+
+template <typename QuantTmpl, typename IOTmpl>
+void
+MultiVectorDataCell<QuantTmpl, IOTmpl>::Deserialize(lvalue_or_rvalue<StreamReader> reader) {
+    throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                        "Deserialize is not yet implemented for MultiVectorDataCell");
+}
+
+template <typename QuantTmpl, typename IOTmpl>
+ComputerInterfacePtr
+MultiVectorDataCell<QuantTmpl, IOTmpl>::FactoryComputer(const void* query) {
+    throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                        "FactoryComputer is not yet implemented for MultiVectorDataCell");
+}
+
+template <typename QuantTmpl, typename IOTmpl>
+void
+MultiVectorDataCell<QuantTmpl, IOTmpl>::Query(float* result_dists,
+                                              const ComputerInterfacePtr& computer,
+                                              const InnerIdType* idx,
+                                              InnerIdType id_count,
+                                              QueryContext* ctx) {
+    throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                        "Query is not yet implemented for MultiVectorDataCell");
+}
+
+template <typename QuantTmpl, typename IOTmpl>
+int64_t
+MultiVectorDataCell<QuantTmpl, IOTmpl>::GetMemoryUsage() const {
+    int64_t memory = sizeof(MultiVectorDataCell<QuantTmpl, IOTmpl>);
+    memory += this->offset_io_->size_;
+    if (IOTmpl::InMemory) {
+        memory += this->io_->GetMemoryUsage();
+    }
+    memory += sizeof(QuantTmpl);
+    return memory;
+}
+
+}  // namespace vsag

--- a/src/datacell/multi_vector_datacell.inl
+++ b/src/datacell/multi_vector_datacell.inl
@@ -15,7 +15,12 @@
 
 #pragma once
 
+#include <algorithm>
+#include <cstring>
+
+#include "common.h"
 #include "multi_vector_datacell.h"
+#include "utils/byte_buffer.h"
 #include "vsag/options.h"
 
 namespace vsag {
@@ -45,8 +50,39 @@ MultiVectorDataCell<QuantTmpl, IOTmpl>::Train(const void* data, uint64_t count) 
 template <typename QuantTmpl, typename IOTmpl>
 void
 MultiVectorDataCell<QuantTmpl, IOTmpl>::InsertVector(const void* vector, InnerIdType idx) {
-    throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                        "InsertVector is not yet implemented for MultiVectorDataCell");
+    CHECK_ARGUMENT(vector != nullptr, "multi-vector data is nullptr");
+    const MultiVector* multi_vector = static_cast<const MultiVector*>(vector);
+    CHECK_ARGUMENT(multi_vector->len_ > 0, "multi-vector token count must be greater than 0");
+    CHECK_ARGUMENT(multi_vector->vectors_ != nullptr, "multi-vector tokens are nullptr");
+    CHECK_ARGUMENT(multi_vector_dim_ > 0, "multi-vector dim must be greater than 0");
+
+    {
+        std::lock_guard lock(mutex_);
+        if (idx == std::numeric_limits<InnerIdType>::max()) {
+            idx = total_count_;
+            ++total_count_;
+        } else {
+            total_count_ = std::max(total_count_, idx + 1);
+        }
+    }
+
+    const uint64_t vector_bytes = static_cast<uint64_t>(multi_vector->len_) *
+                                  static_cast<uint64_t>(multi_vector_dim_) * sizeof(float);
+    const uint64_t code_size = sizeof(uint32_t) + vector_bytes;
+    ByteBuffer codes(code_size, allocator_);
+    std::memcpy(codes.data, &multi_vector->len_, sizeof(uint32_t));
+    std::memcpy(codes.data + sizeof(uint32_t), multi_vector->vectors_, vector_bytes);
+
+    uint64_t old_offset = 0;
+    {
+        std::lock_guard lock(current_offset_mutex_);
+        old_offset = current_offset_;
+        current_offset_ += code_size;
+    }
+    offset_io_->Write(reinterpret_cast<const uint8_t*>(&old_offset),
+                      sizeof(old_offset),
+                      static_cast<uint64_t>(idx) * sizeof(old_offset));
+    io_->Write(codes.data, code_size, old_offset);
 }
 
 template <typename QuantTmpl, typename IOTmpl>
@@ -54,8 +90,22 @@ void
 MultiVectorDataCell<QuantTmpl, IOTmpl>::BatchInsertVector(const void* vectors,
                                                           InnerIdType count,
                                                           InnerIdType* idx_vec) {
-    throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                        "BatchInsertVector is not yet implemented for MultiVectorDataCell");
+    CHECK_ARGUMENT(vectors != nullptr, "multi-vector array is nullptr");
+    const MultiVector* multi_vectors = static_cast<const MultiVector*>(vectors);
+    Vector<InnerIdType> reserved_idx(count, allocator_);
+    if (idx_vec == nullptr) {
+        idx_vec = reserved_idx.data();
+        {
+            std::lock_guard lock(mutex_);
+            for (InnerIdType i = 0; i < count; ++i) {
+                idx_vec[i] = total_count_ + i;
+            }
+            total_count_ += count;
+        }
+    }
+    for (InnerIdType i = 0; i < count; ++i) {
+        this->InsertVector(multi_vectors + i, idx_vec[i]);
+    }
 }
 
 template <typename QuantTmpl, typename IOTmpl>

--- a/src/datacell/multi_vector_datacell.inl
+++ b/src/datacell/multi_vector_datacell.inl
@@ -160,15 +160,23 @@ MultiVectorDataCell<QuantTmpl, IOTmpl>::InMemory() const {
 template <typename QuantTmpl, typename IOTmpl>
 void
 MultiVectorDataCell<QuantTmpl, IOTmpl>::Serialize(StreamWriter& writer) {
-    throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                        "Serialize is not yet implemented for MultiVectorDataCell");
+    FlattenInterface::Serialize(writer);
+    StreamWriter::WriteObj(writer, multi_vector_dim_);
+    StreamWriter::WriteObj(writer, current_offset_);
+    this->offset_io_->Serialize(writer);
+    this->io_->Serialize(writer);
+    this->quantizer_->Serialize(writer);
 }
 
 template <typename QuantTmpl, typename IOTmpl>
 void
 MultiVectorDataCell<QuantTmpl, IOTmpl>::Deserialize(lvalue_or_rvalue<StreamReader> reader) {
-    throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                        "Deserialize is not yet implemented for MultiVectorDataCell");
+    FlattenInterface::Deserialize(reader);
+    StreamReader::ReadObj(reader, multi_vector_dim_);
+    StreamReader::ReadObj(reader, current_offset_);
+    this->offset_io_->Deserialize(reader);
+    this->io_->Deserialize(reader);
+    this->quantizer_->Deserialize(reader);
 }
 
 template <typename QuantTmpl, typename IOTmpl>

--- a/src/datacell/multi_vector_datacell_parameter.h
+++ b/src/datacell/multi_vector_datacell_parameter.h
@@ -18,6 +18,7 @@
 #include <fmt/format.h>
 
 #include "flatten_interface_parameter.h"
+#include "impl/logger/logger.h"
 #include "inner_string_params.h"
 #include "quantization/fp32_quantizer_parameter.h"
 #include "utils/pointer_define.h"
@@ -27,14 +28,14 @@ DEFINE_POINTER2(MultiVectorDataCellParam, MultiVectorDataCellParameter);
 
 class MultiVectorDataCellParameter : public FlattenInterfaceParameter {
 public:
-    explicit MultiVectorDataCellParameter()
-        : FlattenInterfaceParameter(MULTI_VECTOR_DATA_CELL) {
+    explicit MultiVectorDataCellParameter() : FlattenInterfaceParameter(MULTI_VECTOR_DATA_CELL) {
     }
 
     void
     FromJson(const JsonType& json) override {
-        CHECK_ARGUMENT(json.Contains(IO_PARAMS_KEY),
-                       fmt::format("multi-vector datacell parameters must contain {}", IO_PARAMS_KEY));
+        CHECK_ARGUMENT(
+            json.Contains(IO_PARAMS_KEY),
+            fmt::format("multi-vector datacell parameters must contain {}", IO_PARAMS_KEY));
         this->io_parameter = IOParameter::GetIOParameterByJson(json[IO_PARAMS_KEY]);
         this->quantizer_parameter = std::make_shared<FP32QuantizerParameter>();
     }

--- a/src/datacell/multi_vector_datacell_parameter.h
+++ b/src/datacell/multi_vector_datacell_parameter.h
@@ -1,0 +1,62 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <fmt/format.h>
+
+#include "flatten_interface_parameter.h"
+#include "inner_string_params.h"
+#include "quantization/fp32_quantizer_parameter.h"
+#include "utils/pointer_define.h"
+
+namespace vsag {
+DEFINE_POINTER2(MultiVectorDataCellParam, MultiVectorDataCellParameter);
+
+class MultiVectorDataCellParameter : public FlattenInterfaceParameter {
+public:
+    explicit MultiVectorDataCellParameter()
+        : FlattenInterfaceParameter(MULTI_VECTOR_DATA_CELL) {
+    }
+
+    void
+    FromJson(const JsonType& json) override {
+        CHECK_ARGUMENT(json.Contains(IO_PARAMS_KEY),
+                       fmt::format("multi-vector datacell parameters must contain {}", IO_PARAMS_KEY));
+        this->io_parameter = IOParameter::GetIOParameterByJson(json[IO_PARAMS_KEY]);
+        this->quantizer_parameter = std::make_shared<FP32QuantizerParameter>();
+    }
+
+    JsonType
+    ToJson() const override {
+        JsonType json;
+        json[IO_PARAMS_KEY].SetJson(this->io_parameter->ToJson());
+        json[CODES_TYPE_KEY].SetString(MULTI_VECTOR_CODES);
+        return json;
+    }
+
+    bool
+    CheckCompatibility(const vsag::ParamPtr& other) const override {
+        auto mv_param = std::dynamic_pointer_cast<MultiVectorDataCellParameter>(other);
+        if (not mv_param) {
+            logger::error(
+                "MultiVectorDataCellParameter::CheckCompatibility: "
+                "other parameter is not MultiVectorDataCellParameter");
+            return false;
+        }
+        return true;
+    }
+};
+}  // namespace vsag

--- a/src/datacell/multi_vector_datacell_test.cpp
+++ b/src/datacell/multi_vector_datacell_test.cpp
@@ -17,12 +17,14 @@
 #include <cmath>
 #include <cstdint>
 #include <limits>
+#include <sstream>
 #include <vector>
 
 #include "datacell/flatten_interface.h"
 #include "datacell/multi_vector_datacell_parameter.h"
 #include "impl/allocator/safe_allocator.h"
 #include "index_common_param.h"
+#include "storage/serialization.h"
 #include "unittest.h"
 #include "vsag/dataset.h"
 
@@ -214,6 +216,60 @@ TEST_CASE("MultiVectorDataCell Query computes MaxSim distances", "[ut][MultiVect
         float expected =
             CalMaxSimIP(query_data.data(), 2, doc_list[i].first, doc_list[i].second, dim);
         REQUIRE(std::abs(dists[i] - expected) < kEpsilon);
+    }
+}
+
+TEST_CASE("MultiVectorDataCell Serialize/Deserialize round-trip", "[ut][MultiVectorDataCell]") {
+    const std::string io_type = GENERATE("memory_io", "block_memory_io");
+    constexpr uint32_t dim = 4;
+
+    std::vector<float> doc0_data = {0.1F, 0.3F, 0.5F, 0.7F, 0.2F, 0.4F, 0.6F, 0.8F};
+    std::vector<float> doc1_data = {
+        0.9F, 0.1F, 0.2F, 0.3F, 0.4F, 0.8F, 0.1F, 0.5F, 0.3F, 0.6F, 0.7F, 0.2F};
+    std::vector<float> doc2_data = {0.5F, 0.3F, 0.4F, 0.6F};
+
+    MultiVector doc0{2, doc0_data.data()};
+    MultiVector doc1{3, doc1_data.data()};
+    MultiVector doc2{1, doc2_data.data()};
+    std::vector<MultiVector> docs = {doc0, doc1, doc2};
+
+    std::shared_ptr<Allocator> allocator = SafeAllocator::FactoryDefaultAllocator();
+    FlattenInterfacePtr original = MakeMultiVectorDataCell(io_type, dim, allocator);
+    original->Resize(static_cast<InnerIdType>(docs.size()));
+    for (uint64_t i = 0; i < docs.size(); ++i) {
+        original->InsertVector(docs.data() + i, static_cast<InnerIdType>(i));
+    }
+
+    std::vector<float> query_data = {0.7F, 0.2F, 0.3F, 0.1F, 0.1F, 0.5F, 0.8F, 0.4F};
+    MultiVector query_mv{2, query_data.data()};
+
+    std::vector<InnerIdType> idx = {0, 1, 2};
+    std::vector<float> dists_before(3, 0.0F);
+    {
+        ComputerInterfacePtr computer = original->FactoryComputer(&query_mv);
+        original->Query(
+            dists_before.data(), computer, idx.data(), static_cast<InnerIdType>(idx.size()), nullptr);
+    }
+
+    std::stringstream ss;
+    IOStreamWriter writer(ss);
+    original->Serialize(writer);
+
+    FlattenInterfacePtr restored = MakeMultiVectorDataCell(io_type, dim, allocator);
+    IOStreamReader reader(ss);
+    restored->Deserialize(reader);
+
+    REQUIRE(restored->TotalCount() == original->TotalCount());
+
+    std::vector<float> dists_after(3, 0.0F);
+    {
+        ComputerInterfacePtr computer = restored->FactoryComputer(&query_mv);
+        restored->Query(
+            dists_after.data(), computer, idx.data(), static_cast<InnerIdType>(idx.size()), nullptr);
+    }
+
+    for (uint64_t i = 0; i < 3; ++i) {
+        REQUIRE(dists_before[i] == dists_after[i]);
     }
 }
 

--- a/src/datacell/multi_vector_datacell_test.cpp
+++ b/src/datacell/multi_vector_datacell_test.cpp
@@ -273,4 +273,60 @@ TEST_CASE("MultiVectorDataCell Serialize/Deserialize round-trip", "[ut][MultiVec
     }
 }
 
+TEST_CASE("MultiVectorDataCell rejects invalid InsertVector inputs",
+          "[ut][MultiVectorDataCell]") {
+    constexpr uint32_t dim = 4;
+    std::shared_ptr<Allocator> allocator = SafeAllocator::FactoryDefaultAllocator();
+    FlattenInterfacePtr data_cell = MakeMultiVectorDataCell("memory_io", dim, allocator);
+    data_cell->Resize(4);
+
+    SECTION("nullptr vector") {
+        REQUIRE_THROWS(data_cell->InsertVector(nullptr, 0));
+    }
+
+    SECTION("zero token count") {
+        std::vector<float> dummy(dim, 1.0F);
+        MultiVector mv{0, dummy.data()};
+        REQUIRE_THROWS(data_cell->InsertVector(&mv, 0));
+    }
+
+    SECTION("nullptr tokens") {
+        MultiVector mv{2, nullptr};
+        REQUIRE_THROWS(data_cell->InsertVector(&mv, 0));
+    }
+}
+
+TEST_CASE("MultiVectorDataCell rejects invalid BatchInsertVector inputs",
+          "[ut][MultiVectorDataCell]") {
+    constexpr uint32_t dim = 4;
+    std::shared_ptr<Allocator> allocator = SafeAllocator::FactoryDefaultAllocator();
+    FlattenInterfacePtr data_cell = MakeMultiVectorDataCell("memory_io", dim, allocator);
+
+    SECTION("nullptr vectors array") {
+        REQUIRE_THROWS(data_cell->BatchInsertVector(nullptr, 3, nullptr));
+    }
+}
+
+TEST_CASE("MultiVectorDataCell rejects invalid FactoryComputer inputs",
+          "[ut][MultiVectorDataCell]") {
+    constexpr uint32_t dim = 4;
+    std::shared_ptr<Allocator> allocator = SafeAllocator::FactoryDefaultAllocator();
+    FlattenInterfacePtr data_cell = MakeMultiVectorDataCell("memory_io", dim, allocator);
+
+    SECTION("nullptr query") {
+        REQUIRE_THROWS(data_cell->FactoryComputer(nullptr));
+    }
+
+    SECTION("zero query token count") {
+        std::vector<float> dummy(dim, 1.0F);
+        MultiVector mv{0, dummy.data()};
+        REQUIRE_THROWS(data_cell->FactoryComputer(&mv));
+    }
+
+    SECTION("nullptr query vectors") {
+        MultiVector mv{2, nullptr};
+        REQUIRE_THROWS(data_cell->FactoryComputer(&mv));
+    }
+}
+
 }  // namespace vsag

--- a/src/datacell/multi_vector_datacell_test.cpp
+++ b/src/datacell/multi_vector_datacell_test.cpp
@@ -247,8 +247,11 @@ TEST_CASE("MultiVectorDataCell Serialize/Deserialize round-trip", "[ut][MultiVec
     std::vector<float> dists_before(3, 0.0F);
     {
         ComputerInterfacePtr computer = original->FactoryComputer(&query_mv);
-        original->Query(
-            dists_before.data(), computer, idx.data(), static_cast<InnerIdType>(idx.size()), nullptr);
+        original->Query(dists_before.data(),
+                        computer,
+                        idx.data(),
+                        static_cast<InnerIdType>(idx.size()),
+                        nullptr);
     }
 
     std::stringstream ss;
@@ -264,8 +267,11 @@ TEST_CASE("MultiVectorDataCell Serialize/Deserialize round-trip", "[ut][MultiVec
     std::vector<float> dists_after(3, 0.0F);
     {
         ComputerInterfacePtr computer = restored->FactoryComputer(&query_mv);
-        restored->Query(
-            dists_after.data(), computer, idx.data(), static_cast<InnerIdType>(idx.size()), nullptr);
+        restored->Query(dists_after.data(),
+                        computer,
+                        idx.data(),
+                        static_cast<InnerIdType>(idx.size()),
+                        nullptr);
     }
 
     for (uint64_t i = 0; i < 3; ++i) {
@@ -273,8 +279,7 @@ TEST_CASE("MultiVectorDataCell Serialize/Deserialize round-trip", "[ut][MultiVec
     }
 }
 
-TEST_CASE("MultiVectorDataCell rejects invalid InsertVector inputs",
-          "[ut][MultiVectorDataCell]") {
+TEST_CASE("MultiVectorDataCell rejects invalid InsertVector inputs", "[ut][MultiVectorDataCell]") {
     constexpr uint32_t dim = 4;
     std::shared_ptr<Allocator> allocator = SafeAllocator::FactoryDefaultAllocator();
     FlattenInterfacePtr data_cell = MakeMultiVectorDataCell("memory_io", dim, allocator);

--- a/src/datacell/multi_vector_datacell_test.cpp
+++ b/src/datacell/multi_vector_datacell_test.cpp
@@ -14,7 +14,9 @@
 
 #include <fmt/format.h>
 
+#include <cmath>
 #include <cstdint>
+#include <limits>
 #include <vector>
 
 #include "datacell/flatten_interface.h"
@@ -69,6 +71,30 @@ FillMultiVectors(const std::vector<uint32_t>& token_counts,
         multi_vectors[doc_id].len_ = token_counts[doc_id];
         multi_vectors[doc_id].vectors_ = token_storage[doc_id].data();
     }
+}
+
+float
+CalMaxSimIP(const float* query,
+            uint32_t query_token_count,
+            const float* doc,
+            uint32_t doc_token_count,
+            uint32_t dim) {
+    float total = 0.0F;
+    for (uint32_t q = 0; q < query_token_count; ++q) {
+        float min_dist = std::numeric_limits<float>::max();
+        for (uint32_t d = 0; d < doc_token_count; ++d) {
+            float ip = 0.0F;
+            for (uint32_t k = 0; k < dim; ++k) {
+                ip += query[q * dim + k] * doc[d * dim + k];
+            }
+            float dist = 1.0F - ip;
+            if (dist < min_dist) {
+                min_dist = dist;
+            }
+        }
+        total += min_dist;
+    }
+    return total;
 }
 
 }  // namespace
@@ -143,6 +169,51 @@ TEST_CASE("MultiVectorDataCell GetCodesById reads back inserted data",
         }
 
         data_cell->Release(codes);
+    }
+}
+
+TEST_CASE("MultiVectorDataCell Query computes MaxSim distances", "[ut][MultiVectorDataCell]") {
+    const std::string io_type = GENERATE("memory_io", "block_memory_io");
+    constexpr uint32_t dim = 4;
+
+    // doc0: 2 tokens
+    std::vector<float> doc0_data = {0.1F, 0.3F, 0.5F, 0.7F, 0.2F, 0.4F, 0.6F, 0.8F};
+    // doc1: 3 tokens
+    std::vector<float> doc1_data = {
+        0.9F, 0.1F, 0.2F, 0.3F, 0.4F, 0.8F, 0.1F, 0.5F, 0.3F, 0.6F, 0.7F, 0.2F};
+    // doc2: 1 token
+    std::vector<float> doc2_data = {0.5F, 0.3F, 0.4F, 0.6F};
+
+    MultiVector doc0{2, doc0_data.data()};
+    MultiVector doc1{3, doc1_data.data()};
+    MultiVector doc2{1, doc2_data.data()};
+    std::vector<MultiVector> docs = {doc0, doc1, doc2};
+
+    std::shared_ptr<Allocator> allocator = SafeAllocator::FactoryDefaultAllocator();
+    FlattenInterfacePtr data_cell = MakeMultiVectorDataCell(io_type, dim, allocator);
+    data_cell->Resize(static_cast<InnerIdType>(docs.size()));
+    for (uint64_t i = 0; i < docs.size(); ++i) {
+        data_cell->InsertVector(docs.data() + i, static_cast<InnerIdType>(i));
+    }
+
+    // query: 2 tokens
+    std::vector<float> query_data = {0.7F, 0.2F, 0.3F, 0.1F, 0.1F, 0.5F, 0.8F, 0.4F};
+    MultiVector query_mv{2, query_data.data()};
+    ComputerInterfacePtr computer = data_cell->FactoryComputer(&query_mv);
+    REQUIRE(computer != nullptr);
+
+    std::vector<InnerIdType> idx = {0, 1, 2};
+    std::vector<float> dists(3, 0.0F);
+    data_cell->Query(
+        dists.data(), computer, idx.data(), static_cast<InnerIdType>(idx.size()), nullptr);
+
+    constexpr float kEpsilon = 1e-5F;
+    const std::vector<std::pair<const float*, uint32_t>> doc_list = {
+        {doc0_data.data(), 2}, {doc1_data.data(), 3}, {doc2_data.data(), 1}};
+    for (uint64_t i = 0; i < doc_list.size(); ++i) {
+        float expected =
+            CalMaxSimIP(query_data.data(), 2, doc_list[i].first, doc_list[i].second, dim);
+        REQUIRE(std::abs(dists[i] - expected) < kEpsilon);
     }
 }
 

--- a/src/datacell/multi_vector_datacell_test.cpp
+++ b/src/datacell/multi_vector_datacell_test.cpp
@@ -111,4 +111,39 @@ TEST_CASE("MultiVectorDataCell batch insert reserves ids when idx is null",
     REQUIRE(data_cell->TotalCount() == token_counts.size());
 }
 
+TEST_CASE("MultiVectorDataCell GetCodesById reads back inserted data",
+          "[ut][MultiVectorDataCell]") {
+    const std::string io_type = GENERATE("memory_io", "block_memory_io");
+    constexpr uint32_t dim = 4;
+    const std::vector<uint32_t> token_counts = {1, 3, 2, 5, 4};
+    std::vector<std::vector<float>> token_storage;
+    std::vector<MultiVector> multi_vectors;
+    FillMultiVectors(token_counts, dim, token_storage, multi_vectors);
+
+    std::shared_ptr<Allocator> allocator = SafeAllocator::FactoryDefaultAllocator();
+    FlattenInterfacePtr data_cell = MakeMultiVectorDataCell(io_type, dim, allocator);
+    data_cell->Resize(static_cast<InnerIdType>(multi_vectors.size()));
+
+    for (uint64_t i = 0; i < multi_vectors.size(); ++i) {
+        data_cell->InsertVector(multi_vectors.data() + i, static_cast<InnerIdType>(i));
+    }
+
+    for (uint64_t i = 0; i < multi_vectors.size(); ++i) {
+        bool need_release = false;
+        const uint8_t* codes = data_cell->GetCodesById(static_cast<InnerIdType>(i), need_release);
+        REQUIRE(need_release == true);
+
+        uint32_t len = 0;
+        std::memcpy(&len, codes, sizeof(uint32_t));
+        REQUIRE(len == token_counts[i]);
+
+        const auto* floats = reinterpret_cast<const float*>(codes + sizeof(uint32_t));
+        for (uint64_t j = 0; j < static_cast<uint64_t>(len) * dim; ++j) {
+            REQUIRE(floats[j] == token_storage[i][j]);
+        }
+
+        data_cell->Release(codes);
+    }
+}
+
 }  // namespace vsag

--- a/src/datacell/multi_vector_datacell_test.cpp
+++ b/src/datacell/multi_vector_datacell_test.cpp
@@ -1,0 +1,114 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <fmt/format.h>
+
+#include <cstdint>
+#include <vector>
+
+#include "datacell/flatten_interface.h"
+#include "datacell/multi_vector_datacell_parameter.h"
+#include "impl/allocator/safe_allocator.h"
+#include "index_common_param.h"
+#include "unittest.h"
+#include "vsag/dataset.h"
+
+namespace vsag {
+namespace {
+
+FlattenInterfacePtr
+MakeMultiVectorDataCell(const std::string& io_type,
+                        int64_t dim,
+                        const std::shared_ptr<Allocator>& allocator) {
+    constexpr const char* param_template =
+        R"(
+        {{
+            "io_params": {{
+                "type": "{}"
+            }}
+        }}
+        )";
+    const std::string param_str = fmt::format(param_template, io_type);
+    JsonType parsed_json = JsonType::Parse(param_str);
+    MultiVectorDataCellParamPtr param = std::make_shared<MultiVectorDataCellParameter>();
+    param->FromJson(parsed_json);
+
+    IndexCommonParam index_common_param;
+    index_common_param.allocator_ = allocator;
+    index_common_param.metric_ = MetricType::METRIC_TYPE_IP;
+    index_common_param.dim_ = dim;
+    return FlattenInterface::MakeInstance(param, index_common_param);
+}
+
+void
+FillMultiVectors(const std::vector<uint32_t>& token_counts,
+                 uint32_t dim,
+                 std::vector<std::vector<float>>& token_storage,
+                 std::vector<MultiVector>& multi_vectors) {
+    const uint64_t doc_count = static_cast<uint64_t>(token_counts.size());
+    token_storage.resize(doc_count);
+    multi_vectors.resize(doc_count);
+
+    for (uint64_t doc_id = 0; doc_id < doc_count; ++doc_id) {
+        const uint64_t float_count = static_cast<uint64_t>(token_counts[doc_id]) * dim;
+        token_storage[doc_id].resize(float_count);
+        for (uint64_t pos = 0; pos < float_count; ++pos) {
+            token_storage[doc_id][pos] = static_cast<float>(doc_id * 100 + pos);
+        }
+        multi_vectors[doc_id].len_ = token_counts[doc_id];
+        multi_vectors[doc_id].vectors_ = token_storage[doc_id].data();
+    }
+}
+
+}  // namespace
+
+TEST_CASE("MultiVectorDataCell inserts variable-length documents", "[ut][MultiVectorDataCell]") {
+    const std::string io_type = GENERATE("memory_io", "block_memory_io");
+    constexpr uint32_t dim = 4;
+    const std::vector<uint32_t> token_counts = {1, 3, 2, 5, 4};
+    std::vector<std::vector<float>> token_storage;
+    std::vector<MultiVector> multi_vectors;
+    FillMultiVectors(token_counts, dim, token_storage, multi_vectors);
+
+    std::shared_ptr<Allocator> allocator = SafeAllocator::FactoryDefaultAllocator();
+    FlattenInterfacePtr data_cell = MakeMultiVectorDataCell(io_type, dim, allocator);
+    data_cell->Resize(static_cast<InnerIdType>(multi_vectors.size()));
+
+    data_cell->InsertVector(multi_vectors.data(), 0);
+    data_cell->InsertVector(multi_vectors.data() + 1, 1);
+    std::vector<InnerIdType> idx = {2, 3, 4};
+    data_cell->BatchInsertVector(
+        multi_vectors.data() + 2, static_cast<InnerIdType>(idx.size()), idx.data());
+
+    REQUIRE(data_cell->TotalCount() == token_counts.size());
+}
+
+TEST_CASE("MultiVectorDataCell batch insert reserves ids when idx is null",
+          "[ut][MultiVectorDataCell]") {
+    const std::string io_type = GENERATE("memory_io", "block_memory_io");
+    constexpr uint32_t dim = 4;
+    const std::vector<uint32_t> token_counts = {1, 3, 2, 5, 4};
+    std::vector<std::vector<float>> token_storage;
+    std::vector<MultiVector> multi_vectors;
+    FillMultiVectors(token_counts, dim, token_storage, multi_vectors);
+
+    std::shared_ptr<Allocator> allocator = SafeAllocator::FactoryDefaultAllocator();
+    FlattenInterfacePtr data_cell = MakeMultiVectorDataCell(io_type, dim, allocator);
+    data_cell->BatchInsertVector(
+        multi_vectors.data(), static_cast<InnerIdType>(multi_vectors.size()), nullptr);
+
+    REQUIRE(data_cell->TotalCount() == token_counts.size());
+}
+
+}  // namespace vsag

--- a/src/impl/reorder/flatten_reorder.cpp
+++ b/src/impl/reorder/flatten_reorder.cpp
@@ -29,7 +29,7 @@ namespace vsag {
 
 DistHeapPtr
 FlattenReorder::Reorder(const vsag::DistHeapPtr& input,
-                        const float* query,
+                        const void* query,
                         int64_t topk,
                         QueryContext& ctx,
                         IteratorFilterContext* iter_ctx,

--- a/src/impl/reorder/flatten_reorder.h
+++ b/src/impl/reorder/flatten_reorder.h
@@ -32,7 +32,7 @@ public:
 
     DistHeapPtr
     Reorder(const DistHeapPtr& input,
-            const float* query,
+            const void* query,
             int64_t topk,
             QueryContext& ctx,
             IteratorFilterContext* iter_ctx = nullptr,

--- a/src/impl/reorder/reorder.h
+++ b/src/impl/reorder/reorder.h
@@ -28,7 +28,7 @@ class ReorderInterface {
 public:
     virtual DistHeapPtr
     Reorder(const DistHeapPtr& input,
-            const float* query,
+            const void* query,
             int64_t topk,
             QueryContext& ctx,
             IteratorFilterContext* iter_ctx = nullptr,

--- a/src/inner_string_params.h
+++ b/src/inner_string_params.h
@@ -158,6 +158,9 @@ const char* const GNO_IMI_SEARCH_PARAM_FIRST_ORDER_SCAN_RATIO = "first_order_sca
 const char* const FLATTEN_DATA_CELL = "flatten_data_cell";
 const char* const RABITQ_SPLIT_DATA_CELL = "rabitq_split_data_cell";
 const char* const SPARSE_VECTOR_DATA_CELL = "sparse_vector_data_cell";
+const char* const MULTI_VECTOR_DATA_CELL = "multi_vector_data_cell";
+
+const char* const MULTI_VECTOR_CODES = "multi_vector";
 
 // for pyramid index
 const char* const NO_BUILD_LEVELS = "no_build_levels";

--- a/src/quantization/CMakeLists.txt
+++ b/src/quantization/CMakeLists.txt
@@ -18,6 +18,7 @@ set (QUANTIZER_SRC
         quantizer_adapter.cpp
         fp32_quantizer.cpp
         int8_quantizer.cpp
+        multi_vector_computer.cpp
         scalar_quantization/scalar_quantizer.cpp
         scalar_quantization/half_precision_quantizer.cpp
         scalar_quantization/sq4_uniform_quantizer.cpp

--- a/src/quantization/multi_vector_computer.cpp
+++ b/src/quantization/multi_vector_computer.cpp
@@ -1,0 +1,81 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "multi_vector_computer.h"
+
+#include <algorithm>
+#include <cstring>
+#include <limits>
+
+#include "simd/fp32_simd.h"
+#include "vsag_exception.h"
+
+namespace vsag {
+
+MultiVectorComputer::MultiVectorComputer(uint32_t dim, MetricType metric, Allocator* allocator)
+    : dim_(dim), metric_(metric), allocator_(allocator), query_tokens_(allocator) {
+}
+
+void
+MultiVectorComputer::SetQuery(const float* query_tokens, uint32_t query_token_count) {
+    query_token_count_ = query_token_count;
+    if (query_token_count == 0) {
+        query_tokens_.clear();
+        return;
+    }
+    const uint64_t total_floats = static_cast<uint64_t>(query_token_count) * dim_;
+    try {
+        query_tokens_.resize(total_floats);
+    } catch (const std::bad_alloc&) {
+        throw VsagException(ErrorType::NO_ENOUGH_MEMORY,
+                            "bad alloc when resizing multi-vector query buffer");
+    }
+    std::memcpy(query_tokens_.data(), query_tokens, total_floats * sizeof(float));
+}
+
+void
+MultiVectorComputer::ComputeDist(const uint8_t* codes,
+                                 uint32_t token_count,
+                                 float* dist) const {
+    const float* doc_tokens = reinterpret_cast<const float*>(codes);
+    float total = 0.0F;
+
+    for (uint32_t q = 0; q < query_token_count_; ++q) {
+        const float* q_tok = query_tokens_.data() + static_cast<uint64_t>(q) * dim_;
+        float min_dist = std::numeric_limits<float>::max();
+
+        for (uint32_t d = 0; d < token_count; ++d) {
+            const float* d_tok = doc_tokens + static_cast<uint64_t>(d) * dim_;
+            float dist_val = 0.0F;
+            if (metric_ == MetricType::METRIC_TYPE_IP) {
+                dist_val = 1.0F - FP32ComputeIP(q_tok, d_tok, dim_);
+            } else if (metric_ == MetricType::METRIC_TYPE_L2SQR) {
+                dist_val = FP32ComputeL2Sqr(q_tok, d_tok, dim_);
+            } else {
+                throw VsagException(ErrorType::INVALID_ARGUMENT,
+                                    "unsupported metric type for MultiVectorComputer");
+            }
+            if (dist_val < min_dist) {
+                min_dist = dist_val;
+            }
+        }
+
+        total += min_dist;
+    }
+
+    *dist = total;
+}
+
+}  // namespace vsag

--- a/src/quantization/multi_vector_computer.cpp
+++ b/src/quantization/multi_vector_computer.cpp
@@ -47,7 +47,7 @@ MultiVectorComputer::SetQuery(const float* query_tokens, uint32_t query_token_co
 
 void
 MultiVectorComputer::ComputeDist(const uint8_t* codes, uint32_t token_count, float* dist) const {
-    const float* doc_tokens = reinterpret_cast<const float*>(codes);
+    const auto* doc_tokens = reinterpret_cast<const float*>(codes);
     float total = 0.0F;
 
     for (uint32_t q = 0; q < query_token_count_; ++q) {

--- a/src/quantization/multi_vector_computer.cpp
+++ b/src/quantization/multi_vector_computer.cpp
@@ -50,27 +50,39 @@ MultiVectorComputer::ComputeDist(const uint8_t* codes, uint32_t token_count, flo
     const auto* doc_tokens = reinterpret_cast<const float*>(codes);
     float total = 0.0F;
 
-    for (uint32_t q = 0; q < query_token_count_; ++q) {
-        const float* q_tok = query_tokens_.data() + static_cast<uint64_t>(q) * dim_;
-        float min_dist = std::numeric_limits<float>::max();
+    if (metric_ == MetricType::METRIC_TYPE_IP) {
+        for (uint32_t q = 0; q < query_token_count_; ++q) {
+            const float* q_tok = query_tokens_.data() + static_cast<uint64_t>(q) * dim_;
+            float min_dist = std::numeric_limits<float>::max();
 
-        for (uint32_t d = 0; d < token_count; ++d) {
-            const float* d_tok = doc_tokens + static_cast<uint64_t>(d) * dim_;
-            float dist_val = 0.0F;
-            if (metric_ == MetricType::METRIC_TYPE_IP) {
-                dist_val = 1.0F - FP32ComputeIP(q_tok, d_tok, dim_);
-            } else if (metric_ == MetricType::METRIC_TYPE_L2SQR) {
-                dist_val = FP32ComputeL2Sqr(q_tok, d_tok, dim_);
-            } else {
-                throw VsagException(ErrorType::INVALID_ARGUMENT,
-                                    "unsupported metric type for MultiVectorComputer");
+            for (uint32_t d = 0; d < token_count; ++d) {
+                const float* d_tok = doc_tokens + static_cast<uint64_t>(d) * dim_;
+                float dist_val = 1.0F - FP32ComputeIP(q_tok, d_tok, dim_);
+                if (dist_val < min_dist) {
+                    min_dist = dist_val;
+                }
             }
-            if (dist_val < min_dist) {
-                min_dist = dist_val;
-            }
+
+            total += min_dist;
         }
+    } else if (metric_ == MetricType::METRIC_TYPE_L2SQR) {
+        for (uint32_t q = 0; q < query_token_count_; ++q) {
+            const float* q_tok = query_tokens_.data() + static_cast<uint64_t>(q) * dim_;
+            float min_dist = std::numeric_limits<float>::max();
 
-        total += min_dist;
+            for (uint32_t d = 0; d < token_count; ++d) {
+                const float* d_tok = doc_tokens + static_cast<uint64_t>(d) * dim_;
+                float dist_val = FP32ComputeL2Sqr(q_tok, d_tok, dim_);
+                if (dist_val < min_dist) {
+                    min_dist = dist_val;
+                }
+            }
+
+            total += min_dist;
+        }
+    } else {
+        throw VsagException(ErrorType::INVALID_ARGUMENT,
+                            "unsupported metric type for MultiVectorComputer");
     }
 
     *dist = total;

--- a/src/quantization/multi_vector_computer.cpp
+++ b/src/quantization/multi_vector_computer.cpp
@@ -46,9 +46,7 @@ MultiVectorComputer::SetQuery(const float* query_tokens, uint32_t query_token_co
 }
 
 void
-MultiVectorComputer::ComputeDist(const uint8_t* codes,
-                                 uint32_t token_count,
-                                 float* dist) const {
+MultiVectorComputer::ComputeDist(const uint8_t* codes, uint32_t token_count, float* dist) const {
     const float* doc_tokens = reinterpret_cast<const float*>(codes);
     float total = 0.0F;
 

--- a/src/quantization/multi_vector_computer.h
+++ b/src/quantization/multi_vector_computer.h
@@ -1,0 +1,100 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+
+#include "computer.h"
+#include "metric_type.h"
+#include "typing.h"
+#include "utils/pointer_define.h"
+#include "vsag/allocator.h"
+
+namespace vsag {
+
+DEFINE_POINTER(MultiVectorComputer)
+
+/**
+ * @brief Computer that scores a multi-vector (ColBERT-style) doc against a multi-vector query
+ *        using the MaxSim distance:
+ *
+ *            MaxSim(query, doc) = sum_{q_tok in query} min_{d_tok in doc} dist(q_tok, d_tok)
+ *
+ *        Smaller is more similar (every per-token term is itself a distance):
+ *          - IP   : 1 - <q_tok, d_tok>
+ *          - L2   : ||q_tok - d_tok||^2
+ *          - COSINE will be added in a follow-up PR (normalize then reuse IP).
+ *
+ *        The class is intentionally storage-agnostic: ComputeDist accepts a flat
+ *        token-codes buffer (no length prefix) plus an explicit token_count. The
+ *        caller (typically MultiVectorDataCell) is responsible for stripping any
+ *        on-disk prefix before passing the pointer in.
+ *
+ *        First version supports FP32 token codes only (codes are reinterpreted as
+ *        const float*).
+ */
+class MultiVectorComputer : public ComputerInterface {
+public:
+    MultiVectorComputer(uint32_t dim, MetricType metric, Allocator* allocator);
+
+    ~MultiVectorComputer() override = default;
+
+    /**
+     * @brief Bind a query (a flat array of `query_token_count * dim` floats).
+     *
+     * The query is copied into an internal buffer so the caller may release the
+     * input afterwards. May be called multiple times to rebind a different query.
+     */
+    void
+    SetQuery(const float* query_tokens, uint32_t query_token_count);
+
+    /**
+     * @brief Compute MaxSim(query, doc).
+     *
+     * @param codes        pure token codes for the doc, reinterpretable as
+     *                     `const float*` of `token_count * dim` floats. Must NOT
+     *                     contain a token-count prefix.
+     * @param token_count  number of tokens in the doc (>= 1).
+     * @param dist         output distance (smaller is more similar).
+     */
+    void
+    ComputeDist(const uint8_t* codes, uint32_t token_count, float* dist) const;
+
+    [[nodiscard]] uint32_t
+    GetDim() const {
+        return dim_;
+    }
+
+    [[nodiscard]] uint32_t
+    GetQueryTokenCount() const {
+        return query_token_count_;
+    }
+
+    [[nodiscard]] MetricType
+    GetMetric() const {
+        return metric_;
+    }
+
+private:
+    uint32_t dim_{0};
+    MetricType metric_{MetricType::METRIC_TYPE_L2SQR};
+    Allocator* const allocator_{nullptr};
+
+    Vector<float> query_tokens_;
+    uint32_t query_token_count_{0};
+};
+
+}  // namespace vsag

--- a/src/quantization/multi_vector_computer_test.cpp
+++ b/src/quantization/multi_vector_computer_test.cpp
@@ -29,8 +29,9 @@ namespace {
 
 constexpr float kEpsilon = 1e-5F;
 
-// 朴素 oracle:对 query 每个 token,在 doc 所有 token 里找 min distance,累加。
-// metric: METRIC_TYPE_IP 用 1 - <q,d>, METRIC_TYPE_L2SQR 用 ||q-d||^2。
+// Naive oracle: for each query token, find the minimum distance among all doc tokens and
+// accumulate the results. For METRIC_TYPE_IP, use 1 - <q,d>; for METRIC_TYPE_L2SQR,
+// use ||q-d||^2.
 float
 NaiveMaxSim(const std::vector<float>& query,
             uint32_t query_token_count,

--- a/src/quantization/multi_vector_computer_test.cpp
+++ b/src/quantization/multi_vector_computer_test.cpp
@@ -79,14 +79,29 @@ TEST_CASE("MultiVectorComputer hand-computed oracle (dim=4, q=2, d=3)",
 
     // query: q0=(1,0,0,0), q1=(0,1,1,0)
     std::vector<float> query = {
-        1.0F, 0.0F, 0.0F, 0.0F,
-        0.0F, 1.0F, 1.0F, 0.0F,
+        1.0F,
+        0.0F,
+        0.0F,
+        0.0F,
+        0.0F,
+        1.0F,
+        1.0F,
+        0.0F,
     };
     // doc:   d0=(1,0,0,0), d1=(0,2,0,0), d2=(0,0,1,0)
     std::vector<float> doc = {
-        1.0F, 0.0F, 0.0F, 0.0F,
-        0.0F, 2.0F, 0.0F, 0.0F,
-        0.0F, 0.0F, 1.0F, 0.0F,
+        1.0F,
+        0.0F,
+        0.0F,
+        0.0F,
+        0.0F,
+        2.0F,
+        0.0F,
+        0.0F,
+        0.0F,
+        0.0F,
+        1.0F,
+        0.0F,
     };
 
     SECTION("IP metric: hand-computed expected = -1") {
@@ -213,8 +228,7 @@ TEST_CASE("MultiVectorComputer randomized vs naive oracle (dim=8, q=4, d=6)",
         computer.SetQuery(query.data(), query_tok_count);
 
         float actual = 0.0F;
-        computer.ComputeDist(
-            reinterpret_cast<const uint8_t*>(doc.data()), doc_tok_count, &actual);
+        computer.ComputeDist(reinterpret_cast<const uint8_t*>(doc.data()), doc_tok_count, &actual);
 
         float expected = NaiveMaxSim(query, query_tok_count, doc, doc_tok_count, dim, metric);
         REQUIRE(std::abs(actual - expected) < 1e-4F);

--- a/src/quantization/multi_vector_computer_test.cpp
+++ b/src/quantization/multi_vector_computer_test.cpp
@@ -1,0 +1,222 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "multi_vector_computer.h"
+
+#include <cmath>
+#include <limits>
+#include <random>
+#include <vector>
+
+#include "impl/allocator/safe_allocator.h"
+#include "unittest.h"
+
+using namespace vsag;
+
+namespace {
+
+constexpr float kEpsilon = 1e-5F;
+
+// 朴素 oracle:对 query 每个 token,在 doc 所有 token 里找 min distance,累加。
+// metric: METRIC_TYPE_IP 用 1 - <q,d>, METRIC_TYPE_L2SQR 用 ||q-d||^2。
+float
+NaiveMaxSim(const std::vector<float>& query,
+            uint32_t query_token_count,
+            const std::vector<float>& doc,
+            uint32_t doc_token_count,
+            uint32_t dim,
+            MetricType metric) {
+    float total = 0.0F;
+    for (uint32_t q = 0; q < query_token_count; ++q) {
+        const float* q_tok = query.data() + q * dim;
+        float min_dist = std::numeric_limits<float>::max();
+        for (uint32_t d = 0; d < doc_token_count; ++d) {
+            const float* d_tok = doc.data() + d * dim;
+            float dist_val = 0.0F;
+            if (metric == MetricType::METRIC_TYPE_IP) {
+                float ip = 0.0F;
+                for (uint32_t i = 0; i < dim; ++i) {
+                    ip += q_tok[i] * d_tok[i];
+                }
+                dist_val = 1.0F - ip;
+            } else {
+                float l2 = 0.0F;
+                for (uint32_t i = 0; i < dim; ++i) {
+                    float diff = q_tok[i] - d_tok[i];
+                    l2 += diff * diff;
+                }
+                dist_val = l2;
+            }
+            if (dist_val < min_dist) {
+                min_dist = dist_val;
+            }
+        }
+        total += min_dist;
+    }
+    return total;
+}
+
+}  // namespace
+
+TEST_CASE("MultiVectorComputer hand-computed oracle (dim=4, q=2, d=3)",
+          "[ut][MultiVectorComputer]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    constexpr uint32_t dim = 4;
+    constexpr uint32_t query_tok_count = 2;
+    constexpr uint32_t doc_tok_count = 3;
+
+    // query: q0=(1,0,0,0), q1=(0,1,1,0)
+    std::vector<float> query = {
+        1.0F, 0.0F, 0.0F, 0.0F,
+        0.0F, 1.0F, 1.0F, 0.0F,
+    };
+    // doc:   d0=(1,0,0,0), d1=(0,2,0,0), d2=(0,0,1,0)
+    std::vector<float> doc = {
+        1.0F, 0.0F, 0.0F, 0.0F,
+        0.0F, 2.0F, 0.0F, 0.0F,
+        0.0F, 0.0F, 1.0F, 0.0F,
+    };
+
+    SECTION("IP metric: hand-computed expected = -1") {
+        // q0: IP=[1,0,0] -> dist=[0,1,1] -> min=0
+        // q1: IP=[0,2,1] -> dist=[1,-1,0] -> min=-1
+        // total = -1
+        MultiVectorComputer computer(dim, MetricType::METRIC_TYPE_IP, allocator.get());
+        computer.SetQuery(query.data(), query_tok_count);
+
+        float dist = 0.0F;
+        computer.ComputeDist(reinterpret_cast<const uint8_t*>(doc.data()), doc_tok_count, &dist);
+
+        REQUIRE(std::abs(dist - (-1.0F)) < kEpsilon);
+
+        float oracle = NaiveMaxSim(
+            query, query_tok_count, doc, doc_tok_count, dim, MetricType::METRIC_TYPE_IP);
+        REQUIRE(std::abs(dist - oracle) < kEpsilon);
+    }
+
+    SECTION("L2 metric: hand-computed expected = 1") {
+        // q0 L2 with doc: 0, 5, 2 -> min=0
+        // q1 L2 with doc: 3, 2, 1 -> min=1
+        // total = 1
+        MultiVectorComputer computer(dim, MetricType::METRIC_TYPE_L2SQR, allocator.get());
+        computer.SetQuery(query.data(), query_tok_count);
+
+        float dist = 0.0F;
+        computer.ComputeDist(reinterpret_cast<const uint8_t*>(doc.data()), doc_tok_count, &dist);
+
+        REQUIRE(std::abs(dist - 1.0F) < kEpsilon);
+
+        float oracle = NaiveMaxSim(
+            query, query_tok_count, doc, doc_tok_count, dim, MetricType::METRIC_TYPE_L2SQR);
+        REQUIRE(std::abs(dist - oracle) < kEpsilon);
+    }
+}
+
+TEST_CASE("MultiVectorComputer accessors", "[ut][MultiVectorComputer]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    MultiVectorComputer computer(8, MetricType::METRIC_TYPE_IP, allocator.get());
+
+    REQUIRE(computer.GetDim() == 8);
+    REQUIRE(computer.GetMetric() == MetricType::METRIC_TYPE_IP);
+    REQUIRE(computer.GetQueryTokenCount() == 0);
+
+    std::vector<float> query(16, 0.5F);
+    computer.SetQuery(query.data(), 2);
+    REQUIRE(computer.GetQueryTokenCount() == 2);
+}
+
+TEST_CASE("MultiVectorComputer rebind query overwrites previous tokens",
+          "[ut][MultiVectorComputer]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    constexpr uint32_t dim = 2;
+    MultiVectorComputer computer(dim, MetricType::METRIC_TYPE_L2SQR, allocator.get());
+
+    // First query: 3 tokens
+    std::vector<float> query_a = {1.0F, 0.0F, 0.0F, 1.0F, 1.0F, 1.0F};
+    computer.SetQuery(query_a.data(), 3);
+    REQUIRE(computer.GetQueryTokenCount() == 3);
+
+    // Rebind to a smaller query: 1 token
+    std::vector<float> query_b = {2.0F, 2.0F};
+    computer.SetQuery(query_b.data(), 1);
+    REQUIRE(computer.GetQueryTokenCount() == 1);
+
+    // doc: single token (3, 3)
+    std::vector<float> doc = {3.0F, 3.0F};
+    float dist = 0.0F;
+    computer.ComputeDist(reinterpret_cast<const uint8_t*>(doc.data()), 1, &dist);
+
+    // L2: ||(2,2)-(3,3)||^2 = 1 + 1 = 2
+    REQUIRE(std::abs(dist - 2.0F) < kEpsilon);
+}
+
+TEST_CASE("MultiVectorComputer boundary: query_token_count=1, doc_token_count=1, dim=1",
+          "[ut][MultiVectorComputer]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+
+    SECTION("IP, dim=1") {
+        MultiVectorComputer computer(1, MetricType::METRIC_TYPE_IP, allocator.get());
+        std::vector<float> query = {3.0F};
+        std::vector<float> doc = {2.0F};
+        computer.SetQuery(query.data(), 1);
+        float dist = 0.0F;
+        computer.ComputeDist(reinterpret_cast<const uint8_t*>(doc.data()), 1, &dist);
+        // 1 - 3*2 = -5
+        REQUIRE(std::abs(dist - (-5.0F)) < kEpsilon);
+    }
+
+    SECTION("L2, dim=1") {
+        MultiVectorComputer computer(1, MetricType::METRIC_TYPE_L2SQR, allocator.get());
+        std::vector<float> query = {3.0F};
+        std::vector<float> doc = {2.0F};
+        computer.SetQuery(query.data(), 1);
+        float dist = 0.0F;
+        computer.ComputeDist(reinterpret_cast<const uint8_t*>(doc.data()), 1, &dist);
+        // (3-2)^2 = 1
+        REQUIRE(std::abs(dist - 1.0F) < kEpsilon);
+    }
+}
+
+TEST_CASE("MultiVectorComputer randomized vs naive oracle (dim=8, q=4, d=6)",
+          "[ut][MultiVectorComputer]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    constexpr uint32_t dim = 8;
+    constexpr uint32_t query_tok_count = 4;
+    constexpr uint32_t doc_tok_count = 6;
+
+    std::mt19937 rng(42);
+    std::uniform_real_distribution<float> dist_uniform(-1.0F, 1.0F);
+
+    std::vector<float> query(query_tok_count * dim);
+    std::vector<float> doc(doc_tok_count * dim);
+    for (auto& v : query) {
+        v = dist_uniform(rng);
+    }
+    for (auto& v : doc) {
+        v = dist_uniform(rng);
+    }
+
+    for (auto metric : {MetricType::METRIC_TYPE_IP, MetricType::METRIC_TYPE_L2SQR}) {
+        MultiVectorComputer computer(dim, metric, allocator.get());
+        computer.SetQuery(query.data(), query_tok_count);
+
+        float actual = 0.0F;
+        computer.ComputeDist(
+            reinterpret_cast<const uint8_t*>(doc.data()), doc_tok_count, &actual);
+
+        float expected = NaiveMaxSim(query, query_tok_count, doc, doc_tok_count, dim, metric);
+        REQUIRE(std::abs(actual - expected) < 1e-4F);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `MultiVectorComputer` implementing MaxSim distance (IP and L2) for ColBERT-style multi-vector queries
- Add `MultiVectorDataCell` as a new `FlattenInterface` implementation supporting variable-length token storage per document
- Widen `ReorderInterface::Reorder` query parameter from `const float*` to `const void*` to support non-float query types (multi-vector, sparse) through the existing reorder pipeline

## Details

### MultiVectorComputer (`src/quantization/multi_vector_computer.{h,cpp}`)
- Computes MaxSim distance: `sum_q min_d dist(q_token, d_token)` 
- Supports both IP (`1 - dot`) and L2Sqr metrics
- Query tokens set via `SetQuery()`; per-document distance via `ComputeDist(codes, token_count, &dist)`

### MultiVectorDataCell (`src/datacell/multi_vector_datacell.{h,inl}`)
- Stores variable-length multi-vector documents (each doc = N token vectors of fixed dim)
- Storage format: per-document `[uint32_t token_count][float[token_count * dim]]`
- Implements full `FlattenInterface`: InsertVector, BatchInsertVector, GetCodesById, FactoryComputer, Query, Serialize/Deserialize
- Supports both `memory_io` and `block_memory_io` backends

### ReorderInterface signature change (`src/impl/reorder/`)
- Changed `const float* query` → `const void* query` in `ReorderInterface::Reorder` and `FlattenReorder::Reorder`
- Enables `FlattenReorder` to be reused directly with `MultiVectorDataCell` (no new reorder class needed)
- Existing callers (IVF, Pyramid) pass `const float*` which implicitly converts to `const void*`

## Test plan

- [x] Unit tests for MultiVectorComputer (MaxSim correctness for IP/L2)
- [x] Unit tests for MultiVectorDataCell insert, read-back, query, serialize/deserialize
- [x] Boundary/exception tests (nullptr, zero tokens, etc.)
- [x] Tests pass with both `memory_io` and `block_memory_io` backends
- [ ] Verify existing IVF/Pyramid/HGraph tests still pass (implicit float*→void* conversion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes: #2077