### PR TITLE
fix(hgraph): add radius filtering after reorder in RangeSearch

### DIFF
--- a/src/algorithm/hgraph/hgraph_search.cpp
+++ b/src/algorithm/hgraph/hgraph_search.cpp
@@ -430,6 +430,11 @@ HGraph::RangeSearch(const DatasetPtr& query,
             raw_query, this->basic_flatten_codes_, search_result, limited_size, nullptr, ctx);
     }
 
+    // Filter by radius using final distances (high-precision if reordered)
+    while (not search_result->Empty() and search_result->Top().first > radius + THRESHOLD_ERROR) {
+        search_result->Pop();
+    }
+
     if (limited_size > 0) {
         while (search_result->Size() > limited_size) {
             search_result->Pop();


### PR DESCRIPTION
## Description

Fixes #2319

In HGraph's two-stage search mode for Range Search, after reordering with high-precision quantizer, there was no radius filtering with the recalculated distances. This caused recall issues:

- False positives: points with true distance > radius were incorrectly returned
- False negatives: points with true distance <= radius were incorrectly filtered out

## Changes

Added radius filtering after reordering in `HGraph::RangeSearch` to ensure only points within the radius (based on high-precision distances) are returned.

```cpp
// After reorder, filter by radius using high-precision distances
// This ensures only points within the radius are returned
while (not search_result->Empty() && search_result->Top().first > radius + THRESHOLD_ERROR) {
    search_result->Pop();
}
```

This aligns with the existing implementation in `Pyramid::RangeSearch`.

## Testing

- Code compiles successfully
- Code formatted with `make fmt`
- Follows existing code patterns from Pyramid

## Checklist

- [x] Code follows the project's coding standards
- [x] Commit message follows conventional commits format
- [x] Signed-off-by included
- [x] Changes are minimal and focused on the specific issue
