### PR TITLE
docs(indexes): add overview SVG diagrams for each index

### DIFF
--- a/docs/docs/en/src/figures/indexes/brute_force-overview.svg
+++ b/docs/docs/en/src/figures/indexes/brute_force-overview.svg
@@ -1,0 +1,503 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 560" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="12">
+  <title>BruteForce index overview</title>
+  <desc>BruteForce stores vectors in a single flat array and, for each query, computes the distance against every stored vector and keeps the smallest distances in a top-k heap. The scan can be split across multiple threads via the parallelism parameter; the result is exact when base_quantization_type is fp32.</desc>
+
+  <style>
+    .title       { font-size: 16px; font-weight: 600; fill: #0f172a; }
+    .subtitle    { font-size: 12px; fill: #6b7280; }
+    .lbl         { fill: #334155; }
+    .lbl-mute    { fill: #6b7280; font-size: 11px; }
+    .layer-lbl   { font-size: 11px; font-weight: 700; fill: #475569; letter-spacing: 0.6px; text-transform: uppercase; }
+    .layer-sub   { font-size: 11px; fill: #94a3b8; }
+
+    .band        { fill: #f8fafc; stroke: #e2e8f0; stroke-width: 1; }
+    .panel       { fill: #f1f5f9; stroke: #cbd5e1; stroke-width: 1; }
+    .note-box    { fill: #fff4e6; stroke: #ffd8a8; stroke-width: 1; }
+
+    /* Vector cells */
+    .vcell       { fill: #ffffff; stroke: #94a3b8; stroke-width: 1; }
+    .vcell-hi    { fill: #ffd8a8; stroke: #e8590c; stroke-width: 1.5; }
+    .vbar        { fill: #cbd5e1; }
+    .vbar-hi     { fill: #e8590c; }
+
+    /* Thread stripe overlays */
+    .stripe      { fill: #5c7cfa; opacity: 0.07; stroke: #5c7cfa; stroke-dasharray: 4 3; stroke-opacity: 0.5; }
+    .stripe-lbl  { font-size: 10px; fill: #364fc7; font-weight: 600; letter-spacing: 0.4px; }
+
+    /* Query */
+    .q-star      { fill: #e03131; stroke: #a61e1e; stroke-width: 1; stroke-linejoin: round; }
+    .q-box       { fill: #fff5f5; stroke: #ffa8a8; }
+
+    /* Distance arrows fan-out */
+    .darr        { stroke: #94a3b8; stroke-width: 0.9; fill: none; opacity: 0.6; }
+    .darr-hi     { stroke: #e8590c; stroke-width: 1.6; fill: none; }
+
+    /* Heap */
+    .heap-box    { fill: #fff4e6; stroke: #ffd8a8; }
+    .heap-slot   { fill: #ffffff; stroke: #e8590c; stroke-width: 1.3; }
+    .heap-num    { font-size: 11px; font-weight: 600; fill: #a14503; }
+
+    .step-badge  { fill: #e8590c; stroke: #ffffff; stroke-width: 2; }
+    .step-num    { fill: #ffffff; font-weight: 700; font-size: 11px; }
+  </style>
+
+  <text class="title"    x="40" y="34">BruteForce</text>
+  <text class="subtitle" x="40" y="52">Exact flat scan · distance computed against every stored vector · optional intra-query parallelism</text>
+
+  <!-- =========================================================
+       Query column (left)
+       ========================================================= -->
+  <g transform="translate(40, 110)">
+    <rect class="q-box" x="0" y="0" width="120" height="410" rx="10"/>
+    <text class="layer-lbl" x="12" y="20">QUERY</text>
+
+    <!-- Query star -->
+    <g transform="translate(60, 90)">
+      <polygon class="q-star"
+               points="0,-22 6.5,-7 22,-7 9.5,3 14,18 0,9 -14,18 -9.5,3 -22,-7 -6.5,-7"/>
+    </g>
+    <text class="lbl" x="60" y="125" text-anchor="middle" font-size="13" font-weight="700" fill="#a61e1e">q</text>
+
+    <!-- Note about exactness / parallelism -->
+    <rect class="note-box" x="10" y="160" width="100" height="78" rx="6"/>
+    <text class="lbl" x="60" y="178" text-anchor="middle" font-size="10" font-weight="700" fill="#a14503">EXACT</text>
+    <text class="lbl-mute" x="60" y="194" text-anchor="middle" font-size="10">when base_</text>
+    <text class="lbl-mute" x="60" y="207" text-anchor="middle" font-size="10">quantization_type</text>
+    <text class="lbl-mute" x="60" y="220" text-anchor="middle" font-size="10">= fp32</text>
+
+    <!-- parallelism note -->
+    <rect class="band" x="10" y="260" width="100" height="62" rx="6"/>
+    <text class="layer-lbl" x="60" y="278" text-anchor="middle" font-size="10">PARALLELISM</text>
+    <text class="lbl-mute" x="60" y="297" text-anchor="middle" font-size="10">scan split</text>
+    <text class="lbl-mute" x="60" y="310" text-anchor="middle" font-size="10">across N threads</text>
+
+    <!-- metric note -->
+    <rect class="band" x="10" y="340" width="100" height="56" rx="6"/>
+    <text class="layer-lbl" x="60" y="358" text-anchor="middle" font-size="10">METRIC</text>
+    <text class="lbl-mute" x="60" y="376" text-anchor="middle" font-size="10">l2 · ip · cosine</text>
+  </g>
+
+  <!-- =========================================================
+       Center panel: flat vector store
+       Panel origin (180, 110), size 420 x 410.
+       ========================================================= -->
+  <g transform="translate(180, 110)">
+    <rect class="band" x="0" y="0" width="420" height="410" rx="10"/>
+    <text class="layer-lbl" x="14" y="20">FLAT VECTOR STORE</text>
+    <text class="layer-sub" x="170" y="20">one row of dense cells · no graph · no inverted lists</text>
+
+    <!-- Thread stripe backgrounds (parallelism = 3 illustration).
+         Each stripe fully encloses its 4 columns (12 cells) with 3px padding.
+         Inside a thread, cells use step=30 (w=28, 2px gap); between threads
+         there is a 14px gap so the stripe boxes do not touch. -->
+    <!-- Stripe 1 (thread 0): columns 0..3, panel-x 21..147 -->
+    <rect class="stripe" x="15" y="56" width="126" height="320" rx="6"/>
+    <text class="stripe-lbl" x="78" y="50" text-anchor="middle">THREAD 0</text>
+    <!-- Stripe 2 (thread 1): columns 4..7, panel-x 153..279 -->
+    <rect class="stripe" x="147" y="56" width="126" height="320" rx="6"/>
+    <text class="stripe-lbl" x="210" y="50" text-anchor="middle">THREAD 1</text>
+    <!-- Stripe 3 (thread 2): columns 8..11, panel-x 285..411 -->
+    <rect class="stripe" x="279" y="56" width="126" height="320" rx="6"/>
+    <text class="stripe-lbl" x="342" y="50" text-anchor="middle">THREAD 2</text>
+
+    <!-- Flat vectors: 4 rows x 10 cols. Each cell shows a tiny bar chart "vector".
+         We highlight a small set as the top-k winners (orange). -->
+    <!-- Helper: cell w=28, h=70, gap=3 horizontally and vertically. Origin (24, 64). -->
+
+    <!-- ROW 0 -->
+    <g transform="translate(18, 64)">
+      <!-- 10 cells per row -->
+      <!-- generate cells inline -->
+      <g transform="translate(0,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="44" width="3" height="22"/>
+        <rect class="vbar" x="9"  y="22" width="3" height="44"/>
+        <rect class="vbar" x="14" y="34" width="3" height="32"/>
+        <rect class="vbar" x="19" y="16" width="3" height="50"/>
+      </g>
+      <g transform="translate(30,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="30" width="3" height="36"/>
+        <rect class="vbar" x="9"  y="40" width="3" height="26"/>
+        <rect class="vbar" x="14" y="14" width="3" height="52"/>
+        <rect class="vbar" x="19" y="36" width="3" height="30"/>
+      </g>
+      <g transform="translate(60,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="20" width="3" height="46"/>
+        <rect class="vbar" x="9"  y="46" width="3" height="20"/>
+        <rect class="vbar" x="14" y="26" width="3" height="40"/>
+        <rect class="vbar" x="19" y="34" width="3" height="32"/>
+      </g>
+      <g transform="translate(90,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="38" width="3" height="28"/>
+        <rect class="vbar" x="9"  y="18" width="3" height="48"/>
+        <rect class="vbar" x="14" y="42" width="3" height="24"/>
+        <rect class="vbar" x="19" y="24" width="3" height="42"/>
+      </g>
+      <g transform="translate(132,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="28" width="3" height="38"/>
+        <rect class="vbar" x="9"  y="38" width="3" height="28"/>
+        <rect class="vbar" x="14" y="20" width="3" height="46"/>
+        <rect class="vbar" x="19" y="40" width="3" height="26"/>
+      </g>
+      <!-- Highlighted winner -->
+      <g transform="translate(162,0)">
+        <rect class="vcell-hi" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar-hi" x="4"  y="18" width="3" height="48"/>
+        <rect class="vbar-hi" x="9"  y="22" width="3" height="44"/>
+        <rect class="vbar-hi" x="14" y="26" width="3" height="40"/>
+        <rect class="vbar-hi" x="19" y="20" width="3" height="46"/>
+      </g>
+      <g transform="translate(192,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="34" width="3" height="32"/>
+        <rect class="vbar" x="9"  y="20" width="3" height="46"/>
+        <rect class="vbar" x="14" y="42" width="3" height="24"/>
+        <rect class="vbar" x="19" y="28" width="3" height="38"/>
+      </g>
+      <g transform="translate(222,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="22" width="3" height="44"/>
+        <rect class="vbar" x="9"  y="36" width="3" height="30"/>
+        <rect class="vbar" x="14" y="18" width="3" height="48"/>
+        <rect class="vbar" x="19" y="40" width="3" height="26"/>
+      </g>
+      <g transform="translate(264,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="40" width="3" height="26"/>
+        <rect class="vbar" x="9"  y="24" width="3" height="42"/>
+        <rect class="vbar" x="14" y="36" width="3" height="30"/>
+        <rect class="vbar" x="19" y="20" width="3" height="46"/>
+      </g>
+      <g transform="translate(294,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="20" width="3" height="46"/>
+        <rect class="vbar" x="9"  y="42" width="3" height="24"/>
+        <rect class="vbar" x="14" y="30" width="3" height="36"/>
+        <rect class="vbar" x="19" y="38" width="3" height="28"/>
+      </g>
+      <g transform="translate(324,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="32" width="3" height="34"/>
+        <rect class="vbar" x="9"  y="46" width="3" height="20"/>
+        <rect class="vbar" x="14" y="24" width="3" height="42"/>
+        <rect class="vbar" x="19" y="36" width="3" height="30"/>
+      </g>
+      <g transform="translate(354,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="26" width="3" height="40"/>
+        <rect class="vbar" x="9"  y="14" width="3" height="52"/>
+        <rect class="vbar" x="14" y="40" width="3" height="26"/>
+        <rect class="vbar" x="19" y="32" width="3" height="34"/>
+      </g>
+    </g>
+
+    <!-- ROW 1 -->
+    <g transform="translate(18, 142)">
+      <g transform="translate(0,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="22" width="3" height="44"/>
+        <rect class="vbar" x="9"  y="44" width="3" height="22"/>
+        <rect class="vbar" x="14" y="18" width="3" height="48"/>
+        <rect class="vbar" x="19" y="40" width="3" height="26"/>
+      </g>
+      <g transform="translate(30,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="32" width="3" height="34"/>
+        <rect class="vbar" x="9"  y="18" width="3" height="48"/>
+        <rect class="vbar" x="14" y="42" width="3" height="24"/>
+        <rect class="vbar" x="19" y="22" width="3" height="44"/>
+      </g>
+      <!-- another winner -->
+      <g transform="translate(60,0)">
+        <rect class="vcell-hi" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar-hi" x="4"  y="22" width="3" height="44"/>
+        <rect class="vbar-hi" x="9"  y="26" width="3" height="40"/>
+        <rect class="vbar-hi" x="14" y="20" width="3" height="46"/>
+        <rect class="vbar-hi" x="19" y="18" width="3" height="48"/>
+      </g>
+      <g transform="translate(90,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="36" width="3" height="30"/>
+        <rect class="vbar" x="9"  y="28" width="3" height="38"/>
+        <rect class="vbar" x="14" y="44" width="3" height="22"/>
+        <rect class="vbar" x="19" y="20" width="3" height="46"/>
+      </g>
+      <g transform="translate(132,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="14" width="3" height="52"/>
+        <rect class="vbar" x="9"  y="42" width="3" height="24"/>
+        <rect class="vbar" x="14" y="32" width="3" height="34"/>
+        <rect class="vbar" x="19" y="38" width="3" height="28"/>
+      </g>
+      <g transform="translate(162,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="44" width="3" height="22"/>
+        <rect class="vbar" x="9"  y="22" width="3" height="44"/>
+        <rect class="vbar" x="14" y="36" width="3" height="30"/>
+        <rect class="vbar" x="19" y="28" width="3" height="38"/>
+      </g>
+      <g transform="translate(192,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="20" width="3" height="46"/>
+        <rect class="vbar" x="9"  y="38" width="3" height="28"/>
+        <rect class="vbar" x="14" y="46" width="3" height="20"/>
+        <rect class="vbar" x="19" y="26" width="3" height="40"/>
+      </g>
+      <g transform="translate(222,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="40" width="3" height="26"/>
+        <rect class="vbar" x="9"  y="18" width="3" height="48"/>
+        <rect class="vbar" x="14" y="30" width="3" height="36"/>
+        <rect class="vbar" x="19" y="42" width="3" height="24"/>
+      </g>
+      <g transform="translate(264,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="24" width="3" height="42"/>
+        <rect class="vbar" x="9"  y="36" width="3" height="30"/>
+        <rect class="vbar" x="14" y="20" width="3" height="46"/>
+        <rect class="vbar" x="19" y="40" width="3" height="26"/>
+      </g>
+      <g transform="translate(294,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="34" width="3" height="32"/>
+        <rect class="vbar" x="9"  y="20" width="3" height="46"/>
+        <rect class="vbar" x="14" y="38" width="3" height="28"/>
+        <rect class="vbar" x="19" y="22" width="3" height="44"/>
+      </g>
+      <!-- another winner -->
+      <g transform="translate(324,0)">
+        <rect class="vcell-hi" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar-hi" x="4"  y="20" width="3" height="46"/>
+        <rect class="vbar-hi" x="9"  y="24" width="3" height="42"/>
+        <rect class="vbar-hi" x="14" y="22" width="3" height="44"/>
+        <rect class="vbar-hi" x="19" y="26" width="3" height="40"/>
+      </g>
+      <g transform="translate(354,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="36" width="3" height="30"/>
+        <rect class="vbar" x="9"  y="46" width="3" height="20"/>
+        <rect class="vbar" x="14" y="22" width="3" height="44"/>
+        <rect class="vbar" x="19" y="34" width="3" height="32"/>
+      </g>
+    </g>
+
+    <!-- ROW 2 -->
+    <g transform="translate(18, 220)">
+      <g transform="translate(0,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="20" width="3" height="46"/>
+        <rect class="vbar" x="9"  y="36" width="3" height="30"/>
+        <rect class="vbar" x="14" y="44" width="3" height="22"/>
+        <rect class="vbar" x="19" y="28" width="3" height="38"/>
+      </g>
+      <g transform="translate(30,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="42" width="3" height="24"/>
+        <rect class="vbar" x="9"  y="26" width="3" height="40"/>
+        <rect class="vbar" x="14" y="14" width="3" height="52"/>
+        <rect class="vbar" x="19" y="38" width="3" height="28"/>
+      </g>
+      <g transform="translate(60,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="34" width="3" height="32"/>
+        <rect class="vbar" x="9"  y="20" width="3" height="46"/>
+        <rect class="vbar" x="14" y="46" width="3" height="20"/>
+        <rect class="vbar" x="19" y="24" width="3" height="42"/>
+      </g>
+      <g transform="translate(90,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="18" width="3" height="48"/>
+        <rect class="vbar" x="9"  y="40" width="3" height="26"/>
+        <rect class="vbar" x="14" y="32" width="3" height="34"/>
+        <rect class="vbar" x="19" y="22" width="3" height="44"/>
+      </g>
+      <g transform="translate(132,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="38" width="3" height="28"/>
+        <rect class="vbar" x="9"  y="22" width="3" height="44"/>
+        <rect class="vbar" x="14" y="44" width="3" height="22"/>
+        <rect class="vbar" x="19" y="36" width="3" height="30"/>
+      </g>
+      <g transform="translate(162,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="22" width="3" height="44"/>
+        <rect class="vbar" x="9"  y="44" width="3" height="22"/>
+        <rect class="vbar" x="14" y="28" width="3" height="38"/>
+        <rect class="vbar" x="19" y="40" width="3" height="26"/>
+      </g>
+      <!-- another winner -->
+      <g transform="translate(192,0)">
+        <rect class="vcell-hi" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar-hi" x="4"  y="24" width="3" height="42"/>
+        <rect class="vbar-hi" x="9"  y="20" width="3" height="46"/>
+        <rect class="vbar-hi" x="14" y="22" width="3" height="44"/>
+        <rect class="vbar-hi" x="19" y="18" width="3" height="48"/>
+      </g>
+      <g transform="translate(222,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="16" width="3" height="50"/>
+        <rect class="vbar" x="9"  y="38" width="3" height="28"/>
+        <rect class="vbar" x="14" y="46" width="3" height="20"/>
+        <rect class="vbar" x="19" y="24" width="3" height="42"/>
+      </g>
+      <g transform="translate(264,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="34" width="3" height="32"/>
+        <rect class="vbar" x="9"  y="46" width="3" height="20"/>
+        <rect class="vbar" x="14" y="20" width="3" height="46"/>
+        <rect class="vbar" x="19" y="36" width="3" height="30"/>
+      </g>
+      <g transform="translate(294,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="44" width="3" height="22"/>
+        <rect class="vbar" x="9"  y="22" width="3" height="44"/>
+        <rect class="vbar" x="14" y="38" width="3" height="28"/>
+        <rect class="vbar" x="19" y="28" width="3" height="38"/>
+      </g>
+      <g transform="translate(324,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="20" width="3" height="46"/>
+        <rect class="vbar" x="9"  y="40" width="3" height="26"/>
+        <rect class="vbar" x="14" y="28" width="3" height="38"/>
+        <rect class="vbar" x="19" y="42" width="3" height="24"/>
+      </g>
+      <g transform="translate(354,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="32" width="3" height="34"/>
+        <rect class="vbar" x="9"  y="18" width="3" height="48"/>
+        <rect class="vbar" x="14" y="40" width="3" height="26"/>
+        <rect class="vbar" x="19" y="26" width="3" height="40"/>
+      </g>
+    </g>
+
+    <!-- Vector id axis -->
+    <text class="lbl-mute" x="5" y="318" font-size="10">id 0</text>
+    <text class="lbl-mute" x="405" y="318" text-anchor="end" font-size="10">N-1</text>
+    <line x1="15" y1="306" x2="405" y2="306" stroke="#cbd5e1" stroke-width="1"/>
+
+    <!-- "compute distance" sweep arrow -->
+    <text class="lbl-mute" x="210" y="346" text-anchor="middle" font-size="11">scan every vector · compute d(q, v_i)</text>
+    <path d="M 15 358 L 405 358" stroke="#5c7cfa" stroke-width="1.4" fill="none" marker-end="url(#scan-arrow)"/>
+
+    <!-- Step badge 1: at the start of the scan -->
+    <circle class="step-badge" cx="13" cy="358" r="11"/>
+    <text class="step-num"    x="13" y="362" text-anchor="middle">1</text>
+  </g>
+
+  <!-- Distance fan-out arrows from q to a sample of cells (to convey "every cell scored").
+       q world position is (40+60, 110+90) = (100, 200). Sample a few cell centers across the grid. -->
+  <g>
+    <!-- highlighted distance lines (to the 3 winners) -->
+    <path class="darr-hi" d="M 102 200 Q 240 178 374 199"/>   <!-- row 0 col 5 (winner) center approx (180+24+155+14, 110+64+35)=(373,209) -->
+    <path class="darr-hi" d="M 102 200 Q 200 256 272 287"/>   <!-- row 1 col 2 winner (180+24+62+14, 110+142+35)=(280,287) -->
+    <path class="darr-hi" d="M 102 200 Q 260 280 404 365"/>   <!-- row 2 col 6 winner (180+24+186+14, 110+220+35)=(404,365) -->
+
+    <!-- faint distance lines to other cells (sample 14) -->
+    <path class="darr" d="M 102 200 L 212 209"/>
+    <path class="darr" d="M 102 200 L 242 209"/>
+    <path class="darr" d="M 102 200 L 302 209"/>
+    <path class="darr" d="M 102 200 L 476 209"/>
+    <path class="darr" d="M 102 200 L 566 209"/>
+    <path class="darr" d="M 102 200 L 212 287"/>
+    <path class="darr" d="M 102 200 L 344 287"/>
+    <path class="darr" d="M 102 200 L 476 287"/>
+    <path class="darr" d="M 102 200 L 566 287"/>
+    <path class="darr" d="M 102 200 L 212 365"/>
+    <path class="darr" d="M 102 200 L 302 365"/>
+    <path class="darr" d="M 102 200 L 476 365"/>
+    <path class="darr" d="M 102 200 L 536 365"/>
+    <path class="darr" d="M 102 200 L 566 365"/>
+  </g>
+
+  <!-- arrow marker for the scan sweep -->
+  <defs>
+    <marker id="scan-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#5c7cfa"/>
+    </marker>
+  </defs>
+
+  <!-- =========================================================
+       Right panel: top-k heap
+       Panel origin (620, 110), size 130 x 410.
+       ========================================================= -->
+  <g transform="translate(610, 110)">
+    <rect class="band" x="0" y="0" width="130" height="410" rx="10"/>
+    <text class="layer-lbl" x="14" y="20">TOP-K HEAP</text>
+    <text class="layer-sub" x="14" y="36">smallest d(q, v_i)</text>
+
+    <!-- Heap slots (k = 5) -->
+    <g transform="translate(15, 56)">
+      <!-- slot 1 (winner) -->
+      <rect class="heap-slot" x="0" y="0" width="100" height="44" rx="6"/>
+      <text class="heap-num" x="14" y="28">#1</text>
+      <text class="lbl-mute" x="44" y="22" font-size="10">id 5</text>
+      <text class="lbl-mute" x="44" y="35" font-size="10">d = 0.12</text>
+
+      <!-- slot 2 -->
+      <rect class="heap-slot" x="0" y="56" width="100" height="44" rx="6"/>
+      <text class="heap-num" x="14" y="84">#2</text>
+      <text class="lbl-mute" x="44" y="78" font-size="10">id 12</text>
+      <text class="lbl-mute" x="44" y="91" font-size="10">d = 0.18</text>
+
+      <!-- slot 3 -->
+      <rect class="heap-slot" x="0" y="112" width="100" height="44" rx="6"/>
+      <text class="heap-num" x="14" y="140">#3</text>
+      <text class="lbl-mute" x="44" y="134" font-size="10">id 28</text>
+      <text class="lbl-mute" x="44" y="147" font-size="10">d = 0.21</text>
+
+      <!-- slot 4 (placeholder, lighter) -->
+      <rect class="heap-slot" x="0" y="168" width="100" height="44" rx="6" opacity="0.55"/>
+      <text class="heap-num" x="14" y="196" opacity="0.55">#4</text>
+      <text class="lbl-mute" x="44" y="190" font-size="10" opacity="0.6">…</text>
+
+      <!-- slot 5 -->
+      <rect class="heap-slot" x="0" y="224" width="100" height="44" rx="6" opacity="0.45"/>
+      <text class="heap-num" x="14" y="252" opacity="0.45">#k</text>
+      <text class="lbl-mute" x="44" y="246" font-size="10" opacity="0.55">…</text>
+    </g>
+
+    <!-- step badge 2: at top of heap -->
+    <circle class="step-badge" cx="105" cy="56" r="11"/>
+    <text class="step-num"    x="105" y="60" text-anchor="middle">2</text>
+
+    <!-- Output label -->
+    <text class="lbl" x="65" y="360" text-anchor="middle" font-size="11" font-weight="600" fill="#a14503">result</text>
+    <text class="lbl-mute" x="65" y="376" text-anchor="middle" font-size="10">k ids returned</text>
+  </g>
+
+  <!-- =========================================================
+       Bottom legend
+       ========================================================= -->
+  <g transform="translate(40, 553)">
+    <rect class="vcell" x="0" y="-7" width="14" height="14" rx="2"/>
+    <text class="lbl-mute" x="20" y="4">stored vector</text>
+
+    <rect class="vcell-hi" x="120" y="-7" width="14" height="14" rx="2"/>
+    <text class="lbl-mute" x="140" y="4">top-k winner</text>
+
+    <line x1="248" y1="0" x2="276" y2="0" class="darr-hi"/>
+    <text class="lbl-mute" x="284" y="4">distance to winner</text>
+
+    <line x1="402" y1="0" x2="430" y2="0" class="darr"/>
+    <text class="lbl-mute" x="438" y="4">distance to other vectors</text>
+
+    <rect class="stripe" x="582" y="-7" width="14" height="14"/>
+    <text class="lbl-mute" x="602" y="4">parallelism thread stripe</text>
+  </g>
+
+  <!-- Step legend bar at top right -->
+  <g transform="translate(420, 70)">
+    <rect class="note-box" x="0" y="-12" width="320" height="32" rx="6"/>
+    <circle class="step-badge" cx="14" cy="4" r="8"/>
+    <text x="14" y="8" text-anchor="middle" fill="#fff" font-size="9" font-weight="700">1</text>
+    <text class="lbl" x="28" y="8" font-size="11" font-weight="600">score every vector</text>
+
+    <circle class="step-badge" cx="180" cy="4" r="8"/>
+    <text x="180" y="8" text-anchor="middle" fill="#fff" font-size="9" font-weight="700">2</text>
+    <text class="lbl" x="194" y="8" font-size="11" font-weight="600">keep smallest in top-k heap</text>
+  </g>
+</svg>

--- a/docs/docs/en/src/figures/indexes/hgraph-overview.svg
+++ b/docs/docs/en/src/figures/indexes/hgraph-overview.svg
@@ -1,0 +1,345 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 560" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="12">
+  <title>HGraph index overview</title>
+  <desc>HGraph stores vectors as a multi-layer proximity graph. A vector may appear on several layers; upper layers are sparse and act as a navigation skip-list, the bottom layer holds every vector with dense max_degree neighbours. A search enters at the fixed top-layer entry, greedily hops to the locally-closest neighbour, drops to the next layer at the local minimum, and on the bottom layer expands an ef_search-sized beam around the query until it converges on the topk nearest neighbours. An optional reorder pass re-ranks candidates against a high-precision storage copy.</desc>
+
+  <defs>
+    <marker id="arrow-search" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#e8590c"/>
+    </marker>
+  </defs>
+
+  <style>
+    .title    { fill: #1a1a1a; font-size: 16px; font-weight: 600; }
+    .subtitle { fill: #6b7280; font-size: 12px; }
+    .lbl      { fill: #1f2937; }
+    .lbl-mute { fill: #6b7280; }
+    .layer-lbl { fill: #475569; font-size: 11px; font-weight: 600; letter-spacing: 0.6px; }
+    .layer-sub { fill: #94a3b8; font-size: 11px; }
+
+    .band       { fill: #f8fafc; stroke: #e2e8f0; stroke-width: 1; }
+    .band-top   { fill: #f1f5f9; stroke: #e2e8f0; stroke-width: 1; }
+
+    .node       { fill: #ffffff; stroke: #94a3b8; stroke-width: 1; }
+    .node-hi    { fill: #ffffff; stroke: #5c7cfa; stroke-width: 1.3; }
+    .node-entry { fill: #5c7cfa; stroke: #364fc7; stroke-width: 1.4; }
+    .node-visit { fill: #ffd8a8; stroke: #e8590c; stroke-width: 1.5; }
+    .node-result{ fill: #e03131; stroke: #a61e1e; stroke-width: 1.4; }
+
+    .edge        { stroke: #cbd5e1; stroke-width: 0.8; fill: none; }
+    .edge-hi     { stroke: #5c7cfa; stroke-width: 1.1; fill: none; opacity: 0.75; }
+    .crosslink   { stroke: #94a3b8; stroke-width: 0.9; fill: none; stroke-dasharray: 2 3; opacity: 0.8; }
+    .frontier    { fill: #fff4e6; stroke: #e8590c; stroke-width: 1; stroke-dasharray: 4 3; opacity: 0.85; }
+    .search      { stroke: #e8590c; stroke-width: 2; fill: none; stroke-linecap: round; }
+    .descent     { stroke: #e8590c; stroke-width: 2; fill: none; stroke-dasharray: 4 3; stroke-linecap: round; }
+
+    .step-badge  { fill: #e8590c; stroke: #ffffff; stroke-width: 2; }
+    .step-num    { fill: #ffffff; font-size: 11px; font-weight: 700; }
+
+    .note-box    { fill: #ffffff; stroke: #e2e8f0; stroke-width: 1; }
+  </style>
+
+  <!-- Header -->
+  <text class="title"    x="40" y="34">HGraph</text>
+  <text class="subtitle" x="40" y="52">Multi-layer proximity graph · greedy descent · ef_search beam on the bottom layer</text>
+
+  <!--
+    Layer-2 node x positions (panel origin 40,80):
+      60 (entry), 190, 330, 460
+    L2 panel y=80..190 (height 110), nodes at panel-y 48 or 70.
+    L1 panel y=210..320 (height 110), nodes at panel-y 50 or 78.
+    L0 panel y=340..540 (height 200), nodes at panel-y 55..185.
+
+    Query q is at panel x=395, panel y=115 in L0 → svg (435, 455).
+    The ghost-q indicator on upper layers sits at panel x=395.
+  -->
+
+  <!-- =========================================================
+       Layer 2 (top, sparse)
+       ========================================================= -->
+  <g transform="translate(40, 80)">
+    <rect class="band-top" x="0" y="0" width="540" height="110" rx="10"/>
+    <text class="layer-lbl" x="14" y="20">LAYER 2</text>
+    <text class="layer-sub" x="68" y="20">sparse · long-range hops · entry layer</text>
+
+    <line class="edge-hi" x1="60"  y1="70" x2="190" y2="48"/>
+    <line class="edge-hi" x1="190" y1="48" x2="330" y2="72"/>
+    <line class="edge-hi" x1="330" y1="72" x2="460" y2="50"/>
+    <line class="edge-hi" x1="190" y1="48" x2="460" y2="50"/>
+
+    <!-- ghost-q hint (small open star) -->
+    <polygon points="395,68 396.6,72 401,72 397.5,74.5 398.7,79 395,76.3 391.3,79 392.5,74.5 389,72 393.4,72"
+             fill="none" stroke="#e03131" stroke-width="1" stroke-dasharray="2 2" opacity="0.6"/>
+
+    <!-- nodes -->
+    <circle class="node-entry" cx="60"  cy="70" r="7"/>
+    <circle class="node-visit" cx="190" cy="48" r="6"/>   <!-- L2 local-min -->
+    <circle class="node-hi"    cx="330" cy="72" r="5.5"/>
+    <circle class="node-hi"    cx="460" cy="50" r="5.5"/>
+
+    <text class="lbl" x="60" y="92" text-anchor="middle" font-size="11" fill="#364fc7" font-weight="600">entry</text>
+
+    <!-- search through layer 2: enter → hop to nearest-to-q (190,48) -->
+    <path class="search" d="M 60 70 Q 130 30 190 48"/>
+  </g>
+
+  <!-- Descent L2 → L1 at x=190 (panel local-min) -->
+  <path class="descent" d="M 230 158 L 230 258"/>
+
+  <!-- =========================================================
+       Layer 1 (middle)
+       ========================================================= -->
+  <g transform="translate(40, 210)">
+    <rect class="band" x="0" y="0" width="540" height="110" rx="10"/>
+    <text class="layer-lbl" x="14" y="20">LAYER 1</text>
+    <text class="layer-sub" x="68" y="20">intermediate · medium-range hops</text>
+
+    <line class="edge-hi" x1="60"  y1="70" x2="135" y2="50"/>
+    <line class="edge-hi" x1="135" y1="50" x2="190" y2="78"/>
+    <line class="edge-hi" x1="190" y1="78" x2="265" y2="50"/>
+    <line class="edge-hi" x1="265" y1="50" x2="330" y2="72"/>
+    <line class="edge-hi" x1="330" y1="72" x2="395" y2="50"/>
+    <line class="edge-hi" x1="395" y1="50" x2="460" y2="76"/>
+    <line class="edge-hi" x1="135" y1="50" x2="265" y2="50"/>
+    <line class="edge-hi" x1="265" y1="50" x2="395" y2="50"/>
+
+    <!-- ghost-q hint -->
+    <polygon points="395,68 396.6,72 401,72 397.5,74.5 398.7,79 395,76.3 391.3,79 392.5,74.5 389,72 393.4,72"
+             fill="none" stroke="#e03131" stroke-width="1" stroke-dasharray="2 2" opacity="0.6"/>
+
+    <!-- nodes -->
+    <circle class="node-hi"    cx="60"  cy="70" r="5"/>
+    <circle class="node-hi"    cx="135" cy="50" r="5"/>
+    <circle class="node-hi"    cx="190" cy="78" r="5"/>
+    <circle class="node-hi"    cx="265" cy="50" r="5"/>
+    <circle class="node-hi"    cx="330" cy="72" r="5"/>
+    <circle class="node-visit" cx="395" cy="50" r="6"/>  <!-- L1 local-min closest to q -->
+    <circle class="node-hi"    cx="460" cy="76" r="5"/>
+
+    <!-- search through layer 1: from descent landing at (190,78) → (265,50) → (395,50) -->
+    <path class="search" d="M 190 78 Q 230 40 265 50 T 395 50"/>
+  </g>
+
+  <!-- Cross-layer dashed links (same vector at the same xy across multiple layers) -->
+  <!-- L2 (x,y): (60,150),(190,128),(330,152),(460,130) ; L1 same x at y +130 -->
+  <line class="crosslink" x1="100" y1="150" x2="100" y2="280"/>  <!-- 60 entry -->
+  <line class="crosslink" x1="230" y1="128" x2="230" y2="288"/>  <!-- 190 -->
+  <line class="crosslink" x1="370" y1="152" x2="370" y2="282"/>  <!-- 330 -->
+  <line class="crosslink" x1="500" y1="130" x2="500" y2="286"/>  <!-- 460 -->
+  <!-- L1 → L0 same-xy dashes for the four L2 anchors + the 395 anchor where q lives -->
+  <line class="crosslink" x1="100" y1="280" x2="100" y2="450"/>
+  <line class="crosslink" x1="230" y1="288" x2="230" y2="448"/>
+  <line class="crosslink" x1="370" y1="282" x2="370" y2="450"/>
+  <line class="crosslink" x1="500" y1="286" x2="500" y2="450"/>
+  <line class="crosslink" x1="435" y1="260" x2="435" y2="410"/>  <!-- L1 (395,50) → L0 (395,70) -->
+
+  <!-- Descent L1 → L0 at x=395 (L1 local-min). Starts just below L1 node, ends just above the L0 landing node. -->
+  <path class="descent" d="M 435 266 L 435 408"/>
+
+  <!-- =========================================================
+       Layer 0 (bottom, dense)
+       ========================================================= -->
+  <g transform="translate(40, 340)">
+    <rect class="band" x="0" y="0" width="540" height="200" rx="10"/>
+    <text class="layer-lbl" x="14" y="20">LAYER 0</text>
+    <text class="layer-sub" x="68" y="20">dense · every vector · up to max_degree neighbours · ef_search beam</text>
+
+    <!-- ef_search frontier (drawn first, behind nodes) -->
+    <ellipse class="frontier" cx="395" cy="100" rx="58" ry="42"/>
+
+    <!-- proximity edges -->
+    <line class="edge" x1="60"  y1="110" x2="95"  y2="85"/>
+    <line class="edge" x1="60"  y1="110" x2="80"  y2="148"/>
+    <line class="edge" x1="95"  y1="85"  x2="135" y2="68"/>
+    <line class="edge" x1="95"  y1="85"  x2="130" y2="110"/>
+    <line class="edge" x1="80"  y1="148" x2="130" y2="160"/>
+    <line class="edge" x1="130" y1="110" x2="135" y2="68"/>
+    <line class="edge" x1="130" y1="110" x2="170" y2="135"/>
+    <line class="edge" x1="130" y1="160" x2="170" y2="135"/>
+    <line class="edge" x1="135" y1="68"  x2="195" y2="55"/>
+    <line class="edge" x1="170" y1="135" x2="210" y2="105"/>
+    <line class="edge" x1="170" y1="135" x2="200" y2="170"/>
+    <line class="edge" x1="195" y1="55"  x2="250" y2="70"/>
+    <line class="edge" x1="195" y1="55"  x2="210" y2="105"/>
+    <line class="edge" x1="210" y1="105" x2="250" y2="70"/>
+    <line class="edge" x1="210" y1="105" x2="255" y2="135"/>
+    <line class="edge" x1="200" y1="170" x2="255" y2="135"/>
+    <line class="edge" x1="200" y1="170" x2="245" y2="175"/>
+    <line class="edge" x1="250" y1="70"  x2="305" y2="60"/>
+    <line class="edge" x1="250" y1="70"  x2="295" y2="105"/>
+    <line class="edge" x1="255" y1="135" x2="295" y2="105"/>
+    <line class="edge" x1="255" y1="135" x2="300" y2="150"/>
+    <line class="edge" x1="245" y1="175" x2="300" y2="150"/>
+    <line class="edge" x1="245" y1="175" x2="295" y2="178"/>
+    <line class="edge" x1="305" y1="60"  x2="345" y2="78"/>
+    <line class="edge" x1="305" y1="60"  x2="360" y2="55"/>
+    <line class="edge" x1="295" y1="105" x2="345" y2="78"/>
+    <line class="edge" x1="295" y1="105" x2="345" y2="120"/>
+    <line class="edge" x1="300" y1="150" x2="345" y2="120"/>
+    <line class="edge" x1="300" y1="150" x2="355" y2="155"/>
+    <line class="edge" x1="295" y1="178" x2="355" y2="155"/>
+    <line class="edge" x1="295" y1="178" x2="345" y2="185"/>
+    <line class="edge" x1="345" y1="78"  x2="395" y2="70"/>
+    <line class="edge" x1="345" y1="78"  x2="395" y2="105"/>
+    <line class="edge" x1="345" y1="120" x2="395" y2="105"/>
+    <line class="edge" x1="345" y1="120" x2="395" y2="135"/>
+    <line class="edge" x1="355" y1="155" x2="395" y2="135"/>
+    <line class="edge" x1="355" y1="155" x2="405" y2="160"/>
+    <line class="edge" x1="345" y1="185" x2="405" y2="160"/>
+    <line class="edge" x1="360" y1="55"  x2="395" y2="70"/>
+    <line class="edge" x1="360" y1="55"  x2="425" y2="55"/>
+    <line class="edge" x1="395" y1="70"  x2="425" y2="55"/>
+    <line class="edge" x1="395" y1="70"  x2="445" y2="80"/>
+    <line class="edge" x1="395" y1="105" x2="445" y2="80"/>
+    <line class="edge" x1="395" y1="105" x2="445" y2="115"/>
+    <line class="edge" x1="395" y1="135" x2="445" y2="115"/>
+    <line class="edge" x1="395" y1="135" x2="445" y2="148"/>
+    <line class="edge" x1="405" y1="160" x2="445" y2="148"/>
+    <line class="edge" x1="405" y1="160" x2="450" y2="178"/>
+    <line class="edge" x1="425" y1="55"  x2="475" y2="65"/>
+    <line class="edge" x1="445" y1="80"  x2="475" y2="65"/>
+    <line class="edge" x1="445" y1="80"  x2="495" y2="100"/>
+    <line class="edge" x1="445" y1="115" x2="495" y2="100"/>
+    <line class="edge" x1="445" y1="115" x2="495" y2="130"/>
+    <line class="edge" x1="445" y1="148" x2="495" y2="130"/>
+    <line class="edge" x1="445" y1="148" x2="490" y2="170"/>
+    <line class="edge" x1="450" y1="178" x2="490" y2="170"/>
+    <line class="edge" x1="475" y1="65"  x2="510" y2="85"/>
+    <line class="edge" x1="495" y1="100" x2="510" y2="85"/>
+    <line class="edge" x1="495" y1="100" x2="515" y2="135"/>
+    <line class="edge" x1="495" y1="130" x2="515" y2="135"/>
+    <line class="edge" x1="495" y1="130" x2="510" y2="165"/>
+    <line class="edge" x1="490" y1="170" x2="510" y2="165"/>
+
+    <!-- plain nodes -->
+    <circle class="node" cx="60"  cy="110" r="4"/>
+    <circle class="node" cx="95"  cy="85"  r="4"/>
+    <circle class="node" cx="80"  cy="148" r="4"/>
+    <circle class="node" cx="135" cy="68"  r="4"/>
+    <circle class="node" cx="130" cy="110" r="4"/>
+    <circle class="node" cx="130" cy="160" r="4"/>
+    <circle class="node" cx="170" cy="135" r="4"/>
+    <circle class="node" cx="195" cy="55"  r="4"/>
+    <circle class="node" cx="210" cy="105" r="4"/>
+    <circle class="node" cx="200" cy="170" r="4"/>
+    <circle class="node" cx="250" cy="70"  r="4"/>
+    <circle class="node" cx="255" cy="135" r="4"/>
+    <circle class="node" cx="245" cy="175" r="4"/>
+    <circle class="node" cx="305" cy="60"  r="4"/>
+    <circle class="node" cx="295" cy="105" r="4"/>
+    <circle class="node" cx="300" cy="150" r="4"/>
+    <circle class="node" cx="295" cy="178" r="4"/>
+    <circle class="node" cx="345" cy="78"  r="4"/>
+    <circle class="node" cx="345" cy="185" r="4"/>
+    <circle class="node" cx="355" cy="155" r="4"/>
+    <circle class="node" cx="360" cy="55"  r="4"/>
+    <circle class="node" cx="425" cy="55"  r="4"/>
+    <circle class="node" cx="445" cy="80"  r="4"/>
+    <circle class="node" cx="445" cy="148" r="4"/>
+    <circle class="node" cx="450" cy="178" r="4"/>
+    <circle class="node" cx="475" cy="65"  r="4"/>
+    <circle class="node" cx="510" cy="85"  r="4"/>
+    <circle class="node" cx="495" cy="130" r="4"/>
+    <circle class="node" cx="490" cy="170" r="4"/>
+    <circle class="node" cx="510" cy="165" r="4"/>
+    <circle class="node" cx="515" cy="135" r="4"/>
+
+    <!-- visited along the last-mile search -->
+    <circle class="node-visit" cx="395" cy="70"  r="5.4"/>  <!-- landing from L1 -->
+    <circle class="node-visit" cx="345" cy="120" r="5.4"/>
+    <circle class="node-visit" cx="395" cy="135" r="5.4"/>
+    <circle class="node-visit" cx="445" cy="115" r="5.4"/>
+
+    <!-- nearest neighbour (the topk-1 result, closest node to q) -->
+    <circle class="node-result" cx="395" cy="105" r="5.6"/>
+
+    <!-- query star: q is a point in the embedding space, placed inside the frontier -->
+    <polygon points="420,110 422.6,116.4 429.5,116.4 424,120.4 426.2,127 420,122.7 413.8,127 416,120.4 410.5,116.4 417.4,116.4"
+             fill="#e03131" stroke="#a61e1e" stroke-width="1.1" stroke-linejoin="round"/>
+    <text class="lbl" x="420" y="142" text-anchor="middle" font-size="11" font-weight="700" fill="#a61e1e">q</text>
+
+    <!-- last-mile search path on layer 0: lands at (395,70) → ... → nearest neighbour (395,105) -->
+    <path class="search" d="M 395 70 Q 360 95 345 120 T 395 135 T 395 105" marker-end="url(#arrow-search)"/>
+
+    <!-- ef_search caption -->
+    <text class="lbl-mute" x="395" y="178" text-anchor="middle" font-size="11">ef_search frontier</text>
+  </g>
+
+  <!-- Step badges placed along the search trajectory (svg coords) -->
+  <g>
+    <!-- 1: enter top  (just right of entry vertex, svg (60+10, 150-12) ) -->
+    <circle class="step-badge" cx="78" cy="138" r="11"/>
+    <text class="step-num"    x="78" y="142" text-anchor="middle">1</text>
+
+    <!-- 2: descent — placed beside the descent dash at x≈230, y≈208 -->
+    <circle class="step-badge" cx="246" cy="208" r="11"/>
+    <text class="step-num"    x="246" y="212" text-anchor="middle">2</text>
+
+    <!-- 3: beam — placed in upper-right of L0 panel, outside the frontier ellipse -->
+    <circle class="step-badge" cx="525" cy="370" r="11"/>
+    <text class="step-num"    x="525" y="374" text-anchor="middle">3</text>
+  </g>
+
+  <!-- =========================================================
+       Right-side legend / annotations
+       ========================================================= -->
+  <g transform="translate(600, 92)">
+    <g>
+      <circle class="step-badge" cx="10" cy="10" r="9"/>
+      <text x="10" y="14" text-anchor="middle" fill="#fff" font-size="10" font-weight="700">1</text>
+      <text class="lbl" x="28" y="8" font-weight="600">Enter at top</text>
+      <text class="lbl-mute" x="28" y="22" font-size="11">fixed entry vertex</text>
+    </g>
+
+    <g transform="translate(0, 44)">
+      <circle class="step-badge" cx="10" cy="10" r="9"/>
+      <text x="10" y="14" text-anchor="middle" fill="#fff" font-size="10" font-weight="700">2</text>
+      <text class="lbl" x="28" y="8" font-weight="600">Greedy descend</text>
+      <text class="lbl-mute" x="28" y="22" font-size="11">hop to closest neighbour;</text>
+      <text class="lbl-mute" x="28" y="36" font-size="11">drop layer at local minimum</text>
+    </g>
+
+    <g transform="translate(0, 102)">
+      <circle class="step-badge" cx="10" cy="10" r="9"/>
+      <text x="10" y="14" text-anchor="middle" fill="#fff" font-size="10" font-weight="700">3</text>
+      <text class="lbl" x="28" y="8" font-weight="600">Beam search on layer 0</text>
+      <text class="lbl-mute" x="28" y="22" font-size="11">expand ef_search candidates</text>
+      <text class="lbl-mute" x="28" y="36" font-size="11">→ topk nearest to q</text>
+    </g>
+
+    <g transform="translate(0, 168)">
+      <rect class="note-box" x="0" y="0" width="160" height="92" rx="6"/>
+      <text class="layer-lbl" x="10" y="18" font-size="10">STORAGE</text>
+      <text class="lbl-mute"  x="10" y="36" font-size="11">base_quantization_type:</text>
+      <text class="lbl"       x="10" y="50" font-size="11">sq8 · pq · rabitq · fp16 · ...</text>
+
+      <line x1="10" y1="58" x2="150" y2="58" stroke="#e2e8f0"/>
+
+      <text class="layer-lbl" x="10" y="74" font-size="10">RERANK (OPTIONAL)</text>
+      <text class="lbl-mute"  x="10" y="88" font-size="11">use_reorder + precise codes</text>
+    </g>
+  </g>
+
+  <!-- =========================================================
+       Bottom legend
+       ========================================================= -->
+  <g transform="translate(40, 553)">
+    <circle class="node-entry" cx="6" cy="0" r="6"/>
+    <text class="lbl-mute" x="18" y="4">entry</text>
+
+    <circle class="node-visit" cx="78" cy="0" r="6"/>
+    <text class="lbl-mute" x="90" y="4">visited</text>
+
+    <polygon points="164,-6.2 166.2,-1.4 171.5,-1.4 167.2,1.6 168.8,6.2 164,3.2 159.2,6.2 160.8,1.6 156.5,-1.4 161.8,-1.4"
+             fill="#e03131" stroke="#a61e1e" stroke-width="1" stroke-linejoin="round"/>
+    <text class="lbl-mute" x="178" y="4">query q</text>
+
+    <circle class="node-result" cx="254" cy="0" r="6"/>
+    <text class="lbl-mute" x="266" y="4">nearest neighbour</text>
+
+    <line class="search" x1="386" y1="0" x2="416" y2="0" marker-end="url(#arrow-search)"/>
+    <text class="lbl-mute" x="422" y="4">search path</text>
+
+    <line class="crosslink" x1="508" y1="0" x2="538" y2="0"/>
+    <text class="lbl-mute" x="544" y="4">same vector across layers</text>
+  </g>
+</svg>

--- a/docs/docs/en/src/figures/indexes/ivf-overview.svg
+++ b/docs/docs/en/src/figures/indexes/ivf-overview.svg
@@ -1,0 +1,284 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 560" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="12">
+  <title>IVF index overview</title>
+  <desc>IVF partitions the embedding space into buckets_count Voronoi cells around k-means centroids. Each base vector is stored in the inverted list of its nearest centroid using the configured coarse quantization. At query time the scan_buckets_count centroids closest to q are picked, only the vectors in those buckets are scored, and an optional reorder pass re-ranks factor*topk coarse candidates against a high-precision copy.</desc>
+
+  <defs>
+    <marker id="arrow-search" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#e8590c"/>
+    </marker>
+    <clipPath id="space-clip">
+      <rect x="0" y="0" width="540" height="380" rx="10"/>
+    </clipPath>
+  </defs>
+
+  <style>
+    .title    { fill: #1a1a1a; font-size: 16px; font-weight: 600; }
+    .subtitle { fill: #6b7280; font-size: 12px; }
+    .lbl      { fill: #1f2937; }
+    .lbl-mute { fill: #6b7280; }
+    .layer-lbl { fill: #475569; font-size: 11px; font-weight: 600; letter-spacing: 0.6px; }
+    .layer-sub { fill: #94a3b8; font-size: 11px; }
+
+    .band       { fill: #f8fafc; stroke: #e2e8f0; stroke-width: 1; }
+
+    /* Voronoi cells */
+    .cell        { fill: #ffffff; stroke: #cbd5e1; stroke-width: 1; }
+    .cell-hi     { fill: #fff4e6; stroke: #e8590c; stroke-width: 1.4; }
+
+    /* Base vectors (small dots) */
+    .pt          { fill: #94a3b8; stroke: none; }
+    .pt-hi       { fill: #ffd8a8; stroke: #e8590c; stroke-width: 1; }
+    .pt-result   { fill: #e03131; stroke: #a61e1e; stroke-width: 1.2; }
+
+    /* Centroids */
+    .centroid    { fill: #5c7cfa; stroke: #364fc7; stroke-width: 1.4; }
+    .centroid-hi { fill: #e8590c; stroke: #a14503; stroke-width: 1.5; }
+
+    .probe       { stroke: #e8590c; stroke-width: 1.4; fill: none; stroke-dasharray: 4 3; stroke-linecap: round; opacity: 0.85; }
+    .search      { stroke: #e8590c; stroke-width: 2; fill: none; stroke-linecap: round; }
+
+    .step-badge  { fill: #e8590c; stroke: #ffffff; stroke-width: 2; }
+    .step-num    { fill: #ffffff; font-size: 11px; font-weight: 700; }
+
+    .note-box    { fill: #ffffff; stroke: #e2e8f0; stroke-width: 1; }
+  </style>
+
+  <!-- Header -->
+  <text class="title"    x="40" y="34">IVF</text>
+  <text class="subtitle" x="40" y="52">Voronoi partition over centroids · scan only the scan_buckets_count nearest buckets</text>
+
+  <!-- =========================================================
+       Embedding space panel (Voronoi diagram)
+       Panel origin: (40, 80), size 540 x 380.
+       Centroids (panel coords):
+         c0 ( 95,  75)
+         c1 (245,  55)
+         c2 (415,  90)
+         c3 ( 75, 210)
+         c4 (215, 175)  [highlighted]
+         c5 (370, 195)  [highlighted, contains q]
+         c6 ( 90, 330)
+         c7 (260, 320)  [highlighted, neighbour cell]
+         c8 (440, 305)
+       Cells are drawn as hand-crafted convex polygons that
+       approximately tile the panel.
+       ========================================================= -->
+  <g transform="translate(40, 80)">
+    <rect class="band" x="0" y="0" width="540" height="380" rx="10"/>
+    <text class="layer-lbl" x="14" y="20">EMBEDDING SPACE</text>
+    <text class="layer-sub" x="160" y="20">buckets_count cells · one centroid per cell</text>
+
+    <g clip-path="url(#space-clip)">
+      <!-- Voronoi-like cells. The three highlighted cells (c4, c5, c7) sit in the middle band. -->
+      <!-- c0 top-left -->
+      <polygon class="cell" points="0,40 170,40 165,125 30,140 0,135"/>
+      <!-- c1 top-center -->
+      <polygon class="cell" points="170,40 335,40 330,130 165,125"/>
+      <!-- c2 top-right -->
+      <polygon class="cell" points="335,40 540,40 540,150 340,140 330,130"/>
+      <!-- c3 mid-left -->
+      <polygon class="cell" points="0,135 30,140 165,125 150,255 25,260 0,255"/>
+      <!-- c4 mid-center (highlighted) -->
+      <polygon class="cell-hi" points="165,125 330,130 320,250 150,255"/>
+      <!-- c5 mid-right (highlighted, contains q) -->
+      <polygon class="cell-hi" points="330,130 340,140 540,150 540,270 325,260 320,250"/>
+      <!-- c6 bottom-left -->
+      <polygon class="cell" points="0,255 25,260 150,255 165,380 0,380"/>
+      <!-- c7 bottom-center (highlighted, holds nearest neighbour) -->
+      <polygon class="cell-hi" points="150,255 320,250 325,260 350,380 165,380"/>
+      <!-- c8 bottom-right -->
+      <polygon class="cell" points="325,260 540,270 540,380 350,380"/>
+    </g>
+
+    <!-- ============ base vectors (panel coords) ============ -->
+    <!-- c0 -->
+    <circle class="pt" cx="50"  cy="60"  r="2.5"/>
+    <circle class="pt" cx="80"  cy="85"  r="2.5"/>
+    <circle class="pt" cx="115" cy="62"  r="2.5"/>
+    <circle class="pt" cx="130" cy="95"  r="2.5"/>
+    <circle class="pt" cx="60"  cy="105" r="2.5"/>
+    <circle class="pt" cx="100" cy="115" r="2.5"/>
+    <!-- c1 -->
+    <circle class="pt" cx="200" cy="55"  r="2.5"/>
+    <circle class="pt" cx="225" cy="80"  r="2.5"/>
+    <circle class="pt" cx="260" cy="60"  r="2.5"/>
+    <circle class="pt" cx="290" cy="85"  r="2.5"/>
+    <circle class="pt" cx="245" cy="100" r="2.5"/>
+    <circle class="pt" cx="195" cy="100" r="2.5"/>
+    <circle class="pt" cx="305" cy="110" r="2.5"/>
+    <!-- c2 -->
+    <circle class="pt" cx="365" cy="65"  r="2.5"/>
+    <circle class="pt" cx="395" cy="80"  r="2.5"/>
+    <circle class="pt" cx="430" cy="58"  r="2.5"/>
+    <circle class="pt" cx="465" cy="90"  r="2.5"/>
+    <circle class="pt" cx="500" cy="72"  r="2.5"/>
+    <circle class="pt" cx="445" cy="115" r="2.5"/>
+    <circle class="pt" cx="385" cy="115" r="2.5"/>
+    <circle class="pt" cx="510" cy="115" r="2.5"/>
+    <!-- c3 -->
+    <circle class="pt" cx="40"  cy="170" r="2.5"/>
+    <circle class="pt" cx="75"  cy="195" r="2.5"/>
+    <circle class="pt" cx="110" cy="180" r="2.5"/>
+    <circle class="pt" cx="55"  cy="225" r="2.5"/>
+    <circle class="pt" cx="115" cy="230" r="2.5"/>
+    <circle class="pt" cx="135" cy="200" r="2.5"/>
+    <!-- c4 (highlighted) -->
+    <circle class="pt-hi" cx="195" cy="155" r="2.8"/>
+    <circle class="pt-hi" cx="225" cy="170" r="2.8"/>
+    <circle class="pt-hi" cx="260" cy="155" r="2.8"/>
+    <circle class="pt-hi" cx="290" cy="175" r="2.8"/>
+    <circle class="pt-hi" cx="190" cy="205" r="2.8"/>
+    <circle class="pt-hi" cx="240" cy="215" r="2.8"/>
+    <circle class="pt-hi" cx="285" cy="220" r="2.8"/>
+    <circle class="pt-hi" cx="220" cy="235" r="2.8"/>
+    <!-- c5 (highlighted, contains q) -->
+    <circle class="pt-hi" cx="360" cy="155" r="2.8"/>
+    <circle class="pt-hi" cx="395" cy="170" r="2.8"/>
+    <circle class="pt-hi" cx="430" cy="158" r="2.8"/>
+    <circle class="pt-hi" cx="475" cy="180" r="2.8"/>
+    <circle class="pt-hi" cx="505" cy="200" r="2.8"/>
+    <circle class="pt-hi" cx="360" cy="215" r="2.8"/>
+    <circle class="pt-hi" cx="445" cy="220" r="2.8"/>
+    <circle class="pt-hi" cx="490" cy="240" r="2.8"/>
+    <circle class="pt-hi" cx="400" cy="240" r="2.8"/>
+    <!-- c6 -->
+    <circle class="pt" cx="50"  cy="290" r="2.5"/>
+    <circle class="pt" cx="85"  cy="310" r="2.5"/>
+    <circle class="pt" cx="120" cy="295" r="2.5"/>
+    <circle class="pt" cx="60"  cy="345" r="2.5"/>
+    <circle class="pt" cx="110" cy="350" r="2.5"/>
+    <circle class="pt" cx="135" cy="325" r="2.5"/>
+    <!-- c7 (highlighted) -->
+    <circle class="pt-hi" cx="195" cy="290" r="2.8"/>
+    <circle class="pt-hi" cx="230" cy="305" r="2.8"/>
+    <circle class="pt-hi" cx="270" cy="295" r="2.8"/>
+    <circle class="pt-hi" cx="310" cy="315" r="2.8"/>
+    <circle class="pt-hi" cx="205" cy="345" r="2.8"/>
+    <circle class="pt-hi" cx="250" cy="355" r="2.8"/>
+    <circle class="pt-hi" cx="300" cy="350" r="2.8"/>
+    <!-- c8 -->
+    <circle class="pt" cx="380" cy="295" r="2.5"/>
+    <circle class="pt" cx="420" cy="280" r="2.5"/>
+    <circle class="pt" cx="460" cy="300" r="2.5"/>
+    <circle class="pt" cx="500" cy="285" r="2.5"/>
+    <circle class="pt" cx="395" cy="335" r="2.5"/>
+    <circle class="pt" cx="445" cy="345" r="2.5"/>
+    <circle class="pt" cx="490" cy="335" r="2.5"/>
+    <circle class="pt" cx="515" cy="315" r="2.5"/>
+
+    <!-- ============ centroids ============ -->
+    <circle class="centroid"    cx="95"  cy="75"  r="6"/>
+    <circle class="centroid"    cx="245" cy="55"  r="6"/>
+    <circle class="centroid"    cx="415" cy="90"  r="6"/>
+    <circle class="centroid"    cx="75"  cy="210" r="6"/>
+    <circle class="centroid-hi" cx="240" cy="190" r="7"/>
+    <circle class="centroid-hi" cx="425" cy="200" r="7"/>
+    <circle class="centroid"    cx="90"  cy="330" r="6"/>
+    <circle class="centroid-hi" cx="255" cy="325" r="7"/>
+    <circle class="centroid"    cx="445" cy="320" r="6"/>
+
+    <!-- centroid labels -->
+    <text class="lbl-mute" x="95"  y="92"  text-anchor="middle" font-size="10">c0</text>
+    <text class="lbl-mute" x="245" y="42"  text-anchor="middle" font-size="10">c1</text>
+    <text class="lbl-mute" x="415" y="107" text-anchor="middle" font-size="10">c2</text>
+    <text class="lbl-mute" x="75"  y="227" text-anchor="middle" font-size="10">c3</text>
+    <text class="lbl"      x="240" y="207" text-anchor="middle" font-size="10" font-weight="700" fill="#a14503">c4</text>
+    <text class="lbl"      x="425" y="217" text-anchor="middle" font-size="10" font-weight="700" fill="#a14503">c5</text>
+    <text class="lbl-mute" x="90"  y="347" text-anchor="middle" font-size="10">c6</text>
+    <text class="lbl"      x="255" y="342" text-anchor="middle" font-size="10" font-weight="700" fill="#a14503">c7</text>
+    <text class="lbl-mute" x="445" y="337" text-anchor="middle" font-size="10">c8</text>
+
+    <!-- ============ query q ============ -->
+    <!-- q sits inside cell c5, near its boundary with c4/c7 -->
+    <polygon points="345,205 347.9,212.1 355.5,212.1 349.4,216.5 351.7,223.6 345,219.2 338.3,223.6 340.6,216.5 334.5,212.1 342.1,212.1"
+             fill="#e03131" stroke="#a61e1e" stroke-width="1.1" stroke-linejoin="round"/>
+    <text class="lbl" x="345" y="240" text-anchor="middle" font-size="11" font-weight="700" fill="#a61e1e">q</text>
+
+    <!-- ============ probe lines: q → 3 highlighted centroids ============ -->
+    <line class="probe" x1="345" y1="210" x2="240" y2="190"/>
+    <line class="probe" x1="345" y1="210" x2="425" y2="200"/>
+    <line class="probe" x1="345" y1="210" x2="255" y2="325"/>
+
+    <!-- nearest neighbour to q (in c5, very close to q) -->
+    <circle class="pt-result" cx="360" cy="215" r="4.2"/>
+  </g>
+
+  <!-- =========================================================
+       Step badges placed in/near the panel (svg coords).
+       Panel origin (40, 80).
+       ========================================================= -->
+  <g>
+    <!-- 1: probe centroids — placed near q in the embedding panel -->
+    <circle class="step-badge" cx="320" cy="265" r="11"/>
+    <text class="step-num"    x="320" y="269" text-anchor="middle">1</text>
+
+    <!-- 2: scan buckets — placed in upper-right of highlighted c5 -->
+    <circle class="step-badge" cx="540" cy="240" r="11"/>
+    <text class="step-num"    x="540" y="244" text-anchor="middle">2</text>
+
+    <!-- step 3 (reorder) is post-processing and has no spatial location;
+         it appears only in the right-side legend. -->
+  </g>
+
+  <!-- =========================================================
+       Right-side legend / annotations
+       ========================================================= -->
+  <g transform="translate(600, 92)">
+    <g>
+      <circle class="step-badge" cx="10" cy="10" r="9"/>
+      <text x="10" y="14" text-anchor="middle" fill="#fff" font-size="10" font-weight="700">1</text>
+      <text class="lbl" x="28" y="8" font-weight="600">Probe centroids</text>
+      <text class="lbl-mute" x="28" y="22" font-size="11">score q against all</text>
+      <text class="lbl-mute" x="28" y="36" font-size="11">buckets_count centroids</text>
+    </g>
+
+    <g transform="translate(0, 58)">
+      <circle class="step-badge" cx="10" cy="10" r="9"/>
+      <text x="10" y="14" text-anchor="middle" fill="#fff" font-size="10" font-weight="700">2</text>
+      <text class="lbl" x="28" y="8" font-weight="600">Scan nearest buckets</text>
+      <text class="lbl-mute" x="28" y="22" font-size="11">visit vectors inside the</text>
+      <text class="lbl-mute" x="28" y="36" font-size="11">scan_buckets_count cells</text>
+    </g>
+
+    <g transform="translate(0, 116)">
+      <circle class="step-badge" cx="10" cy="10" r="9"/>
+      <text x="10" y="14" text-anchor="middle" fill="#fff" font-size="10" font-weight="700">3</text>
+      <text class="lbl" x="28" y="8" font-weight="600">Reorder (optional)</text>
+      <text class="lbl-mute" x="28" y="22" font-size="11">re-rank factor*topk on</text>
+      <text class="lbl-mute" x="28" y="36" font-size="11">precise codes → topk</text>
+    </g>
+
+    <g transform="translate(0, 174)">
+      <rect class="note-box" x="0" y="0" width="160" height="92" rx="6"/>
+      <text class="layer-lbl" x="10" y="18" font-size="10">STORAGE</text>
+      <text class="lbl-mute"  x="10" y="36" font-size="11">base_quantization_type:</text>
+      <text class="lbl"       x="10" y="50" font-size="11">sq8 · pq · pqfs · rabitq · ...</text>
+
+      <line x1="10" y1="58" x2="150" y2="58" stroke="#e2e8f0"/>
+
+      <text class="layer-lbl" x="10" y="74" font-size="10">PARTITION STRATEGY</text>
+      <text class="lbl-mute"  x="10" y="88" font-size="11">ivf · gno_imi (two-level)</text>
+    </g>
+  </g>
+
+  <!-- =========================================================
+       Bottom legend
+       ========================================================= -->
+  <g transform="translate(40, 495)">
+    <circle class="centroid" cx="6" cy="0" r="6"/>
+    <text class="lbl-mute" x="18" y="4">centroid</text>
+
+    <circle class="centroid-hi" cx="92" cy="0" r="6"/>
+    <text class="lbl-mute" x="104" y="4">probed centroid</text>
+
+    <circle class="pt-hi" cx="218" cy="0" r="4"/>
+    <text class="lbl-mute" x="228" y="4">vector in scanned bucket</text>
+
+    <polygon points="384,-6.2 386.2,-1.4 391.5,-1.4 387.2,1.6 388.8,6.2 384,3.2 379.2,6.2 380.8,1.6 376.5,-1.4 381.8,-1.4"
+             fill="#e03131" stroke="#a61e1e" stroke-width="1" stroke-linejoin="round"/>
+    <text class="lbl-mute" x="398" y="4">query q</text>
+
+    <circle class="pt-result" cx="464" cy="0" r="5"/>
+    <text class="lbl-mute" x="476" y="4">nearest neighbour</text>
+  </g>
+</svg>

--- a/docs/docs/en/src/figures/indexes/pyramid-overview.svg
+++ b/docs/docs/en/src/figures/indexes/pyramid-overview.svg
@@ -1,0 +1,327 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 560" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="12">
+  <title>Pyramid index overview</title>
+  <desc>Pyramid stores every vector along a path string like "a/d/f" and builds one proximity sub-graph per node in the resulting path tree. A query is tagged with a path prefix; the search walks down the tree to the most specific matching sub-graph, then runs ef_search inside the leaf graph. Levels listed in no_build_levels are passthrough containers and fall back to linear scan.</desc>
+
+  <defs>
+    <marker id="arrow-search" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#e8590c"/>
+    </marker>
+  </defs>
+
+  <style>
+    .title    { fill: #1a1a1a; font-size: 16px; font-weight: 600; }
+    .subtitle { fill: #6b7280; font-size: 12px; }
+    .lbl      { fill: #1f2937; }
+    .lbl-mute { fill: #6b7280; }
+    .layer-lbl { fill: #475569; font-size: 11px; font-weight: 600; letter-spacing: 0.6px; }
+    .layer-sub { fill: #94a3b8; font-size: 11px; }
+
+    .band       { fill: #f8fafc; stroke: #e2e8f0; stroke-width: 1; }
+    .band-top   { fill: #f1f5f9; stroke: #e2e8f0; stroke-width: 1; }
+
+    /* tree nodes */
+    .tnode       { fill: #ffffff; stroke: #94a3b8; stroke-width: 1; }
+    .tnode-hi    { fill: #fff4e6; stroke: #e8590c; stroke-width: 1.6; }
+    .tnode-skip  { fill: #f1f5f9; stroke: #cbd5e1; stroke-width: 1; stroke-dasharray: 4 3; }
+    .tedge       { stroke: #cbd5e1; stroke-width: 1; fill: none; }
+    .tedge-hi    { stroke: #e8590c; stroke-width: 2; fill: none; stroke-linecap: round; }
+    .tnode-lbl   { fill: #1f2937; font-size: 11px; font-weight: 600; }
+    .tnode-lbl-hi{ fill: #a14503; font-size: 11px; font-weight: 700; }
+    .tnode-lbl-skip{ fill: #94a3b8; font-size: 11px; font-weight: 600; }
+    .tnode-sub   { fill: #94a3b8; font-size: 9px; }
+
+    /* leaf graph */
+    .gnode       { fill: #ffffff; stroke: #94a3b8; stroke-width: 1; }
+    .gnode-hi    { fill: #ffffff; stroke: #5c7cfa; stroke-width: 1.3; }
+    .gnode-entry { fill: #5c7cfa; stroke: #364fc7; stroke-width: 1.4; }
+    .gnode-visit { fill: #ffd8a8; stroke: #e8590c; stroke-width: 1.5; }
+    .gnode-result{ fill: #e03131; stroke: #a61e1e; stroke-width: 1.4; }
+    .gedge       { stroke: #cbd5e1; stroke-width: 0.8; fill: none; }
+
+    .frontier    { fill: #fff4e6; stroke: #e8590c; stroke-width: 1; stroke-dasharray: 4 3; opacity: 0.85; }
+    .search      { stroke: #e8590c; stroke-width: 2; fill: none; stroke-linecap: round; }
+
+    .step-badge  { fill: #e8590c; stroke: #ffffff; stroke-width: 2; }
+    .step-num    { fill: #ffffff; font-size: 11px; font-weight: 700; }
+
+    .note-box    { fill: #ffffff; stroke: #e2e8f0; stroke-width: 1; }
+
+    /* query path chip */
+    .pchip       { fill: #fff4e6; stroke: #e8590c; stroke-width: 1.3; }
+    .pchip-text  { fill: #a14503; font-size: 11px; font-weight: 700; }
+  </style>
+
+  <!-- Header -->
+  <text class="title"    x="40" y="34">Pyramid</text>
+  <text class="subtitle" x="40" y="52">Hierarchical path-partitioned graph · one sub-graph per node · search restricted to the query path</text>
+
+  <!-- Query path chip -->
+  <g transform="translate(40, 70)">
+    <text class="layer-lbl" x="0" y="12">QUERY PATH</text>
+    <rect class="pchip" x="100" y="0" width="120" height="22" rx="5"/>
+    <text class="pchip-text" x="160" y="16" text-anchor="middle">"a / d / f"</text>
+  </g>
+
+  <!-- =========================================================
+       Left panel: path tree
+       Panel origin (40, 110), size 340 x 410.
+       Tree: root → {a*, b, c} → {d*, e, ...} → {f*, g} → {sub-graph}
+       * = on query path → highlighted
+       ========================================================= -->
+  <g transform="translate(40, 110)">
+    <rect class="band" x="0" y="0" width="340" height="410" rx="10"/>
+    <text class="layer-lbl" x="14" y="20">PATH TREE</text>
+    <text class="layer-sub" x="88" y="20">one sub-graph per node</text>
+
+    <!--
+      Level y positions (panel y):
+        L0 (root)     :  56
+        L1            : 130
+        L2            : 220
+        L3 (leaves)   : 310
+    -->
+
+    <!-- edges (drawn first, so nodes sit on top) -->
+    <!-- root → L1 -->
+    <line class="tedge-hi" x1="170" y1="64" x2="80"  y2="122"/>
+    <line class="tedge"    x1="170" y1="64" x2="170" y2="122"/>
+    <line class="tedge"    x1="170" y1="64" x2="260" y2="122"/>
+    <!-- a → L2 -->
+    <line class="tedge-hi" x1="80"  y1="138" x2="40"  y2="212"/>
+    <line class="tedge"    x1="80"  y1="138" x2="120" y2="212"/>
+    <!-- b → L2 -->
+    <line class="tedge"    x1="170" y1="138" x2="170" y2="212"/>
+    <!-- c → L2 -->
+    <line class="tedge"    x1="260" y1="138" x2="240" y2="212"/>
+    <line class="tedge"    x1="260" y1="138" x2="295" y2="212"/>
+    <!-- d → L3 -->
+    <line class="tedge-hi" x1="40"  y1="228" x2="40"  y2="302"/>
+    <line class="tedge"    x1="40"  y1="228" x2="80"  y2="302"/>
+
+    <!-- nodes -->
+    <!-- root -->
+    <circle class="tnode" cx="170" cy="56" r="14"/>
+    <text class="tnode-lbl" x="170" y="60" text-anchor="middle">/</text>
+    <text class="tnode-sub" x="170" y="40" text-anchor="middle">root</text>
+
+    <!-- L1: a (hi), b, c -->
+    <circle class="tnode-hi" cx="80"  cy="130" r="14"/>
+    <text class="tnode-lbl-hi" x="80" y="134" text-anchor="middle">a</text>
+
+    <circle class="tnode-skip" cx="170" cy="130" r="14"/>
+    <text class="tnode-lbl-skip" x="170" y="134" text-anchor="middle">b</text>
+
+    <circle class="tnode" cx="260" cy="130" r="14"/>
+    <text class="tnode-lbl" x="260" y="134" text-anchor="middle">c</text>
+
+    <!-- L2: d (hi), e ; under b: stub ; under c: f, g -->
+    <circle class="tnode-hi" cx="40"  cy="220" r="14"/>
+    <text class="tnode-lbl-hi" x="40" y="224" text-anchor="middle">d</text>
+
+    <circle class="tnode" cx="120" cy="220" r="14"/>
+    <text class="tnode-lbl" x="120" y="224" text-anchor="middle">e</text>
+
+    <circle class="tnode-skip" cx="170" cy="220" r="14"/>
+    <text class="tnode-lbl-skip" x="170" y="224" text-anchor="middle">…</text>
+
+    <circle class="tnode" cx="240" cy="220" r="14"/>
+    <text class="tnode-lbl" x="240" y="224" text-anchor="middle">x</text>
+
+    <circle class="tnode" cx="295" cy="220" r="14"/>
+    <text class="tnode-lbl" x="295" y="224" text-anchor="middle">y</text>
+
+    <!-- L3 leaves: f (hi), g  (children of d) -->
+    <circle class="tnode-hi" cx="40"  cy="310" r="14"/>
+    <text class="tnode-lbl-hi" x="40" y="314" text-anchor="middle">f</text>
+
+    <circle class="tnode" cx="80"  cy="310" r="14"/>
+    <text class="tnode-lbl" x="80" y="314" text-anchor="middle">g</text>
+
+    <!-- Level labels on the right gutter -->
+    <text class="lbl-mute" x="320" y="60" text-anchor="end" font-size="10">L0</text>
+    <text class="lbl-mute" x="320" y="134" text-anchor="end" font-size="10">L1</text>
+    <text class="lbl-mute" x="320" y="224" text-anchor="end" font-size="10">L2</text>
+    <text class="lbl-mute" x="320" y="314" text-anchor="end" font-size="10">L3</text>
+
+    <!-- annotation: dashed node = no_build_levels / small partition -->
+    <g transform="translate(140, 348)">
+      <circle class="tnode-skip" cx="10" cy="10" r="8"/>
+      <text class="lbl-mute" x="26" y="14" font-size="10">passthrough · no_build_levels</text>
+    </g>
+    <g transform="translate(140, 372)">
+      <circle class="tnode-hi" cx="10" cy="10" r="8"/>
+      <text class="lbl-mute" x="26" y="14" font-size="10">node on query path "a/d/f"</text>
+    </g>
+
+    <!-- "zoom" indicator from leaf f → right panel -->
+    <path d="M 56 310 L 90 310" stroke="#e8590c" stroke-width="1.4" fill="none"
+          stroke-dasharray="3 3" opacity="0.7"/>
+  </g>
+
+  <!-- =========================================================
+       Right panel: sub-graph at leaf "a/d/f"
+       Panel origin (400, 110), size 360 x 410.
+       ========================================================= -->
+  <g transform="translate(400, 110)">
+    <rect class="band" x="0" y="0" width="360" height="410" rx="10"/>
+    <text class="layer-lbl" x="14" y="20">LEAF SUB-GRAPH "a/d/f"</text>
+    <text class="layer-sub" x="170" y="20">ef_search beam over sub-graph</text>
+
+    <!-- ef_search frontier behind nodes -->
+    <ellipse class="frontier" cx="240" cy="240" rx="65" ry="48"/>
+
+    <!-- proximity edges -->
+    <line class="gedge" x1="60"  y1="80"  x2="100" y2="105"/>
+    <line class="gedge" x1="60"  y1="80"  x2="90"  y2="140"/>
+    <line class="gedge" x1="100" y1="105" x2="140" y2="135"/>
+    <line class="gedge" x1="100" y1="105" x2="155" y2="90"/>
+    <line class="gedge" x1="90"  y1="140" x2="140" y2="135"/>
+    <line class="gedge" x1="90"  y1="140" x2="120" y2="180"/>
+    <line class="gedge" x1="140" y1="135" x2="170" y2="170"/>
+    <line class="gedge" x1="140" y1="135" x2="195" y2="135"/>
+    <line class="gedge" x1="120" y1="180" x2="170" y2="170"/>
+    <line class="gedge" x1="120" y1="180" x2="160" y2="220"/>
+    <line class="gedge" x1="170" y1="170" x2="195" y2="135"/>
+    <line class="gedge" x1="170" y1="170" x2="215" y2="200"/>
+    <line class="gedge" x1="170" y1="170" x2="160" y2="220"/>
+    <line class="gedge" x1="195" y1="135" x2="235" y2="115"/>
+    <line class="gedge" x1="195" y1="135" x2="240" y2="170"/>
+    <line class="gedge" x1="155" y1="90"  x2="235" y2="115"/>
+    <line class="gedge" x1="235" y1="115" x2="240" y2="170"/>
+    <line class="gedge" x1="235" y1="115" x2="295" y2="120"/>
+    <line class="gedge" x1="240" y1="170" x2="215" y2="200"/>
+    <line class="gedge" x1="240" y1="170" x2="280" y2="200"/>
+    <line class="gedge" x1="240" y1="170" x2="240" y2="220"/>
+    <line class="gedge" x1="215" y1="200" x2="240" y2="240"/>
+    <line class="gedge" x1="215" y1="200" x2="240" y2="220"/>
+    <line class="gedge" x1="160" y1="220" x2="200" y2="250"/>
+    <line class="gedge" x1="200" y1="250" x2="240" y2="240"/>
+    <line class="gedge" x1="200" y1="250" x2="225" y2="285"/>
+    <line class="gedge" x1="240" y1="220" x2="240" y2="240"/>
+    <line class="gedge" x1="240" y1="220" x2="285" y2="245"/>
+    <line class="gedge" x1="240" y1="240" x2="265" y2="275"/>
+    <line class="gedge" x1="240" y1="240" x2="285" y2="245"/>
+    <line class="gedge" x1="240" y1="240" x2="225" y2="285"/>
+    <line class="gedge" x1="265" y1="275" x2="285" y2="245"/>
+    <line class="gedge" x1="265" y1="275" x2="305" y2="285"/>
+    <line class="gedge" x1="225" y1="285" x2="265" y2="275"/>
+    <line class="gedge" x1="280" y1="200" x2="285" y2="245"/>
+    <line class="gedge" x1="280" y1="200" x2="320" y2="200"/>
+    <line class="gedge" x1="285" y1="245" x2="320" y2="200"/>
+    <line class="gedge" x1="285" y1="245" x2="320" y2="270"/>
+    <line class="gedge" x1="295" y1="120" x2="320" y2="160"/>
+    <line class="gedge" x1="295" y1="120" x2="330" y2="100"/>
+    <line class="gedge" x1="320" y1="160" x2="320" y2="200"/>
+    <line class="gedge" x1="305" y1="285" x2="320" y2="270"/>
+
+    <!-- entry node (top-left) -->
+    <circle class="gnode-entry" cx="60" cy="80" r="6"/>
+    <text class="lbl" x="60" y="68" text-anchor="middle" font-size="10" fill="#364fc7" font-weight="600">entry</text>
+
+    <!-- regular nodes -->
+    <circle class="gnode" cx="100" cy="105" r="4"/>
+    <circle class="gnode" cx="90"  cy="140" r="4"/>
+    <circle class="gnode" cx="140" cy="135" r="4"/>
+    <circle class="gnode" cx="155" cy="90"  r="4"/>
+    <circle class="gnode" cx="120" cy="180" r="4"/>
+    <circle class="gnode" cx="195" cy="135" r="4"/>
+    <circle class="gnode" cx="160" cy="220" r="4"/>
+    <circle class="gnode" cx="235" cy="115" r="4"/>
+    <circle class="gnode" cx="200" cy="250" r="4"/>
+    <circle class="gnode" cx="280" cy="200" r="4"/>
+    <circle class="gnode" cx="225" cy="285" r="4"/>
+    <circle class="gnode" cx="305" cy="285" r="4"/>
+    <circle class="gnode" cx="320" cy="200" r="4"/>
+    <circle class="gnode" cx="320" cy="270" r="4"/>
+    <circle class="gnode" cx="295" cy="120" r="4"/>
+    <circle class="gnode" cx="320" cy="160" r="4"/>
+    <circle class="gnode" cx="330" cy="100" r="4"/>
+
+    <!-- visited along the search -->
+    <circle class="gnode-visit" cx="170" cy="170" r="5.4"/>
+    <circle class="gnode-visit" cx="215" cy="200" r="5.4"/>
+    <circle class="gnode-visit" cx="240" cy="220" r="5.4"/>
+    <circle class="gnode-visit" cx="265" cy="275" r="5.4"/>
+    <circle class="gnode-visit" cx="285" cy="245" r="5.4"/>
+
+    <!-- nearest neighbour -->
+    <circle class="gnode-result" cx="240" cy="240" r="5.6"/>
+
+    <!-- query star -->
+    <polygon points="263,247 265.6,253.4 272.5,253.4 267,257.4 269.2,264 263,259.7 256.8,264 259,257.4 253.5,253.4 260.4,253.4"
+             fill="#e03131" stroke="#a61e1e" stroke-width="1.1" stroke-linejoin="round"/>
+    <text class="lbl" x="263" y="280" text-anchor="middle" font-size="11" font-weight="700" fill="#a61e1e">q</text>
+
+    <!-- search path from entry → ... → nearest -->
+    <path class="search" d="M 60 80 Q 110 130 170 170 T 240 220 T 240 240" marker-end="url(#arrow-search)"/>
+
+    <!-- ef_search caption -->
+    <text class="lbl-mute" x="240" y="305" text-anchor="middle" font-size="11">ef_search frontier</text>
+  </g>
+
+  <!-- =========================================================
+       Step badges placed along the trajectory (svg coords)
+       ========================================================= -->
+  <g>
+    <!-- 1: at root node of left panel (svg ~210, 158) -->
+    <circle class="step-badge" cx="232" cy="158" r="11"/>
+    <text class="step-num"    x="232" y="162" text-anchor="middle">1</text>
+
+    <!-- 2: zoom from leaf 'f' to right panel (svg ~410, 420) -->
+    <circle class="step-badge" cx="408" cy="420" r="11"/>
+    <text class="step-num"    x="408" y="424" text-anchor="middle">2</text>
+
+    <!-- 3: ef_search inside right panel — near the frontier ellipse -->
+    <circle class="step-badge" cx="715" cy="305" r="11"/>
+    <text class="step-num"    x="715" y="309" text-anchor="middle">3</text>
+  </g>
+
+  <!-- =========================================================
+       Bottom legend
+       ========================================================= -->
+  <g transform="translate(40, 553)">
+    <circle class="tnode-hi" cx="6" cy="0" r="7"/>
+    <text class="lbl-mute" x="20" y="4">path-prefix match</text>
+
+    <circle class="tnode-skip" cx="142" cy="0" r="7"/>
+    <text class="lbl-mute" x="156" y="4">no_build_levels (scan fallback)</text>
+
+    <circle class="gnode-entry" cx="358" cy="0" r="6"/>
+    <text class="lbl-mute" x="370" y="4">leaf graph entry</text>
+
+    <circle class="gnode-result" cx="488" cy="0" r="6"/>
+    <text class="lbl-mute" x="500" y="4">nearest neighbour</text>
+
+    <polygon points="624,-6.2 626.2,-1.4 631.5,-1.4 627.2,1.6 628.8,6.2 624,3.2 619.2,6.2 620.8,1.6 616.5,-1.4 621.8,-1.4"
+             fill="#e03131" stroke="#a61e1e" stroke-width="1" stroke-linejoin="round"/>
+    <text class="lbl-mute" x="638" y="4">query q</text>
+  </g>
+
+  <!-- =========================================================
+       Right-side note (compact). Place steps 1-3 next to the leaf-graph panel
+       in the lower-right vacant area.
+       Actually the leaf-graph panel already occupies right; put step legend
+       below the bottom of the right panel. We have y=520 → bottom legend at 545.
+       So place inline step legend at the top-right INSIDE the leaf panel area.
+       To keep the figure clean we use NO right-side annotation column;
+       step numbers reference the in-place badges plus this small inline panel.
+       ========================================================= -->
+
+  <!-- compact step legend at the very top right corner -->
+  <g transform="translate(400, 70)">
+    <rect class="note-box" x="0" y="-12" width="360" height="32" rx="6"/>
+    <g>
+      <circle class="step-badge" cx="14" cy="4" r="8"/>
+      <text x="14" y="8" text-anchor="middle" fill="#fff" font-size="9" font-weight="700">1</text>
+      <text class="lbl" x="28" y="8" font-size="11" font-weight="600">walk path</text>
+
+      <circle class="step-badge" cx="104" cy="4" r="8"/>
+      <text x="104" y="8" text-anchor="middle" fill="#fff" font-size="9" font-weight="700">2</text>
+      <text class="lbl" x="118" y="8" font-size="11" font-weight="600">enter leaf sub-graph</text>
+
+      <circle class="step-badge" cx="240" cy="4" r="8"/>
+      <text x="240" y="8" text-anchor="middle" fill="#fff" font-size="9" font-weight="700">3</text>
+      <text class="lbl" x="254" y="8" font-size="11" font-weight="600">ef_search → top-k</text>
+    </g>
+  </g>
+</svg>

--- a/docs/docs/en/src/figures/indexes/sindi-overview.svg
+++ b/docs/docs/en/src/figures/indexes/sindi-overview.svg
@@ -1,0 +1,301 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 560" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="12">
+  <title>SINDI index overview</title>
+  <desc>SINDI is VSAG's sparse-vector index. Documents are partitioned into fixed-size windows; within each window an inverted list per term id holds (doc_id, value) postings. At query time SINDI walks only the inverted lists matching the query's non-zero term ids, accumulates partial inner-product contributions into an n_candidate-sized heap, and optionally rescores against a high-precision flat copy.</desc>
+
+  <defs>
+    <marker id="arrow-search" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#e8590c"/>
+    </marker>
+  </defs>
+
+  <style>
+    .title    { fill: #1a1a1a; font-size: 16px; font-weight: 600; }
+    .subtitle { fill: #6b7280; font-size: 12px; }
+    .lbl      { fill: #1f2937; }
+    .lbl-mute { fill: #6b7280; }
+    .layer-lbl { fill: #475569; font-size: 11px; font-weight: 600; letter-spacing: 0.6px; }
+    .layer-sub { fill: #94a3b8; font-size: 11px; }
+
+    .band       { fill: #f8fafc; stroke: #e2e8f0; stroke-width: 1; }
+    .band-top   { fill: #f1f5f9; stroke: #e2e8f0; stroke-width: 1; }
+
+    /* query term chip */
+    .qchip      { fill: #fff4e6; stroke: #e8590c; stroke-width: 1.2; }
+    .qchip-mute { fill: #ffffff; stroke: #cbd5e1; stroke-width: 1; stroke-dasharray: 3 2; }
+    .qtext      { fill: #a14503; font-size: 10px; font-weight: 700; }
+    .qtext-mute { fill: #94a3b8; font-size: 10px; font-weight: 600; }
+
+    /* posting cell (doc_id, value) */
+    .post       { fill: #ffffff; stroke: #94a3b8; stroke-width: 0.8; }
+    .post-hi    { fill: #ffd8a8; stroke: #e8590c; stroke-width: 1.1; }
+    .post-result{ fill: #e03131; stroke: #a61e1e; stroke-width: 1.2; }
+    .post-text  { fill: #1f2937; font-size: 9px; }
+    .post-text-hi { fill: #a14503; font-size: 9px; font-weight: 700; }
+    .post-text-result { fill: #ffffff; font-size: 9px; font-weight: 700; }
+
+    /* term row label */
+    .term-lbl   { fill: #364fc7; font-size: 10px; font-weight: 700; }
+
+    /* window separators */
+    .win-rect   { fill: none; stroke: #cbd5e1; stroke-width: 1; stroke-dasharray: 3 3; }
+    .win-lbl    { fill: #94a3b8; font-size: 9px; letter-spacing: 0.4px; }
+
+    /* search arrows */
+    .search     { stroke: #e8590c; stroke-width: 1.6; fill: none; stroke-linecap: round; }
+    .feed       { stroke: #e8590c; stroke-width: 1.4; fill: none; stroke-dasharray: 4 3; stroke-linecap: round; opacity: 0.85; }
+
+    .step-badge  { fill: #e8590c; stroke: #ffffff; stroke-width: 2; }
+    .step-num    { fill: #ffffff; font-size: 11px; font-weight: 700; }
+
+    .note-box    { fill: #ffffff; stroke: #e2e8f0; stroke-width: 1; }
+
+    /* heap shape */
+    .heap-box   { fill: #fff4e6; stroke: #e8590c; stroke-width: 1.2; }
+    .heap-lbl   { fill: #a14503; font-size: 10px; font-weight: 700; letter-spacing: 0.4px; }
+  </style>
+
+  <!-- Header -->
+  <text class="title"    x="40" y="34">SINDI</text>
+  <text class="subtitle" x="40" y="52">Sparse inverted index · per-term posting lists in fixed windows · score only matching terms</text>
+
+  <!-- =========================================================
+       Query band (top): sparse vector as a list of (term, value) chips
+       Panel origin (40, 80), size 540 x 70.
+       ========================================================= -->
+  <g transform="translate(40, 80)">
+    <rect class="band-top" x="0" y="0" width="540" height="86" rx="10"/>
+    <text class="layer-lbl" x="14" y="20">QUERY q</text>
+    <text class="layer-sub" x="80" y="20">non-zero terms · iterate only these inverted lists</text>
+
+    <!-- 4 query chips: t5, t12, t27, t41 ; one (t41) is dashed = pruned by query_prune_ratio -->
+    <g transform="translate(16, 32)">
+      <rect class="qchip" x="0"   y="0" width="90" height="26" rx="6"/>
+      <text class="qtext" x="45"  y="17" text-anchor="middle">t5 : 0.92</text>
+
+      <rect class="qchip" x="100" y="0" width="90" height="26" rx="6"/>
+      <text class="qtext" x="145" y="17" text-anchor="middle">t12 : 0.71</text>
+
+      <rect class="qchip" x="200" y="0" width="90" height="26" rx="6"/>
+      <text class="qtext" x="245" y="17" text-anchor="middle">t27 : 0.55</text>
+
+      <rect class="qchip-mute" x="300" y="0" width="90" height="26" rx="6"/>
+      <text class="qtext-mute" x="345" y="17" text-anchor="middle">t41 : 0.08</text>
+      <text class="lbl-mute" x="345" y="44" text-anchor="middle" font-size="9">pruned by query_prune_ratio</text>
+    </g>
+  </g>
+
+  <!-- =========================================================
+       Inverted lists (middle): one row per query term, two windows wide
+       Panel origin (40, 168), size 540 x 256.
+       Rows at y = 50, 110, 170 inside panel.
+       Two windows: W0 (x=80..295) and W1 (x=310..525).
+       ========================================================= -->
+  <g transform="translate(40, 168)">
+    <rect class="band" x="0" y="0" width="540" height="232" rx="10"/>
+    <text class="layer-lbl" x="14" y="20">INVERTED LISTS</text>
+    <text class="layer-sub" x="130" y="20">term → (doc_id, value) postings, grouped by window_size</text>
+
+    <!-- Window dividers / labels -->
+    <text class="win-lbl" x="187" y="40" text-anchor="middle">WINDOW W0</text>
+    <text class="win-lbl" x="417" y="40" text-anchor="middle">WINDOW W1</text>
+    <rect class="win-rect" x="74"  y="44" width="226" height="172" rx="6"/>
+    <rect class="win-rect" x="304" y="44" width="226" height="172" rx="6"/>
+
+    <!-- Row 1: term t5 -->
+    <text class="term-lbl" x="14" y="74" font-size="11">term t5</text>
+    <!-- W0 postings -->
+    <g transform="translate(80, 60)">
+      <rect class="post-hi" x="0"   y="0" width="62" height="22" rx="3"/>
+      <text class="post-text-hi" x="31"  y="14" text-anchor="middle">d12 : .80</text>
+
+      <rect class="post"    x="68"  y="0" width="62" height="22" rx="3"/>
+      <text class="post-text" x="99"  y="14" text-anchor="middle">d31 : .45</text>
+
+      <rect class="post-hi" x="136" y="0" width="62" height="22" rx="3"/>
+      <text class="post-text-hi" x="167" y="14" text-anchor="middle">d47 : .65</text>
+    </g>
+    <!-- W1 postings -->
+    <g transform="translate(310, 60)">
+      <rect class="post"    x="0"   y="0" width="62" height="22" rx="3"/>
+      <text class="post-text" x="31"  y="14" text-anchor="middle">d83 : .31</text>
+
+      <rect class="post-hi" x="68"  y="0" width="62" height="22" rx="3"/>
+      <text class="post-text-hi" x="99"  y="14" text-anchor="middle">d97 : .72</text>
+
+      <rect class="post"    x="136" y="0" width="62" height="22" rx="3"/>
+      <text class="post-text" x="167" y="14" text-anchor="middle">d115: .28</text>
+    </g>
+
+    <!-- Row 2: term t12 -->
+    <text class="term-lbl" x="14" y="124" font-size="11">term t12</text>
+    <g transform="translate(80, 110)">
+      <rect class="post-hi" x="0"   y="0" width="62" height="22" rx="3"/>
+      <text class="post-text-hi" x="31"  y="14" text-anchor="middle">d12 : .55</text>
+
+      <rect class="post"    x="68"  y="0" width="62" height="22" rx="3"/>
+      <text class="post-text" x="99"  y="14" text-anchor="middle">d20 : .42</text>
+
+      <rect class="post"    x="136" y="0" width="62" height="22" rx="3"/>
+      <text class="post-text" x="167" y="14" text-anchor="middle">d58 : .19</text>
+    </g>
+    <g transform="translate(310, 110)">
+      <rect class="post-hi" x="0"   y="0" width="62" height="22" rx="3"/>
+      <text class="post-text-hi" x="31"  y="14" text-anchor="middle">d97 : .60</text>
+
+      <rect class="post"    x="68"  y="0" width="62" height="22" rx="3"/>
+      <text class="post-text" x="99"  y="14" text-anchor="middle">d104: .33</text>
+    </g>
+
+    <!-- Row 3: term t27 -->
+    <text class="term-lbl" x="14" y="174" font-size="11">term t27</text>
+    <g transform="translate(80, 160)">
+      <rect class="post"    x="0"   y="0" width="62" height="22" rx="3"/>
+      <text class="post-text" x="31"  y="14" text-anchor="middle">d09 : .22</text>
+
+      <rect class="post-hi" x="68"  y="0" width="62" height="22" rx="3"/>
+      <text class="post-text-hi" x="99"  y="14" text-anchor="middle">d12 : .48</text>
+
+      <rect class="post"    x="136" y="0" width="62" height="22" rx="3"/>
+      <text class="post-text" x="167" y="14" text-anchor="middle">d47 : .25</text>
+    </g>
+    <g transform="translate(310, 160)">
+      <rect class="post"    x="0"   y="0" width="62" height="22" rx="3"/>
+      <text class="post-text" x="31"  y="14" text-anchor="middle">d83 : .29</text>
+
+      <rect class="post"    x="68"  y="0" width="62" height="22" rx="3"/>
+      <text class="post-text" x="99"  y="14" text-anchor="middle">d97 : .15</text>
+
+      <rect class="post"    x="136" y="0" width="62" height="22" rx="3"/>
+      <text class="post-text" x="167" y="14" text-anchor="middle">d128: .19</text>
+    </g>
+
+    <!-- Term-walk highlight arrows (one per row, left → right) -->
+    <path class="search" d="M 70 71 L 308 71" marker-end="url(#arrow-search)" opacity="0.55"/>
+    <path class="search" d="M 70 121 L 308 121" marker-end="url(#arrow-search)" opacity="0.55"/>
+    <path class="search" d="M 70 171 L 308 171" marker-end="url(#arrow-search)" opacity="0.55"/>
+  </g>
+
+  <!-- =========================================================
+       Bottom band: n_candidate heap → topk
+       Panel origin (40, 420), size 540 x 80.
+       ========================================================= -->
+  <g transform="translate(40, 420)">
+    <rect class="band" x="0" y="0" width="540" height="80" rx="10"/>
+    <text class="layer-lbl" x="14" y="20">CANDIDATE HEAP</text>
+    <text class="layer-sub" x="140" y="20">size n_candidate · sum q·d contributions · keep top-k</text>
+
+    <!-- candidate items -->
+    <g transform="translate(80, 36)">
+      <rect class="post-result" x="0"   y="0" width="74" height="30" rx="4"/>
+      <text class="post-text-result" x="37"  y="13" text-anchor="middle">d12</text>
+      <text class="post-text-result" x="37"  y="25" text-anchor="middle">1.83</text>
+
+      <rect class="post-result" x="84"  y="0" width="74" height="30" rx="4"/>
+      <text class="post-text-result" x="121" y="13" text-anchor="middle">d97</text>
+      <text class="post-text-result" x="121" y="25" text-anchor="middle">1.32</text>
+
+      <rect class="post-hi" x="168" y="0" width="74" height="30" rx="4"/>
+      <text class="post-text-hi"  x="205" y="13" text-anchor="middle">d47</text>
+      <text class="post-text-hi"  x="205" y="25" text-anchor="middle">0.90</text>
+
+      <rect class="post-hi" x="252" y="0" width="74" height="30" rx="4"/>
+      <text class="post-text-hi"  x="289" y="13" text-anchor="middle">d83</text>
+      <text class="post-text-hi"  x="289" y="25" text-anchor="middle">0.60</text>
+
+      <rect class="post"    x="336" y="0" width="74" height="30" rx="4"/>
+      <text class="post-text" x="373" y="13" text-anchor="middle">d31</text>
+      <text class="post-text" x="373" y="25" text-anchor="middle">0.45</text>
+
+      <text class="lbl-mute" x="426" y="20" font-size="11">...</text>
+    </g>
+
+    <!-- topk callout: small bracket underlining the two red chips (svg x=120..238) -->
+    <path d="M 120 70 L 120 73 L 238 73 L 238 70" stroke="#a61e1e" stroke-width="1.2" fill="none"/>
+    <text class="heap-lbl" x="179" y="75" text-anchor="middle" fill="#a61e1e" dominant-baseline="hanging">TOP-K</text>
+  </g>
+
+  <!-- feed arrows from inverted lists → candidate heap -->
+  <path class="feed" d="M 130 410 Q 130 418 130 430"/>
+  <path class="feed" d="M 195 410 Q 195 418 195 430"/>
+  <path class="feed" d="M 265 410 Q 265 418 265 430"/>
+  <path class="feed" d="M 350 410 Q 350 418 350 430"/>
+  <path class="feed" d="M 430 410 Q 430 418 430 430"/>
+
+  <!-- =========================================================
+       Step badges
+       ========================================================= -->
+  <g>
+    <!-- 1: query non-zero terms (top band) -->
+    <circle class="step-badge" cx="545" cy="114" r="11"/>
+    <text class="step-num"    x="545" y="118" text-anchor="middle">1</text>
+
+    <!-- 2: walk inverted lists -->
+    <circle class="step-badge" cx="545" cy="200" r="11"/>
+    <text class="step-num"    x="545" y="204" text-anchor="middle">2</text>
+
+    <!-- 3: aggregate into heap (bottom band) -->
+    <circle class="step-badge" cx="545" cy="436" r="11"/>
+    <text class="step-num"    x="545" y="440" text-anchor="middle">3</text>
+  </g>
+
+  <!-- =========================================================
+       Right-side legend / annotations
+       ========================================================= -->
+  <g transform="translate(600, 92)">
+    <g>
+      <circle class="step-badge" cx="10" cy="10" r="9"/>
+      <text x="10" y="14" text-anchor="middle" fill="#fff" font-size="10" font-weight="700">1</text>
+      <text class="lbl" x="28" y="8" font-weight="600">Query terms</text>
+      <text class="lbl-mute" x="28" y="22" font-size="11">non-zero (term, weight)</text>
+      <text class="lbl-mute" x="28" y="36" font-size="11">pairs of q</text>
+    </g>
+
+    <g transform="translate(0, 58)">
+      <circle class="step-badge" cx="10" cy="10" r="9"/>
+      <text x="10" y="14" text-anchor="middle" fill="#fff" font-size="10" font-weight="700">2</text>
+      <text class="lbl" x="28" y="8" font-weight="600">Walk inverted lists</text>
+      <text class="lbl-mute" x="28" y="22" font-size="11">one list per query term,</text>
+      <text class="lbl-mute" x="28" y="36" font-size="11">window by window</text>
+    </g>
+
+    <g transform="translate(0, 116)">
+      <circle class="step-badge" cx="10" cy="10" r="9"/>
+      <text x="10" y="14" text-anchor="middle" fill="#fff" font-size="10" font-weight="700">3</text>
+      <text class="lbl" x="28" y="8" font-weight="600">Aggregate &amp; rank</text>
+      <text class="lbl-mute" x="28" y="22" font-size="11">sum q·d contributions</text>
+      <text class="lbl-mute" x="28" y="36" font-size="11">into heap → top-k</text>
+    </g>
+
+    <g transform="translate(0, 174)">
+      <rect class="note-box" x="0" y="0" width="160" height="92" rx="6"/>
+      <text class="layer-lbl" x="10" y="18" font-size="10">PRUNING</text>
+      <text class="lbl-mute"  x="10" y="34" font-size="11">doc_prune_ratio (build)</text>
+      <text class="lbl-mute"  x="10" y="48" font-size="11">query_prune_ratio (search)</text>
+
+      <line x1="10" y1="58" x2="150" y2="58" stroke="#e2e8f0"/>
+
+      <text class="layer-lbl" x="10" y="74" font-size="10">RERANK (OPTIONAL)</text>
+      <text class="lbl-mute"  x="10" y="88" font-size="11">use_reorder + flat copy</text>
+    </g>
+  </g>
+
+  <!-- =========================================================
+       Bottom legend
+       ========================================================= -->
+  <g transform="translate(40, 525)">
+    <rect class="qchip" x="0" y="-6" width="14" height="12" rx="3"/>
+    <text class="lbl-mute" x="20" y="4">query term</text>
+
+    <rect class="post-hi" x="96" y="-6" width="14" height="12" rx="3"/>
+    <text class="lbl-mute" x="116" y="4">matched posting</text>
+
+    <rect class="post-result" x="234" y="-6" width="14" height="12" rx="3"/>
+    <text class="lbl-mute" x="254" y="4">top-k result</text>
+
+    <rect class="post" x="352" y="-6" width="14" height="12" rx="3"/>
+    <text class="lbl-mute" x="372" y="4">unmatched posting</text>
+
+    <line class="search" x1="490" y1="0" x2="520" y2="0" marker-end="url(#arrow-search)"/>
+    <text class="lbl-mute" x="528" y="4">term walk</text>
+  </g>
+</svg>

--- a/docs/docs/en/src/indexes/brute_force.md
+++ b/docs/docs/en/src/indexes/brute_force.md
@@ -1,5 +1,7 @@
 # BruteForce
 
+![BruteForce: vectors live in a flat store; the query is compared against every stored vector, with optional intra-query parallelism splitting the scan across threads, and the smallest distances are kept in a top-k heap](../figures/indexes/brute_force-overview.svg)
+
 BruteForce is VSAG's **exact, flat** index. At query time it scores the query against every
 vector in the corpus and returns the true top-k — no graph traversal, no inverted lists, no
 approximation. Its main role is to be the **ground-truth baseline** that approximate indexes

--- a/docs/docs/en/src/indexes/hgraph.md
+++ b/docs/docs/en/src/indexes/hgraph.md
@@ -1,5 +1,7 @@
 # HGraph
 
+![HGraph: hierarchical proximity graph with top-down greedy search and optional reorder](../figures/indexes/hgraph-overview.svg)
+
 HGraph is VSAG's flagship **graph-based** index. It builds a hierarchical proximity graph
 similar in spirit to HNSW, but with a richer set of quantization options, a unified
 build-parameter schema (`index_param`), and first-class support for reordering,

--- a/docs/docs/en/src/indexes/ivf.md
+++ b/docs/docs/en/src/indexes/ivf.md
@@ -1,5 +1,7 @@
 # IVF
 
+![IVF: Voronoi partition over k-means centroids; only the scan_buckets_count buckets closest to the query are scanned, with an optional precise rerank](../figures/indexes/ivf-overview.svg)
+
 IVF (Inverted File) is VSAG's **partition-based** index. It clusters the corpus into
 buckets at build time, and at query time only scans the buckets whose centroids are
 closest to the query. This turns an O(N) linear scan into O(N · `scan_buckets_count`

--- a/docs/docs/en/src/indexes/pyramid.md
+++ b/docs/docs/en/src/indexes/pyramid.md
@@ -1,5 +1,7 @@
 # Pyramid
 
+![Pyramid: a tree of per-node proximity sub-graphs keyed by a path string; the search walks down the tree along the query's path prefix and runs ef_search inside the leaf sub-graph](../figures/indexes/pyramid-overview.svg)
+
 Pyramid is VSAG's **hierarchical, path-partitioned** graph index. Every vector is
 tagged with a path string such as `"a/d/f"`, and Pyramid builds a graph per node
 in that path tree. At query time you supply a path prefix, and Pyramid restricts

--- a/docs/docs/en/src/indexes/sindi.md
+++ b/docs/docs/en/src/indexes/sindi.md
@@ -1,5 +1,7 @@
 # SINDI
 
+![SINDI: per-term inverted lists grouped by window; only the lists matching the query's non-zero terms are walked and accumulated into an n_candidate-sized heap](../figures/indexes/sindi-overview.svg)
+
 SINDI (**S**parse **IN**verted **D**ense **I**ndex) is VSAG's index for **sparse
 vectors** — the kind produced by BM25, SPLADE, and other learned-sparse encoders.
 Unlike the dense indexes (HGraph, IVF), SINDI operates directly on term/value

--- a/docs/docs/zh/src/figures/indexes/brute_force-overview.svg
+++ b/docs/docs/zh/src/figures/indexes/brute_force-overview.svg
@@ -1,0 +1,503 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 560" font-family="-apple-system, BlinkMacSystemFont, 'PingFang SC', 'Microsoft YaHei', 'Segoe UI', Helvetica, Arial, sans-serif" font-size="12">
+  <title>BruteForce 索引概览</title>
+  <desc>BruteForce 将向量存放在一个扁平数组中；对每个查询，它会与所有存储向量逐一计算距离，并用 top-k 堆保留最近的几个。扫描可以通过 parallelism 参数切到多线程执行；当 base_quantization_type 为 fp32 时结果是精确的。</desc>
+
+  <style>
+    .title       { font-size: 16px; font-weight: 600; fill: #0f172a; }
+    .subtitle    { font-size: 12px; fill: #6b7280; }
+    .lbl         { fill: #334155; }
+    .lbl-mute    { fill: #6b7280; font-size: 11px; }
+    .layer-lbl   { font-size: 11px; font-weight: 700; fill: #475569; letter-spacing: 0.6px; text-transform: uppercase; }
+    .layer-sub   { font-size: 11px; fill: #94a3b8; }
+
+    .band        { fill: #f8fafc; stroke: #e2e8f0; stroke-width: 1; }
+    .panel       { fill: #f1f5f9; stroke: #cbd5e1; stroke-width: 1; }
+    .note-box    { fill: #fff4e6; stroke: #ffd8a8; stroke-width: 1; }
+
+    /* Vector cells */
+    .vcell       { fill: #ffffff; stroke: #94a3b8; stroke-width: 1; }
+    .vcell-hi    { fill: #ffd8a8; stroke: #e8590c; stroke-width: 1.5; }
+    .vbar        { fill: #cbd5e1; }
+    .vbar-hi     { fill: #e8590c; }
+
+    /* Thread stripe overlays */
+    .stripe      { fill: #5c7cfa; opacity: 0.07; stroke: #5c7cfa; stroke-dasharray: 4 3; stroke-opacity: 0.5; }
+    .stripe-lbl  { font-size: 10px; fill: #364fc7; font-weight: 600; letter-spacing: 0.4px; }
+
+    /* Query */
+    .q-star      { fill: #e03131; stroke: #a61e1e; stroke-width: 1; stroke-linejoin: round; }
+    .q-box       { fill: #fff5f5; stroke: #ffa8a8; }
+
+    /* Distance arrows fan-out */
+    .darr        { stroke: #94a3b8; stroke-width: 0.9; fill: none; opacity: 0.6; }
+    .darr-hi     { stroke: #e8590c; stroke-width: 1.6; fill: none; }
+
+    /* Heap */
+    .heap-box    { fill: #fff4e6; stroke: #ffd8a8; }
+    .heap-slot   { fill: #ffffff; stroke: #e8590c; stroke-width: 1.3; }
+    .heap-num    { font-size: 11px; font-weight: 600; fill: #a14503; }
+
+    .step-badge  { fill: #e8590c; stroke: #ffffff; stroke-width: 2; }
+    .step-num    { fill: #ffffff; font-weight: 700; font-size: 11px; }
+  </style>
+
+  <text class="title"    x="40" y="34">BruteForce</text>
+  <text class="subtitle" x="40" y="52">精确线性扫描 · 与每个存储向量逐一比对 · 可选的查询内并行</text>
+
+  <!-- =========================================================
+       Query column (left)
+       ========================================================= -->
+  <g transform="translate(40, 110)">
+    <rect class="q-box" x="0" y="0" width="120" height="410" rx="10"/>
+    <text class="layer-lbl" x="12" y="20">查询</text>
+
+    <!-- Query star -->
+    <g transform="translate(60, 90)">
+      <polygon class="q-star"
+               points="0,-22 6.5,-7 22,-7 9.5,3 14,18 0,9 -14,18 -9.5,3 -22,-7 -6.5,-7"/>
+    </g>
+    <text class="lbl" x="60" y="125" text-anchor="middle" font-size="13" font-weight="700" fill="#a61e1e">q</text>
+
+    <!-- Note about exactness / parallelism -->
+    <rect class="note-box" x="10" y="160" width="100" height="78" rx="6"/>
+    <text class="lbl" x="60" y="178" text-anchor="middle" font-size="10" font-weight="700" fill="#a14503">精确</text>
+    <text class="lbl-mute" x="60" y="194" text-anchor="middle" font-size="10">当 base_</text>
+    <text class="lbl-mute" x="60" y="207" text-anchor="middle" font-size="10">quantization_type</text>
+    <text class="lbl-mute" x="60" y="220" text-anchor="middle" font-size="10">= fp32</text>
+
+    <!-- parallelism note -->
+    <rect class="band" x="10" y="260" width="100" height="62" rx="6"/>
+    <text class="layer-lbl" x="60" y="278" text-anchor="middle" font-size="10">PARALLELISM</text>
+    <text class="lbl-mute" x="60" y="297" text-anchor="middle" font-size="10">扫描切分</text>
+    <text class="lbl-mute" x="60" y="310" text-anchor="middle" font-size="10">到 N 个线程</text>
+
+    <!-- metric note -->
+    <rect class="band" x="10" y="340" width="100" height="56" rx="6"/>
+    <text class="layer-lbl" x="60" y="358" text-anchor="middle" font-size="10">距离度量</text>
+    <text class="lbl-mute" x="60" y="376" text-anchor="middle" font-size="10">l2 · ip · cosine</text>
+  </g>
+
+  <!-- =========================================================
+       Center panel: flat vector store
+       Panel origin (180, 110), size 420 x 410.
+       ========================================================= -->
+  <g transform="translate(180, 110)">
+    <rect class="band" x="0" y="0" width="420" height="410" rx="10"/>
+    <text class="layer-lbl" x="14" y="20">扁平向量存储</text>
+    <text class="layer-sub" x="120" y="20">一排稠密单元 · 无图 · 无倒排表</text>
+
+    <!-- Thread stripe backgrounds (parallelism = 3 illustration).
+         Each stripe fully encloses its 4 columns (12 cells) with 3px padding.
+         Inside a thread, cells use step=30 (w=28, 2px gap); between threads
+         there is a 14px gap so the stripe boxes do not touch. -->
+    <!-- Stripe 1 (thread 0): columns 0..3, panel-x 21..147 -->
+    <rect class="stripe" x="15" y="56" width="126" height="320" rx="6"/>
+    <text class="stripe-lbl" x="78" y="50" text-anchor="middle">线程 0</text>
+    <!-- Stripe 2 (thread 1): columns 4..7, panel-x 153..279 -->
+    <rect class="stripe" x="147" y="56" width="126" height="320" rx="6"/>
+    <text class="stripe-lbl" x="210" y="50" text-anchor="middle">线程 1</text>
+    <!-- Stripe 3 (thread 2): columns 8..11, panel-x 285..411 -->
+    <rect class="stripe" x="279" y="56" width="126" height="320" rx="6"/>
+    <text class="stripe-lbl" x="342" y="50" text-anchor="middle">线程 2</text>
+
+    <!-- Flat vectors: 4 rows x 10 cols. Each cell shows a tiny bar chart "vector".
+         We highlight a small set as the top-k winners (orange). -->
+    <!-- Helper: cell w=28, h=70, gap=3 horizontally and vertically. Origin (24, 64). -->
+
+    <!-- ROW 0 -->
+    <g transform="translate(18, 64)">
+      <!-- 10 cells per row -->
+      <!-- generate cells inline -->
+      <g transform="translate(0,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="44" width="3" height="22"/>
+        <rect class="vbar" x="9"  y="22" width="3" height="44"/>
+        <rect class="vbar" x="14" y="34" width="3" height="32"/>
+        <rect class="vbar" x="19" y="16" width="3" height="50"/>
+      </g>
+      <g transform="translate(30,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="30" width="3" height="36"/>
+        <rect class="vbar" x="9"  y="40" width="3" height="26"/>
+        <rect class="vbar" x="14" y="14" width="3" height="52"/>
+        <rect class="vbar" x="19" y="36" width="3" height="30"/>
+      </g>
+      <g transform="translate(60,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="20" width="3" height="46"/>
+        <rect class="vbar" x="9"  y="46" width="3" height="20"/>
+        <rect class="vbar" x="14" y="26" width="3" height="40"/>
+        <rect class="vbar" x="19" y="34" width="3" height="32"/>
+      </g>
+      <g transform="translate(90,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="38" width="3" height="28"/>
+        <rect class="vbar" x="9"  y="18" width="3" height="48"/>
+        <rect class="vbar" x="14" y="42" width="3" height="24"/>
+        <rect class="vbar" x="19" y="24" width="3" height="42"/>
+      </g>
+      <g transform="translate(132,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="28" width="3" height="38"/>
+        <rect class="vbar" x="9"  y="38" width="3" height="28"/>
+        <rect class="vbar" x="14" y="20" width="3" height="46"/>
+        <rect class="vbar" x="19" y="40" width="3" height="26"/>
+      </g>
+      <!-- Highlighted winner -->
+      <g transform="translate(162,0)">
+        <rect class="vcell-hi" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar-hi" x="4"  y="18" width="3" height="48"/>
+        <rect class="vbar-hi" x="9"  y="22" width="3" height="44"/>
+        <rect class="vbar-hi" x="14" y="26" width="3" height="40"/>
+        <rect class="vbar-hi" x="19" y="20" width="3" height="46"/>
+      </g>
+      <g transform="translate(192,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="34" width="3" height="32"/>
+        <rect class="vbar" x="9"  y="20" width="3" height="46"/>
+        <rect class="vbar" x="14" y="42" width="3" height="24"/>
+        <rect class="vbar" x="19" y="28" width="3" height="38"/>
+      </g>
+      <g transform="translate(222,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="22" width="3" height="44"/>
+        <rect class="vbar" x="9"  y="36" width="3" height="30"/>
+        <rect class="vbar" x="14" y="18" width="3" height="48"/>
+        <rect class="vbar" x="19" y="40" width="3" height="26"/>
+      </g>
+      <g transform="translate(264,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="40" width="3" height="26"/>
+        <rect class="vbar" x="9"  y="24" width="3" height="42"/>
+        <rect class="vbar" x="14" y="36" width="3" height="30"/>
+        <rect class="vbar" x="19" y="20" width="3" height="46"/>
+      </g>
+      <g transform="translate(294,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="20" width="3" height="46"/>
+        <rect class="vbar" x="9"  y="42" width="3" height="24"/>
+        <rect class="vbar" x="14" y="30" width="3" height="36"/>
+        <rect class="vbar" x="19" y="38" width="3" height="28"/>
+      </g>
+      <g transform="translate(324,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="32" width="3" height="34"/>
+        <rect class="vbar" x="9"  y="46" width="3" height="20"/>
+        <rect class="vbar" x="14" y="24" width="3" height="42"/>
+        <rect class="vbar" x="19" y="36" width="3" height="30"/>
+      </g>
+      <g transform="translate(354,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="26" width="3" height="40"/>
+        <rect class="vbar" x="9"  y="14" width="3" height="52"/>
+        <rect class="vbar" x="14" y="40" width="3" height="26"/>
+        <rect class="vbar" x="19" y="32" width="3" height="34"/>
+      </g>
+    </g>
+
+    <!-- ROW 1 -->
+    <g transform="translate(18, 142)">
+      <g transform="translate(0,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="22" width="3" height="44"/>
+        <rect class="vbar" x="9"  y="44" width="3" height="22"/>
+        <rect class="vbar" x="14" y="18" width="3" height="48"/>
+        <rect class="vbar" x="19" y="40" width="3" height="26"/>
+      </g>
+      <g transform="translate(30,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="32" width="3" height="34"/>
+        <rect class="vbar" x="9"  y="18" width="3" height="48"/>
+        <rect class="vbar" x="14" y="42" width="3" height="24"/>
+        <rect class="vbar" x="19" y="22" width="3" height="44"/>
+      </g>
+      <!-- another winner -->
+      <g transform="translate(60,0)">
+        <rect class="vcell-hi" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar-hi" x="4"  y="22" width="3" height="44"/>
+        <rect class="vbar-hi" x="9"  y="26" width="3" height="40"/>
+        <rect class="vbar-hi" x="14" y="20" width="3" height="46"/>
+        <rect class="vbar-hi" x="19" y="18" width="3" height="48"/>
+      </g>
+      <g transform="translate(90,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="36" width="3" height="30"/>
+        <rect class="vbar" x="9"  y="28" width="3" height="38"/>
+        <rect class="vbar" x="14" y="44" width="3" height="22"/>
+        <rect class="vbar" x="19" y="20" width="3" height="46"/>
+      </g>
+      <g transform="translate(132,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="14" width="3" height="52"/>
+        <rect class="vbar" x="9"  y="42" width="3" height="24"/>
+        <rect class="vbar" x="14" y="32" width="3" height="34"/>
+        <rect class="vbar" x="19" y="38" width="3" height="28"/>
+      </g>
+      <g transform="translate(162,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="44" width="3" height="22"/>
+        <rect class="vbar" x="9"  y="22" width="3" height="44"/>
+        <rect class="vbar" x="14" y="36" width="3" height="30"/>
+        <rect class="vbar" x="19" y="28" width="3" height="38"/>
+      </g>
+      <g transform="translate(192,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="20" width="3" height="46"/>
+        <rect class="vbar" x="9"  y="38" width="3" height="28"/>
+        <rect class="vbar" x="14" y="46" width="3" height="20"/>
+        <rect class="vbar" x="19" y="26" width="3" height="40"/>
+      </g>
+      <g transform="translate(222,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="40" width="3" height="26"/>
+        <rect class="vbar" x="9"  y="18" width="3" height="48"/>
+        <rect class="vbar" x="14" y="30" width="3" height="36"/>
+        <rect class="vbar" x="19" y="42" width="3" height="24"/>
+      </g>
+      <g transform="translate(264,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="24" width="3" height="42"/>
+        <rect class="vbar" x="9"  y="36" width="3" height="30"/>
+        <rect class="vbar" x="14" y="20" width="3" height="46"/>
+        <rect class="vbar" x="19" y="40" width="3" height="26"/>
+      </g>
+      <g transform="translate(294,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="34" width="3" height="32"/>
+        <rect class="vbar" x="9"  y="20" width="3" height="46"/>
+        <rect class="vbar" x="14" y="38" width="3" height="28"/>
+        <rect class="vbar" x="19" y="22" width="3" height="44"/>
+      </g>
+      <!-- another winner -->
+      <g transform="translate(324,0)">
+        <rect class="vcell-hi" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar-hi" x="4"  y="20" width="3" height="46"/>
+        <rect class="vbar-hi" x="9"  y="24" width="3" height="42"/>
+        <rect class="vbar-hi" x="14" y="22" width="3" height="44"/>
+        <rect class="vbar-hi" x="19" y="26" width="3" height="40"/>
+      </g>
+      <g transform="translate(354,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="36" width="3" height="30"/>
+        <rect class="vbar" x="9"  y="46" width="3" height="20"/>
+        <rect class="vbar" x="14" y="22" width="3" height="44"/>
+        <rect class="vbar" x="19" y="34" width="3" height="32"/>
+      </g>
+    </g>
+
+    <!-- ROW 2 -->
+    <g transform="translate(18, 220)">
+      <g transform="translate(0,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="20" width="3" height="46"/>
+        <rect class="vbar" x="9"  y="36" width="3" height="30"/>
+        <rect class="vbar" x="14" y="44" width="3" height="22"/>
+        <rect class="vbar" x="19" y="28" width="3" height="38"/>
+      </g>
+      <g transform="translate(30,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="42" width="3" height="24"/>
+        <rect class="vbar" x="9"  y="26" width="3" height="40"/>
+        <rect class="vbar" x="14" y="14" width="3" height="52"/>
+        <rect class="vbar" x="19" y="38" width="3" height="28"/>
+      </g>
+      <g transform="translate(60,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="34" width="3" height="32"/>
+        <rect class="vbar" x="9"  y="20" width="3" height="46"/>
+        <rect class="vbar" x="14" y="46" width="3" height="20"/>
+        <rect class="vbar" x="19" y="24" width="3" height="42"/>
+      </g>
+      <g transform="translate(90,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="18" width="3" height="48"/>
+        <rect class="vbar" x="9"  y="40" width="3" height="26"/>
+        <rect class="vbar" x="14" y="32" width="3" height="34"/>
+        <rect class="vbar" x="19" y="22" width="3" height="44"/>
+      </g>
+      <g transform="translate(132,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="38" width="3" height="28"/>
+        <rect class="vbar" x="9"  y="22" width="3" height="44"/>
+        <rect class="vbar" x="14" y="44" width="3" height="22"/>
+        <rect class="vbar" x="19" y="36" width="3" height="30"/>
+      </g>
+      <g transform="translate(162,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="22" width="3" height="44"/>
+        <rect class="vbar" x="9"  y="44" width="3" height="22"/>
+        <rect class="vbar" x="14" y="28" width="3" height="38"/>
+        <rect class="vbar" x="19" y="40" width="3" height="26"/>
+      </g>
+      <!-- another winner -->
+      <g transform="translate(192,0)">
+        <rect class="vcell-hi" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar-hi" x="4"  y="24" width="3" height="42"/>
+        <rect class="vbar-hi" x="9"  y="20" width="3" height="46"/>
+        <rect class="vbar-hi" x="14" y="22" width="3" height="44"/>
+        <rect class="vbar-hi" x="19" y="18" width="3" height="48"/>
+      </g>
+      <g transform="translate(222,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="16" width="3" height="50"/>
+        <rect class="vbar" x="9"  y="38" width="3" height="28"/>
+        <rect class="vbar" x="14" y="46" width="3" height="20"/>
+        <rect class="vbar" x="19" y="24" width="3" height="42"/>
+      </g>
+      <g transform="translate(264,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="34" width="3" height="32"/>
+        <rect class="vbar" x="9"  y="46" width="3" height="20"/>
+        <rect class="vbar" x="14" y="20" width="3" height="46"/>
+        <rect class="vbar" x="19" y="36" width="3" height="30"/>
+      </g>
+      <g transform="translate(294,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="44" width="3" height="22"/>
+        <rect class="vbar" x="9"  y="22" width="3" height="44"/>
+        <rect class="vbar" x="14" y="38" width="3" height="28"/>
+        <rect class="vbar" x="19" y="28" width="3" height="38"/>
+      </g>
+      <g transform="translate(324,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="20" width="3" height="46"/>
+        <rect class="vbar" x="9"  y="40" width="3" height="26"/>
+        <rect class="vbar" x="14" y="28" width="3" height="38"/>
+        <rect class="vbar" x="19" y="42" width="3" height="24"/>
+      </g>
+      <g transform="translate(354,0)">
+        <rect class="vcell" x="0" y="0" width="28" height="70" rx="3"/>
+        <rect class="vbar" x="4"  y="32" width="3" height="34"/>
+        <rect class="vbar" x="9"  y="18" width="3" height="48"/>
+        <rect class="vbar" x="14" y="40" width="3" height="26"/>
+        <rect class="vbar" x="19" y="26" width="3" height="40"/>
+      </g>
+    </g>
+
+    <!-- Vector id axis -->
+    <text class="lbl-mute" x="5" y="318" font-size="10">id 0</text>
+    <text class="lbl-mute" x="405" y="318" text-anchor="end" font-size="10">N-1</text>
+    <line x1="15" y1="306" x2="405" y2="306" stroke="#cbd5e1" stroke-width="1"/>
+
+    <!-- "compute distance" sweep arrow -->
+    <text class="lbl-mute" x="210" y="346" text-anchor="middle" font-size="11">扫描每个向量 · 计算 d(q, v_i)</text>
+    <path d="M 15 358 L 405 358" stroke="#5c7cfa" stroke-width="1.4" fill="none" marker-end="url(#scan-arrow)"/>
+
+    <!-- Step badge 1: at the start of the scan -->
+    <circle class="step-badge" cx="13" cy="358" r="11"/>
+    <text class="step-num"    x="13" y="362" text-anchor="middle">1</text>
+  </g>
+
+  <!-- Distance fan-out arrows from q to a sample of cells (to convey "every cell scored").
+       q world position is (40+60, 110+90) = (100, 200). Sample a few cell centers across the grid. -->
+  <g>
+    <!-- highlighted distance lines (to the 3 winners) -->
+    <path class="darr-hi" d="M 102 200 Q 240 178 374 199"/>   <!-- row 0 col 5 (winner) center approx (180+24+155+14, 110+64+35)=(373,209) -->
+    <path class="darr-hi" d="M 102 200 Q 200 256 272 287"/>   <!-- row 1 col 2 winner (180+24+62+14, 110+142+35)=(280,287) -->
+    <path class="darr-hi" d="M 102 200 Q 260 280 404 365"/>   <!-- row 2 col 6 winner (180+24+186+14, 110+220+35)=(404,365) -->
+
+    <!-- faint distance lines to other cells (sample 14) -->
+    <path class="darr" d="M 102 200 L 212 209"/>
+    <path class="darr" d="M 102 200 L 242 209"/>
+    <path class="darr" d="M 102 200 L 302 209"/>
+    <path class="darr" d="M 102 200 L 476 209"/>
+    <path class="darr" d="M 102 200 L 566 209"/>
+    <path class="darr" d="M 102 200 L 212 287"/>
+    <path class="darr" d="M 102 200 L 344 287"/>
+    <path class="darr" d="M 102 200 L 476 287"/>
+    <path class="darr" d="M 102 200 L 566 287"/>
+    <path class="darr" d="M 102 200 L 212 365"/>
+    <path class="darr" d="M 102 200 L 302 365"/>
+    <path class="darr" d="M 102 200 L 476 365"/>
+    <path class="darr" d="M 102 200 L 536 365"/>
+    <path class="darr" d="M 102 200 L 566 365"/>
+  </g>
+
+  <!-- arrow marker for the scan sweep -->
+  <defs>
+    <marker id="scan-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#5c7cfa"/>
+    </marker>
+  </defs>
+
+  <!-- =========================================================
+       Right panel: top-k heap
+       Panel origin (620, 110), size 130 x 410.
+       ========================================================= -->
+  <g transform="translate(610, 110)">
+    <rect class="band" x="0" y="0" width="130" height="410" rx="10"/>
+    <text class="layer-lbl" x="14" y="20">TOP-K 堆</text>
+    <text class="layer-sub" x="14" y="36">最小的 d(q, v_i)</text>
+
+    <!-- Heap slots (k = 5) -->
+    <g transform="translate(15, 56)">
+      <!-- slot 1 (winner) -->
+      <rect class="heap-slot" x="0" y="0" width="100" height="44" rx="6"/>
+      <text class="heap-num" x="14" y="28">#1</text>
+      <text class="lbl-mute" x="44" y="22" font-size="10">id 5</text>
+      <text class="lbl-mute" x="44" y="35" font-size="10">d = 0.12</text>
+
+      <!-- slot 2 -->
+      <rect class="heap-slot" x="0" y="56" width="100" height="44" rx="6"/>
+      <text class="heap-num" x="14" y="84">#2</text>
+      <text class="lbl-mute" x="44" y="78" font-size="10">id 12</text>
+      <text class="lbl-mute" x="44" y="91" font-size="10">d = 0.18</text>
+
+      <!-- slot 3 -->
+      <rect class="heap-slot" x="0" y="112" width="100" height="44" rx="6"/>
+      <text class="heap-num" x="14" y="140">#3</text>
+      <text class="lbl-mute" x="44" y="134" font-size="10">id 28</text>
+      <text class="lbl-mute" x="44" y="147" font-size="10">d = 0.21</text>
+
+      <!-- slot 4 (placeholder, lighter) -->
+      <rect class="heap-slot" x="0" y="168" width="100" height="44" rx="6" opacity="0.55"/>
+      <text class="heap-num" x="14" y="196" opacity="0.55">#4</text>
+      <text class="lbl-mute" x="44" y="190" font-size="10" opacity="0.6">…</text>
+
+      <!-- slot 5 -->
+      <rect class="heap-slot" x="0" y="224" width="100" height="44" rx="6" opacity="0.45"/>
+      <text class="heap-num" x="14" y="252" opacity="0.45">#k</text>
+      <text class="lbl-mute" x="44" y="246" font-size="10" opacity="0.55">…</text>
+    </g>
+
+    <!-- step badge 2: at top of heap -->
+    <circle class="step-badge" cx="105" cy="56" r="11"/>
+    <text class="step-num"    x="105" y="60" text-anchor="middle">2</text>
+
+    <!-- Output label -->
+    <text class="lbl" x="65" y="360" text-anchor="middle" font-size="11" font-weight="600" fill="#a14503">结果</text>
+    <text class="lbl-mute" x="65" y="376" text-anchor="middle" font-size="10">返回 k 个 id</text>
+  </g>
+
+  <!-- =========================================================
+       Bottom legend
+       ========================================================= -->
+  <g transform="translate(40, 553)">
+    <rect class="vcell" x="0" y="-7" width="14" height="14" rx="2"/>
+    <text class="lbl-mute" x="20" y="4">存储向量</text>
+
+    <rect class="vcell-hi" x="100" y="-7" width="14" height="14" rx="2"/>
+    <text class="lbl-mute" x="120" y="4">top-k 命中</text>
+
+    <line x1="208" y1="0" x2="236" y2="0" class="darr-hi"/>
+    <text class="lbl-mute" x="244" y="4">命中向量的距离</text>
+
+    <line x1="368" y1="0" x2="396" y2="0" class="darr"/>
+    <text class="lbl-mute" x="404" y="4">其余向量的距离</text>
+
+    <rect class="stripe" x="528" y="-7" width="14" height="14"/>
+    <text class="lbl-mute" x="548" y="4">并行扫描线程条带</text>
+  </g>
+
+  <!-- Step legend bar at top right -->
+  <g transform="translate(420, 70)">
+    <rect class="note-box" x="0" y="-12" width="320" height="32" rx="6"/>
+    <circle class="step-badge" cx="14" cy="4" r="8"/>
+    <text x="14" y="8" text-anchor="middle" fill="#fff" font-size="9" font-weight="700">1</text>
+    <text class="lbl" x="28" y="8" font-size="11" font-weight="600">为每个向量打分</text>
+
+    <circle class="step-badge" cx="160" cy="4" r="8"/>
+    <text x="160" y="8" text-anchor="middle" fill="#fff" font-size="9" font-weight="700">2</text>
+    <text class="lbl" x="174" y="8" font-size="11" font-weight="600">在 top-k 堆中保留最小</text>
+  </g>
+</svg>

--- a/docs/docs/zh/src/figures/indexes/hgraph-overview.svg
+++ b/docs/docs/zh/src/figures/indexes/hgraph-overview.svg
@@ -1,0 +1,345 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 560" font-family="-apple-system, BlinkMacSystemFont, 'PingFang SC', 'Microsoft YaHei', 'Segoe UI', Helvetica, Arial, sans-serif" font-size="12">
+  <title>HGraph 索引示意图</title>
+  <desc>HGraph 将向量组织成多层近邻图。一个向量可能同时出现在若干层中；上层稀疏，作为跳表式的导航层；最底层包含所有向量，每个点最多保留 max_degree 个邻居。检索从固定的顶层入口进入，逐层贪心跳到距离查询点最近的邻居，到达局部最小时下沉一层；在最底层用 ef_search 大小的束在查询点附近扩展，直至收敛到 topk 个最近邻。可选的精排步骤会用高精度副本对候选重新打分。</desc>
+
+  <defs>
+    <marker id="arrow-search" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#e8590c"/>
+    </marker>
+  </defs>
+
+  <style>
+    .title    { fill: #1a1a1a; font-size: 16px; font-weight: 600; }
+    .subtitle { fill: #6b7280; font-size: 12px; }
+    .lbl      { fill: #1f2937; }
+    .lbl-mute { fill: #6b7280; }
+    .layer-lbl { fill: #475569; font-size: 11px; font-weight: 600; letter-spacing: 0.6px; }
+    .layer-sub { fill: #94a3b8; font-size: 11px; }
+
+    .band       { fill: #f8fafc; stroke: #e2e8f0; stroke-width: 1; }
+    .band-top   { fill: #f1f5f9; stroke: #e2e8f0; stroke-width: 1; }
+
+    .node       { fill: #ffffff; stroke: #94a3b8; stroke-width: 1; }
+    .node-hi    { fill: #ffffff; stroke: #5c7cfa; stroke-width: 1.3; }
+    .node-entry { fill: #5c7cfa; stroke: #364fc7; stroke-width: 1.4; }
+    .node-visit { fill: #ffd8a8; stroke: #e8590c; stroke-width: 1.5; }
+    .node-result{ fill: #e03131; stroke: #a61e1e; stroke-width: 1.4; }
+
+    .edge        { stroke: #cbd5e1; stroke-width: 0.8; fill: none; }
+    .edge-hi     { stroke: #5c7cfa; stroke-width: 1.1; fill: none; opacity: 0.75; }
+    .crosslink   { stroke: #94a3b8; stroke-width: 0.9; fill: none; stroke-dasharray: 2 3; opacity: 0.8; }
+    .frontier    { fill: #fff4e6; stroke: #e8590c; stroke-width: 1; stroke-dasharray: 4 3; opacity: 0.85; }
+    .search      { stroke: #e8590c; stroke-width: 2; fill: none; stroke-linecap: round; }
+    .descent     { stroke: #e8590c; stroke-width: 2; fill: none; stroke-dasharray: 4 3; stroke-linecap: round; }
+
+    .step-badge  { fill: #e8590c; stroke: #ffffff; stroke-width: 2; }
+    .step-num    { fill: #ffffff; font-size: 11px; font-weight: 700; }
+
+    .note-box    { fill: #ffffff; stroke: #e2e8f0; stroke-width: 1; }
+  </style>
+
+  <!-- Header -->
+  <text class="title"    x="40" y="34">HGraph</text>
+  <text class="subtitle" x="40" y="52">多层近邻图 · 贪心下降 · 在第 0 层用 ef_search 束搜索</text>
+
+  <!--
+    Layer-2 node x positions (panel origin 40,80):
+      60 (entry), 190, 330, 460
+    L2 panel y=80..190 (height 110), nodes at panel-y 48 or 70.
+    L1 panel y=210..320 (height 110), nodes at panel-y 50 or 78.
+    L0 panel y=340..540 (height 200), nodes at panel-y 55..185.
+
+    Query q is at panel x=395, panel y=115 in L0 → svg (435, 455).
+    The ghost-q indicator on upper layers sits at panel x=395.
+  -->
+
+  <!-- =========================================================
+       Layer 2 (top, sparse)
+       ========================================================= -->
+  <g transform="translate(40, 80)">
+    <rect class="band-top" x="0" y="0" width="540" height="110" rx="10"/>
+    <text class="layer-lbl" x="14" y="20">第 2 层</text>
+    <text class="layer-sub" x="68" y="20">稀疏 · 长距离跳跃 · 入口层</text>
+
+    <line class="edge-hi" x1="60"  y1="70" x2="190" y2="48"/>
+    <line class="edge-hi" x1="190" y1="48" x2="330" y2="72"/>
+    <line class="edge-hi" x1="330" y1="72" x2="460" y2="50"/>
+    <line class="edge-hi" x1="190" y1="48" x2="460" y2="50"/>
+
+    <!-- ghost-q hint (small open star) -->
+    <polygon points="395,68 396.6,72 401,72 397.5,74.5 398.7,79 395,76.3 391.3,79 392.5,74.5 389,72 393.4,72"
+             fill="none" stroke="#e03131" stroke-width="1" stroke-dasharray="2 2" opacity="0.6"/>
+
+    <!-- nodes -->
+    <circle class="node-entry" cx="60"  cy="70" r="7"/>
+    <circle class="node-visit" cx="190" cy="48" r="6"/>   <!-- L2 local-min -->
+    <circle class="node-hi"    cx="330" cy="72" r="5.5"/>
+    <circle class="node-hi"    cx="460" cy="50" r="5.5"/>
+
+    <text class="lbl" x="60" y="92" text-anchor="middle" font-size="11" fill="#364fc7" font-weight="600">入口</text>
+
+    <!-- search through layer 2: enter → hop to nearest-to-q (190,48) -->
+    <path class="search" d="M 60 70 Q 130 30 190 48"/>
+  </g>
+
+  <!-- Descent L2 → L1 at x=190 (panel local-min) -->
+  <path class="descent" d="M 230 158 L 230 258"/>
+
+  <!-- =========================================================
+       Layer 1 (middle)
+       ========================================================= -->
+  <g transform="translate(40, 210)">
+    <rect class="band" x="0" y="0" width="540" height="110" rx="10"/>
+    <text class="layer-lbl" x="14" y="20">第 1 层</text>
+    <text class="layer-sub" x="68" y="20">中间层 · 中距离跳跃</text>
+
+    <line class="edge-hi" x1="60"  y1="70" x2="135" y2="50"/>
+    <line class="edge-hi" x1="135" y1="50" x2="190" y2="78"/>
+    <line class="edge-hi" x1="190" y1="78" x2="265" y2="50"/>
+    <line class="edge-hi" x1="265" y1="50" x2="330" y2="72"/>
+    <line class="edge-hi" x1="330" y1="72" x2="395" y2="50"/>
+    <line class="edge-hi" x1="395" y1="50" x2="460" y2="76"/>
+    <line class="edge-hi" x1="135" y1="50" x2="265" y2="50"/>
+    <line class="edge-hi" x1="265" y1="50" x2="395" y2="50"/>
+
+    <!-- ghost-q hint -->
+    <polygon points="395,68 396.6,72 401,72 397.5,74.5 398.7,79 395,76.3 391.3,79 392.5,74.5 389,72 393.4,72"
+             fill="none" stroke="#e03131" stroke-width="1" stroke-dasharray="2 2" opacity="0.6"/>
+
+    <!-- nodes -->
+    <circle class="node-hi"    cx="60"  cy="70" r="5"/>
+    <circle class="node-hi"    cx="135" cy="50" r="5"/>
+    <circle class="node-hi"    cx="190" cy="78" r="5"/>
+    <circle class="node-hi"    cx="265" cy="50" r="5"/>
+    <circle class="node-hi"    cx="330" cy="72" r="5"/>
+    <circle class="node-visit" cx="395" cy="50" r="6"/>  <!-- L1 local-min closest to q -->
+    <circle class="node-hi"    cx="460" cy="76" r="5"/>
+
+    <!-- search through layer 1: from descent landing at (190,78) → (265,50) → (395,50) -->
+    <path class="search" d="M 190 78 Q 230 40 265 50 T 395 50"/>
+  </g>
+
+  <!-- Cross-layer dashed links (same vector at the same xy across multiple layers) -->
+  <!-- L2 (x,y): (60,150),(190,128),(330,152),(460,130) ; L1 same x at y +130 -->
+  <line class="crosslink" x1="100" y1="150" x2="100" y2="280"/>  <!-- 60 entry -->
+  <line class="crosslink" x1="230" y1="128" x2="230" y2="288"/>  <!-- 190 -->
+  <line class="crosslink" x1="370" y1="152" x2="370" y2="282"/>  <!-- 330 -->
+  <line class="crosslink" x1="500" y1="130" x2="500" y2="286"/>  <!-- 460 -->
+  <!-- L1 → L0 same-xy dashes for the four L2 anchors + the 395 anchor where q lives -->
+  <line class="crosslink" x1="100" y1="280" x2="100" y2="450"/>
+  <line class="crosslink" x1="230" y1="288" x2="230" y2="448"/>
+  <line class="crosslink" x1="370" y1="282" x2="370" y2="450"/>
+  <line class="crosslink" x1="500" y1="286" x2="500" y2="450"/>
+  <line class="crosslink" x1="435" y1="260" x2="435" y2="410"/>  <!-- L1 (395,50) → L0 (395,70) -->
+
+  <!-- Descent L1 → L0 at x=395 (L1 local-min). Starts just below L1 node, ends just above the L0 landing node. -->
+  <path class="descent" d="M 435 266 L 435 408"/>
+
+  <!-- =========================================================
+       Layer 0 (bottom, dense)
+       ========================================================= -->
+  <g transform="translate(40, 340)">
+    <rect class="band" x="0" y="0" width="540" height="200" rx="10"/>
+    <text class="layer-lbl" x="14" y="20">第 0 层</text>
+    <text class="layer-sub" x="68" y="20">稠密 · 每个向量 · 每点最多 max_degree 邻居 · ef_search 束</text>
+
+    <!-- ef_search frontier (drawn first, behind nodes) -->
+    <ellipse class="frontier" cx="395" cy="100" rx="58" ry="42"/>
+
+    <!-- proximity edges -->
+    <line class="edge" x1="60"  y1="110" x2="95"  y2="85"/>
+    <line class="edge" x1="60"  y1="110" x2="80"  y2="148"/>
+    <line class="edge" x1="95"  y1="85"  x2="135" y2="68"/>
+    <line class="edge" x1="95"  y1="85"  x2="130" y2="110"/>
+    <line class="edge" x1="80"  y1="148" x2="130" y2="160"/>
+    <line class="edge" x1="130" y1="110" x2="135" y2="68"/>
+    <line class="edge" x1="130" y1="110" x2="170" y2="135"/>
+    <line class="edge" x1="130" y1="160" x2="170" y2="135"/>
+    <line class="edge" x1="135" y1="68"  x2="195" y2="55"/>
+    <line class="edge" x1="170" y1="135" x2="210" y2="105"/>
+    <line class="edge" x1="170" y1="135" x2="200" y2="170"/>
+    <line class="edge" x1="195" y1="55"  x2="250" y2="70"/>
+    <line class="edge" x1="195" y1="55"  x2="210" y2="105"/>
+    <line class="edge" x1="210" y1="105" x2="250" y2="70"/>
+    <line class="edge" x1="210" y1="105" x2="255" y2="135"/>
+    <line class="edge" x1="200" y1="170" x2="255" y2="135"/>
+    <line class="edge" x1="200" y1="170" x2="245" y2="175"/>
+    <line class="edge" x1="250" y1="70"  x2="305" y2="60"/>
+    <line class="edge" x1="250" y1="70"  x2="295" y2="105"/>
+    <line class="edge" x1="255" y1="135" x2="295" y2="105"/>
+    <line class="edge" x1="255" y1="135" x2="300" y2="150"/>
+    <line class="edge" x1="245" y1="175" x2="300" y2="150"/>
+    <line class="edge" x1="245" y1="175" x2="295" y2="178"/>
+    <line class="edge" x1="305" y1="60"  x2="345" y2="78"/>
+    <line class="edge" x1="305" y1="60"  x2="360" y2="55"/>
+    <line class="edge" x1="295" y1="105" x2="345" y2="78"/>
+    <line class="edge" x1="295" y1="105" x2="345" y2="120"/>
+    <line class="edge" x1="300" y1="150" x2="345" y2="120"/>
+    <line class="edge" x1="300" y1="150" x2="355" y2="155"/>
+    <line class="edge" x1="295" y1="178" x2="355" y2="155"/>
+    <line class="edge" x1="295" y1="178" x2="345" y2="185"/>
+    <line class="edge" x1="345" y1="78"  x2="395" y2="70"/>
+    <line class="edge" x1="345" y1="78"  x2="395" y2="105"/>
+    <line class="edge" x1="345" y1="120" x2="395" y2="105"/>
+    <line class="edge" x1="345" y1="120" x2="395" y2="135"/>
+    <line class="edge" x1="355" y1="155" x2="395" y2="135"/>
+    <line class="edge" x1="355" y1="155" x2="405" y2="160"/>
+    <line class="edge" x1="345" y1="185" x2="405" y2="160"/>
+    <line class="edge" x1="360" y1="55"  x2="395" y2="70"/>
+    <line class="edge" x1="360" y1="55"  x2="425" y2="55"/>
+    <line class="edge" x1="395" y1="70"  x2="425" y2="55"/>
+    <line class="edge" x1="395" y1="70"  x2="445" y2="80"/>
+    <line class="edge" x1="395" y1="105" x2="445" y2="80"/>
+    <line class="edge" x1="395" y1="105" x2="445" y2="115"/>
+    <line class="edge" x1="395" y1="135" x2="445" y2="115"/>
+    <line class="edge" x1="395" y1="135" x2="445" y2="148"/>
+    <line class="edge" x1="405" y1="160" x2="445" y2="148"/>
+    <line class="edge" x1="405" y1="160" x2="450" y2="178"/>
+    <line class="edge" x1="425" y1="55"  x2="475" y2="65"/>
+    <line class="edge" x1="445" y1="80"  x2="475" y2="65"/>
+    <line class="edge" x1="445" y1="80"  x2="495" y2="100"/>
+    <line class="edge" x1="445" y1="115" x2="495" y2="100"/>
+    <line class="edge" x1="445" y1="115" x2="495" y2="130"/>
+    <line class="edge" x1="445" y1="148" x2="495" y2="130"/>
+    <line class="edge" x1="445" y1="148" x2="490" y2="170"/>
+    <line class="edge" x1="450" y1="178" x2="490" y2="170"/>
+    <line class="edge" x1="475" y1="65"  x2="510" y2="85"/>
+    <line class="edge" x1="495" y1="100" x2="510" y2="85"/>
+    <line class="edge" x1="495" y1="100" x2="515" y2="135"/>
+    <line class="edge" x1="495" y1="130" x2="515" y2="135"/>
+    <line class="edge" x1="495" y1="130" x2="510" y2="165"/>
+    <line class="edge" x1="490" y1="170" x2="510" y2="165"/>
+
+    <!-- plain nodes -->
+    <circle class="node" cx="60"  cy="110" r="4"/>
+    <circle class="node" cx="95"  cy="85"  r="4"/>
+    <circle class="node" cx="80"  cy="148" r="4"/>
+    <circle class="node" cx="135" cy="68"  r="4"/>
+    <circle class="node" cx="130" cy="110" r="4"/>
+    <circle class="node" cx="130" cy="160" r="4"/>
+    <circle class="node" cx="170" cy="135" r="4"/>
+    <circle class="node" cx="195" cy="55"  r="4"/>
+    <circle class="node" cx="210" cy="105" r="4"/>
+    <circle class="node" cx="200" cy="170" r="4"/>
+    <circle class="node" cx="250" cy="70"  r="4"/>
+    <circle class="node" cx="255" cy="135" r="4"/>
+    <circle class="node" cx="245" cy="175" r="4"/>
+    <circle class="node" cx="305" cy="60"  r="4"/>
+    <circle class="node" cx="295" cy="105" r="4"/>
+    <circle class="node" cx="300" cy="150" r="4"/>
+    <circle class="node" cx="295" cy="178" r="4"/>
+    <circle class="node" cx="345" cy="78"  r="4"/>
+    <circle class="node" cx="345" cy="185" r="4"/>
+    <circle class="node" cx="355" cy="155" r="4"/>
+    <circle class="node" cx="360" cy="55"  r="4"/>
+    <circle class="node" cx="425" cy="55"  r="4"/>
+    <circle class="node" cx="445" cy="80"  r="4"/>
+    <circle class="node" cx="445" cy="148" r="4"/>
+    <circle class="node" cx="450" cy="178" r="4"/>
+    <circle class="node" cx="475" cy="65"  r="4"/>
+    <circle class="node" cx="510" cy="85"  r="4"/>
+    <circle class="node" cx="495" cy="130" r="4"/>
+    <circle class="node" cx="490" cy="170" r="4"/>
+    <circle class="node" cx="510" cy="165" r="4"/>
+    <circle class="node" cx="515" cy="135" r="4"/>
+
+    <!-- visited along the last-mile search -->
+    <circle class="node-visit" cx="395" cy="70"  r="5.4"/>  <!-- landing from L1 -->
+    <circle class="node-visit" cx="345" cy="120" r="5.4"/>
+    <circle class="node-visit" cx="395" cy="135" r="5.4"/>
+    <circle class="node-visit" cx="445" cy="115" r="5.4"/>
+
+    <!-- nearest neighbour (the topk-1 result, closest node to q) -->
+    <circle class="node-result" cx="395" cy="105" r="5.6"/>
+
+    <!-- query star: q is a point in the embedding space, placed inside the frontier -->
+    <polygon points="420,110 422.6,116.4 429.5,116.4 424,120.4 426.2,127 420,122.7 413.8,127 416,120.4 410.5,116.4 417.4,116.4"
+             fill="#e03131" stroke="#a61e1e" stroke-width="1.1" stroke-linejoin="round"/>
+    <text class="lbl" x="420" y="142" text-anchor="middle" font-size="11" font-weight="700" fill="#a61e1e">q</text>
+
+    <!-- last-mile search path on layer 0: lands at (395,70) → ... → nearest neighbour (395,105) -->
+    <path class="search" d="M 395 70 Q 360 95 345 120 T 395 135 T 395 105" marker-end="url(#arrow-search)"/>
+
+    <!-- ef_search caption -->
+    <text class="lbl-mute" x="395" y="178" text-anchor="middle" font-size="11">ef_search 候选区</text>
+  </g>
+
+  <!-- Step badges placed along the search trajectory (svg coords) -->
+  <g>
+    <!-- 1: enter top  (just right of entry vertex, svg (60+10, 150-12) ) -->
+    <circle class="step-badge" cx="78" cy="138" r="11"/>
+    <text class="step-num"    x="78" y="142" text-anchor="middle">1</text>
+
+    <!-- 2: descent — placed beside the descent dash at x≈230, y≈208 -->
+    <circle class="step-badge" cx="246" cy="208" r="11"/>
+    <text class="step-num"    x="246" y="212" text-anchor="middle">2</text>
+
+    <!-- 3: beam — placed in upper-right of L0 panel, outside the frontier ellipse -->
+    <circle class="step-badge" cx="525" cy="370" r="11"/>
+    <text class="step-num"    x="525" y="374" text-anchor="middle">3</text>
+  </g>
+
+  <!-- =========================================================
+       Right-side legend / annotations
+       ========================================================= -->
+  <g transform="translate(600, 92)">
+    <g>
+      <circle class="step-badge" cx="10" cy="10" r="9"/>
+      <text x="10" y="14" text-anchor="middle" fill="#fff" font-size="10" font-weight="700">1</text>
+      <text class="lbl" x="28" y="8" font-weight="600">从顶层进入</text>
+      <text class="lbl-mute" x="28" y="22" font-size="11">固定的入口顶点</text>
+    </g>
+
+    <g transform="translate(0, 44)">
+      <circle class="step-badge" cx="10" cy="10" r="9"/>
+      <text x="10" y="14" text-anchor="middle" fill="#fff" font-size="10" font-weight="700">2</text>
+      <text class="lbl" x="28" y="8" font-weight="600">贪心下降</text>
+      <text class="lbl-mute" x="28" y="22" font-size="11">每跳到最近邻居；</text>
+      <text class="lbl-mute" x="28" y="36" font-size="11">到达局部最小则下沉一层</text>
+    </g>
+
+    <g transform="translate(0, 102)">
+      <circle class="step-badge" cx="10" cy="10" r="9"/>
+      <text x="10" y="14" text-anchor="middle" fill="#fff" font-size="10" font-weight="700">3</text>
+      <text class="lbl" x="28" y="8" font-weight="600">第 0 层束搜索</text>
+      <text class="lbl-mute" x="28" y="22" font-size="11">扩展 ef_search 候选</text>
+      <text class="lbl-mute" x="28" y="36" font-size="11">→ 返回距离 q 最近的 topk</text>
+    </g>
+
+    <g transform="translate(0, 168)">
+      <rect class="note-box" x="0" y="0" width="160" height="92" rx="6"/>
+      <text class="layer-lbl" x="10" y="18" font-size="10">存储</text>
+      <text class="lbl-mute"  x="10" y="36" font-size="11">base_quantization_type：</text>
+      <text class="lbl"       x="10" y="50" font-size="11">sq8 · pq · rabitq · fp16 · ...</text>
+
+      <line x1="10" y1="58" x2="150" y2="58" stroke="#e2e8f0"/>
+
+      <text class="layer-lbl" x="10" y="74" font-size="10">精排（可选）</text>
+      <text class="lbl-mute"  x="10" y="88" font-size="11">use_reorder + 高精度编码</text>
+    </g>
+  </g>
+
+  <!-- =========================================================
+       Bottom legend
+       ========================================================= -->
+  <g transform="translate(40, 553)">
+    <circle class="node-entry" cx="6" cy="0" r="6"/>
+    <text class="lbl-mute" x="18" y="4">入口</text>
+
+    <circle class="node-visit" cx="64" cy="0" r="6"/>
+    <text class="lbl-mute" x="76" y="4">访问节点</text>
+
+    <polygon points="158,-6.2 160.2,-1.4 165.5,-1.4 161.2,1.6 162.8,6.2 158,3.2 153.2,6.2 154.8,1.6 150.5,-1.4 155.8,-1.4"
+             fill="#e03131" stroke="#a61e1e" stroke-width="1" stroke-linejoin="round"/>
+    <text class="lbl-mute" x="172" y="4">查询 q</text>
+
+    <circle class="node-result" cx="232" cy="0" r="6"/>
+    <text class="lbl-mute" x="244" y="4">最近邻</text>
+
+    <line class="search" x1="316" y1="0" x2="346" y2="0" marker-end="url(#arrow-search)"/>
+    <text class="lbl-mute" x="352" y="4">检索路径</text>
+
+    <line class="crosslink" x1="436" y1="0" x2="466" y2="0"/>
+    <text class="lbl-mute" x="472" y="4">同一向量的跨层副本</text>
+  </g>
+</svg>

--- a/docs/docs/zh/src/figures/indexes/ivf-overview.svg
+++ b/docs/docs/zh/src/figures/indexes/ivf-overview.svg
@@ -1,0 +1,284 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 560" font-family="-apple-system, BlinkMacSystemFont, 'PingFang SC', 'Microsoft YaHei', 'Segoe UI', Helvetica, Arial, sans-serif" font-size="12">
+  <title>IVF 索引示意图</title>
+  <desc>IVF 将嵌入空间按 k-means 中心划分成 buckets_count 个 Voronoi 单元（桶），每条基向量以配置的粗量化形式写入距离最近的中心对应的倒排列表。查询时先选出与 q 距离最近的 scan_buckets_count 个中心，只对这些桶内的向量打分，启用精排时再对 factor*topk 个粗排候选用高精度副本重打分得到最终 topk。</desc>
+
+  <defs>
+    <marker id="arrow-search" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#e8590c"/>
+    </marker>
+    <clipPath id="space-clip">
+      <rect x="0" y="0" width="540" height="380" rx="10"/>
+    </clipPath>
+  </defs>
+
+  <style>
+    .title    { fill: #1a1a1a; font-size: 16px; font-weight: 600; }
+    .subtitle { fill: #6b7280; font-size: 12px; }
+    .lbl      { fill: #1f2937; }
+    .lbl-mute { fill: #6b7280; }
+    .layer-lbl { fill: #475569; font-size: 11px; font-weight: 600; letter-spacing: 0.6px; }
+    .layer-sub { fill: #94a3b8; font-size: 11px; }
+
+    .band       { fill: #f8fafc; stroke: #e2e8f0; stroke-width: 1; }
+
+    /* Voronoi cells */
+    .cell        { fill: #ffffff; stroke: #cbd5e1; stroke-width: 1; }
+    .cell-hi     { fill: #fff4e6; stroke: #e8590c; stroke-width: 1.4; }
+
+    /* Base vectors (small dots) */
+    .pt          { fill: #94a3b8; stroke: none; }
+    .pt-hi       { fill: #ffd8a8; stroke: #e8590c; stroke-width: 1; }
+    .pt-result   { fill: #e03131; stroke: #a61e1e; stroke-width: 1.2; }
+
+    /* Centroids */
+    .centroid    { fill: #5c7cfa; stroke: #364fc7; stroke-width: 1.4; }
+    .centroid-hi { fill: #e8590c; stroke: #a14503; stroke-width: 1.5; }
+
+    .probe       { stroke: #e8590c; stroke-width: 1.4; fill: none; stroke-dasharray: 4 3; stroke-linecap: round; opacity: 0.85; }
+    .search      { stroke: #e8590c; stroke-width: 2; fill: none; stroke-linecap: round; }
+
+    .step-badge  { fill: #e8590c; stroke: #ffffff; stroke-width: 2; }
+    .step-num    { fill: #ffffff; font-size: 11px; font-weight: 700; }
+
+    .note-box    { fill: #ffffff; stroke: #e2e8f0; stroke-width: 1; }
+  </style>
+
+  <!-- Header -->
+  <text class="title"    x="40" y="34">IVF</text>
+  <text class="subtitle" x="40" y="52">基于中心的 Voronoi 分桶 · 仅扫描距离 q 最近的 scan_buckets_count 个桶</text>
+
+  <!-- =========================================================
+       Embedding space panel (Voronoi diagram)
+       Panel origin: (40, 80), size 540 x 380.
+       Centroids (panel coords):
+         c0 ( 95,  75)
+         c1 (245,  55)
+         c2 (415,  90)
+         c3 ( 75, 210)
+         c4 (215, 175)  [highlighted]
+         c5 (370, 195)  [highlighted, contains q]
+         c6 ( 90, 330)
+         c7 (260, 320)  [highlighted, neighbour cell]
+         c8 (440, 305)
+       Cells are drawn as hand-crafted convex polygons that
+       approximately tile the panel.
+       ========================================================= -->
+  <g transform="translate(40, 80)">
+    <rect class="band" x="0" y="0" width="540" height="380" rx="10"/>
+    <text class="layer-lbl" x="14" y="20">嵌入空间</text>
+    <text class="layer-sub" x="100" y="20">共 buckets_count 个单元 · 每个单元一个中心</text>
+
+    <g clip-path="url(#space-clip)">
+      <!-- Voronoi-like cells. The three highlighted cells (c4, c5, c7) sit in the middle band. -->
+      <!-- c0 top-left -->
+      <polygon class="cell" points="0,40 170,40 165,125 30,140 0,135"/>
+      <!-- c1 top-center -->
+      <polygon class="cell" points="170,40 335,40 330,130 165,125"/>
+      <!-- c2 top-right -->
+      <polygon class="cell" points="335,40 540,40 540,150 340,140 330,130"/>
+      <!-- c3 mid-left -->
+      <polygon class="cell" points="0,135 30,140 165,125 150,255 25,260 0,255"/>
+      <!-- c4 mid-center (highlighted) -->
+      <polygon class="cell-hi" points="165,125 330,130 320,250 150,255"/>
+      <!-- c5 mid-right (highlighted, contains q) -->
+      <polygon class="cell-hi" points="330,130 340,140 540,150 540,270 325,260 320,250"/>
+      <!-- c6 bottom-left -->
+      <polygon class="cell" points="0,255 25,260 150,255 165,380 0,380"/>
+      <!-- c7 bottom-center (highlighted, holds nearest neighbour) -->
+      <polygon class="cell-hi" points="150,255 320,250 325,260 350,380 165,380"/>
+      <!-- c8 bottom-right -->
+      <polygon class="cell" points="325,260 540,270 540,380 350,380"/>
+    </g>
+
+    <!-- ============ base vectors (panel coords) ============ -->
+    <!-- c0 -->
+    <circle class="pt" cx="50"  cy="60"  r="2.5"/>
+    <circle class="pt" cx="80"  cy="85"  r="2.5"/>
+    <circle class="pt" cx="115" cy="62"  r="2.5"/>
+    <circle class="pt" cx="130" cy="95"  r="2.5"/>
+    <circle class="pt" cx="60"  cy="105" r="2.5"/>
+    <circle class="pt" cx="100" cy="115" r="2.5"/>
+    <!-- c1 -->
+    <circle class="pt" cx="200" cy="55"  r="2.5"/>
+    <circle class="pt" cx="225" cy="80"  r="2.5"/>
+    <circle class="pt" cx="260" cy="60"  r="2.5"/>
+    <circle class="pt" cx="290" cy="85"  r="2.5"/>
+    <circle class="pt" cx="245" cy="100" r="2.5"/>
+    <circle class="pt" cx="195" cy="100" r="2.5"/>
+    <circle class="pt" cx="305" cy="110" r="2.5"/>
+    <!-- c2 -->
+    <circle class="pt" cx="365" cy="65"  r="2.5"/>
+    <circle class="pt" cx="395" cy="80"  r="2.5"/>
+    <circle class="pt" cx="430" cy="58"  r="2.5"/>
+    <circle class="pt" cx="465" cy="90"  r="2.5"/>
+    <circle class="pt" cx="500" cy="72"  r="2.5"/>
+    <circle class="pt" cx="445" cy="115" r="2.5"/>
+    <circle class="pt" cx="385" cy="115" r="2.5"/>
+    <circle class="pt" cx="510" cy="115" r="2.5"/>
+    <!-- c3 -->
+    <circle class="pt" cx="40"  cy="170" r="2.5"/>
+    <circle class="pt" cx="75"  cy="195" r="2.5"/>
+    <circle class="pt" cx="110" cy="180" r="2.5"/>
+    <circle class="pt" cx="55"  cy="225" r="2.5"/>
+    <circle class="pt" cx="115" cy="230" r="2.5"/>
+    <circle class="pt" cx="135" cy="200" r="2.5"/>
+    <!-- c4 (highlighted) -->
+    <circle class="pt-hi" cx="195" cy="155" r="2.8"/>
+    <circle class="pt-hi" cx="225" cy="170" r="2.8"/>
+    <circle class="pt-hi" cx="260" cy="155" r="2.8"/>
+    <circle class="pt-hi" cx="290" cy="175" r="2.8"/>
+    <circle class="pt-hi" cx="190" cy="205" r="2.8"/>
+    <circle class="pt-hi" cx="240" cy="215" r="2.8"/>
+    <circle class="pt-hi" cx="285" cy="220" r="2.8"/>
+    <circle class="pt-hi" cx="220" cy="235" r="2.8"/>
+    <!-- c5 (highlighted, contains q) -->
+    <circle class="pt-hi" cx="360" cy="155" r="2.8"/>
+    <circle class="pt-hi" cx="395" cy="170" r="2.8"/>
+    <circle class="pt-hi" cx="430" cy="158" r="2.8"/>
+    <circle class="pt-hi" cx="475" cy="180" r="2.8"/>
+    <circle class="pt-hi" cx="505" cy="200" r="2.8"/>
+    <circle class="pt-hi" cx="360" cy="215" r="2.8"/>
+    <circle class="pt-hi" cx="445" cy="220" r="2.8"/>
+    <circle class="pt-hi" cx="490" cy="240" r="2.8"/>
+    <circle class="pt-hi" cx="400" cy="240" r="2.8"/>
+    <!-- c6 -->
+    <circle class="pt" cx="50"  cy="290" r="2.5"/>
+    <circle class="pt" cx="85"  cy="310" r="2.5"/>
+    <circle class="pt" cx="120" cy="295" r="2.5"/>
+    <circle class="pt" cx="60"  cy="345" r="2.5"/>
+    <circle class="pt" cx="110" cy="350" r="2.5"/>
+    <circle class="pt" cx="135" cy="325" r="2.5"/>
+    <!-- c7 (highlighted) -->
+    <circle class="pt-hi" cx="195" cy="290" r="2.8"/>
+    <circle class="pt-hi" cx="230" cy="305" r="2.8"/>
+    <circle class="pt-hi" cx="270" cy="295" r="2.8"/>
+    <circle class="pt-hi" cx="310" cy="315" r="2.8"/>
+    <circle class="pt-hi" cx="205" cy="345" r="2.8"/>
+    <circle class="pt-hi" cx="250" cy="355" r="2.8"/>
+    <circle class="pt-hi" cx="300" cy="350" r="2.8"/>
+    <!-- c8 -->
+    <circle class="pt" cx="380" cy="295" r="2.5"/>
+    <circle class="pt" cx="420" cy="280" r="2.5"/>
+    <circle class="pt" cx="460" cy="300" r="2.5"/>
+    <circle class="pt" cx="500" cy="285" r="2.5"/>
+    <circle class="pt" cx="395" cy="335" r="2.5"/>
+    <circle class="pt" cx="445" cy="345" r="2.5"/>
+    <circle class="pt" cx="490" cy="335" r="2.5"/>
+    <circle class="pt" cx="515" cy="315" r="2.5"/>
+
+    <!-- ============ centroids ============ -->
+    <circle class="centroid"    cx="95"  cy="75"  r="6"/>
+    <circle class="centroid"    cx="245" cy="55"  r="6"/>
+    <circle class="centroid"    cx="415" cy="90"  r="6"/>
+    <circle class="centroid"    cx="75"  cy="210" r="6"/>
+    <circle class="centroid-hi" cx="240" cy="190" r="7"/>
+    <circle class="centroid-hi" cx="425" cy="200" r="7"/>
+    <circle class="centroid"    cx="90"  cy="330" r="6"/>
+    <circle class="centroid-hi" cx="255" cy="325" r="7"/>
+    <circle class="centroid"    cx="445" cy="320" r="6"/>
+
+    <!-- centroid labels -->
+    <text class="lbl-mute" x="95"  y="92"  text-anchor="middle" font-size="10">c0</text>
+    <text class="lbl-mute" x="245" y="42"  text-anchor="middle" font-size="10">c1</text>
+    <text class="lbl-mute" x="415" y="107" text-anchor="middle" font-size="10">c2</text>
+    <text class="lbl-mute" x="75"  y="227" text-anchor="middle" font-size="10">c3</text>
+    <text class="lbl"      x="240" y="207" text-anchor="middle" font-size="10" font-weight="700" fill="#a14503">c4</text>
+    <text class="lbl"      x="425" y="217" text-anchor="middle" font-size="10" font-weight="700" fill="#a14503">c5</text>
+    <text class="lbl-mute" x="90"  y="347" text-anchor="middle" font-size="10">c6</text>
+    <text class="lbl"      x="255" y="342" text-anchor="middle" font-size="10" font-weight="700" fill="#a14503">c7</text>
+    <text class="lbl-mute" x="445" y="337" text-anchor="middle" font-size="10">c8</text>
+
+    <!-- ============ query q ============ -->
+    <!-- q sits inside cell c5, near its boundary with c4/c7 -->
+    <polygon points="345,205 347.9,212.1 355.5,212.1 349.4,216.5 351.7,223.6 345,219.2 338.3,223.6 340.6,216.5 334.5,212.1 342.1,212.1"
+             fill="#e03131" stroke="#a61e1e" stroke-width="1.1" stroke-linejoin="round"/>
+    <text class="lbl" x="345" y="240" text-anchor="middle" font-size="11" font-weight="700" fill="#a61e1e">q</text>
+
+    <!-- ============ probe lines: q → 3 highlighted centroids ============ -->
+    <line class="probe" x1="345" y1="210" x2="240" y2="190"/>
+    <line class="probe" x1="345" y1="210" x2="425" y2="200"/>
+    <line class="probe" x1="345" y1="210" x2="255" y2="325"/>
+
+    <!-- nearest neighbour to q (in c5, very close to q) -->
+    <circle class="pt-result" cx="360" cy="215" r="4.2"/>
+  </g>
+
+  <!-- =========================================================
+       Step badges placed in/near the panel (svg coords).
+       Panel origin (40, 80).
+       ========================================================= -->
+  <g>
+    <!-- 1: probe centroids — placed near q in the embedding panel -->
+    <circle class="step-badge" cx="320" cy="265" r="11"/>
+    <text class="step-num"    x="320" y="269" text-anchor="middle">1</text>
+
+    <!-- 2: scan buckets — placed in upper-right of highlighted c5 -->
+    <circle class="step-badge" cx="540" cy="240" r="11"/>
+    <text class="step-num"    x="540" y="244" text-anchor="middle">2</text>
+
+    <!-- step 3 (reorder) is post-processing and has no spatial location;
+         it appears only in the right-side legend. -->
+  </g>
+
+  <!-- =========================================================
+       Right-side legend / annotations
+       ========================================================= -->
+  <g transform="translate(600, 92)">
+    <g>
+      <circle class="step-badge" cx="10" cy="10" r="9"/>
+      <text x="10" y="14" text-anchor="middle" fill="#fff" font-size="10" font-weight="700">1</text>
+      <text class="lbl" x="28" y="8" font-weight="600">选取中心</text>
+      <text class="lbl-mute" x="28" y="22" font-size="11">计算 q 到全部</text>
+      <text class="lbl-mute" x="28" y="36" font-size="11">buckets_count 个中心的距离</text>
+    </g>
+
+    <g transform="translate(0, 58)">
+      <circle class="step-badge" cx="10" cy="10" r="9"/>
+      <text x="10" y="14" text-anchor="middle" fill="#fff" font-size="10" font-weight="700">2</text>
+      <text class="lbl" x="28" y="8" font-weight="600">扫描最近桶</text>
+      <text class="lbl-mute" x="28" y="22" font-size="11">仅对 scan_buckets_count</text>
+      <text class="lbl-mute" x="28" y="36" font-size="11">个桶内的向量打分</text>
+    </g>
+
+    <g transform="translate(0, 116)">
+      <circle class="step-badge" cx="10" cy="10" r="9"/>
+      <text x="10" y="14" text-anchor="middle" fill="#fff" font-size="10" font-weight="700">3</text>
+      <text class="lbl" x="28" y="8" font-weight="600">精排（可选）</text>
+      <text class="lbl-mute" x="28" y="22" font-size="11">对 factor*topk 个粗排候选</text>
+      <text class="lbl-mute" x="28" y="36" font-size="11">用高精度副本重打分 → topk</text>
+    </g>
+
+    <g transform="translate(0, 174)">
+      <rect class="note-box" x="0" y="0" width="160" height="92" rx="6"/>
+      <text class="layer-lbl" x="10" y="18" font-size="10">存储</text>
+      <text class="lbl-mute"  x="10" y="36" font-size="11">base_quantization_type：</text>
+      <text class="lbl"       x="10" y="50" font-size="11">sq8 · pq · pqfs · rabitq · ...</text>
+
+      <line x1="10" y1="58" x2="150" y2="58" stroke="#e2e8f0"/>
+
+      <text class="layer-lbl" x="10" y="74" font-size="10">分桶策略</text>
+      <text class="lbl-mute"  x="10" y="88" font-size="11">ivf · gno_imi（双层）</text>
+    </g>
+  </g>
+
+  <!-- =========================================================
+       Bottom legend
+       ========================================================= -->
+  <g transform="translate(40, 495)">
+    <circle class="centroid" cx="6" cy="0" r="6"/>
+    <text class="lbl-mute" x="18" y="4">中心</text>
+
+    <circle class="centroid-hi" cx="92" cy="0" r="6"/>
+    <text class="lbl-mute" x="104" y="4">被选中的中心</text>
+
+    <circle class="pt-hi" cx="218" cy="0" r="4"/>
+    <text class="lbl-mute" x="228" y="4">被扫描桶内的向量</text>
+
+    <polygon points="384,-6.2 386.2,-1.4 391.5,-1.4 387.2,1.6 388.8,6.2 384,3.2 379.2,6.2 380.8,1.6 376.5,-1.4 381.8,-1.4"
+             fill="#e03131" stroke="#a61e1e" stroke-width="1" stroke-linejoin="round"/>
+    <text class="lbl-mute" x="398" y="4">查询 q</text>
+
+    <circle class="pt-result" cx="464" cy="0" r="5"/>
+    <text class="lbl-mute" x="476" y="4">最近邻</text>
+  </g>
+</svg>

--- a/docs/docs/zh/src/figures/indexes/pyramid-overview.svg
+++ b/docs/docs/zh/src/figures/indexes/pyramid-overview.svg
@@ -1,0 +1,327 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 560" font-family="-apple-system, BlinkMacSystemFont, 'PingFang SC', 'Microsoft YaHei', 'Segoe UI', Helvetica, Arial, sans-serif" font-size="12">
+  <title>Pyramid 索引概览</title>
+  <desc>Pyramid 为每个向量绑定一个路径字符串（如 "a/d/f"），并为路径树的每个节点构建一个邻近子图。查询带有路径前缀；搜索沿树下行到最具体的匹配子图，再在叶子图内执行 ef_search。no_build_levels 中列出的层级是透传容器，回退到线性扫描。</desc>
+
+  <defs>
+    <marker id="arrow-search" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#e8590c"/>
+    </marker>
+  </defs>
+
+  <style>
+    .title    { fill: #1a1a1a; font-size: 16px; font-weight: 600; }
+    .subtitle { fill: #6b7280; font-size: 12px; }
+    .lbl      { fill: #1f2937; }
+    .lbl-mute { fill: #6b7280; }
+    .layer-lbl { fill: #475569; font-size: 11px; font-weight: 600; letter-spacing: 0.6px; }
+    .layer-sub { fill: #94a3b8; font-size: 11px; }
+
+    .band       { fill: #f8fafc; stroke: #e2e8f0; stroke-width: 1; }
+    .band-top   { fill: #f1f5f9; stroke: #e2e8f0; stroke-width: 1; }
+
+    /* tree nodes */
+    .tnode       { fill: #ffffff; stroke: #94a3b8; stroke-width: 1; }
+    .tnode-hi    { fill: #fff4e6; stroke: #e8590c; stroke-width: 1.6; }
+    .tnode-skip  { fill: #f1f5f9; stroke: #cbd5e1; stroke-width: 1; stroke-dasharray: 4 3; }
+    .tedge       { stroke: #cbd5e1; stroke-width: 1; fill: none; }
+    .tedge-hi    { stroke: #e8590c; stroke-width: 2; fill: none; stroke-linecap: round; }
+    .tnode-lbl   { fill: #1f2937; font-size: 11px; font-weight: 600; }
+    .tnode-lbl-hi{ fill: #a14503; font-size: 11px; font-weight: 700; }
+    .tnode-lbl-skip{ fill: #94a3b8; font-size: 11px; font-weight: 600; }
+    .tnode-sub   { fill: #94a3b8; font-size: 9px; }
+
+    /* leaf graph */
+    .gnode       { fill: #ffffff; stroke: #94a3b8; stroke-width: 1; }
+    .gnode-hi    { fill: #ffffff; stroke: #5c7cfa; stroke-width: 1.3; }
+    .gnode-entry { fill: #5c7cfa; stroke: #364fc7; stroke-width: 1.4; }
+    .gnode-visit { fill: #ffd8a8; stroke: #e8590c; stroke-width: 1.5; }
+    .gnode-result{ fill: #e03131; stroke: #a61e1e; stroke-width: 1.4; }
+    .gedge       { stroke: #cbd5e1; stroke-width: 0.8; fill: none; }
+
+    .frontier    { fill: #fff4e6; stroke: #e8590c; stroke-width: 1; stroke-dasharray: 4 3; opacity: 0.85; }
+    .search      { stroke: #e8590c; stroke-width: 2; fill: none; stroke-linecap: round; }
+
+    .step-badge  { fill: #e8590c; stroke: #ffffff; stroke-width: 2; }
+    .step-num    { fill: #ffffff; font-size: 11px; font-weight: 700; }
+
+    .note-box    { fill: #ffffff; stroke: #e2e8f0; stroke-width: 1; }
+
+    /* query path chip */
+    .pchip       { fill: #fff4e6; stroke: #e8590c; stroke-width: 1.3; }
+    .pchip-text  { fill: #a14503; font-size: 11px; font-weight: 700; }
+  </style>
+
+  <!-- Header -->
+  <text class="title"    x="40" y="34">Pyramid</text>
+  <text class="subtitle" x="40" y="52">按路径分区的层级图 · 每个节点一个子图 · 搜索被限制在查询路径上</text>
+
+  <!-- Query path chip -->
+  <g transform="translate(40, 70)">
+    <text class="layer-lbl" x="0" y="12">查询路径</text>
+    <rect class="pchip" x="100" y="0" width="120" height="22" rx="5"/>
+    <text class="pchip-text" x="160" y="16" text-anchor="middle">"a / d / f"</text>
+  </g>
+
+  <!-- =========================================================
+       Left panel: path tree
+       Panel origin (40, 110), size 340 x 410.
+       Tree: root → {a*, b, c} → {d*, e, ...} → {f*, g} → {sub-graph}
+       * = on query path → highlighted
+       ========================================================= -->
+  <g transform="translate(40, 110)">
+    <rect class="band" x="0" y="0" width="340" height="410" rx="10"/>
+    <text class="layer-lbl" x="14" y="20">路径树</text>
+    <text class="layer-sub" x="68" y="20">每个节点一个子图</text>
+
+    <!--
+      Level y positions (panel y):
+        L0 (root)     :  56
+        L1            : 130
+        L2            : 220
+        L3 (leaves)   : 310
+    -->
+
+    <!-- edges (drawn first, so nodes sit on top) -->
+    <!-- root → L1 -->
+    <line class="tedge-hi" x1="170" y1="64" x2="80"  y2="122"/>
+    <line class="tedge"    x1="170" y1="64" x2="170" y2="122"/>
+    <line class="tedge"    x1="170" y1="64" x2="260" y2="122"/>
+    <!-- a → L2 -->
+    <line class="tedge-hi" x1="80"  y1="138" x2="40"  y2="212"/>
+    <line class="tedge"    x1="80"  y1="138" x2="120" y2="212"/>
+    <!-- b → L2 -->
+    <line class="tedge"    x1="170" y1="138" x2="170" y2="212"/>
+    <!-- c → L2 -->
+    <line class="tedge"    x1="260" y1="138" x2="240" y2="212"/>
+    <line class="tedge"    x1="260" y1="138" x2="295" y2="212"/>
+    <!-- d → L3 -->
+    <line class="tedge-hi" x1="40"  y1="228" x2="40"  y2="302"/>
+    <line class="tedge"    x1="40"  y1="228" x2="80"  y2="302"/>
+
+    <!-- nodes -->
+    <!-- root -->
+    <circle class="tnode" cx="170" cy="56" r="14"/>
+    <text class="tnode-lbl" x="170" y="60" text-anchor="middle">/</text>
+    <text class="tnode-sub" x="170" y="40" text-anchor="middle">根</text>
+
+    <!-- L1: a (hi), b, c -->
+    <circle class="tnode-hi" cx="80"  cy="130" r="14"/>
+    <text class="tnode-lbl-hi" x="80" y="134" text-anchor="middle">a</text>
+
+    <circle class="tnode-skip" cx="170" cy="130" r="14"/>
+    <text class="tnode-lbl-skip" x="170" y="134" text-anchor="middle">b</text>
+
+    <circle class="tnode" cx="260" cy="130" r="14"/>
+    <text class="tnode-lbl" x="260" y="134" text-anchor="middle">c</text>
+
+    <!-- L2: d (hi), e ; under b: stub ; under c: f, g -->
+    <circle class="tnode-hi" cx="40"  cy="220" r="14"/>
+    <text class="tnode-lbl-hi" x="40" y="224" text-anchor="middle">d</text>
+
+    <circle class="tnode" cx="120" cy="220" r="14"/>
+    <text class="tnode-lbl" x="120" y="224" text-anchor="middle">e</text>
+
+    <circle class="tnode-skip" cx="170" cy="220" r="14"/>
+    <text class="tnode-lbl-skip" x="170" y="224" text-anchor="middle">…</text>
+
+    <circle class="tnode" cx="240" cy="220" r="14"/>
+    <text class="tnode-lbl" x="240" y="224" text-anchor="middle">x</text>
+
+    <circle class="tnode" cx="295" cy="220" r="14"/>
+    <text class="tnode-lbl" x="295" y="224" text-anchor="middle">y</text>
+
+    <!-- L3 leaves: f (hi), g  (children of d) -->
+    <circle class="tnode-hi" cx="40"  cy="310" r="14"/>
+    <text class="tnode-lbl-hi" x="40" y="314" text-anchor="middle">f</text>
+
+    <circle class="tnode" cx="80"  cy="310" r="14"/>
+    <text class="tnode-lbl" x="80" y="314" text-anchor="middle">g</text>
+
+    <!-- Level labels on the right gutter -->
+    <text class="lbl-mute" x="320" y="60" text-anchor="end" font-size="10">L0</text>
+    <text class="lbl-mute" x="320" y="134" text-anchor="end" font-size="10">L1</text>
+    <text class="lbl-mute" x="320" y="224" text-anchor="end" font-size="10">L2</text>
+    <text class="lbl-mute" x="320" y="314" text-anchor="end" font-size="10">L3</text>
+
+    <!-- annotation: dashed node = no_build_levels / small partition -->
+    <g transform="translate(140, 348)">
+      <circle class="tnode-skip" cx="10" cy="10" r="8"/>
+      <text class="lbl-mute" x="26" y="14" font-size="10">透传 · no_build_levels</text>
+    </g>
+    <g transform="translate(140, 372)">
+      <circle class="tnode-hi" cx="10" cy="10" r="8"/>
+      <text class="lbl-mute" x="26" y="14" font-size="10">查询路径 "a/d/f" 上的节点</text>
+    </g>
+
+    <!-- "zoom" indicator from leaf f → right panel -->
+    <path d="M 56 310 L 90 310" stroke="#e8590c" stroke-width="1.4" fill="none"
+          stroke-dasharray="3 3" opacity="0.7"/>
+  </g>
+
+  <!-- =========================================================
+       Right panel: sub-graph at leaf "a/d/f"
+       Panel origin (400, 110), size 360 x 410.
+       ========================================================= -->
+  <g transform="translate(400, 110)">
+    <rect class="band" x="0" y="0" width="360" height="410" rx="10"/>
+    <text class="layer-lbl" x="14" y="20">叶子子图 "a/d/f"</text>
+    <text class="layer-sub" x="160" y="20">在子图内进行 ef_search</text>
+
+    <!-- ef_search frontier behind nodes -->
+    <ellipse class="frontier" cx="240" cy="240" rx="65" ry="48"/>
+
+    <!-- proximity edges -->
+    <line class="gedge" x1="60"  y1="80"  x2="100" y2="105"/>
+    <line class="gedge" x1="60"  y1="80"  x2="90"  y2="140"/>
+    <line class="gedge" x1="100" y1="105" x2="140" y2="135"/>
+    <line class="gedge" x1="100" y1="105" x2="155" y2="90"/>
+    <line class="gedge" x1="90"  y1="140" x2="140" y2="135"/>
+    <line class="gedge" x1="90"  y1="140" x2="120" y2="180"/>
+    <line class="gedge" x1="140" y1="135" x2="170" y2="170"/>
+    <line class="gedge" x1="140" y1="135" x2="195" y2="135"/>
+    <line class="gedge" x1="120" y1="180" x2="170" y2="170"/>
+    <line class="gedge" x1="120" y1="180" x2="160" y2="220"/>
+    <line class="gedge" x1="170" y1="170" x2="195" y2="135"/>
+    <line class="gedge" x1="170" y1="170" x2="215" y2="200"/>
+    <line class="gedge" x1="170" y1="170" x2="160" y2="220"/>
+    <line class="gedge" x1="195" y1="135" x2="235" y2="115"/>
+    <line class="gedge" x1="195" y1="135" x2="240" y2="170"/>
+    <line class="gedge" x1="155" y1="90"  x2="235" y2="115"/>
+    <line class="gedge" x1="235" y1="115" x2="240" y2="170"/>
+    <line class="gedge" x1="235" y1="115" x2="295" y2="120"/>
+    <line class="gedge" x1="240" y1="170" x2="215" y2="200"/>
+    <line class="gedge" x1="240" y1="170" x2="280" y2="200"/>
+    <line class="gedge" x1="240" y1="170" x2="240" y2="220"/>
+    <line class="gedge" x1="215" y1="200" x2="240" y2="240"/>
+    <line class="gedge" x1="215" y1="200" x2="240" y2="220"/>
+    <line class="gedge" x1="160" y1="220" x2="200" y2="250"/>
+    <line class="gedge" x1="200" y1="250" x2="240" y2="240"/>
+    <line class="gedge" x1="200" y1="250" x2="225" y2="285"/>
+    <line class="gedge" x1="240" y1="220" x2="240" y2="240"/>
+    <line class="gedge" x1="240" y1="220" x2="285" y2="245"/>
+    <line class="gedge" x1="240" y1="240" x2="265" y2="275"/>
+    <line class="gedge" x1="240" y1="240" x2="285" y2="245"/>
+    <line class="gedge" x1="240" y1="240" x2="225" y2="285"/>
+    <line class="gedge" x1="265" y1="275" x2="285" y2="245"/>
+    <line class="gedge" x1="265" y1="275" x2="305" y2="285"/>
+    <line class="gedge" x1="225" y1="285" x2="265" y2="275"/>
+    <line class="gedge" x1="280" y1="200" x2="285" y2="245"/>
+    <line class="gedge" x1="280" y1="200" x2="320" y2="200"/>
+    <line class="gedge" x1="285" y1="245" x2="320" y2="200"/>
+    <line class="gedge" x1="285" y1="245" x2="320" y2="270"/>
+    <line class="gedge" x1="295" y1="120" x2="320" y2="160"/>
+    <line class="gedge" x1="295" y1="120" x2="330" y2="100"/>
+    <line class="gedge" x1="320" y1="160" x2="320" y2="200"/>
+    <line class="gedge" x1="305" y1="285" x2="320" y2="270"/>
+
+    <!-- entry node (top-left) -->
+    <circle class="gnode-entry" cx="60" cy="80" r="6"/>
+    <text class="lbl" x="60" y="68" text-anchor="middle" font-size="10" fill="#364fc7" font-weight="600">入口点</text>
+
+    <!-- regular nodes -->
+    <circle class="gnode" cx="100" cy="105" r="4"/>
+    <circle class="gnode" cx="90"  cy="140" r="4"/>
+    <circle class="gnode" cx="140" cy="135" r="4"/>
+    <circle class="gnode" cx="155" cy="90"  r="4"/>
+    <circle class="gnode" cx="120" cy="180" r="4"/>
+    <circle class="gnode" cx="195" cy="135" r="4"/>
+    <circle class="gnode" cx="160" cy="220" r="4"/>
+    <circle class="gnode" cx="235" cy="115" r="4"/>
+    <circle class="gnode" cx="200" cy="250" r="4"/>
+    <circle class="gnode" cx="280" cy="200" r="4"/>
+    <circle class="gnode" cx="225" cy="285" r="4"/>
+    <circle class="gnode" cx="305" cy="285" r="4"/>
+    <circle class="gnode" cx="320" cy="200" r="4"/>
+    <circle class="gnode" cx="320" cy="270" r="4"/>
+    <circle class="gnode" cx="295" cy="120" r="4"/>
+    <circle class="gnode" cx="320" cy="160" r="4"/>
+    <circle class="gnode" cx="330" cy="100" r="4"/>
+
+    <!-- visited along the search -->
+    <circle class="gnode-visit" cx="170" cy="170" r="5.4"/>
+    <circle class="gnode-visit" cx="215" cy="200" r="5.4"/>
+    <circle class="gnode-visit" cx="240" cy="220" r="5.4"/>
+    <circle class="gnode-visit" cx="265" cy="275" r="5.4"/>
+    <circle class="gnode-visit" cx="285" cy="245" r="5.4"/>
+
+    <!-- nearest neighbour -->
+    <circle class="gnode-result" cx="240" cy="240" r="5.6"/>
+
+    <!-- query star -->
+    <polygon points="263,247 265.6,253.4 272.5,253.4 267,257.4 269.2,264 263,259.7 256.8,264 259,257.4 253.5,253.4 260.4,253.4"
+             fill="#e03131" stroke="#a61e1e" stroke-width="1.1" stroke-linejoin="round"/>
+    <text class="lbl" x="263" y="280" text-anchor="middle" font-size="11" font-weight="700" fill="#a61e1e">q</text>
+
+    <!-- search path from entry → ... → nearest -->
+    <path class="search" d="M 60 80 Q 110 130 170 170 T 240 220 T 240 240" marker-end="url(#arrow-search)"/>
+
+    <!-- ef_search caption -->
+    <text class="lbl-mute" x="240" y="305" text-anchor="middle" font-size="11">ef_search 候选边界</text>
+  </g>
+
+  <!-- =========================================================
+       Step badges placed along the trajectory (svg coords)
+       ========================================================= -->
+  <g>
+    <!-- 1: at root node of left panel (svg ~210, 158) -->
+    <circle class="step-badge" cx="232" cy="158" r="11"/>
+    <text class="step-num"    x="232" y="162" text-anchor="middle">1</text>
+
+    <!-- 2: zoom from leaf 'f' to right panel (svg ~410, 420) -->
+    <circle class="step-badge" cx="408" cy="420" r="11"/>
+    <text class="step-num"    x="408" y="424" text-anchor="middle">2</text>
+
+    <!-- 3: ef_search inside right panel — near the frontier ellipse -->
+    <circle class="step-badge" cx="715" cy="305" r="11"/>
+    <text class="step-num"    x="715" y="309" text-anchor="middle">3</text>
+  </g>
+
+  <!-- =========================================================
+       Bottom legend
+       ========================================================= -->
+  <g transform="translate(40, 553)">
+    <circle class="tnode-hi" cx="6" cy="0" r="7"/>
+    <text class="lbl-mute" x="20" y="4">路径前缀匹配</text>
+
+    <circle class="tnode-skip" cx="130" cy="0" r="7"/>
+    <text class="lbl-mute" x="144" y="4">no_build_levels（回退扫描）</text>
+
+    <circle class="gnode-entry" cx="358" cy="0" r="6"/>
+    <text class="lbl-mute" x="370" y="4">叶子图入口</text>
+
+    <circle class="gnode-result" cx="468" cy="0" r="6"/>
+    <text class="lbl-mute" x="480" y="4">最近邻</text>
+
+    <polygon points="568,-6.2 570.2,-1.4 575.5,-1.4 571.2,1.6 572.8,6.2 568,3.2 563.2,6.2 564.8,1.6 560.5,-1.4 565.8,-1.4"
+             fill="#e03131" stroke="#a61e1e" stroke-width="1" stroke-linejoin="round"/>
+    <text class="lbl-mute" x="582" y="4">查询 q</text>
+  </g>
+
+  <!-- =========================================================
+       Right-side note (compact). Place steps 1-3 next to the leaf-graph panel
+       in the lower-right vacant area.
+       Actually the leaf-graph panel already occupies right; put step legend
+       below the bottom of the right panel. We have y=520 → bottom legend at 545.
+       So place inline step legend at the top-right INSIDE the leaf panel area.
+       To keep the figure clean we use NO right-side annotation column;
+       step numbers reference the in-place badges plus this small inline panel.
+       ========================================================= -->
+
+  <!-- compact step legend at the very top right corner -->
+  <g transform="translate(400, 70)">
+    <rect class="note-box" x="0" y="-12" width="360" height="32" rx="6"/>
+    <g>
+      <circle class="step-badge" cx="14" cy="4" r="8"/>
+      <text x="14" y="8" text-anchor="middle" fill="#fff" font-size="9" font-weight="700">1</text>
+      <text class="lbl" x="28" y="8" font-size="11" font-weight="600">下行路径</text>
+
+      <circle class="step-badge" cx="110" cy="4" r="8"/>
+      <text x="110" y="8" text-anchor="middle" fill="#fff" font-size="9" font-weight="700">2</text>
+      <text class="lbl" x="124" y="8" font-size="11" font-weight="600">进入叶子子图</text>
+
+      <circle class="step-badge" cx="230" cy="4" r="8"/>
+      <text x="230" y="8" text-anchor="middle" fill="#fff" font-size="9" font-weight="700">3</text>
+      <text class="lbl" x="244" y="8" font-size="11" font-weight="600">ef_search → top-k</text>
+    </g>
+  </g>
+</svg>

--- a/docs/docs/zh/src/figures/indexes/sindi-overview.svg
+++ b/docs/docs/zh/src/figures/indexes/sindi-overview.svg
@@ -1,0 +1,301 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 560" font-family="-apple-system, BlinkMacSystemFont, 'PingFang SC', 'Microsoft YaHei', 'Segoe UI', Helvetica, Arial, sans-serif" font-size="12">
+  <title>SINDI 索引示意图</title>
+  <desc>SINDI 是 VSAG 面向稀疏向量的索引。文档按固定窗口划分；每个窗口内为每个词项维护一份倒排列表，记录 (doc_id, value) 投递项。检索时只遍历查询非零词项对应的倒排表，把内积分量累加进大小为 n_candidate 的候选堆，可选地在高精度扁平副本上重打分。</desc>
+
+  <defs>
+    <marker id="arrow-search" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#e8590c"/>
+    </marker>
+  </defs>
+
+  <style>
+    .title    { fill: #1a1a1a; font-size: 16px; font-weight: 600; }
+    .subtitle { fill: #6b7280; font-size: 12px; }
+    .lbl      { fill: #1f2937; }
+    .lbl-mute { fill: #6b7280; }
+    .layer-lbl { fill: #475569; font-size: 11px; font-weight: 600; letter-spacing: 0.6px; }
+    .layer-sub { fill: #94a3b8; font-size: 11px; }
+
+    .band       { fill: #f8fafc; stroke: #e2e8f0; stroke-width: 1; }
+    .band-top   { fill: #f1f5f9; stroke: #e2e8f0; stroke-width: 1; }
+
+    /* query term chip */
+    .qchip      { fill: #fff4e6; stroke: #e8590c; stroke-width: 1.2; }
+    .qchip-mute { fill: #ffffff; stroke: #cbd5e1; stroke-width: 1; stroke-dasharray: 3 2; }
+    .qtext      { fill: #a14503; font-size: 10px; font-weight: 700; }
+    .qtext-mute { fill: #94a3b8; font-size: 10px; font-weight: 600; }
+
+    /* posting cell (doc_id, value) */
+    .post       { fill: #ffffff; stroke: #94a3b8; stroke-width: 0.8; }
+    .post-hi    { fill: #ffd8a8; stroke: #e8590c; stroke-width: 1.1; }
+    .post-result{ fill: #e03131; stroke: #a61e1e; stroke-width: 1.2; }
+    .post-text  { fill: #1f2937; font-size: 9px; }
+    .post-text-hi { fill: #a14503; font-size: 9px; font-weight: 700; }
+    .post-text-result { fill: #ffffff; font-size: 9px; font-weight: 700; }
+
+    /* term row label */
+    .term-lbl   { fill: #364fc7; font-size: 10px; font-weight: 700; }
+
+    /* window separators */
+    .win-rect   { fill: none; stroke: #cbd5e1; stroke-width: 1; stroke-dasharray: 3 3; }
+    .win-lbl    { fill: #94a3b8; font-size: 9px; letter-spacing: 0.4px; }
+
+    /* search arrows */
+    .search     { stroke: #e8590c; stroke-width: 1.6; fill: none; stroke-linecap: round; }
+    .feed       { stroke: #e8590c; stroke-width: 1.4; fill: none; stroke-dasharray: 4 3; stroke-linecap: round; opacity: 0.85; }
+
+    .step-badge  { fill: #e8590c; stroke: #ffffff; stroke-width: 2; }
+    .step-num    { fill: #ffffff; font-size: 11px; font-weight: 700; }
+
+    .note-box    { fill: #ffffff; stroke: #e2e8f0; stroke-width: 1; }
+
+    /* heap shape */
+    .heap-box   { fill: #fff4e6; stroke: #e8590c; stroke-width: 1.2; }
+    .heap-lbl   { fill: #a14503; font-size: 10px; font-weight: 700; letter-spacing: 0.4px; }
+  </style>
+
+  <!-- Header -->
+  <text class="title"    x="40" y="34">SINDI</text>
+  <text class="subtitle" x="40" y="52">稀疏倒排索引 · 按窗口维护每个词项的投递列表 · 仅对查询中出现的词项打分</text>
+
+  <!-- =========================================================
+       Query band (top): sparse vector as a list of (term, value) chips
+       Panel origin (40, 80), size 540 x 70.
+       ========================================================= -->
+  <g transform="translate(40, 80)">
+    <rect class="band-top" x="0" y="0" width="540" height="86" rx="10"/>
+    <text class="layer-lbl" x="14" y="20">查询 q</text>
+    <text class="layer-sub" x="70" y="20">非零词项 · 仅遍历这些倒排表</text>
+
+    <!-- 4 query chips: t5, t12, t27, t41 ; one (t41) is dashed = pruned by query_prune_ratio -->
+    <g transform="translate(16, 32)">
+      <rect class="qchip" x="0"   y="0" width="90" height="26" rx="6"/>
+      <text class="qtext" x="45"  y="17" text-anchor="middle">t5 : 0.92</text>
+
+      <rect class="qchip" x="100" y="0" width="90" height="26" rx="6"/>
+      <text class="qtext" x="145" y="17" text-anchor="middle">t12 : 0.71</text>
+
+      <rect class="qchip" x="200" y="0" width="90" height="26" rx="6"/>
+      <text class="qtext" x="245" y="17" text-anchor="middle">t27 : 0.55</text>
+
+      <rect class="qchip-mute" x="300" y="0" width="90" height="26" rx="6"/>
+      <text class="qtext-mute" x="345" y="17" text-anchor="middle">t41 : 0.08</text>
+      <text class="lbl-mute" x="345" y="44" text-anchor="middle" font-size="9">已被 query_prune_ratio 剪枝</text>
+    </g>
+  </g>
+
+  <!-- =========================================================
+       Inverted lists (middle): one row per query term, two windows wide
+       Panel origin (40, 168), size 540 x 256.
+       Rows at y = 50, 110, 170 inside panel.
+       Two windows: W0 (x=80..295) and W1 (x=310..525).
+       ========================================================= -->
+  <g transform="translate(40, 168)">
+    <rect class="band" x="0" y="0" width="540" height="232" rx="10"/>
+    <text class="layer-lbl" x="14" y="20">倒排列表</text>
+    <text class="layer-sub" x="90" y="20">词项 → (doc_id, value) 投递项，按 window_size 分组</text>
+
+    <!-- Window dividers / labels -->
+    <text class="win-lbl" x="187" y="40" text-anchor="middle">窗口 W0</text>
+    <text class="win-lbl" x="417" y="40" text-anchor="middle">窗口 W1</text>
+    <rect class="win-rect" x="74"  y="44" width="226" height="172" rx="6"/>
+    <rect class="win-rect" x="304" y="44" width="226" height="172" rx="6"/>
+
+    <!-- Row 1: term t5 -->
+    <text class="term-lbl" x="14" y="74" font-size="11">词项 t5</text>
+    <!-- W0 postings -->
+    <g transform="translate(80, 60)">
+      <rect class="post-hi" x="0"   y="0" width="62" height="22" rx="3"/>
+      <text class="post-text-hi" x="31"  y="14" text-anchor="middle">d12 : .80</text>
+
+      <rect class="post"    x="68"  y="0" width="62" height="22" rx="3"/>
+      <text class="post-text" x="99"  y="14" text-anchor="middle">d31 : .45</text>
+
+      <rect class="post-hi" x="136" y="0" width="62" height="22" rx="3"/>
+      <text class="post-text-hi" x="167" y="14" text-anchor="middle">d47 : .65</text>
+    </g>
+    <!-- W1 postings -->
+    <g transform="translate(310, 60)">
+      <rect class="post"    x="0"   y="0" width="62" height="22" rx="3"/>
+      <text class="post-text" x="31"  y="14" text-anchor="middle">d83 : .31</text>
+
+      <rect class="post-hi" x="68"  y="0" width="62" height="22" rx="3"/>
+      <text class="post-text-hi" x="99"  y="14" text-anchor="middle">d97 : .72</text>
+
+      <rect class="post"    x="136" y="0" width="62" height="22" rx="3"/>
+      <text class="post-text" x="167" y="14" text-anchor="middle">d115: .28</text>
+    </g>
+
+    <!-- Row 2: term t12 -->
+    <text class="term-lbl" x="14" y="124" font-size="11">词项 t12</text>
+    <g transform="translate(80, 110)">
+      <rect class="post-hi" x="0"   y="0" width="62" height="22" rx="3"/>
+      <text class="post-text-hi" x="31"  y="14" text-anchor="middle">d12 : .55</text>
+
+      <rect class="post"    x="68"  y="0" width="62" height="22" rx="3"/>
+      <text class="post-text" x="99"  y="14" text-anchor="middle">d20 : .42</text>
+
+      <rect class="post"    x="136" y="0" width="62" height="22" rx="3"/>
+      <text class="post-text" x="167" y="14" text-anchor="middle">d58 : .19</text>
+    </g>
+    <g transform="translate(310, 110)">
+      <rect class="post-hi" x="0"   y="0" width="62" height="22" rx="3"/>
+      <text class="post-text-hi" x="31"  y="14" text-anchor="middle">d97 : .60</text>
+
+      <rect class="post"    x="68"  y="0" width="62" height="22" rx="3"/>
+      <text class="post-text" x="99"  y="14" text-anchor="middle">d104: .33</text>
+    </g>
+
+    <!-- Row 3: term t27 -->
+    <text class="term-lbl" x="14" y="174" font-size="11">词项 t27</text>
+    <g transform="translate(80, 160)">
+      <rect class="post"    x="0"   y="0" width="62" height="22" rx="3"/>
+      <text class="post-text" x="31"  y="14" text-anchor="middle">d09 : .22</text>
+
+      <rect class="post-hi" x="68"  y="0" width="62" height="22" rx="3"/>
+      <text class="post-text-hi" x="99"  y="14" text-anchor="middle">d12 : .48</text>
+
+      <rect class="post"    x="136" y="0" width="62" height="22" rx="3"/>
+      <text class="post-text" x="167" y="14" text-anchor="middle">d47 : .25</text>
+    </g>
+    <g transform="translate(310, 160)">
+      <rect class="post"    x="0"   y="0" width="62" height="22" rx="3"/>
+      <text class="post-text" x="31"  y="14" text-anchor="middle">d83 : .29</text>
+
+      <rect class="post"    x="68"  y="0" width="62" height="22" rx="3"/>
+      <text class="post-text" x="99"  y="14" text-anchor="middle">d97 : .15</text>
+
+      <rect class="post"    x="136" y="0" width="62" height="22" rx="3"/>
+      <text class="post-text" x="167" y="14" text-anchor="middle">d128: .19</text>
+    </g>
+
+    <!-- Term-walk highlight arrows (one per row, left → right) -->
+    <path class="search" d="M 70 71 L 308 71" marker-end="url(#arrow-search)" opacity="0.55"/>
+    <path class="search" d="M 70 121 L 308 121" marker-end="url(#arrow-search)" opacity="0.55"/>
+    <path class="search" d="M 70 171 L 308 171" marker-end="url(#arrow-search)" opacity="0.55"/>
+  </g>
+
+  <!-- =========================================================
+       Bottom band: n_candidate heap → topk
+       Panel origin (40, 420), size 540 x 80.
+       ========================================================= -->
+  <g transform="translate(40, 420)">
+    <rect class="band" x="0" y="0" width="540" height="80" rx="10"/>
+    <text class="layer-lbl" x="14" y="20">候选堆</text>
+    <text class="layer-sub" x="80" y="20">大小为 n_candidate · 累加 q·d 分量 · 保留 top-k</text>
+
+    <!-- candidate items -->
+    <g transform="translate(80, 36)">
+      <rect class="post-result" x="0"   y="0" width="74" height="30" rx="4"/>
+      <text class="post-text-result" x="37"  y="13" text-anchor="middle">d12</text>
+      <text class="post-text-result" x="37"  y="25" text-anchor="middle">1.83</text>
+
+      <rect class="post-result" x="84"  y="0" width="74" height="30" rx="4"/>
+      <text class="post-text-result" x="121" y="13" text-anchor="middle">d97</text>
+      <text class="post-text-result" x="121" y="25" text-anchor="middle">1.32</text>
+
+      <rect class="post-hi" x="168" y="0" width="74" height="30" rx="4"/>
+      <text class="post-text-hi"  x="205" y="13" text-anchor="middle">d47</text>
+      <text class="post-text-hi"  x="205" y="25" text-anchor="middle">0.90</text>
+
+      <rect class="post-hi" x="252" y="0" width="74" height="30" rx="4"/>
+      <text class="post-text-hi"  x="289" y="13" text-anchor="middle">d83</text>
+      <text class="post-text-hi"  x="289" y="25" text-anchor="middle">0.60</text>
+
+      <rect class="post"    x="336" y="0" width="74" height="30" rx="4"/>
+      <text class="post-text" x="373" y="13" text-anchor="middle">d31</text>
+      <text class="post-text" x="373" y="25" text-anchor="middle">0.45</text>
+
+      <text class="lbl-mute" x="426" y="20" font-size="11">...</text>
+    </g>
+
+    <!-- topk callout: small bracket underlining the two red chips (svg x=120..238) -->
+    <path d="M 120 70 L 120 73 L 238 73 L 238 70" stroke="#a61e1e" stroke-width="1.2" fill="none"/>
+    <text class="heap-lbl" x="179" y="75" text-anchor="middle" fill="#a61e1e" dominant-baseline="hanging">TOP-K</text>
+  </g>
+
+  <!-- feed arrows from inverted lists → candidate heap -->
+  <path class="feed" d="M 130 410 Q 130 418 130 430"/>
+  <path class="feed" d="M 195 410 Q 195 418 195 430"/>
+  <path class="feed" d="M 265 410 Q 265 418 265 430"/>
+  <path class="feed" d="M 350 410 Q 350 418 350 430"/>
+  <path class="feed" d="M 430 410 Q 430 418 430 430"/>
+
+  <!-- =========================================================
+       Step badges
+       ========================================================= -->
+  <g>
+    <!-- 1: query non-zero terms (top band) -->
+    <circle class="step-badge" cx="545" cy="114" r="11"/>
+    <text class="step-num"    x="545" y="118" text-anchor="middle">1</text>
+
+    <!-- 2: walk inverted lists -->
+    <circle class="step-badge" cx="545" cy="200" r="11"/>
+    <text class="step-num"    x="545" y="204" text-anchor="middle">2</text>
+
+    <!-- 3: aggregate into heap (bottom band) -->
+    <circle class="step-badge" cx="545" cy="436" r="11"/>
+    <text class="step-num"    x="545" y="440" text-anchor="middle">3</text>
+  </g>
+
+  <!-- =========================================================
+       Right-side legend / annotations
+       ========================================================= -->
+  <g transform="translate(600, 92)">
+    <g>
+      <circle class="step-badge" cx="10" cy="10" r="9"/>
+      <text x="10" y="14" text-anchor="middle" fill="#fff" font-size="10" font-weight="700">1</text>
+      <text class="lbl" x="28" y="8" font-weight="600">取出非零项</text>
+      <text class="lbl-mute" x="28" y="22" font-size="11">q 的所有非零</text>
+      <text class="lbl-mute" x="28" y="36" font-size="11">(词项, 权重) 对</text>
+    </g>
+
+    <g transform="translate(0, 58)">
+      <circle class="step-badge" cx="10" cy="10" r="9"/>
+      <text x="10" y="14" text-anchor="middle" fill="#fff" font-size="10" font-weight="700">2</text>
+      <text class="lbl" x="28" y="8" font-weight="600">遍历倒排表</text>
+      <text class="lbl-mute" x="28" y="22" font-size="11">每个查询词项对应一张表，</text>
+      <text class="lbl-mute" x="28" y="36" font-size="11">逐窗口访问</text>
+    </g>
+
+    <g transform="translate(0, 116)">
+      <circle class="step-badge" cx="10" cy="10" r="9"/>
+      <text x="10" y="14" text-anchor="middle" fill="#fff" font-size="10" font-weight="700">3</text>
+      <text class="lbl" x="28" y="8" font-weight="600">聚合 &amp; 取 top-k</text>
+      <text class="lbl-mute" x="28" y="22" font-size="11">累加 q·d 分量到堆中</text>
+      <text class="lbl-mute" x="28" y="36" font-size="11">→ 输出 top-k</text>
+    </g>
+
+    <g transform="translate(0, 174)">
+      <rect class="note-box" x="0" y="0" width="160" height="92" rx="6"/>
+      <text class="layer-lbl" x="10" y="18" font-size="10">剪枝</text>
+      <text class="lbl-mute"  x="10" y="34" font-size="11">doc_prune_ratio（建索引）</text>
+      <text class="lbl-mute"  x="10" y="48" font-size="11">query_prune_ratio（检索）</text>
+
+      <line x1="10" y1="58" x2="150" y2="58" stroke="#e2e8f0"/>
+
+      <text class="layer-lbl" x="10" y="74" font-size="10">精排（可选）</text>
+      <text class="lbl-mute"  x="10" y="88" font-size="11">use_reorder + 扁平副本</text>
+    </g>
+  </g>
+
+  <!-- =========================================================
+       Bottom legend
+       ========================================================= -->
+  <g transform="translate(40, 525)">
+    <rect class="qchip" x="0" y="-6" width="14" height="12" rx="3"/>
+    <text class="lbl-mute" x="20" y="4">查询词项</text>
+
+    <rect class="post-hi" x="96" y="-6" width="14" height="12" rx="3"/>
+    <text class="lbl-mute" x="116" y="4">命中的投递项</text>
+
+    <rect class="post-result" x="234" y="-6" width="14" height="12" rx="3"/>
+    <text class="lbl-mute" x="254" y="4">top-k 结果</text>
+
+    <rect class="post" x="352" y="-6" width="14" height="12" rx="3"/>
+    <text class="lbl-mute" x="372" y="4">未命中的投递项</text>
+
+    <line class="search" x1="490" y1="0" x2="520" y2="0" marker-end="url(#arrow-search)"/>
+    <text class="lbl-mute" x="528" y="4">词项遍历</text>
+  </g>
+</svg>

--- a/docs/docs/zh/src/indexes/brute_force.md
+++ b/docs/docs/zh/src/indexes/brute_force.md
@@ -1,5 +1,7 @@
 # BruteForce
 
+![BruteForce：向量存放在扁平数组中；查询会与每个存储向量逐一比对，可通过 parallelism 把扫描切到多个线程，最小的距离保留在 top-k 堆中](../figures/indexes/brute_force-overview.svg)
+
 BruteForce 是 VSAG 提供的**精确扁平索引**。查询时直接对语料中的每条向量计算距离并返回真实的
 top-k —— 没有图遍历、没有倒排表、不做近似。它的主要用途是为 HGraph、IVF 等近似索引提供
 **ground truth 基准**，也适合用于小规模语料或对召回率有严格要求的生产场景。

--- a/docs/docs/zh/src/indexes/hgraph.md
+++ b/docs/docs/zh/src/indexes/hgraph.md
@@ -1,5 +1,7 @@
 # HGraph
 
+![HGraph：自顶向下贪心搜索的层级近邻图，支持可选精排](../figures/indexes/hgraph-overview.svg)
+
 HGraph 是 VSAG 的旗舰 **图索引**。它构建的是与 HNSW 思路类似的多层近邻图，但在此基础上
 提供了更丰富的量化方案、统一的构建参数 schema（`index_param`），并原生支持精排（reorder）、
 增量更新、删除、以及基于 ELP 的运行时自动调优。

--- a/docs/docs/zh/src/indexes/ivf.md
+++ b/docs/docs/zh/src/indexes/ivf.md
@@ -1,5 +1,7 @@
 # IVF
 
+![IVF：基于 k-means 中心的 Voronoi 分桶，仅扫描距离 q 最近的 scan_buckets_count 个桶，并支持可选的精排](../figures/indexes/ivf-overview.svg)
+
 IVF（Inverted File，倒排索引）是 VSAG 的 **分桶式** 索引。它在构建时将语料聚类成若干桶，
 查询时只扫描与查询距离最近的若干个桶的中心对应的倒排列表，把 O(N) 的线性扫描降为
 O(N · `scan_buckets_count` / `buckets_count`)，并通过这两个参数在召回与延迟之间进行权衡。

--- a/docs/docs/zh/src/indexes/pyramid.md
+++ b/docs/docs/zh/src/indexes/pyramid.md
@@ -1,5 +1,7 @@
 # Pyramid
 
+![Pyramid：以路径字符串为键的"每节点一个邻近子图"的树形结构；搜索沿查询路径前缀下行到叶子子图后再执行 ef_search](../figures/indexes/pyramid-overview.svg)
+
 Pyramid 是 VSAG 的 **层级路径分区** 图索引。每条向量都附带一个路径字符串（例如
 `"a/d/f"`），Pyramid 会按路径树为每个节点构建一个子图；查询时提供一个路径前缀，
 检索即被限定在相应的子树内。

--- a/docs/docs/zh/src/indexes/sindi.md
+++ b/docs/docs/zh/src/indexes/sindi.md
@@ -1,5 +1,7 @@
 # SINDI
 
+![SINDI：按窗口维护的每词项倒排表，只对查询非零词项对应的列表做遍历并累加进 n_candidate 候选堆](../figures/indexes/sindi-overview.svg)
+
 SINDI（**S**parse **IN**verted **D**ense **I**ndex）是 VSAG 面向 **稀疏向量** 的索引——
 例如 BM25、SPLADE 以及其他学习稀疏（learned sparse）编码器产出的向量。与稠密索引
 （HGraph、IVF）不同，SINDI 直接在“词项-权重”对上工作，是 VSAG 中唯一接受


### PR DESCRIPTION
## Summary

- Add a hand-drawn SVG diagram at the top of every index page (HGraph, IVF, SINDI, Pyramid, BruteForce) in both the English and Chinese docs.
- Each diagram illustrates the index's data layout and search procedure so readers can grasp the algorithm at a glance before diving into parameters.
- All diagrams share a consistent visual language (viewBox `0 0 780 560`, cool-blue structure + single orange highlight + red query/result, numbered step badges along the search path).

## Diagrams

| Index | Visual idea |
|---|---|
| HGraph     | Stacked panels for the layered proximity graph; top-down greedy search across layers down to the ef_search ellipse at L0. |
| IVF        | Voronoi tessellation over k-means centroids; only `scan_buckets_count` cells nearest to q are scanned. |
| SINDI      | Sparse inverted lists grouped by window; only posting lists matching the query's non-zero terms are walked into an `n_candidate` heap. |
| Pyramid    | Path tree on the left (highlighted query path `a/d/f`, dashed `no_build_levels` nodes); zoomed-in leaf sub-graph on the right with ef_search beam. |
| BruteForce | Flat vector store with dashed `parallelism` thread stripes; q fans out distance computations to every cell, top-k heap collects winners. |

## Files

- `docs/docs/en/src/figures/indexes/{hgraph,ivf,sindi,pyramid,brute_force}-overview.svg`
- `docs/docs/zh/src/figures/indexes/{hgraph,ivf,sindi,pyramid,brute_force}-overview.svg`
- Image inserted just under the H1 of each `docs/docs/{en,zh}/src/indexes/*.md`.

## Verification

- Each SVG validated with `xmllint --noout` and rendered via `rsvg-convert -w 1400`.
- Diagrams kept compatible with the existing docs build (no other doc structure changes; the figures directory follows the convention already used by `quantization/`).

## Notes

This PR is intentionally docs-only and is meant as a base for further iteration tomorrow.