### PR TITLE
perf(hgraph): skip mutex acquisition on immutable index search

### DIFF
--- a/src/algorithm/hgraph/hgraph.cpp
+++ b/src/algorithm/hgraph/hgraph.cpp
@@ -433,14 +433,15 @@ HGraph::GetVectorByInnerId(InnerIdType inner_id, float* data) const {
 
 void
 HGraph::SetImmutable() {
-    if (this->immutable_) {
+    if (this->immutable_.load(std::memory_order_acquire)) {
         return;
     }
+    std::scoped_lock<std::shared_mutex> add_lock(this->add_mutex_);
     std::scoped_lock<std::shared_mutex> wlock(this->global_mutex_);
     this->neighbors_mutex_.reset();
     this->neighbors_mutex_ = std::make_shared<EmptyMutex>();
     this->searcher_->SetMutexArray(this->neighbors_mutex_);
-    this->immutable_ = true;
+    this->immutable_.store(true, std::memory_order_release);
 }
 
 void

--- a/src/algorithm/hgraph/hgraph.cpp
+++ b/src/algorithm/hgraph/hgraph.cpp
@@ -134,6 +134,9 @@ HGraph::Tune(const std::string& parameters, bool disable_future_tuning) {
     }
 
     std::scoped_lock lock(this->add_mutex_);
+    if (this->immutable_.load(std::memory_order_acquire)) {
+        return false;
+    }
 
     // check which code need to tune and update create_param_ptr_
     bool is_tune_base_code = false;

--- a/src/algorithm/hgraph/hgraph_search.cpp
+++ b/src/algorithm/hgraph/hgraph_search.cpp
@@ -82,10 +82,13 @@ HGraph::KnnSearch(const DatasetPtr& query,
         fmt::format("ef_search({}) must in range[1, {}]", params.ef_search, ef_search_threshold));
 
     std::shared_lock<std::shared_mutex> force_remove_rlock;
-    if (this->support_force_remove()) {
-        force_remove_rlock = std::shared_lock<std::shared_mutex>(this->force_remove_mutex_);
+    std::shared_lock<std::shared_mutex> shared_lock;
+    if (!this->immutable_.load(std::memory_order_acquire)) {
+        if (this->support_force_remove()) {
+            force_remove_rlock = std::shared_lock<std::shared_mutex>(this->force_remove_mutex_);
+        }
+        shared_lock = std::shared_lock<std::shared_mutex>(this->global_mutex_);
     }
-    std::shared_lock shared_lock(this->global_mutex_);
     k = std::min(k, GetNumElements());
 
     FilterPtr ft = this->create_search_filter(filter, params.use_extra_info_filter);
@@ -357,10 +360,13 @@ HGraph::RangeSearch(const DatasetPtr& query,
     this->validate_range_args(query, radius, limited_size);
 
     std::shared_lock<std::shared_mutex> force_remove_rlock;
-    if (this->support_force_remove()) {
-        force_remove_rlock = std::shared_lock<std::shared_mutex>(this->force_remove_mutex_);
+    std::shared_lock<std::shared_mutex> shared_lock;
+    if (!this->immutable_.load(std::memory_order_acquire)) {
+        if (this->support_force_remove()) {
+            force_remove_rlock = std::shared_lock<std::shared_mutex>(this->force_remove_mutex_);
+        }
+        shared_lock = std::shared_lock<std::shared_mutex>(this->global_mutex_);
     }
-    std::shared_lock shared_lock(this->global_mutex_);
 
     InnerSearchParam search_param;
     search_param.ep = this->entry_point_id_;
@@ -455,10 +461,13 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
         fmt::format("ef_search({}) must in range[1, {}]", params.ef_search, ef_search_threshold));
 
     std::shared_lock<std::shared_mutex> force_remove_rlock;
-    if (this->support_force_remove()) {
-        force_remove_rlock = std::shared_lock<std::shared_mutex>(this->force_remove_mutex_);
+    std::shared_lock<std::shared_mutex> shared_lock;
+    if (!this->immutable_.load(std::memory_order_acquire)) {
+        if (this->support_force_remove()) {
+            force_remove_rlock = std::shared_lock<std::shared_mutex>(this->force_remove_mutex_);
+        }
+        shared_lock = std::shared_lock<std::shared_mutex>(this->global_mutex_);
     }
-    std::shared_lock shared_lock(this->global_mutex_);
     k = std::min(k, GetNumElements());
 
     // Setup reasoning context if expected labels are provided.

--- a/src/algorithm/inner_index_interface.h
+++ b/src/algorithm/inner_index_interface.h
@@ -567,7 +567,7 @@ public:
     IndexFeatureListUPtr index_feature_list_{nullptr};
 
     const InnerIndexParameterPtr create_param_ptr_{nullptr};
-    bool immutable_{false};
+    std::atomic<bool> immutable_{false};
 
 protected:
     std::atomic<int64_t> current_memory_usage_{0};

--- a/src/algorithm/sindi/sindi.cpp
+++ b/src/algorithm/sindi/sindi.cpp
@@ -709,7 +709,7 @@ SINDI::CalDistanceById(const DatasetPtr& query,
 void
 SINDI::SetImmutable() {
     std::scoped_lock wlock(this->global_mutex_);
-    this->immutable_ = true;
+    this->immutable_.store(true, std::memory_order_release);
 }
 
 void

--- a/src/index/index_impl.h
+++ b/src/index/index_impl.h
@@ -57,10 +57,10 @@ public:
     if ((query)->GetNumElements() == 0) {       \
         return DatasetImpl::MakeEmptyDataset(); \
     }
-#define CHECK_IMMUTABLE_INDEX(operation_str)                                                    \
-    if (this->inner_index_->immutable_.load(std::memory_order_acquire)) {                      \
-        return tl::unexpected(Error(ErrorType::UNSUPPORTED_INDEX_OPERATION,                    \
-                                    "immutable index no support " operation_str));              \
+#define CHECK_IMMUTABLE_INDEX(operation_str)                                       \
+    if (this->inner_index_->immutable_.load(std::memory_order_acquire)) {          \
+        return tl::unexpected(Error(ErrorType::UNSUPPORTED_INDEX_OPERATION,        \
+                                    "immutable index no support " operation_str)); \
     }
 
 #define CHECK_NONEMPTY_DATASET(dataset)     \

--- a/src/index/index_impl.h
+++ b/src/index/index_impl.h
@@ -57,10 +57,10 @@ public:
     if ((query)->GetNumElements() == 0) {       \
         return DatasetImpl::MakeEmptyDataset(); \
     }
-#define CHECK_IMMUTABLE_INDEX(operation_str)                                       \
-    if (this->inner_index_->immutable_) {                                          \
-        return tl::unexpected(Error(ErrorType::UNSUPPORTED_INDEX_OPERATION,        \
-                                    "immutable index no support " operation_str)); \
+#define CHECK_IMMUTABLE_INDEX(operation_str)                                                    \
+    if (this->inner_index_->immutable_.load(std::memory_order_acquire)) {                      \
+        return tl::unexpected(Error(ErrorType::UNSUPPORTED_INDEX_OPERATION,                    \
+                                    "immutable index no support " operation_str));              \
     }
 
 #define CHECK_NONEMPTY_DATASET(dataset)     \


### PR DESCRIPTION
## Summary

- Skip `global_mutex_` and `force_remove_mutex_` acquisition in all three HGraph search paths (KnnSearch, RangeSearch, SearchWithRequest) when the index is immutable
- Change `immutable_` from `bool` to `std::atomic<bool>` with acquire/release semantics for ARM correctness
- Have `SetImmutable()` acquire `add_mutex_` before `global_mutex_` to prevent TOCTOU race with `Tune()`

## Motivation

After `SetImmutable()`, no writer can modify shared state (all mutations guarded by `CHECK_IMMUTABLE_INDEX`). Yet every search unconditionally acquired `shared_lock(global_mutex_)`, causing atomic CAS cache-line contention across all search threads on read-only indexes.

## Test plan

- [x] Unit tests: 441 cases / 85M assertions passed (release)
- [x] PR-level HGraph functional tests: 38 cases / 827K assertions passed (release)
- [ ] CI format/lint check (no local clang-format-15)
- [x] Adversarial review by 3 independent agents (concurrency specialist, memory model specialist, edge case hunter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)