### PR TITLE
improve(pyramid): use RAII guard for VisitedList pool handles

### DIFF
--- a/src/algorithm/pyramid/pyramid.cpp
+++ b/src/algorithm/pyramid/pyramid.cpp
@@ -361,14 +361,14 @@ Pyramid::search_impl(const DatasetPtr& query,
     DistHeapPtr search_result = std::make_shared<StandardHeap<true, false>>(allocator_, -1);
 
     std::shared_lock<std::shared_mutex> lock(resize_mutex_);
-    auto vl = pool_->TakeOne();
+    VisitedListGuard vl_guard(pool_.get());
+    const VisitedListPtr& vl = vl_guard.get();
     if (query_path != nullptr) {
         const std::string& current_path = query_path[0];
         search_hierarchy(h, search_func, vl, search_result, current_path, search_param);
     } else {
         h.root->Search(search_func, vl, search_result, search_param.ef);
     }
-    pool_->ReturnOne(vl);
 
     if (use_reorder_) {
         search_result = this->reorder_->Reorder(
@@ -1059,10 +1059,10 @@ Pyramid::add_one_point(const Hierarchy& h,
             graph_lock.unlock();
         }
 
-        auto vl = pool_->TakeOne();
+        VisitedListGuard vl_guard(pool_.get());
+        const VisitedListPtr& vl = vl_guard.get();
         auto results = searcher_->Search(
             node->graph_, codes, vl, vector, search_param, (LabelTablePtr) nullptr, nullptr);
-        pool_->ReturnOne(vl);
         if (this->support_duplicate_ && search_param.duplicate_id >= 0) {
             std::unique_lock lock(this->label_lookup_mutex_);
             node->graph_->SetDuplicateId(static_cast<InnerIdType>(search_param.duplicate_id),
@@ -1167,9 +1167,9 @@ Pyramid::search_hierarchy(const Hierarchy& h,
         if (valid) {
             if (thread_pool_ != nullptr && search_param.parallel_search_thread_count > 1) {
                 futures.push_back(thread_pool_->GeneralEnqueue([&, node, i]() -> void {
-                    auto local_vl = pool_->TakeOne();
+                    VisitedListGuard vl_guard(pool_.get());
+                    const VisitedListPtr& local_vl = vl_guard.get();
                     node->Search(search_func, local_vl, search_result_lists[i], search_param.ef);
-                    pool_->ReturnOne(local_vl);
                 }));
             } else {
                 node->Search(search_func, vl, search_result_lists[i], search_param.ef);

--- a/src/algorithm/pyramid/pyramid.h
+++ b/src/algorithm/pyramid/pyramid.h
@@ -278,6 +278,30 @@ private:
     void
     deserialize_hierarchies(StreamReader& reader, const JsonType& basic_info);
 
+    // RAII guard that returns the VisitedList to the pool on scope exit,
+    // ensuring no leak if the search throws.
+    class VisitedListGuard {
+    public:
+        explicit VisitedListGuard(VisitedListPool* pool) : pool_(pool), vl_(pool->TakeOne()) {
+        }
+        ~VisitedListGuard() {
+            if (vl_ != nullptr) {
+                pool_->ReturnOne(vl_);
+            }
+        }
+        VisitedListGuard(const VisitedListGuard&) = delete;
+        VisitedListGuard&
+        operator=(const VisitedListGuard&) = delete;
+        [[nodiscard]] const VisitedListPtr&
+        get() const {
+            return vl_;
+        }
+
+    private:
+        VisitedListPool* pool_;
+        VisitedListPtr vl_;
+    };
+
     /// One named hierarchy with its own root IndexNode and build parameters.
     struct Hierarchy {
         std::string name;                          // hierarchy name (empty = default)


### PR DESCRIPTION
## Summary

Wrap VisitedList pool acquisition in an RAII guard (VisitedListGuard) so the handle is always returned to the pool on scope exit, including when Search() throws.

### Background

The Pyramid search paths use raw pool_->TakeOne() / pool_->ReturnOne(). If node->Search() (parallel + serial paths) or root_->Search() throws between the two calls, ReturnOne is skipped and the VisitedList leaks from the pool.

**Severity: LOW.** The pool recreates VisitedLists on demand, so it self-heals — this is a resource-hygiene hardening, not a crash or correctness fix. The data race that previously existed here was already fixed by #2226 (each parallel task gets its own local_vl); this PR only closes the exception-safety gap.

### Changes

- Add VisitedListGuard RAII class (private nested in Pyramid)
- Convert the 3 raw TakeOne/ReturnOne sites to use the guard
- No behavioral change on the happy path; each parallel task still gets its own VisitedList

## Test plan

- [x] Pyramid unit + functional tests pass
- [x] Concurrent pyramid test passes
- [x] Adversarial review: guard correctness, coverage, lifetime, no double-return
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)