### PR TITLE
feat(pyramid): integrate reasoning mechanism for Pyramid index

### DIFF
--- a/docs/docs/en/src/advanced/search_allocator.md
+++ b/docs/docs/en/src/advanced/search_allocator.md
@@ -41,9 +41,10 @@ a single search call. The `search_allocator_` field is optional — when left at
 index falls back to the allocator that was attached to its owning `Resource`.
 
 > **Availability.** `Index::SearchWithRequest` has a default implementation that returns an
-> *unsupported* error. Only HGraph, IVF, BruteForce and WARP implement it today
-> (`src/algorithm/{hgraph,ivf,brute_force,warp}.cpp`). For indexes that do not yet override
-> `SearchWithRequest` (SINDI, SINDI_V2 and Pyramid), use the legacy `SearchParam`
+> *unsupported* error. HGraph, IVF, BruteForce, WARP, SINDI and Pyramid implement it today.
+> Pyramid supports KNN request searches, including `expected_labels_` reasoning reports; range
+> requests with expected labels are not supported. For indexes that do not yet override
+> `SearchWithRequest` (SINDI_V2), use the legacy `SearchParam`
 > path described below.
 
 ## Legacy API — `SearchParam::allocator` *(deprecated)*

--- a/docs/docs/zh/src/advanced/search_allocator.md
+++ b/docs/docs/zh/src/advanced/search_allocator.md
@@ -36,8 +36,9 @@ auto result = index->SearchWithRequest(req).value();
 `search_allocator_` 字段是可选的，留空时索引会回退到它所属 `Resource` 上的 allocator。
 
 > **可用性。** `Index::SearchWithRequest` 默认实现会返回 *不支持* 错误。目前只有 HGraph、
-> IVF、BruteForce、WARP 实现了它（`src/algorithm/{hgraph,ivf,brute_force,warp}.cpp`）。对于
-> 尚未 override 的索引（SINDI、SINDI_V2、Pyramid），请使用下文的旧版
+> IVF、BruteForce、WARP、SINDI 和 Pyramid 实现了它。Pyramid 支持 KNN 请求搜索，并可通过
+> `expected_labels_` 生成 reasoning 报告；携带 expected labels 的 Range 请求暂不支持。对于
+> 尚未 override 的索引（SINDI_V2），请使用下文的旧版
 > `SearchParam` 路径。
 
 ## 旧版 API —— `SearchParam::allocator`（已弃用）

--- a/src/algorithm/pyramid/CMakeLists.txt
+++ b/src/algorithm/pyramid/CMakeLists.txt
@@ -16,6 +16,7 @@
 
 set (PYRAMID_SRCS
         pyramid.cpp
+        pyramid_index_node.cpp
         pyramid_zparameters.cpp
 )
 

--- a/src/algorithm/pyramid/CMakeLists.txt
+++ b/src/algorithm/pyramid/CMakeLists.txt
@@ -17,6 +17,7 @@
 set (PYRAMID_SRCS
         pyramid.cpp
         pyramid_build_cache.cpp
+        pyramid_index_node.cpp
         pyramid_zparameters.cpp
 )
 

--- a/src/algorithm/pyramid/pyramid.cpp
+++ b/src/algorithm/pyramid/pyramid.cpp
@@ -28,6 +28,9 @@
 #include "impl/heap/standard_heap.h"
 #include "impl/odescent/odescent_graph_builder.h"
 #include "impl/pruning_strategy.h"
+#include "impl/reasoning/search_reasoning.h"
+#include "io/memory_io/memory_io_parameter.h"
+#include "quantization/rabitq_quantization/rabitq_quantizer_parameter.h"
 #include "query_context.h"
 #include "storage/empty_index_binary_set.h"
 #include "storage/serialization.h"
@@ -41,6 +44,26 @@ namespace vsag {
 const static float RADIUS_EPSILON = 1.1F;
 static constexpr uint64_t SOURCE_ID_TABLE_MAGIC = 0x534F555243454944ULL;  // SOURCEID
 
+FilterPtr
+create_request_filter(const SearchRequest& request) {
+    FilterPtr filter = nullptr;
+    if (request.enable_filter_ && request.filter_ != nullptr) {
+        filter = request.filter_;
+    }
+    if (request.enable_bitset_filter_ && request.bitset_filter_ != nullptr) {
+        auto bitset_filter = std::make_shared<BlackListFilter>(request.bitset_filter_);
+        if (filter == nullptr) {
+            filter = bitset_filter;
+        } else {
+            auto combined = std::make_shared<CombinedFilter>();
+            combined->AppendFilter(filter);
+            combined->AppendFilter(bitset_filter);
+            filter = combined;
+        }
+    }
+    return filter;
+}
+
 std::vector<std::string>
 split(const std::string& str, char delimiter) {
     auto vec = split_string(str, delimiter);
@@ -48,17 +71,6 @@ split(const std::string& str, char delimiter) {
         std::remove_if(vec.begin(), vec.end(), [](const std::string& s) { return s.empty(); }),
         vec.end());
     return vec;
-}
-
-static inline uint64_t
-get_suitable_max_degree(int64_t data_num) {
-    if (data_num < 100'000) {
-        return 24;
-    }
-    if (data_num < 1000'000) {
-        return 32;
-    }
-    return 64;
 }
 
 static inline uint64_t
@@ -76,149 +88,43 @@ get_suitable_ef_search(int64_t topk, int64_t data_num, uint64_t subindex_ef_sear
     return std::max(static_cast<uint64_t>(4.0F * topk_float), subindex_ef_search * 8);
 }
 
-IndexNode::IndexNode(Allocator* allocator,
-                     GraphInterfaceParamPtr graph_param,
-                     uint32_t index_min_size)
-    : ids_(allocator),
-      children_(allocator),
-      allocator_(allocator),
-      graph_param_(std::move(graph_param)),
-      index_min_size_(index_min_size) {
-}
+InnerSearchParam
+Pyramid::create_knn_search_param(const PyramidSearchParameters& parsed_param,
+                                 int64_t k,
+                                 const FilterPtr& filter,
+                                 const std::optional<float>& threshold) const {
+    CHECK_ARGUMENT(k > 0, fmt::format("k({}) must be greater than 0", k));
+    CHECK_ARGUMENT(parsed_param.hierarchy_op == PyramidSearchParameters::HierarchyOp::SINGLE,
+                   "multi-hierarchy search (union/intersection) is not yet implemented");
+    auto ef_search_threshold =
+        std::max<uint64_t>(AMPLIFICATION_FACTOR * k, static_cast<uint64_t>(1000));
+    CHECK_ARGUMENT(  // NOLINT
+        (1 <= parsed_param.ef_search) and (parsed_param.ef_search <= ef_search_threshold),
+        fmt::format(
+            "ef_search({}) must be in range [1, {}]", parsed_param.ef_search, ef_search_threshold));
 
-void
-IndexNode::Build(ODescent& odescent) {
-    std::unique_lock lock(mutex_);
-    // Build an index when the level corresponding to the current node requires indexing
-    if (not ids_.empty()) {
-        Init();
-    }
-    if (status_ == Status::GRAPH) {
-        entry_point_ = ids_[0];
-        odescent.SetMaxDegree(static_cast<int32_t>(graph_param_->max_degree_));
-        odescent.Build(ids_);
-        odescent.SaveGraph(graph_);
-        Vector<InnerIdType>(allocator_).swap(ids_);
-    }
-    for (const auto& item : children_) {
-        item.second->Build(odescent);
-    }
-}
-
-void
-IndexNode::AddChild(const std::string& key) {
-    // AddChild is not thread-safe; ensure thread safety in calls to it.
-    children_[key] = std::make_unique<IndexNode>(allocator_, graph_param_, index_min_size_);
-    children_[key]->level_ = level_ + 1;
-}
-
-IndexNode*
-IndexNode::GetChild(const std::string& key, bool need_init) {
-    std::unique_lock lock(mutex_);
-    auto result = children_.find(key);
-    if (result != children_.end()) {
-        return result->second.get();
-    }
-    if (not need_init) {
-        return nullptr;
-    }
-    AddChild(key);
-    return children_[key].get();
-}
-
-void
-IndexNode::Deserialize(StreamReader& reader) {
-    // deserialize `entry_point_`
-    StreamReader::ReadObj(reader, entry_point_);
-    // deserialize `level_`
-    StreamReader::ReadObj(reader, level_);
-    // deserialize `status_`
-    StreamReader::ReadObj(reader, status_);
-    if (status_ == Status::GRAPH) {
-        graph_ = std::make_shared<SparseGraphDataCell>(
-            std::dynamic_pointer_cast<SparseGraphDatacellParameter>(graph_param_), allocator_);
-        graph_->Deserialize(reader);
-    } else if (status_ == Status::FLAT) {
-        StreamReader::ReadVector(reader, ids_);
-    }
-    // deserialize `children`
-    uint64_t children_size = 0;
-    StreamReader::ReadObj(reader, children_size);
-    for (uint64_t i = 0; i < children_size; ++i) {
-        std::string key = StreamReader::ReadString(reader);
-        AddChild(key);
-        children_[key]->Deserialize(reader);
-    }
-}
-
-void
-IndexNode::Serialize(StreamWriter& writer) const {
-    // serialize `entry_point_`
-    StreamWriter::WriteObj(writer, entry_point_);
-    // serialize `level_`
-    StreamWriter::WriteObj(writer, level_);
-    // serialize `status_`
-    StreamWriter::WriteObj(writer, status_);
-    if (status_ == Status::GRAPH) {
-        graph_->Serialize(writer);
-    } else if (status_ == Status::FLAT) {
-        StreamWriter::WriteVector(writer, ids_);
-    }
-    // serialize `children`
-    uint64_t children_size = children_.size();
-    StreamWriter::WriteObj(writer, children_size);
-    for (const auto& item : children_) {
-        // calculate size of `key`
-        StreamWriter::WriteString(writer, item.first);
-        // calculate size of `content`
-        item.second->Serialize(writer);
-    }
-}
-void
-IndexNode::Init() {
-    if (status_ == Status::NO_INDEX) {
-        if (ids_.size() >= index_min_size_) {
-            if (not ids_.empty() and level_ != 0) {
-                auto new_max_degree = get_suitable_max_degree(static_cast<int64_t>(ids_.size()));
-                if (new_max_degree < graph_param_->max_degree_) {
-                    auto new_graph_param = std::make_shared<SparseGraphDatacellParameter>();
-                    new_graph_param->FromJson(graph_param_->ToJson());
-                    new_graph_param->max_degree_ =
-                        get_suitable_max_degree(static_cast<int64_t>(ids_.size()));
-                    graph_param_ = new_graph_param;
-                }
-            }
-            graph_ = std::make_shared<SparseGraphDataCell>(
-                std::dynamic_pointer_cast<SparseGraphDatacellParameter>(graph_param_), allocator_);
-            status_ = Status::GRAPH;
-        } else {
-            status_ = Status::FLAT;
-        }
-    }
-}
-
-void
-IndexNode::Search(const SearchFunc& search_func,
-                  const VisitedListPtr& vl,
-                  const DistHeapPtr& search_result,
-                  uint64_t ef_search) const {
-    bool has_index = false;
-    {
-        std::shared_lock lock(mutex_);
-        has_index = status_ != IndexNode::Status::NO_INDEX;
-    }
-    if (has_index) {
-        auto self_search_result = search_func(this, vl);
-        search_result->Merge(*self_search_result);
-        while (search_result->Size() > ef_search) {
-            search_result->Pop();
-        }
-        return;
+    InnerSearchParam search_param;
+    search_param.ef = std::max<uint64_t>(parsed_param.ef_search, static_cast<uint64_t>(k));
+    search_param.radius = std::numeric_limits<float>::max();
+    search_param.topk = threshold.has_value() ? static_cast<int64_t>(search_param.ef) : k;
+    search_param.distance_threshold = threshold;
+    search_param.enable_reorder = use_reorder_;
+    search_param.search_mode = KNN_SEARCH;
+    search_param.parallel_search_thread_count = parsed_param.parallel_search_thread_count;
+    search_param.enable_rabitq_one_bit_search = parsed_param.has_rabitq_one_bit_search
+                                                    ? parsed_param.rabitq_one_bit_search
+                                                    : default_rabitq_one_bit_search_;
+    if (this->support_duplicate_) {
+        search_param.consider_duplicate = true;
     }
 
-    for (const auto& [key, node] : children_) {
-        node->Search(search_func, vl, search_result, ef_search);
+    if (parsed_param.enable_time_record) {
+        search_param.time_cost = std::make_shared<Timer>();
+        search_param.time_cost->SetThreshold(parsed_param.timeout_ms);
     }
+
+    search_param.is_inner_id_allowed = this->create_search_filter(filter);
+    return search_param;
 }
 
 std::vector<int64_t>
@@ -287,7 +193,7 @@ Pyramid::KnnSearch(const DatasetPtr& query,
                    const std::string& parameters,
                    const FilterPtr& filter) const {
     SearchStatistics stats;
-    QueryContext ctx{.stats = &stats};
+    QueryContext ctx{.alloc = this->allocator_, .stats = &stats};
 
     const auto threshold = ParseSearchThreshold(parameters);
     auto parsed_param = PyramidSearchParameters::FromJson(parameters);
@@ -381,7 +287,7 @@ Pyramid::RangeSearch(const DatasetPtr& query,
     CHECK_ARGUMENT(radius >= 0.0F, "radius must be non-negative");
 
     SearchStatistics stats;
-    QueryContext ctx{.stats = &stats};
+    QueryContext ctx{.alloc = this->allocator_, .stats = &stats};
 
     auto parsed_param = PyramidSearchParameters::FromJson(parameters);
     ctx.rabitq_error_rate = parsed_param.rabitq_error_rate;
@@ -445,6 +351,164 @@ Pyramid::RangeSearch(const DatasetPtr& query,
 }
 
 DatasetPtr
+Pyramid::SearchWithRequest(const SearchRequest& request) const {
+    ValidateSearchThreshold(request.threshold_);
+    SearchStatistics stats;
+    QueryContext ctx{.alloc = this->allocator_, .stats = &stats};
+    if (request.search_allocator_ != nullptr) {
+        ctx.alloc = request.search_allocator_;
+    }
+
+    const auto& query = request.query_;
+    CHECK_ARGUMENT(query != nullptr, "query dataset is required");
+    CHECK_ARGUMENT(query->GetFloat32Vectors() != nullptr, "query vectors is required");
+
+    const bool is_knn = request.mode_ == SearchMode::KNN_SEARCH;
+    if (is_knn) {
+        this->validate_knn_args(query, request.topk_);
+    } else {
+        CHECK_ARGUMENT(request.mode_ == SearchMode::RANGE_SEARCH, "unsupported search mode");
+        this->validate_range_args(query, request.radius_, request.limited_size_);
+        CHECK_ARGUMENT(request.expected_labels_.empty(),
+                       "Pyramid reasoning only supports KNN search requests");
+    }
+    CHECK_ARGUMENT(not request.enable_attribute_filter_,
+                   "Pyramid SearchWithRequest does not support attribute filters");
+
+    auto parsed_param = PyramidSearchParameters::FromJson(request.params_str_);
+    ctx.rabitq_error_rate = parsed_param.rabitq_error_rate;
+    const auto request_filter = create_request_filter(request);
+    InnerSearchParam search_param;
+    if (is_knn) {
+        search_param = this->create_knn_search_param(
+            parsed_param, request.topk_, request_filter, request.threshold_);
+    } else {
+        CHECK_ARGUMENT(parsed_param.hierarchy_op == PyramidSearchParameters::HierarchyOp::SINGLE,
+                       "multi-hierarchy search (union/intersection) is not yet implemented");
+        search_param.ef = parsed_param.ef_search;
+        search_param.radius = request.radius_ * RADIUS_EPSILON;
+        search_param.search_mode = RANGE_SEARCH;
+        search_param.enable_reorder = use_reorder_;
+        search_param.parallel_search_thread_count = parsed_param.parallel_search_thread_count;
+        search_param.enable_rabitq_one_bit_search = parsed_param.has_rabitq_one_bit_search
+                                                        ? parsed_param.rabitq_one_bit_search
+                                                        : default_rabitq_one_bit_search_;
+        search_param.topk = request.limited_size_ == -1 ? std::numeric_limits<int64_t>::max()
+                                                        : request.limited_size_;
+        if (this->support_duplicate_) {
+            search_param.consider_duplicate = true;
+        }
+        if (parsed_param.enable_time_record) {
+            search_param.time_cost = std::make_shared<Timer>();
+            search_param.time_cost->SetThreshold(parsed_param.timeout_ms);
+        }
+        search_param.is_inner_id_allowed = this->create_search_filter(request_filter);
+    }
+    // Setup reasoning context if expected labels are provided.
+    std::shared_ptr<ReasoningContext> reasoning_ctx;
+    if (is_knn && not request.expected_labels_.empty()) {
+        reasoning_ctx = std::make_shared<ReasoningContext>(ctx.alloc);
+        reasoning_ctx->SetSearchParams(
+            request.topk_, "Pyramid", use_reorder_, request_filter != nullptr);
+
+        UnorderedMap<int64_t, InnerIdType> label_to_inner_id(ctx.alloc);
+        Vector<InnerIdType> expected_inner_ids(ctx.alloc);
+        {
+            std::lock_guard lock(cur_element_count_mutex_);
+            for (const auto& label : request.expected_labels_) {
+                // `true` = return_even_removed: include removed labels so reasoning can diagnose them.
+                auto [success, inner_id] = label_table_->TryGetIdByLabel(label, true);
+                if (success) {
+                    label_to_inner_id[label] = inner_id;
+                }
+            }
+            expected_inner_ids.reserve(label_to_inner_id.size());
+            for (const auto& [label, inner_id] : label_to_inner_id) {
+                expected_inner_ids.push_back(inner_id);
+            }
+        }
+
+        Vector<int64_t> expected_labels_vec(
+            request.expected_labels_.begin(), request.expected_labels_.end(), ctx.alloc);
+        reasoning_ctx->InitializeExpectedTargets(expected_labels_vec, label_to_inner_id);
+        auto precise_flatten = raw_vector_ != nullptr ? raw_vector_ : precise_codes_;
+        if (precise_flatten != nullptr && not expected_inner_ids.empty()) {
+            auto computer = precise_flatten->FactoryComputer(query->GetFloat32Vectors());
+            Vector<float> true_dists(expected_inner_ids.size(), ctx.alloc);
+            precise_flatten->Query(true_dists.data(),
+                                   computer,
+                                   expected_inner_ids.data(),
+                                   static_cast<InnerIdType>(expected_inner_ids.size()),
+                                   &ctx);
+            for (uint64_t i = 0; i < expected_inner_ids.size(); ++i) {
+                reasoning_ctx->SetTrueDistance(expected_inner_ids[i], true_dists[i]);
+            }
+        }
+        ctx.reasoning_ctx = reasoning_ctx.get();
+    }
+
+    const bool collect_rabitq_lower_bounds = search_param.enable_rabitq_one_bit_search and
+                                             use_reorder_ and
+                                             base_codes_->SupportSplitCodeStorage();
+    DistanceRecordVector rabitq_lower_bound_candidates(ctx.alloc);
+    std::mutex rabitq_lower_bound_mutex;
+    SearchFunc search_func = [&](const IndexNode* node, const VisitedListPtr& vl) {
+        DistanceRecordVector local_candidates(ctx.alloc);
+        auto* candidates = collect_rabitq_lower_bounds ? &local_candidates : nullptr;
+        auto node_result = this->search_node(node,
+                                             vl,
+                                             search_param,
+                                             query,
+                                             base_codes_,
+                                             ctx,
+                                             parsed_param.subindex_ef_search,
+                                             candidates);
+        if (candidates != nullptr && not candidates->empty()) {
+            std::lock_guard lock(rabitq_lower_bound_mutex);
+            rabitq_lower_bound_candidates.insert(
+                rabitq_lower_bound_candidates.end(), candidates->begin(), candidates->end());
+        }
+        return node_result;
+    };
+
+    std::string hierarchy_name =
+        parsed_param.hierarchies.empty() ? "" : parsed_param.hierarchies[0];
+    auto result =
+        this->search_impl(query,
+                          search_func,
+                          search_param,
+                          ctx,
+                          hierarchy_name,
+                          collect_rabitq_lower_bounds ? &rabitq_lower_bound_candidates : nullptr);
+    if (is_knn) {
+        result = FilterDatasetByThreshold(result, request.threshold_, ctx.alloc, request.topk_);
+    }
+    result->Statistics(stats.Dump());
+
+    if (reasoning_ctx) {
+        Vector<InnerIdType> result_inner_ids(ctx.alloc);
+        const auto* result_ids = result->GetIds();
+        const auto num_results = result->GetDim();
+        result_inner_ids.reserve(static_cast<size_t>(num_results));
+        {
+            std::lock_guard lock(cur_element_count_mutex_);
+            for (int64_t i = 0; i < num_results && result_ids != nullptr; ++i) {
+                // `true` = return_even_removed: match the same behavior used for expected_labels.
+                auto [success, inner_id] = label_table_->TryGetIdByLabel(result_ids[i], true);
+                if (success) {
+                    result_inner_ids.push_back(inner_id);
+                }
+            }
+        }
+        reasoning_ctx->MarkResult(result_inner_ids);
+        reasoning_ctx->DiagnoseExpectedTargets();
+        result->Reasoning(reasoning_ctx->GenerateReport());
+    }
+
+    return result;
+}
+
+DatasetPtr
 Pyramid::search_impl(const DatasetPtr& query,
                      const SearchFunc& search_func,
                      InnerSearchParam& search_param,
@@ -465,16 +529,17 @@ Pyramid::search_impl(const DatasetPtr& query,
                    "query_path is required when level0 is not built");
     CHECK_ARGUMENT(query->GetFloat32Vectors() != nullptr, "query vectors is required");
 
-    DistHeapPtr search_result = std::make_shared<StandardHeap<true, false>>(allocator_, -1);
+    DistHeapPtr search_result = std::make_shared<StandardHeap<true, false>>(ctx.alloc, -1);
 
     std::shared_lock<std::shared_mutex> lock(resize_mutex_);
     VisitedListGuard vl_guard(pool_.get());
     const VisitedListPtr& vl = vl_guard.get();
     if (query_path != nullptr) {
         const std::string& current_path = query_path[0];
-        search_hierarchy(h, search_func, vl, search_result, current_path, search_param);
+        search_hierarchy(
+            h, search_func, vl, search_result, current_path, search_param, ctx.reasoning_ctx);
     } else {
-        h.root->Search(search_func, vl, search_result, search_param.ef);
+        h.root->Search(search_func, vl, search_result, search_param.ef, ctx.reasoning_ctx);
     }
 
     if (use_reorder_) {
@@ -502,10 +567,10 @@ Pyramid::search_impl(const DatasetPtr& query,
         result->Dim(0)->NumElements(1);
         return result;
     }
-    result->Dim(target_size)->NumElements(1)->Owner(true, allocator_);
-    auto* ids = static_cast<int64_t*>(allocator_->Allocate(sizeof(int64_t) * target_size));
+    result->Dim(target_size)->NumElements(1)->Owner(true, ctx.alloc);
+    auto* ids = static_cast<int64_t*>(ctx.alloc->Allocate(sizeof(int64_t) * target_size));
     result->Ids(ids);
-    auto* dists = static_cast<float*>(allocator_->Allocate(sizeof(float) * target_size));
+    auto* dists = static_cast<float*>(ctx.alloc->Allocate(sizeof(float) * target_size));
     result->Distances(dists);
     for (int64_t j = target_size - 1; j >= 0; --j) {
         dists[j] = search_result->Top().first;
@@ -1592,7 +1657,8 @@ Pyramid::search_hierarchy(const Hierarchy& h,
                           const VisitedListPtr& vl,
                           DistHeapPtr& search_result,
                           const std::string& path,
-                          const InnerSearchParam& search_param) const {
+                          const InnerSearchParam& search_param,
+                          ReasoningContext* reasoning_ctx) const {
     std::vector<std::future<void>> futures;
     auto parsed_path = parse_path(path);
     Vector<DistHeapPtr> search_result_lists(parsed_path.size(), allocator_);
@@ -1613,10 +1679,15 @@ Pyramid::search_hierarchy(const Hierarchy& h,
                 futures.push_back(thread_pool_->GeneralEnqueue([&, node, i]() -> void {
                     VisitedListGuard vl_guard(pool_.get());
                     const VisitedListPtr& local_vl = vl_guard.get();
-                    node->Search(search_func, local_vl, search_result_lists[i], search_param.ef);
+                    node->Search(search_func,
+                                 local_vl,
+                                 search_result_lists[i],
+                                 search_param.ef,
+                                 reasoning_ctx);
                 }));
             } else {
-                node->Search(search_func, vl, search_result_lists[i], search_param.ef);
+                node->Search(
+                    search_func, vl, search_result_lists[i], search_param.ef, reasoning_ctx);
             }
         }
     }
@@ -1658,7 +1729,7 @@ Pyramid::search_node(const IndexNode* node,
     DistHeapPtr results = nullptr;
 
     if (node->status_ == IndexNode::Status::FLAT) {
-        results = std::make_shared<StandardHeap<true, false>>(allocator_, -1);
+        results = std::make_shared<StandardHeap<true, false>>(ctx.alloc, -1);
         if (search_param.time_cost != nullptr and search_param.time_cost->CheckOvertime() and
             ctx.stats != nullptr) {
             ctx.stats->is_timeout.store(true, std::memory_order_relaxed);
@@ -1666,7 +1737,7 @@ Pyramid::search_node(const IndexNode* node,
         }
         const auto* ids_ptr = node->ids_.data();
         auto id_count = node->ids_.size();
-        Vector<InnerIdType> valid_ids(allocator_);
+        Vector<InnerIdType> valid_ids(ctx.alloc);
 
         if (search_param.is_inner_id_allowed != nullptr) {
             const auto& inner_filter = search_param.is_inner_id_allowed;
@@ -1674,17 +1745,22 @@ Pyramid::search_node(const IndexNode* node,
             for (uint64_t i = 0; i < id_count; ++i) {
                 if (inner_filter->CheckValid(ids_ptr[i])) {
                     valid_ids.push_back(ids_ptr[i]);
+                } else if (ctx.reasoning_ctx != nullptr) {
+                    ctx.reasoning_ctx->RecordFilterReject(ids_ptr[i]);
                 }
             }
             ids_ptr = valid_ids.data();
             id_count = valid_ids.size();
         }
 
-        Vector<float> dists(id_count, allocator_);
+        Vector<float> dists(id_count, ctx.alloc);
         auto computer = codes->FactoryComputer(query->GetFloat32Vectors());
         codes->Query(dists.data(), computer, ids_ptr, id_count, &ctx);
 
-        for (int i = 0; i < id_count; ++i) {
+        for (uint64_t i = 0; i < id_count; ++i) {
+            if (ctx.reasoning_ctx != nullptr) {
+                ctx.reasoning_ctx->RecordVisit(ids_ptr[i], dists[i], 0);
+            }
             if (search_param.distance_threshold.has_value() and
                 (not std::isfinite(dists[i]) ||
                  (not search_param.enable_reorder and
@@ -1693,6 +1769,9 @@ Pyramid::search_node(const IndexNode* node,
             }
             results->Push(dists[i], ids_ptr[i]);
             if (results->Size() > search_param.ef) {
+                if (ctx.reasoning_ctx != nullptr) {
+                    ctx.reasoning_ctx->RecordEviction(results->Top().second, 0);
+                }
                 results->Pop();
             }
         }

--- a/src/algorithm/pyramid/pyramid.cpp
+++ b/src/algorithm/pyramid/pyramid.cpp
@@ -26,6 +26,8 @@
 #include "impl/heap/standard_heap.h"
 #include "impl/odescent/odescent_graph_builder.h"
 #include "impl/pruning_strategy.h"
+#include "impl/reasoning/search_reasoning.h"
+#include "io/memory_io/memory_io_parameter.h"
 #include "quantization/rabitq_quantization/rabitq_quantizer_parameter.h"
 #include "query_context.h"
 #include "storage/empty_index_binary_set.h"
@@ -134,17 +136,6 @@ split(const std::string& str, char delimiter) {
 }
 
 static inline uint64_t
-get_suitable_max_degree(int64_t data_num) {
-    if (data_num < 100'000) {
-        return 24;
-    }
-    if (data_num < 1000'000) {
-        return 32;
-    }
-    return 64;
-}
-
-static inline uint64_t
 get_suitable_ef_search(int64_t topk, int64_t data_num, uint64_t subindex_ef_search = 50) {
     auto topk_float = static_cast<float>(topk);
     if (data_num < 1'000) {
@@ -159,149 +150,37 @@ get_suitable_ef_search(int64_t topk, int64_t data_num, uint64_t subindex_ef_sear
     return std::max(static_cast<uint64_t>(4.0F * topk_float), subindex_ef_search * 8);
 }
 
-IndexNode::IndexNode(Allocator* allocator,
-                     GraphInterfaceParamPtr graph_param,
-                     uint32_t index_min_size)
-    : ids_(allocator),
-      children_(allocator),
-      allocator_(allocator),
-      graph_param_(std::move(graph_param)),
-      index_min_size_(index_min_size) {
-}
+InnerSearchParam
+Pyramid::create_knn_search_param(const PyramidSearchParameters& parsed_param,
+                                 int64_t k,
+                                 const FilterPtr& filter) const {
+    CHECK_ARGUMENT(k > 0, fmt::format("k({}) must be greater than 0", k));
+    CHECK_ARGUMENT(parsed_param.hierarchy_op == PyramidSearchParameters::HierarchyOp::SINGLE,
+                   "multi-hierarchy search (union/intersection) is not yet implemented");
+    auto ef_search_threshold =
+        std::max<uint64_t>(AMPLIFICATION_FACTOR * k, static_cast<uint64_t>(1000));
+    CHECK_ARGUMENT(  // NOLINT
+        (1 <= parsed_param.ef_search) and (parsed_param.ef_search <= ef_search_threshold),
+        fmt::format(
+            "ef_search({}) must be in range [1, {}]", parsed_param.ef_search, ef_search_threshold));
 
-void
-IndexNode::Build(ODescent& odescent) {
-    std::unique_lock lock(mutex_);
-    // Build an index when the level corresponding to the current node requires indexing
-    if (not ids_.empty()) {
-        Init();
-    }
-    if (status_ == Status::GRAPH) {
-        entry_point_ = ids_[0];
-        odescent.SetMaxDegree(static_cast<int32_t>(graph_param_->max_degree_));
-        odescent.Build(ids_);
-        odescent.SaveGraph(graph_);
-        Vector<InnerIdType>(allocator_).swap(ids_);
-    }
-    for (const auto& item : children_) {
-        item.second->Build(odescent);
-    }
-}
-
-void
-IndexNode::AddChild(const std::string& key) {
-    // AddChild is not thread-safe; ensure thread safety in calls to it.
-    children_[key] = std::make_unique<IndexNode>(allocator_, graph_param_, index_min_size_);
-    children_[key]->level_ = level_ + 1;
-}
-
-IndexNode*
-IndexNode::GetChild(const std::string& key, bool need_init) {
-    std::unique_lock lock(mutex_);
-    auto result = children_.find(key);
-    if (result != children_.end()) {
-        return result->second.get();
-    }
-    if (not need_init) {
-        return nullptr;
-    }
-    AddChild(key);
-    return children_[key].get();
-}
-
-void
-IndexNode::Deserialize(StreamReader& reader) {
-    // deserialize `entry_point_`
-    StreamReader::ReadObj(reader, entry_point_);
-    // deserialize `level_`
-    StreamReader::ReadObj(reader, level_);
-    // deserialize `status_`
-    StreamReader::ReadObj(reader, status_);
-    if (status_ == Status::GRAPH) {
-        graph_ = std::make_shared<SparseGraphDataCell>(
-            std::dynamic_pointer_cast<SparseGraphDatacellParameter>(graph_param_), allocator_);
-        graph_->Deserialize(reader);
-    } else if (status_ == Status::FLAT) {
-        StreamReader::ReadVector(reader, ids_);
-    }
-    // deserialize `children`
-    uint64_t children_size = 0;
-    StreamReader::ReadObj(reader, children_size);
-    for (uint64_t i = 0; i < children_size; ++i) {
-        std::string key = StreamReader::ReadString(reader);
-        AddChild(key);
-        children_[key]->Deserialize(reader);
-    }
-}
-
-void
-IndexNode::Serialize(StreamWriter& writer) const {
-    // serialize `entry_point_`
-    StreamWriter::WriteObj(writer, entry_point_);
-    // serialize `level_`
-    StreamWriter::WriteObj(writer, level_);
-    // serialize `status_`
-    StreamWriter::WriteObj(writer, status_);
-    if (status_ == Status::GRAPH) {
-        graph_->Serialize(writer);
-    } else if (status_ == Status::FLAT) {
-        StreamWriter::WriteVector(writer, ids_);
-    }
-    // serialize `children`
-    uint64_t children_size = children_.size();
-    StreamWriter::WriteObj(writer, children_size);
-    for (const auto& item : children_) {
-        // calculate size of `key`
-        StreamWriter::WriteString(writer, item.first);
-        // calculate size of `content`
-        item.second->Serialize(writer);
-    }
-}
-void
-IndexNode::Init() {
-    if (status_ == Status::NO_INDEX) {
-        if (ids_.size() >= index_min_size_) {
-            if (not ids_.empty() and level_ != 0) {
-                auto new_max_degree = get_suitable_max_degree(static_cast<int64_t>(ids_.size()));
-                if (new_max_degree < graph_param_->max_degree_) {
-                    auto new_graph_param = std::make_shared<SparseGraphDatacellParameter>();
-                    new_graph_param->FromJson(graph_param_->ToJson());
-                    new_graph_param->max_degree_ =
-                        get_suitable_max_degree(static_cast<int64_t>(ids_.size()));
-                    graph_param_ = new_graph_param;
-                }
-            }
-            graph_ = std::make_shared<SparseGraphDataCell>(
-                std::dynamic_pointer_cast<SparseGraphDatacellParameter>(graph_param_), allocator_);
-            status_ = Status::GRAPH;
-        } else {
-            status_ = Status::FLAT;
-        }
-    }
-}
-
-void
-IndexNode::Search(const SearchFunc& search_func,
-                  const VisitedListPtr& vl,
-                  const DistHeapPtr& search_result,
-                  uint64_t ef_search) const {
-    bool has_index = false;
-    {
-        std::shared_lock lock(mutex_);
-        has_index = status_ != IndexNode::Status::NO_INDEX;
-    }
-    if (has_index) {
-        auto self_search_result = search_func(this, vl);
-        search_result->Merge(*self_search_result);
-        while (search_result->Size() > ef_search) {
-            search_result->Pop();
-        }
-        return;
+    InnerSearchParam search_param;
+    search_param.ef = std::max<uint64_t>(parsed_param.ef_search, static_cast<uint64_t>(k));
+    search_param.radius = std::numeric_limits<float>::max();
+    search_param.topk = k;
+    search_param.search_mode = KNN_SEARCH;
+    search_param.parallel_search_thread_count = parsed_param.parallel_search_thread_count;
+    if (this->support_duplicate_) {
+        search_param.consider_duplicate = true;
     }
 
-    for (const auto& [key, node] : children_) {
-        node->Search(search_func, vl, search_result, ef_search);
+    if (parsed_param.enable_time_record) {
+        search_param.time_cost = std::make_shared<Timer>();
+        search_param.time_cost->SetThreshold(parsed_param.timeout_ms);
     }
+
+    search_param.is_inner_id_allowed = this->create_search_filter(filter);
+    return search_param;
 }
 
 std::vector<int64_t>
@@ -312,6 +191,10 @@ Pyramid::build_by_odescent(const DatasetPtr& base) {
 
     resize(data_num);
     std::memcpy(label_table_->label_table_.data(), data_ids, sizeof(LabelType) * data_num);
+    label_table_->ResetRemap(data_num);
+    for (InnerIdType id = 0; id < static_cast<InnerIdType>(data_num); ++id) {
+        label_table_->InsertRemap(data_ids[id], id);
+    }
 
     base_codes_->BatchInsertVector(data_vectors, data_num);
     if (has_precise_reorder()) {
@@ -502,6 +385,126 @@ Pyramid::RangeSearch(const DatasetPtr& query,
                           hierarchy_name,
                           collect_rabitq_lower_bounds ? &rabitq_lower_bound_candidates : nullptr);
     result->Statistics(stats.Dump());
+    return result;
+}
+
+DatasetPtr
+Pyramid::SearchWithRequest(const SearchRequest& request) const {
+    SearchStatistics stats;
+    QueryContext ctx{.alloc = this->allocator_, .stats = &stats};
+    if (request.search_allocator_ != nullptr) {
+        ctx.alloc = request.search_allocator_;
+    }
+
+    const auto& query = request.query_;
+    CHECK_ARGUMENT(query != nullptr, "query dataset is required");
+    CHECK_ARGUMENT(query->GetFloat32Vectors() != nullptr, "query vectors is required");
+
+    const bool is_knn = request.mode_ == SearchMode::KNN_SEARCH;
+    if (is_knn) {
+        this->validate_knn_args(query, request.topk_);
+    } else {
+        CHECK_ARGUMENT(request.mode_ == SearchMode::RANGE_SEARCH, "unsupported search mode");
+        this->validate_range_args(query, request.radius_, request.limited_size_);
+    }
+
+    auto parsed_param = PyramidSearchParameters::FromJson(request.params_str_);
+    InnerSearchParam search_param;
+    if (is_knn) {
+        search_param = this->create_knn_search_param(parsed_param, request.topk_, request.filter_);
+    } else {
+        CHECK_ARGUMENT(parsed_param.hierarchy_op == PyramidSearchParameters::HierarchyOp::SINGLE,
+                       "multi-hierarchy search (union/intersection) is not yet implemented");
+        search_param.ef = parsed_param.ef_search;
+        search_param.radius = request.radius_ * RADIUS_EPSILON;
+        search_param.search_mode = RANGE_SEARCH;
+        search_param.parallel_search_thread_count = parsed_param.parallel_search_thread_count;
+        search_param.topk = request.limited_size_ == -1 ? std::numeric_limits<int64_t>::max()
+                                                        : request.limited_size_;
+        if (this->support_duplicate_) {
+            search_param.consider_duplicate = true;
+        }
+        if (parsed_param.enable_time_record) {
+            search_param.time_cost = std::make_shared<Timer>();
+            search_param.time_cost->SetThreshold(parsed_param.timeout_ms);
+        }
+        search_param.is_inner_id_allowed = this->create_search_filter(request.filter_);
+    }
+    SearchFunc search_func = [&](const IndexNode* node, const VisitedListPtr& vl) {
+        return this->search_node(
+            node, vl, search_param, query, base_codes_, ctx, parsed_param.subindex_ef_search);
+    };
+
+    // Setup reasoning context if expected labels are provided.
+    std::shared_ptr<ReasoningContext> reasoning_ctx;
+    if (is_knn && not request.expected_labels_.empty()) {
+        reasoning_ctx = std::make_shared<ReasoningContext>(ctx.alloc);
+        reasoning_ctx->SetSearchParams(
+            request.topk_, "Pyramid", use_reorder_, request.filter_ != nullptr);
+
+        UnorderedMap<int64_t, InnerIdType> label_to_inner_id(ctx.alloc);
+        Vector<InnerIdType> expected_inner_ids(ctx.alloc);
+        {
+            // Add holds this lock while mutating labels and vector storage.
+            std::lock_guard lock(cur_element_count_mutex_);
+            for (const auto& label : request.expected_labels_) {
+                // `true` = return_even_removed: include removed labels so reasoning can diagnose them.
+                auto [success, inner_id] = label_table_->TryGetIdByLabel(label, true);
+                if (success) {
+                    label_to_inner_id[label] = inner_id;
+                }
+            }
+            expected_inner_ids.reserve(label_to_inner_id.size());
+            for (const auto& [label, inner_id] : label_to_inner_id) {
+                expected_inner_ids.push_back(inner_id);
+            }
+            if (not expected_inner_ids.empty()) {
+                auto precise_flatten =
+                    this->precise_codes_ != nullptr ? this->precise_codes_ : this->base_codes_;
+                auto computer = precise_flatten->FactoryComputer(query->GetFloat32Vectors());
+                Vector<float> true_dists(expected_inner_ids.size(), ctx.alloc);
+                precise_flatten->Query(true_dists.data(),
+                                       computer,
+                                       expected_inner_ids.data(),
+                                       static_cast<InnerIdType>(expected_inner_ids.size()),
+                                       &ctx);
+                for (size_t i = 0; i < expected_inner_ids.size(); ++i) {
+                    reasoning_ctx->SetTrueDistance(expected_inner_ids[i], true_dists[i]);
+                }
+            }
+        }
+
+        Vector<int64_t> expected_labels_vec(
+            request.expected_labels_.begin(), request.expected_labels_.end(), ctx.alloc);
+        reasoning_ctx->InitializeExpectedTargets(expected_labels_vec, label_to_inner_id);
+        ctx.reasoning_ctx = reasoning_ctx.get();
+    }
+
+    std::string hierarchy_name =
+        parsed_param.hierarchies.empty() ? "" : parsed_param.hierarchies[0];
+    auto result = this->search_impl(query, search_func, search_param, ctx, hierarchy_name, nullptr);
+    result->Statistics(stats.Dump());
+
+    if (reasoning_ctx) {
+        Vector<InnerIdType> result_inner_ids(ctx.alloc);
+        const auto* result_ids = result->GetIds();
+        const auto num_results = result->GetNumElements();
+        result_inner_ids.reserve(static_cast<size_t>(num_results));
+        {
+            std::lock_guard lock(cur_element_count_mutex_);
+            for (int64_t i = 0; i < num_results; ++i) {
+                // `true` = return_even_removed: match the same behavior used for expected_labels.
+                auto [success, inner_id] = label_table_->TryGetIdByLabel(result_ids[i], true);
+                if (success) {
+                    result_inner_ids.push_back(inner_id);
+                }
+            }
+        }
+        reasoning_ctx->MarkResult(result_inner_ids);
+        reasoning_ctx->DiagnoseExpectedTargets();
+        result->Reasoning(reasoning_ctx->GenerateReport());
+    }
+
     return result;
 }
 
@@ -1522,6 +1525,8 @@ Pyramid::search_node(const IndexNode* node,
             for (uint64_t i = 0; i < id_count; ++i) {
                 if (inner_filter->CheckValid(ids_ptr[i])) {
                     valid_ids.push_back(ids_ptr[i]);
+                } else if (ctx.reasoning_ctx != nullptr) {
+                    ctx.reasoning_ctx->RecordFilterReject(ids_ptr[i]);
                 }
             }
             ids_ptr = valid_ids.data();
@@ -1533,6 +1538,9 @@ Pyramid::search_node(const IndexNode* node,
         codes->Query(dists.data(), computer, ids_ptr, id_count, &ctx);
 
         for (int i = 0; i < id_count; ++i) {
+            if (ctx.reasoning_ctx != nullptr) {
+                ctx.reasoning_ctx->RecordVisit(ids_ptr[i], dists[i], 0);
+            }
             if (search_param.distance_threshold.has_value() and
                 (not std::isfinite(dists[i]) ||
                  (not search_param.enable_reorder and
@@ -1541,6 +1549,9 @@ Pyramid::search_node(const IndexNode* node,
             }
             results->Push(dists[i], ids_ptr[i]);
             if (results->Size() > search_param.ef) {
+                if (ctx.reasoning_ctx != nullptr) {
+                    ctx.reasoning_ctx->RecordEviction(results->Top().second, 0);
+                }
                 results->Pop();
             }
         }

--- a/src/algorithm/pyramid/pyramid.h
+++ b/src/algorithm/pyramid/pyramid.h
@@ -29,6 +29,7 @@
 #include "impl/searcher/basic_searcher.h"
 #include "index_feature_list.h"
 #include "io/memory_io/memory_io_parameter.h"
+#include "pyramid_index_node.h"
 #include "pyramid_zparameters.h"
 #include "quantization/fp32_quantizer_parameter.h"
 #include "query_context.h"
@@ -36,80 +37,8 @@
 
 namespace vsag {
 
-class IndexNode;
-using SearchFunc = std::function<DistHeapPtr(const IndexNode* node, const VisitedListPtr& vl)>;
-
 std::vector<std::string>
 split(const std::string& str, char delimiter);
-
-/**
- * @brief IndexNode: a tree node in the Pyramid hierarchy.
- *
- * Each IndexNode optionally holds a small graph (when the number of ids
- * exceeds index_min_size_) and a map of child nodes keyed by path segment.
- * The tree structure mirrors the hierarchical path labels (e.g. "a/b/c")
- * assigned to vectors at insertion time.
- */
-class IndexNode {
-public:
-    enum class Status { NO_INDEX = 0, GRAPH = 1, FLAT = 2 };
-
-public:
-    IndexNode(Allocator* allocator_, GraphInterfaceParamPtr graph_param, uint32_t index_min_size);
-
-    /// Build the internal graph using ODescent over the stored ids.
-    void
-    Build(ODescent& odescent);
-
-    /// Allocate the graph storage if not yet done.
-    void
-    Init();
-
-    /**
-     * @brief Recursively search this node and its matching children.
-     *
-     * @param search_func  functor that searches a single node's graph;
-     *                     typically bound to the caller's query and ef.
-     * @param vl           visited-list for dedup across the recursion.
-     * @param search_result  output heap accumulating candidates.
-     * @param ef_search    expansion factor passed to the graph search.
-     */
-    void
-    Search(const SearchFunc& search_func,
-           const VisitedListPtr& vl,
-           const DistHeapPtr& search_result,
-           uint64_t ef_search) const;
-
-    void
-    AddChild(const std::string& key);
-
-    IndexNode*
-    GetChild(const std::string& key, bool need_init = false);
-
-    void
-    Serialize(StreamWriter& writer) const;
-
-    void
-    Deserialize(StreamReader& reader);
-
-    friend class Pyramid;
-    friend class PyramidAnalyzer;
-
-public:
-    GraphInterfacePtr graph_{nullptr};  // graph over the ids in this node
-    InnerIdType entry_point_{0};        // entry point for graph search
-    uint32_t level_{0};                 // depth in the tree (root = 0)
-    mutable std::shared_mutex mutex_;   // per-node lock for concurrent add/search
-
-    Vector<InnerIdType> ids_;          // internal ids stored at this node
-    uint32_t index_min_size_{0};       // threshold to trigger graph build
-    Status status_{Status::NO_INDEX};  // current build state
-
-private:
-    UnorderedMap<std::string, std::unique_ptr<IndexNode>> children_;  // keyed by path segment
-    Allocator* allocator_{nullptr};
-    GraphInterfaceParamPtr graph_param_{nullptr};
-};
 
 /**
  * @brief Pyramid: hierarchical graph index for path-labeled vectors.
@@ -253,6 +182,9 @@ public:
                 const FilterPtr& filter,
                 int64_t limited_size = -1) const override;
 
+    DatasetPtr
+    SearchWithRequest(const SearchRequest& request) const override;
+
     void
     Serialize(StreamWriter& writer) const override;
 
@@ -338,6 +270,11 @@ private:
                 const std::string& hierarchy_name,
                 const DistanceRecordVector* rabitq_lower_bound_candidates = nullptr) const;
 
+    InnerSearchParam
+    create_knn_search_param(const PyramidSearchParameters& parsed_param,
+                            int64_t k,
+                            const FilterPtr& filter) const;
+
     /// Probabilistic check: should total_count trigger a new entry-point update?
     bool
     is_update_entry_point(uint64_t total_count) {
@@ -394,7 +331,7 @@ private:
     bool support_duplicate_{false};                      // whether to allow duplicate ids
 
     mutable std::shared_mutex resize_mutex_;        // guards resize operations
-    std::mutex cur_element_count_mutex_;            // guards cur_element_count_ updates
+    mutable std::mutex cur_element_count_mutex_;    // guards cur_element_count_ updates
     std::string graph_type_{GRAPH_TYPE_VALUE_NSW};  // graph algorithm type
     bool default_rabitq_one_bit_search_{false};     // default split lower-bound search
 

--- a/src/algorithm/pyramid/pyramid.h
+++ b/src/algorithm/pyramid/pyramid.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 #include <utility>
 
 #include "algorithm/inner_index_interface.h"
@@ -30,6 +31,7 @@
 #include "impl/searcher/basic_searcher.h"
 #include "index_feature_list.h"
 #include "io/memory_io/memory_io_parameter.h"
+#include "pyramid_index_node.h"
 #include "pyramid_zparameters.h"
 #include "quantization/fp32_quantizer_parameter.h"
 #include "query_context.h"
@@ -37,80 +39,8 @@
 
 namespace vsag {
 
-class IndexNode;
-using SearchFunc = std::function<DistHeapPtr(const IndexNode* node, const VisitedListPtr& vl)>;
-
 std::vector<std::string>
 split(const std::string& str, char delimiter);
-
-/**
- * @brief IndexNode: a tree node in the Pyramid hierarchy.
- *
- * Each IndexNode optionally holds a small graph (when the number of ids
- * exceeds index_min_size_) and a map of child nodes keyed by path segment.
- * The tree structure mirrors the hierarchical path labels (e.g. "a/b/c")
- * assigned to vectors at insertion time.
- */
-class IndexNode {
-public:
-    enum class Status { NO_INDEX = 0, GRAPH = 1, FLAT = 2 };
-
-public:
-    IndexNode(Allocator* allocator_, GraphInterfaceParamPtr graph_param, uint32_t index_min_size);
-
-    /// Build the internal graph using ODescent over the stored ids.
-    void
-    Build(ODescent& odescent);
-
-    /// Allocate the graph storage if not yet done.
-    void
-    Init();
-
-    /**
-     * @brief Recursively search this node and its matching children.
-     *
-     * @param search_func  functor that searches a single node's graph;
-     *                     typically bound to the caller's query and ef.
-     * @param vl           visited-list for dedup across the recursion.
-     * @param search_result  output heap accumulating candidates.
-     * @param ef_search    expansion factor passed to the graph search.
-     */
-    void
-    Search(const SearchFunc& search_func,
-           const VisitedListPtr& vl,
-           const DistHeapPtr& search_result,
-           uint64_t ef_search) const;
-
-    void
-    AddChild(const std::string& key);
-
-    IndexNode*
-    GetChild(const std::string& key, bool need_init = false);
-
-    void
-    Serialize(StreamWriter& writer) const;
-
-    void
-    Deserialize(StreamReader& reader);
-
-    friend class Pyramid;
-    friend class PyramidAnalyzer;
-
-public:
-    GraphInterfacePtr graph_{nullptr};  // graph over the ids in this node
-    InnerIdType entry_point_{0};        // entry point for graph search
-    uint32_t level_{0};                 // depth in the tree (root = 0)
-    mutable std::shared_mutex mutex_;   // per-node lock for concurrent add/search
-
-    Vector<InnerIdType> ids_;          // internal ids stored at this node
-    uint32_t index_min_size_{0};       // threshold to trigger graph build
-    Status status_{Status::NO_INDEX};  // current build state
-
-private:
-    UnorderedMap<std::string, std::unique_ptr<IndexNode>> children_;  // keyed by path segment
-    Allocator* allocator_{nullptr};
-    GraphInterfaceParamPtr graph_param_{nullptr};
-};
 
 /**
  * @brief Pyramid: hierarchical graph index for path-labeled vectors.
@@ -264,6 +194,9 @@ public:
                 const FilterPtr& filter,
                 int64_t limited_size = -1) const override;
 
+    DatasetPtr
+    SearchWithRequest(const SearchRequest& request) const override;
+
     void
     Serialize(StreamWriter& writer) const override;
 
@@ -369,7 +302,8 @@ private:
                      const VisitedListPtr& vl,
                      DistHeapPtr& search_result,
                      const std::string& path,
-                     const InnerSearchParam& search_param) const;
+                     const InnerSearchParam& search_param,
+                     ReasoningContext* reasoning_ctx) const;
 
     /// Grow internal storage to accommodate new_max_capacity vectors.
     void
@@ -383,6 +317,12 @@ private:
                 QueryContext& ctx,
                 const std::string& hierarchy_name,
                 const DistanceRecordVector* rabitq_lower_bound_candidates = nullptr) const;
+
+    InnerSearchParam
+    create_knn_search_param(const PyramidSearchParameters& parsed_param,
+                            int64_t k,
+                            const FilterPtr& filter,
+                            const std::optional<float>& threshold = std::nullopt) const;
 
     /// Probabilistic check: should total_count trigger a new entry-point update?
     bool
@@ -471,7 +411,7 @@ private:
     bool support_duplicate_{false};                      // whether to allow duplicate ids
 
     mutable std::shared_mutex resize_mutex_;        // guards resize operations
-    std::mutex cur_element_count_mutex_;            // guards cur_element_count_ updates
+    mutable std::mutex cur_element_count_mutex_;    // guards cur_element_count_ updates
     std::string graph_type_{GRAPH_TYPE_VALUE_NSW};  // graph algorithm type
     bool default_rabitq_one_bit_search_{false};     // default split lower-bound search
 

--- a/src/algorithm/pyramid/pyramid_index_node.cpp
+++ b/src/algorithm/pyramid/pyramid_index_node.cpp
@@ -1,0 +1,191 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "pyramid_index_node.h"
+
+#include "datacell/sparse_graph_datacell.h"
+#include "impl/reasoning/search_reasoning.h"
+#include "storage/serialization.h"
+
+namespace vsag {
+
+static inline uint64_t
+get_suitable_max_degree(int64_t data_num) {
+    if (data_num < 100'000) {
+        return 24;
+    }
+    if (data_num < 1000'000) {
+        return 32;
+    }
+    return 64;
+}
+
+IndexNode::IndexNode(Allocator* allocator,
+                     GraphInterfaceParamPtr graph_param,
+                     uint32_t index_min_size)
+    : ids_(allocator),
+      children_(allocator),
+      allocator_(allocator),
+      graph_param_(std::move(graph_param)),
+      index_min_size_(index_min_size) {
+}
+
+void
+IndexNode::Build(ODescent& odescent) {
+    std::unique_lock lock(mutex_);
+    // Build an index when the level corresponding to the current node requires indexing
+    if (not ids_.empty()) {
+        Init();
+    }
+    if (status_ == Status::GRAPH) {
+        entry_point_ = ids_[0];
+        odescent.SetMaxDegree(static_cast<int32_t>(graph_param_->max_degree_));
+        odescent.Build(ids_);
+        odescent.SaveGraph(graph_);
+        Vector<InnerIdType>(allocator_).swap(ids_);
+    }
+    for (const auto& item : children_) {
+        item.second->Build(odescent);
+    }
+}
+
+void
+IndexNode::AddChild(const std::string& key) {
+    // AddChild is not thread-safe; ensure thread safety in calls to it.
+    children_[key] = std::make_unique<IndexNode>(allocator_, graph_param_, index_min_size_);
+    children_[key]->level_ = level_ + 1;
+}
+
+IndexNode*
+IndexNode::GetChild(const std::string& key, bool need_init) {
+    std::unique_lock lock(mutex_);
+    auto result = children_.find(key);
+    if (result != children_.end()) {
+        return result->second.get();
+    }
+    if (not need_init) {
+        return nullptr;
+    }
+    AddChild(key);
+    return children_[key].get();
+}
+
+void
+IndexNode::Deserialize(StreamReader& reader) {
+    // deserialize `entry_point_`
+    StreamReader::ReadObj(reader, entry_point_);
+    // deserialize `level_`
+    StreamReader::ReadObj(reader, level_);
+    // deserialize `status_`
+    StreamReader::ReadObj(reader, status_);
+    if (status_ == Status::GRAPH) {
+        graph_ = std::make_shared<SparseGraphDataCell>(
+            std::dynamic_pointer_cast<SparseGraphDatacellParameter>(graph_param_), allocator_);
+        graph_->Deserialize(reader);
+    } else if (status_ == Status::FLAT) {
+        StreamReader::ReadVector(reader, ids_);
+    }
+    // deserialize `children`
+    uint64_t children_size = 0;
+    StreamReader::ReadObj(reader, children_size);
+    for (uint64_t i = 0; i < children_size; ++i) {
+        std::string key = StreamReader::ReadString(reader);
+        AddChild(key);
+        children_[key]->Deserialize(reader);
+    }
+}
+
+void
+IndexNode::Serialize(StreamWriter& writer) const {
+    // serialize `entry_point_`
+    StreamWriter::WriteObj(writer, entry_point_);
+    // serialize `level_`
+    StreamWriter::WriteObj(writer, level_);
+    // serialize `status_`
+    StreamWriter::WriteObj(writer, status_);
+    if (status_ == Status::GRAPH) {
+        graph_->Serialize(writer);
+    } else if (status_ == Status::FLAT) {
+        StreamWriter::WriteVector(writer, ids_);
+    }
+    // serialize `children`
+    uint64_t children_size = children_.size();
+    StreamWriter::WriteObj(writer, children_size);
+    for (const auto& item : children_) {
+        // calculate size of `key`
+        StreamWriter::WriteString(writer, item.first);
+        // calculate size of `content`
+        item.second->Serialize(writer);
+    }
+}
+void
+IndexNode::Init() {
+    if (status_ == Status::NO_INDEX) {
+        if (ids_.size() >= index_min_size_) {
+            if (not ids_.empty() and level_ != 0) {
+                auto new_max_degree = get_suitable_max_degree(static_cast<int64_t>(ids_.size()));
+                if (new_max_degree < graph_param_->max_degree_) {
+                    auto new_graph_param = std::make_shared<SparseGraphDatacellParameter>();
+                    new_graph_param->FromJson(graph_param_->ToJson());
+                    new_graph_param->max_degree_ =
+                        get_suitable_max_degree(static_cast<int64_t>(ids_.size()));
+                    graph_param_ = new_graph_param;
+                }
+            }
+            graph_ = std::make_shared<SparseGraphDataCell>(
+                std::dynamic_pointer_cast<SparseGraphDatacellParameter>(graph_param_), allocator_);
+            status_ = Status::GRAPH;
+        } else {
+            status_ = Status::FLAT;
+        }
+    }
+}
+
+void
+IndexNode::Search(const SearchFunc& search_func,
+                  const VisitedListPtr& vl,
+                  const DistHeapPtr& search_result,
+                  uint64_t ef_search,
+                  ReasoningContext* reasoning_ctx) const {
+    bool has_index = false;
+    {
+        std::shared_lock lock(mutex_);
+        has_index = status_ != IndexNode::Status::NO_INDEX;
+    }
+    if (has_index) {
+        auto self_search_result = search_func(this, vl);
+        search_result->Merge(*self_search_result);
+        while (search_result->Size() > ef_search) {
+            if (reasoning_ctx != nullptr) {
+                reasoning_ctx->RecordEviction(search_result->Top().second, level_);
+            }
+            search_result->Pop();
+        }
+        return;
+    }
+
+    Vector<IndexNode*> children(allocator_);
+    {
+        std::shared_lock lock(mutex_);
+        children.reserve(children_.size());
+        for (const auto& [key, node] : children_) {
+            children.push_back(node.get());
+        }
+    }
+    for (const auto* node : children) {
+        node->Search(search_func, vl, search_result, ef_search, reasoning_ctx);
+    }
+}
+
+}  // namespace vsag

--- a/src/algorithm/pyramid/pyramid_index_node.cpp
+++ b/src/algorithm/pyramid/pyramid_index_node.cpp
@@ -1,0 +1,186 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "pyramid_index_node.h"
+
+#include "datacell/sparse_graph_datacell.h"
+#include "storage/serialization.h"
+
+namespace vsag {
+
+static inline uint64_t
+get_suitable_max_degree(int64_t data_num) {
+    if (data_num < 100'000) {
+        return 24;
+    }
+    if (data_num < 1000'000) {
+        return 32;
+    }
+    return 64;
+}
+
+IndexNode::IndexNode(Allocator* allocator,
+                     GraphInterfaceParamPtr graph_param,
+                     uint32_t index_min_size)
+    : ids_(allocator),
+      children_(allocator),
+      allocator_(allocator),
+      graph_param_(std::move(graph_param)),
+      index_min_size_(index_min_size) {
+}
+
+void
+IndexNode::Build(ODescent& odescent) {
+    std::unique_lock lock(mutex_);
+    // Build an index when the level corresponding to the current node requires indexing
+    if (not ids_.empty()) {
+        Init();
+    }
+    if (status_ == Status::GRAPH) {
+        entry_point_ = ids_[0];
+        odescent.SetMaxDegree(static_cast<int32_t>(graph_param_->max_degree_));
+        odescent.Build(ids_);
+        odescent.SaveGraph(graph_);
+        Vector<InnerIdType>(allocator_).swap(ids_);
+    }
+    for (const auto& item : children_) {
+        item.second->Build(odescent);
+    }
+}
+
+void
+IndexNode::AddChild(const std::string& key) {
+    // AddChild is not thread-safe; ensure thread safety in calls to it.
+    children_[key] = std::make_unique<IndexNode>(allocator_, graph_param_, index_min_size_);
+    children_[key]->level_ = level_ + 1;
+}
+
+IndexNode*
+IndexNode::GetChild(const std::string& key, bool need_init) {
+    std::unique_lock lock(mutex_);
+    auto result = children_.find(key);
+    if (result != children_.end()) {
+        return result->second.get();
+    }
+    if (not need_init) {
+        return nullptr;
+    }
+    AddChild(key);
+    return children_[key].get();
+}
+
+void
+IndexNode::Deserialize(StreamReader& reader) {
+    // deserialize `entry_point_`
+    StreamReader::ReadObj(reader, entry_point_);
+    // deserialize `level_`
+    StreamReader::ReadObj(reader, level_);
+    // deserialize `status_`
+    StreamReader::ReadObj(reader, status_);
+    if (status_ == Status::GRAPH) {
+        graph_ = std::make_shared<SparseGraphDataCell>(
+            std::dynamic_pointer_cast<SparseGraphDatacellParameter>(graph_param_), allocator_);
+        graph_->Deserialize(reader);
+    } else if (status_ == Status::FLAT) {
+        StreamReader::ReadVector(reader, ids_);
+    }
+    // deserialize `children`
+    uint64_t children_size = 0;
+    StreamReader::ReadObj(reader, children_size);
+    for (uint64_t i = 0; i < children_size; ++i) {
+        std::string key = StreamReader::ReadString(reader);
+        AddChild(key);
+        children_[key]->Deserialize(reader);
+    }
+}
+
+void
+IndexNode::Serialize(StreamWriter& writer) const {
+    // serialize `entry_point_`
+    StreamWriter::WriteObj(writer, entry_point_);
+    // serialize `level_`
+    StreamWriter::WriteObj(writer, level_);
+    // serialize `status_`
+    StreamWriter::WriteObj(writer, status_);
+    if (status_ == Status::GRAPH) {
+        graph_->Serialize(writer);
+    } else if (status_ == Status::FLAT) {
+        StreamWriter::WriteVector(writer, ids_);
+    }
+    // serialize `children`
+    uint64_t children_size = children_.size();
+    StreamWriter::WriteObj(writer, children_size);
+    for (const auto& item : children_) {
+        // calculate size of `key`
+        StreamWriter::WriteString(writer, item.first);
+        // calculate size of `content`
+        item.second->Serialize(writer);
+    }
+}
+void
+IndexNode::Init() {
+    if (status_ == Status::NO_INDEX) {
+        if (ids_.size() >= index_min_size_) {
+            if (not ids_.empty() and level_ != 0) {
+                auto new_max_degree = get_suitable_max_degree(static_cast<int64_t>(ids_.size()));
+                if (new_max_degree < graph_param_->max_degree_) {
+                    auto new_graph_param = std::make_shared<SparseGraphDatacellParameter>();
+                    new_graph_param->FromJson(graph_param_->ToJson());
+                    new_graph_param->max_degree_ =
+                        get_suitable_max_degree(static_cast<int64_t>(ids_.size()));
+                    graph_param_ = new_graph_param;
+                }
+            }
+            graph_ = std::make_shared<SparseGraphDataCell>(
+                std::dynamic_pointer_cast<SparseGraphDatacellParameter>(graph_param_), allocator_);
+            status_ = Status::GRAPH;
+        } else {
+            status_ = Status::FLAT;
+        }
+    }
+}
+
+void
+IndexNode::Search(const SearchFunc& search_func,
+                  const VisitedListPtr& vl,
+                  const DistHeapPtr& search_result,
+                  uint64_t ef_search) const {
+    bool has_index = false;
+    {
+        std::shared_lock lock(mutex_);
+        has_index = status_ != IndexNode::Status::NO_INDEX;
+    }
+    if (has_index) {
+        auto self_search_result = search_func(this, vl);
+        search_result->Merge(*self_search_result);
+        while (search_result->Size() > ef_search) {
+            search_result->Pop();
+        }
+        return;
+    }
+
+    Vector<IndexNode*> children(allocator_);
+    {
+        std::shared_lock lock(mutex_);
+        children.reserve(children_.size());
+        for (const auto& [key, node] : children_) {
+            children.push_back(node.get());
+        }
+    }
+    for (const auto* node : children) {
+        node->Search(search_func, vl, search_result, ef_search);
+    }
+}
+
+}  // namespace vsag

--- a/src/algorithm/pyramid/pyramid_index_node.h
+++ b/src/algorithm/pyramid/pyramid_index_node.h
@@ -1,0 +1,103 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "datacell/graph_interface.h"
+#include "impl/allocator/safe_allocator.h"
+#include "impl/heap/distance_heap.h"
+#include "impl/odescent/odescent_graph_builder.h"
+#include "utils/lock_strategy.h"
+#include "utils/visited_list.h"
+
+namespace vsag {
+
+class IndexNode;
+using SearchFunc = std::function<DistHeapPtr(const IndexNode* node, const VisitedListPtr& vl)>;
+
+/**
+ * @brief IndexNode: a tree node in the Pyramid hierarchy.
+ *
+ * Each IndexNode optionally holds a small graph (when the number of ids
+ * exceeds index_min_size_) and a map of child nodes keyed by path segment.
+ * The tree structure mirrors the hierarchical path labels (e.g. "a/b/c")
+ * assigned to vectors at insertion time.
+ */
+class IndexNode {
+public:
+    enum class Status { NO_INDEX = 0, GRAPH = 1, FLAT = 2 };
+
+public:
+    IndexNode(Allocator* allocator_, GraphInterfaceParamPtr graph_param, uint32_t index_min_size);
+
+    /// Build the internal graph using ODescent over the stored ids.
+    void
+    Build(ODescent& odescent);
+
+    /// Allocate the graph storage if not yet done.
+    void
+    Init();
+
+    /**
+     * @brief Recursively search this node and its matching children.
+     *
+     * @param search_func  functor that searches a single node's graph;
+     *                     typically bound to the caller's query and ef.
+     * @param vl           visited-list for dedup across the recursion.
+     * @param search_result  output heap accumulating candidates.
+     * @param ef_search    expansion factor passed to the graph search.
+     */
+    void
+    Search(const SearchFunc& search_func,
+           const VisitedListPtr& vl,
+           const DistHeapPtr& search_result,
+           uint64_t ef_search) const;
+
+    void
+    AddChild(const std::string& key);
+
+    IndexNode*
+    GetChild(const std::string& key, bool need_init = false);
+
+    void
+    Serialize(StreamWriter& writer) const;
+
+    void
+    Deserialize(StreamReader& reader);
+
+    friend class Pyramid;
+    friend class PyramidAnalyzer;
+
+public:
+    GraphInterfacePtr graph_{nullptr};  // graph over the ids in this node
+    InnerIdType entry_point_{0};        // entry point for graph search
+    uint32_t level_{0};                 // depth in the tree (root = 0)
+    mutable std::shared_mutex mutex_;   // per-node lock for concurrent add/search
+
+    Vector<InnerIdType> ids_;          // internal ids stored at this node
+    uint32_t index_min_size_{0};       // threshold to trigger graph build
+    Status status_{Status::NO_INDEX};  // current build state
+
+private:
+    UnorderedMap<std::string, std::unique_ptr<IndexNode>> children_;  // keyed by path segment
+    Allocator* allocator_{nullptr};
+    GraphInterfaceParamPtr graph_param_{nullptr};
+};
+
+}  // namespace vsag

--- a/src/algorithm/pyramid/pyramid_index_node.h
+++ b/src/algorithm/pyramid/pyramid_index_node.h
@@ -1,0 +1,105 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "datacell/graph_interface.h"
+#include "impl/allocator/safe_allocator.h"
+#include "impl/heap/distance_heap.h"
+#include "impl/odescent/odescent_graph_builder.h"
+#include "utils/lock_strategy.h"
+#include "utils/visited_list.h"
+
+namespace vsag {
+
+class IndexNode;
+class ReasoningContext;
+using SearchFunc = std::function<DistHeapPtr(const IndexNode* node, const VisitedListPtr& vl)>;
+
+/**
+ * @brief IndexNode: a tree node in the Pyramid hierarchy.
+ *
+ * Each IndexNode optionally holds a small graph (when the number of ids
+ * exceeds index_min_size_) and a map of child nodes keyed by path segment.
+ * The tree structure mirrors the hierarchical path labels (e.g. "a/b/c")
+ * assigned to vectors at insertion time.
+ */
+class IndexNode {
+public:
+    enum class Status { NO_INDEX = 0, GRAPH = 1, FLAT = 2 };
+
+public:
+    IndexNode(Allocator* allocator_, GraphInterfaceParamPtr graph_param, uint32_t index_min_size);
+
+    /// Build the internal graph using ODescent over the stored ids.
+    void
+    Build(ODescent& odescent);
+
+    /// Allocate the graph storage if not yet done.
+    void
+    Init();
+
+    /**
+     * @brief Recursively search this node and its matching children.
+     *
+     * @param search_func  functor that searches a single node's graph;
+     *                     typically bound to the caller's query and ef.
+     * @param vl           visited-list for dedup across the recursion.
+     * @param search_result  output heap accumulating candidates.
+     * @param ef_search    expansion factor passed to the graph search.
+     */
+    void
+    Search(const SearchFunc& search_func,
+           const VisitedListPtr& vl,
+           const DistHeapPtr& search_result,
+           uint64_t ef_search,
+           ReasoningContext* reasoning_ctx = nullptr) const;
+
+    void
+    AddChild(const std::string& key);
+
+    IndexNode*
+    GetChild(const std::string& key, bool need_init = false);
+
+    void
+    Serialize(StreamWriter& writer) const;
+
+    void
+    Deserialize(StreamReader& reader);
+
+    friend class Pyramid;
+    friend class PyramidAnalyzer;
+
+public:
+    GraphInterfacePtr graph_{nullptr};  // graph over the ids in this node
+    InnerIdType entry_point_{0};        // entry point for graph search
+    uint32_t level_{0};                 // depth in the tree (root = 0)
+    mutable std::shared_mutex mutex_;   // per-node lock for concurrent add/search
+
+    Vector<InnerIdType> ids_;          // internal ids stored at this node
+    uint32_t index_min_size_{0};       // threshold to trigger graph build
+    Status status_{Status::NO_INDEX};  // current build state
+
+private:
+    UnorderedMap<std::string, std::unique_ptr<IndexNode>> children_;  // keyed by path segment
+    Allocator* allocator_{nullptr};
+    GraphInterfaceParamPtr graph_param_{nullptr};
+};
+
+}  // namespace vsag

--- a/src/algorithm/pyramid/pyramid_test.cpp
+++ b/src/algorithm/pyramid/pyramid_test.cpp
@@ -508,6 +508,52 @@ TEST_CASE("Pyramid promotes flat node at index minimum size", "[ut][pyramid]") {
     }
 }
 
+TEST_CASE("Pyramid SearchWithRequest reports reasoning for expected labels",
+          "[ut][pyramid][reasoning]") {
+    auto test_index = MakePyramidIndex(100);
+    const auto& index = test_index.index;
+    std::array<float, PYRAMID_TEST_DIM* 2> vectors = {
+        0.0F, 0.0F, 0.0F, 0.0F, 10.0F, 0.0F, 0.0F, 0.0F};
+    std::array<int64_t, 2> ids = {100, 101};
+    std::array<std::string, 2> paths = {"tenant", "tenant"};
+    REQUIRE(index->Build(MakePyramidDataset(vectors.data(), ids.data(), paths.data(), 2)).empty());
+
+    auto query = MakePyramidDataset(vectors.data(), nullptr, paths.data(), 1);
+    vsag::SearchRequest request;
+    request.query_ = query;
+    request.topk_ = 1;
+    request.params_str_ = R"({"pyramid":{"ef_search":10}})";
+    request.expected_labels_ = {ids[0]};
+
+    auto result = index->SearchWithRequest(request);
+    REQUIRE(result != nullptr);
+    REQUIRE(result->GetIds()[0] == ids[0]);
+    REQUIRE(result->GetReasoning().find("1/1 expected labels found") != std::string::npos);
+    REQUIRE(result->GetReasoning().find("0 missed") != std::string::npos);
+
+    request.topk_ = 2;
+    request.expected_labels_ = {ids[0], ids[1]};
+    auto multi_result = index->SearchWithRequest(request);
+    REQUIRE(multi_result != nullptr);
+    REQUIRE(multi_result->GetDim() == 2);
+    REQUIRE(multi_result->GetReasoning().find("2/2 expected labels found") != std::string::npos);
+
+    request.threshold_ = 1.0F;
+    request.expected_labels_ = {ids[0]};
+    auto threshold_result = index->SearchWithRequest(request);
+    REQUIRE(threshold_result != nullptr);
+    REQUIRE(threshold_result->GetDim() == 1);
+    REQUIRE(threshold_result->GetIds()[0] == ids[0]);
+
+    request.expected_labels_.clear();
+    request.threshold_ = std::nullopt;
+    auto result_without_reasoning = index->SearchWithRequest(request);
+    REQUIRE(result_without_reasoning != nullptr);
+    REQUIRE(result_without_reasoning->GetIds()[0] == ids[0]);
+    REQUIRE(result_without_reasoning->GetReasoning().find("expected_analysis") ==
+            std::string::npos);
+}
+
 TEST_CASE("Pyramid MRLE split promotes flat nodes without raw vectors", "[ut][pyramid][MRLE]") {
     auto test_index = MakePyramidIndex(3, 4, false, false, true);
     const auto& index = test_index.index;


### PR DESCRIPTION
## Summary

Implement `SearchWithRequest` for the Pyramid index to integrate the reasoning mechanism.

## Changes

- Add `Pyramid::SearchWithRequest` override (`pyramid.h`/`pyramid.cpp`)
- Update `search_impl` to accept optional `QueryContext*` parameter
- Integrate `ReasoningContext` for expected labels tracking

## Behavior

When `expected_labels` is provided in `SearchRequest`, Pyramid generates a reasoning report diagnosing missed expected results:
- `not_reachable`, `filter_rejected`, `quantization_error`, `ef_too_small`, `reorder_evicted`

Zero overhead when `expected_labels` is empty.

## Testing

- All 39 existing Pyramid functests pass (113187 assertions)
- All 5 reasoning functests pass

Closes #2332