### PR TITLE
fix(quantizer): use correct copy length in FP32Quantizer::DecodeBatchImpl

### DIFF
--- a/src/quantization/fp32_quantizer.cpp
+++ b/src/quantization/fp32_quantizer.cpp
@@ -91,8 +91,12 @@ FP32Quantizer<metric>::DecodeOneImpl(const uint8_t* codes, float* data) {
 template <MetricType metric>
 bool
 FP32Quantizer<metric>::DecodeBatchImpl(const uint8_t* codes, float* data, uint64_t count) {
-    for (uint64_t i = 0; i < count; ++i) {
-        memcpy(data + i * this->dim_, codes + i * this->code_size_, this->code_size_);
+    if (this->code_size_ == this->dim_ * sizeof(float)) {
+        memcpy(data, codes, count * this->code_size_);
+    } else {
+        for (uint64_t i = 0; i < count; ++i) {
+            memcpy(data + i * this->dim_, codes + i * this->code_size_, this->dim_ * sizeof(float));
+        }
     }
     return true;
 }

--- a/src/quantization/fp32_quantizer_test.cpp
+++ b/src/quantization/fp32_quantizer_test.cpp
@@ -17,8 +17,10 @@
 
 #include <memory>
 
+#include "fp32_quantizer_parameter.h"
 #include "impl/allocator/default_allocator.h"
 #include "impl/allocator/safe_allocator.h"
+#include "index_common_param.h"
 #include "quantizer_test.h"
 #include "unittest.h"
 
@@ -43,6 +45,33 @@ TEST_CASE("FP32 Encode and Decode", "[ut][FP32Quantizer]") {
         for (auto count : counts) {
             TestQuantizerEncodeDecodeMetricFP32<metrics[0]>(dim, count, error);
             TestQuantizerEncodeDecodeMetricFP32<metrics[1]>(dim, count, error);
+        }
+    }
+}
+
+TEST_CASE("FP32 DecodeBatch with hold_molds", "[ut][FP32Quantizer]") {
+    float error = 2e-5f;
+    for (auto dim : dims) {
+        for (auto count : counts) {
+            auto param = std::make_shared<FP32QuantizerParameter>();
+            param->hold_molds = true;
+            IndexCommonParam common_param;
+            common_param.dim_ = dim;
+            common_param.allocator_ = SafeAllocator::FactoryDefaultAllocator();
+            FP32Quantizer<MetricType::METRIC_TYPE_COSINE> quantizer(param, common_param);
+
+            auto vecs = fixtures::generate_vectors(count, dim, true);
+            std::vector<uint8_t> codes(quantizer.GetCodeSize() * count);
+            quantizer.EncodeBatch(vecs.data(), codes.data(), count);
+
+            std::vector<float> decoded(dim * count, -1.0f);
+            quantizer.DecodeBatch(codes.data(), decoded.data(), count);
+
+            for (int64_t i = 0; i < count; ++i) {
+                for (int64_t j = 0; j < dim; ++j) {
+                    REQUIRE(std::abs(vecs[i * dim + j] - decoded[i * dim + j]) < error);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #2180

## Summary

When `hold_molds_` is true (cosine metric), `code_size_` is `dim * sizeof(float) + sizeof(float)`. `DecodeBatchImpl` was using `code_size_` as the memcpy length into a buffer sized for `dim` floats per vector, causing a 4-byte overflow on every vector decoded.

This overwrites the first float of the next vector with the mold value and writes 4 bytes past the end of the buffer on the last vector.

## Fix

Use `this->dim_ * sizeof(float)` as the copy length, consistent with `DecodeOneImpl` in the same file (line 87).

## Test

All existing FP32Quantizer unit tests pass (116178 assertions in 3 test cases).