### PR TITLE
add SIMQ

### DIFF
--- a/include/vsag/constants.h
+++ b/include/vsag/constants.h
@@ -27,6 +27,7 @@ extern const char* const INDEX_SINDI;
 extern const char* const INDEX_BRUTE_FORCE;
 extern const char* const INDEX_IVF;
 extern const char* const INDEX_WARP;
+extern const char* const INDEX_SIMQ;
 extern const char* const DIM;
 extern const char* const NUM_ELEMENTS;
 extern const char* const IDS;

--- a/include/vsag/index.h
+++ b/include/vsag/index.h
@@ -60,7 +60,8 @@ enum class IndexType {
     SPARSE,
     SINDI,
     WARP,
-    LAZY_HGRAPH
+    LAZY_HGRAPH,
+    SIMQ
 };
 
 #define DATA_FLAG_FLOAT32_VECTOR 0x01

--- a/src/algorithm/CMakeLists.txt
+++ b/src/algorithm/CMakeLists.txt
@@ -23,6 +23,7 @@ add_subdirectory (ivf)
 add_subdirectory (pyramid)
 add_subdirectory (sparse_index)
 add_subdirectory (warp)
+add_subdirectory (simq)
 
 file (GLOB ALGORITHM_SRCS "*.cpp")
 list (FILTER ALGORITHM_SRCS EXCLUDE REGEX "_test.cpp")
@@ -43,6 +44,7 @@ set (ALGORITHM_LIBS
         pyramid
         sparse_index
         warp
+        simq
         PARENT_SCOPE)
 
 if (ENABLE_TESTS)

--- a/src/algorithm/simq/CMakeLists.txt
+++ b/src/algorithm/simq/CMakeLists.txt
@@ -1,0 +1,23 @@
+
+# Copyright 2024-present the vsag project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+set (SIMQ_SRCS
+        simq.cpp
+        simq_parameter.cpp
+)
+
+add_library (simq OBJECT ${SIMQ_SRCS})
+target_link_libraries (simq PRIVATE coverage_config vsag_src_common)

--- a/src/algorithm/simq/simq.cpp
+++ b/src/algorithm/simq/simq.cpp
@@ -1,0 +1,830 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "simq.h"
+
+#include <algorithm>
+#include <cstring>
+#include <limits>
+#include <numeric>
+#include <random>
+#include <sstream>
+#include <unordered_map>
+#include <unordered_set>
+
+#include "datacell/flatten_datacell.h"
+#include "datacell/flatten_datacell_parameter.h"
+#include "index_feature_list.h"
+#include "inner_string_params.h"
+#include "storage/serialization.h"
+#include "storage/stream_reader.h"
+#include "storage/stream_writer.h"
+#include "metric_type.h"
+#include "typing.h"
+#include "utils/util_functions.h"
+
+namespace vsag {
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Internal clustering helper
+// ─────────────────────────────────────────────────────────────────────────────
+
+namespace {
+
+struct ClusterMemberEntry {
+    InnerIdType vec_id;
+    float       distance;
+};
+
+class HNSWDynamicClustering {
+public:
+    HNSWDynamicClustering(float init_cluster_ratio,
+                          int64_t max_cluster_size,
+                          int64_t split_start_idx,
+                          int64_t random_seed,
+                          vsag::Allocator* allocator)
+        : init_cluster_ratio_(init_cluster_ratio),
+          max_cluster_size_(static_cast<int>(max_cluster_size)),
+          split_start_idx_(static_cast<int>(split_start_idx)),
+          random_seed_(static_cast<int>(random_seed)),
+          allocator_(allocator) {}
+
+    ~HNSWDynamicClustering() {
+        delete hnsw_;
+        delete space_;
+    }
+
+    void
+    fit(const float* vecs, int64_t num_vecs, int64_t dim);
+
+    void
+    find_representatives(const float* vecs, int64_t dim);
+
+    std::vector<int>                                         cluster_centers_;
+    std::unordered_map<int, std::vector<ClusterMemberEntry>> clusters_;
+    std::vector<int>                                         vec_to_cluster_;
+    std::vector<int>                                         representative_vids_;
+
+private:
+    void
+    build_hnsw(const std::vector<int>& center_ids, int64_t dim);
+
+    int
+    find_nearest_cluster(int vec_id) const;
+
+    float
+    ip_distance(int v1, int v2) const;
+
+    void
+    sorted_insert(std::vector<ClusterMemberEntry>& members, InnerIdType vec_id, float dist);
+
+    void
+    split_cluster(int old_center_id, int64_t dim);
+
+    float            init_cluster_ratio_;
+    int              max_cluster_size_;
+    int              split_start_idx_;
+    int              random_seed_;
+    vsag::Allocator* allocator_{nullptr};
+
+    const float* vecs_{nullptr};
+    int64_t      num_vecs_{0};
+    int64_t      dim_{0};
+
+    hnswlib::InnerProductSpace* space_{nullptr};
+    hnswlib::HierarchicalNSW*   hnsw_{nullptr};
+
+    std::vector<int> hnsw_id_to_vec_;
+    std::vector<int> vec_to_hnsw_id_;
+    int              next_hnsw_id_{0};
+};
+
+void
+HNSWDynamicClustering::build_hnsw(const std::vector<int>& center_ids, int64_t dim) {
+    delete hnsw_;
+    delete space_;
+
+    space_ = new hnswlib::InnerProductSpace(static_cast<uint64_t>(dim),
+                                            vsag::DataTypes::DATA_TYPE_FLOAT);
+    hnsw_ = new hnswlib::HierarchicalNSW(
+        space_, static_cast<uint64_t>(center_ids.size()), allocator_, 16, 100);
+    hnsw_->init_memory_space();
+
+    hnsw_id_to_vec_.clear();
+    vec_to_hnsw_id_.assign(static_cast<uint64_t>(num_vecs_), -1);
+    next_hnsw_id_ = 0;
+
+    for (int cid : center_ids) {
+        hnsw_->addPoint(vecs_ + cid * dim_, static_cast<hnswlib::LabelType>(next_hnsw_id_));
+        hnsw_id_to_vec_.push_back(cid);
+        vec_to_hnsw_id_[cid] = next_hnsw_id_;
+        ++next_hnsw_id_;
+    }
+}
+
+int
+HNSWDynamicClustering::find_nearest_cluster(int vec_id) const {
+    auto result = hnsw_->searchKnn(vecs_ + vec_id * dim_, 1, 50);
+    return hnsw_id_to_vec_[static_cast<int>(result.top().second)];
+}
+
+float
+HNSWDynamicClustering::ip_distance(int v1, int v2) const {
+    const float* a = vecs_ + v1 * dim_;
+    const float* b = vecs_ + v2 * dim_;
+    float dot = 0.0f;
+    for (int i = 0; i < dim_; ++i) dot += a[i] * b[i];
+    return 1.0f - dot;
+}
+
+void
+HNSWDynamicClustering::sorted_insert(std::vector<ClusterMemberEntry>& members,
+                                     InnerIdType vec_id,
+                                     float dist) {
+    int lo = 0, hi = static_cast<int>(members.size());
+    while (lo < hi) {
+        int mid = (lo + hi) / 2;
+        if (members[mid].distance < dist) lo = mid + 1;
+        else hi = mid;
+    }
+    members.insert(members.begin() + lo, {vec_id, dist});
+}
+
+void
+HNSWDynamicClustering::split_cluster(int old_center_id, int64_t dim) {
+    auto& cluster = clusters_[old_center_id];
+
+    int new_center_id = static_cast<int>(cluster.back().vec_id);
+
+    auto split_it = cluster.begin() + (split_start_idx_ - 1);
+    std::vector<ClusterMemberEntry> to_move(split_it, cluster.end());
+    cluster.erase(split_it, cluster.end());
+
+    std::vector<ClusterMemberEntry> new_cluster;
+    new_cluster.push_back({static_cast<InnerIdType>(new_center_id), 0.0f});
+    vec_to_cluster_[new_center_id] = new_center_id;
+
+    for (auto& m : to_move) {
+        if (static_cast<int>(m.vec_id) == new_center_id) continue;
+        float d = ip_distance(static_cast<int>(m.vec_id), new_center_id);
+        sorted_insert(new_cluster, m.vec_id, d);
+        vec_to_cluster_[m.vec_id] = new_center_id;
+    }
+
+    clusters_[new_center_id] = std::move(new_cluster);
+    cluster_centers_.push_back(new_center_id);
+
+    if (hnsw_ != nullptr) {
+        if (static_cast<uint64_t>(next_hnsw_id_) >= hnsw_->getMaxElements()) {
+            hnsw_->resizeIndex(hnsw_->getMaxElements() * 2);
+        }
+        hnsw_->addPoint(vecs_ + new_center_id * dim_,
+                        static_cast<hnswlib::LabelType>(next_hnsw_id_));
+        if (new_center_id >= static_cast<int>(vec_to_hnsw_id_.size()))
+            vec_to_hnsw_id_.resize(new_center_id + 1, -1);
+        hnsw_id_to_vec_.push_back(new_center_id);
+        vec_to_hnsw_id_[new_center_id] = next_hnsw_id_;
+        ++next_hnsw_id_;
+    }
+}
+
+void
+HNSWDynamicClustering::fit(const float* vecs, int64_t num_vecs, int64_t dim) {
+    vecs_     = vecs;
+    num_vecs_ = num_vecs;
+    dim_      = dim;
+
+    vec_to_cluster_.assign(num_vecs, -1);
+
+    int num_init = std::max(1, static_cast<int>(num_vecs * init_cluster_ratio_));
+    std::vector<int> all_indices(num_vecs);
+    std::iota(all_indices.begin(), all_indices.end(), 0);
+    std::mt19937 rng(random_seed_);
+    std::shuffle(all_indices.begin(), all_indices.end(), rng);
+
+    std::vector<int> init_centers(all_indices.begin(), all_indices.begin() + num_init);
+    std::vector<int> remaining(all_indices.begin() + num_init, all_indices.end());
+
+    cluster_centers_ = init_centers;
+    for (int cid : init_centers) {
+        clusters_[cid] = {{static_cast<InnerIdType>(cid), 0.0f}};
+        vec_to_cluster_[cid] = cid;
+    }
+
+    build_hnsw(init_centers, dim);
+
+    for (int vid : remaining) {
+        int nearest = find_nearest_cluster(vid);
+        float dist  = ip_distance(vid, nearest);
+
+        sorted_insert(clusters_[nearest], static_cast<InnerIdType>(vid), dist);
+        vec_to_cluster_[vid] = nearest;
+
+        if (static_cast<int>(clusters_[nearest].size()) > max_cluster_size_) {
+            split_cluster(nearest, dim);
+        }
+    }
+}
+
+void
+HNSWDynamicClustering::find_representatives(const float* vecs, int64_t dim) {
+    representative_vids_.clear();
+    representative_vids_.reserve(cluster_centers_.size());
+
+    for (int cid : cluster_centers_) {
+        auto& members = clusters_[cid];
+
+        std::vector<float> mean(dim, 0.0f);
+        for (auto& m : members) {
+            const float* v = vecs + m.vec_id * dim;
+            for (int d = 0; d < dim; ++d) mean[d] += v[d];
+        }
+
+        float best_dot = -1e30f;
+        int   best_vid = static_cast<int>(members[0].vec_id);
+        for (auto& m : members) {
+            const float* v = vecs + m.vec_id * dim;
+            float dot = 0.0f;
+            for (int d = 0; d < dim; ++d) dot += v[d] * mean[d];
+            if (dot > best_dot) {
+                best_dot = dot;
+                best_vid = static_cast<int>(m.vec_id);
+            }
+        }
+        representative_vids_.push_back(best_vid);
+    }
+}
+
+}  // anonymous namespace
+
+// ─────────────────────────────────────────────────────────────────────────────
+// HNSW serialization helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+static std::string
+save_hnsw_to_string(hnswlib::HierarchicalNSW* hnsw) {
+    std::ostringstream oss(std::ios::binary);
+    IOStreamWriter writer(oss);
+    hnsw->saveIndex(writer);
+    return oss.str();
+}
+
+static hnswlib::HierarchicalNSW*
+load_hnsw_from_string(const std::string& bytes,
+                      hnswlib::SpaceInterface* space,
+                      vsag::Allocator* allocator) {
+    std::istringstream iss(bytes, std::ios::binary);
+    IOStreamReader reader(iss);
+    auto* hnsw = new hnswlib::HierarchicalNSW(space, 0, allocator);
+    hnsw->loadIndex(reader, space);
+    return hnsw;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Constructor / destructor
+// ─────────────────────────────────────────────────────────────────────────────
+
+SIMQ::SIMQ(const SIMQParameterPtr& param, const IndexCommonParam& common_param)
+    : InnerIndexInterface(param, common_param),
+      cluster_offsets_(allocator_),
+      cluster_data_(allocator_),
+      vec_to_doc_(allocator_),
+      doc_offsets_(allocator_),
+      vec_to_cluster_(allocator_) {
+    inner_codes_ = FlattenInterface::MakeInstance(param->base_codes_param, common_param);
+    init_cluster_ratio_ = param->init_cluster_ratio;
+    max_cluster_size_   = param->max_cluster_size;
+    split_start_idx_    = param->split_start_idx;
+    random_seed_        = param->random_seed;
+    default_coarse_k_   = param->coarse_k;
+    default_rerank_k_   = param->rerank_k;
+    this->has_raw_vector_ = true;
+}
+
+SIMQ::~SIMQ() {
+    delete rep_hnsw_;
+    delete rep_space_;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Build
+// ─────────────────────────────────────────────────────────────────────────────
+
+std::vector<int64_t>
+SIMQ::Build(const DatasetPtr& data) {
+    std::unique_lock lock(global_mutex_);
+
+    const MultiVector* mvs = data->GetMultiVectors();
+    CHECK_ARGUMENT(mvs != nullptr, "simq build: data.multi_vectors is nullptr");
+
+    int64_t mv_dim = data->GetMultiVectorDim();
+    CHECK_ARGUMENT(mv_dim == dim_,
+                   fmt::format("simq build: multi_vector_dim({}) != index dim({})", mv_dim, dim_));
+
+    int64_t num_docs = data->GetNumElements();
+    const int64_t* labels = data->GetIds();
+    CHECK_ARGUMENT(labels != nullptr, "simq build: labels (ids) is nullptr");
+
+    uint64_t total_vecs = 0;
+    for (int64_t i = 0; i < num_docs; ++i) total_vecs += mvs[i].len_;
+
+    Vector<float> flat(total_vecs * static_cast<uint64_t>(mv_dim), allocator_);
+    doc_offsets_.resize(static_cast<uint64_t>(num_docs) + 1);
+    vec_to_doc_.resize(total_vecs);
+
+    uint64_t vec_off = 0;
+    for (int64_t i = 0; i < num_docs; ++i) {
+        doc_offsets_[i] = static_cast<uint32_t>(vec_off);
+        uint64_t n = static_cast<uint64_t>(mvs[i].len_) * static_cast<uint64_t>(mv_dim);
+        std::memcpy(flat.data() + vec_off * static_cast<uint64_t>(mv_dim),
+                    mvs[i].vectors_,
+                    n * sizeof(float));
+        for (uint32_t t = 0; t < mvs[i].len_; ++t) {
+            vec_to_doc_[vec_off + t] = static_cast<InnerIdType>(i);
+        }
+        vec_off += mvs[i].len_;
+    }
+    doc_offsets_[num_docs] = static_cast<uint32_t>(total_vecs);
+    total_count_        = static_cast<uint64_t>(num_docs);
+    total_vector_count_ = total_vecs;
+
+    inner_codes_->Train(flat.data(), total_vecs);
+    inner_codes_->Resize(static_cast<InnerIdType>(total_vecs));
+    inner_codes_->BatchInsertVector(flat.data(), static_cast<InnerIdType>(total_vecs), nullptr);
+
+    for (int64_t i = 0; i < num_docs; ++i) {
+        this->label_table_->Insert(static_cast<InnerIdType>(i), labels[i]);
+    }
+
+    run_clustering(flat.data(), static_cast<int64_t>(total_vecs), mv_dim);
+    build_rep_hnsw(flat.data(), mv_dim);
+
+    { Vector<InnerIdType> tmp(allocator_); tmp.swap(vec_to_cluster_); }
+
+    return {};
+}
+
+void
+SIMQ::run_clustering(const float* flat_vecs, int64_t num_vecs, int64_t dim) {
+    HNSWDynamicClustering clustering(
+        init_cluster_ratio_, max_cluster_size_, split_start_idx_, random_seed_, allocator_);
+    clustering.fit(flat_vecs, num_vecs, dim);
+
+    int64_t nc = static_cast<int64_t>(clustering.cluster_centers_.size());
+    num_clusters_ = nc;
+
+    std::vector<int> center_to_idx(num_vecs, -1);
+    for (int idx = 0; idx < nc; ++idx) {
+        center_to_idx[clustering.cluster_centers_[idx]] = idx;
+    }
+
+    // Build flat inverted index
+    cluster_offsets_.resize(static_cast<uint64_t>(nc) + 1);
+    uint64_t total_members = 0;
+    for (int idx = 0; idx < nc; ++idx) {
+        cluster_offsets_[idx] = static_cast<InnerIdType>(total_members);
+        int cid = clustering.cluster_centers_[idx];
+        total_members += clustering.clusters_.count(cid) ? clustering.clusters_[cid].size() : 0;
+    }
+    cluster_offsets_[nc] = static_cast<InnerIdType>(total_members);
+
+    cluster_data_.resize(total_members);
+    for (int idx = 0; idx < nc; ++idx) {
+        int cid = clustering.cluster_centers_[idx];
+        auto it = clustering.clusters_.find(cid);
+        if (it == clustering.clusters_.end()) continue;
+        uint64_t off = cluster_offsets_[idx];
+        for (auto& m : it->second) {
+            cluster_data_[off++] = m.vec_id;
+        }
+    }
+
+    vec_to_cluster_.resize(static_cast<uint64_t>(num_vecs));
+    for (int64_t v = 0; v < num_vecs; ++v) {
+        int cid = clustering.vec_to_cluster_[v];
+        vec_to_cluster_[v] = static_cast<InnerIdType>(center_to_idx[cid]);
+    }
+}
+
+void
+SIMQ::build_rep_hnsw(const float* flat_vecs, int64_t dim) {
+    std::vector<int> representative_vids(num_clusters_);
+    for (int64_t idx = 0; idx < num_clusters_; ++idx) {
+        uint64_t beg = cluster_offsets_[idx];
+        uint64_t end = cluster_offsets_[idx + 1];
+        if (beg == end) {
+            representative_vids[idx] = 0;
+            continue;
+        }
+
+        std::vector<float> mean(dim, 0.0f);
+        for (uint64_t j = beg; j < end; ++j) {
+            const float* v = flat_vecs + cluster_data_[j] * dim;
+            for (int d = 0; d < dim; ++d) mean[d] += v[d];
+        }
+
+        float best_dot = -1e30f;
+        int   best_vid = static_cast<int>(cluster_data_[beg]);
+        for (uint64_t j = beg; j < end; ++j) {
+            InnerIdType vid = cluster_data_[j];
+            const float* v = flat_vecs + vid * dim;
+            float dot = 0.0f;
+            for (int d = 0; d < dim; ++d) dot += v[d] * mean[d];
+            if (dot > best_dot) {
+                best_dot = dot;
+                best_vid = static_cast<int>(vid);
+            }
+        }
+        representative_vids[idx] = best_vid;
+    }
+
+    delete rep_hnsw_;
+    delete rep_space_;
+    rep_space_ = new hnswlib::InnerProductSpace(static_cast<uint64_t>(dim),
+                                                vsag::DataTypes::DATA_TYPE_FLOAT);
+    rep_hnsw_ = new hnswlib::HierarchicalNSW(
+        rep_space_, static_cast<uint64_t>(num_clusters_), allocator_, 16, 100);
+    rep_hnsw_->init_memory_space();
+
+    for (int64_t idx = 0; idx < num_clusters_; ++idx) {
+        rep_hnsw_->addPoint(flat_vecs + representative_vids[idx] * dim,
+                            static_cast<hnswlib::LabelType>(idx));
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Add
+// ─────────────────────────────────────────────────────────────────────────────
+
+std::vector<int64_t>
+SIMQ::Add(const DatasetPtr& /*data*/, AddMode /*mode*/) {
+    throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                        "simq: incremental Add is not supported; use Build");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Search helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+std::vector<std::pair<InnerIdType, float>>
+SIMQ::coarse_search(const float* query_tokens,
+                    uint32_t query_token_count,
+                    int64_t coarse_k) const {
+    // All buffers are local — safe for concurrent searches under shared_lock.
+    std::unordered_map<InnerIdType, float> score_map;
+    std::unordered_set<InnerIdType>        seen_this_token;
+
+    for (uint32_t ti = 0; ti < query_token_count; ++ti) {
+        const float* qt = query_tokens + ti * dim_;
+
+        auto result = rep_hnsw_->searchKnn(qt, static_cast<uint64_t>(coarse_k), 50);
+
+        std::vector<std::pair<float, InnerIdType>> cscores;
+        cscores.reserve(result.size());
+        while (!result.empty()) {
+            float cscore = 1.0f - result.top().first;
+            auto  cidx   = static_cast<InnerIdType>(result.top().second);
+            cscores.push_back({cscore, cidx});
+            result.pop();
+        }
+        std::sort(cscores.begin(), cscores.end(),
+                  [](const auto& a, const auto& b) { return a.first > b.first; });
+
+        seen_this_token.clear();
+        for (auto& [cscore, cidx] : cscores) {
+            if (cidx >= static_cast<InnerIdType>(num_clusters_)) continue;
+            uint64_t beg = cluster_offsets_[cidx];
+            uint64_t end = cluster_offsets_[cidx + 1];
+            for (uint64_t j = beg; j < end; ++j) {
+                InnerIdType doc_id = vec_to_doc_[cluster_data_[j]];
+                if (!seen_this_token.insert(doc_id).second) continue;
+                score_map[doc_id] += cscore;
+            }
+        }
+    }
+
+    std::vector<std::pair<InnerIdType, float>> ranked(score_map.begin(), score_map.end());
+    std::sort(ranked.begin(), ranked.end(),
+              [](const auto& a, const auto& b) { return a.second > b.second; });
+    return ranked;
+}
+
+float
+SIMQ::maxsim_score(const float* query_tokens,
+                   uint32_t query_token_count,
+                   InnerIdType doc_inner_id) const {
+    uint32_t doc_start = doc_offsets_[doc_inner_id];
+    uint32_t doc_count = doc_offsets_[doc_inner_id + 1] - doc_start;
+    if (doc_count == 0 || query_token_count == 0) return 0.0f;
+
+    static constexpr uint32_t kStackCap = 128;
+    InnerIdType idx_static[kStackCap];
+    float       dists_static[kStackCap];
+    Vector<InnerIdType> idx_heap(allocator_);
+    Vector<float>       dists_heap(allocator_);
+
+    InnerIdType* idx_ptr;
+    float*       dists_ptr;
+    if (doc_count <= kStackCap) {
+        idx_ptr   = idx_static;
+        dists_ptr = dists_static;
+    } else {
+        idx_heap.resize(doc_count);
+        dists_heap.resize(doc_count);
+        idx_ptr   = idx_heap.data();
+        dists_ptr = dists_heap.data();
+    }
+    std::iota(idx_ptr, idx_ptr + doc_count, doc_start);
+
+    float total = 0.0f;
+    for (uint32_t q = 0; q < query_token_count; ++q) {
+        auto computer = inner_codes_->FactoryComputer(query_tokens + q * dim_);
+        inner_codes_->Query(dists_ptr, computer, idx_ptr, doc_count);
+        total += *std::min_element(dists_ptr, dists_ptr + doc_count);
+    }
+    return total;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// KnnSearch
+// ─────────────────────────────────────────────────────────────────────────────
+
+DatasetPtr
+SIMQ::KnnSearch(const DatasetPtr& query,
+                int64_t k,
+                const std::string& parameters,
+                const FilterPtr& filter) const {
+    std::shared_lock lock(global_mutex_);
+
+    const MultiVector* query_mvs = query->GetMultiVectors();
+    CHECK_ARGUMENT(query_mvs != nullptr, "simq search: query.multi_vectors is nullptr");
+
+    const float* query_tokens      = query_mvs[0].vectors_;
+    uint32_t     query_token_count = query_mvs[0].len_;
+
+    auto sp = SIMQSearchParameters::FromJson(parameters);
+    int64_t coarse_k = sp.coarse_k > 0 ? sp.coarse_k : default_coarse_k_;
+    int64_t rerank_k = sp.rerank_k > 0 ? sp.rerank_k : default_rerank_k_;
+    rerank_k = std::min(rerank_k, static_cast<int64_t>(total_count_));
+    k        = std::min(k, static_cast<int64_t>(total_count_));
+
+    auto coarse_results = coarse_search(query_tokens, query_token_count, coarse_k);
+    if (static_cast<int64_t>(coarse_results.size()) > rerank_k)
+        coarse_results.resize(rerank_k);
+
+    std::vector<std::pair<float, InnerIdType>> reranked;
+    reranked.reserve(coarse_results.size());
+    for (auto& [doc_id, _] : coarse_results) {
+        if (filter != nullptr &&
+            !filter->CheckValid(this->label_table_->GetLabelById(doc_id)))
+            continue;
+        float score = maxsim_score(query_tokens, query_token_count, doc_id);
+        reranked.push_back({score, doc_id});
+    }
+    std::sort(reranked.begin(), reranked.end(),
+              [](const auto& a, const auto& b) { return a.first < b.first; });
+
+    int64_t result_count = std::min(k, static_cast<int64_t>(reranked.size()));
+    auto [result_ds, dists, ids] = create_fast_dataset(result_count, allocator_);
+    for (int64_t i = 0; i < result_count; ++i) {
+        dists[i] = reranked[i].first;
+        ids[i]   = this->label_table_->GetLabelById(reranked[i].second);
+    }
+    return std::move(result_ds);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// RangeSearch
+// ─────────────────────────────────────────────────────────────────────────────
+
+DatasetPtr
+SIMQ::RangeSearch(const DatasetPtr& query,
+                  float radius,
+                  const std::string& parameters,
+                  const FilterPtr& filter,
+                  int64_t limited_size) const {
+    std::shared_lock lock(global_mutex_);
+
+    const MultiVector* query_mvs = query->GetMultiVectors();
+    CHECK_ARGUMENT(query_mvs != nullptr, "simq range search: query.multi_vectors is nullptr");
+
+    const float* query_tokens      = query_mvs[0].vectors_;
+    uint32_t     query_token_count = query_mvs[0].len_;
+
+    auto sp = SIMQSearchParameters::FromJson(parameters);
+    int64_t coarse_k = sp.coarse_k > 0 ? sp.coarse_k : default_coarse_k_;
+    int64_t rerank_k = sp.rerank_k > 0 ? sp.rerank_k : default_rerank_k_;
+    rerank_k = std::min(rerank_k, static_cast<int64_t>(total_count_));
+
+    auto coarse_results = coarse_search(query_tokens, query_token_count, coarse_k);
+    if (static_cast<int64_t>(coarse_results.size()) > rerank_k)
+        coarse_results.resize(rerank_k);
+
+    std::vector<std::pair<float, InnerIdType>> in_range;
+    for (auto& [doc_id, _] : coarse_results) {
+        if (filter != nullptr &&
+            !filter->CheckValid(this->label_table_->GetLabelById(doc_id)))
+            continue;
+        float score = maxsim_score(query_tokens, query_token_count, doc_id);
+        if (score <= radius) {
+            in_range.push_back({score, doc_id});
+        }
+    }
+
+    if (limited_size >= 0 && static_cast<int64_t>(in_range.size()) > limited_size) {
+        std::nth_element(in_range.begin(),
+                         in_range.begin() + limited_size,
+                         in_range.end(),
+                         [](const auto& a, const auto& b) { return a.first < b.first; });
+        in_range.resize(limited_size);
+    }
+    std::sort(in_range.begin(), in_range.end(),
+              [](const auto& a, const auto& b) { return a.first < b.first; });
+
+    auto [result_ds, dists, ids] =
+        create_fast_dataset(static_cast<int64_t>(in_range.size()), allocator_);
+    for (uint64_t i = 0; i < in_range.size(); ++i) {
+        dists[i] = in_range[i].first;
+        ids[i]   = this->label_table_->GetLabelById(in_range[i].second);
+    }
+    return std::move(result_ds);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Serialize / Deserialize
+// ─────────────────────────────────────────────────────────────────────────────
+
+void
+SIMQ::serialize_rep_hnsw(StreamWriter& writer) const {
+    std::string bytes = save_hnsw_to_string(rep_hnsw_);
+    auto sz = static_cast<uint64_t>(bytes.size());
+    StreamWriter::WriteObj(writer, sz);
+    writer.Write(bytes.data(), sz);
+}
+
+void
+SIMQ::deserialize_rep_hnsw(StreamReader& reader) {
+    uint64_t sz{0};
+    StreamReader::ReadObj(reader, sz);
+    std::string bytes(sz, '\0');
+    reader.Read(bytes.data(), sz);
+
+    delete rep_hnsw_;
+    delete rep_space_;
+    rep_space_ = new hnswlib::InnerProductSpace(static_cast<uint64_t>(dim_),
+                                                vsag::DataTypes::DATA_TYPE_FLOAT);
+    rep_hnsw_ = load_hnsw_from_string(bytes, rep_space_, allocator_);
+}
+
+void
+SIMQ::Serialize(StreamWriter& writer) const {
+    StreamWriter::WriteObj(writer, total_count_);
+    StreamWriter::WriteObj(writer, total_vector_count_);
+    StreamWriter::WriteObj(writer, num_clusters_);
+
+    StreamWriter::WriteVector(writer, cluster_offsets_);
+    StreamWriter::WriteVector(writer, cluster_data_);
+
+    StreamWriter::WriteVector(writer, vec_to_doc_);
+    StreamWriter::WriteVector(writer, doc_offsets_);
+
+    serialize_rep_hnsw(writer);
+
+    inner_codes_->Serialize(writer);
+    this->label_table_->Serialize(writer);
+
+    JsonType info;
+    info["dim"].SetInt(dim_);
+    info["total_count"].SetInt(total_count_);
+    info["total_vector_count"].SetInt(total_vector_count_);
+    info[INDEX_PARAM].SetString(this->create_param_ptr_->ToString());
+    write_index_footer(writer, info);
+}
+
+void
+SIMQ::Deserialize(StreamReader& reader) {
+    std::unique_lock lock(global_mutex_);
+
+    JsonType info;
+    if (!read_index_footer(reader, info)) {
+        throw VsagException(ErrorType::READ_ERROR, "simq: failed to read index footer");
+    }
+
+    BufferStreamReader buf_reader(&reader, std::numeric_limits<uint64_t>::max(), allocator_);
+
+    dim_ = info["dim"].GetInt();
+
+    StreamReader::ReadObj(buf_reader, total_count_);
+    StreamReader::ReadObj(buf_reader, total_vector_count_);
+    StreamReader::ReadObj(buf_reader, num_clusters_);
+
+    StreamReader::ReadVector(buf_reader, cluster_offsets_);
+    StreamReader::ReadVector(buf_reader, cluster_data_);
+
+    StreamReader::ReadVector(buf_reader, vec_to_doc_);
+    StreamReader::ReadVector(buf_reader, doc_offsets_);
+
+    deserialize_rep_hnsw(buf_reader);
+
+    inner_codes_->Deserialize(buf_reader);
+    this->label_table_->Deserialize(buf_reader);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// InitFeatures
+// ─────────────────────────────────────────────────────────────────────────────
+
+void
+SIMQ::InitFeatures() {
+    auto name = inner_codes_->GetQuantizerName();
+    if (name != QUANTIZATION_TYPE_VALUE_FP32 && name != QUANTIZATION_TYPE_VALUE_BF16) {
+        index_feature_list_->SetFeature(IndexFeature::NEED_TRAIN);
+    }
+
+    index_feature_list_->SetFeatures({
+        IndexFeature::SUPPORT_BUILD,
+        IndexFeature::SUPPORT_KNN_SEARCH,
+        IndexFeature::SUPPORT_KNN_SEARCH_WITH_ID_FILTER,
+        IndexFeature::SUPPORT_RANGE_SEARCH,
+        IndexFeature::SUPPORT_RANGE_SEARCH_WITH_ID_FILTER,
+        IndexFeature::SUPPORT_DESERIALIZE_BINARY_SET,
+        IndexFeature::SUPPORT_DESERIALIZE_FILE,
+        IndexFeature::SUPPORT_DESERIALIZE_READER_SET,
+        IndexFeature::SUPPORT_SERIALIZE_BINARY_SET,
+        IndexFeature::SUPPORT_SERIALIZE_FILE,
+        IndexFeature::SUPPORT_SERIALIZE_WRITE_FUNC,
+        IndexFeature::SUPPORT_GET_MEMORY_USAGE,
+        IndexFeature::SUPPORT_ESTIMATE_MEMORY,
+        IndexFeature::SUPPORT_CHECK_ID_EXIST,
+        IndexFeature::SUPPORT_SEARCH_CONCURRENT,
+    });
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// External parameter mapping
+// ─────────────────────────────────────────────────────────────────────────────
+
+static const std::string SIMQ_PARAMS_TEMPLATE =
+    R"(
+    {
+        "{TYPE_KEY}": "{INDEX_SIMQ}",
+        "{BASE_CODES_KEY}": {
+            "{IO_PARAMS_KEY}": {
+                "{TYPE_KEY}": "{IO_TYPE_VALUE_MEMORY_IO}",
+                "{IO_FILE_PATH_KEY}": "{DEFAULT_FILE_PATH_VALUE}"
+            },
+            "{CODES_TYPE_KEY}": "flatten",
+            "{QUANTIZATION_PARAMS_KEY}": {
+                "{TYPE_KEY}": "{QUANTIZATION_TYPE_VALUE_FP32}"
+            }
+        }
+    })";
+
+ParamPtr
+SIMQ::CheckAndMappingExternalParam(const JsonType& external_param,
+                                   const IndexCommonParam& common_param) {
+    const ConstParamMap external_mapping = {
+        {BRUTE_FORCE_BASE_QUANTIZATION_TYPE,
+         {BASE_CODES_KEY, QUANTIZATION_PARAMS_KEY, TYPE_KEY}},
+        {BRUTE_FORCE_BASE_IO_TYPE, {BASE_CODES_KEY, IO_PARAMS_KEY, TYPE_KEY}},
+        {BRUTE_FORCE_BASE_FILE_PATH, {BASE_CODES_KEY, IO_PARAMS_KEY, IO_FILE_PATH_KEY}},
+        {"init_cluster_ratio", {"init_cluster_ratio"}},
+        {"max_cluster_size", {"max_cluster_size"}},
+        {"split_start_idx", {"split_start_idx"}},
+        {"random_seed", {"random_seed"}},
+        {"coarse_k", {"coarse_k"}},
+        {"rerank_k", {"rerank_k"}},
+    };
+
+    if (common_param.data_type_ == DataTypes::DATA_TYPE_INT8) {
+        throw VsagException(ErrorType::INVALID_ARGUMENT,
+                            fmt::format("simq does not support {} datatype", DATATYPE_INT8));
+    }
+    if (common_param.metric_ != MetricType::METRIC_TYPE_IP &&
+        common_param.metric_ != MetricType::METRIC_TYPE_COSINE) {
+        throw VsagException(ErrorType::INVALID_ARGUMENT,
+                            "simq only supports ip or cosine metric types");
+    }
+
+    std::string str = format_map(SIMQ_PARAMS_TEMPLATE, DEFAULT_MAP);
+    auto inner_json = JsonType::Parse(str);
+    mapping_external_param_to_inner(external_param, external_mapping, inner_json);
+
+    auto simq_param = std::make_shared<SIMQParameter>();
+    simq_param->FromJson(inner_json);
+    return simq_param;
+}
+
+}  // namespace vsag

--- a/src/algorithm/simq/simq.h
+++ b/src/algorithm/simq/simq.h
@@ -1,0 +1,143 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <shared_mutex>
+
+#include "algorithm/hnswlib/hnswlib.h"
+#include "algorithm/hnswlib/space_ip.h"
+#include "algorithm/inner_index_interface.h"
+#include "datacell/flatten_interface.h"
+#include "simq_parameter.h"
+#include "typing.h"
+#include "utils/pointer_define.h"
+
+namespace vsag {
+
+class SIMQ : public InnerIndexInterface {
+public:
+    static ParamPtr
+    CheckAndMappingExternalParam(const JsonType& external_param,
+                                 const IndexCommonParam& common_param);
+
+public:
+    explicit SIMQ(const SIMQParameterPtr& param, const IndexCommonParam& common_param);
+
+    explicit SIMQ(const ParamPtr& param, const IndexCommonParam& common_param)
+        : SIMQ(std::dynamic_pointer_cast<SIMQParameter>(param), common_param){};
+
+    ~SIMQ() override;
+
+    std::vector<int64_t>
+    Build(const DatasetPtr& data) override;
+
+    std::vector<int64_t>
+    Add(const DatasetPtr& data, AddMode mode = AddMode::DEFAULT) override;
+
+    DatasetPtr
+    KnnSearch(const DatasetPtr& query,
+              int64_t k,
+              const std::string& parameters,
+              const FilterPtr& filter) const override;
+
+    DatasetPtr
+    RangeSearch(const DatasetPtr& query,
+                float radius,
+                const std::string& parameters,
+                const FilterPtr& filter,
+                int64_t limited_size = -1) const override;
+
+    void
+    Serialize(StreamWriter& writer) const override;
+
+    void
+    Deserialize(StreamReader& reader) override;
+
+    IndexType
+    GetIndexType() const override {
+        return IndexType::SIMQ;
+    }
+
+    std::string
+    GetName() const override {
+        return INDEX_SIMQ;
+    }
+
+    int64_t
+    GetNumElements() const override {
+        return static_cast<int64_t>(total_count_);
+    }
+
+    void
+    InitFeatures() override;
+
+private:
+    void
+    run_clustering(const float* flat_vecs, int64_t num_vecs, int64_t dim);
+
+    void
+    build_rep_hnsw(const float* flat_vecs, int64_t dim);
+
+    std::vector<std::pair<InnerIdType, float>>
+    coarse_search(const float* query_tokens,
+                  uint32_t query_token_count,
+                  int64_t coarse_k) const;
+
+    float
+    maxsim_score(const float* query_tokens,
+                 uint32_t query_token_count,
+                 InnerIdType doc_inner_id) const;
+
+    void
+    serialize_rep_hnsw(StreamWriter& writer) const;
+
+    void
+    deserialize_rep_hnsw(StreamReader& reader);
+
+private:
+    hnswlib::InnerProductSpace* rep_space_{nullptr};
+    hnswlib::HierarchicalNSW* rep_hnsw_{nullptr};
+    int64_t num_clusters_{0};
+
+    // Flat inverted index: cluster i owns [cluster_offsets_[i], cluster_offsets_[i+1])
+    Vector<InnerIdType> cluster_offsets_;
+    Vector<InnerIdType> cluster_data_;
+
+    Vector<InnerIdType> vec_to_doc_;
+
+    FlattenInterfacePtr inner_codes_{nullptr};
+
+    // doc_offsets_[i] = start flat-vec index of doc i; doc_offsets_[i+1] = end (exclusive)
+    Vector<uint32_t> doc_offsets_;
+
+    uint64_t total_count_{0};
+    uint64_t total_vector_count_{0};
+
+    Vector<InnerIdType> vec_to_cluster_;
+
+    float   init_cluster_ratio_{0.2f};
+    int64_t max_cluster_size_{64};
+    int64_t split_start_idx_{32};
+    int64_t random_seed_{42};
+    int64_t default_coarse_k_{8};
+    int64_t default_rerank_k_{100};
+
+    uint64_t resize_increase_count_bit_{10};
+
+    mutable std::shared_mutex global_mutex_;
+};
+
+}  // namespace vsag

--- a/src/algorithm/simq/simq_parameter.cpp
+++ b/src/algorithm/simq/simq_parameter.cpp
@@ -1,0 +1,104 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "simq_parameter.h"
+
+#include <fmt/format.h>
+
+#include "inner_string_params.h"
+#include "utils/param_compat_macros.h"
+#include "vsag/constants.h"
+
+namespace vsag {
+
+static constexpr const char* SIMQ_INIT_CLUSTER_RATIO = "init_cluster_ratio";
+static constexpr const char* SIMQ_MAX_CLUSTER_SIZE    = "max_cluster_size";
+static constexpr const char* SIMQ_SPLIT_START_IDX     = "split_start_idx";
+static constexpr const char* SIMQ_RANDOM_SEED         = "random_seed";
+static constexpr const char* SIMQ_COARSE_K            = "coarse_k";
+static constexpr const char* SIMQ_RERANK_K            = "rerank_k";
+
+void
+SIMQParameter::FromJson(const JsonType& json) {
+    InnerIndexParameter::FromJson(json);
+
+    if (json.Contains(SIMQ_INIT_CLUSTER_RATIO))
+        init_cluster_ratio = json[SIMQ_INIT_CLUSTER_RATIO].GetFloat();
+    if (json.Contains(SIMQ_MAX_CLUSTER_SIZE))
+        max_cluster_size = json[SIMQ_MAX_CLUSTER_SIZE].GetInt();
+    if (json.Contains(SIMQ_SPLIT_START_IDX))
+        split_start_idx = json[SIMQ_SPLIT_START_IDX].GetInt();
+    if (json.Contains(SIMQ_RANDOM_SEED))
+        random_seed = json[SIMQ_RANDOM_SEED].GetInt();
+    if (json.Contains(SIMQ_COARSE_K))
+        coarse_k = json[SIMQ_COARSE_K].GetInt();
+    if (json.Contains(SIMQ_RERANK_K))
+        rerank_k = json[SIMQ_RERANK_K].GetInt();
+
+    CHECK_ARGUMENT(init_cluster_ratio > 0.0f && init_cluster_ratio <= 1.0f,
+                   "simq: init_cluster_ratio must be in (0, 1]");
+    CHECK_ARGUMENT(max_cluster_size > 1, "simq: max_cluster_size must be > 1");
+    CHECK_ARGUMENT(split_start_idx > 0 && split_start_idx < max_cluster_size,
+                   "simq: split_start_idx must be in (0, max_cluster_size)");
+
+    CHECK_ARGUMENT(json.Contains(BASE_CODES_KEY),
+                   fmt::format("simq parameters must contain {}", BASE_CODES_KEY));
+    base_codes_param = CreateFlattenParam(json[BASE_CODES_KEY]);
+}
+
+JsonType
+SIMQParameter::ToJson() const {
+    JsonType json = InnerIndexParameter::ToJson();
+    json[TYPE_KEY].SetString(INDEX_SIMQ);
+    json[SIMQ_INIT_CLUSTER_RATIO].SetFloat(init_cluster_ratio);
+    json[SIMQ_MAX_CLUSTER_SIZE].SetInt(max_cluster_size);
+    json[SIMQ_SPLIT_START_IDX].SetInt(split_start_idx);
+    json[SIMQ_RANDOM_SEED].SetInt(random_seed);
+    json[SIMQ_COARSE_K].SetInt(coarse_k);
+    json[SIMQ_RERANK_K].SetInt(rerank_k);
+    json[BASE_CODES_KEY].SetJson(base_codes_param->ToJson());
+    return json;
+}
+
+bool
+SIMQParameter::CheckCompatibility(const vsag::ParamPtr& other) const {
+    if (not InnerIndexParameter::CheckCompatibility(other)) {
+        return false;
+    }
+    PARAM_CAST_OR_RETURN(SIMQParameter, p, other);
+    CHECK_SUB_PARAM(*this, *p, base_codes_param);
+    return true;
+}
+
+SIMQSearchParameters
+SIMQSearchParameters::FromJson(const std::string& json_string) {
+    SIMQSearchParameters obj;
+    if (json_string.empty()) {
+        return obj;
+    }
+    auto params = JsonType::Parse(json_string);
+    if (!params.Contains(INDEX_SIMQ)) {
+        return obj;
+    }
+    const auto& simq_params = params[INDEX_SIMQ];
+    obj.IndexSearchParameter::FromJson(simq_params);
+    if (simq_params.Contains(SIMQ_COARSE_K))
+        obj.coarse_k = simq_params[SIMQ_COARSE_K].GetInt();
+    if (simq_params.Contains(SIMQ_RERANK_K))
+        obj.rerank_k = simq_params[SIMQ_RERANK_K].GetInt();
+    return obj;
+}
+
+}  // namespace vsag

--- a/src/algorithm/simq/simq_parameter.h
+++ b/src/algorithm/simq/simq_parameter.h
@@ -1,0 +1,63 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "algorithm/index_search_parameter.h"
+#include "algorithm/inner_index_parameter.h"
+#include "datacell/flatten_interface_parameter.h"
+#include "typing.h"
+#include "utils/pointer_define.h"
+
+namespace vsag {
+
+class SIMQParameter : public InnerIndexParameter {
+public:
+    void
+    FromJson(const JsonType& json) override;
+
+    JsonType
+    ToJson() const override;
+
+    bool
+    CheckCompatibility(const vsag::ParamPtr& other) const override;
+
+public:
+    // Clustering construction parameters
+    float   init_cluster_ratio{0.2f};  // fraction of vectors used as initial seeds
+    int64_t max_cluster_size{64};      // split threshold
+    int64_t split_start_idx{32};       // index within sorted cluster where new cluster begins
+    int64_t random_seed{42};
+
+    // Search parameters (index-level defaults, overridable per-query)
+    int64_t coarse_k{8};    // clusters searched per query token
+    int64_t rerank_k{100};  // docs reranked with exact MaxSim
+
+    // Storage for doc token vectors (used during MaxSim rerank)
+    FlattenInterfaceParamPtr base_codes_param{nullptr};
+};
+
+DEFINE_POINTER(SIMQParameter);
+
+class SIMQSearchParameters : public IndexSearchParameter {
+public:
+    int64_t coarse_k{-1};   // -1 means use index default
+    int64_t rerank_k{-1};   // -1 means use index default
+
+    static SIMQSearchParameters
+    FromJson(const std::string& json_string);
+};
+
+}  // namespace vsag

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -30,6 +30,7 @@ const char* const INDEX_BRUTE_FORCE = "brute_force";
 const char* const INDEX_IVF = "ivf";
 const char* const INDEX_GNO_IMI = "gno_imi";
 const char* const INDEX_WARP = "warp";
+const char* const INDEX_SIMQ = "simq";
 
 const char* const DIM = "dim";
 const char* const NUM_ELEMENTS = "num_elements";

--- a/src/factory/index_creators.cpp
+++ b/src/factory/index_creators.cpp
@@ -26,6 +26,7 @@
 #include "algorithm/pyramid/pyramid_zparameters.h"
 #include "algorithm/sindi/sindi.h"
 #include "algorithm/sparse_index/sparse_index.h"
+#include "algorithm/simq/simq.h"
 #include "algorithm/warp/warp.h"
 #include "common.h"
 #include "index/diskann.h"
@@ -149,6 +150,12 @@ create_warp_index(JsonType& parsed_params, const IndexCommonParam& index_common_
         "created a warp index", parsed_params, index_common_params);
 }
 
+tl::expected<std::shared_ptr<Index>, Error>
+create_simq_index(JsonType& parsed_params, const IndexCommonParam& index_common_params) {
+    return create_index_impl_with_param_log<SIMQ>(
+        "created a simq index", parsed_params, index_common_params);
+}
+
 }  // namespace
 
 void
@@ -166,6 +173,7 @@ register_all_index_creators() {
         register_index_creator(INDEX_SPARSE, &create_sparse_index);
         register_index_creator(INDEX_SINDI, &create_sindi_index);
         register_index_creator(INDEX_WARP, &create_warp_index);
+        register_index_creator(INDEX_SIMQ, &create_simq_index);
     });
 }
 

--- a/tests/test_simq.cpp
+++ b/tests/test_simq.cpp
@@ -1,0 +1,412 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * SIMQ functional test
+ *
+ * Dataset:
+ *   - 1000 documents, each with 8 token vectors of dim 128 (8000 token vecs total)
+ *   - 100 query documents, each with 4 token vectors
+ *   - metric: inner product (ip)
+ *
+ * Search design (ColBERT-style two-phase retrieval):
+ *   Phase 1 (coarse): each query token searches the cluster-center HNSW for
+ *   coarse_k nearest cluster centers; their member docs form the candidate set.
+ *   Phase 2 (rerank): exact MaxSim over the top-rerank_k candidates.
+ *
+ * Build parameters:
+ *   - init_cluster_ratio = 0.01 → ~80 clusters for 8000 token vecs  (≈ sqrt(N))
+ *   - max_cluster_size   = 200  → split threshold
+ *   - split_start_idx    = 100  → new cluster starts at position 100 in sorted cluster
+ *   - coarse_k           = 10   → each query token probes 10 cluster centers
+ *   - rerank_k           = 1000 → exact MaxSim rerank over top-1000 candidates
+ *
+ * Tests:
+ *   1. Build + KNN search + recall@10
+ *   2. Serialize / Deserialize (binary set) + recall preserved
+ *   3. Parameter sweep: coarse_k in {5, 10, 20}
+ */
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <iostream>
+#include <random>
+#include <unordered_set>
+#include <vector>
+
+#include <fmt/format.h>
+
+#include "framework/test_dataset.h"
+#include "framework/test_dataset_pool.h"
+#include "test_index.h"
+#include "vsag/dataset.h"
+#include "vsag/index.h"
+#include "vsag/vsag.h"
+
+using namespace vsag;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+static constexpr int64_t  SIMQ_DIM         = 128;   // token vector dimension
+static constexpr uint64_t BASE_DOCS   = 1000;  // documents to index
+static constexpr uint64_t QUERY_DOCS  = 100;   // query documents
+static constexpr int      DOC_TOKENS  = 8;     // tokens per base document
+static constexpr int      QUERY_TOKENS = 4;    // tokens per query document
+static constexpr int      TOP_K       = 10;
+
+static std::string
+make_build_param(float init_cluster_ratio   = 0.01f,  // ~80 clusters for 8000 token vecs
+                 int64_t max_cluster_size   = 200,
+                 int64_t split_start_idx    = 100,
+                 int64_t coarse_k           = 20,
+                 int64_t rerank_k           = 1000) {
+    return fmt::format(
+        R"({{
+            "dtype": "float32",
+            "metric_type": "ip",
+            "dim": {},
+            "index_param": {{
+                "base_quantization_type": "fp32",
+                "base_io_type": "memory_io",
+                "init_cluster_ratio": {},
+                "max_cluster_size": {},
+                "split_start_idx": {},
+                "coarse_k": {},
+                "rerank_k": {}
+            }}
+        }})",
+        SIMQ_DIM, init_cluster_ratio, max_cluster_size, split_start_idx, coarse_k, rerank_k);
+}
+
+static std::string
+make_search_param(int64_t coarse_k = 10, int64_t rerank_k = 1000) {
+    return fmt::format(
+        R"({{"simq": {{"coarse_k": {}, "rerank_k": {}}}}})",
+        coarse_k, rerank_k);
+}
+
+// Generate normalized random vectors (unit sphere for IP metric)
+static void
+fill_normalized(float* buf, int64_t n, int64_t dim, std::mt19937& rng) {
+    std::normal_distribution<float> nd(0.0f, 1.0f);
+    for (int64_t i = 0; i < n; ++i) {
+        float* v = buf + i * dim;
+        float  norm = 0.0f;
+        for (int64_t d = 0; d < dim; ++d) {
+            v[d] = nd(rng);
+            norm += v[d] * v[d];
+        }
+        norm = std::sqrt(norm) + 1e-9f;
+        for (int64_t d = 0; d < dim; ++d) v[d] /= norm;
+    }
+}
+
+// MaxSim score: sum over query tokens of max IP over doc tokens
+static float
+maxsim(const float* q_toks, int nq, const float* d_toks, int nd, int64_t dim) {
+    float score = 0.0f;
+    for (int qi = 0; qi < nq; ++qi) {
+        float best = -1e30f;
+        for (int di = 0; di < nd; ++di) {
+            float dot = 0.0f;
+            for (int64_t d = 0; d < dim; ++d)
+                dot += q_toks[qi * dim + d] * d_toks[di * dim + d];
+            if (dot > best) best = dot;
+        }
+        score += best;
+    }
+    return score;
+}
+
+struct MultiVectorDataset {
+    // base: BASE_DOCS documents × DOC_TOKENS tokens × SIMQ_DIM floats
+    std::vector<float> base_storage;
+    std::vector<vsag::MultiVector> base_mvs;
+    std::vector<int64_t> base_ids;
+
+    // query: QUERY_DOCS documents × QUERY_TOKENS tokens × SIMQ_DIM floats
+    std::vector<float> query_storage;
+    std::vector<vsag::MultiVector> query_mvs;
+
+    // ground truth: for each query, sorted list of (doc_id, score)
+    // gt_ids[q][k] = k-th nearest doc_id for query q
+    std::vector<std::vector<int64_t>> gt_ids;
+    std::vector<std::vector<float>> gt_scores;
+
+    vsag::DatasetPtr base_dataset;
+    vsag::DatasetPtr query_dataset;
+};
+
+static MultiVectorDataset
+generate_dataset(uint64_t seed = 42) {
+    MultiVectorDataset ds;
+    std::mt19937 rng(seed);
+
+    // ── Base documents ────────────────────────────────────────────────────
+    ds.base_storage.resize(BASE_DOCS * DOC_TOKENS * SIMQ_DIM);
+    fill_normalized(ds.base_storage.data(), BASE_DOCS * DOC_TOKENS, SIMQ_DIM, rng);
+
+    ds.base_mvs.resize(BASE_DOCS);
+    ds.base_ids.resize(BASE_DOCS);
+    for (uint64_t i = 0; i < BASE_DOCS; ++i) {
+        ds.base_mvs[i].len_     = DOC_TOKENS;
+        ds.base_mvs[i].vectors_ = ds.base_storage.data() + i * DOC_TOKENS * SIMQ_DIM;
+        ds.base_ids[i]          = static_cast<int64_t>(i);
+    }
+
+    // ── Query documents ───────────────────────────────────────────────────
+    ds.query_storage.resize(QUERY_DOCS * QUERY_TOKENS * SIMQ_DIM);
+    fill_normalized(ds.query_storage.data(), QUERY_DOCS * QUERY_TOKENS, SIMQ_DIM, rng);
+
+    ds.query_mvs.resize(QUERY_DOCS);
+    for (uint64_t q = 0; q < QUERY_DOCS; ++q) {
+        ds.query_mvs[q].len_     = QUERY_TOKENS;
+        ds.query_mvs[q].vectors_ = ds.query_storage.data() + q * QUERY_TOKENS * SIMQ_DIM;
+    }
+
+    // ── Ground truth (exact MaxSim brute-force) ───────────────────────────
+    ds.gt_ids.resize(QUERY_DOCS);
+    ds.gt_scores.resize(QUERY_DOCS);
+    for (uint64_t q = 0; q < QUERY_DOCS; ++q) {
+        const float* qtoks = ds.query_mvs[q].vectors_;
+        std::vector<std::pair<float, int64_t>> scores(BASE_DOCS);
+        for (uint64_t d = 0; d < BASE_DOCS; ++d) {
+            float s = maxsim(qtoks, QUERY_TOKENS,
+                             ds.base_mvs[d].vectors_, DOC_TOKENS, SIMQ_DIM);
+            scores[d] = {s, static_cast<int64_t>(d)};
+        }
+        std::sort(scores.begin(), scores.end(),
+                  [](const auto& a, const auto& b) { return a.first > b.first; });
+        ds.gt_ids[q].resize(TOP_K);
+        ds.gt_scores[q].resize(TOP_K);
+        for (int k = 0; k < TOP_K; ++k) {
+            ds.gt_ids[q][k]    = scores[k].second;
+            ds.gt_scores[q][k] = scores[k].first;
+        }
+    }
+
+    // ── VSAG Dataset wrappers ─────────────────────────────────────────────
+    ds.base_dataset = vsag::Dataset::Make();
+    ds.base_dataset
+        ->NumElements(static_cast<int64_t>(BASE_DOCS))
+        ->Dim(SIMQ_DIM)
+        ->Ids(ds.base_ids.data())
+        ->MultiVectors(ds.base_mvs.data())
+        ->MultiVectorDim(SIMQ_DIM)
+        ->Owner(false);
+
+    ds.query_dataset = vsag::Dataset::Make();
+    ds.query_dataset
+        ->NumElements(static_cast<int64_t>(QUERY_DOCS))
+        ->Dim(SIMQ_DIM)
+        ->MultiVectors(ds.query_mvs.data())
+        ->MultiVectorDim(SIMQ_DIM)
+        ->Owner(false);
+
+    return ds;
+}
+
+// Compute recall@TOP_K between returned ids and ground-truth ids for one query
+static float
+recall_at_k(const int64_t* returned, int64_t n_returned,
+            const int64_t* gt, int64_t n_gt) {
+    std::unordered_set<int64_t> gt_set(gt, gt + n_gt);
+    int64_t hits = 0;
+    for (int64_t i = 0; i < n_returned; ++i)
+        if (gt_set.count(returned[i])) ++hits;
+    return static_cast<float>(hits) / static_cast<float>(n_gt);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test cases
+// ─────────────────────────────────────────────────────────────────────────────
+
+TEST_CASE("SIMQ: dataset generation stats", "[simq][dataset]") {
+    auto ds = generate_dataset();
+    INFO("Base docs    : " << BASE_DOCS);
+    INFO("Doc tokens   : " << DOC_TOKENS);
+    INFO("Total tokens : " << BASE_DOCS * DOC_TOKENS);
+    INFO("Query docs   : " << QUERY_DOCS);
+    INFO("Query tokens : " << QUERY_TOKENS);
+    INFO("Dim          : " << SIMQ_DIM);
+
+    REQUIRE(ds.base_mvs.size() == BASE_DOCS);
+    REQUIRE(ds.query_mvs.size() == QUERY_DOCS);
+    REQUIRE(ds.gt_ids.size() == QUERY_DOCS);
+    REQUIRE(ds.gt_ids[0].size() == static_cast<size_t>(TOP_K));
+
+    // Spot-check: ground-truth scores should be descending
+    for (uint64_t q = 0; q < QUERY_DOCS; ++q) {
+        for (int k = 1; k < TOP_K; ++k) {
+            REQUIRE(ds.gt_scores[q][k - 1] >= ds.gt_scores[q][k] - 1e-5f);
+        }
+    }
+    SUCCEED("Dataset generated and ground truth looks sane.");
+}
+
+TEST_CASE("SIMQ: build and knn search recall", "[simq][build][search]") {
+    auto ds = generate_dataset();
+
+    // ~80 clusters (sqrt(8000)); coarse_k=10 per token → 4×10=40 probes / 80 = 50% coverage
+    auto build_param  = make_build_param();
+    auto search_param = make_search_param();
+
+    // Create index
+    auto result = vsag::Factory::CreateIndex("simq", build_param);
+    REQUIRE(result.has_value());
+    auto index = result.value();
+    REQUIRE(index->GetIndexType() == vsag::IndexType::SIMQ);
+
+    // Build
+    auto build_result = index->Build(ds.base_dataset);
+    REQUIRE(build_result.has_value());
+    REQUIRE(index->GetNumElements() == static_cast<int64_t>(BASE_DOCS));
+
+    // KNN search
+    float total_recall = 0.0f;
+    for (uint64_t q = 0; q < QUERY_DOCS; ++q) {
+        vsag::DatasetPtr one_query = vsag::Dataset::Make();
+        one_query
+            ->NumElements(1)
+            ->Dim(SIMQ_DIM)
+            ->MultiVectors(&ds.query_mvs[q])
+            ->MultiVectorDim(SIMQ_DIM)
+            ->Owner(false);
+
+        auto search_result = index->KnnSearch(one_query, TOP_K, search_param, vsag::FilterPtr(nullptr));
+        REQUIRE(search_result.has_value());
+
+        auto* ret_ids = search_result.value()->GetIds();
+        float r = recall_at_k(ret_ids, TOP_K,
+                               ds.gt_ids[q].data(), static_cast<int64_t>(TOP_K));
+        total_recall += r;
+    }
+
+    float mean_recall = total_recall / static_cast<float>(QUERY_DOCS);
+    std::cout << "\n[SIMQ] Mean Recall@" << TOP_K << " = " << mean_recall
+              << "  (over " << QUERY_DOCS << " queries)\n";
+
+    // SIMQ is an approximate method; 0.5 is a sanity floor for this small dataset
+    REQUIRE(mean_recall >= 0.5f);
+    SUCCEED("Build and search completed.");
+}
+
+TEST_CASE("SIMQ: serialize and deserialize preserves recall", "[simq][serialization]") {
+    auto ds = generate_dataset();
+
+    auto build_param  = make_build_param();
+    auto search_param = make_search_param();
+
+    auto r1 = vsag::Factory::CreateIndex("simq", build_param);
+    REQUIRE(r1.has_value());
+    auto index = r1.value();
+    auto build_result = index->Build(ds.base_dataset);
+    REQUIRE(build_result.has_value());
+
+    // Serialize
+    auto serial = index->Serialize();
+    REQUIRE(serial.has_value());
+
+    // Deserialize into fresh index
+    auto r2 = vsag::Factory::CreateIndex("simq", build_param);
+    REQUIRE(r2.has_value());
+    auto index2 = r2.value();
+    auto deser = index2->Deserialize(serial.value());
+    REQUIRE(deser.has_value());
+    REQUIRE(index2->GetNumElements() == static_cast<int64_t>(BASE_DOCS));
+
+    // Compare recall between original and deserialized index
+    float recall_orig = 0.0f, recall_deser = 0.0f;
+    for (uint64_t q = 0; q < QUERY_DOCS; ++q) {
+        vsag::DatasetPtr one_query = vsag::Dataset::Make();
+        one_query
+            ->NumElements(1)
+            ->Dim(SIMQ_DIM)
+            ->MultiVectors(&ds.query_mvs[q])
+            ->MultiVectorDim(SIMQ_DIM)
+            ->Owner(false);
+
+        auto sr1 = index->KnnSearch(one_query, TOP_K, search_param, vsag::FilterPtr(nullptr));
+        auto sr2 = index2->KnnSearch(one_query, TOP_K, search_param, vsag::FilterPtr(nullptr));
+        REQUIRE(sr1.has_value());
+        REQUIRE(sr2.has_value());
+
+        recall_orig  += recall_at_k(sr1.value()->GetIds(), TOP_K,
+                                    ds.gt_ids[q].data(), TOP_K);
+        recall_deser += recall_at_k(sr2.value()->GetIds(), TOP_K,
+                                    ds.gt_ids[q].data(), TOP_K);
+    }
+    recall_orig  /= static_cast<float>(QUERY_DOCS);
+    recall_deser /= static_cast<float>(QUERY_DOCS);
+
+    std::cout << "\n[SIMQ Serialize] Original recall@" << TOP_K << " = " << recall_orig
+              << "  Deserialized recall@" << TOP_K << " = " << recall_deser << "\n";
+
+    // Deserialized index should produce identical results
+    REQUIRE(std::abs(recall_orig - recall_deser) < 0.01f);
+    SUCCEED("Serialize/deserialize recall matches.");
+}
+
+TEST_CASE("SIMQ: parameter sweep on coarse_k and rerank_k", "[simq][sweep]") {
+    auto ds = generate_dataset();
+
+    // ~80 clusters; each query token probes coarse_k centers; 4 tokens total
+    auto build_param = make_build_param();
+
+    auto r = vsag::Factory::CreateIndex("simq", build_param);
+    REQUIRE(r.has_value());
+    auto index = r.value();
+    auto build_result = index->Build(ds.base_dataset);
+    REQUIRE(build_result.has_value());
+
+    struct Combo { int64_t ck; int64_t rk; float floor; };
+    // coarse_k=5  → 4×5=20/80 = 25% cluster coverage → modest recall
+    // coarse_k=10 → 4×10=40/80 = 50% cluster coverage → good recall
+    // coarse_k=20 → 4×20=80/80 = 100% cluster coverage → near-perfect
+    std::vector<Combo> combos = {
+        {5,  1000, 0.3f},
+        {10, 1000, 0.5f},
+        {20, 1000, 0.7f},
+    };
+
+    std::cout << "\n[SIMQ Sweep] coarse_k / rerank_k → Recall@" << TOP_K << "\n";
+    for (auto& c : combos) {
+        auto sp = make_search_param(c.ck, c.rk);
+        float total = 0.0f;
+        for (uint64_t q = 0; q < QUERY_DOCS; ++q) {
+            vsag::DatasetPtr one_query = vsag::Dataset::Make();
+            one_query
+                ->NumElements(1)
+                ->Dim(SIMQ_DIM)
+                ->MultiVectors(&ds.query_mvs[q])
+                ->MultiVectorDim(SIMQ_DIM)
+                ->Owner(false);
+
+            auto sr = index->KnnSearch(one_query, TOP_K, sp, vsag::FilterPtr(nullptr));
+            REQUIRE(sr.has_value());
+            total += recall_at_k(sr.value()->GetIds(), TOP_K,
+                                 ds.gt_ids[q].data(), TOP_K);
+        }
+        float recall = total / static_cast<float>(QUERY_DOCS);
+        std::cout << "  coarse_k=" << c.ck << " rerank_k=" << c.rk
+                  << "  recall=" << recall << "\n";
+        REQUIRE(recall >= c.floor);
+    }
+}


### PR DESCRIPTION
## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Improvement/Refactor
- [ ] Documentation
- [ ] CI/Build/Infra

## Linked Issue

(none — self-contained new feature, no prior issue)

## What Changed

- Add SIMQ index type for ColBERT-style multi-vector (MaxSim) retrieval
- Two-phase search: per-query-token HNSW coarse lookup over cluster centers, then exact MaxSim rerank over top candidates
- Dynamic clustering with online split via `HNSWDynamicClustering`
- Full serialize/deserialize support via binary stream
- Register `"simq"` in Factory; add `IndexType::SIMQ` and `INDEX_SIMQ` constant

## Test Evidence

- [ ] `make fmt`
- [ ] `make lint`
- [x] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [ ] Other (describe below)

Test details:

```text
./build/tests/functests "[simq]"

[SIMQ] Mean Recall@10 = 0.997  (over 100 queries)
[SIMQ Serialize] Original recall@10 = 0.997  Deserialized recall@10 = 0.997
[SIMQ Sweep] coarse_k / rerank_k → Recall@10
  coarse_k=5  rerank_k=1000  recall=0.903
  coarse_k=10 rerank_k=1000  recall=0.997
  coarse_k=20 rerank_k=1000  recall=1.000
All tests passed (1524 assertions in 4 test cases)