### PR TITLE
feat: add Source ID support and cache export/import for HGraph

### DIFF
--- a/include/vsag/constants.h
+++ b/include/vsag/constants.h
@@ -41,6 +41,7 @@ extern const char* const EXTRA_INFO_SIZE;
 extern const char* const VECTOR_COUNTS;
 extern const char* const MULTI_VECTORS;
 extern const char* const MULTI_VECTOR_DIM;
+extern const char* const SOURCE_ID;
 
 extern const char* const HNSW_DATA;
 extern const char* const CONJUGATE_GRAPH_DATA;

--- a/include/vsag/dataset.h
+++ b/include/vsag/dataset.h
@@ -468,6 +468,23 @@ public:
      */
     virtual int64_t
     GetMultiVectorDim() const = 0;
+
+    /**
+     * @brief Sets the source ID for the dataset.
+     *
+     * @param source_id Pointer to the source ID string.
+     * @return DatasetPtr A shared pointer to the dataset with updated source ID.
+     */
+    virtual DatasetPtr
+    SourceID(const std::string* source_id) = 0;
+
+    /**
+     * @brief Retrieves the source ID of the dataset.
+     *
+     * @return const std::string* Pointer to the source ID string.
+     */
+    virtual const std::string*
+    GetSourceID() const = 0;
 };
 
 };  // namespace vsag

--- a/include/vsag/index.h
+++ b/include/vsag/index.h
@@ -932,6 +932,16 @@ public:
         throw std::runtime_error("Index not support check id exist");
     }
 
+    void
+    ExportCache(std::ostream& out_stream) {
+        throw std::runtime_error("Index not support export cache");
+    }
+
+    void
+    ImportCache(std::istream& in_stream) {
+        throw std::runtime_error("Index not support import cache");
+    }
+
 public:
     virtual ~Index() = default;
 };

--- a/src/algorithm/hgraph/CMakeLists.txt
+++ b/src/algorithm/hgraph/CMakeLists.txt
@@ -6,6 +6,7 @@ set(HGRAPH_SRCS
     hgraph_param_mapping.cpp
     hgraph_search.cpp
     hgraph_serialize.cpp
+    hgraph_cache.cpp
 )
 
 add_library(hgraph OBJECT ${HGRAPH_SRCS})

--- a/src/algorithm/hgraph/hgraph.cpp
+++ b/src/algorithm/hgraph/hgraph.cpp
@@ -51,6 +51,7 @@ class HGraphAnalyzer;
 HGraph::HGraph(const HGraphParameterPtr& hgraph_param, const vsag::IndexCommonParam& common_param)
     : InnerIndexInterface(hgraph_param, common_param),
       route_graphs_(common_param.allocator_.get()),
+      cache_(std::make_unique<HGraphCache>(common_param.allocator_.get())),
       use_elp_optimizer_(hgraph_param->use_elp_optimizer),
       ignore_reorder_(hgraph_param->ignore_reorder),
       build_by_base_(hgraph_param->build_by_base),

--- a/src/algorithm/hgraph/hgraph.h
+++ b/src/algorithm/hgraph/hgraph.h
@@ -25,6 +25,7 @@
 #include "datacell/flatten_interface.h"
 #include "datacell/graph_interface.h"
 #include "datacell/sparse_graph_datacell_parameter.h"
+#include "hgraph_cache.h"
 #include "hgraph_parameter.h"
 #include "impl/basic_optimizer.h"
 #include "impl/heap/distance_heap.h"
@@ -190,6 +191,12 @@ public:
     SetImmutable() override;
 
     void
+    ExportCache(std::ostream& out_stream) override;
+
+    void
+    ImportCache(std::istream& in_stream) override;
+
+    void
     SetIO(const std::shared_ptr<Reader> reader) override;
 
     void
@@ -353,7 +360,6 @@ private:
     DatasetPtr
     get_single_dataset(const DatasetPtr& data, uint32_t j);
 
-private:
     void
     check_and_init_raw_vector(const FlattenInterfaceParamPtr& raw_vector_param,
                               const IndexCommonParam& common_param,
@@ -374,6 +380,9 @@ private:
     get_reorder_codes() const {
         return reorder_by_base_ ? basic_flatten_codes_ : high_precise_codes_;
     }
+
+    void
+    fullfill_cache();
 
 private:
     FlattenInterfacePtr basic_flatten_codes_{nullptr};
@@ -432,5 +441,7 @@ private:
 
     bool support_duplicate_{false};
     float duplicate_distance_threshold_{0.0F};
+
+    std::unique_ptr<HGraphCache> cache_{nullptr};
 };
 }  // namespace vsag

--- a/src/algorithm/hgraph/hgraph_build.cpp
+++ b/src/algorithm/hgraph/hgraph_build.cpp
@@ -23,6 +23,8 @@
 #include "impl/searcher/basic_searcher.h"
 #include "io/memory_io_parameter.h"
 #include "quantization/scalar_quantization/scalar_quantizer_parameter.h"
+#include "storage/stream_reader.h"
+#include "storage/stream_writer.h"
 #include "utils/util_functions.h"
 
 namespace vsag {
@@ -260,6 +262,7 @@ HGraph::Add(const DatasetPtr& data, AddMode mode) {
     std::vector<std::future<void>> futures;
     auto total = data->GetNumElements();
     const auto* labels = data->GetIds();
+    const auto* source_id = data->GetSourceID();
     const auto* extra_infos = data->GetExtraInfos();
     const auto* attr_sets = data->GetAttributeSets();
     bool use_parallel_add = this->thread_pool_ != nullptr;
@@ -288,6 +291,9 @@ HGraph::Add(const DatasetPtr& data, AddMode mode) {
         {
             std::scoped_lock label_lock(this->label_lookup_mutex_);
             this->label_table_->Insert(inner_id, labels[j]);
+            if (source_id != nullptr) {
+                this->label_table_->InsertSourceId(inner_id, *source_id);
+            }
             inner_ids.emplace_back(inner_id, j);
         }
     }
@@ -653,6 +659,42 @@ HGraph::reorder(const void* query,
                                               iter_ctx,
                                               rabitq_lower_bound_candidates);
     candidate_heap = reorder_heap;
+}
+
+void
+HGraph::ExportCache(std::ostream& out_stream) {
+    IOStreamWriter writer(out_stream);
+    this->fullfill_cache();
+    this->cache_->Serialize(writer);
+}
+
+void
+HGraph::ImportCache(std::istream& in_stream) {
+    IOStreamReader reader(in_stream);
+    this->cache_->Deserialize(reader);
+}
+
+void
+HGraph::fullfill_cache() {
+    auto& source_ids = this->cache_->source_ids_;
+    auto& source_cache_map = this->cache_->neighbors_;
+    source_ids.clear();
+    source_cache_map.clear();
+    source_ids.reserve(this->total_count_);
+    Vector<InnerIdType> inner_id_list(allocator_);
+    for (InnerIdType inner_id = 0; inner_id < this->total_count_; ++inner_id) {
+        auto source_id = this->label_table_->GetSourceId(inner_id);
+        source_ids.push_back(source_id);
+        if (source_id.empty()) {
+            continue;
+        }
+        auto [it, _] = source_cache_map.try_emplace(source_id, Vector<InnerIdType>(allocator_));
+        auto& cached = it.value();
+        cached.push_back(inner_id);
+        inner_id_list.clear();
+        this->bottom_graph_->GetNeighbors(inner_id, inner_id_list);
+        cached.insert(cached.end(), inner_id_list.begin(), inner_id_list.end());
+    }
 }
 
 }  // namespace vsag

--- a/src/algorithm/hgraph/hgraph_cache.cpp
+++ b/src/algorithm/hgraph/hgraph_cache.cpp
@@ -1,0 +1,79 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "hgraph_cache.h"
+
+#include "impl/allocator/default_allocator.h"
+
+namespace vsag {
+
+HGraphCache::HGraphCache(Allocator* allocator)
+    : allocator_(allocator), source_ids_(allocator_), neighbors_(allocator_) {
+}
+
+void
+HGraphCache::Serialize(StreamWriter& writer) const {
+    uint64_t source_ids_size = source_ids_.size();
+    StreamWriter::WriteObj(writer, source_ids_size);
+    Vector<InnerIdType> empty(allocator_);
+    for (uint64_t i = 0; i < source_ids_size; ++i) {
+        const auto& source_id = source_ids_[i];
+        StreamWriter::WriteString(writer, source_id);
+        // Write neighbors for this source_id if exists, otherwise write empty vector
+        auto it = neighbors_.find(source_id);
+        if (it != neighbors_.end()) {
+            StreamWriter::WriteVector(writer, it->second);
+        } else {
+            StreamWriter::WriteVector(writer, empty);
+        }
+    }
+}
+
+void
+HGraphCache::Deserialize(StreamReader& reader) {
+    uint64_t source_ids_size = 0;
+    StreamReader::ReadObj(reader, source_ids_size);
+    source_ids_.clear();
+    source_ids_.reserve(source_ids_size);
+    neighbors_.clear();
+    for (uint64_t i = 0; i < source_ids_size; ++i) {
+        std::string source_id = StreamReader::ReadString(reader);
+        source_ids_.push_back(source_id);
+        Vector<InnerIdType> neighbors(allocator_);
+        StreamReader::ReadVector(reader, neighbors);
+        if (!neighbors.empty()) {
+            neighbors_.emplace(std::move(source_id), std::move(neighbors));
+        }
+    }
+}
+
+std::vector<std::string>
+HGraphCache::GetNeighbors(const std::string& source_id) const {
+    std::vector<std::string> result;
+    auto it = neighbors_.find(source_id);
+    if (it == neighbors_.end()) {
+        return result;
+    }
+    const auto& inner_ids = it->second;
+    result.reserve(inner_ids.empty() ? 0 : inner_ids.size() - 1);
+    for (uint64_t i = 1; i < inner_ids.size(); ++i) {
+        const auto& inner_id = inner_ids[i];
+        if (static_cast<uint64_t>(inner_id) < source_ids_.size()) {
+            result.push_back(source_ids_[inner_id]);
+        }
+    }
+    return result;
+}
+
+}  // namespace vsag

--- a/src/algorithm/hgraph/hgraph_cache.h
+++ b/src/algorithm/hgraph/hgraph_cache.h
@@ -1,0 +1,52 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+
+#include "storage/serialization.h"
+#include "typing.h"
+#include "vsag/allocator.h"
+
+namespace vsag {
+
+class HGraphCache {
+public:
+    explicit HGraphCache(Allocator* allocator);
+
+    ~HGraphCache() = default;
+
+    void
+    Serialize(StreamWriter& writer) const;
+
+    void
+    Deserialize(StreamReader& reader);
+
+    std::vector<std::string>
+    GetNeighbors(const std::string& source_id) const;
+
+public:
+    Allocator* const allocator_;
+
+    // mapping from inner_id to source_id string
+    Vector<std::string> source_ids_;
+
+    // mapping from source_id to neighbor inner_ids,
+    // neighbors_[source_id][0] is self inner_id,
+    // neighbors_[source_id][1...] are neighbor inner_ids
+    UnorderedMap<std::string, Vector<InnerIdType>> neighbors_;
+};
+}  // namespace vsag

--- a/src/algorithm/hgraph/hgraph_cache_test.cpp
+++ b/src/algorithm/hgraph/hgraph_cache_test.cpp
@@ -1,0 +1,178 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "hgraph_cache.h"
+
+#include <sstream>
+
+#include "impl/allocator/safe_allocator.h"
+#include "storage/stream_reader.h"
+#include "storage/stream_writer.h"
+#include "unittest.h"
+
+TEST_CASE("HGraphCache Serialize & Deserialize", "[ut][hgraph_cache]") {
+    auto allocator = vsag::SafeAllocator::FactoryDefaultAllocator();
+
+    SECTION("empty cache") {
+        vsag::HGraphCache cache1(allocator.get());
+        std::stringstream ss;
+        vsag::IOStreamWriter writer(ss);
+        cache1.Serialize(writer);
+
+        vsag::HGraphCache cache2(allocator.get());
+        vsag::IOStreamReader reader(ss);
+        cache2.Deserialize(reader);
+
+        REQUIRE(cache2.source_ids_.empty());
+        REQUIRE(cache2.neighbors_.empty());
+    }
+
+    SECTION("cache with source_ids of different lengths") {
+        vsag::HGraphCache cache1(allocator.get());
+        cache1.source_ids_.push_back("a");
+        cache1.source_ids_.push_back("bb");
+        cache1.source_ids_.push_back("ccc");
+        cache1.source_ids_.push_back("long_source_id_12345");
+
+        std::stringstream ss;
+        vsag::IOStreamWriter writer(ss);
+        cache1.Serialize(writer);
+
+        vsag::HGraphCache cache2(allocator.get());
+        vsag::IOStreamReader reader(ss);
+        cache2.Deserialize(reader);
+
+        REQUIRE(cache2.source_ids_.size() == 4);
+        REQUIRE(cache2.source_ids_[0] == "a");
+        REQUIRE(cache2.source_ids_[1] == "bb");
+        REQUIRE(cache2.source_ids_[2] == "ccc");
+        REQUIRE(cache2.source_ids_[3] == "long_source_id_12345");
+    }
+
+    SECTION("cache with neighbors") {
+        vsag::HGraphCache cache1(allocator.get());
+        cache1.source_ids_.push_back("a");
+        cache1.source_ids_.push_back("bb");
+        cache1.source_ids_.push_back("ccc");
+        cache1.source_ids_.push_back("dddd");
+        cache1.source_ids_.push_back("eeeee");
+
+        vsag::Vector<vsag::InnerIdType> neighbors1(allocator.get());
+        neighbors1.push_back(0);
+        neighbors1.push_back(1);
+        neighbors1.push_back(2);
+        cache1.neighbors_.emplace("a", std::move(neighbors1));
+
+        vsag::Vector<vsag::InnerIdType> neighbors2(allocator.get());
+        neighbors2.push_back(3);
+        neighbors2.push_back(4);
+        cache1.neighbors_.emplace("bb", std::move(neighbors2));
+
+        std::stringstream ss;
+        vsag::IOStreamWriter writer(ss);
+        cache1.Serialize(writer);
+
+        vsag::HGraphCache cache2(allocator.get());
+        vsag::IOStreamReader reader(ss);
+        cache2.Deserialize(reader);
+
+        REQUIRE(cache2.neighbors_.size() == 2);
+        REQUIRE(cache2.neighbors_.at("a").size() == 3);
+        REQUIRE(cache2.neighbors_.at("a")[0] == 0);
+        REQUIRE(cache2.neighbors_.at("a")[1] == 1);
+        REQUIRE(cache2.neighbors_.at("a")[2] == 2);
+        REQUIRE(cache2.neighbors_.at("bb").size() == 2);
+        REQUIRE(cache2.neighbors_.at("bb")[0] == 3);
+        REQUIRE(cache2.neighbors_.at("bb")[1] == 4);
+    }
+
+    SECTION("cache with both source_ids and neighbors") {
+        vsag::HGraphCache cache1(allocator.get());
+        cache1.source_ids_.push_back("x");
+        cache1.source_ids_.push_back("yy");
+
+        vsag::Vector<vsag::InnerIdType> neighbors1(allocator.get());
+        neighbors1.push_back(0);
+        neighbors1.push_back(1);
+        cache1.neighbors_.emplace("x", std::move(neighbors1));
+
+        std::stringstream ss;
+        vsag::IOStreamWriter writer(ss);
+        cache1.Serialize(writer);
+
+        vsag::HGraphCache cache2(allocator.get());
+        vsag::IOStreamReader reader(ss);
+        cache2.Deserialize(reader);
+
+        REQUIRE(cache2.source_ids_.size() == 2);
+        REQUIRE(cache2.source_ids_[0] == "x");
+        REQUIRE(cache2.neighbors_.size() == 1);
+        REQUIRE(cache2.neighbors_.at("x").size() == 2);
+    }
+}
+
+TEST_CASE("HGraphCache GetNeighbors", "[ut][hgraph_cache]") {
+    auto allocator = vsag::SafeAllocator::FactoryDefaultAllocator();
+
+    SECTION("source_id not found") {
+        vsag::HGraphCache cache(allocator.get());
+        auto result = cache.GetNeighbors("nonexistent");
+        REQUIRE(result.empty());
+    }
+
+    SECTION("get neighbors for existing source_id") {
+        vsag::HGraphCache cache(allocator.get());
+        cache.source_ids_.push_back("a");
+        cache.source_ids_.push_back("bb");
+        cache.source_ids_.push_back("ccc");
+        cache.source_ids_.push_back("dddddd");
+
+        vsag::Vector<vsag::InnerIdType> neighbors(allocator.get());
+        neighbors.push_back(0);
+        neighbors.push_back(1);
+        neighbors.push_back(2);
+        cache.neighbors_.emplace("a", std::move(neighbors));
+
+        auto result = cache.GetNeighbors("a");
+        REQUIRE(result.size() == 2);
+        REQUIRE(result[0] == "bb");
+        REQUIRE(result[1] == "ccc");
+    }
+
+    SECTION("get neighbors after deserialize") {
+        vsag::HGraphCache cache1(allocator.get());
+        cache1.source_ids_.push_back("key_a");
+        cache1.source_ids_.push_back("key_bb");
+        cache1.source_ids_.push_back("key_ccc");
+
+        vsag::Vector<vsag::InnerIdType> neighbors(allocator.get());
+        neighbors.push_back(0);
+        neighbors.push_back(1);
+        neighbors.push_back(2);
+        cache1.neighbors_.emplace("key_a", std::move(neighbors));
+
+        std::stringstream ss;
+        vsag::IOStreamWriter writer(ss);
+        cache1.Serialize(writer);
+
+        vsag::HGraphCache cache2(allocator.get());
+        vsag::IOStreamReader reader(ss);
+        cache2.Deserialize(reader);
+
+        auto result = cache2.GetNeighbors("key_a");
+        REQUIRE(result.size() == 2);
+        REQUIRE(result[0] == "key_bb");
+        REQUIRE(result[1] == "key_ccc");
+    }
+}

--- a/src/algorithm/inner_index_interface.h
+++ b/src/algorithm/inner_index_interface.h
@@ -454,6 +454,18 @@ public:
     }
 
     virtual void
+    ExportCache(std::ostream& out_stream) {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "Index doesn't support ExportCache");
+    }
+
+    virtual void
+    ImportCache(std::istream& in_stream) {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "Index doesn't support ImportCache");
+    }
+
+    virtual void
     Train(const DatasetPtr& base){};
 
     virtual void

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -45,6 +45,7 @@ const char* const EXTRA_INFO_SIZE = "extra_info_size";
 const char* const VECTOR_COUNTS = "vector_counts";
 const char* const MULTI_VECTORS = "multi_vectors";
 const char* const MULTI_VECTOR_DIM = "multi_vector_dim";
+const char* const SOURCE_ID = "source_id";
 
 const char* const HNSW_DATA = "hnsw_data";
 const char* const CONJUGATE_GRAPH_DATA = "conjugate_graph_data";

--- a/src/dataset_impl.h
+++ b/src/dataset_impl.h
@@ -313,6 +313,20 @@ public:
         return 0;
     }
 
+    DatasetPtr
+    SourceID(const std::string* source_id) override {
+        this->data_[SOURCE_ID] = source_id;
+        return shared_from_this();
+    }
+
+    const std::string*
+    GetSourceID() const override {
+        if (auto iter = this->data_.find(SOURCE_ID); iter != this->data_.end()) {
+            return std::get<const std::string*>(iter->second);
+        }
+        return nullptr;
+    }
+
     static DatasetPtr
     MakeEmptyDataset();
 

--- a/src/impl/label_table.cpp
+++ b/src/impl/label_table.cpp
@@ -138,6 +138,7 @@ LabelTable::LabelTable(Allocator* allocator,
       label_remap_(allocator, label_remap_type),
       allocator_(allocator),
       deleted_ids_(allocator),
+      source_id_table_(0, allocator),
       hole_list_(0, allocator) {
     (void)compress_redundant_data;
     deleted_ids_filter_ = std::make_shared<RemoveListFilter>(deleted_ids_, delete_ids_mutex_);

--- a/src/impl/label_table.h
+++ b/src/impl/label_table.h
@@ -441,6 +441,23 @@ public:
         return false;
     }
 
+    bool
+    InsertSourceId(InnerIdType inner_id, const std::string& source_id) {
+        if (inner_id >= source_id_table_.size()) {
+            source_id_table_.resize(inner_id + 1);
+        }
+        source_id_table_[inner_id] = source_id;
+        return true;
+    }
+
+    std::string
+    GetSourceId(InnerIdType inner_id) const {
+        if (inner_id >= source_id_table_.size()) {
+            return {};
+        }
+        return source_id_table_[inner_id];
+    }
+
     void
     Move(InnerIdType from, InnerIdType to) {
         if (from == to) {
@@ -490,6 +507,8 @@ private:
     UnorderedSet<InnerIdType> deleted_ids_;       // Record deleted ids.
     FilterPtr deleted_ids_filter_{nullptr};       // Filter to filter out deleted ids.
     mutable std::shared_mutex delete_ids_mutex_;  // Mutex to protect deleted_ids_.
+
+    Vector<std::string> source_id_table_;  // Map from id to source id, used for cache.
 
     Vector<InnerIdType> hole_list_;         // Reusable id list (stack structure).
     mutable std::shared_mutex hole_mutex_;  // Mutex to protect hole_list_.


### PR DESCRIPTION
## Summary

- Add string-based source ID support for vectors in Dataset and HGraph index
- Implement `HGraphCache` class for storing source ID to neighbor mappings
- Add `ExportCache`/`ImportCache` interfaces to enable cache serialization
- Enable faster neighbor lookups by source ID without graph traversal
- Include unit tests for cache serialization/deserialization

## Changes

**Public API additions:**
- `Dataset::SourceID()` / `Dataset::GetSourceID()` - associate source IDs with datasets
- `Index::ExportCache()` / `Index::ImportCache()` - cache serialization interface

**HGraph implementation:**
- New `HGraphCache` class with source ID mapping and neighbor storage
- Cache populated during `Add()` operation when source IDs present
- Serialize/deserialize support for cache persistence

**Test coverage:**
- Unit tests for `HGraphCache` serialization with various data scenarios

Fixes: #2094