### PR TITLE
fix(hgraph): update parallel_searcher_ mutex in SetImmutable() [0.18 backport]

### DIFF
--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -2097,9 +2097,10 @@ HGraph::SetImmutable() {
         return;
     }
     std::scoped_lock<std::shared_mutex> wlock(this->global_mutex_);
-    this->neighbors_mutex_.reset();
-    this->neighbors_mutex_ = std::make_shared<EmptyMutex>();
-    this->searcher_->SetMutexArray(this->neighbors_mutex_);
+    auto empty_mutex = std::make_shared<EmptyMutex>();
+    this->searcher_->SetMutexArray(empty_mutex);
+    this->parallel_searcher_->SetMutexArray(empty_mutex);
+    this->neighbors_mutex_ = empty_mutex;
     this->immutable_ = true;
 }
 


### PR DESCRIPTION
## Change Type

- [x] Bug fix

## Linked Issue

- Fixes: #2334

## What Changed

Backport of #2329 to the 0.18 branch.

When `SetImmutable()` is called, `neighbors_mutex_` is replaced with `EmptyMutex` to optimize read-only search performance. However, only `searcher_` was updated, leaving `parallel_searcher_` with the old `PointsMutex` reference.

Fix by creating `EmptyMutex` first and assigning to both searchers before replacing `neighbors_mutex_`, also avoiding the temporary `nullptr` state from `reset()`.

```cpp
// Before:
this->neighbors_mutex_.reset();
this->neighbors_mutex_ = std::make_shared<EmptyMutex>();
this->searcher_->SetMutexArray(this->neighbors_mutex_);

// After:
auto empty_mutex = std::make_shared<EmptyMutex>();
this->searcher_->SetMutexArray(empty_mutex);
this->parallel_searcher_->SetMutexArray(empty_mutex);
this->neighbors_mutex_ = empty_mutex;
```

## Test Evidence

- [x] Code compiles successfully
- [x] `make fmt` passed
- Original fix validated on main branch (CI all green in #2329)

## Compatibility Impact

- API/ABI compatibility: none
- Behavior changes: parallel search now correctly uses EmptyMutex after SetImmutable()

## Performance and Concurrency Impact

- Performance impact: improved (removes unnecessary mutex locking in parallel search after SetImmutable)
- Concurrency/thread-safety impact: improved (eliminates temporary nullptr state of neighbors_mutex_)

## Documentation Impact

- [x] No docs update needed

## Risk and Rollback

- Risk level: low (1-file change, 4 lines added, 3 removed)
- Rollback plan: revert this commit

## Checklist

- [x] I have linked the relevant issue
- [x] My commit messages follow project conventions