### PR TITLE
feat(hgraph): expose ImportCache build hit-rate via GetStats

### DIFF
--- a/docs/docs/en/src/resources/analyze_index.md
+++ b/docs/docs/en/src/resources/analyze_index.md
@@ -46,6 +46,8 @@ exposed through `GetStats()` rather than through `AnalyzeIndexBySearch`.
 | `proximity_recall_neighbor` | Recall of graph neighbor lists against true nearest neighbors |
 | `quantization_bias_ratio` | Quantized-distance bias against exact distance |
 | `quantization_inversion_count_rate` | Rate of distance-order inversions caused by quantization |
+| `build_cache_hit_rate` | Fraction of nodes warm-started from an imported cache during the last `Build()`; emits a `skipped_reason` when the index was not built from a cache imported via `ImportCache()` |
+| `build_cache_hit_nodes` / `build_cache_missed_nodes` | Node counts behind `build_cache_hit_rate` (only present when the index was built from an imported cache) |
 
 #### SINDI metrics
 

--- a/docs/docs/zh/src/resources/analyze_index.md
+++ b/docs/docs/zh/src/resources/analyze_index.md
@@ -43,6 +43,8 @@ AnalyzeIndexBySearch(const SearchRequest& request);
 | `proximity_recall_neighbor` | 邻居列表相对真实最近邻的召回率 |
 | `quantization_bias_ratio` | 量化距离相对精确距离的偏差比率 |
 | `quantization_inversion_count_rate` | 量化导致的距离顺序倒置比率 |
+| `build_cache_hit_rate` | 上一次 `Build()` 中从导入缓存完成 warm-start 的节点占比；当索引并非由 `ImportCache()` 导入的缓存构建时，输出 `skipped_reason` |
+| `build_cache_hit_nodes` / `build_cache_missed_nodes` | `build_cache_hit_rate` 背后的命中 / 未命中节点数（仅在索引由导入缓存构建时存在） |
 
 #### SINDI 指标
 

--- a/src/algorithm/hgraph/hgraph.cpp
+++ b/src/algorithm/hgraph/hgraph.cpp
@@ -470,6 +470,18 @@ HGraph::GetStats() const {
         fmt::format(R"({{"hgraph": {{"ef_search": {}}}}})", ef_construct_);
     auto analyzer = CreateAnalyzer(this, analyzer_param);
     JsonType stats = analyzer->GetStats();
+    // Build-time cache hit-rate is a transient property of the
+    // build_with_cache() path (taken only after ImportCache()), so it lives on
+    // HGraph rather than in the post-hoc analyzer. A negative rate means this
+    // index was not built from an imported cache.
+    if (this->build_cache_hit_rate_ >= 0.0F) {
+        stats["build_cache_hit_rate"].SetFloat(this->build_cache_hit_rate_);
+        stats["build_cache_hit_nodes"].SetInt(this->build_cache_hit_nodes_);
+        stats["build_cache_missed_nodes"].SetInt(this->build_cache_missed_nodes_);
+    } else {
+        stats["build_cache_hit_rate"]["skipped_reason"].SetString(
+            "index was not built from an imported cache");
+    }
     return stats.Dump(4);
 }
 

--- a/src/algorithm/hgraph/hgraph.h
+++ b/src/algorithm/hgraph/hgraph.h
@@ -545,5 +545,14 @@ private:
     bool persist_source_id_{false};
 
     std::unique_ptr<HGraphCache> cache_{nullptr};
+
+    // Build-time warm-start cache hit statistics, populated by
+    // cache_warm_start_and_classify() when Build() takes the
+    // build_with_cache() path (i.e. after ImportCache()). A negative
+    // hit-rate marks "this index was not built from an imported cache",
+    // in which case GetStats() emits a skipped_reason instead of values.
+    float build_cache_hit_rate_{-1.0F};
+    uint64_t build_cache_hit_nodes_{0};
+    uint64_t build_cache_missed_nodes_{0};
 };
 }  // namespace vsag

--- a/src/algorithm/hgraph/hgraph_build.cpp
+++ b/src/algorithm/hgraph/hgraph_build.cpp
@@ -88,6 +88,9 @@ HGraph::Train(const DatasetPtr& base) {
 std::vector<int64_t>
 HGraph::Build(const DatasetPtr& data) {
     CHECK_ARGUMENT(GetNumElements() == 0, "index is not empty");
+    this->build_cache_hit_rate_ = -1.0F;
+    this->build_cache_hit_nodes_ = 0;
+    this->build_cache_missed_nodes_ = 0;
     if (this->has_loaded_cache()) {
         // A previously exported cache has been imported via ImportCache().
         // Take the accelerated build path that warm-starts neighbours from
@@ -1432,6 +1435,11 @@ HGraph::cache_warm_start_and_classify(BuildCachePlan& plan) {
     const float hit_rate = total_classified > 0 ? static_cast<float>(hit_ids.size()) /
                                                       static_cast<float>(total_classified)
                                                 : 0.0F;
+    // Publish the classification result so GetStats() can report how well the
+    // imported cache covered this build without having to scrape the log.
+    this->build_cache_hit_nodes_ = hit_ids.size();
+    this->build_cache_missed_nodes_ = missed_ids.size();
+    this->build_cache_hit_rate_ = hit_rate;
     logger::info(
         "[hgraph_build_cache] warm_start finished in {:.3f}s hit_nodes={} missed_nodes={} "
         "hit_empty_seed_nodes={} hit_seed_neighbor_total={} hit_rate={:.4f}",

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -2840,3 +2840,87 @@ TEST_CASE("HGraph ExportCache + ImportCache + Build miss-only path", "[ft][hgrap
     }
     REQUIRE(found_self);
 }
+
+TEST_CASE("HGraph GetStats reports build cache hit-rate", "[ft][hgraph][cache][pr]") {
+    // Verify that the build-time warm-start hit-rate computed during
+    // build_with_cache() is surfaced through GetStats():
+    //   (1) A normal Build() (no imported cache) reports a skipped_reason.
+    //   (2) A Build() after ImportCache() reports a numeric hit-rate plus the
+    //       hit / missed node counts, and the counts sum to the index size.
+    constexpr int64_t TEST_DIM = 32;
+    constexpr int64_t TEST_COUNT = 200;
+
+    const auto* param = R"(
+    {
+        "dtype": "float32",
+        "metric_type": "l2",
+        "dim": 32,
+        "index_param": {
+            "base_quantization_type": "fp32",
+            "max_degree": 16,
+            "ef_construction": 50
+        }
+    }
+    )";
+
+    std::mt19937 rng(42);
+    std::uniform_real_distribution<float> dist(-1.0F, 1.0F);
+    std::vector<float> vectors(TEST_DIM * TEST_COUNT);
+    for (auto& v : vectors) {
+        v = dist(rng);
+    }
+    std::vector<int64_t> ids(TEST_COUNT);
+    std::vector<std::string> source_ids(TEST_COUNT);
+    for (int64_t i = 0; i < TEST_COUNT; ++i) {
+        ids[i] = i + 1;
+        source_ids[i] = fmt::format("sid_{}", i);
+    }
+
+    auto make_dataset = [&]() {
+        auto base = vsag::Dataset::Make();
+        base->NumElements(TEST_COUNT)
+            ->Dim(TEST_DIM)
+            ->Ids(ids.data())
+            ->Float32Vectors(vectors.data())
+            ->SourceID(source_ids.data())
+            ->Owner(false);
+        return base;
+    };
+
+    // ---- (1) normal build: hit-rate is skipped ----
+    auto baseline = vsag::Factory::CreateIndex("hgraph", param).value();
+    REQUIRE(baseline->Build(make_dataset()).has_value());
+    auto baseline_stats = baseline->GetStats();
+    INFO(baseline_stats);
+    auto baseline_parsed = vsag::JsonType::Parse(baseline_stats);
+    REQUIRE(baseline_parsed.Contains("build_cache_hit_rate"));
+    // Without an imported cache the rate is not a number but a skipped_reason
+    // object nested under the build_cache_hit_rate key.
+    REQUIRE(baseline_parsed["build_cache_hit_rate"].Contains("skipped_reason"));
+    REQUIRE(baseline_parsed["build_cache_hit_rate"]["skipped_reason"].GetString() ==
+            std::string("index was not built from an imported cache"));
+    REQUIRE_FALSE(baseline_parsed.Contains("build_cache_hit_nodes"));
+    REQUIRE_FALSE(baseline_parsed.Contains("build_cache_missed_nodes"));
+
+    // ---- (2) cache-accelerated build: hit-rate is reported ----
+    std::stringstream cache_buf;
+    REQUIRE(baseline->ExportCache(cache_buf).has_value());
+
+    auto warmed = vsag::Factory::CreateIndex("hgraph", param).value();
+    REQUIRE(warmed->ImportCache(cache_buf).has_value());
+    REQUIRE(warmed->Build(make_dataset()).has_value());
+    REQUIRE(warmed->GetNumElements() == TEST_COUNT);
+
+    auto warmed_stats = warmed->GetStats();
+    INFO(warmed_stats);
+    auto parsed = vsag::JsonType::Parse(warmed_stats);
+    REQUIRE(parsed.Contains("build_cache_hit_rate"));
+    REQUIRE(parsed.Contains("build_cache_hit_nodes"));
+    REQUIRE(parsed.Contains("build_cache_missed_nodes"));
+    const float hit_rate = parsed["build_cache_hit_rate"].GetFloat();
+    REQUIRE(hit_rate >= 0.0F);
+    REQUIRE(hit_rate <= 1.0F);
+    const auto hit_nodes = parsed["build_cache_hit_nodes"].GetInt();
+    const auto missed_nodes = parsed["build_cache_missed_nodes"].GetInt();
+    REQUIRE(hit_nodes + missed_nodes == TEST_COUNT);
+}


### PR DESCRIPTION
## What

When `Build()` runs after `ImportCache()`, HGraph takes the `build_with_cache()` warm-start path. `cache_warm_start_and_classify()` already computes the cache **hit-rate** (how many nodes were warm-started from the imported cache vs. cold-started), but today it is only emitted via `logger::info` and cannot be read programmatically.

This PR surfaces that signal through the existing `Index::GetStats()` JSON, **without adding a new public method**.

## How

- Store the warm-start classification result on `HGraph`: `build_cache_hit_rate_` (sentinel `-1` = "not built from an imported cache"), `build_cache_hit_nodes_`, `build_cache_missed_nodes_`.
- Populate them in `cache_warm_start_and_classify()` next to the existing log line (reuses the already-computed values, no extra work).
- In `HGraph::GetStats()`, inject the fields into the analyzer JSON. When the index was not built from an imported cache, emit a `skipped_reason` instead — consistent with the analyzer's existing convention for unavailable metrics. The hit-rate is a transient property of the build, so it lives on `HGraph` rather than in the post-hoc analyzer (which cannot observe build-time state).

New `GetStats()` fields (HGraph):

| Field | Meaning |
| --- | --- |
| `build_cache_hit_rate` | Fraction of nodes warm-started from the imported cache during the last `Build()`; a `skipped_reason` object when not built from a cache |
| `build_cache_hit_nodes` / `build_cache_missed_nodes` | Node counts behind the rate (present only when built from a cache) |

## Tests

Added functest `HGraph GetStats reports build cache hit-rate` covering both paths:
- normal `Build()` (no imported cache) -> `skipped_reason`;
- `ExportCache` -> `ImportCache` -> `Build()` -> numeric hit-rate in `[0,1]`, with `hit_nodes + missed_nodes == count` and a strictly positive hit-rate.

Existing `[cache]` tests and `HGraph GetStatus` pass unchanged.

## Docs

Updated `docs/docs/{en,zh}/src/resources/analyze_index.md` HGraph static-metrics tables with the new fields.