### PR TITLE
fix(io): add nullptr check in AsyncIO::ReadImpl before memcpy

### DIFF
--- a/src/io/async_io.cpp
+++ b/src/io/async_io.cpp
@@ -91,6 +91,9 @@ bool
 AsyncIO::ReadImpl(uint64_t size, uint64_t offset, uint8_t* data) const {
     bool need_release = true;
     const auto* ptr = DirectReadImpl(size, offset, need_release);
+    if (ptr == nullptr) {
+        return false;
+    }
     memcpy(data, ptr, size);
     AsyncIO::ReleaseImpl(ptr);
     return true;


### PR DESCRIPTION
## Summary

Fix undefined behavior in `AsyncIO::ReadImpl` when `DirectReadImpl` returns `nullptr`.

`DirectReadImpl` returns `nullptr` when `check_valid_offset(size + offset)` fails or `size == 0`. Without a null check, the subsequent `memcpy(data, nullptr, size)` is UB per the C++ standard. Additionally, `ReadImpl` was unconditionally returning `true`, masking the failure from callers.

## Changes

- Add `nullptr` check after `DirectReadImpl` call
- Return `false` early to correctly signal read failure

Closes #2230