### PR TITLE
fix(bruteforce): RangeSearch must exclude MarkRemove-deleted documents

### DIFF
--- a/src/algorithm/bruteforce/bruteforce.cpp
+++ b/src/algorithm/bruteforce/bruteforce.cpp
@@ -403,6 +403,8 @@ BruteForce::RangeSearch(const vsag::DatasetPtr& query,
 
     auto computer = this->make_search_computer(query);
 
+    FilterPtr ft = this->create_search_filter(filter);
+
     if (not is_multi_vector_) {
         this->validate_range_args(query, radius, limited_size);
     }
@@ -420,7 +422,7 @@ BruteForce::RangeSearch(const vsag::DatasetPtr& query,
             DistanceHeap::MakeInstanceBySize<true, true>(this->allocator_, limited_size);
         for (InnerIdType i = start; i < end; ++i) {
             float dist;
-            if (filter == nullptr or filter->CheckValid(this->label_table_->GetLabelById(i))) {
+            if (ft == nullptr or ft->CheckValid(i)) {
                 inner_codes_->Query(&dist, computer, &i, 1);
                 if (dist > radius) {
                     continue;

--- a/tests/test_brute_force.cpp
+++ b/tests/test_brute_force.cpp
@@ -668,6 +668,68 @@ TEST_CASE("(Daily) BruteForce Mark Remove", "[ft][remove][bruteforce][daily]") {
     TestBruteForceMarkRemove(resource);
 }
 
+TEST_CASE("(PR) BruteForce RangeSearch After MarkRemove",
+          "[ft][remove][range_search][bruteforce][pr]") {
+    // Regression: RangeSearch must exclude documents removed via MARK_REMOVE,
+    // mirroring KnnSearch behavior (see create_search_filter usage).
+    using namespace fixtures;
+    auto resource = fixtures::BruteForceTestIndex::GetResource(true);
+    auto origin_size = vsag::Options::Instance().block_size_limit();
+    auto size = 1024 * 1024 * 2;
+    for (const auto& metric_type : resource->metric_types) {
+        for (auto& dim : resource->dims) {
+            for (auto& [base_quantization_str, recall] : resource->test_cases) {
+                vsag::Options::Instance().set_block_size_limit(size);
+                auto param = BruteForceTestIndex::GenerateBruteForceBuildParametersString(
+                    metric_type, dim, base_quantization_str);
+                auto index = TestIndex::TestFactory(BruteForceTestIndex::name, param, true);
+                auto dataset = BruteForceTestIndex::pool.GetDatasetAndCreate(
+                    dim, BruteForceTestIndex::base_count, metric_type);
+
+                // Build and add
+                auto train_result = index->Train(dataset->base_);
+                REQUIRE(train_result.has_value());
+                auto add_results = index->Add(dataset->base_);
+                REQUIRE(add_results.has_value());
+
+                auto base_num = dataset->base_->GetNumElements();
+                auto base_dim = dataset->base_->GetDim();
+                auto ids = dataset->base_->GetIds();
+
+                // Mark-remove half of the base data
+                int64_t remove_count = base_num / 2;
+                std::vector<int64_t> remove_ids(ids, ids + remove_count);
+                auto remove_result = index->Remove(remove_ids, vsag::RemoveMode::MARK_REMOVE);
+                REQUIRE(remove_result.has_value());
+                REQUIRE(index->GetNumberRemoved() == remove_count);
+
+                // RangeSearch from each query; verify no removed id appears.
+                // Build a hash set of removed ids for O(1) lookup.
+                std::unordered_set<int64_t> removed_set(remove_ids.begin(), remove_ids.end());
+                auto queries = dataset->range_query_;
+                auto query_count = queries->GetNumElements();
+                auto radius = dataset->range_radius_;
+                for (int64_t q = 0; q < query_count; ++q) {
+                    auto query = vsag::Dataset::Make();
+                    query->NumElements(1)
+                        ->Dim(base_dim)
+                        ->Float32Vectors(queries->GetFloat32Vectors() + q * base_dim)
+                        ->Owner(false);
+                    auto res = index->RangeSearch(query, radius[q], search_param_tmp);
+                    REQUIRE(res.has_value());
+                    auto result_ids = res.value()->GetIds();
+                    auto result_dim = res.value()->GetDim();
+                    for (int64_t j = 0; j < result_dim; ++j) {
+                        REQUIRE(removed_set.count(result_ids[j]) == 0);
+                    }
+                }
+
+                vsag::Options::Instance().set_block_size_limit(origin_size);
+            }
+        }
+    }
+}
+
 static void
 TestBruteForceRemoveById(const fixtures::BruteForceResourcePtr& resource) {
     using namespace fixtures;


### PR DESCRIPTION
Fixes #2337

## Problem

`BruteForce::RangeSearch` uses the raw user-provided `Filter*` directly, bypassing the `create_search_filter()` wrapper that `SearchWithRequest` (KnnSearch) applies. As a result, documents removed via `MARK_REMOVE` (tracked by `label_table_`) still appear in range search results.

This bug migrated from the WARP index when PR #2275 refactored WARP into BruteForce multi-vector mode.

## Root Cause

In `src/algorithm/bruteforce/bruteforce.cpp`, `RangeSearch` passes the user filter directly into the search lambda:

```cpp
if (filter == nullptr or filter->CheckValid(this->label_table_->GetLabelById(i))) {
```

This only checks the user's filter condition, not whether the document has been marked as removed. Only the wrapped filter from `create_search_filter()` combines both checks (user filter + deleted IDs filter).

## Fix

Wrap the user filter via `create_search_filter()` at the top of `RangeSearch`, matching the pattern used in `SearchWithRequest`:

```cpp
FilterPtr ft = this->create_search_filter(filter);
// ...
if (ft == nullptr or ft->CheckValid(i)) {
```

## Changes

- `src/algorithm/bruteforce/bruteforce.cpp`: Call `create_search_filter(filter)` once and use the returned `FilterPtr` in the search lambda instead of the raw filter.
- `tests/test_brute_force.cpp`: Add regression test `(PR) BruteForce RangeSearch After MarkRemove` that builds an index, mark-removes half the data, and verifies `RangeSearch` returns no deleted IDs. The test fails against the unfixed code and passes with the fix applied.

## Testing

- Code compiles successfully
- Code formatted with `make fmt`
- Regression test added and passes
- All 29 BruteForce tests pass (1,339,418 assertions)
- Signed-off-by included
