### PR TITLE
feat: define pyramid named hierarchy API parameters

### DIFF
--- a/include/vsag/constants.h
+++ b/include/vsag/constants.h
@@ -129,7 +129,11 @@ extern const char* const PYRAMID_PRECISE_IO_TYPE;
 extern const char* const PYRAMID_PRECISE_FILE_PATH;
 extern const char* const PYRAMID_PARAMETER_EF_SEARCH;
 extern const char* const PYRAMID_PARAMETER_SUBINDEX_EF_SEARCH;
+extern const char* const PYRAMID_PARAMETER_HIERARCHY;
+extern const char* const PYRAMID_PARAMETER_HIERARCHIES;
+extern const char* const PYRAMID_PARAMETER_HIERARCHY_OP;
 extern const char* const PYRAMID_NO_BUILD_LEVELS;
+extern const char* const PYRAMID_HIERARCHIES;
 extern const char* const PYRAMID_INDEX_MIN_SIZE;
 
 extern const char PART_SLASH;

--- a/include/vsag/constants.h
+++ b/include/vsag/constants.h
@@ -129,7 +129,6 @@ extern const char* const PYRAMID_PRECISE_IO_TYPE;
 extern const char* const PYRAMID_PRECISE_FILE_PATH;
 extern const char* const PYRAMID_PARAMETER_EF_SEARCH;
 extern const char* const PYRAMID_PARAMETER_SUBINDEX_EF_SEARCH;
-extern const char* const PYRAMID_PARAMETER_HIERARCHY;
 extern const char* const PYRAMID_PARAMETER_HIERARCHIES;
 extern const char* const PYRAMID_PARAMETER_HIERARCHY_OP;
 extern const char* const PYRAMID_NO_BUILD_LEVELS;

--- a/include/vsag/dataset.h
+++ b/include/vsag/dataset.h
@@ -328,12 +328,31 @@ public:
     Paths(const std::string* paths) = 0;
 
     /**
+     * @brief Sets the paths array for a named hierarchy.
+     *
+     * @param hierarchy_name The hierarchy name. An empty string targets the default hierarchy.
+     * @param paths Pointer to the array of paths.
+     * @return DatasetPtr A shared pointer to the dataset with updated paths.
+     */
+    virtual DatasetPtr
+    Paths(const std::string& hierarchy_name, const std::string* paths) = 0;
+
+    /**
      * @brief Retrieves the paths array of the dataset.
      *
      * @return const std::string* Pointer to the array of paths.
      */
     virtual const std::string*
     GetPaths() const = 0;
+
+    /**
+     * @brief Retrieves the paths array of a named hierarchy.
+     *
+     * @param hierarchy_name The hierarchy name. An empty string targets the default hierarchy.
+     * @return const std::string* Pointer to the array of paths.
+     */
+    virtual const std::string*
+    GetPaths(const std::string& hierarchy_name) const = 0;
 
     /**
      * @brief Sets the extra info for the dataset.

--- a/src/algorithm/pyramid/pyramid.cpp
+++ b/src/algorithm/pyramid/pyramid.cpp
@@ -479,7 +479,8 @@ Pyramid::ExportModel(const IndexCommonParam& param) const {
 std::vector<int64_t>
 Pyramid::Add(const DatasetPtr& base, AddMode mode) {
     const auto pyramid_param = std::dynamic_pointer_cast<PyramidParameters>(create_param_ptr_);
-    CHECK_ARGUMENT(pyramid_param == nullptr || not pyramid_param->has_hierarchies,
+    CHECK_ARGUMENT(  // NOLINT(readability-simplify-boolean-expr)
+        pyramid_param == nullptr || not pyramid_param->has_hierarchies,
                    "pyramid named hierarchy add is reserved but not implemented");
     const auto* path = base->GetPaths();
     CHECK_ARGUMENT(path != nullptr, "path is required");
@@ -738,7 +739,8 @@ Pyramid::Train(const DatasetPtr& base) {
 std::vector<int64_t>
 Pyramid::Build(const DatasetPtr& base) {
     const auto pyramid_param = std::dynamic_pointer_cast<PyramidParameters>(create_param_ptr_);
-    CHECK_ARGUMENT(pyramid_param == nullptr || not pyramid_param->has_hierarchies,
+    CHECK_ARGUMENT(  // NOLINT(readability-simplify-boolean-expr)
+        pyramid_param == nullptr || not pyramid_param->has_hierarchies,
                    "pyramid named hierarchy build is reserved but not implemented");
     CHECK_ARGUMENT(GetNumElements() == 0, "index is not empty");
     this->Train(base);

--- a/src/algorithm/pyramid/pyramid.cpp
+++ b/src/algorithm/pyramid/pyramid.cpp
@@ -481,7 +481,7 @@ Pyramid::Add(const DatasetPtr& base, AddMode mode) {
     const auto pyramid_param = std::dynamic_pointer_cast<PyramidParameters>(create_param_ptr_);
     CHECK_ARGUMENT(  // NOLINT(readability-simplify-boolean-expr)
         pyramid_param == nullptr || not pyramid_param->has_hierarchies,
-                   "pyramid named hierarchy add is reserved but not implemented");
+        "pyramid named hierarchy add is reserved but not implemented");
     const auto* path = base->GetPaths();
     CHECK_ARGUMENT(path != nullptr, "path is required");
     int64_t data_num = base->GetNumElements();
@@ -741,7 +741,7 @@ Pyramid::Build(const DatasetPtr& base) {
     const auto pyramid_param = std::dynamic_pointer_cast<PyramidParameters>(create_param_ptr_);
     CHECK_ARGUMENT(  // NOLINT(readability-simplify-boolean-expr)
         pyramid_param == nullptr || not pyramid_param->has_hierarchies,
-                   "pyramid named hierarchy build is reserved but not implemented");
+        "pyramid named hierarchy build is reserved but not implemented");
     CHECK_ARGUMENT(GetNumElements() == 0, "index is not empty");
     this->Train(base);
     std::vector<int64_t> ret;

--- a/src/algorithm/pyramid/pyramid.cpp
+++ b/src/algorithm/pyramid/pyramid.cpp
@@ -287,7 +287,9 @@ Pyramid::RangeSearch(const DatasetPtr& query,
     QueryContext ctx{.stats = &stats};
 
     auto parsed_param = PyramidSearchParameters::FromJson(parameters);
-    CHECK_ARGUMENT(not parsed_param.HasHierarchySelector() && not parsed_param.has_hierarchy_op,
+    const bool has_named_hierarchy_param =
+        parsed_param.HasHierarchySelector() || parsed_param.has_hierarchy_op;
+    CHECK_ARGUMENT(has_named_hierarchy_param == false,
                    "pyramid named hierarchy search is reserved but not implemented");
     InnerSearchParam search_param;
     search_param.ef = parsed_param.ef_search;
@@ -479,7 +481,9 @@ Pyramid::ExportModel(const IndexCommonParam& param) const {
 std::vector<int64_t>
 Pyramid::Add(const DatasetPtr& base, AddMode mode) {
     const auto pyramid_param = std::dynamic_pointer_cast<PyramidParameters>(create_param_ptr_);
-    CHECK_ARGUMENT(pyramid_param == nullptr || not pyramid_param->has_hierarchies,
+    const bool has_named_hierarchy_param =
+        pyramid_param != nullptr && pyramid_param->has_hierarchies;
+    CHECK_ARGUMENT(has_named_hierarchy_param == false,
                    "pyramid named hierarchy add is reserved but not implemented");
     const auto* path = base->GetPaths();
     CHECK_ARGUMENT(path != nullptr, "path is required");
@@ -738,7 +742,9 @@ Pyramid::Train(const DatasetPtr& base) {
 std::vector<int64_t>
 Pyramid::Build(const DatasetPtr& base) {
     const auto pyramid_param = std::dynamic_pointer_cast<PyramidParameters>(create_param_ptr_);
-    CHECK_ARGUMENT(pyramid_param == nullptr || not pyramid_param->has_hierarchies,
+    const bool has_named_hierarchy_param =
+        pyramid_param != nullptr && pyramid_param->has_hierarchies;
+    CHECK_ARGUMENT(has_named_hierarchy_param == false,
                    "pyramid named hierarchy build is reserved but not implemented");
     CHECK_ARGUMENT(GetNumElements() == 0, "index is not empty");
     this->Train(base);

--- a/src/algorithm/pyramid/pyramid.cpp
+++ b/src/algorithm/pyramid/pyramid.cpp
@@ -287,8 +287,7 @@ Pyramid::RangeSearch(const DatasetPtr& query,
     QueryContext ctx{.stats = &stats};
 
     auto parsed_param = PyramidSearchParameters::FromJson(parameters);
-    const bool has_named_hierarchy_param =
-        parsed_param.HasHierarchySelector() || parsed_param.has_hierarchy_op;
+    const bool has_named_hierarchy_param = parsed_param.HasHierarchySelector();
     CHECK_ARGUMENT(has_named_hierarchy_param == false,
                    "pyramid named hierarchy search is reserved but not implemented");
     InnerSearchParam search_param;

--- a/src/algorithm/pyramid/pyramid.cpp
+++ b/src/algorithm/pyramid/pyramid.cpp
@@ -241,6 +241,8 @@ Pyramid::KnnSearch(const DatasetPtr& query,
 
     auto parsed_param = PyramidSearchParameters::FromJson(parameters);
     CHECK_ARGUMENT(k > 0, fmt::format("k({}) must be greater than 0", k));
+    CHECK_ARGUMENT(not parsed_param.HasHierarchySelector(),
+                   "pyramid named hierarchy search is reserved but not implemented");
     auto ef_search_threshold = std::max<uint64_t>(AMPLIFICATION_FACTOR * k, 1000L);
     CHECK_ARGUMENT(  // NOLINT
         (1 <= parsed_param.ef_search) and (parsed_param.ef_search <= ef_search_threshold),
@@ -285,6 +287,8 @@ Pyramid::RangeSearch(const DatasetPtr& query,
     QueryContext ctx{.stats = &stats};
 
     auto parsed_param = PyramidSearchParameters::FromJson(parameters);
+    CHECK_ARGUMENT(not parsed_param.HasHierarchySelector() && not parsed_param.has_hierarchy_op,
+                   "pyramid named hierarchy search is reserved but not implemented");
     InnerSearchParam search_param;
     search_param.ef = parsed_param.ef_search;
     search_param.radius = radius * RADIUS_EPSILON;
@@ -474,6 +478,9 @@ Pyramid::ExportModel(const IndexCommonParam& param) const {
 
 std::vector<int64_t>
 Pyramid::Add(const DatasetPtr& base, AddMode mode) {
+    const auto pyramid_param = std::dynamic_pointer_cast<PyramidParameters>(create_param_ptr_);
+    CHECK_ARGUMENT(pyramid_param == nullptr || not pyramid_param->has_hierarchies,
+                   "pyramid named hierarchy add is reserved but not implemented");
     const auto* path = base->GetPaths();
     CHECK_ARGUMENT(path != nullptr, "path is required");
     int64_t data_num = base->GetNumElements();
@@ -699,6 +706,7 @@ Pyramid::CheckAndMappingExternalParam(const JsonType& external_param,
         {PYRAMID_PRECISE_IO_TYPE, {PRECISE_CODES_KEY, IO_PARAMS_KEY, TYPE_KEY}},
         {PYRAMID_BUILD_THREAD_COUNT, {BUILD_THREAD_COUNT_KEY}},
         {PYRAMID_NO_BUILD_LEVELS, {NO_BUILD_LEVELS}},
+        {PYRAMID_HIERARCHIES, {PYRAMID_HIERARCHIES}},
         {PYRAMID_BASE_PQ_DIM,
          {BASE_CODES_KEY, QUANTIZATION_PARAMS_KEY, PRODUCT_QUANTIZATION_DIM_KEY}},
         {PYRAMID_BASE_FILE_PATH, {BASE_CODES_KEY, IO_PARAMS_KEY, IO_FILE_PATH_KEY}},
@@ -729,6 +737,9 @@ Pyramid::Train(const DatasetPtr& base) {
 }
 std::vector<int64_t>
 Pyramid::Build(const DatasetPtr& base) {
+    const auto pyramid_param = std::dynamic_pointer_cast<PyramidParameters>(create_param_ptr_);
+    CHECK_ARGUMENT(pyramid_param == nullptr || not pyramid_param->has_hierarchies,
+                   "pyramid named hierarchy build is reserved but not implemented");
     CHECK_ARGUMENT(GetNumElements() == 0, "index is not empty");
     this->Train(base);
     std::vector<int64_t> ret;

--- a/src/algorithm/pyramid/pyramid.cpp
+++ b/src/algorithm/pyramid/pyramid.cpp
@@ -287,8 +287,7 @@ Pyramid::RangeSearch(const DatasetPtr& query,
     QueryContext ctx{.stats = &stats};
 
     auto parsed_param = PyramidSearchParameters::FromJson(parameters);
-    const bool has_named_hierarchy_param = parsed_param.HasHierarchySelector();
-    CHECK_ARGUMENT(has_named_hierarchy_param == false,
+    CHECK_ARGUMENT(not parsed_param.HasHierarchySelector(),
                    "pyramid named hierarchy search is reserved but not implemented");
     InnerSearchParam search_param;
     search_param.ef = parsed_param.ef_search;
@@ -480,9 +479,7 @@ Pyramid::ExportModel(const IndexCommonParam& param) const {
 std::vector<int64_t>
 Pyramid::Add(const DatasetPtr& base, AddMode mode) {
     const auto pyramid_param = std::dynamic_pointer_cast<PyramidParameters>(create_param_ptr_);
-    const bool has_named_hierarchy_param =
-        pyramid_param != nullptr && pyramid_param->has_hierarchies;
-    CHECK_ARGUMENT(has_named_hierarchy_param == false,
+    CHECK_ARGUMENT(pyramid_param == nullptr || not pyramid_param->has_hierarchies,
                    "pyramid named hierarchy add is reserved but not implemented");
     const auto* path = base->GetPaths();
     CHECK_ARGUMENT(path != nullptr, "path is required");
@@ -741,9 +738,7 @@ Pyramid::Train(const DatasetPtr& base) {
 std::vector<int64_t>
 Pyramid::Build(const DatasetPtr& base) {
     const auto pyramid_param = std::dynamic_pointer_cast<PyramidParameters>(create_param_ptr_);
-    const bool has_named_hierarchy_param =
-        pyramid_param != nullptr && pyramid_param->has_hierarchies;
-    CHECK_ARGUMENT(has_named_hierarchy_param == false,
+    CHECK_ARGUMENT(pyramid_param == nullptr || not pyramid_param->has_hierarchies,
                    "pyramid named hierarchy build is reserved but not implemented");
     CHECK_ARGUMENT(GetNumElements() == 0, "index is not empty");
     this->Train(base);

--- a/src/algorithm/pyramid/pyramid_zparameters.cpp
+++ b/src/algorithm/pyramid/pyramid_zparameters.cpp
@@ -66,6 +66,7 @@ PyramidHierarchyParameters::FromJson(const JsonType& json) {
         return;
     }
 
+    CHECK_ARGUMENT(json.IsObject(), "hierarchy definition must be a string or an object");
     CHECK_ARGUMENT(json.Contains("name"), "hierarchy must contain name");
     CHECK_ARGUMENT(json["name"].IsString(), "hierarchy name must be a string");
     name = json["name"].GetString();

--- a/src/algorithm/pyramid/pyramid_zparameters.cpp
+++ b/src/algorithm/pyramid/pyramid_zparameters.cpp
@@ -80,15 +80,25 @@ PyramidHierarchyParameters::FromJson(const JsonType& json) {
     }
     if (json.Contains(GRAPH_PARAM_MAX_DEGREE_KEY)) {
         max_degree = json[GRAPH_PARAM_MAX_DEGREE_KEY].GetInt();
+        CHECK_ARGUMENT(max_degree > 0,
+                       fmt::format("hierarchy {} max_degree must be positive", name));
     }
     if (json.Contains(EF_CONSTRUCTION_KEY)) {
         ef_construction = json[EF_CONSTRUCTION_KEY].GetInt();
+        CHECK_ARGUMENT(ef_construction > 0,
+                       fmt::format("hierarchy {} ef_construction must be positive", name));
     }
     if (json.Contains(ALPHA_KEY)) {
         alpha = json[ALPHA_KEY].GetFloat();
+        CHECK_ARGUMENT(alpha > 0.0F,
+                       fmt::format("hierarchy {} alpha must be positive", name));
     }
     if (json.Contains(INDEX_MIN_SIZE)) {
         index_min_size = json[INDEX_MIN_SIZE].GetInt();
+    }
+    for (auto level : no_build_levels) {
+        CHECK_ARGUMENT(level >= 0,
+                       fmt::format("hierarchy {} no_build_levels values must be non-negative", name));
     }
 }
 

--- a/src/algorithm/pyramid/pyramid_zparameters.cpp
+++ b/src/algorithm/pyramid/pyramid_zparameters.cpp
@@ -15,16 +15,96 @@
 
 #include "pyramid_zparameters.h"
 
+#include <algorithm>
+#include <nlohmann/json.hpp>
+#include <unordered_set>
+#include <utility>
+
 #include "common.h"
 #include "impl/logger/logger.h"
 #include "index/diskann_zparameters.h"
 #include "io/memory_io_parameter.h"
 #include "quantization/fp32_quantizer_parameter.h"
 #include "utils/param_compat_macros.h"
+#include "vsag/constants.h"
 
 // NOLINTBEGIN(readability-simplify-boolean-expr)
 
 namespace vsag {
+namespace {
+
+PyramidSearchParameters::HierarchyOp
+parse_hierarchy_op(const std::string& op) {
+    if (op == "union") {
+        return PyramidSearchParameters::HierarchyOp::UNION;
+    }
+    if (op == "intersection") {
+        return PyramidSearchParameters::HierarchyOp::INTERSECTION;
+    }
+    CHECK_ARGUMENT(false, fmt::format("unsupported pyramid hierarchy_op {}", op));
+    return PyramidSearchParameters::HierarchyOp::SINGLE;
+}
+
+void
+append_hierarchy_selector(PyramidSearchParameters& params,
+                          std::unordered_set<std::string>& seen_names,
+                          const std::string& hierarchy_name) {
+    CHECK_ARGUMENT(not hierarchy_name.empty(), "pyramid hierarchy name must not be empty");
+    CHECK_ARGUMENT(seen_names.insert(hierarchy_name).second,
+                   fmt::format("duplicate pyramid hierarchy {}", hierarchy_name));
+    params.hierarchies.emplace_back(hierarchy_name);
+}
+
+}  // namespace
+
+void
+PyramidHierarchyParameters::FromJson(const JsonType& json) {
+    if (json.IsString()) {
+        name = json.GetString();
+        CHECK_ARGUMENT(not name.empty(), "hierarchy name must not be empty");
+        no_build_levels.clear();
+        return;
+    }
+
+    CHECK_ARGUMENT(json.Contains("name"), "hierarchy must contain name");
+    CHECK_ARGUMENT(json["name"].IsString(), "hierarchy name must be a string");
+    name = json["name"].GetString();
+    CHECK_ARGUMENT(not name.empty(), "hierarchy name must not be empty");
+
+    if (json.Contains(NO_BUILD_LEVELS)) {
+        const auto& no_build_levels_json = json[NO_BUILD_LEVELS];
+        CHECK_ARGUMENT(no_build_levels_json.IsArray(),
+                       fmt::format("hierarchy {} no_build_levels must be an array", name));
+        no_build_levels = no_build_levels_json.GetVector();
+        std::sort(no_build_levels.begin(), no_build_levels.end());
+    } else {
+        no_build_levels.clear();
+    }
+}
+
+JsonType
+PyramidHierarchyParameters::ToJson() const {
+    JsonType json;
+    json["name"].SetString(name);
+    json[NO_BUILD_LEVELS].SetVector(no_build_levels);
+    return json;
+}
+
+bool
+PyramidHierarchyParameters::CheckCompatibility(const PyramidHierarchyParameters& other) const {
+    if (name != other.name) {
+        logger::error("PyramidHierarchyParameters::CheckCompatibility: names are not compatible");
+        return false;
+    }
+    if (no_build_levels.size() != other.no_build_levels.size() ||
+        not std::is_permutation(
+            no_build_levels.begin(), no_build_levels.end(), other.no_build_levels.begin())) {
+        logger::error(
+            "PyramidHierarchyParameters::CheckCompatibility: no_build_levels are not compatible");
+        return false;
+    }
+    return true;
+}
 
 void
 PyramidParameters::FromJson(const JsonType& json) {
@@ -69,6 +149,28 @@ PyramidParameters::FromJson(const JsonType& json) {
     if (json.Contains(SUPPORT_DUPLICATE)) {
         this->support_duplicate = json[SUPPORT_DUPLICATE].GetBool();
     }
+
+    this->has_hierarchies = false;
+    this->hierarchies.clear();
+    if (json.Contains(PYRAMID_HIERARCHIES)) {
+        const auto& hierarchies_json = json[PYRAMID_HIERARCHIES];
+        CHECK_ARGUMENT(hierarchies_json.IsArray(), "hierarchies must be an array");
+        CHECK_ARGUMENT(not hierarchies_json.GetInnerJson()->empty(),
+                       "hierarchies must not be empty");
+        this->has_hierarchies = true;
+
+        std::unordered_set<std::string> seen_names;
+        for (const auto& hierarchy_raw_json : *hierarchies_json.GetInnerJson()) {
+            JsonType hierarchy_json;
+            *hierarchy_json.GetInnerJson() = hierarchy_raw_json;
+
+            PyramidHierarchyParameters hierarchy;
+            hierarchy.FromJson(hierarchy_json);
+            CHECK_ARGUMENT(seen_names.insert(hierarchy.name).second,
+                           fmt::format("duplicate hierarchy name {}", hierarchy.name));
+            this->hierarchies.emplace_back(std::move(hierarchy));
+        }
+    }
 }
 JsonType
 PyramidParameters::ToJson() const {
@@ -91,6 +193,14 @@ PyramidParameters::ToJson() const {
     if (this->use_reorder) {
         json[PRECISE_CODES_KEY].SetJson(precise_codes_param->ToJson());
     }
+    if (this->has_hierarchies) {
+        auto* hierarchies_json = json[PYRAMID_HIERARCHIES].GetInnerJson();
+        *hierarchies_json = nlohmann::json::array();
+        for (const auto& hierarchy : this->hierarchies) {
+            auto hierarchy_json = hierarchy.ToJson();
+            hierarchies_json->push_back(*hierarchy_json.GetInnerJson());
+        }
+    }
     return json;
 }
 
@@ -99,9 +209,42 @@ PyramidParameters::CheckCompatibility(const ParamPtr& other) const {
     PARAM_CAST_OR_RETURN(PyramidParameters, p, other);
     CHECK_SUB_PARAM(*this, *p, graph_param);
     CHECK_SUB_PARAM(*this, *p, base_codes_param);
-    if (no_build_levels.size() != p->no_build_levels.size() ||
-        not std::is_permutation(
-            no_build_levels.begin(), no_build_levels.end(), p->no_build_levels.begin())) {
+    if (this->has_hierarchies != p->has_hierarchies) {
+        logger::error(
+            "PyramidParameters::CheckCompatibility: hierarchies mode settings are not compatible");
+        return false;
+    }
+    if (this->has_hierarchies) {
+        if (this->hierarchies.size() != p->hierarchies.size()) {
+            logger::error(
+                "PyramidParameters::CheckCompatibility: hierarchy counts are not compatible");
+            return false;
+        }
+        for (const auto& hierarchy : this->hierarchies) {
+            bool found = false;
+            for (const auto& other_hierarchy : p->hierarchies) {
+                if (hierarchy.name != other_hierarchy.name) {
+                    continue;
+                }
+                if (not hierarchy.CheckCompatibility(other_hierarchy)) {
+                    logger::error(
+                        "PyramidParameters::CheckCompatibility: hierarchies are not compatible");
+                    return false;
+                }
+                found = true;
+                break;
+            }
+            if (not found) {
+                logger::error("PyramidParameters::CheckCompatibility: hierarchy {} is missing",
+                              hierarchy.name);
+                return false;
+            }
+        }
+    }
+    if (not this->has_hierarchies &&
+        (no_build_levels.size() != p->no_build_levels.size() ||
+         not std::is_permutation(
+             no_build_levels.begin(), no_build_levels.end(), p->no_build_levels.begin()))) {
         logger::error("PyramidParameters::CheckCompatibility: no_build_levels are not compatible");
         return false;
     }
@@ -133,7 +276,52 @@ PyramidSearchParameters::FromJson(const std::string& json_string) {
         obj.subindex_ef_search =
             params[INDEX_PYRAMID][PYRAMID_PARAMETER_SUBINDEX_EF_SEARCH].GetInt();
     }
+    bool has_hierarchy = false;
+    bool has_hierarchies = false;
+    std::unordered_set<std::string> seen_names;
+    if (params[INDEX_PYRAMID].Contains(PYRAMID_PARAMETER_HIERARCHY)) {
+        CHECK_ARGUMENT(not params[INDEX_PYRAMID].Contains(PYRAMID_PARAMETER_HIERARCHIES),
+                       "pyramid hierarchy and hierarchies cannot both be set");
+        CHECK_ARGUMENT(not params[INDEX_PYRAMID].Contains(PYRAMID_PARAMETER_HIERARCHY_OP),
+                       "pyramid hierarchy and hierarchy_op cannot both be set");
+        CHECK_ARGUMENT(params[INDEX_PYRAMID][PYRAMID_PARAMETER_HIERARCHY].IsString(),
+                       "pyramid hierarchy must be a string");
+        append_hierarchy_selector(
+            obj, seen_names, params[INDEX_PYRAMID][PYRAMID_PARAMETER_HIERARCHY].GetString());
+        has_hierarchy = true;
+    }
+    if (params[INDEX_PYRAMID].Contains(PYRAMID_PARAMETER_HIERARCHIES)) {
+        CHECK_ARGUMENT(not has_hierarchy, "pyramid hierarchy and hierarchies cannot both be set");
+        const auto& hierarchies_json = params[INDEX_PYRAMID][PYRAMID_PARAMETER_HIERARCHIES];
+        CHECK_ARGUMENT(hierarchies_json.IsArray(), "pyramid hierarchies must be an array");
+        CHECK_ARGUMENT(hierarchies_json.GetInnerJson()->size() >= 2,
+                       "pyramid hierarchies must contain at least two hierarchy names");
+
+        for (const auto& hierarchy_raw_json : *hierarchies_json.GetInnerJson()) {
+            JsonType hierarchy_json;
+            *hierarchy_json.GetInnerJson() = hierarchy_raw_json;
+            CHECK_ARGUMENT(hierarchy_json.IsString(), "pyramid hierarchy name must be a string");
+            append_hierarchy_selector(obj, seen_names, hierarchy_json.GetString());
+        }
+        has_hierarchies = true;
+    }
+    if (params[INDEX_PYRAMID].Contains(PYRAMID_PARAMETER_HIERARCHY_OP)) {
+        CHECK_ARGUMENT(has_hierarchies,
+                       "pyramid hierarchy_op requires pyramid hierarchies to be set");
+        CHECK_ARGUMENT(params[INDEX_PYRAMID][PYRAMID_PARAMETER_HIERARCHY_OP].IsString(),
+                       "pyramid hierarchy_op must be a string");
+        obj.hierarchy_op =
+            parse_hierarchy_op(params[INDEX_PYRAMID][PYRAMID_PARAMETER_HIERARCHY_OP].GetString());
+        obj.has_hierarchy_op = true;
+    }
+    CHECK_ARGUMENT(not has_hierarchies || obj.has_hierarchy_op,
+                   "pyramid hierarchy_op is required for multiple hierarchies");
     return obj;
+}
+
+bool
+PyramidSearchParameters::HasHierarchySelector() const {
+    return not hierarchies.empty();
 }
 }  // namespace vsag
 

--- a/src/algorithm/pyramid/pyramid_zparameters.cpp
+++ b/src/algorithm/pyramid/pyramid_zparameters.cpp
@@ -117,6 +117,12 @@ PyramidHierarchyParameters::CheckCompatibility(const PyramidHierarchyParameters&
             "PyramidHierarchyParameters::CheckCompatibility: no_build_levels are not compatible");
         return false;
     }
+    if (max_degree != other.max_degree || ef_construction != other.ef_construction ||
+        alpha != other.alpha || index_min_size != other.index_min_size) {
+        logger::error(
+            "PyramidHierarchyParameters::CheckCompatibility: build params are not compatible");
+        return false;
+    }
     return true;
 }
 

--- a/src/algorithm/pyramid/pyramid_zparameters.cpp
+++ b/src/algorithm/pyramid/pyramid_zparameters.cpp
@@ -16,6 +16,7 @@
 #include "pyramid_zparameters.h"
 
 #include <algorithm>
+#include <limits>
 #include <nlohmann/json.hpp>
 #include <unordered_set>
 #include <utility>
@@ -51,7 +52,7 @@ append_hierarchy_selector(PyramidSearchParameters& params,
                           const std::string& hierarchy_name) {
     CHECK_ARGUMENT(not hierarchy_name.empty(), "pyramid hierarchy name must not be empty");
     CHECK_ARGUMENT(seen_names.insert(hierarchy_name).second,
-                   fmt::format("duplicate pyramid hierarchy {}", hierarchy_name));
+                   fmt::format("duplicate hierarchy name {}", hierarchy_name));
     params.hierarchies.emplace_back(hierarchy_name);
 }
 
@@ -84,21 +85,27 @@ PyramidHierarchyParameters::FromJson(const JsonType& json) {
                        fmt::format("hierarchy {} max_degree must be positive", name));
     }
     if (json.Contains(EF_CONSTRUCTION_KEY)) {
-        ef_construction = json[EF_CONSTRUCTION_KEY].GetInt();
-        CHECK_ARGUMENT(ef_construction > 0,
+        const auto ef_construction_value = json[EF_CONSTRUCTION_KEY].GetInt();
+        CHECK_ARGUMENT(ef_construction_value > 0,
                        fmt::format("hierarchy {} ef_construction must be positive", name));
+        ef_construction = static_cast<uint64_t>(ef_construction_value);
     }
     if (json.Contains(ALPHA_KEY)) {
         alpha = json[ALPHA_KEY].GetFloat();
-        CHECK_ARGUMENT(alpha > 0.0F,
-                       fmt::format("hierarchy {} alpha must be positive", name));
+        CHECK_ARGUMENT(alpha > 0.0F, fmt::format("hierarchy {} alpha must be positive", name));
     }
     if (json.Contains(INDEX_MIN_SIZE)) {
-        index_min_size = json[INDEX_MIN_SIZE].GetInt();
+        const auto index_min_size_value = json[INDEX_MIN_SIZE].GetInt();
+        CHECK_ARGUMENT(index_min_size_value >= 0,
+                       fmt::format("hierarchy {} index_min_size must be non-negative", name));
+        CHECK_ARGUMENT(index_min_size_value <= std::numeric_limits<uint32_t>::max(),
+                       fmt::format("hierarchy {} index_min_size exceeds uint32_t", name));
+        index_min_size = static_cast<uint32_t>(index_min_size_value);
     }
     for (auto level : no_build_levels) {
-        CHECK_ARGUMENT(level >= 0,
-                       fmt::format("hierarchy {} no_build_levels values must be non-negative", name));
+        CHECK_ARGUMENT(
+            level >= 0,
+            fmt::format("hierarchy {} no_build_levels values must be non-negative", name));
     }
 }
 

--- a/src/algorithm/pyramid/pyramid_zparameters.cpp
+++ b/src/algorithm/pyramid/pyramid_zparameters.cpp
@@ -62,7 +62,6 @@ PyramidHierarchyParameters::FromJson(const JsonType& json) {
     if (json.IsString()) {
         name = json.GetString();
         CHECK_ARGUMENT(not name.empty(), "hierarchy name must not be empty");
-        no_build_levels.clear();
         return;
     }
 
@@ -78,8 +77,18 @@ PyramidHierarchyParameters::FromJson(const JsonType& json) {
                        fmt::format("hierarchy {} no_build_levels must be an array", name));
         no_build_levels = no_build_levels_json.GetVector();
         std::sort(no_build_levels.begin(), no_build_levels.end());
-    } else {
-        no_build_levels.clear();
+    }
+    if (json.Contains(GRAPH_PARAM_MAX_DEGREE_KEY)) {
+        max_degree = json[GRAPH_PARAM_MAX_DEGREE_KEY].GetInt();
+    }
+    if (json.Contains(EF_CONSTRUCTION_KEY)) {
+        ef_construction = json[EF_CONSTRUCTION_KEY].GetInt();
+    }
+    if (json.Contains(ALPHA_KEY)) {
+        alpha = json[ALPHA_KEY].GetFloat();
+    }
+    if (json.Contains(INDEX_MIN_SIZE)) {
+        index_min_size = json[INDEX_MIN_SIZE].GetInt();
     }
 }
 
@@ -88,6 +97,10 @@ PyramidHierarchyParameters::ToJson() const {
     JsonType json;
     json["name"].SetString(name);
     json[NO_BUILD_LEVELS].SetVector(no_build_levels);
+    json[GRAPH_PARAM_MAX_DEGREE_KEY].SetInt(max_degree);
+    json[EF_CONSTRUCTION_KEY].SetInt(ef_construction);
+    json[ALPHA_KEY].SetFloat(alpha);
+    json[INDEX_MIN_SIZE].SetInt(index_min_size);
     return json;
 }
 
@@ -166,6 +179,11 @@ PyramidParameters::FromJson(const JsonType& json) {
             *hierarchy_json.GetInnerJson() = hierarchy_raw_json;
 
             PyramidHierarchyParameters hierarchy;
+            hierarchy.no_build_levels = this->no_build_levels;
+            hierarchy.max_degree = this->max_degree;
+            hierarchy.ef_construction = this->ef_construction;
+            hierarchy.alpha = this->alpha;
+            hierarchy.index_min_size = this->index_min_size;
             hierarchy.FromJson(hierarchy_json);
             CHECK_ARGUMENT(seen_names.insert(hierarchy.name).second,
                            fmt::format("duplicate hierarchy name {}", hierarchy.name));
@@ -277,26 +295,12 @@ PyramidSearchParameters::FromJson(const std::string& json_string) {
         obj.subindex_ef_search =
             params[INDEX_PYRAMID][PYRAMID_PARAMETER_SUBINDEX_EF_SEARCH].GetInt();
     }
-    bool has_hierarchy = false;
-    bool has_hierarchies = false;
     std::unordered_set<std::string> seen_names;
-    if (params[INDEX_PYRAMID].Contains(PYRAMID_PARAMETER_HIERARCHY)) {
-        CHECK_ARGUMENT(not params[INDEX_PYRAMID].Contains(PYRAMID_PARAMETER_HIERARCHIES),
-                       "pyramid hierarchy and hierarchies cannot both be set");
-        CHECK_ARGUMENT(not params[INDEX_PYRAMID].Contains(PYRAMID_PARAMETER_HIERARCHY_OP),
-                       "pyramid hierarchy and hierarchy_op cannot both be set");
-        CHECK_ARGUMENT(params[INDEX_PYRAMID][PYRAMID_PARAMETER_HIERARCHY].IsString(),
-                       "pyramid hierarchy must be a string");
-        append_hierarchy_selector(
-            obj, seen_names, params[INDEX_PYRAMID][PYRAMID_PARAMETER_HIERARCHY].GetString());
-        has_hierarchy = true;
-    }
     if (params[INDEX_PYRAMID].Contains(PYRAMID_PARAMETER_HIERARCHIES)) {
-        CHECK_ARGUMENT(not has_hierarchy, "pyramid hierarchy and hierarchies cannot both be set");
         const auto& hierarchies_json = params[INDEX_PYRAMID][PYRAMID_PARAMETER_HIERARCHIES];
         CHECK_ARGUMENT(hierarchies_json.IsArray(), "pyramid hierarchies must be an array");
-        CHECK_ARGUMENT(hierarchies_json.GetInnerJson()->size() >= 2,
-                       "pyramid hierarchies must contain at least two hierarchy names");
+        CHECK_ARGUMENT(not hierarchies_json.GetInnerJson()->empty(),
+                       "pyramid hierarchies must not be empty");
 
         for (const auto& hierarchy_raw_json : *hierarchies_json.GetInnerJson()) {
             JsonType hierarchy_json;
@@ -304,18 +308,16 @@ PyramidSearchParameters::FromJson(const std::string& json_string) {
             CHECK_ARGUMENT(hierarchy_json.IsString(), "pyramid hierarchy name must be a string");
             append_hierarchy_selector(obj, seen_names, hierarchy_json.GetString());
         }
-        has_hierarchies = true;
     }
     if (params[INDEX_PYRAMID].Contains(PYRAMID_PARAMETER_HIERARCHY_OP)) {
-        CHECK_ARGUMENT(has_hierarchies,
-                       "pyramid hierarchy_op requires pyramid hierarchies to be set");
+        CHECK_ARGUMENT(obj.hierarchies.size() >= 2,
+                       "pyramid hierarchy_op requires at least two hierarchies");
         CHECK_ARGUMENT(params[INDEX_PYRAMID][PYRAMID_PARAMETER_HIERARCHY_OP].IsString(),
                        "pyramid hierarchy_op must be a string");
         obj.hierarchy_op =
             parse_hierarchy_op(params[INDEX_PYRAMID][PYRAMID_PARAMETER_HIERARCHY_OP].GetString());
-        obj.has_hierarchy_op = true;
     }
-    CHECK_ARGUMENT(not has_hierarchies || obj.has_hierarchy_op,
+    CHECK_ARGUMENT(obj.hierarchies.size() <= 1 || obj.hierarchy_op != HierarchyOp::SINGLE,
                    "pyramid hierarchy_op is required for multiple hierarchies");
     return obj;
 }

--- a/src/algorithm/pyramid/pyramid_zparameters.h
+++ b/src/algorithm/pyramid/pyramid_zparameters.h
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <functional>
 #include <string>
 #include <vector>
@@ -48,6 +49,10 @@ public:
 public:
     std::string name;
     std::vector<int32_t> no_build_levels;
+    int64_t max_degree{64};
+    uint64_t ef_construction{400};
+    float alpha{1.2F};
+    uint32_t index_min_size{0};
 };
 
 struct PyramidParameters : public InnerIndexParameter {
@@ -97,7 +102,6 @@ public:
     uint64_t subindex_ef_search{50};
     std::vector<std::string> hierarchies;
     HierarchyOp hierarchy_op{HierarchyOp::SINGLE};
-    bool has_hierarchy_op{false};
 
 private:
     PyramidSearchParameters() = default;

--- a/src/algorithm/pyramid/pyramid_zparameters.h
+++ b/src/algorithm/pyramid/pyramid_zparameters.h
@@ -16,6 +16,8 @@
 #pragma once
 
 #include <functional>
+#include <string>
+#include <vector>
 
 #include "algorithm/hgraph/hgraph_parameter.h"
 #include "algorithm/index_search_parameter.h"
@@ -32,6 +34,22 @@
 namespace vsag {
 
 DEFINE_POINTER2(PyramidParam, PyramidParameters);
+struct PyramidHierarchyParameters {
+public:
+    void
+    FromJson(const JsonType& json);
+
+    JsonType
+    ToJson() const;
+
+    bool
+    CheckCompatibility(const PyramidHierarchyParameters& other) const;
+
+public:
+    std::string name;
+    std::vector<int32_t> no_build_levels;
+};
+
 struct PyramidParameters : public InnerIndexParameter {
 public:
     void
@@ -49,6 +67,7 @@ public:
     ODescentParameterPtr odescent_param{nullptr};
 
     std::vector<int32_t> no_build_levels;
+    std::vector<PyramidHierarchyParameters> hierarchies;
     uint64_t ef_construction{400};
     int64_t max_degree{64};
     std::string graph_type{GRAPH_TYPE_VALUE_NSW};
@@ -56,16 +75,29 @@ public:
     uint32_t index_min_size{0};
 
     bool support_duplicate{false};
+    bool has_hierarchies{false};
 };
 
 class PyramidSearchParameters : public IndexSearchParameter {
 public:
+    enum class HierarchyOp {
+        SINGLE,
+        UNION,
+        INTERSECTION,
+    };
+
     static PyramidSearchParameters
     FromJson(const std::string& json_string);
+
+    bool
+    HasHierarchySelector() const;
 
 public:
     uint64_t ef_search{100};
     uint64_t subindex_ef_search{50};
+    std::vector<std::string> hierarchies;
+    HierarchyOp hierarchy_op{HierarchyOp::SINGLE};
+    bool has_hierarchy_op{false};
 
 private:
     PyramidSearchParameters() = default;

--- a/src/algorithm/pyramid/pyramid_zparameters_test.cpp
+++ b/src/algorithm/pyramid/pyramid_zparameters_test.cpp
@@ -210,6 +210,16 @@ TEST_CASE("Pyramid Hierarchy Parameters Test", "[ut][PyramidParameters][hierarch
         REQUIRE_THROWS(ParsePyramidWithHierarchies(nlohmann::json::array({{{"name", ""}}})));
         REQUIRE_THROWS(ParsePyramidWithHierarchies(
             nlohmann::json::array({{{"name", "site"}, {"no_build_levels", 1}}})));
+        REQUIRE_THROWS(ParsePyramidWithHierarchies(
+            nlohmann::json::array({{{"name", "site"}, {"no_build_levels", {-1}}}})));
+        REQUIRE_THROWS(ParsePyramidWithHierarchies(
+            nlohmann::json::array({{{"name", "site"}, {"max_degree", 0}}})));
+        REQUIRE_THROWS(ParsePyramidWithHierarchies(
+            nlohmann::json::array({{{"name", "site"}, {"ef_construction", -1}}})));
+        REQUIRE_THROWS(
+            ParsePyramidWithHierarchies(nlohmann::json::array({{{"name", "site"}, {"alpha", 0}}})));
+        REQUIRE_THROWS(ParsePyramidWithHierarchies(
+            nlohmann::json::array({{{"name", "site"}, {"index_min_size", -1}}})));
         REQUIRE_THROWS(ParsePyramidWithHierarchies(nlohmann::json::array({{{"foo", "site"}}})));
         REQUIRE_THROWS_AS(ParsePyramidWithHierarchies(nlohmann::json::array({1})),
                           vsag::VsagException);

--- a/src/algorithm/pyramid/pyramid_zparameters_test.cpp
+++ b/src/algorithm/pyramid/pyramid_zparameters_test.cpp
@@ -151,7 +151,7 @@ TEST_CASE("Pyramid Hierarchy Parameters Test", "[ut][PyramidParameters][hierarch
         REQUIRE(param->has_hierarchies);
         REQUIRE(param->hierarchies.size() == 2);
         REQUIRE(param->hierarchies[0].name == "site");
-        REQUIRE(param->hierarchies[0].no_build_levels.empty());
+        REQUIRE(param->hierarchies[0].no_build_levels == std::vector<int32_t>{0, 1, 2});
         REQUIRE(param->hierarchies[1].name == "taxonomy");
         REQUIRE(param->hierarchies[1].no_build_levels == std::vector<int32_t>{0, 2});
 
@@ -161,6 +161,45 @@ TEST_CASE("Pyramid Hierarchy Parameters Test", "[ut][PyramidParameters][hierarch
         REQUIRE((*hierarchies_json)[0]["name"] == "site");
         REQUIRE((*hierarchies_json)[1]["name"] == "taxonomy");
         REQUIRE((*hierarchies_json)[1]["no_build_levels"] == nlohmann::json::array({0, 2}));
+    }
+
+    SECTION("per-hierarchy build params override top-level") {
+        auto param = ParsePyramidWithHierarchies(nlohmann::json::array(
+            {{{"name", "site"}, {"max_degree", 128}, {"alpha", 1.5}},
+             {{"name", "cat"}, {"ef_construction", 800}, {"index_min_size", 50}}}));
+
+        REQUIRE(param->hierarchies.size() == 2);
+        // "site" overrides max_degree and alpha, inherits the rest from top-level
+        REQUIRE(param->hierarchies[0].max_degree == 128);
+        REQUIRE(param->hierarchies[0].alpha == 1.5F);
+        REQUIRE(param->hierarchies[0].ef_construction == param->ef_construction);
+        REQUIRE(param->hierarchies[0].index_min_size == param->index_min_size);
+        REQUIRE(param->hierarchies[0].no_build_levels == param->no_build_levels);
+        // "cat" overrides ef_construction and index_min_size, inherits the rest
+        REQUIRE(param->hierarchies[1].ef_construction == 800);
+        REQUIRE(param->hierarchies[1].index_min_size == 50);
+        REQUIRE(param->hierarchies[1].max_degree == param->max_degree);
+        REQUIRE(param->hierarchies[1].alpha == param->alpha);
+
+        // ToJson roundtrip preserves per-hierarchy params
+        auto output = param->ToJson();
+        const auto* h_json = output["hierarchies"].GetInnerJson();
+        REQUIRE((*h_json)[0]["max_degree"] == 128);
+        REQUIRE((*h_json)[0]["alpha"] == 1.5F);
+        REQUIRE((*h_json)[1]["ef_construction"] == 800);
+        REQUIRE((*h_json)[1]["index_min_size"] == 50);
+    }
+
+    SECTION("string shorthand inherits all top-level build params") {
+        auto param = ParsePyramidWithHierarchies(nlohmann::json::array({"onlyone"}));
+
+        REQUIRE(param->hierarchies.size() == 1);
+        REQUIRE(param->hierarchies[0].name == "onlyone");
+        REQUIRE(param->hierarchies[0].no_build_levels == param->no_build_levels);
+        REQUIRE(param->hierarchies[0].max_degree == param->max_degree);
+        REQUIRE(param->hierarchies[0].ef_construction == param->ef_construction);
+        REQUIRE(param->hierarchies[0].alpha == param->alpha);
+        REQUIRE(param->hierarchies[0].index_min_size == param->index_min_size);
     }
 
     SECTION("invalid hierarchy definitions are rejected") {
@@ -273,11 +312,10 @@ TEST_CASE("Pyramid Search Hierarchy Parameters Test",
           "[ut][PyramidParameters][hierarchy][search]") {
     SECTION("single hierarchy selector") {
         auto search_param = vsag::PyramidSearchParameters::FromJson(
-            R"({"pyramid":{"ef_search":100,"hierarchy":"taxonomy"}})");
+            R"({"pyramid":{"ef_search":100,"hierarchies":["taxonomy"]}})");
 
         REQUIRE(search_param.HasHierarchySelector());
         REQUIRE(search_param.hierarchies == std::vector<std::string>{"taxonomy"});
-        REQUIRE_FALSE(search_param.has_hierarchy_op);
         REQUIRE(search_param.hierarchy_op == vsag::PyramidSearchParameters::HierarchyOp::SINGLE);
     }
 
@@ -288,7 +326,7 @@ TEST_CASE("Pyramid Search Hierarchy Parameters Test",
 
         REQUIRE(search_param.HasHierarchySelector());
         REQUIRE(search_param.hierarchies == std::vector<std::string>{"site", "taxonomy"});
-        REQUIRE(search_param.has_hierarchy_op);
+        REQUIRE(search_param.hierarchy_op != vsag::PyramidSearchParameters::HierarchyOp::SINGLE);
         REQUIRE(search_param.hierarchy_op ==
                 vsag::PyramidSearchParameters::HierarchyOp::INTERSECTION);
     }
@@ -299,28 +337,41 @@ TEST_CASE("Pyramid Search Hierarchy Parameters Test",
             R"("hierarchy_op":"union"}})");
 
         REQUIRE(search_param.hierarchies == std::vector<std::string>{"site", "date"});
-        REQUIRE(search_param.has_hierarchy_op);
+        REQUIRE(search_param.hierarchy_op != vsag::PyramidSearchParameters::HierarchyOp::SINGLE);
         REQUIRE(search_param.hierarchy_op == vsag::PyramidSearchParameters::HierarchyOp::UNION);
     }
 
+    SECTION("no hierarchies field (legacy mode)") {
+        auto search_param =
+            vsag::PyramidSearchParameters::FromJson(R"({"pyramid":{"ef_search":100}})");
+
+        REQUIRE_FALSE(search_param.HasHierarchySelector());
+        REQUIRE(search_param.hierarchies.empty());
+        REQUIRE(search_param.hierarchy_op == vsag::PyramidSearchParameters::HierarchyOp::SINGLE);
+    }
+
     SECTION("invalid hierarchy search parameters are rejected") {
+        // empty hierarchy name
         REQUIRE_THROWS(vsag::PyramidSearchParameters::FromJson(
-            R"({"pyramid":{"ef_search":100,"hierarchy":""}})"));
+            R"({"pyramid":{"ef_search":100,"hierarchies":[""]}})"));
+        // empty array
         REQUIRE_THROWS(vsag::PyramidSearchParameters::FromJson(
-            R"({"pyramid":{"ef_search":100,"hierarchy":"site",)"
-            R"("hierarchies":["taxonomy","date"]}})"));
-        REQUIRE_THROWS(vsag::PyramidSearchParameters::FromJson(
-            R"({"pyramid":{"ef_search":100,"hierarchy":"site","hierarchy_op":"union"}})"));
-        REQUIRE_THROWS(vsag::PyramidSearchParameters::FromJson(
-            R"({"pyramid":{"ef_search":100,"hierarchies":["site"]}})"));
+            R"({"pyramid":{"ef_search":100,"hierarchies":[]}})"));
+        // multiple hierarchies without hierarchy_op
         REQUIRE_THROWS(vsag::PyramidSearchParameters::FromJson(
             R"({"pyramid":{"ef_search":100,"hierarchies":["site","taxonomy"]}})"));
+        // duplicate names
         REQUIRE_THROWS(vsag::PyramidSearchParameters::FromJson(
             R"({"pyramid":{"ef_search":100,"hierarchies":["site","site"],)"
             R"("hierarchy_op":"union"}})"));
+        // invalid hierarchy_op value
         REQUIRE_THROWS(vsag::PyramidSearchParameters::FromJson(
             R"({"pyramid":{"ef_search":100,"hierarchies":["site","taxonomy"],)"
             R"("hierarchy_op":"minus"}})"));
+        // hierarchy_op with single hierarchy
+        REQUIRE_THROWS(vsag::PyramidSearchParameters::FromJson(
+            R"({"pyramid":{"ef_search":100,"hierarchies":["site"],)"
+            R"("hierarchy_op":"union"}})"));
     }
 }
 

--- a/src/algorithm/pyramid/pyramid_zparameters_test.cpp
+++ b/src/algorithm/pyramid/pyramid_zparameters_test.cpp
@@ -21,6 +21,7 @@
 #include "parameter_test.h"
 #include "pyramid.h"
 #include "unittest.h"
+#include "vsag_exception.h"
 
 struct PyramidDefaultParam {
     int max_degree = 32;
@@ -171,6 +172,12 @@ TEST_CASE("Pyramid Hierarchy Parameters Test", "[ut][PyramidParameters][hierarch
         REQUIRE_THROWS(ParsePyramidWithHierarchies(
             nlohmann::json::array({{{"name", "site"}, {"no_build_levels", 1}}})));
         REQUIRE_THROWS(ParsePyramidWithHierarchies(nlohmann::json::array({{{"foo", "site"}}})));
+        REQUIRE_THROWS_AS(ParsePyramidWithHierarchies(nlohmann::json::array({1})),
+                          vsag::VsagException);
+        REQUIRE_THROWS_AS(ParsePyramidWithHierarchies(nlohmann::json::array({true})),
+                          vsag::VsagException);
+        REQUIRE_THROWS_AS(ParsePyramidWithHierarchies(nlohmann::json::array({nullptr})),
+                          vsag::VsagException);
     }
 }
 

--- a/src/algorithm/pyramid/pyramid_zparameters_test.cpp
+++ b/src/algorithm/pyramid/pyramid_zparameters_test.cpp
@@ -15,12 +15,12 @@
 
 #include "pyramid_zparameters.h"
 
+#include <nlohmann/json.hpp>
+
 #include "index_common_param.h"
 #include "parameter_test.h"
 #include "pyramid.h"
 #include "unittest.h"
-
-#include <nlohmann/json.hpp>
 
 struct PyramidDefaultParam {
     int max_degree = 32;
@@ -144,8 +144,8 @@ ParsePyramidWithHierarchies(const nlohmann::json& hierarchies) {
 
 TEST_CASE("Pyramid Hierarchy Parameters Test", "[ut][PyramidParameters][hierarchy]") {
     SECTION("parse string and object hierarchy definitions") {
-        auto param = ParsePyramidWithHierarchies(nlohmann::json::array(
-            {"site", {{"name", "taxonomy"}, {"no_build_levels", {2, 0}}}}));
+        auto param = ParsePyramidWithHierarchies(
+            nlohmann::json::array({"site", {{"name", "taxonomy"}, {"no_build_levels", {2, 0}}}}));
 
         REQUIRE(param->has_hierarchies);
         REQUIRE(param->hierarchies.size() == 2);
@@ -165,8 +165,8 @@ TEST_CASE("Pyramid Hierarchy Parameters Test", "[ut][PyramidParameters][hierarch
     SECTION("invalid hierarchy definitions are rejected") {
         REQUIRE_THROWS(ParsePyramidWithHierarchies(nlohmann::json::array()));
         REQUIRE_THROWS(ParsePyramidWithHierarchies(nlohmann::json::array({""})));
-        REQUIRE_THROWS(ParsePyramidWithHierarchies(
-            nlohmann::json::array({"site", {{"name", "site"}}})));
+        REQUIRE_THROWS(
+            ParsePyramidWithHierarchies(nlohmann::json::array({"site", {{"name", "site"}}})));
         REQUIRE_THROWS(ParsePyramidWithHierarchies(nlohmann::json::array({{{"name", ""}}})));
         REQUIRE_THROWS(ParsePyramidWithHierarchies(
             nlohmann::json::array({{{"name", "site"}, {"no_build_levels", 1}}})));
@@ -225,21 +225,21 @@ TEST_CASE("Pyramid Parameters CheckCompatibility", "[ut][PyramidParameter][Check
     TEST_COMPATIBILITY_CASE("different support duplicate", support_duplicate, false, true, false);
 
     SECTION("same hierarchies in different order") {
-        auto param1 = ParsePyramidWithHierarchies(nlohmann::json::array(
-            {{{"name", "site"}, {"no_build_levels", {0, 1}}},
-             {{"name", "taxonomy"}, {"no_build_levels", {2}}}}));
-        auto param2 = ParsePyramidWithHierarchies(nlohmann::json::array(
-            {{{"name", "taxonomy"}, {"no_build_levels", {2}}},
-             {{"name", "site"}, {"no_build_levels", {1, 0}}}}));
+        auto param1 = ParsePyramidWithHierarchies(
+            nlohmann::json::array({{{"name", "site"}, {"no_build_levels", {0, 1}}},
+                                   {{"name", "taxonomy"}, {"no_build_levels", {2}}}}));
+        auto param2 = ParsePyramidWithHierarchies(
+            nlohmann::json::array({{{"name", "taxonomy"}, {"no_build_levels", {2}}},
+                                   {{"name", "site"}, {"no_build_levels", {1, 0}}}}));
 
         REQUIRE(param1->CheckCompatibility(param2));
     }
 
     SECTION("different hierarchy no_build_levels") {
-        auto param1 = ParsePyramidWithHierarchies(nlohmann::json::array(
-            {{{"name", "site"}, {"no_build_levels", {0}}}}));
-        auto param2 = ParsePyramidWithHierarchies(nlohmann::json::array(
-            {{{"name", "site"}, {"no_build_levels", {1}}}}));
+        auto param1 = ParsePyramidWithHierarchies(
+            nlohmann::json::array({{{"name", "site"}, {"no_build_levels", {0}}}}));
+        auto param2 = ParsePyramidWithHierarchies(
+            nlohmann::json::array({{{"name", "site"}, {"no_build_levels", {1}}}}));
 
         REQUIRE_FALSE(param1->CheckCompatibility(param2));
     }

--- a/src/algorithm/pyramid/pyramid_zparameters_test.cpp
+++ b/src/algorithm/pyramid/pyramid_zparameters_test.cpp
@@ -20,6 +20,8 @@
 #include "pyramid.h"
 #include "unittest.h"
 
+#include <nlohmann/json.hpp>
+
 struct PyramidDefaultParam {
     int max_degree = 32;
     float alpha = 1.3f;
@@ -130,6 +132,48 @@ TEST_CASE("Pyramid Parameters Test", "[ut][PyramidParameters]") {
     vsag::ParameterTest::TestToJson(param);
 }
 
+std::shared_ptr<vsag::PyramidParameters>
+ParsePyramidWithHierarchies(const nlohmann::json& hierarchies) {
+    PyramidDefaultParam index_param;
+    auto param_json = vsag::JsonType::Parse(generate_pyramid(index_param));
+    *param_json["hierarchies"].GetInnerJson() = hierarchies;
+    auto param = std::make_shared<vsag::PyramidParameters>();
+    param->FromJson(param_json);
+    return param;
+}
+
+TEST_CASE("Pyramid Hierarchy Parameters Test", "[ut][PyramidParameters][hierarchy]") {
+    SECTION("parse string and object hierarchy definitions") {
+        auto param = ParsePyramidWithHierarchies(nlohmann::json::array(
+            {"site", {{"name", "taxonomy"}, {"no_build_levels", {2, 0}}}}));
+
+        REQUIRE(param->has_hierarchies);
+        REQUIRE(param->hierarchies.size() == 2);
+        REQUIRE(param->hierarchies[0].name == "site");
+        REQUIRE(param->hierarchies[0].no_build_levels.empty());
+        REQUIRE(param->hierarchies[1].name == "taxonomy");
+        REQUIRE(param->hierarchies[1].no_build_levels == std::vector<int32_t>{0, 2});
+
+        auto output = param->ToJson();
+        const auto* hierarchies_json = output["hierarchies"].GetInnerJson();
+        REQUIRE(hierarchies_json->size() == 2);
+        REQUIRE((*hierarchies_json)[0]["name"] == "site");
+        REQUIRE((*hierarchies_json)[1]["name"] == "taxonomy");
+        REQUIRE((*hierarchies_json)[1]["no_build_levels"] == nlohmann::json::array({0, 2}));
+    }
+
+    SECTION("invalid hierarchy definitions are rejected") {
+        REQUIRE_THROWS(ParsePyramidWithHierarchies(nlohmann::json::array()));
+        REQUIRE_THROWS(ParsePyramidWithHierarchies(nlohmann::json::array({""})));
+        REQUIRE_THROWS(ParsePyramidWithHierarchies(
+            nlohmann::json::array({"site", {{"name", "site"}}})));
+        REQUIRE_THROWS(ParsePyramidWithHierarchies(nlohmann::json::array({{{"name", ""}}})));
+        REQUIRE_THROWS(ParsePyramidWithHierarchies(
+            nlohmann::json::array({{{"name", "site"}, {"no_build_levels", 1}}})));
+        REQUIRE_THROWS(ParsePyramidWithHierarchies(nlohmann::json::array({{{"foo", "site"}}})));
+    }
+}
+
 #define TEST_COMPATIBILITY_CASE(section_name, param_member, val1, val2, expect_compatible) \
     SECTION(section_name) {                                                                \
         PyramidDefaultParam param1;                                                        \
@@ -179,6 +223,98 @@ TEST_CASE("Pyramid Parameters CheckCompatibility", "[ut][PyramidParameter][Check
         "different precise quantization type", precise_quantization_type, "fp32", "fp16", false);
     TEST_COMPATIBILITY_CASE("different index min size", index_min_size, 500, 1500, false);
     TEST_COMPATIBILITY_CASE("different support duplicate", support_duplicate, false, true, false);
+
+    SECTION("same hierarchies in different order") {
+        auto param1 = ParsePyramidWithHierarchies(nlohmann::json::array(
+            {{{"name", "site"}, {"no_build_levels", {0, 1}}},
+             {{"name", "taxonomy"}, {"no_build_levels", {2}}}}));
+        auto param2 = ParsePyramidWithHierarchies(nlohmann::json::array(
+            {{{"name", "taxonomy"}, {"no_build_levels", {2}}},
+             {{"name", "site"}, {"no_build_levels", {1, 0}}}}));
+
+        REQUIRE(param1->CheckCompatibility(param2));
+    }
+
+    SECTION("different hierarchy no_build_levels") {
+        auto param1 = ParsePyramidWithHierarchies(nlohmann::json::array(
+            {{{"name", "site"}, {"no_build_levels", {0}}}}));
+        auto param2 = ParsePyramidWithHierarchies(nlohmann::json::array(
+            {{{"name", "site"}, {"no_build_levels", {1}}}}));
+
+        REQUIRE_FALSE(param1->CheckCompatibility(param2));
+    }
+
+    SECTION("different hierarchy names") {
+        auto param1 = ParsePyramidWithHierarchies(nlohmann::json::array({"site"}));
+        auto param2 = ParsePyramidWithHierarchies(nlohmann::json::array({"taxonomy"}));
+
+        REQUIRE_FALSE(param1->CheckCompatibility(param2));
+    }
+
+    SECTION("legacy and explicit hierarchy modes are incompatible") {
+        PyramidDefaultParam default_param;
+        auto legacy_param = std::make_shared<vsag::PyramidParameters>();
+        legacy_param->FromString(generate_pyramid(default_param));
+        auto hierarchy_param = ParsePyramidWithHierarchies(nlohmann::json::array({"site"}));
+
+        REQUIRE_FALSE(legacy_param->CheckCompatibility(hierarchy_param));
+        REQUIRE_FALSE(hierarchy_param->CheckCompatibility(legacy_param));
+    }
+}
+
+TEST_CASE("Pyramid Search Hierarchy Parameters Test",
+          "[ut][PyramidParameters][hierarchy][search]") {
+    SECTION("single hierarchy selector") {
+        auto search_param = vsag::PyramidSearchParameters::FromJson(
+            R"({"pyramid":{"ef_search":100,"hierarchy":"taxonomy"}})");
+
+        REQUIRE(search_param.HasHierarchySelector());
+        REQUIRE(search_param.hierarchies == std::vector<std::string>{"taxonomy"});
+        REQUIRE_FALSE(search_param.has_hierarchy_op);
+        REQUIRE(search_param.hierarchy_op == vsag::PyramidSearchParameters::HierarchyOp::SINGLE);
+    }
+
+    SECTION("multi hierarchy intersection selector") {
+        auto search_param = vsag::PyramidSearchParameters::FromJson(
+            R"({"pyramid":{"ef_search":100,"hierarchies":["site","taxonomy"],)"
+            R"("hierarchy_op":"intersection"}})");
+
+        REQUIRE(search_param.HasHierarchySelector());
+        REQUIRE(search_param.hierarchies == std::vector<std::string>{"site", "taxonomy"});
+        REQUIRE(search_param.has_hierarchy_op);
+        REQUIRE(search_param.hierarchy_op ==
+                vsag::PyramidSearchParameters::HierarchyOp::INTERSECTION);
+    }
+
+    SECTION("multi hierarchy union selector") {
+        auto search_param = vsag::PyramidSearchParameters::FromJson(
+            R"({"pyramid":{"ef_search":100,"hierarchies":["site","date"],)"
+            R"("hierarchy_op":"union"}})");
+
+        REQUIRE(search_param.hierarchies == std::vector<std::string>{"site", "date"});
+        REQUIRE(search_param.has_hierarchy_op);
+        REQUIRE(search_param.hierarchy_op == vsag::PyramidSearchParameters::HierarchyOp::UNION);
+    }
+
+    SECTION("invalid hierarchy search parameters are rejected") {
+        REQUIRE_THROWS(vsag::PyramidSearchParameters::FromJson(
+            R"({"pyramid":{"ef_search":100,"hierarchy":""}})"));
+        REQUIRE_THROWS(vsag::PyramidSearchParameters::FromJson(
+            R"({"pyramid":{"ef_search":100,"hierarchy":"site",)"
+            R"("hierarchies":["taxonomy","date"]}})"));
+        REQUIRE_THROWS(vsag::PyramidSearchParameters::FromJson(
+            R"({"pyramid":{"ef_search":100,"hierarchy":"site","hierarchy_op":"union"}})"));
+        REQUIRE_THROWS(vsag::PyramidSearchParameters::FromJson(
+            R"({"pyramid":{"ef_search":100,"hierarchies":["site"]}})"));
+        REQUIRE_THROWS(vsag::PyramidSearchParameters::FromJson(
+            R"({"pyramid":{"ef_search":100,"hierarchies":["site","taxonomy"]}})"));
+        REQUIRE_THROWS(vsag::PyramidSearchParameters::FromJson(
+            R"({"pyramid":{"ef_search":100,"hierarchies":["site","site"],)"
+            R"("hierarchy_op":"union"}})"));
+        REQUIRE_THROWS(vsag::PyramidSearchParameters::FromJson(
+            R"({"pyramid":{"ef_search":100,"hierarchies":["site","taxonomy"],)"
+            R"("hierarchy_op":"minus"}})"));
+    }
 }
 
 TEST_CASE("Pyramid maps support_duplicate to graph parameter", "[ut][PyramidParameters]") {
@@ -195,6 +331,10 @@ TEST_CASE("Pyramid maps support_duplicate to graph parameter", "[ut][PyramidPara
         "ef_construction": 100,
         "index_min_size": 0,
         "support_duplicate": true,
+        "hierarchies": [
+            "site",
+            {"name": "taxonomy", "no_build_levels": [0, 2]}
+        ],
         "use_reorder": true
     })");
 
@@ -207,4 +347,9 @@ TEST_CASE("Pyramid maps support_duplicate to graph parameter", "[ut][PyramidPara
     REQUIRE(typed_param != nullptr);
     REQUIRE(typed_param->support_duplicate);
     REQUIRE(typed_param->graph_param->support_duplicate_);
+    REQUIRE(typed_param->has_hierarchies);
+    REQUIRE(typed_param->hierarchies.size() == 2);
+    REQUIRE(typed_param->hierarchies[0].name == "site");
+    REQUIRE(typed_param->hierarchies[1].name == "taxonomy");
+    REQUIRE(typed_param->hierarchies[1].no_build_levels == std::vector<int32_t>{0, 2});
 }

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -230,7 +230,11 @@ const char* const PYRAMID_PRECISE_IO_TYPE = "precise_io_type";
 const char* const PYRAMID_PRECISE_FILE_PATH = "precise_file_path";
 const char* const PYRAMID_PARAMETER_EF_SEARCH = "ef_search";
 const char* const PYRAMID_PARAMETER_SUBINDEX_EF_SEARCH = "subindex_ef_search";
+const char* const PYRAMID_PARAMETER_HIERARCHY = "hierarchy";
+const char* const PYRAMID_PARAMETER_HIERARCHIES = "hierarchies";
+const char* const PYRAMID_PARAMETER_HIERARCHY_OP = "hierarchy_op";
 const char* const PYRAMID_NO_BUILD_LEVELS = "no_build_levels";
+const char* const PYRAMID_HIERARCHIES = "hierarchies";
 const char* const PYRAMID_INDEX_MIN_SIZE = "index_min_size";
 
 const char* const GNO_IMI_FIRST_ORDER_BUCKETS_COUNT = "first_order_buckets_count";

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -230,7 +230,6 @@ const char* const PYRAMID_PRECISE_IO_TYPE = "precise_io_type";
 const char* const PYRAMID_PRECISE_FILE_PATH = "precise_file_path";
 const char* const PYRAMID_PARAMETER_EF_SEARCH = "ef_search";
 const char* const PYRAMID_PARAMETER_SUBINDEX_EF_SEARCH = "subindex_ef_search";
-const char* const PYRAMID_PARAMETER_HIERARCHY = "hierarchy";
 const char* const PYRAMID_PARAMETER_HIERARCHIES = "hierarchies";
 const char* const PYRAMID_PARAMETER_HIERARCHY_OP = "hierarchy_op";
 const char* const PYRAMID_NO_BUILD_LEVELS = "no_build_levels";

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -230,9 +230,12 @@ const char* const PYRAMID_PRECISE_IO_TYPE = "precise_io_type";
 const char* const PYRAMID_PRECISE_FILE_PATH = "precise_file_path";
 const char* const PYRAMID_PARAMETER_EF_SEARCH = "ef_search";
 const char* const PYRAMID_PARAMETER_SUBINDEX_EF_SEARCH = "subindex_ef_search";
+// search-time param key (in search JSON under "pyramid")
 const char* const PYRAMID_PARAMETER_HIERARCHIES = "hierarchies";
 const char* const PYRAMID_PARAMETER_HIERARCHY_OP = "hierarchy_op";
 const char* const PYRAMID_NO_BUILD_LEVELS = "no_build_levels";
+// build-time param key (in index_param JSON); same literal as search-time but kept separate
+// so either can evolve independently without coupling the other context
 const char* const PYRAMID_HIERARCHIES = "hierarchies";
 const char* const PYRAMID_INDEX_MIN_SIZE = "index_min_size";
 

--- a/src/dataset_impl.cpp
+++ b/src/dataset_impl.cpp
@@ -499,18 +499,20 @@ DatasetImpl::Append(const DatasetPtr& other) {
     }
 
     // append paths
-    if (auto iter = this->data_.find(DATASET_PATHS); iter != this->data_.end()) {
-        auto* ptr = const_cast<std::string*>(std::get<const std::string*>(iter->second));
+    std::unordered_set<const std::string*> replaced_paths;
+    auto append_paths = [&](const std::string* current_paths, const std::string* other_paths) {
         auto* paths_copy = new std::string[old_num_elements + new_num_elements];
-        for (int i = 0; i < old_num_elements; ++i) {
-            paths_copy[i] += ptr[i];
+        for (int64_t i = 0; i < old_num_elements; ++i) {
+            paths_copy[i] = current_paths[i];
         }
-        delete[] ptr;
-        ptr = nullptr;
-        for (int i = 0; i < new_num_elements; ++i) {
-            paths_copy[old_num_elements + i] += other->GetPaths()[i];
+        for (int64_t i = 0; i < new_num_elements; ++i) {
+            paths_copy[old_num_elements + i] = other_paths[i];
         }
-        this->Paths(paths_copy);
+        replaced_paths.insert(current_paths);
+        return paths_copy;
+    };
+    if (auto iter = this->data_.find(DATASET_PATHS); iter != this->data_.end()) {
+        this->Paths(append_paths(std::get<const std::string*>(iter->second), other->GetPaths()));
     }
     for (const auto& key : hierarchy_path_keys) {
         auto iter = this->data_.find(key);
@@ -518,18 +520,12 @@ DatasetImpl::Append(const DatasetPtr& other) {
             continue;
         }
         auto hierarchy_name = HierarchyNameFromPathsKey(key);
-        auto* ptr = const_cast<std::string*>(std::get<const std::string*>(iter->second));
-        auto* paths_copy = new std::string[old_num_elements + new_num_elements];
-        for (int i = 0; i < old_num_elements; ++i) {
-            paths_copy[i] = ptr[i];
-        }
-        delete[] ptr;
-        ptr = nullptr;
-        const auto* other_paths = other->GetPaths(hierarchy_name);
-        for (int i = 0; i < new_num_elements; ++i) {
-            paths_copy[old_num_elements + i] = other_paths[i];
-        }
-        this->Paths(hierarchy_name, paths_copy);
+        this->Paths(hierarchy_name,
+                    append_paths(std::get<const std::string*>(iter->second),
+                                 other->GetPaths(hierarchy_name)));
+    }
+    for (const auto* paths : replaced_paths) {
+        delete[] paths;
     }
 
     // append sparse-vectors

--- a/src/dataset_impl.cpp
+++ b/src/dataset_impl.cpp
@@ -356,10 +356,9 @@ DatasetImpl::DeepCopy(Allocator* allocator) const {
     }
     for (const auto& [key, value] : this->data_) {
         if (IsHierarchyPathsKey(key)) {
-            copy_dataset->Paths(
-                HierarchyNameFromPathsKey(key),
-                allocate_and_copy_paths(std::get<const std::string*>(value),
-                                        static_cast<uint64_t>(num_elements)));
+            copy_dataset->Paths(HierarchyNameFromPathsKey(key),
+                                allocate_and_copy_paths(std::get<const std::string*>(value),
+                                                        static_cast<uint64_t>(num_elements)));
         }
     }
 
@@ -429,8 +428,8 @@ DatasetImpl::Append(const DatasetPtr& other) {
         if (other->GetPaths(hierarchy_name) == nullptr) {
             throw VsagException(ErrorType::INVALID_ARGUMENT,
                                 "Cannot append dataset without paths for hierarchy " +
-                                    hierarchy_name +
-                                    " to dataset with paths for hierarchy " + hierarchy_name);
+                                    hierarchy_name + " to dataset with paths for hierarchy " +
+                                    hierarchy_name);
         }
         hierarchy_path_keys.push_back(key);
     }

--- a/src/dataset_impl.cpp
+++ b/src/dataset_impl.cpp
@@ -426,10 +426,11 @@ DatasetImpl::Append(const DatasetPtr& other) {
         }
         const auto hierarchy_name = HierarchyNameFromPathsKey(key);
         if (other->GetPaths(hierarchy_name) == nullptr) {
-            throw VsagException(ErrorType::INVALID_ARGUMENT,
-                                "Cannot append dataset without paths for hierarchy " +
-                                    hierarchy_name + " to dataset with paths for hierarchy " +
-                                    hierarchy_name);
+            std::string error_message = "Cannot append dataset without paths for hierarchy ";
+            error_message.append(hierarchy_name)
+                .append(" to dataset with paths for hierarchy ")
+                .append(hierarchy_name);
+            throw VsagException(ErrorType::INVALID_ARGUMENT, error_message);
         }
         hierarchy_path_keys.push_back(key);
     }

--- a/src/dataset_impl.cpp
+++ b/src/dataset_impl.cpp
@@ -16,6 +16,8 @@
 #include "dataset_impl.h"
 
 #include <cstring>
+#include <unordered_set>
+#include <vector>
 
 #include "typing.h"
 #include "vsag_exception.h"
@@ -159,6 +161,19 @@ allocate_and_copy_multi_vectors(const MultiVector* src,
     return dest;
 }
 
+static std::string*
+allocate_and_copy_paths(const std::string* src, uint64_t count) {
+    if (src == nullptr) {
+        return nullptr;
+    }
+
+    auto* dest = new std::string[count];
+    for (uint64_t i = 0; i < count; ++i) {
+        dest[i] = src[i];
+    }
+    return dest;
+}
+
 static SparseVector*
 allocate_and_copy_sparse_vectors(const SparseVector* src,
                                  uint64_t count,
@@ -261,7 +276,18 @@ DatasetImpl::~DatasetImpl() {  // NOLINT
             delete[] DatasetImpl::GetMultiVectors();
         }
     }
-    delete[] DatasetImpl::GetPaths();
+    std::unordered_set<const std::string*> released_paths;
+    auto release_paths = [&released_paths](const std::string* paths) {
+        if (paths != nullptr && released_paths.insert(paths).second) {
+            delete[] paths;
+        }
+    };
+    release_paths(DatasetImpl::GetPaths());
+    for (const auto& [key, value] : this->data_) {
+        if (IsHierarchyPathsKey(key)) {
+            release_paths(std::get<const std::string*>(value));
+        }
+    }
     if (DatasetImpl::GetAttributeSets() != nullptr) {
         const auto* attrsets = DatasetImpl::GetAttributeSets();
         for (int i = 0; i < DatasetImpl::GetNumElements(); ++i) {
@@ -325,10 +351,15 @@ DatasetImpl::DeepCopy(Allocator* allocator) const {
             this->GetMultiVectors(), num_elements, mv_dim, allocator_ref));
     }
     if (this->GetPaths() != nullptr) {
-        auto* paths = new std::string[num_elements];
-        copy_dataset->Paths(paths);
-        for (int i = 0; i < num_elements; ++i) {
-            paths[i] += this->GetPaths()[i];
+        copy_dataset->Paths(
+            allocate_and_copy_paths(this->GetPaths(), static_cast<uint64_t>(num_elements)));
+    }
+    for (const auto& [key, value] : this->data_) {
+        if (IsHierarchyPathsKey(key)) {
+            copy_dataset->Paths(
+                HierarchyNameFromPathsKey(key),
+                allocate_and_copy_paths(std::get<const std::string*>(value),
+                                        static_cast<uint64_t>(num_elements)));
         }
     }
 
@@ -384,6 +415,24 @@ DatasetImpl::Append(const DatasetPtr& other) {
     if (this->data_.find(DATASET_PATHS) != this->data_.end() && other->GetPaths() == nullptr) {
         throw VsagException(ErrorType::INVALID_ARGUMENT,
                             "Cannot append dataset without paths to dataset with paths");
+    }
+    std::vector<std::string> hierarchy_path_keys;
+    for (const auto& [key, value] : this->data_) {
+        if (not IsHierarchyPathsKey(key)) {
+            continue;
+        }
+        const auto* paths = std::get<const std::string*>(value);
+        if (paths == nullptr) {
+            continue;
+        }
+        const auto hierarchy_name = HierarchyNameFromPathsKey(key);
+        if (other->GetPaths(hierarchy_name) == nullptr) {
+            throw VsagException(ErrorType::INVALID_ARGUMENT,
+                                "Cannot append dataset without paths for hierarchy " +
+                                    hierarchy_name +
+                                    " to dataset with paths for hierarchy " + hierarchy_name);
+        }
+        hierarchy_path_keys.push_back(key);
     }
 
     // check sparse-vectors
@@ -443,6 +492,25 @@ DatasetImpl::Append(const DatasetPtr& other) {
             paths_copy[old_num_elements + i] += other->GetPaths()[i];
         }
         this->Paths(paths_copy);
+    }
+    for (const auto& key : hierarchy_path_keys) {
+        auto iter = this->data_.find(key);
+        if (iter == this->data_.end()) {
+            continue;
+        }
+        auto hierarchy_name = HierarchyNameFromPathsKey(key);
+        auto* ptr = const_cast<std::string*>(std::get<const std::string*>(iter->second));
+        auto* paths_copy = new std::string[old_num_elements + new_num_elements];
+        for (int i = 0; i < old_num_elements; ++i) {
+            paths_copy[i] = ptr[i];
+        }
+        delete[] ptr;
+        ptr = nullptr;
+        const auto* other_paths = other->GetPaths(hierarchy_name);
+        for (int i = 0; i < new_num_elements; ++i) {
+            paths_copy[old_num_elements + i] = other_paths[i];
+        }
+        this->Paths(hierarchy_name, paths_copy);
     }
 
     // append sparse-vectors

--- a/src/dataset_impl.cpp
+++ b/src/dataset_impl.cpp
@@ -434,6 +434,25 @@ DatasetImpl::Append(const DatasetPtr& other) {
         }
         hierarchy_path_keys.push_back(key);
     }
+    auto other_impl = std::dynamic_pointer_cast<DatasetImpl>(other);
+    if (other_impl != nullptr) {
+        for (const auto& [key, value] : other_impl->data_) {
+            if (not IsHierarchyPathsKey(key)) {
+                continue;
+            }
+            if (std::get<const std::string*>(value) == nullptr) {
+                continue;
+            }
+            const auto hierarchy_name = HierarchyNameFromPathsKey(key);
+            if (this->GetPaths(hierarchy_name) == nullptr) {
+                std::string error_message = "Cannot append dataset with paths for hierarchy ";
+                error_message.append(hierarchy_name)
+                    .append(" to dataset without paths for hierarchy ")
+                    .append(hierarchy_name);
+                throw VsagException(ErrorType::INVALID_ARGUMENT, error_message);
+            }
+        }
+    }
 
     // check sparse-vectors
     if (this->data_.find(SPARSE_VECTORS) != this->data_.end() &&

--- a/src/dataset_impl.h
+++ b/src/dataset_impl.h
@@ -210,9 +210,30 @@ public:
         return shared_from_this();
     }
 
+    DatasetPtr
+    Paths(const std::string& hierarchy_name, const std::string* paths) override {
+        if (hierarchy_name.empty()) {
+            return Paths(paths);
+        }
+        this->data_[HierarchyPathsKey(hierarchy_name)] = paths;
+        return shared_from_this();
+    }
+
     const std::string*
     GetPaths() const override {
         if (auto iter = this->data_.find(DATASET_PATHS); iter != this->data_.end()) {
+            return std::get<const std::string*>(iter->second);
+        }
+        return nullptr;
+    }
+
+    const std::string*
+    GetPaths(const std::string& hierarchy_name) const override {
+        if (hierarchy_name.empty()) {
+            return GetPaths();
+        }
+        if (auto iter = this->data_.find(HierarchyPathsKey(hierarchy_name));
+            iter != this->data_.end()) {
             return std::get<const std::string*>(iter->second);
         }
         return nullptr;
@@ -329,6 +350,27 @@ public:
 
     static DatasetPtr
     MakeEmptyDataset();
+
+private:
+    static std::string
+    HierarchyPathsPrefix() {
+        return std::string(DATASET_PATHS) + ":";
+    }
+
+    static std::string
+    HierarchyPathsKey(const std::string& hierarchy_name) {
+        return HierarchyPathsPrefix() + hierarchy_name;
+    }
+
+    static bool
+    IsHierarchyPathsKey(const std::string& key) {
+        return key.rfind(HierarchyPathsPrefix(), 0) == 0;
+    }
+
+    static std::string
+    HierarchyNameFromPathsKey(const std::string& key) {
+        return key.substr(HierarchyPathsPrefix().size());
+    }
 
 private:
     bool owner_{true};

--- a/src/dataset_impl.h
+++ b/src/dataset_impl.h
@@ -352,9 +352,10 @@ public:
     MakeEmptyDataset();
 
 private:
-    static std::string
+    static const std::string&
     HierarchyPathsPrefix() {
-        return std::string(DATASET_PATHS) + ":";
+        static const std::string prefix = std::string(DATASET_PATHS) + ":";
+        return prefix;
     }
 
     static std::string

--- a/src/dataset_impl_test.cpp
+++ b/src/dataset_impl_test.cpp
@@ -478,6 +478,36 @@ TEST_CASE("Dataset Named Paths Test", "[ut][dataset]") {
 
         REQUIRE_THROWS(dataset->Append(append_dataset));
     }
+
+    SECTION("append rejects extra named paths on appended dataset") {
+        auto dataset = MakeDatasetWithNamedPaths({"root/a"}, {});
+        auto append_dataset = MakeDatasetWithNamedPaths({"root/b"}, {{"site", {"site/b"}}});
+
+        REQUIRE_THROWS(dataset->Append(append_dataset));
+    }
+
+    SECTION("append handles aliased named path arrays") {
+        auto* shared_paths = CopyPathArray({"shared/a", "shared/b"});
+        auto dataset = vsag::Dataset::Make();
+        dataset->NumElements(2)
+            ->Dim(1)
+            ->Paths(shared_paths)
+            ->Paths("site", shared_paths)
+            ->Paths("taxonomy", shared_paths)
+            ->Owner(true);
+        auto append_dataset = MakeDatasetWithNamedPaths(
+            {"root/c"}, {{"site", {"site/c"}}, {"taxonomy", {"taxonomy/c"}}});
+
+        dataset->Append(append_dataset);
+
+        REQUIRE(dataset->GetNumElements() == 3);
+        REQUIRE(dataset->GetPaths()[0] == "shared/a");
+        REQUIRE(dataset->GetPaths("site")[0] == "shared/a");
+        REQUIRE(dataset->GetPaths("taxonomy")[0] == "shared/a");
+        REQUIRE(dataset->GetPaths()[2] == "root/c");
+        REQUIRE(dataset->GetPaths("site")[2] == "site/c");
+        REQUIRE(dataset->GetPaths("taxonomy")[2] == "taxonomy/c");
+    }
 }
 
 TEST_CASE("Dataset MultiVector Basic Test", "[ut][dataset]") {

--- a/src/dataset_impl_test.cpp
+++ b/src/dataset_impl_test.cpp
@@ -342,6 +342,30 @@ ArePathArraysDeepCopied(const std::string* original,
     return true;
 }
 
+std::string*
+CopyPathArray(const std::vector<std::string>& paths) {
+    auto* path_array = new std::string[paths.size()];
+    for (uint64_t i = 0; i < paths.size(); ++i) {
+        path_array[i] = paths[i];
+    }
+    return path_array;
+}
+
+vsag::DatasetPtr
+MakeDatasetWithNamedPaths(
+    const std::vector<std::string>& default_paths,
+    const std::vector<std::pair<std::string, std::vector<std::string>>>& hierarchy_paths) {
+    auto dataset = vsag::Dataset::Make();
+    dataset->NumElements(static_cast<int64_t>(default_paths.size()))
+        ->Dim(1)
+        ->Paths(CopyPathArray(default_paths))
+        ->Owner(true);
+    for (const auto& [hierarchy_name, paths] : hierarchy_paths) {
+        dataset->Paths(hierarchy_name, CopyPathArray(paths));
+    }
+    return dataset;
+}
+
 TEST_CASE("Dataset Copy and Append Test", "[ut][Dataset]") {
     std::random_device rd;
     std::mt19937 gen(rd());
@@ -394,6 +418,68 @@ TEST_CASE("Dataset Copy and Append Test", "[ut][Dataset]") {
             ->ExtraInfos(original->GetExtraInfos() + num_elements * extra_info_size)
             ->Owner(false);
         REQUIRE(EqualDataset(sub_original, append_dataset));
+    }
+}
+
+TEST_CASE("Dataset Named Paths Test", "[ut][dataset]") {
+    SECTION("named path setter and getter") {
+        std::string default_paths[2] = {"root/a", "root/b"};
+        std::string site_paths[2] = {"site/a", "site/b"};
+        std::string taxonomy_paths[2] = {"taxonomy/a", "taxonomy/b"};
+        std::string replacement_default_paths[2] = {"root/c", "root/d"};
+
+        auto dataset = vsag::Dataset::Make();
+        dataset->NumElements(2)->Dim(1)->Owner(false);
+        dataset->Paths(default_paths)
+            ->Paths("site", site_paths)
+            ->Paths("taxonomy", taxonomy_paths);
+
+        REQUIRE(dataset->GetPaths() == default_paths);
+        REQUIRE(dataset->GetPaths("") == default_paths);
+        REQUIRE(dataset->GetPaths("site") == site_paths);
+        REQUIRE(dataset->GetPaths("taxonomy") == taxonomy_paths);
+        REQUIRE(dataset->GetPaths("missing") == nullptr);
+
+        dataset->Paths("", replacement_default_paths);
+        REQUIRE(dataset->GetPaths() == replacement_default_paths);
+        REQUIRE(dataset->GetPaths("") == replacement_default_paths);
+        REQUIRE(dataset->GetPaths("site") == site_paths);
+    }
+
+    SECTION("deep copy preserves named paths") {
+        auto original = MakeDatasetWithNamedPaths(
+            {"root/a", "root/b"},
+            {{"site", {"site/a", "site/b"}}, {"taxonomy", {"taxonomy/a", "taxonomy/b"}}});
+
+        auto copy = original->DeepCopy();
+
+        REQUIRE(ArePathArraysDeepCopied(original->GetPaths(), copy->GetPaths(), 2));
+        REQUIRE(ArePathArraysDeepCopied(original->GetPaths("site"), copy->GetPaths("site"), 2));
+        REQUIRE(ArePathArraysDeepCopied(
+            original->GetPaths("taxonomy"), copy->GetPaths("taxonomy"), 2));
+    }
+
+    SECTION("append preserves named paths") {
+        auto dataset = MakeDatasetWithNamedPaths(
+            {"root/a", "root/b"},
+            {{"site", {"site/a", "site/b"}}, {"taxonomy", {"taxonomy/a", "taxonomy/b"}}});
+        auto append_dataset =
+            MakeDatasetWithNamedPaths({"root/c"},
+                                      {{"site", {"site/c"}}, {"taxonomy", {"taxonomy/c"}}});
+
+        dataset->Append(append_dataset);
+
+        REQUIRE(dataset->GetNumElements() == 3);
+        REQUIRE(dataset->GetPaths()[2] == "root/c");
+        REQUIRE(dataset->GetPaths("site")[2] == "site/c");
+        REQUIRE(dataset->GetPaths("taxonomy")[2] == "taxonomy/c");
+    }
+
+    SECTION("append requires matching named paths") {
+        auto dataset = MakeDatasetWithNamedPaths({"root/a"}, {{"site", {"site/a"}}});
+        auto append_dataset = MakeDatasetWithNamedPaths({"root/b"}, {});
+
+        REQUIRE_THROWS(dataset->Append(append_dataset));
     }
 }
 

--- a/src/dataset_impl_test.cpp
+++ b/src/dataset_impl_test.cpp
@@ -430,9 +430,7 @@ TEST_CASE("Dataset Named Paths Test", "[ut][dataset]") {
 
         auto dataset = vsag::Dataset::Make();
         dataset->NumElements(2)->Dim(1)->Owner(false);
-        dataset->Paths(default_paths)
-            ->Paths("site", site_paths)
-            ->Paths("taxonomy", taxonomy_paths);
+        dataset->Paths(default_paths)->Paths("site", site_paths)->Paths("taxonomy", taxonomy_paths);
 
         REQUIRE(dataset->GetPaths() == default_paths);
         REQUIRE(dataset->GetPaths("") == default_paths);
@@ -455,17 +453,16 @@ TEST_CASE("Dataset Named Paths Test", "[ut][dataset]") {
 
         REQUIRE(ArePathArraysDeepCopied(original->GetPaths(), copy->GetPaths(), 2));
         REQUIRE(ArePathArraysDeepCopied(original->GetPaths("site"), copy->GetPaths("site"), 2));
-        REQUIRE(ArePathArraysDeepCopied(
-            original->GetPaths("taxonomy"), copy->GetPaths("taxonomy"), 2));
+        REQUIRE(
+            ArePathArraysDeepCopied(original->GetPaths("taxonomy"), copy->GetPaths("taxonomy"), 2));
     }
 
     SECTION("append preserves named paths") {
         auto dataset = MakeDatasetWithNamedPaths(
             {"root/a", "root/b"},
             {{"site", {"site/a", "site/b"}}, {"taxonomy", {"taxonomy/a", "taxonomy/b"}}});
-        auto append_dataset =
-            MakeDatasetWithNamedPaths({"root/c"},
-                                      {{"site", {"site/c"}}, {"taxonomy", {"taxonomy/c"}}});
+        auto append_dataset = MakeDatasetWithNamedPaths(
+            {"root/c"}, {{"site", {"site/c"}}, {"taxonomy", {"taxonomy/c"}}});
 
         dataset->Append(append_dataset);
 

--- a/src/json_wrapper.cpp
+++ b/src/json_wrapper.cpp
@@ -101,6 +101,11 @@ JsonWrapper::IsArray() const {
     return json_->is_array();
 }
 
+bool
+JsonWrapper::IsObject() const {
+    return json_->is_object();
+}
+
 void
 JsonWrapper::SetString(const std::string& str_value) {
     (*json_) = str_value;

--- a/src/json_wrapper.h
+++ b/src/json_wrapper.h
@@ -49,6 +49,9 @@ public:
     bool
     IsArray() const;
 
+    bool
+    IsObject() const;
+
     JsonWrapper&
     operator=(const JsonWrapper& other);
 

--- a/src/json_wrapper_test.cpp
+++ b/src/json_wrapper_test.cpp
@@ -53,6 +53,15 @@ TEST_CASE("JsonWrapper Copy Nested Json", "[ut][json_wrapper]") {
     CHECK(w2["outer"]["inner"].GetString() == "data");
 }
 
+TEST_CASE("JsonWrapper Object Type Check", "[ut][json_wrapper]") {
+    auto object = vsag::JsonWrapper::Parse(R"({"key": "value"})");
+    auto array = vsag::JsonWrapper::Parse(R"(["value"])");
+    auto string = vsag::JsonWrapper::Parse(R"("value")");
+    CHECK(object.IsObject());
+    CHECK_FALSE(array.IsObject());
+    CHECK_FALSE(string.IsObject());
+}
+
 TEST_CASE("JsonWrapper Copy Non-owning Wrapper", "[ut][json_wrapper]") {
     vsag::JsonWrapper sub;
     {


### PR DESCRIPTION
## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Improvement/Refactor
- [ ] Documentation
- [ ] CI/Build/Infra

## Linked Issue

- Fixes: #2097
- Refs: #1947

## What Changed

- Added named dataset path APIs: `Dataset::Paths(name, paths)` and `Dataset::GetPaths(name)`.
- Added Pyramid hierarchy parameter parsing for `hierarchies`, including per-hierarchy `no_build_levels` validation.
- Added search parameter parsing for single `hierarchy` and reserved multi-hierarchy `hierarchies` + `hierarchy_op` selectors.
- Added runtime guards so reserved multi-hierarchy execution fails clearly until the implementation PRs land.
- Added unit coverage for dataset named path lifecycle and Pyramid hierarchy parameter validation.

## Test Evidence

- [ ] `make fmt`
- [ ] `make lint`
- [ ] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [x] Other (describe below)

Test details:

```text
git diff --check

Local compile/test was not run because this local environment does not have the required VSAG build toolchain available. clang-format-15 and clang-tidy-15 are also not installed locally, so no alternate clang version was used. CI is expected to provide the compile/test validation.
```

## Compatibility Impact

- API/ABI compatibility: additive public Dataset APIs and Pyramid parameter constants.
- Behavior changes: legacy Pyramid behavior remains unchanged unless reserved hierarchy parameters are explicitly supplied; those fail with a clear not-implemented error until later PRs implement execution.

## Performance and Concurrency Impact

- Performance impact: none expected; this PR only adds API/parameter parsing and Dataset metadata handling.
- Concurrency/thread-safety impact: none expected.

## Documentation Impact

- [x] No docs update needed
- [ ] Updated docs:
  - [ ] `README.md`
  - [ ] `DEVELOPMENT.md`
  - [ ] `CONTRIBUTING.md`
  - [ ] Other:

## Risk and Rollback

- Risk level: low
- Rollback plan: revert this PR; no serialized format or Pyramid storage changes are introduced.

## Checklist

- [x] I have linked the relevant issue (required for `kind/bug` and `kind/feature`; see "Linked Issue" above)
- [x] I have added/updated tests for new behavior or bug fixes
- [x] I have considered API compatibility impact
- [x] I have updated docs if behavior/workflow changed
- [x] My commit messages follow project conventions (Conventional Commits, optional `[skip ci]` prefix)
