### PR TITLE
fix(datacell): avoid integer overflow in FlattenDataCell::MergeOther offset

### DIFF
--- a/src/datacell/flatten_datacell.h
+++ b/src/datacell/flatten_datacell.h
@@ -484,7 +484,7 @@ FlattenDataCell<QuantTmpl, IOTmpl>::MergeOther(const FlattenInterfacePtr& other,
     }
     constexpr uint64_t BUFFER_SIZE = 1024 * 1024 * 10;
     uint64_t total_count = ptr->total_count_;
-    uint64_t offset = bias * code_size_;
+    uint64_t offset = static_cast<uint64_t>(bias) * static_cast<uint64_t>(code_size_);
     uint64_t read_count = 0;
     while (read_count < total_count) {
         bool need_release = false;


### PR DESCRIPTION
## Summary

Fix an integer-overflow bug in `FlattenDataCell::MergeOther` (`src/datacell/flatten_datacell.h`).

`bias` (`InnerIdType`/`uint32_t`) multiplied by `code_size_` (`uint32_t`) is computed in 32-bit arithmetic and only then promoted to `uint64_t`. When merging large indexes (`bias > 2^32 / code_size_`), the product overflows and truncates, so merged data is written to a wrong offset and corrupts existing data.

## Change

Cast both operands to `uint64_t` before the multiplication, matching the existing pattern already used in the same file (e.g. `static_cast<uint64_t>(idx[i]) * this->code_size_`):

```cpp
uint64_t offset = static_cast<uint64_t>(bias) * static_cast<uint64_t>(code_size_);
```

Fixes #2209
