### PR TITLE
fix: add null-check before buf_ allocation in ProcessQueryImpl

### DIFF
--- a/src/quantization/transform_quantization/transform_quantizer.h
+++ b/src/quantization/transform_quantization/transform_quantizer.h
@@ -284,8 +284,10 @@ TransformQuantizer<QuantTmpl, metric>::ProcessQueryImpl(
     const float* query, Computer<TransformQuantizer>& computer) const {
     // 0. allocate
     try {
-        computer.inner_computer_->buf_ =
-            reinterpret_cast<uint8_t*>(this->allocator_->Allocate(this->query_code_size_));
+        if (computer.inner_computer_->buf_ == nullptr) {
+            computer.inner_computer_->buf_ =
+                reinterpret_cast<uint8_t*>(this->allocator_->Allocate(this->query_code_size_));
+        }
     } catch (const std::bad_alloc& e) {
         computer.inner_computer_->buf_ = nullptr;
         throw VsagException(ErrorType::NO_ENOUGH_MEMORY, "bad alloc when init computer buf");


### PR DESCRIPTION
## Fixes #2163

**Root cause:** `ProcessQueryImpl` unconditionally allocates `computer.inner_computer_->buf_` without checking if it is already non-null. If `SetQuery()` is called more than once on the same `Computer` object, the previously allocated buffer is leaked.

**Fix:** Wrap the allocation in a null-check, matching the pattern already used in `ScalarQuantizer`:

```cpp
// Before (leaks memory on repeated SetQuery calls):
try {
    computer.inner_computer_->buf_ =
        reinterpret_cast<uint8_t*>(this->allocator_->Allocate(this->query_code_size_));

// After (safe):
try {
    if (computer.inner_computer_->buf_ == nullptr) {
        computer.inner_computer_->buf_ =
            reinterpret_cast<uint8_t*>(this->allocator_->Allocate(this->query_code_size_));
    }
```

Also applies to the `bad_alloc` catch block — `buf_` is now only set to `nullptr` when it was originally null, avoiding overwriting an existing allocation on rethrow.