### PR TITLE
feat: use tl::unexpected in Index default implementations

### DIFF
--- a/include/vsag/index.h
+++ b/include/vsag/index.h
@@ -1,4 +1,3 @@
-
 // Copyright 2024-present the vsag project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -90,7 +89,7 @@ public:
      */
     [[nodiscard]] virtual IndexType
     GetIndexType() const {
-        throw std::runtime_error("Index not support GetIndexType");
+        throw std::runtime_error("Index does not support GetIndexType");
     }
 
 public:
@@ -116,7 +115,8 @@ public:
      */
     virtual tl::expected<bool, Error>
     Tune(const std::string& parameters, bool disable_future_tuning = false) {
-        throw std::runtime_error("Tune is not supported by this index");
+        return tl::unexpected(
+            Error(ErrorType::UNSUPPORTED_INDEX_OPERATION, "Index does not support Tune"));
     }
 
     /**
@@ -127,7 +127,8 @@ public:
       */
     virtual tl::expected<void, Error>
     Train(const DatasetPtr& data) {
-        throw std::runtime_error("Index not support Train");
+        return tl::unexpected(
+            Error(ErrorType::UNSUPPORTED_INDEX_OPERATION, "Index does not support Train"));
     }
 
     struct Checkpoint {
@@ -144,7 +145,8 @@ public:
       */
     virtual tl::expected<Checkpoint, Error>
     ContinueBuild(const DatasetPtr& base, const BinarySet& binary_set) {
-        throw std::runtime_error("Index not support partial build");
+        return tl::unexpected(
+            Error(ErrorType::UNSUPPORTED_INDEX_OPERATION, "Index does not support partial build"));
     }
 
     /**
@@ -155,7 +157,8 @@ public:
       */
     [[nodiscard]] virtual tl::expected<std::vector<int64_t>, Error>
     Add(const DatasetPtr& base, AddMode mode = AddMode::DEFAULT) {
-        throw std::runtime_error("Index not support adding vectors");
+        return tl::unexpected(
+            Error(ErrorType::UNSUPPORTED_INDEX_OPERATION, "Index does not support adding vectors"));
     }
 
     /**
@@ -166,7 +169,8 @@ public:
      */
     virtual tl::expected<uint32_t, Error>
     Remove(const std::vector<int64_t>& ids, RemoveMode mode = RemoveMode::MARK_REMOVE) {
-        throw std::runtime_error("Index not support Remove");
+        return tl::unexpected(
+            Error(ErrorType::UNSUPPORTED_INDEX_OPERATION, "Index does not support Remove"));
     }
 
     /**
@@ -189,7 +193,8 @@ public:
      */
     virtual tl::expected<bool, Error>
     UpdateId(int64_t old_id, int64_t new_id) {
-        throw std::runtime_error("Index not support update id");
+        return tl::unexpected(
+            Error(ErrorType::UNSUPPORTED_INDEX_OPERATION, "Index does not support update id"));
     }
 
     /**
@@ -202,12 +207,14 @@ public:
      */
     virtual tl::expected<bool, Error>
     UpdateVector(int64_t id, const DatasetPtr& new_base, bool force_update = false) {
-        throw std::runtime_error("Index not support update vector");
+        return tl::unexpected(
+            Error(ErrorType::UNSUPPORTED_INDEX_OPERATION, "Index does not support update vector"));
     }
 
     virtual tl::expected<bool, Error>
     UpdateExtraInfo(const DatasetPtr& new_base) {
-        throw std::runtime_error("Index not support update extra info");
+        return tl::unexpected(Error(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                                    "Index does not support update extra info"));
     }
 
     /**
@@ -220,7 +227,8 @@ public:
      */
     virtual tl::expected<void, Error>
     UpdateAttribute(int64_t id, const AttributeSet& new_attrs) {
-        throw std::runtime_error("Index not support update attribute");
+        return tl::unexpected(Error(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                                    "Index does not support update attribute"));
     }
 
     /**
@@ -233,7 +241,9 @@ public:
      */
     virtual tl::expected<void, Error>
     UpdateAttribute(int64_t id, const AttributeSet& new_attrs, const AttributeSet& origin_attrs) {
-        throw std::runtime_error("Index not support update attribute with origin attributes");
+        return tl::unexpected(
+            Error(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                  "Index does not support update attribute with origin attributes"));
     }
 
 public:
@@ -286,7 +296,8 @@ public:
               int64_t k,
               const std::string& parameters,
               const FilterPtr& filter) const {
-        throw std::runtime_error("Index doesn't support new filter");
+        return tl::unexpected(Error(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                                    "Index does not support KnnSearch with FilterPtr"));
     }
 
     /**
@@ -299,7 +310,8 @@ public:
       */
     [[nodiscard]] virtual tl::expected<DatasetPtr, Error>
     SearchWithRequest(const SearchRequest& request) const {
-        throw std::runtime_error("Index doesn't support Search With Request");
+        return tl::unexpected(Error(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                                    "Index does not support Search With Request"));
     }
 
     /**
@@ -321,7 +333,8 @@ public:
               const FilterPtr& filter,
               IteratorContext*& iter_ctx,
               bool is_last_search) const {
-        throw std::runtime_error("Index doesn't support new filter");
+        return tl::unexpected(Error(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                                    "Index does not support KnnSearch with IteratorContext"));
     }
 
     /**
@@ -338,7 +351,8 @@ public:
       */
     [[nodiscard]] virtual tl::expected<DatasetPtr, Error>
     KnnSearch(const DatasetPtr& query, int64_t k, SearchParam& search_param) const {
-        throw std::runtime_error("Index doesn't support new filter");
+        return tl::unexpected(Error(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                                    "Index does not support KnnSearch with SearchParam"));
     }
 
     /**
@@ -426,7 +440,8 @@ public:
                 const std::string& parameters,
                 const FilterPtr& filter,
                 int64_t limited_size = -1) const {
-        throw std::runtime_error("Index doesn't support new filter");
+        return tl::unexpected(Error(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                                    "Index does not support RangeSearch with FilterPtr"));
     }
 
     /**
@@ -438,8 +453,9 @@ public:
      */
     virtual tl::expected<uint32_t, Error>
     Pretrain(const std::vector<int64_t>& base_tag_ids, uint32_t k, const std::string& parameters) {
-        throw std::runtime_error("Index doesn't support pretrain");
-    };
+        return tl::unexpected(
+            Error(ErrorType::UNSUPPORTED_INDEX_OPERATION, "Index does not support pretrain"));
+    }
 
     /**
      * @brief Performing feedback on conjugate graph
@@ -454,8 +470,9 @@ public:
              int64_t k,
              const std::string& parameters,
              int64_t global_optimum_tag_id = std::numeric_limits<int64_t>::max()) {
-        throw std::runtime_error("Index doesn't support feedback");
-    };
+        return tl::unexpected(
+            Error(ErrorType::UNSUPPORTED_INDEX_OPERATION, "Index does not support feedback"));
+    }
 
     /**
      * @brief Calculate the distance between the query and the vector of the given ID.
@@ -477,8 +494,9 @@ public:
     CalcDistanceById(const float* vector,
                      int64_t id,
                      bool calculate_precise_distance = true) const {
-        throw std::runtime_error("Index doesn't support get distance by id");
-    };
+        return tl::unexpected(Error(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                                    "Index does not support get distance by id"));
+    }
 
     /**
      * @brief Calculate the distance between the query and the vector of the given ID.
@@ -501,8 +519,9 @@ public:
     CalcDistanceById(const DatasetPtr& vector,
                      int64_t id,
                      bool calculate_precise_distance = true) const {
-        throw std::runtime_error("Index doesn't support get distance by id");
-    };
+        return tl::unexpected(Error(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                                    "Index does not support get distance by id"));
+    }
 
     /**
      * @brief Calculate the distance between the query and the vector of the given ID for batch.
@@ -526,8 +545,9 @@ public:
                     const int64_t* ids,
                     int64_t count,
                     bool calculate_precise_distance = true) const {
-        throw std::runtime_error("Index doesn't support get distance by id");
-    };
+        return tl::unexpected(Error(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                                    "Index does not support get distance by id"));
+    }
 
     /**
      * @brief Calculate the distance between the query and the vector of the given ID for batch.
@@ -552,8 +572,9 @@ public:
                     const int64_t* ids,
                     int64_t count,
                     bool calculate_precise_distance = true) const {
-        throw std::runtime_error("Index doesn't support get distance by id");
-    };
+        return tl::unexpected(Error(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                                    "Index does not support get distance by id"));
+    }
 
     /**
      * @brief Calculate the maximum and minimum labels.
@@ -563,7 +584,8 @@ public:
      */
     [[nodiscard]] virtual tl::expected<std::pair<int64_t, int64_t>, Error>
     GetMinAndMaxId() const {
-        throw std::runtime_error("Index doesn't support get Min and Max id");
+        return tl::unexpected(Error(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                                    "Index does not support get Min and Max id"));
     }
 
     /**
@@ -578,13 +600,14 @@ public:
      * @param extra_infos A char* pointer to the retrieved extra data if successful
      * (format is implementation-specific). Returns an error object
      * if any retrieval failure occurs (e.g., invalid ID, out of memory).
-     * @throws std::runtime_error If the index implementation does not support this operation
+     * @note The default base-class implementation returns tl::unexpected(ErrorType::UNSUPPORTED_INDEX_OPERATION) If the index implementation does not support this operation
      * (default behavior for base class).
      */
     virtual tl::expected<void, Error>
     GetExtraInfoByIds(const int64_t* ids, int64_t count, char* extra_infos) const {
-        throw std::runtime_error("Index doesn't support GetExtraInfoByIds");
-    };
+        return tl::unexpected(Error(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                                    "Index does not support GetExtraInfoByIds"));
+    }
 
     /**
      * @brief Retrieve raw vector data associated with given IDs.
@@ -602,7 +625,7 @@ public:
      *         - On success: A DatasetPtr containing the raw vector data
      *           (format depends on implementation, but typically includes vector arrays).
      *         - On failure: An error object (e.g., invalid ID, out of memory).
-     * @throws std::runtime_error If the index implementation does not support this operation
+     * @note The default base-class implementation returns tl::unexpected(ErrorType::UNSUPPORTED_INDEX_OPERATION) If the index implementation does not support this operation
      *            (default behavior for base class).
      *
      * @note The returned vectors are guaranteed to have a distance **close to 0** (e.g., Euclidean
@@ -619,8 +642,9 @@ public:
     GetRawVectorByIds(const int64_t* ids,
                       int64_t count,
                       Allocator* specified_allocator = nullptr) const {
-        throw std::runtime_error("Index doesn't support GetRawVectorByIds");
-    };
+        return tl::unexpected(Error(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                                    "Index does not support GetRawVectorByIds"));
+    }
 
     /**
      * @brief Retrieve all data associated with vectors identified by given IDs.
@@ -634,13 +658,14 @@ public:
      * @return tl::expected<DatasetPtr, Error>
      *         - On success: A DatasetPtr containing the extra data, attribute and vector
      *         - On failure: An error object (e.g., invalid ID, out of memory).
-     * @throws std::runtime_error If the index implementation does not support this operation
+     * @note The default base-class implementation returns tl::unexpected(ErrorType::UNSUPPORTED_INDEX_OPERATION) If the index implementation does not support this operation
      *            (default behavior for base class).
      */
     [[nodiscard]] virtual tl::expected<DatasetPtr, Error>
     GetDataByIdsWithFlag(const int64_t* ids, int64_t count, uint64_t selected_data_flag) const {
-        throw std::runtime_error("Index doesn't support GetDataByIdsWithFlag");
-    };
+        return tl::unexpected(Error(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                                    "Index does not support GetDataByIdsWithFlag"));
+    }
 
     /*
      * @brief Retrieve all detail information associated with the index.
@@ -651,13 +676,14 @@ public:
      * @return tl::expected<std::vector<IndexDetailInfo>, Error>
      *         - On success: A vector of IndexDetailInfo structs containing the detail information.
      *         - On failure: An error object (e.g., out of memory).
-     * @throws std::runtime_error If the index implementation does not support this operation
+     * @note The default base-class implementation returns tl::unexpected(ErrorType::UNSUPPORTED_INDEX_OPERATION) If the index implementation does not support this operation
      *            (default behavior for base class).
      */
     [[nodiscard]] virtual tl::expected<std::vector<IndexDetailInfo>, Error>
     GetIndexDetailInfos() const {
-        throw std::runtime_error("Index doesn't support GetIndexDetailInfos");
-    };
+        return tl::unexpected(Error(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                                    "Index does not support GetIndexDetailInfos"));
+    }
 
     /*
      * @brief Retrieve one detail data associated with the index.
@@ -667,13 +693,14 @@ public:
      * @return tl::expected<DetailDataPtr, Error>
      *         - On success: A DetailDataPtr containing the detail data.
      *         - On failure: An error object (e.g., no such detail information name).
-     * @throws std::runtime_error If the index implementation does not support this operation
+     * @note The default base-class implementation returns tl::unexpected(ErrorType::UNSUPPORTED_INDEX_OPERATION) If the index implementation does not support this operation
      *            (default behavior for base class).
      */
     virtual tl::expected<DetailDataPtr, Error>
     GetDetailDataByName(const std::string& name, IndexDetailInfo& info) const {
-        throw std::runtime_error("Index doesn't support GetDetailDataByName");
-    };
+        return tl::unexpected(Error(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                                    "Index does not support GetDetailDataByName"));
+    }
 
     /**
      * @brief Retrieve all data associated with vectors identified by given IDs.
@@ -686,14 +713,15 @@ public:
      * @return tl::expected<DatasetPtr, Error>
      *         - On success: A DatasetPtr containing the extra data, attribute and vector
      *         - On failure: An error object (e.g., invalid ID, out of memory).
-     * @throws std::runtime_error If the index implementation does not support this operation
+     * @note The default base-class implementation returns tl::unexpected(ErrorType::UNSUPPORTED_INDEX_OPERATION) If the index implementation does not support this operation
      *            (default behavior for base class).
      * @note The default implementation returns all data which in current index
      */
     [[nodiscard]] virtual tl::expected<DatasetPtr, Error>
     GetDataByIds(const int64_t* ids, int64_t count) const {
-        throw std::runtime_error("Index doesn't support GetDataByIds");
-    };
+        return tl::unexpected(
+            Error(ErrorType::UNSUPPORTED_INDEX_OPERATION, "Index does not support GetDataByIds"));
+    }
 
     /**
      * @brief Checks if the specified feature is supported by the index.
@@ -706,7 +734,7 @@ public:
      */
     [[nodiscard]] virtual bool
     CheckFeature(IndexFeature feature) const {
-        throw std::runtime_error("Index doesn't support check feature");
+        return false;
     }
 
     /**
@@ -724,7 +752,8 @@ public:
      */
     virtual tl::expected<void, Error>
     Merge(const std::vector<MergeUnit>& merge_units) {
-        throw std::runtime_error("Index doesn't support merge");
+        return tl::unexpected(
+            Error(ErrorType::UNSUPPORTED_INDEX_OPERATION, "Index does not support merge"));
     }
 
     /**
@@ -736,40 +765,44 @@ public:
      */
     [[nodiscard]] virtual tl::expected<IndexPtr, Error>
     Clone(const std::shared_ptr<Allocator>& allocator = nullptr) const {
-        throw std::runtime_error("Index doesn't support Clone");
+        return tl::unexpected(
+            Error(ErrorType::UNSUPPORTED_INDEX_OPERATION, "Index does not support Clone"));
     }
 
     /**
      * @brief Export the index's model as an empty index.
      * 
      * @return IndexPtr A pointer to the exported model index.
-     * @throws std::runtime_error If the index does not support exporting the model.
+     * @note The default base-class implementation returns tl::unexpected(ErrorType::UNSUPPORTED_INDEX_OPERATION) If the index does not support exporting the model.
      */
     [[nodiscard]] virtual tl::expected<IndexPtr, Error>
     ExportModel() const {
-        throw std::runtime_error("Index doesn't support ExportModel");
+        return tl::unexpected(
+            Error(ErrorType::UNSUPPORTED_INDEX_OPERATION, "Index does not support ExportModel"));
     }
 
     /**
      * @brief Export the index's IDs as a dataset.
      * 
      * @return DatasetPtr A pointer to the exported IDs dataset.
-     * @throws std::runtime_error If the index does not support exporting the IDs.
+     * @note The default base-class implementation returns tl::unexpected(ErrorType::UNSUPPORTED_INDEX_OPERATION) If the index does not support exporting the IDs.
      */
     [[nodiscard]] virtual tl::expected<DatasetPtr, Error>
     ExportIDs() const {
-        throw std::runtime_error("Index doesn't support ExportIDs");
+        return tl::unexpected(
+            Error(ErrorType::UNSUPPORTED_INDEX_OPERATION, "Index does not support ExportIDs"));
     }
 
     /**
      * @brief set the index to immutable state.
      * After setting this state, no further modifications are supported, such as no additions or deletions 
      *
-     * @throws std::runtime_error If the index does not support to set immutable
+     * @note The default base-class implementation returns tl::unexpected(ErrorType::UNSUPPORTED_INDEX_OPERATION) If the index does not support to set immutable
      */
     virtual tl::expected<void, Error>
     SetImmutable() {
-        throw std::runtime_error("Index doesn't support SetImmutable");
+        return tl::unexpected(
+            Error(ErrorType::UNSUPPORTED_INDEX_OPERATION, "Index does not support SetImmutable"));
     }
 
 public:
@@ -790,7 +823,8 @@ public:
       */
     [[nodiscard]] virtual tl::expected<void, Error>
     Serialize(WriteFuncType write_func) const {
-        throw std::runtime_error("Index doesn't support Serialize with write function");
+        return tl::unexpected(Error(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                                    "Index does not support Serialize with write function"));
     }
 
     /**
@@ -819,7 +853,8 @@ public:
       */
     virtual tl::expected<void, Error>
     Serialize(std::ostream& out_stream) {
-        throw std::runtime_error("Index not support serialize to a file stream");
+        return tl::unexpected(Error(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                                    "Index does not support serialize to a file stream"));
     }
 
     /**
@@ -831,7 +866,8 @@ public:
       */
     virtual tl::expected<void, Error>
     Deserialize(std::istream& in_stream) {
-        throw std::runtime_error("Index not support deserialize from a file stream");
+        return tl::unexpected(Error(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                                    "Index does not support deserialize from a file stream"));
     }
 
 public:
@@ -852,7 +888,7 @@ public:
       */
     [[nodiscard]] virtual int64_t
     GetNumberRemoved() const {
-        throw std::runtime_error("Index not support GetNumberRemoved");
+        throw std::runtime_error("Index does not support GetNumberRemoved");
     }
 
     /**
@@ -873,7 +909,7 @@ public:
     // GetMemoryUsageDetail() const = 0;
     [[nodiscard]] virtual std::string
     GetMemoryUsageDetail() const {
-        throw std::runtime_error("Index not support GetMemoryUsageDetail");
+        throw std::runtime_error("Index does not support GetMemoryUsageDetail");
     }
 
     /**
@@ -884,7 +920,7 @@ public:
       */
     [[nodiscard]] virtual uint64_t
     EstimateMemory(uint64_t num_elements) const {
-        throw std::runtime_error("Index not support estimate the memory by element counts");
+        throw std::runtime_error("Index does not support estimate the memory by element counts");
     }
 
     /**
@@ -895,7 +931,7 @@ public:
       */
     [[nodiscard]] virtual int64_t
     GetEstimateBuildMemory(const int64_t num_elements) const {
-        throw std::runtime_error("Index not support estimate the memory while building");
+        throw std::runtime_error("Index does not support estimate the memory while building");
     }
 
     /**
@@ -905,7 +941,7 @@ public:
       */
     [[nodiscard]] virtual std::string
     GetStats() const {
-        throw std::runtime_error("Index not support GetStats");
+        throw std::runtime_error("Index does not support GetStats");
     }
 
     /**
@@ -917,7 +953,7 @@ public:
       */
     virtual std::string
     AnalyzeIndexBySearch(const SearchRequest& request) {
-        throw std::runtime_error("Index not support analyze index by search");
+        throw std::runtime_error("Index does not support analyze index by search");
     }
 
     /**
@@ -929,7 +965,7 @@ public:
       */
     [[nodiscard]] virtual bool
     CheckIdExist(int64_t id) const {
-        throw std::runtime_error("Index not support check id exist");
+        throw std::runtime_error("Index does not support check id exist");
     }
 
     /**
@@ -943,7 +979,8 @@ public:
      */
     virtual tl::expected<void, Error>
     ExportCache(std::ostream& out_stream) const {
-        throw std::runtime_error("Index doesn't support ExportCache");
+        return tl::unexpected(
+            Error(ErrorType::UNSUPPORTED_INDEX_OPERATION, "Index does not support ExportCache"));
     }
 
     /**
@@ -956,7 +993,8 @@ public:
      */
     virtual tl::expected<void, Error>
     ImportCache(std::istream& in_stream) {
-        throw std::runtime_error("Index doesn't support ImportCache");
+        return tl::unexpected(
+            Error(ErrorType::UNSUPPORTED_INDEX_OPERATION, "Index does not support ImportCache"));
     }
 
 public:

--- a/tests/test_hnsw.cpp
+++ b/tests/test_hnsw.cpp
@@ -90,7 +90,7 @@ HNSWTestIndex::TestGeneral(const TestIndex::IndexPtr& index,
     TestRangeSearch(index, dataset, search_param, recall / 2.0, 5, true);
     TestFilterSearch(index, dataset, search_param, recall, true, true);
     TestCheckIdExist(index, dataset);
-    TestBatchCalcDistanceById(index, dataset, 1e-5, true, false, true);
+    TestBatchCalcDistanceById(index, dataset, 1e-5, true, false);
     TestSearchAllocator(index, dataset, search_param, recall, true);
     TestUpdateVector(index, dataset, search_param, false);
     TestUpdateId(index, dataset, search_param, true);
@@ -533,7 +533,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex,
         auto index = TestFactory(name, param, true);
         auto dataset = pool.GetDatasetAndCreate(dim, base_count, metric_type);
         TestBuildIndex(index, dataset, true);
-        TestBatchCalcDistanceById(index, dataset, 1e-5, true, false, true);
+        TestBatchCalcDistanceById(index, dataset, 1e-5, true, false);
         vsag::Options::Instance().set_block_size_limit(origin_size);
     }
 }

--- a/tests/test_index.h
+++ b/tests/test_index.h
@@ -119,6 +119,7 @@ public:
     TestRecoverRemoveIndex(const IndexPtr& index,
                            const TestDatasetPtr& dataset,
                            const std::string& search_parameters);
+
     static void
     TestUpdateId(const IndexPtr& index,
                  const TestDatasetPtr& dataset,
@@ -214,8 +215,7 @@ public:
                               const TestDatasetPtr& dataset,
                               float error = 1e-5,
                               bool expected_success = true,
-                              bool is_sparse = false,
-                              bool is_old_index = false);
+                              bool is_sparse = false);
 
     static void
     TestGetMinAndMaxId(const IndexPtr& index,

--- a/tests/test_index/test_index_calc.cpp
+++ b/tests/test_index/test_index_calc.cpp
@@ -56,8 +56,7 @@ TestIndex::TestBatchCalcDistanceById(const IndexPtr& index,
                                      const TestDatasetPtr& dataset,
                                      float error,
                                      bool expected_success,
-                                     bool is_sparse,
-                                     bool is_old_index) {
+                                     bool is_sparse) {
     if (not index->CheckFeature(vsag::SUPPORT_CAL_DISTANCE_BY_ID)) {
         return;
     }
@@ -74,15 +73,8 @@ TestIndex::TestBatchCalcDistanceById(const IndexPtr& index,
         } else {
             result = index->CalDistanceById(
                 query->GetFloat32Vectors(), gts->GetIds() + (i * gt_topK), gt_topK);
-            if (is_old_index) {
-                // for old index (hnsw and diskann)
-                REQUIRE_THROWS(index->CalDistanceById(query, gts->GetIds() + (i * gt_topK), gt_topK)
-                                   .has_value());
-            } else {
-                // for new index (from inner_index_interface)
-                REQUIRE_FALSE(index->CalDistanceById(query, gts->GetIds() + (i * gt_topK), gt_topK)
-                                  .has_value());
-            }
+            REQUIRE_FALSE(
+                index->CalDistanceById(query, gts->GetIds() + (i * gt_topK), gt_topK).has_value());
         }
         if (not expected_success) {
             return;

--- a/tests/test_index_old.cpp
+++ b/tests/test_index_old.cpp
@@ -564,7 +564,7 @@ TEST_CASE("remove vectors from the index", "[ft][remove][hnsw][diskann]") {
         float recall_after = ((float)correct) / num_vectors;
         REQUIRE(std::abs(recall_before - recall_after) < 0.001);
     } else {  // index that does not supports remove
-        REQUIRE_THROWS(index->Remove(-1));
+        REQUIRE_FALSE(index->Remove(-1).has_value());
         REQUIRE_THROWS(index->GetNumberRemoved());
     }
 }
@@ -1272,10 +1272,10 @@ TEST_CASE("using indexes that do not support conjugate graph", "[ft][diskann]") 
     int64_t k = 10;
     std::vector<int64_t> base_tag_ids;
 
-    REQUIRE_THROWS(index->Feedback(query, k, search_parameters, -1));
-    REQUIRE_THROWS(index->Feedback(query, k, search_parameters));
+    REQUIRE_FALSE(index->Feedback(query, k, search_parameters, -1).has_value());
+    REQUIRE_FALSE(index->Feedback(query, k, search_parameters).has_value());
 
-    REQUIRE_THROWS(index->Pretrain(base_tag_ids, k, search_parameters));
+    REQUIRE_FALSE(index->Pretrain(base_tag_ids, k, search_parameters).has_value());
 }
 
 TEST_CASE("hnsw with pretrained by conjugate graph", "[ft][feedback][hnsw]") {

--- a/tests/test_simple_index.cpp
+++ b/tests/test_simple_index.cpp
@@ -110,60 +110,62 @@ TEST_CASE("Test Simple Index", "[ft][simple_index]") {
     std::string search_param = "{}";
     SearchParam param(true, search_param, filter, nullptr);
 
-    REQUIRE_THROWS(index->Add(dataset->base_));
-    REQUIRE_THROWS(index->Remove(0));
-    REQUIRE_THROWS(index->CheckFeature(IndexFeature::SUPPORT_ESTIMATE_MEMORY));
+    REQUIRE_FALSE(index->Add(dataset->base_).has_value());
+    REQUIRE_FALSE(index->Remove(0).has_value());
+    REQUIRE_FALSE(index->CheckFeature(IndexFeature::SUPPORT_ESTIMATE_MEMORY));
     REQUIRE_THROWS(index->EstimateMemory(1000));
     REQUIRE_THROWS(index->GetEstimateBuildMemory(1000));
-    REQUIRE_THROWS(index->Feedback(dataset->query_, 10, ""));
+    REQUIRE_FALSE(index->Feedback(dataset->query_, 10, "").has_value());
     REQUIRE_THROWS_MATCHES(index->GetStats(),
                            std::runtime_error,
-                           Catch::Matchers::Message("Index not support GetStats"));
-    REQUIRE_THROWS(index->UpdateId(0, 1));
-    REQUIRE_THROWS(index->UpdateVector(0, dataset->query_));
-    REQUIRE_THROWS(index->ContinueBuild(dataset->base_, binary));
-    REQUIRE_THROWS(index->Pretrain(pretrain_ids, 10, ""));
+                           Catch::Matchers::Message("Index does not support GetStats"));
+    REQUIRE_FALSE(index->UpdateId(0, 1).has_value());
+    REQUIRE_FALSE(index->UpdateVector(0, dataset->query_).has_value());
+    REQUIRE_FALSE(index->ContinueBuild(dataset->base_, binary).has_value());
+    REQUIRE_FALSE(index->Pretrain(pretrain_ids, 10, "").has_value());
     REQUIRE_THROWS(index->CheckIdExist(0));
-    REQUIRE_THROWS(index->CalcDistanceById(dataset->base_->GetFloat32Vectors(), 1));
-    REQUIRE_THROWS(index->CalcDistanceById(dataset->query_, 1));
-    REQUIRE_THROWS(index->CalDistanceById(dataset->base_->GetFloat32Vectors(), nullptr, 1));
-    REQUIRE_THROWS(index->GetMinAndMaxId());
-    REQUIRE_THROWS(index->GetExtraInfoByIds(nullptr, 1, nullptr));
-    REQUIRE_THROWS(index->UpdateExtraInfo(dataset->query_));
-    REQUIRE_THROWS(index->GetRawVectorByIds(nullptr, 1));
-    REQUIRE_THROWS(index->Clone());
-    REQUIRE_THROWS(index->ExportModel());
-    REQUIRE_THROWS(index->Train(dataset->base_));
-    REQUIRE_THROWS(index->KnnSearch(dataset->query_, 10, search_param, filter, itex, true));
-    REQUIRE_THROWS(index->KnnSearch(dataset->query_, 10, search_param, filter));
-    REQUIRE_THROWS(index->KnnSearch(dataset->query_, 10, param));
-    REQUIRE_THROWS(index->SearchWithRequest(req));
-    REQUIRE_THROWS(index->RangeSearch(dataset->query_, 1.0F, search_param, filter));
+    REQUIRE_FALSE(index->CalcDistanceById(dataset->base_->GetFloat32Vectors(), 1).has_value());
+    REQUIRE_FALSE(index->CalcDistanceById(dataset->query_, 1).has_value());
+    REQUIRE_FALSE(
+        index->CalDistanceById(dataset->base_->GetFloat32Vectors(), nullptr, 1).has_value());
+    REQUIRE_FALSE(index->GetMinAndMaxId().has_value());
+    REQUIRE_FALSE(index->GetExtraInfoByIds(nullptr, 1, nullptr).has_value());
+    REQUIRE_FALSE(index->UpdateExtraInfo(dataset->query_).has_value());
+    REQUIRE_FALSE(index->GetRawVectorByIds(nullptr, 1).has_value());
+    REQUIRE_FALSE(index->Clone().has_value());
+    REQUIRE_FALSE(index->ExportModel().has_value());
+    REQUIRE_FALSE(index->Train(dataset->base_).has_value());
+    REQUIRE_FALSE(
+        index->KnnSearch(dataset->query_, 10, search_param, filter, itex, true).has_value());
+    REQUIRE_FALSE(index->KnnSearch(dataset->query_, 10, search_param, filter).has_value());
+    REQUIRE_FALSE(index->KnnSearch(dataset->query_, 10, param).has_value());
+    REQUIRE_FALSE(index->SearchWithRequest(req).has_value());
+    REQUIRE_FALSE(index->RangeSearch(dataset->query_, 1.0F, search_param, filter).has_value());
     REQUIRE_THROWS(index->GetMemoryUsageDetail());
-    REQUIRE_THROWS(index->SetImmutable());
+    REQUIRE_FALSE(index->SetImmutable().has_value());
     AttributeSet old_attrs;
     AttributeSet new_attrs;
-    REQUIRE_THROWS(index->UpdateAttribute(0, new_attrs));
-    REQUIRE_THROWS(index->UpdateAttribute(1, new_attrs, old_attrs));
+    REQUIRE_FALSE(index->UpdateAttribute(0, new_attrs).has_value());
+    REQUIRE_FALSE(index->UpdateAttribute(1, new_attrs, old_attrs).has_value());
 
     std::vector<MergeUnit> units;
-    REQUIRE_THROWS(index->Merge(units));
+    REQUIRE_FALSE(index->Merge(units).has_value());
 
     fixtures::TempDir dir("test_simple_index");
     std::ofstream o_file(dir.path + "1234", std::ios::binary);
-    REQUIRE_THROWS(index->Serialize(o_file));
+    REQUIRE_FALSE(index->Serialize(o_file).has_value());
 
     std::ifstream i_file(dir.path + "1234", std::ios::binary);
-    REQUIRE_THROWS(index->Deserialize(i_file));
+    REQUIRE_FALSE(index->Deserialize(i_file).has_value());
 
-    REQUIRE_THROWS(index->GetDataByIds(nullptr, 1));
-    REQUIRE_THROWS(index->ExportIDs());
+    REQUIRE_FALSE(index->GetDataByIds(nullptr, 1).has_value());
+    REQUIRE_FALSE(index->ExportIDs().has_value());
     REQUIRE_THROWS(index->AnalyzeIndexBySearch(req));
     REQUIRE_THROWS(index->GetIndexType());
-    REQUIRE_THROWS(index->GetIndexDetailInfos());
-    REQUIRE_THROWS(index->Serialize(WriteFuncType(nullptr)));
+    REQUIRE_FALSE(index->GetIndexDetailInfos().has_value());
+    REQUIRE_FALSE(index->Serialize(WriteFuncType(nullptr)).has_value());
 
     IndexDetailInfo info;
     std::string name = INDEX_DETAIL_NAME_NUM_ELEMENTS;
-    REQUIRE_THROWS(index->GetDetailDataByName(name, info));
+    REQUIRE_FALSE(index->GetDetailDataByName(name, info).has_value());
 }


### PR DESCRIPTION
## Summary
- Replace throw std::runtime_error with LOG_ERROR_AND_RETURNS in Index class virtual method default implementations
- Provides consistent error handling via tl::expected<T, Error>

Fixes #2140
