### PR TITLE
fix(pyramid): acquire per-task VisitedList in parallel search

### DIFF
--- a/src/algorithm/pyramid/pyramid.cpp
+++ b/src/algorithm/pyramid/pyramid.cpp
@@ -353,11 +353,13 @@ Pyramid::search_impl(const DatasetPtr& query,
                 if (thread_pool_ != nullptr && search_param.parallel_search_thread_count > 1) {
                     futures.push_back(thread_pool_->GeneralEnqueue([&, node, i]() -> void {
                         VisitedListGuard vl_guard(pool_.get());
-                        node->Search(search_func, vl_guard.get(), search_result_lists[i], search_param.ef);
+                        node->Search(
+                            search_func, vl_guard.get(), search_result_lists[i], search_param.ef);
                     }));
                 } else {
                     VisitedListGuard vl_guard(pool_.get());
-                    node->Search(search_func, vl_guard.get(), search_result_lists[i], search_param.ef);
+                    node->Search(
+                        search_func, vl_guard.get(), search_result_lists[i], search_param.ef);
                 }
             }
         }

--- a/src/algorithm/pyramid/pyramid.cpp
+++ b/src/algorithm/pyramid/pyramid.cpp
@@ -353,8 +353,7 @@ Pyramid::search_impl(const DatasetPtr& query,
                 if (thread_pool_ != nullptr && search_param.parallel_search_thread_count > 1) {
                     futures.push_back(thread_pool_->GeneralEnqueue([&, node, i]() -> void {
                         auto task_vl = pool_->TakeOne();
-                        node->Search(
-                            search_func, task_vl, search_result_lists[i], search_param.ef);
+                        node->Search(search_func, task_vl, search_result_lists[i], search_param.ef);
                         pool_->ReturnOne(task_vl);
                     }));
                 } else {

--- a/src/algorithm/pyramid/pyramid.cpp
+++ b/src/algorithm/pyramid/pyramid.cpp
@@ -352,14 +352,12 @@ Pyramid::search_impl(const DatasetPtr& query,
             if (valid) {
                 if (thread_pool_ != nullptr && search_param.parallel_search_thread_count > 1) {
                     futures.push_back(thread_pool_->GeneralEnqueue([&, node, i]() -> void {
-                        auto task_vl = pool_->TakeOne();
-                        node->Search(search_func, task_vl, search_result_lists[i], search_param.ef);
-                        pool_->ReturnOne(task_vl);
+                        VisitedListGuard vl_guard(pool_.get());
+                        node->Search(search_func, vl_guard.get(), search_result_lists[i], search_param.ef);
                     }));
                 } else {
-                    auto vl = pool_->TakeOne();
-                    node->Search(search_func, vl, search_result_lists[i], search_param.ef);
-                    pool_->ReturnOne(vl);
+                    VisitedListGuard vl_guard(pool_.get());
+                    node->Search(search_func, vl_guard.get(), search_result_lists[i], search_param.ef);
                 }
             }
         }
@@ -377,9 +375,8 @@ Pyramid::search_impl(const DatasetPtr& query,
         }
 
     } else {
-        auto vl = pool_->TakeOne();
-        root_->Search(search_func, vl, search_result, search_param.ef);
-        pool_->ReturnOne(vl);
+        VisitedListGuard vl_guard(pool_.get());
+        root_->Search(search_func, vl_guard.get(), search_result, search_param.ef);
     }
 
     if (use_reorder_) {

--- a/src/algorithm/pyramid/pyramid.cpp
+++ b/src/algorithm/pyramid/pyramid.cpp
@@ -332,7 +332,6 @@ Pyramid::search_impl(const DatasetPtr& query,
     DistHeapPtr search_result = std::make_shared<StandardHeap<true, false>>(allocator_, -1);
 
     std::shared_lock<std::shared_mutex> lock(resize_mutex_);
-    auto vl = pool_->TakeOne();
     if (query_path != nullptr) {
         std::vector<std::future<void>> futures;
         const std::string& current_path = query_path[0];
@@ -353,10 +352,15 @@ Pyramid::search_impl(const DatasetPtr& query,
             if (valid) {
                 if (thread_pool_ != nullptr && search_param.parallel_search_thread_count > 1) {
                     futures.push_back(thread_pool_->GeneralEnqueue([&, node, i]() -> void {
-                        node->Search(search_func, vl, search_result_lists[i], search_param.ef);
+                        auto task_vl = pool_->TakeOne();
+                        node->Search(
+                            search_func, task_vl, search_result_lists[i], search_param.ef);
+                        pool_->ReturnOne(task_vl);
                     }));
                 } else {
+                    auto vl = pool_->TakeOne();
                     node->Search(search_func, vl, search_result_lists[i], search_param.ef);
+                    pool_->ReturnOne(vl);
                 }
             }
         }
@@ -374,9 +378,10 @@ Pyramid::search_impl(const DatasetPtr& query,
         }
 
     } else {
+        auto vl = pool_->TakeOne();
         root_->Search(search_func, vl, search_result, search_param.ef);
+        pool_->ReturnOne(vl);
     }
-    pool_->ReturnOne(vl);
 
     if (use_reorder_) {
         search_result = this->reorder_->Reorder(

--- a/src/algorithm/pyramid/pyramid.h
+++ b/src/algorithm/pyramid/pyramid.h
@@ -205,7 +205,8 @@ private:
     // RAII guard for VisitedList pool resources
     class VisitedListGuard {
     public:
-        VisitedListGuard(ResourceObjectPool<VisitedList>* pool) : pool_(pool), vl_(pool->TakeOne()) {
+        VisitedListGuard(ResourceObjectPool<VisitedList>* pool)
+            : pool_(pool), vl_(pool->TakeOne()) {
         }
 
         ~VisitedListGuard() {

--- a/src/algorithm/pyramid/pyramid.h
+++ b/src/algorithm/pyramid/pyramid.h
@@ -202,6 +202,35 @@ public:
     friend class PyramidAnalyzer;
 
 private:
+    // RAII guard for VisitedList pool resources
+    class VisitedListGuard {
+    public:
+        VisitedListGuard(ResourceObjectPool<VisitedList>* pool) : pool_(pool), vl_(pool->TakeOne()) {
+        }
+
+        ~VisitedListGuard() {
+            if (vl_) {
+                pool_->ReturnOne(vl_);
+            }
+        }
+
+        VisitedListGuard(const VisitedListGuard&) = delete;
+        VisitedListGuard& operator=(const VisitedListGuard&) = delete;
+
+        VisitedListPtr
+        get() const {
+            return vl_;
+        }
+
+        operator VisitedListPtr() const {
+            return vl_;
+        }
+
+    private:
+        ResourceObjectPool<VisitedList>* pool_;
+        VisitedListPtr vl_;
+    };
+
     void
     resize(int64_t new_max_capacity);
 

--- a/src/algorithm/pyramid/pyramid.h
+++ b/src/algorithm/pyramid/pyramid.h
@@ -216,7 +216,8 @@ private:
         }
 
         VisitedListGuard(const VisitedListGuard&) = delete;
-        VisitedListGuard& operator=(const VisitedListGuard&) = delete;
+        VisitedListGuard&
+        operator=(const VisitedListGuard&) = delete;
 
         VisitedListPtr
         get() const {


### PR DESCRIPTION
## Summary

- Fix data race in Pyramid parallel search: each concurrent search task now acquires its own VisitedList from the pool instead of sharing one via lambda reference capture.
- Single-threaded and root-only search paths also acquire/return VisitedList locally instead of at function scope.

Fixes: #2213

## Changes

- `src/algorithm/pyramid/pyramid.cpp`: Move `pool_->TakeOne()` inside the parallel task lambda so each task gets its own VisitedList; add matching `pool_->ReturnOne()` at task completion. Single-threaded and root-only paths similarly scoped.

## Test plan

- [x] Pyramid unit tests passed
- [x] Full unit test suite: no regressions
- [x] Adversarial review: lifetime, thread safety, exception safety verified
- [ ] CI format/lint check

🤖 Generated with [Claude Code](https://claude.com/claude-code)