### PR TITLE
fix: correct bucket bias calculation in IVF merge when buckets_per_data > 1

### DIFF
--- a/src/algorithm/ivf/ivf.cpp
+++ b/src/algorithm/ivf/ivf.cpp
@@ -879,14 +879,14 @@ IVF::merge_one_unit(const MergeUnit& unit) {
     check_merge_illegal(unit);
     const auto other_index = std::dynamic_pointer_cast<IVF>(
         std::dynamic_pointer_cast<IndexImpl<IVF>>(unit.index)->GetInnerIndex());
-    auto bias = this->total_elements_;
+    auto bucket_bias = static_cast<InnerIdType>(this->total_elements_ * this->buckets_per_data_);
     this->label_table_->MergeOther(other_index->label_table_, unit.id_map_func);
     other_index->bucket_->Unpack();
-    this->bucket_->MergeOther(other_index->bucket_, bias);
+    this->bucket_->MergeOther(other_index->bucket_, bucket_bias);
     other_index->bucket_->Package();
 
     if (this->use_reorder_) {
-        this->reorder_codes_->MergeOther(other_index->reorder_codes_, bias);
+        this->reorder_codes_->MergeOther(other_index->reorder_codes_, this->total_elements_);
     }
     this->total_elements_ += other_index->total_elements_;
 }

--- a/tests/test_ivf.cpp
+++ b/tests/test_ivf.cpp
@@ -1045,6 +1045,41 @@ TestIVFMerge(const fixtures::IVFResourcePtr& resource) {
 IVF_PR_DAILY_CASE("IVF Merge", "[ft][merge][ivf]", TestIVFMerge)
 
 static void
+TestIVFMergeMultiBucketsPerData(const fixtures::IVFResourcePtr& resource) {
+    using namespace fixtures;
+    ForEachIVFCase(
+        resource,
+        resource->test_cases,
+        [&](const auto& metric_type,
+            int64_t dim,
+            const auto& train_type,
+            const auto& base_quantization_str,
+            float recall) {
+            RunWithGeneratedBlockSizeLimit([&] {
+                const auto count = std::min(300, static_cast<int32_t>(dim / 4));
+                const auto search_param =
+                    fmt::format(fixtures::search_param_tmp, std::max(200, count));
+                auto param = IVFTestIndex::GenerateIVFBuildParametersString(
+                    metric_type, dim, base_quantization_str, 300, train_type, false, 2);
+                auto model = IVFTestIndex::TestFactory(IVFTestIndex::name, param, true);
+                auto dataset =
+                    IVFTestIndex::pool.GetDatasetAndCreate(dim, resource->base_count, metric_type);
+                auto ret = model->Train(dataset->base_);
+                REQUIRE(ret.has_value());
+                auto merge_index =
+                    IVFTestIndex::TestMergeIndexWithSameModel(model, dataset, 5, true);
+                if (model->CheckFeature(vsag::SUPPORT_MERGE_INDEX)) {
+                    IVFTestIndex::TestGeneral(merge_index, dataset, search_param, recall);
+                }
+            });
+        });
+}
+
+IVF_PR_DAILY_CASE("IVF Merge Multi Buckets Per Data",
+                  "[ft][merge][ivf]",
+                  TestIVFMergeMultiBucketsPerData)
+
+static void
 TestIVFConcurrentAdd(const fixtures::IVFResourcePtr& resource) {
     using namespace fixtures;
     ForEachIVFCase(resource,


### PR DESCRIPTION
Fixes #2260

## Problem

When `buckets_per_data_ > 1`, inner_ids in buckets are scaled by `buckets_per_data_` (computed as `element_index * buckets_per_data_ + copy_index` in the Add function). During merge, `bucket_->MergeOther` received `total_elements_` as bias, but the correct bias should be `total_elements_ * buckets_per_data_` to account for the scaled inner_id space.

## Fix

- Use `bucket_bias = total_elements_ * buckets_per_data_` for `bucket_->MergeOther`
- Keep `total_elements_` for `reorder_codes_->MergeOther` (element-indexed, not inner_id-indexed)

## Test

Added `TestIVFMergeMultiBucketsPerData` that exercises merge with `buckets_per_data=2` and verifies search correctness after merge.