### PR TITLE
fix: add minimum sample count check in PCATransformer::Train (backport 0.18)

### DIFF
--- a/src/impl/transform/pca_transformer.cpp
+++ b/src/impl/transform/pca_transformer.cpp
@@ -34,6 +34,29 @@ PCATransformer::PCATransformer(Allocator* allocator, int64_t input_dim, int64_t 
 
 void
 PCATransformer::Train(const float* data, uint64_t count) {
+    if (data == nullptr) {
+        throw VsagException(ErrorType::INVALID_ARGUMENT, "PCA training data pointer is null");
+    }
+    if (count < 2) {
+        throw VsagException(ErrorType::INVALID_ARGUMENT,
+                            fmt::format("PCA training requires at least 2 samples, got {}", count));
+    }
+    if (input_dim_ <= 0) {
+        throw VsagException(
+            ErrorType::INVALID_ARGUMENT,
+            fmt::format("PCA training requires positive input dimension, got {}", input_dim_));
+    }
+    if (static_cast<uint64_t>(input_dim_) > SIZE_MAX / static_cast<uint64_t>(input_dim_)) {
+        throw VsagException(
+            ErrorType::INVALID_ARGUMENT,
+            fmt::format("PCA training input dimension is too large, got {}", input_dim_));
+    }
+    if (count > SIZE_MAX / static_cast<uint64_t>(input_dim_)) {
+        throw VsagException(
+            ErrorType::INVALID_ARGUMENT,
+            fmt::format(
+                "PCA training data size overflow: count {} * input_dim {}", count, input_dim_));
+    }
     vsag::Vector<float> centralized_data(allocator_);
     centralized_data.resize(count * input_dim_, 0.0F);
 

--- a/src/impl/transform/pca_transformer_test.cpp
+++ b/src/impl/transform/pca_transformer_test.cpp
@@ -20,6 +20,7 @@
 #include "fixtures.h"
 #include "impl/allocator/safe_allocator.h"
 #include "storage/serialization_template_test.h"
+#include "vsag_exception.h"
 
 using namespace vsag;
 
@@ -170,6 +171,22 @@ TestTrain() {
     }
 }
 
+void
+TestTrainInvalidArguments() {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    const uint64_t original_dim = 2;
+    const uint64_t target_dim = 2;
+
+    PCATransformer pca(allocator.get(), original_dim, target_dim);
+
+    std::vector<float> single_sample = {1.0f, 2.0f};
+    REQUIRE_THROWS_AS(pca.Train(single_sample.data(), 1), VsagException);
+    REQUIRE_THROWS_AS(pca.Train(single_sample.data(), 0), VsagException);
+    const float* null_data = nullptr;
+    REQUIRE_THROWS_AS(pca.Train(null_data, 2), VsagException);
+    REQUIRE_THROWS_AS(pca.Train(single_sample.data(), UINT64_MAX), VsagException);
+}
+
 TEST_CASE("PCA Basic Test", "[ut][PCA]") {
     auto allocator = SafeAllocator::FactoryDefaultAllocator();
     const auto dims = fixtures::get_common_used_dims();
@@ -178,6 +195,7 @@ TEST_CASE("PCA Basic Test", "[ut][PCA]") {
     TestComputeCovarianceMatrix();
     TestTransform();
     TestTrain();
+    TestTrainInvalidArguments();
 
     for (auto dim : dims) {
         PCATransformer pca(allocator.get(), dim, dim);


### PR DESCRIPTION
Fixes: #2172

## Summary

Backport of #2173 to the 0.18 branch.

`PCATransformer::Train` divides by `count - 1` for unbiased covariance estimation (Bessel correction). When `count < 2`, this causes:
- `count == 1`: division by zero producing inf/NaN, silently corrupting the PCA matrix
- `count == 0`: `uint64_t` underflow wrapping to `UINT64_MAX`, producing near-zero covariance

This patch adds defensive guards at the entry of `Train()`:
- Null pointer check for `data`
- `count < 2` check
- `input_dim_ <= 0` check
- Integer overflow check for `count * input_dim_`

## Test plan

- [x] PCA Basic Test passed (including new TestTrainMinSampleCount)
- [x] PCA Serialize / Deserialize Test passed
- [x] All 9,926,579 assertions passed