### PR TITLE
docs: add offline / internal-mirror third-party build guide

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -142,9 +142,22 @@ The legacy switch **`USE_SYSTEM_OPENBLAS`** (default: `OFF`) is kept as a deprec
 
 ### Third-Party Source Overrides
 
-- **`VSAG_THIRDPARTY_OPENBLAS`**
+VSAG downloads its third-party libraries at configure/build time. Each
+downloaded dependency honors a `VSAG_THIRDPARTY_<LIB>` **environment variable**
+that, when set, is tried before the upstream URL and the project's Aliyun OSS
+mirror. The value may be a local filesystem path or any URL (internal HTTP
+server, OSS bucket, etc.), which makes it the primary mechanism for offline,
+air-gapped, or internal-mirror builds.
+
+- **`VSAG_THIRDPARTY_OPENBLAS`** (representative example)
   - Override the OpenBLAS source archive URL/path used by `ExternalProject_Add`
   - Useful for offline builds, local mirrors, or pre-downloaded archives
+
+The full list of variables (`VSAG_THIRDPARTY_ANTLR4`, `VSAG_THIRDPARTY_BOOST`,
+`VSAG_THIRDPARTY_FMT`, …), usage examples, and the exact archives to mirror are
+documented in the [Offline / Air-gapped Builds](docs/docs/en/src/development/offline_build.md)
+guide. The note next to each `URL_HASH` in `extern/<lib>/<lib>.cmake` is the
+source of truth for the exact upstream URL and expected checksum.
 
 ### Other Build Options
 

--- a/docs/docs/en/src/SUMMARY.md
+++ b/docs/docs/en/src/SUMMARY.md
@@ -35,6 +35,7 @@
 
 - [Code Structure](development/code_structure.md)
 - [Building](development/building.md)
+- [Offline / Air-gapped Builds](development/offline_build.md)
 - [Running Tests](development/testing.md)
 - [Contributing](development/contributing.md)
 

--- a/docs/docs/en/src/development/building.md
+++ b/docs/docs/en/src/development/building.md
@@ -75,6 +75,15 @@ cmake -S . -B build-release -DCMAKE_BUILD_TYPE=Release -DENABLE_INTEL_MKL=ON
 cmake --build build-release -j
 ```
 
+## Offline / Air-gapped Builds
+
+VSAG downloads its third-party libraries at configure/build time. In offline or
+restricted-network environments, set the per-dependency `VSAG_THIRDPARTY_*`
+environment variables to fetch each archive from a local path or an internal
+mirror (internal HTTP server, OSS bucket, etc.). See
+[Offline / Air-gapped Builds](offline_build.md) for the full list of variables
+and worked examples.
+
 ## Python Wheel (pyvsag)
 
 ```bash

--- a/docs/docs/en/src/development/offline_build.md
+++ b/docs/docs/en/src/development/offline_build.md
@@ -1,0 +1,211 @@
+# Offline / Air-gapped Builds
+
+VSAG downloads a set of third-party libraries at CMake **configure / build time**
+(via `ExternalProject_Add` and `FetchContent`). On a machine without internet
+access, or behind a slow / restricted network, those downloads can fail or time
+out. This page explains how to point each dependency at a **local path** or an
+**internal mirror** (internal HTTP server, OSS bucket, Artifactory, etc.) so the
+build can complete fully offline.
+
+## How third-party downloads are resolved
+
+For every downloaded dependency, VSAG builds a *list* of candidate URLs and lets
+CMake try them **in order**, stopping at the first one that succeeds. Using
+`antlr4` as the representative example
+([`extern/antlr4/antlr4.cmake`](https://github.com/antgroup/vsag/blob/main/extern/antlr4/antlr4.cmake)):
+
+```cmake
+set (antlr4_urls
+    https://github.com/antlr/antlr4/archive/refs/tags/4.13.2.tar.gz   # 1. upstream
+    https://vsagcache.oss-rg-china-mainland.aliyuncs.com/antlr4/v4.13.2.tar.gz  # 2. project mirror
+)
+if (DEFINED ENV{VSAG_THIRDPARTY_ANTLR4})
+    message (STATUS "Using local path for antlr4: $ENV{VSAG_THIRDPARTY_ANTLR4}")
+    list (PREPEND antlr4_urls "$ENV{VSAG_THIRDPARTY_ANTLR4}")   # 0. your override (tried first)
+endif ()
+
+ExternalProject_Add (antlr4
+    URL ${antlr4_urls}
+    URL_HASH MD5=3b75610fc8a827119258cba09a068be5
+    ...)
+```
+
+The resolution order is therefore:
+
+1. **`VSAG_THIRDPARTY_<LIB>`** — your override, if the environment variable is
+   set to a **non-empty** value. Tried **first**.
+2. The **upstream** URL (GitHub / project release page).
+3. The project-maintained **Aliyun OSS mirror**
+   (`vsagcache.oss-rg-china-mainland.aliyuncs.com`). This fallback is always
+   present and helps in mainland-China / poor-network environments, but it is
+   **not** user-configurable — for a fully internal mirror, use the environment
+   variable.
+
+> **Availability:** the `VSAG_THIRDPARTY_*` override is available on `main` and on
+> the `0.15`, `0.16`, `0.17`, and `0.18` release lines — see
+> [Version availability](#version-availability).
+
+## Key facts before you start
+
+- **The value may be a local path or a URL.** Accepted forms include an
+  absolute filesystem path (`/data/deps/fmt-10.2.1.tar.gz`), a `file://` URL, or
+  any `http(s)://` URL — including an internal HTTP server or an OSS / S3 bucket.
+- **The archive hash is still verified.** Each dependency declares a
+  `URL_HASH` (MD5 or SHA256). Your mirrored / local archive must be **byte
+  identical to the upstream archive**, otherwise CMake aborts with a hash
+  mismatch. The simplest safe approach is to download the exact upstream file
+  once and re-host it unchanged.
+- **Overrides are read at configure time.** If you change a variable after a
+  previous configure, re-run CMake configure or run `make clean` first so the
+  new value takes effect.
+- **Use a non-empty value, or leave it unset.** CMake treats a variable that is
+  exported but empty as *defined*, so `export VSAG_THIRDPARTY_FMT=` would prepend
+  an empty entry to the URL list and break the download. To disable an override,
+  `unset` it instead of setting it to an empty string.
+- **Each dependency is independent.** There is no single global mirror variable;
+  set one `VSAG_THIRDPARTY_<LIB>` per dependency you need. You only need to set
+  variables for the dependencies your build actually pulls in (see
+  [Which dependencies do I need?](#which-dependencies-do-i-need)).
+- **Confirmation in the log.** When an override is picked up, CMake prints
+  `-- Using local path for <lib>: <your value>`.
+
+## Environment variables
+
+| Environment variable | Library | Upstream archive to mirror | Pulled in when |
+| --- | --- | --- | --- |
+| `VSAG_THIRDPARTY_JSON` | nlohmann/json 3.11.3 | `github.com/nlohmann/json/.../v3.11.3.tar.gz` | always |
+| `VSAG_THIRDPARTY_ANTLR4` | ANTLR4 runtime 4.13.2 | `github.com/antlr/antlr4/.../4.13.2.tar.gz` | always |
+| `VSAG_THIRDPARTY_BOOST` | Boost 1.67.0 (headers) | `archives.boost.io/.../boost_1_67_0.tar.gz` | always |
+| `VSAG_THIRDPARTY_OPENBLAS` | OpenBLAS 0.3.23 | `github.com/OpenMathLib/OpenBLAS/.../OpenBLAS-0.3.23.tar.gz` | default BLAS backend (when not using system / MKL) |
+| `VSAG_THIRDPARTY_CPUINFO` | pytorch/cpuinfo | `github.com/pytorch/cpuinfo/archive/ca678952...tar.gz` | always |
+| `VSAG_THIRDPARTY_FMT` | fmt 10.2.1 | `github.com/fmtlib/fmt/.../10.2.1.tar.gz` | always (unless system fmt) |
+| `VSAG_THIRDPARTY_THREAD_POOL` | log4cplus/ThreadPool | `github.com/log4cplus/ThreadPool/archive/3507796e...tar.gz` | always |
+| `VSAG_THIRDPARTY_TSL` | Tessil/robin-map 1.4.0 | `github.com/Tessil/robin-map/.../v1.4.0.tar.gz` | always |
+| `VSAG_THIRDPARTY_ROARINGBITMAP` | CRoaring 3.0.1 | `github.com/RoaringBitmap/CRoaring/.../v3.0.1.tar.gz` | always |
+| `VSAG_THIRDPARTY_CATCH2` | Catch2 3.7.1 | `github.com/catchorg/Catch2/.../v3.7.1.tar.gz` | `ENABLE_TESTS=ON` |
+| `VSAG_THIRDPARTY_HDF5` | HDF5 1.14.4 | `github.com/HDFGroup/hdf5/.../hdf5_1.14.4.tar.gz` | `ENABLE_TOOLS=ON` (+ C++11 ABI) |
+| `VSAG_THIRDPARTY_ARGPARSE` | p-ranav/argparse 3.1 | `github.com/p-ranav/argparse/.../v3.1.tar.gz` | `ENABLE_TOOLS=ON` (+ C++11 ABI) |
+| `VSAG_THIRDPARTY_YAML_CPP` | yaml-cpp 0.9.0 | `github.com/jbeder/yaml-cpp/.../yaml-cpp-0.9.0.tar.gz` | `ENABLE_TOOLS=ON` (+ C++11 ABI) |
+| `VSAG_THIRDPARTY_TABULATE` | p-ranav/tabulate | `github.com/p-ranav/tabulate/archive/3a583010...tar.gz` | `ENABLE_TOOLS=ON` (+ C++11 ABI) |
+| `VSAG_THIRDPARTY_HTTPLIB` | cpp-httplib 0.35.0 | `github.com/yhirose/cpp-httplib/.../v0.35.0.tar.gz` | `ENABLE_TOOLS=ON` (+ C++11 ABI) |
+| `VSAG_THIRDPARTY_PYBIND11` | pybind11 2.11.1 | `github.com/pybind/pybind11/.../v2.11.1.tar.gz` | Python bindings (`pyvsag` / `ENABLE_PYBINDS=ON`) |
+
+> The exact upstream URL **and** the expected `URL_HASH` for each dependency are
+> the single source of truth in the corresponding
+> [`extern/<lib>/<lib>.cmake`](https://github.com/antgroup/vsag/tree/main/extern)
+> file. Check that file when mirroring, especially after a version bump.
+
+Not listed here (no download, so no override needed): **Intel MKL** (located on
+the host with `find_path`) and **DiskANN** (vendored in-tree under
+`extern/diskann/`).
+
+## Which dependencies do I need?
+
+You only have to mirror what your specific build actually downloads:
+
+- **Core library** (`make debug` / `make release`): `JSON`, `ANTLR4`, `BOOST`,
+  `OPENBLAS`, `CPUINFO`, `FMT`, `THREAD_POOL`, `TSL`, `ROARINGBITMAP`.
+  Two of these are conditional: `OPENBLAS` is **not** downloaded when BLAS comes
+  from Intel MKL (x86_64 with `ENABLE_INTEL_MKL=ON`) or from a system OpenBLAS,
+  and `FMT` is skipped when a system `fmt` is found.
+- **+ Tests** (`make test`, `ENABLE_TESTS=ON`): also `CATCH2`.
+- **+ Tools** (`ENABLE_TOOLS=ON` **and** `ENABLE_CXX11_ABI=ON`): also `HDF5`,
+  `ARGPARSE`, `YAML_CPP`, `TABULATE`, `HTTPLIB` — downloaded only when *both*
+  options are enabled (see
+  [`cmake/VSAGThirdParty.cmake`](https://github.com/antgroup/vsag/blob/main/cmake/VSAGThirdParty.cmake)).
+- **+ Python wheel** (`make pyvsag`): also `PYBIND11`.
+
+## Examples
+
+### A. Internal HTTP server or OSS bucket (recommended)
+
+Re-host the upstream archives unchanged on an internal endpoint, then point each
+variable at it. A base-URL shell variable keeps this compact:
+
+```bash
+# Internal mirror that serves the upstream archives byte-for-byte
+export VSAG_MIRROR=https://mirror.corp.example.com/vsag-thirdparty
+
+export VSAG_THIRDPARTY_JSON=$VSAG_MIRROR/v3.11.3.tar.gz
+export VSAG_THIRDPARTY_ANTLR4=$VSAG_MIRROR/antlr4-4.13.2.tar.gz
+export VSAG_THIRDPARTY_BOOST=$VSAG_MIRROR/boost_1_67_0.tar.gz
+export VSAG_THIRDPARTY_OPENBLAS=$VSAG_MIRROR/OpenBLAS-0.3.23.tar.gz
+export VSAG_THIRDPARTY_CPUINFO=$VSAG_MIRROR/cpuinfo-ca678952.tar.gz
+export VSAG_THIRDPARTY_FMT=$VSAG_MIRROR/fmt-10.2.1.tar.gz
+export VSAG_THIRDPARTY_THREAD_POOL=$VSAG_MIRROR/thread_pool-3507796e.tar.gz
+export VSAG_THIRDPARTY_TSL=$VSAG_MIRROR/robin-map-1.4.0.tar.gz
+export VSAG_THIRDPARTY_ROARINGBITMAP=$VSAG_MIRROR/CRoaring-3.0.1.tar.gz
+
+make release
+```
+
+An OSS / S3 bucket works identically — just use its public (or
+network-reachable) object URL, for example
+`https://my-bucket.oss-cn-hangzhou.aliyuncs.com/vsag/OpenBLAS-0.3.23.tar.gz`.
+
+### B. Pre-downloaded local files (fully air-gapped)
+
+On a machine that has *no* network at all, copy the archives onto the box first
+(e.g. to `/data/vsag-deps`) and point the variables at the local files:
+
+```bash
+export VSAG_THIRDPARTY_JSON=/data/vsag-deps/v3.11.3.tar.gz
+export VSAG_THIRDPARTY_ANTLR4=/data/vsag-deps/antlr4-4.13.2.tar.gz
+export VSAG_THIRDPARTY_BOOST=/data/vsag-deps/boost_1_67_0.tar.gz
+export VSAG_THIRDPARTY_OPENBLAS=/data/vsag-deps/OpenBLAS-0.3.23.tar.gz
+export VSAG_THIRDPARTY_CPUINFO=/data/vsag-deps/cpuinfo-ca678952.tar.gz
+export VSAG_THIRDPARTY_FMT=/data/vsag-deps/fmt-10.2.1.tar.gz
+export VSAG_THIRDPARTY_THREAD_POOL=/data/vsag-deps/thread_pool-3507796e.tar.gz
+export VSAG_THIRDPARTY_TSL=/data/vsag-deps/robin-map-1.4.0.tar.gz
+export VSAG_THIRDPARTY_ROARINGBITMAP=/data/vsag-deps/CRoaring-3.0.1.tar.gz
+
+make release
+```
+
+A `file://` URL (`export VSAG_THIRDPARTY_FMT=file:///data/vsag-deps/fmt-10.2.1.tar.gz`)
+is equally valid.
+
+### C. Override a single dependency
+
+If only one download is unreliable, override just that one and let the rest use
+the defaults:
+
+```bash
+export VSAG_THIRDPARTY_OPENBLAS=https://mirror.corp.example.com/OpenBLAS-0.3.23.tar.gz
+make release
+```
+
+## Alternative: reuse system libraries
+
+For dependencies that are already installed on the host, you can skip the
+download entirely instead of mirroring it. Set `VSAG_USE_SYSTEM_DEPS=ON` (or the
+per-dependency `VSAG_USE_SYSTEM_<DEP>=ON`). See
+[`DEVELOPMENT.md`](https://github.com/antgroup/vsag/blob/main/DEVELOPMENT.md#system-third-party-dependencies)
+for the list of dependencies that currently support system reuse.
+
+## Troubleshooting
+
+- **Hash mismatch / "HASH mismatch" error** — your mirrored or local archive is
+  not byte-identical to the upstream file. Re-download the exact upstream
+  archive and re-host it unchanged, or confirm the expected `URL_HASH` in
+  `extern/<lib>/<lib>.cmake`.
+- **Override seems ignored** — make sure the variable was `export`ed in the same
+  shell that runs `make` / `cmake`, then re-run configure (or `make clean`),
+  because the value is read at CMake configure time. Confirm the
+  `-- Using local path for <lib>: <your value>` line appears in the configure output.
+- **Still hitting the network** — you probably missed a dependency that your
+  build pulls in. Cross-check the list in
+  [Which dependencies do I need?](#which-dependencies-do-i-need) against your
+  enabled options (`ENABLE_TESTS`, `ENABLE_TOOLS`, Python bindings).
+
+## Version availability
+
+The per-dependency `VSAG_THIRDPARTY_*` override is available on the `main`
+development line and on the `0.15`, `0.16`, `0.17`, and `0.18` release lines, so
+local-path and internal-mirror overrides behave the same way across all of them.
+It was introduced on `main` by
+[#1606](https://github.com/antgroup/vsag/pull/1606) and backported to the release
+lines (tracked in [#2308](https://github.com/antgroup/vsag/issues/2308)). The
+built-in upstream + Aliyun OSS mirror fallback remains present on every line, and
+[system-library reuse](#alternative-reuse-system-libraries) is still available when
+you would rather not mirror a dependency at all.

--- a/docs/docs/zh/src/SUMMARY.md
+++ b/docs/docs/zh/src/SUMMARY.md
@@ -35,6 +35,7 @@
 
 - [代码目录结构](development/code_structure.md)
 - [编译构建](development/building.md)
+- [离线 / 内网环境构建](development/offline_build.md)
 - [运行测试](development/testing.md)
 - [贡献到 VSAG](development/contributing.md)
 

--- a/docs/docs/zh/src/development/building.md
+++ b/docs/docs/zh/src/development/building.md
@@ -138,6 +138,12 @@ make pyvsag-all
 - `VSAG_ENABLE_INTEL_MKL`：是否启用 Intel MKL 作为 BLAS 后端，默认 `OFF`；关闭时使用 OpenBLAS；
 - `VSAG_ENABLE_LIBAIO`：是否启用 `libaio`，默认 `ON`。
 
+## 离线 / 内网环境构建
+
+VSAG 会在配置 / 构建阶段下载第三方库。在离线或网络受限的环境中，可以设置按依赖的
+`VSAG_THIRDPARTY_*` 环境变量，从本地路径或内网镜像（内网 HTTP 服务、OSS 存储桶等）获取每个
+压缩包。完整的变量列表与示例见[离线 / 内网环境构建](offline_build.md)。
+
 ## 发布流程
 
 如果要在 GitHub 上手动发布 Release，请到 GitHub Actions 页面运行 `Build and Publish Release` 工作流，并填写以下参数：

--- a/docs/docs/zh/src/development/offline_build.md
+++ b/docs/docs/zh/src/development/offline_build.md
@@ -1,0 +1,185 @@
+# 离线 / 内网环境构建
+
+VSAG 在 CMake **配置 / 构建阶段**会下载一批第三方库（通过 `ExternalProject_Add`
+与 `FetchContent`）。在没有外网访问、或网络较慢 / 受限的机器上，这些下载可能失败或
+超时。本文介绍如何把每个依赖指向**本地路径**或**内网镜像**（内网 HTTP 服务、OSS
+存储桶、Artifactory 等），从而在完全离线的环境中完成编译。
+
+## 第三方下载的解析顺序
+
+对每一个需要下载的依赖，VSAG 会构造一个候选 URL *列表*，由 CMake **按顺序**依次尝试，
+命中第一个成功的即停止。以 `antlr4` 为代表
+（[`extern/antlr4/antlr4.cmake`](https://github.com/antgroup/vsag/blob/main/extern/antlr4/antlr4.cmake)）：
+
+```cmake
+set (antlr4_urls
+    https://github.com/antlr/antlr4/archive/refs/tags/4.13.2.tar.gz   # 1. 上游
+    https://vsagcache.oss-rg-china-mainland.aliyuncs.com/antlr4/v4.13.2.tar.gz  # 2. 项目镜像
+)
+if (DEFINED ENV{VSAG_THIRDPARTY_ANTLR4})
+    message (STATUS "Using local path for antlr4: $ENV{VSAG_THIRDPARTY_ANTLR4}")
+    list (PREPEND antlr4_urls "$ENV{VSAG_THIRDPARTY_ANTLR4}")   # 0. 你的覆盖项（最先尝试）
+endif ()
+
+ExternalProject_Add (antlr4
+    URL ${antlr4_urls}
+    URL_HASH MD5=3b75610fc8a827119258cba09a068be5
+    ...)
+```
+
+因此解析顺序为：
+
+1. **`VSAG_THIRDPARTY_<LIB>`** —— 你设置的覆盖项（如果该环境变量已设置为**非空**值）。**最先尝试**。
+2. **上游** URL（GitHub / 项目发布页）。
+3. 项目维护的 **阿里云 OSS 镜像**
+   （`vsagcache.oss-rg-china-mainland.aliyuncs.com`）。该兜底地址始终存在，在中国大陆 /
+   弱网环境下很有帮助，但**不可由用户配置**——若要使用纯内网镜像，请使用环境变量。
+
+> **可用版本：** `VSAG_THIRDPARTY_*` 覆盖能力在 `main` 分支以及 `0.15`、`0.16`、
+> `0.17`、`0.18` 发布线上均可用——详见[版本可用性](#版本可用性)。
+
+## 开始前的关键事项
+
+- **取值可以是本地路径，也可以是 URL。** 支持绝对文件路径
+  （`/data/deps/fmt-10.2.1.tar.gz`）、`file://` URL，或任意 `http(s)://` URL——
+  包括内网 HTTP 服务或 OSS / S3 存储桶。
+- **依然会校验压缩包哈希。** 每个依赖都声明了 `URL_HASH`（MD5 或 SHA256）。你镜像 /
+  本地的压缩包必须与**上游压缩包逐字节一致**，否则 CMake 会因哈希不匹配而中止。最稳妥的
+  做法是把上游原始文件下载一次，原封不动地重新托管。
+- **覆盖项在配置阶段读取。** 如果你在上一次配置之后修改了变量，请重新执行 CMake 配置或
+  先运行 `make clean`，新值才会生效。
+- **请使用非空值，否则就不要设置。** CMake 把“已 export 但为空”的变量视为*已定义*，因此
+  `export VSAG_THIRDPARTY_FMT=` 会把一个空项 prepend 到 URL 列表里，导致下载失败。若要停用
+  某个覆盖项，请 `unset` 它，而不要把它设为空字符串。
+- **每个依赖相互独立。** 没有单一的全局镜像变量；每个需要的依赖各自设置一个
+  `VSAG_THIRDPARTY_<LIB>`。你只需为本次构建实际拉取的依赖设置变量（见
+  [我需要哪些依赖？](#我需要哪些依赖)）。
+- **日志中的确认信息。** 覆盖项生效时，CMake 会打印
+  `-- Using local path for <lib>: <你的取值>`。
+
+## 环境变量
+
+| 环境变量 | 库 | 需镜像的上游压缩包 | 何时被拉取 |
+| --- | --- | --- | --- |
+| `VSAG_THIRDPARTY_JSON` | nlohmann/json 3.11.3 | `github.com/nlohmann/json/.../v3.11.3.tar.gz` | 始终 |
+| `VSAG_THIRDPARTY_ANTLR4` | ANTLR4 runtime 4.13.2 | `github.com/antlr/antlr4/.../4.13.2.tar.gz` | 始终 |
+| `VSAG_THIRDPARTY_BOOST` | Boost 1.67.0（头文件） | `archives.boost.io/.../boost_1_67_0.tar.gz` | 始终 |
+| `VSAG_THIRDPARTY_OPENBLAS` | OpenBLAS 0.3.23 | `github.com/OpenMathLib/OpenBLAS/.../OpenBLAS-0.3.23.tar.gz` | 默认 BLAS 后端（未使用系统库 / MKL 时） |
+| `VSAG_THIRDPARTY_CPUINFO` | pytorch/cpuinfo | `github.com/pytorch/cpuinfo/archive/ca678952...tar.gz` | 始终 |
+| `VSAG_THIRDPARTY_FMT` | fmt 10.2.1 | `github.com/fmtlib/fmt/.../10.2.1.tar.gz` | 始终（除非使用系统 fmt） |
+| `VSAG_THIRDPARTY_THREAD_POOL` | log4cplus/ThreadPool | `github.com/log4cplus/ThreadPool/archive/3507796e...tar.gz` | 始终 |
+| `VSAG_THIRDPARTY_TSL` | Tessil/robin-map 1.4.0 | `github.com/Tessil/robin-map/.../v1.4.0.tar.gz` | 始终 |
+| `VSAG_THIRDPARTY_ROARINGBITMAP` | CRoaring 3.0.1 | `github.com/RoaringBitmap/CRoaring/.../v3.0.1.tar.gz` | 始终 |
+| `VSAG_THIRDPARTY_CATCH2` | Catch2 3.7.1 | `github.com/catchorg/Catch2/.../v3.7.1.tar.gz` | `ENABLE_TESTS=ON` |
+| `VSAG_THIRDPARTY_HDF5` | HDF5 1.14.4 | `github.com/HDFGroup/hdf5/.../hdf5_1.14.4.tar.gz` | `ENABLE_TOOLS=ON`（且 C++11 ABI） |
+| `VSAG_THIRDPARTY_ARGPARSE` | p-ranav/argparse 3.1 | `github.com/p-ranav/argparse/.../v3.1.tar.gz` | `ENABLE_TOOLS=ON`（且 C++11 ABI） |
+| `VSAG_THIRDPARTY_YAML_CPP` | yaml-cpp 0.9.0 | `github.com/jbeder/yaml-cpp/.../yaml-cpp-0.9.0.tar.gz` | `ENABLE_TOOLS=ON`（且 C++11 ABI） |
+| `VSAG_THIRDPARTY_TABULATE` | p-ranav/tabulate | `github.com/p-ranav/tabulate/archive/3a583010...tar.gz` | `ENABLE_TOOLS=ON`（且 C++11 ABI） |
+| `VSAG_THIRDPARTY_HTTPLIB` | cpp-httplib 0.35.0 | `github.com/yhirose/cpp-httplib/.../v0.35.0.tar.gz` | `ENABLE_TOOLS=ON`（且 C++11 ABI） |
+| `VSAG_THIRDPARTY_PYBIND11` | pybind11 2.11.1 | `github.com/pybind/pybind11/.../v2.11.1.tar.gz` | Python 绑定（`pyvsag` / `ENABLE_PYBINDS=ON`） |
+
+> 每个依赖确切的上游 URL **以及**期望的 `URL_HASH`，其唯一权威来源是对应的
+> [`extern/<lib>/<lib>.cmake`](https://github.com/antgroup/vsag/tree/main/extern)
+> 文件。镜像时（尤其是版本升级后）请以该文件为准。
+
+此处未列出的（不下载，因此无需覆盖）：**Intel MKL**（通过 `find_path` 在主机上查找）与
+**DiskANN**（以源码内置于 `extern/diskann/`）。
+
+## 我需要哪些依赖？
+
+你只需镜像本次构建实际会下载的依赖：
+
+- **核心库**（`make debug` / `make release`）：`JSON`、`ANTLR4`、`BOOST`、
+  `OPENBLAS`、`CPUINFO`、`FMT`、`THREAD_POOL`、`TSL`、`ROARINGBITMAP`。
+  其中两个是条件依赖：当 BLAS 由 Intel MKL（x86_64 且 `ENABLE_INTEL_MKL=ON`）或系统
+  OpenBLAS 提供时，`OPENBLAS` **不会**下载；当找到系统 `fmt` 时，`FMT` 会被跳过。
+- **+ 测试**（`make test`，`ENABLE_TESTS=ON`）：另加 `CATCH2`。
+- **+ 工具**（`ENABLE_TOOLS=ON` **且** `ENABLE_CXX11_ABI=ON`）：另加 `HDF5`、
+  `ARGPARSE`、`YAML_CPP`、`TABULATE`、`HTTPLIB`——仅当两个选项同时开启时才会下载
+  （见 [`cmake/VSAGThirdParty.cmake`](https://github.com/antgroup/vsag/blob/main/cmake/VSAGThirdParty.cmake)）。
+- **+ Python wheel**（`make pyvsag`）：另加 `PYBIND11`。
+
+## 示例
+
+### A. 内网 HTTP 服务或 OSS 存储桶（推荐）
+
+将上游压缩包原封不动地重新托管到内网地址，再让每个变量指向它。用一个基础 URL 的 shell
+变量可以让配置更简洁：
+
+```bash
+# 内网镜像，逐字节提供上游压缩包
+export VSAG_MIRROR=https://mirror.corp.example.com/vsag-thirdparty
+
+export VSAG_THIRDPARTY_JSON=$VSAG_MIRROR/v3.11.3.tar.gz
+export VSAG_THIRDPARTY_ANTLR4=$VSAG_MIRROR/antlr4-4.13.2.tar.gz
+export VSAG_THIRDPARTY_BOOST=$VSAG_MIRROR/boost_1_67_0.tar.gz
+export VSAG_THIRDPARTY_OPENBLAS=$VSAG_MIRROR/OpenBLAS-0.3.23.tar.gz
+export VSAG_THIRDPARTY_CPUINFO=$VSAG_MIRROR/cpuinfo-ca678952.tar.gz
+export VSAG_THIRDPARTY_FMT=$VSAG_MIRROR/fmt-10.2.1.tar.gz
+export VSAG_THIRDPARTY_THREAD_POOL=$VSAG_MIRROR/thread_pool-3507796e.tar.gz
+export VSAG_THIRDPARTY_TSL=$VSAG_MIRROR/robin-map-1.4.0.tar.gz
+export VSAG_THIRDPARTY_ROARINGBITMAP=$VSAG_MIRROR/CRoaring-3.0.1.tar.gz
+
+make release
+```
+
+OSS / S3 存储桶用法完全相同——直接使用其公网（或网络可达）的对象 URL，例如
+`https://my-bucket.oss-cn-hangzhou.aliyuncs.com/vsag/OpenBLAS-0.3.23.tar.gz`。
+
+### B. 预先下载的本地文件（完全离线）
+
+在完全没有网络的机器上，先把压缩包拷贝到本机（例如 `/data/vsag-deps`），再让变量指向本地
+文件：
+
+```bash
+export VSAG_THIRDPARTY_JSON=/data/vsag-deps/v3.11.3.tar.gz
+export VSAG_THIRDPARTY_ANTLR4=/data/vsag-deps/antlr4-4.13.2.tar.gz
+export VSAG_THIRDPARTY_BOOST=/data/vsag-deps/boost_1_67_0.tar.gz
+export VSAG_THIRDPARTY_OPENBLAS=/data/vsag-deps/OpenBLAS-0.3.23.tar.gz
+export VSAG_THIRDPARTY_CPUINFO=/data/vsag-deps/cpuinfo-ca678952.tar.gz
+export VSAG_THIRDPARTY_FMT=/data/vsag-deps/fmt-10.2.1.tar.gz
+export VSAG_THIRDPARTY_THREAD_POOL=/data/vsag-deps/thread_pool-3507796e.tar.gz
+export VSAG_THIRDPARTY_TSL=/data/vsag-deps/robin-map-1.4.0.tar.gz
+export VSAG_THIRDPARTY_ROARINGBITMAP=/data/vsag-deps/CRoaring-3.0.1.tar.gz
+
+make release
+```
+
+使用 `file://` URL（`export VSAG_THIRDPARTY_FMT=file:///data/vsag-deps/fmt-10.2.1.tar.gz`）
+同样有效。
+
+### C. 只覆盖单个依赖
+
+如果只有某一个下载不稳定，只覆盖它即可，其余继续使用默认地址：
+
+```bash
+export VSAG_THIRDPARTY_OPENBLAS=https://mirror.corp.example.com/OpenBLAS-0.3.23.tar.gz
+make release
+```
+
+## 备选方案：复用系统库
+
+对于主机上已安装的依赖，你可以直接跳过下载，而不必镜像。设置
+`VSAG_USE_SYSTEM_DEPS=ON`（或按依赖设置 `VSAG_USE_SYSTEM_<DEP>=ON`）。当前支持系统复用的
+依赖列表见
+[`DEVELOPMENT.md`](https://github.com/antgroup/vsag/blob/main/DEVELOPMENT.md#system-third-party-dependencies)。
+
+## 常见问题
+
+- **哈希不匹配 / 出现 “HASH mismatch” 错误** —— 你镜像或本地的压缩包与上游文件不是逐字节
+  一致。请重新下载确切的上游压缩包并原样托管，或在 `extern/<lib>/<lib>.cmake` 中核对期望的
+  `URL_HASH`。
+- **覆盖项似乎未生效** —— 确认变量是在运行 `make` / `cmake` 的同一个 shell 中 `export` 的，
+  然后重新执行配置（或 `make clean`），因为取值是在 CMake 配置阶段读取的。确认配置输出中出现
+  `-- Using local path for <lib>: <你的取值>` 这一行。
+- **仍然在访问网络** —— 多半是漏掉了本次构建会拉取的某个依赖。请对照
+  [我需要哪些依赖？](#我需要哪些依赖) 与你启用的选项（`ENABLE_TESTS`、`ENABLE_TOOLS`、
+  Python 绑定）逐项核对。
+
+## 版本可用性
+
+按依赖配置的 `VSAG_THIRDPARTY_*` 覆盖能力在 `main` 开发线以及 `0.15`、`0.16`、`0.17`、
+`0.18` 发布线上均可用，因此本地路径与内网镜像覆盖在所有这些分支上的行为完全一致。该能力最初由
+[#1606](https://github.com/antgroup/vsag/pull/1606) 在 `main` 引入，并已合入各发布线（跟踪于
+[#2308](https://github.com/antgroup/vsag/issues/2308)）。内置的“上游 + 阿里云 OSS 镜像”兜底在
+每条线上依然保留；若你不想镜像某个依赖，也仍可使用[复用系统库](#备选方案复用系统库)。


### PR DESCRIPTION
## Summary

- Documents the per-dependency `VSAG_THIRDPARTY_*` environment variables that let users fetch the bundled third-party archives from a **local path** or an **internal mirror** (internal HTTP server, OSS/S3 bucket, Artifactory, …), enabling builds in **offline / restricted-network** environments.
- Adds a dedicated bilingual Developer-Guide page and wires it into the existing build docs.

## What's included

- New page `docs/docs/{en,zh}/src/development/offline_build.md`:
  - how the URL list is resolved (override → upstream → Aliyun OSS mirror) and that `URL_HASH` is still enforced;
  - the full table of all 16 `VSAG_THIRDPARTY_*` variables, the library/archive each one mirrors, and when it is pulled in;
  - which dependencies are needed per build profile (core / tests / tools / pyvsag);
  - worked examples (internal HTTP & OSS mirror, fully air-gapped local files, single-dependency override) plus troubleshooting.
- Adds the page to both `SUMMARY.md` files and cross-links it from both `development/building.md` pages.
- Generalizes the `DEVELOPMENT.md` "Third-Party Source Overrides" section beyond the single OpenBLAS example and links to the new guide.

## Version availability (capability check)

The per-dependency override (`VSAG_THIRDPARTY_*`, via `list(PREPEND …)` + `$ENV{…}`) was introduced on `main` by #1606 (commit `736d5a2f`) and is being backported to the active release lines, tracked by #2308. Once those backports land, local-path and internal-mirror overrides behave identically across all of the branches below:

| Ref | Built-in OSS mirror fallback | `VSAG_THIRDPARTY_*` override |
| --- | --- | --- |
| `0.15` | yes | yes (via #2308) |
| `0.16` | yes | yes (via #2308) |
| `0.17` | yes | yes (via #2308) |
| `0.18` | yes | yes (via #2308) |
| `main` | yes | yes (16 deps) |

This is documented in the new page's "Version availability" section. This PR is documentation-only and makes no source changes to any branch; the per-line code backports are tracked separately in #2308.

## Notes

- Documentation-only change (`kind/documentation`), so no linked issue is required.
