### PR TITLE
feat: add LazyHGraph index

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ Thrive together in VSAG community with users and developers from all around the 
 
 - **Optimized Index Types**
   - **HGraph (Graph Index)**: For scenarios demanding high recall and low latency.
+  - **LazyHGraph (Adaptive Graph Index)**: Uses exact BruteForce for small FP32 datasets and automatically converts to HGraph after a configurable threshold.
   - **IVF (Inverted File Index)**: Optimized for large-scale search (high `k`) and batch queries.
   - **SINDI (Sparse Inverted Non-redundant Distance Index)**: Optimized sparse vector index.
 

--- a/examples/cpp/111_index_lazy_hgraph.cpp
+++ b/examples/cpp/111_index_lazy_hgraph.cpp
@@ -1,0 +1,110 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <vsag/vsag.h>
+
+#include <iostream>
+#include <random>
+#include <string>
+#include <vector>
+
+namespace {
+
+vsag::DatasetPtr
+MakeDataset(int64_t first_id,
+            int64_t count,
+            int64_t dim,
+            std::vector<int64_t>& ids,
+            std::vector<float>& vectors) {
+    ids.resize(count);
+    vectors.resize(count * dim);
+    std::mt19937 rng(static_cast<uint32_t>(first_id));
+    std::uniform_real_distribution<float> distrib_real;
+    for (int64_t i = 0; i < count; ++i) {
+        ids[i] = first_id + i;
+        for (int64_t j = 0; j < dim; ++j) {
+            vectors[i * dim + j] = distrib_real(rng);
+        }
+    }
+    return vsag::Dataset::Make()
+        ->NumElements(count)
+        ->Dim(dim)
+        ->Ids(ids.data())
+        ->Float32Vectors(vectors.data())
+        ->Owner(false);
+}
+
+}  // namespace
+
+int
+main() {
+    vsag::init();
+
+    int64_t dim = 128;
+    uint64_t transition_threshold = 1000;
+    std::string lazy_hgraph_build_parameters = R"(
+    {
+        "dtype": "float32",
+        "metric_type": "l2",
+        "dim": 128,
+        "lazy_hgraph": {
+            "transition_threshold": 1000,
+            "hgraph": {
+                "base_quantization_type": "sq8",
+                "max_degree": 26,
+                "ef_construction": 100,
+                "build_thread_count": 4
+            }
+        }
+    }
+    )";
+
+    auto index = vsag::Factory::CreateIndex("lazy_hgraph", lazy_hgraph_build_parameters).value();
+
+    std::vector<int64_t> small_ids;
+    std::vector<float> small_vectors;
+    auto small_batch = MakeDataset(0, 100, dim, small_ids, small_vectors);
+    index->Add(small_batch);
+    std::cout << "After small Add(), LazyHGraph contains: " << index->GetNumElements()
+              << " vectors; it remains in its low-overhead FLAT phase." << std::endl;
+
+    std::vector<int64_t> grow_ids;
+    std::vector<float> grow_vectors;
+    auto grow_batch = MakeDataset(
+        100, transition_threshold - small_batch->GetNumElements(), dim, grow_ids, grow_vectors);
+    index->Add(grow_batch);
+    std::cout << "After reaching transition_threshold, LazyHGraph contains: "
+              << index->GetNumElements() << " vectors and has converted to HGraph internally."
+              << std::endl;
+
+    auto query = vsag::Dataset::Make()
+                     ->NumElements(1)
+                     ->Dim(dim)
+                     ->Float32Vectors(small_vectors.data())
+                     ->Owner(false);
+    auto search_parameters = R"(
+    {
+        "hgraph": {
+            "ef_search": 100
+        }
+    }
+    )";
+    auto result = index->KnnSearch(query, 5, search_parameters).value();
+    std::cout << "results: " << std::endl;
+    for (int64_t i = 0; i < result->GetDim(); ++i) {
+        std::cout << result->GetIds()[i] << ": " << result->GetDistances()[i] << std::endl;
+    }
+
+    return 0;
+}

--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -44,6 +44,9 @@ target_link_libraries (109_index_sindi vsag)
 add_executable (110_index_warp 110_index_warp.cpp)
 target_link_libraries (110_index_warp vsag)
 
+add_executable (111_index_lazy_hgraph 111_index_lazy_hgraph.cpp)
+target_link_libraries (111_index_lazy_hgraph vsag)
+
 add_executable (201_custom_allocator 201_custom_allocator.cpp)
 target_link_libraries (201_custom_allocator vsag)
 

--- a/examples/cpp/README.md
+++ b/examples/cpp/README.md
@@ -61,6 +61,7 @@ together when the directory is listed:
 | [`108_index_gno_imi.cpp`](108_index_gno_imi.cpp) | GNO-IMI | IVF variant with multi-index partitioning. |
 | [`109_index_sindi.cpp`](109_index_sindi.cpp) | SINDI | Sparse vector index (text / inverted retrieval). |
 | [`110_index_warp.cpp`](110_index_warp.cpp) | Warp | Hybrid index. |
+| [`111_index_lazy_hgraph.cpp`](111_index_lazy_hgraph.cpp) | LazyHGraph | Starts as exact BruteForce for small data, then converts to HGraph after a threshold. |
 | [`316_index_int8_hgraph.cpp`](316_index_int8_hgraph.cpp) | HGraph + INT8 | HGraph with INT8-quantized vectors. |
 | [`321_index_fp16_hgraph.cpp`](321_index_fp16_hgraph.cpp) | HGraph + FP16 | HGraph with FP16-quantized vectors. |
 

--- a/include/vsag/constants.h
+++ b/include/vsag/constants.h
@@ -17,6 +17,7 @@
 namespace vsag {
 
 extern const char* const INDEX_HGRAPH;
+extern const char* const INDEX_LAZY_HGRAPH;
 extern const char* const INDEX_DISKANN;
 extern const char* const INDEX_HNSW;
 extern const char* const INDEX_FRESH_HNSW;

--- a/include/vsag/index.h
+++ b/include/vsag/index.h
@@ -51,7 +51,18 @@ struct MergeUnit {
     IdMapFunction id_map_func = nullptr;
 };
 
-enum class IndexType { HNSW, DISKANN, HGRAPH, IVF, PYRAMID, BRUTEFORCE, SPARSE, SINDI, WARP };
+enum class IndexType {
+    HNSW,
+    DISKANN,
+    HGRAPH,
+    IVF,
+    PYRAMID,
+    BRUTEFORCE,
+    SPARSE,
+    SINDI,
+    WARP,
+    LAZY_HGRAPH
+};
 
 #define DATA_FLAG_FLOAT32_VECTOR 0x01
 #define DATA_FLAG_INT8_VECTOR 0x02

--- a/src/algorithm/CMakeLists.txt
+++ b/src/algorithm/CMakeLists.txt
@@ -17,6 +17,7 @@
 add_subdirectory (hnswlib)
 add_subdirectory (sindi)
 add_subdirectory (hgraph)
+add_subdirectory (lazy_hgraph)
 add_subdirectory (bruteforce)
 add_subdirectory (ivf)
 add_subdirectory (pyramid)
@@ -36,6 +37,7 @@ set (ALGORITHM_LIBS
         hnswlib
         sindi
         hgraph
+        lazy_hgraph
         bruteforce
         ivf
         pyramid

--- a/src/algorithm/lazy_hgraph/CMakeLists.txt
+++ b/src/algorithm/lazy_hgraph/CMakeLists.txt
@@ -1,0 +1,7 @@
+set(LAZY_HGRAPH_SRCS
+    lazy_hgraph.cpp
+    lazy_hgraph_parameter.cpp
+)
+
+add_library(lazy_hgraph OBJECT ${LAZY_HGRAPH_SRCS})
+target_link_libraries(lazy_hgraph PRIVATE coverage_config vsag_src_common)

--- a/src/algorithm/lazy_hgraph/lazy_hgraph.cpp
+++ b/src/algorithm/lazy_hgraph/lazy_hgraph.cpp
@@ -47,13 +47,27 @@ reject_flat_param(const JsonType& external_param, const char* key) {
         fmt::format("lazy_hgraph flat phase is fixed to fp32 and does not accept {}", key));
 }
 
+uint64_t
+parse_transition_threshold(const JsonType& threshold_json) {
+    CHECK_ARGUMENT(threshold_json.IsNumberInteger(),
+                   "lazy_hgraph transition_threshold must be an integer");
+    if (threshold_json.IsNumberUnsigned()) {
+        const auto threshold_value = threshold_json.GetUint64();
+        CHECK_ARGUMENT(threshold_value > 0, "lazy_hgraph transition_threshold must be positive");
+        return threshold_value;
+    }
+    const auto threshold_value = threshold_json.GetInt();
+    CHECK_ARGUMENT(threshold_value > 0, "lazy_hgraph transition_threshold must be positive");
+    return static_cast<uint64_t>(threshold_value);
+}
+
 JsonType
 make_lazy_inner_json(uint64_t transition_threshold,
                      const ParamPtr& flat_param,
                      const ParamPtr& graph_param) {
     JsonType inner_json;
     inner_json["type"].SetString(INDEX_LAZY_HGRAPH);
-    inner_json[LAZY_HGRAPH_TRANSITION_THRESHOLD].SetInt(transition_threshold);
+    inner_json[LAZY_HGRAPH_TRANSITION_THRESHOLD].SetUint64(transition_threshold);
     inner_json["flat"].SetJson(flat_param->ToJson());
     inner_json[LAZY_HGRAPH_HGRAPH].SetJson(graph_param->ToJson());
     return inner_json;
@@ -81,17 +95,14 @@ LazyHGraph::CheckAndMappingExternalParam(const JsonType& external_param,
                    "lazy_hgraph only supports float32 vectors");
     reject_flat_param(external_param, INDEX_BRUTE_FORCE);
     reject_flat_param(external_param, "bruteforce");
+    reject_flat_param(external_param, "flat");
     reject_flat_param(external_param, "flat_quantization_type");
     reject_flat_param(external_param, "flat_base_quantization_type");
 
     uint64_t transition_threshold = 1000;
     if (external_param.Contains(LAZY_HGRAPH_TRANSITION_THRESHOLD)) {
-        const auto threshold_json = external_param[LAZY_HGRAPH_TRANSITION_THRESHOLD];
-        CHECK_ARGUMENT(threshold_json.IsNumberInteger(),
-                       "lazy_hgraph transition_threshold must be an integer");
-        const auto threshold_value = threshold_json.GetInt();
-        CHECK_ARGUMENT(threshold_value > 0, "lazy_hgraph transition_threshold must be positive");
-        transition_threshold = static_cast<uint64_t>(threshold_value);
+        transition_threshold =
+            parse_transition_threshold(external_param[LAZY_HGRAPH_TRANSITION_THRESHOLD]);
     }
     CHECK_ARGUMENT(transition_threshold > 0, "lazy_hgraph transition_threshold must be positive");
 
@@ -318,10 +329,6 @@ LazyHGraph::GetVectorByIds(const int64_t* ids,
 
 void
 LazyHGraph::Serialize(StreamWriter& writer) const {
-    if (phase_.load(std::memory_order_acquire) == Phase::FLAT and GetNumElements() > 0) {
-        const_cast<LazyHGraph*>(this)->TransitionToGraph();
-    }
-
     std::shared_lock lock(this->phase_mutex_);
     StreamWriter::WriteObj(writer, LAZY_HGRAPH_MAGIC);
     StreamWriter::WriteObj(writer, LAZY_HGRAPH_VERSION);
@@ -330,6 +337,8 @@ LazyHGraph::Serialize(StreamWriter& writer) const {
     StreamWriter::WriteObj(writer, phase_value);
     if (phase == Phase::GRAPH) {
         graph_index_->Serialize(writer);
+    } else {
+        flat_index_->Serialize(writer);
     }
 }
 
@@ -344,11 +353,13 @@ LazyHGraph::Deserialize(StreamReader& reader) {
 
     uint8_t phase_value = 0;
     StreamReader::ReadObj(reader, phase_value);
+    CHECK_ARGUMENT(phase_value <= static_cast<uint8_t>(Phase::GRAPH), "invalid lazy_hgraph phase");
     auto phase = static_cast<Phase>(phase_value);
     std::unique_lock lock(this->phase_mutex_);
     if (phase == Phase::FLAT) {
         flat_index_ = std::make_shared<BruteForce>(flat_param_, this->common_param_);
         flat_index_->InitFeatures();
+        flat_index_->Deserialize(reader);
         graph_index_.reset();
         phase_.store(Phase::FLAT, std::memory_order_release);
         return;

--- a/src/algorithm/lazy_hgraph/lazy_hgraph.cpp
+++ b/src/algorithm/lazy_hgraph/lazy_hgraph.cpp
@@ -18,6 +18,7 @@
 
 #include <algorithm>
 #include <cstring>
+#include <limits>
 #include <mutex>
 #include <stdexcept>
 #include <vector>
@@ -58,6 +59,19 @@ make_lazy_inner_json(uint64_t transition_threshold,
     return inner_json;
 }
 
+LazyHGraphParameterPtr
+checked_lazy_hgraph_param(const ParamPtr& param) {
+    auto lazy_param = std::dynamic_pointer_cast<LazyHGraphParameter>(param);
+    CHECK_ARGUMENT(lazy_param != nullptr, "lazy_hgraph parameter must be LazyHGraphParameter");
+    return lazy_param;
+}
+
+const LazyHGraphParameterPtr&
+checked_lazy_hgraph_param(const LazyHGraphParameterPtr& param) {
+    CHECK_ARGUMENT(param != nullptr, "lazy_hgraph parameter must be LazyHGraphParameter");
+    return param;
+}
+
 }  // namespace
 
 ParamPtr
@@ -72,7 +86,12 @@ LazyHGraph::CheckAndMappingExternalParam(const JsonType& external_param,
 
     uint64_t transition_threshold = 1000;
     if (external_param.Contains(LAZY_HGRAPH_TRANSITION_THRESHOLD)) {
-        transition_threshold = external_param[LAZY_HGRAPH_TRANSITION_THRESHOLD].GetInt();
+        const auto threshold_json = external_param[LAZY_HGRAPH_TRANSITION_THRESHOLD];
+        CHECK_ARGUMENT(threshold_json.IsNumberInteger(),
+                       "lazy_hgraph transition_threshold must be an integer");
+        const auto threshold_value = threshold_json.GetInt();
+        CHECK_ARGUMENT(threshold_value > 0, "lazy_hgraph transition_threshold must be positive");
+        transition_threshold = static_cast<uint64_t>(threshold_value);
     }
     CHECK_ARGUMENT(transition_threshold > 0, "lazy_hgraph transition_threshold must be positive");
 
@@ -90,11 +109,15 @@ LazyHGraph::CheckAndMappingExternalParam(const JsonType& external_param,
     return lazy_param;
 }
 
+LazyHGraph::LazyHGraph(const ParamPtr& param, const IndexCommonParam& common_param)
+    : LazyHGraph(checked_lazy_hgraph_param(param), common_param) {
+}
+
 LazyHGraph::LazyHGraph(const LazyHGraphParameterPtr& param, const IndexCommonParam& common_param)
-    : InnerIndexInterface(param, common_param),
-      transition_threshold_(param->transition_threshold),
-      flat_param_(param->flat_param),
-      graph_param_(param->graph_param),
+    : InnerIndexInterface(checked_lazy_hgraph_param(param), common_param),
+      transition_threshold_(checked_lazy_hgraph_param(param)->transition_threshold),
+      flat_param_(checked_lazy_hgraph_param(param)->flat_param),
+      graph_param_(checked_lazy_hgraph_param(param)->graph_param),
       common_param_(common_param) {
     this->flat_index_ = std::make_shared<BruteForce>(flat_param_, common_param);
     this->flat_index_->InitFeatures();
@@ -153,10 +176,16 @@ LazyHGraph::TransitionToGraph() {
         return;
     }
     auto id_dataset = flat_index_->ExportIDs();
+    if (id_dataset == nullptr) {
+        return;
+    }
     const auto total = id_dataset->GetNumElements();
     const auto* ids = id_dataset->GetIds();
+    if (ids == nullptr) {
+        return;
+    }
     std::vector<int64_t> valid_ids;
-    valid_ids.reserve(total);
+    valid_ids.reserve(static_cast<uint64_t>(total));
     for (int64_t i = 0; i < total; ++i) {
         if (flat_index_->CheckIdExist(ids[i])) {
             valid_ids.emplace_back(ids[i]);
@@ -166,18 +195,29 @@ LazyHGraph::TransitionToGraph() {
         return;
     }
 
-    auto build_data = flat_index_->GetVectorByIds(valid_ids.data(), valid_ids.size(), nullptr);
+    CHECK_ARGUMENT(valid_ids.size() <= static_cast<uint64_t>(std::numeric_limits<int64_t>::max()),
+                   "lazy_hgraph transition id count is too large");
+    const auto valid_count = static_cast<int64_t>(valid_ids.size());
+
+    auto build_data = flat_index_->GetVectorByIds(valid_ids.data(), valid_count, this->allocator_);
+    if (build_data == nullptr) {
+        throw VsagException(ErrorType::NO_ENOUGH_MEMORY, "failed to get lazy_hgraph vectors");
+    }
     auto* build_ids =
         static_cast<int64_t*>(this->allocator_->Allocate(sizeof(int64_t) * valid_ids.size()));
     if (build_ids == nullptr) {
         throw VsagException(ErrorType::NO_ENOUGH_MEMORY, "failed to allocate lazy_hgraph ids");
     }
     std::memcpy(build_ids, valid_ids.data(), sizeof(int64_t) * valid_ids.size());
-    build_data->Ids(build_ids)->NumElements(valid_ids.size())->Dim(this->dim_);
+    build_data->Ids(build_ids)
+        ->NumElements(valid_count)
+        ->Dim(this->dim_)
+        ->Owner(true, this->allocator_);
 
     auto new_graph = std::make_shared<HGraph>(graph_param_, this->common_param_);
     new_graph->InitFeatures();
-    new_graph->Build(build_data);
+    auto failed_ids = new_graph->Build(build_data);
+    CHECK_ARGUMENT(failed_ids.empty(), "lazy_hgraph transition failed to build all ids");
     graph_index_ = new_graph;
     flat_index_.reset();
     phase_.store(Phase::GRAPH, std::memory_order_release);

--- a/src/algorithm/lazy_hgraph/lazy_hgraph.cpp
+++ b/src/algorithm/lazy_hgraph/lazy_hgraph.cpp
@@ -1,0 +1,352 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lazy_hgraph.h"
+
+#include <fmt/format.h>
+
+#include <algorithm>
+#include <cstring>
+#include <mutex>
+#include <stdexcept>
+#include <vector>
+
+#include "dataset_impl.h"
+#include "index_common_param.h"
+#include "index_feature_list.h"
+#include "storage/stream_reader.h"
+#include "storage/stream_writer.h"
+#include "vsag/constants.h"
+
+namespace vsag {
+
+namespace {
+
+const char* const LAZY_HGRAPH_TRANSITION_THRESHOLD = "transition_threshold";
+const char* const LAZY_HGRAPH_HGRAPH = "hgraph";
+
+constexpr uint64_t LAZY_HGRAPH_MAGIC = 0x4C415A5948475246ULL;  // "LAZYHGRF"
+constexpr uint64_t LAZY_HGRAPH_VERSION = 1;
+
+void
+reject_flat_param(const JsonType& external_param, const char* key) {
+    CHECK_ARGUMENT(
+        not external_param.Contains(key),
+        fmt::format("lazy_hgraph flat phase is fixed to fp32 and does not accept {}", key));
+}
+
+JsonType
+make_lazy_inner_json(uint64_t transition_threshold,
+                     const ParamPtr& flat_param,
+                     const ParamPtr& graph_param) {
+    JsonType inner_json;
+    inner_json["type"].SetString(INDEX_LAZY_HGRAPH);
+    inner_json[LAZY_HGRAPH_TRANSITION_THRESHOLD].SetInt(transition_threshold);
+    inner_json["flat"].SetJson(flat_param->ToJson());
+    inner_json[LAZY_HGRAPH_HGRAPH].SetJson(graph_param->ToJson());
+    return inner_json;
+}
+
+}  // namespace
+
+ParamPtr
+LazyHGraph::CheckAndMappingExternalParam(const JsonType& external_param,
+                                         const IndexCommonParam& common_param) {
+    CHECK_ARGUMENT(common_param.data_type_ == DataTypes::DATA_TYPE_FLOAT,
+                   "lazy_hgraph only supports float32 vectors");
+    reject_flat_param(external_param, INDEX_BRUTE_FORCE);
+    reject_flat_param(external_param, "bruteforce");
+    reject_flat_param(external_param, "flat_quantization_type");
+    reject_flat_param(external_param, "flat_base_quantization_type");
+
+    uint64_t transition_threshold = 1000;
+    if (external_param.Contains(LAZY_HGRAPH_TRANSITION_THRESHOLD)) {
+        transition_threshold = external_param[LAZY_HGRAPH_TRANSITION_THRESHOLD].GetInt();
+    }
+    CHECK_ARGUMENT(transition_threshold > 0, "lazy_hgraph transition_threshold must be positive");
+
+    JsonType hgraph_json;
+    if (external_param.Contains(LAZY_HGRAPH_HGRAPH)) {
+        hgraph_json = external_param[LAZY_HGRAPH_HGRAPH];
+    }
+
+    JsonType flat_json;
+    auto flat_param = BruteForce::CheckAndMappingExternalParam(flat_json, common_param);
+    auto graph_param = HGraph::CheckAndMappingExternalParam(hgraph_json, common_param);
+
+    auto lazy_param = std::make_shared<LazyHGraphParameter>();
+    lazy_param->FromJson(make_lazy_inner_json(transition_threshold, flat_param, graph_param));
+    return lazy_param;
+}
+
+LazyHGraph::LazyHGraph(const LazyHGraphParameterPtr& param, const IndexCommonParam& common_param)
+    : InnerIndexInterface(param, common_param),
+      transition_threshold_(param->transition_threshold),
+      flat_param_(param->flat_param),
+      graph_param_(param->graph_param),
+      common_param_(common_param) {
+    this->flat_index_ = std::make_shared<BruteForce>(flat_param_, common_param);
+    this->flat_index_->InitFeatures();
+    this->has_raw_vector_ = true;
+}
+
+InnerIndexInterface*
+LazyHGraph::ActiveIndex() const {
+    if (phase_.load(std::memory_order_acquire) == Phase::FLAT) {
+        return flat_index_.get();
+    }
+    CHECK_ARGUMENT(graph_index_ != nullptr, "lazy_hgraph graph index is not initialized");
+    return graph_index_.get();
+}
+
+std::vector<int64_t>
+LazyHGraph::Build(const DatasetPtr& data) {
+    std::unique_lock lock(this->phase_mutex_);
+    CHECK_ARGUMENT(ActiveIndex()->GetNumElements() == 0, "index is not empty");
+    if (static_cast<uint64_t>(data->GetNumElements()) < transition_threshold_) {
+        phase_.store(Phase::FLAT, std::memory_order_release);
+        return flat_index_->Build(data);
+    }
+    graph_index_ = std::make_shared<HGraph>(graph_param_, this->common_param_);
+    graph_index_->InitFeatures();
+    auto failed_ids = graph_index_->Build(data);
+    phase_.store(Phase::GRAPH, std::memory_order_release);
+    flat_index_.reset();
+    return failed_ids;
+}
+
+std::vector<int64_t>
+LazyHGraph::Add(const DatasetPtr& data, AddMode mode) {
+    std::vector<int64_t> failed_ids;
+    bool need_transition = false;
+    {
+        std::shared_lock lock(this->phase_mutex_);
+        if (phase_.load(std::memory_order_acquire) == Phase::FLAT) {
+            failed_ids = flat_index_->Add(data, mode);
+            need_transition =
+                static_cast<uint64_t>(flat_index_->GetNumElements()) >= transition_threshold_;
+        } else {
+            failed_ids = graph_index_->Add(data, mode);
+        }
+    }
+    if (need_transition) {
+        TransitionToGraph();
+    }
+    return failed_ids;
+}
+
+void
+LazyHGraph::TransitionToGraph() {
+    std::unique_lock lock(this->phase_mutex_);
+    if (phase_.load(std::memory_order_acquire) == Phase::GRAPH) {
+        return;
+    }
+    auto id_dataset = flat_index_->ExportIDs();
+    const auto total = id_dataset->GetNumElements();
+    const auto* ids = id_dataset->GetIds();
+    std::vector<int64_t> valid_ids;
+    valid_ids.reserve(total);
+    for (int64_t i = 0; i < total; ++i) {
+        if (flat_index_->CheckIdExist(ids[i])) {
+            valid_ids.emplace_back(ids[i]);
+        }
+    }
+    if (valid_ids.empty()) {
+        return;
+    }
+
+    auto build_data = flat_index_->GetVectorByIds(valid_ids.data(), valid_ids.size(), nullptr);
+    auto* build_ids =
+        static_cast<int64_t*>(this->allocator_->Allocate(sizeof(int64_t) * valid_ids.size()));
+    if (build_ids == nullptr) {
+        throw VsagException(ErrorType::NO_ENOUGH_MEMORY, "failed to allocate lazy_hgraph ids");
+    }
+    std::memcpy(build_ids, valid_ids.data(), sizeof(int64_t) * valid_ids.size());
+    build_data->Ids(build_ids)->NumElements(valid_ids.size())->Dim(this->dim_);
+
+    auto new_graph = std::make_shared<HGraph>(graph_param_, this->common_param_);
+    new_graph->InitFeatures();
+    new_graph->Build(build_data);
+    graph_index_ = new_graph;
+    flat_index_.reset();
+    phase_.store(Phase::GRAPH, std::memory_order_release);
+}
+
+DatasetPtr
+LazyHGraph::KnnSearch(const DatasetPtr& query,
+                      int64_t k,
+                      const std::string& parameters,
+                      const FilterPtr& filter) const {
+    std::shared_lock lock(this->phase_mutex_);
+    return ActiveIndex()->KnnSearch(query, k, parameters, filter);
+}
+
+DatasetPtr
+LazyHGraph::RangeSearch(const DatasetPtr& query,
+                        float radius,
+                        const std::string& parameters,
+                        const FilterPtr& filter,
+                        int64_t limited_size) const {
+    std::shared_lock lock(this->phase_mutex_);
+    return ActiveIndex()->RangeSearch(query, radius, parameters, filter, limited_size);
+}
+
+float
+LazyHGraph::CalcDistanceById(const float* query,
+                             int64_t id,
+                             bool calculate_precise_distance) const {
+    std::shared_lock lock(this->phase_mutex_);
+    return ActiveIndex()->CalcDistanceById(query, id, calculate_precise_distance);
+}
+
+bool
+LazyHGraph::CheckIdExist(int64_t id) const {
+    std::shared_lock lock(this->phase_mutex_);
+    return ActiveIndex()->CheckIdExist(id);
+}
+
+uint32_t
+LazyHGraph::Remove(const std::vector<int64_t>& ids, RemoveMode mode) {
+    std::shared_lock lock(this->phase_mutex_);
+    return ActiveIndex()->Remove(ids, mode);
+}
+
+int64_t
+LazyHGraph::GetNumElements() const {
+    std::shared_lock lock(this->phase_mutex_);
+    return ActiveIndex()->GetNumElements();
+}
+
+int64_t
+LazyHGraph::GetNumberRemoved() const {
+    std::shared_lock lock(this->phase_mutex_);
+    return ActiveIndex()->GetNumberRemoved();
+}
+
+void
+LazyHGraph::GetVectorByInnerId(InnerIdType inner_id, float* data) const {
+    std::shared_lock lock(this->phase_mutex_);
+    ActiveIndex()->GetVectorByInnerId(inner_id, data);
+}
+
+uint64_t
+LazyHGraph::EstimateMemory(uint64_t num_elements) const {
+    if (num_elements < transition_threshold_) {
+        auto flat_index = std::make_shared<BruteForce>(flat_param_, this->common_param_);
+        return flat_index->EstimateMemory(num_elements);
+    }
+    auto graph_index = std::make_shared<HGraph>(graph_param_, this->common_param_);
+    return graph_index->EstimateMemory(num_elements);
+}
+
+DatasetPtr
+LazyHGraph::ExportIDs() const {
+    std::shared_lock lock(this->phase_mutex_);
+    return ActiveIndex()->ExportIDs();
+}
+
+DatasetPtr
+LazyHGraph::GetDataByIds(const int64_t* ids, int64_t count) const {
+    std::shared_lock lock(this->phase_mutex_);
+    return ActiveIndex()->GetDataByIds(ids, count);
+}
+
+int64_t
+LazyHGraph::GetMemoryUsage() const {
+    std::shared_lock lock(this->phase_mutex_);
+    return ActiveIndex()->GetMemoryUsage();
+}
+
+DatasetPtr
+LazyHGraph::GetVectorByIds(const int64_t* ids,
+                           int64_t count,
+                           Allocator* specified_allocator) const {
+    std::shared_lock lock(this->phase_mutex_);
+    return ActiveIndex()->GetVectorByIds(ids, count, specified_allocator);
+}
+
+void
+LazyHGraph::Serialize(StreamWriter& writer) const {
+    if (phase_.load(std::memory_order_acquire) == Phase::FLAT and GetNumElements() > 0) {
+        const_cast<LazyHGraph*>(this)->TransitionToGraph();
+    }
+
+    std::shared_lock lock(this->phase_mutex_);
+    StreamWriter::WriteObj(writer, LAZY_HGRAPH_MAGIC);
+    StreamWriter::WriteObj(writer, LAZY_HGRAPH_VERSION);
+    auto phase = phase_.load(std::memory_order_acquire);
+    auto phase_value = static_cast<uint8_t>(phase);
+    StreamWriter::WriteObj(writer, phase_value);
+    if (phase == Phase::GRAPH) {
+        graph_index_->Serialize(writer);
+    }
+}
+
+void
+LazyHGraph::Deserialize(StreamReader& reader) {
+    uint64_t magic = 0;
+    uint64_t version = 0;
+    StreamReader::ReadObj(reader, magic);
+    StreamReader::ReadObj(reader, version);
+    CHECK_ARGUMENT(magic == LAZY_HGRAPH_MAGIC, "invalid lazy_hgraph magic");
+    CHECK_ARGUMENT(version == LAZY_HGRAPH_VERSION, "unsupported lazy_hgraph version");
+
+    uint8_t phase_value = 0;
+    StreamReader::ReadObj(reader, phase_value);
+    auto phase = static_cast<Phase>(phase_value);
+    std::unique_lock lock(this->phase_mutex_);
+    if (phase == Phase::FLAT) {
+        flat_index_ = std::make_shared<BruteForce>(flat_param_, this->common_param_);
+        flat_index_->InitFeatures();
+        graph_index_.reset();
+        phase_.store(Phase::FLAT, std::memory_order_release);
+        return;
+    }
+    graph_index_ = std::make_shared<HGraph>(graph_param_, this->common_param_);
+    graph_index_->InitFeatures();
+    graph_index_->Deserialize(reader);
+    flat_index_.reset();
+    phase_.store(Phase::GRAPH, std::memory_order_release);
+}
+
+void
+LazyHGraph::InitFeatures() {
+    this->index_feature_list_->SetFeatures({
+        IndexFeature::SUPPORT_ADD_FROM_EMPTY,
+        IndexFeature::SUPPORT_BUILD,
+        IndexFeature::SUPPORT_ADD_AFTER_BUILD,
+        IndexFeature::SUPPORT_DELETE_BY_ID,
+        IndexFeature::SUPPORT_KNN_SEARCH,
+        IndexFeature::SUPPORT_KNN_SEARCH_WITH_ID_FILTER,
+        IndexFeature::SUPPORT_RANGE_SEARCH,
+        IndexFeature::SUPPORT_RANGE_SEARCH_WITH_ID_FILTER,
+        IndexFeature::SUPPORT_CAL_DISTANCE_BY_ID,
+        IndexFeature::SUPPORT_GET_RAW_VECTOR_BY_IDS,
+        IndexFeature::SUPPORT_SEARCH_CONCURRENT,
+        IndexFeature::SUPPORT_ADD_CONCURRENT,
+        IndexFeature::SUPPORT_DELETE_CONCURRENT,
+        IndexFeature::SUPPORT_DESERIALIZE_BINARY_SET,
+        IndexFeature::SUPPORT_DESERIALIZE_FILE,
+        IndexFeature::SUPPORT_DESERIALIZE_READER_SET,
+        IndexFeature::SUPPORT_SERIALIZE_BINARY_SET,
+        IndexFeature::SUPPORT_SERIALIZE_FILE,
+        IndexFeature::SUPPORT_SERIALIZE_WRITE_FUNC,
+        IndexFeature::SUPPORT_ESTIMATE_MEMORY,
+        IndexFeature::SUPPORT_GET_MEMORY_USAGE,
+        IndexFeature::SUPPORT_CHECK_ID_EXIST,
+        IndexFeature::SUPPORT_CLONE,
+    });
+}
+
+}  // namespace vsag

--- a/src/algorithm/lazy_hgraph/lazy_hgraph.h
+++ b/src/algorithm/lazy_hgraph/lazy_hgraph.h
@@ -1,0 +1,146 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <atomic>
+#include <memory>
+#include <shared_mutex>
+
+#include "algorithm/bruteforce/bruteforce.h"
+#include "algorithm/hgraph/hgraph.h"
+#include "algorithm/inner_index_interface.h"
+#include "index_common_param.h"
+#include "lazy_hgraph_parameter.h"
+
+namespace vsag {
+
+class LazyHGraph : public InnerIndexInterface {
+public:
+    enum class Phase : uint8_t { FLAT = 0, GRAPH = 1 };
+
+    static ParamPtr
+    CheckAndMappingExternalParam(const JsonType& external_param,
+                                 const IndexCommonParam& common_param);
+
+public:
+    LazyHGraph(const LazyHGraphParameterPtr& param, const IndexCommonParam& common_param);
+
+    LazyHGraph(const ParamPtr& param, const IndexCommonParam& common_param)
+        : LazyHGraph(std::dynamic_pointer_cast<LazyHGraphParameter>(param), common_param){};
+
+    std::vector<int64_t>
+    Add(const DatasetPtr& data, AddMode mode = AddMode::DEFAULT) override;
+
+    std::vector<int64_t>
+    Build(const DatasetPtr& data) override;
+
+    float
+    CalcDistanceById(const float* query,
+                     int64_t id,
+                     bool calculate_precise_distance = true) const override;
+
+    void
+    Deserialize(StreamReader& reader) override;
+
+    uint64_t
+    EstimateMemory(uint64_t num_elements) const override;
+
+    DatasetPtr
+    ExportIDs() const override;
+
+    [[nodiscard]] InnerIndexPtr
+    Fork(const IndexCommonParam& param) override {
+        return std::make_shared<LazyHGraph>(this->create_param_ptr_, param);
+    }
+
+    [[nodiscard]] bool
+    CheckIdExist(int64_t id) const override;
+
+    [[nodiscard]] IndexType
+    GetIndexType() const override {
+        return IndexType::LAZY_HGRAPH;
+    }
+
+    [[nodiscard]] std::string
+    GetName() const override {
+        return INDEX_LAZY_HGRAPH;
+    }
+
+    [[nodiscard]] int64_t
+    GetNumElements() const override;
+
+    [[nodiscard]] int64_t
+    GetNumberRemoved() const override;
+
+    [[nodiscard]] DatasetPtr
+    GetDataByIds(const int64_t* ids, int64_t count) const override;
+
+    [[nodiscard]] int64_t
+    GetMemoryUsage() const override;
+
+    void
+    GetVectorByInnerId(InnerIdType inner_id, float* data) const override;
+
+    DatasetPtr
+    GetVectorByIds(const int64_t* ids,
+                   int64_t count,
+                   Allocator* specified_allocator) const override;
+
+    void
+    InitFeatures() override;
+
+    [[nodiscard]] DatasetPtr
+    KnnSearch(const DatasetPtr& query,
+              int64_t k,
+              const std::string& parameters,
+              const FilterPtr& filter) const override;
+
+    [[nodiscard]] DatasetPtr
+    RangeSearch(const DatasetPtr& query,
+                float radius,
+                const std::string& parameters,
+                const FilterPtr& filter,
+                int64_t limited_size = -1) const override;
+
+    uint32_t
+    Remove(const std::vector<int64_t>& ids, RemoveMode mode = RemoveMode::MARK_REMOVE) override;
+
+    void
+    Serialize(StreamWriter& writer) const override;
+
+    [[nodiscard]] Phase
+    GetPhase() const {
+        return phase_.load(std::memory_order_acquire);
+    }
+
+private:
+    void
+    TransitionToGraph();
+
+    InnerIndexInterface*
+    ActiveIndex() const;
+
+private:
+    std::atomic<Phase> phase_{Phase::FLAT};
+    uint64_t transition_threshold_{1000};
+    BruteForceParameterPtr flat_param_{nullptr};
+    HGraphParameterPtr graph_param_{nullptr};
+    IndexCommonParam common_param_;
+    std::shared_ptr<BruteForce> flat_index_{nullptr};
+    std::shared_ptr<HGraph> graph_index_{nullptr};
+    mutable std::shared_mutex phase_mutex_;
+};
+
+}  // namespace vsag

--- a/src/algorithm/lazy_hgraph/lazy_hgraph.h
+++ b/src/algorithm/lazy_hgraph/lazy_hgraph.h
@@ -37,8 +37,7 @@ public:
 public:
     LazyHGraph(const LazyHGraphParameterPtr& param, const IndexCommonParam& common_param);
 
-    LazyHGraph(const ParamPtr& param, const IndexCommonParam& common_param)
-        : LazyHGraph(std::dynamic_pointer_cast<LazyHGraphParameter>(param), common_param){};
+    LazyHGraph(const ParamPtr& param, const IndexCommonParam& common_param);
 
     std::vector<int64_t>
     Add(const DatasetPtr& data, AddMode mode = AddMode::DEFAULT) override;

--- a/src/algorithm/lazy_hgraph/lazy_hgraph_parameter.cpp
+++ b/src/algorithm/lazy_hgraph/lazy_hgraph_parameter.cpp
@@ -1,0 +1,75 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lazy_hgraph_parameter.h"
+
+#include <fmt/format.h>
+
+#include "impl/logger/logger.h"
+#include "vsag/constants.h"
+
+namespace vsag {
+
+namespace {
+const char* const LAZY_HGRAPH_TRANSITION_THRESHOLD = "transition_threshold";
+const char* const LAZY_HGRAPH_GRAPH = "hgraph";
+const char* const LAZY_HGRAPH_FLAT = "flat";
+}  // namespace
+
+void
+LazyHGraphParameter::FromJson(const JsonType& json) {
+    InnerIndexParameter::FromJson(json);
+    CHECK_ARGUMENT(
+        json.Contains(LAZY_HGRAPH_TRANSITION_THRESHOLD),
+        fmt::format("lazy_hgraph parameters must contain {}", LAZY_HGRAPH_TRANSITION_THRESHOLD));
+    CHECK_ARGUMENT(json.Contains(LAZY_HGRAPH_GRAPH),
+                   fmt::format("lazy_hgraph parameters must contain {}", LAZY_HGRAPH_GRAPH));
+    CHECK_ARGUMENT(json.Contains(LAZY_HGRAPH_FLAT),
+                   fmt::format("lazy_hgraph parameters must contain {}", LAZY_HGRAPH_FLAT));
+
+    this->transition_threshold = json[LAZY_HGRAPH_TRANSITION_THRESHOLD].GetInt();
+    this->graph_param = std::make_shared<HGraphParameter>();
+    this->graph_param->FromJson(json[LAZY_HGRAPH_GRAPH]);
+    this->flat_param = std::make_shared<BruteForceParameter>();
+    this->flat_param->FromJson(json[LAZY_HGRAPH_FLAT]);
+}
+
+JsonType
+LazyHGraphParameter::ToJson() const {
+    JsonType json = InnerIndexParameter::ToJson();
+    json["type"].SetString(INDEX_LAZY_HGRAPH);
+    json[LAZY_HGRAPH_TRANSITION_THRESHOLD].SetInt(this->transition_threshold);
+    json[LAZY_HGRAPH_GRAPH].SetJson(this->graph_param->ToJson());
+    json[LAZY_HGRAPH_FLAT].SetJson(this->flat_param->ToJson());
+    return json;
+}
+
+bool
+LazyHGraphParameter::CheckCompatibility(const ParamPtr& other) const {
+    if (not InnerIndexParameter::CheckCompatibility(other)) {
+        return false;
+    }
+    auto lazy_param = std::dynamic_pointer_cast<LazyHGraphParameter>(other);
+    if (not lazy_param) {
+        logger::error(
+            "LazyHGraphParameter::CheckCompatibility: "
+            "other parameter is not a LazyHGraphParameter");
+        return false;
+    }
+    return this->transition_threshold == lazy_param->transition_threshold and
+           this->flat_param->CheckCompatibility(lazy_param->flat_param) and
+           this->graph_param->CheckCompatibility(lazy_param->graph_param);
+}
+
+}  // namespace vsag

--- a/src/algorithm/lazy_hgraph/lazy_hgraph_parameter.cpp
+++ b/src/algorithm/lazy_hgraph/lazy_hgraph_parameter.cpp
@@ -41,9 +41,15 @@ LazyHGraphParameter::FromJson(const JsonType& json) {
     const auto threshold_json = json[LAZY_HGRAPH_TRANSITION_THRESHOLD];
     CHECK_ARGUMENT(threshold_json.IsNumberInteger(),
                    "lazy_hgraph transition_threshold must be an integer");
-    const auto threshold = threshold_json.GetInt();
-    CHECK_ARGUMENT(threshold > 0, "lazy_hgraph transition_threshold must be positive");
-    this->transition_threshold = static_cast<uint64_t>(threshold);
+    if (threshold_json.IsNumberUnsigned()) {
+        this->transition_threshold = threshold_json.GetUint64();
+        CHECK_ARGUMENT(this->transition_threshold > 0,
+                       "lazy_hgraph transition_threshold must be positive");
+    } else {
+        const auto threshold = threshold_json.GetInt();
+        CHECK_ARGUMENT(threshold > 0, "lazy_hgraph transition_threshold must be positive");
+        this->transition_threshold = static_cast<uint64_t>(threshold);
+    }
     this->graph_param = std::make_shared<HGraphParameter>();
     this->graph_param->FromJson(json[LAZY_HGRAPH_GRAPH]);
     this->flat_param = std::make_shared<BruteForceParameter>();
@@ -54,7 +60,7 @@ JsonType
 LazyHGraphParameter::ToJson() const {
     JsonType json = InnerIndexParameter::ToJson();
     json["type"].SetString(INDEX_LAZY_HGRAPH);
-    json[LAZY_HGRAPH_TRANSITION_THRESHOLD].SetInt(this->transition_threshold);
+    json[LAZY_HGRAPH_TRANSITION_THRESHOLD].SetUint64(this->transition_threshold);
     json[LAZY_HGRAPH_GRAPH].SetJson(this->graph_param->ToJson());
     json[LAZY_HGRAPH_FLAT].SetJson(this->flat_param->ToJson());
     return json;

--- a/src/algorithm/lazy_hgraph/lazy_hgraph_parameter.cpp
+++ b/src/algorithm/lazy_hgraph/lazy_hgraph_parameter.cpp
@@ -38,7 +38,12 @@ LazyHGraphParameter::FromJson(const JsonType& json) {
     CHECK_ARGUMENT(json.Contains(LAZY_HGRAPH_FLAT),
                    fmt::format("lazy_hgraph parameters must contain {}", LAZY_HGRAPH_FLAT));
 
-    this->transition_threshold = json[LAZY_HGRAPH_TRANSITION_THRESHOLD].GetInt();
+    const auto threshold_json = json[LAZY_HGRAPH_TRANSITION_THRESHOLD];
+    CHECK_ARGUMENT(threshold_json.IsNumberInteger(),
+                   "lazy_hgraph transition_threshold must be an integer");
+    const auto threshold = threshold_json.GetInt();
+    CHECK_ARGUMENT(threshold > 0, "lazy_hgraph transition_threshold must be positive");
+    this->transition_threshold = static_cast<uint64_t>(threshold);
     this->graph_param = std::make_shared<HGraphParameter>();
     this->graph_param->FromJson(json[LAZY_HGRAPH_GRAPH]);
     this->flat_param = std::make_shared<BruteForceParameter>();

--- a/src/algorithm/lazy_hgraph/lazy_hgraph_parameter.h
+++ b/src/algorithm/lazy_hgraph/lazy_hgraph_parameter.h
@@ -1,0 +1,43 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "algorithm/bruteforce/bruteforce_parameter.h"
+#include "algorithm/hgraph/hgraph_parameter.h"
+
+namespace vsag {
+
+DEFINE_POINTER(LazyHGraphParameter);
+
+class LazyHGraphParameter : public InnerIndexParameter {
+public:
+    LazyHGraphParameter() = default;
+
+    void
+    FromJson(const JsonType& json) override;
+
+    JsonType
+    ToJson() const override;
+
+    bool
+    CheckCompatibility(const ParamPtr& other) const override;
+
+public:
+    uint64_t transition_threshold{1000};
+    BruteForceParameterPtr flat_param{nullptr};
+    HGraphParameterPtr graph_param{nullptr};
+};
+
+}  // namespace vsag

--- a/src/algorithm/lazy_hgraph/lazy_hgraph_test.cpp
+++ b/src/algorithm/lazy_hgraph/lazy_hgraph_test.cpp
@@ -14,9 +14,13 @@
 
 #include "lazy_hgraph.h"
 
+#include <atomic>
+#include <cmath>
 #include <memory>
+#include <thread>
 #include <vector>
 
+#include "algorithm/hgraph/hgraph.h"
 #include "impl/allocator/safe_allocator.h"
 #include "index_common_param.h"
 #include "unittest.h"
@@ -37,7 +41,7 @@ MakeCommonParam() {
 }
 
 vsag::JsonType
-MakeLazyParam(uint64_t threshold) {
+MakeLazyParam(uint64_t threshold, const std::string& base_quantization_type = "fp32") {
     auto param = vsag::JsonType::Parse(R"({
         "transition_threshold": 4,
         "hgraph": {
@@ -48,6 +52,7 @@ MakeLazyParam(uint64_t threshold) {
         }
     })");
     param["transition_threshold"].SetInt(threshold);
+    param["hgraph"]["base_quantization_type"].SetString(base_quantization_type);
     return param;
 }
 
@@ -82,10 +87,10 @@ MakeQuery(const std::vector<float>& vectors, int64_t row) {
 }
 
 std::shared_ptr<vsag::LazyHGraph>
-MakeLazyIndex(uint64_t threshold) {
+MakeLazyIndex(uint64_t threshold, const std::string& base_quantization_type = "fp32") {
     auto common_param = MakeCommonParam();
-    auto param =
-        vsag::LazyHGraph::CheckAndMappingExternalParam(MakeLazyParam(threshold), common_param);
+    auto param = vsag::LazyHGraph::CheckAndMappingExternalParam(
+        MakeLazyParam(threshold, base_quantization_type), common_param);
     auto index = std::make_shared<vsag::LazyHGraph>(param, common_param);
     index->InitFeatures();
     return index;
@@ -109,6 +114,16 @@ MakeFactoryParam(uint64_t threshold) {
     })");
     root["lazy_hgraph"]["transition_threshold"].SetInt(threshold);
     return root.Dump();
+}
+
+float
+L2(const float* lhs, const float* rhs) {
+    float distance = 0.0F;
+    for (int64_t i = 0; i < DIM; ++i) {
+        auto diff = lhs[i] - rhs[i];
+        distance += diff * diff;
+    }
+    return distance;
 }
 
 }  // namespace
@@ -210,4 +225,192 @@ TEST_CASE("LazyHGraph rejects flat quantization parameters", "[ut][lazy_hgraph]"
     param["flat_quantization_type"].SetString("sq8");
 
     REQUIRE_THROWS(vsag::LazyHGraph::CheckAndMappingExternalParam(param, common_param));
+}
+
+TEST_CASE("LazyHGraph build chooses flat or graph by threshold", "[ut][lazy_hgraph]") {
+    auto small_index = MakeLazyIndex(4);
+    std::vector<float> small_vectors;
+    std::vector<int64_t> small_ids;
+    auto small = MakeDataset(3, 800, small_vectors, small_ids);
+
+    REQUIRE(small_index->Build(small).empty());
+    REQUIRE(small_index->GetPhase() == vsag::LazyHGraph::Phase::FLAT);
+    REQUIRE(small_index->KnnSearch(MakeQuery(small_vectors, 0), 1, "{}", nullptr)->GetIds()[0] ==
+            800);
+
+    auto large_index = MakeLazyIndex(4);
+    std::vector<float> large_vectors;
+    std::vector<int64_t> large_ids;
+    auto large = MakeDataset(4, 900, large_vectors, large_ids);
+
+    REQUIRE(large_index->Build(large).empty());
+    REQUIRE(large_index->GetPhase() == vsag::LazyHGraph::Phase::GRAPH);
+    REQUIRE(
+        large_index
+            ->KnnSearch(MakeQuery(large_vectors, 0), 1, R"({"hgraph":{"ef_search":40}})", nullptr)
+            ->GetIds()[0] == 900);
+}
+
+TEST_CASE("LazyHGraph serializes empty flat and graph phases", "[ut][lazy_hgraph]") {
+    auto empty = MakeLazyIndex(4);
+    auto empty_binary = static_cast<vsag::InnerIndexInterface*>(empty.get())->Serialize();
+
+    auto restored_empty = MakeLazyIndex(4);
+    static_cast<vsag::InnerIndexInterface*>(restored_empty.get())->Deserialize(empty_binary);
+    REQUIRE(restored_empty->GetPhase() == vsag::LazyHGraph::Phase::FLAT);
+    REQUIRE(restored_empty->GetNumElements() == 0);
+
+    auto graph = MakeLazyIndex(2);
+    std::vector<float> vectors;
+    std::vector<int64_t> ids;
+    auto data = MakeDataset(2, 1000, vectors, ids);
+    REQUIRE(graph->Add(data).empty());
+    REQUIRE(graph->GetPhase() == vsag::LazyHGraph::Phase::GRAPH);
+
+    auto graph_binary = static_cast<vsag::InnerIndexInterface*>(graph.get())->Serialize();
+    auto restored_graph = MakeLazyIndex(2);
+    static_cast<vsag::InnerIndexInterface*>(restored_graph.get())->Deserialize(graph_binary);
+    REQUIRE(restored_graph->GetPhase() == vsag::LazyHGraph::Phase::GRAPH);
+    REQUIRE(restored_graph
+                ->KnnSearch(MakeQuery(vectors, 1), 1, R"({"hgraph":{"ef_search":40}})", nullptr)
+                ->GetIds()[0] == 1001);
+}
+
+TEST_CASE("LazyHGraph removes ids in both phases", "[ut][lazy_hgraph]") {
+    auto index = MakeLazyIndex(4);
+    std::vector<float> vectors;
+    std::vector<int64_t> ids;
+    auto data = MakeDataset(3, 1100, vectors, ids);
+
+    REQUIRE(index->Add(data).empty());
+    REQUIRE(index->GetPhase() == vsag::LazyHGraph::Phase::FLAT);
+    REQUIRE(index->Remove({1101}) == 1);
+    REQUIRE_FALSE(index->CheckIdExist(1101));
+    REQUIRE(index->GetNumberRemoved() == 1);
+
+    std::vector<float> more_vectors;
+    std::vector<int64_t> more_ids;
+    auto more = MakeDataset(2, 1200, more_vectors, more_ids);
+    REQUIRE(index->Add(more).empty());
+    REQUIRE(index->GetPhase() == vsag::LazyHGraph::Phase::GRAPH);
+    REQUIRE(index->Remove({1200}) == 1);
+    REQUIRE_FALSE(index->CheckIdExist(1200));
+    REQUIRE(index->GetNumberRemoved() == 1);
+}
+
+TEST_CASE("LazyHGraph preserves fp32 vectors during transition", "[ut][lazy_hgraph]") {
+    auto index = MakeLazyIndex(4);
+    std::vector<float> vectors;
+    std::vector<int64_t> ids;
+    auto data = MakeDataset(4, 1300, vectors, ids);
+
+    REQUIRE(index->Add(data).empty());
+    REQUIRE(index->GetPhase() == vsag::LazyHGraph::Phase::GRAPH);
+
+    auto fetched = index->GetVectorByIds(ids.data(), ids.size(), nullptr);
+    REQUIRE(fetched->GetNumElements() == ids.size());
+    const auto* fetched_vectors = fetched->GetFloat32Vectors();
+    for (int64_t i = 0; i < data->GetNumElements() * DIM; ++i) {
+        REQUIRE(fetched_vectors[i] == vectors[i]);
+    }
+}
+
+TEST_CASE("LazyHGraph graph search matches direct HGraph baseline", "[ut][lazy_hgraph]") {
+    std::vector<float> vectors;
+    std::vector<int64_t> ids;
+    auto data = MakeDataset(4, 1400, vectors, ids);
+    auto query = MakeQuery(vectors, 2);
+    auto search_param = R"({"hgraph":{"ef_search":40}})";
+
+    auto lazy = MakeLazyIndex(4);
+    REQUIRE(lazy->Add(data).empty());
+    auto lazy_result = lazy->KnnSearch(query, 2, search_param, nullptr);
+
+    auto common_param = MakeCommonParam();
+    auto graph_param =
+        vsag::HGraph::CheckAndMappingExternalParam(MakeLazyParam(4)["hgraph"], common_param);
+    auto hgraph = std::make_shared<vsag::HGraph>(graph_param, common_param);
+    hgraph->InitFeatures();
+    REQUIRE(hgraph->Build(data).empty());
+    auto hgraph_result = hgraph->KnnSearch(query, 2, search_param, nullptr);
+
+    REQUIRE(lazy_result->GetDim() == hgraph_result->GetDim());
+    for (int64_t i = 0; i < lazy_result->GetDim(); ++i) {
+        REQUIRE(lazy_result->GetIds()[i] == hgraph_result->GetIds()[i]);
+        REQUIRE(lazy_result->GetDistances()[i] == hgraph_result->GetDistances()[i]);
+    }
+}
+
+TEST_CASE("LazyHGraph keeps flat fp32 while graph quantization is configurable",
+          "[ut][lazy_hgraph]") {
+    auto index = MakeLazyIndex(4, "sq8");
+    std::vector<float> vectors;
+    std::vector<int64_t> ids;
+    auto data = MakeDataset(3, 1500, vectors, ids);
+
+    REQUIRE(index->Add(data).empty());
+    REQUIRE(index->GetPhase() == vsag::LazyHGraph::Phase::FLAT);
+    REQUIRE(index->CalcDistanceById(vectors.data(), 1500) == 0.0F);
+
+    std::vector<float> more_vectors;
+    std::vector<int64_t> more_ids;
+    auto more = MakeDataset(1, 1600, more_vectors, more_ids);
+    REQUIRE(index->Add(more).empty());
+    REQUIRE(index->GetPhase() == vsag::LazyHGraph::Phase::GRAPH);
+    REQUIRE(index->CheckIdExist(1600));
+}
+
+TEST_CASE("LazyHGraph calculates distance by id in flat and graph phases", "[ut][lazy_hgraph]") {
+    auto index = MakeLazyIndex(4);
+    std::vector<float> vectors;
+    std::vector<int64_t> ids;
+    auto data = MakeDataset(3, 1700, vectors, ids);
+
+    REQUIRE(index->Add(data).empty());
+    auto expected = L2(vectors.data(), vectors.data() + DIM);
+    REQUIRE(index->CalcDistanceById(vectors.data(), 1701) == expected);
+
+    std::vector<float> more_vectors;
+    std::vector<int64_t> more_ids;
+    auto more = MakeDataset(1, 1800, more_vectors, more_ids);
+    REQUIRE(index->Add(more).empty());
+    REQUIRE(index->GetPhase() == vsag::LazyHGraph::Phase::GRAPH);
+    REQUIRE(index->CalcDistanceById(more_vectors.data(), 1800) == 0.0F);
+}
+
+TEST_CASE("LazyHGraph supports concurrent search during transition", "[ut][lazy_hgraph]") {
+    auto index = MakeLazyIndex(8);
+    std::vector<float> vectors;
+    std::vector<int64_t> ids;
+    auto data = MakeDataset(4, 1900, vectors, ids);
+    REQUIRE(index->Add(data).empty());
+
+    std::atomic<bool> stop{false};
+    std::atomic<bool> failed{false};
+    std::thread search_thread([&]() {
+        while (not stop.load(std::memory_order_acquire)) {
+            try {
+                auto result = index->KnnSearch(
+                    MakeQuery(vectors, 0), 1, R"({"hgraph":{"ef_search":40}})", nullptr);
+                if (result == nullptr or result->GetIds()[0] != 1900) {
+                    failed.store(true, std::memory_order_release);
+                    return;
+                }
+            } catch (...) {
+                failed.store(true, std::memory_order_release);
+                return;
+            }
+        }
+    });
+
+    std::vector<float> more_vectors;
+    std::vector<int64_t> more_ids;
+    auto more = MakeDataset(4, 2000, more_vectors, more_ids);
+    REQUIRE(index->Add(more).empty());
+    stop.store(true, std::memory_order_release);
+    search_thread.join();
+
+    REQUIRE_FALSE(failed.load(std::memory_order_acquire));
+    REQUIRE(index->GetPhase() == vsag::LazyHGraph::Phase::GRAPH);
+    REQUIRE(index->CheckIdExist(2000));
 }

--- a/src/algorithm/lazy_hgraph/lazy_hgraph_test.cpp
+++ b/src/algorithm/lazy_hgraph/lazy_hgraph_test.cpp
@@ -227,6 +227,19 @@ TEST_CASE("LazyHGraph rejects flat quantization parameters", "[ut][lazy_hgraph]"
     REQUIRE_THROWS(vsag::LazyHGraph::CheckAndMappingExternalParam(param, common_param));
 }
 
+TEST_CASE("LazyHGraph rejects invalid parameter types", "[ut][lazy_hgraph]") {
+    auto common_param = MakeCommonParam();
+
+    auto negative_threshold = MakeLazyParam(4);
+    negative_threshold["transition_threshold"].SetJson(vsag::JsonType::Parse("-1"));
+    REQUIRE_THROWS(
+        vsag::LazyHGraph::CheckAndMappingExternalParam(negative_threshold, common_param));
+
+    auto graph_param =
+        vsag::HGraph::CheckAndMappingExternalParam(MakeLazyParam(4)["hgraph"], common_param);
+    REQUIRE_THROWS(vsag::LazyHGraph(graph_param, common_param));
+}
+
 TEST_CASE("LazyHGraph build chooses flat or graph by threshold", "[ut][lazy_hgraph]") {
     auto small_index = MakeLazyIndex(4);
     std::vector<float> small_vectors;
@@ -400,6 +413,7 @@ TEST_CASE("LazyHGraph supports concurrent search during transition", "[ut][lazy_
                 failed.store(true, std::memory_order_release);
                 return;
             }
+            std::this_thread::yield();
         }
     });
 

--- a/src/algorithm/lazy_hgraph/lazy_hgraph_test.cpp
+++ b/src/algorithm/lazy_hgraph/lazy_hgraph_test.cpp
@@ -1,0 +1,213 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lazy_hgraph.h"
+
+#include <memory>
+#include <vector>
+
+#include "impl/allocator/safe_allocator.h"
+#include "index_common_param.h"
+#include "unittest.h"
+#include "vsag/factory.h"
+
+namespace {
+
+constexpr int64_t DIM = 8;
+
+vsag::IndexCommonParam
+MakeCommonParam() {
+    vsag::IndexCommonParam common_param;
+    common_param.dim_ = DIM;
+    common_param.data_type_ = vsag::DataTypes::DATA_TYPE_FLOAT;
+    common_param.metric_ = vsag::MetricType::METRIC_TYPE_L2SQR;
+    common_param.allocator_ = vsag::SafeAllocator::FactoryDefaultAllocator();
+    return common_param;
+}
+
+vsag::JsonType
+MakeLazyParam(uint64_t threshold) {
+    auto param = vsag::JsonType::Parse(R"({
+        "transition_threshold": 4,
+        "hgraph": {
+            "base_quantization_type": "fp32",
+            "max_degree": 4,
+            "ef_construction": 8,
+            "build_thread_count": 1
+        }
+    })");
+    param["transition_threshold"].SetInt(threshold);
+    return param;
+}
+
+vsag::DatasetPtr
+MakeDataset(int64_t count,
+            int64_t first_id,
+            std::vector<float>& vectors,
+            std::vector<int64_t>& ids) {
+    vectors.resize(count * DIM);
+    ids.resize(count);
+    for (int64_t i = 0; i < count; ++i) {
+        ids[i] = first_id + i;
+        for (int64_t j = 0; j < DIM; ++j) {
+            vectors[i * DIM + j] = static_cast<float>((first_id + i) * 0.1 + j);
+        }
+    }
+    return vsag::Dataset::Make()
+        ->NumElements(count)
+        ->Dim(DIM)
+        ->Ids(ids.data())
+        ->Float32Vectors(vectors.data())
+        ->Owner(false);
+}
+
+vsag::DatasetPtr
+MakeQuery(const std::vector<float>& vectors, int64_t row) {
+    return vsag::Dataset::Make()
+        ->NumElements(1)
+        ->Dim(DIM)
+        ->Float32Vectors(vectors.data() + row * DIM)
+        ->Owner(false);
+}
+
+std::shared_ptr<vsag::LazyHGraph>
+MakeLazyIndex(uint64_t threshold) {
+    auto common_param = MakeCommonParam();
+    auto param =
+        vsag::LazyHGraph::CheckAndMappingExternalParam(MakeLazyParam(threshold), common_param);
+    auto index = std::make_shared<vsag::LazyHGraph>(param, common_param);
+    index->InitFeatures();
+    return index;
+}
+
+std::string
+MakeFactoryParam(uint64_t threshold) {
+    auto root = vsag::JsonType::Parse(R"({
+        "dtype": "float32",
+        "metric_type": "l2",
+        "dim": 8,
+        "lazy_hgraph": {
+            "transition_threshold": 4,
+            "hgraph": {
+                "base_quantization_type": "fp32",
+                "max_degree": 4,
+                "ef_construction": 8,
+                "build_thread_count": 1
+            }
+        }
+    })");
+    root["lazy_hgraph"]["transition_threshold"].SetInt(threshold);
+    return root.Dump();
+}
+
+}  // namespace
+
+TEST_CASE("LazyHGraph stays flat before threshold and searches exactly", "[ut][lazy_hgraph]") {
+    auto index = MakeLazyIndex(4);
+    std::vector<float> vectors;
+    std::vector<int64_t> ids;
+    auto data = MakeDataset(3, 100, vectors, ids);
+
+    auto failed_ids = index->Add(data);
+    REQUIRE(failed_ids.empty());
+    REQUIRE(index->GetPhase() == vsag::LazyHGraph::Phase::FLAT);
+
+    auto result =
+        index->KnnSearch(MakeQuery(vectors, 1), 1, R"({"hgraph":{"ef_search":40}})", nullptr);
+    REQUIRE(result->GetIds()[0] == 101);
+    REQUIRE(result->GetDistances()[0] == 0.0F);
+
+    auto range = index->RangeSearch(MakeQuery(vectors, 2), 0.0F, "{}", nullptr);
+    REQUIRE(range->GetNumElements() == 1);
+    REQUIRE(range->GetIds()[0] == 102);
+}
+
+TEST_CASE("LazyHGraph transitions to graph and accepts more data", "[ut][lazy_hgraph]") {
+    auto index = MakeLazyIndex(4);
+    std::vector<float> vectors;
+    std::vector<int64_t> ids;
+    auto data = MakeDataset(4, 200, vectors, ids);
+
+    REQUIRE(index->Add(data).empty());
+    REQUIRE(index->GetPhase() == vsag::LazyHGraph::Phase::GRAPH);
+    REQUIRE(index->GetNumElements() == 4);
+
+    std::vector<float> more_vectors;
+    std::vector<int64_t> more_ids;
+    auto more = MakeDataset(1, 300, more_vectors, more_ids);
+    REQUIRE(index->Add(more).empty());
+    REQUIRE(index->GetNumElements() == 5);
+
+    auto result =
+        index->KnnSearch(MakeQuery(more_vectors, 0), 1, R"({"hgraph":{"ef_search":40}})", nullptr);
+    REQUIRE(result->GetIds()[0] == 300);
+}
+
+TEST_CASE("LazyHGraph filters removed flat ids during transition", "[ut][lazy_hgraph]") {
+    auto index = MakeLazyIndex(3);
+    std::vector<float> vectors;
+    std::vector<int64_t> ids;
+    auto data = MakeDataset(2, 400, vectors, ids);
+    REQUIRE(index->Add(data).empty());
+    REQUIRE(index->Remove({401}) == 1);
+
+    std::vector<float> more_vectors;
+    std::vector<int64_t> more_ids;
+    auto more = MakeDataset(2, 500, more_vectors, more_ids);
+    REQUIRE(index->Add(more).empty());
+    REQUIRE(index->GetPhase() == vsag::LazyHGraph::Phase::GRAPH);
+    REQUIRE(index->GetNumElements() == 3);
+    REQUIRE_FALSE(index->CheckIdExist(401));
+}
+
+TEST_CASE("LazyHGraph threshold one transitions immediately", "[ut][lazy_hgraph]") {
+    auto index = MakeLazyIndex(1);
+    std::vector<float> vectors;
+    std::vector<int64_t> ids;
+    auto data = MakeDataset(1, 600, vectors, ids);
+
+    REQUIRE(index->Add(data).empty());
+    REQUIRE(index->GetPhase() == vsag::LazyHGraph::Phase::GRAPH);
+}
+
+TEST_CASE("LazyHGraph factory and flat serialization round trip", "[ut][lazy_hgraph]") {
+    auto index = vsag::Factory::CreateIndex("lazy_hgraph", MakeFactoryParam(10));
+    REQUIRE(index.has_value());
+    REQUIRE(index.value()->GetIndexType() == vsag::IndexType::LAZY_HGRAPH);
+
+    std::vector<float> vectors;
+    std::vector<int64_t> ids;
+    auto data = MakeDataset(3, 700, vectors, ids);
+    REQUIRE(index.value()->Add(data).has_value());
+
+    auto binary = index.value()->Serialize();
+    REQUIRE(binary.has_value());
+
+    auto restored = vsag::Factory::CreateIndex("lazy_hgraph", MakeFactoryParam(10));
+    REQUIRE(restored.has_value());
+    REQUIRE(restored.value()->Deserialize(binary.value()).has_value());
+
+    auto result = restored.value()->KnnSearch(
+        MakeQuery(vectors, 0), 1, R"({"hgraph":{"ef_search":40}})", vsag::FilterPtr{});
+    REQUIRE(result.has_value());
+    REQUIRE(result.value()->GetIds()[0] == 700);
+}
+
+TEST_CASE("LazyHGraph rejects flat quantization parameters", "[ut][lazy_hgraph]") {
+    auto common_param = MakeCommonParam();
+    auto param = MakeLazyParam(4);
+    param["flat_quantization_type"].SetString("sq8");
+
+    REQUIRE_THROWS(vsag::LazyHGraph::CheckAndMappingExternalParam(param, common_param));
+}

--- a/src/algorithm/lazy_hgraph/lazy_hgraph_test.cpp
+++ b/src/algorithm/lazy_hgraph/lazy_hgraph_test.cpp
@@ -51,7 +51,7 @@ MakeLazyParam(uint64_t threshold, const std::string& base_quantization_type = "f
             "build_thread_count": 1
         }
     })");
-    param["transition_threshold"].SetInt(threshold);
+    param["transition_threshold"].SetUint64(threshold);
     param["hgraph"]["base_quantization_type"].SetString(base_quantization_type);
     return param;
 }
@@ -112,7 +112,7 @@ MakeFactoryParam(uint64_t threshold) {
             }
         }
     })");
-    root["lazy_hgraph"]["transition_threshold"].SetInt(threshold);
+    root["lazy_hgraph"]["transition_threshold"].SetUint64(threshold);
     return root.Dump();
 }
 
@@ -225,6 +225,10 @@ TEST_CASE("LazyHGraph rejects flat quantization parameters", "[ut][lazy_hgraph]"
     param["flat_quantization_type"].SetString("sq8");
 
     REQUIRE_THROWS(vsag::LazyHGraph::CheckAndMappingExternalParam(param, common_param));
+
+    auto flat_param = MakeLazyParam(4);
+    flat_param["flat"].SetJson(vsag::JsonType::Parse(R"({"base_quantization_type":"sq8"})"));
+    REQUIRE_THROWS(vsag::LazyHGraph::CheckAndMappingExternalParam(flat_param, common_param));
 }
 
 TEST_CASE("LazyHGraph rejects invalid parameter types", "[ut][lazy_hgraph]") {
@@ -238,6 +242,10 @@ TEST_CASE("LazyHGraph rejects invalid parameter types", "[ut][lazy_hgraph]") {
     auto graph_param =
         vsag::HGraph::CheckAndMappingExternalParam(MakeLazyParam(4)["hgraph"], common_param);
     REQUIRE_THROWS(vsag::LazyHGraph(graph_param, common_param));
+
+    auto large_threshold = MakeLazyParam(1ULL << 40U);
+    auto lazy_param = vsag::LazyHGraph::CheckAndMappingExternalParam(large_threshold, common_param);
+    REQUIRE(lazy_param->ToJson()["transition_threshold"].GetUint64() == (1ULL << 40U));
 }
 
 TEST_CASE("LazyHGraph build chooses flat or graph by threshold", "[ut][lazy_hgraph]") {
@@ -273,6 +281,22 @@ TEST_CASE("LazyHGraph serializes empty flat and graph phases", "[ut][lazy_hgraph
     REQUIRE(restored_empty->GetPhase() == vsag::LazyHGraph::Phase::FLAT);
     REQUIRE(restored_empty->GetNumElements() == 0);
 
+    auto flat = MakeLazyIndex(4);
+    std::vector<float> flat_vectors;
+    std::vector<int64_t> flat_ids;
+    auto flat_data = MakeDataset(3, 950, flat_vectors, flat_ids);
+    REQUIRE(flat->Add(flat_data).empty());
+    REQUIRE(flat->GetPhase() == vsag::LazyHGraph::Phase::FLAT);
+
+    auto flat_binary = static_cast<vsag::InnerIndexInterface*>(flat.get())->Serialize();
+    auto restored_flat = MakeLazyIndex(4);
+    static_cast<vsag::InnerIndexInterface*>(restored_flat.get())->Deserialize(flat_binary);
+    REQUIRE(restored_flat->GetPhase() == vsag::LazyHGraph::Phase::FLAT);
+    REQUIRE(
+        restored_flat
+            ->KnnSearch(MakeQuery(flat_vectors, 2), 1, R"({"hgraph":{"ef_search":40}})", nullptr)
+            ->GetIds()[0] == 952);
+
     auto graph = MakeLazyIndex(2);
     std::vector<float> vectors;
     std::vector<int64_t> ids;
@@ -287,6 +311,17 @@ TEST_CASE("LazyHGraph serializes empty flat and graph phases", "[ut][lazy_hgraph
     REQUIRE(restored_graph
                 ->KnnSearch(MakeQuery(vectors, 1), 1, R"({"hgraph":{"ef_search":40}})", nullptr)
                 ->GetIds()[0] == 1001);
+}
+
+TEST_CASE("LazyHGraph rejects invalid serialized phase", "[ut][lazy_hgraph]") {
+    auto index = MakeLazyIndex(4);
+    auto binary = static_cast<vsag::InnerIndexInterface*>(index.get())->Serialize();
+    auto payload = binary.Get(vsag::INDEX_LAZY_HGRAPH);
+    REQUIRE(payload.size > 16);
+    payload.data.get()[16] = 2;
+
+    auto restored = MakeLazyIndex(4);
+    REQUIRE_THROWS(static_cast<vsag::InnerIndexInterface*>(restored.get())->Deserialize(binary));
 }
 
 TEST_CASE("LazyHGraph removes ids in both phases", "[ut][lazy_hgraph]") {

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -19,6 +19,7 @@
 namespace vsag {
 
 const char* const INDEX_HGRAPH = "hgraph";
+const char* const INDEX_LAZY_HGRAPH = "lazy_hgraph";
 const char* const INDEX_DISKANN = "diskann";
 const char* const INDEX_HNSW = "hnsw";
 const char* const INDEX_FRESH_HNSW = "fresh_hnsw";

--- a/src/factory/index_creators.cpp
+++ b/src/factory/index_creators.cpp
@@ -118,11 +118,11 @@ create_hgraph_index(JsonType& parsed_params, const IndexCommonParam& index_commo
 
 tl::expected<std::shared_ptr<Index>, Error>
 create_lazy_hgraph_index(JsonType& parsed_params, const IndexCommonParam& index_common_params) {
-    CHECK_ARGUMENT(parsed_params.Contains(INDEX_LAZY_HGRAPH),
-                   fmt::format("parameters must contain {}", INDEX_LAZY_HGRAPH));
+    auto lazy_hgraph_param = parsed_params.Contains(INDEX_LAZY_HGRAPH)
+                                 ? parsed_params[INDEX_LAZY_HGRAPH]
+                                 : get_index_param_or_empty(parsed_params);
     logger::debug("created a lazy_hgraph index");
-    return {std::make_shared<IndexImpl<LazyHGraph>>(parsed_params[INDEX_LAZY_HGRAPH],
-                                                    index_common_params)};
+    return {std::make_shared<IndexImpl<LazyHGraph>>(lazy_hgraph_param, index_common_params)};
 }
 
 tl::expected<std::shared_ptr<Index>, Error>

--- a/src/factory/index_creators.cpp
+++ b/src/factory/index_creators.cpp
@@ -21,6 +21,7 @@
 #include "algorithm/bruteforce/bruteforce.h"
 #include "algorithm/hgraph/hgraph.h"
 #include "algorithm/ivf/ivf.h"
+#include "algorithm/lazy_hgraph/lazy_hgraph.h"
 #include "algorithm/pyramid/pyramid.h"
 #include "algorithm/pyramid/pyramid_zparameters.h"
 #include "algorithm/sindi/sindi.h"
@@ -116,6 +117,15 @@ create_hgraph_index(JsonType& parsed_params, const IndexCommonParam& index_commo
 }
 
 tl::expected<std::shared_ptr<Index>, Error>
+create_lazy_hgraph_index(JsonType& parsed_params, const IndexCommonParam& index_common_params) {
+    CHECK_ARGUMENT(parsed_params.Contains(INDEX_LAZY_HGRAPH),
+                   fmt::format("parameters must contain {}", INDEX_LAZY_HGRAPH));
+    logger::debug("created a lazy_hgraph index");
+    return {std::make_shared<IndexImpl<LazyHGraph>>(parsed_params[INDEX_LAZY_HGRAPH],
+                                                    index_common_params)};
+}
+
+tl::expected<std::shared_ptr<Index>, Error>
 create_ivf_index(JsonType& parsed_params, const IndexCommonParam& index_common_params) {
     return create_index_impl_with_param_log<IVF>(
         "created an ivf index", parsed_params, index_common_params);
@@ -150,6 +160,7 @@ register_all_index_creators() {
         register_index_creator(INDEX_BRUTE_FORCE, &create_brute_force_index);
         register_index_creator(INDEX_DISKANN, &create_diskann_index);
         register_index_creator(INDEX_HGRAPH, &create_hgraph_index);
+        register_index_creator(INDEX_LAZY_HGRAPH, &create_lazy_hgraph_index);
         register_index_creator(INDEX_IVF, &create_ivf_index);
         register_index_creator(INDEX_PYRAMID, &create_pyramid_index);
         register_index_creator(INDEX_SPARSE, &create_sparse_index);

--- a/src/json_wrapper.cpp
+++ b/src/json_wrapper.cpp
@@ -87,6 +87,11 @@ JsonWrapper::IsNumberInteger() const {
 }
 
 bool
+JsonWrapper::IsNumberUnsigned() const {
+    return json_->is_number_unsigned();
+}
+
+bool
 JsonWrapper::IsString() const {
     return json_->is_string();
 }
@@ -121,6 +126,11 @@ JsonWrapper::SetInt(uint64_t value) {
     (*json_) = value;
 }
 
+void
+JsonWrapper::SetUint64(uint64_t value) {
+    (*json_) = value;
+}
+
 template <class T>
 void
 JsonWrapper::SetVector(std::vector<T> value) {
@@ -145,6 +155,11 @@ JsonWrapper::GetString() const {
 int64_t
 JsonWrapper::GetInt() const {
     return (*json_).get<int64_t>();
+}
+
+uint64_t
+JsonWrapper::GetUint64() const {
+    return (*json_).get<uint64_t>();
 }
 
 float

--- a/src/json_wrapper.h
+++ b/src/json_wrapper.h
@@ -41,6 +41,9 @@ public:
     IsNumberInteger() const;
 
     bool
+    IsNumberUnsigned() const;
+
+    bool
     IsString() const;
 
     bool
@@ -68,6 +71,9 @@ public:
     SetInt(uint64_t value);
 
     void
+    SetUint64(uint64_t value);
+
+    void
     SetFloat(float value);
 
     void
@@ -85,6 +91,9 @@ public:
 
     int64_t
     GetInt() const;
+
+    uint64_t
+    GetUint64() const;
 
     float
     GetFloat() const;

--- a/src/json_wrapper_test.cpp
+++ b/src/json_wrapper_test.cpp
@@ -37,6 +37,13 @@ TEST_CASE("JsonWrapper Copy With Integer Data", "[ut][json_wrapper]") {
     CHECK(w2["num"].GetInt() == 42);
 }
 
+TEST_CASE("JsonWrapper Uint64 Round Trip", "[ut][json_wrapper]") {
+    constexpr uint64_t value = 1ULL << 40U;
+    vsag::JsonWrapper wrapper;
+    wrapper["num"].SetUint64(value);
+    CHECK(wrapper["num"].GetUint64() == value);
+}
+
 TEST_CASE("JsonWrapper Copy Independence", "[ut][json_wrapper]") {
     auto w1 = vsag::JsonWrapper::Parse(R"({"key": "value1"})");
     vsag::JsonWrapper w2 = w1;


### PR DESCRIPTION
## Summary
- Add `lazy_hgraph`, an adaptive FP32 index that uses exact BruteForce below a configurable threshold and lazily converts to HGraph after the threshold is reached.
- Register `lazy_hgraph` in the factory/constants/API enum and wire it into the algorithm build.
- Add a C++ example plus README/example documentation entries.
- Expand focused LazyHGraph coverage for threshold build behavior, serialization, remove, distance lookup, fp32 transition fidelity, HGraph baseline matching, configurable graph quantization, and basic concurrent search during transition.

## Acceptance Test Report
- PASS: `clang-format --version` -> 15.0.7.
- PASS: `cmake --build ./build --target unittests --parallel 6 && ./build/tests/unittests "[ut][lazy_hgraph]"` -> 14 test cases, 109 assertions.
- PASS: `cmake ... -DENABLE_EXAMPLES=ON ... && cmake --build ./build --target 111_index_lazy_hgraph --parallel 6`.
- PARTIAL: `make test` completed all unit tests successfully: 447 test cases, 85,045,614 assertions. Functional tests were manually interrupted after 45 minutes in the pre-existing `(Daily) HGraph Build & ContinueAdd Test`; before interruption, 50/51 functional test cases had passed, and the recorded failure was caused by SIGINT.

## Notes
- `lazy_hgraph` accepts only float32 vectors and rejects user-specified flat/BruteForce quantization parameters because the flat phase is fixed to exact FP32.
- Serialization of a non-empty flat-phase index forces transition to HGraph; an empty flat index serializes as an empty flat header.
- The delivery report file is kept local and is intentionally not included in this PR.
