### PR TITLE
feat(pyramid): implement multi-hierarchy Build/Add/Search

### DIFF
--- a/src/algorithm/pyramid/pyramid.cpp
+++ b/src/algorithm/pyramid/pyramid.cpp
@@ -210,8 +210,6 @@ IndexNode::Search(const SearchFunc& search_func,
 
 std::vector<int64_t>
 Pyramid::build_by_odescent(const DatasetPtr& base) {
-    const auto* path = base->GetPaths();
-    CHECK_ARGUMENT(path != nullptr, "path is required");
     int64_t data_num = base->GetNumElements();
     const auto* data_vectors = base->GetFloat32Vectors();
     const auto* data_ids = base->GetIds();
@@ -226,7 +224,9 @@ Pyramid::build_by_odescent(const DatasetPtr& base) {
     auto codes = use_reorder_ ? precise_codes_ : base_codes_;
 
     ODescent graph_builder(odescent_param_, codes, allocator_, this->thread_pool_.get());
-    root_->Build(graph_builder);
+    for (auto& [hname, h_ptr] : hierarchies_) {
+        h_ptr->root->Build(graph_builder);
+    }
     cur_element_count_ = data_num;
     return {};
 }
@@ -241,8 +241,8 @@ Pyramid::KnnSearch(const DatasetPtr& query,
 
     auto parsed_param = PyramidSearchParameters::FromJson(parameters);
     CHECK_ARGUMENT(k > 0, fmt::format("k({}) must be greater than 0", k));
-    CHECK_ARGUMENT(not parsed_param.HasHierarchySelector(),
-                   "pyramid named hierarchy search is reserved but not implemented");
+    CHECK_ARGUMENT(parsed_param.hierarchy_op == PyramidSearchParameters::HierarchyOp::SINGLE,
+                   "multi-hierarchy search (union/intersection) is not yet implemented");
     auto ef_search_threshold = std::max<uint64_t>(AMPLIFICATION_FACTOR * k, 1000L);
     CHECK_ARGUMENT(  // NOLINT
         (1 <= parsed_param.ef_search) and (parsed_param.ef_search <= ef_search_threshold),
@@ -270,7 +270,9 @@ Pyramid::KnnSearch(const DatasetPtr& query,
             node, vl, search_param, query, base_codes_, ctx, parsed_param.subindex_ef_search);
     };
 
-    auto result = this->search_impl(query, search_func, search_param);
+    std::string hierarchy_name =
+        parsed_param.hierarchies.empty() ? "" : parsed_param.hierarchies[0];
+    auto result = this->search_impl(query, search_func, search_param, hierarchy_name);
     result->Statistics(stats.Dump());
     return result;
 }
@@ -287,8 +289,8 @@ Pyramid::RangeSearch(const DatasetPtr& query,
     QueryContext ctx{.stats = &stats};
 
     auto parsed_param = PyramidSearchParameters::FromJson(parameters);
-    CHECK_ARGUMENT(not parsed_param.HasHierarchySelector(),
-                   "pyramid named hierarchy search is reserved but not implemented");
+    CHECK_ARGUMENT(parsed_param.hierarchy_op == PyramidSearchParameters::HierarchyOp::SINGLE,
+                   "multi-hierarchy search (union/intersection) is not yet implemented");
     InnerSearchParam search_param;
     search_param.ef = parsed_param.ef_search;
     search_param.radius = radius * RADIUS_EPSILON;
@@ -311,7 +313,9 @@ Pyramid::RangeSearch(const DatasetPtr& query,
             node, vl, search_param, query, base_codes_, ctx, parsed_param.subindex_ef_search);
     };
 
-    auto result = this->search_impl(query, search_func, search_param);
+    std::string hierarchy_name =
+        parsed_param.hierarchies.empty() ? "" : parsed_param.hierarchies[0];
+    auto result = this->search_impl(query, search_func, search_param, hierarchy_name);
     result->Statistics(stats.Dump());
     return result;
 }
@@ -319,14 +323,22 @@ Pyramid::RangeSearch(const DatasetPtr& query,
 DatasetPtr
 Pyramid::search_impl(const DatasetPtr& query,
                      const SearchFunc& search_func,
-                     InnerSearchParam& search_param) const {
+                     InnerSearchParam& search_param,
+                     const std::string& hierarchy_name) const {
     SearchStatistics stats;
     QueryContext ctx{.stats = &stats};
 
-    const auto* query_path = query->GetPaths();
-    CHECK_ARGUMENT(  // NOLINT
-        query_path != nullptr || root_->status_ != IndexNode::Status::NO_INDEX,
-        "query_path is required when level0 is not built");
+    auto h_iter = hierarchies_.find(hierarchy_name);
+    CHECK_ARGUMENT(h_iter != hierarchies_.end(),
+                   fmt::format("unknown hierarchy name: '{}'", hierarchy_name));
+    const auto& h = *h_iter->second;
+
+    const auto* query_path = query->GetPaths(hierarchy_name);
+    if (query_path == nullptr) {
+        query_path = query->GetPaths();
+    }
+    CHECK_ARGUMENT(query_path != nullptr || h.root->status_ != IndexNode::Status::NO_INDEX,
+                   "query_path is required when level0 is not built");
     CHECK_ARGUMENT(query->GetFloat32Vectors() != nullptr, "query vectors is required");
 
     DistHeapPtr search_result = std::make_shared<StandardHeap<true, false>>(allocator_, -1);
@@ -334,47 +346,10 @@ Pyramid::search_impl(const DatasetPtr& query,
     std::shared_lock<std::shared_mutex> lock(resize_mutex_);
     auto vl = pool_->TakeOne();
     if (query_path != nullptr) {
-        std::vector<std::future<void>> futures;
         const std::string& current_path = query_path[0];
-        auto parsed_path = parse_path(current_path);
-        Vector<DistHeapPtr> search_result_lists(parsed_path.size(), allocator_);
-        for (uint32_t i = 0; i < parsed_path.size(); ++i) {
-            const auto& one_path = parsed_path[i];
-            search_result_lists[i] = std::make_shared<StandardHeap<true, false>>(allocator_, -1);
-            IndexNode* node = root_.get();
-            bool valid = true;
-            for (const auto& item : one_path) {
-                node = node->GetChild(item, false);
-                if (node == nullptr) {
-                    valid = false;
-                    break;
-                }
-            }
-            if (valid) {
-                if (thread_pool_ != nullptr && search_param.parallel_search_thread_count > 1) {
-                    futures.push_back(thread_pool_->GeneralEnqueue([&, node, i]() -> void {
-                        node->Search(search_func, vl, search_result_lists[i], search_param.ef);
-                    }));
-                } else {
-                    node->Search(search_func, vl, search_result_lists[i], search_param.ef);
-                }
-            }
-        }
-
-        for (auto& future : futures) {
-            future.get();
-        }
-
-        for (uint32_t i = 0; i < search_result_lists.size(); ++i) {
-            if (i != 0) {
-                search_result->Merge(*search_result_lists[i]);
-            } else {
-                search_result = search_result_lists[i];
-            }
-        }
-
+        search_hierarchy(h, search_func, vl, search_result, current_path, search_param);
     } else {
-        root_->Search(search_func, vl, search_result, search_param.ef);
+        h.root->Search(search_func, vl, search_result, search_param.ef);
     }
     pool_->ReturnOne(vl);
 
@@ -425,7 +400,16 @@ Pyramid::Serialize(StreamWriter& writer) const {
     if (use_reorder_) {
         precise_codes_->Serialize(writer);
     }
-    root_->Serialize(writer);
+
+    auto pyramid_param = std::dynamic_pointer_cast<PyramidParameters>(create_param_ptr_);
+    if (pyramid_param && pyramid_param->has_hierarchies) {
+        for (const auto& [hname, h_ptr] : hierarchies_) {
+            StreamWriter::WriteString(writer, hname);
+            h_ptr->root->Serialize(writer);
+        }
+    } else {
+        hierarchies_.at("")->root->Serialize(writer);
+    }
 
     // serialize footer (introduced since v0.15)
     JsonType basic_info;
@@ -452,7 +436,20 @@ Pyramid::Deserialize(StreamReader& reader) {
         precise_codes_->Deserialize(buffer_reader);
     }
     cur_element_count_ = base_codes_->TotalCount();
-    root_->Deserialize(buffer_reader);
+
+    auto param_json = JsonType::Parse(basic_info[INDEX_PARAM].GetString());
+    if (param_json.Contains(PYRAMID_HIERARCHIES)) {
+        for (size_t i = 0; i < hierarchies_.size(); ++i) {
+            std::string hname = StreamReader::ReadString(buffer_reader);
+            auto h_iter = hierarchies_.find(hname);
+            CHECK_ARGUMENT(h_iter != hierarchies_.end(),
+                           fmt::format("deserialized hierarchy '{}' not in config", hname));
+            h_iter->second->root->Deserialize(buffer_reader);
+        }
+    } else {
+        hierarchies_.at("")->root->Deserialize(buffer_reader);
+    }
+
     resize(max_capacity);
     this->current_memory_usage_ = static_cast<int64_t>(this->CalSerializeSize());
 }
@@ -478,12 +475,6 @@ Pyramid::ExportModel(const IndexCommonParam& param) const {
 
 std::vector<int64_t>
 Pyramid::Add(const DatasetPtr& base, AddMode mode) {
-    const auto pyramid_param = std::dynamic_pointer_cast<PyramidParameters>(create_param_ptr_);
-    CHECK_ARGUMENT(  // NOLINT(readability-simplify-boolean-expr)
-        pyramid_param == nullptr || not pyramid_param->has_hierarchies,
-        "pyramid named hierarchy add is reserved but not implemented");
-    const auto* path = base->GetPaths();
-    CHECK_ARGUMENT(path != nullptr, "path is required");
     int64_t data_num = base->GetNumElements();
     const auto* data_vectors = base->GetFloat32Vectors();
     const auto* data_ids = base->GetIds();
@@ -523,41 +514,10 @@ Pyramid::Add(const DatasetPtr& base, AddMode mode) {
     }
     std::shared_lock<std::shared_mutex> lock(resize_mutex_);
 
-    auto add_func = [&](int64_t i, int64_t data_bias) {
-        std::string current_path = path[data_bias];
-        auto path_slices = split(current_path, PART_SLASH);
-        IndexNode* node = root_.get();
-        auto inner_id = static_cast<InnerIdType>(i + local_cur_element_count);
-        const auto* vector = data_vectors + dim_ * data_bias;
-        int no_build_level_index = 0;
-        for (int j = 0; j <= path_slices.size(); ++j) {
-            IndexNode* new_node = nullptr;
-            if (j != path_slices.size()) {
-                new_node = node->GetChild(path_slices[j], true);
-            }
-            if (no_build_level_index < no_build_levels_.size() &&
-                j == no_build_levels_[no_build_level_index]) {
-                node = new_node;
-                no_build_level_index++;
-                continue;
-            }
-            add_one_point(node, inner_id, vector);
-            node = new_node;
-        }
-    };
-
-    Vector<std::future<void>> futures(allocator_);
-    for (int64_t i = 0; i < data_biases.size(); ++i) {
-        auto data_bias = data_biases[i];
-        if (this->thread_pool_ != nullptr) {
-            futures.push_back(this->thread_pool_->GeneralEnqueue(add_func, i, data_bias));
-        } else {
-            add_func(i, data_bias);
-        }
-    }
-    if (this->thread_pool_ != nullptr) {
-        for (auto& future : futures) {
-            future.get();
+    for (auto& [hname, h_ptr] : hierarchies_) {
+        const auto* hpath = base->GetPaths(hname);
+        if (hpath != nullptr) {
+            add_to_hierarchy(*h_ptr, data_vectors, hpath, data_biases, local_cur_element_count);
         }
     }
     return failed_ids;
@@ -738,30 +698,16 @@ Pyramid::Train(const DatasetPtr& base) {
 }
 std::vector<int64_t>
 Pyramid::Build(const DatasetPtr& base) {
-    const auto pyramid_param = std::dynamic_pointer_cast<PyramidParameters>(create_param_ptr_);
-    CHECK_ARGUMENT(  // NOLINT(readability-simplify-boolean-expr)
-        pyramid_param == nullptr || not pyramid_param->has_hierarchies,
-        "pyramid named hierarchy build is reserved but not implemented");
     CHECK_ARGUMENT(GetNumElements() == 0, "index is not empty");
+    int64_t data_num = base->GetNumElements();
+
     this->Train(base);
     std::vector<int64_t> ret;
-    const auto* path = base->GetPaths();
-    CHECK_ARGUMENT(path != nullptr, "path is required");
-    int64_t data_num = base->GetNumElements();
-    for (int i = 0; i < data_num; ++i) {
-        std::string current_path = path[i];
-        auto path_slices = split(current_path, PART_SLASH);
-        IndexNode* node = root_.get();
-        if (std::find(no_build_levels_.begin(), no_build_levels_.end(), node->level_) ==
-            no_build_levels_.end()) {
-            node->ids_.push_back(i);
-        }
-        for (auto& path_slice : path_slices) {
-            node = node->GetChild(path_slice, true);
-            if (std::find(no_build_levels_.begin(), no_build_levels_.end(), node->level_) ==
-                no_build_levels_.end()) {
-                node->ids_.push_back(i);
-            }
+
+    for (auto& [hname, h_ptr] : hierarchies_) {
+        const auto* hpath = base->GetPaths(hname);
+        if (hpath != nullptr) {
+            populate_path_tree(*h_ptr, hpath, data_num);
         }
     }
 
@@ -774,7 +720,10 @@ Pyramid::Build(const DatasetPtr& base) {
 }
 
 void
-Pyramid::add_one_point(IndexNode* node, InnerIdType inner_id, const float* vector) {
+Pyramid::add_one_point(const Hierarchy& h,
+                       IndexNode* node,
+                       InnerIdType inner_id,
+                       const float* vector) {
     std::unique_lock graph_lock(node->mutex_);
 
     if (node->status_ == IndexNode::Status::NO_INDEX) {
@@ -792,10 +741,10 @@ Pyramid::add_one_point(IndexNode* node, InnerIdType inner_id, const float* vecto
         node->entry_point_ = inner_id;
     } else {
         InnerSearchParam search_param;
-        search_param.ef = ef_construction_;
-        search_param.topk = static_cast<int64_t>(ef_construction_);
+        search_param.ef = h.ef_construction;
+        search_param.topk = static_cast<int64_t>(h.ef_construction);
         search_param.search_mode = KNN_SEARCH;
-        search_param.hops_limit = 10000;  // Add hops limit to prevent infinite loop
+        search_param.hops_limit = 10000;
         if (support_duplicate_) {
             search_param.find_duplicate = true;
             search_param.duplicate_query_id = inner_id;
@@ -822,9 +771,120 @@ Pyramid::add_one_point(IndexNode* node, InnerIdType inner_id, const float* vecto
             return;
         }
         mutually_connect_new_element(
-            inner_id, results, node->graph_, codes, points_mutex_, allocator_, alpha_);
+            inner_id, results, node->graph_, codes, points_mutex_, allocator_, h.alpha);
         if (update_entry_point) {
             node->entry_point_ = inner_id;
+        }
+    }
+}
+
+void
+Pyramid::populate_path_tree(Hierarchy& h, const std::string* paths, int64_t count) {
+    for (int64_t i = 0; i < count; ++i) {
+        std::string current_path = paths[i];
+        auto path_slices = split(current_path, PART_SLASH);
+        IndexNode* node = h.root.get();
+        if (std::find(h.no_build_levels.begin(), h.no_build_levels.end(), node->level_) ==
+            h.no_build_levels.end()) {
+            node->ids_.push_back(i);
+        }
+        for (auto& path_slice : path_slices) {
+            node = node->GetChild(path_slice, true);
+            if (std::find(h.no_build_levels.begin(), h.no_build_levels.end(), node->level_) ==
+                h.no_build_levels.end()) {
+                node->ids_.push_back(i);
+            }
+        }
+    }
+}
+
+void
+Pyramid::add_to_hierarchy(Hierarchy& h,
+                           const float* data_vectors,
+                           const std::string* paths,
+                           const Vector<int64_t>& data_biases,
+                           int64_t local_cur_element_count) {
+    auto add_func = [&](int64_t i, int64_t data_bias) {
+        std::string current_path = paths[data_bias];
+        auto path_slices = split(current_path, PART_SLASH);
+        IndexNode* node = h.root.get();
+        auto inner_id = static_cast<InnerIdType>(i + local_cur_element_count);
+        const auto* vector = data_vectors + dim_ * data_bias;
+        int no_build_level_index = 0;
+        for (int j = 0; j <= static_cast<int>(path_slices.size()); ++j) {
+            IndexNode* new_node = nullptr;
+            if (j != static_cast<int>(path_slices.size())) {
+                new_node = node->GetChild(path_slices[j], true);
+            }
+            if (no_build_level_index < static_cast<int>(h.no_build_levels.size()) &&
+                j == h.no_build_levels[no_build_level_index]) {
+                node = new_node;
+                no_build_level_index++;
+                continue;
+            }
+            add_one_point(h, node, inner_id, vector);
+            node = new_node;
+        }
+    };
+
+    Vector<std::future<void>> futures(allocator_);
+    for (int64_t i = 0; i < static_cast<int64_t>(data_biases.size()); ++i) {
+        auto data_bias = data_biases[i];
+        if (this->thread_pool_ != nullptr) {
+            futures.push_back(this->thread_pool_->GeneralEnqueue(add_func, i, data_bias));
+        } else {
+            add_func(i, data_bias);
+        }
+    }
+    if (this->thread_pool_ != nullptr) {
+        for (auto& future : futures) {
+            future.get();
+        }
+    }
+}
+
+void
+Pyramid::search_hierarchy(const Hierarchy& h,
+                           const SearchFunc& search_func,
+                           const VisitedListPtr& vl,
+                           DistHeapPtr& search_result,
+                           const std::string& path,
+                           const InnerSearchParam& search_param) const {
+    std::vector<std::future<void>> futures;
+    auto parsed_path = parse_path(path);
+    Vector<DistHeapPtr> search_result_lists(parsed_path.size(), allocator_);
+    for (uint32_t i = 0; i < parsed_path.size(); ++i) {
+        const auto& one_path = parsed_path[i];
+        search_result_lists[i] = std::make_shared<StandardHeap<true, false>>(allocator_, -1);
+        IndexNode* node = h.root.get();
+        bool valid = true;
+        for (const auto& item : one_path) {
+            node = node->GetChild(item, false);
+            if (node == nullptr) {
+                valid = false;
+                break;
+            }
+        }
+        if (valid) {
+            if (thread_pool_ != nullptr && search_param.parallel_search_thread_count > 1) {
+                futures.push_back(thread_pool_->GeneralEnqueue([&, node, i]() -> void {
+                    node->Search(search_func, vl, search_result_lists[i], search_param.ef);
+                }));
+            } else {
+                node->Search(search_func, vl, search_result_lists[i], search_param.ef);
+            }
+        }
+    }
+
+    for (auto& future : futures) {
+        future.get();
+    }
+
+    for (uint32_t i = 0; i < search_result_lists.size(); ++i) {
+        if (i != 0) {
+            search_result->Merge(*search_result_lists[i]);
+        } else {
+            search_result = search_result_lists[i];
         }
     }
 }

--- a/src/algorithm/pyramid/pyramid.cpp
+++ b/src/algorithm/pyramid/pyramid.cpp
@@ -223,9 +223,22 @@ Pyramid::build_by_odescent(const DatasetPtr& base) {
     }
     auto codes = use_reorder_ ? precise_codes_ : base_codes_;
 
-    ODescent graph_builder(odescent_param_, codes, allocator_, this->thread_pool_.get());
-    for (auto& [hname, h_ptr] : hierarchies_) {
-        h_ptr->root->Build(graph_builder);
+    if (thread_pool_ != nullptr && hierarchies_.size() > 1) {
+        Vector<std::future<void>> futures(allocator_);
+        for (auto& [hname, h_ptr] : hierarchies_) {
+            futures.push_back(thread_pool_->GeneralEnqueue([&, codes]() {
+                ODescent builder(odescent_param_, codes, allocator_, nullptr);
+                h_ptr->root->Build(builder);
+            }));
+        }
+        for (auto& f : futures) {
+            f.get();
+        }
+    } else {
+        ODescent graph_builder(odescent_param_, codes, allocator_, this->thread_pool_.get());
+        for (auto& [hname, h_ptr] : hierarchies_) {
+            h_ptr->root->Build(graph_builder);
+        }
     }
     cur_element_count_ = data_num;
     return {};
@@ -704,10 +717,24 @@ Pyramid::Build(const DatasetPtr& base) {
     this->Train(base);
     std::vector<int64_t> ret;
 
-    for (auto& [hname, h_ptr] : hierarchies_) {
-        const auto* hpath = base->GetPaths(hname);
-        if (hpath != nullptr) {
-            populate_path_tree(*h_ptr, hpath, data_num);
+    if (thread_pool_ != nullptr && hierarchies_.size() > 1) {
+        Vector<std::future<void>> futures(allocator_);
+        for (auto& [hname, h_ptr] : hierarchies_) {
+            const auto* hpath = base->GetPaths(hname);
+            if (hpath != nullptr) {
+                futures.push_back(thread_pool_->GeneralEnqueue(
+                    [&h = *h_ptr, hpath, data_num, this]() { populate_path_tree(h, hpath, data_num); }));
+            }
+        }
+        for (auto& f : futures) {
+            f.get();
+        }
+    } else {
+        for (auto& [hname, h_ptr] : hierarchies_) {
+            const auto* hpath = base->GetPaths(hname);
+            if (hpath != nullptr) {
+                populate_path_tree(*h_ptr, hpath, data_num);
+            }
         }
     }
 

--- a/src/algorithm/pyramid/pyramid.cpp
+++ b/src/algorithm/pyramid/pyramid.cpp
@@ -418,6 +418,8 @@ Pyramid::Serialize(StreamWriter& writer) const {
 
     auto pyramid_param = std::dynamic_pointer_cast<PyramidParameters>(create_param_ptr_);
     if (pyramid_param && pyramid_param->has_hierarchies) {
+        uint64_t hierarchy_count = hierarchies_.size();
+        StreamWriter::WriteObj(writer, hierarchy_count);
         for (const auto& [hname, h_ptr] : hierarchies_) {
             StreamWriter::WriteString(writer, hname);
             h_ptr->root->Serialize(writer);
@@ -454,7 +456,13 @@ Pyramid::Deserialize(StreamReader& reader) {
 
     auto param_json = JsonType::Parse(basic_info[INDEX_PARAM].GetString());
     if (param_json.Contains(PYRAMID_HIERARCHIES)) {
-        for (size_t i = 0; i < hierarchies_.size(); ++i) {
+        uint64_t hierarchy_count = 0;
+        StreamReader::ReadObj(buffer_reader, hierarchy_count);
+        CHECK_ARGUMENT(hierarchy_count == hierarchies_.size(),
+                       fmt::format("serialized hierarchy count ({}) != config ({})",
+                                   hierarchy_count,
+                                   hierarchies_.size()));
+        for (uint64_t i = 0; i < hierarchy_count; ++i) {
             std::string hname = StreamReader::ReadString(buffer_reader);
             auto h_iter = hierarchies_.find(hname);
             CHECK_ARGUMENT(h_iter != hierarchies_.end(),
@@ -462,7 +470,11 @@ Pyramid::Deserialize(StreamReader& reader) {
             h_iter->second->root->Deserialize(buffer_reader);
         }
     } else {
-        hierarchies_.at("")->root->Deserialize(buffer_reader);
+        auto h_iter = hierarchies_.find("");
+        CHECK_ARGUMENT(
+            h_iter != hierarchies_.end(),
+            "deserialized single-hierarchy index but current config has named hierarchies");
+        h_iter->second->root->Deserialize(buffer_reader);
     }
 
     resize(max_capacity);
@@ -899,7 +911,9 @@ Pyramid::search_hierarchy(const Hierarchy& h,
         if (valid) {
             if (thread_pool_ != nullptr && search_param.parallel_search_thread_count > 1) {
                 futures.push_back(thread_pool_->GeneralEnqueue([&, node, i]() -> void {
-                    node->Search(search_func, vl, search_result_lists[i], search_param.ef);
+                    auto local_vl = pool_->TakeOne();
+                    node->Search(search_func, local_vl, search_result_lists[i], search_param.ef);
+                    pool_->ReturnOne(local_vl);
                 }));
             } else {
                 node->Search(search_func, vl, search_result_lists[i], search_param.ef);

--- a/src/algorithm/pyramid/pyramid.cpp
+++ b/src/algorithm/pyramid/pyramid.cpp
@@ -225,10 +225,11 @@ Pyramid::build_by_odescent(const DatasetPtr& base) {
 
     if (thread_pool_ != nullptr && hierarchies_.size() > 1) {
         Vector<std::future<void>> futures(allocator_);
-        for (auto& [hname, h_ptr] : hierarchies_) {
-            futures.push_back(thread_pool_->GeneralEnqueue([&, codes]() {
+        for (const auto& [hname, h_ptr] : hierarchies_) {
+            auto* root_ptr = h_ptr->root.get();
+            futures.push_back(thread_pool_->GeneralEnqueue([&, codes, root_ptr]() {
                 ODescent builder(odescent_param_, codes, allocator_, nullptr);
-                h_ptr->root->Build(builder);
+                root_ptr->Build(builder);
             }));
         }
         for (auto& f : futures) {
@@ -236,7 +237,7 @@ Pyramid::build_by_odescent(const DatasetPtr& base) {
         }
     } else {
         ODescent graph_builder(odescent_param_, codes, allocator_, this->thread_pool_.get());
-        for (auto& [hname, h_ptr] : hierarchies_) {
+        for (const auto& [hname, h_ptr] : hierarchies_) {
             h_ptr->root->Build(graph_builder);
         }
     }
@@ -350,6 +351,7 @@ Pyramid::search_impl(const DatasetPtr& query,
     if (query_path == nullptr) {
         query_path = query->GetPaths();
     }
+    // NOLINTNEXTLINE(readability-simplify-boolean-expr)
     CHECK_ARGUMENT(query_path != nullptr || h.root->status_ != IndexNode::Status::NO_INDEX,
                    "query_path is required when level0 is not built");
     CHECK_ARGUMENT(query->GetFloat32Vectors() != nullptr, "query vectors is required");
@@ -527,7 +529,7 @@ Pyramid::Add(const DatasetPtr& base, AddMode mode) {
     }
     std::shared_lock<std::shared_mutex> lock(resize_mutex_);
 
-    for (auto& [hname, h_ptr] : hierarchies_) {
+    for (const auto& [hname, h_ptr] : hierarchies_) {
         const auto* hpath = base->GetPaths(hname);
         if (hpath != nullptr) {
             add_to_hierarchy(*h_ptr, data_vectors, hpath, data_biases, local_cur_element_count);
@@ -719,18 +721,20 @@ Pyramid::Build(const DatasetPtr& base) {
 
     if (thread_pool_ != nullptr && hierarchies_.size() > 1) {
         Vector<std::future<void>> futures(allocator_);
-        for (auto& [hname, h_ptr] : hierarchies_) {
+        for (const auto& [hname, h_ptr] : hierarchies_) {
             const auto* hpath = base->GetPaths(hname);
             if (hpath != nullptr) {
-                futures.push_back(thread_pool_->GeneralEnqueue(
-                    [&h = *h_ptr, hpath, data_num, this]() { populate_path_tree(h, hpath, data_num); }));
+                futures.push_back(
+                    thread_pool_->GeneralEnqueue([&h = *h_ptr, hpath, data_num, this]() {
+                        populate_path_tree(h, hpath, data_num);
+                    }));
             }
         }
         for (auto& f : futures) {
             f.get();
         }
     } else {
-        for (auto& [hname, h_ptr] : hierarchies_) {
+        for (const auto& [hname, h_ptr] : hierarchies_) {
             const auto* hpath = base->GetPaths(hname);
             if (hpath != nullptr) {
                 populate_path_tree(*h_ptr, hpath, data_num);
@@ -827,10 +831,10 @@ Pyramid::populate_path_tree(Hierarchy& h, const std::string* paths, int64_t coun
 
 void
 Pyramid::add_to_hierarchy(Hierarchy& h,
-                           const float* data_vectors,
-                           const std::string* paths,
-                           const Vector<int64_t>& data_biases,
-                           int64_t local_cur_element_count) {
+                          const float* data_vectors,
+                          const std::string* paths,
+                          const Vector<int64_t>& data_biases,
+                          int64_t local_cur_element_count) {
     auto add_func = [&](int64_t i, int64_t data_bias) {
         std::string current_path = paths[data_bias];
         auto path_slices = split(current_path, PART_SLASH);
@@ -872,11 +876,11 @@ Pyramid::add_to_hierarchy(Hierarchy& h,
 
 void
 Pyramid::search_hierarchy(const Hierarchy& h,
-                           const SearchFunc& search_func,
-                           const VisitedListPtr& vl,
-                           DistHeapPtr& search_result,
-                           const std::string& path,
-                           const InnerSearchParam& search_param) const {
+                          const SearchFunc& search_func,
+                          const VisitedListPtr& vl,
+                          DistHeapPtr& search_result,
+                          const std::string& path,
+                          const InnerSearchParam& search_param) const {
     std::vector<std::future<void>> futures;
     auto parsed_path = parse_path(path);
     Vector<DistHeapPtr> search_result_lists(parsed_path.size(), allocator_);

--- a/src/algorithm/pyramid/pyramid.h
+++ b/src/algorithm/pyramid/pyramid.h
@@ -224,6 +224,36 @@ public:
     friend class PyramidAnalyzer;
 
 private:
+    struct Hierarchy {
+        std::string name;
+        std::unique_ptr<IndexNode> root{nullptr};
+        Vector<int32_t> no_build_levels;
+        uint64_t ef_construction{400};
+        float alpha{1.2F};
+
+        Hierarchy(const std::string& n, std::unique_ptr<IndexNode> r, Allocator* alloc)
+            : name(n), root(std::move(r)), no_build_levels(alloc) {
+        }
+    };
+
+    void
+    populate_path_tree(Hierarchy& h, const std::string* paths, int64_t count);
+
+    void
+    add_to_hierarchy(Hierarchy& h,
+                     const float* data_vectors,
+                     const std::string* paths,
+                     const Vector<int64_t>& data_biases,
+                     int64_t local_cur_element_count);
+
+    void
+    search_hierarchy(const Hierarchy& h,
+                     const SearchFunc& search_func,
+                     const VisitedListPtr& vl,
+                     DistHeapPtr& search_result,
+                     const std::string& path,
+                     const InnerSearchParam& search_param) const;
+
     void
     resize(int64_t new_max_capacity);
 
@@ -257,37 +287,6 @@ private:
                 const FlattenInterfacePtr& codes,
                 QueryContext& ctx,
                 uint64_t subindex_ef_search) const;
-
-private:
-    struct Hierarchy {
-        std::string name;
-        std::unique_ptr<IndexNode> root{nullptr};
-        Vector<int32_t> no_build_levels;
-        uint64_t ef_construction{400};
-        float alpha{1.2F};
-
-        Hierarchy(const std::string& n, std::unique_ptr<IndexNode> r, Allocator* alloc)
-            : name(n), root(std::move(r)), no_build_levels(alloc) {
-        }
-    };
-
-    void
-    populate_path_tree(Hierarchy& h, const std::string* paths, int64_t count);
-
-    void
-    add_to_hierarchy(Hierarchy& h,
-                     const float* data_vectors,
-                     const std::string* paths,
-                     const Vector<int64_t>& data_biases,
-                     int64_t local_cur_element_count);
-
-    void
-    search_hierarchy(const Hierarchy& h,
-                     const SearchFunc& search_func,
-                     const VisitedListPtr& vl,
-                     DistHeapPtr& search_result,
-                     const std::string& path,
-                     const InnerSearchParam& search_param) const;
 
 private:
     ODescentParameterPtr odescent_param_{nullptr};

--- a/src/algorithm/pyramid/pyramid.h
+++ b/src/algorithm/pyramid/pyramid.h
@@ -20,6 +20,7 @@
 
 #include "algorithm/inner_index_interface.h"
 #include "datacell/graph_interface.h"
+#include "datacell/sparse_graph_datacell_parameter.h"
 #include "impl/allocator/safe_allocator.h"
 #include "impl/filter/filter_headers.h"
 #include "impl/heap/distance_heap.h"
@@ -100,21 +101,42 @@ public:
 public:
     Pyramid(const PyramidParamPtr& pyramid_param, const IndexCommonParam& common_param)
         : InnerIndexInterface(pyramid_param, common_param),
-          alpha_(pyramid_param->alpha),
-          no_build_levels_(common_param.allocator_.get()),
+          hierarchies_(common_param.allocator_.get()),
           odescent_param_(pyramid_param->odescent_param),
-          ef_construction_(pyramid_param->ef_construction),
-          max_degree_(pyramid_param->max_degree),
           index_min_size_(pyramid_param->index_min_size),
           graph_type_(pyramid_param->graph_type),
           support_duplicate_(pyramid_param->support_duplicate) {
         base_codes_ = FlattenInterface::MakeInstance(pyramid_param->base_codes_param, common_param);
-        root_ =
-            std::make_unique<IndexNode>(allocator_, pyramid_param->graph_param, index_min_size_);
+        if (pyramid_param->has_hierarchies) {
+            for (const auto& h_param : pyramid_param->hierarchies) {
+                auto graph_param = pyramid_param->graph_param;
+                if (h_param.max_degree != pyramid_param->max_degree) {
+                    auto new_gp = std::make_shared<SparseGraphDatacellParameter>();
+                    new_gp->FromJson(graph_param->ToJson());
+                    new_gp->max_degree_ = h_param.max_degree;
+                    graph_param = new_gp;
+                }
+                auto root = std::make_unique<IndexNode>(
+                    allocator_, graph_param, h_param.index_min_size);
+                auto h = std::make_unique<Hierarchy>(h_param.name, std::move(root), allocator_);
+                h->no_build_levels.assign(
+                    h_param.no_build_levels.begin(), h_param.no_build_levels.end());
+                h->ef_construction = h_param.ef_construction;
+                h->alpha = h_param.alpha;
+                hierarchies_.insert({h_param.name, std::move(h)});
+            }
+        } else {
+            auto root = std::make_unique<IndexNode>(
+                allocator_, pyramid_param->graph_param, index_min_size_);
+            auto h = std::make_unique<Hierarchy>("", std::move(root), allocator_);
+            h->no_build_levels.assign(
+                pyramid_param->no_build_levels.begin(), pyramid_param->no_build_levels.end());
+            h->ef_construction = pyramid_param->ef_construction;
+            h->alpha = pyramid_param->alpha;
+            hierarchies_.insert({"", std::move(h)});
+        }
         points_mutex_ = std::make_shared<PointsMutex>(max_capacity_, allocator_);
         searcher_ = std::make_unique<BasicSearcher>(common_param, points_mutex_);
-        no_build_levels_.assign(pyramid_param->no_build_levels.begin(),
-                                pyramid_param->no_build_levels.end());
         if (use_reorder_) {
             precise_codes_ =
                 FlattenInterface::MakeInstance(pyramid_param->precise_codes_param, common_param);
@@ -208,7 +230,8 @@ private:
     DatasetPtr
     search_impl(const DatasetPtr& query,
                 const SearchFunc& search_func,
-                InnerSearchParam& search_param) const;
+                InnerSearchParam& search_param,
+                const std::string& hierarchy_name = "") const;
 
     bool
     is_update_entry_point(uint64_t total_count) {
@@ -221,7 +244,7 @@ private:
     build_by_odescent(const DatasetPtr& base);
 
     void
-    add_one_point(IndexNode* node, InnerIdType inner_id, const float* vector);
+    add_one_point(const Hierarchy& h, IndexNode* node, InnerIdType inner_id, const float* vector);
 
     static std::vector<std::vector<std::string>>
     parse_path(const std::string& path);
@@ -236,11 +259,39 @@ private:
                 uint64_t subindex_ef_search) const;
 
 private:
+    struct Hierarchy {
+        std::string name;
+        std::unique_ptr<IndexNode> root{nullptr};
+        Vector<int32_t> no_build_levels;
+        uint64_t ef_construction{400};
+        float alpha{1.2F};
+
+        Hierarchy(const std::string& n, std::unique_ptr<IndexNode> r, Allocator* alloc)
+            : name(n), root(std::move(r)), no_build_levels(alloc) {
+        }
+    };
+
+    void
+    populate_path_tree(Hierarchy& h, const std::string* paths, int64_t count);
+
+    void
+    add_to_hierarchy(Hierarchy& h,
+                     const float* data_vectors,
+                     const std::string* paths,
+                     const Vector<int64_t>& data_biases,
+                     int64_t local_cur_element_count);
+
+    void
+    search_hierarchy(const Hierarchy& h,
+                     const SearchFunc& search_func,
+                     const VisitedListPtr& vl,
+                     DistHeapPtr& search_result,
+                     const std::string& path,
+                     const InnerSearchParam& search_param) const;
+
+private:
     ODescentParameterPtr odescent_param_{nullptr};
-    Vector<int32_t> no_build_levels_;
-    uint64_t ef_construction_{400};
-    int64_t max_degree_{64};
-    std::unique_ptr<IndexNode> root_{nullptr};
+    UnorderedMap<std::string, std::unique_ptr<Hierarchy>> hierarchies_;
     FlattenInterfacePtr base_codes_{nullptr};
     FlattenInterfacePtr precise_codes_{nullptr};
     std::unique_ptr<VisitedListPool> pool_ = nullptr;
@@ -249,7 +300,6 @@ private:
     std::unique_ptr<BasicSearcher> searcher_ = nullptr;
     int64_t max_capacity_{0};
     int64_t cur_element_count_{0};
-    float alpha_{1.0F};
     bool support_duplicate_{false};
 
     mutable std::shared_mutex resize_mutex_;

--- a/src/algorithm/pyramid/pyramid.h
+++ b/src/algorithm/pyramid/pyramid.h
@@ -116,11 +116,11 @@ public:
                     new_gp->max_degree_ = h_param.max_degree;
                     graph_param = new_gp;
                 }
-                auto root = std::make_unique<IndexNode>(
-                    allocator_, graph_param, h_param.index_min_size);
+                auto root =
+                    std::make_unique<IndexNode>(allocator_, graph_param, h_param.index_min_size);
                 auto h = std::make_unique<Hierarchy>(h_param.name, std::move(root), allocator_);
-                h->no_build_levels.assign(
-                    h_param.no_build_levels.begin(), h_param.no_build_levels.end());
+                h->no_build_levels.assign(h_param.no_build_levels.begin(),
+                                          h_param.no_build_levels.end());
                 h->ef_construction = h_param.ef_construction;
                 h->alpha = h_param.alpha;
                 hierarchies_.insert({h_param.name, std::move(h)});
@@ -129,8 +129,8 @@ public:
             auto root = std::make_unique<IndexNode>(
                 allocator_, pyramid_param->graph_param, index_min_size_);
             auto h = std::make_unique<Hierarchy>("", std::move(root), allocator_);
-            h->no_build_levels.assign(
-                pyramid_param->no_build_levels.begin(), pyramid_param->no_build_levels.end());
+            h->no_build_levels.assign(pyramid_param->no_build_levels.begin(),
+                                      pyramid_param->no_build_levels.end());
             h->ef_construction = pyramid_param->ef_construction;
             h->alpha = pyramid_param->alpha;
             hierarchies_.insert({"", std::move(h)});
@@ -236,7 +236,7 @@ private:
         }
     };
 
-    void
+    static void
     populate_path_tree(Hierarchy& h, const std::string* paths, int64_t count);
 
     void

--- a/src/analyzer/pyramid_analyzer.cpp
+++ b/src/analyzer/pyramid_analyzer.cpp
@@ -55,7 +55,7 @@ PyramidAnalyzer::GetStats() {
         return h_stats;
     };
 
-    if (pyramid_->hierarchies_.size() == 1) {
+    if (pyramid_->hierarchies_.size() == 1 && pyramid_->hierarchies_.begin()->first.empty()) {
         auto* root = pyramid_->hierarchies_.begin()->second->root.get();
         auto h_stats = analyze_one_hierarchy(root);
         stats["index_node_structure"].SetJson(h_stats["index_node_structure"]);

--- a/src/analyzer/pyramid_analyzer.cpp
+++ b/src/analyzer/pyramid_analyzer.cpp
@@ -167,7 +167,7 @@ PyramidAnalyzer::get_index_node_structure() {
         }
     };
 
-    traverse(pyramid_->root_.get(), 0);
+    traverse(pyramid_->hierarchies_.begin()->second->root.get(), 0);
 
     structure["total_nodes"].SetInt(total_nodes);
     structure["max_depth"].SetInt(max_depth);
@@ -192,7 +192,7 @@ PyramidAnalyzer::get_leaf_node_size_distribution() {
     JsonType distribution;
 
     Vector<uint32_t> leaf_sizes(allocator_);
-    collect_leaf_sizes(pyramid_->root_.get(), leaf_sizes);
+    collect_leaf_sizes(pyramid_->hierarchies_.begin()->second->root.get(), leaf_sizes);
 
     if (leaf_sizes.empty()) {
         distribution["total_leaf_nodes"].SetInt(0);
@@ -310,7 +310,7 @@ PyramidAnalyzer::get_subindex_quality() {
     JsonType quality;
 
     subindex_stats_.clear();
-    analyze_subindexes(pyramid_->root_.get(), "");
+    analyze_subindexes(pyramid_->hierarchies_.begin()->second->root.get(), "");
 
     uint32_t graph_count = 0;
     uint32_t flat_count = 0;
@@ -1378,7 +1378,7 @@ PyramidAnalyzer::get_graph_node_recall_stats(const std::string& search_param_str
         }
     };
 
-    traverse(pyramid_->root_.get(), "");
+    traverse(pyramid_->hierarchies_.begin()->second->root.get(), "");
 
     float weighted_recall =
         total_size > 0 ? total_weighted_recall / static_cast<float>(total_size) : 0.0F;
@@ -1449,7 +1449,7 @@ PyramidAnalyzer::GetDuplicateRatio() {
         }
     };
 
-    traverse(pyramid_->root_.get());
+    traverse(pyramid_->hierarchies_.begin()->second->root.get());
 
     return total_vector_count > 0
                ? static_cast<float>(total_duplicate_count) / static_cast<float>(total_vector_count)

--- a/src/analyzer/pyramid_analyzer.cpp
+++ b/src/analyzer/pyramid_analyzer.cpp
@@ -30,57 +30,55 @@ namespace vsag {
 JsonType
 PyramidAnalyzer::GetStats() {
     JsonType stats;
+    stats["total_count"].SetInt(this->total_count_);
 
-    auto start = std::chrono::steady_clock::now();
-    stats["index_node_structure"].SetJson(get_index_node_structure());
-    auto end = std::chrono::steady_clock::now();
-    logger::info("[PyramidAnalyzer] get_index_node_structure: {}ms",
-                 std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count());
-
-    start = std::chrono::steady_clock::now();
-    stats["leaf_node_size_distribution"].SetJson(get_leaf_node_size_distribution());
-    end = std::chrono::steady_clock::now();
-    logger::info("[PyramidAnalyzer] get_leaf_node_size_distribution: {}ms",
-                 std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count());
-
-    start = std::chrono::steady_clock::now();
-    stats["subindex_quality"].SetJson(get_subindex_quality());
-    end = std::chrono::steady_clock::now();
-    logger::info("[PyramidAnalyzer] get_subindex_quality: {}ms",
-                 std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count());
-
-    start = std::chrono::steady_clock::now();
     sample_global();
-    end = std::chrono::steady_clock::now();
-    logger::info("[PyramidAnalyzer] sample_global: {}ms",
-                 std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count());
 
-    if (not sample_ids_.empty()) {
-        if (not search_params_.empty()) {
-            start = std::chrono::steady_clock::now();
-            auto recall_stats = get_graph_node_recall_stats(search_params_);
-            end = std::chrono::steady_clock::now();
-            logger::info(
-                "[PyramidAnalyzer] get_graph_node_recall_stats: {}ms",
-                std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count());
+    auto analyze_one_hierarchy = [&](IndexNode* root) -> JsonType {
+        JsonType h_stats;
+        h_stats["index_node_structure"].SetJson(get_index_node_structure(root));
+        h_stats["leaf_node_size_distribution"].SetJson(get_leaf_node_size_distribution(root));
+        h_stats["subindex_quality"].SetJson(get_subindex_quality(root));
 
-            stats["recall_base"].SetFloat(recall_stats["weighted_recall"].GetFloat());
-            stats["graph_node_count"].SetInt(recall_stats["node_count"].GetInt());
-            stats["total_graph_size"].SetInt(recall_stats["total_size"].GetInt());
-            stats["skipped_node_count"].SetInt(recall_stats["skipped_node_count"].GetInt());
+        if (not sample_ids_.empty() && not search_params_.empty()) {
+            auto recall_stats = get_graph_node_recall_stats(root, search_params_);
+            h_stats["recall_base"].SetFloat(recall_stats["weighted_recall"].GetFloat());
+            h_stats["graph_node_count"].SetInt(recall_stats["node_count"].GetInt());
+            h_stats["total_graph_size"].SetInt(recall_stats["total_size"].GetInt());
+            h_stats["skipped_node_count"].SetInt(recall_stats["skipped_node_count"].GetInt());
             if (recall_stats.Contains("low_recall_nodes")) {
-                stats["low_recall_nodes"].SetJson(recall_stats["low_recall_nodes"]);
+                h_stats["low_recall_nodes"].SetJson(recall_stats["low_recall_nodes"]);
             }
         }
+
+        h_stats["duplicate_ratio"].SetFloat(GetDuplicateRatio(root));
+        return h_stats;
+    };
+
+    if (pyramid_->hierarchies_.size() == 1) {
+        auto* root = pyramid_->hierarchies_.begin()->second->root.get();
+        auto h_stats = analyze_one_hierarchy(root);
+        stats["index_node_structure"].SetJson(h_stats["index_node_structure"]);
+        stats["leaf_node_size_distribution"].SetJson(h_stats["leaf_node_size_distribution"]);
+        stats["subindex_quality"].SetJson(h_stats["subindex_quality"]);
+        if (h_stats.Contains("recall_base")) {
+            stats["recall_base"].SetFloat(h_stats["recall_base"].GetFloat());
+            stats["graph_node_count"].SetInt(h_stats["graph_node_count"].GetInt());
+            stats["total_graph_size"].SetInt(h_stats["total_graph_size"].GetInt());
+            stats["skipped_node_count"].SetInt(h_stats["skipped_node_count"].GetInt());
+            if (h_stats.Contains("low_recall_nodes")) {
+                stats["low_recall_nodes"].SetJson(h_stats["low_recall_nodes"]);
+            }
+        }
+        stats["duplicate_ratio"].SetFloat(h_stats["duplicate_ratio"].GetFloat());
+    } else {
+        stats["hierarchy_count"].SetInt(static_cast<int64_t>(pyramid_->hierarchies_.size()));
+        JsonType hierarchies_stats;
+        for (const auto& [hname, h_ptr] : pyramid_->hierarchies_) {
+            hierarchies_stats[hname].SetJson(analyze_one_hierarchy(h_ptr->root.get()));
+        }
+        stats["hierarchies"].SetJson(hierarchies_stats);
     }
-
-    start = std::chrono::steady_clock::now();
-    stats["duplicate_ratio"].SetFloat(GetDuplicateRatio());
-    end = std::chrono::steady_clock::now();
-    logger::info("[PyramidAnalyzer] GetDuplicateRatio: {}ms",
-                 std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count());
-
-    stats["total_count"].SetInt(this->total_count_);
 
     return stats;
 }
@@ -131,7 +129,7 @@ PyramidAnalyzer::AnalyzeIndexBySearch(const SearchRequest& request) {
 }
 
 JsonType
-PyramidAnalyzer::get_index_node_structure() {
+PyramidAnalyzer::get_index_node_structure(IndexNode* root) {
     JsonType structure;
 
     uint32_t total_nodes = 0;
@@ -167,7 +165,7 @@ PyramidAnalyzer::get_index_node_structure() {
         }
     };
 
-    traverse(pyramid_->hierarchies_.begin()->second->root.get(), 0);
+    traverse(root, 0);
 
     structure["total_nodes"].SetInt(total_nodes);
     structure["max_depth"].SetInt(max_depth);
@@ -188,11 +186,11 @@ PyramidAnalyzer::get_index_node_structure() {
 }
 
 JsonType
-PyramidAnalyzer::get_leaf_node_size_distribution() {
+PyramidAnalyzer::get_leaf_node_size_distribution(IndexNode* root) {
     JsonType distribution;
 
     Vector<uint32_t> leaf_sizes(allocator_);
-    collect_leaf_sizes(pyramid_->hierarchies_.begin()->second->root.get(), leaf_sizes);
+    collect_leaf_sizes(root, leaf_sizes);
 
     if (leaf_sizes.empty()) {
         distribution["total_leaf_nodes"].SetInt(0);
@@ -306,11 +304,11 @@ PyramidAnalyzer::collect_leaf_sizes(IndexNode* node, Vector<uint32_t>& sizes) {
 }
 
 JsonType
-PyramidAnalyzer::get_subindex_quality() {
+PyramidAnalyzer::get_subindex_quality(IndexNode* root) {
     JsonType quality;
 
     subindex_stats_.clear();
-    analyze_subindexes(pyramid_->hierarchies_.begin()->second->root.get(), "");
+    analyze_subindexes(root, "");
 
     uint32_t graph_count = 0;
     uint32_t flat_count = 0;
@@ -1305,7 +1303,7 @@ PyramidAnalyzer::analyze_node_graph_quality(const IndexNode* node,
 }
 
 JsonType
-PyramidAnalyzer::get_graph_node_recall_stats(const std::string& search_param_str) {
+PyramidAnalyzer::get_graph_node_recall_stats(IndexNode* root, const std::string& search_param_str) {
     JsonType stats;
 
     low_recall_nodes_.clear();
@@ -1378,7 +1376,7 @@ PyramidAnalyzer::get_graph_node_recall_stats(const std::string& search_param_str
         }
     };
 
-    traverse(pyramid_->hierarchies_.begin()->second->root.get(), "");
+    traverse(root, "");
 
     float weighted_recall =
         total_size > 0 ? total_weighted_recall / static_cast<float>(total_size) : 0.0F;
@@ -1414,7 +1412,7 @@ PyramidAnalyzer::get_graph_node_recall_stats(const std::string& search_param_str
 }
 
 float
-PyramidAnalyzer::GetDuplicateRatio() {
+PyramidAnalyzer::GetDuplicateRatio(IndexNode* root) {
     if (sample_datas_.empty()) {
         sample_global();
     }
@@ -1449,7 +1447,7 @@ PyramidAnalyzer::GetDuplicateRatio() {
         }
     };
 
-    traverse(pyramid_->hierarchies_.begin()->second->root.get());
+    traverse(root);
 
     return total_vector_count > 0
                ? static_cast<float>(total_duplicate_count) / static_cast<float>(total_vector_count)

--- a/src/analyzer/pyramid_analyzer.h
+++ b/src/analyzer/pyramid_analyzer.h
@@ -83,7 +83,7 @@ private:
         float avg_distance_from_entry{0.0F};
     };
 
-    JsonType
+    static JsonType
     get_index_node_structure(IndexNode* root);
 
     JsonType

--- a/src/analyzer/pyramid_analyzer.h
+++ b/src/analyzer/pyramid_analyzer.h
@@ -43,7 +43,7 @@ public:
     AnalyzeIndexBySearch(const SearchRequest& request) override;
 
     float
-    GetDuplicateRatio();
+    GetDuplicateRatio(IndexNode* root);
 
 private:
     struct SubIndexStats {
@@ -84,16 +84,16 @@ private:
     };
 
     JsonType
-    get_index_node_structure();
+    get_index_node_structure(IndexNode* root);
 
     JsonType
-    get_leaf_node_size_distribution();
+    get_leaf_node_size_distribution(IndexNode* root);
 
     void
     collect_leaf_sizes(IndexNode* node, Vector<uint32_t>& sizes);
 
     JsonType
-    get_subindex_quality();
+    get_subindex_quality(IndexNode* root);
 
     void
     analyze_subindexes(IndexNode* node, const std::string& path);
@@ -145,7 +145,7 @@ private:
     analyze_entry_point(const IndexNode* node, const Vector<InnerIdType>& node_ids);
 
     JsonType
-    get_graph_node_recall_stats(const std::string& search_param_str);
+    get_graph_node_recall_stats(IndexNode* root, const std::string& search_param_str);
 
     void
     sample_global();

--- a/tests/test_pyramid.cpp
+++ b/tests/test_pyramid.cpp
@@ -770,10 +770,22 @@ struct MultiHierarchyFixture {
     static constexpr int64_t DIM = 4;
 
     std::vector<float> vectors = {
-        1.0f, 0.0f, 0.0f, 0.0f,
-        0.0f, 1.0f, 0.0f, 0.0f,
-        0.0f, 0.0f, 1.0f, 0.0f,
-        0.0f, 0.0f, 0.0f, 1.0f,
+        1.0f,
+        0.0f,
+        0.0f,
+        0.0f,
+        0.0f,
+        1.0f,
+        0.0f,
+        0.0f,
+        0.0f,
+        0.0f,
+        1.0f,
+        0.0f,
+        0.0f,
+        0.0f,
+        0.0f,
+        1.0f,
     };
     std::vector<int64_t> ids = {100, 101, 102, 103};
     std::vector<std::string> site_paths = {"www/news", "www/sports", "www/news", "www/sports"};
@@ -1112,8 +1124,7 @@ TEST_CASE("Multi-Hierarchy: Error - unknown hierarchy in search",
     REQUIRE_FALSE(result.has_value());
 }
 
-TEST_CASE("Multi-Hierarchy: Duplicate label rejected on Add",
-          "[ft][pyramid][multi_hierarchy]") {
+TEST_CASE("Multi-Hierarchy: Duplicate label rejected on Add", "[ft][pyramid][multi_hierarchy]") {
     MultiHierarchyFixture f;
     auto index = vsag::Factory::CreateIndex("pyramid", f.build_param("nsw"));
     REQUIRE(index.has_value());
@@ -1338,7 +1349,8 @@ TEST_CASE("Multi-Hierarchy: Multi-hierarchy union/intersection rejected",
     auto query = vsag::Dataset::Make();
     query->NumElements(1)->Dim(4)->Float32Vectors(qv)->Paths("site", qp_s)->Owner(true);
 
-    std::string sp = R"({"pyramid": {"ef_search": 100, "hierarchies": ["site", "cat"], "hierarchy_op": "intersection"}})";
+    std::string sp =
+        R"({"pyramid": {"ef_search": 100, "hierarchies": ["site", "cat"], "hierarchy_op": "intersection"}})";
     auto result = index.value()->KnnSearch(query, 4, sp);
     REQUIRE_FALSE(result.has_value());
 }

--- a/tests/test_pyramid.cpp
+++ b/tests/test_pyramid.cpp
@@ -758,3 +758,659 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
         REQUIRE(stats.contains("subindex_quality"));
     }
 }
+
+// ============================================================================
+// Multi-Hierarchy Tests
+// ============================================================================
+
+namespace {
+
+struct MultiHierarchyFixture {
+    static constexpr int64_t NUM = 4;
+    static constexpr int64_t DIM = 4;
+
+    std::vector<float> vectors = {
+        1.0f, 0.0f, 0.0f, 0.0f,
+        0.0f, 1.0f, 0.0f, 0.0f,
+        0.0f, 0.0f, 1.0f, 0.0f,
+        0.0f, 0.0f, 0.0f, 1.0f,
+    };
+    std::vector<int64_t> ids = {100, 101, 102, 103};
+    std::vector<std::string> site_paths = {"www/news", "www/sports", "www/news", "www/sports"};
+    std::vector<std::string> cat_paths = {"tech/ai", "tech/web", "science/bio", "science/phys"};
+
+    vsag::DatasetPtr
+    make_base() {
+        auto* rv = new float[NUM * DIM];
+        auto* ri = new int64_t[NUM];
+        auto* rs = new std::string[NUM];
+        auto* rc = new std::string[NUM];
+        std::copy(vectors.begin(), vectors.end(), rv);
+        std::copy(ids.begin(), ids.end(), ri);
+        for (int i = 0; i < NUM; ++i) {
+            rs[i] = site_paths[i];
+            rc[i] = cat_paths[i];
+        }
+        auto ds = vsag::Dataset::Make();
+        ds->NumElements(NUM)
+            ->Dim(DIM)
+            ->Float32Vectors(rv)
+            ->Ids(ri)
+            ->Paths("site", rs)
+            ->Paths("cat", rc)
+            ->Owner(true);
+        return ds;
+    }
+
+    vsag::DatasetPtr
+    make_query(const std::string& hierarchy, const std::string& path) {
+        auto* qv = new float[DIM]{1.0f, 0.0f, 0.0f, 0.0f};
+        auto* qp = new std::string[1]{path};
+        auto ds = vsag::Dataset::Make();
+        ds->NumElements(1)->Dim(DIM)->Float32Vectors(qv)->Paths(hierarchy, qp)->Owner(true);
+        return ds;
+    }
+
+    std::set<int64_t>
+    search_ids(const std::shared_ptr<vsag::Index>& index,
+               const std::string& hierarchy,
+               const std::string& path,
+               int64_t k = 4) {
+        auto query = make_query(hierarchy, path);
+        std::string sp =
+            R"({"pyramid": {"ef_search": 100, "hierarchies": [")" + hierarchy + R"("]}})";
+        auto result = index->KnnSearch(query, k, sp);
+        REQUIRE(result.has_value());
+        auto* rids = result.value()->GetIds();
+        auto cnt = result.value()->GetDim();
+        return std::set<int64_t>(rids, rids + cnt);
+    }
+
+    static std::string
+    build_param(const std::string& graph_type = "nsw", bool use_reorder = false) {
+        std::string reorder_str = use_reorder ? "true" : "false";
+        std::string precise = use_reorder ? R"(, "precise_quantization_type": "fp32")" : "";
+        std::string base_q = use_reorder ? "rabitq" : "fp32";
+        return R"({
+            "dtype": "float32", "metric_type": "l2", "dim": 4,
+            "index_param": {
+                "max_degree": 32, "alpha": 1.2,
+                "graph_type": ")" +
+               graph_type + R"(",
+                "graph_iter_turn": 15, "neighbor_sample_rate": 0.2,
+                "base_quantization_type": ")" +
+               base_q + R"(",
+                "use_reorder": )" +
+               reorder_str + precise + R"(,
+                "index_min_size": 0, "support_duplicate": false,
+                "hierarchies": [
+                    {"name": "site", "no_build_levels": [0]},
+                    {"name": "cat", "no_build_levels": [0, 1]}
+                ]
+            }
+        })";
+    }
+};
+
+}  // namespace
+
+TEST_CASE("Multi-Hierarchy: NSW Build and Search", "[ft][pyramid][multi_hierarchy]") {
+    MultiHierarchyFixture f;
+    auto index = vsag::Factory::CreateIndex("pyramid", f.build_param("nsw"));
+    REQUIRE(index.has_value());
+
+    auto build_result = index.value()->Build(f.make_base());
+    REQUIRE(build_result.has_value());
+
+    // site hierarchy: "www/news" -> ids 100, 102
+    auto site_news = f.search_ids(index.value(), "site", "www/news");
+    REQUIRE(site_news.count(100) == 1);
+    REQUIRE(site_news.count(102) == 1);
+    REQUIRE(site_news.count(101) == 0);
+    REQUIRE(site_news.count(103) == 0);
+
+    // site hierarchy: "www/sports" -> ids 101, 103
+    auto site_sports = f.search_ids(index.value(), "site", "www/sports");
+    REQUIRE(site_sports.count(101) == 1);
+    REQUIRE(site_sports.count(103) == 1);
+    REQUIRE(site_sports.count(100) == 0);
+
+    // cat hierarchy: "tech" -> ids 100, 101
+    auto cat_tech = f.search_ids(index.value(), "cat", "tech");
+    REQUIRE(cat_tech.count(100) == 1);
+    REQUIRE(cat_tech.count(101) == 1);
+    REQUIRE(cat_tech.count(102) == 0);
+
+    // cat hierarchy: "science" -> ids 102, 103
+    auto cat_science = f.search_ids(index.value(), "cat", "science");
+    REQUIRE(cat_science.count(102) == 1);
+    REQUIRE(cat_science.count(103) == 1);
+    REQUIRE(cat_science.count(100) == 0);
+}
+
+TEST_CASE("Multi-Hierarchy: ODescent Build and Search", "[ft][pyramid][multi_hierarchy]") {
+    MultiHierarchyFixture f;
+    auto index = vsag::Factory::CreateIndex("pyramid", f.build_param("odescent"));
+    REQUIRE(index.has_value());
+
+    auto build_result = index.value()->Build(f.make_base());
+    REQUIRE(build_result.has_value());
+
+    auto site_news = f.search_ids(index.value(), "site", "www/news");
+    REQUIRE(site_news.count(100) == 1);
+    REQUIRE(site_news.count(102) == 1);
+
+    auto cat_tech = f.search_ids(index.value(), "cat", "tech");
+    REQUIRE(cat_tech.count(100) == 1);
+    REQUIRE(cat_tech.count(101) == 1);
+}
+
+TEST_CASE("Multi-Hierarchy: Add after Build", "[ft][pyramid][multi_hierarchy]") {
+    MultiHierarchyFixture f;
+    auto index = vsag::Factory::CreateIndex("pyramid", f.build_param("nsw"));
+    REQUIRE(index.has_value());
+
+    // Build with first 2 vectors
+    auto* rv = new float[8];
+    auto* ri = new int64_t[2]{100, 101};
+    auto* rs = new std::string[2]{"www/news", "www/sports"};
+    auto* rc = new std::string[2]{"tech/ai", "tech/web"};
+    std::copy(f.vectors.begin(), f.vectors.begin() + 8, rv);
+    auto base1 = vsag::Dataset::Make();
+    base1->NumElements(2)
+        ->Dim(4)
+        ->Float32Vectors(rv)
+        ->Ids(ri)
+        ->Paths("site", rs)
+        ->Paths("cat", rc)
+        ->Owner(true);
+    REQUIRE(index.value()->Build(base1).has_value());
+
+    // Add 2 more vectors
+    auto* rv2 = new float[8];
+    auto* ri2 = new int64_t[2]{102, 103};
+    auto* rs2 = new std::string[2]{"www/news", "www/sports"};
+    auto* rc2 = new std::string[2]{"science/bio", "science/phys"};
+    std::copy(f.vectors.begin() + 8, f.vectors.end(), rv2);
+    auto base2 = vsag::Dataset::Make();
+    base2->NumElements(2)
+        ->Dim(4)
+        ->Float32Vectors(rv2)
+        ->Ids(ri2)
+        ->Paths("site", rs2)
+        ->Paths("cat", rc2)
+        ->Owner(true);
+    REQUIRE(index.value()->Add(base2).has_value());
+
+    // Verify all 4 vectors are searchable
+    auto site_news = f.search_ids(index.value(), "site", "www/news");
+    REQUIRE(site_news.count(100) == 1);
+    REQUIRE(site_news.count(102) == 1);
+
+    auto cat_science = f.search_ids(index.value(), "cat", "science");
+    REQUIRE(cat_science.count(102) == 1);
+    REQUIRE(cat_science.count(103) == 1);
+}
+
+TEST_CASE("Multi-Hierarchy: Serialize and Deserialize", "[ft][pyramid][multi_hierarchy]") {
+    MultiHierarchyFixture f;
+    auto param_str = f.build_param("nsw");
+    auto index = vsag::Factory::CreateIndex("pyramid", param_str);
+    REQUIRE(index.has_value());
+    REQUIRE(index.value()->Build(f.make_base()).has_value());
+
+    // Serialize
+    auto bs = index.value()->Serialize();
+    REQUIRE(bs.has_value());
+
+    // Deserialize into new index
+    auto index2 = vsag::Factory::CreateIndex("pyramid", param_str);
+    REQUIRE(index2.has_value());
+    index2.value()->Deserialize(bs.value());
+
+    // Search deserialized index
+    auto site_news = f.search_ids(index2.value(), "site", "www/news");
+    REQUIRE(site_news.count(100) == 1);
+    REQUIRE(site_news.count(102) == 1);
+    REQUIRE(site_news.count(101) == 0);
+
+    auto cat_tech = f.search_ids(index2.value(), "cat", "tech");
+    REQUIRE(cat_tech.count(100) == 1);
+    REQUIRE(cat_tech.count(101) == 1);
+    REQUIRE(cat_tech.count(102) == 0);
+}
+
+TEST_CASE("Multi-Hierarchy: Different no_build_levels per hierarchy",
+          "[ft][pyramid][multi_hierarchy]") {
+    MultiHierarchyFixture f;
+    auto index = vsag::Factory::CreateIndex("pyramid", f.build_param("nsw"));
+    REQUIRE(index.has_value());
+    REQUIRE(index.value()->Build(f.make_base()).has_value());
+
+    // Both hierarchies should still return correct results
+    auto site_news = f.search_ids(index.value(), "site", "www/news");
+    REQUIRE(site_news.count(100) == 1);
+    REQUIRE(site_news.count(102) == 1);
+
+    // cat/tech/ai should find id 100
+    auto cat_ai = f.search_ids(index.value(), "cat", "tech/ai");
+    REQUIRE(cat_ai.count(100) == 1);
+}
+
+TEST_CASE("Multi-Hierarchy: Shared vector base distances", "[ft][pyramid][multi_hierarchy]") {
+    MultiHierarchyFixture f;
+    auto index = vsag::Factory::CreateIndex("pyramid", f.build_param("nsw"));
+    REQUIRE(index.has_value());
+    REQUIRE(index.value()->Build(f.make_base()).has_value());
+
+    // id=100 has vector [1,0,0,0]. Query with same vector -> distance = 0.
+    auto* qv1 = new float[4]{1.0f, 0.0f, 0.0f, 0.0f};
+    auto* qp1 = new std::string[1]{"www/news"};
+    auto q_site = vsag::Dataset::Make();
+    q_site->NumElements(1)->Dim(4)->Float32Vectors(qv1)->Paths("site", qp1)->Owner(true);
+    std::string sp_site = R"({"pyramid": {"ef_search": 100, "hierarchies": ["site"]}})";
+    auto r_site = index.value()->KnnSearch(q_site, 4, sp_site);
+    REQUIRE(r_site.has_value());
+
+    auto* qv2 = new float[4]{1.0f, 0.0f, 0.0f, 0.0f};
+    auto* qp2 = new std::string[1]{"tech"};
+    auto q_cat = vsag::Dataset::Make();
+    q_cat->NumElements(1)->Dim(4)->Float32Vectors(qv2)->Paths("cat", qp2)->Owner(true);
+    std::string sp_cat = R"({"pyramid": {"ef_search": 100, "hierarchies": ["cat"]}})";
+    auto r_cat = index.value()->KnnSearch(q_cat, 4, sp_cat);
+    REQUIRE(r_cat.has_value());
+
+    // Find distance for id=100 in both results — should be ~0 and identical
+    float dist_site = -1, dist_cat = -1;
+    for (int64_t i = 0; i < r_site.value()->GetDim(); ++i) {
+        if (r_site.value()->GetIds()[i] == 100) {
+            dist_site = r_site.value()->GetDistances()[i];
+        }
+    }
+    for (int64_t i = 0; i < r_cat.value()->GetDim(); ++i) {
+        if (r_cat.value()->GetIds()[i] == 100) {
+            dist_cat = r_cat.value()->GetDistances()[i];
+        }
+    }
+    REQUIRE(dist_site >= 0);
+    REQUIRE(dist_cat >= 0);
+    REQUIRE(std::abs(dist_site - dist_cat) < 1e-6f);
+    REQUIRE(std::abs(dist_site) < 1e-6f);
+}
+
+TEST_CASE("Multi-Hierarchy: Partial paths - only some hierarchies provided",
+          "[ft][pyramid][multi_hierarchy]") {
+    MultiHierarchyFixture f;
+    auto index = vsag::Factory::CreateIndex("pyramid", f.build_param("nsw"));
+    REQUIRE(index.has_value());
+
+    // Build with only "site" paths, no "cat" paths
+    auto* rv = new float[4]{1.0f, 0.0f, 0.0f, 0.0f};
+    auto* ri = new int64_t[1]{100};
+    auto* rs = new std::string[1]{"www/news"};
+    auto base = vsag::Dataset::Make();
+    base->NumElements(1)->Dim(4)->Float32Vectors(rv)->Ids(ri)->Paths("site", rs)->Owner(true);
+
+    auto result = index.value()->Build(base);
+    REQUIRE(result.has_value());
+
+    // Search in "site" hierarchy -> should find id=100
+    auto site_result = f.search_ids(index.value(), "site", "www/news");
+    REQUIRE(site_result.count(100) == 1);
+
+    // Search in "cat" hierarchy -> should NOT find id=100
+    auto* qv = new float[4]{1.0f, 0.0f, 0.0f, 0.0f};
+    auto* qp = new std::string[1]{"tech"};
+    auto query = vsag::Dataset::Make();
+    query->NumElements(1)->Dim(4)->Float32Vectors(qv)->Paths("cat", qp)->Owner(true);
+    std::string sp = R"({"pyramid": {"ef_search": 100, "hierarchies": ["cat"]}})";
+    auto cat_result = index.value()->KnnSearch(query, 4, sp);
+    REQUIRE(cat_result.has_value());
+    REQUIRE(cat_result.value()->GetDim() == 0);
+}
+
+TEST_CASE("Multi-Hierarchy: Partial paths - Add to subset of hierarchies",
+          "[ft][pyramid][multi_hierarchy]") {
+    MultiHierarchyFixture f;
+    auto index = vsag::Factory::CreateIndex("pyramid", f.build_param("nsw"));
+    REQUIRE(index.has_value());
+    REQUIRE(index.value()->Build(f.make_base()).has_value());
+
+    // Add with only "site" paths, no "cat" paths
+    auto* rv = new float[4]{0.5f, 0.5f, 0.0f, 0.0f};
+    auto* ri = new int64_t[1]{200};
+    auto* rs = new std::string[1]{"www/news"};
+    auto add_ds = vsag::Dataset::Make();
+    add_ds->NumElements(1)->Dim(4)->Float32Vectors(rv)->Ids(ri)->Paths("site", rs)->Owner(true);
+
+    auto result = index.value()->Add(add_ds);
+    REQUIRE(result.has_value());
+
+    // id=200 should be findable in "site"
+    auto site_result = f.search_ids(index.value(), "site", "www/news");
+    REQUIRE(site_result.count(200) == 1);
+
+    // id=200 should NOT be findable in "cat"
+    auto cat_tech = f.search_ids(index.value(), "cat", "tech");
+    REQUIRE(cat_tech.count(200) == 0);
+}
+
+TEST_CASE("Multi-Hierarchy: Error - unknown hierarchy in search",
+          "[ft][pyramid][multi_hierarchy]") {
+    MultiHierarchyFixture f;
+    auto index = vsag::Factory::CreateIndex("pyramid", f.build_param("nsw"));
+    REQUIRE(index.has_value());
+    REQUIRE(index.value()->Build(f.make_base()).has_value());
+
+    auto* qv = new float[4]{1.0f, 0.0f, 0.0f, 0.0f};
+    auto* qp = new std::string[1]{"anything"};
+    auto query = vsag::Dataset::Make();
+    query->NumElements(1)->Dim(4)->Float32Vectors(qv)->Paths("unknown", qp)->Owner(true);
+
+    std::string sp = R"({"pyramid": {"ef_search": 100, "hierarchies": ["unknown"]}})";
+    auto result = index.value()->KnnSearch(query, 4, sp);
+    REQUIRE_FALSE(result.has_value());
+}
+
+TEST_CASE("Multi-Hierarchy: Duplicate label rejected on Add",
+          "[ft][pyramid][multi_hierarchy]") {
+    MultiHierarchyFixture f;
+    auto index = vsag::Factory::CreateIndex("pyramid", f.build_param("nsw"));
+    REQUIRE(index.has_value());
+    REQUIRE(index.value()->Build(f.make_base()).has_value());
+
+    // Try to add id=100 again (already exists)
+    auto* rv = new float[4]{0.9f, 0.1f, 0.0f, 0.0f};
+    auto* ri = new int64_t[1]{100};
+    auto* rs = new std::string[1]{"www/news"};
+    auto* rc = new std::string[1]{"tech/ai"};
+    auto add_ds = vsag::Dataset::Make();
+    add_ds->NumElements(1)
+        ->Dim(4)
+        ->Float32Vectors(rv)
+        ->Ids(ri)
+        ->Paths("site", rs)
+        ->Paths("cat", rc)
+        ->Owner(true);
+
+    auto result = index.value()->Add(add_ds);
+    REQUIRE(result.has_value());
+    // id=100 should be in the failed list
+    auto failed = result.value();
+    bool found_in_failed = false;
+    for (auto id : failed) {
+        if (id == 100) {
+            found_in_failed = true;
+        }
+    }
+    REQUIRE(found_in_failed);
+}
+
+TEST_CASE("Multi-Hierarchy: Legacy single-hierarchy serialize compat",
+          "[ft][pyramid][multi_hierarchy][serialization]") {
+    // Build with single-hierarchy (no "hierarchies" param) -> serialize -> deserialize -> search
+    std::string single_param = R"({
+        "dtype": "float32", "metric_type": "l2", "dim": 4,
+        "index_param": {
+            "max_degree": 32, "alpha": 1.2, "graph_type": "nsw",
+            "base_quantization_type": "fp32", "use_reorder": false,
+            "index_min_size": 0, "support_duplicate": false,
+            "no_build_levels": [0]
+        }
+    })";
+
+    auto index1 = vsag::Factory::CreateIndex("pyramid", single_param);
+    REQUIRE(index1.has_value());
+
+    auto* rv = new float[8]{1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f};
+    auto* ri = new int64_t[2]{10, 20};
+    auto* rp = new std::string[2]{"a/b", "a/c"};
+    auto base = vsag::Dataset::Make();
+    base->NumElements(2)->Dim(4)->Float32Vectors(rv)->Ids(ri)->Paths(rp)->Owner(true);
+    REQUIRE(index1.value()->Build(base).has_value());
+
+    auto bs = index1.value()->Serialize();
+    REQUIRE(bs.has_value());
+
+    auto index2 = vsag::Factory::CreateIndex("pyramid", single_param);
+    REQUIRE(index2.has_value());
+    index2.value()->Deserialize(bs.value());
+
+    auto* qv = new float[4]{1.0f, 0.0f, 0.0f, 0.0f};
+    auto* qp = new std::string[1]{"a/b"};
+    auto query = vsag::Dataset::Make();
+    query->NumElements(1)->Dim(4)->Float32Vectors(qv)->Paths(qp)->Owner(true);
+    std::string sp = R"({"pyramid": {"ef_search": 100}})";
+    auto result = index2.value()->KnnSearch(query, 2, sp);
+    REQUIRE(result.has_value());
+
+    auto* result_ids = result.value()->GetIds();
+    auto cnt = result.value()->GetDim();
+    std::set<int64_t> found(result_ids, result_ids + cnt);
+    REQUIRE(found.count(10) == 1);
+}
+
+TEST_CASE("Multi-Hierarchy: Serialize roundtrip preserves isolation",
+          "[ft][pyramid][multi_hierarchy][serialization]") {
+    MultiHierarchyFixture f;
+    auto param_str = f.build_param("nsw");
+
+    auto index1 = vsag::Factory::CreateIndex("pyramid", param_str);
+    REQUIRE(index1.has_value());
+    REQUIRE(index1.value()->Build(f.make_base()).has_value());
+
+    auto bs = index1.value()->Serialize();
+    REQUIRE(bs.has_value());
+
+    auto index2 = vsag::Factory::CreateIndex("pyramid", param_str);
+    REQUIRE(index2.has_value());
+    index2.value()->Deserialize(bs.value());
+
+    // Verify isolation: site/www/sports should NOT contain id=100
+    auto site_sports = f.search_ids(index2.value(), "site", "www/sports");
+    REQUIRE(site_sports.count(100) == 0);
+    REQUIRE(site_sports.count(101) == 1);
+    REQUIRE(site_sports.count(103) == 1);
+
+    // Verify isolation: cat/science should NOT contain id=100 or id=101
+    auto cat_science = f.search_ids(index2.value(), "cat", "science");
+    REQUIRE(cat_science.count(100) == 0);
+    REQUIRE(cat_science.count(101) == 0);
+    REQUIRE(cat_science.count(102) == 1);
+    REQUIRE(cat_science.count(103) == 1);
+}
+
+TEST_CASE("Multi-Hierarchy: Per-hierarchy build params take effect",
+          "[ft][pyramid][multi_hierarchy]") {
+    // Create with different max_degree per hierarchy
+    std::string param = R"({
+        "dtype": "float32", "metric_type": "l2", "dim": 4,
+        "index_param": {
+            "max_degree": 16, "alpha": 1.0,
+            "graph_type": "nsw",
+            "base_quantization_type": "fp32",
+            "use_reorder": false,
+            "index_min_size": 0, "support_duplicate": false,
+            "hierarchies": [
+                {"name": "site", "no_build_levels": [0], "max_degree": 64, "alpha": 1.5},
+                {"name": "cat", "no_build_levels": [0]}
+            ]
+        }
+    })";
+
+    MultiHierarchyFixture f;
+    auto index = vsag::Factory::CreateIndex("pyramid", param);
+    REQUIRE(index.has_value());
+    REQUIRE(index.value()->Build(f.make_base()).has_value());
+
+    // Both hierarchies should work correctly regardless of different params
+    auto site_news = f.search_ids(index.value(), "site", "www/news");
+    REQUIRE(site_news.count(100) == 1);
+    REQUIRE(site_news.count(102) == 1);
+
+    auto cat_tech = f.search_ids(index.value(), "cat", "tech");
+    REQUIRE(cat_tech.count(100) == 1);
+    REQUIRE(cat_tech.count(101) == 1);
+}
+
+TEST_CASE("Multi-Hierarchy: Analyzer output format - multi hierarchy",
+          "[ft][pyramid][multi_hierarchy][analyzer]") {
+    MultiHierarchyFixture f;
+    auto index = vsag::Factory::CreateIndex("pyramid", f.build_param("nsw"));
+    REQUIRE(index.has_value());
+    REQUIRE(index.value()->Build(f.make_base()).has_value());
+
+    auto stats_str = index.value()->GetStats();
+    REQUIRE(!stats_str.empty());
+    auto stats = nlohmann::json::parse(stats_str);
+
+    REQUIRE(stats.contains("total_count"));
+    REQUIRE(stats["total_count"].get<int64_t>() == 4);
+    REQUIRE(stats.contains("hierarchy_count"));
+    REQUIRE(stats["hierarchy_count"].get<int64_t>() == 2);
+    REQUIRE(stats.contains("hierarchies"));
+    REQUIRE(stats["hierarchies"].contains("site"));
+    REQUIRE(stats["hierarchies"].contains("cat"));
+    REQUIRE(stats["hierarchies"]["site"].contains("index_node_structure"));
+    REQUIRE(stats["hierarchies"]["site"].contains("leaf_node_size_distribution"));
+    REQUIRE(stats["hierarchies"]["site"].contains("subindex_quality"));
+    REQUIRE(stats["hierarchies"]["cat"].contains("index_node_structure"));
+}
+
+TEST_CASE("Multi-Hierarchy: Analyzer output format - single hierarchy compat",
+          "[ft][pyramid][multi_hierarchy][analyzer]") {
+    std::string param = R"({
+        "dtype": "float32", "metric_type": "l2", "dim": 4,
+        "index_param": {
+            "max_degree": 32, "alpha": 1.2, "graph_type": "nsw",
+            "base_quantization_type": "fp32", "use_reorder": false,
+            "index_min_size": 0, "support_duplicate": false,
+            "no_build_levels": [0, 1, 2]
+        }
+    })";
+    auto index = vsag::Factory::CreateIndex("pyramid", param);
+    REQUIRE(index.has_value());
+
+    auto* rv = new float[8]{1, 0, 0, 0, 0, 1, 0, 0};
+    auto* ri = new int64_t[2]{1, 2};
+    auto* rp = new std::string[2]{"a/b/c", "a/b/d"};
+    auto ds = vsag::Dataset::Make();
+    ds->NumElements(2)->Dim(4)->Float32Vectors(rv)->Ids(ri)->Paths(rp)->Owner(true);
+    REQUIRE(index.value()->Build(ds).has_value());
+
+    auto stats_str = index.value()->GetStats();
+    auto stats = nlohmann::json::parse(stats_str);
+
+    REQUIRE(stats.contains("total_count"));
+    REQUIRE(stats.contains("index_node_structure"));
+    REQUIRE(stats.contains("leaf_node_size_distribution"));
+    REQUIRE(stats.contains("subindex_quality"));
+    REQUIRE_FALSE(stats.contains("hierarchies"));
+    REQUIRE_FALSE(stats.contains("hierarchy_count"));
+}
+
+TEST_CASE("Multi-Hierarchy: Search without hierarchies param in multi-mode errors",
+          "[ft][pyramid][multi_hierarchy]") {
+    MultiHierarchyFixture f;
+    auto index = vsag::Factory::CreateIndex("pyramid", f.build_param("nsw"));
+    REQUIRE(index.has_value());
+    REQUIRE(index.value()->Build(f.make_base()).has_value());
+
+    auto* qv = new float[4]{1.0f, 0.0f, 0.0f, 0.0f};
+    auto* qp = new std::string[1]{"www/news"};
+    auto query = vsag::Dataset::Make();
+    query->NumElements(1)->Dim(4)->Float32Vectors(qv)->Paths(qp)->Owner(true);
+
+    std::string sp = R"({"pyramid": {"ef_search": 100}})";
+    auto result = index.value()->KnnSearch(query, 4, sp);
+    REQUIRE_FALSE(result.has_value());
+}
+
+TEST_CASE("Multi-Hierarchy: Multi-hierarchy union/intersection rejected",
+          "[ft][pyramid][multi_hierarchy]") {
+    MultiHierarchyFixture f;
+    auto index = vsag::Factory::CreateIndex("pyramid", f.build_param("nsw"));
+    REQUIRE(index.has_value());
+    REQUIRE(index.value()->Build(f.make_base()).has_value());
+
+    auto* qv = new float[4]{1.0f, 0.0f, 0.0f, 0.0f};
+    auto* qp_s = new std::string[1]{"www/news"};
+    auto query = vsag::Dataset::Make();
+    query->NumElements(1)->Dim(4)->Float32Vectors(qv)->Paths("site", qp_s)->Owner(true);
+
+    std::string sp = R"({"pyramid": {"ef_search": 100, "hierarchies": ["site", "cat"], "hierarchy_op": "intersection"}})";
+    auto result = index.value()->KnnSearch(query, 4, sp);
+    REQUIRE_FALSE(result.has_value());
+}
+
+TEST_CASE("Multi-Hierarchy: RangeSearch works", "[ft][pyramid][multi_hierarchy]") {
+    MultiHierarchyFixture f;
+    auto index = vsag::Factory::CreateIndex("pyramid", f.build_param("nsw"));
+    REQUIRE(index.has_value());
+    REQUIRE(index.value()->Build(f.make_base()).has_value());
+
+    auto* qv = new float[4]{1.0f, 0.0f, 0.0f, 0.0f};
+    auto* qp = new std::string[1]{"www/news"};
+    auto query = vsag::Dataset::Make();
+    query->NumElements(1)->Dim(4)->Float32Vectors(qv)->Paths("site", qp)->Owner(true);
+
+    std::string sp = R"({"pyramid": {"ef_search": 100, "hierarchies": ["site"]}})";
+    auto result = index.value()->RangeSearch(query, 2.0f, sp);
+    REQUIRE(result.has_value());
+    auto* rids = result.value()->GetIds();
+    auto cnt = result.value()->GetDim();
+    std::set<int64_t> found(rids, rids + cnt);
+    REQUIRE(found.count(100) == 1);
+    REQUIRE(found.count(101) == 0);
+    REQUIRE(found.count(103) == 0);
+}
+
+TEST_CASE("Multi-Hierarchy: Reorder with multi-hierarchy", "[ft][pyramid][multi_hierarchy]") {
+    MultiHierarchyFixture f;
+    auto index = vsag::Factory::CreateIndex("pyramid", f.build_param("nsw", true));
+    REQUIRE(index.has_value());
+    REQUIRE(index.value()->Build(f.make_base()).has_value());
+
+    auto site_news = f.search_ids(index.value(), "site", "www/news");
+    REQUIRE(site_news.count(100) == 1);
+    REQUIRE(site_news.count(102) == 1);
+    REQUIRE(site_news.count(101) == 0);
+
+    auto cat_tech = f.search_ids(index.value(), "cat", "tech");
+    REQUIRE(cat_tech.count(100) == 1);
+    REQUIRE(cat_tech.count(101) == 1);
+}
+
+TEST_CASE("Multi-Hierarchy: Single hierarchy in hierarchies config",
+          "[ft][pyramid][multi_hierarchy]") {
+    std::string param = R"({
+        "dtype": "float32", "metric_type": "l2", "dim": 4,
+        "index_param": {
+            "max_degree": 32, "alpha": 1.2, "graph_type": "nsw",
+            "base_quantization_type": "fp32", "use_reorder": false,
+            "index_min_size": 0, "support_duplicate": false,
+            "hierarchies": [{"name": "only", "no_build_levels": [0]}]
+        }
+    })";
+
+    auto index = vsag::Factory::CreateIndex("pyramid", param);
+    REQUIRE(index.has_value());
+
+    auto* rv = new float[8]{1, 0, 0, 0, 0, 1, 0, 0};
+    auto* ri = new int64_t[2]{10, 20};
+    auto* rp = new std::string[2]{"a/b", "a/c"};
+    auto ds = vsag::Dataset::Make();
+    ds->NumElements(2)->Dim(4)->Float32Vectors(rv)->Ids(ri)->Paths("only", rp)->Owner(true);
+    REQUIRE(index.value()->Build(ds).has_value());
+
+    auto* qv = new float[4]{1, 0, 0, 0};
+    auto* qp = new std::string[1]{"a/b"};
+    auto query = vsag::Dataset::Make();
+    query->NumElements(1)->Dim(4)->Float32Vectors(qv)->Paths("only", qp)->Owner(true);
+    std::string sp = R"({"pyramid": {"ef_search": 100, "hierarchies": ["only"]}})";
+    auto result = index.value()->KnnSearch(query, 2, sp);
+    REQUIRE(result.has_value());
+    auto* rids = result.value()->GetIds();
+    std::set<int64_t> found(rids, rids + result.value()->GetDim());
+    REQUIRE(found.count(10) == 1);
+}


### PR DESCRIPTION
## Summary
- Implement multi-hierarchy support for Pyramid index: per-hierarchy parameters (max_degree, ef_construction, alpha, no_build_levels, index_min_size), parallel Build/Add across hierarchies, and single-hierarchy KnnSearch/RangeSearch
- Add comprehensive test coverage for the multi-hierarchy API
- Fix clang-tidy lint errors (const correctness, static method, lambda captures)

Closes: #2100

## Test plan
- [x] Unit tests for multi-hierarchy Build with per-hierarchy graph params
- [x] Unit tests for Add with path-based routing to named hierarchies
- [x] Unit tests for single-hierarchy KnnSearch and RangeSearch
- [x] clang-tidy passes cleanly (`make lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)