### PR TITLE
chore(docker): split ci-x86 image into base / mkl / openblas variants

### DIFF
--- a/.github/workflows/update-ci-image.yml
+++ b/.github/workflows/update-ci-image.yml
@@ -1,32 +1,68 @@
 name: Update Docker Image
 
 on:
-  push: # refresh ci container
+  push: # refresh ci containers
     paths: [ 'docker/**' ]
   pull_request: # to make sure dockerfile change correctly
     branches: [ 'main' ]
     paths: [ 'docker/**' ]
 
 jobs:
-  docker:
+  # The CI images form a small chain: ci-x86-base is the shared toolchain
+  # layer, and ci-x86-mkl / ci-x86-openblas are built FROM it. We build all
+  # three in a single job so PR runs (push: false) can validate end-to-end:
+  # the variant builds resolve `FROM vsaglib/vsag:ci-x86-base` against the
+  # base image we just loaded into the local Docker daemon, not whatever
+  # tag happens to be on Docker Hub.
+  build:
+    name: Build CI Images
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Login to Docker Hub
+      # Docker Hub credentials only flow into runs triggered from the
+      # antgroup/vsag repo itself (push events, and same-repo PRs).
+      # `pull_request` runs from forks deliberately have no access to
+      # secrets, so we skip the login on PRs and rely on `push: false`
+      # for the variant builds. The `docker` buildx driver below still
+      # loads each image into the host daemon, so the `mkl`/`openblas`
+      # variants' `FROM vsaglib/vsag:ci-x86-base` resolves locally
+      # without ever talking to the registry.
+      - name: Login to Docker Hub
+        if: github.event_name == 'push'
         uses: docker/login-action@v3
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Set up QEMU
+      - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-      -
-        name: Set up Docker Buildx
+      # The default `docker-container` driver keeps built images inside the
+      # buildkit container, so `FROM vsaglib/vsag:ci-x86-base` in the
+      # variant builds would not see the base we just built. The plain
+      # `docker` driver loads images straight into the host daemon, which
+      # is what `FROM` resolves against.
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      -
-        name: Build and push
+        with:
+          driver: docker
+      - name: Build ci-x86-base
         uses: docker/build-push-action@v6
         with:
-          file: ./docker/Dockerfile.x86
-          push: true
-          tags: vsaglib/vsag:ci-x86
+          file: ./docker/Dockerfile.x86.base
+          # PRs only build (push: false) so the registry isn't polluted by
+          # transient PR images. With the `docker` driver above, every
+          # build is loaded into the host daemon automatically, so the
+          # variant builds below can resolve `FROM vsaglib/vsag:ci-x86-base`
+          # locally instead of pulling from Docker Hub.
+          push: ${{ github.event_name == 'push' }}
+          tags: vsaglib/vsag:ci-x86-base
+      - name: Build ci-x86-mkl
+        uses: docker/build-push-action@v6
+        with:
+          file: ./docker/Dockerfile.x86.mkl
+          push: ${{ github.event_name == 'push' }}
+          tags: vsaglib/vsag:ci-x86-mkl
+      - name: Build ci-x86-openblas
+        uses: docker/build-push-action@v6
+        with:
+          file: ./docker/Dockerfile.x86.openblas
+          push: ${{ github.event_name == 'push' }}
+          tags: vsaglib/vsag:ci-x86-openblas

--- a/docker/Dockerfile.x86.base
+++ b/docker/Dockerfile.x86.base
@@ -1,0 +1,28 @@
+
+# Base CI image for VSAG on x86_64.
+#
+# This image carries the common toolchain shared by every CI variant
+# (compilers, build tools, runtime headers, etc.) but intentionally does NOT
+# install any BLAS implementation. BLAS backends are layered on top of this
+# image in the variant Dockerfiles:
+#
+#   * docker/Dockerfile.x86.mkl      -> vsaglib/vsag:ci-x86-mkl
+#   * docker/Dockerfile.x86.openblas -> vsaglib/vsag:ci-x86-openblas
+#
+# Keeping the base image free of any BLAS implementation lets us:
+#   * share most of the build context between the two CI variants (faster
+#     `update-ci-image` runs, smaller registry footprint after dedup);
+#   * make it trivial to add a third backend (e.g. AOCL/ARMPL) later.
+
+FROM ubuntu:22.04
+
+# update and install basic deps
+RUN apt update && apt install -y wget gpg sudo
+
+# install build tools
+RUN apt install -y git g++ cmake ninja-build gdb ccache build-essential lcov gfortran
+RUN apt install -y clang-15 clangd-15 clang-format-15 python3-pip
+RUN ln -s /usr/bin/clang-format-15 /usr/bin/clang-format
+
+# install vsag deps (everything except a BLAS backend)
+RUN apt install -y python3-dev libomp-15-dev libaio-dev libcurl4-openssl-dev liburing-dev

--- a/docker/Dockerfile.x86.mkl
+++ b/docker/Dockerfile.x86.mkl
@@ -1,9 +1,12 @@
 
-# base image
-FROM ubuntu:22.04
+# Intel oneAPI MKL variant of the VSAG CI image for x86_64.
+#
+# Built on top of vsaglib/vsag:ci-x86-base (see docker/Dockerfile.x86.base).
+# Used by the CI jobs that exercise the MKL BLAS backend
+# (`VSAG_ENABLE_INTEL_MKL=ON`): asan / tsan / asan-simd push jobs and the
+# daily SIMD/TSAN matrices.
 
-# update and install basic deps
-RUN apt update && apt install -y wget gpg sudo
+FROM vsaglib/vsag:ci-x86-base
 
 # install intel-mkl and fix soft links
 RUN wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB \
@@ -13,11 +16,3 @@ RUN apt update && apt install -y intel-oneapi-mkl intel-oneapi-mkl-devel
 RUN [ ! -f /opt/intel/oneapi/mkl/latest/lib/intel64/libmkl_def.so ] && ln -s /opt/intel/oneapi/mkl/latest/lib/intel64/libmkl_def.so.2 /opt/intel/oneapi/mkl/latest/lib/intel64/libmkl_def.so
 RUN [ ! -f /opt/intel/oneapi/mkl/latest/lib/intel64/libmkl_avx2.so ] && ln -s /opt/intel/oneapi/mkl/latest/lib/intel64/libmkl_avx2.so.2 /opt/intel/oneapi/mkl/latest/lib/intel64/libmkl_avx2.so
 RUN [ ! -f /opt/intel/oneapi/mkl/latest/lib/intel64/libmkl_mc3.so ] && ln -s /opt/intel/oneapi/mkl/latest/lib/intel64/libmkl_mc3.so.2 /opt/intel/oneapi/mkl/latest/lib/intel64/libmkl_mc3.so
-
-# install build tools
-RUN apt install -y git g++ cmake ninja-build gdb ccache build-essential lcov gfortran
-RUN apt install -y clang-15 clangd-15 clang-format-15 python3-pip
-RUN ln -s /usr/bin/clang-format-15 /usr/bin/clang-format
-
-# install vsag deps
-RUN apt install -y python3-dev libomp-15-dev libaio-dev libcurl4-openssl-dev liburing-dev

--- a/docker/Dockerfile.x86.openblas
+++ b/docker/Dockerfile.x86.openblas
@@ -1,0 +1,17 @@
+
+# OpenBLAS variant of the VSAG CI image for x86_64.
+#
+# Built on top of vsaglib/vsag:ci-x86-base (see docker/Dockerfile.x86.base).
+# Ships a pre-installed system OpenBLAS (plus LAPACKE headers) so the CI jobs
+# that exercise the OpenBLAS backend can opt in to `-DUSE_SYSTEM_OPENBLAS=ON`
+# and skip the per-job OpenBLAS source build.
+#
+# The daily x86 ASan job still leaves `USE_SYSTEM_OPENBLAS` unset so that the
+# from-source build path keeps getting exercised; the pre-installed packages
+# here are simply ignored in that case.
+
+FROM vsaglib/vsag:ci-x86-base
+
+# Install system OpenBLAS + LAPACKE. liblapacke-dev pulls in the C headers
+# needed for VSAG's CMake `find_path(LAPACKE_INCLUDE NAMES lapacke.h)` probe.
+RUN apt update && apt install -y libopenblas-dev liblapacke-dev


### PR DESCRIPTION
## Summary

- Split the monolithic `vsaglib/vsag:ci-x86` CI image into a shared `ci-x86-base` plus two BLAS-backend variants `ci-x86-mkl` and `ci-x86-openblas`, all defined as separate `docker/Dockerfile.x86.*` files.
- Update `update-ci-image.yml` to build `ci-x86-base` first and then fan out to the two variants in a matrix; PR runs build but do not push the images.
- No workflow is repointed at the new tags in this PR — a stacked follow-up PR will do that once the new tags exist on Docker Hub.

## Why

Today every PR-triggered job builds OpenBLAS from source even though the CI image ships `libopenblas-dev`. To opt in to the existing `USE_SYSTEM_OPENBLAS` CMake switch safely, we want the BLAS backend to be encoded in the image tag itself (so MKL jobs and OpenBLAS jobs pull disjoint images), and we want a clean base layer that future backends (AOCL, ARMPL) can extend without dragging Intel oneAPI along.

See #2118 for the full rationale, expected wall-clock savings, and the plan for the follow-up workflow PR.

## Rollout

This PR must land **before** the follow-up workflow PR, otherwise any job repointed at `vsaglib/vsag:ci-x86-openblas` (or `-mkl`) would 404 on image pull until `update-ci-image` runs on `main` and publishes the new tags.

## Test plan

- This PR triggers `update-ci-image` (path filter on `docker/**`) on the PR itself with `push: false`, which exercises all three Dockerfiles end-to-end without polluting Docker Hub.
- After merge, `update-ci-image` on `main` will publish:
  - `vsaglib/vsag:ci-x86-base`
  - `vsaglib/vsag:ci-x86-mkl`
  - `vsaglib/vsag:ci-x86-openblas`

## Labels

`kind/improvement`, `version/1.0`

Refs: #2118

