### PR TITLE
fix(hgraph): make repeated force remove idempotent

### DIFF
--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -2307,7 +2307,11 @@ HGraph::force_remove_one(int64_t label) {
     InnerIdType inner_id;
     {
         std::shared_lock lock(this->label_lookup_mutex_);
-        inner_id = this->label_table_->GetIdByLabel(label);
+        bool found = false;
+        std::tie(found, inner_id) = this->label_table_->TryGetIdByLabel(label, false);
+        if (not found) {
+            return 0;
+        }
     }
     if (inner_id == this->entry_point_id_) {
         this->find_new_entry_point();
@@ -2323,7 +2327,8 @@ HGraph::force_remove_one(int64_t label) {
     if (swap_id != inner_id) {
         this->move_id(swap_id, inner_id);
     }
-    this->total_count_--;
+    this->label_table_->ForceRemove(label);
+    this->total_count_.fetch_sub(1);
     return 1;
 }
 

--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -2308,7 +2308,7 @@ HGraph::force_remove_one(int64_t label) {
     {
         std::shared_lock lock(this->label_lookup_mutex_);
         bool found = false;
-        std::tie(found, inner_id) = this->label_table_->TryGetIdByLabel(label, false);
+        std::tie(found, inner_id) = this->label_table_->TryGetIdByLabel(label, true);
         if (not found) {
             return 0;
         }
@@ -2324,10 +2324,18 @@ HGraph::force_remove_one(int64_t label) {
     }
     InnerIdType swap_id = this->total_count_.load() - 1;
 
-    if (swap_id != inner_id) {
-        this->move_id(swap_id, inner_id);
+    bool was_mark_removed = false;
+    {
+        std::unique_lock lock(this->label_lookup_mutex_);
+        was_mark_removed = this->label_table_->IsRemoved(inner_id);
+        this->label_table_->ForceRemove(label, inner_id);
+        if (swap_id != inner_id) {
+            this->move_id(swap_id, inner_id);
+        }
     }
-    this->label_table_->ForceRemove(label);
+    if (was_mark_removed) {
+        this->delete_count_.fetch_sub(1);
+    }
     this->total_count_.fetch_sub(1);
     return 1;
 }

--- a/src/impl/label_table.h
+++ b/src/impl/label_table.h
@@ -447,6 +447,16 @@ public:
             return;
         }
 
+        bool from_removed = false;
+        {
+            std::scoped_lock wlock(delete_ids_mutex_);
+            from_removed = deleted_ids_.erase(from) > 0;
+            deleted_ids_.erase(to);
+            if (from_removed) {
+                deleted_ids_.insert(to);
+            }
+        }
+
         if (use_reverse_map_) {
             label_remap_.Erase(label_table_[to]);
         }
@@ -465,15 +475,15 @@ public:
     }
 
     void
-    ForceRemove(LabelType label) {
-        auto [found, inner_id] = TryGetIdByLabel(label, true);
-        if (found) {
-            if (use_reverse_map_) {
-                label_remap_.Erase(label);
-            }
+    ForceRemove(LabelType label, InnerIdType inner_id) {
+        if (use_reverse_map_) {
+            label_remap_.Erase(label);
+        }
+        {
             std::scoped_lock wlock(delete_ids_mutex_);
             deleted_ids_.erase(inner_id);
         }
+        total_count_.fetch_sub(1);
     }
 
 private:

--- a/src/impl/label_table.h
+++ b/src/impl/label_table.h
@@ -464,6 +464,18 @@ public:
         }
     }
 
+    void
+    ForceRemove(LabelType label) {
+        auto [found, inner_id] = TryGetIdByLabel(label, true);
+        if (found) {
+            if (use_reverse_map_) {
+                label_remap_.Erase(label);
+            }
+            std::scoped_lock wlock(delete_ids_mutex_);
+            deleted_ids_.erase(inner_id);
+        }
+    }
+
 private:
     UnorderedSet<InnerIdType> deleted_ids_;       // Record deleted ids.
     FilterPtr deleted_ids_filter_{nullptr};       // Filter to filter out deleted ids.

--- a/src/impl/label_table_test.cpp
+++ b/src/impl/label_table_test.cpp
@@ -457,4 +457,33 @@ TEST_CASE("LabelTable Move", "[ut][LabelTable]") {
         REQUIRE(label_table.GetLabelById(0) == 100);
         REQUIRE(label_table.GetIdByLabel(100) == 0);
     }
+
+    SECTION("Move preserves removed state") {
+        LabelTable label_table(allocator.get(), true);
+        label_table.Resize(5);
+        label_table.Insert(0, 100);
+        label_table.Insert(4, 500);
+        label_table.MarkRemove(500);
+
+        label_table.Move(4, 0);
+
+        REQUIRE(label_table.GetLabelById(0) == 500);
+        REQUIRE(label_table.GetIdByLabel(500, true) == 0);
+        REQUIRE(label_table.IsRemoved(0) == true);
+        REQUIRE(label_table.IsRemoved(4) == false);
+    }
+
+    SECTION("ForceRemove clears deleted state and total count") {
+        LabelTable label_table(allocator.get(), true);
+        label_table.Resize(2);
+        label_table.Insert(0, 100);
+        label_table.Insert(1, 200);
+        label_table.MarkRemove(100);
+
+        label_table.ForceRemove(100, 0);
+
+        REQUIRE(label_table.TryGetIdByLabel(100, true).first == false);
+        REQUIRE(label_table.IsRemoved(0) == false);
+        REQUIRE(label_table.GetTotalCount() == 1);
+    }
 }

--- a/tests/test_hgraph_remove.cpp
+++ b/tests/test_hgraph_remove.cpp
@@ -332,6 +332,58 @@ TEST_CASE("HGraph ForceRemove All Elements Twice", "[ft][hgraph]") {
     REQUIRE(index->GetNumElements() == 0);
 }
 
+TEST_CASE("HGraph ForceRemove MarkRemoved Elements", "[ft][hgraph]") {
+    fixtures::logger::LoggerReplacer _;
+
+    auto index = CreateHGraphIndex();
+
+    constexpr int64_t MARK_REMOVE_NUM_ELEMENTS = 6;
+    std::vector<int64_t> ids(MARK_REMOVE_NUM_ELEMENTS);
+    std::vector<float> vectors(DIM * MARK_REMOVE_NUM_ELEMENTS);
+    std::mt19937 rng(47);
+    std::uniform_real_distribution<float> distrib(0.1, 0.9);
+    for (int64_t i = 0; i < MARK_REMOVE_NUM_ELEMENTS; ++i) {
+        ids[i] = i;
+    }
+    for (int64_t i = 0; i < DIM * MARK_REMOVE_NUM_ELEMENTS; ++i) {
+        vectors[i] = distrib(rng);
+    }
+
+    auto base_dataset = vsag::Dataset::Make();
+    base_dataset->Dim(DIM)
+        ->NumElements(MARK_REMOVE_NUM_ELEMENTS)
+        ->Ids(ids.data())
+        ->Float32Vectors(vectors.data())
+        ->Owner(false);
+    auto build_result = index->Build(base_dataset);
+    REQUIRE(build_result.has_value());
+    REQUIRE(index->GetNumElements() == MARK_REMOVE_NUM_ELEMENTS);
+    REQUIRE(index->GetNumberRemoved() == 0);
+
+    std::vector<int64_t> remove_ids{ids.front(), ids.back()};
+    auto mark_remove_result = index->Remove(remove_ids, vsag::RemoveMode::MARK_REMOVE);
+    REQUIRE(mark_remove_result.has_value());
+    REQUIRE(mark_remove_result.value() == remove_ids.size());
+    REQUIRE(index->GetNumElements() == MARK_REMOVE_NUM_ELEMENTS - remove_ids.size());
+    REQUIRE(index->GetNumberRemoved() == remove_ids.size());
+
+    auto first_force_remove = index->Remove(ids.front(), vsag::RemoveMode::FORCE_REMOVE);
+    REQUIRE(first_force_remove.has_value());
+    REQUIRE(first_force_remove.value() > 0);
+    REQUIRE(index->GetNumElements() == MARK_REMOVE_NUM_ELEMENTS - remove_ids.size());
+    REQUIRE(index->GetNumberRemoved() == 1);
+
+    auto second_force_remove = index->Remove(ids.back(), vsag::RemoveMode::FORCE_REMOVE);
+    REQUIRE(second_force_remove.has_value());
+    REQUIRE(second_force_remove.value() > 0);
+    REQUIRE(index->GetNumElements() == MARK_REMOVE_NUM_ELEMENTS - remove_ids.size());
+    REQUIRE(index->GetNumberRemoved() == 0);
+
+    auto duplicate_force_remove = index->Remove(ids.back(), vsag::RemoveMode::FORCE_REMOVE);
+    REQUIRE(duplicate_force_remove.has_value());
+    REQUIRE(duplicate_force_remove.value() == 0);
+}
+
 TEST_CASE("HGraph Batch ForceRemove", "[ft][hgraph]") {
     fixtures::logger::LoggerReplacer _;
 

--- a/tests/test_hgraph_remove.cpp
+++ b/tests/test_hgraph_remove.cpp
@@ -288,6 +288,50 @@ TEST_CASE("HGraph ForceRemove All Elements", "[ft][hgraph]") {
     REQUIRE(empty_result.value()->GetDim() == 0);
 }
 
+TEST_CASE("HGraph ForceRemove All Elements Twice", "[ft][hgraph]") {
+    fixtures::logger::LoggerReplacer _;
+
+    auto index = CreateHGraphIndex();
+
+    constexpr int64_t FULL_REMOVE_NUM_ELEMENTS = 100;
+    std::vector<int64_t> ids(FULL_REMOVE_NUM_ELEMENTS);
+    std::vector<float> vectors(DIM * FULL_REMOVE_NUM_ELEMENTS);
+    std::mt19937 rng(47);
+    std::uniform_real_distribution<float> distrib(0.1, 0.9);
+    for (int64_t i = 0; i < FULL_REMOVE_NUM_ELEMENTS; ++i) {
+        ids[i] = i;
+    }
+    for (int64_t i = 0; i < DIM * FULL_REMOVE_NUM_ELEMENTS; ++i) {
+        vectors[i] = distrib(rng);
+    }
+
+    auto base_dataset = vsag::Dataset::Make();
+    base_dataset->Dim(DIM)
+        ->NumElements(FULL_REMOVE_NUM_ELEMENTS)
+        ->Ids(ids.data())
+        ->Float32Vectors(vectors.data())
+        ->Owner(false);
+    auto build_result = index->Build(base_dataset);
+    REQUIRE(build_result.has_value());
+    REQUIRE(index->GetNumElements() == FULL_REMOVE_NUM_ELEMENTS);
+
+    for (int64_t i = 0; i < FULL_REMOVE_NUM_ELEMENTS; ++i) {
+        auto first_remove_result = index->Remove(ids[i], vsag::RemoveMode::FORCE_REMOVE);
+        REQUIRE(first_remove_result.has_value());
+        REQUIRE(first_remove_result.value() > 0);
+    }
+
+    REQUIRE(index->GetNumElements() == 0);
+
+    for (int64_t i = 0; i < FULL_REMOVE_NUM_ELEMENTS; ++i) {
+        auto second_remove_result = index->Remove(ids[i], vsag::RemoveMode::FORCE_REMOVE);
+        REQUIRE(second_remove_result.has_value());
+        REQUIRE(second_remove_result.value() == 0);
+    }
+
+    REQUIRE(index->GetNumElements() == 0);
+}
+
 TEST_CASE("HGraph Batch ForceRemove", "[ft][hgraph]") {
     fixtures::logger::LoggerReplacer _;
 


### PR DESCRIPTION
## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement/Refactor
- [ ] Documentation
- [ ] CI/Build/Infra

## Linked Issue

- Fixes: #2079

## What Changed

- Make `HGraph::force_remove_one` return `0` immediately when the label is already absent.
- Clear HGraph force-remove label bookkeeping through `LabelTable::ForceRemove` after a successful delete.
- Add a regression test that builds 100 vectors, deletes all of them, and repeats the same deletes to verify the second pass is harmless.

## Test Evidence

- [ ] `make fmt`
- [ ] `make lint`
- [ ] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [x] Other (describe below)

Test details:

```text
Attempted to rebuild and run the new HGraph regression test, but the local build directory is incomplete (`build/CMakeFiles/rules.ninja` missing) and re-running `cmake -S . -B build` fails in this environment because `clang-cl-14` links through `/usr/bin/ld`, which rejects the `-nologo` flag.
```

## Compatibility Impact

- API/ABI compatibility: none
- Behavior changes: repeated `FORCE_REMOVE` on an already deleted HGraph label now returns `0` cleanly instead of reusing stale label mappings.

## Performance and Concurrency Impact

- Performance impact: none expected
- Concurrency/thread-safety impact: none intended; the change preserves existing HGraph removal locking.

## Documentation Impact

- [x] No docs update needed
- [ ] Updated docs:
- [ ] `README.md`
- [ ] `DEVELOPMENT.md`
- [ ] `CONTRIBUTING.md`
- [ ] Other: <!-- path -->

## Risk and Rollback

- Risk level: low
- Rollback plan: revert commit `e5b1d31b5a31ecb0cd366487b13d042b39c50d25`.

## Checklist

- [x] I have linked the relevant issue (required for `kind/bug` and `kind/feature`; see "Linked Issue" above)
- [x] I have added/updated tests for new behavior or bug fixes
- [x] I have considered API compatibility impact
- [x] I have updated docs if behavior/workflow changed
- [x] My commit messages follow project conventions (Conventional Commits, optional `[skip ci]` prefix)