### PR TITLE
feat: integrate reasoning into IVF search

### DIFF
--- a/src/algorithm/ivf/ivf.cpp
+++ b/src/algorithm/ivf/ivf.cpp
@@ -26,6 +26,7 @@
 #include "gno_imi_partition.h"
 #include "impl/heap/standard_heap.h"
 #include "impl/inner_search_param.h"
+#include "impl/reasoning/search_reasoning.h"
 #include "impl/reorder/flatten_reorder.h"
 #include "impl/searcher/basic_searcher.h"
 #include "index/index_impl.h"
@@ -687,9 +688,14 @@ IVF::reorder(int64_t topk,
              DistHeapPtr& input,
              const float* query,
              const InnerSearchParam& param,
-             QueryContext& ctx) const {
+             QueryContext& ctx,
+             ReasoningContext* reasoning_ctx) const {
     auto reorder_heap = reorder_->Reorder(input, query, topk, ctx);
-    return this->pack_knn_result(reorder_heap);
+    auto dataset_results = this->pack_knn_result(reorder_heap, ctx.alloc);
+
+    this->AttachReasoningReport(dataset_results, reasoning_ctx);
+
+    return dataset_results;
 }
 
 InnerIndexPtr
@@ -706,11 +712,17 @@ IVF::ExportModel(const IndexCommonParam& param) const {
 
 template <InnerSearchMode mode>
 DistHeapPtr
-IVF::search(const DatasetPtr& query, const InnerSearchParam& param, QueryContext& ctx) const {
+IVF::search(const DatasetPtr& query,
+            const InnerSearchParam& param,
+            QueryContext& ctx,
+            ReasoningContext* reasoning_ctx) const {
     const auto* query_data = query->GetFloat32Vectors();
     Vector<float> normalize_data(dim_, allocator_);
     auto candidate_buckets =
         partition_strategy_->ClassifyDatasForSearch(query_data, 1, param, &ctx);
+    if (reasoning_ctx != nullptr) {
+        reasoning_ctx->RecordBucketSelection(candidate_buckets);
+    }
     auto computer = bucket_->FactoryComputer(query_data);
 
     auto cur_heap_top = std::numeric_limits<float>::max();
@@ -771,7 +783,13 @@ IVF::search(const DatasetPtr& query, const InnerSearchParam& param, QueryContext
             }
             for (int j = 0; j < bucket_size; ++j) {
                 auto origin_id = ids[j] / buckets_per_data_;
+                if (reasoning_ctx != nullptr) {
+                    reasoning_ctx->RecordVisit(origin_id, dist[j], 0);
+                }
                 if (attr_ft != nullptr and not attr_ft->CheckValid(j)) {
+                    if (reasoning_ctx != nullptr) {
+                        reasoning_ctx->RecordFilterReject(origin_id);
+                    }
                     continue;
                 }
                 if (ft == nullptr or ft->CheckValid(origin_id)) {
@@ -785,11 +803,17 @@ IVF::search(const DatasetPtr& query, const InnerSearchParam& param, QueryContext
                         }
                     }
                     if (heap->Size() > topk) {
+                        if (reasoning_ctx != nullptr) {
+                            reasoning_ctx->RecordEviction(heap->Top().second / buckets_per_data_,
+                                                          0);
+                        }
                         heap->Pop();
                     }
                     if (not heap->Empty() and heap->Size() == topk) {
                         cur_heap_top = heap->Top().first;
                     }
+                } else if (reasoning_ctx != nullptr) {
+                    reasoning_ctx->RecordFilterReject(origin_id);
                 }
             }
         }
@@ -925,6 +949,42 @@ IVF::SearchWithRequest(const SearchRequest& request) const {
             param.executors.emplace_back(executor);
         }
     }
+    std::shared_ptr<ReasoningContext> reasoning_ctx;
+    if (not request.expected_labels_.empty()) {
+        reasoning_ctx = std::make_shared<ReasoningContext>(this->allocator_);
+        reasoning_ctx->SetSearchParams(
+            request.topk_, "IVF", use_reorder_, request.filter_ != nullptr);
+
+        UnorderedMap<int64_t, InnerIdType> label_to_inner_id(this->allocator_);
+        std::vector<std::tuple<InnerIdType, BucketIdType, InnerIdType>> locations;
+        {
+            std::shared_lock<std::shared_mutex> lock(this->label_lookup_mutex_);
+            locations.reserve(request.expected_labels_.size());
+            for (const auto& label : request.expected_labels_) {
+                auto [success, inner_id] = this->label_table_->TryGetIdByLabel(label, true);
+                if (success) {
+                    label_to_inner_id[label] = inner_id;
+                    auto [bucket_id, offset_id] = this->get_location(inner_id);
+                    locations.emplace_back(inner_id, bucket_id, offset_id);
+                }
+            }
+        }
+
+        Vector<int64_t> expected_labels_vec(this->allocator_);
+        expected_labels_vec.reserve(request.expected_labels_.size());
+        for (const auto& label : request.expected_labels_) {
+            expected_labels_vec.push_back(label);
+        }
+        reasoning_ctx->InitializeExpectedTargets(expected_labels_vec, label_to_inner_id);
+
+        const auto* query_data = query->GetFloat32Vectors();
+        auto computer = this->bucket_->FactoryComputer(query_data);
+        for (const auto& [inner_id, bucket_id, offset_id] : locations) {
+            float dist = this->bucket_->QueryOneById(computer, bucket_id, offset_id);
+            reasoning_ctx->SetTrueDistance(inner_id, dist);
+        }
+        ctx.reasoning_ctx = reasoning_ctx.get();
+    }
 
     if (is_range) {
         param.search_mode = RANGE_SEARCH;
@@ -937,16 +997,18 @@ IVF::SearchWithRequest(const SearchRequest& request) const {
             param.range_search_limit_size =
                 static_cast<int>(param.factor * static_cast<float>(request.limited_size_));
         }
-        auto search_result = this->search<RANGE_SEARCH>(query, param, ctx);
+        auto search_result = this->search<RANGE_SEARCH>(query, param, ctx, reasoning_ctx.get());
         if (use_reorder_ and param.enable_reorder) {
             int64_t k = (request.limited_size_ > 0) ? request.limited_size_
                                                     : static_cast<int64_t>(search_result->Size());
-            auto result = reorder(k, search_result, query->GetFloat32Vectors(), param, ctx);
+            auto result = reorder(
+                k, search_result, query->GetFloat32Vectors(), param, ctx, reasoning_ctx.get());
             result->Statistics(stats.Dump());
             return result;
         }
-        auto dataset_results = this->pack_knn_result(search_result);
+        auto dataset_results = this->pack_knn_result(search_result, ctx.alloc);
         dataset_results->Statistics(stats.Dump());
+        this->AttachReasoningReport(dataset_results, reasoning_ctx.get());
         return dataset_results;
     }
 
@@ -959,15 +1021,52 @@ IVF::SearchWithRequest(const SearchRequest& request) const {
             fmt::format("factor must be positive when use_reorder is true, got {}", param.factor));
         param.topk = static_cast<int64_t>(param.factor * static_cast<float>(request.topk_));
     }
-    auto search_result = this->search<KNN_SEARCH>(query, param, ctx);
+    auto search_result = this->search<KNN_SEARCH>(query, param, ctx, reasoning_ctx.get());
     if (use_reorder_ and param.enable_reorder) {
-        auto result = reorder(request.topk_, search_result, query->GetFloat32Vectors(), param, ctx);
+        auto result = reorder(request.topk_,
+                              search_result,
+                              query->GetFloat32Vectors(),
+                              param,
+                              ctx,
+                              reasoning_ctx.get());
         result->Statistics(stats.Dump());
         return result;
     }
-    auto dataset_results = this->pack_knn_result(search_result);
+    if (search_result == nullptr || search_result->Empty()) {
+        auto dataset_results = DatasetImpl::MakeEmptyDataset();
+        this->AttachReasoningReport(dataset_results, reasoning_ctx.get());
+        dataset_results->Statistics(stats.Dump());
+        return dataset_results;
+    }
+
+    auto dataset_results = this->pack_knn_result(search_result, ctx.alloc);
     dataset_results->Statistics(stats.Dump());
+
+    this->AttachReasoningReport(dataset_results, reasoning_ctx.get());
+
     return dataset_results;
+}
+
+void
+IVF::AttachReasoningReport(const DatasetPtr& dataset_results,
+                           ReasoningContext* reasoning_ctx) const {
+    if (reasoning_ctx == nullptr) {
+        return;
+    }
+    auto count = dataset_results->GetNumElements();
+    if (count > 0 and dataset_results->GetIds() != nullptr) {
+        Vector<InnerIdType> result_inner_ids(static_cast<uint64_t>(count), this->allocator_);
+        {
+            std::shared_lock<std::shared_mutex> lock(this->label_lookup_mutex_);
+            for (int64_t i = 0; i < count; ++i) {
+                result_inner_ids[i] =
+                    this->label_table_->GetIdByLabel(dataset_results->GetIds()[i]);
+            }
+        }
+        reasoning_ctx->MarkResult(result_inner_ids);
+    }
+    reasoning_ctx->DiagnoseExpectedTargets();
+    dataset_results->Reasoning(reasoning_ctx->GenerateReport());
 }
 
 void
@@ -1017,8 +1116,8 @@ IVF::CalDistanceById(const float* query,
             distances[i] = -1;
             continue;
         }
-        auto location = this->get_location(inner_id);
-        distances[i] = this->bucket_->QueryOneById(computer, location.first, location.second);
+        auto [bucket_id, offset_id] = this->get_location(inner_id);
+        distances[i] = this->bucket_->QueryOneById(computer, bucket_id, offset_id);
     }
     return result;
 }
@@ -1037,8 +1136,8 @@ IVF::CalcDistanceById(const float* query, int64_t id, bool calculate_precise_dis
         return dist;
     }
     auto computer = this->bucket_->FactoryComputer(query);
-    auto location = this->get_location(inner_id);
-    return this->bucket_->QueryOneById(computer, location.first, location.second);
+    auto [bucket_id, offset_id] = this->get_location(inner_id);
+    return this->bucket_->QueryOneById(computer, bucket_id, offset_id);
 }
 
 void

--- a/src/algorithm/ivf/ivf.h
+++ b/src/algorithm/ivf/ivf.h
@@ -187,7 +187,10 @@ private:
      */
     template <InnerSearchMode mode = KNN_SEARCH>
     DistHeapPtr
-    search(const DatasetPtr& query, const InnerSearchParam& param, QueryContext& ctx) const;
+    search(const DatasetPtr& query,
+           const InnerSearchParam& param,
+           QueryContext& ctx,
+           ReasoningContext* reasoning_ctx = nullptr) const;
 
     /**
      * @brief Re-score the top candidates in @p input with high-precision
@@ -198,7 +201,11 @@ private:
             DistHeapPtr& input,
             const float* query,
             const InnerSearchParam& param,
-            QueryContext& ctx) const;
+            QueryContext& ctx,
+            ReasoningContext* reasoning_ctx = nullptr) const;
+
+    void
+    AttachReasoningReport(const DatasetPtr& dataset_results, ReasoningContext* reasoning_ctx) const;
 
     /// Merge a single source shard into this index.
     void

--- a/src/impl/heap/memmove_heap.cpp
+++ b/src/impl/heap/memmove_heap.cpp
@@ -49,11 +49,16 @@ MemmoveHeap<max_heap, fixed_size>::Push(float dist, InnerIdType id) {
         }
     } else {
         DistanceRecord record = {dist, id};
-        auto pos =
-            std::upper_bound(
-                this->ordered_buffer_.begin(), this->ordered_buffer_.end(), record, CompareType()) -
-            this->ordered_buffer_.begin();
-        ordered_buffer_.emplace_back(record);
+        auto pos = std::upper_bound(this->ordered_buffer_.begin(),
+                                    this->ordered_buffer_.begin() + cur_size_,
+                                    record,
+                                    CompareType()) -
+                   this->ordered_buffer_.begin();
+        if (cur_size_ < static_cast<int64_t>(ordered_buffer_.size())) {
+            ordered_buffer_[cur_size_] = record;
+        } else {
+            ordered_buffer_.push_back(record);
+        }
         // NOLINTNEXTLINE(bugprone-undefined-memory-manipulation)
         memmove(ordered_buffer_.data() + pos + 1,
                 ordered_buffer_.data() + pos,

--- a/src/impl/reasoning/search_reasoning.cpp
+++ b/src/impl/reasoning/search_reasoning.cpp
@@ -21,7 +21,8 @@ ReasoningContext::ReasoningContext(Allocator* allocator)
       expected_inner_ids_(AllocatorWrapper<InnerIdType>(allocator)),
       expected_traces_(
           AllocatorWrapper<std::pair<const InnerIdType, ExpectedTargetTrace>>(allocator)),
-      reorder_changes_(AllocatorWrapper<ReorderRecord>(allocator)) {
+      reorder_changes_(AllocatorWrapper<ReorderRecord>(allocator)),
+      selected_buckets_(AllocatorWrapper<BucketIdType>(allocator)) {
 }
 
 ReasoningContext::~ReasoningContext() = default;
@@ -29,6 +30,7 @@ ReasoningContext::~ReasoningContext() = default;
 void
 ReasoningContext::InitializeExpectedTargets(
     const Vector<int64_t>& labels, const UnorderedMap<int64_t, InnerIdType>& label_to_inner_id) {
+    std::lock_guard<std::mutex> guard(mutex_);
     expected_inner_ids_.clear();
     expected_traces_.clear();
 
@@ -49,6 +51,7 @@ ReasoningContext::InitializeExpectedTargets(
 
 void
 ReasoningContext::SetTrueDistance(InnerIdType id, float dist) {
+    std::lock_guard<std::mutex> guard(mutex_);
     auto it = expected_traces_.find(id);
     if (it != expected_traces_.end()) {
         it.value().true_distance = dist;
@@ -57,6 +60,7 @@ ReasoningContext::SetTrueDistance(InnerIdType id, float dist) {
 
 void
 ReasoningContext::RecordVisit(InnerIdType id, float dist, uint32_t hop) {
+    std::lock_guard<std::mutex> guard(mutex_);
     auto it = expected_traces_.find(id);
     if (it != expected_traces_.end()) {
         it.value().was_visited = true;
@@ -69,6 +73,7 @@ ReasoningContext::RecordVisit(InnerIdType id, float dist, uint32_t hop) {
 
 void
 ReasoningContext::RecordEviction(InnerIdType id, uint32_t hop) {
+    std::lock_guard<std::mutex> guard(mutex_);
     auto it = expected_traces_.find(id);
     if (it != expected_traces_.end()) {
         it.value().was_evicted = true;
@@ -81,6 +86,7 @@ ReasoningContext::RecordEviction(InnerIdType id, uint32_t hop) {
 
 void
 ReasoningContext::RecordFilterReject(InnerIdType id) {
+    std::lock_guard<std::mutex> guard(mutex_);
     auto it = expected_traces_.find(id);
     if (it != expected_traces_.end()) {
         it.value().filter_rejected = true;
@@ -90,6 +96,7 @@ ReasoningContext::RecordFilterReject(InnerIdType id) {
 
 void
 ReasoningContext::RecordReorder(InnerIdType id, float dist_before, float dist_after) {
+    std::lock_guard<std::mutex> guard(mutex_);
     auto it = expected_traces_.find(id);
     if (it == expected_traces_.end()) {
         return;
@@ -107,6 +114,7 @@ ReasoningContext::RecordReorder(InnerIdType id, float dist_before, float dist_af
 
 void
 ReasoningContext::RecordReorderEviction(InnerIdType id, uint32_t hop) {
+    std::lock_guard<std::mutex> guard(mutex_);
     auto it = expected_traces_.find(id);
     if (it != expected_traces_.end()) {
         it.value().reorder_evicted = true;
@@ -119,11 +127,19 @@ ReasoningContext::RecordReorderEviction(InnerIdType id, uint32_t hop) {
 
 void
 ReasoningContext::SetTermination(const std::string& reason) {
+    std::lock_guard<std::mutex> guard(mutex_);
     termination_reason_ = reason;
 }
 
 void
+ReasoningContext::RecordBucketSelection(const Vector<BucketIdType>& buckets) {
+    std::lock_guard<std::mutex> guard(mutex_);
+    selected_buckets_ = buckets;
+}
+
+void
 ReasoningContext::MarkResult(const Vector<InnerIdType>& result_ids) {
+    std::lock_guard<std::mutex> guard(mutex_);
     for (const auto& id : result_ids) {
         auto it = expected_traces_.find(id);
         if (it != expected_traces_.end()) {
@@ -134,6 +150,7 @@ ReasoningContext::MarkResult(const Vector<InnerIdType>& result_ids) {
 
 void
 ReasoningContext::DiagnoseExpectedTargets() {
+    std::lock_guard<std::mutex> guard(mutex_);
     for (auto it = expected_traces_.begin(); it != expected_traces_.end(); ++it) {
         it.value().diagnosis = DiagnoseTarget(it.value());
     }
@@ -170,6 +187,7 @@ ReasoningContext::DiagnoseTarget(const ExpectedTargetTrace& trace) {
 
 std::string
 ReasoningContext::GenerateReport() const {
+    std::lock_guard<std::mutex> guard(mutex_);
     JsonType report;
     JsonType missed_targets = JsonType::Parse("[]");
 
@@ -205,6 +223,18 @@ ReasoningContext::GenerateReport() const {
     report["expected_analysis"]["summary"].SetString(summary);
     report["expected_analysis"]["missed_targets"].SetJson(missed_targets);
 
+    if (not selected_buckets_.empty()) {
+        JsonType bucket_array = JsonType::Parse("[]");
+        for (const auto bucket_id : selected_buckets_) {
+            JsonType bucket_json;
+            bucket_json.SetInt(static_cast<int64_t>(bucket_id));
+            bucket_array.AppendJson(bucket_json);
+        }
+        report["bucket_selection"]["selected_bucket_count"].SetInt(
+            static_cast<int64_t>(selected_buckets_.size()));
+        report["bucket_selection"]["selected_buckets"].SetJson(bucket_array);
+    }
+
     return report.Dump();
 }
 
@@ -213,6 +243,7 @@ ReasoningContext::SetSearchParams(int64_t topk,
                                   const std::string& index_type,
                                   bool use_reorder,
                                   bool filter_active) {
+    std::lock_guard<std::mutex> guard(mutex_);
     topk_ = topk;
     index_type_ = index_type;
     use_reorder_ = use_reorder;
@@ -221,11 +252,13 @@ ReasoningContext::SetSearchParams(int64_t topk,
 
 void
 ReasoningContext::AddSearchHop() {
+    std::lock_guard<std::mutex> guard(mutex_);
     total_hops_++;
 }
 
 void
 ReasoningContext::AddDistanceComputation(uint32_t count) {
+    std::lock_guard<std::mutex> guard(mutex_);
     total_dist_computations_ += count;
 }
 

--- a/src/impl/reasoning/search_reasoning.h
+++ b/src/impl/reasoning/search_reasoning.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <cstdint>
+#include <mutex>
 #include <string>
 
 #include "impl/allocator/allocator_wrapper.h"
@@ -81,6 +82,8 @@ public:
 
     void
     DiagnoseExpectedTargets();
+    void
+    RecordBucketSelection(const Vector<BucketIdType>& buckets);
 
     std::string
     GenerateReport() const;
@@ -114,9 +117,11 @@ public:
     UnorderedSet<InnerIdType> expected_inner_ids_;
     UnorderedMap<InnerIdType, ExpectedTargetTrace> expected_traces_;
     Vector<ReorderRecord> reorder_changes_;
+    Vector<BucketIdType> selected_buckets_;
 
 private:
     Allocator* allocator_{nullptr};
+    mutable std::mutex mutex_;
 
     static std::string
     DiagnoseTarget(const ExpectedTargetTrace& trace);

--- a/tests/test_ivf.cpp
+++ b/tests/test_ivf.cpp
@@ -1449,3 +1449,145 @@ TestIVFGNOIMIBuildWithResidual(const fixtures::IVFResourcePtr& resource) {
 IVF_PR_DAILY_CASE("IVF GNO-IMI Build with Residual",
                   "[ft][build][ivf]",
                   TestIVFGNOIMIBuildWithResidual)
+
+// RejectAllFilter for testing empty results
+class RejectAllFilter : public vsag::Filter {
+public:
+    bool
+    CheckValid(int64_t) const override {
+        return false;
+    }
+    bool
+    CheckValid(const char*) const override {
+        return false;
+    }
+};
+
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::IVFTestIndex,
+                             "IVF Reasoning Basic",
+                             "[ft][ivf][reasoning][pr]") {
+    auto dim = 32;
+    auto metric = "l2";
+    auto param = IVFTestIndex::GenerateIVFBuildParametersString(metric, dim, "fp32", 10);
+    auto index = TestIndex::TestFactory(IVFTestIndex::name, param, true);
+    auto dataset = IVFTestIndex::pool.GetDatasetAndCreate(dim, 200, metric);
+    TestIndex::TestBuildIndex(index, dataset, true);
+
+    auto query = vsag::Dataset::Make();
+    query->NumElements(1)
+        ->Dim(dim)
+        ->Float32Vectors(dataset->base_->GetFloat32Vectors())
+        ->Owner(false);
+
+    vsag::SearchRequest req;
+    req.topk_ = 5;
+    req.params_str_ = fmt::format(fixtures::search_param_tmp, 10);
+    req.query_ = query;
+    req.expected_labels_ = {dataset->base_->GetIds()[0]};
+
+    auto result = index->SearchWithRequest(req);
+    REQUIRE(result.has_value());
+    REQUIRE_FALSE(result.value()->GetReasoning().empty());
+    REQUIRE(result.value()->GetReasoning().find("missed_targets") != std::string::npos);
+    REQUIRE(result.value()->GetReasoning().find("bucket_selection") != std::string::npos);
+}
+
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::IVFTestIndex,
+                             "IVF Reasoning Found Target",
+                             "[ft][ivf][reasoning][pr]") {
+    auto dim = 32;
+    auto metric = "l2";
+    auto param = IVFTestIndex::GenerateIVFBuildParametersString(metric, dim, "fp32", 10);
+    auto index = TestIndex::TestFactory(IVFTestIndex::name, param, true);
+    auto dataset = IVFTestIndex::pool.GetDatasetAndCreate(dim, 200, metric);
+    TestIndex::TestBuildIndex(index, dataset, true);
+
+    // First search to find a result
+    auto query = vsag::Dataset::Make();
+    query->NumElements(1)
+        ->Dim(dim)
+        ->Float32Vectors(dataset->base_->GetFloat32Vectors())
+        ->Owner(false);
+
+    vsag::SearchRequest req_no_reasoning;
+    req_no_reasoning.topk_ = 5;
+    req_no_reasoning.params_str_ = fmt::format(fixtures::search_param_tmp, 10);
+    req_no_reasoning.query_ = query;
+
+    auto result_no_reasoning = index->SearchWithRequest(req_no_reasoning);
+    REQUIRE(result_no_reasoning.has_value());
+    REQUIRE(result_no_reasoning.value()->GetDim() > 0);
+
+    auto found_label = result_no_reasoning.value()->GetIds()[0];
+
+    // Now search with reasoning for that label
+    vsag::SearchRequest req;
+    req.topk_ = 5;
+    req.params_str_ = fmt::format(fixtures::search_param_tmp, 10);
+    req.query_ = query;
+    req.expected_labels_ = {found_label};
+
+    auto result = index->SearchWithRequest(req);
+    REQUIRE(result.has_value());
+    REQUIRE_FALSE(result.value()->GetReasoning().empty());
+    REQUIRE(result.value()->GetReasoning().find("expected_analysis") != std::string::npos);
+}
+
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::IVFTestIndex,
+                             "IVF Reasoning Empty Labels No Overhead",
+                             "[ft][ivf][reasoning][pr]") {
+    auto dim = 32;
+    auto metric = "l2";
+    auto param = IVFTestIndex::GenerateIVFBuildParametersString(metric, dim, "fp32", 10);
+    auto index = TestIndex::TestFactory(IVFTestIndex::name, param, true);
+    auto dataset = IVFTestIndex::pool.GetDatasetAndCreate(dim, 200, metric);
+    TestIndex::TestBuildIndex(index, dataset, true);
+
+    auto query = vsag::Dataset::Make();
+    query->NumElements(1)
+        ->Dim(dim)
+        ->Float32Vectors(dataset->base_->GetFloat32Vectors())
+        ->Owner(false);
+
+    vsag::SearchRequest req;
+    req.topk_ = 5;
+    req.params_str_ = fmt::format(fixtures::search_param_tmp, 10);
+    req.query_ = query;
+    req.expected_labels_ = {};  // empty
+
+    auto result = index->SearchWithRequest(req);
+    REQUIRE(result.has_value());
+    // Empty expected_labels means no reasoning report
+    REQUIRE(result.value()->GetReasoning().find("expected_analysis") == std::string::npos);
+}
+
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::IVFTestIndex,
+                             "IVF Reasoning With Filter All",
+                             "[ft][ivf][reasoning][pr]") {
+    auto dim = 32;
+    auto metric = "l2";
+    auto param = IVFTestIndex::GenerateIVFBuildParametersString(metric, dim, "fp32", 10);
+    auto index = TestIndex::TestFactory(IVFTestIndex::name, param, true);
+    auto dataset = IVFTestIndex::pool.GetDatasetAndCreate(dim, 200, metric);
+    TestIndex::TestBuildIndex(index, dataset, true);
+
+    auto query = vsag::Dataset::Make();
+    query->NumElements(1)
+        ->Dim(dim)
+        ->Float32Vectors(dataset->base_->GetFloat32Vectors())
+        ->Owner(false);
+
+    vsag::SearchRequest req;
+    req.topk_ = 5;
+    req.params_str_ = fmt::format(fixtures::search_param_tmp, 10);
+    req.query_ = query;
+    req.expected_labels_ = {dataset->base_->GetIds()[0]};
+    req.enable_filter_ = true;
+    req.filter_ = std::make_shared<RejectAllFilter>();
+
+    auto result = index->SearchWithRequest(req);
+    REQUIRE(result.has_value());
+    REQUIRE(result.value()->GetDim() == 0);
+    REQUIRE_FALSE(result.value()->GetReasoning().empty());
+    REQUIRE(result.value()->GetReasoning().find("missed_targets") != std::string::npos);
+}


### PR DESCRIPTION
## Summary
- Integrate reasoning context into IVF search/reorder paths
- Record bucket selection, visits, filter rejects, and evictions
- Emit reasoning reports in IVF results

## Verification
- make fmt
- make release

Fixes #1830