### PR TITLE
fix: defer NumElements update in DatasetImpl::Append for exception safety

### DIFF
--- a/src/dataset_impl.cpp
+++ b/src/dataset_impl.cpp
@@ -498,9 +498,6 @@ DatasetImpl::Append(const DatasetPtr& other) {
                             "Cannot append dataset without source id to dataset with source id");
     }
 
-    // all validation passed; safe to mutate state (destructor relies on NumElements for cleanup)
-    this->NumElements(old_num_elements + new_num_elements);
-
     // append contiguous arrays via realloc-and-copy
     APPEND_DATA(IDS, int64_t*, Ids, 1);
     APPEND_DATA(DISTS, float*, Distances, dim);
@@ -594,6 +591,9 @@ DatasetImpl::Append(const DatasetPtr& other) {
             }
         }
     }
+
+    // update element count only after all copies succeed (exception safety)
+    this->NumElements(old_num_elements + new_num_elements);
 
     return shared_from_this();
 }


### PR DESCRIPTION
Closes #2189

## Problem

In `DatasetImpl::Append`, `this->NumElements()` was updated to the new total count **before** data arrays were actually copied. If any subsequent allocation threw (e.g. `std::bad_alloc` from `allocate_and_copy`):

- `NumElements` already reflected `old + new`
- Data arrays (SparseVectors, MultiVectors, etc.) remained at old size
- Destructor iterates using `NumElements` → out-of-bounds access / crash

## Fix

Move the `NumElements` update to after all data copy operations complete successfully. This ensures the object remains in a consistent state if any allocation fails mid-way.

## Testing

- All existing Dataset unit tests pass (99,083 assertions in 5 test cases)
- The fix is purely structural: no behavior change in the happy path