### PR TITLE
fix: compact SINDI sparse term lists

### DIFF
--- a/src/algorithm/sindi/sindi.cpp
+++ b/src/algorithm/sindi/sindi.cpp
@@ -245,7 +245,15 @@ SINDI::Add(const DatasetPtr& base) {
 std::vector<int64_t>
 SINDI::Build(const DatasetPtr& base) {
     // note that there's a wlock in Add()
-    return this->Add(base);
+    auto failed_ids = this->Add(base);
+    {
+        std::scoped_lock wlock(this->global_mutex_);
+        for (auto& window : window_term_list_) {
+            window->Compact();
+        }
+        this->cal_memory_usage();
+    }
+    return failed_ids;
 }
 
 bool

--- a/src/datacell/sparse_term_datacell.cpp
+++ b/src/datacell/sparse_term_datacell.cpp
@@ -15,6 +15,7 @@
 
 #include "sparse_term_datacell.h"
 
+#include <algorithm>
 #include <cstring>
 
 #include "simd/fp16_simd.h"
@@ -313,6 +314,40 @@ SparseTermDataCell::ResizeTermList(InnerIdType new_term_capacity) {
     term_capacity_ = new_capacity;
 }
 
+void
+SparseTermDataCell::Compact() {
+    uint32_t compact_term_capacity = 0;
+    const uint64_t compactable_capacity = std::min(
+        std::min(static_cast<uint64_t>(term_capacity_), static_cast<uint64_t>(term_sizes_.size())),
+        std::min(static_cast<uint64_t>(term_ids_.size()),
+                 static_cast<uint64_t>(term_datas_.size())));
+    for (uint64_t i = 0; i < compactable_capacity; ++i) {
+        if (term_sizes_[i] != 0) {
+            compact_term_capacity = static_cast<uint32_t>(i + 1);
+        }
+    }
+
+    Vector<std::unique_ptr<Vector<uint16_t>>> compact_ids(compact_term_capacity, allocator_);
+    Vector<std::unique_ptr<Vector<uint8_t>>> compact_datas(compact_term_capacity, allocator_);
+    Vector<uint32_t> compact_sizes(compact_term_capacity, 0, allocator_);
+    for (uint32_t i = 0; i < compact_term_capacity; ++i) {
+        compact_sizes[i] = term_sizes_[i];
+        if (term_sizes_[i] != 0) {
+            CHECK_ARGUMENT(term_ids_[i] != nullptr && term_datas_[i] != nullptr,
+                           "non-empty sparse term has null posting data");
+            compact_ids[i] = std::make_unique<Vector<uint16_t>>(
+                term_ids_[i]->begin(), term_ids_[i]->end(), allocator_);
+            compact_datas[i] = std::make_unique<Vector<uint8_t>>(
+                term_datas_[i]->begin(), term_datas_[i]->end(), allocator_);
+        }
+    }
+
+    term_ids_.swap(compact_ids);
+    term_datas_.swap(compact_datas);
+    term_sizes_.swap(compact_sizes);
+    term_capacity_ = compact_term_capacity;
+}
+
 float
 SparseTermDataCell::CalcDistanceByInnerId(const SparseTermComputerPtr& computer, uint16_t base_id) {
     float ip = 0;
@@ -362,20 +397,22 @@ SparseTermDataCell::CalcDistanceByInnerId(const SparseTermComputerPtr& computer,
 int64_t
 SparseTermDataCell::GetMemoryUsage() const {
     auto memory = sizeof(SparseTermDataCell);
-    memory += term_ids_.size() * sizeof(std::unique_ptr<Vector<uint16_t>>);
-    memory += term_datas_.size() * sizeof(std::unique_ptr<Vector<uint8_t>>);
+    memory += term_ids_.capacity() * sizeof(std::unique_ptr<Vector<uint16_t>>);
+    memory += term_datas_.capacity() * sizeof(std::unique_ptr<Vector<uint8_t>>);
     for (const auto& ptr : term_ids_) {
         if (ptr != nullptr) {
-            memory += ptr->size() * sizeof(uint16_t);
+            memory += sizeof(Vector<uint16_t>);
+            memory += ptr->capacity() * sizeof(uint16_t);
         }
     }
     for (const auto& ptr : term_datas_) {
         if (ptr != nullptr) {
-            memory += ptr->size() * sizeof(uint8_t);
+            memory += sizeof(Vector<uint8_t>);
+            memory += ptr->capacity() * sizeof(uint8_t);
         }
     }
     memory += sizeof(QuantizationParams);
-    memory += term_sizes_.size() * sizeof(uint32_t);
+    memory += term_sizes_.capacity() * sizeof(uint32_t);
     return static_cast<int64_t>(memory);
 }
 
@@ -486,8 +523,16 @@ SparseTermDataCell::Deserialize(StreamReader& reader) {
         }
     }
     StreamReader::ReadVector(reader, term_sizes_);
+    for (uint64_t i = 0; i < term_ids_.size(); ++i) {
+        if (i >= term_sizes_.size() || term_sizes_[i] == 0) {
+            term_ids_[i].reset();
+            term_datas_[i].reset();
+        }
+    }
 
-    // Restore total_count_ from deserialized data (not serialized to maintain compatibility)
+    Compact();
+
+    // Restore total_count_ from compacted deserialized data (not serialized for compatibility).
     total_count_ = 0;
     for (const auto& term_id_vec : term_ids_) {
         if (term_id_vec != nullptr) {

--- a/src/datacell/sparse_term_datacell.h
+++ b/src/datacell/sparse_term_datacell.h
@@ -95,6 +95,9 @@ public:
     ResizeTermList(InnerIdType new_term_capacity);
 
     void
+    Compact();
+
+    void
     Serialize(StreamWriter& writer) const;
 
     void

--- a/src/datacell/sparse_term_datacell_test.cpp
+++ b/src/datacell/sparse_term_datacell_test.cpp
@@ -15,6 +15,8 @@
 
 #include "sparse_term_datacell.h"
 
+#include <sstream>
+
 #include "impl/allocator/safe_allocator.h"
 #include "unittest.h"
 
@@ -333,6 +335,100 @@ TEST_CASE("SparseTermDatacell FP16 Roundtrip Test", "[ut][SparseTermDatacell]") 
 
     allocator->Deallocate(retrieved_sv.ids_);
     allocator->Deallocate(retrieved_sv.vals_);
+}
+
+TEST_CASE("SparseTermDatacell Compact Memory Usage", "[ut][SparseTermDatacell]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    auto data_cell = std::make_shared<SparseTermDataCell>(
+        1.0F, DEFAULT_TERM_ID_LIMIT, allocator.get(), SparseValueQuantizationType::FP32, nullptr);
+
+    std::vector<uint32_t> ids = {1, 3, 5};
+    std::vector<float> vals = {1.0F, 2.0F, 3.0F};
+    SparseVector sparse_vector;
+    sparse_vector.len_ = static_cast<uint32_t>(ids.size());
+    sparse_vector.ids_ = ids.data();
+    sparse_vector.vals_ = vals.data();
+    data_cell->InsertVector(sparse_vector, 0);
+
+    data_cell->term_ids_[1]->reserve(32);
+    data_cell->term_datas_[1]->reserve(128);
+    auto compact_capacity = data_cell->term_capacity_;
+    auto reserved_id_capacity = data_cell->term_ids_[1]->capacity();
+    auto reserved_data_capacity = data_cell->term_datas_[1]->capacity();
+    data_cell->ResizeTermList(128);
+
+    auto memory_with_reserved_capacity = data_cell->GetMemoryUsage();
+    REQUIRE(data_cell->term_capacity_ >= 128);
+
+    data_cell->Compact();
+
+    REQUIRE(data_cell->term_capacity_ == compact_capacity);
+    REQUIRE(data_cell->term_ids_[1]->capacity() <= reserved_id_capacity);
+    REQUIRE(data_cell->term_datas_[1]->capacity() <= reserved_data_capacity);
+    REQUIRE(data_cell->GetMemoryUsage() < memory_with_reserved_capacity);
+}
+
+TEST_CASE("SparseTermDatacell Deserialize Compacts Capacity", "[ut][SparseTermDatacell]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    auto data_cell = std::make_shared<SparseTermDataCell>(
+        1.0F, DEFAULT_TERM_ID_LIMIT, allocator.get(), SparseValueQuantizationType::FP32, nullptr);
+
+    std::vector<uint32_t> ids = {1, 3, 5};
+    std::vector<float> vals = {1.0F, 2.0F, 3.0F};
+    SparseVector sparse_vector;
+    sparse_vector.len_ = static_cast<uint32_t>(ids.size());
+    sparse_vector.ids_ = ids.data();
+    sparse_vector.vals_ = vals.data();
+    data_cell->InsertVector(sparse_vector, 0);
+    data_cell->ResizeTermList(128);
+
+    std::stringstream ss;
+    IOStreamWriter writer(ss);
+    data_cell->Serialize(writer);
+
+    SparseTermDataCell restored(
+        1.0F, DEFAULT_TERM_ID_LIMIT, allocator.get(), SparseValueQuantizationType::FP32, nullptr);
+    IOStreamReader reader(ss);
+    restored.Deserialize(reader);
+
+    REQUIRE(restored.term_capacity_ == 6);
+    REQUIRE(restored.GetMemoryUsage() < data_cell->GetMemoryUsage());
+}
+
+TEST_CASE("SparseTermDatacell Deserialize Clears Stale Posting Lists", "[ut][SparseTermDatacell]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    auto make_sparse_vector = [](std::vector<uint32_t>& ids, std::vector<float>& vals) {
+        SparseVector sparse_vector;
+        sparse_vector.len_ = static_cast<uint32_t>(ids.size());
+        sparse_vector.ids_ = ids.data();
+        sparse_vector.vals_ = vals.data();
+        return sparse_vector;
+    };
+
+    SparseTermDataCell stale(
+        1.0F, DEFAULT_TERM_ID_LIMIT, allocator.get(), SparseValueQuantizationType::FP32, nullptr);
+    std::vector<uint32_t> stale_ids = {9};
+    std::vector<float> stale_vals = {9.0F};
+    auto stale_vector = make_sparse_vector(stale_ids, stale_vals);
+    stale.InsertVector(stale_vector, 42);
+
+    SparseTermDataCell source(
+        1.0F, DEFAULT_TERM_ID_LIMIT, allocator.get(), SparseValueQuantizationType::FP32, nullptr);
+    std::vector<uint32_t> ids = {1};
+    std::vector<float> vals = {1.0F};
+    auto sparse_vector = make_sparse_vector(ids, vals);
+    source.InsertVector(sparse_vector, 0);
+
+    std::stringstream ss;
+    IOStreamWriter writer(ss);
+    source.Serialize(writer);
+
+    IOStreamReader reader(ss);
+    stale.Deserialize(reader);
+
+    REQUIRE(stale.total_count_ == 1);
+    REQUIRE(stale.term_capacity_ == 2);
+    REQUIRE(stale.term_ids_.size() == 2);
 }
 
 TEST_CASE("SparseTermDatacell Last Term Test", "[ut][SparseTermDatacell]") {


### PR DESCRIPTION
## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement/Refactor
- [ ] Documentation
- [ ] CI/Build/Infra

## Linked Issue

- Fixes: antgroup/vsag#2346

## What Changed

- Count sparse term posting-list memory by vector capacity instead of size so `GetMemoryUsage()` reflects reserved storage.
- Add `SparseTermDataCell::Compact()` and call it after SINDI `Build()` to release posting-list over-allocation from static builds.
- Compact sparse term data after deserialize so indexes loaded from older un-compacted serialized data do not keep excess vector capacity.
- Add regression coverage for compacted memory usage and deserialize compaction.

## Test Evidence

- [x] `make fmt`
- [ ] `make lint`
- [ ] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [x] Other (describe below)

Test details:

```text
make fmt
make debug
make test CASE='[ut][SparseTermDatacell]'
./build/tests/unittests -d yes '[ut][SINDI]' --allow-running-no-tests
./build/tests/functests -d yes '[ft][build][search][sindi]' --allow-running-no-tests
./build/tests/functests -d yes '[ft][serialize][sindi]' --allow-running-no-tests
```

## Compatibility Impact

- API/ABI compatibility: no public API changes.
- Behavior changes: SINDI static `Build()` and sparse-term deserialize now shrink reserved posting-list capacity; `GetMemoryUsage()` reports capacity-backed storage more accurately.

## Performance and Concurrency Impact

- Performance impact: static build and deserialize do a one-time compaction; search path is unchanged.
- Concurrency/thread-safety impact: no new shared mutable state.

## Documentation Impact

- [x] No docs update needed
- [ ] Updated docs:
  - [ ] `README.md`
  - [ ] `DEVELOPMENT.md`
  - [ ] `CONTRIBUTING.md`
  - [ ] Other: <!-- path -->

## Risk and Rollback

- Risk level: low.
- Rollback plan: revert this commit to restore the previous capacity retention behavior.

## Checklist

- [x] I have linked the relevant issue (required for `kind/bug` and `kind/feature`; see "Linked Issue" above)
- [x] I have added/updated tests for new behavior or bug fixes
- [x] I have considered API compatibility impact
- [x] I have updated docs if behavior/workflow changed
- [x] My commit messages follow project conventions (Conventional Commits, optional `[skip ci]` prefix)
