### PR TITLE
chore: add Apache 2.0 license headers to remaining source files

### DIFF
--- a/src/impl/blas/blas_compat.h
+++ b/src/impl/blas/blas_compat.h
@@ -1,3 +1,17 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #if defined(VSAG_USE_MKL_HEADERS)

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -1,3 +1,17 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <fmt/format.h>
 
 #include <future>

--- a/src/version.h.in
+++ b/src/version.h.in
@@ -1,3 +1,17 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef VSAG_VERSION_H_
 #define VSAG_VERSION_H_
 #define VSAG_VERSION "@VSAG_VERSION@"


### PR DESCRIPTION
## Summary

A repo-wide scan of `src/` and `include/` for the Apache 2.0 license header turned up three tracked files that still lack one:

- `src/reader.cpp`
- `src/version.h.in` — template; the generated `src/version.h` is gitignored and inherits the header on rebuild
- `src/impl/blas/blas_compat.h`

After this PR every tracked `*.cpp` / `*.h` under `src/` and `include/` carries the standard `// Copyright 2024-present the vsag project` block (matching the format used across the rest of the tree, e.g. `src/dataset_impl.cpp`). No code change.

## Test plan

- [x] `find src include \( -name "*.cpp" -o -name "*.h" \) -exec grep -L "Licensed under the Apache License" {} \;` — returns only the gitignored generated `src/version.h`, which gets the header from `version.h.in` on the next build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)