### PR TITLE
ci: switch fast-path jobs to system OpenBLAS and split-image tags

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -46,13 +46,13 @@ jobs:
           command: |
             sudo apt update
             sudo apt install -y gfortran python3-dev libomp-15-dev gcc make cmake g++ lcov libaio-dev libcurl4-openssl-dev ninja-build 
-            sudo apt-get install -y libopenblas-dev
+            sudo apt-get install -y libopenblas-dev liblapacke-dev
             sudo dd if=/dev/zero of=.swapfile bs=2M count=2048
             sudo chmod 600 .swapfile
             sudo mkswap .swapfile
             sudo swapon .swapfile
       - run:
-          command: export CMAKE_GENERATOR="Ninja" && export VSAG_ENABLE_INTEL_MKL=OFF && export COMPILE_JOBS=4 && make test_parallel
+          command: export CMAKE_GENERATOR="Ninja" && export VSAG_ENABLE_INTEL_MKL=OFF && export EXTRA_DEFINED="-DUSE_SYSTEM_OPENBLAS=ON" && export COMPILE_JOBS=4 && make test_parallel
           no_output_timeout: 50m
       - run:
           name: remove_swap_file
@@ -78,13 +78,13 @@ jobs:
           command: |
             sudo apt update
             sudo apt install -y gfortran python3-dev libomp-15-dev gcc make cmake g++ lcov libaio-dev libcurl4-openssl-dev ninja-build 
-            sudo apt-get install -y libopenblas-dev
+            sudo apt-get install -y libopenblas-dev liblapacke-dev
             sudo dd if=/dev/zero of=.swapfile bs=2M count=2048
             sudo chmod 600 .swapfile
             sudo mkswap .swapfile
             sudo swapon .swapfile
       - run:
-          command: export CMAKE_GENERATOR="Ninja" && export VSAG_ENABLE_INTEL_MKL=OFF && export COMPILE_JOBS=4 && make test_parallel
+          command: export CMAKE_GENERATOR="Ninja" && export VSAG_ENABLE_INTEL_MKL=OFF && export EXTRA_DEFINED="-DUSE_SYSTEM_OPENBLAS=ON" && export COMPILE_JOBS=4 && make test_parallel
           no_output_timeout: 50m
       - run:
           name: remove_swap_file

--- a/.github/workflows/asan_build_and_test.yml
+++ b/.github/workflows/asan_build_and_test.yml
@@ -11,7 +11,7 @@ jobs:
     name: Asan Build X86
     runs-on: ubuntu-22.04
     container:
-      image: vsaglib/vsag:ci-x86
+      image: vsaglib/vsag:ci-x86-mkl
       volumes:
         - /opt:/useless
     concurrency:
@@ -88,7 +88,7 @@ jobs:
       matrix:
         test_type: [ unittests, functests ]
     container:
-      image: vsaglib/vsag:ci-x86
+      image: vsaglib/vsag:ci-x86-mkl
       volumes:
         - /opt:/useless
     steps:
@@ -162,7 +162,7 @@ jobs:
     needs: build_asan_x86
     runs-on: ubuntu-22.04
     container:
-      image: vsaglib/vsag:ci-x86
+      image: vsaglib/vsag:ci-x86-mkl
       volumes:
         - /opt:/useless
     concurrency:

--- a/.github/workflows/asan_with_simd_option.yml
+++ b/.github/workflows/asan_with_simd_option.yml
@@ -12,7 +12,7 @@ jobs:
     name: Asan Build Simd
     runs-on: ubuntu-22.04
     container:
-      image: vsaglib/vsag:ci-x86
+      image: vsaglib/vsag:ci-x86-mkl
       volumes:
         - /opt:/useless
     strategy:
@@ -72,7 +72,7 @@ jobs:
       group: test-${{ matrix.simd_key }}-${{ matrix.test_type }}-${{ github.event.pull_request.number || github.sha }}
       cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     container:
-      image: vsaglib/vsag:ci-x86
+      image: vsaglib/vsag:ci-x86-mkl
       volumes:
         - /opt:/useless
     steps:

--- a/.github/workflows/check_compatibility.yml
+++ b/.github/workflows/check_compatibility.yml
@@ -15,7 +15,7 @@ jobs:
       group: compatibility-${{ github.event.pull_request.number || github.sha }}
       cancel-in-progress: ${{ github.event_name == "pull_request" }}
     container:
-      image: vsaglib/vsag:ci-x86
+      image: vsaglib/vsag:ci-x86-openblas
     steps:
       - name: Install GitHub CLI
         run: |
@@ -38,6 +38,6 @@ jobs:
             || echo "Warning: Failed to download compatibility indexes"
       - uses: actions/checkout@v4
       - name: Compile Check Compatibility Tools
-        run: export CMAKE_GENERATOR="Ninja"; make release VSAG_ENABLE_TOOLS=ON
+        run: export CMAKE_GENERATOR="Ninja" EXTRA_DEFINED="-DUSE_SYSTEM_OPENBLAS=ON"; make release VSAG_ENABLE_TOOLS=ON
       - name: Run Check Compatibility
         run: bash ./scripts/check_compatibility.sh

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -35,7 +35,7 @@ jobs:
       group: coverage-${{ github.event.pull_request.number || github.sha }}
       cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     container:
-      image: vsaglib/vsag:ci-x86
+      image: vsaglib/vsag:ci-x86-openblas
     steps:
       - uses: actions/checkout@v4
         with:
@@ -54,7 +54,10 @@ jobs:
           save: ${{ github.event_name != 'pull_request' }}
           key: build-cov-${{ hashFiles('./CMakeLists.txt') }}-${{ hashFiles('./.circleci/fresh_ci_cache.commit') }}
       - name: Compile with Coverage Flags
-        run: export CMAKE_GENERATOR="Ninja"; make cov
+        # `make cov` defaults to the OpenBLAS backend. Use the system-installed
+        # OpenBLAS in the ci-x86-openblas image instead of building OpenBLAS
+        # from source every run.
+        run: export CMAKE_GENERATOR="Ninja" EXTRA_DEFINED="-DUSE_SYSTEM_OPENBLAS=ON"; make cov
       - name: Run Test
         run: |
           ./scripts/testing/test_parallel_bg.sh

--- a/.github/workflows/daily_test.yml
+++ b/.github/workflows/daily_test.yml
@@ -10,7 +10,7 @@ jobs:
     name: Asan Build X86
     runs-on: ubuntu-22.04
     container:
-      image: vsaglib/vsag:ci-x86
+      image: vsaglib/vsag:ci-x86-openblas
       volumes:
         - /opt:/useless
     concurrency:
@@ -29,7 +29,14 @@ jobs:
           save: false
           key: build-${{ hashFiles('./CMakeLists.txt') }}-${{ hashFiles('./.circleci/fresh_ci_cache.commit') }}
       - name: Make Asan
-        run: export VSAG_ENABLE_INTEL_MKL=ON CMAKE_GENERATOR="Ninja"; make asan COMPILE_JOBS=4 VSAG_ENABLE_EXAMPLES=ON
+        # Daily guard for the from-source OpenBLAS build path. We intentionally
+        # do NOT pass -DUSE_SYSTEM_OPENBLAS=ON here: even though the image
+        # ships libopenblas-dev, leaving the flag at its default (OFF) means
+        # CMake downloads and compiles OpenBLAS via ExternalProject_Add, which
+        # is what release artifacts depend on. PR CI / coverage / lint use the
+        # system OpenBLAS for speed; this job is the one that keeps the
+        # source-build path covered.
+        run: export CMAKE_GENERATOR="Ninja"; make asan COMPILE_JOBS=4 VSAG_ENABLE_EXAMPLES=ON
       - name: Clean
         run: find ./build -type f -name "*.o" -exec rm -f {} +
       - name: Save Test
@@ -85,7 +92,10 @@ jobs:
       matrix:
         test_type: [ unittests, functests ]
     container:
-      image: vsaglib/vsag:ci-x86
+      # Matches daily_build_asan_x86: the test binaries were built against the
+      # from-source OpenBLAS (statically linked), so any image with the rest
+      # of the runtime would do. We pick ci-x86-openblas for consistency.
+      image: vsaglib/vsag:ci-x86-openblas
       volumes:
         - /opt:/useless
     steps:
@@ -184,7 +194,7 @@ jobs:
     name: Asan Build Simd
     runs-on: ubuntu-22.04
     container:
-      image: vsaglib/vsag:ci-x86
+      image: vsaglib/vsag:ci-x86-mkl
       volumes:
         - /opt:/useless
     strategy:
@@ -240,7 +250,7 @@ jobs:
       group: daily_test_simd-${{ matrix.simd_key }}-${{ matrix.test_type }}
       cancel-in-progress: true
     container:
-      image: vsaglib/vsag:ci-x86
+      image: vsaglib/vsag:ci-x86-mkl
       volumes:
         - /opt:/useless
     steps:
@@ -294,7 +304,7 @@ jobs:
       group: daily_build_tsan_x86
       cancel-in-progress: true
     container:
-      image: vsaglib/vsag:ci-x86
+      image: vsaglib/vsag:ci-x86-mkl
     steps:
       - uses: actions/checkout@v4
         with:
@@ -327,7 +337,7 @@ jobs:
       group: daily_test_tsan_x86
       cancel-in-progress: true
     container:
-      image: vsaglib/vsag:ci-x86
+      image: vsaglib/vsag:ci-x86-mkl
     steps:
       - uses: actions/checkout@v4
       - name: Clean Env

--- a/.github/workflows/generate_old_version_index.yml
+++ b/.github/workflows/generate_old_version_index.yml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       contents: write
     container:
-      image: vsaglib/vsag:ci-x86
+      image: vsaglib/vsag:ci-x86-openblas
     steps:
       - name: Get Repo
         uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     # runs-on: self-hosted
     container:
-      image: vsaglib/vsag:ci-x86
+      image: vsaglib/vsag:ci-x86-openblas
     concurrency:
       group: lint-${{ github.event.pull_request.number || github.sha }}
       cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -29,4 +29,7 @@ jobs:
           save: ${{ github.event_name != 'pull_request' }}
           key: build-lint-${{ hashFiles('./CMakeLists.txt') }}-${{ hashFiles('./.circleci/fresh_ci_cache.commit') }}
       - name: Run lint
-        run: export CMAKE_GENERATOR="Ninja" && make release && make lint
+        # `make release` defaults to the OpenBLAS backend. Reuse the system
+        # OpenBLAS shipped in the ci-x86-openblas image so lint doesn't have
+        # to rebuild OpenBLAS from source on every run.
+        run: export CMAKE_GENERATOR="Ninja" EXTRA_DEFINED="-DUSE_SYSTEM_OPENBLAS=ON" && make release && make lint

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -13,7 +13,7 @@ jobs:
       group: performance-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     container:
-      image: vsaglib/vsag:ci-x86
+      image: vsaglib/vsag:ci-x86-openblas
     env:
       PERF_DINGDING_ACCESS_TOKEN: ${{ secrets.PERF_DINGDING_ACCESS_TOKEN }}
       PERF_DINGDING_SERCRET: ${{ secrets.PERF_DINGDING_SERCRET }}
@@ -25,7 +25,10 @@ jobs:
       - name: Download Datasets
         run: bash ./scripts/download_annbench_datasets.sh
       - name: Build Release
-        run: make release
+        # Performance benchmarks already run against OpenBLAS (the default
+        # backend). Use the pre-installed system OpenBLAS so the BLAS build
+        # itself doesn't eat into the daily perf window.
+        run: EXTRA_DEFINED="-DUSE_SYSTEM_OPENBLAS=ON" make release
       - name: Run Perf - Recall 90%, 95%, 99%
         run:  |
           ./build-release/tools/eval/eval_performance .github/perf-mini.yml

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -70,7 +70,7 @@ jobs:
     if: needs.changes.outputs.cpp == 'true'
     runs-on: ubuntu-22.04
     container:
-      image: vsaglib/vsag:ci-x86
+      image: vsaglib/vsag:ci-x86-openblas
       volumes:
         - /opt:/useless
     steps:
@@ -84,7 +84,11 @@ jobs:
           save: ${{ github.event_name != 'pull_request' }}
           key: build-${{ hashFiles('./CMakeLists.txt') }}-${{ hashFiles('./.circleci/fresh_ci_cache.commit') }}
       - name: Make Asan
-        run: export VSAG_ENABLE_INTEL_MKL=ON CMAKE_GENERATOR="Ninja" CMAKE_EXPORT_COMPILE_COMMANDS=ON; make asan VSAG_ENABLE_EXAMPLES=ON
+        # PR CI runs against the pre-installed system OpenBLAS shipped in the
+        # ci-x86-openblas image to keep iteration latency low. The
+        # build-from-source OpenBLAS path is exercised by the daily x86 ASan
+        # job in daily_test.yml.
+        run: export CMAKE_GENERATOR="Ninja" CMAKE_EXPORT_COMPILE_COMMANDS=ON EXTRA_DEFINED="-DUSE_SYSTEM_OPENBLAS=ON"; make asan VSAG_ENABLE_EXAMPLES=ON
       - name: Install clang-tidy 15
         run: sudo apt install clang-tidy-15 -y
       - name: Run Lint
@@ -144,7 +148,7 @@ jobs:
     if: needs.changes.outputs.cpp == 'true'
     runs-on: ubuntu-22.04
     container:
-      image: vsaglib/vsag:ci-x86
+      image: vsaglib/vsag:ci-x86-openblas
       volumes:
         - /opt:/useless
     steps:
@@ -180,7 +184,7 @@ jobs:
     if: needs.changes.outputs.cpp == 'true'
     runs-on: ubuntu-22.04
     container:
-      image: vsaglib/vsag:ci-x86
+      image: vsaglib/vsag:ci-x86-openblas
       volumes:
         - /opt:/useless
     steps:
@@ -216,7 +220,7 @@ jobs:
     if: needs.changes.outputs.cpp == 'true'
     runs-on: ubuntu-22.04
     container:
-      image: vsaglib/vsag:ci-x86
+      image: vsaglib/vsag:ci-x86-openblas
       volumes:
         - /opt:/useless
     steps:
@@ -248,7 +252,7 @@ jobs:
     if: needs.changes.outputs.cpp == 'true'
     runs-on: ubuntu-latest
     container:
-      image: vsaglib/vsag:ci-x86
+      image: vsaglib/vsag:ci-x86-openblas
     steps:
       - name: Install GitHub CLI
         run: |
@@ -271,7 +275,7 @@ jobs:
             || echo "Warning: Failed to download compatibility indexes"
       - uses: actions/checkout@v4
       - name: Compile Check Compatibility Tools
-        run: export CMAKE_GENERATOR="Ninja"; make release VSAG_ENABLE_TOOLS=ON
+        run: export CMAKE_GENERATOR="Ninja" EXTRA_DEFINED="-DUSE_SYSTEM_OPENBLAS=ON"; make release VSAG_ENABLE_TOOLS=ON
       - name: Run Check Compatibility
         run: bash ./scripts/check_compatibility.sh
 

--- a/.github/workflows/tsan_build_and_test.yml
+++ b/.github/workflows/tsan_build_and_test.yml
@@ -39,7 +39,7 @@ jobs:
       group: test_tsan_x86-${{ github.event.pull_request.number || github.sha }}
       cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     container:
-      image: vsaglib/vsag:ci-x86
+      image: vsaglib/vsag:ci-x86-mkl
       volumes:
         - /opt:/useless
     steps:
@@ -76,7 +76,7 @@ jobs:
       group: test_tsan_x86-${{ github.event.pull_request.number || github.sha }}
       cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     container:
-      image: vsaglib/vsag:ci-x86
+      image: vsaglib/vsag:ci-x86-mkl
     steps:
       - uses: actions/checkout@v4
       - name: Clean Env


### PR DESCRIPTION
## Summary

- Repoint every x86 CI job at the new `ci-x86-mkl` / `ci-x86-openblas` image tags introduced in #2119.
- Turn on `-DUSE_SYSTEM_OPENBLAS=ON` (forwarded via the existing `EXTRA_DEFINED` Makefile knob, no `Makefile` change required) on the OpenBLAS-backed jobs so they reuse the pre-installed system OpenBLAS instead of rebuilding it from source on every run.
- Leave the daily x86 ASan job unflagged on purpose: it now becomes the dedicated guard for the from-source OpenBLAS path (`ExternalProject_Add(openblas)` in `extern/openblas/openblas.cmake`).
- Release artifacts and `make pyvsag` are unchanged and still build OpenBLAS from source.

## Why

See #2118 for the full rationale. Short version: every PR CI / coverage / lint / compatibility / performance / CircleCI run currently spends 2–3 min building OpenBLAS even though `libopenblas-dev` is already in the image. Switching to the system package eliminates that rebuild on the fast path while the daily ASan job keeps the source-build path under daily coverage.

## Image routing after this PR

| Job(s) | Image | `USE_SYSTEM_OPENBLAS` |
| --- | --- | --- |
| `pr-ci` (asan build, unittests, functests, examples, compatibility) | `ci-x86-openblas` | `ON` (build job only) |
| `coverage`, `lint`, `check_compatibility`, `performance` | `ci-x86-openblas` | `ON` (build steps) |
| `generate_old_version_index` | `ci-x86-openblas` | **unset** — builds historical release tags whose CMake doesn't necessarily understand the flag, so the source-build path is kept here on purpose |
| `asan_build_and_test`, `tsan_build_and_test`, `asan_with_simd_option`, daily SIMD / TSAN | `ci-x86-mkl` | n/a (MKL path) |
| Daily x86 ASan | `ci-x86-openblas` | **unset** — guards source build |
| CircleCI | host VM + apt | `ON` (build step) |

## Prerequisite

#2119 has merged and `update-ci-image` has published the new `ci-x86-base` / `ci-x86-mkl` / `ci-x86-openblas` tags to Docker Hub, so the workflows in this PR can now pull their new container images.

## Notes on related work

`USE_SYSTEM_OPENBLAS=ON` is forwarded via `EXTRA_DEFINED` rather than a new `make` flag, deliberately avoiding any change to `Makefile`. This keeps this PR independent of #2117, which introduces a different `VSAG_USE_SYSTEM_OPENBLAS` CMake option with stricter semantics. The two changes can land in either order.

## Test plan

- Every PR triggers the affected jobs in this repo on push, so the CI run on this PR is itself the test.
- After merge, watch the first PR-CI run on `main` to confirm the OpenBLAS build step has dropped out of the timeline.

## Labels

`kind/improvement`, `version/1.0`

Refs: #2118



