### PR TITLE
fix(quantizer): add nullptr check in SQ4UniformQuantizer::ProcessQueryImpl

### DIFF
--- a/src/quantization/scalar_quantization/sq4_uniform_quantizer.cpp
+++ b/src/quantization/scalar_quantization/sq4_uniform_quantizer.cpp
@@ -202,7 +202,10 @@ void
 SQ4UniformQuantizer<metric>::ProcessQueryImpl(const float* query,
                                               Computer<SQ4UniformQuantizer>& computer) const {
     try {
-        computer.buf_ = reinterpret_cast<uint8_t*>(this->allocator_->Allocate(this->code_size_));
+        if (computer.buf_ == nullptr) {
+            computer.buf_ =
+                reinterpret_cast<uint8_t*>(this->allocator_->Allocate(this->code_size_));
+        }
         this->EncodeOneImpl(query, computer.buf_);
     } catch (const std::bad_alloc& e) {
         throw VsagException(ErrorType::NO_ENOUGH_MEMORY, "bad alloc when init computer buf");


### PR DESCRIPTION
Closes #2268

## What

Add `if (computer.buf_ == nullptr)` guard before buffer allocation in `SQ4UniformQuantizer::ProcessQueryImpl`.

## Why

All other quantizers guard `ProcessQueryImpl` buffer allocation with a nullptr check to prevent memory leaks when `SetQuery` is called multiple times. SQ4UniformQuantizer is the only one missing this check, causing `code_size_` bytes to leak per repeated call.

## Test

All 4 SQ4UniformQuantizer unit tests pass (3,197,017 assertions).