### PR TITLE
perf(utils): pass MutexArrayPtr by const ref in LockGuard

### DIFF
--- a/src/utils/lock_strategy.h
+++ b/src/utils/lock_strategy.h
@@ -121,7 +121,7 @@ private:
 
 class LockGuard {
 public:
-    LockGuard(MutexArrayPtr mutex_impl, uint32_t locked_index)
+    LockGuard(const MutexArrayPtr& mutex_impl, uint32_t locked_index)
         : mutex_impl_(mutex_impl), locked_index_(locked_index) {
         mutex_impl_->Lock(locked_index_);
     }
@@ -131,7 +131,7 @@ public:
 
 private:
     uint32_t locked_index_;
-    MutexArrayPtr mutex_impl_;
+    const MutexArrayPtr& mutex_impl_;
 };
 
 }  // namespace vsag


### PR DESCRIPTION
## Closed

Reverting this PR. The `const MutexArrayPtr&` member variable approach causes a stack-use-after-scope bug detected by ASan in the `LockStrategy Basic` test — the reference does not extend the lifetime of temporary `shared_ptr` objects passed to the constructor.

The original by-value semantics are correct and necessary for safety. The atomic refcount overhead is acceptable given the memory safety guarantee.

Lesson learned: storing a const reference to `std::shared_ptr` as a class member is fundamentally unsafe when the class may outlive the referenced object.