### PR TITLE
refactor(simd): unify cross-ISA implementations via traits + kernel templates

### DIFF
--- a/src/simd/avx.cpp
+++ b/src/simd/avx.cpp
@@ -16,6 +16,9 @@
 #if defined(ENABLE_AVX)
 #include <immintrin.h>
 
+#include "simd/kernels/kernels.h"
+#include "simd/traits/simd_traits_avx.h"
+
 inline float
 avx_reduce_add_ps(__m256 a) {
     alignas(32) float tmp[8];
@@ -76,17 +79,8 @@ INT8InnerProductDistance(const void* pVect1v, const void* pVect2v, const void* q
 void
 PQDistanceFloat256(const void* single_dim_centers, float single_dim_val, void* result) {
 #if defined(ENABLE_AVX)
-    auto* float_centers = (const float*)single_dim_centers;
-    auto* float_result = (float*)result;
-    for (uint64_t idx = 0; idx < 256; idx += 8) {
-        __m256 v_centers_dim = _mm256_loadu_ps(float_centers + idx);
-        __m256 v_query_vec = _mm256_set1_ps(single_dim_val);
-        __m256 v_diff = _mm256_sub_ps(v_centers_dim, v_query_vec);
-        __m256 v_diff_sq = _mm256_mul_ps(v_diff, v_diff);
-        __m256 v_chunk_dists = _mm256_loadu_ps(&float_result[idx]);
-        v_chunk_dists = _mm256_add_ps(v_chunk_dists, v_diff_sq);
-        _mm256_storeu_ps(&float_result[idx], v_chunk_dists);
-    }
+    simd::PQDistanceFloat256Impl<simd::SimdTraits<simd::AVX_Tag>>(
+        single_dim_centers, single_dim_val, result, &sse::PQDistanceFloat256);
 #else
     return sse::PQDistanceFloat256(single_dim_centers, single_dim_val, result);
 #endif
@@ -112,19 +106,8 @@ __inline __m256i __attribute__((__always_inline__)) load_8_char_and_convert(cons
 float
 FP32ComputeIP(const float* RESTRICT query, const float* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_AVX)
-    const uint32_t n = dim / 8;
-    if (n == 0) {
-        return sse::FP32ComputeIP(query, codes, dim);
-    }
-    __m256 sum = _mm256_setzero_ps();
-    for (int i = 0; i < n; ++i) {
-        __m256 a = _mm256_loadu_ps(query + i * 8);
-        __m256 b = _mm256_loadu_ps(codes + i * 8);
-        sum = _mm256_add_ps(sum, _mm256_mul_ps(a, b));
-    }
-    float ip = avx_reduce_add_ps(sum);
-    ip += sse::FP32ComputeIP(query + n * 8, codes + n * 8, dim - n * 8);
-    return ip;
+    return simd::ComputeIPImpl<simd::SimdTraits<simd::AVX_Tag>>(
+        query, codes, dim, &sse::FP32ComputeIP);
 #else
     return sse::FP32ComputeIP(query, codes, dim);
 #endif
@@ -133,20 +116,8 @@ FP32ComputeIP(const float* RESTRICT query, const float* RESTRICT codes, uint64_t
 float
 FP32ComputeL2Sqr(const float* RESTRICT query, const float* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_AVX)
-    const int n = dim / 8;
-    if (n == 0) {
-        return sse::FP32ComputeL2Sqr(query, codes, dim);
-    }
-    __m256 sum = _mm256_setzero_ps();
-    for (int i = 0; i < n; ++i) {
-        __m256 a = _mm256_loadu_ps(query + i * 8);
-        __m256 b = _mm256_loadu_ps(codes + i * 8);
-        __m256 diff = _mm256_sub_ps(a, b);
-        sum = _mm256_add_ps(sum, _mm256_mul_ps(diff, diff));
-    }
-    float l2 = avx_reduce_add_ps(sum);
-    l2 += sse::FP32ComputeL2Sqr(query + n * 8, codes + n * 8, dim - n * 8);
-    return l2;
+    return simd::ComputeL2SqrImpl<simd::SimdTraits<simd::AVX_Tag>>(
+        query, codes, dim, &sse::FP32ComputeL2Sqr);
 #else
     return sse::FP32ComputeL2Sqr(query, codes, dim);
 #endif
@@ -164,52 +135,18 @@ FP32ComputeIPBatch4(const float* RESTRICT query,
                     float& result3,
                     float& result4) {
 #if defined(ENABLE_AVX)
-    if (dim < 8) {
-        return sse::FP32ComputeIPBatch4(
-            query, dim, codes1, codes2, codes3, codes4, result1, result2, result3, result4);
-    }
-    __m256 sum1 = _mm256_setzero_ps();
-    __m256 sum2 = _mm256_setzero_ps();
-    __m256 sum3 = _mm256_setzero_ps();
-    __m256 sum4 = _mm256_setzero_ps();
-    int i = 0;
-    for (; i + 7 < dim; i += 8) {
-        __m256 q = _mm256_loadu_ps(query + i);
-        __m256 c1 = _mm256_loadu_ps(codes1 + i);
-        __m256 c2 = _mm256_loadu_ps(codes2 + i);
-        __m256 c3 = _mm256_loadu_ps(codes3 + i);
-        __m256 c4 = _mm256_loadu_ps(codes4 + i);
-        sum1 = _mm256_add_ps(sum1, _mm256_mul_ps(q, c1));
-        sum2 = _mm256_add_ps(sum2, _mm256_mul_ps(q, c2));
-        sum3 = _mm256_add_ps(sum3, _mm256_mul_ps(q, c3));
-        sum4 = _mm256_add_ps(sum4, _mm256_mul_ps(q, c4));
-    }
-    alignas(32) float result[8];
-    _mm256_store_ps(result, sum1);
-    result1 += result[0] + result[1] + result[2] + result[3] + result[4] + result[5] + result[6] +
-               result[7];
-    _mm256_store_ps(result, sum2);
-    result2 += result[0] + result[1] + result[2] + result[3] + result[4] + result[5] + result[6] +
-               result[7];
-    _mm256_store_ps(result, sum3);
-    result3 += result[0] + result[1] + result[2] + result[3] + result[4] + result[5] + result[6] +
-               result[7];
-    _mm256_store_ps(result, sum4);
-    result4 += result[0] + result[1] + result[2] + result[3] + result[4] + result[5] + result[6] +
-               result[7];
-
-    if (i < dim) {
-        sse::FP32ComputeIPBatch4(query + i,
-                                 dim - i,
-                                 codes1 + i,
-                                 codes2 + i,
-                                 codes3 + i,
-                                 codes4 + i,
-                                 result1,
-                                 result2,
-                                 result3,
-                                 result4);
-    }
+    simd::ComputeBatch4Impl<simd::SimdTraits<simd::AVX_Tag>, simd::Batch4Kind::IP>(
+        query,
+        dim,
+        codes1,
+        codes2,
+        codes3,
+        codes4,
+        result1,
+        result2,
+        result3,
+        result4,
+        &sse::FP32ComputeIPBatch4);
 #else
     return sse::FP32ComputeIPBatch4(
         query, dim, codes1, codes2, codes3, codes4, result1, result2, result3, result4);
@@ -228,55 +165,18 @@ FP32ComputeL2SqrBatch4(const float* RESTRICT query,
                        float& result3,
                        float& result4) {
 #if defined(ENABLE_AVX)
-    if (dim < 8) {
-        return sse::FP32ComputeL2SqrBatch4(
-            query, dim, codes1, codes2, codes3, codes4, result1, result2, result3, result4);
-    }
-    __m256 sum1 = _mm256_setzero_ps();
-    __m256 sum2 = _mm256_setzero_ps();
-    __m256 sum3 = _mm256_setzero_ps();
-    __m256 sum4 = _mm256_setzero_ps();
-    int i = 0;
-    for (; i + 7 < dim; i += 8) {
-        __m256 q = _mm256_loadu_ps(query + i);
-        __m256 c1 = _mm256_loadu_ps(codes1 + i);
-        __m256 c2 = _mm256_loadu_ps(codes2 + i);
-        __m256 c3 = _mm256_loadu_ps(codes3 + i);
-        __m256 c4 = _mm256_loadu_ps(codes4 + i);
-        __m256 diff1 = _mm256_sub_ps(q, c1);
-        __m256 diff2 = _mm256_sub_ps(q, c2);
-        __m256 diff3 = _mm256_sub_ps(q, c3);
-        __m256 diff4 = _mm256_sub_ps(q, c4);
-        sum1 = _mm256_add_ps(sum1, _mm256_mul_ps(diff1, diff1));
-        sum2 = _mm256_add_ps(sum2, _mm256_mul_ps(diff2, diff2));
-        sum3 = _mm256_add_ps(sum3, _mm256_mul_ps(diff3, diff3));
-        sum4 = _mm256_add_ps(sum4, _mm256_mul_ps(diff4, diff4));
-    }
-    alignas(32) float result[8];
-    _mm256_store_ps(result, sum1);
-    result1 += result[0] + result[1] + result[2] + result[3] + result[4] + result[5] + result[6] +
-               result[7];
-    _mm256_store_ps(result, sum2);
-    result2 += result[0] + result[1] + result[2] + result[3] + result[4] + result[5] + result[6] +
-               result[7];
-    _mm256_store_ps(result, sum3);
-    result3 += result[0] + result[1] + result[2] + result[3] + result[4] + result[5] + result[6] +
-               result[7];
-    _mm256_store_ps(result, sum4);
-    result4 += result[0] + result[1] + result[2] + result[3] + result[4] + result[5] + result[6] +
-               result[7];
-    if (i < dim) {
-        sse::FP32ComputeL2SqrBatch4(query + i,
-                                    dim - i,
-                                    codes1 + i,
-                                    codes2 + i,
-                                    codes3 + i,
-                                    codes4 + i,
-                                    result1,
-                                    result2,
-                                    result3,
-                                    result4);
-    }
+    simd::ComputeBatch4Impl<simd::SimdTraits<simd::AVX_Tag>, simd::Batch4Kind::L2>(
+        query,
+        dim,
+        codes1,
+        codes2,
+        codes3,
+        codes4,
+        result1,
+        result2,
+        result3,
+        result4,
+        &sse::FP32ComputeL2SqrBatch4);
 #else
     return sse::FP32ComputeL2SqrBatch4(
         query, dim, codes1, codes2, codes3, codes4, result1, result2, result3, result4);
@@ -286,19 +186,8 @@ FP32ComputeL2SqrBatch4(const float* RESTRICT query,
 void
 FP32Sub(const float* x, const float* y, float* z, uint64_t dim) {
 #if defined(ENABLE_AVX)
-    if (dim < 8) {
-        return sse::FP32Sub(x, y, z, dim);
-    }
-    int i = 0;
-    for (; i + 7 < dim; i += 8) {
-        __m256 a = _mm256_loadu_ps(x + i);
-        __m256 b = _mm256_loadu_ps(y + i);
-        __m256 c = _mm256_sub_ps(a, b);
-        _mm256_storeu_ps(z + i, c);
-    }
-    if (i < dim) {
-        sse::FP32Sub(x + i, y + i, z + i, dim - i);
-    }
+    simd::BinaryOpImpl<simd::SimdTraits<simd::AVX_Tag>, simd::BinaryOp::Sub>(
+        x, y, z, dim, &sse::FP32Sub);
 #else
     sse::FP32Sub(x, y, z, dim);
 #endif
@@ -307,19 +196,8 @@ FP32Sub(const float* x, const float* y, float* z, uint64_t dim) {
 void
 FP32Add(const float* x, const float* y, float* z, uint64_t dim) {
 #if defined(ENABLE_AVX)
-    if (dim < 8) {
-        return sse::FP32Add(x, y, z, dim);
-    }
-    int i = 0;
-    for (; i + 7 < dim; i += 8) {
-        __m256 a = _mm256_loadu_ps(x + i);
-        __m256 b = _mm256_loadu_ps(y + i);
-        __m256 c = _mm256_add_ps(a, b);
-        _mm256_storeu_ps(z + i, c);
-    }
-    if (i < dim) {
-        sse::FP32Add(x + i, y + i, z + i, dim - i);
-    }
+    simd::BinaryOpImpl<simd::SimdTraits<simd::AVX_Tag>, simd::BinaryOp::Add>(
+        x, y, z, dim, &sse::FP32Add);
 #else
     sse::FP32Add(x, y, z, dim);
 #endif
@@ -328,19 +206,8 @@ FP32Add(const float* x, const float* y, float* z, uint64_t dim) {
 void
 FP32Mul(const float* x, const float* y, float* z, uint64_t dim) {
 #if defined(ENABLE_AVX)
-    if (dim < 8) {
-        return sse::FP32Mul(x, y, z, dim);
-    }
-    int i = 0;
-    for (; i + 7 < dim; i += 8) {
-        __m256 a = _mm256_loadu_ps(x + i);
-        __m256 b = _mm256_loadu_ps(y + i);
-        __m256 c = _mm256_mul_ps(a, b);
-        _mm256_storeu_ps(z + i, c);
-    }
-    if (i < dim) {
-        sse::FP32Mul(x + i, y + i, z + i, dim - i);
-    }
+    simd::BinaryOpImpl<simd::SimdTraits<simd::AVX_Tag>, simd::BinaryOp::Mul>(
+        x, y, z, dim, &sse::FP32Mul);
 #else
     sse::FP32Mul(x, y, z, dim);
 #endif
@@ -349,19 +216,8 @@ FP32Mul(const float* x, const float* y, float* z, uint64_t dim) {
 void
 FP32Div(const float* x, const float* y, float* z, uint64_t dim) {
 #if defined(ENABLE_AVX)
-    if (dim < 8) {
-        return sse::FP32Div(x, y, z, dim);
-    }
-    int i = 0;
-    for (; i + 7 < dim; i += 8) {
-        __m256 a = _mm256_loadu_ps(x + i);
-        __m256 b = _mm256_loadu_ps(y + i);
-        __m256 c = _mm256_div_ps(a, b);
-        _mm256_storeu_ps(z + i, c);
-    }
-    if (i < dim) {
-        sse::FP32Div(x + i, y + i, z + i, dim - i);
-    }
+    simd::BinaryOpImpl<simd::SimdTraits<simd::AVX_Tag>, simd::BinaryOp::Div>(
+        x, y, z, dim, &sse::FP32Div);
 #else
     sse::FP32Div(x, y, z, dim);
 #endif
@@ -396,32 +252,8 @@ __inline __m256i __attribute__((__always_inline__)) load_8_short(const uint16_t*
 float
 BF16ComputeIP(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_AVX)
-    // Initialize the sum to 0
-    __m256 sum = _mm256_setzero_ps();
-    const auto* query_bf16 = (const uint16_t*)(query);
-    const auto* codes_bf16 = (const uint16_t*)(codes);
-
-    // Process the data in 128-bit chunks
-    uint64_t i = 0;
-    for (; i + 7 < dim; i += 8) {
-        // Load data into registers
-        __m256i query_shift = load_8_short(query_bf16 + i);
-        __m256 query_float = _mm256_castsi256_ps(query_shift);
-
-        // Load data into registers
-        __m256i code_shift = load_8_short(codes_bf16 + i);
-        __m256 code_float = _mm256_castsi256_ps(code_shift);
-
-        __m256 val = _mm256_mul_ps(code_float, query_float);
-        sum = _mm256_add_ps(sum, val);
-    }
-
-    alignas(32) float result[8];
-    _mm256_store_ps(result, sum);  // store the accumulated result into an array
-    float ip = result[0] + result[1] + result[2] + result[3] + result[4] + result[5] + result[6] +
-               result[7];  // calculate the sum of the accumulated results
-
-    return ip + sse::BF16ComputeIP(query + i * 2, codes + i * 2, dim - i);
+    return simd::HalfComputeIPImpl<simd::BF16Traits<simd::AVX_BF16_Tag>>(
+        query, codes, dim, &sse::BF16ComputeIP);
 #else
     return sse::BF16ComputeIP(query, codes, dim);
 #endif
@@ -430,33 +262,8 @@ BF16ComputeIP(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint
 float
 BF16ComputeL2Sqr(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_AVX)
-    // Initialize the sum to 0
-    __m256 sum = _mm256_setzero_ps();
-    const auto* query_bf16 = (const uint16_t*)(query);
-    const auto* codes_bf16 = (const uint16_t*)(codes);
-
-    // Process the data in 128-bit chunks
-    uint64_t i = 0;
-    for (; i + 7 < dim; i += 8) {
-        // Load data into registers
-        __m256i query_shift = load_8_short(query_bf16 + i);
-        __m256 query_float = _mm256_castsi256_ps(query_shift);
-
-        // Load data into registers
-        __m256i code_shift = load_8_short(codes_bf16 + i);
-        __m256 code_float = _mm256_castsi256_ps(code_shift);
-
-        __m256 diff = _mm256_sub_ps(code_float, query_float);
-        __m256 val = _mm256_mul_ps(diff, diff);
-        sum = _mm256_add_ps(sum, val);
-    }
-
-    alignas(32) float result[8];
-    _mm256_store_ps(result, sum);  // store the accumulated result into an array
-    float l2 = result[0] + result[1] + result[2] + result[3] + result[4] + result[5] + result[6] +
-               result[7];  // calculate the sum of the accumulated results
-
-    return l2 + sse::BF16ComputeL2Sqr(query + i * 2, codes + i * 2, dim - i);
+    return simd::HalfComputeL2SqrImpl<simd::BF16Traits<simd::AVX_BF16_Tag>>(
+        query, codes, dim, &sse::BF16ComputeL2Sqr);
 #else
     return sse::BF16ComputeL2Sqr(query, codes, dim);
 #endif
@@ -465,32 +272,8 @@ BF16ComputeL2Sqr(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, u
 float
 FP16ComputeIP(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_AVX)
-    // Initialize the sum to 0
-    __m256 sum = _mm256_setzero_ps();
-    const auto* query_fp16 = (const uint16_t*)(query);
-    const auto* codes_fp16 = (const uint16_t*)(codes);
-
-    // Process the data in 128-bit chunks
-    uint64_t i = 0;
-    for (; i + 7 < dim; i += 8) {
-        // Load data into registers
-        __m128i query_load = _mm_loadu_si128(reinterpret_cast<const __m128i*>(query_fp16 + i));
-        __m256 query_float = _mm256_cvtph_ps(query_load);
-
-        // Load data into registers
-        __m128i code_load = _mm_loadu_si128(reinterpret_cast<const __m128i*>(codes_fp16 + i));
-        __m256 code_float = _mm256_cvtph_ps(code_load);
-
-        __m256 val = _mm256_mul_ps(code_float, query_float);
-        sum = _mm256_add_ps(sum, val);
-    }
-
-    alignas(32) float result[8];
-    _mm256_store_ps(result, sum);  // store the accumulated result into an array
-    float ip = result[0] + result[1] + result[2] + result[3] + result[4] + result[5] + result[6] +
-               result[7];  // calculate the sum of the accumulated results
-
-    return ip + sse::FP16ComputeIP(query + i * 2, codes + i * 2, dim - i);
+    return simd::HalfComputeIPImpl<simd::FP16Traits<simd::AVX_FP16_Tag>>(
+        query, codes, dim, &sse::FP16ComputeIP);
 #else
     return sse::FP16ComputeIP(query, codes, dim);
 #endif
@@ -499,33 +282,8 @@ FP16ComputeIP(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint
 float
 FP16ComputeL2Sqr(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_AVX)
-    // Initialize the sum to 0
-    __m256 sum = _mm256_setzero_ps();
-    const auto* query_fp16 = (const uint16_t*)(query);
-    const auto* codes_fp16 = (const uint16_t*)(codes);
-
-    // Process the data in 128-bit chunks
-    uint64_t i = 0;
-    for (; i + 7 < dim; i += 8) {
-        // Load data into registers
-        __m128i query_load = _mm_loadu_si128(reinterpret_cast<const __m128i*>(query_fp16 + i));
-        __m256 query_float = _mm256_cvtph_ps(query_load);
-
-        // Load data into registers
-        __m128i code_load = _mm_loadu_si128(reinterpret_cast<const __m128i*>(codes_fp16 + i));
-        __m256 code_float = _mm256_cvtph_ps(code_load);
-
-        __m256 diff = _mm256_sub_ps(code_float, query_float);
-        __m256 val = _mm256_mul_ps(diff, diff);
-        sum = _mm256_add_ps(sum, val);
-    }
-
-    alignas(32) float result[8];
-    _mm256_store_ps(result, sum);  // store the accumulated result into an array
-    float l2 = result[0] + result[1] + result[2] + result[3] + result[4] + result[5] + result[6] +
-               result[7];  // calculate the sum of the accumulated results
-
-    return l2 + sse::FP16ComputeL2Sqr(query + i * 2, codes + i * 2, dim - i);
+    return simd::HalfComputeL2SqrImpl<simd::FP16Traits<simd::AVX_FP16_Tag>>(
+        query, codes, dim, &sse::FP16ComputeL2Sqr);
 #else
     return sse::FP16ComputeL2Sqr(query, codes, dim);
 #endif
@@ -557,34 +315,8 @@ SQ8ComputeIP(const float* RESTRICT query,
              const float* RESTRICT diff,
              uint64_t dim) {
 #if defined(ENABLE_AVX)
-    __m256 sum = _mm256_setzero_ps();
-    uint64_t i = 0;
-
-    for (; i + 7 < dim; i += 8) {
-        __m256i code_values = load_8_char_and_convert(codes + i);
-        __m256 code_floats = _mm256_cvtepi32_ps(code_values);
-        __m256 query_values = _mm256_loadu_ps(query + i);
-        __m256 diff_values = _mm256_loadu_ps(diff + i);
-        __m256 lower_bound_values = _mm256_loadu_ps(lower_bound + i);
-
-        __m256 scaled_codes =
-            _mm256_mul_ps(_mm256_div_ps(code_floats, _mm256_set1_ps(255.0F)), diff_values);
-        __m256 adjusted_codes = _mm256_add_ps(scaled_codes, lower_bound_values);
-        __m256 val = _mm256_mul_ps(query_values, adjusted_codes);
-        sum = _mm256_add_ps(sum, val);
-    }
-
-    __m128 sum_high = _mm256_extractf128_ps(sum, 1);
-    __m128 sum_low = _mm256_castps256_ps128(sum);
-    __m128 sum_final = _mm_add_ps(sum_low, sum_high);
-
-    alignas(16) float result[4];
-    _mm_store_ps(result, sum_final);
-    float finalResult = result[0] + result[1] + result[2] + result[3];
-
-    // Process the remaining elements recursively
-    finalResult += sse::SQ8ComputeIP(query + i, codes + i, lower_bound + i, diff + i, dim - i);
-    return finalResult;
+    return simd::SQ8ComputeIPImpl<simd::SQ8Traits<simd::AVX_SQ8_Tag>>(
+        query, codes, lower_bound, diff, dim, &sse::SQ8ComputeIP);
 #else
     return sse::SQ8ComputeIP(query, codes, lower_bound, diff, dim);
 #endif
@@ -597,41 +329,10 @@ SQ8ComputeL2Sqr(const float* RESTRICT query,
                 const float* RESTRICT diff,
                 uint64_t dim) {
 #if defined(ENABLE_AVX)
-    __m256 sum = _mm256_setzero_ps();
-    uint64_t i = 0;
-
-    for (; i + 7 < dim; i += 8) {
-        // Load data into registers
-        __m256i code_values = load_8_char_and_convert(codes + i);
-        __m256 code_floats = _mm256_div_ps(_mm256_cvtepi32_ps(code_values), _mm256_set1_ps(255.0F));
-        __m256 diff_values = _mm256_loadu_ps(diff + i);
-        __m256 lower_bound_values = _mm256_loadu_ps(lower_bound + i);
-        __m256 query_values = _mm256_loadu_ps(query + i);
-
-        // Perform calculations
-        __m256 scaled_codes = _mm256_mul_ps(code_floats, diff_values);
-        scaled_codes = _mm256_add_ps(scaled_codes, lower_bound_values);
-        __m256 val = _mm256_sub_ps(query_values, scaled_codes);
-        val = _mm256_mul_ps(val, val);
-        sum = _mm256_add_ps(sum, val);
-    }
-
-    // Horizontal addition
-    __m128 sum_high = _mm256_extractf128_ps(sum, 1);
-    __m128 sum_low = _mm256_castps256_ps128(sum);
-    __m128 sum_final = _mm_add_ps(sum_low, sum_high);
-    sum_final = _mm_hadd_ps(sum_final, sum_final);
-    sum_final = _mm_hadd_ps(sum_final, sum_final);
-
-    // Extract the result from the register
-    float result;
-    _mm_store_ss(&result, sum_final);
-
-    // Process the remaining elements
-    result += sse::SQ8ComputeL2Sqr(query + i, codes + i, lower_bound + i, diff + i, dim - i);
-    return result;
+    return simd::SQ8ComputeL2SqrImpl<simd::SQ8Traits<simd::AVX_SQ8_Tag>>(
+        query, codes, lower_bound, diff, dim, &sse::SQ8ComputeL2Sqr);
 #else
-    return vsag::sse::SQ8ComputeL2Sqr(query, codes, lower_bound, diff, dim);  // TODO
+    return sse::SQ8ComputeL2Sqr(query, codes, lower_bound, diff, dim);
 #endif
 }
 
@@ -642,38 +343,8 @@ SQ8ComputeCodesIP(const uint8_t* RESTRICT codes1,
                   const float* RESTRICT diff,
                   uint64_t dim) {
 #if defined(ENABLE_AVX)
-    __m256 sum = _mm256_setzero_ps();
-    uint64_t i = 0;
-    for (; i + 7 < dim; i += 8) {
-        // Load data into registers
-        __m256i codes1_256 = load_8_char_and_convert(codes1 + i);
-        __m256i codes2_256 = load_8_char_and_convert(codes2 + i);
-        __m256 code1_floats = _mm256_div_ps(_mm256_cvtepi32_ps(codes1_256), _mm256_set1_ps(255.0F));
-        __m256 code2_floats = _mm256_div_ps(_mm256_cvtepi32_ps(codes2_256), _mm256_set1_ps(255.0F));
-        __m256 diff_values = _mm256_loadu_ps(diff + i);
-        __m256 lower_bound_values = _mm256_loadu_ps(lower_bound + i);
-        // Perform calculations
-        __m256 scaled_codes1 =
-            _mm256_add_ps(_mm256_mul_ps(code1_floats, diff_values), lower_bound_values);
-        __m256 scaled_codes2 =
-            _mm256_add_ps(_mm256_mul_ps(code2_floats, diff_values), lower_bound_values);
-        __m256 val = _mm256_mul_ps(scaled_codes1, scaled_codes2);
-        sum = _mm256_add_ps(sum, val);
-    }
-
-    // Horizontal addition
-    __m128 sum_high = _mm256_extractf128_ps(sum, 1);
-    __m128 sum_low = _mm256_castps256_ps128(sum);
-    __m128 sum_final = _mm_add_ps(sum_low, sum_high);
-    sum_final = _mm_hadd_ps(sum_final, sum_final);
-    sum_final = _mm_hadd_ps(sum_final, sum_final);
-
-    // Extract the result from the register
-    float result;
-    _mm_store_ss(&result, sum_final);
-
-    result += sse::SQ8ComputeCodesIP(codes1 + i, codes2 + i, lower_bound + i, diff + i, dim - i);
-    return result;
+    return simd::SQ8ComputeCodesIPImpl<simd::SQ8Traits<simd::AVX_SQ8_Tag>>(
+        codes1, codes2, lower_bound, diff, dim, &sse::SQ8ComputeCodesIP);
 #else
     return sse::SQ8ComputeCodesIP(codes1, codes2, lower_bound, diff, dim);
 #endif
@@ -686,39 +357,8 @@ SQ8ComputeCodesL2Sqr(const uint8_t* RESTRICT codes1,
                      const float* RESTRICT diff,
                      uint64_t dim) {
 #if defined(ENABLE_AVX)
-    __m256 sum = _mm256_setzero_ps();
-    uint64_t i = 0;
-    for (; i + 7 < dim; i += 8) {
-        // Load data into registers
-        __m256i code1_values = load_8_char_and_convert(codes1 + i);
-        __m256i code2_values = load_8_char_and_convert(codes2 + i);
-        __m256 codes1_floats =
-            _mm256_div_ps(_mm256_cvtepi32_ps(code1_values), _mm256_set1_ps(255.0F));
-        __m256 codes2_floats =
-            _mm256_div_ps(_mm256_cvtepi32_ps(code2_values), _mm256_set1_ps(255.0F));
-        __m256 diff_values = _mm256_loadu_ps(diff + i);
-        __m256 lower_bound_values = _mm256_loadu_ps(lower_bound + i);
-        // Perform calculations
-        __m256 scaled_codes1 =
-            _mm256_add_ps(_mm256_mul_ps(codes1_floats, diff_values), lower_bound_values);
-        __m256 scaled_codes2 =
-            _mm256_add_ps(_mm256_mul_ps(codes2_floats, diff_values), lower_bound_values);
-        __m256 val = _mm256_sub_ps(scaled_codes1, scaled_codes2);
-        val = _mm256_mul_ps(val, val);
-        sum = _mm256_add_ps(sum, val);
-    }
-    // Horizontal addition
-    __m128 sum_high = _mm256_extractf128_ps(sum, 1);
-    __m128 sum_low = _mm256_castps256_ps128(sum);
-    __m128 sum_final = _mm_add_ps(sum_low, sum_high);
-    sum_final = _mm_hadd_ps(sum_final, sum_final);
-    sum_final = _mm_hadd_ps(sum_final, sum_final);
-    // Extract the result from the register
-    float result;
-    _mm_store_ss(&result, sum_final);
-
-    result += sse::SQ8ComputeCodesL2Sqr(codes1 + i, codes2 + i, lower_bound + i, diff + i, dim - i);
-    return result;
+    return simd::SQ8ComputeCodesL2SqrImpl<simd::SQ8Traits<simd::AVX_SQ8_Tag>>(
+        codes1, codes2, lower_bound, diff, dim, &sse::SQ8ComputeCodesL2Sqr);
 #else
     return sse::SQ8ComputeCodesL2Sqr(codes1, codes2, lower_bound, diff, dim);
 #endif
@@ -792,42 +432,8 @@ SQ4ComputeIP(const float* RESTRICT query,
              const float* RESTRICT diff,
              uint64_t dim) {
 #if defined(ENABLE_AVX)
-    if (dim == 0) {
-        return 0;
-    }
-
-    float result = 0;
-    uint64_t d = 0;
-
-    // Process 16 values at a time (8 bytes containing 16 4-bit values)
-    for (; d + 15 < dim; d += 16) {
-        __m256 values01, values23;
-        SQ4Decode16Values(codes, d, values01, values23, lower_bound, diff);
-
-        // Load query vectors
-        __m256 query_vec0 = _mm256_loadu_ps(query + d);
-        __m256 query_vec1 = _mm256_loadu_ps(query + d + 8);
-
-        // Compute dot products
-        __m256 prod0 = _mm256_mul_ps(query_vec0, values01);
-        __m256 prod1 = _mm256_mul_ps(query_vec1, values23);
-
-        // Horizontal sum
-        __m256 sum = _mm256_add_ps(prod0, prod1);
-        __m128 sum_low = _mm256_castps256_ps128(sum);
-        __m128 sum_high = _mm256_extractf128_ps(sum, 1);
-        __m128 sum01 = _mm_add_ps(sum_low, sum_high);
-        __m128 sum23 = _mm_shuffle_ps(sum01, sum01, _MM_SHUFFLE(2, 3, 0, 1));
-        __m128 sum0123 = _mm_add_ps(sum01, sum23);
-        __m128 sum4567 = _mm_movehl_ps(sum0123, sum0123);
-        __m128 total_sum = _mm_add_ss(sum0123, sum4567);
-
-        result += _mm_cvtss_f32(total_sum);
-    }
-
-    // Process remaining elements with SSE implementation
-    result += sse::SQ4ComputeIP(query + d, codes + (d >> 1), lower_bound + d, diff + d, dim - d);
-    return result;
+    return simd::SQ4ComputeIPImpl<simd::SQ4Traits<simd::AVX_SQ4_Tag>>(
+        query, codes, lower_bound, diff, dim, &sse::SQ4ComputeIP);
 #else
     return sse::SQ4ComputeIP(query, codes, lower_bound, diff, dim);
 #endif
@@ -840,46 +446,8 @@ SQ4ComputeL2Sqr(const float* RESTRICT query,
                 const float* RESTRICT diff,
                 uint64_t dim) {
 #if defined(ENABLE_AVX)
-    if (dim == 0) {
-        return 0;
-    }
-
-    float result = 0;
-    uint64_t d = 0;
-
-    // Process 16 values at a time (8 bytes containing 16 4-bit values)
-    for (; d + 15 < dim; d += 16) {
-        __m256 values01, values23;
-        SQ4Decode16Values(codes, d, values01, values23, lower_bound, diff);
-
-        // Load query vectors
-        __m256 query_vec0 = _mm256_loadu_ps(query + d);
-        __m256 query_vec1 = _mm256_loadu_ps(query + d + 8);
-
-        // Compute differences
-        __m256 diff0 = _mm256_sub_ps(query_vec0, values01);
-        __m256 diff1 = _mm256_sub_ps(query_vec1, values23);
-
-        // Square differences
-        __m256 sq_diff0 = _mm256_mul_ps(diff0, diff0);
-        __m256 sq_diff1 = _mm256_mul_ps(diff1, diff1);
-
-        // Horizontal sum
-        __m256 sum = _mm256_add_ps(sq_diff0, sq_diff1);
-        __m128 sum_low = _mm256_castps256_ps128(sum);
-        __m128 sum_high = _mm256_extractf128_ps(sum, 1);
-        __m128 sum01 = _mm_add_ps(sum_low, sum_high);
-        __m128 sum23 = _mm_shuffle_ps(sum01, sum01, _MM_SHUFFLE(2, 3, 0, 1));
-        __m128 sum0123 = _mm_add_ps(sum01, sum23);
-        __m128 sum4567 = _mm_movehl_ps(sum0123, sum0123);
-        __m128 total_sum = _mm_add_ss(sum0123, sum4567);
-
-        result += _mm_cvtss_f32(total_sum);
-    }
-
-    // Process remaining elements with SSE implementation
-    result += sse::SQ4ComputeL2Sqr(query + d, codes + (d >> 1), lower_bound + d, diff + d, dim - d);
-    return result;
+    return simd::SQ4ComputeL2SqrImpl<simd::SQ4Traits<simd::AVX_SQ4_Tag>>(
+        query, codes, lower_bound, diff, dim, &sse::SQ4ComputeL2Sqr);
 #else
     return sse::SQ4ComputeL2Sqr(query, codes, lower_bound, diff, dim);
 #endif
@@ -892,41 +460,8 @@ SQ4ComputeCodesIP(const uint8_t* RESTRICT codes1,
                   const float* RESTRICT diff,
                   uint64_t dim) {
 #if defined(ENABLE_AVX)
-    if (dim == 0) {
-        return 0;
-    }
-
-    float result = 0;
-    uint64_t d = 0;
-
-    // Process 16 values at a time (8 bytes containing 16 4-bit values)
-    for (; d + 15 < dim; d += 16) {
-        __m256 code1_values01, code1_values23;
-        __m256 code2_values01, code2_values23;
-
-        SQ4Decode16Values(codes1, d, code1_values01, code1_values23, lower_bound, diff);
-        SQ4Decode16Values(codes2, d, code2_values01, code2_values23, lower_bound, diff);
-        // Compute dot products
-        __m256 prod0 = _mm256_mul_ps(code1_values01, code2_values01);
-        __m256 prod1 = _mm256_mul_ps(code1_values23, code2_values23);
-
-        // Horizontal sum
-        __m256 sum = _mm256_add_ps(prod0, prod1);
-        __m128 sum_low = _mm256_castps256_ps128(sum);
-        __m128 sum_high = _mm256_extractf128_ps(sum, 1);
-        __m128 sum01 = _mm_add_ps(sum_low, sum_high);
-        __m128 sum23 = _mm_shuffle_ps(sum01, sum01, _MM_SHUFFLE(2, 3, 0, 1));
-        __m128 sum0123 = _mm_add_ps(sum01, sum23);
-        __m128 sum4567 = _mm_movehl_ps(sum0123, sum0123);
-        __m128 total_sum = _mm_add_ss(sum0123, sum4567);
-
-        result += _mm_cvtss_f32(total_sum);
-    }
-
-    // Process remaining elements with SSE implementation
-    result += sse::SQ4ComputeCodesIP(
-        codes1 + (d >> 1), codes2 + (d >> 1), lower_bound + d, diff + d, dim - d);
-    return result;
+    return simd::SQ4ComputeCodesIPImpl<simd::SQ4Traits<simd::AVX_SQ4_Tag>>(
+        codes1, codes2, lower_bound, diff, dim, &sse::SQ4ComputeCodesIP);
 #else
     return sse::SQ4ComputeCodesIP(codes1, codes2, lower_bound, diff, dim);
 #endif
@@ -939,46 +474,8 @@ SQ4ComputeCodesL2Sqr(const uint8_t* RESTRICT codes1,
                      const float* RESTRICT diff,
                      uint64_t dim) {
 #if defined(ENABLE_AVX)
-    if (dim == 0) {
-        return 0;
-    }
-
-    float result = 0;
-    uint64_t d = 0;
-
-    // Process 16 values at a time (8 bytes containing 16 4-bit values)
-    for (; d + 15 < dim; d += 16) {
-        __m256 code1_values01, code1_values23;
-        __m256 code2_values01, code2_values23;
-
-        SQ4Decode16Values(codes1, d, code1_values01, code1_values23, lower_bound, diff);
-        SQ4Decode16Values(codes2, d, code2_values01, code2_values23, lower_bound, diff);
-
-        // Compute differences
-        __m256 diff0 = _mm256_sub_ps(code1_values01, code2_values01);
-        __m256 diff1 = _mm256_sub_ps(code1_values23, code2_values23);
-
-        // Square differences
-        __m256 sq_diff0 = _mm256_mul_ps(diff0, diff0);
-        __m256 sq_diff1 = _mm256_mul_ps(diff1, diff1);
-
-        // Horizontal sum
-        __m256 sum = _mm256_add_ps(sq_diff0, sq_diff1);
-        __m128 sum_low = _mm256_castps256_ps128(sum);
-        __m128 sum_high = _mm256_extractf128_ps(sum, 1);
-        __m128 sum01 = _mm_add_ps(sum_low, sum_high);
-        __m128 sum23 = _mm_shuffle_ps(sum01, sum01, _MM_SHUFFLE(2, 3, 0, 1));
-        __m128 sum0123 = _mm_add_ps(sum01, sum23);
-        __m128 sum4567 = _mm_movehl_ps(sum0123, sum0123);
-        __m128 total_sum = _mm_add_ss(sum0123, sum4567);
-
-        result += _mm_cvtss_f32(total_sum);
-    }
-
-    // Process remaining elements with SSE implementation
-    result += sse::SQ4ComputeCodesL2Sqr(
-        codes1 + (d >> 1), codes2 + (d >> 1), lower_bound + d, diff + d, dim - d);
-    return result;
+    return simd::SQ4ComputeCodesL2SqrImpl<simd::SQ4Traits<simd::AVX_SQ4_Tag>>(
+        codes1, codes2, lower_bound, diff, dim, &sse::SQ4ComputeCodesL2Sqr);
 #else
     return sse::SQ4ComputeCodesL2Sqr(codes1, codes2, lower_bound, diff, dim);
 #endif
@@ -1021,46 +518,8 @@ SQ8UniformComputeCodesIPBatch(const uint8_t* RESTRICT query,
 float
 RaBitQFloatBinaryIP(const float* vector, const uint8_t* bits, uint64_t dim, float inv_sqrt_d) {
 #if defined(ENABLE_AVX)
-    if (dim == 0) {
-        return 0.0F;
-    }
-
-    if (dim < 8 or inv_sqrt_d < 1e-3) {
-        return sse::RaBitQFloatBinaryIP(vector, bits, dim, inv_sqrt_d);
-    }
-
-    uint64_t d = 0;
-    float result = 0.0F;
-    alignas(32) float temp[8];
-    __m256 sum = _mm256_setzero_ps();
-    const __m256 inv_sqrt_d_vec = _mm256_set1_ps(inv_sqrt_d);
-
-    for (; d + 8 <= dim; d += 8) {
-        __m256 vec = _mm256_loadu_ps(vector + d);
-
-        uint8_t byte = bits[d / 8];
-        __m256 b_vec = _mm256_set_ps(((byte >> 7) & 1) ? 1.0F : -1.0F,
-                                     ((byte >> 6) & 1) ? 1.0F : -1.0F,
-                                     ((byte >> 5) & 1) ? 1.0F : -1.0F,
-                                     ((byte >> 4) & 1) ? 1.0F : -1.0F,
-                                     ((byte >> 3) & 1) ? 1.0F : -1.0F,
-                                     ((byte >> 2) & 1) ? 1.0F : -1.0F,
-                                     ((byte >> 1) & 1) ? 1.0F : -1.0F,
-                                     ((byte >> 0) & 1) ? 1.0F : -1.0F);
-
-        b_vec = _mm256_mul_ps(b_vec, inv_sqrt_d_vec);
-
-        sum = _mm256_add_ps(_mm256_mul_ps(b_vec, vec), sum);
-    }
-
-    _mm256_store_ps(temp, sum);
-    for (float val : temp) {
-        result += val;
-    }
-
-    result += sse::RaBitQFloatBinaryIP(vector + d, bits + d / 8, dim - d, inv_sqrt_d);
-
-    return result;
+    return simd::RaBitQFloatBinaryIPImpl<simd::RaBitQTraits<simd::AVX_RaBitQ_Tag>>(
+        vector, bits, dim, inv_sqrt_d, &sse::RaBitQFloatBinaryIP);
 #else
     return sse::RaBitQFloatBinaryIP(vector, bits, dim, inv_sqrt_d);
 #endif
@@ -1076,8 +535,16 @@ RaBitQFloatBinaryIPBatch4(const float* vector,
                           float inv_sqrt_d,
                           float* results) {
 #if defined(ENABLE_AVX)
-    generic::RaBitQFloatBinaryIPBatch4(
-        vector, bits1, bits2, bits3, bits4, dim, inv_sqrt_d, results);
+    simd::RaBitQFloatBinaryIPBatch4Impl<simd::RaBitQTraits<simd::AVX_RaBitQ_Tag>>(
+        vector,
+        bits1,
+        bits2,
+        bits3,
+        bits4,
+        dim,
+        inv_sqrt_d,
+        results,
+        &generic::RaBitQFloatBinaryIPBatch4);
 #else
     sse::RaBitQFloatBinaryIPBatch4(vector, bits1, bits2, bits3, bits4, dim, inv_sqrt_d, results);
 #endif
@@ -1090,64 +557,8 @@ RaBitQFloatSplitCodeIP(const float* vector,
                        uint64_t dim,
                        uint32_t supplement_bits) {
 #if defined(ENABLE_AVX)
-    if (dim == 0) {
-        return 0.0F;
-    }
-
-    const uint64_t plane_bytes = (dim + 7) / 8;
-    const uint32_t one_bit_weight = 1U << supplement_bits;
-    __m256 sum = _mm256_setzero_ps();
-
-    uint64_t d = 0;
-    for (; d + 8 <= dim; d += 8) {
-        float code_values[8];
-        const uint64_t byte_idx = d >> 3;
-        const uint8_t one_bit_byte = one_bit_code[byte_idx];
-        for (uint32_t lane = 0; lane < 8; ++lane) {
-            const uint8_t bit_mask = static_cast<uint8_t>(1U << lane);
-            uint32_t code = (one_bit_byte & bit_mask) != 0 ? one_bit_weight : 0U;
-            for (uint32_t bit = 0; bit < supplement_bits; ++bit) {
-                const auto* plane = supplement_code + static_cast<uint64_t>(bit) * plane_bytes;
-                if ((plane[byte_idx] & bit_mask) != 0) {
-                    code += 1U << bit;
-                }
-            }
-            code_values[lane] = static_cast<float>(code);
-        }
-
-        const __m256 code = _mm256_set_ps(code_values[7],
-                                          code_values[6],
-                                          code_values[5],
-                                          code_values[4],
-                                          code_values[3],
-                                          code_values[2],
-                                          code_values[1],
-                                          code_values[0]);
-        const __m256 vec = _mm256_loadu_ps(vector + d);
-        sum = _mm256_add_ps(_mm256_mul_ps(code, vec), sum);
-    }
-
-    alignas(32) float temp[8];
-    _mm256_store_ps(temp, sum);
-    float result = 0.0F;
-    for (float value : temp) {
-        result += value;
-    }
-
-    for (; d < dim; ++d) {
-        const uint64_t byte_idx = d >> 3;
-        const uint8_t bit_mask = static_cast<uint8_t>(1U << (d & 7));
-        uint32_t code = (one_bit_code[byte_idx] & bit_mask) != 0 ? one_bit_weight : 0U;
-        for (uint32_t bit = 0; bit < supplement_bits; ++bit) {
-            const auto* plane = supplement_code + static_cast<uint64_t>(bit) * plane_bytes;
-            if ((plane[byte_idx] & bit_mask) != 0) {
-                code += 1U << bit;
-            }
-        }
-        result += vector[d] * static_cast<float>(code);
-    }
-
-    return result;
+    return simd::RaBitQFloatSplitCodeIPImpl<simd::RaBitQTraits<simd::AVX_RaBitQ_Tag>>(
+        vector, one_bit_code, supplement_code, dim, supplement_bits);
 #else
     return sse::RaBitQFloatSplitCodeIP(vector, one_bit_code, supplement_code, dim, supplement_bits);
 #endif
@@ -1156,20 +567,7 @@ RaBitQFloatSplitCodeIP(const float* vector,
 void
 DivScalar(const float* from, float* to, uint64_t dim, float scalar) {
 #if defined(ENABLE_AVX)
-    if (dim == 0) {
-        return;
-    }
-    if (scalar == 0) {
-        scalar = 1.0F;  // TODO(LHT): logger?
-    }
-    int i = 0;
-    __m256 scalarVec = _mm256_set1_ps(scalar);
-    for (; i + 7 < dim; i += 8) {
-        __m256 vec = _mm256_loadu_ps(from + i);
-        vec = _mm256_div_ps(vec, scalarVec);
-        _mm256_storeu_ps(to + i, vec);
-    }
-    sse::DivScalar(from + i, to + i, dim - i, scalar);
+    simd::DivScalarImpl<simd::SimdTraits<simd::AVX_Tag>>(from, to, dim, scalar, &sse::DivScalar);
 #else
     sse::DivScalar(from, to, dim, scalar);
 #endif
@@ -1197,22 +595,7 @@ PQFastScanLookUp32(const uint8_t* RESTRICT lookup_table,
 void
 BitAnd(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* result) {
 #if defined(ENABLE_AVX)
-    if (num_byte == 0) {
-        return;
-    }
-    if (num_byte < 32) {
-        return sse::BitAnd(x, y, num_byte, result);
-    }
-    int64_t i = 0;
-    for (; i + 31 < num_byte; i += 32) {
-        __m256 x_vec = _mm256_loadu_ps(reinterpret_cast<const float*>(x + i));
-        __m256 y_vec = _mm256_loadu_ps(reinterpret_cast<const float*>(y + i));
-        __m256 z_vec = _mm256_and_ps(x_vec, y_vec);
-        _mm256_storeu_ps(reinterpret_cast<float*>(result + i), z_vec);
-    }
-    if (i < num_byte) {
-        sse::BitAnd(x + i, y + i, num_byte - i, result + i);
-    }
+    simd::BitAndImpl<simd::BitTraits<simd::AVX_Bit_Tag>>(x, y, num_byte, result, &sse::BitAnd);
 #else
     return sse::BitAnd(x, y, num_byte, result);
 #endif
@@ -1221,22 +604,7 @@ BitAnd(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* res
 void
 BitOr(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* result) {
 #if defined(ENABLE_AVX)
-    if (num_byte == 0) {
-        return;
-    }
-    if (num_byte < 32) {
-        return sse::BitOr(x, y, num_byte, result);
-    }
-    int64_t i = 0;
-    for (; i + 31 < num_byte; i += 32) {
-        __m256 x_vec = _mm256_loadu_ps(reinterpret_cast<const float*>(x + i));
-        __m256 y_vec = _mm256_loadu_ps(reinterpret_cast<const float*>(y + i));
-        __m256 z_vec = _mm256_or_ps(x_vec, y_vec);
-        _mm256_storeu_ps(reinterpret_cast<float*>(result + i), z_vec);
-    }
-    if (i < num_byte) {
-        sse::BitOr(x + i, y + i, num_byte - i, result + i);
-    }
+    simd::BitOrImpl<simd::BitTraits<simd::AVX_Bit_Tag>>(x, y, num_byte, result, &sse::BitOr);
 #else
     return sse::BitOr(x, y, num_byte, result);
 #endif
@@ -1245,22 +613,7 @@ BitOr(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* resu
 void
 BitXor(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* result) {
 #if defined(ENABLE_AVX)
-    if (num_byte == 0) {
-        return;
-    }
-    if (num_byte < 32) {
-        return sse::BitXor(x, y, num_byte, result);
-    }
-    int64_t i = 0;
-    for (; i + 31 < num_byte; i += 32) {
-        __m256 x_vec = _mm256_loadu_ps(reinterpret_cast<const float*>(x + i));
-        __m256 y_vec = _mm256_loadu_ps(reinterpret_cast<const float*>(y + i));
-        __m256 z_vec = _mm256_xor_ps(x_vec, y_vec);
-        _mm256_storeu_ps(reinterpret_cast<float*>(result + i), z_vec);
-    }
-    if (i < num_byte) {
-        sse::BitXor(x + i, y + i, num_byte - i, result + i);
-    }
+    simd::BitXorImpl<simd::BitTraits<simd::AVX_Bit_Tag>>(x, y, num_byte, result, &sse::BitXor);
 #else
     return sse::BitXor(x, y, num_byte, result);
 #endif
@@ -1269,22 +622,7 @@ BitXor(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* res
 void
 BitNot(const uint8_t* x, const uint64_t num_byte, uint8_t* result) {
 #if defined(ENABLE_AVX)
-    if (num_byte == 0) {
-        return;
-    }
-    if (num_byte < 32) {
-        return sse::BitNot(x, num_byte, result);
-    }
-    int64_t i = 0;
-    __m256 all_one = _mm256_castsi256_ps(_mm256_set1_epi32(-1));
-    for (; i + 31 < num_byte; i += 32) {
-        __m256 x_vec = _mm256_loadu_ps(reinterpret_cast<const float*>(x + i));
-        __m256 z_vec = _mm256_xor_ps(x_vec, all_one);
-        _mm256_storeu_ps(reinterpret_cast<float*>(result + i), z_vec);
-    }
-    if (i < num_byte) {
-        sse::BitNot(x + i, num_byte - i, result + i);
-    }
+    simd::BitNotImpl<simd::BitTraits<simd::AVX_Bit_Tag>>(x, num_byte, result, &sse::BitNot);
 #else
     return sse::BitNot(x, num_byte, result);
 #endif
@@ -1292,36 +630,18 @@ BitNot(const uint8_t* x, const uint64_t num_byte, uint8_t* result) {
 void
 VecRescale(float* data, uint64_t dim, float val) {
 #if defined(ENABLE_AVX)
-    int i = 0;
-    __m256 val_vec = _mm256_set1_ps(val);
-
-    for (; i + 8 <= dim; i += 8) {
-        __m256 data_vec = _mm256_loadu_ps(&data[i]);
-        __m256 result_vec = _mm256_mul_ps(data_vec, val_vec);
-        _mm256_storeu_ps(&data[i], result_vec);
-    }
-
-    sse::VecRescale(data + i, dim - i, val);
+    simd::VecRescaleImpl<simd::SimdTraits<simd::AVX_Tag>>(data, dim, val, &sse::VecRescale);
 #else
-    return sse::VecRescale(data, dim, val);
+    sse::VecRescale(data, dim, val);
 #endif
 }
 
 void
 RotateOp(float* data, int idx, int dim_, int step) {
 #if defined(ENABLE_AVX)
-    for (int i = idx; i < dim_; i += step * 2) {
-        for (int j = 0; j < step; j += 8) {
-            __m256 g1 = _mm256_loadu_ps(&data[i + j]);
-            __m256 g2 = _mm256_loadu_ps(&data[i + j + step]);
-            __m256 result_add = _mm256_add_ps(g1, g2);
-            __m256 result_sub = _mm256_sub_ps(g1, g2);
-            _mm256_storeu_ps(&data[i + j], result_add);
-            _mm256_storeu_ps(&data[i + j + step], result_sub);
-        }
-    }
+    simd::RotateOpImpl<simd::SimdTraits<simd::AVX_Tag>>(data, idx, dim_, step);
 #else
-    return sse::RotateOp(data, idx, dim_, step);
+    sse::RotateOp(data, idx, dim_, step);
 #endif
 }
 
@@ -1348,74 +668,17 @@ FHTRotate(float* data, uint64_t dim_) {
 void
 KacsWalk(float* data, uint64_t len) {
 #if defined(ENABLE_AVX)
-    uint64_t base = len % 2;
-    uint64_t offset = base + (len / 2);
-    uint64_t i = 0;
-
-    for (; i + 8 <= len / 2; i += 8) {
-        __m256 x = _mm256_loadu_ps(&data[i]);
-        __m256 y = _mm256_loadu_ps(&data[i + offset]);
-        __m256 add_result = _mm256_add_ps(x, y);
-        __m256 sub_result = _mm256_sub_ps(x, y);
-        _mm256_storeu_ps(&data[i], add_result);
-        _mm256_storeu_ps(&data[i + offset], sub_result);
-    }
-
-    for (; i < len / 2; i++) {
-        float add = data[i] + data[i + offset];
-        float sub = data[i] - data[i + offset];
-        data[i] = add;
-        data[i + offset] = sub;
-    }
-
-    if (base != 0) {
-        data[len / 2] *= std::sqrt(2.0F);
-    }
+    simd::KacsWalkImpl<simd::SimdTraits<simd::AVX_Tag>>(data, len, &sse::KacsWalk);
 #else
-    return sse::FHTRotate(data, len);
+    sse::KacsWalk(data, len);
 #endif
 }
 
 float
 NormalizeWithCentroid(const float* from, const float* centroid, float* to, uint64_t dim) {
 #if defined(ENABLE_AVX)
-    float norm_sq = 0;
-    uint64_t i = 0;
-    if (dim >= 8) {
-        __m256 sum = _mm256_setzero_ps();
-        for (; i + 7 < dim; i += 8) {
-            __m256 f = _mm256_loadu_ps(from + i);
-            __m256 c = _mm256_loadu_ps(centroid + i);
-            __m256 diff = _mm256_sub_ps(f, c);
-            sum = _mm256_add_ps(sum, _mm256_mul_ps(diff, diff));
-        }
-        norm_sq = avx_reduce_add_ps(sum);
-        norm_sq += sse::FP32ComputeL2Sqr(from + i, centroid + i, dim - i);
-    } else {
-        norm_sq = sse::FP32ComputeL2Sqr(from, centroid, dim);
-    }
-
-    float norm = 0;
-    if (norm_sq < 1e-5f) {
-        norm = 1.0f;
-    } else {
-        norm = std::sqrt(norm_sq);
-    }
-
-    __m256 normVec = _mm256_set1_ps(norm);
-    for (i = 0; i + 7 < dim; i += 8) {
-        __m256 f = _mm256_loadu_ps(from + i);
-        __m256 c = _mm256_loadu_ps(centroid + i);
-        __m256 diff = _mm256_sub_ps(f, c);
-        __m256 result = _mm256_div_ps(diff, normVec);
-        _mm256_storeu_ps(to + i, result);
-    }
-    if (i < dim) {
-        for (; i < dim; ++i) {
-            to[i] = (from[i] - centroid[i]) / norm;
-        }
-    }
-    return norm;
+    return simd::NormalizeWithCentroidImpl<simd::SimdTraits<simd::AVX_Tag>>(
+        from, centroid, to, dim, &sse::NormalizeWithCentroid);
 #else
     return sse::NormalizeWithCentroid(from, centroid, to, dim);
 #endif
@@ -1425,17 +688,8 @@ void
 InverseNormalizeWithCentroid(
     const float* from, const float* centroid, float* to, uint64_t dim, float norm) {
 #if defined(ENABLE_AVX)
-    uint64_t i = 0;
-    __m256 normVec = _mm256_set1_ps(norm);
-    for (; i + 7 < dim; i += 8) {
-        __m256 f = _mm256_loadu_ps(from + i);
-        __m256 c = _mm256_loadu_ps(centroid + i);
-        __m256 result = _mm256_add_ps(_mm256_mul_ps(f, normVec), c);
-        _mm256_storeu_ps(to + i, result);
-    }
-    if (i < dim) {
-        sse::InverseNormalizeWithCentroid(from + i, centroid + i, to + i, dim - i, norm);
-    }
+    simd::InverseNormalizeWithCentroidImpl<simd::SimdTraits<simd::AVX_Tag>>(
+        from, centroid, to, dim, norm, &sse::InverseNormalizeWithCentroid);
 #else
     sse::InverseNormalizeWithCentroid(from, centroid, to, dim, norm);
 #endif

--- a/src/simd/avx2.cpp
+++ b/src/simd/avx2.cpp
@@ -23,6 +23,9 @@
 #if defined(ENABLE_AVX2)
 #include <immintrin.h>
 
+#include "simd/kernels/kernels.h"
+#include "simd/traits/simd_traits_avx2.h"
+
 inline float
 avx2_reduce_add_ps(__m256 a) {
     alignas(32) float tmp[8];
@@ -30,41 +33,6 @@ avx2_reduce_add_ps(__m256 a) {
     return tmp[0] + tmp[1] + tmp[2] + tmp[3] + tmp[4] + tmp[5] + tmp[6] + tmp[7];
 }
 #define AVX2_REDUCE_ADD_PS(a) avx2_reduce_add_ps(a)
-
-template <typename OP>
-inline float
-avx2_compute_fp32(const float* RESTRICT query, const float* RESTRICT codes, uint64_t dim, OP&& op) {
-    const int n = dim / 8;
-    if (dim < 8) {
-        return op.fallback(query, codes, dim);
-    }
-    __m256 sum = _mm256_setzero_ps();
-    for (int i = 0; i < n; ++i) {
-        __m256 a = _mm256_loadu_ps(query + i * 8);
-        __m256 b = _mm256_loadu_ps(codes + i * 8);
-        sum = op.compute(sum, a, b);
-    }
-    float result = AVX2_REDUCE_ADD_PS(sum);
-    result += op.fallback(query + n * 8, codes + n * 8, dim - n * 8);
-    return result;
-}
-
-struct Fp32IPOp {
-    __m256
-    compute(__m256 sum, __m256 a, __m256 b) {
-        return _mm256_add_ps(sum, _mm256_mul_ps(a, b));
-    }
-    float (*fallback)(const float*, const float*, uint64_t);
-};
-
-struct Fp32L2Op {
-    __m256
-    compute(__m256 sum, __m256 a, __m256 b) {
-        __m256 diff = _mm256_sub_ps(a, b);
-        return _mm256_fmadd_ps(diff, diff, sum);
-    }
-    float (*fallback)(const float*, const float*, uint64_t);
-};
 #endif
 
 namespace vsag::avx2 {
@@ -114,17 +82,8 @@ INT8InnerProductDistance(const void* pVect1v, const void* pVect2v, const void* q
 void
 PQDistanceFloat256(const void* single_dim_centers, float single_dim_val, void* result) {
 #if defined(ENABLE_AVX2)
-    auto* float_centers = (const float*)single_dim_centers;
-    auto* float_result = (float*)result;
-    for (uint64_t idx = 0; idx < 256; idx += 8) {
-        __m256 v_centers_dim = _mm256_loadu_ps(float_centers + idx);
-        __m256 v_query_vec = _mm256_set1_ps(single_dim_val);
-        __m256 v_diff = _mm256_sub_ps(v_centers_dim, v_query_vec);
-        __m256 v_diff_sq = _mm256_mul_ps(v_diff, v_diff);
-        __m256 v_chunk_dists = _mm256_loadu_ps(&float_result[idx]);
-        v_chunk_dists = _mm256_add_ps(v_chunk_dists, v_diff_sq);
-        _mm256_storeu_ps(&float_result[idx], v_chunk_dists);
-    }
+    simd::PQDistanceFloat256Impl<simd::SimdTraits<simd::AVX2_Tag>>(
+        single_dim_centers, single_dim_val, result, &avx::PQDistanceFloat256);
 #else
     return avx::PQDistanceFloat256(single_dim_centers, single_dim_val, result);
 #endif
@@ -144,8 +103,8 @@ __inline __m128i __attribute__((__always_inline__)) load_8_char(const uint8_t* d
 float
 FP32ComputeIP(const float* RESTRICT query, const float* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_AVX2)
-    Fp32IPOp op{sse::FP32ComputeIP};
-    return avx2_compute_fp32(query, codes, dim, op);
+    return simd::ComputeIPImpl<simd::SimdTraits<simd::AVX2_Tag>>(
+        query, codes, dim, &sse::FP32ComputeIP);
 #else
     return avx::FP32ComputeIP(query, codes, dim);
 #endif
@@ -154,8 +113,8 @@ FP32ComputeIP(const float* RESTRICT query, const float* RESTRICT codes, uint64_t
 float
 FP32ComputeL2Sqr(const float* RESTRICT query, const float* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_AVX2)
-    Fp32L2Op op{sse::FP32ComputeL2Sqr};
-    return avx2_compute_fp32(query, codes, dim, op);
+    return simd::ComputeL2SqrImpl<simd::SimdTraits<simd::AVX2_Tag>>(
+        query, codes, dim, &sse::FP32ComputeL2Sqr);
 #else
     return avx::FP32ComputeL2Sqr(query, codes, dim);
 #endif
@@ -173,52 +132,18 @@ FP32ComputeIPBatch4(const float* RESTRICT query,
                     float& result3,
                     float& result4) {
 #if defined(ENABLE_AVX2)
-    if (dim < 8) {
-        return avx::FP32ComputeIPBatch4(
-            query, dim, codes1, codes2, codes3, codes4, result1, result2, result3, result4);
-    }
-
-    __m256 sum1 = _mm256_setzero_ps();
-    __m256 sum2 = _mm256_setzero_ps();
-    __m256 sum3 = _mm256_setzero_ps();
-    __m256 sum4 = _mm256_setzero_ps();
-    int i = 0;
-    for (; i + 7 < dim; i += 8) {
-        __m256 q = _mm256_loadu_ps(query + i);
-        __m256 c1 = _mm256_loadu_ps(codes1 + i);
-        __m256 c2 = _mm256_loadu_ps(codes2 + i);
-        __m256 c3 = _mm256_loadu_ps(codes3 + i);
-        __m256 c4 = _mm256_loadu_ps(codes4 + i);
-        sum1 = _mm256_fmadd_ps(q, c1, sum1);
-        sum2 = _mm256_fmadd_ps(q, c2, sum2);
-        sum3 = _mm256_fmadd_ps(q, c3, sum3);
-        sum4 = _mm256_fmadd_ps(q, c4, sum4);
-    }
-    alignas(32) float result[8];
-    _mm256_store_ps(result, sum1);
-    result1 += result[0] + result[1] + result[2] + result[3] + result[4] + result[5] + result[6] +
-               result[7];
-    _mm256_store_ps(result, sum2);
-    result2 += result[0] + result[1] + result[2] + result[3] + result[4] + result[5] + result[6] +
-               result[7];
-    _mm256_store_ps(result, sum3);
-    result3 += result[0] + result[1] + result[2] + result[3] + result[4] + result[5] + result[6] +
-               result[7];
-    _mm256_store_ps(result, sum4);
-    result4 += result[0] + result[1] + result[2] + result[3] + result[4] + result[5] + result[6] +
-               result[7];
-    if (i < dim) {
-        avx::FP32ComputeIPBatch4(query + i,
-                                 dim - i,
-                                 codes1 + i,
-                                 codes2 + i,
-                                 codes3 + i,
-                                 codes4 + i,
-                                 result1,
-                                 result2,
-                                 result3,
-                                 result4);
-    }
+    simd::ComputeBatch4Impl<simd::SimdTraits<simd::AVX2_Tag>, simd::Batch4Kind::IP>(
+        query,
+        dim,
+        codes1,
+        codes2,
+        codes3,
+        codes4,
+        result1,
+        result2,
+        result3,
+        result4,
+        &avx::FP32ComputeIPBatch4);
 #else
     return avx::FP32ComputeIPBatch4(
         query, dim, codes1, codes2, codes3, codes4, result1, result2, result3, result4);
@@ -237,55 +162,18 @@ FP32ComputeL2SqrBatch4(const float* RESTRICT query,
                        float& result3,
                        float& result4) {
 #if defined(ENABLE_AVX2)
-    if (dim < 8) {
-        return sse::FP32ComputeL2SqrBatch4(
-            query, dim, codes1, codes2, codes3, codes4, result1, result2, result3, result4);
-    }
-    __m256 sum1 = _mm256_setzero_ps();
-    __m256 sum2 = _mm256_setzero_ps();
-    __m256 sum3 = _mm256_setzero_ps();
-    __m256 sum4 = _mm256_setzero_ps();
-    int i = 0;
-    for (; i + 7 < dim; i += 8) {
-        __m256 q = _mm256_loadu_ps(query + i);
-        __m256 c1 = _mm256_loadu_ps(codes1 + i);
-        __m256 c2 = _mm256_loadu_ps(codes2 + i);
-        __m256 c3 = _mm256_loadu_ps(codes3 + i);
-        __m256 c4 = _mm256_loadu_ps(codes4 + i);
-        __m256 diff1 = _mm256_sub_ps(q, c1);
-        __m256 diff2 = _mm256_sub_ps(q, c2);
-        __m256 diff3 = _mm256_sub_ps(q, c3);
-        __m256 diff4 = _mm256_sub_ps(q, c4);
-        sum1 = _mm256_fmadd_ps(diff1, diff1, sum1);
-        sum2 = _mm256_fmadd_ps(diff2, diff2, sum2);
-        sum3 = _mm256_fmadd_ps(diff3, diff3, sum3);
-        sum4 = _mm256_fmadd_ps(diff4, diff4, sum4);
-    }
-    alignas(32) float result[8];
-    _mm256_store_ps(result, sum1);
-    result1 += result[0] + result[1] + result[2] + result[3] + result[4] + result[5] + result[6] +
-               result[7];
-    _mm256_store_ps(result, sum2);
-    result2 += result[0] + result[1] + result[2] + result[3] + result[4] + result[5] + result[6] +
-               result[7];
-    _mm256_store_ps(result, sum3);
-    result3 += result[0] + result[1] + result[2] + result[3] + result[4] + result[5] + result[6] +
-               result[7];
-    _mm256_store_ps(result, sum4);
-    result4 += result[0] + result[1] + result[2] + result[3] + result[4] + result[5] + result[6] +
-               result[7];
-    if (i < dim) {
-        avx::FP32ComputeL2SqrBatch4(query + i,
-                                    dim - i,
-                                    codes1 + i,
-                                    codes2 + i,
-                                    codes3 + i,
-                                    codes4 + i,
-                                    result1,
-                                    result2,
-                                    result3,
-                                    result4);
-    }
+    simd::ComputeBatch4Impl<simd::SimdTraits<simd::AVX2_Tag>, simd::Batch4Kind::L2>(
+        query,
+        dim,
+        codes1,
+        codes2,
+        codes3,
+        codes4,
+        result1,
+        result2,
+        result3,
+        result4,
+        &avx::FP32ComputeL2SqrBatch4);
 #else
     return avx::FP32ComputeL2SqrBatch4(
         query, dim, codes1, codes2, codes3, codes4, result1, result2, result3, result4);
@@ -295,19 +183,8 @@ FP32ComputeL2SqrBatch4(const float* RESTRICT query,
 void
 FP32Sub(const float* x, const float* y, float* z, uint64_t dim) {
 #if defined(ENABLE_AVX2)
-    if (dim < 8) {
-        return sse::FP32Sub(x, y, z, dim);
-    }
-    int i = 0;
-    for (; i + 7 < dim; i += 8) {
-        __m256 a = _mm256_loadu_ps(x + i);
-        __m256 b = _mm256_loadu_ps(y + i);
-        __m256 c = _mm256_sub_ps(a, b);
-        _mm256_storeu_ps(z + i, c);
-    }
-    if (i < dim) {
-        sse::FP32Sub(x + i, y + i, z + i, dim - i);
-    }
+    simd::BinaryOpImpl<simd::SimdTraits<simd::AVX2_Tag>, simd::BinaryOp::Sub>(
+        x, y, z, dim, &sse::FP32Sub);
 #else
     return sse::FP32Sub(x, y, z, dim);
 #endif
@@ -316,19 +193,8 @@ FP32Sub(const float* x, const float* y, float* z, uint64_t dim) {
 void
 FP32Add(const float* x, const float* y, float* z, uint64_t dim) {
 #if defined(ENABLE_AVX2)
-    if (dim < 8) {
-        return sse::FP32Add(x, y, z, dim);
-    }
-    int i = 0;
-    for (; i + 7 < dim; i += 8) {
-        __m256 a = _mm256_loadu_ps(x + i);
-        __m256 b = _mm256_loadu_ps(y + i);
-        __m256 c = _mm256_add_ps(a, b);
-        _mm256_storeu_ps(z + i, c);
-    }
-    if (i < dim) {
-        sse::FP32Add(x + i, y + i, z + i, dim - i);
-    }
+    simd::BinaryOpImpl<simd::SimdTraits<simd::AVX2_Tag>, simd::BinaryOp::Add>(
+        x, y, z, dim, &sse::FP32Add);
 #else
     return sse::FP32Add(x, y, z, dim);
 #endif
@@ -337,19 +203,8 @@ FP32Add(const float* x, const float* y, float* z, uint64_t dim) {
 void
 FP32Mul(const float* x, const float* y, float* z, uint64_t dim) {
 #if defined(ENABLE_AVX2)
-    if (dim < 8) {
-        return sse::FP32Mul(x, y, z, dim);
-    }
-    int i = 0;
-    for (; i + 7 < dim; i += 8) {
-        __m256 a = _mm256_loadu_ps(x + i);
-        __m256 b = _mm256_loadu_ps(y + i);
-        __m256 c = _mm256_mul_ps(a, b);
-        _mm256_storeu_ps(z + i, c);
-    }
-    if (i < dim) {
-        sse::FP32Mul(x + i, y + i, z + i, dim - i);
-    }
+    simd::BinaryOpImpl<simd::SimdTraits<simd::AVX2_Tag>, simd::BinaryOp::Mul>(
+        x, y, z, dim, &sse::FP32Mul);
 #else
     return sse::FP32Mul(x, y, z, dim);
 #endif
@@ -358,19 +213,8 @@ FP32Mul(const float* x, const float* y, float* z, uint64_t dim) {
 void
 FP32Div(const float* x, const float* y, float* z, uint64_t dim) {
 #if defined(ENABLE_AVX2)
-    if (dim < 8) {
-        return sse::FP32Div(x, y, z, dim);
-    }
-    int i = 0;
-    for (; i + 7 < dim; i += 8) {
-        __m256 a = _mm256_loadu_ps(x + i);
-        __m256 b = _mm256_loadu_ps(y + i);
-        __m256 c = _mm256_div_ps(a, b);
-        _mm256_storeu_ps(z + i, c);
-    }
-    if (i < dim) {
-        sse::FP32Div(x + i, y + i, z + i, dim - i);
-    }
+    simd::BinaryOpImpl<simd::SimdTraits<simd::AVX2_Tag>, simd::BinaryOp::Div>(
+        x, y, z, dim, &sse::FP32Div);
 #else
     return sse::FP32Div(x, y, z, dim);
 #endif
@@ -378,20 +222,7 @@ FP32Div(const float* x, const float* y, float* z, uint64_t dim) {
 float
 FP32ReduceAdd(const float* x, uint64_t dim) {
 #if defined(ENABLE_AVX2)
-    if (dim < 8) {
-        return sse::FP32ReduceAdd(x, dim);
-    }
-    __m256 sum = _mm256_setzero_ps();
-    uint64_t i = 0;
-    for (; i + 7 < dim; i += 8) {
-        __m256 a = _mm256_loadu_ps(x + i);
-        sum = _mm256_add_ps(sum, a);
-    }
-    float result = AVX2_REDUCE_ADD_PS(sum);
-    if (i < dim) {
-        result += sse::FP32ReduceAdd(x + i, dim - i);
-    }
-    return result;
+    return simd::ReduceAddImpl<simd::SimdTraits<simd::AVX2_Tag>>(x, dim, &sse::FP32ReduceAdd);
 #else
     return sse::FP32ReduceAdd(x, dim);
 #endif
@@ -408,31 +239,8 @@ __inline __m256i __attribute__((__always_inline__)) load_8_short(const uint16_t*
 float
 BF16ComputeIP(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_AVX2)
-    // Initialize the sum to 0
-    __m256 sum = _mm256_setzero_ps();
-    const auto* query_bf16 = (const uint16_t*)(query);
-    const auto* codes_bf16 = (const uint16_t*)(codes);
-
-    // Process the data in 128-bit chunks
-    uint64_t i = 0;
-    for (; i + 7 < dim; i += 8) {
-        // Load data into registers
-        __m256i query_shift = load_8_short(query_bf16 + i);
-        __m256 query_float = _mm256_castsi256_ps(query_shift);
-
-        // Load data into registers
-        __m256i code_shift = load_8_short(codes_bf16 + i);
-        __m256 code_float = _mm256_castsi256_ps(code_shift);
-
-        sum = _mm256_fmadd_ps(code_float, query_float, sum);
-    }
-
-    alignas(32) float result[8];
-    _mm256_store_ps(result, sum);  // store the accumulated result into an array
-    float ip = result[0] + result[1] + result[2] + result[3] + result[4] + result[5] + result[6] +
-               result[7];  // calculate the sum of the accumulated results
-
-    return ip + avx::BF16ComputeIP(query + i * 2, codes + i * 2, dim - i);
+    return simd::HalfComputeIPImpl<simd::BF16Traits<simd::AVX2_BF16_Tag>>(
+        query, codes, dim, &avx::BF16ComputeIP);
 #else
     return avx::BF16ComputeIP(query, codes, dim);
 #endif
@@ -441,32 +249,8 @@ BF16ComputeIP(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint
 float
 BF16ComputeL2Sqr(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_AVX2)
-    // Initialize the sum to 0
-    __m256 sum = _mm256_setzero_ps();
-    const auto* query_bf16 = (const uint16_t*)(query);
-    const auto* codes_bf16 = (const uint16_t*)(codes);
-
-    // Process the data in 128-bit chunks
-    uint64_t i = 0;
-    for (; i + 7 < dim; i += 8) {
-        // Load data into registers
-        __m256i query_shift = load_8_short(query_bf16 + i);
-        __m256 query_float = _mm256_castsi256_ps(query_shift);
-
-        // Load data into registers
-        __m256i code_shift = load_8_short(codes_bf16 + i);
-        __m256 code_float = _mm256_castsi256_ps(code_shift);
-
-        __m256 diff = _mm256_sub_ps(code_float, query_float);
-        sum = _mm256_fmadd_ps(diff, diff, sum);
-    }
-
-    alignas(32) float result[8];
-    _mm256_store_ps(result, sum);  // store the accumulated result into an array
-    float l2 = result[0] + result[1] + result[2] + result[3] + result[4] + result[5] + result[6] +
-               result[7];  // calculate the sum of the accumulated results
-
-    return l2 + avx::BF16ComputeL2Sqr(query + i * 2, codes + i * 2, dim - i);
+    return simd::HalfComputeL2SqrImpl<simd::BF16Traits<simd::AVX2_BF16_Tag>>(
+        query, codes, dim, &avx::BF16ComputeL2Sqr);
 #else
     return avx::BF16ComputeL2Sqr(query, codes, dim);
 #endif
@@ -475,31 +259,8 @@ BF16ComputeL2Sqr(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, u
 float
 FP16ComputeIP(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_AVX2)
-    // Initialize the sum to 0
-    __m256 sum = _mm256_setzero_ps();
-    const auto* query_fp16 = (const uint16_t*)(query);
-    const auto* codes_fp16 = (const uint16_t*)(codes);
-
-    // Process the data in 128-bit chunks
-    uint64_t i = 0;
-    for (; i + 7 < dim; i += 8) {
-        // Load data into registers
-        __m128i query_load = _mm_loadu_si128(reinterpret_cast<const __m128i*>(query_fp16 + i));
-        __m256 query_float = _mm256_cvtph_ps(query_load);
-
-        // Load data into registers
-        __m128i code_load = _mm_loadu_si128(reinterpret_cast<const __m128i*>(codes_fp16 + i));
-        __m256 code_float = _mm256_cvtph_ps(code_load);
-
-        sum = _mm256_fmadd_ps(code_float, query_float, sum);
-    }
-
-    alignas(32) float result[8];
-    _mm256_store_ps(result, sum);  // store the accumulated result into an array
-    float ip = result[0] + result[1] + result[2] + result[3] + result[4] + result[5] + result[6] +
-               result[7];  // calculate the sum of the accumulated results
-
-    return ip + avx::FP16ComputeIP(query + i * 2, codes + i * 2, dim - i);
+    return simd::HalfComputeIPImpl<simd::FP16Traits<simd::AVX2_FP16_Tag>>(
+        query, codes, dim, &avx::FP16ComputeIP);
 #else
     return avx::FP16ComputeIP(query, codes, dim);
 #endif
@@ -508,32 +269,8 @@ FP16ComputeIP(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint
 float
 FP16ComputeL2Sqr(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_AVX2)
-    // Initialize the sum to 0
-    __m256 sum = _mm256_setzero_ps();
-    const auto* query_fp16 = (const uint16_t*)(query);
-    const auto* codes_fp16 = (const uint16_t*)(codes);
-
-    // Process the data in 128-bit chunks
-    uint64_t i = 0;
-    for (; i + 7 < dim; i += 8) {
-        // Load data into registers
-        __m128i query_load = _mm_loadu_si128(reinterpret_cast<const __m128i*>(query_fp16 + i));
-        __m256 query_float = _mm256_cvtph_ps(query_load);
-
-        // Load data into registers
-        __m128i code_load = _mm_loadu_si128(reinterpret_cast<const __m128i*>(codes_fp16 + i));
-        __m256 code_float = _mm256_cvtph_ps(code_load);
-
-        __m256 diff = _mm256_sub_ps(code_float, query_float);
-        sum = _mm256_fmadd_ps(diff, diff, sum);
-    }
-
-    alignas(32) float result[8];
-    _mm256_store_ps(result, sum);  // store the accumulated result into an array
-    float l2 = result[0] + result[1] + result[2] + result[3] + result[4] + result[5] + result[6] +
-               result[7];  // calculate the sum of the accumulated results
-
-    return l2 + avx::FP16ComputeL2Sqr(query + i * 2, codes + i * 2, dim - i);
+    return simd::HalfComputeL2SqrImpl<simd::FP16Traits<simd::AVX2_FP16_Tag>>(
+        query, codes, dim, &avx::FP16ComputeL2Sqr);
 #else
     return avx::FP16ComputeL2Sqr(query, codes, dim);
 #endif
@@ -542,85 +279,20 @@ FP16ComputeL2Sqr(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, u
 float
 INT8ComputeL2Sqr(const int8_t* RESTRICT query, const int8_t* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_AVX2)
-    constexpr int64_t BATCH_SIZE{16};
-
-    const int n = dim / BATCH_SIZE;
-
-    if (n == 0) {
-        return avx::INT8ComputeL2Sqr(query, codes, dim);
-    }
-
-    __m256i sum_sq = _mm256_setzero_si256();
-
-    for (int i{0}; i < n; ++i) {
-        __m128i q = _mm_loadu_si128(reinterpret_cast<const __m128i*>(query + BATCH_SIZE * i));
-        __m128i c = _mm_loadu_si128(reinterpret_cast<const __m128i*>(codes + BATCH_SIZE * i));
-
-        __m256i q_int16 = _mm256_cvtepi8_epi16(q);
-        __m256i c_int16 = _mm256_cvtepi8_epi16(c);
-
-        __m256i diff = _mm256_sub_epi16(q_int16, c_int16);
-
-        __m256i sq = _mm256_madd_epi16(diff, diff);
-
-        sum_sq = _mm256_add_epi32(sum_sq, sq);
-    }
-
-    alignas(32) int32_t result[BATCH_SIZE / 2];
-    _mm256_store_si256(reinterpret_cast<__m256i*>(result), sum_sq);
-
-    int32_t l2 = 0;
-    for (int i = 0; i < BATCH_SIZE / 2; ++i) {
-        l2 += result[i];
-    }
-
-    l2 +=
-        avx::INT8ComputeL2Sqr(query + BATCH_SIZE * n, codes + BATCH_SIZE * n, dim - BATCH_SIZE * n);
-
-    return static_cast<float>(l2);
+    return simd::Int8ComputeL2SqrImpl<simd::Int8Traits<simd::AVX2_Int8_Tag>>(
+        query, codes, dim, &avx::INT8ComputeL2Sqr);
 #else
-    return avx::INT8ComputeL2Sqr(query, codes, dim);
+    return sse::INT8ComputeL2Sqr(query, codes, dim);
 #endif
 }
 
 float
 INT8ComputeIP(const int8_t* __restrict query, const int8_t* __restrict codes, uint64_t dim) {
 #if defined(ENABLE_AVX2)
-    constexpr int64_t BATCH_SIZE{16};
-
-    const int n = dim / BATCH_SIZE;
-
-    if (n == 0) {
-        return avx::INT8ComputeIP(query, codes, dim);
-    }
-
-    __m256i sum_sq = _mm256_setzero_si256();
-
-    for (int i{0}; i < n; ++i) {
-        __m128i q = _mm_loadu_si128(reinterpret_cast<const __m128i*>(query + BATCH_SIZE * i));
-        __m128i c = _mm_loadu_si128(reinterpret_cast<const __m128i*>(codes + BATCH_SIZE * i));
-
-        __m256i q_int16 = _mm256_cvtepi8_epi16(q);
-        __m256i c_int16 = _mm256_cvtepi8_epi16(c);
-
-        __m256i sq = _mm256_madd_epi16(q_int16, c_int16);
-
-        sum_sq = _mm256_add_epi32(sum_sq, sq);
-    }
-
-    alignas(32) int32_t result[BATCH_SIZE / 2];
-    _mm256_store_si256(reinterpret_cast<__m256i*>(result), sum_sq);
-
-    int32_t ip = 0;
-    for (int i = 0; i < BATCH_SIZE / 2; ++i) {
-        ip += result[i];
-    }
-
-    ip += avx::INT8ComputeIP(query + BATCH_SIZE * n, codes + BATCH_SIZE * n, dim - BATCH_SIZE * n);
-
-    return static_cast<float>(ip);
+    return simd::Int8ComputeIPImpl<simd::Int8Traits<simd::AVX2_Int8_Tag>>(
+        query, codes, dim, &avx::INT8ComputeIP);
 #else
-    return avx::INT8ComputeIP(query, codes, dim);
+    return sse::INT8ComputeIP(query, codes, dim);
 #endif
 }
 
@@ -631,34 +303,8 @@ SQ8ComputeIP(const float* RESTRICT query,
              const float* RESTRICT diff,
              uint64_t dim) {
 #if defined(ENABLE_AVX2)
-    __m256 sum = _mm256_setzero_ps();
-    uint64_t i = 0;
-
-    for (; i + 7 < dim; i += 8) {
-        __m128i code_values = load_8_char(codes + i);
-        __m256 code_floats = _mm256_cvtepi32_ps(_mm256_cvtepu8_epi32(code_values));
-        __m256 query_values = _mm256_loadu_ps(query + i);
-        __m256 diff_values = _mm256_loadu_ps(diff + i);
-        __m256 lower_bound_values = _mm256_loadu_ps(lower_bound + i);
-
-        __m256 scaled_codes =
-            _mm256_mul_ps(_mm256_div_ps(code_floats, _mm256_set1_ps(255.0F)), diff_values);
-        __m256 adjusted_codes = _mm256_add_ps(scaled_codes, lower_bound_values);
-        __m256 val = _mm256_mul_ps(query_values, adjusted_codes);
-        sum = _mm256_add_ps(sum, val);
-    }
-
-    __m128 sum_high = _mm256_extractf128_ps(sum, 1);
-    __m128 sum_low = _mm256_castps256_ps128(sum);
-    __m128 sum_final = _mm_add_ps(sum_low, sum_high);
-
-    alignas(16) float result[4];
-    _mm_store_ps(result, sum_final);
-    float finalResult = result[0] + result[1] + result[2] + result[3];
-
-    // Process the remaining elements recursively
-    finalResult += avx::SQ8ComputeIP(query + i, codes + i, lower_bound + i, diff + i, dim - i);
-    return finalResult;
+    return simd::SQ8ComputeIPImpl<simd::SQ8Traits<simd::AVX2_SQ8_Tag>>(
+        query, codes, lower_bound, diff, dim, &avx::SQ8ComputeIP);
 #else
     return avx::SQ8ComputeIP(query, codes, lower_bound, diff, dim);
 #endif
@@ -671,39 +317,8 @@ SQ8ComputeL2Sqr(const float* RESTRICT query,
                 const float* RESTRICT diff,
                 uint64_t dim) {
 #if defined(ENABLE_AVX2)
-    __m256 sum = _mm256_setzero_ps();
-    uint64_t i = 0;
-
-    for (; i + 7 < dim; i += 8) {
-        // Load data into registers
-        __m256i code_values = _mm256_cvtepu8_epi32(load_8_char(codes + i));
-        __m256 code_floats = _mm256_div_ps(_mm256_cvtepi32_ps(code_values), _mm256_set1_ps(255.0F));
-        __m256 diff_values = _mm256_loadu_ps(diff + i);
-        __m256 lower_bound_values = _mm256_loadu_ps(lower_bound + i);
-        __m256 query_values = _mm256_loadu_ps(query + i);
-
-        // Perform calculations
-        __m256 scaled_codes = _mm256_mul_ps(code_floats, diff_values);
-        scaled_codes = _mm256_add_ps(scaled_codes, lower_bound_values);
-        __m256 val = _mm256_sub_ps(query_values, scaled_codes);
-        val = _mm256_mul_ps(val, val);
-        sum = _mm256_add_ps(sum, val);
-    }
-
-    // Horizontal addition
-    __m128 sum_high = _mm256_extractf128_ps(sum, 1);
-    __m128 sum_low = _mm256_castps256_ps128(sum);
-    __m128 sum_final = _mm_add_ps(sum_low, sum_high);
-    sum_final = _mm_hadd_ps(sum_final, sum_final);
-    sum_final = _mm_hadd_ps(sum_final, sum_final);
-
-    // Extract the result from the register
-    float result;
-    _mm_store_ss(&result, sum_final);
-
-    // Process the remaining elements
-    result += avx::SQ8ComputeL2Sqr(query + i, codes + i, lower_bound + i, diff + i, dim - i);
-    return result;
+    return simd::SQ8ComputeL2SqrImpl<simd::SQ8Traits<simd::AVX2_SQ8_Tag>>(
+        query, codes, lower_bound, diff, dim, &avx::SQ8ComputeL2Sqr);
 #else
     return avx::SQ8ComputeL2Sqr(query, codes, lower_bound, diff, dim);
 #endif
@@ -716,38 +331,8 @@ SQ8ComputeCodesIP(const uint8_t* RESTRICT codes1,
                   const float* RESTRICT diff,
                   uint64_t dim) {
 #if defined(ENABLE_AVX2)
-    __m256 sum = _mm256_setzero_ps();
-    uint64_t i = 0;
-    for (; i + 7 < dim; i += 8) {
-        // Load data into registers
-        __m128i code1_values = load_8_char(codes1 + i);
-        __m128i code2_values = load_8_char(codes2 + i);
-        __m256i codes1_256 = _mm256_cvtepu8_epi32(code1_values);
-        __m256i codes2_256 = _mm256_cvtepu8_epi32(code2_values);
-        __m256 code1_floats = _mm256_div_ps(_mm256_cvtepi32_ps(codes1_256), _mm256_set1_ps(255.0F));
-        __m256 code2_floats = _mm256_div_ps(_mm256_cvtepi32_ps(codes2_256), _mm256_set1_ps(255.0F));
-        __m256 diff_values = _mm256_loadu_ps(diff + i);
-        __m256 lower_bound_values = _mm256_loadu_ps(lower_bound + i);
-        // Perform calculations
-        __m256 scaled_codes1 = _mm256_fmadd_ps(code1_floats, diff_values, lower_bound_values);
-        __m256 scaled_codes2 = _mm256_fmadd_ps(code2_floats, diff_values, lower_bound_values);
-        __m256 val = _mm256_mul_ps(scaled_codes1, scaled_codes2);
-        sum = _mm256_add_ps(sum, val);
-    }
-
-    // Horizontal addition
-    __m128 sum_high = _mm256_extractf128_ps(sum, 1);
-    __m128 sum_low = _mm256_castps256_ps128(sum);
-    __m128 sum_final = _mm_add_ps(sum_low, sum_high);
-    sum_final = _mm_hadd_ps(sum_final, sum_final);
-    sum_final = _mm_hadd_ps(sum_final, sum_final);
-
-    // Extract the result from the register
-    float result;
-    _mm_store_ss(&result, sum_final);
-
-    result += avx::SQ8ComputeCodesIP(codes1 + i, codes2 + i, lower_bound + i, diff + i, dim - i);
-    return result;
+    return simd::SQ8ComputeCodesIPImpl<simd::SQ8Traits<simd::AVX2_SQ8_Tag>>(
+        codes1, codes2, lower_bound, diff, dim, &avx::SQ8ComputeCodesIP);
 #else
     return avx::SQ8ComputeCodesIP(codes1, codes2, lower_bound, diff, dim);
 #endif
@@ -760,37 +345,8 @@ SQ8ComputeCodesL2Sqr(const uint8_t* RESTRICT codes1,
                      const float* RESTRICT diff,
                      uint64_t dim) {
 #if defined(ENABLE_AVX2)
-    __m256 sum = _mm256_setzero_ps();
-    uint64_t i = 0;
-    for (; i + 7 < dim; i += 8) {
-        // Load data into registers
-        __m256i code1_values = _mm256_cvtepu8_epi32(load_8_char(codes1 + i));
-        __m256i code2_values = _mm256_cvtepu8_epi32(load_8_char(codes2 + i));
-        __m256 codes1_floats =
-            _mm256_div_ps(_mm256_cvtepi32_ps(code1_values), _mm256_set1_ps(255.0F));
-        __m256 codes2_floats =
-            _mm256_div_ps(_mm256_cvtepi32_ps(code2_values), _mm256_set1_ps(255.0F));
-        __m256 diff_values = _mm256_loadu_ps(diff + i);
-        __m256 lower_bound_values = _mm256_loadu_ps(lower_bound + i);
-        // Perform calculations
-        __m256 scaled_codes1 = _mm256_fmadd_ps(codes1_floats, diff_values, lower_bound_values);
-        __m256 scaled_codes2 = _mm256_fmadd_ps(codes2_floats, diff_values, lower_bound_values);
-        __m256 val = _mm256_sub_ps(scaled_codes1, scaled_codes2);
-        val = _mm256_mul_ps(val, val);
-        sum = _mm256_add_ps(sum, val);
-    }
-    // Horizontal addition
-    __m128 sum_high = _mm256_extractf128_ps(sum, 1);
-    __m128 sum_low = _mm256_castps256_ps128(sum);
-    __m128 sum_final = _mm_add_ps(sum_low, sum_high);
-    sum_final = _mm_hadd_ps(sum_final, sum_final);
-    sum_final = _mm_hadd_ps(sum_final, sum_final);
-    // Extract the result from the register
-    float result;
-    _mm_store_ss(&result, sum_final);
-
-    result += avx::SQ8ComputeCodesL2Sqr(codes1 + i, codes2 + i, lower_bound + i, diff + i, dim - i);
-    return result;
+    return simd::SQ8ComputeCodesL2SqrImpl<simd::SQ8Traits<simd::AVX2_SQ8_Tag>>(
+        codes1, codes2, lower_bound, diff, dim, &avx::SQ8ComputeCodesL2Sqr);
 #else
     return avx::SQ8ComputeCodesL2Sqr(codes1, codes2, lower_bound, diff, dim);
 #endif
@@ -862,42 +418,8 @@ SQ4ComputeIP(const float* RESTRICT query,
              const float* RESTRICT diff,
              uint64_t dim) {
 #if defined(ENABLE_AVX2)
-    if (dim == 0) {
-        return 0;
-    }
-
-    float result = 0;
-    uint64_t d = 0;
-
-    // Process 16 values at a time (8 bytes containing 16 4-bit values)
-    for (; d + 15 < dim; d += 16) {
-        __m256 values01, values23;
-        SQ4Decode16Values(codes, d, values01, values23, lower_bound, diff);
-
-        // Load query vectors
-        __m256 query_vec0 = _mm256_loadu_ps(query + d);
-        __m256 query_vec1 = _mm256_loadu_ps(query + d + 8);
-
-        // Compute dot products
-        __m256 prod0 = _mm256_mul_ps(query_vec0, values01);
-        __m256 prod1 = _mm256_mul_ps(query_vec1, values23);
-
-        // Horizontal sum
-        __m256 sum = _mm256_add_ps(prod0, prod1);
-        __m128 sum_low = _mm256_castps256_ps128(sum);
-        __m128 sum_high = _mm256_extractf128_ps(sum, 1);
-        __m128 sum01 = _mm_add_ps(sum_low, sum_high);
-        __m128 sum23 = _mm_shuffle_ps(sum01, sum01, _MM_SHUFFLE(2, 3, 0, 1));
-        __m128 sum0123 = _mm_add_ps(sum01, sum23);
-        __m128 sum4567 = _mm_movehl_ps(sum0123, sum0123);
-        __m128 total_sum = _mm_add_ss(sum0123, sum4567);
-
-        result += _mm_cvtss_f32(total_sum);
-    }
-
-    // Process remaining elements with SSE implementation
-    result += sse::SQ4ComputeIP(query + d, codes + (d >> 1), lower_bound + d, diff + d, dim - d);
-    return result;
+    return simd::SQ4ComputeIPImpl<simd::SQ4Traits<simd::AVX2_SQ4_Tag>>(
+        query, codes, lower_bound, diff, dim, &sse::SQ4ComputeIP);
 #else
     return sse::SQ4ComputeIP(query, codes, lower_bound, diff, dim);
 #endif
@@ -910,45 +432,8 @@ SQ4ComputeL2Sqr(const float* RESTRICT query,
                 const float* RESTRICT diff,
                 uint64_t dim) {
 #if defined(ENABLE_AVX2)
-    if (dim == 0) {
-        return 0;
-    }
-
-    float result = 0;
-    uint64_t d = 0;
-
-    // Process 16 values at a time (8 bytes containing 16 4-bit values)
-    for (; d + 15 < dim; d += 16) {
-        __m256 values01, values23;
-        SQ4Decode16Values(codes, d, values01, values23, lower_bound, diff);
-        // Load query vectors
-        __m256 query_vec0 = _mm256_loadu_ps(query + d);
-        __m256 query_vec1 = _mm256_loadu_ps(query + d + 8);
-
-        // Compute differences
-        __m256 diff0 = _mm256_sub_ps(query_vec0, values01);
-        __m256 diff1 = _mm256_sub_ps(query_vec1, values23);
-
-        // Square differences
-        __m256 sq_diff0 = _mm256_mul_ps(diff0, diff0);
-        __m256 sq_diff1 = _mm256_mul_ps(diff1, diff1);
-
-        // Horizontal sum
-        __m256 sum = _mm256_add_ps(sq_diff0, sq_diff1);
-        __m128 sum_low = _mm256_castps256_ps128(sum);
-        __m128 sum_high = _mm256_extractf128_ps(sum, 1);
-        __m128 sum01 = _mm_add_ps(sum_low, sum_high);
-        __m128 sum23 = _mm_shuffle_ps(sum01, sum01, _MM_SHUFFLE(2, 3, 0, 1));
-        __m128 sum0123 = _mm_add_ps(sum01, sum23);
-        __m128 sum4567 = _mm_movehl_ps(sum0123, sum0123);
-        __m128 total_sum = _mm_add_ss(sum0123, sum4567);
-
-        result += _mm_cvtss_f32(total_sum);
-    }
-
-    // Process remaining elements with SSE implementation
-    result += sse::SQ4ComputeL2Sqr(query + d, codes + (d >> 1), lower_bound + d, diff + d, dim - d);
-    return result;
+    return simd::SQ4ComputeL2SqrImpl<simd::SQ4Traits<simd::AVX2_SQ4_Tag>>(
+        query, codes, lower_bound, diff, dim, &sse::SQ4ComputeL2Sqr);
 #else
     return sse::SQ4ComputeL2Sqr(query, codes, lower_bound, diff, dim);
 #endif
@@ -961,42 +446,8 @@ SQ4ComputeCodesIP(const uint8_t* RESTRICT codes1,
                   const float* RESTRICT diff,
                   uint64_t dim) {
 #if defined(ENABLE_AVX2)
-    if (dim == 0) {
-        return 0;
-    }
-
-    float result = 0;
-    uint64_t d = 0;
-
-    // Process 16 values at a time (8 bytes containing 16 4-bit values)
-    for (; d + 15 < dim; d += 16) {
-        __m256 code1_values01, code1_values23;
-        __m256 code2_values01, code2_values23;
-
-        SQ4Decode16Values(codes1, d, code1_values01, code1_values23, lower_bound, diff);
-        SQ4Decode16Values(codes2, d, code2_values01, code2_values23, lower_bound, diff);
-
-        // Compute dot products
-        __m256 prod0 = _mm256_mul_ps(code1_values01, code2_values01);
-        __m256 prod1 = _mm256_mul_ps(code1_values23, code2_values23);
-
-        // Horizontal sum
-        __m256 sum = _mm256_add_ps(prod0, prod1);
-        __m128 sum_low = _mm256_castps256_ps128(sum);
-        __m128 sum_high = _mm256_extractf128_ps(sum, 1);
-        __m128 sum01 = _mm_add_ps(sum_low, sum_high);
-        __m128 sum23 = _mm_shuffle_ps(sum01, sum01, _MM_SHUFFLE(2, 3, 0, 1));
-        __m128 sum0123 = _mm_add_ps(sum01, sum23);
-        __m128 sum4567 = _mm_movehl_ps(sum0123, sum0123);
-        __m128 total_sum = _mm_add_ss(sum0123, sum4567);
-
-        result += _mm_cvtss_f32(total_sum);
-    }
-
-    // Process remaining elements with SSE implementation
-    result += sse::SQ4ComputeCodesIP(
-        codes1 + (d >> 1), codes2 + (d >> 1), lower_bound + d, diff + d, dim - d);
-    return result;
+    return simd::SQ4ComputeCodesIPImpl<simd::SQ4Traits<simd::AVX2_SQ4_Tag>>(
+        codes1, codes2, lower_bound, diff, dim, &sse::SQ4ComputeCodesIP);
 #else
     return sse::SQ4ComputeCodesIP(codes1, codes2, lower_bound, diff, dim);
 #endif
@@ -1009,46 +460,8 @@ SQ4ComputeCodesL2Sqr(const uint8_t* RESTRICT codes1,
                      const float* RESTRICT diff,
                      uint64_t dim) {
 #if defined(ENABLE_AVX2)
-    if (dim == 0) {
-        return 0;
-    }
-
-    float result = 0;
-    uint64_t d = 0;
-
-    // Process 16 values at a time (8 bytes containing 16 4-bit values)
-    for (; d + 15 < dim; d += 16) {
-        __m256 code1_values01, code1_values23;
-        __m256 code2_values01, code2_values23;
-
-        SQ4Decode16Values(codes1, d, code1_values01, code1_values23, lower_bound, diff);
-        SQ4Decode16Values(codes2, d, code2_values01, code2_values23, lower_bound, diff);
-
-        // Compute differences
-        __m256 diff0 = _mm256_sub_ps(code1_values01, code2_values01);
-        __m256 diff1 = _mm256_sub_ps(code1_values23, code2_values23);
-
-        // Square differences
-        __m256 sq_diff0 = _mm256_mul_ps(diff0, diff0);
-        __m256 sq_diff1 = _mm256_mul_ps(diff1, diff1);
-
-        // Horizontal sum
-        __m256 sum = _mm256_add_ps(sq_diff0, sq_diff1);
-        __m128 sum_low = _mm256_castps256_ps128(sum);
-        __m128 sum_high = _mm256_extractf128_ps(sum, 1);
-        __m128 sum01 = _mm_add_ps(sum_low, sum_high);
-        __m128 sum23 = _mm_shuffle_ps(sum01, sum01, _MM_SHUFFLE(2, 3, 0, 1));
-        __m128 sum0123 = _mm_add_ps(sum01, sum23);
-        __m128 sum4567 = _mm_movehl_ps(sum0123, sum0123);
-        __m128 total_sum = _mm_add_ss(sum0123, sum4567);
-
-        result += _mm_cvtss_f32(total_sum);
-    }
-
-    // Process remaining elements with SSE implementation
-    result += sse::SQ4ComputeCodesL2Sqr(
-        codes1 + (d >> 1), codes2 + (d >> 1), lower_bound + d, diff + d, dim - d);
-    return result;
+    return simd::SQ4ComputeCodesL2SqrImpl<simd::SQ4Traits<simd::AVX2_SQ4_Tag>>(
+        codes1, codes2, lower_bound, diff, dim, &sse::SQ4ComputeCodesL2Sqr);
 #else
     return sse::SQ4ComputeCodesL2Sqr(codes1, codes2, lower_bound, diff, dim);
 #endif
@@ -1059,31 +472,8 @@ SQ4UniformComputeCodesIP(const uint8_t* RESTRICT codes1,
                          const uint8_t* RESTRICT codes2,
                          uint64_t dim) {
 #if defined(ENABLE_AVX2)
-    if (dim == 0) {
-        return 0;
-    }
-    alignas(256) int16_t temp[16];
-    int32_t result = 0;
-    uint64_t d = 0;
-    __m256i sum = _mm256_setzero_si256();
-    __m256i mask = _mm256_set1_epi8(0xf);
-    for (; d + 63 < dim; d += 64) {
-        auto xx = _mm256_loadu_si256((__m256i*)(codes1 + (d >> 1)));
-        auto yy = _mm256_loadu_si256((__m256i*)(codes2 + (d >> 1)));
-        auto xx1 = _mm256_and_si256(xx, mask);                        // 32 * 8bits
-        auto xx2 = _mm256_and_si256(_mm256_srli_epi16(xx, 4), mask);  // 32 * 8bits
-        auto yy1 = _mm256_and_si256(yy, mask);
-        auto yy2 = _mm256_and_si256(_mm256_srli_epi16(yy, 4), mask);
-
-        sum = _mm256_add_epi16(sum, _mm256_maddubs_epi16(xx1, yy1));
-        sum = _mm256_add_epi16(sum, _mm256_maddubs_epi16(xx2, yy2));
-    }
-    _mm256_store_si256((__m256i*)temp, sum);
-    for (int i = 0; i < 16; ++i) {
-        result += temp[i];
-    }
-    result += avx::SQ4UniformComputeCodesIP(codes1 + (d >> 1), codes2 + (d >> 1), dim - d);
-    return result;
+    return simd::SQ4UniformComputeCodesIPImpl<simd::UniformCodeTraits<simd::AVX2_Uniform_Tag>>(
+        codes1, codes2, dim, &avx::SQ4UniformComputeCodesIP);
 #else
     return avx::SQ4UniformComputeCodesIP(codes1, codes2, dim);
 #endif
@@ -1094,33 +484,8 @@ SQ8UniformComputeCodesIP(const uint8_t* RESTRICT codes1,
                          const uint8_t* RESTRICT codes2,
                          uint64_t dim) {
 #if defined(ENABLE_AVX2)
-    if (dim == 0) {
-        return 0.0F;
-    }
-
-    alignas(32) int32_t temp[8];
-    int32_t result = 0;
-    uint64_t d = 0;
-    __m256i sum = _mm256_setzero_si256();
-    __m256i mask = _mm256_set1_epi16(0xff);
-    for (; d + 31 < dim; d += 32) {
-        auto xx = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(codes1 + d));
-        auto yy = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(codes2 + d));
-
-        auto xx1 = _mm256_and_si256(xx, mask);
-        auto xx2 = _mm256_srli_epi16(xx, 8);
-        auto yy1 = _mm256_and_si256(yy, mask);
-        auto yy2 = _mm256_srli_epi16(yy, 8);
-
-        sum = _mm256_add_epi32(sum, _mm256_madd_epi16(xx1, yy1));
-        sum = _mm256_add_epi32(sum, _mm256_madd_epi16(xx2, yy2));
-    }
-    _mm256_store_si256(reinterpret_cast<__m256i*>(temp), sum);
-    for (int i : temp) {
-        result += i;
-    }
-    result += static_cast<int32_t>(avx::SQ8UniformComputeCodesIP(codes1 + d, codes2 + d, dim - d));
-    return static_cast<float>(result);
+    return simd::SQ8UniformComputeCodesIPImpl<simd::UniformCodeTraits<simd::AVX2_Uniform_Tag>>(
+        codes1, codes2, dim, &avx::SQ8UniformComputeCodesIP);
 #else
     return avx::SQ8UniformComputeCodesIP(codes1, codes2, dim);
 #endif
@@ -1141,49 +506,8 @@ SQ8UniformComputeCodesIPBatch(const uint8_t* RESTRICT query,
 float
 RaBitQFloatBinaryIP(const float* vector, const uint8_t* bits, uint64_t dim, float inv_sqrt_d) {
 #if defined(ENABLE_AVX2)
-    if (dim == 0) {
-        return 0.0F;
-    }
-
-    if (dim < 8) {
-        return sse::RaBitQFloatBinaryIP(vector, bits, dim, inv_sqrt_d);
-    }
-
-    uint64_t d = 0;
-    float result = 0.0F;
-    alignas(32) float temp[8];
-    __m256 sum = _mm256_setzero_ps();
-    __m256 pos, neg;
-    if (inv_sqrt_d > 1e-3) {
-        pos = _mm256_set1_ps(inv_sqrt_d);
-        neg = _mm256_set1_ps(-inv_sqrt_d);
-    } else {
-        pos = _mm256_set1_ps(1.0f);
-        neg = _mm256_setzero_ps();
-    }
-
-    for (; d + 8 <= dim; d += 8) {
-        __m256 vec = _mm256_loadu_ps(vector + d);
-
-        __m256i mask = _mm256_set1_epi32(static_cast<int>(bits[d / 8]));
-        mask = _mm256_and_si256(mask,
-                                _mm256_setr_epi32(0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80));
-        mask = _mm256_cmpeq_epi32(mask, _mm256_setzero_si256());
-        mask = _mm256_andnot_si256(mask, _mm256_set1_epi32(0xFFFFFFFF));
-
-        __m256 b_vec = _mm256_blendv_ps(neg, pos, _mm256_castsi256_ps(mask));
-
-        sum = _mm256_fmadd_ps(b_vec, vec, sum);
-    }
-
-    _mm256_storeu_ps(temp, sum);
-    for (float val : temp) {
-        result += val;
-    }
-
-    result += avx::RaBitQFloatBinaryIP(vector + d, bits + d / 8, dim - d, inv_sqrt_d);
-
-    return result;
+    return simd::RaBitQFloatBinaryIPImpl<simd::RaBitQTraits<simd::AVX2_RaBitQ_Tag>>(
+        vector, bits, dim, inv_sqrt_d, &avx::RaBitQFloatBinaryIP);
 #else
     return avx::RaBitQFloatBinaryIP(vector, bits, dim, inv_sqrt_d);
 #endif
@@ -1199,61 +523,16 @@ RaBitQFloatBinaryIPBatch4(const float* vector,
                           float inv_sqrt_d,
                           float* results) {
 #if defined(ENABLE_AVX2)
-    if (dim == 0) {
-        results[0] = 0.0F;
-        results[1] = 0.0F;
-        results[2] = 0.0F;
-        results[3] = 0.0F;
-        return;
-    }
-    if (dim < 8) {
-        generic::RaBitQFloatBinaryIPBatch4(
-            vector, bits1, bits2, bits3, bits4, dim, inv_sqrt_d, results);
-        return;
-    }
-
-    const __m256i bit_masks = _mm256_setr_epi32(0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80);
-    const __m256i all_ones = _mm256_set1_epi32(-1);
-    const __m256i zero_i = _mm256_setzero_si256();
-    const __m256 pos = inv_sqrt_d > 1e-3F ? _mm256_set1_ps(inv_sqrt_d) : _mm256_set1_ps(1.0F);
-    const __m256 neg = inv_sqrt_d > 1e-3F ? _mm256_set1_ps(-inv_sqrt_d) : _mm256_setzero_ps();
-    __m256 sums[4] = {
-        _mm256_setzero_ps(), _mm256_setzero_ps(), _mm256_setzero_ps(), _mm256_setzero_ps()};
-    const uint8_t* bits[4] = {bits1, bits2, bits3, bits4};
-
-    uint64_t d = 0;
-    for (; d + 8 <= dim; d += 8) {
-        const __m256 vec = _mm256_loadu_ps(vector + d);
-        for (uint32_t i = 0; i < 4; ++i) {
-            __m256i mask = _mm256_set1_epi32(static_cast<int>(bits[i][d >> 3]));
-            mask = _mm256_and_si256(mask, bit_masks);
-            mask = _mm256_cmpeq_epi32(mask, zero_i);
-            mask = _mm256_andnot_si256(mask, all_ones);
-            const __m256 binary = _mm256_blendv_ps(neg, pos, _mm256_castsi256_ps(mask));
-            sums[i] = _mm256_fmadd_ps(binary, vec, sums[i]);
-        }
-    }
-
-    alignas(32) float lanes[8];
-    for (uint32_t i = 0; i < 4; ++i) {
-        _mm256_store_ps(lanes, sums[i]);
-        results[i] =
-            lanes[0] + lanes[1] + lanes[2] + lanes[3] + lanes[4] + lanes[5] + lanes[6] + lanes[7];
-    }
-    if (d < dim) {
-        float tail[4];
-        generic::RaBitQFloatBinaryIPBatch4(vector + d,
-                                           bits1 + (d >> 3),
-                                           bits2 + (d >> 3),
-                                           bits3 + (d >> 3),
-                                           bits4 + (d >> 3),
-                                           dim - d,
-                                           inv_sqrt_d,
-                                           tail);
-        for (uint32_t i = 0; i < 4; ++i) {
-            results[i] += tail[i];
-        }
-    }
+    simd::RaBitQFloatBinaryIPBatch4Impl<simd::RaBitQTraits<simd::AVX2_RaBitQ_Tag>>(
+        vector,
+        bits1,
+        bits2,
+        bits3,
+        bits4,
+        dim,
+        inv_sqrt_d,
+        results,
+        &generic::RaBitQFloatBinaryIPBatch4);
 #else
     avx::RaBitQFloatBinaryIPBatch4(vector, bits1, bits2, bits3, bits4, dim, inv_sqrt_d, results);
 #endif
@@ -1266,66 +545,8 @@ RaBitQFloatSplitCodeIP(const float* vector,
                        uint64_t dim,
                        uint32_t supplement_bits) {
 #if defined(ENABLE_AVX2)
-    if (dim == 0) {
-        return 0.0F;
-    }
-
-    const uint64_t plane_bytes = (dim + 7) / 8;
-    const __m256 zero = _mm256_setzero_ps();
-    const __m256i bit_masks = _mm256_setr_epi32(0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80);
-    const __m256i all_ones = _mm256_set1_epi32(-1);
-    const __m256i zero_i = _mm256_setzero_si256();
-    __m256 sum = _mm256_setzero_ps();
-
-    uint64_t d = 0;
-    for (; d + 8 <= dim; d += 8) {
-        const uint64_t byte_idx = d >> 3;
-        __m256 code = _mm256_setzero_ps();
-
-        for (uint32_t bit = 0; bit < supplement_bits; ++bit) {
-            const auto* plane = supplement_code + static_cast<uint64_t>(bit) * plane_bytes;
-            __m256i mask = _mm256_set1_epi32(static_cast<int>(plane[byte_idx]));
-            mask = _mm256_and_si256(mask, bit_masks);
-            mask = _mm256_cmpeq_epi32(mask, zero_i);
-            mask = _mm256_andnot_si256(mask, all_ones);
-            const __m256 weight = _mm256_set1_ps(static_cast<float>(1U << bit));
-            code = _mm256_add_ps(code, _mm256_blendv_ps(zero, weight, _mm256_castsi256_ps(mask)));
-        }
-
-        __m256i one_bit_mask = _mm256_set1_epi32(static_cast<int>(one_bit_code[byte_idx]));
-        one_bit_mask = _mm256_and_si256(one_bit_mask, bit_masks);
-        one_bit_mask = _mm256_cmpeq_epi32(one_bit_mask, zero_i);
-        one_bit_mask = _mm256_andnot_si256(one_bit_mask, all_ones);
-        const __m256 one_bit_weight = _mm256_set1_ps(static_cast<float>(1U << supplement_bits));
-        code = _mm256_add_ps(
-            code, _mm256_blendv_ps(zero, one_bit_weight, _mm256_castsi256_ps(one_bit_mask)));
-
-        const __m256 vec = _mm256_loadu_ps(vector + d);
-        sum = _mm256_fmadd_ps(code, vec, sum);
-    }
-
-    alignas(32) float temp[8];
-    _mm256_storeu_ps(temp, sum);
-    float result = 0.0F;
-    for (float value : temp) {
-        result += value;
-    }
-
-    const uint32_t one_bit_scalar_weight = 1U << supplement_bits;
-    for (; d < dim; ++d) {
-        const uint64_t byte_idx = d >> 3;
-        const uint8_t bit_mask = static_cast<uint8_t>(1U << (d & 7));
-        uint32_t code = (one_bit_code[byte_idx] & bit_mask) != 0 ? one_bit_scalar_weight : 0U;
-        for (uint32_t bit = 0; bit < supplement_bits; ++bit) {
-            const auto* plane = supplement_code + static_cast<uint64_t>(bit) * plane_bytes;
-            if ((plane[byte_idx] & bit_mask) != 0) {
-                code += 1U << bit;
-            }
-        }
-        result += vector[d] * static_cast<float>(code);
-    }
-
-    return result;
+    return simd::RaBitQFloatSplitCodeIPImpl<simd::RaBitQTraits<simd::AVX2_RaBitQ_Tag>>(
+        vector, one_bit_code, supplement_code, dim, supplement_bits);
 #else
     return avx::RaBitQFloatSplitCodeIP(vector, one_bit_code, supplement_code, dim, supplement_bits);
 #endif
@@ -1334,22 +555,9 @@ RaBitQFloatSplitCodeIP(const float* vector,
 void
 DivScalar(const float* from, float* to, uint64_t dim, float scalar) {
 #if defined(ENABLE_AVX2)
-    if (dim == 0) {
-        return;
-    }
-    if (scalar == 0) {
-        scalar = 1.0F;  // TODO(LHT): logger?
-    }
-    int i = 0;
-    __m256 scalarVec = _mm256_set1_ps(scalar);
-    for (; i + 7 < dim; i += 8) {
-        __m256 vec = _mm256_loadu_ps(from + i);
-        vec = _mm256_div_ps(vec, scalarVec);
-        _mm256_storeu_ps(to + i, vec);
-    }
-    avx::DivScalar(from + i, to + i, dim - i, scalar);
+    simd::DivScalarImpl<simd::SimdTraits<simd::AVX2_Tag>>(from, to, dim, scalar, &avx::DivScalar);
 #else
-    avx::DivScalar(from, to, dim, scalar);
+    sse::DivScalar(from, to, dim, scalar);
 #endif
 }
 
@@ -1408,22 +616,7 @@ PQFastScanLookUp32(const uint8_t* RESTRICT lookup_table,
 void
 BitAnd(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* result) {
 #if defined(ENABLE_AVX2)
-    if (num_byte == 0) {
-        return;
-    }
-    if (num_byte < 32) {
-        return sse::BitAnd(x, y, num_byte, result);
-    }
-    int64_t i = 0;
-    for (; i + 31 < num_byte; i += 32) {
-        __m256i x_vec = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(x + i));
-        __m256i y_vec = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(y + i));
-        __m256i z_vec = _mm256_and_si256(x_vec, y_vec);
-        _mm256_storeu_si256(reinterpret_cast<__m256i*>(result + i), z_vec);
-    }
-    if (i < num_byte) {
-        sse::BitAnd(x + i, y + i, num_byte - i, result + i);
-    }
+    simd::BitAndImpl<simd::BitTraits<simd::AVX2_Bit_Tag>>(x, y, num_byte, result, &sse::BitAnd);
 #else
     return sse::BitAnd(x, y, num_byte, result);
 #endif
@@ -1432,22 +625,7 @@ BitAnd(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* res
 void
 BitOr(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* result) {
 #if defined(ENABLE_AVX2)
-    if (num_byte == 0) {
-        return;
-    }
-    if (num_byte < 32) {
-        return sse::BitOr(x, y, num_byte, result);
-    }
-    int64_t i = 0;
-    for (; i + 31 < num_byte; i += 32) {
-        __m256i x_vec = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(x + i));
-        __m256i y_vec = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(y + i));
-        __m256i z_vec = _mm256_or_si256(x_vec, y_vec);
-        _mm256_storeu_si256(reinterpret_cast<__m256i*>(result + i), z_vec);
-    }
-    if (i < num_byte) {
-        sse::BitOr(x + i, y + i, num_byte - i, result + i);
-    }
+    simd::BitOrImpl<simd::BitTraits<simd::AVX2_Bit_Tag>>(x, y, num_byte, result, &sse::BitOr);
 #else
     return sse::BitOr(x, y, num_byte, result);
 #endif
@@ -1456,22 +634,7 @@ BitOr(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* resu
 void
 BitXor(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* result) {
 #if defined(ENABLE_AVX2)
-    if (num_byte == 0) {
-        return;
-    }
-    if (num_byte < 32) {
-        return sse::BitXor(x, y, num_byte, result);
-    }
-    int64_t i = 0;
-    for (; i + 31 < num_byte; i += 32) {
-        __m256i x_vec = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(x + i));
-        __m256i y_vec = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(y + i));
-        __m256i z_vec = _mm256_xor_si256(x_vec, y_vec);
-        _mm256_storeu_si256(reinterpret_cast<__m256i*>(result + i), z_vec);
-    }
-    if (i < num_byte) {
-        sse::BitXor(x + i, y + i, num_byte - i, result + i);
-    }
+    simd::BitXorImpl<simd::BitTraits<simd::AVX2_Bit_Tag>>(x, y, num_byte, result, &sse::BitXor);
 #else
     return sse::BitXor(x, y, num_byte, result);
 #endif
@@ -1480,21 +643,7 @@ BitXor(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* res
 void
 BitNot(const uint8_t* x, const uint64_t num_byte, uint8_t* result) {
 #if defined(ENABLE_AVX2)
-    if (num_byte == 0) {
-        return;
-    }
-    if (num_byte < 32) {
-        return sse::BitNot(x, num_byte, result);
-    }
-    int64_t i = 0;
-    for (; i + 31 < num_byte; i += 32) {
-        __m256i x_vec = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(x + i));
-        __m256i z_vec = _mm256_xor_si256(x_vec, _mm256_set1_epi8(0xFF));
-        _mm256_storeu_si256(reinterpret_cast<__m256i*>(result + i), z_vec);
-    }
-    if (i < num_byte) {
-        sse::BitNot(x + i, num_byte - i, result + i);
-    }
+    simd::BitNotImpl<simd::BitTraits<simd::AVX2_Bit_Tag>>(x, num_byte, result, &sse::BitNot);
 #else
     return sse::BitNot(x, num_byte, result);
 #endif
@@ -1503,33 +652,18 @@ BitNot(const uint8_t* x, const uint64_t num_byte, uint8_t* result) {
 void
 VecRescale(float* data, uint64_t dim, float val) {
 #if defined(ENABLE_AVX2)
-    int i = 0;
-    __m256 val_vec = _mm256_set1_ps(val);
-    for (; i + 8 < dim; i += 8) {
-        __m256 data_vec = _mm256_loadu_ps(&data[i]);
-        __m256 result_vec = _mm256_mul_ps(data_vec, val_vec);
-        _mm256_storeu_ps(&data[i], result_vec);
-    }
-
-    sse::VecRescale(data + i, dim - i, val);
+    simd::VecRescaleImpl<simd::SimdTraits<simd::AVX2_Tag>>(data, dim, val, &sse::VecRescale);
 #else
-    return avx::VecRescale(data, dim, val);
+    sse::VecRescale(data, dim, val);
 #endif
 }
 
 void
 RotateOp(float* data, int idx, int dim_, int step) {
 #if defined(ENABLE_AVX2)
-    for (int i = idx; i < dim_; i += step * 2) {
-        for (int j = 0; j < step; j += 8) {
-            __m256 g1 = _mm256_loadu_ps(&data[i + j]);
-            __m256 g2 = _mm256_loadu_ps(&data[i + j + step]);
-            _mm256_storeu_ps(&data[i + j], _mm256_add_ps(g1, g2));
-            _mm256_storeu_ps(&data[i + j + step], _mm256_sub_ps(g1, g2));
-        }
-    }
+    simd::RotateOpImpl<simd::SimdTraits<simd::AVX2_Tag>>(data, idx, dim_, step);
 #else
-    return avx::RotateOp(data, idx, dim_, step);
+    avx::RotateOp(data, idx, dim_, step);
 #endif
 }
 
@@ -1556,73 +690,19 @@ FHTRotate(float* data, uint64_t dim_) {
 void
 KacsWalk(float* data, uint64_t len) {
 #if defined(ENABLE_AVX2)
-    uint64_t base = len % 2;
-    uint64_t offset = base + (len / 2);  // for odd dim
-    uint64_t i = 0;
-    for (; i + 8 < len / 2; i += 8) {
-        __m256 x = _mm256_loadu_ps(&data[i]);
-        __m256 y = _mm256_loadu_ps(&data[i + offset]);
-        _mm256_storeu_ps(&data[i], _mm256_add_ps(x, y));
-        _mm256_storeu_ps(&data[i + offset], _mm256_sub_ps(x, y));
-    }
-    for (; i < len / 2; i++) {
-        float add = data[i] + data[i + offset];
-        float sub = data[i] - data[i + offset];
-        data[i] = add;
-        data[i + offset] = sub;
-    }
-    if (base != 0) {
-        data[len / 2] *= std::sqrt(2.0F);
-        //In odd condition, we operate the prev len/2 items and the post len/2 items, the No.len/2 item stay still,
-        //As we need to resize the while sequence in the next step, so we increase the val of No.len/2 item to eliminate the impact of the following resize.
-    }
+    simd::KacsWalkImpl<simd::SimdTraits<simd::AVX2_Tag>>(data, len, &avx::KacsWalk);
 #else
-    return avx::KacsWalk(data, len);
+    avx::KacsWalk(data, len);
 #endif
 }
 
 float
 NormalizeWithCentroid(const float* from, const float* centroid, float* to, uint64_t dim) {
 #if defined(ENABLE_AVX2)
-    float norm_sq = 0;
-    uint64_t i = 0;
-    if (dim >= 8) {
-        __m256 sum = _mm256_setzero_ps();
-        for (; i + 7 < dim; i += 8) {
-            __m256 f = _mm256_loadu_ps(from + i);
-            __m256 c = _mm256_loadu_ps(centroid + i);
-            __m256 diff = _mm256_sub_ps(f, c);
-            sum = _mm256_fmadd_ps(diff, diff, sum);
-        }
-        norm_sq = avx2_reduce_add_ps(sum);
-        norm_sq += avx::FP32ComputeL2Sqr(from + i, centroid + i, dim - i);
-    } else {
-        norm_sq = avx::FP32ComputeL2Sqr(from, centroid, dim);
-    }
-
-    float norm = 0;
-    if (norm_sq < 1e-5f) {
-        norm = 1.0f;
-    } else {
-        norm = std::sqrt(norm_sq);
-    }
-
-    __m256 normVec = _mm256_set1_ps(norm);
-    for (i = 0; i + 7 < dim; i += 8) {
-        __m256 f = _mm256_loadu_ps(from + i);
-        __m256 c = _mm256_loadu_ps(centroid + i);
-        __m256 diff = _mm256_sub_ps(f, c);
-        __m256 result = _mm256_div_ps(diff, normVec);
-        _mm256_storeu_ps(to + i, result);
-    }
-    if (i < dim) {
-        for (; i < dim; ++i) {
-            to[i] = (from[i] - centroid[i]) / norm;
-        }
-    }
-    return norm;
+    return simd::NormalizeWithCentroidImpl<simd::SimdTraits<simd::AVX2_Tag>>(
+        from, centroid, to, dim, &avx::NormalizeWithCentroid);
 #else
-    return avx::NormalizeWithCentroid(from, centroid, to, dim);
+    return sse::NormalizeWithCentroid(from, centroid, to, dim);
 #endif
 }
 
@@ -1630,19 +710,10 @@ void
 InverseNormalizeWithCentroid(
     const float* from, const float* centroid, float* to, uint64_t dim, float norm) {
 #if defined(ENABLE_AVX2)
-    uint64_t i = 0;
-    __m256 normVec = _mm256_set1_ps(norm);
-    for (; i + 7 < dim; i += 8) {
-        __m256 f = _mm256_loadu_ps(from + i);
-        __m256 c = _mm256_loadu_ps(centroid + i);
-        __m256 result = _mm256_fmadd_ps(f, normVec, c);
-        _mm256_storeu_ps(to + i, result);
-    }
-    if (i < dim) {
-        avx::InverseNormalizeWithCentroid(from + i, centroid + i, to + i, dim - i, norm);
-    }
+    simd::InverseNormalizeWithCentroidImpl<simd::SimdTraits<simd::AVX2_Tag>>(
+        from, centroid, to, dim, norm, &avx::InverseNormalizeWithCentroid);
 #else
-    avx::InverseNormalizeWithCentroid(from, centroid, to, dim, norm);
+    sse::InverseNormalizeWithCentroid(from, centroid, to, dim, norm);
 #endif
 }
 

--- a/src/simd/avx512.cpp
+++ b/src/simd/avx512.cpp
@@ -15,6 +15,9 @@
 #include "simd/int8_simd.h"
 #if defined(ENABLE_AVX512)
 #include <immintrin.h>
+
+#include "simd/kernels/kernels.h"
+#include "simd/traits/simd_traits_avx512.h"
 #endif
 
 #include <cmath>
@@ -66,7 +69,12 @@ INT8InnerProductDistance(const void* pVect1v, const void* pVect2v, const void* q
 
 void
 PQDistanceFloat256(const void* single_dim_centers, float single_dim_val, void* result) {
+#if defined(ENABLE_AVX512)
+    simd::PQDistanceFloat256Impl<simd::SimdTraits<simd::AVX512_Tag>>(
+        single_dim_centers, single_dim_val, result, &avx2::PQDistanceFloat256);
+#else
     return avx2::PQDistanceFloat256(single_dim_centers, single_dim_val, result);
+#endif
 }
 
 void
@@ -77,47 +85,8 @@ Prefetch(const void* data) {
 float
 FP32ComputeIP(const float* RESTRICT query, const float* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_AVX512)
-    if (dim < 16) {
-        return avx2::FP32ComputeIP(query, codes, dim);
-    }
-    __m512 sum0 = _mm512_setzero_ps();
-    __m512 sum1 = _mm512_setzero_ps();
-    __m512 sum2 = _mm512_setzero_ps();
-    __m512 sum3 = _mm512_setzero_ps();
-
-    uint64_t i = 0;
-    for (; i + 63 < dim; i += 64) {
-        __m512 a0 = _mm512_loadu_ps(query + i);
-        __m512 b0 = _mm512_loadu_ps(codes + i);
-
-        __m512 a1 = _mm512_loadu_ps(query + i + 16);
-        __m512 b1 = _mm512_loadu_ps(codes + i + 16);
-
-        __m512 a2 = _mm512_loadu_ps(query + i + 32);
-        __m512 b2 = _mm512_loadu_ps(codes + i + 32);
-
-        __m512 a3 = _mm512_loadu_ps(query + i + 48);
-        __m512 b3 = _mm512_loadu_ps(codes + i + 48);
-
-        sum0 = _mm512_fmadd_ps(a0, b0, sum0);
-        sum1 = _mm512_fmadd_ps(a1, b1, sum1);
-        sum2 = _mm512_fmadd_ps(a2, b2, sum2);
-        sum3 = _mm512_fmadd_ps(a3, b3, sum3);
-    }
-    __m512 sum = _mm512_add_ps(sum0, sum1);
-    sum = _mm512_add_ps(sum, sum2);
-    sum = _mm512_add_ps(sum, sum3);
-
-    for (; i + 15 < dim; i += 16) {
-        __m512 a = _mm512_loadu_ps(query + i);  // load 16 floats from memory
-        __m512 b = _mm512_loadu_ps(codes + i);  // load 16 floats from memory
-        sum = _mm512_fmadd_ps(a, b, sum);
-    }
-    float ip = _mm512_reduce_add_ps(sum);
-    if (dim - i > 0) {
-        ip += avx2::FP32ComputeIP(query + i, codes + i, dim - i);
-    }
-    return ip;
+    return simd::ComputeIPImpl<simd::SimdTraits<simd::AVX512_Tag>, /*Unroll=*/4>(
+        query, codes, dim, &avx2::FP32ComputeIP);
 #else
     return avx2::FP32ComputeIP(query, codes, dim);
 #endif
@@ -126,56 +95,8 @@ FP32ComputeIP(const float* RESTRICT query, const float* RESTRICT codes, uint64_t
 float
 FP32ComputeL2Sqr(const float* RESTRICT query, const float* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_AVX512)
-    if (dim < 16) {
-        return avx2::FP32ComputeL2Sqr(query, codes, dim);
-    }
-
-    __m512 sum0 = _mm512_setzero_ps();
-    __m512 sum1 = _mm512_setzero_ps();
-    __m512 sum2 = _mm512_setzero_ps();
-    __m512 sum3 = _mm512_setzero_ps();
-
-    uint64_t i = 0;
-    for (; i + 63 < dim; i += 64) {
-        __m512 a0 = _mm512_loadu_ps(query + i);
-        __m512 b0 = _mm512_loadu_ps(codes + i);
-
-        __m512 a1 = _mm512_loadu_ps(query + i + 16);
-        __m512 b1 = _mm512_loadu_ps(codes + i + 16);
-
-        __m512 a2 = _mm512_loadu_ps(query + i + 32);
-        __m512 b2 = _mm512_loadu_ps(codes + i + 32);
-
-        __m512 a3 = _mm512_loadu_ps(query + i + 48);
-        __m512 b3 = _mm512_loadu_ps(codes + i + 48);
-
-        __m512 diff0 = _mm512_sub_ps(a0, b0);
-        __m512 diff1 = _mm512_sub_ps(a1, b1);
-        __m512 diff2 = _mm512_sub_ps(a2, b2);
-        __m512 diff3 = _mm512_sub_ps(a3, b3);
-
-        sum0 = _mm512_fmadd_ps(diff0, diff0, sum0);
-        sum1 = _mm512_fmadd_ps(diff1, diff1, sum1);
-        sum2 = _mm512_fmadd_ps(diff2, diff2, sum2);
-        sum3 = _mm512_fmadd_ps(diff3, diff3, sum3);
-    }
-
-    __m512 sum = _mm512_add_ps(sum0, sum1);
-    sum = _mm512_add_ps(sum, sum2);
-    sum = _mm512_add_ps(sum, sum3);
-
-    for (; i + 15 < dim; i += 16) {
-        __m512 a = _mm512_loadu_ps(query + i);
-        __m512 b = _mm512_loadu_ps(codes + i);
-        __m512 diff = _mm512_sub_ps(a, b);
-        sum = _mm512_fmadd_ps(diff, diff, sum);
-    }
-
-    float l2 = _mm512_reduce_add_ps(sum);
-    if (dim > i) {
-        l2 += avx2::FP32ComputeL2Sqr(query + i, codes + i, dim - i);
-    }
-    return l2;
+    return simd::ComputeL2SqrImpl<simd::SimdTraits<simd::AVX512_Tag>, /*Unroll=*/4>(
+        query, codes, dim, &avx2::FP32ComputeL2Sqr);
 #else
     return avx2::FP32ComputeL2Sqr(query, codes, dim);
 #endif
@@ -193,45 +114,18 @@ FP32ComputeIPBatch4(const float* RESTRICT query,
                     float& result3,
                     float& result4) {
 #if defined(ENABLE_AVX512)
-    if (dim < 16) {
-        return avx2::FP32ComputeIPBatch4(
-            query, dim, codes1, codes2, codes3, codes4, result1, result2, result3, result4);
-    }
-
-    __m512 sum1 = _mm512_setzero_ps();
-    __m512 sum2 = _mm512_setzero_ps();
-    __m512 sum3 = _mm512_setzero_ps();
-    __m512 sum4 = _mm512_setzero_ps();
-    uint64_t i = 0;
-    for (; i + 15 < dim; i += 16) {
-        __m512 q = _mm512_loadu_ps(query + i);
-        __m512 c1 = _mm512_loadu_ps(codes1 + i);
-        __m512 c2 = _mm512_loadu_ps(codes2 + i);
-        __m512 c3 = _mm512_loadu_ps(codes3 + i);
-        __m512 c4 = _mm512_loadu_ps(codes4 + i);
-
-        sum1 = _mm512_fmadd_ps(q, c1, sum1);
-        sum2 = _mm512_fmadd_ps(q, c2, sum2);
-        sum3 = _mm512_fmadd_ps(q, c3, sum3);
-        sum4 = _mm512_fmadd_ps(q, c4, sum4);
-    }
-    result1 += _mm512_reduce_add_ps(sum1);
-    result2 += _mm512_reduce_add_ps(sum2);
-    result3 += _mm512_reduce_add_ps(sum3);
-    result4 += _mm512_reduce_add_ps(sum4);
-    if (dim - i > 0) {
-        avx2::FP32ComputeIPBatch4(query + i,
-                                  dim - i,
-                                  codes1 + i,
-                                  codes2 + i,
-                                  codes3 + i,
-                                  codes4 + i,
-                                  result1,
-                                  result2,
-                                  result3,
-                                  result4);
-    }
-
+    simd::ComputeBatch4Impl<simd::SimdTraits<simd::AVX512_Tag>, simd::Batch4Kind::IP>(
+        query,
+        dim,
+        codes1,
+        codes2,
+        codes3,
+        codes4,
+        result1,
+        result2,
+        result3,
+        result4,
+        &avx2::FP32ComputeIPBatch4);
 #else
     return avx2::FP32ComputeIPBatch4(
         query, dim, codes1, codes2, codes3, codes4, result1, result2, result3, result4);
@@ -250,46 +144,18 @@ FP32ComputeL2SqrBatch4(const float* RESTRICT query,
                        float& result3,
                        float& result4) {
 #if defined(ENABLE_AVX512)
-    if (dim < 16) {
-        return avx2::FP32ComputeL2SqrBatch4(
-            query, dim, codes1, codes2, codes3, codes4, result1, result2, result3, result4);
-    }
-    __m512 sum1 = _mm512_setzero_ps();
-    __m512 sum2 = _mm512_setzero_ps();
-    __m512 sum3 = _mm512_setzero_ps();
-    __m512 sum4 = _mm512_setzero_ps();
-    uint64_t i = 0;
-    for (; i + 15 < dim; i += 16) {
-        __m512 q = _mm512_loadu_ps(query + i);
-        __m512 c1 = _mm512_loadu_ps(codes1 + i);
-        __m512 c2 = _mm512_loadu_ps(codes2 + i);
-        __m512 c3 = _mm512_loadu_ps(codes3 + i);
-        __m512 c4 = _mm512_loadu_ps(codes4 + i);
-        __m512 diff1 = _mm512_sub_ps(q, c1);
-        __m512 diff2 = _mm512_sub_ps(q, c2);
-        __m512 diff3 = _mm512_sub_ps(q, c3);
-        __m512 diff4 = _mm512_sub_ps(q, c4);
-        sum1 = _mm512_fmadd_ps(diff1, diff1, sum1);
-        sum2 = _mm512_fmadd_ps(diff2, diff2, sum2);
-        sum3 = _mm512_fmadd_ps(diff3, diff3, sum3);
-        sum4 = _mm512_fmadd_ps(diff4, diff4, sum4);
-    }
-    result1 += _mm512_reduce_add_ps(sum1);
-    result2 += _mm512_reduce_add_ps(sum2);
-    result3 += _mm512_reduce_add_ps(sum3);
-    result4 += _mm512_reduce_add_ps(sum4);
-    if (dim - i > 0) {
-        avx2::FP32ComputeL2SqrBatch4(query + i,
-                                     dim - i,
-                                     codes1 + i,
-                                     codes2 + i,
-                                     codes3 + i,
-                                     codes4 + i,
-                                     result1,
-                                     result2,
-                                     result3,
-                                     result4);
-    }
+    simd::ComputeBatch4Impl<simd::SimdTraits<simd::AVX512_Tag>, simd::Batch4Kind::L2>(
+        query,
+        dim,
+        codes1,
+        codes2,
+        codes3,
+        codes4,
+        result1,
+        result2,
+        result3,
+        result4,
+        &avx2::FP32ComputeL2SqrBatch4);
 #else
     return avx::FP32ComputeL2SqrBatch4(
         query, dim, codes1, codes2, codes3, codes4, result1, result2, result3, result4);
@@ -299,19 +165,8 @@ FP32ComputeL2SqrBatch4(const float* RESTRICT query,
 void
 FP32Sub(const float* x, const float* y, float* z, uint64_t dim) {
 #if defined(ENABLE_AVX512)
-    if (dim < 16) {
-        return avx2::FP32Sub(x, y, z, dim);
-    }
-    uint64_t i = 0;
-    for (; i + 15 < dim; i += 16) {
-        __m512 x_vec = _mm512_loadu_ps(x + i);
-        __m512 y_vec = _mm512_loadu_ps(y + i);
-        __m512 diff_vec = _mm512_sub_ps(x_vec, y_vec);
-        _mm512_storeu_ps(z + i, diff_vec);
-    }
-    if (dim > i) {
-        avx2::FP32Sub(x + i, y + i, z + i, dim - i);
-    }
+    simd::BinaryOpImpl<simd::SimdTraits<simd::AVX512_Tag>, simd::BinaryOp::Sub>(
+        x, y, z, dim, &avx2::FP32Sub);
 #else
     return avx2::FP32Sub(x, y, z, dim);
 #endif
@@ -320,19 +175,8 @@ FP32Sub(const float* x, const float* y, float* z, uint64_t dim) {
 void
 FP32Add(const float* x, const float* y, float* z, uint64_t dim) {
 #if defined(ENABLE_AVX512)
-    if (dim < 16) {
-        return avx2::FP32Add(x, y, z, dim);
-    }
-    uint64_t i = 0;
-    for (; i + 15 < dim; i += 16) {
-        __m512 x_vec = _mm512_loadu_ps(x + i);
-        __m512 y_vec = _mm512_loadu_ps(y + i);
-        __m512 sum_vec = _mm512_add_ps(x_vec, y_vec);
-        _mm512_storeu_ps(z + i, sum_vec);
-    }
-    if (dim > i) {
-        avx2::FP32Add(x + i, y + i, z + i, dim - i);
-    }
+    simd::BinaryOpImpl<simd::SimdTraits<simd::AVX512_Tag>, simd::BinaryOp::Add>(
+        x, y, z, dim, &avx2::FP32Add);
 #else
     return avx2::FP32Add(x, y, z, dim);
 #endif
@@ -341,19 +185,8 @@ FP32Add(const float* x, const float* y, float* z, uint64_t dim) {
 void
 FP32Mul(const float* x, const float* y, float* z, uint64_t dim) {
 #if defined(ENABLE_AVX512)
-    if (dim < 16) {
-        return avx2::FP32Mul(x, y, z, dim);
-    }
-    uint64_t i = 0;
-    for (; i + 15 < dim; i += 16) {
-        __m512 x_vec = _mm512_loadu_ps(x + i);
-        __m512 y_vec = _mm512_loadu_ps(y + i);
-        __m512 mul_vec = _mm512_mul_ps(x_vec, y_vec);
-        _mm512_storeu_ps(z + i, mul_vec);
-    }
-    if (dim > i) {
-        avx2::FP32Mul(x + i, y + i, z + i, dim - i);
-    }
+    simd::BinaryOpImpl<simd::SimdTraits<simd::AVX512_Tag>, simd::BinaryOp::Mul>(
+        x, y, z, dim, &avx2::FP32Mul);
 #else
     return avx2::FP32Mul(x, y, z, dim);
 #endif
@@ -362,19 +195,8 @@ FP32Mul(const float* x, const float* y, float* z, uint64_t dim) {
 void
 FP32Div(const float* x, const float* y, float* z, uint64_t dim) {
 #if defined(ENABLE_AVX512)
-    if (dim < 16) {
-        return avx2::FP32Div(x, y, z, dim);
-    }
-    uint64_t i = 0;
-    for (; i + 15 < dim; i += 16) {
-        __m512 x_vec = _mm512_loadu_ps(x + i);
-        __m512 y_vec = _mm512_loadu_ps(y + i);
-        __m512 div_vec = _mm512_div_ps(x_vec, y_vec);
-        _mm512_storeu_ps(z + i, div_vec);
-    }
-    if (dim > i) {
-        avx2::FP32Div(x + i, y + i, z + i, dim - i);
-    }
+    simd::BinaryOpImpl<simd::SimdTraits<simd::AVX512_Tag>, simd::BinaryOp::Div>(
+        x, y, z, dim, &avx2::FP32Div);
 #else
     return avx2::FP32Div(x, y, z, dim);
 #endif
@@ -383,20 +205,7 @@ FP32Div(const float* x, const float* y, float* z, uint64_t dim) {
 float
 FP32ReduceAdd(const float* x, uint64_t dim) {
 #if defined(ENABLE_AVX512)
-    if (dim < 16) {
-        return avx2::FP32ReduceAdd(x, dim);
-    }
-    __m512 sum = _mm512_setzero_ps();
-    uint64_t i = 0;
-    for (; i + 15 < dim; i += 16) {
-        __m512 a = _mm512_loadu_ps(x + i);
-        sum = _mm512_add_ps(sum, a);
-    }
-    float result = _mm512_reduce_add_ps(sum);
-    if (i < dim) {
-        result += avx2::FP32ReduceAdd(x + i, dim - i);
-    }
-    return result;
+    return simd::ReduceAddImpl<simd::SimdTraits<simd::AVX512_Tag>>(x, dim, &avx2::FP32ReduceAdd);
 #else
     return sse::FP32ReduceAdd(x, dim);
 #endif
@@ -413,26 +222,8 @@ __inline __m512i __attribute__((__always_inline__)) load_16_short(const uint16_t
 float
 INT8ComputeIP(const int8_t* __restrict query, const int8_t* __restrict codes, uint64_t dim) {
 #if defined(ENABLE_AVX512)
-    __mmask32 mask = 0xFFFFFFFF;
-
-    auto qty = dim;
-    const uint32_t n = (qty >> 5);
-    if (n == 0) {
-        return avx2::INT8ComputeIP(query, codes, dim);
-    }
-
-    __m512i sum512 = _mm512_set1_epi32(0);
-    for (uint32_t i = 0; i < n; ++i) {
-        __m256i v1 = _mm256_maskz_loadu_epi8(mask, query + (i << 5));
-        __m512i v1_512 = _mm512_cvtepi8_epi16(v1);
-        __m256i v2 = _mm256_maskz_loadu_epi8(mask, codes + (i << 5));
-        __m512i v2_512 = _mm512_cvtepi8_epi16(v2);
-        sum512 = _mm512_add_epi32(sum512, _mm512_madd_epi16(v1_512, v2_512));
-    }
-    auto res = static_cast<float>(_mm512_reduce_add_epi32(sum512));
-    uint64_t new_dim = qty & (0x1F);
-    res += avx2::INT8ComputeIP(query + (n << 5), codes + (n << 5), new_dim);
-    return res;
+    return simd::Int8ComputeIPImpl<simd::Int8Traits<simd::AVX512_Int8_Tag>>(
+        query, codes, dim, &avx2::INT8ComputeIP);
 #else
     return avx2::INT8ComputeIP(query, codes, dim);
 #endif
@@ -441,35 +232,8 @@ INT8ComputeIP(const int8_t* __restrict query, const int8_t* __restrict codes, ui
 float
 INT8ComputeL2Sqr(const int8_t* RESTRICT query, const int8_t* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_AVX512)
-    constexpr int64_t BATCH_SIZE{32};
-
-    const uint64_t n = dim / BATCH_SIZE;
-
-    if (n == 0) {
-        return avx2::INT8ComputeL2Sqr(query, codes, dim);
-    }
-
-    __m512i sum_sq = _mm512_setzero_si512();
-
-    for (uint64_t i = 0; i < n; ++i) {
-        __m256i q = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(query + BATCH_SIZE * i));
-        __m256i c = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(codes + BATCH_SIZE * i));
-
-        __m512i q_int16 = _mm512_cvtepi8_epi16(q);
-        __m512i c_int16 = _mm512_cvtepi8_epi16(c);
-
-        __m512i diff = _mm512_sub_epi16(q_int16, c_int16);
-
-        __m512i sq = _mm512_madd_epi16(diff, diff);
-
-        sum_sq = _mm512_add_epi32(sq, sum_sq);
-    }
-
-    int32_t l2 = _mm512_reduce_add_epi32(sum_sq);
-
-    l2 += avx2::INT8ComputeL2Sqr(
-        query + BATCH_SIZE * n, codes + BATCH_SIZE * n, dim - BATCH_SIZE * n);
-    return static_cast<float>(l2);
+    return simd::Int8ComputeL2SqrImpl<simd::Int8Traits<simd::AVX512_Int8_Tag>>(
+        query, codes, dim, &avx2::INT8ComputeL2Sqr);
 #else
     return avx2::INT8ComputeL2Sqr(query, codes, dim);
 #endif
@@ -478,29 +242,8 @@ INT8ComputeL2Sqr(const int8_t* RESTRICT query, const int8_t* RESTRICT codes, uin
 float
 BF16ComputeIP(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_AVX512)
-    // Initialize the sum to 0
-    __m512 sum = _mm512_setzero_ps();
-    const auto* query_bf16 = (const uint16_t*)(query);
-    const auto* codes_bf16 = (const uint16_t*)(codes);
-
-    // Process the data in 128-bit chunks
-    uint64_t i = 0;
-    for (; i + 15 < dim; i += 16) {
-        // Load data into registers
-        __m512i query_shift = load_16_short(query_bf16 + i);
-        __m512 query_float = _mm512_castsi512_ps(query_shift);
-
-        // Load data into registers
-        __m512i code_shift = load_16_short(codes_bf16 + i);
-        __m512 code_float = _mm512_castsi512_ps(code_shift);
-
-        sum = _mm512_fmadd_ps(code_float, query_float, sum);
-    }
-    float ip = _mm512_reduce_add_ps(sum);
-    if (dim > i) {
-        ip += avx2::BF16ComputeIP(query + i * 2, codes + i * 2, dim - i);
-    }
-    return ip;
+    return simd::HalfComputeIPImpl<simd::BF16Traits<simd::AVX512_BF16_Tag>>(
+        query, codes, dim, &avx2::BF16ComputeIP);
 #else
     return avx2::BF16ComputeIP(query, codes, dim);
 #endif
@@ -509,30 +252,8 @@ BF16ComputeIP(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint
 float
 BF16ComputeL2Sqr(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_AVX512)
-    // Initialize the sum to 0
-    __m512 sum = _mm512_setzero_ps();
-    const auto* query_bf16 = (const uint16_t*)(query);
-    const auto* codes_bf16 = (const uint16_t*)(codes);
-
-    // Process the data in 128-bit chunks
-    uint64_t i = 0;
-    for (; i + 15 < dim; i += 16) {
-        // Load data into registers
-        __m512i query_shift = load_16_short(query_bf16 + i);
-        __m512 query_float = _mm512_castsi512_ps(query_shift);
-
-        // Load data into registers
-        __m512i code_shift = load_16_short(codes_bf16 + i);
-        __m512 code_float = _mm512_castsi512_ps(code_shift);
-
-        __m512 diff = _mm512_sub_ps(code_float, query_float);
-        sum = _mm512_fmadd_ps(diff, diff, sum);
-    }
-    float l2 = _mm512_reduce_add_ps(sum);
-    if (dim > i) {
-        l2 += avx2::BF16ComputeL2Sqr(query + i * 2, codes + i * 2, dim - i);
-    }
-    return l2;
+    return simd::HalfComputeL2SqrImpl<simd::BF16Traits<simd::AVX512_BF16_Tag>>(
+        query, codes, dim, &avx2::BF16ComputeL2Sqr);
 #else
     return avx2::BF16ComputeL2Sqr(query, codes, dim);
 #endif
@@ -541,29 +262,8 @@ BF16ComputeL2Sqr(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, u
 float
 FP16ComputeIP(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_AVX512)
-    // Initialize the sum to 0
-    __m512 sum = _mm512_setzero_ps();
-    const auto* query_fp16 = (const uint16_t*)(query);
-    const auto* codes_fp16 = (const uint16_t*)(codes);
-
-    // Process the data in 128-bit chunks
-    uint64_t i = 0;
-    for (; i + 15 < dim; i += 16) {
-        // Load data into registers
-        __m256i query_load = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(query_fp16 + i));
-        __m512 query_float = _mm512_cvtph_ps(query_load);
-
-        // Load data into registers
-        __m256i code_load = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(codes_fp16 + i));
-        __m512 code_float = _mm512_cvtph_ps(code_load);
-
-        sum = _mm512_fmadd_ps(code_float, query_float, sum);
-    }
-    float ip = _mm512_reduce_add_ps(sum);
-    if (dim > i) {
-        ip += avx2::FP16ComputeIP(query + i * 2, codes + i * 2, dim - i);
-    }
-    return ip;
+    return simd::HalfComputeIPImpl<simd::FP16Traits<simd::AVX512_FP16_Tag>>(
+        query, codes, dim, &avx2::FP16ComputeIP);
 #else
     return avx2::FP16ComputeIP(query, codes, dim);
 #endif
@@ -572,30 +272,8 @@ FP16ComputeIP(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint
 float
 FP16ComputeL2Sqr(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_AVX512)
-    // Initialize the sum to 0
-    __m512 sum = _mm512_setzero_ps();
-    const auto* query_fp16 = (const uint16_t*)(query);
-    const auto* codes_fp16 = (const uint16_t*)(codes);
-
-    // Process the data in 128-bit chunks
-    uint64_t i = 0;
-    for (; i + 15 < dim; i += 16) {
-        // Load data into registers
-        __m256i query_load = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(query_fp16 + i));
-        __m512 query_float = _mm512_cvtph_ps(query_load);
-
-        // Load data into registers
-        __m256i code_load = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(codes_fp16 + i));
-        __m512 code_float = _mm512_cvtph_ps(code_load);
-
-        __m512 diff = _mm512_sub_ps(code_float, query_float);
-        sum = _mm512_fmadd_ps(diff, diff, sum);
-    }
-    float l2 = _mm512_reduce_add_ps(sum);
-    if (dim > i) {
-        l2 += avx2::FP16ComputeL2Sqr(query + i * 2, codes + i * 2, dim - i);
-    }
-    return l2;
+    return simd::HalfComputeL2SqrImpl<simd::FP16Traits<simd::AVX512_FP16_Tag>>(
+        query, codes, dim, &avx2::FP16ComputeL2Sqr);
 #else
     return avx2::FP16ComputeL2Sqr(query, codes, dim);
 #endif
@@ -608,29 +286,8 @@ SQ8ComputeIP(const float* RESTRICT query,
              const float* RESTRICT diff,
              uint64_t dim) {
 #if defined(ENABLE_AVX512)
-    // Initialize the sum to 0
-    __m512 sum = _mm512_setzero_ps();
-    uint64_t i = 0;
-
-    for (; i + 15 < dim; i += 16) {
-        __m128i code_values = _mm_loadu_si128(reinterpret_cast<const __m128i*>(codes + i));
-        __m512i codes_512 = _mm512_cvtepu8_epi32(code_values);
-        __m512 query_values = _mm512_loadu_ps(query + i);
-        __m512 diff_values = _mm512_loadu_ps(diff + i);
-        __m512 lower_bound_values = _mm512_loadu_ps(lower_bound + i);
-
-        __m512 normalized =
-            _mm512_mul_ps(_mm512_cvtepi32_ps(codes_512), _mm512_set1_ps(1.0F / 255.0F));
-        __m512 adjusted = _mm512_fmadd_ps(normalized, diff_values, lower_bound_values);
-        sum = _mm512_fmadd_ps(query_values, adjusted, sum);
-    }
-
-    float ip = _mm512_reduce_add_ps(sum);
-
-    if (dim > i) {
-        ip += avx2::SQ8ComputeIP(query + i, codes + i, lower_bound + i, diff + i, dim - i);
-    }
-    return ip;
+    return simd::SQ8ComputeIPImpl<simd::SQ8Traits<simd::AVX512_SQ8_Tag>>(
+        query, codes, lower_bound, diff, dim, &avx2::SQ8ComputeIP);
 #else
     return avx2::SQ8ComputeIP(query, codes, lower_bound, diff, dim);
 #endif
@@ -643,28 +300,8 @@ SQ8ComputeL2Sqr(const float* RESTRICT query,
                 const float* RESTRICT diff,
                 uint64_t dim) {
 #if defined(ENABLE_AVX512)
-    __m512 sum = _mm512_setzero_ps();
-    uint64_t i = 0;
-
-    for (; i + 15 < dim; i += 16) {
-        __m128i code_values = _mm_loadu_si128(reinterpret_cast<const __m128i*>(codes + i));
-        __m512i codes_512 = _mm512_cvtepu8_epi32(code_values);
-        __m512 query_values = _mm512_loadu_ps(query + i);
-        __m512 diff_values = _mm512_loadu_ps(diff + i);
-        __m512 lower_bound_values = _mm512_loadu_ps(lower_bound + i);
-
-        __m512 normalized =
-            _mm512_mul_ps(_mm512_cvtepi32_ps(codes_512), _mm512_set1_ps(1.0f / 255.0f));
-        __m512 adjusted = _mm512_fmadd_ps(normalized, diff_values, lower_bound_values);
-        __m512 dist = _mm512_sub_ps(query_values, adjusted);
-        sum = _mm512_fmadd_ps(dist, dist, sum);
-    }
-
-    float l2 = _mm512_reduce_add_ps(sum);
-    if (dim > i) {
-        l2 += avx2::SQ8ComputeL2Sqr(query + i, codes + i, lower_bound + i, diff + i, dim - i);
-    }
-    return l2;
+    return simd::SQ8ComputeL2SqrImpl<simd::SQ8Traits<simd::AVX512_SQ8_Tag>>(
+        query, codes, lower_bound, diff, dim, &avx2::SQ8ComputeL2Sqr);
 #else
     return avx2::SQ8ComputeL2Sqr(query, codes, lower_bound, diff, dim);
 #endif
@@ -677,31 +314,8 @@ SQ8ComputeCodesIP(const uint8_t* RESTRICT codes1,
                   const float* RESTRICT diff,
                   uint64_t dim) {
 #if defined(ENABLE_AVX512)
-    __m512 sum = _mm512_setzero_ps();
-    uint64_t i = 0;
-
-    for (; i + 15 < dim; i += 16) {
-        __m128i code1_values = _mm_loadu_si128(reinterpret_cast<const __m128i*>(codes1 + i));
-        __m128i code2_values = _mm_loadu_si128(reinterpret_cast<const __m128i*>(codes2 + i));
-        __m512 diff_values = _mm512_loadu_ps(diff + i);
-        __m512 lower_bound_values = _mm512_loadu_ps(lower_bound + i);
-
-        __m512 code1_floats = _mm512_mul_ps(_mm512_cvtepi32_ps(_mm512_cvtepu8_epi32(code1_values)),
-                                            _mm512_set1_ps(1.0f / 255.0f));
-        __m512 code2_floats = _mm512_mul_ps(_mm512_cvtepi32_ps(_mm512_cvtepu8_epi32(code2_values)),
-                                            _mm512_set1_ps(1.0f / 255.0f));
-
-        __m512 scaled_codes1 = _mm512_fmadd_ps(code1_floats, diff_values, lower_bound_values);
-        __m512 scaled_codes2 = _mm512_fmadd_ps(code2_floats, diff_values, lower_bound_values);
-        sum = _mm512_fmadd_ps(scaled_codes1, scaled_codes2, sum);
-    }
-    float result = _mm512_reduce_add_ps(sum);
-
-    if (dim > i) {
-        result +=
-            avx2::SQ8ComputeCodesIP(codes1 + i, codes2 + i, lower_bound + i, diff + i, dim - i);
-    }
-    return result;
+    return simd::SQ8ComputeCodesIPImpl<simd::SQ8Traits<simd::AVX512_SQ8_Tag>>(
+        codes1, codes2, lower_bound, diff, dim, &avx2::SQ8ComputeCodesIP);
 #else
     return avx2::SQ8ComputeCodesIP(codes1, codes2, lower_bound, diff, dim);
 #endif
@@ -714,29 +328,8 @@ SQ8ComputeCodesL2Sqr(const uint8_t* RESTRICT codes1,
                      const float* RESTRICT diff,
                      uint64_t dim) {
 #if defined(ENABLE_AVX512)
-    __m512 sum = _mm512_setzero_ps();
-    uint64_t i = 0;
-
-    for (; i + 15 < dim; i += 16) {
-        __m128i code1_values = _mm_loadu_si128(reinterpret_cast<const __m128i*>(codes1 + i));
-        __m128i code2_values = _mm_loadu_si128(reinterpret_cast<const __m128i*>(codes2 + i));
-        __m512 diff_values = _mm512_loadu_ps(diff + i);
-
-        __m512i codes1_512 = _mm512_cvtepu8_epi32(code1_values);
-        __m512i codes2_512 = _mm512_cvtepu8_epi32(code2_values);
-        __m512 sub = _mm512_cvtepi32_ps(_mm512_sub_epi32(codes1_512, codes2_512));
-        __m512 scaled = _mm512_mul_ps(sub, _mm512_set1_ps(1.0 / 255.0f));
-        __m512 val = _mm512_mul_ps(scaled, diff_values);
-        sum = _mm512_fmadd_ps(val, val, sum);
-    }
-
-    float result = _mm512_reduce_add_ps(sum);
-
-    if (dim > i) {
-        result +=
-            avx2::SQ8ComputeCodesL2Sqr(codes1 + i, codes2 + i, lower_bound + i, diff + i, dim - i);
-    }
-    return result;
+    return simd::SQ8ComputeCodesL2SqrImpl<simd::SQ8Traits<simd::AVX512_SQ8_Tag>>(
+        codes1, codes2, lower_bound, diff, dim, &avx2::SQ8ComputeCodesL2Sqr);
 #else
     return avx2::SQ8ComputeCodesL2Sqr(codes1, codes2, lower_bound, diff, dim);
 #endif
@@ -776,39 +369,8 @@ SQ4ComputeIP(const float* RESTRICT query,
              const float* RESTRICT diff,
              uint64_t dim) {
 #if defined(ENABLE_AVX512)
-    if (dim == 0) {
-        return 0;
-    }
-
-    float result = 0;
-    uint64_t d = 0;
-    __m512 sum0 = _mm512_setzero_ps();
-    __m512 sum1 = _mm512_setzero_ps();
-
-    // Process 32 elements at a time (16 bytes of codes)
-    for (; d + 31 < dim; d += 32) {
-        __m512 decoded0, decoded1;
-        unpack_4bit_to_m512(codes + (d >> 1), &decoded0, &decoded1);
-
-        // Apply affine transform: value = lower_bound + decoded * diff
-        __m512 lb0 = _mm512_loadu_ps(lower_bound + d);
-        __m512 lb1 = _mm512_loadu_ps(lower_bound + d + 16);
-        __m512 diff0 = _mm512_loadu_ps(diff + d);
-        __m512 diff1 = _mm512_loadu_ps(diff + d + 16);
-
-        __m512 val0 = _mm512_fmadd_ps(decoded0, diff0, lb0);
-        __m512 val1 = _mm512_fmadd_ps(decoded1, diff1, lb1);
-
-        // Load query
-        __m512 q0 = _mm512_loadu_ps(query + d);
-        __m512 q1 = _mm512_loadu_ps(query + d + 16);
-
-        sum0 = _mm512_fmadd_ps(q0, val0, sum0);
-        sum1 = _mm512_fmadd_ps(q1, val1, sum1);
-    }
-    result += _mm512_reduce_add_ps(_mm512_add_ps(sum0, sum1));
-    result += avx2::SQ4ComputeIP(query + d, codes + (d >> 1), lower_bound + d, diff + d, dim - d);
-    return result;
+    return simd::SQ4ComputeIPImpl<simd::SQ4Traits<simd::AVX512_SQ4_Tag>>(
+        query, codes, lower_bound, diff, dim, &avx2::SQ4ComputeIP);
 #else
     return avx2::SQ4ComputeIP(query, codes, lower_bound, diff, dim);
 #endif
@@ -821,42 +383,8 @@ SQ4ComputeL2Sqr(const float* RESTRICT query,
                 const float* RESTRICT diff,
                 uint64_t dim) {
 #if defined(ENABLE_AVX512)
-    if (dim == 0) {
-        return 0;
-    }
-
-    float result = 0;
-    uint64_t d = 0;
-    __m512 sum0 = _mm512_setzero_ps();
-    __m512 sum1 = _mm512_setzero_ps();
-    // Process 32 elements at a time (16 bytes of codes)
-    for (; d + 31 < dim; d += 32) {
-        __m512 decoded0, decoded1;
-        unpack_4bit_to_m512(codes + (d >> 1), &decoded0, &decoded1);
-
-        // Apply affine transform: value = lower_bound + decoded * diff
-        __m512 lb0 = _mm512_loadu_ps(lower_bound + d);
-        __m512 lb1 = _mm512_loadu_ps(lower_bound + d + 16);
-        __m512 diff0 = _mm512_loadu_ps(diff + d);
-        __m512 diff1 = _mm512_loadu_ps(diff + d + 16);
-
-        __m512 val0 = _mm512_fmadd_ps(decoded0, diff0, lb0);
-        __m512 val1 = _mm512_fmadd_ps(decoded1, diff1, lb1);
-
-        // Load query
-        __m512 q0 = _mm512_loadu_ps(query + d);
-        __m512 q1 = _mm512_loadu_ps(query + d + 16);
-
-        __m512 q0_sub = _mm512_sub_ps(q0, val0);
-        __m512 q1_sub = _mm512_sub_ps(q1, val1);
-
-        sum0 = _mm512_fmadd_ps(q0_sub, q0_sub, sum0);
-        sum1 = _mm512_fmadd_ps(q1_sub, q1_sub, sum1);
-    }
-    result += _mm512_reduce_add_ps(sum0) + _mm512_reduce_add_ps(sum1);
-    result +=
-        avx2::SQ4ComputeL2Sqr(query + d, codes + (d >> 1), lower_bound + d, diff + d, dim - d);
-    return result;
+    return simd::SQ4ComputeL2SqrImpl<simd::SQ4Traits<simd::AVX512_SQ4_Tag>>(
+        query, codes, lower_bound, diff, dim, &avx2::SQ4ComputeL2Sqr);
 #else
     return avx2::SQ4ComputeL2Sqr(query, codes, lower_bound, diff, dim);
 #endif
@@ -869,39 +397,8 @@ SQ4ComputeCodesIP(const uint8_t* RESTRICT codes1,
                   const float* RESTRICT diff,
                   uint64_t dim) {
 #if defined(ENABLE_AVX512)
-    if (dim == 0) {
-        return 0;
-    }
-    float result = 0;
-    uint64_t d = 0;
-    __m512 sum0 = _mm512_setzero_ps();
-    __m512 sum1 = _mm512_setzero_ps();
-
-    // Process 32 elements at a time (16 bytes of codes)
-    for (; d + 31 < dim; d += 32) {
-        __m512 decoded0, decoded1, decoded2, decoded3;
-        unpack_4bit_to_m512(codes1 + (d >> 1), &decoded0, &decoded1);
-        unpack_4bit_to_m512(codes2 + (d >> 1), &decoded2, &decoded3);
-
-        // Apply affine transform: value = lower_bound + decoded * diff
-        __m512 lb0 = _mm512_loadu_ps(lower_bound + d);
-        __m512 lb1 = _mm512_loadu_ps(lower_bound + d + 16);
-        __m512 diff0 = _mm512_loadu_ps(diff + d);
-        __m512 diff1 = _mm512_loadu_ps(diff + d + 16);
-        __m512 val0 = _mm512_fmadd_ps(decoded0, diff0, lb0);
-        __m512 val1 = _mm512_fmadd_ps(decoded1, diff1, lb1);
-
-        __m512 val2 = _mm512_fmadd_ps(decoded2, diff0, lb0);
-        __m512 val3 = _mm512_fmadd_ps(decoded3, diff1, lb1);
-
-        sum0 = _mm512_fmadd_ps(val2, val0, sum0);
-        sum1 = _mm512_fmadd_ps(val3, val1, sum1);
-    }
-    result += _mm512_reduce_add_ps(_mm512_add_ps(sum0, sum1));
-    result += avx2::SQ4ComputeCodesIP(
-        codes1 + (d >> 1), codes2 + (d >> 1), lower_bound + d, diff + d, dim - d);
-    return result;
-
+    return simd::SQ4ComputeCodesIPImpl<simd::SQ4Traits<simd::AVX512_SQ4_Tag>>(
+        codes1, codes2, lower_bound, diff, dim, &avx2::SQ4ComputeCodesIP);
 #else
     return avx2::SQ4ComputeCodesIP(codes1, codes2, lower_bound, diff, dim);
 #endif
@@ -914,44 +411,8 @@ SQ4ComputeCodesL2Sqr(const uint8_t* RESTRICT codes1,
                      const float* RESTRICT diff,
                      uint64_t dim) {
 #if defined(ENABLE_AVX512)
-    if (dim == 0) {
-        return 0;
-    }
-    float result = 0;
-    uint64_t d = 0;
-
-    __m512 sum0 = _mm512_setzero_ps();
-    __m512 sum1 = _mm512_setzero_ps();
-
-    // Process 32 elements at a time (16 bytes of codes)
-    for (; d + 31 < dim; d += 32) {
-        __m512 decoded0, decoded1, decoded2, decoded3;
-        unpack_4bit_to_m512(codes1 + (d >> 1), &decoded0, &decoded1);
-        unpack_4bit_to_m512(codes2 + (d >> 1), &decoded2, &decoded3);
-
-        // Apply affine transform: value = lower_bound + decoded * diff
-        __m512 lb0 = _mm512_loadu_ps(lower_bound + d);
-        __m512 lb1 = _mm512_loadu_ps(lower_bound + d + 16);
-        __m512 diff0 = _mm512_loadu_ps(diff + d);
-        __m512 diff1 = _mm512_loadu_ps(diff + d + 16);
-        __m512 val0 = _mm512_fmadd_ps(decoded0, diff0, lb0);
-        __m512 val1 = _mm512_fmadd_ps(decoded1, diff1, lb1);
-
-        __m512 val2 = _mm512_fmadd_ps(decoded2, diff0, lb0);
-        __m512 val3 = _mm512_fmadd_ps(decoded3, diff1, lb1);
-
-        __m512 sub0 = _mm512_sub_ps(val2, val0);
-        __m512 sub1 = _mm512_sub_ps(val3, val1);
-
-        // Dot product
-        sum0 = _mm512_fmadd_ps(sub0, sub0, sum0);
-        sum1 = _mm512_fmadd_ps(sub1, sub1, sum1);
-    }
-    result += _mm512_reduce_add_ps(sum0) + _mm512_reduce_add_ps(sum1);
-    result += avx2::SQ4ComputeCodesL2Sqr(
-        codes1 + (d >> 1), codes2 + (d >> 1), lower_bound + d, diff + d, dim - d);
-    return result;
-
+    return simd::SQ4ComputeCodesL2SqrImpl<simd::SQ4Traits<simd::AVX512_SQ4_Tag>>(
+        codes1, codes2, lower_bound, diff, dim, &avx2::SQ4ComputeCodesL2Sqr);
 #else
     return avx2::SQ4ComputeCodesL2Sqr(codes1, codes2, lower_bound, diff, dim);
 #endif
@@ -962,32 +423,8 @@ SQ4UniformComputeCodesIP(const uint8_t* RESTRICT codes1,
                          const uint8_t* RESTRICT codes2,
                          uint64_t dim) {
 #if defined(ENABLE_AVX512)
-    if (dim == 0) {
-        return 0;
-    }
-    int32_t result = 0;
-    uint64_t d = 0;
-    __m512i sum = _mm512_setzero_si512();
-    __m512i mask = _mm512_set1_epi8(0xf);
-    for (; d + 127 < dim; d += 128) {
-        auto xx = _mm512_loadu_si512((__m512i*)(codes1 + (d >> 1)));
-        auto yy = _mm512_loadu_si512((__m512i*)(codes2 + (d >> 1)));
-        auto xx1 = _mm512_and_si512(xx, mask);                        // 64 * 8bits
-        auto xx2 = _mm512_and_si512(_mm512_srli_epi16(xx, 4), mask);  // 64 * 8bits
-        auto yy1 = _mm512_and_si512(yy, mask);
-        auto yy2 = _mm512_and_si512(_mm512_srli_epi16(yy, 4), mask);
-
-        sum = _mm512_add_epi16(sum, _mm512_maddubs_epi16(xx1, yy1));
-        sum = _mm512_add_epi16(sum, _mm512_maddubs_epi16(xx2, yy2));
-    }
-    auto sum1 = _mm512_cvtepi16_epi32(_mm512_castsi512_si256(sum));
-    auto sum2 = _mm512_cvtepi16_epi32(_mm512_extracti32x8_epi32(sum, 1));
-    result += _mm512_reduce_add_epi32(sum1);
-    result += _mm512_reduce_add_epi32(sum2);
-    if (d < dim) {
-        result += avx2::SQ4UniformComputeCodesIP(codes1 + (d >> 1), codes2 + (d >> 1), dim - d);
-    }
-    return result;
+    return simd::SQ4UniformComputeCodesIPImpl<simd::UniformCodeTraits<simd::AVX512_Uniform_Tag>>(
+        codes1, codes2, dim, &avx2::SQ4UniformComputeCodesIP);
 #else
     return avx2::SQ4UniformComputeCodesIP(codes1, codes2, dim);
 #endif
@@ -998,30 +435,8 @@ SQ8UniformComputeCodesIP(const uint8_t* RESTRICT codes1,
                          const uint8_t* RESTRICT codes2,
                          uint64_t dim) {
 #if defined(ENABLE_AVX512)
-    if (dim == 0) {
-        return 0.0f;
-    }
-
-    uint64_t d = 0;
-    __m512i sum = _mm512_setzero_si512();
-    const __m512i mask = _mm512_set1_epi16(0xff);
-    for (; d + 63 < dim; d += 64) {
-        auto xx = _mm512_loadu_si512(reinterpret_cast<const __m512i*>(codes1 + d));
-        auto yy = _mm512_loadu_si512(reinterpret_cast<const __m512i*>(codes2 + d));
-
-        auto xx1 = _mm512_and_si512(xx, mask);
-        auto yy1 = _mm512_and_si512(yy, mask);
-        auto xx2 = _mm512_srli_epi16(xx, 8);
-        auto yy2 = _mm512_srli_epi16(yy, 8);
-
-        sum = _mm512_add_epi32(sum, _mm512_madd_epi16(xx1, yy1));
-        sum = _mm512_add_epi32(sum, _mm512_madd_epi16(xx2, yy2));
-    }
-    int32_t result = _mm512_reduce_add_epi32(sum);
-    if (d < dim) {
-        result += avx2::SQ8UniformComputeCodesIP(codes1 + d, codes2 + d, dim - d);
-    }
-    return static_cast<float>(result);
+    return simd::SQ8UniformComputeCodesIPImpl<simd::UniformCodeTraits<simd::AVX512_Uniform_Tag>>(
+        codes1, codes2, dim, &avx2::SQ8UniformComputeCodesIP);
 #else
     return avx2::SQ8UniformComputeCodesIP(codes1, codes2, dim);
 #endif
@@ -1042,42 +457,8 @@ SQ8UniformComputeCodesIPBatch(const uint8_t* RESTRICT query,
 float
 RaBitQFloatBinaryIP(const float* vector, const uint8_t* bits, uint64_t dim, float inv_sqrt_d) {
 #if defined(ENABLE_AVX512)
-    if (dim == 0) {
-        return 0.0f;
-    }
-
-    if (dim < 16) {
-        return avx2::RaBitQFloatBinaryIP(vector, bits, dim, inv_sqrt_d);
-    }
-
-    uint64_t d = 0;
-    __m512 sum = _mm512_setzero_ps();
-    __m512 pos, neg;
-    if (inv_sqrt_d > 1e-3) {
-        pos = _mm512_set1_ps(inv_sqrt_d);
-        neg = _mm512_set1_ps(-inv_sqrt_d);
-    } else {
-        pos = _mm512_set1_ps(1.0f);
-        neg = _mm512_setzero_ps();
-    }
-
-    for (; d + 16 <= dim; d += 16) {
-        __m512 vec = _mm512_loadu_ps(vector + d);
-
-        __mmask16 mask = static_cast<__mmask16>(bits[d / 8 + 1] << 8 | bits[d / 8]);
-
-        __m512 b_vec = _mm512_mask_blend_ps(mask, neg, pos);
-
-        sum = _mm512_fmadd_ps(b_vec, vec, sum);
-    }
-
-    float result = _mm512_reduce_add_ps(sum);
-
-    if (d < dim) {
-        result += avx2::RaBitQFloatBinaryIP(vector + d, bits + (d / 8), dim - d, inv_sqrt_d);
-    }
-
-    return result;
+    return simd::RaBitQFloatBinaryIPImpl<simd::RaBitQTraits<simd::AVX512_RaBitQ_Tag>>(
+        vector, bits, dim, inv_sqrt_d, &avx2::RaBitQFloatBinaryIP);
 #else
     return avx2::RaBitQFloatBinaryIP(vector, bits, dim, inv_sqrt_d);
 #endif
@@ -1093,55 +474,16 @@ RaBitQFloatBinaryIPBatch4(const float* vector,
                           float inv_sqrt_d,
                           float* results) {
 #if defined(ENABLE_AVX512)
-    if (dim == 0) {
-        results[0] = 0.0F;
-        results[1] = 0.0F;
-        results[2] = 0.0F;
-        results[3] = 0.0F;
-        return;
-    }
-    if (dim < 16) {
-        avx2::RaBitQFloatBinaryIPBatch4(
-            vector, bits1, bits2, bits3, bits4, dim, inv_sqrt_d, results);
-        return;
-    }
-
-    const __m512 pos = inv_sqrt_d > 1e-3F ? _mm512_set1_ps(inv_sqrt_d) : _mm512_set1_ps(1.0F);
-    const __m512 neg = inv_sqrt_d > 1e-3F ? _mm512_set1_ps(-inv_sqrt_d) : _mm512_setzero_ps();
-    __m512 sums[4] = {
-        _mm512_setzero_ps(), _mm512_setzero_ps(), _mm512_setzero_ps(), _mm512_setzero_ps()};
-    const uint8_t* bits[4] = {bits1, bits2, bits3, bits4};
-
-    uint64_t d = 0;
-    for (; d + 16 <= dim; d += 16) {
-        const __m512 vec = _mm512_loadu_ps(vector + d);
-        const uint64_t byte_id = d >> 3;
-        for (uint32_t i = 0; i < 4; ++i) {
-            const auto mask =
-                static_cast<__mmask16>(static_cast<uint16_t>(bits[i][byte_id]) |
-                                       (static_cast<uint16_t>(bits[i][byte_id + 1]) << 8));
-            const __m512 binary = _mm512_mask_blend_ps(mask, neg, pos);
-            sums[i] = _mm512_fmadd_ps(binary, vec, sums[i]);
-        }
-    }
-
-    for (uint32_t i = 0; i < 4; ++i) {
-        results[i] = _mm512_reduce_add_ps(sums[i]);
-    }
-    if (d < dim) {
-        float tail[4];
-        avx2::RaBitQFloatBinaryIPBatch4(vector + d,
-                                        bits1 + (d >> 3),
-                                        bits2 + (d >> 3),
-                                        bits3 + (d >> 3),
-                                        bits4 + (d >> 3),
-                                        dim - d,
-                                        inv_sqrt_d,
-                                        tail);
-        for (uint32_t i = 0; i < 4; ++i) {
-            results[i] += tail[i];
-        }
-    }
+    simd::RaBitQFloatBinaryIPBatch4Impl<simd::RaBitQTraits<simd::AVX512_RaBitQ_Tag>>(
+        vector,
+        bits1,
+        bits2,
+        bits3,
+        bits4,
+        dim,
+        inv_sqrt_d,
+        results,
+        &avx2::RaBitQFloatBinaryIPBatch4);
 #else
     avx2::RaBitQFloatBinaryIPBatch4(vector, bits1, bits2, bits3, bits4, dim, inv_sqrt_d, results);
 #endif
@@ -1154,54 +496,8 @@ RaBitQFloatSplitCodeIP(const float* vector,
                        uint64_t dim,
                        uint32_t supplement_bits) {
 #if defined(ENABLE_AVX512)
-    if (dim == 0) {
-        return 0.0F;
-    }
-
-    const uint64_t plane_bytes = (dim + 7) / 8;
-    __m512 sum = _mm512_setzero_ps();
-
-    uint64_t d = 0;
-    for (; d + 16 <= dim; d += 16) {
-        const uint64_t byte_idx = d >> 3;
-        __m512 code = _mm512_setzero_ps();
-
-        for (uint32_t bit = 0; bit < supplement_bits; ++bit) {
-            const auto* plane = supplement_code + static_cast<uint64_t>(bit) * plane_bytes;
-            const auto mask =
-                static_cast<__mmask16>(static_cast<uint16_t>(plane[byte_idx]) |
-                                       (static_cast<uint16_t>(plane[byte_idx + 1]) << 8));
-            const __m512 weight = _mm512_set1_ps(static_cast<float>(1U << bit));
-            code = _mm512_mask_add_ps(code, mask, code, weight);
-        }
-
-        const auto one_bit_mask =
-            static_cast<__mmask16>(static_cast<uint16_t>(one_bit_code[byte_idx]) |
-                                   (static_cast<uint16_t>(one_bit_code[byte_idx + 1]) << 8));
-        const __m512 one_bit_weight = _mm512_set1_ps(static_cast<float>(1U << supplement_bits));
-        code = _mm512_mask_add_ps(code, one_bit_mask, code, one_bit_weight);
-
-        const __m512 vec = _mm512_loadu_ps(vector + d);
-        sum = _mm512_fmadd_ps(code, vec, sum);
-    }
-
-    float result = _mm512_reduce_add_ps(sum);
-
-    const uint32_t one_bit_scalar_weight = 1U << supplement_bits;
-    for (; d < dim; ++d) {
-        const uint64_t byte_idx = d >> 3;
-        const uint8_t bit_mask = static_cast<uint8_t>(1U << (d & 7));
-        uint32_t code = (one_bit_code[byte_idx] & bit_mask) != 0 ? one_bit_scalar_weight : 0U;
-        for (uint32_t bit = 0; bit < supplement_bits; ++bit) {
-            const auto* plane = supplement_code + static_cast<uint64_t>(bit) * plane_bytes;
-            if ((plane[byte_idx] & bit_mask) != 0) {
-                code += 1U << bit;
-            }
-        }
-        result += vector[d] * static_cast<float>(code);
-    }
-
-    return result;
+    return simd::RaBitQFloatSplitCodeIPImpl<simd::RaBitQTraits<simd::AVX512_RaBitQ_Tag>>(
+        vector, one_bit_code, supplement_code, dim, supplement_bits);
 #else
     return avx2::RaBitQFloatSplitCodeIP(
         vector, one_bit_code, supplement_code, dim, supplement_bits);
@@ -1285,22 +581,8 @@ RaBitQSQ4UBinaryIP(const uint8_t* codes, const uint8_t* bits, uint64_t dim) {
 void
 DivScalar(const float* from, float* to, uint64_t dim, float scalar) {
 #if defined(ENABLE_AVX512)
-    if (dim == 0) {
-        return;
-    }
-    if (scalar == 0) {
-        scalar = 1.0f;  // TODO(LHT): logger?
-    }
-    int i = 0;
-    __m512 scalarVec = _mm512_set1_ps(scalar);
-    for (; i + 15 < dim; i += 16) {
-        __m512 vec = _mm512_loadu_ps(from + i);
-        vec = _mm512_div_ps(vec, scalarVec);
-        _mm512_storeu_ps(to + i, vec);
-    }
-    if (dim > i) {
-        avx2::DivScalar(from + i, to + i, dim - i, scalar);
-    }
+    simd::DivScalarImpl<simd::SimdTraits<simd::AVX512_Tag>>(
+        from, to, dim, scalar, &avx2::DivScalar);
 #else
     avx2::DivScalar(from, to, dim, scalar);
 #endif
@@ -1361,22 +643,7 @@ PQFastScanLookUp32(const uint8_t* RESTRICT lookup_table,
 void
 BitAnd(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* result) {
 #if defined(ENABLE_AVX512)
-    if (num_byte == 0) {
-        return;
-    }
-    if (num_byte < 64) {
-        return avx2::BitAnd(x, y, num_byte, result);
-    }
-    int64_t i = 0;
-    for (; i + 63 < num_byte; i += 64) {
-        __m512i x_vec = _mm512_loadu_si512(reinterpret_cast<const __m512i*>(x + i));
-        __m512i y_vec = _mm512_loadu_si512(reinterpret_cast<const __m512i*>(y + i));
-        __m512i z_vec = _mm512_and_si512(x_vec, y_vec);
-        _mm512_storeu_si512(reinterpret_cast<__m512i*>(result + i), z_vec);
-    }
-    if (i < num_byte) {
-        avx2::BitAnd(x + i, y + i, num_byte - i, result + i);
-    }
+    simd::BitAndImpl<simd::BitTraits<simd::AVX512_Bit_Tag>>(x, y, num_byte, result, &avx2::BitAnd);
 #else
     return avx2::BitAnd(x, y, num_byte, result);
 #endif
@@ -1385,22 +652,7 @@ BitAnd(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* res
 void
 BitOr(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* result) {
 #if defined(ENABLE_AVX512)
-    if (num_byte == 0) {
-        return;
-    }
-    if (num_byte < 64) {
-        return avx2::BitOr(x, y, num_byte, result);
-    }
-    int64_t i = 0;
-    for (; i + 63 < num_byte; i += 64) {
-        __m512i x_vec = _mm512_loadu_si512(reinterpret_cast<const __m512i*>(x + i));
-        __m512i y_vec = _mm512_loadu_si512(reinterpret_cast<const __m512i*>(y + i));
-        __m512i z_vec = _mm512_or_si512(x_vec, y_vec);
-        _mm512_storeu_si512(reinterpret_cast<__m512i*>(result + i), z_vec);
-    }
-    if (i < num_byte) {
-        avx2::BitOr(x + i, y + i, num_byte - i, result + i);
-    }
+    simd::BitOrImpl<simd::BitTraits<simd::AVX512_Bit_Tag>>(x, y, num_byte, result, &avx2::BitOr);
 #else
     return avx2::BitOr(x, y, num_byte, result);
 #endif
@@ -1409,22 +661,7 @@ BitOr(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* resu
 void
 BitXor(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* result) {
 #if defined(ENABLE_AVX512)
-    if (num_byte == 0) {
-        return;
-    }
-    if (num_byte < 64) {
-        return avx2::BitXor(x, y, num_byte, result);
-    }
-    int64_t i = 0;
-    for (; i + 63 < num_byte; i += 64) {
-        __m512i x_vec = _mm512_loadu_si512(reinterpret_cast<const __m512i*>(x + i));
-        __m512i y_vec = _mm512_loadu_si512(reinterpret_cast<const __m512i*>(y + i));
-        __m512i z_vec = _mm512_xor_si512(x_vec, y_vec);
-        _mm512_storeu_si512(reinterpret_cast<__m512i*>(result + i), z_vec);
-    }
-    if (i < num_byte) {
-        avx2::BitXor(x + i, y + i, num_byte - i, result + i);
-    }
+    simd::BitXorImpl<simd::BitTraits<simd::AVX512_Bit_Tag>>(x, y, num_byte, result, &avx2::BitXor);
 #else
     return avx2::BitXor(x, y, num_byte, result);
 #endif
@@ -1433,21 +670,7 @@ BitXor(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* res
 void
 BitNot(const uint8_t* x, const uint64_t num_byte, uint8_t* result) {
 #if defined(ENABLE_AVX512)
-    if (num_byte == 0) {
-        return;
-    }
-    if (num_byte < 64) {
-        return avx2::BitNot(x, num_byte, result);
-    }
-    int64_t i = 0;
-    for (; i + 63 < num_byte; i += 64) {
-        __m512i x_vec = _mm512_loadu_si512(reinterpret_cast<const __m512i*>(x + i));
-        __m512i z_vec = _mm512_xor_si512(x_vec, _mm512_set1_epi8(0xFF));
-        _mm512_storeu_si512(reinterpret_cast<__m512i*>(result + i), z_vec);
-    }
-    if (i < num_byte) {
-        avx2::BitNot(x + i, num_byte - i, result + i);
-    }
+    simd::BitNotImpl<simd::BitTraits<simd::AVX512_Bit_Tag>>(x, num_byte, result, &avx2::BitNot);
 #else
     return avx2::BitNot(x, num_byte, result);
 #endif
@@ -1456,30 +679,9 @@ BitNot(const uint8_t* x, const uint64_t num_byte, uint8_t* result) {
 void
 KacsWalk(float* data, uint64_t len) {
 #if defined(ENABLE_AVX512)
-    int base = len % 2;
-    int offset = base + (len / 2);
-    int i = 0;
-    for (; i + 16 < len / 2; i += 16) {
-        __m512 x = _mm512_loadu_ps(&data[i]);
-        __m512 y = _mm512_loadu_ps(&data[i + offset]);
-
-        __m512 new_x = _mm512_add_ps(x, y);
-        __m512 new_y = _mm512_sub_ps(x, y);
-
-        _mm512_storeu_ps(&data[i], new_x);
-        _mm512_storeu_ps(&data[i + offset], new_y);
-    }
-    for (; i < len / 2; i++) {
-        float x = data[i];
-        float y = data[i + offset];
-        data[i] = x + y;
-        data[i + offset] = x - y;
-    }
-    if (base != 0) {
-        data[len / 2] *= std::sqrt(2);
-    }
+    simd::KacsWalkImpl<simd::SimdTraits<simd::AVX512_Tag>>(data, len, &avx2::KacsWalk);
 #else
-    return avx2::KacsWalk(data, len);
+    avx2::KacsWalk(data, len);
 #endif
 }
 
@@ -1533,32 +735,18 @@ FlipSign(const uint8_t* flip, float* data, uint64_t dim) {
 void
 VecRescale(float* data, uint64_t dim, float val) {
 #if defined(ENABLE_AVX512)
-    __m512 scalar = _mm512_set1_ps(val);
-    uint64_t i = 0;
-    for (; i + 16 <= dim; i += 16) {
-        __m512 vec = _mm512_loadu_ps(&data[i]);
-        vec = _mm512_mul_ps(vec, scalar);
-        _mm512_storeu_ps(&data[i], vec);
-    }
-    avx2::VecRescale(data + i, dim - i, val);
+    simd::VecRescaleImpl<simd::SimdTraits<simd::AVX512_Tag>>(data, dim, val, &avx2::VecRescale);
 #else
-    return avx2::VecRescale(data, dim, val);
+    avx2::VecRescale(data, dim, val);
 #endif
 }
 
 void
 RotateOp(float* data, int idx, int dim_, int step) {
 #if defined(ENABLE_AVX512)
-    for (int i = 0; i < dim_; i += step * 2) {
-        for (int j = 0; j < step; j += 16) {
-            __m512 g1 = _mm512_loadu_ps(&data[i + j]);
-            __m512 g2 = _mm512_loadu_ps(&data[i + j + step]);
-            _mm512_storeu_ps(&data[i + j], _mm512_add_ps(g1, g2));
-            _mm512_storeu_ps(&data[i + j + step], _mm512_sub_ps(g1, g2));
-        }
-    }
+    simd::RotateOpImpl<simd::SimdTraits<simd::AVX512_Tag>>(data, idx, dim_, step);
 #else
-    return avx2::RotateOp(data, idx, dim_, step);
+    avx2::RotateOp(data, idx, dim_, step);
 #endif
 }
 
@@ -1587,46 +775,8 @@ FHTRotate(float* data, uint64_t dim_) {
 float
 NormalizeWithCentroid(const float* from, const float* centroid, float* to, uint64_t dim) {
 #if defined(ENABLE_AVX512)
-    float norm_sq = 0;
-    uint64_t i = 0;
-    if (dim >= 16) {
-        __m512 sum = _mm512_setzero_ps();
-        for (; i + 15 < dim; i += 16) {
-            __m512 f = _mm512_loadu_ps(from + i);
-            __m512 c = _mm512_loadu_ps(centroid + i);
-            __m512 diff = _mm512_sub_ps(f, c);
-            sum = _mm512_fmadd_ps(diff, diff, sum);
-        }
-        norm_sq = _mm512_reduce_add_ps(sum);
-        for (; i < dim; ++i) {
-            auto diff = from[i] - centroid[i];
-            norm_sq += diff * diff;
-        }
-    } else {
-        norm_sq = generic::FP32ComputeL2Sqr(from, centroid, dim);
-    }
-
-    float norm = 0;
-    if (norm_sq < 1e-5f) {
-        norm = 1.0f;
-    } else {
-        norm = std::sqrt(norm_sq);
-    }
-
-    __m512 normVec = _mm512_set1_ps(norm);
-    for (i = 0; i + 15 < dim; i += 16) {
-        __m512 f = _mm512_loadu_ps(from + i);
-        __m512 c = _mm512_loadu_ps(centroid + i);
-        __m512 diff = _mm512_sub_ps(f, c);
-        __m512 result = _mm512_div_ps(diff, normVec);
-        _mm512_storeu_ps(to + i, result);
-    }
-    if (i < dim) {
-        for (; i < dim; ++i) {
-            to[i] = (from[i] - centroid[i]) / norm;
-        }
-    }
-    return norm;
+    return simd::NormalizeWithCentroidImpl<simd::SimdTraits<simd::AVX512_Tag>>(
+        from, centroid, to, dim, &avx2::NormalizeWithCentroid);
 #else
     return avx2::NormalizeWithCentroid(from, centroid, to, dim);
 #endif
@@ -1636,19 +786,8 @@ void
 InverseNormalizeWithCentroid(
     const float* from, const float* centroid, float* to, uint64_t dim, float norm) {
 #if defined(ENABLE_AVX512)
-    uint64_t i = 0;
-    __m512 normVec = _mm512_set1_ps(norm);
-    for (; i + 15 < dim; i += 16) {
-        __m512 f = _mm512_loadu_ps(from + i);
-        __m512 c = _mm512_loadu_ps(centroid + i);
-        __m512 result = _mm512_fmadd_ps(f, normVec, c);
-        _mm512_storeu_ps(to + i, result);
-    }
-    if (i < dim) {
-        for (; i < dim; ++i) {
-            to[i] = from[i] * norm + centroid[i];
-        }
-    }
+    simd::InverseNormalizeWithCentroidImpl<simd::SimdTraits<simd::AVX512_Tag>>(
+        from, centroid, to, dim, norm, &avx2::InverseNormalizeWithCentroid);
 #else
     avx2::InverseNormalizeWithCentroid(from, centroid, to, dim, norm);
 #endif

--- a/src/simd/generic.cpp
+++ b/src/simd/generic.cpp
@@ -15,6 +15,8 @@
 
 #include "simd.h"
 #include "simd/int8_simd.h"
+#include "simd/kernels/kernels.h"
+#include "simd/traits/simd_traits_generic.h"
 
 namespace vsag::generic {
 
@@ -95,22 +97,12 @@ PQDistanceFloat256(const void* single_dim_centers, float single_dim_val, void* r
 
 float
 FP32ComputeIP(const float* RESTRICT query, const float* RESTRICT codes, uint64_t dim) {
-    float result = 0.0f;
-
-    for (uint64_t i = 0; i < dim; ++i) {
-        result += query[i] * codes[i];
-    }
-    return result;
+    return simd::ComputeIPImpl<simd::SimdTraits<simd::Generic_Tag>>(query, codes, dim);
 }
 
 float
 FP32ComputeL2Sqr(const float* RESTRICT query, const float* RESTRICT codes, uint64_t dim) {
-    float result = 0.0f;
-    for (uint64_t i = 0; i < dim; ++i) {
-        auto val = query[i] - codes[i];
-        result += val * val;
-    }
-    return result;
+    return simd::ComputeL2SqrImpl<simd::SimdTraits<simd::Generic_Tag>>(query, codes, dim);
 }
 
 void
@@ -124,12 +116,8 @@ FP32ComputeIPBatch4(const float* RESTRICT query,
                     float& result2,
                     float& result3,
                     float& result4) {
-    for (uint64_t i = 0; i < dim; ++i) {
-        result1 += query[i] * codes1[i];
-        result2 += query[i] * codes2[i];
-        result3 += query[i] * codes3[i];
-        result4 += query[i] * codes4[i];
-    }
+    simd::ComputeBatch4Impl<simd::SimdTraits<simd::Generic_Tag>, simd::Batch4Kind::IP>(
+        query, dim, codes1, codes2, codes3, codes4, result1, result2, result3, result4);
 }
 
 void
@@ -143,49 +131,33 @@ FP32ComputeL2SqrBatch4(const float* RESTRICT query,
                        float& result2,
                        float& result3,
                        float& result4) {
-    for (uint64_t i = 0; i < dim; ++i) {
-        result1 += (query[i] - codes1[i]) * (query[i] - codes1[i]);
-        result2 += (query[i] - codes2[i]) * (query[i] - codes2[i]);
-        result3 += (query[i] - codes3[i]) * (query[i] - codes3[i]);
-        result4 += (query[i] - codes4[i]) * (query[i] - codes4[i]);
-    }
+    simd::ComputeBatch4Impl<simd::SimdTraits<simd::Generic_Tag>, simd::Batch4Kind::L2>(
+        query, dim, codes1, codes2, codes3, codes4, result1, result2, result3, result4);
 }
 
 void
 FP32Sub(const float* x, const float* y, float* z, uint64_t dim) {
-    for (uint64_t i = 0; i < dim; ++i) {
-        z[i] = x[i] - y[i];
-    }
+    simd::BinaryOpImpl<simd::SimdTraits<simd::Generic_Tag>, simd::BinaryOp::Sub>(x, y, z, dim);
 }
 
 void
 FP32Add(const float* x, const float* y, float* z, uint64_t dim) {
-    for (uint64_t i = 0; i < dim; ++i) {
-        z[i] = x[i] + y[i];
-    }
+    simd::BinaryOpImpl<simd::SimdTraits<simd::Generic_Tag>, simd::BinaryOp::Add>(x, y, z, dim);
 }
 
 void
 FP32Mul(const float* x, const float* y, float* z, uint64_t dim) {
-    for (uint64_t i = 0; i < dim; ++i) {
-        z[i] = x[i] * y[i];
-    }
+    simd::BinaryOpImpl<simd::SimdTraits<simd::Generic_Tag>, simd::BinaryOp::Mul>(x, y, z, dim);
 }
 
 void
 FP32Div(const float* x, const float* y, float* z, uint64_t dim) {
-    for (uint64_t i = 0; i < dim; ++i) {
-        z[i] = x[i] / y[i];
-    }
+    simd::BinaryOpImpl<simd::SimdTraits<simd::Generic_Tag>, simd::BinaryOp::Div>(x, y, z, dim);
 }
 
 float
 FP32ReduceAdd(const float* x, uint64_t dim) {
-    float result = 0.0F;
-    for (uint64_t i = 0; i < dim; ++i) {
-        result += x[i];
-    }
-    return result;
+    return simd::ReduceAddImpl<simd::SimdTraits<simd::Generic_Tag>>(x, dim);
 }
 
 union FP32Struct {
@@ -194,22 +166,13 @@ union FP32Struct {
 };
 
 float
-INT8ComputeL2Sqr(const int8_t* RESTRICT query, const int8_t* RESTRICT codes, uint64_t dim) {
-    float result = 0.0f;
-    for (uint64_t i = 0; i < dim; ++i) {
-        auto val = static_cast<float>(query[i] - codes[i]);
-        result += val * val;
-    }
-    return result;
+INT8ComputeL2Sqr(const int8_t* query, const int8_t* codes, uint64_t dim) {
+    return simd::Int8ComputeL2SqrImpl<simd::Int8Traits<simd::Generic_Int8_Tag>>(query, codes, dim);
 }
 
 float
-INT8ComputeIP(const int8_t* __restrict query, const int8_t* __restrict codes, uint64_t dim) {
-    float result = 0.0f;
-    for (uint64_t i = 0; i < dim; ++i) {
-        result += static_cast<float>(query[i] * codes[i]);
-    }
-    return result;
+INT8ComputeIP(const int8_t* query, const int8_t* codes, uint64_t dim) {
+    return simd::Int8ComputeIPImpl<simd::Int8Traits<simd::Generic_Int8_Tag>>(query, codes, dim);
 }
 
 float
@@ -254,48 +217,26 @@ FloatToFP16(const float fp32_value) {
 
 float
 BF16ComputeIP(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim) {
-    float result = 0.0f;
-    auto* query_bf16 = reinterpret_cast<const uint16_t*>(query);
-    auto* codes_bf16 = reinterpret_cast<const uint16_t*>(codes);
-    for (uint64_t i = 0; i < dim; ++i) {
-        result += BF16ToFloat(query_bf16[i]) * BF16ToFloat(codes_bf16[i]);
-    }
-    return result;
+    return simd::HalfComputeIPImpl<simd::BF16Traits<simd::Generic_BF16_Tag>>(
+        query, codes, dim, nullptr);
 }
 
 float
 BF16ComputeL2Sqr(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim) {
-    float result = 0.0f;
-    auto* query_bf16 = reinterpret_cast<const uint16_t*>(query);
-    auto* codes_bf16 = reinterpret_cast<const uint16_t*>(codes);
-    for (uint64_t i = 0; i < dim; ++i) {
-        auto val = BF16ToFloat(query_bf16[i]) - BF16ToFloat(codes_bf16[i]);
-        result += val * val;
-    }
-    return result;
+    return simd::HalfComputeL2SqrImpl<simd::BF16Traits<simd::Generic_BF16_Tag>>(
+        query, codes, dim, nullptr);
 }
 
 float
 FP16ComputeIP(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim) {
-    float result = 0.0f;
-    auto* query_bf16 = reinterpret_cast<const uint16_t*>(query);
-    auto* codes_bf16 = reinterpret_cast<const uint16_t*>(codes);
-    for (uint64_t i = 0; i < dim; ++i) {
-        result += FP16ToFloat(query_bf16[i]) * FP16ToFloat(codes_bf16[i]);
-    }
-    return result;
+    return simd::HalfComputeIPImpl<simd::FP16Traits<simd::Generic_FP16_Tag>>(
+        query, codes, dim, nullptr);
 }
 
 float
 FP16ComputeL2Sqr(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim) {
-    float result = 0.0f;
-    auto* query_bf16 = reinterpret_cast<const uint16_t*>(query);
-    auto* codes_bf16 = reinterpret_cast<const uint16_t*>(codes);
-    for (uint64_t i = 0; i < dim; ++i) {
-        auto val = FP16ToFloat(query_bf16[i]) - FP16ToFloat(codes_bf16[i]);
-        result += val * val;
-    }
-    return result;
+    return simd::HalfComputeL2SqrImpl<simd::FP16Traits<simd::Generic_FP16_Tag>>(
+        query, codes, dim, nullptr);
 }
 
 float
@@ -304,12 +245,8 @@ SQ8ComputeIP(const float* RESTRICT query,
              const float* RESTRICT lower_bound,
              const float* RESTRICT diff,
              uint64_t dim) {
-    float result = 0.0f;
-    for (uint64_t i = 0; i < dim; ++i) {
-        result += query[i] * static_cast<float>(static_cast<float>(codes[i]) / 255.0 * diff[i] +
-                                                lower_bound[i]);
-    }
-    return result;
+    return simd::SQ8ComputeIPImpl<simd::SQ8Traits<simd::Generic_SQ8_Tag>>(
+        query, codes, lower_bound, diff, dim);
 }
 
 float
@@ -318,13 +255,8 @@ SQ8ComputeL2Sqr(const float* RESTRICT query,
                 const float* RESTRICT lower_bound,
                 const float* RESTRICT diff,
                 uint64_t dim) {
-    float result = 0.0f;
-    for (uint64_t i = 0; i < dim; ++i) {
-        auto val = (query[i] - static_cast<float>(static_cast<float>(codes[i]) / 255.0 * diff[i] +
-                                                  lower_bound[i]));
-        result += val * val;
-    }
-    return result;
+    return simd::SQ8ComputeL2SqrImpl<simd::SQ8Traits<simd::Generic_SQ8_Tag>>(
+        query, codes, lower_bound, diff, dim);
 }
 
 float
@@ -333,15 +265,8 @@ SQ8ComputeCodesIP(const uint8_t* RESTRICT codes1,
                   const float* RESTRICT lower_bound,
                   const float* RESTRICT diff,
                   uint64_t dim) {
-    float result = 0.0f;
-    for (uint64_t i = 0; i < dim; ++i) {
-        auto val1 =
-            static_cast<float>(static_cast<float>(codes1[i]) / 255.0 * diff[i] + lower_bound[i]);
-        auto val2 =
-            static_cast<float>(static_cast<float>(codes2[i]) / 255.0 * diff[i] + lower_bound[i]);
-        result += val1 * val2;
-    }
-    return result;
+    return simd::SQ8ComputeCodesIPImpl<simd::SQ8Traits<simd::Generic_SQ8_Tag>>(
+        codes1, codes2, lower_bound, diff, dim);
 }
 
 float
@@ -350,16 +275,59 @@ SQ8ComputeCodesL2Sqr(const uint8_t* RESTRICT codes1,
                      const float* RESTRICT lower_bound,
                      const float* RESTRICT diff,
                      uint64_t dim) {
-    float result = 0.0f;
+    return simd::SQ8ComputeCodesL2SqrImpl<simd::SQ8Traits<simd::Generic_SQ8_Tag>>(
+        codes1, codes2, lower_bound, diff, dim);
+}
+
+namespace {
+float
+SQ4ScalarIP(const float* q, const uint8_t* c, const float* lb, const float* d, uint64_t dim) {
+    float result = 0;
     for (uint64_t i = 0; i < dim; ++i) {
-        auto val1 =
-            static_cast<float>(static_cast<float>(codes1[i]) / 255.0 * diff[i] + lower_bound[i]);
-        auto val2 =
-            static_cast<float>(static_cast<float>(codes2[i]) / 255.0 * diff[i] + lower_bound[i]);
-        result += (val1 - val2) * (val1 - val2);
+        uint8_t nibble = (i & 1) ? (c[i >> 1] >> 4) : (c[i >> 1] & 0x0f);
+        result += q[i] * (nibble * (1.0f / 15.0f) * d[i] + lb[i]);
     }
     return result;
 }
+float
+SQ4ScalarL2(const float* q, const uint8_t* c, const float* lb, const float* d, uint64_t dim) {
+    float result = 0;
+    for (uint64_t i = 0; i < dim; ++i) {
+        uint8_t nibble = (i & 1) ? (c[i >> 1] >> 4) : (c[i >> 1] & 0x0f);
+        float v = nibble * (1.0f / 15.0f) * d[i] + lb[i];
+        float diff = q[i] - v;
+        result += diff * diff;
+    }
+    return result;
+}
+float
+SQ4ScalarCodesIP(
+    const uint8_t* c1, const uint8_t* c2, const float* lb, const float* d, uint64_t dim) {
+    float result = 0;
+    for (uint64_t i = 0; i < dim; ++i) {
+        uint8_t n1 = (i & 1) ? (c1[i >> 1] >> 4) : (c1[i >> 1] & 0x0f);
+        uint8_t n2 = (i & 1) ? (c2[i >> 1] >> 4) : (c2[i >> 1] & 0x0f);
+        float v1 = n1 * (1.0f / 15.0f) * d[i] + lb[i];
+        float v2 = n2 * (1.0f / 15.0f) * d[i] + lb[i];
+        result += v1 * v2;
+    }
+    return result;
+}
+float
+SQ4ScalarCodesL2(
+    const uint8_t* c1, const uint8_t* c2, const float* lb, const float* d, uint64_t dim) {
+    float result = 0;
+    for (uint64_t i = 0; i < dim; ++i) {
+        uint8_t n1 = (i & 1) ? (c1[i >> 1] >> 4) : (c1[i >> 1] & 0x0f);
+        uint8_t n2 = (i & 1) ? (c2[i >> 1] >> 4) : (c2[i >> 1] & 0x0f);
+        float v1 = n1 * (1.0f / 15.0f) * d[i] + lb[i];
+        float v2 = n2 * (1.0f / 15.0f) * d[i] + lb[i];
+        float diff = v1 - v2;
+        result += diff * diff;
+    }
+    return result;
+}
+}  // namespace
 
 float
 SQ4ComputeIP(const float* RESTRICT query,
@@ -367,24 +335,8 @@ SQ4ComputeIP(const float* RESTRICT query,
              const float* RESTRICT lower_bound,
              const float* RESTRICT diff,
              uint64_t dim) {
-    float result = 0;
-    float x_lo = 0, x_hi = 0, y_lo = 0, y_hi = 0;
-
-    for (uint64_t d = 0; d < dim; d += 2) {
-        x_lo = query[d];
-        y_lo = (codes[d >> 1] & 0x0f) / 15.0 * diff[d] + lower_bound[d];
-        if (d + 1 < dim) {
-            x_hi = query[d + 1];
-            y_hi = (codes[d >> 1] >> 4) / 15.0 * diff[d + 1] + lower_bound[d + 1];
-        } else {
-            x_hi = 0;
-            y_hi = 0;
-        }
-
-        result += (x_lo * y_lo + x_hi * y_hi);
-    }
-
-    return result;
+    return simd::SQ4ComputeIPImpl<simd::SQ4Traits<simd::Generic_SQ4_Tag>>(
+        query, codes, lower_bound, diff, dim, &SQ4ScalarIP);
 }
 
 float
@@ -393,24 +345,8 @@ SQ4ComputeL2Sqr(const float* RESTRICT query,
                 const float* RESTRICT lower_bound,
                 const float* RESTRICT diff,
                 uint64_t dim) {
-    float result = 0;
-    float x_lo = 0, x_hi = 0, y_lo = 0, y_hi = 0;
-
-    for (uint64_t d = 0; d < dim; d += 2) {
-        x_lo = query[d];
-        y_lo = (codes[d >> 1] & 0x0f) / 15.0 * diff[d] + lower_bound[d];
-        if (d + 1 < dim) {
-            x_hi = query[d + 1];
-            y_hi = ((codes[d >> 1] & 0xf0) >> 4) / 15.0 * diff[d + 1] + lower_bound[d + 1];
-        } else {
-            x_hi = 0;
-            y_hi = 0;
-        }
-
-        result += (x_lo - y_lo) * (x_lo - y_lo) + (x_hi - y_hi) * (x_hi - y_hi);
-    }
-
-    return result;
+    return simd::SQ4ComputeL2SqrImpl<simd::SQ4Traits<simd::Generic_SQ4_Tag>>(
+        query, codes, lower_bound, diff, dim, &SQ4ScalarL2);
 }
 
 float
@@ -419,24 +355,8 @@ SQ4ComputeCodesIP(const uint8_t* RESTRICT codes1,
                   const float* RESTRICT lower_bound,
                   const float* RESTRICT diff,
                   uint64_t dim) {
-    float result = 0, delta = 0;
-    float x_lo = 0, x_hi = 0, y_lo = 0, y_hi = 0;
-
-    for (uint64_t d = 0; d < dim; d += 2) {
-        x_lo = (codes1[d >> 1] & 0x0f) / 15.0 * diff[d] + lower_bound[d];
-        y_lo = (codes2[d >> 1] & 0x0f) / 15.0 * diff[d] + lower_bound[d];
-        if (d + 1 < dim) {
-            x_hi = ((codes1[d >> 1] & 0xf0) >> 4) / 15.0 * diff[d + 1] + lower_bound[d + 1];
-            y_hi = ((codes2[d >> 1] & 0xf0) >> 4) / 15.0 * diff[d + 1] + lower_bound[d + 1];
-        } else {
-            x_hi = 0;
-            y_hi = 0;
-        }
-
-        result += (x_lo * y_lo + x_hi * y_hi);
-    }
-
-    return result;
+    return simd::SQ4ComputeCodesIPImpl<simd::SQ4Traits<simd::Generic_SQ4_Tag>>(
+        codes1, codes2, lower_bound, diff, dim, &SQ4ScalarCodesIP);
 }
 
 float
@@ -445,24 +365,8 @@ SQ4ComputeCodesL2Sqr(const uint8_t* RESTRICT codes1,
                      const float* RESTRICT lower_bound,
                      const float* RESTRICT diff,
                      uint64_t dim) {
-    float result = 0, delta = 0;
-    float x_lo = 0, x_hi = 0, y_lo = 0, y_hi = 0;
-
-    for (uint64_t d = 0; d < dim; d += 2) {
-        x_lo = (codes1[d >> 1] & 0x0f) / 15.0 * diff[d] + lower_bound[d];
-        y_lo = (codes2[d >> 1] & 0x0f) / 15.0 * diff[d] + lower_bound[d];
-        if (d + 1 < dim) {
-            x_hi = ((codes1[d >> 1] & 0xf0) >> 4) / 15.0 * diff[d + 1] + lower_bound[d + 1];
-            y_hi = ((codes2[d >> 1] & 0xf0) >> 4) / 15.0 * diff[d + 1] + lower_bound[d + 1];
-        } else {
-            x_hi = 0;
-            y_hi = 0;
-        }
-
-        result += (x_lo - y_lo) * (x_lo - y_lo) + (x_hi - y_hi) * (x_hi - y_hi);
-    }
-
-    return result;
+    return simd::SQ4ComputeCodesL2SqrImpl<simd::SQ4Traits<simd::Generic_SQ4_Tag>>(
+        codes1, codes2, lower_bound, diff, dim, &SQ4ScalarCodesL2);
 }
 
 float
@@ -657,43 +561,20 @@ Normalize(const float* from, float* to, uint64_t dim) {
 
 float
 NormalizeWithCentroid(const float* from, const float* centroid, float* to, uint64_t dim) {
-    float norm = 0;
-    for (uint64_t d = 0; d < dim; ++d) {
-        norm += (from[d] - centroid[d]) * (from[d] - centroid[d]);
-    }
-
-    if (norm < 1e-5) {
-        norm = 1;
-    } else {
-        norm = std::sqrt(norm);
-    }
-
-    for (int d = 0; d < dim; d++) {
-        to[d] = (from[d] - centroid[d]) / norm;
-    }
-
-    return norm;
+    return simd::NormalizeWithCentroidImpl<simd::SimdTraits<simd::Generic_Tag>>(
+        from, centroid, to, dim);
 }
 
 void
 InverseNormalizeWithCentroid(
     const float* from, const float* centroid, float* to, uint64_t dim, float norm) {
-    for (int d = 0; d < dim; d++) {
-        to[d] = from[d] * norm + centroid[d];
-    }
+    simd::InverseNormalizeWithCentroidImpl<simd::SimdTraits<simd::Generic_Tag>>(
+        from, centroid, to, dim, norm);
 }
 
 void
 DivScalar(const float* from, float* to, uint64_t dim, float scalar) {
-    if (dim == 0) {
-        return;
-    }
-    if (scalar == 0) {
-        scalar = 1.0f;  // TODO(LHT): logger?
-    }
-    for (uint64_t i = 0; i < dim; ++i) {
-        to[i] = from[i] / scalar;
-    }
+    simd::DivScalarImpl<simd::SimdTraits<simd::Generic_Tag>>(from, to, dim, scalar);
 }
 
 void
@@ -751,19 +632,7 @@ BitNot(const uint8_t* x, const uint64_t num_byte, uint8_t* result) {
 
 void
 KacsWalk(float* data, uint64_t len) {
-    uint64_t base = len % 2;
-    uint64_t offset = base + (len / 2);  // for odd dim
-    for (uint64_t i = 0; i < len / 2; i++) {
-        float add = data[i] + data[i + offset];
-        float sub = data[i] - data[i + offset];
-        data[i] = add;
-        data[i + offset] = sub;
-    }
-    if (base != 0) {
-        data[len / 2] *= std::sqrt(2.0F);
-        //In odd condition, we operate the prev len/2 items and the post len/2 items, the No.len/2 item stay still,
-        //As we need to resize the while sequence in the next step, so we increase the val of No.len/2 item to eliminate the impact of the following resize.
-    }
+    simd::KacsWalkImpl<simd::SimdTraits<simd::Generic_Tag>>(data, len);
 }
 
 void
@@ -778,21 +647,12 @@ FlipSign(const uint8_t* flip, float* data, uint64_t dim) {
 
 void
 VecRescale(float* data, uint64_t dim, float val) {
-    for (int i = 0; i < dim; i++) {
-        data[i] *= val;
-    }
+    simd::VecRescaleImpl<simd::SimdTraits<simd::Generic_Tag>>(data, dim, val);
 }
 
 void
 RotateOp(float* data, int idx, int dim_, int step) {
-    for (int i = idx; i < dim_; i += 2 * step) {
-        for (int j = 0; j < step; j++) {
-            float x = data[i + j];
-            float y = data[i + j + step];
-            data[i + j] = x + y;
-            data[i + j + step] = x - y;
-        }
-    }
+    simd::RotateOpImpl<simd::SimdTraits<simd::Generic_Tag>>(data, idx, dim_, step);
 }
 
 void

--- a/src/simd/kernels/binary_op.h
+++ b/src/simd/kernels/binary_op.h
@@ -1,0 +1,75 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+// Element-wise binary op kernel: z[i] = op(x[i], y[i]).
+// Used by FP32Add / FP32Sub / FP32Mul / FP32Div across all ISAs.
+//
+// Op selects the per-element operation via a tag dispatched at compile time
+// to the corresponding traits method (add/sub/mul/div). The Generic backend
+// (Width == 1) compiles out the fallback branch via `if constexpr`.
+
+#include <cstdint>
+
+namespace vsag::simd {
+
+using BinaryFallback = void (*)(const float*, const float*, float*, uint64_t);
+
+enum class BinaryOp { Add, Sub, Mul, Div };
+
+template <typename T, BinaryOp Op>
+inline __attribute__((always_inline)) typename T::FloatVec
+binary_apply(typename T::FloatVec a, typename T::FloatVec b) {
+    if constexpr (Op == BinaryOp::Add) {
+        return T::add(a, b);
+    } else if constexpr (Op == BinaryOp::Sub) {
+        return T::sub(a, b);
+    } else if constexpr (Op == BinaryOp::Mul) {
+        return T::mul(a, b);
+    } else {
+        return T::div(a, b);
+    }
+}
+
+template <typename T, BinaryOp Op>
+inline void
+BinaryOpImpl(
+    const float* x, const float* y, float* z, uint64_t dim, BinaryFallback fallback = nullptr) {
+    using V = typename T::FloatVec;
+    constexpr int W = T::Width;
+
+    if constexpr (W > 1) {
+        if (dim < static_cast<uint64_t>(W)) {
+            fallback(x, y, z, dim);
+            return;
+        }
+    }
+
+    uint64_t i = 0;
+    for (; i + W <= dim; i += W) {
+        V a = T::load(x + i);
+        V b = T::load(y + i);
+        T::store(z + i, binary_apply<T, Op>(a, b));
+    }
+
+    if constexpr (W > 1) {
+        if (dim > i) {
+            fallback(x + i, y + i, z + i, dim - i);
+        }
+    }
+}
+
+}  // namespace vsag::simd

--- a/src/simd/kernels/bit_op.h
+++ b/src/simd/kernels/bit_op.h
@@ -1,0 +1,123 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+// Bitwise operation kernels: AND, OR, XOR, NOT.
+//
+// Parameterized on BitTraits<ISA>, which must expose:
+//   IntVec              - integer vector type (e.g. __m128i, __m256i, __m512i)
+//   ByteWidth           - number of bytes per vector (16, 32, 64)
+//   load(const uint8_t* p)     -> IntVec
+//   store(uint8_t* p, IntVec v)
+//   bit_and(IntVec a, IntVec b) -> IntVec
+//   bit_or(IntVec a, IntVec b)  -> IntVec
+//   bit_xor(IntVec a, IntVec b) -> IntVec
+//   bit_not(IntVec a)            -> IntVec    (optional, only needed for BitNotImpl)
+
+#include <cstdint>
+
+namespace vsag::simd {
+
+using BitOpFallback = void (*)(const uint8_t*, const uint8_t*, uint64_t, uint8_t*);
+using BitNotFallback = void (*)(const uint8_t*, uint64_t, uint8_t*);
+
+template <typename T>
+inline void
+BitAndImpl(const uint8_t* x,
+           const uint8_t* y,
+           uint64_t num_byte,
+           uint8_t* result,
+           BitOpFallback fallback = nullptr) {
+    constexpr int W = T::ByteWidth;
+    if (num_byte == 0)
+        return;
+    if (num_byte < static_cast<uint64_t>(W)) {
+        return fallback(x, y, num_byte, result);
+    }
+    int64_t i = 0;
+    for (; i + W <= static_cast<int64_t>(num_byte); i += W) {
+        T::store(result + i, T::bit_and(T::load(x + i), T::load(y + i)));
+    }
+    if (i < static_cast<int64_t>(num_byte)) {
+        fallback(x + i, y + i, num_byte - i, result + i);
+    }
+}
+
+template <typename T>
+inline void
+BitOrImpl(const uint8_t* x,
+          const uint8_t* y,
+          uint64_t num_byte,
+          uint8_t* result,
+          BitOpFallback fallback = nullptr) {
+    constexpr int W = T::ByteWidth;
+    if (num_byte == 0)
+        return;
+    if (num_byte < static_cast<uint64_t>(W)) {
+        return fallback(x, y, num_byte, result);
+    }
+    int64_t i = 0;
+    for (; i + W <= static_cast<int64_t>(num_byte); i += W) {
+        T::store(result + i, T::bit_or(T::load(x + i), T::load(y + i)));
+    }
+    if (i < static_cast<int64_t>(num_byte)) {
+        fallback(x + i, y + i, num_byte - i, result + i);
+    }
+}
+
+template <typename T>
+inline void
+BitXorImpl(const uint8_t* x,
+           const uint8_t* y,
+           uint64_t num_byte,
+           uint8_t* result,
+           BitOpFallback fallback = nullptr) {
+    constexpr int W = T::ByteWidth;
+    if (num_byte == 0)
+        return;
+    if (num_byte < static_cast<uint64_t>(W)) {
+        return fallback(x, y, num_byte, result);
+    }
+    int64_t i = 0;
+    for (; i + W <= static_cast<int64_t>(num_byte); i += W) {
+        T::store(result + i, T::bit_xor(T::load(x + i), T::load(y + i)));
+    }
+    if (i < static_cast<int64_t>(num_byte)) {
+        fallback(x + i, y + i, num_byte - i, result + i);
+    }
+}
+
+template <typename T>
+inline void
+BitNotImpl(const uint8_t* x,
+           uint64_t num_byte,
+           uint8_t* result,
+           BitNotFallback fallback = nullptr) {
+    constexpr int W = T::ByteWidth;
+    if (num_byte == 0)
+        return;
+    if (num_byte < static_cast<uint64_t>(W)) {
+        return fallback(x, num_byte, result);
+    }
+    int64_t i = 0;
+    for (; i + W <= static_cast<int64_t>(num_byte); i += W) {
+        T::store(result + i, T::bit_not(T::load(x + i)));
+    }
+    if (i < static_cast<int64_t>(num_byte)) {
+        fallback(x + i, num_byte - i, result + i);
+    }
+}
+
+}  // namespace vsag::simd

--- a/src/simd/kernels/butterfly.h
+++ b/src/simd/kernels/butterfly.h
@@ -1,0 +1,96 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+// Butterfly-pattern kernels used in Fast Hadamard Transform (FHT):
+//   RotateOp:  data[i+j] = data[i+j] + data[i+j+step]
+//              data[i+j+step] = data[i+j] - data[i+j+step]
+//   KacsWalk:  in-place butterfly on two halves of the array.
+//
+// These use only load/store/add/sub from the traits interface.
+
+#include <cmath>
+#include <cstdint>
+
+namespace vsag::simd {
+
+using RotateOpFallback = void (*)(float*, int, int, int);
+using KacsWalkFallback = void (*)(float*, uint64_t);
+
+// RotateOp: butterfly on stride `step` within [idx, dim_).
+// Requires step >= T::Width for the vectorized path.
+template <typename T>
+inline void
+RotateOpImpl(float* data, int idx, int dim_, int step) {
+    using V = typename T::FloatVec;
+    constexpr int W = T::Width;
+
+    for (int i = idx; i < dim_; i += step * 2) {
+        int j = 0;
+        for (; j + W <= step; j += W) {
+            V g1 = T::load(&data[i + j]);
+            V g2 = T::load(&data[i + j + step]);
+            T::store(&data[i + j], T::add(g1, g2));
+            T::store(&data[i + j + step], T::sub(g1, g2));
+        }
+        for (; j < step; ++j) {
+            float g1 = data[i + j];
+            float g2 = data[i + j + step];
+            data[i + j] = g1 + g2;
+            data[i + j + step] = g1 - g2;
+        }
+    }
+}
+
+// KacsWalk: in-place butterfly on data[0..len/2-1] vs data[offset..offset+len/2-1].
+// For odd-length arrays, the middle element is scaled by sqrt(2).
+template <typename T>
+inline void
+KacsWalkImpl(float* data, uint64_t len, KacsWalkFallback fallback = nullptr) {
+    using V = typename T::FloatVec;
+    constexpr int W = T::Width;
+
+    if constexpr (W > 1) {
+        if (len / 2 < static_cast<uint64_t>(W)) {
+            fallback(data, len);
+            return;
+        }
+    }
+
+    uint64_t base = len % 2;
+    uint64_t offset = base + (len / 2);
+    uint64_t i = 0;
+
+    for (; i + W <= len / 2; i += W) {
+        V x = T::load(&data[i]);
+        V y = T::load(&data[i + offset]);
+        T::store(&data[i], T::add(x, y));
+        T::store(&data[i + offset], T::sub(x, y));
+    }
+
+    // Scalar tail
+    for (; i < len / 2; i++) {
+        float x = data[i];
+        float y = data[i + offset];
+        data[i] = x + y;
+        data[i + offset] = x - y;
+    }
+
+    if (base != 0) {
+        data[len / 2] *= std::sqrt(2.0f);
+    }
+}
+
+}  // namespace vsag::simd

--- a/src/simd/kernels/compute_batch4.h
+++ b/src/simd/kernels/compute_batch4.h
@@ -1,0 +1,102 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+// Batch-of-4 IP / L2 kernel: one query vector against four code vectors.
+// Results are accumulated into result1..result4 (the caller must initialise
+// them before invocation, e.g. to 0). Matches the existing semantics of
+// FP32ComputeIPBatch4 / FP32ComputeL2SqrBatch4: the four accumulators
+// share the same query load, so we get 4x reuse of every q-cacheline.
+
+#include <cstdint>
+
+#include "simd/simd_marco.h"
+
+namespace vsag::simd {
+
+using Batch4Fallback = void (*)(const float* RESTRICT query,
+                                uint64_t dim,
+                                const float* RESTRICT c1,
+                                const float* RESTRICT c2,
+                                const float* RESTRICT c3,
+                                const float* RESTRICT c4,
+                                float& r1,
+                                float& r2,
+                                float& r3,
+                                float& r4);
+
+enum class Batch4Kind { IP, L2 };
+
+template <typename T, Batch4Kind Kind>
+inline __attribute__((always_inline)) typename T::FloatVec
+batch4_accumulate(typename T::FloatVec q, typename T::FloatVec c, typename T::FloatVec acc) {
+    if constexpr (Kind == Batch4Kind::IP) {
+        return T::fmadd(q, c, acc);
+    } else {
+        typename T::FloatVec d = T::sub(q, c);
+        return T::fmadd(d, d, acc);
+    }
+}
+
+template <typename T, Batch4Kind Kind>
+inline void
+ComputeBatch4Impl(const float* RESTRICT query,
+                  uint64_t dim,
+                  const float* RESTRICT c1,
+                  const float* RESTRICT c2,
+                  const float* RESTRICT c3,
+                  const float* RESTRICT c4,
+                  float& r1,
+                  float& r2,
+                  float& r3,
+                  float& r4,
+                  Batch4Fallback fallback = nullptr) {
+    using V = typename T::FloatVec;
+    constexpr int W = T::Width;
+
+    if constexpr (W > 1) {
+        if (dim < static_cast<uint64_t>(W)) {
+            fallback(query, dim, c1, c2, c3, c4, r1, r2, r3, r4);
+            return;
+        }
+    }
+
+    V s1 = T::zero();
+    V s2 = T::zero();
+    V s3 = T::zero();
+    V s4 = T::zero();
+
+    uint64_t i = 0;
+    for (; i + W <= dim; i += W) {
+        V q = T::load(query + i);
+        s1 = batch4_accumulate<T, Kind>(q, T::load(c1 + i), s1);
+        s2 = batch4_accumulate<T, Kind>(q, T::load(c2 + i), s2);
+        s3 = batch4_accumulate<T, Kind>(q, T::load(c3 + i), s3);
+        s4 = batch4_accumulate<T, Kind>(q, T::load(c4 + i), s4);
+    }
+    r1 += T::reduce_add(s1);
+    r2 += T::reduce_add(s2);
+    r3 += T::reduce_add(s3);
+    r4 += T::reduce_add(s4);
+
+    if constexpr (W > 1) {
+        if (dim > i) {
+            fallback(query + i, dim - i, c1 + i, c2 + i, c3 + i, c4 + i, r1, r2, r3, r4);
+        }
+    }
+}
+
+}  // namespace vsag::simd

--- a/src/simd/kernels/compute_ip.h
+++ b/src/simd/kernels/compute_ip.h
@@ -1,0 +1,92 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+
+// Pure-template inner-product kernel.
+//
+// Architecture-agnostic: each ISA translation unit instantiates
+// ComputeIPImpl<Traits, Unroll>(...) with its own SimdTraits<>
+// specialization, plus a function-pointer fallback that handles tail
+// elements smaller than one vector. The fallback preserves the
+// project's existing ISA-cascade behaviour (avx512 -> avx2 -> sse ->
+// generic, neon -> generic) so we never lose performance on tail
+// processing.
+//
+// Unroll > 1 gives the kernel multiple independent accumulators in the
+// main loop, breaking the FMA dependency chain. Each ISA picks the
+// unroll factor that matches the manually-unrolled code it replaces.
+
+namespace vsag::simd {
+
+using FloatFallback = float (*)(const float*, const float*, uint64_t);
+
+template <typename T, int Unroll = 1>
+inline float
+ComputeIPImpl(const float* query,
+              const float* codes,
+              uint64_t dim,
+              FloatFallback fallback = nullptr) {
+    using V = typename T::FloatVec;
+    constexpr int W = T::Width;
+    constexpr int Stride = W * Unroll;
+
+    // For W == 1 (generic backend) the dim < W branch is dead code.
+    if constexpr (W > 1) {
+        if (dim < static_cast<uint64_t>(W)) {
+            return fallback(query, codes, dim);
+        }
+    }
+
+    // Main loop with Unroll independent accumulators.
+    V acc[Unroll];
+    for (int u = 0; u < Unroll; ++u) {
+        acc[u] = T::zero();
+    }
+
+    uint64_t i = 0;
+    for (; i + Stride <= dim; i += Stride) {
+        for (int u = 0; u < Unroll; ++u) {
+            acc[u] = T::fmadd(T::load(query + i + u * W), T::load(codes + i + u * W), acc[u]);
+        }
+    }
+
+    V sum = acc[0];
+    for (int u = 1; u < Unroll; ++u) {
+        sum = T::add(sum, acc[u]);
+    }
+
+    // Second-tier loop: remaining whole vectors, single accumulator.
+    if constexpr (Unroll > 1) {
+        for (; i + W <= dim; i += W) {
+            sum = T::fmadd(T::load(query + i), T::load(codes + i), sum);
+        }
+    }
+
+    float result = T::reduce_add(sum);
+
+    // Tail: less than one vector left. Generic backend never reaches
+    // here because W == 1 makes (dim > i) impossible (i increments by W).
+    if constexpr (W > 1) {
+        if (dim > i) {
+            result += fallback(query + i, codes + i, dim - i);
+        }
+    }
+    return result;
+}
+
+}  // namespace vsag::simd

--- a/src/simd/kernels/compute_l2.h
+++ b/src/simd/kernels/compute_l2.h
@@ -1,0 +1,78 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+
+// Pure-template squared-L2 kernel. See compute_ip.h for the rationale
+// behind the Unroll parameter and the fallback function pointer.
+
+namespace vsag::simd {
+
+using FloatFallback = float (*)(const float*, const float*, uint64_t);
+
+template <typename T, int Unroll = 1>
+inline float
+ComputeL2SqrImpl(const float* query,
+                 const float* codes,
+                 uint64_t dim,
+                 FloatFallback fallback = nullptr) {
+    using V = typename T::FloatVec;
+    constexpr int W = T::Width;
+    constexpr int Stride = W * Unroll;
+
+    if constexpr (W > 1) {
+        if (dim < static_cast<uint64_t>(W)) {
+            return fallback(query, codes, dim);
+        }
+    }
+
+    V acc[Unroll];
+    for (int u = 0; u < Unroll; ++u) {
+        acc[u] = T::zero();
+    }
+
+    uint64_t i = 0;
+    for (; i + Stride <= dim; i += Stride) {
+        for (int u = 0; u < Unroll; ++u) {
+            V diff = T::sub(T::load(query + i + u * W), T::load(codes + i + u * W));
+            acc[u] = T::fmadd(diff, diff, acc[u]);
+        }
+    }
+
+    V sum = acc[0];
+    for (int u = 1; u < Unroll; ++u) {
+        sum = T::add(sum, acc[u]);
+    }
+
+    if constexpr (Unroll > 1) {
+        for (; i + W <= dim; i += W) {
+            V diff = T::sub(T::load(query + i), T::load(codes + i));
+            sum = T::fmadd(diff, diff, sum);
+        }
+    }
+
+    float result = T::reduce_add(sum);
+
+    if constexpr (W > 1) {
+        if (dim > i) {
+            result += fallback(query + i, codes + i, dim - i);
+        }
+    }
+    return result;
+}
+
+}  // namespace vsag::simd

--- a/src/simd/kernels/half_compute.h
+++ b/src/simd/kernels/half_compute.h
@@ -1,0 +1,94 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+
+// BF16 distance kernels.
+//
+// BF16ComputeIP:     sum += bf16_to_fp32(query[i]) * bf16_to_fp32(codes[i])
+// BF16ComputeL2Sqr:  sum += (bf16_to_fp32(query[i]) - bf16_to_fp32(codes[i]))^2
+//
+// Parameterized on BF16Traits<ISA>, which must expose:
+//   FloatVec, Width, zero/fmadd/sub/reduce_add  (inherited from SimdTraits)
+//   load_half(const uint16_t* p) -> FloatVec
+//     Load Width bf16 values from p, convert to fp32.
+
+namespace vsag::simd {
+
+template <typename T>
+inline float
+HalfComputeIPImpl(const uint8_t* query,
+                  const uint8_t* codes,
+                  uint64_t dim,
+                  float (*fallback)(const uint8_t*, const uint8_t*, uint64_t) = nullptr) {
+    using V = typename T::FloatVec;
+    constexpr int W = T::Width;
+    const auto* q16 = reinterpret_cast<const uint16_t*>(query);
+    const auto* c16 = reinterpret_cast<const uint16_t*>(codes);
+
+    if constexpr (W > 1) {
+        if (dim < static_cast<uint64_t>(W)) {
+            return fallback ? fallback(query, codes, dim) : 0.0f;
+        }
+    }
+
+    V sum = T::zero();
+    uint64_t i = 0;
+    for (; i + W <= dim; i += W) {
+        V qv = T::load_half(q16 + i);
+        V cv = T::load_half(c16 + i);
+        sum = T::fmadd(qv, cv, sum);
+    }
+    float result = T::reduce_add(sum);
+    if (i < dim && fallback) {
+        result += fallback(query + i * 2, codes + i * 2, dim - i);
+    }
+    return result;
+}
+
+template <typename T>
+inline float
+HalfComputeL2SqrImpl(const uint8_t* query,
+                     const uint8_t* codes,
+                     uint64_t dim,
+                     float (*fallback)(const uint8_t*, const uint8_t*, uint64_t) = nullptr) {
+    using V = typename T::FloatVec;
+    constexpr int W = T::Width;
+    const auto* q16 = reinterpret_cast<const uint16_t*>(query);
+    const auto* c16 = reinterpret_cast<const uint16_t*>(codes);
+
+    if constexpr (W > 1) {
+        if (dim < static_cast<uint64_t>(W)) {
+            return fallback ? fallback(query, codes, dim) : 0.0f;
+        }
+    }
+
+    V sum = T::zero();
+    uint64_t i = 0;
+    for (; i + W <= dim; i += W) {
+        V qv = T::load_half(q16 + i);
+        V cv = T::load_half(c16 + i);
+        V d = T::sub(qv, cv);
+        sum = T::fmadd(d, d, sum);
+    }
+    float result = T::reduce_add(sum);
+    if (i < dim && fallback) {
+        result += fallback(query + i * 2, codes + i * 2, dim - i);
+    }
+    return result;
+}
+
+}  // namespace vsag::simd

--- a/src/simd/kernels/int8_compute.h
+++ b/src/simd/kernels/int8_compute.h
@@ -1,0 +1,103 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+// INT8 inner-product and L2-squared kernels.
+//
+// These are parameterized on Int8Traits<ISA>, which must expose:
+//   Int8HalfVec   - the raw loaded int8 vector (half-width of full vector)
+//   Int16Vec      - int8 widened to int16
+//   Int32Vec      - int32 accumulator
+//   BatchSize     - number of int8 elements per iteration
+//   load_i8(ptr)          -> Int8HalfVec
+//   cvt_i8_to_i16(v)     -> Int16Vec
+//   madd_i16(a, b)        -> Int32Vec   (a[i]*b[i] + a[i+1]*b[i+1] pairwise)
+//   sub_i16(a, b)         -> Int16Vec
+//   add_i32(a, b)         -> Int32Vec
+//   zero_i32()            -> Int32Vec
+//   reduce_add_i32(v)     -> int32_t
+
+#include <cstdint>
+
+namespace vsag::simd {
+
+using Int8Fallback = float (*)(const int8_t*, const int8_t*, uint64_t);
+
+template <typename T>
+inline float
+Int8ComputeIPImpl(const int8_t* query,
+                  const int8_t* codes,
+                  uint64_t dim,
+                  Int8Fallback fallback = nullptr) {
+    using I32 = typename T::Int32Vec;
+    constexpr int B = T::BatchSize;
+
+    const uint64_t n = dim / B;
+    if (n == 0) {
+        if (fallback) {
+            return fallback(query, codes, dim);
+        }
+        return 0.0f;
+    }
+
+    I32 sum = T::zero_i32();
+    for (uint64_t i = 0; i < n; ++i) {
+        auto q = T::cvt_i8_to_i16(T::load_i8(query + B * i));
+        auto c = T::cvt_i8_to_i16(T::load_i8(codes + B * i));
+        sum = T::add_i32(sum, T::madd_i16(q, c));
+    }
+
+    auto result = static_cast<float>(T::reduce_add_i32(sum));
+    uint64_t tail = dim - B * n;
+    if (tail > 0 && fallback) {
+        result += fallback(query + B * n, codes + B * n, tail);
+    }
+    return result;
+}
+
+template <typename T>
+inline float
+Int8ComputeL2SqrImpl(const int8_t* query,
+                     const int8_t* codes,
+                     uint64_t dim,
+                     Int8Fallback fallback = nullptr) {
+    using I32 = typename T::Int32Vec;
+    constexpr int B = T::BatchSize;
+
+    const uint64_t n = dim / B;
+    if (n == 0) {
+        if (fallback) {
+            return fallback(query, codes, dim);
+        }
+        return 0.0f;
+    }
+
+    I32 sum = T::zero_i32();
+    for (uint64_t i = 0; i < n; ++i) {
+        auto q = T::cvt_i8_to_i16(T::load_i8(query + B * i));
+        auto c = T::cvt_i8_to_i16(T::load_i8(codes + B * i));
+        auto diff = T::sub_i16(q, c);
+        sum = T::add_i32(sum, T::madd_i16(diff, diff));
+    }
+
+    auto result = static_cast<float>(T::reduce_add_i32(sum));
+    uint64_t tail = dim - B * n;
+    if (tail > 0 && fallback) {
+        result += fallback(query + B * n, codes + B * n, tail);
+    }
+    return result;
+}
+
+}  // namespace vsag::simd

--- a/src/simd/kernels/kernels.h
+++ b/src/simd/kernels/kernels.h
@@ -1,0 +1,34 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "binary_op.h"
+#include "bit_op.h"
+#include "butterfly.h"
+#include "compute_batch4.h"
+#include "compute_ip.h"
+#include "compute_l2.h"
+#include "half_compute.h"
+#include "int8_compute.h"
+#include "normalize.h"
+#include "pq_distance.h"
+#include "rabitq_compute.h"
+#include "reduce_add.h"
+#include "scalar_op.h"
+#include "sq4_compute.h"
+#include "sq4_uniform_compute.h"
+#include "sq8_compute.h"
+#include "sq8_uniform_compute.h"

--- a/src/simd/kernels/normalize.h
+++ b/src/simd/kernels/normalize.h
@@ -1,0 +1,121 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+// Normalize-family kernels:
+//   NormalizeWithCentroid:        to[i] = (from[i] - centroid[i]) / norm
+//   InverseNormalizeWithCentroid: to[i] = from[i] * norm + centroid[i]
+//
+// Both require traits with set1() for scalar broadcast.
+// NormalizeWithCentroid computes norm = sqrt(L2Sqr(from, centroid, dim))
+// internally, using the template-based L2 kernel for the distance part.
+
+#include <cmath>
+#include <cstdint>
+
+namespace vsag::simd {
+
+using NormCentroidFallback = float (*)(const float*, const float*, float*, uint64_t);
+using InvNormCentroidFallback = void (*)(const float*, const float*, float*, uint64_t, float);
+
+// NormalizeWithCentroid: compute norm = sqrt(sum((from-centroid)^2)),
+// then to = (from - centroid) / norm. Returns norm.
+template <typename T>
+inline float
+NormalizeWithCentroidImpl(const float* from,
+                          const float* centroid,
+                          float* to,
+                          uint64_t dim,
+                          NormCentroidFallback fallback = nullptr) {
+    using V = typename T::FloatVec;
+    constexpr int W = T::Width;
+
+    if constexpr (W > 1) {
+        if (dim < static_cast<uint64_t>(W)) {
+            return fallback(from, centroid, to, dim);
+        }
+    }
+
+    // Phase 1: compute norm_sq = sum((from - centroid)^2)
+    V sum = T::zero();
+    uint64_t i = 0;
+    for (; i + W <= dim; i += W) {
+        V f = T::load(from + i);
+        V c = T::load(centroid + i);
+        V diff = T::sub(f, c);
+        sum = T::fmadd(diff, diff, sum);
+    }
+    float norm_sq = T::reduce_add(sum);
+    // Scalar tail for norm computation
+    for (uint64_t j = i; j < dim; ++j) {
+        float d = from[j] - centroid[j];
+        norm_sq += d * d;
+    }
+
+    float norm = (norm_sq < 1e-5f) ? 1.0f : std::sqrt(norm_sq);
+
+    // Phase 2: to = (from - centroid) / norm
+    V normVec = T::set1(norm);
+    for (i = 0; i + W <= dim; i += W) {
+        V f = T::load(from + i);
+        V c = T::load(centroid + i);
+        V diff = T::sub(f, c);
+        T::store(to + i, T::div(diff, normVec));
+    }
+    // Scalar tail for division
+    for (uint64_t j = i; j < dim; ++j) {
+        to[j] = (from[j] - centroid[j]) / norm;
+    }
+
+    return norm;
+}
+
+// InverseNormalizeWithCentroid: to[i] = from[i] * norm + centroid[i]
+template <typename T>
+inline void
+InverseNormalizeWithCentroidImpl(const float* from,
+                                 const float* centroid,
+                                 float* to,
+                                 uint64_t dim,
+                                 float norm,
+                                 InvNormCentroidFallback fallback = nullptr) {
+    using V = typename T::FloatVec;
+    constexpr int W = T::Width;
+
+    if constexpr (W > 1) {
+        if (dim < static_cast<uint64_t>(W)) {
+            fallback(from, centroid, to, dim, norm);
+            return;
+        }
+    }
+
+    V normVec = T::set1(norm);
+    uint64_t i = 0;
+    for (; i + W <= dim; i += W) {
+        V f = T::load(from + i);
+        V c = T::load(centroid + i);
+        T::store(to + i, T::fmadd(f, normVec, c));
+    }
+
+    if constexpr (W > 1) {
+        if (dim > i) {
+            for (uint64_t j = i; j < dim; ++j) {
+                to[j] = from[j] * norm + centroid[j];
+            }
+        }
+    }
+}
+
+}  // namespace vsag::simd

--- a/src/simd/kernels/pq_distance.h
+++ b/src/simd/kernels/pq_distance.h
@@ -1,0 +1,54 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+
+// PQ distance kernel: for each of the 256 float centers, compute
+//   result[i] += (centers[i] - query_val)^2
+//
+// This is the core of PQ distance table construction. Parameterized
+// on SimdTraits<Tag> which must expose: FloatVec, Width, set1, load,
+// sub, mul, add, store.
+
+namespace vsag::simd {
+
+using PQDistFallback = void (*)(const void*, float, void*);
+
+template <typename T>
+inline void
+PQDistanceFloat256Impl(const void* single_dim_centers,
+                       float single_dim_val,
+                       void* result,
+                       PQDistFallback fallback = nullptr) {
+    using V = typename T::FloatVec;
+    constexpr int W = T::Width;
+
+    const auto* float_centers = static_cast<const float*>(single_dim_centers);
+    auto* float_result = static_cast<float*>(result);
+
+    V v_query = T::set1(single_dim_val);
+
+    for (uint64_t idx = 0; idx < 256; idx += W) {
+        V v_centers = T::load(float_centers + idx);
+        V v_diff = T::sub(v_centers, v_query);
+        V v_diff_sq = T::mul(v_diff, v_diff);
+        V v_chunk = T::load(float_result + idx);
+        v_chunk = T::add(v_chunk, v_diff_sq);
+        T::store(float_result + idx, v_chunk);
+    }
+}
+
+}  // namespace vsag::simd

--- a/src/simd/kernels/rabitq_compute.h
+++ b/src/simd/kernels/rabitq_compute.h
@@ -1,0 +1,179 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+
+namespace vsag::simd {
+
+// T must satisfy RaBitQTraits: inherits SimdTraits + provides:
+//   static FloatVec bits_to_signed(const uint8_t* bit_ptr, FloatVec pos, FloatVec neg)
+//   static FloatVec bits_select(const uint8_t* bit_ptr, FloatVec weight)
+//
+// For RaBitQFloatBinaryIP: load float vec, decode bits to ±inv_sqrt_d, fmadd accumulate.
+template <typename T>
+inline float
+RaBitQFloatBinaryIPImpl(const float* vector,
+                        const uint8_t* bits,
+                        uint64_t dim,
+                        float inv_sqrt_d,
+                        float (*fallback)(const float*, const uint8_t*, uint64_t, float)) {
+    if (dim == 0) {
+        return 0.0f;
+    }
+
+    constexpr int W = T::Width;
+    if (dim < static_cast<uint64_t>(W)) {
+        return fallback(vector, bits, dim, inv_sqrt_d);
+    }
+
+    auto sum = T::zero();
+    auto pos = inv_sqrt_d > 1e-3f ? T::set1(inv_sqrt_d) : T::set1(1.0f);
+    auto neg = inv_sqrt_d > 1e-3f ? T::set1(-inv_sqrt_d) : T::zero();
+
+    uint64_t d = 0;
+    for (; d + W <= dim; d += W) {
+        auto vec = T::load(vector + d);
+        auto b_vec = T::bits_to_signed(bits + (d >> 3), pos, neg);
+        sum = T::fmadd(b_vec, vec, sum);
+    }
+
+    float result = T::reduce_add(sum);
+
+    if (d < dim) {
+        result += fallback(vector + d, bits + (d >> 3), dim - d, inv_sqrt_d);
+    }
+
+    return result;
+}
+
+template <typename T>
+inline void
+RaBitQFloatBinaryIPBatch4Impl(const float* vector,
+                              const uint8_t* bits1,
+                              const uint8_t* bits2,
+                              const uint8_t* bits3,
+                              const uint8_t* bits4,
+                              uint64_t dim,
+                              float inv_sqrt_d,
+                              float* results,
+                              void (*fallback)(const float*,
+                                               const uint8_t*,
+                                               const uint8_t*,
+                                               const uint8_t*,
+                                               const uint8_t*,
+                                               uint64_t,
+                                               float,
+                                               float*)) {
+    if (dim == 0) {
+        results[0] = results[1] = results[2] = results[3] = 0.0f;
+        return;
+    }
+
+    constexpr int W = T::Width;
+    if (dim < static_cast<uint64_t>(W)) {
+        fallback(vector, bits1, bits2, bits3, bits4, dim, inv_sqrt_d, results);
+        return;
+    }
+
+    auto pos = inv_sqrt_d > 1e-3f ? T::set1(inv_sqrt_d) : T::set1(1.0f);
+    auto neg = inv_sqrt_d > 1e-3f ? T::set1(-inv_sqrt_d) : T::zero();
+    typename T::FloatVec sums[4] = {T::zero(), T::zero(), T::zero(), T::zero()};
+    const uint8_t* all_bits[4] = {bits1, bits2, bits3, bits4};
+
+    uint64_t d = 0;
+    for (; d + W <= dim; d += W) {
+        auto vec = T::load(vector + d);
+        uint64_t byte_id = d >> 3;
+        for (uint32_t i = 0; i < 4; ++i) {
+            auto binary = T::bits_to_signed(all_bits[i] + byte_id, pos, neg);
+            sums[i] = T::fmadd(binary, vec, sums[i]);
+        }
+    }
+
+    for (uint32_t i = 0; i < 4; ++i) {
+        results[i] = T::reduce_add(sums[i]);
+    }
+
+    if (d < dim) {
+        float tail[4];
+        fallback(vector + d,
+                 bits1 + (d >> 3),
+                 bits2 + (d >> 3),
+                 bits3 + (d >> 3),
+                 bits4 + (d >> 3),
+                 dim - d,
+                 inv_sqrt_d,
+                 tail);
+        for (uint32_t i = 0; i < 4; ++i) {
+            results[i] += tail[i];
+        }
+    }
+}
+
+template <typename T>
+inline float
+RaBitQFloatSplitCodeIPImpl(const float* vector,
+                           const uint8_t* one_bit_code,
+                           const uint8_t* supplement_code,
+                           uint64_t dim,
+                           uint32_t supplement_bits) {
+    if (dim == 0) {
+        return 0.0f;
+    }
+
+    constexpr int W = T::Width;
+    const uint64_t plane_bytes = (dim + 7) / 8;
+    auto sum = T::zero();
+
+    uint64_t d = 0;
+    for (; d + W <= dim; d += W) {
+        const uint64_t byte_idx = d >> 3;
+        auto code = T::zero();
+
+        for (uint32_t bit = 0; bit < supplement_bits; ++bit) {
+            const auto* plane = supplement_code + static_cast<uint64_t>(bit) * plane_bytes;
+            auto weight = T::set1(static_cast<float>(1U << bit));
+            code = T::add(code, T::bits_select(plane + byte_idx, weight));
+        }
+
+        auto one_bit_weight = T::set1(static_cast<float>(1U << supplement_bits));
+        code = T::add(code, T::bits_select(one_bit_code + byte_idx, one_bit_weight));
+
+        auto vec = T::load(vector + d);
+        sum = T::fmadd(code, vec, sum);
+    }
+
+    float result = T::reduce_add(sum);
+
+    const uint32_t one_bit_scalar_weight = 1U << supplement_bits;
+    for (; d < dim; ++d) {
+        const uint64_t byte_idx = d >> 3;
+        const uint8_t bit_mask = static_cast<uint8_t>(1U << (d & 7));
+        uint32_t code = (one_bit_code[byte_idx] & bit_mask) != 0 ? one_bit_scalar_weight : 0U;
+        for (uint32_t bit = 0; bit < supplement_bits; ++bit) {
+            const auto* plane = supplement_code + static_cast<uint64_t>(bit) * plane_bytes;
+            if ((plane[byte_idx] & bit_mask) != 0) {
+                code += 1U << bit;
+            }
+        }
+        result += vector[d] * static_cast<float>(code);
+    }
+
+    return result;
+}
+
+}  // namespace vsag::simd

--- a/src/simd/kernels/reduce_add.h
+++ b/src/simd/kernels/reduce_add.h
@@ -1,0 +1,53 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+// Reduce-add kernel: sum(x[0..dim-1]).
+// Used by FP32ReduceAdd across all ISAs.
+
+#include <cstdint>
+
+namespace vsag::simd {
+
+using ReduceFallback = float (*)(const float*, uint64_t);
+
+template <typename T>
+inline float
+ReduceAddImpl(const float* x, uint64_t dim, ReduceFallback fallback = nullptr) {
+    using V = typename T::FloatVec;
+    constexpr int W = T::Width;
+
+    if constexpr (W > 1) {
+        if (dim < static_cast<uint64_t>(W)) {
+            return fallback(x, dim);
+        }
+    }
+
+    V sum = T::zero();
+    uint64_t i = 0;
+    for (; i + W <= dim; i += W) {
+        sum = T::add(sum, T::load(x + i));
+    }
+    float result = T::reduce_add(sum);
+    if constexpr (W > 1) {
+        if (dim > i) {
+            result += fallback(x + i, dim - i);
+        }
+    }
+    return result;
+}
+
+}  // namespace vsag::simd

--- a/src/simd/kernels/scalar_op.h
+++ b/src/simd/kernels/scalar_op.h
@@ -1,0 +1,92 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+// Scalar-broadcast kernels: to[i] = from[i] / scalar (DivScalar)
+//                           data[i] *= val (VecRescale)
+//
+// These require traits to expose set1(float) in addition to the base
+// interface. The fallback handles tail elements via the next-narrower ISA.
+
+#include <cstdint>
+
+namespace vsag::simd {
+
+using ScalarFallback = void (*)(const float*, float*, uint64_t, float);
+using RescaleFallback = void (*)(float*, uint64_t, float);
+
+template <typename T>
+inline void
+DivScalarImpl(
+    const float* from, float* to, uint64_t dim, float scalar, ScalarFallback fallback = nullptr) {
+    using V = typename T::FloatVec;
+    constexpr int W = T::Width;
+
+    if (dim == 0) {
+        return;
+    }
+    if (scalar == 0) {
+        scalar = 1.0f;
+    }
+
+    if constexpr (W > 1) {
+        if (dim < static_cast<uint64_t>(W)) {
+            fallback(from, to, dim, scalar);
+            return;
+        }
+    }
+
+    V scalarVec = T::set1(scalar);
+    uint64_t i = 0;
+    for (; i + W <= dim; i += W) {
+        V vec = T::load(from + i);
+        T::store(to + i, T::div(vec, scalarVec));
+    }
+
+    if constexpr (W > 1) {
+        if (dim > i) {
+            fallback(from + i, to + i, dim - i, scalar);
+        }
+    }
+}
+
+template <typename T>
+inline void
+VecRescaleImpl(float* data, uint64_t dim, float val, RescaleFallback fallback = nullptr) {
+    using V = typename T::FloatVec;
+    constexpr int W = T::Width;
+
+    if constexpr (W > 1) {
+        if (dim < static_cast<uint64_t>(W)) {
+            fallback(data, dim, val);
+            return;
+        }
+    }
+
+    V scalarVec = T::set1(val);
+    uint64_t i = 0;
+    for (; i + W <= dim; i += W) {
+        V vec = T::load(data + i);
+        T::store(data + i, T::mul(vec, scalarVec));
+    }
+
+    if constexpr (W > 1) {
+        if (dim > i) {
+            fallback(data + i, dim - i, val);
+        }
+    }
+}
+
+}  // namespace vsag::simd

--- a/src/simd/kernels/sq4_compute.h
+++ b/src/simd/kernels/sq4_compute.h
@@ -1,0 +1,185 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+
+namespace vsag::simd {
+
+template <typename T>
+inline float
+SQ4ComputeIPImpl(const float* query,
+                 const uint8_t* codes,
+                 const float* lower_bound,
+                 const float* diff,
+                 uint64_t dim,
+                 float (*fallback)(const float*,
+                                   const uint8_t*,
+                                   const float*,
+                                   const float*,
+                                   uint64_t) = nullptr) {
+    using V = typename T::FloatVec;
+    constexpr int W = T::Width;
+    constexpr int STEP = 2 * W;
+    if (dim < static_cast<uint64_t>(STEP)) {
+        return fallback ? fallback(query, codes, lower_bound, diff, dim) : 0.0f;
+    }
+    V sum = T::zero();
+    uint64_t d = 0;
+    for (; d + STEP <= dim; d += STEP) {
+        V dec0, dec1;
+        T::load_nibbles_2x_as_float(codes + (d >> 1), dec0, dec1);
+        V val0 = T::fmadd(dec0, T::load(diff + d), T::load(lower_bound + d));
+        V val1 = T::fmadd(dec1, T::load(diff + d + W), T::load(lower_bound + d + W));
+        sum = T::fmadd(T::load(query + d), val0, sum);
+        sum = T::fmadd(T::load(query + d + W), val1, sum);
+    }
+    float result = T::reduce_add(sum);
+    if (d < dim) {
+        if (fallback)
+            result += fallback(query + d, codes + (d >> 1), lower_bound + d, diff + d, dim - d);
+    }
+    return result;
+}
+
+template <typename T>
+inline float
+SQ4ComputeL2SqrImpl(const float* query,
+                    const uint8_t* codes,
+                    const float* lower_bound,
+                    const float* diff,
+                    uint64_t dim,
+                    float (*fallback)(const float*,
+                                      const uint8_t*,
+                                      const float*,
+                                      const float*,
+                                      uint64_t) = nullptr) {
+    using V = typename T::FloatVec;
+    constexpr int W = T::Width;
+    constexpr int STEP = 2 * W;
+    if (dim < static_cast<uint64_t>(STEP)) {
+        return fallback ? fallback(query, codes, lower_bound, diff, dim) : 0.0f;
+    }
+    V sum = T::zero();
+    uint64_t d = 0;
+    for (; d + STEP <= dim; d += STEP) {
+        V dec0, dec1;
+        T::load_nibbles_2x_as_float(codes + (d >> 1), dec0, dec1);
+        V val0 = T::fmadd(dec0, T::load(diff + d), T::load(lower_bound + d));
+        V val1 = T::fmadd(dec1, T::load(diff + d + W), T::load(lower_bound + d + W));
+        V d0 = T::sub(T::load(query + d), val0);
+        V d1 = T::sub(T::load(query + d + W), val1);
+        sum = T::fmadd(d0, d0, sum);
+        sum = T::fmadd(d1, d1, sum);
+    }
+    float result = T::reduce_add(sum);
+    if (d < dim) {
+        if (fallback)
+            result += fallback(query + d, codes + (d >> 1), lower_bound + d, diff + d, dim - d);
+    }
+    return result;
+}
+
+template <typename T>
+inline float
+SQ4ComputeCodesIPImpl(const uint8_t* codes1,
+                      const uint8_t* codes2,
+                      const float* lower_bound,
+                      const float* diff,
+                      uint64_t dim,
+                      float (*fallback)(const uint8_t*,
+                                        const uint8_t*,
+                                        const float*,
+                                        const float*,
+                                        uint64_t) = nullptr) {
+    using V = typename T::FloatVec;
+    constexpr int W = T::Width;
+    constexpr int STEP = 2 * W;
+    if (dim < static_cast<uint64_t>(STEP)) {
+        return fallback ? fallback(codes1, codes2, lower_bound, diff, dim) : 0.0f;
+    }
+    V sum = T::zero();
+    uint64_t d = 0;
+    for (; d + STEP <= dim; d += STEP) {
+        V dec1_0, dec1_1, dec2_0, dec2_1;
+        T::load_nibbles_2x_as_float(codes1 + (d >> 1), dec1_0, dec1_1);
+        T::load_nibbles_2x_as_float(codes2 + (d >> 1), dec2_0, dec2_1);
+        V diff0 = T::load(diff + d);
+        V diff1 = T::load(diff + d + W);
+        V lb0 = T::load(lower_bound + d);
+        V lb1 = T::load(lower_bound + d + W);
+        V a0 = T::fmadd(dec1_0, diff0, lb0);
+        V a1 = T::fmadd(dec1_1, diff1, lb1);
+        V b0 = T::fmadd(dec2_0, diff0, lb0);
+        V b1 = T::fmadd(dec2_1, diff1, lb1);
+        sum = T::fmadd(a0, b0, sum);
+        sum = T::fmadd(a1, b1, sum);
+    }
+    float result = T::reduce_add(sum);
+    if (d < dim) {
+        if (fallback)
+            result +=
+                fallback(codes1 + (d >> 1), codes2 + (d >> 1), lower_bound + d, diff + d, dim - d);
+    }
+    return result;
+}
+
+template <typename T>
+inline float
+SQ4ComputeCodesL2SqrImpl(const uint8_t* codes1,
+                         const uint8_t* codes2,
+                         const float* lower_bound,
+                         const float* diff,
+                         uint64_t dim,
+                         float (*fallback)(const uint8_t*,
+                                           const uint8_t*,
+                                           const float*,
+                                           const float*,
+                                           uint64_t) = nullptr) {
+    using V = typename T::FloatVec;
+    constexpr int W = T::Width;
+    constexpr int STEP = 2 * W;
+    if (dim < static_cast<uint64_t>(STEP)) {
+        return fallback ? fallback(codes1, codes2, lower_bound, diff, dim) : 0.0f;
+    }
+    V sum = T::zero();
+    uint64_t d = 0;
+    for (; d + STEP <= dim; d += STEP) {
+        V dec1_0, dec1_1, dec2_0, dec2_1;
+        T::load_nibbles_2x_as_float(codes1 + (d >> 1), dec1_0, dec1_1);
+        T::load_nibbles_2x_as_float(codes2 + (d >> 1), dec2_0, dec2_1);
+        V diff0 = T::load(diff + d);
+        V diff1 = T::load(diff + d + W);
+        V lb0 = T::load(lower_bound + d);
+        V lb1 = T::load(lower_bound + d + W);
+        V a0 = T::fmadd(dec1_0, diff0, lb0);
+        V a1 = T::fmadd(dec1_1, diff1, lb1);
+        V b0 = T::fmadd(dec2_0, diff0, lb0);
+        V b1 = T::fmadd(dec2_1, diff1, lb1);
+        V e0 = T::sub(a0, b0);
+        V e1 = T::sub(a1, b1);
+        sum = T::fmadd(e0, e0, sum);
+        sum = T::fmadd(e1, e1, sum);
+    }
+    float result = T::reduce_add(sum);
+    if (d < dim) {
+        if (fallback)
+            result +=
+                fallback(codes1 + (d >> 1), codes2 + (d >> 1), lower_bound + d, diff + d, dim - d);
+    }
+    return result;
+}
+
+}  // namespace vsag::simd

--- a/src/simd/kernels/sq4_uniform_compute.h
+++ b/src/simd/kernels/sq4_uniform_compute.h
@@ -1,0 +1,61 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+
+namespace vsag::simd {
+
+// T must satisfy UniformCodeTraits: IntVec, ByteWidth, loadu, zero, set1_epi8,
+// and_si, srli_epi16, maddubs_epi16, add_epi16, reduce_add_epi16.
+template <typename T>
+inline float
+SQ4UniformComputeCodesIPImpl(const uint8_t* codes1,
+                             const uint8_t* codes2,
+                             uint64_t dim,
+                             float (*fallback)(const uint8_t*, const uint8_t*, uint64_t)) {
+    if (dim == 0) {
+        return 0;
+    }
+
+    constexpr uint64_t kElemsPerIter = T::ByteWidth * 2;
+    int32_t result = 0;
+    uint64_t d = 0;
+    auto sum = T::zero();
+    auto mask = T::set1_epi8(0x0f);
+
+    for (; d + kElemsPerIter - 1 < dim; d += kElemsPerIter) {
+        auto xx = T::loadu(codes1 + (d >> 1));
+        auto yy = T::loadu(codes2 + (d >> 1));
+        auto xx1 = T::and_si(xx, mask);
+        auto xx2 = T::and_si(T::srli_epi16(xx, 4), mask);
+        auto yy1 = T::and_si(yy, mask);
+        auto yy2 = T::and_si(T::srli_epi16(yy, 4), mask);
+
+        sum = T::add_epi16(sum, T::maddubs_epi16(xx1, yy1));
+        sum = T::add_epi16(sum, T::maddubs_epi16(xx2, yy2));
+    }
+
+    result += T::reduce_add_epi16(sum);
+
+    if (d < dim) {
+        result += fallback(codes1 + (d >> 1), codes2 + (d >> 1), dim - d);
+    }
+
+    return result;
+}
+
+}  // namespace vsag::simd

--- a/src/simd/kernels/sq8_compute.h
+++ b/src/simd/kernels/sq8_compute.h
@@ -1,0 +1,236 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+
+// SQ8 quantized distance kernels.
+//
+// SQ8ComputeIP:  sum += query[i] * (codes[i]/255 * diff[i] + lower_bound[i])
+// SQ8ComputeL2Sqr: sum += (query[i] - (codes[i]/255 * diff[i] + lower_bound[i]))^2
+// SQ8ComputeCodesIP: sum += adj1[i] * adj2[i]   where adj = codes/255*diff+lb
+// SQ8ComputeCodesL2Sqr: sum += (adj1[i] - adj2[i])^2
+//
+// Parameterized on SQ8Traits<ISA>, which must expose:
+//   FloatVec        - SIMD float vector type
+//   Width           - number of float elements per vector
+//   load_u8_as_float(const uint8_t* p) -> FloatVec
+//                    Load Width uint8 values, zero-extend, convert to float
+//   zero()          -> FloatVec
+//   set1(float)     -> FloatVec
+//   load(const float* p) -> FloatVec
+//   mul(FloatVec, FloatVec) -> FloatVec
+//   add(FloatVec, FloatVec) -> FloatVec
+//   sub(FloatVec, FloatVec) -> FloatVec
+//   fmadd(FloatVec a, FloatVec b, FloatVec c) -> FloatVec  (a*b+c)
+//   reduce_add(FloatVec) -> float
+
+namespace vsag::simd {
+
+// --- SQ8ComputeIP ---
+
+template <typename T>
+inline float
+SQ8ComputeIPImpl(const float* query,
+                 const uint8_t* codes,
+                 const float* lower_bound,
+                 const float* diff,
+                 uint64_t dim,
+                 float (*fallback)(const float*,
+                                   const uint8_t*,
+                                   const float*,
+                                   const float*,
+                                   uint64_t) = nullptr) {
+    using V = typename T::FloatVec;
+    constexpr int W = T::Width;
+
+    if constexpr (W > 1) {
+        if (dim < static_cast<uint64_t>(W)) {
+            return fallback(query, codes, lower_bound, diff, dim);
+        }
+    }
+
+    V sum = T::zero();
+    V inv255 = T::set1(1.0f / 255.0f);
+
+    uint64_t i = 0;
+    for (; i + W <= dim; i += W) {
+        V code_floats = T::load_u8_as_float(codes + i);
+        V query_vals = T::load(query + i);
+        V diff_vals = T::load(diff + i);
+        V lb_vals = T::load(lower_bound + i);
+
+        V normalized = T::mul(code_floats, inv255);
+        V adjusted = T::fmadd(normalized, diff_vals, lb_vals);
+        sum = T::fmadd(query_vals, adjusted, sum);
+    }
+
+    float result = T::reduce_add(sum);
+
+    if constexpr (W > 1) {
+        if (i < dim) {
+            result += fallback(query + i, codes + i, lower_bound + i, diff + i, dim - i);
+        }
+    }
+    return result;
+}
+
+// --- SQ8ComputeL2Sqr ---
+
+template <typename T>
+inline float
+SQ8ComputeL2SqrImpl(const float* query,
+                    const uint8_t* codes,
+                    const float* lower_bound,
+                    const float* diff,
+                    uint64_t dim,
+                    float (*fallback)(const float*,
+                                      const uint8_t*,
+                                      const float*,
+                                      const float*,
+                                      uint64_t) = nullptr) {
+    using V = typename T::FloatVec;
+    constexpr int W = T::Width;
+
+    if constexpr (W > 1) {
+        if (dim < static_cast<uint64_t>(W)) {
+            return fallback(query, codes, lower_bound, diff, dim);
+        }
+    }
+
+    V sum = T::zero();
+    V inv255 = T::set1(1.0f / 255.0f);
+
+    uint64_t i = 0;
+    for (; i + W <= dim; i += W) {
+        V code_floats = T::load_u8_as_float(codes + i);
+        V query_vals = T::load(query + i);
+        V diff_vals = T::load(diff + i);
+        V lb_vals = T::load(lower_bound + i);
+
+        V normalized = T::mul(code_floats, inv255);
+        V adjusted = T::fmadd(normalized, diff_vals, lb_vals);
+        V d = T::sub(query_vals, adjusted);
+        sum = T::fmadd(d, d, sum);
+    }
+
+    float result = T::reduce_add(sum);
+
+    if constexpr (W > 1) {
+        if (i < dim) {
+            result += fallback(query + i, codes + i, lower_bound + i, diff + i, dim - i);
+        }
+    }
+    return result;
+}
+
+// --- SQ8ComputeCodesIP ---
+
+template <typename T>
+inline float
+SQ8ComputeCodesIPImpl(const uint8_t* codes1,
+                      const uint8_t* codes2,
+                      const float* lower_bound,
+                      const float* diff,
+                      uint64_t dim,
+                      float (*fallback)(const uint8_t*,
+                                        const uint8_t*,
+                                        const float*,
+                                        const float*,
+                                        uint64_t) = nullptr) {
+    using V = typename T::FloatVec;
+    constexpr int W = T::Width;
+
+    if constexpr (W > 1) {
+        if (dim < static_cast<uint64_t>(W)) {
+            return fallback(codes1, codes2, lower_bound, diff, dim);
+        }
+    }
+
+    V sum = T::zero();
+    V inv255 = T::set1(1.0f / 255.0f);
+
+    uint64_t i = 0;
+    for (; i + W <= dim; i += W) {
+        V c1_floats = T::load_u8_as_float(codes1 + i);
+        V c2_floats = T::load_u8_as_float(codes2 + i);
+        V diff_vals = T::load(diff + i);
+        V lb_vals = T::load(lower_bound + i);
+
+        V adj1 = T::fmadd(T::mul(c1_floats, inv255), diff_vals, lb_vals);
+        V adj2 = T::fmadd(T::mul(c2_floats, inv255), diff_vals, lb_vals);
+        sum = T::fmadd(adj1, adj2, sum);
+    }
+
+    float result = T::reduce_add(sum);
+
+    if constexpr (W > 1) {
+        if (i < dim) {
+            result += fallback(codes1 + i, codes2 + i, lower_bound + i, diff + i, dim - i);
+        }
+    }
+    return result;
+}
+
+// --- SQ8ComputeCodesL2Sqr ---
+
+template <typename T>
+inline float
+SQ8ComputeCodesL2SqrImpl(const uint8_t* codes1,
+                         const uint8_t* codes2,
+                         const float* lower_bound,
+                         const float* diff,
+                         uint64_t dim,
+                         float (*fallback)(const uint8_t*,
+                                           const uint8_t*,
+                                           const float*,
+                                           const float*,
+                                           uint64_t) = nullptr) {
+    using V = typename T::FloatVec;
+    constexpr int W = T::Width;
+
+    if constexpr (W > 1) {
+        if (dim < static_cast<uint64_t>(W)) {
+            return fallback(codes1, codes2, lower_bound, diff, dim);
+        }
+    }
+
+    V sum = T::zero();
+    V inv255 = T::set1(1.0f / 255.0f);
+
+    uint64_t i = 0;
+    for (; i + W <= dim; i += W) {
+        V c1_floats = T::load_u8_as_float(codes1 + i);
+        V c2_floats = T::load_u8_as_float(codes2 + i);
+        V diff_vals = T::load(diff + i);
+        V lb_vals = T::load(lower_bound + i);
+
+        V adj1 = T::fmadd(T::mul(c1_floats, inv255), diff_vals, lb_vals);
+        V adj2 = T::fmadd(T::mul(c2_floats, inv255), diff_vals, lb_vals);
+        V d = T::sub(adj1, adj2);
+        sum = T::fmadd(d, d, sum);
+    }
+
+    float result = T::reduce_add(sum);
+
+    if constexpr (W > 1) {
+        if (i < dim) {
+            result += fallback(codes1 + i, codes2 + i, lower_bound + i, diff + i, dim - i);
+        }
+    }
+    return result;
+}
+
+}  // namespace vsag::simd

--- a/src/simd/kernels/sq8_uniform_compute.h
+++ b/src/simd/kernels/sq8_uniform_compute.h
@@ -1,0 +1,61 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+
+namespace vsag::simd {
+
+// T must satisfy UniformCodeTraits: IntVec, ByteWidth, loadu, zero, set1_epi16,
+// and_si, srli_epi16, madd_epi16, add_epi32, reduce_add_epi32.
+template <typename T>
+inline float
+SQ8UniformComputeCodesIPImpl(const uint8_t* codes1,
+                             const uint8_t* codes2,
+                             uint64_t dim,
+                             float (*fallback)(const uint8_t*, const uint8_t*, uint64_t)) {
+    if (dim == 0) {
+        return 0.0f;
+    }
+
+    constexpr uint64_t kElemsPerIter = T::ByteWidth;
+    uint64_t d = 0;
+    auto sum = T::zero();
+    auto mask = T::set1_epi16(0xff);
+
+    for (; d + kElemsPerIter - 1 < dim; d += kElemsPerIter) {
+        auto xx = T::loadu(codes1 + d);
+        auto yy = T::loadu(codes2 + d);
+
+        auto xx1 = T::and_si(xx, mask);
+        auto xx2 = T::srli_epi16(xx, 8);
+        auto yy1 = T::and_si(yy, mask);
+        auto yy2 = T::srli_epi16(yy, 8);
+
+        sum = T::add_epi32(sum, T::madd_epi16(xx1, yy1));
+        sum = T::add_epi32(sum, T::madd_epi16(xx2, yy2));
+    }
+
+    int32_t result = T::reduce_add_epi32(sum);
+
+    if (d < dim) {
+        result += static_cast<int32_t>(fallback(codes1 + d, codes2 + d, dim - d));
+    }
+
+    return static_cast<float>(result);
+}
+
+}  // namespace vsag::simd

--- a/src/simd/neon.cpp
+++ b/src/simd/neon.cpp
@@ -15,6 +15,9 @@
 #include "simd/int8_simd.h"
 #if defined(ENABLE_NEON)
 #include <arm_neon.h>
+
+#include "simd/kernels/kernels.h"
+#include "simd/traits/simd_traits_neon.h"
 #endif
 
 #include <cmath>
@@ -107,25 +110,8 @@ __inline float32x4_t __attribute__((__always_inline__)) vcvt_f32_half(const uint
 void
 PQDistanceFloat256(const void* single_dim_centers, float single_dim_val, void* result) {
 #if defined(ENABLE_NEON)
-    const auto* float_centers = (const float*)single_dim_centers;
-    auto* float_result = (float*)result;
-    for (uint64_t idx = 0; idx < 256; idx += 8) {
-        float32x4x2_t v_centers_dim = vld1q_f32_x2(float_centers + idx);
-        float32x4x2_t v_query_vec = {vdupq_n_f32(single_dim_val), vdupq_n_f32(single_dim_val)};
-
-        float32x4x2_t v_diff;
-        v_diff.val[0] = vsubq_f32(v_centers_dim.val[0], v_query_vec.val[0]);
-        v_diff.val[1] = vsubq_f32(v_centers_dim.val[1], v_query_vec.val[1]);
-
-        float32x4x2_t v_diff_sq;
-        v_diff_sq.val[0] = vmulq_f32(v_diff.val[0], v_diff.val[0]);
-        v_diff_sq.val[1] = vmulq_f32(v_diff.val[1], v_diff.val[1]);
-
-        float32x4x2_t v_chunk_dists = vld1q_f32_x2(&float_result[idx]);
-        v_chunk_dists.val[0] = vaddq_f32(v_chunk_dists.val[0], v_diff_sq.val[0]);
-        v_chunk_dists.val[1] = vaddq_f32(v_chunk_dists.val[1], v_diff_sq.val[1]);
-        vst1q_f32_x2(&float_result[idx], v_chunk_dists);
-    }
+    simd::PQDistanceFloat256Impl<simd::SimdTraits<simd::NEON_Tag>>(
+        single_dim_centers, single_dim_val, result, &generic::PQDistanceFloat256);
 #else
     return generic::PQDistanceFloat256(single_dim_centers, single_dim_val, result);
 #endif
@@ -134,64 +120,8 @@ PQDistanceFloat256(const void* single_dim_centers, float single_dim_val, void* r
 float
 FP32ComputeIP(const float* query, const float* codes, uint64_t dim) {
 #if defined(ENABLE_NEON)
-    float32x4_t sum_ = vdupq_n_f32(0.0f);
-    auto d = dim;
-    while (d >= 12) {
-        float32x4x3_t a = vld1q_f32_x3(query + dim - d);
-        float32x4x3_t b = vld1q_f32_x3(codes + dim - d);
-        float32x4x3_t c;
-        c.val[0] = vmulq_f32(a.val[0], b.val[0]);
-        c.val[1] = vmulq_f32(a.val[1], b.val[1]);
-        c.val[2] = vmulq_f32(a.val[2], b.val[2]);
-
-        c.val[0] = vaddq_f32(c.val[0], c.val[1]);
-        c.val[0] = vaddq_f32(c.val[0], c.val[2]);
-
-        sum_ = vaddq_f32(sum_, c.val[0]);
-        d -= 12;
-    }
-
-    if (d >= 8) {
-        float32x4x2_t a = vld1q_f32_x2(query + dim - d);
-        float32x4x2_t b = vld1q_f32_x2(codes + dim - d);
-        float32x4x2_t c;
-        c.val[0] = vmulq_f32(a.val[0], b.val[0]);
-        c.val[1] = vmulq_f32(a.val[1], b.val[1]);
-        c.val[0] = vaddq_f32(c.val[0], c.val[1]);
-        sum_ = vaddq_f32(sum_, c.val[0]);
-        d -= 8;
-    }
-    if (d >= 4) {
-        float32x4_t a = vld1q_f32(query + dim - d);
-        float32x4_t b = vld1q_f32(codes + dim - d);
-        float32x4_t c;
-        c = vmulq_f32(a, b);
-        sum_ = vaddq_f32(sum_, c);
-        d -= 4;
-    }
-
-    float32x4_t res_x = vdupq_n_f32(0.0f);
-    float32x4_t res_y = vdupq_n_f32(0.0f);
-    if (d >= 3) {
-        res_x = vld1q_lane_f32(query + dim - d, res_x, 2);
-        res_y = vld1q_lane_f32(codes + dim - d, res_y, 2);
-        d -= 1;
-    }
-
-    if (d >= 2) {
-        res_x = vld1q_lane_f32(query + dim - d, res_x, 1);
-        res_y = vld1q_lane_f32(codes + dim - d, res_y, 1);
-        d -= 1;
-    }
-
-    if (d >= 1) {
-        res_x = vld1q_lane_f32(query + dim - d, res_x, 0);
-        res_y = vld1q_lane_f32(codes + dim - d, res_y, 0);
-        d -= 1;
-    }
-
-    sum_ = vaddq_f32(sum_, vmulq_f32(res_x, res_y));
-    return vaddvq_f32(sum_);
+    return simd::ComputeIPImpl<simd::SimdTraits<simd::NEON_Tag>>(
+        query, codes, dim, &generic::FP32ComputeIP);
 #else
     return generic::FP32ComputeIP(query, codes, dim);
 #endif
@@ -200,75 +130,8 @@ FP32ComputeIP(const float* query, const float* codes, uint64_t dim) {
 float
 FP32ComputeL2Sqr(const float* query, const float* codes, uint64_t dim) {
 #if defined(ENABLE_NEON)
-    float32x4_t sum_ = vdupq_n_f32(0.0f);
-    auto d = dim;
-    while (d >= 12) {
-        float32x4x3_t a = vld1q_f32_x3(query + dim - d);
-        float32x4x3_t b = vld1q_f32_x3(codes + dim - d);
-        float32x4x3_t c;
-
-        c.val[0] = vsubq_f32(a.val[0], b.val[0]);
-        c.val[1] = vsubq_f32(a.val[1], b.val[1]);
-        c.val[2] = vsubq_f32(a.val[2], b.val[2]);
-
-        c.val[0] = vmulq_f32(c.val[0], c.val[0]);
-        c.val[1] = vmulq_f32(c.val[1], c.val[1]);
-        c.val[2] = vmulq_f32(c.val[2], c.val[2]);
-
-        c.val[0] = vaddq_f32(c.val[0], c.val[1]);
-        c.val[0] = vaddq_f32(c.val[0], c.val[2]);
-
-        sum_ = vaddq_f32(sum_, c.val[0]);
-        d -= 12;
-    }
-
-    if (d >= 8) {
-        float32x4x2_t a = vld1q_f32_x2(query + dim - d);
-        float32x4x2_t b = vld1q_f32_x2(codes + dim - d);
-        float32x4x2_t c;
-        c.val[0] = vsubq_f32(a.val[0], b.val[0]);
-        c.val[1] = vsubq_f32(a.val[1], b.val[1]);
-
-        c.val[0] = vmulq_f32(c.val[0], c.val[0]);
-        c.val[1] = vmulq_f32(c.val[1], c.val[1]);
-
-        c.val[0] = vaddq_f32(c.val[0], c.val[1]);
-        sum_ = vaddq_f32(sum_, c.val[0]);
-        d -= 8;
-    }
-    if (d >= 4) {
-        float32x4_t a = vld1q_f32(query + dim - d);
-        float32x4_t b = vld1q_f32(codes + dim - d);
-        float32x4_t c;
-        c = vsubq_f32(a, b);
-        c = vmulq_f32(c, c);
-
-        sum_ = vaddq_f32(sum_, c);
-        d -= 4;
-    }
-
-    float32x4_t res_x = vdupq_n_f32(0.0f);
-    float32x4_t res_y = vdupq_n_f32(0.0f);
-    if (d >= 3) {
-        res_x = vld1q_lane_f32(query + dim - d, res_x, 2);
-        res_y = vld1q_lane_f32(codes + dim - d, res_y, 2);
-        d -= 1;
-    }
-
-    if (d >= 2) {
-        res_x = vld1q_lane_f32(query + dim - d, res_x, 1);
-        res_y = vld1q_lane_f32(codes + dim - d, res_y, 1);
-        d -= 1;
-    }
-
-    if (d >= 1) {
-        res_x = vld1q_lane_f32(query + dim - d, res_x, 0);
-        res_y = vld1q_lane_f32(codes + dim - d, res_y, 0);
-        d -= 1;
-    }
-
-    sum_ = vaddq_f32(sum_, vmulq_f32(vsubq_f32(res_x, res_y), vsubq_f32(res_x, res_y)));
-    return vaddvq_f32(sum_);
+    return simd::ComputeL2SqrImpl<simd::SimdTraits<simd::NEON_Tag>>(
+        query, codes, dim, &generic::FP32ComputeL2Sqr);
 #else
     return vsag::generic::FP32ComputeL2Sqr(query, codes, dim);
 #endif
@@ -286,44 +149,18 @@ FP32ComputeIPBatch4(const float* RESTRICT query,
                     float& result3,
                     float& result4) {
 #if defined(ENABLE_NEON)
-    if (dim < 4) {
-        return generic::FP32ComputeIPBatch4(
-            query, dim, codes1, codes2, codes3, codes4, result1, result2, result3, result4);
-    }
-    float32x4_t sum1 = vdupq_n_f32(0);
-    float32x4_t sum2 = vdupq_n_f32(0);
-    float32x4_t sum3 = vdupq_n_f32(0);
-    float32x4_t sum4 = vdupq_n_f32(0);
-    int i = 0;
-    for (; i + 3 < dim; i += 4) {
-        float32x4_t q = vld1q_f32(query + i);
-        float32x4_t c1 = vld1q_f32(codes1 + i);
-        float32x4_t c2 = vld1q_f32(codes2 + i);
-        float32x4_t c3 = vld1q_f32(codes3 + i);
-        float32x4_t c4 = vld1q_f32(codes4 + i);
-        sum1 = vaddq_f32(sum1, vmulq_f32(q, c1));
-        sum2 = vaddq_f32(sum2, vmulq_f32(q, c2));
-        sum3 = vaddq_f32(sum3, vmulq_f32(q, c3));
-        sum4 = vaddq_f32(sum4, vmulq_f32(q, c4));
-    }
-
-    result1 += vaddvq_f32(sum1);
-    result2 += vaddvq_f32(sum2);
-    result3 += vaddvq_f32(sum3);
-    result4 += vaddvq_f32(sum4);
-
-    if (i < dim) {
-        generic::FP32ComputeIPBatch4(query + i,
-                                     dim - i,
-                                     codes1 + i,
-                                     codes2 + i,
-                                     codes3 + i,
-                                     codes4 + i,
-                                     result1,
-                                     result2,
-                                     result3,
-                                     result4);
-    }
+    simd::ComputeBatch4Impl<simd::SimdTraits<simd::NEON_Tag>, simd::Batch4Kind::IP>(
+        query,
+        dim,
+        codes1,
+        codes2,
+        codes3,
+        codes4,
+        result1,
+        result2,
+        result3,
+        result4,
+        &generic::FP32ComputeIPBatch4);
 #else
     return generic::FP32ComputeIPBatch4(
         query, dim, codes1, codes2, codes3, codes4, result1, result2, result3, result4);
@@ -342,48 +179,18 @@ FP32ComputeL2SqrBatch4(const float* RESTRICT query,
                        float& result3,
                        float& result4) {
 #if defined(ENABLE_NEON)
-    if (dim < 4) {
-        return generic::FP32ComputeL2SqrBatch4(
-            query, dim, codes1, codes2, codes3, codes4, result1, result2, result3, result4);
-    }
-    float32x4_t sum1 = vdupq_n_f32(0);
-    float32x4_t sum2 = vdupq_n_f32(0);
-    float32x4_t sum3 = vdupq_n_f32(0);
-    float32x4_t sum4 = vdupq_n_f32(0);
-    int i = 0;
-    for (; i + 3 < dim; i += 4) {
-        float32x4_t q = vld1q_f32(query + i);
-        float32x4_t c1 = vld1q_f32(codes1 + i);
-        float32x4_t c2 = vld1q_f32(codes2 + i);
-        float32x4_t c3 = vld1q_f32(codes3 + i);
-        float32x4_t c4 = vld1q_f32(codes4 + i);
-        float32x4_t diff1 = vsubq_f32(q, c1);
-        float32x4_t diff2 = vsubq_f32(q, c2);
-        float32x4_t diff3 = vsubq_f32(q, c3);
-        float32x4_t diff4 = vsubq_f32(q, c4);
-        sum1 = vaddq_f32(sum1, vmulq_f32(diff1, diff1));
-        sum2 = vaddq_f32(sum2, vmulq_f32(diff2, diff2));
-        sum3 = vaddq_f32(sum3, vmulq_f32(diff3, diff3));
-        sum4 = vaddq_f32(sum4, vmulq_f32(diff4, diff4));
-    }
-
-    result1 += vaddvq_f32(sum1);
-    result2 += vaddvq_f32(sum2);
-    result3 += vaddvq_f32(sum3);
-    result4 += vaddvq_f32(sum4);
-
-    if (i < dim) {
-        generic::FP32ComputeL2SqrBatch4(query + i,
-                                        dim - i,
-                                        codes1 + i,
-                                        codes2 + i,
-                                        codes3 + i,
-                                        codes4 + i,
-                                        result1,
-                                        result2,
-                                        result3,
-                                        result4);
-    }
+    simd::ComputeBatch4Impl<simd::SimdTraits<simd::NEON_Tag>, simd::Batch4Kind::L2>(
+        query,
+        dim,
+        codes1,
+        codes2,
+        codes3,
+        codes4,
+        result1,
+        result2,
+        result3,
+        result4,
+        &generic::FP32ComputeL2SqrBatch4);
 #else
     return generic::FP32ComputeL2SqrBatch4(
         query, dim, codes1, codes2, codes3, codes4, result1, result2, result3, result4);
@@ -393,19 +200,8 @@ FP32ComputeL2SqrBatch4(const float* RESTRICT query,
 void
 FP32Sub(const float* x, const float* y, float* z, uint64_t dim) {
 #if defined(ENABLE_NEON)
-    if (dim < 4) {
-        return generic::FP32Sub(x, y, z, dim);
-    }
-    int64_t i = 0;
-    for (; i + 3 < dim; i += 4) {
-        float32x4_t a = vld1q_f32(x + i);
-        float32x4_t b = vld1q_f32(y + i);
-        float32x4_t c = vsubq_f32(a, b);
-        vst1q_f32(z + i, c);
-    }
-    if (i < dim) {
-        generic::FP32Sub(x + i, y + i, z + i, dim - i);
-    }
+    simd::BinaryOpImpl<simd::SimdTraits<simd::NEON_Tag>, simd::BinaryOp::Sub>(
+        x, y, z, dim, &generic::FP32Sub);
 #else
     return generic::FP32Sub(x, y, z, dim);
 #endif
@@ -414,19 +210,8 @@ FP32Sub(const float* x, const float* y, float* z, uint64_t dim) {
 void
 FP32Add(const float* x, const float* y, float* z, uint64_t dim) {
 #if defined(ENABLE_NEON)
-    if (dim < 4) {
-        return generic::FP32Add(x, y, z, dim);
-    }
-    int64_t i = 0;
-    for (; i + 3 < dim; i += 4) {
-        float32x4_t a = vld1q_f32(x + i);
-        float32x4_t b = vld1q_f32(y + i);
-        float32x4_t c = vaddq_f32(a, b);
-        vst1q_f32(z + i, c);
-    }
-    if (i < dim) {
-        generic::FP32Add(x + i, y + i, z + i, dim - i);
-    }
+    simd::BinaryOpImpl<simd::SimdTraits<simd::NEON_Tag>, simd::BinaryOp::Add>(
+        x, y, z, dim, &generic::FP32Add);
 #else
     return generic::FP32Add(x, y, z, dim);
 #endif
@@ -435,19 +220,8 @@ FP32Add(const float* x, const float* y, float* z, uint64_t dim) {
 void
 FP32Mul(const float* x, const float* y, float* z, uint64_t dim) {
 #if defined(ENABLE_NEON)
-    if (dim < 4) {
-        return generic::FP32Mul(x, y, z, dim);
-    }
-    int64_t i = 0;
-    for (; i + 3 < dim; i += 4) {
-        float32x4_t a = vld1q_f32(x + i);
-        float32x4_t b = vld1q_f32(y + i);
-        float32x4_t c = vmulq_f32(a, b);
-        vst1q_f32(z + i, c);
-    }
-    if (i < dim) {
-        generic::FP32Mul(x + i, y + i, z + i, dim - i);
-    }
+    simd::BinaryOpImpl<simd::SimdTraits<simd::NEON_Tag>, simd::BinaryOp::Mul>(
+        x, y, z, dim, &generic::FP32Mul);
 #else
     return generic::FP32Mul(x, y, z, dim);
 #endif
@@ -456,19 +230,8 @@ FP32Mul(const float* x, const float* y, float* z, uint64_t dim) {
 void
 FP32Div(const float* x, const float* y, float* z, uint64_t dim) {
 #if defined(ENABLE_NEON)
-    if (dim < 4) {
-        return generic::FP32Div(x, y, z, dim);
-    }
-    int64_t i = 0;
-    for (; i + 3 < dim; i += 4) {
-        float32x4_t a = vld1q_f32(x + i);
-        float32x4_t b = vld1q_f32(y + i);
-        float32x4_t c = vdivq_f32(a, b);
-        vst1q_f32(z + i, c);
-    }
-    if (i < dim) {
-        generic::FP32Div(x + i, y + i, z + i, dim - i);
-    }
+    simd::BinaryOpImpl<simd::SimdTraits<simd::NEON_Tag>, simd::BinaryOp::Div>(
+        x, y, z, dim, &generic::FP32Div);
 #else
     return generic::FP32Div(x, y, z, dim);
 #endif
@@ -477,20 +240,7 @@ FP32Div(const float* x, const float* y, float* z, uint64_t dim) {
 float
 FP32ReduceAdd(const float* x, uint64_t dim) {
 #if defined(ENABLE_NEON)
-    if (dim < 4) {
-        return generic::FP32ReduceAdd(x, dim);
-    }
-    int i = 0;
-    float32x4_t sum = vdupq_n_f32(0.0f);
-    for (; i + 3 < dim; i += 4) {
-        float32x4_t a = vld1q_f32(x + i);
-        sum = vaddq_f32(sum, a);
-    }
-    float result = vaddvq_f32(sum);
-    if (i < dim) {
-        result += generic::FP32ReduceAdd(x + i, dim - i);
-    }
-    return result;
+    return simd::ReduceAddImpl<simd::SimdTraits<simd::NEON_Tag>>(x, dim, &generic::FP32ReduceAdd);
 #else
     return generic::FP32ReduceAdd(x, dim);
 #endif
@@ -506,65 +256,8 @@ __inline uint16x8_t __attribute__((__always_inline__)) load_4_short(const uint16
 float
 BF16ComputeIP(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_NEON)
-    float32x4x3_t res = {vdupq_n_f32(0.0f), vdupq_n_f32(0.0f), vdupq_n_f32(0.0f)};
-    const auto* query_bf16 = (const uint16_t*)(query);
-    const auto* codes_bf16 = (const uint16_t*)(codes);
-    while (dim >= 12) {
-        float32x4x3_t a = vcvt3_f32_half(vld3_u16((const uint16_t*)query_bf16));
-        float32x4x3_t b = vcvt3_f32_half(vld3_u16((const uint16_t*)codes_bf16));
-
-        res.val[0] = vmlaq_f32(res.val[0], a.val[0], b.val[0]);
-        res.val[1] = vmlaq_f32(res.val[1], a.val[1], b.val[1]);
-        res.val[2] = vmlaq_f32(res.val[2], a.val[2], b.val[2]);
-        dim -= 12;
-        query_bf16 += 12;
-        codes_bf16 += 12;
-    }
-    res.val[0] = vaddq_f32(res.val[0], res.val[1]);
-    if (dim >= 8) {
-        float32x4x2_t a = vcvt2_f32_half(vld2_u16((const uint16_t*)query_bf16));
-        float32x4x2_t b = vcvt2_f32_half(vld2_u16((const uint16_t*)codes_bf16));
-        res.val[0] = vmlaq_f32(res.val[0], a.val[0], b.val[0]);
-        res.val[2] = vmlaq_f32(res.val[2], a.val[1], b.val[1]);
-        dim -= 8;
-        query_bf16 += 8;
-        codes_bf16 += 8;
-    }
-    res.val[0] = vaddq_f32(res.val[0], res.val[2]);
-    if (dim >= 4) {
-        float32x4_t a = vcvt_f32_half(vld1_u16((const uint16_t*)query_bf16));
-        float32x4_t b = vcvt_f32_half(vld1_u16((const uint16_t*)codes_bf16));
-        res.val[0] = vmlaq_f32(res.val[0], a, b);
-        dim -= 4;
-        query_bf16 += 4;
-        codes_bf16 += 4;
-    }
-    if (dim >= 0) {
-        uint16x4_t res_x = {0, 0, 0, 0};
-        uint16x4_t res_y = {0, 0, 0, 0};
-        switch (dim) {
-            case 3:
-                res_x = vld1_lane_u16((const uint16_t*)query_bf16, res_x, 2);
-                res_y = vld1_lane_u16((const uint16_t*)codes_bf16, res_y, 2);
-                query_bf16++;
-                codes_bf16++;
-                dim--;
-            case 2:
-                res_x = vld1_lane_u16((const uint16_t*)query_bf16, res_x, 1);
-                res_y = vld1_lane_u16((const uint16_t*)codes_bf16, res_y, 1);
-                query_bf16++;
-                codes_bf16++;
-                dim--;
-            case 1:
-                res_x = vld1_lane_u16((const uint16_t*)query_bf16, res_x, 0);
-                res_y = vld1_lane_u16((const uint16_t*)codes_bf16, res_y, 0);
-                query_bf16++;
-                codes_bf16++;
-                dim--;
-        }
-        res.val[0] = vmlaq_f32(res.val[0], vcvt_f32_half(res_x), vcvt_f32_half(res_y));
-    }
-    return vaddvq_f32(res.val[0]);
+    return simd::HalfComputeIPImpl<simd::BF16Traits<simd::NEON_BF16_Tag>>(
+        query, codes, dim, &generic::BF16ComputeIP);
 #else
     return generic::BF16ComputeIP(query, codes, dim);
 #endif
@@ -573,73 +266,8 @@ BF16ComputeIP(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint
 float
 BF16ComputeL2Sqr(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_NEON)
-    float32x4x3_t res = {vdupq_n_f32(0.0f), vdupq_n_f32(0.0f), vdupq_n_f32(0.0f)};
-    const auto* query_bf16 = (const uint16_t*)(query);
-    const auto* codes_bf16 = (const uint16_t*)(codes);
-
-    while (dim >= 12) {
-        float32x4x3_t a = vcvt3_f32_half(vld3_u16((const uint16_t*)query_bf16));
-        float32x4x3_t b = vcvt3_f32_half(vld3_u16((const uint16_t*)codes_bf16));
-        a.val[0] = vsubq_f32(a.val[0], b.val[0]);
-        a.val[1] = vsubq_f32(a.val[1], b.val[1]);
-        a.val[2] = vsubq_f32(a.val[2], b.val[2]);
-
-        res.val[0] = vmlaq_f32(res.val[0], a.val[0], a.val[0]);
-        res.val[1] = vmlaq_f32(res.val[1], a.val[1], a.val[1]);
-        res.val[2] = vmlaq_f32(res.val[2], a.val[2], a.val[2]);
-        dim -= 12;
-        query_bf16 += 12;
-        codes_bf16 += 12;
-    }
-    res.val[0] = vaddq_f32(res.val[0], res.val[1]);
-    if (dim >= 8) {
-        float32x4x2_t a = vcvt2_f32_half(vld2_u16((const uint16_t*)query_bf16));
-        float32x4x2_t b = vcvt2_f32_half(vld2_u16((const uint16_t*)codes_bf16));
-        a.val[0] = vsubq_f32(a.val[0], b.val[0]);
-        a.val[1] = vsubq_f32(a.val[1], b.val[1]);
-        res.val[0] = vmlaq_f32(res.val[0], a.val[0], a.val[0]);
-        res.val[2] = vmlaq_f32(res.val[2], a.val[1], a.val[1]);
-        dim -= 8;
-        query_bf16 += 8;
-        codes_bf16 += 8;
-    }
-    res.val[0] = vaddq_f32(res.val[0], res.val[2]);
-    if (dim >= 4) {
-        float32x4_t a = vcvt_f32_half(vld1_u16((const uint16_t*)query_bf16));
-        float32x4_t b = vcvt_f32_half(vld1_u16((const uint16_t*)codes_bf16));
-        a = vsubq_f32(a, b);
-        res.val[0] = vmlaq_f32(res.val[0], a, a);
-        dim -= 4;
-        query_bf16 += 4;
-        codes_bf16 += 4;
-    }
-    uint16x4_t res_x = vdup_n_u16(0);
-    uint16x4_t res_y = vdup_n_u16(0);
-    switch (dim) {
-        case 3:
-            res_x = vld1_lane_u16((const uint16_t*)query_bf16, res_x, 2);
-            res_y = vld1_lane_u16((const uint16_t*)codes_bf16, res_y, 2);
-            query_bf16++;
-            codes_bf16++;
-            dim--;
-        case 2:
-            res_x = vld1_lane_u16((const uint16_t*)query_bf16, res_x, 1);
-            res_y = vld1_lane_u16((const uint16_t*)codes_bf16, res_y, 1);
-            query_bf16++;
-            codes_bf16++;
-            dim--;
-        case 1:
-            res_x = vld1_lane_u16((const uint16_t*)query_bf16, res_x, 0);
-            res_y = vld1_lane_u16((const uint16_t*)codes_bf16, res_y, 0);
-            query_bf16++;
-            codes_bf16++;
-            dim--;
-    }
-
-    float32x4_t diff = vsubq_f32(vcvt_f32_half(res_x), vcvt_f32_half(res_y));
-    res.val[0] = vmlaq_f32(res.val[0], diff, diff);
-
-    return vaddvq_f32(res.val[0]);
+    return simd::HalfComputeL2SqrImpl<simd::BF16Traits<simd::NEON_BF16_Tag>>(
+        query, codes, dim, &generic::BF16ComputeL2Sqr);
 #else
     return generic::BF16ComputeL2Sqr(query, codes, dim);
 #endif
@@ -648,66 +276,8 @@ BF16ComputeL2Sqr(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, u
 float
 FP16ComputeIP(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_NEON)
-    const auto* query_fp16 = (const uint16_t*)(query);
-    const auto* codes_fp16 = (const uint16_t*)(codes);
-
-    float32x4x3_t res = {vdupq_n_f32(0.0f), vdupq_n_f32(0.0f), vdupq_n_f32(0.0f)};
-    while (dim >= 12) {
-        float32x4x3_t a = vcvt3_f32_f16(vld3_f16((const __fp16*)query_fp16));
-        float32x4x3_t b = vcvt3_f32_f16(vld3_f16((const __fp16*)codes_fp16));
-
-        res.val[0] = vmlaq_f32(res.val[0], a.val[0], b.val[0]);
-        res.val[1] = vmlaq_f32(res.val[1], a.val[1], b.val[1]);
-        res.val[2] = vmlaq_f32(res.val[2], a.val[2], b.val[2]);
-        dim -= 12;
-        query_fp16 += 12;
-        codes_fp16 += 12;
-    }
-    res.val[0] = vaddq_f32(res.val[0], res.val[1]);
-    if (dim >= 8) {
-        float32x4x2_t a = vcvt2_f32_f16(vld2_f16((const __fp16*)query_fp16));
-        float32x4x2_t b = vcvt2_f32_f16(vld2_f16((const __fp16*)codes_fp16));
-        res.val[0] = vmlaq_f32(res.val[0], a.val[0], b.val[0]);
-        res.val[2] = vmlaq_f32(res.val[2], a.val[1], b.val[1]);
-        dim -= 8;
-        query_fp16 += 8;
-        codes_fp16 += 8;
-    }
-    res.val[0] = vaddq_f32(res.val[0], res.val[2]);
-    if (dim >= 4) {
-        float32x4_t a = vcvt_f32_f16(vld1_f16((const __fp16*)query_fp16));
-        float32x4_t b = vcvt_f32_f16(vld1_f16((const __fp16*)codes_fp16));
-        res.val[0] = vmlaq_f32(res.val[0], a, b);
-        dim -= 4;
-        query_fp16 += 4;
-        codes_fp16 += 4;
-    }
-
-    float16x4_t res_x = {0.0f, 0.0f, 0.0f, 0.0f};
-    float16x4_t res_y = {0.0f, 0.0f, 0.0f, 0.0f};
-    switch (dim) {
-        case 3:
-            res_x = vld1_lane_f16((const __fp16*)query_fp16, res_x, 2);
-            res_y = vld1_lane_f16((const __fp16*)codes_fp16, res_y, 2);
-            query_fp16++;
-            codes_fp16++;
-            dim--;
-        case 2:
-            res_x = vld1_lane_f16((const __fp16*)query_fp16, res_x, 1);
-            res_y = vld1_lane_f16((const __fp16*)codes_fp16, res_y, 1);
-            query_fp16++;
-            codes_fp16++;
-            dim--;
-        case 1:
-            res_x = vld1_lane_f16((const __fp16*)query_fp16, res_x, 0);
-            res_y = vld1_lane_f16((const __fp16*)codes_fp16, res_y, 0);
-            query_fp16++;
-            codes_fp16++;
-            dim--;
-    }
-    res.val[0] = vmlaq_f32(res.val[0], vcvt_f32_f16(res_x), vcvt_f32_f16(res_y));
-
-    return vaddvq_f32(res.val[0]);
+    return simd::HalfComputeIPImpl<simd::FP16Traits<simd::NEON_FP16_Tag>>(
+        query, codes, dim, &generic::FP16ComputeIP);
 #else
     return generic::FP16ComputeIP(query, codes, dim);
 #endif
@@ -716,75 +286,8 @@ FP16ComputeIP(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint
 float
 FP16ComputeL2Sqr(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_NEON)
-    float32x4x3_t res = {vdupq_n_f32(0.0f), vdupq_n_f32(0.0f), vdupq_n_f32(0.0f)};
-
-    const auto* query_fp16 = (const uint16_t*)(query);
-    const auto* codes_fp16 = (const uint16_t*)(codes);
-
-    while (dim >= 12) {
-        float32x4x3_t a = vcvt3_f32_f16(vld3_f16((const __fp16*)query_fp16));
-        float32x4x3_t b = vcvt3_f32_f16(vld3_f16((const __fp16*)codes_fp16));
-        a.val[0] = vsubq_f32(a.val[0], b.val[0]);
-        a.val[1] = vsubq_f32(a.val[1], b.val[1]);
-        a.val[2] = vsubq_f32(a.val[2], b.val[2]);
-
-        res.val[0] = vmlaq_f32(res.val[0], a.val[0], a.val[0]);
-        res.val[1] = vmlaq_f32(res.val[1], a.val[1], a.val[1]);
-        res.val[2] = vmlaq_f32(res.val[2], a.val[2], a.val[2]);
-        dim -= 12;
-        query_fp16 += 12;
-        codes_fp16 += 12;
-    }
-    res.val[0] = vaddq_f32(res.val[0], res.val[1]);
-    if (dim >= 8) {
-        float32x4x2_t a = vcvt2_f32_f16(vld2_f16((const __fp16*)query_fp16));
-        float32x4x2_t b = vcvt2_f32_f16(vld2_f16((const __fp16*)codes_fp16));
-        a.val[0] = vsubq_f32(a.val[0], b.val[0]);
-        a.val[1] = vsubq_f32(a.val[1], b.val[1]);
-        res.val[0] = vmlaq_f32(res.val[0], a.val[0], a.val[0]);
-        res.val[2] = vmlaq_f32(res.val[2], a.val[1], a.val[1]);
-        dim -= 8;
-        query_fp16 += 8;
-        codes_fp16 += 8;
-    }
-    res.val[0] = vaddq_f32(res.val[0], res.val[2]);
-    if (dim >= 4) {
-        float32x4_t a = vcvt_f32_f16(vld1_f16((const __fp16*)query_fp16));
-        float32x4_t b = vcvt_f32_f16(vld1_f16((const __fp16*)codes_fp16));
-        a = vsubq_f32(a, b);
-        res.val[0] = vmlaq_f32(res.val[0], a, a);
-        dim -= 4;
-        query_fp16 += 4;
-        codes_fp16 += 4;
-    }
-    if (dim >= 0) {
-        float16x4_t res_x = vdup_n_f16(0.0f);
-        float16x4_t res_y = vdup_n_f16(0.0f);
-        switch (dim) {
-            case 3:
-                res_x = vld1_lane_f16((const __fp16*)query_fp16, res_x, 2);
-                res_y = vld1_lane_f16((const __fp16*)codes_fp16, res_y, 2);
-                query_fp16++;
-                codes_fp16++;
-                dim--;
-            case 2:
-                res_x = vld1_lane_f16((const __fp16*)query_fp16, res_x, 1);
-                res_y = vld1_lane_f16((const __fp16*)codes_fp16, res_y, 1);
-                query_fp16++;
-                codes_fp16++;
-                dim--;
-            case 1:
-                res_x = vld1_lane_f16((const __fp16*)query_fp16, res_x, 0);
-                res_y = vld1_lane_f16((const __fp16*)codes_fp16, res_y, 0);
-                query_fp16++;
-                codes_fp16++;
-                dim--;
-        }
-        float32x4_t diff = vsubq_f32(vcvt_f32_f16(res_x), vcvt_f32_f16(res_y));
-
-        res.val[0] = vmlaq_f32(res.val[0], diff, diff);
-    }
-    return vaddvq_f32(res.val[0]);
+    return simd::HalfComputeL2SqrImpl<simd::FP16Traits<simd::NEON_FP16_Tag>>(
+        query, codes, dim, &generic::FP16ComputeL2Sqr);
 #else
     return generic::FP16ComputeL2Sqr(query, codes, dim);
 #endif
@@ -840,38 +343,10 @@ load_12_uint8_to_float(const uint8_t* data, float32x4_t& f0, float32x4_t& f1, fl
 #endif
 
 float
-INT8ComputeL2Sqr(const int8_t* __restrict query, const int8_t* __restrict codes, uint64_t dim) {
+INT8ComputeL2Sqr(const int8_t* RESTRICT query, const int8_t* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_NEON)
-    constexpr int BATCH_SIZE{8};
-
-    const uint64_t n = dim / BATCH_SIZE;
-
-    if (n == 0) {
-        return generic::INT8ComputeL2Sqr(query, codes, dim);
-    }
-
-    int32x4_t sum_sq = vdupq_n_s32(0);
-    for (uint64_t i{0}; i < n; i++) {
-        int8x8_t q = vld1_s8(query + BATCH_SIZE * i);
-        int8x8_t c = vld1_s8(codes + BATCH_SIZE * i);
-
-        int16x8_t q_16 = vmovl_s8(q);
-        int16x8_t c_16 = vmovl_s8(c);
-
-        int16x8_t diff = vsubq_s16(q_16, c_16);
-
-        sum_sq = vmlal_s16(sum_sq, vget_low_s16(diff), vget_low_s16(diff));
-        sum_sq = vmlal_s16(sum_sq, vget_high_s16(diff), vget_high_s16(diff));
-    }
-
-    int32_t result[4];
-    vst1q_s32(result, sum_sq);
-    int64_t l2 = static_cast<int64_t>(result[0] + result[1] + result[2] + result[3]);
-
-    l2 += generic::INT8ComputeL2Sqr(
-        query + BATCH_SIZE * n, codes + BATCH_SIZE * n, dim - BATCH_SIZE * n);
-
-    return static_cast<float>(l2);
+    return simd::Int8ComputeL2SqrImpl<simd::Int8Traits<simd::NEON_Int8_Tag>>(
+        query, codes, dim, &generic::INT8ComputeL2Sqr);
 #else
     return generic::INT8ComputeL2Sqr(query, codes, dim);
 #endif
@@ -880,45 +355,8 @@ INT8ComputeL2Sqr(const int8_t* __restrict query, const int8_t* __restrict codes,
 float
 INT8ComputeIP(const int8_t* __restrict query, const int8_t* __restrict codes, uint64_t dim) {
 #if defined(ENABLE_NEON)
-    constexpr int BATCH_SIZE = 8;
-
-    const uint64_t n = dim / BATCH_SIZE;
-
-    if (n == 0) {
-        return generic::INT8ComputeIP(query, codes, dim);
-    }
-
-    int32x4_t sum_0 = vdupq_n_s32(0);
-    int32x4_t sum_1 = vdupq_n_s32(0);
-
-    for (uint64_t i = 0; i < n; ++i) {
-        int8x8_t q_vec = vld1_s8(query + BATCH_SIZE * i);
-        int8x8_t c_vec = vld1_s8(codes + BATCH_SIZE * i);
-
-        int16x8_t q_16 = vmovl_s8(q_vec);
-        int16x8_t c_16 = vmovl_s8(c_vec);
-
-        int16x8_t prod_16 = vmulq_s16(q_16, c_16);
-
-        int32x4_t prod_low = vmovl_s16(vget_low_s16(prod_16));
-        int32x4_t prod_high = vmovl_s16(vget_high_s16(prod_16));
-
-        sum_0 = vaddq_s32(sum_0, prod_low);
-        sum_1 = vaddq_s32(sum_1, prod_high);
-    }
-
-    int32x4_t sum_total = vaddq_s32(sum_0, sum_1);
-
-    int32_t result[4];
-    vst1q_s32(result, sum_total);
-
-    int64_t dot = static_cast<int64_t>(result[0]) + static_cast<int64_t>(result[1]) +
-                  static_cast<int64_t>(result[2]) + static_cast<int64_t>(result[3]);
-
-    dot += generic::INT8ComputeIP(
-        query + BATCH_SIZE * n, codes + BATCH_SIZE * n, dim - BATCH_SIZE * n);
-
-    return static_cast<float>(dot);
+    return simd::Int8ComputeIPImpl<simd::Int8Traits<simd::NEON_Int8_Tag>>(
+        query, codes, dim, &generic::INT8ComputeIP);
 #else
     return generic::INT8ComputeIP(query, codes, dim);
 #endif
@@ -931,107 +369,8 @@ SQ8ComputeIP(const float* RESTRICT query,
              const float* RESTRICT diff,
              uint64_t dim) {
 #if defined(ENABLE_NEON)
-    const float32x4_t inv255 = vdupq_n_f32(1.0f / 255.0f);
-    float32x4_t sum = vdupq_n_f32(0.0f);
-    uint64_t i = 0;
-
-    for (; i + 11 < dim; i += 12) {
-        __builtin_prefetch(codes + i + 48, 0, 1);
-        __builtin_prefetch(query + i + 24, 0, 1);
-
-        // Load 12 codes and convert to float in one operation
-        float32x4_t code_floats_0, code_floats_1, code_floats_2;
-        load_12_uint8_to_float(codes + i, code_floats_0, code_floats_1, code_floats_2);
-
-        float32x4x3_t query_vec = vld1q_f32_x3(query + i);
-        float32x4x3_t diff_vec = vld1q_f32_x3(diff + i);
-        float32x4x3_t lower_bound_vec = vld1q_f32_x3(lower_bound + i);
-
-        // Normalize and adjust codes in one fused operation: lower_bound + (codes/255) * diff
-        float32x4x3_t adjusted_vec;
-        adjusted_vec.val[0] =
-            vfmaq_f32(lower_bound_vec.val[0], vmulq_f32(code_floats_0, inv255), diff_vec.val[0]);
-        adjusted_vec.val[1] =
-            vfmaq_f32(lower_bound_vec.val[1], vmulq_f32(code_floats_1, inv255), diff_vec.val[1]);
-        adjusted_vec.val[2] =
-            vfmaq_f32(lower_bound_vec.val[2], vmulq_f32(code_floats_2, inv255), diff_vec.val[2]);
-
-        // Compute inner product and accumulate
-        sum = vfmaq_f32(sum, query_vec.val[0], adjusted_vec.val[0]);
-        sum = vfmaq_f32(sum, query_vec.val[1], adjusted_vec.val[1]);
-        sum = vfmaq_f32(sum, query_vec.val[2], adjusted_vec.val[2]);
-    }
-
-    uint64_t d = dim - i;
-
-    if (d >= 8) {
-        float32x4_t code_floats_low, code_floats_high;
-        load_8_uint8_to_float(codes + i, code_floats_low, code_floats_high);
-
-        float32x4x2_t query_vec = vld1q_f32_x2(query + i);
-        float32x4x2_t diff_vec = vld1q_f32_x2(diff + i);
-        float32x4x2_t lower_bound_vec = vld1q_f32_x2(lower_bound + i);
-
-        float32x4x2_t adjusted_vec;
-        adjusted_vec.val[0] =
-            vfmaq_f32(lower_bound_vec.val[0], vmulq_f32(code_floats_low, inv255), diff_vec.val[0]);
-        adjusted_vec.val[1] =
-            vfmaq_f32(lower_bound_vec.val[1], vmulq_f32(code_floats_high, inv255), diff_vec.val[1]);
-
-        sum = vfmaq_f32(sum, query_vec.val[0], adjusted_vec.val[0]);
-        sum = vfmaq_f32(sum, query_vec.val[1], adjusted_vec.val[1]);
-        i += 8;
-        d -= 8;
-    }
-
-    if (d >= 4) {
-        float32x4_t code_floats = load_4_uint8_to_float(codes + i);
-        float32x4_t query_vec = vld1q_f32(query + i);
-        float32x4_t diff_vec = vld1q_f32(diff + i);
-        float32x4_t lower_bound_vec = vld1q_f32(lower_bound + i);
-
-        float32x4_t adjusted = vfmaq_f32(lower_bound_vec, vmulq_f32(code_floats, inv255), diff_vec);
-        sum = vfmaq_f32(sum, query_vec, adjusted);
-        i += 4;
-        d -= 4;
-    }
-
-    float32x4_t res_query = vdupq_n_f32(0.0f);
-    float32x4_t res_codes = vdupq_n_f32(0.0f);
-    float32x4_t res_diff = vdupq_n_f32(0.0f);
-    float32x4_t res_lower_bound = vdupq_n_f32(0.0f);
-
-    if (d >= 3) {
-        res_query = vld1q_lane_f32(query + i, res_query, 2);
-        res_codes = vsetq_lane_f32(codes[i], res_codes, 2);
-        res_diff = vld1q_lane_f32(diff + i, res_diff, 2);
-        res_lower_bound = vld1q_lane_f32(lower_bound + i, res_lower_bound, 2);
-        i++;
-        d--;
-    }
-
-    if (d >= 2) {
-        res_query = vld1q_lane_f32(query + i, res_query, 1);
-        res_codes = vsetq_lane_f32(codes[i], res_codes, 1);
-        res_diff = vld1q_lane_f32(diff + i, res_diff, 1);
-        res_lower_bound = vld1q_lane_f32(lower_bound + i, res_lower_bound, 1);
-        i++;
-        d--;
-    }
-
-    if (d >= 1) {
-        res_query = vld1q_lane_f32(query + i, res_query, 0);
-        res_codes = vsetq_lane_f32(codes[i], res_codes, 0);
-        res_diff = vld1q_lane_f32(diff + i, res_diff, 0);
-        res_lower_bound = vld1q_lane_f32(lower_bound + i, res_lower_bound, 0);
-    }
-
-    if (dim > i) {
-        float32x4_t adjusted = vfmaq_f32(res_lower_bound, vmulq_f32(res_codes, inv255), res_diff);
-        sum = vfmaq_f32(sum, res_query, adjusted);
-    }
-
-    return vaddvq_f32(sum);
+    return simd::SQ8ComputeIPImpl<simd::SQ8Traits<simd::NEON_SQ8_Tag>>(
+        query, codes, lower_bound, diff, dim, &generic::SQ8ComputeIP);
 #else
     return generic::SQ8ComputeIP(query, codes, lower_bound, diff, dim);
 #endif
@@ -1044,116 +383,8 @@ SQ8ComputeL2Sqr(const float* RESTRICT query,
                 const float* RESTRICT diff,
                 uint64_t dim) {
 #if defined(ENABLE_NEON)
-    const float32x4_t inv255 = vdupq_n_f32(1.0f / 255.0f);
-    float32x4_t sum = vdupq_n_f32(0.0f);
-    uint64_t i = 0;
-
-    for (; i + 11 < dim; i += 12) {
-        __builtin_prefetch(codes + i + 48, 0, 1);
-        __builtin_prefetch(query + i + 24, 0, 1);
-
-        // Load 12 codes and convert to float in one operation
-        float32x4_t code_floats_0, code_floats_1, code_floats_2;
-        load_12_uint8_to_float(codes + i, code_floats_0, code_floats_1, code_floats_2);
-
-        float32x4x3_t query_vec = vld1q_f32_x3(query + i);
-        float32x4x3_t diff_vec = vld1q_f32_x3(diff + i);
-        float32x4x3_t lower_bound_vec = vld1q_f32_x3(lower_bound + i);
-
-        // Compute adjusted codes and distance in one fused operation
-        float32x4x3_t dist_vec;
-        dist_vec.val[0] = vsubq_f32(
-            query_vec.val[0],
-            vfmaq_f32(lower_bound_vec.val[0], vmulq_f32(code_floats_0, inv255), diff_vec.val[0]));
-        dist_vec.val[1] = vsubq_f32(
-            query_vec.val[1],
-            vfmaq_f32(lower_bound_vec.val[1], vmulq_f32(code_floats_1, inv255), diff_vec.val[1]));
-        dist_vec.val[2] = vsubq_f32(
-            query_vec.val[2],
-            vfmaq_f32(lower_bound_vec.val[2], vmulq_f32(code_floats_2, inv255), diff_vec.val[2]));
-
-        // Compute squared distance and accumulate
-        sum = vfmaq_f32(sum, dist_vec.val[0], dist_vec.val[0]);
-        sum = vfmaq_f32(sum, dist_vec.val[1], dist_vec.val[1]);
-        sum = vfmaq_f32(sum, dist_vec.val[2], dist_vec.val[2]);
-    }
-
-    uint64_t d = dim - i;
-
-    if (d >= 8) {
-        float32x4_t code_floats_low, code_floats_high;
-        load_8_uint8_to_float(codes + i, code_floats_low, code_floats_high);
-
-        float32x4x2_t query_vec = vld1q_f32_x2(query + i);
-        float32x4x2_t diff_vec = vld1q_f32_x2(diff + i);
-        float32x4x2_t lower_bound_vec = vld1q_f32_x2(lower_bound + i);
-
-        float32x4x2_t adjusted_vec;
-        adjusted_vec.val[0] =
-            vfmaq_f32(lower_bound_vec.val[0], vmulq_f32(code_floats_low, inv255), diff_vec.val[0]);
-        adjusted_vec.val[1] =
-            vfmaq_f32(lower_bound_vec.val[1], vmulq_f32(code_floats_high, inv255), diff_vec.val[1]);
-
-        float32x4x2_t dist_vec;
-        dist_vec.val[0] = vsubq_f32(query_vec.val[0], adjusted_vec.val[0]);
-        dist_vec.val[1] = vsubq_f32(query_vec.val[1], adjusted_vec.val[1]);
-
-        sum = vfmaq_f32(sum, dist_vec.val[0], dist_vec.val[0]);
-        sum = vfmaq_f32(sum, dist_vec.val[1], dist_vec.val[1]);
-        i += 8;
-        d -= 8;
-    }
-
-    if (d >= 4) {
-        float32x4_t code_floats = load_4_uint8_to_float(codes + i);
-        float32x4_t query_vec = vld1q_f32(query + i);
-        float32x4_t diff_vec = vld1q_f32(diff + i);
-        float32x4_t lower_bound_vec = vld1q_f32(lower_bound + i);
-
-        float32x4_t adjusted = vfmaq_f32(lower_bound_vec, vmulq_f32(code_floats, inv255), diff_vec);
-        float32x4_t dist = vsubq_f32(query_vec, adjusted);
-        sum = vfmaq_f32(sum, dist, dist);
-        i += 4;
-        d -= 4;
-    }
-
-    float32x4_t res_query = vdupq_n_f32(0.0f);
-    float32x4_t res_codes = vdupq_n_f32(0.0f);
-    float32x4_t res_diff = vdupq_n_f32(0.0f);
-    float32x4_t res_lower_bound = vdupq_n_f32(0.0f);
-
-    if (d >= 3) {
-        res_query = vld1q_lane_f32(query + i, res_query, 2);
-        res_codes = vsetq_lane_f32(codes[i], res_codes, 2);
-        res_diff = vld1q_lane_f32(diff + i, res_diff, 2);
-        res_lower_bound = vld1q_lane_f32(lower_bound + i, res_lower_bound, 2);
-        i++;
-        d--;
-    }
-
-    if (d >= 2) {
-        res_query = vld1q_lane_f32(query + i, res_query, 1);
-        res_codes = vsetq_lane_f32(codes[i], res_codes, 1);
-        res_diff = vld1q_lane_f32(diff + i, res_diff, 1);
-        res_lower_bound = vld1q_lane_f32(lower_bound + i, res_lower_bound, 1);
-        i++;
-        d--;
-    }
-
-    if (d >= 1) {
-        res_query = vld1q_lane_f32(query + i, res_query, 0);
-        res_codes = vsetq_lane_f32(codes[i], res_codes, 0);
-        res_diff = vld1q_lane_f32(diff + i, res_diff, 0);
-        res_lower_bound = vld1q_lane_f32(lower_bound + i, res_lower_bound, 0);
-    }
-
-    if (dim > i) {
-        float32x4_t adjusted = vfmaq_f32(res_lower_bound, vmulq_f32(res_codes, inv255), res_diff);
-        float32x4_t dist = vsubq_f32(res_query, adjusted);
-        sum = vfmaq_f32(sum, dist, dist);
-    }
-
-    return vaddvq_f32(sum);
+    return simd::SQ8ComputeL2SqrImpl<simd::SQ8Traits<simd::NEON_SQ8_Tag>>(
+        query, codes, lower_bound, diff, dim, &generic::SQ8ComputeL2Sqr);
 #else
     return generic::SQ8ComputeL2Sqr(query, codes, lower_bound, diff, dim);
 #endif
@@ -1166,130 +397,8 @@ SQ8ComputeCodesIP(const uint8_t* RESTRICT codes1,
                   const float* RESTRICT diff,
                   uint64_t dim) {
 #if defined(ENABLE_NEON)
-    const float32x4_t inv255 = vdupq_n_f32(1.0f / 255.0f);
-    float32x4_t sum = vdupq_n_f32(0.0f);
-    uint64_t i = 0;
-
-    // Process 12 elements at a time for optimal instruction usage
-    for (; i + 11 < dim; i += 12) {
-        __builtin_prefetch(codes1 + i + 48, 0, 1);
-        __builtin_prefetch(codes2 + i + 48, 0, 1);
-
-        // Load 12 codes from both arrays and convert to float
-        float32x4_t code1_floats_0, code1_floats_1, code1_floats_2;
-        float32x4_t code2_floats_0, code2_floats_1, code2_floats_2;
-        load_12_uint8_to_float(codes1 + i, code1_floats_0, code1_floats_1, code1_floats_2);
-        load_12_uint8_to_float(codes2 + i, code2_floats_0, code2_floats_1, code2_floats_2);
-
-        // Load 12 elements each using x3 intrinsics
-        float32x4x3_t diff_vec = vld1q_f32_x3(diff + i);
-        float32x4x3_t lower_bound_vec = vld1q_f32_x3(lower_bound + i);
-
-        // Compute adjusted codes and inner product in one fused operation
-        float32x4x3_t adjusted1_vec, adjusted2_vec;
-        adjusted1_vec.val[0] =
-            vfmaq_f32(lower_bound_vec.val[0], vmulq_f32(code1_floats_0, inv255), diff_vec.val[0]);
-        adjusted1_vec.val[1] =
-            vfmaq_f32(lower_bound_vec.val[1], vmulq_f32(code1_floats_1, inv255), diff_vec.val[1]);
-        adjusted1_vec.val[2] =
-            vfmaq_f32(lower_bound_vec.val[2], vmulq_f32(code1_floats_2, inv255), diff_vec.val[2]);
-
-        adjusted2_vec.val[0] =
-            vfmaq_f32(lower_bound_vec.val[0], vmulq_f32(code2_floats_0, inv255), diff_vec.val[0]);
-        adjusted2_vec.val[1] =
-            vfmaq_f32(lower_bound_vec.val[1], vmulq_f32(code2_floats_1, inv255), diff_vec.val[1]);
-        adjusted2_vec.val[2] =
-            vfmaq_f32(lower_bound_vec.val[2], vmulq_f32(code2_floats_2, inv255), diff_vec.val[2]);
-
-        // Compute inner product and accumulate
-        sum = vfmaq_f32(sum, adjusted1_vec.val[0], adjusted2_vec.val[0]);
-        sum = vfmaq_f32(sum, adjusted1_vec.val[1], adjusted2_vec.val[1]);
-        sum = vfmaq_f32(sum, adjusted1_vec.val[2], adjusted2_vec.val[2]);
-    }
-
-    // Process remaining elements with optimized NEON instructions
-    uint64_t d = dim - i;
-
-    // Process 8 elements if remaining
-    if (d >= 8) {
-        float32x4_t code1_floats_low, code1_floats_high;
-        float32x4_t code2_floats_low, code2_floats_high;
-        load_8_uint8_to_float(codes1 + i, code1_floats_low, code1_floats_high);
-        load_8_uint8_to_float(codes2 + i, code2_floats_low, code2_floats_high);
-
-        float32x4x2_t diff_vec = vld1q_f32_x2(diff + i);
-        float32x4x2_t lower_bound_vec = vld1q_f32_x2(lower_bound + i);
-
-        float32x4x2_t adjusted1_vec, adjusted2_vec;
-        adjusted1_vec.val[0] =
-            vfmaq_f32(lower_bound_vec.val[0], vmulq_f32(code1_floats_low, inv255), diff_vec.val[0]);
-        adjusted1_vec.val[1] = vfmaq_f32(
-            lower_bound_vec.val[1], vmulq_f32(code1_floats_high, inv255), diff_vec.val[1]);
-        adjusted2_vec.val[0] =
-            vfmaq_f32(lower_bound_vec.val[0], vmulq_f32(code2_floats_low, inv255), diff_vec.val[0]);
-        adjusted2_vec.val[1] = vfmaq_f32(
-            lower_bound_vec.val[1], vmulq_f32(code2_floats_high, inv255), diff_vec.val[1]);
-
-        sum = vfmaq_f32(sum, adjusted1_vec.val[0], adjusted2_vec.val[0]);
-        sum = vfmaq_f32(sum, adjusted1_vec.val[1], adjusted2_vec.val[1]);
-        i += 8;
-        d -= 8;
-    }
-
-    // Process 4 elements if remaining
-    if (d >= 4) {
-        float32x4_t code1_floats = load_4_uint8_to_float(codes1 + i);
-        float32x4_t code2_floats = load_4_uint8_to_float(codes2 + i);
-        float32x4_t diff_vec = vld1q_f32(diff + i);
-        float32x4_t lower_bound_vec = vld1q_f32(lower_bound + i);
-
-        float32x4_t adjusted1 =
-            vfmaq_f32(lower_bound_vec, vmulq_f32(code1_floats, inv255), diff_vec);
-        float32x4_t adjusted2 =
-            vfmaq_f32(lower_bound_vec, vmulq_f32(code2_floats, inv255), diff_vec);
-        sum = vfmaq_f32(sum, adjusted1, adjusted2);
-        i += 4;
-        d -= 4;
-    }
-
-    // Process remaining 1-3 elements
-    float32x4_t res_codes1 = vdupq_n_f32(0.0f);
-    float32x4_t res_codes2 = vdupq_n_f32(0.0f);
-    float32x4_t res_diff = vdupq_n_f32(0.0f);
-    float32x4_t res_lower_bound = vdupq_n_f32(0.0f);
-
-    if (d >= 3) {
-        res_codes1 = vsetq_lane_f32(codes1[i], res_codes1, 2);
-        res_codes2 = vsetq_lane_f32(codes2[i], res_codes2, 2);
-        res_diff = vld1q_lane_f32(diff + i, res_diff, 2);
-        res_lower_bound = vld1q_lane_f32(lower_bound + i, res_lower_bound, 2);
-        i++;
-        d--;
-    }
-
-    if (d >= 2) {
-        res_codes1 = vsetq_lane_f32(codes1[i], res_codes1, 1);
-        res_codes2 = vsetq_lane_f32(codes2[i], res_codes2, 1);
-        res_diff = vld1q_lane_f32(diff + i, res_diff, 1);
-        res_lower_bound = vld1q_lane_f32(lower_bound + i, res_lower_bound, 1);
-        i++;
-        d--;
-    }
-
-    if (d >= 1) {
-        res_codes1 = vsetq_lane_f32(codes1[i], res_codes1, 0);
-        res_codes2 = vsetq_lane_f32(codes2[i], res_codes2, 0);
-        res_diff = vld1q_lane_f32(diff + i, res_diff, 0);
-        res_lower_bound = vld1q_lane_f32(lower_bound + i, res_lower_bound, 0);
-    }
-
-    if (dim > i) {
-        float32x4_t adjusted1 = vfmaq_f32(res_lower_bound, vmulq_f32(res_codes1, inv255), res_diff);
-        float32x4_t adjusted2 = vfmaq_f32(res_lower_bound, vmulq_f32(res_codes2, inv255), res_diff);
-        sum = vfmaq_f32(sum, adjusted1, adjusted2);
-    }
-
-    return vaddvq_f32(sum);
+    return simd::SQ8ComputeCodesIPImpl<simd::SQ8Traits<simd::NEON_SQ8_Tag>>(
+        codes1, codes2, lower_bound, diff, dim, &generic::SQ8ComputeCodesIP);
 #else
     return generic::SQ8ComputeCodesIP(codes1, codes2, lower_bound, diff, dim);
 #endif
@@ -1302,140 +411,8 @@ SQ8ComputeCodesL2Sqr(const uint8_t* RESTRICT codes1,
                      const float* RESTRICT diff,
                      uint64_t dim) {
 #if defined(ENABLE_NEON)
-    const float32x4_t inv255 = vdupq_n_f32(1.0f / 255.0f);
-    float32x4_t sum = vdupq_n_f32(0.0f);
-    uint64_t i = 0;
-
-    // Process 12 elements at a time for optimal instruction usage
-    for (; i + 11 < dim; i += 12) {
-        __builtin_prefetch(codes1 + i + 48, 0, 1);
-        __builtin_prefetch(codes2 + i + 48, 0, 1);
-
-        // Load 12 codes and compute difference at integer level for efficiency
-        uint8x8_t codes1_low = vld1_u8(codes1 + i);
-        uint8x8_t codes2_low = vld1_u8(codes2 + i);
-        uint32x4_t codes1_last = {codes1[i + 8], codes1[i + 9], codes1[i + 10], codes1[i + 11]};
-        uint32x4_t codes2_last = {codes2[i + 8], codes2[i + 9], codes2[i + 10], codes2[i + 11]};
-
-        // Compute code difference at integer level
-        int16x8_t diff_low = vreinterpretq_s16_u16(vsubl_u8(codes1_low, codes2_low));
-        int32x4_t diff_last =
-            vsubq_s32(vreinterpretq_s32_u32(codes1_last), vreinterpretq_s32_u32(codes2_last));
-
-        // Convert to float32x4x3_t
-        float32x4x3_t code_diff_vec;
-        code_diff_vec.val[0] = vcvtq_f32_s32(vmovl_s16(vget_low_s16(diff_low)));
-        code_diff_vec.val[1] = vcvtq_f32_s32(vmovl_s16(vget_high_s16(diff_low)));
-        code_diff_vec.val[2] = vcvtq_f32_s32(diff_last);
-
-        // Load 12 diff values using x3 intrinsics
-        float32x4x3_t diff_vec = vld1q_f32_x3(diff + i);
-
-        // Compute final distance in one fused operation: (code_diff / 255) * diff
-        float32x4x3_t scaled_diff_vec;
-        scaled_diff_vec.val[0] =
-            vmulq_f32(vmulq_f32(code_diff_vec.val[0], inv255), diff_vec.val[0]);
-        scaled_diff_vec.val[1] =
-            vmulq_f32(vmulq_f32(code_diff_vec.val[1], inv255), diff_vec.val[1]);
-        scaled_diff_vec.val[2] =
-            vmulq_f32(vmulq_f32(code_diff_vec.val[2], inv255), diff_vec.val[2]);
-
-        // Compute squared distance and accumulate
-        sum = vfmaq_f32(sum, scaled_diff_vec.val[0], scaled_diff_vec.val[0]);
-        sum = vfmaq_f32(sum, scaled_diff_vec.val[1], scaled_diff_vec.val[1]);
-        sum = vfmaq_f32(sum, scaled_diff_vec.val[2], scaled_diff_vec.val[2]);
-    }
-
-    // Process remaining elements with optimized NEON instructions
-    uint64_t d = dim - i;
-
-    // Process 8 elements if remaining
-    if (d >= 8) {
-        // Load 8 codes and compute difference at integer level
-        uint8x8_t codes1_vec = vld1_u8(codes1 + i);
-        uint8x8_t codes2_vec = vld1_u8(codes2 + i);
-
-        // Compute code difference at integer level
-        int16x8_t diff_codes = vreinterpretq_s16_u16(vsubl_u8(codes1_vec, codes2_vec));
-
-        // Convert to float32x4x2_t
-        float32x4x2_t code_diff_vec;
-        code_diff_vec.val[0] = vcvtq_f32_s32(vmovl_s16(vget_low_s16(diff_codes)));
-        code_diff_vec.val[1] = vcvtq_f32_s32(vmovl_s16(vget_high_s16(diff_codes)));
-
-        // Load 8 diff values
-        float32x4x2_t diff_vec = vld1q_f32_x2(diff + i);
-
-        // Compute scaled distance: (code_diff / 255) * diff
-        float32x4x2_t scaled_diff_vec;
-        scaled_diff_vec.val[0] =
-            vmulq_f32(vmulq_f32(code_diff_vec.val[0], inv255), diff_vec.val[0]);
-        scaled_diff_vec.val[1] =
-            vmulq_f32(vmulq_f32(code_diff_vec.val[1], inv255), diff_vec.val[1]);
-
-        // Compute squared distance and accumulate
-        sum = vfmaq_f32(sum, scaled_diff_vec.val[0], scaled_diff_vec.val[0]);
-        sum = vfmaq_f32(sum, scaled_diff_vec.val[1], scaled_diff_vec.val[1]);
-        i += 8;
-        d -= 8;
-    }
-
-    // Process 4 elements if remaining
-    if (d >= 4) {
-        float32x4_t code1_floats = load_4_uint8_to_float(codes1 + i);
-        float32x4_t code2_floats = load_4_uint8_to_float(codes2 + i);
-        float32x4_t diff_vec = vld1q_f32(diff + i);
-        float32x4_t lower_bound_vec = vld1q_f32(lower_bound + i);
-
-        float32x4_t adjusted1 =
-            vfmaq_f32(lower_bound_vec, vmulq_f32(code1_floats, inv255), diff_vec);
-        float32x4_t adjusted2 =
-            vfmaq_f32(lower_bound_vec, vmulq_f32(code2_floats, inv255), diff_vec);
-        float32x4_t dist = vsubq_f32(adjusted1, adjusted2);
-        sum = vfmaq_f32(sum, dist, dist);
-        i += 4;
-        d -= 4;
-    }
-
-    // Process remaining 1-3 elements
-    float32x4_t res_codes1 = vdupq_n_f32(0.0f);
-    float32x4_t res_codes2 = vdupq_n_f32(0.0f);
-    float32x4_t res_diff = vdupq_n_f32(0.0f);
-    float32x4_t res_lower_bound = vdupq_n_f32(0.0f);
-
-    if (d >= 3) {
-        res_codes1 = vsetq_lane_f32(codes1[i], res_codes1, 2);
-        res_codes2 = vsetq_lane_f32(codes2[i], res_codes2, 2);
-        res_diff = vld1q_lane_f32(diff + i, res_diff, 2);
-        res_lower_bound = vld1q_lane_f32(lower_bound + i, res_lower_bound, 2);
-        i++;
-        d--;
-    }
-
-    if (d >= 2) {
-        res_codes1 = vsetq_lane_f32(codes1[i], res_codes1, 1);
-        res_codes2 = vsetq_lane_f32(codes2[i], res_codes2, 1);
-        res_diff = vld1q_lane_f32(diff + i, res_diff, 1);
-        res_lower_bound = vld1q_lane_f32(lower_bound + i, res_lower_bound, 1);
-        i++;
-        d--;
-    }
-
-    if (d >= 1) {
-        res_codes1 = vsetq_lane_f32(codes1[i], res_codes1, 0);
-        res_codes2 = vsetq_lane_f32(codes2[i], res_codes2, 0);
-        res_diff = vld1q_lane_f32(diff + i, res_diff, 0);
-        res_lower_bound = vld1q_lane_f32(lower_bound + i, res_lower_bound, 0);
-    }
-
-    if (dim > i) {
-        float32x4_t adjusted1 = vfmaq_f32(res_lower_bound, vmulq_f32(res_codes1, inv255), res_diff);
-        float32x4_t adjusted2 = vfmaq_f32(res_lower_bound, vmulq_f32(res_codes2, inv255), res_diff);
-        float32x4_t dist = vsubq_f32(adjusted1, adjusted2);
-        sum = vfmaq_f32(sum, dist, dist);
-    }
-
-    return vaddvq_f32(sum);
+    return simd::SQ8ComputeCodesL2SqrImpl<simd::SQ8Traits<simd::NEON_SQ8_Tag>>(
+        codes1, codes2, lower_bound, diff, dim, &generic::SQ8ComputeCodesL2Sqr);
 #else
     return generic::SQ8ComputeCodesL2Sqr(codes1, codes2, lower_bound, diff, dim);
 #endif
@@ -1448,57 +425,8 @@ SQ4ComputeIP(const float* RESTRICT query,
              const float* RESTRICT diff,
              uint64_t dim) {
 #if defined(ENABLE_NEON)
-    float32x4_t sum = vdupq_n_f32(0.0f);
-    uint64_t d = 0;
-
-    const float inv15 = 1.0f / 15.0f;
-    float32x4_t v_inv15 = vdupq_n_f32(inv15);
-
-    for (; d + 7 < dim; d += 8) {
-        uint8_t byte0 = codes[d >> 1];
-        uint8_t byte1 = codes[(d >> 1) + 1];
-        uint8_t byte2 = codes[(d >> 1) + 2];
-        uint8_t byte3 = codes[(d >> 1) + 3];
-
-        float32x4_t code_low = {
-            static_cast<float>(byte0 & 0x0f),
-            static_cast<float>(byte0 >> 4),
-            static_cast<float>(byte1 & 0x0f),
-            static_cast<float>(byte1 >> 4),
-        };
-
-        float32x4_t code_high = {
-            static_cast<float>(byte2 & 0x0f),
-            static_cast<float>(byte2 >> 4),
-            static_cast<float>(byte3 & 0x0f),
-            static_cast<float>(byte3 >> 4),
-        };
-
-        code_low = vmulq_f32(code_low, v_inv15);
-        code_high = vmulq_f32(code_high, v_inv15);
-
-        float32x4_t query_low = vld1q_f32(query + d);
-        float32x4_t query_high = vld1q_f32(query + d + 4);
-        float32x4_t diff_low = vld1q_f32(diff + d);
-        float32x4_t diff_high = vld1q_f32(diff + d + 4);
-        float32x4_t lb_low = vld1q_f32(lower_bound + d);
-        float32x4_t lb_high = vld1q_f32(lower_bound + d + 4);
-
-        code_low = vmlaq_f32(lb_low, code_low, diff_low);
-        code_high = vmlaq_f32(lb_high, code_high, diff_high);
-
-        sum = vmlaq_f32(sum, query_low, code_low);
-        sum = vmlaq_f32(sum, query_high, code_high);
-    }
-
-    float result = vaddvq_f32(sum);
-
-    if (d < dim) {
-        result +=
-            generic::SQ4ComputeIP(query + d, codes + (d >> 1), lower_bound + d, diff + d, dim - d);
-    }
-
-    return result;
+    return simd::SQ4ComputeIPImpl<simd::SQ4Traits<simd::NEON_SQ4_Tag>>(
+        query, codes, lower_bound, diff, dim, &generic::SQ4ComputeIP);
 #else
     return generic::SQ4ComputeIP(query, codes, lower_bound, diff, dim);
 #endif
@@ -1511,60 +439,8 @@ SQ4ComputeL2Sqr(const float* RESTRICT query,
                 const float* RESTRICT diff,
                 uint64_t dim) {
 #if defined(ENABLE_NEON)
-    float32x4_t sum = vdupq_n_f32(0.0f);
-    uint64_t d = 0;
-
-    const float inv15 = 1.0f / 15.0f;
-    float32x4_t v_inv15 = vdupq_n_f32(inv15);
-
-    for (; d + 7 < dim; d += 8) {
-        uint8_t byte0 = codes[d >> 1];
-        uint8_t byte1 = codes[(d >> 1) + 1];
-        uint8_t byte2 = codes[(d >> 1) + 2];
-        uint8_t byte3 = codes[(d >> 1) + 3];
-
-        float32x4_t code_low = {
-            static_cast<float>(byte0 & 0x0f),
-            static_cast<float>(byte0 >> 4),
-            static_cast<float>(byte1 & 0x0f),
-            static_cast<float>(byte1 >> 4),
-        };
-
-        float32x4_t code_high = {
-            static_cast<float>(byte2 & 0x0f),
-            static_cast<float>(byte2 >> 4),
-            static_cast<float>(byte3 & 0x0f),
-            static_cast<float>(byte3 >> 4),
-        };
-
-        code_low = vmulq_f32(code_low, v_inv15);
-        code_high = vmulq_f32(code_high, v_inv15);
-
-        float32x4_t query_low = vld1q_f32(query + d);
-        float32x4_t query_high = vld1q_f32(query + d + 4);
-        float32x4_t diff_low = vld1q_f32(diff + d);
-        float32x4_t diff_high = vld1q_f32(diff + d + 4);
-        float32x4_t lb_low = vld1q_f32(lower_bound + d);
-        float32x4_t lb_high = vld1q_f32(lower_bound + d + 4);
-
-        code_low = vmlaq_f32(lb_low, code_low, diff_low);
-        code_high = vmlaq_f32(lb_high, code_high, diff_high);
-
-        float32x4_t diff_vec_low = vsubq_f32(query_low, code_low);
-        float32x4_t diff_vec_high = vsubq_f32(query_high, code_high);
-
-        sum = vmlaq_f32(sum, diff_vec_low, diff_vec_low);
-        sum = vmlaq_f32(sum, diff_vec_high, diff_vec_high);
-    }
-
-    float result = vaddvq_f32(sum);
-
-    if (d < dim) {
-        result += generic::SQ4ComputeL2Sqr(
-            query + d, codes + (d >> 1), lower_bound + d, diff + d, dim - d);
-    }
-
-    return result;
+    return simd::SQ4ComputeL2SqrImpl<simd::SQ4Traits<simd::NEON_SQ4_Tag>>(
+        query, codes, lower_bound, diff, dim, &generic::SQ4ComputeL2Sqr);
 #else
     return generic::SQ4ComputeL2Sqr(query, codes, lower_bound, diff, dim);
 #endif
@@ -1577,69 +453,8 @@ SQ4ComputeCodesIP(const uint8_t* RESTRICT codes1,
                   const float* RESTRICT diff,
                   uint64_t dim) {
 #if defined(ENABLE_NEON)
-    float32x4_t sum = vdupq_n_f32(0.0f);
-    uint64_t d = 0;
-    const float inv15 = 1.0f / 15.0f;
-    float32x4_t v_inv15 = vdupq_n_f32(inv15);
-
-    for (; d + 7 < dim; d += 8) {
-        uint8_t byte1_0 = codes1[d >> 1];
-        uint8_t byte1_1 = codes1[(d >> 1) + 1];
-        uint8_t byte1_2 = codes1[(d >> 1) + 2];
-        uint8_t byte1_3 = codes1[(d >> 1) + 3];
-
-        uint8_t byte2_0 = codes2[d >> 1];
-        uint8_t byte2_1 = codes2[(d >> 1) + 1];
-        uint8_t byte2_2 = codes2[(d >> 1) + 2];
-        uint8_t byte2_3 = codes2[(d >> 1) + 3];
-
-        float32x4_t code1_low = {static_cast<float>(byte1_0 & 0x0f),
-                                 static_cast<float>(byte1_0 >> 4),
-                                 static_cast<float>(byte1_1 & 0x0f),
-                                 static_cast<float>(byte1_1 >> 4)};
-
-        float32x4_t code1_high = {static_cast<float>(byte1_2 & 0x0f),
-                                  static_cast<float>(byte1_2 >> 4),
-                                  static_cast<float>(byte1_3 & 0x0f),
-                                  static_cast<float>(byte1_3 >> 4)};
-
-        float32x4_t code2_low = {static_cast<float>(byte2_0 & 0x0f),
-                                 static_cast<float>(byte2_0 >> 4),
-                                 static_cast<float>(byte2_1 & 0x0f),
-                                 static_cast<float>(byte2_1 >> 4)};
-
-        float32x4_t code2_high = {static_cast<float>(byte2_2 & 0x0f),
-                                  static_cast<float>(byte2_2 >> 4),
-                                  static_cast<float>(byte2_3 & 0x0f),
-                                  static_cast<float>(byte2_3 >> 4)};
-
-        code1_low = vmulq_f32(code1_low, v_inv15);
-        code1_high = vmulq_f32(code1_high, v_inv15);
-        code2_low = vmulq_f32(code2_low, v_inv15);
-        code2_high = vmulq_f32(code2_high, v_inv15);
-
-        float32x4_t diff_low = vld1q_f32(diff + d);
-        float32x4_t diff_high = vld1q_f32(diff + d + 4);
-        float32x4_t lb_low = vld1q_f32(lower_bound + d);
-        float32x4_t lb_high = vld1q_f32(lower_bound + d + 4);
-
-        code1_low = vmlaq_f32(lb_low, code1_low, diff_low);
-        code1_high = vmlaq_f32(lb_high, code1_high, diff_high);
-        code2_low = vmlaq_f32(lb_low, code2_low, diff_low);
-        code2_high = vmlaq_f32(lb_high, code2_high, diff_high);
-
-        sum = vmlaq_f32(sum, code1_low, code2_low);
-        sum = vmlaq_f32(sum, code1_high, code2_high);
-    }
-
-    float result = vaddvq_f32(sum);
-
-    if (d < dim) {
-        result += generic::SQ4ComputeCodesIP(
-            codes1 + (d >> 1), codes2 + (d >> 1), lower_bound + d, diff + d, dim - d);
-    }
-
-    return result;
+    return simd::SQ4ComputeCodesIPImpl<simd::SQ4Traits<simd::NEON_SQ4_Tag>>(
+        codes1, codes2, lower_bound, diff, dim, &generic::SQ4ComputeCodesIP);
 #else
     return generic::SQ4ComputeCodesIP(codes1, codes2, lower_bound, diff, dim);
 #endif
@@ -1652,73 +467,8 @@ SQ4ComputeCodesL2Sqr(const uint8_t* RESTRICT codes1,
                      const float* RESTRICT diff,
                      uint64_t dim) {
 #if defined(ENABLE_NEON)
-    float32x4_t sum = vdupq_n_f32(0.0f);
-    uint64_t d = 0;
-
-    const float inv15 = 1.0f / 15.0f;
-    float32x4_t v_inv15 = vdupq_n_f32(inv15);
-
-    for (; d + 7 < dim; d += 8) {
-        uint8_t byte1_0 = codes1[d >> 1];
-        uint8_t byte1_1 = codes1[(d >> 1) + 1];
-        uint8_t byte1_2 = codes1[(d >> 1) + 2];
-        uint8_t byte1_3 = codes1[(d >> 1) + 3];
-
-        uint8_t byte2_0 = codes2[d >> 1];
-        uint8_t byte2_1 = codes2[(d >> 1) + 1];
-        uint8_t byte2_2 = codes2[(d >> 1) + 2];
-        uint8_t byte2_3 = codes2[(d >> 1) + 3];
-
-        float32x4_t code1_low = {static_cast<float>(byte1_0 & 0x0f),
-                                 static_cast<float>(byte1_0 >> 4),
-                                 static_cast<float>(byte1_1 & 0x0f),
-                                 static_cast<float>(byte1_1 >> 4)};
-
-        float32x4_t code1_high = {static_cast<float>(byte1_2 & 0x0f),
-                                  static_cast<float>(byte1_2 >> 4),
-                                  static_cast<float>(byte1_3 & 0x0f),
-                                  static_cast<float>(byte1_3 >> 4)};
-
-        float32x4_t code2_low = {static_cast<float>(byte2_0 & 0x0f),
-                                 static_cast<float>(byte2_0 >> 4),
-                                 static_cast<float>(byte2_1 & 0x0f),
-                                 static_cast<float>(byte2_1 >> 4)};
-
-        float32x4_t code2_high = {static_cast<float>(byte2_2 & 0x0f),
-                                  static_cast<float>(byte2_2 >> 4),
-                                  static_cast<float>(byte2_3 & 0x0f),
-                                  static_cast<float>(byte2_3 >> 4)};
-
-        code1_low = vmulq_f32(code1_low, v_inv15);
-        code1_high = vmulq_f32(code1_high, v_inv15);
-        code2_low = vmulq_f32(code2_low, v_inv15);
-        code2_high = vmulq_f32(code2_high, v_inv15);
-
-        float32x4_t diff_low = vld1q_f32(diff + d);
-        float32x4_t diff_high = vld1q_f32(diff + d + 4);
-        float32x4_t lb_low = vld1q_f32(lower_bound + d);
-        float32x4_t lb_high = vld1q_f32(lower_bound + d + 4);
-
-        code1_low = vmlaq_f32(lb_low, code1_low, diff_low);
-        code1_high = vmlaq_f32(lb_high, code1_high, diff_high);
-        code2_low = vmlaq_f32(lb_low, code2_low, diff_low);
-        code2_high = vmlaq_f32(lb_high, code2_high, diff_high);
-
-        float32x4_t diff_vec_low = vsubq_f32(code1_low, code2_low);
-        float32x4_t diff_vec_high = vsubq_f32(code1_high, code2_high);
-
-        sum = vmlaq_f32(sum, diff_vec_low, diff_vec_low);
-        sum = vmlaq_f32(sum, diff_vec_high, diff_vec_high);
-    }
-
-    float result = vaddvq_f32(sum);
-
-    if (d < dim) {
-        result += generic::SQ4ComputeCodesL2Sqr(
-            codes1 + (d >> 1), codes2 + (d >> 1), lower_bound + d, diff + d, dim - d);
-    }
-
-    return result;
+    return simd::SQ4ComputeCodesL2SqrImpl<simd::SQ4Traits<simd::NEON_SQ4_Tag>>(
+        codes1, codes2, lower_bound, diff, dim, &generic::SQ4ComputeCodesL2Sqr);
 #else
     return generic::SQ4ComputeCodesL2Sqr(codes1, codes2, lower_bound, diff, dim);
 #endif
@@ -2108,18 +858,8 @@ RaBitQFloatSplitCodeIP(const float* vector,
 void
 DivScalar(const float* from, float* to, uint64_t dim, float scalar) {
 #if defined(ENABLE_NEON)
-    if (dim == 0)
-        return;
-    if (scalar == 0)
-        scalar = 1.0f;
-    int i = 0;
-    float32x4_t scalarVec = vdupq_n_f32(scalar);
-    for (; i + 3 < dim; i += 4) {
-        float32x4_t vec = vld1q_f32(from + i);
-        vec = vdivq_f32(vec, scalarVec);
-        vst1q_f32(to + i, vec);
-    }
-    generic::DivScalar(from + i, to + i, dim - i, scalar);
+    simd::DivScalarImpl<simd::SimdTraits<simd::NEON_Tag>>(
+        from, to, dim, scalar, &generic::DivScalar);
 #else
     generic::DivScalar(from, to, dim, scalar);
 #endif
@@ -2193,22 +933,7 @@ PQFastScanLookUp32(const uint8_t* RESTRICT lookup_table,
 void
 BitAnd(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* result) {
 #if defined(ENABLE_NEON)
-    if (num_byte == 0) {
-        return;
-    }
-    if (num_byte < 16) {
-        return generic::BitAnd(x, y, num_byte, result);
-    }
-    int64_t i = 0;
-    for (; i + 15 < num_byte; i += 16) {
-        uint8x16_t x_vec = vld1q_u8(x + i);
-        uint8x16_t y_vec = vld1q_u8(y + i);
-        uint8x16_t result_vec = vandq_u8(x_vec, y_vec);
-        vst1q_u8(result + i, result_vec);
-    }
-    if (i < num_byte) {
-        generic::BitAnd(x + i, y + i, num_byte - i, result + i);
-    }
+    simd::BitAndImpl<simd::BitTraits<simd::NEON_Bit_Tag>>(x, y, num_byte, result, &generic::BitAnd);
 #else
     return generic::BitAnd(x, y, num_byte, result);
 #endif
@@ -2217,22 +942,7 @@ BitAnd(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* res
 void
 BitOr(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* result) {
 #if defined(ENABLE_NEON)
-    if (num_byte == 0) {
-        return;
-    }
-    if (num_byte < 16) {
-        return generic::BitOr(x, y, num_byte, result);
-    }
-    int64_t i = 0;
-    for (; i + 15 < num_byte; i += 16) {
-        uint8x16_t x_vec = vld1q_u8(x + i);
-        uint8x16_t y_vec = vld1q_u8(y + i);
-        uint8x16_t result_vec = vorrq_u8(x_vec, y_vec);
-        vst1q_u8(result + i, result_vec);
-    }
-    if (i < num_byte) {
-        generic::BitOr(x + i, y + i, num_byte - i, result + i);
-    }
+    simd::BitOrImpl<simd::BitTraits<simd::NEON_Bit_Tag>>(x, y, num_byte, result, &generic::BitOr);
 #else
     return generic::BitOr(x, y, num_byte, result);
 #endif
@@ -2241,22 +951,7 @@ BitOr(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* resu
 void
 BitXor(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* result) {
 #if defined(ENABLE_NEON)
-    if (num_byte == 0) {
-        return;
-    }
-    if (num_byte < 16) {
-        return generic::BitXor(x, y, num_byte, result);
-    }
-    int64_t i = 0;
-    for (; i + 15 < num_byte; i += 16) {
-        uint8x16_t x_vec = vld1q_u8(x + i);
-        uint8x16_t y_vec = vld1q_u8(y + i);
-        uint8x16_t result_vec = veorq_u8(x_vec, y_vec);
-        vst1q_u8(result + i, result_vec);
-    }
-    if (i < num_byte) {
-        generic::BitXor(x + i, y + i, num_byte - i, result + i);
-    }
+    simd::BitXorImpl<simd::BitTraits<simd::NEON_Bit_Tag>>(x, y, num_byte, result, &generic::BitXor);
 #else
     return generic::BitXor(x, y, num_byte, result);
 #endif
@@ -2265,21 +960,7 @@ BitXor(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* res
 void
 BitNot(const uint8_t* x, const uint64_t num_byte, uint8_t* result) {
 #if defined(ENABLE_NEON)
-    if (num_byte == 0) {
-        return;
-    }
-    if (num_byte < 16) {
-        return generic::BitNot(x, num_byte, result);
-    }
-    int64_t i = 0;
-    for (; i + 15 < num_byte; i += 16) {
-        uint8x16_t x_vec = vld1q_u8(x + i);
-        uint8x16_t result_vec = veorq_u8(x_vec, vdupq_n_u8(0xFF));
-        vst1q_u8(result + i, result_vec);
-    }
-    if (i < num_byte) {
-        generic::BitNot(x + i, num_byte - i, result + i);
-    }
+    simd::BitNotImpl<simd::BitTraits<simd::NEON_Bit_Tag>>(x, num_byte, result, &generic::BitNot);
 #else
     return generic::BitNot(x, num_byte, result);
 #endif
@@ -2287,31 +968,7 @@ BitNot(const uint8_t* x, const uint64_t num_byte, uint8_t* result) {
 void
 KacsWalk(float* data, uint64_t len) {
 #if defined(ENABLE_NEON)
-    uint64_t base = len % 2;
-    uint64_t offset = base + (len / 2);
-
-    uint64_t i = 0;
-    for (; i + 3 < len / 2; i += 4) {
-        float32x4_t first = vld1q_f32(data + i);
-        float32x4_t second = vld1q_f32(data + i + offset);
-
-        float32x4_t add = vaddq_f32(first, second);
-        float32x4_t sub = vsubq_f32(first, second);
-
-        vst1q_f32(data + i, add);
-        vst1q_f32(data + i + offset, sub);
-    }
-
-    for (; i < len / 2; i++) {
-        float add = data[i] + data[i + offset];
-        float sub = data[i] - data[i + offset];
-        data[i] = add;
-        data[i + offset] = sub;
-    }
-
-    if (base != 0) {
-        data[len / 2] *= std::sqrt(2.0f);
-    }
+    simd::KacsWalkImpl<simd::SimdTraits<simd::NEON_Tag>>(data, len, &generic::KacsWalk);
 #else
     generic::KacsWalk(data, len);
 #endif
@@ -2356,18 +1013,7 @@ FlipSign(const uint8_t* flip, float* data, uint64_t dim) {
 void
 VecRescale(float* data, uint64_t dim, float val) {
 #if defined(ENABLE_NEON)
-    float32x4_t scale = vdupq_n_f32(val);
-    uint64_t i = 0;
-
-    for (; i + 3 < dim; i += 4) {
-        float32x4_t vec = vld1q_f32(data + i);
-        vec = vmulq_f32(vec, scale);
-        vst1q_f32(data + i, vec);
-    }
-
-    for (; i < dim; i++) {
-        data[i] *= val;
-    }
+    simd::VecRescaleImpl<simd::SimdTraits<simd::NEON_Tag>>(data, dim, val, &generic::VecRescale);
 #else
     generic::VecRescale(data, dim, val);
 #endif
@@ -2376,27 +1022,7 @@ VecRescale(float* data, uint64_t dim, float val) {
 void
 RotateOp(float* data, int idx, int dim_, int step) {
 #if defined(ENABLE_NEON)
-    for (int i = idx; i < dim_; i += 2 * step) {
-        int j = 0;
-
-        for (; j + 3 < step; j += 4) {
-            float32x4_t x = vld1q_f32(data + i + j);
-            float32x4_t y = vld1q_f32(data + i + j + step);
-
-            float32x4_t sum = vaddq_f32(x, y);
-            float32x4_t diff = vsubq_f32(x, y);
-
-            vst1q_f32(data + i + j, sum);
-            vst1q_f32(data + i + j + step, diff);
-        }
-
-        for (; j < step; j++) {
-            float x = data[i + j];
-            float y = data[i + j + step];
-            data[i + j] = x + y;
-            data[i + j + step] = x - y;
-        }
-    }
+    simd::RotateOpImpl<simd::SimdTraits<simd::NEON_Tag>>(data, idx, dim_, step);
 #else
     generic::RotateOp(data, idx, dim_, step);
 #endif
@@ -2408,7 +1034,11 @@ FHTRotate(float* data, uint64_t dim_) {
     uint64_t n = dim_;
     uint64_t step = 1;
     while (step < n) {
-        neon::RotateOp(data, 0, dim_, step);
+        if (step >= 4) {
+            neon::RotateOp(data, 0, dim_, step);
+        } else {
+            generic::RotateOp(data, 0, dim_, step);
+        }
         step *= 2;
     }
 #else
@@ -2419,45 +1049,8 @@ FHTRotate(float* data, uint64_t dim_) {
 float
 NormalizeWithCentroid(const float* from, const float* centroid, float* to, uint64_t dim) {
 #if defined(ENABLE_NEON)
-    float norm_sq = 0;
-    uint64_t d = dim;
-    if (d >= 4) {
-        float32x4_t sum = vdupq_n_f32(0.0f);
-        while (d >= 4) {
-            float32x4_t f = vld1q_f32(from + dim - d);
-            float32x4_t c = vld1q_f32(centroid + dim - d);
-            float32x4_t diff = vsubq_f32(f, c);
-            sum = vmlaq_f32(sum, diff, diff);
-            d -= 4;
-        }
-        norm_sq = vaddvq_f32(sum);
-    }
-    if (d > 0) {
-        norm_sq += generic::FP32ComputeL2Sqr(from + dim - d, centroid + dim - d, d);
-    }
-
-    float norm = 0;
-    if (norm_sq < 1e-5f) {
-        norm = 1.0f;
-    } else {
-        norm = std::sqrt(norm_sq);
-    }
-
-    float32x4_t normVec = vdupq_n_f32(norm);
-    uint64_t i = 0;
-    for (; i + 3 < dim; i += 4) {
-        float32x4_t f = vld1q_f32(from + i);
-        float32x4_t c = vld1q_f32(centroid + i);
-        float32x4_t diff = vsubq_f32(f, c);
-        float32x4_t result = vdivq_f32(diff, normVec);
-        vst1q_f32(to + i, result);
-    }
-    if (i < dim) {
-        for (; i < dim; ++i) {
-            to[i] = (from[i] - centroid[i]) / norm;
-        }
-    }
-    return norm;
+    return simd::NormalizeWithCentroidImpl<simd::SimdTraits<simd::NEON_Tag>>(
+        from, centroid, to, dim, &generic::NormalizeWithCentroid);
 #else
     return generic::NormalizeWithCentroid(from, centroid, to, dim);
 #endif
@@ -2467,17 +1060,8 @@ void
 InverseNormalizeWithCentroid(
     const float* from, const float* centroid, float* to, uint64_t dim, float norm) {
 #if defined(ENABLE_NEON)
-    float32x4_t normVec = vdupq_n_f32(norm);
-    uint64_t i = 0;
-    for (; i + 3 < dim; i += 4) {
-        float32x4_t f = vld1q_f32(from + i);
-        float32x4_t c = vld1q_f32(centroid + i);
-        float32x4_t result = vfmaq_f32(c, f, normVec);
-        vst1q_f32(to + i, result);
-    }
-    for (; i < dim; i++) {
-        to[i] = from[i] * norm + centroid[i];
-    }
+    simd::InverseNormalizeWithCentroidImpl<simd::SimdTraits<simd::NEON_Tag>>(
+        from, centroid, to, dim, norm, &generic::InverseNormalizeWithCentroid);
 #else
     generic::InverseNormalizeWithCentroid(from, centroid, to, dim, norm);
 #endif

--- a/src/simd/sse.cpp
+++ b/src/simd/sse.cpp
@@ -18,6 +18,9 @@
 #include "simd/int8_simd.h"
 #if defined(ENABLE_SSE)
 #include <x86intrin.h>
+
+#include "simd/kernels/kernels.h"
+#include "simd/traits/simd_traits_sse.h"
 #endif
 
 #include <cmath>
@@ -71,17 +74,8 @@ INT8InnerProductDistance(const void* pVect1v, const void* pVect2v, const void* q
 void
 PQDistanceFloat256(const void* single_dim_centers, float single_dim_val, void* result) {
 #if defined(ENABLE_SSE)
-    const auto* float_centers = (const float*)single_dim_centers;
-    auto* float_result = (float*)result;
-    for (uint64_t idx = 0; idx < 256; idx += 4) {
-        __m128 v_centers_dim = _mm_loadu_ps(float_centers + idx);
-        __m128 v_query_vec = _mm_set1_ps(single_dim_val);
-        __m128 v_diff = _mm_sub_ps(v_centers_dim, v_query_vec);
-        __m128 v_diff_sq = _mm_mul_ps(v_diff, v_diff);
-        __m128 v_chunk_dists = _mm_loadu_ps(&float_result[idx]);
-        v_chunk_dists = _mm_add_ps(v_chunk_dists, v_diff_sq);
-        _mm_storeu_ps(&float_result[idx], v_chunk_dists);
-    }
+    simd::PQDistanceFloat256Impl<simd::SimdTraits<simd::SSE_Tag>>(
+        single_dim_centers, single_dim_val, result, &generic::PQDistanceFloat256);
 #else
     return generic::PQDistanceFloat256(single_dim_centers, single_dim_val, result);
 #endif
@@ -102,21 +96,8 @@ __inline __m128i __attribute__((__always_inline__)) load_4_short(const uint16_t*
 float
 FP32ComputeIP(const float* RESTRICT query, const float* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_SSE)
-    const int n = dim / 4;
-    if (n == 0) {
-        return generic::FP32ComputeIP(query, codes, dim);
-    }
-    __m128 sum = _mm_setzero_ps();
-    for (int i = 0; i < n; ++i) {
-        __m128 a = _mm_loadu_ps(query + i * 4);
-        __m128 b = _mm_loadu_ps(codes + i * 4);
-        sum = _mm_add_ps(sum, _mm_mul_ps(a, b));
-    }
-    alignas(16) float result[4];
-    _mm_store_ps(result, sum);
-    float ip = result[0] + result[1] + result[2] + result[3];
-    ip += generic::FP32ComputeIP(query + n * 4, codes + n * 4, dim - n * 4);
-    return ip;
+    return simd::ComputeIPImpl<simd::SimdTraits<simd::SSE_Tag>>(
+        query, codes, dim, &generic::FP32ComputeIP);
 #else
     return vsag::generic::FP32ComputeIP(query, codes, dim);
 #endif
@@ -125,22 +106,8 @@ FP32ComputeIP(const float* RESTRICT query, const float* RESTRICT codes, uint64_t
 float
 FP32ComputeL2Sqr(const float* RESTRICT query, const float* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_SSE)
-    const uint64_t n = dim / 4;
-    if (n == 0) {
-        return generic::FP32ComputeL2Sqr(query, codes, dim);
-    }
-    __m128 sum = _mm_setzero_ps();
-    for (int i = 0; i < n; ++i) {
-        __m128 a = _mm_loadu_ps(query + i * 4);
-        __m128 b = _mm_loadu_ps(codes + i * 4);
-        __m128 diff = _mm_sub_ps(a, b);
-        sum = _mm_add_ps(sum, _mm_mul_ps(diff, diff));
-    }
-    alignas(16) float result[4];
-    _mm_store_ps(result, sum);
-    float l2 = result[0] + result[1] + result[2] + result[3];
-    l2 += generic::FP32ComputeL2Sqr(query + n * 4, codes + n * 4, dim - n * 4);
-    return l2;
+    return simd::ComputeL2SqrImpl<simd::SimdTraits<simd::SSE_Tag>>(
+        query, codes, dim, &generic::FP32ComputeL2Sqr);
 #else
     return vsag::generic::FP32ComputeL2Sqr(query, codes, dim);
 #endif
@@ -158,47 +125,18 @@ FP32ComputeIPBatch4(const float* RESTRICT query,
                     float& result3,
                     float& result4) {
 #if defined(ENABLE_SSE)
-    if (dim < 4) {
-        return generic::FP32ComputeIPBatch4(
-            query, dim, codes1, codes2, codes3, codes4, result1, result2, result3, result4);
-    }
-    __m128 sum1 = _mm_setzero_ps();
-    __m128 sum2 = _mm_setzero_ps();
-    __m128 sum3 = _mm_setzero_ps();
-    __m128 sum4 = _mm_setzero_ps();
-    int i = 0;
-    for (; i + 3 < dim; i += 4) {
-        __m128 q = _mm_loadu_ps(query + i);
-        __m128 c1 = _mm_loadu_ps(codes1 + i);
-        __m128 c2 = _mm_loadu_ps(codes2 + i);
-        __m128 c3 = _mm_loadu_ps(codes3 + i);
-        __m128 c4 = _mm_loadu_ps(codes4 + i);
-        sum1 = _mm_add_ps(sum1, _mm_mul_ps(q, c1));
-        sum2 = _mm_add_ps(sum2, _mm_mul_ps(q, c2));
-        sum3 = _mm_add_ps(sum3, _mm_mul_ps(q, c3));
-        sum4 = _mm_add_ps(sum4, _mm_mul_ps(q, c4));
-    }
-    alignas(16) float result[4];
-    _mm_store_ps(result, sum1);
-    result1 += result[0] + result[1] + result[2] + result[3];
-    _mm_store_ps(result, sum2);
-    result2 += result[0] + result[1] + result[2] + result[3];
-    _mm_store_ps(result, sum3);
-    result3 += result[0] + result[1] + result[2] + result[3];
-    _mm_store_ps(result, sum4);
-    result4 += result[0] + result[1] + result[2] + result[3];
-    if (i < dim) {
-        generic::FP32ComputeIPBatch4(query + i,
-                                     dim - i,
-                                     codes1 + i,
-                                     codes2 + i,
-                                     codes3 + i,
-                                     codes4 + i,
-                                     result1,
-                                     result2,
-                                     result3,
-                                     result4);
-    }
+    simd::ComputeBatch4Impl<simd::SimdTraits<simd::SSE_Tag>, simd::Batch4Kind::IP>(
+        query,
+        dim,
+        codes1,
+        codes2,
+        codes3,
+        codes4,
+        result1,
+        result2,
+        result3,
+        result4,
+        &generic::FP32ComputeIPBatch4);
 #else
     return generic::FP32ComputeIPBatch4(
         query, dim, codes1, codes2, codes3, codes4, result1, result2, result3, result4);
@@ -217,51 +155,18 @@ FP32ComputeL2SqrBatch4(const float* RESTRICT query,
                        float& result3,
                        float& result4) {
 #if defined(ENABLE_SSE)
-    if (dim < 4) {
-        return generic::FP32ComputeL2SqrBatch4(
-            query, dim, codes1, codes2, codes3, codes4, result1, result2, result3, result4);
-    }
-    __m128 sum1 = _mm_setzero_ps();
-    __m128 sum2 = _mm_setzero_ps();
-    __m128 sum3 = _mm_setzero_ps();
-    __m128 sum4 = _mm_setzero_ps();
-    int i = 0;
-    for (; i + 3 < dim; i += 4) {
-        __m128 q = _mm_loadu_ps(query + i);
-        __m128 c1 = _mm_loadu_ps(codes1 + i);
-        __m128 c2 = _mm_loadu_ps(codes2 + i);
-        __m128 c3 = _mm_loadu_ps(codes3 + i);
-        __m128 c4 = _mm_loadu_ps(codes4 + i);
-        __m128 diff1 = _mm_sub_ps(q, c1);
-        __m128 diff2 = _mm_sub_ps(q, c2);
-        __m128 diff3 = _mm_sub_ps(q, c3);
-        __m128 diff4 = _mm_sub_ps(q, c4);
-        sum1 = _mm_add_ps(sum1, _mm_mul_ps(diff1, diff1));
-        sum2 = _mm_add_ps(sum2, _mm_mul_ps(diff2, diff2));
-        sum3 = _mm_add_ps(sum3, _mm_mul_ps(diff3, diff3));
-        sum4 = _mm_add_ps(sum4, _mm_mul_ps(diff4, diff4));
-    }
-    alignas(16) float result[4];
-    _mm_store_ps(result, sum1);
-    result1 += result[0] + result[1] + result[2] + result[3];
-    _mm_store_ps(result, sum2);
-    result2 += result[0] + result[1] + result[2] + result[3];
-    _mm_store_ps(result, sum3);
-    result3 += result[0] + result[1] + result[2] + result[3];
-    _mm_store_ps(result, sum4);
-    result4 += result[0] + result[1] + result[2] + result[3];
-    if (i < dim) {
-        generic::FP32ComputeL2SqrBatch4(query + i,
-                                        dim - i,
-                                        codes1 + i,
-                                        codes2 + i,
-                                        codes3 + i,
-                                        codes4 + i,
-                                        result1,
-                                        result2,
-                                        result3,
-                                        result4);
-    }
+    simd::ComputeBatch4Impl<simd::SimdTraits<simd::SSE_Tag>, simd::Batch4Kind::L2>(
+        query,
+        dim,
+        codes1,
+        codes2,
+        codes3,
+        codes4,
+        result1,
+        result2,
+        result3,
+        result4,
+        &generic::FP32ComputeL2SqrBatch4);
 #else
     return generic::FP32ComputeL2SqrBatch4(
         query, dim, codes1, codes2, codes3, codes4, result1, result2, result3, result4);
@@ -271,19 +176,8 @@ FP32ComputeL2SqrBatch4(const float* RESTRICT query,
 void
 FP32Sub(const float* x, const float* y, float* z, uint64_t dim) {
 #if defined(ENABLE_SSE)
-    if (dim < 4) {
-        return generic::FP32Sub(x, y, z, dim);
-    }
-    int64_t i = 0;
-    for (; i + 3 < dim; i += 4) {
-        __m128 a = _mm_loadu_ps(x + i);
-        __m128 b = _mm_loadu_ps(y + i);
-        __m128 c = _mm_sub_ps(a, b);
-        _mm_storeu_ps(z + i, c);
-    }
-    if (i < dim) {
-        generic::FP32Sub(x + i, y + i, z + i, dim - i);
-    }
+    simd::BinaryOpImpl<simd::SimdTraits<simd::SSE_Tag>, simd::BinaryOp::Sub>(
+        x, y, z, dim, &generic::FP32Sub);
 #else
     return generic::FP32Sub(x, y, z, dim);
 #endif
@@ -292,19 +186,8 @@ FP32Sub(const float* x, const float* y, float* z, uint64_t dim) {
 void
 FP32Add(const float* x, const float* y, float* z, uint64_t dim) {
 #if defined(ENABLE_SSE)
-    if (dim < 4) {
-        return generic::FP32Add(x, y, z, dim);
-    }
-    int64_t i = 0;
-    for (; i + 3 < dim; i += 4) {
-        __m128 a = _mm_loadu_ps(x + i);
-        __m128 b = _mm_loadu_ps(y + i);
-        __m128 c = _mm_add_ps(a, b);
-        _mm_storeu_ps(z + i, c);
-    }
-    if (i < dim) {
-        generic::FP32Add(x + i, y + i, z + i, dim - i);
-    }
+    simd::BinaryOpImpl<simd::SimdTraits<simd::SSE_Tag>, simd::BinaryOp::Add>(
+        x, y, z, dim, &generic::FP32Add);
 #else
     return generic::FP32Add(x, y, z, dim);
 #endif
@@ -313,19 +196,8 @@ FP32Add(const float* x, const float* y, float* z, uint64_t dim) {
 void
 FP32Mul(const float* x, const float* y, float* z, uint64_t dim) {
 #if defined(ENABLE_SSE)
-    if (dim < 4) {
-        return generic::FP32Mul(x, y, z, dim);
-    }
-    int64_t i = 0;
-    for (; i + 3 < dim; i += 4) {
-        __m128 a = _mm_loadu_ps(x + i);
-        __m128 b = _mm_loadu_ps(y + i);
-        __m128 c = _mm_mul_ps(a, b);
-        _mm_storeu_ps(z + i, c);
-    }
-    if (i < dim) {
-        generic::FP32Mul(x + i, y + i, z + i, dim - i);
-    }
+    simd::BinaryOpImpl<simd::SimdTraits<simd::SSE_Tag>, simd::BinaryOp::Mul>(
+        x, y, z, dim, &generic::FP32Mul);
 #else
     return generic::FP32Mul(x, y, z, dim);
 #endif
@@ -334,19 +206,8 @@ FP32Mul(const float* x, const float* y, float* z, uint64_t dim) {
 void
 FP32Div(const float* x, const float* y, float* z, uint64_t dim) {
 #if defined(ENABLE_SSE)
-    if (dim < 4) {
-        return generic::FP32Div(x, y, z, dim);
-    }
-    int64_t i = 0;
-    for (; i + 3 < dim; i += 4) {
-        __m128 a = _mm_loadu_ps(x + i);
-        __m128 b = _mm_loadu_ps(y + i);
-        __m128 c = _mm_div_ps(a, b);
-        _mm_storeu_ps(z + i, c);
-    }
-    if (i < dim) {
-        generic::FP32Div(x + i, y + i, z + i, dim - i);
-    }
+    simd::BinaryOpImpl<simd::SimdTraits<simd::SSE_Tag>, simd::BinaryOp::Div>(
+        x, y, z, dim, &generic::FP32Div);
 #else
     return generic::FP32Div(x, y, z, dim);
 #endif
@@ -355,22 +216,7 @@ FP32Div(const float* x, const float* y, float* z, uint64_t dim) {
 float
 FP32ReduceAdd(const float* x, uint64_t dim) {
 #if defined(ENABLE_SSE)
-    if (dim < 4) {
-        return generic::FP32ReduceAdd(x, dim);
-    }
-    __m128 sum = _mm_setzero_ps();
-    int i = 0;
-    for (; i + 3 < dim; i += 4) {
-        __m128 a = _mm_loadu_ps(x + i);
-        sum = _mm_add_ps(sum, a);
-    }
-    sum = _mm_hadd_ps(sum, sum);
-    sum = _mm_hadd_ps(sum, sum);
-    float result = _mm_cvtss_f32(sum);
-    if (i < dim) {
-        result += generic::FP32ReduceAdd(x + i, dim - i);
-    }
-    return result;
+    return simd::ReduceAddImpl<simd::SimdTraits<simd::SSE_Tag>>(x, dim, &generic::FP32ReduceAdd);
 #else
     return generic::FP32ReduceAdd(x, dim);
 #endif
@@ -379,34 +225,8 @@ FP32ReduceAdd(const float* x, uint64_t dim) {
 float
 BF16ComputeIP(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_SSE)
-    // Initialize the sum to 0
-    __m128 sum = _mm_setzero_ps();
-    const auto* query_bf16 = (const uint16_t*)(query);
-    const auto* codes_bf16 = (const uint16_t*)(codes);
-    // Process the data in 128-bit chunks
-    uint64_t i = 0;
-    for (; i + 3 < dim; i += 4) {
-        // Load data into registers
-        __m128i query_vec = load_4_short(query_bf16 + i);
-        __m128 query_float = _mm_castsi128_ps(query_vec);
-
-        // Load data into registers
-        __m128i code_vec = load_4_short(codes_bf16 + i);
-        __m128 code_float = _mm_castsi128_ps(code_vec);
-
-        __m128 mul = _mm_mul_ps(query_float, code_float);
-        sum = _mm_add_ps(sum, mul);
-    }
-
-    // Horizontal addition
-    sum = _mm_hadd_ps(sum, sum);
-    sum = _mm_hadd_ps(sum, sum);
-
-    // Extract the result from the register
-    alignas(16) float result[4];
-    _mm_store_ps(result, sum);
-
-    return result[0] + generic::BF16ComputeIP(query + i * 2, codes + i * 2, dim - i);
+    return simd::HalfComputeIPImpl<simd::BF16Traits<simd::SSE_BF16_Tag>>(
+        query, codes, dim, &generic::BF16ComputeIP);
 #else
     return generic::BF16ComputeIP(query, codes, dim);
 #endif
@@ -415,35 +235,8 @@ BF16ComputeIP(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint
 float
 BF16ComputeL2Sqr(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_SSE)
-    // Initialize the sum to 0
-    __m128 sum = _mm_setzero_ps();
-    const auto* query_bf16 = (const uint16_t*)(query);
-    const auto* codes_bf16 = (const uint16_t*)(codes);
-
-    // Process the data in 128-bit chunks
-    uint64_t i = 0;
-    for (; i + 3 < dim; i += 4) {
-        // Load data into registers
-        __m128i query_vec = load_4_short(query_bf16 + i);
-        __m128 query_float = _mm_castsi128_ps(query_vec);
-
-        // Load data into registers
-        __m128i code_vec = load_4_short(codes_bf16 + i);
-        __m128 code_float = _mm_castsi128_ps(code_vec);
-
-        __m128 diff = _mm_sub_ps(code_float, query_float);
-        sum = _mm_add_ps(sum, _mm_mul_ps(diff, diff));
-    }
-
-    // Horizontal addition
-    sum = _mm_hadd_ps(sum, sum);
-    sum = _mm_hadd_ps(sum, sum);
-
-    // Extract the result from the register
-    alignas(16) float result[4];
-    _mm_store_ps(result, sum);
-
-    return result[0] + generic::BF16ComputeL2Sqr(query + i * 2, codes + i * 2, dim - i);
+    return simd::HalfComputeL2SqrImpl<simd::BF16Traits<simd::SSE_BF16_Tag>>(
+        query, codes, dim, &generic::BF16ComputeL2Sqr);
 #else
     return generic::BF16ComputeL2Sqr(query, codes, dim);
 #endif
@@ -462,38 +255,8 @@ FP16ComputeL2Sqr(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, u
 float
 INT8ComputeL2Sqr(const int8_t* RESTRICT query, const int8_t* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_SSE)
-    constexpr int64_t BATCH_SIZE{8};
-
-    const uint64_t n = dim / BATCH_SIZE;
-
-    if (n == 0) {
-        return generic::INT8ComputeL2Sqr(query, codes, dim);
-    }
-
-    __m128i sum_sq = _mm_setzero_si128();
-
-    for (uint64_t i = 0; i < n; ++i) {
-        __m128i q = _mm_loadl_epi64(reinterpret_cast<const __m128i*>(query + BATCH_SIZE * i));
-        __m128i c = _mm_loadl_epi64(reinterpret_cast<const __m128i*>(codes + BATCH_SIZE * i));
-
-        __m128i q_low = _mm_cvtepi8_epi16(q);
-        __m128i c_low = _mm_cvtepi8_epi16(c);
-
-        __m128i diff = _mm_sub_epi16(q_low, c_low);
-
-        __m128i sq = _mm_madd_epi16(diff, diff);
-
-        sum_sq = _mm_add_epi32(sum_sq, sq);
-    }
-
-    alignas(32) int32_t result[BATCH_SIZE / 2];
-    _mm_store_si128(reinterpret_cast<__m128i*>(result), sum_sq);
-    int64_t l2 = static_cast<int64_t>(result[0]) + result[1] + result[2] + result[3];
-
-    l2 += generic::INT8ComputeL2Sqr(
-        query + BATCH_SIZE * n, codes + BATCH_SIZE * n, dim - BATCH_SIZE * n);
-
-    return static_cast<float>(l2);
+    return simd::Int8ComputeL2SqrImpl<simd::Int8Traits<simd::SSE_Int8_Tag>>(
+        query, codes, dim, &generic::INT8ComputeL2Sqr);
 #else
     return generic::INT8ComputeL2Sqr(query, codes, dim);
 #endif
@@ -502,34 +265,8 @@ INT8ComputeL2Sqr(const int8_t* RESTRICT query, const int8_t* RESTRICT codes, uin
 float
 INT8ComputeIP(const int8_t* __restrict query, const int8_t* __restrict codes, uint64_t dim) {
 #if defined(ENABLE_SSE)
-    constexpr int BATCH_SIZE = 8;
-    const uint64_t n = dim / BATCH_SIZE;
-
-    if (n == 0) {
-        return generic::INT8ComputeIP(query, codes, dim);
-    }
-    __m128i sum_sq = _mm_setzero_si128();
-
-    for (uint64_t i = 0; i < n; ++i) {
-        __m128i q = _mm_loadl_epi64(reinterpret_cast<const __m128i*>(query + BATCH_SIZE * i));
-        __m128i c = _mm_loadl_epi64(reinterpret_cast<const __m128i*>(codes + BATCH_SIZE * i));
-
-        __m128i q_low = _mm_cvtepi8_epi16(q);
-        __m128i c_low = _mm_cvtepi8_epi16(c);
-
-        __m128i sq = _mm_madd_epi16(q_low, c_low);
-
-        sum_sq = _mm_add_epi32(sum_sq, sq);
-    }
-
-    alignas(32) int32_t result[BATCH_SIZE / 2];
-    _mm_store_si128(reinterpret_cast<__m128i*>(result), sum_sq);
-    int64_t ip = static_cast<int64_t>(result[0]) + result[1] + result[2] + result[3];
-
-    ip += generic::INT8ComputeIP(
-        query + BATCH_SIZE * n, codes + BATCH_SIZE * n, dim - BATCH_SIZE * n);
-
-    return static_cast<float>(ip);
+    return simd::Int8ComputeIPImpl<simd::Int8Traits<simd::SSE_Int8_Tag>>(
+        query, codes, dim, &generic::INT8ComputeIP);
 #else
     return generic::INT8ComputeIP(query, codes, dim);
 #endif
@@ -542,36 +279,8 @@ SQ8ComputeIP(const float* RESTRICT query,
              const float* RESTRICT diff,
              uint64_t dim) {
 #if defined(ENABLE_SSE)
-    // Initialize the sum to 0
-    __m128 sum = _mm_setzero_ps();
-
-    // Process the data in 128-bit chunks
-    uint64_t i = 0;
-    for (; i + 3 < dim; i += 4) {
-        // Load data into registers
-        __m128i code_values = load_4_char(codes + i);
-        __m128 code_floats = _mm_cvtepi32_ps(_mm_cvtepu8_epi32(code_values));
-        __m128 query_values = _mm_loadu_ps(query + i);
-        __m128 diff_values = _mm_loadu_ps(diff + i);
-        __m128 lower_bound_values = _mm_loadu_ps(lower_bound + i);
-
-        // Perform calculations
-        __m128 scaled_codes = _mm_mul_ps(_mm_div_ps(code_floats, _mm_set1_ps(255.0f)), diff_values);
-        __m128 adjusted_codes = _mm_add_ps(scaled_codes, lower_bound_values);
-        __m128 val = _mm_mul_ps(query_values, adjusted_codes);
-        sum = _mm_add_ps(sum, val);
-    }
-
-    // Horizontal addition
-    sum = _mm_hadd_ps(sum, sum);
-    sum = _mm_hadd_ps(sum, sum);
-
-    // Extract the result from the register
-    alignas(16) float result[4];
-    _mm_store_ps(result, sum);
-
-    return result[0] +
-           generic::SQ8ComputeIP(query + i, codes + i, lower_bound + i, diff + i, dim - i);
+    return simd::SQ8ComputeIPImpl<simd::SQ8Traits<simd::SSE_SQ8_Tag>>(
+        query, codes, lower_bound, diff, dim, &generic::SQ8ComputeIP);
 #else
     return generic::SQ8ComputeIP(query, codes, lower_bound, diff, dim);
 #endif
@@ -584,36 +293,8 @@ SQ8ComputeL2Sqr(const float* RESTRICT query,
                 const float* RESTRICT diff,
                 uint64_t dim) {
 #if defined(ENABLE_SSE)
-    __m128 sum = _mm_setzero_ps();
-
-    // Process the data in 128-bit chunks
-    uint64_t i = 0;
-    for (; i + 3 < dim; i += 4) {
-        // Load data into registers
-        __m128i code_values = _mm_cvtepu8_epi32(load_4_char(codes + i));
-        __m128 code_floats = _mm_div_ps(_mm_cvtepi32_ps(code_values), _mm_set1_ps(255.0f));
-        __m128 diff_values = _mm_loadu_ps(diff + i);
-        __m128 lower_bound_values = _mm_loadu_ps(lower_bound + i);
-        __m128 query_values = _mm_loadu_ps(query + i);
-
-        // Perform calculations
-        __m128 scaled_codes = _mm_mul_ps(code_floats, diff_values);
-        scaled_codes = _mm_add_ps(scaled_codes, lower_bound_values);
-        __m128 val = _mm_sub_ps(query_values, scaled_codes);
-        val = _mm_mul_ps(val, val);
-        sum = _mm_add_ps(sum, val);
-    }
-    // Perform horizontal addition
-    sum = _mm_hadd_ps(sum, sum);
-    sum = _mm_hadd_ps(sum, sum);
-
-    // Extract the result from the register
-    float result;
-    _mm_store_ss(&result, sum);
-
-    result += generic::SQ8ComputeL2Sqr(query + i, codes + i, lower_bound + i, diff + i, dim - i);
-
-    return result;
+    return simd::SQ8ComputeL2SqrImpl<simd::SQ8Traits<simd::SSE_SQ8_Tag>>(
+        query, codes, lower_bound, diff, dim, &generic::SQ8ComputeL2Sqr);
 #else
     return generic::SQ8ComputeL2Sqr(query, codes, lower_bound, diff, dim);
 #endif
@@ -626,35 +307,8 @@ SQ8ComputeCodesIP(const uint8_t* RESTRICT codes1,
                   const float* RESTRICT diff,
                   uint64_t dim) {
 #if defined(ENABLE_SSE)
-    __m128 sum = _mm_setzero_ps();
-    uint64_t i = 0;
-    for (; i + 3 < dim; i += 4) {
-        // Load data into registers
-        __m128i code1_values = load_4_char(codes1 + i);
-        __m128i code2_values = load_4_char(codes2 + i);
-        __m128i codes1_128 = _mm_cvtepu8_epi32(code1_values);
-        __m128i codes2_128 = _mm_cvtepu8_epi32(code2_values);
-        __m128 codes1_floats = _mm_div_ps(_mm_cvtepi32_ps(codes1_128), _mm_set1_ps(255.0f));
-        __m128 codes2_floats = _mm_div_ps(_mm_cvtepi32_ps(codes2_128), _mm_set1_ps(255.0f));
-        __m128 diff_values = _mm_loadu_ps(diff + i);
-        __m128 lower_bound_values = _mm_loadu_ps(lower_bound + i);
-        // Perform calculations
-        __m128 scaled_codes1 =
-            _mm_add_ps(_mm_mul_ps(codes1_floats, diff_values), lower_bound_values);
-        __m128 scaled_codes2 =
-            _mm_add_ps(_mm_mul_ps(codes2_floats, diff_values), lower_bound_values);
-        __m128 val = _mm_mul_ps(scaled_codes1, scaled_codes2);
-        sum = _mm_add_ps(sum, val);
-    }
-    // Horizontal addition
-    sum = _mm_hadd_ps(sum, sum);
-    sum = _mm_hadd_ps(sum, sum);
-    // Extract the result from the register
-    float result;
-    _mm_store_ss(&result, sum);
-    result +=
-        generic::SQ8ComputeCodesIP(codes1 + i, codes2 + i, lower_bound + i, diff + i, dim - i);
-    return result;
+    return simd::SQ8ComputeCodesIPImpl<simd::SQ8Traits<simd::SSE_SQ8_Tag>>(
+        codes1, codes2, lower_bound, diff, dim, &generic::SQ8ComputeCodesIP);
 #else
     return generic::SQ8ComputeCodesIP(codes1, codes2, lower_bound, diff, dim);
 #endif
@@ -667,38 +321,10 @@ SQ8ComputeCodesL2Sqr(const uint8_t* RESTRICT codes1,
                      const float* RESTRICT diff,
                      uint64_t dim) {
 #if defined(ENABLE_SSE)
-    __m128 sum = _mm_setzero_ps();
-    uint64_t i = 0;
-    for (; i + 3 < dim; i += 4) {
-        // Load data into registers
-        __m128i code1_values = load_4_char(codes1 + i);
-        __m128i code2_values = load_4_char(codes2 + i);
-        __m128i codes1_128 = _mm_cvtepu8_epi32(code1_values);
-        __m128i codes2_128 = _mm_cvtepu8_epi32(code2_values);
-        __m128 codes1_floats = _mm_div_ps(_mm_cvtepi32_ps(codes1_128), _mm_set1_ps(255.0f));
-        __m128 codes2_floats = _mm_div_ps(_mm_cvtepi32_ps(codes2_128), _mm_set1_ps(255.0f));
-        __m128 diff_values = _mm_loadu_ps(diff + i);
-        __m128 lower_bound_values = _mm_loadu_ps(lower_bound + i);
-        // Perform calculations
-        __m128 scaled_codes1 =
-            _mm_add_ps(_mm_mul_ps(codes1_floats, diff_values), lower_bound_values);
-        __m128 scaled_codes2 =
-            _mm_add_ps(_mm_mul_ps(codes2_floats, diff_values), lower_bound_values);
-        __m128 val = _mm_sub_ps(scaled_codes1, scaled_codes2);
-        val = _mm_mul_ps(val, val);
-        sum = _mm_add_ps(sum, val);
-    }
-    // Horizontal addition
-    sum = _mm_hadd_ps(sum, sum);
-    sum = _mm_hadd_ps(sum, sum);
-    // Extract the result from the register
-    float result;
-    _mm_store_ss(&result, sum);
-    result +=
-        generic::SQ8ComputeCodesL2Sqr(codes1 + i, codes2 + i, lower_bound + i, diff + i, dim - i);
-    return result;
+    return simd::SQ8ComputeCodesL2SqrImpl<simd::SQ8Traits<simd::SSE_SQ8_Tag>>(
+        codes1, codes2, lower_bound, diff, dim, &generic::SQ8ComputeCodesL2Sqr);
 #else
-    return generic::SQ8ComputeCodesIP(codes1, codes2, lower_bound, diff, dim);
+    return generic::SQ8ComputeCodesL2Sqr(codes1, codes2, lower_bound, diff, dim);
 #endif
 }
 
@@ -709,68 +335,8 @@ SQ4ComputeIP(const float* RESTRICT query,
              const float* RESTRICT diff,
              uint64_t dim) {
 #if defined(ENABLE_SSE)
-    if (dim == 0) {
-        return 0;
-    }
-
-    float result = 0;
-    uint64_t d = 0;
-
-    // Process 8 values at a time (4 bytes containing 8 4-bit values)
-    for (; d + 7 < dim; d += 8) {
-        // Load 4 bytes (8 4-bit values)
-        __m128i code_vec = load_4_char(codes + (d >> 1));
-
-        // Extract low nibbles (values 0,2,4,6) - even indices
-        __m128i low_nibbles = _mm_and_si128(code_vec, _mm_set1_epi8(0x0F));
-        // Extract high nibbles (values 1,3,5,7) - odd indices
-        __m128i high_nibbles = _mm_and_si128(_mm_srli_epi16(code_vec, 4), _mm_set1_epi8(0x0F));
-
-        // Interleave low and high nibbles to get correct order: [d0, d1, d2, d3, d4, d5, d6, d7]
-        __m128i interleaved = _mm_unpacklo_epi8(low_nibbles, high_nibbles);
-
-        // Convert to float and scale
-        __m128i low_part = _mm_cvtepu8_epi32(interleaved);
-        __m128i high_part = _mm_cvtepu8_epi32(_mm_srli_si128(interleaved, 4));
-        __m128 values0 = _mm_cvtepi32_ps(low_part);
-        __m128 values1 = _mm_cvtepi32_ps(high_part);
-
-        // Scale by 1/15.0
-        __m128 scale = _mm_set1_ps(1.0f / 15.0f);
-        values0 = _mm_mul_ps(values0, scale);
-        values1 = _mm_mul_ps(values1, scale);
-
-        // Apply diff and lower_bound
-        __m128 diff_vec0 = _mm_loadu_ps(diff + d);
-        __m128 diff_vec1 = _mm_loadu_ps(diff + d + 4);
-        __m128 lb_vec0 = _mm_loadu_ps(lower_bound + d);
-        __m128 lb_vec1 = _mm_loadu_ps(lower_bound + d + 4);
-
-        values0 = _mm_add_ps(_mm_mul_ps(values0, diff_vec0), lb_vec0);
-        values1 = _mm_add_ps(_mm_mul_ps(values1, diff_vec1), lb_vec1);
-
-        // Load query vectors
-        __m128 query_vec0 = _mm_loadu_ps(query + d);
-        __m128 query_vec1 = _mm_loadu_ps(query + d + 4);
-
-        // Compute dot products
-        __m128 prod0 = _mm_mul_ps(query_vec0, values0);
-        __m128 prod1 = _mm_mul_ps(query_vec1, values1);
-
-        // Horizontal sum
-        __m128 sum01 = _mm_add_ps(prod0, prod1);
-        __m128 sum23 = _mm_shuffle_ps(sum01, sum01, _MM_SHUFFLE(2, 3, 0, 1));
-        __m128 sum0123 = _mm_add_ps(sum01, sum23);
-        __m128 sum4567 = _mm_movehl_ps(sum0123, sum0123);
-        __m128 sum = _mm_add_ss(sum0123, sum4567);
-
-        result += _mm_cvtss_f32(sum);
-    }
-
-    // Process remaining elements with generic implementation
-    result +=
-        generic::SQ4ComputeIP(query + d, codes + (d >> 1), lower_bound + d, diff + d, dim - d);
-    return result;
+    return simd::SQ4ComputeIPImpl<simd::SQ4Traits<simd::SSE_SQ4_Tag>>(
+        query, codes, lower_bound, diff, dim, &generic::SQ4ComputeIP);
 #else
     return generic::SQ4ComputeIP(query, codes, lower_bound, diff, dim);
 #endif
@@ -783,72 +349,8 @@ SQ4ComputeL2Sqr(const float* RESTRICT query,
                 const float* RESTRICT diff,
                 uint64_t dim) {
 #if defined(ENABLE_SSE)
-    if (dim == 0) {
-        return 0;
-    }
-
-    float result = 0;
-    uint64_t d = 0;
-
-    // Process 8 values at a time (4 bytes containing 8 4-bit values)
-    for (; d + 7 < dim; d += 8) {
-        // Load 4 bytes (8 4-bit values)
-        __m128i code_vec = load_4_char(codes + (d >> 1));
-
-        // Extract low nibbles (values 0,2,4,6) - even indices
-        __m128i low_nibbles = _mm_and_si128(code_vec, _mm_set1_epi8(0x0F));
-        // Extract high nibbles (values 1,3,5,7) - odd indices
-        __m128i high_nibbles = _mm_and_si128(_mm_srli_epi16(code_vec, 4), _mm_set1_epi8(0x0F));
-
-        // Interleave low and high nibbles to get correct order: [d0, d1, d2, d3, d4, d5, d6, d7]
-        __m128i interleaved = _mm_unpacklo_epi8(low_nibbles, high_nibbles);
-
-        // Convert to float and scale
-        __m128i low_part = _mm_cvtepu8_epi32(interleaved);
-        __m128i high_part = _mm_cvtepu8_epi32(_mm_srli_si128(interleaved, 4));
-        __m128 values0 = _mm_cvtepi32_ps(low_part);
-        __m128 values1 = _mm_cvtepi32_ps(high_part);
-
-        // Scale by 1/15.0
-        __m128 scale = _mm_set1_ps(1.0f / 15.0f);
-        values0 = _mm_mul_ps(values0, scale);
-        values1 = _mm_mul_ps(values1, scale);
-
-        // Apply diff and lower_bound
-        __m128 diff_vec0 = _mm_loadu_ps(diff + d);
-        __m128 diff_vec1 = _mm_loadu_ps(diff + d + 4);
-        __m128 lb_vec0 = _mm_loadu_ps(lower_bound + d);
-        __m128 lb_vec1 = _mm_loadu_ps(lower_bound + d + 4);
-
-        values0 = _mm_add_ps(_mm_mul_ps(values0, diff_vec0), lb_vec0);
-        values1 = _mm_add_ps(_mm_mul_ps(values1, diff_vec1), lb_vec1);
-
-        // Load query vectors
-        __m128 query_vec0 = _mm_loadu_ps(query + d);
-        __m128 query_vec1 = _mm_loadu_ps(query + d + 4);
-
-        // Compute differences
-        __m128 diff0 = _mm_sub_ps(query_vec0, values0);
-        __m128 diff1 = _mm_sub_ps(query_vec1, values1);
-
-        // Square differences
-        __m128 sq_diff0 = _mm_mul_ps(diff0, diff0);
-        __m128 sq_diff1 = _mm_mul_ps(diff1, diff1);
-
-        // Horizontal sum
-        __m128 sum01 = _mm_add_ps(sq_diff0, sq_diff1);
-        __m128 sum23 = _mm_shuffle_ps(sum01, sum01, _MM_SHUFFLE(2, 3, 0, 1));
-        __m128 sum0123 = _mm_add_ps(sum01, sum23);
-        __m128 sum4567 = _mm_movehl_ps(sum0123, sum0123);
-        __m128 sum = _mm_add_ss(sum0123, sum4567);
-
-        result += _mm_cvtss_f32(sum);
-    }
-
-    // Process remaining elements with generic implementation
-    result +=
-        generic::SQ4ComputeL2Sqr(query + d, codes + (d >> 1), lower_bound + d, diff + d, dim - d);
-    return result;
+    return simd::SQ4ComputeL2SqrImpl<simd::SQ4Traits<simd::SSE_SQ4_Tag>>(
+        query, codes, lower_bound, diff, dim, &generic::SQ4ComputeL2Sqr);
 #else
     return generic::SQ4ComputeL2Sqr(query, codes, lower_bound, diff, dim);
 #endif
@@ -861,77 +363,8 @@ SQ4ComputeCodesIP(const uint8_t* RESTRICT codes1,
                   const float* RESTRICT diff,
                   uint64_t dim) {
 #if defined(ENABLE_SSE)
-    if (dim == 0) {
-        return 0;
-    }
-
-    float result = 0;
-    uint64_t d = 0;
-
-    // Process 8 values at a time (4 bytes containing 8 4-bit values)
-    for (; d + 7 < dim; d += 8) {
-        // Load 4 bytes from each code vector (8 4-bit values)
-        __m128i code1_vec = load_4_char(codes1 + (d >> 1));
-        __m128i code2_vec = load_4_char(codes2 + (d >> 1));
-
-        // Extract and interleave nibbles for code1
-        __m128i code1_low = _mm_and_si128(code1_vec, _mm_set1_epi8(0x0F));
-        __m128i code1_high = _mm_and_si128(_mm_srli_epi16(code1_vec, 4), _mm_set1_epi8(0x0F));
-        __m128i code1_interleaved = _mm_unpacklo_epi8(code1_low, code1_high);
-
-        // Extract and interleave nibbles for code2
-        __m128i code2_low = _mm_and_si128(code2_vec, _mm_set1_epi8(0x0F));
-        __m128i code2_high = _mm_and_si128(_mm_srli_epi16(code2_vec, 4), _mm_set1_epi8(0x0F));
-        __m128i code2_interleaved = _mm_unpacklo_epi8(code2_low, code2_high);
-
-        // Convert to float and scale for code1
-        __m128i code1_low_part = _mm_cvtepu8_epi32(code1_interleaved);
-        __m128i code1_high_part = _mm_cvtepu8_epi32(_mm_srli_si128(code1_interleaved, 4));
-        __m128 code1_values0 = _mm_cvtepi32_ps(code1_low_part);
-        __m128 code1_values1 = _mm_cvtepi32_ps(code1_high_part);
-
-        // Convert to float and scale for code2
-        __m128i code2_low_part = _mm_cvtepu8_epi32(code2_interleaved);
-        __m128i code2_high_part = _mm_cvtepu8_epi32(_mm_srli_si128(code2_interleaved, 4));
-        __m128 code2_values0 = _mm_cvtepi32_ps(code2_low_part);
-        __m128 code2_values1 = _mm_cvtepi32_ps(code2_high_part);
-
-        // Scale by 1/15.0
-        __m128 scale = _mm_set1_ps(1.0f / 15.0f);
-        code1_values0 = _mm_mul_ps(code1_values0, scale);
-        code1_values1 = _mm_mul_ps(code1_values1, scale);
-        code2_values0 = _mm_mul_ps(code2_values0, scale);
-        code2_values1 = _mm_mul_ps(code2_values1, scale);
-
-        // Apply diff and lower_bound
-        __m128 diff_vec0 = _mm_loadu_ps(diff + d);
-        __m128 diff_vec1 = _mm_loadu_ps(diff + d + 4);
-        __m128 lb_vec0 = _mm_loadu_ps(lower_bound + d);
-        __m128 lb_vec1 = _mm_loadu_ps(lower_bound + d + 4);
-
-        code1_values0 = _mm_add_ps(_mm_mul_ps(code1_values0, diff_vec0), lb_vec0);
-        code1_values1 = _mm_add_ps(_mm_mul_ps(code1_values1, diff_vec1), lb_vec1);
-        code2_values0 = _mm_add_ps(_mm_mul_ps(code2_values0, diff_vec0), lb_vec0);
-        code2_values1 = _mm_add_ps(_mm_mul_ps(code2_values1, diff_vec1), lb_vec1);
-
-        // Compute dot products
-        __m128 prod0 = _mm_mul_ps(code1_values0, code2_values0);
-        __m128 prod1 = _mm_mul_ps(code1_values1, code2_values1);
-
-        // Horizontal sum
-        __m128 sum01 = _mm_add_ps(prod0, prod1);
-        __m128 sum23 = _mm_shuffle_ps(sum01, sum01, _MM_SHUFFLE(2, 3, 0, 1));
-        __m128 sum0123 = _mm_add_ps(sum01, sum23);
-        __m128 sum4567 = _mm_movehl_ps(sum0123, sum0123);
-        __m128 sum = _mm_add_ss(sum0123, sum4567);
-
-        result += _mm_cvtss_f32(sum);
-    }
-
-    // Process remaining elements with generic implementation
-    result += generic::SQ4ComputeCodesIP(
-        codes1 + (d >> 1), codes2 + (d >> 1), lower_bound + d, diff + d, dim - d);
-    return result;
+    return simd::SQ4ComputeCodesIPImpl<simd::SQ4Traits<simd::SSE_SQ4_Tag>>(
+        codes1, codes2, lower_bound, diff, dim, &generic::SQ4ComputeCodesIP);
 #else
     return generic::SQ4ComputeCodesIP(codes1, codes2, lower_bound, diff, dim);
 #endif
@@ -944,81 +377,8 @@ SQ4ComputeCodesL2Sqr(const uint8_t* RESTRICT codes1,
                      const float* RESTRICT diff,
                      uint64_t dim) {
 #if defined(ENABLE_SSE)
-    if (dim == 0) {
-        return 0;
-    }
-
-    float result = 0;
-    uint64_t d = 0;
-
-    // Process 8 values at a time (4 bytes containing 8 4-bit values)
-    for (; d + 7 < dim; d += 8) {
-        // Load 4 bytes from each code vector (8 4-bit values)
-        __m128i code1_vec = load_4_char(codes1 + (d >> 1));
-        __m128i code2_vec = load_4_char(codes2 + (d >> 1));
-
-        // Extract and interleave nibbles for code1
-        __m128i code1_low = _mm_and_si128(code1_vec, _mm_set1_epi8(0x0F));
-        __m128i code1_high = _mm_and_si128(_mm_srli_epi16(code1_vec, 4), _mm_set1_epi8(0x0F));
-        __m128i code1_interleaved = _mm_unpacklo_epi8(code1_low, code1_high);
-
-        // Extract and interleave nibbles for code2
-        __m128i code2_low = _mm_and_si128(code2_vec, _mm_set1_epi8(0x0F));
-        __m128i code2_high = _mm_and_si128(_mm_srli_epi16(code2_vec, 4), _mm_set1_epi8(0x0F));
-        __m128i code2_interleaved = _mm_unpacklo_epi8(code2_low, code2_high);
-
-        // Convert to float and scale for code1
-        __m128i code1_low_part = _mm_cvtepu8_epi32(code1_interleaved);
-        __m128i code1_high_part = _mm_cvtepu8_epi32(_mm_srli_si128(code1_interleaved, 4));
-        __m128 code1_values0 = _mm_cvtepi32_ps(code1_low_part);
-        __m128 code1_values1 = _mm_cvtepi32_ps(code1_high_part);
-
-        // Convert to float and scale for code2
-        __m128i code2_low_part = _mm_cvtepu8_epi32(code2_interleaved);
-        __m128i code2_high_part = _mm_cvtepu8_epi32(_mm_srli_si128(code2_interleaved, 4));
-        __m128 code2_values0 = _mm_cvtepi32_ps(code2_low_part);
-        __m128 code2_values1 = _mm_cvtepi32_ps(code2_high_part);
-
-        // Scale by 1/15.0
-        __m128 scale = _mm_set1_ps(1.0f / 15.0f);
-        code1_values0 = _mm_mul_ps(code1_values0, scale);
-        code1_values1 = _mm_mul_ps(code1_values1, scale);
-        code2_values0 = _mm_mul_ps(code2_values0, scale);
-        code2_values1 = _mm_mul_ps(code2_values1, scale);
-
-        // Apply diff and lower_bound
-        __m128 diff_vec0 = _mm_loadu_ps(diff + d);
-        __m128 diff_vec1 = _mm_loadu_ps(diff + d + 4);
-        __m128 lb_vec0 = _mm_loadu_ps(lower_bound + d);
-        __m128 lb_vec1 = _mm_loadu_ps(lower_bound + d + 4);
-
-        code1_values0 = _mm_add_ps(_mm_mul_ps(code1_values0, diff_vec0), lb_vec0);
-        code1_values1 = _mm_add_ps(_mm_mul_ps(code1_values1, diff_vec1), lb_vec1);
-        code2_values0 = _mm_add_ps(_mm_mul_ps(code2_values0, diff_vec0), lb_vec0);
-        code2_values1 = _mm_add_ps(_mm_mul_ps(code2_values1, diff_vec1), lb_vec1);
-
-        // Compute differences
-        __m128 diff0 = _mm_sub_ps(code1_values0, code2_values0);
-        __m128 diff1 = _mm_sub_ps(code1_values1, code2_values1);
-
-        // Square differences
-        __m128 sq_diff0 = _mm_mul_ps(diff0, diff0);
-        __m128 sq_diff1 = _mm_mul_ps(diff1, diff1);
-
-        // Horizontal sum
-        __m128 sum01 = _mm_add_ps(sq_diff0, sq_diff1);
-        __m128 sum23 = _mm_shuffle_ps(sum01, sum01, _MM_SHUFFLE(2, 3, 0, 1));
-        __m128 sum0123 = _mm_add_ps(sum01, sum23);
-        __m128 sum4567 = _mm_movehl_ps(sum0123, sum0123);
-        __m128 sum = _mm_add_ss(sum0123, sum4567);
-
-        result += _mm_cvtss_f32(sum);
-    }
-
-    // Process remaining elements with generic implementation
-    result += generic::SQ4ComputeCodesL2Sqr(
-        codes1 + (d >> 1), codes2 + (d >> 1), lower_bound + d, diff + d, dim - d);
-    return result;
+    return simd::SQ4ComputeCodesL2SqrImpl<simd::SQ4Traits<simd::SSE_SQ4_Tag>>(
+        codes1, codes2, lower_bound, diff, dim, &generic::SQ4ComputeCodesL2Sqr);
 #else
     return generic::SQ4ComputeCodesL2Sqr(codes1, codes2, lower_bound, diff, dim);
 #endif
@@ -1029,31 +389,8 @@ SQ4UniformComputeCodesIP(const uint8_t* RESTRICT codes1,
                          const uint8_t* RESTRICT codes2,
                          uint64_t dim) {
 #if defined(ENABLE_SSE)
-    if (dim == 0) {
-        return 0;
-    }
-    alignas(128) int16_t temp[8];
-    int32_t result = 0;
-    uint64_t d = 0;
-    __m128i sum = _mm_setzero_si128();
-    __m128i mask = _mm_set1_epi8(0xf);
-    for (; d + 31 < dim; d += 32) {
-        auto xx = _mm_loadu_si128((__m128i*)(codes1 + (d >> 1)));
-        auto yy = _mm_loadu_si128((__m128i*)(codes2 + (d >> 1)));
-        auto xx1 = _mm_and_si128(xx, mask);                     // 16 * 8bits
-        auto xx2 = _mm_and_si128(_mm_srli_epi16(xx, 4), mask);  // 16 * 8bits
-        auto yy1 = _mm_and_si128(yy, mask);
-        auto yy2 = _mm_and_si128(_mm_srli_epi16(yy, 4), mask);
-
-        sum = _mm_add_epi16(sum, _mm_maddubs_epi16(xx1, yy1));
-        sum = _mm_add_epi16(sum, _mm_maddubs_epi16(xx2, yy2));
-    }
-    _mm_store_si128((__m128i*)temp, sum);
-    for (int i = 0; i < 8; ++i) {
-        result += temp[i];
-    }
-    result += generic::SQ4UniformComputeCodesIP(codes1 + (d >> 1), codes2 + (d >> 1), dim - d);
-    return result;
+    return simd::SQ4UniformComputeCodesIPImpl<simd::UniformCodeTraits<simd::SSE_Uniform_Tag>>(
+        codes1, codes2, dim, &generic::SQ4UniformComputeCodesIP);
 #else
     return generic::SQ4UniformComputeCodesIP(codes1, codes2, dim);
 #endif
@@ -1064,33 +401,8 @@ SQ8UniformComputeCodesIP(const uint8_t* RESTRICT codes1,
                          const uint8_t* RESTRICT codes2,
                          uint64_t dim) {
 #if defined(ENABLE_SSE)
-    if (dim == 0) {
-        return 0;
-    }
-    alignas(128) int32_t temp[4];
-    int32_t result = 0;
-    uint64_t d = 0;
-    __m128i sum = _mm_setzero_si128();
-    __m128i mask = _mm_set1_epi16(0xff);
-    for (; d + 15 < dim; d += 16) {
-        auto xx = _mm_loadu_si128((__m128i*)(codes1 + d));
-        auto yy = _mm_loadu_si128((__m128i*)(codes2 + d));
-
-        auto xx1 = _mm_and_si128(xx, mask);  // 16 * 8bits
-        auto xx2 = _mm_srli_epi16(xx, 8);    // 16 * 8bits
-        auto yy1 = _mm_and_si128(yy, mask);
-        auto yy2 = _mm_srli_epi16(yy, 8);
-
-        sum = _mm_add_epi32(sum, _mm_madd_epi16(xx1, yy1));
-        sum = _mm_add_epi32(sum, _mm_madd_epi16(xx2, yy2));
-    }
-    _mm_store_si128((__m128i*)temp, sum);
-    for (int i = 0; i < 4; ++i) {
-        result += temp[i];
-    }
-    result +=
-        static_cast<int32_t>(generic::SQ8UniformComputeCodesIP(codes1 + d, codes2 + d, dim - d));
-    return static_cast<float>(result);
+    return simd::SQ8UniformComputeCodesIPImpl<simd::UniformCodeTraits<simd::SSE_Uniform_Tag>>(
+        codes1, codes2, dim, &generic::SQ8UniformComputeCodesIP);
 #else
     return generic::SQ8UniformComputeCodesIP(codes1, codes2, dim);
 #endif
@@ -1143,20 +455,8 @@ RaBitQFloatSplitCodeIP(const float* vector,
 void
 DivScalar(const float* from, float* to, uint64_t dim, float scalar) {
 #if defined(ENABLE_SSE)
-    if (dim == 0) {
-        return;
-    }
-    if (scalar == 0) {
-        scalar = 1.0f;  // TODO(LHT): logger?
-    }
-    int i = 0;
-    __m128 scalarVec = _mm_set1_ps(scalar);
-    for (; i + 3 < dim; i += 4) {
-        __m128 vec = _mm_loadu_ps(from + i);
-        vec = _mm_div_ps(vec, scalarVec);
-        _mm_storeu_ps(to + i, vec);
-    }
-    generic::DivScalar(from + i, to + i, dim - i, scalar);
+    simd::DivScalarImpl<simd::SimdTraits<simd::SSE_Tag>>(
+        from, to, dim, scalar, &generic::DivScalar);
 #else
     generic::DivScalar(from, to, dim, scalar);
 #endif
@@ -1217,22 +517,7 @@ PQFastScanLookUp32(const uint8_t* RESTRICT lookup_table,
 void
 BitAnd(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* result) {
 #if defined(ENABLE_SSE)
-    if (num_byte == 0) {
-        return;
-    }
-    if (num_byte < 16) {
-        return generic::BitAnd(x, y, num_byte, result);
-    }
-    int64_t i = 0;
-    for (; i + 15 < num_byte; i += 16) {
-        __m128i x_vec = _mm_loadu_si128(reinterpret_cast<const __m128i*>(x + i));
-        __m128i y_vec = _mm_loadu_si128(reinterpret_cast<const __m128i*>(y + i));
-        __m128i result_vec = _mm_and_si128(x_vec, y_vec);
-        _mm_storeu_si128(reinterpret_cast<__m128i*>(result + i), result_vec);
-    }
-    if (i < num_byte) {
-        generic::BitAnd(x + i, y + i, num_byte - i, result + i);
-    }
+    simd::BitAndImpl<simd::BitTraits<simd::SSE_Bit_Tag>>(x, y, num_byte, result, &generic::BitAnd);
 #else
     return generic::BitAnd(x, y, num_byte, result);
 #endif
@@ -1241,22 +526,7 @@ BitAnd(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* res
 void
 BitOr(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* result) {
 #if defined(ENABLE_SSE)
-    if (num_byte == 0) {
-        return;
-    }
-    if (num_byte < 16) {
-        return generic::BitOr(x, y, num_byte, result);
-    }
-    int64_t i = 0;
-    for (; i + 15 < num_byte; i += 16) {
-        __m128i x_vec = _mm_loadu_si128(reinterpret_cast<const __m128i*>(x + i));
-        __m128i y_vec = _mm_loadu_si128(reinterpret_cast<const __m128i*>(y + i));
-        __m128i result_vec = _mm_or_si128(x_vec, y_vec);
-        _mm_storeu_si128(reinterpret_cast<__m128i*>(result + i), result_vec);
-    }
-    if (i < num_byte) {
-        generic::BitOr(x + i, y + i, num_byte - i, result + i);
-    }
+    simd::BitOrImpl<simd::BitTraits<simd::SSE_Bit_Tag>>(x, y, num_byte, result, &generic::BitOr);
 #else
     return generic::BitOr(x, y, num_byte, result);
 #endif
@@ -1265,22 +535,7 @@ BitOr(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* resu
 void
 BitXor(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* result) {
 #if defined(ENABLE_SSE)
-    if (num_byte == 0) {
-        return;
-    }
-    if (num_byte < 16) {
-        return generic::BitXor(x, y, num_byte, result);
-    }
-    int64_t i = 0;
-    for (; i + 15 < num_byte; i += 16) {
-        __m128i x_vec = _mm_loadu_si128(reinterpret_cast<const __m128i*>(x + i));
-        __m128i y_vec = _mm_loadu_si128(reinterpret_cast<const __m128i*>(y + i));
-        __m128i result_vec = _mm_xor_si128(x_vec, y_vec);
-        _mm_storeu_si128(reinterpret_cast<__m128i*>(result + i), result_vec);
-    }
-    if (i < num_byte) {
-        generic::BitXor(x + i, y + i, num_byte - i, result + i);
-    }
+    simd::BitXorImpl<simd::BitTraits<simd::SSE_Bit_Tag>>(x, y, num_byte, result, &generic::BitXor);
 #else
     return generic::BitXor(x, y, num_byte, result);
 #endif
@@ -1289,21 +544,7 @@ BitXor(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* res
 void
 BitNot(const uint8_t* x, const uint64_t num_byte, uint8_t* result) {
 #if defined(ENABLE_SSE)
-    if (num_byte == 0) {
-        return;
-    }
-    if (num_byte < 16) {
-        return generic::BitNot(x, num_byte, result);
-    }
-    int64_t i = 0;
-    for (; i + 15 < num_byte; i += 16) {
-        __m128i x_vec = _mm_loadu_si128(reinterpret_cast<const __m128i*>(x + i));
-        __m128i result_vec = _mm_xor_si128(x_vec, _mm_set1_epi8(0xFF));
-        _mm_storeu_si128(reinterpret_cast<__m128i*>(result + i), result_vec);
-    }
-    if (i < num_byte) {
-        generic::BitNot(x + i, num_byte - i, result + i);
-    }
+    simd::BitNotImpl<simd::BitTraits<simd::SSE_Bit_Tag>>(x, num_byte, result, &generic::BitNot);
 #else
     return generic::BitNot(x, num_byte, result);
 #endif
@@ -1312,16 +553,9 @@ BitNot(const uint8_t* x, const uint64_t num_byte, uint8_t* result) {
 void
 RotateOp(float* data, int idx, int dim_, int step) {
 #if defined(ENABLE_SSE)
-    for (int i = idx; i < dim_; i += step * 2) {
-        for (int j = 0; j < step; j += 4) {
-            __m128 g1 = _mm_loadu_ps(&data[i + j]);
-            __m128 g2 = _mm_loadu_ps(&data[i + j + step]);
-            _mm_storeu_ps(&data[i + j], _mm_add_ps(g1, g2));
-            _mm_storeu_ps(&data[i + j + step], _mm_sub_ps(g1, g2));
-        }
-    }
+    simd::RotateOpImpl<simd::SimdTraits<simd::SSE_Tag>>(data, idx, dim_, step);
 #else
-    return generic::RotateOp(data, idx, dim_, step);
+    generic::RotateOp(data, idx, dim_, step);
 #endif
 }
 
@@ -1346,91 +580,26 @@ FHTRotate(float* data, uint64_t dim_) {
 void
 VecRescale(float* data, uint64_t dim, float val) {
 #if defined(ENABLE_SSE)
-    int i = 0;
-    __m128 val_vec = _mm_set1_ps(val);
-    for (; i + 4 < dim; i += 4) {
-        __m128 data_vec = _mm_loadu_ps(&data[i]);
-        __m128 result_vec = _mm_mul_ps(data_vec, val_vec);
-        _mm_storeu_ps(&data[i], result_vec);
-    }
-    for (; i < dim; i++) {
-        data[i] *= val;
-    }
+    simd::VecRescaleImpl<simd::SimdTraits<simd::SSE_Tag>>(data, dim, val, &generic::VecRescale);
 #else
-    return generic::VecRescale(data, dim, val);
+    generic::VecRescale(data, dim, val);
 #endif
 }
 
 void
 KacsWalk(float* data, uint64_t len) {
 #if defined(ENABLE_SSE)
-    uint64_t base = len % 2;
-    uint64_t offset = base + (len / 2);  // for odd dim
-    uint64_t i = 0;
-    for (; i + 4 < len / 2; i += 4) {
-        __m128 x = _mm_loadu_ps(&data[i]);
-        __m128 y = _mm_loadu_ps(&data[i + offset]);
-        _mm_storeu_ps(&data[i], _mm_add_ps(x, y));
-        _mm_storeu_ps(&data[i + offset], _mm_sub_ps(x, y));
-    }
-    for (; i < len / 2; i++) {
-        float add = data[i] + data[i + offset];
-        float sub = data[i] - data[i + offset];
-        data[i] = add;
-        data[i + offset] = sub;
-    }
-    if (base != 0) {
-        data[len / 2] *= std::sqrt(2.0F);
-        //In odd condition, we operate the prev len/2 items and the post len/2 items, the No.len/2 item stay still,
-        //As we need to resize the while sequence in the next step, so we increase the val of No.len/2 item to eliminate the impact of the following resize.
-    }
+    simd::KacsWalkImpl<simd::SimdTraits<simd::SSE_Tag>>(data, len, &generic::KacsWalk);
 #else
-    return generic::KacsWalk(data, len);
+    generic::KacsWalk(data, len);
 #endif
 }
 
 float
 NormalizeWithCentroid(const float* from, const float* centroid, float* to, uint64_t dim) {
 #if defined(ENABLE_SSE)
-    float norm_sq = 0;
-    uint64_t i = 0;
-    if (dim >= 4) {
-        __m128 sum = _mm_setzero_ps();
-        for (; i + 3 < dim; i += 4) {
-            __m128 f = _mm_loadu_ps(from + i);
-            __m128 c = _mm_loadu_ps(centroid + i);
-            __m128 diff = _mm_sub_ps(f, c);
-            sum = _mm_add_ps(sum, _mm_mul_ps(diff, diff));
-        }
-        alignas(16) float result[4];
-        _mm_store_ps(result, sum);
-        norm_sq = result[0] + result[1] + result[2] + result[3];
-        norm_sq += generic::FP32ComputeL2Sqr(from + i, centroid + i, dim - i);
-    } else {
-        norm_sq = generic::FP32ComputeL2Sqr(from, centroid, dim);
-    }
-
-    float norm = 0;
-    if (norm_sq < 1e-5f) {
-        norm = 1.0f;
-    } else {
-        norm = std::sqrt(norm_sq);
-    }
-
-    __m128 normVec = _mm_set1_ps(norm);
-    for (i = 0; i + 3 < dim; i += 4) {
-        __m128 f = _mm_loadu_ps(from + i);
-        __m128 c = _mm_loadu_ps(centroid + i);
-        __m128 diff = _mm_sub_ps(f, c);
-        __m128 result = _mm_div_ps(diff, normVec);
-        _mm_storeu_ps(to + i, result);
-    }
-    if (i < dim) {
-        for (; i < dim; ++i) {
-            to[i] = (from[i] - centroid[i]) / norm;
-        }
-    }
-    return norm;
+    return simd::NormalizeWithCentroidImpl<simd::SimdTraits<simd::SSE_Tag>>(
+        from, centroid, to, dim, &generic::NormalizeWithCentroid);
 #else
     return generic::NormalizeWithCentroid(from, centroid, to, dim);
 #endif
@@ -1440,17 +609,8 @@ void
 InverseNormalizeWithCentroid(
     const float* from, const float* centroid, float* to, uint64_t dim, float norm) {
 #if defined(ENABLE_SSE)
-    uint64_t i = 0;
-    __m128 normVec = _mm_set1_ps(norm);
-    for (; i + 3 < dim; i += 4) {
-        __m128 f = _mm_loadu_ps(from + i);
-        __m128 c = _mm_loadu_ps(centroid + i);
-        __m128 result = _mm_add_ps(_mm_mul_ps(f, normVec), c);
-        _mm_storeu_ps(to + i, result);
-    }
-    for (; i < dim; i++) {
-        to[i] = from[i] * norm + centroid[i];
-    }
+    simd::InverseNormalizeWithCentroidImpl<simd::SimdTraits<simd::SSE_Tag>>(
+        from, centroid, to, dim, norm, &generic::InverseNormalizeWithCentroid);
 #else
     generic::InverseNormalizeWithCentroid(from, centroid, to, dim, norm);
 #endif

--- a/src/simd/traits/simd_traits_avx.h
+++ b/src/simd/traits/simd_traits_avx.h
@@ -1,0 +1,265 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+// AVX traits (Width = 8, __m256). MUST only be included from a TU
+// compiled with -mavx.
+
+#include <immintrin.h>
+
+#include <cstring>
+
+#include "simd_traits_generic.h"
+
+namespace vsag::simd {
+
+struct AVX_Tag {};
+
+template <>
+struct SimdTraits<AVX_Tag> {
+    using FloatVec = __m256;
+    static constexpr int Width = 8;
+
+    static inline __attribute__((always_inline)) FloatVec
+    zero() {
+        return _mm256_setzero_ps();
+    }
+
+    static inline __attribute__((always_inline)) FloatVec
+    load(const float* p) {
+        return _mm256_loadu_ps(p);
+    }
+
+    static inline __attribute__((always_inline)) FloatVec
+    mul(FloatVec a, FloatVec b) {
+        return _mm256_mul_ps(a, b);
+    }
+
+    static inline __attribute__((always_inline)) FloatVec
+    add(FloatVec a, FloatVec b) {
+        return _mm256_add_ps(a, b);
+    }
+
+    static inline __attribute__((always_inline)) FloatVec
+    sub(FloatVec a, FloatVec b) {
+        return _mm256_sub_ps(a, b);
+    }
+
+    // Plain AVX lacks FMA; emulate to match the original avx.cpp.
+    static inline __attribute__((always_inline)) FloatVec
+    fmadd(FloatVec a, FloatVec b, FloatVec c) {
+        return _mm256_add_ps(_mm256_mul_ps(a, b), c);
+    }
+
+    static inline __attribute__((always_inline)) FloatVec
+    div(FloatVec a, FloatVec b) {
+        return _mm256_div_ps(a, b);
+    }
+
+    static inline __attribute__((always_inline)) void
+    store(float* p, FloatVec v) {
+        _mm256_storeu_ps(p, v);
+    }
+
+    static inline __attribute__((always_inline)) float
+    reduce_add(FloatVec v) {
+        // Byte-for-byte match avx_reduce_add_ps in avx.cpp.
+        alignas(32) float tmp[8];
+        _mm256_store_ps(tmp, v);
+        return tmp[0] + tmp[1] + tmp[2] + tmp[3] + tmp[4] + tmp[5] + tmp[6] + tmp[7];
+    }
+
+    static inline __attribute__((always_inline)) FloatVec
+    set1(float v) {
+        return _mm256_set1_ps(v);
+    }
+};
+
+// --- Bit operation traits for AVX (uses float ops since AVX has no 256-bit integer) ---
+struct AVX_Bit_Tag {};
+template <>
+struct BitTraits<AVX_Bit_Tag> {
+    using IntVec = __m256;  // reuse float vector for bitwise ops
+    static constexpr int ByteWidth = 32;
+
+    static inline __attribute__((always_inline)) IntVec
+    load(const uint8_t* p) {
+        return _mm256_castsi256_ps(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(p)));
+    }
+    static inline __attribute__((always_inline)) void
+    store(uint8_t* p, IntVec v) {
+        _mm256_storeu_si256(reinterpret_cast<__m256i*>(p), _mm256_castps_si256(v));
+    }
+    static inline __attribute__((always_inline)) IntVec
+    bit_and(IntVec a, IntVec b) {
+        return _mm256_and_ps(a, b);
+    }
+    static inline __attribute__((always_inline)) IntVec
+    bit_or(IntVec a, IntVec b) {
+        return _mm256_or_ps(a, b);
+    }
+    static inline __attribute__((always_inline)) IntVec
+    bit_xor(IntVec a, IntVec b) {
+        return _mm256_xor_ps(a, b);
+    }
+    static inline __attribute__((always_inline)) IntVec
+    bit_not(IntVec a) {
+        return _mm256_xor_ps(a, _mm256_castsi256_ps(_mm256_set1_epi32(-1)));
+    }
+};
+
+// --- SQ8 traits for AVX ---
+struct AVX_SQ8_Tag {};
+template <>
+struct SQ8Traits<AVX_SQ8_Tag> : SimdTraits<AVX_Tag> {
+    static inline __attribute__((always_inline)) FloatVec
+    load_u8_as_float(const uint8_t* p) {
+        int32_t lo_val, hi_val;
+        std::memcpy(&lo_val, p, 4);
+        std::memcpy(&hi_val, p + 4, 4);
+        __m128i lo = _mm_cvtepu8_epi32(_mm_set_epi32(0, 0, 0, lo_val));
+        __m128i hi = _mm_cvtepu8_epi32(_mm_set_epi32(0, 0, 0, hi_val));
+        return _mm256_cvtepi32_ps(_mm256_set_m128i(hi, lo));
+    }
+};
+
+// --- SQ4Traits for AVX (Width=8, STEP=16 nibbles = 8 bytes per call) ---
+struct AVX_SQ4_Tag {};
+template <>
+struct SQ4Traits<AVX_SQ4_Tag> : SimdTraits<AVX_Tag> {
+    static inline __attribute__((always_inline)) void
+    load_nibbles_2x_as_float(const uint8_t* p, FloatVec& out0, FloatVec& out1) {
+        __m128i code0 = _mm_set_epi8(0,
+                                     0,
+                                     0,
+                                     0,
+                                     0,
+                                     0,
+                                     0,
+                                     0,
+                                     0,
+                                     0,
+                                     0,
+                                     0,
+                                     static_cast<char>(p[3]),
+                                     static_cast<char>(p[2]),
+                                     static_cast<char>(p[1]),
+                                     static_cast<char>(p[0]));
+        __m128i code1 = _mm_set_epi8(0,
+                                     0,
+                                     0,
+                                     0,
+                                     0,
+                                     0,
+                                     0,
+                                     0,
+                                     0,
+                                     0,
+                                     0,
+                                     0,
+                                     static_cast<char>(p[7]),
+                                     static_cast<char>(p[6]),
+                                     static_cast<char>(p[5]),
+                                     static_cast<char>(p[4]));
+        const __m128i mask = _mm_set1_epi8(0x0F);
+        __m128i lo0 = _mm_and_si128(code0, mask);
+        __m128i hi0 = _mm_and_si128(_mm_srli_epi16(code0, 4), mask);
+        __m128i lo1 = _mm_and_si128(code1, mask);
+        __m128i hi1 = _mm_and_si128(_mm_srli_epi16(code1, 4), mask);
+        __m128i il0 = _mm_unpacklo_epi8(lo0, hi0);
+        __m128i il1 = _mm_unpacklo_epi8(lo1, hi1);
+        __m128 v00 = _mm_cvtepi32_ps(_mm_cvtepu8_epi32(il0));
+        __m128 v01 = _mm_cvtepi32_ps(_mm_cvtepu8_epi32(_mm_srli_si128(il0, 4)));
+        __m128 v10 = _mm_cvtepi32_ps(_mm_cvtepu8_epi32(il1));
+        __m128 v11 = _mm_cvtepi32_ps(_mm_cvtepu8_epi32(_mm_srli_si128(il1, 4)));
+        const __m256 inv15 = _mm256_set1_ps(1.0f / 15.0f);
+        out0 = _mm256_mul_ps(_mm256_set_m128(v01, v00), inv15);
+        out1 = _mm256_mul_ps(_mm256_set_m128(v11, v10), inv15);
+    }
+};
+
+// --- BF16Traits for AVX ---
+struct AVX_BF16_Tag {};
+template <>
+struct BF16Traits<AVX_BF16_Tag> : SimdTraits<AVX_Tag> {
+    static inline __attribute__((always_inline)) FloatVec
+    load_half(const uint16_t* p) {
+        __m256i v = _mm256_set_epi16(static_cast<short>(p[7]),
+                                     0,
+                                     static_cast<short>(p[6]),
+                                     0,
+                                     static_cast<short>(p[5]),
+                                     0,
+                                     static_cast<short>(p[4]),
+                                     0,
+                                     static_cast<short>(p[3]),
+                                     0,
+                                     static_cast<short>(p[2]),
+                                     0,
+                                     static_cast<short>(p[1]),
+                                     0,
+                                     static_cast<short>(p[0]),
+                                     0);
+        return _mm256_castsi256_ps(v);
+    }
+};
+
+// --- FP16Traits for AVX (uses F16C: _mm256_cvtph_ps) ---
+struct AVX_FP16_Tag {};
+template <>
+struct FP16Traits<AVX_FP16_Tag> : SimdTraits<AVX_Tag> {
+    static inline __attribute__((always_inline)) FloatVec
+    load_half(const uint16_t* p) {
+        __m128i fp16 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(p));
+        return _mm256_cvtph_ps(fp16);
+    }
+};
+
+// --- RaBitQTraits for AVX (8-wide, no AVX2 integer ops) ---
+struct AVX_RaBitQ_Tag {};
+template <>
+struct RaBitQTraits<AVX_RaBitQ_Tag> : SimdTraits<AVX_Tag> {
+    static inline __attribute__((always_inline)) FloatVec
+    bits_to_signed(const uint8_t* bit_ptr, FloatVec pos, FloatVec neg) {
+        uint8_t byte = bit_ptr[0];
+        float p = _mm_cvtss_f32(_mm256_castps256_ps128(pos));
+        float n = _mm_cvtss_f32(_mm256_castps256_ps128(neg));
+        return _mm256_set_ps(((byte >> 7) & 1) ? p : n,
+                             ((byte >> 6) & 1) ? p : n,
+                             ((byte >> 5) & 1) ? p : n,
+                             ((byte >> 4) & 1) ? p : n,
+                             ((byte >> 3) & 1) ? p : n,
+                             ((byte >> 2) & 1) ? p : n,
+                             ((byte >> 1) & 1) ? p : n,
+                             ((byte >> 0) & 1) ? p : n);
+    }
+
+    static inline __attribute__((always_inline)) FloatVec
+    bits_select(const uint8_t* bit_ptr, FloatVec weight) {
+        uint8_t byte = bit_ptr[0];
+        float w = _mm_cvtss_f32(_mm256_castps256_ps128(weight));
+        return _mm256_set_ps(((byte >> 7) & 1) ? w : 0.0f,
+                             ((byte >> 6) & 1) ? w : 0.0f,
+                             ((byte >> 5) & 1) ? w : 0.0f,
+                             ((byte >> 4) & 1) ? w : 0.0f,
+                             ((byte >> 3) & 1) ? w : 0.0f,
+                             ((byte >> 2) & 1) ? w : 0.0f,
+                             ((byte >> 1) & 1) ? w : 0.0f,
+                             ((byte >> 0) & 1) ? w : 0.0f);
+    }
+};
+
+}  // namespace vsag::simd

--- a/src/simd/traits/simd_traits_avx2.h
+++ b/src/simd/traits/simd_traits_avx2.h
@@ -1,0 +1,260 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+// AVX2 traits (Width = 8, __m256, with FMA). MUST only be included from
+// a TU compiled with -mavx2 -mfma. Inherits SimdTraits<AVX_Tag> and
+// overrides fmadd to use the real FMA instruction.
+
+#include "simd_traits_avx.h"
+
+namespace vsag::simd {
+
+struct AVX2_Tag {};
+
+template <>
+struct SimdTraits<AVX2_Tag> : SimdTraits<AVX_Tag> {
+    // Override: AVX2 + FMA gives us a single fused mul-add.
+    static inline __attribute__((always_inline)) FloatVec
+    fmadd(FloatVec a, FloatVec b, FloatVec c) {
+        return _mm256_fmadd_ps(a, b, c);
+    }
+};
+
+// --- Int8 traits for AVX2 ---
+struct AVX2_Int8_Tag {};
+template <>
+struct Int8Traits<AVX2_Int8_Tag> {
+    using Int8HalfVec = __m128i;
+    using Int16Vec = __m256i;
+    using Int32Vec = __m256i;
+    static constexpr int BatchSize = 16;
+
+    static inline __attribute__((always_inline)) Int8HalfVec
+    load_i8(const int8_t* p) {
+        return _mm_loadu_si128(reinterpret_cast<const __m128i*>(p));
+    }
+    static inline __attribute__((always_inline)) Int16Vec
+    cvt_i8_to_i16(Int8HalfVec v) {
+        return _mm256_cvtepi8_epi16(v);
+    }
+    static inline __attribute__((always_inline)) Int32Vec
+    madd_i16(Int16Vec a, Int16Vec b) {
+        return _mm256_madd_epi16(a, b);
+    }
+    static inline __attribute__((always_inline)) Int16Vec
+    sub_i16(Int16Vec a, Int16Vec b) {
+        return _mm256_sub_epi16(a, b);
+    }
+    static inline __attribute__((always_inline)) Int32Vec
+    add_i32(Int32Vec a, Int32Vec b) {
+        return _mm256_add_epi32(a, b);
+    }
+    static inline __attribute__((always_inline)) Int32Vec
+    zero_i32() {
+        return _mm256_setzero_si256();
+    }
+    static inline __attribute__((always_inline)) int32_t
+    reduce_add_i32(Int32Vec v) {
+        alignas(32) int32_t tmp[8];
+        _mm256_store_si256(reinterpret_cast<__m256i*>(tmp), v);
+        int32_t sum = 0;
+        for (int i = 0; i < 8; ++i) sum += tmp[i];
+        return sum;
+    }
+};
+
+// --- Bit operation traits for AVX2 ---
+struct AVX2_Bit_Tag {};
+template <>
+struct BitTraits<AVX2_Bit_Tag> {
+    using IntVec = __m256i;
+    static constexpr int ByteWidth = 32;
+
+    static inline __attribute__((always_inline)) IntVec
+    load(const uint8_t* p) {
+        return _mm256_loadu_si256(reinterpret_cast<const __m256i*>(p));
+    }
+    static inline __attribute__((always_inline)) void
+    store(uint8_t* p, IntVec v) {
+        _mm256_storeu_si256(reinterpret_cast<__m256i*>(p), v);
+    }
+    static inline __attribute__((always_inline)) IntVec
+    bit_and(IntVec a, IntVec b) {
+        return _mm256_and_si256(a, b);
+    }
+    static inline __attribute__((always_inline)) IntVec
+    bit_or(IntVec a, IntVec b) {
+        return _mm256_or_si256(a, b);
+    }
+    static inline __attribute__((always_inline)) IntVec
+    bit_xor(IntVec a, IntVec b) {
+        return _mm256_xor_si256(a, b);
+    }
+    static inline __attribute__((always_inline)) IntVec
+    bit_not(IntVec a) {
+        return _mm256_xor_si256(a, _mm256_set1_epi8(static_cast<char>(0xFF)));
+    }
+};
+
+// --- SQ8 traits for AVX2 ---
+struct AVX2_SQ8_Tag {};
+template <>
+struct SQ8Traits<AVX2_SQ8_Tag> : SimdTraits<AVX2_Tag> {
+    static inline __attribute__((always_inline)) FloatVec
+    load_u8_as_float(const uint8_t* p) {
+        __m128i v = _mm_loadl_epi64(reinterpret_cast<const __m128i*>(p));
+        return _mm256_cvtepi32_ps(_mm256_cvtepu8_epi32(v));
+    }
+};
+
+// --- SQ4Traits for AVX2 (Width=8, STEP=16 nibbles = 8 bytes per call) ---
+struct AVX2_SQ4_Tag {};
+template <>
+struct SQ4Traits<AVX2_SQ4_Tag> : SimdTraits<AVX2_Tag> {
+    static inline __attribute__((always_inline)) void
+    load_nibbles_2x_as_float(const uint8_t* p, FloatVec& out0, FloatVec& out1) {
+        __m128i code = _mm_loadl_epi64(reinterpret_cast<const __m128i*>(p));
+        __m128i mask = _mm_set1_epi8(0x0F);
+        __m128i lo = _mm_and_si128(code, mask);
+        __m128i hi = _mm_and_si128(_mm_srli_epi16(code, 4), mask);
+        __m128i il = _mm_unpacklo_epi8(lo, hi);
+        __m256i e0 = _mm256_cvtepu8_epi32(il);
+        __m256i e1 = _mm256_cvtepu8_epi32(_mm_srli_si128(il, 8));
+        const __m256 inv15 = _mm256_set1_ps(1.0f / 15.0f);
+        out0 = _mm256_mul_ps(_mm256_cvtepi32_ps(e0), inv15);
+        out1 = _mm256_mul_ps(_mm256_cvtepi32_ps(e1), inv15);
+    }
+};
+
+// --- BF16Traits for AVX2 ---
+struct AVX2_BF16_Tag {};
+template <>
+struct BF16Traits<AVX2_BF16_Tag> : SimdTraits<AVX2_Tag> {
+    static inline __attribute__((always_inline)) FloatVec
+    load_half(const uint16_t* p) {
+        __m128i bf16 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(p));
+        __m256i bf32 = _mm256_cvtepu16_epi32(bf16);
+        return _mm256_castsi256_ps(_mm256_slli_epi32(bf32, 16));
+    }
+};
+
+// --- FP16Traits for AVX2 ---
+struct AVX2_FP16_Tag {};
+template <>
+struct FP16Traits<AVX2_FP16_Tag> : SimdTraits<AVX2_Tag> {
+    static inline __attribute__((always_inline)) FloatVec
+    load_half(const uint16_t* p) {
+        __m128i fp16 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(p));
+        return _mm256_cvtph_ps(fp16);
+    }
+};
+
+// --- UniformCodeTraits for AVX2 (32-byte integer vectors) ---
+struct AVX2_Uniform_Tag {};
+template <>
+struct UniformCodeTraits<AVX2_Uniform_Tag> {
+    using IntVec = __m256i;
+    static constexpr int ByteWidth = 32;
+
+    static inline __attribute__((always_inline)) IntVec
+    loadu(const uint8_t* p) {
+        return _mm256_loadu_si256(reinterpret_cast<const __m256i*>(p));
+    }
+    static inline __attribute__((always_inline)) IntVec
+    zero() {
+        return _mm256_setzero_si256();
+    }
+    static inline __attribute__((always_inline)) IntVec
+    set1_epi8(int8_t v) {
+        return _mm256_set1_epi8(v);
+    }
+    static inline __attribute__((always_inline)) IntVec
+    set1_epi16(int16_t v) {
+        return _mm256_set1_epi16(v);
+    }
+    static inline __attribute__((always_inline)) IntVec
+    and_si(IntVec a, IntVec b) {
+        return _mm256_and_si256(a, b);
+    }
+    static inline __attribute__((always_inline)) IntVec
+    srli_epi16(IntVec a, int imm) {
+        return _mm256_srli_epi16(a, imm);
+    }
+    static inline __attribute__((always_inline)) IntVec
+    maddubs_epi16(IntVec a, IntVec b) {
+        return _mm256_maddubs_epi16(a, b);
+    }
+    static inline __attribute__((always_inline)) IntVec
+    madd_epi16(IntVec a, IntVec b) {
+        return _mm256_madd_epi16(a, b);
+    }
+    static inline __attribute__((always_inline)) IntVec
+    add_epi16(IntVec a, IntVec b) {
+        return _mm256_add_epi16(a, b);
+    }
+    static inline __attribute__((always_inline)) IntVec
+    add_epi32(IntVec a, IntVec b) {
+        return _mm256_add_epi32(a, b);
+    }
+    static inline __attribute__((always_inline)) int32_t
+    reduce_add_epi16(IntVec v) {
+        alignas(32) int16_t tmp[16];
+        _mm256_store_si256(reinterpret_cast<__m256i*>(tmp), v);
+        int32_t sum = 0;
+        for (int i = 0; i < 16; ++i) sum += tmp[i];
+        return sum;
+    }
+    static inline __attribute__((always_inline)) int32_t
+    reduce_add_epi32(IntVec v) {
+        alignas(32) int32_t tmp[8];
+        _mm256_store_si256(reinterpret_cast<__m256i*>(tmp), v);
+        int32_t sum = 0;
+        for (int i = 0; i < 8; ++i) sum += tmp[i];
+        return sum;
+    }
+};
+
+// --- RaBitQTraits for AVX2 (8-wide, uses AVX2 integer ops for bit decode) ---
+struct AVX2_RaBitQ_Tag {};
+template <>
+struct RaBitQTraits<AVX2_RaBitQ_Tag> : SimdTraits<AVX2_Tag> {
+    static inline __attribute__((always_inline)) FloatVec
+    bits_to_signed(const uint8_t* bit_ptr, FloatVec pos, FloatVec neg) {
+        const __m256i bit_masks = _mm256_setr_epi32(0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80);
+        const __m256i all_ones = _mm256_set1_epi32(-1);
+        const __m256i zero_i = _mm256_setzero_si256();
+        __m256i mask = _mm256_set1_epi32(static_cast<int>(bit_ptr[0]));
+        mask = _mm256_and_si256(mask, bit_masks);
+        mask = _mm256_cmpeq_epi32(mask, zero_i);
+        mask = _mm256_andnot_si256(mask, all_ones);
+        return _mm256_blendv_ps(neg, pos, _mm256_castsi256_ps(mask));
+    }
+
+    static inline __attribute__((always_inline)) FloatVec
+    bits_select(const uint8_t* bit_ptr, FloatVec weight) {
+        const __m256i bit_masks = _mm256_setr_epi32(0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80);
+        const __m256i all_ones = _mm256_set1_epi32(-1);
+        const __m256i zero_i = _mm256_setzero_si256();
+        __m256i mask = _mm256_set1_epi32(static_cast<int>(bit_ptr[0]));
+        mask = _mm256_and_si256(mask, bit_masks);
+        mask = _mm256_cmpeq_epi32(mask, zero_i);
+        mask = _mm256_andnot_si256(mask, all_ones);
+        return _mm256_blendv_ps(_mm256_setzero_ps(), weight, _mm256_castsi256_ps(mask));
+    }
+};
+
+}  // namespace vsag::simd

--- a/src/simd/traits/simd_traits_avx512.h
+++ b/src/simd/traits/simd_traits_avx512.h
@@ -1,0 +1,289 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+// AVX512 traits (Width = 16, __m512). MUST only be included from a TU
+// compiled with -mavx512f (and friends).
+
+#include <immintrin.h>
+
+#include "simd_traits_generic.h"
+
+namespace vsag::simd {
+
+struct AVX512_Tag {};
+
+template <>
+struct SimdTraits<AVX512_Tag> {
+    using FloatVec = __m512;
+    static constexpr int Width = 16;
+
+    static inline __attribute__((always_inline)) FloatVec
+    zero() {
+        return _mm512_setzero_ps();
+    }
+
+    static inline __attribute__((always_inline)) FloatVec
+    load(const float* p) {
+        return _mm512_loadu_ps(p);
+    }
+
+    static inline __attribute__((always_inline)) FloatVec
+    mul(FloatVec a, FloatVec b) {
+        return _mm512_mul_ps(a, b);
+    }
+
+    static inline __attribute__((always_inline)) FloatVec
+    add(FloatVec a, FloatVec b) {
+        return _mm512_add_ps(a, b);
+    }
+
+    static inline __attribute__((always_inline)) FloatVec
+    sub(FloatVec a, FloatVec b) {
+        return _mm512_sub_ps(a, b);
+    }
+
+    static inline __attribute__((always_inline)) FloatVec
+    fmadd(FloatVec a, FloatVec b, FloatVec c) {
+        return _mm512_fmadd_ps(a, b, c);
+    }
+
+    static inline __attribute__((always_inline)) FloatVec
+    div(FloatVec a, FloatVec b) {
+        return _mm512_div_ps(a, b);
+    }
+
+    static inline __attribute__((always_inline)) void
+    store(float* p, FloatVec v) {
+        _mm512_storeu_ps(p, v);
+    }
+
+    static inline __attribute__((always_inline)) float
+    reduce_add(FloatVec v) {
+        return _mm512_reduce_add_ps(v);
+    }
+
+    static inline __attribute__((always_inline)) FloatVec
+    set1(float v) {
+        return _mm512_set1_ps(v);
+    }
+};
+
+// --- Int8 traits for AVX512 ---
+struct AVX512_Int8_Tag {};
+template <>
+struct Int8Traits<AVX512_Int8_Tag> {
+    using Int8HalfVec = __m256i;
+    using Int16Vec = __m512i;
+    using Int32Vec = __m512i;
+    static constexpr int BatchSize = 32;
+
+    static inline __attribute__((always_inline)) Int8HalfVec
+    load_i8(const int8_t* p) {
+        return _mm256_loadu_si256(reinterpret_cast<const __m256i*>(p));
+    }
+    static inline __attribute__((always_inline)) Int16Vec
+    cvt_i8_to_i16(Int8HalfVec v) {
+        return _mm512_cvtepi8_epi16(v);
+    }
+    static inline __attribute__((always_inline)) Int32Vec
+    madd_i16(Int16Vec a, Int16Vec b) {
+        return _mm512_madd_epi16(a, b);
+    }
+    static inline __attribute__((always_inline)) Int16Vec
+    sub_i16(Int16Vec a, Int16Vec b) {
+        return _mm512_sub_epi16(a, b);
+    }
+    static inline __attribute__((always_inline)) Int32Vec
+    add_i32(Int32Vec a, Int32Vec b) {
+        return _mm512_add_epi32(a, b);
+    }
+    static inline __attribute__((always_inline)) Int32Vec
+    zero_i32() {
+        return _mm512_setzero_si512();
+    }
+    static inline __attribute__((always_inline)) int32_t
+    reduce_add_i32(Int32Vec v) {
+        return _mm512_reduce_add_epi32(v);
+    }
+};
+
+// --- Bit operation traits for AVX512 ---
+struct AVX512_Bit_Tag {};
+template <>
+struct BitTraits<AVX512_Bit_Tag> {
+    using IntVec = __m512i;
+    static constexpr int ByteWidth = 64;
+
+    static inline __attribute__((always_inline)) IntVec
+    load(const uint8_t* p) {
+        return _mm512_loadu_si512(reinterpret_cast<const __m512i*>(p));
+    }
+    static inline __attribute__((always_inline)) void
+    store(uint8_t* p, IntVec v) {
+        _mm512_storeu_si512(reinterpret_cast<__m512i*>(p), v);
+    }
+    static inline __attribute__((always_inline)) IntVec
+    bit_and(IntVec a, IntVec b) {
+        return _mm512_and_si512(a, b);
+    }
+    static inline __attribute__((always_inline)) IntVec
+    bit_or(IntVec a, IntVec b) {
+        return _mm512_or_si512(a, b);
+    }
+    static inline __attribute__((always_inline)) IntVec
+    bit_xor(IntVec a, IntVec b) {
+        return _mm512_xor_si512(a, b);
+    }
+    static inline __attribute__((always_inline)) IntVec
+    bit_not(IntVec a) {
+        return _mm512_xor_si512(a, _mm512_set1_epi8(static_cast<char>(0xFF)));
+    }
+};
+
+// --- SQ8 traits for AVX512 ---
+struct AVX512_SQ8_Tag {};
+template <>
+struct SQ8Traits<AVX512_SQ8_Tag> : SimdTraits<AVX512_Tag> {
+    static inline __attribute__((always_inline)) FloatVec
+    load_u8_as_float(const uint8_t* p) {
+        __m128i v = _mm_loadu_si128(reinterpret_cast<const __m128i*>(p));
+        return _mm512_cvtepi32_ps(_mm512_cvtepu8_epi32(v));
+    }
+};
+
+// --- SQ4Traits for AVX512 (Width=16, STEP=32 nibbles = 16 bytes per call) ---
+struct AVX512_SQ4_Tag {};
+template <>
+struct SQ4Traits<AVX512_SQ4_Tag> : SimdTraits<AVX512_Tag> {
+    static inline __attribute__((always_inline)) void
+    load_nibbles_2x_as_float(const uint8_t* p, FloatVec& out0, FloatVec& out1) {
+        __m128i code = _mm_loadu_si128(reinterpret_cast<const __m128i*>(p));
+        __m128i mask = _mm_set1_epi8(0x0F);
+        __m128i lo = _mm_and_si128(code, mask);
+        __m128i hi = _mm_and_si128(_mm_srli_epi16(code, 4), mask);
+        __m128i il_lo = _mm_unpacklo_epi8(lo, hi);
+        __m128i il_hi = _mm_unpackhi_epi8(lo, hi);
+        __m512i e0 = _mm512_cvtepu8_epi32(il_lo);
+        __m512i e1 = _mm512_cvtepu8_epi32(il_hi);
+        const __m512 inv15 = _mm512_set1_ps(1.0f / 15.0f);
+        out0 = _mm512_mul_ps(_mm512_cvtepi32_ps(e0), inv15);
+        out1 = _mm512_mul_ps(_mm512_cvtepi32_ps(e1), inv15);
+    }
+};
+
+// --- BF16Traits for AVX512 ---
+struct AVX512_BF16_Tag {};
+template <>
+struct BF16Traits<AVX512_BF16_Tag> : SimdTraits<AVX512_Tag> {
+    static inline __attribute__((always_inline)) FloatVec
+    load_half(const uint16_t* p) {
+        __m256i bf16 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(p));
+        __m512i bf32 = _mm512_cvtepu16_epi32(bf16);
+        return _mm512_castsi512_ps(_mm512_slli_epi32(bf32, 16));
+    }
+};
+
+// --- FP16Traits for AVX512 ---
+struct AVX512_FP16_Tag {};
+template <>
+struct FP16Traits<AVX512_FP16_Tag> : SimdTraits<AVX512_Tag> {
+    static inline __attribute__((always_inline)) FloatVec
+    load_half(const uint16_t* p) {
+        __m256i fp16 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(p));
+        return _mm512_cvtph_ps(fp16);
+    }
+};
+
+// --- UniformCodeTraits for AVX512 (64-byte integer vectors) ---
+struct AVX512_Uniform_Tag {};
+template <>
+struct UniformCodeTraits<AVX512_Uniform_Tag> {
+    using IntVec = __m512i;
+    static constexpr int ByteWidth = 64;
+
+    static inline __attribute__((always_inline)) IntVec
+    loadu(const uint8_t* p) {
+        return _mm512_loadu_si512(reinterpret_cast<const __m512i*>(p));
+    }
+    static inline __attribute__((always_inline)) IntVec
+    zero() {
+        return _mm512_setzero_si512();
+    }
+    static inline __attribute__((always_inline)) IntVec
+    set1_epi8(int8_t v) {
+        return _mm512_set1_epi8(v);
+    }
+    static inline __attribute__((always_inline)) IntVec
+    set1_epi16(int16_t v) {
+        return _mm512_set1_epi16(v);
+    }
+    static inline __attribute__((always_inline)) IntVec
+    and_si(IntVec a, IntVec b) {
+        return _mm512_and_si512(a, b);
+    }
+    static inline __attribute__((always_inline)) IntVec
+    srli_epi16(IntVec a, int imm) {
+        return _mm512_srli_epi16(a, imm);
+    }
+    static inline __attribute__((always_inline)) IntVec
+    maddubs_epi16(IntVec a, IntVec b) {
+        return _mm512_maddubs_epi16(a, b);
+    }
+    static inline __attribute__((always_inline)) IntVec
+    madd_epi16(IntVec a, IntVec b) {
+        return _mm512_madd_epi16(a, b);
+    }
+    static inline __attribute__((always_inline)) IntVec
+    add_epi16(IntVec a, IntVec b) {
+        return _mm512_add_epi16(a, b);
+    }
+    static inline __attribute__((always_inline)) IntVec
+    add_epi32(IntVec a, IntVec b) {
+        return _mm512_add_epi32(a, b);
+    }
+    static inline __attribute__((always_inline)) int32_t
+    reduce_add_epi16(IntVec v) {
+        auto lo = _mm512_cvtepi16_epi32(_mm512_castsi512_si256(v));
+        auto hi = _mm512_cvtepi16_epi32(_mm512_extracti32x8_epi32(v, 1));
+        return _mm512_reduce_add_epi32(lo) + _mm512_reduce_add_epi32(hi);
+    }
+    static inline __attribute__((always_inline)) int32_t
+    reduce_add_epi32(IntVec v) {
+        return _mm512_reduce_add_epi32(v);
+    }
+};
+
+// --- RaBitQTraits for AVX512 (16-wide, uses mask registers) ---
+struct AVX512_RaBitQ_Tag {};
+template <>
+struct RaBitQTraits<AVX512_RaBitQ_Tag> : SimdTraits<AVX512_Tag> {
+    static inline __attribute__((always_inline)) FloatVec
+    bits_to_signed(const uint8_t* bit_ptr, FloatVec pos, FloatVec neg) {
+        auto mask = static_cast<__mmask16>(static_cast<uint16_t>(bit_ptr[0]) |
+                                           (static_cast<uint16_t>(bit_ptr[1]) << 8));
+        return _mm512_mask_blend_ps(mask, neg, pos);
+    }
+
+    static inline __attribute__((always_inline)) FloatVec
+    bits_select(const uint8_t* bit_ptr, FloatVec weight) {
+        auto mask = static_cast<__mmask16>(static_cast<uint16_t>(bit_ptr[0]) |
+                                           (static_cast<uint16_t>(bit_ptr[1]) << 8));
+        return _mm512_mask_add_ps(_mm512_setzero_ps(), mask, _mm512_setzero_ps(), weight);
+    }
+};
+
+}  // namespace vsag::simd

--- a/src/simd/traits/simd_traits_generic.h
+++ b/src/simd/traits/simd_traits_generic.h
@@ -1,0 +1,265 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+// Scalar "pseudo-SIMD" traits for the generic backend.
+//
+// IMPORTANT (compile-strategy invariant):
+//   - This header MUST only be included by ISA translation units whose
+//     COMPILE_FLAGS are compatible with the intrinsics it exposes.
+//   - The generic backend uses no intrinsics, so this header is safe in
+//     any TU; the convention nevertheless holds for the AVX/NEON/SVE
+//     traits headers that will be added in later phases.
+//   - Cross-ISA inclusion of a higher-tier traits header from a lower-tier
+//     TU (e.g. avx512 traits in sse.cpp) will trigger
+//     "target specific option mismatch" errors. Do not break this rule.
+
+namespace vsag::simd {
+
+struct Generic_Tag {};
+
+// Primary template; specializations live in sibling headers.
+template <typename ISA>
+struct SimdTraits;
+
+template <typename ISA>
+struct Int8Traits;
+
+template <>
+struct SimdTraits<Generic_Tag> {
+    using FloatVec = float;
+    static constexpr int Width = 1;
+
+    static inline __attribute__((always_inline)) FloatVec
+    zero() {
+        return 0.0f;
+    }
+
+    static inline __attribute__((always_inline)) FloatVec
+    load(const float* p) {
+        return *p;
+    }
+
+    static inline __attribute__((always_inline)) FloatVec
+    mul(FloatVec a, FloatVec b) {
+        return a * b;
+    }
+
+    static inline __attribute__((always_inline)) FloatVec
+    add(FloatVec a, FloatVec b) {
+        return a + b;
+    }
+
+    static inline __attribute__((always_inline)) FloatVec
+    sub(FloatVec a, FloatVec b) {
+        return a - b;
+    }
+
+    static inline __attribute__((always_inline)) FloatVec
+    fmadd(FloatVec a, FloatVec b, FloatVec c) {
+        return a * b + c;
+    }
+
+    static inline __attribute__((always_inline)) FloatVec
+    div(FloatVec a, FloatVec b) {
+        return a / b;
+    }
+
+    static inline __attribute__((always_inline)) void
+    store(float* p, FloatVec v) {
+        *p = v;
+    }
+
+    static inline __attribute__((always_inline)) float
+    reduce_add(FloatVec v) {
+        return v;
+    }
+
+    static inline __attribute__((always_inline)) FloatVec
+    set1(float v) {
+        return v;
+    }
+};
+
+// --- Int8 traits for generic (scalar) ---
+struct Generic_Int8_Tag {};
+template <>
+struct Int8Traits<Generic_Int8_Tag> {
+    using Int8HalfVec = int8_t;
+    using Int16Vec = int16_t;
+    using Int32Vec = int32_t;
+    static constexpr int BatchSize = 1;
+
+    static inline __attribute__((always_inline)) Int8HalfVec
+    load_i8(const int8_t* p) {
+        return *p;
+    }
+    static inline __attribute__((always_inline)) Int16Vec
+    cvt_i8_to_i16(Int8HalfVec v) {
+        return static_cast<int16_t>(v);
+    }
+    static inline __attribute__((always_inline)) Int32Vec
+    madd_i16(Int16Vec a, Int16Vec b) {
+        return static_cast<int32_t>(a) * b;
+    }
+    static inline __attribute__((always_inline)) Int16Vec
+    sub_i16(Int16Vec a, Int16Vec b) {
+        return a - b;
+    }
+    static inline __attribute__((always_inline)) Int32Vec
+    add_i32(Int32Vec a, Int32Vec b) {
+        return a + b;
+    }
+    static inline __attribute__((always_inline)) Int32Vec
+    zero_i32() {
+        return 0;
+    }
+    static inline __attribute__((always_inline)) int32_t
+    reduce_add_i32(Int32Vec v) {
+        return v;
+    }
+};
+
+// --- BitTraits primary template ---
+template <typename Tag>
+struct BitTraits;
+
+// Generic scalar bit operations (ByteWidth = 1, process byte by byte)
+struct Generic_Bit_Tag {};
+template <>
+struct BitTraits<Generic_Bit_Tag> {
+    using IntVec = uint8_t;
+    static constexpr int ByteWidth = 1;
+
+    static inline __attribute__((always_inline)) IntVec
+    load(const uint8_t* p) {
+        return *p;
+    }
+    static inline __attribute__((always_inline)) void
+    store(uint8_t* p, IntVec v) {
+        *p = v;
+    }
+    static inline __attribute__((always_inline)) IntVec
+    bit_and(IntVec a, IntVec b) {
+        return a & b;
+    }
+    static inline __attribute__((always_inline)) IntVec
+    bit_or(IntVec a, IntVec b) {
+        return a | b;
+    }
+    static inline __attribute__((always_inline)) IntVec
+    bit_xor(IntVec a, IntVec b) {
+        return a ^ b;
+    }
+    static inline __attribute__((always_inline)) IntVec
+    bit_not(IntVec a) {
+        return ~a;
+    }
+};
+
+// --- SQ8Traits primary template ---
+template <typename Tag>
+struct SQ8Traits;
+
+// Generic SQ8 traits (scalar, Width=1)
+struct Generic_SQ8_Tag {};
+template <>
+struct SQ8Traits<Generic_SQ8_Tag> : SimdTraits<Generic_Tag> {
+    static inline __attribute__((always_inline)) FloatVec
+    load_u8_as_float(const uint8_t* p) {
+        return static_cast<float>(p[0]);
+    }
+};
+
+// --- SQ4Traits primary template ---
+template <typename Tag>
+struct SQ4Traits;
+
+// Generic SQ4 (scalar, Width=1, STEP=2 nibbles per iter)
+struct Generic_SQ4_Tag {};
+template <>
+struct SQ4Traits<Generic_SQ4_Tag> : SimdTraits<Generic_Tag> {
+    static inline __attribute__((always_inline)) void
+    load_nibbles_2x_as_float(const uint8_t* p, FloatVec& out0, FloatVec& out1) {
+        constexpr float inv15 = 1.0f / 15.0f;
+        out0 = (p[0] & 0x0f) * inv15;
+        out1 = (p[0] >> 4) * inv15;
+    }
+};
+
+// --- BF16Traits primary template ---
+template <typename Tag>
+struct BF16Traits;
+
+struct Generic_BF16_Tag {};
+template <>
+struct BF16Traits<Generic_BF16_Tag> : SimdTraits<Generic_Tag> {
+    static inline __attribute__((always_inline)) FloatVec
+    load_half(const uint16_t* p) {
+        uint32_t bits = static_cast<uint32_t>(*p) << 16;
+        float f;
+        __builtin_memcpy(&f, &bits, sizeof(f));
+        return f;
+    }
+};
+
+// --- RaBitQTraits primary template ---
+template <typename Tag>
+struct RaBitQTraits;
+
+// --- UniformCodeTraits primary template ---
+// Provides integer vector ops for SQ4/SQ8 uniform code IP computation.
+template <typename Tag>
+struct UniformCodeTraits;
+
+// --- FP16Traits primary template ---
+template <typename Tag>
+struct FP16Traits;
+
+struct Generic_FP16_Tag {};
+template <>
+struct FP16Traits<Generic_FP16_Tag> : SimdTraits<Generic_Tag> {
+    static inline __attribute__((always_inline)) FloatVec
+    load_half(const uint16_t* p) {
+        uint32_t h = *p;
+        uint32_t sign = (h & 0x8000u) << 16;
+        uint32_t exp = (h >> 10) & 0x1F;
+        uint32_t mant = h & 0x3FFu;
+        uint32_t f;
+        if (exp == 0) {
+            if (mant == 0) {
+                f = sign;
+            } else {
+                exp = 1;
+                while (!(mant & 0x400)) {
+                    mant <<= 1;
+                    exp--;
+                }
+                mant &= 0x3FF;
+                f = sign | ((exp + 127 - 15) << 23) | (mant << 13);
+            }
+        } else if (exp == 31) {
+            f = sign | 0x7F800000u | (mant << 13);
+        } else {
+            f = sign | ((exp + 127 - 15) << 23) | (mant << 13);
+        }
+        float result;
+        __builtin_memcpy(&result, &f, sizeof(result));
+        return result;
+    }
+};
+
+}  // namespace vsag::simd

--- a/src/simd/traits/simd_traits_neon.h
+++ b/src/simd/traits/simd_traits_neon.h
@@ -1,0 +1,219 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+// NEON traits (Width = 4, float32x4_t). MUST only be included from a
+// TU compiled with -march=armv8-a (i.e. neon.cpp).
+
+#include <arm_neon.h>
+
+#include "simd_traits_generic.h"
+
+namespace vsag::simd {
+
+struct NEON_Tag {};
+
+template <>
+struct SimdTraits<NEON_Tag> {
+    using FloatVec = float32x4_t;
+    static constexpr int Width = 4;
+
+    static inline __attribute__((always_inline)) FloatVec
+    zero() {
+        return vdupq_n_f32(0.0f);
+    }
+
+    static inline __attribute__((always_inline)) FloatVec
+    load(const float* p) {
+        return vld1q_f32(p);
+    }
+
+    static inline __attribute__((always_inline)) FloatVec
+    mul(FloatVec a, FloatVec b) {
+        return vmulq_f32(a, b);
+    }
+
+    static inline __attribute__((always_inline)) FloatVec
+    add(FloatVec a, FloatVec b) {
+        return vaddq_f32(a, b);
+    }
+
+    static inline __attribute__((always_inline)) FloatVec
+    sub(FloatVec a, FloatVec b) {
+        return vsubq_f32(a, b);
+    }
+
+    static inline __attribute__((always_inline)) FloatVec
+    fmadd(FloatVec a, FloatVec b, FloatVec c) {
+        return vfmaq_f32(c, a, b);
+    }
+
+    static inline __attribute__((always_inline)) FloatVec
+    div(FloatVec a, FloatVec b) {
+        return vdivq_f32(a, b);
+    }
+
+    static inline __attribute__((always_inline)) void
+    store(float* p, FloatVec v) {
+        vst1q_f32(p, v);
+    }
+
+    static inline __attribute__((always_inline)) float
+    reduce_add(FloatVec v) {
+        return vaddvq_f32(v);
+    }
+
+    static inline __attribute__((always_inline)) FloatVec
+    set1(float v) {
+        return vdupq_n_f32(v);
+    }
+};
+
+// --- Int8 traits for NEON ---
+struct NEON_Int8_Tag {};
+template <>
+struct Int8Traits<NEON_Int8_Tag> {
+    using Int8HalfVec = int8x8_t;
+    using Int16Vec = int16x8_t;
+    using Int32Vec = int32x4_t;
+    static constexpr int BatchSize = 8;
+
+    static inline __attribute__((always_inline)) Int8HalfVec
+    load_i8(const int8_t* p) {
+        return vld1_s8(p);
+    }
+    static inline __attribute__((always_inline)) Int16Vec
+    cvt_i8_to_i16(Int8HalfVec v) {
+        return vmovl_s8(v);
+    }
+    // Emulate x86 madd_epi16: pairwise (a[2i]*b[2i] + a[2i+1]*b[2i+1])
+    static inline __attribute__((always_inline)) Int32Vec
+    madd_i16(Int16Vec a, Int16Vec b) {
+        int32x4_t lo = vmull_s16(vget_low_s16(a), vget_low_s16(b));
+        int32x4_t hi = vmull_s16(vget_high_s16(a), vget_high_s16(b));
+        return vaddq_s32(vpaddq_s32(lo, hi), vdupq_n_s32(0));
+    }
+    static inline __attribute__((always_inline)) Int16Vec
+    sub_i16(Int16Vec a, Int16Vec b) {
+        return vsubq_s16(a, b);
+    }
+    static inline __attribute__((always_inline)) Int32Vec
+    add_i32(Int32Vec a, Int32Vec b) {
+        return vaddq_s32(a, b);
+    }
+    static inline __attribute__((always_inline)) Int32Vec
+    zero_i32() {
+        return vdupq_n_s32(0);
+    }
+    static inline __attribute__((always_inline)) int32_t
+    reduce_add_i32(Int32Vec v) {
+        return vaddvq_s32(v);
+    }
+};
+
+// --- Bit operation traits for NEON ---
+struct NEON_Bit_Tag {};
+template <>
+struct BitTraits<NEON_Bit_Tag> {
+    using IntVec = uint8x16_t;
+    static constexpr int ByteWidth = 16;
+
+    static inline __attribute__((always_inline)) IntVec
+    load(const uint8_t* p) {
+        return vld1q_u8(p);
+    }
+    static inline __attribute__((always_inline)) void
+    store(uint8_t* p, IntVec v) {
+        vst1q_u8(p, v);
+    }
+    static inline __attribute__((always_inline)) IntVec
+    bit_and(IntVec a, IntVec b) {
+        return vandq_u8(a, b);
+    }
+    static inline __attribute__((always_inline)) IntVec
+    bit_or(IntVec a, IntVec b) {
+        return vorrq_u8(a, b);
+    }
+    static inline __attribute__((always_inline)) IntVec
+    bit_xor(IntVec a, IntVec b) {
+        return veorq_u8(a, b);
+    }
+    static inline __attribute__((always_inline)) IntVec
+    bit_not(IntVec a) {
+        return vmvnq_u8(a);
+    }
+};
+
+// --- SQ8 traits for NEON ---
+struct NEON_SQ8_Tag {};
+template <>
+struct SQ8Traits<NEON_SQ8_Tag> : SimdTraits<NEON_Tag> {
+    static inline __attribute__((always_inline)) FloatVec
+    load_u8_as_float(const uint8_t* p) {
+        uint32x4_t v32 = {p[0], p[1], p[2], p[3]};
+        return vcvtq_f32_u32(v32);
+    }
+};
+
+// --- SQ4Traits for NEON (Width=4, STEP=8 nibbles = 4 bytes per call) ---
+struct NEON_SQ4_Tag {};
+template <>
+struct SQ4Traits<NEON_SQ4_Tag> : SimdTraits<NEON_Tag> {
+    static inline __attribute__((always_inline)) void
+    load_nibbles_2x_as_float(const uint8_t* p, FloatVec& out0, FloatVec& out1) {
+        constexpr float inv15 = 1.0f / 15.0f;
+        float32x4_t v_inv15 = vdupq_n_f32(inv15);
+        float32x4_t lo = {
+            static_cast<float>(p[0] & 0x0f),
+            static_cast<float>(p[0] >> 4),
+            static_cast<float>(p[1] & 0x0f),
+            static_cast<float>(p[1] >> 4),
+        };
+        float32x4_t hi = {
+            static_cast<float>(p[2] & 0x0f),
+            static_cast<float>(p[2] >> 4),
+            static_cast<float>(p[3] & 0x0f),
+            static_cast<float>(p[3] >> 4),
+        };
+        out0 = vmulq_f32(lo, v_inv15);
+        out1 = vmulq_f32(hi, v_inv15);
+    }
+};
+
+// --- BF16Traits for NEON ---
+struct NEON_BF16_Tag {};
+template <>
+struct BF16Traits<NEON_BF16_Tag> : SimdTraits<NEON_Tag> {
+    static inline __attribute__((always_inline)) FloatVec
+    load_half(const uint16_t* p) {
+        uint16x4_t bf16 = vld1_u16(p);
+        uint32x4_t bf32 = vshll_n_u16(bf16, 16);
+        return vreinterpretq_f32_u32(bf32);
+    }
+};
+
+// --- FP16Traits for NEON ---
+struct NEON_FP16_Tag {};
+template <>
+struct FP16Traits<NEON_FP16_Tag> : SimdTraits<NEON_Tag> {
+    static inline __attribute__((always_inline)) FloatVec
+    load_half(const uint16_t* p) {
+        float16x4_t fp16 = vld1_f16(reinterpret_cast<const __fp16*>(p));
+        return vcvt_f32_f16(fp16);
+    }
+};
+
+}  // namespace vsag::simd

--- a/src/simd/traits/simd_traits_sse.h
+++ b/src/simd/traits/simd_traits_sse.h
@@ -1,0 +1,314 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+// SSE traits (Width = 4, __m128).
+//
+// IMPORTANT: This header uses SSE intrinsics. It MUST only be included
+// from translation units compiled with -msse (and friends). Including
+// it from sse.cpp is correct; including it from generic.cpp or any
+// other ISA TU will trigger "target specific option mismatch" errors.
+
+#include <immintrin.h>
+
+#include "simd_traits_generic.h"
+
+namespace vsag::simd {
+
+struct SSE_Tag {};
+
+template <>
+struct SimdTraits<SSE_Tag> {
+    using FloatVec = __m128;
+    static constexpr int Width = 4;
+
+    static inline __attribute__((always_inline)) FloatVec
+    zero() {
+        return _mm_setzero_ps();
+    }
+
+    static inline __attribute__((always_inline)) FloatVec
+    load(const float* p) {
+        return _mm_loadu_ps(p);
+    }
+
+    static inline __attribute__((always_inline)) FloatVec
+    mul(FloatVec a, FloatVec b) {
+        return _mm_mul_ps(a, b);
+    }
+
+    static inline __attribute__((always_inline)) FloatVec
+    add(FloatVec a, FloatVec b) {
+        return _mm_add_ps(a, b);
+    }
+
+    static inline __attribute__((always_inline)) FloatVec
+    sub(FloatVec a, FloatVec b) {
+        return _mm_sub_ps(a, b);
+    }
+
+    // SSE has no FMA; emulate as add(mul(a, b), c). Matches the
+    // original sse.cpp implementation byte-for-byte.
+    static inline __attribute__((always_inline)) FloatVec
+    fmadd(FloatVec a, FloatVec b, FloatVec c) {
+        return _mm_add_ps(_mm_mul_ps(a, b), c);
+    }
+
+    static inline __attribute__((always_inline)) FloatVec
+    div(FloatVec a, FloatVec b) {
+        return _mm_div_ps(a, b);
+    }
+
+    static inline __attribute__((always_inline)) void
+    store(float* p, FloatVec v) {
+        _mm_storeu_ps(p, v);
+    }
+
+    static inline __attribute__((always_inline)) float
+    reduce_add(FloatVec v) {
+        // Match the original sse FP32ReduceAdd / FP32ComputeIP shape:
+        // the existing sse.cpp uses two different reductions (hadd for
+        // FP32ReduceAdd, scalar-sum for FP32ComputeIP). To keep numerical
+        // results bit-stable against the FP32ComputeIP baseline we use
+        // the scalar-sum form here, which matches the original IP/L2
+        // tail. FP32ReduceAdd's hadd path differs only in last-bit
+        // ordering and is allowed to diverge.
+        alignas(16) float tmp[4];
+        _mm_store_ps(tmp, v);
+        return tmp[0] + tmp[1] + tmp[2] + tmp[3];
+    }
+
+    static inline __attribute__((always_inline)) FloatVec
+    set1(float v) {
+        return _mm_set1_ps(v);
+    }
+};
+
+// --- Int8 traits for SSE ---
+struct SSE_Int8_Tag {};
+template <>
+struct Int8Traits<SSE_Int8_Tag> {
+    using Int8HalfVec = __m128i;  // only lower 64 bits used
+    using Int16Vec = __m128i;
+    using Int32Vec = __m128i;
+    static constexpr int BatchSize = 8;
+
+    static inline __attribute__((always_inline)) Int8HalfVec
+    load_i8(const int8_t* p) {
+        return _mm_loadl_epi64(reinterpret_cast<const __m128i*>(p));
+    }
+    static inline __attribute__((always_inline)) Int16Vec
+    cvt_i8_to_i16(Int8HalfVec v) {
+        return _mm_cvtepi8_epi16(v);
+    }
+    static inline __attribute__((always_inline)) Int32Vec
+    madd_i16(Int16Vec a, Int16Vec b) {
+        return _mm_madd_epi16(a, b);
+    }
+    static inline __attribute__((always_inline)) Int16Vec
+    sub_i16(Int16Vec a, Int16Vec b) {
+        return _mm_sub_epi16(a, b);
+    }
+    static inline __attribute__((always_inline)) Int32Vec
+    add_i32(Int32Vec a, Int32Vec b) {
+        return _mm_add_epi32(a, b);
+    }
+    static inline __attribute__((always_inline)) Int32Vec
+    zero_i32() {
+        return _mm_setzero_si128();
+    }
+    static inline __attribute__((always_inline)) int32_t
+    reduce_add_i32(Int32Vec v) {
+        alignas(16) int32_t tmp[4];
+        _mm_store_si128(reinterpret_cast<__m128i*>(tmp), v);
+        return tmp[0] + tmp[1] + tmp[2] + tmp[3];
+    }
+};
+
+// --- Bit operation traits for SSE ---
+struct SSE_Bit_Tag {};
+template <>
+struct BitTraits<SSE_Bit_Tag> {
+    using IntVec = __m128i;
+    static constexpr int ByteWidth = 16;
+
+    static inline __attribute__((always_inline)) IntVec
+    load(const uint8_t* p) {
+        return _mm_loadu_si128(reinterpret_cast<const __m128i*>(p));
+    }
+    static inline __attribute__((always_inline)) void
+    store(uint8_t* p, IntVec v) {
+        _mm_storeu_si128(reinterpret_cast<__m128i*>(p), v);
+    }
+    static inline __attribute__((always_inline)) IntVec
+    bit_and(IntVec a, IntVec b) {
+        return _mm_and_si128(a, b);
+    }
+    static inline __attribute__((always_inline)) IntVec
+    bit_or(IntVec a, IntVec b) {
+        return _mm_or_si128(a, b);
+    }
+    static inline __attribute__((always_inline)) IntVec
+    bit_xor(IntVec a, IntVec b) {
+        return _mm_xor_si128(a, b);
+    }
+    static inline __attribute__((always_inline)) IntVec
+    bit_not(IntVec a) {
+        return _mm_xor_si128(a, _mm_set1_epi8(static_cast<char>(0xFF)));
+    }
+};
+
+// --- SQ8 traits for SSE ---
+struct SSE_SQ8_Tag {};
+template <>
+struct SQ8Traits<SSE_SQ8_Tag> : SimdTraits<SSE_Tag> {
+    static inline __attribute__((always_inline)) FloatVec
+    load_u8_as_float(const uint8_t* p) {
+        __m128i v = _mm_set_epi8(0,
+                                 0,
+                                 0,
+                                 0,
+                                 0,
+                                 0,
+                                 0,
+                                 0,
+                                 0,
+                                 0,
+                                 0,
+                                 0,
+                                 static_cast<char>(p[3]),
+                                 static_cast<char>(p[2]),
+                                 static_cast<char>(p[1]),
+                                 static_cast<char>(p[0]));
+        return _mm_cvtepi32_ps(_mm_cvtepu8_epi32(v));
+    }
+};
+
+// --- SQ4Traits for SSE (Width=4, STEP=8 nibbles = 4 bytes per call) ---
+struct SSE_SQ4_Tag {};
+template <>
+struct SQ4Traits<SSE_SQ4_Tag> : SimdTraits<SSE_Tag> {
+    static inline __attribute__((always_inline)) void
+    load_nibbles_2x_as_float(const uint8_t* p, FloatVec& out0, FloatVec& out1) {
+        __m128i code_vec = _mm_set_epi8(0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        static_cast<char>(p[3]),
+                                        static_cast<char>(p[2]),
+                                        static_cast<char>(p[1]),
+                                        static_cast<char>(p[0]));
+        __m128i lo = _mm_and_si128(code_vec, _mm_set1_epi8(0x0F));
+        __m128i hi = _mm_and_si128(_mm_srli_epi16(code_vec, 4), _mm_set1_epi8(0x0F));
+        __m128i interleaved = _mm_unpacklo_epi8(lo, hi);
+        __m128i v0 = _mm_cvtepu8_epi32(interleaved);
+        __m128i v1 = _mm_cvtepu8_epi32(_mm_srli_si128(interleaved, 4));
+        const __m128 inv15 = _mm_set1_ps(1.0f / 15.0f);
+        out0 = _mm_mul_ps(_mm_cvtepi32_ps(v0), inv15);
+        out1 = _mm_mul_ps(_mm_cvtepi32_ps(v1), inv15);
+    }
+};
+
+// --- BF16Traits for SSE ---
+struct SSE_BF16_Tag {};
+template <>
+struct BF16Traits<SSE_BF16_Tag> : SimdTraits<SSE_Tag> {
+    static inline __attribute__((always_inline)) FloatVec
+    load_half(const uint16_t* p) {
+        __m128i v = _mm_set_epi16(static_cast<short>(p[3]),
+                                  0,
+                                  static_cast<short>(p[2]),
+                                  0,
+                                  static_cast<short>(p[1]),
+                                  0,
+                                  static_cast<short>(p[0]),
+                                  0);
+        return _mm_castsi128_ps(v);
+    }
+};
+
+// --- UniformCodeTraits for SSE (16-byte integer vectors) ---
+struct SSE_Uniform_Tag {};
+template <>
+struct UniformCodeTraits<SSE_Uniform_Tag> {
+    using IntVec = __m128i;
+    static constexpr int ByteWidth = 16;
+
+    static inline __attribute__((always_inline)) IntVec
+    loadu(const uint8_t* p) {
+        return _mm_loadu_si128(reinterpret_cast<const __m128i*>(p));
+    }
+    static inline __attribute__((always_inline)) IntVec
+    zero() {
+        return _mm_setzero_si128();
+    }
+    static inline __attribute__((always_inline)) IntVec
+    set1_epi8(int8_t v) {
+        return _mm_set1_epi8(v);
+    }
+    static inline __attribute__((always_inline)) IntVec
+    set1_epi16(int16_t v) {
+        return _mm_set1_epi16(v);
+    }
+    static inline __attribute__((always_inline)) IntVec
+    and_si(IntVec a, IntVec b) {
+        return _mm_and_si128(a, b);
+    }
+    static inline __attribute__((always_inline)) IntVec
+    srli_epi16(IntVec a, int imm) {
+        return _mm_srli_epi16(a, imm);
+    }
+    static inline __attribute__((always_inline)) IntVec
+    maddubs_epi16(IntVec a, IntVec b) {
+        return _mm_maddubs_epi16(a, b);
+    }
+    static inline __attribute__((always_inline)) IntVec
+    madd_epi16(IntVec a, IntVec b) {
+        return _mm_madd_epi16(a, b);
+    }
+    static inline __attribute__((always_inline)) IntVec
+    add_epi16(IntVec a, IntVec b) {
+        return _mm_add_epi16(a, b);
+    }
+    static inline __attribute__((always_inline)) IntVec
+    add_epi32(IntVec a, IntVec b) {
+        return _mm_add_epi32(a, b);
+    }
+    static inline __attribute__((always_inline)) int32_t
+    reduce_add_epi16(IntVec v) {
+        alignas(16) int16_t tmp[8];
+        _mm_store_si128(reinterpret_cast<__m128i*>(tmp), v);
+        int32_t sum = 0;
+        for (int i = 0; i < 8; ++i) sum += tmp[i];
+        return sum;
+    }
+    static inline __attribute__((always_inline)) int32_t
+    reduce_add_epi32(IntVec v) {
+        alignas(16) int32_t tmp[4];
+        _mm_store_si128(reinterpret_cast<__m128i*>(tmp), v);
+        return tmp[0] + tmp[1] + tmp[2] + tmp[3];
+    }
+};
+
+}  // namespace vsag::simd


### PR DESCRIPTION
## Summary

Resolves #2131

Introduce a type-traits abstraction layer and shared kernel templates to eliminate
copy-paste SIMD implementations across ISAs (SSE/AVX/AVX2/AVX512/NEON).

**Key changes:**
- Add per-ISA traits headers (`src/simd/traits/simd_traits_*.h`) exposing a uniform
  static interface over each ISA's native vector types
- Add 17 kernel templates (`src/simd/kernels/*.h`) that implement algorithms once
  in terms of traits, replacing 5-way duplicated hand-written intrinsics
- Covered function families: FP32 compute/batch/binary-ops/reduce, SQ8/SQ4 quantized
  compute, SQ4/SQ8 uniform code IP, INT8 compute, BF16/FP16 half-precision compute,
  bit operations, normalize, RaBitQ binary/batch/split-code IP, butterfly/rotate,
  and scalar ops

**Net effect:**
- ISA implementation files shrink from ~11,049 to ~4,628 lines (**-58%**)
- New SIMD function cost drops from ~7 files x 30 lines to 1 kernel template + 0-2 trait extensions
- Zero runtime overhead: all traits are `always_inline`, verified via CPU-pinned benchmarks

**Out of scope:** SVE (scalable vectors), AMX (tile/matrix model), `simd_dispatch.h` (unchanged)

## Test plan

- [x] All 51 SIMD unit test cases pass (30,591,891 assertions)
- [x] CPU-pinned (`taskset -c 0`) benchmarks show no regression on AVX2/AVX512 paths
- [x] Release build compiles cleanly with all ISA flags
