### PR TITLE
fix(ci): add shell: bash to Run Examples step to fix silent skip

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -231,6 +231,7 @@ jobs:
           name: build-x86-${{ github.run_id }}
           path: ./build
       - name: Run Examples
+        shell: bash
         run: |
           cd ./build/examples/cpp
           for example in ./*; do


### PR DESCRIPTION
## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement/Refactor
- [ ] Documentation
- [x] CI/Build/Infra

## Linked Issue

- Fixes: #2217

## What Changed

- Added `shell: bash` to the "Run Examples" step in `pr-ci.yml`. The step uses bash-only syntax (`[[ $filename =~ ^[0-9]{3} ]]`) but container jobs default to `sh` (dash), which does not support `[[` or `=~`. This caused every iteration to emit `[[: not found` and silently skip all example binaries while still reporting success.

## Test Evidence

- [ ] `make fmt`
- [ ] `make lint`
- [ ] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [x] Other (describe below)

Test details:

```text
Verified by reviewing the CI log for PR #2157 job 80030569285:
- Before: 38 lines of "[[: not found", zero "Run ./NNN" lines, step exits 0
- After: the shell: bash directive ensures [[ is available and examples will actually execute
```

## Compatibility Impact

- API/ABI compatibility: none
- Behavior changes: CI will now actually run the example binaries (the intended behavior)

## Performance and Concurrency Impact

- Performance impact: none
- Concurrency/thread-safety impact: none

## Documentation Impact

- [x] No docs update needed

## Risk and Rollback

- Risk level: low
- Rollback plan: revert the one-line `shell: bash` addition

## Checklist

- [x] I have linked the relevant issue (required for `kind/bug` and `kind/feature`; see "Linked Issue" above)
- [ ] I have added/updated tests for new behavior or bug fixes
- [x] I have considered API compatibility impact
- [x] I have updated docs if behavior/workflow changed
- [x] My commit messages follow project conventions (Conventional Commits, optional `[skip ci]` prefix)

_Drafted with AI assistant: ClaudeCode:claude-opus-4.6_