### PR TITLE
feat: add BuildWithCache support for HGraph incremental index building

### DIFF
--- a/include/vsag/constants.h
+++ b/include/vsag/constants.h
@@ -36,6 +36,7 @@ extern const char* const SPARSE_VECTORS;
 extern const char* const INT8_VECTORS;
 extern const char* const ATTRIBUTE_SETS;
 extern const char* const DATASET_PATHS;
+extern const char* const FEATURE_IDS;
 extern const char* const EXTRA_INFOS;
 extern const char* const EXTRA_INFO_SIZE;
 extern const char* const VECTOR_COUNTS;

--- a/include/vsag/dataset.h
+++ b/include/vsag/dataset.h
@@ -330,6 +330,23 @@ public:
     GetPaths() const = 0;
 
     /**
+     * @brief Sets the FeatureID array for the dataset.
+     *
+     * @param feature_ids Pointer to the array of FeatureID strings.
+     * @return DatasetPtr A shared pointer to the dataset with updated FeatureIDs.
+     */
+    virtual DatasetPtr
+    FeatureIds(const std::string* feature_ids) = 0;
+
+    /**
+     * @brief Retrieves the FeatureID array of the dataset.
+     *
+     * @return const std::string* Pointer to the array of FeatureIDs.
+     */
+    virtual const std::string*
+    GetFeatureIds() const = 0;
+
+    /**
      * @brief Sets the extra info for the dataset.
      *
      * @param paths Pointer to extra info.

--- a/include/vsag/index.h
+++ b/include/vsag/index.h
@@ -51,6 +51,44 @@ struct MergeUnit {
     IdMapFunction id_map_func = nullptr;
 };
 
+struct BuildCacheOptions {
+  bool enable_warm_start = true;
+  uint32_t hit_refine_rounds = 2;
+  uint32_t missed_refine_rounds = 4;
+  uint32_t hit_refine_ef = 0;
+  uint32_t missed_refine_ef = 0;
+  bool enable_parallel_refine = false;
+  uint32_t refine_parallelism = 0;
+  bool drop_invalid_neighbors = true;
+  bool build_route_graph = true;
+};
+
+struct BuildCacheStats {
+  uint64_t total_nodes = 0;
+  uint64_t cached_nodes = 0;
+  uint64_t hit_nodes = 0;
+  uint64_t missed_nodes = 0;
+  uint64_t hit_seed_neighbor_total = 0;
+  uint64_t missed_seed_neighbor_total = 0;
+  uint64_t hit_empty_seed_nodes = 0;
+  uint64_t missed_empty_seed_nodes = 0;
+  uint64_t dropped_neighbors = 0;
+  uint64_t invalid_neighbors = 0;
+  uint64_t hit_refine_rounds = 0;
+  uint64_t missed_refine_rounds = 0;
+  uint32_t hit_refine_ef = 0;
+  uint32_t missed_refine_ef = 0;
+  uint32_t hit_refine_parallelism = 0;
+  uint32_t missed_refine_parallelism = 0;
+  uint64_t cache_load_us = 0;
+  uint64_t warm_start_apply_us = 0;
+  uint64_t hit_refine_us = 0;
+  uint64_t missed_refine_us = 0;
+  uint64_t route_graph_build_us = 0;
+  uint64_t route_graph_levels = 0;
+  float cache_hit_rate = 0;
+};
+
 enum class IndexType { HNSW, DISKANN, HGRAPH, IVF, PYRAMID, BRUTEFORCE, SPARSE, SINDI, WARP };
 
 #define DATA_FLAG_FLOAT32_VECTOR 0x01
@@ -145,6 +183,33 @@ public:
     virtual tl::expected<Checkpoint, Error>
     ContinueBuild(const DatasetPtr& base, const BinarySet& binary_set) {
         throw std::runtime_error("Index not support partial build");
+    }
+
+    [[nodiscard]] virtual bool
+    SupportsBuildCache() const {
+      return false;
+    }
+
+    virtual tl::expected<void, Error>
+    ExportBuildCache(std::ostream& out_stream) const {
+      throw std::runtime_error("Index doesn't support ExportBuildCache");
+    }
+
+    virtual tl::expected<std::vector<int64_t>, Error>
+    BuildWithCache(const DatasetPtr& base,
+             std::istream& in_stream,
+             const BuildCacheOptions& options = BuildCacheOptions{}) {
+      throw std::runtime_error("Index doesn't support BuildWithCache");
+    }
+
+    virtual tl::expected<void, Error>
+    PrepareFeatureIdsForBuildCache(const DatasetPtr& base) {
+      throw std::runtime_error("Index doesn't support PrepareFeatureIdsForBuildCache");
+    }
+
+    [[nodiscard]] virtual tl::expected<BuildCacheStats, Error>
+    GetBuildCacheStats() const {
+      throw std::runtime_error("Index doesn't support GetBuildCacheStats");
     }
 
     /**

--- a/src/algorithm/hgraph/CMakeLists.txt
+++ b/src/algorithm/hgraph/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(HGRAPH_SRCS
     hgraph.cpp
     hgraph_build.cpp
+    hgraph_build_cache.cpp
     hgraph_modify.cpp
     hgraph_parameter.cpp
     hgraph_param_mapping.cpp

--- a/src/algorithm/hgraph/hgraph.h
+++ b/src/algorithm/hgraph/hgraph.h
@@ -18,6 +18,7 @@
 #include <random>
 #include <shared_mutex>
 #include <string>
+#include <unordered_map>
 
 #include "../inner_index_interface.h"
 #include "common.h"
@@ -206,6 +207,23 @@ public:
                     const AttributeSet& new_attrs,
                     const AttributeSet& origin_attrs) override;
 
+    [[nodiscard]] bool
+    SupportsBuildCache() const override;
+
+    void
+    ExportBuildCache(std::ostream& out_stream) const override;
+
+    std::vector<int64_t>
+    BuildWithCache(const DatasetPtr& data,
+                   std::istream& in_stream,
+                   const BuildCacheOptions& options) override;
+
+    void
+    PrepareFeatureIdsForBuildCache(const DatasetPtr& data) override;
+
+    [[nodiscard]] BuildCacheStats
+    GetBuildCacheStats() const override;
+
     static JsonType
     map_hgraph_param(const JsonType& hgraph_json);
 
@@ -294,6 +312,88 @@ public:
                      DistanceRecordVector* rabitq_lower_bound_candidates = nullptr) const;
 
 private:
+    void
+    serialize_feature_ids(StreamWriter& writer) const;
+
+    void
+    deserialize_feature_ids(StreamReader& reader, uint64_t expected_count);
+
+    void
+    validate_feature_ids_dataset(const DatasetPtr& data) const;
+
+    uint64_t
+    calculate_build_cache_param_hash() const;
+
+    struct RefineRoundStats {
+        uint64_t elapsed_us = 0;
+        uint64_t processed_nodes = 0;
+    };
+
+    struct RefineExecutionStats {
+        uint64_t elapsed_us = 0;
+        uint64_t executed_rounds = 0;
+        uint32_t effective_parallelism = 0;
+        std::vector<RefineRoundStats> round_stats;
+    };
+
+    DistHeapPtr
+    collect_refine_candidates(const DatasetPtr& data,
+                              InnerIdType inner_id,
+                              uint32_t input_idx,
+                              const FlattenInterfacePtr& flatten_codes,
+                              uint32_t refine_ef,
+                              bool use_self_as_entry) const;
+
+    void
+    refine_single_node(const DatasetPtr& data,
+                       InnerIdType inner_id,
+                       uint32_t input_idx,
+                       const FlattenInterfacePtr& flatten_codes,
+                       uint32_t refine_ef,
+                       bool use_self_as_entry);
+
+    RefineExecutionStats
+    refine_nodes_for_build_cache(const DatasetPtr& data,
+                                 const std::vector<InnerIdType>& ids_to_refine,
+                                 std::string_view phase_name,
+                                 uint32_t rounds,
+                                 uint32_t refine_ef,
+                                 bool use_self_as_entry,
+                                 bool enable_parallel_refine,
+                                 uint32_t requested_parallelism,
+                                 const FlattenInterfacePtr& flatten_codes,
+                                 const std::unordered_map<InnerIdType, uint32_t>& inner_id_to_input_idx);
+
+    RefineExecutionStats
+    refine_nodes_two_phase(const DatasetPtr& data,
+                           const std::vector<InnerIdType>& ids_to_refine,
+                           std::string_view phase_name,
+                           uint32_t rounds,
+                           uint32_t refine_ef,
+                           bool use_self_as_entry,
+                           bool enable_parallel_refine,
+                           uint32_t requested_parallelism,
+                           const FlattenInterfacePtr& flatten_codes,
+                           const std::unordered_map<InnerIdType, uint32_t>& inner_id_to_input_idx);
+
+    Vector<InnerIdType>
+    select_refine_neighbors_for_node(const DatasetPtr& data,
+                                     InnerIdType inner_id,
+                                     uint32_t input_idx,
+                                     const FlattenInterfacePtr& flatten_codes,
+                                     uint32_t refine_ef,
+                                     bool use_self_as_entry) const;
+
+    void
+    select_refine_neighbors_with_distances(const DatasetPtr& data,
+                                           InnerIdType inner_id,
+                                           uint32_t input_idx,
+                                           const FlattenInterfacePtr& flatten_codes,
+                                           uint32_t refine_ef,
+                                           bool use_self_as_entry,
+                                           Vector<InnerIdType>& out_neighbors,
+                                           Vector<float>& out_distances) const;
+
     // since v0.15
     JsonType
     serialize_basic_info() const;
@@ -432,5 +532,8 @@ private:
 
     bool support_duplicate_{false};
     float duplicate_distance_threshold_{0.0F};
+
+    std::vector<std::string> feature_ids_;
+    BuildCacheStats build_cache_stats_;
 };
 }  // namespace vsag

--- a/src/algorithm/hgraph/hgraph_build.cpp
+++ b/src/algorithm/hgraph/hgraph_build.cpp
@@ -95,6 +95,7 @@ HGraph::build_by_odescent(const DatasetPtr& data) {
 
     auto total = data->GetNumElements();
     const auto* labels = data->GetIds();
+    const auto* feature_ids = data->GetFeatureIds();
     const auto* vectors = data->GetFloat32Vectors();
     const auto* extra_infos = data->GetExtraInfos();
     Vector<int64_t> valid_indices(allocator_);
@@ -118,6 +119,8 @@ HGraph::build_by_odescent(const DatasetPtr& data) {
     }
     this->resize(current_count + new_ids_count);
     this->total_count_ += new_ids_count;
+    this->feature_ids_.clear();
+    this->feature_ids_.resize(this->total_count_.load());
     Vector<Vector<InnerIdType>> route_graph_ids(allocator_);
     auto need_sq8_build_data =
         need_temporary_sq8_build_data(this->basic_flatten_codes_, this->has_precise_reorder());
@@ -142,6 +145,9 @@ HGraph::build_by_odescent(const DatasetPtr& data) {
         auto label = labels[i];
         InnerIdType inner_id = inner_ids.at(cur_size);
         this->label_table_->Insert(inner_id, label);
+        if (feature_ids != nullptr && inner_id < this->feature_ids_.size()) {
+            this->feature_ids_[inner_id] = feature_ids[i];
+        }
         if (not defer_persistent_codes) {
             this->insert_persistent_codes(vectors + dim_ * i, inner_id);
         } else {
@@ -261,6 +267,7 @@ HGraph::Add(const DatasetPtr& data, AddMode mode) {
     auto total = data->GetNumElements();
     const auto* labels = data->GetIds();
     const auto* extra_infos = data->GetExtraInfos();
+    const auto* feature_ids = data->GetFeatureIds();
     const auto* attr_sets = data->GetAttributeSets();
     bool use_parallel_add = this->thread_pool_ != nullptr;
     Vector<std::pair<InnerIdType, LabelType>> inner_ids(allocator_);
@@ -289,6 +296,12 @@ HGraph::Add(const DatasetPtr& data, AddMode mode) {
             std::scoped_lock label_lock(this->label_lookup_mutex_);
             this->label_table_->Insert(inner_id, labels[j]);
             inner_ids.emplace_back(inner_id, j);
+        }
+        if (feature_ids != nullptr) {
+            if (inner_id >= this->feature_ids_.size()) {
+                this->feature_ids_.resize(this->total_count_.load());
+            }
+            this->feature_ids_[inner_id] = feature_ids[j];
         }
     }
     if (temporary_build_flatten_codes_ != nullptr) {

--- a/src/algorithm/hgraph/hgraph_build_cache.cpp
+++ b/src/algorithm/hgraph/hgraph_build_cache.cpp
@@ -1,0 +1,1317 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "hgraph.h"
+
+#include <chrono>
+#include <cstring>
+#include <future>
+#include <iostream>
+#include <unordered_map>
+#include <unordered_set>
+
+#include <fmt/format.h>
+
+#include "impl/heap/standard_heap.h"
+#include "impl/odescent/odescent_graph_builder.h"
+#include "impl/pruning_strategy.h"
+#include "storage/stream_reader.h"
+#include "storage/stream_writer.h"
+
+namespace vsag {
+
+namespace {
+
+constexpr uint64_t kBuildCacheMagic = 0x5653414743484500ULL;
+constexpr uint32_t kBuildCacheVersion = 1;
+constexpr uint32_t kBuildCacheFeatureModeVariableText = 1;
+constexpr uint32_t kInvalidOldId = std::numeric_limits<uint32_t>::max();
+constexpr int64_t kFeatureIdsFormatVersion = 1;
+constexpr std::string_view kFeatureIdsFormatVersionKey = "feature_ids_format_version";
+
+struct BuildCacheHeader {
+    uint64_t magic = kBuildCacheMagic;
+    uint32_t version = kBuildCacheVersion;
+    uint32_t feature_id_mode = kBuildCacheFeatureModeVariableText;
+    uint64_t node_count = 0;
+    uint32_t max_degree = 0;
+    uint32_t reserved0 = 0;
+    uint64_t feature_id_count = 0;
+    uint64_t feature_id_bytes = 0;
+    uint64_t build_param_hash = 0;
+    uint64_t create_time = 0;
+    uint8_t reserved[64] = {0};
+};
+
+static_assert(sizeof(BuildCacheHeader) == 128, "BuildCacheHeader must be 128 bytes");
+
+struct FeatureIdIndexEntry {
+    uint64_t offset = 0;
+    uint32_t length = 0;
+    uint32_t reserved = 0;
+};
+
+static_assert(sizeof(FeatureIdIndexEntry) == 16,
+              "FeatureIdIndexEntry must be 16 bytes");
+
+struct NeighborRecordHeader {
+    uint16_t degree = 0;
+};
+
+uint64_t
+hash_combine_u64(uint64_t seed, uint64_t value) {
+    seed ^= value + 0x9e3779b97f4a7c15ULL + (seed << 6U) + (seed >> 2U);
+    return seed;
+}
+
+uint64_t
+now_us() {
+    return static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::microseconds>(
+                                     std::chrono::steady_clock::now().time_since_epoch())
+                                     .count());
+}
+
+uint64_t
+now_unix_seconds() {
+    return static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::seconds>(
+                                     std::chrono::system_clock::now().time_since_epoch())
+                                     .count());
+}
+
+void
+log_build_cache_detail(const std::string& message) {
+    std::cerr << "[hgraph_build_cache] " << message << std::endl;
+}
+
+void
+log_build_cache_detail_elapsed(const std::string& stage_name, uint64_t duration_us) {
+    std::cerr << "[hgraph_build_cache] " << stage_name << " finished in "
+              << fmt::format("{:.3f}", static_cast<double>(duration_us) / 1000000.0) << "s"
+              << std::endl;
+}
+
+}  // namespace
+
+bool
+HGraph::SupportsBuildCache() const {
+    return true;
+}
+
+void
+HGraph::validate_feature_ids_dataset(const DatasetPtr& data) const {
+    CHECK_ARGUMENT(data != nullptr, "dataset is nullptr");
+    CHECK_ARGUMENT(data->GetFeatureIds() != nullptr, "base.feature_ids is nullptr");
+    CHECK_ARGUMENT(data->GetIds() != nullptr, "base.ids is nullptr");
+    CHECK_ARGUMENT(get_data(data) != nullptr, "base.vector is nullptr");
+
+    const auto total = data->GetNumElements();
+    const auto* feature_ids = data->GetFeatureIds();
+    std::unordered_set<std::string> unique_feature_ids;
+    unique_feature_ids.reserve(static_cast<size_t>(total));
+    for (int64_t i = 0; i < total; ++i) {
+        CHECK_ARGUMENT(not feature_ids[i].empty(), "base.feature_ids contains empty value");
+        auto inserted = unique_feature_ids.emplace(feature_ids[i]);
+        CHECK_ARGUMENT(inserted.second,
+                       fmt::format("duplicate feature_id found: {}", feature_ids[i]));
+    }
+}
+
+void
+HGraph::PrepareFeatureIdsForBuildCache(const DatasetPtr& data) {
+    CHECK_ARGUMENT(data != nullptr, "dataset is nullptr");
+    CHECK_ARGUMENT(data->GetFeatureIds() != nullptr, "base.feature_ids is nullptr");
+    CHECK_ARGUMENT(data->GetIds() != nullptr, "base.ids is nullptr");
+    CHECK_ARGUMENT(data->GetNumElements() > 0, "dataset is empty");
+    CHECK_ARGUMENT(this->total_count_.load() > 0, "index is empty");
+
+    const auto total = data->GetNumElements();
+    const auto* labels = data->GetIds();
+    const auto* feature_ids = data->GetFeatureIds();
+
+    std::unordered_set<std::string> unique_feature_ids;
+    unique_feature_ids.reserve(static_cast<size_t>(total));
+    this->feature_ids_.clear();
+    this->feature_ids_.resize(this->total_count_.load());
+
+    std::unordered_map<LabelType, InnerIdType> label_to_inner_id;
+    label_to_inner_id.reserve(static_cast<size_t>(this->total_count_.load()));
+    for (uint64_t inner_id = 0; inner_id < static_cast<uint64_t>(this->total_count_.load()); ++inner_id) {
+        auto label = this->label_table_->GetLabelById(static_cast<InnerIdType>(inner_id));
+        auto [iter, inserted] = label_to_inner_id.emplace(label, static_cast<InnerIdType>(inner_id));
+        CHECK_ARGUMENT(inserted || this->support_duplicate_,
+                       fmt::format("duplicate label {} found in index when preparing feature ids",
+                                   label));
+        if (!inserted && this->support_duplicate_) {
+            iter->second = static_cast<InnerIdType>(inner_id);
+        }
+    }
+
+    uint64_t mapped_count = 0;
+    uint64_t found_by_label_count = 0;
+    bool row_order_consistent = true;
+    for (int64_t i = 0; i < total; ++i) {
+        CHECK_ARGUMENT(not feature_ids[i].empty(), "base.feature_ids contains empty value");
+        auto inserted = unique_feature_ids.emplace(feature_ids[i]);
+        CHECK_ARGUMENT(inserted.second,
+                       fmt::format("duplicate feature_id found: {}", feature_ids[i]));
+
+        auto iter = label_to_inner_id.find(labels[i]);
+        if (iter == label_to_inner_id.end()) {
+            continue;
+        }
+        auto inner_id = iter->second;
+        ++found_by_label_count;
+        CHECK_ARGUMENT(inner_id < this->feature_ids_.size(),
+                       fmt::format("inner_id {} out of range when preparing feature ids",
+                                   inner_id));
+        row_order_consistent = row_order_consistent &&
+                               (static_cast<uint64_t>(i) == static_cast<uint64_t>(inner_id));
+        CHECK_ARGUMENT(this->feature_ids_[inner_id].empty() || this->feature_ids_[inner_id] == feature_ids[i],
+                       fmt::format("label {} maps to conflicting feature ids", labels[i]));
+        if (this->feature_ids_[inner_id].empty()) {
+            this->feature_ids_[inner_id] = feature_ids[i];
+            ++mapped_count;
+        }
+    }
+
+    const auto expected_count = static_cast<uint64_t>(this->total_count_.load());
+    const bool can_use_row_order_fallback = this->delete_count_.load() == 0 &&
+                                            static_cast<uint64_t>(total) == expected_count &&
+                                            row_order_consistent;
+    if (mapped_count != expected_count && can_use_row_order_fallback) {
+        for (uint64_t i = 0; i < expected_count; ++i) {
+            if (this->feature_ids_[i].empty()) {
+                this->feature_ids_[i] = feature_ids[i];
+                ++mapped_count;
+            } else {
+                CHECK_ARGUMENT(this->feature_ids_[i] == feature_ids[i],
+                               fmt::format("row-order fallback found conflicting feature id at row {}",
+                                           i));
+            }
+        }
+    }
+
+    CHECK_ARGUMENT(mapped_count == expected_count,
+                   fmt::format("feature_ids metadata is incomplete after preparation: mapped={}, expected={}, found_by_label={}, row_order_consistent={}",
+                               mapped_count,
+                               expected_count,
+                               found_by_label_count,
+                               row_order_consistent));
+}
+
+uint64_t
+HGraph::calculate_build_cache_param_hash() const {
+    uint64_t seed = 0;
+    seed = hash_combine_u64(seed, static_cast<uint64_t>(this->dim_));
+    seed = hash_combine_u64(seed, static_cast<uint64_t>(this->metric_));
+    seed = hash_combine_u64(seed, static_cast<uint64_t>(this->data_type_));
+    seed = hash_combine_u64(seed, static_cast<uint64_t>(this->bottom_graph_->MaximumDegree()));
+    seed = hash_combine_u64(seed, static_cast<uint64_t>(this->ef_construct_));
+    uint32_t alpha_bits = 0;
+    static_assert(sizeof(alpha_bits) == sizeof(this->alpha_));
+    std::memcpy(&alpha_bits, &this->alpha_, sizeof(alpha_bits));
+    seed = hash_combine_u64(seed, alpha_bits);
+    return seed;
+}
+
+DistHeapPtr
+HGraph::collect_refine_candidates(const DatasetPtr& data,
+                                  InnerIdType inner_id,
+                                  uint32_t input_idx,
+                                  const FlattenInterfacePtr& flatten_codes,
+                                  uint32_t refine_ef,
+                                  bool use_self_as_entry) const {
+    const uint32_t effective_refine_ef = refine_ef == 0 ? this->ef_construct_ : refine_ef;
+    CHECK_ARGUMENT(effective_refine_ef > 0, "refine ef must be greater than 0");
+
+    auto candidates = std::make_shared<StandardHeap<true, false>>(allocator_, -1);
+    std::unordered_set<InnerIdType> seen;
+
+    Vector<InnerIdType> current_neighbors(allocator_);
+    this->bottom_graph_->GetNeighbors(inner_id, current_neighbors);
+    seen.reserve(current_neighbors.size() + effective_refine_ef);
+    for (const auto neighbor : current_neighbors) {
+        if (neighbor == inner_id || !seen.emplace(neighbor).second) {
+            continue;
+        }
+        candidates->Push(flatten_codes->ComputePairVectors(neighbor, inner_id), neighbor);
+    }
+
+    if (this->entry_point_id_ != INVALID_ENTRY_POINT && this->bottom_graph_->TotalCount() > 0) {
+        // Honour use_self_as_entry:
+        //   - true  (cache-hit nodes): start the search from inner_id itself so
+        //     the warm-started stale neighbours act as the initial frontier and
+        //     refine exploits the local neighbourhood efficiently.
+        //   - false (cache-missed / cold-start nodes): use the global entry
+        //     point for broad exploration.
+        // When the node has no cached neighbours, self-entry is meaningless,
+        // so we also fall back to the global entry point.
+        const auto search_entry_point =
+            (use_self_as_entry && !current_neighbors.empty()) ? inner_id : this->entry_point_id_;
+        InnerSearchParam param;
+        param.topk = static_cast<int64_t>(effective_refine_ef);
+        param.ef = effective_refine_ef;
+        param.ep = search_entry_point;
+        param.is_inner_id_allowed = nullptr;
+        auto result = this->search_one_graph(get_data(data, input_idx),
+                                             this->bottom_graph_,
+                                             flatten_codes,
+                                             param,
+                                             (VisitedListPtr) nullptr,
+                                             nullptr);
+        while (not result->Empty()) {
+            auto candidate = result->Top().second;
+            result->Pop();
+            if (candidate == inner_id || !seen.emplace(candidate).second) {
+                continue;
+            }
+            candidates->Push(flatten_codes->ComputePairVectors(candidate, inner_id), candidate);
+        }
+    }
+
+    return candidates;
+}
+
+void
+HGraph::refine_single_node(const DatasetPtr& data,
+                           InnerIdType inner_id,
+                           uint32_t input_idx,
+                           const FlattenInterfacePtr& flatten_codes,
+                           uint32_t refine_ef,
+                           bool use_self_as_entry) {
+    auto candidates =
+        this->collect_refine_candidates(
+            data, inner_id, input_idx, flatten_codes, refine_ef, use_self_as_entry);
+
+    LockGuard cur_lock(neighbors_mutex_, inner_id);
+    if (candidates->Empty()) {
+        Vector<InnerIdType> empty_neighbors(allocator_);
+        this->bottom_graph_->InsertNeighborsById(inner_id, empty_neighbors);
+        return;
+    }
+
+    mutually_connect_new_element(inner_id,
+                                 candidates,
+                                 this->bottom_graph_,
+                                 flatten_codes,
+                                 neighbors_mutex_,
+                                 allocator_,
+                                 alpha_);
+}
+
+HGraph::RefineExecutionStats
+HGraph::refine_nodes_for_build_cache(
+    const DatasetPtr& data,
+    const std::vector<InnerIdType>& ids_to_refine,
+    std::string_view phase_name,
+    uint32_t rounds,
+    uint32_t refine_ef,
+    bool use_self_as_entry,
+    bool enable_parallel_refine,
+    uint32_t requested_parallelism,
+    const FlattenInterfacePtr& flatten_codes,
+    const std::unordered_map<InnerIdType, uint32_t>& inner_id_to_input_idx) {
+    RefineExecutionStats stats;
+    if (ids_to_refine.empty() || rounds == 0) {
+        return stats;
+    }
+
+    // Force sequential mode to avoid deadlock in mutually_connect
+    // (multiple threads trying to lock each other's nodes)
+    uint32_t effective_parallelism = 1;
+    stats.effective_parallelism = effective_parallelism;
+
+    const uint32_t effective_refine_ef = refine_ef == 0 ? this->ef_construct_ : refine_ef;
+    CHECK_ARGUMENT(effective_refine_ef > 0, "refine ef must be greater than 0");
+
+    log_build_cache_detail(fmt::format("starting {} nodes={} rounds={} parallelism={}",
+                                       phase_name,
+                                       ids_to_refine.size(),
+                                       rounds,
+                                       effective_parallelism));
+
+    const auto begin = now_us();
+    stats.round_stats.reserve(rounds);
+    for (uint32_t round = 0; round < rounds; ++round) {
+        const auto round_begin = now_us();
+        if (effective_parallelism <= 1) {
+            for (const auto inner_id : ids_to_refine) {
+                auto data_iter = inner_id_to_input_idx.find(inner_id);
+                CHECK_ARGUMENT(data_iter != inner_id_to_input_idx.end(),
+                               fmt::format("missing input row for inner_id {}", inner_id));
+                this->refine_single_node(data,
+                                         inner_id,
+                                         data_iter->second,
+                                         flatten_codes,
+                                         effective_refine_ef,
+                                         use_self_as_entry);
+            }
+        } else {
+            const size_t chunk_count =
+                std::min<size_t>(effective_parallelism, ids_to_refine.size());
+            const size_t chunk_size = (ids_to_refine.size() + chunk_count - 1) / chunk_count;
+            std::vector<std::future<void>> futures;
+            futures.reserve(chunk_count);
+
+            for (size_t chunk = 0; chunk < chunk_count; ++chunk) {
+                const size_t begin_idx = chunk * chunk_size;
+                const size_t end_idx = std::min(ids_to_refine.size(), begin_idx + chunk_size);
+                if (begin_idx >= end_idx) {
+                    break;
+                }
+
+                futures.emplace_back(this->thread_pool_->GeneralEnqueue(
+                    [this,
+                     &data,
+                     &ids_to_refine,
+                     &inner_id_to_input_idx,
+                     &flatten_codes,
+                     effective_refine_ef,
+                     use_self_as_entry,
+                     begin_idx,
+                     end_idx]() {
+                        for (size_t index = begin_idx; index < end_idx; ++index) {
+                            const auto inner_id = ids_to_refine[index];
+                            auto data_iter = inner_id_to_input_idx.find(inner_id);
+                            CHECK_ARGUMENT(data_iter != inner_id_to_input_idx.end(),
+                                           fmt::format("missing input row for inner_id {}",
+                                                       inner_id));
+                            this->refine_single_node(data,
+                                                     inner_id,
+                                                     data_iter->second,
+                                                     flatten_codes,
+                                                     effective_refine_ef,
+                                                     use_self_as_entry);
+                        }
+                    }));
+            }
+
+            for (auto& future : futures) {
+                future.get();
+            }
+        }
+        const auto round_elapsed = now_us() - round_begin;
+        stats.round_stats.emplace_back(
+            RefineRoundStats{.elapsed_us = round_elapsed,
+                             .processed_nodes = static_cast<uint64_t>(ids_to_refine.size())});
+        log_build_cache_detail(fmt::format("{} round {}/{} finished in {:.3f}s processed_nodes={}",
+                                           phase_name,
+                                           round + 1,
+                                           rounds,
+                                           static_cast<double>(round_elapsed) / 1000000.0,
+                                           ids_to_refine.size()));
+    }
+    stats.elapsed_us = now_us() - begin;
+    stats.executed_rounds = rounds;
+    log_build_cache_detail_elapsed(std::string(phase_name), stats.elapsed_us);
+    return stats;
+}
+
+Vector<InnerIdType>
+HGraph::select_refine_neighbors_for_node(const DatasetPtr& data,
+                                         InnerIdType inner_id,
+                                         uint32_t input_idx,
+                                         const FlattenInterfacePtr& flatten_codes,
+                                         uint32_t refine_ef,
+                                         bool use_self_as_entry) const {
+    Vector<InnerIdType> result(allocator_);
+    Vector<float> distances(allocator_);
+    this->select_refine_neighbors_with_distances(
+        data, inner_id, input_idx, flatten_codes, refine_ef, use_self_as_entry, result, distances);
+    return result;
+}
+
+void
+HGraph::select_refine_neighbors_with_distances(const DatasetPtr& data,
+                                               InnerIdType inner_id,
+                                               uint32_t input_idx,
+                                               const FlattenInterfacePtr& flatten_codes,
+                                               uint32_t refine_ef,
+                                               bool use_self_as_entry,
+                                               Vector<InnerIdType>& out_neighbors,
+                                               Vector<float>& out_distances) const {
+    out_neighbors.clear();
+    out_distances.clear();
+
+    auto candidates =
+        this->collect_refine_candidates(
+            data, inner_id, input_idx, flatten_codes, refine_ef, use_self_as_entry);
+
+    if (candidates->Empty()) {
+        return;
+    }
+
+    const uint64_t max_size = this->bottom_graph_->MaximumDegree();
+
+    select_edges_by_heuristic(candidates, max_size, flatten_codes, allocator_, this->alpha_);
+
+    out_neighbors.reserve(candidates->Size());
+    out_distances.reserve(candidates->Size());
+    while (not candidates->Empty()) {
+        out_neighbors.emplace_back(candidates->Top().second);
+        out_distances.emplace_back(candidates->Top().first);
+        candidates->Pop();
+    }
+}
+
+HGraph::RefineExecutionStats
+HGraph::refine_nodes_two_phase(const DatasetPtr& data,
+                               const std::vector<InnerIdType>& ids_to_refine,
+                               std::string_view phase_name,
+                               uint32_t rounds,
+                               uint32_t refine_ef,
+                               bool use_self_as_entry,
+                               bool enable_parallel_refine,
+                               uint32_t requested_parallelism,
+                               const FlattenInterfacePtr& flatten_codes,
+                               const std::unordered_map<InnerIdType, uint32_t>& inner_id_to_input_idx) {
+    RefineExecutionStats stats;
+    if (ids_to_refine.empty() || rounds == 0) {
+        return stats;
+    }
+
+    uint32_t effective_parallelism = 1;
+    if (enable_parallel_refine && this->thread_pool_ != nullptr &&
+        this->build_thread_count_ > 1 && ids_to_refine.size() > 1) {
+        effective_parallelism = requested_parallelism > 0
+            ? std::min<uint32_t>(requested_parallelism, this->build_thread_count_)
+            : static_cast<uint32_t>(this->build_thread_count_);
+        effective_parallelism =
+            std::min<uint32_t>(effective_parallelism,
+                               static_cast<uint32_t>(ids_to_refine.size()));
+    }
+    stats.effective_parallelism = effective_parallelism;
+
+    const uint32_t effective_refine_ef = refine_ef == 0 ? this->ef_construct_ : refine_ef;
+    CHECK_ARGUMENT(effective_refine_ef > 0, "refine ef must be greater than 0");
+
+    log_build_cache_detail(fmt::format("starting {} nodes={} rounds={} parallelism={} (two-phase)",
+                                       phase_name,
+                                       ids_to_refine.size(),
+                                       rounds,
+                                       effective_parallelism));
+
+    const auto begin = now_us();
+    stats.round_stats.reserve(rounds);
+
+    constexpr int64_t kBlockSize = 128;
+
+    for (uint32_t round = 0; round < rounds; ++round) {
+        const auto round_begin = now_us();
+
+        // ===== Phase 1: parallel search & local select (collect distances too) =====
+        Vector<Vector<InnerIdType>> selected_neighbors(
+            ids_to_refine.size(), Vector<InnerIdType>(allocator_), allocator_);
+        Vector<Vector<float>> selected_distances(
+            ids_to_refine.size(), Vector<float>(allocator_), allocator_);
+
+        if (effective_parallelism <= 1) {
+            for (size_t i = 0; i < ids_to_refine.size(); ++i) {
+                const auto inner_id = ids_to_refine[i];
+                auto data_iter = inner_id_to_input_idx.find(inner_id);
+                CHECK_ARGUMENT(data_iter != inner_id_to_input_idx.end(),
+                               fmt::format("missing input row for inner_id {}", inner_id));
+                this->select_refine_neighbors_with_distances(
+                    data, inner_id, data_iter->second, flatten_codes,
+                    effective_refine_ef, use_self_as_entry,
+                    selected_neighbors[i], selected_distances[i]);
+            }
+        } else {
+            std::vector<std::future<void>> futures;
+            futures.reserve((ids_to_refine.size() + kBlockSize - 1) / kBlockSize);
+
+            for (int64_t i = 0; i < static_cast<int64_t>(ids_to_refine.size()); i += kBlockSize) {
+                auto end = std::min(i + kBlockSize, static_cast<int64_t>(ids_to_refine.size()));
+
+                futures.emplace_back(this->thread_pool_->GeneralEnqueue(
+                    [this, &data, &ids_to_refine, &inner_id_to_input_idx, &flatten_codes,
+                     effective_refine_ef, use_self_as_entry,
+                     &selected_neighbors, &selected_distances, i, end]() {
+                        for (int64_t idx = i; idx < end; ++idx) {
+                            const auto inner_id = ids_to_refine[idx];
+                            auto data_iter = inner_id_to_input_idx.find(inner_id);
+                            CHECK_ARGUMENT(data_iter != inner_id_to_input_idx.end(),
+                                           fmt::format("missing input row for inner_id {}", inner_id));
+                            this->select_refine_neighbors_with_distances(
+                                data, inner_id, data_iter->second, flatten_codes,
+                                effective_refine_ef, use_self_as_entry,
+                                selected_neighbors[idx], selected_distances[idx]);
+                        }
+                    }));
+            }
+
+            for (auto& future : futures) {
+                future.get();
+            }
+        }
+
+        const auto search_elapsed = now_us() - round_begin;
+        log_build_cache_detail(
+            fmt::format("{} round {}/{} search phase finished in {:.3f}s",
+                        phase_name,
+                        round + 1,
+                        rounds,
+                        static_cast<double>(search_elapsed) / 1000000.0));
+
+        // ===== Phase 2: serial writeback of selected neighbours =====
+        const auto writeback_begin = now_us();
+
+        for (size_t i = 0; i < ids_to_refine.size(); ++i) {
+            LockGuard lock(neighbors_mutex_, ids_to_refine[i]);
+            this->bottom_graph_->InsertNeighborsById(ids_to_refine[i], selected_neighbors[i]);
+        }
+
+        const auto writeback_elapsed = now_us() - writeback_begin;
+
+        // ===== Phase 3: reverse edge install =====
+        // Optimisations vs. the previous version:
+        //   (1) Carry the (src -> neighbour) distance computed during the
+        //       select phase, so the heuristic prune below does not need to
+        //       recompute these distances.
+        //   (2) Shard the reverse map by `target_id % N_shard` and process
+        //       shards in parallel. Each target id lives in exactly one shard,
+        //       so the in-shard serial processing preserves the original
+        //       single-writer-per-target invariant -- no extra mutex needed
+        //       beyond the existing `neighbors_mutex_` per-id lock.
+        //   (3) Replace the O(M^2) `std::find` dedup with an O(M) set lookup
+        //       on small fixed-size scratch buffers.
+        //   (4) Build the per-shard (target -> [(src,dist), ...]) map in two
+        //       fully parallel stages: every worker first scatters its slice
+        //       of `ids_to_refine` into per-(worker, shard) local buffers
+        //       (lock-free); afterwards each shard is materialised into its
+        //       hash map by a separate worker (shard-parallel) by simply
+        //       concatenating the relevant slices.
+        const auto reverse_begin = now_us();
+
+        const uint32_t reverse_shard_count =
+            (effective_parallelism > 1)
+                ? std::max<uint32_t>(effective_parallelism,
+                                     static_cast<uint32_t>(this->build_thread_count_))
+                : 1U;
+
+        struct ReverseEdgeEntry {
+            InnerIdType src_id;
+            float dist;
+        };
+
+        // Scatter target_id together with src/dist so the materialise stage
+        // can directly bucket-by-target. Using a tagged struct (target,src,dist)
+        // is the simplest layout; tail-packing avoids padding cost vs. a
+        // separate vectors-of-arrays representation.
+        struct ScatterRecord {
+            InnerIdType target_id;
+            InnerIdType src_id;
+            float dist;
+        };
+
+        struct ReverseShard {
+            // target_id -> list of (src_id, dist(src->target)) to add
+            std::unordered_map<InnerIdType, std::vector<ReverseEdgeEntry>> pending;
+        };
+        std::vector<ReverseShard> shards(reverse_shard_count);
+
+        // ----- (3a) group reverse edges into shards (parallel) -----
+        const auto reverse_group_begin = now_us();
+
+        // Pick a worker count for the scatter stage. Each worker owns one
+        // private slice of the input array, so contention is zero.
+        const uint32_t scatter_worker_count =
+            (effective_parallelism > 1)
+                ? std::min<uint32_t>(effective_parallelism,
+                                     static_cast<uint32_t>(ids_to_refine.size()))
+                : 1U;
+
+        // worker_buckets[w][s] holds the (target,src,dist) records that
+        // worker `w` produced for shard `s`. After the scatter stage we
+        // simply concatenate worker_buckets[*][s] into shard `s`.
+        std::vector<std::vector<std::vector<ScatterRecord>>> worker_buckets(
+            scatter_worker_count,
+            std::vector<std::vector<ScatterRecord>>(reverse_shard_count));
+
+        // Heuristic per-bucket reserve so push_back stays in the fast path.
+        const uint64_t max_degree_for_reserve = this->bottom_graph_->MaximumDegree();
+        const size_t avg_per_bucket =
+            (ids_to_refine.size() * static_cast<size_t>(max_degree_for_reserve)
+             + static_cast<size_t>(scatter_worker_count) * reverse_shard_count - 1) /
+            (static_cast<size_t>(scatter_worker_count) * reverse_shard_count);
+        for (auto& wb : worker_buckets) {
+            for (auto& shard_buf : wb) {
+                shard_buf.reserve(avg_per_bucket + 16);
+            }
+        }
+
+        auto scatter_slice = [&](uint32_t worker_idx, size_t lo, size_t hi) {
+            auto& my_buckets = worker_buckets[worker_idx];
+            for (size_t i = lo; i < hi; ++i) {
+                const auto src_id = ids_to_refine[i];
+                const auto& neighbors = selected_neighbors[i];
+                const auto& dists = selected_distances[i];
+                const size_t k = neighbors.size();
+                CHECK_ARGUMENT(dists.size() == k,
+                               "selected_neighbors and selected_distances size mismatch");
+                for (size_t j = 0; j < k; ++j) {
+                    const auto neighbor_id = neighbors[j];
+                    const uint32_t shard_idx =
+                        static_cast<uint32_t>(neighbor_id) % reverse_shard_count;
+                    my_buckets[shard_idx].push_back(
+                        {neighbor_id, src_id, dists[j]});
+                }
+            }
+        };
+
+        if (scatter_worker_count <= 1) {
+            scatter_slice(0, 0, ids_to_refine.size());
+        } else {
+            const size_t per_worker =
+                (ids_to_refine.size() + scatter_worker_count - 1) / scatter_worker_count;
+            std::vector<std::future<void>> scatter_futures;
+            scatter_futures.reserve(scatter_worker_count);
+            for (uint32_t w = 0; w < scatter_worker_count; ++w) {
+                const size_t lo = w * per_worker;
+                if (lo >= ids_to_refine.size()) {
+                    break;
+                }
+                const size_t hi = std::min(lo + per_worker, ids_to_refine.size());
+                scatter_futures.emplace_back(this->thread_pool_->GeneralEnqueue(
+                    [&scatter_slice, w, lo, hi]() { scatter_slice(w, lo, hi); }));
+            }
+            for (auto& f : scatter_futures) {
+                f.get();
+            }
+        }
+
+        // Materialise each shard's per-(target) map in parallel across shards.
+        auto materialise_shard = [&](uint32_t shard_idx) {
+            // Pre-sum incoming entries for a sensible reserve.
+            size_t total = 0;
+            for (uint32_t w = 0; w < scatter_worker_count; ++w) {
+                total += worker_buckets[w][shard_idx].size();
+            }
+            auto& pending = shards[shard_idx].pending;
+            // Heuristic: average ~max_degree entries per target. Reserve at
+            // total / max_degree buckets to avoid most rehashes.
+            const size_t hint =
+                total / std::max<size_t>(max_degree_for_reserve / 2, 1) + 16;
+            pending.reserve(hint);
+            for (uint32_t w = 0; w < scatter_worker_count; ++w) {
+                auto& buf = worker_buckets[w][shard_idx];
+                for (const auto& rec : buf) {
+                    pending[rec.target_id].push_back({rec.src_id, rec.dist});
+                }
+                // Free worker buffer ASAP to cap peak memory.
+                std::vector<ScatterRecord>().swap(buf);
+            }
+        };
+
+        if (effective_parallelism <= 1 || reverse_shard_count <= 1) {
+            for (uint32_t s = 0; s < reverse_shard_count; ++s) {
+                materialise_shard(s);
+            }
+        } else {
+            std::vector<std::future<void>> mat_futures;
+            mat_futures.reserve(reverse_shard_count);
+            for (uint32_t s = 0; s < reverse_shard_count; ++s) {
+                mat_futures.emplace_back(this->thread_pool_->GeneralEnqueue(
+                    [&materialise_shard, s]() { materialise_shard(s); }));
+            }
+            for (auto& f : mat_futures) {
+                f.get();
+            }
+        }
+
+        // Release the now-empty worker_buckets vector skeleton.
+        std::vector<std::vector<std::vector<ScatterRecord>>>().swap(worker_buckets);
+
+        const auto reverse_group_elapsed = now_us() - reverse_group_begin;
+
+        // ----- (3b) per-shard merge + heuristic prune (parallel across shards) -----
+        const uint64_t max_degree = this->bottom_graph_->MaximumDegree();
+
+        auto process_shard = [this, &flatten_codes, max_degree](ReverseShard& shard) {
+            Vector<InnerIdType> current_neighbors(allocator_);
+            current_neighbors.reserve(max_degree + 16);
+            // Reusable lookup set to dedup against existing neighbours.
+            std::unordered_set<InnerIdType> existing_set;
+            existing_set.reserve(max_degree * 2 + 16);
+
+            for (auto& entry : shard.pending) {
+                const auto target_id = entry.first;
+                auto& reverse_adds = entry.second;
+
+                // Hold the per-target lock for the whole merge+prune so that
+                // concurrent reverse-edge processing for *other* targets does
+                // not race with this target. The shard partitioning already
+                // ensures no two threads touch the same target_id, but the
+                // graph data cell itself may be concurrently *read* by other
+                // shards while we mutate this target; the per-id LockGuard
+                // matches the original code's contract.
+                LockGuard lock(neighbors_mutex_, target_id);
+
+                current_neighbors.clear();
+                this->bottom_graph_->GetNeighbors(target_id, current_neighbors);
+
+                existing_set.clear();
+                for (auto nid : current_neighbors) {
+                    existing_set.insert(nid);
+                }
+
+                bool changed = false;
+                // Append distinct, non-self reverse adds.
+                // We do not yet know their distance to target; they will only
+                // be needed if a prune triggers below.
+                for (const auto& add : reverse_adds) {
+                    if (add.src_id == target_id) {
+                        continue;
+                    }
+                    if (existing_set.insert(add.src_id).second) {
+                        current_neighbors.push_back(add.src_id);
+                        changed = true;
+                    }
+                }
+
+                if (!changed) {
+                    continue;
+                }
+
+                if (current_neighbors.size() > max_degree) {
+                    // Prune via heuristic. Build a (distance, neighbour) heap.
+                    // For neighbours that were just inserted as reverse edges
+                    // we already know dist(src -> target) thanks to the
+                    // distances captured during the select phase, so we can
+                    // skip recomputation for those.
+                    std::unordered_map<InnerIdType, float> reuse_dist;
+                    reuse_dist.reserve(reverse_adds.size());
+                    for (const auto& add : reverse_adds) {
+                        // If duplicates exist for the same src_id, keep the
+                        // smaller distance (tighter upper bound is fine for
+                        // heuristic select).
+                        auto [it, inserted] = reuse_dist.emplace(add.src_id, add.dist);
+                        if (!inserted && add.dist < it->second) {
+                            it->second = add.dist;
+                        }
+                    }
+
+                    auto edges =
+                        std::make_shared<StandardHeap<true, false>>(allocator_, -1);
+                    for (auto neighbor_id : current_neighbors) {
+                        auto rit = reuse_dist.find(neighbor_id);
+                        const float d = (rit != reuse_dist.end())
+                                            ? rit->second
+                                            : flatten_codes->ComputePairVectors(neighbor_id,
+                                                                                target_id);
+                        edges->Push(d, neighbor_id);
+                    }
+                    select_edges_by_heuristic(
+                        edges, max_degree, flatten_codes, allocator_, this->alpha_);
+                    current_neighbors.clear();
+                    while (not edges->Empty()) {
+                        current_neighbors.emplace_back(edges->Top().second);
+                        edges->Pop();
+                    }
+                }
+
+                this->bottom_graph_->InsertNeighborsById(target_id, current_neighbors);
+            }
+        };
+
+        const auto reverse_merge_begin = now_us();
+        if (effective_parallelism <= 1 || reverse_shard_count <= 1) {
+            for (auto& shard : shards) {
+                process_shard(shard);
+            }
+        } else {
+            std::vector<std::future<void>> shard_futures;
+            shard_futures.reserve(shards.size());
+            for (auto& shard : shards) {
+                shard_futures.emplace_back(this->thread_pool_->GeneralEnqueue(
+                    [&process_shard, &shard]() { process_shard(shard); }));
+            }
+            for (auto& f : shard_futures) {
+                f.get();
+            }
+        }
+        const auto reverse_merge_elapsed = now_us() - reverse_merge_begin;
+
+        const auto reverse_elapsed = now_us() - reverse_begin;
+        const auto round_elapsed = now_us() - round_begin;
+        stats.round_stats.emplace_back(
+            RefineRoundStats{.elapsed_us = round_elapsed,
+                             .processed_nodes = static_cast<uint64_t>(ids_to_refine.size())});
+        log_build_cache_detail(
+            fmt::format("{} round {}/{} finished in {:.3f}s (search={:.3f}s writeback={:.3f}s reverse={:.3f}s [group={:.3f}s merge_prune={:.3f}s shards={}]) processed_nodes={}",
+                        phase_name,
+                        round + 1,
+                        rounds,
+                        static_cast<double>(round_elapsed) / 1000000.0,
+                        static_cast<double>(search_elapsed) / 1000000.0,
+                        static_cast<double>(writeback_elapsed) / 1000000.0,
+                        static_cast<double>(reverse_elapsed) / 1000000.0,
+                        static_cast<double>(reverse_group_elapsed) / 1000000.0,
+                        static_cast<double>(reverse_merge_elapsed) / 1000000.0,
+                        reverse_shard_count,
+                        ids_to_refine.size()));
+    }
+
+    stats.elapsed_us = now_us() - begin;
+    stats.executed_rounds = rounds;
+    log_build_cache_detail_elapsed(std::string(phase_name), stats.elapsed_us);
+    return stats;
+}
+
+void
+HGraph::ExportBuildCache(std::ostream& out_stream) const {
+    CHECK_ARGUMENT(this->total_count_.load() > 0, "index is empty");
+    CHECK_ARGUMENT(this->delete_count_.load() == 0,
+                   "ExportBuildCache requires index without removed nodes");
+    CHECK_ARGUMENT(this->feature_ids_.size() >= this->total_count_.load(),
+                   "feature_ids metadata is incomplete");
+
+    IOStreamWriter writer(out_stream);
+    BuildCacheHeader header;
+    header.node_count = this->total_count_.load();
+    header.max_degree = this->bottom_graph_->MaximumDegree();
+    header.feature_id_count = header.node_count;
+    header.build_param_hash = this->calculate_build_cache_param_hash();
+    header.create_time = now_unix_seconds();
+
+    std::vector<FeatureIdIndexEntry> index_entries(header.node_count);
+    uint64_t feature_blob_bytes = 0;
+    for (uint64_t i = 0; i < header.node_count; ++i) {
+        const auto& feature_id = this->feature_ids_[i];
+        CHECK_ARGUMENT(not feature_id.empty(),
+                       fmt::format("feature_id missing for inner_id {}", i));
+        index_entries[i].offset = feature_blob_bytes;
+        index_entries[i].length = static_cast<uint32_t>(feature_id.size());
+        feature_blob_bytes += feature_id.size();
+    }
+    header.feature_id_bytes = feature_blob_bytes;
+
+    StreamWriter::WriteObj(writer, header);
+    for (const auto& entry : index_entries) {
+        StreamWriter::WriteObj(writer, entry);
+    }
+    for (uint64_t i = 0; i < header.node_count; ++i) {
+        const auto& feature_id = this->feature_ids_[i];
+        if (not feature_id.empty()) {
+            writer.Write(feature_id.data(), static_cast<uint64_t>(feature_id.size()));
+        }
+    }
+
+    for (uint64_t i = 0; i < header.node_count; ++i) {
+        Vector<InnerIdType> neighbors(allocator_);
+        this->bottom_graph_->GetNeighbors(static_cast<InnerIdType>(i), neighbors);
+        NeighborRecordHeader record_header{.degree = static_cast<uint16_t>(neighbors.size())};
+        StreamWriter::WriteObj(writer, record_header);
+        for (uint32_t j = 0; j < header.max_degree; ++j) {
+            uint32_t neighbor = UINT32_MAX;
+            if (j < neighbors.size()) {
+                neighbor = neighbors[j];
+            }
+            StreamWriter::WriteObj(writer, neighbor);
+        }
+    }
+}
+
+std::vector<int64_t>
+HGraph::BuildWithCache(const DatasetPtr& data,
+                       std::istream& in_stream,
+                       const BuildCacheOptions& options) {
+    CHECK_ARGUMENT(GetNumElements() == 0, "index is not empty");
+    if (not options.enable_warm_start) {
+        build_cache_stats_ = BuildCacheStats{};
+        build_cache_stats_.total_nodes = data->GetNumElements();
+        return this->Build(data);
+    }
+
+    this->validate_feature_ids_dataset(data);
+    this->Train(data);
+    this->build_cache_stats_ = BuildCacheStats{};
+    this->build_cache_stats_.total_nodes = static_cast<uint64_t>(data->GetNumElements());
+
+    IOStreamReader reader(in_stream);
+    const auto cache_load_begin = now_us();
+
+    BuildCacheHeader header;
+    StreamReader::ReadObj(reader, header);
+    CHECK_ARGUMENT(header.magic == kBuildCacheMagic,
+                   fmt::format("Invalid cache file: magic mismatch, expected {}", kBuildCacheMagic));
+    CHECK_ARGUMENT(header.version == kBuildCacheVersion,
+                   fmt::format("Cache version incompatible: expected v{}, got v{}",
+                               kBuildCacheVersion,
+                               header.version));
+    CHECK_ARGUMENT(header.feature_id_mode == kBuildCacheFeatureModeVariableText,
+                   "FeatureID metadata mismatch: unsupported feature_id_mode");
+    CHECK_ARGUMENT(header.feature_id_count == header.node_count,
+                   "FeatureID metadata mismatch: feature_id_count != node_count");
+    CHECK_ARGUMENT(header.build_param_hash == this->calculate_build_cache_param_hash(),
+                   fmt::format("Build params changed: old_hash={}, new_hash={}",
+                               header.build_param_hash,
+                               this->calculate_build_cache_param_hash()));
+
+    std::vector<FeatureIdIndexEntry> old_feature_index(header.node_count);
+    for (uint64_t i = 0; i < header.node_count; ++i) {
+        StreamReader::ReadObj(reader, old_feature_index[i]);
+    }
+    std::string feature_blob(header.feature_id_bytes, '\0');
+    if (header.feature_id_bytes > 0) {
+        reader.Read(feature_blob.data(), header.feature_id_bytes);
+    }
+
+    std::vector<std::string> old_feature_ids(header.node_count);
+    for (uint64_t i = 0; i < header.node_count; ++i) {
+        const auto& entry = old_feature_index[i];
+        CHECK_ARGUMENT(entry.offset + entry.length <= feature_blob.size(),
+                       fmt::format("Cache stream read error at feature entry {}", i));
+        old_feature_ids[i] = feature_blob.substr(entry.offset, entry.length);
+    }
+
+    std::vector<std::vector<uint32_t>> old_neighbors(header.node_count);
+    for (uint64_t i = 0; i < header.node_count; ++i) {
+        NeighborRecordHeader record_header;
+        StreamReader::ReadObj(reader, record_header);
+        CHECK_ARGUMENT(record_header.degree <= header.max_degree,
+                       fmt::format("Cache stream read error at neighbor record {}", i));
+        old_neighbors[i].reserve(record_header.degree);
+        for (uint32_t j = 0; j < header.max_degree; ++j) {
+            uint32_t neighbor = UINT32_MAX;
+            StreamReader::ReadObj(reader, neighbor);
+            if (j < record_header.degree) {
+                old_neighbors[i].push_back(neighbor);
+            }
+        }
+    }
+    build_cache_stats_.cache_load_us = now_us() - cache_load_begin;
+    build_cache_stats_.cached_nodes = header.node_count;
+
+    const auto total = data->GetNumElements();
+    const auto* labels = data->GetIds();
+    const auto* feature_ids = data->GetFeatureIds();
+    const auto* extra_infos = data->GetExtraInfos();
+    const auto* attr_sets = data->GetAttributeSets();
+
+    auto inner_ids = this->get_unique_inner_ids(total);
+    Vector<Vector<InnerIdType>> route_graph_ids(allocator_);
+    this->feature_ids_.clear();
+    this->feature_ids_.resize(this->total_count_.load());
+
+    std::unordered_map<std::string, uint32_t> fid_to_new_id;
+    fid_to_new_id.reserve(static_cast<size_t>(total));
+    std::vector<InnerIdType> inserted_inner_ids;
+    inserted_inner_ids.reserve(static_cast<size_t>(total));
+    std::unordered_map<InnerIdType, uint32_t> inner_id_to_input_idx;
+    inner_id_to_input_idx.reserve(static_cast<size_t>(total));
+    std::vector<int64_t> failed_ids;
+    for (int64_t i = 0; i < total; ++i) {
+        auto [it, inserted] = fid_to_new_id.emplace(feature_ids[i], inner_ids[i]);
+        CHECK_ARGUMENT(inserted, fmt::format("duplicate feature_id found: {}", feature_ids[i]));
+        auto label = labels[i];
+        if (this->label_table_->CheckLabel(label)) {
+            failed_ids.emplace_back(label);
+            continue;
+        }
+
+        InnerIdType inner_id = inner_ids[i];
+        this->label_table_->Insert(inner_id, label);
+        this->basic_flatten_codes_->InsertVector(get_data(data, static_cast<uint32_t>(i)), inner_id);
+        if (use_reorder_) {
+            this->high_precise_codes_->InsertVector(get_data(data, static_cast<uint32_t>(i)), inner_id);
+        }
+        if (create_new_raw_vector_) {
+            this->raw_vector_->InsertVector(get_data(data, static_cast<uint32_t>(i)), inner_id);
+        }
+        if (this->extra_infos_ != nullptr && extra_infos != nullptr) {
+            this->extra_infos_->InsertExtraInfo(extra_infos + i * extra_info_size_, inner_id);
+        }
+        if (attr_sets != nullptr && this->use_attribute_filter_) {
+            this->attr_filter_index_->Insert(attr_sets[i], inner_id);
+        }
+
+        if (inner_id >= this->feature_ids_.size()) {
+            this->feature_ids_.resize(inner_id + 1);
+        }
+        this->feature_ids_[inner_id] = feature_ids[i];
+        inserted_inner_ids.push_back(inner_id);
+        inner_id_to_input_idx.emplace(inner_id, static_cast<uint32_t>(i));
+
+        auto level = this->get_random_level() - 1;
+        if (level >= 0) {
+            if (level >= static_cast<int>(route_graph_ids.size()) || route_graph_ids.empty()) {
+                for (auto k = static_cast<int>(route_graph_ids.size()); k <= level; ++k) {
+                    route_graph_ids.emplace_back(allocator_);
+                }
+                entry_point_id_ = inner_id;
+            }
+            for (int j = 0; j <= level; ++j) {
+                route_graph_ids[j].emplace_back(inner_id);
+            }
+        }
+    }
+    this->resize(total_count_);
+    if (entry_point_id_ == INVALID_ENTRY_POINT && not inserted_inner_ids.empty()) {
+        entry_point_id_ = inserted_inner_ids.front();
+    }
+
+    std::vector<uint32_t> old_to_new(header.node_count, UINT32_MAX);
+    std::unordered_map<std::string, uint32_t> old_fid_to_old_id;
+    old_fid_to_old_id.reserve(static_cast<size_t>(header.node_count));
+    for (uint32_t old_id = 0; old_id < header.node_count; ++old_id) {
+        old_fid_to_old_id.emplace(old_feature_ids[old_id], old_id);
+        auto iter = fid_to_new_id.find(old_feature_ids[old_id]);
+        if (iter != fid_to_new_id.end()) {
+            old_to_new[old_id] = iter->second;
+        }
+    }
+
+    std::vector<InnerIdType> hit_ids;
+    std::vector<InnerIdType> missed_ids;
+    hit_ids.reserve(inserted_inner_ids.size());
+    missed_ids.reserve(inserted_inner_ids.size());
+
+    struct WarmStartChunkResult {
+        std::vector<InnerIdType> hit_ids;
+        std::vector<InnerIdType> missed_ids;
+        uint64_t hit_seed_neighbor_total{0};
+        uint64_t missed_seed_neighbor_total{0};
+        uint64_t hit_empty_seed_nodes{0};
+        uint64_t missed_empty_seed_nodes{0};
+        uint64_t invalid_neighbors{0};
+        uint64_t dropped_neighbors{0};
+    };
+
+    const auto warm_start_begin = now_us();
+    log_build_cache_detail(fmt::format("starting warm_start nodes={} cached_nodes={} build_threads={}",
+                                       inserted_inner_ids.size(),
+                                       header.node_count,
+                                       this->build_thread_count_));
+    const auto process_warm_start_range =
+        [&](size_t begin, size_t end) -> WarmStartChunkResult {
+        WarmStartChunkResult result;
+        result.hit_ids.reserve(end - begin);
+        result.missed_ids.reserve(end - begin);
+
+        for (size_t i = begin; i < end; ++i) {
+            const auto inner_id = inserted_inner_ids[i];
+            auto old_id_iter = old_fid_to_old_id.find(this->feature_ids_[inner_id]);
+            Vector<InnerIdType> mapped_neighbors(allocator_);
+            std::unordered_set<InnerIdType> dedup;
+            dedup.reserve(header.max_degree);
+
+            if (old_id_iter != old_fid_to_old_id.end()) {
+                const auto old_id = old_id_iter->second;
+                for (auto neighbor_old_id : old_neighbors[old_id]) {
+                    if (neighbor_old_id >= old_to_new.size()) {
+                        ++result.invalid_neighbors;
+                        continue;
+                    }
+                    auto new_neighbor_id = old_to_new[neighbor_old_id];
+                    if (new_neighbor_id == UINT32_MAX) {
+                        ++result.invalid_neighbors;
+                        if (options.drop_invalid_neighbors) {
+                            ++result.dropped_neighbors;
+                            continue;
+                        }
+                        continue;
+                    }
+                    if (new_neighbor_id == inner_id) {
+                        continue;
+                    }
+                    if (dedup.emplace(new_neighbor_id).second) {
+                        mapped_neighbors.emplace_back(new_neighbor_id);
+                    }
+                }
+                if (mapped_neighbors.size() > this->bottom_graph_->MaximumDegree()) {
+                    mapped_neighbors.resize(this->bottom_graph_->MaximumDegree());
+                }
+                result.hit_seed_neighbor_total += mapped_neighbors.size();
+                if (mapped_neighbors.empty()) {
+                    ++result.hit_empty_seed_nodes;
+                }
+                this->bottom_graph_->InsertNeighborsById(inner_id, mapped_neighbors);
+                result.hit_ids.push_back(inner_id);
+            } else {
+                result.missed_seed_neighbor_total += mapped_neighbors.size();
+                if (mapped_neighbors.empty()) {
+                    ++result.missed_empty_seed_nodes;
+                }
+                this->bottom_graph_->InsertNeighborsById(inner_id, mapped_neighbors);
+                result.missed_ids.push_back(inner_id);
+            }
+        }
+        return result;
+    };
+
+    if (this->thread_pool_ != nullptr && this->build_thread_count_ > 1 &&
+        inserted_inner_ids.size() > 1) {
+        const size_t chunk_count =
+            std::min<size_t>(static_cast<size_t>(this->build_thread_count_), inserted_inner_ids.size());
+        const size_t chunk_size = (inserted_inner_ids.size() + chunk_count - 1) / chunk_count;
+
+        std::vector<std::future<WarmStartChunkResult>> futures;
+        futures.reserve(chunk_count);
+        for (size_t chunk = 0; chunk < chunk_count; ++chunk) {
+            const size_t begin = chunk * chunk_size;
+            const size_t end = std::min(inserted_inner_ids.size(), begin + chunk_size);
+            if (begin >= end) {
+                break;
+            }
+            futures.emplace_back(
+                this->thread_pool_->GeneralEnqueue(process_warm_start_range, begin, end));
+        }
+
+        for (auto& future : futures) {
+            auto chunk_result = future.get();
+            build_cache_stats_.hit_seed_neighbor_total += chunk_result.hit_seed_neighbor_total;
+            build_cache_stats_.missed_seed_neighbor_total += chunk_result.missed_seed_neighbor_total;
+            build_cache_stats_.hit_empty_seed_nodes += chunk_result.hit_empty_seed_nodes;
+            build_cache_stats_.missed_empty_seed_nodes += chunk_result.missed_empty_seed_nodes;
+            build_cache_stats_.invalid_neighbors += chunk_result.invalid_neighbors;
+            build_cache_stats_.dropped_neighbors += chunk_result.dropped_neighbors;
+            hit_ids.insert(hit_ids.end(), chunk_result.hit_ids.begin(), chunk_result.hit_ids.end());
+            missed_ids.insert(
+                missed_ids.end(), chunk_result.missed_ids.begin(), chunk_result.missed_ids.end());
+        }
+    } else {
+        auto chunk_result = process_warm_start_range(0, inserted_inner_ids.size());
+        build_cache_stats_.hit_seed_neighbor_total += chunk_result.hit_seed_neighbor_total;
+        build_cache_stats_.missed_seed_neighbor_total += chunk_result.missed_seed_neighbor_total;
+        build_cache_stats_.hit_empty_seed_nodes += chunk_result.hit_empty_seed_nodes;
+        build_cache_stats_.missed_empty_seed_nodes += chunk_result.missed_empty_seed_nodes;
+        build_cache_stats_.invalid_neighbors += chunk_result.invalid_neighbors;
+        build_cache_stats_.dropped_neighbors += chunk_result.dropped_neighbors;
+        hit_ids = std::move(chunk_result.hit_ids);
+        missed_ids = std::move(chunk_result.missed_ids);
+    }
+    build_cache_stats_.hit_nodes = hit_ids.size();
+    build_cache_stats_.missed_nodes = missed_ids.size();
+    build_cache_stats_.cache_hit_rate = total > 0 ? static_cast<float>(hit_ids.size()) / total : 0.0F;
+    build_cache_stats_.warm_start_apply_us = now_us() - warm_start_begin;
+    log_build_cache_detail(fmt::format(
+        "warm_start summary hit_nodes={} missed_nodes={} hit_empty_seed_nodes={} missed_empty_seed_nodes={} hit_seed_neighbor_total={} missed_seed_neighbor_total={} invalid_neighbors={} dropped_neighbors={}",
+        build_cache_stats_.hit_nodes,
+        build_cache_stats_.missed_nodes,
+        build_cache_stats_.hit_empty_seed_nodes,
+        build_cache_stats_.missed_empty_seed_nodes,
+        build_cache_stats_.hit_seed_neighbor_total,
+        build_cache_stats_.missed_seed_neighbor_total,
+        build_cache_stats_.invalid_neighbors,
+        build_cache_stats_.dropped_neighbors));
+    log_build_cache_detail_elapsed("warm_start", build_cache_stats_.warm_start_apply_us);
+
+    auto flatten_codes = this->basic_flatten_codes_;
+    if (has_precise_reorder()) {
+        flatten_codes = this->high_precise_codes_;
+    }
+
+    // Refine hit nodes first to restore graph connectivity, then refine missed
+    // nodes on the improved graph. Hit nodes (92%+) carry stale neighbors from
+    // the previous day's cache; refining them first gives missed nodes a better
+    // connected graph to search from during their own refine phase.
+    auto hit_refine_stats = this->refine_nodes_two_phase(data,
+                                                         hit_ids,
+                                                         "hit_refine",
+                                                         options.hit_refine_rounds,
+                                                         options.hit_refine_ef,
+                                                         true,
+                                                         options.enable_parallel_refine,
+                                                         options.refine_parallelism,
+                                                         flatten_codes,
+                                                         inner_id_to_input_idx);
+    build_cache_stats_.hit_refine_us = hit_refine_stats.elapsed_us;
+    build_cache_stats_.hit_refine_rounds = hit_refine_stats.executed_rounds;
+    build_cache_stats_.hit_refine_ef =
+        options.hit_refine_ef == 0 ? this->ef_construct_ : options.hit_refine_ef;
+    build_cache_stats_.hit_refine_parallelism = hit_refine_stats.effective_parallelism;
+
+    auto missed_refine_stats = this->refine_nodes_two_phase(data,
+                                                            missed_ids,
+                                                            "missed_refine",
+                                                            options.missed_refine_rounds,
+                                                            options.missed_refine_ef,
+                                                            false,
+                                                            options.enable_parallel_refine,
+                                                            options.refine_parallelism,
+                                                            flatten_codes,
+                                                            inner_id_to_input_idx);
+    build_cache_stats_.missed_refine_us = missed_refine_stats.elapsed_us;
+    build_cache_stats_.missed_refine_rounds = missed_refine_stats.executed_rounds;
+    build_cache_stats_.missed_refine_ef =
+        options.missed_refine_ef == 0 ? this->ef_construct_ : options.missed_refine_ef;
+    build_cache_stats_.missed_refine_parallelism = missed_refine_stats.effective_parallelism;
+
+    this->route_graphs_.clear();
+    if (options.build_route_graph) {
+        const auto route_graph_begin = now_us();
+        log_build_cache_detail(
+            fmt::format("starting route_graph_build levels_to_build={}", route_graph_ids.size()));
+        auto build_data = (has_precise_reorder()) ? this->high_precise_codes_
+                                                               : this->basic_flatten_codes_;
+        for (auto& route_graph_id : route_graph_ids) {
+            odescent_param_->max_degree = bottom_graph_->MaximumDegree() / 2;
+            ODescent sparse_odescent_builder(
+                odescent_param_, build_data, allocator_, this->thread_pool_.get());
+            auto graph = this->generate_one_route_graph();
+            sparse_odescent_builder.Build(route_graph_id);
+            sparse_odescent_builder.SaveGraph(graph);
+            this->route_graphs_.emplace_back(graph);
+        }
+        build_cache_stats_.route_graph_build_us = now_us() - route_graph_begin;
+        build_cache_stats_.route_graph_levels = this->route_graphs_.size();
+        log_build_cache_detail(fmt::format("route_graph_build summary levels={}",
+                                           build_cache_stats_.route_graph_levels));
+        log_build_cache_detail_elapsed("route_graph_build",
+                                       build_cache_stats_.route_graph_build_us);
+    } else {
+        build_cache_stats_.route_graph_build_us = 0;
+        build_cache_stats_.route_graph_levels = 0;
+        log_build_cache_detail("route_graph_build skipped");
+    }
+
+    if (use_elp_optimizer_) {
+        elp_optimize();
+    }
+
+    return failed_ids;
+}
+
+BuildCacheStats
+HGraph::GetBuildCacheStats() const {
+    return this->build_cache_stats_;
+}
+
+void
+HGraph::serialize_feature_ids(StreamWriter& writer) const {
+    const auto count = this->total_count_.load();
+    StreamWriter::WriteObj(writer, count);
+    for (uint64_t i = 0; i < count; ++i) {
+        StreamWriter::WriteString(writer, this->feature_ids_[i]);
+    }
+}
+
+void
+HGraph::deserialize_feature_ids(StreamReader& reader, uint64_t expected_count) {
+    uint64_t count = 0;
+    StreamReader::ReadObj(reader, count);
+    CHECK_ARGUMENT(count == expected_count,
+                   fmt::format("FeatureID count mismatch: expected {}, got {}",
+                               expected_count,
+                               count));
+
+    this->feature_ids_.clear();
+    this->feature_ids_.resize(count);
+    for (uint64_t i = 0; i < count; ++i) {
+        this->feature_ids_[i] = StreamReader::ReadString(reader);
+    }
+}
+
+}  // namespace vsag

--- a/src/algorithm/hgraph/hgraph_modify.cpp
+++ b/src/algorithm/hgraph/hgraph_modify.cpp
@@ -146,6 +146,14 @@ HGraph::move_id(InnerIdType from, InnerIdType to) {
 
     label_table_->Move(from, to);
 
+    if (from < this->feature_ids_.size()) {
+        if (to >= this->feature_ids_.size()) {
+            this->feature_ids_.resize(to + 1);
+        }
+        this->feature_ids_[to] = std::move(this->feature_ids_[from]);
+        this->feature_ids_[from].clear();
+    }
+
     if (entry_point_id_ == from) {
         entry_point_id_ = to;
     }
@@ -202,6 +210,7 @@ HGraph::shrink_to_fit() {
         route_graph->ShrinkToFit(total_count);
     }
     label_table_->ShrinkToFit(total_count);
+    this->feature_ids_.resize(total_count);
 }
 
 void

--- a/src/algorithm/hgraph/hgraph_serialize.cpp
+++ b/src/algorithm/hgraph/hgraph_serialize.cpp
@@ -27,6 +27,12 @@
 
 namespace vsag {
 
+namespace {
+constexpr int64_t kFeatureIdsFormatVersion = 1;
+constexpr std::string_view kFeatureIdsFormatVersionKey = "feature_ids_format_version";
+}  // namespace
+
+
 void
 HGraph::serialize_basic_info_v0_14(StreamWriter& writer) const {
     StreamWriter::WriteObj(writer, this->use_reorder_);
@@ -241,7 +247,15 @@ HGraph::Serialize(StreamWriter& writer) const {
     if (this->support_duplicate_) {
         metadata->Set("duplicate_format_version", 1);
     }
+    const bool has_feature_ids = this->feature_ids_.size() >= this->total_count_.load();
+    if (has_feature_ids) {
+        metadata->Set(std::string(kFeatureIdsFormatVersionKey), kFeatureIdsFormatVersion);
+    }
     logger::debug(jsonify_basic_info.Dump());
+
+    if (has_feature_ids) {
+        this->serialize_feature_ids(writer);
+    }
 
     auto footer = std::make_shared<Footer>(metadata);
     footer->Write(writer);
@@ -325,6 +339,17 @@ HGraph::Deserialize(StreamReader& reader) {
         }
         if (this->raw_vector_ != nullptr) {
             this->has_raw_vector_ = true;
+        }
+
+        int64_t feature_ids_version = 0;
+        if (metadata->Get(std::string(kFeatureIdsFormatVersionKey)).IsNumberInteger()) {
+            feature_ids_version = metadata->Get(std::string(kFeatureIdsFormatVersionKey)).GetInt();
+        }
+        if (feature_ids_version >= kFeatureIdsFormatVersion) {
+            this->deserialize_feature_ids(buffer_reader,
+                                          static_cast<uint64_t>(this->total_count_.load()));
+        } else {
+            this->feature_ids_.clear();
         }
     }
     this->cal_memory_usage();

--- a/src/algorithm/inner_index_interface.h
+++ b/src/algorithm/inner_index_interface.h
@@ -182,6 +182,37 @@ public:
                             "Index doesn't support ContinueBuild");
     }
 
+    [[nodiscard]] virtual bool
+    SupportsBuildCache() const {
+        return false;
+    }
+
+    virtual void
+    ExportBuildCache(std::ostream& out_stream) const {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "Index doesn't support ExportBuildCache");
+    }
+
+    virtual std::vector<int64_t>
+    BuildWithCache(const DatasetPtr& base,
+                   std::istream& in_stream,
+                   const BuildCacheOptions& options) {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "Index doesn't support BuildWithCache");
+    }
+
+    virtual void
+    PrepareFeatureIdsForBuildCache(const DatasetPtr& base) {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "Index doesn't support PrepareFeatureIdsForBuildCache");
+    }
+
+    [[nodiscard]] virtual BuildCacheStats
+    GetBuildCacheStats() const {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "Index doesn't support GetBuildCacheStats");
+    }
+
     virtual bool
     Tune(const std::string& parameters, bool disable_future_tuning) {
         throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION, "Index doesn't support Tune");

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -41,6 +41,7 @@ const char* const INT8_VECTORS = "i8_vectors";
 const char* const ATTRIBUTE_SETS = "attribute_sets";
 const char* const DATASET_PATHS = "paths";
 const char* const EXTRA_INFOS = "extra_infos";
+const char* const FEATURE_IDS = "feature_ids";
 const char* const EXTRA_INFO_SIZE = "extra_info_size";
 const char* const VECTOR_COUNTS = "vector_counts";
 const char* const MULTI_VECTORS = "multi_vectors";

--- a/src/dataset_impl.cpp
+++ b/src/dataset_impl.cpp
@@ -244,6 +244,7 @@ DatasetImpl::~DatasetImpl() {  // NOLINT
         }
     }
     delete[] DatasetImpl::GetPaths();
+    delete[] DatasetImpl::GetFeatureIds();
     if (DatasetImpl::GetAttributeSets() != nullptr) {
         const auto* attrsets = DatasetImpl::GetAttributeSets();
         for (int i = 0; i < DatasetImpl::GetNumElements(); ++i) {
@@ -311,6 +312,13 @@ DatasetImpl::DeepCopy(Allocator* allocator) const {
         copy_dataset->Paths(paths);
         for (int i = 0; i < num_elements; ++i) {
             paths[i] += this->GetPaths()[i];
+        }
+    }
+    if (this->GetFeatureIds() != nullptr) {
+        auto* feature_ids = new std::string[num_elements];
+        copy_dataset->FeatureIds(feature_ids);
+        for (int i = 0; i < num_elements; ++i) {
+            feature_ids[i] += this->GetFeatureIds()[i];
         }
     }
 
@@ -425,6 +433,25 @@ DatasetImpl::Append(const DatasetPtr& other) {
             paths_copy[old_num_elements + i] += other->GetPaths()[i];
         }
         this->Paths(paths_copy);
+    }
+
+    // append feature_ids
+    if (auto iter = this->data_.find(FEATURE_IDS); iter != this->data_.end()) {
+        if (other->GetFeatureIds() == nullptr) {
+            throw VsagException(ErrorType::INVALID_ARGUMENT,
+                                "Cannot append dataset without feature_ids to dataset with feature_ids");
+        }
+        auto* ptr = const_cast<std::string*>(std::get<const std::string*>(iter->second));
+        auto* feature_ids_copy = new std::string[old_num_elements + new_num_elements];
+        for (int i = 0; i < old_num_elements; ++i) {
+            feature_ids_copy[i] += ptr[i];
+        }
+        delete[] ptr;
+        ptr = nullptr;
+        for (int i = 0; i < new_num_elements; ++i) {
+            feature_ids_copy[old_num_elements + i] += other->GetFeatureIds()[i];
+        }
+        this->FeatureIds(feature_ids_copy);
     }
 
     // append sparse-vectors

--- a/src/dataset_impl.h
+++ b/src/dataset_impl.h
@@ -219,6 +219,20 @@ public:
     }
 
     DatasetPtr
+    FeatureIds(const std::string* feature_ids) override {
+        this->data_[FEATURE_IDS] = feature_ids;
+        return shared_from_this();
+    }
+
+    const std::string*
+    GetFeatureIds() const override {
+        if (auto iter = this->data_.find(FEATURE_IDS); iter != this->data_.end()) {
+            return std::get<const std::string*>(iter->second);
+        }
+        return nullptr;
+    }
+
+    DatasetPtr
     ExtraInfos(const char* extra_info) override {
         this->data_[EXTRA_INFOS] = extra_info;
         return shared_from_this();

--- a/src/index/index_impl.h
+++ b/src/index/index_impl.h
@@ -157,6 +157,38 @@ public:
         SAFE_CALL(return this->inner_index_->ContinueBuild(base, binary_set));
     }
 
+    [[nodiscard]] bool
+    SupportsBuildCache() const override {
+        return this->inner_index_->SupportsBuildCache();
+    }
+
+    tl::expected<void, Error>
+    ExportBuildCache(std::ostream& out_stream) const override {
+        SAFE_CALL(this->inner_index_->ExportBuildCache(out_stream));
+    }
+
+    tl::expected<std::vector<int64_t>, Error>
+    BuildWithCache(const DatasetPtr& base,
+                   std::istream& in_stream,
+                   const BuildCacheOptions& options = BuildCacheOptions{}) override {
+        CHECK_IMMUTABLE_INDEX("build with cache");
+        CHECK_NONEMPTY_DATASET(base);
+        SAFE_CALL(return this->inner_index_->BuildWithCache(base, in_stream, options));
+    }
+
+    tl::expected<void, Error>
+    PrepareFeatureIdsForBuildCache(const DatasetPtr& base) override {
+        if (base->GetNumElements() == 0) {
+            return {};
+        }
+        SAFE_CALL(this->inner_index_->PrepareFeatureIdsForBuildCache(base));
+    }
+
+    [[nodiscard]] tl::expected<BuildCacheStats, Error>
+    GetBuildCacheStats() const override {
+        SAFE_CALL(return this->inner_index_->GetBuildCacheStats());
+    }
+
     tl::expected<void, Error>
     Deserialize(const BinarySet& binary_set) override {
         SAFE_CALL(this->inner_index_->Deserialize(binary_set));

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -17,3 +17,4 @@
 add_subdirectory (eval)
 add_subdirectory (check_compatibility)
 add_subdirectory (analyze_index)
+add_subdirectory (build_cache)

--- a/tools/build_cache/CMakeLists.txt
+++ b/tools/build_cache/CMakeLists.txt
@@ -1,0 +1,29 @@
+add_library (build_cache_tool_common OBJECT
+    build_cache_tool_common.cpp)
+target_link_libraries (build_cache_tool_common PRIVATE
+    vsag)
+
+add_executable (export_hgraph_build_cache export_hgraph_build_cache.cpp)
+target_sources (export_hgraph_build_cache PRIVATE
+    $<TARGET_OBJECTS:build_cache_tool_common>)
+target_link_libraries (export_hgraph_build_cache PRIVATE
+    argparse::argparse
+    vsag)
+
+add_executable (build_hgraph_with_cache build_hgraph_with_cache.cpp)
+target_sources (build_hgraph_with_cache PRIVATE
+    $<TARGET_OBJECTS:build_cache_tool_common>)
+target_link_libraries (build_hgraph_with_cache PRIVATE
+    argparse::argparse
+    vsag)
+
+add_executable (compare_hgraph_ids compare_hgraph_ids.cpp)
+target_link_libraries (compare_hgraph_ids PRIVATE
+    argparse::argparse
+    vsag)
+
+add_executable (eval_recall_brute_force eval_recall_brute_force.cpp)
+target_link_libraries (eval_recall_brute_force PRIVATE
+    argparse::argparse
+    vsag
+    pthread)

--- a/tools/build_cache/build_cache_tool_common.cpp
+++ b/tools/build_cache/build_cache_tool_common.cpp
@@ -1,0 +1,373 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "build_cache_tool_common.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cstring>
+#include <fstream>
+#include <limits>
+#include <sstream>
+#include <stdexcept>
+#include <unordered_set>
+
+namespace vsag::tools {
+
+namespace {
+
+std::string
+trim_left(std::string text) {
+    auto iter = std::find_if(text.begin(), text.end(), [](unsigned char ch) {
+        return not std::isspace(ch);
+    });
+    text.erase(text.begin(), iter);
+    return text;
+}
+
+std::string
+load_text_file(const std::string& path) {
+    std::ifstream input(path);
+    if (not input.is_open()) {
+        throw std::runtime_error("failed to open text file: " + path);
+    }
+    return std::string((std::istreambuf_iterator<char>(input)), std::istreambuf_iterator<char>());
+}
+
+void
+validate_feature_ids(const std::vector<std::string>& feature_ids) {
+    if (feature_ids.empty()) {
+        throw std::runtime_error("id_map is empty");
+    }
+
+    std::unordered_set<std::string> unique_feature_ids;
+    unique_feature_ids.reserve(feature_ids.size());
+    for (const auto& feature_id : feature_ids) {
+        if (feature_id.empty()) {
+            throw std::runtime_error("id_map contains empty feature id");
+        }
+        auto inserted = unique_feature_ids.emplace(feature_id);
+        if (not inserted.second) {
+            throw std::runtime_error("duplicate feature_id found: " + feature_id);
+        }
+    }
+}
+
+void
+align_label_vector_counts(std::vector<int64_t>* labels,
+                          std::vector<float>* vectors,
+                          int64_t dim,
+                          AlignmentPolicy alignment_policy,
+                          DatasetAlignmentStats* stats) {
+    if (labels == nullptr || stats == nullptr) {
+        throw std::runtime_error("alignment input is nullptr");
+    }
+
+    const auto label_count = labels->size();
+    uint64_t vector_count = 0;
+    if (vectors != nullptr) {
+        if (dim <= 0) {
+            throw std::runtime_error("dim must be positive when vectors are provided");
+        }
+        vector_count = static_cast<uint64_t>(vectors->size() / static_cast<size_t>(dim));
+    }
+
+    stats->raw_label_count = label_count;
+    stats->raw_vector_count = vector_count;
+
+    uint64_t aligned_count = label_count;
+    if (vectors != nullptr) {
+        aligned_count = std::min<uint64_t>(aligned_count, vector_count);
+    }
+
+    const bool mismatch =
+        vectors != nullptr && static_cast<uint64_t>(labels->size()) != vector_count;
+
+    if (mismatch && alignment_policy == AlignmentPolicy::STRICT) {
+        throw std::runtime_error("dataset row count mismatch: labels=" +
+                                 std::to_string(labels->size()) +
+                                 ", vectors=" +
+                                 std::to_string(vector_count));
+    }
+
+    if (aligned_count == 0) {
+        throw std::runtime_error("aligned dataset is empty");
+    }
+
+    stats->aligned_count = aligned_count;
+    stats->was_truncated = mismatch;
+
+    labels->resize(aligned_count);
+    if (vectors != nullptr) {
+        vectors->resize(static_cast<size_t>(aligned_count) * static_cast<size_t>(dim));
+    }
+}
+
+std::vector<std::string>
+materialize_feature_ids_from_labels(const std::vector<int64_t>& labels,
+                                    const std::vector<std::string>& feature_table,
+                                    const std::string& feature_id_path) {
+    std::vector<std::string> feature_ids;
+    feature_ids.reserve(labels.size());
+
+    for (size_t row = 0; row < labels.size(); ++row) {
+        const auto label = labels[row];
+        if (label < 0) {
+            throw std::runtime_error("label.bin contains negative label at row " +
+                                     std::to_string(row) +
+                                     ": " + std::to_string(label));
+        }
+        const auto feature_index = static_cast<uint64_t>(label);
+        if (feature_index >= feature_table.size()) {
+            std::ostringstream builder;
+            builder << "label.bin references out-of-range feature index at row " << row
+                    << ": label=" << label
+                    << ", available_non_empty_id_map_rows=" << feature_table.size()
+                    << ", id_map_path=" << feature_id_path;
+            throw std::runtime_error(builder.str());
+        }
+        feature_ids.emplace_back(feature_table[feature_index]);
+    }
+
+    return feature_ids;
+}
+
+DatasetPtr
+make_feature_id_dataset(const std::vector<int64_t>& labels,
+                        const std::vector<std::string>& feature_ids) {
+    auto* labels_data = new int64_t[labels.size()];
+    auto* feature_ids_data = new std::string[feature_ids.size()];
+    std::copy(labels.begin(), labels.end(), labels_data);
+    std::copy(feature_ids.begin(), feature_ids.end(), feature_ids_data);
+
+    return Dataset::Make()
+        ->Owner(true)
+        ->NumElements(static_cast<int64_t>(labels.size()))
+        ->Ids(labels_data)
+        ->FeatureIds(feature_ids_data);
+}
+
+DatasetPtr
+make_float32_dataset(const std::vector<int64_t>& labels,
+                     const std::vector<std::string>& feature_ids,
+                     const std::vector<float>& vectors,
+                     int64_t dim) {
+    auto* labels_data = new int64_t[labels.size()];
+    auto* feature_ids_data = new std::string[feature_ids.size()];
+    auto* vectors_data = new float[vectors.size()];
+
+    std::copy(labels.begin(), labels.end(), labels_data);
+    std::copy(feature_ids.begin(), feature_ids.end(), feature_ids_data);
+    std::copy(vectors.begin(), vectors.end(), vectors_data);
+
+    return Dataset::Make()
+        ->Owner(true)
+        ->NumElements(static_cast<int64_t>(labels.size()))
+        ->Dim(dim)
+        ->Ids(labels_data)
+        ->Float32Vectors(vectors_data)
+        ->FeatureIds(feature_ids_data);
+}
+
+}  // namespace
+
+std::string
+StripCr(std::string line) {
+    if (not line.empty() && line.back() == '\r') {
+        line.pop_back();
+    }
+    return line;
+}
+
+AlignmentPolicy
+ParseAlignmentPolicy(const std::string& text) {
+    if (text == "strict") {
+        return AlignmentPolicy::STRICT;
+    }
+    if (text == "truncate_to_min") {
+        return AlignmentPolicy::TRUNCATE_TO_MIN;
+    }
+    throw std::runtime_error(
+        "invalid --alignment_policy, expected one of: strict, truncate_to_min");
+}
+
+const char*
+AlignmentPolicyName(AlignmentPolicy policy) {
+    switch (policy) {
+        case AlignmentPolicy::STRICT:
+            return "strict";
+        case AlignmentPolicy::TRUNCATE_TO_MIN:
+            return "truncate_to_min";
+    }
+    return "unknown";
+}
+
+BuildParameterConfig
+ParseBuildParameterSource(const std::string& source) {
+    if (source.empty()) {
+        throw std::runtime_error("build parameter source is empty");
+    }
+
+    auto normalized = trim_left(source);
+    if (normalized.empty()) {
+        throw std::runtime_error("build parameter source is empty");
+    }
+
+    std::string raw_json = normalized.front() == '{' ? source : load_text_file(source);
+    auto parsed = JsonType::Parse(raw_json);
+
+    BuildParameterConfig config;
+    config.raw_json = raw_json;
+
+    if (parsed.Contains("type")) {
+        config.index_name = parsed["type"].GetString();
+    } else if (parsed.Contains("hgraph")) {
+        config.index_name = "hgraph";
+    }
+
+    if (config.index_name != "hgraph") {
+        throw std::runtime_error("build parameter must describe HGraph index");
+    }
+    if (not parsed.Contains("dim")) {
+        throw std::runtime_error("build parameter missing dim");
+    }
+    if (not parsed.Contains("dtype")) {
+        throw std::runtime_error("build parameter missing dtype");
+    }
+    if (not parsed.Contains("metric_type")) {
+        throw std::runtime_error("build parameter missing metric_type");
+    }
+
+    config.dim = parsed["dim"].GetInt();
+    config.dtype = parsed["dtype"].GetString();
+    config.metric_type = parsed["metric_type"].GetString();
+    return config;
+}
+
+std::vector<int64_t>
+ReadLabels(const std::string& path) {
+    std::ifstream input(path, std::ios::binary);
+    if (not input.is_open()) {
+        throw std::runtime_error("failed to open label file: " + path);
+    }
+
+    input.seekg(0, std::ios::end);
+    const auto size = input.tellg();
+    input.seekg(0, std::ios::beg);
+    if (size < 0 || (size % static_cast<std::streamoff>(sizeof(int64_t))) != 0) {
+        throw std::runtime_error("label.bin size is not aligned to int64: " + path);
+    }
+
+    std::vector<int64_t> labels(static_cast<size_t>(size / sizeof(int64_t)));
+    if (not labels.empty()) {
+        input.read(reinterpret_cast<char*>(labels.data()), size);
+    }
+    if (not input.good() && not input.eof()) {
+        throw std::runtime_error("failed to read label file: " + path);
+    }
+    return labels;
+}
+
+std::vector<std::string>
+ReadFeatureIds(const std::string& path) {
+    std::ifstream input(path);
+    if (not input.is_open()) {
+        throw std::runtime_error("failed to open feature id file: " + path);
+    }
+
+    std::vector<std::string> feature_ids;
+    std::string line;
+    while (std::getline(input, line)) {
+        feature_ids.emplace_back(StripCr(std::move(line)));
+    }
+
+    if (not feature_ids.empty() && feature_ids.back().empty()) {
+        feature_ids.pop_back();
+    }
+    return feature_ids;
+}
+
+std::vector<float>
+ReadFloat32Vectors(const std::string& path, int64_t dim) {
+    if (dim <= 0) {
+        throw std::runtime_error("dim must be positive when reading vector_data.bin");
+    }
+
+    std::ifstream input(path, std::ios::binary);
+    if (not input.is_open()) {
+        throw std::runtime_error("failed to open vector file: " + path);
+    }
+
+    input.seekg(0, std::ios::end);
+    const auto size = input.tellg();
+    input.seekg(0, std::ios::beg);
+    if (size < 0 || (size % static_cast<std::streamoff>(sizeof(float))) != 0) {
+        throw std::runtime_error("vector_data.bin size is not aligned to float32: " + path);
+    }
+
+    const auto float_count = static_cast<uint64_t>(size / sizeof(float));
+    if (float_count % static_cast<uint64_t>(dim) != 0) {
+        throw std::runtime_error("vector_data.bin float count is not aligned to dim: " + path);
+    }
+
+    if (float_count > static_cast<uint64_t>(std::numeric_limits<size_t>::max())) {
+        throw std::runtime_error("vector_data.bin is too large to load into memory: " + path);
+    }
+
+    std::vector<float> vectors(static_cast<size_t>(float_count));
+    if (not vectors.empty()) {
+        input.read(reinterpret_cast<char*>(vectors.data()), size);
+    }
+    if (not input.good() && not input.eof()) {
+        throw std::runtime_error("failed to read vector file: " + path);
+    }
+    return vectors;
+}
+
+ImportedDataset
+LoadFeatureIdDatasetFromFiles(const std::string& label_path,
+                              const std::string& feature_id_path,
+                              AlignmentPolicy alignment_policy) {
+    auto labels = ReadLabels(label_path);
+    auto feature_table = ReadFeatureIds(feature_id_path);
+
+    ImportedDataset imported;
+    align_label_vector_counts(&labels, nullptr, 0, alignment_policy, &imported.stats);
+    imported.stats.raw_feature_id_count = feature_table.size();
+    auto feature_ids = materialize_feature_ids_from_labels(labels, feature_table, feature_id_path);
+    validate_feature_ids(feature_ids);
+    imported.dataset = make_feature_id_dataset(labels, feature_ids);
+    return imported;
+}
+
+ImportedDataset
+LoadFloat32DatasetFromFiles(const std::string& label_path,
+                            const std::string& feature_id_path,
+                            const std::string& vector_path,
+                            int64_t dim,
+                            AlignmentPolicy alignment_policy) {
+    auto labels = ReadLabels(label_path);
+    auto feature_table = ReadFeatureIds(feature_id_path);
+    auto vectors = ReadFloat32Vectors(vector_path, dim);
+
+    ImportedDataset imported;
+    align_label_vector_counts(&labels, &vectors, dim, alignment_policy, &imported.stats);
+    imported.stats.raw_feature_id_count = feature_table.size();
+    auto feature_ids = materialize_feature_ids_from_labels(labels, feature_table, feature_id_path);
+    validate_feature_ids(feature_ids);
+    imported.dataset = make_float32_dataset(labels, feature_ids, vectors, dim);
+    return imported;
+}
+
+}  // namespace vsag::tools

--- a/tools/build_cache/build_cache_tool_common.h
+++ b/tools/build_cache/build_cache_tool_common.h
@@ -1,0 +1,86 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include <vsag/vsag.h>
+
+#include "typing.h"
+
+namespace vsag::tools {
+
+enum class AlignmentPolicy {
+    STRICT,
+    TRUNCATE_TO_MIN,
+};
+
+struct DatasetAlignmentStats {
+    uint64_t raw_label_count = 0;
+    uint64_t raw_feature_id_count = 0;
+    uint64_t raw_vector_count = 0;
+    uint64_t aligned_count = 0;
+    bool was_truncated = false;
+};
+
+struct BuildParameterConfig {
+    std::string raw_json;
+    std::string index_name;
+    std::string dtype;
+    std::string metric_type;
+    int64_t dim = 0;
+};
+
+struct ImportedDataset {
+    DatasetPtr dataset;
+    DatasetAlignmentStats stats;
+};
+
+std::string
+StripCr(std::string line);
+
+AlignmentPolicy
+ParseAlignmentPolicy(const std::string& text);
+
+const char*
+AlignmentPolicyName(AlignmentPolicy policy);
+
+BuildParameterConfig
+ParseBuildParameterSource(const std::string& source);
+
+std::vector<int64_t>
+ReadLabels(const std::string& path);
+
+std::vector<std::string>
+ReadFeatureIds(const std::string& path);
+
+std::vector<float>
+ReadFloat32Vectors(const std::string& path, int64_t dim);
+
+ImportedDataset
+LoadFeatureIdDatasetFromFiles(const std::string& label_path,
+                              const std::string& feature_id_path,
+                              AlignmentPolicy alignment_policy);
+
+ImportedDataset
+LoadFloat32DatasetFromFiles(const std::string& label_path,
+                            const std::string& feature_id_path,
+                            const std::string& vector_path,
+                            int64_t dim,
+                            AlignmentPolicy alignment_policy);
+
+}  // namespace vsag::tools

--- a/tools/build_cache/build_hgraph_with_cache.cpp
+++ b/tools/build_cache/build_hgraph_with_cache.cpp
@@ -1,0 +1,475 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <vsag/vsag.h>
+
+#include <argparse/argparse.hpp>
+#include <chrono>
+#include <fstream>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "build_cache_tool_common.h"
+
+using namespace vsag;
+
+namespace {
+
+enum class ExitCode {
+    SUCCESS = 0,
+    INVALID_ARGUMENT = 1,
+    INPUT_IO_ERROR = 2,
+    DATASET_ALIGNMENT_ERROR = 3,
+    CREATE_INDEX_ERROR = 4,
+    BUILD_WITH_CACHE_ERROR = 5,
+    SERIALIZE_INDEX_ERROR = 6,
+    EXPORT_CACHE_ERROR = 7,
+    GET_STATS_ERROR = 8,
+};
+
+uint64_t
+now_us() {
+    return std::chrono::duration_cast<std::chrono::microseconds>(
+               std::chrono::steady_clock::now().time_since_epoch())
+        .count();
+}
+
+double
+us_to_seconds(uint64_t duration_us) {
+    return static_cast<double>(duration_us) / 1000000.0;
+}
+
+void
+log_stage(const std::string& message) {
+    std::cerr << "[build_hgraph_with_cache] " << message << std::endl;
+}
+
+void
+log_stage_elapsed(const std::string& stage_name,
+                  uint64_t stage_duration_us,
+                  uint64_t total_elapsed_us) {
+    std::cerr << "[build_hgraph_with_cache] " << stage_name << " finished in "
+              << us_to_seconds(stage_duration_us) << "s"
+              << ", total_elapsed=" << us_to_seconds(total_elapsed_us) << "s" << std::endl;
+}
+
+void
+parse_args(argparse::ArgumentParser& parser, int argc, char** argv) {
+    parser.add_argument<std::string>("--cache_input_path", "-c")
+        .required()
+        .help("Input build cache file path");
+    parser.add_argument<std::string>("--vector_path", "-v")
+        .required()
+        .help("Path to vector_data.bin");
+    parser.add_argument<std::string>("--label_path", "-l")
+        .required()
+        .help("Path to label.bin");
+    parser.add_argument<std::string>("--feature_id_path", "-f")
+        .required()
+        .help("Path to id_map");
+    parser.add_argument<std::string>("--index_output_path", "-o")
+        .required()
+        .help("Output serialized index file path");
+    parser.add_argument<std::string>("--build_parameter", "-bp")
+        .required()
+        .help("Full HGraph build JSON or a path to a JSON file");
+    parser.add_argument<std::string>("--cache_output_path", "-co")
+        .help("Optional output build cache file path");
+    parser.add_argument<std::string>("--alignment_policy", "-ap")
+        .default_value(std::string("truncate_to_min"))
+        .help("How to handle row-count mismatch: strict or truncate_to_min");
+    parser.add_argument("--dimension", "-d")
+        .default_value(int64_t{-1})
+        .help("Optional explicit dim override")
+        .scan<'i', int64_t>();
+    parser.add_argument("--hit_refine_rounds")
+        .default_value(uint32_t{2})
+        .help("Refine rounds for cache-hit nodes")
+        .scan<'i', uint32_t>();
+    parser.add_argument("--missed_refine_rounds")
+        .default_value(uint32_t{4})
+        .help("Refine rounds for cache-missed nodes")
+        .scan<'i', uint32_t>();
+    parser.add_argument("--hit_refine_ef")
+        .default_value(uint32_t{0})
+        .help("Search pool width for cache-hit refine, 0 means reuse ef_construction")
+        .scan<'i', uint32_t>();
+    parser.add_argument("--missed_refine_ef")
+        .default_value(uint32_t{0})
+        .help("Search pool width for cache-missed refine, 0 means reuse ef_construction")
+        .scan<'i', uint32_t>();
+    parser.add_argument("--enable_parallel_refine")
+        .default_value(false)
+        .implicit_value(true)
+        .help("Enable round-internal parallel refine for BuildWithCache");
+    parser.add_argument("--refine_parallelism")
+        .default_value(uint32_t{0})
+        .help("Requested refine worker count, 0 means reuse build_thread_count")
+        .scan<'i', uint32_t>();
+    parser.add_argument("--print_failed_ids_limit")
+        .default_value(size_t{20})
+        .help("Maximum number of failed ids to print")
+        .scan<'i', size_t>();
+    parser.add_argument("--disable_warm_start")
+        .default_value(false)
+        .implicit_value(true)
+        .help("Disable warm start and fall back to normal Build through BuildWithCache option");
+    parser.add_argument("--keep_invalid_neighbors")
+        .default_value(false)
+        .implicit_value(true)
+        .help("Keep invalid mapped neighbors instead of dropping them");
+    parser.add_argument("--skip_route_graph_build")
+        .default_value(false)
+        .implicit_value(true)
+        .help("Skip route_graph construction and only warm start bottom_graph");
+    parser.add_argument("--log_stats_as_json")
+        .default_value(false)
+        .implicit_value(true)
+        .help("Print BuildCacheStats as JSON");
+
+    try {
+        parser.parse_args(argc, argv);
+    } catch (const std::runtime_error& err) {
+        std::cerr << err.what() << std::endl;
+        std::cerr << parser;
+        throw;
+    }
+}
+
+std::optional<std::string>
+get_optional_string_arg(const argparse::ArgumentParser& parser, const std::string& name) {
+    if (parser.is_used(name)) {
+        return parser.get<std::string>(name);
+    }
+    return std::nullopt;
+}
+
+JsonType
+build_stats_json(const tools::DatasetAlignmentStats& import_stats,
+                 const BuildCacheStats& cache_stats,
+                 uint64_t dataset_load_us,
+                 uint64_t build_us,
+                 uint64_t serialize_index_us,
+                 const std::vector<int64_t>& failed_ids,
+                 size_t failed_id_limit,
+                 const std::string& index_output_path,
+                 const std::optional<std::string>& cache_output_path) {
+    JsonType json;
+    json["raw_label_count"].SetInt(import_stats.raw_label_count);
+    json["raw_feature_id_count"].SetInt(import_stats.raw_feature_id_count);
+    json["raw_vector_count"].SetInt(import_stats.raw_vector_count);
+    json["aligned_count"].SetInt(import_stats.aligned_count);
+    json["was_truncated"].SetBool(import_stats.was_truncated);
+    json["failed_id_count"].SetInt(failed_ids.size());
+    json["total_nodes"].SetInt(cache_stats.total_nodes);
+    json["cached_nodes"].SetInt(cache_stats.cached_nodes);
+    json["hit_nodes"].SetInt(cache_stats.hit_nodes);
+    json["missed_nodes"].SetInt(cache_stats.missed_nodes);
+    json["hit_seed_neighbor_total"].SetInt(cache_stats.hit_seed_neighbor_total);
+    json["missed_seed_neighbor_total"].SetInt(cache_stats.missed_seed_neighbor_total);
+    json["hit_empty_seed_nodes"].SetInt(cache_stats.hit_empty_seed_nodes);
+    json["missed_empty_seed_nodes"].SetInt(cache_stats.missed_empty_seed_nodes);
+    json["invalid_neighbors"].SetInt(cache_stats.invalid_neighbors);
+    json["dropped_neighbors"].SetInt(cache_stats.dropped_neighbors);
+    json["hit_refine_rounds"].SetInt(cache_stats.hit_refine_rounds);
+    json["missed_refine_rounds"].SetInt(cache_stats.missed_refine_rounds);
+    json["hit_refine_ef"].SetInt(cache_stats.hit_refine_ef);
+    json["missed_refine_ef"].SetInt(cache_stats.missed_refine_ef);
+    json["hit_refine_parallelism"].SetInt(cache_stats.hit_refine_parallelism);
+    json["missed_refine_parallelism"].SetInt(cache_stats.missed_refine_parallelism);
+    json["cache_load_us"].SetInt(cache_stats.cache_load_us);
+    json["warm_start_apply_us"].SetInt(cache_stats.warm_start_apply_us);
+    json["hit_refine_us"].SetInt(cache_stats.hit_refine_us);
+    json["missed_refine_us"].SetInt(cache_stats.missed_refine_us);
+    json["route_graph_build_us"].SetInt(cache_stats.route_graph_build_us);
+    json["route_graph_levels"].SetInt(cache_stats.route_graph_levels);
+    json["cache_hit_rate"].SetFloat(cache_stats.cache_hit_rate);
+    json["dataset_load_us"].SetInt(dataset_load_us);
+    json["build_us"].SetInt(build_us);
+    json["serialize_index_us"].SetInt(serialize_index_us);
+    json["index_output_path"].SetString(index_output_path);
+    if (cache_output_path.has_value()) {
+        json["cache_output_path"].SetString(*cache_output_path);
+    }
+    const auto sample_count = std::min(failed_ids.size(), failed_id_limit);
+    for (size_t i = 0; i < sample_count; ++i) {
+        json["failed_ids_sample"][std::to_string(i)].SetInt(static_cast<uint64_t>(failed_ids[i]));
+    }
+    return json;
+}
+
+void
+print_stats_text(const tools::DatasetAlignmentStats& import_stats,
+                 const BuildCacheStats& cache_stats,
+                 uint64_t dataset_load_us,
+                 uint64_t build_us,
+                 uint64_t serialize_index_us,
+                 const std::vector<int64_t>& failed_ids,
+                 size_t failed_id_limit,
+                 const std::string& index_output_path,
+                 const std::optional<std::string>& cache_output_path) {
+    std::cout << "raw_label_count=" << import_stats.raw_label_count << std::endl;
+    std::cout << "raw_feature_id_count=" << import_stats.raw_feature_id_count << std::endl;
+    std::cout << "raw_vector_count=" << import_stats.raw_vector_count << std::endl;
+    std::cout << "aligned_count=" << import_stats.aligned_count << std::endl;
+    std::cout << "was_truncated=" << (import_stats.was_truncated ? "true" : "false")
+              << std::endl;
+    std::cout << "failed_id_count=" << failed_ids.size() << std::endl;
+    if (not failed_ids.empty()) {
+        std::cout << "failed_ids_sample=";
+        const auto sample_count = std::min(failed_ids.size(), failed_id_limit);
+        for (size_t i = 0; i < sample_count; ++i) {
+            if (i != 0) {
+                std::cout << ',';
+            }
+            std::cout << failed_ids[i];
+        }
+        std::cout << std::endl;
+    }
+    std::cout << "cache_hit_rate=" << cache_stats.cache_hit_rate << std::endl;
+    std::cout << "hit_nodes=" << cache_stats.hit_nodes << std::endl;
+    std::cout << "missed_nodes=" << cache_stats.missed_nodes << std::endl;
+    std::cout << "hit_seed_neighbor_total=" << cache_stats.hit_seed_neighbor_total << std::endl;
+    std::cout << "missed_seed_neighbor_total=" << cache_stats.missed_seed_neighbor_total
+              << std::endl;
+    std::cout << "hit_empty_seed_nodes=" << cache_stats.hit_empty_seed_nodes << std::endl;
+    std::cout << "missed_empty_seed_nodes=" << cache_stats.missed_empty_seed_nodes << std::endl;
+    std::cout << "cache_load_us=" << cache_stats.cache_load_us << std::endl;
+    std::cout << "warm_start_apply_us=" << cache_stats.warm_start_apply_us << std::endl;
+    std::cout << "hit_refine_us=" << cache_stats.hit_refine_us << std::endl;
+    std::cout << "missed_refine_us=" << cache_stats.missed_refine_us << std::endl;
+    std::cout << "hit_refine_ef=" << cache_stats.hit_refine_ef << std::endl;
+    std::cout << "missed_refine_ef=" << cache_stats.missed_refine_ef << std::endl;
+    std::cout << "hit_refine_parallelism=" << cache_stats.hit_refine_parallelism << std::endl;
+    std::cout << "missed_refine_parallelism=" << cache_stats.missed_refine_parallelism
+              << std::endl;
+    std::cout << "route_graph_build_us=" << cache_stats.route_graph_build_us << std::endl;
+    std::cout << "route_graph_levels=" << cache_stats.route_graph_levels << std::endl;
+    std::cout << "dataset_load_us=" << dataset_load_us << std::endl;
+    std::cout << "build_us=" << build_us << std::endl;
+    std::cout << "serialize_index_us=" << serialize_index_us << std::endl;
+    std::cout << "index_output_path=" << index_output_path << std::endl;
+    if (cache_output_path.has_value()) {
+        std::cout << "cache_output_path=" << *cache_output_path << std::endl;
+    }
+}
+
+}  // namespace
+
+int
+main(int argc, char** argv) {
+    try {
+        const auto total_begin = now_us();
+        argparse::ArgumentParser parser("build_hgraph_with_cache");
+        parse_args(parser, argc, argv);
+
+        const auto cache_input_path = parser.get<std::string>("--cache_input_path");
+        const auto vector_path = parser.get<std::string>("--vector_path");
+        const auto label_path = parser.get<std::string>("--label_path");
+        const auto feature_id_path = parser.get<std::string>("--feature_id_path");
+        const auto index_output_path = parser.get<std::string>("--index_output_path");
+        const auto build_parameter_source = parser.get<std::string>("--build_parameter");
+        const auto cache_output_path = get_optional_string_arg(parser, "--cache_output_path");
+        const auto alignment_policy =
+            tools::ParseAlignmentPolicy(parser.get<std::string>("--alignment_policy"));
+        const auto dimension_override = parser.get<int64_t>("--dimension");
+        const auto hit_refine_rounds = parser.get<uint32_t>("--hit_refine_rounds");
+        const auto missed_refine_rounds = parser.get<uint32_t>("--missed_refine_rounds");
+        const auto hit_refine_ef = parser.get<uint32_t>("--hit_refine_ef");
+        const auto missed_refine_ef = parser.get<uint32_t>("--missed_refine_ef");
+        const auto enable_parallel_refine = parser.get<bool>("--enable_parallel_refine");
+        const auto refine_parallelism = parser.get<uint32_t>("--refine_parallelism");
+        const auto failed_ids_limit = parser.get<size_t>("--print_failed_ids_limit");
+        const auto disable_warm_start = parser.get<bool>("--disable_warm_start");
+        const auto keep_invalid_neighbors = parser.get<bool>("--keep_invalid_neighbors");
+        const auto skip_route_graph_build = parser.get<bool>("--skip_route_graph_build");
+        const auto log_stats_as_json = parser.get<bool>("--log_stats_as_json");
+
+        const auto build_config = tools::ParseBuildParameterSource(build_parameter_source);
+        const auto dim = dimension_override > 0 ? dimension_override : build_config.dim;
+        if (build_config.dtype != "float32") {
+            std::cerr << "only float32 dataset is supported in build_hgraph_with_cache, got dtype="
+                      << build_config.dtype << std::endl;
+            return static_cast<int>(ExitCode::INVALID_ARGUMENT);
+        }
+
+        log_stage("starting prebuild"
+                  " cache_input_path=" + cache_input_path +
+                  " index_output_path=" + index_output_path +
+                  " dim=" + std::to_string(dim) +
+                  " hit_refine_rounds=" + std::to_string(hit_refine_rounds) +
+                  " missed_refine_rounds=" + std::to_string(missed_refine_rounds) +
+                  " hit_refine_ef=" + std::to_string(hit_refine_ef) +
+                  " missed_refine_ef=" + std::to_string(missed_refine_ef) +
+                  " enable_parallel_refine=" +
+                  (enable_parallel_refine ? std::string("true") : std::string("false")) +
+                  " refine_parallelism=" + std::to_string(refine_parallelism) +
+                  " warm_start=" + (disable_warm_start ? std::string("false") : std::string("true")) +
+                  " build_route_graph=" +
+                  (skip_route_graph_build ? std::string("false") : std::string("true")));
+        log_stage("loading dataset from input files");
+
+        const auto dataset_load_begin = now_us();
+        tools::ImportedDataset imported_dataset;
+        try {
+            imported_dataset = tools::LoadFloat32DatasetFromFiles(
+                label_path, feature_id_path, vector_path, dim, alignment_policy);
+        } catch (const std::runtime_error& ex) {
+            std::cerr << ex.what() << std::endl;
+            const std::string message = ex.what();
+            if (message.find("row count mismatch") != std::string::npos ||
+                message.find("aligned dataset is empty") != std::string::npos ||
+                message.find("duplicate feature_id") != std::string::npos ||
+                message.find("contains empty feature id") != std::string::npos) {
+                return static_cast<int>(ExitCode::DATASET_ALIGNMENT_ERROR);
+            }
+            return static_cast<int>(ExitCode::INPUT_IO_ERROR);
+        }
+        const auto dataset_load_us = now_us() - dataset_load_begin;
+        log_stage_elapsed("dataset_load", dataset_load_us, now_us() - total_begin);
+        log_stage("dataset rows aligned=" + std::to_string(imported_dataset.stats.aligned_count) +
+                  " truncated=" +
+                  (imported_dataset.stats.was_truncated ? std::string("true")
+                                                       : std::string("false")));
+
+        auto create_result = Factory::CreateIndex("hgraph", build_config.raw_json);
+        if (not create_result.has_value()) {
+            std::cerr << "failed to create HGraph index: " << create_result.error().message
+                      << std::endl;
+            return static_cast<int>(ExitCode::CREATE_INDEX_ERROR);
+        }
+        auto index = create_result.value();
+
+        BuildCacheOptions options;
+        options.enable_warm_start = not disable_warm_start;
+        options.hit_refine_rounds = hit_refine_rounds;
+        options.missed_refine_rounds = missed_refine_rounds;
+        options.hit_refine_ef = hit_refine_ef;
+        options.missed_refine_ef = missed_refine_ef;
+        options.enable_parallel_refine = enable_parallel_refine;
+        options.refine_parallelism = refine_parallelism;
+        options.drop_invalid_neighbors = not keep_invalid_neighbors;
+        options.build_route_graph = not skip_route_graph_build;
+
+        std::ifstream cache_input(cache_input_path, std::ios::binary);
+        if (not cache_input.is_open()) {
+            std::cerr << "failed to open cache input file: " << cache_input_path << std::endl;
+            return static_cast<int>(ExitCode::INPUT_IO_ERROR);
+        }
+
+        log_stage("starting BuildWithCache");
+        const auto build_begin = now_us();
+        auto build_result = index->BuildWithCache(imported_dataset.dataset, cache_input, options);
+        const auto build_us = now_us() - build_begin;
+        if (not build_result.has_value()) {
+            std::cerr << "build with cache failed: " << build_result.error().message << std::endl;
+            return static_cast<int>(ExitCode::BUILD_WITH_CACHE_ERROR);
+        }
+        const auto failed_ids = build_result.value();
+        log_stage_elapsed("build_with_cache", build_us, now_us() - total_begin);
+        log_stage("starting index serialization");
+
+        const auto serialize_begin = now_us();
+        std::ofstream index_output(index_output_path, std::ios::binary);
+        if (not index_output.is_open()) {
+            std::cerr << "failed to open index output file: " << index_output_path << std::endl;
+            return static_cast<int>(ExitCode::SERIALIZE_INDEX_ERROR);
+        }
+        auto serialize_result = index->Serialize(index_output);
+        const auto serialize_index_us = now_us() - serialize_begin;
+        if (not serialize_result.has_value()) {
+            std::cerr << "serialize index failed: " << serialize_result.error().message
+                      << std::endl;
+            return static_cast<int>(ExitCode::SERIALIZE_INDEX_ERROR);
+        }
+        log_stage_elapsed("serialize_index", serialize_index_us, now_us() - total_begin);
+
+        if (cache_output_path.has_value()) {
+            log_stage("starting cache export");
+            const auto export_begin = now_us();
+            std::ofstream cache_output(*cache_output_path, std::ios::binary);
+            if (not cache_output.is_open()) {
+                std::cerr << "failed to open cache output file: " << *cache_output_path
+                          << std::endl;
+                return static_cast<int>(ExitCode::EXPORT_CACHE_ERROR);
+            }
+            auto export_result = index->ExportBuildCache(cache_output);
+            if (not export_result.has_value()) {
+                std::cerr << "export build cache failed: " << export_result.error().message
+                          << std::endl;
+                return static_cast<int>(ExitCode::EXPORT_CACHE_ERROR);
+            }
+            log_stage_elapsed("export_cache", now_us() - export_begin, now_us() - total_begin);
+        }
+
+        auto stats_result = index->GetBuildCacheStats();
+        if (not stats_result.has_value()) {
+            std::cerr << "get build cache stats failed: " << stats_result.error().message
+                      << std::endl;
+            return static_cast<int>(ExitCode::GET_STATS_ERROR);
+        }
+
+        log_stage("refine summary"
+                  " hit_nodes=" + std::to_string(stats_result.value().hit_nodes) +
+                  " missed_nodes=" + std::to_string(stats_result.value().missed_nodes) +
+                  " hit_seed_neighbor_total=" +
+                  std::to_string(stats_result.value().hit_seed_neighbor_total) +
+                  " missed_seed_neighbor_total=" +
+                  std::to_string(stats_result.value().missed_seed_neighbor_total) +
+                  " hit_empty_seed_nodes=" +
+                  std::to_string(stats_result.value().hit_empty_seed_nodes) +
+                  " missed_empty_seed_nodes=" +
+                  std::to_string(stats_result.value().missed_empty_seed_nodes) +
+                  " hit_refine_rounds=" +
+                  std::to_string(stats_result.value().hit_refine_rounds) +
+                  " missed_refine_rounds=" +
+                  std::to_string(stats_result.value().missed_refine_rounds) +
+                  " hit_refine_parallelism=" +
+                  std::to_string(stats_result.value().hit_refine_parallelism) +
+                  " missed_refine_parallelism=" +
+                  std::to_string(stats_result.value().missed_refine_parallelism));
+
+        if (log_stats_as_json) {
+            auto json = build_stats_json(imported_dataset.stats,
+                                         stats_result.value(),
+                                         dataset_load_us,
+                                         build_us,
+                                         serialize_index_us,
+                                         failed_ids,
+                                         failed_ids_limit,
+                                         index_output_path,
+                                         cache_output_path);
+            std::cout << json.Dump() << std::endl;
+        } else {
+            print_stats_text(imported_dataset.stats,
+                             stats_result.value(),
+                             dataset_load_us,
+                             build_us,
+                             serialize_index_us,
+                             failed_ids,
+                             failed_ids_limit,
+                             index_output_path,
+                             cache_output_path);
+        }
+
+        log_stage_elapsed("total_prebuild", now_us() - total_begin, now_us() - total_begin);
+
+        return static_cast<int>(ExitCode::SUCCESS);
+    } catch (const std::exception& ex) {
+        std::cerr << ex.what() << std::endl;
+        return static_cast<int>(ExitCode::INVALID_ARGUMENT);
+    }
+}

--- a/tools/build_cache/compare_hgraph_ids.cpp
+++ b/tools/build_cache/compare_hgraph_ids.cpp
@@ -1,0 +1,258 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <vsag/vsag.h>
+
+#include <algorithm>
+#include <argparse/argparse.hpp>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "algorithm/hgraph/hgraph.h"
+#include "index/index_impl.h"
+#include "inner_string_params.h"
+#include "storage/serialization.h"
+#include "storage/stream_reader.h"
+
+using namespace vsag;
+
+namespace {
+
+constexpr static const char* DEFAULT_BUILD_PARAM = "default";
+
+void
+parse_args(argparse::ArgumentParser& parser, int argc, char** argv) {
+    parser.add_argument<std::string>("--index_path", "-i")
+        .required()
+        .help("Serialized HGraph index file path");
+
+    parser.add_argument<std::string>("--label_path", "-l")
+        .required()
+        .help("Path to label.bin used for comparison");
+
+    parser.add_argument<std::string>("--build_parameter", "-bp")
+        .default_value(std::string(DEFAULT_BUILD_PARAM))
+        .help("Optional full build parameter JSON, required when the index uses old serialization format");
+
+    parser.add_argument("--sample_limit", "-s")
+        .default_value(10)
+        .help("How many mismatched labels to print as samples")
+        .scan<'i', int>();
+
+    try {
+        parser.parse_args(argc, argv);
+    } catch (const std::runtime_error& err) {
+        std::cerr << err.what() << std::endl;
+        std::cerr << parser;
+        throw;
+    }
+}
+
+std::vector<int64_t>
+read_labels(const std::string& path) {
+    std::ifstream input(path, std::ios::binary);
+    if (not input.is_open()) {
+        throw std::runtime_error("failed to open label file: " + path);
+    }
+    input.seekg(0, std::ios::end);
+    const auto size = input.tellg();
+    input.seekg(0, std::ios::beg);
+    if (size < 0 || (size % static_cast<std::streamoff>(sizeof(int64_t))) != 0) {
+        throw std::runtime_error("label.bin size is not aligned to int64: " + path);
+    }
+
+    std::vector<int64_t> labels(static_cast<size_t>(size / sizeof(int64_t)));
+    if (not labels.empty()) {
+        input.read(reinterpret_cast<char*>(labels.data()), size);
+    }
+    if (not input.good() && not input.eof()) {
+        throw std::runtime_error("failed to read label file: " + path);
+    }
+    return labels;
+}
+
+class HGraphIndexLoader {
+public:
+    explicit HGraphIndexLoader(std::string build_param) : build_param_(std::move(build_param)) {
+    }
+
+    IndexPtr
+    Load(const std::string& index_path) {
+        std::ifstream probe_stream(index_path, std::ios::binary);
+        if (not probe_stream.is_open()) {
+            throw std::runtime_error("failed to open index file: " + index_path);
+        }
+
+        IOStreamReader reader(probe_stream);
+        auto footer = Footer::Parse(reader);
+        if (footer != nullptr) {
+            return load_new_format(index_path, footer);
+        }
+        if (build_param_ == DEFAULT_BUILD_PARAM) {
+            throw std::runtime_error(
+                "old-format index requires --build_parameter with full HGraph build JSON");
+        }
+        return load_with_factory(index_path, build_param_);
+    }
+
+private:
+    IndexPtr
+    load_with_factory(const std::string& index_path, const std::string& build_param) {
+        auto create_result = Factory::CreateIndex(INDEX_HGRAPH, build_param);
+        if (not create_result.has_value()) {
+            throw std::runtime_error("failed to create index: " +
+                                     create_result.error().message);
+        }
+        auto index = create_result.value();
+        std::ifstream input(index_path, std::ios::binary);
+        if (not input.is_open()) {
+            throw std::runtime_error("failed to reopen index file: " + index_path);
+        }
+        auto deserialize_result = index->Deserialize(input);
+        if (not deserialize_result.has_value()) {
+            throw std::runtime_error("failed to deserialize index: " +
+                                     deserialize_result.error().message);
+        }
+        return index;
+    }
+
+    IndexPtr
+    load_new_format(const std::string& index_path, const FooterPtr& footer) {
+        auto metadata = footer->GetMetadata();
+        auto basic_info = metadata->Get(BASIC_INFO);
+        if (not basic_info.Contains(INDEX_PARAM)) {
+            throw std::runtime_error("index metadata does not contain build parameters");
+        }
+
+        auto index_param = JsonType::Parse(basic_info[INDEX_PARAM].GetString());
+        auto index_name = index_param[TYPE_KEY].GetString();
+        if (index_name != INDEX_HGRAPH) {
+            throw std::runtime_error("only HGraph index is supported, got: " + index_name);
+        }
+
+        IndexCommonParam index_common_params;
+        index_common_params.dim_ = basic_info[DIM].GetInt();
+        index_common_params.extra_info_size_ = basic_info["extra_info_size"].GetInt();
+        index_common_params.data_type_ = static_cast<DataTypes>(basic_info["data_type"].GetInt());
+        index_common_params.metric_ = static_cast<MetricType>(basic_info["metric"].GetInt());
+        index_common_params.allocator_ = Engine::CreateDefaultAllocator();
+
+        auto hgraph_parameter = std::make_shared<HGraphParameter>();
+        hgraph_parameter->FromJson(index_param);
+        hgraph_parameter->data_type = index_common_params.data_type_;
+
+        auto inner_index = std::make_shared<HGraph>(hgraph_parameter, index_common_params);
+        auto index = std::make_shared<IndexImpl<HGraph>>(inner_index, index_common_params);
+
+        std::ifstream input(index_path, std::ios::binary);
+        if (not input.is_open()) {
+            throw std::runtime_error("failed to reopen index file: " + index_path);
+        }
+        auto deserialize_result = index->Deserialize(input);
+        if (not deserialize_result.has_value()) {
+            throw std::runtime_error("failed to deserialize index: " +
+                                     deserialize_result.error().message);
+        }
+        return index;
+    }
+
+private:
+    std::string build_param_;
+};
+
+void
+print_samples(const std::vector<int64_t>& values, const std::string& title, int sample_limit) {
+    std::cout << title << ": " << values.size() << std::endl;
+    const auto count = std::min<int>(sample_limit, static_cast<int>(values.size()));
+    for (int i = 0; i < count; ++i) {
+        std::cout << "  [" << i << "] " << values[static_cast<size_t>(i)] << std::endl;
+    }
+}
+
+}  // namespace
+
+int
+main(int argc, char** argv) {
+    try {
+        argparse::ArgumentParser parser("compare_hgraph_ids");
+        parse_args(parser, argc, argv);
+
+        const auto index_path = parser.get<std::string>("--index_path");
+        const auto label_path = parser.get<std::string>("--label_path");
+        const auto build_param = parser.get<std::string>("--build_parameter");
+        const auto sample_limit = parser.get<int>("--sample_limit");
+
+        auto labels = read_labels(label_path);
+        HGraphIndexLoader loader(build_param);
+        auto index = loader.Load(index_path);
+        auto export_ids_result = index->ExportIDs();
+        if (not export_ids_result.has_value()) {
+            throw std::runtime_error("failed to export index ids: " +
+                                     export_ids_result.error().message);
+        }
+
+        const auto* index_ids_ptr = export_ids_result.value()->GetIds();
+        const auto index_count = export_ids_result.value()->GetNumElements();
+        std::vector<int64_t> index_ids(index_ids_ptr, index_ids_ptr + index_count);
+
+        std::sort(labels.begin(), labels.end());
+        std::sort(index_ids.begin(), index_ids.end());
+
+        std::vector<int64_t> only_in_labels;
+        std::vector<int64_t> only_in_index;
+        only_in_labels.reserve(4096);
+        only_in_index.reserve(4096);
+
+        size_t i = 0;
+        size_t j = 0;
+        uint64_t intersection_count = 0;
+        while (i < labels.size() && j < index_ids.size()) {
+            if (labels[i] == index_ids[j]) {
+                ++intersection_count;
+                ++i;
+                ++j;
+            } else if (labels[i] < index_ids[j]) {
+                only_in_labels.push_back(labels[i]);
+                ++i;
+            } else {
+                only_in_index.push_back(index_ids[j]);
+                ++j;
+            }
+        }
+        while (i < labels.size()) {
+            only_in_labels.push_back(labels[i]);
+            ++i;
+        }
+        while (j < index_ids.size()) {
+            only_in_index.push_back(index_ids[j]);
+            ++j;
+        }
+
+        std::cout << "label.bin rows: " << labels.size() << std::endl;
+        std::cout << "index exported ids: " << index_ids.size() << std::endl;
+        std::cout << "intersection count: " << intersection_count << std::endl;
+        std::cout << "only in label.bin: " << only_in_labels.size() << std::endl;
+        std::cout << "only in index: " << only_in_index.size() << std::endl;
+
+        print_samples(only_in_labels, "sample labels only in label.bin", sample_limit);
+        print_samples(only_in_index, "sample labels only in index", sample_limit);
+
+        return 0;
+    } catch (const std::exception& ex) {
+        std::cerr << ex.what() << std::endl;
+        return 1;
+    }
+}

--- a/tools/build_cache/eval_recall_brute_force.cpp
+++ b/tools/build_cache/eval_recall_brute_force.cpp
@@ -1,0 +1,452 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Tool: eval_recall_brute_force
+// Loads a serialised hgraph index and evaluates recall@k against ground truth
+// computed on-the-fly via brute-force L2 distances over the original
+// vector_data.bin. Uses label.bin to map brute-force row indices to the
+// external labels returned by KnnSearch.
+
+#include <vsag/vsag.h>
+
+#include <argparse/argparse.hpp>
+#include <atomic>
+#include <chrono>
+#include <cctype>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <cerrno>
+#include <fcntl.h>
+#include <fstream>
+#include <future>
+#include <iostream>
+#include <memory>
+#include <mutex>
+#include <queue>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <thread>
+#include <unistd.h>
+#include <vector>
+#include <algorithm>
+
+using namespace vsag;
+
+namespace {
+
+uint64_t now_ns() {
+    return std::chrono::duration_cast<std::chrono::nanoseconds>(
+               std::chrono::steady_clock::now().time_since_epoch())
+        .count();
+}
+
+double ns_to_s(uint64_t ns) {
+    return static_cast<double>(ns) / 1e9;
+}
+
+void log_stage(const std::string& msg) {
+    std::cerr << "[eval_recall_bf] " << msg << std::endl;
+}
+
+struct MmapVectorData {
+    int fd = -1;
+    size_t bytes = 0;
+    const float* data = nullptr;
+    size_t row_count = 0;
+    ~MmapVectorData() {
+        if (data != nullptr && bytes > 0) {
+            ::munmap(const_cast<float*>(data), bytes);
+        }
+        if (fd >= 0) {
+            ::close(fd);
+        }
+    }
+};
+
+std::unique_ptr<MmapVectorData>
+mmap_vector_data(const std::string& path, int64_t dim) {
+    auto holder = std::make_unique<MmapVectorData>();
+    holder->fd = ::open(path.c_str(), O_RDONLY);
+    if (holder->fd < 0) {
+        throw std::runtime_error("failed to open vector file: " + path);
+    }
+    struct stat st {};
+    if (::fstat(holder->fd, &st) != 0) {
+        throw std::runtime_error("failed to stat vector file: " + path);
+    }
+    if (st.st_size <= 0 || (st.st_size % static_cast<off_t>(sizeof(float))) != 0) {
+        throw std::runtime_error("vector_data.bin not aligned to float32: " + path);
+    }
+    const auto float_count = static_cast<size_t>(st.st_size / sizeof(float));
+    if (float_count % static_cast<size_t>(dim) != 0) {
+        throw std::runtime_error("vector_data.bin float count not aligned to dim: " + path);
+    }
+    holder->bytes = static_cast<size_t>(st.st_size);
+    holder->row_count = float_count / static_cast<size_t>(dim);
+    void* mapped = ::mmap(nullptr, holder->bytes, PROT_READ, MAP_SHARED, holder->fd, 0);
+    if (mapped == MAP_FAILED) {
+        throw std::runtime_error("mmap failed for " + path + ": " + std::strerror(errno));
+    }
+    holder->data = static_cast<const float*>(mapped);
+    ::madvise(const_cast<float*>(holder->data), holder->bytes, MADV_SEQUENTIAL);
+    return holder;
+}
+
+inline float l2_sqr(const float* a, const float* b, int64_t dim) {
+    float sum = 0.0F;
+    for (int64_t i = 0; i < dim; ++i) {
+        const float d = a[i] - b[i];
+        sum += d * d;
+    }
+    return sum;
+}
+
+struct TopK {
+    int64_t k;
+    std::priority_queue<std::pair<float, int64_t>> heap;
+    explicit TopK(int64_t kk) : k(kk) {}
+    void push(float dist, int64_t id) {
+        if (static_cast<int64_t>(heap.size()) < k) {
+            heap.emplace(dist, id);
+        } else if (dist < heap.top().first) {
+            heap.pop();
+            heap.emplace(dist, id);
+        }
+    }
+    std::vector<std::pair<float, int64_t>> sorted_ascending() {
+        std::vector<std::pair<float, int64_t>> out;
+        out.reserve(heap.size());
+        while (not heap.empty()) {
+            out.push_back(heap.top());
+            heap.pop();
+        }
+        std::reverse(out.begin(), out.end());
+        return out;
+    }
+};
+
+std::vector<int64_t>
+parse_query_indices(int64_t total_rows, int64_t query_count, int64_t query_stride) {
+    if (query_count <= 0) throw std::runtime_error("query_count must be positive");
+    if (query_count > total_rows) throw std::runtime_error("query_count > total_rows");
+    std::vector<int64_t> indices;
+    indices.reserve(query_count);
+    if (query_stride <= 0) {
+        const double step = static_cast<double>(total_rows) / static_cast<double>(query_count);
+        for (int64_t i = 0; i < query_count; ++i) {
+            indices.push_back(static_cast<int64_t>(static_cast<double>(i) * step));
+        }
+    } else {
+        for (int64_t i = 0; i < query_count; ++i) {
+            int64_t idx = i * query_stride;
+            if (idx >= total_rows) break;
+            indices.push_back(idx);
+        }
+    }
+    return indices;
+}
+
+std::vector<std::vector<int64_t>>
+brute_force_top_k(const float* base, int64_t total_rows, int64_t dim,
+                  const float* queries, int64_t query_count, int64_t k, int threads) {
+    if (threads <= 0) {
+        threads = static_cast<int>(std::thread::hardware_concurrency());
+        if (threads <= 0) threads = 8;
+    }
+    log_stage("brute_force start: rows=" + std::to_string(total_rows) +
+              ", queries=" + std::to_string(query_count) + ", k=" + std::to_string(k) +
+              ", threads=" + std::to_string(threads));
+
+    std::vector<std::vector<TopK>> per_thread;
+    per_thread.reserve(threads);
+    for (int t = 0; t < threads; ++t) {
+        per_thread.emplace_back();
+        per_thread[t].reserve(query_count);
+        for (int64_t q = 0; q < query_count; ++q) {
+            per_thread[t].emplace_back(k);
+        }
+    }
+
+    std::atomic<int64_t> processed_blocks{0};
+    constexpr int64_t kBlock = 8192;
+    const int64_t block_count = (total_rows + kBlock - 1) / kBlock;
+
+    auto worker = [&](int thread_id) {
+        for (int64_t blk = thread_id; blk < block_count; blk += threads) {
+            const int64_t row_begin = blk * kBlock;
+            const int64_t row_end = std::min(total_rows, row_begin + kBlock);
+            for (int64_t q = 0; q < query_count; ++q) {
+                const float* qvec = queries + q * dim;
+                auto& heap = per_thread[thread_id][q];
+                for (int64_t r = row_begin; r < row_end; ++r) {
+                    const float* base_vec = base + r * dim;
+                    const float dist = l2_sqr(qvec, base_vec, dim);
+                    heap.push(dist, r);
+                }
+            }
+            const auto done = processed_blocks.fetch_add(1) + 1;
+            if ((done % 256) == 0 || done == block_count) {
+                log_stage("brute_force progress " + std::to_string(done) + "/" +
+                          std::to_string(block_count));
+            }
+        }
+    };
+
+    std::vector<std::thread> ths;
+    ths.reserve(threads);
+    const auto bf_begin = now_ns();
+    for (int t = 0; t < threads; ++t) ths.emplace_back(worker, t);
+    for (auto& th : ths) th.join();
+    log_stage("brute_force compute finished in " +
+              std::to_string(ns_to_s(now_ns() - bf_begin)) + "s");
+
+    std::vector<std::vector<int64_t>> result(query_count);
+    for (int64_t q = 0; q < query_count; ++q) {
+        TopK merged(k);
+        for (int t = 0; t < threads; ++t) {
+            for (auto& entry : per_thread[t][q].sorted_ascending()) {
+                merged.push(entry.first, entry.second);
+            }
+        }
+        auto sorted = merged.sorted_ascending();
+        result[q].reserve(sorted.size());
+        for (auto& entry : sorted) result[q].push_back(entry.second);
+    }
+    return result;
+}
+
+std::vector<int> parse_int_list(const std::string& csv) {
+    std::vector<int> out;
+    std::stringstream ss(csv);
+    std::string item;
+    while (std::getline(ss, item, ',')) {
+        if (item.empty()) continue;
+        out.push_back(std::stoi(item));
+    }
+    return out;
+}
+
+std::string read_file_text(const std::string& path) {
+    std::ifstream in(path);
+    if (not in.is_open()) throw std::runtime_error("failed to open: " + path);
+    std::stringstream ss;
+    ss << in.rdbuf();
+    return ss.str();
+}
+
+int64_t extract_dim_from_json(const std::string& json) {
+    auto pos = json.find("\"dim\"");
+    if (pos == std::string::npos) return -1;
+    auto colon = json.find(':', pos);
+    if (colon == std::string::npos) return -1;
+    int64_t value = 0;
+    int sign = 1;
+    size_t i = colon + 1;
+    while (i < json.size() && (json[i] == ' ' || json[i] == '\t')) ++i;
+    if (i < json.size() && json[i] == '-') { sign = -1; ++i; }
+    bool has_digit = false;
+    while (i < json.size() && std::isdigit(static_cast<unsigned char>(json[i]))) {
+        value = value * 10 + (json[i] - '0');
+        ++i;
+        has_digit = true;
+    }
+    if (not has_digit) return -1;
+    return sign * value;
+}
+
+std::vector<int64_t> read_labels_int64(const std::string& path) {
+    std::ifstream input(path, std::ios::binary);
+    if (not input.is_open()) throw std::runtime_error("failed to open label file: " + path);
+    input.seekg(0, std::ios::end);
+    const auto size = input.tellg();
+    input.seekg(0, std::ios::beg);
+    if (size < 0 || (size % static_cast<std::streamoff>(sizeof(int64_t))) != 0) {
+        throw std::runtime_error("label.bin not aligned to int64: " + path);
+    }
+    std::vector<int64_t> labels(static_cast<size_t>(size / sizeof(int64_t)));
+    if (not labels.empty()) {
+        input.read(reinterpret_cast<char*>(labels.data()), size);
+    }
+    if (not input.good() && not input.eof()) {
+        throw std::runtime_error("failed to read label file: " + path);
+    }
+    return labels;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    try {
+        argparse::ArgumentParser parser("eval_recall_brute_force");
+        parser.add_argument<std::string>("--index_path", "-i").required();
+        parser.add_argument<std::string>("--vector_path", "-v").required();
+        parser.add_argument<std::string>("--label_path", "-l").required();
+        parser.add_argument<std::string>("--build_parameter", "-bp").required();
+        parser.add_argument("--query_count").default_value(int64_t{1000}).scan<'i', int64_t>();
+        parser.add_argument("--query_stride").default_value(int64_t{0}).scan<'i', int64_t>();
+        parser.add_argument("--topk").default_value(int64_t{10}).scan<'i', int64_t>();
+        parser.add_argument<std::string>("--ef_search").default_value(std::string("50,100,200,400,1000"));
+        parser.add_argument("--brute_force_threads").default_value(100).scan<'i', int>();
+        parser.add_argument("--search_threads").default_value(16).scan<'i', int>();
+        parser.add_argument("--dim").default_value(int64_t{-1}).scan<'i', int64_t>();
+        parser.parse_args(argc, argv);
+
+        const auto index_path = parser.get<std::string>("--index_path");
+        const auto vector_path = parser.get<std::string>("--vector_path");
+        const auto label_path = parser.get<std::string>("--label_path");
+        const auto build_parameter_arg = parser.get<std::string>("--build_parameter");
+        const auto query_count = parser.get<int64_t>("--query_count");
+        const auto query_stride = parser.get<int64_t>("--query_stride");
+        const auto topk = parser.get<int64_t>("--topk");
+        const auto ef_list = parse_int_list(parser.get<std::string>("--ef_search"));
+        const auto bf_threads = parser.get<int>("--brute_force_threads");
+        const auto search_threads = parser.get<int>("--search_threads");
+        int64_t dim = parser.get<int64_t>("--dim");
+
+        std::string build_param_json;
+        {
+            std::ifstream test(build_parameter_arg);
+            if (test.is_open()) build_param_json = read_file_text(build_parameter_arg);
+            else build_param_json = build_parameter_arg;
+        }
+        if (dim <= 0) {
+            dim = extract_dim_from_json(build_param_json);
+            if (dim <= 0) throw std::runtime_error("could not infer dim, pass --dim");
+        }
+        log_stage("dim=" + std::to_string(dim));
+
+        log_stage("mmap vector file: " + vector_path);
+        auto base_holder = mmap_vector_data(vector_path, dim);
+        const float* base = base_holder->data;
+        const int64_t total_rows = static_cast<int64_t>(base_holder->row_count);
+        log_stage("base rows=" + std::to_string(total_rows));
+
+        log_stage("loading labels: " + label_path);
+        auto labels = read_labels_int64(label_path);
+        if (static_cast<int64_t>(labels.size()) < total_rows) {
+            throw std::runtime_error("label count < vector row count");
+        }
+        if (static_cast<int64_t>(labels.size()) > total_rows) {
+            log_stage("label count > vector row count, truncating");
+            labels.resize(static_cast<size_t>(total_rows));
+        }
+
+        auto query_indices = parse_query_indices(total_rows, query_count, query_stride);
+        const int64_t actual_q = static_cast<int64_t>(query_indices.size());
+        std::vector<float> queries(static_cast<size_t>(actual_q * dim));
+        for (int64_t q = 0; q < actual_q; ++q) {
+            std::memcpy(queries.data() + q * dim, base + query_indices[q] * dim,
+                        static_cast<size_t>(dim) * sizeof(float));
+        }
+        log_stage("collected " + std::to_string(actual_q) + " queries");
+
+        log_stage("create index from build_parameter");
+        auto create_result = Factory::CreateIndex("hgraph", build_param_json);
+        if (not create_result.has_value()) {
+            throw std::runtime_error("CreateIndex failed: " + create_result.error().message);
+        }
+        auto index = create_result.value();
+
+        log_stage("deserialize index from " + index_path);
+        const auto deser_begin = now_ns();
+        std::ifstream istr(index_path, std::ios::binary);
+        if (not istr.is_open()) throw std::runtime_error("open index_path failed: " + index_path);
+        auto deser_result = index->Deserialize(istr);
+        if (not deser_result.has_value()) {
+            throw std::runtime_error("Deserialize failed: " + deser_result.error().message);
+        }
+        log_stage("deserialize finished in " +
+                  std::to_string(ns_to_s(now_ns() - deser_begin)) + "s");
+
+        auto gt = brute_force_top_k(base, total_rows, dim, queries.data(),
+                                    actual_q, topk, bf_threads);
+
+        std::cout << "ef_search\trecall@" << topk << "\tavg_latency_us\twall_qps\n";
+
+        std::mutex io_mu;
+        for (int ef : ef_list) {
+            std::ostringstream sp;
+            sp << "{\"hgraph\":{\"ef_search\":" << ef << "}}";
+            const std::string search_param = sp.str();
+
+            std::atomic<int64_t> total_correct{0};
+            std::atomic<uint64_t> total_search_ns{0};
+
+            auto worker = [&](int64_t qbegin, int64_t qend) {
+                for (int64_t qi = qbegin; qi < qend; ++qi) {
+                    auto query_ds = Dataset::Make();
+                    query_ds->NumElements(1)
+                        ->Dim(dim)
+                        ->Float32Vectors(queries.data() + qi * dim)
+                        ->Owner(false);
+                    const auto t0 = now_ns();
+                    auto result = index->KnnSearch(query_ds, topk, search_param);
+                    const auto t1 = now_ns();
+                    if (not result.has_value()) {
+                        std::lock_guard<std::mutex> lk(io_mu);
+                        std::cerr << "knn search failed at qi=" << qi
+                                  << ": " << result.error().message << std::endl;
+                        continue;
+                    }
+                    total_search_ns.fetch_add(t1 - t0);
+                    auto ds = result.value();
+                    const auto* ids = ds->GetIds();
+                    const auto count = ds->GetDim();
+                    int64_t correct = 0;
+                    for (int64_t i = 0; i < count; ++i) {
+                        const int64_t got = ids[i];
+                        for (int64_t g_row : gt[qi]) {
+                            if (labels[g_row] == got) {
+                                ++correct;
+                                break;
+                            }
+                        }
+                    }
+                    total_correct.fetch_add(correct);
+                }
+            };
+
+            const auto run_begin = now_ns();
+            std::vector<std::thread> ths;
+            ths.reserve(search_threads);
+            const int64_t chunk = (actual_q + search_threads - 1) / search_threads;
+            for (int t = 0; t < search_threads; ++t) {
+                const int64_t b = std::min<int64_t>(actual_q, t * chunk);
+                const int64_t e = std::min<int64_t>(actual_q, b + chunk);
+                if (b >= e) break;
+                ths.emplace_back(worker, b, e);
+            }
+            for (auto& th : ths) th.join();
+            const auto wall_ns = now_ns() - run_begin;
+
+            const double recall = static_cast<double>(total_correct.load()) /
+                                  static_cast<double>(actual_q * topk);
+            const double avg_latency_us =
+                static_cast<double>(total_search_ns.load()) / actual_q / 1000.0;
+            const double wall_qps =
+                static_cast<double>(actual_q) / (static_cast<double>(wall_ns) / 1e9);
+
+            std::cout << ef << '\t' << recall << '\t' << avg_latency_us << '\t'
+                      << wall_qps << std::endl;
+        }
+        return 0;
+    } catch (const std::exception& ex) {
+        std::cerr << "ERROR: " << ex.what() << std::endl;
+        return 1;
+    }
+}

--- a/tools/build_cache/export_hgraph_build_cache.cpp
+++ b/tools/build_cache/export_hgraph_build_cache.cpp
@@ -1,0 +1,220 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <vsag/vsag.h>
+
+#include <argparse/argparse.hpp>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+#include "algorithm/hgraph/hgraph.h"
+#include "build_cache_tool_common.h"
+#include "index/index_impl.h"
+#include "inner_string_params.h"
+#include "storage/serialization.h"
+#include "storage/stream_reader.h"
+
+using namespace vsag;
+
+namespace {
+
+constexpr static const char* DEFAULT_BUILD_PARAM = "default";
+
+void
+parse_args(argparse::ArgumentParser& parser, int argc, char** argv) {
+    parser.add_argument<std::string>("--index_path", "-i")
+        .required()
+        .help("Serialized HGraph index file path");
+
+    parser.add_argument<std::string>("--label_path", "-l")
+        .help("Path to label.bin");
+
+    parser.add_argument<std::string>("--feature_id_path", "-f")
+        .help("Path to id_map");
+
+    parser.add_argument<std::string>("--cache_output_path", "-o")
+        .required()
+        .help("Output cache file path");
+
+    parser.add_argument<std::string>("--build_parameter", "-bp")
+        .default_value(std::string(DEFAULT_BUILD_PARAM))
+        .help("Optional full build parameter JSON, required when the index uses old serialization format");
+
+    parser.add_argument<std::string>("--alignment_policy", "-ap")
+        .default_value(std::string("truncate_to_min"))
+        .help("How to handle label.bin and id_map row-count mismatch: strict or truncate_to_min");
+
+    try {
+        parser.parse_args(argc, argv);
+    } catch (const std::runtime_error& err) {
+        std::cerr << err.what() << std::endl;
+        std::cerr << parser;
+        throw;
+    }
+}
+
+class HGraphIndexLoader {
+public:
+    explicit HGraphIndexLoader(std::string build_param) : build_param_(std::move(build_param)) {
+    }
+
+    IndexPtr
+    Load(const std::string& index_path) {
+        std::ifstream probe_stream(index_path, std::ios::binary);
+        if (not probe_stream.is_open()) {
+            throw std::runtime_error("failed to open index file: " + index_path);
+        }
+
+        IOStreamReader reader(probe_stream);
+        auto footer = Footer::Parse(reader);
+        if (footer != nullptr) {
+            return load_new_format(index_path, footer);
+        }
+        if (build_param_ == DEFAULT_BUILD_PARAM) {
+            throw std::runtime_error(
+                "old-format index requires --build_parameter with full HGraph build JSON");
+        }
+        return load_with_factory(index_path, build_param_);
+    }
+
+private:
+    IndexPtr
+    load_new_format(const std::string& index_path, const FooterPtr& footer) {
+        auto metadata = footer->GetMetadata();
+        auto basic_info = metadata->Get(BASIC_INFO);
+        if (not basic_info.Contains(INDEX_PARAM)) {
+            throw std::runtime_error("index metadata does not contain build parameters");
+        }
+
+        auto index_param = JsonType::Parse(basic_info[INDEX_PARAM].GetString());
+        auto index_name = index_param[TYPE_KEY].GetString();
+        if (index_name != INDEX_HGRAPH) {
+            throw std::runtime_error("only HGraph index is supported, got: " + index_name);
+        }
+
+        IndexCommonParam index_common_params;
+        index_common_params.dim_ = basic_info[DIM].GetInt();
+        index_common_params.extra_info_size_ = basic_info["extra_info_size"].GetInt();
+        index_common_params.data_type_ = static_cast<DataTypes>(basic_info["data_type"].GetInt());
+        index_common_params.metric_ = static_cast<MetricType>(basic_info["metric"].GetInt());
+        index_common_params.allocator_ = Engine::CreateDefaultAllocator();
+
+        auto hgraph_parameter = std::make_shared<HGraphParameter>();
+        hgraph_parameter->FromJson(index_param);
+        hgraph_parameter->data_type = index_common_params.data_type_;
+
+        auto inner_index = std::make_shared<HGraph>(hgraph_parameter, index_common_params);
+        auto index = std::make_shared<IndexImpl<HGraph>>(inner_index, index_common_params);
+
+        std::ifstream input(index_path, std::ios::binary);
+        if (not input.is_open()) {
+            throw std::runtime_error("failed to reopen index file: " + index_path);
+        }
+        auto deserialize_result = index->Deserialize(input);
+        if (not deserialize_result.has_value()) {
+            throw std::runtime_error("failed to deserialize index: " +
+                                     deserialize_result.error().message);
+        }
+        return index;
+    }
+
+    IndexPtr
+    load_with_factory(const std::string& index_path, const std::string& build_param) {
+        auto create_result = Factory::CreateIndex(INDEX_HGRAPH, build_param);
+        if (not create_result.has_value()) {
+            throw std::runtime_error("failed to create HGraph index: " +
+                                     create_result.error().message);
+        }
+        auto index = create_result.value();
+        std::ifstream input(index_path, std::ios::binary);
+        if (not input.is_open()) {
+            throw std::runtime_error("failed to reopen index file: " + index_path);
+        }
+        auto deserialize_result = index->Deserialize(input);
+        if (not deserialize_result.has_value()) {
+            throw std::runtime_error("failed to deserialize index: " +
+                                     deserialize_result.error().message);
+        }
+        return index;
+    }
+
+private:
+    std::string build_param_;
+};
+
+}  // namespace
+
+int
+main(int argc, char** argv) {
+    try {
+        argparse::ArgumentParser parser("export_hgraph_build_cache");
+        parse_args(parser, argc, argv);
+
+        const auto index_path = parser.get<std::string>("--index_path");
+        const auto cache_output_path = parser.get<std::string>("--cache_output_path");
+        const auto build_param = parser.get<std::string>("--build_parameter");
+        const auto alignment_policy =
+            tools::ParseAlignmentPolicy(parser.get<std::string>("--alignment_policy"));
+
+        HGraphIndexLoader loader(build_param);
+        auto index = loader.Load(index_path);
+
+        const bool has_label_path = parser.is_used("--label_path");
+        const bool has_feature_id_path = parser.is_used("--feature_id_path");
+        if (has_label_path != has_feature_id_path) {
+            std::cerr << "--label_path and --feature_id_path must be provided together"
+                      << std::endl;
+            return 2;
+        }
+
+        if (has_label_path && has_feature_id_path) {
+            const auto label_path = parser.get<std::string>("--label_path");
+            const auto feature_id_path = parser.get<std::string>("--feature_id_path");
+            auto imported_dataset =
+                tools::LoadFeatureIdDatasetFromFiles(label_path, feature_id_path, alignment_policy);
+
+            if (imported_dataset.stats.was_truncated) {
+                std::cerr << "warning: label.bin and id_map row counts mismatch, truncating to "
+                          << imported_dataset.stats.aligned_count << " rows" << std::endl;
+            }
+
+            auto prepare_result = index->PrepareFeatureIdsForBuildCache(imported_dataset.dataset);
+            if (not prepare_result.has_value()) {
+                std::cerr << "prepare feature ids failed: " << prepare_result.error().message
+                          << std::endl;
+                return 2;
+            }
+        }
+
+        std::ofstream output(cache_output_path, std::ios::binary);
+        if (not output.is_open()) {
+            std::cerr << "failed to open cache output file: " << cache_output_path << std::endl;
+            return 3;
+        }
+
+        auto export_result = index->ExportBuildCache(output);
+        if (not export_result.has_value()) {
+            std::cerr << "export build cache failed: " << export_result.error().message
+                      << std::endl;
+            return 4;
+        }
+
+        std::cout << "cache exported successfully to " << cache_output_path << std::endl;
+        return 0;
+    } catch (const std::exception& ex) {
+        std::cerr << ex.what() << std::endl;
+        return 1;
+    }
+}


### PR DESCRIPTION
## Summary

Add **BuildWithCache** to support incremental HGraph index building from a cache exported by a previous build. This reduces rebuild time when the dataset changes between builds (for example, day1 → day2 updates), while keeping recall stable.

## Change Type

- [ ] Bug fix
- [x] New feature
- [x] Improvement/Refactor
- [ ] Documentation
- [ ] CI/Build/Infra

## Linked Issue

- Fixes: <!-- #<number> -->

## What Changed

### Core implementation
- Added `hgraph_build_cache.cpp` with the main `BuildWithCache` workflow:
  - cache loading
  - warm start with hit/miss classification
  - two-phase parallel refine
  - route graph building

### Performance optimizations
- Optimized reverse-edge construction using a scatter-materialize parallel pattern in the group phase
- Added shard-parallel `merge_prune`
- Reused distances computed in the select phase
- Replaced quadratic deduplication with `unordered_set`-based deduplication (`O(M)` vs. `O(M^2)`)
- Added self-entry optimization: hit nodes use their own `inner_id` as the search entry for faster convergence

### Public API additions
- Added `BuildCacheOptions` and `BuildCacheStats` to `index.h`
- Added virtual methods:
  - `SupportsBuildCache`
  - `ExportBuildCache`
  - `BuildWithCache`
  - `PrepareFeatureIdsForBuildCache`
  - `GetBuildCacheStats`
- Added feature ID tracking via:
  - `Dataset::FeatureIds`
  - `Dataset::GetFeatureIds`

### Tools
- `build_hgraph_with_cache`: build an index with cache
- `export_hgraph_build_cache`: export build cache from an existing index
- `eval_recall_brute_force`: brute-force recall evaluation
- `compare_hgraph_ids`: compare IDs across indexes

## Performance and Quality

Tested on **30M 768-dim vectors** with **day1 → day2** incremental updates:

- Reverse phase: `858s -> 23s` (`-97.3%`)
- Group sub-phase: `408s -> 12s` (`-97.1%`)
- Total build time: `4920s -> 4070s` (`-17.3%`)
- Recall: stable within `±0.35pp`

## Test Evidence

- [ ] `make fmt`
- [ ] `make lint`
- [ ] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [ ] Other (describe below)

Test details:

```text
<!-- Paste commands and key output here -->
```

## Compatibility Impact

- API/ABI compatibility: new public API added; no breaking change intended
- Behavior changes: optional cache-based build path added for HGraph

## Performance and Concurrency Impact

- Performance impact: improved for incremental rebuild scenarios
- Concurrency/thread-safety impact: parallel build path updated; no intended thread-safety regression

## Documentation Impact

- [x] No docs update needed

- [ ] Updated docs:
  - [ ] `README.md`
  - [ ] `DEVELOPMENT.md`
  - [ ] `CONTRIBUTING.md`
  - [ ] Other: <!-- path -->

## Risk and Rollback

- Risk level: medium
- Rollback plan: revert this PR and fall back to the existing full-build path without cache

## Checklist

- [ ] I have linked the relevant issue (required for `kind/bug` and `kind/feature`; see "Linked Issue" above)
- [ ] I have added/updated tests for new behavior or bug fixes
- [x] I have considered API compatibility impact
- [ ] I have updated docs if behavior/workflow changed
- [x] My commit messages follow project conventions (Conventional Commits, optional `[skip ci]` prefix)
