### PR TITLE
fix(io): zero-initialize buffer in BasicIO::Resize fallback path

### DIFF
--- a/src/io/basic_io.h
+++ b/src/io/basic_io.h
@@ -18,6 +18,7 @@
 #include <fmt/format.h>
 
 #include <cstdint>
+#include <cstring>
 
 #include "io_parameter.h"
 #include "storage/stream_reader.h"
@@ -227,6 +228,7 @@ public:
                 return;
             }
             ByteBuffer buffer(SERIALIZE_BUFFER_SIZE, this->allocator_);
+            memset(buffer.data, 0, SERIALIZE_BUFFER_SIZE);
             uint64_t offset = this->size_;
             while (offset < size) {
                 auto cur_size = std::min(SERIALIZE_BUFFER_SIZE, size - offset);


### PR DESCRIPTION
Closes #2220

## What

Zero-initialize the `ByteBuffer` in `BasicIO::Resize` default (fallback) implementation before writing it to storage.

## Why

The fallback `Resize` path allocates a 2MB `ByteBuffer` via `Allocator::Allocate` (equivalent to `malloc`), which returns uninitialized heap memory. This memory is then written directly to the underlying storage, causing:

- Potential information leakage when serialized indexes are transferred
- Nondeterministic values in expanded regions
- Valgrind/MSAN uninitialized-read warnings

## How

Add `memset(buffer.data, 0, SERIALIZE_BUFFER_SIZE)` after the `ByteBuffer` allocation, only in the `Resize` fallback path. The `Serialize`/`Deserialize` paths are unaffected since their buffers are immediately overwritten by `Read`/`StreamReader`.

## Test

All 29 IO unit tests pass (465,407 assertions), including `NonContinuousIO` which exercises the fallback Resize path.