### PR TITLE
fix: add minimum sample count check in PCATransformer::Train

### DIFF
--- a/src/impl/transform/pca_transformer.cpp
+++ b/src/impl/transform/pca_transformer.cpp
@@ -34,6 +34,13 @@ PCATransformer::PCATransformer(Allocator* allocator, int64_t input_dim, int64_t 
 
 void
 PCATransformer::Train(const float* data, uint64_t count) {
+    if (data == nullptr) {
+        throw VsagException(ErrorType::INVALID_ARGUMENT, "PCA training data pointer is null");
+    }
+    if (count < 2) {
+        throw VsagException(ErrorType::INVALID_ARGUMENT,
+                            fmt::format("PCA training requires at least 2 samples, got {}", count));
+    }
     vsag::Vector<float> centralized_data(allocator_);
     centralized_data.resize(count * input_dim_, 0.0F);
 

--- a/src/impl/transform/pca_transformer_test.cpp
+++ b/src/impl/transform/pca_transformer_test.cpp
@@ -18,6 +18,7 @@
 #include "impl/allocator/safe_allocator.h"
 #include "storage/serialization_template_test.h"
 #include "unittest.h"
+#include "vsag_exception.h"
 using namespace vsag;
 
 void
@@ -167,6 +168,21 @@ TestTrain() {
     }
 }
 
+void
+TestTrainMinSampleCount() {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    const uint64_t original_dim = 2;
+    const uint64_t target_dim = 2;
+
+    PCATransformer pca(allocator.get(), original_dim, target_dim);
+
+    std::vector<float> single_sample = {1.0f, 2.0f};
+    REQUIRE_THROWS_AS(pca.Train(single_sample.data(), 1), VsagException);
+    REQUIRE_THROWS_AS(pca.Train(single_sample.data(), 0), VsagException);
+    const float* null_data = nullptr;
+    REQUIRE_THROWS_AS(pca.Train(null_data, 2), VsagException);
+}
+
 TEST_CASE("PCA Basic Test", "[ut][PCA]") {
     auto allocator = SafeAllocator::FactoryDefaultAllocator();
     const auto dims = fixtures::get_common_used_dims();
@@ -175,6 +191,7 @@ TEST_CASE("PCA Basic Test", "[ut][PCA]") {
     TestComputeCovarianceMatrix();
     TestTransform();
     TestTrain();
+    TestTrainMinSampleCount();
 
     for (auto dim : dims) {
         PCATransformer pca(allocator.get(), dim, dim);


### PR DESCRIPTION
Fixes: #2172

## Summary

`PCATransformer::Train` divides by `count - 1` for unbiased covariance estimation (Bessel correction). When `count < 2`, this causes:
- `count == 1`: division by zero producing inf/NaN, silently corrupting the PCA matrix
- `count == 0`: `uint64_t` underflow wrapping to `UINT64_MAX`, producing near-zero covariance

This patch adds a guard at the entry of `Train()` that throws `VsagException(INVALID_ARGUMENT)` when `count < 2`, matching the existing validation pattern in `KMeansCluster`.

## Changes

- `src/impl/transform/pca_transformer.cpp`: Add `count < 2` check at the start of `Train()`
- `src/impl/transform/pca_transformer_test.cpp`: Add `TestTrainMinSampleCount()` covering both `count=0` and `count=1`

## Test plan

- [x] PCA Basic Test passed (including new TestTrainMinSampleCount)
- [x] PCA Serialize / Deserialize Test passed  
- [x] All 9,926,577 assertions passed
- [x] `make fmt` clean (clang-format-15)