### PR TITLE
fix(ci): strip -Ofast/-ffast-math from third-party build flags

### DIFF
--- a/extern/openblas/openblas.cmake
+++ b/extern/openblas/openblas.cmake
@@ -183,6 +183,15 @@ if (NOT OPENBLAS_FOUND)
         list (PREPEND openblas_urls "$ENV{VSAG_THIRDPARTY_OPENBLAS}")
     endif ()
 
+    # OpenBLAS build tools (getarch) require strict FP semantics; -Ofast
+    # (which implies -ffast-math) breaks CPU detection. Replace with -O2.
+    string (REPLACE "-Ofast" "-O2" _openblas_c_flags "${VSAG_THIRDPARTY_C_FLAGS}")
+    string (REPLACE "-ffast-math" "" _openblas_c_flags "${_openblas_c_flags}")
+    string (REPLACE "-Ofast" "-O2" _openblas_cxx_flags "${VSAG_THIRDPARTY_CXX_FLAGS}")
+    string (REPLACE "-ffast-math" "" _openblas_cxx_flags "${_openblas_cxx_flags}")
+    string (STRIP "${_openblas_c_flags}" _openblas_c_flags)
+    string (STRIP "${_openblas_cxx_flags}" _openblas_cxx_flags)
+
     ExternalProject_Add (
         ${name}
         URL ${openblas_urls}
@@ -196,6 +205,8 @@ if (NOT OPENBLAS_FOUND)
         CONFIGURE_COMMAND ""
         BUILD_COMMAND
             ${common_configure_envs}
+            "CFLAGS=${_openblas_c_flags} -D_DEFAULT_SOURCE -D_GNU_SOURCE"
+            "CXXFLAGS=${_openblas_cxx_flags} -D_DEFAULT_SOURCE -D_GNU_SOURCE"
             OMP_NUM_THREADS=1
             PATH=/usr/lib/ccache:$ENV{PATH}
             LD_LIBRARY_PATH=/opt/alibaba-cloud-compiler/lib64/:$ENV{LD_LIBRARY_PATH}


### PR DESCRIPTION
## Summary

- Override CFLAGS/CXXFLAGS in the OpenBLAS `BUILD_COMMAND` to strip `-Ofast` (→ `-O2`) and remove `-ffast-math`
- Fixes intermittent failures of the Python Wheel Build X86 job on main

## Root Cause

In Release mode, vsag adds `-Ofast` (which implies `-ffast-math`) to compile flags. These flags propagate to all ExternalProject builds via `common_configure_envs`. OpenBLAS build-time tools (e.g. `getarch`) rely on strict floating-point semantics for CPU architecture detection. Under `-ffast-math`, these tools produce incorrect results or segfault, causing the `make` command to fail with exit code 2 within seconds of starting. The failure is intermittent because it depends on timing/parallelism with `-j4`.

## Approach

Keep `common_configure_envs` intact (preserving all shared third-party hardening: sanitizer stripping, -Werror removal, linker flags). Override only CFLAGS/CXXFLAGS after it in the OpenBLAS BUILD_COMMAND — env treats later duplicate assignments as overrides. This is scoped to OpenBLAS only; other third-party libraries are unaffected.

## Evidence

Failed runs (OpenBLAS make fails ~6s after starting):
- https://github.com/antgroup/vsag/actions/runs/27336255869/job/80761100616
- https://github.com/antgroup/vsag/actions/runs/27399193211

Successful runs take ~16 minutes for OpenBLAS build, confirming the 6s failure is not a timeout but an immediate compilation error.

## Test Plan

- [x] Single file change, scoped to OpenBLAS ExternalProject only
- [x] common_configure_envs preserved for shared hardening
- [ ] CI Python Build \& Test workflow passes consistently after merge

Fixes #2249