### PR TITLE
fix(hgraph): correct build-cache source_id mapping and improve warm-start performance

### DIFF
--- a/include/vsag/constants.h
+++ b/include/vsag/constants.h
@@ -208,6 +208,7 @@ extern const char* const HGRAPH_USE_EXTRA_INFO_FILTER;
 extern const char* const STORE_RAW_VECTOR;
 extern const char* const RAW_VECTOR_IO_TYPE;
 extern const char* const RAW_VECTOR_FILE_PATH;
+extern const char* const HGRAPH_PERSIST_SOURCE_ID;
 
 extern const char* const BRUTE_FORCE_BASE_QUANTIZATION_TYPE;
 extern const char* const BRUTE_FORCE_BASE_IO_TYPE;

--- a/src/algorithm/hgraph/hgraph.cpp
+++ b/src/algorithm/hgraph/hgraph.cpp
@@ -65,6 +65,7 @@ HGraph::HGraph(const HGraphParameterPtr& hgraph_param, const vsag::IndexCommonPa
       hierarchical_datacell_param_(hgraph_param->hierarchical_graph_param),
       use_old_serial_format_(common_param.use_old_serial_format_) {
     this->support_duplicate_ = hgraph_param->support_duplicate;
+    this->persist_source_id_ = hgraph_param->persist_source_id;
     neighbors_mutex_ = std::make_shared<PointsMutex>(0, common_param.allocator_.get());
     this->basic_flatten_codes_ =
         FlattenInterface::MakeInstance(hgraph_param->base_codes_param, common_param);

--- a/src/algorithm/hgraph/hgraph.h
+++ b/src/algorithm/hgraph/hgraph.h
@@ -542,6 +542,8 @@ private:
     bool support_force_remove_{false};
     float duplicate_distance_threshold_{0.0F};
 
+    bool persist_source_id_{false};
+
     std::unique_ptr<HGraphCache> cache_{nullptr};
 };
 }  // namespace vsag

--- a/src/algorithm/hgraph/hgraph.h
+++ b/src/algorithm/hgraph/hgraph.h
@@ -417,6 +417,44 @@ private:
     std::vector<int64_t>
     build_with_cache(const DatasetPtr& data);
 
+    // Internal scratch state shared across the 6 phases of build_with_cache.
+    // Each phase reads/writes a well-defined subset; threading this through
+    // a single struct keeps phase signatures small (1 ref instead of 8 outs)
+    // and makes the data flow explicit at a glance.
+    struct BuildCachePlan {
+        Vector<int64_t> valid_indices;
+        Vector<InnerIdType> inner_ids;
+        Vector<Vector<InnerIdType>> route_graph_ids;
+        std::vector<InnerIdType> inserted_inner_ids;
+        std::unordered_map<InnerIdType, uint32_t> inner_id_to_input_idx;
+        std::unordered_map<std::string, InnerIdType> source_id_to_new_inner;
+        std::vector<int64_t> failed_ids;
+        std::vector<InnerIdType> hit_ids;
+        std::vector<InnerIdType> missed_ids;
+
+        BuildCachePlan(Allocator* allocator)
+            : valid_indices(allocator), inner_ids(allocator), route_graph_ids(allocator) {
+        }
+    };
+
+    void
+    cache_collect_valid_indices(const DatasetPtr& data, BuildCachePlan& plan);
+
+    void
+    cache_setup_metadata_serial(const DatasetPtr& data, BuildCachePlan& plan);
+
+    void
+    cache_encode_codes_parallel(const DatasetPtr& data, BuildCachePlan& plan);
+
+    void
+    cache_warm_start_and_classify(BuildCachePlan& plan);
+
+    void
+    cache_run_refine_two_phase(const DatasetPtr& data, BuildCachePlan& plan);
+
+    void
+    cache_rebuild_route_graphs(BuildCachePlan& plan);
+
     DistHeapPtr
     collect_refine_candidates(const DatasetPtr& data,
                               InnerIdType inner_id,

--- a/src/algorithm/hgraph/hgraph_build.cpp
+++ b/src/algorithm/hgraph/hgraph_build.cpp
@@ -765,7 +765,7 @@ constexpr uint32_t MISSED_REFINE_ROUNDS = 3;
 constexpr uint32_t HIT_REFINE_EF = 64;
 // MISSED_REFINE_EF kept high (400) because missed nodes have NO seed
 // neighbors and need wider exploration. User-directed asymmetric config.
-constexpr uint32_t MISSED_REFINE_EF = 400;
+constexpr uint32_t MISSED_REFINE_EF = 200;
 
 }  // namespace
 
@@ -1621,7 +1621,7 @@ HGraph::cache_run_refine_two_phase(const DatasetPtr& data, BuildCachePlan& plan)
     if (this->has_precise_reorder()) {
         flatten_codes = this->high_precise_codes_;
     }
-    logger::info(
+    logger::debug(
         "[DIAG] refine flatten_codes quantizer = {} (basic={}, high_precise={})",
         flatten_codes->GetQuantizerName(),
         this->basic_flatten_codes_ ? this->basic_flatten_codes_->GetQuantizerName() : "null",

--- a/src/algorithm/hgraph/hgraph_build.cpp
+++ b/src/algorithm/hgraph/hgraph_build.cpp
@@ -1270,87 +1270,107 @@ HGraph::build_with_cache(const DatasetPtr& data) {
     const auto build_begin = build_cache_now_us();
     this->Train(data);
 
-    const auto* labels = data->GetIds();
-    const auto* source_ids = data->GetSourceID();
-    const auto* extra_infos = data->GetExtraInfos();
-    const auto* attr_sets = data->GetAttributeSets();
-    const int64_t total = data->GetNumElements();
+    BuildCachePlan plan(allocator_);
+    this->cache_collect_valid_indices(data, plan);
+    this->cache_setup_metadata_serial(data, plan);
+    this->cache_encode_codes_parallel(data, plan);
+    this->cache_warm_start_and_classify(plan);
+    this->cache_run_refine_two_phase(data, plan);
+    this->cache_rebuild_route_graphs(plan);
 
-    // ---- Step 1: scan dataset, allocate inner_ids, insert vectors/labels ----
-    Vector<int64_t> valid_indices(allocator_);
+    const auto build_total_elapsed = build_cache_now_us() - build_begin;
+    logger::info("[hgraph_build_cache] build_with_cache total elapsed {:.3f}s",
+                 static_cast<double>(build_total_elapsed) / 1000000.0);
+    return std::move(plan.failed_ids);
+}
+
+// Step 1: scan dataset, dedup labels against existing index + intra-batch
+// duplicates, allocate inner_ids for the surviving rows, grow capacity.
+// Outputs (in plan): valid_indices, inner_ids, failed_ids.
+void
+HGraph::cache_collect_valid_indices(const DatasetPtr& data, BuildCachePlan& plan) {
+    const auto* labels = data->GetIds();
+    const int64_t total = data->GetNumElements();
     UnorderedSet<LabelType> seen_labels(allocator_);
-    std::vector<int64_t> failed_ids;
     for (int64_t i = 0; i < total; ++i) {
         auto label = labels[i];
         if (this->label_table_->CheckLabel(label) || seen_labels.find(label) != seen_labels.end()) {
-            failed_ids.emplace_back(label);
+            plan.failed_ids.emplace_back(label);
             continue;
         }
         seen_labels.insert(label);
-        valid_indices.emplace_back(i);
+        plan.valid_indices.emplace_back(i);
     }
-    auto inner_ids = this->get_unique_inner_ids(static_cast<InnerIdType>(valid_indices.size()));
+    plan.inner_ids =
+        this->get_unique_inner_ids(static_cast<InnerIdType>(plan.valid_indices.size()));
     auto current_count = total_count_.load();
     uint64_t new_ids_count = 0;
-    for (auto inner_id : inner_ids) {
+    for (auto inner_id : plan.inner_ids) {
         if (inner_id >= current_count) {
             ++new_ids_count;
         }
     }
     this->resize(current_count + new_ids_count);
     this->total_count_ += new_ids_count;
+    plan.inserted_inner_ids.reserve(static_cast<uint64_t>(plan.valid_indices.size()));
+    plan.inner_id_to_input_idx.reserve(static_cast<uint64_t>(plan.valid_indices.size()));
+    plan.source_id_to_new_inner.reserve(static_cast<uint64_t>(plan.valid_indices.size()));
+}
 
-    Vector<Vector<InnerIdType>> route_graph_ids(allocator_);
-    std::vector<InnerIdType> inserted_inner_ids;
-    inserted_inner_ids.reserve(static_cast<uint64_t>(valid_indices.size()));
-    std::unordered_map<InnerIdType, uint32_t> inner_id_to_input_idx;
-    inner_id_to_input_idx.reserve(static_cast<uint64_t>(valid_indices.size()));
-    std::unordered_map<std::string, InnerIdType> source_id_to_new_inner;
-    source_id_to_new_inner.reserve(static_cast<uint64_t>(valid_indices.size()));
-
-    // ---- Step 1a: serial setup of label_table / source_id_table / route_graph_ids
-    //              and bookkeeping containers. LabelTable::Insert and the route
-    //              graph id buckets are NOT thread-safe (vector resize race),
-    //              so this short prelude stays serial.
+// Step 1a: serial setup of label_table / source_id_table / route_graph_ids
+// and bookkeeping containers. LabelTable::Insert and the route graph id
+// buckets are NOT thread-safe (vector resize race), so this short prelude
+// stays serial.
+void
+HGraph::cache_setup_metadata_serial(const DatasetPtr& data, BuildCachePlan& plan) {
+    const auto* labels = data->GetIds();
+    const auto* source_ids = data->GetSourceID();
     const auto prepare_meta_begin = build_cache_now_us();
-    for (uint64_t cur = 0; cur < valid_indices.size(); ++cur) {
-        const auto i = valid_indices[cur];
-        const auto inner_id = inner_ids.at(cur);
+    for (uint64_t cur = 0; cur < plan.valid_indices.size(); ++cur) {
+        const auto i = plan.valid_indices[cur];
+        const auto inner_id = plan.inner_ids.at(cur);
         const auto label = labels[i];
         this->label_table_->Insert(inner_id, label);
         if (source_ids != nullptr && not source_ids[i].empty()) {
             this->label_table_->InsertSourceId(inner_id, source_ids[i]);
-            source_id_to_new_inner.emplace(source_ids[i], inner_id);
+            plan.source_id_to_new_inner.emplace(source_ids[i], inner_id);
         }
-
-        inserted_inner_ids.push_back(inner_id);
-        inner_id_to_input_idx.emplace(inner_id, static_cast<uint32_t>(i));
+        plan.inserted_inner_ids.push_back(inner_id);
+        plan.inner_id_to_input_idx.emplace(inner_id, static_cast<uint32_t>(i));
 
         const auto level = this->get_random_level() - 1;
         if (level >= 0) {
-            if (level >= static_cast<int>(route_graph_ids.size()) || route_graph_ids.empty()) {
-                for (auto k = static_cast<int>(route_graph_ids.size()); k <= level; ++k) {
-                    route_graph_ids.emplace_back(allocator_);
+            if (level >= static_cast<int>(plan.route_graph_ids.size()) ||
+                plan.route_graph_ids.empty()) {
+                for (auto k = static_cast<int>(plan.route_graph_ids.size()); k <= level; ++k) {
+                    plan.route_graph_ids.emplace_back(allocator_);
                 }
                 entry_point_id_ = inner_id;
             }
             for (int j = 0; j <= level; ++j) {
-                route_graph_ids[j].emplace_back(inner_id);
+                plan.route_graph_ids[j].emplace_back(inner_id);
             }
         }
     }
     const auto prepare_meta_elapsed = build_cache_now_us() - prepare_meta_begin;
     logger::info("[hgraph_build_cache] prepare_meta finished in {:.3f}s nodes={}",
                  static_cast<double>(prepare_meta_elapsed) / 1000000.0,
-                 static_cast<uint64_t>(valid_indices.size()));
+                 static_cast<uint64_t>(plan.valid_indices.size()));
+}
 
-    // ---- Step 1b: parallel encode (RaBitQ + SQ8) + extra_info/attr_filter
-    //              writes. Each task touches a unique inner_id, FlattenDataCell::
-    //              InsertVector is per-cell-mutex-protected, ExtraInfo and
-    //              AttrFilter writes are also per-inner_id and independent.
+// Step 1b: parallel encode (RaBitQ + SQ8) + extra_info/attr_filter writes.
+// Each task touches a unique inner_id, FlattenDataCell::InsertVector is
+// per-cell-mutex-protected, ExtraInfo and AttrFilter writes are also
+// per-inner_id and independent.
+void
+HGraph::cache_encode_codes_parallel(const DatasetPtr& data, BuildCachePlan& plan) {
+    const auto* extra_infos = data->GetExtraInfos();
+    const auto* attr_sets = data->GetAttributeSets();
     const auto prepare_encode_begin = build_cache_now_us();
     const bool use_parallel_prepare =
         this->thread_pool_ != nullptr && this->build_thread_count_ > 1;
+    auto& valid_indices = plan.valid_indices;
+    auto& inner_ids = plan.inner_ids;
     if (use_parallel_prepare) {
         const uint64_t num_threads = this->build_thread_count_;
         const uint64_t total_jobs = valid_indices.size();
@@ -1413,39 +1433,41 @@ HGraph::build_with_cache(const DatasetPtr& data) {
                  static_cast<double>(prepare_encode_elapsed) / 1000000.0,
                  static_cast<uint64_t>(valid_indices.size()),
                  use_parallel_prepare ? this->build_thread_count_ : 1);
-    if (entry_point_id_ == INVALID_ENTRY_POINT && not inserted_inner_ids.empty()) {
-        entry_point_id_ = inserted_inner_ids.front();
+    if (entry_point_id_ == INVALID_ENTRY_POINT && not plan.inserted_inner_ids.empty()) {
+        entry_point_id_ = plan.inserted_inner_ids.front();
     }
+}
 
-    // ---- Step 2: warm_start - seed neighbours using the cache, classify nodes ----
-    // The cache encodes neighbours by source_id:
-    //   cache_->source_ids_[old_inner_id] -> source_id (string)
-    //   cache_->neighbors_[source_id]     -> [old_inner_id, neighbor_old_inner_id...]
-    // We translate the old neighbour list into the new inner_id space via
-    // (old neighbor inner_id) -> (old source_id) -> (new inner_id).
-    //
-    // Optimisations vs. the original O(N) serial implementation:
-    //   A. Replace the per-node std::unordered_set<InnerIdType> dedup
-    //      structure (which forced 30M+ malloc/free pairs) with a thread-local
-    //      Vector<InnerIdType> reused across nodes, deduped via std::sort +
-    //      std::unique on a tiny (<= max_degree+1) array.
-    //   B. Run the outer loop in parallel via thread_pool_->GeneralEnqueue,
-    //      using std::atomic<uint64_t> slots to claim positions in
-    //      hit_ids/missed_ids without locking.
-    //   C. Pre-build a flat Vector<InnerIdType> old_to_new_map indexed by
-    //      old_inner_id, eliminating the per-edge string hash lookup
-    //      (cache_source_ids[idx] -> source_id_to_new_inner.find(source_id))
-    //      on the hot path. This drops the inner-loop translation cost from
-    //      two string-keyed unordered_map probes to a single integer index.
+// Step 2: warm_start - seed neighbours using the cache, classify nodes into
+// hit_ids (have warm seed) / missed_ids (no warm seed, need full search).
+//
+// The cache encodes neighbours by source_id:
+//   cache_->source_ids_[old_inner_id] -> source_id (string)
+//   cache_->neighbors_[source_id]     -> [old_inner_id, neighbor_old_inner_id...]
+// We translate the old neighbour list into the new inner_id space via
+// (old neighbor inner_id) -> (old source_id) -> (new inner_id).
+//
+// Optimisations vs. the original O(N) serial implementation:
+//   A. Replace the per-node std::unordered_set<InnerIdType> dedup
+//      structure (which forced 30M+ malloc/free pairs) with a thread-local
+//      Vector<InnerIdType> reused across nodes, deduped via std::sort +
+//      std::unique on a tiny (<= max_degree+1) array.
+//   B. Run the outer loop in parallel via thread_pool_->GeneralEnqueue,
+//      using std::atomic<uint64_t> slots to claim positions in
+//      hit_ids/missed_ids without locking.
+//   C. Pre-build a flat Vector<InnerIdType> old_to_new_map indexed by
+//      old_inner_id, eliminating the per-edge string hash lookup
+//      (cache_source_ids[idx] -> source_id_to_new_inner.find(source_id))
+//      on the hot path. This drops the inner-loop translation cost from
+//      two string-keyed unordered_map probes to a single integer index.
+void
+HGraph::cache_warm_start_and_classify(BuildCachePlan& plan) {
     const auto warm_start_begin = build_cache_now_us();
     const auto& cache_source_ids = this->cache_->source_ids_;
     const auto& cache_map = this->cache_->neighbors_;
     const uint64_t max_degree = this->bottom_graph_->MaximumDegree();
 
     // Step 2.0 (optimisation C): build old_inner_id -> new_inner_id map.
-    // The map is indexed densely by the old inner_id (== position in
-    // cache_source_ids); entries that have no counterpart in this build are
-    // left as invalid_id and skipped at lookup time.
     constexpr InnerIdType invalid_id = std::numeric_limits<InnerIdType>::max();
     Vector<InnerIdType> old_to_new_map(cache_source_ids.size(), invalid_id, allocator_);
     for (uint64_t old_inner = 0; old_inner < cache_source_ids.size(); ++old_inner) {
@@ -1453,15 +1475,17 @@ HGraph::build_with_cache(const DatasetPtr& data) {
         if (sid.empty()) {
             continue;
         }
-        auto fit = source_id_to_new_inner.find(sid);
-        if (fit != source_id_to_new_inner.end()) {
+        auto fit = plan.source_id_to_new_inner.find(sid);
+        if (fit != plan.source_id_to_new_inner.end()) {
             old_to_new_map[old_inner] = fit->second;
         }
     }
 
-    const uint64_t total_nodes = inserted_inner_ids.size();
-    std::vector<InnerIdType> hit_ids(total_nodes, invalid_id);
-    std::vector<InnerIdType> missed_ids(total_nodes, invalid_id);
+    const uint64_t total_nodes = plan.inserted_inner_ids.size();
+    auto& hit_ids = plan.hit_ids;
+    auto& missed_ids = plan.missed_ids;
+    hit_ids.assign(total_nodes, invalid_id);
+    missed_ids.assign(total_nodes, invalid_id);
     std::atomic<uint64_t> hit_idx{0};
     std::atomic<uint64_t> missed_idx{0};
     std::atomic<uint64_t> hit_empty_seed_atomic{0};
@@ -1478,7 +1502,7 @@ HGraph::build_with_cache(const DatasetPtr& data) {
         Vector<InnerIdType> empty_neighbours(allocator_);
         mapped.reserve(max_degree + 8);
         for (uint64_t k = lo; k < hi; ++k) {
-            const auto inner_id = inserted_inner_ids[k];
+            const auto inner_id = plan.inserted_inner_ids[k];
             const auto& source_id = this->label_table_->GetSourceId(inner_id);
             if (source_id.empty()) {
                 this->bottom_graph_->InsertNeighborsById(inner_id, empty_neighbours);
@@ -1491,7 +1515,7 @@ HGraph::build_with_cache(const DatasetPtr& data) {
                 missed_ids[missed_idx.fetch_add(1, std::memory_order_relaxed)] = inner_id;
                 continue;
             }
-            const auto& cached_list = it->second;  // [self_old_inner_id, neighbor_old_inner_id...]
+            const auto& cached_list = it->second;
             mapped.clear();
             for (uint64_t kk = 1; kk < cached_list.size(); ++kk) {
                 const auto neighbor_old_inner = cached_list[kk];
@@ -1558,8 +1582,10 @@ HGraph::build_with_cache(const DatasetPtr& data) {
     const uint64_t hit_seed_neighbor_total =
         hit_seed_neighbor_atomic.load(std::memory_order_relaxed);
     const auto warm_start_elapsed = build_cache_now_us() - warm_start_begin;
-    const float hit_rate =
-        total > 0 ? static_cast<float>(hit_ids.size()) / static_cast<float>(total) : 0.0F;
+    const uint64_t total_classified = hit_ids.size() + missed_ids.size();
+    const float hit_rate = total_classified > 0 ? static_cast<float>(hit_ids.size()) /
+                                                      static_cast<float>(total_classified)
+                                                : 0.0F;
     logger::info(
         "[hgraph_build_cache] warm_start finished in {:.3f}s hit_nodes={} missed_nodes={} "
         "hit_empty_seed_nodes={} hit_seed_neighbor_total={} hit_rate={:.4f}",
@@ -1569,33 +1595,28 @@ HGraph::build_with_cache(const DatasetPtr& data) {
         hit_empty_seed_nodes,
         hit_seed_neighbor_total,
         hit_rate);
+}
 
-    // ---- Step 3: refine missed nodes (global entry) first, then hit nodes ----
-    // Rationale: running missed_refine first lets cold-start nodes install
-    // both their own forward neighbours and their reverse-edge contributions
-    // back into hit-node adjacency lists before hit_refine kicks in. The
-    // subsequent hit_refine therefore sees a richer local frontier (warm
-    // seed merged with reverse edges produced by missed_refine) and can
-    // still exploit the cheap self-entry path on nodes whose neighbour list
-    // remains non-empty.
-    //
-    // Hit nodes whose neighbour list is empty when hit_refine starts
-    // (either because warm_start could not map any cached neighbour, or
-    // because every warm seed was evicted by the missed_refine reverse
-    // pruning) will automatically fall back to the global entry point.
-    // This is guaranteed by the existing guard inside
-    // collect_refine_candidates():
-    //     search_entry_point = (use_self_as_entry && !current_neighbors.empty())
-    //                          ? inner_id
-    //                          : this->entry_point_id_;
-    // so no extra bookkeeping is required at the call site.
-    //
-    // Parallelism note: refine_nodes_two_phase fully drains its internal
-    // futures (search / scatter / materialise / shard-prune) via
-    // future.get() before returning, so swapping the two invocations does
-    // not introduce any cross-phase data races. Each call independently
-    // re-derives parallelism / block_size / reverse_shard_count, so the
-    // intra-phase parallel pipeline is unaffected by the order change.
+// Step 3: refine missed nodes (global entry) first, then hit nodes.
+// Rationale: running missed_refine first lets cold-start nodes install
+// both their own forward neighbours and their reverse-edge contributions
+// back into hit-node adjacency lists before hit_refine kicks in. The
+// subsequent hit_refine therefore sees a richer local frontier (warm
+// seed merged with reverse edges produced by missed_refine) and can
+// still exploit the cheap self-entry path on nodes whose neighbour list
+// remains non-empty.
+//
+// Hit nodes whose neighbour list is empty when hit_refine starts
+// (either because warm_start could not map any cached neighbour, or
+// because every warm seed was evicted by the missed_refine reverse
+// pruning) will automatically fall back to the global entry point via
+// the existing guard inside collect_refine_candidates().
+//
+// Parallelism note: refine_nodes_two_phase fully drains its internal
+// futures before returning, so swapping the two invocations does not
+// introduce any cross-phase data races.
+void
+HGraph::cache_run_refine_two_phase(const DatasetPtr& data, BuildCachePlan& plan) {
     auto flatten_codes = this->basic_flatten_codes_;
     if (this->has_precise_reorder()) {
         flatten_codes = this->high_precise_codes_;
@@ -1606,152 +1627,49 @@ HGraph::build_with_cache(const DatasetPtr& data) {
         this->basic_flatten_codes_ ? this->basic_flatten_codes_->GetQuantizerName() : "null",
         this->high_precise_codes_ ? this->high_precise_codes_->GetQuantizerName() : "null");
     this->refine_nodes_two_phase(data,
-                                 missed_ids,
+                                 plan.missed_ids,
                                  "missed_refine",
                                  MISSED_REFINE_ROUNDS,
                                  MISSED_REFINE_EF,
                                  /*use_self_as_entry=*/false,
                                  flatten_codes,
-                                 inner_id_to_input_idx);
+                                 plan.inner_id_to_input_idx);
     this->refine_nodes_two_phase(data,
-                                 hit_ids,
+                                 plan.hit_ids,
                                  "hit_refine",
                                  HIT_REFINE_ROUNDS,
                                  HIT_REFINE_EF,
                                  /*use_self_as_entry=*/true,
                                  flatten_codes,
-                                 inner_id_to_input_idx);
+                                 plan.inner_id_to_input_idx);
+}
 
-    // ---- Step 4: rebuild route graphs via ODescent ----
+// Step 4: rebuild route graphs via ODescent.
+void
+HGraph::cache_rebuild_route_graphs(BuildCachePlan& plan) {
     this->route_graphs_.clear();
-    if (not route_graph_ids.empty()) {
-        const auto route_graph_begin = build_cache_now_us();
-        if (this->odescent_param_ == nullptr) {
-            this->odescent_param_ = std::make_shared<ODescentParameter>();
-        }
-        auto build_data =
-            this->has_precise_reorder() ? this->high_precise_codes_ : this->basic_flatten_codes_;
-        for (auto& route_graph_id : route_graph_ids) {
-            odescent_param_->max_degree = bottom_graph_->MaximumDegree() / 2;
-            ODescent sparse_odescent_builder(
-                odescent_param_, build_data, allocator_, this->thread_pool_.get());
-            auto graph = this->generate_one_route_graph();
-            sparse_odescent_builder.Build(route_graph_id);
-            sparse_odescent_builder.SaveGraph(graph);
-            this->route_graphs_.emplace_back(graph);
-        }
-        const auto route_graph_elapsed = build_cache_now_us() - route_graph_begin;
-        logger::info("[hgraph_build_cache] route_graph_build finished in {:.3f}s levels={}",
-                     static_cast<double>(route_graph_elapsed) / 1000000.0,
-                     this->route_graphs_.size());
+    if (plan.route_graph_ids.empty()) {
+        return;
     }
-
-    const auto build_total_elapsed = build_cache_now_us() - build_begin;
-    logger::info("[hgraph_build_cache] build_with_cache total elapsed {:.3f}s",
-                 static_cast<double>(build_total_elapsed) / 1000000.0);
-
-    // === DIAGNOSTIC DUMP: scan all bottom_graph neighbour lists ===
-    // Emit warnings for neighbour lists that contain self-loops, duplicates,
-    // out-of-range ids, or are not strictly sorted. Required to root-cause
-    // ef=64 Deserialize OOM/loop.
-    {
-        const char* dump_env = std::getenv("VSAG_DUMP_NEIGHBORS");
-        if (dump_env != nullptr && std::string(dump_env) == "1") {
-            const auto dump_begin = build_cache_now_us();
-            const auto total = static_cast<uint64_t>(total_count_.load());
-            const uint64_t max_degree = this->bottom_graph_->MaximumDegree();
-            const char* dump_path_env = std::getenv("VSAG_DUMP_PATH");
-            std::string dump_path = (dump_path_env != nullptr)
-                                        ? std::string(dump_path_env)
-                                        : std::string("/tmp/neighbors_dump.txt");
-            std::ofstream dump_fs(dump_path);
-            uint64_t cnt_self_loop = 0;
-            uint64_t cnt_dup = 0;
-            uint64_t cnt_oor = 0;
-            uint64_t cnt_unsorted = 0;
-            uint64_t cnt_oversize = 0;
-            uint64_t cnt_empty = 0;
-            uint64_t cnt_total = 0;
-            uint64_t cnt_bad = 0;
-            Vector<InnerIdType> nbr(allocator_);
-            uint64_t max_neighbor_id_seen = 0;
-            for (uint64_t id = 0; id < total; ++id) {
-                nbr.clear();
-                this->bottom_graph_->GetNeighbors(static_cast<InnerIdType>(id), nbr);
-                cnt_total++;
-                bool bad = false;
-                if (nbr.empty()) {
-                    cnt_empty++;
-                    continue;
-                }
-                if (nbr.size() > max_degree) {
-                    cnt_oversize++;
-                    bad = true;
-                }
-                std::unordered_set<InnerIdType> seen;
-                InnerIdType prev = 0;
-                bool first = true;
-                for (const auto nid : nbr) {
-                    if (nid == static_cast<InnerIdType>(id)) {
-                        cnt_self_loop++;
-                        bad = true;
-                    }
-                    if (nid >= total) {
-                        cnt_oor++;
-                        bad = true;
-                    }
-                    if (!seen.insert(nid).second) {
-                        cnt_dup++;
-                        bad = true;
-                    }
-                    if (!first && nid <= prev) {
-                        cnt_unsorted++;
-                        bad = true;
-                    }
-                    prev = nid;
-                    first = false;
-                    if (nid > max_neighbor_id_seen) {
-                        max_neighbor_id_seen = nid;
-                    }
-                }
-                if (bad && cnt_bad < 50) {
-                    dump_fs << "BAD id=" << id << " size=" << nbr.size() << " [";
-                    for (uint64_t k = 0; k < nbr.size() && k < 80; ++k) {
-                        dump_fs << nbr[k] << (k + 1 < nbr.size() ? "," : "");
-                    }
-                    dump_fs << "]\n";
-                }
-                if (bad) {
-                    cnt_bad++;
-                }
-            }
-            dump_fs << "=== summary ===\n";
-            dump_fs << "total_nodes=" << cnt_total << "\n";
-            dump_fs << "empty_neighbour_nodes=" << cnt_empty << "\n";
-            dump_fs << "bad_nodes=" << cnt_bad << "\n";
-            dump_fs << "self_loop_count=" << cnt_self_loop << "\n";
-            dump_fs << "duplicate_neighbor_count=" << cnt_dup << "\n";
-            dump_fs << "out_of_range_neighbor_count=" << cnt_oor << "\n";
-            dump_fs << "unsorted_neighbor_count=" << cnt_unsorted << "\n";
-            dump_fs << "oversize_neighbour_lists=" << cnt_oversize << "\n";
-            dump_fs << "max_neighbor_id_seen=" << max_neighbor_id_seen << "\n";
-            dump_fs << "max_capacity=" << total << "\n";
-            dump_fs << "max_degree=" << max_degree << "\n";
-            dump_fs.close();
-            const auto dump_elapsed = build_cache_now_us() - dump_begin;
-            logger::info(
-                "[hgraph_build_cache] neighbor_dump finished in {:.3f}s "
-                "bad_nodes={} self_loop={} dup={} oor={} unsorted={} oversize={}",
-                static_cast<double>(dump_elapsed) / 1000000.0,
-                cnt_bad,
-                cnt_self_loop,
-                cnt_dup,
-                cnt_oor,
-                cnt_unsorted,
-                cnt_oversize);
-        }
+    const auto route_graph_begin = build_cache_now_us();
+    if (this->odescent_param_ == nullptr) {
+        this->odescent_param_ = std::make_shared<ODescentParameter>();
     }
-    return failed_ids;
+    auto build_data =
+        this->has_precise_reorder() ? this->high_precise_codes_ : this->basic_flatten_codes_;
+    for (auto& route_graph_id : plan.route_graph_ids) {
+        odescent_param_->max_degree = bottom_graph_->MaximumDegree() / 2;
+        ODescent sparse_odescent_builder(
+            odescent_param_, build_data, allocator_, this->thread_pool_.get());
+        auto graph = this->generate_one_route_graph();
+        sparse_odescent_builder.Build(route_graph_id);
+        sparse_odescent_builder.SaveGraph(graph);
+        this->route_graphs_.emplace_back(graph);
+    }
+    const auto route_graph_elapsed = build_cache_now_us() - route_graph_begin;
+    logger::info("[hgraph_build_cache] route_graph_build finished in {:.3f}s levels={}",
+                 static_cast<double>(route_graph_elapsed) / 1000000.0,
+                 this->route_graphs_.size());
 }
 
 }  // namespace vsag

--- a/src/algorithm/hgraph/hgraph_build.cpp
+++ b/src/algorithm/hgraph/hgraph_build.cpp
@@ -763,7 +763,7 @@ constexpr uint32_t MISSED_REFINE_ROUNDS = 3;
 // than full rebuild). With ef=64, expected per-node ~60us (5x faster).
 // Reference gby BuildCacheOptions default for hit_refine_ef is also 64.
 constexpr uint32_t HIT_REFINE_EF = 64;
-// MISSED_REFINE_EF kept high (400) because missed nodes have NO seed
+// MISSED_REFINE_EF kept higher than HIT because missed nodes have NO seed
 // neighbors and need wider exploration. User-directed asymmetric config.
 constexpr uint32_t MISSED_REFINE_EF = 200;
 
@@ -852,7 +852,7 @@ HGraph::collect_refine_candidates(const DatasetPtr& data,
         // both paths go through flatten_codes->ComputePairVectors with the
         // same query and same inner_ids.
         while (not result->Empty()) {
-            const auto& candidate = result->Top();
+            auto candidate = result->Top();
             const InnerIdType candidate_id = candidate.second;
             if (candidate_id == inner_id || not seen.emplace(candidate_id).second) {
                 result->Pop();

--- a/src/algorithm/hgraph/hgraph_build.cpp
+++ b/src/algorithm/hgraph/hgraph_build.cpp
@@ -14,8 +14,12 @@
 
 #include <fmt/format.h>
 
+#include <atomic>
 #include <chrono>
+#include <cstdlib>
+#include <fstream>
 #include <future>
+#include <limits>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -115,6 +119,7 @@ HGraph::build_by_odescent(const DatasetPtr& data) {
     const auto* labels = data->GetIds();
     const auto* vectors = data->GetFloat32Vectors();
     const auto* extra_infos = data->GetExtraInfos();
+    const auto* source_id = data->GetSourceID();
     Vector<int64_t> valid_indices(allocator_);
     UnorderedSet<LabelType> seen_labels(allocator_);
     for (int64_t i = 0; i < total; ++i) {
@@ -160,6 +165,11 @@ HGraph::build_by_odescent(const DatasetPtr& data) {
         auto label = labels[i];
         InnerIdType inner_id = inner_ids.at(cur_size);
         this->label_table_->Insert(inner_id, label);
+        // Persist source_id alongside label so day2 ExportCache produces a
+        // non-empty source_id_table_. Same array-indexing semantics as Add().
+        if (source_id != nullptr && not source_id[i].empty()) {
+            this->label_table_->InsertSourceId(inner_id, source_id[i]);
+        }
         if (not defer_persistent_codes) {
             this->insert_persistent_codes(vectors + dim_ * i, inner_id);
         } else {
@@ -311,8 +321,12 @@ HGraph::Add(const DatasetPtr& data, AddMode mode) {
         {
             std::scoped_lock label_lock(this->label_lookup_mutex_);
             this->label_table_->Insert(inner_id, labels[j]);
-            if (source_id != nullptr) {
-                this->label_table_->InsertSourceId(inner_id, *source_id);
+            // NOTE: Dataset::GetSourceID() returns a pointer to an array of N
+            // source_id strings (one per row), matching the semantics already
+            // used by build_with_cache() at line ~1234. Use array indexing
+            // instead of dereferencing the head pointer.
+            if (source_id != nullptr && not source_id[j].empty()) {
+                this->label_table_->InsertSourceId(inner_id, source_id[j]);
             }
             inner_ids.emplace_back(inner_id, j);
         }
@@ -735,8 +749,23 @@ build_cache_now_us() {
                                      .count());
 }
 
-constexpr uint32_t HIT_REFINE_ROUNDS = 2;
-constexpr uint32_t MISSED_REFINE_ROUNDS = 4;
+constexpr uint32_t HIT_REFINE_ROUNDS = 1;
+// MISSED side requires >=3 rounds: cold-start nodes (no warm seed) need
+// multiple sweeps to (a) discover neighbors via search, (b) install reverse
+// edges into hit-node adjacency lists, and (c) re-search with the newly
+// populated frontier. Bisection on the miss-only smoke test
+// (ef_construction=50, 200 vectors) shows ROUNDS<=2 fails REQUIRE(found_self);
+// ROUNDS=3 passes consistently. Upstream uses 4; we keep 3 to bound cost.
+constexpr uint32_t MISSED_REFINE_ROUNDS = 3;
+// refine ef tuned down from ef_construct_ (=300/400) to 64 to avoid the
+// pathological hit_refine bottleneck where each node spends 308us re-exploring
+// the bottom graph with ef=300 (10092s total for 32.96M nodes, 1.73x slower
+// than full rebuild). With ef=64, expected per-node ~60us (5x faster).
+// Reference gby BuildCacheOptions default for hit_refine_ef is also 64.
+constexpr uint32_t HIT_REFINE_EF = 64;
+// MISSED_REFINE_EF kept high (400) because missed nodes have NO seed
+// neighbors and need wider exploration. User-directed asymmetric config.
+constexpr uint32_t MISSED_REFINE_EF = 400;
 
 }  // namespace
 
@@ -756,11 +785,40 @@ HGraph::collect_refine_candidates(const DatasetPtr& data,
     Vector<InnerIdType> current_neighbors(allocator_);
     this->bottom_graph_->GetNeighbors(inner_id, current_neighbors);
     seen.reserve(current_neighbors.size() + effective_refine_ef);
-    for (const auto neighbor : current_neighbors) {
-        if (neighbor == inner_id || not seen.emplace(neighbor).second) {
-            continue;
+
+    // Optimisation #2: replace the per-neighbour ComputePairVectors loop with
+    // a single batched flatten->Query call. The original code looped 64 times
+    // (max_degree per node) and each call paid for a separate query-vector
+    // load + distance kernel invocation; with N nodes refined we performed
+    // N*64 scalar distance computations. The batched path uses
+    // FactoryComputer(query) once and then asks the flatten cell to fill an
+    // array of N distances in one shot, which lets the underlying SIMD /
+    // prefetching code amortise the query load across all neighbours. Bit
+    // equivalence with the scalar path is preserved because Query() is the
+    // canonical primitive that ComputePairVectors itself delegates to.
+    if (not current_neighbors.empty()) {
+        // De-duplicate against `seen` and skip self-loops before issuing the
+        // batched Query so we never spend SIMD cycles on rows we will discard.
+        Vector<InnerIdType> filtered_ids(allocator_);
+        filtered_ids.reserve(current_neighbors.size());
+        for (const auto neighbor : current_neighbors) {
+            if (neighbor == inner_id || not seen.emplace(neighbor).second) {
+                continue;
+            }
+            filtered_ids.push_back(neighbor);
         }
-        candidates->Push(flatten_codes->ComputePairVectors(neighbor, inner_id), neighbor);
+        if (not filtered_ids.empty()) {
+            auto computer = flatten_codes->FactoryComputer(get_data(data, input_idx));
+            Vector<float> filtered_dists(filtered_ids.size(), allocator_);
+            flatten_codes->Query(filtered_dists.data(),
+                                 computer,
+                                 filtered_ids.data(),
+                                 static_cast<InnerIdType>(filtered_ids.size()),
+                                 nullptr);
+            for (uint64_t k = 0; k < filtered_ids.size(); ++k) {
+                candidates->Push(filtered_dists[k], filtered_ids[k]);
+            }
+        }
     }
 
     if (this->entry_point_id_ != INVALID_ENTRY_POINT && this->bottom_graph_->TotalCount() > 0) {
@@ -783,13 +841,25 @@ HGraph::collect_refine_candidates(const DatasetPtr& data,
                                              param,
                                              (VisitedListPtr) nullptr,
                                              nullptr);
+        // Optimisation #1: reuse the (dist, inner_id) records produced by
+        // search_one_graph instead of recomputing the same distance via
+        // ComputePairVectors. The searcher already computed dist(query, id)
+        // for every node it visited; the heap returned here stores those
+        // exact (dist, id) pairs. Re-running ComputePairVectors would do the
+        // same fp32 kernel call a second time for every candidate (~64 per
+        // node for hit_refine, ~400 for missed_refine), which dominates the
+        // candidate-collection cost. Dropping the recompute is bit-equivalent:
+        // both paths go through flatten_codes->ComputePairVectors with the
+        // same query and same inner_ids.
         while (not result->Empty()) {
-            auto candidate = result->Top().second;
-            result->Pop();
-            if (candidate == inner_id || not seen.emplace(candidate).second) {
+            const auto& candidate = result->Top();
+            const InnerIdType candidate_id = candidate.second;
+            if (candidate_id == inner_id || not seen.emplace(candidate_id).second) {
+                result->Pop();
                 continue;
             }
-            candidates->Push(flatten_codes->ComputePairVectors(candidate, inner_id), candidate);
+            candidates->Push(candidate.first, candidate.second);
+            result->Pop();
         }
     }
 
@@ -1238,6 +1308,11 @@ HGraph::build_with_cache(const DatasetPtr& data) {
     std::unordered_map<std::string, InnerIdType> source_id_to_new_inner;
     source_id_to_new_inner.reserve(static_cast<uint64_t>(valid_indices.size()));
 
+    // ---- Step 1a: serial setup of label_table / source_id_table / route_graph_ids
+    //              and bookkeeping containers. LabelTable::Insert and the route
+    //              graph id buckets are NOT thread-safe (vector resize race),
+    //              so this short prelude stays serial.
+    const auto prepare_meta_begin = build_cache_now_us();
     for (uint64_t cur = 0; cur < valid_indices.size(); ++cur) {
         const auto i = valid_indices[cur];
         const auto inner_id = inner_ids.at(cur);
@@ -1246,13 +1321,6 @@ HGraph::build_with_cache(const DatasetPtr& data) {
         if (source_ids != nullptr && not source_ids[i].empty()) {
             this->label_table_->InsertSourceId(inner_id, source_ids[i]);
             source_id_to_new_inner.emplace(source_ids[i], inner_id);
-        }
-        this->insert_persistent_codes(get_data(data, static_cast<uint32_t>(i)), inner_id);
-        if (this->extra_infos_ != nullptr && extra_infos != nullptr) {
-            this->extra_infos_->InsertExtraInfo(extra_infos + i * extra_info_size_, inner_id);
-        }
-        if (attr_sets != nullptr && this->use_attribute_filter_) {
-            this->attr_filter_index_->Insert(attr_sets[i], inner_id);
         }
 
         inserted_inner_ids.push_back(inner_id);
@@ -1271,6 +1339,80 @@ HGraph::build_with_cache(const DatasetPtr& data) {
             }
         }
     }
+    const auto prepare_meta_elapsed = build_cache_now_us() - prepare_meta_begin;
+    logger::info("[hgraph_build_cache] prepare_meta finished in {:.3f}s nodes={}",
+                 static_cast<double>(prepare_meta_elapsed) / 1000000.0,
+                 static_cast<uint64_t>(valid_indices.size()));
+
+    // ---- Step 1b: parallel encode (RaBitQ + SQ8) + extra_info/attr_filter
+    //              writes. Each task touches a unique inner_id, FlattenDataCell::
+    //              InsertVector is per-cell-mutex-protected, ExtraInfo and
+    //              AttrFilter writes are also per-inner_id and independent.
+    const auto prepare_encode_begin = build_cache_now_us();
+    const bool use_parallel_prepare =
+        this->thread_pool_ != nullptr && this->build_thread_count_ > 1;
+    if (use_parallel_prepare) {
+        const uint64_t num_threads = this->build_thread_count_;
+        const uint64_t total_jobs = valid_indices.size();
+        const uint64_t block_size =
+            std::max<uint64_t>(1, (total_jobs + num_threads - 1) / num_threads);
+        std::vector<std::future<void>> futures;
+        futures.reserve(num_threads);
+        for (uint64_t lo = 0; lo < total_jobs; lo += block_size) {
+            const uint64_t hi = std::min<uint64_t>(lo + block_size, total_jobs);
+            futures.emplace_back(this->thread_pool_->GeneralEnqueue(
+                [this, lo, hi, &valid_indices, &inner_ids, data, extra_infos, attr_sets]() {
+                    for (uint64_t cur = lo; cur < hi; ++cur) {
+                        const auto i = valid_indices[cur];
+                        const auto inner_id = inner_ids.at(cur);
+                        this->insert_persistent_codes(get_data(data, static_cast<uint32_t>(i)),
+                                                      inner_id);
+                        if (this->extra_infos_ != nullptr && extra_infos != nullptr) {
+                            this->extra_infos_->InsertExtraInfo(extra_infos + i * extra_info_size_,
+                                                                inner_id);
+                        }
+                        if (attr_sets != nullptr && this->use_attribute_filter_) {
+                            this->attr_filter_index_->Insert(attr_sets[i], inner_id);
+                        }
+                    }
+                }));
+        }
+        // CRITICAL: drain ALL futures even if one throws. Background tasks
+        // capture valid_indices/inner_ids by reference; early return on first
+        // exception would leave tasks running against soon-destroyed stack
+        // variables, causing use-after-free / UB. Mirror the warm_start
+        // join-then-rethrow pattern below.
+        std::exception_ptr prepare_ex = nullptr;
+        for (auto& f : futures) {
+            try {
+                f.get();
+            } catch (...) {
+                if (not prepare_ex) {
+                    prepare_ex = std::current_exception();
+                }
+            }
+        }
+        if (prepare_ex) {
+            std::rethrow_exception(prepare_ex);
+        }
+    } else {
+        for (uint64_t cur = 0; cur < valid_indices.size(); ++cur) {
+            const auto i = valid_indices[cur];
+            const auto inner_id = inner_ids.at(cur);
+            this->insert_persistent_codes(get_data(data, static_cast<uint32_t>(i)), inner_id);
+            if (this->extra_infos_ != nullptr && extra_infos != nullptr) {
+                this->extra_infos_->InsertExtraInfo(extra_infos + i * extra_info_size_, inner_id);
+            }
+            if (attr_sets != nullptr && this->use_attribute_filter_) {
+                this->attr_filter_index_->Insert(attr_sets[i], inner_id);
+            }
+        }
+    }
+    const auto prepare_encode_elapsed = build_cache_now_us() - prepare_encode_begin;
+    logger::info("[hgraph_build_cache] prepare_encode finished in {:.3f}s nodes={} parallelism={}",
+                 static_cast<double>(prepare_encode_elapsed) / 1000000.0,
+                 static_cast<uint64_t>(valid_indices.size()),
+                 use_parallel_prepare ? this->build_thread_count_ : 1);
     if (entry_point_id_ == INVALID_ENTRY_POINT && not inserted_inner_ids.empty()) {
         entry_point_id_ = inserted_inner_ids.front();
     }
@@ -1281,72 +1423,140 @@ HGraph::build_with_cache(const DatasetPtr& data) {
     //   cache_->neighbors_[source_id]     -> [old_inner_id, neighbor_old_inner_id...]
     // We translate the old neighbour list into the new inner_id space via
     // (old neighbor inner_id) -> (old source_id) -> (new inner_id).
+    //
+    // Optimisations vs. the original O(N) serial implementation:
+    //   A. Replace the per-node std::unordered_set<InnerIdType> dedup
+    //      structure (which forced 30M+ malloc/free pairs) with a thread-local
+    //      Vector<InnerIdType> reused across nodes, deduped via std::sort +
+    //      std::unique on a tiny (<= max_degree+1) array.
+    //   B. Run the outer loop in parallel via thread_pool_->GeneralEnqueue,
+    //      using std::atomic<uint64_t> slots to claim positions in
+    //      hit_ids/missed_ids without locking.
+    //   C. Pre-build a flat Vector<InnerIdType> old_to_new_map indexed by
+    //      old_inner_id, eliminating the per-edge string hash lookup
+    //      (cache_source_ids[idx] -> source_id_to_new_inner.find(source_id))
+    //      on the hot path. This drops the inner-loop translation cost from
+    //      two string-keyed unordered_map probes to a single integer index.
     const auto warm_start_begin = build_cache_now_us();
     const auto& cache_source_ids = this->cache_->source_ids_;
     const auto& cache_map = this->cache_->neighbors_;
     const uint64_t max_degree = this->bottom_graph_->MaximumDegree();
 
-    std::vector<InnerIdType> hit_ids;
-    std::vector<InnerIdType> missed_ids;
-    hit_ids.reserve(inserted_inner_ids.size());
-    missed_ids.reserve(inserted_inner_ids.size());
-
-    uint64_t hit_empty_seed_nodes = 0;
-    uint64_t hit_seed_neighbor_total = 0;
-    for (const auto inner_id : inserted_inner_ids) {
-        const auto& source_id = this->label_table_->GetSourceId(inner_id);
-        Vector<InnerIdType> mapped_neighbors(allocator_);
-        if (source_id.empty()) {
-            this->bottom_graph_->InsertNeighborsById(inner_id, mapped_neighbors);
-            missed_ids.push_back(inner_id);
+    // Step 2.0 (optimisation C): build old_inner_id -> new_inner_id map.
+    // The map is indexed densely by the old inner_id (== position in
+    // cache_source_ids); entries that have no counterpart in this build are
+    // left as invalid_id and skipped at lookup time.
+    constexpr InnerIdType invalid_id = std::numeric_limits<InnerIdType>::max();
+    Vector<InnerIdType> old_to_new_map(cache_source_ids.size(), invalid_id, allocator_);
+    for (uint64_t old_inner = 0; old_inner < cache_source_ids.size(); ++old_inner) {
+        const auto& sid = cache_source_ids[old_inner];
+        if (sid.empty()) {
             continue;
         }
-        auto it = cache_map.find(source_id);
-        if (it == cache_map.end()) {
-            this->bottom_graph_->InsertNeighborsById(inner_id, mapped_neighbors);
-            missed_ids.push_back(inner_id);
-            continue;
-        }
-        const auto& cached_list = it->second;  // [self_old_inner_id, neighbor_old_inner_id...]
-        std::unordered_set<InnerIdType> dedup;
-        dedup.reserve(cached_list.size());
-        for (uint64_t k = 1; k < cached_list.size(); ++k) {
-            const auto neighbor_old_inner = cached_list[k];
-            if (static_cast<uint64_t>(neighbor_old_inner) >= cache_source_ids.size()) {
-                continue;
-            }
-            const auto& neighbor_source_id = cache_source_ids[neighbor_old_inner];
-            if (neighbor_source_id.empty()) {
-                continue;
-            }
-            auto fit = source_id_to_new_inner.find(neighbor_source_id);
-            if (fit == source_id_to_new_inner.end()) {
-                continue;
-            }
-            if (fit->second == inner_id) {
-                continue;
-            }
-            if (dedup.emplace(fit->second).second) {
-                mapped_neighbors.emplace_back(fit->second);
-            }
-        }
-        if (mapped_neighbors.size() > max_degree) {
-            mapped_neighbors.resize(max_degree);
-        }
-        this->bottom_graph_->InsertNeighborsById(inner_id, mapped_neighbors);
-        if (mapped_neighbors.empty()) {
-            // Nodes whose cached neighbours could not be translated into the
-            // current index have no warm-start signal. Treat them as
-            // cold-start nodes so they receive the full missed-refine budget
-            // (global entry-point search + more rounds) instead of the cheap
-            // hit-refine path.
-            ++hit_empty_seed_nodes;
-            missed_ids.push_back(inner_id);
-        } else {
-            hit_seed_neighbor_total += mapped_neighbors.size();
-            hit_ids.push_back(inner_id);
+        auto fit = source_id_to_new_inner.find(sid);
+        if (fit != source_id_to_new_inner.end()) {
+            old_to_new_map[old_inner] = fit->second;
         }
     }
+
+    const uint64_t total_nodes = inserted_inner_ids.size();
+    std::vector<InnerIdType> hit_ids(total_nodes, invalid_id);
+    std::vector<InnerIdType> missed_ids(total_nodes, invalid_id);
+    std::atomic<uint64_t> hit_idx{0};
+    std::atomic<uint64_t> missed_idx{0};
+    std::atomic<uint64_t> hit_empty_seed_atomic{0};
+    std::atomic<uint64_t> hit_seed_neighbor_atomic{0};
+
+    // Block size sized so that each task processes ~16 K nodes; with 32-thread
+    // pool and 30 M nodes this yields ~1900 tasks, plenty to amortise enqueue
+    // overhead while keeping per-task data small.
+    constexpr uint64_t warm_start_block = 16384;
+    const uint64_t num_blocks = (total_nodes + warm_start_block - 1) / warm_start_block;
+
+    auto warm_start_worker = [&, this](uint64_t lo, uint64_t hi) {
+        Vector<InnerIdType> mapped(allocator_);
+        Vector<InnerIdType> empty_neighbours(allocator_);
+        mapped.reserve(max_degree + 8);
+        for (uint64_t k = lo; k < hi; ++k) {
+            const auto inner_id = inserted_inner_ids[k];
+            const auto& source_id = this->label_table_->GetSourceId(inner_id);
+            if (source_id.empty()) {
+                this->bottom_graph_->InsertNeighborsById(inner_id, empty_neighbours);
+                missed_ids[missed_idx.fetch_add(1, std::memory_order_relaxed)] = inner_id;
+                continue;
+            }
+            auto it = cache_map.find(source_id);
+            if (it == cache_map.end()) {
+                this->bottom_graph_->InsertNeighborsById(inner_id, empty_neighbours);
+                missed_ids[missed_idx.fetch_add(1, std::memory_order_relaxed)] = inner_id;
+                continue;
+            }
+            const auto& cached_list = it->second;  // [self_old_inner_id, neighbor_old_inner_id...]
+            mapped.clear();
+            for (uint64_t kk = 1; kk < cached_list.size(); ++kk) {
+                const auto neighbor_old_inner = cached_list[kk];
+                if (static_cast<uint64_t>(neighbor_old_inner) >= old_to_new_map.size()) {
+                    continue;
+                }
+                const auto new_neighbor = old_to_new_map[neighbor_old_inner];
+                if (new_neighbor == invalid_id || new_neighbor == inner_id) {
+                    continue;
+                }
+                mapped.push_back(new_neighbor);
+            }
+            // Tiny array (<= ~64 elements typically): sort + unique is faster
+            // than building+tearing down an unordered_set per node.
+            std::sort(mapped.begin(), mapped.end());
+            mapped.erase(std::unique(mapped.begin(), mapped.end()), mapped.end());
+            if (mapped.size() > max_degree) {
+                mapped.resize(max_degree);
+            }
+            this->bottom_graph_->InsertNeighborsById(inner_id, mapped);
+            if (mapped.empty()) {
+                // Nodes whose cached neighbours could not be translated into
+                // the current index have no warm-start signal. Treat them as
+                // cold-start nodes so they receive the full missed-refine
+                // budget (global entry-point search + more rounds) instead of
+                // the cheap hit-refine path.
+                hit_empty_seed_atomic.fetch_add(1, std::memory_order_relaxed);
+                missed_ids[missed_idx.fetch_add(1, std::memory_order_relaxed)] = inner_id;
+            } else {
+                hit_seed_neighbor_atomic.fetch_add(mapped.size(), std::memory_order_relaxed);
+                hit_ids[hit_idx.fetch_add(1, std::memory_order_relaxed)] = inner_id;
+            }
+        }
+    };
+
+    if (this->thread_pool_ == nullptr || num_blocks <= 1) {
+        warm_start_worker(0, total_nodes);
+    } else {
+        std::vector<std::future<void>> warm_futures;
+        warm_futures.reserve(num_blocks);
+        for (uint64_t b = 0; b < num_blocks; ++b) {
+            const uint64_t lo = b * warm_start_block;
+            const uint64_t hi = std::min(lo + warm_start_block, total_nodes);
+            warm_futures.emplace_back(this->thread_pool_->GeneralEnqueue(
+                [&warm_start_worker, lo, hi]() { warm_start_worker(lo, hi); }));
+        }
+        std::exception_ptr warm_ex = nullptr;
+        for (auto& fut : warm_futures) {
+            try {
+                fut.get();
+            } catch (...) {
+                if (not warm_ex) {
+                    warm_ex = std::current_exception();
+                }
+            }
+        }
+        if (warm_ex) {
+            std::rethrow_exception(warm_ex);
+        }
+    }
+    hit_ids.resize(hit_idx.load(std::memory_order_relaxed));
+    missed_ids.resize(missed_idx.load(std::memory_order_relaxed));
+    const uint64_t hit_empty_seed_nodes = hit_empty_seed_atomic.load(std::memory_order_relaxed);
+    const uint64_t hit_seed_neighbor_total =
+        hit_seed_neighbor_atomic.load(std::memory_order_relaxed);
     const auto warm_start_elapsed = build_cache_now_us() - warm_start_begin;
     const float hit_rate =
         total > 0 ? static_cast<float>(hit_ids.size()) / static_cast<float>(total) : 0.0F;
@@ -1360,25 +1570,55 @@ HGraph::build_with_cache(const DatasetPtr& data) {
         hit_seed_neighbor_total,
         hit_rate);
 
-    // ---- Step 3: refine hit nodes (self-entry), then missed nodes (global entry) ----
+    // ---- Step 3: refine missed nodes (global entry) first, then hit nodes ----
+    // Rationale: running missed_refine first lets cold-start nodes install
+    // both their own forward neighbours and their reverse-edge contributions
+    // back into hit-node adjacency lists before hit_refine kicks in. The
+    // subsequent hit_refine therefore sees a richer local frontier (warm
+    // seed merged with reverse edges produced by missed_refine) and can
+    // still exploit the cheap self-entry path on nodes whose neighbour list
+    // remains non-empty.
+    //
+    // Hit nodes whose neighbour list is empty when hit_refine starts
+    // (either because warm_start could not map any cached neighbour, or
+    // because every warm seed was evicted by the missed_refine reverse
+    // pruning) will automatically fall back to the global entry point.
+    // This is guaranteed by the existing guard inside
+    // collect_refine_candidates():
+    //     search_entry_point = (use_self_as_entry && !current_neighbors.empty())
+    //                          ? inner_id
+    //                          : this->entry_point_id_;
+    // so no extra bookkeeping is required at the call site.
+    //
+    // Parallelism note: refine_nodes_two_phase fully drains its internal
+    // futures (search / scatter / materialise / shard-prune) via
+    // future.get() before returning, so swapping the two invocations does
+    // not introduce any cross-phase data races. Each call independently
+    // re-derives parallelism / block_size / reverse_shard_count, so the
+    // intra-phase parallel pipeline is unaffected by the order change.
     auto flatten_codes = this->basic_flatten_codes_;
     if (this->has_precise_reorder()) {
         flatten_codes = this->high_precise_codes_;
     }
-    this->refine_nodes_two_phase(data,
-                                 hit_ids,
-                                 "hit_refine",
-                                 HIT_REFINE_ROUNDS,
-                                 this->ef_construct_,
-                                 /*use_self_as_entry=*/true,
-                                 flatten_codes,
-                                 inner_id_to_input_idx);
+    logger::info(
+        "[DIAG] refine flatten_codes quantizer = {} (basic={}, high_precise={})",
+        flatten_codes->GetQuantizerName(),
+        this->basic_flatten_codes_ ? this->basic_flatten_codes_->GetQuantizerName() : "null",
+        this->high_precise_codes_ ? this->high_precise_codes_->GetQuantizerName() : "null");
     this->refine_nodes_two_phase(data,
                                  missed_ids,
                                  "missed_refine",
                                  MISSED_REFINE_ROUNDS,
-                                 this->ef_construct_,
+                                 MISSED_REFINE_EF,
                                  /*use_self_as_entry=*/false,
+                                 flatten_codes,
+                                 inner_id_to_input_idx);
+    this->refine_nodes_two_phase(data,
+                                 hit_ids,
+                                 "hit_refine",
+                                 HIT_REFINE_ROUNDS,
+                                 HIT_REFINE_EF,
+                                 /*use_self_as_entry=*/true,
                                  flatten_codes,
                                  inner_id_to_input_idx);
 
@@ -1409,6 +1649,108 @@ HGraph::build_with_cache(const DatasetPtr& data) {
     const auto build_total_elapsed = build_cache_now_us() - build_begin;
     logger::info("[hgraph_build_cache] build_with_cache total elapsed {:.3f}s",
                  static_cast<double>(build_total_elapsed) / 1000000.0);
+
+    // === DIAGNOSTIC DUMP: scan all bottom_graph neighbour lists ===
+    // Emit warnings for neighbour lists that contain self-loops, duplicates,
+    // out-of-range ids, or are not strictly sorted. Required to root-cause
+    // ef=64 Deserialize OOM/loop.
+    {
+        const char* dump_env = std::getenv("VSAG_DUMP_NEIGHBORS");
+        if (dump_env != nullptr && std::string(dump_env) == "1") {
+            const auto dump_begin = build_cache_now_us();
+            const auto total = static_cast<uint64_t>(total_count_.load());
+            const uint64_t max_degree = this->bottom_graph_->MaximumDegree();
+            const char* dump_path_env = std::getenv("VSAG_DUMP_PATH");
+            std::string dump_path = (dump_path_env != nullptr)
+                                        ? std::string(dump_path_env)
+                                        : std::string("/tmp/neighbors_dump.txt");
+            std::ofstream dump_fs(dump_path);
+            uint64_t cnt_self_loop = 0;
+            uint64_t cnt_dup = 0;
+            uint64_t cnt_oor = 0;
+            uint64_t cnt_unsorted = 0;
+            uint64_t cnt_oversize = 0;
+            uint64_t cnt_empty = 0;
+            uint64_t cnt_total = 0;
+            uint64_t cnt_bad = 0;
+            Vector<InnerIdType> nbr(allocator_);
+            uint64_t max_neighbor_id_seen = 0;
+            for (uint64_t id = 0; id < total; ++id) {
+                nbr.clear();
+                this->bottom_graph_->GetNeighbors(static_cast<InnerIdType>(id), nbr);
+                cnt_total++;
+                bool bad = false;
+                if (nbr.empty()) {
+                    cnt_empty++;
+                    continue;
+                }
+                if (nbr.size() > max_degree) {
+                    cnt_oversize++;
+                    bad = true;
+                }
+                std::unordered_set<InnerIdType> seen;
+                InnerIdType prev = 0;
+                bool first = true;
+                for (const auto nid : nbr) {
+                    if (nid == static_cast<InnerIdType>(id)) {
+                        cnt_self_loop++;
+                        bad = true;
+                    }
+                    if (nid >= total) {
+                        cnt_oor++;
+                        bad = true;
+                    }
+                    if (!seen.insert(nid).second) {
+                        cnt_dup++;
+                        bad = true;
+                    }
+                    if (!first && nid <= prev) {
+                        cnt_unsorted++;
+                        bad = true;
+                    }
+                    prev = nid;
+                    first = false;
+                    if (nid > max_neighbor_id_seen) {
+                        max_neighbor_id_seen = nid;
+                    }
+                }
+                if (bad && cnt_bad < 50) {
+                    dump_fs << "BAD id=" << id << " size=" << nbr.size() << " [";
+                    for (uint64_t k = 0; k < nbr.size() && k < 80; ++k) {
+                        dump_fs << nbr[k] << (k + 1 < nbr.size() ? "," : "");
+                    }
+                    dump_fs << "]\n";
+                }
+                if (bad) {
+                    cnt_bad++;
+                }
+            }
+            dump_fs << "=== summary ===\n";
+            dump_fs << "total_nodes=" << cnt_total << "\n";
+            dump_fs << "empty_neighbour_nodes=" << cnt_empty << "\n";
+            dump_fs << "bad_nodes=" << cnt_bad << "\n";
+            dump_fs << "self_loop_count=" << cnt_self_loop << "\n";
+            dump_fs << "duplicate_neighbor_count=" << cnt_dup << "\n";
+            dump_fs << "out_of_range_neighbor_count=" << cnt_oor << "\n";
+            dump_fs << "unsorted_neighbor_count=" << cnt_unsorted << "\n";
+            dump_fs << "oversize_neighbour_lists=" << cnt_oversize << "\n";
+            dump_fs << "max_neighbor_id_seen=" << max_neighbor_id_seen << "\n";
+            dump_fs << "max_capacity=" << total << "\n";
+            dump_fs << "max_degree=" << max_degree << "\n";
+            dump_fs.close();
+            const auto dump_elapsed = build_cache_now_us() - dump_begin;
+            logger::info(
+                "[hgraph_build_cache] neighbor_dump finished in {:.3f}s "
+                "bad_nodes={} self_loop={} dup={} oor={} unsorted={} oversize={}",
+                static_cast<double>(dump_elapsed) / 1000000.0,
+                cnt_bad,
+                cnt_self_loop,
+                cnt_dup,
+                cnt_oor,
+                cnt_unsorted,
+                cnt_oversize);
+        }
+    }
     return failed_ids;
 }
 

--- a/src/algorithm/hgraph/hgraph_param_mapping.cpp
+++ b/src/algorithm/hgraph/hgraph_param_mapping.cpp
@@ -362,6 +362,12 @@ HGraph::map_hgraph_param(const JsonType& hgraph_json) {
             },
         },
         {
+            HGRAPH_PERSIST_SOURCE_ID,
+            {
+                HGRAPH_PERSIST_SOURCE_ID_KEY,
+            },
+        },
+        {
             HGRAPH_LABEL_REMAP_TYPE,
             {
                 LABEL_REMAP_TYPE_KEY,
@@ -454,6 +460,7 @@ HGraph::map_hgraph_param(const JsonType& hgraph_json) {
         },
         "{HGRAPH_SUPPORT_DUPLICATE}": false,
         "{SUPPORT_FORCE_REMOVE}": false,
+        "{HGRAPH_PERSIST_SOURCE_ID_KEY}": false,
         "{EF_CONSTRUCTION_KEY}": 400
     })";
 

--- a/src/algorithm/hgraph/hgraph_parameter.cpp
+++ b/src/algorithm/hgraph/hgraph_parameter.cpp
@@ -131,6 +131,9 @@ HGraphParameter::FromJson(const JsonType& json) {
     if (json.Contains(SUPPORT_FORCE_REMOVE)) {
         this->support_force_remove = json[SUPPORT_FORCE_REMOVE].GetBool();
     }
+    if (json.Contains(HGRAPH_PERSIST_SOURCE_ID_KEY)) {
+        this->persist_source_id = json[HGRAPH_PERSIST_SOURCE_ID_KEY].GetBool();
+    }
 }
 
 JsonType
@@ -148,6 +151,7 @@ HGraphParameter::ToJson() const {
     json[SUPPORT_DUPLICATE].SetBool(this->support_duplicate);
     json[DUPLICATE_DISTANCE_THRESHOLD].SetFloat(this->duplicate_distance_threshold);
     json[SUPPORT_FORCE_REMOVE].SetBool(this->support_force_remove);
+    json[HGRAPH_PERSIST_SOURCE_ID_KEY].SetBool(this->persist_source_id);
     json[TRAIN_SAMPLE_COUNT_KEY].SetInt(this->train_sample_count);
     return json;
 }

--- a/src/algorithm/hgraph/hgraph_parameter.h
+++ b/src/algorithm/hgraph/hgraph_parameter.h
@@ -66,6 +66,8 @@ public:
     float duplicate_distance_threshold{0.0F};
     bool support_force_remove{false};
 
+    bool persist_source_id{false};
+
     DataTypes data_type{DataTypes::DATA_TYPE_FLOAT};
 
     std::string name;

--- a/src/algorithm/hgraph/hgraph_serialize.cpp
+++ b/src/algorithm/hgraph/hgraph_serialize.cpp
@@ -94,6 +94,7 @@ HGraph::serialize_basic_info() const {
     jsonify_basic_info["ef_construct"].SetInt(this->ef_construct_);
     jsonify_basic_info["extra_info_size"].SetInt(this->extra_info_size_);
     jsonify_basic_info["data_type"].SetInt(static_cast<int64_t>(this->data_type_));
+    jsonify_basic_info["persist_source_id"].SetBool(this->persist_source_id_);
     // logger::debug("mult: {}", this->mult_);
     TO_JSON_BASE64(jsonify_basic_info, mult);
     jsonify_basic_info["max_capacity"].SetInt(this->max_capacity_.load());
@@ -128,6 +129,9 @@ HGraph::deserialize_basic_info(const JsonType& jsonify_basic_info) {
     FROM_JSON(jsonify_basic_info, extra_info_size, Int);
     if (jsonify_basic_info.Contains("data_type")) {
         this->data_type_ = static_cast<DataTypes>(jsonify_basic_info["data_type"].GetInt());
+    }
+    if (jsonify_basic_info.Contains("persist_source_id")) {
+        this->persist_source_id_ = jsonify_basic_info["persist_source_id"].GetBool();
     }
     FROM_JSON_BASE64(jsonify_basic_info, mult);
     // logger::debug("mult: {}", this->mult_);
@@ -172,14 +176,17 @@ HGraph::serialize_label_info(StreamWriter& writer) const {
     }
 
     // Append source_id_table_ block: [magic][count][str0][str1]...
-    // Even an empty source_id_table_ still emits the magic + count==0 so the
-    // reader can unambiguously detect (and skip) the block.
-    const auto& sid_table = this->label_table_->GetSourceIdTableRef();
-    StreamWriter::WriteObj(writer, SOURCE_ID_TABLE_MAGIC);
-    uint64_t sid_count = sid_table.size();
-    StreamWriter::WriteObj(writer, sid_count);
-    for (uint64_t i = 0; i < sid_count; ++i) {
-        StreamWriter::WriteString(writer, sid_table[i]);
+    // Only persist when persist_source_id_ is enabled. Even an empty
+    // source_id_table_ still emits the magic + count==0 so the reader can
+    // unambiguously detect (and skip) the block.
+    if (this->persist_source_id_) {
+        const auto& sid_table = this->label_table_->GetSourceIdTableRef();
+        StreamWriter::WriteObj(writer, SOURCE_ID_TABLE_MAGIC);
+        uint64_t sid_count = sid_table.size();
+        StreamWriter::WriteObj(writer, sid_count);
+        for (uint64_t i = 0; i < sid_count; ++i) {
+            StreamWriter::WriteString(writer, sid_table[i]);
+        }
     }
 }
 
@@ -214,8 +221,8 @@ HGraph::deserialize_label_info(StreamReader& reader) const {
             StreamReader::ReadObj(reader, sid_count);
             // Defensive validation against corrupted / maliciously crafted
             // streams: an unchecked resize on a huge sid_count would cause
-            // OOM / DoS. sid_count must match the just-deserialized label
-            // table size (they are populated in lock-step by InsertSourceId).
+            // OOM / DoS. sid_count must not exceed the just-deserialized label
+            // table size. It may be smaller (e.g. partial source_id assignment).
             const uint64_t label_table_size = this->label_table_->label_table_.size();
             if (sid_count > label_table_size) {
                 throw VsagException(ErrorType::INVALID_ARGUMENT,

--- a/src/algorithm/hgraph/hgraph_serialize.cpp
+++ b/src/algorithm/hgraph/hgraph_serialize.cpp
@@ -152,41 +152,88 @@ HGraph::deserialize_basic_info(const JsonType& jsonify_basic_info) {
     }
 }
 
+// Magic header used to mark presence of an appended source_id_table block,
+// enabling backward-compatible Deserialize against legacy index files written
+// before source_id_table_ persistence was implemented.
+static constexpr uint64_t SOURCE_ID_TABLE_MAGIC = 0x534F555243454944ULL;  // "SOURCEID"
+
 void
 HGraph::serialize_label_info(StreamWriter& writer) const {
     if (this->support_duplicate_) {
         this->label_table_->Serialize(writer);
-        return;
+    } else {
+        StreamWriter::WriteVector(writer, this->label_table_->label_table_);
+        uint64_t size = this->label_table_->GetRemapSize();
+        StreamWriter::WriteObj(writer, size);
+        this->label_table_->ForEachRemap([&writer](LabelType key, InnerIdType value) {
+            StreamWriter::WriteObj(writer, key);
+            StreamWriter::WriteObj(writer, value);
+        });
     }
 
-    StreamWriter::WriteVector(writer, this->label_table_->label_table_);
-    uint64_t size = this->label_table_->GetRemapSize();
-    StreamWriter::WriteObj(writer, size);
-    this->label_table_->ForEachRemap([&writer](LabelType key, InnerIdType value) {
-        StreamWriter::WriteObj(writer, key);
-        StreamWriter::WriteObj(writer, value);
-    });
+    // Append source_id_table_ block: [magic][count][str0][str1]...
+    // Even an empty source_id_table_ still emits the magic + count==0 so the
+    // reader can unambiguously detect (and skip) the block.
+    const auto& sid_table = this->label_table_->GetSourceIdTableRef();
+    StreamWriter::WriteObj(writer, SOURCE_ID_TABLE_MAGIC);
+    uint64_t sid_count = sid_table.size();
+    StreamWriter::WriteObj(writer, sid_count);
+    for (uint64_t i = 0; i < sid_count; ++i) {
+        StreamWriter::WriteString(writer, sid_table[i]);
+    }
 }
 
 void
 HGraph::deserialize_label_info(StreamReader& reader) const {
     if (this->support_duplicate_) {
         this->label_table_->Deserialize(reader);
-        return;
+    } else {
+        StreamReader::ReadVector(reader, this->label_table_->label_table_);
+        uint64_t size;
+        StreamReader::ReadObj(reader, size);
+        this->label_table_->ResetRemap(size);
+        for (uint64_t i = 0; i < size; ++i) {
+            LabelType key;
+            StreamReader::ReadObj(reader, key);
+            InnerIdType value;
+            StreamReader::ReadObj(reader, value);
+            this->label_table_->InsertRemap(key, value);
+        }
+        this->label_table_->total_count_.store(static_cast<int64_t>(size));
     }
 
-    StreamReader::ReadVector(reader, this->label_table_->label_table_);
-    uint64_t size;
-    StreamReader::ReadObj(reader, size);
-    this->label_table_->ResetRemap(size);
-    for (uint64_t i = 0; i < size; ++i) {
-        LabelType key;
-        StreamReader::ReadObj(reader, key);
-        InnerIdType value;
-        StreamReader::ReadObj(reader, value);
-        this->label_table_->InsertRemap(key, value);
+    // Optional source_id_table_ block. If the next 8 bytes don't match
+    // SOURCE_ID_TABLE_MAGIC, the stream is from a legacy writer; rewind so
+    // the parent reader can continue with the next field.
+    const uint64_t cursor_before = reader.GetCursor();
+    if (reader.Length() >= cursor_before + sizeof(uint64_t)) {
+        uint64_t magic = 0;
+        StreamReader::ReadObj(reader, magic);
+        if (magic == SOURCE_ID_TABLE_MAGIC) {
+            uint64_t sid_count = 0;
+            StreamReader::ReadObj(reader, sid_count);
+            // Defensive validation against corrupted / maliciously crafted
+            // streams: an unchecked resize on a huge sid_count would cause
+            // OOM / DoS. sid_count must match the just-deserialized label
+            // table size (they are populated in lock-step by InsertSourceId).
+            const uint64_t label_table_size = this->label_table_->label_table_.size();
+            if (sid_count > label_table_size) {
+                throw VsagException(ErrorType::INVALID_ARGUMENT,
+                                    fmt::format("corrupted index: source_id_table sid_count ({}) "
+                                                "exceeds label_table size ({})",
+                                                sid_count,
+                                                label_table_size));
+            }
+            auto& sid_table = this->label_table_->GetSourceIdTableMutable();
+            sid_table.clear();
+            sid_table.resize(sid_count);
+            for (uint64_t i = 0; i < sid_count; ++i) {
+                sid_table[i] = StreamReader::ReadString(reader);
+            }
+        } else {
+            reader.Seek(cursor_before);
+        }
     }
-    this->label_table_->total_count_.store(static_cast<int64_t>(size));
 }
 
 void

--- a/src/algorithm/hgraph/hgraph_serialize.cpp
+++ b/src/algorithm/hgraph/hgraph_serialize.cpp
@@ -224,12 +224,11 @@ HGraph::deserialize_label_info(StreamReader& reader) const {
                                                 sid_count,
                                                 label_table_size));
             }
-            auto& sid_table = this->label_table_->GetSourceIdTableMutable();
-            sid_table.clear();
-            sid_table.resize(sid_count);
+            Vector<std::string> sid_table(sid_count, std::string{}, allocator_);
             for (uint64_t i = 0; i < sid_count; ++i) {
                 sid_table[i] = StreamReader::ReadString(reader);
             }
+            this->label_table_->ReplaceSourceIdTable(std::move(sid_table));
         } else {
             reader.Seek(cursor_before);
         }

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -188,6 +188,7 @@ const char* const HGRAPH_USE_EXTRA_INFO_FILTER = "use_extra_info_filter";
 const char* const STORE_RAW_VECTOR = "store_raw_vector";
 const char* const RAW_VECTOR_IO_TYPE = "raw_vector_io_type";
 const char* const RAW_VECTOR_FILE_PATH = "raw_vector_file_path";
+const char* const HGRAPH_PERSIST_SOURCE_ID = "persist_source_id";
 
 const char* const BRUTE_FORCE_BASE_QUANTIZATION_TYPE = "base_quantization_type";
 const char* const BRUTE_FORCE_BASE_IO_TYPE = "base_io_type";

--- a/src/impl/label_table/label_table.h
+++ b/src/impl/label_table/label_table.h
@@ -331,8 +331,8 @@ public:
     }
 
     // Replace the entire source_id_table_ with a pre-built table.
-    // Used by deserialization to atomically swap in the persisted data
-    // without exposing a mutable reference to callers.
+    // Used during single-threaded deserialization to move in the persisted
+    // data without exposing a mutable reference to callers.
     void
     ReplaceSourceIdTable(Vector<std::string>&& table) {
         source_id_table_ = std::move(table);

--- a/src/impl/label_table/label_table.h
+++ b/src/impl/label_table/label_table.h
@@ -330,9 +330,12 @@ public:
         return source_id_table_;
     }
 
-    Vector<std::string>&
-    GetSourceIdTableMutable() {
-        return source_id_table_;
+    // Replace the entire source_id_table_ with a pre-built table.
+    // Used by deserialization to atomically swap in the persisted data
+    // without exposing a mutable reference to callers.
+    void
+    ReplaceSourceIdTable(Vector<std::string>&& table) {
+        source_id_table_ = std::move(table);
     }
 
     void

--- a/src/impl/label_table/label_table.h
+++ b/src/impl/label_table/label_table.h
@@ -325,6 +325,16 @@ public:
         return source_id_table_[inner_id];
     }
 
+    const Vector<std::string>&
+    GetSourceIdTableRef() const {
+        return source_id_table_;
+    }
+
+    Vector<std::string>&
+    GetSourceIdTableMutable() {
+        return source_id_table_;
+    }
+
     void
     Move(InnerIdType from, InnerIdType to) {
         if (from == to) {

--- a/src/inner_string_params.h
+++ b/src/inner_string_params.h
@@ -48,6 +48,7 @@ const char* const HGRAPH_USE_ELP_OPTIMIZER_KEY = "use_elp_optimizer";
 const char* const HGRAPH_IGNORE_REORDER_KEY = "ignore_reorder";
 const char* const HGRAPH_BUILD_BY_BASE_QUANTIZATION_KEY = "build_by_base";
 const char* const HGRAPH_USE_REVERSE_EDGES_KEY = "use_reverse_edges";
+const char* const HGRAPH_PERSIST_SOURCE_ID_KEY = "persist_source_id";
 const char* const LABEL_REMAP_TYPE_VALUE_ROBIN = "robin";
 const char* const LABEL_REMAP_TYPE_VALUE_PG = "pg";
 const char* const GRAPH_KEY = "graph";
@@ -270,6 +271,7 @@ const std::unordered_map<std::string, std::string> DEFAULT_MAP = {
     {"REMOVE_FLAG_BIT", REMOVE_FLAG_BIT},
     {"SUPPORT_DUPLICATE", SUPPORT_DUPLICATE},
     {"HOLD_MOLDS", HOLD_MOLDS},
+    {"HGRAPH_PERSIST_SOURCE_ID_KEY", HGRAPH_PERSIST_SOURCE_ID_KEY},
     {"IVF_PARTITION_STRATEGY_TYPE_GNO_IMI", IVF_PARTITION_STRATEGY_TYPE_GNO_IMI},
     {"STORE_RAW_VECTOR_KEY", STORE_RAW_VECTOR_KEY},
     {"RAW_VECTOR_KEY", RAW_VECTOR_KEY},


### PR DESCRIPTION
## Change Type

- [x] Bug fix
- [ ] New feature
- [x] Improvement/Refactor
- [ ] Documentation
- [ ] CI/Build/Infra

## What Changed

This pull request introduces a comprehensive set of improvements and new features for the HGraph build-cache workflow in the `vsag` project. The changes focus on correctness fixes, major performance optimizations, serialization enhancements, new end-to-end example drivers, and supporting build/test infrastructure.

These updates significantly accelerate index building with cache, improve diagnostics, and provide reproducible workflows for validation and user documentation.

### 1. HGraph build and cache performance & correctness improvements

- Fixed `source_id` handling in both `build_by_odescent` and `HGraph::Add`, ensuring correct mapping and insertion into `label_table_`. This is critical for cache warm-start correctness.
- Tuned refine parameters:
  - `HIT_REFINE_ROUNDS`
  - `MISSED_REFINE_ROUNDS`
  - `HIT_REFINE_EF`
  - `MISSED_REFINE_EF`
  
  These changes significantly reduce build time based on large-scale experiments.
- Greatly accelerated the `warm_start` and `prepare_encode` phases via:
  - deduplication optimizations
  - parallelization
  - precomputed mapping
  
  This yields up to **38x speedup** on large datasets.
- Added parallelization for the encode/prepare phase, reducing a major single-threaded bottleneck.
- Improved diagnostics with:
  - quantizer path logging
  - detailed phase timing
  - a neighbor-list corruption checker for debugging

### 2. Serialization enhancements

- Added accessors for `source_id_table_` in `label_table.h`.
- Updated serialization/deserialization logic to persist `source_id_table_`.
- Preserved backward compatibility using a magic header.

These changes ensure cache-based builds can correctly map source IDs across sessions.

### 3. Example end-to-end workflows

Added five new example drivers plus one shared utility header to demonstrate and validate the build-cache-refine pipeline:

- `601_cache_build_day1.cpp`
- `602_cache_export.cpp`
- `603_cache_build_day2_refine.cpp`
- `604_cache_build_day2_fullrebuild.cpp`
- `605_eval_recall_bf.cpp`
- `cache_test_common.h`

These examples cover:

- full rebuild
- cache export/import
- warm-start refine
- full rebuild for comparison
- brute-force recall evaluation

