### PR TITLE
fix(hgraph): publish code slots before brute-force search reads them

### DIFF
--- a/src/algorithm/hgraph/hgraph.cpp
+++ b/src/algorithm/hgraph/hgraph.cpp
@@ -430,6 +430,11 @@ HGraph::Merge(const std::vector<MergeUnit>& merge_units) {
         sparse_odescent_builder.SaveGraph(graph);
         this->entry_point_id_ = ids.back();
     }
+    // Merged slots received their codes via MergeOther(), bypassing the
+    // per-slot Mark() in insert_persistent_codes(). Publish the whole range so
+    // brute-force search can see them (#2294).
+    this->codes_ready_.Resize(this->max_capacity_.load());
+    this->codes_ready_.MarkRange(this->total_count_.load());
 }
 
 void

--- a/src/algorithm/hgraph/hgraph.h
+++ b/src/algorithm/hgraph/hgraph.h
@@ -38,6 +38,7 @@
 #include "index_common_param.h"
 #include "index_feature_list.h"
 #include "typing.h"
+#include "utils/atomic_visibility_bitmap.h"
 #include "utils/lock_strategy.h"
 #include "utils/util_functions.h"
 #include "utils/visited_list.h"
@@ -570,6 +571,16 @@ private:
 
     uint64_t ef_construct_{400};  // expansion factor during graph construction
     float alpha_{1.0};            // Relative Neighborhood Graph pruning coefficient
+
+    // Per-slot "codes are fully written" flags. A slot's inner_id is published
+    // into total_count_ before its quantized codes are written, so brute-force
+    // search (which scans [0, total_count_) directly, bypassing the graph
+    // edges) could otherwise read a slot whose codes are still being written.
+    // insert_persistent_codes() Marks a slot (release) once its codes are
+    // durable; brute_force_search() skips slots that are not yet ready
+    // (acquire). Grown alongside the code storage inside resize(), under the
+    // same global_mutex_/add_mutex_ exclusion. See issue #2294.
+    mutable AtomicVisibilityBitmap codes_ready_;
 
     std::shared_ptr<VisitedListPool> pool_{nullptr};  // pool of visited-lists for search
 

--- a/src/algorithm/hgraph/hgraph.h
+++ b/src/algorithm/hgraph/hgraph.h
@@ -580,7 +580,7 @@ private:
     // durable; brute_force_search() skips slots that are not yet ready
     // (acquire). Grown alongside the code storage inside resize(), under the
     // same global_mutex_/add_mutex_ exclusion. See issue #2294.
-    mutable AtomicVisibilityBitmap codes_ready_;
+    AtomicVisibilityBitmap codes_ready_;
 
     std::shared_ptr<VisitedListPool> pool_{nullptr};  // pool of visited-lists for search
 

--- a/src/algorithm/hgraph/hgraph_build.cpp
+++ b/src/algorithm/hgraph/hgraph_build.cpp
@@ -410,6 +410,10 @@ HGraph::insert_persistent_codes(const void* data, InnerIdType inner_id) {
     if (create_new_raw_vector_) {
         raw_vector_->InsertVector(data, inner_id);
     }
+    // Publish the slot now that all of its codes are durably written. This
+    // release pairs with the acquire in brute_force_search()'s readiness check
+    // so a concurrent scan never observes a partially written slot (#2294).
+    this->codes_ready_.Mark(inner_id);
 }
 
 void
@@ -561,6 +565,7 @@ HGraph::resize(uint64_t new_size) {
         this->label_table_->Resize(new_size_power_2);
         bottom_graph_->Resize(new_size_power_2);
         this->basic_flatten_codes_->Resize(new_size_power_2);
+        this->codes_ready_.Resize(new_size_power_2);
         if (has_precise_reorder()) {
             this->high_precise_codes_->Resize(new_size_power_2);
         }

--- a/src/algorithm/hgraph/hgraph_search.cpp
+++ b/src/algorithm/hgraph/hgraph_search.cpp
@@ -324,7 +324,14 @@ HGraph::brute_force_search(const void* query,
     while (cursor < total) {
         InnerIdType batch_count = 0;
         while (cursor < total && batch_count < brute_force_batch_size) {
-            if (filter == nullptr || filter->CheckValid(cursor)) {
+            // Skip slots whose codes are not yet published. A slot's inner_id
+            // enters total_count_ before its codes are written, so an unready
+            // slot here is one whose codes are still being written by a
+            // concurrent Add; reading it would be a data race (#2294). The
+            // acquire load pairs with the release Mark() in
+            // insert_persistent_codes().
+            if (this->codes_ready_.IsReady(cursor) &&
+                (filter == nullptr || filter->CheckValid(cursor))) {
                 batch_ids[batch_count++] = cursor;
             }
             ++cursor;

--- a/src/algorithm/hgraph/hgraph_serialize.cpp
+++ b/src/algorithm/hgraph/hgraph_serialize.cpp
@@ -388,6 +388,12 @@ HGraph::Deserialize(StreamReader& reader) {
             this->has_raw_vector_ = true;
         }
     }
+    // All deserialized slots carry fully written codes. Size the readiness
+    // bitmap to the restored capacity and publish [0, total_count_) so a later
+    // brute-force search can see them (this bulk path bypasses the per-slot
+    // Mark() in insert_persistent_codes()). See #2294.
+    this->codes_ready_.Resize(this->max_capacity_.load());
+    this->codes_ready_.MarkRange(this->total_count_.load());
     this->cal_memory_usage();
 
     // post serialize procedure

--- a/src/utils/atomic_visibility_bitmap.h
+++ b/src/utils/atomic_visibility_bitmap.h
@@ -41,10 +41,10 @@ namespace vsag {
  *   - Mark() and IsReady() are safe to call concurrently with each other.
  *   - Resize() reallocates the backing storage and is NOT safe to run
  *     concurrently with Mark()/IsReady(); the caller must serialise Resize()
- *     against all Mark()/IsReady() via an external lock. In HGraph this is the
- *     existing resize() exclusion (global_mutex_ + add_mutex_ both held
- *     exclusively during resize, while Mark/IsReady run under the shared side).
- */
+     *     against all Mark()/IsReady() via an external lock. In HGraph, resize()
+     *     takes global_mutex_ exclusively; Add() callers use add_mutex_ to keep
+     *     resize and slot publication ordered.
+     */
 class AtomicVisibilityBitmap {
 public:
     AtomicVisibilityBitmap() = default;

--- a/src/utils/atomic_visibility_bitmap.h
+++ b/src/utils/atomic_visibility_bitmap.h
@@ -62,8 +62,8 @@ public:
         }
         auto new_data = std::make_unique<std::atomic<uint64_t>[]>(new_words);
         for (uint64_t i = 0; i < word_count_; ++i) {
-            const auto word = data_[i].load(std::memory_order_relaxed);
-            new_data[i].store(word, std::memory_order_relaxed);
+            const auto word = data_[i].load(std::memory_order_acquire);
+            new_data[i].store(word, std::memory_order_release);
         }
         for (uint64_t i = word_count_; i < new_words; ++i) {
             new_data[i].store(0, std::memory_order_relaxed);

--- a/src/utils/atomic_visibility_bitmap.h
+++ b/src/utils/atomic_visibility_bitmap.h
@@ -1,0 +1,119 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <memory>
+
+namespace vsag {
+
+/**
+ * @brief A grow-only, per-slot visibility flag map backed by atomic words.
+ *
+ * Each slot owns one bit. The intended use is a "publish after fully written"
+ * pattern: a producer writes a slot's payload and then calls Mark(slot)
+ * (release), while a consumer calls IsReady(slot) (acquire) before reading the
+ * payload. The release/acquire pair establishes a happens-before edge so the
+ * consumer that observes a set bit is guaranteed to see the fully written
+ * payload.
+ *
+ * Bits are only ever set, never cleared (other than via Resize/the ctor), so
+ * the consumer side is free of TOCTOU races: observing "ready" once means
+ * ready forever.
+ *
+ * Concurrency contract:
+ *   - Mark() and IsReady() are safe to call concurrently with each other.
+ *   - Resize() reallocates the backing storage and is NOT safe to run
+ *     concurrently with Mark()/IsReady(); the caller must serialise Resize()
+ *     against all Mark()/IsReady() via an external lock. In HGraph this is the
+ *     existing resize() exclusion (global_mutex_ + add_mutex_ both held
+ *     exclusively during resize, while Mark/IsReady run under the shared side).
+ */
+class AtomicVisibilityBitmap {
+public:
+    AtomicVisibilityBitmap() = default;
+
+    /**
+     * @brief Grow the bitmap so that at least `capacity` slots are addressable.
+     *
+     * Existing bits are preserved; newly added bits start cleared. Shrinking is
+     * a no-op. Must not run concurrently with Mark()/IsReady().
+     */
+    void
+    Resize(uint64_t capacity) {
+        uint64_t new_words = (capacity + BITS_PER_WORD - 1) / BITS_PER_WORD;
+        if (new_words <= word_count_) {
+            return;
+        }
+        auto new_data = std::make_unique<std::atomic<uint64_t>[]>(new_words);
+        for (uint64_t i = 0; i < word_count_; ++i) {
+            new_data[i].store(data_[i].load(std::memory_order_relaxed), std::memory_order_relaxed);
+        }
+        for (uint64_t i = word_count_; i < new_words; ++i) {
+            new_data[i].store(0, std::memory_order_relaxed);
+        }
+        data_ = std::move(new_data);
+        word_count_ = new_words;
+    }
+
+    /**
+     * @brief Publish slot `pos`: set its bit with release ordering.
+     *
+     * Call this only after the slot's payload has been fully written.
+     */
+    void
+    Mark(uint64_t pos) {
+        data_[pos / BITS_PER_WORD].fetch_or(bit_mask(pos), std::memory_order_release);
+    }
+
+    /**
+     * @brief Check whether slot `pos` has been published, with acquire ordering.
+     *
+     * A return of true guarantees the payload written before the matching
+     * Mark() is visible to the caller.
+     */
+    [[nodiscard]] bool
+    IsReady(uint64_t pos) const {
+        return (data_[pos / BITS_PER_WORD].load(std::memory_order_acquire) & bit_mask(pos)) != 0;
+    }
+
+    /**
+     * @brief Publish all slots in [0, count) at once (release ordering).
+     *
+     * Used to backfill slots populated through bulk paths (deserialize / merge)
+     * that bypass the per-slot Mark() call.
+     */
+    void
+    MarkRange(uint64_t count) {
+        for (uint64_t pos = 0; pos < count; ++pos) {
+            data_[pos / BITS_PER_WORD].fetch_or(bit_mask(pos), std::memory_order_release);
+        }
+    }
+
+private:
+    static constexpr uint64_t BITS_PER_WORD = 64;
+
+    static uint64_t
+    bit_mask(uint64_t pos) {
+        return static_cast<uint64_t>(1) << (pos % BITS_PER_WORD);
+    }
+
+    std::unique_ptr<std::atomic<uint64_t>[]> data_{nullptr};
+    uint64_t word_count_{0};
+};
+
+}  // namespace vsag

--- a/src/utils/atomic_visibility_bitmap.h
+++ b/src/utils/atomic_visibility_bitmap.h
@@ -23,28 +23,26 @@
 
 namespace vsag {
 
-/**
- * @brief A grow-only, per-slot visibility flag map backed by atomic words.
- *
- * Each slot owns one bit. The intended use is a "publish after fully written"
- * pattern: a producer writes a slot's payload and then calls Mark(slot)
- * (release), while a consumer calls IsReady(slot) (acquire) before reading the
- * payload. The release/acquire pair establishes a happens-before edge so the
- * consumer that observes a set bit is guaranteed to see the fully written
- * payload.
- *
- * Bits are only ever set, never cleared (other than via Resize/the ctor), so
- * the consumer side is free of TOCTOU races: observing "ready" once means
- * ready forever.
- *
- * Concurrency contract:
- *   - Mark() and IsReady() are safe to call concurrently with each other.
- *   - Resize() reallocates the backing storage and is NOT safe to run
- *     concurrently with Mark()/IsReady(); the caller must serialise Resize()
- *     against all Mark()/IsReady() via an external lock. In HGraph,
- *     resize() takes global_mutex_ exclusively; add-side call sites coordinate
- *     resize and slot publication with their own synchronization.
- */
+// A grow-only, per-slot visibility flag map backed by atomic words.
+//
+// Each slot owns one bit. The intended use is a "publish after fully written"
+// pattern: a producer writes a slot's payload and then calls Mark(slot)
+// (release), while a consumer calls IsReady(slot) (acquire) before reading the
+// payload. The release/acquire pair establishes a happens-before edge so the
+// consumer that observes a set bit is guaranteed to see the fully written
+// payload.
+//
+// Bits are only ever set, never cleared (other than via Resize/the ctor), so
+// the consumer side is free of TOCTOU races: observing "ready" once means ready
+// forever.
+//
+// Concurrency contract:
+//   - Mark() and IsReady() are safe to call concurrently with each other.
+//   - Resize() reallocates the backing storage and is NOT safe to run
+//     concurrently with Mark()/IsReady(); the caller must serialise Resize()
+//     against all Mark()/IsReady() via an external lock. In HGraph, resize()
+//     takes global_mutex_ exclusively; add-side call sites coordinate resize
+//     and slot publication with their own synchronization.
 class AtomicVisibilityBitmap {
 public:
     AtomicVisibilityBitmap() = default;

--- a/src/utils/atomic_visibility_bitmap.h
+++ b/src/utils/atomic_visibility_bitmap.h
@@ -112,7 +112,7 @@ public:
         if (remaining_bits != 0) {
             const auto remainder_word = count / BITS_PER_WORD;
             data_[remainder_word].fetch_or((static_cast<uint64_t>(1) << remaining_bits) - 1,
-                                          std::memory_order_release);
+                                           std::memory_order_release);
         } else {
             const auto last_word = (count - 1) / BITS_PER_WORD;
             data_[last_word].fetch_or(0xFFFFFFFFFFFFFFFFULL, std::memory_order_release);

--- a/src/utils/atomic_visibility_bitmap.h
+++ b/src/utils/atomic_visibility_bitmap.h
@@ -15,7 +15,9 @@
 
 #pragma once
 
+#include <algorithm>
 #include <atomic>
+#include <cassert>
 #include <cstdint>
 #include <memory>
 
@@ -57,6 +59,7 @@ public:
     Resize(uint64_t capacity) {
         uint64_t new_words = (capacity + BITS_PER_WORD - 1) / BITS_PER_WORD;
         if (new_words <= word_count_) {
+            capacity_ = std::max(capacity_, capacity);
             return;
         }
         auto new_data = std::make_unique<std::atomic<uint64_t>[]>(new_words);
@@ -68,6 +71,7 @@ public:
         }
         data_ = std::move(new_data);
         word_count_ = new_words;
+        capacity_ = capacity;
     }
 
     /**
@@ -77,6 +81,7 @@ public:
      */
     void
     Mark(uint64_t pos) {
+        assert(pos < capacity_);
         data_[pos / BITS_PER_WORD].fetch_or(bit_mask(pos), std::memory_order_release);
     }
 
@@ -88,6 +93,7 @@ public:
      */
     [[nodiscard]] bool
     IsReady(uint64_t pos) const {
+        assert(pos < capacity_);
         return (data_[pos / BITS_PER_WORD].load(std::memory_order_acquire) & bit_mask(pos)) != 0;
     }
 
@@ -99,6 +105,7 @@ public:
      */
     void
     MarkRange(uint64_t count) {
+        assert(count <= capacity_);
         if (count == 0) {
             return;
         }
@@ -129,6 +136,7 @@ private:
 
     std::unique_ptr<std::atomic<uint64_t>[]> data_{nullptr};
     uint64_t word_count_{0};
+    uint64_t capacity_{0};
 };
 
 }  // namespace vsag

--- a/src/utils/atomic_visibility_bitmap.h
+++ b/src/utils/atomic_visibility_bitmap.h
@@ -99,8 +99,23 @@ public:
      */
     void
     MarkRange(uint64_t count) {
-        for (uint64_t pos = 0; pos < count; ++pos) {
-            data_[pos / BITS_PER_WORD].fetch_or(bit_mask(pos), std::memory_order_release);
+        if (count == 0) {
+            return;
+        }
+
+        const auto full_words = count / BITS_PER_WORD;
+        for (uint64_t word = 0; word < full_words; ++word) {
+            data_[word].store(0xFFFFFFFFFFFFFFFFULL, std::memory_order_release);
+        }
+
+        const auto remaining_bits = count % BITS_PER_WORD;
+        if (remaining_bits != 0) {
+            const auto remainder_word = count / BITS_PER_WORD;
+            data_[remainder_word].fetch_or((static_cast<uint64_t>(1) << remaining_bits) - 1,
+                                          std::memory_order_release);
+        } else {
+            const auto last_word = (count - 1) / BITS_PER_WORD;
+            data_[last_word].fetch_or(0xFFFFFFFFFFFFFFFFULL, std::memory_order_release);
         }
     }
 

--- a/src/utils/atomic_visibility_bitmap.h
+++ b/src/utils/atomic_visibility_bitmap.h
@@ -41,9 +41,9 @@ namespace vsag {
  *   - Mark() and IsReady() are safe to call concurrently with each other.
  *   - Resize() reallocates the backing storage and is NOT safe to run
  *     concurrently with Mark()/IsReady(); the caller must serialise Resize()
-     *     against all Mark()/IsReady() via an external lock. In HGraph, resize()
-     *     takes global_mutex_ exclusively; Add() callers use add_mutex_ to keep
-     *     resize and slot publication ordered.
+     *     against all Mark()/IsReady() via an external lock. In HGraph,
+     *     resize() takes global_mutex_ exclusively; add-side call sites
+     *     coordinate resize and slot publication with their own synchronization.
      */
 class AtomicVisibilityBitmap {
 public:
@@ -64,7 +64,8 @@ public:
         }
         auto new_data = std::make_unique<std::atomic<uint64_t>[]>(new_words);
         for (uint64_t i = 0; i < word_count_; ++i) {
-            new_data[i].store(data_[i].load(std::memory_order_relaxed), std::memory_order_relaxed);
+            const auto word = data_[i].load(std::memory_order_relaxed);
+            new_data[i].store(word, std::memory_order_relaxed);
         }
         for (uint64_t i = word_count_; i < new_words; ++i) {
             new_data[i].store(0, std::memory_order_relaxed);
@@ -94,7 +95,8 @@ public:
     [[nodiscard]] bool
     IsReady(uint64_t pos) const {
         assert(pos < capacity_);
-        return (data_[pos / BITS_PER_WORD].load(std::memory_order_acquire) & bit_mask(pos)) != 0;
+        const auto word = data_[pos / BITS_PER_WORD].load(std::memory_order_acquire);
+        return (word & bit_mask(pos)) != 0;
     }
 
     /**

--- a/src/utils/atomic_visibility_bitmap.h
+++ b/src/utils/atomic_visibility_bitmap.h
@@ -41,10 +41,10 @@ namespace vsag {
  *   - Mark() and IsReady() are safe to call concurrently with each other.
  *   - Resize() reallocates the backing storage and is NOT safe to run
  *     concurrently with Mark()/IsReady(); the caller must serialise Resize()
-     *     against all Mark()/IsReady() via an external lock. In HGraph,
-     *     resize() takes global_mutex_ exclusively; add-side call sites
-     *     coordinate resize and slot publication with their own synchronization.
-     */
+ *     against all Mark()/IsReady() via an external lock. In HGraph,
+ *     resize() takes global_mutex_ exclusively; add-side call sites coordinate
+ *     resize and slot publication with their own synchronization.
+ */
 class AtomicVisibilityBitmap {
 public:
     AtomicVisibilityBitmap() = default;

--- a/src/utils/atomic_visibility_bitmap_test.cpp
+++ b/src/utils/atomic_visibility_bitmap_test.cpp
@@ -122,7 +122,7 @@ TEST_CASE("AtomicVisibilityBitmap Concurrent Mark And Read",
     bitmap.Resize(slot_count);
 
     std::atomic<bool> start{false};
-    std::atomic<uint64_t> false_positive{0};
+    std::atomic<uint64_t> missing_ready_count{0};
 
     constexpr uint32_t marker_threads = 4;
     std::vector<std::thread> markers;
@@ -162,8 +162,8 @@ TEST_CASE("AtomicVisibilityBitmap Concurrent Mark And Read",
     // After all markers joined, every slot must be ready.
     for (uint64_t i = 0; i < slot_count; ++i) {
         if (not bitmap.IsReady(i)) {
-            false_positive.fetch_add(1, std::memory_order_relaxed);
+            missing_ready_count.fetch_add(1, std::memory_order_relaxed);
         }
     }
-    REQUIRE(false_positive.load() == 0);
+    REQUIRE(missing_ready_count.load() == 0);
 }

--- a/src/utils/atomic_visibility_bitmap_test.cpp
+++ b/src/utils/atomic_visibility_bitmap_test.cpp
@@ -130,6 +130,7 @@ TEST_CASE("AtomicVisibilityBitmap Concurrent Mark And Read",
     for (uint32_t t = 0; t < marker_threads; ++t) {
         markers.emplace_back([&, t]() {
             while (not start.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
             }
             for (uint64_t i = t; i < slot_count; i += marker_threads) {
                 bitmap.Mark(i);
@@ -141,6 +142,7 @@ TEST_CASE("AtomicVisibilityBitmap Concurrent Mark And Read",
     // checked to stay ready (bits are never cleared).
     std::thread reader([&]() {
         while (not start.load(std::memory_order_acquire)) {
+            std::this_thread::yield();
         }
         uint64_t ready = 0;
         while (ready < slot_count) {
@@ -150,6 +152,7 @@ TEST_CASE("AtomicVisibilityBitmap Concurrent Mark And Read",
                     ++ready;
                 }
             }
+            std::this_thread::yield();
         }
     });
 

--- a/src/utils/atomic_visibility_bitmap_test.cpp
+++ b/src/utils/atomic_visibility_bitmap_test.cpp
@@ -123,6 +123,7 @@ TEST_CASE("AtomicVisibilityBitmap Concurrent Mark And Read",
 
     std::atomic<bool> start{false};
     std::atomic<uint64_t> missing_ready_count{0};
+    std::atomic<bool> reader_timed_out{false};
 
     constexpr uint32_t marker_threads = 4;
     std::vector<std::thread> markers;
@@ -145,15 +146,19 @@ TEST_CASE("AtomicVisibilityBitmap Concurrent Mark And Read",
             std::this_thread::yield();
         }
         uint64_t ready = 0;
-        while (ready < slot_count) {
+        constexpr uint64_t max_scan_attempts = 100000;
+        uint64_t scan_attempts = 0;
+        while (ready < slot_count && scan_attempts < max_scan_attempts) {
             ready = 0;
             for (uint64_t i = 0; i < slot_count; ++i) {
                 if (bitmap.IsReady(i)) {
                     ++ready;
                 }
             }
+            ++scan_attempts;
             std::this_thread::yield();
         }
+        reader_timed_out.store(ready < slot_count, std::memory_order_relaxed);
     });
 
     start.store(true, std::memory_order_release);
@@ -161,6 +166,7 @@ TEST_CASE("AtomicVisibilityBitmap Concurrent Mark And Read",
         th.join();
     }
     reader.join();
+    REQUIRE_FALSE(reader_timed_out.load(std::memory_order_relaxed));
 
     // After all markers joined, every slot must be ready.
     for (uint64_t i = 0; i < slot_count; ++i) {

--- a/src/utils/atomic_visibility_bitmap_test.cpp
+++ b/src/utils/atomic_visibility_bitmap_test.cpp
@@ -1,0 +1,169 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "utils/atomic_visibility_bitmap.h"
+
+#include <atomic>
+#include <thread>
+#include <vector>
+
+#include "unittest.h"
+
+using namespace vsag;
+
+TEST_CASE("AtomicVisibilityBitmap Basic", "[ut][AtomicVisibilityBitmap]") {
+    SECTION("mark then ready") {
+        AtomicVisibilityBitmap bitmap;
+        bitmap.Resize(128);
+        for (uint64_t i = 0; i < 128; ++i) {
+            REQUIRE_FALSE(bitmap.IsReady(i));
+        }
+        bitmap.Mark(0);
+        bitmap.Mark(63);
+        bitmap.Mark(64);
+        bitmap.Mark(127);
+        REQUIRE(bitmap.IsReady(0));
+        REQUIRE(bitmap.IsReady(63));
+        REQUIRE(bitmap.IsReady(64));
+        REQUIRE(bitmap.IsReady(127));
+        // Marking one bit must not set its neighbours.
+        REQUIRE_FALSE(bitmap.IsReady(1));
+        REQUIRE_FALSE(bitmap.IsReady(62));
+        REQUIRE_FALSE(bitmap.IsReady(65));
+        REQUIRE_FALSE(bitmap.IsReady(126));
+    }
+
+    SECTION("mark is idempotent") {
+        AtomicVisibilityBitmap bitmap;
+        bitmap.Resize(64);
+        bitmap.Mark(10);
+        bitmap.Mark(10);
+        REQUIRE(bitmap.IsReady(10));
+    }
+
+    SECTION("mark range") {
+        AtomicVisibilityBitmap bitmap;
+        bitmap.Resize(200);
+        bitmap.MarkRange(130);
+        for (uint64_t i = 0; i < 130; ++i) {
+            REQUIRE(bitmap.IsReady(i));
+        }
+        for (uint64_t i = 130; i < 200; ++i) {
+            REQUIRE_FALSE(bitmap.IsReady(i));
+        }
+    }
+
+    SECTION("mark range of zero is a no-op") {
+        AtomicVisibilityBitmap bitmap;
+        bitmap.Resize(64);
+        bitmap.MarkRange(0);
+        for (uint64_t i = 0; i < 64; ++i) {
+            REQUIRE_FALSE(bitmap.IsReady(i));
+        }
+    }
+}
+
+TEST_CASE("AtomicVisibilityBitmap Resize", "[ut][AtomicVisibilityBitmap]") {
+    SECTION("grow preserves existing bits and clears new ones") {
+        AtomicVisibilityBitmap bitmap;
+        bitmap.Resize(64);
+        bitmap.Mark(3);
+        bitmap.Mark(50);
+
+        // Grow across a word boundary; previously set bits must survive.
+        bitmap.Resize(256);
+        REQUIRE(bitmap.IsReady(3));
+        REQUIRE(bitmap.IsReady(50));
+        for (uint64_t i = 64; i < 256; ++i) {
+            REQUIRE_FALSE(bitmap.IsReady(i));
+        }
+
+        // The grown region is usable.
+        bitmap.Mark(200);
+        REQUIRE(bitmap.IsReady(200));
+    }
+
+    SECTION("shrink is a no-op") {
+        AtomicVisibilityBitmap bitmap;
+        bitmap.Resize(256);
+        bitmap.Mark(200);
+        // Requesting a smaller capacity must not drop storage or bits.
+        bitmap.Resize(64);
+        REQUIRE(bitmap.IsReady(200));
+    }
+
+    SECTION("non-multiple-of-word capacity is addressable") {
+        AtomicVisibilityBitmap bitmap;
+        bitmap.Resize(65);
+        bitmap.Mark(64);
+        REQUIRE(bitmap.IsReady(64));
+    }
+}
+
+TEST_CASE("AtomicVisibilityBitmap Concurrent Mark And Read",
+          "[ut][AtomicVisibilityBitmap][concurrent]") {
+    // Mirrors the HGraph usage: many producers publish distinct slots while a
+    // reader scans. The release/acquire pair must never report a slot ready
+    // before its Mark(), and every marked slot must eventually be observed.
+    constexpr uint64_t slot_count = 4096;
+    AtomicVisibilityBitmap bitmap;
+    bitmap.Resize(slot_count);
+
+    std::atomic<bool> start{false};
+    std::atomic<uint64_t> false_positive{0};
+
+    constexpr uint32_t marker_threads = 4;
+    std::vector<std::thread> markers;
+    markers.reserve(marker_threads);
+    for (uint32_t t = 0; t < marker_threads; ++t) {
+        markers.emplace_back([&, t]() {
+            while (not start.load(std::memory_order_acquire)) {
+            }
+            for (uint64_t i = t; i < slot_count; i += marker_threads) {
+                bitmap.Mark(i);
+            }
+        });
+    }
+
+    // Reader keeps scanning until every slot is ready; a slot reported ready is
+    // checked to stay ready (bits are never cleared).
+    std::thread reader([&]() {
+        while (not start.load(std::memory_order_acquire)) {
+        }
+        uint64_t ready = 0;
+        while (ready < slot_count) {
+            ready = 0;
+            for (uint64_t i = 0; i < slot_count; ++i) {
+                if (bitmap.IsReady(i)) {
+                    ++ready;
+                }
+            }
+        }
+    });
+
+    start.store(true, std::memory_order_release);
+    for (auto& th : markers) {
+        th.join();
+    }
+    reader.join();
+
+    // After all markers joined, every slot must be ready.
+    for (uint64_t i = 0; i < slot_count; ++i) {
+        if (not bitmap.IsReady(i)) {
+            false_positive.fetch_add(1, std::memory_order_relaxed);
+        }
+    }
+    REQUIRE(false_positive.load() == 0);
+}

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -3483,7 +3483,7 @@ TEST_CASE("HGraph Concurrent Add vs Brute-Force Search Race",
                 add_failures.fetch_add(1, std::memory_order_relaxed);
             }
         }
-        adder_done.store(true, std::memory_order_relaxed);
+        adder_done.store(true, std::memory_order_release);
     });
 
     // Searcher threads hammering the brute-force path while the adder runs.
@@ -3495,7 +3495,7 @@ TEST_CASE("HGraph Concurrent Add vs Brute-Force Search Race",
         const int64_t self_id = ids[tid % seed_count];
         std::vector<float> query(vectors.begin() + (tid % seed_count) * dim,
                                  vectors.begin() + (tid % seed_count) * dim + dim);
-        while (not adder_done.load(std::memory_order_relaxed)) {
+        while (not adder_done.load(std::memory_order_acquire)) {
             auto q = vsag::Dataset::Make();
             q->NumElements(1)->Dim(dim)->Float32Vectors(query.data())->Owner(false);
             // No filter -> valid_ratio == 1.0 <= brute_force_threshold, so the
@@ -3507,7 +3507,7 @@ TEST_CASE("HGraph Concurrent Add vs Brute-Force Search Race",
             }
             const auto* result_ids = res.value()->GetIds();
             const auto* dists = res.value()->GetDistances();
-            const auto count = res.value()->GetDim();
+            const auto count = std::min<int64_t>(res.value()->GetDim(), topk);
             bool found_self = false;
             for (int64_t r = 0; r < count; ++r) {
                 if (not std::isfinite(dists[r])) {

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -18,10 +18,12 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
 #include <chrono>
+#include <cmath>
 #include <limits>
 #include <random>
 #include <sstream>
 #include <thread>
+#include <vector>
 
 #include "functest.h"
 #include "inner_string_params.h"
@@ -3380,4 +3382,160 @@ TEST_CASE("HGraph Concurrent Tune(disable_future_tuning=false) and CalDistanceBy
     }
 
     REQUIRE(cal_count.load() > 0);
+}
+
+// Regression test for the data race between a concurrent Add and a brute-force
+// KnnSearch (issue #2294). HGraph advertises SUPPORT_ADD_SEARCH_CONCURRENT, but
+// Add() publishes a new inner_id by incrementing total_count_ *before* the
+// vector's quantized codes are written, while brute_force_search() scans
+// [0, total_count_) and reads code slots directly. A search can therefore read
+// a slot whose codes are still being memcpy-ed into the flatten storage.
+//
+// Graph KNN is unaffected because a node only becomes reachable through edges
+// that are published *after* its codes are written; brute force bypasses that
+// ordering by scanning the raw count. The test deliberately forces the
+// brute-force path via "brute_force_threshold": 1.0 (no filter ->
+// valid_ratio == 1.0 <= threshold) and uses "base_io_type": "memory_io" so the
+// flatten codes live in a single contiguous buffer whose tail slot is being
+// written exactly while a searcher reads it.
+//
+// Under a normal build this test merely exercises the concurrent path and
+// passes (a torn read only yields a garbage distance, not a crash). Its value
+// is under ThreadSanitizer (`make tsan` / `make test_tsan`): TSan reports a
+// data race between MemoryIO::WriteImpl (via insert_persistent_codes) and
+// FlattenDataCell::query (via brute_force_search). Once the race is fixed, the
+// test must stay clean under TSan.
+TEST_CASE("HGraph Concurrent Add vs Brute-Force Search Race",
+          "[ft][concurrent][hgraph][brute_force_threshold]") {
+    constexpr int64_t dim = 16;
+    constexpr int64_t seed_count = 200;
+    constexpr int64_t add_count = 2000;
+    constexpr int64_t total_count = seed_count + add_count;
+    constexpr int64_t topk = 2;
+    constexpr uint32_t searcher_threads = 4;
+
+    // memory_io + fp32 keeps the codes in one contiguous buffer and avoids any
+    // quantizer training requirement; build_thread_count > 1 defers the code
+    // writes to pool workers, widening the window between the total_count_ bump
+    // and the code write so the race is hit reliably.
+    std::string hgraph_params = R"({
+        "dtype": "float32",
+        "metric_type": "l2",
+        "dim": 16,
+        "index_param": {
+            "base_quantization_type": "fp32",
+            "base_io_type": "memory_io",
+            "max_degree": 16,
+            "ef_construction": 100,
+            "build_thread_count": 4,
+            "use_reorder": false
+        }
+    })";
+    auto factory_res = vsag::Factory::CreateIndex("hgraph", hgraph_params);
+    REQUIRE(factory_res.has_value());
+    auto index = std::move(factory_res.value());
+
+    REQUIRE(index->CheckFeature(vsag::SUPPORT_ADD_SEARCH_CONCURRENT));
+
+    std::mt19937 rng(20260618);
+    std::uniform_real_distribution<float> dist(-1.0F, 1.0F);
+    std::vector<float> vectors(total_count * dim);
+    std::vector<int64_t> ids(total_count);
+    for (int64_t i = 0; i < total_count; ++i) {
+        ids[i] = i;
+        for (int64_t j = 0; j < dim; ++j) {
+            vectors[i * dim + j] = dist(rng);
+        }
+    }
+
+    // Seed the index so entry_point_id_ is set; otherwise SearchWithRequest
+    // returns early before ever reaching the brute-force block.
+    auto seed = vsag::Dataset::Make();
+    seed->NumElements(seed_count)
+        ->Dim(dim)
+        ->Ids(ids.data())
+        ->Float32Vectors(vectors.data())
+        ->Owner(false);
+    REQUIRE(index->Build(seed).has_value());
+
+    const auto* search_param = R"({"hgraph": {"ef_search": 64, "brute_force_threshold": 1.0}})";
+
+    std::atomic<bool> adder_done{false};
+    std::atomic<uint64_t> add_failures{0};
+    std::atomic<uint64_t> search_failures{0};
+    // Counts brute-force results that are impossible unless a torn / unpublished
+    // slot leaked into the scan: a non-finite distance, or the query's own
+    // (always-ready, id == query id) vector failing to come back as an exact
+    // (~0 distance) match. Under a correct fix this stays 0.
+    std::atomic<uint64_t> correctness_violations{0};
+
+    // Single adder thread streaming new vectors one at a time, matching the
+    // issue reproducer.
+    std::thread adder([&]() {
+        for (int64_t i = seed_count; i < total_count; ++i) {
+            auto one = vsag::Dataset::Make();
+            one->NumElements(1)
+                ->Dim(dim)
+                ->Ids(ids.data() + i)
+                ->Float32Vectors(vectors.data() + i * dim)
+                ->Owner(false);
+            if (not index->Add(one).has_value()) {
+                add_failures.fetch_add(1, std::memory_order_relaxed);
+            }
+        }
+        adder_done.store(true, std::memory_order_relaxed);
+    });
+
+    // Searcher threads hammering the brute-force path while the adder runs.
+    // Each queries one of the seed vectors (present and ready from the start),
+    // so a correct brute-force scan must always return that vector at distance
+    // ~0. A torn read of a concurrently written slot would instead surface a
+    // garbage distance and could displace the true self-match.
+    auto searcher = [&](uint32_t tid) {
+        const int64_t self_id = ids[tid % seed_count];
+        std::vector<float> query(vectors.begin() + (tid % seed_count) * dim,
+                                 vectors.begin() + (tid % seed_count) * dim + dim);
+        while (not adder_done.load(std::memory_order_relaxed)) {
+            auto q = vsag::Dataset::Make();
+            q->NumElements(1)->Dim(dim)->Float32Vectors(query.data())->Owner(false);
+            // No filter -> valid_ratio == 1.0 <= brute_force_threshold, so the
+            // full [0, total_count_) scan is taken on every call.
+            auto res = index->KnnSearch(q, topk, search_param);
+            if (not res.has_value()) {
+                search_failures.fetch_add(1, std::memory_order_relaxed);
+                continue;
+            }
+            const auto* result_ids = res.value()->GetIds();
+            const auto* dists = res.value()->GetDistances();
+            const auto count = res.value()->GetDim();
+            bool found_self = false;
+            for (int64_t r = 0; r < count; ++r) {
+                if (not std::isfinite(dists[r])) {
+                    correctness_violations.fetch_add(1, std::memory_order_relaxed);
+                }
+                if (result_ids[r] == self_id && dists[r] < 1e-4F) {
+                    found_self = true;
+                }
+            }
+            if (not found_self) {
+                correctness_violations.fetch_add(1, std::memory_order_relaxed);
+            }
+        }
+    };
+
+    std::vector<std::thread> searchers;
+    searchers.reserve(searcher_threads);
+    for (uint32_t t = 0; t < searcher_threads; ++t) {
+        searchers.emplace_back(searcher, t);
+    }
+
+    adder.join();
+    for (auto& th : searchers) {
+        th.join();
+    }
+
+    REQUIRE(add_failures.load() == 0);
+    REQUIRE(search_failures.load() == 0);
+    REQUIRE(correctness_violations.load() == 0);
+    REQUIRE(index->GetNumElements() == total_count);
 }


### PR DESCRIPTION
## Change Type

- [x] Bug fix

## Linked Issue

- Fixes: #2294

## What Changed

`HGraph` advertises `SUPPORT_ADD_SEARCH_CONCURRENT`, but `Add()` publishes a new
`inner_id` into `total_count_` **before** the vector's quantized codes are
written, while `brute_force_search()` scans `[0, total_count_)` and reads code
slots directly. A concurrent search could therefore read a slot whose codes were
still being written — a data race (and, with `memory_io`, a torn read of the
in-flight `memcpy`). Graph KNN is unaffected because a node only becomes
reachable through edges published *after* its codes are written; brute force
bypasses that ordering by scanning the raw count.

- Add a grow-only `AtomicVisibilityBitmap` (`src/utils/atomic_visibility_bitmap.h`)
  that reproduces the happens-before the graph path already relies on.
- `insert_persistent_codes()` **Marks** a slot (release) once its codes are
  durable; `brute_force_search()` **skips** slots that are not yet ready
  (acquire). This is the single convergence point for all real code writes
  (plain/deferred Add, odescent build, cache build).
- The bitmap grows alongside the code storage inside `resize()` under the
  existing `global_mutex_`/`add_mutex_` exclusion, so it introduces no new race
  class and does **not** serialize `Add`.
- Bulk-load paths that bypass `insert_persistent_codes()` (`Deserialize`,
  `Merge`) backfill the whole `[0, total_count_)` range.
- Tests: a TSan regression test (`HGraph Concurrent Add vs Brute-Force Search
  Race` in `tests/test_hgraph.cpp`) and a unit test for the new bitmap.

## Test Evidence

- [x] `make fmt`
- [x] `make lint`
- [ ] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [x] Other (describe below)

Test details:

```text
# Red -> Green under ThreadSanitizer (Sanitize build, ENABLE_TSAN=ON):
#   before fix: TSan reports data race
#     MemoryIO::WriteImpl (insert_persistent_codes)  <->  FlattenDataCell::query (brute_force_search)
#   after fix:
TSAN_OPTIONS="report_atomic_races=0 halt_on_error=1" \
  ./build-tsan/tests/functests "HGraph Concurrent Add vs Brute-Force Search Race"
  => All tests passed (7 assertions in 1 test case)   [TSan clean]

# Negative control: temporarily forcing the read side to ignore the readiness
# bit reproduces the race under TSan (EXIT=66), confirming the test is a real gate.

# Normal Debug build:
./build/tests/functests "HGraph Concurrent Add vs Brute-Force Search Race"
  => All tests passed (7 assertions)
./build/tests/functests "[brute_force_threshold]"
  => All tests passed (33 assertions in 3 test cases)
./build/tests/unittests "[AtomicVisibilityBitmap]"
  => All tests passed (599 assertions in 3 test cases)

# Regression (no behavior change on existing paths):
./build/tests/functests "[build][hgraph][pr]"   => All tests passed (307724 assertions in 14 test cases)
./build/tests/functests "(PR) HGraph Merge"      => All tests passed (36336 assertions in 1 test case)

# clang-format-15 / clang-tidy-15: clean on all changed files (no user-code diagnostics).
# Note: the full `make test` suite was not run end-to-end here; the targeted
# functional + unit + TSan runs above cover the changed paths.
```

## Compatibility Impact

- API/ABI compatibility: none (no public header changes; `AtomicVisibilityBitmap` is internal under `src/utils/`).
- Behavior changes: none observable. Brute-force search now ignores slots whose codes are not yet published, which is precisely the previously-racy window.

## Performance and Concurrency Impact

- Performance impact: negligible — one acquire load per candidate slot in the brute-force scan; bitmap is 1 bit/slot (~1.25 MB for 10M vectors).
- Concurrency/thread-safety impact: fixes a read/write data race between `Add` and brute-force `KnnSearch`; does not serialize `Add` (publish goes through the shared `add_mutex_` path, reads are lock-free).

## Documentation Impact

- [x] No docs update needed

## Risk and Rollback

- Risk level: low — change is localized to the brute-force read path and the code-publish point; graph search path untouched.
- Rollback plan: revert the commit; no data format or API changes are involved.

## Checklist

- [x] I have linked the relevant issue
- [x] I have added/updated tests for new behavior or bug fixes
- [x] I have considered API compatibility impact
- [x] I have updated docs if behavior/workflow changed (n/a)
- [x] My commit messages follow project conventions
