### PR TITLE
feat: backport third-party download overrides to 0.18

### DIFF
--- a/extern/antlr4/antlr4.cmake
+++ b/extern/antlr4/antlr4.cmake
@@ -12,12 +12,20 @@ endif ()
 
 set (FULL_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${VSAG_ANTLR4_CXX11_ABI}")
 
+set(antlr4_urls
+    https://github.com/antlr/antlr4/archive/refs/tags/4.13.2.tar.gz
+    # this url is maintained by the vsag project, if it's broken, please try
+    #  the latest commit or contact the vsag project
+    https://vsagcache.oss-rg-china-mainland.aliyuncs.com/antlr4/v4.13.2.tar.gz
+)
+if(NOT "$ENV{VSAG_THIRDPARTY_ANTLR4}" STREQUAL "")
+    message(STATUS "Using override URL/archive for antlr4: $ENV{VSAG_THIRDPARTY_ANTLR4}")
+    list(PREPEND antlr4_urls "$ENV{VSAG_THIRDPARTY_ANTLR4}")
+endif()
+
 ExternalProject_Add(
         ${name}
-        URL https://github.com/antlr/antlr4/archive/refs/tags/4.13.2.tar.gz
-        # this url is maintained by the vsag project, if it's broken, please try
-        #  the latest commit or contact the vsag project
-        https://vsagcache.oss-rg-china-mainland.aliyuncs.com/antlr4/v4.13.2.tar.gz
+        URL ${antlr4_urls}
         URL_HASH MD5=3b75610fc8a827119258cba09a068be5
         DOWNLOAD_NAME antlr4_4.13.2.tar.gz
         PREFIX ${CMAKE_CURRENT_BINARY_DIR}/${name}

--- a/extern/argparse/argparse.cmake
+++ b/extern/argparse/argparse.cmake
@@ -1,11 +1,18 @@
 include (FetchContent)
 
+set(argparse_urls
+    https://github.com/p-ranav/argparse/archive/refs/tags/v3.1.tar.gz
+    # this url is maintained by the vsag project, if it's broken, please try
+    #  the latest commit or contact the vsag project
+    https://vsagcache.oss-rg-china-mainland.aliyuncs.com/argparse/v3.1.tar.gz
+)
+if(NOT "$ENV{VSAG_THIRDPARTY_ARGPARSE}" STREQUAL "")
+  message(STATUS "Using override URL/archive for argparse: $ENV{VSAG_THIRDPARTY_ARGPARSE}")
+  list(PREPEND argparse_urls "$ENV{VSAG_THIRDPARTY_ARGPARSE}")
+endif()
 FetchContent_Declare (
         argparse
-        URL https://github.com/p-ranav/argparse/archive/refs/tags/v3.1.tar.gz
-        # this url is maintained by the vsag project, if it's broken, please try
-        #  the latest commit or contact the vsag project
-        http://vsagcache.oss-rg-china-mainland.aliyuncs.com/argparse/v3.1.tar.gz
+        URL ${argparse_urls}
         URL_HASH MD5=11822ccbe1bd8d84c948450d24281b67
         DOWNLOAD_NO_PROGRESS 1
         INACTIVITY_TIMEOUT 5

--- a/extern/boost/boost.cmake
+++ b/extern/boost/boost.cmake
@@ -6,12 +6,21 @@ set(name boost)
 set(source_dir ${CMAKE_CURRENT_BINARY_DIR}/${name}/source)
 set(install_dir ${CMAKE_CURRENT_BINARY_DIR}/${name}/install)
 get_filename_component(compiler_path ${CMAKE_CXX_COMPILER} DIRECTORY)
+
+set(boost_urls
+    https://archives.boost.io/release/1.67.0/source/boost_1_67_0.tar.gz
+    # this url is maintained by the vsag project, if it's broken, please try
+    #  the latest commit or contact the vsag project
+    https://vsagcache.oss-rg-china-mainland.aliyuncs.com/boost/boost_1_67_0.tar.gz
+)
+if(NOT "$ENV{VSAG_THIRDPARTY_BOOST}" STREQUAL "")
+    message(STATUS "Using override URL/archive for boost: $ENV{VSAG_THIRDPARTY_BOOST}")
+    list(PREPEND boost_urls "$ENV{VSAG_THIRDPARTY_BOOST}")
+endif()
+
 ExternalProject_Add(
     ${name}
-    URL https://archives.boost.io/release/1.67.0/source/boost_1_67_0.tar.gz
-        # this url is maintained by the vsag project, if it's broken, please try
-        #  the latest commit or contact the vsag project
-        http://vsagcache.oss-rg-china-mainland.aliyuncs.com/boost/boost_1_67_0.tar.gz
+    URL ${boost_urls}
     URL_HASH SHA256=8aa4e330c870ef50a896634c931adf468b21f8a69b77007e45c444151229f665
     DOWNLOAD_NAME boost_1_67_0.tar.gz
     PREFIX ${CMAKE_CURRENT_BINARY_DIR}/${name}

--- a/extern/catch2/catch2.cmake
+++ b/extern/catch2/catch2.cmake
@@ -1,10 +1,17 @@
 Include(FetchContent)
+set(catch2_urls
+    https://github.com/catchorg/Catch2/archive/refs/tags/v3.7.1.tar.gz
+    # this url is maintained by the vsag project, if it's broken, please try
+    #  the latest commit or contact the vsag project
+    https://vsagcache.oss-rg-china-mainland.aliyuncs.com/catch2/v3.7.1.tar.gz
+)
+if(NOT "$ENV{VSAG_THIRDPARTY_CATCH2}" STREQUAL "")
+  message(STATUS "Using override URL/archive for catch2: $ENV{VSAG_THIRDPARTY_CATCH2}")
+  list(PREPEND catch2_urls "$ENV{VSAG_THIRDPARTY_CATCH2}")
+endif()
 FetchContent_Declare(
   Catch2
-  URL      https://github.com/catchorg/Catch2/archive/refs/tags/v3.7.1.tar.gz
-            # this url is maintained by the vsag project, if it's broken, please try
-            #  the latest commit or contact the vsag project
-           http://vsagcache.oss-rg-china-mainland.aliyuncs.com/catch2/v3.7.1.tar.gz
+  URL      ${catch2_urls}
   URL_HASH MD5=9fcbec1dc95edcb31c6a0d6c5320e098
   DOWNLOAD_NO_PROGRESS 1
   INACTIVITY_TIMEOUT 5

--- a/extern/cpuinfo/cpuinfo.cmake
+++ b/extern/cpuinfo/cpuinfo.cmake
@@ -1,10 +1,17 @@
 Include (FetchContent)
+set(cpuinfo_urls
+    https://github.com/pytorch/cpuinfo/archive/ca678952a9a8eaa6de112d154e8e104b22f9ab3f.tar.gz
+    # this url is maintained by the vsag project, if it's broken, please try
+    #  the latest commit or contact the vsag project
+    https://vsagcache.oss-rg-china-mainland.aliyuncs.com/cpuinfo/ca678952a9a8eaa6de112d154e8e104b22f9ab3f.tar.gz
+)
+if(NOT "$ENV{VSAG_THIRDPARTY_CPUINFO}" STREQUAL "")
+  message(STATUS "Using override URL/archive for cpuinfo: $ENV{VSAG_THIRDPARTY_CPUINFO}")
+  list(PREPEND cpuinfo_urls "$ENV{VSAG_THIRDPARTY_CPUINFO}")
+endif()
 FetchContent_Declare (
   cpuinfo
-  URL      https://github.com/pytorch/cpuinfo/archive/ca678952a9a8eaa6de112d154e8e104b22f9ab3f.tar.gz 
-            # this url is maintained by the vsag project, if it's broken, please try
-            #  the latest commit or contact the vsag project
-           http://vsagcache.oss-rg-china-mainland.aliyuncs.com/cpuinfo/ca678952a9a8eaa6de112d154e8e104b22f9ab3f.tar.gz
+  URL      ${cpuinfo_urls}
   URL_HASH MD5=a72699bc703dfea4ab2c9c01025e46e9
   DOWNLOAD_NO_PROGRESS 1
   INACTIVITY_TIMEOUT 5

--- a/extern/fmt/fmt.cmake
+++ b/extern/fmt/fmt.cmake
@@ -5,12 +5,19 @@ include(FetchContent)
 # ref: https://github.com/fmtlib/fmt/issues/2708
 set (FMT_SYSTEM_HEADERS ON)
 
+set(fmt_urls
+    https://github.com/fmtlib/fmt/archive/refs/tags/10.2.1.tar.gz
+    # this url is maintained by the vsag project, if it's broken, please try
+    #  the latest commit or contact the vsag project
+    https://vsagcache.oss-rg-china-mainland.aliyuncs.com/fmt/10.2.1.tar.gz
+)
+if(NOT "$ENV{VSAG_THIRDPARTY_FMT}" STREQUAL "")
+  message(STATUS "Using override URL/archive for fmt: $ENV{VSAG_THIRDPARTY_FMT}")
+  list(PREPEND fmt_urls "$ENV{VSAG_THIRDPARTY_FMT}")
+endif()
 FetchContent_Declare(
     fmt
-    URL https://github.com/fmtlib/fmt/archive/refs/tags/10.2.1.tar.gz
-        # this url is maintained by the vsag project, if it's broken, please try
-        #  the latest commit or contact the vsag project
-        http://vsagcache.oss-rg-china-mainland.aliyuncs.com/fmt/10.2.1.tar.gz
+    URL ${fmt_urls}
     URL_HASH MD5=dc09168c94f90ea890257995f2c497a5
     DOWNLOAD_NO_PROGRESS 1
     INACTIVITY_TIMEOUT 5

--- a/extern/hdf5/hdf5.cmake
+++ b/extern/hdf5/hdf5.cmake
@@ -4,12 +4,21 @@ include(ExternalProject)
 set(name hdf5)
 set(source_dir ${CMAKE_CURRENT_BINARY_DIR}/${name}/source)
 set(install_dir ${CMAKE_CURRENT_BINARY_DIR}/${name}/install)
+
+set(hdf5_urls
+    https://github.com/HDFGroup/hdf5/archive/refs/tags/hdf5_1.14.4.tar.gz
+    # this url is maintained by the vsag project, if it's broken, please try
+    #  the latest commit or contact the vsag project
+    https://vsagcache.oss-rg-china-mainland.aliyuncs.com/hdf5/hdf5_1.14.4.tar.gz
+)
+if(NOT "$ENV{VSAG_THIRDPARTY_HDF5}" STREQUAL "")
+    message(STATUS "Using override URL/archive for hdf5: $ENV{VSAG_THIRDPARTY_HDF5}")
+    list(PREPEND hdf5_urls "$ENV{VSAG_THIRDPARTY_HDF5}")
+endif()
+
 ExternalProject_Add(
     ${name}
-    URL https://github.com/HDFGroup/hdf5/archive/refs/tags/hdf5_1.14.4.tar.gz
-        # this url is maintained by the vsag project, if it's broken, please try
-        #  the latest commit or contact the vsag project
-        http://vsagcache.oss-rg-china-mainland.aliyuncs.com/hdf5/hdf5_1.14.4.tar.gz
+    URL ${hdf5_urls}
     URL_HASH MD5=fdea52afcce07ed6c3e2a36e7fa11f21
     DOWNLOAD_NAME hdf5_1.14.4.tar.gz
     PREFIX ${CMAKE_CURRENT_BINARY_DIR}/${name}

--- a/extern/json/json.cmake
+++ b/extern/json/json.cmake
@@ -1,12 +1,19 @@
 
 include(FetchContent)
 
+set(nlohmann_json_urls
+    https://github.com/nlohmann/json/archive/refs/tags/v3.11.3.tar.gz
+    # this url is maintained by the vsag project, if it's broken, please try
+    #  the latest commit or contact the vsag project
+    https://vsagcache.oss-rg-china-mainland.aliyuncs.com/nlohmann_json/v3.11.3.tar.gz
+)
+if(NOT "$ENV{VSAG_THIRDPARTY_JSON}" STREQUAL "")
+  message(STATUS "Using override URL/archive for nlohmann_json: $ENV{VSAG_THIRDPARTY_JSON}")
+  list(PREPEND nlohmann_json_urls "$ENV{VSAG_THIRDPARTY_JSON}")
+endif()
 FetchContent_Declare(
     nlohmann_json
-    URL https://github.com/nlohmann/json/archive/refs/tags/v3.11.3.tar.gz
-        # this url is maintained by the vsag project, if it's broken, please try
-        #  the latest commit or contact the vsag project
-        http://vsagcache.oss-rg-china-mainland.aliyuncs.com/nlohmann_json/v3.11.3.tar.gz
+    URL ${nlohmann_json_urls}
     URL_HASH MD5=d603041cbc6051edbaa02ebb82cf0aa9
     DOWNLOAD_NO_PROGRESS 1
     INACTIVITY_TIMEOUT 5

--- a/extern/openblas/openblas.cmake
+++ b/extern/openblas/openblas.cmake
@@ -3,12 +3,20 @@ set(name openblas)
 set(source_dir ${CMAKE_CURRENT_BINARY_DIR}/${name}/source)
 set(install_dir ${CMAKE_CURRENT_BINARY_DIR}/${name}/install)
 
+set(openblas_urls
+    https://github.com/OpenMathLib/OpenBLAS/releases/download/v0.3.23/OpenBLAS-0.3.23.tar.gz
+    # this url is maintained by the vsag project, if it's broken, please try
+    #  the latest commit or contact the vsag project
+    https://vsagcache.oss-rg-china-mainland.aliyuncs.com/openblas/OpenBLAS-0.3.23.tar.gz
+)
+if(NOT "$ENV{VSAG_THIRDPARTY_OPENBLAS}" STREQUAL "")
+    message(STATUS "Using override URL/archive for openblas: $ENV{VSAG_THIRDPARTY_OPENBLAS}")
+    list(PREPEND openblas_urls "$ENV{VSAG_THIRDPARTY_OPENBLAS}")
+endif()
+
 ExternalProject_Add(
     ${name}
-    URL https://github.com/OpenMathLib/OpenBLAS/releases/download/v0.3.23/OpenBLAS-0.3.23.tar.gz
-        # this url is maintained by the vsag project, if it's broken, please try
-        #  the latest commit or contact the vsag project
-        http://vsagcache.oss-rg-china-mainland.aliyuncs.com/openblas/OpenBLAS-0.3.23.tar.gz
+    URL ${openblas_urls}
     URL_HASH MD5=115634b39007de71eb7e75cf7591dfb2
     DOWNLOAD_NAME OpenBLAS-v0.3.23.tar.gz
     PREFIX ${CMAKE_CURRENT_BINARY_DIR}/${name}

--- a/extern/pybind11/pybind11.cmake
+++ b/extern/pybind11/pybind11.cmake
@@ -1,11 +1,18 @@
 include(FetchContent)
 
+set(pybind11_urls
+    https://github.com/pybind/pybind11/archive/refs/tags/v2.11.1.tar.gz
+    # this url is maintained by the vsag project, if it's broken, please try
+    #  the latest commit or contact the vsag project
+    https://vsagcache.oss-rg-china-mainland.aliyuncs.com/pybind11/v2.11.1.tar.gz
+)
+if(NOT "$ENV{VSAG_THIRDPARTY_PYBIND11}" STREQUAL "")
+  message(STATUS "Using override URL/archive for pybind11: $ENV{VSAG_THIRDPARTY_PYBIND11}")
+  list(PREPEND pybind11_urls "$ENV{VSAG_THIRDPARTY_PYBIND11}")
+endif()
 FetchContent_Declare(
         pybind11
-        URL https://github.com/pybind/pybind11/archive/refs/tags/v2.11.1.tar.gz
-            # this url is maintained by the vsag project, if it's broken, please try
-            #  the latest commit or contact the vsag project
-            http://vsagcache.oss-rg-china-mainland.aliyuncs.com/pybind11/v2.11.1.tar.gz
+        URL ${pybind11_urls}
         URL_HASH MD5=49e92f92244021912a56935918c927d0
         DOWNLOAD_NO_PROGRESS 1
         INACTIVITY_TIMEOUT 5

--- a/extern/roaringbitmap/roaringbitmap.cmake
+++ b/extern/roaringbitmap/roaringbitmap.cmake
@@ -1,15 +1,22 @@
 include(FetchContent)
+set(roaringbitmap_urls
+    https://github.com/RoaringBitmap/CRoaring/archive/refs/tags/v3.0.1.tar.gz
+    # this url is maintained by the vsag project, if it's broken, please try
+    #  the latest commit or contact the vsag project
+    https://vsagcache.oss-rg-china-mainland.aliyuncs.com/roaringbitmap/v3.0.1.tar.gz
+)
+if(NOT "$ENV{VSAG_THIRDPARTY_ROARINGBITMAP}" STREQUAL "")
+  message(STATUS "Using override URL/archive for roaringbitmap: $ENV{VSAG_THIRDPARTY_ROARINGBITMAP}")
+  list(PREPEND roaringbitmap_urls "$ENV{VSAG_THIRDPARTY_ROARINGBITMAP}")
+endif()
 FetchContent_Declare(
-		roaringbitmap
-		URL https://github.com/RoaringBitmap/CRoaring/archive/refs/tags/v3.0.1.tar.gz
-                    # this url is maintained by the vsag project, if it's broken, please try
-                    #  the latest commit or contact the vsag project
-		    http://vsagcache.oss-rg-china-mainland.aliyuncs.com/roaringbitmap/v3.0.1.tar.gz
-		URL_HASH MD5=463db911f97d5da69393d4a3190f9201
-                DOWNLOAD_NO_PROGRESS 0
-                INACTIVITY_TIMEOUT 5
-                # filesize ~= 90MiB
-                TIMEOUT 90
+        roaringbitmap
+        URL ${roaringbitmap_urls}
+        URL_HASH MD5=463db911f97d5da69393d4a3190f9201
+        DOWNLOAD_NO_PROGRESS 0
+        INACTIVITY_TIMEOUT 5
+        # filesize ~= 90MiB
+        TIMEOUT 90
 )
 
 set(ROARING_USE_CPM OFF)

--- a/extern/tabulate/tabulate.cmake
+++ b/extern/tabulate/tabulate.cmake
@@ -1,11 +1,18 @@
 include (FetchContent)
 
+set(tabulate_urls
+    https://github.com/p-ranav/tabulate/archive/3a58301067bbc03da89ae5a51b3e05b7da719d38.tar.gz
+    # this url is maintained by the vsag project, if it's broken, please try
+    # the latest commit or contact the vsag project
+    https://vsagcache.oss-rg-china-mainland.aliyuncs.com/tabulate/3a58301067bbc03da89ae5a51b3e05b7da719d38.tar.gz
+)
+if(NOT "$ENV{VSAG_THIRDPARTY_TABULATE}" STREQUAL "")
+  message(STATUS "Using override URL/archive for tabulate: $ENV{VSAG_THIRDPARTY_TABULATE}")
+  list(PREPEND tabulate_urls "$ENV{VSAG_THIRDPARTY_TABULATE}")
+endif()
 FetchContent_Declare (
         tabulate
-        URL https://github.com/p-ranav/tabulate/archive/3a58301067bbc03da89ae5a51b3e05b7da719d38.tar.gz
-        # this url is maintained by the vsag project, if it's broken, please try
-        # the latest commit or contact the vsag project
-        http://vsagcache.oss-rg-china-mainland.aliyuncs.com/tabulate/3a58301067bbc03da89ae5a51b3e05b7da719d38.tar.gz
+        URL ${tabulate_urls}
         URL_HASH MD5=9d396f30fcc513abbb970773c8ddf8ff
         DOWNLOAD_NO_PROGRESS 1
         INACTIVITY_TIMEOUT 5

--- a/extern/thread_pool/thread_pool.cmake
+++ b/extern/thread_pool/thread_pool.cmake
@@ -1,14 +1,20 @@
 
 include(FetchContent)
 
+set(thread_pool_urls
+    https://github.com/log4cplus/ThreadPool/archive/3507796e172d36555b47d6191f170823d9f6b12c.tar.gz
+    # this url is maintained by the vsag project, if it's broken, please try
+    #  the latest commit or contact the vsag project
+    https://vsagcache.oss-rg-china-mainland.aliyuncs.com/thread_pool/3507796e172d36555b47d6191f170823d9f6b12c.tar.gz
+)
+if(NOT "$ENV{VSAG_THIRDPARTY_THREAD_POOL}" STREQUAL "")
+  message(STATUS "Using override URL/archive for thread_pool: $ENV{VSAG_THIRDPARTY_THREAD_POOL}")
+  list(PREPEND thread_pool_urls "$ENV{VSAG_THIRDPARTY_THREAD_POOL}")
+endif()
 FetchContent_Declare(
         thread_pool
-        URL https://github.com/log4cplus/ThreadPool/archive/3507796e172d36555b47d6191f170823d9f6b12c.tar.gz
-            # this url is maintained by the vsag project, if it's broken, please try
-            #  the latest commit or contact the vsag project
-            https://vsagcache.oss-rg-china-mainland.aliyuncs.com/thread_pool/3507796e172d36555b47d6191f170823d9f6b12c.tar.gz
-            URL_HASH MD5=e5b67a770f9f37500561a431d1dc1afe
-
+        URL ${thread_pool_urls}
+        URL_HASH MD5=e5b67a770f9f37500561a431d1dc1afe
         DOWNLOAD_NO_PROGRESS 1
         INACTIVITY_TIMEOUT 5
         TIMEOUT 30

--- a/extern/tsl/tsl.cmake
+++ b/extern/tsl/tsl.cmake
@@ -1,12 +1,18 @@
 
 include(FetchContent)
 
+set(tsl_urls
+    https://github.com/Tessil/robin-map/archive/refs/tags/v1.4.0.tar.gz
+    https://vsagcache.oss-rg-china-mainland.aliyuncs.com/robin-map/v1.4.0.tar.gz
+)
+if(NOT "$ENV{VSAG_THIRDPARTY_TSL}" STREQUAL "")
+  message(STATUS "Using override URL/archive for tsl: $ENV{VSAG_THIRDPARTY_TSL}")
+  list(PREPEND tsl_urls "$ENV{VSAG_THIRDPARTY_TSL}")
+endif()
 FetchContent_Declare(
         tsl
-        URL https://github.com/Tessil/robin-map/archive/refs/tags/v1.4.0.tar.gz
-            https://vsagcache.oss-rg-china-mainland.aliyuncs.com/robin-map/v1.4.0.tar.gz
+        URL ${tsl_urls}
         URL_HASH MD5=d56a879c94e021c55d8956e37deb3e4f
-
         DOWNLOAD_NO_PROGRESS 1
         INACTIVITY_TIMEOUT 5
         TIMEOUT 30

--- a/extern/yaml-cpp/yaml-cpp.cmake
+++ b/extern/yaml-cpp/yaml-cpp.cmake
@@ -1,11 +1,18 @@
 include (FetchContent)
 
+set(yaml_cpp_urls
+    https://github.com/jbeder/yaml-cpp/archive/refs/tags/0.8.0.tar.gz
+    # this url is maintained by the vsag project, if it's broken, please try
+    #  the latest commit or contact the vsag project
+    https://vsagcache.oss-rg-china-mainland.aliyuncs.com/yaml-cpp/0.8.0.tar.gz
+)
+if(NOT "$ENV{VSAG_THIRDPARTY_YAML_CPP}" STREQUAL "")
+  message(STATUS "Using override URL/archive for yaml-cpp: $ENV{VSAG_THIRDPARTY_YAML_CPP}")
+  list(PREPEND yaml_cpp_urls "$ENV{VSAG_THIRDPARTY_YAML_CPP}")
+endif()
 FetchContent_Declare (
         yaml-cpp
-        URL https://github.com/jbeder/yaml-cpp/archive/refs/tags/0.8.0.tar.gz
-        # this url is maintained by the vsag project, if it's broken, please try
-        #  the latest commit or contact the vsag project
-        http://vsagcache.oss-rg-china-mainland.aliyuncs.com/yaml-cpp/0.8.0.tar.gz
+        URL ${yaml_cpp_urls}
         URL_HASH MD5=1d2c7975edba60e995abe3c4af6480e5
         DOWNLOAD_NO_PROGRESS 1
         INACTIVITY_TIMEOUT 5


### PR DESCRIPTION
## Summary
- Backport per-dependency VSAG_THIRDPARTY_* URL overrides for third-party downloads on 0.18.
- Preserve existing upstream and VSAG cache URLs plus URL_HASH verification when overrides are unset.
- Apply only to dependencies present on this release line.

Fixes: #2308

## Testing
- git diff --cached --check before commit
- verified added VSAG_THIRDPARTY_* sites in staged diff