### PR TITLE
fix(io): zero-initialize MemoryBlockIO blocks to prevent reverse edge corruption

### DIFF
--- a/src/datacell/graph_interface_test.cpp
+++ b/src/datacell/graph_interface_test.cpp
@@ -201,7 +201,10 @@ generate_graph(int count, int max_degree, Allocator* allocator) {
         }
 
         int k = std::min(max_degree, count - 1);
-        std::shuffle(candidates.begin(), candidates.begin() + k, rng);
+        for (int step = 0; step < k; ++step) {
+            std::uniform_int_distribution<int> dist(step, candidates.size() - 1);
+            std::swap(candidates[step], candidates[dist(rng)]);
+        }
 
         maps[i]->insert(maps[i]->end(), candidates.begin(), candidates.begin() + k);
     }

--- a/src/io/memory_block_io.cpp
+++ b/src/io/memory_block_io.cpp
@@ -133,6 +133,7 @@ MemoryBlockIO::check_and_realloc(uint64_t size) {
         if (ptr == nullptr) {
             throw VsagException(ErrorType::NO_ENOUGH_MEMORY, "MemoryBlockIO allocation failed");
         }
+        memset(ptr, 0, block_size_);
         this->blocks_.emplace_back(ptr);
         ++cur_block_size;
     }


### PR DESCRIPTION
## Summary

Fix reverse edge test regression introduced after #2151 (LazyHGraph merge).

- Zero-initialize newly allocated MemoryBlockIO blocks to prevent reading garbage as neighbor data
- Fix partial shuffle bug in test helper `generate_graph` for uniformly random neighbor selection

Closes #2211

## Root Cause

`MemoryBlockIO::check_and_realloc` used `malloc` without zeroing new blocks. When `InsertNeighborsById` processed nodes out of insertion order, it read uninitialized IO areas as old neighbors, corrupting the reverse edge index. The LazyHGraph tests poisoned the malloc free list, making this latent bug manifest in ~75% of CI runs.

## Changes

| File | Change |
|------|--------|
| `src/io/memory_block_io.cpp` | `memset(ptr, 0, block_size_)` after block allocation |
| `src/datacell/graph_interface_test.cpp` | Shuffle full candidate list in `generate_graph` |

## Test Plan

- [x] `GraphDataCell Reverse Edges` passes 20/20 runs with `--order rand`
- [x] `GraphDataCell Move` passes 20/20 runs with `--order rand`
- [x] Full `[GraphDataCell]` suite passes with randomized order
- [ ] CI `main-branch-check` passes (verify in CI)