### PR TITLE
fix(io): guard resource cleanup on error paths in AsyncIO and MMapIO

### DIFF
--- a/src/io/async_io.cpp
+++ b/src/io/async_io.cpp
@@ -108,6 +108,7 @@ AsyncIO::DirectReadImpl(uint64_t size, uint64_t offset, bool& need_release) cons
     DirectIOObject obj(size, offset);
     auto ret = IOSyscall::PRead(this->rfd_, obj.align_data, obj.size, obj.offset);
     if (ret < 0) {
+        obj.Release();
         throw VsagException(ErrorType::INTERNAL_ERROR, fmt::format("pread error {}", ret));
     }
     return obj.data;

--- a/src/io/mmap_io.cpp
+++ b/src/io/mmap_io.cpp
@@ -19,6 +19,7 @@
 #include <sys/mman.h>
 #include <unistd.h>
 
+#include <algorithm>
 #include <cerrno>
 #include <filesystem>
 #include <system_error>
@@ -93,10 +94,7 @@ MMapIO::MMapIO(const IOParamPtr& param, const IndexCommonParam& common_param)
     : MMapIO(std::dynamic_pointer_cast<MMapIOParameter>(param), common_param){};
 
 MMapIO::~MMapIO() {
-    auto munmap_size = this->size_;
-    if (munmap_size == 0) {
-        munmap_size = DEFAULT_INIT_MMAP_SIZE;
-    }
+    auto munmap_size = std::max(this->size_, static_cast<uint64_t>(DEFAULT_INIT_MMAP_SIZE));
     munmap(this->start_, munmap_size);
     close(this->fd_);
     // remove file

--- a/src/io/mmap_io.cpp
+++ b/src/io/mmap_io.cpp
@@ -93,7 +93,11 @@ MMapIO::MMapIO(const IOParamPtr& param, const IndexCommonParam& common_param)
     : MMapIO(std::dynamic_pointer_cast<MMapIOParameter>(param), common_param){};
 
 MMapIO::~MMapIO() {
-    munmap(this->start_, this->size_);
+    auto munmap_size = this->size_;
+    if (munmap_size == 0) {
+        munmap_size = DEFAULT_INIT_MMAP_SIZE;
+    }
+    munmap(this->start_, munmap_size);
     close(this->fd_);
     // remove file
     if (not this->exist_file_) {


### PR DESCRIPTION
## Summary

Fix two resource leak issues on error/destruction paths:

1. **AsyncIO::DirectReadImpl**: Add `obj.Release()` before throwing on pread failure to prevent aligned memory leak.
2. **MMapIO destructor**: Use `std::max(size_, DEFAULT_INIT_MMAP_SIZE)` to prevent `munmap(ptr, 0)` returning EINVAL when size_ was never updated from its initial 0 value (new file path).

## Verification

- 仅单测
- Format check: passed locally (clang-format-15)

## Changes

- `src/io/async_io.cpp`: Add Release() call on error path
- `src/io/mmap_io.cpp`: Defensive size in destructor munmap call