### PR TITLE
fix(datacell): prevent uint32 multiplication overflow in FlattenDataCell::query

### DIFF
--- a/src/datacell/flatten_datacell.h
+++ b/src/datacell/flatten_datacell.h
@@ -325,7 +325,9 @@ FlattenDataCell<QuantTmpl, IOTmpl>::query(float* result_dists,
     }
     if constexpr (not IOTmpl::InMemory) {
         if (id_count > 1) {
-            ByteBuffer codes(id_count * this->code_size_, search_alloc);
+            ByteBuffer codes(
+                static_cast<uint64_t>(id_count) * static_cast<uint64_t>(this->code_size_),
+                search_alloc);
             Vector<uint64_t> sizes(id_count, this->code_size_, search_alloc);
             Vector<uint64_t> offsets(id_count, this->code_size_, search_alloc);
             for (int64_t i = 0; i < id_count; ++i) {


### PR DESCRIPTION
Fixes #2187

## Summary

In the non-InMemory path of FlattenDataCell::query, the buffer size calculation id_count * code_size_ was performed in uint32_t arithmetic. When the product exceeds 2^32, this silently wraps around, allocating a buffer far smaller than needed and causing heap overflow in subsequent MultiRead and ScanBatchDists calls.

## Changes

- Cast both operands to uint64_t before multiplication in src/datacell/flatten_datacell.h:328

## Test

FlattenDataCell Basic Test passed (8,654,544 assertions).