### PR TITLE
Fix/sindi auto heap insert

### DIFF
--- a/docs/docs/en/src/indexes/sindi.md
+++ b/docs/docs/en/src/indexes/sindi.md
@@ -92,7 +92,14 @@ Search-time parameters live under the `sindi` sub-object:
 | `n_candidate` | int | `0` | Candidate heap size. When `0`, defaults to `SPARSE_AMPLIFICATION_FACTOR · topk` (500×). If set, must satisfy `1 ≤ n_candidate ≤ SPARSE_AMPLIFICATION_FACTOR · topk`. |
 | `query_prune_ratio` | float | `0.0` | Fraction of lowest-weight query terms skipped (0.0 – 0.9). |
 | `term_prune_ratio` | float | `0.0` | Fraction of term-list entries skipped (0.0 – 0.9). |
-| `use_term_lists_heap_insert` | bool | `true` | Term-list-ordered heap insertion; usually faster. |
+
+SINDI chooses the heap-insertion strategy automatically from the build-time
+`doc_prune_ratio` and search-time `query_prune_ratio`. With the current `0.1`
+threshold, SINDI uses the distance-array insertion path when both ratios are
+`<= 0.1`; if either ratio is greater than `0.1`, it uses term-list heap
+insertion. The legacy
+`use_term_lists_heap_insert` search parameter is ignored; configure pruning
+ratios instead.
 
 ```cpp
 auto result = index->KnnSearch(

--- a/docs/docs/en/src/resources/release_notes.md
+++ b/docs/docs/en/src/resources/release_notes.md
@@ -48,5 +48,8 @@ npm install vsag@X.Y.Z
   versions.
 - When the serialization format changes, validate deserialization compatibility in a staging
   environment first.
+- For SINDI, the legacy `use_term_lists_heap_insert` search parameter is ignored. SINDI
+  now derives the heap-insertion strategy from `doc_prune_ratio` and `query_prune_ratio`;
+  update configs that relied on forcing this path directly.
 - Roll out gradually in production and use the
   [performance evaluation tool](eval.md) to compare recall and latency.

--- a/docs/docs/zh/src/indexes/sindi.md
+++ b/docs/docs/zh/src/indexes/sindi.md
@@ -87,7 +87,11 @@ auto result = index->KnnSearch(
 | `n_candidate` | int | `0` | 候选堆大小。为 `0` 时自动取 `SPARSE_AMPLIFICATION_FACTOR · topk`（500 倍）；若显式设置，须满足 `1 ≤ n_candidate ≤ SPARSE_AMPLIFICATION_FACTOR · topk` |
 | `query_prune_ratio` | float | `0.0` | 查询时丢弃权重最低查询项的比例（0.0 – 0.9） |
 | `term_prune_ratio` | float | `0.0` | 查询时丢弃倒排表中低权项的比例（0.0 – 0.9） |
-| `use_term_lists_heap_insert` | bool | `true` | 按倒排表顺序做堆插入，通常更快 |
+
+SINDI 会根据构建阶段的 `doc_prune_ratio` 与检索阶段的 `query_prune_ratio`
+自动选择堆插入策略。按当前 `0.1` 阈值，当两个比例都 `<= 0.1` 时，SINDI 使用
+基于距离数组的入堆路径；只要任一比例大于 `0.1`，就使用基于 term-list 的入堆路径。
+旧版 `use_term_lists_heap_insert` 检索参数会被忽略；请改用剪枝比例控制该行为。
 
 ```cpp
 auto result = index->KnnSearch(

--- a/docs/docs/zh/src/resources/release_notes.md
+++ b/docs/docs/zh/src/resources/release_notes.md
@@ -46,4 +46,7 @@ npm install vsag@X.Y.Z
 
 - 跨大版本升级前，请先阅读对应 Release 的 **Breaking Changes** 部分；
 - 涉及序列化格式变更时，建议先在测试环境验证反序列化兼容性；
+- 对于 SINDI，旧版 `use_term_lists_heap_insert` 检索参数会被忽略。SINDI 现在根据
+  `doc_prune_ratio` 和 `query_prune_ratio` 自动推导堆插入策略；如果配置曾依赖直接指定
+  该路径，请改用剪枝比例。
 - 生产环境灰度升级，结合 [性能评估工具](eval.md) 对比召回与延迟。

--- a/src/algorithm/simq/simq.cpp
+++ b/src/algorithm/simq/simq.cpp
@@ -445,7 +445,7 @@ SIMQ::build_rep_hgraph(const float* flat_vecs, int64_t dim) {
 // ─────────────────────────────────────────────────────────────────────────────
 
 std::vector<int64_t>
-SIMQ::Add(const DatasetPtr& data, AddMode /*mode*/) {
+SIMQ::Add(const DatasetPtr& data) {
     std::unique_lock lock(global_mutex_);
 
     if (rep_hgraph_ == nullptr) {

--- a/src/algorithm/simq/simq.h
+++ b/src/algorithm/simq/simq.h
@@ -46,7 +46,7 @@ public:
     Build(const DatasetPtr& data) override;
 
     std::vector<int64_t>
-    Add(const DatasetPtr& data, AddMode mode = AddMode::DEFAULT) override;
+    Add(const DatasetPtr& data) override;
 
     DatasetPtr
     KnnSearch(const DatasetPtr& query,

--- a/src/algorithm/sindi/sindi.cpp
+++ b/src/algorithm/sindi/sindi.cpp
@@ -78,6 +78,7 @@ SINDI::SINDI(const SINDIParameterPtr& param, const IndexCommonParam& common_para
       sparse_value_quant_type_(param->sparse_value_quant_type),
       term_id_limit_(param->term_id_limit),
       window_size_(param->window_size),
+      doc_prune_ratio_(param->doc_prune_ratio),
       doc_retain_ratio_(1.0F - param->doc_prune_ratio),
       window_term_list_(common_param.allocator_.get()),
       deserialize_without_footer_(param->deserialize_without_footer),
@@ -107,7 +108,7 @@ SINDI::GetStats() const {
     analyzer_param.base_sample_size =
         std::min<uint64_t>(K_ANALYZE_BASE_SAMPLE_SIZE, cur_element_count_);
     analyzer_param.search_params =
-        R"({"sindi": {"query_prune_ratio": 0, "term_prune_ratio": 0, "n_candidate": 500, "use_term_lists_heap_insert": true}})";
+        R"({"sindi": {"query_prune_ratio": 0, "term_prune_ratio": 0, "n_candidate": 500}})";
     auto analyzer = CreateAnalyzer(this, analyzer_param);
     JsonType stats = analyzer->GetStats();
     return stats.Dump(4);
@@ -331,14 +332,11 @@ SINDI::KnnSearch(const DatasetPtr& query,
     auto computer = std::make_shared<SparseTermComputer>(effective_query, search_param, allocator_);
     const SparseVector* rerank_query = (remap_term_ids_ && use_reorder_) ? &sparse_query : nullptr;
     if (immutable_data_ != nullptr) {
-        return immutable_search_impl<KNN_SEARCH>(computer,
-                                                 inner_param,
-                                                 allocator,
-                                                 search_param.use_term_lists_heap_insert,
-                                                 rerank_query);
+        return immutable_search_impl<KNN_SEARCH>(
+            computer, inner_param, allocator, UseTermListsHeapInsert(search_param), rerank_query);
     }
     return search_impl<KNN_SEARCH>(
-        computer, inner_param, allocator, search_param.use_term_lists_heap_insert, rerank_query);
+        computer, inner_param, allocator, UseTermListsHeapInsert(search_param), rerank_query);
 }
 
 std::optional<uint32_t>
@@ -857,14 +855,20 @@ SINDI::RangeSearch(const DatasetPtr& query,
     auto computer = std::make_shared<SparseTermComputer>(effective_query, search_param, allocator_);
     const SparseVector* rerank_query = (remap_term_ids_ && use_reorder_) ? &sparse_query : nullptr;
     if (immutable_data_ != nullptr) {
-        return immutable_search_impl<RANGE_SEARCH>(computer,
-                                                   inner_param,
-                                                   allocator_,
-                                                   search_param.use_term_lists_heap_insert,
-                                                   rerank_query);
+        return immutable_search_impl<RANGE_SEARCH>(
+            computer, inner_param, allocator_, UseTermListsHeapInsert(search_param), rerank_query);
     }
     return search_impl<RANGE_SEARCH>(
-        computer, inner_param, allocator_, search_param.use_term_lists_heap_insert, rerank_query);
+        computer, inner_param, allocator_, UseTermListsHeapInsert(search_param), rerank_query);
+}
+
+bool
+SINDI::UseTermListsHeapInsert(const SINDISearchParameter& search_param) const {
+    // Low build-time doc pruning and low search-time query pruning keep the old
+    // distance-array heap insertion path for accuracy. Once either side exceeds the
+    // threshold, term-list heap insertion avoids scanning the whole window for heap updates.
+    return doc_prune_ratio_ > SINDI::K_TERM_LISTS_HEAP_INSERT_PRUNE_THRESHOLD ||
+           search_param.query_prune_ratio > SINDI::K_TERM_LISTS_HEAP_INSERT_PRUNE_THRESHOLD;
 }
 
 void
@@ -956,6 +960,8 @@ SINDI::Deserialize(StreamReader& reader) {
                 logger::error(message);
                 throw VsagException(ErrorType::INVALID_ARGUMENT, message);
             }
+            doc_prune_ratio_ = index_param->doc_prune_ratio;
+            doc_retain_ratio_ = 1.0F - doc_prune_ratio_;
         }
     }
     auto* reader_ptr = &reader;

--- a/src/algorithm/sindi/sindi.h
+++ b/src/algorithm/sindi/sindi.h
@@ -188,6 +188,8 @@ public:
     SetImmutable() override;
 
 private:
+    static constexpr float K_TERM_LISTS_HEAP_INSERT_PRUNE_THRESHOLD = 0.1F;
+
     /**
      * @brief Core search implementation shared by KnnSearch / RangeSearch.
      *
@@ -215,6 +217,13 @@ private:
                           Allocator* allocator,
                           bool use_term_lists_heap_insert,
                           const SparseVector* original_query = nullptr) const;
+
+    bool
+    UseTermListsHeapInsert(const SINDISearchParameter& search_param) const;
+
+#ifdef VSAG_SINDI_TEST_ACCESS
+    friend class SINDITestAccess;
+#endif
 
     /**
      * @brief Derive the [min_window_id, max_window_id] range that could
@@ -315,6 +324,7 @@ private:
     bool use_reorder_{false};       // enable reranking stage
     bool use_quantization_{false};  // enable term-value quantization
 
+    float doc_prune_ratio_{0};   // ratio of docs pruned during build
     float doc_retain_ratio_{0};  // ratio of docs kept after pruning
 
     std::shared_ptr<SparseIndex> rerank_flat_index_{nullptr};  // re-rank back-end

--- a/src/algorithm/sindi/sindi_parameter.cpp
+++ b/src/algorithm/sindi/sindi_parameter.cpp
@@ -15,6 +15,7 @@
 
 #include "sindi_parameter.h"
 
+#include "impl/logger/logger.h"
 #include "inner_string_params.h"
 #include "utils/param_compat_macros.h"
 
@@ -49,6 +50,12 @@ parse_sparse_value_quant_type(const std::string& type_name) {
         false, fmt::format("use_quantization must be false, true, or fp16, but got {}", type_name));
     return SparseValueQuantizationType::FP32;
 }
+
+namespace {
+
+constexpr auto LEGACY_USE_TERM_LISTS_HEAP_INSERT_KEY = "use_term_lists_heap_insert";
+
+}  // namespace
 
 void
 SINDIParameter::FromJson(const JsonType& json) {
@@ -181,10 +188,11 @@ SINDISearchParameter::FromJson(const JsonType& json) {
         n_candidate = DEFAULT_N_CANDIDATE;
     }
 
-    if (json[INDEX_SINDI].Contains(SPARSE_USE_TERM_LISTS_HEAP_INSERT)) {
-        use_term_lists_heap_insert = json[INDEX_SINDI][SPARSE_USE_TERM_LISTS_HEAP_INSERT].GetBool();
-    } else {
-        use_term_lists_heap_insert = true;
+    if (json[INDEX_SINDI].Contains(LEGACY_USE_TERM_LISTS_HEAP_INSERT_KEY)) {
+        logger::warn(
+            "SINDI search parameter use_term_lists_heap_insert is ignored. "
+            "Remove this key; heap insertion is derived from doc_prune_ratio "
+            "and query_prune_ratio with the current SINDI prune-ratio threshold");
     }
 }
 JsonType
@@ -194,7 +202,6 @@ SINDISearchParameter::ToJson() const {
     json[INDEX_SINDI][SPARSE_QUERY_PRUNE_RATIO].SetFloat(query_prune_ratio);
     json[INDEX_SINDI][SPARSE_N_CANDIDATE].SetInt(n_candidate);
     json[INDEX_SINDI][SPARSE_TERM_PRUNE_RATIO].SetFloat(term_prune_ratio);
-    json[INDEX_SINDI][SPARSE_USE_TERM_LISTS_HEAP_INSERT].SetBool(use_term_lists_heap_insert);
     return json;
 }
 

--- a/src/algorithm/sindi/sindi_parameter.h
+++ b/src/algorithm/sindi/sindi_parameter.h
@@ -83,9 +83,6 @@ public:
     // search
     uint32_t n_candidate{0};
 
-    // choose heap insert path during search
-    bool use_term_lists_heap_insert{true};
-
     // data cell
     float query_prune_ratio{0};
     float term_prune_ratio{0};

--- a/src/algorithm/sindi/sindi_parameter_test.cpp
+++ b/src/algorithm/sindi/sindi_parameter_test.cpp
@@ -92,14 +92,27 @@ TEST_CASE("SINDI Index Parameters Test", "[ut][SINDIParameter]") {
         "sindi": {
             "query_prune_ratio": 0.2,
             "n_candidate": 20,
-            "term_prune_ratio": 0.1,
-            "use_term_lists_heap_insert": false
+            "term_prune_ratio": 0.1
         }
     })";
     auto search_param = std::make_shared<vsag::SINDISearchParameter>();
     vsag::JsonType search_param_json = vsag::JsonType::Parse(search_param_str);
     search_param->FromJson(search_param_json);
     vsag::ParameterTest::TestToJson(search_param);
+    REQUIRE_FALSE(search_param->ToJson()[INDEX_SINDI].Contains("use_term_lists_heap_insert"));
+
+    auto legacy_search_param_str = R"({
+        "sindi": {
+            "query_prune_ratio": 0.2,
+            "n_candidate": 20,
+            "term_prune_ratio": 0.1,
+            "use_term_lists_heap_insert": false
+        }
+    })";
+    auto legacy_search_param = std::make_shared<vsag::SINDISearchParameter>();
+    legacy_search_param->FromJson(vsag::JsonType::Parse(legacy_search_param_str));
+    REQUIRE_FALSE(
+        legacy_search_param->ToJson()[INDEX_SINDI].Contains("use_term_lists_heap_insert"));
 }
 
 TEST_CASE("SINDI Index Parameters Compatibility Test", "[ut][SINDIParameter]") {

--- a/src/algorithm/sindi/sindi_test.cpp
+++ b/src/algorithm/sindi/sindi_test.cpp
@@ -13,8 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#define VSAG_SINDI_TEST_ACCESS
 #include "sindi.h"
 
+#include <array>
 #include <set>
 
 #include "impl/allocator/safe_allocator.h"
@@ -22,6 +24,23 @@
 #include "storage/serialization_template_test.h"
 #include "unittest.h"
 using namespace vsag;
+
+namespace vsag {
+
+class SINDITestAccess {
+public:
+    static bool
+    UseTermListsHeapInsert(const SINDI& index, const SINDISearchParameter& search_param) {
+        return index.UseTermListsHeapInsert(search_param);
+    }
+
+    static float
+    TermListsHeapInsertPruneThreshold() {
+        return SINDI::K_TERM_LISTS_HEAP_INSERT_PRUNE_THRESHOLD;
+    }
+};
+
+}  // namespace vsag
 
 class MockFilter : public Filter {
 public:
@@ -59,6 +78,49 @@ private:
     std::vector<int64_t> valid_ids_;
     std::unordered_set<int64_t> valid_ids_set_;
 };
+
+TEST_CASE("SINDI Heap Insert Strategy Test", "[ut][SINDI]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    IndexCommonParam common_param;
+    common_param.allocator_ = allocator;
+
+    auto make_index = [&](float doc_prune_ratio) {
+        auto param = std::make_shared<vsag::SINDIParameter>();
+        param->term_id_limit = 30001;
+        param->window_size = 10000;
+        param->doc_prune_ratio = doc_prune_ratio;
+        param->avg_doc_term_length = 100;
+        return SINDI(param, common_param);
+    };
+
+    auto make_search_param = [](float query_prune_ratio) {
+        SINDISearchParameter search_param;
+        search_param.query_prune_ratio = query_prune_ratio;
+        return search_param;
+    };
+
+    SECTION("uses distance insertion when both prune ratios are no greater than threshold") {
+        std::array<float, 3> prune_ratios = {
+            0.0F, 0.05F, SINDITestAccess::TermListsHeapInsertPruneThreshold()};
+        for (auto doc_prune_ratio : prune_ratios) {
+            auto index = make_index(doc_prune_ratio);
+            for (auto query_prune_ratio : prune_ratios) {
+                auto search_param = make_search_param(query_prune_ratio);
+                REQUIRE_FALSE(SINDITestAccess::UseTermListsHeapInsert(index, search_param));
+            }
+        }
+    }
+
+    SECTION("matches threshold rule for distance and term-list insertion") {
+        auto doc_prune_ratio = GENERATE(0.0F, 0.2F);
+        auto query_prune_ratio = GENERATE(0.0F, 0.2F);
+        auto index = make_index(doc_prune_ratio);
+        auto search_param = make_search_param(query_prune_ratio);
+        REQUIRE(SINDITestAccess::UseTermListsHeapInsert(index, search_param) ==
+                (doc_prune_ratio > SINDITestAccess::TermListsHeapInsertPruneThreshold() ||
+                 query_prune_ratio > SINDITestAccess::TermListsHeapInsertPruneThreshold()));
+    }
+}
 
 TEST_CASE("SINDI Basic Test", "[ut][SINDI]") {
     auto allocator = SafeAllocator::FactoryDefaultAllocator();
@@ -135,8 +197,7 @@ TEST_CASE("SINDI Basic Test", "[ut][SINDI]") {
         "sindi": {
             "query_prune_ratio": 0.0,
             "term_prune_ratio": 0.0,
-            "n_candidate": 20,
-            "use_term_lists_heap_insert": false
+            "n_candidate": 20
         }
     }
     )";
@@ -300,8 +361,7 @@ TEST_CASE("SINDI Quantization Test", "[ut][SINDI]") {
         "sindi": {
             "query_prune_ratio": 0.0,
             "term_prune_ratio": 0.0,
-            "n_candidate": 20,
-            "use_term_lists_heap_insert": false
+            "n_candidate": 20
         }
     }
     )";
@@ -590,8 +650,7 @@ TEST_CASE("SINDI Remap Basic Test", "[ut][SINDI]") {
         "sindi": {
             "query_prune_ratio": 0.0,
             "term_prune_ratio": 0.0,
-            "n_candidate": 20,
-            "use_term_lists_heap_insert": false
+            "n_candidate": 20
         }
     }
     )";
@@ -734,8 +793,7 @@ TEST_CASE("SINDI Remap with Reorder Test", "[ut][SINDI]") {
         "sindi": {
             "query_prune_ratio": 0.0,
             "term_prune_ratio": 0.0,
-            "n_candidate": 20,
-            "use_term_lists_heap_insert": false
+            "n_candidate": 20
         }
     }
     )";
@@ -876,8 +934,7 @@ TEST_CASE("SINDI Remap with Quantization Test", "[ut][SINDI]") {
         "sindi": {
             "query_prune_ratio": 0.0,
             "term_prune_ratio": 0.0,
-            "n_candidate": 20,
-            "use_term_lists_heap_insert": false
+            "n_candidate": 20
         }
     }
     )";
@@ -974,8 +1031,7 @@ TEST_CASE("SINDI Remap with Filter Test", "[ut][SINDI]") {
         "sindi": {
             "query_prune_ratio": 0.0,
             "term_prune_ratio": 0.0,
-            "n_candidate": 20,
-            "use_term_lists_heap_insert": false
+            "n_candidate": 20
         }
     }
     )";
@@ -1390,8 +1446,7 @@ TEST_CASE("SINDI Remap Memory Comparison - MD5 Vocabulary", "[ut][SINDI]") {
         "sindi": {
             "query_prune_ratio": 0.0,
             "term_prune_ratio": 0.0,
-            "n_candidate": 20,
-            "use_term_lists_heap_insert": false
+            "n_candidate": 20
         }
     }
     )";

--- a/src/analyzer/sindi_analyzer.cpp
+++ b/src/analyzer/sindi_analyzer.cpp
@@ -222,13 +222,14 @@ SINDIAnalyzer::collect_coarse_candidates(const SparseVector& query,
     MaxHeap heap(sindi_->allocator_);
     auto computer =
         std::make_shared<SparseTermComputer>(effective_query, search_param, sindi_->allocator_);
+    const bool use_term_lists_heap_insert = sindi_->UseTermListsHeapInsert(search_param);
 
     Vector<float> dists(sindi_->window_size_, 0.0F, sindi_->allocator_);
     for (int64_t cur = 0; cur < static_cast<int64_t>(sindi_->window_term_list_.size()); ++cur) {
         auto window_start_id = static_cast<uint32_t>(cur * sindi_->window_size_);
         auto term_list = sindi_->window_term_list_[cur];
         term_list->Query(dists.data(), computer);
-        if (search_param.use_term_lists_heap_insert) {
+        if (use_term_lists_heap_insert) {
             term_list->InsertHeapByTermLists<KNN_SEARCH, PURE>(
                 dists.data(), computer, heap, inner_param, window_start_id);
         } else {
@@ -272,6 +273,7 @@ SINDIAnalyzer::collect_doc_prune_candidates(const SparseVector& query,
     MaxHeap heap(sindi_->allocator_);
     auto computer =
         std::make_shared<SparseTermComputer>(effective_query, search_param, sindi_->allocator_);
+    const bool use_term_lists_heap_insert = sindi_->UseTermListsHeapInsert(search_param);
 
     Vector<float> dists(sindi_->window_size_, 0.0F, sindi_->allocator_);
     Vector<float> decoded_values(sindi_->allocator_);
@@ -321,7 +323,7 @@ SINDIAnalyzer::collect_doc_prune_candidates(const SparseVector& query,
         }
         computer->ResetTerm();
 
-        if (search_param.use_term_lists_heap_insert) {
+        if (use_term_lists_heap_insert) {
             term_list->InsertHeapByTermLists<KNN_SEARCH, PURE>(
                 dists.data(), computer, heap, inner_param, window_start_id);
         } else {
@@ -1199,7 +1201,6 @@ SINDIAnalyzer::GetStats() {
     default_search_json[INDEX_SINDI][SPARSE_QUERY_PRUNE_RATIO].SetFloat(0.0F);
     default_search_json[INDEX_SINDI][SPARSE_TERM_PRUNE_RATIO].SetFloat(0.0F);
     default_search_json[INDEX_SINDI][SPARSE_N_CANDIDATE].SetInt(500);
-    default_search_json[INDEX_SINDI][SPARSE_USE_TERM_LISTS_HEAP_INSERT].SetBool(true);
     auto default_search_param = default_search_json.Dump();
 
     auto base_search_stats = get_base_search_stats(default_search_param, base_dataset);

--- a/src/inner_string_params.h
+++ b/src/inner_string_params.h
@@ -120,7 +120,6 @@ const char* const SPARSE_TERM_ID_LIMIT = "term_id_limit";
 const char* const SPARSE_WINDOW_SIZE = "window_size";
 const char* const SPARSE_DESERIALIZE_WITHOUT_FOOTER = "deserialize_without_footer";
 const char* const SPARSE_DESERIALIZE_WITHOUT_BUFFER = "deserialize_without_buffer";
-const char* const SPARSE_USE_TERM_LISTS_HEAP_INSERT = "use_term_lists_heap_insert";
 const char* const SPARSE_AVG_DOC_TERM_LENGTH = "avg_doc_term_length";
 const char* const SPARSE_REMAP_TERM_IDS = "remap_term_ids";
 const char* const SPARSE_IMMUTABLE = "immutable";

--- a/tests/test_sindi.cpp
+++ b/tests/test_sindi.cpp
@@ -78,18 +78,17 @@ public:
     }
 
     static std::string
-    GenerateSearchParameter(bool use_term_lists_heap_insert) {
+    GenerateSearchParameter(float query_prune_ratio) {
         constexpr static const char* search_param_template = R"(
         {{
             "sindi":
             {{
                 "n_candidate": 20,
-                "query_prune_ratio": 0.0,
-                "term_prune_ratio": 0.0,
-                "use_term_lists_heap_insert": {}
+                "query_prune_ratio": {},
+                "term_prune_ratio": 0.0
             }}
         }})";
-        return fmt::format(search_param_template, use_term_lists_heap_insert);
+        return fmt::format(search_param_template, query_prune_ratio);
     }
 };
 TestDatasetPool SINDITestIndex::pool{};
@@ -229,7 +228,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex, "SINDI Analyze", "[ft][an
 
     vsag::SearchRequest request;
     request.topk_ = 10;
-    request.params_str_ = fixtures::SINDITestIndex::GenerateSearchParameter(true);
+    request.params_str_ = fixtures::SINDITestIndex::GenerateSearchParameter(0.2F);
     request.query_ = dataset->query_;
     auto raw_query_count = dataset->query_->GetNumElements();
     dataset->query_->NumElements(5);
@@ -268,8 +267,8 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex,
     param.sparse_value_quant_type = GENERATE("fp32", "sq8", "fp16");
     param.remap_term_ids = GENERATE(true, false);
     auto build_param = fixtures::SINDITestIndex::GenerateBuildParameter(param);
-    auto search_param_with_heap_insert =
-        fixtures::SINDITestIndex::GenerateSearchParameter(GENERATE(true, false));
+    auto search_param_with_prune_ratio =
+        fixtures::SINDITestIndex::GenerateSearchParameter(GENERATE(0.0F, 0.2F));
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
     auto metric_type = GENERATE("ip");
@@ -287,15 +286,15 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex,
     TestBuildIndex(index, dataset, true);
     SECTION("serialize/deserialize by binary") {
         auto index2 = TestFactory(name, build_param, true);
-        TestSerializeBinarySet(index, index2, dataset, search_param_with_heap_insert, true);
+        TestSerializeBinarySet(index, index2, dataset, search_param_with_prune_ratio, true);
     }
     SECTION("serialize/deserialize by readerset") {
         auto index2 = TestFactory(name, build_param, true);
-        TestSerializeReaderSet(index, index2, dataset, search_param_with_heap_insert, name, true);
+        TestSerializeReaderSet(index, index2, dataset, search_param_with_prune_ratio, name, true);
     }
     SECTION("serialize/deserialize by file") {
         auto index2 = TestFactory(name, build_param, true);
-        TestSerializeFile(index, index2, dataset, search_param_with_heap_insert, true);
+        TestSerializeFile(index, index2, dataset, search_param_with_prune_ratio, true);
     }
     vsag::Options::Instance().set_block_size_limit(origin_size);
 }


### PR DESCRIPTION
## Summary

- Remove the public SINDI search parameter `use_term_lists_heap_insert`.
- Derive the heap insertion strategy internally from `doc_prune_ratio` and `query_prune_ratio`.
- Update SINDI analyzer logic, tests, and SINDI documentation in English and Chinese.

## Details

SINDI now selects the heap insertion path automatically:

- When both `doc_prune_ratio` and `query_prune_ratio` are `<= 0.1`, use the original `use_term_lists_heap_insert = false` distance-array path.
- In all other cases, use the original `use_term_lists_heap_insert = true` term-list heap-insert path.

## Validation

- `clang-format --version` -> `15.0.7`
- `git diff --check`
- `cmake --build build --target unittests -j2`
  - SINDI and `algorithm_test` compiled successfully.
  - Final `tests/unittests` link failed due to local OpenBLAS/libgfortran unresolved symbol: `_gfortran_concat_string`.
- `cmake --build build --target functests -j2`
  - `tests/test_sindi.cpp` compiled successfully.
  - Final `tests/functests` link failed with the same local `_gfortran_concat_string` issue.