### PR TITLE
docs: add Doxygen comments to InnerIndex subclass headers

### DIFF
--- a/src/algorithm/bruteforce/bruteforce.h
+++ b/src/algorithm/bruteforce/bruteforce.h
@@ -136,42 +136,74 @@ public:
     GetMemoryUsage() const override;
 
 private:
+    /**
+     * @brief Grow the capacity of inner_codes_ to at least new_size slots.
+     *
+     * Capacity grows arithmetically (by a fixed increment of 2^resize_increase_count_bit_) to
+     * amortise allocation cost.  Safe to call with a smaller value than the
+     * current capacity (no-op).
+     */
     void
     resize(uint64_t new_size);
 
+    /**
+     * @brief Reserve the next available internal slot for @p label.
+     *
+     * In single-vector mode the slot index equals total_count_.
+     * In multi-vector mode the slot is reserved only if @p label is new;
+     * attribute-based dedup is performed when @p attr is non-null.
+     *
+     * @return the allocated inner id, or std::nullopt if the label was
+     *         already present (multi-vector mode only).
+     */
     std::optional<InnerIdType>
     claim_slot(int64_t label, const AttributeSet* attr);
 
+    /**
+     * @brief Write one vector into inner_codes_ at position @p inner_id.
+     *
+     * The caller must have already called claim_slot() and resize().
+     */
     void
     add_one(const float* data, InnerIdType inner_id);
 
+    /**
+     * @brief Recalculate and cache the memory-usage counter.
+     *
+     * Called after Add/Build/Remove to keep GetMemoryUsage() cheap.
+     */
     void
     cal_memory_usage();
 
-    // Multi-vector mode helpers
+    /// Build the multi-vector label table and train the quantizer.
     void
     train_multi_vector(const DatasetPtr& data);
 
+    /// Insert multi-vector (WARP) data; returns failed external ids.
     std::vector<int64_t>
     add_multi_vector(const DatasetPtr& data);
 
+    /**
+     * @brief Create a Computer object sized for @p query, used by
+     *        KnnSearch / RangeSearch in multi-vector mode.
+     */
     ComputerInterfacePtr
     make_search_computer(const DatasetPtr& query) const;
 
 private:
-    FlattenInterfacePtr inner_codes_{nullptr};
+    FlattenInterfacePtr inner_codes_{nullptr};  // quantized or raw vector storage
 
-    std::atomic<uint64_t> delete_count_{0};
+    std::atomic<uint64_t> delete_count_{0};  // number of soft-deleted vectors
 
-    uint64_t resize_increase_count_bit_{DEFAULT_RESIZE_BIT};
+    uint64_t resize_increase_count_bit_{DEFAULT_RESIZE_BIT};  // log2 of capacity increment
 
-    mutable std::shared_mutex global_mutex_;
-    mutable std::shared_mutex add_mutex_;
+    mutable std::shared_mutex global_mutex_;  // protects reads during resize
+    mutable std::shared_mutex add_mutex_;     // serialises Add / Remove
 
-    std::atomic<InnerIdType> max_capacity_{0};
+    std::atomic<InnerIdType> max_capacity_{0};  // allocated slot count
 
-    bool is_multi_vector_{false};
+    bool is_multi_vector_{false};  // true ⇒ WARP / multi-vector mode
 
-    static constexpr uint64_t DEFAULT_RESIZE_BIT = 10;
+    static constexpr uint64_t DEFAULT_RESIZE_BIT = 10;  // default increment = 1024
 };
 }  // namespace vsag

--- a/src/algorithm/hgraph/hgraph.h
+++ b/src/algorithm/hgraph/hgraph.h
@@ -47,7 +47,13 @@
 
 namespace vsag {
 
-// HGraph index was introduced since v0.12
+/**
+ * @brief HGraph: hierarchical navigable graph index.
+ *
+ * Multi-layer NSW graph with bottom-level graph + optional upper route graphs.
+ * Supports quantized codes, reorder, attribute filtering, cache warm-start,
+ * force remove, and iterative search. Introduced since v0.12.
+ */
 class HGraph : public InnerIndexInterface {
 public:
     static ParamPtr
@@ -183,6 +189,7 @@ public:
     void
     Serialize(StreamWriter& writer) const override;
 
+    /// Set the number of threads used during Build().
     void
     SetBuildThreadsCount(uint64_t count) {
         this->build_thread_count_ = count;
@@ -215,9 +222,17 @@ public:
                     const AttributeSet& new_attrs,
                     const AttributeSet& origin_attrs) override;
 
+    /// Map hgraph JSON parameters (legacy helper for external param mapping).
     static JsonType
     map_hgraph_param(const JsonType& hgraph_json);
 
+    /**
+     * @brief Extract a pointer to the data vector at the given index.
+     *
+     * Dispatches on data_type_ to the correct typed getter on the dataset
+     * and offsets by `index * dim_`. Returns nullptr if the underlying
+     * pointer is absent.
+     */
     const void*
     get_data(const DatasetPtr& dataset, uint32_t index = 0) const {
         if (data_type_ == DataTypes::DATA_TYPE_FLOAT) {
@@ -237,6 +252,7 @@ public:
         throw VsagException(ErrorType::INVALID_ARGUMENT, "invalid data_type in HGraph");
     }
 
+    /// Sample a random level from the exponential distribution for a new node.
     int
     get_random_level() {
         std::uniform_real_distribution<double> distribution(0.0, 1.0);
@@ -272,27 +288,37 @@ public:
         return ret;
     }
 
+    /// Build all graphs (bottom + route) via ODescent in batch mode.
     std::vector<int64_t>
     build_by_odescent(const DatasetPtr& data);
 
+    /// Insert a single point into the graph(s) at the given level.
     void
     add_one_point(const void* data, int level, InnerIdType id);
 
+    /// Write codes for inner_id into the persistent flatten storage.
     void
     insert_persistent_codes(const void* data, InnerIdType inner_id);
 
+    /// Insert a single point, optionally also inserting codes.
     void
     add_one_point(const void* data, int level, InnerIdType id, bool insert_codes);
 
+    /// Core graph insertion: connect the new node and update neighbors.
+    /// Returns true if the entry point was updated.
     bool
     graph_add_one(const void* data, int level, InnerIdType inner_id);
 
+    /// Grow internal storage to at least new_size capacity.
     void
     resize(uint64_t new_size);
 
+    /// Create a single route (upper-layer) graph from the hierarchical params.
     GraphInterfacePtr
     generate_one_route_graph();
 
+    /// Search a single graph layer, returning a candidate distance heap.
+    /// @param ctx  may be nullptr during add (non-query) scenarios.
     template <InnerSearchMode mode = InnerSearchMode::KNN_SEARCH>
     DistHeapPtr
     search_one_graph(const void* query,
@@ -300,10 +326,10 @@ public:
                      const FlattenInterfacePtr& flatten,
                      InnerSearchParam& inner_search_param,
                      const VisitedListPtr& vt,
-                     // ctx can be nullptr in adding scenario
                      QueryContext* ctx,
                      DistanceRecordVector* rabitq_lower_bound_candidates = nullptr) const;
 
+    /// Overload that accepts an IteratorFilterContext for iterative search.
     template <InnerSearchMode mode = InnerSearchMode::KNN_SEARCH>
     DistHeapPtr
     search_one_graph(const void* query,
@@ -316,43 +342,53 @@ public:
                      DistanceRecordVector* rabitq_lower_bound_candidates = nullptr) const;
 
 private:
-    // since v0.15
+    // since v0.15: serialize basic index metadata to JSON.
     JsonType
     serialize_basic_info() const;
 
+    /// Restore basic index metadata from JSON.
     void
     deserialize_basic_info(const JsonType& jsonify_basic_info);
 
+    /// Write label (external id) mappings to stream.
     void
     serialize_label_info(StreamWriter& writer) const;
 
+    /// Read label (external id) mappings from stream.
     void
     deserialize_label_info(StreamReader& reader) const;
 
-    // used in version [0.12.*, 0.14.*]
+    /// Legacy serialize for version [0.12.*, 0.14.*].
     void
     serialize_basic_info_v0_14(StreamWriter& writer) const;
 
+    /// Legacy deserialize for version [0.12.*, 0.14.*].
     void
     deserialize_basic_info_v0_14(StreamReader& reader);
 
+    /// Force-remove a single label: physically delete from all graphs.
     uint32_t
     force_remove_one(int64_t label);
 
+    /// Scan all graphs to find a new entry point after the current one is removed.
     void
     find_new_entry_point();
 
+    /// Force-remove a single inner_id from a specific graph layer.
     void
     graph_force_remove_one(const InnerIdType& inner_id,
                            const FlattenInterfacePtr& flatten,
                            const GraphInterfacePtr& graph);
 
+    /// Move data at inner_id `from` to `to`, updating all references.
     void
     move_id(InnerIdType from, InnerIdType to);
 
+    /// Compact internal storage after deletions.
     void
     shrink_to_fit();
 
+    /// Flat brute-force search used when the index is too small or graph is unavailable.
     template <InnerSearchMode mode = InnerSearchMode::KNN_SEARCH>
     DistHeapPtr
     brute_force_search(const void* query,
@@ -362,6 +398,7 @@ private:
                        QueryContext* ctx) const;
 
 private:
+    /// Reorder the candidate heap using precise codes, updating in-place.
     void
     reorder(const void* query,
             const FlattenInterfacePtr& flatten,
@@ -371,35 +408,43 @@ private:
             QueryContext& ctx,
             const DistanceRecordVector* rabitq_lower_bound_candidates = nullptr) const;
 
+    /// Run ELP (Edge-Link Pruning) optimizer on the bottom graph.
     void
     elp_optimize();
 
+    /// Initialize raw_vector_ from the given parameter if needed.
     void
     check_and_init_raw_vector(const FlattenInterfaceParamPtr& raw_vector_param,
                               const IndexCommonParam& common_param,
                               bool is_create_new = true);
 
+    /// Compute resize_increase_count_bit_ and initialize reorder if enabled.
     void
     init_resize_bit_and_reorder();
 
+    /// Compute memory usage breakdown and cache the result.
     void
     cal_memory_usage();
 
+    /// True when reorder uses a separate high-precision flatten (not base codes).
     [[nodiscard]] bool
     has_precise_reorder() const {
         return use_reorder_ and not reorder_by_base_;
     }
 
+    /// True when force-remove is enabled.
     [[nodiscard]] bool
     support_force_remove() const {
         return support_force_remove_;
     }
 
+    /// Return the flatten used for reorder (base or high-precision).
     [[nodiscard]] FlattenInterfacePtr
     get_reorder_codes() const {
         return reorder_by_base_ ? basic_flatten_codes_ : high_precise_codes_;
     }
 
+    /// Populate the neighbor cache from the index state.
     void
     fullfill_cache() const;
 
@@ -418,47 +463,56 @@ private:
         return this->cache_ != nullptr && not this->cache_->neighbors_.empty();
     }
 
+    /// Build from imported cache: warm-start, refine, and rebuild route graphs.
     std::vector<int64_t>
     build_with_cache(const DatasetPtr& data);
 
-    // Internal scratch state shared across the 6 phases of build_with_cache.
-    // Each phase reads/writes a well-defined subset; threading this through
-    // a single struct keeps phase signatures small (1 ref instead of 8 outs)
-    // and makes the data flow explicit at a glance.
+    /// Internal scratch state shared across the 6 phases of build_with_cache.
+    /// Each phase reads/writes a well-defined subset; threading this through
+    /// a single struct keeps phase signatures small (1 ref instead of 8 outs)
+    /// and makes the data flow explicit at a glance.
     struct BuildCachePlan {
-        Vector<int64_t> valid_indices;
-        Vector<InnerIdType> inner_ids;
-        Vector<Vector<InnerIdType>> route_graph_ids;
-        std::vector<InnerIdType> inserted_inner_ids;
-        std::unordered_map<InnerIdType, uint32_t> inner_id_to_input_idx;
-        std::unordered_map<std::string, InnerIdType> source_id_to_new_inner;
-        std::vector<int64_t> failed_ids;
-        std::vector<InnerIdType> hit_ids;
-        std::vector<InnerIdType> missed_ids;
+        Vector<int64_t> valid_indices;                // input indices that pass filter
+        Vector<InnerIdType> inner_ids;                // allocated inner ids per valid input
+        Vector<Vector<InnerIdType>> route_graph_ids;  // ids assigned to each route graph level
+        std::vector<InnerIdType> inserted_inner_ids;  // all successfully inserted ids
+        std::unordered_map<InnerIdType, uint32_t> inner_id_to_input_idx;  // inner_id -> input index
+        std::unordered_map<std::string, InnerIdType>
+            source_id_to_new_inner;           // source_id -> inner_id
+        std::vector<int64_t> failed_ids;      // ids that failed insertion
+        std::vector<InnerIdType> hit_ids;     // nodes with cache hit (warm-started)
+        std::vector<InnerIdType> missed_ids;  // nodes without cache hit
 
         BuildCachePlan(Allocator* allocator)
             : valid_indices(allocator), inner_ids(allocator), route_graph_ids(allocator) {
         }
     };
 
+    /// Phase 1: collect valid input indices (serial).
     void
     cache_collect_valid_indices(const DatasetPtr& data, BuildCachePlan& plan);
 
+    /// Phase 2: set up metadata (ids, route graph assignment) (serial).
     void
     cache_setup_metadata_serial(const DatasetPtr& data, BuildCachePlan& plan);
 
+    /// Phase 3: encode all codes in parallel.
     void
     cache_encode_codes_parallel(const DatasetPtr& data, BuildCachePlan& plan);
 
+    /// Phase 4: warm-start neighbors from cache, classify nodes as hit/missed.
     void
     cache_warm_start_and_classify(BuildCachePlan& plan);
 
+    /// Phase 5: refine hit and missed nodes via two-phase parallel refine.
     void
     cache_run_refine_two_phase(const DatasetPtr& data, BuildCachePlan& plan);
 
+    /// Phase 6: rebuild route (upper-layer) graphs via ODescent.
     void
     cache_rebuild_route_graphs(BuildCachePlan& plan);
 
+    /// Collect refine candidates for a single node via graph search.
     DistHeapPtr
     collect_refine_candidates(const DatasetPtr& data,
                               InnerIdType inner_id,
@@ -467,6 +521,7 @@ private:
                               uint32_t refine_ef,
                               bool use_self_as_entry) const;
 
+    /// Select refined neighbors and their distances for a single node.
     void
     select_refine_neighbors_with_distances(const DatasetPtr& data,
                                            InnerIdType inner_id,
@@ -477,6 +532,7 @@ private:
                                            Vector<InnerIdType>& out_neighbors,
                                            Vector<float>& out_distances) const;
 
+    /// Refine a batch of nodes in two phases: parallel search+select, then serial writeback.
     void
     refine_nodes_two_phase(const DatasetPtr& data,
                            const std::vector<InnerIdType>& ids_to_refine,
@@ -488,73 +544,68 @@ private:
                            const std::unordered_map<InnerIdType, uint32_t>& inner_id_to_input_idx);
 
 private:
-    FlattenInterfacePtr basic_flatten_codes_{nullptr};
-    FlattenInterfacePtr high_precise_codes_{nullptr};
+    FlattenInterfacePtr basic_flatten_codes_{nullptr};  // coarse/quantized codes for graph search
+    FlattenInterfacePtr high_precise_codes_{nullptr};   // precise codes for reorder (optional)
 
-    Vector<GraphInterfacePtr> route_graphs_;
-    GraphInterfacePtr bottom_graph_{nullptr};
-    SparseGraphDatacellParamPtr hierarchical_datacell_param_{nullptr};
+    Vector<GraphInterfacePtr> route_graphs_;   // upper-layer route graphs
+    GraphInterfacePtr bottom_graph_{nullptr};  // base-level graph (all vectors)
+    SparseGraphDatacellParamPtr hierarchical_datacell_param_{nullptr};  // params for route graphs
 
-    bool use_elp_optimizer_{false};
-    bool ignore_reorder_{false};
-    bool build_by_base_{false};
-    bool reorder_by_base_{false};
+    bool use_elp_optimizer_{false};  // enable ELP edge-link pruning
+    bool ignore_reorder_{false};     // skip reorder even if configured
+    bool build_by_base_{false};      // build graph using base (not quantized) codes
+    bool reorder_by_base_{false};    // use base codes for reorder (no separate precise)
 
-    BasicSearcherPtr searcher_;
-    ParallelSearcherPtr parallel_searcher_;
+    BasicSearcherPtr searcher_;              // single-thread graph searcher
+    ParallelSearcherPtr parallel_searcher_;  // multi-thread graph searcher
 
-    std::default_random_engine level_generator_{2021};
-    double mult_{1.0};
+    std::default_random_engine level_generator_{
+        2021};          // random number generator for level sampling
+    double mult_{1.0};  // level multiplier (1/ln(max_degree))
 
-    InnerIdType entry_point_id_{INVALID_ENTRY_POINT};
+    InnerIdType entry_point_id_{INVALID_ENTRY_POINT};  // top-level entry point
 
-    ODescentParameterPtr odescent_param_{nullptr};
-    std::string graph_type_{GRAPH_TYPE_VALUE_NSW};
+    ODescentParameterPtr odescent_param_{nullptr};  // ODescent build parameters
+    std::string graph_type_{GRAPH_TYPE_VALUE_NSW};  // graph algorithm type
 
-    uint64_t ef_construct_{400};
-    float alpha_{1.0};
+    uint64_t ef_construct_{400};  // expansion factor during graph construction
+    float alpha_{1.0};            // Relative Neighborhood Graph pruning coefficient
 
-    std::shared_ptr<VisitedListPool> pool_{nullptr};
+    std::shared_ptr<VisitedListPool> pool_{nullptr};  // pool of visited-lists for search
 
-    mutable std::shared_mutex global_mutex_;
-    mutable MutexArrayPtr neighbors_mutex_;
-    mutable std::shared_mutex add_mutex_;
-    mutable std::shared_mutex force_remove_mutex_;
+    mutable std::shared_mutex global_mutex_;        // guards total_count_, entry_point_id_
+    mutable MutexArrayPtr neighbors_mutex_;         // per-node locks for neighbor lists
+    mutable std::shared_mutex add_mutex_;           // serializes Add() operations
+    mutable std::shared_mutex force_remove_mutex_;  // serializes force-remove operations
 
-    std::atomic<InnerIdType> max_capacity_{0};
+    std::atomic<InnerIdType> max_capacity_{0};  // allocated storage capacity
 
-    uint64_t resize_increase_count_bit_{
-        DEFAULT_RESIZE_BIT};  // 2^resize_increase_count_bit_ for resize count
+    uint64_t resize_increase_count_bit_{DEFAULT_RESIZE_BIT};  // log2(resize batch size)
 
-    static constexpr uint64_t DEFAULT_RESIZE_BIT = 10;
+    static constexpr uint64_t DEFAULT_RESIZE_BIT = 10;  // default resize batch = 1024
 
-    std::atomic<int64_t> delete_count_{0};
+    std::atomic<int64_t> delete_count_{0};  // number of force-removed vectors
 
-    std::shared_ptr<Optimizer<BasicSearcher>> optimizer_;
+    std::shared_ptr<Optimizer<BasicSearcher>> optimizer_;  // search parameter optimizer
 
-    bool create_new_raw_vector_{false};
-    FlattenInterfacePtr temporary_build_flatten_codes_{nullptr};
-    FlattenInterfacePtr raw_vector_{nullptr};
+    bool create_new_raw_vector_{false};  // whether a separate raw vector exists
+    FlattenInterfacePtr temporary_build_flatten_codes_{nullptr};  // temp flatten during build
+    FlattenInterfacePtr raw_vector_{nullptr};  // raw float vectors (for distance calc)
 
-    ReorderInterfacePtr reorder_{nullptr};
+    ReorderInterfacePtr reorder_{nullptr};  // reorder helper
 
-    bool use_old_serial_format_{false};
+    bool use_old_serial_format_{false};  // true when deserialized from legacy format
 
-    bool support_duplicate_{false};
-    bool support_force_remove_{false};
-    float duplicate_distance_threshold_{0.0F};
+    bool support_duplicate_{false};             // allow duplicate external ids
+    bool support_force_remove_{false};          // enable physical deletion
+    float duplicate_distance_threshold_{0.0F};  // distance threshold for duplicate detection
 
-    bool persist_source_id_{false};
+    bool persist_source_id_{false};  // whether to persist source_id in serialization
 
-    std::unique_ptr<HGraphCache> cache_{nullptr};
+    std::unique_ptr<HGraphCache> cache_{nullptr};  // neighbor cache for warm-start build
 
-    // Build-time warm-start cache hit statistics, populated by
-    // cache_warm_start_and_classify() when Build() takes the
-    // build_with_cache() path (i.e. after ImportCache()). A negative
-    // hit-rate marks "this index was not built from an imported cache",
-    // in which case GetStats() emits a skipped_reason instead of values.
-    float build_cache_hit_rate_{-1.0F};
-    uint64_t build_cache_hit_nodes_{0};
-    uint64_t build_cache_missed_nodes_{0};
+    float build_cache_hit_rate_{-1.0F};     // cache hit rate from last cache-based build
+    uint64_t build_cache_hit_nodes_{0};     // number of nodes with cache hit
+    uint64_t build_cache_missed_nodes_{0};  // number of nodes without cache hit
 };
 }  // namespace vsag

--- a/src/algorithm/ivf/ivf.h
+++ b/src/algorithm/ivf/ivf.h
@@ -33,7 +33,28 @@
 
 namespace vsag {
 
-// IVF index was introduced since v0.14
+/**
+ * @brief IVF: Inverted File index for dense vectors.
+ *
+ * IVF partitions the vector space into a configurable number of buckets
+ * (Voronoi cells) using a partition strategy (e.g. nearest-centroid or
+ * GNO-IMI).  Each vector is assigned to one or more buckets; at search
+ * time only the nprobe closest buckets are scanned, giving sub-linear
+ * complexity at the cost of some recall.
+ *
+ * Workflow:
+ *   1. Train() – build the partition centroids from a sample.
+ *   2. Add()   – assign incoming vectors to their bucket(s).
+ *   3. Search  – scan the nprobe nearest buckets, optionally reorder
+ *               with high-precision codes.
+ *
+ * Supports:
+ *   - Attribute-based filtering (via AttributeBucketInvertedDataCell).
+ *   - Merge of pre-built shards (Merge()).
+ *   - Reordering with a separate quantizer for better precision.
+ *
+ * @since v0.14
+ */
 class IVF : public InnerIndexInterface {
 public:
     static ParamPtr
@@ -152,13 +173,26 @@ public:
     GetMemoryUsage() const override;
 
 private:
+    /**
+     * @brief Parse the JSON search parameter string and populate an
+     *        InnerSearchParam (nprobe, ef_search, etc.).
+     */
     InnerSearchParam
     create_search_param(const std::string& parameters, const FilterPtr& filter) const;
 
+    /**
+     * @brief Scan the selected buckets and return a distance heap.
+     *
+     * @tparam mode  KNN_SEARCH or RANGE_SEARCH.
+     */
     template <InnerSearchMode mode = KNN_SEARCH>
     DistHeapPtr
     search(const DatasetPtr& query, const InnerSearchParam& param, QueryContext& ctx) const;
 
+    /**
+     * @brief Re-score the top candidates in @p input with high-precision
+     *        codes and return the final result Dataset.
+     */
     DatasetPtr
     reorder(int64_t topk,
             DistHeapPtr& input,
@@ -166,42 +200,54 @@ private:
             const InnerSearchParam& param,
             QueryContext& ctx) const;
 
+    /// Merge a single source shard into this index.
     void
     merge_one_unit(const MergeUnit& unit);
 
+    /// Validate that @p unit is compatible with this index's configuration.
     void
     check_merge_illegal(const MergeUnit& unit) const;
 
+    /// Populate location_map_ after deserialization or merge.
     void
     fill_location_map();
 
+    /**
+     * @brief Decode the packed (bucket_id, local_inner_id) pair from
+     *        location_map_[inner_id].
+     */
     std::pair<BucketIdType, InnerIdType>
     get_location(InnerIdType inner_id) const;
 
+    /// Recalculate and cache the memory-usage counter (throttled).
     void
     cal_memory_usage();
 
 private:
-    BucketInterfacePtr bucket_{nullptr};
+    BucketInterfacePtr bucket_{nullptr};  // bucket storage (raw or attribute-aware)
 
-    IVFPartitionStrategyPtr partition_strategy_{nullptr};
-    BucketIdType buckets_per_data_;
+    IVFPartitionStrategyPtr partition_strategy_{nullptr};  // centroid / partition logic
+    BucketIdType buckets_per_data_;                        // buckets each vector is assigned to
 
-    int64_t total_elements_{0};
-    bool is_trained_{false};
+    int64_t total_elements_{0};  // total inserted (incl. deleted)
+    bool is_trained_{false};     // true after Train() succeeds
 
-    FlattenInterfacePtr reorder_codes_{nullptr};
-    ReorderInterfacePtr reorder_{nullptr};
+    FlattenInterfacePtr reorder_codes_{nullptr};  // high-precision codes for reranking
+    ReorderInterfacePtr reorder_{nullptr};        // reordering engine
 
-    std::shared_ptr<SafeThreadPool> thread_pool_{nullptr};
+    std::shared_ptr<SafeThreadPool> thread_pool_{nullptr};  // for parallel bucket scans
 
+    /**
+     * Packed mapping: location_map_[inner_id] = (bucket_id << 32) | local_id.
+     * LOCATION_SPLIT_BIT controls the split position.
+     */
     Vector<uint64_t> location_map_;
 
-    static const uint64_t LOCATION_SPLIT_BIT = 32;
+    static const uint64_t LOCATION_SPLIT_BIT = 32;  // bit position of bucket/local split
 
     std::atomic<int64_t> delete_count_{0};
 
-    // last_cal_memory_element_ is used to avoid cal memory usage too frequently
+    // Throttle cal_memory_usage(): skip if element delta < interval
     int64_t last_cal_memory_element_{0};
     int64_t cal_memory_element_interval_{1024L};
 };

--- a/src/algorithm/lazy_hgraph/lazy_hgraph.h
+++ b/src/algorithm/lazy_hgraph/lazy_hgraph.h
@@ -26,8 +26,26 @@
 
 namespace vsag {
 
+/**
+ * @brief LazyHGraph: a two-phase adaptive index that starts as BruteForce
+ *        and transitions to HGraph when the dataset grows.
+ *
+ * LazyHGraph delays graph construction until the number of elements exceeds
+ * a configurable threshold.  During the FLAT phase all operations are served
+ * by a BruteForce sub-index; once the threshold is reached the index rebuilds
+ * itself as an HGraph.  This amortises the high fixed cost of graph
+ * construction for workloads that begin with very few vectors.
+ *
+ * @since v0.15
+ */
 class LazyHGraph : public InnerIndexInterface {
 public:
+    /**
+     * @brief Operational phase of the index.
+     *
+     * FLAT  – backed by BruteForce; low overhead, linear search.
+     * GRAPH – backed by HGraph; higher build cost, sub-linear search.
+     */
     enum class Phase : uint8_t { FLAT = 0, GRAPH = 1 };
 
     static ParamPtr
@@ -119,27 +137,43 @@ public:
     void
     Serialize(StreamWriter& writer) const override;
 
+    /**
+     * @brief Return the current operational phase.
+     *
+     * Thread-safe (acquire load on the atomic phase_).
+     */
     [[nodiscard]] Phase
     GetPhase() const {
         return phase_.load(std::memory_order_acquire);
     }
 
 private:
+    /**
+     * @brief Migrate data from the flat index to a new HGraph and switch
+     *        phase_ to GRAPH.  Idempotent after the first successful call.
+     */
     void
     TransitionToGraph();
 
+    /**
+     * @brief Return the raw pointer to the currently active sub-index.
+     *
+     * The caller must hold phase_mutex_ (read or write) while using the
+     * returned pointer because a concurrent TransitionToGraph() may
+     * destroy the flat_index_.
+     */
     InnerIndexInterface*
     ActiveIndex() const;
 
 private:
-    std::atomic<Phase> phase_{Phase::FLAT};
-    uint64_t transition_threshold_{1000};
-    BruteForceParameterPtr flat_param_{nullptr};
-    HGraphParameterPtr graph_param_{nullptr};
-    IndexCommonParam common_param_;
-    std::shared_ptr<BruteForce> flat_index_{nullptr};
-    std::shared_ptr<HGraph> graph_index_{nullptr};
-    mutable std::shared_mutex phase_mutex_;
+    std::atomic<Phase> phase_{Phase::FLAT};            // current phase
+    uint64_t transition_threshold_{1000};              // element count that triggers FLAT→GRAPH
+    BruteForceParameterPtr flat_param_{nullptr};       // config for the BruteForce sub-index
+    HGraphParameterPtr graph_param_{nullptr};          // config for the HGraph sub-index
+    IndexCommonParam common_param_;                    // shared index-wide parameters
+    std::shared_ptr<BruteForce> flat_index_{nullptr};  // active only in FLAT phase
+    std::shared_ptr<HGraph> graph_index_{nullptr};     // active only in GRAPH phase
+    mutable std::shared_mutex phase_mutex_;            // guards phase transitions
 };
 
 }  // namespace vsag

--- a/src/algorithm/pyramid/pyramid.h
+++ b/src/algorithm/pyramid/pyramid.h
@@ -42,6 +42,14 @@ using SearchFunc = std::function<DistHeapPtr(const IndexNode* node, const Visite
 std::vector<std::string>
 split(const std::string& str, char delimiter);
 
+/**
+ * @brief IndexNode: a tree node in the Pyramid hierarchy.
+ *
+ * Each IndexNode optionally holds a small graph (when the number of ids
+ * exceeds index_min_size_) and a map of child nodes keyed by path segment.
+ * The tree structure mirrors the hierarchical path labels (e.g. "a/b/c")
+ * assigned to vectors at insertion time.
+ */
 class IndexNode {
 public:
     enum class Status { NO_INDEX = 0, GRAPH = 1, FLAT = 2 };
@@ -49,12 +57,23 @@ public:
 public:
     IndexNode(Allocator* allocator_, GraphInterfaceParamPtr graph_param, uint32_t index_min_size);
 
+    /// Build the internal graph using ODescent over the stored ids.
     void
     Build(ODescent& odescent);
 
+    /// Allocate the graph storage if not yet done.
     void
     Init();
 
+    /**
+     * @brief Recursively search this node and its matching children.
+     *
+     * @param search_func  functor that searches a single node's graph;
+     *                     typically bound to the caller's query and ef.
+     * @param vl           visited-list for dedup across the recursion.
+     * @param search_result  output heap accumulating candidates.
+     * @param ef_search    expansion factor passed to the graph search.
+     */
     void
     Search(const SearchFunc& search_func,
            const VisitedListPtr& vl,
@@ -76,22 +95,28 @@ public:
     friend class PyramidAnalyzer;
 
 public:
-    GraphInterfacePtr graph_{nullptr};
-    InnerIdType entry_point_{0};
-    uint32_t level_{0};
-    mutable std::shared_mutex mutex_;
+    GraphInterfacePtr graph_{nullptr};  // graph over the ids in this node
+    InnerIdType entry_point_{0};        // entry point for graph search
+    uint32_t level_{0};                 // depth in the tree (root = 0)
+    mutable std::shared_mutex mutex_;   // per-node lock for concurrent add/search
 
-    Vector<InnerIdType> ids_;
-    uint32_t index_min_size_{0};
-    Status status_{Status::NO_INDEX};
+    Vector<InnerIdType> ids_;          // internal ids stored at this node
+    uint32_t index_min_size_{0};       // threshold to trigger graph build
+    Status status_{Status::NO_INDEX};  // current build state
 
 private:
-    UnorderedMap<std::string, std::unique_ptr<IndexNode>> children_;
+    UnorderedMap<std::string, std::unique_ptr<IndexNode>> children_;  // keyed by path segment
     Allocator* allocator_{nullptr};
     GraphInterfaceParamPtr graph_param_{nullptr};
 };
 
-// Pyramid index was introduced since v0.14
+/**
+ * @brief Pyramid: hierarchical graph index for path-labeled vectors.
+ *
+ * Organizes vectors into a tree of IndexNode graphs keyed by hierarchical
+ * path labels (e.g. "country/city"). Search traverses matching branches.
+ * Introduced since v0.14.
+ */
 class Pyramid : public InnerIndexInterface {
 public:
     static ParamPtr
@@ -230,21 +255,24 @@ public:
     friend class PyramidAnalyzer;
 
 private:
+    /// One named hierarchy with its own root IndexNode and build parameters.
     struct Hierarchy {
-        std::string name;
-        std::unique_ptr<IndexNode> root{nullptr};
-        Vector<int32_t> no_build_levels;
-        uint64_t ef_construction{400};
-        float alpha{1.2F};
+        std::string name;                          // hierarchy name (empty = default)
+        std::unique_ptr<IndexNode> root{nullptr};  // root node of the tree
+        Vector<int32_t> no_build_levels;           // depths where graph build is skipped
+        uint64_t ef_construction{400};             // expansion factor during graph build
+        float alpha{1.2F};  // Relative Neighborhood Graph pruning coefficient
 
         Hierarchy(const std::string& n, std::unique_ptr<IndexNode> r, Allocator* alloc)
             : name(n), root(std::move(r)), no_build_levels(alloc) {
         }
     };
 
+    /// Pre-create the IndexNode tree structure from the path labels.
     static void
     populate_path_tree(Hierarchy& h, const std::string* paths, int64_t count);
 
+    /// Insert vectors and their path labels into the hierarchy tree.
     void
     add_to_hierarchy(Hierarchy& h,
                      const float* data_vectors,
@@ -252,6 +280,7 @@ private:
                      const Vector<int64_t>& data_biases,
                      int64_t local_cur_element_count);
 
+    /// Search a single hierarchy along a path prefix, accumulating candidates.
     void
     search_hierarchy(const Hierarchy& h,
                      const SearchFunc& search_func,
@@ -260,15 +289,18 @@ private:
                      const std::string& path,
                      const InnerSearchParam& search_param) const;
 
+    /// Grow internal storage to accommodate new_max_capacity vectors.
     void
     resize(int64_t new_max_capacity);
 
+    /// Execute search across hierarchies and return results as a Dataset.
     DatasetPtr
     search_impl(const DatasetPtr& query,
                 const SearchFunc& search_func,
                 InnerSearchParam& search_param,
                 const std::string& hierarchy_name = "") const;
 
+    /// Probabilistic check: should total_count trigger a new entry-point update?
     bool
     is_update_entry_point(uint64_t total_count) {
         std::uniform_real_distribution<double> distribution(0.0, 1.0);
@@ -276,15 +308,19 @@ private:
         return static_cast<double>(total_count) * rand_value < 1.0;
     }
 
+    /// Build all hierarchy graphs via ODescent in batch mode.
     std::vector<int64_t>
     build_by_odescent(const DatasetPtr& base);
 
+    /// Recursively insert a single vector into the hierarchy tree.
     void
     add_one_point(const Hierarchy& h, IndexNode* node, InnerIdType inner_id, const float* vector);
 
+    /// Split a path string into its hierarchical segments.
     static std::vector<std::vector<std::string>>
     parse_path(const std::string& path);
 
+    /// Search a single IndexNode's graph, returning candidate heap.
     DistHeapPtr
     search_node(const IndexNode* node,
                 const VisitedListPtr& vl,
@@ -295,30 +331,30 @@ private:
                 uint64_t subindex_ef_search) const;
 
 private:
-    ODescentParameterPtr odescent_param_{nullptr};
-    UnorderedMap<std::string, std::unique_ptr<Hierarchy>> hierarchies_;
-    FlattenInterfacePtr base_codes_{nullptr};
-    FlattenInterfacePtr precise_codes_{nullptr};
-    std::unique_ptr<VisitedListPool> pool_ = nullptr;
+    ODescentParameterPtr odescent_param_{nullptr};  // ODescent build parameters
+    UnorderedMap<std::string, std::unique_ptr<Hierarchy>> hierarchies_;  // named hierarchies
+    FlattenInterfacePtr base_codes_{nullptr};          // coarse codes for graph build/search
+    FlattenInterfacePtr precise_codes_{nullptr};       // precise codes for reorder (if enabled)
+    std::unique_ptr<VisitedListPool> pool_ = nullptr;  // pool of visited-lists for search
 
-    MutexArrayPtr points_mutex_{nullptr};
-    std::unique_ptr<BasicSearcher> searcher_ = nullptr;
-    int64_t max_capacity_{0};
-    int64_t cur_element_count_{0};
-    std::atomic<int64_t> delete_count_{0};
-    bool support_duplicate_{false};
+    MutexArrayPtr points_mutex_{nullptr};                // per-point locks for concurrent access
+    std::unique_ptr<BasicSearcher> searcher_ = nullptr;  // graph traversal engine
+    int64_t max_capacity_{0};                            // allocated capacity
+    int64_t cur_element_count_{0};                       // number of vectors currently stored
+    std::atomic<int64_t> delete_count_{0};               // number of deleted vectors
+    bool support_duplicate_{false};                      // whether to allow duplicate ids
 
-    mutable std::shared_mutex resize_mutex_;
-    std::mutex cur_element_count_mutex_;
-    std::string graph_type_{GRAPH_TYPE_VALUE_NSW};
+    mutable std::shared_mutex resize_mutex_;        // guards resize operations
+    std::mutex cur_element_count_mutex_;            // guards cur_element_count_ updates
+    std::string graph_type_{GRAPH_TYPE_VALUE_NSW};  // graph algorithm type
 
-    std::mutex entry_point_mutex_;
-    std::default_random_engine level_generator_{2021};
-    ReorderInterfacePtr reorder_{nullptr};
+    std::mutex entry_point_mutex_;  // guards entry-point selection
+    std::default_random_engine level_generator_{
+        2021};                              // random number generator for level promotion
+    ReorderInterfacePtr reorder_{nullptr};  // reorder helper (if use_reorder_)
 
-    // static
-    uint32_t index_min_size_{0};
-    bool immutable_{false};
+    uint32_t index_min_size_{0};  // min node size before graph is built
+    bool immutable_{false};       // true after SetImmutable()
 };
 
 }  // namespace vsag

--- a/src/algorithm/sindi/sindi.h
+++ b/src/algorithm/sindi/sindi.h
@@ -23,6 +23,24 @@
 
 namespace vsag {
 
+/**
+ * @brief SINDI: Sparse INverted Index with windowed term lists.
+ *
+ * SINDI is designed for high-dimensional sparse vectors (e.g. learned sparse
+ * representations such as SPLADE).  The index partitions the internal-id
+ * space into fixed-size windows; each window maintains per-term inverted
+ * lists so that a query only touches the windows that overlap the query's
+ * non-zero dimensions.
+ *
+ * Optional features:
+ *  - Quantization: compress stored term values.
+ *  - Reranking: use an embedded SparseIndex for precise re-scoring.
+ *  - Term-id remapping: remap external dim-ids to a dense [0,N) range to
+ *    save memory when the vocabulary is sparse.
+ *
+ * Fork() is intentionally unsupported (returns nullptr) because the window
+ * layout depends on the insertion order and cannot be trivially cloned.
+ */
 class SINDI : public InnerIndexInterface {
 public:
     static ParamPtr
@@ -143,6 +161,18 @@ public:
     SetImmutable() override;
 
 private:
+    /**
+     * @brief Core search implementation shared by KnnSearch / RangeSearch.
+     *
+     * @tparam mode   KNN_SEARCH or RANGE_SEARCH.
+     * @param computer  evaluates partial IP contributions per window.
+     * @param inner_param  top-k / radius / ef parameters.
+     * @param allocator  scratch allocator for the result heap.
+     * @param use_term_lists_heap_insert  when true, accumulate candidates via
+     *                                    per-term heap insertion (faster for
+     *                                    very sparse queries).
+     * @param original_query  non-null only when reranking is needed.
+     */
     template <InnerSearchMode mode>
     DatasetPtr
     search_impl(const SparseTermComputerPtr& computer,
@@ -151,49 +181,61 @@ private:
                 bool use_term_lists_heap_insert,
                 const SparseVector* original_query = nullptr) const;
 
+    /**
+     * @brief Derive the [min_window_id, max_window_id] range that could
+     *        contain vectors passing @p filter.
+     */
     std::pair<int64_t, int64_t>
     get_min_max_window_id(const FilterPtr& filter) const;
 
+    /// Recalculate and cache the memory-usage counter.
     void
     cal_memory_usage();
 
+    /**
+     * @brief Compact a sparse vector's dim-ids into the remapped space
+     *        during Build.  Uses @p tmp_ids as scratch buffer.
+     */
     SparseVector
     remap_sparse_vector_for_build(const SparseVector& input, Vector<uint32_t>& tmp_ids);
 
+    /**
+     * @brief Map a query's dim-ids into the remapped space.
+     *
+     * Unlike the Build variant this does not mutate the index and uses
+     * @p tmp_ids / @p tmp_vals as scratch buffers.
+     */
     SparseVector
     remap_sparse_vector_for_query(const SparseVector& input,
                                   Vector<uint32_t>& tmp_ids,
                                   Vector<float>& tmp_vals) const;
 
 private:
-    mutable std::shared_mutex global_mutex_;
+    mutable std::shared_mutex global_mutex_;  // protects structural mutations
 
-    uint32_t term_id_limit_{0};
+    uint32_t term_id_limit_{0};  // max number of distinct terms per window
+    uint32_t window_size_{0};    // number of vectors per window
 
-    uint32_t window_size_{0};
+    Vector<SparseTermDataCellPtr> window_term_list_;  // one inverted list per window
 
-    Vector<SparseTermDataCellPtr> window_term_list_;
+    std::atomic<int64_t> cur_element_count_{0};  // total inserted vectors
+    std::atomic<int64_t> delete_count_{0};       // soft-deleted vectors
 
-    std::atomic<int64_t> cur_element_count_{0};
+    bool use_reorder_{false};       // enable reranking stage
+    bool use_quantization_{false};  // enable term-value quantization
 
-    std::atomic<int64_t> delete_count_{0};
+    float doc_retain_ratio_{0};  // ratio of docs kept after pruning
 
-    bool use_reorder_{false};
+    std::shared_ptr<SparseIndex> rerank_flat_index_{nullptr};  // re-rank back-end
 
-    bool use_quantization_{false};
-
-    float doc_retain_ratio_{0};
-
-    std::shared_ptr<SparseIndex> rerank_flat_index_{nullptr};
-
-    bool deserialize_without_footer_{false};
-    bool deserialize_without_buffer_{false};
+    bool deserialize_without_footer_{false};  // backward-compat: old format lacks footer
+    bool deserialize_without_buffer_{false};  // backward-compat: old format lacks buffer
 
     std::shared_ptr<QuantizationParams> quantization_params_;
-    uint32_t avg_doc_term_length_{100};
+    uint32_t avg_doc_term_length_{100};  // average non-zero terms per doc (estimation)
 
-    bool remap_term_ids_{false};
-    std::shared_ptr<TermIdMapper> term_id_mapper_{nullptr};
+    bool remap_term_ids_{false};                             // enable dense dim-id remapping
+    std::shared_ptr<TermIdMapper> term_id_mapper_{nullptr};  // maps external→internal ids
 };
 
 }  // namespace vsag

--- a/src/algorithm/sparse_index/sparse_index.h
+++ b/src/algorithm/sparse_index/sparse_index.h
@@ -21,6 +21,15 @@
 
 namespace vsag {
 
+/**
+ * @brief SparseIndex: a flat brute-force index for sparse vectors.
+ *
+ * Stores raw sparse vectors (dimension ids as uint32_t, values as float
+ * bit-cast into uint32_t) and performs exhaustive linear scan for KNN / range queries.
+ * Suitable as a reranking back-end for SINDI or for small sparse datasets.
+ *
+ * Distance metric: inner product (IP).
+ */
 class SparseIndex : public InnerIndexInterface {
 public:
     static ParamPtr
@@ -96,6 +105,18 @@ public:
     void
     InitFeatures() override;
 
+    /**
+     * @brief Compute the IP distance between a pre-sorted query and a stored
+     *        vector without acquiring any lock.
+     *
+     * The caller must guarantee that the index is not mutated concurrently
+     * and that inner_id < cur_element_count_.
+     *
+     * @param sorted_ids  sorted dimension ids of the query (uint32).
+     * @param sorted_vals corresponding values, parallel to sorted_ids.
+     * @param inner_id    internal id of the target vector.
+     * @return inner-product distance.
+     */
     float
     CalDistanceByIdUnsafe(Vector<uint32_t>& sorted_ids,
                           Vector<float>& sorted_vals,
@@ -104,9 +125,15 @@ public:
     int64_t
     GetMemoryUsage() const override;
 
+    /**
+     * @brief Pack a distance heap into a Dataset with (id, distance) pairs.
+     */
     DatasetPtr
     collect_results(const DistHeapPtr& results) const;
 
+    /**
+     * @brief Return a sorted copy of the given sparse vector by dimension id.
+     */
     std::tuple<Vector<uint32_t>, Vector<float>>
     sort_sparse_vector(const SparseVector& vector) const;
 
@@ -121,10 +148,11 @@ private:
     }
 
 private:
-    Vector<uint32_t*> datas_;
-    bool need_sort_;
-    int64_t cur_element_count_{0};
-    int64_t max_capacity_{0};
+    Vector<uint32_t*> datas_;       // raw sparse vectors; each entry encodes
+                                    // [dim_count, id0, val0_as_uint32, id1, val1_as_uint32, ...]
+    bool need_sort_;                // true if stored vectors may be unsorted by dim id
+    int64_t cur_element_count_{0};  // number of valid entries in datas_
+    int64_t max_capacity_{0};       // allocated capacity of datas_
 };
 
 }  // namespace vsag


### PR DESCRIPTION
## Summary

Add class-level documentation, method comments, and member variable inline comments to all 7 InnerIndex subclass headers:

- hgraph.h - hierarchical navigable graph index
- ivf.h - IVF with partition strategy
- bruteforce.h - brute-force flat index
- sindi.h - windowed sparse inverted index
- pyramid.h - hierarchical path-labeled graph index
- sparse_index.h - flat brute-force sparse index
- lazy_hgraph.h - lazy-build hgraph with phase transitions

## Changes

- Override methods receive minimal notes
- Non-override public methods receive full Doxygen @brief documentation
- Member variables receive trailing inline comments
- All files pass make fmt (clang-format-15)

## Stats

7 files changed, +419 / -152 lines (comments only, no logic changes)