### PR TITLE
fix(io): add RAII destructor to DirectIOObject and simplify AsyncIO ownership

### DIFF
--- a/src/io/async_io/async_io.cpp
+++ b/src/io/async_io/async_io.cpp
@@ -114,10 +114,7 @@ AsyncIO::DirectReadImpl(uint64_t size, uint64_t offset, bool& need_release) cons
         // destructor automatically frees align_data
         throw VsagException(ErrorType::INTERNAL_ERROR, fmt::format("pread error {}", ret));
     }
-    auto* result = obj.data;
-    obj.align_data = nullptr;  // transfer ownership to caller
-    obj.data = nullptr;
-    return result;
+    return obj.TakeData();
 }
 
 void

--- a/src/io/async_io/async_io.cpp
+++ b/src/io/async_io/async_io.cpp
@@ -111,10 +111,13 @@ AsyncIO::DirectReadImpl(uint64_t size, uint64_t offset, bool& need_release) cons
     DirectIOObject obj(size, offset);
     auto ret = IOSyscall::PRead(this->rfd_, obj.align_data, obj.size, obj.offset);
     if (ret < 0) {
-        obj.Release();
+        // destructor automatically frees align_data
         throw VsagException(ErrorType::INTERNAL_ERROR, fmt::format("pread error {}", ret));
     }
-    return obj.data;
+    auto* result = obj.data;
+    obj.align_data = nullptr;  // transfer ownership to caller
+    obj.data = nullptr;
+    return result;
 }
 
 void
@@ -146,9 +149,7 @@ AsyncIO::MultiReadImpl(uint8_t* datas, uint64_t* sizes, uint64_t* offsets, uint6
         int submitted = io_submit(context->ctx_, static_cast<int64_t>(count), cb);
         if (submitted < 0) {
             io_context_pool->ReturnOne(context);
-            for (auto& obj : objs) {
-                obj.Release();
-            }
+            // objs destructor automatically frees all align_data
             throw VsagException(ErrorType::INTERNAL_ERROR, "io submit failed");
         }
 
@@ -174,9 +175,7 @@ AsyncIO::MultiReadImpl(uint8_t* datas, uint64_t* sizes, uint64_t* offsets, uint6
 
         if (submitted != static_cast<int>(count)) {
             io_context_pool->ReturnOne(context);
-            for (auto& obj : objs) {
-                obj.Release();
-            }
+            // objs destructor automatically frees all align_data
             throw VsagException(ErrorType::INTERNAL_ERROR,
                                 "io_submit partial: requested " + std::to_string(count) +
                                     " but submitted " + std::to_string(submitted));
@@ -185,7 +184,7 @@ AsyncIO::MultiReadImpl(uint8_t* datas, uint64_t* sizes, uint64_t* offsets, uint6
         for (int64_t i = 0; i < count; ++i) {
             memcpy(cur_data, objs[i].data, sizes[i]);
             cur_data += sizes[i];
-            this->ReleaseImpl(objs[i].data);
+            // no manual release — vector<DirectIOObject> destructor handles cleanup
         }
 
         sizes += count;

--- a/src/io/async_io/direct_io_object.h
+++ b/src/io/async_io/direct_io_object.h
@@ -53,6 +53,48 @@ public:
     }
 
     /**
+     * @brief Destructor that frees the aligned memory buffer.
+     */
+    ~DirectIOObject() {
+        free(align_data);
+    }
+
+    // Non-copyable
+    DirectIOObject(const DirectIOObject&) = delete;
+    DirectIOObject&
+    operator=(const DirectIOObject&) = delete;
+
+    // Movable
+    DirectIOObject(DirectIOObject&& other) noexcept
+        : data(other.data),
+          size(other.size),
+          offset(other.offset),
+          align_data(other.align_data),
+          align_bit(other.align_bit),
+          align_size(other.align_size),
+          align_mask(other.align_mask) {
+        other.data = nullptr;
+        other.align_data = nullptr;
+    }
+
+    DirectIOObject&
+    operator=(DirectIOObject&& other) noexcept {
+        if (this != &other) {
+            free(align_data);
+            data = other.data;
+            size = other.size;
+            offset = other.offset;
+            align_data = other.align_data;
+            align_bit = other.align_bit;
+            align_size = other.align_size;
+            align_mask = other.align_mask;
+            other.data = nullptr;
+            other.align_data = nullptr;
+        }
+        return *this;
+    }
+
+    /**
      * @brief Sets up aligned buffer for a given size and offset.
      *
      * Calculates the aligned offset and size, allocates aligned memory,

--- a/src/io/async_io/direct_io_object.h
+++ b/src/io/async_io/direct_io_object.h
@@ -95,6 +95,24 @@ public:
     }
 
     /**
+     * @brief Transfers ownership of the aligned buffer to the caller.
+     *
+     * After this call, the object no longer owns the buffer and will not
+     * free it in the destructor. The caller is responsible for freeing
+     * the returned pointer (via the owning IO's ReleaseImpl).
+     *
+     * @return Pointer to the usable data region (may be offset from the
+     *         allocation base).
+     */
+    uint8_t*
+    TakeData() {
+        auto* ptr = data;
+        align_data = nullptr;
+        data = nullptr;
+        return ptr;
+    }
+
+    /**
      * @brief Sets up aligned buffer for a given size and offset.
      *
      * Calculates the aligned offset and size, allocates aligned memory,


### PR DESCRIPTION
## Summary

Add proper RAII lifecycle management to `DirectIOObject`, eliminating manual memory management in `AsyncIO`.

### Changes

**`src/io/direct_io_object.h`**:
- Add `~DirectIOObject()` that calls `free(align_data)`
- Delete copy constructor and copy assignment (prevent double-free)
- Add move constructor and move assignment (transfer ownership)

**`src/io/async_io.cpp`**:
- `DirectReadImpl`: Transfer ownership to caller by nulling `align_data` before return; error path relies on RAII destructor instead of manual `Release()`
- `MultiReadImpl`: Remove manual `ReleaseImpl()` loop and exception-path `Release()` loops; `std::vector<DirectIOObject>` destructor handles cleanup automatically

### Safety Analysis

- **No double-free**: Success paths null `align_data` before obj destruction; `free(nullptr)` is no-op
- **No use-after-free**: Returned pointers remain valid until `ReleaseImpl()` is called by the caller
- **No leaks**: Exception paths are covered by RAII destructor
- **Backward compatible**: `ReleaseImpl()` still works for external callers via `BasicIO::Release()`

### Verification

- Release build: passed
- Unit tests: 439/441 passed (2 pre-existing failures in int8_quantizer_test unrelated to this change)
- Code review: PASS (no blocking issues)