### PR TITLE
fix(rabitq): use fabs to skip near-zero dims in EncodeExtendRaBitQ

### DIFF
--- a/src/quantization/rabitq_quantization/rabitq_quantizer.cpp
+++ b/src/quantization/rabitq_quantization/rabitq_quantizer.cpp
@@ -382,7 +382,7 @@ RaBitQuantizer<metric>::EncodeExtendRaBitQ(const float* o_prime,
 
     auto compute_next_t_for_dim = [&](size_t i) -> double {
         auto oi = double(o_prime[i]);
-        if (oi < 1e-3) {
+        if (std::fabs(oi) < 1e-3) {
             return std::numeric_limits<double>::infinity();
         }
 


### PR DESCRIPTION
## Summary

Fix a bug in `EncodeExtendRaBitQ` where the condition `oi < 1e-3` incorrectly skips all negative-valued dimensions from participating in the t-value optimization loop.

The fix changes the condition to `std::fabs(oi) < 1e-3` so that only dimensions with near-zero absolute values are skipped (avoiding division by near-zero), regardless of sign.

## Problem

For normalized vectors with negative components, the multi-bit RaBitQ encoding optimization was ignoring approximately half of the dimensions, degrading encoding quality and search recall.

## Changes

- `src/quantization/rabitq_quantization/rabitq_quantizer.cpp`: Replace `oi < 1e-3` with `std::fabs(oi) < 1e-3` in `compute_next_t_for_dim` lambda (line 385)

Closes #2196
