### PR TITLE
test: optimize TSAN CI test performance

### DIFF
--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -1710,9 +1710,14 @@ static void
 TestHGraphConcurrentAddSearchRemove(const fixtures::HGraphTestIndexPtr& test_index,
                                     const fixtures::HGraphResourcePtr& resource) {
     using namespace fixtures;
+    // Only reduce for PR variant (GetResource(true) gives 2 test cases)
+    if (resource->test_cases.size() <= 2) {
+        resource->test_cases = fixtures::RandomSelect(resource->test_cases, 1);
+    }
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
     auto search_param = fmt::format(fixtures::search_param_tmp, 200, false);
+    vsag::Options::Instance().set_block_size_limit(size);
 
     for (auto metric_type : resource->metric_types) {
         for (auto dim : resource->dims) {
@@ -1727,9 +1732,6 @@ TestHGraphConcurrentAddSearchRemove(const fixtures::HGraphTestIndexPtr& test_ind
                     dim = fixtures::RABITQ_MIN_RACALL_DIM;
                 }
 
-                // Set block size limit for current test iteration
-                vsag::Options::Instance().set_block_size_limit(size);
-
                 // Generate index parameters with attribute support enabled
                 HGraphTestIndex::HGraphBuildParam build_param(
                     metric_type, dim, base_quantization_str);
@@ -1740,11 +1742,10 @@ TestHGraphConcurrentAddSearchRemove(const fixtures::HGraphTestIndexPtr& test_ind
                     dim, resource->base_count, metric_type);
                 // Execute build test
                 TestIndex::TestConcurrentAddSearchRemove(index, dataset, search_param, true);
-                // Restore original block size limit
-                vsag::Options::Instance().set_block_size_limit(origin_size);
             }
         }
     }
+    vsag::Options::Instance().set_block_size_limit(origin_size);
 }
 
 HGRAPH_PR_DAILY_CASE("HGraph Concurrent Add Search Remove",

--- a/tests/test_hnsw.cpp
+++ b/tests/test_hnsw.cpp
@@ -453,27 +453,30 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex,
                              "[ft][build][hnsw][concurrent][build]") {
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
-    auto metric_type = GENERATE("l2", "ip", "cosine");
+    auto metric_types = fixtures::RandomSelect<std::string>({"l2", "ip", "cosine"}, 1);
+    auto selected_dims = fixtures::RandomSelect<int>(dims, 1);
     const std::string name = "hnsw";
     auto search_param = fmt::format(search_param_tmp, 100);
-    for (auto& dim : dims) {
-        vsag::Options::Instance().set_block_size_limit(size);
-        auto param = GenerateHNSWBuildParametersString(metric_type, dim);
-        auto index = TestFactory(name, param, true);
+    vsag::Options::Instance().set_block_size_limit(size);
+    for (auto& metric_type : metric_types) {
+        for (auto& dim : selected_dims) {
+            INFO(fmt::format("metric_type: {}, dim: {}", metric_type, dim));
+            auto param = GenerateHNSWBuildParametersString(metric_type, dim);
+            auto index = TestFactory(name, param, true);
 
-        auto dataset = pool.GetDatasetAndCreate(dim, base_count, metric_type);
-        TestConcurrentAdd(index, dataset, true);
-        TestKnnSearch(index, dataset, search_param, 0.95, true);
-        TestConcurrentKnnSearch(index, dataset, search_param, 0.95, true);
-        TestRangeSearch(index, dataset, search_param, 0.95, 10, true);
-        TestRangeSearch(index, dataset, search_param, 0.45, 5, true);
-        TestFilterSearch(index, dataset, search_param, 0.95, true);
-        if (index->CheckFeature(vsag::IndexFeature::SUPPORT_CHECK_ID_EXIST)) {
-            TestCheckIdExist(index, dataset);
+            auto dataset = pool.GetDatasetAndCreate(dim, base_count, metric_type);
+            TestConcurrentAdd(index, dataset, true);
+            TestKnnSearch(index, dataset, search_param, 0.95, true);
+            TestConcurrentKnnSearch(index, dataset, search_param, 0.95, true);
+            TestRangeSearch(index, dataset, search_param, 0.95, 10, true);
+            TestRangeSearch(index, dataset, search_param, 0.45, 5, true);
+            TestFilterSearch(index, dataset, search_param, 0.95, true);
+            if (index->CheckFeature(vsag::IndexFeature::SUPPORT_CHECK_ID_EXIST)) {
+                TestCheckIdExist(index, dataset);
+            }
         }
-
-        vsag::Options::Instance().set_block_size_limit(origin_size);
     }
+    vsag::Options::Instance().set_block_size_limit(origin_size);
 }
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Remove", "[ft][remove][hnsw]") {
@@ -640,24 +643,27 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex,
                              "[ft][build][hnsw][concurrent]") {
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
-    auto metric_type = GENERATE("l2", "ip", "cosine");
+    auto metric_types = fixtures::RandomSelect<std::string>({"l2", "ip", "cosine"}, 1);
+    auto selected_dims = fixtures::RandomSelect<int>(dims, 1);
     const std::string name = "hnsw";
     auto search_param = fmt::format(search_param_tmp, 100);
-    for (auto& dim : dims) {
-        vsag::Options::Instance().set_block_size_limit(size);
-        auto param = GenerateHNSWBuildParametersString(metric_type, dim);
-        auto index = TestFactory(name, param, true);
+    vsag::Options::Instance().set_block_size_limit(size);
+    for (auto& metric_type : metric_types) {
+        for (auto& dim : selected_dims) {
+            INFO(fmt::format("metric_type: {}, dim: {}", metric_type, dim));
+            auto param = GenerateHNSWBuildParametersString(metric_type, dim);
+            auto index = TestFactory(name, param, true);
 
-        auto dataset = pool.GetDatasetAndCreate(dim, base_count, metric_type);
-        TestDuplicateAdd(index, dataset);
-        TestKnnSearch(index, dataset, search_param, 0.99, true);
-        TestConcurrentKnnSearch(index, dataset, search_param, 0.99, true);
-        TestRangeSearch(index, dataset, search_param, 0.99, 10, true);
-        TestRangeSearch(index, dataset, search_param, 0.49, 5, true);
-        TestFilterSearch(index, dataset, search_param, 0.99, true);
-
-        vsag::Options::Instance().set_block_size_limit(origin_size);
+            auto dataset = pool.GetDatasetAndCreate(dim, base_count, metric_type);
+            TestDuplicateAdd(index, dataset);
+            TestKnnSearch(index, dataset, search_param, 0.99, true);
+            TestConcurrentKnnSearch(index, dataset, search_param, 0.99, true);
+            TestRangeSearch(index, dataset, search_param, 0.99, 10, true);
+            TestRangeSearch(index, dataset, search_param, 0.49, 5, true);
+            TestFilterSearch(index, dataset, search_param, 0.99, true);
+        }
     }
+    vsag::Options::Instance().set_block_size_limit(origin_size);
 }
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex,

--- a/tests/test_multi_thread.cpp
+++ b/tests/test_multi_thread.cpp
@@ -191,7 +191,7 @@ TEST_CASE("Test HNSW Multi-threading Read and Write", "[ft][hnsw][concurrent]") 
     vsag::Options::Instance().logger()->SetLevel(vsag::Logger::Level::kWARN);
 
     int dim = 16;
-    int max_elements = 5000;
+    int max_elements = 1000;
     int max_degree = 16;
     int ef_construction = 200;
     int ef_search = 100;
@@ -206,7 +206,7 @@ TEST_CASE("Test HNSW Multi-threading Read and Write", "[ft][hnsw][concurrent]") 
     std::shared_ptr<int64_t[]> ids(new int64_t[max_elements]);
     std::shared_ptr<float[]> data(new float[dim * max_elements]);
 
-    fixtures::ThreadPool pool(16);
+    fixtures::ThreadPool pool(4);
 
     // Generate random data
     std::mt19937 rng;
@@ -250,6 +250,9 @@ TEST_CASE("Test HNSW Multi-threading Read and Write", "[ft][hnsw][concurrent]") 
 
     for (int i = 0; i < max_elements; ++i) {
         REQUIRE(insert_results[i].get());
+    }
+    for (int i = 0; i < max_elements; ++i) {
+        REQUIRE(search_results[i].get());
     }
 }
 


### PR DESCRIPTION
## Summary

Reduce test coverage parameters for slow concurrent tests to speed up TSAN CI:

- **HNSW Concurrent Add**: random 1 metric × 1 dim (was 3 metrics × 2 dims = 6 iterations)
- **HNSW Duplicate Add**: random 1 metric × 1 dim (was 3 metrics × 2 dims = 6 iterations)  
- **HGraph Concurrent Add Search Remove**: 1 quantization type (was 2)
- **HNSW Multi-threading Read/Write**: 1000 elements with 4 threads (was 5000 elements with 16 threads)

## Expected Impact

TSAN CI test time: ~68min → ~31min (**-54% reduction**)

## Rationale

Analysis of recent 10 merged PRs shows these 4 tests account for ~75% of TSAN CI time:
- (PR) HGraph Concurrent Add Search Remove: ~17min avg
- HNSW Concurrent Add: ~15min avg
- HNSW Duplicate Add: ~12min avg
- Test HNSW Multi-threading Read and Write: ~7min avg

The changes maintain test validity while reducing redundant parameter combinations. Random selection ensures all metrics/dims/quantization types are tested across multiple CI runs.