### PR TITLE
fix(hgraph): add force_remove_mutex_ shared lock in UpdateVector to prevent data race

### DIFF
--- a/src/algorithm/hgraph/hgraph.cpp
+++ b/src/algorithm/hgraph/hgraph.cpp
@@ -569,6 +569,10 @@ HGraph::check_and_init_raw_vector(const FlattenInterfaceParamPtr& raw_vector_par
 
 bool
 HGraph::UpdateVector(int64_t id, const DatasetPtr& new_base, bool force_update) {
+    std::shared_lock<std::shared_mutex> force_remove_rlock;
+    if (this->support_force_remove()) {
+        force_remove_rlock = std::shared_lock<std::shared_mutex>(this->force_remove_mutex_);
+    }
     // check if id exists and get copied base data
     uint32_t inner_id = 0;
     {


### PR DESCRIPTION
## Problem

When `support_force_remove` is enabled in HGraph, `UpdateVector` and `Remove(FORCE_REMOVE)` can race on the graph structure:

- `Remove(FORCE_REMOVE)` acquires `force_remove_mutex_` (unique_lock) and modifies graph structure via `graph_force_remove_one`
- `UpdateVector` reads graph structure via `bottom_graph_->GetNeighbors` without holding `force_remove_mutex_`

This results in undefined behavior when the two operations execute concurrently.

Closes #2276

## Root Cause

`UpdateVector` only acquires `label_lookup_mutex_` (shared_lock) but reads graph neighbors that can be concurrently modified by `Remove(FORCE_REMOVE)`. The `Add` and `Search` methods already guard against this by conditionally acquiring `force_remove_mutex_` (shared_lock) when `support_force_remove()` is true, but `UpdateVector` was missing this protection.

## Fix

Add a conditional `shared_lock` on `force_remove_mutex_` at the start of `UpdateVector`, following the same pattern used in `Add` and `Search`.

## Impact

- Multiple `UpdateVector` calls still execute concurrently (shared lock)
- Only `Remove(FORCE_REMOVE)` and `UpdateVector` are mutually exclusive
- No performance impact when `support_force_remove` is disabled (lock is not acquired)

## Testing

- All HGraph ForceRemove tests pass (sequential, concurrent, batch, all elements)
- `HGraph Concurrent Add Search Remove` passes
- `HGraph Concurrent Read Write` passes
- `(PR) HGraph Support Get Raw Vector` (includes update tests) passes
