### PR TITLE
fix(quantization): guard TransformQuantizer ProcessQueryImpl against repeated allocation

### DIFF
--- a/src/quantization/transform_quantization/transform_quantizer.h
+++ b/src/quantization/transform_quantization/transform_quantizer.h
@@ -284,8 +284,10 @@ TransformQuantizer<QuantTmpl, metric>::ProcessQueryImpl(
     const float* query, Computer<TransformQuantizer>& computer) const {
     // 0. allocate
     try {
-        computer.inner_computer_->buf_ =
-            reinterpret_cast<uint8_t*>(this->allocator_->Allocate(this->query_code_size_));
+        if (computer.inner_computer_->buf_ == nullptr) {
+            computer.inner_computer_->buf_ =
+                reinterpret_cast<uint8_t*>(this->allocator_->Allocate(this->query_code_size_));
+        }
     } catch (const std::bad_alloc& e) {
         computer.inner_computer_->buf_ = nullptr;
         throw VsagException(ErrorType::NO_ENOUGH_MEMORY, "bad alloc when init computer buf");

--- a/src/quantization/transform_quantization/transform_quantizer_test.cpp
+++ b/src/quantization/transform_quantization/transform_quantizer_test.cpp
@@ -124,3 +124,43 @@ TEST_CASE("TQ Serialize and Deserialize", "[ut][TransformQuantizer]") {
         }
     }
 }
+
+TEST_CASE("TQ Repeated SetQuery No Leak", "[ut][TransformQuantizer]") {
+    constexpr MetricType metric = MetricType::METRIC_TYPE_L2SQR;
+    uint64_t dim = 128;
+    uint64_t count = 200;
+
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    auto param = std::make_shared<TransformQuantizerParameter>();
+    static constexpr const char* param_template = R"(
+        {{
+            "tq_chain": "rom, fp32",
+            "pca_dim": {},
+            "mrle_dim": {}
+        }}
+    )";
+    auto param_str = fmt::format(param_template, dim, dim - 1);
+    auto param_json = vsag::JsonType::Parse(param_str);
+    param->FromJson(param_json);
+
+    IndexCommonParam common_param;
+    common_param.allocator_ = allocator;
+    common_param.dim_ = dim;
+    TransformQuantizer<FP32Quantizer<metric>, metric> quantizer(param, common_param);
+
+    auto vecs = fixtures::generate_vectors(count, dim);
+    quantizer.Train(vecs.data(), count);
+
+    auto computer = quantizer.FactoryComputer();
+    auto queries = fixtures::generate_vectors(10, dim, false, 42);
+
+    for (int i = 0; i < 10; ++i) {
+        computer->SetQuery(queries.data() + i * dim);
+    }
+
+    std::vector<uint8_t> codes(quantizer.GetCodeSize());
+    quantizer.EncodeOne(vecs.data(), codes.data());
+    float dist = 0;
+    quantizer.ComputeDist(*computer, codes.data(), &dist);
+    REQUIRE(dist >= 0);
+}


### PR DESCRIPTION
## Summary

- Add nullptr check before allocating `inner_computer->buf_` in `TransformQuantizer::ProcessQueryImpl`, preventing memory leak on repeated `SetQuery` calls
- Consistent with all other quantizer implementations (FP32, INT8, SQ8Uniform, etc.)
- Add regression test exercising repeated `SetQuery` on the same Computer object

Fixes: #2163