### PR TITLE
build: install OpenBLAS in dependency scripts

### DIFF
--- a/scripts/deps/install_deps_centos.sh
+++ b/scripts/deps/install_deps_centos.sh
@@ -1,4 +1,6 @@
+set -e
+
 # install python3-devel
-yum install -y gcc gcc-c++ gcc-gfortran python3-devel libaio-devel libcurl-devel ca-certificates
+yum install -y epel-release && yum install -y gcc gcc-c++ gcc-gfortran python3-devel libaio-devel libcurl-devel ca-certificates openblas-devel lapack-devel
 
 yum install -y libgomp

--- a/scripts/deps/install_deps_ubuntu.sh
+++ b/scripts/deps/install_deps_ubuntu.sh
@@ -1,11 +1,13 @@
 arch=$(uname -m)
+common_pkgs="gfortran python3-dev libomp-15-dev gcc make cmake g++ lcov libaio-dev libopenblas-dev liblapacke-dev libcurl4-openssl-dev liburing-dev"
 
 if [[ "$arch" == "x86_64" ]]; then
     echo "Executing apt install for x86_64"
-    apt update && apt install -y gfortran python3-dev libomp-15-dev gcc make cmake g++ lcov libaio-dev intel-mkl libcurl4-openssl-dev liburing-dev
+    apt update && DEBIAN_FRONTEND=noninteractive apt install -y $common_pkgs intel-mkl
 elif [[ "$arch" == "aarch64" ]]; then
     echo "Executing apt install for aarch64"
-    apt update && apt install -y gfortran python3-dev libomp-15-dev gcc make cmake g++ lcov libaio-dev libcurl4-openssl-dev liburing-dev
+    apt update && DEBIAN_FRONTEND=noninteractive apt install -y $common_pkgs
 else
     echo "Unknown architecture: $arch"
+    exit 1
 fi


### PR DESCRIPTION
## Summary
- Install OpenBLAS and LAPACKE development packages in Ubuntu dependency setup.
- Install OpenBLAS and LAPACKE development packages in CentOS dependency setup.
- Keep the existing build behavior: OpenBLAS by default, MKL only when ENABLE_INTEL_MKL is enabled.

## Verification
- cmake configure with ENABLE_INTEL_MKL=OFF selects OpenBLAS backend.
- cmake configure with ENABLE_INTEL_MKL=ON selects Intel MKL backend.