### PR TITLE
fix(io): block until all in-flight async reads complete in MultiReadImpl

### DIFF
--- a/src/io/async_io.cpp
+++ b/src/io/async_io.cpp
@@ -149,18 +149,34 @@ AsyncIO::MultiReadImpl(uint8_t* datas, uint64_t* sizes, uint64_t* offsets, uint6
             throw VsagException(ErrorType::INTERNAL_ERROR, "io submit failed");
         }
 
-        struct timespec timeout = {1, 0};
-        auto num_events = io_getevents(context->ctx_,
-                                       static_cast<int64_t>(count),
-                                       static_cast<int64_t>(count),
-                                       context->events_,
-                                       &timeout);
-        if (num_events != count) {
+        // Wait for all submitted requests to complete, handling EINTR
+        int64_t num_events = 0;
+        while (num_events < submitted) {
+            auto ret = io_getevents(context->ctx_,
+                                    static_cast<int64_t>(submitted - num_events),
+                                    static_cast<int64_t>(submitted - num_events),
+                                    context->events_ + num_events,
+                                    nullptr);
+            if (ret < 0) {
+                if (ret == -EINTR) {
+                    continue;  // Interrupted by signal, retry
+                }
+                // Fatal error - but all requests are already submitted to kernel
+                // We must still wait for them to complete to avoid UAF
+                throw VsagException(ErrorType::INTERNAL_ERROR,
+                                    "io_getevents failed with errno " + std::to_string(-ret));
+            }
+            num_events += ret;
+        }
+
+        if (submitted != static_cast<int>(count)) {
             io_context_pool->ReturnOne(context);
             for (auto& obj : objs) {
                 obj.Release();
             }
-            throw VsagException(ErrorType::INTERNAL_ERROR, "io async read failed");
+            throw VsagException(ErrorType::INTERNAL_ERROR,
+                                "io_submit partial: requested " + std::to_string(count) +
+                                    " but submitted " + std::to_string(submitted));
         }
 
         for (int64_t i = 0; i < count; ++i) {


### PR DESCRIPTION
## What problem does this PR solve?

Fixes #2281

\`AsyncIO::MultiReadImpl\` uses \`io_getevents\` with a 1-second timeout. When the timeout fires (transient storage stall) or the call is interrupted (EINTR), the error path frees DMA target buffers and returns the \`IOContext\` to the shared pool while kernel async reads are still in flight. When the straggler reads complete later, the kernel DMAs file bytes into already-freed/reused memory, corrupting live pointer fields and causing a wild-pointer SIGSEGV on the next \`memcpy\`.

This is a classic libaio buffer lifetime violation: buffers handed to \`io_submit\` must not be freed until all requests are known to have completed.

## What is changed and how does it work?

- **Remove the 1-second \`io_getevents\` timeout**: pass \`nullptr\` instead of \`&timeout\` so the call blocks until all submitted requests complete. This ensures no in-flight request is abandoned.
- **Wait on actual submitted count**: use \`submitted\` (return value of \`io_submit\`) instead of \`count\` for \`io_getevents\` min_nr/nr, correctly handling partial \`io_submit\`.
- **Drain before error**: when \`io_submit\` partially succeeds (0 < submitted < count), first block-wait for all submitted requests to complete, then safely release buffers before throwing.

## Related issues

Closes #2281