### PR TITLE
feat(pyramid,sindi,warp): add MARK_REMOVE support

### DIFF
--- a/docs/docs/en/src/indexes/pyramid.md
+++ b/docs/docs/en/src/indexes/pyramid.md
@@ -124,6 +124,17 @@ auto result = index->KnnSearch(
 If you don't need path-based scoping, [HGraph](hgraph.md) is simpler and generally
 faster.
 
+## Mark remove
+
+Pyramid supports `RemoveMode::MARK_REMOVE`. Calling `Remove(ids)` (the default
+mode) tombstones the given ids: they are excluded from subsequent search results,
+`GetNumElements()` drops by the number removed, and `GetNumberRemoved()` reports
+the running total. Removing an id that is absent or already removed is a no-op.
+`RemoveMode::FORCE_REMOVE` is not supported and returns an error.
+
+Mark-removed vectors still occupy memory until the index is rebuilt; the space is
+not physically reclaimed.
+
 ## See also
 
 - [Creating an Index](../guide/create_index.md)

--- a/docs/docs/en/src/indexes/sindi.md
+++ b/docs/docs/en/src/indexes/sindi.md
@@ -141,6 +141,17 @@ Range search and id-based filtering are supported; see the example for usage.
      with large gaps, enable `remap_term_ids: true`. This avoids managing many
      empty posting lists and helps stay below the `term_id_limit` ceiling.
 
+## Mark remove
+
+SINDI supports `RemoveMode::MARK_REMOVE`. Calling `Remove(ids)` (the default mode)
+tombstones the given ids so they no longer appear in search results;
+`GetNumElements()` drops accordingly and `GetNumberRemoved()` reports the running
+total. Removing an id that is absent or already removed is a no-op.
+`RemoveMode::FORCE_REMOVE` is not supported and returns an error.
+
+Mark-removed documents still occupy memory until the index is rebuilt; the space
+is not physically reclaimed.
+
 ## See also
 
 - [Creating an Index](../guide/create_index.md)

--- a/docs/docs/zh/src/indexes/pyramid.md
+++ b/docs/docs/zh/src/indexes/pyramid.md
@@ -116,6 +116,15 @@ auto result = index->KnnSearch(
 
 如果不需要按路径限定查询范围，[HGraph](hgraph.md) 更简洁，性能通常也更高。
 
+## 标记删除
+
+Pyramid 支持 `RemoveMode::MARK_REMOVE`。调用 `Remove(ids)`（默认模式）会为给定的 id
+打上删除标记：它们会从后续检索结果中排除，`GetNumElements()` 相应减少，
+`GetNumberRemoved()` 返回累计删除数量。删除不存在或已删除的 id 不会有任何效果。
+`RemoveMode::FORCE_REMOVE` 不支持，调用会返回错误。
+
+被标记删除的向量在索引重建前仍占用内存，空间不会被物理回收。
+
 ## 相关文档
 
 - [创建索引](../guide/create_index.md)

--- a/docs/docs/zh/src/indexes/sindi.md
+++ b/docs/docs/zh/src/indexes/sindi.md
@@ -129,6 +129,15 @@ SINDI **不支持** 稠密向量，只支持内积相似度。范围检索与基
      这样可以避免管理大量空倒排列表带来的内存浪费，也能降低触达 `term_id_limit`
      上限的风险。
 
+## 标记删除
+
+SINDI 支持 `RemoveMode::MARK_REMOVE`。调用 `Remove(ids)`（默认模式）会为给定的 id
+打上删除标记：它们不再出现在检索结果中，`GetNumElements()` 相应减少，
+`GetNumberRemoved()` 返回累计删除数量。删除不存在或已删除的 id 不会有任何效果。
+`RemoveMode::FORCE_REMOVE` 不支持，调用会返回错误。
+
+被标记删除的文档在索引重建前仍占用内存，空间不会被物理回收。
+
 ## 相关文档
 
 - [创建索引](../guide/create_index.md)

--- a/examples/cpp/303_feature_remove.cpp
+++ b/examples/cpp/303_feature_remove.cpp
@@ -95,6 +95,9 @@ main(int argc, char** argv) {
     }
 
     /******************* HGraph Remove Some result ids *****************/
+    // Remove() defaults to RemoveMode::MARK_REMOVE: the ids are tombstoned and
+    // skipped in subsequent searches. Besides HGraph, the Pyramid, SINDI, and
+    // WARP indexes also support MARK_REMOVE; BruteForce and IVF support it too.
     for (int64_t i = 0; i < 5; ++i) {
         index->Remove(result->GetIds()[i]);
     }

--- a/src/algorithm/pyramid/pyramid.cpp
+++ b/src/algorithm/pyramid/pyramid.cpp
@@ -405,7 +405,25 @@ Pyramid::search_impl(const DatasetPtr& query,
 
 int64_t
 Pyramid::GetNumElements() const {
-    return base_codes_->TotalCount();
+    auto total = static_cast<int64_t>(base_codes_->TotalCount());
+    auto deleted = delete_count_.load();
+    return total > deleted ? total - deleted : 0;
+}
+
+int64_t
+Pyramid::GetNumberRemoved() const {
+    return delete_count_.load();
+}
+
+uint32_t
+Pyramid::Remove(const std::vector<int64_t>& ids, RemoveMode mode) {
+    if (mode != RemoveMode::MARK_REMOVE) {
+        throw VsagException(ErrorType::INVALID_ARGUMENT, "Pyramid only supports MARK_REMOVE");
+    }
+    std::scoped_lock lock(this->label_lookup_mutex_, this->cur_element_count_mutex_);
+    uint32_t delete_count = this->label_table_->MarkRemove(ids);
+    delete_count_.fetch_add(delete_count, std::memory_order_relaxed);
+    return delete_count;
 }
 
 void
@@ -448,6 +466,8 @@ Pyramid::Deserialize(StreamReader& reader) {
         &reader, std::numeric_limits<uint64_t>::max(), this->allocator_);
 
     label_table_->Deserialize(buffer_reader);
+    delete_count_.store(static_cast<int64_t>(label_table_->GetAllDeletedIds().size()),
+                        std::memory_order_relaxed);
     base_codes_->Deserialize(buffer_reader);
     if (use_reorder_) {
         precise_codes_->Deserialize(buffer_reader);
@@ -609,6 +629,8 @@ Pyramid::InitFeatures() {
         IndexFeature::SUPPORT_EXPORT_MODEL,
         IndexFeature::SUPPORT_GET_MEMORY_USAGE,
     });
+
+    this->index_feature_list_->SetFeature(IndexFeature::SUPPORT_DELETE_BY_ID);
 }
 
 static const std::string HGRAPH_PARAMS_TEMPLATE =

--- a/src/algorithm/pyramid/pyramid.h
+++ b/src/algorithm/pyramid/pyramid.h
@@ -190,6 +190,12 @@ public:
     int64_t
     GetNumElements() const override;
 
+    int64_t
+    GetNumberRemoved() const override;
+
+    uint32_t
+    Remove(const std::vector<int64_t>& ids, RemoveMode mode) override;
+
     std::string
     GetStats() const override;
 
@@ -299,6 +305,7 @@ private:
     std::unique_ptr<BasicSearcher> searcher_ = nullptr;
     int64_t max_capacity_{0};
     int64_t cur_element_count_{0};
+    std::atomic<int64_t> delete_count_{0};
     bool support_duplicate_{false};
 
     mutable std::shared_mutex resize_mutex_;

--- a/src/algorithm/sindi/sindi.cpp
+++ b/src/algorithm/sindi/sindi.cpp
@@ -545,6 +545,8 @@ SINDI::Deserialize(StreamReader& reader) {
     }
 
     label_table_->Deserialize(reader_ref);
+    delete_count_.store(static_cast<int64_t>(label_table_->GetAllDeletedIds().size()),
+                        std::memory_order_relaxed);
 
     if (use_reorder_) {
         rerank_flat_index_->Deserialize(reader_ref);
@@ -750,6 +752,7 @@ SINDI::InitFeatures() {
                                             IndexFeature::SUPPORT_UPDATE_VECTOR_CONCURRENT});
 
     // metric
+    this->index_feature_list_->SetFeature(IndexFeature::SUPPORT_DELETE_BY_ID);
     this->index_feature_list_->SetFeature(IndexFeature::SUPPORT_METRIC_TYPE_INNER_PRODUCT);
 }
 
@@ -818,6 +821,16 @@ SINDI::remap_sparse_vector_for_build(const SparseVector& input, Vector<uint32_t>
     remapped.ids_ = tmp_ids.data();
     remapped.vals_ = input.vals_;
     return remapped;
+}
+uint32_t
+SINDI::Remove(const std::vector<int64_t>& ids, RemoveMode mode) {
+    if (mode != RemoveMode::MARK_REMOVE) {
+        throw VsagException(ErrorType::INVALID_ARGUMENT, "SINDI only supports MARK_REMOVE");
+    }
+    std::scoped_lock lock(this->global_mutex_, this->label_lookup_mutex_);
+    uint32_t delete_count = this->label_table_->MarkRemove(ids);
+    delete_count_.fetch_add(delete_count, std::memory_order_relaxed);
+    return delete_count;
 }
 
 }  // namespace vsag

--- a/src/algorithm/sindi/sindi.h
+++ b/src/algorithm/sindi/sindi.h
@@ -109,8 +109,18 @@ public:
 
     int64_t
     GetNumElements() const override {
-        return cur_element_count_;
+        auto total = cur_element_count_.load();
+        auto deleted = delete_count_.load();
+        return total > deleted ? total - deleted : 0;
     }
+
+    int64_t
+    GetNumberRemoved() const override {
+        return delete_count_.load();
+    }
+
+    uint32_t
+    Remove(const std::vector<int64_t>& ids, RemoveMode mode) override;
 
     [[nodiscard]] uint64_t
     EstimateMemory(uint64_t num_elements) const override;
@@ -164,7 +174,9 @@ private:
 
     Vector<SparseTermDataCellPtr> window_term_list_;
 
-    int64_t cur_element_count_{0};
+    std::atomic<int64_t> cur_element_count_{0};
+
+    std::atomic<int64_t> delete_count_{0};
 
     bool use_reorder_{false};
 

--- a/src/algorithm/warp/warp.cpp
+++ b/src/algorithm/warp/warp.cpp
@@ -529,6 +529,7 @@ WARP::Deserialize(StreamReader& reader) {
 
     this->inner_codes_->Deserialize(buffer_reader);
     this->label_table_->Deserialize(buffer_reader);
+    delete_count_.store(label_table_->GetAllDeletedIds().size(), std::memory_order_relaxed);
     this->cal_memory_usage();
 }
 
@@ -647,6 +648,17 @@ WARP::InitFeatures() {
         IndexFeature::SUPPORT_CHECK_ID_EXIST,
         IndexFeature::SUPPORT_CLONE,
     });
+}
+
+uint32_t
+WARP::Remove(const std::vector<int64_t>& ids, RemoveMode mode) {
+    if (mode != RemoveMode::MARK_REMOVE) {
+        throw VsagException(ErrorType::INVALID_ARGUMENT, "WARP only supports MARK_REMOVE");
+    }
+    std::scoped_lock label_lock(this->label_lookup_mutex_);
+    uint32_t delete_count = this->label_table_->MarkRemove(ids);
+    delete_count_.fetch_add(delete_count, std::memory_order_relaxed);
+    return delete_count;
 }
 
 static const std::string WARP_PARAMS_TEMPLATE =

--- a/src/algorithm/warp/warp.h
+++ b/src/algorithm/warp/warp.h
@@ -73,14 +73,18 @@ public:
 
     [[nodiscard]] int64_t
     GetNumElements() const override {
-        return static_cast<int64_t>(this->total_count_.load()) -
-               static_cast<int64_t>(this->delete_count_);
+        auto deleted = static_cast<int64_t>(this->delete_count_.load());
+        auto total = static_cast<int64_t>(this->total_count_.load());
+        return total > deleted ? total - deleted : 0;
     }
 
     [[nodiscard]] int64_t
     GetNumberRemoved() const override {
-        return this->delete_count_;
+        return this->delete_count_.load();
     }
+
+    uint32_t
+    Remove(const std::vector<int64_t>& ids, RemoveMode mode) override;
 
     void
     GetVectorByInnerId(InnerIdType inner_id, float* data) const override;
@@ -133,7 +137,7 @@ private:
 private:
     FlattenInterfacePtr inner_codes_{nullptr};
 
-    uint64_t delete_count_{0};
+    std::atomic<uint64_t> delete_count_{0};
 
     uint64_t total_vector_count_{0};  // Total number of vectors across all docs
 

--- a/src/analyzer/sindi_analyzer.cpp
+++ b/src/analyzer/sindi_analyzer.cpp
@@ -413,8 +413,8 @@ SINDIAnalyzer::calculate_ground_truth(const DatasetPtr& query_dataset,
     }
 
     auto query_count = query_dataset->GetNumElements();
-    auto base_count =
-        base_dataset == nullptr ? sindi_->cur_element_count_ : base_dataset->GetNumElements();
+    auto base_count = base_dataset == nullptr ? sindi_->cur_element_count_.load()
+                                              : base_dataset->GetNumElements();
     auto effective_topk = std::min<int64_t>(topk, base_count);
     if (effective_topk <= 0) {
         return nullptr;

--- a/tests/test_pyramid.cpp
+++ b/tests/test_pyramid.cpp
@@ -1426,3 +1426,53 @@ TEST_CASE("Multi-Hierarchy: Single hierarchy in hierarchies config",
     std::set<int64_t> found(rids, rids + result.value()->GetDim());
     REQUIRE(found.count(10) == 1);
 }
+
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
+                             "Pyramid Mark Remove",
+                             "[ft][remove][pyramid]") {
+    auto metric_type = GENERATE("l2");
+    PyramidParam pyramid_param;
+    pyramid_param.no_build_levels = {0, 1, 2};
+    const std::string name = "pyramid";
+    auto search_param = GeneratePyramidSearchParametersString(200);
+    for (auto& dim : dims) {
+        INFO(fmt::format("metric_type={}, dim={}", metric_type, dim));
+        auto param = GeneratePyramidBuildParametersString(metric_type, dim, pyramid_param);
+        auto index = TestFactory(name, param, true);
+        auto dataset = pool.GetDatasetAndCreate(dim, base_count, metric_type, /*with_path=*/true);
+        TestBuildIndex(index, dataset, true);
+
+        auto base_num = dataset->base_->GetNumElements();
+        const auto* ids = dataset->base_->GetIds();
+        REQUIRE(index->GetNumElements() == base_num);
+        REQUIRE(index->GetNumberRemoved() == 0);
+
+        // FORCE_REMOVE is not supported by Pyramid
+        auto force_result = index->Remove(ids[0], vsag::RemoveMode::FORCE_REMOVE);
+        REQUIRE_FALSE(force_result.has_value());
+
+        // mark remove half of the base data
+        int64_t remove_count = base_num / 2;
+        std::vector<int64_t> remove_ids(ids, ids + remove_count);
+        auto remove_result = index->Remove(remove_ids, vsag::RemoveMode::MARK_REMOVE);
+        REQUIRE(remove_result.has_value());
+        REQUIRE(remove_result.value() == remove_count);
+        REQUIRE(index->GetNumElements() == base_num - remove_count);
+        REQUIRE(index->GetNumberRemoved() == remove_count);
+
+        // removing the same ids again should remove nothing
+        auto duplicate_remove = index->Remove(remove_ids, vsag::RemoveMode::MARK_REMOVE);
+        REQUIRE(duplicate_remove.has_value());
+        REQUIRE(duplicate_remove.value() == 0);
+
+        // removed ids must not appear in search results
+        for (int64_t i = 0; i < remove_count; ++i) {
+            auto query = fixtures::get_one_query(dataset->base_, static_cast<int>(i));
+            auto search_result = index->KnnSearch(query, 10, search_param);
+            REQUIRE(search_result.has_value());
+            for (int64_t j = 0; j < search_result.value()->GetDim(); ++j) {
+                REQUIRE(search_result.value()->GetIds()[j] != ids[i]);
+            }
+        }
+    }
+}

--- a/tests/test_sindi.cpp
+++ b/tests/test_sindi.cpp
@@ -325,3 +325,46 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex,
     TestRangeSearch(index, dataset, search_param, 0.99, 10, true);
     TestFilterSearch(index, dataset, search_param, 0.99, true);
 }
+
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex, "SINDI Mark Remove", "[ft][remove][sindi]") {
+    fixtures::SINDIParam param;
+    param.use_reorder = GENERATE(true, false);
+    auto build_param = fixtures::SINDITestIndex::GenerateBuildParameter(param);
+    auto index = TestFactory("sindi", build_param, true);
+    auto dataset = pool.GetSparseDatasetAndCreate(base_count, 128, 0.8);
+    REQUIRE(index->GetIndexType() == vsag::IndexType::SINDI);
+    TestBuildIndex(index, dataset, true);
+
+    auto base_num = dataset->base_->GetNumElements();
+    const auto* ids = dataset->base_->GetIds();
+    REQUIRE(index->GetNumElements() == base_num);
+    REQUIRE(index->GetNumberRemoved() == 0);
+
+    // FORCE_REMOVE is not supported by SINDI
+    auto force_result = index->Remove(ids[0], vsag::RemoveMode::FORCE_REMOVE);
+    REQUIRE_FALSE(force_result.has_value());
+
+    // mark remove half of the base data
+    int64_t remove_count = base_num / 2;
+    std::vector<int64_t> remove_ids(ids, ids + remove_count);
+    auto remove_result = index->Remove(remove_ids, vsag::RemoveMode::MARK_REMOVE);
+    REQUIRE(remove_result.has_value());
+    REQUIRE(remove_result.value() == remove_count);
+    REQUIRE(index->GetNumElements() == base_num - remove_count);
+    REQUIRE(index->GetNumberRemoved() == remove_count);
+
+    // removing the same ids again should remove nothing
+    auto duplicate_remove = index->Remove(remove_ids, vsag::RemoveMode::MARK_REMOVE);
+    REQUIRE(duplicate_remove.has_value());
+    REQUIRE(duplicate_remove.value() == 0);
+
+    // removed ids must not appear in search results
+    for (int64_t i = 0; i < remove_count; ++i) {
+        auto query = fixtures::get_one_query(dataset->base_, static_cast<int>(i));
+        auto search_result = index->KnnSearch(query, 10, search_param);
+        REQUIRE(search_result.has_value());
+        for (int64_t j = 0; j < search_result.value()->GetDim(); ++j) {
+            REQUIRE(search_result.value()->GetIds()[j] != ids[i]);
+        }
+    }
+}

--- a/tests/test_warp.cpp
+++ b/tests/test_warp.cpp
@@ -173,3 +173,61 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::WarpTestIndex, "Warp IP Multiple Dims", "
         TestKnnSearch(index, dataset, search_param, 0.99, true);
     }
 }
+
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::WarpTestIndex, "Warp Mark Remove", "[ft][remove][warp]") {
+    auto metric_type = GENERATE("ip");
+    std::string base_quantization_str = GENERATE("fp32");
+    WarpParam warp_param;
+    warp_param.base_quantization_type = base_quantization_str;
+    const std::string name = "warp";
+    auto search_param = GenerateWarpSearchParametersString();
+    for (auto& dim : dims) {
+        INFO(fmt::format("metric_type={}, dim={}", metric_type, dim));
+        auto param = GenerateWarpBuildParametersString(metric_type, dim, warp_param);
+        auto index = TestFactory(name, param, true);
+        auto dataset =
+            pool.GetDatasetAndCreate(dim, base_count, metric_type, false, 0.8, 0, 16, "multi");
+        TestBuildIndex(index, dataset, true);
+
+        auto base_num = dataset->base_->GetNumElements();
+        const auto* ids = dataset->base_->GetIds();
+        REQUIRE(index->GetNumElements() == base_num);
+        REQUIRE(index->GetNumberRemoved() == 0);
+
+        // FORCE_REMOVE is not supported by WARP
+        auto force_result = index->Remove(ids[0], vsag::RemoveMode::FORCE_REMOVE);
+        REQUIRE_FALSE(force_result.has_value());
+
+        // mark remove half of the base data
+        int64_t remove_count = base_num / 2;
+        std::vector<int64_t> remove_ids(ids, ids + remove_count);
+        auto remove_result = index->Remove(remove_ids, vsag::RemoveMode::MARK_REMOVE);
+        REQUIRE(remove_result.has_value());
+        REQUIRE(remove_result.value() == remove_count);
+        REQUIRE(index->GetNumElements() == base_num - remove_count);
+        REQUIRE(index->GetNumberRemoved() == remove_count);
+
+        // removing the same ids again should remove nothing
+        auto duplicate_remove = index->Remove(remove_ids, vsag::RemoveMode::MARK_REMOVE);
+        REQUIRE(duplicate_remove.has_value());
+        REQUIRE(duplicate_remove.value() == 0);
+
+        // removing an id that is not present is a no-op
+        std::vector<int64_t> absent_ids = {base_num + 10000};
+        auto absent_remove = index->Remove(absent_ids, vsag::RemoveMode::MARK_REMOVE);
+        REQUIRE(absent_remove.has_value());
+        REQUIRE(absent_remove.value() == 0);
+        REQUIRE(index->GetNumElements() == base_num - remove_count);
+        REQUIRE(index->GetNumberRemoved() == remove_count);
+
+        // removed ids must not appear in search results
+        for (int64_t i = 0; i < remove_count; ++i) {
+            auto query = fixtures::get_one_query(dataset->base_, static_cast<int>(i));
+            auto search_result = index->KnnSearch(query, 10, search_param);
+            REQUIRE(search_result.has_value());
+            for (int64_t j = 0; j < search_result.value()->GetDim(); ++j) {
+                REQUIRE(search_result.value()->GetIds()[j] != ids[i]);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Add Remove() method to Pyramid, SINDI, and WARP indexes to support MARK_REMOVE mode, enabling marking vectors as deleted without physical removal.

## Changes

### WARP Index
- Implement Remove() method using existing delete_count_ member
- Support RemoveMode::MARK_REMOVE only

### Pyramid Index  
- Add std::atomic<int64_t> delete_count_ member variable
- Modify GetNumElements() to return cur_element_count_ - delete_count_
- Add GetNumberRemoved() method
- Implement Remove() method

### SINDI Index
- Add std::atomic<int64_t> delete_count_ member variable  
- Modify GetNumElements() to return cur_element_count_ - delete_count_
- Add GetNumberRemoved() method
- Implement Remove() method

## Implementation Details

All three indexes:
- Support Remove(ids, RemoveMode::MARK_REMOVE) operation
- Return correct active element count via GetNumElements()
- Return correct deleted element count via GetNumberRemoved()
- Throw VsagException for unsupported FORCE_REMOVE mode
- Use label_table_->MarkRemove(ids) for marking deletions
- Thread-safe with std::scoped_lock protection

## Test Plan

- Build: ✅ Release build successful
- Format: ✅ Code formatted with make fmt
- Existing tests: Pyramid, SINDI, WARP tests pass

## Related Issue

Closes #2135

## Reference

- HGraph Remove: src/algorithm/hgraph/hgraph_modify.cpp:22-45
- BruteForce Remove: src/algorithm/bruteforce/bruteforce.cpp:149-187