### PR TITLE
fix: initialize IVF reader IO reorder data

### DIFF
--- a/src/algorithm/ivf/ivf.cpp
+++ b/src/algorithm/ivf/ivf.cpp
@@ -656,7 +656,8 @@ IVF::Deserialize(StreamReader& reader) {
             this->check_reorder_codes_ready();
             if (this->use_reader_io_for_reorder()) {
                 buffer_reader.PushSeek(datacell_offsets["reorder_codes"].GetInt());
-                this->reorder_codes_->Deserialize(buffer_reader);
+                this->reorder_codes_->Deserialize(
+                    buffer_reader.Slice(datacell_sizes["reorder_codes"].GetInt()));
                 buffer_reader.PopSeek();
             } else {
                 READ_DATACELL_WITH_NAME(buffer_reader, "reorder_codes", this->reorder_codes_);

--- a/src/algorithm/ivf/ivf.cpp
+++ b/src/algorithm/ivf/ivf.cpp
@@ -42,6 +42,59 @@
 #include "vsag_exception.h"
 
 namespace vsag {
+static uint64_t
+checked_datacell_end(uint64_t begin, uint64_t length) {
+    if (length > std::numeric_limits<uint64_t>::max() - begin) {
+        throw VsagException(ErrorType::READ_ERROR, "Serialized datacell boundary overflows");
+    }
+    return begin + length;
+}
+
+class AbsoluteBoundedStreamReader : public StreamReader {
+public:
+    AbsoluteBoundedStreamReader(StreamReader* reader, uint64_t begin, uint64_t length)
+        : StreamReader(checked_datacell_end(begin, length)),
+          reader_(reader),
+          begin_(begin),
+          end_(begin + length) {
+        reader_->Seek(begin_);
+    }
+
+    void
+    Read(char* data, uint64_t size) override {
+        auto cursor = this->GetCursor();
+        if (cursor > end_ or size > end_ - cursor) {
+            throw VsagException(ErrorType::READ_ERROR,
+                                "Read operation exceeds serialized datacell boundary");
+        }
+        reader_->Read(data, size);
+    }
+
+    void
+    Seek(uint64_t cursor) override {
+        if (cursor < begin_ or cursor > end_) {
+            throw VsagException(ErrorType::READ_ERROR,
+                                "Seek operation exceeds serialized datacell boundary");
+        }
+        reader_->Seek(cursor);
+    }
+
+    [[nodiscard]] uint64_t
+    GetCursor() const override {
+        return reader_->GetCursor();
+    }
+
+    [[nodiscard]] uint64_t
+    Length() override {
+        return end_;
+    }
+
+private:
+    StreamReader* const reader_{nullptr};
+    uint64_t begin_{0};
+    uint64_t end_{0};
+};
+
 static constexpr const char* IVF_PARAMS_TEMPLATE =
     R"(
     {
@@ -655,9 +708,13 @@ IVF::Deserialize(StreamReader& reader) {
         if (use_reorder_) {
             this->check_reorder_codes_ready();
             if (this->use_reader_io_for_reorder()) {
-                buffer_reader.PushSeek(datacell_offsets["reorder_codes"].GetInt());
+                auto reorder_codes_offset = datacell_offsets["reorder_codes"].GetInt();
+                auto reorder_codes_size = datacell_sizes["reorder_codes"].GetInt();
+                buffer_reader.PushSeek(reorder_codes_offset);
+                AbsoluteBoundedStreamReader reorder_codes_reader(
+                    &buffer_reader, reorder_codes_offset, reorder_codes_size);
                 // ReaderIO records absolute offsets into the owning index reader.
-                this->reorder_codes_->Deserialize(buffer_reader);
+                this->reorder_codes_->Deserialize(reorder_codes_reader);
                 buffer_reader.PopSeek();
             } else {
                 READ_DATACELL_WITH_NAME(buffer_reader, "reorder_codes", this->reorder_codes_);

--- a/src/algorithm/ivf/ivf.cpp
+++ b/src/algorithm/ivf/ivf.cpp
@@ -32,6 +32,7 @@
 #include "index/index_impl.h"
 #include "index_feature_list.h"
 #include "inner_string_params.h"
+#include "io/reader_io_parameter.h"
 #include "ivf_nearest_partition.h"
 #include "query_context.h"
 #include "storage/serialization.h"
@@ -610,6 +611,7 @@ IVF::Deserialize(StreamReader& reader) {
         this->partition_strategy_->Deserialize(buffer_reader);
         this->label_table_->Deserialize(buffer_reader);
         if (use_reorder_) {
+            this->check_reorder_codes_ready();
             this->reorder_codes_->Deserialize(buffer_reader);
         }
 
@@ -651,7 +653,14 @@ IVF::Deserialize(StreamReader& reader) {
         READ_DATACELL_WITH_NAME(buffer_reader, "partition_strategy", this->partition_strategy_);
         READ_DATACELL_WITH_NAME(buffer_reader, "label_table", this->label_table_);
         if (use_reorder_) {
-            READ_DATACELL_WITH_NAME(buffer_reader, "reorder_codes", this->reorder_codes_);
+            this->check_reorder_codes_ready();
+            if (this->use_reader_io_for_reorder()) {
+                buffer_reader.PushSeek(datacell_offsets["reorder_codes"].GetInt());
+                this->reorder_codes_->Deserialize(buffer_reader);
+                buffer_reader.PopSeek();
+            } else {
+                READ_DATACELL_WITH_NAME(buffer_reader, "reorder_codes", this->reorder_codes_);
+            }
         }
         if (use_attribute_filter_) {
             READ_DATACELL_WITH_NAME(buffer_reader, "attr_filter_index", this->attr_filter_index_);
@@ -663,6 +672,16 @@ IVF::Deserialize(StreamReader& reader) {
     }
     this->fill_location_map();
     this->cal_memory_usage();
+}
+
+void
+IVF::SetIO(const std::shared_ptr<Reader> reader) {
+    auto reader_param = std::make_shared<ReaderIOParameter>();
+    reader_param->reader = reader;
+    if (this->use_reorder_) {
+        this->check_reorder_codes_ready();
+        this->reorder_codes_->InitIO(reader_param);
+    }
 }
 
 InnerSearchParam
@@ -1256,6 +1275,22 @@ IVF::cal_memory_usage() {
     memory += partition_strategy_->GetMemoryUsage();
     std::unique_lock lock(this->memory_usage_mutex_);
     this->current_memory_usage_.store(static_cast<int64_t>(memory));
+}
+
+bool
+IVF::use_reader_io_for_reorder() const {
+    auto ivf_param = std::dynamic_pointer_cast<IVFParameter>(this->create_param_ptr_);
+    return ivf_param != nullptr and ivf_param->precise_codes_param != nullptr and
+           ivf_param->precise_codes_param->io_parameter != nullptr and
+           ivf_param->precise_codes_param->io_parameter->GetTypeName() == IO_TYPE_VALUE_READER_IO;
+}
+
+void
+IVF::check_reorder_codes_ready() const {
+    if (this->reorder_codes_ == nullptr) {
+        throw VsagException(ErrorType::INTERNAL_ERROR,
+                            "reorder_codes is null but use_reorder is true");
+    }
 }
 
 int64_t

--- a/src/algorithm/ivf/ivf.cpp
+++ b/src/algorithm/ivf/ivf.cpp
@@ -656,8 +656,8 @@ IVF::Deserialize(StreamReader& reader) {
             this->check_reorder_codes_ready();
             if (this->use_reader_io_for_reorder()) {
                 buffer_reader.PushSeek(datacell_offsets["reorder_codes"].GetInt());
-                this->reorder_codes_->Deserialize(
-                    buffer_reader.Slice(datacell_sizes["reorder_codes"].GetInt()));
+                // ReaderIO records absolute offsets into the owning index reader.
+                this->reorder_codes_->Deserialize(buffer_reader);
                 buffer_reader.PopSeek();
             } else {
                 READ_DATACELL_WITH_NAME(buffer_reader, "reorder_codes", this->reorder_codes_);

--- a/src/algorithm/ivf/ivf.h
+++ b/src/algorithm/ivf/ivf.h
@@ -159,6 +159,9 @@ public:
     Serialize(StreamWriter& writer) const override;
 
     void
+    SetIO(const std::shared_ptr<Reader> reader) override;
+
+    void
     Train(const DatasetPtr& data) override;
 
     void
@@ -229,6 +232,12 @@ private:
     /// Recalculate and cache the memory-usage counter (throttled).
     void
     cal_memory_usage();
+
+    [[nodiscard]] bool
+    use_reader_io_for_reorder() const;
+
+    void
+    check_reorder_codes_ready() const;
 
 private:
     BucketInterfacePtr bucket_{nullptr};  // bucket storage (raw or attribute-aware)

--- a/tests/test_ivf.cpp
+++ b/tests/test_ivf.cpp
@@ -42,7 +42,8 @@ public:
                                      int buckets_per_data = 1,
                                      bool use_attr_filter = false,
                                      int thread_count = 1,
-                                     int64_t sample_count = 10000L);
+                                     int64_t sample_count = 10000L,
+                                     const std::string& precise_io_type = "block_memory_io");
 
     static IVFResourcePtr
     GetResource(bool sample = true);
@@ -130,7 +131,8 @@ IVFTestIndex::GenerateIVFBuildParametersString(const std::string& metric_type,
                                                int buckets_per_data,
                                                bool use_attr_filter,
                                                int thread_count,
-                                               int64_t sample_count) {
+                                               int64_t sample_count,
+                                               const std::string& precise_io_type) {
     std::string build_parameters_str;
     constexpr auto parameter_temp = R"(
     {{
@@ -144,6 +146,7 @@ IVFTestIndex::GenerateIVFBuildParametersString(const std::string& metric_type,
             "use_reorder": {},
             "base_pq_dim": {},
             "precise_quantization_type": "{}",
+            "precise_io_type": "{}",
             "use_residual": {},
             "buckets_per_data": {},
             "use_attribute_filter": {},
@@ -174,6 +177,7 @@ IVFTestIndex::GenerateIVFBuildParametersString(const std::string& metric_type,
                                        use_reorder,
                                        pq_dim,
                                        precise_quantizer_str,
+                                       precise_io_type,
                                        use_residual,
                                        buckets_per_data,
                                        use_attr_filter,
@@ -1171,6 +1175,56 @@ TestIVFSerialize(const fixtures::IVFResourcePtr& resource) {
 }
 
 IVF_PR_DAILY_CASE("IVF Serialize File", "[ft][serialize][ivf]", TestIVFSerialize)
+
+TEST_CASE("(PR) IVF Reader IO", "[ft][serialize][ivf][pr]") {
+    using namespace fixtures;
+    auto metric_type = "l2";
+    auto dim = 64;
+    auto base_count = 800;
+    auto bucket_count = 32;
+    auto train_sample_count = static_cast<int64_t>(base_count);
+    auto search_param = fmt::format(fixtures::search_param_tmp, bucket_count);
+
+    auto param = IVFTestIndex::GenerateIVFBuildParametersString(metric_type,
+                                                                dim,
+                                                                "sq8,fp32",
+                                                                bucket_count,
+                                                                "kmeans",
+                                                                false,
+                                                                1,
+                                                                false,
+                                                                1,
+                                                                train_sample_count);
+    auto reader_param = IVFTestIndex::GenerateIVFBuildParametersString(metric_type,
+                                                                       dim,
+                                                                       "sq8,fp32",
+                                                                       bucket_count,
+                                                                       "kmeans",
+                                                                       false,
+                                                                       1,
+                                                                       false,
+                                                                       1,
+                                                                       train_sample_count,
+                                                                       "reader_io");
+    auto index = IVFTestIndex::TestFactory(IVFTestIndex::name, param, true);
+    auto dataset = IVFTestIndex::pool.GetDatasetAndCreate(dim, base_count, metric_type);
+    IVFTestIndex::TestBuildIndex(index, dataset, true);
+
+    auto reader_index = IVFTestIndex::TestFactory(IVFTestIndex::name, reader_param, true);
+    IVFTestIndex::TestSerializeReaderSet(
+        index, reader_index, dataset, search_param, IVFTestIndex::name, true);
+
+    const auto* query = dataset->query_->GetFloat32Vectors();
+    const auto* ids = dataset->ground_truth_->GetIds();
+    auto expected_distances = index->CalDistanceById(query, ids, dataset->top_k);
+    auto reader_distances = reader_index->CalDistanceById(query, ids, dataset->top_k);
+    REQUIRE(expected_distances.has_value());
+    REQUIRE(reader_distances.has_value());
+    for (int64_t i = 0; i < dataset->top_k; ++i) {
+        REQUIRE(std::abs(expected_distances.value()->GetDistances()[i] -
+                         reader_distances.value()->GetDistances()[i]) < 1e-6F);
+    }
+}
 
 static void
 TestIVFClone(const fixtures::IVFResourcePtr& resource) {


### PR DESCRIPTION
## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement/Refactor
- [ ] Documentation
- [ ] CI/Build/Infra

## Linked Issue

- Fixes: #2302

## What Changed

- Initialize IVF reorder `ReaderIO` when deserializing from `ReaderSet`.
- Deserialize IVF `reader_io` reorder codes from the full stream position so `ReaderIO::start_` keeps the absolute offset instead of a slice-relative offset.
- Add a regression test covering IVF `precise_io_type = reader_io` with `ReaderSet` deserialization and search.

## Test Evidence

- [ ] `make fmt`
- [ ] `make lint`
- [ ] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [x] Other (describe below)

Test details:

```text
./scripts/format/format-cpp.sh
Using clang-format version 15 (required: 15)
Code formatting completed with /opt/homebrew/opt/llvm@15/bin/clang-format

git diff --check

# macOS validation on codex/macos-build-baseline with local roaringbitmap source override:
make test CASE='"(PR) IVF Reader IO"' COMPILE_JOBS=6 EXTRA_DEFINED='-DFETCHCONTENT_SOURCE_DIR_ROARINGBITMAP=/Users/jiangchao/workspace/vsag/build/_deps/roaringbitmap-src'
All tests passed (1307 assertions in 1 test case)
```

Note: Direct `make test` on upstream/main in this macOS worktree is blocked before compiling this change by the existing AppleClang/libc++ baseline issue, so the targeted test was verified on the macOS build baseline branch.

## Compatibility Impact

- API/ABI compatibility: none
- Behavior changes: IVF `ReaderSet` deserialization now supports documented `precise_io_type = reader_io`.

## Performance and Concurrency Impact

- Performance impact: none expected
- Concurrency/thread-safety impact: none

## Documentation Impact

- [x] No docs update needed
- [ ] Updated docs:
  - [ ] `README.md`
  - [ ] `DEVELOPMENT.md`
  - [ ] `CONTRIBUTING.md`
  - [ ] Other:

## Risk and Rollback

- Risk level: low
- Rollback plan: revert this commit.

## Checklist

- [x] I have linked the relevant issue (required for `kind/bug` and `kind/feature`; see "Linked Issue" above)
- [x] I have added/updated tests for new behavior or bug fixes
- [x] I have considered API compatibility impact
- [x] I have updated docs if behavior/workflow changed
- [x] My commit messages follow project conventions (Conventional Commits, optional `[skip ci]` prefix)
