### PR TITLE
refactor: extract pyramid vector store for legacy mode

### DIFF
--- a/src/algorithm/pyramid.cpp
+++ b/src/algorithm/pyramid.cpp
@@ -212,22 +212,13 @@ std::vector<int64_t>
 Pyramid::build_by_odescent(const DatasetPtr& base) {
     const auto* path = base->GetPaths();
     CHECK_ARGUMENT(path != nullptr, "path is required");
-    int64_t data_num = base->GetNumElements();
-    const auto* data_vectors = base->GetFloat32Vectors();
-    const auto* data_ids = base->GetIds();
 
-    resize(data_num);
-    std::memcpy(label_table_->label_table_.data(), data_ids, sizeof(LabelType) * data_num);
-
-    base_codes_->BatchInsertVector(data_vectors, data_num);
-    if (use_reorder_) {
-        precise_codes_->BatchInsertVector(data_vectors, data_num);
-    }
-    auto codes = use_reorder_ ? precise_codes_ : base_codes_;
+    store_->InsertForBuild(base,
+                           [this](int64_t new_max_capacity) { this->resize(new_max_capacity); });
+    auto codes = store_->DefaultCodes();
 
     ODescent graph_builder(odescent_param_, codes, allocator_, this->thread_pool_.get());
     root_->Build(graph_builder);
-    cur_element_count_ = data_num;
     return {};
 }
 
@@ -266,8 +257,13 @@ Pyramid::KnnSearch(const DatasetPtr& query,
             std::make_shared<InnerIdWrapperFilter>(filter, *label_table_);
     }
     SearchFunc search_func = [&](const IndexNode* node, const VisitedListPtr& vl) {
-        return this->search_node(
-            node, vl, search_param, query, base_codes_, ctx, parsed_param.subindex_ef_search);
+        return this->search_node(node,
+                                 vl,
+                                 search_param,
+                                 query,
+                                 store_->base_codes(),
+                                 ctx,
+                                 parsed_param.subindex_ef_search);
     };
 
     auto result = this->search_impl(query, search_func, search_param);
@@ -308,8 +304,13 @@ Pyramid::RangeSearch(const DatasetPtr& query,
             std::make_shared<InnerIdWrapperFilter>(filter, *label_table_);
     }
     SearchFunc search_func = [&](const IndexNode* node, const VisitedListPtr& vl) {
-        return this->search_node(
-            node, vl, search_param, query, base_codes_, ctx, parsed_param.subindex_ef_search);
+        return this->search_node(node,
+                                 vl,
+                                 search_param,
+                                 query,
+                                 store_->base_codes(),
+                                 ctx,
+                                 parsed_param.subindex_ef_search);
     };
 
     auto result = this->search_impl(query, search_func, search_param);
@@ -332,7 +333,7 @@ Pyramid::search_impl(const DatasetPtr& query,
 
     DistHeapPtr search_result = std::make_shared<StandardHeap<true, false>>(allocator_, -1);
 
-    std::shared_lock<std::shared_mutex> lock(resize_mutex_);
+    auto lock = store_->ResizeLock();
     auto vl = pool_->TakeOne();
     if (query_path != nullptr) {
         std::vector<std::future<void>> futures;
@@ -380,7 +381,7 @@ Pyramid::search_impl(const DatasetPtr& query,
     pool_->ReturnOne(vl);
 
     if (use_reorder_) {
-        search_result = this->reorder_->Reorder(
+        search_result = this->store_->reorder()->Reorder(
             search_result, query->GetFloat32Vectors(), search_param.topk, ctx);
     }
 
@@ -416,21 +417,17 @@ Pyramid::search_impl(const DatasetPtr& query,
 
 int64_t
 Pyramid::GetNumElements() const {
-    return base_codes_->TotalCount();
+    return store_->GetNumElements();
 }
 
 void
 Pyramid::Serialize(StreamWriter& writer) const {
-    label_table_->Serialize(writer);
-    base_codes_->Serialize(writer);
-    if (use_reorder_) {
-        precise_codes_->Serialize(writer);
-    }
+    store_->Serialize(writer);
     root_->Serialize(writer);
 
     // serialize footer (introduced since v0.15)
     JsonType basic_info;
-    basic_info["max_capacity"].SetInt(max_capacity_);
+    basic_info["max_capacity"].SetInt(store_->max_capacity());
     basic_info[INDEX_PARAM].SetString(this->create_param_ptr_->ToString());
     auto metadata = std::make_shared<Metadata>();
     metadata->Set(BASIC_INFO, basic_info);
@@ -449,14 +446,10 @@ Pyramid::Deserialize(StreamReader& reader) {
     BufferStreamReader buffer_reader(
         &reader, std::numeric_limits<uint64_t>::max(), this->allocator_);
 
-    label_table_->Deserialize(buffer_reader);
-    base_codes_->Deserialize(buffer_reader);
-    if (use_reorder_) {
-        precise_codes_->Deserialize(buffer_reader);
-    }
-    cur_element_count_ = base_codes_->TotalCount();
+    store_->Deserialize(buffer_reader);
     root_->Deserialize(buffer_reader);
-    resize(max_capacity);
+    store_->Resize(max_capacity,
+                   [this](int64_t new_max_capacity) { this->resize(new_max_capacity); });
     this->current_memory_usage_ = static_cast<int64_t>(this->CalSerializeSize());
 }
 
@@ -467,14 +460,7 @@ Pyramid::ExportModel(const IndexCommonParam& param) const {
         throw VsagException(ErrorType::INTERNAL_ERROR,
                             "Export model's pyramid reorder config mismatched");
     }
-    this->base_codes_->ExportModel(index->base_codes_);
-    if (use_reorder_) {
-        if (index->precise_codes_ == nullptr) {
-            throw VsagException(ErrorType::INTERNAL_ERROR,
-                                "Export model's pyramid precise codes is empty");
-        }
-        this->precise_codes_->ExportModel(index->precise_codes_);
-    }
+    store_->ExportModel(*index->store_);
     index->current_memory_usage_ = static_cast<int64_t>(index->CalSerializeSize());
     return index;
 }
@@ -483,50 +469,15 @@ std::vector<int64_t>
 Pyramid::Add(const DatasetPtr& base, AddMode mode) {
     const auto* path = base->GetPaths();
     CHECK_ARGUMENT(path != nullptr, "path is required");
-    int64_t data_num = base->GetNumElements();
     const auto* data_vectors = base->GetFloat32Vectors();
-    const auto* data_ids = base->GetIds();
-    std::vector<int64_t> failed_ids;
-    Vector<int64_t> data_biases(allocator_);
-    int64_t local_cur_element_count = 0;
-    {
-        std::lock_guard lock(cur_element_count_mutex_);
-        local_cur_element_count = cur_element_count_;
-        if (max_capacity_ == 0) {
-            auto new_capacity = std::max(INIT_CAPACITY, data_num);
-            resize(new_capacity);
-        } else if (max_capacity_ < data_num + cur_element_count_) {
-            auto new_capacity = std::min(MAX_CAPACITY_EXTEND, max_capacity_);
-            new_capacity = std::max(data_num + cur_element_count_ - max_capacity_, new_capacity) +
-                           max_capacity_;
-            resize(new_capacity);
-        }
-        int64_t valid_id_count = 0;
-        for (int64_t i = 0; i < data_num; ++i) {
-            if (not label_table_->CheckLabel(data_ids[i])) {
-                label_table_->Insert(valid_id_count + local_cur_element_count, data_ids[i]);
-                base_codes_->InsertVector(data_vectors + dim_ * i,
-                                          valid_id_count + local_cur_element_count);
-                if (use_reorder_) {
-                    precise_codes_->InsertVector(data_vectors + dim_ * i,
-                                                 valid_id_count + local_cur_element_count);
-                }
-                valid_id_count++;
-                data_biases.push_back(i);
-            } else {
-                logger::warn("Label {} already exists, skip adding.", data_ids[i]);
-                failed_ids.push_back(data_ids[i]);
-            }
-        }
-        cur_element_count_ += valid_id_count;
-    }
-    std::shared_lock<std::shared_mutex> lock(resize_mutex_);
+    auto insert_result = store_->Insert(
+        base, true, [this](int64_t new_max_capacity) { this->resize(new_max_capacity); });
+    auto lock = store_->ResizeLock();
 
-    auto add_func = [&](int64_t i, int64_t data_bias) {
+    auto add_func = [&](InnerIdType inner_id, int64_t data_bias) {
         std::string current_path = path[data_bias];
         auto path_slices = split(current_path, PART_SLASH);
         IndexNode* node = root_.get();
-        auto inner_id = static_cast<InnerIdType>(i + local_cur_element_count);
         const auto* vector = data_vectors + dim_ * data_bias;
         int no_build_level_index = 0;
         for (int j = 0; j <= path_slices.size(); ++j) {
@@ -546,12 +497,13 @@ Pyramid::Add(const DatasetPtr& base, AddMode mode) {
     };
 
     Vector<std::future<void>> futures(allocator_);
-    for (int64_t i = 0; i < data_biases.size(); ++i) {
-        auto data_bias = data_biases[i];
+    for (int64_t i = 0; i < insert_result.data_biases.size(); ++i) {
+        auto data_bias = insert_result.data_biases[i];
+        auto inner_id = insert_result.inner_ids[i];
         if (this->thread_pool_ != nullptr) {
-            futures.push_back(this->thread_pool_->GeneralEnqueue(add_func, i, data_bias));
+            futures.push_back(this->thread_pool_->GeneralEnqueue(add_func, inner_id, data_bias));
         } else {
-            add_func(i, data_bias);
+            add_func(inner_id, data_bias);
         }
     }
     if (this->thread_pool_ != nullptr) {
@@ -559,23 +511,13 @@ Pyramid::Add(const DatasetPtr& base, AddMode mode) {
             future.get();
         }
     }
-    return failed_ids;
+    return insert_result.failed_ids;
 }
 
 void
 Pyramid::resize(int64_t new_max_capacity) {
-    std::unique_lock<std::shared_mutex> lock(resize_mutex_);
-    if (new_max_capacity <= max_capacity_) {
-        return;
-    }
     pool_ = std::make_unique<VisitedListPool>(1, allocator_, new_max_capacity, allocator_);
-    label_table_->Resize(new_max_capacity);
-    base_codes_->Resize(new_max_capacity);
-    if (use_reorder_) {
-        precise_codes_->Resize(new_max_capacity);
-    }
     points_mutex_->Resize(new_max_capacity);
-    max_capacity_ = new_max_capacity;
 }
 
 void
@@ -729,10 +671,7 @@ Pyramid::CheckAndMappingExternalParam(const JsonType& external_param,
 
 void
 Pyramid::Train(const DatasetPtr& base) {
-    this->base_codes_->Train(base->GetFloat32Vectors(), base->GetNumElements());
-    if (use_reorder_) {
-        this->precise_codes_->Train(base->GetFloat32Vectors(), base->GetNumElements());
-    }
+    store_->Train(base);
 }
 std::vector<int64_t>
 Pyramid::Build(const DatasetPtr& base) {
@@ -793,7 +732,7 @@ Pyramid::add_one_point(IndexNode* node, InnerIdType inner_id, const float* vecto
         if (support_duplicate_) {
             search_param.find_duplicate = true;
         }
-        auto codes = use_reorder_ ? precise_codes_ : base_codes_;
+        auto codes = store_->DefaultCodes();
         bool update_entry_point;
         {
             std::scoped_lock<std::mutex> entry_point_lock(entry_point_mutex_);
@@ -903,7 +842,7 @@ Pyramid::SetImmutable() {
     if (this->immutable_) {
         return;
     }
-    label_table_->SetImmutable();
+    store_->SetImmutable();
     this->points_mutex_.reset();
     this->points_mutex_ = std::make_shared<EmptyMutex>();
     this->searcher_->SetMutexArray(this->points_mutex_);
@@ -912,10 +851,10 @@ Pyramid::SetImmutable() {
 
 float
 Pyramid::CalcDistanceById(const float* query, int64_t id, bool calculate_precise_distance) const {
-    std::shared_lock<std::shared_mutex> lock(resize_mutex_);
-    auto flat = this->base_codes_;
+    auto lock = store_->ResizeLock();
+    auto flat = store_->base_codes();
     if (use_reorder_ && calculate_precise_distance) {
-        flat = this->precise_codes_;
+        flat = store_->precise_codes();
     }
     return InnerIndexInterface::calc_distance_by_id(query, id, flat);
 }
@@ -925,18 +864,18 @@ Pyramid::CalDistanceById(const float* query,
                          const int64_t* ids,
                          int64_t count,
                          bool calculate_precise_distance) const {
-    std::shared_lock<std::shared_mutex> lock(resize_mutex_);
-    auto flat = this->base_codes_;
+    auto lock = store_->ResizeLock();
+    auto flat = store_->base_codes();
     if (use_reorder_ && calculate_precise_distance) {
-        flat = this->precise_codes_;
+        flat = store_->precise_codes();
     }
     return InnerIndexInterface::cal_distance_by_id(query, ids, count, flat);
 }
 
 void
 Pyramid::GetVectorByInnerId(InnerIdType inner_id, float* data) const {
-    std::shared_lock<std::shared_mutex> lock(resize_mutex_);
-    auto codes = (use_reorder_) ? precise_codes_ : base_codes_;
+    auto lock = store_->ResizeLock();
+    auto codes = store_->DefaultCodes();
     bool release = false;
     const auto* buffer = codes->GetCodesById(inner_id, release);
     codes->Decode(buffer, data);

--- a/src/algorithm/pyramid.h
+++ b/src/algorithm/pyramid.h
@@ -23,11 +23,11 @@
 #include "impl/filter/filter_headers.h"
 #include "impl/heap/distance_heap.h"
 #include "impl/odescent/odescent_graph_builder.h"
-#include "impl/reorder/flatten_reorder.h"
 #include "impl/searcher/basic_searcher.h"
 #include "index_feature_list.h"
 #include "inner_index_interface.h"
 #include "io/memory_io_parameter.h"
+#include "pyramid_store.h"
 #include "pyramid_zparameters.h"
 #include "quantization/fp32_quantizer_parameter.h"
 #include "query_context.h"
@@ -107,19 +107,15 @@ public:
           max_degree_(pyramid_param->max_degree),
           index_min_size_(pyramid_param->index_min_size),
           graph_type_(pyramid_param->graph_type),
-          support_duplicate_(pyramid_param->support_duplicate) {
-        base_codes_ = FlattenInterface::MakeInstance(pyramid_param->base_codes_param, common_param);
+          support_duplicate_(pyramid_param->support_duplicate),
+          store_(std::make_unique<PyramidStore>(pyramid_param, common_param)) {
+        label_table_ = store_->label_table();
         root_ =
             std::make_unique<IndexNode>(allocator_, pyramid_param->graph_param, index_min_size_);
-        points_mutex_ = std::make_shared<PointsMutex>(max_capacity_, allocator_);
+        points_mutex_ = std::make_shared<PointsMutex>(store_->max_capacity(), allocator_);
         searcher_ = std::make_unique<BasicSearcher>(common_param, points_mutex_);
         no_build_levels_.assign(pyramid_param->no_build_levels.begin(),
                                 pyramid_param->no_build_levels.end());
-        if (use_reorder_) {
-            precise_codes_ =
-                FlattenInterface::MakeInstance(pyramid_param->precise_codes_param, common_param);
-            reorder_ = std::make_shared<FlattenReorder>(precise_codes_, allocator_);
-        }
     }
 
     explicit Pyramid(const ParamPtr& param, const IndexCommonParam& common_param)
@@ -241,24 +237,18 @@ private:
     uint64_t ef_construction_{400};
     int64_t max_degree_{64};
     std::unique_ptr<IndexNode> root_{nullptr};
-    FlattenInterfacePtr base_codes_{nullptr};
-    FlattenInterfacePtr precise_codes_{nullptr};
+    std::unique_ptr<PyramidStore> store_{nullptr};
     std::unique_ptr<VisitedListPool> pool_ = nullptr;
 
     MutexArrayPtr points_mutex_{nullptr};
     std::unique_ptr<BasicSearcher> searcher_ = nullptr;
-    int64_t max_capacity_{0};
-    int64_t cur_element_count_{0};
     float alpha_{1.0F};
     bool support_duplicate_{false};
 
-    mutable std::shared_mutex resize_mutex_;
-    std::mutex cur_element_count_mutex_;
     std::string graph_type_{GRAPH_TYPE_VALUE_NSW};
 
     std::mutex entry_point_mutex_;
     std::default_random_engine level_generator_{2021};
-    ReorderInterfacePtr reorder_{nullptr};
 
     // static
     uint32_t index_min_size_{0};

--- a/src/algorithm/pyramid_store.cpp
+++ b/src/algorithm/pyramid_store.cpp
@@ -1,0 +1,181 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "pyramid_store.h"
+
+#include <algorithm>
+#include <cstring>
+
+#include "common.h"
+#include "datacell/flatten_interface.h"
+#include "impl/logger/logger.h"
+
+namespace vsag {
+
+PyramidStore::PyramidStore(const PyramidParamPtr& pyramid_param,
+                           const IndexCommonParam& common_param)
+    : label_table_(std::make_shared<LabelTable>(
+          common_param.allocator_.get(), true, false, pyramid_param->label_remap_type)),
+      allocator_(common_param.allocator_.get()),
+      dim_(common_param.dim_),
+      use_reorder_(pyramid_param->use_reorder) {
+    base_codes_ = FlattenInterface::MakeInstance(pyramid_param->base_codes_param, common_param);
+    if (use_reorder_) {
+        precise_codes_ =
+            FlattenInterface::MakeInstance(pyramid_param->precise_codes_param, common_param);
+        reorder_ = std::make_shared<FlattenReorder>(precise_codes_, allocator_);
+    }
+}
+
+void
+PyramidStore::Train(const DatasetPtr& base) {
+    CHECK_ARGUMENT(base != nullptr, "base dataset is required");
+    base_codes_->Train(base->GetFloat32Vectors(), base->GetNumElements());
+    if (use_reorder_) {
+        precise_codes_->Train(base->GetFloat32Vectors(), base->GetNumElements());
+    }
+}
+
+void
+PyramidStore::resize_locked(int64_t new_max_capacity, const ResizeCallback& on_resize) {
+    if (new_max_capacity <= max_capacity_) {
+        return;
+    }
+
+    label_table_->Resize(new_max_capacity);
+    base_codes_->Resize(new_max_capacity);
+    if (use_reorder_) {
+        precise_codes_->Resize(new_max_capacity);
+    }
+    if (on_resize != nullptr) {
+        on_resize(new_max_capacity);
+    }
+    max_capacity_ = new_max_capacity;
+}
+
+void
+PyramidStore::Resize(int64_t new_max_capacity, const ResizeCallback& on_resize) {
+    std::unique_lock<std::shared_mutex> lock(resize_mutex_);
+    resize_locked(new_max_capacity, on_resize);
+}
+
+PyramidStore::InsertResult
+PyramidStore::Insert(const DatasetPtr& base,
+                     bool check_duplicate,
+                     const ResizeCallback& on_resize) {
+    CHECK_ARGUMENT(base != nullptr, "base dataset is required");
+    const auto* data_vectors = base->GetFloat32Vectors();
+    const auto* data_ids = base->GetIds();
+    CHECK_ARGUMENT(data_vectors != nullptr, "base vectors are required");
+    CHECK_ARGUMENT(data_ids != nullptr, "base ids are required");
+
+    InsertResult result(allocator_);
+    int64_t data_num = base->GetNumElements();
+    {
+        std::lock_guard lock(cur_element_count_mutex_);
+        auto local_cur_element_count = cur_element_count_;
+        if (max_capacity_ == 0) {
+            Resize(std::max(INIT_CAPACITY, data_num), on_resize);
+        } else if (max_capacity_ < data_num + cur_element_count_) {
+            auto new_capacity = std::min(MAX_CAPACITY_EXTEND, max_capacity_);
+            new_capacity = std::max(data_num + cur_element_count_ - max_capacity_, new_capacity) +
+                           max_capacity_;
+            Resize(new_capacity, on_resize);
+        }
+
+        int64_t valid_id_count = 0;
+        for (int64_t i = 0; i < data_num; ++i) {
+            if (check_duplicate && label_table_->CheckLabel(data_ids[i])) {
+                logger::warn("Label {} already exists, skip adding.", data_ids[i]);
+                result.failed_ids.push_back(data_ids[i]);
+                continue;
+            }
+            auto inner_id = static_cast<InnerIdType>(valid_id_count + local_cur_element_count);
+            label_table_->Insert(inner_id, data_ids[i]);
+            base_codes_->InsertVector(data_vectors + dim_ * i, inner_id);
+            if (use_reorder_) {
+                precise_codes_->InsertVector(data_vectors + dim_ * i, inner_id);
+            }
+            valid_id_count++;
+            result.data_biases.push_back(i);
+            result.inner_ids.push_back(inner_id);
+        }
+        cur_element_count_ += valid_id_count;
+    }
+    return result;
+}
+
+void
+PyramidStore::InsertForBuild(const DatasetPtr& base, const ResizeCallback& on_resize) {
+    CHECK_ARGUMENT(base != nullptr, "base dataset is required");
+    const auto* data_vectors = base->GetFloat32Vectors();
+    const auto* data_ids = base->GetIds();
+    CHECK_ARGUMENT(data_vectors != nullptr, "base vectors are required");
+    CHECK_ARGUMENT(data_ids != nullptr, "base ids are required");
+
+    int64_t data_num = base->GetNumElements();
+    {
+        std::lock_guard lock(cur_element_count_mutex_);
+        Resize(data_num, on_resize);
+        std::memcpy(label_table_->label_table_.data(), data_ids, sizeof(LabelType) * data_num);
+
+        base_codes_->BatchInsertVector(data_vectors, data_num);
+        if (use_reorder_) {
+            precise_codes_->BatchInsertVector(data_vectors, data_num);
+        }
+        cur_element_count_ = data_num;
+    }
+}
+
+void
+PyramidStore::Serialize(StreamWriter& writer) const {
+    label_table_->Serialize(writer);
+    base_codes_->Serialize(writer);
+    if (use_reorder_) {
+        precise_codes_->Serialize(writer);
+    }
+}
+
+void
+PyramidStore::Deserialize(StreamReader& reader) {
+    label_table_->Deserialize(reader);
+    base_codes_->Deserialize(reader);
+    if (use_reorder_) {
+        precise_codes_->Deserialize(reader);
+    }
+    cur_element_count_ = base_codes_->TotalCount();
+}
+
+void
+PyramidStore::ExportModel(PyramidStore& target) const {
+    if (target.use_reorder_ != this->use_reorder_) {
+        throw VsagException(ErrorType::INTERNAL_ERROR,
+                            "Export model's pyramid reorder config mismatched");
+    }
+    this->base_codes_->ExportModel(target.base_codes_);
+    if (use_reorder_) {
+        if (target.precise_codes_ == nullptr) {
+            throw VsagException(ErrorType::INTERNAL_ERROR,
+                                "Export model's pyramid precise codes is empty");
+        }
+        this->precise_codes_->ExportModel(target.precise_codes_);
+    }
+}
+
+void
+PyramidStore::SetImmutable() {
+    label_table_->SetImmutable();
+}
+
+}  // namespace vsag

--- a/src/algorithm/pyramid_store.h
+++ b/src/algorithm/pyramid_store.h
@@ -1,0 +1,139 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <shared_mutex>
+#include <vector>
+
+#include "algorithm/pyramid_zparameters.h"
+#include "datacell/flatten_interface.h"
+#include "impl/label_table.h"
+#include "impl/reorder/flatten_reorder.h"
+#include "impl/reorder/reorder.h"
+#include "index_common_param.h"
+#include "storage/stream_reader.h"
+#include "storage/stream_writer.h"
+#include "typing.h"
+#include "vsag/dataset.h"
+
+namespace vsag {
+
+class PyramidStore {
+public:
+    using ResizeCallback = std::function<void(int64_t)>;
+
+    struct InsertResult {
+        explicit InsertResult(Allocator* allocator) : data_biases(allocator), inner_ids(allocator) {
+        }
+
+        std::vector<int64_t> failed_ids;
+        Vector<int64_t> data_biases;
+        Vector<InnerIdType> inner_ids;
+    };
+
+public:
+    PyramidStore(const PyramidParamPtr& pyramid_param, const IndexCommonParam& common_param);
+
+    void
+    Train(const DatasetPtr& base);
+
+    InsertResult
+    Insert(const DatasetPtr& base, bool check_duplicate, const ResizeCallback& on_resize);
+
+    void
+    InsertForBuild(const DatasetPtr& base, const ResizeCallback& on_resize);
+
+    void
+    Resize(int64_t new_max_capacity, const ResizeCallback& on_resize);
+
+    void
+    Serialize(StreamWriter& writer) const;
+
+    void
+    Deserialize(StreamReader& reader);
+
+    void
+    ExportModel(PyramidStore& target) const;
+
+    [[nodiscard]] std::shared_lock<std::shared_mutex>
+    ResizeLock() const {
+        return std::shared_lock<std::shared_mutex>(resize_mutex_);
+    }
+
+    [[nodiscard]] int64_t
+    GetNumElements() const {
+        return base_codes_->TotalCount();
+    }
+
+    void
+    SetImmutable();
+
+    [[nodiscard]] const LabelTablePtr&
+    label_table() const {
+        return label_table_;
+    }
+
+    [[nodiscard]] const FlattenInterfacePtr&
+    base_codes() const {
+        return base_codes_;
+    }
+
+    [[nodiscard]] const FlattenInterfacePtr&
+    precise_codes() const {
+        return precise_codes_;
+    }
+
+    [[nodiscard]] const ReorderInterfacePtr&
+    reorder() const {
+        return reorder_;
+    }
+
+    [[nodiscard]] bool
+    use_reorder() const {
+        return use_reorder_;
+    }
+
+    [[nodiscard]] int64_t
+    max_capacity() const {
+        return max_capacity_;
+    }
+
+    [[nodiscard]] FlattenInterfacePtr
+    DefaultCodes() const {
+        return use_reorder_ ? precise_codes_ : base_codes_;
+    }
+
+private:
+    void
+    resize_locked(int64_t new_max_capacity, const ResizeCallback& on_resize);
+
+private:
+    LabelTablePtr label_table_{nullptr};
+    FlattenInterfacePtr base_codes_{nullptr};
+    FlattenInterfacePtr precise_codes_{nullptr};
+    ReorderInterfacePtr reorder_{nullptr};
+    Allocator* allocator_{nullptr};
+    uint64_t dim_{0};
+    mutable std::shared_mutex resize_mutex_;
+    std::mutex cur_element_count_mutex_;
+    int64_t max_capacity_{0};
+    int64_t cur_element_count_{0};
+    bool use_reorder_{false};
+};
+
+}  // namespace vsag

--- a/src/analyzer/pyramid_analyzer.cpp
+++ b/src/analyzer/pyramid_analyzer.cpp
@@ -120,7 +120,7 @@ PyramidAnalyzer::AnalyzeIndexBySearch(const SearchRequest& request) {
         get_search_recall(query_num, query_ids, query_ground_truth, query_search_result));
     stats["time_cost_query"].SetFloat(query_time_ms);
 
-    if (pyramid_->use_reorder_) {
+    if (pyramid_->store_->use_reorder()) {
         auto [q_error, q_inversion] =
             calculate_quantization_result(query_datas, query_ids, query_search_result, query_num);
         stats["quantization_error_query"].SetFloat(q_error);
@@ -510,7 +510,7 @@ PyramidAnalyzer::calculate_groundtruth(const Vector<float>& sample_datas,
     Vector<InnerIdType> ids_array(this->total_count_, allocator_);
     std::iota(ids_array.begin(), ids_array.end(), 0);
 
-    auto codes = pyramid_->use_reorder_ ? pyramid_->precise_codes_ : pyramid_->base_codes_;
+    auto codes = pyramid_->store_->DefaultCodes();
 
     for (uint32_t i = 0; i < sample_size; ++i) {
         if (i % 10 == 0) {
@@ -547,7 +547,7 @@ PyramidAnalyzer::get_avg_distance() {
 
 float
 PyramidAnalyzer::get_quantization_error(const std::string& search_param) {
-    if (not pyramid_->use_reorder_ || search_result_.empty()) {
+    if (not pyramid_->store_->use_reorder() || search_result_.empty()) {
         return 0.0F;
     }
 
@@ -557,7 +557,7 @@ PyramidAnalyzer::get_quantization_error(const std::string& search_param) {
 
 float
 PyramidAnalyzer::get_quantization_inversion_ratio(const std::string& search_param) {
-    if (not pyramid_->use_reorder_ || search_result_.empty()) {
+    if (not pyramid_->store_->use_reorder() || search_result_.empty()) {
         return 0.0F;
     }
 
@@ -571,7 +571,7 @@ PyramidAnalyzer::calculate_quantization_result(
     const Vector<InnerIdType>& sample_ids,
     const UnorderedMap<InnerIdType, Vector<LabelType>>& search_result,
     uint32_t sample_size) {
-    if (not pyramid_->use_reorder_) {
+    if (not pyramid_->store_->use_reorder()) {
         return {0.0F, 0.0F};
     }
 
@@ -720,7 +720,7 @@ PyramidAnalyzer::get_search_recall(
         UnorderedSet<LabelType> gt_set(allocator_);
         const auto* gt_data = gt->GetData();
         for (uint32_t j = 0; j < gt->Size(); ++j) {
-            gt_set.insert(pyramid_->label_table_->GetLabelById(gt_data[j].second));
+            gt_set.insert(pyramid_->store_->label_table()->GetLabelById(gt_data[j].second));
         }
 
         uint32_t hit_count = 0;
@@ -795,7 +795,7 @@ PyramidAnalyzer::calculate_node_groundtruth(const IndexNode* node,
         return gt;
     }
 
-    auto codes = pyramid_->use_reorder_ ? pyramid_->precise_codes_ : pyramid_->base_codes_;
+    auto codes = pyramid_->store_->DefaultCodes();
     if (codes == nullptr) {
         return gt;
     }
@@ -832,7 +832,7 @@ PyramidAnalyzer::search_single_node(const IndexNode* node,
             return result;
         }
 
-        auto codes = pyramid_->use_reorder_ ? pyramid_->precise_codes_ : pyramid_->base_codes_;
+        auto codes = pyramid_->store_->DefaultCodes();
         Vector<float> distances(node_ids.size(), allocator_);
         auto computer = codes->FactoryComputer(query);
         codes->Query(distances.data(), computer, node_ids.data(), node_ids.size());
@@ -885,11 +885,16 @@ PyramidAnalyzer::search_single_node(const IndexNode* node,
 
         DistHeapPtr result;
         try {
-            result = pyramid_->search_node(
-                node, vl, inner_param, query_dataset, pyramid_->base_codes_, ctx, ef_search);
+            result = pyramid_->search_node(node,
+                                           vl,
+                                           inner_param,
+                                           query_dataset,
+                                           pyramid_->store_->base_codes(),
+                                           ctx,
+                                           ef_search);
 
-            if (pyramid_->use_reorder_ && result != nullptr && !result->Empty()) {
-                result = pyramid_->reorder_->Reorder(result, query, inner_param.topk, ctx);
+            if (pyramid_->store_->use_reorder() && result != nullptr && !result->Empty()) {
+                result = pyramid_->store_->reorder()->Reorder(result, query, inner_param.topk, ctx);
             }
         } catch (const std::exception& e) {
             logger::error("[search_single_node] search_node threw exception: {}", e.what());
@@ -1023,7 +1028,7 @@ PyramidAnalyzer::get_node_neighbor_recall(const IndexNode* node,
     }
 
     auto graph = node->graph_;
-    auto codes = pyramid_->use_reorder_ ? pyramid_->precise_codes_ : pyramid_->base_codes_;
+    auto codes = pyramid_->store_->DefaultCodes();
     if (codes == nullptr) {
         return 0.0F;
     }
@@ -1464,7 +1469,7 @@ PyramidAnalyzer::get_node_duplicate_ratio(const IndexNode* node,
     }
 
     constexpr float epsilon = 2e-6F;
-    auto codes = pyramid_->base_codes_;
+    auto codes = pyramid_->store_->base_codes();
 
     Vector<Vector<InnerIdType>> groups(allocator_);
     groups.emplace_back(node_ids.begin(), node_ids.end(), allocator_);
@@ -1541,7 +1546,7 @@ PyramidAnalyzer::check_entry_point_duplicate(const IndexNode* node,
     Vector<float> entry_vector(dim_, allocator_);
     pyramid_->GetVectorByInnerId(entry_id, entry_vector.data());
 
-    auto codes = pyramid_->base_codes_;
+    auto codes = pyramid_->store_->base_codes();
     auto comp = codes->FactoryComputer(entry_vector.data());
     Vector<float> dists(node_ids.size(), allocator_);
     codes->Query(dists.data(), comp, node_ids.data(), node_ids.size());

--- a/tests/test_pyramid.cpp
+++ b/tests/test_pyramid.cpp
@@ -530,12 +530,12 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
     auto deserialize_result = restored_index->Deserialize(serialize_binary.value());
     REQUIRE(deserialize_result.has_value());
 
-    auto extra = MakeDenseDataset({{2.0F, 0.0F, 0.0F, 0.0F}}, {505}, {"site/c"});
+    auto extra = MakeDenseDataset({{2.0F, 0.0F, 0.0F, 0.0F}}, {505}, {"site/c/new"});
     auto add_result = restored_index->Add(extra);
     REQUIRE(add_result.has_value());
     REQUIRE(add_result.value().empty());
 
-    auto query = MakeSingleQuery({2.0F, 0.0F, 0.0F, 0.0F}, "site/c");
+    auto query = MakeSingleQuery({2.0F, 0.0F, 0.0F, 0.0F}, "site/c/new");
     auto search_result =
         restored_index->KnnSearch(query, 1, GeneratePyramidSearchParametersString(20));
     REQUIRE(search_result.has_value());

--- a/tests/test_pyramid.cpp
+++ b/tests/test_pyramid.cpp
@@ -502,6 +502,59 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
     vsag::Options::Instance().set_block_size_limit(origin_size);
 }
 
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
+                             "Pyramid Store Extraction Legacy Regression",
+                             "[ft][pyramid][store][serialization]") {
+    PyramidParam pyramid_param;
+    pyramid_param.no_build_levels = {0, 1, 2};
+    pyramid_param.use_reorder = true;
+    pyramid_param.base_quantization_type = "fp32";
+    pyramid_param.precise_quantization_type = "fp32";
+
+    const auto param = GeneratePyramidBuildParametersString("l2", 4, pyramid_param);
+    auto index = TestFactory("pyramid", param, true);
+
+    auto base = MakeDenseDataset({{1.0F, 0.0F, 0.0F, 0.0F},
+                                  {0.0F, 1.0F, 0.0F, 0.0F},
+                                  {0.0F, 0.0F, 1.0F, 0.0F},
+                                  {0.0F, 0.0F, 0.0F, 1.0F}},
+                                 {501, 502, 503, 504},
+                                 {"site/a", "site/b", "date/2026", "date/2027"});
+    auto build_result = index->Build(base);
+    REQUIRE(build_result.has_value());
+
+    auto serialize_binary = index->Serialize();
+    REQUIRE(serialize_binary.has_value());
+
+    auto restored_index = TestFactory("pyramid", param, true);
+    auto deserialize_result = restored_index->Deserialize(serialize_binary.value());
+    REQUIRE(deserialize_result.has_value());
+
+    auto extra = MakeDenseDataset({{2.0F, 0.0F, 0.0F, 0.0F}}, {505}, {"site/c"});
+    auto add_result = restored_index->Add(extra);
+    REQUIRE(add_result.has_value());
+    REQUIRE(add_result.value().empty());
+
+    auto query = MakeSingleQuery({2.0F, 0.0F, 0.0F, 0.0F}, "site/c");
+    auto search_result =
+        restored_index->KnnSearch(query, 1, GeneratePyramidSearchParametersString(20));
+    REQUIRE(search_result.has_value());
+    REQUIRE(search_result.value()->GetDim() == 1);
+    REQUIRE(search_result.value()->GetIds()[0] == 505);
+    RequireDistancesNearZero(search_result.value(), {505});
+
+    auto distance = restored_index->CalcDistanceById(query->GetFloat32Vectors(), 505);
+    REQUIRE(distance.has_value());
+    REQUIRE(std::abs(distance.value()) <= 1e-6F);
+
+    auto stats_str = restored_index->GetStats();
+    REQUIRE(!stats_str.empty());
+    auto stats = nlohmann::json::parse(stats_str);
+    REQUIRE(stats.contains("total_count"));
+    REQUIRE(stats["total_count"].get<int64_t>() == 5);
+    REQUIRE(stats.contains("index_node_structure"));
+}
+
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex, "Pyramid Clone", "[ft][clone][pyramid]") {
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);


### PR DESCRIPTION
## Summary

Refs: #2098

This PR extracts Pyramid-owned vector storage into `PyramidStore` while keeping the current single-hierarchy behavior unchanged.

- Move label table, base codes, precise reorder codes, reorder helper, capacity, count, and resize/count locks into `PyramidStore`.
- Keep Pyramid responsible for the path tree, node graph insertion/search, visited-list pool, points mutex, searcher, and Pyramid config.
- Adapt `PyramidAnalyzer` to read vector data through the store.

## Compatibility

- Legacy Build/Add/Search behavior is intended to remain unchanged.
- Serialization order is unchanged: label table, base codes, optional precise codes, root, footer.
- Duplicate label handling, reorder search, export model, and analyzer output are intended to remain unchanged.

## Validation

- `make fmt`
- `git diff --check`

`make lint` was not run locally because clang-tidy version compatibility is enforced by CI. Full compile/test validation is expected from PR CI.
