### PR TITLE
feat(bruteforce): integrate reasoning mechanism for search diagnostics

### DIFF
--- a/src/algorithm/bruteforce/bruteforce.cpp
+++ b/src/algorithm/bruteforce/bruteforce.cpp
@@ -26,6 +26,7 @@
 #include "datacell/flatten_interface.h"
 #include "fmt/chrono.h"
 #include "impl/heap/standard_heap.h"
+#include "impl/reasoning/search_reasoning.h"
 #include "index_common_param.h"
 #include "index_feature_list.h"
 #include "inner_string_params.h"
@@ -359,6 +360,36 @@ BruteForce::SearchWithRequest(const SearchRequest& request) const {
         attr_filter = executor->Run();
     }
 
+    // Setup reasoning context if expected labels are provided.
+    std::shared_ptr<ReasoningContext> reasoning_ctx;
+    if (not request.expected_labels_.empty()) {
+        reasoning_ctx = std::make_shared<ReasoningContext>(this->allocator_);
+        reasoning_ctx->SetSearchParams(
+            request.topk_, is_multi_vector_ ? "WARP" : "BruteForce", false, ft != nullptr);
+
+        UnorderedMap<int64_t, InnerIdType> label_to_inner_id(this->allocator_);
+        for (const auto& label : request.expected_labels_) {
+            auto [success, inner_id] = label_table_->TryGetIdByLabel(label, true);
+            if (success) {
+                label_to_inner_id[label] = inner_id;
+            }
+        }
+
+        Vector<int64_t> expected_labels_vec(
+            request.expected_labels_.begin(), request.expected_labels_.end(), this->allocator_);
+        reasoning_ctx->InitializeExpectedTargets(expected_labels_vec, label_to_inner_id);
+
+        // Compute true distances for expected targets.
+        // BruteForce uses inner_codes_ directly; for multi-vector, this is the
+        // same tokenizer used during search, so the distance is already precise.
+        for (const auto& pair : label_to_inner_id) {
+            float dist = 0.0F;
+            const auto inner_id = pair.second;
+            this->inner_codes_->Query(&dist, computer, &inner_id, 1);
+            reasoning_ctx->SetTrueDistance(inner_id, dist);
+        }
+    }
+
     std::atomic<uint32_t> dist_cmp{0};
 
     auto brute_force_params = BruteForceSearchParameters::FromJson(request.params_str_);
@@ -367,27 +398,43 @@ BruteForce::SearchWithRequest(const SearchRequest& request) const {
     for (auto& cur_heap : heaps) {
         cur_heap = DistanceHeap::MakeInstanceBySize<true, true>(this->allocator_, heap_size);
     }
+    auto* reasoning = reasoning_ctx ? reasoning_ctx.get() : nullptr;
+
     auto search_func = [&](InnerIdType start, InnerIdType end, const DistHeapPtr& cur_heap) {
         uint32_t dist_cmp_local = 0;
         for (InnerIdType i = start; i < end; ++i) {
             float dist = 0.0F;
             if (attr_filter != nullptr and not attr_filter->CheckValid(i)) {
+                if (reasoning != nullptr) {
+                    reasoning->RecordFilterReject(i);
+                }
                 continue;
             }
             if (ft == nullptr or ft->CheckValid(i)) {
                 inner_codes_->Query(&dist, computer, &i, 1);
                 ++dist_cmp_local;
+                if (reasoning != nullptr) {
+                    reasoning->RecordVisit(i, dist, 0);
+                }
                 if (is_range and dist > radius) {
                     continue;
                 }
                 cur_heap->Push(dist, i);
+            } else {
+                if (reasoning != nullptr) {
+                    reasoning->RecordFilterReject(i);
+                }
             }
         }
         dist_cmp.fetch_add(dist_cmp_local, std::memory_order_relaxed);
     };
 
     auto count = total_count_.load();
-    if (parallel_count == 1 || this->thread_pool_ == nullptr) {
+    // Reasoning context is not thread-safe; force single-threaded search when
+    // reasoning is enabled so that RecordVisit / RecordFilterReject calls are
+    // serialized.  Reasoning is a diagnostic tool and does not need maximum
+    // throughput.
+    if (parallel_count == 1 || this->thread_pool_ == nullptr || reasoning != nullptr) {
         search_func(0, count, heaps[0]);
         heap = heaps[0];
     } else {
@@ -408,7 +455,29 @@ BruteForce::SearchWithRequest(const SearchRequest& request) const {
         }
     }
 
+    // Collect result inner IDs before pack_knn_result consumes the heap,
+    // so we can call MarkResult for reasoning analysis.
+    Vector<InnerIdType> result_inner_ids(this->allocator_);
+    if (reasoning_ctx && heap != nullptr && !heap->Empty()) {
+        auto heap_size = static_cast<uint64_t>(heap->Size());
+        result_inner_ids.reserve(heap_size);
+        const auto* data = heap->GetData();
+        for (uint64_t i = 0; i < heap_size; ++i) {
+            result_inner_ids.push_back(data[i].second);
+        }
+    }
+
     auto result = this->pack_knn_result(heap);
+
+    // Generate reasoning report if reasoning context was created.
+    if (reasoning_ctx) {
+        if (not result_inner_ids.empty()) {
+            reasoning_ctx->MarkResult(result_inner_ids);
+        }
+        reasoning_ctx->SetTermination(ReasoningContext::kTerminationLowerBoundReached);
+        reasoning_ctx->DiagnoseExpectedTargets();
+        result->Reasoning(reasoning_ctx->GenerateReport());
+    }
 
     JsonType stats;
     stats["dist_cmp"].SetInt(dist_cmp.load(std::memory_order_relaxed));

--- a/tests/test_brute_force.cpp
+++ b/tests/test_brute_force.cpp
@@ -20,8 +20,17 @@
 #include "functest.h"
 #include "test_index.h"
 #include "vsag/options.h"
+#include "vsag/search_request.h"
 
 namespace fixtures {
+
+class RejectAllFilter : public vsag::Filter {
+public:
+    bool
+    CheckValid(int64_t id) const override {
+        return false;
+    }
+};
 
 class EvenIdFilter : public vsag::Filter {
 public:
@@ -800,4 +809,293 @@ TEST_CASE("(PR) BruteForce BruteForce Estimate Memory Test", "[ft][memory][brute
 TEST_CASE("(Daily) BruteForce BruteForce Estimate Memory Test", "[ft][memory][bruteforce][daily]") {
     auto resource = fixtures::BruteForceTestIndex::GetResource(false);
     TestBruteForceEstimateMemory(resource);
+}
+
+// BruteForce Reasoning Tests
+
+TEST_CASE("(PR) BruteForce SearchWithRequest Reasoning", "[ft][bruteforce][reasoning][pr]") {
+    using namespace fixtures;
+
+    auto param = BruteForceTestIndex::GenerateBruteForceBuildParametersString("l2", 16, "fp32");
+    auto index = TestIndex::TestFactory(BruteForceTestIndex::name, param, true);
+    auto dataset = BruteForceTestIndex::pool.GetDatasetAndCreate(16, 256, "l2");
+    TestIndex::TestBuildIndex(index, dataset, true);
+
+    auto query = vsag::Dataset::Make();
+    query->NumElements(1)
+        ->Dim(dataset->base_->GetDim())
+        ->Float32Vectors(dataset->base_->GetFloat32Vectors())
+        ->Owner(false);
+
+    vsag::SearchRequest req;
+    req.topk_ = 5;
+    req.params_str_ = "";
+    req.query_ = query;
+    req.expected_labels_ = {dataset->base_->GetIds()[0]};
+
+    auto result = index->SearchWithRequest(req);
+    REQUIRE(result.has_value());
+    REQUIRE_FALSE(result.value()->GetReasoning().empty());
+    REQUIRE(result.value()->GetReasoning().find("expected_analysis") != std::string::npos);
+    REQUIRE(result.value()->GetReasoning().find("missed_targets") != std::string::npos);
+
+    // With RejectAll filter, expected label should be diagnosed as filter_rejected
+    req.enable_filter_ = true;
+    req.filter_ = std::make_shared<RejectAllFilter>();
+
+    auto empty_result = index->SearchWithRequest(req);
+    REQUIRE(empty_result.has_value());
+    REQUIRE(empty_result.value()->GetDim() == 0);
+    REQUIRE_FALSE(empty_result.value()->GetReasoning().empty());
+    REQUIRE(empty_result.value()->GetReasoning().find("missed_targets") != std::string::npos);
+    REQUIRE(empty_result.value()->GetReasoning().find("filter_rejected") != std::string::npos);
+}
+
+TEST_CASE("(PR) BruteForce Reasoning Found Verification", "[ft][bruteforce][reasoning][pr]") {
+    using namespace fixtures;
+
+    auto param = BruteForceTestIndex::GenerateBruteForceBuildParametersString("l2", 16, "fp32");
+    auto index = TestIndex::TestFactory(BruteForceTestIndex::name, param, true);
+    auto dataset = BruteForceTestIndex::pool.GetDatasetAndCreate(16, 256, "l2");
+    TestIndex::TestBuildIndex(index, dataset, true);
+
+    auto query = vsag::Dataset::Make();
+    query->NumElements(1)
+        ->Dim(dataset->base_->GetDim())
+        ->Float32Vectors(dataset->base_->GetFloat32Vectors())
+        ->Owner(false);
+
+    vsag::SearchRequest req;
+    req.topk_ = 10;
+    req.params_str_ = "";
+    req.query_ = query;
+
+    auto baseline = index->SearchWithRequest(req);
+    REQUIRE(baseline.has_value());
+    REQUIRE(baseline.value()->GetDim() > 0);
+
+    auto* ids = baseline.value()->GetIds();
+    int64_t found_label = ids[0];
+
+    req.expected_labels_ = {found_label};
+    auto result = index->SearchWithRequest(req);
+    REQUIRE(result.has_value());
+    REQUIRE_FALSE(result.value()->GetReasoning().empty());
+
+    auto reasoning = result.value()->GetReasoning();
+    REQUIRE(reasoning.find("1/1") != std::string::npos);
+    REQUIRE(reasoning.find("0 missed") != std::string::npos);
+}
+
+TEST_CASE("(PR) BruteForce Reasoning Multiple Labels Mixed", "[ft][bruteforce][reasoning][pr]") {
+    using namespace fixtures;
+
+    auto param = BruteForceTestIndex::GenerateBruteForceBuildParametersString("l2", 16, "fp32");
+    auto index = TestIndex::TestFactory(BruteForceTestIndex::name, param, true);
+    auto dataset = BruteForceTestIndex::pool.GetDatasetAndCreate(16, 256, "l2");
+    TestIndex::TestBuildIndex(index, dataset, true);
+
+    auto query = vsag::Dataset::Make();
+    query->NumElements(1)
+        ->Dim(dataset->base_->GetDim())
+        ->Float32Vectors(dataset->base_->GetFloat32Vectors())
+        ->Owner(false);
+
+    vsag::SearchRequest req;
+    req.topk_ = 10;
+    req.params_str_ = "";
+    req.query_ = query;
+
+    auto baseline = index->SearchWithRequest(req);
+    REQUIRE(baseline.has_value());
+    REQUIRE(baseline.value()->GetDim() > 0);
+
+    auto* ids = baseline.value()->GetIds();
+    // Test with a label that is in the top-k result (should be found)
+    // and a label from the dataset that is outside the top-k (should be
+    // diagnosed as ef_too_small since BruteForce visits all vectors but
+    // the top-k heap may evict it).
+    int64_t found_label = ids[0];
+    int64_t missed_label = dataset->base_->GetIds()[0];
+    // Ensure missed_label is not in the top-10 result
+    bool missed_in_result = false;
+    for (int64_t i = 0; i < baseline.value()->GetDim(); ++i) {
+        if (ids[i] == missed_label) {
+            missed_in_result = true;
+            break;
+        }
+    }
+    if (missed_in_result) {
+        // Pick a different label that is not in the result
+        for (int64_t i = 0; i < dataset->base_->GetNumElements(); ++i) {
+            missed_label = dataset->base_->GetIds()[i];
+            missed_in_result = false;
+            for (int64_t j = 0; j < baseline.value()->GetDim(); ++j) {
+                if (ids[j] == missed_label) {
+                    missed_in_result = true;
+                    break;
+                }
+            }
+            if (!missed_in_result) {
+                break;
+            }
+        }
+    }
+
+    req.expected_labels_ = {found_label, missed_label};
+    auto result = index->SearchWithRequest(req);
+    REQUIRE(result.has_value());
+    REQUIRE_FALSE(result.value()->GetReasoning().empty());
+
+    auto reasoning = result.value()->GetReasoning();
+    REQUIRE(reasoning.find("expected_analysis") != std::string::npos);
+    // found_label should be found; missed_label may be found or missed
+    // depending on the dataset. At minimum the report should be valid.
+    if (!missed_in_result) {
+        REQUIRE(reasoning.find("missed_targets") != std::string::npos);
+    }
+}
+
+TEST_CASE("(PR) BruteForce Reasoning With Filter Rejection", "[ft][bruteforce][reasoning][pr]") {
+    using namespace fixtures;
+
+    auto param = BruteForceTestIndex::GenerateBruteForceBuildParametersString("l2", 16, "fp32");
+    auto index = TestIndex::TestFactory(BruteForceTestIndex::name, param, true);
+    auto dataset = BruteForceTestIndex::pool.GetDatasetAndCreate(16, 256, "l2");
+    TestIndex::TestBuildIndex(index, dataset, true);
+
+    auto query = vsag::Dataset::Make();
+    query->NumElements(1)
+        ->Dim(dataset->base_->GetDim())
+        ->Float32Vectors(dataset->base_->GetFloat32Vectors())
+        ->Owner(false);
+
+    // Use RejectAllFilter to guarantee that expected labels are rejected.
+    // This makes the test deterministic: all expected labels will be
+    // diagnosed as filter_rejected since RejectAllFilter rejects everything.
+    int64_t target_label = dataset->base_->GetIds()[0];
+
+    vsag::SearchRequest req;
+    req.topk_ = 5;
+    req.params_str_ = "";
+    req.query_ = query;
+    req.enable_filter_ = true;
+    req.filter_ = std::make_shared<RejectAllFilter>();
+    req.expected_labels_ = {target_label};
+
+    auto result = index->SearchWithRequest(req);
+    REQUIRE(result.has_value());
+    REQUIRE(result.value()->GetDim() == 0);
+    REQUIRE_FALSE(result.value()->GetReasoning().empty());
+
+    auto reasoning = result.value()->GetReasoning();
+    REQUIRE(reasoning.find("expected_analysis") != std::string::npos);
+    REQUIRE(reasoning.find("filter_rejected") != std::string::npos);
+}
+
+TEST_CASE("(PR) BruteForce Reasoning Does Not Affect Results", "[ft][bruteforce][reasoning][pr]") {
+    using namespace fixtures;
+
+    auto param = BruteForceTestIndex::GenerateBruteForceBuildParametersString("l2", 16, "fp32");
+    auto index = TestIndex::TestFactory(BruteForceTestIndex::name, param, true);
+    auto dataset = BruteForceTestIndex::pool.GetDatasetAndCreate(16, 256, "l2");
+    TestIndex::TestBuildIndex(index, dataset, true);
+
+    auto query = vsag::Dataset::Make();
+    query->NumElements(1)
+        ->Dim(dataset->base_->GetDim())
+        ->Float32Vectors(dataset->base_->GetFloat32Vectors())
+        ->Owner(false);
+
+    vsag::SearchRequest req_without;
+    req_without.topk_ = 10;
+    req_without.params_str_ = "";
+    req_without.query_ = query;
+
+    auto result_without = index->SearchWithRequest(req_without);
+    REQUIRE(result_without.has_value());
+    REQUIRE(result_without.value()->GetDim() > 0);
+
+    vsag::SearchRequest req_with;
+    req_with.topk_ = 10;
+    req_with.params_str_ = "";
+    req_with.query_ = query;
+    req_with.expected_labels_ = {result_without.value()->GetIds()[0]};
+
+    auto result_with = index->SearchWithRequest(req_with);
+    REQUIRE(result_with.has_value());
+    REQUIRE(result_with.value()->GetDim() == result_without.value()->GetDim());
+
+    auto dim_without = result_without.value()->GetDim();
+    for (int64_t i = 0; i < dim_without; ++i) {
+        REQUIRE(result_with.value()->GetIds()[i] == result_without.value()->GetIds()[i]);
+        REQUIRE(result_with.value()->GetDistances()[i] ==
+                result_without.value()->GetDistances()[i]);
+    }
+}
+
+TEST_CASE("(PR) BruteForce Reasoning Empty Expected Labels", "[ft][bruteforce][reasoning][pr]") {
+    using namespace fixtures;
+
+    auto param = BruteForceTestIndex::GenerateBruteForceBuildParametersString("l2", 16, "fp32");
+    auto index = TestIndex::TestFactory(BruteForceTestIndex::name, param, true);
+    auto dataset = BruteForceTestIndex::pool.GetDatasetAndCreate(16, 256, "l2");
+    TestIndex::TestBuildIndex(index, dataset, true);
+
+    auto query = vsag::Dataset::Make();
+    query->NumElements(1)
+        ->Dim(dataset->base_->GetDim())
+        ->Float32Vectors(dataset->base_->GetFloat32Vectors())
+        ->Owner(false);
+
+    vsag::SearchRequest req;
+    req.topk_ = 5;
+    req.params_str_ = "";
+    req.query_ = query;
+    req.expected_labels_ = {};
+
+    auto result = index->SearchWithRequest(req);
+    REQUIRE(result.has_value());
+    REQUIRE(result.value()->GetDim() > 0);
+    // No reasoning analysis when expected_labels is empty
+    REQUIRE(result.value()->GetReasoning().find("expected_analysis") == std::string::npos);
+}
+
+TEST_CASE("(PR) BruteForce Reasoning No Output When Disabled", "[ft][bruteforce][reasoning][pr]") {
+    using namespace fixtures;
+
+    auto param = BruteForceTestIndex::GenerateBruteForceBuildParametersString("l2", 16, "fp32");
+    auto index = TestIndex::TestFactory(BruteForceTestIndex::name, param, true);
+    auto dataset = BruteForceTestIndex::pool.GetDatasetAndCreate(16, 256, "l2");
+    TestIndex::TestBuildIndex(index, dataset, true);
+
+    auto query = vsag::Dataset::Make();
+    query->NumElements(1)
+        ->Dim(dataset->base_->GetDim())
+        ->Float32Vectors(dataset->base_->GetFloat32Vectors())
+        ->Owner(false);
+
+    // When expected_labels is empty, reasoning is completely disabled:
+    // no ReasoningContext is created, and the result should contain no
+    // reasoning analysis. This is a deterministic check (no timing).
+    vsag::SearchRequest req;
+    req.topk_ = 5;
+    req.params_str_ = "";
+    req.query_ = query;
+    req.expected_labels_ = {};
+
+    auto result = index->SearchWithRequest(req);
+    REQUIRE(result.has_value());
+    REQUIRE(result.value()->GetDim() > 0);
+    REQUIRE(result.value()->GetReasoning().find("expected_analysis") == std::string::npos);
+
+    // Also verify that KnnSearch (which delegates to SearchWithRequest with
+    // empty expected_labels) produces identical results with and without
+    // the reasoning code path active.
+    auto knn_result = index->KnnSearch(query, 5, "", vsag::BitsetPtr(nullptr));
+    REQUIRE(knn_result.has_value());
+    REQUIRE(knn_result.value()->GetDim() == result.value()->GetDim());
+    for (int64_t i = 0; i < result.value()->GetDim(); ++i) {
+        REQUIRE(result.value()->GetIds()[i] == knn_result.value()->GetIds()[i]);
+    }
 }


### PR DESCRIPTION
## Summary

Add ReasoningContext support to BruteForce::SearchWithRequest, enabling search recall diagnostics when expected_labels are provided via SearchRequest.

## Changes

### Source Code (src/algorithm/bruteforce/bruteforce.cpp)
- Create ReasoningContext when expected_labels_ is non-empty
- Map labels to inner IDs and compute true distances
- Record Visit/FilterReject events during linear scan
- Force single-threaded search when reasoning is active
- Generate reasoning report via DiagnoseExpectedTargets/GenerateReport

### Tests (tests/test_brute_force.cpp)
Add 7 functional tests covering: basic reasoning, found verification, multiple labels, filter rejection (RejectAllFilter), result determinism, empty labels, and no-output-when-disabled.

Closes: #2327
Parent: #1829