### PR TITLE
fix(datacell): memory leak in SparseVectorDataCell query and ComputePairVectors on exception path

### DIFF
--- a/src/datacell/sparse_vector_datacell.inl
+++ b/src/datacell/sparse_vector_datacell.inl
@@ -27,7 +27,14 @@ SparseVectorDataCell<QuantTmpl, IOTmpl>::query(float* result_dists,
     for (int i = 0; i < id_count; ++i) {
         bool need_release{true};
         auto codes = this->GetCodesById(idx[i], need_release);
-        computer->ComputeDist(codes, result_dists + i);
+        try {
+            computer->ComputeDist(codes, result_dists + i);
+        } catch (...) {
+            if (need_release) {
+                allocator_->Deallocate((void*)codes);
+            }
+            throw;
+        }
         if (need_release) {
             allocator_->Deallocate((void*)codes);
         }
@@ -152,13 +159,29 @@ SparseVectorDataCell<QuantTmpl, IOTmpl>::Train(const void* data, uint64_t count)
 template <typename QuantTmpl, typename IOTmpl>
 float
 SparseVectorDataCell<QuantTmpl, IOTmpl>::ComputePairVectors(InnerIdType id1, InnerIdType id2) {
-    bool release1, release2;
-    auto* codes1 = this->GetCodesById(id1, release1);
-    auto* codes2 = this->GetCodesById(id2, release2);
-    auto result = this->quantizer_->Compute(codes1, codes2);
-    allocator_->Deallocate((void*)codes1);
-    allocator_->Deallocate((void*)codes2);
-    return result;
+    bool release1 = false, release2 = false;
+    const uint8_t* codes1 = nullptr;
+    const uint8_t* codes2 = nullptr;
+    try {
+        codes1 = this->GetCodesById(id1, release1);
+        codes2 = this->GetCodesById(id2, release2);
+        auto result = this->quantizer_->Compute(codes1, codes2);
+        if (release1) {
+            allocator_->Deallocate((void*)codes1);
+        }
+        if (release2) {
+            allocator_->Deallocate((void*)codes2);
+        }
+        return result;
+    } catch (...) {
+        if (codes1 && release1) {
+            allocator_->Deallocate((void*)codes1);
+        }
+        if (codes2 && release2) {
+            allocator_->Deallocate((void*)codes2);
+        }
+        throw;
+    }
 }
 
 template <typename QuantTmpl, typename IOTmpl>


### PR DESCRIPTION
Fixes #2241

## What

Add exception safety to `SparseVectorDataCell::query()` and `ComputePairVectors()` in `src/datacell/sparse_vector_datacell.inl`.

## Why

If `ComputeDist` (in `query()`) or `GetCodesById`/`Compute` (in `ComputePairVectors()`) throws an exception, the `codes` buffer allocated by `GetCodesById` via the allocator is never released, causing a memory leak.

`FlattenDataCell::query()` already guards the identical pattern with try-catch, confirming this is an oversight.

## Changes

- **`query()`**: Wrap `ComputeDist` in try-catch; deallocate `codes` on exception before re-throwing.
- **`ComputePairVectors()`**: Wrap `GetCodesById`/`Compute` in try-catch; deallocate both `codes1` and `codes2` (if allocated) on exception before re-throwing. Also initialize variables to safe defaults (`false`/`nullptr`).

## Test

Existing `[SparseDataCell]` and `[SparseVectorDataCellParameter]` tests pass.