### PR TITLE
fix(ci): keep docs sync branch aligned

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -23,6 +23,7 @@ jobs:
         with:
           repository: vsag-io/vsag-io.github.io
           token: ${{ secrets.GH_PAT }}
+          ref: main
           path: repo-vsagio
 
       - name: Sync docs books (zh, en)
@@ -47,11 +48,12 @@ jobs:
           cd repo-vsagio
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -B sync origin/main
+          git add -A docs blogs landing
           if [[ -z $(git status --porcelain) ]]; then
             echo "No changes to commit."
+            git push --force origin sync
             exit 0
           fi
-          git checkout -B sync
-          git add docs blogs landing
           git commit -m "docs: sync from vsag@${{ github.sha }}"
           git push --force origin sync


### PR DESCRIPTION
## Summary
- Rebuild the website `sync` branch from `origin/main` before applying docs sync changes.
- Force-push `sync` even when there are no content changes so stale sync commits are cleared.
- Prevent repeated PRs from replaying the same old sync commit and creating empty-effect merge commits.

## Verification
- `git diff --check -- .github/workflows/docs.yaml`