### PR TITLE
chore: align coverage threshold check

### DIFF
--- a/scripts/coverage/check_cov.sh
+++ b/scripts/coverage/check_cov.sh
@@ -1,11 +1,18 @@
 #!/bin/bash
 
-line_coverage=`lcov --summary coverage/coverage.info | grep "lines......" | awk '/lines/ { print $2 }' | cut -d '%' -f 1`
-line_coverage=$(printf "%.0f" $line_coverage)
-if [ "$line_coverage" -gt 84 ]; then
-  echo "line coverage is ${line_coverage}, more than 84"
-  exit 0;
+set -eo pipefail
+
+MIN_LINE_COVERAGE=90
+
+line_coverage=$(lcov --summary coverage/coverage.info | \
+  grep "lines......" | \
+  awk '/lines/ { print $2 }' | \
+  cut -d '%' -f 1)
+
+if awk -v cov="${line_coverage}" -v min="${MIN_LINE_COVERAGE}" 'BEGIN { exit !(cov+0 >= min+0) }'; then
+  echo "line coverage is ${line_coverage}, meets ${MIN_LINE_COVERAGE}"
+  exit 0
 else
-  echo "line coverage is ${line_coverage}, less than 84"
-  exit 1;
+  echo "line coverage is ${line_coverage}, less than ${MIN_LINE_COVERAGE}"
+  exit 1
 fi


### PR DESCRIPTION
## Summary
- align scripts/coverage/check_cov.sh with the documented 90% C++ coverage requirement
- compare the raw lcov percentage instead of rounding before the threshold check

## Tests
- bash -n scripts/coverage/check_cov.sh
- fake lcov output: 89.99% fails, 90.00% passes
