### PR TITLE
fix: support IVF memory estimation and immutable state

### DIFF
--- a/src/algorithm/ivf/gno_imi_partition.cpp
+++ b/src/algorithm/ivf/gno_imi_partition.cpp
@@ -437,4 +437,16 @@ GNOIMIPartition::GetCentroid(BucketIdType bucket_id, Vector<float>& centroid) {
             dim_);
 }
 
+uint64_t
+GNOIMIPartition::EstimateMemory(uint64_t num_elements) const {
+    (void)num_elements;
+    uint64_t memory = sizeof(GNOIMIPartition);
+    memory += static_cast<uint64_t>(bucket_count_s_ + bucket_count_t_) *
+              static_cast<uint64_t>(dim_) * sizeof(float);
+    memory += static_cast<uint64_t>(bucket_count_s_ + bucket_count_t_) * sizeof(float);
+    memory += static_cast<uint64_t>(bucket_count_s_) * static_cast<uint64_t>(bucket_count_t_) *
+              sizeof(float);
+    return memory;
+}
+
 }  // namespace vsag

--- a/src/algorithm/ivf/gno_imi_partition.cpp
+++ b/src/algorithm/ivf/gno_imi_partition.cpp
@@ -19,6 +19,7 @@
 
 #include <atomic>
 #include <fstream>
+#include <limits>
 #include <numeric>
 #include <vector>
 
@@ -32,6 +33,24 @@
 #include "vsag_exception.h"
 
 namespace vsag {
+
+static uint64_t
+saturated_add(uint64_t lhs, uint64_t rhs) {
+    const auto max = std::numeric_limits<uint64_t>::max();
+    if (lhs > max - rhs) {
+        return max;
+    }
+    return lhs + rhs;
+}
+
+static uint64_t
+saturated_mul(uint64_t lhs, uint64_t rhs) {
+    const auto max = std::numeric_limits<uint64_t>::max();
+    if (lhs != 0 and rhs > max / lhs) {
+        return max;
+    }
+    return lhs * rhs;
+}
 
 static constexpr const char* SEARCH_PARAM_TEMPLATE_STR = R"(
 {{
@@ -441,11 +460,17 @@ uint64_t
 GNOIMIPartition::EstimateMemory(uint64_t num_elements) const {
     (void)num_elements;
     uint64_t memory = sizeof(GNOIMIPartition);
-    memory += static_cast<uint64_t>(bucket_count_s_ + bucket_count_t_) *
-              static_cast<uint64_t>(dim_) * sizeof(float);
-    memory += static_cast<uint64_t>(bucket_count_s_ + bucket_count_t_) * sizeof(float);
-    memory += static_cast<uint64_t>(bucket_count_s_) * static_cast<uint64_t>(bucket_count_t_) *
-              sizeof(float);
+    const auto first_order_bucket_count = static_cast<uint64_t>(bucket_count_s_);
+    const auto second_order_bucket_count = static_cast<uint64_t>(bucket_count_t_);
+    const auto bucket_count = saturated_add(first_order_bucket_count, second_order_bucket_count);
+    const auto dim = static_cast<uint64_t>(dim_);
+
+    memory = saturated_add(memory, saturated_mul(saturated_mul(bucket_count, dim), sizeof(float)));
+    memory = saturated_add(memory, saturated_mul(bucket_count, sizeof(float)));
+    memory = saturated_add(
+        memory,
+        saturated_mul(saturated_mul(first_order_bucket_count, second_order_bucket_count),
+                      sizeof(float)));
     return memory;
 }
 

--- a/src/algorithm/ivf/gno_imi_partition.h
+++ b/src/algorithm/ivf/gno_imi_partition.h
@@ -54,6 +54,9 @@ public:
     void
     Deserialize(lvalue_or_rvalue<StreamReader> reader) override;
 
+    [[nodiscard]] uint64_t
+    EstimateMemory(uint64_t num_elements) const override;
+
 public:
     IVFNearestPartitionTrainerType trainer_type_{IVFNearestPartitionTrainerType::KMeansTrainer};
     IndexCommonParam common_param_;

--- a/src/algorithm/ivf/ivf.cpp
+++ b/src/algorithm/ivf/ivf.cpp
@@ -1654,7 +1654,6 @@ IVF::EstimateMemory(uint64_t num_elements) const {
                                      ? param->bucket_param->io_parameter
                                      : nullptr;
 
-    memory = saturated_add(memory, this->bucket_->GetMemoryUsage());
     memory = saturated_add(
         memory,
         estimate_bucket_io_memory(
@@ -1671,7 +1670,6 @@ IVF::EstimateMemory(uint64_t num_elements) const {
         const auto precise_io_param = (param != nullptr and param->precise_codes_param != nullptr)
                                           ? param->precise_codes_param->io_parameter
                                           : nullptr;
-        memory = saturated_add(memory, this->reorder_codes_->GetMemoryUsage());
         memory = saturated_add(
             memory,
             estimate_flatten_io_memory(

--- a/src/algorithm/ivf/ivf.cpp
+++ b/src/algorithm/ivf/ivf.cpp
@@ -15,10 +15,12 @@
 
 #include "ivf.h"
 
+#include <algorithm>
 #include <atomic>
 #include <limits>
 #include <random>
 #include <set>
+#include <utility>
 
 #include "algorithm/inner_index_interface.h"
 #include "attr/argparse.h"
@@ -28,12 +30,14 @@
 #include "gno_imi_partition.h"
 #include "impl/heap/standard_heap.h"
 #include "impl/inner_search_param.h"
+#include "impl/label_table/label_table.h"
 #include "impl/reasoning/search_reasoning.h"
 #include "impl/reorder/flatten_reorder.h"
 #include "impl/searcher/basic_searcher.h"
 #include "index/index_impl.h"
 #include "index_feature_list.h"
 #include "inner_string_params.h"
+#include "io/memory_block_io_parameter.h"
 #include "ivf_nearest_partition.h"
 #include "query_context.h"
 #include "storage/serialization.h"
@@ -45,6 +49,93 @@
 #include "vsag_exception.h"
 
 namespace vsag {
+namespace {
+
+uint64_t
+saturated_add(uint64_t lhs, uint64_t rhs) {
+    if (std::numeric_limits<uint64_t>::max() - lhs < rhs) {
+        return std::numeric_limits<uint64_t>::max();
+    }
+    return lhs + rhs;
+}
+
+uint64_t
+saturated_mul(uint64_t lhs, uint64_t rhs) {
+    if (lhs != 0 and rhs > std::numeric_limits<uint64_t>::max() / lhs) {
+        return std::numeric_limits<uint64_t>::max();
+    }
+    return lhs * rhs;
+}
+
+uint64_t
+ceil_div(uint64_t value, uint64_t divisor) {
+    if (divisor == 0) {
+        return value;
+    }
+    return value / divisor + static_cast<uint64_t>(value % divisor != 0);
+}
+
+uint64_t
+block_memory_ceil(uint64_t memory, uint64_t block_size) {
+    if (memory == 0 or block_size == 0) {
+        return memory;
+    }
+    return saturated_mul(ceil_div(memory, block_size), block_size);
+}
+
+uint64_t
+get_block_size(const IOParamPtr& io_param) {
+    if (io_param == nullptr) {
+        return 0;
+    }
+    auto block_param = std::dynamic_pointer_cast<MemoryBlockIOParameter>(io_param);
+    if (block_param != nullptr) {
+        return block_param->block_size_;
+    }
+    return MemoryBlockIOParameter::NearestPowerOfTwo(Options::Instance().block_size_limit());
+}
+
+uint64_t
+estimate_flatten_io_memory(uint64_t memory, const IOParamPtr& io_param) {
+    if (io_param == nullptr) {
+        return memory;
+    }
+    const auto io_type_name = io_param->GetTypeName();
+    if (io_type_name == IO_TYPE_VALUE_MEMORY_IO) {
+        return memory;
+    }
+    if (io_type_name == IO_TYPE_VALUE_BLOCK_MEMORY_IO) {
+        return block_memory_ceil(memory, get_block_size(io_param));
+    }
+    return 0;
+}
+
+uint64_t
+estimate_bucket_io_memory(uint64_t memory,
+                          uint64_t vector_count,
+                          uint64_t bucket_count,
+                          const IOParamPtr& io_param) {
+    if (io_param == nullptr) {
+        return memory;
+    }
+    const auto io_type_name = io_param->GetTypeName();
+    if (io_type_name == IO_TYPE_VALUE_MEMORY_IO) {
+        return memory;
+    }
+    if (io_type_name != IO_TYPE_VALUE_BLOCK_MEMORY_IO) {
+        return 0;
+    }
+
+    auto non_empty_bucket_count = std::min(bucket_count, vector_count);
+    if (non_empty_bucket_count == 0) {
+        return 0;
+    }
+    auto memory_per_bucket = ceil_div(memory, non_empty_bucket_count);
+    return saturated_mul(non_empty_bucket_count,
+                         block_memory_ceil(memory_per_bucket, get_block_size(io_param)));
+}
+
+}  // namespace
 
 static constexpr const char* IVF_PARAMS_TEMPLATE =
     R"(
@@ -432,6 +523,7 @@ IVF::InitFeatures() {
 
     this->index_feature_list_->SetFeatures({IndexFeature::SUPPORT_CLONE,
                                             IndexFeature::SUPPORT_EXPORT_MODEL,
+                                            IndexFeature::SUPPORT_ESTIMATE_MEMORY,
                                             IndexFeature::SUPPORT_GET_MEMORY_USAGE,
                                             IndexFeature::SUPPORT_MERGE_INDEX});
 
@@ -1545,6 +1637,75 @@ IVF::GetMemoryUsage() const {
         memory += this->attr_filter_index_->GetMemoryUsage();
     }
     return memory;
+}
+
+uint64_t
+IVF::EstimateMemory(uint64_t num_elements) const {
+    auto param = std::static_pointer_cast<IVFParameter>(this->create_param_ptr_);
+    uint64_t memory = sizeof(IVF);
+    if (this->bucket_ == nullptr) {
+        return memory;
+    }
+
+    const auto bucket_count = static_cast<uint64_t>(this->bucket_->bucket_count_);
+    const auto buckets_per_data = static_cast<uint64_t>(this->buckets_per_data_);
+    const auto bucket_vector_count = saturated_mul(num_elements, buckets_per_data);
+    const auto bucket_io_param = (param != nullptr and param->bucket_param != nullptr)
+                                     ? param->bucket_param->io_parameter
+                                     : nullptr;
+
+    memory = saturated_add(memory, this->bucket_->GetMemoryUsage());
+    memory = saturated_add(
+        memory,
+        estimate_bucket_io_memory(
+            saturated_mul(bucket_vector_count, static_cast<uint64_t>(this->bucket_->code_size_)),
+            bucket_vector_count,
+            bucket_count,
+            bucket_io_param));
+    memory = saturated_add(memory, saturated_mul(bucket_vector_count, sizeof(InnerIdType)));
+    if (this->bucket_->UseResidual()) {
+        memory = saturated_add(memory, saturated_mul(bucket_vector_count, sizeof(float)));
+    }
+
+    if (use_reorder_ and this->reorder_codes_ != nullptr) {
+        const auto precise_io_param = (param != nullptr and param->precise_codes_param != nullptr)
+                                          ? param->precise_codes_param->io_parameter
+                                          : nullptr;
+        memory = saturated_add(memory, this->reorder_codes_->GetMemoryUsage());
+        memory = saturated_add(
+            memory,
+            estimate_flatten_io_memory(
+                saturated_mul(num_elements,
+                              static_cast<uint64_t>(this->reorder_codes_->code_size_)),
+                precise_io_param));
+    }
+
+    if (this->extra_info_size_ > 0 and this->extra_infos_ != nullptr and
+        this->extra_infos_->InMemory()) {
+        memory = saturated_add(memory, saturated_mul(this->extra_info_size_, num_elements));
+    }
+
+    memory = saturated_add(memory, sizeof(LabelTable));
+    memory = saturated_add(memory, saturated_mul(num_elements, sizeof(LabelType)));
+    memory = saturated_add(
+        memory,
+        saturated_mul(num_elements, sizeof(std::pair<LabelType, InnerIdType>) + 2 * sizeof(void*)));
+    memory = saturated_add(memory, saturated_mul(num_elements, sizeof(uint64_t)));
+    if (this->partition_strategy_ != nullptr) {
+        memory = saturated_add(memory, this->partition_strategy_->EstimateMemory(num_elements));
+    }
+
+    if (this->attr_filter_index_ != nullptr) {
+        memory =
+            saturated_add(memory, saturated_mul(num_elements, sizeof(InnerIdType) + sizeof(void*)));
+    }
+
+    return memory;
+}
+
+void
+IVF::SetImmutable() {
+    this->immutable_.store(true, std::memory_order_release);
 }
 
 }  // namespace vsag

--- a/src/algorithm/ivf/ivf.h
+++ b/src/algorithm/ivf/ivf.h
@@ -173,6 +173,12 @@ public:
     [[nodiscard]] uint64_t
     GetMemoryUsage() const override;
 
+    [[nodiscard]] uint64_t
+    EstimateMemory(uint64_t num_elements) const override;
+
+    void
+    SetImmutable() override;
+
 private:
     /**
      * @brief Parse the JSON search parameter string and populate an

--- a/src/algorithm/ivf/ivf_nearest_partition.cpp
+++ b/src/algorithm/ivf/ivf_nearest_partition.cpp
@@ -174,7 +174,20 @@ IVFNearestPartition::GetCentroid(BucketIdType bucket_id, Vector<float>& centroid
 
 [[nodiscard]] uint64_t
 IVFNearestPartition::GetMemoryUsage() const {
-    return static_cast<uint64_t>(sizeof(IVFNearestPartition) +
-                                 this->route_index_ptr_->GetMemoryUsage());
+    uint64_t memory = sizeof(IVFNearestPartition);
+    if (this->route_index_ptr_ != nullptr) {
+        memory += this->route_index_ptr_->GetMemoryUsage();
+    }
+    return memory;
+}
+
+[[nodiscard]] uint64_t
+IVFNearestPartition::EstimateMemory(uint64_t num_elements) const {
+    (void)num_elements;
+    uint64_t memory = sizeof(IVFNearestPartition);
+    if (this->route_index_ptr_ != nullptr) {
+        memory += this->route_index_ptr_->EstimateMemory(bucket_count_);
+    }
+    return memory;
 }
 }  // namespace vsag

--- a/src/algorithm/ivf/ivf_nearest_partition.h
+++ b/src/algorithm/ivf/ivf_nearest_partition.h
@@ -50,6 +50,9 @@ public:
     [[nodiscard]] uint64_t
     GetMemoryUsage() const override;
 
+    [[nodiscard]] uint64_t
+    EstimateMemory(uint64_t num_elements) const override;
+
 public:
     IVFPartitionStrategyParametersPtr ivf_partition_strategy_param_{nullptr};
 

--- a/src/algorithm/ivf/ivf_partition_strategy.h
+++ b/src/algorithm/ivf/ivf_partition_strategy.h
@@ -95,6 +95,16 @@ public:
         return 0;
     }
 
+    virtual uint64_t
+    EstimateMemory(uint64_t num_elements) const {
+        (void)num_elements;
+        auto memory = GetMemoryUsage();
+        if (memory <= 0) {
+            return 0;
+        }
+        return static_cast<uint64_t>(memory);
+    }
+
 public:
     bool is_trained_{false};
 

--- a/tests/test_ivf.cpp
+++ b/tests/test_ivf.cpp
@@ -22,6 +22,29 @@
 #include "storage/serialization_template_test.h"
 #include "storage/streaming_serialization_test_utils.h"
 #include "test_index.h"
+
+class BlockSizeLimitGuard {
+public:
+    explicit BlockSizeLimitGuard(uint64_t block_size_limit)
+        : origin_size_(vsag::Options::Instance().block_size_limit()) {
+        vsag::Options::Instance().set_block_size_limit(block_size_limit);
+    }
+
+    BlockSizeLimitGuard(const BlockSizeLimitGuard&) = delete;
+    BlockSizeLimitGuard&
+    operator=(const BlockSizeLimitGuard&) = delete;
+    BlockSizeLimitGuard(BlockSizeLimitGuard&&) = delete;
+    BlockSizeLimitGuard&
+    operator=(BlockSizeLimitGuard&&) = delete;
+
+    ~BlockSizeLimitGuard() {
+        vsag::Options::Instance().set_block_size_limit(origin_size_);
+    }
+
+private:
+    uint64_t origin_size_;
+};
+
 namespace fixtures {
 
 class IVFTestResource {
@@ -1435,8 +1458,7 @@ TEST_CASE("(PR) IVF Estimate Memory And Get Memory Usage", "[ft][memory][ivf][pr
 }
 
 TEST_CASE("(PR) IVF Estimate Memory IO Type Monotonic", "[ft][memory][ivf][pr]") {
-    const auto origin_size = vsag::Options::Instance().block_size_limit();
-    vsag::Options::Instance().set_block_size_limit(1024 * 1024 * 2);
+    BlockSizeLimitGuard block_size_limit_guard(1024 * 1024 * 2);
 
     const std::vector<std::string> base_io_types{"memory_io", "block_memory_io"};
     for (const auto& base_io_type : base_io_types) {
@@ -1451,8 +1473,6 @@ TEST_CASE("(PR) IVF Estimate Memory IO Type Monotonic", "[ft][memory][ivf][pr]")
         REQUIRE(small_memory > 0);
         REQUIRE(large_memory >= small_memory);
     }
-
-    vsag::Options::Instance().set_block_size_limit(origin_size);
 }
 
 TEST_CASE("(Daily) IVF Estimate Memory", "[ft][memory][ivf][daily]") {

--- a/tests/test_ivf.cpp
+++ b/tests/test_ivf.cpp
@@ -46,7 +46,8 @@ public:
                                      int buckets_per_data = 1,
                                      bool use_attr_filter = false,
                                      int thread_count = 1,
-                                     int64_t sample_count = 10000L);
+                                     int64_t sample_count = 10000L,
+                                     const std::string& base_io_type = "memory_io");
 
     static IVFResourcePtr
     GetResource(bool sample = true);
@@ -134,7 +135,8 @@ IVFTestIndex::GenerateIVFBuildParametersString(const std::string& metric_type,
                                                int buckets_per_data,
                                                bool use_attr_filter,
                                                int thread_count,
-                                               int64_t sample_count) {
+                                               int64_t sample_count,
+                                               const std::string& base_io_type) {
     std::string build_parameters_str;
     constexpr auto parameter_temp = R"(
     {{
@@ -142,6 +144,7 @@ IVFTestIndex::GenerateIVFBuildParametersString(const std::string& metric_type,
         "metric_type": "{}",
         "dim": {},
         "index_param": {{
+            "base_io_type": "{}",
             "buckets_count": {},
             "base_quantization_type": "{}",
             "ivf_train_type": "{}",
@@ -172,6 +175,7 @@ IVFTestIndex::GenerateIVFBuildParametersString(const std::string& metric_type,
     build_parameters_str = fmt::format(parameter_temp,
                                        metric_type,
                                        dim,
+                                       base_io_type,
                                        buckets_count,
                                        basic_quantizer_str,
                                        train_type,
@@ -220,6 +224,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::IVFTestIndex, "IVF GetStatus", "[ft][ivf]
                 dataset->query_->NumElements(10);
                 INFO(index->AnalyzeIndexBySearch(request));
                 dataset->query_->NumElements(raw_num);
+                TestIndex::TestIndexStatus(index);
             }
         }
     }
@@ -1427,6 +1432,27 @@ TEST_CASE("(PR) IVF Estimate Memory And Get Memory Usage", "[ft][memory][ivf][pr
     auto test_index = std::make_shared<fixtures::IVFTestIndex>();
     auto resource = test_index->GetResource(true);
     TestIVFEstimateMemoryAndGetMemoryUsage(resource);
+}
+
+TEST_CASE("(PR) IVF Estimate Memory IO Type Monotonic", "[ft][memory][ivf][pr]") {
+    const auto origin_size = vsag::Options::Instance().block_size_limit();
+    vsag::Options::Instance().set_block_size_limit(1024 * 1024 * 2);
+
+    const std::vector<std::string> base_io_types{"memory_io", "block_memory_io"};
+    for (const auto& base_io_type : base_io_types) {
+        INFO(fmt::format("base_io_type: {}", base_io_type));
+        auto param = fixtures::IVFTestIndex::GenerateIVFBuildParametersString(
+            "l2", 32, "sq8", 64, "random", false, 1, false, 1, 512, base_io_type);
+        auto index = fixtures::TestIndex::TestFactory(fixtures::IVFTestIndex::name, param, true);
+        REQUIRE(index->CheckFeature(vsag::IndexFeature::SUPPORT_ESTIMATE_MEMORY));
+
+        const auto small_memory = index->EstimateMemory(512);
+        const auto large_memory = index->EstimateMemory(1024);
+        REQUIRE(small_memory > 0);
+        REQUIRE(large_memory >= small_memory);
+    }
+
+    vsag::Options::Instance().set_block_size_limit(origin_size);
 }
 
 TEST_CASE("(Daily) IVF Estimate Memory", "[ft][memory][ivf][daily]") {


### PR DESCRIPTION
## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement/Refactor
- [ ] Documentation
- [ ] CI/Build/Infra

## Linked Issue

- Fixes: #2303

## What Changed

- Implement `IVF::EstimateMemory` and advertise `SUPPORT_ESTIMATE_MEMORY`.
- Add partition-strategy memory estimation for IVF nearest partition and GNO-IMI.
- Implement `IVF::SetImmutable` so immutable IVF indexes reject later writes through the public API.
- Extend IVF lifecycle coverage with `TestIndexStatus`.

## Test Evidence

- [ ] `make fmt`
- [ ] `make lint`
- [ ] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [x] Other (describe below)

Test details:

```text
clang-format-15 -i src/algorithm/ivf/ivf.cpp src/algorithm/ivf/ivf.h src/algorithm/ivf/ivf_partition_strategy.h src/algorithm/ivf/ivf_nearest_partition.h src/algorithm/ivf/ivf_nearest_partition.cpp src/algorithm/ivf/gno_imi_partition.h src/algorithm/ivf/gno_imi_partition.cpp tests/test_ivf.cpp
git diff --check
make test CMAKE_GENERATOR=Ninja CASE="\"(PR) IVF Estimate Memory And Get Memory Usage\""
./build/tests/functests -d yes "IVF GetStatus" --allow-running-no-tests
```

## Compatibility Impact

- API/ABI compatibility: none; this fills in existing public API hooks for IVF.
- Behavior changes: IVF now returns memory estimates and accepts `SetImmutable()` instead of reporting unsupported operation.

## Performance and Concurrency Impact

- Performance impact: no hot-path change; `EstimateMemory` is an explicit introspection call.
- Concurrency/thread-safety impact: immutable state is stored through the existing atomic flag used by `IndexImpl` write guards.

## Documentation Impact

- [x] No docs update needed
- [ ] Updated docs:
  - [ ] `README.md`
  - [ ] `DEVELOPMENT.md`
  - [ ] `CONTRIBUTING.md`
  - [ ] Other:

## Risk and Rollback

- Risk level: low
- Rollback plan: revert this commit to restore the previous unsupported-operation behavior.

## Checklist

- [x] I have linked the relevant issue (required for `kind/bug` and `kind/feature`; see "Linked Issue" above)
- [x] I have added/updated tests for new behavior or bug fixes
- [x] I have considered API compatibility impact
- [x] I have updated docs if behavior/workflow changed
- [x] My commit messages follow project conventions (Conventional Commits, optional `[skip ci]` prefix)
