### PR TITLE
refactor: clean up include dependencies in src/ based on IWYU analysis

### DIFF
--- a/src/algorithm/bruteforce/bruteforce_parameter.cpp
+++ b/src/algorithm/bruteforce/bruteforce_parameter.cpp
@@ -15,7 +15,7 @@
 
 #include "bruteforce_parameter.h"
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "datacell/flatten_datacell_parameter.h"
 #include "inner_string_params.h"

--- a/src/algorithm/hgraph/hgraph.cpp
+++ b/src/algorithm/hgraph/hgraph.cpp
@@ -14,39 +14,50 @@
 
 #include "hgraph.h"
 
-#include <datacell/compressed_graph_datacell_parameter.h>
-#include <fmt/format.h>
+#include <fmt/core.h>
 
+#include <algorithm>
 #include <atomic>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
 #include <memory>
+#include <mutex>
 #include <stdexcept>
 
+#include "algorithm/hgraph/hgraph_cache.h"
+#include "algorithm/hgraph/hgraph_parameter.h"
 #include "algorithm/inner_index_interface.h"
+#include "algorithm/inner_index_parameter.h"
 #include "analyzer/analyzer.h"
-#include "attr/argparse.h"
-#include "common.h"
+#include "datacell/attribute_inverted_interface.h"
+#include "datacell/extra_info_interface.h"
 #include "datacell/flatten_interface.h"
+#include "datacell/flatten_interface_parameter.h"
 #include "datacell/sparse_graph_datacell.h"
-#include "dataset_impl.h"
-#include "impl/filter/filter_headers.h"
-#include "impl/heap/standard_heap.h"
+#include "impl/basic_optimizer.h"
+#include "impl/label_table/label_table.h"
 #include "impl/odescent/odescent_graph_builder.h"
+#include "impl/odescent/odescent_graph_parameter.h"
 #include "impl/pruning_strategy.h"
-#include "impl/reasoning/search_reasoning.h"
 #include "impl/reorder/flatten_reorder.h"
 #include "index/index_impl.h"
-#include "index/iterator_filter.h"
+#include "index_common_param.h"
+#include "index_feature_list.h"
+#include "io/io_parameter.h"
 #include "io/reader_io_parameter.h"
-#include "storage/serialization.h"
-#include "storage/stream_reader.h"
-#include "typing.h"
+#include "json_wrapper.h"
+#include "tsl/robin_hash.h"
+#include "utils/resource_object_pool.h"
 #include "utils/util_functions.h"
-#include "utils/visited_list.h"
+#include "vsag/constants.h"
+#include "vsag/index_features.h"
 #include "vsag/options.h"
+#include "vsag/search_request.h"
 
 namespace vsag {
-
-class HGraphAnalyzer;
+class Reader;
+struct AttributeSet;
 
 HGraph::HGraph(const HGraphParameterPtr& hgraph_param, const vsag::IndexCommonParam& common_param)
     : InnerIndexInterface(hgraph_param, common_param),

--- a/src/algorithm/hgraph/hgraph_build.cpp
+++ b/src/algorithm/hgraph/hgraph_build.cpp
@@ -12,32 +12,83 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <fmt/format.h>
+#include <cxxabi.h>
+#include <fmt/core.h>
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
+#include <cstdint>
 #include <cstdlib>
+#include <exception>
 #include <fstream>
 #include <future>
+#include <iosfwd>
 #include <limits>
+#include <memory>
+#include <mutex>
+#include <shared_mutex>
+#include <string>
+#include <string_view>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
+#include <vector>
 
+#include "algorithm/hgraph/hgraph_cache.h"
+#include "algorithm/hgraph/hgraph_parameter.h"
+#include "algorithm/inner_index_interface.h"
+#include "basic_types.h"
+#include "common.h"
+#include "container_types.h"
+#include "data_type.h"
+#include "datacell/attribute_inverted_interface.h"
+#include "datacell/extra_info_interface.h"
 #include "datacell/flatten_datacell_parameter.h"
-#include "dataset_impl.h"
+#include "datacell/flatten_interface.h"
+#include "datacell/graph_interface.h"
+#include "hash_types.h"
 #include "hgraph.h"  // IWYU pragma: keep
+#include "impl/basic_optimizer.h"
+#include "impl/heap/distance_heap.h"
 #include "impl/heap/standard_heap.h"
+#include "impl/inner_search_param.h"
+#include "impl/label_table/label_table.h"
 #include "impl/logger/logger.h"
 #include "impl/odescent/odescent_graph_builder.h"
+#include "impl/odescent/odescent_graph_parameter.h"
 #include "impl/pruning_strategy.h"
+#include "impl/reorder/flatten_reorder.h"
+#include "impl/reorder/reorder.h"
+#include "impl/runtime_parameter.h"
 #include "impl/searcher/basic_searcher.h"
+#include "impl/thread_pool/safe_thread_pool.h"
+#include "index_common_param.h"
+#include "index_feature_list.h"
+#include "inner_string_params.h"
+#include "io/io_parameter.h"
 #include "io/memory_io_parameter.h"
+#include "metric_type.h"
+#include "quantization/quantizer_parameter.h"
 #include "quantization/scalar_quantization/scalar_quantizer_parameter.h"
 #include "storage/stream_reader.h"
 #include "storage/stream_writer.h"
+#include "tsl/robin_hash.h"
+#include "tsl/robin_map.h"
+#include "tsl/robin_set.h"
+#include "utils/lock_strategy.h"
 #include "utils/util_functions.h"
+#include "utils/visited_list.h"
+#include "vsag/attribute.h"
+#include "vsag/constants.h"
+#include "vsag/dataset.h"
+#include "vsag/index.h"
+#include "vsag/index_features.h"
 
 namespace vsag {
+class Allocator;
+class IteratorFilterContext;
+struct QueryContext;
 
 static FlattenInterfacePtr
 make_temporary_sq8_flatten(MetricType metric,

--- a/src/algorithm/hgraph/hgraph_cache.cpp
+++ b/src/algorithm/hgraph/hgraph_cache.cpp
@@ -14,9 +14,15 @@
 
 #include "hgraph_cache.h"
 
-#include "impl/allocator/default_allocator.h"
+#include <cstdint>
+#include <utility>
+
+#include "storage/stream_reader.h"
+#include "storage/stream_writer.h"
+#include "tsl/robin_hash.h"
 
 namespace vsag {
+class Allocator;
 
 HGraphCache::HGraphCache(Allocator* allocator)
     : allocator_(allocator), source_ids_(allocator_), neighbors_(allocator_) {

--- a/src/algorithm/hgraph/hgraph_modify.cpp
+++ b/src/algorithm/hgraph/hgraph_modify.cpp
@@ -12,11 +12,35 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <ostream>
+#include <shared_mutex>
+#include <tuple>
+#include <vector>
+
+#include "algorithm/inner_index_interface.h"
+#include "basic_types.h"
+#include "common.h"
+#include "container_types.h"
+#include "datacell/attribute_inverted_interface.h"
+#include "datacell/extra_info_interface.h"
+#include "datacell/flatten_interface.h"
+#include "datacell/graph_interface.h"
+#include "hash_types.h"
 #include "hgraph.h"  // IWYU pragma: keep
+#include "impl/label_table/label_table.h"
 #include "impl/pruning_strategy.h"
-#include "utils/util_functions.h"
+#include "tsl/robin_hash.h"
+#include "utils/lock_strategy.h"
+#include "vsag/errors.h"
+#include "vsag/index.h"
+#include "vsag_exception.h"
 
 namespace vsag {
+struct AttributeSet;
 
 uint32_t
 HGraph::Remove(const std::vector<int64_t>& ids, RemoveMode mode) {

--- a/src/algorithm/hgraph/hgraph_param_mapping.cpp
+++ b/src/algorithm/hgraph/hgraph_param_mapping.cpp
@@ -12,11 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <fmt/format.h>
+#include <fmt/core.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <string>
 
 #include "common.h"
+#include "data_type.h"
+#include "datacell/graph_interface_parameter.h"
 #include "hgraph.h"  // IWYU pragma: keep
 #include "hgraph_parameter.h"
+#include "index_common_param.h"
+#include "inner_string_params.h"
+#include "json_types.h"
+#include "json_wrapper.h"
+#include "parameter.h"
+#include "type_helpers.h"
+#include "utils/util_functions.h"
+#include "vsag/constants.h"
 
 namespace vsag {
 

--- a/src/algorithm/hgraph/hgraph_parameter_test.cpp
+++ b/src/algorithm/hgraph/hgraph_parameter_test.cpp
@@ -15,7 +15,7 @@
 
 #include "hgraph_parameter.h"
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "hgraph.h"
 #include "index_common_param.h"

--- a/src/algorithm/hgraph/hgraph_search.cpp
+++ b/src/algorithm/hgraph/hgraph_search.cpp
@@ -12,18 +12,63 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
+#include <algorithm>
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <ostream>
+#include <shared_mutex>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "algorithm/hgraph/hgraph_parameter.h"
+#include "algorithm/inner_index_interface.h"
 #include "attr/argparse.h"
+#include "attr/executor/executor.h"
+#include "basic_types.h"
+#include "common.h"
+#include "container_types.h"
+#include "data_type.h"
+#include "datacell/attribute_inverted_interface.h"
+#include "datacell/extra_info_interface.h"
+#include "datacell/flatten_interface.h"
+#include "datacell/graph_interface.h"
 #include "dataset_impl.h"
+#include "hash_types.h"
 #include "hgraph.h"  // IWYU pragma: keep
-#include "impl/filter/filter_headers.h"
-#include "impl/heap/standard_heap.h"
+#include "impl/filter/combined_filter.h"
+#include "impl/filter/extrainfo_wrapper_filter.h"
+#include "impl/filter/inner_id_wrapper_filter.h"
+#include "impl/heap/distance_heap.h"
+#include "impl/inner_search_param.h"
+#include "impl/label_table/label_table.h"
+#include "impl/logger/logger.h"
 #include "impl/reasoning/search_reasoning.h"
+#include "impl/searcher/basic_searcher.h"
+#include "impl/searcher/parallel_searcher.h"
 #include "index/iterator_filter.h"
+#include "query_context.h"
+#include "tsl/robin_hash.h"
+#include "utils/resource_object_pool.h"
+#include "utils/timer.h"
 #include "utils/util_functions.h"
+#include "utils/visited_list.h"
+#include "vsag/allocator.h"
+#include "vsag/dataset.h"
+#include "vsag/errors.h"
+#include "vsag/expected.hpp"
+#include "vsag/filter.h"
+#include "vsag/search_request.h"
+#include "vsag_exception.h"
 
 namespace vsag {
+class IteratorContext;
 
 static DatasetPtr
 make_empty_dataset_with_stats() {

--- a/src/algorithm/hgraph/hgraph_serialize.cpp
+++ b/src/algorithm/hgraph/hgraph_serialize.cpp
@@ -12,18 +12,42 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
-#include "datacell/sparse_graph_datacell.h"
+#include <atomic>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "algorithm/hgraph/hgraph_parameter.h"
+#include "algorithm/inner_index_interface.h"
+#include "algorithm/inner_index_parameter.h"
+#include "basic_types.h"
+#include "container_types.h"
+#include "data_type.h"
+#include "datacell/attribute_inverted_interface.h"
+#include "datacell/extra_info_interface.h"
+#include "datacell/flatten_interface.h"
+#include "datacell/graph_interface.h"
 #include "hgraph.h"  // IWYU pragma: keep
-#include "impl/heap/standard_heap.h"
-#include "impl/odescent/odescent_graph_builder.h"
-#include "impl/pruning_strategy.h"
+#include "impl/label_table/label_table.h"
+#include "impl/logger/logger.h"
+#include "inner_string_params.h"
+#include "json_types.h"
+#include "json_wrapper.h"
+#include "metric_type.h"
 #include "storage/serialization.h"
 #include "storage/stream_reader.h"
-#include "typing.h"
+#include "storage/stream_writer.h"
+#include "tsl/robin_map.h"
+#include "utils/lock_strategy.h"
 #include "utils/util_functions.h"
-#include "vsag/options.h"
+#include "utils/visited_list.h"
+#include "vsag/constants.h"
+#include "vsag/errors.h"
+#include "vsag_exception.h"
 
 namespace vsag {
 

--- a/src/algorithm/hnswlib/block_manager.cpp
+++ b/src/algorithm/hnswlib/block_manager.cpp
@@ -15,6 +15,17 @@
 
 #include "block_manager.h"
 
+#include <algorithm>
+#include <cstdint>
+#include <ios>
+#include <new>
+#include <stdexcept>
+#include <string>
+
+#include "storage/stream_reader.h"
+#include "storage/stream_writer.h"
+#include "vsag/allocator.h"
+
 namespace hnswlib {
 
 BlockManager::BlockManager(uint64_t size_data_per_element,

--- a/src/algorithm/hnswlib/hnswalg.cpp
+++ b/src/algorithm/hnswlib/hnswalg.cpp
@@ -15,12 +15,34 @@
 
 #include "hnswalg.h"
 
-#include <memory>
+#include <fmt/core.h>
 
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <exception>
+#include <fstream>
+#include <functional>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <stdexcept>
+#include <vector>
+
+#include "algorithm/hnswlib/algorithm_interface.h"
+#include "algorithm/hnswlib/block_manager.h"
+#include "algorithm/hnswlib/visited_list_pool.h"
 #include "datacell/graph_interface.h"
+#include "impl/inner_search_param.h"
 #include "impl/searcher/basic_searcher.h"
+#include "index/iterator_filter.h"
+#include "storage/stream_reader.h"
+#include "storage/stream_writer.h"
+#include "tsl/robin_set.h"
 #include "utils/filter_search_skip_strategy.h"
 #include "utils/prefetch.h"
+#include "vsag/allocator.h"
+#include "vsag/errors.h"
 #include "vsag_exception.h"
 
 using vsag::ErrorType;

--- a/src/algorithm/inner_index_interface.cpp
+++ b/src/algorithm/inner_index_interface.cpp
@@ -15,21 +15,42 @@
 
 #include "inner_index_interface.h"
 
-#include <fmt/format.h>
+#include <cxxabi.h>
+#include <fmt/core.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <future>
+#include <istream>
+#include <mutex>
+#include <new>
 
 #include "algorithm/bruteforce/bruteforce.h"
 #include "algorithm/hgraph/hgraph.h"
-#include "impl/filter/filter_headers.h"
+#include "algorithm/inner_index_parameter.h"
+#include "common.h"
+#include "container_types.h"
+#include "impl/filter/black_list_filter.h"
+#include "impl/inner_search_param.h"
 #include "impl/label_table/label_table.h"
+#include "impl/logger/logger.h"
 #include "impl/thread_pool/safe_thread_pool.h"
 #include "index_common_param.h"
 #include "index_detail_data.h"
 #include "index_feature_list.h"
-#include "storage/empty_index_binary_set.h"
+#include "inner_string_params.h"
+#include "json_wrapper.h"
 #include "storage/serialization.h"
+#include "storage/stream_reader.h"
+#include "storage/stream_writer.h"
+#include "tsl/robin_map.h"
 #include "utils/slow_task_timer.h"
 #include "utils/util_functions.h"
 #include "vsag/allocator.h"
+#include "vsag/attribute.h"
+#include "vsag/constants.h"
+#include "vsag/readerset.h"
 
 namespace vsag {
 

--- a/src/algorithm/inner_index_parameter.cpp
+++ b/src/algorithm/inner_index_parameter.cpp
@@ -15,14 +15,21 @@
 
 #include "inner_index_parameter.h"
 
+#include <fmt/core.h>
+
+#include <memory>
+
 #include "common.h"
 #include "datacell/attribute_inverted_interface_parameter.h"
 #include "datacell/extra_info_datacell_parameter.h"
-#include "datacell/flatten_datacell_parameter.h"
+#include "datacell/flatten_interface_parameter.h"
 #include "impl/logger/logger.h"
 #include "inner_string_params.h"
+#include "json_wrapper.h"
 #include "utils/param_compat_macros.h"
 #include "vsag/constants.h"
+#include "vsag/errors.h"
+#include "vsag_exception.h"
 
 namespace vsag {
 

--- a/src/algorithm/ivf/gno_imi_parameter.cpp
+++ b/src/algorithm/ivf/gno_imi_parameter.cpp
@@ -15,9 +15,14 @@
 
 #include "gno_imi_parameter.h"
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
+#include <cstdint>
+
+#include "common.h"
+#include "impl/logger/logger.h"
 #include "inner_string_params.h"
+#include "json_wrapper.h"
 #include "utils/param_compat_macros.h"
 
 namespace vsag {

--- a/src/algorithm/ivf/gno_imi_parameter.h
+++ b/src/algorithm/ivf/gno_imi_parameter.h
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 #pragma once
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "datacell/bucket_datacell_parameter.h"
 #include "inner_string_params.h"

--- a/src/algorithm/ivf/gno_imi_partition.cpp
+++ b/src/algorithm/ivf/gno_imi_partition.cpp
@@ -15,20 +15,45 @@
 
 #include "gno_imi_partition.h"
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
+#include <algorithm>
 #include <atomic>
+#include <cmath>
+#include <cstring>
 #include <fstream>
+#include <functional>
+#include <limits>
 #include <numeric>
+#include <utility>
 #include <vector>
 
-#include "algorithm/inner_index_interface.h"
-#include "impl/allocator/safe_allocator.h"
+#include "algorithm/bruteforce/bruteforce.h"
+#include "algorithm/bruteforce/bruteforce_parameter.h"
+#include "algorithm/inner_index_parameter.h"
+#include "algorithm/ivf/gno_imi_parameter.h"
+#include "algorithm/ivf/ivf_partition_strategy.h"
+#include "algorithm/ivf/ivf_partition_strategy_parameter.h"
+#include "common.h"
+#include "datacell/flatten_datacell_parameter.h"
+#include "datacell/flatten_interface_parameter.h"
 #include "impl/blas/blas_function.h"
 #include "impl/cluster/kmeans_cluster.h"
+#include "impl/inner_search_param.h"
+#include "impl/logger/logger.h"
 #include "inner_string_params.h"
+#include "io/io_parameter.h"
+#include "json_types.h"
+#include "json_wrapper.h"
+#include "metric_type.h"
+#include "quantization/quantizer_parameter.h"
 #include "query_context.h"
-#include "utils/util_functions.h"
+#include "simd/fp32_simd.h"
+#include "simd/normalize.h"
+#include "storage/stream_reader.h"
+#include "storage/stream_writer.h"
+#include "type_helpers.h"
+#include "vsag/errors.h"
 #include "vsag_exception.h"
 
 namespace vsag {

--- a/src/algorithm/ivf/ivf.cpp
+++ b/src/algorithm/ivf/ivf.cpp
@@ -15,28 +15,62 @@
 
 #include "ivf.h"
 
+#include <cxxabi.h>
+#include <fmt/core.h>
+
+#include <algorithm>
 #include <atomic>
-#include <random>
-#include <set>
+#include <cmath>
+#include <future>
+#include <limits>
+#include <mutex>
+#include <ostream>
+#include <shared_mutex>
+#include <tuple>
+#include <unordered_map>
 
 #include "algorithm/inner_index_interface.h"
+#include "algorithm/inner_index_parameter.h"
+#include "algorithm/ivf/ivf_parameter.h"
+#include "algorithm/ivf/ivf_partition_strategy.h"
+#include "algorithm/ivf/ivf_partition_strategy_parameter.h"
 #include "attr/argparse.h"
 #include "attr/executor/executor.h"
+#include "common.h"
+#include "data_type.h"
+#include "datacell/attribute_inverted_interface.h"
+#include "datacell/bucket_datacell_parameter.h"
+#include "datacell/extra_info_interface.h"
 #include "datacell/flatten_interface.h"
 #include "gno_imi_partition.h"
-#include "impl/heap/standard_heap.h"
+#include "impl/filter/combined_filter.h"
+#include "impl/filter/inner_id_wrapper_filter.h"
 #include "impl/inner_search_param.h"
+#include "impl/label_table/label_table.h"
+#include "impl/logger/logger.h"
 #include "impl/reorder/flatten_reorder.h"
 #include "impl/searcher/basic_searcher.h"
+#include "impl/thread_pool/safe_thread_pool.h"
 #include "index/index_impl.h"
+#include "index_common_param.h"
 #include "index_feature_list.h"
 #include "inner_string_params.h"
 #include "ivf_nearest_partition.h"
+#include "json_wrapper.h"
+#include "metric_type.h"
 #include "query_context.h"
 #include "storage/serialization.h"
 #include "storage/stream_reader.h"
 #include "storage/stream_writer.h"
+#include "type_helpers.h"
+#include "utils/timer.h"
 #include "utils/util_functions.h"
+#include "vsag/allocator.h"
+#include "vsag/attribute.h"
+#include "vsag/errors.h"
+#include "vsag/filter.h"
+#include "vsag/index_features.h"
+#include "vsag/search_request.h"
 #include "vsag_exception.h"
 
 namespace vsag {

--- a/src/algorithm/ivf/ivf_nearest_partition.cpp
+++ b/src/algorithm/ivf/ivf_nearest_partition.cpp
@@ -15,21 +15,44 @@
 
 #include "ivf_nearest_partition.h"
 
-#include <fmt/format.h>
+#include <cxxabi.h>
+#include <fmt/core.h>
 
+#include <algorithm>
 #include <atomic>
 #include <cstdlib>
+#include <cstring>
+#include <future>
+#include <memory>
+#include <mutex>
+#include <numeric>
+#include <ostream>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "algorithm/hgraph/hgraph.h"
 #include "algorithm/inner_index_interface.h"
-#include "impl/allocator/safe_allocator.h"
+#include "algorithm/ivf/ivf_partition_strategy.h"
+#include "algorithm/ivf/ivf_partition_strategy_parameter.h"
 #include "impl/cluster/kmeans_cluster.h"
-#include "inner_string_params.h"
+#include "impl/inner_search_param.h"
+#include "impl/thread_pool/safe_thread_pool.h"
+#include "json_types.h"
+#include "json_wrapper.h"
+#include "metric_type.h"
+#include "parameter.h"
 #include "query_context.h"
+#include "simd/normalize.h"
+#include "storage/stream_reader.h"
+#include "type_helpers.h"
 #include "utils/util_functions.h"
+#include "vsag/errors.h"
 #include "vsag_exception.h"
 
 namespace vsag {
+class IndexCommonParam;
+class StreamWriter;
 
 static constexpr const char* SEARCH_PARAM_TEMPLATE_STR = R"(
 {{

--- a/src/algorithm/ivf/ivf_parameter.cpp
+++ b/src/algorithm/ivf/ivf_parameter.cpp
@@ -15,11 +15,19 @@
 
 #include "ivf_parameter.h"
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
+#include <memory>
+
+#include "algorithm/ivf/gno_imi_parameter.h"
+#include "algorithm/ivf/ivf_partition_strategy_parameter.h"
+#include "common.h"
+#include "impl/logger/logger.h"
 #include "inner_string_params.h"
+#include "json_wrapper.h"
 #include "utils/param_compat_macros.h"
 #include "vsag/constants.h"
+
 namespace vsag {
 
 void

--- a/src/algorithm/ivf/ivf_parameter.h
+++ b/src/algorithm/ivf/ivf_parameter.h
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 #pragma once
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "algorithm/index_search_parameter.h"
 #include "algorithm/inner_index_parameter.h"

--- a/src/algorithm/ivf/ivf_partition_strategy.cpp
+++ b/src/algorithm/ivf/ivf_partition_strategy.cpp
@@ -15,6 +15,8 @@
 
 #include "ivf_partition_strategy.h"
 
+#include <cstring>
+
 #include "impl/blas/blas_function.h"
 
 namespace vsag {

--- a/src/algorithm/ivf/ivf_partition_strategy_parameter.cpp
+++ b/src/algorithm/ivf/ivf_partition_strategy_parameter.cpp
@@ -15,11 +15,15 @@
 
 #include "ivf_partition_strategy_parameter.h"
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
-#include <iostream>
+#include <string>
 
+#include "algorithm/ivf/gno_imi_parameter.h"
+#include "common.h"
+#include "impl/logger/logger.h"
 #include "inner_string_params.h"
+#include "json_wrapper.h"
 #include "utils/param_compat_macros.h"
 #include "vsag/constants.h"
 

--- a/src/algorithm/ivf/ivf_partition_strategy_parameter.h
+++ b/src/algorithm/ivf/ivf_partition_strategy_parameter.h
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 #pragma once
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "datacell/bucket_datacell_parameter.h"
 #include "gno_imi_parameter.h"

--- a/src/algorithm/pyramid/pyramid.cpp
+++ b/src/algorithm/pyramid/pyramid.cpp
@@ -15,20 +15,51 @@
 
 #include "pyramid.h"
 
-#include <chrono>
+#include <cxxabi.h>
+#include <fmt/core.h>
+
+#include <algorithm>
+#include <atomic>
+#include <cstdint>
+#include <cstring>
+#include <future>
+#include <limits>
+#include <ostream>
+#include <utility>
 
 #include "algorithm/inner_index_interface.h"
+#include "algorithm/pyramid/pyramid_zparameters.h"
 #include "analyzer/analyzer.h"
+#include "common.h"
 #include "datacell/flatten_interface.h"
+#include "datacell/graph_interface_parameter.h"
+#include "datacell/sparse_graph_datacell.h"
+#include "datacell/sparse_graph_datacell_parameter.h"
+#include "dataset_impl.h"
+#include "impl/filter/inner_id_wrapper_filter.h"
 #include "impl/heap/standard_heap.h"
+#include "impl/label_table/label_table.h"
+#include "impl/logger/logger.h"
 #include "impl/odescent/odescent_graph_builder.h"
 #include "impl/pruning_strategy.h"
-#include "io/memory_io_parameter.h"
+#include "impl/thread_pool/safe_thread_pool.h"
+#include "index_feature_list.h"
+#include "json_wrapper.h"
 #include "query_context.h"
-#include "storage/empty_index_binary_set.h"
 #include "storage/serialization.h"
-#include "utils/slow_task_timer.h"
+#include "storage/stream_reader.h"
+#include "storage/stream_writer.h"
+#include "tsl/robin_hash.h"
+#include "type_helpers.h"
+#include "utils/resource_object_pool.h"
+#include "utils/timer.h"
 #include "utils/util_functions.h"
+#include "vsag/allocator.h"
+#include "vsag/errors.h"
+#include "vsag/filter.h"
+#include "vsag/index_features.h"
+#include "vsag_exception.h"
+
 namespace vsag {
 
 const static float RADIUS_EPSILON = 1.1F;

--- a/src/algorithm/pyramid/pyramid_zparameters.cpp
+++ b/src/algorithm/pyramid/pyramid_zparameters.cpp
@@ -15,12 +15,20 @@
 
 #include "pyramid_zparameters.h"
 
+#include <fmt/core.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+
 #include "common.h"
 #include "impl/logger/logger.h"
 #include "index/diskann_zparameters.h"
 #include "io/memory_io_parameter.h"
+#include "json_wrapper.h"
 #include "quantization/fp32_quantizer_parameter.h"
 #include "utils/param_compat_macros.h"
+#include "vsag/constants.h"
 
 // NOLINTBEGIN(readability-simplify-boolean-expr)
 

--- a/src/algorithm/pyramid/pyramid_zparameters_test.cpp
+++ b/src/algorithm/pyramid/pyramid_zparameters_test.cpp
@@ -15,6 +15,8 @@
 
 #include "pyramid_zparameters.h"
 
+#include <fmt/ranges.h>
+
 #include "index_common_param.h"
 #include "parameter_test.h"
 #include "pyramid.h"

--- a/src/algorithm/sindi/sindi.cpp
+++ b/src/algorithm/sindi/sindi.cpp
@@ -15,12 +15,46 @@
 
 #include "sindi.h"
 
+#include <fmt/core.h>
+
+#include <algorithm>
+#include <atomic>
+#include <cstdint>
+#include <limits>
+#include <mutex>
+#include <new>
+#include <optional>
+#include <ostream>
+#include <stdexcept>
+#include <unordered_map>
+
+#include "algorithm/inner_index_parameter.h"
+#include "algorithm/sindi/term_id_mapper.h"
+#include "algorithm/sparse_index/sparse_index.h"
+#include "algorithm/sparse_index/sparse_index_parameters.h"
 #include "analyzer/analyzer.h"
+#include "common.h"
+#include "datacell/extra_info_interface.h"
+#include "impl/filter/inner_id_wrapper_filter.h"
+#include "impl/filter/white_list_filter.h"
+#include "impl/heap/distance_heap.h"
 #include "impl/heap/standard_heap.h"
+#include "impl/label_table/label_table.h"
+#include "impl/logger/logger.h"
+#include "index_common_param.h"
 #include "index_feature_list.h"
+#include "json_wrapper.h"
 #include "storage/serialization.h"
+#include "storage/stream_reader.h"
+#include "storage/stream_writer.h"
+#include "utils/sparse_vector_transform.h"
 #include "utils/util_functions.h"
 #include "vsag/allocator.h"
+#include "vsag/constants.h"
+#include "vsag/errors.h"
+#include "vsag/filter.h"
+#include "vsag/index_features.h"
+#include "vsag/search_request.h"
 #include "vsag_exception.h"
 
 namespace vsag {

--- a/src/algorithm/sindi/sindi_parameter.cpp
+++ b/src/algorithm/sindi/sindi_parameter.cpp
@@ -15,8 +15,15 @@
 
 #include "sindi_parameter.h"
 
+#include <fmt/core.h>
+
+#include <memory>
+
+#include "common.h"
 #include "inner_string_params.h"
+#include "json_wrapper.h"
 #include "utils/param_compat_macros.h"
+#include "vsag/constants.h"
 
 namespace vsag {
 

--- a/src/algorithm/sindi/term_id_mapper.cpp
+++ b/src/algorithm/sindi/term_id_mapper.cpp
@@ -15,11 +15,16 @@
 
 #include "term_id_mapper.h"
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
+#include "storage/stream_reader.h"
+#include "storage/stream_writer.h"
+#include "tsl/robin_hash.h"
+#include "vsag/errors.h"
 #include "vsag_exception.h"
 
 namespace vsag {
+class Allocator;
 
 TermIdMapper::TermIdMapper(uint32_t term_id_limit, Allocator* allocator)
     : orig_to_compact_(allocator),

--- a/src/algorithm/sparse_index/sparse_index.cpp
+++ b/src/algorithm/sparse_index/sparse_index.cpp
@@ -15,13 +15,23 @@
 
 #include "sparse_index.h"
 
+#include <algorithm>
+#include <cstring>
 #include <numeric>
 
+#include "algorithm/inner_index_parameter.h"
+#include "algorithm/sparse_index/sparse_index_parameters.h"
+#include "common.h"
 #include "impl/heap/standard_heap.h"
 #include "impl/label_table/label_table.h"
+#include "index_common_param.h"
 #include "index_feature_list.h"
+#include "storage/stream_reader.h"
+#include "storage/stream_writer.h"
 #include "utils/util_functions.h"
 #include "vsag/allocator.h"
+#include "vsag/index_features.h"
+
 namespace vsag {
 
 static float

--- a/src/algorithm/sparse_index/sparse_index_parameters.cpp
+++ b/src/algorithm/sparse_index/sparse_index_parameters.cpp
@@ -15,7 +15,10 @@
 
 #include "sparse_index_parameters.h"
 
+#include <memory>
+
 #include "inner_string_params.h"
+#include "json_wrapper.h"
 
 namespace vsag {
 

--- a/src/algorithm/warp/warp_parameter.cpp
+++ b/src/algorithm/warp/warp_parameter.cpp
@@ -15,9 +15,15 @@
 
 #include "warp_parameter.h"
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
+#include <memory>
+
+#include "common.h"
+#include "inner_string_params.h"
+#include "json_wrapper.h"
 #include "utils/param_compat_macros.h"
+#include "vsag/constants.h"
 
 namespace vsag {
 

--- a/src/analyzer/analyzer.cpp
+++ b/src/analyzer/analyzer.cpp
@@ -15,9 +15,20 @@
 
 #include "analyzer.h"
 
+#include <fmt/core.h>
+
+#include <memory>
+#include <ostream>
+
+#include "algorithm/hgraph/hgraph.h"
+#include "algorithm/inner_index_interface.h"
+#include "algorithm/pyramid/pyramid.h"
+#include "algorithm/sindi/sindi.h"
 #include "hgraph_analyzer.h"
 #include "pyramid_analyzer.h"
 #include "sindi_analyzer.h"
+#include "vsag/errors.h"
+#include "vsag_exception.h"
 
 namespace vsag {
 

--- a/src/analyzer/hgraph_analyzer.cpp
+++ b/src/analyzer/hgraph_analyzer.cpp
@@ -15,7 +15,26 @@
 
 #include "hgraph_analyzer.h"
 
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <numeric>
+#include <queue>
+#include <random>
+#include <unordered_set>
+
+#include "algorithm/inner_index_interface.h"
+#include "datacell/flatten_interface.h"
+#include "datacell/graph_interface.h"
 #include "impl/heap/standard_heap.h"
+#include "impl/label_table/label_table.h"
+#include "impl/logger/logger.h"
+#include "impl/reorder/reorder.h"
+#include "json_wrapper.h"
+#include "tsl/robin_hash.h"
+#include "utils/timer.h"
+#include "vsag/search_request.h"
 
 namespace vsag {
 

--- a/src/analyzer/pyramid_analyzer.cpp
+++ b/src/analyzer/pyramid_analyzer.cpp
@@ -15,15 +15,37 @@
 #include "pyramid_analyzer.h"
 
 #include <algorithm>
+#include <chrono>
 #include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <exception>
+#include <functional>
+#include <map>
+#include <memory>
+#include <numeric>
+#include <queue>
 #include <random>
+#include <utility>
+#include <vector>
 
+#include "algorithm/inner_index_interface.h"
+#include "datacell/flatten_interface.h"
+#include "datacell/graph_interface.h"
 #include "impl/heap/standard_heap.h"
+#include "impl/inner_search_param.h"
+#include "impl/label_table/label_table.h"
 #include "impl/logger/logger.h"
-#include "impl/searcher/basic_searcher.h"
+#include "impl/reorder/reorder.h"
+#include "json_wrapper.h"
 #include "query_context.h"
-#include "typing.h"
+#include "tsl/robin_hash.h"
+#include "tsl/robin_map.h"
+#include "tsl/robin_set.h"
+#include "utils/resource_object_pool.h"
+#include "utils/timer.h"
 #include "vsag/dataset.h"
+#include "vsag/search_request.h"
 
 namespace vsag {
 

--- a/src/analyzer/sindi_analyzer.cpp
+++ b/src/analyzer/sindi_analyzer.cpp
@@ -18,16 +18,38 @@
 #include <chrono>
 #include <cmath>
 #include <cstdint>
+#include <cstdlib>
 #include <fstream>
+#include <initializer_list>
 #include <limits>
+#include <memory>
+#include <new>
 #include <numeric>
+#include <optional>
 #include <queue>
 #include <random>
+#include <ratio>
+#include <shared_mutex>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
+#include "algorithm/inner_index_interface.h"
+#include "algorithm/sindi/sindi_parameter.h"
+#include "algorithm/sindi/term_id_mapper.h"
+#include "common.h"
+#include "container_types.h"
+#include "datacell/sparse_term_datacell.h"
+#include "impl/inner_search_param.h"
+#include "impl/label_table/label_table.h"
+#include "impl/logger/logger.h"
+#include "inner_string_params.h"
+#include "json_wrapper.h"
+#include "quantization/sparse_quantization/sparse_term_computer.h"
 #include "utils/sparse_vector_transform.h"
+#include "vsag/allocator.h"
+#include "vsag/constants.h"
+#include "vsag/search_request.h"
 
 namespace vsag {
 namespace {

--- a/src/attr/attr_type_schema.cpp
+++ b/src/attr/attr_type_schema.cpp
@@ -15,9 +15,20 @@
 
 #include "attr_type_schema.h"
 
+#include <fmt/core.h>
+
+#include <cstdint>
+
+#include "storage/stream_reader.h"
+#include "storage/stream_writer.h"
+#include "tsl/robin_hash.h"
+#include "type_helpers.h"
+#include "vsag/errors.h"
 #include "vsag_exception.h"
 
 namespace vsag {
+class Allocator;
+
 AttrTypeSchema::AttrTypeSchema(Allocator* allocator) : allocator_(allocator), schema_(allocator) {
 }
 

--- a/src/attr/attr_value_map.cpp
+++ b/src/attr/attr_value_map.cpp
@@ -15,7 +15,15 @@
 
 #include "attr_value_map.h"
 
+#include <cstdint>
+
+#include "attr/multi_bitset_manager.h"
+#include "storage/stream_reader.h"
+#include "storage/stream_writer.h"
+#include "tsl/robin_hash.h"
+
 namespace vsag {
+class Allocator;
 
 template <class T>
 void

--- a/src/attr/attribute.cpp
+++ b/src/attr/attribute.cpp
@@ -15,8 +15,9 @@
 
 #include "vsag/attribute.h"
 
+#include <cstdint>
 #include <cstring>
-#include <memory>
+#include <type_traits>
 
 namespace vsag {
 

--- a/src/attr/executor/comparison_executor.cpp
+++ b/src/attr/executor/comparison_executor.cpp
@@ -15,10 +15,21 @@
 
 #include "comparison_executor.h"
 
-#include "impl/bitset/fast_bitset.h"
+#include <cstdint>
+#include <memory>
+#include <ostream>
+
+#include "attr/executor/executor.h"
+#include "attr/multi_bitset_manager.h"
+#include "impl/bitset/computable_bitset.h"
+#include "impl/filter/black_list_filter.h"
+#include "impl/filter/white_list_filter.h"
+#include "vsag/errors.h"
 #include "vsag_exception.h"
 
 namespace vsag {
+class Allocator;
+class Filter;
 
 ComparisonExecutor::ComparisonExecutor(Allocator* allocator,
                                        const ExprPtr& expr,

--- a/src/attr/executor/executor.cpp
+++ b/src/attr/executor/executor.cpp
@@ -15,11 +15,17 @@
 
 #include "executor.h"
 
+#include <ostream>
+
 #include "comparison_executor.h"
 #include "integer_list_executor.h"
 #include "logical_executor.h"
 #include "string_list_executor.h"
+#include "vsag/errors.h"
+#include "vsag_exception.h"
+
 namespace vsag {
+class Allocator;
 
 ExecutorPtr
 Executor::MakeInstance(Allocator* allocator,

--- a/src/attr/executor/integer_list_executor.cpp
+++ b/src/attr/executor/integer_list_executor.cpp
@@ -15,13 +15,24 @@
 
 #include "integer_list_executor.h"
 
+#include <cstdint>
+#include <memory>
+#include <ostream>
 #include <variant>
 
-#include "impl/bitset/fast_bitset.h"
+#include "attr/executor/executor.h"
+#include "attr/multi_bitset_manager.h"
+#include "impl/bitset/computable_bitset.h"
+#include "impl/filter/black_list_filter.h"
+#include "impl/filter/white_list_filter.h"
 #include "utils/util_functions.h"
+#include "vsag/errors.h"
 #include "vsag_exception.h"
 
 namespace vsag {
+class Allocator;
+class Filter;
+
 using ListVariant = std::variant<std::shared_ptr<const IntListConstant<int64_t>>,
                                  std::shared_ptr<const IntListConstant<uint64_t>>>;
 

--- a/src/attr/executor/logical_executor.cpp
+++ b/src/attr/executor/logical_executor.cpp
@@ -15,8 +15,19 @@
 
 #include "logical_executor.h"
 
+#include <cstdint>
+#include <memory>
+#include <ostream>
+
+#include "attr/executor/executor.h"
+#include "impl/bitset/computable_bitset.h"
+#include "impl/filter/white_list_filter.h"
+#include "vsag/errors.h"
+#include "vsag/filter.h"
 #include "vsag_exception.h"
+
 namespace vsag {
+class Allocator;
 
 LogicalExecutor::LogicalExecutor(Allocator* allocator,
                                  const ExprPtr& expr,

--- a/src/attr/executor/string_list_executor.cpp
+++ b/src/attr/executor/string_list_executor.cpp
@@ -15,11 +15,21 @@
 
 #include "string_list_executor.h"
 
-#include "impl/bitset/fast_bitset.h"
+#include <memory>
+#include <ostream>
+
+#include "attr/executor/executor.h"
+#include "attr/multi_bitset_manager.h"
+#include "impl/bitset/computable_bitset.h"
+#include "impl/filter/black_list_filter.h"
+#include "impl/filter/white_list_filter.h"
 #include "utils/util_functions.h"
+#include "vsag/errors.h"
 #include "vsag_exception.h"
 
 namespace vsag {
+class Allocator;
+class Filter;
 
 StringListExecutor::StringListExecutor(Allocator* allocator,
                                        const ExprPtr& expr,

--- a/src/attr/expression_visitor.h
+++ b/src/attr/expression_visitor.h
@@ -17,7 +17,7 @@
 
 #include <antlr4-autogen/FCBaseVisitor.h>
 #include <antlr4-runtime/antlr4-runtime.h>
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include <any>
 #include <cstdio>

--- a/src/attr/multi_bitset_manager.cpp
+++ b/src/attr/multi_bitset_manager.cpp
@@ -15,7 +15,15 @@
 
 #include "multi_bitset_manager.h"
 
+#include <iosfwd>
+#include <vector>
+
+#include "storage/stream_reader.h"
+#include "storage/stream_writer.h"
+#include "type_helpers.h"
+
 namespace vsag {
+class Allocator;
 
 MultiBitsetManager::MultiBitsetManager(Allocator* allocator,
                                        uint64_t count,

--- a/src/datacell/attribute_bucket_inverted_datacell.cpp
+++ b/src/datacell/attribute_bucket_inverted_datacell.cpp
@@ -14,7 +14,27 @@
 // limitations under the License.
 
 #include "attribute_bucket_inverted_datacell.h"
+
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <ostream>
+#include <type_traits>
+#include <utility>
+
+#include "attr/attr_type_schema.h"
+#include "datacell/attribute_inverted_interface.h"
+#include "storage/stream_reader.h"
+#include "storage/stream_writer.h"
+#include "tsl/robin_hash.h"
+#include "tsl/robin_map.h"
+#include "type_helpers.h"
+#include "vsag/attribute.h"
+#include "vsag/errors.h"
+#include "vsag_exception.h"
+
 namespace vsag {
+class MultiBitsetManager;
 
 template <class T>
 static void

--- a/src/datacell/attribute_inverted_interface.cpp
+++ b/src/datacell/attribute_inverted_interface.cpp
@@ -15,8 +15,13 @@
 
 #include "attribute_inverted_interface.h"
 
+#include <memory>
+
 #include "attribute_bucket_inverted_datacell.h"
+#include "datacell/attribute_inverted_interface_parameter.h"
+
 namespace vsag {
+class Allocator;
 
 AttrInvertedInterfacePtr
 AttributeInvertedInterface::MakeInstance(Allocator* allocator, bool have_bucket) {

--- a/src/datacell/attribute_inverted_interface_parameter.cpp
+++ b/src/datacell/attribute_inverted_interface_parameter.cpp
@@ -16,6 +16,7 @@
 #include "attribute_inverted_interface_parameter.h"
 
 #include "inner_string_params.h"
+#include "json_wrapper.h"
 #include "utils/param_compat_macros.h"
 
 namespace vsag {

--- a/src/datacell/bucket_datacell_parameter.cpp
+++ b/src/datacell/bucket_datacell_parameter.cpp
@@ -15,9 +15,12 @@
 
 #include "bucket_datacell_parameter.h"
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
+#include "common.h"
+#include "impl/logger/logger.h"
 #include "inner_string_params.h"
+#include "json_wrapper.h"
 #include "utils/param_compat_macros.h"
 
 namespace vsag {

--- a/src/datacell/bucket_interface.cpp
+++ b/src/datacell/bucket_interface.cpp
@@ -15,7 +15,7 @@
 
 #include "bucket_interface.h"
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "bucket_datacell.h"
 #include "inner_string_params.h"

--- a/src/datacell/compressed_graph_datacell.cpp
+++ b/src/datacell/compressed_graph_datacell.cpp
@@ -15,8 +15,22 @@
 
 #include "compressed_graph_datacell.h"
 
-#include "graph_datacell_parameter.h"
+#include <fmt/core.h>
+
+#include <algorithm>
+#include <atomic>
+#include <ostream>
+#include <utility>
+#include <vector>
+
+#include "datacell/compressed_graph_datacell_parameter.h"
+#include "datacell/graph_interface.h"
+#include "impl/elias_fano_encoder.h"
 #include "index_common_param.h"
+#include "storage/stream_reader.h"
+#include "storage/stream_writer.h"
+#include "vsag/allocator.h"
+#include "vsag/errors.h"
 #include "vsag_exception.h"
 
 namespace vsag {

--- a/src/datacell/compressed_graph_datacell_test.cpp
+++ b/src/datacell/compressed_graph_datacell_test.cpp
@@ -15,7 +15,7 @@
 
 #include "compressed_graph_datacell.h"
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "graph_datacell_parameter.h"
 #include "graph_interface_test.h"

--- a/src/datacell/dense_duplicate_tracker.cpp
+++ b/src/datacell/dense_duplicate_tracker.cpp
@@ -15,8 +15,13 @@
 #include "dense_duplicate_tracker.h"
 
 #include <algorithm>
+#include <mutex>
+
+#include "storage/stream_reader.h"
+#include "storage/stream_writer.h"
 
 namespace vsag {
+class Allocator;
 
 DenseDuplicateTracker::DenseDuplicateTracker(Allocator* allocator)
     : allocator_(allocator), duplicate_ids_(0, allocator_) {

--- a/src/datacell/extra_info_datacell_parameter.cpp
+++ b/src/datacell/extra_info_datacell_parameter.cpp
@@ -15,9 +15,13 @@
 
 #include "extra_info_datacell_parameter.h"
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
+#include <memory>
+
+#include "common.h"
 #include "inner_string_params.h"
+#include "json_wrapper.h"
 
 namespace vsag {
 ExtraInfoDataCellParameter::ExtraInfoDataCellParameter() = default;

--- a/src/datacell/extra_info_interface.cpp
+++ b/src/datacell/extra_info_interface.cpp
@@ -15,7 +15,7 @@
 
 #include "extra_info_interface.h"
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "extra_info_datacell.h"
 #include "inner_string_params.h"

--- a/src/datacell/flatten_datacell_parameter.cpp
+++ b/src/datacell/flatten_datacell_parameter.cpp
@@ -15,9 +15,18 @@
 
 #include "flatten_datacell_parameter.h"
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
+#include <memory>
+#include <string>
+
+#include "common.h"
+#include "datacell/flatten_interface_parameter.h"
+#include "impl/logger/logger.h"
 #include "inner_string_params.h"
+#include "io/io_parameter.h"
+#include "json_wrapper.h"
+#include "quantization/quantizer_parameter.h"
 #include "utils/param_compat_macros.h"
 
 namespace vsag {

--- a/src/datacell/flatten_interface_parameter.cpp
+++ b/src/datacell/flatten_interface_parameter.cpp
@@ -15,8 +15,11 @@
 
 #include "flatten_interface_parameter.h"
 
+#include <memory>
+
 #include "flatten_datacell_parameter.h"
 #include "inner_string_params.h"
+#include "json_wrapper.h"
 #include "multi_vector_datacell_parameter.h"
 #include "sparse_vector_datacell_parameter.h"
 

--- a/src/datacell/graph_datacell_parameter.cpp
+++ b/src/datacell/graph_datacell_parameter.cpp
@@ -15,9 +15,14 @@
 
 #include "graph_datacell_parameter.h"
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
+#include <memory>
+
+#include "common.h"
+#include "impl/logger/logger.h"
 #include "inner_string_params.h"
+#include "json_wrapper.h"
 #include "utils/param_compat_macros.h"
 #include "vsag/constants.h"
 namespace vsag {

--- a/src/datacell/graph_datacell_test.cpp
+++ b/src/datacell/graph_datacell_test.cpp
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "graph_datacell_parameter.h"
 #include "graph_interface_parameter.h"

--- a/src/datacell/graph_interface_parameter.cpp
+++ b/src/datacell/graph_interface_parameter.cpp
@@ -15,6 +15,8 @@
 
 #include "graph_interface_parameter.h"
 
+#include <memory>
+
 #include "compressed_graph_datacell_parameter.h"
 #include "graph_datacell_parameter.h"
 #include "sparse_graph_datacell_parameter.h"

--- a/src/datacell/multi_vector_datacell_parameter.h
+++ b/src/datacell/multi_vector_datacell_parameter.h
@@ -15,7 +15,7 @@
 
 #pragma once
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "flatten_interface_parameter.h"
 #include "inner_string_params.h"

--- a/src/datacell/multi_vector_datacell_test.cpp
+++ b/src/datacell/multi_vector_datacell_test.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include <cmath>
 #include <cstdint>

--- a/src/datacell/sparse_duplicate_tracker.cpp
+++ b/src/datacell/sparse_duplicate_tracker.cpp
@@ -15,8 +15,15 @@
 #include "sparse_duplicate_tracker.h"
 
 #include <algorithm>
+#include <mutex>
+
+#include "container_types.h"
+#include "storage/stream_reader.h"
+#include "storage/stream_writer.h"
+#include "tsl/robin_hash.h"
 
 namespace vsag {
+class Allocator;
 
 namespace {
 

--- a/src/datacell/sparse_graph_datacell.cpp
+++ b/src/datacell/sparse_graph_datacell.cpp
@@ -15,11 +15,28 @@
 
 #include "sparse_graph_datacell.h"
 
+#include <fmt/core.h>
+
+#include <algorithm>
+#include <atomic>
+#include <mutex>
+#include <ostream>
+#include <utility>
+#include <vector>
+
+#include "datacell/graph_interface.h"
+#include "impl/reverse_edge.h"
 #include "index_common_param.h"
 #include "sparse_graph_datacell_parameter.h"
+#include "storage/stream_reader.h"
+#include "storage/stream_writer.h"
+#include "tsl/robin_hash.h"
+#include "tsl/robin_map.h"
+#include "vsag/errors.h"
 #include "vsag_exception.h"
 
 namespace vsag {
+class Allocator;
 
 SparseGraphDataCell::SparseGraphDataCell(const SparseGraphDatacellParamPtr& graph_param,
                                          Allocator* allocator)

--- a/src/datacell/sparse_graph_datacell_parameter.cpp
+++ b/src/datacell/sparse_graph_datacell_parameter.cpp
@@ -15,6 +15,12 @@
 
 #include "sparse_graph_datacell_parameter.h"
 
+#include <memory>
+
+#include "datacell/graph_interface_parameter.h"
+#include "impl/logger/logger.h"
+#include "inner_string_params.h"
+#include "json_wrapper.h"
 #include "utils/param_compat_macros.h"
 
 namespace vsag {

--- a/src/datacell/sparse_graph_datacell_test.cpp
+++ b/src/datacell/sparse_graph_datacell_test.cpp
@@ -15,7 +15,7 @@
 
 #include "sparse_graph_datacell.h"
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "graph_interface_test.h"
 #include "impl/allocator/safe_allocator.h"

--- a/src/datacell/sparse_vector_datacell_parameter.h
+++ b/src/datacell/sparse_vector_datacell_parameter.h
@@ -15,7 +15,7 @@
 
 #pragma once
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "flatten_interface.h"
 #include "inner_string_params.h"

--- a/src/distances.cpp
+++ b/src/distances.cpp
@@ -14,7 +14,10 @@
 // limitations under the License.
 
 #include <cstdint>
+#include <limits>
+#include <memory>
 
+#include "vsag/bitset.h"
 #include "vsag/utils.h"
 
 namespace vsag {

--- a/src/factory/factory.cpp
+++ b/src/factory/factory.cpp
@@ -15,20 +15,24 @@
 
 #include "vsag/factory.h"
 
-#include <algorithm>
+#include <cxxabi.h>
+
 #include <cstdint>
-#include <exception>
 #include <fstream>
 #include <ios>
 #include <memory>
 #include <mutex>
 #include <string>
+#include <utility>
 
 #include "impl/thread_pool/safe_thread_pool.h"
 #include "vsag/engine.h"
-#include "vsag/options.h"
+#include "vsag/errors.h"
+#include "vsag/readerset.h"
+#include "vsag/resource.h"
 
 namespace vsag {
+class Allocator;
 
 tl::expected<std::shared_ptr<Index>, Error>
 Factory::CreateIndex(const std::string& origin_name,

--- a/src/factory/index_creators.cpp
+++ b/src/factory/index_creators.cpp
@@ -14,27 +14,40 @@
 
 #include "index_creators.h"
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
+#include <exception>
+#include <memory>
 #include <mutex>
+#include <new>
+#include <string>
 
 #include "algorithm/bruteforce/bruteforce.h"
 #include "algorithm/hgraph/hgraph.h"
 #include "algorithm/ivf/ivf.h"
 #include "algorithm/pyramid/pyramid.h"
-#include "algorithm/pyramid/pyramid_zparameters.h"
 #include "algorithm/sindi/sindi.h"
 #include "algorithm/sparse_index/sparse_index.h"
 #include "algorithm/warp/warp.h"
 #include "common.h"
+#include "impl/logger/logger.h"
 #include "index/diskann.h"
 #include "index/diskann_zparameters.h"
 #include "index/hnsw.h"
 #include "index/hnsw_zparameters.h"
 #include "index/index_impl.h"
 #include "index_registry.h"
+#include "json_types.h"
+#include "json_wrapper.h"
+#include "vsag/constants.h"
+#include "vsag/errors.h"
+#include "vsag/expected.hpp"
+#include "vsag_exception.h"
 
 namespace vsag {
+class Index;
+class IndexCommonParam;
+
 namespace {
 
 JsonType

--- a/src/factory/index_registry.cpp
+++ b/src/factory/index_registry.cpp
@@ -19,10 +19,12 @@
 #include <map>
 #include <mutex>
 #include <string>
-
-#include "common.h"
+#include <utility>
 
 namespace vsag {
+class Index;
+class IndexCommonParam;
+
 namespace {
 
 auto&

--- a/src/factory/resource.cpp
+++ b/src/factory/resource.cpp
@@ -19,6 +19,8 @@
 #include "impl/thread_pool/safe_thread_pool.h"
 
 namespace vsag {
+class Allocator;
+class ThreadPool;
 
 Resource::Resource() {
     this->allocator_ = SafeAllocator::FactoryDefaultAllocator();

--- a/src/impl/allocator/default_allocator.cpp
+++ b/src/impl/allocator/default_allocator.cpp
@@ -15,7 +15,9 @@
 
 #include "default_allocator.h"
 
-#include <fmt/format.h>
+#include <fmt/core.h>
+
+#include <cstdlib>
 
 #include "impl/logger/logger.h"
 #include "vsag_exception.h"

--- a/src/impl/basic_optimizer.cpp
+++ b/src/impl/basic_optimizer.cpp
@@ -15,8 +15,16 @@
 
 #include "basic_optimizer.h"
 
-#include "algorithm/inner_index_interface.h"
+#include <fmt/core.h>
+
+#include <utility>
+#include <vector>
+
+#include "impl/logger/logger.h"
+#include "impl/runtime_parameter.h"
+#include "query_context.h"
 #include "searcher/basic_searcher.h"
+#include "tsl/robin_hash.h"
 
 namespace vsag {
 

--- a/src/impl/bitset/computable_bitset.cpp
+++ b/src/impl/bitset/computable_bitset.cpp
@@ -15,11 +15,17 @@
 
 #include "computable_bitset.h"
 
+#include <memory>
+#include <ostream>
+
 #include "fast_bitset.h"
 #include "sparse_bitset.h"
+#include "vsag/errors.h"
 #include "vsag_exception.h"
 
 namespace vsag {
+class Allocator;
+
 ComputableBitsetPtr
 ComputableBitset::MakeInstance(ComputableBitsetType type, Allocator* allocator) {
     if (type == ComputableBitsetType::SparseBitset) {

--- a/src/impl/bitset/fast_bitset.cpp
+++ b/src/impl/bitset/fast_bitset.cpp
@@ -15,14 +15,22 @@
 
 #include "fast_bitset.h"
 
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
 #include <limits>
 #include <memory>
+#include <ostream>
 #include <string>
 
 #include "simd/bit_simd.h"
+#include "storage/stream_reader.h"
+#include "storage/stream_writer.h"
+#include "vsag/errors.h"
 #include "vsag_exception.h"
 
 namespace vsag {
+class ComputableBitset;
 
 static constexpr uint64_t FILL_ONE = 0xFFFFFFFFFFFFFFFF;
 // The high bit of capacity_ stores fill_bit, so serialized word count must fit in 31 bits.

--- a/src/impl/bitset/sparse_bitset.cpp
+++ b/src/impl/bitset/sparse_bitset.cpp
@@ -17,8 +17,15 @@
 
 #include <cstdint>
 #include <mutex>
+#include <utility>
+#include <vector>
+
+#include "roaring.hh"
+#include "storage/stream_reader.h"
+#include "storage/stream_writer.h"
 
 namespace vsag {
+class ComputableBitset;
 
 void
 SparseBitset::Set(int64_t pos, bool value) {

--- a/src/impl/blas/blas_function.cpp
+++ b/src/impl/blas/blas_function.cpp
@@ -17,6 +17,7 @@
 #include <omp.h>
 
 #include "blas_compat.h"
+
 namespace vsag {
 
 void

--- a/src/impl/cluster/kmeans_cluster.cpp
+++ b/src/impl/cluster/kmeans_cluster.cpp
@@ -15,19 +15,40 @@
 
 #include "kmeans_cluster.h"
 
+#include <cxxabi.h>
+#include <fmt/core.h>
 #include <omp.h>
 
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <future>
+#include <iterator>
+#include <limits>
+#include <memory>
+#include <mutex>
+#include <numeric>
+#include <ostream>
 #include <random>
+#include <utility>
+#include <vector>
 
 #include "algorithm/inner_index_interface.h"
-#include "diskann_logger.h"
 #include "impl/allocator/safe_allocator.h"
 #include "impl/blas/blas_function.h"
+#include "impl/logger/logger.h"
+#include "index_common_param.h"
+#include "metric_type.h"
 #include "simd/amx_bf16_matmul.h"
 #include "simd/fp32_simd.h"
 #include "simd/simd_status.h"
 #include "utils/byte_buffer.h"
 #include "utils/util_functions.h"
+#include "vsag/allocator.h"
+#include "vsag/dataset.h"
+#include "vsag/errors.h"
+#include "vsag/filter.h"
+#include "vsag_exception.h"
 
 namespace vsag {
 KMeansCluster::KMeansCluster(int32_t dim, Allocator* allocator, SafeThreadPoolPtr thread_pool)

--- a/src/impl/conjugate_graph.cpp
+++ b/src/impl/conjugate_graph.cpp
@@ -15,9 +15,25 @@
 
 #include "conjugate_graph.h"
 
+#include <fmt/core.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <istream>
+#include <stdexcept>
+#include <string>
+
+#include "container_types.h"
+#include "storage/stream_reader.h"
+#include "tsl/robin_hash.h"
+#include "tsl/robin_set.h"
+#include "vsag/binaryset.h"
+#include "vsag/errors.h"
 #include "vsag_exception.h"
 
 namespace vsag {
+class Allocator;
 
 ConjugateGraph::ConjugateGraph(Allocator* allocator)
     : allocator_(allocator), conjugate_graph_(allocator) {

--- a/src/impl/elias_fano_encoder.cpp
+++ b/src/impl/elias_fano_encoder.cpp
@@ -15,9 +15,11 @@
 
 #include "elias_fano_encoder.h"
 
+#include <algorithm>
 #include <cmath>
 #include <iostream>
 
+#include "vsag/errors.h"
 #include "vsag_exception.h"
 
 namespace vsag {

--- a/src/impl/heap/distance_heap.cpp
+++ b/src/impl/heap/distance_heap.cpp
@@ -15,10 +15,14 @@
 
 #include "distance_heap.h"
 
+#include <memory>
+
 #include "memmove_heap.h"
 #include "standard_heap.h"
 
 namespace vsag {
+class Allocator;
+
 template <bool max_heap, bool fixed_size>
 DistHeapPtr
 DistanceHeap::MakeInstanceBySize(Allocator* allocator, int64_t max_size) {

--- a/src/impl/heap/memmove_heap.cpp
+++ b/src/impl/heap/memmove_heap.cpp
@@ -15,8 +15,17 @@
 
 #include "memmove_heap.h"
 
+#include <algorithm>
 #include <cstring>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "impl/heap/distance_heap.h"
+
 namespace vsag {
+class Allocator;
+
 template <bool max_heap, bool fixed_size>
 MemmoveHeap<max_heap, fixed_size>::MemmoveHeap(Allocator* allocator, int64_t max_size)
     : DistanceHeap(allocator, max_size), ordered_buffer_(allocator) {

--- a/src/impl/heap/standard_heap.cpp
+++ b/src/impl/heap/standard_heap.cpp
@@ -15,7 +15,14 @@
 
 #include "standard_heap.h"
 
+#include <memory>
+#include <utility>
+
+#include "impl/heap/distance_heap.h"
+
 namespace vsag {
+class Allocator;
+
 template <bool max_heap, bool fixed_size>
 StandardHeap<max_heap, fixed_size>::StandardHeap(Allocator* allocator, int64_t max_size)
     : DistanceHeap(allocator, max_size), queue_(allocator) {

--- a/src/impl/label_table/label_remap.cpp
+++ b/src/impl/label_table/label_remap.cpp
@@ -16,6 +16,7 @@
 #include "label_remap.h"
 
 namespace vsag {
+class Allocator;
 
 /**
  * @brief LabelRemap constructor implementation

--- a/src/impl/label_table/label_table.cpp
+++ b/src/impl/label_table/label_table.cpp
@@ -15,7 +15,13 @@
 
 #include "label_table.h"
 
+#include <cstdint>
+
+#include "impl/label_table/label_remap.h"
+#include "vsag/filter.h"
+
 namespace vsag {
+class Allocator;
 
 class RemoveListFilter : public Filter {
 public:

--- a/src/impl/label_table/label_table.h
+++ b/src/impl/label_table/label_table.h
@@ -15,7 +15,7 @@
 
 #pragma once
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 #include <vsag/filter.h>
 
 #include <atomic>

--- a/src/impl/logger/logger.cpp
+++ b/src/impl/logger/logger.cpp
@@ -15,6 +15,8 @@
 
 #include "logger.h"
 
+#include "vsag/options.h"
+
 namespace vsag ::logger {
 void
 set_level(level log_level) {

--- a/src/impl/logger/logger.h
+++ b/src/impl/logger/logger.h
@@ -15,7 +15,7 @@
 
 #pragma once
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "vsag/logger.h"
 #include "vsag/options.h"

--- a/src/impl/odescent/odescent_graph_builder.cpp
+++ b/src/impl/odescent/odescent_graph_builder.cpp
@@ -15,11 +15,19 @@
 
 #include "odescent_graph_builder.h"
 
-#include <chrono>
-#include <ios>
+#include <cxxabi.h>
 
-#include "simd/simd.h"
+#include <algorithm>
+#include <cstdint>
+#include <future>
+
+#include "impl/odescent/odescent_graph_parameter.h"
+#include "impl/thread_pool/safe_thread_pool.h"
+#include "tsl/robin_hash.h"
+#include "tsl/robin_set.h"
 #include "utils/linear_congruential_generator.h"
+#include "vsag/errors.h"
+#include "vsag_exception.h"
 
 namespace vsag {
 

--- a/src/impl/odescent/odescent_graph_parameter.cpp
+++ b/src/impl/odescent/odescent_graph_parameter.cpp
@@ -15,8 +15,12 @@
 
 #include "odescent_graph_parameter.h"
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
+#include <memory>
+
+#include "common.h"
+#include "json_wrapper.h"
 #include "vsag/constants.h"
 
 namespace vsag {

--- a/src/impl/reasoning/search_reasoning.cpp
+++ b/src/impl/reasoning/search_reasoning.cpp
@@ -14,7 +14,17 @@
 
 #include "search_reasoning.h"
 
+#include <utility>
+#include <vector>
+
+#include "impl/allocator/allocator_wrapper.h"
+#include "json_types.h"
+#include "json_wrapper.h"
+#include "tsl/robin_hash.h"
+#include "tsl/robin_map.h"
+
 namespace vsag {
+class Allocator;
 
 ReasoningContext::ReasoningContext(Allocator* allocator)
     : allocator_(allocator),

--- a/src/impl/reorder/flatten_reorder.cpp
+++ b/src/impl/reorder/flatten_reorder.cpp
@@ -18,14 +18,23 @@
 #include <algorithm>
 #include <cmath>
 #include <limits>
+#include <memory>
 #include <numeric>
+#include <utility>
+#include <vector>
 
+#include "basic_types.h"
+#include "container_types.h"
 #include "datacell/flatten_interface.h"
+#include "hash_types.h"
 #include "impl/heap/standard_heap.h"
 #include "impl/reasoning/search_reasoning.h"
+#include "index/iterator_filter.h"
 #include "query_context.h"
+#include "tsl/robin_hash.h"
 
 namespace vsag {
+class Allocator;
 
 DistHeapPtr
 FlattenReorder::Reorder(const vsag::DistHeapPtr& input,

--- a/src/impl/reverse_edge.cpp
+++ b/src/impl/reverse_edge.cpp
@@ -14,6 +14,13 @@
 
 #include "reverse_edge.h"
 
+#include <mutex>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "tsl/robin_hash.h"
+
 namespace vsag {
 
 void

--- a/src/impl/searcher/basic_searcher.cpp
+++ b/src/impl/searcher/basic_searcher.cpp
@@ -15,19 +15,29 @@
 
 #include "basic_searcher.h"
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
-#include <cstring>
+#include <cstdint>
 #include <limits>
+#include <vector>
 
-#include "algorithm/inner_index_interface.h"
+#include "attr/executor/executor.h"
 #include "datacell/flatten_interface.h"
 #include "impl/heap/standard_heap.h"
 #include "impl/reasoning/search_reasoning.h"
+#include "index/iterator_filter.h"
+#include "index_common_param.h"
+#include "query_context.h"
+#include "tsl/robin_hash.h"
 #include "utils/filter_search_skip_strategy.h"
-#include "vsag/allocator.h"
+#include "utils/resource_object_pool.h"
+#include "utils/timer.h"
+#include "vsag/constants.h"
+#include "vsag/filter.h"
 
 namespace vsag {
+class Allocator;
 
 BasicSearcher::BasicSearcher(const IndexCommonParam& common_param, MutexArrayPtr mutex_array)
     : allocator_(common_param.allocator_.get()), mutex_array_(std::move(mutex_array)) {

--- a/src/impl/searcher/parallel_searcher.cpp
+++ b/src/impl/searcher/parallel_searcher.cpp
@@ -15,6 +15,8 @@
 
 #include "parallel_searcher.h"
 
+#include <cxxabi.h>
+
 #include <atomic>
 #include <future>
 #include <limits>
@@ -22,12 +24,19 @@
 #include <utility>
 #include <vector>
 
+#include "attr/executor/executor.h"
 #include "datacell/flatten_interface.h"
 #include "impl/heap/standard_heap.h"
+#include "impl/searcher/basic_searcher.h"
+#include "index_common_param.h"
+#include "query_context.h"
 #include "utils/filter_search_skip_strategy.h"
 #include "utils/spsc_queue.h"
+#include "vsag/filter.h"
 
 namespace vsag {
+class Allocator;
+class SafeThreadPool;
 
 ParallelSearcher::ParallelSearcher(const IndexCommonParam& common_param,
                                    std::shared_ptr<SafeThreadPool> search_pool,

--- a/src/impl/thread_pool/default_thread_pool.cpp
+++ b/src/impl/thread_pool/default_thread_pool.cpp
@@ -15,7 +15,7 @@
 
 #include "default_thread_pool.h"
 
-#include "vsag/options.h"
+#include <ThreadPool.h>
 
 namespace vsag {
 

--- a/src/impl/transform/fht_kac_rotate_transformer.cpp
+++ b/src/impl/transform/fht_kac_rotate_transformer.cpp
@@ -15,11 +15,19 @@
 
 #include "fht_kac_rotate_transformer.h"
 
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <memory>
 #include <random>
 
+#include "impl/transform/vector_transformer.h"
 #include "simd/rabitq_simd.h"
+#include "storage/stream_reader.h"
+#include "storage/stream_writer.h"
 
 namespace vsag {
+class Allocator;
 
 inline uint64_t
 floor_log2(uint64_t x) {  //smaller or equal

--- a/src/impl/transform/pca_transformer.cpp
+++ b/src/impl/transform/pca_transformer.cpp
@@ -15,14 +15,23 @@
 
 #include "pca_transformer.h"
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
-#include <random>
+#include <memory>
+#include <ostream>
+#include <vector>
 
 #include "impl/blas/blas_function.h"
+#include "impl/logger/logger.h"
+#include "impl/transform/vector_transformer.h"
+#include "storage/stream_reader.h"
+#include "storage/stream_writer.h"
+#include "vsag/errors.h"
 #include "vsag_exception.h"
 
 namespace vsag {
+class Allocator;
+
 PCATransformer::PCATransformer(Allocator* allocator, int64_t input_dim, int64_t output_dim)
     : VectorTransformer(allocator, input_dim, output_dim),
       pca_matrix_(allocator),

--- a/src/impl/transform/random_orthogonal_transformer.cpp
+++ b/src/impl/transform/random_orthogonal_transformer.cpp
@@ -14,14 +14,23 @@
 
 #include "random_orthogonal_transformer.h"
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
+#include <algorithm>
+#include <cmath>
+#include <memory>
 #include <random>
+#include <vector>
 
 #include "impl/blas/blas_function.h"
 #include "impl/logger/logger.h"
+#include "impl/transform/vector_transformer.h"
+#include "storage/stream_reader.h"
+#include "storage/stream_writer.h"
 
 namespace vsag {
+class Allocator;
+
 RandomOrthogonalMatrix::RandomOrthogonalMatrix(Allocator* allocator, int64_t dim, uint64_t retries)
     : VectorTransformer(allocator, dim), orthogonal_matrix_(allocator), generate_retries_(retries) {
     orthogonal_matrix_.resize(dim * dim);

--- a/src/impl/transform/vector_transformer.cpp
+++ b/src/impl/transform/vector_transformer.cpp
@@ -15,6 +15,9 @@
 
 #include "vector_transformer.h"
 
+#include <ostream>
+
+#include "vsag/errors.h"
 #include "vsag_exception.h"
 
 namespace vsag {

--- a/src/impl/transform/vector_transformer_parameter.cpp
+++ b/src/impl/transform/vector_transformer_parameter.cpp
@@ -15,7 +15,11 @@
 
 #include "vector_transformer_parameter.h"
 
+#include <memory>
+
+#include "impl/logger/logger.h"
 #include "inner_string_params.h"
+#include "json_wrapper.h"
 #include "utils/param_compat_macros.h"
 
 namespace vsag {

--- a/src/impl/transform/vector_transformer_parameter_test.cpp
+++ b/src/impl/transform/vector_transformer_parameter_test.cpp
@@ -15,7 +15,7 @@
 
 #include "vector_transformer_parameter.h"
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "inner_string_params.h"
 #include "parameter_test.h"

--- a/src/index/diskann.cpp
+++ b/src/index/diskann.cpp
@@ -15,33 +15,58 @@
 
 #include "diskann.h"
 
+#include <cxxabi.h>
+#include <fmt/core.h>
 #include <local_file_reader.h>
 
-#include <exception>
+#include <algorithm>
+#include <atomic>
+#include <cstdint>
+#include <cstring>
 #include <functional>
 #include <future>
 #include <iterator>
 #include <memory>
 #include <new>
-#include <nlohmann/json.hpp>
+#include <sstream>
 #include <stdexcept>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
-#include "datacell/flatten_datacell.h"
+#include "datacell/flatten_datacell_parameter.h"
+#include "datacell/flatten_interface.h"
 #include "dataset_impl.h"
+#include "disk_utils.h"
+#include "impl/logger/logger.h"
 #include "impl/odescent/odescent_graph_builder.h"
+#include "impl/odescent/odescent_graph_parameter.h"
+#include "impl/thread_pool/safe_thread_pool.h"
+#include "index.h"
+#include "index/diskann_zparameters.h"
+#include "io/io_parameter.h"
 #include "io/memory_io_parameter.h"
+#include "json_types.h"
+#include "json_wrapper.h"
+#include "parameters.h"
+#include "percentile_stats.h"
+#include "pq.h"
+#include "pq_flash_index.h"
 #include "quantization/fp32_quantizer_parameter.h"
+#include "quantization/quantizer_parameter.h"
 #include "storage/empty_index_binary_set.h"
 #include "storage/serialization.h"
+#include "storage/stream_reader.h"
+#include "storage/stream_writer.h"
 #include "utils/slow_task_timer.h"
 #include "utils/timer.h"
 #include "vsag/constants.h"
 #include "vsag/errors.h"
 #include "vsag/expected.hpp"
 #include "vsag/index.h"
+#include "vsag/options.h"
 #include "vsag/readerset.h"
+#include "vsag_exception.h"
 
 namespace vsag {
 

--- a/src/index/diskann_zparameters.cpp
+++ b/src/index/diskann_zparameters.cpp
@@ -15,12 +15,17 @@
 
 #include "diskann_zparameters.h"
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "common.h"
+#include "data_type.h"
+#include "distance.h"
 #include "index_common_param.h"
 #include "inner_string_params.h"
+#include "json_wrapper.h"
+#include "metric_type.h"
 #include "vsag/constants.h"
+#include "vsag/errors.h"
 #include "vsag_exception.h"
 // NOLINTBEGIN(readability-simplify-boolean-expr)
 

--- a/src/index/hnsw.cpp
+++ b/src/index/hnsw.cpp
@@ -15,38 +15,57 @@
 
 #include "hnsw.h"
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
+#include <algorithm>
+#include <cmath>
 #include <cstdint>
-#include <exception>
+#include <cstdlib>
+#include <cstring>
 #include <memory>
 #include <new>
-#include <nlohmann/json.hpp>
+#include <queue>
 #include <stdexcept>
+#include <tuple>
+#include <type_traits>
 
-#include "algorithm/hnswlib/hnswlib.h"
+#include "algorithm/hnswlib/algorithm_interface.h"
+#include "algorithm/hnswlib/hnswalg.h"
 #include "common.h"
-#include "datacell/flatten_datacell.h"
+#include "datacell/flatten_datacell_parameter.h"
 #include "datacell/graph_datacell_parameter.h"
-#include "impl/allocator/safe_allocator.h"
+#include "impl/conjugate_graph.h"
+#include "impl/logger/logger.h"
 #include "impl/odescent/odescent_graph_builder.h"
+#include "impl/odescent/odescent_graph_parameter.h"
 #include "index/hnsw_zparameters.h"
+#include "index/iterator_filter.h"
 #include "index_detail_data.h"
+#include "io/io_parameter.h"
 #include "io/memory_block_io_parameter.h"
+#include "json_types.h"
+#include "json_wrapper.h"
 #include "quantization/fp32_quantizer_parameter.h"
+#include "quantization/quantizer_parameter.h"
 #include "storage/empty_index_binary_set.h"
 #include "storage/serialization.h"
+#include "storage/stream_reader.h"
 #include "storage/stream_writer.h"
 #include "utils/slow_task_timer.h"
 #include "utils/timer.h"
 #include "utils/util_functions.h"
+#include "vsag/allocator.h"
 #include "vsag/binaryset.h"
 #include "vsag/constants.h"
 #include "vsag/errors.h"
 #include "vsag/expected.hpp"
 #include "vsag/options.h"
+#include "vsag/readerset.h"
+#include "vsag_exception.h"
 
 namespace vsag {
+class BlackListFilter;
+class IteratorContext;
 
 static const std::string EMPTY_HNSW = "EMPTY_HNSW";
 

--- a/src/index/hnsw_zparameters.cpp
+++ b/src/index/hnsw_zparameters.cpp
@@ -15,9 +15,18 @@
 
 #include "hnsw_zparameters.h"
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
+#include <algorithm>
+
+#include "algorithm/hnswlib/space_ip.h"
+#include "algorithm/hnswlib/space_l2.h"
+#include "common.h"
+#include "index_common_param.h"
+#include "json_wrapper.h"
+#include "metric_type.h"
 #include "vsag/constants.h"
+#include "vsag/errors.h"
 #include "vsag_exception.h"
 
 namespace vsag {

--- a/src/index/iterator_filter.cpp
+++ b/src/index/iterator_filter.cpp
@@ -15,8 +15,13 @@
 
 #include "iterator_filter.h"
 
-#include "impl/logger/logger.h"
+#include <cstring>
+#include <new>
+#include <queue>
+
 #include "utils/util_functions.h"
+#include "vsag/allocator.h"
+#include "vsag/errors.h"
 
 namespace vsag {
 

--- a/src/index_common_param.cpp
+++ b/src/index_common_param.cpp
@@ -14,13 +14,19 @@
 
 #include "index_common_param.h"
 
-#include <fmt/format.h>
+#include <fmt/core.h>
+
+#include <string>
 
 #include "common.h"
+#include "json_wrapper.h"
 #include "vsag/constants.h"
+#include "vsag/errors.h"
 #include "vsag/resource.h"
+#include "vsag_exception.h"
 
 namespace vsag {
+class SafeThreadPool;
 
 static constexpr const int64_t MAX_DIM_SPARSE = 4096;
 

--- a/src/index_feature_list.cpp
+++ b/src/index_feature_list.cpp
@@ -15,10 +15,12 @@
 
 #include "index_feature_list.h"
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
-#include <stdexcept>
+#include <ostream>
+#include <utility>
 
+#include "vsag/errors.h"
 #include "vsag_exception.h"
 
 namespace vsag {

--- a/src/io/async_io.cpp
+++ b/src/io/async_io.cpp
@@ -18,15 +18,33 @@
 #include "async_io.h"
 
 #include <fcntl.h>
+#include <fmt/core.h>
+#include <libaio.h>
 #include <unistd.h>
 
+#include <algorithm>
+#include <cerrno>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
 #include <filesystem>
+#include <ostream>
+#include <utility>
+#include <vector>
 
 #include "direct_io_object.h"
+#include "index_common_param.h"
+#include "io/async_io_parameter.h"
+#include "io/basic_io.h"
 #include "io_context.h"
 #include "io_syscall.h"
+#include "utils/resource_object_pool.h"
+#include "vsag/errors.h"
+#include "vsag/options.h"
+#include "vsag_exception.h"
 
 namespace vsag {
+class Allocator;
 
 std::unique_ptr<IOContextPool> AsyncIO::io_context_pool =
     std::make_unique<IOContextPool>(10, nullptr);

--- a/src/io/async_io_parameter.cpp
+++ b/src/io/async_io_parameter.cpp
@@ -15,7 +15,10 @@
 
 #include "async_io_parameter.h"
 
+#include "common.h"
 #include "inner_string_params.h"
+#include "io/io_parameter.h"
+#include "json_wrapper.h"
 
 namespace vsag {
 

--- a/src/io/async_io_parameter_test.cpp
+++ b/src/io/async_io_parameter_test.cpp
@@ -15,7 +15,7 @@
 
 #include "async_io_parameter.h"
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "parameter_test.h"
 #include "unittest.h"

--- a/src/io/basic_io.h
+++ b/src/io/basic_io.h
@@ -15,7 +15,7 @@
 
 #pragma once
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include <cstdint>
 

--- a/src/io/buffer_io.cpp
+++ b/src/io/buffer_io.cpp
@@ -15,12 +15,23 @@
 #include "buffer_io.h"
 
 #include <fcntl.h>
+#include <fmt/core.h>
 #include <unistd.h>
 
+#include <cerrno>
+#include <cstring>
 #include <filesystem>
+#include <memory>
+#include <ostream>
+#include <utility>
 
 #include "index_common_param.h"
+#include "io/basic_io.h"
+#include "io/buffer_io_parameter.h"
 #include "io_syscall.h"
+#include "vsag/allocator.h"
+#include "vsag/errors.h"
+#include "vsag_exception.h"
 
 namespace vsag {
 

--- a/src/io/buffer_io_parameter.cpp
+++ b/src/io/buffer_io_parameter.cpp
@@ -15,7 +15,10 @@
 
 #include "buffer_io_parameter.h"
 
+#include "common.h"
 #include "inner_string_params.h"
+#include "io/io_parameter.h"
+#include "json_wrapper.h"
 
 namespace vsag {
 

--- a/src/io/buffer_io_parameter_test.cpp
+++ b/src/io/buffer_io_parameter_test.cpp
@@ -15,7 +15,7 @@
 
 #include "buffer_io_parameter.h"
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "parameter_test.h"
 #include "unittest.h"

--- a/src/io/io_parameter.cpp
+++ b/src/io/io_parameter.cpp
@@ -15,7 +15,10 @@
 
 #include "io_parameter.h"
 
+#include <memory>
 #include <mutex>
+#include <stdexcept>
+#include <utility>
 
 #include "async_io_parameter.h"
 #include "buffer_io_parameter.h"

--- a/src/io/memory_block_io.cpp
+++ b/src/io/memory_block_io.cpp
@@ -17,11 +17,16 @@
 
 #include <algorithm>
 #include <cstring>
+#include <memory>
+#include <ostream>
+#include <vector>
 
-#include "common.h"
 #include "index_common_param.h"
-#include "inner_string_params.h"
+#include "io/basic_io.h"
+#include "io/memory_block_io_parameter.h"
 #include "utils/prefetch.h"
+#include "vsag/errors.h"
+#include "vsag_exception.h"
 
 namespace vsag {
 

--- a/src/io/memory_block_io_parameter.cpp
+++ b/src/io/memory_block_io_parameter.cpp
@@ -15,7 +15,11 @@
 
 #include "memory_block_io_parameter.h"
 
+#include <string>
+
 #include "inner_string_params.h"
+#include "io/io_parameter.h"
+#include "json_wrapper.h"
 #include "vsag/options.h"
 
 namespace vsag {

--- a/src/io/memory_io.cpp
+++ b/src/io/memory_io.cpp
@@ -15,6 +15,10 @@
 
 #include "memory_io.h"
 
+#include <cstring>
+
+#include "utils/prefetch.h"
+
 namespace vsag {
 
 void

--- a/src/io/memory_io_parameter.cpp
+++ b/src/io/memory_io_parameter.cpp
@@ -15,7 +15,11 @@
 
 #include "memory_io_parameter.h"
 
+#include <string>
+
 #include "inner_string_params.h"
+#include "io/io_parameter.h"
+#include "json_wrapper.h"
 
 namespace vsag {
 

--- a/src/io/mmap_io.cpp
+++ b/src/io/mmap_io.cpp
@@ -16,16 +16,25 @@
 #include "mmap_io.h"
 
 #include <fcntl.h>
+#include <fmt/core.h>
 #include <sys/mman.h>
 #include <unistd.h>
 
+#include <algorithm>
 #include <cerrno>
+#include <cstring>
 #include <filesystem>
+#include <memory>
+#include <ostream>
 #include <system_error>
 #include <utility>
 
 #include "index_common_param.h"
+#include "io/basic_io.h"
+#include "io/mmap_io_parameter.h"
 #include "io_syscall.h"
+#include "vsag/errors.h"
+#include "vsag_exception.h"
 
 namespace vsag {
 

--- a/src/io/mmap_io_parameter.cpp
+++ b/src/io/mmap_io_parameter.cpp
@@ -15,7 +15,10 @@
 
 #include "mmap_io_parameter.h"
 
+#include "common.h"
 #include "inner_string_params.h"
+#include "io/io_parameter.h"
+#include "json_wrapper.h"
 
 namespace vsag {
 

--- a/src/io/mmap_io_parameter_test.cpp
+++ b/src/io/mmap_io_parameter_test.cpp
@@ -15,7 +15,7 @@
 
 #include "mmap_io_parameter.h"
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "parameter_test.h"
 #include "unittest.h"

--- a/src/io/reader_io.cpp
+++ b/src/io/reader_io.cpp
@@ -14,11 +14,17 @@
 
 #include "reader_io.h"
 
-#include <fmt/format.h>
-
-#include <future>
+#include <cstdint>
+#include <ostream>
+#include <vector>
 
 #include "index_common_param.h"
+#include "io/basic_io.h"
+#include "io/reader_io_parameter.h"
+#include "vsag/allocator.h"
+#include "vsag/errors.h"
+#include "vsag/readerset.h"
+#include "vsag_exception.h"
 
 namespace vsag {
 

--- a/src/json_wrapper.cpp
+++ b/src/json_wrapper.cpp
@@ -15,6 +15,7 @@
 
 #include "json_wrapper.h"
 
+#include <cstdint>
 #include <nlohmann/json.hpp>
 
 namespace vsag {

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -15,11 +15,16 @@
 
 #include "vsag/options.h"
 
-#include <fmt/format.h>
+#include <fmt/core.h>
+
+#include <memory>
 
 #include "impl/logger/default_logger.h"
+#include "vsag/errors.h"
 #include "vsag_exception.h"
+
 namespace vsag {
+class Logger;
 
 Options&
 Options::Instance() {

--- a/src/parameter_check.cpp
+++ b/src/parameter_check.cpp
@@ -13,16 +13,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <stdexcept>
+#include <fmt/core.h>
+
+#include <exception>
+#include <memory>
+#include <string>
 
 #include "factory/resource_owner_wrapper.h"
 #include "index/diskann_zparameters.h"
 #include "index/hnsw_zparameters.h"
+#include "index_common_param.h"
+#include "json_types.h"
+#include "json_wrapper.h"
 #include "utils/util_functions.h"
 #include "vsag/constants.h"
 #include "vsag/errors.h"
 #include "vsag/expected.hpp"
 #include "vsag/index.h"
+#include "vsag/resource.h"
 #include "vsag_exception.h"
 
 namespace vsag {

--- a/src/parameter_generator.cpp
+++ b/src/parameter_generator.cpp
@@ -13,17 +13,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <fmt/core.h>
+
 #include <algorithm>
+#include <cctype>
 #include <cmath>
-#include <sstream>
+#include <cstdint>
+#include <exception>
+#include <string>
 
 #include "impl/logger/logger.h"
 #include "index/hnsw_zparameters.h"
 #include "utils/number.h"
 #include "utils/util_functions.h"
+#include "vsag/constants.h"
 #include "vsag/errors.h"
 #include "vsag/expected.hpp"
 #include "vsag/index.h"
+#include "vsag_exception.h"
 
 namespace vsag {
 

--- a/src/quantization/fp32_quantizer.cpp
+++ b/src/quantization/fp32_quantizer.cpp
@@ -15,9 +15,21 @@
 
 #include "fp32_quantizer.h"
 
+#include <cmath>
+#include <cstring>
+#include <memory>
+#include <new>
+#include <ostream>
+
+#include "index_common_param.h"
+#include "quantization/computer.h"
+#include "quantization/fp32_quantizer_parameter.h"
+#include "quantization/quantizer.h"
 #include "simd/fp32_simd.h"
 #include "simd/normalize.h"
-#include "simd/simd.h"
+#include "vsag/allocator.h"
+#include "vsag/errors.h"
+#include "vsag_exception.h"
 
 namespace vsag {
 

--- a/src/quantization/fp32_quantizer_parameter.cpp
+++ b/src/quantization/fp32_quantizer_parameter.cpp
@@ -15,7 +15,11 @@
 
 #include "fp32_quantizer_parameter.h"
 
+#include <string>
+
 #include "inner_string_params.h"
+#include "json_wrapper.h"
+#include "quantization/quantizer_parameter.h"
 
 namespace vsag {
 FP32QuantizerParameter::FP32QuantizerParameter()

--- a/src/quantization/int8_quantizer.cpp
+++ b/src/quantization/int8_quantizer.cpp
@@ -15,17 +15,22 @@
 
 #include "quantization/int8_quantizer.h"
 
+#include <algorithm>
 #include <cmath>
 #include <cstdint>
 #include <cstring>
 #include <memory>
 #include <new>
+#include <ostream>
 
+#include "index_common_param.h"
 #include "metric_type.h"
 #include "quantization/computer.h"
 #include "quantization/int8_quantizer_parameter.h"
 #include "quantization/quantizer.h"
 #include "simd/int8_simd.h"
+#include "vsag/allocator.h"
+#include "vsag/errors.h"
 #include "vsag_exception.h"
 
 namespace vsag {

--- a/src/quantization/int8_quantizer_parameter.cpp
+++ b/src/quantization/int8_quantizer_parameter.cpp
@@ -15,7 +15,11 @@
 
 #include "int8_quantizer_parameter.h"
 
+#include <string>
+
 #include "inner_string_params.h"
+#include "json_wrapper.h"
+#include "quantization/quantizer_parameter.h"
 
 namespace vsag {
 INT8QuantizerParameter::INT8QuantizerParameter()

--- a/src/quantization/multi_vector_computer.cpp
+++ b/src/quantization/multi_vector_computer.cpp
@@ -15,14 +15,17 @@
 
 #include "multi_vector_computer.h"
 
-#include <algorithm>
 #include <cstring>
 #include <limits>
+#include <new>
+#include <ostream>
 
 #include "simd/fp32_simd.h"
+#include "vsag/errors.h"
 #include "vsag_exception.h"
 
 namespace vsag {
+class Allocator;
 
 MultiVectorComputer::MultiVectorComputer(uint32_t dim, MetricType metric, Allocator* allocator)
     : dim_(dim), metric_(metric), allocator_(allocator), query_tokens_(allocator) {

--- a/src/quantization/product_quantization/pq_fastscan_quantizer.cpp
+++ b/src/quantization/product_quantization/pq_fastscan_quantizer.cpp
@@ -15,16 +15,30 @@
 
 #include "pq_fastscan_quantizer.h"
 
+#include <fmt/core.h>
+
+#include <algorithm>
+#include <cstring>
+#include <limits>
+#include <memory>
+#include <new>
+#include <ostream>
+
 #include "impl/blas/blas_function.h"
 #include "impl/cluster/kmeans_cluster.h"
 #include "index_common_param.h"
 #include "pq_fastscan_quantizer_parameter.h"
+#include "quantization/computer.h"
 #include "quantization/quantizer.h"
 #include "quantization/scalar_quantization/scalar_quantization_trainer.h"
 #include "simd/fp32_simd.h"
 #include "simd/normalize.h"
 #include "simd/pqfs_simd.h"
-#include "utils/prefetch.h"
+#include "storage/stream_reader.h"
+#include "storage/stream_writer.h"
+#include "vsag/allocator.h"
+#include "vsag/errors.h"
+#include "vsag_exception.h"
 
 namespace vsag {
 

--- a/src/quantization/product_quantization/pq_fastscan_quantizer_parameter.cpp
+++ b/src/quantization/product_quantization/pq_fastscan_quantizer_parameter.cpp
@@ -15,7 +15,12 @@
 
 #include "pq_fastscan_quantizer_parameter.h"
 
+#include <memory>
+#include <string>
+
+#include "impl/logger/logger.h"
 #include "inner_string_params.h"
+#include "json_wrapper.h"
 #include "utils/param_compat_macros.h"
 
 namespace vsag {

--- a/src/quantization/product_quantization/product_quantizer.cpp
+++ b/src/quantization/product_quantization/product_quantizer.cpp
@@ -15,11 +15,27 @@
 
 #include "product_quantizer.h"
 
+#include <fmt/core.h>
+
+#include <algorithm>
+#include <cstring>
+#include <limits>
+#include <memory>
+#include <new>
+#include <ostream>
+
 #include "impl/blas/blas_function.h"
 #include "impl/cluster/kmeans_cluster.h"
+#include "index_common_param.h"
+#include "quantization/computer.h"
+#include "quantization/product_quantization/product_quantizer_parameter.h"
 #include "simd/fp32_simd.h"
 #include "simd/normalize.h"
-#include "utils/prefetch.h"
+#include "storage/stream_reader.h"
+#include "storage/stream_writer.h"
+#include "vsag/allocator.h"
+#include "vsag/errors.h"
+#include "vsag_exception.h"
 
 namespace vsag {
 

--- a/src/quantization/product_quantization/product_quantizer_parameter.cpp
+++ b/src/quantization/product_quantization/product_quantizer_parameter.cpp
@@ -15,7 +15,12 @@
 
 #include "product_quantizer_parameter.h"
 
+#include <memory>
+#include <string>
+
+#include "impl/logger/logger.h"
 #include "inner_string_params.h"
+#include "json_wrapper.h"
 #include "utils/param_compat_macros.h"
 
 namespace vsag {

--- a/src/quantization/quantizer_adapter.cpp
+++ b/src/quantization/quantizer_adapter.cpp
@@ -19,13 +19,18 @@
 #include <memory>
 #include <type_traits>
 
+#include "container_types.h"
+#include "index_common_param.h"
 #include "quantization/computer.h"
 #include "quantization/quantizer.h"
 #include "quantization/scalar_quantization/half_precision_quantizer.h"
 #include "simd/bf16_simd.h"
 #include "simd/fp16_simd.h"
+#include "vsag/allocator.h"
 
 namespace vsag {
+class StreamReader;
+class StreamWriter;
 
 using generic::BF16ToFloat;
 using generic::FloatToBF16;

--- a/src/quantization/quantizer_parameter.cpp
+++ b/src/quantization/quantizer_parameter.cpp
@@ -15,7 +15,7 @@
 
 #include "quantizer_parameter.h"
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include <unordered_set>
 

--- a/src/quantization/rabitq_quantization/rabitq_quantizer_parameter.cpp
+++ b/src/quantization/rabitq_quantization/rabitq_quantizer_parameter.cpp
@@ -15,10 +15,17 @@
 
 #include "rabitq_quantizer_parameter.h"
 
+#include <fmt/core.h>
+
 #include <cmath>
+#include <memory>
+#include <ostream>
 
 #include "inner_string_params.h"
+#include "json_wrapper.h"
 #include "utils/param_compat_macros.h"
+#include "vsag/errors.h"
+#include "vsag_exception.h"
 
 namespace vsag {
 

--- a/src/quantization/rabitq_quantization/rabitq_quantizer_parameter_test.cpp
+++ b/src/quantization/rabitq_quantization/rabitq_quantizer_parameter_test.cpp
@@ -15,7 +15,7 @@
 
 #include "rabitq_quantizer_parameter.h"
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include <cmath>
 

--- a/src/quantization/scalar_quantization/half_precision_quantizer.cpp
+++ b/src/quantization/scalar_quantization/half_precision_quantizer.cpp
@@ -14,11 +14,22 @@
 
 #include "half_precision_quantizer.h"
 
+#include <memory>
+#include <new>
+#include <ostream>
+
+#include "container_types.h"
+#include "index_common_param.h"
+#include "quantization/computer.h"
+#include "quantization/scalar_quantization/half_precision_traits.h"
 #include "simd/normalize.h"
-#include "typing.h"
+#include "vsag/allocator.h"
+#include "vsag/errors.h"
 #include "vsag_exception.h"
 
 namespace vsag {
+template <typename Format>
+class HalfPrecisionQuantizerParameter;
 
 template <typename Format, MetricType metric>
 HalfPrecisionQuantizer<Format, metric>::HalfPrecisionQuantizer(int dim, Allocator* allocator)

--- a/src/quantization/scalar_quantization/scalar_quantization_trainer.cpp
+++ b/src/quantization/scalar_quantization/scalar_quantization_trainer.cpp
@@ -15,9 +15,12 @@
 
 #include "scalar_quantization_trainer.h"
 
+#include <algorithm>
 #include <cstring>
+#include <functional>
+#include <limits>
 #include <queue>
-#include <random>
+#include <utility>
 
 #include "simd/normalize.h"
 

--- a/src/quantization/scalar_quantization/scalar_quantizer.cpp
+++ b/src/quantization/scalar_quantization/scalar_quantizer.cpp
@@ -15,13 +15,27 @@
 
 #include "scalar_quantizer.h"
 
+#include <cstring>
+#include <limits>
+#include <new>
+#include <ostream>
+
+#include "container_types.h"
+#include "impl/logger/logger.h"
+#include "index_common_param.h"
+#include "quantization/computer.h"
+#include "quantization/scalar_quantization/scalar_quantizer_parameter.h"
 #include "scalar_quantization_trainer.h"
 #include "scalar_quantization_utils.h"
 #include "simd/normalize.h"
 #include "simd/sq4_simd.h"
 #include "simd/sq8_simd.h"
-#include "typing.h"
+#include "storage/stream_reader.h"
+#include "storage/stream_writer.h"
 #include "utils/util_functions.h"
+#include "vsag/allocator.h"
+#include "vsag/errors.h"
+#include "vsag_exception.h"
 
 namespace vsag {
 

--- a/src/quantization/scalar_quantization/sq4_uniform_quantizer.cpp
+++ b/src/quantization/scalar_quantization/sq4_uniform_quantizer.cpp
@@ -15,16 +15,28 @@
 
 #include "sq4_uniform_quantizer.h"
 
-#include <cstddef>
+#include <algorithm>
+#include <limits>
+#include <memory>
+#include <new>
+#include <ostream>
 
+#include "container_types.h"
+#include "impl/logger/logger.h"
 #include "index_common_param.h"
+#include "quantization/computer.h"
+#include "quantization/quantizer_parameter.h"
 #include "scalar_quantization_trainer.h"
 #include "scalar_quantization_utils.h"
 #include "simd/normalize.h"
 #include "simd/sq4_uniform_simd.h"
 #include "sq4_uniform_quantizer_parameter.h"
-#include "typing.h"
+#include "storage/stream_reader.h"
+#include "storage/stream_writer.h"
 #include "utils/util_functions.h"
+#include "vsag/allocator.h"
+#include "vsag/errors.h"
+#include "vsag_exception.h"
 
 namespace vsag {
 

--- a/src/quantization/scalar_quantization/sq4_uniform_quantizer_parameter.cpp
+++ b/src/quantization/scalar_quantization/sq4_uniform_quantizer_parameter.cpp
@@ -15,7 +15,12 @@
 
 #include "sq4_uniform_quantizer_parameter.h"
 
+#include <memory>
+#include <string>
+
+#include "impl/logger/logger.h"
 #include "inner_string_params.h"
+#include "json_wrapper.h"
 #include "utils/param_compat_macros.h"
 
 namespace vsag {

--- a/src/quantization/scalar_quantization/sq8_uniform_quantizer.cpp
+++ b/src/quantization/scalar_quantization/sq8_uniform_quantizer.cpp
@@ -15,15 +15,28 @@
 
 #include "sq8_uniform_quantizer.h"
 
-#include <cstddef>
+#include <algorithm>
 #include <cstring>
+#include <limits>
+#include <memory>
+#include <new>
+#include <ostream>
 
+#include "container_types.h"
+#include "impl/logger/logger.h"
+#include "index_common_param.h"
+#include "quantization/computer.h"
+#include "quantization/scalar_quantization/sq8_uniform_quantizer_parameter.h"
 #include "scalar_quantization_trainer.h"
 #include "scalar_quantization_utils.h"
 #include "simd/normalize.h"
 #include "simd/sq8_uniform_simd.h"
-#include "typing.h"
+#include "storage/stream_reader.h"
+#include "storage/stream_writer.h"
 #include "utils/util_functions.h"
+#include "vsag/allocator.h"
+#include "vsag/errors.h"
+#include "vsag_exception.h"
 
 namespace vsag {
 

--- a/src/quantization/scalar_quantization/sq8_uniform_quantizer_parameter.cpp
+++ b/src/quantization/scalar_quantization/sq8_uniform_quantizer_parameter.cpp
@@ -15,7 +15,10 @@
 
 #include "sq8_uniform_quantizer_parameter.h"
 
+#include <string>
+
 #include "inner_string_params.h"
+#include "json_wrapper.h"
 
 namespace vsag {
 SQ8UniformQuantizerParameter::SQ8UniformQuantizerParameter()

--- a/src/quantization/transform_quantization/transform_quantizer_parameter.cpp
+++ b/src/quantization/transform_quantization/transform_quantizer_parameter.cpp
@@ -15,7 +15,18 @@
 
 #include "transform_quantizer_parameter.h"
 
+#include <fmt/core.h>
+
+#include <algorithm>
+#include <cctype>
+#include <cstdint>
+#include <istream>
+#include <memory>
+
+#include "impl/logger/logger.h"
 #include "utils/param_compat_macros.h"
+#include "vsag/errors.h"
+#include "vsag_exception.h"
 
 namespace vsag {
 

--- a/src/quantization/transform_quantization/transform_quantizer_parameter_test.cpp
+++ b/src/quantization/transform_quantization/transform_quantizer_parameter_test.cpp
@@ -15,7 +15,7 @@
 
 #include "transform_quantizer_parameter.h"
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "inner_string_params.h"
 #include "parameter_test.h"

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -12,10 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
+#include <atomic>
+#include <cstdint>
 #include <future>
+#include <string>
 
+#include "vsag/errors.h"
 #include "vsag/readerset.h"
 #include "vsag_exception.h"
 

--- a/src/simd/amx.cpp
+++ b/src/simd/amx.cpp
@@ -21,6 +21,7 @@
 // elements that don't fill an AMX tile.
 
 #include "amx_bf16_matmul.h"
+#include "simd/simd_marco.h"
 #include "simd_status.h"
 #include "sq8_uniform_simd.h"
 
@@ -29,7 +30,6 @@
 
 #include <algorithm>
 #include <cassert>
-#include <climits>
 #include <cstdint>
 #include <cstring>
 #include <vector>

--- a/src/simd/rabitq_simd.cpp
+++ b/src/simd/rabitq_simd.cpp
@@ -14,6 +14,7 @@
 
 #include "rabitq_simd.h"
 
+#include "simd/simd_status.h"
 #include "simd_dispatch.h"
 
 namespace vsag {

--- a/src/simd/simd.cpp
+++ b/src/simd/simd.cpp
@@ -17,6 +17,8 @@
 
 #include <cpuinfo.h>
 
+#include "simd/simd_status.h"
+
 namespace vsag {
 
 SimdStatus

--- a/src/simd/sq8_uniform_simd.cpp
+++ b/src/simd/sq8_uniform_simd.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 #include "sq8_uniform_simd.h"
 
+#include "simd/simd_status.h"
 #include "simd_dispatch.h"
 
 namespace vsag {

--- a/src/storage/footer.cpp
+++ b/src/storage/footer.cpp
@@ -15,6 +15,16 @@
 
 #include "footer.h"
 
+#include <fmt/core.h>
+
+#include <cstdint>
+#include <ostream>
+#include <vector>
+
+#include "json_wrapper.h"
+#include "storage/stream_reader.h"
+#include "vsag/constants.h"
+#include "vsag/errors.h"
 #include "vsag_exception.h"
 
 namespace vsag {

--- a/src/storage/footer.h
+++ b/src/storage/footer.h
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 #pragma once
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "stream_reader.h"
 #include "typing.h"

--- a/src/storage/stream_reader.cpp
+++ b/src/storage/stream_reader.cpp
@@ -15,14 +15,18 @@
 
 #include "stream_reader.h"
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
+#include <algorithm>
 #include <cstdint>
-#include <fstream>
-#include <iostream>
+#include <cstring>
+#include <limits>
+#include <string>
+#include <utility>
 
-#include "footer.h"
 #include "impl/logger/logger.h"
+#include "vsag/allocator.h"
+#include "vsag/errors.h"
 #include "vsag/options.h"
 #include "vsag_exception.h"
 

--- a/src/utils/filter_search_skip_strategy.cpp
+++ b/src/utils/filter_search_skip_strategy.cpp
@@ -14,7 +14,10 @@
 
 #include "filter_search_skip_strategy.h"
 
+#include <ostream>
+
 #include "linear_congruential_generator.h"
+#include "vsag/errors.h"
 #include "vsag_exception.h"
 
 namespace vsag {

--- a/src/utils/lock_strategy.cpp
+++ b/src/utils/lock_strategy.cpp
@@ -15,7 +15,10 @@
 
 #include "lock_strategy.h"
 
+#include "type_helpers.h"
+
 namespace vsag {
+class Allocator;
 
 PointsMutex::PointsMutex(uint32_t element_num, Allocator* allocator)
     : allocator_(allocator),

--- a/src/utils/prefetch.cpp
+++ b/src/utils/prefetch.cpp
@@ -14,6 +14,9 @@
 // limitations under the License.
 
 #include "prefetch.h"
+
+#include <algorithm>
+
 namespace vsag {
 
 #define PREFETCH_LINE(X)       \

--- a/src/utils/slow_task_timer.cpp
+++ b/src/utils/slow_task_timer.cpp
@@ -15,6 +15,9 @@
 
 #include "slow_task_timer.h"
 
+#include <ratio>
+#include <utility>
+
 #include "impl/logger/logger.h"
 
 namespace vsag {

--- a/src/utils/sparse_vector_transform.cpp
+++ b/src/utils/sparse_vector_transform.cpp
@@ -16,6 +16,13 @@
 
 #include "sparse_vector_transform.h"
 
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <unordered_map>
+
+#include "vsag/dataset.h"
+
 namespace vsag {
 
 void

--- a/src/utils/timer.cpp
+++ b/src/utils/timer.cpp
@@ -15,7 +15,7 @@
 
 #include "timer.h"
 
-#include <numeric>
+#include <limits>
 
 namespace vsag {
 Timer::Timer(double* ref) : ref_(ref) {

--- a/src/utils/visited_list.cpp
+++ b/src/utils/visited_list.cpp
@@ -15,7 +15,10 @@
 
 #include "visited_list.h"
 
+#include <cstring>
 #include <limits>
+
+#include "vsag/allocator.h"
 
 namespace vsag {
 VisitedList::VisitedList(InnerIdType max_size, Allocator* allocator)

--- a/src/utils/window_result_queue.cpp
+++ b/src/utils/window_result_queue.cpp
@@ -14,6 +14,8 @@
 
 #include "window_result_queue.h"
 
+#include <algorithm>
+
 namespace vsag {
 
 static constexpr int64_t DEFAULT_WATCH_WINDOW_SIZE = 20;

--- a/src/vsag.cpp
+++ b/src/vsag.cpp
@@ -15,13 +15,13 @@
 
 #include "vsag/vsag.h"
 
-#include <../extern/diskann/DiskANN/include/diskann_logger.h>
 #include <cpuinfo.h>
 
 #include <sstream>
 
 #include "impl/logger/logger.h"
 #include "simd/simd.h"
+#include "simd/simd_status.h"
 #include "version.h"
 
 namespace vsag {

--- a/src/vsag_c_api.cpp
+++ b/src/vsag_c_api.cpp
@@ -17,10 +17,20 @@
 #include <vsag/index.h>
 #include <vsag/vsag_c_api.h>
 
+#include <cstdint>
+#include <cstdio>
 #include <cstring>
+#include <exception>
 #include <fstream>
-#include <streambuf>
-#include <type_traits>
+#include <functional>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "vsag/dataset.h"
+#include "vsag/errors.h"
+#include "vsag/expected.hpp"
+#include "vsag/filter.h"
 
 Error_t success = {VSAG_SUCCESS, "success"};
 

--- a/src/vsag_ext.cpp
+++ b/src/vsag_ext.cpp
@@ -15,7 +15,14 @@
 
 #include "vsag/vsag_ext.h"
 
+#include <memory>
+
+#include "vsag/binaryset.h"
+
 namespace vsag {
+class Allocator;
+class ReaderSet;
+
 namespace ext {
 
 DatasetHandler*


### PR DESCRIPTION
Closes #2144

## What

Clean up include dependencies across 148 implementation files (`.cpp`) in `src/` based on IWYU (include-what-you-use) analysis.

## Why

IWYU analysis identified the following issues in `src/`:
1. **Redundant heavy headers**: 56 files use `<fmt/format.h>` but only need `<fmt/core.h>`
2. **Over-reliance on aggregate headers**: `common.h`, `filter_headers.h`, `io_headers.h`, `quantizer_headers.h`, etc. pull in far more dependencies than needed
3. **Missing explicit includes**: Some symbols are only available via transitive dependencies without direct includes

## Changes

### Commit 1: Replace fmt headers (56 files)
- `<fmt/format.h>` → `<fmt/core.h>`
- No behavioral change; `fmt/core.h` is a strict subset of `fmt/format.h`

### Commit 2: IWYU include cleanup (148 files)
- Split aggregate headers into specific headers actually needed
- Add missing explicit includes for symbols used
- Remove unused includes
- +1,424 lines, -117 lines

## Verification

- ✅ `make release` build passes
- ✅ `make fmt` format check passes

## Affected Directories

`algorithm/`, `analyzer/`, `attr/`, `datacell/`, `factory/`, `impl/`, `index/`, `io/`, `quantization/`, `simd/`, `storage/`, `utils/`, `src/` root