### PR TITLE
refactor: extract total_count_ to InnerIndexInterface base class

### DIFF
--- a/src/algorithm/bruteforce/bruteforce.cpp
+++ b/src/algorithm/bruteforce/bruteforce.cpp
@@ -73,7 +73,7 @@ BruteForce::Add(const DatasetPtr& data, AddMode mode) {
 
     {
         std::lock_guard lock(this->add_mutex_);
-        if (this->total_count_ == 0) {
+        if (this->total_count_.load() == 0) {
             this->Train(data);
         }
     }
@@ -88,9 +88,9 @@ BruteForce::Add(const DatasetPtr& data, AddMode mode) {
             if (this->label_table_->CheckLabel(label)) {
                 return label;
             }
-            inner_id = this->total_count_;
-            this->total_count_++;
-            this->resize(total_count_);
+            inner_id = this->total_count_.load();
+            ++this->total_count_;
+            this->resize(total_count_.load());
             this->label_table_->Insert(inner_id, label);
         }
         std::shared_lock global_lock(this->global_mutex_);
@@ -160,7 +160,7 @@ BruteForce::Remove(const std::vector<int64_t>& ids, RemoveMode mode) {
 
     std::scoped_lock lock(this->add_mutex_, this->label_lookup_mutex_);
     for (auto label : ids) {
-        const auto last_inner_id = static_cast<InnerIdType>(this->total_count_ - 1);
+        const auto last_inner_id = static_cast<InnerIdType>(this->total_count_.load() - 1);
         const auto inner_id = this->label_table_->GetIdByLabel(label);
 
         CHECK_ARGUMENT(inner_id <= last_inner_id, "the element to be remove is invalid");
@@ -180,7 +180,7 @@ BruteForce::Remove(const std::vector<int64_t>& ids, RemoveMode mode) {
             this->label_table_->Insert(inner_id, last_label);
         }
 
-        this->total_count_--;
+        --this->total_count_;
     }
     return 1;
 }
@@ -246,15 +246,16 @@ BruteForce::SearchWithRequest(const SearchRequest& request) const {
         dist_cmp.fetch_add(dist_cmp_local, std::memory_order_relaxed);
     };
 
+    auto count = total_count_.load();
     if (parallel_count == 1 || this->thread_pool_ == nullptr) {
-        search_func(0, total_count_, heaps[0]);
+        search_func(0, count, heaps[0]);
         heap = heaps[0];
     } else {
         std::vector<std::future<void>> futures;
-        auto chunk_size = (total_count_ + parallel_count - 1) / parallel_count;
+        auto chunk_size = (count + parallel_count - 1) / parallel_count;
         for (auto i = 0; i < parallel_count; ++i) {
             auto start = i * chunk_size;
-            auto end = std::min(start + chunk_size, total_count_);
+            auto end = std::min(start + chunk_size, count);
             auto future = this->thread_pool_->GeneralEnqueue(search_func, start, end, heaps[i]);
             futures.emplace_back(std::move(future));
         }
@@ -288,7 +289,7 @@ BruteForce::RangeSearch(const vsag::DatasetPtr& query,
     if (limited_size < 0) {
         limited_size = std::numeric_limits<int64_t>::max();
     }
-    if (total_count_ == 0) {
+    if (total_count_.load() == 0) {
         return make_empty_result();
     }
 
@@ -311,16 +312,17 @@ BruteForce::RangeSearch(const vsag::DatasetPtr& query,
     };
 
     DistHeapPtr heap = nullptr;
-    parallel_count = std::min(parallel_count, total_count_);
+    auto count = total_count_.load();
+    parallel_count = std::min(parallel_count, count);
     if (parallel_count <= 1 or this->thread_pool_ == nullptr) {
-        heap = search_func(0, total_count_);
+        heap = search_func(0, count);
     } else {
         std::vector<std::future<DistHeapPtr>> futures;
         futures.reserve(parallel_count);
-        auto chunk_size = (total_count_ + parallel_count - 1) / parallel_count;
+        auto chunk_size = (count + parallel_count - 1) / parallel_count;
         for (uint64_t i = 0; i < parallel_count; ++i) {
             auto start = static_cast<InnerIdType>(i * chunk_size);
-            auto end = static_cast<InnerIdType>(std::min(start + chunk_size, total_count_));
+            auto end = static_cast<InnerIdType>(std::min(start + chunk_size, count));
             futures.emplace_back(this->thread_pool_->GeneralEnqueue(search_func, start, end));
         }
 
@@ -367,7 +369,7 @@ BruteForce::Serialize(StreamWriter& writer) const {
     // serialize footer (introduced since v0.15)
     JsonType basic_info;
     basic_info["dim"].SetInt(dim_);
-    basic_info["total_count"].SetInt(total_count_);
+    basic_info["total_count"].SetInt(total_count_.load());
     basic_info[INDEX_PARAM].SetString(this->create_param_ptr_->ToString());
     write_index_footer(writer, basic_info);
 }
@@ -385,7 +387,9 @@ BruteForce::Deserialize(StreamReader& reader) {
         logger::debug("parse with v0.13 version format");
 
         StreamReader::ReadObj(buffer_reader, dim_);
-        StreamReader::ReadObj(buffer_reader, total_count_);
+        uint64_t count = 0;
+        StreamReader::ReadObj(buffer_reader, count);
+        total_count_.store(count);
     } else {  // create like `else if ( ver in [v0.15, v0.17] )` here if need in the future
         logger::debug("parse with new version format");
 
@@ -403,7 +407,7 @@ BruteForce::Deserialize(StreamReader& reader) {
             }
         }
         dim_ = basic_info["dim"].GetInt();
-        total_count_ = basic_info["total_count"].GetInt();
+        total_count_.store(basic_info["total_count"].GetInt());
 
         if (this->use_attribute_filter_ and this->attr_filter_index_ != nullptr) {
             this->attr_filter_index_->Deserialize(buffer_reader);

--- a/src/algorithm/bruteforce/bruteforce.h
+++ b/src/algorithm/bruteforce/bruteforce.h
@@ -80,7 +80,8 @@ public:
 
     [[nodiscard]] int64_t
     GetNumElements() const override {
-        return this->total_count_ - this->delete_count_;
+        return static_cast<int64_t>(this->total_count_.load()) -
+               static_cast<int64_t>(this->delete_count_);
     }
 
     [[nodiscard]] int64_t
@@ -142,8 +143,6 @@ private:
 
 private:
     FlattenInterfacePtr inner_codes_{nullptr};
-
-    uint64_t total_count_{0};
 
     uint64_t delete_count_{0};
 

--- a/src/algorithm/hgraph/hgraph.h
+++ b/src/algorithm/hgraph/hgraph.h
@@ -510,8 +510,6 @@ private:
     uint64_t ef_construct_{400};
     float alpha_{1.0};
 
-    std::atomic<uint64_t> total_count_{0};
-
     std::shared_ptr<VisitedListPool> pool_{nullptr};
 
     mutable std::shared_mutex global_mutex_;

--- a/src/algorithm/inner_index_interface.h
+++ b/src/algorithm/inner_index_interface.h
@@ -570,6 +570,8 @@ public:
     std::atomic<bool> immutable_{false};
 
 protected:
+    std::atomic<uint64_t> total_count_{0};
+
     std::atomic<int64_t> current_memory_usage_{0};
     mutable std::shared_mutex memory_usage_mutex_{};
 

--- a/src/algorithm/warp/warp.cpp
+++ b/src/algorithm/warp/warp.cpp
@@ -110,7 +110,7 @@ WARP::Add(const DatasetPtr& data, AddMode mode) {
 
     {
         std::lock_guard lock(this->add_mutex_);
-        if (this->total_count_ == 0) {
+        if (this->total_count_.load() == 0) {
             this->Train(data);
         }
     }
@@ -150,9 +150,9 @@ WARP::Add(const DatasetPtr& data, AddMode mode) {
             if (this->label_table_->CheckLabel(label)) {
                 return label;
             }
-            inner_id = this->total_count_;
-            this->total_count_++;
-            this->resize(total_count_);
+            inner_id = this->total_count_.load();
+            ++this->total_count_;
+            this->resize(total_count_.load());
             this->label_table_->Insert(inner_id, label);
         }
         std::shared_lock global_lock(this->global_mutex_);
@@ -304,16 +304,17 @@ WARP::SearchWithRequest(const SearchRequest& request) const {
     };
 
     DistHeapPtr heap = nullptr;
+    auto count = total_count_.load();
 
     if (parallel_count == 1 || this->thread_pool_ == nullptr ||
-        total_count_ < MIN_PARALLEL_SEARCH_DOC_COUNT) {
-        heap = search_func(0, total_count_);
+        count < MIN_PARALLEL_SEARCH_DOC_COUNT) {
+        heap = search_func(0, count);
     } else {
         std::vector<std::future<DistHeapPtr>> futures;
-        auto chunk_size = (total_count_ + parallel_count - 1) / parallel_count;
+        auto chunk_size = (count + parallel_count - 1) / parallel_count;
         for (auto i = 0; i < static_cast<int>(parallel_count); ++i) {
             auto start = i * chunk_size;
-            auto end = std::min(start + chunk_size, static_cast<uint64_t>(total_count_));
+            auto end = std::min(start + chunk_size, count);
             if (start < end) {
                 auto future = this->thread_pool_->GeneralEnqueue(search_func, start, end);
                 futures.emplace_back(std::move(future));
@@ -375,12 +376,13 @@ WARP::RangeSearch(const vsag::DatasetPtr& query,
     auto parallel_count = warp_params.parallel_search_thread_count;
 
     // Use serial version if no thread pool or small dataset
+    auto count = total_count_.load();
     if (parallel_count == 1 || this->thread_pool_ == nullptr ||
-        total_count_ < MIN_PARALLEL_SEARCH_DOC_COUNT) {
+        count < MIN_PARALLEL_SEARCH_DOC_COUNT) {
         DistHeapPtr heap =
             std::make_shared<StandardHeap<true, true>>(this->allocator_, limited_size);
 
-        for (InnerIdType doc_id = 0; doc_id < total_count_; ++doc_id) {
+        for (InnerIdType doc_id = 0; doc_id < count; ++doc_id) {
             if (filter != nullptr and
                 not filter->CheckValid(this->label_table_->GetLabelById(doc_id))) {
                 continue;
@@ -410,12 +412,12 @@ WARP::RangeSearch(const vsag::DatasetPtr& query,
         auto future = this->thread_pool_->GeneralEnqueue([&]() {
             std::vector<std::pair<float, InnerIdType>> local_results;
             // Pre-allocate to avoid frequent reallocations
-            local_results.reserve(std::min(static_cast<size_t>(1024),
-                                           static_cast<size_t>(total_count_) / parallel_count));
+            local_results.reserve(
+                std::min(static_cast<size_t>(1024), static_cast<size_t>(count) / parallel_count));
 
             while (true) {
                 auto doc_id = next_doc.fetch_add(1);
-                if (doc_id >= total_count_) {
+                if (doc_id >= count) {
                     break;
                 }
 
@@ -474,7 +476,8 @@ WARP::RangeSearch(const vsag::DatasetPtr& query,
 void
 WARP::Serialize(StreamWriter& writer) const {
     // Serialize document offsets (size = total_count_ + 1)
-    StreamWriter::WriteObj(writer, total_count_);
+    uint64_t count = total_count_.load();
+    StreamWriter::WriteObj(writer, count);
     StreamWriter::WriteObj(writer, total_vector_count_);
 
     // Batch write the doc_offsets array using WriteVector
@@ -486,7 +489,7 @@ WARP::Serialize(StreamWriter& writer) const {
     // Serialize footer
     JsonType basic_info;
     basic_info["dim"].SetInt(dim_);
-    basic_info["total_count"].SetInt(total_count_);
+    basic_info["total_count"].SetInt(total_count_.load());
     basic_info["total_vector_count"].SetInt(total_vector_count_);
     basic_info[INDEX_PARAM].SetString(this->create_param_ptr_->ToString());
     write_index_footer(writer, basic_info);
@@ -516,7 +519,9 @@ WARP::Deserialize(StreamReader& reader) {
     }
     dim_ = basic_info["dim"].GetInt();
 
-    StreamReader::ReadObj(buffer_reader, total_count_);
+    uint64_t count = 0;
+    StreamReader::ReadObj(buffer_reader, count);
+    total_count_.store(count);
     StreamReader::ReadObj(buffer_reader, total_vector_count_);
 
     // Batch read the doc_offsets array using ReadVector

--- a/src/algorithm/warp/warp.h
+++ b/src/algorithm/warp/warp.h
@@ -73,7 +73,8 @@ public:
 
     [[nodiscard]] int64_t
     GetNumElements() const override {
-        return this->total_count_ - this->delete_count_;
+        return static_cast<int64_t>(this->total_count_.load()) -
+               static_cast<int64_t>(this->delete_count_);
     }
 
     [[nodiscard]] int64_t
@@ -131,8 +132,6 @@ private:
 
 private:
     FlattenInterfacePtr inner_codes_{nullptr};
-
-    uint64_t total_count_{0};  // Number of documents (not vectors)
 
     uint64_t delete_count_{0};
 


### PR DESCRIPTION
## Summary

Move `total_count_` from HGraph, BruteForce, and WARP into the `InnerIndexInterface` base class as `std::atomic<uint64_t>`.

### Changes
- Add `std::atomic<uint64_t> total_count_{0}` to the protected section of `InnerIndexInterface`
- Remove the per-index `total_count_` member from `HGraph`, `BruteForce`, and `WARP`
- Update `BruteForce` and `WARP` to use atomic operations (`.load()`, `.store()`, prefix `++`/`--`) for all `total_count_` accesses
- HGraph was already using `std::atomic<uint64_t>` so its usage is unchanged

### Motivation
- Eliminates code duplication across index implementations
- Ensures thread-safe access uniformly (BruteForce and WARP previously used non-atomic `uint64_t`)
- Provides a consistent base for future index implementations

Supersedes #1682 (closed due to directory restructure in #2127).
Closes: #1681
