### PR TITLE
feat(serialization): add streaming serialization foundation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,8 @@ published documentation.
 | IVF | [docs/docs/en/src/indexes/ivf.md](docs/en/src/indexes/ivf.md) | <https://vsag.io/docs/indexes/ivf.html> |
 | SINDI | [docs/docs/en/src/indexes/sindi.md](docs/en/src/indexes/sindi.md) | <https://vsag.io/docs/indexes/sindi.html> |
 | BruteForce | [docs/docs/en/src/indexes/brute_force.md](docs/en/src/indexes/brute_force.md) | <https://vsag.io/docs/indexes/brute_force.html> |
+| Serialization | [docs/docs/en/src/advanced/serialization.md](docs/en/src/advanced/serialization.md) | <https://vsag.io/docs/advanced/serialization.html> |
+| New serialization | [docs/docs/en/src/advanced/new_serialization.md](docs/en/src/advanced/new_serialization.md) | <https://vsag.io/docs/advanced/new_serialization.html> |
 | Memory management | [docs/docs/en/src/advanced/memory.md](docs/en/src/advanced/memory.md) | <https://vsag.io/docs/advanced/memory.html> |
 | Evaluation tool | [docs/docs/en/src/resources/eval.md](docs/en/src/resources/eval.md) | <https://vsag.io/docs/resources/eval.html> |
 | HDF5 dataset format | [docs/docs/en/src/resources/dataset_format.md](docs/en/src/resources/dataset_format.md) | <https://vsag.io/docs/resources/dataset_format.html> |
@@ -32,6 +34,8 @@ published documentation.
 | IVF | [docs/docs/zh/src/indexes/ivf.md](docs/zh/src/indexes/ivf.md) | <https://vsag.io/docs/zh/indexes/ivf.html> |
 | SINDI | [docs/docs/zh/src/indexes/sindi.md](docs/zh/src/indexes/sindi.md) | <https://vsag.io/docs/zh/indexes/sindi.html> |
 | BruteForce | [docs/docs/zh/src/indexes/brute_force.md](docs/zh/src/indexes/brute_force.md) | <https://vsag.io/docs/zh/indexes/brute_force.html> |
+| 序列化格式 | [docs/docs/zh/src/advanced/serialization.md](docs/zh/src/advanced/serialization.md) | <https://vsag.io/docs/zh/advanced/serialization.html> |
+| 新序列化格式 | [docs/docs/zh/src/advanced/new_serialization.md](docs/zh/src/advanced/new_serialization.md) | <https://vsag.io/docs/zh/advanced/new_serialization.html> |
 | Memory management | [docs/docs/zh/src/advanced/memory.md](docs/zh/src/advanced/memory.md) | <https://vsag.io/docs/zh/advanced/memory.html> |
 | Evaluation tool | [docs/docs/zh/src/resources/eval.md](docs/zh/src/resources/eval.md) | <https://vsag.io/docs/zh/resources/eval.html> |
 | HDF5 dataset format | [docs/docs/zh/src/resources/dataset_format.md](docs/zh/src/resources/dataset_format.md) | <https://vsag.io/docs/zh/resources/dataset_format.html> |

--- a/docs/docs/en/src/SUMMARY.md
+++ b/docs/docs/en/src/SUMMARY.md
@@ -50,6 +50,7 @@
 - [Iterator Search](advanced/iterator_search.md)
 - [Attribute Filter (Hybrid Search)](advanced/attribute_filter.md)
 - [Serialization](advanced/serialization.md)
+- [New Serialization](advanced/new_serialization.md)
 - [Memory Management](advanced/memory.md)
 - [Per-Search Allocator](advanced/search_allocator.md)
 - [Index Introspection](advanced/introspection.md)

--- a/docs/docs/en/src/advanced/new_serialization.md
+++ b/docs/docs/en/src/advanced/new_serialization.md
@@ -1,0 +1,232 @@
+# New Serialization
+
+The new serialization format is designed for large index artifacts and forward-only readers. Its
+main goals are:
+
+- Make the file self-describing from the beginning, so readers can inspect the magic, version,
+  metadata, and block manifest without seeking to a footer.
+- Split index content into typed TLV blocks, so tools can inspect block sizes and future readers can
+  skip unknown non-critical blocks.
+- Provide one streaming path for full restoration (`DeserializeStreaming`) and policy-based loading
+  (`Load`).
+- Support debugging and operations tooling through a stable layout that can be visualized.
+
+The new serialization format is **not compatible** with the previous `Serialize`/`Deserialize`
+format. Files written by `SerializeStreaming` must be read with `DeserializeStreaming` or `Load`;
+files written by `Serialize` must be read with `Deserialize`.
+
+## Usage Model
+
+Serialization and deserialization are the persistence and transport path for index artifacts.
+`SerializeStreaming` writes a built index into a self-describing file, and `DeserializeStreaming`
+restores the complete in-memory index when a caller already knows which index object to create.
+`Index::Load` is the serving path: it creates the index from the file metadata and returns an
+`IndexPtr` that can be used for search.
+
+![Streaming serialization usage model](../figures/advanced/streaming-serialization-usage.svg)
+
+## Streaming Serialization
+
+`SerializeStreaming`, `DeserializeStreaming`, and `Load` write and read a forward-only index file.
+The format is designed for large index artifacts where the reader should not seek to a footer
+before it can understand the file layout. It is currently implemented for BruteForce, HGraph, IVF,
+SINDI, and Pyramid.
+
+```cpp
+auto index = vsag::Factory::CreateIndex("hgraph", build_params).value();
+index->Build(base).value();
+
+{
+    std::ofstream out("hgraph.streaming", std::ios::binary);
+    index->SerializeStreaming(out).value();
+}
+
+auto restored = vsag::Factory::CreateIndex("hgraph", build_params).value();
+{
+    std::ifstream in("hgraph.streaming", std::ios::binary);
+    restored->DeserializeStreaming(in).value();
+}
+
+vsag::IndexPtr loaded;
+{
+    std::ifstream in("hgraph.streaming", std::ios::binary);
+    loaded = vsag::Index::Load(in, "{}").value();
+}
+```
+
+## Static Load
+
+`Index::Load` is the entry point for policy-based loading from the new streaming format. Unlike
+`DeserializeStreaming`, callers do not create an empty index first. `Load` reads the streaming
+metadata, checks the serialized index type and `basic_info["index_param"]`, creates the matching
+index internally, and then loads the TLV body blocks according to the load parameters.
+
+```cpp
+std::ifstream in("hgraph.streaming", std::ios::binary);
+vsag::LoadParameters load_parameters(R"({"base_io_type":"block_memory_io"})");
+auto loaded = vsag::Index::Load(in, load_parameters).value();
+```
+
+The returned value is a ready-to-use `IndexPtr`, so this is the preferred path for loading
+an index that will serve search traffic. Load parameters control placement policy for supported
+blocks. The parameters object can be built from a JSON string and can also carry reader objects
+with `SetReader`. Unsupported policies return an error instead of silently falling back. The API
+currently supports streaming BruteForce, HGraph, IVF, SINDI, and Pyramid indexes. BruteForce
+supports limited block placement policies. HGraph can bind `high_precision_codes` to an external
+reader through `precise_reader`. IVF, SINDI, and Pyramid currently load all emitted streaming
+blocks into memory.
+
+## File Layout
+
+A streaming file starts with a fixed header and then a sequence of TLV blocks:
+
+```text
+magic("vsagstm0")
+format_version
+metadata_length
+metadata_json
+metadata_checksum
+block_header + block_payload
+block_header + block_payload
+...
+section_end
+```
+
+The metadata JSON stores the index name, basic index information, and a block manifest; build
+parameters are stored in `basic_info["index_param"]`. The manifest lists the expected block tags,
+block versions, and whether a block is critical. Unknown critical blocks fail deserialization;
+unknown non-critical blocks can be skipped by compatible readers.
+
+## TLV Block Version Compatibility
+
+`format_version` describes the whole streaming file structure, such as the fixed header, metadata
+layout, and TLV framing. When only one block payload changes in a binary-incompatible
+way, the format should not bump the global format version. Instead, bump the
+`block_version` of that TLV block. For
+example, if HGraph `base_codes` cannot be parsed by older readers after a `basic_flatten_codes`
+implementation change, the `base_codes` block version must be increased.
+
+Each independently evolving block must distinguish two kinds of version information:
+
+- **Current write version**: the `block_version` written by the current code when serializing that
+  block.
+- **Supported read versions**: the set or range of block versions that the current code can read for
+  that block.
+
+After a reader reads the TLV header, it checks whether `tag + block_version` is supported by the
+current code:
+
+- Supported versions are parsed by the matching block reader.
+- Unsupported critical blocks fail fast, preventing older code from misreading newer bytes.
+- Unsupported non-critical blocks are skipped with `value_len`, then reading continues from the next
+  block.
+
+Therefore, when a block is upgraded from v1 to v2, the implementation must not only change the
+current write version to v2; it must also update that block's supported read versions. If the new
+code keeps the v1 reader, supported versions should include both v1 and v2 so v2 code can still load
+v1 indexes. If v1 is intentionally no longer supported, remove it from the supported versions and
+make old critical blocks fail explicitly.
+
+The block manifest in metadata lets tools and readers inspect expected block versions before reading
+the body. During body parsing, the `block_version` stored in each TLV header remains the
+authoritative version for that payload.
+
+![TLV block version check](../figures/advanced/streaming-block-version-check.svg)
+
+## BruteForce Blocks
+
+BruteForce writes these streaming blocks in order:
+
+| Block | Contents | Required |
+| --- | --- | --- |
+| `attribute_filter` | optional attribute filter index | conditional |
+| `base_codes` | flatten codes used for exhaustive search | yes |
+| `label_table` | external labels and label remap | yes |
+
+`DeserializeStreaming` restores the full in-memory BruteForce index. `Load` currently requires
+`base_codes` to be loaded into memory; reader-based loading for required BruteForce codes is
+rejected.
+
+## HGraph Blocks
+
+HGraph writes these streaming blocks in order:
+
+| Block | Contents | Required |
+| --- | --- | --- |
+| `label_table` | external labels, label remap, optional source id table | yes |
+| `base_codes` | base flatten codes used by graph search | yes |
+| `bottom_graph` | bottom-layer graph over all vectors | yes |
+| `high_precision_codes` | precise reorder codes when reorder uses separate codes | conditional |
+| `route_graphs` | all upper route graph layers | yes |
+| `extra_info` | optional extra info payloads | conditional |
+| `attribute_filter` | optional attribute filter index | conditional |
+| `raw_vector` | optional stored raw vectors | conditional |
+
+`DeserializeStreaming` restores the full in-memory index. `Load` loads HGraph blocks into memory by
+default. Load parameters can set `precise_io_type` to override the IO type for `precise_codes`. If
+they also provide `precise_reader`, and that reader size matches the `high_precision_codes` payload
+size, `Load` validates the external reader payload checksum and then binds reorder codes to that
+reader.
+
+## IVF Blocks
+
+IVF writes these streaming blocks in order:
+
+| Block | Contents | Required |
+| --- | --- | --- |
+| `ivf_bucket` | bucket datacell payloads for inverted lists | yes |
+| `ivf_partition_strategy` | partition strategy state, such as trained centroids | yes |
+| `label_table` | external labels and label remap | yes |
+| `high_precision_codes` | reorder codes when IVF reorder is enabled | conditional |
+| `attribute_filter` | optional attribute filter index | conditional |
+
+`DeserializeStreaming` restores the full in-memory IVF index. `Index::Load` can create the IVF
+index directly from streaming metadata and currently loads all emitted IVF blocks into memory.
+
+## SINDI Blocks
+
+SINDI writes these streaming blocks in order:
+
+| Block | Contents | Required |
+| --- | --- | --- |
+| `sindi_windows` | sparse term windows and quantization runtime state | yes |
+| `label_table` | external labels and label remap | yes |
+| `sindi_rerank_index` | optional rerank flat index when rerank is enabled | conditional |
+| `sindi_term_id_mapper` | optional term-id remapping table | conditional |
+
+`DeserializeStreaming` restores the full in-memory SINDI index. `Index::Load` can create the SINDI
+index directly from streaming metadata and currently loads all emitted SINDI blocks into memory.
+Immutable SINDI runtime serialization is not supported by this streaming path.
+
+## Pyramid Blocks
+
+Pyramid writes these streaming blocks in order:
+
+| Block | Contents | Required |
+| --- | --- | --- |
+| `label_table` | external labels and label remap | yes |
+| `base_codes` | base flatten codes used by graph search | yes |
+| `high_precision_codes` | precise reorder codes when reorder is enabled | conditional |
+| `pyramid_hierarchies` | hierarchy names and graph roots | yes |
+
+`DeserializeStreaming` restores the full in-memory Pyramid index. `Index::Load` can create the
+Pyramid index directly from streaming metadata and currently loads all emitted Pyramid blocks into
+memory.
+
+## Visualizing a Streaming Index
+
+Build the tool and point it at a streaming index file:
+
+```bash
+cmake --build build --target visualize_index
+build/tools/visualize_index/visualize_index \
+  --index_path /tmp/vsag-hgraph-streaming.index \
+  --html /tmp/vsag-hgraph-streaming.html
+```
+
+The CLI output includes a raw horizontal layout by real byte proportion and a compact logical-block
+layout. The HTML output groups related small segments, such as a TLV header and its payload, and
+shows exact segment details in tables.
+
+See `examples/cpp/403_persistent_streaming_load.cpp` for runnable examples of streaming
+serialization and `Index::Load`.

--- a/docs/docs/en/src/advanced/serialization.md
+++ b/docs/docs/en/src/advanced/serialization.md
@@ -1,7 +1,11 @@
 # Serialization
 
-VSAG indexes can be serialized and deserialized through several interfaces, supporting
-persistence, cross-process sharing, and distributed deployment.
+VSAG indexes can be serialized and deserialized through the existing serialization interfaces,
+supporting persistence, cross-process sharing, and distributed deployment.
+
+This page describes the existing serialization format used by `Serialize` and `Deserialize`. For
+the header-first streaming format introduced later, see [New Serialization](new_serialization.md).
+The two formats are not compatible with each other.
 
 ## Three Interfaces
 
@@ -31,7 +35,7 @@ scenarios.
 
 ### 2. File Streams (`std::ostream` / `std::istream`)
 
-The simplest option — serialize the whole index to a file or memory stream:
+The simplest option: serialize the whole index to a file or memory stream:
 
 ```cpp
 std::ofstream out("index.bin", std::ios::binary);
@@ -55,8 +59,9 @@ index->Serialize([&](const void* buf, uint64_t offset, uint64_t size) {
 
 - `Deserialize` requires an **empty** target index whose configuration (`dim`, `metric_type`, etc.)
   matches the one used at serialization time.
+- `Serialize`/`Deserialize` keep the existing footer-based format. The new `SerializeStreaming`
+  format is header-first and must be read with `DeserializeStreaming` or `Load`.
 - When upgrading across major versions, check the compatibility notes in the
   [release notes](../resources/release_notes.md).
-- References:
-  `examples/cpp/318_feature_tune.cpp`, `examples/cpp/401_persistent_kv.cpp`,
+- References: `examples/cpp/318_feature_tune.cpp`, `examples/cpp/401_persistent_kv.cpp`, and
   `examples/cpp/402_persistent_streaming.cpp`.

--- a/docs/docs/en/src/figures/advanced/streaming-block-version-check.svg
+++ b/docs/docs/en/src/figures/advanced/streaming-block-version-check.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 860 360" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#44546a"/>
+    </marker>
+  </defs>
+  <rect x="30" y="36" width="170" height="58" rx="6" fill="#e8f1ff" stroke="#4f81bd"/>
+  <text x="115" y="62" text-anchor="middle" font-size="14" fill="#1f2937">Read TLV header</text>
+  <text x="115" y="82" text-anchor="middle" font-size="12" fill="#4b5563">tag / version / flags</text>
+  <line x1="200" y1="65" x2="285" y2="65" stroke="#44546a" stroke-width="2" marker-end="url(#arrow)"/>
+  <rect x="290" y="36" width="190" height="58" rx="6" fill="#fff3df" stroke="#d9902f"/>
+  <text x="385" y="62" text-anchor="middle" font-size="14" fill="#1f2937">Check support</text>
+  <text x="385" y="82" text-anchor="middle" font-size="12" fill="#4b5563">by block tag</text>
+  <line x1="480" y1="65" x2="565" y2="65" stroke="#44546a" stroke-width="2" marker-end="url(#arrow)"/>
+  <rect x="570" y="36" width="240" height="58" rx="6" fill="#eef7ee" stroke="#6aa84f"/>
+  <text x="690" y="62" text-anchor="middle" font-size="14" fill="#1f2937">Supported</text>
+  <text x="690" y="82" text-anchor="middle" font-size="12" fill="#4b5563">parse with matching reader</text>
+  <line x1="385" y1="94" x2="385" y2="150" stroke="#44546a" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="415" y="126" font-size="12" fill="#374151">too new or unsupported</text>
+  <rect x="250" y="154" width="270" height="58" rx="6" fill="#f8e8e8" stroke="#cc6666"/>
+  <text x="385" y="180" text-anchor="middle" font-size="14" fill="#1f2937">Critical block?</text>
+  <text x="385" y="200" text-anchor="middle" font-size="12" fill="#4b5563">base_codes / graph / label_table</text>
+  <line x1="250" y1="183" x2="165" y2="260" stroke="#44546a" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="185" y="215" text-anchor="middle" font-size="12" fill="#374151">yes</text>
+  <rect x="30" y="266" width="230" height="58" rx="6" fill="#fdecec" stroke="#c0504d"/>
+  <text x="145" y="292" text-anchor="middle" font-size="14" fill="#1f2937">Fail fast</text>
+  <text x="145" y="312" text-anchor="middle" font-size="12" fill="#4b5563">avoid misreading newer bytes</text>
+  <line x1="520" y1="183" x2="610" y2="260" stroke="#44546a" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="585" y="215" text-anchor="middle" font-size="12" fill="#374151">no</text>
+  <rect x="600" y="266" width="230" height="58" rx="6" fill="#eef7ee" stroke="#6aa84f"/>
+  <text x="715" y="292" text-anchor="middle" font-size="14" fill="#1f2937">Skip payload</text>
+  <text x="715" y="312" text-anchor="middle" font-size="12" fill="#4b5563">use value_len for next block</text>
+</svg>

--- a/docs/docs/en/src/figures/advanced/streaming-serialization-usage.svg
+++ b/docs/docs/en/src/figures/advanced/streaming-serialization-usage.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 190" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#44546a"/>
+    </marker>
+  </defs>
+  <rect x="15" y="45" width="140" height="58" rx="6" fill="#e8f1ff" stroke="#4f81bd"/>
+  <text x="85" y="70" text-anchor="middle" font-size="14" fill="#1f2937">Built Index</text>
+  <text x="85" y="90" text-anchor="middle" font-size="12" fill="#4b5563">in memory</text>
+  <line x1="155" y1="74" x2="250" y2="74" stroke="#44546a" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="202" y="58" text-anchor="middle" font-size="12" fill="#374151">SerializeStreaming</text>
+  <rect x="255" y="45" width="150" height="58" rx="6" fill="#fff3df" stroke="#d9902f"/>
+  <text x="330" y="70" text-anchor="middle" font-size="14" fill="#1f2937">Streaming File</text>
+  <text x="330" y="90" text-anchor="middle" font-size="12" fill="#4b5563">storage / transport</text>
+  <line x1="405" y1="58" x2="565" y2="35" stroke="#44546a" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="488" y="36" text-anchor="middle" font-size="12" fill="#374151">DeserializeStreaming</text>
+  <rect x="570" y="8" width="170" height="58" rx="6" fill="#eef7ee" stroke="#6aa84f"/>
+  <text x="655" y="33" text-anchor="middle" font-size="14" fill="#1f2937">Full Restore</text>
+  <text x="655" y="53" text-anchor="middle" font-size="12" fill="#4b5563">caller-created index</text>
+  <line x1="405" y1="92" x2="565" y2="126" stroke="#44546a" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="488" y="119" text-anchor="middle" font-size="12" fill="#374151">Index::Load</text>
+  <rect x="570" y="105" width="170" height="58" rx="6" fill="#f4ecff" stroke="#8e7cc3"/>
+  <text x="655" y="130" text-anchor="middle" font-size="14" fill="#1f2937">Serving Index</text>
+  <text x="655" y="150" text-anchor="middle" font-size="12" fill="#4b5563">ready for search</text>
+</svg>

--- a/docs/docs/zh/src/SUMMARY.md
+++ b/docs/docs/zh/src/SUMMARY.md
@@ -50,6 +50,7 @@
 - [迭代式搜索](advanced/iterator_search.md)
 - [属性过滤（混合搜索）](advanced/attribute_filter.md)
 - [序列化格式](advanced/serialization.md)
+- [新序列化格式](advanced/new_serialization.md)
 - [内存管理](advanced/memory.md)
 - [搜索路径 Allocator](advanced/search_allocator.md)
 - [索引自省](advanced/introspection.md)

--- a/docs/docs/zh/src/advanced/new_serialization.md
+++ b/docs/docs/zh/src/advanced/new_serialization.md
@@ -1,0 +1,210 @@
+# 新序列化格式
+
+新的序列化格式面向大索引产物和 forward-only 读取场景。它的设计目标是：
+
+- 让文件从头部开始就是自描述的，读取端无需先 seek 到文件尾部，就能识别 magic、版本、metadata 和
+  block manifest。
+- 将索引内容拆分成带类型的 TLV block，便于工具检查各部分大小，也便于未来 reader 跳过未知的
+  non-critical block。
+- 为完整恢复（`DeserializeStreaming`）和带策略加载（`Load`）提供统一的流式入口。
+- 提供稳定、可检查的布局，便于调试和运维工具进行可视化。
+
+新的序列化格式与之前的 `Serialize`/`Deserialize` 格式**不兼容**。`SerializeStreaming` 写出的文件
+必须用 `DeserializeStreaming` 或 `Load` 读取；`Serialize` 写出的文件必须用 `Deserialize` 读取。
+
+## 使用模型
+
+序列化和反序列化是索引产物的存储、传输路径。`SerializeStreaming` 将已经构建好的索引写成自描述文件，
+`DeserializeStreaming` 在调用方已经知道要创建哪种索引对象时，恢复完整的内存索引。`Index::Load` 才是
+提供搜索服务的加载路径：它从文件 metadata 中创建索引对象，并返回可以直接用于搜索的 `IndexPtr`。
+
+![新序列化格式使用模型](../figures/advanced/streaming-serialization-usage.svg)
+
+## 流式序列化
+
+`SerializeStreaming`、`DeserializeStreaming` 和 `Load` 读写 forward-only 的索引文件。该格式面向
+较大的索引产物：读取端不需要先 seek 到文件尾部解析 footer，就能从文件头拿到格式版本和 block 清单。
+当前 BruteForce、HGraph、IVF、SINDI 和 Pyramid 已实现该路径。
+
+```cpp
+auto index = vsag::Factory::CreateIndex("hgraph", build_params).value();
+index->Build(base).value();
+
+{
+    std::ofstream out("hgraph.streaming", std::ios::binary);
+    index->SerializeStreaming(out).value();
+}
+
+auto restored = vsag::Factory::CreateIndex("hgraph", build_params).value();
+{
+    std::ifstream in("hgraph.streaming", std::ios::binary);
+    restored->DeserializeStreaming(in).value();
+}
+
+vsag::IndexPtr loaded;
+{
+    std::ifstream in("hgraph.streaming", std::ios::binary);
+    loaded = vsag::Index::Load(in, "{}").value();
+}
+```
+
+## Static Load
+
+`Index::Load` 是新 streaming 格式的带策略加载入口。它和 `DeserializeStreaming` 的区别是：调用方不需要
+先创建一个空索引对象。`Load` 会先读取 streaming metadata，识别序列化文件中的索引类型和
+`basic_info["index_param"]`，在内部创建匹配的索引对象，然后按照 load parameters 加载后续
+TLV body blocks。
+
+```cpp
+std::ifstream in("hgraph.streaming", std::ios::binary);
+vsag::LoadParameters load_parameters(R"({"base_io_type":"block_memory_io"})");
+auto loaded = vsag::Index::Load(in, load_parameters).value();
+```
+
+返回值是可直接使用的 `IndexPtr`，因此它是把索引加载起来并提供搜索服务时优先使用的路径。load
+parameters 用来控制已支持 block 的加载策略；参数对象既可以从 JSON 字符串构造，也可以通过
+`SetReader` 携带 reader 对象。不支持的策略会返回错误，不会静默 fallback。当前该 API 支持 streaming
+BruteForce、HGraph、IVF、SINDI 和 Pyramid 索引。其中 BruteForce 支持有限的 block placement 策略；
+HGraph 支持通过 `precise_reader` 将 `high_precision_codes` 绑定到外部 reader；IVF、SINDI 和 Pyramid
+目前会把写出的 streaming blocks 加载到内存。
+
+## 文件布局
+
+流式文件由固定头部和一组 TLV block 构成：
+
+```text
+magic("vsagstm0")
+format_version
+metadata_length
+metadata_json
+metadata_checksum
+block_header + block_payload
+block_header + block_payload
+...
+section_end
+```
+
+metadata JSON 中保存索引名称、基础索引信息和 block manifest；构建参数保存在
+`basic_info["index_param"]` 中。manifest 描述预期的 block tag、block version，以及该 block 是否
+critical。未知 critical block 会导致反序列化失败；未知 non-critical block 可以被兼容 reader 跳过。
+
+## TLV Block 版本兼容
+
+`format_version` 描述 streaming 文件整体结构，例如固定头、metadata 布局和 TLV framing。当某个 block
+payload 的二进制语义发生不兼容变化时，不应直接升级整体格式，而应升级对应 TLV block 的
+`block_version`。例如 HGraph 的 `base_codes` payload 如果因为 `basic_flatten_codes` 实现变化而无法被旧
+reader 正确解析，就需要升级 `base_codes` block version。
+
+每个可独立演进的 block 都需要区分两类版本信息：
+
+- **当前写出版本**：当前代码序列化该 block 时写入的 `block_version`。
+- **支持读取版本**：当前代码能读取的该 block 版本集合或版本范围。
+
+reader 读取 TLV header 后，先检查 `tag + block_version` 是否被当前代码支持：
+
+- 支持的版本按对应 block reader 继续解析 payload。
+- 不支持的 critical block 直接返回错误，避免旧代码误读新格式。
+- 不支持的 non-critical block 使用 `value_len` 跳过 payload，并继续读取后续 block。
+
+因此，后续如果某个 block 从 v1 升级到 v2，不能只把当前写出版本改成 v2，还需要同步维护该 block
+的支持读取版本。如果新代码仍保留 v1 reader，则 supported versions 应包含 v1 和 v2，这样 v2 代码仍可读取
+v1 索引；如果不再支持 v1，则应显式从 supported versions 中移除，并让读取旧 critical block 失败。
+
+metadata 中的 block manifest 用来让工具和 reader 在读取 body 前知道预期 block 版本；真正解析 body 时，
+TLV header 中的 `block_version` 仍是每个 payload 的权威版本。
+
+![TLV block version check](../figures/advanced/streaming-block-version-check.svg)
+
+## BruteForce Blocks
+
+BruteForce 按顺序写入以下 streaming blocks：
+
+| Block | 内容 | 是否必需 |
+| --- | --- | --- |
+| `attribute_filter` | 开启属性过滤时写入的可选属性过滤索引 | 条件必需 |
+| `base_codes` | 暴力搜索使用的 flatten codes | 是 |
+| `label_table` | 外部 label 和 label remap | 是 |
+
+`DeserializeStreaming` 会恢复完整的内存 BruteForce 索引。`Load` 当前要求 `base_codes` 加载到内存中；
+必需的 BruteForce codes 不支持 reader-based 加载。
+
+## HGraph Blocks
+
+HGraph 按顺序写入以下 streaming blocks：
+
+| Block | 内容 | 是否必需 |
+| --- | --- | --- |
+| `label_table` | 外部 label、label remap、可选 source id table | 是 |
+| `base_codes` | 图搜索使用的 base flatten codes | 是 |
+| `bottom_graph` | 覆盖全部向量的底层图 | 是 |
+| `high_precision_codes` | reorder 使用独立精排 codes 时的高精度 codes | 条件必需 |
+| `route_graphs` | 所有上层 route graph | 是 |
+| `extra_info` | 可选 extra info 数据 | 条件必需 |
+| `attribute_filter` | 可选属性过滤索引 | 条件必需 |
+| `raw_vector` | 可选原始向量存储 | 条件必需 |
+
+`DeserializeStreaming` 会恢复完整的内存索引。`Load` 默认把 HGraph blocks 加载到内存中；如果
+load parameters 中设置 `precise_io_type`，可以覆盖 `precise_codes` 的 IO 类型。如果同时提供
+`precise_reader`，并且该 reader 大小与 `high_precision_codes` payload 大小一致，`Load` 会校验该外部
+reader 的 payload checksum，然后将 reorder codes 绑定到该 reader。
+
+## IVF Blocks
+
+IVF 按顺序写入以下 streaming blocks：
+
+| Block | 内容 | 是否必需 |
+| --- | --- | --- |
+| `ivf_bucket` | 倒排列表使用的 bucket datacell 数据 | 是 |
+| `ivf_partition_strategy` | partition strategy 状态，例如已训练的中心点 | 是 |
+| `label_table` | 外部 label 和 label remap | 是 |
+| `high_precision_codes` | IVF reorder 开启时的 reorder codes | 条件必需 |
+| `attribute_filter` | 开启属性过滤时写入的可选属性过滤索引 | 条件必需 |
+
+`DeserializeStreaming` 会恢复完整的内存 IVF 索引。`Index::Load` 可以直接从 streaming metadata
+创建 IVF 索引对象，当前会把写出的 IVF blocks 都加载到内存中。
+
+## SINDI Blocks
+
+SINDI 按顺序写入以下 streaming blocks：
+
+| Block | 内容 | 是否必需 |
+| --- | --- | --- |
+| `sindi_windows` | sparse term windows 和量化运行时状态 | 是 |
+| `label_table` | 外部 label 和 label remap | 是 |
+| `sindi_rerank_index` | rerank 开启时的可选 rerank flat index | 条件必需 |
+| `sindi_term_id_mapper` | 可选 term-id remap 表 | 条件必需 |
+
+`DeserializeStreaming` 会恢复完整的内存 SINDI 索引。`Index::Load` 可以直接从 streaming metadata
+创建 SINDI 索引对象，当前会把写出的 SINDI blocks 都加载到内存中。immutable SINDI runtime 暂不支持
+该 streaming 序列化路径。
+
+## Pyramid Blocks
+
+Pyramid 按顺序写入以下 streaming blocks：
+
+| Block | 内容 | 是否必需 |
+| --- | --- | --- |
+| `label_table` | 外部 label 和 label remap | 是 |
+| `base_codes` | 图搜索使用的 base flatten codes | 是 |
+| `high_precision_codes` | reorder 开启时的精排 codes | 条件必需 |
+| `pyramid_hierarchies` | hierarchy 名称和 graph roots | 是 |
+
+`DeserializeStreaming` 会恢复完整的内存 Pyramid 索引。`Index::Load` 可以直接从 streaming metadata
+创建 Pyramid 索引对象，当前会把写出的 Pyramid blocks 都加载到内存中。
+
+## 可视化流式索引
+
+构建工具后，传入 streaming index 文件：
+
+```bash
+cmake --build build --target visualize_index
+build/tools/visualize_index/visualize_index \
+  --index_path /tmp/vsag-hgraph-streaming.index \
+  --html /tmp/vsag-hgraph-streaming.html
+```
+
+CLI 输出包含按真实字节比例展示的 raw horizontal layout，以及高密度的 logical-block layout。HTML
+输出会把相关的小 segment 聚合展示，例如 TLV header 与 payload，并在表格中保留精确 segment 明细。
+
+streaming serialization 和 `Index::Load` 的可运行示例见
+`examples/cpp/403_persistent_streaming_load.cpp`。

--- a/docs/docs/zh/src/advanced/serialization.md
+++ b/docs/docs/zh/src/advanced/serialization.md
@@ -1,6 +1,9 @@
 # 序列化格式
 
-VSAG 索引可通过多种方式序列化与反序列化，便于持久化、跨进程共享及分布式部署。
+VSAG 索引可通过现有序列化接口进行序列化与反序列化，便于持久化、跨进程共享及分布式部署。
+
+本文介绍 `Serialize` 和 `Deserialize` 使用的现有序列化格式。后续引入的 header-first 流式格式见
+[新序列化格式](new_serialization.md)。两种格式互不兼容。
 
 ## 三种接口
 
@@ -51,6 +54,8 @@ index->Serialize([&](const void* buf, uint64_t offset, uint64_t size) {
 ## 注意事项
 
 - `Deserialize` 要求目标索引为**空**索引，并且参数配置与序列化时一致（如 `dim`、`metric_type`）。
+- `Serialize`/`Deserialize` 保留现有 footer-based 格式。新的 `SerializeStreaming` 格式是
+  header-first 格式，需要用 `DeserializeStreaming` 或 `Load` 读取。
 - 跨大版本升级时请关注 [版本日志](../resources/release_notes.md) 中的兼容性说明。
 - 示例参考：`examples/cpp/318_feature_tune.cpp`、`examples/cpp/401_persistent_kv.cpp`、
   `examples/cpp/402_persistent_streaming.cpp`。

--- a/docs/docs/zh/src/figures/advanced/streaming-block-version-check.svg
+++ b/docs/docs/zh/src/figures/advanced/streaming-block-version-check.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 860 360" font-family="-apple-system, BlinkMacSystemFont, 'PingFang SC', 'Microsoft YaHei', 'Segoe UI', Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#44546a"/>
+    </marker>
+  </defs>
+  <rect x="30" y="36" width="170" height="58" rx="6" fill="#e8f1ff" stroke="#4f81bd"/>
+  <text x="115" y="62" text-anchor="middle" font-size="14" fill="#1f2937">读取 TLV header</text>
+  <text x="115" y="82" text-anchor="middle" font-size="12" fill="#4b5563">tag / version / flags</text>
+  <line x1="200" y1="65" x2="285" y2="65" stroke="#44546a" stroke-width="2" marker-end="url(#arrow)"/>
+  <rect x="290" y="36" width="190" height="58" rx="6" fill="#fff3df" stroke="#d9902f"/>
+  <text x="385" y="62" text-anchor="middle" font-size="14" fill="#1f2937">查支持版本</text>
+  <text x="385" y="82" text-anchor="middle" font-size="12" fill="#4b5563">按 block tag 判断</text>
+  <line x1="480" y1="65" x2="565" y2="65" stroke="#44546a" stroke-width="2" marker-end="url(#arrow)"/>
+  <rect x="570" y="36" width="240" height="58" rx="6" fill="#eef7ee" stroke="#6aa84f"/>
+  <text x="690" y="62" text-anchor="middle" font-size="14" fill="#1f2937">版本支持</text>
+  <text x="690" y="82" text-anchor="middle" font-size="12" fill="#4b5563">按对应 reader 解析 payload</text>
+  <line x1="385" y1="94" x2="385" y2="150" stroke="#44546a" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="415" y="126" font-size="12" fill="#374151">版本过高或不支持</text>
+  <rect x="250" y="154" width="270" height="58" rx="6" fill="#f8e8e8" stroke="#cc6666"/>
+  <text x="385" y="180" text-anchor="middle" font-size="14" fill="#1f2937">critical block?</text>
+  <text x="385" y="200" text-anchor="middle" font-size="12" fill="#4b5563">例如 base_codes / graph / label_table</text>
+  <line x1="250" y1="183" x2="165" y2="260" stroke="#44546a" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="185" y="215" text-anchor="middle" font-size="12" fill="#374151">是</text>
+  <rect x="30" y="266" width="230" height="58" rx="6" fill="#fdecec" stroke="#c0504d"/>
+  <text x="145" y="292" text-anchor="middle" font-size="14" fill="#1f2937">报错中断</text>
+  <text x="145" y="312" text-anchor="middle" font-size="12" fill="#4b5563">避免旧代码误读新格式</text>
+  <line x1="520" y1="183" x2="610" y2="260" stroke="#44546a" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="585" y="215" text-anchor="middle" font-size="12" fill="#374151">否</text>
+  <rect x="600" y="266" width="230" height="58" rx="6" fill="#eef7ee" stroke="#6aa84f"/>
+  <text x="715" y="292" text-anchor="middle" font-size="14" fill="#1f2937">跳过 payload</text>
+  <text x="715" y="312" text-anchor="middle" font-size="12" fill="#4b5563">使用 value_len 定位下一块</text>
+</svg>

--- a/docs/docs/zh/src/figures/advanced/streaming-serialization-usage.svg
+++ b/docs/docs/zh/src/figures/advanced/streaming-serialization-usage.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 190" font-family="-apple-system, BlinkMacSystemFont, 'PingFang SC', 'Microsoft YaHei', 'Segoe UI', Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#44546a"/>
+    </marker>
+  </defs>
+  <rect x="15" y="45" width="140" height="58" rx="6" fill="#e8f1ff" stroke="#4f81bd"/>
+  <text x="85" y="70" text-anchor="middle" font-size="14" fill="#1f2937">已构建索引</text>
+  <text x="85" y="90" text-anchor="middle" font-size="12" fill="#4b5563">内存对象</text>
+  <line x1="155" y1="74" x2="250" y2="74" stroke="#44546a" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="202" y="58" text-anchor="middle" font-size="12" fill="#374151">SerializeStreaming</text>
+  <rect x="255" y="45" width="150" height="58" rx="6" fill="#fff3df" stroke="#d9902f"/>
+  <text x="330" y="70" text-anchor="middle" font-size="14" fill="#1f2937">Streaming 文件</text>
+  <text x="330" y="90" text-anchor="middle" font-size="12" fill="#4b5563">存储 / 传输</text>
+  <line x1="405" y1="58" x2="565" y2="35" stroke="#44546a" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="488" y="36" text-anchor="middle" font-size="12" fill="#374151">DeserializeStreaming</text>
+  <rect x="570" y="8" width="170" height="58" rx="6" fill="#eef7ee" stroke="#6aa84f"/>
+  <text x="655" y="33" text-anchor="middle" font-size="14" fill="#1f2937">完整恢复</text>
+  <text x="655" y="53" text-anchor="middle" font-size="12" fill="#4b5563">调用方先创建索引</text>
+  <line x1="405" y1="92" x2="565" y2="126" stroke="#44546a" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="488" y="119" text-anchor="middle" font-size="12" fill="#374151">Index::Load</text>
+  <rect x="570" y="105" width="170" height="58" rx="6" fill="#f4ecff" stroke="#8e7cc3"/>
+  <text x="655" y="130" text-anchor="middle" font-size="14" fill="#1f2937">服务索引</text>
+  <text x="655" y="150" text-anchor="middle" font-size="12" fill="#4b5563">可直接搜索</text>
+</svg>

--- a/examples/cpp/403_persistent_streaming_load.cpp
+++ b/examples/cpp/403_persistent_streaming_load.cpp
@@ -1,0 +1,378 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <vsag/vsag.h>
+
+#include <algorithm>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <random>
+#include <string>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "vsag/options.h"
+
+namespace {
+
+enum class ExampleIndex {
+    K_BRUTE_FORCE,
+    K_H_GRAPH,
+    K_IVF,
+    K_PYRAMID,
+    K_SINDI,
+};
+
+constexpr ExampleIndex K_INDEX_KIND = ExampleIndex::K_H_GRAPH;
+constexpr int64_t K_DENSE_DIM = 16;
+constexpr int64_t K_SPARSE_DIM = 128;
+constexpr int64_t K_NUM_VECTORS = 100;
+constexpr int64_t K_TOP_K = 5;
+
+struct ExampleConfig {
+    const char* index_name;
+    const char* build_parameters;
+    const char* load_parameters;
+    const char* search_parameters;
+    const char* file_path;
+    int64_t dim;
+    bool use_paths;
+    bool use_sparse;
+};
+
+ExampleConfig
+get_example_config() {
+    switch (K_INDEX_KIND) {
+        case ExampleIndex::K_BRUTE_FORCE:
+            return {
+                "brute_force",
+                R"(
+                {
+                    "dtype": "float32",
+                    "metric_type": "l2",
+                    "dim": 16,
+                    "index_param": {
+                        "base_quantization_type": "fp32",
+                        "base_io_type": "memory_io"
+                    }
+                }
+                )",
+                R"(
+                {
+                    "base_io_type": "memory_io"
+                }
+                )",
+                "{}",
+                "/tmp/vsag-streaming-load-bruteforce.index",
+                K_DENSE_DIM,
+                false,
+                false,
+            };
+        case ExampleIndex::K_H_GRAPH:
+            return {
+                "hgraph",
+                R"(
+                {
+                    "dtype": "float32",
+                    "metric_type": "l2",
+                    "dim": 16,
+                    "index_param": {
+                        "base_quantization_type": "sq8",
+                        "max_degree": 16,
+                        "ef_construction": 100,
+                        "alpha": 1.2
+                    }
+                }
+                )",
+                "{}",
+                R"(
+                {
+                    "hgraph": {
+                        "ef_search": 100
+                    }
+                }
+                )",
+                "/tmp/vsag-streaming-load-hgraph.index",
+                K_DENSE_DIM,
+                false,
+                false,
+            };
+        case ExampleIndex::K_IVF:
+            return {
+                "ivf",
+                R"(
+                {
+                    "dtype": "float32",
+                    "metric_type": "l2",
+                    "dim": 16,
+                    "index_param": {
+                        "buckets_count": 10,
+                        "base_quantization_type": "fp32",
+                        "partition_strategy_type": "ivf",
+                        "ivf_train_type": "kmeans",
+                        "train_sample_count": 512
+                    }
+                }
+                )",
+                "{}",
+                R"(
+                {
+                    "ivf": {
+                        "scan_buckets_count": 5
+                    }
+                }
+                )",
+                "/tmp/vsag-streaming-load-ivf.index",
+                K_DENSE_DIM,
+                false,
+                false,
+            };
+        case ExampleIndex::K_PYRAMID:
+            return {
+                "pyramid",
+                R"(
+                {
+                    "dtype": "float32",
+                    "metric_type": "l2",
+                    "dim": 16,
+                    "index_param": {
+                        "base_quantization_type": "sq8",
+                        "max_degree": 24,
+                        "alpha": 1.2,
+                        "graph_iter_turn": 15,
+                        "neighbor_sample_rate": 0.2,
+                        "no_build_levels": [0, 1],
+                        "use_reorder": true,
+                        "graph_type": "odescent",
+                        "build_thread_count": 1
+                    }
+                }
+                )",
+                "{}",
+                R"(
+                {
+                    "pyramid": {
+                        "ef_search": 100
+                    }
+                }
+                )",
+                "/tmp/vsag-streaming-load-pyramid.index",
+                K_DENSE_DIM,
+                true,
+                false,
+            };
+        case ExampleIndex::K_SINDI:
+            return {
+                "sindi",
+                R"(
+                {
+                    "dtype": "sparse",
+                    "metric_type": "ip",
+                    "dim": 128,
+                    "index_param": {
+                        "use_reorder": true,
+                        "use_quantization": false,
+                        "doc_prune_ratio": 0.0,
+                        "term_prune_ratio": 0.0,
+                        "window_size": 10000,
+                        "term_id_limit": 30001,
+                        "avg_doc_term_length": 100
+                    }
+                }
+                )",
+                "{}",
+                R"(
+                {
+                    "sindi": {
+                        "query_prune_ratio": 0.0,
+                        "term_prune_ratio": 0.0,
+                        "n_candidate": 20
+                    }
+                }
+                )",
+                "/tmp/vsag-streaming-load-sindi.index",
+                K_SPARSE_DIM,
+                false,
+                true,
+            };
+    }
+    std::abort();
+}
+
+vsag::DatasetPtr
+make_dense_dataset(std::vector<int64_t>& ids,
+                   std::vector<float>& vectors,
+                   std::vector<std::string>& paths,
+                   int64_t dim,
+                   bool use_paths) {
+    auto dataset = vsag::Dataset::Make()
+                       ->NumElements(static_cast<int64_t>(ids.size()))
+                       ->Dim(dim)
+                       ->Ids(ids.data())
+                       ->Float32Vectors(vectors.data())
+                       ->Owner(false);
+    if (use_paths) {
+        dataset->Paths(paths.data());
+    }
+    return dataset;
+}
+
+void
+fill_sparse_vector(vsag::SparseVector& vector,
+                   std::mt19937& rng,
+                   std::uniform_real_distribution<float>& value_dist,
+                   std::uniform_int_distribution<uint32_t>& term_dist,
+                   int64_t nnz) {
+    vector.len_ = nnz;
+    vector.ids_ = new uint32_t[vector.len_];
+    vector.vals_ = new float[vector.len_];
+    std::unordered_set<uint32_t> terms;
+    std::vector<std::pair<uint32_t, float>> entries;
+    entries.reserve(static_cast<size_t>(nnz));
+    for (int64_t i = 0; i < nnz; ++i) {
+        auto term = term_dist(rng);
+        while (terms.count(term) != 0) {
+            term = term_dist(rng);
+        }
+        terms.insert(term);
+        entries.emplace_back(term, value_dist(rng));
+    }
+    std::sort(entries.begin(), entries.end(), [](const auto& lhs, const auto& rhs) {
+        return lhs.first < rhs.first;
+    });
+    for (int64_t i = 0; i < nnz; ++i) {
+        vector.ids_[i] = entries[static_cast<size_t>(i)].first;
+        vector.vals_[i] = entries[static_cast<size_t>(i)].second;
+    }
+}
+
+void
+release_sparse_vectors(std::vector<vsag::SparseVector>& vectors) {
+    for (auto& vector : vectors) {
+        delete[] vector.ids_;
+        delete[] vector.vals_;
+        vector.ids_ = nullptr;
+        vector.vals_ = nullptr;
+        vector.len_ = 0;
+    }
+}
+
+vsag::DatasetPtr
+make_sparse_dataset(std::vector<int64_t>& ids, std::vector<vsag::SparseVector>& vectors) {
+    return vsag::Dataset::Make()
+        ->NumElements(static_cast<int64_t>(ids.size()))
+        ->Ids(ids.data())
+        ->SparseVectors(vectors.data())
+        ->Owner(false);
+}
+
+template <typename T>
+void
+check_result(const tl::expected<T, vsag::Error>& result, const std::string& action) {
+    if (!result.has_value()) {
+        std::cerr << action << " failed: " << result.error().message << std::endl;
+        std::abort();
+    }
+}
+
+}  // namespace
+
+int
+main() {
+    vsag::init();
+    vsag::Options::Instance().set_block_size_limit(2UL * 1024 * 1024);
+    const auto config = get_example_config();
+
+    std::vector<int64_t> ids(K_NUM_VECTORS);
+    std::vector<float> vectors(K_NUM_VECTORS * config.dim);
+    std::vector<std::string> paths(K_NUM_VECTORS);
+    std::vector<vsag::SparseVector> sparse_vectors(K_NUM_VECTORS);
+    std::mt19937 rng(47);
+    std::uniform_real_distribution<float> distrib;
+    std::uniform_real_distribution<float> sparse_value_dist(0.0F, 10.0F);
+    std::uniform_int_distribution<uint32_t> sparse_term_dist(0, 30000);
+    for (int64_t i = 0; i < K_NUM_VECTORS; ++i) {
+        ids[i] = i;
+        paths[i] = "path/" + std::to_string(i);
+        if (config.use_sparse) {
+            fill_sparse_vector(sparse_vectors[i], rng, sparse_value_dist, sparse_term_dist, 64);
+        }
+    }
+    for (auto& value : vectors) {
+        value = distrib(rng);
+    }
+
+    auto index = vsag::Factory::CreateIndex(config.index_name, config.build_parameters).value();
+    auto base = config.use_sparse
+                    ? make_sparse_dataset(ids, sparse_vectors)
+                    : make_dense_dataset(ids, vectors, paths, config.dim, config.use_paths);
+    auto build_result = index->Build(base);
+    if (!build_result.has_value()) {
+        std::cerr << "build failed: " << build_result.error().message << std::endl;
+        return -1;
+    }
+
+    {
+        std::ofstream out(config.file_path, std::ios::binary);
+        check_result(index->SerializeStreaming(out), "SerializeStreaming");
+    }
+
+    auto full_index =
+        vsag::Factory::CreateIndex(config.index_name, config.build_parameters).value();
+    {
+        std::ifstream in(config.file_path, std::ios::binary);
+        check_result(full_index->DeserializeStreaming(in), "DeserializeStreaming");
+    }
+
+    vsag::IndexPtr loaded_index;
+    {
+        std::ifstream in(config.file_path, std::ios::binary);
+        auto load_result = vsag::Index::Load(in, config.load_parameters);
+        check_result(load_result, "Load");
+        loaded_index = load_result.value();
+    }
+
+    std::vector<float> query_vector(config.dim);
+    std::vector<std::string> query_paths{"path/0"};
+    std::vector<vsag::SparseVector> query_sparse_vectors(1);
+    for (auto& value : query_vector) {
+        value = distrib(rng);
+    }
+    if (config.use_sparse) {
+        fill_sparse_vector(query_sparse_vectors[0], rng, sparse_value_dist, sparse_term_dist, 64);
+    }
+    auto query = vsag::Dataset::Make()->NumElements(1)->Owner(false);
+    if (config.use_sparse) {
+        query->SparseVectors(query_sparse_vectors.data());
+    } else {
+        query->Dim(config.dim)->Float32Vectors(query_vector.data());
+    }
+    if (config.use_paths) {
+        query->Paths(query_paths.data());
+    }
+    auto result = loaded_index->KnnSearch(query, K_TOP_K, config.search_parameters).value();
+
+    std::cout << "After Build(), Index " << config.index_name
+              << " contains: " << index->GetNumElements() << std::endl;
+    std::cout << "Streaming index file: " << config.file_path << std::endl;
+    std::cout << "results: " << std::endl;
+    for (int64_t i = 0; i < result->GetDim(); ++i) {
+        std::cout << result->GetIds()[i] << ": " << result->GetDistances()[i] << std::endl;
+    }
+    release_sparse_vectors(sparse_vectors);
+    release_sparse_vectors(query_sparse_vectors);
+    return 0;
+}

--- a/examples/cpp/404_persistent_streaming_load_hybrid.cpp
+++ b/examples/cpp/404_persistent_streaming_load_hybrid.cpp
@@ -1,0 +1,220 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <vsag/vsag.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <mutex>
+#include <random>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "vsag/options.h"
+
+namespace {
+
+constexpr int64_t K_DIM = 128;
+constexpr int64_t K_NUM_VECTORS = 500;
+constexpr int64_t K_TOP_K = 10;
+constexpr uint64_t K_DB_HEADER_SIZE = 4096;
+constexpr uint64_t K_DB_FOOTER_SIZE = 128;
+constexpr const char* K_DB_FILE_PATH = "/tmp/vsag-streaming-load-hybrid.index";
+
+// Build parameters describe the index algorithm and encoding only. They no longer need
+// placement keys such as base_io_type, precise_io_type, or their file paths.
+// Those keys belong to Index::Load(), where callers choose the serving layout.
+const char* hybrid_hgraph_build_parameters = R"(
+{
+    "dtype": "float32",
+    "metric_type": "l2",
+    "dim": 128,
+    "index_param": {
+        "base_quantization_type": "rabitq",
+        "precise_quantization_type": "sq8",
+        "use_reorder": true,
+        "rabitq_bits_per_dim_base": 3,
+        "rabitq_bits_per_dim_query": 32,
+        "rabitq_error_rate": 1.9,
+        "max_degree": 32,
+        "ef_construction": 200,
+        "graph_storage_type": "compressed"
+    }
+}
+)";
+
+// Load parameters choose where each serialized component is placed for serving.
+// This example keeps RaBitQ base codes in memory and serves SQ8 reorder codes
+// through a read_func reader. The build parameters stay independent from the
+// final memory/disk placement.
+
+const char* hgraph_search_parameters = R"(
+{
+    "hgraph": {
+        "ef_search": 200,
+        "rabitq_one_bit_search": true
+    }
+}
+)";
+
+void
+cleanup_hybrid_files() {
+    std::remove(K_DB_FILE_PATH);
+}
+
+vsag::DatasetPtr
+make_base_dataset(std::vector<int64_t>& ids, std::vector<float>& vectors) {
+    ids.resize(K_NUM_VECTORS);
+    vectors.resize(K_NUM_VECTORS * K_DIM);
+
+    std::mt19937 rng(47);
+    std::uniform_real_distribution<float> dist;
+    for (int64_t i = 0; i < K_NUM_VECTORS; ++i) {
+        ids[i] = i;
+    }
+    for (auto& value : vectors) {
+        value = dist(rng);
+    }
+
+    return vsag::Dataset::Make()
+        ->NumElements(K_NUM_VECTORS)
+        ->Dim(K_DIM)
+        ->Ids(ids.data())
+        ->Float32Vectors(vectors.data())
+        ->Owner(false);
+}
+
+vsag::DatasetPtr
+make_query_dataset(std::vector<float>& query_vector) {
+    query_vector.resize(K_DIM);
+    std::mt19937 rng(101);
+    std::uniform_real_distribution<float> dist;
+    for (auto& value : query_vector) {
+        value = dist(rng);
+    }
+
+    return vsag::Dataset::Make()
+        ->NumElements(1)
+        ->Dim(K_DIM)
+        ->Float32Vectors(query_vector.data())
+        ->Owner(false);
+}
+
+template <typename T>
+void
+check_result(const tl::expected<T, vsag::Error>& result, const std::string& action) {
+    if (!result.has_value()) {
+        std::cerr << action << " failed: " << result.error().message << std::endl;
+        std::abort();
+    }
+}
+
+void
+print_results(const vsag::DatasetPtr& result) {
+    std::cout << "results:" << std::endl;
+    for (int64_t i = 0; i < result->GetDim(); ++i) {
+        std::cout << "  " << result->GetIds()[i] << ": " << result->GetDistances()[i] << std::endl;
+    }
+}
+
+}  // namespace
+
+int
+main() {
+    vsag::Options::Instance().set_block_size_limit(2UL * 1024 * 1024);
+    cleanup_hybrid_files();
+
+    std::vector<int64_t> ids;
+    std::vector<float> vectors;
+    auto base = make_base_dataset(ids, vectors);
+
+    auto index = vsag::Factory::CreateIndex("hgraph", hybrid_hgraph_build_parameters).value();
+    check_result(index->Build(base), "Build");
+
+    {
+        std::ofstream out(K_DB_FILE_PATH, std::ios::binary);
+        std::vector<char> db_header(K_DB_HEADER_SIZE, 'H');
+        std::vector<char> db_footer(K_DB_FOOTER_SIZE, 'F');
+        out.write(db_header.data(), static_cast<std::streamsize>(db_header.size()));
+        check_result(index->SerializeStreaming(out), "SerializeStreaming");
+        out.write(db_footer.data(), static_cast<std::streamsize>(db_footer.size()));
+    }
+
+    auto metadata_file = std::ifstream(K_DB_FILE_PATH, std::ios::binary);
+    metadata_file.seekg(static_cast<std::streamoff>(K_DB_HEADER_SIZE), std::ios::beg);
+    auto metadata_result = vsag::Index::GetStreamingMetadata(metadata_file);
+    check_result(metadata_result, "GetStreamingMetadata");
+
+    const vsag::StreamingBlockLayout* high_precision_codes = nullptr;
+    for (const auto& block : metadata_result.value().blocks) {
+        if (block.name == "high_precision_codes") {
+            high_precision_codes = &block;
+            break;
+        }
+    }
+    if (high_precision_codes == nullptr) {
+        std::cerr << "high_precision_codes block is missing" << std::endl;
+        std::abort();
+    }
+
+    auto db_reader_file = std::make_shared<std::ifstream>(K_DB_FILE_PATH, std::ios::binary);
+    auto db_reader_mutex = std::make_shared<std::mutex>();
+    auto db_read_func = [db_reader_file, db_reader_mutex](
+                            uint64_t offset, uint64_t len, void* dest) {
+        std::lock_guard<std::mutex> lock(*db_reader_mutex);
+        db_reader_file->clear();
+        db_reader_file->seekg(static_cast<std::streamoff>(offset), std::ios::beg);
+        db_reader_file->read(static_cast<char*>(dest), static_cast<std::streamsize>(len));
+        if (db_reader_file->fail()) {
+            throw std::runtime_error("failed to read wrapped DB index file");
+        }
+    };
+
+    const uint64_t high_precision_codes_offset =
+        K_DB_HEADER_SIZE + high_precision_codes->payload_offset;
+    auto precise_reader = vsag::Factory::CreateReadFuncReader(
+        db_read_func, high_precision_codes_offset, high_precision_codes->payload_size);
+
+    vsag::LoadParameters load_parameters;
+    load_parameters.Set("base_io_type", "block_memory_io")
+        .Set("precise_io_type", "reader_io")
+        .SetReader("precise_reader", precise_reader);
+
+    vsag::IndexPtr loaded_index;
+    {
+        std::ifstream in(K_DB_FILE_PATH, std::ios::binary);
+        in.seekg(static_cast<std::streamoff>(K_DB_HEADER_SIZE), std::ios::beg);
+        auto load_result = vsag::Index::Load(in, load_parameters);
+        check_result(load_result, "Load");
+        loaded_index = load_result.value();
+    }
+
+    std::vector<float> query_vector;
+    auto query = make_query_dataset(query_vector);
+    auto result = loaded_index->KnnSearch(query, K_TOP_K, hgraph_search_parameters);
+    check_result(result, "KnnSearch");
+
+    std::cout << "After streaming Load(), hybrid HGraph contains: "
+              << loaded_index->GetNumElements() << std::endl;
+    std::cout << "Wrapped DB index file: " << K_DB_FILE_PATH << std::endl;
+    std::cout << "Load parameters: " << load_parameters.Dump() << std::endl;
+    std::cout << "high_precision_codes payload offset in DB file: " << high_precision_codes_offset
+              << std::endl;
+    print_results(result.value());
+    return 0;
+}

--- a/examples/cpp/405_persistent_streaming_transfer.cpp
+++ b/examples/cpp/405_persistent_streaming_transfer.cpp
@@ -1,0 +1,255 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <vsag/vsag.h>
+
+#include <array>
+#include <condition_variable>
+#include <cstdlib>
+#include <deque>
+#include <exception>
+#include <iostream>
+#include <mutex>
+#include <random>
+#include <streambuf>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "vsag/options.h"
+
+namespace {
+
+constexpr int64_t K_DIM = 16;
+constexpr int64_t K_NUM_VECTORS = 200;
+constexpr int64_t K_TOP_K = 5;
+
+const char* hgraph_build_parameters = R"(
+{
+    "dtype": "float32",
+    "metric_type": "l2",
+    "dim": 16,
+    "index_param": {
+        "base_quantization_type": "sq8",
+        "max_degree": 16,
+        "ef_construction": 100,
+        "alpha": 1.2
+    }
+}
+)";
+
+const char* hgraph_search_parameters = R"(
+{
+    "hgraph": {
+        "ef_search": 100
+    }
+}
+)";
+
+class BlockingStreamBuffer : public std::streambuf {
+public:
+    void
+    Close() {
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            closed_ = true;
+        }
+        ready_.notify_all();
+    }
+
+protected:
+    int_type
+    overflow(int_type ch) override {
+        if (traits_type::eq_int_type(ch, traits_type::eof())) {
+            return traits_type::not_eof(ch);
+        }
+        char value = traits_type::to_char_type(ch);
+        return xsputn(&value, 1) == 1 ? ch : traits_type::eof();
+    }
+
+    std::streamsize
+    xsputn(const char* data, std::streamsize count) override {
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            for (std::streamsize i = 0; i < count; ++i) {
+                buffer_.push_back(data[i]);
+            }
+        }
+        ready_.notify_all();
+        return count;
+    }
+
+    int
+    sync() override {
+        ready_.notify_all();
+        return 0;
+    }
+
+    int_type
+    underflow() override {
+        if (gptr() != nullptr && gptr() < egptr()) {
+            return traits_type::to_int_type(*gptr());
+        }
+
+        std::unique_lock<std::mutex> lock(mutex_);
+        ready_.wait(lock, [&] { return closed_ || !buffer_.empty(); });
+        if (buffer_.empty()) {
+            return traits_type::eof();
+        }
+
+        uint64_t count = 0;
+        while (count < read_buffer_.size() && !buffer_.empty()) {
+            read_buffer_[count] = buffer_.front();
+            buffer_.pop_front();
+            ++count;
+        }
+        setg(read_buffer_.data(),
+             read_buffer_.data(),
+             read_buffer_.data() + static_cast<std::ptrdiff_t>(count));
+        return traits_type::to_int_type(*gptr());
+    }
+
+    std::streamsize
+    showmanyc() override {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return static_cast<std::streamsize>(buffer_.size());
+    }
+
+private:
+    std::mutex mutex_;
+    std::condition_variable ready_;
+    std::deque<char> buffer_;
+    std::array<char, 4096> read_buffer_{};
+    bool closed_{false};
+};
+
+vsag::DatasetPtr
+make_base_dataset(std::vector<int64_t>& ids, std::vector<float>& vectors) {
+    ids.resize(K_NUM_VECTORS);
+    vectors.resize(K_NUM_VECTORS * K_DIM);
+
+    std::mt19937 rng(47);
+    std::uniform_real_distribution<float> dist;
+    for (int64_t i = 0; i < K_NUM_VECTORS; ++i) {
+        ids[i] = i;
+    }
+    for (auto& value : vectors) {
+        value = dist(rng);
+    }
+
+    return vsag::Dataset::Make()
+        ->NumElements(K_NUM_VECTORS)
+        ->Dim(K_DIM)
+        ->Ids(ids.data())
+        ->Float32Vectors(vectors.data())
+        ->Owner(false);
+}
+
+vsag::DatasetPtr
+make_query_dataset(std::vector<float>& query_vector) {
+    query_vector.resize(K_DIM);
+    std::mt19937 rng(101);
+    std::uniform_real_distribution<float> dist;
+    for (auto& value : query_vector) {
+        value = dist(rng);
+    }
+
+    return vsag::Dataset::Make()
+        ->NumElements(1)
+        ->Dim(K_DIM)
+        ->Float32Vectors(query_vector.data())
+        ->Owner(false);
+}
+
+template <typename T>
+void
+check_result(const tl::expected<T, vsag::Error>& result, const std::string& action) {
+    if (!result.has_value()) {
+        std::cerr << action << " failed: " << result.error().message << std::endl;
+        std::abort();
+    }
+}
+
+void
+rethrow_if_set(const std::exception_ptr& error) {
+    if (error != nullptr) {
+        std::rethrow_exception(error);
+    }
+}
+
+void
+print_results(const vsag::DatasetPtr& result) {
+    std::cout << "results:" << std::endl;
+    for (int64_t i = 0; i < result->GetDim(); ++i) {
+        std::cout << "  " << result->GetIds()[i] << ": " << result->GetDistances()[i] << std::endl;
+    }
+}
+
+}  // namespace
+
+int
+main() {
+    vsag::Options::Instance().set_block_size_limit(2UL * 1024 * 1024);
+
+    std::vector<int64_t> ids;
+    std::vector<float> vectors;
+    auto base = make_base_dataset(ids, vectors);
+
+    auto index = vsag::Factory::CreateIndex("hgraph", hgraph_build_parameters).value();
+    check_result(index->Build(base), "Build");
+
+    BlockingStreamBuffer shared_buffer;
+    std::iostream shared_stream(&shared_buffer);
+    vsag::IndexPtr received_index;
+    std::exception_ptr writer_error;
+    std::exception_ptr reader_error;
+
+    std::thread reader([&] {
+        try {
+            auto create_index = vsag::Factory::CreateIndex("hgraph", hgraph_build_parameters);
+            check_result(create_index, "Create receiver index");
+            received_index = create_index.value();
+            check_result(received_index->DeserializeStreaming(shared_stream),
+                         "DeserializeStreaming");
+        } catch (...) {
+            reader_error = std::current_exception();
+        }
+    });
+
+    std::thread writer([&] {
+        try {
+            check_result(index->SerializeStreaming(shared_stream), "SerializeStreaming");
+            shared_stream.flush();
+        } catch (...) {
+            writer_error = std::current_exception();
+        }
+        shared_buffer.Close();
+    });
+
+    writer.join();
+    reader.join();
+    rethrow_if_set(writer_error);
+    rethrow_if_set(reader_error);
+
+    std::vector<float> query_vector;
+    auto query = make_query_dataset(query_vector);
+    auto result = received_index->KnnSearch(query, K_TOP_K, hgraph_search_parameters);
+    check_result(result, "KnnSearch");
+
+    std::cout << "Transferred HGraph through one std::iostream with streaming serialization"
+              << std::endl;
+    std::cout << "Received index contains: " << received_index->GetNumElements() << std::endl;
+    print_results(result.value());
+    return 0;
+}

--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -125,6 +125,15 @@ target_link_libraries (401_persistent_kv vsag)
 add_executable (402_persistent_streaming 402_persistent_streaming.cpp)
 target_link_libraries (402_persistent_streaming vsag)
 
+add_executable (403_persistent_streaming_load 403_persistent_streaming_load.cpp)
+target_link_libraries (403_persistent_streaming_load vsag)
+
+add_executable (404_persistent_streaming_load_hybrid 404_persistent_streaming_load_hybrid.cpp)
+target_link_libraries (404_persistent_streaming_load_hybrid vsag)
+
+add_executable (405_persistent_streaming_transfer 405_persistent_streaming_transfer.cpp)
+target_link_libraries (405_persistent_streaming_transfer vsag)
+
 add_executable (501_quantization_transform 501_quantization_transform.cpp)
 target_link_libraries (501_quantization_transform vsag)
 

--- a/examples/cpp/README.md
+++ b/examples/cpp/README.md
@@ -109,6 +109,8 @@ together when the directory is listed:
 | --- | --- |
 | [`401_persistent_kv.cpp`](401_persistent_kv.cpp) | Serialize / deserialize against a key-value backend. |
 | [`402_persistent_streaming.cpp`](402_persistent_streaming.cpp) | Streaming serialization for large indexes. |
+| [`403_persistent_streaming_load.cpp`](403_persistent_streaming_load.cpp) | Static `Index::Load` from streaming serialization across index types. |
+| [`404_persistent_streaming_load_hybrid.cpp`](404_persistent_streaming_load_hybrid.cpp) | Static `Index::Load` for a hybrid HGraph index with memory and disk-backed RaBitQ split codes. |
 
 ### Quantization (`5xx`)
 

--- a/include/vsag/constants.h
+++ b/include/vsag/constants.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace vsag {
 
 extern const char* const INDEX_HGRAPH;
@@ -254,5 +256,9 @@ extern const char* const GNO_IMI_SECOND_ORDER_BUCKETS_COUNT;
 extern const char* const SERIAL_MAGIC_BEGIN;
 extern const char* const SERIAL_MAGIC_END;
 extern const char* const SERIAL_META_KEY;
+extern const char* const SERIAL_STREAM_MAGIC;
+extern const uint16_t SERIAL_STREAM_FORMAT_MAJOR;
+extern const uint16_t SERIAL_STREAM_FORMAT_MINOR;
+extern const uint32_t SERIAL_STREAM_SECTION_END;
 
 }  // namespace vsag

--- a/include/vsag/factory.h
+++ b/include/vsag/factory.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <string>
 
@@ -26,6 +27,7 @@ namespace vsag {
 
 class Index;
 class Reader;
+using ReadFunc = std::function<void(uint64_t, uint64_t, void*)>;
 
 class Factory {
 public:
@@ -60,6 +62,12 @@ public:
      */
     static std::shared_ptr<Reader>
     CreateLocalFileReader(const std::string& filename, int64_t base_offset, int64_t size);
+
+    static std::shared_ptr<Reader>
+    CreateReadFuncReader(ReadFunc read_func, uint64_t size);
+
+    static std::shared_ptr<Reader>
+    CreateReadFuncReader(ReadFunc read_func, uint64_t base_offset, uint64_t size);
 
 private:
     Factory() = default;

--- a/include/vsag/index.h
+++ b/include/vsag/index.h
@@ -36,6 +36,7 @@
 #include "vsag/index_detail_info.h"
 #include "vsag/index_features.h"
 #include "vsag/iterator_context.h"
+#include "vsag/load_parameters.h"
 #include "vsag/readerset.h"
 #include "vsag/search_param.h"
 #include "vsag/search_request.h"
@@ -84,6 +85,21 @@ enum class RemoveMode {
     /** remove the vector from index and repair the index, this mode is heavy */
     FORCE_REMOVE = 1,
 
+};
+
+struct StreamingBlockLayout {
+    std::string name;
+    uint32_t tag{0};
+    uint32_t version{0};
+    bool critical{false};
+    uint64_t header_offset{0};
+    uint64_t payload_offset{0};
+    uint64_t payload_size{0};
+};
+
+struct StreamingIndexMetadata {
+    std::string metadata_json;
+    std::vector<StreamingBlockLayout> blocks;
 };
 
 class Index {
@@ -863,6 +879,19 @@ public:
     }
 
     /**
+      * @brief Serialize the full index to the header-first streaming format.
+      *
+      * The stream starts with the VSAG streaming magic/version header, followed by metadata and
+      * TLV body blocks, and ends with a SECTION_END block. Use DeserializeStreaming or Load to
+      * read this format.
+      */
+    virtual tl::expected<void, Error>
+    SerializeStreaming(std::ostream& out_stream) const {
+        return tl::unexpected(Error(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                                    "Index does not support streaming serialize"));
+    }
+
+    /**
       * @brief Deserialize index from a file stream
       * 
       * @param in_stream is a already opened file stream contains serialized index
@@ -874,6 +903,37 @@ public:
         return tl::unexpected(Error(ErrorType::UNSUPPORTED_INDEX_OPERATION,
                                     "Index does not support deserialize from a file stream"));
     }
+
+    /**
+      * @brief Restore the full in-memory index from the streaming format.
+      *
+      * The target index must be empty and compatible with the serialized build parameters. This
+      * API does not accept loading policy options; use Load for policy-based placement.
+      */
+    virtual tl::expected<void, Error>
+    DeserializeStreaming(std::istream& in_stream) {
+        return tl::unexpected(Error(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                                    "Index does not support streaming deserialize"));
+    }
+
+    /**
+      * @brief Load an index from the streaming format using a loading policy.
+      *
+      * This static API reads the serialized metadata, creates the matching index internally, and
+      * then loads the index body according to the loading policy. The parameters object can be
+      * constructed from a JSON string, and can also carry Reader objects for reader_io-backed
+      * blocks. Policy keys are index-specific; supported keys include IO-related keys from
+      * CreateIndex, such as base_io_type, precise_io_type, raw_vector_io_type and their file path
+      * counterparts. Invalid parameter JSON or values return INVALID_ARGUMENT; unsupported loading
+      * policies return UNSUPPORTED_INDEX_OPERATION.
+      */
+    static tl::expected<StreamingIndexMetadata, Error>
+    GetStreamingMetadata(std::istream& in_stream);
+
+    static tl::expected<IndexPtr, Error>
+    Load(std::istream& in_stream,
+         const LoadParameters& parameters = LoadParameters(),
+         Allocator* allocator = nullptr);
 
 public:
     // [statstics methods]

--- a/include/vsag/load_parameters.h
+++ b/include/vsag/load_parameters.h
@@ -1,0 +1,73 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+#include "vsag/readerset.h"
+
+namespace vsag {
+
+class LoadParameters {
+public:
+    LoadParameters();
+    LoadParameters(const char* json_string);
+    LoadParameters(const std::string& json_string);
+    LoadParameters(const LoadParameters& other);
+    LoadParameters&
+    operator=(const LoadParameters& other);
+    ~LoadParameters();
+
+    LoadParameters&
+    Set(const std::string& key, const std::string& value);
+
+    LoadParameters&
+    Set(const std::string& key, const char* value);
+
+    LoadParameters&
+    Set(const std::string& key, bool value);
+
+    LoadParameters&
+    Set(const std::string& key, int64_t value);
+
+    LoadParameters&
+    Set(const std::string& key, uint64_t value);
+
+    LoadParameters&
+    Set(const std::string& key, double value);
+
+    LoadParameters&
+    Set(const std::string& key, const LoadParameters& value);
+
+    LoadParameters&
+    SetReader(const std::string& key, ReaderPtr reader);
+
+    [[nodiscard]] bool
+    HasReader(const std::string& key) const;
+
+    [[nodiscard]] ReaderPtr
+    GetReader(const std::string& key) const;
+
+    [[nodiscard]] std::string
+    Dump() const;
+
+private:
+    struct Impl;
+    std::shared_ptr<Impl> impl_;
+};
+
+}  // namespace vsag

--- a/include/vsag/vsag.h
+++ b/include/vsag/vsag.h
@@ -50,6 +50,7 @@ init();
 #include "vsag/index_detail_info.h"
 #include "vsag/index_features.h"
 #include "vsag/iterator_context.h"
+#include "vsag/load_parameters.h"
 #include "vsag/logger.h"
 #include "vsag/options.h"
 #include "vsag/readerset.h"

--- a/src/algorithm/bruteforce/bruteforce.cpp
+++ b/src/algorithm/bruteforce/bruteforce.cpp
@@ -32,13 +32,36 @@
 #include "index_feature_list.h"
 #include "inner_string_params.h"
 #include "storage/serialization.h"
+#include "storage/serialization_tags.h"
+#include "storage/tlv_section.h"
 #include "typing.h"
 #include "utils/slow_task_timer.h"
 #include "utils/util_functions.h"
 namespace vsag {
 
 namespace {
+
 constexpr const char* WARP_MODE_MARKER = "_warp_mode";
+
+void
+require_string_member(const JsonType& json, const std::string& key) {
+    CHECK_ARGUMENT(json[key].IsString(),
+                   fmt::format("BruteForce streaming load parameter '{}' must be a string", key));
+}
+
+void
+require_object_member(const JsonType& json, const std::string& key) {
+    CHECK_ARGUMENT(json[key].IsObject(),
+                   fmt::format("BruteForce streaming load parameter '{}' must be an object", key));
+}
+
+void
+require_bool_or_string_member(const JsonType& json, const std::string& key) {
+    CHECK_ARGUMENT(
+        json[key].IsBool() or json[key].IsString(),
+        fmt::format("BruteForce streaming load parameter '{}' must be a bool or string", key));
+}
+
 }  // namespace
 
 BruteForce::BruteForce(const BruteForceParameterPtr& param, const IndexCommonParam& common_param)
@@ -375,6 +398,8 @@ BruteForce::SearchWithRequest(const SearchRequest& request) const {
         this->create_search_filter(request.filter_, brute_force_params.use_extra_info_filter);
 
     if (request.enable_attribute_filter_) {
+        CHECK_ARGUMENT(this->use_attribute_filter_ && this->attr_filter_index_ != nullptr,
+                       "attribute filter is not available");
         auto& schema = this->attr_filter_index_->field_type_map_;
         auto expr = AstParse(request.attribute_filter_str_, &schema);
         executor = Executor::MakeInstance(this->allocator_, expr, this->attr_filter_index_);
@@ -568,6 +593,294 @@ BruteForce::Serialize(StreamWriter& writer) const {
                                          this->extra_infos_ != nullptr);
     basic_info[INDEX_PARAM].SetString(this->create_param_ptr_->ToString());
     write_index_footer(writer, basic_info);
+}
+
+MetadataPtr
+BruteForce::collect_streaming_header() const {
+    auto metadata = std::make_shared<Metadata>();
+    metadata->Set("format", "vsag_stream_v1");
+    metadata->Set("index_name", this->GetName());
+
+    JsonType basic_info;
+    basic_info["dim"].SetInt(dim_);
+    basic_info["metric"].SetInt(static_cast<int64_t>(metric_));
+    basic_info["data_type"].SetInt(static_cast<int64_t>(data_type_));
+    basic_info["total_count"].SetUint64(total_count_.load());
+    basic_info["is_multi_vector"].SetBool(is_multi_vector_);
+    basic_info[INDEX_PARAM].SetString(this->create_param_ptr_->ToString());
+    metadata->Set("basic_info", basic_info);
+
+    JsonType manifest;
+    auto attribute_filter_tag = static_cast<uint32_t>(StreamSerializationTag::ATTRIBUTE_FILTER);
+    auto base_codes_tag = static_cast<uint32_t>(StreamSerializationTag::BASE_CODES);
+    auto label_table_tag = static_cast<uint32_t>(StreamSerializationTag::LABEL_TABLE);
+    if (this->use_attribute_filter_ && this->attr_filter_index_ != nullptr) {
+        AppendStreamingManifestBlock(manifest,
+                                     attribute_filter_tag,
+                                     StreamSerializationBlockCurrentVersion(attribute_filter_tag),
+                                     StreamSerializationTagCritical(attribute_filter_tag));
+    }
+    AppendStreamingManifestBlock(manifest,
+                                 base_codes_tag,
+                                 StreamSerializationBlockCurrentVersion(base_codes_tag),
+                                 StreamSerializationTagCritical(base_codes_tag));
+    AppendStreamingManifestBlock(manifest,
+                                 label_table_tag,
+                                 StreamSerializationBlockCurrentVersion(label_table_tag),
+                                 StreamSerializationTagCritical(label_table_tag));
+    metadata->Set("block_manifest", manifest);
+    metadata->SetEmptyIndex(this->GetNumElements() == 0);
+    return metadata;
+}
+
+void
+BruteForce::serialize_streaming_body(StreamWriter& writer) const {
+    if (this->use_attribute_filter_ && this->attr_filter_index_ != nullptr) {
+        auto tag = static_cast<uint32_t>(StreamSerializationTag::ATTRIBUTE_FILTER);
+        WriteStreamingBlock(
+            writer, tag, StreamSerializationTagCritical(tag), [this](StreamWriter& block_writer) {
+                this->attr_filter_index_->Serialize(block_writer);
+            });
+    }
+
+    auto base_codes_tag = static_cast<uint32_t>(StreamSerializationTag::BASE_CODES);
+    auto label_table_tag = static_cast<uint32_t>(StreamSerializationTag::LABEL_TABLE);
+    WriteStreamingBlock(
+        writer,
+        base_codes_tag,
+        StreamSerializationTagCritical(base_codes_tag),
+        [this](StreamWriter& block_writer) { this->inner_codes_->Serialize(block_writer); });
+    WriteStreamingBlock(
+        writer,
+        label_table_tag,
+        StreamSerializationTagCritical(label_table_tag),
+        [this](StreamWriter& block_writer) { this->label_table_->Serialize(block_writer); });
+}
+
+void
+BruteForce::deserialize_streaming_body(StreamReader& reader, const MetadataPtr& metadata) {
+    StreamingLoadPlan plan;
+    plan.base_codes = StreamingLoadTarget::MEMORY;
+    plan.precise_codes = StreamingLoadTarget::MEMORY;
+    plan.raw_vector = StreamingLoadTarget::MEMORY;
+    plan.attribute_filter = StreamingLoadTarget::MEMORY;
+    this->read_streaming_body(reader, metadata, plan, true);
+}
+
+void
+BruteForce::load_streaming_body(StreamReader& reader,
+                                const MetadataPtr& metadata,
+                                const LoadParameters& parameters) {
+    auto plan = BruteForce::parse_streaming_load_parameters(parameters);
+    this->read_streaming_body(reader, metadata, plan, false);
+}
+
+BruteForce::StreamingLoadPlan
+BruteForce::parse_streaming_load_parameters(const LoadParameters& parameters) {
+    StreamingLoadPlan plan;
+    auto parameter_string = parameters.Dump();
+    auto json = JsonType::Parse(parameter_string.empty() ? "{}" : parameter_string, false);
+    CHECK_ARGUMENT(not json.IsDiscarded(),
+                   "BruteForce streaming load parameters must be valid JSON");
+    CHECK_ARGUMENT(json.IsObject(), "BruteForce streaming load parameters must be a JSON object");
+    if (json.Contains(BRUTE_FORCE_BASE_IO_TYPE)) {
+        require_string_member(json, BRUTE_FORCE_BASE_IO_TYPE);
+        plan.base_codes = BruteForce::streaming_load_target_from_io_type(
+            json[BRUTE_FORCE_BASE_IO_TYPE].GetString());
+    }
+    if (json.Contains(BRUTE_FORCE_PRECISE_IO_TYPE)) {
+        require_string_member(json, BRUTE_FORCE_PRECISE_IO_TYPE);
+        plan.precise_codes = BruteForce::streaming_load_target_from_io_type(
+            json[BRUTE_FORCE_PRECISE_IO_TYPE].GetString());
+    }
+    if (json.Contains(RAW_VECTOR_IO_TYPE)) {
+        require_string_member(json, RAW_VECTOR_IO_TYPE);
+        plan.raw_vector =
+            BruteForce::streaming_load_target_from_io_type(json[RAW_VECTOR_IO_TYPE].GetString());
+    }
+    if (json.Contains(USE_ATTRIBUTE_FILTER)) {
+        CHECK_ARGUMENT(json[USE_ATTRIBUTE_FILTER].IsBool(),
+                       fmt::format("BruteForce streaming load parameter '{}' must be a bool",
+                                   USE_ATTRIBUTE_FILTER));
+        if (not json[USE_ATTRIBUTE_FILTER].GetBool()) {
+            plan.attribute_filter = StreamingLoadTarget::SKIP;
+        }
+    }
+    if (json.Contains("load")) {
+        require_object_member(json, "load");
+        auto load_json = json["load"];
+        if (load_json.Contains(BASE_CODES_KEY)) {
+            require_string_member(load_json, BASE_CODES_KEY);
+            plan.base_codes = BruteForce::streaming_load_target_from_string(
+                load_json[BASE_CODES_KEY].GetString());
+        }
+        if (load_json.Contains(PRECISE_CODES_KEY)) {
+            require_string_member(load_json, PRECISE_CODES_KEY);
+            plan.precise_codes = BruteForce::streaming_load_target_from_string(
+                load_json[PRECISE_CODES_KEY].GetString());
+        }
+        if (load_json.Contains(RAW_VECTOR_KEY)) {
+            require_string_member(load_json, RAW_VECTOR_KEY);
+            plan.raw_vector = BruteForce::streaming_load_target_from_string(
+                load_json[RAW_VECTOR_KEY].GetString());
+        }
+        if (load_json.Contains(USE_ATTRIBUTE_FILTER_KEY)) {
+            require_bool_or_string_member(load_json, USE_ATTRIBUTE_FILTER_KEY);
+            auto attr_policy = load_json[USE_ATTRIBUTE_FILTER_KEY];
+            if (attr_policy.IsBool()) {
+                plan.attribute_filter =
+                    attr_policy.GetBool() ? StreamingLoadTarget::MEMORY : StreamingLoadTarget::SKIP;
+            } else {
+                plan.attribute_filter =
+                    BruteForce::streaming_load_target_from_string(attr_policy.GetString());
+            }
+        }
+    }
+    return plan;
+}
+
+BruteForce::StreamingLoadTarget
+BruteForce::streaming_load_target_from_io_type(const std::string& io_type) {
+    if (io_type == IO_TYPE_VALUE_READER_IO || io_type == IO_TYPE_VALUE_MMAP_IO ||
+        io_type == IO_TYPE_VALUE_ASYNC_IO) {
+        return StreamingLoadTarget::READER;
+    }
+    if (io_type == IO_TYPE_VALUE_MEMORY_IO || io_type == IO_TYPE_VALUE_BLOCK_MEMORY_IO ||
+        io_type == IO_TYPE_VALUE_BUFFER_IO) {
+        return StreamingLoadTarget::MEMORY;
+    }
+    throw VsagException(ErrorType::INVALID_ARGUMENT,
+                        fmt::format("unsupported BruteForce streaming load io_type: {}", io_type));
+}
+
+BruteForce::StreamingLoadTarget
+BruteForce::streaming_load_target_from_string(const std::string& value) {
+    if (value == "skip") {
+        return StreamingLoadTarget::SKIP;
+    }
+    if (value == "reader") {
+        return StreamingLoadTarget::READER;
+    }
+    if (value == "memory") {
+        return StreamingLoadTarget::MEMORY;
+    }
+    throw VsagException(
+        ErrorType::INVALID_ARGUMENT,
+        fmt::format("unsupported BruteForce streaming load placement policy: {}", value));
+}
+
+void
+BruteForce::read_streaming_body(StreamReader& reader,
+                                const MetadataPtr& metadata,
+                                const StreamingLoadPlan& plan,
+                                bool full_deserialize) {
+    auto basic_info = metadata->Get("basic_info");
+    if (basic_info.Contains(INDEX_PARAM)) {
+        std::string index_param_string = basic_info[INDEX_PARAM].GetString();
+        auto index_param = std::make_shared<BruteForceParameter>();
+        index_param->FromString(index_param_string);
+        if (not this->create_param_ptr_->CheckCompatibility(index_param)) {
+            auto message = fmt::format("BruteForce index parameter not match, current: {}, new: {}",
+                                       this->create_param_ptr_->ToString(),
+                                       index_param->ToString());
+            logger::error(message);
+            throw VsagException(ErrorType::INVALID_ARGUMENT, message);
+        }
+    }
+
+    dim_ = basic_info["dim"].GetInt();
+    total_count_.store(basic_info["total_count"].GetUint64());
+
+    bool loaded_base_codes = false;
+    bool loaded_label_table = false;
+    bool loaded_attribute_filter = false;
+    while (true) {
+        auto block_header = StreamBlockHeader::Read(reader);
+        if (block_header.IsSectionEnd()) {
+            break;
+        }
+        BoundedForwardReader block_reader(&reader, block_header.value_len);
+        if (!StreamSerializationBlockVersionSupported(block_header.tag,
+                                                      block_header.block_version)) {
+            if (block_header.IsCritical()) {
+                throw VsagException(
+                    ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                    fmt::format("unsupported BruteForce streaming block version: tag={}, name={}, "
+                                "version={}, flags={}, value_len={}",
+                                block_header.tag,
+                                StreamSerializationTagName(block_header.tag),
+                                block_header.block_version,
+                                block_header.flags,
+                                block_header.value_len));
+            }
+            block_reader.SkipRemaining();
+            continue;
+        }
+        switch (static_cast<StreamSerializationTag>(block_header.tag)) {
+            case StreamSerializationTag::ATTRIBUTE_FILTER:
+                if ((full_deserialize || plan.attribute_filter == StreamingLoadTarget::MEMORY) &&
+                    this->use_attribute_filter_ && this->attr_filter_index_ != nullptr) {
+                    ReadSeekableBlockPayload(
+                        block_reader, block_header, [this](StreamReader& block) {
+                            this->attr_filter_index_->Deserialize(block);
+                        });
+                    loaded_attribute_filter = true;
+                } else if (plan.attribute_filter == StreamingLoadTarget::READER &&
+                           this->use_attribute_filter_ && this->attr_filter_index_ != nullptr) {
+                    throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                                        "BruteForce attribute filter does not support reader load");
+                }
+                break;
+            case StreamSerializationTag::BASE_CODES:
+                if (!full_deserialize && plan.base_codes != StreamingLoadTarget::MEMORY) {
+                    throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                                        "BruteForce base codes must be loaded into memory");
+                }
+                ReadSeekableBlockPayload(block_reader, block_header, [this](StreamReader& block) {
+                    this->inner_codes_->Deserialize(block);
+                });
+                loaded_base_codes = true;
+                break;
+            case StreamSerializationTag::LABEL_TABLE:
+                ReadSeekableBlockPayload(block_reader, block_header, [this](StreamReader& block) {
+                    this->label_table_->Deserialize(block);
+                });
+                loaded_label_table = true;
+                break;
+            default:
+                if (block_header.IsCritical()) {
+                    throw VsagException(
+                        ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                        fmt::format("unknown streaming serialization block: tag={}, name={}, "
+                                    "version={}, flags={}, value_len={}",
+                                    block_header.tag,
+                                    StreamSerializationTagName(block_header.tag),
+                                    block_header.block_version,
+                                    block_header.flags,
+                                    block_header.value_len));
+                }
+                break;
+        }
+        block_reader.SkipRemaining();
+    }
+
+    if (not loaded_base_codes || not loaded_label_table) {
+        throw VsagException(ErrorType::READ_ERROR,
+                            "BruteForce streaming serialization required block is missing");
+    }
+    if (this->use_attribute_filter_ && this->attr_filter_index_ != nullptr &&
+        (full_deserialize || plan.attribute_filter == StreamingLoadTarget::MEMORY) &&
+        !loaded_attribute_filter) {
+        throw VsagException(ErrorType::READ_ERROR,
+                            "BruteForce streaming serialization attribute filter block is missing");
+    }
+    if (!full_deserialize && plan.attribute_filter == StreamingLoadTarget::SKIP) {
+        this->use_attribute_filter_ = false;
+        this->has_attribute_ = false;
+        this->attr_filter_index_.reset();
+    }
+    delete_count_.store(label_table_->GetAllDeletedIds().size(), std::memory_order_relaxed);
+    this->cal_memory_usage();
 }
 
 void

--- a/src/algorithm/bruteforce/bruteforce.h
+++ b/src/algorithm/bruteforce/bruteforce.h
@@ -139,6 +139,48 @@ public:
     GetMemoryUsage() const override;
 
 private:
+    enum class StreamingLoadTarget {
+        SKIP,
+        MEMORY,
+        READER,
+    };
+
+    struct StreamingLoadPlan {
+        StreamingLoadTarget base_codes{StreamingLoadTarget::MEMORY};
+        StreamingLoadTarget precise_codes{StreamingLoadTarget::READER};
+        StreamingLoadTarget raw_vector{StreamingLoadTarget::SKIP};
+        StreamingLoadTarget attribute_filter{StreamingLoadTarget::MEMORY};
+    };
+
+    MetadataPtr
+    collect_streaming_header() const override;
+
+    void
+    serialize_streaming_body(StreamWriter& writer) const override;
+
+    void
+    deserialize_streaming_body(StreamReader& reader, const MetadataPtr& metadata) override;
+
+    void
+    load_streaming_body(StreamReader& reader,
+                        const MetadataPtr& metadata,
+                        const LoadParameters& parameters) override;
+
+    static StreamingLoadPlan
+    parse_streaming_load_parameters(const LoadParameters& parameters);
+
+    static StreamingLoadTarget
+    streaming_load_target_from_io_type(const std::string& io_type);
+
+    static StreamingLoadTarget
+    streaming_load_target_from_string(const std::string& value);
+
+    void
+    read_streaming_body(StreamReader& reader,
+                        const MetadataPtr& metadata,
+                        const StreamingLoadPlan& plan,
+                        bool full_deserialize);
+
     /**
      * @brief Grow the capacity of inner_codes_ to at least new_size slots.
      *

--- a/src/algorithm/hgraph/hgraph.cpp
+++ b/src/algorithm/hgraph/hgraph.cpp
@@ -473,6 +473,13 @@ HGraph::SetIO(const std::shared_ptr<Reader> reader) {
     bottom_graph_->InitIO(reader_param);
 }
 
+void
+HGraph::SetPreciseCodesIO(const std::shared_ptr<Reader>& reader) {
+    auto reader_param = std::make_shared<ReaderIOParameter>();
+    reader_param->reader = reader;
+    high_precise_codes_->InitIO(reader_param);
+}
+
 const static uint64_t QUERY_SAMPLE_SIZE = 10;
 const static int64_t DEFAULT_TOPK = 100;
 

--- a/src/algorithm/hgraph/hgraph.h
+++ b/src/algorithm/hgraph/hgraph.h
@@ -209,6 +209,9 @@ public:
     SetIO(const std::shared_ptr<Reader> reader) override;
 
     void
+    SetPreciseCodesIO(const std::shared_ptr<Reader>& reader);
+
+    void
     Train(const DatasetPtr& base) override;
 
     bool
@@ -342,6 +345,28 @@ public:
                      DistanceRecordVector* rabitq_lower_bound_candidates = nullptr) const;
 
 private:
+    MetadataPtr
+    collect_streaming_header() const override;
+
+    void
+    serialize_streaming_body(StreamWriter& writer) const override;
+
+    void
+    deserialize_streaming_body(StreamReader& reader, const MetadataPtr& metadata) override;
+
+    void
+    load_streaming_body(StreamReader& reader,
+                        const MetadataPtr& metadata,
+                        const LoadParameters& parameters) override;
+
+    void
+    read_streaming_body(StreamReader& reader,
+                        const MetadataPtr& metadata,
+                        const LoadParameters* load_parameters = nullptr);
+
+    void
+    deserialize_label_info_streaming(StreamReader& reader) const;
+
     // since v0.15: serialize basic index metadata to JSON.
     JsonType
     serialize_basic_info() const;

--- a/src/algorithm/hgraph/hgraph_serialize.cpp
+++ b/src/algorithm/hgraph/hgraph_serialize.cpp
@@ -14,6 +14,8 @@
 
 #include <fmt/format.h>
 
+#include <algorithm>
+#include <array>
 #include <limits>
 
 #include "datacell/sparse_graph_datacell.h"
@@ -22,12 +24,109 @@
 #include "impl/odescent/odescent_graph_builder.h"
 #include "impl/pruning_strategy.h"
 #include "storage/serialization.h"
+#include "storage/serialization_tags.h"
 #include "storage/stream_reader.h"
+#include "storage/tlv_section.h"
 #include "typing.h"
 #include "utils/util_functions.h"
 #include "vsag/options.h"
 
 namespace vsag {
+
+namespace {
+
+std::string
+dump_basic_info_for_log(const JsonType& basic_info) {
+    JsonType log_basic_info = basic_info;
+    if (log_basic_info.Contains(INDEX_PARAM) and log_basic_info[INDEX_PARAM].IsString()) {
+        auto index_param = JsonType::Parse(log_basic_info[INDEX_PARAM].GetString(), false);
+        if (not index_param.IsDiscarded() and index_param.IsObject()) {
+            log_basic_info[INDEX_PARAM].SetJson(index_param);
+        }
+    }
+    return log_basic_info.Dump(4);
+}
+
+class PayloadChecksumStreamReader : public StreamReader {
+public:
+    PayloadChecksumStreamReader(StreamReader& reader, const StreamBlockHeader& header)
+        : StreamReader(header.value_len),
+          reader_(reader),
+          expected_checksum_(header.payload_checksum) {
+    }
+
+    void
+    Read(char* data, uint64_t size) override {
+        const auto cursor = reader_.GetCursor();
+        if (cursor > length_ || size > length_ - cursor) {
+            throw VsagException(ErrorType::READ_ERROR,
+                                "checksum stream reader exceeds payload boundary");
+        }
+        if (cursor > checksum_cursor_) {
+            checksum_range(checksum_cursor_, cursor - checksum_cursor_);
+        }
+
+        reader_.Read(data, size);
+        if (cursor + size > checksum_cursor_) {
+            const auto checksum_offset = checksum_cursor_ > cursor ? checksum_cursor_ - cursor : 0;
+            const auto checksum_size = size - checksum_offset;
+            crc_ = StreamHeader::UpdateChecksum(
+                crc_, std::string_view(data + checksum_offset, checksum_size));
+            checksum_cursor_ += checksum_size;
+        }
+    }
+
+    void
+    Seek(uint64_t cursor) override {
+        if (cursor > length_) {
+            throw VsagException(ErrorType::READ_ERROR,
+                                "checksum stream reader seek exceeds payload boundary");
+        }
+        reader_.Seek(cursor);
+    }
+
+    [[nodiscard]] uint64_t
+    GetCursor() const override {
+        return reader_.GetCursor();
+    }
+
+    void
+    Validate() {
+        if (checksum_cursor_ < length_) {
+            checksum_range(checksum_cursor_, length_ - checksum_cursor_);
+        }
+        if (StreamHeader::FinalizeChecksum(crc_) != expected_checksum_) {
+            throw VsagException(ErrorType::INVALID_BINARY,
+                                "streaming block payload checksum mismatch");
+        }
+    }
+
+private:
+    void
+    checksum_range(uint64_t offset, uint64_t size) {
+        constexpr uint64_t kBufferSize = 8192;
+        std::array<char, kBufferSize> buffer{};
+        const auto original_cursor = reader_.GetCursor();
+        reader_.Seek(offset);
+        uint64_t remaining = size;
+        while (remaining > 0) {
+            const auto read_size = std::min<uint64_t>(remaining, kBufferSize);
+            reader_.Read(buffer.data(), read_size);
+            crc_ = StreamHeader::UpdateChecksum(crc_, std::string_view(buffer.data(), read_size));
+            remaining -= read_size;
+        }
+        checksum_cursor_ += size;
+        reader_.Seek(original_cursor);
+    }
+
+private:
+    StreamReader& reader_;
+    uint32_t expected_checksum_{0};
+    uint32_t crc_{StreamHeader::InitialChecksum()};
+    uint64_t checksum_cursor_{0};
+};
+
+}  // namespace
 
 void
 HGraph::serialize_basic_info_v0_14(StreamWriter& writer) const {
@@ -118,7 +217,7 @@ HGraph::serialize_basic_info() const {
 
 void
 HGraph::deserialize_basic_info(const JsonType& jsonify_basic_info) {
-    logger::debug("jsonify_basic_info: {}", jsonify_basic_info.Dump());
+    logger::debug("jsonify_basic_info:\n{}", dump_basic_info_for_log(jsonify_basic_info));
     FROM_JSON(jsonify_basic_info, use_reorder, Bool);
     this->reorder_by_base_ = false;
     FROM_JSON(jsonify_basic_info, reorder_by_base, Bool);
@@ -306,6 +405,361 @@ HGraph::Serialize(StreamWriter& writer) const {
 
     auto footer = std::make_shared<Footer>(metadata);
     footer->Write(writer);
+}
+
+MetadataPtr
+HGraph::collect_streaming_header() const {
+    auto metadata = std::make_shared<Metadata>();
+    metadata->Set("format", "vsag_stream_v1");
+    metadata->Set("index_name", this->GetName());
+
+    auto jsonify_basic_info = this->serialize_basic_info();
+    const bool include_precise_codes = this->has_precise_reorder() && !this->ignore_reorder_;
+    if (this->ignore_reorder_) {
+        jsonify_basic_info["use_reorder"].SetBool(false);
+    }
+    metadata->Set(BASIC_INFO, jsonify_basic_info);
+    if (this->support_duplicate_) {
+        metadata->Set("duplicate_format_version", 1);
+    }
+
+    JsonType manifest;
+    auto append_manifest = [&manifest](uint32_t tag, bool critical) {
+        AppendStreamingManifestBlock(
+            manifest, tag, StreamSerializationBlockCurrentVersion(tag), critical);
+    };
+    auto label_table_tag = static_cast<uint32_t>(StreamSerializationTag::LABEL_TABLE);
+    auto base_codes_tag = static_cast<uint32_t>(StreamSerializationTag::BASE_CODES);
+    auto bottom_graph_tag = static_cast<uint32_t>(StreamSerializationTag::BOTTOM_GRAPH);
+    auto route_graphs_tag = static_cast<uint32_t>(StreamSerializationTag::ROUTE_GRAPHS);
+    append_manifest(label_table_tag, StreamSerializationTagCritical(label_table_tag));
+    append_manifest(base_codes_tag, StreamSerializationTagCritical(base_codes_tag));
+    append_manifest(bottom_graph_tag, StreamSerializationTagCritical(bottom_graph_tag));
+    if (include_precise_codes) {
+        auto tag = static_cast<uint32_t>(StreamSerializationTag::HIGH_PRECISION_CODES);
+        append_manifest(tag, StreamSerializationTagCritical(tag));
+    }
+    append_manifest(route_graphs_tag, StreamSerializationTagCritical(route_graphs_tag));
+    if (this->extra_info_size_ > 0 && this->extra_infos_ != nullptr) {
+        auto tag = static_cast<uint32_t>(StreamSerializationTag::EXTRA_INFO);
+        append_manifest(tag, StreamSerializationTagCritical(tag));
+    }
+    if (this->use_attribute_filter_ && this->attr_filter_index_ != nullptr) {
+        auto tag = static_cast<uint32_t>(StreamSerializationTag::ATTRIBUTE_FILTER);
+        append_manifest(tag, StreamSerializationTagCritical(tag));
+    }
+    if (create_new_raw_vector_) {
+        auto tag = static_cast<uint32_t>(StreamSerializationTag::RAW_VECTOR);
+        append_manifest(tag, StreamSerializationTagCritical(tag));
+    }
+    metadata->Set("block_manifest", manifest);
+    metadata->SetEmptyIndex(this->GetNumElements() == 0);
+    return metadata;
+}
+
+void
+HGraph::serialize_streaming_body(StreamWriter& writer) const {
+    const bool include_precise_codes = this->has_precise_reorder() && !this->ignore_reorder_;
+
+    auto label_table_tag = static_cast<uint32_t>(StreamSerializationTag::LABEL_TABLE);
+    auto base_codes_tag = static_cast<uint32_t>(StreamSerializationTag::BASE_CODES);
+    auto bottom_graph_tag = static_cast<uint32_t>(StreamSerializationTag::BOTTOM_GRAPH);
+    auto route_graphs_tag = static_cast<uint32_t>(StreamSerializationTag::ROUTE_GRAPHS);
+
+    WriteStreamingBlock(
+        writer,
+        label_table_tag,
+        StreamSerializationTagCritical(label_table_tag),
+        [this](StreamWriter& block_writer) { this->serialize_label_info(block_writer); });
+    WriteStreamingBlock(writer,
+                        base_codes_tag,
+                        StreamSerializationTagCritical(base_codes_tag),
+                        [this](StreamWriter& block_writer) {
+                            this->basic_flatten_codes_->Serialize(block_writer);
+                        });
+    WriteStreamingBlock(
+        writer,
+        bottom_graph_tag,
+        StreamSerializationTagCritical(bottom_graph_tag),
+        [this](StreamWriter& block_writer) { this->bottom_graph_->Serialize(block_writer); });
+    if (include_precise_codes) {
+        auto tag = static_cast<uint32_t>(StreamSerializationTag::HIGH_PRECISION_CODES);
+        WriteStreamingBlock(
+            writer, tag, StreamSerializationTagCritical(tag), [this](StreamWriter& block_writer) {
+                this->high_precise_codes_->Serialize(block_writer);
+            });
+    }
+    WriteStreamingBlock(writer,
+                        route_graphs_tag,
+                        StreamSerializationTagCritical(route_graphs_tag),
+                        [this](StreamWriter& block_writer) {
+                            for (const auto& route_graph : this->route_graphs_) {
+                                route_graph->Serialize(block_writer);
+                            }
+                        });
+    if (this->extra_info_size_ > 0 && this->extra_infos_ != nullptr) {
+        auto tag = static_cast<uint32_t>(StreamSerializationTag::EXTRA_INFO);
+        WriteStreamingBlock(
+            writer, tag, StreamSerializationTagCritical(tag), [this](StreamWriter& block_writer) {
+                this->extra_infos_->Serialize(block_writer);
+            });
+    }
+    if (this->use_attribute_filter_ && this->attr_filter_index_ != nullptr) {
+        auto tag = static_cast<uint32_t>(StreamSerializationTag::ATTRIBUTE_FILTER);
+        WriteStreamingBlock(
+            writer, tag, StreamSerializationTagCritical(tag), [this](StreamWriter& block_writer) {
+                this->attr_filter_index_->Serialize(block_writer);
+            });
+    }
+    if (create_new_raw_vector_) {
+        auto tag = static_cast<uint32_t>(StreamSerializationTag::RAW_VECTOR);
+        WriteStreamingBlock(
+            writer, tag, StreamSerializationTagCritical(tag), [this](StreamWriter& block_writer) {
+                this->raw_vector_->Serialize(block_writer);
+            });
+    }
+}
+
+void
+HGraph::deserialize_label_info_streaming(StreamReader& reader) const {
+    if (this->support_duplicate_) {
+        this->label_table_->Deserialize(reader);
+    } else {
+        StreamReader::ReadVector(reader, this->label_table_->label_table_);
+        uint64_t size;
+        StreamReader::ReadObj(reader, size);
+        this->label_table_->ResetRemap(size);
+        for (uint64_t i = 0; i < size; ++i) {
+            LabelType key;
+            StreamReader::ReadObj(reader, key);
+            InnerIdType value;
+            StreamReader::ReadObj(reader, value);
+            this->label_table_->InsertRemap(key, value);
+        }
+        this->label_table_->total_count_.store(static_cast<int64_t>(size));
+    }
+
+    if (this->persist_source_id_) {
+        uint64_t magic = 0;
+        StreamReader::ReadObj(reader, magic);
+        if (magic != SOURCE_ID_TABLE_MAGIC) {
+            throw VsagException(ErrorType::READ_ERROR, "missing HGraph source_id_table marker");
+        }
+        uint64_t sid_count = 0;
+        StreamReader::ReadObj(reader, sid_count);
+        const uint64_t label_table_size = this->label_table_->label_table_.size();
+        if (sid_count > label_table_size) {
+            throw VsagException(ErrorType::INVALID_ARGUMENT,
+                                fmt::format("corrupted index: source_id_table sid_count ({}) "
+                                            "exceeds label_table size ({})",
+                                            sid_count,
+                                            label_table_size));
+        }
+        Vector<std::string> sid_table(sid_count, std::string{}, allocator_);
+        for (uint64_t i = 0; i < sid_count; ++i) {
+            sid_table[i] = StreamReader::ReadString(reader);
+        }
+        this->label_table_->ReplaceSourceIdTable(std::move(sid_table));
+    }
+}
+
+void
+HGraph::deserialize_streaming_body(StreamReader& reader, const MetadataPtr& metadata) {
+    this->read_streaming_body(reader, metadata);
+}
+
+void
+HGraph::load_streaming_body(StreamReader& reader,
+                            const MetadataPtr& metadata,
+                            const LoadParameters& parameters) {
+    this->read_streaming_body(reader, metadata, &parameters);
+}
+
+void
+HGraph::read_streaming_body(StreamReader& reader,
+                            const MetadataPtr& metadata,
+                            const LoadParameters* load_parameters) {
+    auto basic_info = metadata->Get(BASIC_INFO);
+    this->deserialize_basic_info(basic_info);
+
+    int64_t dup_version = 0;
+    if (metadata->Get("duplicate_format_version").IsNumberInteger()) {
+        dup_version = metadata->Get("duplicate_format_version").GetInt();
+    }
+    this->label_table_->is_legacy_duplicate_format_ = (dup_version == 0);
+
+    bool loaded_label_table = false;
+    bool loaded_base_codes = false;
+    bool loaded_bottom_graph = false;
+    bool loaded_high_precision_codes = false;
+    bool loaded_route_graphs = false;
+    bool loaded_extra_info = false;
+    bool loaded_attribute_filter = false;
+    bool loaded_raw_vector = false;
+
+    while (true) {
+        auto block_header = StreamBlockHeader::Read(reader);
+        if (block_header.IsSectionEnd()) {
+            break;
+        }
+        BoundedForwardReader block_reader(&reader, block_header.value_len);
+        if (!StreamSerializationBlockVersionSupported(block_header.tag,
+                                                      block_header.block_version)) {
+            if (block_header.IsCritical()) {
+                throw VsagException(
+                    ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                    fmt::format("unsupported HGraph streaming block version: tag={}, name={}, "
+                                "version={}, flags={}, value_len={}",
+                                block_header.tag,
+                                StreamSerializationTagName(block_header.tag),
+                                block_header.block_version,
+                                block_header.flags,
+                                block_header.value_len));
+            }
+            block_reader.SkipRemaining();
+            continue;
+        }
+
+        switch (static_cast<StreamSerializationTag>(block_header.tag)) {
+            case StreamSerializationTag::LABEL_TABLE:
+                ReadSeekableBlockPayload(block_reader, block_header, [this](StreamReader& block) {
+                    this->deserialize_label_info_streaming(block);
+                });
+                loaded_label_table = true;
+                break;
+            case StreamSerializationTag::BASE_CODES:
+                ReadSeekableBlockPayload(block_reader, block_header, [this](StreamReader& block) {
+                    this->basic_flatten_codes_->Deserialize(block);
+                });
+                loaded_base_codes = true;
+                break;
+            case StreamSerializationTag::BOTTOM_GRAPH:
+                ReadSeekableBlockPayload(block_reader, block_header, [this](StreamReader& block) {
+                    this->bottom_graph_->Deserialize(block);
+                });
+                loaded_bottom_graph = true;
+                break;
+            case StreamSerializationTag::HIGH_PRECISION_CODES:
+                if (this->has_precise_reorder()) {
+                    constexpr const char* kPreciseReader = "precise_reader";
+                    if (load_parameters != nullptr && load_parameters->HasReader(kPreciseReader)) {
+                        auto reader_ptr = load_parameters->GetReader(kPreciseReader);
+                        if (reader_ptr == nullptr) {
+                            throw VsagException(ErrorType::INVALID_ARGUMENT,
+                                                "precise_reader is null");
+                        }
+                        if (reader_ptr->Size() != block_header.value_len) {
+                            throw VsagException(
+                                ErrorType::INVALID_ARGUMENT,
+                                fmt::format("precise_reader size {} does not match streaming block "
+                                            "payload size {}",
+                                            reader_ptr->Size(),
+                                            block_header.value_len));
+                        }
+                        auto read_func = [reader_ptr](uint64_t offset, uint64_t len, void* dest) {
+                            reader_ptr->Read(offset, len, dest);
+                        };
+                        block_reader.SkipRemaining();
+                        this->SetPreciseCodesIO(reader_ptr);
+                        ReadFuncStreamReader external_reader(read_func, 0, reader_ptr->Size());
+                        PayloadChecksumStreamReader checksum_reader(external_reader, block_header);
+                        this->high_precise_codes_->Deserialize(checksum_reader);
+                        checksum_reader.Validate();
+                    } else {
+                        ReadSeekableBlockPayload(
+                            block_reader, block_header, [this](StreamReader& block) {
+                                this->high_precise_codes_->Deserialize(block);
+                            });
+                    }
+                    loaded_high_precision_codes = true;
+                }
+                break;
+            case StreamSerializationTag::ROUTE_GRAPHS:
+                ReadSeekableBlockPayload(block_reader, block_header, [this](StreamReader& block) {
+                    for (auto& route_graph : this->route_graphs_) {
+                        route_graph->Deserialize(block);
+                    }
+                });
+                loaded_route_graphs = true;
+                break;
+            case StreamSerializationTag::EXTRA_INFO:
+                if (this->extra_info_size_ > 0 && this->extra_infos_ != nullptr) {
+                    ReadSeekableBlockPayload(
+                        block_reader, block_header, [this](StreamReader& block) {
+                            this->extra_infos_->Deserialize(block);
+                        });
+                    loaded_extra_info = true;
+                }
+                break;
+            case StreamSerializationTag::ATTRIBUTE_FILTER:
+                if (this->use_attribute_filter_ && this->attr_filter_index_ != nullptr) {
+                    ReadSeekableBlockPayload(
+                        block_reader, block_header, [this](StreamReader& block) {
+                            this->attr_filter_index_->Deserialize(block);
+                        });
+                    loaded_attribute_filter = true;
+                }
+                break;
+            case StreamSerializationTag::RAW_VECTOR:
+                if (create_new_raw_vector_) {
+                    ReadSeekableBlockPayload(
+                        block_reader, block_header, [this](StreamReader& block) {
+                            this->raw_vector_->Deserialize(block);
+                        });
+                    loaded_raw_vector = true;
+                }
+                break;
+            default:
+                if (block_header.IsCritical()) {
+                    throw VsagException(
+                        ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                        fmt::format("unknown HGraph streaming serialization block: tag={}, "
+                                    "name={}, version={}, flags={}, value_len={}",
+                                    block_header.tag,
+                                    StreamSerializationTagName(block_header.tag),
+                                    block_header.block_version,
+                                    block_header.flags,
+                                    block_header.value_len));
+                }
+                break;
+        }
+        block_reader.SkipRemaining();
+    }
+
+    if (!loaded_label_table || !loaded_base_codes || !loaded_bottom_graph || !loaded_route_graphs) {
+        throw VsagException(ErrorType::READ_ERROR,
+                            "HGraph streaming serialization required block is missing");
+    }
+    if (this->has_precise_reorder() && !loaded_high_precision_codes) {
+        throw VsagException(ErrorType::READ_ERROR,
+                            "HGraph streaming serialization high precision block is missing");
+    }
+    if (this->extra_info_size_ > 0 && this->extra_infos_ != nullptr && !loaded_extra_info) {
+        throw VsagException(ErrorType::READ_ERROR,
+                            "HGraph streaming serialization extra info block is missing");
+    }
+    if (this->use_attribute_filter_ && this->attr_filter_index_ != nullptr &&
+        !loaded_attribute_filter) {
+        throw VsagException(ErrorType::READ_ERROR,
+                            "HGraph streaming serialization attribute filter block is missing");
+    }
+    if (create_new_raw_vector_ && !loaded_raw_vector) {
+        throw VsagException(ErrorType::READ_ERROR,
+                            "HGraph streaming serialization raw vector block is missing");
+    }
+
+    auto new_size = max_capacity_.load();
+    this->neighbors_mutex_->Resize(new_size);
+    pool_ = std::make_shared<VisitedListPool>(1, allocator_, new_size, allocator_);
+    this->total_count_ = this->basic_flatten_codes_->TotalCount();
+    if (this->raw_vector_ != nullptr) {
+        this->has_raw_vector_ = true;
+    }
+    this->cal_memory_usage();
+
+    if (use_elp_optimizer_) {
+        elp_optimize();
+    }
 }
 
 void

--- a/src/algorithm/inner_index_interface.cpp
+++ b/src/algorithm/inner_index_interface.cpp
@@ -32,11 +32,25 @@
 #include "index_feature_list.h"
 #include "storage/empty_index_binary_set.h"
 #include "storage/serialization.h"
+#include "storage/tlv_section.h"
 #include "utils/slow_task_timer.h"
 #include "utils/util_functions.h"
 #include "vsag/allocator.h"
 
 namespace vsag {
+
+namespace {
+
+void
+read_streaming_section_end(StreamReader& reader) {
+    auto block_header = StreamBlockHeader::Read(reader);
+    if (!block_header.IsSectionEnd()) {
+        throw VsagException(ErrorType::INVALID_BINARY,
+                            "streaming serialization empty index missing section end");
+    }
+}
+
+}  // namespace
 
 InnerIndexInterface::InnerIndexInterface(const InnerIndexParameterPtr& index_param,
                                          const IndexCommonParam& common_param)
@@ -309,6 +323,20 @@ InnerIndexInterface::Serialize(std::ostream& out_stream) const {
 }
 
 void
+InnerIndexInterface::SerializeStreaming(std::ostream& out_stream) const {
+    std::string time_record_name = this->GetName() + " Streaming Serialize";
+    SlowTaskTimer t(time_record_name);
+
+    IOStreamWriter writer(out_stream);
+    auto metadata = this->collect_streaming_header();
+    StreamHeader::Write(writer, metadata);
+    if (!metadata->EmptyIndex()) {
+        this->serialize_streaming_body(writer);
+    }
+    StreamBlockHeader::WriteSectionEnd(writer);
+}
+
+void
 InnerIndexInterface::Deserialize(std::istream& in_stream) {
     std::string time_record_name = this->GetName() + " Deserialize";
     SlowTaskTimer t(time_record_name);
@@ -327,6 +355,73 @@ InnerIndexInterface::Deserialize(std::istream& in_stream) {
     } catch (const std::bad_alloc& e) {
         throw VsagException(ErrorType::NO_ENOUGH_MEMORY, "failed to Deserialize: ", e.what());
     }
+}
+
+void
+InnerIndexInterface::DeserializeStreaming(std::istream& in_stream) {
+    std::string time_record_name = this->GetName() + " Streaming Deserialize";
+    SlowTaskTimer t(time_record_name);
+    try {
+        ForwardStreamReader reader(in_stream);
+        auto metadata = StreamHeader::Read(reader);
+        if (metadata->EmptyIndex()) {
+            read_streaming_section_end(reader);
+            return;
+        }
+        this->deserialize_streaming_body(reader, metadata);
+    } catch (const std::bad_alloc& e) {
+        throw VsagException(
+            ErrorType::NO_ENOUGH_MEMORY, "failed to streaming deserialize: ", e.what());
+    }
+}
+
+void
+InnerIndexInterface::LoadStreamingBody(StreamReader& reader,
+                                       const MetadataPtr& metadata,
+                                       const LoadParameters& parameters) {
+    std::string time_record_name = this->GetName() + " Streaming Load";
+    SlowTaskTimer t(time_record_name);
+    try {
+        if (metadata->EmptyIndex()) {
+            read_streaming_section_end(reader);
+            return;
+        }
+        this->load_streaming_body(reader, metadata, parameters);
+    } catch (const std::bad_alloc& e) {
+        throw VsagException(ErrorType::NO_ENOUGH_MEMORY, "failed to streaming load: ", e.what());
+    }
+}
+
+MetadataPtr
+InnerIndexInterface::collect_streaming_header() const {
+    throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                        "Index doesn't support collecting streaming serialization header");
+}
+
+void
+InnerIndexInterface::serialize_streaming_body(StreamWriter& writer) const {
+    (void)writer;
+    throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                        "Index doesn't support streaming serialization body");
+}
+
+void
+InnerIndexInterface::deserialize_streaming_body(StreamReader& reader, const MetadataPtr& metadata) {
+    (void)reader;
+    (void)metadata;
+    throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                        "Index doesn't support streaming deserialization body");
+}
+
+void
+InnerIndexInterface::load_streaming_body(StreamReader& reader,
+                                         const MetadataPtr& metadata,
+                                         const LoadParameters& parameters) {
+    (void)reader;
+    (void)metadata;
+    (void)parameters;
+    throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                        "Index doesn't support streaming load body");
 }
 
 uint64_t

--- a/src/algorithm/inner_index_interface.h
+++ b/src/algorithm/inner_index_interface.h
@@ -31,6 +31,7 @@
 #include "json_types.h"
 #include "metric_type.h"
 #include "parameter.h"
+#include "storage/serialization.h"
 #include "storage/stream_reader.h"
 #include "storage/stream_writer.h"
 #include "type_helpers.h"
@@ -197,6 +198,14 @@ public:
 
     virtual void
     Deserialize(std::istream& in_stream);
+
+    virtual void
+    DeserializeStreaming(std::istream& in_stream);
+
+    virtual void
+    LoadStreamingBody(StreamReader& reader,
+                      const MetadataPtr& metadata,
+                      const LoadParameters& parameters);
 
     virtual void
     Deserialize(StreamReader& reader) = 0;
@@ -436,6 +445,9 @@ public:
     Serialize(std::ostream& out_stream) const;
 
     virtual void
+    SerializeStreaming(std::ostream& out_stream) const;
+
+    virtual void
     Serialize(const WriteFuncType& write_func) const;
 
     virtual void
@@ -494,6 +506,20 @@ public:
     }
 
 protected:
+    virtual MetadataPtr
+    collect_streaming_header() const;
+
+    virtual void
+    serialize_streaming_body(StreamWriter& writer) const;
+
+    virtual void
+    deserialize_streaming_body(StreamReader& reader, const MetadataPtr& metadata);
+
+    virtual void
+    load_streaming_body(StreamReader& reader,
+                        const MetadataPtr& metadata,
+                        const LoadParameters& parameters);
+
     void
     analyze_quantizer(JsonType& stats,
                       const float* data,

--- a/src/algorithm/ivf/ivf.cpp
+++ b/src/algorithm/ivf/ivf.cpp
@@ -35,12 +35,15 @@
 #include "ivf_nearest_partition.h"
 #include "query_context.h"
 #include "storage/serialization.h"
+#include "storage/serialization_tags.h"
 #include "storage/stream_reader.h"
 #include "storage/stream_writer.h"
+#include "storage/tlv_section.h"
 #include "utils/util_functions.h"
 #include "vsag_exception.h"
 
 namespace vsag {
+
 static constexpr const char* IVF_PARAMS_TEMPLATE =
     R"(
     {
@@ -636,6 +639,225 @@ IVF::Serialize(StreamWriter& writer) const {
 
     auto footer = std::make_shared<Footer>(metadata);
     footer->Write(writer);
+}
+
+MetadataPtr
+IVF::collect_streaming_header() const {
+    auto metadata = std::make_shared<Metadata>();
+    metadata->Set("format", "vsag_stream_v1");
+    metadata->Set("index_name", this->GetName());
+
+    JsonType basic_info;
+    basic_info["total_elements"].SetInt(this->total_elements_);
+    basic_info["use_reorder"].SetBool(this->use_reorder_);
+    basic_info["is_trained"].SetBool(this->is_trained_);
+    basic_info[DIM].SetInt(this->dim_);
+    basic_info[EXTRA_INFO_SIZE].SetInt(0);
+    basic_info[INDEX_PARAM].SetString(this->create_param_ptr_->ToString());
+    basic_info["data_type"].SetInt(static_cast<int64_t>(this->data_type_));
+    basic_info["metric"].SetInt(static_cast<int64_t>(this->metric_));
+    metadata->Set(BASIC_INFO, basic_info);
+
+    JsonType manifest;
+    auto bucket_tag = static_cast<uint32_t>(StreamSerializationTag::IVF_BUCKET);
+    auto partition_tag = static_cast<uint32_t>(StreamSerializationTag::IVF_PARTITION_STRATEGY);
+    auto label_tag = static_cast<uint32_t>(StreamSerializationTag::LABEL_TABLE);
+    AppendStreamingManifestBlock(manifest,
+                                 bucket_tag,
+                                 StreamSerializationBlockCurrentVersion(bucket_tag),
+                                 StreamSerializationTagCritical(bucket_tag));
+    AppendStreamingManifestBlock(manifest,
+                                 partition_tag,
+                                 StreamSerializationBlockCurrentVersion(partition_tag),
+                                 StreamSerializationTagCritical(partition_tag));
+    AppendStreamingManifestBlock(manifest,
+                                 label_tag,
+                                 StreamSerializationBlockCurrentVersion(label_tag),
+                                 StreamSerializationTagCritical(label_tag));
+    if (this->use_reorder_) {
+        auto tag = static_cast<uint32_t>(StreamSerializationTag::HIGH_PRECISION_CODES);
+        AppendStreamingManifestBlock(manifest,
+                                     tag,
+                                     StreamSerializationBlockCurrentVersion(tag),
+                                     StreamSerializationTagCritical(tag));
+    }
+    if (this->use_attribute_filter_) {
+        auto tag = static_cast<uint32_t>(StreamSerializationTag::ATTRIBUTE_FILTER);
+        AppendStreamingManifestBlock(manifest,
+                                     tag,
+                                     StreamSerializationBlockCurrentVersion(tag),
+                                     StreamSerializationTagCritical(tag));
+    }
+    metadata->Set("block_manifest", manifest);
+    metadata->SetEmptyIndex(this->GetNumElements() == 0);
+    return metadata;
+}
+
+void
+IVF::serialize_streaming_body(StreamWriter& writer) const {
+    auto bucket_tag = static_cast<uint32_t>(StreamSerializationTag::IVF_BUCKET);
+    auto partition_tag = static_cast<uint32_t>(StreamSerializationTag::IVF_PARTITION_STRATEGY);
+    auto label_tag = static_cast<uint32_t>(StreamSerializationTag::LABEL_TABLE);
+
+    WriteStreamingBlock(
+        writer, bucket_tag, StreamSerializationTagCritical(bucket_tag), [this](StreamWriter& w) {
+            this->bucket_->Serialize(w);
+        });
+    WriteStreamingBlock(writer,
+                        partition_tag,
+                        StreamSerializationTagCritical(partition_tag),
+                        [this](StreamWriter& w) { this->partition_strategy_->Serialize(w); });
+    WriteStreamingBlock(
+        writer, label_tag, StreamSerializationTagCritical(label_tag), [this](StreamWriter& w) {
+            this->label_table_->Serialize(w);
+        });
+    if (this->use_reorder_) {
+        auto tag = static_cast<uint32_t>(StreamSerializationTag::HIGH_PRECISION_CODES);
+        WriteStreamingBlock(
+            writer, tag, StreamSerializationTagCritical(tag), [this](StreamWriter& w) {
+                this->reorder_codes_->Serialize(w);
+            });
+    }
+    if (this->use_attribute_filter_) {
+        auto tag = static_cast<uint32_t>(StreamSerializationTag::ATTRIBUTE_FILTER);
+        WriteStreamingBlock(
+            writer, tag, StreamSerializationTagCritical(tag), [this](StreamWriter& w) {
+                this->attr_filter_index_->Serialize(w);
+            });
+    }
+}
+
+void
+IVF::deserialize_streaming_body(StreamReader& reader, const MetadataPtr& metadata) {
+    this->read_streaming_body(reader, metadata);
+}
+
+void
+IVF::load_streaming_body(StreamReader& reader,
+                         const MetadataPtr& metadata,
+                         const LoadParameters& parameters) {
+    (void)parameters;
+    this->read_streaming_body(reader, metadata);
+}
+
+void
+IVF::read_streaming_body(StreamReader& reader, const MetadataPtr& metadata) {
+    auto basic_info = metadata->Get(BASIC_INFO);
+    this->total_elements_ = basic_info["total_elements"].GetInt();
+    this->use_reorder_ = basic_info["use_reorder"].GetBool();
+    this->is_trained_ = basic_info["is_trained"].GetBool();
+    if (basic_info.Contains(INDEX_PARAM)) {
+        auto index_param = std::make_shared<IVFParameter>();
+        index_param->FromString(basic_info[INDEX_PARAM].GetString());
+        if (not this->create_param_ptr_->CheckCompatibility(index_param)) {
+            auto message = fmt::format("IVF index parameter not match, current: {}, new: {}",
+                                       this->create_param_ptr_->ToString(),
+                                       index_param->ToString());
+            logger::error(message);
+            throw VsagException(ErrorType::INVALID_ARGUMENT, message);
+        }
+    }
+
+    bool loaded_bucket = false;
+    bool loaded_partition = false;
+    bool loaded_label_table = false;
+    bool loaded_reorder_codes = false;
+    bool loaded_attribute_filter = false;
+
+    while (true) {
+        auto block_header = StreamBlockHeader::Read(reader);
+        if (block_header.IsSectionEnd()) {
+            break;
+        }
+        BoundedForwardReader block_reader(&reader, block_header.value_len);
+        if (!StreamSerializationBlockVersionSupported(block_header.tag,
+                                                      block_header.block_version)) {
+            if (block_header.IsCritical()) {
+                throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                                    fmt::format("unsupported IVF streaming block version: tag={}, "
+                                                "name={}, version={}, flags={}, value_len={}",
+                                                block_header.tag,
+                                                StreamSerializationTagName(block_header.tag),
+                                                block_header.block_version,
+                                                block_header.flags,
+                                                block_header.value_len));
+            }
+            block_reader.SkipRemaining();
+            continue;
+        }
+
+        switch (static_cast<StreamSerializationTag>(block_header.tag)) {
+            case StreamSerializationTag::IVF_BUCKET:
+                ReadSeekableBlockPayload(block_reader, block_header, [this](StreamReader& block) {
+                    this->bucket_->Deserialize(block);
+                });
+                loaded_bucket = true;
+                break;
+            case StreamSerializationTag::IVF_PARTITION_STRATEGY:
+                ReadSeekableBlockPayload(block_reader, block_header, [this](StreamReader& block) {
+                    this->partition_strategy_->Deserialize(block);
+                });
+                loaded_partition = true;
+                break;
+            case StreamSerializationTag::LABEL_TABLE:
+                ReadSeekableBlockPayload(block_reader, block_header, [this](StreamReader& block) {
+                    this->label_table_->Deserialize(block);
+                });
+                loaded_label_table = true;
+                break;
+            case StreamSerializationTag::HIGH_PRECISION_CODES:
+                if (this->use_reorder_) {
+                    ReadSeekableBlockPayload(
+                        block_reader, block_header, [this](StreamReader& block) {
+                            this->reorder_codes_->Deserialize(block);
+                        });
+                    loaded_reorder_codes = true;
+                }
+                break;
+            case StreamSerializationTag::ATTRIBUTE_FILTER:
+                if (this->use_attribute_filter_) {
+                    ReadSeekableBlockPayload(
+                        block_reader, block_header, [this](StreamReader& block) {
+                            this->attr_filter_index_->Deserialize(block);
+                        });
+                    loaded_attribute_filter = true;
+                    this->has_attribute_ = true;
+                }
+                break;
+            default:
+                if (block_header.IsCritical()) {
+                    throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                                        fmt::format("unknown IVF streaming serialization block: "
+                                                    "tag={}, name={}, version={}, flags={}, "
+                                                    "value_len={}",
+                                                    block_header.tag,
+                                                    StreamSerializationTagName(block_header.tag),
+                                                    block_header.block_version,
+                                                    block_header.flags,
+                                                    block_header.value_len));
+                }
+                break;
+        }
+        block_reader.SkipRemaining();
+    }
+
+    if (!loaded_bucket || !loaded_partition || !loaded_label_table) {
+        throw VsagException(ErrorType::READ_ERROR,
+                            "IVF streaming serialization required block is missing");
+    }
+    if (this->use_reorder_ && !loaded_reorder_codes) {
+        throw VsagException(ErrorType::READ_ERROR,
+                            "IVF streaming serialization reorder block is missing");
+    }
+    if (this->use_attribute_filter_ && !loaded_attribute_filter) {
+        throw VsagException(ErrorType::READ_ERROR,
+                            "IVF streaming serialization attribute filter block is missing");
+    }
+    if (this->bucket_->GetQuantizerName() == QUANTIZATION_TYPE_VALUE_FP32) {
+        this->has_raw_vector_ = true;
+    }
+    this->fill_location_map();
+    this->cal_memory_usage();
 }
 
 #define READ_DATACELL_WITH_NAME(reader, name, datacell)                       \

--- a/src/algorithm/ivf/ivf.h
+++ b/src/algorithm/ivf/ivf.h
@@ -226,6 +226,23 @@ private:
     std::pair<BucketIdType, InnerIdType>
     get_location(InnerIdType inner_id) const;
 
+    MetadataPtr
+    collect_streaming_header() const override;
+
+    void
+    serialize_streaming_body(StreamWriter& writer) const override;
+
+    void
+    deserialize_streaming_body(StreamReader& reader, const MetadataPtr& metadata) override;
+
+    void
+    load_streaming_body(StreamReader& reader,
+                        const MetadataPtr& metadata,
+                        const LoadParameters& parameters) override;
+
+    void
+    read_streaming_body(StreamReader& reader, const MetadataPtr& metadata);
+
     /// Recalculate and cache the memory-usage counter (throttled).
     void
     cal_memory_usage();

--- a/src/algorithm/pyramid/pyramid.cpp
+++ b/src/algorithm/pyramid/pyramid.cpp
@@ -27,6 +27,8 @@
 #include "query_context.h"
 #include "storage/empty_index_binary_set.h"
 #include "storage/serialization.h"
+#include "storage/serialization_tags.h"
+#include "storage/tlv_section.h"
 #include "utils/slow_task_timer.h"
 #include "utils/util_functions.h"
 namespace vsag {
@@ -451,6 +453,238 @@ Pyramid::Serialize(StreamWriter& writer) const {
     basic_info["max_capacity"].SetInt(max_capacity_);
     basic_info[INDEX_PARAM].SetString(this->create_param_ptr_->ToString());
     write_index_footer(writer, basic_info);
+}
+
+MetadataPtr
+Pyramid::collect_streaming_header() const {
+    auto metadata = std::make_shared<Metadata>();
+    metadata->Set("format", "vsag_stream_v1");
+    metadata->Set("index_name", this->GetName());
+
+    JsonType basic_info;
+    basic_info["max_capacity"].SetInt(max_capacity_);
+    basic_info["dim"].SetInt(dim_);
+    basic_info["metric"].SetInt(static_cast<int64_t>(metric_));
+    basic_info["data_type"].SetInt(static_cast<int64_t>(data_type_));
+    basic_info["extra_info_size"].SetInt(static_cast<int64_t>(extra_info_size_));
+    basic_info[INDEX_PARAM].SetString(this->create_param_ptr_->ToString());
+    metadata->Set(BASIC_INFO, basic_info);
+
+    JsonType manifest;
+    auto label_tag = static_cast<uint32_t>(StreamSerializationTag::LABEL_TABLE);
+    auto base_tag = static_cast<uint32_t>(StreamSerializationTag::BASE_CODES);
+    auto hierarchy_tag = static_cast<uint32_t>(StreamSerializationTag::PYRAMID_HIERARCHIES);
+    AppendStreamingManifestBlock(manifest,
+                                 label_tag,
+                                 StreamSerializationBlockCurrentVersion(label_tag),
+                                 StreamSerializationTagCritical(label_tag));
+    AppendStreamingManifestBlock(manifest,
+                                 base_tag,
+                                 StreamSerializationBlockCurrentVersion(base_tag),
+                                 StreamSerializationTagCritical(base_tag));
+    if (this->use_reorder_) {
+        auto tag = static_cast<uint32_t>(StreamSerializationTag::HIGH_PRECISION_CODES);
+        AppendStreamingManifestBlock(manifest,
+                                     tag,
+                                     StreamSerializationBlockCurrentVersion(tag),
+                                     StreamSerializationTagCritical(tag));
+    }
+    AppendStreamingManifestBlock(manifest,
+                                 hierarchy_tag,
+                                 StreamSerializationBlockCurrentVersion(hierarchy_tag),
+                                 StreamSerializationTagCritical(hierarchy_tag));
+    metadata->Set("block_manifest", manifest);
+    metadata->SetEmptyIndex(this->GetNumElements() == 0);
+    return metadata;
+}
+
+void
+Pyramid::serialize_hierarchies(StreamWriter& writer) const {
+    auto pyramid_param = std::dynamic_pointer_cast<PyramidParameters>(create_param_ptr_);
+    if (pyramid_param && pyramid_param->has_hierarchies) {
+        uint64_t hierarchy_count = hierarchies_.size();
+        StreamWriter::WriteObj(writer, hierarchy_count);
+        for (const auto& [hname, h_ptr] : hierarchies_) {
+            StreamWriter::WriteString(writer, hname);
+            h_ptr->root->Serialize(writer);
+        }
+    } else {
+        hierarchies_.at("")->root->Serialize(writer);
+    }
+}
+
+void
+Pyramid::serialize_streaming_body(StreamWriter& writer) const {
+    auto label_tag = static_cast<uint32_t>(StreamSerializationTag::LABEL_TABLE);
+    auto base_tag = static_cast<uint32_t>(StreamSerializationTag::BASE_CODES);
+    auto hierarchy_tag = static_cast<uint32_t>(StreamSerializationTag::PYRAMID_HIERARCHIES);
+
+    WriteStreamingBlock(
+        writer, label_tag, StreamSerializationTagCritical(label_tag), [this](StreamWriter& w) {
+            this->label_table_->Serialize(w);
+        });
+    WriteStreamingBlock(
+        writer, base_tag, StreamSerializationTagCritical(base_tag), [this](StreamWriter& w) {
+            this->base_codes_->Serialize(w);
+        });
+    if (this->use_reorder_) {
+        auto tag = static_cast<uint32_t>(StreamSerializationTag::HIGH_PRECISION_CODES);
+        WriteStreamingBlock(
+            writer, tag, StreamSerializationTagCritical(tag), [this](StreamWriter& w) {
+                this->precise_codes_->Serialize(w);
+            });
+    }
+    WriteStreamingBlock(writer,
+                        hierarchy_tag,
+                        StreamSerializationTagCritical(hierarchy_tag),
+                        [this](StreamWriter& w) { this->serialize_hierarchies(w); });
+}
+
+void
+Pyramid::deserialize_hierarchies(StreamReader& reader, const JsonType& basic_info) {
+    auto param_json = JsonType::Parse(basic_info[INDEX_PARAM].GetString());
+    if (param_json.Contains(PYRAMID_HIERARCHIES)) {
+        uint64_t hierarchy_count = 0;
+        StreamReader::ReadObj(reader, hierarchy_count);
+        CHECK_ARGUMENT(hierarchy_count == hierarchies_.size(),
+                       fmt::format("serialized hierarchy count ({}) != config ({})",
+                                   hierarchy_count,
+                                   hierarchies_.size()));
+        for (uint64_t i = 0; i < hierarchy_count; ++i) {
+            std::string hname = StreamReader::ReadString(reader);
+            auto h_iter = hierarchies_.find(hname);
+            CHECK_ARGUMENT(h_iter != hierarchies_.end(),
+                           fmt::format("deserialized hierarchy '{}' not in config", hname));
+            h_iter->second->root->Deserialize(reader);
+        }
+    } else {
+        auto h_iter = hierarchies_.find("");
+        CHECK_ARGUMENT(
+            h_iter != hierarchies_.end(),
+            "deserialized single-hierarchy index but current config has named hierarchies");
+        h_iter->second->root->Deserialize(reader);
+    }
+}
+
+void
+Pyramid::deserialize_streaming_body(StreamReader& reader, const MetadataPtr& metadata) {
+    this->read_streaming_body(reader, metadata);
+}
+
+void
+Pyramid::load_streaming_body(StreamReader& reader,
+                             const MetadataPtr& metadata,
+                             const LoadParameters& parameters) {
+    (void)parameters;
+    this->read_streaming_body(reader, metadata);
+}
+
+void
+Pyramid::read_streaming_body(StreamReader& reader, const MetadataPtr& metadata) {
+    auto basic_info = metadata->Get(BASIC_INFO);
+    auto max_capacity = basic_info["max_capacity"].GetInt();
+    if (basic_info.Contains(INDEX_PARAM)) {
+        auto index_param = std::make_shared<PyramidParameters>();
+        index_param->FromString(basic_info[INDEX_PARAM].GetString());
+        if (not this->create_param_ptr_->CheckCompatibility(index_param)) {
+            auto message = fmt::format("Pyramid index parameter not match, current: {}, new: {}",
+                                       this->create_param_ptr_->ToString(),
+                                       index_param->ToString());
+            logger::error(message);
+            throw VsagException(ErrorType::INVALID_ARGUMENT, message);
+        }
+    }
+
+    bool loaded_label_table = false;
+    bool loaded_base_codes = false;
+    bool loaded_precise_codes = false;
+    bool loaded_hierarchies = false;
+
+    while (true) {
+        auto block_header = StreamBlockHeader::Read(reader);
+        if (block_header.IsSectionEnd()) {
+            break;
+        }
+        BoundedForwardReader block_reader(&reader, block_header.value_len);
+        if (!StreamSerializationBlockVersionSupported(block_header.tag,
+                                                      block_header.block_version)) {
+            if (block_header.IsCritical()) {
+                throw VsagException(
+                    ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                    fmt::format("unsupported Pyramid streaming block version: tag={}, "
+                                "name={}, version={}, flags={}, value_len={}",
+                                block_header.tag,
+                                StreamSerializationTagName(block_header.tag),
+                                block_header.block_version,
+                                block_header.flags,
+                                block_header.value_len));
+            }
+            block_reader.SkipRemaining();
+            continue;
+        }
+
+        switch (static_cast<StreamSerializationTag>(block_header.tag)) {
+            case StreamSerializationTag::LABEL_TABLE:
+                ReadSeekableBlockPayload(block_reader, block_header, [this](StreamReader& block) {
+                    this->label_table_->Deserialize(block);
+                });
+                this->delete_count_.store(
+                    static_cast<int64_t>(this->label_table_->GetAllDeletedIds().size()),
+                    std::memory_order_relaxed);
+                loaded_label_table = true;
+                break;
+            case StreamSerializationTag::BASE_CODES:
+                ReadSeekableBlockPayload(block_reader, block_header, [this](StreamReader& block) {
+                    this->base_codes_->Deserialize(block);
+                });
+                this->cur_element_count_ = this->base_codes_->TotalCount();
+                loaded_base_codes = true;
+                break;
+            case StreamSerializationTag::HIGH_PRECISION_CODES:
+                if (this->use_reorder_) {
+                    ReadSeekableBlockPayload(
+                        block_reader, block_header, [this](StreamReader& block) {
+                            this->precise_codes_->Deserialize(block);
+                        });
+                    loaded_precise_codes = true;
+                }
+                break;
+            case StreamSerializationTag::PYRAMID_HIERARCHIES:
+                ReadSeekableBlockPayload(
+                    block_reader, block_header, [this, &basic_info](StreamReader& block) {
+                        this->deserialize_hierarchies(block, basic_info);
+                    });
+                loaded_hierarchies = true;
+                break;
+            default:
+                if (block_header.IsCritical()) {
+                    throw VsagException(
+                        ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                        fmt::format("unknown Pyramid streaming serialization block: "
+                                    "tag={}, name={}, version={}, flags={}, "
+                                    "value_len={}",
+                                    block_header.tag,
+                                    StreamSerializationTagName(block_header.tag),
+                                    block_header.block_version,
+                                    block_header.flags,
+                                    block_header.value_len));
+                }
+                break;
+        }
+        block_reader.SkipRemaining();
+    }
+
+    if (!loaded_label_table || !loaded_base_codes || !loaded_hierarchies) {
+        throw VsagException(ErrorType::READ_ERROR,
+                            "Pyramid streaming serialization required block is missing");
+    }
+    if (this->use_reorder_ && !loaded_precise_codes) {
+        throw VsagException(ErrorType::READ_ERROR,
+                            "Pyramid streaming serialization precise codes block is missing");
+    }
+
+    resize(max_capacity);
+    this->current_memory_usage_ = static_cast<int64_t>(this->CalSerializeSize());
 }
 
 void

--- a/src/algorithm/pyramid/pyramid.h
+++ b/src/algorithm/pyramid/pyramid.h
@@ -255,6 +255,29 @@ public:
     friend class PyramidAnalyzer;
 
 private:
+    MetadataPtr
+    collect_streaming_header() const override;
+
+    void
+    serialize_streaming_body(StreamWriter& writer) const override;
+
+    void
+    deserialize_streaming_body(StreamReader& reader, const MetadataPtr& metadata) override;
+
+    void
+    load_streaming_body(StreamReader& reader,
+                        const MetadataPtr& metadata,
+                        const LoadParameters& parameters) override;
+
+    void
+    read_streaming_body(StreamReader& reader, const MetadataPtr& metadata);
+
+    void
+    serialize_hierarchies(StreamWriter& writer) const;
+
+    void
+    deserialize_hierarchies(StreamReader& reader, const JsonType& basic_info);
+
     /// One named hierarchy with its own root IndexNode and build parameters.
     struct Hierarchy {
         std::string name;                          // hierarchy name (empty = default)

--- a/src/algorithm/simq/simq.cpp
+++ b/src/algorithm/simq/simq.cpp
@@ -611,7 +611,7 @@ SIMQ::split_cluster_incremental(InnerIdType cluster_idx) {
 
     // Update token_to_dist_ for tokens moved to new cluster so future splits
     // sort by distance to the new representative, not the old one.
-    const uint64_t udim = static_cast<uint64_t>(dim_);
+    const auto udim = static_cast<uint64_t>(dim_);
     for (uint64_t rank = half; rank < n; ++rank) {
         InnerIdType tid = cluster_tokens[rank];
         InnerIdType doc_id = token_to_doc_[tid];

--- a/src/algorithm/sindi/sindi.cpp
+++ b/src/algorithm/sindi/sindi.cpp
@@ -28,6 +28,8 @@
 #include "quantization/sparse_quantization/sparse_quantizer_parameter.h"
 #include "simd/fp16_simd.h"
 #include "storage/serialization.h"
+#include "storage/serialization_tags.h"
+#include "storage/tlv_section.h"
 #include "utils/util_functions.h"
 #include "vsag/allocator.h"
 #include "vsag/options.h"
@@ -1146,7 +1148,8 @@ SINDI::Serialize(StreamWriter& writer) const {
     std::shared_lock rlock(this->global_mutex_);
 
     if (cur_element_count_ == 0) {
-        StreamWriter::WriteObj(writer, cur_element_count_);
+        auto cur_element_count = cur_element_count_.load();
+        StreamWriter::WriteObj(writer, cur_element_count);
         if (sparse_value_quant_type_ == SparseValueQuantizationType::SQ8) {
             StreamWriter::WriteObj(writer, quantization_params_->min_val);
             StreamWriter::WriteObj(writer, quantization_params_->max_val);
@@ -1163,7 +1166,8 @@ SINDI::Serialize(StreamWriter& writer) const {
         return;
     }
 
-    StreamWriter::WriteObj(writer, cur_element_count_);
+    auto cur_element_count = cur_element_count_.load();
+    StreamWriter::WriteObj(writer, cur_element_count);
 
     if (sparse_value_quant_type_ == SparseValueQuantizationType::SQ8) {
         StreamWriter::WriteObj(writer, quantization_params_->min_val);
@@ -1200,6 +1204,269 @@ SINDI::Serialize(StreamWriter& writer) const {
         jsonify_basic_info[SINDI_RERANK_FLAT_FORMAT_KEY].SetInt(SINDI_RERANK_FLAT_FORMAT_DATACELL);
     }
     write_index_footer(writer, jsonify_basic_info);
+}
+
+MetadataPtr
+SINDI::collect_streaming_header() const {
+    auto metadata = std::make_shared<Metadata>();
+    metadata->Set("format", "vsag_stream_v1");
+    metadata->Set("index_name", this->GetName());
+
+    JsonType basic_info;
+    basic_info[INDEX_PARAM].SetString(this->create_param_ptr_->ToString());
+    basic_info["dim"].SetInt(dim_);
+    basic_info["metric"].SetInt(static_cast<int64_t>(metric_));
+    basic_info["data_type"].SetInt(static_cast<int64_t>(data_type_));
+    basic_info["extra_info_size"].SetInt(static_cast<int64_t>(extra_info_size_));
+    basic_info["cur_element_count"].SetInt(this->cur_element_count_.load());
+    basic_info["use_reorder"].SetBool(this->use_reorder_);
+    basic_info["remap_term_ids"].SetBool(this->remap_term_ids_);
+    if (use_reorder_) {
+        basic_info[SINDI_RERANK_FLAT_FORMAT_KEY].SetInt(SINDI_RERANK_FLAT_FORMAT_DATACELL);
+    }
+    metadata->Set(BASIC_INFO, basic_info);
+
+    JsonType manifest;
+    auto windows_tag = static_cast<uint32_t>(StreamSerializationTag::SINDI_WINDOWS);
+    auto label_tag = static_cast<uint32_t>(StreamSerializationTag::LABEL_TABLE);
+    AppendStreamingManifestBlock(manifest,
+                                 windows_tag,
+                                 StreamSerializationBlockCurrentVersion(windows_tag),
+                                 StreamSerializationTagCritical(windows_tag));
+    AppendStreamingManifestBlock(manifest,
+                                 label_tag,
+                                 StreamSerializationBlockCurrentVersion(label_tag),
+                                 StreamSerializationTagCritical(label_tag));
+    if (this->use_reorder_) {
+        auto tag = static_cast<uint32_t>(StreamSerializationTag::SINDI_RERANK_INDEX);
+        AppendStreamingManifestBlock(manifest,
+                                     tag,
+                                     StreamSerializationBlockCurrentVersion(tag),
+                                     StreamSerializationTagCritical(tag));
+    }
+    if (this->remap_term_ids_ && this->term_id_mapper_) {
+        auto tag = static_cast<uint32_t>(StreamSerializationTag::SINDI_TERM_ID_MAPPER);
+        AppendStreamingManifestBlock(manifest,
+                                     tag,
+                                     StreamSerializationBlockCurrentVersion(tag),
+                                     StreamSerializationTagCritical(tag));
+    }
+    metadata->Set("block_manifest", manifest);
+    metadata->SetEmptyIndex(this->GetNumElements() == 0);
+    return metadata;
+}
+
+void
+SINDI::serialize_windows(StreamWriter& writer) const {
+    auto cur_element_count = cur_element_count_.load();
+    StreamWriter::WriteObj(writer, cur_element_count);
+
+    if (sparse_value_quant_type_ == SparseValueQuantizationType::SQ8) {
+        StreamWriter::WriteObj(writer, quantization_params_->min_val);
+        StreamWriter::WriteObj(writer, quantization_params_->max_val);
+        StreamWriter::WriteObj(writer, quantization_params_->diff);
+    }
+
+    uint32_t window_term_list_size = window_term_list_.size();
+    StreamWriter::WriteObj(writer, window_term_list_size);
+    for (const auto& window : window_term_list_) {
+        window->Serialize(writer);
+    }
+}
+
+void
+SINDI::serialize_streaming_body(StreamWriter& writer) const {
+    std::shared_lock rlock(this->global_mutex_);
+    const bool mutable_runtime = not immutable_enabled_ and immutable_data_ == nullptr;
+    CHECK_ARGUMENT(mutable_runtime, "immutable SINDI runtime does not support SerializeStreaming");
+
+    auto windows_tag = static_cast<uint32_t>(StreamSerializationTag::SINDI_WINDOWS);
+    auto label_tag = static_cast<uint32_t>(StreamSerializationTag::LABEL_TABLE);
+    WriteStreamingBlock(
+        writer, windows_tag, StreamSerializationTagCritical(windows_tag), [this](StreamWriter& w) {
+            this->serialize_windows(w);
+        });
+    WriteStreamingBlock(
+        writer, label_tag, StreamSerializationTagCritical(label_tag), [this](StreamWriter& w) {
+            this->label_table_->Serialize(w);
+        });
+    if (this->use_reorder_) {
+        auto tag = static_cast<uint32_t>(StreamSerializationTag::SINDI_RERANK_INDEX);
+        WriteStreamingBlock(
+            writer, tag, StreamSerializationTagCritical(tag), [this](StreamWriter& w) {
+                this->rerank_flat_->Serialize(w);
+            });
+    }
+    if (this->remap_term_ids_ && this->term_id_mapper_) {
+        auto tag = static_cast<uint32_t>(StreamSerializationTag::SINDI_TERM_ID_MAPPER);
+        WriteStreamingBlock(
+            writer, tag, StreamSerializationTagCritical(tag), [this](StreamWriter& w) {
+                this->term_id_mapper_->Serialize(w);
+            });
+    }
+}
+
+void
+SINDI::deserialize_windows(StreamReader& reader_ref) {
+    uint64_t cur_element_count = 0;
+    StreamReader::ReadObj(reader_ref, cur_element_count);
+    cur_element_count_.store(cur_element_count);
+
+    if (sparse_value_quant_type_ == SparseValueQuantizationType::SQ8) {
+        StreamReader::ReadObj(reader_ref, quantization_params_->min_val);
+        StreamReader::ReadObj(reader_ref, quantization_params_->max_val);
+        StreamReader::ReadObj(reader_ref, quantization_params_->diff);
+    }
+
+    uint32_t window_term_list_size = 0;
+    StreamReader::ReadObj(reader_ref, window_term_list_size);
+    if (immutable_enabled_) {
+        immutable_data_ = std::make_unique<ImmutableSINDIData>(allocator_);
+        immutable_data_->sparse_value_quant_type = sparse_value_quant_type_;
+        immutable_data_->value_code_size = sparse_value_code_size(sparse_value_quant_type_);
+        immutable_data_->windows.reserve(window_term_list_size);
+        for (uint32_t i = 0; i < window_term_list_size; ++i) {
+            immutable_data_->windows.emplace_back(allocator_);
+            deserialize_immutable_window(reader_ref, immutable_data_->windows.back());
+        }
+        window_term_list_.clear();
+        window_term_list_.shrink_to_fit();
+    } else {
+        window_term_list_.resize(window_term_list_size);
+        for (auto& window : window_term_list_) {
+            window = std::make_shared<SparseTermDataCell>(doc_retain_ratio_,
+                                                          term_id_limit_,
+                                                          allocator_,
+                                                          sparse_value_quant_type_,
+                                                          quantization_params_);
+            window->Deserialize(reader_ref);
+        }
+    }
+}
+
+void
+SINDI::deserialize_streaming_body(StreamReader& reader, const MetadataPtr& metadata) {
+    this->read_streaming_body(reader, metadata);
+}
+
+void
+SINDI::load_streaming_body(StreamReader& reader,
+                           const MetadataPtr& metadata,
+                           const LoadParameters& parameters) {
+    (void)parameters;
+    this->read_streaming_body(reader, metadata);
+}
+
+void
+SINDI::read_streaming_body(StreamReader& reader, const MetadataPtr& metadata) {
+    std::scoped_lock wlock(this->global_mutex_);
+
+    auto basic_info = metadata->Get(BASIC_INFO);
+    if (basic_info.Contains(INDEX_PARAM)) {
+        auto index_param = std::make_shared<SINDIParameter>();
+        index_param->FromString(basic_info[INDEX_PARAM].GetString());
+        if (not this->create_param_ptr_->CheckCompatibility(index_param)) {
+            auto message = fmt::format("SINDI index parameter not match, current: {}, new: {}",
+                                       this->create_param_ptr_->ToString(),
+                                       index_param->ToString());
+            logger::error(message);
+            throw VsagException(ErrorType::INVALID_ARGUMENT, message);
+        }
+    }
+
+    bool loaded_windows = false;
+    bool loaded_label_table = false;
+    bool loaded_rerank = false;
+    bool loaded_term_mapper = false;
+
+    while (true) {
+        auto block_header = StreamBlockHeader::Read(reader);
+        if (block_header.IsSectionEnd()) {
+            break;
+        }
+        BoundedForwardReader block_reader(&reader, block_header.value_len);
+        if (!StreamSerializationBlockVersionSupported(block_header.tag,
+                                                      block_header.block_version)) {
+            if (block_header.IsCritical()) {
+                throw VsagException(
+                    ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                    fmt::format("unsupported SINDI streaming block version: tag={}, "
+                                "name={}, version={}, flags={}, value_len={}",
+                                block_header.tag,
+                                StreamSerializationTagName(block_header.tag),
+                                block_header.block_version,
+                                block_header.flags,
+                                block_header.value_len));
+            }
+            block_reader.SkipRemaining();
+            continue;
+        }
+
+        switch (static_cast<StreamSerializationTag>(block_header.tag)) {
+            case StreamSerializationTag::SINDI_WINDOWS:
+                ReadSeekableBlockPayload(block_reader, block_header, [this](StreamReader& block) {
+                    this->deserialize_windows(block);
+                });
+                loaded_windows = true;
+                break;
+            case StreamSerializationTag::LABEL_TABLE:
+                ReadSeekableBlockPayload(block_reader, block_header, [this](StreamReader& block) {
+                    this->label_table_->Deserialize(block);
+                });
+                this->delete_count_.store(
+                    static_cast<int64_t>(this->label_table_->GetAllDeletedIds().size()),
+                    std::memory_order_relaxed);
+                loaded_label_table = true;
+                break;
+            case StreamSerializationTag::SINDI_RERANK_INDEX:
+                if (this->use_reorder_) {
+                    ReadSeekableBlockPayload(
+                        block_reader, block_header, [this](StreamReader& block) {
+                            deserialize_rerank_flat(
+                                block, this->rerank_flat_, this->allocator_, true);
+                        });
+                    loaded_rerank = true;
+                }
+                break;
+            case StreamSerializationTag::SINDI_TERM_ID_MAPPER:
+                if (this->remap_term_ids_ && this->term_id_mapper_) {
+                    ReadSeekableBlockPayload(
+                        block_reader, block_header, [this](StreamReader& block) {
+                            this->term_id_mapper_->Deserialize(block);
+                        });
+                    loaded_term_mapper = true;
+                }
+                break;
+            default:
+                if (block_header.IsCritical()) {
+                    throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                                        fmt::format("unknown SINDI streaming serialization block: "
+                                                    "tag={}, name={}, version={}, flags={}, "
+                                                    "value_len={}",
+                                                    block_header.tag,
+                                                    StreamSerializationTagName(block_header.tag),
+                                                    block_header.block_version,
+                                                    block_header.flags,
+                                                    block_header.value_len));
+                }
+                break;
+        }
+        block_reader.SkipRemaining();
+    }
+
+    if (!loaded_windows || !loaded_label_table) {
+        throw VsagException(ErrorType::READ_ERROR,
+                            "SINDI streaming serialization required block is missing");
+    }
+    if (this->use_reorder_ && !loaded_rerank) {
+        throw VsagException(ErrorType::READ_ERROR,
+                            "SINDI streaming serialization rerank block is missing");
+    }
+    if (this->remap_term_ids_ && this->term_id_mapper_ && !loaded_term_mapper) {
+        throw VsagException(ErrorType::READ_ERROR,
+                            "SINDI streaming serialization term mapper block is missing");
+    }
+    this->cal_memory_usage();
 }
 
 void
@@ -1251,7 +1518,9 @@ SINDI::Deserialize(StreamReader& reader) {
     }
     auto& reader_ref = *reader_ptr;
 
-    StreamReader::ReadObj(reader_ref, cur_element_count_);
+    uint64_t cur_element_count = 0;
+    StreamReader::ReadObj(reader_ref, cur_element_count);
+    cur_element_count_.store(cur_element_count);
 
     if (sparse_value_quant_type_ == SparseValueQuantizationType::SQ8) {
         StreamReader::ReadObj(reader_ref, quantization_params_->min_val);

--- a/src/algorithm/sindi/sindi.h
+++ b/src/algorithm/sindi/sindi.h
@@ -232,6 +232,29 @@ private:
     std::pair<int64_t, int64_t>
     get_min_max_window_id(const FilterPtr& filter) const;
 
+    MetadataPtr
+    collect_streaming_header() const override;
+
+    void
+    serialize_streaming_body(StreamWriter& writer) const override;
+
+    void
+    deserialize_streaming_body(StreamReader& reader, const MetadataPtr& metadata) override;
+
+    void
+    load_streaming_body(StreamReader& reader,
+                        const MetadataPtr& metadata,
+                        const LoadParameters& parameters) override;
+
+    void
+    read_streaming_body(StreamReader& reader, const MetadataPtr& metadata);
+
+    void
+    serialize_windows(StreamWriter& writer) const;
+
+    void
+    deserialize_windows(StreamReader& reader_ref);
+
     void
     deserialize_immutable_window(StreamReader& reader_ref, ImmutableSINDIWindow& window) const;
 

--- a/src/algorithm/sindi/sindi_test.cpp
+++ b/src/algorithm/sindi/sindi_test.cpp
@@ -17,12 +17,16 @@
 #include "sindi.h"
 
 #include <array>
+#include <cstring>
 #include <set>
+#include <sstream>
 #include <tuple>
 
 #include "impl/allocator/safe_allocator.h"
 #include "index_common_param.h"
+#include "storage/serialization_tags.h"
 #include "storage/serialization_template_test.h"
+#include "storage/streaming_serialization_test_utils.h"
 #include "unittest.h"
 using namespace vsag;
 
@@ -42,6 +46,13 @@ public:
 };
 
 }  // namespace vsag
+
+namespace {
+
+using vsag::test::EraseStreamingBlock;
+using vsag::test::InsertUnknownStreamingBlock;
+
+}  // namespace
 
 class MockFilter : public Filter {
 public:
@@ -146,6 +157,85 @@ create_exact_sindi_param(uint32_t term_id_limit,
     return index_param;
 }
 
+TEST_CASE("SINDI streaming compatibility", "[ut][SINDI][streaming][compatibility]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    IndexCommonParam common_param;
+    common_param.allocator_ = allocator;
+    common_param.metric_ = MetricType::METRIC_TYPE_IP;
+    common_param.dim_ = 64;
+
+    constexpr uint32_t num_base = 128;
+    constexpr int64_t max_dim = 64;
+    constexpr int64_t max_id = 30000;
+    std::vector<int64_t> ids(num_base);
+    for (uint32_t i = 0; i < num_base; ++i) {
+        ids[i] = i;
+    }
+
+    auto sv_base = fixtures::GenerateSparseVectors(num_base, max_dim, max_id, 0, 10, 114);
+    auto base = Dataset::Make();
+    base->NumElements(num_base)->SparseVectors(sv_base.data())->Ids(ids.data())->Owner(false);
+
+    static constexpr auto param_str = R"({
+        "use_reorder": false,
+        "use_quantization": false,
+        "doc_prune_ratio": 0.0,
+        "term_prune_ratio": 0.0,
+        "window_size": 10000,
+        "term_id_limit": 30001,
+        "avg_doc_term_length": 100
+    })";
+    auto param_json = JsonType::Parse(param_str);
+    auto index_param = std::make_shared<SINDIParameter>();
+    index_param->FromJson(param_json);
+
+    auto index = std::make_unique<SINDI>(index_param, common_param);
+    auto build_res = index->Build(base);
+    REQUIRE(build_res.size() == 0);
+
+    std::stringstream stream;
+    REQUIRE_NOTHROW(index->SerializeStreaming(stream));
+    const auto bytes = stream.str();
+
+    SECTION("skips unknown non-critical block") {
+        auto mutated = InsertUnknownStreamingBlock(bytes, false);
+        auto restored = std::make_unique<SINDI>(index_param, common_param);
+        std::stringstream deserialize_stream(mutated);
+        REQUIRE_NOTHROW(restored->DeserializeStreaming(deserialize_stream));
+        REQUIRE(restored->GetNumElements() == num_base);
+
+        std::stringstream load_stream(mutated);
+        auto loaded = Index::Load(load_stream, "{}");
+        REQUIRE(loaded.has_value());
+        REQUIRE(loaded.value()->GetNumElements() == num_base);
+    }
+
+    SECTION("rejects unknown critical block") {
+        auto mutated = InsertUnknownStreamingBlock(bytes, true);
+        auto restored = std::make_unique<SINDI>(index_param, common_param);
+        std::stringstream deserialize_stream(mutated);
+        REQUIRE_THROWS(restored->DeserializeStreaming(deserialize_stream));
+
+        std::stringstream load_stream(mutated);
+        REQUIRE_FALSE(Index::Load(load_stream, "{}").has_value());
+    }
+
+    SECTION("rejects missing required block") {
+        auto mutated = EraseStreamingBlock(bytes, StreamSerializationTag::SINDI_WINDOWS);
+        auto restored = std::make_unique<SINDI>(index_param, common_param);
+        std::stringstream deserialize_stream(mutated);
+        REQUIRE_THROWS(restored->DeserializeStreaming(deserialize_stream));
+
+        std::stringstream load_stream(mutated);
+        REQUIRE_FALSE(Index::Load(load_stream, "{}").has_value());
+    }
+
+    for (auto& item : sv_base) {
+        delete[] item.vals_;
+        delete[] item.ids_;
+    }
+}
+
 TEST_CASE("SINDI Basic Test", "[ut][SINDI]") {
     auto allocator = SafeAllocator::FactoryDefaultAllocator();
     IndexCommonParam common_param;
@@ -216,6 +306,19 @@ TEST_CASE("SINDI Basic Test", "[ut][SINDI]") {
     // test serialize
     test_serializion(*index, *another_index);
     REQUIRE(another_index->GetNumElements() == num_base);
+    auto streaming_index = std::make_unique<SINDI>(index_param, common_param);
+    std::stringstream streaming_buffer;
+    REQUIRE_NOTHROW(index->SerializeStreaming(streaming_buffer));
+    const auto streaming_bytes = streaming_buffer.str();
+
+    std::stringstream deserialize_stream(streaming_bytes);
+    REQUIRE_NOTHROW(streaming_index->DeserializeStreaming(deserialize_stream));
+    REQUIRE(streaming_index->GetNumElements() == num_base);
+
+    std::stringstream load_stream(streaming_bytes);
+    auto loaded_index = vsag::Index::Load(load_stream, "{}");
+    REQUIRE(loaded_index.has_value());
+    REQUIRE(loaded_index.value()->GetNumElements() == num_base);
 
     // test search process
     std::string search_param_str = R"(
@@ -249,10 +352,16 @@ TEST_CASE("SINDI Basic Test", "[ut][SINDI]") {
 
         // test basic performance
         auto result = index->KnnSearch(query, k, search_param_str, nullptr);
+        auto loaded_result =
+            loaded_index.value()->KnnSearch(query, k, search_param_str, vsag::BitsetPtr(nullptr));
+        REQUIRE(loaded_result.has_value());
         REQUIRE(result->GetNumElements() == bf_result->GetNumElements());
         REQUIRE(result->GetDim() == bf_result->GetDim());
+        REQUIRE(loaded_result.value()->GetNumElements() == result->GetNumElements());
+        REQUIRE(loaded_result.value()->GetDim() == result->GetDim());
         for (int j = 0; j < k; j++) {
             REQUIRE(result->GetIds()[j] == bf_result->GetIds()[j]);
+            REQUIRE(loaded_result.value()->GetIds()[j] == result->GetIds()[j]);
             REQUIRE(std::abs(result->GetDistances()[j] - bf_result->GetDistances()[j]) < 3e-3);
         }
 

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -261,5 +261,9 @@ const char* const IVF_THREAD_COUNT = "thread_count";
 const char* const SERIAL_MAGIC_BEGIN = "vsag0000";
 const char* const SERIAL_MAGIC_END = "0000gasv";
 const char* const SERIAL_META_KEY = "_meta";
+const char* const SERIAL_STREAM_MAGIC = "vsagstm0";
+const uint16_t SERIAL_STREAM_FORMAT_MAJOR = 1;
+const uint16_t SERIAL_STREAM_FORMAT_MINOR = 0;
+const uint32_t SERIAL_STREAM_SECTION_END = 0;
 
 };  // namespace vsag

--- a/src/factory/factory.cpp
+++ b/src/factory/factory.cpp
@@ -15,20 +15,236 @@
 
 #include "vsag/factory.h"
 
+#include <fmt/format.h>
+
 #include <algorithm>
 #include <cstdint>
+#include <cstring>
 #include <exception>
 #include <fstream>
 #include <ios>
 #include <memory>
 #include <mutex>
+#include <nlohmann/json.hpp>
+#include <stdexcept>
 #include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
 
+#include "algorithm/bruteforce/bruteforce.h"
+#include "algorithm/bruteforce/bruteforce_parameter.h"
+#include "algorithm/hgraph/hgraph.h"
+#include "algorithm/hgraph/hgraph_parameter.h"
+#include "algorithm/ivf/ivf.h"
+#include "algorithm/ivf/ivf_parameter.h"
+#include "algorithm/pyramid/pyramid.h"
+#include "algorithm/pyramid/pyramid_zparameters.h"
+#include "algorithm/sindi/sindi.h"
+#include "algorithm/sindi/sindi_parameter.h"
+#include "common.h"
+#include "data_type.h"
 #include "impl/thread_pool/safe_thread_pool.h"
+#include "index/index_impl.h"
+#include "index_common_param.h"
+#include "inner_string_params.h"
+#include "json_wrapper.h"
+#include "metric_type.h"
+#include "storage/serialization.h"
+#include "storage/serialization_tags.h"
+#include "storage/stream_reader.h"
+#include "storage/tlv_section.h"
+#include "vsag/constants.h"
 #include "vsag/engine.h"
+#include "vsag/index.h"
 #include "vsag/options.h"
+#include "vsag/resource.h"
 
 namespace vsag {
+namespace {
+
+IndexCommonParam
+make_streaming_common_param(const MetadataPtr& metadata, Allocator* allocator) {
+    auto resource = allocator == nullptr
+                        ? std::make_shared<Resource>(Engine::CreateDefaultAllocator(), nullptr)
+                        : std::make_shared<Resource>(allocator, nullptr);
+
+    IndexCommonParam common_param;
+    common_param.allocator_ = resource->GetAllocator();
+    common_param.thread_pool_ =
+        std::dynamic_pointer_cast<SafeThreadPool>(resource->GetThreadPool());
+
+    auto basic_info = metadata->Get("basic_info");
+    if (basic_info.Contains("dim")) {
+        common_param.dim_ = basic_info["dim"].GetInt();
+    }
+    if (basic_info.Contains("metric")) {
+        common_param.metric_ = static_cast<MetricType>(basic_info["metric"].GetInt());
+    }
+    if (basic_info.Contains("data_type")) {
+        common_param.data_type_ = static_cast<DataTypes>(basic_info["data_type"].GetInt());
+    }
+    if (basic_info.Contains("extra_info_size")) {
+        common_param.extra_info_size_ = basic_info["extra_info_size"].GetInt();
+    }
+    return common_param;
+}
+
+void
+require_string_load_parameter(const JsonType& json, const std::string& key) {
+    CHECK_ARGUMENT(json[key].IsString(),
+                   fmt::format("streaming load parameter '{}' must be a string", key));
+}
+
+bool
+is_valid_streaming_io_type(const char* io_type) {
+    const std::string_view type(io_type);
+    return type == IO_TYPE_VALUE_MEMORY_IO || type == IO_TYPE_VALUE_BLOCK_MEMORY_IO ||
+           type == IO_TYPE_VALUE_BUFFER_IO || type == IO_TYPE_VALUE_ASYNC_IO ||
+           type == IO_TYPE_VALUE_MMAP_IO || type == IO_TYPE_VALUE_READER_IO;
+}
+
+void
+set_streaming_io_override(JsonType& index_param,
+                          const char* block_key,
+                          const char* io_type,
+                          const char* file_path) {
+    if (!index_param.Contains(block_key)) {
+        return;
+    }
+    if (io_type != nullptr) {
+        CHECK_ARGUMENT(is_valid_streaming_io_type(io_type),
+                       std::string("unsupported streaming load io_type: ") + io_type);
+        index_param[block_key][IO_PARAMS_KEY][TYPE_KEY].SetString(io_type);
+    }
+    if (file_path != nullptr) {
+        index_param[block_key][IO_PARAMS_KEY][IO_FILE_PATH_KEY].SetString(file_path);
+    }
+}
+
+void
+apply_hgraph_streaming_load_parameters(JsonType& index_param, const std::string& parameters) {
+    auto load_json = JsonType::Parse(parameters.empty() ? "{}" : parameters);
+    if (load_json.Contains(HGRAPH_BASE_IO_TYPE)) {
+        require_string_load_parameter(load_json, HGRAPH_BASE_IO_TYPE);
+        set_streaming_io_override(index_param,
+                                  BASE_CODES_KEY,
+                                  load_json[HGRAPH_BASE_IO_TYPE].GetString().c_str(),
+                                  nullptr);
+    }
+    if (load_json.Contains(HGRAPH_BASE_FILE_PATH)) {
+        require_string_load_parameter(load_json, HGRAPH_BASE_FILE_PATH);
+        set_streaming_io_override(index_param,
+                                  BASE_CODES_KEY,
+                                  nullptr,
+                                  load_json[HGRAPH_BASE_FILE_PATH].GetString().c_str());
+    }
+    if (load_json.Contains(HGRAPH_PRECISE_IO_TYPE)) {
+        require_string_load_parameter(load_json, HGRAPH_PRECISE_IO_TYPE);
+        set_streaming_io_override(index_param,
+                                  PRECISE_CODES_KEY,
+                                  load_json[HGRAPH_PRECISE_IO_TYPE].GetString().c_str(),
+                                  nullptr);
+    }
+    if (load_json.Contains(HGRAPH_PRECISE_FILE_PATH)) {
+        require_string_load_parameter(load_json, HGRAPH_PRECISE_FILE_PATH);
+        set_streaming_io_override(index_param,
+                                  PRECISE_CODES_KEY,
+                                  nullptr,
+                                  load_json[HGRAPH_PRECISE_FILE_PATH].GetString().c_str());
+    }
+    if (load_json.Contains(RAW_VECTOR_IO_TYPE)) {
+        require_string_load_parameter(load_json, RAW_VECTOR_IO_TYPE);
+        set_streaming_io_override(index_param,
+                                  RAW_VECTOR_KEY,
+                                  load_json[RAW_VECTOR_IO_TYPE].GetString().c_str(),
+                                  nullptr);
+    }
+    if (load_json.Contains(RAW_VECTOR_FILE_PATH)) {
+        require_string_load_parameter(load_json, RAW_VECTOR_FILE_PATH);
+        set_streaming_io_override(index_param,
+                                  RAW_VECTOR_KEY,
+                                  nullptr,
+                                  load_json[RAW_VECTOR_FILE_PATH].GetString().c_str());
+    }
+}
+
+struct StreamingIndexLoadTarget {
+    IndexPtr index;
+    InnerIndexPtr inner_index;
+};
+
+template <typename IndexT, typename ParamT>
+StreamingIndexLoadTarget
+create_streaming_index(const JsonType& index_param, const IndexCommonParam& common_param) {
+    auto param = std::make_shared<ParamT>();
+    param->FromJson(index_param);
+    auto inner_index = std::make_shared<IndexT>(param, common_param);
+    return {std::make_shared<IndexImpl<IndexT>>(inner_index, common_param), inner_index};
+}
+
+tl::expected<StreamingIndexLoadTarget, Error>
+create_streaming_index_from_metadata(const MetadataPtr& metadata,
+                                     const std::string& parameters,
+                                     Allocator* allocator) {
+    auto index_name_json = metadata->Get("index_name");
+    if (!index_name_json.IsString()) {
+        throw VsagException(ErrorType::INVALID_BINARY,
+                            "streaming metadata missing string field: index_name");
+    }
+    const auto index_name = index_name_json.GetString();
+
+    auto basic_info = metadata->Get(BASIC_INFO);
+    if (!basic_info.IsObject()) {
+        throw VsagException(ErrorType::INVALID_BINARY,
+                            "streaming metadata missing object field: basic_info");
+    }
+
+    std::string build_parameters;
+    std::string build_parameters_source = "basic_info.index_param";
+    if (basic_info.Contains(INDEX_PARAM) && basic_info[INDEX_PARAM].IsString()) {
+        build_parameters = basic_info[INDEX_PARAM].GetString();
+    } else {
+        auto build_parameters_json = metadata->Get("build_param_snapshot");
+        if (!build_parameters_json.IsString()) {
+            throw VsagException(ErrorType::INVALID_BINARY,
+                                "streaming metadata missing string field: build_param_snapshot");
+        }
+        build_parameters_source = "build_param_snapshot";
+        build_parameters = build_parameters_json.GetString();
+    }
+
+    auto index_param = JsonType::Parse(build_parameters, false);
+    if (index_param.IsDiscarded() || !index_param.IsObject()) {
+        throw VsagException(
+            ErrorType::INVALID_BINARY,
+            fmt::format("streaming metadata {} must be a JSON object", build_parameters_source));
+    }
+    auto common_param = make_streaming_common_param(metadata, allocator);
+
+    if (index_name == INDEX_BRUTE_FORCE || index_name == INDEX_WARP) {
+        return create_streaming_index<BruteForce, BruteForceParameter>(index_param, common_param);
+    }
+    if (index_name == INDEX_HGRAPH) {
+        apply_hgraph_streaming_load_parameters(index_param, parameters);
+        return create_streaming_index<HGraph, HGraphParameter>(index_param, common_param);
+    }
+    if (index_name == INDEX_IVF) {
+        return create_streaming_index<IVF, IVFParameter>(index_param, common_param);
+    }
+    if (index_name == INDEX_PYRAMID) {
+        return create_streaming_index<Pyramid, PyramidParameters>(index_param, common_param);
+    }
+    if (index_name == INDEX_SINDI) {
+        return create_streaming_index<SINDI, SINDIParameter>(index_param, common_param);
+    }
+
+    LOG_ERROR_AND_RETURNS(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                          "streaming load does not support index type: ",
+                          index_name);
+}
+
+}  // namespace
 
 tl::expected<std::shared_ptr<Index>, Error>
 Factory::CreateIndex(const std::string& origin_name,
@@ -42,6 +258,155 @@ Factory::CreateIndex(const std::string& origin_name,
     }
     Engine e(resource.get());
     return e.CreateIndex(origin_name, parameters);
+}
+
+tl::expected<StreamingIndexMetadata, Error>
+Index::GetStreamingMetadata(std::istream& in_stream) {
+    try {
+        auto read_metadata = [](StreamReader& reader,
+                                uint64_t stream_begin) -> StreamingIndexMetadata {
+            auto stream_header = StreamHeader::ReadRaw(reader);
+
+            StreamingIndexMetadata result;
+            result.metadata_json = std::move(stream_header.metadata_string);
+
+            struct ManifestBlock {
+                std::string name;
+                uint32_t tag{0};
+                uint32_t version{0};
+                bool critical{false};
+                uint64_t payload_size{0};
+                bool has_payload_size{false};
+            };
+            std::vector<ManifestBlock> manifest_blocks;
+            auto manifest = stream_header.metadata->Get("block_manifest");
+            if (manifest.IsArray()) {
+                const auto* manifest_json = manifest.GetInnerJson();
+                manifest_blocks.reserve(manifest_json->size());
+                for (const auto& block_json : *manifest_json) {
+                    ManifestBlock block;
+                    block.name = block_json.value("name", std::string{});
+                    block.tag = block_json.value("tag", 0U);
+                    block.version = block_json.value("version", 0U);
+                    block.critical = block_json.value("critical", false);
+                    block.has_payload_size = block_json.contains("payload_size");
+                    block.payload_size = block_json.value("payload_size", uint64_t{0});
+                    manifest_blocks.emplace_back(std::move(block));
+                }
+            }
+
+            if (stream_header.metadata->EmptyIndex()) {
+                auto block_header = StreamBlockHeader::Read(reader);
+                if (!block_header.IsSectionEnd()) {
+                    throw VsagException(ErrorType::INVALID_BINARY,
+                                        "empty streaming body must end without blocks");
+                }
+                return result;
+            }
+
+            uint64_t manifest_index = 0;
+            while (true) {
+                const uint64_t header_offset = reader.GetCursor() - stream_begin;
+                auto block_header = StreamBlockHeader::Read(reader);
+                if (block_header.IsSectionEnd()) {
+                    break;
+                }
+
+                StreamingBlockLayout block;
+                block.name = StreamSerializationTagName(block_header.tag);
+                block.tag = block_header.tag;
+                block.version = block_header.block_version;
+                block.critical = block_header.IsCritical();
+                block.header_offset = header_offset;
+                block.payload_offset = reader.GetCursor() - stream_begin;
+                block.payload_size = block_header.value_len;
+
+                if (!manifest_blocks.empty()) {
+                    if (manifest_index >= static_cast<uint64_t>(manifest_blocks.size())) {
+                        throw VsagException(ErrorType::INVALID_BINARY,
+                                            "streaming body has more blocks than manifest");
+                    }
+                    const auto& manifest_block =
+                        manifest_blocks[static_cast<size_t>(manifest_index)];
+                    if (manifest_block.tag != block.tag ||
+                        manifest_block.version != block.version ||
+                        manifest_block.critical != block.critical) {
+                        throw VsagException(ErrorType::INVALID_BINARY,
+                                            "streaming body block does not match manifest");
+                    }
+                    if (manifest_block.has_payload_size && manifest_block.payload_size != 0 &&
+                        manifest_block.payload_size != block.payload_size) {
+                        throw VsagException(
+                            ErrorType::INVALID_BINARY,
+                            "streaming body block payload size does not match manifest");
+                    }
+                    if (!manifest_block.name.empty()) {
+                        block.name = manifest_block.name;
+                    }
+                }
+
+                result.blocks.emplace_back(std::move(block));
+                SkipBlockPayload(reader, block_header);
+                ++manifest_index;
+            }
+            if (!manifest_blocks.empty() && manifest_index != manifest_blocks.size()) {
+                throw VsagException(ErrorType::INVALID_BINARY,
+                                    "streaming body has fewer blocks than manifest");
+            }
+
+            return result;
+        };
+
+        const auto stream_pos = in_stream.tellg();
+        if (stream_pos == std::istream::pos_type(-1)) {
+            in_stream.clear();
+            ForwardStreamReader reader(in_stream);
+            return read_metadata(reader, 0);
+        }
+
+        IOStreamReader reader(in_stream);
+        return read_metadata(reader, reader.GetCursor());
+    } catch (const vsag::VsagException& e) {
+        LOG_ERROR_AND_RETURNS(e.error_.type, e.error_.message);
+    } catch (const std::bad_alloc& e) {
+        LOG_ERROR_AND_RETURNS(ErrorType::NO_ENOUGH_MEMORY, "not enough memory: ", e.what());
+    } catch (const std::exception& e) {
+        LOG_ERROR_AND_RETURNS(ErrorType::UNKNOWN_ERROR, "unknownError: ", e.what());
+    } catch (...) {
+        LOG_ERROR_AND_RETURNS(ErrorType::UNKNOWN_ERROR, "unknown error");
+    }
+}
+
+tl::expected<IndexPtr, Error>
+Index::Load(std::istream& in_stream, const LoadParameters& parameters, Allocator* allocator) {
+    try {
+        const auto parameter_string = parameters.Dump();
+        auto load_parameters =
+            JsonType::Parse(parameter_string.empty() ? "{}" : parameter_string, false);
+        CHECK_ARGUMENT(not load_parameters.IsDiscarded(),
+                       "streaming load parameters must be valid JSON");
+        CHECK_ARGUMENT(load_parameters.IsObject(),
+                       "streaming load parameters must be a JSON object");
+
+        ForwardStreamReader reader(in_stream);
+        auto metadata = StreamHeader::Read(reader);
+
+        auto index = create_streaming_index_from_metadata(metadata, parameter_string, allocator);
+        if (not index.has_value()) {
+            return tl::unexpected(index.error());
+        }
+
+        index.value().inner_index->LoadStreamingBody(reader, metadata, parameters);
+        return index.value().index;
+    } catch (const vsag::VsagException& e) {
+        LOG_ERROR_AND_RETURNS(e.error_.type, e.error_.message);
+    } catch (const std::bad_alloc& e) {
+        LOG_ERROR_AND_RETURNS(ErrorType::NO_ENOUGH_MEMORY, "not enough memory: ", e.what());
+    } catch (const std::exception& e) {
+        LOG_ERROR_AND_RETURNS(ErrorType::UNKNOWN_ERROR, "unknownError: ", e.what());
+    } catch (...) {
+        LOG_ERROR_AND_RETURNS(ErrorType::UNKNOWN_ERROR, "unknown error");
+    }
 }
 
 class LocalFileReader : public Reader {
@@ -115,6 +480,56 @@ private:
 std::shared_ptr<Reader>
 Factory::CreateLocalFileReader(const std::string& filename, int64_t base_offset, int64_t size) {
     return std::make_shared<LocalFileReader>(filename, base_offset, size);
+}
+
+class ReadFuncReader : public Reader {
+public:
+    ReadFuncReader(ReadFunc read_func, uint64_t base_offset, uint64_t size)
+        : read_func_(std::move(read_func)), base_offset_(base_offset), size_(size) {
+        if (!read_func_) {
+            throw std::runtime_error("ReadFuncReader: read_func is empty");
+        }
+    }
+
+    void
+    Read(uint64_t offset, uint64_t len, void* dest) override {
+        if (offset > size_ || len > size_ - offset) {
+            throw std::runtime_error("ReadFuncReader: read range is out of bounds");
+        }
+        std::lock_guard<std::mutex> lock(read_mutex_);
+        read_func_(base_offset_ + offset, len, dest);
+    }
+
+    void
+    AsyncRead(uint64_t offset, uint64_t len, void* dest, CallBack callback) override {
+        try {
+            this->Read(offset, len, dest);
+            callback(IOErrorCode::IO_SUCCESS, "success");
+        } catch (const std::exception& e) {
+            callback(IOErrorCode::IO_ERROR, e.what());
+        }
+    }
+
+    uint64_t
+    Size() const override {
+        return size_;
+    }
+
+private:
+    ReadFunc read_func_;
+    uint64_t base_offset_{0};
+    uint64_t size_{0};
+    std::mutex read_mutex_;
+};
+
+std::shared_ptr<Reader>
+Factory::CreateReadFuncReader(ReadFunc read_func, uint64_t size) {
+    return std::make_shared<ReadFuncReader>(std::move(read_func), 0, size);
+}
+
+std::shared_ptr<Reader>
+Factory::CreateReadFuncReader(ReadFunc read_func, uint64_t base_offset, uint64_t size) {
+    return std::make_shared<ReadFuncReader>(std::move(read_func), base_offset, size);
 }
 
 }  // namespace vsag

--- a/src/index/index_impl.h
+++ b/src/index/index_impl.h
@@ -181,6 +181,12 @@ public:
         SAFE_CALL(this->inner_index_->Deserialize(in_stream));
     }
 
+    tl::expected<void, Error>
+    DeserializeStreaming(std::istream& in_stream) override {
+        CHECK_DESERIALIZE_EMPTY_INDEX;
+        SAFE_CALL(this->inner_index_->DeserializeStreaming(in_stream));
+    }
+
     [[nodiscard]] uint64_t
     EstimateMemory(uint64_t num_elements) const override {
         return this->inner_index_->EstimateMemory(num_elements);
@@ -440,6 +446,11 @@ public:
     tl::expected<void, Error>
     Serialize(std::ostream& out_stream) override {
         SAFE_CALL(this->inner_index_->Serialize(out_stream));
+    }
+
+    tl::expected<void, Error>
+    SerializeStreaming(std::ostream& out_stream) const override {
+        SAFE_CALL(this->inner_index_->SerializeStreaming(out_stream));
     }
 
     [[nodiscard]] tl::expected<DatasetPtr, Error>

--- a/src/json_wrapper.cpp
+++ b/src/json_wrapper.cpp
@@ -159,6 +159,11 @@ JsonWrapper::SetFloat(float value) {
 }
 
 void
+JsonWrapper::SetDouble(double value) {
+    (*json_) = value;
+}
+
+void
 JsonWrapper::SetBool(bool value) {
     (*json_) = value;
 }

--- a/src/json_wrapper.h
+++ b/src/json_wrapper.h
@@ -95,6 +95,9 @@ public:
     SetFloat(float value);
 
     void
+    SetDouble(double value);
+
+    void
     SetBool(bool value);
 
     template <class T>

--- a/src/load_parameters.cpp
+++ b/src/load_parameters.cpp
@@ -1,0 +1,148 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "vsag/load_parameters.h"
+
+#include <utility>
+
+#include "json_types.h"
+
+namespace vsag {
+
+struct LoadParameters::Impl {
+    JsonType json{JsonType::Parse("{}")};
+    ReaderSet readers;
+    std::string raw_json{"{}"};
+    bool valid_json{true};
+    bool mutated{false};
+};
+
+LoadParameters::LoadParameters() : impl_(std::make_shared<Impl>()) {
+}
+
+LoadParameters::LoadParameters(const char* json_string)
+    : LoadParameters(json_string == nullptr ? std::string{} : std::string(json_string)) {
+}
+
+LoadParameters::LoadParameters(const std::string& json_string) : impl_(std::make_shared<Impl>()) {
+    impl_->raw_json = json_string.empty() ? "{}" : json_string;
+    impl_->json = JsonType::Parse(impl_->raw_json, false);
+    impl_->valid_json = !impl_->json.IsDiscarded() && impl_->json.IsObject();
+    if (!impl_->valid_json) {
+        impl_->json = JsonType::Parse("{}");
+    }
+}
+
+LoadParameters::LoadParameters(const LoadParameters& other)
+    : impl_(std::make_shared<Impl>(*other.impl_)) {
+}
+
+LoadParameters&
+LoadParameters::operator=(const LoadParameters& other) {
+    if (this != &other) {
+        impl_ = std::make_shared<Impl>(*other.impl_);
+    }
+    return *this;
+}
+
+LoadParameters::~LoadParameters() = default;
+
+LoadParameters&
+LoadParameters::Set(const std::string& key, const std::string& value) {
+    impl_->mutated = true;
+    impl_->valid_json = true;
+    impl_->json[key].SetString(value);
+    return *this;
+}
+
+LoadParameters&
+LoadParameters::Set(const std::string& key, const char* value) {
+    impl_->mutated = true;
+    impl_->valid_json = true;
+    impl_->json[key].SetString(value == nullptr ? "" : value);
+    return *this;
+}
+
+LoadParameters&
+LoadParameters::Set(const std::string& key, bool value) {
+    impl_->mutated = true;
+    impl_->valid_json = true;
+    impl_->json[key].SetBool(value);
+    return *this;
+}
+
+LoadParameters&
+LoadParameters::Set(const std::string& key, int64_t value) {
+    impl_->mutated = true;
+    impl_->valid_json = true;
+    impl_->json[key].SetInt64(value);
+    return *this;
+}
+
+LoadParameters&
+LoadParameters::Set(const std::string& key, uint64_t value) {
+    impl_->mutated = true;
+    impl_->valid_json = true;
+    impl_->json[key].SetUint64(value);
+    return *this;
+}
+
+LoadParameters&
+LoadParameters::Set(const std::string& key, double value) {
+    impl_->mutated = true;
+    impl_->valid_json = true;
+    impl_->json[key].SetDouble(value);
+    return *this;
+}
+
+LoadParameters&
+LoadParameters::Set(const std::string& key, const LoadParameters& value) {
+    impl_->mutated = true;
+    impl_->valid_json = true;
+    auto nested_json = JsonType::Parse(value.Dump(), false);
+    if (nested_json.IsDiscarded()) {
+        nested_json = JsonType::Parse("{}");
+    }
+    impl_->json[key].SetJson(nested_json);
+    return *this;
+}
+
+LoadParameters&
+LoadParameters::SetReader(const std::string& key, ReaderPtr reader) {
+    impl_->mutated = true;
+    impl_->valid_json = true;
+    impl_->readers.Set(key, std::move(reader));
+    impl_->json[key].SetString("<Reader>");
+    return *this;
+}
+
+bool
+LoadParameters::HasReader(const std::string& key) const {
+    return impl_->readers.Contains(key);
+}
+
+ReaderPtr
+LoadParameters::GetReader(const std::string& key) const {
+    return impl_->readers.Get(key);
+}
+
+std::string
+LoadParameters::Dump() const {
+    if (!impl_->valid_json && !impl_->mutated) {
+        return impl_->raw_json;
+    }
+    return impl_->json.Dump();
+}
+
+}  // namespace vsag

--- a/src/storage/serialization.cpp
+++ b/src/storage/serialization.cpp
@@ -16,38 +16,114 @@
 #include "serialization.h"
 
 #include <cstring>
-#include <sstream>
 
-namespace {
-constexpr uint64_t FOOTER_TRAILER_SIZE = 16;
-constexpr uint64_t FOOTER_MIN_SIZE = 36;
-}  // namespace
+#include "vsag_exception.h"
 
 namespace vsag {
 
+namespace {
+
+constexpr uint64_t FOOTER_TRAILER_SIZE = 16;
+constexpr uint64_t FOOTER_MIN_SIZE = 36;
+
+}  // namespace
+
 void
 Metadata::make_sure_metadata_not_null() {
-    time_t now = time(nullptr);
-    tm* ltm = localtime(&now);
+    metadata_["_update_time"].SetString("1970-01-01 00:00:00");
+}
 
-    int32_t year = 1900 + ltm->tm_year;
-    int32_t month = 1 + ltm->tm_mon;
-    int32_t day = ltm->tm_mday;
-    int32_t hour = ltm->tm_hour;
-    int32_t min = ltm->tm_min;
-    int32_t sec = ltm->tm_sec;
+uint32_t
+StreamHeader::InitialChecksum() {
+    return 0xFFFFFFFF;
+}
 
-    std::stringstream ss;
-    ss << year << "-" << (month < 10 ? "0" : "") << month << "-" << (day < 10 ? "0" : "") << day
-       << " " << (hour < 10 ? "0" : "") << hour << ":" << (min < 10 ? "0" : "") << min << ":"
-       << (sec < 10 ? "0" : "") << sec;
-    std::string formatted_datetime = ss.str();
+uint32_t
+StreamHeader::UpdateChecksum(uint32_t crc, std::string_view bytes) {
+    constexpr uint32_t polynomial = 0xEDB88320;
+    for (const char& byte : bytes) {
+        crc ^= static_cast<uint8_t>(byte);
+        for (uint64_t j = 0; j < 8; ++j) {
+            crc = (crc >> 1) ^ ((crc & 1) == 1 ? polynomial : 0);
+        }
+    }
+    return crc;
+}
 
-    // FIXME(wxyu): Index merge depends on model comparison, timestamp in footer may cause the
-    // two models not to be equal, remove this line after supporting comparing two indexes in memory
-    formatted_datetime = "1970-01-01 00:00:00";
+uint32_t
+StreamHeader::FinalizeChecksum(uint32_t crc) {
+    return crc ^ 0xFFFFFFFF;
+}
 
-    metadata_["_update_time"].SetString(formatted_datetime);
+uint32_t
+StreamHeader::CalculateChecksum(std::string_view bytes) {
+    return StreamHeader::FinalizeChecksum(
+        StreamHeader::UpdateChecksum(StreamHeader::InitialChecksum(), bytes));
+}
+
+void
+StreamHeader::Write(StreamWriter& writer, const MetadataPtr& metadata) {
+    writer.Write(SERIAL_STREAM_MAGIC, 8);
+    StreamWriter::WriteObj(writer, SERIAL_STREAM_FORMAT_MAJOR);
+    StreamWriter::WriteObj(writer, SERIAL_STREAM_FORMAT_MINOR);
+
+    auto metadata_string = metadata->ToString();
+    const uint64_t metadata_len = metadata_string.size();
+    if (metadata_len > STREAM_HEADER_MAX_METADATA_LEN) {
+        throw VsagException(ErrorType::INVALID_BINARY,
+                            "streaming serialization metadata is too large");
+    }
+    StreamWriter::WriteObj(writer, metadata_len);
+    writer.Write(metadata_string.c_str(), metadata_len);
+    const uint32_t checksum = StreamHeader::CalculateChecksum(metadata_string);
+    StreamWriter::WriteObj(writer, checksum);
+}
+
+MetadataPtr
+StreamHeader::Read(StreamReader& reader) {
+    return StreamHeader::ReadRaw(reader).metadata;
+}
+
+StreamHeaderData
+StreamHeader::ReadRaw(StreamReader& reader) {
+    char magic[8] = {};
+    reader.Read(magic, 8);
+    if (std::memcmp(magic, SERIAL_STREAM_MAGIC, 8) != 0) {
+        throw VsagException(ErrorType::INVALID_BINARY, "invalid streaming serialization magic");
+    }
+
+    uint16_t major = 0;
+    uint16_t minor = 0;
+    StreamReader::ReadObj(reader, major);
+    StreamReader::ReadObj(reader, minor);
+    if (major != SERIAL_STREAM_FORMAT_MAJOR) {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "unsupported streaming serialization major version");
+    }
+
+    uint64_t metadata_len = 0;
+    StreamReader::ReadObj(reader, metadata_len);
+    if (metadata_len > STREAM_HEADER_MAX_METADATA_LEN) {
+        throw VsagException(ErrorType::INVALID_BINARY,
+                            "streaming serialization metadata is too large");
+    }
+    std::string metadata_string(metadata_len, '\0');
+    reader.Read(metadata_string.data(), metadata_len);
+
+    uint32_t checksum = 0;
+    StreamReader::ReadObj(reader, checksum);
+    if (StreamHeader::CalculateChecksum(metadata_string) != checksum) {
+        throw VsagException(ErrorType::INVALID_BINARY,
+                            "streaming serialization metadata checksum mismatch");
+    }
+
+    (void)minor;
+    auto metadata_json = JsonType::Parse(metadata_string, false);
+    if (metadata_json.IsDiscarded() || !metadata_json.IsObject()) {
+        throw VsagException(ErrorType::INVALID_BINARY,
+                            "streaming serialization metadata must be a JSON object");
+    }
+    return {std::make_shared<Metadata>(metadata_json), std::move(metadata_string)};
 }
 
 FooterPtr

--- a/src/storage/serialization.h
+++ b/src/storage/serialization.h
@@ -21,6 +21,7 @@
 #include <iostream>
 #include <memory>
 #include <string>
+#include <string_view>
 
 #include "../typing.h"
 #include "impl/logger/logger.h"
@@ -32,6 +33,8 @@
 #include "vsag/constants.h"
 
 namespace vsag {
+
+constexpr uint64_t STREAM_HEADER_MAX_METADATA_LEN = 16ULL * 1024ULL * 1024ULL;
 
 // Metadata is using to describe how is the index create
 DEFINE_POINTER(Metadata);
@@ -128,6 +131,35 @@ private:
     JsonType metadata_;
 };
 
+struct StreamHeaderData {
+    MetadataPtr metadata;
+    std::string metadata_string;
+};
+
+class StreamHeader {
+public:
+    static MetadataPtr
+    Read(StreamReader& reader);
+
+    static StreamHeaderData
+    ReadRaw(StreamReader& reader);
+
+    static void
+    Write(StreamWriter& writer, const MetadataPtr& metadata);
+
+    static uint32_t
+    InitialChecksum();
+
+    static uint32_t
+    UpdateChecksum(uint32_t crc, std::string_view bytes);
+
+    static uint32_t
+    FinalizeChecksum(uint32_t crc);
+
+    static uint32_t
+    CalculateChecksum(std::string_view bytes);
+};
+
 // Footer is a wrapper of metadata, only used in all-in-one serialize format
 DEFINE_POINTER(Footer);
 class Footer {
@@ -156,7 +188,7 @@ public:
     virtual ~Footer() = default;
 
 private:
-    // TODO(wxyu): optimize performance
+    // Keep this byte-for-byte compatible with the legacy footer checksum.
     static uint32_t
     calculate_checksum(std::string_view bytes) {
         const uint32_t polynomial = 0xEDB88320;

--- a/src/storage/serialization_tags.h
+++ b/src/storage/serialization_tags.h
@@ -1,0 +1,147 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+#include "typing.h"
+#include "vsag/constants.h"
+
+namespace vsag {
+
+enum class StreamSerializationTag : uint32_t {
+    SECTION_END = 0,
+    LABEL_TABLE = 1,
+    BASE_CODES = 2,
+    ATTRIBUTE_FILTER = 3,
+    BOTTOM_GRAPH = 4,
+    HIGH_PRECISION_CODES = 5,
+    ROUTE_GRAPHS = 6,
+    EXTRA_INFO = 7,
+    RAW_VECTOR = 8,
+    IVF_BUCKET = 9,
+    IVF_PARTITION_STRATEGY = 10,
+    SINDI_WINDOWS = 11,
+    SINDI_RERANK_INDEX = 12,
+    SINDI_TERM_ID_MAPPER = 13,
+    PYRAMID_HIERARCHIES = 14,
+};
+
+inline const char*
+StreamSerializationTagName(uint32_t tag) {
+    switch (static_cast<StreamSerializationTag>(tag)) {
+        case StreamSerializationTag::SECTION_END:
+            return "section_end";
+        case StreamSerializationTag::LABEL_TABLE:
+            return "label_table";
+        case StreamSerializationTag::BASE_CODES:
+            return "base_codes";
+        case StreamSerializationTag::ATTRIBUTE_FILTER:
+            return "attribute_filter";
+        case StreamSerializationTag::BOTTOM_GRAPH:
+            return "bottom_graph";
+        case StreamSerializationTag::HIGH_PRECISION_CODES:
+            return "high_precision_codes";
+        case StreamSerializationTag::ROUTE_GRAPHS:
+            return "route_graphs";
+        case StreamSerializationTag::EXTRA_INFO:
+            return "extra_info";
+        case StreamSerializationTag::RAW_VECTOR:
+            return "raw_vector";
+        case StreamSerializationTag::IVF_BUCKET:
+            return "ivf_bucket";
+        case StreamSerializationTag::IVF_PARTITION_STRATEGY:
+            return "ivf_partition_strategy";
+        case StreamSerializationTag::SINDI_WINDOWS:
+            return "sindi_windows";
+        case StreamSerializationTag::SINDI_RERANK_INDEX:
+            return "sindi_rerank_index";
+        case StreamSerializationTag::SINDI_TERM_ID_MAPPER:
+            return "sindi_term_id_mapper";
+        case StreamSerializationTag::PYRAMID_HIERARCHIES:
+            return "pyramid_hierarchies";
+    }
+    return "unknown";
+}
+
+inline bool
+StreamSerializationTagCritical(uint32_t tag) {
+    switch (static_cast<StreamSerializationTag>(tag)) {
+        case StreamSerializationTag::SECTION_END:
+            return false;
+        case StreamSerializationTag::LABEL_TABLE:
+        case StreamSerializationTag::BASE_CODES:
+        case StreamSerializationTag::BOTTOM_GRAPH:
+        case StreamSerializationTag::ROUTE_GRAPHS:
+        case StreamSerializationTag::IVF_BUCKET:
+        case StreamSerializationTag::IVF_PARTITION_STRATEGY:
+        case StreamSerializationTag::HIGH_PRECISION_CODES:
+        case StreamSerializationTag::SINDI_WINDOWS:
+        case StreamSerializationTag::SINDI_RERANK_INDEX:
+        case StreamSerializationTag::SINDI_TERM_ID_MAPPER:
+        case StreamSerializationTag::PYRAMID_HIERARCHIES:
+            return true;
+        case StreamSerializationTag::ATTRIBUTE_FILTER:
+        case StreamSerializationTag::EXTRA_INFO:
+        case StreamSerializationTag::RAW_VECTOR:
+            return false;
+    }
+    return false;
+}
+
+inline constexpr uint32_t kStreamSerializationBlockVersionV1 = 1;
+
+inline uint32_t
+StreamSerializationBlockCurrentVersion(uint32_t tag) {
+    switch (static_cast<StreamSerializationTag>(tag)) {
+        case StreamSerializationTag::SECTION_END:
+        case StreamSerializationTag::LABEL_TABLE:
+        case StreamSerializationTag::BASE_CODES:
+        case StreamSerializationTag::ATTRIBUTE_FILTER:
+        case StreamSerializationTag::BOTTOM_GRAPH:
+        case StreamSerializationTag::HIGH_PRECISION_CODES:
+        case StreamSerializationTag::ROUTE_GRAPHS:
+        case StreamSerializationTag::EXTRA_INFO:
+        case StreamSerializationTag::RAW_VECTOR:
+        case StreamSerializationTag::IVF_BUCKET:
+        case StreamSerializationTag::IVF_PARTITION_STRATEGY:
+        case StreamSerializationTag::SINDI_WINDOWS:
+        case StreamSerializationTag::SINDI_RERANK_INDEX:
+        case StreamSerializationTag::SINDI_TERM_ID_MAPPER:
+        case StreamSerializationTag::PYRAMID_HIERARCHIES:
+            return kStreamSerializationBlockVersionV1;
+    }
+    return kStreamSerializationBlockVersionV1;
+}
+
+inline bool
+StreamSerializationBlockVersionSupported(uint32_t tag, uint32_t version) {
+    return version == StreamSerializationBlockCurrentVersion(tag);
+}
+
+inline void
+AppendStreamingManifestBlock(
+    JsonType& manifest, uint32_t tag, uint32_t version, bool critical, uint64_t payload_size = 0) {
+    JsonType block;
+    block["tag"].SetInt(tag);
+    block["name"].SetString(StreamSerializationTagName(tag));
+    block["version"].SetInt(version);
+    block["critical"].SetBool(critical);
+    block["payload_size"].SetUint64(payload_size);
+    manifest.AppendJson(block);
+}
+
+}  // namespace vsag

--- a/src/storage/stream_reader.cpp
+++ b/src/storage/stream_reader.cpp
@@ -17,9 +17,12 @@
 
 #include <fmt/format.h>
 
+#include <algorithm>
+#include <array>
 #include <cstdint>
 #include <fstream>
 #include <iostream>
+#include <limits>
 
 #include "footer.h"
 #include "impl/logger/logger.h"
@@ -27,6 +30,18 @@
 #include "vsag_exception.h"
 
 namespace vsag {
+
+void
+SkipForward(StreamReader& reader, uint64_t size) {
+    constexpr uint64_t buffer_size = 8192;
+    std::array<char, buffer_size> buffer{};
+    uint64_t remaining = size;
+    while (remaining > 0) {
+        uint64_t read_size = std::min<uint64_t>(remaining, buffer_size);
+        reader.Read(buffer.data(), read_size);
+        remaining -= read_size;
+    }
+}
 
 SliceStreamReader
 StreamReader::Slice(uint64_t begin, uint64_t length) {
@@ -62,7 +77,7 @@ ReadFuncStreamReader::ReadFuncStreamReader(std::function<void(uint64_t, uint64_t
 }
 
 ReadFuncStreamReader::~ReadFuncStreamReader() {
-    vsag::logger::info("ReadFuncStreamReader io count ({}) in deserialize process", io_count_);
+    vsag::logger::debug("ReadFuncStreamReader io count ({}) in deserialize process", io_count_);
 }
 
 void
@@ -101,6 +116,48 @@ IOStreamReader::IOStreamReader(std::istream& istream) : istream_(istream) {
 
 IOStreamReader::~IOStreamReader() {
     vsag::logger::info("IOStreamReader io count ({}) in deserialize process", io_count_);
+}
+
+void
+ForwardStreamReader::Read(char* data, uint64_t size) {
+    if (size == 0) {
+        return;
+    }
+    if (size > static_cast<uint64_t>(std::numeric_limits<std::streamsize>::max())) {
+        throw VsagException(ErrorType::READ_ERROR, "ForwardStreamReader read size is too large");
+    }
+    const auto stream_size = static_cast<std::streamsize>(size);
+    istream_.read(data, stream_size);
+    if (istream_.fail()) {
+        auto bytes_read = istream_.gcount();
+        throw vsag::VsagException(
+            vsag::ErrorType::READ_ERROR,
+            fmt::format(
+                "Attempted to read: {} bytes. Bytes read before failure: {}.", size, bytes_read));
+    }
+    cursor_ += size;
+    io_count_++;
+}
+
+void
+ForwardStreamReader::Seek(uint64_t cursor) {
+    (void)cursor;
+    throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                        "ForwardStreamReader does not support seek");
+}
+
+uint64_t
+ForwardStreamReader::GetCursor() const {
+    return cursor_;
+}
+
+uint64_t
+ForwardStreamReader::Length() {
+    throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                        "ForwardStreamReader does not support length");
+}
+
+ForwardStreamReader::ForwardStreamReader(std::istream& istream) : istream_(istream) {
 }
 
 uint64_t
@@ -219,6 +276,47 @@ SliceStreamReader::SliceStreamReader(StreamReader* reader, uint64_t length)
     : StreamReader(length), reader_impl_(reader) {
     begin_ = reader->GetCursor();
     // vsag::logger::trace("SliceReader [{}, {})", begin_, begin_ + length_);
+}
+
+void
+BoundedForwardReader::Read(char* data, uint64_t size) {
+    if (cursor_ > length_ || size > length_ - cursor_) {
+        throw vsag::VsagException(vsag::ErrorType::READ_ERROR,
+                                  "BoundedForwardReader: read exceeds block boundary");
+    }
+    reader_impl_->Read(data, size);
+    cursor_ += size;
+}
+
+void
+BoundedForwardReader::Seek(uint64_t cursor) {
+    (void)cursor;
+    throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                        "BoundedForwardReader does not support seek");
+}
+
+uint64_t
+BoundedForwardReader::GetCursor() const {
+    return cursor_;
+}
+
+uint64_t
+BoundedForwardReader::Length() {
+    return length_;
+}
+
+void
+BoundedForwardReader::SkipRemaining() {
+    if (cursor_ > length_) {
+        throw vsag::VsagException(vsag::ErrorType::READ_ERROR,
+                                  "BoundedForwardReader: cursor exceeds block boundary");
+    }
+    SkipForward(*reader_impl_, length_ - cursor_);
+    cursor_ = length_;
+}
+
+BoundedForwardReader::BoundedForwardReader(StreamReader* reader, uint64_t length)
+    : StreamReader(length), reader_impl_(reader) {
 }
 
 }  // namespace vsag

--- a/src/storage/stream_reader.h
+++ b/src/storage/stream_reader.h
@@ -112,6 +112,9 @@ private:
     std::stack<uint64_t> positions_;
 };
 
+void
+SkipForward(StreamReader& reader, uint64_t size);
+
 class ReadFuncStreamReader : public StreamReader {
 public:
     void
@@ -153,6 +156,28 @@ public:
 
 private:
     std::istream& istream_;
+};
+
+class ForwardStreamReader : public StreamReader {
+public:
+    void
+    Read(char* data, uint64_t size) override;
+
+    void
+    Seek(uint64_t cursor) override;
+
+    [[nodiscard]] uint64_t
+    GetCursor() const override;
+
+    [[nodiscard]] uint64_t
+    Length() override;
+
+public:
+    explicit ForwardStreamReader(std::istream& istream);
+
+private:
+    std::istream& istream_;
+    uint64_t cursor_{0};
 };
 
 class BufferStreamReader : public StreamReader {
@@ -208,6 +233,33 @@ public:
 private:
     StreamReader* const reader_impl_{nullptr};
     uint64_t begin_{0};
+    uint64_t cursor_{0};
+};
+
+class BoundedForwardReader : public StreamReader {
+public:
+    void
+    Read(char* data, uint64_t size) override;
+
+    void
+    Seek(uint64_t cursor) override;
+
+    [[nodiscard]] uint64_t
+    GetCursor() const override;
+
+    [[nodiscard]] uint64_t
+    Length() override;
+
+    void
+    SkipRemaining();
+
+public:
+    BoundedForwardReader(StreamReader* reader, uint64_t length);
+
+    ~BoundedForwardReader() = default;
+
+private:
+    StreamReader* const reader_impl_{nullptr};
     uint64_t cursor_{0};
 };
 

--- a/src/storage/stream_writer.cpp
+++ b/src/storage/stream_writer.cpp
@@ -39,6 +39,12 @@ IOStreamWriter::Write(const char* data, uint64_t size) {
     bytes_written_ += size;
 }
 
+void
+CountingStreamWriter::Write(const char* data, uint64_t size) {
+    (void)data;
+    bytes_written_ += size;
+}
+
 WriteFuncStreamWriter::WriteFuncStreamWriter(
     std::function<void(uint64_t, uint64_t, void*)> writeFunc, uint64_t cursor)
     : writeFunc_(std::move(writeFunc)), cursor_(cursor) {

--- a/src/storage/stream_writer.h
+++ b/src/storage/stream_writer.h
@@ -96,7 +96,12 @@ public:
 
 private:
     std::ostream& ostream_;
-    uint64_t written_bytes_{0};
+};
+
+class CountingStreamWriter : public StreamWriter {
+public:
+    void
+    Write(const char* data, uint64_t size) override;
 };
 
 class WriteFuncStreamWriter : public StreamWriter {

--- a/src/storage/streaming_serialization_test.cpp
+++ b/src/storage/streaming_serialization_test.cpp
@@ -1,0 +1,277 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <limits>
+#include <sstream>
+
+#include "serialization.h"
+#include "serialization_tags.h"
+#include "tlv_section.h"
+#include "unittest.h"
+#include "vsag/options.h"
+
+TEST_CASE("StreamHeader", "[ut][streaming_serialization]") {
+    auto metadata = std::make_shared<vsag::Metadata>();
+    metadata->Set("index_name", std::string("brute_force"));
+    metadata->SetEmptyIndex(false);
+
+    std::stringstream stream;
+    vsag::IOStreamWriter writer(stream);
+    vsag::StreamHeader::Write(writer, metadata);
+
+    auto bytes = stream.str();
+    REQUIRE(bytes.substr(0, 8) == vsag::SERIAL_STREAM_MAGIC);
+
+    vsag::ForwardStreamReader reader(stream);
+    auto parsed = vsag::StreamHeader::Read(reader);
+    REQUIRE(parsed->Get("index_name").GetString() == "brute_force");
+    REQUIRE_FALSE(parsed->EmptyIndex());
+}
+
+TEST_CASE("StreamHeader rejects oversized metadata", "[ut][streaming_serialization]") {
+    std::stringstream stream;
+    vsag::IOStreamWriter writer(stream);
+    writer.Write(vsag::SERIAL_STREAM_MAGIC, 8);
+    vsag::StreamWriter::WriteObj(writer, vsag::SERIAL_STREAM_FORMAT_MAJOR);
+    vsag::StreamWriter::WriteObj(writer, vsag::SERIAL_STREAM_FORMAT_MINOR);
+    uint64_t oversized_metadata_len = 16ULL * 1024ULL * 1024ULL + 1ULL;
+    vsag::StreamWriter::WriteObj(writer, oversized_metadata_len);
+
+    vsag::ForwardStreamReader reader(stream);
+    REQUIRE_THROWS(vsag::StreamHeader::Read(reader));
+}
+
+TEST_CASE("StreamHeader rejects non-object metadata", "[ut][streaming_serialization]") {
+    const std::string metadata_string = "[]";
+    std::stringstream stream;
+    vsag::IOStreamWriter writer(stream);
+    writer.Write(vsag::SERIAL_STREAM_MAGIC, 8);
+    vsag::StreamWriter::WriteObj(writer, vsag::SERIAL_STREAM_FORMAT_MAJOR);
+    vsag::StreamWriter::WriteObj(writer, vsag::SERIAL_STREAM_FORMAT_MINOR);
+    vsag::StreamWriter::WriteObj(writer, static_cast<uint64_t>(metadata_string.size()));
+    writer.Write(metadata_string.data(), metadata_string.size());
+    vsag::StreamWriter::WriteObj(writer, vsag::StreamHeader::CalculateChecksum(metadata_string));
+
+    vsag::ForwardStreamReader reader(stream);
+    REQUIRE_THROWS(vsag::StreamHeader::Read(reader));
+}
+
+TEST_CASE("StreamBlockHeader rejects chunked payload sentinel", "[ut][streaming_serialization]") {
+    std::stringstream stream;
+    vsag::IOStreamWriter writer(stream);
+    vsag::StreamBlockHeader header;
+    header.tag = 42;
+    header.block_version = vsag::kStreamSerializationBlockVersionV1;
+    header.value_len = std::numeric_limits<uint64_t>::max();
+    vsag::StreamBlockHeader::Write(writer, header);
+
+    vsag::ForwardStreamReader reader(stream);
+    REQUIRE_THROWS(vsag::StreamBlockHeader::Read(reader));
+}
+
+TEST_CASE("StreamBlockHeader accepts payload checksum", "[ut][streaming_serialization]") {
+    std::stringstream stream;
+    vsag::IOStreamWriter writer(stream);
+    vsag::StreamBlockHeader header;
+    header.tag = 42;
+    header.block_version = vsag::kStreamSerializationBlockVersionV1;
+    header.value_len = 3;
+    header.payload_checksum = vsag::StreamHeader::CalculateChecksum("abc");
+    vsag::StreamBlockHeader::Write(writer, header);
+
+    vsag::ForwardStreamReader reader(stream);
+    auto parsed = vsag::StreamBlockHeader::Read(reader);
+    REQUIRE(parsed.payload_checksum == header.payload_checksum);
+}
+
+TEST_CASE("ReadSeekableBlockPayload rejects checksum mismatch", "[ut][streaming_serialization]") {
+    std::stringstream stream;
+    vsag::IOStreamWriter writer(stream);
+    vsag::WriteStreamingBlock(
+        writer, 42, true, [](vsag::StreamWriter& block_writer) { block_writer.Write("abc", 3); });
+
+    auto bytes = stream.str();
+    bytes.back() = 'd';
+    std::stringstream corrupted(bytes);
+    vsag::ForwardStreamReader reader(corrupted);
+    auto header = vsag::StreamBlockHeader::Read(reader);
+    REQUIRE_THROWS(
+        vsag::ReadSeekableBlockPayload(reader, header, [](vsag::StreamReader& block_reader) {
+            char buffer[3] = {};
+            block_reader.Read(buffer, 3);
+        }));
+}
+
+TEST_CASE("ReadSeekableBlockPayload rejects cursor past small payload",
+          "[ut][streaming_serialization]") {
+    std::stringstream stream;
+    vsag::IOStreamWriter writer(stream);
+    vsag::WriteStreamingBlock(
+        writer, 42, true, [](vsag::StreamWriter& block_writer) { block_writer.Write("abc", 3); });
+
+    vsag::ForwardStreamReader reader(stream);
+    auto header = vsag::StreamBlockHeader::Read(reader);
+    REQUIRE_THROWS(vsag::ReadSeekableBlockPayload(
+        reader, header, [](vsag::StreamReader& block_reader) { block_reader.Seek(4); }));
+}
+
+TEST_CASE("ReadSeekableBlockPayload spills oversized payload", "[ut][streaming_serialization]") {
+    const auto origin_size = vsag::Options::Instance().block_size_limit();
+    vsag::Options::Instance().set_block_size_limit(256UL * 1024);
+
+    std::string payload(512UL * 1024, 'x');
+    payload[384UL * 1024] = 'y';
+    std::stringstream stream;
+    vsag::IOStreamWriter writer(stream);
+    vsag::WriteStreamingBlock(writer, 42, true, [&payload](vsag::StreamWriter& block_writer) {
+        block_writer.Write(payload.data(), payload.size());
+    });
+
+    vsag::ForwardStreamReader reader(stream);
+    auto header = vsag::StreamBlockHeader::Read(reader);
+    vsag::ReadSeekableBlockPayload(reader, header, [](vsag::StreamReader& block_reader) {
+        block_reader.Seek(384UL * 1024);
+        char value = 0;
+        block_reader.Read(&value, 1);
+        REQUIRE(value == 'y');
+    });
+
+    vsag::Options::Instance().set_block_size_limit(origin_size);
+}
+
+TEST_CASE("ReadSeekableBlockPayload rejects cursor past spilled payload",
+          "[ut][streaming_serialization]") {
+    const auto origin_size = vsag::Options::Instance().block_size_limit();
+    vsag::Options::Instance().set_block_size_limit(256UL * 1024);
+
+    std::string payload(512UL * 1024, 'x');
+    std::stringstream stream;
+    vsag::IOStreamWriter writer(stream);
+    vsag::WriteStreamingBlock(writer, 42, true, [&payload](vsag::StreamWriter& block_writer) {
+        block_writer.Write(payload.data(), payload.size());
+    });
+
+    vsag::ForwardStreamReader reader(stream);
+    auto header = vsag::StreamBlockHeader::Read(reader);
+    REQUIRE_THROWS(vsag::ReadSeekableBlockPayload(
+        reader, header, [&payload](vsag::StreamReader& block_reader) {
+            block_reader.Seek(payload.size() + 1);
+        }));
+
+    vsag::Options::Instance().set_block_size_limit(origin_size);
+}
+
+TEST_CASE("ValidateAndSkipBlockPayload", "[ut][streaming_serialization]") {
+    std::stringstream stream;
+    vsag::IOStreamWriter writer(stream);
+    vsag::WriteStreamingBlock(
+        writer, 42, true, [](vsag::StreamWriter& block_writer) { block_writer.Write("abc", 3); });
+    vsag::StreamBlockHeader::WriteSectionEnd(writer);
+
+    vsag::ForwardStreamReader reader(stream);
+    auto header = vsag::StreamBlockHeader::Read(reader);
+    vsag::ValidateAndSkipBlockPayload(reader, header);
+    auto end = vsag::StreamBlockHeader::Read(reader);
+    REQUIRE(end.IsSectionEnd());
+}
+
+TEST_CASE("ValidateAndSkipBlockPayload rejects checksum mismatch",
+          "[ut][streaming_serialization]") {
+    std::stringstream stream;
+    vsag::IOStreamWriter writer(stream);
+    vsag::WriteStreamingBlock(
+        writer, 42, true, [](vsag::StreamWriter& block_writer) { block_writer.Write("abc", 3); });
+
+    auto bytes = stream.str();
+    bytes.back() = 'd';
+    std::stringstream corrupted(bytes);
+    vsag::ForwardStreamReader reader(corrupted);
+    auto header = vsag::StreamBlockHeader::Read(reader);
+    REQUIRE_THROWS(vsag::ValidateAndSkipBlockPayload(reader, header));
+}
+
+TEST_CASE("StreamBlockHeader", "[ut][streaming_serialization]") {
+    std::stringstream stream;
+    vsag::IOStreamWriter writer(stream);
+    vsag::StreamBlockHeader header;
+    header.tag = 42;
+    header.block_version = vsag::kStreamSerializationBlockVersionV1;
+    header.flags = vsag::StreamBlockHeader::kCriticalFlag;
+    header.value_len = 3;
+    vsag::StreamBlockHeader::Write(writer, header);
+    writer.Write("abc", 3);
+    vsag::StreamBlockHeader::WriteSectionEnd(writer);
+
+    vsag::ForwardStreamReader reader(stream);
+    auto parsed = vsag::StreamBlockHeader::Read(reader);
+    REQUIRE(parsed.tag == 42);
+    REQUIRE(parsed.IsCritical());
+    vsag::SkipBlockPayload(reader, parsed);
+    auto end = vsag::StreamBlockHeader::Read(reader);
+    REQUIRE(end.IsSectionEnd());
+}
+
+TEST_CASE("SkipBlockPayload uses seekable reader", "[ut][streaming_serialization]") {
+    std::stringstream stream;
+    vsag::IOStreamWriter writer(stream);
+    vsag::StreamBlockHeader header;
+    header.tag = 42;
+    header.block_version = vsag::kStreamSerializationBlockVersionV1;
+    header.value_len = 3;
+    vsag::StreamBlockHeader::Write(writer, header);
+    writer.Write("abc", 3);
+    vsag::StreamBlockHeader::WriteSectionEnd(writer);
+
+    vsag::IOStreamReader reader(stream);
+    auto parsed = vsag::StreamBlockHeader::Read(reader);
+    vsag::SkipBlockPayload(reader, parsed);
+    REQUIRE(reader.GetCursor() == vsag::StreamBlockHeader::kSerializedSize + parsed.value_len);
+    auto end = vsag::StreamBlockHeader::Read(reader);
+    REQUIRE(end.IsSectionEnd());
+}
+
+TEST_CASE("ForwardStreamReader forbids random access", "[ut][streaming_serialization]") {
+    std::stringstream stream;
+    stream << "abcdef";
+    vsag::ForwardStreamReader reader(stream);
+    char buffer[3] = {};
+    reader.Read(buffer, 3);
+    REQUIRE(std::string(buffer, 3) == "abc");
+    REQUIRE(reader.GetCursor() == 3);
+    REQUIRE_THROWS(reader.Seek(0));
+    REQUIRE_THROWS(reader.Length());
+}
+
+TEST_CASE("BoundedForwardReader", "[ut][streaming_serialization]") {
+    std::stringstream stream;
+    stream << "abcdef";
+    vsag::ForwardStreamReader reader(stream);
+    vsag::BoundedForwardReader bounded(&reader, 4);
+    char buffer[2] = {};
+    bounded.Read(buffer, 2);
+    REQUIRE(std::string(buffer, 2) == "ab");
+    REQUIRE_THROWS(bounded.Read(buffer, 3));
+    bounded.SkipRemaining();
+    REQUIRE(reader.GetCursor() == 4);
+}
+
+TEST_CASE("BoundedForwardReader rejects overflow-sized read", "[ut][streaming_serialization]") {
+    std::stringstream stream;
+    stream << "abcdef";
+    vsag::ForwardStreamReader reader(stream);
+    vsag::BoundedForwardReader bounded(&reader, std::numeric_limits<uint64_t>::max());
+    char buffer[1] = {};
+    bounded.Read(buffer, 1);
+    REQUIRE_THROWS(bounded.Read(buffer, std::numeric_limits<uint64_t>::max()));
+}

--- a/src/storage/streaming_serialization_test_utils.h
+++ b/src/storage/streaming_serialization_test_utils.h
@@ -1,0 +1,145 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <catch2/catch_test_macros.hpp>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "serialization_tags.h"
+
+namespace vsag::test {
+
+constexpr uint64_t STREAM_MAGIC_SIZE = 8;
+constexpr uint64_t STREAM_VERSION_OFFSET = STREAM_MAGIC_SIZE;
+constexpr uint64_t STREAM_MAJOR_OFFSET = STREAM_VERSION_OFFSET;
+constexpr uint64_t STREAM_MINOR_OFFSET = STREAM_VERSION_OFFSET + sizeof(uint16_t);
+constexpr uint64_t STREAM_METADATA_LENGTH_OFFSET = STREAM_VERSION_OFFSET + 2 * sizeof(uint16_t);
+constexpr uint64_t STREAM_BLOCK_HEADER_SIZE = 4 + 4 + 8 + 8 + 4;
+constexpr uint64_t STREAM_BLOCK_CRITICAL_FLAG = 1;
+
+struct StreamingBlockSlice {
+    uint32_t tag{0};
+    uint64_t header_offset{0};
+    uint64_t payload_offset{0};
+    uint64_t payload_size{0};
+
+    [[nodiscard]] uint64_t
+    end_offset() const {
+        return payload_offset + payload_size;
+    }
+};
+
+template <typename T>
+T
+ReadStreamingObj(const std::string& bytes, uint64_t offset) {
+    REQUIRE(offset + sizeof(T) <= bytes.size());
+    T value{};
+    std::memcpy(&value, bytes.data() + offset, sizeof(T));
+    return value;
+}
+
+template <typename T>
+void
+WriteStreamingObj(std::string& bytes, uint64_t offset, T value) {
+    REQUIRE(offset + sizeof(T) <= bytes.size());
+    std::memcpy(bytes.data() + offset, &value, sizeof(T));
+}
+
+inline uint64_t
+StreamingBodyOffset(const std::string& bytes) {
+    REQUIRE(bytes.size() >= STREAM_METADATA_LENGTH_OFFSET + sizeof(uint64_t));
+    const auto metadata_len = ReadStreamingObj<uint64_t>(bytes, STREAM_METADATA_LENGTH_OFFSET);
+    return STREAM_METADATA_LENGTH_OFFSET + sizeof(uint64_t) + metadata_len + sizeof(uint32_t);
+}
+
+inline std::vector<StreamingBlockSlice>
+ParseStreamingBlocks(const std::string& bytes) {
+    std::vector<StreamingBlockSlice> blocks;
+    uint64_t cursor = StreamingBodyOffset(bytes);
+    while (cursor < bytes.size()) {
+        REQUIRE(cursor + STREAM_BLOCK_HEADER_SIZE <= bytes.size());
+        const auto tag = ReadStreamingObj<uint32_t>(bytes, cursor);
+        const auto value_len = ReadStreamingObj<uint64_t>(bytes, cursor + 4 + 4 + 8);
+        blocks.push_back(
+            StreamingBlockSlice{tag, cursor, cursor + STREAM_BLOCK_HEADER_SIZE, value_len});
+        cursor += STREAM_BLOCK_HEADER_SIZE;
+        if (tag == static_cast<uint32_t>(StreamSerializationTag::SECTION_END)) {
+            break;
+        }
+        REQUIRE(cursor + value_len <= bytes.size());
+        cursor += value_len;
+    }
+    return blocks;
+}
+
+inline StreamingBlockSlice
+FindStreamingBlock(const std::string& bytes, StreamSerializationTag tag) {
+    const auto tag_value = static_cast<uint32_t>(tag);
+    for (const auto& block : ParseStreamingBlocks(bytes)) {
+        if (block.tag == tag_value) {
+            return block;
+        }
+    }
+    FAIL("streaming block not found");
+    return StreamingBlockSlice{};
+}
+
+inline std::string
+SetStreamingMinorVersion(std::string bytes, uint16_t minor) {
+    WriteStreamingObj<uint16_t>(bytes, STREAM_MINOR_OFFSET, minor);
+    return bytes;
+}
+
+inline std::string
+SetStreamingMajorVersion(std::string bytes, uint16_t major) {
+    WriteStreamingObj<uint16_t>(bytes, STREAM_MAJOR_OFFSET, major);
+    return bytes;
+}
+
+inline std::string
+SetStreamingBlockVersion(std::string bytes, StreamSerializationTag tag, uint32_t version) {
+    const auto block = FindStreamingBlock(bytes, tag);
+    WriteStreamingObj<uint32_t>(bytes, block.header_offset + sizeof(uint32_t), version);
+    return bytes;
+}
+
+inline std::string
+EraseStreamingBlock(std::string bytes, StreamSerializationTag tag) {
+    const auto block = FindStreamingBlock(bytes, tag);
+    bytes.erase(static_cast<size_t>(block.header_offset),
+                static_cast<size_t>(STREAM_BLOCK_HEADER_SIZE + block.payload_size));
+    return bytes;
+}
+
+inline std::string
+InsertUnknownStreamingBlock(std::string bytes, bool critical, uint32_t version = 1) {
+    const auto section_end = FindStreamingBlock(bytes, StreamSerializationTag::SECTION_END);
+    std::string block(STREAM_BLOCK_HEADER_SIZE, '\0');
+    constexpr uint32_t unknown_tag = 0x00ABCDEF;
+    constexpr uint64_t payload_size = 5;
+    WriteStreamingObj<uint32_t>(block, 0, unknown_tag);
+    WriteStreamingObj<uint32_t>(block, 4, version);
+    WriteStreamingObj<uint64_t>(block, 8, critical ? STREAM_BLOCK_CRITICAL_FLAG : 0);
+    WriteStreamingObj<uint64_t>(block, 16, payload_size);
+    WriteStreamingObj<uint32_t>(block, 24, 0);
+    block.append("hello", payload_size);
+    bytes.insert(static_cast<size_t>(section_end.header_offset), block);
+    return bytes;
+}
+
+}  // namespace vsag::test

--- a/src/storage/tlv_section.cpp
+++ b/src/storage/tlv_section.cpp
@@ -1,0 +1,323 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tlv_section.h"
+
+#include <algorithm>
+#include <array>
+#include <cstdio>
+#include <cstring>
+#include <limits>
+#include <memory>
+#include <string_view>
+#include <vector>
+
+#if !defined(_WIN32)
+#include <sys/types.h>
+#endif
+
+#include "storage/serialization.h"
+#include "storage/serialization_tags.h"
+#include "vsag/constants.h"
+#include "vsag/options.h"
+#include "vsag_exception.h"
+
+namespace vsag {
+
+namespace {
+
+void
+SeekTemporaryFile(std::FILE* file, uint64_t offset) {
+#if defined(_WIN32)
+    if (offset > static_cast<uint64_t>(std::numeric_limits<__int64>::max())) {
+        throw VsagException(ErrorType::READ_ERROR,
+                            "seekable streaming block reader offset is too large");
+    }
+    if (::_fseeki64(file, static_cast<__int64>(offset), SEEK_SET) != 0) {
+        throw VsagException(ErrorType::READ_ERROR, "failed to seek streaming block temporary file");
+    }
+#else
+    if (offset > static_cast<uint64_t>(std::numeric_limits<off_t>::max())) {
+        throw VsagException(ErrorType::READ_ERROR,
+                            "seekable streaming block reader offset is too large");
+    }
+    if (::fseeko(file, static_cast<off_t>(offset), SEEK_SET) != 0) {
+        throw VsagException(ErrorType::READ_ERROR, "failed to seek streaming block temporary file");
+    }
+#endif
+}
+
+class ChecksumStreamWriter : public StreamWriter {
+public:
+    explicit ChecksumStreamWriter(StreamWriter& writer) : writer_(writer) {
+    }
+
+    void
+    Write(const char* data, uint64_t size) override {
+        writer_.Write(data, size);
+        bytes_written_ += size;
+        crc_ = StreamHeader::UpdateChecksum(crc_, std::string_view(data, size));
+    }
+
+    [[nodiscard]] uint32_t
+    GetChecksum() const {
+        return StreamHeader::FinalizeChecksum(crc_);
+    }
+
+private:
+    StreamWriter& writer_;
+    uint32_t crc_{StreamHeader::InitialChecksum()};
+};
+
+class CountingChecksumStreamWriter : public StreamWriter {
+public:
+    void
+    Write(const char* data, uint64_t size) override {
+        bytes_written_ += size;
+        crc_ = StreamHeader::UpdateChecksum(crc_, std::string_view(data, size));
+    }
+
+    [[nodiscard]] uint64_t
+    GetCursor() const {
+        return bytes_written_;
+    }
+
+    [[nodiscard]] uint32_t
+    GetChecksum() const {
+        return StreamHeader::FinalizeChecksum(crc_);
+    }
+
+private:
+    uint32_t crc_{StreamHeader::InitialChecksum()};
+};
+
+}  // namespace
+
+bool
+StreamBlockHeader::IsSectionEnd() const {
+    return tag == SERIAL_STREAM_SECTION_END;
+}
+
+StreamBlockHeader
+StreamBlockHeader::Read(StreamReader& reader) {
+    StreamBlockHeader header;
+    StreamReader::ReadObj(reader, header.tag);
+    StreamReader::ReadObj(reader, header.block_version);
+    StreamReader::ReadObj(reader, header.flags);
+    StreamReader::ReadObj(reader, header.value_len);
+    StreamReader::ReadObj(reader, header.payload_checksum);
+    if (header.IsSectionEnd() && (header.block_version != 0 || header.flags != 0 ||
+                                  header.value_len != 0 || header.payload_checksum != 0)) {
+        throw VsagException(ErrorType::INVALID_BINARY,
+                            "invalid streaming serialization section end block");
+    }
+    if (!header.IsSectionEnd() && header.value_len == std::numeric_limits<uint64_t>::max()) {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "chunked streaming block payload is not implemented yet");
+    }
+    return header;
+}
+
+void
+StreamBlockHeader::Write(StreamWriter& writer, const StreamBlockHeader& header) {
+    StreamWriter::WriteObj(writer, header.tag);
+    StreamWriter::WriteObj(writer, header.block_version);
+    StreamWriter::WriteObj(writer, header.flags);
+    StreamWriter::WriteObj(writer, header.value_len);
+    StreamWriter::WriteObj(writer, header.payload_checksum);
+}
+
+void
+StreamBlockHeader::WriteSectionEnd(StreamWriter& writer) {
+    StreamBlockHeader header;
+    header.tag = SERIAL_STREAM_SECTION_END;
+    StreamBlockHeader::Write(writer, header);
+}
+
+uint64_t
+CountStreamingBlockPayload(const std::function<void(StreamWriter&)>& serialize) {
+    CountingStreamWriter counting_writer;
+    serialize(counting_writer);
+    return counting_writer.GetCursor();
+}
+
+uint32_t
+CalculateStreamingBlockPayloadChecksum(const std::function<void(StreamWriter&)>& serialize) {
+    CountingChecksumStreamWriter checksum_writer;
+    serialize(checksum_writer);
+    return checksum_writer.GetChecksum();
+}
+
+void
+WriteStreamingBlock(StreamWriter& writer,
+                    uint32_t tag,
+                    bool critical,
+                    const std::function<void(StreamWriter&)>& serialize) {
+    CountingChecksumStreamWriter counting_checksum_writer;
+    serialize(counting_checksum_writer);
+
+    StreamBlockHeader header;
+    header.tag = tag;
+    header.block_version = StreamSerializationBlockCurrentVersion(tag);
+    header.flags = critical ? StreamBlockHeader::kCriticalFlag : 0;
+    header.value_len = counting_checksum_writer.GetCursor();
+    header.payload_checksum = counting_checksum_writer.GetChecksum();
+    StreamBlockHeader::Write(writer, header);
+    ChecksumStreamWriter payload_writer(writer);
+    serialize(payload_writer);
+    if (payload_writer.GetCursor() != header.value_len ||
+        payload_writer.GetChecksum() != header.payload_checksum) {
+        throw VsagException(ErrorType::INVALID_BINARY,
+                            "streaming block serializer produced inconsistent payload");
+    }
+}
+
+void
+SkipBlockPayload(StreamReader& reader, const StreamBlockHeader& header) {
+    if (header.value_len == std::numeric_limits<uint64_t>::max()) {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "chunked streaming block payload is not implemented yet");
+    }
+    const auto current = reader.GetCursor();
+    if (header.value_len > std::numeric_limits<uint64_t>::max() - current) {
+        throw VsagException(ErrorType::INVALID_BINARY,
+                            "streaming block payload size overflows reader cursor");
+    }
+
+    try {
+        reader.Seek(current + header.value_len);
+    } catch (const VsagException& e) {
+        if (e.error_.type != ErrorType::UNSUPPORTED_INDEX_OPERATION) {
+            throw;
+        }
+        SkipForward(reader, header.value_len);
+    }
+}
+
+void
+ValidateSeekableBlockCursor(const StreamReader& reader, const StreamBlockHeader& header) {
+    if (reader.GetCursor() > header.value_len) {
+        throw VsagException(ErrorType::INVALID_BINARY,
+                            "seekable streaming block reader cursor exceeds payload boundary");
+    }
+}
+
+void
+ValidateAndSkipBlockPayload(StreamReader& reader, const StreamBlockHeader& header) {
+    if (header.value_len == std::numeric_limits<uint64_t>::max()) {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "chunked streaming block payload is not implemented yet");
+    }
+
+    constexpr uint64_t buffer_size = 8192;
+    std::array<char, buffer_size> buffer{};
+    uint64_t remaining = header.value_len;
+    uint32_t crc = StreamHeader::InitialChecksum();
+    while (remaining > 0) {
+        const auto read_size = std::min<uint64_t>(remaining, buffer_size);
+        reader.Read(buffer.data(), read_size);
+        crc = StreamHeader::UpdateChecksum(crc, std::string_view(buffer.data(), read_size));
+        remaining -= read_size;
+    }
+    if (StreamHeader::FinalizeChecksum(crc) != header.payload_checksum) {
+        throw VsagException(ErrorType::INVALID_BINARY, "streaming block payload checksum mismatch");
+    }
+}
+
+void
+ReadSeekableBlockPayload(StreamReader& reader,
+                         const StreamBlockHeader& header,
+                         const std::function<void(StreamReader&)>& deserialize) {
+    if (header.value_len > static_cast<uint64_t>(std::numeric_limits<size_t>::max())) {
+        throw VsagException(ErrorType::NO_ENOUGH_MEMORY,
+                            "streaming block payload is too large to buffer");
+    }
+
+    const auto block_size_limit = Options::Instance().block_size_limit();
+    if (header.value_len <= block_size_limit) {
+        std::vector<char> payload(static_cast<size_t>(header.value_len));
+        if (!payload.empty()) {
+            reader.Read(payload.data(), header.value_len);
+        }
+        const auto payload_view =
+            payload.empty() ? std::string_view{} : std::string_view(payload.data(), payload.size());
+        if (StreamHeader::CalculateChecksum(payload_view) != header.payload_checksum) {
+            throw VsagException(ErrorType::INVALID_BINARY,
+                                "streaming block payload checksum mismatch");
+        }
+
+        auto read_func = [&payload, payload_size = static_cast<uint64_t>(payload.size())](
+                             uint64_t offset, uint64_t size, void* dest) {
+            if (offset > payload_size || size > payload_size - offset) {
+                throw VsagException(ErrorType::READ_ERROR,
+                                    "seekable streaming block reader exceeds payload boundary");
+            }
+            if (size > 0) {
+                std::memcpy(
+                    dest, payload.data() + static_cast<size_t>(offset), static_cast<size_t>(size));
+            }
+        };
+        ReadFuncStreamReader block_reader(read_func, 0, header.value_len);
+        deserialize(block_reader);
+        ValidateSeekableBlockCursor(block_reader, header);
+        return;
+    }
+
+    std::unique_ptr<std::FILE, decltype(&std::fclose)> temp_file(std::tmpfile(), std::fclose);
+    if (temp_file == nullptr) {
+        throw VsagException(ErrorType::READ_ERROR,
+                            "failed to create temporary file for streaming block payload");
+    }
+
+    if (block_size_limit > static_cast<uint64_t>(std::numeric_limits<size_t>::max())) {
+        throw VsagException(ErrorType::NO_ENOUGH_MEMORY,
+                            "streaming block size limit is too large to buffer");
+    }
+    std::vector<char> buffer(static_cast<size_t>(block_size_limit));
+    uint64_t remaining = header.value_len;
+    uint32_t crc = StreamHeader::InitialChecksum();
+    while (remaining > 0) {
+        const auto read_size = std::min<uint64_t>(remaining, block_size_limit);
+        const auto read_size_bytes = static_cast<size_t>(read_size);
+        reader.Read(buffer.data(), read_size);
+        crc = StreamHeader::UpdateChecksum(crc, std::string_view(buffer.data(), read_size));
+        if (std::fwrite(buffer.data(), 1, read_size_bytes, temp_file.get()) != read_size_bytes) {
+            throw VsagException(ErrorType::READ_ERROR,
+                                "failed to spill streaming block payload to temporary file");
+        }
+        remaining -= read_size;
+    }
+    if (StreamHeader::FinalizeChecksum(crc) != header.payload_checksum) {
+        throw VsagException(ErrorType::INVALID_BINARY, "streaming block payload checksum mismatch");
+    }
+    std::fflush(temp_file.get());
+
+    auto read_func = [&temp_file, payload_size = header.value_len](
+                         uint64_t offset, uint64_t size, void* dest) {
+        if (offset > payload_size || size > payload_size - offset) {
+            throw VsagException(ErrorType::READ_ERROR,
+                                "seekable streaming block reader exceeds payload boundary");
+        }
+        SeekTemporaryFile(temp_file.get(), offset);
+        if (size > 0 && std::fread(dest, 1, static_cast<size_t>(size), temp_file.get()) != size) {
+            throw VsagException(ErrorType::READ_ERROR,
+                                "failed to read streaming block temporary file");
+        }
+    };
+    ReadFuncStreamReader block_reader(read_func, 0, header.value_len);
+    deserialize(block_reader);
+    ValidateSeekableBlockCursor(block_reader, header);
+}
+
+}  // namespace vsag

--- a/src/storage/tlv_section.h
+++ b/src/storage/tlv_section.h
@@ -1,0 +1,81 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <functional>
+
+#include "stream_reader.h"
+#include "stream_writer.h"
+
+namespace vsag {
+
+struct StreamBlockHeader {
+    uint32_t tag{0};
+    uint32_t block_version{0};
+    uint64_t flags{0};
+    uint64_t value_len{0};
+    uint32_t payload_checksum{0};
+
+    [[nodiscard]] bool
+    IsCritical() const {
+        return (flags & kCriticalFlag) != 0;
+    }
+
+    [[nodiscard]] bool
+    IsSectionEnd() const;
+
+    static StreamBlockHeader
+    Read(StreamReader& reader);
+
+    static void
+    Write(StreamWriter& writer, const StreamBlockHeader& header);
+
+    static void
+    WriteSectionEnd(StreamWriter& writer);
+
+    static constexpr uint64_t kCriticalFlag = 1;
+    static constexpr uint64_t kSerializedSize = sizeof(uint32_t) + sizeof(uint32_t) +
+                                                sizeof(uint64_t) + sizeof(uint64_t) +
+                                                sizeof(uint32_t);
+};
+
+uint64_t
+CountStreamingBlockPayload(const std::function<void(StreamWriter&)>& serialize);
+
+uint32_t
+CalculateStreamingBlockPayloadChecksum(const std::function<void(StreamWriter&)>& serialize);
+
+void
+SkipBlockPayload(StreamReader& reader, const StreamBlockHeader& header);
+
+void
+ValidateAndSkipBlockPayload(StreamReader& reader, const StreamBlockHeader& header);
+
+void
+ReadSeekableBlockPayload(StreamReader& reader,
+                         const StreamBlockHeader& header,
+                         const std::function<void(StreamReader&)>& deserialize);
+
+// Invokes serialize twice: first to compute payload length/checksum, then to emit bytes.
+// Serializers must be deterministic and side-effect free for a given index state; the second
+// pass is checked against the payload length and checksum stored in the header.
+void
+WriteStreamingBlock(StreamWriter& writer,
+                    uint32_t tag,
+                    bool critical,
+                    const std::function<void(StreamWriter&)>& serialize);
+
+}  // namespace vsag

--- a/tests/test_brute_force.cpp
+++ b/tests/test_brute_force.cpp
@@ -15,10 +15,15 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
+#include <cstring>
 #include <limits>
+#include <sstream>
 
 #include "functest.h"
+#include "storage/serialization_tags.h"
+#include "storage/streaming_serialization_test_utils.h"
 #include "test_index.h"
+#include "vsag/constants.h"
 #include "vsag/options.h"
 #include "vsag/search_request.h"
 
@@ -158,6 +163,20 @@ BruteForceTestIndex::TestGeneral(const IndexPtr& index,
     TestCheckIdExist(index, dataset);
 }
 }  // namespace fixtures
+
+namespace {
+
+using vsag::test::InsertUnknownStreamingBlock;
+using vsag::test::SetStreamingBlockVersion;
+
+void
+RequireStreamTail(std::stringstream& stream, const std::string& expected_tail) {
+    std::string tail(expected_tail.size(), '\0');
+    stream.read(tail.data(), static_cast<std::streamsize>(tail.size()));
+    REQUIRE(tail == expected_tail);
+}
+
+}  // namespace
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::BruteForceTestIndex,
                              "BruteForce Factory Test With Exceptions",
@@ -459,9 +478,213 @@ TestBruteForceSerializeFile(const fixtures::BruteForceResourcePtr& resource) {
     }
 }
 
+static void
+TestBruteForceGetStreamingMetadataOnEmptyIndex() {
+    using namespace fixtures;
+    auto param = BruteForceTestIndex::GenerateBruteForceBuildParametersString("l2", 16, "fp32");
+    auto index = TestIndex::TestFactory(BruteForceTestIndex::name, param, true);
+
+    std::stringstream stream;
+    REQUIRE(index->SerializeStreaming(stream).has_value());
+
+    auto metadata_result = vsag::Index::GetStreamingMetadata(stream);
+    REQUIRE(metadata_result.has_value());
+    REQUIRE(metadata_result.value().metadata_json.find("\"_empty\":true") != std::string::npos);
+    REQUIRE(metadata_result.value().blocks.empty());
+}
+
+static void
+TestBruteForceSerializeStreaming() {
+    using namespace fixtures;
+    auto param = BruteForceTestIndex::GenerateBruteForceBuildParametersString("l2", 16, "fp32");
+    auto index = TestIndex::TestFactory(BruteForceTestIndex::name, param, true);
+    auto dataset = BruteForceTestIndex::pool.GetDatasetAndCreate(16, 100, "l2");
+    TestIndex::TestBuildIndex(index, dataset, true);
+
+    std::stringstream stream;
+    auto serialize_result = index->SerializeStreaming(stream);
+    REQUIRE(serialize_result.has_value());
+    auto bytes = stream.str();
+    REQUIRE(bytes.substr(0, 8) == vsag::SERIAL_STREAM_MAGIC);
+
+    auto index2 = TestIndex::TestFactory(BruteForceTestIndex::name, param, true);
+    std::stringstream deserialize_stream(bytes);
+    auto deserialize_result = index2->DeserializeStreaming(deserialize_stream);
+    REQUIRE(deserialize_result.has_value());
+    REQUIRE(index2->GetNumElements() == index->GetNumElements());
+
+    std::stringstream load_stream(bytes);
+    auto load_result = vsag::Index::Load(load_stream, R"({"base_io_type": "memory_io"})");
+    REQUIRE(load_result.has_value());
+    auto index3 = load_result.value();
+    REQUIRE(index3->GetNumElements() == index->GetNumElements());
+
+    std::stringstream buffer_load_stream(bytes);
+    auto buffer_load_result =
+        vsag::Index::Load(buffer_load_stream, R"({"base_io_type": "buffer_io"})");
+    REQUIRE(buffer_load_result.has_value());
+    REQUIRE(buffer_load_result.value()->GetNumElements() == index->GetNumElements());
+
+    std::stringstream reader_load_stream(bytes);
+    auto reader_load_result =
+        vsag::Index::Load(reader_load_stream, R"({"base_io_type": "reader_io"})");
+    REQUIRE_FALSE(reader_load_result.has_value());
+
+    auto query = get_one_query(dataset->query_, 0);
+    auto result = index->KnnSearch(query, 10, search_param_tmp);
+    auto result2 = index2->KnnSearch(query, 10, search_param_tmp);
+    auto result3 = index3->KnnSearch(query, 10, search_param_tmp);
+    REQUIRE(result.has_value());
+    REQUIRE(result2.has_value());
+    REQUIRE(result3.has_value());
+    REQUIRE(result.value()->GetDim() == result2.value()->GetDim());
+    for (int64_t i = 0; i < result.value()->GetDim(); ++i) {
+        REQUIRE(result.value()->GetIds()[i] == result2.value()->GetIds()[i]);
+        REQUIRE(result.value()->GetDistances()[i] == result2.value()->GetDistances()[i]);
+        REQUIRE(result.value()->GetIds()[i] == result3.value()->GetIds()[i]);
+        REQUIRE(result.value()->GetDistances()[i] == result3.value()->GetDistances()[i]);
+    }
+}
+
+TEST_CASE("BruteForce streaming compatibility",
+          "[ft][serialize][streaming][bruteforce][compatibility]") {
+    using namespace fixtures;
+    auto param = BruteForceTestIndex::GenerateBruteForceBuildParametersString("l2", 16, "fp32");
+    auto index = TestIndex::TestFactory(BruteForceTestIndex::name, param, true);
+    auto dataset = BruteForceTestIndex::pool.GetDatasetAndCreate(16, 100, "l2");
+    TestIndex::TestBuildIndex(index, dataset, true);
+
+    std::stringstream stream;
+    REQUIRE(index->SerializeStreaming(stream).has_value());
+    const auto bytes = stream.str();
+
+    SECTION("skips unknown non-critical block") {
+        auto mutated = InsertUnknownStreamingBlock(bytes, false);
+        auto restored = TestIndex::TestFactory(BruteForceTestIndex::name, param, true);
+        std::stringstream deserialize_stream(mutated);
+        REQUIRE(restored->DeserializeStreaming(deserialize_stream).has_value());
+        REQUIRE(restored->GetNumElements() == index->GetNumElements());
+    }
+
+    SECTION("skips unknown non-critical block with unsupported version") {
+        auto mutated = InsertUnknownStreamingBlock(bytes, false, 99);
+        auto restored = TestIndex::TestFactory(BruteForceTestIndex::name, param, true);
+        std::stringstream deserialize_stream(mutated);
+        REQUIRE(restored->DeserializeStreaming(deserialize_stream).has_value());
+        REQUIRE(restored->GetNumElements() == index->GetNumElements());
+    }
+
+    SECTION("rejects unknown critical block") {
+        auto mutated = InsertUnknownStreamingBlock(bytes, true);
+        auto restored = TestIndex::TestFactory(BruteForceTestIndex::name, param, true);
+        std::stringstream deserialize_stream(mutated);
+        REQUIRE_FALSE(restored->DeserializeStreaming(deserialize_stream).has_value());
+    }
+
+    SECTION("rejects unsupported critical block version") {
+        auto mutated =
+            SetStreamingBlockVersion(bytes, vsag::StreamSerializationTag::BASE_CODES, 99);
+        auto restored = TestIndex::TestFactory(BruteForceTestIndex::name, param, true);
+        std::stringstream deserialize_stream(mutated);
+        REQUIRE_FALSE(restored->DeserializeStreaming(deserialize_stream).has_value());
+    }
+
+    SECTION("supports nested load memory policy") {
+        std::stringstream load_stream(bytes);
+        auto loaded = vsag::Index::Load(load_stream, R"({"load":{"base_codes":"memory"}})");
+        REQUIRE(loaded.has_value());
+        REQUIRE(loaded.value()->GetNumElements() == index->GetNumElements());
+    }
+
+    SECTION("rejects nested load reader policy for required base codes") {
+        std::stringstream load_stream(bytes);
+        REQUIRE_FALSE(
+            vsag::Index::Load(load_stream, R"({"load":{"base_codes":"reader"}})").has_value());
+    }
+
+    SECTION("rejects invalid streaming load JSON as invalid argument") {
+        std::stringstream load_stream(bytes);
+        auto loaded = vsag::Index::Load(load_stream, "{");
+        REQUIRE_FALSE(loaded.has_value());
+        REQUIRE(loaded.error().type == vsag::ErrorType::INVALID_ARGUMENT);
+    }
+
+    SECTION("rejects wrong streaming load policy type as invalid argument") {
+        std::stringstream load_stream(bytes);
+        auto loaded = vsag::Index::Load(load_stream, R"({"load":{"base_codes":false}})");
+        REQUIRE_FALSE(loaded.has_value());
+        REQUIRE(loaded.error().type == vsag::ErrorType::INVALID_ARGUMENT);
+    }
+}
+
+TEST_CASE("BruteForce streaming Load skips attribute filter state",
+          "[ft][serialize][streaming][bruteforce][compatibility]") {
+    using namespace fixtures;
+    auto param =
+        BruteForceTestIndex::GenerateBruteForceBuildParametersString("l2", 16, "fp32", true);
+    auto index = TestIndex::TestFactory(BruteForceTestIndex::name, param, true);
+    auto dataset = BruteForceTestIndex::pool.GetDatasetAndCreate(16, 100, "l2");
+    TestIndex::TestBuildIndex(index, dataset, true);
+
+    std::stringstream stream;
+    REQUIRE(index->SerializeStreaming(stream).has_value());
+    std::stringstream load_stream(stream.str());
+    auto loaded = vsag::Index::Load(load_stream, R"({"load":{"use_attribute_filter":"skip"}})");
+    REQUIRE(loaded.has_value());
+    REQUIRE(loaded.value()->GetNumElements() == index->GetNumElements());
+
+    auto query = get_one_query(dataset->query_, 0);
+    auto search_result = loaded.value()->KnnSearch(query, 10, search_param_tmp);
+    REQUIRE(search_result.has_value());
+
+    vsag::SearchRequest request;
+    request.query_ = query;
+    request.topk_ = 10;
+    request.params_str_ = search_param_tmp;
+    request.enable_attribute_filter_ = true;
+    request.attribute_filter_str_ = R"(multi_in(term_0, "0", "|"))";
+    auto attr_search_result = loaded.value()->SearchWithRequest(request);
+    REQUIRE_FALSE(attr_search_result.has_value());
+    REQUIRE(attr_search_result.error().type == vsag::ErrorType::INVALID_ARGUMENT);
+
+    auto remove_result = loaded.value()->Remove(dataset->base_->GetIds()[0]);
+    REQUIRE(remove_result.has_value());
+}
+
+TEST_CASE("BruteForce empty streaming index consumes section end",
+          "[ft][serialize][streaming][bruteforce][compatibility]") {
+    using namespace fixtures;
+    auto param = BruteForceTestIndex::GenerateBruteForceBuildParametersString("l2", 16, "fp32");
+    auto index = TestIndex::TestFactory(BruteForceTestIndex::name, param, true);
+    std::stringstream stream;
+    REQUIRE(index->SerializeStreaming(stream).has_value());
+    stream << "tail";
+    auto bytes = stream.str();
+
+    auto restored = TestIndex::TestFactory(BruteForceTestIndex::name, param, true);
+    std::stringstream deserialize_stream(bytes);
+    REQUIRE(restored->DeserializeStreaming(deserialize_stream).has_value());
+    RequireStreamTail(deserialize_stream, "tail");
+
+    std::stringstream load_stream(bytes);
+    auto loaded = vsag::Index::Load(load_stream, "{}");
+    REQUIRE(loaded.has_value());
+    RequireStreamTail(load_stream, "tail");
+}
+
 TEST_CASE("(PR) BruteForce Serialize File Test", "[ft][serialize][bruteforce][pr]") {
     auto resource = fixtures::BruteForceTestIndex::GetResource(true);
     TestBruteForceSerializeFile(resource);
+}
+
+TEST_CASE("(PR) BruteForce Streaming Metadata Empty Index Test",
+          "[ft][serialize][streaming][bruteforce][pr]") {
+    TestBruteForceGetStreamingMetadataOnEmptyIndex();
+}
+
+TEST_CASE("(PR) BruteForce Streaming Serialize Test",
+          "[ft][serialize][streaming][bruteforce][pr]") {
+    TestBruteForceSerializeStreaming();
 }
 
 TEST_CASE("(Daily) BruteForce Serialize File Test", "[ft][serialize][bruteforce][daily]") {

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -18,6 +18,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
 #include <chrono>
+#include <cstring>
 #include <limits>
 #include <random>
 #include <sstream>
@@ -25,6 +26,8 @@
 
 #include "functest.h"
 #include "inner_string_params.h"
+#include "storage/serialization_tags.h"
+#include "storage/streaming_serialization_test_utils.h"
 #include "test_index.h"
 #include "typing.h"
 #include "vsag/filter.h"
@@ -405,6 +408,70 @@ ForEachHGraphCase(const fixtures::HGraphResourcePtr& resource, const Cases& test
                 fn(metric_type, dim, base_quantization_str, recall);
             }
         }
+    }
+}
+
+using vsag::test::EraseStreamingBlock;
+using vsag::test::InsertUnknownStreamingBlock;
+using vsag::test::SetStreamingBlockVersion;
+using vsag::test::SetStreamingMajorVersion;
+using vsag::test::SetStreamingMinorVersion;
+
+struct HGraphStreamingFixture {
+    std::string param;
+    fixtures::TestDatasetPtr dataset;
+    fixtures::TestIndex::IndexPtr index;
+    std::string bytes;
+};
+
+HGraphStreamingFixture
+MakeHGraphStreamingFixture(const std::string& quantization = "fp32") {
+    using namespace fixtures;
+    HGraphTestIndex::HGraphBuildParam build_param("l2", 16, quantization);
+    auto param = HGraphTestIndex::GenerateHGraphBuildParametersString(build_param);
+    auto index = TestIndex::TestFactory(HGraphTestIndex::name, param, true);
+    auto dataset = HGraphTestIndex::pool.GetDatasetAndCreate(16, 100, "l2");
+    TestIndex::TestBuildIndex(index, dataset, true);
+
+    std::stringstream stream;
+    auto serialize_result = index->SerializeStreaming(stream);
+    REQUIRE(serialize_result.has_value());
+    auto bytes = stream.str();
+    REQUIRE(bytes.substr(0, 8) == vsag::SERIAL_STREAM_MAGIC);
+    return HGraphStreamingFixture{param, dataset, index, bytes};
+}
+
+fixtures::TestIndex::IndexPtr
+DeserializeHGraphStreamingBytes(const std::string& param, const std::string& bytes) {
+    auto index = fixtures::TestIndex::TestFactory(fixtures::HGraphTestIndex::name, param, true);
+    std::stringstream stream(bytes);
+    auto result = index->DeserializeStreaming(stream);
+    REQUIRE(result.has_value());
+    return index;
+}
+
+void
+RequireHGraphStreamingDeserializeFails(const std::string& param, const std::string& bytes) {
+    auto index = fixtures::TestIndex::TestFactory(fixtures::HGraphTestIndex::name, param, true);
+    std::stringstream stream(bytes);
+    REQUIRE_FALSE(index->DeserializeStreaming(stream).has_value());
+}
+
+void
+RequireHGraphStreamingSearchMatches(const fixtures::TestIndex::IndexPtr& expected,
+                                    const fixtures::TestIndex::IndexPtr& actual,
+                                    const fixtures::TestDatasetPtr& dataset) {
+    auto query = fixtures::get_one_query(dataset->query_, 0);
+    auto search_param = fmt::format(fixtures::search_param_tmp, 200, false);
+    auto expected_result = expected->KnnSearch(query, 10, search_param);
+    auto actual_result = actual->KnnSearch(query, 10, search_param);
+    REQUIRE(expected_result.has_value());
+    REQUIRE(actual_result.has_value());
+    REQUIRE(expected_result.value()->GetDim() == actual_result.value()->GetDim());
+    for (int64_t i = 0; i < expected_result.value()->GetDim(); ++i) {
+        REQUIRE(expected_result.value()->GetIds()[i] == actual_result.value()->GetIds()[i]);
+        REQUIRE(expected_result.value()->GetDistances()[i] ==
+                actual_result.value()->GetDistances()[i]);
     }
 }
 
@@ -1804,6 +1871,133 @@ TestHGraphSerialize(const fixtures::HGraphTestIndexPtr& test_index,
 HGRAPH_PR_DAILY_CASE("HGraph Serialize File",
                      "[ft][serialize][hgraph][serialization]",
                      TestHGraphSerialize)
+
+TEST_CASE("HGraph Serialize Streaming", "[ft][serialize][hgraph][streaming]") {
+    using namespace fixtures;
+    HGraphTestIndex::HGraphBuildParam build_param("l2", 16, "fp32");
+    auto param = HGraphTestIndex::GenerateHGraphBuildParametersString(build_param);
+    auto index = TestIndex::TestFactory(HGraphTestIndex::name, param, true);
+    auto dataset = HGraphTestIndex::pool.GetDatasetAndCreate(16, 100, "l2");
+    TestIndex::TestBuildIndex(index, dataset, true);
+
+    std::stringstream stream;
+    auto serialize_result = index->SerializeStreaming(stream);
+    REQUIRE(serialize_result.has_value());
+    auto bytes = stream.str();
+    REQUIRE(bytes.substr(0, 8) == vsag::SERIAL_STREAM_MAGIC);
+
+    auto index2 = TestIndex::TestFactory(HGraphTestIndex::name, param, true);
+    std::stringstream deserialize_stream(bytes);
+    auto deserialize_result = index2->DeserializeStreaming(deserialize_stream);
+    REQUIRE(deserialize_result.has_value());
+    REQUIRE(index2->GetNumElements() == index->GetNumElements());
+
+    std::stringstream load_stream(bytes);
+    auto load_result = vsag::Index::Load(load_stream, "{}");
+    REQUIRE(load_result.has_value());
+    auto index3 = load_result.value();
+    REQUIRE(index3->GetNumElements() == index->GetNumElements());
+
+    auto query = get_one_query(dataset->query_, 0);
+    auto search_param = fmt::format(fixtures::search_param_tmp, 200, false);
+    auto result = index->KnnSearch(query, 10, search_param);
+    auto result2 = index2->KnnSearch(query, 10, search_param);
+    auto result3 = index3->KnnSearch(query, 10, search_param);
+    REQUIRE(result.has_value());
+    REQUIRE(result2.has_value());
+    REQUIRE(result3.has_value());
+    REQUIRE(result.value()->GetDim() == result2.value()->GetDim());
+    REQUIRE(result.value()->GetDim() == result3.value()->GetDim());
+    for (int64_t i = 0; i < result.value()->GetDim(); ++i) {
+        REQUIRE(result.value()->GetIds()[i] == result2.value()->GetIds()[i]);
+        REQUIRE(result.value()->GetDistances()[i] == result2.value()->GetDistances()[i]);
+        REQUIRE(result.value()->GetIds()[i] == result3.value()->GetIds()[i]);
+        REQUIRE(result.value()->GetDistances()[i] == result3.value()->GetDistances()[i]);
+    }
+}
+
+TEST_CASE("HGraph streaming Load applies IO parameters", "[ft][serialize][hgraph][streaming]") {
+    using namespace fixtures;
+    HGraphTestIndex::HGraphBuildParam build_param("l2", 128, "rabitq,sq8,block_memory_io,32,3");
+    build_param.graph_storage = "compressed";
+    build_param.thread_count = 1;
+    auto param = HGraphTestIndex::GenerateHGraphBuildParametersString(build_param);
+    auto index = TestIndex::TestFactory(HGraphTestIndex::name, param, true);
+    auto dataset = HGraphTestIndex::pool.GetDatasetAndCreate(128, 200, "l2");
+    TestIndex::TestBuildIndex(index, dataset, true);
+
+    std::stringstream stream;
+    REQUIRE(index->SerializeStreaming(stream).has_value());
+    auto bytes = stream.str();
+
+    auto precise_path = HGraphTestIndex::dir.GenerateRandomFile(false);
+    auto load_param =
+        fmt::format(R"({{"precise_io_type":"buffer_io","precise_file_path":"{}"}})", precise_path);
+    std::stringstream load_stream(bytes);
+    auto loaded = vsag::Index::Load(load_stream, load_param);
+    REQUIRE(loaded.has_value());
+    REQUIRE(loaded.value()->GetNumElements() == index->GetNumElements());
+
+    std::stringstream invalid_load_stream(bytes);
+    REQUIRE_FALSE(
+        vsag::Index::Load(invalid_load_stream, R"({"precise_io_type":"invalid_io"})").has_value());
+}
+
+TEST_CASE("HGraph streaming serialization compatibility",
+          "[ft][serialize][hgraph][streaming][compatibility]") {
+    SECTION("accepts newer minor version") {
+        auto fixture = MakeHGraphStreamingFixture();
+        auto bytes = SetStreamingMinorVersion(fixture.bytes, 7);
+        auto restored = DeserializeHGraphStreamingBytes(fixture.param, bytes);
+        RequireHGraphStreamingSearchMatches(fixture.index, restored, fixture.dataset);
+    }
+
+    SECTION("rejects unsupported major version") {
+        auto fixture = MakeHGraphStreamingFixture();
+        auto bytes = SetStreamingMajorVersion(fixture.bytes, 2);
+        RequireHGraphStreamingDeserializeFails(fixture.param, bytes);
+    }
+
+    SECTION("skips unknown non-critical block") {
+        auto fixture = MakeHGraphStreamingFixture();
+        auto bytes = InsertUnknownStreamingBlock(fixture.bytes, false);
+        auto restored = DeserializeHGraphStreamingBytes(fixture.param, bytes);
+        RequireHGraphStreamingSearchMatches(fixture.index, restored, fixture.dataset);
+    }
+
+    SECTION("skips unknown non-critical block with unsupported version") {
+        auto fixture = MakeHGraphStreamingFixture();
+        auto bytes = InsertUnknownStreamingBlock(fixture.bytes, false, 99);
+        auto restored = DeserializeHGraphStreamingBytes(fixture.param, bytes);
+        RequireHGraphStreamingSearchMatches(fixture.index, restored, fixture.dataset);
+    }
+
+    SECTION("rejects unknown critical block") {
+        auto fixture = MakeHGraphStreamingFixture();
+        auto bytes = InsertUnknownStreamingBlock(fixture.bytes, true);
+        RequireHGraphStreamingDeserializeFails(fixture.param, bytes);
+    }
+
+    SECTION("rejects unsupported critical block version") {
+        auto fixture = MakeHGraphStreamingFixture();
+        auto bytes =
+            SetStreamingBlockVersion(fixture.bytes, vsag::StreamSerializationTag::BASE_CODES, 99);
+        RequireHGraphStreamingDeserializeFails(fixture.param, bytes);
+    }
+
+    SECTION("rejects missing required block") {
+        auto fixture = MakeHGraphStreamingFixture();
+        auto bytes = EraseStreamingBlock(fixture.bytes, vsag::StreamSerializationTag::BOTTOM_GRAPH);
+        RequireHGraphStreamingDeserializeFails(fixture.param, bytes);
+    }
+
+    SECTION("rejects missing conditional high precision block") {
+        auto fixture = MakeHGraphStreamingFixture("sq8,fp32");
+        auto bytes =
+            EraseStreamingBlock(fixture.bytes, vsag::StreamSerializationTag::HIGH_PRECISION_CODES);
+        RequireHGraphStreamingDeserializeFails(fixture.param, bytes);
+    }
+}
 
 static void
 TestHGraphReaderIO(const fixtures::HGraphTestIndexPtr& test_index,

--- a/tests/test_ivf.cpp
+++ b/tests/test_ivf.cpp
@@ -13,10 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstring>
 #include <limits>
+#include <sstream>
 
 #include "functest.h"
+#include "storage/serialization_tags.h"
 #include "storage/serialization_template_test.h"
+#include "storage/streaming_serialization_test_utils.h"
 #include "test_index.h"
 namespace fixtures {
 
@@ -183,6 +187,13 @@ IVFTestIndex::GenerateIVFBuildParametersString(const std::string& metric_type,
     return build_parameters_str;
 }
 
+namespace {
+
+using vsag::test::EraseStreamingBlock;
+using vsag::test::InsertUnknownStreamingBlock;
+
+}  // namespace
+
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::IVFTestIndex, "IVF GetStatus", "[ft][ivf]") {
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(true);
@@ -290,6 +301,58 @@ IVFTestIndex::TestGeneral(const TestIndex::IndexPtr& index,
     TestFilterSearch(index, dataset, search_param, recall, true);
     TestCalcDistanceById(index, dataset, 2e-6, true);
     TestCheckIdExist(index, dataset);
+}
+
+TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
+                             "IVF streaming compatibility",
+                             "[ft][serialize][streaming][ivf]") {
+    auto origin_size = vsag::Options::Instance().block_size_limit();
+    vsag::Options::Instance().set_block_size_limit(1024 * 1024 * 2);
+
+    auto param = IVFTestIndex::GenerateIVFBuildParametersString("l2", 16, "sq8", 32, "random");
+    auto index = TestIndex::TestFactory(IVFTestIndex::name, param, true);
+    auto dataset = IVFTestIndex::pool.GetDatasetAndCreate(16, 200, "l2");
+    TestIndex::TestBuildIndex(index, dataset, true);
+
+    std::stringstream stream;
+    REQUIRE(index->SerializeStreaming(stream).has_value());
+    const auto bytes = stream.str();
+    const auto search_param = fmt::format(search_param_tmp, 32);
+
+    SECTION("skips unknown non-critical block") {
+        auto mutated = InsertUnknownStreamingBlock(bytes, false);
+        auto restored = TestIndex::TestFactory(IVFTestIndex::name, param, true);
+        std::stringstream deserialize_stream(mutated);
+        REQUIRE(restored->DeserializeStreaming(deserialize_stream).has_value());
+        IVFTestIndex::TestGeneral(restored, dataset, search_param, 0.70F);
+
+        std::stringstream load_stream(mutated);
+        auto loaded = vsag::Index::Load(load_stream, "{}");
+        REQUIRE(loaded.has_value());
+        IVFTestIndex::TestGeneral(loaded.value(), dataset, search_param, 0.70F);
+    }
+
+    SECTION("rejects unknown critical block") {
+        auto mutated = InsertUnknownStreamingBlock(bytes, true);
+        auto restored = TestIndex::TestFactory(IVFTestIndex::name, param, true);
+        std::stringstream deserialize_stream(mutated);
+        REQUIRE_FALSE(restored->DeserializeStreaming(deserialize_stream).has_value());
+
+        std::stringstream load_stream(mutated);
+        REQUIRE_FALSE(vsag::Index::Load(load_stream, "{}").has_value());
+    }
+
+    SECTION("rejects missing required block") {
+        auto mutated = EraseStreamingBlock(bytes, vsag::StreamSerializationTag::IVF_BUCKET);
+        auto restored = TestIndex::TestFactory(IVFTestIndex::name, param, true);
+        std::stringstream deserialize_stream(mutated);
+        REQUIRE_FALSE(restored->DeserializeStreaming(deserialize_stream).has_value());
+
+        std::stringstream load_stream(mutated);
+        REQUIRE_FALSE(vsag::Index::Load(load_stream, "{}").has_value());
+    }
+
+    vsag::Options::Instance().set_block_size_limit(origin_size);
 }
 }  // namespace fixtures
 
@@ -1207,6 +1270,21 @@ TestIVFSerialize(const fixtures::IVFResourcePtr& resource) {
                         auto index2 = IVFTestIndex::TestFactory(IVFTestIndex::name, param, true);
                         IVFTestIndex::TestSerializeWriteFunc(
                             index, index2, dataset, search_param, true);
+                    }
+                    {
+                        auto index2 = IVFTestIndex::TestFactory(IVFTestIndex::name, param, true);
+                        std::stringstream stream;
+                        REQUIRE(index->SerializeStreaming(stream).has_value());
+                        const auto bytes = stream.str();
+
+                        std::stringstream deserialize_stream(bytes);
+                        REQUIRE(index2->DeserializeStreaming(deserialize_stream).has_value());
+                        IVFTestIndex::TestGeneral(index2, dataset, search_param, recall);
+
+                        std::stringstream load_stream(bytes);
+                        auto loaded = vsag::Index::Load(load_stream, "{}");
+                        REQUIRE(loaded.has_value());
+                        IVFTestIndex::TestGeneral(loaded.value(), dataset, search_param, recall);
                     }
                 }
             });

--- a/tests/test_pyramid.cpp
+++ b/tests/test_pyramid.cpp
@@ -20,10 +20,14 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
 #include <cmath>
+#include <cstring>
 #include <nlohmann/json.hpp>
 #include <set>
+#include <sstream>
 
 #include "functest.h"
+#include "storage/serialization_tags.h"
+#include "storage/streaming_serialization_test_utils.h"
 #include "test_index.h"
 #include "vsag/vsag.h"
 
@@ -171,6 +175,9 @@ RequireDistancesNearZero(const vsag::DatasetPtr& result, const std::set<int64_t>
         }
     }
 }
+
+using vsag::test::EraseStreamingBlock;
+using vsag::test::InsertUnknownStreamingBlock;
 
 class BlockSizeLimitGuard {
 public:
@@ -536,8 +543,73 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
             auto index2 = TestFactory(name, param, true);
             TestSerializeFile(index, index2, dataset, search_param, true);
         }
+        SECTION("streaming serialize/deserialize/load") {
+            auto index2 = TestFactory(name, param, true);
+            std::stringstream stream;
+            REQUIRE(index->SerializeStreaming(stream).has_value());
+            const auto bytes = stream.str();
+
+            std::stringstream deserialize_stream(bytes);
+            REQUIRE(index2->DeserializeStreaming(deserialize_stream).has_value());
+            TestKnnSearch(index2, dataset, search_param, 0.94, true);
+
+            std::stringstream load_stream(bytes);
+            auto loaded = vsag::Index::Load(load_stream, "{}");
+            REQUIRE(loaded.has_value());
+            TestKnnSearch(loaded.value(), dataset, search_param, 0.94, true);
+        }
     }
     vsag::Options::Instance().set_block_size_limit(origin_size);
+}
+
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
+                             "Pyramid streaming compatibility",
+                             "[ft][pyramid][serialization][streaming][compatibility]") {
+    BlockSizeLimitGuard block_size_limit_guard(1024 * 1024 * 2);
+    PyramidParam pyramid_param;
+    pyramid_param.no_build_levels = {0, 1, 2};
+    const auto param = GeneratePyramidBuildParametersString("l2", 16, pyramid_param);
+    auto index = TestFactory("pyramid", param, true);
+    auto dataset = pool.GetDatasetAndCreate(16, 200, "l2", /*with_path=*/true);
+    TestBuildIndex(index, dataset, true);
+
+    std::stringstream stream;
+    REQUIRE(index->SerializeStreaming(stream).has_value());
+    const auto bytes = stream.str();
+    const auto expected_count = dataset->base_->GetNumElements();
+
+    SECTION("skips unknown non-critical block") {
+        auto mutated = InsertUnknownStreamingBlock(bytes, false);
+        auto restored = TestFactory("pyramid", param, true);
+        std::stringstream deserialize_stream(mutated);
+        REQUIRE(restored->DeserializeStreaming(deserialize_stream).has_value());
+        REQUIRE(restored->GetNumElements() == expected_count);
+
+        std::stringstream load_stream(mutated);
+        auto loaded = vsag::Index::Load(load_stream, "{}");
+        REQUIRE(loaded.has_value());
+        REQUIRE(loaded.value()->GetNumElements() == expected_count);
+    }
+
+    SECTION("rejects unknown critical block") {
+        auto mutated = InsertUnknownStreamingBlock(bytes, true);
+        auto restored = TestFactory("pyramid", param, true);
+        std::stringstream deserialize_stream(mutated);
+        REQUIRE_FALSE(restored->DeserializeStreaming(deserialize_stream).has_value());
+
+        std::stringstream load_stream(mutated);
+        REQUIRE_FALSE(vsag::Index::Load(load_stream, "{}").has_value());
+    }
+
+    SECTION("rejects missing required block") {
+        auto mutated = EraseStreamingBlock(bytes, vsag::StreamSerializationTag::BASE_CODES);
+        auto restored = TestFactory("pyramid", param, true);
+        std::stringstream deserialize_stream(mutated);
+        REQUIRE_FALSE(restored->DeserializeStreaming(deserialize_stream).has_value());
+
+        std::stringstream load_stream(mutated);
+        REQUIRE_FALSE(vsag::Index::Load(load_stream, "{}").has_value());
+    }
 }
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex, "Pyramid Clone", "[ft][clone][pyramid]") {

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -17,3 +17,4 @@
 add_subdirectory (eval)
 add_subdirectory (check_compatibility)
 add_subdirectory (analyze_index)
+add_subdirectory (visualize_index)

--- a/tools/visualize_index/CMakeLists.txt
+++ b/tools/visualize_index/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 # Copyright 2024-present the vsag project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,20 +13,5 @@
 # limitations under the License.
 
 
-set (STORAGE_SRC
-  footer.cpp
-  serialization.cpp
-  stream_reader.cpp
-  stream_writer.cpp
-  tlv_section.cpp
-)
-
-add_library (storage OBJECT ${STORAGE_SRC})
-target_link_libraries (storage PRIVATE coverage_config vsag_src_common)
-
-if (ENABLE_TESTS)
-    file (GLOB_RECURSE STORAGE_TESTS "*_test.cpp")
-    add_library (storage_test STATIC ${STORAGE_TESTS})
-    target_link_libraries (storage_test PRIVATE Catch2::Catch2 vsag_static unittest_deps)
-    add_dependencies (storage_test Catch2)
-endif ()
+add_executable (visualize_index visualize_index.cpp)
+target_link_libraries (visualize_index PRIVATE vsag argparse::argparse)

--- a/tools/visualize_index/README.md
+++ b/tools/visualize_index/README.md
@@ -1,0 +1,22 @@
+# visualize_index
+
+`visualize_index` inspects a streaming-serialized VSAG index file and shows each
+part's byte-size proportion.
+
+```bash
+./build/tools/visualize_index/visualize_index --index_path ./index.bin
+./build/tools/visualize_index/visualize_index --index_path ./index.bin --html ./index.html
+```
+
+The terminal output remains a raw/exploded layout summary. The logical block
+view groups every TLV header with its payload, so blocks such as `base_codes`,
+`bottom_graph`, `ivf_bucket`, `sindi_windows`, and `pyramid_hierarchies` are
+shown as single size-proportional units.
+
+The HTML output uses a grouped exploded horizontal layout: related small segments
+are merged into logical blocks, very large blocks are visually folded with
+stripes, and tables keep exact byte sizes and real percentages.
+
+The tool currently supports the streaming format whose magic is `vsagstm0`,
+including streaming BruteForce, HGraph, IVF, SINDI, and Pyramid index files.
+Footer-based legacy index files are reported as unsupported.

--- a/tools/visualize_index/visualize_index.cpp
+++ b/tools/visualize_index/visualize_index.cpp
@@ -1,0 +1,1104 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <algorithm>
+#include <argparse/argparse.hpp>
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <nlohmann/json.hpp>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "storage/serialization_tags.h"
+#include "vsag/constants.h"
+
+namespace {
+
+constexpr uint64_t STREAM_BLOCK_HEADER_SIZE = 4 + 4 + 8 + 8 + 4;
+constexpr uint64_t STREAM_BLOCK_CRITICAL_FLAG = 1;
+constexpr uint64_t STREAM_METADATA_CHECKSUM_SIZE = 4;
+constexpr uint64_t STREAM_HEADER_MAX_METADATA_LEN = 16ULL * 1024ULL * 1024ULL;
+constexpr uint64_t TERMINAL_BAR_WIDTH = 96;
+constexpr uint64_t TERMINAL_VERTICAL_BAR_WIDTH = 18;
+constexpr uint64_t TERMINAL_VERTICAL_SMALL_BLOCK_SIZE = 4ULL * 1024ULL;
+constexpr uint64_t TERMINAL_VERTICAL_HUGE_ROWS = 4;
+constexpr uint64_t TERMINAL_VERTICAL_MAX_ROWS = 10;
+constexpr double EXPLODED_LARGE_SEGMENT_THRESHOLD = 0.60;
+constexpr double EXPLODED_LARGE_SEGMENT_WIDTH = 0.18;
+
+struct StreamBlockHeaderView {
+    uint32_t tag{0};
+    uint32_t block_version{0};
+    uint64_t flags{0};
+    uint64_t value_len{0};
+    uint32_t payload_checksum{0};
+
+    [[nodiscard]] bool
+    IsCritical() const {
+        return (flags & STREAM_BLOCK_CRITICAL_FLAG) != 0;
+    }
+
+    [[nodiscard]] bool
+    IsSectionEnd() const {
+        return tag == 0;
+    }
+};
+
+struct Segment {
+    std::string name;
+    std::string kind;
+    uint64_t offset{0};
+    uint64_t size{0};
+    std::string detail;
+    std::string color;
+};
+
+struct ParsedIndex {
+    uint64_t file_size{0};
+    uint16_t format_major{0};
+    uint16_t format_minor{0};
+    std::string metadata_json;
+    std::vector<Segment> segments;
+};
+
+struct VisualSegment {
+    const Segment* segment{nullptr};
+    double width_ratio{0.0};
+    bool folded{false};
+};
+
+struct LogicalBlock {
+    std::string name;
+    std::string kind;
+    uint64_t offset{0};
+    uint64_t size{0};
+    std::string color;
+    std::vector<const Segment*> segments;
+};
+
+struct VisualBlock {
+    const LogicalBlock* block{nullptr};
+    double width_ratio{0.0};
+    bool folded{false};
+};
+
+std::string
+escape_html(const std::string& input) {
+    std::string output;
+    output.reserve(input.size());
+    for (char ch : input) {
+        switch (ch) {
+            case '&':
+                output += "&amp;";
+                break;
+            case '<':
+                output += "&lt;";
+                break;
+            case '>':
+                output += "&gt;";
+                break;
+            case '"':
+                output += "&quot;";
+                break;
+            case '\'':
+                output += "&#39;";
+                break;
+            default:
+                output += ch;
+                break;
+        }
+    }
+    return output;
+}
+
+std::string
+format_bytes(uint64_t bytes) {
+    constexpr double kib = 1024.0;
+    constexpr double mib = 1024.0 * 1024.0;
+    constexpr double gib = 1024.0 * 1024.0 * 1024.0;
+
+    std::ostringstream out;
+    if (bytes >= static_cast<uint64_t>(gib)) {
+        out << std::fixed << std::setprecision(2) << static_cast<double>(bytes) / gib << " GiB";
+    } else if (bytes >= static_cast<uint64_t>(mib)) {
+        out << std::fixed << std::setprecision(2) << static_cast<double>(bytes) / mib << " MiB";
+    } else if (bytes >= static_cast<uint64_t>(kib)) {
+        out << std::fixed << std::setprecision(2) << static_cast<double>(bytes) / kib << " KiB";
+    } else {
+        out << bytes << " B";
+    }
+    return out.str();
+}
+
+std::string
+format_percent(uint64_t size, uint64_t total) {
+    std::ostringstream out;
+    const double percent = total == 0 ? 0.0 : static_cast<double>(size) * 100.0 / total;
+    out << std::fixed << std::setprecision(2) << percent << "%";
+    return out.str();
+}
+
+uint64_t
+file_size(std::ifstream& input) {
+    input.seekg(0, std::ios::end);
+    const auto end = input.tellg();
+    if (end < 0) {
+        throw std::runtime_error("failed to get input file size");
+    }
+    input.seekg(0, std::ios::beg);
+    return static_cast<uint64_t>(end);
+}
+
+uint64_t
+current_offset(std::istream& input) {
+    const auto cursor = input.tellg();
+    if (cursor < 0) {
+        throw std::runtime_error("failed to get current input offset");
+    }
+    return static_cast<uint64_t>(cursor);
+}
+
+void
+read_exact(std::istream& input, char* data, uint64_t size) {
+    if (size > static_cast<uint64_t>(std::numeric_limits<std::streamsize>::max())) {
+        throw std::runtime_error("read size is too large");
+    }
+    input.read(data, static_cast<std::streamsize>(size));
+    if (!input) {
+        throw std::runtime_error("unexpected end of index file");
+    }
+}
+
+template <typename T>
+T
+read_obj(std::istream& input) {
+    T value{};
+    read_exact(input, reinterpret_cast<char*>(&value), sizeof(value));
+    return value;
+}
+
+uint32_t
+calculate_checksum(std::string_view bytes) {
+    const uint32_t polynomial = 0xEDB88320;
+    uint32_t crc = 0xFFFFFFFF;
+    for (const char& byte : bytes) {
+        crc ^= static_cast<uint8_t>(byte);
+        for (uint64_t j = 0; j < 8; ++j) {
+            crc = (crc >> 1) ^ ((crc & 1) == 1 ? polynomial : 0);
+        }
+    }
+    return crc ^ 0xFFFFFFFF;
+}
+
+StreamBlockHeaderView
+read_block_header(std::istream& input) {
+    StreamBlockHeaderView header;
+    header.tag = read_obj<uint32_t>(input);
+    header.block_version = read_obj<uint32_t>(input);
+    header.flags = read_obj<uint64_t>(input);
+    header.value_len = read_obj<uint64_t>(input);
+    header.payload_checksum = read_obj<uint32_t>(input);
+    if (header.IsSectionEnd() && (header.block_version != 0 || header.flags != 0 ||
+                                  header.value_len != 0 || header.payload_checksum != 0)) {
+        throw std::runtime_error("invalid streaming serialization section end block");
+    }
+    return header;
+}
+
+void
+skip_forward(std::istream& input, uint64_t size) {
+    constexpr uint64_t buffer_size = 8192;
+    std::array<char, buffer_size> buffer{};
+    uint64_t remaining = size;
+    while (remaining > 0) {
+        const uint64_t read_size = std::min<uint64_t>(remaining, buffer_size);
+        read_exact(input, buffer.data(), read_size);
+        remaining -= read_size;
+    }
+}
+
+void
+add_segment(std::vector<Segment>& segments,
+            std::string name,
+            std::string kind,
+            uint64_t offset,
+            uint64_t size,
+            std::string detail,
+            std::string color) {
+    segments.push_back(Segment{
+        std::move(name), std::move(kind), offset, size, std::move(detail), std::move(color)});
+}
+
+std::string
+streaming_tag_name(uint32_t tag) {
+    std::string name = vsag::StreamSerializationTagName(tag);
+    if (name == "unknown") {
+        name += "_" + std::to_string(tag);
+    }
+    return name;
+}
+
+ParsedIndex
+parse_streaming_index(const std::string& index_path) {
+    std::ifstream input(index_path, std::ios::binary);
+    if (!input.is_open()) {
+        throw std::runtime_error("failed to open index file: " + index_path);
+    }
+
+    ParsedIndex parsed;
+    parsed.file_size = file_size(input);
+    const uint64_t magic_offset = current_offset(input);
+    std::array<char, 9> magic{};
+    read_exact(input, magic.data(), 8);
+    if (std::string_view(magic.data(), 8) != vsag::SERIAL_STREAM_MAGIC) {
+        throw std::runtime_error("unsupported index format: only streaming magic " +
+                                 std::string(vsag::SERIAL_STREAM_MAGIC) + " is supported");
+    }
+    add_segment(parsed.segments,
+                "stream_magic",
+                "header",
+                magic_offset,
+                8,
+                std::string(magic.data(), 8),
+                "#5465ff");
+
+    const uint64_t version_offset = current_offset(input);
+    parsed.format_major = read_obj<uint16_t>(input);
+    parsed.format_minor = read_obj<uint16_t>(input);
+    add_segment(parsed.segments,
+                "format_version",
+                "header",
+                version_offset,
+                4,
+                std::to_string(parsed.format_major) + "." + std::to_string(parsed.format_minor),
+                "#6a8dff");
+
+    const uint64_t metadata_len_offset = current_offset(input);
+    const uint64_t metadata_len = read_obj<uint64_t>(input);
+    add_segment(parsed.segments,
+                "metadata_length",
+                "header",
+                metadata_len_offset,
+                8,
+                std::to_string(metadata_len),
+                "#8aa4ff");
+
+    const uint64_t metadata_offset = current_offset(input);
+    if (metadata_len > STREAM_HEADER_MAX_METADATA_LEN) {
+        throw std::runtime_error("streaming serialization metadata is too large");
+    }
+    parsed.metadata_json.resize(metadata_len);
+    if (metadata_len > 0) {
+        read_exact(input, parsed.metadata_json.data(), metadata_len);
+    }
+    add_segment(parsed.segments,
+                "metadata_json",
+                "metadata",
+                metadata_offset,
+                metadata_len,
+                "StreamHeader metadata",
+                "#33a02c");
+
+    const uint64_t metadata_checksum_offset = current_offset(input);
+    const uint32_t metadata_checksum = read_obj<uint32_t>(input);
+    const uint32_t calculated_checksum = calculate_checksum(parsed.metadata_json);
+    add_segment(parsed.segments,
+                "metadata_checksum",
+                "header",
+                metadata_checksum_offset,
+                STREAM_METADATA_CHECKSUM_SIZE,
+                metadata_checksum == calculated_checksum ? "crc32 ok" : "crc32 mismatch",
+                metadata_checksum == calculated_checksum ? "#74c476" : "#e31a1c");
+
+    while (true) {
+        const uint64_t block_header_offset = current_offset(input);
+        auto block_header = read_block_header(input);
+        const std::string tag_name = streaming_tag_name(block_header.tag);
+
+        if (block_header.IsSectionEnd()) {
+            add_segment(parsed.segments,
+                        "section_end",
+                        "block_header",
+                        block_header_offset,
+                        STREAM_BLOCK_HEADER_SIZE,
+                        "tag=0",
+                        "#6c757d");
+            break;
+        }
+
+        std::ostringstream block_detail;
+        block_detail << "tag=" << block_header.tag << " (" << tag_name
+                     << "), version=" << block_header.block_version
+                     << ", critical=" << (block_header.IsCritical() ? "true" : "false")
+                     << ", payload=" << block_header.value_len << " bytes";
+        add_segment(parsed.segments,
+                    tag_name + "_header",
+                    "block_header",
+                    block_header_offset,
+                    STREAM_BLOCK_HEADER_SIZE,
+                    block_detail.str(),
+                    "#fdbf6f");
+
+        if (block_header.value_len == std::numeric_limits<uint64_t>::max()) {
+            throw std::runtime_error(
+                "chunked streaming block payload is not supported by visualize_index yet");
+        }
+
+        const uint64_t payload_offset = current_offset(input);
+        add_segment(parsed.segments,
+                    tag_name + "_payload",
+                    block_header.IsCritical() ? "critical_payload" : "optional_payload",
+                    payload_offset,
+                    block_header.value_len,
+                    block_detail.str(),
+                    block_header.IsCritical() ? "#1f78b4" : "#a6cee3");
+        skip_forward(input, block_header.value_len);
+    }
+
+    const uint64_t consumed = current_offset(input);
+    if (consumed < parsed.file_size) {
+        add_segment(parsed.segments,
+                    "trailing_bytes",
+                    "trailing",
+                    consumed,
+                    parsed.file_size - consumed,
+                    "bytes after SECTION_END",
+                    "#b15928");
+    }
+
+    return parsed;
+}
+
+double
+segment_ratio(const Segment& segment, uint64_t total) {
+    if (total == 0) {
+        return 0.0;
+    }
+    return static_cast<double>(segment.size) / static_cast<double>(total);
+}
+
+std::vector<VisualSegment>
+build_raw_view(const ParsedIndex& parsed) {
+    std::vector<VisualSegment> view;
+    view.reserve(parsed.segments.size());
+    for (const auto& segment : parsed.segments) {
+        view.push_back(VisualSegment{&segment, segment_ratio(segment, parsed.file_size), false});
+    }
+    return view;
+}
+
+std::vector<uint64_t>
+allocate_terminal_units(const std::vector<VisualSegment>& view, uint64_t total_units) {
+    std::vector<uint64_t> units(view.size(), 0);
+    if (view.empty() || total_units == 0) {
+        return units;
+    }
+
+    uint64_t used_units = 0;
+    for (uint64_t i = 0; i < view.size(); ++i) {
+        const auto index = static_cast<size_t>(i);
+        const auto& segment = *view[index].segment;
+        units[index] = static_cast<uint64_t>(view[index].width_ratio * total_units);
+        if (segment.size > 0 && units[index] == 0) {
+            units[index] = 1;
+        }
+        used_units += units[index];
+    }
+
+    while (used_units > total_units) {
+        auto largest = std::max_element(units.begin(), units.end());
+        if (largest == units.end() || *largest <= 1) {
+            break;
+        }
+        --(*largest);
+        --used_units;
+    }
+
+    while (used_units < total_units) {
+        auto largest =
+            std::max_element(view.begin(), view.end(), [](const auto& lhs, const auto& rhs) {
+                return lhs.width_ratio < rhs.width_ratio;
+            });
+        if (largest == view.end()) {
+            break;
+        }
+        ++units[static_cast<size_t>(std::distance(view.begin(), largest))];
+        ++used_units;
+    }
+    return units;
+}
+
+std::string
+ansi_color_for(const Segment& segment) {
+    if (segment.name == "stream_magic") {
+        return "\033[45m";
+    }
+    if (segment.name == "format_version") {
+        return "\033[46m";
+    }
+    if (segment.name == "metadata_length") {
+        return "\033[44m";
+    }
+    if (segment.name == "metadata_checksum") {
+        return segment.detail == "crc32 ok" ? "\033[42m" : "\033[41m";
+    }
+    if (segment.kind == "metadata") {
+        return "\033[42m";
+    }
+    if (segment.kind == "critical_payload") {
+        return "\033[44m";
+    }
+    if (segment.kind == "optional_payload") {
+        return "\033[46m";
+    }
+    if (segment.kind == "block_header") {
+        return "\033[43m";
+    }
+    if (segment.kind == "trailing") {
+        return "\033[41m";
+    }
+    if (segment.kind == "header") {
+        return "\033[45m";
+    }
+    return "\033[47m";
+}
+
+void
+print_terminal_horizontal_bar(const std::string& title, const std::vector<VisualSegment>& view) {
+    std::cout << title << std::endl;
+    auto widths = allocate_terminal_units(view, TERMINAL_BAR_WIDTH);
+    for (uint64_t i = 0; i < view.size(); ++i) {
+        const auto index = static_cast<size_t>(i);
+        const auto& visual = view[index];
+        const auto& segment = *visual.segment;
+        const uint64_t width = widths[index];
+        const char fill = visual.folded ? '/' : ' ';
+        std::cout << ansi_color_for(segment) << std::string(static_cast<size_t>(width), fill)
+                  << "\033[0m";
+    }
+    std::cout << std::endl << std::endl;
+}
+
+std::vector<LogicalBlock>
+build_logical_blocks(const ParsedIndex& parsed);
+
+void
+print_terminal_logical_block_bars(const std::string& title,
+                                  const std::vector<LogicalBlock>& blocks,
+                                  uint64_t total_size);
+
+void
+print_summary(const ParsedIndex& parsed) {
+    std::cout << "Streaming index layout" << std::endl;
+    std::cout << "Format: " << parsed.format_major << "." << parsed.format_minor << std::endl;
+    std::cout << "File size: " << parsed.file_size << " bytes (" << format_bytes(parsed.file_size)
+              << ")" << std::endl
+              << std::endl;
+
+    auto raw_view = build_raw_view(parsed);
+    print_terminal_horizontal_bar(
+        "Raw horizontal layout by real byte proportion (rounded to 96 terminal columns):",
+        raw_view);
+    const auto logical_blocks = build_logical_blocks(parsed);
+    print_terminal_logical_block_bars(
+        "Exploded vertical layout by logical block size:", logical_blocks, parsed.file_size);
+
+    std::cout << std::left << std::setw(4) << "#" << std::setw(26) << "name" << std::setw(18)
+              << "kind" << std::right << std::setw(14) << "offset" << std::setw(14) << "size"
+              << std::setw(10) << "percent"
+              << "  detail" << std::endl;
+
+    for (uint64_t i = 0; i < parsed.segments.size(); ++i) {
+        const auto& segment = parsed.segments[static_cast<size_t>(i)];
+        std::cout << std::left << std::setw(4) << i << std::setw(26) << segment.name
+                  << std::setw(18) << segment.kind << std::right << std::setw(14) << segment.offset
+                  << std::setw(14) << segment.size << std::setw(10)
+                  << format_percent(segment.size, parsed.file_size) << "  " << segment.detail
+                  << std::endl;
+    }
+}
+
+std::string
+base_block_name(const std::string& name) {
+    constexpr std::string_view header_suffix = "_header";
+    constexpr std::string_view payload_suffix = "_payload";
+    if (name.size() > header_suffix.size() &&
+        name.compare(name.size() - header_suffix.size(), header_suffix.size(), header_suffix) ==
+            0) {
+        return name.substr(0, name.size() - header_suffix.size());
+    }
+    if (name.size() > payload_suffix.size() &&
+        name.compare(name.size() - payload_suffix.size(), payload_suffix.size(), payload_suffix) ==
+            0) {
+        return name.substr(0, name.size() - payload_suffix.size());
+    }
+    return name;
+}
+
+std::string
+logical_block_detail(const LogicalBlock& block, uint64_t total_size) {
+    std::ostringstream detail;
+    detail << block.name << " - " << block.size << " bytes - "
+           << format_percent(block.size, total_size);
+    for (const auto* segment : block.segments) {
+        detail << "\n" << segment->name << ": " << segment->size << " bytes @ " << segment->offset;
+    }
+    return detail.str();
+}
+
+std::string
+logical_block_color(uint64_t index) {
+    static const std::array<const char*, 10> colors{"#4c78a8",
+                                                    "#f58518",
+                                                    "#54a24b",
+                                                    "#e45756",
+                                                    "#72b7b2",
+                                                    "#b279a2",
+                                                    "#ff9da6",
+                                                    "#9d755d",
+                                                    "#bab0ac",
+                                                    "#59a14f"};
+    return colors[static_cast<size_t>(index % colors.size())];
+}
+
+std::vector<LogicalBlock>
+build_logical_blocks(const ParsedIndex& parsed) {
+    std::vector<LogicalBlock> blocks;
+    LogicalBlock stream_header;
+    stream_header.name = "stream_header";
+    stream_header.kind = "header_group";
+    stream_header.color = "#6f79d8";
+
+    for (const auto& segment : parsed.segments) {
+        if (segment.name == "section_end" || segment.name == "trailing_bytes") {
+            LogicalBlock block;
+            block.name = segment.name;
+            block.kind = segment.kind;
+            block.offset = segment.offset;
+            block.size = segment.size;
+            block.color = segment.color;
+            block.segments.push_back(&segment);
+            blocks.push_back(std::move(block));
+            continue;
+        }
+
+        const bool is_tlv_part = segment.name.size() > std::string("_header").size() &&
+                                 (segment.name.rfind("_header") == segment.name.size() - 7 ||
+                                  segment.name.rfind("_payload") == segment.name.size() - 8);
+        if (!is_tlv_part) {
+            if (stream_header.segments.empty()) {
+                stream_header.offset = segment.offset;
+            }
+            stream_header.size += segment.size;
+            stream_header.segments.push_back(&segment);
+            continue;
+        }
+
+        if (!stream_header.segments.empty()) {
+            blocks.push_back(std::move(stream_header));
+            stream_header = LogicalBlock{};
+        }
+
+        const auto block_name = base_block_name(segment.name);
+        if (blocks.empty() || blocks.back().name != block_name) {
+            LogicalBlock block;
+            block.name = block_name;
+            block.kind = "tlv_block";
+            block.offset = segment.offset;
+            block.color = logical_block_color(blocks.size());
+            blocks.push_back(std::move(block));
+        }
+        auto& block = blocks.back();
+        block.size += segment.size;
+        block.segments.push_back(&segment);
+        if (segment.kind == "block_header" && block.color.empty()) {
+            block.color = segment.color;
+        }
+    }
+
+    if (!stream_header.segments.empty()) {
+        blocks.push_back(std::move(stream_header));
+    }
+    return blocks;
+}
+
+std::string
+ansi_color_for_logical_block(const LogicalBlock& block, uint64_t index) {
+    if (block.kind == "header_group") {
+        return "\033[45m";
+    }
+    if (block.kind == "trailing") {
+        return "\033[41m";
+    }
+    if (block.name == "section_end") {
+        return "\033[43m";
+    }
+    static const std::array<const char*, 6> colors{
+        "\033[44m", "\033[46m", "\033[42m", "\033[43m", "\033[45m", "\033[41m"};
+    return colors[static_cast<size_t>(index % colors.size())];
+}
+
+void
+print_terminal_logical_block_bars(const std::string& title,
+                                  const std::vector<LogicalBlock>& blocks,
+                                  uint64_t total_size) {
+    std::cout << title << std::endl;
+    constexpr uint64_t bar_width = 32;
+    for (uint64_t i = 0; i < blocks.size(); ++i) {
+        const auto& block = blocks[static_cast<size_t>(i)];
+        const double ratio =
+            total_size == 0 ? 0.0
+                            : static_cast<double>(block.size) / static_cast<double>(total_size);
+        uint64_t width = static_cast<uint64_t>(std::round(ratio * bar_width));
+        if (block.size > 0 && width == 0) {
+            width = 1;
+        }
+        width = std::min<uint64_t>(bar_width, width);
+        const uint64_t padding = bar_width - width;
+        std::cout << std::left << std::setw(18) << block.name << " ["
+                  << ansi_color_for_logical_block(block, i)
+                  << std::string(static_cast<size_t>(width), ' ') << "\033[0m"
+                  << std::string(static_cast<size_t>(padding), ' ') << "] " << std::right
+                  << std::setw(10) << format_bytes(block.size) << " " << std::setw(8)
+                  << format_percent(block.size, total_size) << "  " << block.segments.size()
+                  << " segment" << (block.segments.size() == 1 ? "" : "s") << std::endl;
+    }
+    std::cout << std::endl;
+}
+
+std::vector<VisualBlock>
+build_exploded_block_view(const std::vector<LogicalBlock>& blocks, uint64_t total_size) {
+    std::vector<VisualBlock> view;
+    view.reserve(blocks.size());
+    double reserved_width = 0.0;
+    double remaining_source_ratio = 0.0;
+    for (const auto& block : blocks) {
+        const double ratio = total_size == 0 ? 0.0 : static_cast<double>(block.size) / total_size;
+        const bool fold = ratio >= EXPLODED_LARGE_SEGMENT_THRESHOLD;
+        if (fold) {
+            reserved_width += EXPLODED_LARGE_SEGMENT_WIDTH;
+        } else {
+            remaining_source_ratio += ratio;
+        }
+        view.push_back(VisualBlock{&block, 0.0, fold});
+    }
+
+    const double remaining_width = std::max(0.0, 1.0 - reserved_width);
+    for (auto& visual : view) {
+        const double ratio =
+            total_size == 0 ? 0.0 : static_cast<double>(visual.block->size) / total_size;
+        if (visual.folded) {
+            visual.width_ratio = EXPLODED_LARGE_SEGMENT_WIDTH;
+        } else if (remaining_source_ratio > 0.0) {
+            visual.width_ratio = ratio / remaining_source_ratio * remaining_width;
+        }
+    }
+    return view;
+}
+
+std::string
+json_type_name(const nlohmann::json& value) {
+    if (value.is_object()) {
+        return "object";
+    }
+    if (value.is_array()) {
+        return "array";
+    }
+    if (value.is_string()) {
+        return "string";
+    }
+    if (value.is_boolean()) {
+        return "boolean";
+    }
+    if (value.is_number()) {
+        return "number";
+    }
+    if (value.is_null()) {
+        return "null";
+    }
+    return "unknown";
+}
+
+std::string
+json_value_summary(const nlohmann::json& value) {
+    if (value.is_string()) {
+        return value.get<std::string>();
+    }
+    if (value.is_object()) {
+        return "object (" + std::to_string(value.size()) + " keys)";
+    }
+    if (value.is_array()) {
+        return "array (" + std::to_string(value.size()) + " items)";
+    }
+    return value.dump();
+}
+
+bool
+try_parse_json(const std::string& raw, nlohmann::json& output) {
+    output = nlohmann::json::parse(raw, nullptr, false);
+    return !output.is_discarded();
+}
+
+std::string
+pretty_json_or_raw(const std::string& raw) {
+    nlohmann::json parsed;
+    if (try_parse_json(raw, parsed)) {
+        return parsed.dump(2);
+    }
+    return raw;
+}
+
+void
+write_json_table(std::ofstream& output, const nlohmann::json& object) {
+    output << "<table><thead><tr><th>Key</th><th>Type</th><th>Value</th></tr></thead><tbody>\n";
+    if (object.is_object()) {
+        for (const auto& item : object.items()) {
+            output << "<tr><td>" << escape_html(item.key()) << "</td><td>"
+                   << escape_html(json_type_name(item.value())) << "</td><td>"
+                   << escape_html(json_value_summary(item.value())) << "</td></tr>\n";
+        }
+    }
+    output << "</tbody></table>\n";
+}
+
+void
+write_metadata_overview(std::ofstream& output, const nlohmann::json& metadata) {
+    output << "<div class=\"meta-grid\">\n";
+    const std::array<std::string, 4> keys{"index_name", "format", "_update_time", "_empty"};
+    for (const auto& key : keys) {
+        if (!metadata.contains(key)) {
+            continue;
+        }
+        output << "<div class=\"meta-card\"><div class=\"meta-label\">" << escape_html(key)
+               << "</div><div class=\"meta-value\">"
+               << escape_html(json_value_summary(metadata.at(key))) << "</div></div>\n";
+    }
+    output << "</div>\n";
+}
+
+void
+write_block_manifest(std::ofstream& output, const nlohmann::json& metadata) {
+    if (!metadata.contains("block_manifest") || !metadata.at("block_manifest").is_array()) {
+        return;
+    }
+    output << "<h3>Block Manifest</h3>\n";
+    output << "<table class=\"manifest-table\"><colgroup><col class=\"manifest-name\"><col "
+              "class=\"manifest-center\"><col class=\"manifest-center\"><col "
+              "class=\"manifest-critical\"></colgroup><thead><tr><th>Name</th><th "
+              "class=\"manifest-center\">Tag</th><th class=\"manifest-center\">Version</th><th "
+              "class=\"manifest-critical\">Critical</th></tr>"
+              "</thead><tbody>\n";
+    for (const auto& block : metadata.at("block_manifest")) {
+        output << "<tr><td>" << escape_html(json_value_summary(block.value("name", "")))
+               << "</td><td class=\"manifest-center\">" << block.value("tag", 0)
+               << "</td><td class=\"manifest-center\">" << block.value("version", 0)
+               << "</td><td class=\"manifest-critical\">"
+               << (block.value("critical", false) ? "<span class=\"badge yes\">yes</span>"
+                                                  : "<span class=\"badge no\">no</span>")
+               << "</td></tr>\n";
+    }
+    output << "</tbody></table>\n";
+}
+
+void
+write_json_block(std::ofstream& output,
+                 const std::string& title,
+                 const std::string& content,
+                 bool enable_copy) {
+    output << R"(<div class="json-block"><div class="json-title"><h3>)" << escape_html(title)
+           << "</h3>";
+    if (enable_copy) {
+        output << R"HTML(<button type="button" class="copy-json" )HTML"
+               << R"HTML(onclick="copyJsonBlock(this)">Copy</button>)HTML";
+    }
+    output << R"(</div><pre class="json-pre">)" << escape_html(content) << "</pre></div>\n";
+}
+
+void
+write_pretty_json_section(std::ofstream& output,
+                          const std::string& title,
+                          const std::string& raw,
+                          bool enable_copy = false) {
+    if (raw.empty()) {
+        return;
+    }
+    write_json_block(output, title, pretty_json_or_raw(raw), enable_copy);
+}
+
+void
+write_metadata_panel(std::ofstream& output, const ParsedIndex& parsed) {
+    nlohmann::json metadata;
+    if (!try_parse_json(parsed.metadata_json, metadata) || !metadata.is_object()) {
+        output
+            << "<section class=\"panel metadata-panel\"><h2>Metadata</h2><pre class=\"json-pre\">"
+            << escape_html(parsed.metadata_json) << "</pre></section>\n";
+        return;
+    }
+
+    output << "<section class=\"panel metadata-panel\"><h2>Metadata</h2>\n";
+    write_metadata_overview(output, metadata);
+    write_block_manifest(output, metadata);
+
+    if (metadata.contains("basic_info") && metadata.at("basic_info").is_object()) {
+        output << "<h3>Basic Info</h3>\n";
+        write_json_table(output, metadata.at("basic_info"));
+        const auto& basic_info = metadata.at("basic_info");
+        if (basic_info.contains("index_param")) {
+            if (basic_info.at("index_param").is_string()) {
+                write_pretty_json_section(output,
+                                          "Basic Info / Index Param",
+                                          basic_info.at("index_param").get<std::string>(),
+                                          true);
+            } else {
+                write_json_block(
+                    output, "Basic Info / Index Param", basic_info.at("index_param").dump(2), true);
+            }
+        }
+    }
+
+    if (metadata.contains("build_param_snapshot")) {
+        if (metadata.at("build_param_snapshot").is_string()) {
+            write_pretty_json_section(output,
+                                      "Build Param Snapshot",
+                                      metadata.at("build_param_snapshot").get<std::string>());
+        } else {
+            output << "<h3>Build Param Snapshot</h3><pre class=\"json-pre\">"
+                   << escape_html(metadata.at("build_param_snapshot").dump(2)) << "</pre>\n";
+        }
+    }
+
+    write_json_block(output, "Full Metadata", metadata.dump(2), true);
+    output << "</section>\n";
+}
+
+void
+write_html(const ParsedIndex& parsed, const std::string& output_path) {
+    std::ofstream output(output_path, std::ios::binary);
+    if (!output.is_open()) {
+        throw std::runtime_error("failed to open html output path: " + output_path);
+    }
+
+    const auto logical_blocks = build_logical_blocks(parsed);
+    const auto exploded_blocks = build_exploded_block_view(logical_blocks, parsed.file_size);
+
+    output
+        << "<!doctype html>\n<html><head><meta charset=\"utf-8\">\n"
+        << "<title>VSAG streaming index layout</title>\n"
+        << "<style>\n"
+        << "body{font-family:Inter,Arial,sans-serif;margin:32px;background:#f7f8fa;color:#17202a;}"
+        << "h1{font-size:24px;margin:0 0 8px;}h2{font-size:18px;margin:28px 0 8px;}"
+        << ".muted{color:#5f6b7a}.note{color:#5f6b7a;font-size:13px;line-height:1.5}"
+        << ".summary{display:flex;gap:18px;flex-wrap:wrap;margin:12px 0 18px}.summary "
+           "span{background:#fff;border:1px solid #d7dde5;padding:8px 10px;font-size:13px}"
+        << ".panel{background:#fff;border:1px solid #d7dde5;padding:16px;margin:18px 0;}"
+        << ".bar{display:flex;align-items:stretch;width:100%;height:84px;border:1px solid "
+           "#cfd6df;background:#fff;}"
+        << ".block{position:relative;min-width:12px;max-width:52%;border-right:1px solid "
+           "rgba(255,255,255,.85);box-sizing:border-box;}"
+        << ".block.folded{background-image:repeating-linear-gradient(45deg,rgba(255,255,255,.55) "
+           "0,rgba(255,255,255,.55) 8px,rgba(0,0,0,.10) 8px,rgba(0,0,0,.10) 16px);}"
+        << ".block:hover::after{content:attr(data-tip);position:absolute;left:0;top:calc(100% + "
+           "6px);white-space:pre;background:#111827;color:#fff;padding:7px "
+           "9px;border-radius:4px;font-size:12px;z-index:10;max-width:680px;}"
+        << ".legend{display:flex;gap:12px;flex-wrap:wrap;margin:12px 0 0}.legend "
+           "span{display:inline-flex;align-items:center;gap:6px;font-size:12px}.sw{width:12px;"
+           "height:12px;display:inline-block;border:1px solid #c8ced8}"
+        << "table{border-collapse:collapse;width:100%;background:#fff;margin-top:16px}th,td{border-"
+           "bottom:1px solid #e5e7eb;padding:8px "
+           "10px;text-align:left;font-size:13px}th{background:#edf1f5}td.num{text-align:right;font-"
+           "variant-numeric:tabular-nums}"
+        << "pre{background:#111827;color:#e5e7eb;padding:16px;overflow:auto;max-height:360px;}"
+        << "h3{font-size:15px;margin:18px 0 8px}.metadata-panel{margin-top:24px}"
+        << ".meta-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:"
+           "10px;margin:12px 0}"
+        << ".meta-card{border:1px solid #d7dde5;background:#f8fafc;padding:10px}"
+        << ".meta-label{font-size:11px;text-transform:uppercase;color:#5f6b7a;margin-bottom:4px}"
+        << ".meta-value{font-size:13px;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;"
+           "word-break:break-word}"
+        << ".manifest-table{width:100%;table-layout:fixed}"
+        << ".manifest-table th,.manifest-table td{padding:8px 12px;white-space:nowrap}"
+        << ".manifest-table td:first-child{overflow:hidden;text-overflow:ellipsis}"
+        << ".manifest-name{width:auto}.manifest-center{width:96px;text-align:center}.manifest-"
+           "critical{width:120px;text-align:center}"
+        << ".badge{display:inline-block;min-width:34px;text-align:center;padding:2px "
+           "7px;border-radius:999px;font-size:11px;font-weight:600}"
+        << ".badge.yes{background:#dcfce7;color:#166534}.badge.no{background:#fee2e2;color:#991b1b}"
+        << ".json-block{margin-top:14px}.json-title{display:flex;align-items:center;gap:10px;"
+           "justify-content:space-between}.json-title h3{margin:0}.copy-json{border:1px solid "
+           "#cbd5e1;background:#f8fafc;color:#17202a;padding:4px 10px;border-radius:4px;"
+           "font-size:12px;cursor:pointer}.copy-json:hover{background:#edf1f5}.copy-json.copied{"
+           "border-color:#86efac;background:#dcfce7;color:#166534}.copy-json.failed{border-color:"
+           "#fecaca;background:#fee2e2;color:#991b1b}"
+        << ".json-pre{font-size:12px;line-height:1.45;border-radius:4px;max-height:520px;margin-"
+           "top:8px}"
+        << "</style></head><body>\n";
+
+    output << "<h1>VSAG streaming index layout</h1>\n";
+    output << "<div class=\"muted\">Grouped exploded layout for streaming serialization "
+              "files.</div>\n";
+    output << "<div class=\"summary\"><span>Format " << parsed.format_major << "."
+           << parsed.format_minor << "</span><span>Total " << parsed.file_size << " bytes ("
+           << format_bytes(parsed.file_size) << ")</span><span>Logical blocks "
+           << logical_blocks.size() << "</span></div>\n";
+
+    auto write_tip = [&](const LogicalBlock& block) {
+        return escape_html(logical_block_detail(block, parsed.file_size));
+    };
+
+    output
+        << "<section class=\"panel\"><h2>Grouped Exploded Layout</h2>\n"
+        << "<div class=\"note\">Related small segments are merged into logical blocks. "
+        << "Very large blocks are visually folded with diagonal stripes. Hover a block to inspect "
+        << "its internal segments; tables below keep exact byte sizes and real percentages.</div>\n"
+        << "<div class=\"bar\">\n";
+    for (const auto& visual : exploded_blocks) {
+        const auto& block = *visual.block;
+        output << "<div class=\"block" << (visual.folded ? " folded" : "")
+               << "\" style=\"flex:" << std::fixed << std::setprecision(8) << visual.width_ratio
+               << " 1 0;background-color:" << block.color << "\" data-tip=\"" << write_tip(block)
+               << "\"></div>\n";
+    }
+    output << "</div><div class=\"legend\">\n";
+    for (const auto& block : logical_blocks) {
+        output << "<span><i class=\"sw\" style=\"background-color:" << block.color << "\"></i>"
+               << escape_html(block.name) << "</span>\n";
+    }
+    output << "</div></section>\n";
+
+    output << "<h2>Logical Block Summary</h2>\n";
+    output << "<table><thead><tr><th>Name</th><th>Offset</th><th>Size</th><th>Percent</"
+              "th><th>Segments</th></tr></thead><tbody>\n";
+    for (const auto& block : logical_blocks) {
+        output << "<tr><td>" << escape_html(block.name) << "</td><td class=\"num\">" << block.offset
+               << "</td><td class=\"num\">" << block.size << "</td><td class=\"num\">"
+               << format_percent(block.size, parsed.file_size) << "</td><td>";
+        for (uint64_t i = 0; i < block.segments.size(); ++i) {
+            if (i > 0) {
+                output << ", ";
+            }
+            output << escape_html(block.segments[static_cast<size_t>(i)]->name);
+        }
+        output << "</td></tr>\n";
+    }
+    output << "</tbody></table>\n";
+
+    output << "<h2>Exact Segment Table</h2>\n";
+    output << "<table><thead><tr><th>#</th><th>Name</th><th>Kind</th><th>Offset</th>"
+           << "<th>Size</th><th>Percent</th><th>Detail</th></tr></thead><tbody>\n";
+    for (uint64_t i = 0; i < parsed.segments.size(); ++i) {
+        const auto& segment = parsed.segments[static_cast<size_t>(i)];
+        output << "<tr><td>" << i << "</td><td>" << escape_html(segment.name) << "</td><td>"
+               << escape_html(segment.kind) << "</td><td class=\"num\">" << segment.offset
+               << "</td><td class=\"num\">" << segment.size << "</td><td class=\"num\">"
+               << format_percent(segment.size, parsed.file_size) << "</td><td>"
+               << escape_html(segment.detail) << "</td></tr>\n";
+    }
+    output << "</tbody></table>\n";
+    write_metadata_panel(output, parsed);
+    output << R"(<script>
+function copyJsonBlock(button) {
+  var block = button.closest('.json-block');
+  var pre = block ? block.querySelector('pre') : null;
+  if (!pre) {
+    return;
+  }
+  var text = pre.textContent;
+  var finish = function(ok) {
+    button.classList.remove('copied', 'failed');
+    button.classList.add(ok ? 'copied' : 'failed');
+    button.textContent = ok ? 'Copied' : 'Failed';
+    window.setTimeout(function() {
+      button.classList.remove('copied', 'failed');
+      button.textContent = 'Copy';
+    }, 1200);
+  };
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    navigator.clipboard.writeText(text).then(
+      function() { finish(true); },
+      function() { fallbackCopy(text, finish); });
+  } else {
+    fallbackCopy(text, finish);
+  }
+}
+function fallbackCopy(text, finish) {
+  var area = document.createElement('textarea');
+  area.value = text;
+  area.setAttribute('readonly', '');
+  area.style.position = 'fixed';
+  area.style.left = '-9999px';
+  document.body.appendChild(area);
+  area.select();
+  var ok = false;
+  try {
+    ok = document.execCommand('copy');
+  } catch (err) {
+    ok = false;
+  }
+  document.body.removeChild(area);
+  finish(ok);
+}
+</script></body></html>
+)";
+}
+
+void
+parse_args(argparse::ArgumentParser& parser, int argc, char** argv) {
+    parser.add_argument<std::string>("--index_path", "-i")
+        .required()
+        .help("Streaming serialized index file path");
+    parser.add_argument<std::string>("--html")
+        .default_value(std::string())
+        .help("Optional output path for a self-contained HTML visualization");
+
+    try {
+        parser.parse_args(argc, argv);
+    } catch (const std::runtime_error& err) {
+        std::cerr << err.what() << std::endl;
+        std::cerr << parser;
+        std::exit(1);
+    }
+}
+
+}  // namespace
+
+int
+main(int argc, char** argv) {
+    argparse::ArgumentParser parser("visualize_index");
+    parse_args(parser, argc, argv);
+
+    try {
+        const auto index_path = parser.get<std::string>("--index_path");
+        const auto html_path = parser.get<std::string>("--html");
+        auto parsed = parse_streaming_index(index_path);
+        print_summary(parsed);
+        if (!html_path.empty()) {
+            write_html(parsed, html_path);
+            std::cout << std::endl << "HTML visualization written to: " << html_path << std::endl;
+        }
+    } catch (const std::exception& err) {
+        std::cerr << "visualize_index failed: " << err.what() << std::endl;
+        return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add a new header-first streaming serialization foundation with TLV body blocks
- add forward-only reader, bounded reader, counting writer, stream header, and TLV helpers
- expose the three streaming responsibilities through `SerializeStreaming`, `DeserializeStreaming`, and `Load`
- make `Load` take `LoadParameters`, which can be constructed from a JSON string and can also carry reader objects
- add end-to-end streaming adapters and compatibility coverage for BruteForce, HGraph, IVF, SINDI, and Pyramid

## API Direction
The streaming APIs now follow the split defined in #2255:

- `serialize`: full in-memory index to byte-stream serialization, with no options.
- `deserialize`: full byte-stream to in-memory index restoration, with no options.
- `Load`: policy-based loading for version compatibility, capability selection, and memory/reader placement.

`Load` takes a `LoadParameters` object. `LoadParameters` can be constructed from a JSON string for existing key-value loading policy usage, and can also carry reader objects for `reader_io`-backed blocks. The JSON policy reuses IO-related parameter names already used by `CreateIndex`, such as `base_io_type`, `base_file_path`, `precise_io_type`, `precise_file_path`, `raw_vector_io_type`, and `raw_vector_file_path`; `CreateIndex` parameters remain unchanged.

`Load` is where mixed memory/disk-state behavior belongs. For example, HGraph should be able to load basic codes into memory while binding high-precision codes to a reader and fetching that data lazily during search. BruteForce currently validates the API split and rejects unsupported reader-placement policies for required in-memory blocks.

## Scope
This PR is the first foundation milestone for the full streaming serialization feature. It keeps the existing footer-based serialization path unchanged, adds the shared stream/TLV infrastructure, and wires streaming serialization/deserialization through BruteForce, HGraph, IVF, SINDI, and Pyramid with targeted compatibility tests.

Resolves #2255

## Example
- `examples/cpp/403_persistent_streaming_load.cpp`

## Tests
- `make debug`
- `make test CASE="[streaming_serialization]"`
- `./build/tests/functests -d yes "[streaming]" --allow-running-no-tests`
- `make debug VSAG_ENABLE_EXAMPLES=ON`
