### PR TITLE
fix(dataset): handle SourceID in DeepCopy, Append, and destructor

### DIFF
--- a/src/dataset_impl.cpp
+++ b/src/dataset_impl.cpp
@@ -288,6 +288,7 @@ DatasetImpl::~DatasetImpl() {  // NOLINT
             release_paths(std::get<const std::string*>(value));
         }
     }
+    delete[] DatasetImpl::GetSourceID();
     if (DatasetImpl::GetAttributeSets() != nullptr) {
         const auto* attrsets = DatasetImpl::GetAttributeSets();
         for (int i = 0; i < DatasetImpl::GetNumElements(); ++i) {
@@ -362,6 +363,13 @@ DatasetImpl::DeepCopy(Allocator* allocator) const {
         }
     }
 
+    if (this->GetSourceID() != nullptr) {
+        auto* source_ids = new std::string[num_elements];
+        copy_dataset->SourceID(source_ids);
+        for (int i = 0; i < num_elements; ++i) {
+            source_ids[i] = this->GetSourceID()[i];
+        }
+    }
     if (this->GetAttributeSets() != nullptr) {
         const auto* attrsets = this->GetAttributeSets();
         auto* attrsets_copy = new AttributeSet[num_elements];
@@ -484,6 +492,12 @@ DatasetImpl::Append(const DatasetPtr& other) {
             "Cannot append dataset without attribute sets to dataset with attribute sets");
     }
 
+    // check source-id
+    if (this->data_.find(SOURCE_ID) != this->data_.end() && other->GetSourceID() == nullptr) {
+        throw VsagException(ErrorType::INVALID_ARGUMENT,
+                            "Cannot append dataset without source id to dataset with source id");
+    }
+
     // all validation passed; safe to mutate state (destructor relies on NumElements for cleanup)
     this->NumElements(old_num_elements + new_num_elements);
 
@@ -526,6 +540,20 @@ DatasetImpl::Append(const DatasetPtr& other) {
     }
     for (const auto* paths : replaced_paths) {
         delete[] paths;
+    }
+
+    // append source-id
+    if (auto iter = this->data_.find(SOURCE_ID); iter != this->data_.end()) {
+        auto* ptr = const_cast<std::string*>(std::get<const std::string*>(iter->second));
+        auto* source_id_copy = new std::string[old_num_elements + new_num_elements];
+        for (int i = 0; i < old_num_elements; ++i) {
+            source_id_copy[i] = ptr[i];
+        }
+        for (int i = 0; i < new_num_elements; ++i) {
+            source_id_copy[old_num_elements + i] = other->GetSourceID()[i];
+        }
+        this->SourceID(source_id_copy);
+        delete[] ptr;
     }
 
     // append sparse-vectors

--- a/src/dataset_impl_test.cpp
+++ b/src/dataset_impl_test.cpp
@@ -181,6 +181,10 @@ CreateTestDataset(int num_elements = 777,
     for (int i = 0; i < num_elements; ++i) {
         paths[i] = fixtures::create_random_string(false);
     }
+    std::string* source_ids = new std::string[num_elements];
+    for (int i = 0; i < num_elements; ++i) {
+        source_ids[i] = fixtures::create_random_string(false);
+    }
     std::vector<int64_t> ids(num_elements);
 
     std::random_device rd;
@@ -198,6 +202,7 @@ CreateTestDataset(int num_elements = 777,
     base->Dim(dim)
         ->Ids(fixtures::CopyVector(ids, allocator))
         ->Paths(paths)
+        ->SourceID(source_ids)
         ->AttributeSets(attr_sets)
         ->NumElements(num_elements)
         ->Distances(fixtures::CopyVector(distances, allocator))
@@ -260,6 +265,18 @@ EqualDataset(const vsag::DatasetPtr& data1, const vsag::DatasetPtr& data2) {
             }
         }
     } else if (path1 != nullptr || path2 != nullptr) {
+        return false;
+    }
+
+    auto sid1 = data1->GetSourceID();
+    auto sid2 = data2->GetSourceID();
+    if (sid1 != nullptr && sid2 != nullptr) {
+        for (int i = 0; i < num_element; ++i) {
+            if (sid1[i] != sid2[i]) {
+                return false;
+            }
+        }
+    } else if (sid1 != nullptr || sid2 != nullptr) {
         return false;
     }
 
@@ -394,6 +411,9 @@ TEST_CASE("Dataset Copy and Append Test", "[ut][Dataset]") {
             original->GetAttributeSets(), copy->GetAttributeSets(), num_elements));
 
         REQUIRE(ArePathArraysDeepCopied(original->GetPaths(), copy->GetPaths(), num_elements));
+
+        REQUIRE(
+            ArePathArraysDeepCopied(original->GetSourceID(), copy->GetSourceID(), num_elements));
     }
     SECTION("Append") {
         auto copy = original->DeepCopy();
@@ -411,6 +431,7 @@ TEST_CASE("Dataset Copy and Append Test", "[ut][Dataset]") {
             ->Int8Vectors(original->GetInt8Vectors() + num_elements * dim)
             ->Distances(original->GetDistances() + num_elements * dim)
             ->Paths(original->GetPaths() + num_elements)
+            ->SourceID(original->GetSourceID() + num_elements)
             ->AttributeSets(original->GetAttributeSets() + num_elements)
             ->VectorCounts(original->GetVectorCounts() + num_elements)
             ->NumElements(append_num_elements)


### PR DESCRIPTION
## Summary

- Add SourceID array copy in `DatasetImpl::DeepCopy` (same pattern as Paths)
- Add SourceID validation and concatenation in `DatasetImpl::Append` (same pattern as Paths)
- Add SourceID cleanup (`delete[]`) in destructor to fix memory leak
- Update unit tests: add SourceID to test dataset factory, equality check, and deep-copy/append assertions

## Background

`SourceID` is a `const std::string*` array field (one entry per element) with identical semantics to `Paths`. When SourceID was added to the Dataset interface, DeepCopy, Append, and the destructor were not updated to handle it.

Fixes #2202