### PR TITLE
perf(simd): hoist SQ4 horizontal reduction out of loop body

### DIFF
--- a/src/simd/avx.cpp
+++ b/src/simd/avx.cpp
@@ -796,8 +796,8 @@ SQ4ComputeIP(const float* RESTRICT query,
         return 0;
     }
 
-    float result = 0;
     uint64_t d = 0;
+    __m256 acc = _mm256_setzero_ps();
 
     // Process 16 values at a time (8 bytes containing 16 4-bit values)
     for (; d + 15 < dim; d += 16) {
@@ -808,22 +808,14 @@ SQ4ComputeIP(const float* RESTRICT query,
         __m256 query_vec0 = _mm256_loadu_ps(query + d);
         __m256 query_vec1 = _mm256_loadu_ps(query + d + 8);
 
-        // Compute dot products
+        // Compute dot products and accumulate
         __m256 prod0 = _mm256_mul_ps(query_vec0, values01);
         __m256 prod1 = _mm256_mul_ps(query_vec1, values23);
-
-        // Horizontal sum
-        __m256 sum = _mm256_add_ps(prod0, prod1);
-        __m128 sum_low = _mm256_castps256_ps128(sum);
-        __m128 sum_high = _mm256_extractf128_ps(sum, 1);
-        __m128 sum01 = _mm_add_ps(sum_low, sum_high);
-        __m128 sum23 = _mm_shuffle_ps(sum01, sum01, _MM_SHUFFLE(2, 3, 0, 1));
-        __m128 sum0123 = _mm_add_ps(sum01, sum23);
-        __m128 sum4567 = _mm_movehl_ps(sum0123, sum0123);
-        __m128 total_sum = _mm_add_ss(sum0123, sum4567);
-
-        result += _mm_cvtss_f32(total_sum);
+        acc = _mm256_add_ps(acc, _mm256_add_ps(prod0, prod1));
     }
+
+    // Single horizontal reduction after the loop
+    float result = avx_reduce_add_ps(acc);
 
     // Process remaining elements with SSE implementation
     result += sse::SQ4ComputeIP(query + d, codes + (d >> 1), lower_bound + d, diff + d, dim - d);
@@ -844,8 +836,8 @@ SQ4ComputeL2Sqr(const float* RESTRICT query,
         return 0;
     }
 
-    float result = 0;
     uint64_t d = 0;
+    __m256 acc = _mm256_setzero_ps();
 
     // Process 16 values at a time (8 bytes containing 16 4-bit values)
     for (; d + 15 < dim; d += 16) {
@@ -860,22 +852,14 @@ SQ4ComputeL2Sqr(const float* RESTRICT query,
         __m256 diff0 = _mm256_sub_ps(query_vec0, values01);
         __m256 diff1 = _mm256_sub_ps(query_vec1, values23);
 
-        // Square differences
-        __m256 sq_diff0 = _mm256_mul_ps(diff0, diff0);
-        __m256 sq_diff1 = _mm256_mul_ps(diff1, diff1);
-
-        // Horizontal sum
-        __m256 sum = _mm256_add_ps(sq_diff0, sq_diff1);
-        __m128 sum_low = _mm256_castps256_ps128(sum);
-        __m128 sum_high = _mm256_extractf128_ps(sum, 1);
-        __m128 sum01 = _mm_add_ps(sum_low, sum_high);
-        __m128 sum23 = _mm_shuffle_ps(sum01, sum01, _MM_SHUFFLE(2, 3, 0, 1));
-        __m128 sum0123 = _mm_add_ps(sum01, sum23);
-        __m128 sum4567 = _mm_movehl_ps(sum0123, sum0123);
-        __m128 total_sum = _mm_add_ss(sum0123, sum4567);
-
-        result += _mm_cvtss_f32(total_sum);
+        // Square differences and accumulate
+        __m256 sq0 = _mm256_mul_ps(diff0, diff0);
+        __m256 sq1 = _mm256_mul_ps(diff1, diff1);
+        acc = _mm256_add_ps(acc, _mm256_add_ps(sq0, sq1));
     }
+
+    // Single horizontal reduction after the loop
+    float result = avx_reduce_add_ps(acc);
 
     // Process remaining elements with SSE implementation
     result += sse::SQ4ComputeL2Sqr(query + d, codes + (d >> 1), lower_bound + d, diff + d, dim - d);
@@ -896,8 +880,8 @@ SQ4ComputeCodesIP(const uint8_t* RESTRICT codes1,
         return 0;
     }
 
-    float result = 0;
     uint64_t d = 0;
+    __m256 acc = _mm256_setzero_ps();
 
     // Process 16 values at a time (8 bytes containing 16 4-bit values)
     for (; d + 15 < dim; d += 16) {
@@ -906,22 +890,15 @@ SQ4ComputeCodesIP(const uint8_t* RESTRICT codes1,
 
         SQ4Decode16Values(codes1, d, code1_values01, code1_values23, lower_bound, diff);
         SQ4Decode16Values(codes2, d, code2_values01, code2_values23, lower_bound, diff);
-        // Compute dot products
+
+        // Compute dot products and accumulate
         __m256 prod0 = _mm256_mul_ps(code1_values01, code2_values01);
         __m256 prod1 = _mm256_mul_ps(code1_values23, code2_values23);
-
-        // Horizontal sum
-        __m256 sum = _mm256_add_ps(prod0, prod1);
-        __m128 sum_low = _mm256_castps256_ps128(sum);
-        __m128 sum_high = _mm256_extractf128_ps(sum, 1);
-        __m128 sum01 = _mm_add_ps(sum_low, sum_high);
-        __m128 sum23 = _mm_shuffle_ps(sum01, sum01, _MM_SHUFFLE(2, 3, 0, 1));
-        __m128 sum0123 = _mm_add_ps(sum01, sum23);
-        __m128 sum4567 = _mm_movehl_ps(sum0123, sum0123);
-        __m128 total_sum = _mm_add_ss(sum0123, sum4567);
-
-        result += _mm_cvtss_f32(total_sum);
+        acc = _mm256_add_ps(acc, _mm256_add_ps(prod0, prod1));
     }
+
+    // Single horizontal reduction after the loop
+    float result = avx_reduce_add_ps(acc);
 
     // Process remaining elements with SSE implementation
     result += sse::SQ4ComputeCodesIP(
@@ -943,8 +920,8 @@ SQ4ComputeCodesL2Sqr(const uint8_t* RESTRICT codes1,
         return 0;
     }
 
-    float result = 0;
     uint64_t d = 0;
+    __m256 acc = _mm256_setzero_ps();
 
     // Process 16 values at a time (8 bytes containing 16 4-bit values)
     for (; d + 15 < dim; d += 16) {
@@ -958,22 +935,14 @@ SQ4ComputeCodesL2Sqr(const uint8_t* RESTRICT codes1,
         __m256 diff0 = _mm256_sub_ps(code1_values01, code2_values01);
         __m256 diff1 = _mm256_sub_ps(code1_values23, code2_values23);
 
-        // Square differences
-        __m256 sq_diff0 = _mm256_mul_ps(diff0, diff0);
-        __m256 sq_diff1 = _mm256_mul_ps(diff1, diff1);
-
-        // Horizontal sum
-        __m256 sum = _mm256_add_ps(sq_diff0, sq_diff1);
-        __m128 sum_low = _mm256_castps256_ps128(sum);
-        __m128 sum_high = _mm256_extractf128_ps(sum, 1);
-        __m128 sum01 = _mm_add_ps(sum_low, sum_high);
-        __m128 sum23 = _mm_shuffle_ps(sum01, sum01, _MM_SHUFFLE(2, 3, 0, 1));
-        __m128 sum0123 = _mm_add_ps(sum01, sum23);
-        __m128 sum4567 = _mm_movehl_ps(sum0123, sum0123);
-        __m128 total_sum = _mm_add_ss(sum0123, sum4567);
-
-        result += _mm_cvtss_f32(total_sum);
+        // Square differences and accumulate
+        __m256 sq0 = _mm256_mul_ps(diff0, diff0);
+        __m256 sq1 = _mm256_mul_ps(diff1, diff1);
+        acc = _mm256_add_ps(acc, _mm256_add_ps(sq0, sq1));
     }
+
+    // Single horizontal reduction after the loop
+    float result = avx_reduce_add_ps(acc);
 
     // Process remaining elements with SSE implementation
     result += sse::SQ4ComputeCodesL2Sqr(

--- a/src/simd/avx.cpp
+++ b/src/simd/avx.cpp
@@ -797,7 +797,8 @@ SQ4ComputeIP(const float* RESTRICT query,
     }
 
     uint64_t d = 0;
-    __m256 acc = _mm256_setzero_ps();
+    __m256 acc0 = _mm256_setzero_ps();
+    __m256 acc1 = _mm256_setzero_ps();
 
     // Process 16 values at a time (8 bytes containing 16 4-bit values)
     for (; d + 15 < dim; d += 16) {
@@ -808,14 +809,13 @@ SQ4ComputeIP(const float* RESTRICT query,
         __m256 query_vec0 = _mm256_loadu_ps(query + d);
         __m256 query_vec1 = _mm256_loadu_ps(query + d + 8);
 
-        // Compute dot products and accumulate
-        __m256 prod0 = _mm256_mul_ps(query_vec0, values01);
-        __m256 prod1 = _mm256_mul_ps(query_vec1, values23);
-        acc = _mm256_add_ps(acc, _mm256_add_ps(prod0, prod1));
+        // Compute dot products and accumulate into separate accumulators for ILP
+        acc0 = _mm256_add_ps(acc0, _mm256_mul_ps(query_vec0, values01));
+        acc1 = _mm256_add_ps(acc1, _mm256_mul_ps(query_vec1, values23));
     }
 
     // Single horizontal reduction after the loop
-    float result = avx_reduce_add_ps(acc);
+    float result = avx_reduce_add_ps(_mm256_add_ps(acc0, acc1));
 
     // Process remaining elements with SSE implementation
     result += sse::SQ4ComputeIP(query + d, codes + (d >> 1), lower_bound + d, diff + d, dim - d);
@@ -837,7 +837,8 @@ SQ4ComputeL2Sqr(const float* RESTRICT query,
     }
 
     uint64_t d = 0;
-    __m256 acc = _mm256_setzero_ps();
+    __m256 acc0 = _mm256_setzero_ps();
+    __m256 acc1 = _mm256_setzero_ps();
 
     // Process 16 values at a time (8 bytes containing 16 4-bit values)
     for (; d + 15 < dim; d += 16) {
@@ -848,18 +849,15 @@ SQ4ComputeL2Sqr(const float* RESTRICT query,
         __m256 query_vec0 = _mm256_loadu_ps(query + d);
         __m256 query_vec1 = _mm256_loadu_ps(query + d + 8);
 
-        // Compute differences
+        // Compute differences and accumulate into separate accumulators for ILP
         __m256 diff0 = _mm256_sub_ps(query_vec0, values01);
         __m256 diff1 = _mm256_sub_ps(query_vec1, values23);
-
-        // Square differences and accumulate
-        __m256 sq0 = _mm256_mul_ps(diff0, diff0);
-        __m256 sq1 = _mm256_mul_ps(diff1, diff1);
-        acc = _mm256_add_ps(acc, _mm256_add_ps(sq0, sq1));
+        acc0 = _mm256_add_ps(acc0, _mm256_mul_ps(diff0, diff0));
+        acc1 = _mm256_add_ps(acc1, _mm256_mul_ps(diff1, diff1));
     }
 
     // Single horizontal reduction after the loop
-    float result = avx_reduce_add_ps(acc);
+    float result = avx_reduce_add_ps(_mm256_add_ps(acc0, acc1));
 
     // Process remaining elements with SSE implementation
     result += sse::SQ4ComputeL2Sqr(query + d, codes + (d >> 1), lower_bound + d, diff + d, dim - d);
@@ -881,7 +879,8 @@ SQ4ComputeCodesIP(const uint8_t* RESTRICT codes1,
     }
 
     uint64_t d = 0;
-    __m256 acc = _mm256_setzero_ps();
+    __m256 acc0 = _mm256_setzero_ps();
+    __m256 acc1 = _mm256_setzero_ps();
 
     // Process 16 values at a time (8 bytes containing 16 4-bit values)
     for (; d + 15 < dim; d += 16) {
@@ -891,14 +890,13 @@ SQ4ComputeCodesIP(const uint8_t* RESTRICT codes1,
         SQ4Decode16Values(codes1, d, code1_values01, code1_values23, lower_bound, diff);
         SQ4Decode16Values(codes2, d, code2_values01, code2_values23, lower_bound, diff);
 
-        // Compute dot products and accumulate
-        __m256 prod0 = _mm256_mul_ps(code1_values01, code2_values01);
-        __m256 prod1 = _mm256_mul_ps(code1_values23, code2_values23);
-        acc = _mm256_add_ps(acc, _mm256_add_ps(prod0, prod1));
+        // Compute dot products and accumulate into separate accumulators for ILP
+        acc0 = _mm256_add_ps(acc0, _mm256_mul_ps(code1_values01, code2_values01));
+        acc1 = _mm256_add_ps(acc1, _mm256_mul_ps(code1_values23, code2_values23));
     }
 
     // Single horizontal reduction after the loop
-    float result = avx_reduce_add_ps(acc);
+    float result = avx_reduce_add_ps(_mm256_add_ps(acc0, acc1));
 
     // Process remaining elements with SSE implementation
     result += sse::SQ4ComputeCodesIP(
@@ -921,7 +919,8 @@ SQ4ComputeCodesL2Sqr(const uint8_t* RESTRICT codes1,
     }
 
     uint64_t d = 0;
-    __m256 acc = _mm256_setzero_ps();
+    __m256 acc0 = _mm256_setzero_ps();
+    __m256 acc1 = _mm256_setzero_ps();
 
     // Process 16 values at a time (8 bytes containing 16 4-bit values)
     for (; d + 15 < dim; d += 16) {
@@ -931,18 +930,15 @@ SQ4ComputeCodesL2Sqr(const uint8_t* RESTRICT codes1,
         SQ4Decode16Values(codes1, d, code1_values01, code1_values23, lower_bound, diff);
         SQ4Decode16Values(codes2, d, code2_values01, code2_values23, lower_bound, diff);
 
-        // Compute differences
+        // Compute differences and accumulate into separate accumulators for ILP
         __m256 diff0 = _mm256_sub_ps(code1_values01, code2_values01);
         __m256 diff1 = _mm256_sub_ps(code1_values23, code2_values23);
-
-        // Square differences and accumulate
-        __m256 sq0 = _mm256_mul_ps(diff0, diff0);
-        __m256 sq1 = _mm256_mul_ps(diff1, diff1);
-        acc = _mm256_add_ps(acc, _mm256_add_ps(sq0, sq1));
+        acc0 = _mm256_add_ps(acc0, _mm256_mul_ps(diff0, diff0));
+        acc1 = _mm256_add_ps(acc1, _mm256_mul_ps(diff1, diff1));
     }
 
     // Single horizontal reduction after the loop
-    float result = avx_reduce_add_ps(acc);
+    float result = avx_reduce_add_ps(_mm256_add_ps(acc0, acc1));
 
     // Process remaining elements with SSE implementation
     result += sse::SQ4ComputeCodesL2Sqr(

--- a/src/simd/avx2.cpp
+++ b/src/simd/avx2.cpp
@@ -867,7 +867,8 @@ SQ4ComputeIP(const float* RESTRICT query,
     }
 
     uint64_t d = 0;
-    __m256 acc = _mm256_setzero_ps();
+    __m256 acc0 = _mm256_setzero_ps();
+    __m256 acc1 = _mm256_setzero_ps();
 
     // Process 16 values at a time (8 bytes containing 16 4-bit values)
     for (; d + 15 < dim; d += 16) {
@@ -878,13 +879,13 @@ SQ4ComputeIP(const float* RESTRICT query,
         __m256 query_vec0 = _mm256_loadu_ps(query + d);
         __m256 query_vec1 = _mm256_loadu_ps(query + d + 8);
 
-        // Compute dot products and accumulate
-        acc = _mm256_fmadd_ps(query_vec0, values01, acc);
-        acc = _mm256_fmadd_ps(query_vec1, values23, acc);
+        // Compute dot products and accumulate into separate accumulators for ILP
+        acc0 = _mm256_fmadd_ps(query_vec0, values01, acc0);
+        acc1 = _mm256_fmadd_ps(query_vec1, values23, acc1);
     }
 
     // Single horizontal reduction after the loop
-    float result = AVX2_REDUCE_ADD_PS(acc);
+    float result = AVX2_REDUCE_ADD_PS(_mm256_add_ps(acc0, acc1));
 
     // Process remaining elements with SSE implementation
     result += sse::SQ4ComputeIP(query + d, codes + (d >> 1), lower_bound + d, diff + d, dim - d);
@@ -906,7 +907,8 @@ SQ4ComputeL2Sqr(const float* RESTRICT query,
     }
 
     uint64_t d = 0;
-    __m256 acc = _mm256_setzero_ps();
+    __m256 acc0 = _mm256_setzero_ps();
+    __m256 acc1 = _mm256_setzero_ps();
 
     // Process 16 values at a time (8 bytes containing 16 4-bit values)
     for (; d + 15 < dim; d += 16) {
@@ -916,15 +918,15 @@ SQ4ComputeL2Sqr(const float* RESTRICT query,
         __m256 query_vec0 = _mm256_loadu_ps(query + d);
         __m256 query_vec1 = _mm256_loadu_ps(query + d + 8);
 
-        // Compute differences and accumulate squared distances
+        // Compute differences and accumulate squared distances into separate accumulators for ILP
         __m256 diff0 = _mm256_sub_ps(query_vec0, values01);
         __m256 diff1 = _mm256_sub_ps(query_vec1, values23);
-        acc = _mm256_fmadd_ps(diff0, diff0, acc);
-        acc = _mm256_fmadd_ps(diff1, diff1, acc);
+        acc0 = _mm256_fmadd_ps(diff0, diff0, acc0);
+        acc1 = _mm256_fmadd_ps(diff1, diff1, acc1);
     }
 
     // Single horizontal reduction after the loop
-    float result = AVX2_REDUCE_ADD_PS(acc);
+    float result = AVX2_REDUCE_ADD_PS(_mm256_add_ps(acc0, acc1));
 
     // Process remaining elements with SSE implementation
     result += sse::SQ4ComputeL2Sqr(query + d, codes + (d >> 1), lower_bound + d, diff + d, dim - d);
@@ -946,7 +948,8 @@ SQ4ComputeCodesIP(const uint8_t* RESTRICT codes1,
     }
 
     uint64_t d = 0;
-    __m256 acc = _mm256_setzero_ps();
+    __m256 acc0 = _mm256_setzero_ps();
+    __m256 acc1 = _mm256_setzero_ps();
 
     // Process 16 values at a time (8 bytes containing 16 4-bit values)
     for (; d + 15 < dim; d += 16) {
@@ -956,13 +959,13 @@ SQ4ComputeCodesIP(const uint8_t* RESTRICT codes1,
         SQ4Decode16Values(codes1, d, code1_values01, code1_values23, lower_bound, diff);
         SQ4Decode16Values(codes2, d, code2_values01, code2_values23, lower_bound, diff);
 
-        // Compute dot products and accumulate
-        acc = _mm256_fmadd_ps(code1_values01, code2_values01, acc);
-        acc = _mm256_fmadd_ps(code1_values23, code2_values23, acc);
+        // Compute dot products and accumulate into separate accumulators for ILP
+        acc0 = _mm256_fmadd_ps(code1_values01, code2_values01, acc0);
+        acc1 = _mm256_fmadd_ps(code1_values23, code2_values23, acc1);
     }
 
     // Single horizontal reduction after the loop
-    float result = AVX2_REDUCE_ADD_PS(acc);
+    float result = AVX2_REDUCE_ADD_PS(_mm256_add_ps(acc0, acc1));
 
     // Process remaining elements with SSE implementation
     result += sse::SQ4ComputeCodesIP(
@@ -985,7 +988,8 @@ SQ4ComputeCodesL2Sqr(const uint8_t* RESTRICT codes1,
     }
 
     uint64_t d = 0;
-    __m256 acc = _mm256_setzero_ps();
+    __m256 acc0 = _mm256_setzero_ps();
+    __m256 acc1 = _mm256_setzero_ps();
 
     // Process 16 values at a time (8 bytes containing 16 4-bit values)
     for (; d + 15 < dim; d += 16) {
@@ -995,15 +999,15 @@ SQ4ComputeCodesL2Sqr(const uint8_t* RESTRICT codes1,
         SQ4Decode16Values(codes1, d, code1_values01, code1_values23, lower_bound, diff);
         SQ4Decode16Values(codes2, d, code2_values01, code2_values23, lower_bound, diff);
 
-        // Compute differences and accumulate squared distances
+        // Compute differences and accumulate squared distances into separate accumulators for ILP
         __m256 diff0 = _mm256_sub_ps(code1_values01, code2_values01);
         __m256 diff1 = _mm256_sub_ps(code1_values23, code2_values23);
-        acc = _mm256_fmadd_ps(diff0, diff0, acc);
-        acc = _mm256_fmadd_ps(diff1, diff1, acc);
+        acc0 = _mm256_fmadd_ps(diff0, diff0, acc0);
+        acc1 = _mm256_fmadd_ps(diff1, diff1, acc1);
     }
 
     // Single horizontal reduction after the loop
-    float result = AVX2_REDUCE_ADD_PS(acc);
+    float result = AVX2_REDUCE_ADD_PS(_mm256_add_ps(acc0, acc1));
 
     // Process remaining elements with SSE implementation
     result += sse::SQ4ComputeCodesL2Sqr(

--- a/src/simd/avx2.cpp
+++ b/src/simd/avx2.cpp
@@ -866,8 +866,8 @@ SQ4ComputeIP(const float* RESTRICT query,
         return 0;
     }
 
-    float result = 0;
     uint64_t d = 0;
+    __m256 acc = _mm256_setzero_ps();
 
     // Process 16 values at a time (8 bytes containing 16 4-bit values)
     for (; d + 15 < dim; d += 16) {
@@ -878,22 +878,13 @@ SQ4ComputeIP(const float* RESTRICT query,
         __m256 query_vec0 = _mm256_loadu_ps(query + d);
         __m256 query_vec1 = _mm256_loadu_ps(query + d + 8);
 
-        // Compute dot products
-        __m256 prod0 = _mm256_mul_ps(query_vec0, values01);
-        __m256 prod1 = _mm256_mul_ps(query_vec1, values23);
-
-        // Horizontal sum
-        __m256 sum = _mm256_add_ps(prod0, prod1);
-        __m128 sum_low = _mm256_castps256_ps128(sum);
-        __m128 sum_high = _mm256_extractf128_ps(sum, 1);
-        __m128 sum01 = _mm_add_ps(sum_low, sum_high);
-        __m128 sum23 = _mm_shuffle_ps(sum01, sum01, _MM_SHUFFLE(2, 3, 0, 1));
-        __m128 sum0123 = _mm_add_ps(sum01, sum23);
-        __m128 sum4567 = _mm_movehl_ps(sum0123, sum0123);
-        __m128 total_sum = _mm_add_ss(sum0123, sum4567);
-
-        result += _mm_cvtss_f32(total_sum);
+        // Compute dot products and accumulate
+        acc = _mm256_fmadd_ps(query_vec0, values01, acc);
+        acc = _mm256_fmadd_ps(query_vec1, values23, acc);
     }
+
+    // Single horizontal reduction after the loop
+    float result = AVX2_REDUCE_ADD_PS(acc);
 
     // Process remaining elements with SSE implementation
     result += sse::SQ4ComputeIP(query + d, codes + (d >> 1), lower_bound + d, diff + d, dim - d);
@@ -914,8 +905,8 @@ SQ4ComputeL2Sqr(const float* RESTRICT query,
         return 0;
     }
 
-    float result = 0;
     uint64_t d = 0;
+    __m256 acc = _mm256_setzero_ps();
 
     // Process 16 values at a time (8 bytes containing 16 4-bit values)
     for (; d + 15 < dim; d += 16) {
@@ -925,26 +916,15 @@ SQ4ComputeL2Sqr(const float* RESTRICT query,
         __m256 query_vec0 = _mm256_loadu_ps(query + d);
         __m256 query_vec1 = _mm256_loadu_ps(query + d + 8);
 
-        // Compute differences
+        // Compute differences and accumulate squared distances
         __m256 diff0 = _mm256_sub_ps(query_vec0, values01);
         __m256 diff1 = _mm256_sub_ps(query_vec1, values23);
-
-        // Square differences
-        __m256 sq_diff0 = _mm256_mul_ps(diff0, diff0);
-        __m256 sq_diff1 = _mm256_mul_ps(diff1, diff1);
-
-        // Horizontal sum
-        __m256 sum = _mm256_add_ps(sq_diff0, sq_diff1);
-        __m128 sum_low = _mm256_castps256_ps128(sum);
-        __m128 sum_high = _mm256_extractf128_ps(sum, 1);
-        __m128 sum01 = _mm_add_ps(sum_low, sum_high);
-        __m128 sum23 = _mm_shuffle_ps(sum01, sum01, _MM_SHUFFLE(2, 3, 0, 1));
-        __m128 sum0123 = _mm_add_ps(sum01, sum23);
-        __m128 sum4567 = _mm_movehl_ps(sum0123, sum0123);
-        __m128 total_sum = _mm_add_ss(sum0123, sum4567);
-
-        result += _mm_cvtss_f32(total_sum);
+        acc = _mm256_fmadd_ps(diff0, diff0, acc);
+        acc = _mm256_fmadd_ps(diff1, diff1, acc);
     }
+
+    // Single horizontal reduction after the loop
+    float result = AVX2_REDUCE_ADD_PS(acc);
 
     // Process remaining elements with SSE implementation
     result += sse::SQ4ComputeL2Sqr(query + d, codes + (d >> 1), lower_bound + d, diff + d, dim - d);
@@ -965,8 +945,8 @@ SQ4ComputeCodesIP(const uint8_t* RESTRICT codes1,
         return 0;
     }
 
-    float result = 0;
     uint64_t d = 0;
+    __m256 acc = _mm256_setzero_ps();
 
     // Process 16 values at a time (8 bytes containing 16 4-bit values)
     for (; d + 15 < dim; d += 16) {
@@ -976,22 +956,13 @@ SQ4ComputeCodesIP(const uint8_t* RESTRICT codes1,
         SQ4Decode16Values(codes1, d, code1_values01, code1_values23, lower_bound, diff);
         SQ4Decode16Values(codes2, d, code2_values01, code2_values23, lower_bound, diff);
 
-        // Compute dot products
-        __m256 prod0 = _mm256_mul_ps(code1_values01, code2_values01);
-        __m256 prod1 = _mm256_mul_ps(code1_values23, code2_values23);
-
-        // Horizontal sum
-        __m256 sum = _mm256_add_ps(prod0, prod1);
-        __m128 sum_low = _mm256_castps256_ps128(sum);
-        __m128 sum_high = _mm256_extractf128_ps(sum, 1);
-        __m128 sum01 = _mm_add_ps(sum_low, sum_high);
-        __m128 sum23 = _mm_shuffle_ps(sum01, sum01, _MM_SHUFFLE(2, 3, 0, 1));
-        __m128 sum0123 = _mm_add_ps(sum01, sum23);
-        __m128 sum4567 = _mm_movehl_ps(sum0123, sum0123);
-        __m128 total_sum = _mm_add_ss(sum0123, sum4567);
-
-        result += _mm_cvtss_f32(total_sum);
+        // Compute dot products and accumulate
+        acc = _mm256_fmadd_ps(code1_values01, code2_values01, acc);
+        acc = _mm256_fmadd_ps(code1_values23, code2_values23, acc);
     }
+
+    // Single horizontal reduction after the loop
+    float result = AVX2_REDUCE_ADD_PS(acc);
 
     // Process remaining elements with SSE implementation
     result += sse::SQ4ComputeCodesIP(
@@ -1013,8 +984,8 @@ SQ4ComputeCodesL2Sqr(const uint8_t* RESTRICT codes1,
         return 0;
     }
 
-    float result = 0;
     uint64_t d = 0;
+    __m256 acc = _mm256_setzero_ps();
 
     // Process 16 values at a time (8 bytes containing 16 4-bit values)
     for (; d + 15 < dim; d += 16) {
@@ -1024,26 +995,15 @@ SQ4ComputeCodesL2Sqr(const uint8_t* RESTRICT codes1,
         SQ4Decode16Values(codes1, d, code1_values01, code1_values23, lower_bound, diff);
         SQ4Decode16Values(codes2, d, code2_values01, code2_values23, lower_bound, diff);
 
-        // Compute differences
+        // Compute differences and accumulate squared distances
         __m256 diff0 = _mm256_sub_ps(code1_values01, code2_values01);
         __m256 diff1 = _mm256_sub_ps(code1_values23, code2_values23);
-
-        // Square differences
-        __m256 sq_diff0 = _mm256_mul_ps(diff0, diff0);
-        __m256 sq_diff1 = _mm256_mul_ps(diff1, diff1);
-
-        // Horizontal sum
-        __m256 sum = _mm256_add_ps(sq_diff0, sq_diff1);
-        __m128 sum_low = _mm256_castps256_ps128(sum);
-        __m128 sum_high = _mm256_extractf128_ps(sum, 1);
-        __m128 sum01 = _mm_add_ps(sum_low, sum_high);
-        __m128 sum23 = _mm_shuffle_ps(sum01, sum01, _MM_SHUFFLE(2, 3, 0, 1));
-        __m128 sum0123 = _mm_add_ps(sum01, sum23);
-        __m128 sum4567 = _mm_movehl_ps(sum0123, sum0123);
-        __m128 total_sum = _mm_add_ss(sum0123, sum4567);
-
-        result += _mm_cvtss_f32(total_sum);
+        acc = _mm256_fmadd_ps(diff0, diff0, acc);
+        acc = _mm256_fmadd_ps(diff1, diff1, acc);
     }
+
+    // Single horizontal reduction after the loop
+    float result = AVX2_REDUCE_ADD_PS(acc);
 
     // Process remaining elements with SSE implementation
     result += sse::SQ4ComputeCodesL2Sqr(

--- a/src/simd/avx512.cpp
+++ b/src/simd/avx512.cpp
@@ -787,8 +787,9 @@ SQ4ComputeIP(const float* RESTRICT query,
         return 0;
     }
 
-    float result = 0;
     uint64_t d = 0;
+    __m512 acc0 = _mm512_setzero_ps();
+    __m512 acc1 = _mm512_setzero_ps();
 
     // Process 32 elements at a time (16 bytes of codes)
     for (; d + 31 < dim; d += 32) {
@@ -808,12 +809,13 @@ SQ4ComputeIP(const float* RESTRICT query,
         __m512 q0 = _mm512_loadu_ps(query + d);
         __m512 q1 = _mm512_loadu_ps(query + d + 16);
 
-        // Dot product
-        __m512 prod0 = _mm512_mul_ps(q0, val0);
-        __m512 prod1 = _mm512_mul_ps(q1, val1);
-
-        result += _mm512_reduce_add_ps(prod0) + _mm512_reduce_add_ps(prod1);
+        // Accumulate dot products
+        acc0 = _mm512_fmadd_ps(q0, val0, acc0);
+        acc1 = _mm512_fmadd_ps(q1, val1, acc1);
     }
+
+    // Single horizontal reduction after the loop
+    float result = _mm512_reduce_add_ps(acc0) + _mm512_reduce_add_ps(acc1);
     result += avx2::SQ4ComputeIP(query + d, codes + (d >> 1), lower_bound + d, diff + d, dim - d);
     return result;
 #else
@@ -879,8 +881,9 @@ SQ4ComputeCodesIP(const uint8_t* RESTRICT codes1,
     if (dim == 0) {
         return 0;
     }
-    float result = 0;
     uint64_t d = 0;
+    __m512 acc0 = _mm512_setzero_ps();
+    __m512 acc1 = _mm512_setzero_ps();
 
     // Process 32 elements at a time (16 bytes of codes)
     for (; d + 31 < dim; d += 32) {
@@ -899,12 +902,13 @@ SQ4ComputeCodesIP(const uint8_t* RESTRICT codes1,
         __m512 val2 = _mm512_fmadd_ps(decoded2, diff0, lb0);
         __m512 val3 = _mm512_fmadd_ps(decoded3, diff1, lb1);
 
-        // Dot product
-        __m512 prod0 = _mm512_mul_ps(val2, val0);
-        __m512 prod1 = _mm512_mul_ps(val3, val1);
-
-        result += _mm512_reduce_add_ps(prod0) + _mm512_reduce_add_ps(prod1);
+        // Accumulate dot products
+        acc0 = _mm512_fmadd_ps(val2, val0, acc0);
+        acc1 = _mm512_fmadd_ps(val3, val1, acc1);
     }
+
+    // Single horizontal reduction after the loop
+    float result = _mm512_reduce_add_ps(acc0) + _mm512_reduce_add_ps(acc1);
     result += avx2::SQ4ComputeCodesIP(
         codes1 + (d >> 1), codes2 + (d >> 1), lower_bound + d, diff + d, dim - d);
     return result;

--- a/src/simd/sse.cpp
+++ b/src/simd/sse.cpp
@@ -713,8 +713,8 @@ SQ4ComputeIP(const float* RESTRICT query,
         return 0;
     }
 
-    float result = 0;
     uint64_t d = 0;
+    __m128 acc = _mm_setzero_ps();
 
     // Process 8 values at a time (4 bytes containing 8 4-bit values)
     for (; d + 7 < dim; d += 8) {
@@ -753,19 +753,17 @@ SQ4ComputeIP(const float* RESTRICT query,
         __m128 query_vec0 = _mm_loadu_ps(query + d);
         __m128 query_vec1 = _mm_loadu_ps(query + d + 4);
 
-        // Compute dot products
+        // Compute dot products and accumulate
         __m128 prod0 = _mm_mul_ps(query_vec0, values0);
         __m128 prod1 = _mm_mul_ps(query_vec1, values1);
-
-        // Horizontal sum
-        __m128 sum01 = _mm_add_ps(prod0, prod1);
-        __m128 sum23 = _mm_shuffle_ps(sum01, sum01, _MM_SHUFFLE(2, 3, 0, 1));
-        __m128 sum0123 = _mm_add_ps(sum01, sum23);
-        __m128 sum4567 = _mm_movehl_ps(sum0123, sum0123);
-        __m128 sum = _mm_add_ss(sum0123, sum4567);
-
-        result += _mm_cvtss_f32(sum);
+        acc = _mm_add_ps(acc, _mm_add_ps(prod0, prod1));
     }
+
+    // Single horizontal reduction after the loop
+    __m128 shuf = _mm_shuffle_ps(acc, acc, _MM_SHUFFLE(2, 3, 0, 1));
+    __m128 sums = _mm_add_ps(acc, shuf);
+    __m128 hi = _mm_movehl_ps(sums, sums);
+    float result = _mm_cvtss_f32(_mm_add_ss(sums, hi));
 
     // Process remaining elements with generic implementation
     result +=
@@ -787,8 +785,8 @@ SQ4ComputeL2Sqr(const float* RESTRICT query,
         return 0;
     }
 
-    float result = 0;
     uint64_t d = 0;
+    __m128 acc = _mm_setzero_ps();
 
     // Process 8 values at a time (4 bytes containing 8 4-bit values)
     for (; d + 7 < dim; d += 8) {
@@ -827,23 +825,18 @@ SQ4ComputeL2Sqr(const float* RESTRICT query,
         __m128 query_vec0 = _mm_loadu_ps(query + d);
         __m128 query_vec1 = _mm_loadu_ps(query + d + 4);
 
-        // Compute differences
+        // Compute differences and accumulate squared distances
         __m128 diff0 = _mm_sub_ps(query_vec0, values0);
         __m128 diff1 = _mm_sub_ps(query_vec1, values1);
-
-        // Square differences
-        __m128 sq_diff0 = _mm_mul_ps(diff0, diff0);
-        __m128 sq_diff1 = _mm_mul_ps(diff1, diff1);
-
-        // Horizontal sum
-        __m128 sum01 = _mm_add_ps(sq_diff0, sq_diff1);
-        __m128 sum23 = _mm_shuffle_ps(sum01, sum01, _MM_SHUFFLE(2, 3, 0, 1));
-        __m128 sum0123 = _mm_add_ps(sum01, sum23);
-        __m128 sum4567 = _mm_movehl_ps(sum0123, sum0123);
-        __m128 sum = _mm_add_ss(sum0123, sum4567);
-
-        result += _mm_cvtss_f32(sum);
+        acc = _mm_add_ps(acc, _mm_mul_ps(diff0, diff0));
+        acc = _mm_add_ps(acc, _mm_mul_ps(diff1, diff1));
     }
+
+    // Single horizontal reduction after the loop
+    __m128 shuf = _mm_shuffle_ps(acc, acc, _MM_SHUFFLE(2, 3, 0, 1));
+    __m128 sums = _mm_add_ps(acc, shuf);
+    __m128 hi = _mm_movehl_ps(sums, sums);
+    float result = _mm_cvtss_f32(_mm_add_ss(sums, hi));
 
     // Process remaining elements with generic implementation
     result +=
@@ -865,8 +858,8 @@ SQ4ComputeCodesIP(const uint8_t* RESTRICT codes1,
         return 0;
     }
 
-    float result = 0;
     uint64_t d = 0;
+    __m128 acc = _mm_setzero_ps();
 
     // Process 8 values at a time (4 bytes containing 8 4-bit values)
     for (; d + 7 < dim; d += 8) {
@@ -914,19 +907,17 @@ SQ4ComputeCodesIP(const uint8_t* RESTRICT codes1,
         code2_values0 = _mm_add_ps(_mm_mul_ps(code2_values0, diff_vec0), lb_vec0);
         code2_values1 = _mm_add_ps(_mm_mul_ps(code2_values1, diff_vec1), lb_vec1);
 
-        // Compute dot products
+        // Compute dot products and accumulate
         __m128 prod0 = _mm_mul_ps(code1_values0, code2_values0);
         __m128 prod1 = _mm_mul_ps(code1_values1, code2_values1);
-
-        // Horizontal sum
-        __m128 sum01 = _mm_add_ps(prod0, prod1);
-        __m128 sum23 = _mm_shuffle_ps(sum01, sum01, _MM_SHUFFLE(2, 3, 0, 1));
-        __m128 sum0123 = _mm_add_ps(sum01, sum23);
-        __m128 sum4567 = _mm_movehl_ps(sum0123, sum0123);
-        __m128 sum = _mm_add_ss(sum0123, sum4567);
-
-        result += _mm_cvtss_f32(sum);
+        acc = _mm_add_ps(acc, _mm_add_ps(prod0, prod1));
     }
+
+    // Single horizontal reduction after the loop
+    __m128 shuf = _mm_shuffle_ps(acc, acc, _MM_SHUFFLE(2, 3, 0, 1));
+    __m128 sums = _mm_add_ps(acc, shuf);
+    __m128 hi = _mm_movehl_ps(sums, sums);
+    float result = _mm_cvtss_f32(_mm_add_ss(sums, hi));
 
     // Process remaining elements with generic implementation
     result += generic::SQ4ComputeCodesIP(
@@ -948,8 +939,8 @@ SQ4ComputeCodesL2Sqr(const uint8_t* RESTRICT codes1,
         return 0;
     }
 
-    float result = 0;
     uint64_t d = 0;
+    __m128 acc = _mm_setzero_ps();
 
     // Process 8 values at a time (4 bytes containing 8 4-bit values)
     for (; d + 7 < dim; d += 8) {
@@ -997,23 +988,18 @@ SQ4ComputeCodesL2Sqr(const uint8_t* RESTRICT codes1,
         code2_values0 = _mm_add_ps(_mm_mul_ps(code2_values0, diff_vec0), lb_vec0);
         code2_values1 = _mm_add_ps(_mm_mul_ps(code2_values1, diff_vec1), lb_vec1);
 
-        // Compute differences
+        // Compute differences and accumulate squared distances
         __m128 diff0 = _mm_sub_ps(code1_values0, code2_values0);
         __m128 diff1 = _mm_sub_ps(code1_values1, code2_values1);
-
-        // Square differences
-        __m128 sq_diff0 = _mm_mul_ps(diff0, diff0);
-        __m128 sq_diff1 = _mm_mul_ps(diff1, diff1);
-
-        // Horizontal sum
-        __m128 sum01 = _mm_add_ps(sq_diff0, sq_diff1);
-        __m128 sum23 = _mm_shuffle_ps(sum01, sum01, _MM_SHUFFLE(2, 3, 0, 1));
-        __m128 sum0123 = _mm_add_ps(sum01, sum23);
-        __m128 sum4567 = _mm_movehl_ps(sum0123, sum0123);
-        __m128 sum = _mm_add_ss(sum0123, sum4567);
-
-        result += _mm_cvtss_f32(sum);
+        acc = _mm_add_ps(acc, _mm_mul_ps(diff0, diff0));
+        acc = _mm_add_ps(acc, _mm_mul_ps(diff1, diff1));
     }
+
+    // Single horizontal reduction after the loop
+    __m128 shuf = _mm_shuffle_ps(acc, acc, _MM_SHUFFLE(2, 3, 0, 1));
+    __m128 sums = _mm_add_ps(acc, shuf);
+    __m128 hi = _mm_movehl_ps(sums, sums);
+    float result = _mm_cvtss_f32(_mm_add_ss(sums, hi));
 
     // Process remaining elements with generic implementation
     result += generic::SQ4ComputeCodesL2Sqr(

--- a/src/simd/sse.cpp
+++ b/src/simd/sse.cpp
@@ -714,7 +714,8 @@ SQ4ComputeIP(const float* RESTRICT query,
     }
 
     uint64_t d = 0;
-    __m128 acc = _mm_setzero_ps();
+    __m128 acc0 = _mm_setzero_ps();
+    __m128 acc1 = _mm_setzero_ps();
 
     // Process 8 values at a time (4 bytes containing 8 4-bit values)
     for (; d + 7 < dim; d += 8) {
@@ -753,13 +754,13 @@ SQ4ComputeIP(const float* RESTRICT query,
         __m128 query_vec0 = _mm_loadu_ps(query + d);
         __m128 query_vec1 = _mm_loadu_ps(query + d + 4);
 
-        // Compute dot products and accumulate
-        __m128 prod0 = _mm_mul_ps(query_vec0, values0);
-        __m128 prod1 = _mm_mul_ps(query_vec1, values1);
-        acc = _mm_add_ps(acc, _mm_add_ps(prod0, prod1));
+        // Compute dot products and accumulate into separate accumulators for ILP
+        acc0 = _mm_add_ps(acc0, _mm_mul_ps(query_vec0, values0));
+        acc1 = _mm_add_ps(acc1, _mm_mul_ps(query_vec1, values1));
     }
 
     // Single horizontal reduction after the loop
+    __m128 acc = _mm_add_ps(acc0, acc1);
     __m128 shuf = _mm_shuffle_ps(acc, acc, _MM_SHUFFLE(2, 3, 0, 1));
     __m128 sums = _mm_add_ps(acc, shuf);
     __m128 hi = _mm_movehl_ps(sums, sums);
@@ -786,7 +787,8 @@ SQ4ComputeL2Sqr(const float* RESTRICT query,
     }
 
     uint64_t d = 0;
-    __m128 acc = _mm_setzero_ps();
+    __m128 acc0 = _mm_setzero_ps();
+    __m128 acc1 = _mm_setzero_ps();
 
     // Process 8 values at a time (4 bytes containing 8 4-bit values)
     for (; d + 7 < dim; d += 8) {
@@ -825,14 +827,15 @@ SQ4ComputeL2Sqr(const float* RESTRICT query,
         __m128 query_vec0 = _mm_loadu_ps(query + d);
         __m128 query_vec1 = _mm_loadu_ps(query + d + 4);
 
-        // Compute differences and accumulate squared distances
+        // Compute differences and accumulate squared distances into separate accumulators for ILP
         __m128 diff0 = _mm_sub_ps(query_vec0, values0);
         __m128 diff1 = _mm_sub_ps(query_vec1, values1);
-        acc = _mm_add_ps(acc, _mm_mul_ps(diff0, diff0));
-        acc = _mm_add_ps(acc, _mm_mul_ps(diff1, diff1));
+        acc0 = _mm_add_ps(acc0, _mm_mul_ps(diff0, diff0));
+        acc1 = _mm_add_ps(acc1, _mm_mul_ps(diff1, diff1));
     }
 
     // Single horizontal reduction after the loop
+    __m128 acc = _mm_add_ps(acc0, acc1);
     __m128 shuf = _mm_shuffle_ps(acc, acc, _MM_SHUFFLE(2, 3, 0, 1));
     __m128 sums = _mm_add_ps(acc, shuf);
     __m128 hi = _mm_movehl_ps(sums, sums);
@@ -859,7 +862,8 @@ SQ4ComputeCodesIP(const uint8_t* RESTRICT codes1,
     }
 
     uint64_t d = 0;
-    __m128 acc = _mm_setzero_ps();
+    __m128 acc0 = _mm_setzero_ps();
+    __m128 acc1 = _mm_setzero_ps();
 
     // Process 8 values at a time (4 bytes containing 8 4-bit values)
     for (; d + 7 < dim; d += 8) {
@@ -907,13 +911,13 @@ SQ4ComputeCodesIP(const uint8_t* RESTRICT codes1,
         code2_values0 = _mm_add_ps(_mm_mul_ps(code2_values0, diff_vec0), lb_vec0);
         code2_values1 = _mm_add_ps(_mm_mul_ps(code2_values1, diff_vec1), lb_vec1);
 
-        // Compute dot products and accumulate
-        __m128 prod0 = _mm_mul_ps(code1_values0, code2_values0);
-        __m128 prod1 = _mm_mul_ps(code1_values1, code2_values1);
-        acc = _mm_add_ps(acc, _mm_add_ps(prod0, prod1));
+        // Compute dot products and accumulate into separate accumulators for ILP
+        acc0 = _mm_add_ps(acc0, _mm_mul_ps(code1_values0, code2_values0));
+        acc1 = _mm_add_ps(acc1, _mm_mul_ps(code1_values1, code2_values1));
     }
 
     // Single horizontal reduction after the loop
+    __m128 acc = _mm_add_ps(acc0, acc1);
     __m128 shuf = _mm_shuffle_ps(acc, acc, _MM_SHUFFLE(2, 3, 0, 1));
     __m128 sums = _mm_add_ps(acc, shuf);
     __m128 hi = _mm_movehl_ps(sums, sums);
@@ -940,7 +944,8 @@ SQ4ComputeCodesL2Sqr(const uint8_t* RESTRICT codes1,
     }
 
     uint64_t d = 0;
-    __m128 acc = _mm_setzero_ps();
+    __m128 acc0 = _mm_setzero_ps();
+    __m128 acc1 = _mm_setzero_ps();
 
     // Process 8 values at a time (4 bytes containing 8 4-bit values)
     for (; d + 7 < dim; d += 8) {
@@ -988,14 +993,15 @@ SQ4ComputeCodesL2Sqr(const uint8_t* RESTRICT codes1,
         code2_values0 = _mm_add_ps(_mm_mul_ps(code2_values0, diff_vec0), lb_vec0);
         code2_values1 = _mm_add_ps(_mm_mul_ps(code2_values1, diff_vec1), lb_vec1);
 
-        // Compute differences and accumulate squared distances
+        // Compute differences and accumulate squared distances into separate accumulators for ILP
         __m128 diff0 = _mm_sub_ps(code1_values0, code2_values0);
         __m128 diff1 = _mm_sub_ps(code1_values1, code2_values1);
-        acc = _mm_add_ps(acc, _mm_mul_ps(diff0, diff0));
-        acc = _mm_add_ps(acc, _mm_mul_ps(diff1, diff1));
+        acc0 = _mm_add_ps(acc0, _mm_mul_ps(diff0, diff0));
+        acc1 = _mm_add_ps(acc1, _mm_mul_ps(diff1, diff1));
     }
 
     // Single horizontal reduction after the loop
+    __m128 acc = _mm_add_ps(acc0, acc1);
     __m128 shuf = _mm_shuffle_ps(acc, acc, _MM_SHUFFLE(2, 3, 0, 1));
     __m128 sums = _mm_add_ps(acc, shuf);
     __m128 hi = _mm_movehl_ps(sums, sums);


### PR DESCRIPTION
## Summary

Move per-iteration horizontal SIMD reduction to a single post-loop reduction across all SQ4 distance functions (14 functions, 4 files). Eliminates 7-22 cycles of serial dependency per loop iteration.

| ISA | Functions | Pattern |
|-----|-----------|---------|
| SSE (4) | SQ4Compute IP/L2/CodesIP/CodesL2 | __m128 acc + manual hsum |
| AVX (4) | same | __m256 acc + 128-bit fold |
| AVX2 (4) | same | __m256 acc + fmadd + AVX2_REDUCE_ADD_PS |
| AVX-512 (2) | IP variants | __m512 acc + _mm512_reduce_add_ps |

AVX-512 L2Sqr and NEON already used correct pattern (unchanged).

## Test plan

- [x] SQ4 SIMD: 11,200 assertions across 7 dims x 100 samples x all backends -- passed
- [x] SQ4 Quantizer: 6,752,625 assertions / 8 cases -- passed
- [x] Full SIMD suite: 30,591,891 assertions / 52 cases -- passed
- [x] Full unit tests: 439/441 passed (2 pre-existing INT8 failures, unrelated)
- [x] Adversarial review: zero-init, accumulation semantics, tail dispatch, FP precision all verified
- [ ] CI format/lint check

🤖 Generated with [Claude Code](https://claude.com/claude-code)