### PR TITLE
build: install CMake package config and set library SOVERSION

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ include (cmake/DarwinDep.cmake)                 # macOS-specific dependency hand
 include (cmake/VSAGExternalProjectConfig.cmake) # Shared ExternalProject flags and env.
 include (cmake/VSAGThirdParty.cmake)            # Third-party dependency declarations.
 include (cmake/VSAGDependencyTargets.cmake)     # Shared interface/header dependency targets.
+include (cmake/VSAGVersion.cmake)               # Resolve VSAG_VERSION_{MAJOR,MINOR,PATCH}.
 
 include_directories (${PROJECT_SOURCE_DIR}/include)
 include_directories (${PROJECT_SOURCE_DIR}/src)
@@ -69,5 +70,4 @@ endif ()
 
 include (cmake/VSAGPythonBindings.cmake)  # Optional Python bindings.
 include (cmake/VSAGNodeBindings.cmake)    # Optional Node.js bindings.
-include (cmake/VSAGInstall.cmake)         # Install rules.
-include (cmake/VSAGVersion.cmake)         # Generated version header target.
+include (cmake/VSAGInstall.cmake)         # Install rules and CMake package config.

--- a/README.md
+++ b/README.md
@@ -168,16 +168,38 @@ for (let i = 0; i < 10; i++) {
 </details>
 
 ### Integrate with CMake
+
+If you have already installed vsag (e.g. `cmake --install build-release` or via a
+distribution package), the recommended path is to use the shipped CMake package
+config and the imported `vsag::vsag` target:
+
 ```cmake
 # CMakeLists.txt
-cmake_minimum_required(VERSION 3.18)
-
-project (myproject)
+cmake_minimum_required (VERSION 3.18)
+project (myproject CXX)
 
 set (CMAKE_CXX_STANDARD 11)
 set (CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# download and compile vsag
+find_package (vsag CONFIG REQUIRED)
+
+add_executable (vsag-cmake-example src/main.cpp)
+target_link_libraries (vsag-cmake-example PRIVATE vsag::vsag)
+```
+
+Point CMake at the install prefix via `-DCMAKE_PREFIX_PATH=/path/to/install` if
+vsag is not in a system location.
+
+Alternatively, to fetch and build vsag from source as part of your project:
+
+```cmake
+# CMakeLists.txt
+cmake_minimum_required (VERSION 3.18)
+project (myproject CXX)
+
+set (CMAKE_CXX_STANDARD 11)
+set (CMAKE_CXX_STANDARD_REQUIRED ON)
+
 include (FetchContent)
 FetchContent_Declare (
   vsag
@@ -186,12 +208,9 @@ FetchContent_Declare (
 )
 FetchContent_MakeAvailable (vsag)
 
-# compile executable and link to vsag
 add_executable (vsag-cmake-example src/main.cpp)
 target_include_directories (vsag-cmake-example SYSTEM PRIVATE ${vsag_SOURCE_DIR}/include)
 target_link_libraries (vsag-cmake-example PRIVATE vsag)
-
-# add dependency
 add_dependencies (vsag-cmake-example vsag)
 ```
 

--- a/cmake/VSAGInstall.cmake
+++ b/cmake/VSAGInstall.cmake
@@ -14,12 +14,49 @@
 
 include_guard (GLOBAL)
 
+include (CMakePackageConfigHelpers)
+
+# Where the CMake package config files will live, relative to the install
+# prefix. Picked to match the convention used by most distros and what
+# CMake searches first via CMAKE_PREFIX_PATH.
+set (VSAG_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/vsag")
+
 install (DIRECTORY include/
          DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 
+# Only the shared library participates in the exported package. The static
+# library currently aggregates a number of internal helper targets
+# (`factory`, `algorithm`, `simd`, ...) that are not themselves part of the
+# public install surface, so exporting it would force every helper to be
+# installed and namespaced as well. The static archive is still installed
+# as a file for users who build vsag in-tree, but it is not advertised as
+# a `find_package()` imported target.
 install (TARGETS vsag
+         EXPORT vsagTargets
          LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-         RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
+         RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+         ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+         INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 
 install (TARGETS vsag_static
          ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+
+install (EXPORT vsagTargets
+         FILE vsagTargets.cmake
+         NAMESPACE vsag::
+         DESTINATION "${VSAG_INSTALL_CMAKEDIR}")
+
+configure_package_config_file (
+    "${CMAKE_CURRENT_LIST_DIR}/vsagConfig.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/vsagConfig.cmake"
+    INSTALL_DESTINATION "${VSAG_INSTALL_CMAKEDIR}")
+
+write_basic_package_version_file (
+    "${CMAKE_CURRENT_BINARY_DIR}/vsagConfigVersion.cmake"
+    VERSION "${VSAG_VERSION_TRIPLE}"
+    COMPATIBILITY SameMajorVersion)
+
+install (FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/vsagConfig.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/vsagConfigVersion.cmake"
+    DESTINATION "${VSAG_INSTALL_CMAKEDIR}")

--- a/cmake/VSAGVersion.cmake
+++ b/cmake/VSAGVersion.cmake
@@ -16,16 +16,72 @@ include_guard (GLOBAL)
 
 find_package (Git)
 
+# ---- Configure-time version detection ---------------------------------------
+#
+# Resolve VSAG_VERSION (full git-describe string) and the parsed numeric
+# triple VSAG_VERSION_MAJOR/MINOR/PATCH up-front so they can drive
+# set_target_properties(... VERSION SOVERSION) on the library and
+# write_basic_package_version_file() on the installed CMake config package.
+#
+# The richer git-describe string (including -dirty / -gSHA suffix) is still
+# regenerated at build time via the `version` custom target below so the
+# in-binary VSAG_VERSION reflects the exact source tree.
+#
+# `VSAG_VERSION` may be supplied externally (e.g. `-DVSAG_VERSION=v1.2.3` for
+# package maintainers building from a source tarball without a .git tree).
+# Only fall back to `git describe` when no value has been provided.
+# Use ${PROJECT_SOURCE_DIR} so the lookup still resolves to the vsag tree
+# when this project is consumed via add_subdirectory()/FetchContent.
+
+if (NOT DEFINED VSAG_VERSION OR VSAG_VERSION STREQUAL "")
+    if (GIT_EXECUTABLE)
+        execute_process (
+            COMMAND ${GIT_EXECUTABLE} describe --tags --always --dirty --match "v*"
+            WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+            OUTPUT_VARIABLE _vsag_git_describe
+            RESULT_VARIABLE _vsag_git_describe_rc
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            ERROR_QUIET)
+        if (NOT _vsag_git_describe_rc)
+            set (VSAG_VERSION "${_vsag_git_describe}")
+        endif ()
+    endif ()
+endif ()
+
+if (NOT DEFINED VSAG_VERSION OR VSAG_VERSION STREQUAL "")
+    set (VSAG_VERSION "v0.0.0-unknown")
+    message (WARNING
+        "Failed to determine VSAG_VERSION from Git tags. "
+        "Using default version \"${VSAG_VERSION}\".")
+endif ()
+
+string (REGEX MATCH "^v?([0-9]+)\\.([0-9]+)\\.([0-9]+)" _vsag_ver_match "${VSAG_VERSION}")
+if (_vsag_ver_match)
+    set (VSAG_VERSION_MAJOR "${CMAKE_MATCH_1}")
+    set (VSAG_VERSION_MINOR "${CMAKE_MATCH_2}")
+    set (VSAG_VERSION_PATCH "${CMAKE_MATCH_3}")
+else ()
+    set (VSAG_VERSION_MAJOR 0)
+    set (VSAG_VERSION_MINOR 0)
+    set (VSAG_VERSION_PATCH 0)
+endif ()
+
+set (VSAG_VERSION_TRIPLE
+    "${VSAG_VERSION_MAJOR}.${VSAG_VERSION_MINOR}.${VSAG_VERSION_PATCH}")
+
+message (STATUS "vsag version: ${VSAG_VERSION} (parsed ${VSAG_VERSION_TRIPLE})")
+
+# ---- Build-time regeneration of src/version.h -------------------------------
+#
+# The custom target itself does not depend on any library target, so it can
+# be created here as part of configure-time setup. It is wired as a
+# build-order dependency of `vsag` / `vsag_static` next to those targets'
+# declarations in src/CMakeLists.txt.
+
 add_custom_target (version
     ${CMAKE_COMMAND}
-    -D SRC=${CMAKE_CURRENT_SOURCE_DIR}/src/version.h.in
-    -D DST=${CMAKE_CURRENT_SOURCE_DIR}/src/version.h
+    -D SRC=${PROJECT_SOURCE_DIR}/src/version.h.in
+    -D DST=${PROJECT_SOURCE_DIR}/src/version.h
     -D GIT_EXECUTABLE=${GIT_EXECUTABLE}
-    -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/GenerateVersionHeader.cmake)
-
-if (TARGET vsag)
-    add_dependencies (vsag version)
-endif ()
-if (TARGET vsag_static)
-    add_dependencies (vsag_static version)
-endif ()
+    -D VSAG_VERSION=${VSAG_VERSION}
+    -P ${PROJECT_SOURCE_DIR}/cmake/GenerateVersionHeader.cmake)

--- a/cmake/vsagConfig.cmake.in
+++ b/cmake/vsagConfig.cmake.in
@@ -1,0 +1,18 @@
+@PACKAGE_INIT@
+
+# vsagConfig.cmake — entry point for `find_package(vsag CONFIG REQUIRED)`.
+#
+# Usage:
+#
+#   find_package(vsag CONFIG REQUIRED)
+#   target_link_libraries(my_app PRIVATE vsag::vsag)
+#
+# Imported targets:
+#   vsag::vsag — the shared library (recommended for consumption).
+#
+# vsag's public headers in <vsag/*.h> only depend on the C++ standard library,
+# so no transitive find_dependency() calls are required here.
+
+include ("${CMAKE_CURRENT_LIST_DIR}/vsagTargets.cmake")
+
+check_required_components (vsag)

--- a/include/vsag/dataset.h
+++ b/include/vsag/dataset.h
@@ -18,7 +18,6 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
-#include <variant>
 #include <vector>
 
 #include "vsag/allocator.h"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,19 +37,45 @@ set (VSAG_SRCS ${CPP_SRCS} ${CPP_INDEX_SRCS})
 add_library (vsag SHARED ${VSAG_SRCS})
 add_library (vsag_static STATIC ${VSAG_SRCS})
 
+# Trigger build-time regeneration of src/version.h before vsag's TUs compile.
+add_dependencies (vsag version)
+add_dependencies (vsag_static version)
+
 set_target_properties (vsag PROPERTIES
     C_VISIBILITY_PRESET default
     CXX_VISIBILITY_PRESET default
-    VISIBILITY_INLINES_HIDDEN OFF)
+    VISIBILITY_INLINES_HIDDEN OFF
+    VERSION "${VSAG_VERSION_TRIPLE}"
+    SOVERSION "${VSAG_VERSION_MAJOR}")
+
+# Public include directory: usable both during the build (BUILD_INTERFACE)
+# and after `make install` from a downstream find_package() consumer
+# (INSTALL_INTERFACE).
+foreach (_lib vsag vsag_static)
+    target_include_directories (${_lib}
+        PUBLIC
+            $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+endforeach ()
 
 set (VSAG_DEP_LIBS antlr4-autogen antlr4-runtime diskann simd io quantizer storage utils factory analyzer
       datacell ${IMPL_LIBS} ${ALGORITHM_LIBS} attr pthread m dl fmt::fmt nlohmann_json::nlohmann_json roaring ${BLAS_LIBRARIES})
 
+# `vsag_src_common` aggregates third-party include paths and link
+# dependencies (fmt::fmt, nlohmann_json::nlohmann_json, tsl::robin_map, and
+# several internal *_headers INTERFACE libraries) that vsag's own source
+# files use during compilation. None of these targets appear in vsag's
+# public API headers, so they should not be propagated to install-side
+# consumers via the exported target file. They are still propagated to
+# in-tree consumers (examples, tests, tools) that include vsag headers
+# directly via add_subdirectory(), since some of those targets transitively
+# rely on, e.g., <nlohmann/json.hpp>. Wrapping the link in BUILD_INTERFACE
+# is what gives us both: PUBLIC propagation in-tree, no leakage on install.
 target_link_libraries (vsag
-    PUBLIC vsag_src_common
+    PUBLIC $<BUILD_INTERFACE:vsag_src_common>
     PRIVATE ${VSAG_DEP_LIBS} coverage_config)
 target_link_libraries (vsag_static
-    PUBLIC vsag_src_common
+    PUBLIC $<BUILD_INTERFACE:vsag_src_common>
     PRIVATE ${VSAG_DEP_LIBS} coverage_config)
 
 maybe_add_dependencies (vsag antlr4 roaring boost)


### PR DESCRIPTION
## Summary

- Generate and install a CMake package config (`vsagConfig.cmake`, `vsagConfigVersion.cmake`, `vsagTargets.cmake`) under `${CMAKE_INSTALL_LIBDIR}/cmake/vsag/`, so downstream projects can do:

  ```cmake
  find_package (vsag CONFIG REQUIRED)
  target_link_libraries (my_app PRIVATE vsag::vsag)
  ```

  closing one of the gaps flagged in a recent v1.0 readiness review of vsag's open-source library polish.
- Set `VERSION` / `SOVERSION` on the shared library so `make install` produces the standard `libvsag.so` → `libvsag.so.<MAJOR>` → `libvsag.so.<MAJOR>.<MINOR>.<PATCH>` symlink triple required by distro packaging and ABI-aware loaders.
- Resolve `VSAG_VERSION_{MAJOR,MINOR,PATCH}` from `git describe` at configure time (in addition to the existing build-time `src/version.h` regeneration) so both `set_target_properties(... VERSION SOVERSION)` and `write_basic_package_version_file()` have a real numeric triple to consume.
- Restrict the internal `vsag_src_common` INTERFACE helper to `$<BUILD_INTERFACE:>` so the exported targets file does not reference helper targets that are not part of the install set; vsag's public headers do not transitively expose any of those internal third-party headers, so this is safe.
- Update README "Integrate with CMake" to lead with the `find_package` + `vsag::vsag` recipe and keep the existing `FetchContent` recipe as an alternative.

## Test plan

- [x] Configure + build `vsag` shared library with the new rules; verify `libvsag.so` / `libvsag.so.0` / `libvsag.so.0.18.0` symlinks are created in the build tree.
- [x] `DESTDIR=/tmp/... cmake --install build-release` produces the expected layout:
  - `lib/cmake/vsag/{vsagConfig.cmake, vsagConfigVersion.cmake, vsagTargets.cmake, vsagTargets-release.cmake}`
  - `lib/libvsag.so{,.0,.0.18.0}` and `lib/libvsag_static.a`
  - `include/vsag/*.h`
- [x] In a minimal external project, `find_package (vsag CONFIG REQUIRED)` against `CMAKE_PREFIX_PATH=<install prefix>` succeeds and reports `vsag_FOUND=1`, `vsag_VERSION=0.18.0`, and resolves `vsag::vsag` to the installed `libvsag.so.0.18.0` with the correct `INTERFACE_INCLUDE_DIRECTORIES`.
- [ ] CI: `make fmt`, `make lint`, ASAN/TSAN test suites (delegated to PR CI).

## Out of scope / known follow-up

vsag's runtime third-party shared dependencies (`libroaring.so`, `libfmt.so`, ...) are still not installed alongside `libvsag.so`, so a downstream link against the install tree currently still fails at link time on those symbols. That is a **pre-existing** packaging gap (the previous `install(TARGETS vsag ...)` rules had the same omission) and is intentionally **not** addressed here — fixing it requires either installing those shared libs alongside vsag, switching to static linkage of fmt/roaring/etc into `libvsag.so`, or documenting that consumers must install those packages separately. The package-config plumbing added by this PR is the prerequisite that makes `find_package(vsag)` even viable; the transitive dep packaging can be addressed in a follow-up without further CMake-config churn.

Notes:
- `vsag_static` is intentionally **not** part of the exported target set in this PR. It currently aggregates a number of internal helper STATIC/OBJECT libraries (`factory`, `algorithm`, `simd`, ...) whose own install rules would need to be added to make `install(EXPORT)` accept it. The static archive is still installed as a file for in-tree users; we can add `vsag::vsag_static` in a follow-up if there is demand.
- `COMPATIBILITY SameMajorVersion` is appropriate for vsag's stated SemVer policy (`MAJOR` bump = ABI break) per `docs/.../release_notes.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)