### PR TITLE
fix(allocator): use throw instead of throw e to prevent exception slicing

### DIFF
--- a/include/vsag/allocator.h
+++ b/include/vsag/allocator.h
@@ -101,7 +101,7 @@ public:
             return (T*)::new (p) T(std::forward<Args>(args)...);
         } catch (std::exception& e) {
             Deallocate(p);
-            throw e;
+            throw;
         }
     }
 


### PR DESCRIPTION
Fixes #2177

## Summary

Fix exception slicing in `Allocator::New` template method by changing `throw e;` to `throw;`.

## Problem

The catch block in `Allocator::New` (`include/vsag/allocator.h`) used `throw e;` which copies the caught `std::exception&` by value. This slices any derived exception type (e.g. `std::bad_alloc`, `std::runtime_error`) down to `std::exception`, preventing callers from catching specific exception types.

## Fix

Changed to `throw;` (parameterless rethrow) which preserves the original exception object and its complete type information.

## Testing

- All allocator-related unit tests pass (10 test cases, 27 assertions)
- Release build succeeds
- `make fmt` clean

## Reference

- [C++ Core Guidelines E.15](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Re-throw)
