### PR TITLE
ci: add aarch64 CI docker images and run arm jobs in containers

### DIFF
--- a/.github/workflows/asan_build_and_test.yml
+++ b/.github/workflows/asan_build_and_test.yml
@@ -49,15 +49,17 @@ jobs:
   build_asan_aarch64:
     name: Asan Build Aarch64
     runs-on: ubuntu-22.04-arm
+    container:
+      image: vsaglib/vsag:ci-aarch64-openblas
+      volumes:
+        - /opt:/useless
     concurrency:
       group: asan_build_aarch-${{ github.event.pull_request.number || github.sha }}
       cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - name: Free Disk Space
-        run: rm -rf /opt/hostedtoolcache
+        run: rm -rf /useless/hostedtoolcache
       - uses: actions/checkout@v4
-      - name: Prepare Env
-        run: sudo bash ./scripts/deps/install_deps_ubuntu.sh
       - name: Load Cache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
@@ -125,15 +127,17 @@ jobs:
     strategy:
       matrix:
         test_type: [ unittests, functests ]
+    container:
+      image: vsaglib/vsag:ci-aarch64-openblas
+      volumes:
+        - /opt:/useless
     concurrency:
       group: test_asan_aarch64-${{ matrix.test_type }}-${{ github.event.pull_request.number || github.sha }}
       cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - name: Free Disk Space
-        run: rm -rf /opt/hostedtoolcache
+        run: rm -rf /useless/hostedtoolcache
       - uses: actions/checkout@v4
-      - name: Prepare Env
-        run: sudo bash ./scripts/deps/install_deps_ubuntu.sh
       - name: Clean Build
         run: rm -rf ./build
       - name: Download Test
@@ -195,12 +199,16 @@ jobs:
     name: Test Example Aarch64
     needs: build_asan_aarch64
     runs-on: ubuntu-22.04-arm
+    container:
+      image: vsaglib/vsag:ci-aarch64-openblas
+      volumes:
+        - /opt:/useless
     concurrency:
       group: test_example_aarch64-${{ matrix.test_type }}-${{ github.event.pull_request.number || github.sha }}
       cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - name: Free Disk Space
-        run: rm -rf /opt/hostedtoolcache
+        run: rm -rf /useless/hostedtoolcache
       - uses: actions/checkout@v4
       - name: Clean Env
         run: rm -rf ./build

--- a/.github/workflows/daily_test.yml
+++ b/.github/workflows/daily_test.yml
@@ -51,17 +51,19 @@ jobs:
   daily_build_asan_aarch64:
     name: Asan Build Aarch64
     runs-on: ubuntu-22.04-arm
+    container:
+      image: vsaglib/vsag:ci-aarch64-openblas
+      volumes:
+        - /opt:/useless
     concurrency:
       group: daily_build_aarch
       cancel-in-progress: true
     steps:
       - name: Free Disk Space
-        run: rm -rf /opt/hostedtoolcache
+        run: rm -rf /useless/hostedtoolcache
       - uses: actions/checkout@v4
         with:
           ref: main
-      - name: Prepare Env
-        run: sudo bash ./scripts/deps/install_deps_ubuntu.sh
       - name: Load Cache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
@@ -133,17 +135,19 @@ jobs:
     strategy:
       matrix:
         test_type: [ unittests, functests ]
+    container:
+      image: vsaglib/vsag:ci-aarch64-openblas
+      volumes:
+        - /opt:/useless
     concurrency:
       group: daily_test_aarch64-${{ matrix.test_type }}
       cancel-in-progress: true
     steps:
       - name: Free Disk Space
-        run: rm -rf /opt/hostedtoolcache
+        run: rm -rf /useless/hostedtoolcache
       - uses: actions/checkout@v4
         with:
           ref: main
-      - name: Prepare Env
-        run: sudo bash ./scripts/deps/install_deps_ubuntu.sh
       - name: Clean Build
         run: rm -rf ./build
       - name: Download Test

--- a/.github/workflows/update-ci-image.yml
+++ b/.github/workflows/update-ci-image.yml
@@ -8,14 +8,16 @@ on:
     paths: [ 'docker/**' ]
 
 jobs:
-  # The CI images form a small chain: ci-x86-base is the shared toolchain
+  # The x86 CI images form a small chain: ci-x86-base is the shared toolchain
   # layer, and ci-x86-mkl / ci-x86-openblas are built FROM it. We build all
   # three in a single job so PR runs (push: false) can validate end-to-end:
   # the variant builds resolve `FROM vsaglib/vsag:ci-x86-base` against the
   # base image we just loaded into the local Docker daemon, not whatever
-  # tag happens to be on Docker Hub.
-  build:
-    name: Build CI Images
+  # tag happens to be on Docker Hub. The aarch64 images are built by a separate
+  # job below; they live on their own ci-aarch64-* tags and must be built on a
+  # native arm64 runner so the resulting layers are genuinely arm64.
+  build-x86:
+    name: Build CI Images (x86)
     runs-on: ubuntu-latest
     steps:
       # Docker Hub credentials only flow into runs triggered from the
@@ -66,3 +68,41 @@ jobs:
           file: ./docker/Dockerfile.x86.openblas
           push: ${{ github.event_name == 'push' }}
           tags: vsaglib/vsag:ci-x86-openblas
+
+  # aarch64 counterpart of the job above. There is no MKL variant on aarch64
+  # (Intel oneAPI MKL is x86-only), so the chain is just ci-aarch64-base ->
+  # ci-aarch64-openblas. We run on a native arm64 runner instead of emulating
+  # via QEMU so the published layers are real arm64 and image builds stay fast.
+  build-aarch64:
+    name: Build CI Images (aarch64)
+    runs-on: ubuntu-22.04-arm
+    steps:
+      # Same fork-safety reasoning as the x86 job: secrets (and therefore the
+      # Docker Hub login) only flow into push events / same-repo PRs. Fork PRs
+      # build with push: false and resolve the openblas variant's
+      # `FROM vsaglib/vsag:ci-aarch64-base` against the locally loaded base.
+      - name: Login to Docker Hub
+        if: github.event_name == 'push'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      # The plain `docker` driver loads each build straight into the host
+      # daemon, so the openblas build can resolve `FROM vsaglib/vsag:ci-aarch64-base`
+      # against the base we just built rather than pulling from Docker Hub.
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker
+      - name: Build ci-aarch64-base
+        uses: docker/build-push-action@v6
+        with:
+          file: ./docker/Dockerfile.aarch64.base
+          push: ${{ github.event_name == 'push' }}
+          tags: vsaglib/vsag:ci-aarch64-base
+      - name: Build ci-aarch64-openblas
+        uses: docker/build-push-action@v6
+        with:
+          file: ./docker/Dockerfile.aarch64.openblas
+          push: ${{ github.event_name == 'push' }}
+          tags: vsaglib/vsag:ci-aarch64-openblas

--- a/docker/Dockerfile.aarch64.base
+++ b/docker/Dockerfile.aarch64.base
@@ -1,0 +1,39 @@
+
+# Base CI image for VSAG on aarch64.
+#
+# This image carries the common toolchain shared by every aarch64 CI variant
+# (compilers, build tools, runtime headers, etc.) but intentionally does NOT
+# install any BLAS implementation. BLAS backends are layered on top of this
+# image in the variant Dockerfiles:
+#
+#   * docker/Dockerfile.aarch64.openblas -> vsaglib/vsag:ci-aarch64-openblas
+#
+# Unlike x86_64 there is no Intel MKL variant here: Intel oneAPI MKL ships
+# x86-only, so on aarch64 OpenBLAS is the sole BLAS backend. Keeping the base
+# image free of any BLAS implementation still lets us:
+#   * share the build context across future aarch64 variants;
+#   * make it trivial to add another backend (e.g. Arm Performance Libraries)
+#     later.
+#
+# `FROM ubuntu:22.04` is a multi-arch manifest; building this Dockerfile on an
+# aarch64 host (the ubuntu-22.04-arm runner in docker/update-ci-image.yml)
+# selects the arm64 base automatically, so no QEMU emulation is required.
+
+FROM ubuntu:22.04
+
+# Install the whole toolchain in a single layer and drop the apt cache so the
+# published image stays small (it is pulled by every aarch64 CI job). Grouped
+# by purpose:
+#   * basic deps:  wget gpg sudo
+#   * build tools: git g++ cmake ninja-build gdb ccache build-essential lcov
+#                  gfortran clang-15 clangd-15 clang-format-15 python3-pip
+#   * vsag deps (everything except a BLAS backend): python3-dev libomp-15-dev
+#                  libaio-dev libcurl4-openssl-dev liburing-dev
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        wget gpg sudo \
+        git g++ cmake ninja-build gdb ccache build-essential lcov gfortran \
+        clang-15 clangd-15 clang-format-15 python3-pip \
+        python3-dev libomp-15-dev libaio-dev libcurl4-openssl-dev liburing-dev \
+    && ln -s /usr/bin/clang-format-15 /usr/bin/clang-format \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*

--- a/docker/Dockerfile.aarch64.openblas
+++ b/docker/Dockerfile.aarch64.openblas
@@ -1,0 +1,24 @@
+
+# OpenBLAS variant of the VSAG CI image for aarch64.
+#
+# Built on top of vsaglib/vsag:ci-aarch64-base (see docker/Dockerfile.aarch64.base).
+# Ships a pre-installed system OpenBLAS (plus LAPACKE headers) so the aarch64 CI
+# jobs (asan_build_and_test.yml / daily_test.yml) can run straight from the image
+# instead of installing dependencies per job via scripts/deps/install_deps_ubuntu.sh.
+#
+# Jobs that want to skip the per-job OpenBLAS source build can opt in to
+# `-DUSE_SYSTEM_OPENBLAS=ON`; jobs that leave the flag unset still exercise the
+# from-source OpenBLAS build and simply ignore the pre-installed packages.
+#
+# This is the aarch64 counterpart of docker/Dockerfile.x86.openblas. There is no
+# MKL counterpart on aarch64 because Intel oneAPI MKL is x86-only.
+
+FROM vsaglib/vsag:ci-aarch64-base
+
+# Install system OpenBLAS + LAPACKE in a single layer and drop the apt cache to
+# keep the image small. liblapacke-dev pulls in the C headers needed for VSAG's
+# CMake `find_path(LAPACKE_INCLUDE NAMES lapacke.h)` probe.
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        libopenblas-dev liblapacke-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary

Mirror the existing x86 CI image chain for aarch64 so the arm CI jobs can pull a prebuilt image instead of running `scripts/deps/install_deps_ubuntu.sh` on every run.

- **New images** (counterparts of `Dockerfile.x86.{base,openblas}`):
  - `docker/Dockerfile.aarch64.base` → `vsaglib/vsag:ci-aarch64-base` — shared toolchain (clang-15, gcc, cmake, ninja, gfortran, libomp-15, libaio, liburing, curl…), no BLAS.
  - `docker/Dockerfile.aarch64.openblas` → `vsaglib/vsag:ci-aarch64-openblas` — layers system OpenBLAS + LAPACKE on the base.
  - No MKL variant: Intel oneAPI MKL is x86-only, so OpenBLAS is the sole aarch64 BLAS backend (matches `install_deps_ubuntu.sh`, which never installed MKL on aarch64).
- **`update-ci-image.yml`**: split into `build-x86` (unchanged) and a new `build-aarch64` job that builds/pushes the two images on a native `ubuntu-22.04-arm` runner — no QEMU, so the published layers are genuinely arm64.
- **`asan_build_and_test.yml`** and **`daily_test.yml`**: the aarch64 jobs now run `container: vsaglib/vsag:ci-aarch64-openblas`, drop the per-job `Prepare Env` / `install_deps` step, and reuse the `/opt:/useless` free-disk pattern from the x86 jobs.

The `ci-aarch64-openblas` image covers every package `install_deps_ubuntu.sh` installs for aarch64, so it is a complete replacement. The Python wheel jobs (`python_build_and_test.yml`, `pr-ci.yml`) still use `install_deps` on the host, intentionally unchanged (same as x86).

## Notes / validation

- The `update-ci-image` workflow runs on this PR with `push: false`, so it validates that both aarch64 Dockerfiles actually **build on the arm runner** (incl. that `clang-15` / `libomp-15` exist for arm64 jammy) before merge.
- First-run bootstrapping is the same as when the x86 images were introduced: the images are only pushed once `docker/**` lands on `main`. The merge push triggers both `update-ci-image` and `asan_build_and_test` at once, so the first aarch64 job run may briefly race ahead of the image push and need a re-run; steady-state afterward.
- Build behavior is preserved: aarch64 jobs still build OpenBLAS from source (no `-DUSE_SYSTEM_OPENBLAS=ON`); the system OpenBLAS in the image is available if we later want to opt into the faster path.