### PR TITLE
fix: guard extra_info pointer arithmetic against nullptr in BruteForce::Add [backport 0.17]

### DIFF
--- a/src/algorithm/brute_force.cpp
+++ b/src/algorithm/brute_force.cpp
@@ -118,18 +118,17 @@ BruteForce::Add(const DatasetPtr& data) {
                 continue;
             }
         }
+        const auto* ei_ptr = extra_info == nullptr ? nullptr : extra_info + j * extra_info_size;
         if (this->build_pool_ != nullptr) {
             auto future = this->build_pool_->GeneralEnqueue(add_func,
                                                             vectors + j * dim_,
                                                             label,
                                                             attrs == nullptr ? nullptr : attrs + j,
-                                                            extra_info + j * extra_info_size);
+                                                            ei_ptr);
             futures.emplace_back(std::move(future));
         } else {
-            if (auto add_res = add_func(vectors + j * dim_,
-                                        label,
-                                        attrs == nullptr ? nullptr : attrs + j,
-                                        extra_info + j * extra_info_size);
+            if (auto add_res = add_func(
+                    vectors + j * dim_, label, attrs == nullptr ? nullptr : attrs + j, ei_ptr);
                 add_res.has_value()) {
                 failed_ids.emplace_back(add_res.value());
             }


### PR DESCRIPTION
## Summary

Backport of #2168 to the 0.17 release branch.

- Add nullptr check before performing pointer arithmetic on `extra_info` in `BruteForce::Add`
- When `extra_info` is nullptr (user does not pass extra info), the original code performs `nullptr + offset` which is undefined behavior

Fixes #2167