### PR TITLE
ci: reuse ASan build artifacts for compatibility check

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -88,7 +88,7 @@ jobs:
         # ci-x86-openblas image to keep iteration latency low. The
         # build-from-source OpenBLAS path is exercised by the daily x86 ASan
         # job in daily_test.yml.
-        run: export CMAKE_GENERATOR="Ninja" CMAKE_EXPORT_COMPILE_COMMANDS=ON EXTRA_DEFINED="-DUSE_SYSTEM_OPENBLAS=ON"; make asan VSAG_ENABLE_EXAMPLES=ON
+        run: export CMAKE_GENERATOR="Ninja" CMAKE_EXPORT_COMPILE_COMMANDS=ON EXTRA_DEFINED="-DUSE_SYSTEM_OPENBLAS=ON"; make asan VSAG_ENABLE_EXAMPLES=ON VSAG_ENABLE_TOOLS=ON
       - name: Install clang-tidy 15
         run: sudo apt install clang-tidy-15 -y
       - name: Run Lint
@@ -101,7 +101,6 @@ jobs:
           find ./build -type f -name "*.a" -exec rm -f {} +
           rm -rf ./build/hdf5
           rm -rf ./build/boost
-          rm -rf ./build/tools
       - name: Save Build
         uses: actions/upload-artifact@v5
         with:
@@ -249,12 +248,16 @@ jobs:
 
   compatibility:
     name: Check Compatibility
-    needs: [changes, format]
+    needs: [changes, build-asan-x86]
     if: needs.changes.outputs.cpp == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: vsaglib/vsag:ci-x86-openblas
+      volumes:
+        - /opt:/useless
     steps:
+      - name: Free Disk Space
+        run: rm -rf /useless/hostedtoolcache
       - name: Install GitHub CLI
         env:
           GH_VERSION: 2.75.0
@@ -280,10 +283,17 @@ jobs:
             --pattern "*.json" \
             || echo "Warning: Failed to download compatibility indexes"
       - uses: actions/checkout@v4
-      - name: Compile Check Compatibility Tools
-        run: export CMAKE_GENERATOR="Ninja" EXTRA_DEFINED="-DUSE_SYSTEM_OPENBLAS=ON"; make release VSAG_ENABLE_TOOLS=ON
+      - name: Clean Env
+        run: rm -rf ./build
+      - name: Download Build
+        uses: actions/download-artifact@v5
+        with:
+          name: build-x86-${{ github.run_id }}
+          path: ./build
+      - name: Fix Permissions
+        run: chmod +x ./build/tools/check_compatibility/check_compatibility
       - name: Run Check Compatibility
-        run: bash ./scripts/check_compatibility.sh
+        run: BUILD_DIR=./build bash ./scripts/check_compatibility.sh
 
   test-python-x86:
     name: Test Python X86

--- a/scripts/check_compatibility.sh
+++ b/scripts/check_compatibility.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 
 compatibility_index_dir="${COMPATIBILITY_INDEX_DIR:-/tmp}"
+build_dir="${BUILD_DIR:-./build-release}"
+compatibility_tool="${build_dir}/tools/check_compatibility/check_compatibility"
+
+if [[ ! -x "${compatibility_tool}" ]]; then
+    echo "Error: Compatibility tool not found or not executable at ${compatibility_tool}" >&2
+    exit 1
+fi
 
 old_version_indexes=()
 shopt -s nullglob
@@ -21,7 +28,7 @@ all_success=true
 
 for version in "${old_version_indexes[@]}"; do
     echo "Checking compatibility for: $version"
-    if ! ./build-release/tools/check_compatibility/check_compatibility "$version"; then
+    if ! "${compatibility_tool}" "$version"; then
         echo "Error: Compatibility check failed for $version"
         all_success=false
         break


### PR DESCRIPTION
## Summary

Eliminate the redundant  build in the  job by reusing the  artifact.

## Changes

### 
- **build-asan-x86**: add  to compile  tool alongside the ASan build
- **build-asan-x86**: remove  from the Clean step to preserve the tools artifact
- **compatibility**: change  from  to 
- **compatibility**: replace  with  step
- **compatibility**: add ,  step for consistency with other container jobs

### 
- Parameterize build directory via  environment variable (default:  for backward compatibility)

## Why

 defaults to  (), and tools are gated by  (). So adding  to  is sufficient to build the compatibility tool in the ASan build, avoiding a full redundant Release build.