### PR TITLE
docs(hgraph): document brute_force_threshold and add example

### DIFF
--- a/docs/docs/en/src/advanced/filtered_search.md
+++ b/docs/docs/en/src/advanced/filtered_search.md
@@ -172,6 +172,13 @@ filtering, see [Extra Info](extra_info.md).
 - The more selective the filter (smaller `ValidRatio`), the more candidates the search has
   to expand. For graph indexes, increase `ef_search` proportionally when the filter is very
   selective; otherwise recall will drop sharply below ~1% selectivity.
+- **HGraph also offers a selectivity-aware brute-force fallback**: set
+  `brute_force_threshold` (e.g. `0.01–0.05`) in the search params so that, when
+  `Filter::ValidRatio()` is small enough, HGraph automatically skips graph
+  traversal and runs an exact scan over the surviving ids. This is often a
+  better choice than chasing recall by raising `ef_search` to very large values.
+  See the [HGraph index page](../indexes/hgraph.md#brute-force-fallback-under-highly-selective-filters-brute_force_threshold)
+  and example [`322_feature_hgraph_brute_force_threshold.cpp`](https://github.com/antgroup/vsag/blob/main/examples/cpp/322_feature_hgraph_brute_force_threshold.cpp).
 - Bitset filters are fastest because `Test()` is a single bit lookup. A `Filter` object that
   performs heavy work in `CheckValid` will be called many times per query.
 - For `RangeSearch`, set a finite `limited_size` when filters can let through millions of

--- a/docs/docs/en/src/indexes/hgraph.md
+++ b/docs/docs/en/src/indexes/hgraph.md
@@ -200,14 +200,70 @@ still controlled by `base_quantization_type` (and optionally `precise_quantizati
 
 Search-time parameters live under the `hgraph` sub-object:
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `ef_search` | int | Size of the search frontier. Larger = higher recall, slower query. |
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `ef_search` | int | — (required) | Size of the search frontier. Larger = higher recall, slower query. |
+| `hops_limit` | int | unlimited | Hard cap on the number of hops the beam search performs before returning the current frontier. |
+| `brute_force_threshold` | float | `0.0` | Selectivity-aware brute-force fallback. When `> 0` and the supplied filter's `ValidRatio()` is `≤ brute_force_threshold`, the search **bypasses the graph traversal entirely** and runs an exact scan over the valid ids using the best available flatten codes (see the section below). Must lie in `[0.0, 1.0]`; the default `0.0` disables the feature and preserves legacy behavior. |
+| `rabitq_one_bit_search` | bool | `false` | RabitQ one-bit search path; see the [Quantization chapter](../quantization/README.md). |
 
 ```cpp
 auto result = index->KnnSearch(
     query, topk, R"({"hgraph": {"ef_search": 200}})").value();
 ```
+
+### Brute-force fallback under highly selective filters (`brute_force_threshold`)
+
+Graph traversal is the right strategy when most candidates pass the filter — the
+graph quickly reaches the neighborhood of the query. As filter selectivity
+increases (only a tiny fraction of vectors survive), the beam has to expand far
+more nodes just to fill `ef_search` with **valid** candidates, and recall drops.
+At some point an exhaustive scan over the surviving ids is both faster *and*
+exact.
+
+`brute_force_threshold` lets HGraph make that switch automatically on a
+per-query basis:
+
+```cpp
+// When the active filter keeps ≤ 1% of ids, run an exact scan instead.
+auto params = R"({"hgraph": {"ef_search": 200, "brute_force_threshold": 0.01}})";
+auto result = index->KnnSearch(query, topk, params, my_filter).value();
+```
+
+How it works (`src/algorithm/hgraph/hgraph_search.cpp`):
+
+- The fallback only fires when **all** of the following hold:
+    - `brute_force_threshold > 0.0`, **and**
+    - a filter is supplied, **and**
+    - `filter->ValidRatio() <= brute_force_threshold`.
+- The accuracy of `Filter::ValidRatio()` matters — it is the user-supplied hint
+  the dispatcher checks against the threshold. See
+  [Filtered Search](../advanced/filtered_search.md) for the API contract.
+- The scan iterates every valid inner id and computes distances in batches of
+  64 using the most precise flatten storage available (raw vectors if
+  `store_raw_vector` was set, otherwise the high-precision reorder codes when
+  `use_reorder=true`, otherwise the base quantized codes).
+- Because the scan already uses precise codes when present, the post-search
+  reorder pass is **skipped** for queries that took the brute-force branch.
+- Applies to `KnnSearch` (the non-iterator overload, which is what
+  `SearchWithRequest` and the standard `KnnSearch(query, k, params, filter)`
+  call) and to `RangeSearch`. It does **not** apply to the iterator-style
+  `KnnSearch(..., IteratorContext*&, ...)`, because a single sweep cannot be
+  paged across multiple iterator calls.
+
+Picking a value:
+
+- Leave at `0.0` (default) for unfiltered or weakly filtered workloads.
+- For highly selective filters, `0.01–0.05` is a reasonable starting point.
+  Setting it higher than that effectively turns the index into a brute-force
+  scanner whenever a filter is present.
+- The cost of the brute-force scan is roughly `O(N × dim)` where `N` is the
+  total number of indexed vectors (regardless of selectivity, because every id
+  is visited to check `CheckValid`). The benefit grows when graph search would
+  otherwise need a much larger `ef_search` to recover recall.
+
+A runnable example is
+[`322_feature_hgraph_brute_force_threshold.cpp`](https://github.com/antgroup/vsag/blob/main/examples/cpp/322_feature_hgraph_brute_force_threshold.cpp).
 
 ## When to use HGraph
 

--- a/docs/docs/en/src/resources/index_parameters.md
+++ b/docs/docs/en/src/resources/index_parameters.md
@@ -77,6 +77,13 @@ At search time:
 {"hgraph": {"ef_search": 100}}
 ```
 
+The `hgraph` search-param object also accepts `brute_force_threshold` (a float
+in `[0.0, 1.0]`, default `0.0`). When set above zero and the request carries a
+filter whose `ValidRatio()` is at most this threshold, HGraph skips the graph
+traversal and runs an exact scan over the surviving ids. See the
+[HGraph index page](../indexes/hgraph.md#brute-force-fallback-under-highly-selective-filters-brute_force_threshold)
+for details.
+
 ## DiskANN
 
 ```json

--- a/docs/docs/zh/src/advanced/filtered_search.md
+++ b/docs/docs/zh/src/advanced/filtered_search.md
@@ -166,6 +166,12 @@ index->KnnSearch(query, topk, params, filter, ctx, /*is_last_search=*/false);
 
 - 谓词越严格（`ValidRatio` 越小），搜索需要扩展的候选越多。对图索引而言，谓词非常严格时
   应同步增大 `ef_search`，否则当通过率低于约 1% 时召回率会显著下降。
+- **HGraph 还提供选择率感知的暴搜回退**：在搜索参数里设置
+  `brute_force_threshold`（例如 `0.01–0.05`），当 `Filter::ValidRatio()` 足够
+  小时，HGraph 会自动跳过图遍历，对通过过滤的 id 做一次精确暴扫。当谓词非常
+  严格时，这通常比一味把 `ef_search` 调到很大更划算。详见
+  [HGraph 索引文档](../indexes/hgraph.md#高选择性过滤下的暴搜回退brute_force_threshold)
+  以及示例 [`322_feature_hgraph_brute_force_threshold.cpp`](https://github.com/antgroup/vsag/blob/main/examples/cpp/322_feature_hgraph_brute_force_threshold.cpp)。
 - 位图过滤最快，因为 `Test()` 只是一次位查询。`Filter` 对象内若有重逻辑，需注意它会被
   调用很多次。
 - `RangeSearch` 在过滤通过率较高、范围较宽时建议设定一个合理的 `limited_size`，避免结果

--- a/docs/docs/zh/src/indexes/hgraph.md
+++ b/docs/docs/zh/src/indexes/hgraph.md
@@ -186,14 +186,61 @@ base->NumElements(num_vectors)->Dim(dim)->Ids(ids)
 
 检索参数放在 `hgraph` 子对象下：
 
-| 参数 | 类型 | 说明 |
-|------|------|------|
-| `ef_search` | int | 搜索前沿候选集的大小，越大召回越高、查询越慢 |
+| 参数 | 类型 | 默认值 | 说明 |
+|------|------|--------|------|
+| `ef_search` | int | —（必填） | 搜索前沿候选集的大小，越大召回越高、查询越慢。 |
+| `hops_limit` | int | 不限 | beam search 在返回当前前沿前允许的最大跳数。 |
+| `brute_force_threshold` | float | `0.0` | 选择率感知的暴搜回退开关。当取值 `> 0` 且当前 filter 的 `ValidRatio()` 小于等于 `brute_force_threshold` 时，搜索会**完全跳过图遍历**，直接在通过过滤的 id 上用最佳精度的 flatten 编码做一次暴力扫描（细节见下一节）。取值范围 `[0.0, 1.0]`；默认 `0.0` 表示关闭，保持原有行为。 |
+| `rabitq_one_bit_search` | bool | `false` | RabitQ 一比特搜索路径，详见[量化章节](../quantization/README.md)。 |
 
 ```cpp
 auto result = index->KnnSearch(
     query, topk, R"({"hgraph": {"ef_search": 200}})").value();
 ```
+
+### 高选择性过滤下的暴搜回退（`brute_force_threshold`）
+
+图搜索在大多数候选都能通过过滤时是最优策略——图遍历能很快进入查询邻域。但是当
+过滤越来越严格（只有极少数向量能通过）时，beam 需要扩展非常多的节点才能凑够
+`ef_search` 个**通过过滤的**候选，此时召回率会下降，延迟反而上升。在某个临界点，
+对通过过滤的 id 做一次完整暴扫既更快又精确。
+
+`brute_force_threshold` 允许 HGraph 在每次查询时自动按 filter 选择率做这个切换：
+
+```cpp
+// 当 filter 仅保留 ≤ 1% 的 id 时，自动改走暴力扫描。
+auto params = R"({"hgraph": {"ef_search": 200, "brute_force_threshold": 0.01}})";
+auto result = index->KnnSearch(query, topk, params, my_filter).value();
+```
+
+工作原理（实现位于 `src/algorithm/hgraph/hgraph_search.cpp`）：
+
+- 暴搜回退仅在**同时**满足以下条件时触发：
+    - `brute_force_threshold > 0.0`，**并且**
+    - 提供了 filter，**并且**
+    - `filter->ValidRatio() <= brute_force_threshold`。
+- `Filter::ValidRatio()` 的准确性会直接影响是否切换 —— 这是用户提供的提示值。
+  详见 [带过滤的搜索](../advanced/filtered_search.md) 中关于该方法的约定。
+- 暴搜会遍历所有通过过滤的内部 id，并按 64 一批用当前最精确的 flatten 存储
+  计算距离（顺序：若启用了 `store_raw_vector` 则用原始向量；否则若
+  `use_reorder=true` 则用精排副本；否则用基础量化编码）。
+- 由于暴搜在有精排副本时本身就用了精确编码，**走暴搜分支的查询不会再做精排**。
+- 该机制对 `KnnSearch`（非迭代器重载，也即 `SearchWithRequest` 与标准的
+  `KnnSearch(query, k, params, filter)` 走的入口）和 `RangeSearch` 生效；对
+  迭代器风格的 `KnnSearch(..., IteratorContext*&, ...)` **不生效**，因为一次
+  扫描无法分页跨越多次迭代调用。
+
+取值建议：
+
+- 不带过滤或过滤通过率较高的场景，保持默认 `0.0`。
+- 高选择性过滤（如 `ValidRatio` ≤ 0.05）下，`0.01–0.05` 是合理起点。再往上调
+  实际上等于「只要带 filter 就走暴搜」。
+- 暴搜的代价大致是 `O(N × dim)`，`N` 是索引内总向量数（与选择率无关，因为
+  每个 id 都要走一次 `CheckValid`）。当原本需要把 `ef_search` 调到很大才能
+  维持召回时，暴搜带来的收益最明显。
+
+可运行示例：
+[`322_feature_hgraph_brute_force_threshold.cpp`](https://github.com/antgroup/vsag/blob/main/examples/cpp/322_feature_hgraph_brute_force_threshold.cpp)。
 
 ## 何时选择 HGraph
 

--- a/docs/docs/zh/src/resources/index_parameters.md
+++ b/docs/docs/zh/src/resources/index_parameters.md
@@ -75,6 +75,11 @@ HGraph 的构建参数使用通用的 `index_param` 键（参见 `examples/cpp/1
 {"hgraph": {"ef_search": 100}}
 ```
 
+`hgraph` 搜索参数还接受 `brute_force_threshold`（`[0.0, 1.0]` 区间的 float，
+默认 `0.0`）。当取值 `> 0` 且当前请求的 filter 的 `ValidRatio()` 不超过该
+阈值时，HGraph 会跳过图遍历，直接在通过过滤的 id 上做精确暴扫。详见
+[HGraph 索引文档](../indexes/hgraph.md#高选择性过滤下的暴搜回退brute_force_threshold)。
+
 ## DiskANN
 
 ```json

--- a/docs/hgraph.md
+++ b/docs/hgraph.md
@@ -269,6 +269,14 @@ means that the index uses PQ quantization with 64 subspaces, enables reordering 
 - **Default Value**: false
 - **Note**: This mode supports the `parallelism` search parameter for parallel search within a single query.
 
+### brute_force_threshold
+- **Parameter Type**: float
+- **Parameter Description**: Selectivity-aware brute-force fallback. When set to a value greater than `0.0` and the active filter's `ValidRatio()` is less than or equal to this threshold, the search bypasses graph traversal and runs an exact scan over the valid ids using the best available flatten codes (raw vectors > precise reorder codes > base quantized codes, in that order of preference). The post-search reorder pass is skipped on queries that take the brute-force branch.
+- **Optional Values**: any float in `[0.0, 1.0]`
+- **Default Value**: 0.0 (disabled — preserves legacy behavior)
+- **Applies to**: `KnnSearch` (non-iterator overload, also used by `SearchWithRequest`) and `RangeSearch`. The iterator-style `KnnSearch` does not use this parameter.
+- **Note**: The decision relies on `Filter::ValidRatio()` returning a meaningful selectivity estimate; see [filtered search](docs/docs/en/src/advanced/filtered_search.md). The brute-force scan visits every indexed id once to call `CheckValid`, so its cost is roughly `O(N × dim)` regardless of selectivity. A runnable example is [`322_feature_hgraph_brute_force_threshold.cpp`](https://github.com/antgroup/vsag/blob/main/examples/cpp/322_feature_hgraph_brute_force_threshold.cpp).
+
 ## Examples for Search Parameter String
 ```json
 "hgraph": {
@@ -278,3 +286,11 @@ means that the index uses PQ quantization with 64 subspaces, enables reordering 
 }
 ```
 means that the search will use an ef_search value of 200 to control the search quality and performance trade-off. When the index uses RabitQ split storage, rabitq_one_bit_search=true enables one-bit graph search and parallelism=4 enables parallel search within a single query.
+
+```json
+"hgraph": {
+    "ef_search": 200,
+    "brute_force_threshold": 0.02
+}
+```
+means that whenever the request supplies a filter whose `ValidRatio()` is ≤ 0.02 (i.e. only ~2% of the indexed ids survive the predicate), HGraph will skip the graph traversal and run an exact scan over the surviving ids; queries with weaker filters or no filter at all keep using the normal graph search.

--- a/examples/cpp/322_feature_hgraph_brute_force_threshold.cpp
+++ b/examples/cpp/322_feature_hgraph_brute_force_threshold.cpp
@@ -1,0 +1,210 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Demonstrates the HGraph search-time parameter `brute_force_threshold`.
+//
+// Background
+// ----------
+// When a filter is supplied to HGraph's KnnSearch / RangeSearch, the graph
+// beam search has to expand more and more candidates to fill `ef_search` with
+// ids that actually pass the predicate. Under a very selective filter (only a
+// tiny fraction of ids survive) the beam quickly runs out of useful neighbours
+// and recall drops.
+//
+// `brute_force_threshold` lets HGraph automatically skip the graph traversal
+// and run an exact scan over the surviving ids whenever the filter's
+// `ValidRatio()` falls below the configured threshold. The brute-force scan
+// uses the most precise flatten storage available (raw vectors > precise
+// reorder codes > base quantized codes) and skips the post-search reorder
+// because it already computed precise distances.
+//
+// This example builds a small HGraph index, defines a `Filter` whose
+// `ValidRatio()` is 0.02, and runs the same query three ways:
+//   1. graph search, no brute-force fallback (baseline)
+//   2. brute_force_threshold = 0.01 — filter ratio (0.02) is ABOVE the
+//      threshold, so the fallback is NOT triggered (behaves like baseline)
+//   3. brute_force_threshold = 0.05 — filter ratio (0.02) is at or BELOW the
+//      threshold, so HGraph runs the exact scan
+//
+// Run (1) and (3) should produce identical, exact results (mode 3 is by
+// definition an exact scan over the surviving ids).
+
+#include <vsag/vsag.h>
+
+#include <iostream>
+#include <random>
+#include <vector>
+
+namespace {
+
+/// A toy filter that keeps only ids where `id % modulus == residue`.
+/// It returns a fixed `ValidRatio()` hint (e.g. 1/modulus) so HGraph can
+/// compare it against `brute_force_threshold`.
+class ModuloFilter : public vsag::Filter {
+public:
+    ModuloFilter(int64_t modulus, int64_t residue, float valid_ratio)
+        : modulus_(modulus), residue_(residue), valid_ratio_(valid_ratio) {
+    }
+
+    bool
+    CheckValid(int64_t id) const override {
+        return (id % modulus_) == residue_;
+    }
+
+    float
+    ValidRatio() const override {
+        return valid_ratio_;
+    }
+
+private:
+    int64_t modulus_;
+    int64_t residue_;
+    float valid_ratio_;
+};
+
+void
+print_results(const std::string& label, const vsag::DatasetPtr& result) {
+    std::cout << label << " (top " << result->GetDim() << "):\n";
+    for (int64_t i = 0; i < result->GetDim(); ++i) {
+        std::cout << "  id=" << result->GetIds()[i] << "  dist=" << result->GetDistances()[i]
+                  << "\n";
+    }
+}
+
+}  // namespace
+
+int
+main(int /*argc*/, char** /*argv*/) {
+    vsag::init();
+
+    /******************* Prepare base dataset *****************/
+    constexpr int64_t num_vectors = 10000;
+    constexpr int64_t dim = 64;
+    constexpr int64_t modulus = 50;  // filter keeps 1 in every 50 ids -> ratio = 0.02
+    constexpr int64_t residue = 7;
+    constexpr int64_t topk = 5;
+    constexpr float filter_valid_ratio = 1.0F / static_cast<float>(modulus);
+
+    std::vector<int64_t> ids(num_vectors);
+    std::vector<float> data(num_vectors * dim);
+    std::mt19937 rng(20260528);
+    std::uniform_real_distribution<float> distrib(-1.0F, 1.0F);
+    for (int64_t i = 0; i < num_vectors; ++i) {
+        ids[i] = i;
+    }
+    for (int64_t i = 0; i < num_vectors * dim; ++i) {
+        data[i] = distrib(rng);
+    }
+    auto base = vsag::Dataset::Make();
+    base->NumElements(num_vectors)
+        ->Dim(dim)
+        ->Ids(ids.data())
+        ->Float32Vectors(data.data())
+        ->Owner(false);
+
+    /******************* Build HGraph index *****************/
+    const std::string build_params = R"({
+        "dtype": "float32",
+        "metric_type": "l2",
+        "dim": 64,
+        "index_param": {
+            "base_quantization_type": "fp32",
+            "max_degree": 32,
+            "ef_construction": 200
+        }
+    })";
+    auto index = vsag::Factory::CreateIndex("hgraph", build_params).value();
+    if (auto build_res = index->Build(base); not build_res.has_value()) {
+        std::cerr << "Build failed: " << build_res.error().message << std::endl;
+        return -1;
+    }
+
+    /******************* Prepare query and filter *****************/
+    std::vector<float> query_vec(dim);
+    for (int64_t i = 0; i < dim; ++i) {
+        query_vec[i] = distrib(rng);
+    }
+    auto query = vsag::Dataset::Make();
+    query->NumElements(1)->Dim(dim)->Float32Vectors(query_vec.data())->Owner(false);
+
+    // ValidRatio is the user's selectivity hint to HGraph; it should reflect
+    // the fraction of ids that actually pass `CheckValid`.
+    auto filter = std::make_shared<ModuloFilter>(modulus, residue, filter_valid_ratio);
+    std::cout << "Filter keeps approximately " << (filter_valid_ratio * 100.0F) << "% of ids\n\n";
+
+    /******************* 1. Baseline: graph search, no fallback *****************/
+    {
+        const std::string params = R"({"hgraph": {"ef_search": 200}})";
+        auto res = index->KnnSearch(query, topk, params, filter);
+        if (not res.has_value()) {
+            std::cerr << "Search 1 failed: " << res.error().message << std::endl;
+            return -1;
+        }
+        print_results("[1] graph search (brute_force_threshold unset)", res.value());
+    }
+
+    /******************* 2. Threshold below the filter's valid ratio:
+                              fallback does NOT trigger             *****************/
+    {
+        const std::string params =
+            R"({"hgraph": {"ef_search": 200, "brute_force_threshold": 0.01}})";
+        auto res = index->KnnSearch(query, topk, params, filter);
+        if (not res.has_value()) {
+            std::cerr << "Search 2 failed: " << res.error().message << std::endl;
+            return -1;
+        }
+        print_results("\n[2] graph search (threshold 0.01 < valid_ratio 0.02 -> graph path)",
+                      res.value());
+    }
+
+    /******************* 3. Threshold at or above the filter's valid ratio:
+                              fallback triggers, exact scan         *****************/
+    {
+        const std::string params =
+            R"({"hgraph": {"ef_search": 200, "brute_force_threshold": 0.05}})";
+        auto res = index->KnnSearch(query, topk, params, filter);
+        if (not res.has_value()) {
+            std::cerr << "Search 3 failed: " << res.error().message << std::endl;
+            return -1;
+        }
+        print_results(
+            "\n[3] brute-force fallback (threshold 0.05 >= valid_ratio 0.02 -> exact scan)",
+            res.value());
+    }
+
+    /******************* Reference: hand-rolled exact scan *****************/
+    std::vector<std::pair<float, int64_t>> reference;
+    for (int64_t i = 0; i < num_vectors; ++i) {
+        if ((ids[i] % modulus) != residue) {
+            continue;
+        }
+        float d = 0.0F;
+        for (int64_t j = 0; j < dim; ++j) {
+            float diff = data[i * dim + j] - query_vec[j];
+            d += diff * diff;
+        }
+        reference.emplace_back(d, ids[i]);
+    }
+    std::sort(reference.begin(), reference.end());
+    std::cout << "\n[ref] hand-rolled exact scan over filtered ids:\n";
+    for (int64_t k = 0; k < topk; ++k) {
+        std::cout << "  id=" << reference[k].second << "  dist=" << reference[k].first << "\n";
+    }
+    std::cout << "\nResult set (3) above must match this reference; results (1) and (2)\n"
+                 "are approximate and may differ when ef_search is too small relative to\n"
+                 "the filter's selectivity.\n";
+
+    return 0;
+}

--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -124,3 +124,6 @@ target_link_libraries (501_quantization_transform vsag)
 
 add_executable (321_index_fp16_hgraph 321_index_fp16_hgraph.cpp)
 target_link_libraries (321_index_fp16_hgraph vsag)
+
+add_executable (322_feature_hgraph_brute_force_threshold 322_feature_hgraph_brute_force_threshold.cpp)
+target_link_libraries (322_feature_hgraph_brute_force_threshold vsag)

--- a/examples/cpp/README.md
+++ b/examples/cpp/README.md
@@ -99,6 +99,7 @@ together when the directory is listed:
 | [`318_feature_tune.cpp`](318_feature_tune.cpp) | Online `Tune()` optimizer. |
 | [`319_feature_get_memory_usage.cpp`](319_feature_get_memory_usage.cpp) | Live memory-usage reporting. |
 | [`320_feature_extra_info.cpp`](320_feature_extra_info.cpp) | Attach per-vector extra info / payload. |
+| [`322_feature_hgraph_brute_force_threshold.cpp`](322_feature_hgraph_brute_force_threshold.cpp) | HGraph search-time `brute_force_threshold`: automatically switch to an exact scan under highly selective filters. |
 
 ### Persistence (`4xx`)
 


### PR DESCRIPTION
## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement/Refactor
- [x] Documentation
- [ ] CI/Build/Infra

## Linked Issue

Closes: #2123

(Tracks the docs/example gap left by the now-merged feature issue #1631,
which only covered the code change for `brute_force_threshold` and did not
include user-facing documentation or an example.)

## What Changed

The HGraph search-time parameter `brute_force_threshold` already ships in
code (`src/algorithm/hgraph/hgraph_parameter.{h,cpp}`,
`src/algorithm/hgraph/hgraph_search.cpp`, tests at
`tests/test_hgraph.cpp:2480-2619`) but is not mentioned in any user-facing
doc and has no example. This PR closes that discoverability gap without
touching any code path.

- `docs/docs/{en,zh}/src/indexes/hgraph.md` — new row in the *Search
  parameters* table plus a dedicated subsection explaining trigger
  condition, storage-preference order, reorder-skip behavior, the
  intentional iterator-search opt-out, and how to pick a value.
- `docs/hgraph.md` — new `brute_force_threshold` reference entry and an
  extra JSON snippet.
- `docs/docs/{en,zh}/src/resources/index_parameters.md` — mention the key
  in the HGraph search-params snippet.
- `docs/docs/{en,zh}/src/advanced/filtered_search.md` — cross-link from the
  Performance Notes section so users hitting "very selective filter"
  guidance see the new option alongside the existing "raise `ef_search`"
  advice.
- New example `examples/cpp/322_feature_hgraph_brute_force_threshold.cpp`
  with three runs (baseline graph search, threshold-below-ratio →
  fallback NOT triggered, threshold-above-ratio → fallback triggered) plus
  a hand-rolled exact reference. Registered in
  `examples/cpp/CMakeLists.txt`; listed in `examples/cpp/README.md`.

## Test Evidence

- [x] `make fmt`
- [x] `make lint`
- [x] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [ ] Other (describe below)

Test details:

```text
Docs-only + new example. The existing functional tests at
tests/test_hgraph.cpp:2480-2619 already cover the parameter behaviour:
- "(PR) HGraph brute_force_threshold" — verifies the fallback's exact-scan
  results match an independent hand-rolled exhaustive scan.
- "(PR) HGraph brute_force_threshold default is no-op" — verifies that
  threshold=0.0 leaves graph-search results bit-identical.
The new example exercises the same API surface end-to-end.

Local environment is macOS, where CI tooling (clang-format-15 /
clang-tidy-15) is not available; fmt/lint/test will be exercised by the
project CI checks on this PR.
```

## Compatibility Impact

- API/ABI compatibility: none — docs and a new standalone example only.
- Behavior changes: none — no code modified; the parameter, its default
  (`0.0`, disabled), and its dispatch logic are unchanged.

## Performance and Concurrency Impact

- Performance impact: none.
- Concurrency/thread-safety impact: none.

## Documentation Impact

- [ ] No docs update needed
- [x] Updated docs:
  - [ ] `README.md`
  - [ ] `DEVELOPMENT.md`
  - [ ] `CONTRIBUTING.md`
  - [x] Other: `docs/docs/{en,zh}/src/indexes/hgraph.md`,
        `docs/docs/{en,zh}/src/resources/index_parameters.md`,
        `docs/docs/{en,zh}/src/advanced/filtered_search.md`,
        `docs/hgraph.md`, `examples/cpp/README.md`,
        `examples/cpp/322_feature_hgraph_brute_force_threshold.cpp`,
        `examples/cpp/CMakeLists.txt`

## Risk and Rollback

- Risk level: low (docs + new opt-in example; no existing binary or build
  target changed besides adding a new `add_executable`).
- Rollback plan: revert the single commit.

## Checklist

- [x] I have linked the relevant issue (`Closes: #2123`)
- [x] I have added/updated tests for new behavior or bug fixes
      (N/A — pre-existing functional tests cover the parameter; the new
      example serves as additional manual verification)
- [x] I have considered API compatibility impact
- [x] I have updated docs if behavior/workflow changed
- [x] My commit messages follow project conventions (Conventional Commits)
