### PR TITLE
feat: support disabling reorder through search params

### DIFF
--- a/docs/docs/en/src/indexes/hgraph.md
+++ b/docs/docs/en/src/indexes/hgraph.md
@@ -202,10 +202,17 @@ Search-time parameters live under the `hgraph` sub-object:
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `ef_search` | int | Size of the search frontier. Larger = higher recall, slower query. |
+| `enable_reorder` | bool | `true` by default. Set to `false` to skip the final reorder stage for this request even when the index was built with reorder enabled. This also disables the RaBitQ one-bit reorder path. |
 
 ```cpp
 auto result = index->KnnSearch(
     query, topk, R"({"hgraph": {"ef_search": 200}})").value();
+```
+
+```cpp
+auto fast_result = index->KnnSearch(
+    query, topk,
+    R"({"hgraph": {"ef_search": 200, "enable_reorder": false}})").value();
 ```
 
 ## When to use HGraph

--- a/docs/docs/en/src/indexes/ivf.md
+++ b/docs/docs/en/src/indexes/ivf.md
@@ -94,6 +94,7 @@ Search-time parameters live under the `ivf` sub-object:
 |-----------|------|---------|-------------|
 | `scan_buckets_count` | int | — (required) | Number of buckets probed per query. Must be ≤ `buckets_count`. |
 | `factor` | float | `2.0` | With reordering enabled, pulls `factor * topk` coarse candidates before the precise rescore. |
+| `enable_reorder` | bool | `true` | Set to `false` to skip the final reorder stage for this request even when the index was built with reorder enabled. |
 | `parallelism` | int | `1` | Threads used to scan buckets in parallel for a single query. |
 | `timeout_ms` | double | `+∞` | Hard cap in milliseconds; partial results are returned once exceeded. |
 
@@ -101,6 +102,12 @@ Search-time parameters live under the `ivf` sub-object:
 auto result = index->KnnSearch(
     query, topk,
     R"({"ivf": {"scan_buckets_count": 32, "factor": 2.0, "parallelism": 4}})").value();
+```
+
+```cpp
+auto fast_result = index->KnnSearch(
+    query, topk,
+    R"({"ivf": {"scan_buckets_count": 32, "factor": 2.0, "enable_reorder": false}})").value();
 ```
 
 ## When to use IVF

--- a/docs/docs/zh/src/indexes/hgraph.md
+++ b/docs/docs/zh/src/indexes/hgraph.md
@@ -188,10 +188,17 @@ base->NumElements(num_vectors)->Dim(dim)->Ids(ids)
 | 参数 | 类型 | 说明 |
 |------|------|------|
 | `ef_search` | int | 搜索前沿候选集的大小，越大召回越高、查询越慢 |
+| `enable_reorder` | bool | 默认值为 `true`。当索引构建时启用了 reorder，也可以在单次请求里设为 `false` 跳过最终精排；这也会一并关闭 RaBitQ 的 one-bit reorder 路径。 |
 
 ```cpp
 auto result = index->KnnSearch(
     query, topk, R"({"hgraph": {"ef_search": 200}})").value();
+```
+
+```cpp
+auto fast_result = index->KnnSearch(
+    query, topk,
+    R"({"hgraph": {"ef_search": 200, "enable_reorder": false}})").value();
 ```
 
 ## 何时选择 HGraph

--- a/docs/docs/zh/src/indexes/ivf.md
+++ b/docs/docs/zh/src/indexes/ivf.md
@@ -87,6 +87,7 @@ auto result = index->KnnSearch(
 |------|------|--------|------|
 | `scan_buckets_count` | int | —（必填） | 每次查询扫描的桶数，须 ≤ `buckets_count` |
 | `factor` | float | `2.0` | 启用精排时，粗排阶段会预取 `factor * topk` 个候选再重打分 |
+| `enable_reorder` | bool | `true` | 即使索引构建时启用了 reorder，也可以在单次请求里设为 `false` 跳过最终精排 |
 | `parallelism` | int | `1` | 单次查询内扫描桶时使用的线程数 |
 | `timeout_ms` | double | `+∞` | 单次查询最长耗时（毫秒），超时会返回当前的部分结果 |
 
@@ -94,6 +95,12 @@ auto result = index->KnnSearch(
 auto result = index->KnnSearch(
     query, topk,
     R"({"ivf": {"scan_buckets_count": 32, "factor": 2.0, "parallelism": 4}})").value();
+```
+
+```cpp
+auto fast_result = index->KnnSearch(
+    query, topk,
+    R"({"ivf": {"scan_buckets_count": 32, "factor": 2.0, "enable_reorder": false}})").value();
 ```
 
 ## 何时选择 IVF

--- a/src/algorithm/hgraph/hgraph_search.cpp
+++ b/src/algorithm/hgraph/hgraph_search.cpp
@@ -161,11 +161,13 @@ HGraph::KnnSearch(const DatasetPtr& query,
         search_param.is_inner_id_allowed = ft;
         search_param.topk = static_cast<int64_t>(search_param.ef);
         search_param.parallel_search_thread_count = params.parallel_search_thread_count;
+        search_param.enable_reorder = params.enable_reorder;
         search_param.enable_rabitq_one_bit_search = params.rabitq_one_bit_search;
 
         DistanceRecordVector rabitq_lower_bound_candidates(ctx.alloc);
         auto* rabitq_lower_bound_candidates_ptr =
-            search_param.enable_rabitq_one_bit_search and use_reorder_ and reorder_by_base_
+            search_param.enable_rabitq_one_bit_search and use_reorder_ and
+                    search_param.enable_reorder and reorder_by_base_
                 ? &rabitq_lower_bound_candidates
                 : nullptr;
 
@@ -177,7 +179,7 @@ HGraph::KnnSearch(const DatasetPtr& query,
                                                &ctx,
                                                rabitq_lower_bound_candidates_ptr);
 
-        if (use_reorder_) {
+        if (use_reorder_ and search_param.enable_reorder) {
             this->reorder(query_data,
                           this->get_reorder_codes(),
                           search_result,
@@ -185,7 +187,7 @@ HGraph::KnnSearch(const DatasetPtr& query,
                           iter_filter_ctx,
                           ctx,
                           rabitq_lower_bound_candidates_ptr);
-        } else if (params.rabitq_one_bit_search) {
+        } else if (search_param.enable_reorder and params.rabitq_one_bit_search) {
             this->reorder(
                 query_data, this->basic_flatten_codes_, search_result, k, iter_filter_ctx, ctx);
         }
@@ -360,6 +362,7 @@ HGraph::RangeSearch(const DatasetPtr& query,
     search_param.consider_duplicate = true;
     search_param.range_search_limit_size = static_cast<int>(limited_size);
     search_param.parallel_search_thread_count = params.parallel_search_thread_count;
+    search_param.enable_reorder = params.enable_reorder;
     search_param.enable_rabitq_one_bit_search = params.rabitq_one_bit_search;
 
     auto search_result = this->search_one_graph(raw_query,
@@ -369,10 +372,10 @@ HGraph::RangeSearch(const DatasetPtr& query,
                                                 (VisitedListPtr) nullptr,
                                                 &ctx);
 
-    if (use_reorder_) {
+    if (use_reorder_ and search_param.enable_reorder) {
         this->reorder(
             raw_query, this->get_reorder_codes(), search_result, limited_size, nullptr, ctx);
-    } else if (params.rabitq_one_bit_search) {
+    } else if (search_param.enable_reorder and params.rabitq_one_bit_search) {
         this->reorder(
             raw_query, this->basic_flatten_codes_, search_result, limited_size, nullptr, ctx);
     }
@@ -525,6 +528,7 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
         search_param.topk = std::min(
             search_param.topk, static_cast<int64_t>(static_cast<float>(k) * params.topk_factor));
     }
+    search_param.enable_reorder = params.enable_reorder;
     search_param.consider_duplicate = true;
     search_param.enable_rabitq_one_bit_search = params.rabitq_one_bit_search;
     if (params.enable_time_record) {
@@ -549,7 +553,8 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
 
     DistanceRecordVector rabitq_lower_bound_candidates(ctx.alloc);
     auto* rabitq_lower_bound_candidates_ptr =
-        search_param.enable_rabitq_one_bit_search and use_reorder_ and reorder_by_base_
+        search_param.enable_rabitq_one_bit_search and use_reorder_ and
+                search_param.enable_reorder and reorder_by_base_
             ? &rabitq_lower_bound_candidates
             : nullptr;
 
@@ -563,7 +568,7 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
 
     this->pool_->ReturnOne(vt);
 
-    if (use_reorder_) {
+    if (use_reorder_ and search_param.enable_reorder) {
         this->reorder(raw_query,
                       this->get_reorder_codes(),
                       search_result,
@@ -571,7 +576,7 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
                       nullptr,
                       ctx,
                       rabitq_lower_bound_candidates_ptr);
-    } else if (params.rabitq_one_bit_search) {
+    } else if (search_param.enable_reorder and params.rabitq_one_bit_search) {
         this->reorder(raw_query, this->basic_flatten_codes_, search_result, k, nullptr, ctx);
     }
 

--- a/src/algorithm/index_search_parameter.h
+++ b/src/algorithm/index_search_parameter.h
@@ -41,6 +41,10 @@ public:
         if (json.Contains(SEARCH_PARAM_FACTOR)) {
             topk_factor = json[SEARCH_PARAM_FACTOR].GetFloat();
         }
+
+        if (json.Contains(SEARCH_PARAM_ENABLE_REORDER)) {
+            enable_reorder = json[SEARCH_PARAM_ENABLE_REORDER].GetBool();
+        }
     }
 
 public:
@@ -52,5 +56,6 @@ public:
 
     // for reorder, controls the number of candidates to reorder
     float topk_factor{0.0F};
+    bool enable_reorder{true};
 };
 }  // namespace vsag

--- a/src/algorithm/ivf.cpp
+++ b/src/algorithm/ivf.cpp
@@ -467,14 +467,14 @@ IVF::KnnSearch(const DatasetPtr& query,
     auto param = this->create_search_param(parameters, filter);
     param.search_mode = KNN_SEARCH;
     param.topk = k;
-    if (use_reorder_) {
+    if (use_reorder_ and param.enable_reorder) {
         CHECK_ARGUMENT(
             param.factor > 0.0F,
             fmt::format("factor must be positive when use_reorder is true, got {}", param.factor));
         param.topk = static_cast<int64_t>(param.factor * static_cast<float>(k));
     }
     auto search_result = this->search<KNN_SEARCH>(query, param, ctx);
-    if (use_reorder_) {
+    if (use_reorder_ and param.enable_reorder) {
         auto dataset_results = reorder(k, search_result, query->GetFloat32Vectors(), param, ctx);
         dataset_results->Statistics(stats.Dump());
         return std::move(dataset_results);
@@ -503,7 +503,7 @@ IVF::RangeSearch(const DatasetPtr& query,
     param.search_mode = RANGE_SEARCH;
     param.radius = radius;
     param.range_search_limit_size = static_cast<int>(limited_size);
-    if (use_reorder_ and limited_size > 0) {
+    if (use_reorder_ and param.enable_reorder and limited_size > 0) {
         CHECK_ARGUMENT(
             param.factor > 0.0F,
             fmt::format("factor must be positive when use_reorder is true, got {}", param.factor));
@@ -511,7 +511,7 @@ IVF::RangeSearch(const DatasetPtr& query,
             static_cast<int>(param.factor * static_cast<float>(limited_size));
     }
     auto search_result = this->search<RANGE_SEARCH>(query, param, ctx);
-    if (use_reorder_) {
+    if (use_reorder_ and param.enable_reorder) {
         int64_t k = (limited_size > 0) ? limited_size : static_cast<int64_t>(search_result->Size());
         return reorder(k, search_result, query->GetFloat32Vectors(), param, ctx);
     }
@@ -719,6 +719,7 @@ IVF::create_search_param(const std::string& parameters, const FilterPtr& filter)
     param.scan_bucket_size = std::min(static_cast<BucketIdType>(search_param.scan_buckets_count),
                                       bucket_->bucket_count_);
     param.factor = search_param.topk_factor;
+    param.enable_reorder = search_param.enable_reorder;
     param.first_order_scan_ratio = search_param.first_order_scan_ratio;
     param.parallel_search_thread_count = search_param.parallel_search_thread_count;
     if (search_param.enable_time_record) {
@@ -966,7 +967,7 @@ IVF::SearchWithRequest(const SearchRequest& request) const {
     auto param = this->create_search_param(request.params_str_, request.filter_);
     param.search_mode = KNN_SEARCH;
     param.topk = request.topk_;
-    if (use_reorder_) {
+    if (use_reorder_ and param.enable_reorder) {
         CHECK_ARGUMENT(
             param.factor > 0.0F,
             fmt::format("factor must be positive when use_reorder is true, got {}", param.factor));
@@ -984,7 +985,7 @@ IVF::SearchWithRequest(const SearchRequest& request) const {
         }
     }
     auto search_result = this->search<KNN_SEARCH>(query, param, ctx);
-    if (use_reorder_) {
+    if (use_reorder_ and param.enable_reorder) {
         return reorder(request.topk_, search_result, query->GetFloat32Vectors(), param, ctx);
     }
     auto count = static_cast<const int64_t>(search_result->Size());

--- a/src/impl/inner_search_param.h
+++ b/src/impl/inner_search_param.h
@@ -54,6 +54,7 @@ public:
     // for ivf
     int scan_bucket_size{1};
     float factor{2.0F};
+    bool enable_reorder{true};
     float first_order_scan_ratio{1.0F};
     std::vector<ExecutorPtr> executors;
 

--- a/src/inner_string_params.h
+++ b/src/inner_string_params.h
@@ -185,6 +185,7 @@ const char* const SPARSE_CODES = "sparse";
 
 const char* const IVF_SEARCH_PARAM_SCAN_BUCKETS_COUNT = "scan_buckets_count";
 const char* const SEARCH_PARAM_FACTOR = "factor";
+const char* const SEARCH_PARAM_ENABLE_REORDER = "enable_reorder";
 const char* const SEARCH_PARALLELISM = "parallelism";
 const char* const SEARCH_MAX_TIME_COST_MS = "timeout_ms";
 const char* const SPARSE_N_CANDIDATE = "n_candidate";
@@ -254,6 +255,7 @@ const std::unordered_map<std::string, std::string> DEFAULT_MAP = {
     {"EXTRA_INFO_KEY", EXTRA_INFO_KEY},
     {"CODES_TYPE_KEY", CODES_TYPE_KEY},
     {"SEARCH_PARAM_FACTOR", SEARCH_PARAM_FACTOR},
+    {"SEARCH_PARAM_ENABLE_REORDER", SEARCH_PARAM_ENABLE_REORDER},
     {"BUCKET_PER_DATA_KEY", BUCKET_PER_DATA_KEY},
     {"IVF_PARTITION_STRATEGY_PARAMS_KEY", IVF_PARTITION_STRATEGY_PARAMS_KEY},
     {"IVF_PARTITION_STRATEGY_TYPE_KEY", IVF_PARTITION_STRATEGY_TYPE_KEY},

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -328,6 +328,48 @@ HGraphTestIndex::TestMemoryUsageDetail(const IndexPtr& index) {
 
 namespace {
 
+static void
+RequireRangeSearchDisableReorderChangesResult(const fixtures::TestIndex::IndexPtr& index,
+                                              const fixtures::TestDatasetPtr& dataset,
+                                              const std::string& search_param_with_reorder,
+                                              const std::string& search_param_without_reorder,
+                                              int64_t limited_size = 10) {
+    const auto queries = dataset->query_;
+    const auto query_count = queries->GetNumElements();
+    const auto dim = queries->GetDim();
+    bool found_difference = false;
+    for (int64_t i = 0; i < query_count; ++i) {
+        auto query = vsag::Dataset::Make();
+        query->NumElements(1)
+            ->Dim(dim)
+            ->Float32Vectors(queries->GetFloat32Vectors() + i * dim)
+            ->Owner(false);
+        auto with_reorder = index->RangeSearch(
+            query, std::numeric_limits<float>::max(), search_param_with_reorder, limited_size);
+        auto without_reorder = index->RangeSearch(
+            query, std::numeric_limits<float>::max(), search_param_without_reorder, limited_size);
+        REQUIRE(with_reorder.has_value());
+        REQUIRE(without_reorder.has_value());
+        if (with_reorder.value()->GetDim() != without_reorder.value()->GetDim()) {
+            found_difference = true;
+            break;
+        }
+        const auto result_dim = with_reorder.value()->GetDim();
+        for (int64_t j = 0; j < result_dim; ++j) {
+            if (with_reorder.value()->GetIds()[j] != without_reorder.value()->GetIds()[j] ||
+                std::abs(with_reorder.value()->GetDistances()[j] -
+                         without_reorder.value()->GetDistances()[j]) > 1e-6F) {
+                found_difference = true;
+                break;
+            }
+        }
+        if (found_difference) {
+            break;
+        }
+    }
+    REQUIRE(found_difference);
+}
+
 template <typename Fn>
 void
 RunWithGeneratedBlockSizeLimit(Fn&& fn) {
@@ -1902,6 +1944,79 @@ TestHGraphIgnoreReorder(const fixtures::HGraphTestIndexPtr& test_index,
 }
 
 HGRAPH_PR_DAILY_CASE("HGraph Ignore Reorder", "[ft][search][hgraph]", TestHGraphIgnoreReorder)
+
+static void
+TestHGraphSearchDisableReorder(const fixtures::HGraphTestIndexPtr& test_index,
+                               const fixtures::HGraphResourcePtr& resource) {
+    using namespace fixtures;
+    auto origin_size = vsag::Options::Instance().block_size_limit();
+    auto size = GENERATE(1024 * 1024 * 2);
+    constexpr const char* search_param_tmp_disable_reorder = R"({{
+            "hgraph": {{
+                "ef_search": 200,
+                "enable_reorder": {}
+            }}
+        }})";
+
+    for (auto metric_type : resource->metric_types) {
+        for (auto dim : resource->dims) {
+            auto base_quantization_str = "sq4_uniform,fp32";
+            float recall_with_reorder = 0.95F;
+            float recall_without_reorder = 0.75F;
+            INFO(
+                fmt::format("metric_type: {}, dim: {}, base_quantization_str: {}, "
+                            "recall_with_reorder: {}, recall_without_reorder: {}",
+                            metric_type,
+                            dim,
+                            base_quantization_str,
+                            recall_with_reorder,
+                            recall_without_reorder));
+            vsag::Options::Instance().set_block_size_limit(size);
+            HGraphTestIndex::HGraphBuildParam build_param(metric_type, dim, base_quantization_str);
+            auto param = HGraphTestIndex::GenerateHGraphBuildParametersString(build_param);
+            auto index = TestIndex::TestFactory(test_index->name, param, true);
+            auto dataset =
+                HGraphTestIndex::pool.GetDatasetAndCreate(dim, resource->base_count, metric_type);
+            TestIndex::TestBuildIndex(index, dataset, true);
+            auto recall_result_with_reorder =
+                TestIndex::TestKnnSearch(index,
+                                         dataset,
+                                         fmt::format(search_param_tmp_disable_reorder, true),
+                                         recall_with_reorder,
+                                         true);
+            auto recall_result_without_reorder =
+                TestIndex::TestKnnSearch(index,
+                                         dataset,
+                                         fmt::format(search_param_tmp_disable_reorder, false),
+                                         recall_without_reorder,
+                                         true);
+            auto iter_recall_result_with_reorder =
+                TestIndex::TestKnnSearchIter(index,
+                                             dataset,
+                                             fmt::format(search_param_tmp_disable_reorder, true),
+                                             recall_with_reorder,
+                                             true);
+            auto iter_recall_result_without_reorder =
+                TestIndex::TestKnnSearchIter(index,
+                                             dataset,
+                                             fmt::format(search_param_tmp_disable_reorder, false),
+                                             recall_without_reorder,
+                                             true);
+            auto search_param_with_reorder = fmt::format(search_param_tmp_disable_reorder, true);
+            auto search_param_without_reorder =
+                fmt::format(search_param_tmp_disable_reorder, false);
+            REQUIRE(recall_result_with_reorder > recall_result_without_reorder);
+            REQUIRE(iter_recall_result_with_reorder > iter_recall_result_without_reorder);
+            RequireRangeSearchDisableReorderChangesResult(
+                index, dataset, search_param_with_reorder, search_param_without_reorder);
+            vsag::Options::Instance().set_block_size_limit(origin_size);
+        }
+    }
+}
+
+HGRAPH_PR_DAILY_CASE("HGraph Search Disable Reorder",
+                     "[ft][search][hgraph]",
+                     TestHGraphSearchDisableReorder)
 
 static void
 TestHGraphWithExtraInfo(const fixtures::HGraphTestIndexPtr& test_index,

--- a/tests/test_index.h
+++ b/tests/test_index.h
@@ -152,7 +152,7 @@ public:
                                  const TestDatasetPtr& dataset,
                                  float build_ratio = 0.5);
 
-    static void
+    static float
     TestKnnSearch(const IndexPtr& index,
                   const TestDatasetPtr& dataset,
                   const std::string& search_param,
@@ -166,7 +166,7 @@ public:
                          const std::string& search_param,
                          bool expected_success = true);
 
-    static void
+    static float
     TestKnnSearchIter(const IndexPtr& index,
                       const TestDatasetPtr& dataset,
                       const std::string& search_param,
@@ -187,7 +187,7 @@ public:
                               const std::string& search_param,
                               bool expected_success = true);
 
-    static void
+    static float
     TestRangeSearch(const IndexPtr& index,
                     const TestDatasetPtr& dataset,
                     const std::string& search_param,

--- a/tests/test_index/test_index_search.cpp
+++ b/tests/test_index/test_index_search.cpp
@@ -56,14 +56,14 @@ TestIndex::TestKnnSearchCompare(const IndexPtr& index_weak,
     }
 }
 
-void
+float
 TestIndex::TestKnnSearch(const IndexPtr& index,
                          const TestDatasetPtr& dataset,
                          const std::string& search_param,
                          float expected_recall,
                          bool expected_success) {
     if (not index->CheckFeature(vsag::SUPPORT_KNN_SEARCH)) {
-        return;
+        return 0.0F;
     }
     auto queries = dataset->query_;
     auto query_count = queries->GetNumElements();
@@ -79,7 +79,7 @@ TestIndex::TestKnnSearch(const IndexPtr& index,
             if (res.has_value()) {
                 REQUIRE(res.value()->GetDim() == 0);
             }
-            return;
+            return 0.0F;
         } else {
             REQUIRE(res.has_value() == true);
         }
@@ -95,9 +95,10 @@ TestIndex::TestKnnSearch(const IndexPtr& index,
                          expected_recall * query_count));
     }
     REQUIRE(cur_recall > expected_recall * query_count * RECALL_THRESHOLD);
+    return cur_recall / static_cast<float>(query_count);
 }
 
-void
+float
 TestIndex::TestRangeSearch(const IndexPtr& index,
                            const TestDatasetPtr& dataset,
                            const std::string& search_param,
@@ -105,7 +106,7 @@ TestIndex::TestRangeSearch(const IndexPtr& index,
                            int64_t limited_size,
                            bool expected_success) {
     if (not index->CheckFeature(vsag::SUPPORT_RANGE_SEARCH)) {
-        return;
+        return 0.0F;
     }
     auto queries = dataset->range_query_;
     auto query_count = queries->GetNumElements();
@@ -125,7 +126,7 @@ TestIndex::TestRangeSearch(const IndexPtr& index,
             REQUIRE(res.has_value() == expected_success);
         }
         if (!expected_success) {
-            return;
+            return 0.0F;
         }
         if (limited_size > 0) {
             REQUIRE(res.value()->GetDim() <= limited_size);
@@ -148,6 +149,7 @@ TestIndex::TestRangeSearch(const IndexPtr& index,
                          expected_recall * query_count));
     }
     REQUIRE(cur_recall > expected_recall * query_count * RECALL_THRESHOLD);
+    return cur_recall / static_cast<float>(query_count);
 }
 
 class FilterObj : public vsag::Filter {
@@ -184,7 +186,7 @@ private:
     float valid_ratio_{1.0F};
 };
 
-void
+float
 TestIndex::TestKnnSearchIter(const IndexPtr& index,
                              const TestDatasetPtr& dataset,
                              const std::string& search_param,
@@ -192,10 +194,10 @@ TestIndex::TestKnnSearchIter(const IndexPtr& index,
                              bool expected_success,
                              bool use_ex_filter) {
     if (not index->CheckFeature(vsag::SUPPORT_KNN_ITERATOR_FILTER_SEARCH)) {
-        return;
+        return 0.0F;
     }
     if (use_ex_filter && not index->CheckFeature(vsag::SUPPORT_KNN_SEARCH_WITH_EX_FILTER)) {
-        return;
+        return 0.0F;
     }
     auto queries = dataset->query_;
     auto query_count = queries->GetNumElements();
@@ -222,7 +224,7 @@ TestIndex::TestKnnSearchIter(const IndexPtr& index,
             REQUIRE(res.has_value() == expected_success);
         }
         if (!expected_success) {
-            return;
+            return 0.0F;
         }
         int64_t get_cnt = res.value()->GetDim();
         REQUIRE(res.value()->GetDim() == first_top);
@@ -230,14 +232,14 @@ TestIndex::TestKnnSearchIter(const IndexPtr& index,
         auto res2 = index->KnnSearch(query, second_top, search_param, filter, filter_ctx, false);
         REQUIRE(res2.has_value() == expected_success);
         if (!expected_success) {
-            return;
+            return 0.0F;
         }
         REQUIRE(res2.value()->GetDim() == second_top);
         memcpy(ids.data() + first_top, res2.value()->GetIds(), sizeof(int64_t) * second_top);
         auto res3 = index->KnnSearch(query, third_top, search_param, filter, filter_ctx, false);
         REQUIRE(res3.has_value() == expected_success);
         if (!expected_success) {
-            return;
+            return 0.0F;
         }
         REQUIRE(res3.value()->GetDim() == third_top);
         memcpy(ids.data() + first_top + second_top,
@@ -254,6 +256,7 @@ TestIndex::TestKnnSearchIter(const IndexPtr& index,
                          expected_recall * query_count));
     }
     REQUIRE(cur_recall > expected_recall * query_count * RECALL_THRESHOLD);
+    return cur_recall / static_cast<float>(query_count);
 }
 
 void

--- a/tests/test_ivf.cpp
+++ b/tests/test_ivf.cpp
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <limits>
+
 #include "functest.h"
 #include "storage/serialization_template_test.h"
 #include "test_index.h"
@@ -290,6 +292,48 @@ IVFTestIndex::TestGeneral(const TestIndex::IndexPtr& index,
     TestCheckIdExist(index, dataset);
 }
 }  // namespace fixtures
+
+static void
+RequireRangeSearchDisableReorderChangesResult(const fixtures::TestIndex::IndexPtr& index,
+                                              const fixtures::TestDatasetPtr& dataset,
+                                              const std::string& search_param_with_reorder,
+                                              const std::string& search_param_without_reorder,
+                                              int64_t limited_size = 10) {
+    const auto queries = dataset->query_;
+    const auto query_count = queries->GetNumElements();
+    const auto dim = queries->GetDim();
+    bool found_difference = false;
+    for (int64_t i = 0; i < query_count; ++i) {
+        auto query = vsag::Dataset::Make();
+        query->NumElements(1)
+            ->Dim(dim)
+            ->Float32Vectors(queries->GetFloat32Vectors() + i * dim)
+            ->Owner(false);
+        auto with_reorder = index->RangeSearch(
+            query, std::numeric_limits<float>::max(), search_param_with_reorder, limited_size);
+        auto without_reorder = index->RangeSearch(
+            query, std::numeric_limits<float>::max(), search_param_without_reorder, limited_size);
+        REQUIRE(with_reorder.has_value());
+        REQUIRE(without_reorder.has_value());
+        if (with_reorder.value()->GetDim() != without_reorder.value()->GetDim()) {
+            found_difference = true;
+            break;
+        }
+        const auto result_dim = with_reorder.value()->GetDim();
+        for (int64_t j = 0; j < result_dim; ++j) {
+            if (with_reorder.value()->GetIds()[j] != without_reorder.value()->GetIds()[j] ||
+                std::abs(with_reorder.value()->GetDistances()[j] -
+                         without_reorder.value()->GetDistances()[j]) > 1e-6F) {
+                found_difference = true;
+                break;
+            }
+        }
+        if (found_difference) {
+            break;
+        }
+    }
+    REQUIRE(found_difference);
+}
 
 template <typename Fn>
 void
@@ -681,6 +725,73 @@ TestIVFSearchOvertime(const fixtures::IVFResourcePtr& resource) {
 }
 
 IVF_PR_DAILY_CASE("IVF Search Overtime", "[ft][search][ivf]", TestIVFSearchOvertime)
+
+static void
+TestIVFSearchDisableReorder(const fixtures::IVFResourcePtr& resource) {
+    using namespace fixtures;
+    auto origin_size = vsag::Options::Instance().block_size_limit();
+    auto size = GENERATE(1024 * 1024 * 2);
+    constexpr static const char* search_param_tmp_disable_reorder = R"(
+        {{
+            "ivf": {{
+                "scan_buckets_count": {},
+                "factor": 4.0,
+                "enable_reorder": {}
+            }}
+        }})";
+    for (auto metric_type : resource->metric_types) {
+        for (auto dim : resource->dims) {
+            for (auto train_type : resource->train_types) {
+                auto base_quantization_str = "sq4_uniform,fp32";
+                float recall_with_reorder = 0.89F;
+                float recall_without_reorder = 0.55F;
+                auto count = std::min(300, static_cast<int32_t>(dim / 4));
+                if (train_type == "kmeans") {
+                    recall_with_reorder *= 0.8F;
+                    recall_without_reorder *= 0.8F;
+                }
+                INFO(fmt::format(
+                    "metric_type: {}, dim: {}, base_quantization_str: {}, "
+                    "train_type: {}, recall_with_reorder: {}, recall_without_reorder: {}",
+                    metric_type,
+                    dim,
+                    base_quantization_str,
+                    train_type,
+                    recall_with_reorder,
+                    recall_without_reorder));
+                vsag::Options::Instance().set_block_size_limit(size);
+                auto param = IVFTestIndex::GenerateIVFBuildParametersString(
+                    metric_type, dim, base_quantization_str, 300, train_type, false, 1, false, 3);
+                auto index = IVFTestIndex::TestFactory(IVFTestIndex::name, param, true);
+                auto dataset =
+                    IVFTestIndex::pool.GetDatasetAndCreate(dim, resource->base_count, metric_type);
+                IVFTestIndex::TestBuildIndex(index, dataset, true);
+                auto recall_result_with_reorder = TestIndex::TestKnnSearch(
+                    index,
+                    dataset,
+                    fmt::format(search_param_tmp_disable_reorder, std::max(200, count), true),
+                    recall_with_reorder,
+                    true);
+                auto recall_result_without_reorder = TestIndex::TestKnnSearch(
+                    index,
+                    dataset,
+                    fmt::format(search_param_tmp_disable_reorder, std::max(200, count), false),
+                    recall_without_reorder,
+                    true);
+                auto search_param_with_reorder =
+                    fmt::format(search_param_tmp_disable_reorder, std::max(200, count), true);
+                auto search_param_without_reorder =
+                    fmt::format(search_param_tmp_disable_reorder, std::max(200, count), false);
+                REQUIRE(recall_result_with_reorder > recall_result_without_reorder);
+                RequireRangeSearchDisableReorderChangesResult(
+                    index, dataset, search_param_with_reorder, search_param_without_reorder);
+                vsag::Options::Instance().set_block_size_limit(origin_size);
+            }
+        }
+    }
+}
+
+IVF_PR_DAILY_CASE("IVF Search Disable Reorder", "[ft][search][ivf]", TestIVFSearchDisableReorder)
 
 static void
 TestIVFBuildWithLargeK(const fixtures::IVFResourcePtr& resource) {


### PR DESCRIPTION
## Summary
- add a shared enable_reorder search parameter so HGraph and IVF can skip reorder on a per-request basis
- gate reorder execution in HGraph and IVF on the new flag while keeping the default behavior unchanged
- add functests that verify recall changes when reorder is explicitly disabled

## Linked Issue
- Fixes: #1498

## Testing
- make fmt
- ./build/tests/functests -d yes '(PR) HGraph Search Disable Reorder'
- ./build/tests/functests -d yes '(PR) IVF Search Disable Reorder'