### PR TITLE
fix(datacell): widen SparseVectorDataCell offset from uint32 to uint64

### DIFF
--- a/src/datacell/sparse_vector_datacell.h
+++ b/src/datacell/sparse_vector_datacell.h
@@ -80,7 +80,7 @@ public:
         }
         uint64_t io_size = (new_capacity - total_count_) * max_code_size_ + current_offset_;
         this->io_->Resize(io_size);
-        this->offset_io_->Resize(static_cast<uint64_t>(new_capacity) * sizeof(uint32_t));
+        this->offset_io_->Resize(static_cast<uint64_t>(new_capacity) * sizeof(uint64_t));
         this->max_capacity_ = new_capacity;
     }
 
@@ -159,7 +159,7 @@ private:
 
     Allocator* const allocator_{nullptr};
     std::shared_ptr<MemoryBlockIO> offset_io_{nullptr};
-    uint32_t current_offset_{0};
+    uint64_t current_offset_{0};
     uint64_t max_code_size_{0};
     std::mutex current_offset_mutex_;
 };

--- a/src/datacell/sparse_vector_datacell.inl
+++ b/src/datacell/sparse_vector_datacell.inl
@@ -93,7 +93,7 @@ SparseVectorDataCell<QuantTmpl, IOTmpl>::InsertVector(const void* vector, InnerI
     }
     auto* codes = reinterpret_cast<uint8_t*>(allocator_->Allocate(code_size));
     quantizer_->EncodeOne((const float*)vector, codes);
-    uint32_t old_offset = 0;
+    uint64_t old_offset = 0;
     {
         std::lock_guard lock(current_offset_mutex_);
         old_offset = current_offset_;
@@ -114,7 +114,7 @@ SparseVectorDataCell<QuantTmpl, IOTmpl>::InMemory() const {
 template <typename QuantTmpl, typename IOTmpl>
 const uint8_t*
 SparseVectorDataCell<QuantTmpl, IOTmpl>::GetCodesById(InnerIdType id, bool& need_release) const {
-    uint32_t offset;
+    uint64_t offset = 0;
     offset_io_->Read(sizeof(offset), id * sizeof(offset), (uint8_t*)&offset);
     uint32_t length;
     io_->Read(sizeof(length), offset, (uint8_t*)&length);


### PR DESCRIPTION
Closes #2234

## Problem

`SparseVectorDataCell` uses `uint32_t` for `current_offset_` and the per-vector offset stored in `offset_io_`. When cumulative sparse vector data exceeds 4GB (2^32 bytes), the offset wraps around silently, causing newly inserted vectors to overwrite earlier data.

## Root Cause

- `current_offset_` is declared as `uint32_t` (max ~4GB)
- `InsertVector` stores offsets as 4-byte values in `offset_io_`
- `GetCodesById` reads offsets as `uint32_t`
- No overflow check exists

## Fix

Widen all offset-related types from `uint32_t` to `uint64_t`:
- Member `current_offset_`: `uint32_t` -> `uint64_t`
- Local `old_offset` in `InsertVector`: `uint32_t` -> `uint64_t`
- Local `offset` in `GetCodesById`: `uint32_t` -> `uint64_t`
- Offset slot width in `Resize`: `sizeof(uint32_t)` -> `sizeof(uint64_t)`

## Files Changed

- `src/datacell/sparse_vector_datacell.h`
- `src/datacell/sparse_vector_datacell.inl`

## Testing

- All `[SparseDataCell]` tests pass (12006 assertions)
- `[SparseVectorDataCellParameter]` test passes
- `[SparseGraphDataCell]` tests pass (663030 assertions)
- Release build succeeds