### PR TITLE
feat(eval): support Pyramid index paths in eval_performance tool

### DIFF
--- a/tools/eval/case/build_eval_case.cpp
+++ b/tools/eval/case/build_eval_case.cpp
@@ -68,6 +68,14 @@ BuildEvalCase::do_build() {
     } else {
         base->SparseVectors((const SparseVector*)this->dataset_ptr_->GetTrain());
     }
+    if (this->dataset_ptr_->HasPaths()) {
+        for (const auto& hname : this->dataset_ptr_->GetHierarchyNames()) {
+            const auto* paths = this->dataset_ptr_->GetTrainPaths(hname);
+            if (paths != nullptr) {
+                base->Paths(hname, paths);
+            }
+        }
+    }
     for (auto& monitor : monitors_) {
         monitor->Start();
     }

--- a/tools/eval/case/search_eval_case.cpp
+++ b/tools/eval/case/search_eval_case.cpp
@@ -172,6 +172,14 @@ SearchEvalCase::do_knn_search() {
         } else {
             query->SparseVectors((const SparseVector*)query_vector);
         }
+        if (this->dataset_ptr_->HasPaths()) {
+            for (const auto& hname : this->dataset_ptr_->GetHierarchyNames()) {
+                const auto* paths = this->dataset_ptr_->GetTestPaths(hname);
+                if (paths != nullptr) {
+                    query->Paths(hname, paths + query_id);
+                }
+            }
+        }
         return std::make_pair(std::move(query), query_vector);
     };
 
@@ -292,6 +300,14 @@ SearchEvalCase::do_knn_filter_search() {
                 } else if (this->dataset_ptr_->GetTestDataType() == vsag::DATATYPE_INT8) {
                     query->Int8Vectors((const int8_t*)query_vector);
                 }
+                if (this->dataset_ptr_->HasPaths()) {
+                    for (const auto& hname : this->dataset_ptr_->GetHierarchyNames()) {
+                        const auto* paths = this->dataset_ptr_->GetTestPaths(hname);
+                        if (paths != nullptr) {
+                            query->Paths(hname, paths + i);
+                        }
+                    }
+                }
                 auto test_label = test_labels[i];
                 auto filter = std::make_shared<FilterObj>(
                     train_labels, test_label, this->dataset_ptr_->GetValidRatio(test_label));
@@ -324,6 +340,14 @@ SearchEvalCase::do_knn_filter_search() {
                 query->Float32Vectors((const float*)query_vector);
             } else if (this->dataset_ptr_->GetTestDataType() == vsag::DATATYPE_INT8) {
                 query->Int8Vectors((const int8_t*)query_vector);
+            }
+            if (this->dataset_ptr_->HasPaths()) {
+                for (const auto& hname : this->dataset_ptr_->GetHierarchyNames()) {
+                    const auto* paths = this->dataset_ptr_->GetTestPaths(hname);
+                    if (paths != nullptr) {
+                        query->Paths(hname, paths + i);
+                    }
+                }
             }
             auto test_label = test_labels[i];
             auto filter = std::make_shared<FilterObj>(

--- a/tools/eval/case/search_eval_case.cpp
+++ b/tools/eval/case/search_eval_case.cpp
@@ -159,7 +159,18 @@ SearchEvalCase::do_knn_search() {
     this->logger_->Debug("query count is " + std::to_string(query_count));
     auto min_query = std::max(static_cast<uint64_t>(query_count), config_.search_query_count);
 
-    auto prepare_query = [this](uint64_t query_id) {
+    // Precompute per-hierarchy test path pointers to avoid repeated map lookups.
+    std::vector<std::pair<std::string, const std::string*>> test_path_refs;
+    if (this->dataset_ptr_->HasPaths()) {
+        for (const auto& hname : this->dataset_ptr_->GetHierarchyNames()) {
+            const auto* paths = this->dataset_ptr_->GetTestPaths(hname);
+            if (paths != nullptr) {
+                test_path_refs.emplace_back(hname, paths);
+            }
+        }
+    }
+
+    auto prepare_query = [this, &test_path_refs](uint64_t query_id) {
         auto query = vsag::Dataset::Make();
         query->NumElements(1)->Dim(this->dataset_ptr_->GetDim())->Owner(false);
         const void* query_vector = this->dataset_ptr_->GetOneTest(query_id);
@@ -172,13 +183,8 @@ SearchEvalCase::do_knn_search() {
         } else {
             query->SparseVectors((const SparseVector*)query_vector);
         }
-        if (this->dataset_ptr_->HasPaths()) {
-            for (const auto& hname : this->dataset_ptr_->GetHierarchyNames()) {
-                const auto* paths = this->dataset_ptr_->GetTestPaths(hname);
-                if (paths != nullptr) {
-                    query->Paths(hname, paths + query_id);
-                }
-            }
+        for (const auto& [hname, paths] : test_path_refs) {
+            query->Paths(hname, paths + query_id);
         }
         return std::make_pair(std::move(query), query_vector);
     };
@@ -282,6 +288,17 @@ SearchEvalCase::do_knn_filter_search() {
     }
     this->logger_->Debug("query count is " + std::to_string(query_count));
     auto min_query = std::max<int64_t>(query_count, 10000);
+
+    std::vector<std::pair<std::string, const std::string*>> filter_path_refs;
+    if (this->dataset_ptr_->HasPaths()) {
+        for (const auto& hname : this->dataset_ptr_->GetHierarchyNames()) {
+            const auto* paths = this->dataset_ptr_->GetTestPaths(hname);
+            if (paths != nullptr) {
+                filter_path_refs.emplace_back(hname, paths);
+            }
+        }
+    }
+
     for (auto& monitor : this->monitors_) {
         const bool is_latency_monitor =
             this->latency_monitor_ != nullptr and monitor.get() == this->latency_monitor_.get();
@@ -300,13 +317,8 @@ SearchEvalCase::do_knn_filter_search() {
                 } else if (this->dataset_ptr_->GetTestDataType() == vsag::DATATYPE_INT8) {
                     query->Int8Vectors((const int8_t*)query_vector);
                 }
-                if (this->dataset_ptr_->HasPaths()) {
-                    for (const auto& hname : this->dataset_ptr_->GetHierarchyNames()) {
-                        const auto* paths = this->dataset_ptr_->GetTestPaths(hname);
-                        if (paths != nullptr) {
-                            query->Paths(hname, paths + i);
-                        }
-                    }
+                for (const auto& [hname, paths] : filter_path_refs) {
+                    query->Paths(hname, paths + i);
                 }
                 auto test_label = test_labels[i];
                 auto filter = std::make_shared<FilterObj>(
@@ -341,13 +353,8 @@ SearchEvalCase::do_knn_filter_search() {
             } else if (this->dataset_ptr_->GetTestDataType() == vsag::DATATYPE_INT8) {
                 query->Int8Vectors((const int8_t*)query_vector);
             }
-            if (this->dataset_ptr_->HasPaths()) {
-                for (const auto& hname : this->dataset_ptr_->GetHierarchyNames()) {
-                    const auto* paths = this->dataset_ptr_->GetTestPaths(hname);
-                    if (paths != nullptr) {
-                        query->Paths(hname, paths + i);
-                    }
-                }
+            for (const auto& [hname, paths] : filter_path_refs) {
+                query->Paths(hname, paths + i);
             }
             auto test_label = test_labels[i];
             auto filter = std::make_shared<FilterObj>(

--- a/tools/eval/eval_dataset.cpp
+++ b/tools/eval/eval_dataset.cpp
@@ -612,40 +612,53 @@ EvalDataset::Load(const std::string& filename) {
                 continue;
             }
             H5::Group h_group = paths_group.openGroup(hname);
-            obj->hierarchy_names_.push_back(hname);
 
             auto read_string_dataset = [](H5::Group& group,
                                           const std::string& dsname,
                                           int64_t expected_count) -> std::vector<std::string> {
-                H5::DataSet ds = group.openDataSet(dsname);
-                H5::DataSpace space = ds.getSpace();
-                hsize_t dims[1];
-                space.getSimpleExtentDims(dims, NULL);
-                if (static_cast<int64_t>(dims[0]) != expected_count) {
-                    throw std::runtime_error("paths dataset size mismatch: expected " +
-                                             std::to_string(expected_count) + ", got " +
-                                             std::to_string(dims[0]));
+                try {
+                    H5::DataSet ds = group.openDataSet(dsname);
+                    H5::DataSpace space = ds.getSpace();
+                    hsize_t dims[1];
+                    space.getSimpleExtentDims(dims, NULL);
+                    if (static_cast<int64_t>(dims[0]) != expected_count) {
+                        throw std::runtime_error("paths dataset size mismatch: expected " +
+                                                 std::to_string(expected_count) + ", got " +
+                                                 std::to_string(dims[0]));
+                    }
+                    std::vector<const char*> raw(dims[0]);
+                    H5::StrType str_type(H5::PredType::C_S1, H5T_VARIABLE);
+                    ds.read(raw.data(), str_type);
+                    std::vector<std::string> result(dims[0]);
+                    for (hsize_t j = 0; j < dims[0]; ++j) {
+                        result[j] = raw[j] ? raw[j] : "";
+                    }
+                    H5::DataSet::vlenReclaim(raw.data(), str_type, space);
+                    return result;
+                } catch (H5::Exception&) {
+                    return {};
                 }
-                std::vector<const char*> raw(dims[0]);
-                H5::StrType str_type(H5::PredType::C_S1, H5T_VARIABLE);
-                ds.read(raw.data(), str_type);
-                std::vector<std::string> result(dims[0]);
-                for (hsize_t j = 0; j < dims[0]; ++j) {
-                    result[j] = raw[j] ? raw[j] : "";
-                }
-                H5::DataSet::vlenReclaim(raw.data(), str_type, space);
-                return result;
             };
 
-            obj->train_paths_[hname] = read_string_dataset(h_group, "train", obj->number_of_base_);
-            obj->test_paths_[hname] = read_string_dataset(h_group, "test", obj->number_of_query_);
+            auto train_paths = read_string_dataset(h_group, "train", obj->number_of_base_);
+            auto test_paths = read_string_dataset(h_group, "test", obj->number_of_query_);
 
-            logger::debug("loaded paths hierarchy '{}': {} train, {} test",
-                          hname,
-                          obj->train_paths_[hname].size(),
-                          obj->test_paths_[hname].size());
+            if (!train_paths.empty() || !test_paths.empty()) {
+                obj->hierarchy_names_.push_back(hname);
+                if (!train_paths.empty()) {
+                    obj->train_paths_[hname] = std::move(train_paths);
+                }
+                if (!test_paths.empty()) {
+                    obj->test_paths_[hname] = std::move(test_paths);
+                }
+                logger::debug("loaded paths hierarchy '{}': {} train, {} test",
+                              hname,
+                              obj->train_paths_.count(hname) ? obj->train_paths_[hname].size() : 0,
+                              obj->test_paths_.count(hname) ? obj->test_paths_[hname].size() : 0);
+            }
         }
-    } catch (H5::Exception&) {
+    } catch (H5::Exception& e) {
+        logger::debug("no /paths/ group in HDF5 file (not a Pyramid dataset)");
     }
 
     try {

--- a/tools/eval/eval_dataset.cpp
+++ b/tools/eval/eval_dataset.cpp
@@ -598,6 +598,56 @@ EvalDataset::Load(const std::string& filename) {
         }
     }
 
+    // Load Pyramid path hierarchies from /paths/ group (if present).
+    // Structure: /paths/<hierarchy_name>/train  (1D variable-length strings, size N)
+    //            /paths/<hierarchy_name>/test   (1D variable-length strings, size Q)
+    try {
+        H5::Group paths_group = file.openGroup("/paths");
+        hsize_t num_hierarchies = paths_group.getNumObjs();
+        for (hsize_t i = 0; i < num_hierarchies; ++i) {
+            std::string hname = paths_group.getObjnameByIdx(i);
+            H5O_info_t info;
+            paths_group.getObjinfo(hname, info);
+            if (info.type != H5O_type_t::H5O_TYPE_GROUP) {
+                continue;
+            }
+            H5::Group h_group = paths_group.openGroup(hname);
+            obj->hierarchy_names_.push_back(hname);
+
+            auto read_string_dataset = [](H5::Group& group,
+                                          const std::string& dsname,
+                                          int64_t expected_count) -> std::vector<std::string> {
+                H5::DataSet ds = group.openDataSet(dsname);
+                H5::DataSpace space = ds.getSpace();
+                hsize_t dims[1];
+                space.getSimpleExtentDims(dims, NULL);
+                if (static_cast<int64_t>(dims[0]) != expected_count) {
+                    throw std::runtime_error("paths dataset size mismatch: expected " +
+                                             std::to_string(expected_count) + ", got " +
+                                             std::to_string(dims[0]));
+                }
+                std::vector<const char*> raw(dims[0]);
+                H5::StrType str_type(H5::PredType::C_S1, H5T_VARIABLE);
+                ds.read(raw.data(), str_type);
+                std::vector<std::string> result(dims[0]);
+                for (hsize_t j = 0; j < dims[0]; ++j) {
+                    result[j] = raw[j] ? raw[j] : "";
+                }
+                H5::DataSet::vlenReclaim(raw.data(), str_type, space);
+                return result;
+            };
+
+            obj->train_paths_[hname] = read_string_dataset(h_group, "train", obj->number_of_base_);
+            obj->test_paths_[hname] = read_string_dataset(h_group, "test", obj->number_of_query_);
+
+            logger::debug("loaded paths hierarchy '{}': {} train, {} test",
+                          hname,
+                          obj->train_paths_[hname].size(),
+                          obj->test_paths_[hname].size());
+        }
+    } catch (H5::Exception&) {
+    }
+
     try {
         H5::Attribute attr = file.openAttribute("distance");
         H5::StrType str_type = attr.getStrType();
@@ -907,6 +957,37 @@ EvalDataset::Save(const EvalDatasetPtr& dataset, const std::string& filename) {
             DataSet off_ds = file.createDataSet(
                 "/test_token_sequences_offsets", PredType::NATIVE_UINT64, off_space);
             off_ds.write(offsets.data(), PredType::NATIVE_UINT64);
+        }
+    }
+
+    // write Pyramid path hierarchies (if present)
+    if (!dataset->train_paths_.empty()) {
+        H5::Group paths_group = file.createGroup("/paths");
+        H5::StrType str_type(H5::PredType::C_S1, H5T_VARIABLE);
+        for (const auto& [hname, train_vec] : dataset->train_paths_) {
+            H5::Group h_group = paths_group.createGroup(hname);
+            {
+                hsize_t dims[1] = {static_cast<hsize_t>(train_vec.size())};
+                H5::DataSpace dataspace(1, dims);
+                H5::DataSet ds = h_group.createDataSet("train", str_type, dataspace);
+                std::vector<const char*> ptrs(train_vec.size());
+                for (size_t i = 0; i < train_vec.size(); ++i) {
+                    ptrs[i] = train_vec[i].c_str();
+                }
+                ds.write(ptrs.data(), str_type);
+            }
+            auto test_it = dataset->test_paths_.find(hname);
+            if (test_it != dataset->test_paths_.end()) {
+                const auto& test_vec = test_it->second;
+                hsize_t dims[1] = {static_cast<hsize_t>(test_vec.size())};
+                H5::DataSpace dataspace(1, dims);
+                H5::DataSet ds = h_group.createDataSet("test", str_type, dataspace);
+                std::vector<const char*> ptrs(test_vec.size());
+                for (size_t i = 0; i < test_vec.size(); ++i) {
+                    ptrs[i] = test_vec[i].c_str();
+                }
+                ds.write(ptrs.data(), str_type);
+            }
         }
     }
 

--- a/tools/eval/eval_dataset.cpp
+++ b/tools/eval/eval_dataset.cpp
@@ -622,6 +622,8 @@ EvalDataset::Load(const std::string& filename) {
                     hsize_t dims[1];
                     space.getSimpleExtentDims(dims, NULL);
                     if (static_cast<int64_t>(dims[0]) != expected_count) {
+                        // Missing path datasets are optional, but present datasets must match
+                        // the base/query split they describe.
                         throw std::runtime_error("paths dataset size mismatch: expected " +
                                                  std::to_string(expected_count) + ", got " +
                                                  std::to_string(dims[0]));
@@ -642,6 +644,8 @@ EvalDataset::Load(const std::string& filename) {
 
             auto train_paths = read_string_dataset(h_group, "train", obj->number_of_base_);
             auto test_paths = read_string_dataset(h_group, "test", obj->number_of_query_);
+            auto train_count = train_paths.size();
+            auto test_count = test_paths.size();
 
             if (!train_paths.empty() || !test_paths.empty()) {
                 obj->hierarchy_names_.push_back(hname);
@@ -653,8 +657,8 @@ EvalDataset::Load(const std::string& filename) {
                 }
                 logger::debug("loaded paths hierarchy '{}': {} train, {} test",
                               hname,
-                              obj->train_paths_.count(hname) ? obj->train_paths_[hname].size() : 0,
-                              obj->test_paths_.count(hname) ? obj->test_paths_[hname].size() : 0);
+                              train_count,
+                              test_count);
             }
         }
     } catch (H5::Exception& e) {
@@ -974,33 +978,35 @@ EvalDataset::Save(const EvalDatasetPtr& dataset, const std::string& filename) {
     }
 
     // write Pyramid path hierarchies (if present)
-    if (!dataset->train_paths_.empty()) {
+    if (!dataset->train_paths_.empty() || !dataset->test_paths_.empty()) {
         H5::Group paths_group = file.createGroup("/paths");
         H5::StrType str_type(H5::PredType::C_S1, H5T_VARIABLE);
+        auto write_string_dataset = [&](H5::Group& group,
+                                        const std::string& dsname,
+                                        const std::vector<std::string>& values) {
+            hsize_t dims[1] = {static_cast<hsize_t>(values.size())};
+            H5::DataSpace dataspace(1, dims);
+            H5::DataSet ds = group.createDataSet(dsname, str_type, dataspace);
+            std::vector<const char*> ptrs(values.size());
+            for (uint64_t i = 0; i < values.size(); ++i) {
+                ptrs[i] = values[i].c_str();
+            }
+            ds.write(ptrs.data(), str_type);
+        };
         for (const auto& [hname, train_vec] : dataset->train_paths_) {
             H5::Group h_group = paths_group.createGroup(hname);
-            {
-                hsize_t dims[1] = {static_cast<hsize_t>(train_vec.size())};
-                H5::DataSpace dataspace(1, dims);
-                H5::DataSet ds = h_group.createDataSet("train", str_type, dataspace);
-                std::vector<const char*> ptrs(train_vec.size());
-                for (size_t i = 0; i < train_vec.size(); ++i) {
-                    ptrs[i] = train_vec[i].c_str();
-                }
-                ds.write(ptrs.data(), str_type);
-            }
+            write_string_dataset(h_group, "train", train_vec);
             auto test_it = dataset->test_paths_.find(hname);
             if (test_it != dataset->test_paths_.end()) {
-                const auto& test_vec = test_it->second;
-                hsize_t dims[1] = {static_cast<hsize_t>(test_vec.size())};
-                H5::DataSpace dataspace(1, dims);
-                H5::DataSet ds = h_group.createDataSet("test", str_type, dataspace);
-                std::vector<const char*> ptrs(test_vec.size());
-                for (size_t i = 0; i < test_vec.size(); ++i) {
-                    ptrs[i] = test_vec[i].c_str();
-                }
-                ds.write(ptrs.data(), str_type);
+                write_string_dataset(h_group, "test", test_it->second);
             }
+        }
+        for (const auto& [hname, test_vec] : dataset->test_paths_) {
+            if (dataset->train_paths_.count(hname) != 0) {
+                continue;
+            }
+            H5::Group h_group = paths_group.createGroup(hname);
+            write_string_dataset(h_group, "test", test_vec);
         }
     }
 

--- a/tools/eval/eval_dataset.cpp
+++ b/tools/eval/eval_dataset.cpp
@@ -602,57 +602,87 @@ EvalDataset::Load(const std::string& filename) {
     // Structure: /paths/<hierarchy_name>/train  (1D variable-length strings, size N)
     //            /paths/<hierarchy_name>/test   (1D variable-length strings, size Q)
     try {
-        H5::Group paths_group = file.openGroup("/paths");
-        hsize_t num_hierarchies = paths_group.getNumObjs();
-        for (hsize_t i = 0; i < num_hierarchies; ++i) {
-            std::string hname = paths_group.getObjnameByIdx(i);
-            H5O_info_t info;
-            paths_group.getObjinfo(hname, info);
-            if (info.type != H5O_type_t::H5O_TYPE_GROUP) {
-                continue;
-            }
-            H5::Group h_group = paths_group.openGroup(hname);
-
-            auto read_string_dataset = [](H5::Group& group,
-                                          const std::string& dsname,
-                                          int64_t expected_count) -> std::vector<std::string> {
-                try {
-                    H5::DataSet ds = group.openDataSet(dsname);
-                    H5::DataSpace space = ds.getSpace();
-                    hsize_t dims[1];
-                    space.getSimpleExtentDims(dims, NULL);
-                    if (static_cast<int64_t>(dims[0]) != expected_count) {
-                        // Missing path datasets are optional, but present datasets must match
-                        // the base/query split they describe.
-                        throw std::runtime_error("paths dataset size mismatch: expected " +
-                                                 std::to_string(expected_count) + ", got " +
-                                                 std::to_string(dims[0]));
-                    }
-                    std::vector<const char*> raw(dims[0]);
-                    H5::StrType str_type(H5::PredType::C_S1, H5T_VARIABLE);
-                    ds.read(raw.data(), str_type);
-                    std::vector<std::string> result(dims[0]);
-                    for (hsize_t j = 0; j < dims[0]; ++j) {
-                        result[j] = raw[j] ? raw[j] : "";
-                    }
-                    H5::DataSet::vlenReclaim(raw.data(), str_type, space);
-                    return result;
-                } catch (H5::Exception&) {
-                    return {};
+        if (!file.nameExists("/paths")) {
+            logger::debug("no /paths group in HDF5 file");
+        } else {
+            H5::Group paths_group = file.openGroup("/paths");
+            hsize_t num_hierarchies = paths_group.getNumObjs();
+            for (hsize_t i = 0; i < num_hierarchies; ++i) {
+                std::string hname = paths_group.getObjnameByIdx(i);
+                const std::string hierarchy_path = "/paths/" + hname;
+                H5O_info_t info;
+                paths_group.getObjinfo(hname, info);
+                if (info.type != H5O_type_t::H5O_TYPE_GROUP) {
+                    throw std::runtime_error("Pyramid path hierarchy '" + hierarchy_path +
+                                             "' must be an HDF5 group");
                 }
-            };
+                H5::Group h_group = paths_group.openGroup(hname);
 
-            auto train_paths = read_string_dataset(h_group, "train", obj->number_of_base_);
-            auto test_paths = read_string_dataset(h_group, "test", obj->number_of_query_);
-            auto train_count = train_paths.size();
-            auto test_count = test_paths.size();
+                auto read_string_dataset = [&filename](
+                                               H5::Group& group,
+                                               const std::string& dsname,
+                                               const std::string& dataset_path,
+                                               int64_t expected_count) -> std::vector<std::string> {
+                    try {
+                        H5::DataSet ds = group.openDataSet(dsname);
+                        H5::DataSpace space = ds.getSpace();
+                        const int rank = space.getSimpleExtentNdims();
+                        if (rank != 1) {
+                            throw std::runtime_error(
+                                "Pyramid path dataset '" + dataset_path + "' in '" + filename +
+                                "' must be one-dimensional, got rank " + std::to_string(rank));
+                        }
+                        hsize_t dim = 0;
+                        space.getSimpleExtentDims(&dim, nullptr);
+                        if (static_cast<int64_t>(dim) != expected_count) {
+                            throw std::runtime_error("Pyramid path dataset '" + dataset_path +
+                                                     "' in '" + filename + "' has size " +
+                                                     std::to_string(dim) + ", expected " +
+                                                     std::to_string(expected_count));
+                        }
+                        const auto count = static_cast<uint64_t>(dim);
+                        if (count == 0) {
+                            return {};
+                        }
+                        std::vector<char*> raw(count);
+                        H5::StrType str_type(H5::PredType::C_S1, H5T_VARIABLE);
+                        ds.read(raw.data(), str_type);
+                        std::vector<std::string> result(count);
+                        for (uint64_t j = 0; j < count; ++j) {
+                            result[j] = raw[j] ? raw[j] : "";
+                        }
+                        H5::DataSet::vlenReclaim(raw.data(), str_type, space);
+                        return result;
+                    } catch (const H5::Exception& e) {
+                        throw std::runtime_error("failed to load Pyramid path dataset '" +
+                                                 dataset_path + "' from '" + filename +
+                                                 "': " + e.getDetailMsg());
+                    }
+                };
 
-            if (!train_paths.empty() || !test_paths.empty()) {
-                obj->hierarchy_names_.push_back(hname);
-                if (!train_paths.empty()) {
+                const bool has_train = h_group.nameExists("train");
+                const bool has_test = h_group.nameExists("test");
+                if (!has_train && !has_test) {
+                    continue;
+                }
+
+                std::vector<std::string> train_paths;
+                if (has_train) {
+                    train_paths = read_string_dataset(
+                        h_group, "train", hierarchy_path + "/train", obj->number_of_base_);
+                }
+                std::vector<std::string> test_paths;
+                if (has_test) {
+                    test_paths = read_string_dataset(
+                        h_group, "test", hierarchy_path + "/test", obj->number_of_query_);
+                }
+                const auto train_count = train_paths.size();
+                const auto test_count = test_paths.size();
+
+                if (has_train) {
                     obj->train_paths_[hname] = std::move(train_paths);
                 }
-                if (!test_paths.empty()) {
+                if (has_test) {
                     obj->test_paths_[hname] = std::move(test_paths);
                 }
                 logger::debug("loaded paths hierarchy '{}': {} train, {} test",
@@ -661,8 +691,9 @@ EvalDataset::Load(const std::string& filename) {
                               test_count);
             }
         }
-    } catch (H5::Exception& e) {
-        logger::debug("no /paths/ group in HDF5 file (not a Pyramid dataset)");
+    } catch (const H5::Exception& e) {
+        throw std::runtime_error("failed to load Pyramid paths from '" + filename +
+                                 "': " + e.getDetailMsg());
     }
 
     try {
@@ -841,6 +872,20 @@ serialize_token_sequences(const std::vector<SparseVector>& vectors,
 
 void
 EvalDataset::Save(const EvalDatasetPtr& dataset, const std::string& filename) {
+    auto validate_path_sizes =
+        [](const auto& paths_by_hierarchy, int64_t expected_count, const std::string& split) {
+            for (const auto& [hierarchy_name, paths] : paths_by_hierarchy) {
+                if (static_cast<int64_t>(paths.size()) != expected_count) {
+                    const std::string dataset_path = "/paths/" + hierarchy_name + "/" + split;
+                    throw std::runtime_error("Pyramid path dataset '" + dataset_path +
+                                             "' has size " + std::to_string(paths.size()) +
+                                             ", expected " + std::to_string(expected_count));
+                }
+            }
+        };
+    validate_path_sizes(dataset->train_paths_, dataset->number_of_base_, "train");
+    validate_path_sizes(dataset->test_paths_, dataset->number_of_query_, "test");
+
     H5File file(filename, H5F_ACC_TRUNC);
 
     // write vector type attribute
@@ -991,22 +1036,20 @@ EvalDataset::Save(const EvalDatasetPtr& dataset, const std::string& filename) {
             for (uint64_t i = 0; i < values.size(); ++i) {
                 ptrs[i] = values[i].c_str();
             }
-            ds.write(ptrs.data(), str_type);
+            if (!ptrs.empty()) {
+                ds.write(ptrs.data(), str_type);
+            }
         };
-        for (const auto& [hname, train_vec] : dataset->train_paths_) {
+        for (const auto& hname : dataset->GetHierarchyNames()) {
             H5::Group h_group = paths_group.createGroup(hname);
-            write_string_dataset(h_group, "train", train_vec);
+            auto train_it = dataset->train_paths_.find(hname);
+            if (train_it != dataset->train_paths_.end()) {
+                write_string_dataset(h_group, "train", train_it->second);
+            }
             auto test_it = dataset->test_paths_.find(hname);
             if (test_it != dataset->test_paths_.end()) {
                 write_string_dataset(h_group, "test", test_it->second);
             }
-        }
-        for (const auto& [hname, test_vec] : dataset->test_paths_) {
-            if (dataset->train_paths_.count(hname) != 0) {
-                continue;
-            }
-            H5::Group h_group = paths_group.createGroup(hname);
-            write_string_dataset(h_group, "test", test_vec);
         }
     }
 

--- a/tools/eval/eval_dataset.h
+++ b/tools/eval/eval_dataset.h
@@ -332,5 +332,40 @@ protected:
     int64_t multi_vector_dim_{0};
 
     std::string vector_type_ = DENSE_VECTORS;
+
+    // Pyramid path hierarchies: hierarchy_name -> vector of paths
+    // Populated when HDF5 contains a /paths/ group with sub-groups per hierarchy.
+    std::unordered_map<std::string, std::vector<std::string>> train_paths_;
+    std::unordered_map<std::string, std::vector<std::string>> test_paths_;
+
+public:
+    [[nodiscard]] bool
+    HasPaths() const {
+        return !train_paths_.empty();
+    }
+
+    [[nodiscard]] const std::vector<std::string>&
+    GetHierarchyNames() const {
+        static const std::vector<std::string> empty;
+        if (hierarchy_names_.empty()) {
+            return empty;
+        }
+        return hierarchy_names_;
+    }
+
+    [[nodiscard]] const std::string*
+    GetTrainPaths(const std::string& hierarchy_name) const {
+        auto it = train_paths_.find(hierarchy_name);
+        return it != train_paths_.end() ? it->second.data() : nullptr;
+    }
+
+    [[nodiscard]] const std::string*
+    GetTestPaths(const std::string& hierarchy_name) const {
+        auto it = test_paths_.find(hierarchy_name);
+        return it != test_paths_.end() ? it->second.data() : nullptr;
+    }
+
+private:
+    std::vector<std::string> hierarchy_names_;
 };
 }  // namespace vsag::eval

--- a/tools/eval/eval_dataset.h
+++ b/tools/eval/eval_dataset.h
@@ -341,15 +341,11 @@ protected:
 public:
     [[nodiscard]] bool
     HasPaths() const {
-        return !train_paths_.empty();
+        return !train_paths_.empty() || !test_paths_.empty();
     }
 
     [[nodiscard]] const std::vector<std::string>&
     GetHierarchyNames() const {
-        static const std::vector<std::string> empty;
-        if (hierarchy_names_.empty()) {
-            return empty;
-        }
         return hierarchy_names_;
     }
 

--- a/tools/eval/eval_dataset.h
+++ b/tools/eval/eval_dataset.h
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <memory>
 #include <unordered_set>
 
@@ -344,9 +345,20 @@ public:
         return !train_paths_.empty() || !test_paths_.empty();
     }
 
-    [[nodiscard]] const std::vector<std::string>&
+    [[nodiscard]] std::vector<std::string>
     GetHierarchyNames() const {
-        return hierarchy_names_;
+        std::vector<std::string> hierarchy_names;
+        hierarchy_names.reserve(train_paths_.size() + test_paths_.size());
+        for (const auto& entry : train_paths_) {
+            hierarchy_names.push_back(entry.first);
+        }
+        for (const auto& entry : test_paths_) {
+            if (train_paths_.count(entry.first) == 0) {
+                hierarchy_names.push_back(entry.first);
+            }
+        }
+        std::sort(hierarchy_names.begin(), hierarchy_names.end());
+        return hierarchy_names;
     }
 
     [[nodiscard]] const std::string*
@@ -360,8 +372,5 @@ public:
         auto it = test_paths_.find(hierarchy_name);
         return it != test_paths_.end() ? it->second.data() : nullptr;
     }
-
-private:
-    std::vector<std::string> hierarchy_names_;
 };
 }  // namespace vsag::eval

--- a/tools/eval/eval_dataset_test.cpp
+++ b/tools/eval/eval_dataset_test.cpp
@@ -17,10 +17,12 @@
 
 #include <H5Cpp.h>
 
+#include <algorithm>
 #include <catch2/catch_test_macros.hpp>
 #include <cstdio>
 #include <cstring>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace {
@@ -30,7 +32,9 @@ using vsag::eval::EvalDataset;
 using vsag::eval::EvalDatasetPtr;
 
 EvalDatasetPtr
-BuildSparseDataset(bool with_token_sequences) {
+BuildSparseDataset(bool with_token_sequences,
+                   bool with_paths = false,
+                   bool test_only_paths = false) {
     // Build a tiny sparse dataset (3 train, 2 test) and optionally attach
     // the original tokenized term-id sequences.
     auto ds = std::make_shared<EvalDataset>();
@@ -106,6 +110,14 @@ BuildSparseDataset(bool with_token_sequences) {
         set_distances(float* ptr) {
             this->distances_.reset(ptr);
         }
+        std::unordered_map<std::string, std::vector<std::string>>&
+        train_paths() {
+            return this->train_paths_;
+        }
+        std::unordered_map<std::string, std::vector<std::string>>&
+        test_paths() {
+            return this->test_paths_;
+        }
     };
 
     auto shim = std::make_shared<ShimDataset>();
@@ -128,6 +140,12 @@ BuildSparseDataset(bool with_token_sequences) {
     shim->set_neighbors_shape(static_cast<int64_t>(shim->test().size()), kK);
     shim->set_neighbors(nb);
     shim->set_distances(dist);
+    if (with_paths) {
+        if (!test_only_paths) {
+            shim->train_paths()["site"] = {"root/a", "root/b", "root/c"};
+        }
+        shim->test_paths()["site"] = {"root/a", "root/c"};
+    }
 
     return shim;
 }
@@ -344,6 +362,48 @@ TEST_CASE("EvalDataset sparse round-trip writes record-offset indexes", "[ut][ev
     REQUIRE(loaded->GetSparseTestOffsets() == std::vector<uint64_t>{0, 20, 32});
     REQUIRE(loaded->GetTrainTokenSequenceOffsets() == std::vector<uint64_t>{0, 20, 32, 36});
     REQUIRE(loaded->GetTestTokenSequenceOffsets() == std::vector<uint64_t>{0, 8, 24});
+    std::remove(path.c_str());
+}
+
+TEST_CASE("EvalDataset round-trips Pyramid path datasets", "[ut][eval_dataset]") {
+    auto path = TempPath("paths_roundtrip");
+    {
+        auto ds = BuildSparseDataset(/*with_token_sequences=*/false, /*with_paths=*/true);
+        EvalDataset::Save(ds, path);
+    }
+
+    auto loaded = EvalDataset::Load(path);
+    REQUIRE(loaded->HasPaths());
+    const auto& hierarchies = loaded->GetHierarchyNames();
+    REQUIRE(std::find(hierarchies.begin(), hierarchies.end(), "site") != hierarchies.end());
+    const auto* train_paths = loaded->GetTrainPaths("site");
+    REQUIRE(train_paths != nullptr);
+    REQUIRE(train_paths[0] == "root/a");
+    REQUIRE(train_paths[2] == "root/c");
+    const auto* test_paths = loaded->GetTestPaths("site");
+    REQUIRE(test_paths != nullptr);
+    REQUIRE(test_paths[0] == "root/a");
+    REQUIRE(test_paths[1] == "root/c");
+    std::remove(path.c_str());
+}
+
+TEST_CASE("EvalDataset saves and loads test-only Pyramid paths", "[ut][eval_dataset]") {
+    auto path = TempPath("paths_test_only");
+    {
+        auto ds = BuildSparseDataset(
+            /*with_token_sequences=*/false, /*with_paths=*/true, /*test_only_paths=*/true);
+        EvalDataset::Save(ds, path);
+    }
+
+    auto loaded = EvalDataset::Load(path);
+    REQUIRE(loaded->HasPaths());
+    const auto& hierarchies = loaded->GetHierarchyNames();
+    REQUIRE(std::find(hierarchies.begin(), hierarchies.end(), "site") != hierarchies.end());
+    REQUIRE(loaded->GetTrainPaths("site") == nullptr);
+    const auto* test_paths = loaded->GetTestPaths("site");
+    REQUIRE(test_paths != nullptr);
+    REQUIRE(test_paths[0] == "root/a");
+    REQUIRE(test_paths[1] == "root/c");
     std::remove(path.c_str());
 }
 

--- a/tools/eval/eval_dataset_test.cpp
+++ b/tools/eval/eval_dataset_test.cpp
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
 #include <cstdio>
 #include <cstring>
 #include <string>
@@ -29,16 +30,67 @@ namespace {
 
 using vsag::SparseVector;
 using vsag::eval::EvalDataset;
-using vsag::eval::EvalDatasetPtr;
 
-EvalDatasetPtr
+class TestEvalDataset : public EvalDataset {
+public:
+    std::vector<SparseVector>&
+    train() {
+        return this->sparse_train_;
+    }
+
+    std::vector<SparseVector>&
+    test() {
+        return this->sparse_test_;
+    }
+
+    void
+    set_metric(const std::string& metric) {
+        this->metric_ = metric;
+    }
+
+    void
+    set_type(const std::string& type) {
+        this->vector_type_ = type;
+    }
+
+    void
+    set_counts(int64_t base, int64_t query) {
+        this->number_of_base_ = base;
+        this->number_of_query_ = query;
+    }
+
+    void
+    set_neighbors_shape(int64_t query, int64_t topk) {
+        this->neighbors_shape_ = {query, topk};
+    }
+
+    void
+    set_neighbors(int64_t* neighbors) {
+        this->neighbors_.reset(neighbors);
+    }
+
+    void
+    set_distances(float* distances) {
+        this->distances_.reset(distances);
+    }
+
+    std::unordered_map<std::string, std::vector<std::string>>&
+    train_paths() {
+        return this->train_paths_;
+    }
+
+    std::unordered_map<std::string, std::vector<std::string>>&
+    test_paths() {
+        return this->test_paths_;
+    }
+};
+
+std::shared_ptr<TestEvalDataset>
 BuildSparseDataset(bool with_token_sequences,
                    bool with_paths = false,
                    bool test_only_paths = false) {
     // Build a tiny sparse dataset (3 train, 2 test) and optionally attach
     // the original tokenized term-id sequences.
-    auto ds = std::make_shared<EvalDataset>();
-
     // Sparse train vectors.
     std::vector<SparseVector> train(3);
     train[0].len_ = 2;
@@ -72,55 +124,7 @@ BuildSparseDataset(bool with_token_sequences,
         test[1].token_sequence_ = new uint32_t[3]{1, 2, 3};
     }
 
-    // Inject the sparse vectors via friend access through pointer.
-    // EvalDataset's members are private; expose a tiny helper through
-    // direct memory write would be invasive. Instead we build via Save's
-    // public API by reaching through a shim subclass.
-    struct ShimDataset : public EvalDataset {
-        std::vector<SparseVector>&
-        train() {
-            return this->sparse_train_;
-        }
-        std::vector<SparseVector>&
-        test() {
-            return this->sparse_test_;
-        }
-        void
-        set_metric(const std::string& m) {
-            this->metric_ = m;
-        }
-        void
-        set_type(const std::string& t) {
-            this->vector_type_ = t;
-        }
-        void
-        set_counts(int64_t base, int64_t query) {
-            this->number_of_base_ = base;
-            this->number_of_query_ = query;
-        }
-        void
-        set_neighbors_shape(int64_t q, int64_t k) {
-            this->neighbors_shape_ = {q, k};
-        }
-        void
-        set_neighbors(int64_t* ptr) {
-            this->neighbors_.reset(ptr);
-        }
-        void
-        set_distances(float* ptr) {
-            this->distances_.reset(ptr);
-        }
-        std::unordered_map<std::string, std::vector<std::string>>&
-        train_paths() {
-            return this->train_paths_;
-        }
-        std::unordered_map<std::string, std::vector<std::string>>&
-        test_paths() {
-            return this->test_paths_;
-        }
-    };
-
-    auto shim = std::make_shared<ShimDataset>();
+    auto shim = std::make_shared<TestEvalDataset>();
     shim->set_type(vsag::SPARSE_VECTORS);
     shim->set_metric("ip");
     shim->train() = std::move(train);
@@ -369,6 +373,7 @@ TEST_CASE("EvalDataset round-trips Pyramid path datasets", "[ut][eval_dataset]")
     auto path = TempPath("paths_roundtrip");
     {
         auto ds = BuildSparseDataset(/*with_token_sequences=*/false, /*with_paths=*/true);
+        REQUIRE(ds->GetHierarchyNames() == std::vector<std::string>{"site"});
         EvalDataset::Save(ds, path);
     }
 
@@ -404,6 +409,138 @@ TEST_CASE("EvalDataset saves and loads test-only Pyramid paths", "[ut][eval_data
     REQUIRE(test_paths != nullptr);
     REQUIRE(test_paths[0] == "root/a");
     REQUIRE(test_paths[1] == "root/c");
+    std::remove(path.c_str());
+}
+
+TEST_CASE("EvalDataset rejects malformed Pyramid path dataset shapes", "[ut][eval_dataset]") {
+    auto path = TempPath("paths_bad_shape");
+    auto ds = BuildSparseDataset(/*with_token_sequences=*/false, /*with_paths=*/true);
+    EvalDataset::Save(ds, path);
+
+    SECTION("rank two") {
+        H5::H5File file(path, H5F_ACC_RDWR);
+        file.unlink("/paths/site/train");
+        H5::StrType str_type(H5::PredType::C_S1, H5T_VARIABLE);
+        hsize_t dims[2] = {3, 1};
+        H5::DataSpace space(2, dims);
+        auto dataset = file.createDataSet("/paths/site/train", str_type, space);
+        const char* values[3] = {"root/a", "root/b", "root/c"};
+        dataset.write(values, str_type);
+    }
+
+    SECTION("scalar") {
+        H5::H5File file(path, H5F_ACC_RDWR);
+        file.unlink("/paths/site/train");
+        H5::StrType str_type(H5::PredType::C_S1, H5T_VARIABLE);
+        H5::DataSpace space(H5S_SCALAR);
+        auto dataset = file.createDataSet("/paths/site/train", str_type, space);
+        const char* value = "root/a";
+        dataset.write(&value, str_type);
+    }
+
+    REQUIRE_THROWS_WITH(EvalDataset::Load(path),
+                        Catch::Matchers::ContainsSubstring("must be one-dimensional"));
+    std::remove(path.c_str());
+}
+
+TEST_CASE("EvalDataset rejects mismatched Pyramid path counts", "[ut][eval_dataset]") {
+    auto path = TempPath("paths_bad_count");
+    auto ds = BuildSparseDataset(/*with_token_sequences=*/false, /*with_paths=*/true);
+    EvalDataset::Save(ds, path);
+
+    {
+        H5::H5File file(path, H5F_ACC_RDWR);
+        file.unlink("/paths/site/train");
+        H5::StrType str_type(H5::PredType::C_S1, H5T_VARIABLE);
+        hsize_t dims[1] = {2};
+        H5::DataSpace space(1, dims);
+        auto dataset = file.createDataSet("/paths/site/train", str_type, space);
+        const char* values[2] = {"root/a", "root/b"};
+        dataset.write(values, str_type);
+    }
+
+    REQUIRE_THROWS_WITH(
+        EvalDataset::Load(path),
+        Catch::Matchers::ContainsSubstring("Pyramid path dataset '/paths/site/train'"));
+    std::remove(path.c_str());
+}
+
+TEST_CASE("EvalDataset does not ignore malformed Pyramid path objects", "[ut][eval_dataset]") {
+    auto path = TempPath("paths_bad_object");
+    auto ds = BuildSparseDataset(/*with_token_sequences=*/false, /*with_paths=*/true);
+    EvalDataset::Save(ds, path);
+    std::string expected_message;
+
+    SECTION("path split is not a dataset") {
+        {
+            H5::H5File file(path, H5F_ACC_RDWR);
+            file.unlink("/paths/site/train");
+            file.createGroup("/paths/site/train");
+        }
+        expected_message = "/paths/site/train";
+    }
+
+    SECTION("path hierarchy is not a group") {
+        {
+            H5::H5File file(path, H5F_ACC_RDWR);
+            hsize_t dims[1] = {1};
+            H5::DataSpace space(1, dims);
+            int value = 1;
+            auto dataset =
+                file.createDataSet("/paths/not_a_group", H5::PredType::NATIVE_INT, space);
+            dataset.write(&value, H5::PredType::NATIVE_INT);
+        }
+        expected_message = "must be an HDF5 group";
+    }
+
+    SECTION("paths root is not a group") {
+        {
+            H5::H5File file(path, H5F_ACC_RDWR);
+            file.unlink("/paths");
+            hsize_t dims[1] = {1};
+            H5::DataSpace space(1, dims);
+            int value = 1;
+            auto dataset = file.createDataSet("/paths", H5::PredType::NATIVE_INT, space);
+            dataset.write(&value, H5::PredType::NATIVE_INT);
+        }
+        expected_message = "failed to load Pyramid paths";
+    }
+
+    REQUIRE_THROWS_WITH(EvalDataset::Load(path),
+                        Catch::Matchers::ContainsSubstring(expected_message));
+    std::remove(path.c_str());
+}
+
+TEST_CASE("EvalDataset validates Pyramid path counts before truncating output",
+          "[ut][eval_dataset]") {
+    auto path = TempPath("paths_save_count");
+    auto ds = BuildSparseDataset(/*with_token_sequences=*/false, /*with_paths=*/true);
+    std::string invalid_dataset_path;
+
+    SECTION("train paths") {
+        ds->train_paths()["site"].pop_back();
+        invalid_dataset_path = "/paths/site/train";
+    }
+
+    SECTION("test paths") {
+        ds->test_paths()["site"].pop_back();
+        invalid_dataset_path = "/paths/site/test";
+    }
+
+    {
+        H5::H5File file(path, H5F_ACC_TRUNC);
+        H5::DataSpace scalar(H5S_SCALAR);
+        auto attribute = file.createAttribute("sentinel", H5::PredType::NATIVE_INT, scalar);
+        int value = 42;
+        attribute.write(H5::PredType::NATIVE_INT, &value);
+    }
+
+    REQUIRE_THROWS_WITH(EvalDataset::Save(ds, path),
+                        Catch::Matchers::ContainsSubstring(invalid_dataset_path));
+    {
+        H5::H5File file(path, H5F_ACC_RDONLY);
+        REQUIRE(file.attrExists("sentinel"));
+    }
     std::remove(path.c_str());
 }
 


### PR DESCRIPTION
## Summary

- Extend `EvalDataset` to read/write Pyramid path hierarchies from HDF5 `/paths/` group
- Wire paths into `BuildEvalCase` and `SearchEvalCase` for automatic `Dataset::Paths()` setup
- Fully backward-compatible: datasets without `/paths/` are unaffected

### HDF5 format

```
/paths/
  <hierarchy_name>/
    train    (variable-length string[N])
    test     (variable-length string[Q])
```

### Verified locally

- Build: 1000 vectors with `hierarchies: ["site"]`, TPS 1157
- Search: recall_avg 0.998, QPS 1209 with path-scoped ground truth

Closes: #2253

## Test plan

- [x] `eval_performance --type build` with Pyramid params and paths HDF5
- [x] `eval_performance --type search` with hierarchy selector and path-scoped GT
- [x] `make fmt` passes
- [x] Backward-compatible: no `/paths/` group = old behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)