### PR TITLE
feat(hgraph): switch to brute-force search on low valid_ratio

### DIFF
--- a/include/vsag/constants.h
+++ b/include/vsag/constants.h
@@ -197,6 +197,7 @@ extern const char* const HGRAPH_PRECISE_FILE_PATH;
 extern const char* const HGRAPH_PARAMETER_EF_RUNTIME;
 extern const char* const HGRAPH_PARAMETER_HOPS_LIMIT;
 extern const char* const HGRAPH_PARAMETER_RABITQ_ONE_BIT_SEARCH;
+extern const char* const HGRAPH_PARAMETER_BRUTE_FORCE_THRESHOLD;
 extern const char* const HGRAPH_EXTRA_INFO_SIZE;
 extern const char* const HGRAPH_SUPPORT_DUPLICATE;
 extern const char* const HGRAPH_DUPLICATE_DISTANCE_THRESHOLD;

--- a/src/algorithm/hgraph/hgraph.h
+++ b/src/algorithm/hgraph/hgraph.h
@@ -294,6 +294,17 @@ public:
                      DistanceRecordVector* rabitq_lower_bound_candidates = nullptr) const;
 
 private:
+    template <InnerSearchMode mode = InnerSearchMode::KNN_SEARCH>
+    DistHeapPtr
+    brute_force_search(const void* query,
+                       const FilterPtr& filter,
+                       int64_t topk,
+                       float radius,
+                       QueryContext* ctx) const;
+
+public:
+
+private:
     // since v0.15
     JsonType
     serialize_basic_info() const;

--- a/src/algorithm/hgraph/hgraph.h
+++ b/src/algorithm/hgraph/hgraph.h
@@ -294,17 +294,6 @@ public:
                      DistanceRecordVector* rabitq_lower_bound_candidates = nullptr) const;
 
 private:
-    template <InnerSearchMode mode = InnerSearchMode::KNN_SEARCH>
-    DistHeapPtr
-    brute_force_search(const void* query,
-                       const FilterPtr& filter,
-                       int64_t topk,
-                       float radius,
-                       QueryContext* ctx) const;
-
-public:
-
-private:
     // since v0.15
     JsonType
     serialize_basic_info() const;
@@ -341,6 +330,14 @@ private:
 
     void
     shrink_to_fit();
+
+    template <InnerSearchMode mode = InnerSearchMode::KNN_SEARCH>
+    DistHeapPtr
+    brute_force_search(const void* query,
+                       const FilterPtr& filter,
+                       int64_t topk,
+                       float radius,
+                       QueryContext* ctx) const;
 
 private:
     void

--- a/src/algorithm/hgraph/hgraph_parameter.cpp
+++ b/src/algorithm/hgraph/hgraph_parameter.cpp
@@ -229,6 +229,14 @@ HGraphSearchParameters::FromJson(const std::string& json_string) {
         obj.rabitq_one_bit_search =
             params[INDEX_TYPE_HGRAPH][HGRAPH_PARAMETER_RABITQ_ONE_BIT_SEARCH].GetBool();
     }
+    if (params[INDEX_TYPE_HGRAPH].Contains(HGRAPH_PARAMETER_BRUTE_FORCE_THRESHOLD)) {
+        obj.brute_force_threshold =
+            params[INDEX_TYPE_HGRAPH][HGRAPH_PARAMETER_BRUTE_FORCE_THRESHOLD].GetFloat();
+        CHECK_ARGUMENT(  // NOLINT
+            (0.0F <= obj.brute_force_threshold) and (obj.brute_force_threshold <= 1.0F),
+            fmt::format("brute_force_threshold({}) must in range[0.0, 1.0]",
+                        obj.brute_force_threshold));
+    }
 
     return obj;
 }

--- a/src/algorithm/hgraph/hgraph_parameter.h
+++ b/src/algorithm/hgraph/hgraph_parameter.h
@@ -82,6 +82,11 @@ public:
     bool use_reorder{false};
     bool use_extra_info_filter{false};
     bool rabitq_one_bit_search{false};
+    // If > 0 and the active filter's ValidRatio() <= brute_force_threshold,
+    // the search bypasses the graph traversal and runs an exact scan over the
+    // valid inner ids using the best available flatten codes. Default 0
+    // preserves existing behaviour.
+    float brute_force_threshold{0.0F};
 
 private:
     HGraphSearchParameters() = default;

--- a/src/algorithm/hgraph/hgraph_parameter_test.cpp
+++ b/src/algorithm/hgraph/hgraph_parameter_test.cpp
@@ -227,3 +227,32 @@ TEST_CASE("HGraph maps label_remap_type to inner index parameter", "[ut][HGraphP
     REQUIRE(typed_param->bottom_graph_param != nullptr);
     REQUIRE(typed_param->label_remap_type == vsag::LabelRemapType::ROBIN);
 }
+
+TEST_CASE("HGraphSearchParameters parses brute_force_threshold",
+          "[ut][HGraphSearchParameters][brute_force_threshold]") {
+    SECTION("default is 0") {
+        auto params = vsag::HGraphSearchParameters::FromJson(R"({"hgraph": {"ef_search": 32}})");
+        REQUIRE(params.brute_force_threshold == 0.0F);
+    }
+
+    SECTION("accepts values in [0, 1]") {
+        auto params = vsag::HGraphSearchParameters::FromJson(
+            R"({"hgraph": {"ef_search": 32, "brute_force_threshold": 0.25}})");
+        REQUIRE(params.brute_force_threshold == 0.25F);
+
+        params = vsag::HGraphSearchParameters::FromJson(
+            R"({"hgraph": {"ef_search": 32, "brute_force_threshold": 1.0}})");
+        REQUIRE(params.brute_force_threshold == 1.0F);
+
+        params = vsag::HGraphSearchParameters::FromJson(
+            R"({"hgraph": {"ef_search": 32, "brute_force_threshold": 0.0}})");
+        REQUIRE(params.brute_force_threshold == 0.0F);
+    }
+
+    SECTION("rejects out-of-range values") {
+        REQUIRE_THROWS(vsag::HGraphSearchParameters::FromJson(
+            R"({"hgraph": {"ef_search": 32, "brute_force_threshold": -0.1}})"));
+        REQUIRE_THROWS(vsag::HGraphSearchParameters::FromJson(
+            R"({"hgraph": {"ef_search": 32, "brute_force_threshold": 1.5}})"));
+    }
+}

--- a/src/algorithm/hgraph/hgraph_search.cpp
+++ b/src/algorithm/hgraph/hgraph_search.cpp
@@ -129,16 +129,12 @@ HGraph::KnnSearch(const DatasetPtr& query,
     auto* iter_filter_ctx = static_cast<IteratorFilterContext*>(iter_ctx);
     auto search_result = DistanceHeap::MakeInstanceBySize<true, false>(ctx.alloc, k);
     const auto* query_data = get_data(query);
-    bool brute_force_used = false;
-    if (not is_last_filter and iter_filter_ctx->IsFirstUsed() and
-        params.brute_force_threshold > 0.0F) {
-        float valid_ratio = ft != nullptr ? ft->ValidRatio() : 1.0F;
-        if (valid_ratio <= params.brute_force_threshold) {
-            search_result = this->brute_force_search<InnerSearchMode::KNN_SEARCH>(
-                query_data, ft, k, 0.0F, &ctx);
-            brute_force_used = true;
-        }
-    }
+    // Note: brute_force_threshold is intentionally not applied here. The
+    // iterator KnnSearch API pages results across multiple calls via
+    // iter_filter_ctx; a single brute-force sweep would either need to drive
+    // that pagination state itself or be wasted on subsequent calls. The
+    // non-iterator KnnSearch overload (which delegates to SearchWithRequest)
+    // still benefits from the brute-force fallback.
     if (is_last_filter) {
         while (!iter_filter_ctx->Empty()) {
             uint32_t cur_inner_id = iter_filter_ctx->GetTopID();
@@ -146,7 +142,7 @@ HGraph::KnnSearch(const DatasetPtr& query,
             search_result->Push(cur_dist, cur_inner_id);
             iter_filter_ctx->PopDiscard();
         }
-    } else if (not brute_force_used) {
+    } else {
         InnerSearchParam search_param;
         search_param.ep = this->entry_point_id_;
         search_param.topk = 1;
@@ -319,7 +315,12 @@ HGraph::brute_force_search(const void* query,
         flatten = this->raw_vector_;
     }
 
-    auto result = DistanceHeap::MakeInstanceBySize<true, false>(alloc, -1);
+    DistHeapPtr result;
+    if constexpr (mode == InnerSearchMode::RANGE_SEARCH) {
+        result = DistanceHeap::MakeInstanceBySize<true, false>(alloc, -1);
+    } else {
+        result = DistanceHeap::MakeInstanceBySize<true, true>(alloc, topk);
+    }
     if (flatten == nullptr) {
         return result;
     }
@@ -356,12 +357,7 @@ HGraph::brute_force_search(const void* query,
                     result->Push(dist, inner_id);
                 }
             } else {
-                if (static_cast<int64_t>(result->Size()) < topk) {
-                    result->Push(dist, inner_id);
-                } else if (dist < result->Top().first) {
-                    result->Pop();
-                    result->Push(dist, inner_id);
-                }
+                result->Push(dist, inner_id);
             }
         }
     }

--- a/src/algorithm/hgraph/hgraph_search.cpp
+++ b/src/algorithm/hgraph/hgraph_search.cpp
@@ -129,6 +129,16 @@ HGraph::KnnSearch(const DatasetPtr& query,
     auto* iter_filter_ctx = static_cast<IteratorFilterContext*>(iter_ctx);
     auto search_result = DistanceHeap::MakeInstanceBySize<true, false>(ctx.alloc, k);
     const auto* query_data = get_data(query);
+    bool brute_force_used = false;
+    if (not is_last_filter and iter_filter_ctx->IsFirstUsed() and
+        params.brute_force_threshold > 0.0F) {
+        float valid_ratio = ft != nullptr ? ft->ValidRatio() : 1.0F;
+        if (valid_ratio <= params.brute_force_threshold) {
+            search_result = this->brute_force_search<InnerSearchMode::KNN_SEARCH>(
+                query_data, ft, k, 0.0F, &ctx);
+            brute_force_used = true;
+        }
+    }
     if (is_last_filter) {
         while (!iter_filter_ctx->Empty()) {
             uint32_t cur_inner_id = iter_filter_ctx->GetTopID();
@@ -136,7 +146,7 @@ HGraph::KnnSearch(const DatasetPtr& query,
             search_result->Push(cur_dist, cur_inner_id);
             iter_filter_ctx->PopDiscard();
         }
-    } else {
+    } else if (not brute_force_used) {
         InnerSearchParam search_param;
         search_param.ep = this->entry_point_id_;
         search_param.topk = 1;
@@ -292,6 +302,72 @@ HGraph::search_one_graph(const void* query,
     return result;
 }
 
+template <InnerSearchMode mode>
+DistHeapPtr
+HGraph::brute_force_search(const void* query,
+                           const FilterPtr& filter,
+                           int64_t topk,
+                           float radius,
+                           QueryContext* ctx) const {
+    Allocator* alloc = (ctx != nullptr && ctx->alloc != nullptr) ? ctx->alloc : this->allocator_;
+
+    auto flatten = this->basic_flatten_codes_;
+    if (this->has_precise_reorder()) {
+        flatten = this->high_precise_codes_;
+    }
+    if (this->create_new_raw_vector_ && this->raw_vector_ != nullptr) {
+        flatten = this->raw_vector_;
+    }
+
+    auto result = DistanceHeap::MakeInstanceBySize<true, false>(alloc, -1);
+    if (flatten == nullptr) {
+        return result;
+    }
+
+    auto total = static_cast<InnerIdType>(this->total_count_.load());
+    if (total == 0) {
+        return result;
+    }
+
+    auto computer = flatten->FactoryComputer(query);
+
+    constexpr InnerIdType brute_force_batch_size = 64;
+    Vector<InnerIdType> batch_ids(brute_force_batch_size, alloc);
+    Vector<float> batch_dists(brute_force_batch_size, alloc);
+
+    InnerIdType cursor = 0;
+    while (cursor < total) {
+        InnerIdType batch_count = 0;
+        while (cursor < total && batch_count < brute_force_batch_size) {
+            if (filter == nullptr || filter->CheckValid(cursor)) {
+                batch_ids[batch_count++] = cursor;
+            }
+            ++cursor;
+        }
+        if (batch_count == 0) {
+            continue;
+        }
+        flatten->Query(batch_dists.data(), computer, batch_ids.data(), batch_count, ctx);
+        for (InnerIdType i = 0; i < batch_count; ++i) {
+            float dist = batch_dists[i];
+            InnerIdType inner_id = batch_ids[i];
+            if constexpr (mode == InnerSearchMode::RANGE_SEARCH) {
+                if (dist <= radius) {
+                    result->Push(dist, inner_id);
+                }
+            } else {
+                if (static_cast<int64_t>(result->Size()) < topk) {
+                    result->Push(dist, inner_id);
+                } else if (dist < result->Top().first) {
+                    result->Pop();
+                    result->Push(dist, inner_id);
+                }
+            }
+        }
+    }
+    return result;
+}
+
 DatasetPtr
 HGraph::RangeSearch(const DatasetPtr& query,
                     float radius,
@@ -365,17 +441,30 @@ HGraph::RangeSearch(const DatasetPtr& query,
     search_param.enable_reorder = params.enable_reorder;
     search_param.enable_rabitq_one_bit_search = params.rabitq_one_bit_search;
 
-    auto search_result = this->search_one_graph(raw_query,
-                                                this->bottom_graph_,
-                                                this->basic_flatten_codes_,
-                                                search_param,
-                                                (VisitedListPtr) nullptr,
-                                                &ctx);
+    DistHeapPtr search_result;
+    bool brute_force_used = false;
+    if (params.brute_force_threshold > 0.0F) {
+        float valid_ratio = ft != nullptr ? ft->ValidRatio() : 1.0F;
+        if (valid_ratio <= params.brute_force_threshold) {
+            search_result = this->brute_force_search<InnerSearchMode::RANGE_SEARCH>(
+                raw_query, ft, limited_size, radius, &ctx);
+            brute_force_used = true;
+        }
+    }
+    if (not brute_force_used) {
+        search_result = this->search_one_graph(raw_query,
+                                               this->bottom_graph_,
+                                               this->basic_flatten_codes_,
+                                               search_param,
+                                               (VisitedListPtr) nullptr,
+                                               &ctx);
+    }
 
-    if (use_reorder_ and search_param.enable_reorder) {
+    if (not brute_force_used and use_reorder_ and search_param.enable_reorder) {
         this->reorder(
             raw_query, this->get_reorder_codes(), search_result, limited_size, nullptr, ctx);
-    } else if (search_param.enable_reorder and params.rabitq_one_bit_search) {
+    } else if (not brute_force_used and search_param.enable_reorder and
+               params.rabitq_one_bit_search) {
         this->reorder(
             raw_query, this->basic_flatten_codes_, search_result, limited_size, nullptr, ctx);
     }
@@ -558,17 +647,29 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
             ? &rabitq_lower_bound_candidates
             : nullptr;
 
-    auto search_result = this->search_one_graph(raw_query,
-                                                this->bottom_graph_,
-                                                this->basic_flatten_codes_,
-                                                search_param,
-                                                vt,
-                                                &ctx,
-                                                rabitq_lower_bound_candidates_ptr);
+    DistHeapPtr search_result;
+    bool brute_force_used = false;
+    if (params.brute_force_threshold > 0.0F) {
+        float valid_ratio = ft != nullptr ? ft->ValidRatio() : 1.0F;
+        if (valid_ratio <= params.brute_force_threshold) {
+            search_result =
+                this->brute_force_search<InnerSearchMode::KNN_SEARCH>(raw_query, ft, k, 0.0F, &ctx);
+            brute_force_used = true;
+        }
+    }
+    if (not brute_force_used) {
+        search_result = this->search_one_graph(raw_query,
+                                               this->bottom_graph_,
+                                               this->basic_flatten_codes_,
+                                               search_param,
+                                               vt,
+                                               &ctx,
+                                               rabitq_lower_bound_candidates_ptr);
+    }
 
     this->pool_->ReturnOne(vt);
 
-    if (use_reorder_ and search_param.enable_reorder) {
+    if (not brute_force_used and use_reorder_ and search_param.enable_reorder) {
         this->reorder(raw_query,
                       this->get_reorder_codes(),
                       search_result,
@@ -576,7 +677,8 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
                       nullptr,
                       ctx,
                       rabitq_lower_bound_candidates_ptr);
-    } else if (search_param.enable_reorder and params.rabitq_one_bit_search) {
+    } else if (not brute_force_used and search_param.enable_reorder and
+               params.rabitq_one_bit_search) {
         this->reorder(raw_query, this->basic_flatten_codes_, search_result, k, nullptr, ctx);
     }
 

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -177,6 +177,7 @@ const char* const HGRAPH_PRECISE_FILE_PATH = "precise_file_path";
 const char* const HGRAPH_PARAMETER_EF_RUNTIME = "ef_search";
 const char* const HGRAPH_PARAMETER_HOPS_LIMIT = "hops_limit";
 const char* const HGRAPH_PARAMETER_RABITQ_ONE_BIT_SEARCH = "rabitq_one_bit_search";
+const char* const HGRAPH_PARAMETER_BRUTE_FORCE_THRESHOLD = "brute_force_threshold";
 const char* const HGRAPH_EXTRA_INFO_SIZE = "extra_info_size";
 const char* const HGRAPH_SUPPORT_DUPLICATE = "support_duplicate";
 const char* const HGRAPH_DUPLICATE_DISTANCE_THRESHOLD = "duplicate_distance_threshold";

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -2447,3 +2447,171 @@ TestHGraphReverseEdges(const fixtures::HGraphTestIndexPtr& test_index,
 }
 
 HGRAPH_PR_DAILY_CASE("HGraph Reverse Edges", "[ft][build][hgraph]", TestHGraphReverseEdges)
+
+namespace {
+
+class ModuloFilter : public vsag::Filter {
+public:
+    ModuloFilter(int64_t modulus, int64_t residue, float valid_ratio)
+        : modulus_(modulus), residue_(residue), valid_ratio_(valid_ratio) {
+    }
+
+    bool
+    CheckValid(int64_t id) const override {
+        return (id % modulus_) == residue_;
+    }
+
+    float
+    ValidRatio() const override {
+        return valid_ratio_;
+    }
+
+private:
+    int64_t modulus_;
+    int64_t residue_;
+    float valid_ratio_;
+};
+
+}  // namespace
+
+TEST_CASE("(PR) HGraph brute_force_threshold", "[ft][hgraph][pr][brute_force_threshold]") {
+    constexpr int64_t dim = 16;
+    constexpr int64_t base_count = 1000;
+    constexpr int64_t modulus = 50;
+    constexpr int64_t residue = 7;
+    constexpr int64_t topk = 5;
+
+    std::string hgraph_params = R"({
+        "dtype": "float32",
+        "metric_type": "l2",
+        "dim": 16,
+        "index_param": {
+            "base_quantization_type": "fp32",
+            "max_degree": 32,
+            "ef_construction": 100,
+            "use_reorder": false
+        }
+    })";
+    auto factory_res = vsag::Factory::CreateIndex("hgraph", hgraph_params);
+    REQUIRE(factory_res.has_value());
+    auto index = std::move(factory_res.value());
+
+    std::mt19937 rng(20260528);
+    std::uniform_real_distribution<float> dist(-1.0F, 1.0F);
+    std::vector<float> base_vectors(base_count * dim);
+    std::vector<int64_t> ids(base_count);
+    for (int64_t i = 0; i < base_count; ++i) {
+        ids[i] = i;
+        for (int64_t j = 0; j < dim; ++j) {
+            base_vectors[i * dim + j] = dist(rng);
+        }
+    }
+    auto base = vsag::Dataset::Make();
+    base->NumElements(base_count)
+        ->Dim(dim)
+        ->Ids(ids.data())
+        ->Float32Vectors(base_vectors.data())
+        ->Owner(false);
+    auto build_res = index->Build(base);
+    REQUIRE(build_res.has_value());
+
+    std::vector<float> query_vec(dim);
+    for (int64_t j = 0; j < dim; ++j) {
+        query_vec[j] = dist(rng);
+    }
+    auto query = vsag::Dataset::Make();
+    query->NumElements(1)->Dim(dim)->Float32Vectors(query_vec.data())->Owner(false);
+
+    auto filter =
+        std::make_shared<ModuloFilter>(modulus, residue, 1.0F / static_cast<float>(modulus));
+
+    auto search_param_graph = R"({"hgraph": {"ef_search": 200}})";
+    auto search_param_brute = R"({"hgraph": {"ef_search": 200, "brute_force_threshold": 0.5}})";
+
+    auto res_graph = index->KnnSearch(query, topk, search_param_graph, filter);
+    auto res_brute = index->KnnSearch(query, topk, search_param_brute, filter);
+
+    REQUIRE(res_graph.has_value());
+    REQUIRE(res_brute.has_value());
+    REQUIRE(res_brute.value()->GetDim() == topk);
+
+    // Independent reference: scan all base ids that pass the filter, compute L2.
+    std::vector<std::pair<float, int64_t>> reference;
+    for (int64_t i = 0; i < base_count; ++i) {
+        if ((i % modulus) != residue) {
+            continue;
+        }
+        float d = 0.0F;
+        for (int64_t j = 0; j < dim; ++j) {
+            float diff = base_vectors[i * dim + j] - query_vec[j];
+            d += diff * diff;
+        }
+        reference.emplace_back(d, ids[i]);
+    }
+    std::sort(reference.begin(), reference.end());
+    REQUIRE(static_cast<int64_t>(reference.size()) >= topk);
+
+    const auto* brute_ids = res_brute.value()->GetIds();
+    const auto* brute_dists = res_brute.value()->GetDistances();
+    for (int64_t k = 0; k < topk; ++k) {
+        REQUIRE(brute_ids[k] == reference[k].second);
+        REQUIRE(std::abs(brute_dists[k] - reference[k].first) < 1e-5F);
+    }
+}
+
+TEST_CASE("(PR) HGraph brute_force_threshold default is no-op",
+          "[ft][hgraph][pr][brute_force_threshold]") {
+    constexpr int64_t dim = 8;
+    constexpr int64_t base_count = 200;
+    constexpr int64_t topk = 3;
+
+    std::string hgraph_params = R"({
+        "dtype": "float32",
+        "metric_type": "l2",
+        "dim": 8,
+        "index_param": {
+            "base_quantization_type": "fp32",
+            "max_degree": 16,
+            "ef_construction": 64,
+            "use_reorder": false
+        }
+    })";
+    auto index = vsag::Factory::CreateIndex("hgraph", hgraph_params).value();
+
+    std::mt19937 rng(42);
+    std::uniform_real_distribution<float> dist(-1.0F, 1.0F);
+    std::vector<float> base_vectors(base_count * dim);
+    std::vector<int64_t> ids(base_count);
+    for (int64_t i = 0; i < base_count; ++i) {
+        ids[i] = i;
+        for (int64_t j = 0; j < dim; ++j) {
+            base_vectors[i * dim + j] = dist(rng);
+        }
+    }
+    auto base = vsag::Dataset::Make();
+    base->NumElements(base_count)
+        ->Dim(dim)
+        ->Ids(ids.data())
+        ->Float32Vectors(base_vectors.data())
+        ->Owner(false);
+    REQUIRE(index->Build(base).has_value());
+
+    std::vector<float> query_vec(dim);
+    for (int64_t j = 0; j < dim; ++j) {
+        query_vec[j] = dist(rng);
+    }
+    auto query = vsag::Dataset::Make();
+    query->NumElements(1)->Dim(dim)->Float32Vectors(query_vec.data())->Owner(false);
+
+    auto baseline = index->KnnSearch(query, topk, R"({"hgraph": {"ef_search": 64}})");
+    auto with_zero = index->KnnSearch(
+        query, topk, R"({"hgraph": {"ef_search": 64, "brute_force_threshold": 0.0}})");
+    REQUIRE(baseline.has_value());
+    REQUIRE(with_zero.has_value());
+    REQUIRE(baseline.value()->GetDim() == with_zero.value()->GetDim());
+    for (int64_t k = 0; k < baseline.value()->GetDim(); ++k) {
+        REQUIRE(baseline.value()->GetIds()[k] == with_zero.value()->GetIds()[k]);
+        REQUIRE(std::abs(baseline.value()->GetDistances()[k] -
+                         with_zero.value()->GetDistances()[k]) < 1e-6F);
+    }
+}


### PR DESCRIPTION
## Summary

- Add a new HGraph search-time knob `brute_force_threshold` (float, default `0.0` = disabled, range `[0.0, 1.0]`). When the active filter's effective `ValidRatio` is below the threshold, HGraph bypasses the graph traversal and performs an exact scan over the filter-valid inner ids using the best available flatten codes (`raw_vector_` > `high_precise_codes_` > `basic_flatten_codes_`, mirroring `HGraph::CalcDistanceById`).
- Wired into all three HGraph search entry points: `KnnSearch` (both signatures), `RangeSearch`, and `SearchWithRequest`. For the iterator-context `KnnSearch`, the branch only fires on the first call (`IsFirstUsed()`) and never on `is_last_filter` drains, so iteration state is preserved.
- Default behaviour is unchanged: with `brute_force_threshold = 0.0`, the graph path is bit-identical to before.

Fixes: #1631

## Test plan

- [x] `make fmt` — clang-format-15 clean.
- [x] `make lint` — clang-tidy-15 clean (no new warnings against changed files).
- [x] `./build/tests/unittests -d yes "[brute_force_threshold]"` — 6 assertions in 1 test case (param parsing: default 0, valid range `[0,1]`, rejects `<0` and `>1`).
- [x] `./build/tests/functests -d yes "[brute_force_threshold]"` — 26 assertions in 2 test cases (end-to-end brute-force matches an independent reference scan to within float tolerance; `brute_force_threshold = 0.0` matches baseline byte-for-byte).
- [x] `./build/tests/functests -d yes "[hgraph][pr]"` — full HGraph PR suite, 837,663 assertions in 36 test cases passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
