### PR TITLE
fix(heap): bound non-fixed MemmoveHeap Push to prevent buffer overflow (topk<10)

### DIFF
--- a/src/impl/heap/distance_heap_test.cpp
+++ b/src/impl/heap/distance_heap_test.cpp
@@ -15,6 +15,10 @@
 
 #include "distance_heap.h"
 
+#include <algorithm>
+#include <limits>
+#include <vector>
+
 #include "impl/allocator/safe_allocator.h"
 #include "memmove_heap.h"
 #include "standard_heap.h"
@@ -105,5 +109,60 @@ TEST_CASE_METHOD(TestDistanceHeap, "memmove_heap test", "[ut][distance_heap]") {
         RunBasicTest(heap3, false);
         MemmoveHeap<false, false> heap4(allocator.get(), max_size);
         RunBasicTest(heap4, false);
+    }
+}
+
+// Regression for the non-fixed MemmoveHeap buffer overflow hit by IVF::search
+// when topk < 10. The non-fixed heap's Pop() only decrements cur_size_ without
+// shrinking ordered_buffer_, so a stale tail accumulates. IVF interleaves
+// Push with a bounded Pop (the loop replayed below); the non-fixed Push then
+// searched the whole buffer (including the stale tail) and could compute a
+// negative memmove size, overrunning the heap. This exercises that exact
+// interleaving and validates the kept records against a brute-force top-k.
+//
+// RunBasicTest does not catch it because it pushes all elements then pops all,
+// never interleaving Push/Pop; IVF's own tests use top_k == 10, which selects
+// StandardHeap rather than MemmoveHeap.
+TEST_CASE_METHOD(TestDistanceHeap,
+                 "memmove_heap non-fixed Pop-then-Push (topk<10)",
+                 "[ut][distance_heap]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    // seed 0 produces a distance sequence that triggers the overflow within a
+    // few dozen iterations for several of these topk values.
+    auto dists = fixtures::GenerateVectors<float>(1000, 1, 0, false);
+
+    for (int64_t topk = 1; topk < 10; ++topk) {
+        MemmoveHeap<true, false> heap(allocator.get(), topk);
+        auto cur_heap_top = std::numeric_limits<float>::max();
+
+        // Mirror the KNN scan loop in IVF::search (src/algorithm/ivf/ivf.cpp).
+        for (uint64_t i = 0; i < 1000; ++i) {
+            float d = dists[i];
+            if (heap.Size() < static_cast<uint64_t>(topk) or d < cur_heap_top) {
+                heap.Push(d, static_cast<InnerIdType>(i));
+            }
+            if (heap.Size() > static_cast<uint64_t>(topk)) {
+                heap.Pop();
+            }
+            if (not heap.Empty() and heap.Size() == static_cast<uint64_t>(topk)) {
+                cur_heap_top = heap.Top().first;
+            }
+        }
+
+        REQUIRE(heap.Size() == static_cast<uint64_t>(topk));
+
+        // The retained records must be exactly the topk smallest distances.
+        std::vector<float> got;
+        const auto* heap_data = heap.GetData();
+        for (uint64_t i = 0; i < heap.Size(); ++i) {
+            got.emplace_back(heap_data[i].first);
+        }
+        std::sort(got.begin(), got.end());
+
+        std::vector<float> expected(dists.begin(), dists.begin() + 1000);
+        std::sort(expected.begin(), expected.end());
+        expected.resize(topk);
+
+        REQUIRE(got == expected);
     }
 }

--- a/src/impl/heap/memmove_heap.cpp
+++ b/src/impl/heap/memmove_heap.cpp
@@ -54,10 +54,13 @@ MemmoveHeap<max_heap, fixed_size>::Push(float dist, InnerIdType id) {
                                     record,
                                     CompareType()) -
                    this->ordered_buffer_.begin();
-        if (cur_size_ < static_cast<int64_t>(ordered_buffer_.size())) {
-            ordered_buffer_[cur_size_] = record;
-        } else {
-            ordered_buffer_.push_back(record);
+        // Pop() only decrements cur_size_, so ordered_buffer_ may already hold a
+        // stale tail beyond cur_size_. Reuse that slot instead of emplace_back,
+        // which both bounds the buffer growth and keeps the upper_bound above
+        // (which searches only [begin, begin + cur_size_)) consistent with the
+        // memmove size below.
+        if (static_cast<int64_t>(ordered_buffer_.size()) <= cur_size_) {
+            ordered_buffer_.emplace_back(record);
         }
         // NOLINTNEXTLINE(bugprone-undefined-memory-manipulation)
         memmove(ordered_buffer_.data() + pos + 1,


### PR DESCRIPTION
## Change Type

- [x] Bug fix

## Linked Issue

- Fixes: #2298

## What Changed

The non-fixed `MemmoveHeap` (`MemmoveHeap<max_heap, false>`) ran
`std::upper_bound` over the **entire** `ordered_buffer_` (`begin()..end()`).
Because `Pop()` only decrements `cur_size_` without shrinking `ordered_buffer_`,
a stale tail accumulates, so the insertion index `pos` could exceed `cur_size_`
and make `memmove(..., (cur_size_ - pos) * sizeof(DistanceRecord))` underflow to
a huge `size_t`, overrunning the heap buffer.

`DistanceHeap::MakeInstanceBySize` selects `MemmoveHeap` only when
`max_size < 10`, and `IVF::search` requests the non-fixed variant
(`MakeInstanceBySize<true, false>(topk)`) then interleaves `Push` with a bounded
`Pop`. So any `KnnSearch` with `topk < 10` reaches the buggy path; whether it
overruns is data-dependent. The fixed-size branch was already correct (it bounds
`upper_bound` at `begin() + cur_size_`).

- Bound the non-fixed branch's `upper_bound` at `begin() + cur_size_`, matching
  the already-correct fixed-size branch.
- Reuse the stale tail slot instead of `emplace_back` when
  `ordered_buffer_.size() > cur_size_`, which also bounds the previously
  unbounded buffer growth.
- Tests: a regression test (`memmove_heap non-fixed Pop-then-Push (topk<10)` in
  `src/impl/heap/distance_heap_test.cpp`) replaying IVF's `Push`/`Pop`
  interleaving across `topk` 1–9 with a triggering seed, validated against a
  brute-force top-k.

## Test Evidence

- [x] `make fmt`
- [x] `make lint`
- [ ] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [x] Other (describe below)

Test details:

```text
# Red -> Green (normal Debug build, ENABLE_ASAN=OFF):
#   before fix: ./build/tests/unittests "memmove_heap non-fixed Pop-then-Push (topk<10)"
#     => wrong results (0.0f leaked into top-5) + free(): invalid pointer -> SIGABRT (exit 134)
#   after fix:
./build/tests/unittests "memmove_heap non-fixed Pop-then-Push (topk<10)"
  => All tests passed (18 assertions in 1 test case)

# Regression (no behavior change on existing heap paths):
./build/tests/unittests "[distance_heap]"   => All tests passed (8106 assertions in 3 test cases)
./build/tests/unittests "[IVFNearestPartition][ut],[IVFParameter][ut]"
  => All tests passed (3035 assertions in 4 test cases)

# End-to-end: 200 real IVF KnnSearch queries at topk=5 against a rebuilt libvsag.so
#   => "OK: 200 topk=5 queries returned 5 results each, no crash"

# Cross-checked against a brute-force top-k over 4500 cases (500 seeds x topk 1-9):
#   no overflow, results match, worst-case peak buffer memory ~1.5 MB -> 96 bytes.

# clang-format-15 / clang-tidy-15: clean on memmove_heap.cpp. The test file is
# excluded from `make lint` by the repo's `(?<!_test)` source filter.
# Note: the full `make test` suite was not run end-to-end here; the targeted
# heap + IVF unit runs and the end-to-end IVF check above cover the changed paths.
```

## Compatibility Impact

- API/ABI compatibility: none (no public header changes; the change is internal
  to `src/impl/heap/`).
- Behavior changes: `KnnSearch` with `topk < 10` now returns correct top-k
  results without memory corruption, matching `topk >= 10` (`StandardHeap`).

## Performance and Concurrency Impact

- Performance impact: negligible — the non-fixed `Push` now searches a tighter
  range (`[begin, begin + cur_size_)`) and reuses slots, reducing reallocations.
- Concurrency/thread-safety impact: none — each IVF search thread owns its heap.

## Documentation Impact

- [x] No docs update needed

## Risk and Rollback

- Risk level: low — change is localized to the non-fixed `MemmoveHeap::Push`
  branch; the fixed-size branch and `StandardHeap` are untouched.
- Rollback plan: revert the commit; no data format or API changes are involved.

## Checklist

- [x] I have linked the relevant issue
- [x] I have added/updated tests for new behavior or bug fixes
- [x] I have considered API compatibility impact
- [x] I have updated docs if behavior/workflow changed (n/a)
- [x] My commit messages follow project conventions
