### PR TITLE
fix(c-api): add result cap to range_search and validate file open status

### DIFF
--- a/include/vsag/vsag_c_api.h
+++ b/include/vsag/vsag_c_api.h
@@ -162,6 +162,7 @@ vsag_index_knn_search_with_filter(vsag_index_t index,
  * @param query The query data.
  * @param dim The dimension of the query data.
  * @param radius The radius of the search.
+ * @param k The maximum number of results to return (must be >= 1).
  * @param parameters The parameters of the search.
  * @param result The result of the search.
  * @return Error_t The error code.
@@ -171,6 +172,7 @@ vsag_index_range_search(vsag_index_t index,
                         const float* query,
                         uint64_t dim,
                         float radius,
+                        int64_t k,
                         const char* parameters,
                         SearchResult_t* search_result);
 
@@ -181,6 +183,7 @@ vsag_index_range_search(vsag_index_t index,
  * @param query The query data.
  * @param dim The dimension of the query data.
  * @param radius The radius of the search.
+ * @param k The maximum number of results to return (must be >= 1).
  * @param parameters The parameters of the search.
  * @param filter The filter function.
  * @param result The result of the search.
@@ -191,6 +194,7 @@ vsag_index_range_search_with_filter(vsag_index_t index,
                                     const float* query,
                                     uint64_t dim,
                                     float radius,
+                                    int64_t k,
                                     const char* parameters,
                                     FilterFunc_t filter,
                                     SearchResult_t* search_result);

--- a/src/factory/factory.cpp
+++ b/src/factory/factory.cpp
@@ -54,7 +54,8 @@ public:
           file_(std::ifstream(filename, std::ios::binary)),
           base_offset_(base_offset),
           size_(size),
-          pool_(std::move(pool)) {
+          pool_(std::move(pool)),
+          valid_(file_.is_open()) {
     }
 
     ~LocalFileReader() override {
@@ -63,9 +64,15 @@ public:
 
     void
     Read(uint64_t offset, uint64_t len, void* dest) override {
+        if (!valid_) {
+            throw std::runtime_error("LocalFileReader: failed to open file: " + filename_);
+        }
         std::lock_guard<std::mutex> lock(mutex_);
         file_.seekg(static_cast<int64_t>(base_offset_ + offset), std::ios::beg);
         file_.read(static_cast<char*>(dest), static_cast<int64_t>(len));
+        if (file_.fail()) {
+            throw std::runtime_error("LocalFileReader: read failed on file: " + filename_);
+        }
     }
 
     void
@@ -81,8 +88,12 @@ public:
                                len,
                                dest,
                                callback]() {
-            this->Read(offset, len, dest);
-            callback(IOErrorCode::IO_SUCCESS, "success");
+            try {
+                this->Read(offset, len, dest);
+                callback(IOErrorCode::IO_SUCCESS, "success");
+            } catch (const std::exception& e) {
+                callback(IOErrorCode::IO_ERROR, e.what());
+            }
         });
     }
 
@@ -98,6 +109,7 @@ private:
     uint64_t size_;
     std::mutex mutex_;
     std::shared_ptr<SafeThreadPool> pool_;
+    bool valid_;
 };
 
 std::shared_ptr<Reader>

--- a/src/vsag_c_api.cpp
+++ b/src/vsag_c_api.cpp
@@ -17,6 +17,7 @@
 #include <vsag/index.h>
 #include <vsag/vsag_c_api.h>
 
+#include <algorithm>
 #include <cstring>
 #include <fstream>
 #include <streambuf>
@@ -173,6 +174,12 @@ vsag_index_knn_search(vsag_index_t index,
     try {
         auto* vsag_index = static_cast<VsagIndex*>(index);
         if (vsag_index != nullptr) {
+            if (k <= 0) {
+                Error_t err;
+                err.code = VSAG_INVALID_ARGUMENT;
+                snprintf(err.message, sizeof(err.message), "%s", "knn_search requires k >= 1");
+                return err;
+            }
             auto query_dataset = vsag::Dataset::Make();
             query_dataset->Owner(false)
                 ->Dim(static_cast<int64_t>(dim))
@@ -183,16 +190,18 @@ vsag_index_knn_search(vsag_index_t index,
                 const auto* ids_view = result.value()->GetIds();
                 const auto* dists_view = result.value()->GetDistances();
                 auto real_k = result.value()->GetDim();
-                for (int i = 0; i < real_k; ++i) {
+                int64_t to_write = std::min<int64_t>(real_k, k);
+                for (int64_t i = 0; i < to_write; ++i) {
                     search_result->ids[i] = ids_view[i];
                     search_result->dists[i] = dists_view[i];
                 }
-                search_result->count = real_k;
+                search_result->count = to_write;
             } else {
                 return make_error(result.error());
             }
+            return success;
         }
-        return success;
+        return make_error("index is NULL");
     } catch (const std::exception& e) {
         return make_error(e);
     }
@@ -223,6 +232,12 @@ vsag_index_knn_search_with_filter(vsag_index_t index,
     try {
         auto* vsag_index = static_cast<VsagIndex*>(index);
         if (vsag_index != nullptr) {
+            if (k <= 0) {
+                Error_t err;
+                err.code = VSAG_INVALID_ARGUMENT;
+                snprintf(err.message, sizeof(err.message), "%s", "knn_search requires k >= 1");
+                return err;
+            }
             auto query_dataset = vsag::Dataset::Make();
             query_dataset->Owner(false)
                 ->Dim(static_cast<int64_t>(dim))
@@ -234,16 +249,18 @@ vsag_index_knn_search_with_filter(vsag_index_t index,
                 const auto* ids_view = result.value()->GetIds();
                 const auto* dists_view = result.value()->GetDistances();
                 auto real_k = result.value()->GetDim();
-                for (int i = 0; i < real_k; ++i) {
+                int64_t to_write = std::min<int64_t>(real_k, k);
+                for (int64_t i = 0; i < to_write; ++i) {
                     search_result->ids[i] = ids_view[i];
                     search_result->dists[i] = dists_view[i];
                 }
-                search_result->count = real_k;
+                search_result->count = to_write;
             } else {
                 return make_error(result.error());
             }
+            return success;
         }
-        return success;
+        return make_error("index is NULL");
     } catch (const std::exception& e) {
         return make_error(e);
     }
@@ -254,26 +271,37 @@ vsag_index_range_search(vsag_index_t index,
                         const float* query,
                         uint64_t dim,
                         float radius,
+                        int64_t k,
                         const char* parameters,
                         SearchResult_t* search_result) {
     try {
         auto* vsag_index = static_cast<VsagIndex*>(index);
         if (vsag_index != nullptr) {
+            if (k <= 0) {
+                Error_t err;
+                err.code = VSAG_INVALID_ARGUMENT;
+                snprintf(err.message,
+                         sizeof(err.message),
+                         "%s",
+                         "range_search requires k >= 1 as result cap");
+                return err;
+            }
             auto query_dataset = vsag::Dataset::Make();
             query_dataset->Owner(false)
                 ->Dim(static_cast<int64_t>(dim))
                 ->NumElements(static_cast<int64_t>(1))
                 ->Float32Vectors(query);
-            auto result = vsag_index->index_->RangeSearch(query_dataset, radius, parameters);
+            auto result = vsag_index->index_->RangeSearch(query_dataset, radius, parameters, k);
             if (result.has_value()) {
                 const auto* ids_view = result.value()->GetIds();
                 const auto* dists_view = result.value()->GetDistances();
                 auto real_k = result.value()->GetDim();
-                for (int i = 0; i < real_k; ++i) {
+                int64_t to_write = std::min<int64_t>(real_k, k);
+                for (int64_t i = 0; i < to_write; ++i) {
                     search_result->ids[i] = ids_view[i];
                     search_result->dists[i] = dists_view[i];
                 }
-                search_result->count = real_k;
+                search_result->count = to_write;
             } else {
                 return make_error(result.error());
             }
@@ -289,12 +317,22 @@ vsag_index_range_search_with_filter(vsag_index_t index,
                                     const float* query,
                                     uint64_t dim,
                                     float radius,
+                                    int64_t k,
                                     const char* parameters,
                                     FilterFunc_t filter,
                                     SearchResult_t* search_result) {
     try {
         auto* vsag_index = static_cast<VsagIndex*>(index);
         if (vsag_index != nullptr) {
+            if (k <= 0) {
+                Error_t err;
+                err.code = VSAG_INVALID_ARGUMENT;
+                snprintf(err.message,
+                         sizeof(err.message),
+                         "%s",
+                         "range_search requires k >= 1 as result cap");
+                return err;
+            }
             auto query_dataset = vsag::Dataset::Make();
             query_dataset->Owner(false)
                 ->Dim(static_cast<int64_t>(dim))
@@ -302,16 +340,17 @@ vsag_index_range_search_with_filter(vsag_index_t index,
                 ->Float32Vectors(query);
             auto vsag_filter = std::make_shared<VsagFilterWrapper>(filter);
             auto result =
-                vsag_index->index_->RangeSearch(query_dataset, radius, parameters, vsag_filter);
+                vsag_index->index_->RangeSearch(query_dataset, radius, parameters, vsag_filter, k);
             if (result.has_value()) {
                 const auto* ids_view = result.value()->GetIds();
                 const auto* dists_view = result.value()->GetDistances();
                 auto real_k = result.value()->GetDim();
-                for (int i = 0; i < real_k; ++i) {
+                int64_t to_write = std::min<int64_t>(real_k, k);
+                for (int64_t i = 0; i < to_write; ++i) {
                     search_result->ids[i] = ids_view[i];
                     search_result->dists[i] = dists_view[i];
                 }
-                search_result->count = real_k;
+                search_result->count = to_write;
             } else {
                 return make_error(result.error());
             }
@@ -496,6 +535,9 @@ vsag_serialize_file(vsag_index_t index, const char* file_path) {
         auto* vsag_index = static_cast<VsagIndex*>(index);
         if (vsag_index != nullptr) {
             std::ofstream file(file_path, std::ios::binary);
+            if (!file.is_open()) {
+                return make_error("failed to open file for writing: " + std::string(file_path));
+            }
             auto serialize_result = vsag_index->index_->Serialize(file);
             file.close();
             VSAG_CHECK_RESULT(serialize_result);
@@ -512,6 +554,15 @@ vsag_deserialize_file(vsag_index_t index, const char* file_path) {
         auto* vsag_index = static_cast<VsagIndex*>(index);
         if (vsag_index != nullptr) {
             std::ifstream file(file_path, std::ios::binary);
+            if (!file.is_open()) {
+                Error_t err;
+                err.code = VSAG_MISSING_FILE;
+                snprintf(err.message,
+                         sizeof(err.message),
+                         "failed to open file for reading: %s",
+                         file_path);
+                return err;
+            }
             auto deserialize_result = vsag_index->index_->Deserialize(file);
             file.close();
             VSAG_CHECK_RESULT(deserialize_result);

--- a/src/vsag_c_api_test.cpp
+++ b/src/vsag_c_api_test.cpp
@@ -266,9 +266,16 @@ TEST_CASE("vsag_c_api range search", "[vsag_c_api][ut]") {
     result.ids = results.data();
 
     auto idx = random() % num_vectors;
-    ret = vsag_index_range_search(
-        index, test_case.datas.data() + idx * dim, dim, radius, hgraph_search_parameters, &result);
+    int64_t range_k = 100;
+    ret = vsag_index_range_search(index,
+                                  test_case.datas.data() + idx * dim,
+                                  dim,
+                                  radius,
+                                  range_k,
+                                  hgraph_search_parameters,
+                                  &result);
     REQUIRE(ret.code == VSAG_SUCCESS);
+    REQUIRE(result.count <= range_k);
 
     // Test range search with filter
     auto filter_func = [](int64_t id) -> bool {
@@ -279,10 +286,12 @@ TEST_CASE("vsag_c_api range search", "[vsag_c_api][ut]") {
                                               test_case.datas.data() + idx * dim,
                                               dim,
                                               radius,
+                                              range_k,
                                               hgraph_search_parameters,
                                               filter_func,
                                               &result);
     REQUIRE(ret.code == VSAG_SUCCESS);
+    REQUIRE(result.count <= range_k);
 
     // Verify that all returned IDs are less than 50
     for (int64_t i = 0; i < result.count; ++i) {
@@ -441,9 +450,9 @@ TEST_CASE("vsag_c_api null handle paths", "[vsag_c_api][ut]") {
     vsag_index_knn_search_with_filter(
         nullptr, test_case.datas.data(), dim, 3, hgraph_search_parameters, nullptr, &result);
     vsag_index_range_search(
-        nullptr, test_case.datas.data(), dim, 1.0F, hgraph_search_parameters, &result);
+        nullptr, test_case.datas.data(), dim, 1.0F, 10, hgraph_search_parameters, &result);
     vsag_index_range_search_with_filter(
-        nullptr, test_case.datas.data(), dim, 1.0F, hgraph_search_parameters, nullptr, &result);
+        nullptr, test_case.datas.data(), dim, 1.0F, 10, hgraph_search_parameters, nullptr, &result);
 
     vsag_index_t clone_index = nullptr;
     REQUIRE(vsag_index_clone(nullptr, &clone_index).code == VSAG_INTERNAL_ERROR);
@@ -550,11 +559,17 @@ TEST_CASE("vsag_c_api search error paths", "[vsag_c_api][ut]") {
     REQUIRE(ret.code != VSAG_SUCCESS);
 
     ret = vsag_index_range_search(
-        index, test_case.datas.data(), dim, 10.0F, invalid_search_parameters, &result);
+        index, test_case.datas.data(), dim, 10.0F, 10, invalid_search_parameters, &result);
     REQUIRE(ret.code != VSAG_SUCCESS);
 
-    ret = vsag_index_range_search_with_filter(
-        index, test_case.datas.data(), dim, 10.0F, invalid_search_parameters, filter_func, &result);
+    ret = vsag_index_range_search_with_filter(index,
+                                              test_case.datas.data(),
+                                              dim,
+                                              10.0F,
+                                              10,
+                                              invalid_search_parameters,
+                                              filter_func,
+                                              &result);
     REQUIRE(ret.code != VSAG_SUCCESS);
 
     ret = vsag_index_knn_search(
@@ -562,7 +577,7 @@ TEST_CASE("vsag_c_api search error paths", "[vsag_c_api][ut]") {
     REQUIRE(ret.code != VSAG_SUCCESS);
 
     ret = vsag_index_range_search(
-        index, test_case.datas.data(), dim - 1, 10.0F, hgraph_search_parameters, &result);
+        index, test_case.datas.data(), dim - 1, 10.0F, 10, hgraph_search_parameters, &result);
     REQUIRE(ret.code != VSAG_SUCCESS);
 
     vsag_index_destroy(index);
@@ -625,5 +640,90 @@ TEST_CASE("vsag_c_api serialize and update edge paths", "[vsag_c_api][ut]") {
     REQUIRE(ret.code != VSAG_SUCCESS);
 
     vsag_index_destroy(non_empty_index);
+    vsag_index_destroy(index);
+}
+TEST_CASE("vsag_c_api range search k validation", "[vsag_c_api][ut]") {
+    auto index = vsag_index_factory(index_name, index_param);
+    REQUIRE(index != nullptr);
+
+    VsagTestCase test_case;
+    auto ret =
+        vsag_index_build(index, test_case.datas.data(), test_case.ids.data(), dim, num_vectors);
+    REQUIRE(ret.code == VSAG_SUCCESS);
+
+    std::vector<int64_t> results(100);
+    std::vector<float> scores(100);
+    SearchResult_t result{};
+    result.ids = results.data();
+    result.dists = scores.data();
+
+    // k = 0 must be rejected
+    ret = vsag_index_range_search(
+        index, test_case.datas.data(), dim, 10.0F, 0, hgraph_search_parameters, &result);
+    REQUIRE(ret.code != VSAG_SUCCESS);
+
+    // k = -1 must be rejected
+    ret = vsag_index_range_search(
+        index, test_case.datas.data(), dim, 10.0F, -1, hgraph_search_parameters, &result);
+    REQUIRE(ret.code != VSAG_SUCCESS);
+
+    // k = 0 with filter must also be rejected
+    auto filter_func = [](int64_t /*id*/) -> bool { return true; };
+    ret = vsag_index_range_search_with_filter(index,
+                                              test_case.datas.data(),
+                                              dim,
+                                              10.0F,
+                                              0,
+                                              hgraph_search_parameters,
+                                              filter_func,
+                                              &result);
+    REQUIRE(ret.code != VSAG_SUCCESS);
+
+    // k = -1 with filter must also be rejected
+    ret = vsag_index_range_search_with_filter(index,
+                                              test_case.datas.data(),
+                                              dim,
+                                              10.0F,
+                                              -1,
+                                              hgraph_search_parameters,
+                                              filter_func,
+                                              &result);
+    REQUIRE(ret.code != VSAG_SUCCESS);
+
+    // small k must cap the result count
+    int64_t small_k = 3;
+    ret = vsag_index_range_search(index,
+                                  test_case.datas.data(),
+                                  dim,
+                                  /*radius=*/100.0F,
+                                  small_k,
+                                  hgraph_search_parameters,
+                                  &result);
+    REQUIRE(ret.code == VSAG_SUCCESS);
+    REQUIRE(result.count <= small_k);
+
+    vsag_index_destroy(index);
+}
+
+TEST_CASE("vsag_c_api serialize/deserialize invalid path", "[vsag_c_api][ut]") {
+    auto index = vsag_index_factory(index_name, index_param);
+    REQUIRE(index != nullptr);
+
+    VsagTestCase test_case;
+    auto ret =
+        vsag_index_build(index, test_case.datas.data(), test_case.ids.data(), dim, num_vectors);
+    REQUIRE(ret.code == VSAG_SUCCESS);
+
+    // serialize to an unwritable path must fail
+    ret = vsag_serialize_file(index, "/nonexistent_dir/subdir/index.bin");
+    REQUIRE(ret.code != VSAG_SUCCESS);
+
+    // deserialize from a non-existent file must fail
+    auto index2 = vsag_index_factory(index_name, index_param);
+    REQUIRE(index2 != nullptr);
+    ret = vsag_deserialize_file(index2, "/nonexistent_dir/subdir/index.bin");
+    REQUIRE(ret.code != VSAG_SUCCESS);
+
+    vsag_index_destroy(index2);
     vsag_index_destroy(index);
 }


### PR DESCRIPTION
## Summary

Fix two security issues in the C API layer:

1. **RangeSearch buffer overflow (CWE-120)** — Add a mandatory int64_t k parameter (must be >= 1) to vsag_index_range_search and vsag_index_range_search_with_filter. The value is forwarded to the underlying Index::RangeSearch as limited_size. A defensive min(real_k, k) clamp is also applied to all four search entry points (knn/range, with/without filter) so the C API never writes past the caller buffer, even if the backend returns more results than requested.

2. **Missing file-open checks** — vsag_serialize_file and vsag_deserialize_file now verify is_open() right after constructing the stream, returning a clear error on bad paths. LocalFileReader records file-open state via a valid_ flag, checks it on entry to Read(), verifies file_.fail() after read(), and surfaces real IO_ERROR through the AsyncRead callback instead of unconditionally reporting IO_SUCCESS.

Fixes: #2318

## Tests

- Existing range_search tests updated to pass the new k argument and assert result.count <= k.
- New test case vsag_c_api range search k validation: covers k=0, k=-1 (both with and without filter) and a small-k cap check.
- New test case vsag_c_api serialize/deserialize invalid path: covers unwritable and missing paths.

## Checklist

- [x] make fmt (clang-format-15)
- [x] make release passes
- [x] Unit tests pass (unittests + vsag_c_api tests)
