### PR TITLE
fix: prevent int16 accumulator overflow in SQ4UniformComputeCodesIPImpl

### DIFF
--- a/src/simd/kernels/sq4_uniform_compute.h
+++ b/src/simd/kernels/sq4_uniform_compute.h
@@ -32,6 +32,9 @@ SQ4UniformComputeCodesIPImpl(const uint8_t* codes1,
     }
 
     constexpr uint64_t kElemsPerIter = T::ByteWidth * 2;
+    // Each iteration adds at most ~900 to each int16 lane; overflow at ~36 iters.
+    constexpr int kFlushInterval = 32;
+    constexpr uint64_t kFlushElems = kElemsPerIter * kFlushInterval;
     int32_t result = 0;
     uint64_t d = 0;
     auto sum = T::zero();
@@ -47,6 +50,11 @@ SQ4UniformComputeCodesIPImpl(const uint8_t* codes1,
 
         sum = T::add_epi16(sum, T::maddubs_epi16(xx1, yy1));
         sum = T::add_epi16(sum, T::maddubs_epi16(xx2, yy2));
+
+        if ((d + kElemsPerIter) % kFlushElems == 0) {
+            result += T::reduce_add_epi16(sum);
+            sum = T::zero();
+        }
     }
 
     result += T::reduce_add_epi16(sum);

--- a/src/simd/sq4_uniform_simd_test.cpp
+++ b/src/simd/sq4_uniform_simd_test.cpp
@@ -71,6 +71,19 @@ TEST_CASE("SQ4 Uniform SIMD Compute Codes", "[ut][simd]") {
     }
 }
 
+TEST_CASE("SQ4 Uniform SIMD Compute Codes High Dim", "[ut][simd]") {
+    std::vector<int> high_dims = {2048, 4096, 8192};
+    int64_t count = 10;
+    for (const auto& dim : high_dims) {
+        uint32_t code_size = (dim + 1) / 2;
+        auto codes1 = fixtures::generate_int4_codes(count, dim, 114);
+        auto codes2 = fixtures::generate_int4_codes(count, dim, 514);
+        for (uint64_t i = 0; i < count; ++i) {
+            TEST_ACCURACY(SQ4UniformComputeCodesIP);
+        }
+    }
+}
+
 #define BENCHMARK_SIMD_COMPUTE(Simd, Comp)                                                 \
     BENCHMARK_ADVANCED(#Simd #Comp) {                                                      \
         for (int i = 0; i < count; ++i) {                                                  \


### PR DESCRIPTION
## Summary

- Fix int16 accumulator overflow in `SQ4UniformComputeCodesIPImpl` by adding periodic flush every 32 iterations
- The int16 accumulator overflows for dim > 1152 (SSE), > 2304 (AVX2), > 4608 (AVX512), producing incorrect inner product results
- Add high-dimension test cases (2048, 4096, 8192) to prevent regression

Closes #2228

## Changes

- `src/simd/kernels/sq4_uniform_compute.h`: Add `kFlushInterval = 32` and periodic `reduce_add_epi16` + `zero()` inside the loop
- `src/simd/sq4_uniform_simd_test.cpp`: Add "SQ4 Uniform SIMD Compute Codes High Dim" test case

## Test Plan

- [x] Existing SQ4 Uniform SIMD tests pass (10400 assertions)
- [x] New high-dimension tests pass (120 assertions across dims 2048, 4096, 8192)
- [x] `make fmt` clean