### PR TITLE
docs: add agent guide for filing GitHub issues

### DIFF
--- a/docs/docs/en/src/SUMMARY.md
+++ b/docs/docs/en/src/SUMMARY.md
@@ -70,6 +70,7 @@
 - [Release Notes](resources/release_notes.md)
 - [Roadmap](resources/roadmap_2025.md)
 - [Community](resources/community.md)
+- [Filing Issues with an AI Agent](resources/filing_issues_with_agent.md)
 - [Related Projects](resources/related_projects.md)
 - [Research Papers](resources/research_papers.md)
 - [Contributors](misc/contributors.md)

--- a/docs/docs/en/src/resources/filing_issues_with_agent.md
+++ b/docs/docs/en/src/resources/filing_issues_with_agent.md
@@ -1,0 +1,106 @@
+# Filing Issues with an AI Agent
+
+You can use an AI coding agent (Claude Code, OpenCode, or Codex) together with
+the VSAG repository's built-in `/create-issue` slash command to draft and
+submit a high-quality GitHub issue for VSAG. The agent maps your request onto
+the project's issue templates, fills in the required fields, and submits the
+issue through GitHub CLI.
+
+This page walks through the end-to-end setup. The canonical workflow that the
+agent itself follows lives in
+[`.github/agent-prompts/create-issue.md`](https://github.com/antgroup/vsag/blob/main/.github/agent-prompts/create-issue.md);
+this page focuses on the user-facing steps.
+
+## Prerequisites
+
+- A GitHub account.
+- One of the supported AI coding agents installed and configured locally:
+  [Claude Code](https://docs.claude.com/en/docs/claude-code/overview),
+  [OpenCode](https://opencode.ai/), or Codex.
+- `git` available on your machine.
+
+## 1. Install and sign in to GitHub CLI (`gh`)
+
+First, install `gh` by following the official quickstart for your platform:
+
+<https://docs.github.com/en/github-cli/github-cli/quickstart>
+
+Then sign in from your terminal:
+
+```bash
+gh auth login
+```
+
+Choose **GitHub.com**, pick an authentication protocol (HTTPS is fine), and
+follow the browser prompts to complete sign-in.
+
+## 2. Verify your `gh` login
+
+```bash
+gh auth status
+```
+
+Confirm that GitHub.com authentication is active before continuing.
+
+## 3. Clone the VSAG repository
+
+```bash
+git clone https://github.com/antgroup/vsag.git
+cd vsag
+```
+
+The `/create-issue` command and its prompt files live inside the repository,
+so the agent must be launched from within the `vsag/` working directory to
+pick them up.
+
+## 4. Launch your agent inside the repo
+
+From the `vsag/` directory, start one of the supported agents:
+
+```bash
+# Claude Code
+claude
+
+# OpenCode
+opencode
+
+# Codex CLI
+codex
+```
+
+## 5. Run `/create-issue`
+
+In the agent prompt, invoke the slash command and describe your need in
+natural language. For example:
+
+```
+/create-issue HGraph build crashes when dim=0; want a clear error instead.
+```
+
+The agent will:
+
+1. Pick the most appropriate template under
+   [`.github/ISSUE_TEMPLATE/`](https://github.com/antgroup/vsag/tree/main/.github/ISSUE_TEMPLATE).
+2. Ask follow-up questions if required fields are missing.
+3. Draft the issue body with code/doc references in `path:line` form.
+4. Show you the final draft for confirmation.
+5. Submit the issue via `gh issue create` once you approve.
+
+You can iterate with the agent freely — ask it to revise wording, add
+reproduction steps, switch templates, or attach logs before it submits.
+
+## Tips
+
+- Be specific: include the index type, parameters, dataset shape, error
+  message, and platform when filing a bug.
+- For feature requests, describe the use case and the expected API or
+  behavior. The agent will mirror this into the template's required fields.
+- Issues do **not** carry `Signed-off-by:` — DCO applies only to commits.
+- If you prefer to drive the workflow without an interactive agent, see the
+  shell wrapper at
+  [`tools/issue-helper/new-issue.sh`](https://github.com/antgroup/vsag/blob/main/tools/issue-helper/new-issue.sh).
+
+## See also
+
+- [Community](community.md)
+- [Contributing to VSAG](../development/contributing.md)

--- a/docs/docs/zh/src/SUMMARY.md
+++ b/docs/docs/zh/src/SUMMARY.md
@@ -70,6 +70,7 @@
 - [版本日志](resources/release_notes.md)
 - [路线图](resources/roadmap_2025.md)
 - [开源社区](resources/community.md)
+- [使用 AI Agent 创建 Issue](resources/filing_issues_with_agent.md)
 - [关联项目](resources/related_projects.md)
 - [科研论文](resources/research_papers.md)
 - [贡献者列表](misc/contributors.md)

--- a/docs/docs/zh/src/resources/filing_issues_with_agent.md
+++ b/docs/docs/zh/src/resources/filing_issues_with_agent.md
@@ -1,0 +1,99 @@
+# 使用 AI Agent 创建 Issue
+
+你可以借助 AI 编码 Agent（Claude Code、OpenCode 或 Codex）与 VSAG 仓库内置的
+`/create-issue` 斜杠命令一起，为 VSAG 起草并提交一份高质量的 GitHub Issue。
+Agent 会把你的需求映射到项目的 Issue 模板，自动填好必填字段，并通过 GitHub
+CLI 提交。
+
+本页面介绍端到端的使用步骤。Agent 内部遵循的规范工作流位于
+[`.github/agent-prompts/create-issue.md`](https://github.com/antgroup/vsag/blob/main/.github/agent-prompts/create-issue.md)，
+本页只关注用户侧的操作。
+
+## 前置条件
+
+- 一个 GitHub 账号。
+- 本地已安装并配置好以下任意一个受支持的 AI 编码 Agent：
+  [Claude Code](https://docs.claude.com/en/docs/claude-code/overview)、
+  [OpenCode](https://opencode.ai/) 或 Codex。
+- 本机可用的 `git`。
+
+## 1. 安装并登录 GitHub CLI（`gh`）
+
+先按官方快速入门在你的平台上安装 `gh`：
+
+<https://docs.github.com/en/github-cli/github-cli/quickstart>
+
+然后在终端登录：
+
+```bash
+gh auth login
+```
+
+选择 **GitHub.com**，挑选认证协议（HTTPS 即可），并按浏览器提示完成登录。
+
+## 2. 验证 `gh` 登录状态
+
+```bash
+gh auth status
+```
+
+确认 GitHub.com 已成功认证后再继续。
+
+## 3. 克隆 VSAG 仓库
+
+```bash
+git clone https://github.com/antgroup/vsag.git
+cd vsag
+```
+
+`/create-issue` 命令及其 Prompt 文件都在仓库内，因此 Agent 必须在 `vsag/`
+目录下启动，才能识别该命令。
+
+## 4. 在仓库目录中启动 Agent
+
+在 `vsag/` 目录下启动其中一个受支持的 Agent：
+
+```bash
+# Claude Code
+claude
+
+# OpenCode
+opencode
+
+# Codex CLI
+codex
+```
+
+## 5. 运行 `/create-issue`
+
+在 Agent 对话中调用斜杠命令，并用自然语言描述你的需求。例如：
+
+```
+/create-issue HGraph 在 dim=0 时构建会崩溃；希望返回一个明确的错误。
+```
+
+Agent 将会：
+
+1. 在
+   [`.github/ISSUE_TEMPLATE/`](https://github.com/antgroup/vsag/tree/main/.github/ISSUE_TEMPLATE)
+   中选择最合适的模板；
+2. 在必填字段缺失时主动追问；
+3. 以 `path:line` 形式引用代码或文档，撰写 Issue 正文；
+4. 把最终草稿展示给你确认；
+5. 你确认后，通过 `gh issue create` 提交 Issue。
+
+整个过程中你可以反复与 Agent 沟通——让它调整措辞、补充复现步骤、切换模板、
+附加日志，再决定是否提交。
+
+## 小贴士
+
+- 描述要具体：报 Bug 时附上索引类型、参数、数据集形状、报错信息以及运行平台。
+- 提需求时，描述使用场景以及期望的 API 或行为，Agent 会据此填好模板字段。
+- Issue **不需要** `Signed-off-by:`——DCO 仅适用于 commit。
+- 如果不想通过交互式 Agent 驱动整个流程，可参考仓库提供的 Shell 包装脚本
+  [`tools/issue-helper/new-issue.sh`](https://github.com/antgroup/vsag/blob/main/tools/issue-helper/new-issue.sh)。
+
+## 参见
+
+- [开源社区](community.md)
+- [贡献到 VSAG](../development/contributing.md)


### PR DESCRIPTION
## Summary
- Add an English and Chinese Resources page describing the `/create-issue` workflow for Claude Code, OpenCode, and Codex.
- Document gh installation, authentication, repo cloning, agent startup, and issue submission flow.
- Link the new page from both docs summaries.

## Testing
- Docs only; no code tests run.