### PR TITLE
fix(storage): guard footer parse for short streams

### DIFF
--- a/src/storage/footer_parse_test.cpp
+++ b/src/storage/footer_parse_test.cpp
@@ -1,0 +1,45 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cstring>
+#include <sstream>
+
+#include "serialization.h"
+#include "stream_reader.h"
+#include "unittest.h"
+
+namespace {
+constexpr uint64_t FOOTER_MIN_SIZE = 36;
+}  // namespace
+
+TEST_CASE("Footer Parse rejects streams shorter than minimum footer size", "[ut][footer]") {
+    std::stringstream ss(std::ios::in | std::ios::out | std::ios::binary);
+    ss.str(std::string(FOOTER_MIN_SIZE - 1, 'a'));
+    vsag::IOStreamReader reader(ss);
+    REQUIRE(vsag::Footer::Parse(reader) == nullptr);
+}
+
+TEST_CASE("Footer Parse rejects mismatched metadata_string_length", "[ut][footer]") {
+    const uint64_t footer_length = 44;
+    std::string data(footer_length, '\0');
+    std::memcpy(&data[0], "vsag0000", 8);
+    const uint64_t wrong_metadata_length = 16;
+    std::memcpy(&data[8], &wrong_metadata_length, sizeof(wrong_metadata_length));
+    std::memcpy(&data[footer_length - 16], &footer_length, sizeof(footer_length));
+    std::memcpy(&data[footer_length - 8], "0000gasv", 8);
+    std::stringstream ss(std::ios::in | std::ios::out | std::ios::binary);
+    ss.str(data);
+    vsag::IOStreamReader reader(ss);
+    REQUIRE(vsag::Footer::Parse(reader) == nullptr);
+}

--- a/src/storage/serialization.cpp
+++ b/src/storage/serialization.cpp
@@ -17,6 +17,12 @@
 
 #include <cstring>
 #include <sstream>
+
+namespace {
+constexpr uint64_t FOOTER_TRAILER_SIZE = 16;
+constexpr uint64_t FOOTER_MIN_SIZE = 36;
+}  // namespace
+
 namespace vsag {
 
 void
@@ -46,10 +52,14 @@ Metadata::make_sure_metadata_not_null() {
 
 FooterPtr
 Footer::Parse(StreamReader& reader) {
+    const auto stream_length = reader.Length();
+    if (stream_length < FOOTER_MIN_SIZE) {
+        return nullptr;
+    }
     // check cigam
-    reader.PushSeek(reader.Length() - 16);
-    char buffer[16] = {};
-    reader.Read(buffer, 16);
+    reader.PushSeek(stream_length - FOOTER_TRAILER_SIZE);
+    char buffer[FOOTER_TRAILER_SIZE] = {};
+    reader.Read(buffer, FOOTER_TRAILER_SIZE);
     char cigam[9] = {};
     memcpy(cigam, buffer + 8, 8);
     logger::debug("deserial cigam: {}", cigam);
@@ -61,7 +71,7 @@ Footer::Parse(StreamReader& reader) {
     uint64_t length;
     memcpy(&length, buffer, 8);
     logger::debug("deserial length: {}", length);
-    if (length > reader.Length()) {
+    if (length < FOOTER_MIN_SIZE || length > stream_length) {
         reader.PopSeek();
         return nullptr;
     }
@@ -82,6 +92,10 @@ Footer::Parse(StreamReader& reader) {
 
     uint64_t metadata_string_length = 0;
     memcpy(&metadata_string_length, meta_buffer.data() + 8, 8);
+    if (metadata_string_length != length - FOOTER_MIN_SIZE) {
+        reader.PopSeek();
+        return nullptr;
+    }
     std::string metadata_string(meta_buffer.data() + 16, metadata_string_length);
     uint32_t checksum;
     memcpy(&checksum, meta_buffer.data() + 16 + metadata_string_length, 4);
@@ -94,7 +108,7 @@ Footer::Parse(StreamReader& reader) {
 
     auto metadata = std::make_shared<Metadata>(JsonType::Parse(metadata_string));
     auto footer = std::make_shared<Footer>(metadata);
-    footer->length_ = metadata_string.length() + /* wrapper.length= */ 36;
+    footer->length_ = metadata_string.length() + /* wrapper.length= */ FOOTER_MIN_SIZE;
     return footer;
 }
 


### PR DESCRIPTION
Closes #2170

## Summary

Add short-stream guards in Footer::Parse to avoid unsigned underflow and out-of-bounds reads when the input stream is shorter than the minimum valid footer (36 bytes).

## Changes

- Reject streams shorter than FOOTER_MIN_SIZE (36 bytes) up front.
- Validate that the parsed `length` field is within [FOOTER_MIN_SIZE, stream_length] before using it.
- Validate that `metadata_string_length` matches the expected structure size (`length - FOOTER_MIN_SIZE`).
- Cache reader.Length() in a local to avoid repeated calls.
- Use named constants FOOTER_TRAILER_SIZE (16) and FOOTER_MIN_SIZE (36) instead of magic numbers.

## Tests

- `Footer Parse rejects streams shorter than minimum footer size` — covers < 36 byte streams.
- `Footer Parse rejects mismatched metadata_string_length` — covers structural integrity check.
