### PR TITLE
fix(simd): prevent 16-bit accumulator overflow in PQ-FastScan kernels

### DIFF
--- a/src/simd/avx2.cpp
+++ b/src/simd/avx2.cpp
@@ -581,6 +581,21 @@ PQFastScanLookUp32(const uint8_t* RESTRICT lookup_table,
     for (uint64_t i = 0; i < 4; i++) {
         sum[i] = _mm256_setzero_si256();
     }
+    // Each 16-bit lane accumulates one lookup byte (<= 255) per iteration and
+    // would overflow after ~258 of them, so periodically drain the int16
+    // partials into the int32 result and reset the accumulators.
+    constexpr uint64_t kFlushInterval = 32;
+    uint64_t since_flush = 0;
+    auto flush = [&]() {
+        alignas(256) uint16_t temp[16];
+        for (int64_t idx = 0; idx < 4; idx++) {
+            _mm256_store_si256((__m256i*)(temp), sum[idx]);
+            for (int64_t j = 0; j < 8; j++) {
+                result[idx * 8 + j] += temp[j] + temp[j + 8];
+            }
+            sum[idx] = _mm256_setzero_si256();
+        }
+    };
     const auto sign4 = _mm256_set1_epi8(0x0F);
     const auto sign8 = _mm256_set1_epi16(0xFF);
     uint64_t i = 0;
@@ -597,14 +612,12 @@ PQFastScanLookUp32(const uint8_t* RESTRICT lookup_table,
         sum[1] = _mm256_add_epi16(sum[1], _mm256_srli_epi16(res1, 8));
         sum[2] = _mm256_add_epi16(sum[2], _mm256_and_si256(res2, sign8));
         sum[3] = _mm256_add_epi16(sum[3], _mm256_srli_epi16(res2, 8));
-    }
-    alignas(256) uint16_t temp[16];
-    for (int64_t idx = 0; idx < 4; idx++) {
-        _mm256_store_si256((__m256i*)(temp), sum[idx]);
-        for (int64_t j = 0; j < 8; j++) {
-            result[idx * 8 + j] += temp[j] + temp[j + 8];
+        if (++since_flush == kFlushInterval) {
+            flush();
+            since_flush = 0;
         }
     }
+    flush();
     if (pq_dim > i) {
         avx::PQFastScanLookUp32(lookup_table, codes, pq_dim - i, result);
     }

--- a/src/simd/avx2.cpp
+++ b/src/simd/avx2.cpp
@@ -587,7 +587,7 @@ PQFastScanLookUp32(const uint8_t* RESTRICT lookup_table,
     constexpr uint64_t kFlushInterval = 32;
     uint64_t since_flush = 0;
     auto flush = [&]() {
-        alignas(256) uint16_t temp[16];
+        alignas(32) uint16_t temp[16];
         for (int64_t idx = 0; idx < 4; idx++) {
             _mm256_store_si256((__m256i*)(temp), sum[idx]);
             for (int64_t j = 0; j < 8; j++) {

--- a/src/simd/avx512.cpp
+++ b/src/simd/avx512.cpp
@@ -608,6 +608,21 @@ PQFastScanLookUp32(const uint8_t* RESTRICT lookup_table,
     for (uint64_t i = 0; i < 4; i++) {
         sum[i] = _mm512_setzero_si512();
     }
+    // Each 16-bit lane accumulates one lookup byte (<= 255) per iteration and
+    // would overflow after ~258 of them, so periodically drain the int16
+    // partials into the int32 result and reset the accumulators.
+    constexpr uint64_t kFlushInterval = 32;
+    uint64_t since_flush = 0;
+    auto flush = [&]() {
+        alignas(512) uint16_t temp[32];
+        for (int64_t idx = 0; idx < 4; idx++) {
+            _mm512_store_si512((__m512i*)(temp), sum[idx]);
+            for (int64_t j = 0; j < 8; j++) {
+                result[idx * 8 + j] += temp[j] + temp[j + 8] + temp[j + 16] + temp[j + 24];
+            }
+            sum[idx] = _mm512_setzero_si512();
+        }
+    };
     const auto sign4 = _mm512_set1_epi8(0x0F);
     const auto sign8 = _mm512_set1_epi16(0xFF);
     uint64_t i = 0;
@@ -624,14 +639,12 @@ PQFastScanLookUp32(const uint8_t* RESTRICT lookup_table,
         sum[1] = _mm512_add_epi16(sum[1], _mm512_srli_epi16(res1, 8));
         sum[2] = _mm512_add_epi16(sum[2], _mm512_and_si512(res2, sign8));
         sum[3] = _mm512_add_epi16(sum[3], _mm512_srli_epi16(res2, 8));
-    }
-    alignas(512) uint16_t temp[32];
-    for (int64_t idx = 0; idx < 4; idx++) {
-        _mm512_store_si512((__m512i*)(temp), sum[idx]);
-        for (int64_t j = 0; j < 8; j++) {
-            result[idx * 8 + j] += temp[j] + temp[j + 8] + temp[j + 16] + temp[j + 24];
+        if (++since_flush == kFlushInterval) {
+            flush();
+            since_flush = 0;
         }
     }
+    flush();
     if (pq_dim > i) {
         avx2::PQFastScanLookUp32(lookup_table, codes, pq_dim - i, result);
     }

--- a/src/simd/avx512.cpp
+++ b/src/simd/avx512.cpp
@@ -614,7 +614,7 @@ PQFastScanLookUp32(const uint8_t* RESTRICT lookup_table,
     constexpr uint64_t kFlushInterval = 32;
     uint64_t since_flush = 0;
     auto flush = [&]() {
-        alignas(512) uint16_t temp[32];
+        alignas(64) uint16_t temp[32];
         for (int64_t idx = 0; idx < 4; idx++) {
             _mm512_store_si512((__m512i*)(temp), sum[idx]);
             for (int64_t j = 0; j < 8; j++) {

--- a/src/simd/neon.cpp
+++ b/src/simd/neon.cpp
@@ -900,6 +900,21 @@ PQFastScanLookUp32(const uint8_t* RESTRICT lookup_table,
     for (uint64_t i = 0; i < 4; ++i) {
         sum[i] = vdupq_n_u32(0);
     }
+    // Each 16-bit lane accumulates one lookup byte (<= 255) per iteration and
+    // would overflow after ~258 of them, so periodically drain the int16
+    // partials into the int32 result and reset the accumulators.
+    constexpr uint64_t kFlushInterval = 32;
+    uint64_t since_flush = 0;
+    auto flush = [&]() {
+        alignas(128) uint16_t temp[8];
+        for (int64_t k = 0; k < 4; ++k) {
+            vst1q_u16(temp, vreinterpretq_u16_u32(sum[k]));
+            for (int64_t j = 0; j < 8; j++) {
+                result[k * 8 + j] += temp[j];
+            }
+            sum[k] = vdupq_n_u32(0);
+        }
+    };
     const auto sign4 = vdupq_n_u8(0x0F);
     const auto sign8 = vdupq_n_u16(0xFF);
 
@@ -917,14 +932,12 @@ PQFastScanLookUp32(const uint8_t* RESTRICT lookup_table,
         sum[1] = vaddq_u32(sum[1], vreinterpretq_u32_u16(vshrq_n_u16(res1, 8)));
         sum[2] = vaddq_u32(sum[2], vreinterpretq_u32_u16(vandq_u16(res2, sign8)));
         sum[3] = vaddq_u32(sum[3], vreinterpretq_u32_u16(vshrq_n_u16(res2, 8)));
-    }
-    alignas(128) uint16_t temp[8];
-    for (int64_t i = 0; i < 4; ++i) {
-        vst1q_u16(temp, vreinterpretq_u16_u32(sum[i]));
-        for (int64_t j = 0; j < 8; j++) {
-            result[i * 8 + j] += temp[j];
+        if (++since_flush == kFlushInterval) {
+            flush();
+            since_flush = 0;
         }
     }
+    flush();
 #else
     generic::PQFastScanLookUp32(lookup_table, codes, pq_dim, result);
 #endif

--- a/src/simd/neon.cpp
+++ b/src/simd/neon.cpp
@@ -906,7 +906,7 @@ PQFastScanLookUp32(const uint8_t* RESTRICT lookup_table,
     constexpr uint64_t kFlushInterval = 32;
     uint64_t since_flush = 0;
     auto flush = [&]() {
-        alignas(128) uint16_t temp[8];
+        alignas(16) uint16_t temp[8];
         for (int64_t k = 0; k < 4; ++k) {
             vst1q_u16(temp, vreinterpretq_u16_u32(sum[k]));
             for (int64_t j = 0; j < 8; j++) {

--- a/src/simd/pqfs_simd_test.cpp
+++ b/src/simd/pqfs_simd_test.cpp
@@ -88,6 +88,23 @@ TEST_CASE("PQFastScan SIMD Compute", "[ut][simd]") {
     }
 }
 
+TEST_CASE("PQFastScan SIMD Compute High Dim", "[ut][simd]") {
+    // pq_dim beyond ~258 overflows the int16 accumulators in the SIMD kernels;
+    // generic accumulates in int32 and stays exact, so it is the reference.
+    const std::vector<int64_t> dims = {2048, 4096, 8192};
+    int64_t count = 10;
+    for (const auto& pq_dim : dims) {
+        auto dim = pq_dim * 16;
+        auto lut =
+            fixtures::generate_uint8_codes(count, pq_dim * 16, fixtures::RandomValue(0, 999));
+        auto codes =
+            fixtures::generate_uint8_codes(count, pq_dim * 16, fixtures::RandomValue(0, 9999));
+        for (uint64_t i = 0; i < count; ++i) {
+            TEST_ACCURACY(PQFastScanLookUp32);
+        }
+    }
+}
+
 #define BENCHMARK_SIMD_COMPUTE(Simd, Comp)                                               \
     BENCHMARK_ADVANCED(#Simd #Comp) {                                                    \
         for (int i = 0; i < count; ++i) {                                                \

--- a/src/simd/sse.cpp
+++ b/src/simd/sse.cpp
@@ -486,6 +486,21 @@ PQFastScanLookUp32(const uint8_t* RESTRICT lookup_table,
     for (uint64_t i = 0; i < 4; i++) {
         sum[i] = _mm_setzero_si128();
     }
+    // Each 16-bit lane accumulates one lookup byte (<= 255) per iteration and
+    // would overflow after ~258 of them, so periodically drain the int16
+    // partials into the int32 result and reset the accumulators.
+    constexpr uint64_t kFlushInterval = 32;
+    uint64_t since_flush = 0;
+    auto flush = [&]() {
+        alignas(128) uint16_t temp[8];
+        for (int64_t k = 0; k < 4; k++) {
+            _mm_store_si128((__m128i*)(temp), sum[k]);
+            for (int64_t j = 0; j < 8; j++) {
+                result[k * 8 + j] += temp[j];
+            }
+            sum[k] = _mm_setzero_si128();
+        }
+    };
     const auto sign4 = _mm_set1_epi8(0x0F);
     const auto sign8 = _mm_set1_epi16(0xFF);
     for (uint64_t i = 0; i < pq_dim; i++) {
@@ -501,14 +516,12 @@ PQFastScanLookUp32(const uint8_t* RESTRICT lookup_table,
         sum[1] = _mm_add_epi32(sum[1], _mm_srli_epi16(res1, 8));
         sum[2] = _mm_add_epi32(sum[2], _mm_and_si128(res2, sign8));
         sum[3] = _mm_add_epi32(sum[3], _mm_srli_epi16(res2, 8));
-    }
-    alignas(128) uint16_t temp[8];
-    for (int64_t i = 0; i < 4; i++) {
-        _mm_store_si128((__m128i*)(temp), sum[i]);
-        for (int64_t j = 0; j < 8; j++) {
-            result[i * 8 + j] += temp[j];
+        if (++since_flush == kFlushInterval) {
+            flush();
+            since_flush = 0;
         }
     }
+    flush();
 #else
     generic::PQFastScanLookUp32(lookup_table, codes, pq_dim, result);
 #endif

--- a/src/simd/sse.cpp
+++ b/src/simd/sse.cpp
@@ -492,7 +492,7 @@ PQFastScanLookUp32(const uint8_t* RESTRICT lookup_table,
     constexpr uint64_t kFlushInterval = 32;
     uint64_t since_flush = 0;
     auto flush = [&]() {
-        alignas(128) uint16_t temp[8];
+        alignas(16) uint16_t temp[8];
         for (int64_t k = 0; k < 4; k++) {
             _mm_store_si128((__m128i*)(temp), sum[k]);
             for (int64_t j = 0; j < 8; j++) {


### PR DESCRIPTION
## Summary

PQ-FastScan distance kernels (`PQFastScanLookUp32` in sse/avx2/avx512/neon) accumulated LUT bytes (0-255) into 16-bit SIMD lanes with no periodic flush, so the per-lane sum silently wrapped once `pq_dim` exceeded ~258 — wrong distances, wrong nearest neighbors. The generic scalar path accumulates in int32 and is correct, so SIMD diverged above the overflow threshold. Same bug class as the earlier SQ4 overflow fix.

Fixes: #2283

## Changes

- Drain int16 partials into the int32 result every 32 iterations (well below the overflow point) and reset accumulators, in all 4 SIMD kernels
- Discriminating test at `pq_dim = {2048,4096,8192}` asserting SIMD == generic

## Test plan

- [x] Build (Release), incremental
- [x] Full SIMD suite: 30,592,011 assertions / 53 cases pass
- [x] New High Dim test passes with fix
- [x] **Discriminating check**: reverted the SSE fix → High Dim test FAILS (sse != generic); restored → passes. Confirms the test actually catches the overflow.
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)