### PR TITLE
fix: expand Pyramid ef search for large topk

### DIFF
--- a/src/algorithm/pyramid/pyramid.cpp
+++ b/src/algorithm/pyramid/pyramid.cpp
@@ -240,6 +240,7 @@ Pyramid::KnnSearch(const DatasetPtr& query,
     QueryContext ctx{.stats = &stats};
 
     auto parsed_param = PyramidSearchParameters::FromJson(parameters);
+    CHECK_ARGUMENT(k > 0, fmt::format("k({}) must be greater than 0", k));
     auto ef_search_threshold = std::max<uint64_t>(AMPLIFICATION_FACTOR * k, 1000L);
     CHECK_ARGUMENT(  // NOLINT
         (1 <= parsed_param.ef_search) and (parsed_param.ef_search <= ef_search_threshold),
@@ -247,7 +248,7 @@ Pyramid::KnnSearch(const DatasetPtr& query,
             "ef_search({}) must in range[1, {}]", parsed_param.ef_search, ef_search_threshold));
 
     InnerSearchParam search_param;
-    search_param.ef = parsed_param.ef_search;
+    search_param.ef = std::max<uint64_t>(parsed_param.ef_search, static_cast<uint64_t>(k));
     search_param.radius = std::numeric_limits<float>::max();
     search_param.topk = k;
     search_param.search_mode = KNN_SEARCH;

--- a/tests/test_pyramid.cpp
+++ b/tests/test_pyramid.cpp
@@ -374,6 +374,42 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
 }
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
+                             "Pyramid KnnSearch Expands Ef Search To Topk",
+                             "[ft][build][pyramid]") {
+    PyramidParam pyramid_param;
+    pyramid_param.no_build_levels = {};
+
+    const auto param = GeneratePyramidBuildParametersString("l2", 4, pyramid_param);
+    auto index = TestFactory("pyramid", param, true);
+
+    constexpr int64_t data_count = 24;
+    constexpr int64_t topk = 20;
+    constexpr int64_t ef_search = 5;
+    std::vector<std::array<float, 4>> vectors;
+    std::vector<int64_t> ids;
+    std::vector<std::string> paths;
+    vectors.reserve(data_count);
+    ids.reserve(data_count);
+    paths.reserve(data_count);
+    for (int64_t i = 0; i < data_count; ++i) {
+        auto value = static_cast<float>(i);
+        vectors.push_back({value, value + 1.0F, value + 2.0F, value + 3.0F});
+        ids.push_back(1000 + i);
+        paths.emplace_back("all");
+    }
+
+    auto base = MakeDenseDataset(vectors, ids, paths);
+    auto build_result = index->Build(base);
+    REQUIRE(build_result.has_value());
+
+    auto query = MakeSingleQuery(vectors.front(), "all");
+    auto search_result =
+        index->KnnSearch(query, topk, GeneratePyramidSearchParametersString(ef_search));
+    REQUIRE(search_result.has_value());
+    REQUIRE(search_result.value()->GetDim() == topk);
+}
+
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
                              "Pyramid Add Test",
                              "[ft][build][pyramid]") {
     auto metric_type = GENERATE("l2");


### PR DESCRIPTION
## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement/Refactor
- [ ] Documentation
- [ ] CI/Build/Infra

## Linked Issue

- Fixes: #2137

## What Changed

- Expand Pyramid KNN effective `ef` to at least `topk`, matching HGraph behavior when `topk > ef_search`.
- Add a Pyramid regression test covering `ef_search < topk` and asserting KNN returns `topk` results when enough data exists.

## Test Evidence

- [x] `make fmt`
- [ ] `make lint`
- [ ] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [ ] Other (describe below)

Test details:

```text
PATH=/opt/homebrew/opt/llvm@15/bin:$PATH make fmt
Using clang-format version 15 (required: 15)
Code formatting completed with /opt/homebrew/opt/llvm@15/bin/clang-format

Local tests were not run per maintainer request.
```

## Compatibility Impact

- API/ABI compatibility: none
- Behavior changes: Pyramid KNN can search more candidates when `topk` exceeds `ef_search`, so it can return the requested `topk` results instead of being capped by `ef_search`.

## Performance and Concurrency Impact

- Performance impact: searches with `topk > ef_search` may do more work, consistent with the larger requested result count.
- Concurrency/thread-safety impact: none

## Documentation Impact

- [x] No docs update needed
- [ ] Updated docs:
  - [ ] `README.md`
  - [ ] `DEVELOPMENT.md`
  - [ ] `CONTRIBUTING.md`
  - [ ] Other: <!-- path -->

## Risk and Rollback

- Risk level: low
- Rollback plan: revert this commit to restore the previous Pyramid KNN candidate cap behavior.

## Checklist

- [x] I have linked the relevant issue (required for `kind/bug` and `kind/feature`; see "Linked Issue" above)
- [x] I have added/updated tests for new behavior or bug fixes
- [x] I have considered API compatibility impact
- [x] I have updated docs if behavior/workflow changed
- [x] My commit messages follow project conventions (Conventional Commits, optional `[skip ci]` prefix)