### PR TITLE
fix(pyramid): set duplicate_query_id in add_one_point for duplicate detection

### DIFF
--- a/src/algorithm/pyramid/pyramid.cpp
+++ b/src/algorithm/pyramid/pyramid.cpp
@@ -798,6 +798,7 @@ Pyramid::add_one_point(IndexNode* node, InnerIdType inner_id, const float* vecto
         search_param.hops_limit = 10000;  // Add hops limit to prevent infinite loop
         if (support_duplicate_) {
             search_param.find_duplicate = true;
+            search_param.duplicate_query_id = inner_id;
         }
         auto codes = use_reorder_ ? precise_codes_ : base_codes_;
         bool update_entry_point;


### PR DESCRIPTION
## Summary

Fixes #2207

In `Pyramid::add_one_point`, when `support_duplicate_` is true, `search_param.find_duplicate` was set but `search_param.duplicate_query_id` was left at its default value (`std::numeric_limits<InnerIdType>::max()`). This caused the duplicate detection logic in `BasicSearcher::Search` to always fail:

- `duplicate_distance_threshold = 0` skips the threshold branch
- `duplicate_query_id = max` is always `>= TotalCount()`, skipping the CompareVectors branch

Duplicate vectors were never detected and were added as independent graph nodes, degrading NSW graph quality and causing intermittent failures in the Pyramid Duplicate Test.

## Changes

- Set `search_param.duplicate_query_id = inner_id` after `find_duplicate = true`, matching the pattern used by HGraph (`hgraph_build.cpp:474`)

## Test Plan

- [x] All 6 Pyramid duplicate test cases pass (27162 assertions)
- [x] Pyramid Duplicate Test passes consistently across 5 consecutive runs (previously flaky)
- [x] Release build passes
