### PR TITLE
refactor(algorithm): extract common search helpers to InnerIndexInterface base class

### DIFF
--- a/src/algorithm/bruteforce/bruteforce.cpp
+++ b/src/algorithm/bruteforce/bruteforce.cpp
@@ -210,16 +210,7 @@ BruteForce::SearchWithRequest(const SearchRequest& request) const {
     ExecutorPtr executor = nullptr;
     Filter* attr_filter = nullptr;
 
-    auto combined_filter = std::make_shared<CombinedFilter>();
-    combined_filter->AppendFilter(this->label_table_->GetDeletedIdsFilter());
-    if (request.filter_ != nullptr) {
-        combined_filter->AppendFilter(
-            std::make_shared<InnerIdWrapperFilter>(request.filter_, *this->label_table_));
-    }
-    FilterPtr ft = nullptr;
-    if (not combined_filter->IsEmpty()) {
-        ft = combined_filter;
-    }
+    FilterPtr ft = this->create_search_filter(request.filter_);
 
     if (request.enable_attribute_filter_) {
         auto& schema = this->attr_filter_index_->field_type_map_;
@@ -277,19 +268,13 @@ BruteForce::SearchWithRequest(const SearchRequest& request) const {
         }
     }
 
-    auto [dataset_results, dists, ids] =
-        create_fast_dataset(static_cast<int64_t>(heap->Size()), allocator_);
-    for (auto j = static_cast<int64_t>(heap->Size() - 1); j >= 0; --j) {
-        dists[j] = heap->Top().first;
-        ids[j] = this->label_table_->GetLabelById(heap->Top().second);
-        heap->Pop();
-    }
+    auto result = this->pack_knn_result(heap);
 
     JsonType stats;
     stats["dist_cmp"].SetInt(dist_cmp.load(std::memory_order_relaxed));
-    dataset_results->Statistics(stats.Dump());
+    result->Statistics(stats.Dump());
 
-    return std::move(dataset_results);
+    return result;
 }
 
 DatasetPtr
@@ -300,14 +285,12 @@ BruteForce::RangeSearch(const vsag::DatasetPtr& query,
                         int64_t limited_size) const {
     std::shared_lock read_lock(this->global_mutex_);
     auto computer = this->inner_codes_->FactoryComputer(query->GetFloat32Vectors());
-    CHECK_ARGUMENT(limited_size != 0,
-                   fmt::format("limited_size({}) must not be equal to 0", limited_size));
+    this->validate_range_args(query, radius, limited_size);
     if (limited_size < 0) {
         limited_size = std::numeric_limits<int64_t>::max();
     }
     if (total_count_ == 0) {
-        auto [dataset_results, dists, ids] = create_fast_dataset(0, allocator_);
-        return std::move(dataset_results);
+        return make_empty_result();
     }
 
     auto brute_force_params = BruteForceSearchParameters::FromJson(parameters);
@@ -352,14 +335,7 @@ BruteForce::RangeSearch(const vsag::DatasetPtr& query,
         }
     }
 
-    auto [dataset_results, dists, ids] =
-        create_fast_dataset(static_cast<int64_t>(heap->Size()), allocator_);
-    for (auto j = static_cast<int64_t>(heap->Size() - 1); j >= 0; --j) {
-        dists[j] = heap->Top().first;
-        ids[j] = this->label_table_->GetLabelById(heap->Top().second);
-        heap->Pop();
-    }
-    return std::move(dataset_results);
+    return this->pack_knn_result(heap);
 }
 
 float
@@ -390,25 +366,23 @@ BruteForce::Serialize(StreamWriter& writer) const {
     this->label_table_->Serialize(writer);
 
     // serialize footer (introduced since v0.15)
-    auto metadata = std::make_shared<Metadata>();
     JsonType basic_info;
     basic_info["dim"].SetInt(dim_);
     basic_info["total_count"].SetInt(total_count_);
     basic_info[INDEX_PARAM].SetString(this->create_param_ptr_->ToString());
-    metadata->Set("basic_info", basic_info);
-    auto footer = std::make_shared<Footer>(metadata);
-    footer->Write(writer);
+    write_index_footer(writer, basic_info);
 }
 
 void
 BruteForce::Deserialize(StreamReader& reader) {
     // try to deserialize footer (only in new version)
-    auto footer = Footer::Parse(reader);
+    JsonType basic_info;
+    bool has_footer = read_index_footer(reader, basic_info);
 
     BufferStreamReader buffer_reader(
         &reader, std::numeric_limits<uint64_t>::max(), this->allocator_);
 
-    if (footer == nullptr) {  // old format, DON'T EDIT, remove in the future
+    if (not has_footer) {  // old format, DON'T EDIT, remove in the future
         logger::debug("parse with v0.13 version format");
 
         StreamReader::ReadObj(buffer_reader, dim_);
@@ -416,8 +390,6 @@ BruteForce::Deserialize(StreamReader& reader) {
     } else {  // create like `else if ( ver in [v0.15, v0.17] )` here if need in the future
         logger::debug("parse with new version format");
 
-        auto metadata = footer->GetMetadata();
-        auto basic_info = metadata->Get("basic_info");
         if (basic_info.Contains(INDEX_PARAM)) {
             std::string index_param_string = basic_info[INDEX_PARAM].GetString();
             auto index_param = std::make_shared<BruteForceParameter>();

--- a/src/algorithm/hgraph/hgraph_search.cpp
+++ b/src/algorithm/hgraph/hgraph_search.cpp
@@ -73,12 +73,7 @@ HGraph::KnnSearch(const DatasetPtr& query,
     if (GetNumElements() == 0) {
         return DatasetImpl::MakeEmptyDataset();
     }
-    int64_t query_dim = query->GetDim();
-    if (data_type_ != DataTypes::DATA_TYPE_SPARSE) {
-        CHECK_ARGUMENT(
-            query_dim == dim_,
-            fmt::format("query.dim({}) must be equal to index.dim({})", query_dim, dim_));
-    }
+    this->validate_knn_args(query, k);
 
     auto params = HGraphSearchParameters::FromJson(parameters);
     auto ef_search_threshold = std::max<int64_t>(AMPLIFICATION_FACTOR * k, 1000);
@@ -91,28 +86,9 @@ HGraph::KnnSearch(const DatasetPtr& query,
         force_remove_rlock = std::shared_lock<std::shared_mutex>(this->force_remove_mutex_);
     }
     std::shared_lock shared_lock(this->global_mutex_);
-    // check k
-    CHECK_ARGUMENT(k > 0, fmt::format("k({}) must be greater than 0", k));
     k = std::min(k, GetNumElements());
 
-    // check query vector
-    CHECK_ARGUMENT(query->GetNumElements() == 1, "query dataset should contain 1 vector only");
-
-    auto combined_filter = std::make_shared<CombinedFilter>();
-    combined_filter->AppendFilter(this->label_table_->GetDeletedIdsFilter());
-    if (filter != nullptr) {
-        if (params.use_extra_info_filter) {
-            combined_filter->AppendFilter(
-                std::make_shared<ExtraInfoWrapperFilter>(filter, this->extra_infos_));
-        } else {
-            combined_filter->AppendFilter(
-                std::make_shared<InnerIdWrapperFilter>(filter, *this->label_table_));
-        }
-    }
-    FilterPtr ft = nullptr;
-    if (not combined_filter->IsEmpty()) {
-        ft = combined_filter;
-    }
+    FilterPtr ft = this->create_search_filter(filter, params.use_extra_info_filter);
 
     if (iter_ctx == nullptr) {
         auto cur_count = this->total_count_.load();
@@ -376,32 +352,9 @@ HGraph::RangeSearch(const DatasetPtr& query,
     SearchStatistics stats;
     QueryContext ctx{.stats = &stats};
 
-    auto combined_filter = std::make_shared<CombinedFilter>();
-    combined_filter->AppendFilter(this->label_table_->GetDeletedIdsFilter());
-    if (filter != nullptr) {
-        combined_filter->AppendFilter(
-            std::make_shared<InnerIdWrapperFilter>(filter, *this->label_table_));
-    }
-    FilterPtr ft = nullptr;
-    if (not combined_filter->IsEmpty()) {
-        ft = combined_filter;
-    }
+    FilterPtr ft = this->create_search_filter(filter);
 
-    int64_t query_dim = query->GetDim();
-    if (data_type_ != DataTypes::DATA_TYPE_SPARSE) {
-        CHECK_ARGUMENT(
-            query_dim == dim_,
-            fmt::format("query.dim({}) must be equal to index.dim({})", query_dim, dim_));
-    }
-    // check radius
-    CHECK_ARGUMENT(radius >= 0, fmt::format("radius({}) must be greater equal than 0", radius))
-
-    // check query vector
-    CHECK_ARGUMENT(query->GetNumElements() == 1, "query dataset should contain 1 vector only");
-
-    // check limited_size
-    CHECK_ARGUMENT(limited_size != 0,
-                   fmt::format("limited_size({}) must not be equal to 0", limited_size));
+    this->validate_range_args(query, radius, limited_size);
 
     std::shared_lock<std::shared_mutex> force_remove_rlock;
     if (this->support_force_remove()) {
@@ -477,26 +430,9 @@ HGraph::RangeSearch(const DatasetPtr& query,
         }
     }
 
-    auto count = static_cast<const int64_t>(search_result->Size());
-    auto [dataset_results, dists, ids] = create_fast_dataset(count, allocator_);
-    char* extra_infos = nullptr;
-    if (extra_info_size_ > 0) {
-        extra_infos =
-            static_cast<char*>(allocator_->Allocate(extra_info_size_ * search_result->Size()));
-        dataset_results->ExtraInfos(extra_infos);
-    }
-    for (int64_t j = count - 1; j >= 0; --j) {
-        dists[j] = search_result->Top().first;
-        ids[j] = this->label_table_->GetLabelById(search_result->Top().second);
-        if (extra_infos != nullptr) {
-            this->extra_infos_->GetExtraInfoById(search_result->Top().second,
-                                                 extra_infos + extra_info_size_ * j);
-        }
-        search_result->Pop();
-    }
-
-    dataset_results->Statistics(stats.Dump());
-    return std::move(dataset_results);
+    auto result = this->pack_knn_result_with_extra_info(search_result, allocator_);
+    result->Statistics(stats.Dump());
+    return result;
 }
 
 [[nodiscard]] DatasetPtr
@@ -508,13 +444,8 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
     }
 
     const auto& query = request.query_;
-    int64_t query_dim = query->GetDim();
     auto k = request.topk_;
-    if (data_type_ != DataTypes::DATA_TYPE_SPARSE) {
-        CHECK_ARGUMENT(
-            query_dim == dim_,
-            fmt::format("query.dim({}) must be equal to index.dim({})", query_dim, dim_));
-    }
+    this->validate_knn_args(query, k);
 
     auto params = HGraphSearchParameters::FromJson(request.params_str_);
 
@@ -528,13 +459,7 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
         force_remove_rlock = std::shared_lock<std::shared_mutex>(this->force_remove_mutex_);
     }
     std::shared_lock shared_lock(this->global_mutex_);
-
-    // check k
-    CHECK_ARGUMENT(k > 0, fmt::format("k({}) must be greater than 0", k));
     k = std::min(k, GetNumElements());
-
-    // check query vector
-    CHECK_ARGUMENT(query->GetNumElements() == 1, "query dataset should contain 1 vector only");
 
     // Setup reasoning context if expected labels are provided.
     std::shared_ptr<ReasoningContext> reasoning_ctx;
@@ -591,21 +516,7 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
         search_param.ep = result->Top().second;
     }
 
-    auto combined_filter = std::make_shared<CombinedFilter>();
-    combined_filter->AppendFilter(this->label_table_->GetDeletedIdsFilter());
-    if (request.filter_ != nullptr) {
-        if (params.use_extra_info_filter) {
-            combined_filter->AppendFilter(
-                std::make_shared<ExtraInfoWrapperFilter>(request.filter_, this->extra_infos_));
-        } else {
-            combined_filter->AppendFilter(
-                std::make_shared<InnerIdWrapperFilter>(request.filter_, *this->label_table_));
-        }
-    }
-    FilterPtr ft = nullptr;
-    if (not combined_filter->IsEmpty()) {
-        ft = combined_filter;
-    }
+    FilterPtr ft = this->create_search_filter(request.filter_, params.use_extra_info_filter);
 
     if (request.enable_attribute_filter_ and this->attr_filter_index_ != nullptr) {
         auto& schema = this->attr_filter_index_->field_type_map_;

--- a/src/algorithm/inner_index_interface.cpp
+++ b/src/algorithm/inner_index_interface.cpp
@@ -755,4 +755,145 @@ InnerIndexInterface::cal_distance_by_id(const float* query,
     return result;
 }
 
+// ========== Search Helper Methods ==========
+
+FilterPtr
+InnerIndexInterface::create_search_filter(const FilterPtr& user_filter,
+                                          bool use_extra_info_filter) const {
+    auto deleted_filter = this->label_table_->GetDeletedIdsFilter();
+    FilterPtr wrapped_user_filter = nullptr;
+    if (user_filter != nullptr) {
+        if (use_extra_info_filter && this->extra_infos_ != nullptr) {
+            wrapped_user_filter =
+                std::make_shared<ExtraInfoWrapperFilter>(user_filter, this->extra_infos_);
+        } else {
+            wrapped_user_filter =
+                std::make_shared<InnerIdWrapperFilter>(user_filter, *this->label_table_);
+        }
+    }
+
+    // Avoid CombinedFilter when only one filter is present to preserve
+    // GetValidIds() / FilterDistribution() capabilities of the inner filter.
+    if (deleted_filter == nullptr && wrapped_user_filter == nullptr) {
+        return nullptr;
+    }
+    if (deleted_filter == nullptr) {
+        return wrapped_user_filter;
+    }
+    if (wrapped_user_filter == nullptr) {
+        return deleted_filter;
+    }
+    auto combined_filter = std::make_shared<CombinedFilter>();
+    combined_filter->AppendFilter(deleted_filter);
+    combined_filter->AppendFilter(wrapped_user_filter);
+    return combined_filter;
+}
+
+DatasetPtr
+InnerIndexInterface::pack_knn_result(DistHeapPtr& heap, Allocator* allocator) const {
+    if (heap == nullptr || heap->Empty()) {
+        return make_empty_result();
+    }
+    auto* alloc = allocator != nullptr ? allocator : allocator_;
+    auto count = static_cast<int64_t>(heap->Size());
+    auto [dataset_results, dists, ids] = create_fast_dataset(count, alloc);
+    for (auto j = count - 1; j >= 0; --j) {
+        dists[j] = heap->Top().first;
+        ids[j] = this->label_table_->GetLabelById(heap->Top().second);
+        heap->Pop();
+    }
+    return std::move(dataset_results);
+}
+
+DatasetPtr
+InnerIndexInterface::pack_knn_result_with_extra_info(DistHeapPtr& heap,
+                                                     Allocator* allocator) const {
+    if (heap == nullptr || heap->Empty()) {
+        return make_empty_result();
+    }
+    auto* alloc = allocator != nullptr ? allocator : allocator_;
+    auto count = static_cast<int64_t>(heap->Size());
+    auto [dataset_results, dists, ids] = create_fast_dataset(count, alloc);
+
+    if (this->extra_info_size_ > 0 && this->extra_infos_ != nullptr) {
+        auto* extra_infos = static_cast<char*>(alloc->Allocate(this->extra_info_size_ * count));
+        for (auto j = count - 1; j >= 0; --j) {
+            dists[j] = heap->Top().first;
+            auto inner_id = heap->Top().second;
+            ids[j] = this->label_table_->GetLabelById(inner_id);
+            this->extra_infos_->GetExtraInfoById(inner_id,
+                                                 extra_infos + j * this->extra_info_size_);
+            heap->Pop();
+        }
+        dataset_results->ExtraInfos(extra_infos);
+        dataset_results->ExtraInfoSize(static_cast<int64_t>(this->extra_info_size_));
+    } else {
+        for (auto j = count - 1; j >= 0; --j) {
+            dists[j] = heap->Top().first;
+            ids[j] = this->label_table_->GetLabelById(heap->Top().second);
+            heap->Pop();
+        }
+    }
+    return std::move(dataset_results);
+}
+
+DatasetPtr
+InnerIndexInterface::make_empty_result(const std::string& stats_json) {
+    auto dataset_result = DatasetImpl::MakeEmptyDataset();
+    if (!stats_json.empty()) {
+        dataset_result->Statistics(stats_json);
+    }
+    return dataset_result;
+}
+
+void
+InnerIndexInterface::write_index_footer(StreamWriter& writer, const JsonType& basic_info) {
+    auto metadata = std::make_shared<Metadata>();
+    metadata->Set("basic_info", basic_info);
+    auto footer = std::make_shared<Footer>(metadata);
+    footer->Write(writer);
+}
+
+bool
+InnerIndexInterface::read_index_footer(StreamReader& reader, JsonType& basic_info) {
+    auto footer = Footer::Parse(reader);
+    if (footer == nullptr) {
+        // Old format - no footer found
+        return false;
+    }
+    auto metadata = footer->GetMetadata();
+    if (metadata == nullptr || metadata->EmptyIndex()) {
+        throw VsagException(ErrorType::INDEX_EMPTY, "index is empty");
+    }
+    basic_info = metadata->Get("basic_info");
+    return true;
+}
+
+void
+InnerIndexInterface::validate_search_query(const DatasetPtr& query) const {
+    if (data_type_ != DataTypes::DATA_TYPE_SPARSE) {
+        int64_t query_dim = query->GetDim();
+        CHECK_ARGUMENT(
+            query_dim == dim_,
+            fmt::format("query.dim({}) must be equal to index.dim({})", query_dim, dim_));
+    }
+    CHECK_ARGUMENT(query->GetNumElements() == 1, "query dataset should contain 1 vector only");
+}
+
+void
+InnerIndexInterface::validate_knn_args(const DatasetPtr& query, int64_t k) const {
+    validate_search_query(query);
+    CHECK_ARGUMENT(k > 0, fmt::format("k({}) must be greater than 0", k));
+}
+
+void
+InnerIndexInterface::validate_range_args(const DatasetPtr& query,
+                                         float radius,
+                                         int64_t limited_size) const {
+    validate_search_query(query);
+    CHECK_ARGUMENT(radius >= 0.0F, fmt::format("radius({}) must be greater equal than 0", radius));
+    CHECK_ARGUMENT(limited_size != 0,
+                   fmt::format("limited_size({}) must not be equal to 0", limited_size));
+}
+
 }  // namespace vsag

--- a/src/algorithm/inner_index_interface.h
+++ b/src/algorithm/inner_index_interface.h
@@ -25,6 +25,7 @@
 #include "datacell/extra_info_interface.h"
 #include "datacell/flatten_interface.h"
 #include "dataset_impl.h"
+#include "impl/heap/distance_heap.h"
 #include "inner_index_parameter.h"
 #include "json_types.h"
 #include "metric_type.h"
@@ -511,6 +512,45 @@ protected:
                        const int64_t* ids,
                        int64_t count,
                        const FlattenInterfacePtr& data) const;
+
+    // ========== Search Helper Methods ==========
+    // Common filter composition: combines DeletedIdsFilter with user filter
+    // If use_extra_info_filter is true and extra_infos_ is available,
+    // uses ExtraInfoWrapperFilter; otherwise uses InnerIdWrapperFilter.
+    FilterPtr
+    create_search_filter(const FilterPtr& user_filter, bool use_extra_info_filter = false) const;
+
+    // Pack search results from a distance heap into a Dataset
+    DatasetPtr
+    pack_knn_result(DistHeapPtr& heap, Allocator* allocator = nullptr) const;
+
+    // Pack search results from a distance heap with extra info
+    DatasetPtr
+    pack_knn_result_with_extra_info(DistHeapPtr& heap, Allocator* allocator = nullptr) const;
+
+    // Create an empty search result with optional statistics
+    static DatasetPtr
+    make_empty_result(const std::string& stats_json = "");
+
+    // Write index footer with basic_info metadata
+    static void
+    write_index_footer(StreamWriter& writer, const JsonType& basic_info);
+
+    // Read index footer and return basic_info metadata; returns false if old format
+    static bool
+    read_index_footer(StreamReader& reader, JsonType& basic_info);
+
+    // Validate search query: checks dim and num_elements
+    void
+    validate_search_query(const DatasetPtr& query) const;
+
+    // Validate KNN search arguments: query, k
+    void
+    validate_knn_args(const DatasetPtr& query, int64_t k) const;
+
+    // Validate range search arguments: query, radius, limited_size
+    void
+    validate_range_args(const DatasetPtr& query, float radius, int64_t limited_size) const;
 
 public:
     LabelTablePtr label_table_{nullptr};

--- a/src/algorithm/ivf/ivf.cpp
+++ b/src/algorithm/ivf/ivf.cpp
@@ -479,15 +479,9 @@ IVF::KnnSearch(const DatasetPtr& query,
         dataset_results->Statistics(stats.Dump());
         return std::move(dataset_results);
     }
-    auto count = static_cast<const int64_t>(search_result->Size());
-    auto [dataset_results, dists, labels] = create_fast_dataset(count, allocator_);
-    for (int64_t j = count - 1; j >= 0; --j) {
-        dists[j] = search_result->Top().first;
-        labels[j] = label_table_->GetLabelById(search_result->Top().second);
-        search_result->Pop();
-    }
+    auto dataset_results = this->pack_knn_result(search_result);
     dataset_results->Statistics(stats.Dump());
-    return std::move(dataset_results);
+    return dataset_results;
 }
 
 DatasetPtr
@@ -515,16 +509,9 @@ IVF::RangeSearch(const DatasetPtr& query,
         int64_t k = (limited_size > 0) ? limited_size : static_cast<int64_t>(search_result->Size());
         return reorder(k, search_result, query->GetFloat32Vectors(), param, ctx);
     }
-    auto count = static_cast<const int64_t>(search_result->Size());
-    auto [dataset_results, dists, labels] = create_fast_dataset(count, allocator_);
-    for (int64_t j = count - 1; j >= 0; --j) {
-        dists[j] = search_result->Top().first;
-        labels[j] = label_table_->GetLabelById(search_result->Top().second);
-        search_result->Pop();
-    }
-
+    auto dataset_results = this->pack_knn_result(search_result);
     dataset_results->Statistics(stats.Dump());
-    return std::move(dataset_results);
+    return dataset_results;
 }
 
 int64_t
@@ -704,17 +691,7 @@ IVF::Deserialize(StreamReader& reader) {
 InnerSearchParam
 IVF::create_search_param(const std::string& parameters, const FilterPtr& filter) const {
     InnerSearchParam param;
-    auto combined_filter = std::make_shared<CombinedFilter>();
-    combined_filter->AppendFilter(this->label_table_->GetDeletedIdsFilter());
-    if (filter != nullptr) {
-        combined_filter->AppendFilter(
-            std::make_shared<InnerIdWrapperFilter>(filter, *this->label_table_));
-    }
-    FilterPtr ft = nullptr;
-    if (not combined_filter->IsEmpty()) {
-        ft = combined_filter;
-    }
-    param.is_inner_id_allowed = ft;
+    param.is_inner_id_allowed = this->create_search_filter(filter);
     auto search_param = IVFSearchParameters::FromJson(parameters);
     param.scan_bucket_size = std::min(static_cast<BucketIdType>(search_param.scan_buckets_count),
                                       bucket_->bucket_count_);
@@ -735,15 +712,8 @@ IVF::reorder(int64_t topk,
              const float* query,
              const InnerSearchParam& param,
              QueryContext& ctx) const {
-    auto [dataset_results, dists, labels] = create_fast_dataset(topk, allocator_);
     auto reorder_heap = reorder_->Reorder(input, query, topk, ctx);
-    auto size = static_cast<int64_t>(reorder_heap->Size());
-    for (int64_t j = size - 1; j >= 0; --j) {
-        dists[j] = reorder_heap->Top().first;
-        labels[j] = label_table_->GetLabelById(reorder_heap->Top().second);
-        reorder_heap->Pop();
-    }
-    return std::move(dataset_results);
+    return this->pack_knn_result(reorder_heap);
 }
 
 InnerIndexPtr
@@ -988,16 +958,9 @@ IVF::SearchWithRequest(const SearchRequest& request) const {
     if (use_reorder_ and param.enable_reorder) {
         return reorder(request.topk_, search_result, query->GetFloat32Vectors(), param, ctx);
     }
-    auto count = static_cast<const int64_t>(search_result->Size());
-    auto [dataset_results, dists, labels] = create_fast_dataset(count, allocator_);
-    for (int64_t j = count - 1; j >= 0; --j) {
-        dists[j] = search_result->Top().first;
-        labels[j] = label_table_->GetLabelById(search_result->Top().second);
-        search_result->Pop();
-    }
-
+    auto dataset_results = this->pack_knn_result(search_result);
     dataset_results->Statistics(stats.Dump());
-    return std::move(dataset_results);
+    return dataset_results;
 }
 
 void

--- a/src/algorithm/pyramid/pyramid.cpp
+++ b/src/algorithm/pyramid/pyramid.cpp
@@ -261,10 +261,7 @@ Pyramid::KnnSearch(const DatasetPtr& query,
         search_param.time_cost->SetThreshold(parsed_param.timeout_ms);
     }
 
-    if (filter != nullptr) {
-        search_param.is_inner_id_allowed =
-            std::make_shared<InnerIdWrapperFilter>(filter, *label_table_);
-    }
+    search_param.is_inner_id_allowed = this->create_search_filter(filter);
     SearchFunc search_func = [&](const IndexNode* node, const VisitedListPtr& vl) {
         return this->search_node(
             node, vl, search_param, query, base_codes_, ctx, parsed_param.subindex_ef_search);
@@ -303,10 +300,7 @@ Pyramid::RangeSearch(const DatasetPtr& query,
         search_param.consider_duplicate = true;
     }
 
-    if (filter != nullptr) {
-        search_param.is_inner_id_allowed =
-            std::make_shared<InnerIdWrapperFilter>(filter, *label_table_);
-    }
+    search_param.is_inner_id_allowed = this->create_search_filter(filter);
     SearchFunc search_func = [&](const IndexNode* node, const VisitedListPtr& vl) {
         return this->search_node(
             node, vl, search_param, query, base_codes_, ctx, parsed_param.subindex_ef_search);
@@ -432,18 +426,16 @@ Pyramid::Serialize(StreamWriter& writer) const {
     JsonType basic_info;
     basic_info["max_capacity"].SetInt(max_capacity_);
     basic_info[INDEX_PARAM].SetString(this->create_param_ptr_->ToString());
-    auto metadata = std::make_shared<Metadata>();
-    metadata->Set(BASIC_INFO, basic_info);
-    auto footer = std::make_shared<Footer>(metadata);
-    footer->Write(writer);
+    write_index_footer(writer, basic_info);
 }
 
 void
 Pyramid::Deserialize(StreamReader& reader) {
     // try to deserialize footer (only in new version)
-    auto footer = Footer::Parse(reader);
-    auto metadata = footer->GetMetadata();
-    auto basic_info = metadata->Get(BASIC_INFO);
+    JsonType basic_info;
+    if (not read_index_footer(reader, basic_info)) {
+        throw VsagException(ErrorType::READ_ERROR, "failed to read index footer");
+    }
     auto max_capacity = basic_info["max_capacity"].GetInt();
 
     BufferStreamReader buffer_reader(

--- a/src/algorithm/sindi/sindi.cpp
+++ b/src/algorithm/sindi/sindi.cpp
@@ -272,11 +272,7 @@ SINDI::KnnSearch(const DatasetPtr& query,
     inner_param.ef = std::max(static_cast<int64_t>(search_param.n_candidate), k);
     inner_param.topk = k;
 
-    FilterPtr ft = nullptr;
-    if (filter != nullptr) {
-        ft = std::make_shared<InnerIdWrapperFilter>(filter, *this->label_table_);
-    }
-    inner_param.is_inner_id_allowed = ft;
+    inner_param.is_inner_id_allowed = this->create_search_filter(filter);
 
     SparseVector effective_query = sparse_query;
     Vector<uint32_t> tmp_ids(allocator_);
@@ -284,8 +280,7 @@ SINDI::KnnSearch(const DatasetPtr& query,
     if (remap_term_ids_) {
         effective_query = remap_sparse_vector_for_query(sparse_query, tmp_ids, tmp_vals);
         if (effective_query.len_ == 0) {
-            auto [results, ret_dists, ret_ids] = create_fast_dataset(0, allocator);
-            return results;
+            return make_empty_result();
         }
     }
 
@@ -433,11 +428,7 @@ SINDI::RangeSearch(const DatasetPtr& query,
     inner_param.range_search_limit_size = static_cast<int>(limited_size);
     inner_param.radius = radius;
 
-    FilterPtr ft = nullptr;
-    if (filter != nullptr) {
-        ft = std::make_shared<InnerIdWrapperFilter>(filter, *this->label_table_);
-    }
-    inner_param.is_inner_id_allowed = ft;
+    inner_param.is_inner_id_allowed = this->create_search_filter(filter);
 
     SparseVector effective_query = sparse_query;
     Vector<uint32_t> tmp_ids(allocator_);
@@ -445,8 +436,7 @@ SINDI::RangeSearch(const DatasetPtr& query,
     if (remap_term_ids_) {
         effective_query = remap_sparse_vector_for_query(sparse_query, tmp_ids, tmp_vals);
         if (effective_query.len_ == 0) {
-            auto [results, ret_dists, ret_ids] = create_fast_dataset(0, allocator_);
-            return results;
+            return make_empty_result();
         }
     }
 
@@ -501,11 +491,8 @@ SINDI::Serialize(StreamWriter& writer) const {
     }
 
     JsonType jsonify_basic_info;
-    auto metadata = std::make_shared<Metadata>();
     jsonify_basic_info[INDEX_PARAM].SetString(this->create_param_ptr_->ToString());
-    metadata->Set("basic_info", jsonify_basic_info);
-    auto footer = std::make_shared<Footer>(metadata);
-    footer->Write(writer);
+    write_index_footer(writer, jsonify_basic_info);
 }
 
 void
@@ -513,9 +500,10 @@ SINDI::Deserialize(StreamReader& reader) {
     std::scoped_lock wlock(this->global_mutex_);
 
     if (not deserialize_without_footer_) {
-        auto footer = Footer::Parse(reader);
-        auto metadata = footer->GetMetadata();
-        JsonType jsonify_basic_info = metadata->Get("basic_info");
+        JsonType jsonify_basic_info;
+        if (not read_index_footer(reader, jsonify_basic_info)) {
+            throw VsagException(ErrorType::READ_ERROR, "failed to read index footer");
+        }
         // Check if the index parameter is compatible
         {
             auto param = jsonify_basic_info[INDEX_PARAM].GetString();

--- a/src/algorithm/warp/warp.cpp
+++ b/src/algorithm/warp/warp.cpp
@@ -269,16 +269,7 @@ WARP::SearchWithRequest(const SearchRequest& request) const {
     const float* query_vectors = query_multi_vectors[0].vectors_;
     uint32_t query_vec_count = query_multi_vectors[0].len_;
 
-    FilterPtr ft = nullptr;
-    auto combined_filter = std::make_shared<CombinedFilter>();
-    combined_filter->AppendFilter(this->label_table_->GetDeletedIdsFilter());
-    if (request.filter_ != nullptr) {
-        combined_filter->AppendFilter(
-            std::make_shared<InnerIdWrapperFilter>(request.filter_, *this->label_table_));
-    }
-    if (not combined_filter->IsEmpty()) {
-        ft = combined_filter;
-    }
+    FilterPtr ft = this->create_search_filter(request.filter_);
 
     // Parse search parameters
     auto warp_params = WarpSearchParameters::FromJson(request.params_str_);
@@ -351,20 +342,13 @@ WARP::SearchWithRequest(const SearchRequest& request) const {
         heap = heaps.empty() ? nullptr : heaps[0];
     }
 
-    auto [dataset_results, dists, ids] =
-        create_fast_dataset(static_cast<int64_t>(heap->Size()), allocator_);
-    for (auto j = static_cast<int64_t>(heap->Size() - 1); j >= 0; --j) {
-        float dist = heap->Top().first;
-        dists[j] = dist;
-        ids[j] = this->label_table_->GetLabelById(heap->Top().second);
-        heap->Pop();
-    }
+    auto dataset_results = this->pack_knn_result(heap);
 
     JsonType stats;
     stats["dist_cmp"].SetInt(dist_cmp.load(std::memory_order_relaxed));
     dataset_results->Statistics(stats.Dump());
 
-    return std::move(dataset_results);
+    return dataset_results;
 }
 
 DatasetPtr
@@ -393,7 +377,8 @@ WARP::RangeSearch(const vsag::DatasetPtr& query,
     // Use serial version if no thread pool or small dataset
     if (parallel_count == 1 || this->thread_pool_ == nullptr ||
         total_count_ < MIN_PARALLEL_SEARCH_DOC_COUNT) {
-        auto heap = std::make_shared<StandardHeap<true, true>>(this->allocator_, limited_size);
+        DistHeapPtr heap =
+            std::make_shared<StandardHeap<true, true>>(this->allocator_, limited_size);
 
         for (InnerIdType doc_id = 0; doc_id < total_count_; ++doc_id) {
             if (filter != nullptr and
@@ -414,15 +399,7 @@ WARP::RangeSearch(const vsag::DatasetPtr& query,
             heap->Push(heap_dist, doc_id);
         }
 
-        auto [dataset_results, dists, ids] =
-            create_fast_dataset(static_cast<int64_t>(heap->Size()), allocator_);
-        for (auto j = static_cast<int64_t>(heap->Size() - 1); j >= 0; --j) {
-            float dist = heap->Top().first;
-            dists[j] = dist;
-            ids[j] = this->label_table_->GetLabelById(heap->Top().second);
-            heap->Pop();
-        }
-        return std::move(dataset_results);
+        return this->pack_knn_result(heap);
     }
 
     // Parallel version using atomic index distribution
@@ -507,27 +484,24 @@ WARP::Serialize(StreamWriter& writer) const {
     this->label_table_->Serialize(writer);
 
     // Serialize footer
-    auto metadata = std::make_shared<Metadata>();
     JsonType basic_info;
     basic_info["dim"].SetInt(dim_);
     basic_info["total_count"].SetInt(total_count_);
     basic_info["total_vector_count"].SetInt(total_vector_count_);
     basic_info[INDEX_PARAM].SetString(this->create_param_ptr_->ToString());
-    metadata->Set("basic_info", basic_info);
-    auto footer = std::make_shared<Footer>(metadata);
-    footer->Write(writer);
+    write_index_footer(writer, basic_info);
 }
 
 void
 WARP::Deserialize(StreamReader& reader) {
     // Try to deserialize footer
-    auto footer = Footer::Parse(reader);
+    JsonType basic_info;
+    if (not read_index_footer(reader, basic_info)) {
+        throw VsagException(ErrorType::READ_ERROR, "failed to read index footer");
+    }
 
     BufferStreamReader buffer_reader(
         &reader, std::numeric_limits<uint64_t>::max(), this->allocator_);
-
-    auto metadata = footer->GetMetadata();
-    auto basic_info = metadata->Get("basic_info");
     if (basic_info.Contains(INDEX_PARAM)) {
         std::string index_param_string = basic_info[INDEX_PARAM].GetString();
         auto index_param = std::make_shared<WarpParameter>();


### PR DESCRIPTION
## What problem does this PR solve?

Resolves #2138

Extracts repetitive search validation, filter composition, result packing, and serialization footer logic from individual index implementations into protected helper methods in `InnerIndexInterface`.

## What is changed and how does it work?

### New protected helper methods in `InnerIndexInterface`:

| Method | Purpose |
|--------|---------|
| `validate_search_query()` | Checks query dimension and num_elements |
| `validate_knn_args()` | Validates KNN search parameters (query + k) |
| `validate_range_args()` | Validates range search parameters (query + radius + limited_size) |
| `create_search_filter()` | Composes DeletedIdsFilter with user filter (InnerIdWrapperFilter or ExtraInfoWrapperFilter) |
| `pack_knn_result()` | Converts DistHeap to Dataset with label resolution |
| `pack_knn_result_with_extra_info()` | Same as above, with extra info support |
| `make_empty_result()` | Creates an empty Dataset result |
| `write_index_footer()` | Writes Footer with basic_info metadata |
| `read_index_footer()` | Reads Footer and returns basic_info metadata |

### Applied to 6 index implementations:

- **BruteForce**: SearchWithRequest, RangeSearch, Serialize, Deserialize
- **HGraph**: KnnSearch, RangeSearch, SearchWithRequest
- **IVF**: KnnSearch, RangeSearch, SearchWithRequest, reorder, create_search_param
- **Pyramid**: KnnSearch, RangeSearch, Serialize, Deserialize
- **SINDI**: KnnSearch, RangeSearch, Serialize, Deserialize
- **WARP**: SearchWithRequest, RangeSearch, Serialize, Deserialize

### Impact:

- **+218 / -254 lines** net reduction of 36 lines, but more importantly eliminates 6x code duplication
- No behavioral change: same error messages, same error codes, same result format
- All existing tests pass without modification

## Related issues

Closes #2138