### PR TITLE
refactor(searcher): remove dead to_be_visited_rid allocation and writes

### DIFF
--- a/src/impl/searcher/basic_searcher.cpp
+++ b/src/impl/searcher/basic_searcher.cpp
@@ -39,7 +39,6 @@ BasicSearcher::visit(const GraphInterfacePtr& graph,
                      const std::pair<float, uint64_t>& current_node_pair,
                      const FilterPtr& filter,
                      FilterSearchSkipStrategy* skip_strategy,
-                     Vector<InnerIdType>& to_be_visited_rid,
                      Vector<InnerIdType>& to_be_visited_id,
                      Vector<InnerIdType>& neighbors) const {
     uint32_t count_no_visited = 0;
@@ -58,7 +57,6 @@ BasicSearcher::visit(const GraphInterfacePtr& graph,
         if (not vl->Get(neighbors[i])) {
             if (not filter || count_no_visited == 0 || skip_strategy->ShouldSkipFilterCheck() ||
                 filter->CheckValid(neighbors[i])) {
-                to_be_visited_rid[count_no_visited] = i;
                 to_be_visited_id[count_no_visited] = neighbors[i];
                 count_no_visited++;
             }
@@ -150,7 +148,6 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
     uint32_t hops = 0;
     uint32_t dist_cmp = 0;
     uint32_t count_no_visited = 0;
-    Vector<InnerIdType> to_be_visited_rid(graph->MaximumDegree(), alloc);
     Vector<InnerIdType> to_be_visited_id(graph->MaximumDegree(), alloc);
     Vector<InnerIdType> neighbors(graph->MaximumDegree(), alloc);
     Vector<float> line_dists(graph->MaximumDegree(), alloc);
@@ -226,7 +223,6 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
                                  current_node_pair,
                                  inner_search_param.is_inner_id_allowed,
                                  skip_strategy.get(),
-                                 to_be_visited_rid,
                                  to_be_visited_id,
                                  neighbors);
 
@@ -337,7 +333,6 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
     uint32_t hops = 0;
     uint32_t dist_cmp = 0;
     uint32_t count_no_visited = 0;
-    Vector<InnerIdType> to_be_visited_rid(graph->MaximumDegree(), alloc);
     Vector<InnerIdType> to_be_visited_id(graph->MaximumDegree(), alloc);
     Vector<InnerIdType> neighbors(graph->MaximumDegree(), alloc);
     Vector<float> line_dists(graph->MaximumDegree(), alloc);
@@ -425,7 +420,6 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
                                  current_node_pair,
                                  inner_search_param.is_inner_id_allowed,
                                  skip_strategy.get(),
-                                 to_be_visited_rid,
                                  to_be_visited_id,
                                  neighbors);
 

--- a/src/impl/searcher/basic_searcher.h
+++ b/src/impl/searcher/basic_searcher.h
@@ -87,7 +87,6 @@ private:
           const std::pair<float, uint64_t>& current_node_pair,
           const FilterPtr& filter,
           FilterSearchSkipStrategy* skip_strategy,
-          Vector<InnerIdType>& to_be_visited_rid,
           Vector<InnerIdType>& to_be_visited_id,
           Vector<InnerIdType>& neighbors) const;
 

--- a/src/impl/searcher/parallel_searcher.cpp
+++ b/src/impl/searcher/parallel_searcher.cpp
@@ -43,7 +43,6 @@ ParallelSearcher::visit(const GraphInterfacePtr& graph,
                         const Vector<std::pair<float, uint64_t>>& node_pair,
                         const FilterPtr& filter,
                         FilterSearchSkipStrategy* skip_strategy,
-                        Vector<InnerIdType>& to_be_visited_rid,
                         Vector<InnerIdType>& to_be_visited_id,
                         std::vector<Vector<InnerIdType>>& neighbors,
                         uint64_t point_visited_num) const {
@@ -68,7 +67,6 @@ ParallelSearcher::visit(const GraphInterfacePtr& graph,
             if (not vl->Get(neighbors[i][j])) {
                 if (not filter || count_no_visited == 0 || skip_strategy->ShouldSkipFilterCheck() ||
                     filter->CheckValid(neighbors[i][j])) {
-                    to_be_visited_rid[count_no_visited] = j;
                     to_be_visited_id[count_no_visited] = neighbors[i][j];
                     count_no_visited++;
                 }
@@ -143,7 +141,6 @@ ParallelSearcher::search_impl(const GraphInterfacePtr& graph,
     uint64_t beam = 1;
     uint32_t vector_size = graph->MaximumDegree() * beam;
     uint32_t current_start = 0;
-    Vector<InnerIdType> to_be_visited_rid(vector_size, alloc);
     Vector<InnerIdType> to_be_visited_id(vector_size, alloc);
     std::vector<Vector<InnerIdType>> neighbors(beam,
                                                Vector<InnerIdType>(graph->MaximumDegree(), alloc));
@@ -248,7 +245,6 @@ ParallelSearcher::search_impl(const GraphInterfacePtr& graph,
                                  node_pair,
                                  inner_search_param.is_inner_id_allowed,
                                  skip_strategy.get(),
-                                 to_be_visited_rid,
                                  to_be_visited_id,
                                  neighbors,
                                  num_explore_nodes);

--- a/src/impl/searcher/parallel_searcher.h
+++ b/src/impl/searcher/parallel_searcher.h
@@ -54,7 +54,6 @@ private:
           const Vector<std::pair<float, uint64_t>>& node_pair,
           const FilterPtr& filter,
           FilterSearchSkipStrategy* skip_strategy,
-          Vector<InnerIdType>& to_be_visited_rid,
           Vector<InnerIdType>& to_be_visited_id,
           std::vector<Vector<InnerIdType>>& neighbors,
           uint64_t point_visited_num) const;


### PR DESCRIPTION
## Summary

- Remove unused `to_be_visited_rid` vector from `BasicSearcher::visit()` and `ParallelSearcher::visit()` function signatures
- Remove allocation sites in both `search_impl` template overloads
- Remove dead writes inside the visit loops

## Background

`to_be_visited_rid` stored the neighbor rank index but was never read after being written — only `to_be_visited_id` (the actual neighbor ID) is used for distance computation. This wastes `MaximumDegree * 4` bytes per search call and pollutes cache lines.

Fixes #2250