### PR TITLE
feat(sparse): add optional token_sequences to sparse HDF5 datasets

### DIFF
--- a/docs/dataset_format.md
+++ b/docs/dataset_format.md
@@ -19,8 +19,8 @@ benchmark datasets.
 - **Values**:
     - `"dense"` (or attribute missing): `/train` and `/test` are
       `(N, D)` matrices, see [Dense layout](#dense-layout).
-    - `"sparse"`: `/train` and `/test` are one-dimensional byte streams,
-      see [Sparse layout](#sparse-layout).
+    - `"sparse"`: `/train` and `/test` are flat byte streams of shape
+      `(X,)`, see [Sparse layout](#sparse-layout).
 
 ---
 
@@ -110,14 +110,16 @@ benchmark datasets.
 
 When the file-level `type` attribute equals `"sparse"`, the `/train` and
 `/test` datasets do **not** follow the `(N, D)` dense matrix layout.
-Instead they are stored as a one-dimensional `INT8` (`H5T_INTEGER` of
-size 1) dataset whose payload is a raw byte stream of packed sparse
-vectors. The `int8` storage class is a transport detail only; the bytes
-are not int8 vector elements.
+Instead they are stored as a flat `INT8` (`H5T_INTEGER` of size 1)
+dataset whose payload is a raw byte stream of packed sparse vectors.
+Calling `f["/train"].shape` from h5py returns `(X,)` where `X` is the
+total number of bytes; the `int8` storage class is a transport detail
+only — the bytes are not int8 vector elements.
 
 ### `/train`, `/test` (sparse byte stream)
 - **HDF5 type**: `H5T_INTEGER`, size 1 (`INT8`)
-- **HDF5 shape**: 1-D, total length = sum of per-vector record sizes
+- **HDF5 shape**: `(X,)`, where `X` is the total byte-stream length
+  (sum of all per-vector record sizes)
 - **Endianness**: little-endian
 - **Content**: a contiguous sequence of records, one per sparse vector,
   in order. Each record has the layout:
@@ -135,6 +137,97 @@ are not int8 vector elements.
 - **Key ordering**: on load, the eval tool sorts each vector's `ids` in
   ascending order (and reorders `vals` accordingly). Writers may emit
   unordered keys, but readers should not depend on that.
+
+### `/train_offsets`, `/test_offsets` (random-access index, optional)
+
+These two datasets store the per-record byte offsets into the
+corresponding `/train` and `/test` byte streams so that the i-th sparse
+vector can be located in **O(1)** without scanning the stream.
+
+- **HDF5 type**: `H5T_INTEGER`, size 8 (`UINT64`)
+- **HDF5 shape**: `(N + 1,)` for `/train_offsets` and `(Q + 1,)` for
+  `/test_offsets`
+- **Content**: `offsets[i]` is the byte offset where record `i` starts
+  inside the matching byte stream; `offsets[N]` is the sentinel and
+  equals the total byte stream size, so the size of record `i` is
+  `offsets[i + 1] - offsets[i]`. The array is non-decreasing.
+
+Both datasets are **optional**. Writers in this repository always emit
+them when writing sparse files, but legacy sparse HDF5 files that only
+contain `/train` and `/test` keep loading: the offsets are recomputed on
+load by walking the byte stream once. When the on-disk offsets are
+present, they are cross-checked against the recomputed offsets and the
+file is rejected as corrupted on any mismatch.
+
+Example random access (Python):
+
+```python
+import h5py, numpy as np
+
+with h5py.File("sparse.hdf5") as f:
+    buf = f["/train"][:]                        # shape (X,), INT8 byte stream
+    off = f["/train_offsets"][:]                # shape (N+1,), UINT64
+
+def get_sparse_record(byte_stream, offsets, i):
+    start, end = int(offsets[i]), int(offsets[i + 1])
+    rec = byte_stream[start:end].tobytes()
+    ln = int(np.frombuffer(rec, dtype="<u4", count=1)[0])
+    ids = np.frombuffer(rec, dtype="<u4", count=ln, offset=4)
+    vals = np.frombuffer(rec, dtype="<f4", count=ln, offset=4 + ln * 4)
+    return ids, vals
+```
+
+### `/train_token_sequences`, `/test_token_sequences` (optional)
+
+These two datasets carry the **original tokenized document** that
+produced each sparse vector. They are entirely optional: sparse HDF5
+files that omit both datasets still load correctly. When present, they
+must appear in lockstep with `/train` and `/test`: the i-th record in
+`/train_token_sequences` corresponds to the i-th sparse vector in
+`/train` (same for `/test`).
+
+- **HDF5 type**: `H5T_INTEGER`, size 1 (`INT8`)
+- **HDF5 shape**: `(X,)`, where `X` is the total byte-stream length
+  (sum of all per-record sizes)
+- **Endianness**: little-endian
+- **Content**: a contiguous sequence of records, one per sparse vector,
+  in the same order as `/train` / `/test`. Each record has the layout:
+
+  | Field            | Type        | Size                | Description                                  |
+  |------------------|-------------|---------------------|----------------------------------------------|
+  | `seq_len`        | `uint32`    | 4 bytes             | Number of tokens in the original document    |
+  | `term_ids[seq_len]` | `uint32[]` | `4 * seq_len` bytes | Term ids in tokenization order (duplicates and order are preserved) |
+
+  Records are concatenated back-to-back with no padding or separators.
+  A `seq_len == 0` record is allowed and occupies only the 4-byte
+  length field; readers should treat it as "no original document
+  available for this vector".
+
+- **Number of records**: must equal the number of sparse vectors in the
+  matching split. Readers raise an error if the counts disagree or if
+  the stream is truncated.
+- **Ordering vs. `ids`**: `term_ids` are stored in the original token
+  order (with possible duplicates). This is intentionally **different**
+  from `ids`, which the loader sorts ascending and deduplicates.
+
+### `/train_token_sequences_offsets`, `/test_token_sequences_offsets` (required when sequences are present)
+
+Whenever `/train_token_sequences` (resp. `/test_token_sequences`) is
+present, the paired `UINT64` offset index **must** also be present.
+
+- **HDF5 type**: `H5T_INTEGER`, size 8 (`UINT64`)
+- **HDF5 shape**: `(N + 1,)` (resp. `(Q + 1,)`)
+- **Content**: identical contract to `/train_offsets` —
+  `offsets[i]` is the byte offset of the i-th token-sequence record,
+  and `offsets[N]` equals the total byte stream length. This makes
+  per-record random access O(1) without scanning the stream.
+
+Contract: the byte-stream dataset and its offsets dataset **live or die
+together**. Readers reject the file if exactly one of the pair exists
+(either a `*_token_sequences` dataset without its `*_offsets`, or vice
+versa). When both are present, the on-disk offsets are cross-checked
+against the offsets rebuilt from the byte stream; a mismatch is treated
+as corruption and aborts the load.
 
 ### Distance metric
 

--- a/docs/docs/en/src/resources/dataset_format.md
+++ b/docs/docs/en/src/resources/dataset_format.md
@@ -8,8 +8,8 @@ debug failing evaluations.
 
 The dataset layout described below is the **dense** layout (selected by the global
 attribute `type="dense"`, or by omitting the attribute). For **sparse** datasets
-(`type="sparse"`), `/train` and `/test` are 1-D `INT8` byte streams produced by VSAG's
-sparse-vector serialization (decoded by `parse_sparse_vectors` in
+(`type="sparse"`), `/train` and `/test` are flat `INT8` byte streams of shape `(X,)`
+produced by VSAG's sparse-vector serialization (decoded by `parse_sparse_vectors` in
 `tools/eval/eval_dataset.cpp`); all other datasets and attributes below still apply.
 
 ## Mandatory Datasets
@@ -150,15 +150,17 @@ flat array plus the counts, then passes the full array to
 ## Sparse layout
 
 When the global attribute `type` equals `"sparse"`, `/train` and `/test` do **not** follow
-the `(N, D)` dense matrix layout. They are instead stored as one-dimensional `INT8`
+the `(N, D)` dense matrix layout. They are instead stored as flat `INT8`
 (`H5T_INTEGER`, size 1) datasets whose payload is a raw byte stream of packed sparse
-vectors. The `int8` storage class is a transport detail only; the bytes are not int8
-vector elements.
+vectors. Calling `f["/train"].shape` from h5py returns `(X,)` where `X` is the total
+number of bytes; the `int8` storage class is a transport detail only — the bytes are
+not int8 vector elements.
 
 ### `/train`, `/test` (sparse byte stream)
 
 - **HDF5 type**: `H5T_INTEGER`, size 1 (`INT8`)
-- **HDF5 shape**: 1-D; total length equals the sum of per-vector record sizes
+- **HDF5 shape**: `(X,)`, where `X` is the total byte-stream length
+  (sum of all per-vector record sizes)
 - **Endianness**: little-endian
 - **Content**: a contiguous sequence of records, one per sparse vector, in order. Each
   record has the following fields, concatenated with no padding or separators:
@@ -174,6 +176,77 @@ vector elements.
 - **Key ordering**: on load, the eval tool sorts each vector's `ids` in ascending order
   (and reorders `vals` accordingly). Writers may emit unordered keys, but readers should
   not rely on that.
+
+### `/train_offsets`, `/test_offsets` (random-access index, optional)
+
+These two datasets store the per-record byte offsets into the matching
+`/train` and `/test` sparse byte streams so that the i-th sparse vector
+can be located in **O(1)** without scanning the stream.
+
+- **HDF5 type**: `H5T_INTEGER`, size 8 (`UINT64`)
+- **HDF5 shape**: `(N + 1,)` for `/train_offsets` and `(Q + 1,)` for
+  `/test_offsets`
+- **Content**: `offsets[i]` is the byte offset of record `i`;
+  `offsets[N]` is the sentinel and equals the total byte stream length.
+  The size of record `i` is `offsets[i + 1] - offsets[i]`. The array is
+  non-decreasing.
+
+Both datasets are **optional**. VSAG writers always emit them when
+writing sparse files, but legacy sparse files that only contain `/train`
+and `/test` keep loading: the offsets are recomputed on load by walking
+the byte stream once. When the on-disk offsets are present, they are
+cross-checked against the recomputed offsets and the file is rejected as
+corrupted on any mismatch.
+
+### `/train_token_sequences`, `/test_token_sequences` (optional)
+
+These two datasets carry the **original tokenized document** that
+produced each sparse vector. They are entirely optional: sparse HDF5
+files that omit both datasets still load correctly. When present, they
+must appear in lockstep with `/train` and `/test`: the i-th record in
+`/train_token_sequences` corresponds to the i-th sparse vector in
+`/train` (same for `/test`).
+
+- **HDF5 type**: `H5T_INTEGER`, size 1 (`INT8`)
+- **HDF5 shape**: `(X,)`, where `X` is the total byte-stream length
+  (sum of all per-record sizes)
+- **Endianness**: little-endian
+- **Content**: a contiguous sequence of records, one per sparse vector,
+  in the same order as `/train` / `/test`. Each record has the layout:
+
+  | Field               | Type        | Size                | Description                                  |
+  |---------------------|-------------|---------------------|----------------------------------------------|
+  | `seq_len`           | `uint32`    | 4 bytes             | Number of tokens in the original document    |
+  | `term_ids[seq_len]` | `uint32[]`  | `4 * seq_len` bytes | Term ids in tokenization order (duplicates and order are preserved) |
+
+  Records are concatenated with no padding or separators. A
+  `seq_len == 0` record is allowed and occupies only the 4-byte length
+  field; readers should treat it as "no original document available
+  for this vector".
+
+- **Number of records**: must equal the number of sparse vectors in the
+  matching split. Readers raise an error if counts disagree or if the
+  stream is truncated.
+- **Ordering vs. `ids`**: `term_ids` are stored in the original token
+  order (duplicates kept). This is intentionally **different** from
+  `ids`, which the loader sorts ascending.
+
+### `/train_token_sequences_offsets`, `/test_token_sequences_offsets` (required when sequences are present)
+
+Whenever `/train_token_sequences` (resp. `/test_token_sequences`) is
+present, the paired `UINT64` offset index **must** also be present.
+
+- **HDF5 type**: `H5T_INTEGER`, size 8 (`UINT64`)
+- **HDF5 shape**: `(N + 1,)` (resp. `(Q + 1,)`)
+- **Content**: same contract as `/train_offsets`, enabling O(1) random
+  access to the i-th token-sequence record.
+
+Contract: the byte-stream dataset and its offsets dataset **live or die
+together**. Readers reject the file if exactly one of the pair exists
+(either a `*_token_sequences` dataset without its `*_offsets`, or vice
+versa). When both are present, the on-disk offsets are cross-checked
+against the offsets rebuilt from the byte stream; a mismatch is treated
+as corruption and aborts the load.
 
 ### Ground truth and metric
 

--- a/docs/docs/zh/src/resources/dataset_format.md
+++ b/docs/docs/zh/src/resources/dataset_format.md
@@ -6,8 +6,8 @@ VSAG 的评测与基准工具（尤其是 [`eval_performance`](eval.md)）使用
 失败的问题。
 
 下文描述的是 **dense（稠密）** 布局（对应全局属性 `type="dense"`，或省略该属性）。
-对于 **sparse（稀疏）** 数据集（`type="sparse"`），`/train` 与 `/test` 是 1 维
-`INT8` 字节流，由 VSAG 的稀疏向量序列化接口生成（由
+对于 **sparse（稀疏）** 数据集（`type="sparse"`），`/train` 与 `/test` 是形状为
+`(X,)` 的扁平 `INT8` 字节流，由 VSAG 的稀疏向量序列化接口生成（由
 `tools/eval/eval_dataset.cpp` 中的 `parse_sparse_vectors` 解析）；其余数据集与
 全局属性的约束仍然适用。
 
@@ -141,13 +141,14 @@ VSAG 的评测与基准工具（尤其是 [`eval_performance`](eval.md)）使用
 ## Sparse 布局
 
 当全局属性 `type` 取值为 `"sparse"` 时，`/train` 与 `/test` **不再**遵循 `(N, D)` 的
-稠密矩阵布局，而是以 1 维 `INT8`（`H5T_INTEGER`，size 1）数据集存储原始字节流。
+稠密矩阵布局，而是以扁平的 `INT8`（`H5T_INTEGER`，size 1）数据集存储原始字节流。
+通过 h5py 调用 `f["/train"].shape` 得到的形状是 `(X,)`，其中 `X` 为字节流总长度；
 此处的 `int8` 仅是传输形式，**字节本身并不是 int8 向量元素**。
 
 ### `/train`、`/test`（稀疏字节流）
 
 - **HDF5 类型**：`H5T_INTEGER`，size 1（`INT8`）
-- **HDF5 形状**：1 维；总长度等于所有向量记录大小之和
+- **HDF5 形状**：`(X,)`，其中 `X` 为字节流总长度（所有向量记录大小之和）
 - **字节序**：小端（little-endian）
 - **内容**：按向量顺序首尾相接的记录序列，每条记录包含以下字段，紧密拼接，
   无填充、无分隔符：
@@ -162,6 +163,64 @@ VSAG 的评测与基准工具（尤其是 [`eval_performance`](eval.md)）使用
 
 - **键的顺序**：eval 工具在读取时会对每条向量按 `ids` 升序排序（`vals` 同步重排）。
   写入侧可以输出无序键，但读取侧不应假设无序。
+
+### `/train_offsets`、`/test_offsets`（随机访问索引，可选）
+
+这两个数据集分别记录 `/train`、`/test` 字节流中每条记录的起始字节偏移，
+使得按下标取第 i 条稀疏向量可以做到 **O(1)**，无需顺序扫描整条字节流。
+
+- **HDF5 类型**：`H5T_INTEGER`，size 8（`UINT64`）
+- **HDF5 形状**：`/train_offsets` 为 `(N + 1,)`，`/test_offsets` 为 `(Q + 1,)`
+- **内容**：`offsets[i]` 是第 i 条记录在对应字节流中的起始字节偏移，
+  `offsets[N]` 是哨兵，等于字节流总长度，因此第 i 条记录的长度等于
+  `offsets[i + 1] - offsets[i]`，整个数组非递减。
+
+两个数据集都是**可选**的。VSAG 写入端在产出稀疏文件时默认写入它们；
+但只包含 `/train`、`/test` 而不带 offsets 的旧版稀疏 HDF5 文件依然可以
+正常加载——读取端会顺序扫描一遍字节流并自动重建索引。文件中如果已有
+on-disk offsets，会与重建结果做交叉校验，不一致时直接报错以防止误用
+损坏的索引。
+
+### `/train_token_sequences`、`/test_token_sequences`（可选）
+
+这两个数据集保存生成每条稀疏向量的**原始分词序列**。它们是完全可选的：
+不包含这两个数据集的稀疏 HDF5 文件依然可以正常加载。当存在时，它们必须
+与 `/train`、`/test` 一一对应：`/train_token_sequences` 中的第 i 条记录对应
+`/train` 中的第 i 条稀疏向量（`/test` 同理）。
+
+- **HDF5 类型**：`H5T_INTEGER`，size 1（`INT8`）
+- **HDF5 形状**：`(X,)`，其中 `X` 为字节流总长度（所有记录大小之和）
+- **字节序**：小端（little-endian）
+- **内容**：按与 `/train` / `/test` 相同的向量顺序依次首尾相接的记录序列，
+  每条记录字段如下，紧密拼接，无填充、无分隔符：
+
+  | 字段                | 类型        | 大小                  | 说明                                         |
+  |---------------------|-------------|-----------------------|----------------------------------------------|
+  | `seq_len`           | `uint32`    | 4 字节                | 原始文档的 token 个数                         |
+  | `term_ids[seq_len]` | `uint32[]`  | `4 * seq_len` 字节    | 按原始分词顺序的 term id（保留重复与顺序） |
+
+  允许 `seq_len == 0` 的记录，此时仅占 4 字节的长度字段,读取端应当将其
+  视为"该向量没有原始分词信息"。
+
+- **记录数量**：必须与对应分组（train/test）中稀疏向量的数量一致，
+  否则读取端会报错。
+- **与 `ids` 的顺序差异**：`term_ids` 按原始分词顺序存储（可能包含重复），
+  这与 `ids`（被读取端排序去重）**不同**。
+
+### `/train_token_sequences_offsets`、`/test_token_sequences_offsets`（在分词序列存在时必填）
+
+当 `/train_token_sequences`（或 `/test_token_sequences`）存在时，对应的
+`UINT64` 偏移索引**必须**也存在。
+
+- **HDF5 类型**：`H5T_INTEGER`，size 8（`UINT64`）
+- **HDF5 形状**：`(N + 1,)`（或 `(Q + 1,)`）
+- **内容**：与 `/train_offsets` 完全相同的契约，使得按下标访问第 i 条分词
+  记录可以 O(1) 完成。
+
+契约：分词字节流与其偏移数据集**必须同时出现，缺一即视为文件损坏**——
+即只要 `*_token_sequences` 与 `*_token_sequences_offsets` 中只出现了一个，
+读取端就会拒绝该文件。两者同时存在时，读取端会将磁盘上的 offsets 与从
+字节流重建的 offsets 做交叉校验，不一致即抛异常拒绝加载。
 
 ### 真值与距离
 

--- a/include/vsag/dataset.h
+++ b/include/vsag/dataset.h
@@ -32,6 +32,13 @@ struct SparseVector {
                                // (The ids_ will be sorted in ascending order inside the index.
                                // it is recommended to sort them before putting them into VSAG.)
     float* vals_ = nullptr;    // contains vals with size of len_
+
+    // Optional original tokenized document content for the sparse vector.
+    // When present, token_sequence_ owns a buffer of token_seq_len_ uint32_t
+    // term ids, preserving the original tokenization order (duplicates and
+    // ordering are kept as-is, unlike the deduplicated/sorted ids_).
+    uint32_t token_seq_len_ = 0;          // length of the original token sequence
+    uint32_t* token_sequence_ = nullptr;  // original tokenized term ids, length = token_seq_len_
 };
 
 /**

--- a/src/dataset_impl.cpp
+++ b/src/dataset_impl.cpp
@@ -97,6 +97,20 @@ copy_sparse_vector(const SparseVector& src, SparseVector* dest, Allocator* alloc
     dest->len_ = len;
     std::memcpy(dest->ids_, src.ids_, len * sizeof(uint32_t));
     std::memcpy(dest->vals_, src.vals_, len * sizeof(float));
+
+    // Copy optional original token sequence (preserves order & duplicates).
+    dest->token_seq_len_ = src.token_seq_len_;
+    dest->token_sequence_ = nullptr;
+    if (src.token_seq_len_ > 0 && src.token_sequence_ != nullptr) {
+        uint64_t token_len = src.token_seq_len_;
+        if (allocator != nullptr) {
+            dest->token_sequence_ =
+                static_cast<uint32_t*>(allocator->Allocate(token_len * sizeof(uint32_t)));
+        } else {
+            dest->token_sequence_ = new uint32_t[token_len];
+        }
+        std::memcpy(dest->token_sequence_, src.token_sequence_, token_len * sizeof(uint32_t));
+    }
 }
 
 static void
@@ -206,6 +220,9 @@ DatasetImpl::~DatasetImpl() {  // NOLINT
                 if (sparse_vectors[i].vals_ != nullptr) {
                     allocator_->Deallocate(void_ptr(sparse_vectors[i].vals_));
                 }
+                if (sparse_vectors[i].token_sequence_ != nullptr) {
+                    allocator_->Deallocate(void_ptr(sparse_vectors[i].token_sequence_));
+                }
             }
             allocator_->Deallocate(void_ptr(DatasetImpl::GetSparseVectors()));
         }
@@ -232,6 +249,7 @@ DatasetImpl::~DatasetImpl() {  // NOLINT
             for (int i = 0; i < DatasetImpl::GetNumElements(); i++) {
                 delete[] DatasetImpl::GetSparseVectors()[i].ids_;
                 delete[] DatasetImpl::GetSparseVectors()[i].vals_;
+                delete[] DatasetImpl::GetSparseVectors()[i].token_sequence_;
             }
             delete[] DatasetImpl::GetSparseVectors();
         }

--- a/src/dataset_impl_test.cpp
+++ b/src/dataset_impl_test.cpp
@@ -108,6 +108,61 @@ TEST_CASE("Dataset Implement Test", "[ut][dataset]") {
             }
         }
     }
+
+    SECTION("sparse vector with token sequence ownership") {
+        // Build sparse vectors that each carry an original tokenized
+        // document, then transfer ownership to the Dataset and verify the
+        // destructor releases token_sequence_ buffers without leaks/crashes.
+        constexpr uint32_t kNumElements = 4;
+        auto* sparse_vectors = new vsag::SparseVector[kNumElements];
+        for (uint32_t i = 0; i < kNumElements; ++i) {
+            sparse_vectors[i].len_ = 2;
+            sparse_vectors[i].ids_ = new uint32_t[2]{1u + i, 5u + i};
+            sparse_vectors[i].vals_ = new float[2]{0.5f, 0.25f};
+            sparse_vectors[i].token_seq_len_ = 3;
+            sparse_vectors[i].token_sequence_ = new uint32_t[3]{i, i + 1, i};
+        }
+        // Element 2 represents the "no original document" case.
+        delete[] sparse_vectors[2].token_sequence_;
+        sparse_vectors[2].token_seq_len_ = 0;
+        sparse_vectors[2].token_sequence_ = nullptr;
+
+        auto dataset = vsag::Dataset::Make();
+        dataset->NumElements(kNumElements)->SparseVectors(sparse_vectors)->Owner(true, nullptr);
+
+        const auto* readback = dataset->GetSparseVectors();
+        REQUIRE(readback[0].token_seq_len_ == 3);
+        REQUIRE(readback[0].token_sequence_[2] == 0);
+        REQUIRE(readback[1].token_sequence_[1] == 2);
+        REQUIRE(readback[2].token_seq_len_ == 0);
+        REQUIRE(readback[2].token_sequence_ == nullptr);
+    }
+
+    SECTION("sparse vector token sequence deep copy") {
+        constexpr uint32_t kNumElements = 3;
+        auto* sparse_vectors = new vsag::SparseVector[kNumElements];
+        for (uint32_t i = 0; i < kNumElements; ++i) {
+            sparse_vectors[i].len_ = 1;
+            sparse_vectors[i].ids_ = new uint32_t[1]{i + 10};
+            sparse_vectors[i].vals_ = new float[1]{static_cast<float>(i)};
+            sparse_vectors[i].token_seq_len_ = 4;
+            sparse_vectors[i].token_sequence_ =
+                new uint32_t[4]{i, i + 1, i + 2, i};  // duplicate term ids preserved
+        }
+        auto original = vsag::Dataset::Make();
+        original->NumElements(kNumElements)->SparseVectors(sparse_vectors)->Owner(true, nullptr);
+
+        auto copy = original->DeepCopy();
+        const auto* src = original->GetSparseVectors();
+        const auto* dst = copy->GetSparseVectors();
+        for (uint32_t i = 0; i < kNumElements; ++i) {
+            REQUIRE(dst[i].token_seq_len_ == src[i].token_seq_len_);
+            REQUIRE(dst[i].token_sequence_ != src[i].token_sequence_);
+            REQUIRE(std::memcmp(dst[i].token_sequence_,
+                                src[i].token_sequence_,
+                                src[i].token_seq_len_ * sizeof(uint32_t)) == 0);
+        }
+    }
 }
 
 vsag::DatasetPtr

--- a/tools/eval/CMakeLists.txt
+++ b/tools/eval/CMakeLists.txt
@@ -58,3 +58,20 @@ target_link_libraries (eval_performance PRIVATE
     ${HDF5_C_STATIC_LIBRARY}
     z dl)
 add_dependencies (eval_performance hdf5)
+
+if (ENABLE_TESTS)
+    add_executable (eval_dataset_test
+        eval_dataset_test.cpp)
+    target_include_directories (eval_dataset_test PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR})
+    target_link_libraries (eval_dataset_test PRIVATE
+        Catch2::Catch2WithMain
+        eval_obj
+        simd
+        vsag
+        vsag_eval_common
+        ${HDF5_CPP_STATIC_LIBRARY}
+        ${HDF5_C_STATIC_LIBRARY}
+        z dl)
+    add_dependencies (eval_dataset_test hdf5 Catch2)
+endif ()

--- a/tools/eval/eval_dataset.cpp
+++ b/tools/eval/eval_dataset.cpp
@@ -168,9 +168,9 @@ validate_offsets(const std::vector<uint64_t>& offsets,
                  uint64_t expected_total,
                  const std::string& tag) {
     if (offsets.size() != expected_count + 1) {
-        throw std::runtime_error(
-            tag + ": offsets length mismatch (expected " + std::to_string(expected_count + 1) +
-            ", got " + std::to_string(offsets.size()) + ")");
+        throw std::runtime_error(tag + ": offsets length mismatch (expected " +
+                                 std::to_string(expected_count + 1) + ", got " +
+                                 std::to_string(offsets.size()) + ")");
     }
     if (offsets.front() != 0) {
         throw std::runtime_error(tag + ": offsets[0] must be 0");
@@ -494,8 +494,7 @@ EvalDataset::Load(const std::string& filename) {
         // index (/train_offsets, /test_offsets), load it and cross-check
         // against the one we just rebuilt from the byte stream. Mismatches
         // indicate a corrupted file and abort the load.
-        auto load_offsets =
-            [&file, &datasets](const std::string& key) -> std::vector<uint64_t> {
+        auto load_offsets = [&file, &datasets](const std::string& key) -> std::vector<uint64_t> {
             std::vector<uint64_t> out;
             if (datasets.count(key) == 0) {
                 return out;
@@ -508,18 +507,17 @@ EvalDataset::Load(const std::string& filename) {
             ds.read(out.data(), H5::PredType::NATIVE_UINT64);
             return out;
         };
-        auto cross_check =
-            [](const std::vector<uint64_t>& on_disk,
-               const std::vector<uint64_t>& rebuilt,
-               const std::string& tag) {
-                if (on_disk.empty()) {
-                    return;
-                }
-                if (on_disk.size() != rebuilt.size() ||
-                    !std::equal(on_disk.begin(), on_disk.end(), rebuilt.begin())) {
-                    throw std::runtime_error(tag + ": stored offsets disagree with byte stream");
-                }
-            };
+        auto cross_check = [](const std::vector<uint64_t>& on_disk,
+                              const std::vector<uint64_t>& rebuilt,
+                              const std::string& tag) {
+            if (on_disk.empty()) {
+                return;
+            }
+            if (on_disk.size() != rebuilt.size() ||
+                !std::equal(on_disk.begin(), on_disk.end(), rebuilt.begin())) {
+                throw std::runtime_error(tag + ": stored offsets disagree with byte stream");
+            }
+        };
         {
             auto disk_off = load_offsets("train_offsets");
             if (!disk_off.empty()) {
@@ -561,17 +559,14 @@ EvalDataset::Load(const std::string& filename) {
             uint64_t buffer_size = dims_out[0];
             std::shared_ptr<char[]> buffer(new char[buffer_size]);
             dataset.read(buffer.get(), type, dataspace);
-            parse_token_sequences(buffer.get(),
-                                  buffer_size,
-                                  obj->sparse_train_,
-                                  &obj->train_token_seq_offsets_);
+            parse_token_sequences(
+                buffer.get(), buffer_size, obj->sparse_train_, &obj->train_token_seq_offsets_);
             auto disk_off = load_offsets("train_token_sequences_offsets");
             validate_offsets(disk_off,
                              static_cast<uint64_t>(obj->sparse_train_.size()),
                              buffer_size,
                              "train_token_sequences_offsets");
-            cross_check(
-                disk_off, obj->train_token_seq_offsets_, "train_token_sequences_offsets");
+            cross_check(disk_off, obj->train_token_seq_offsets_, "train_token_sequences_offsets");
         } else if (datasets.count("train_token_sequences_offsets")) {
             throw std::runtime_error(
                 "train_token_sequences_offsets present but train_token_sequences is missing");
@@ -589,17 +584,14 @@ EvalDataset::Load(const std::string& filename) {
             uint64_t buffer_size = dims_out[0];
             std::shared_ptr<char[]> buffer(new char[buffer_size]);
             dataset.read(buffer.get(), type, dataspace);
-            parse_token_sequences(buffer.get(),
-                                  buffer_size,
-                                  obj->sparse_test_,
-                                  &obj->test_token_seq_offsets_);
+            parse_token_sequences(
+                buffer.get(), buffer_size, obj->sparse_test_, &obj->test_token_seq_offsets_);
             auto disk_off = load_offsets("test_token_sequences_offsets");
             validate_offsets(disk_off,
                              static_cast<uint64_t>(obj->sparse_test_.size()),
                              buffer_size,
                              "test_token_sequences_offsets");
-            cross_check(
-                disk_off, obj->test_token_seq_offsets_, "test_token_sequences_offsets");
+            cross_check(disk_off, obj->test_token_seq_offsets_, "test_token_sequences_offsets");
         } else if (datasets.count("test_token_sequences_offsets")) {
             throw std::runtime_error(
                 "test_token_sequences_offsets present but test_token_sequences is missing");
@@ -845,8 +837,7 @@ EvalDataset::Save(const EvalDatasetPtr& dataset, const std::string& filename) {
         // readers can do O(1) random access to the i-th sparse vector.
         hsize_t off_dims[1] = {static_cast<hsize_t>(offsets.size())};
         DataSpace off_space(1, off_dims);
-        DataSet off_ds =
-            file.createDataSet("/train_offsets", PredType::NATIVE_UINT64, off_space);
+        DataSet off_ds = file.createDataSet("/train_offsets", PredType::NATIVE_UINT64, off_space);
         off_ds.write(offsets.data(), PredType::NATIVE_UINT64);
     }
 
@@ -875,8 +866,7 @@ EvalDataset::Save(const EvalDatasetPtr& dataset, const std::string& filename) {
         dataset_h5.write(buffer.data(), PredType::NATIVE_CHAR);
         hsize_t off_dims[1] = {static_cast<hsize_t>(offsets.size())};
         DataSpace off_space(1, off_dims);
-        DataSet off_ds =
-            file.createDataSet("/test_offsets", PredType::NATIVE_UINT64, off_space);
+        DataSet off_ds = file.createDataSet("/test_offsets", PredType::NATIVE_UINT64, off_space);
         off_ds.write(offsets.data(), PredType::NATIVE_UINT64);
     }
 

--- a/tools/eval/eval_dataset.cpp
+++ b/tools/eval/eval_dataset.cpp
@@ -24,12 +24,21 @@ void
 parse_sparse_vectors(const char* src_data,
                      size_t data_size,
                      std::vector<SparseVector>& parsed_vectors,
-                     int64_t& max_len) {
+                     int64_t& max_len,
+                     std::vector<uint64_t>* offsets_out) {
     // parse the sparse vectors with ordered keys
     const char* ptr = src_data;
     const char* end = src_data + data_size;
+    if (offsets_out != nullptr) {
+        offsets_out->clear();
+        offsets_out->reserve(64);
+    }
     while (ptr < end) {
         SparseVector vec;
+
+        if (offsets_out != nullptr) {
+            offsets_out->push_back(static_cast<uint64_t>(ptr - src_data));
+        }
 
         if (ptr + sizeof(uint32_t) > end)
             break;
@@ -82,7 +91,101 @@ parse_sparse_vectors(const char* src_data,
     if (ptr != end) {
         throw std::runtime_error("parse_sparse_vectors: fail to parse sparse vectors");
     }
+    if (offsets_out != nullptr) {
+        // append the sentinel offset (== total data_size) so that the
+        // length of record i is offsets_out[i+1] - offsets_out[i].
+        offsets_out->push_back(static_cast<uint64_t>(data_size));
+    }
 }
+
+void
+parse_token_sequences(const char* src_data,
+                      size_t data_size,
+                      std::vector<SparseVector>& target_vectors,
+                      std::vector<uint64_t>* offsets_out) {
+    // Parse token sequences and attach them to the matching sparse vectors
+    // by ordinal position. Each record layout in the byte stream is:
+    //   [seq_len(uint32), term_id_0(uint32), term_id_1(uint32), ...]
+    // Records are concatenated back-to-back with no padding. A seq_len of 0
+    // is allowed and occupies only the 4-byte length field.
+    const char* ptr = src_data;
+    const char* end = src_data + data_size;
+    uint64_t idx = 0;
+    if (offsets_out != nullptr) {
+        offsets_out->clear();
+        offsets_out->reserve(target_vectors.size() + 1);
+    }
+    while (ptr < end) {
+        if (idx >= target_vectors.size()) {
+            throw std::runtime_error(
+                "parse_token_sequences: more token sequence records than sparse vectors");
+        }
+        if (offsets_out != nullptr) {
+            offsets_out->push_back(static_cast<uint64_t>(ptr - src_data));
+        }
+        if (ptr + sizeof(uint32_t) > end) {
+            throw std::runtime_error("parse_token_sequences: truncated stream at length header");
+        }
+        uint32_t seq_len = 0;
+        memcpy(&seq_len, ptr, sizeof(uint32_t));
+        ptr += sizeof(uint32_t);
+
+        target_vectors[idx].token_seq_len_ = seq_len;
+        target_vectors[idx].token_sequence_ = nullptr;
+
+        if (seq_len > 0) {
+            const size_t payload_size = static_cast<size_t>(seq_len) * sizeof(uint32_t);
+            if (ptr + payload_size > end) {
+                throw std::runtime_error("parse_token_sequences: truncated stream at payload");
+            }
+            target_vectors[idx].token_sequence_ = new uint32_t[seq_len];
+            memcpy(target_vectors[idx].token_sequence_, ptr, payload_size);
+            ptr += payload_size;
+        }
+        ++idx;
+    }
+    if (ptr != end) {
+        throw std::runtime_error("parse_token_sequences: trailing bytes in stream");
+    }
+    if (idx != target_vectors.size()) {
+        throw std::runtime_error(
+            "parse_token_sequences: fewer token sequence records than sparse vectors");
+    }
+    if (offsets_out != nullptr) {
+        offsets_out->push_back(static_cast<uint64_t>(data_size));
+    }
+}
+
+namespace {
+
+// Validate that a record-offsets array follows the [0, ..., total] contract:
+// length N+1, strictly non-decreasing, first entry 0, last entry == total
+// byte stream length. Throws on violation so we never silently use a broken
+// index for random access.
+void
+validate_offsets(const std::vector<uint64_t>& offsets,
+                 uint64_t expected_count,
+                 uint64_t expected_total,
+                 const std::string& tag) {
+    if (offsets.size() != expected_count + 1) {
+        throw std::runtime_error(
+            tag + ": offsets length mismatch (expected " + std::to_string(expected_count + 1) +
+            ", got " + std::to_string(offsets.size()) + ")");
+    }
+    if (offsets.front() != 0) {
+        throw std::runtime_error(tag + ": offsets[0] must be 0");
+    }
+    if (offsets.back() != expected_total) {
+        throw std::runtime_error(tag + ": offsets sentinel must equal byte stream size");
+    }
+    for (uint64_t i = 1; i < offsets.size(); ++i) {
+        if (offsets[i] < offsets[i - 1]) {
+            throw std::runtime_error(tag + ": offsets must be non-decreasing");
+        }
+    }
+}
+
+}  // namespace
 
 float
 get_distance(const SparseVector* vector1, const SparseVector* vector2, const void* qty_ptr) {
@@ -361,8 +464,11 @@ EvalDataset::Load(const std::string& filename) {
             obj->train_data_size_ = dims_out[0];
             obj->train_.reset(new char[obj->train_data_size_]);
             dataset.read(obj->train_.get(), type, dataspace);
-            parse_sparse_vectors(
-                obj->train_.get(), obj->train_data_size_, obj->sparse_train_, obj->dim_);
+            parse_sparse_vectors(obj->train_.get(),
+                                 obj->train_data_size_,
+                                 obj->sparse_train_,
+                                 obj->dim_,
+                                 &obj->sparse_train_offsets_);
             obj->train_.reset();
             obj->number_of_base_ = obj->sparse_train_.size();
         }
@@ -375,10 +481,128 @@ EvalDataset::Load(const std::string& filename) {
             obj->test_data_size_ = dims_out[0];
             obj->test_.reset(new char[obj->test_data_size_]);
             dataset.read(obj->test_.get(), type, dataspace);
-            parse_sparse_vectors(
-                obj->test_.get(), obj->test_data_size_, obj->sparse_test_, obj->dim_);
+            parse_sparse_vectors(obj->test_.get(),
+                                 obj->test_data_size_,
+                                 obj->sparse_test_,
+                                 obj->dim_,
+                                 &obj->sparse_test_offsets_);
             obj->test_.reset();
             obj->number_of_query_ = obj->sparse_test_.size();
+        }
+
+        // Optional: if the writer also stored the precomputed record-offset
+        // index (/train_offsets, /test_offsets), load it and cross-check
+        // against the one we just rebuilt from the byte stream. Mismatches
+        // indicate a corrupted file and abort the load.
+        auto load_offsets =
+            [&file, &datasets](const std::string& key) -> std::vector<uint64_t> {
+            std::vector<uint64_t> out;
+            if (datasets.count(key) == 0) {
+                return out;
+            }
+            H5::DataSet ds = file.openDataSet("/" + key);
+            H5::DataSpace sp = ds.getSpace();
+            hsize_t dims_out[1];
+            sp.getSimpleExtentDims(dims_out, NULL);
+            out.resize(dims_out[0]);
+            ds.read(out.data(), H5::PredType::NATIVE_UINT64);
+            return out;
+        };
+        auto cross_check =
+            [](const std::vector<uint64_t>& on_disk,
+               const std::vector<uint64_t>& rebuilt,
+               const std::string& tag) {
+                if (on_disk.empty()) {
+                    return;
+                }
+                if (on_disk.size() != rebuilt.size() ||
+                    !std::equal(on_disk.begin(), on_disk.end(), rebuilt.begin())) {
+                    throw std::runtime_error(tag + ": stored offsets disagree with byte stream");
+                }
+            };
+        {
+            auto disk_off = load_offsets("train_offsets");
+            if (!disk_off.empty()) {
+                validate_offsets(disk_off,
+                                 static_cast<uint64_t>(obj->sparse_train_.size()),
+                                 obj->train_data_size_,
+                                 "train_offsets");
+            }
+            cross_check(disk_off, obj->sparse_train_offsets_, "train_offsets");
+        }
+        {
+            auto disk_off = load_offsets("test_offsets");
+            if (!disk_off.empty()) {
+                validate_offsets(disk_off,
+                                 static_cast<uint64_t>(obj->sparse_test_.size()),
+                                 obj->test_data_size_,
+                                 "test_offsets");
+            }
+            cross_check(disk_off, obj->sparse_test_offsets_, "test_offsets");
+        }
+
+        // Optional: parse the original tokenized term_id sequences. Sparse
+        // datasets that were created before this feature do not contain
+        // these datasets, so missing keys are silently ignored.
+        // Contract: whenever a *_token_sequences byte stream is present, its
+        // companion *_token_sequences_offsets dataset MUST also be present.
+        // A token_sequences-without-offsets file is considered malformed and
+        // we abort the load to surface the problem early.
+        if (datasets.count("train_token_sequences")) {
+            if (datasets.count("train_token_sequences_offsets") == 0) {
+                throw std::runtime_error(
+                    "train_token_sequences present but train_token_sequences_offsets is missing");
+            }
+            H5::PredType type = H5::PredType::ALPHA_I8;
+            H5::DataSet dataset = file.openDataSet("/train_token_sequences");
+            H5::DataSpace dataspace = dataset.getSpace();
+            hsize_t dims_out[2];
+            dataspace.getSimpleExtentDims(dims_out, NULL);
+            uint64_t buffer_size = dims_out[0];
+            std::shared_ptr<char[]> buffer(new char[buffer_size]);
+            dataset.read(buffer.get(), type, dataspace);
+            parse_token_sequences(buffer.get(),
+                                  buffer_size,
+                                  obj->sparse_train_,
+                                  &obj->train_token_seq_offsets_);
+            auto disk_off = load_offsets("train_token_sequences_offsets");
+            validate_offsets(disk_off,
+                             static_cast<uint64_t>(obj->sparse_train_.size()),
+                             buffer_size,
+                             "train_token_sequences_offsets");
+            cross_check(
+                disk_off, obj->train_token_seq_offsets_, "train_token_sequences_offsets");
+        } else if (datasets.count("train_token_sequences_offsets")) {
+            throw std::runtime_error(
+                "train_token_sequences_offsets present but train_token_sequences is missing");
+        }
+        if (datasets.count("test_token_sequences")) {
+            if (datasets.count("test_token_sequences_offsets") == 0) {
+                throw std::runtime_error(
+                    "test_token_sequences present but test_token_sequences_offsets is missing");
+            }
+            H5::PredType type = H5::PredType::ALPHA_I8;
+            H5::DataSet dataset = file.openDataSet("/test_token_sequences");
+            H5::DataSpace dataspace = dataset.getSpace();
+            hsize_t dims_out[2];
+            dataspace.getSimpleExtentDims(dims_out, NULL);
+            uint64_t buffer_size = dims_out[0];
+            std::shared_ptr<char[]> buffer(new char[buffer_size]);
+            dataset.read(buffer.get(), type, dataspace);
+            parse_token_sequences(buffer.get(),
+                                  buffer_size,
+                                  obj->sparse_test_,
+                                  &obj->test_token_seq_offsets_);
+            auto disk_off = load_offsets("test_token_sequences_offsets");
+            validate_offsets(disk_off,
+                             static_cast<uint64_t>(obj->sparse_test_.size()),
+                             buffer_size,
+                             "test_token_sequences_offsets");
+            cross_check(
+                disk_off, obj->test_token_seq_offsets_, "test_token_sequences_offsets");
+        } else if (datasets.count("test_token_sequences_offsets")) {
+            throw std::runtime_error(
+                "test_token_sequences_offsets present but test_token_sequences is missing");
         }
     }
 
@@ -475,7 +699,9 @@ EvalDataset::Load(const std::string& filename) {
 }
 
 std::vector<char>
-serialize_sparse_vectors(const std::vector<SparseVector>& vectors, size_t& total_size_out) {
+serialize_sparse_vectors(const std::vector<SparseVector>& vectors,
+                         size_t& total_size_out,
+                         std::vector<uint64_t>* offsets_out) {
     size_t total_size = 0;
     for (const auto& vec : vectors) {
         total_size += sizeof(uint32_t);  // len_
@@ -486,8 +712,15 @@ serialize_sparse_vectors(const std::vector<SparseVector>& vectors, size_t& total
     }
     total_size_out = total_size;
     std::vector<char> buffer(total_size);
+    if (offsets_out != nullptr) {
+        offsets_out->clear();
+        offsets_out->reserve(vectors.size() + 1);
+    }
     char* ptr = buffer.data();
     for (const auto& vec : vectors) {
+        if (offsets_out != nullptr) {
+            offsets_out->push_back(static_cast<uint64_t>(ptr - buffer.data()));
+        }
         memcpy(ptr, &vec.len_, sizeof(uint32_t));
         ptr += sizeof(uint32_t);
         if (vec.len_ > 0) {
@@ -496,6 +729,53 @@ serialize_sparse_vectors(const std::vector<SparseVector>& vectors, size_t& total
             memcpy(ptr, vec.vals_, vec.len_ * sizeof(float));
             ptr += vec.len_ * sizeof(float);
         }
+    }
+    if (offsets_out != nullptr) {
+        offsets_out->push_back(static_cast<uint64_t>(total_size));
+    }
+    return buffer;
+}
+
+bool
+has_any_token_sequence(const std::vector<SparseVector>& vectors) {
+    for (const auto& vec : vectors) {
+        if (vec.token_seq_len_ > 0 && vec.token_sequence_ != nullptr) {
+            return true;
+        }
+    }
+    return false;
+}
+
+std::vector<char>
+serialize_token_sequences(const std::vector<SparseVector>& vectors,
+                          size_t& total_size_out,
+                          std::vector<uint64_t>* offsets_out) {
+    size_t total_size = 0;
+    for (const auto& vec : vectors) {
+        total_size += sizeof(uint32_t);  // token_seq_len_
+        total_size += static_cast<size_t>(vec.token_seq_len_) * sizeof(uint32_t);
+    }
+    total_size_out = total_size;
+    std::vector<char> buffer(total_size);
+    if (offsets_out != nullptr) {
+        offsets_out->clear();
+        offsets_out->reserve(vectors.size() + 1);
+    }
+    char* ptr = buffer.data();
+    for (const auto& vec : vectors) {
+        if (offsets_out != nullptr) {
+            offsets_out->push_back(static_cast<uint64_t>(ptr - buffer.data()));
+        }
+        memcpy(ptr, &vec.token_seq_len_, sizeof(uint32_t));
+        ptr += sizeof(uint32_t);
+        if (vec.token_seq_len_ > 0 && vec.token_sequence_ != nullptr) {
+            const size_t payload_size = static_cast<size_t>(vec.token_seq_len_) * sizeof(uint32_t);
+            memcpy(ptr, vec.token_sequence_, payload_size);
+            ptr += payload_size;
+        }
+    }
+    if (offsets_out != nullptr) {
+        offsets_out->push_back(static_cast<uint64_t>(total_size));
     }
     return buffer;
 }
@@ -554,11 +834,20 @@ EvalDataset::Save(const EvalDatasetPtr& dataset, const std::string& filename) {
 
     } else if (dataset->vector_type_ == SPARSE_VECTORS) {
         size_t total_size;
-        std::vector<char> buffer = serialize_sparse_vectors(dataset->sparse_train_, total_size);
+        std::vector<uint64_t> offsets;
+        std::vector<char> buffer =
+            serialize_sparse_vectors(dataset->sparse_train_, total_size, &offsets);
         hsize_t dims[1] = {static_cast<hsize_t>(total_size)};
         DataSpace dataspace(1, dims);
         DataSet dataset_h5 = file.createDataSet("/train", PredType::ALPHA_I8, dataspace);
         dataset_h5.write(buffer.data(), PredType::NATIVE_CHAR);
+        // Write the per-record offset index alongside the byte stream so
+        // readers can do O(1) random access to the i-th sparse vector.
+        hsize_t off_dims[1] = {static_cast<hsize_t>(offsets.size())};
+        DataSpace off_space(1, off_dims);
+        DataSet off_ds =
+            file.createDataSet("/train_offsets", PredType::NATIVE_UINT64, off_space);
+        off_ds.write(offsets.data(), PredType::NATIVE_UINT64);
     }
 
     // write test dataset
@@ -577,11 +866,58 @@ EvalDataset::Save(const EvalDatasetPtr& dataset, const std::string& filename) {
         }
     } else if (dataset->vector_type_ == SPARSE_VECTORS) {
         size_t total_size;
-        std::vector<char> buffer = serialize_sparse_vectors(dataset->sparse_test_, total_size);
+        std::vector<uint64_t> offsets;
+        std::vector<char> buffer =
+            serialize_sparse_vectors(dataset->sparse_test_, total_size, &offsets);
         hsize_t dims[1] = {static_cast<hsize_t>(total_size)};
         DataSpace dataspace(1, dims);
         DataSet dataset_h5 = file.createDataSet("/test", PredType::ALPHA_I8, dataspace);
         dataset_h5.write(buffer.data(), PredType::NATIVE_CHAR);
+        hsize_t off_dims[1] = {static_cast<hsize_t>(offsets.size())};
+        DataSpace off_space(1, off_dims);
+        DataSet off_ds =
+            file.createDataSet("/test_offsets", PredType::NATIVE_UINT64, off_space);
+        off_ds.write(offsets.data(), PredType::NATIVE_UINT64);
+    }
+
+    // write optional token_sequences datasets for sparse vectors (only if at
+    // least one entry has a non-empty token sequence, to keep backwards
+    // compatibility with datasets that have no original-document field).
+    // Each token sequence stream is paired with its own per-record offsets
+    // dataset so readers can do O(1) random access without re-scanning the
+    // byte stream.
+    if (dataset->vector_type_ == SPARSE_VECTORS) {
+        if (has_any_token_sequence(dataset->sparse_train_)) {
+            size_t total_size;
+            std::vector<uint64_t> offsets;
+            std::vector<char> buffer =
+                serialize_token_sequences(dataset->sparse_train_, total_size, &offsets);
+            hsize_t dims[1] = {static_cast<hsize_t>(total_size)};
+            DataSpace dataspace(1, dims);
+            DataSet ds =
+                file.createDataSet("/train_token_sequences", PredType::ALPHA_I8, dataspace);
+            ds.write(buffer.data(), PredType::NATIVE_CHAR);
+            hsize_t off_dims[1] = {static_cast<hsize_t>(offsets.size())};
+            DataSpace off_space(1, off_dims);
+            DataSet off_ds = file.createDataSet(
+                "/train_token_sequences_offsets", PredType::NATIVE_UINT64, off_space);
+            off_ds.write(offsets.data(), PredType::NATIVE_UINT64);
+        }
+        if (has_any_token_sequence(dataset->sparse_test_)) {
+            size_t total_size;
+            std::vector<uint64_t> offsets;
+            std::vector<char> buffer =
+                serialize_token_sequences(dataset->sparse_test_, total_size, &offsets);
+            hsize_t dims[1] = {static_cast<hsize_t>(total_size)};
+            DataSpace dataspace(1, dims);
+            DataSet ds = file.createDataSet("/test_token_sequences", PredType::ALPHA_I8, dataspace);
+            ds.write(buffer.data(), PredType::NATIVE_CHAR);
+            hsize_t off_dims[1] = {static_cast<hsize_t>(offsets.size())};
+            DataSpace off_space(1, off_dims);
+            DataSet off_ds = file.createDataSet(
+                "/test_token_sequences_offsets", PredType::NATIVE_UINT64, off_space);
+            off_ds.write(offsets.data(), PredType::NATIVE_UINT64);
+        }
     }
 
     // write neighbors dataset

--- a/tools/eval/eval_dataset.h
+++ b/tools/eval/eval_dataset.h
@@ -182,6 +182,27 @@ public:
         return vector_type_;
     }
 
+    // Per-record byte offsets into the on-disk sparse byte streams. For a
+    // sparse split with N records, GetSparseTrainOffsets() returns a vector
+    // of size N+1 where offsets[i] is the start of record i and offsets[N]
+    // equals the total byte stream length, enabling O(1) record-i lookup.
+    [[nodiscard]] const std::vector<uint64_t>&
+    GetSparseTrainOffsets() const {
+        return sparse_train_offsets_;
+    }
+    [[nodiscard]] const std::vector<uint64_t>&
+    GetSparseTestOffsets() const {
+        return sparse_test_offsets_;
+    }
+    [[nodiscard]] const std::vector<uint64_t>&
+    GetTrainTokenSequenceOffsets() const {
+        return train_token_seq_offsets_;
+    }
+    [[nodiscard]] const std::vector<uint64_t>&
+    GetTestTokenSequenceOffsets() const {
+        return test_token_seq_offsets_;
+    }
+
     std::string
     GetFilePath() {
         return this->file_path_;
@@ -209,10 +230,12 @@ public:
         for (auto& i : sparse_train_) {
             delete[] i.ids_;
             delete[] i.vals_;
+            delete[] i.token_sequence_;
         }
         for (auto& i : sparse_test_) {
             delete[] i.ids_;
             delete[] i.vals_;
+            delete[] i.token_sequence_;
         }
         for (auto& mv : multi_train_vectors_) {
             delete[] mv.vectors_;
@@ -263,7 +286,7 @@ private:
 private:
     vsag::DistanceFuncType distance_func_;
 
-private:
+protected:
     std::shared_ptr<char[]> train_;
     std::shared_ptr<char[]> test_;
     std::shared_ptr<int64_t[]> neighbors_;
@@ -287,6 +310,20 @@ private:
 
     std::vector<SparseVector> sparse_train_;
     std::vector<SparseVector> sparse_test_;
+
+    // Per-record byte offsets within /train and /test sparse byte streams.
+    // Always length N+1 (Q+1 for test), with offsets_.back() == byte stream
+    // total size. Built on load (from the optional /train_offsets &
+    // /test_offsets datasets, or recomputed if absent) and used for O(1)
+    // random access to the i-th sparse vector record on disk.
+    std::vector<uint64_t> sparse_train_offsets_;
+    std::vector<uint64_t> sparse_test_offsets_;
+
+    // Per-record byte offsets within /train_token_sequences &
+    // /test_token_sequences. Only populated when the corresponding token
+    // sequence dataset is present.
+    std::vector<uint64_t> train_token_seq_offsets_;
+    std::vector<uint64_t> test_token_seq_offsets_;
 
     std::vector<vsag::MultiVector> multi_train_vectors_;
     std::vector<vsag::MultiVector> multi_test_vectors_;

--- a/tools/eval/eval_dataset_test.cpp
+++ b/tools/eval/eval_dataset_test.cpp
@@ -1,0 +1,404 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "eval_dataset.h"
+
+#include <H5Cpp.h>
+
+#include <catch2/catch_test_macros.hpp>
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace {
+
+using vsag::SparseVector;
+using vsag::eval::EvalDataset;
+using vsag::eval::EvalDatasetPtr;
+
+EvalDatasetPtr
+BuildSparseDataset(bool with_token_sequences) {
+    // Build a tiny sparse dataset (3 train, 2 test) and optionally attach
+    // the original tokenized term-id sequences.
+    auto ds = std::make_shared<EvalDataset>();
+
+    // Sparse train vectors.
+    std::vector<SparseVector> train(3);
+    train[0].len_ = 2;
+    train[0].ids_ = new uint32_t[2]{1, 5};
+    train[0].vals_ = new float[2]{0.5f, 1.0f};
+    train[1].len_ = 1;
+    train[1].ids_ = new uint32_t[1]{3};
+    train[1].vals_ = new float[1]{0.25f};
+    train[2].len_ = 0;  // empty sparse vector
+
+    std::vector<SparseVector> test(2);
+    test[0].len_ = 2;
+    test[0].ids_ = new uint32_t[2]{2, 7};
+    test[0].vals_ = new float[2]{0.4f, 0.6f};
+    test[1].len_ = 1;
+    test[1].ids_ = new uint32_t[1]{9};
+    test[1].vals_ = new float[1]{1.0f};
+
+    if (with_token_sequences) {
+        train[0].token_seq_len_ = 4;
+        train[0].token_sequence_ = new uint32_t[4]{10, 20, 10, 30};
+        train[1].token_seq_len_ = 2;
+        train[1].token_sequence_ = new uint32_t[2]{42, 42};
+        // train[2] intentionally has no original document.
+        train[2].token_seq_len_ = 0;
+        train[2].token_sequence_ = nullptr;
+
+        test[0].token_seq_len_ = 1;
+        test[0].token_sequence_ = new uint32_t[1]{99};
+        test[1].token_seq_len_ = 3;
+        test[1].token_sequence_ = new uint32_t[3]{1, 2, 3};
+    }
+
+    // Inject the sparse vectors via friend access through pointer.
+    // EvalDataset's members are private; expose a tiny helper through
+    // direct memory write would be invasive. Instead we build via Save's
+    // public API by reaching through a shim subclass.
+    struct ShimDataset : public EvalDataset {
+        std::vector<SparseVector>&
+        train() {
+            return this->sparse_train_;
+        }
+        std::vector<SparseVector>&
+        test() {
+            return this->sparse_test_;
+        }
+        void
+        set_metric(const std::string& m) {
+            this->metric_ = m;
+        }
+        void
+        set_type(const std::string& t) {
+            this->vector_type_ = t;
+        }
+        void
+        set_counts(int64_t base, int64_t query) {
+            this->number_of_base_ = base;
+            this->number_of_query_ = query;
+        }
+        void
+        set_neighbors_shape(int64_t q, int64_t k) {
+            this->neighbors_shape_ = {q, k};
+        }
+        void
+        set_neighbors(int64_t* ptr) {
+            this->neighbors_.reset(ptr);
+        }
+        void
+        set_distances(float* ptr) {
+            this->distances_.reset(ptr);
+        }
+    };
+
+    auto shim = std::make_shared<ShimDataset>();
+    shim->set_type(vsag::SPARSE_VECTORS);
+    shim->set_metric("ip");
+    shim->train() = std::move(train);
+    shim->test() = std::move(test);
+    shim->set_counts(static_cast<int64_t>(shim->train().size()),
+                     static_cast<int64_t>(shim->test().size()));
+
+    // Minimal ground truth (k=1 per query; values do not matter for the
+    // load/save round-trip we are testing).
+    constexpr int64_t kK = 1;
+    int64_t* nb = new int64_t[shim->test().size() * kK];
+    float* dist = new float[shim->test().size() * kK];
+    for (int64_t i = 0; i < static_cast<int64_t>(shim->test().size()); ++i) {
+        nb[i] = 0;
+        dist[i] = 0.0f;
+    }
+    shim->set_neighbors_shape(static_cast<int64_t>(shim->test().size()), kK);
+    shim->set_neighbors(nb);
+    shim->set_distances(dist);
+
+    return shim;
+}
+
+std::string
+TempPath(const std::string& tag) {
+    std::string path = "/tmp/eval_dataset_test_" + tag + ".hdf5";
+    std::remove(path.c_str());
+    return path;
+}
+
+}  // namespace
+
+TEST_CASE("EvalDataset sparse round-trip without token sequences", "[ut][eval_dataset]") {
+    auto path = TempPath("nosqry");
+    {
+        auto ds = BuildSparseDataset(/*with_token_sequences=*/false);
+        EvalDataset::Save(ds, path);
+    }
+
+    // Verify the optional datasets are absent on disk.
+    {
+        H5::H5File file(path, H5F_ACC_RDONLY);
+        H5::Group root = file.openGroup("/");
+        bool has_train_token = false;
+        bool has_test_token = false;
+        hsize_t numObj = root.getNumObjs();
+        for (unsigned i = 0; i < numObj; ++i) {
+            std::string n = root.getObjnameByIdx(i);
+            if (n == "train_token_sequences")
+                has_train_token = true;
+            if (n == "test_token_sequences")
+                has_test_token = true;
+        }
+        REQUIRE_FALSE(has_train_token);
+        REQUIRE_FALSE(has_test_token);
+    }
+
+    // Loading must succeed and token_sequence_ fields stay empty.
+    auto loaded = EvalDataset::Load(path);
+    REQUIRE(loaded->GetVectorType() == vsag::SPARSE_VECTORS);
+    REQUIRE(loaded->GetNumberOfBase() == 3);
+    REQUIRE(loaded->GetNumberOfQuery() == 2);
+    const auto* train = static_cast<const SparseVector*>(loaded->GetTrain());
+    for (int i = 0; i < 3; ++i) {
+        REQUIRE(train[i].token_seq_len_ == 0);
+        REQUIRE(train[i].token_sequence_ == nullptr);
+    }
+    std::remove(path.c_str());
+}
+
+TEST_CASE("EvalDataset sparse round-trip with token sequences", "[ut][eval_dataset]") {
+    auto path = TempPath("withseq");
+    {
+        auto ds = BuildSparseDataset(/*with_token_sequences=*/true);
+        EvalDataset::Save(ds, path);
+    }
+
+    auto loaded = EvalDataset::Load(path);
+    REQUIRE(loaded->GetVectorType() == vsag::SPARSE_VECTORS);
+    REQUIRE(loaded->GetNumberOfBase() == 3);
+    REQUIRE(loaded->GetNumberOfQuery() == 2);
+
+    const auto* train = static_cast<const SparseVector*>(loaded->GetTrain());
+    REQUIRE(train[0].token_seq_len_ == 4);
+    REQUIRE(train[0].token_sequence_[0] == 10u);
+    REQUIRE(train[0].token_sequence_[2] == 10u);  // duplicates preserved
+    REQUIRE(train[1].token_seq_len_ == 2);
+    REQUIRE(train[1].token_sequence_[0] == 42u);
+    REQUIRE(train[1].token_sequence_[1] == 42u);
+    REQUIRE(train[2].token_seq_len_ == 0);
+    REQUIRE(train[2].token_sequence_ == nullptr);
+
+    const auto* test = static_cast<const SparseVector*>(loaded->GetTest());
+    REQUIRE(test[0].token_seq_len_ == 1);
+    REQUIRE(test[0].token_sequence_[0] == 99u);
+    REQUIRE(test[1].token_seq_len_ == 3);
+    REQUIRE(test[1].token_sequence_[0] == 1u);
+    REQUIRE(test[1].token_sequence_[2] == 3u);
+    std::remove(path.c_str());
+}
+
+TEST_CASE("EvalDataset legacy sparse file without token_sequences key still loads",
+          "[ut][eval_dataset]") {
+    // Synthesize a minimal legacy sparse HDF5 file by hand (no
+    // train_token_sequences / test_token_sequences keys), and verify
+    // EvalDataset::Load still succeeds.
+    auto path = TempPath("legacy");
+    {
+        H5::H5File file(path, H5F_ACC_TRUNC);
+
+        H5::StrType str_type(H5::PredType::C_S1, H5T_VARIABLE);
+        {
+            auto a = file.createAttribute("type", str_type, H5::DataSpace(H5S_SCALAR));
+            std::string v = "sparse";
+            a.write(str_type, v);
+        }
+        {
+            auto a = file.createAttribute("distance", str_type, H5::DataSpace(H5S_SCALAR));
+            std::string v = "ip";
+            a.write(str_type, v);
+        }
+
+        // Encode 1 train and 1 test sparse vector each. Layout:
+        //   uint32 len | uint32 ids[len] | float vals[len]
+        auto encode =
+            [](uint32_t len, const std::vector<uint32_t>& ids, const std::vector<float>& vals) {
+                std::vector<char> buf(sizeof(uint32_t) + len * (sizeof(uint32_t) + sizeof(float)));
+                char* p = buf.data();
+                std::memcpy(p, &len, sizeof(uint32_t));
+                p += sizeof(uint32_t);
+                std::memcpy(p, ids.data(), len * sizeof(uint32_t));
+                p += len * sizeof(uint32_t);
+                std::memcpy(p, vals.data(), len * sizeof(float));
+                return buf;
+            };
+        auto train_buf = encode(2, {1, 4}, {0.5f, 1.0f});
+        auto test_buf = encode(1, {2}, {0.7f});
+        {
+            hsize_t dims[1] = {static_cast<hsize_t>(train_buf.size())};
+            H5::DataSpace sp(1, dims);
+            auto ds = file.createDataSet("/train", H5::PredType::ALPHA_I8, sp);
+            ds.write(train_buf.data(), H5::PredType::NATIVE_CHAR);
+        }
+        {
+            hsize_t dims[1] = {static_cast<hsize_t>(test_buf.size())};
+            H5::DataSpace sp(1, dims);
+            auto ds = file.createDataSet("/test", H5::PredType::ALPHA_I8, sp);
+            ds.write(test_buf.data(), H5::PredType::NATIVE_CHAR);
+        }
+        // Minimal ground truth: shape (1, 1).
+        {
+            hsize_t dims[2] = {1, 1};
+            H5::DataSpace sp(2, dims);
+            int64_t nb[1] = {0};
+            auto ds = file.createDataSet("/neighbors", H5::PredType::NATIVE_INT64, sp);
+            ds.write(nb, H5::PredType::NATIVE_INT64);
+        }
+        {
+            hsize_t dims[2] = {1, 1};
+            H5::DataSpace sp(2, dims);
+            float dv[1] = {0.0f};
+            auto ds = file.createDataSet("/distances", H5::PredType::NATIVE_FLOAT, sp);
+            ds.write(dv, H5::PredType::NATIVE_FLOAT);
+        }
+    }
+
+    auto loaded = EvalDataset::Load(path);
+    REQUIRE(loaded->GetVectorType() == vsag::SPARSE_VECTORS);
+    REQUIRE(loaded->GetNumberOfBase() == 1);
+    REQUIRE(loaded->GetNumberOfQuery() == 1);
+    const auto* train = static_cast<const SparseVector*>(loaded->GetTrain());
+    REQUIRE(train[0].token_seq_len_ == 0);
+    REQUIRE(train[0].token_sequence_ == nullptr);
+    // The reader rebuilds offsets from the byte stream when the file does
+    // not store them. For a single 2-nnz record the layout is
+    //   [u32 len=2][u32 ids[2]][f32 vals[2]] = 4 + 8 + 8 = 20 bytes.
+    const auto& train_off = loaded->GetSparseTrainOffsets();
+    REQUIRE(train_off.size() == 2);
+    REQUIRE(train_off[0] == 0u);
+    REQUIRE(train_off[1] == 20u);
+    std::remove(path.c_str());
+}
+
+TEST_CASE("EvalDataset sparse round-trip writes record-offset indexes", "[ut][eval_dataset]") {
+    auto path = TempPath("offsets");
+    {
+        auto ds = BuildSparseDataset(/*with_token_sequences=*/true);
+        EvalDataset::Save(ds, path);
+    }
+
+    // Verify the four offsets datasets exist on disk and have the correct
+    // contents. The /train byte layout is:
+    //   record 0 (len=2): 4 + 8 + 8 = 20 bytes -> starts at 0
+    //   record 1 (len=1): 4 + 4 + 4 = 12 bytes -> starts at 20
+    //   record 2 (len=0): 4 bytes              -> starts at 32
+    //   total                                  = 36 bytes
+    {
+        H5::H5File file(path, H5F_ACC_RDONLY);
+        std::vector<uint64_t> train_off(4);
+        H5::DataSet ds = file.openDataSet("/train_offsets");
+        ds.read(train_off.data(), H5::PredType::NATIVE_UINT64);
+        REQUIRE(train_off == std::vector<uint64_t>{0, 20, 32, 36});
+
+        std::vector<uint64_t> test_off(3);
+        H5::DataSet tds = file.openDataSet("/test_offsets");
+        tds.read(test_off.data(), H5::PredType::NATIVE_UINT64);
+        // record 0 (len=2): 20, record 1 (len=1): 12 -> offsets {0, 20, 32}
+        REQUIRE(test_off == std::vector<uint64_t>{0, 20, 32});
+
+        std::vector<uint64_t> train_token_off(4);
+        H5::DataSet ttds = file.openDataSet("/train_token_sequences_offsets");
+        ttds.read(train_token_off.data(), H5::PredType::NATIVE_UINT64);
+        // train tokens: seq_lens 4, 2, 0
+        //   record 0: 4 + 16 = 20 bytes  -> 0
+        //   record 1: 4 + 8  = 12 bytes  -> 20
+        //   record 2: 4      = 4  bytes  -> 32
+        //   total                        = 36 bytes
+        REQUIRE(train_token_off == std::vector<uint64_t>{0, 20, 32, 36});
+
+        std::vector<uint64_t> test_token_off(3);
+        H5::DataSet etds = file.openDataSet("/test_token_sequences_offsets");
+        etds.read(test_token_off.data(), H5::PredType::NATIVE_UINT64);
+        // test tokens: seq_lens 1, 3
+        //   record 0: 4 + 4  = 8  bytes -> 0
+        //   record 1: 4 + 12 = 16 bytes -> 8
+        //   total                       = 24 bytes
+        REQUIRE(test_token_off == std::vector<uint64_t>{0, 8, 24});
+    }
+
+    // Loading must succeed and surface the offsets through the public API.
+    auto loaded = EvalDataset::Load(path);
+    REQUIRE(loaded->GetSparseTrainOffsets() == std::vector<uint64_t>{0, 20, 32, 36});
+    REQUIRE(loaded->GetSparseTestOffsets() == std::vector<uint64_t>{0, 20, 32});
+    REQUIRE(loaded->GetTrainTokenSequenceOffsets() ==
+            std::vector<uint64_t>{0, 20, 32, 36});
+    REQUIRE(loaded->GetTestTokenSequenceOffsets() == std::vector<uint64_t>{0, 8, 24});
+    std::remove(path.c_str());
+}
+
+TEST_CASE("EvalDataset rejects sparse files with token_sequences missing offsets",
+          "[ut][eval_dataset]") {
+    // Contract: whenever a *_token_sequences byte stream is present, the
+    // companion *_token_sequences_offsets dataset MUST also exist. Files
+    // that violate this invariant are considered malformed.
+    auto path = TempPath("seq_no_off");
+    {
+        auto ds = BuildSparseDataset(/*with_token_sequences=*/true);
+        EvalDataset::Save(ds, path);
+    }
+    // Delete only /train_token_sequences_offsets, keep the byte stream.
+    {
+        H5::H5File file(path, H5F_ACC_RDWR);
+        file.unlink("/train_token_sequences_offsets");
+    }
+    REQUIRE_THROWS(EvalDataset::Load(path));
+    std::remove(path.c_str());
+}
+
+TEST_CASE("EvalDataset rejects sparse files with orphan token_sequences_offsets",
+          "[ut][eval_dataset]") {
+    // The reverse direction: a *_token_sequences_offsets dataset must not
+    // appear without its byte-stream counterpart.
+    auto path = TempPath("orphan_off");
+    {
+        auto ds = BuildSparseDataset(/*with_token_sequences=*/true);
+        EvalDataset::Save(ds, path);
+    }
+    {
+        H5::H5File file(path, H5F_ACC_RDWR);
+        file.unlink("/test_token_sequences");
+    }
+    REQUIRE_THROWS(EvalDataset::Load(path));
+    std::remove(path.c_str());
+}
+
+TEST_CASE("EvalDataset rejects sparse files with corrupted offsets", "[ut][eval_dataset]") {
+    auto path = TempPath("badoff");
+    {
+        auto ds = BuildSparseDataset(/*with_token_sequences=*/false);
+        EvalDataset::Save(ds, path);
+    }
+    // Corrupt /train_offsets: replace the sentinel with a wrong total size.
+    {
+        H5::H5File file(path, H5F_ACC_RDWR);
+        H5::DataSet ds = file.openDataSet("/train_offsets");
+        std::vector<uint64_t> tmp(4);
+        ds.read(tmp.data(), H5::PredType::NATIVE_UINT64);
+        tmp.back() += 7;  // sentinel no longer matches byte stream length
+        ds.write(tmp.data(), H5::PredType::NATIVE_UINT64);
+    }
+    REQUIRE_THROWS(EvalDataset::Load(path));
+    std::remove(path.c_str());
+}

--- a/tools/eval/eval_dataset_test.cpp
+++ b/tools/eval/eval_dataset_test.cpp
@@ -342,8 +342,7 @@ TEST_CASE("EvalDataset sparse round-trip writes record-offset indexes", "[ut][ev
     auto loaded = EvalDataset::Load(path);
     REQUIRE(loaded->GetSparseTrainOffsets() == std::vector<uint64_t>{0, 20, 32, 36});
     REQUIRE(loaded->GetSparseTestOffsets() == std::vector<uint64_t>{0, 20, 32});
-    REQUIRE(loaded->GetTrainTokenSequenceOffsets() ==
-            std::vector<uint64_t>{0, 20, 32, 36});
+    REQUIRE(loaded->GetTrainTokenSequenceOffsets() == std::vector<uint64_t>{0, 20, 32, 36});
     REQUIRE(loaded->GetTestTokenSequenceOffsets() == std::vector<uint64_t>{0, 8, 24});
     std::remove(path.c_str());
 }


### PR DESCRIPTION
Extend the sparse HDF5 schema with two optional datasets, `/train_token_sequences` and `/test_token_sequences`, that carry the original tokenized term-id stream that produced each sparse vector. The new `SparseVector::token_seq_len_` / `token_sequence_` fields hold the per-vector buffer; ownership, DeepCopy and destruction in DatasetImpl release them alongside ids_/vals_.

The eval tool (`tools/eval/eval_dataset.{h,cpp}`) parses/serializes the new records and only emits them when at least one entry carries a non-empty token sequence, so legacy sparse datasets without the new keys keep loading unchanged. The HDF5 format reference in `docs/dataset_format.md` documents the new datasets and the back-compat rule. New unit tests cover Dataset ownership/DeepCopy of token sequences and the eval-tool round-trip (with sequences, without sequences, and the legacy-on-disk path).


Assisted-by: CodeFuse:claude-sonnet-4.5

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement/Refactor
- [ ] Documentation
- [ ] CI/Build/Infra

## Linked Issue

<!--
REQUIRED for `kind/bug` and `kind/feature` PRs. Use a GitHub-recognized
auto-closing keyword so the linked issue is closed when this PR merges:

  Fixes: #<number>
  Closes: #<number>
  Resolves: #<number>

Cross-repo references (`owner/repo#<number>`) and full issue URLs are
also accepted. `kind/improvement` and `kind/documentation` PRs may leave
this blank (delete the line below or keep it empty).
-->

- Fixes: <!-- #<number> -->

## What Changed

- <!-- Briefly describe the key changes -->

## Test Evidence

- [ ] `make fmt`
- [ ] `make lint`
- [ ] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [ ] Other (describe below)

Test details:

```text
<!-- Paste commands and key output here -->
```

## Compatibility Impact

- API/ABI compatibility: <!-- none / describe -->
- Behavior changes: <!-- none / describe -->

## Performance and Concurrency Impact

- Performance impact: <!-- none / improved / regressed / unknown -->
- Concurrency/thread-safety impact: <!-- none / describe -->

## Documentation Impact

- [ ] No docs update needed
- [ ] Updated docs:
  - [ ] `README.md`
  - [ ] `DEVELOPMENT.md`
  - [ ] `CONTRIBUTING.md`
  - [ ] Other: <!-- path -->

## Risk and Rollback

- Risk level: <!-- low / medium / high -->
- Rollback plan: <!-- how to revert safely -->

## Checklist

- [ ] I have linked the relevant issue (required for `kind/bug` and `kind/feature`; see "Linked Issue" above)
- [ ] I have added/updated tests for new behavior or bug fixes
- [ ] I have considered API compatibility impact
- [ ] I have updated docs if behavior/workflow changed
- [ ] My commit messages follow project conventions (Conventional Commits, optional `[skip ci]` prefix)
