### PR TITLE
fix(hgraph): drain parallel build futures on worker errors

### DIFF
--- a/src/algorithm/hgraph/hgraph_build.cpp
+++ b/src/algorithm/hgraph/hgraph_build.cpp
@@ -67,6 +67,23 @@ need_temporary_sq8_build_data(const FlattenInterfacePtr& basic_flatten_codes,
            basic_flatten_codes->GetQuantizerName() == QUANTIZATION_TYPE_VALUE_RABITQ;
 }
 
+static void
+wait_all_futures(std::vector<std::future<void>>& futures) {
+    std::exception_ptr first_exception = nullptr;
+    for (auto& future : futures) {
+        try {
+            future.get();
+        } catch (...) {
+            if (not first_exception) {
+                first_exception = std::current_exception();
+            }
+        }
+    }
+    if (first_exception) {
+        std::rethrow_exception(first_exception);
+    }
+}
+
 void
 HGraph::Train(const DatasetPtr& base) {
     int64_t total_elements = base->GetNumElements();
@@ -359,9 +376,7 @@ HGraph::Add(const DatasetPtr& data) {
         }
     }
     if (use_parallel_add) {
-        for (auto& future : futures) {
-            future.get();
-        }
+        wait_all_futures(futures);
     }
     if (defer_persistent_codes) {
         temporary_build_flatten_codes_.reset();
@@ -384,9 +399,7 @@ HGraph::Add(const DatasetPtr& data) {
             }
         }
         if (use_parallel_add) {
-            for (auto& future : futures) {
-                future.get();
-            }
+            wait_all_futures(futures);
         }
     }
     return failed_ids;
@@ -1080,19 +1093,7 @@ HGraph::refine_nodes_two_phase(
                         }
                     }));
             }
-            std::exception_ptr ex = nullptr;
-            for (auto& future : futures) {
-                try {
-                    future.get();
-                } catch (...) {
-                    if (not ex) {
-                        ex = std::current_exception();
-                    }
-                }
-            }
-            if (ex) {
-                std::rethrow_exception(ex);
-            }
+            wait_all_futures(futures);
         }
 
         const auto round_elapsed = build_cache_now_us() - round_begin;

--- a/src/algorithm/hgraph/hgraph_build.cpp
+++ b/src/algorithm/hgraph/hgraph_build.cpp
@@ -71,6 +71,9 @@ static void
 wait_all_futures(std::vector<std::future<void>>& futures) {
     std::exception_ptr first_exception = nullptr;
     for (auto& future : futures) {
+        if (not future.valid()) {
+            continue;
+        }
         try {
             future.get();
         } catch (...) {

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -593,6 +593,37 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HGraphTestIndex,
     }
 }
 
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::HGraphTestIndex,
+                             "HGraph parallel build drains worker exceptions",
+                             "[ft][hgraph][concurrent][pr]") {
+    auto param = R"(
+    {
+        "dtype": "float32",
+        "metric_type": "l2",
+        "dim": 128,
+        "index_param": {
+            "base_quantization_type": "rabitq",
+            "rabitq_bits_per_dim_base": 3,
+            "use_reorder": true,
+            "precise_quantization_type": "fp32",
+            "build_by_base": true,
+            "max_degree": 26,
+            "ef_construction": 100,
+            "build_thread_count": 8
+        }
+    }
+    )";
+    auto index_result = vsag::Factory::CreateIndex(name, param);
+    REQUIRE(index_result.has_value());
+
+    auto dataset = pool.GetDatasetAndCreate(128, 1000, "l2");
+    auto build_result = index_result.value()->Build(dataset->base_);
+    REQUIRE_FALSE(build_result.has_value());
+    REQUIRE(build_result.error().type == vsag::ErrorType::INTERNAL_ERROR);
+    REQUIRE(build_result.error().message.find("building the index is not supported using RabbitQ "
+                                              "alone") != std::string::npos);
+}
+
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::HGraphTestIndex, "HGraph GetStatus", "[ft][hgraph]") {
     auto test_index = std::make_shared<fixtures::HGraphTestIndex>();
     auto resource = test_index->GetResource(true);


### PR DESCRIPTION
## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement/Refactor
- [ ] Documentation
- [ ] CI/Build/Infra

## Linked Issue

- Fixes: #2352

## What Changed

- Add a shared HGraph helper that waits all submitted `std::future<void>` tasks before rethrowing the first worker exception.
- Use the helper in HGraph parallel `Add()` and deferred persistent-code insertion, so `Build()` cannot return while already-submitted workers are still touching the index.
- Reuse the helper in the build-cache refine path, replacing its local duplicate drain logic.
- Add a regression test using an unsupported RaBitQ build-by-base configuration with `build_thread_count > 1`; the expected behavior is a clean `INTERNAL_ERROR` without a segfault.

## Test Evidence

- [ ] `make fmt`
- [ ] `make lint`
- [ ] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [x] Other (describe below)

Test details:

```text
# Red before the fix
./build/tests/functests "HGraph parallel build drains worker exceptions"
Segmentation fault
EXIT_STATUS=139

# Green after the fix
./build/tests/functests "HGraph parallel build drains worker exceptions"
All tests passed (4 assertions in 1 test case)
EXIT_STATUS=0

# Formatting/whitespace
clang-format-15 -i src/algorithm/hgraph/hgraph_build.cpp tests/test_hgraph.cpp
git diff --check

# Existing RaBitQ no-reorder smoke check on main
/tmp/vsag_hgraph_rabitq_main_repro
Build ok, count=1000
Search ok, returned=10
EXIT_STATUS=0
```

## Compatibility Impact

- API/ABI compatibility: none.
- Behavior changes: unsupported HGraph build configurations still return the original error, but parallel builds now wait all submitted workers before returning that error.

## Performance and Concurrency Impact

- Performance impact: none expected on success paths; the helper still waits the same futures.
- Concurrency/thread-safety impact: improved error-path safety by preventing worker tasks from outliving the failed build call.

## Documentation Impact

- [x] No docs update needed
- [ ] Updated docs:
  - [ ] `README.md`
  - [ ] `DEVELOPMENT.md`
  - [ ] `CONTRIBUTING.md`
  - [ ] Other:

## Risk and Rollback

- Risk level: low.
- Rollback plan: revert this commit to restore the previous future waiting behavior.

## Checklist

- [x] I have linked the relevant issue (required for `kind/bug` and `kind/feature`; see "Linked Issue" above)
- [x] I have added/updated tests for new behavior or bug fixes
- [x] I have considered API compatibility impact
- [x] I have updated docs if behavior/workflow changed
- [x] My commit messages follow project conventions (Conventional Commits, optional `[skip ci]` prefix)
