### PR TITLE
fix: guard extra_info pointer arithmetic against nullptr in BruteForce::Add

### DIFF
--- a/src/algorithm/bruteforce/bruteforce.cpp
+++ b/src/algorithm/bruteforce/bruteforce.cpp
@@ -118,18 +118,17 @@ BruteForce::Add(const DatasetPtr& data, AddMode mode) {
                 continue;
             }
         }
+        const auto* ei_ptr = extra_info == nullptr ? nullptr : extra_info + j * extra_info_size;
         if (this->thread_pool_ != nullptr) {
             auto future = this->thread_pool_->GeneralEnqueue(add_func,
                                                              vectors + j * dim_,
                                                              label,
                                                              attrs == nullptr ? nullptr : attrs + j,
-                                                             extra_info + j * extra_info_size);
+                                                             ei_ptr);
             futures.emplace_back(std::move(future));
         } else {
-            if (auto add_res = add_func(vectors + j * dim_,
-                                        label,
-                                        attrs == nullptr ? nullptr : attrs + j,
-                                        extra_info + j * extra_info_size);
+            if (auto add_res = add_func(
+                    vectors + j * dim_, label, attrs == nullptr ? nullptr : attrs + j, ei_ptr);
                 add_res.has_value()) {
                 failed_ids.emplace_back(add_res.value());
             }


### PR DESCRIPTION
Fixes: #2167

## Summary

When `extra_info` is `nullptr` (the common case when no extra info is provided), `BruteForce::Add` performs `nullptr + j * extra_info_size`, which is undefined behavior in C++.

This PR adds a null check before the pointer arithmetic, consistent with the pattern already used in `warp.cpp:189`.

## Changes

- `src/algorithm/bruteforce/bruteforce.cpp`: Extract `ei_ptr` with null check before passing to `GeneralEnqueue` / `add_func`

## Test plan

- [x] Existing bruteforce functional tests pass (28 test cases, 715363 assertions)
- [x] Release build succeeds