### PR TITLE
perf(io): replace per-write fsync with dirty-flag fdatasync in AsyncIO

### DIFF
--- a/src/io/async_io/async_io.cpp
+++ b/src/io/async_io/async_io.cpp
@@ -92,15 +92,18 @@ void
 AsyncIO::flush_if_dirty() const {
     if (dirty_.load(std::memory_order_acquire)) {
         std::lock_guard<std::mutex> lock(flush_mutex_);
-        if (dirty_.exchange(false, std::memory_order_acq_rel)) {
-            fdatasync(wfd_);
+        if (dirty_.load(std::memory_order_acquire)) {
+            if (fdatasync(wfd_) == -1) {
+                throw VsagException(ErrorType::INTERNAL_ERROR,
+                                    fmt::format("fdatasync failed: {}", strerror(errno)));
+            }
+            dirty_.store(false, std::memory_order_release);
         }
     }
 }
 
 bool
 AsyncIO::ReadImpl(uint64_t size, uint64_t offset, uint8_t* data) const {
-    flush_if_dirty();
     bool need_release = true;
     const auto* ptr = DirectReadImpl(size, offset, need_release);
     if (ptr == nullptr) {

--- a/src/io/async_io/async_io.cpp
+++ b/src/io/async_io/async_io.cpp
@@ -57,7 +57,10 @@ AsyncIO::AsyncIO(const IOParamPtr& param, const IndexCommonParam& common_param)
     : AsyncIO(std::dynamic_pointer_cast<AsyncIOParameter>(param), common_param){};
 
 AsyncIO::~AsyncIO() {
-    flush_if_dirty();
+    try {
+        flush_if_dirty();
+    } catch (...) {
+    }
     close(this->wfd_);
     close(this->rfd_);
     // remove file

--- a/src/io/async_io/async_io.cpp
+++ b/src/io/async_io/async_io.cpp
@@ -75,7 +75,7 @@ AsyncIO::WriteImpl(const uint8_t* data, uint64_t size, uint64_t offset) {
     if (size + offset > this->size_) {
         this->size_ = size + offset;
     }
-    fsync(wfd_);
+    dirty_.store(true, std::memory_order_release);
 }
 
 void
@@ -87,8 +87,19 @@ AsyncIO::ResizeImpl(uint64_t size) {
     this->size_ = size;
 }
 
+void
+AsyncIO::flush_if_dirty() const {
+    if (dirty_.load(std::memory_order_acquire)) {
+        std::lock_guard<std::mutex> lock(flush_mutex_);
+        if (dirty_.exchange(false, std::memory_order_acq_rel)) {
+            fdatasync(wfd_);
+        }
+    }
+}
+
 bool
 AsyncIO::ReadImpl(uint64_t size, uint64_t offset, uint8_t* data) const {
+    flush_if_dirty();
     bool need_release = true;
     const auto* ptr = DirectReadImpl(size, offset, need_release);
     if (ptr == nullptr) {
@@ -101,6 +112,7 @@ AsyncIO::ReadImpl(uint64_t size, uint64_t offset, uint8_t* data) const {
 
 const uint8_t*
 AsyncIO::DirectReadImpl(uint64_t size, uint64_t offset, bool& need_release) const {
+    flush_if_dirty();
     if (not check_valid_offset(size + offset)) {
         return nullptr;
     }
@@ -129,6 +141,7 @@ AsyncIO::ReleaseImpl(const uint8_t* data) {
 
 bool
 AsyncIO::MultiReadImpl(uint8_t* datas, uint64_t* sizes, uint64_t* offsets, uint64_t count) const {
+    flush_if_dirty();
     auto context = io_context_pool->TakeOne();
     uint8_t* cur_data = datas;
     auto all_count = static_cast<int64_t>(count);

--- a/src/io/async_io/async_io.cpp
+++ b/src/io/async_io/async_io.cpp
@@ -57,6 +57,7 @@ AsyncIO::AsyncIO(const IOParamPtr& param, const IndexCommonParam& common_param)
     : AsyncIO(std::dynamic_pointer_cast<AsyncIOParameter>(param), common_param){};
 
 AsyncIO::~AsyncIO() {
+    flush_if_dirty();
     close(this->wfd_);
     close(this->rfd_);
     // remove file

--- a/src/io/async_io/async_io.h
+++ b/src/io/async_io/async_io.h
@@ -16,6 +16,9 @@
 #pragma once
 
 #if HAVE_LIBAIO
+#include <atomic>
+#include <mutex>
+
 #include "index_common_param.h"
 #include "io/async_io/aio_context.h"
 #include "io/async_io/async_io_parameter.h"
@@ -150,6 +153,15 @@ private:
 
     /// Flag indicating if file existed before opening; false means file will be removed on destruction.
     bool exist_file_{false};
+
+    /// Tracks whether unflushed writes exist; read paths check this to ensure O_DIRECT coherence.
+    mutable std::atomic<bool> dirty_{false};
+
+    /// Serializes fdatasync calls so concurrent readers don't race on the flush.
+    mutable std::mutex flush_mutex_;
+
+    void
+    flush_if_dirty() const;
 };
 
 }  // namespace vsag


### PR DESCRIPTION
## Summary

Replace unconditional fsync(wfd_) after every AsyncIO::WriteImpl with a lazy dirty-flag pattern. Writes set an atomic flag; O_DIRECT read paths check it with double-checked locking and issue a single fdatasync per write-to-read transition.

Fixes: #2215

## Changes

- WriteImpl: fsync(wfd_) replaced with dirty_.store(true, release)
- New flush_if_dirty(): double-checked locking + fdatasync(wfd_)
- ReadImpl/DirectReadImpl/MultiReadImpl: call flush_if_dirty() at entry
- +26/-1 lines across 2 files (async_io.cpp, async_io.h)

## Correctness

- Write-then-read (same thread): dirty flag ensures fdatasync before O_DIRECT read
- Concurrent write+read: double-checked locking serializes flush; fdatasync flushes ALL dirty pages
- Concurrent reads: mutex ensures only first reader flushes; others wait then proceed
- Pure search (no writes): dirty_ always false, ~1ns atomic load overhead per read

## Test plan

- [x] AsyncIO unit tests passed
- [x] Full IO test suite passed
- [x] Full unit test regression: no new failures
- [x] Adversarial review: concurrency scenarios, kernel IO semantics, code quality
- [ ] CI format/lint check