### PR TITLE
chore: bundle dependencies for release artifacts

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -17,12 +17,14 @@ class CMakeBuild(build_ext):
         extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
         cfg = "Debug" if self.debug else "Release"
         mkl_static_link = os.environ.get("MKL_STATIC_LINK", "ON")
+        use_system_deps = os.environ.get("VSAG_USE_SYSTEM_DEPS", "OFF").strip().upper() or "OFF"
 
         cmake_args = [
             f"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={extdir}",
             f"-DPYTHON_EXECUTABLE={sys.executable}",
             f"-DPython3_EXECUTABLE={sys.executable}",
             f"-DCMAKE_BUILD_TYPE={cfg}",
+            f"-DVSAG_USE_SYSTEM_DEPS:STRING={use_system_deps}",
             "-DENABLE_PYBINDS=ON",
             "-DENABLE_TESTS=OFF",
             f"-DMKL_STATIC_LINK={mkl_static_link}",

--- a/scripts/release/dist.sh
+++ b/scripts/release/dist.sh
@@ -22,6 +22,7 @@ build() {
            bash -c "\
            export COMPILE_JOBS=\"$compile_jobs\" && \
            export CMAKE_INSTALL_PREFIX=/tmp/vsag && \
+           export EXTRA_DEFINED=\"\${EXTRA_DEFINED:+\$EXTRA_DEFINED }-DVSAG_USE_SYSTEM_DEPS:STRING=OFF\" && \
            make clean-release && make $makefile_target && make run-dist-tests && make install && \
            mkdir -p ./dist && \
            cp -r /tmp/vsag ./dist/ && \


### PR DESCRIPTION
## Summary
- Force C++ release asset builds to use bundled dependencies.
- Default Python wheel CMake builds to bundled dependencies while still allowing `VSAG_USE_SYSTEM_DEPS` override.

## Testing
- `python3 -m py_compile python/setup.py`
- `bash -n scripts/release/dist.sh`