### PR TITLE
docs(pyramid): add multi-hierarchy example and documentation

### DIFF
--- a/docs/docs/en/src/indexes/pyramid.md
+++ b/docs/docs/en/src/indexes/pyramid.md
@@ -108,7 +108,7 @@ Search-time parameters live under the `pyramid` sub-object:
 | `ef_search` | int | `100` | Candidate list size for the leaf-level graph search. |
 | `subindex_ef_search` | int | `50` | Candidate list size used when traversing intermediate sub-graphs on the path. |
 | `hierarchies` | string[] | `[]` | Select which hierarchy to search. Empty means use the default (unnamed) hierarchy. |
-| `hierarchy_op` | string | `"single"` | How to combine results across hierarchies: `single` (search one hierarchy), `union`, or `intersection`. **Note:** `union` and `intersection` are defined but not yet implemented. |
+| `hierarchy_op` | string | `"single"` | How to combine results across hierarchies: `single` (search one hierarchy), `union`, or `intersection`. **Note:** `union` and `intersection` are not yet implemented — setting them will cause `KnnSearch`/`RangeSearch` to return an error. |
 
 ```cpp
 auto result = index->KnnSearch(

--- a/docs/docs/en/src/indexes/pyramid.md
+++ b/docs/docs/en/src/indexes/pyramid.md
@@ -12,7 +12,8 @@ scenario where one logical index serves many groups that must not cross-contamin
 results.
 
 - Source: `src/algorithm/pyramid.{h,cpp}`, `src/algorithm/pyramid_zparameters.{h,cpp}`
-- Example: [`examples/cpp/107_index_pyramid.cpp`](https://github.com/antgroup/vsag/blob/main/examples/cpp/107_index_pyramid.cpp)
+- Example (single hierarchy): [`examples/cpp/107_index_pyramid.cpp`](https://github.com/antgroup/vsag/blob/main/examples/cpp/107_index_pyramid.cpp)
+- Example (multi-hierarchy): [`examples/cpp/112_index_pyramid_multi_hierarchy.cpp`](https://github.com/antgroup/vsag/blob/main/examples/cpp/112_index_pyramid_multi_hierarchy.cpp)
 
 ## How it works
 
@@ -96,6 +97,7 @@ Build-time parameters live under `index_param`.
 | `index_min_size` | int | `0` | Minimum sub-index size; smaller groups fall back to scan. |
 | `support_duplicate` | bool | `false` | Allow duplicate ids. |
 | `build_thread_count` | int | `1` | Threads used for parallel build. |
+| `hierarchies` | array | `[]` | Named hierarchy definitions. Each element is either a string (inherits all top-level params) or an object with `name` and optional overrides (`max_degree`, `ef_construction`, `alpha`, `no_build_levels`, `index_min_size`). When present, multi-hierarchy mode is activated and each hierarchy maintains its own independent path tree. |
 
 ## Search parameters
 
@@ -105,11 +107,135 @@ Search-time parameters live under the `pyramid` sub-object:
 |-----------|------|---------|-------------|
 | `ef_search` | int | `100` | Candidate list size for the leaf-level graph search. |
 | `subindex_ef_search` | int | `50` | Candidate list size used when traversing intermediate sub-graphs on the path. |
+| `hierarchies` | string[] | `[]` | Select which hierarchy to search. Empty means use the default (unnamed) hierarchy. |
+| `hierarchy_op` | string | `"single"` | How to combine results across hierarchies: `single` (search one hierarchy), `union`, or `intersection`. **Note:** `union` and `intersection` are defined but not yet implemented. |
 
 ```cpp
 auto result = index->KnnSearch(
     query, topk,
     R"({"pyramid": {"ef_search": 200, "subindex_ef_search": 80}})").value();
+```
+
+## Multi-Hierarchy Support
+
+A single Pyramid index can maintain **multiple independent path trees**, each
+identified by a name (e.g. `"site"`, `"category"`). Vectors share IDs and data
+across all hierarchies — only the paths differ. Each hierarchy can optionally
+override graph construction parameters.
+
+This is useful when the same set of vectors needs to be partitioned along
+different dimensions simultaneously. For example, an e-commerce platform might
+partition products by **site** (`site-a/lang-en`) and by **category**
+(`electronics/phones`) at the same time, and search can target either hierarchy
+independently.
+
+### Build configuration
+
+Add a `hierarchies` array inside `index_param`. Each element is either:
+- A **string** (inherits all top-level params): `"site"`
+- An **object** with `name` and optional per-hierarchy overrides:
+  `{"name": "category", "max_degree": 64, "no_build_levels": [0]}`
+
+Overridable per-hierarchy parameters: `max_degree`, `ef_construction`, `alpha`,
+`no_build_levels`, `index_min_size`.
+
+```json
+{
+    "dtype": "float32",
+    "metric_type": "l2",
+    "dim": 128,
+    "index_param": {
+        "base_quantization_type": "sq8",
+        "max_degree": 32,
+        "alpha": 1.2,
+        "graph_type": "odescent",
+        "graph_iter_turn": 15,
+        "neighbor_sample_rate": 0.2,
+        "no_build_levels": [0, 1],
+        "use_reorder": true,
+        "build_thread_count": 16,
+        "hierarchies": [
+            "site",
+            {"name": "category", "max_degree": 64, "no_build_levels": [0]}
+        ]
+    }
+}
+```
+
+### Dataset API for named hierarchies
+
+Use the overloaded `Paths(hierarchy_name, paths)` method to assign paths per
+hierarchy. The same `Ids()` and `Float32Vectors()` are shared across all
+hierarchies:
+
+```cpp
+auto base = vsag::Dataset::Make();
+base->NumElements(n)
+    ->Dim(128)
+    ->Ids(ids)
+    ->Float32Vectors(data)
+    ->Paths("site", site_paths)         // std::string* of length n
+    ->Paths("category", category_paths) // independent paths for 2nd hierarchy
+    ->Owner(false);
+index->Build(base);
+```
+
+### Searching a specific hierarchy
+
+Specify which hierarchy to search via `"hierarchies"` in the search parameters.
+The query dataset must also set its path on the matching hierarchy name:
+
+```cpp
+auto query = vsag::Dataset::Make();
+query->NumElements(1)
+    ->Dim(128)
+    ->Float32Vectors(q)
+    ->Paths("site", &query_path)   // target the "site" hierarchy
+    ->Owner(false);
+
+auto result = index->KnnSearch(
+    query, /*topk=*/10,
+    R"({"pyramid": {"ef_search": 100, "hierarchies": ["site"]}})").value();
+```
+
+### Incremental insertion (Add)
+
+`Add()` works the same as `Build()` — provide named paths and the index inserts
+into all matching hierarchies:
+
+```cpp
+auto new_data = vsag::Dataset::Make();
+new_data->NumElements(count)
+    ->Dim(128)
+    ->Ids(new_ids)
+    ->Float32Vectors(new_vectors)
+    ->Paths("site", new_site_paths)
+    ->Paths("category", new_cat_paths);
+index->Add(new_data);
+```
+
+### RangeSearch
+
+RangeSearch also supports hierarchy selection via the same search parameters:
+
+```cpp
+auto result = index->RangeSearch(
+    query, /*radius=*/20.0f,
+    R"({"pyramid": {"ef_search": 100, "hierarchies": ["category"]}})").value();
+```
+
+### Serialize & Deserialize
+
+Multi-hierarchy indexes serialize and deserialize transparently. The serialized
+format includes all hierarchy names and their graph structures:
+
+```cpp
+// Serialize
+auto binary_set = index->Serialize().value();
+
+// Deserialize into a new index (must use the same build params)
+auto new_index = vsag::Factory::CreateIndex("pyramid", build_params).value();
+new_index->Deserialize(binary_set);
 ```
 
 ## When to use Pyramid

--- a/docs/docs/zh/src/indexes/pyramid.md
+++ b/docs/docs/zh/src/indexes/pyramid.md
@@ -10,7 +10,8 @@ Pyramid 是 VSAG 的 **层级路径分区** 图索引。每条向量都附带一
 群体之间不允许结果交叉”的场景。
 
 - 源码：`src/algorithm/pyramid.{h,cpp}`、`src/algorithm/pyramid_zparameters.{h,cpp}`
-- 示例：[`examples/cpp/107_index_pyramid.cpp`](https://github.com/antgroup/vsag/blob/main/examples/cpp/107_index_pyramid.cpp)
+- 示例（单层级）：[`examples/cpp/107_index_pyramid.cpp`](https://github.com/antgroup/vsag/blob/main/examples/cpp/107_index_pyramid.cpp)
+- 示例（多层级）：[`examples/cpp/112_index_pyramid_multi_hierarchy.cpp`](https://github.com/antgroup/vsag/blob/main/examples/cpp/112_index_pyramid_multi_hierarchy.cpp)
 
 ## 工作原理
 
@@ -91,6 +92,7 @@ auto result = index->KnnSearch(
 | `index_min_size` | int | `0` | 子索引的最小规模；小于该值的分区会退化为线性扫描 |
 | `support_duplicate` | bool | `false` | 是否允许重复 ID |
 | `build_thread_count` | int | `1` | 构建阶段并发线程数 |
+| `hierarchies` | array | `[]` | 命名层级定义。每个元素可以是字符串（继承全部顶层参数）或对象（含 `name` 及可选覆盖参数：`max_degree`、`ef_construction`、`alpha`、`no_build_levels`、`index_min_size`）。设置后激活多层级模式，每个层级维护独立的路径树。 |
 
 ## 检索参数
 
@@ -100,11 +102,129 @@ auto result = index->KnnSearch(
 |------|------|--------|------|
 | `ef_search` | int | `100` | 叶子层子图检索的候选集大小 |
 | `subindex_ef_search` | int | `50` | 沿路径向下遍历中间子图时的候选集大小 |
+| `hierarchies` | string[] | `[]` | 指定检索哪个层级。空数组表示使用默认（匿名）层级。 |
+| `hierarchy_op` | string | `"single"` | 多层级结果合并方式：`single`（检索单个层级）、`union`、`intersection`。**注意：** `union` 和 `intersection` 已定义但尚未实现。 |
 
 ```cpp
 auto result = index->KnnSearch(
     query, topk,
     R"({"pyramid": {"ef_search": 200, "subindex_ef_search": 80}})").value();
+```
+
+## 多层级支持 (Multi-Hierarchy)
+
+一个 Pyramid 索引可以同时维护**多棵独立的路径树**，每棵树由名称标识（如
+`"site"`、`"category"`）。所有层级共享向量 ID 和数据——只有路径不同。每个层级可以
+选择性地覆盖图构建参数。
+
+当同一组向量需要沿多个维度同时分区时，这个特性非常有用。例如，一个电商平台可能
+需要按**站点**（`site-a/lang-en`）和按**品类**（`electronics/phones`）同时分区，
+检索时可以独立选择任一层级。
+
+### 构建配置
+
+在 `index_param` 中添加 `hierarchies` 数组。每个元素可以是：
+- **字符串**（继承全部顶层参数）：`"site"`
+- **对象**（含 `name` 和可选的参数覆盖）：
+  `{"name": "category", "max_degree": 64, "no_build_levels": [0]}`
+
+可按层级覆盖的参数：`max_degree`、`ef_construction`、`alpha`、`no_build_levels`、
+`index_min_size`。
+
+```json
+{
+    "dtype": "float32",
+    "metric_type": "l2",
+    "dim": 128,
+    "index_param": {
+        "base_quantization_type": "sq8",
+        "max_degree": 32,
+        "alpha": 1.2,
+        "graph_type": "odescent",
+        "graph_iter_turn": 15,
+        "neighbor_sample_rate": 0.2,
+        "no_build_levels": [0, 1],
+        "use_reorder": true,
+        "build_thread_count": 16,
+        "hierarchies": [
+            "site",
+            {"name": "category", "max_degree": 64, "no_build_levels": [0]}
+        ]
+    }
+}
+```
+
+### 命名层级的 Dataset API
+
+使用重载方法 `Paths(hierarchy_name, paths)` 为每个层级设置路径。所有层级共享同一份
+`Ids()` 和 `Float32Vectors()`：
+
+```cpp
+auto base = vsag::Dataset::Make();
+base->NumElements(n)
+    ->Dim(128)
+    ->Ids(ids)
+    ->Float32Vectors(data)
+    ->Paths("site", site_paths)         // std::string* 长度为 n
+    ->Paths("category", category_paths) // 第二个层级的独立路径
+    ->Owner(false);
+index->Build(base);
+```
+
+### 检索指定层级
+
+通过检索参数中的 `"hierarchies"` 指定要检索的层级。查询 Dataset 也需要在对应的
+层级名称上设置路径：
+
+```cpp
+auto query = vsag::Dataset::Make();
+query->NumElements(1)
+    ->Dim(128)
+    ->Float32Vectors(q)
+    ->Paths("site", &query_path)   // 指向 "site" 层级
+    ->Owner(false);
+
+auto result = index->KnnSearch(
+    query, /*topk=*/10,
+    R"({"pyramid": {"ef_search": 100, "hierarchies": ["site"]}})").value();
+```
+
+### 增量插入 (Add)
+
+`Add()` 的用法与 `Build()` 一致——提供命名路径，索引会自动插入到所有匹配的层级：
+
+```cpp
+auto new_data = vsag::Dataset::Make();
+new_data->NumElements(count)
+    ->Dim(128)
+    ->Ids(new_ids)
+    ->Float32Vectors(new_vectors)
+    ->Paths("site", new_site_paths)
+    ->Paths("category", new_cat_paths);
+index->Add(new_data);
+```
+
+### 范围检索 (RangeSearch)
+
+RangeSearch 同样支持通过检索参数选择层级：
+
+```cpp
+auto result = index->RangeSearch(
+    query, /*radius=*/20.0f,
+    R"({"pyramid": {"ef_search": 100, "hierarchies": ["category"]}})").value();
+```
+
+### 序列化与反序列化
+
+多层级索引的序列化和反序列化完全透明。序列化格式包含所有层级名称及其图结构：
+
+```cpp
+// 序列化
+auto binary_set = index->Serialize().value();
+
+// 反序列化到新索引（必须使用相同的构建参数）
+auto new_index = vsag::Factory::CreateIndex("pyramid", build_params).value();
+new_index->Deserialize(binary_set);
 ```
 
 ## 何时选择 Pyramid

--- a/docs/docs/zh/src/indexes/pyramid.md
+++ b/docs/docs/zh/src/indexes/pyramid.md
@@ -103,7 +103,7 @@ auto result = index->KnnSearch(
 | `ef_search` | int | `100` | 叶子层子图检索的候选集大小 |
 | `subindex_ef_search` | int | `50` | 沿路径向下遍历中间子图时的候选集大小 |
 | `hierarchies` | string[] | `[]` | 指定检索哪个层级。空数组表示使用默认（匿名）层级。 |
-| `hierarchy_op` | string | `"single"` | 多层级结果合并方式：`single`（检索单个层级）、`union`、`intersection`。**注意：** `union` 和 `intersection` 已定义但尚未实现。 |
+| `hierarchy_op` | string | `"single"` | 多层级结果合并方式：`single`（检索单个层级）、`union`、`intersection`。**注意：** `union` 和 `intersection` 尚未实现——设置后 `KnnSearch`/`RangeSearch` 会返回错误。 |
 
 ```cpp
 auto result = index->KnnSearch(

--- a/examples/cpp/112_index_pyramid_multi_hierarchy.cpp
+++ b/examples/cpp/112_index_pyramid_multi_hierarchy.cpp
@@ -133,8 +133,6 @@ main(int argc, char** argv) {
         }
 
         // Search parameters select the "site" hierarchy.
-        // The query path just needs Paths() — the hierarchy is already chosen
-        // in search params. search_impl falls back from GetPaths("site") to GetPaths().
         auto search_params = R"(
         {
             "pyramid": {
@@ -148,7 +146,7 @@ main(int argc, char** argv) {
         query->NumElements(1)
             ->Dim(dim)
             ->Float32Vectors(query_vector)
-            ->Paths(query_path)
+            ->Paths("site", query_path)
             ->Owner(true);
         auto knn_result = index->KnnSearch(query, topk, search_params);
 
@@ -231,12 +229,17 @@ main(int argc, char** argv) {
             ->Ids(add_ids)
             ->Float32Vectors(add_vectors)
             ->Paths("site", add_site_paths)
-            ->Paths("category", add_cat_paths);
+            ->Paths("category", add_cat_paths)
+            ->Owner(false);
         if (auto result = index->Add(add_data); result.has_value()) {
             std::cout << "After Add(), Pyramid contains: " << index->GetNumElements() << std::endl;
         } else {
             std::cerr << "Add failed: " << result.error().message << std::endl;
         }
+        delete[] add_ids;
+        delete[] add_vectors;
+        delete[] add_site_paths;
+        delete[] add_cat_paths;
     }
 
     /******************* RangeSearch on "category" Hierarchy *****************/
@@ -334,6 +337,8 @@ main(int argc, char** argv) {
         }
     }
 
+    delete[] ids;
+    delete[] vectors;
     delete[] site_paths;
     delete[] category_paths;
     return 0;

--- a/examples/cpp/112_index_pyramid_multi_hierarchy.cpp
+++ b/examples/cpp/112_index_pyramid_multi_hierarchy.cpp
@@ -1,0 +1,340 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <vsag/vsag.h>
+
+#include <iostream>
+#include <random>
+#include <string>
+#include <vector>
+
+// Generate a random "site" path, e.g. "site-a/lang-en" or "site-b/lang-zh".
+std::string
+generate_site_path(std::mt19937& rng) {
+    const std::vector<std::string> sites = {"site-a", "site-b", "site-c"};
+    const std::vector<std::string> langs = {"lang-en", "lang-zh", "lang-ja"};
+    return sites[rng() % sites.size()] + "/" + langs[rng() % langs.size()];
+}
+
+// Generate a random "category" path, e.g. "news/politics" or "sports/football".
+std::string
+generate_category_path(std::mt19937& rng) {
+    const std::vector<std::string> top = {"news", "sports", "tech"};
+    const std::vector<std::string> sub_news = {"politics", "economy", "world"};
+    const std::vector<std::string> sub_sports = {"football", "basketball", "tennis"};
+    const std::vector<std::string> sub_tech = {"ai", "web", "cloud"};
+
+    auto top_cat = top[rng() % top.size()];
+    if (top_cat == "news") {
+        return top_cat + "/" + sub_news[rng() % sub_news.size()];
+    } else if (top_cat == "sports") {
+        return top_cat + "/" + sub_sports[rng() % sub_sports.size()];
+    } else {
+        return top_cat + "/" + sub_tech[rng() % sub_tech.size()];
+    }
+}
+
+int
+main(int argc, char** argv) {
+    /******************* Prepare Base Dataset *****************/
+    int64_t num_vectors = 1000;
+    int64_t dim = 128;
+    auto ids = new int64_t[num_vectors];
+    auto vectors = new float[dim * num_vectors];
+
+    std::mt19937 rng(47);
+    std::uniform_real_distribution<float> distrib_real;
+    for (int64_t i = 0; i < num_vectors; ++i) {
+        ids[i] = i;
+    }
+    for (int64_t i = 0; i < dim * num_vectors; ++i) {
+        vectors[i] = distrib_real(rng);
+    }
+
+    // Generate two independent sets of paths — one per hierarchy.
+    auto site_paths = new std::string[num_vectors];
+    auto category_paths = new std::string[num_vectors];
+    for (int64_t i = 0; i < num_vectors; ++i) {
+        site_paths[i] = generate_site_path(rng);
+        category_paths[i] = generate_category_path(rng);
+    }
+
+    auto base = vsag::Dataset::Make();
+    // Vectors and IDs are shared; each hierarchy gets its own path array.
+    base->NumElements(num_vectors)
+        ->Dim(dim)
+        ->Ids(ids)
+        ->Float32Vectors(vectors)
+        ->Paths("site", site_paths)
+        ->Paths("category", category_paths)
+        ->Owner(false);
+
+    /******************* Create Pyramid Index *****************/
+    // Build parameters with two named hierarchies:
+    //   - "site": inherits all top-level graph params (string shorthand).
+    //   - "category": overrides max_degree and no_build_levels (object form).
+    auto build_params = R"(
+    {
+        "dtype": "float32",
+        "metric_type": "l2",
+        "dim": 128,
+        "index_param": {
+            "base_quantization_type": "sq8",
+            "max_degree": 32,
+            "alpha": 1.2,
+            "graph_type": "odescent",
+            "graph_iter_turn": 15,
+            "neighbor_sample_rate": 0.2,
+            "no_build_levels": [0, 1],
+            "use_reorder": true,
+            "build_thread_count": 16,
+            "hierarchies": [
+                "site",
+                {
+                    "name": "category",
+                    "max_degree": 64,
+                    "no_build_levels": [0]
+                }
+            ]
+        }
+    }
+    )";
+    auto index = vsag::Factory::CreateIndex("pyramid", build_params).value();
+
+    /******************* Build Index *****************/
+    if (auto result = index->Build(base); result.has_value()) {
+        std::cout << "After Build(), Pyramid contains: " << index->GetNumElements()
+                  << " vectors with 2 hierarchies (site, category)" << std::endl;
+    } else {
+        std::cerr << "Build failed: " << result.error().message << std::endl;
+        return 1;
+    }
+
+    /******************* Search on "site" Hierarchy *****************/
+    {
+        std::cout << "\n=== Search on 'site' hierarchy ===" << std::endl;
+        auto query_path = new std::string[1];
+        query_path[0] = "site-a";
+        auto query_vector = new float[dim];
+        for (int64_t i = 0; i < dim; ++i) {
+            query_vector[i] = distrib_real(rng);
+        }
+
+        // Search parameters select the "site" hierarchy.
+        // The query path just needs Paths() — the hierarchy is already chosen
+        // in search params. search_impl falls back from GetPaths("site") to GetPaths().
+        auto search_params = R"(
+        {
+            "pyramid": {
+                "ef_search": 100,
+                "hierarchies": ["site"]
+            }
+        }
+        )";
+        int64_t topk = 10;
+        auto query = vsag::Dataset::Make();
+        query->NumElements(1)
+            ->Dim(dim)
+            ->Float32Vectors(query_vector)
+            ->Paths(query_path)
+            ->Owner(true);
+        auto knn_result = index->KnnSearch(query, topk, search_params);
+
+        std::cout << "Query site path: " << query_path[0] << std::endl;
+        if (knn_result.has_value()) {
+            auto result = knn_result.value();
+            std::cout << "Results:" << std::endl;
+            for (int64_t i = 0; i < result->GetDim(); ++i) {
+                auto id = result->GetIds()[i];
+                std::cout << "  id=" << id << "  dist=" << result->GetDistances()[i]
+                          << "  site=" << site_paths[id] << "  category=" << category_paths[id]
+                          << std::endl;
+            }
+        } else {
+            std::cerr << "Search error: " << knn_result.error().message << std::endl;
+        }
+    }
+
+    /******************* Search on "category" Hierarchy *****************/
+    {
+        std::cout << "\n=== Search on 'category' hierarchy ===" << std::endl;
+        auto query_path = new std::string[1];
+        query_path[0] = "news";
+        auto query_vector = new float[dim];
+        for (int64_t i = 0; i < dim; ++i) {
+            query_vector[i] = distrib_real(rng);
+        }
+
+        auto search_params = R"(
+        {
+            "pyramid": {
+                "ef_search": 100,
+                "hierarchies": ["category"]
+            }
+        }
+        )";
+        int64_t topk = 10;
+        auto query = vsag::Dataset::Make();
+        query->NumElements(1)
+            ->Dim(dim)
+            ->Float32Vectors(query_vector)
+            ->Paths("category", query_path)
+            ->Owner(true);
+        auto knn_result = index->KnnSearch(query, topk, search_params);
+
+        std::cout << "Query category path: " << query_path[0] << std::endl;
+        if (knn_result.has_value()) {
+            auto result = knn_result.value();
+            std::cout << "Results:" << std::endl;
+            for (int64_t i = 0; i < result->GetDim(); ++i) {
+                auto id = result->GetIds()[i];
+                std::cout << "  id=" << id << "  dist=" << result->GetDistances()[i]
+                          << "  site=" << site_paths[id] << "  category=" << category_paths[id]
+                          << std::endl;
+            }
+        } else {
+            std::cerr << "Search error: " << knn_result.error().message << std::endl;
+        }
+    }
+
+    /******************* Add (Incremental Insert) *****************/
+    {
+        std::cout << "\n=== Add 100 new vectors ===" << std::endl;
+        int64_t add_count = 100;
+        auto add_ids = new int64_t[add_count];
+        auto add_vectors = new float[dim * add_count];
+        auto add_site_paths = new std::string[add_count];
+        auto add_cat_paths = new std::string[add_count];
+        for (int64_t i = 0; i < add_count; ++i) {
+            add_ids[i] = num_vectors + i;
+            add_site_paths[i] = generate_site_path(rng);
+            add_cat_paths[i] = generate_category_path(rng);
+        }
+        for (int64_t i = 0; i < dim * add_count; ++i) {
+            add_vectors[i] = distrib_real(rng);
+        }
+        auto add_data = vsag::Dataset::Make();
+        add_data->NumElements(add_count)
+            ->Dim(dim)
+            ->Ids(add_ids)
+            ->Float32Vectors(add_vectors)
+            ->Paths("site", add_site_paths)
+            ->Paths("category", add_cat_paths);
+        if (auto result = index->Add(add_data); result.has_value()) {
+            std::cout << "After Add(), Pyramid contains: " << index->GetNumElements() << std::endl;
+        } else {
+            std::cerr << "Add failed: " << result.error().message << std::endl;
+        }
+    }
+
+    /******************* RangeSearch on "category" Hierarchy *****************/
+    {
+        std::cout << "\n=== RangeSearch on 'category' hierarchy ===" << std::endl;
+        auto query_path = new std::string[1];
+        query_path[0] = "sports";
+        auto query_vector = new float[dim];
+        for (int64_t i = 0; i < dim; ++i) {
+            query_vector[i] = distrib_real(rng);
+        }
+        auto search_params = R"(
+        {
+            "pyramid": {
+                "ef_search": 100,
+                "hierarchies": ["category"]
+            }
+        }
+        )";
+        float radius = 20.0f;
+        auto query = vsag::Dataset::Make();
+        query->NumElements(1)
+            ->Dim(dim)
+            ->Float32Vectors(query_vector)
+            ->Paths("category", query_path)
+            ->Owner(true);
+        auto range_result = index->RangeSearch(query, radius, search_params);
+        std::cout << "Query category path: " << query_path[0] << "  radius: " << radius
+                  << std::endl;
+        if (range_result.has_value()) {
+            auto result = range_result.value();
+            std::cout << "Found " << result->GetDim() << " results within radius" << std::endl;
+            for (int64_t i = 0; i < std::min<int64_t>(result->GetDim(), 5); ++i) {
+                std::cout << "  id=" << result->GetIds()[i]
+                          << "  dist=" << result->GetDistances()[i] << std::endl;
+            }
+        } else {
+            std::cerr << "RangeSearch error: " << range_result.error().message << std::endl;
+        }
+    }
+
+    /******************* Serialize & Deserialize *****************/
+    {
+        std::cout << "\n=== Serialize & Deserialize ===" << std::endl;
+        // Serialize
+        auto bs = index->Serialize();
+        if (not bs.has_value()) {
+            std::cerr << "Serialize failed: " << bs.error().message << std::endl;
+            return 1;
+        }
+        auto keys = bs->GetKeys();
+        vsag::BinarySet binary_set;
+        for (const auto& key : keys) {
+            binary_set.Set(key, bs->Get(key));
+        }
+        std::cout << "Serialized " << keys.size() << " blobs" << std::endl;
+
+        // Deserialize into a new index
+        auto new_index = vsag::Factory::CreateIndex("pyramid", build_params).value();
+        new_index->Deserialize(binary_set);
+        std::cout << "Deserialized index contains: " << new_index->GetNumElements() << " vectors"
+                  << std::endl;
+
+        // Verify search on deserialized index
+        auto query_path = new std::string[1];
+        query_path[0] = "site-b";
+        auto query_vector = new float[dim];
+        for (int64_t i = 0; i < dim; ++i) {
+            query_vector[i] = distrib_real(rng);
+        }
+        auto search_params = R"(
+        {
+            "pyramid": {
+                "ef_search": 100,
+                "hierarchies": ["site"]
+            }
+        }
+        )";
+        auto query = vsag::Dataset::Make();
+        query->NumElements(1)
+            ->Dim(dim)
+            ->Float32Vectors(query_vector)
+            ->Paths("site", query_path)
+            ->Owner(true);
+        auto knn_result = new_index->KnnSearch(query, 5, search_params);
+        if (knn_result.has_value()) {
+            auto result = knn_result.value();
+            std::cout << "Search on deserialized index (site-b), top-5:" << std::endl;
+            for (int64_t i = 0; i < result->GetDim(); ++i) {
+                std::cout << "  id=" << result->GetIds()[i]
+                          << "  dist=" << result->GetDistances()[i] << std::endl;
+            }
+        } else {
+            std::cerr << "Search error: " << knn_result.error().message << std::endl;
+        }
+    }
+
+    delete[] site_paths;
+    delete[] category_paths;
+    return 0;
+}

--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -47,6 +47,9 @@ target_link_libraries (110_index_warp vsag)
 add_executable (111_index_lazy_hgraph 111_index_lazy_hgraph.cpp)
 target_link_libraries (111_index_lazy_hgraph vsag)
 
+add_executable (112_index_pyramid_multi_hierarchy 112_index_pyramid_multi_hierarchy.cpp)
+target_link_libraries (112_index_pyramid_multi_hierarchy vsag)
+
 add_executable (201_custom_allocator 201_custom_allocator.cpp)
 target_link_libraries (201_custom_allocator vsag)
 


### PR DESCRIPTION
## Summary

- Add example `112_index_pyramid_multi_hierarchy.cpp` demonstrating all multi-hierarchy APIs: Build, Add, KnnSearch, RangeSearch, Serialize/Deserialize with named hierarchies and per-hierarchy parameter overrides
- Update EN/ZH pyramid docs with new "Multi-Hierarchy Support" section covering build config, Dataset API, search params, incremental insertion, range search, and serialization
- Add `hierarchies` and `hierarchy_op` to parameter tables in both languages

Closes: #2103

## Test plan

- [x] Example builds: `cmake -DENABLE_EXAMPLES=ON && make 112_index_pyramid_multi_hierarchy`
- [x] Example runs successfully with correct results (site/category hierarchies filter correctly)
- [x] `make fmt` passes
- [x] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)