### PR TITLE
docs: add per-language README to examples/{cpp,python,typescript}/

### DIFF
--- a/examples/cpp/README.md
+++ b/examples/cpp/README.md
@@ -1,0 +1,122 @@
+# VSAG C++ Examples
+
+Small, self-contained C++ programs that show how to build, query, and
+manage VSAG indexes from native code. Each file is independent: pick
+one, read it top-to-bottom, then adapt it to your data.
+
+## Prerequisites
+
+- A C++17 (or newer) compiler (`clang-format` / `clang-tidy` 15 are
+  required only for development, not for running these examples).
+- CMake 3.18+.
+- The build prerequisites listed in
+  [`docs/agents/build-and-test.md`](../../docs/agents/build-and-test.md).
+
+## Build
+
+Examples are gated behind `ENABLE_EXAMPLES=ON`. The shortest path is
+`make dev`, which enables tests, Python bindings, tools, mockimpl, and
+the examples in a single configure:
+
+```bash
+make dev
+# binaries land in build/examples/cpp/
+./build/examples/cpp/101_index_hnsw
+```
+
+To build only one example without the full developer set:
+
+```bash
+cmake -B build -DENABLE_EXAMPLES=ON
+cmake --build build --target 101_index_hnsw
+./build/examples/cpp/101_index_hnsw
+```
+
+## File naming convention
+
+Examples are grouped by a three-digit prefix so related ones sit
+together when the directory is listed:
+
+| Prefix | Topic |
+| --- | --- |
+| `1xx` | Index types — one example per supported algorithm. |
+| `2xx` | Resource management — allocator, logger, thread pool injection. |
+| `3xx` | Per-search and per-index features — filter, range search, remove, update, introspection, tuning. |
+| `4xx` | Persistence — serializing and streaming an index in/out of storage. |
+| `5xx` | Quantization — quantizer-level recipes. |
+
+## Examples
+
+### Index types
+
+| File | Index | Notes |
+| --- | --- | --- |
+| [`101_index_hnsw.cpp`](101_index_hnsw.cpp) | HNSW | The shortest "build + KNN" round-trip; start here. |
+| [`102_index_diskann.cpp`](102_index_diskann.cpp) | DiskANN | Disk-resident graph; links against `vsag_static`. |
+| [`103_index_hgraph.cpp`](103_index_hgraph.cpp) | HGraph | VSAG's headline in-memory graph index. |
+| [`104_index_fresh_hnsw.cpp`](104_index_fresh_hnsw.cpp) | Fresh HNSW | HNSW variant that supports incremental updates. |
+| [`105_index_brute_force.cpp`](105_index_brute_force.cpp) | BruteForce | Exact reference for recall calibration. |
+| [`106_index_ivf.cpp`](106_index_ivf.cpp) | IVF | Inverted file, tuned for large-`k` / batch queries. |
+| [`107_index_pyramid.cpp`](107_index_pyramid.cpp) | Pyramid | Multi-tenant index. |
+| [`108_index_gno_imi.cpp`](108_index_gno_imi.cpp) | GNO-IMI | IVF variant with multi-index partitioning. |
+| [`109_index_sindi.cpp`](109_index_sindi.cpp) | SINDI | Sparse vector index (text / inverted retrieval). |
+| [`110_index_warp.cpp`](110_index_warp.cpp) | Warp | Hybrid index. |
+| [`316_index_int8_hgraph.cpp`](316_index_int8_hgraph.cpp) | HGraph + INT8 | HGraph with INT8-quantized vectors. |
+| [`321_index_fp16_hgraph.cpp`](321_index_fp16_hgraph.cpp) | HGraph + FP16 | HGraph with FP16-quantized vectors. |
+
+> Note: `316_*` and `321_*` carry a `3xx` numeric prefix for historical
+> reasons but are topically index-type demos, so they are grouped here
+> rather than under "Per-index / per-search features" below.
+
+### Resource management (`2xx`)
+
+| File | What it shows |
+| --- | --- |
+| [`201_custom_allocator.cpp`](201_custom_allocator.cpp) | Plug in a custom `vsag::Allocator` for per-index memory isolation. |
+| [`202_custom_logger.cpp`](202_custom_logger.cpp) | Redirect VSAG's logs to your own sink. |
+| [`203_custom_thread_pool.cpp`](203_custom_thread_pool.cpp) | Inject a custom `vsag::ThreadPool` to control parallelism. |
+
+### Per-index / per-search features (`3xx`)
+
+| File | What it shows |
+| --- | --- |
+| [`301_feature_filter.cpp`](301_feature_filter.cpp) | Filtered KNN search via `vsag::Filter`. |
+| [`302_feature_range_search.cpp`](302_feature_range_search.cpp) | Range search (`RangeSearch`). |
+| [`303_feature_remove.cpp`](303_feature_remove.cpp) | Soft-remove ids from an index. |
+| [`304_feature_enhance_graph.cpp`](304_feature_enhance_graph.cpp) | Continuous graph enhancement (Conjugate Graph). |
+| [`305_feature_update.cpp`](305_feature_update.cpp) | In-place id/vector update. |
+| [`306_feature_calculate_distance_by_id.cpp`](306_feature_calculate_distance_by_id.cpp) | `CalcDistanceById` API. |
+| [`307_feature_check_features.cpp`](307_feature_check_features.cpp) | Query an index's capability flags (`CheckFeature`). |
+| [`308_feature_estimate_memory.cpp`](308_feature_estimate_memory.cpp) | Pre-build memory estimation. |
+| [`309_feature_clone.cpp`](309_feature_clone.cpp) | Clone an index without re-building. |
+| [`310_feature_export_model.cpp`](310_feature_export_model.cpp) | Export the trained model component. |
+| [`311_feature_train.cpp`](311_feature_train.cpp) | Train a model separately from build. |
+| [`312_feature_odescent.cpp`](312_feature_odescent.cpp) | OD-Escent graph construction. |
+| [`313_feature_search_allocator.cpp`](313_feature_search_allocator.cpp) | Per-search scratch allocator. |
+| [`314_feature_hgraph_search_allocator.cpp`](314_feature_hgraph_search_allocator.cpp) | Per-search scratch allocator on HGraph. |
+| [`315_feature_hgraph_merge.cpp`](315_feature_hgraph_merge.cpp) | Merge multiple HGraph indexes (FGIM). |
+| [`317_feature_get_detail_data.cpp`](317_feature_get_detail_data.cpp) | Introspect raw index detail data. |
+| [`318_feature_tune.cpp`](318_feature_tune.cpp) | Online `Tune()` optimizer. |
+| [`319_feature_get_memory_usage.cpp`](319_feature_get_memory_usage.cpp) | Live memory-usage reporting. |
+| [`320_feature_extra_info.cpp`](320_feature_extra_info.cpp) | Attach per-vector extra info / payload. |
+
+### Persistence (`4xx`)
+
+| File | What it shows |
+| --- | --- |
+| [`401_persistent_kv.cpp`](401_persistent_kv.cpp) | Serialize / deserialize against a key-value backend. |
+| [`402_persistent_streaming.cpp`](402_persistent_streaming.cpp) | Streaming serialization for large indexes. |
+
+### Quantization (`5xx`)
+
+| File | What it shows |
+| --- | --- |
+| [`501_quantization_transform.cpp`](501_quantization_transform.cpp) | Transform Quantizer (TQ) recipe. |
+
+## Where to go next
+
+- For the equivalent recipes in other languages, see
+  [`examples/python/`](../python/) and [`examples/typescript/`](../typescript/).
+- For deeper conceptual material, see the user guide at
+  [https://vsag.io/docs](https://vsag.io/docs) or its in-repo source
+  under [`docs/docs/en/src/`](../../docs/docs/en/src/).

--- a/examples/python/README.md
+++ b/examples/python/README.md
@@ -1,0 +1,58 @@
+# VSAG Python Examples
+
+Short Python programs that exercise `pyvsag`, VSAG's official Python
+binding. Each example builds a small index from random vectors and
+runs a k-NN search; pick one as a template and swap in your data.
+
+## Prerequisites
+
+- Python 3.8+ (see the [PyPI page](https://pypi.org/project/pyvsag/)
+  for the exact set of supported interpreters per release).
+- NumPy.
+- `pyvsag` itself:
+  ```bash
+  pip install pyvsag
+  ```
+
+For local development against an in-tree build of VSAG, follow the
+[Python bindings build instructions](../../python_bindings/) instead
+of installing from PyPI.
+
+## Run
+
+```bash
+pip install pyvsag numpy
+python examples/python/101_index_hnsw.py
+```
+
+## File naming convention
+
+Numbered examples mirror the numbering in
+[`../cpp/`](../cpp/README.md) so a given prefix means the same topic
+across languages. The legacy `example_*.py` files predate that scheme
+and are kept for backward compatibility — prefer the numbered ones for
+new code.
+
+## Examples
+
+| File | Index | Notes |
+| --- | --- | --- |
+| [`101_index_hnsw.py`](101_index_hnsw.py) | HNSW | Shortest "build + KNN" round-trip; start here. |
+| [`102_index_diskann.py`](102_index_diskann.py) | DiskANN | Disk-resident graph index. |
+| [`103_index_hgraph.py`](103_index_hgraph.py) | HGraph | VSAG's headline in-memory graph index. |
+| [`105_index_brute_force.py`](105_index_brute_force.py) | BruteForce | Exact reference for recall calibration. |
+| [`106_index_ivf.py`](106_index_ivf.py) | IVF | Inverted file, tuned for large-`k` / batch queries. |
+| [`109_index_sindi.py`](109_index_sindi.py) | SINDI | Sparse vector index (text / inverted retrieval). |
+| [`example_hnsw.py`](example_hnsw.py) | HNSW (legacy) | Kept for backward compatibility; prefer `101_*.py`. |
+| [`example_diskann.py`](example_diskann.py) | DiskANN (legacy) | Kept for backward compatibility; prefer `102_*.py`. |
+
+## Where to go next
+
+- The C++ examples in [`../cpp/`](../cpp/README.md) cover topics not yet
+  available in Python (custom allocator / thread pool, range search,
+  filtered search, serialization, `Tune` optimizer, extra info,
+  persistent streaming, …). Contributions to add Python counterparts
+  are welcome — see
+  [`CONTRIBUTING.md`](../../CONTRIBUTING.md).
+- For deeper conceptual material, see the user guide at
+  [https://vsag.io/docs](https://vsag.io/docs).

--- a/examples/typescript/README.md
+++ b/examples/typescript/README.md
@@ -1,0 +1,56 @@
+# VSAG TypeScript / Node.js Examples
+
+Small Node.js / TypeScript programs that exercise `vsag`, VSAG's
+official Node.js binding.
+
+> **Note.** The TypeScript binding is still early — the package version
+> on npm trails the C++ library, and not every C++ feature is wrapped
+> yet. Treat these examples as a starting point and expect the surface
+> to grow over time. Contributions welcome — see
+> [`CONTRIBUTING.md`](../../CONTRIBUTING.md).
+
+## Prerequisites
+
+- Node.js 16+ (matches the `engines.node` field in
+  [`../../typescript/package.json`](../../typescript/package.json)).
+- The `vsag` package. For a published version:
+  ```bash
+  npm install vsag
+  ```
+  For local development against an in-tree build, follow the build
+  steps in [`../../typescript/`](../../typescript/) (`npm run build`
+  there produces `dist/` and the native addon).
+
+## Run
+
+```bash
+npx ts-node examples/typescript/101_index_hnsw.ts
+```
+
+…or compile first and run with plain `node`:
+
+```bash
+npx tsc examples/typescript/101_index_hnsw.ts \
+    --target es2020 --module commonjs --esModuleInterop
+node examples/typescript/101_index_hnsw.js
+```
+
+## File naming convention
+
+Numbered examples mirror the numbering in
+[`../cpp/`](../cpp/README.md) — a given prefix means the same topic
+across languages.
+
+## Examples
+
+| File | Index | Notes |
+| --- | --- | --- |
+| [`101_index_hnsw.ts`](101_index_hnsw.ts) | HNSW | Shortest "build + KNN" round-trip in TypeScript. |
+
+## Where to go next
+
+- The C++ examples in [`../cpp/`](../cpp/README.md) and Python examples
+  in [`../python/`](../python/README.md) cover index types and
+  features not yet exposed through the Node binding.
+- For deeper conceptual material, see the user guide at
+  [https://vsag.io/docs](https://vsag.io/docs).


### PR DESCRIPTION
## Summary

None of the three example directories had a README, so a new user landing in `examples/` had to scan 35 (C++) / 8 (Python) / 1 (TypeScript) filenames and guess where to start.

Add a README per directory that documents:

- **Prerequisites and the build / run invocation** appropriate for that language: `make dev` + `cmake --build` for C++, `pip install pyvsag` for Python, `npm install vsag` for Node.js / TypeScript.
- **The shared three-digit naming convention** (1xx index types, 2xx resource management, 3xx features, 4xx persistence, 5xx quantization) so the same prefix means the same topic across languages.
- **A table of every example file** in that directory, with a one-line description of what it demonstrates and which index / feature it exercises.
- **Cross-links** between the three READMEs and out to the user guide (vsag.io/docs / `docs/docs/en/src/`) for deeper material.

The Python README also calls out the legacy `example_*.py` pair (kept for backward compatibility), and the TypeScript README notes that the Node binding is still early and trails the C++ surface so users set expectations correctly.

No code change; no example file is moved, renamed, or rewritten.

## Test plan

- [x] Renders cleanly on GitHub (tables, links).
- [ ] Maintainer review: confirm one-line descriptions are accurate (file naming was used as the source of truth; happy to amend any that I misread).

🤖 Generated with [Claude Code](https://claude.com/claude-code)