### PR TITLE
fix(hgraph): refresh duplicate state on vector update

### DIFF
--- a/src/algorithm/hgraph/hgraph.cpp
+++ b/src/algorithm/hgraph/hgraph.cpp
@@ -637,7 +637,9 @@ HGraph::UpdateVector(int64_t id, const DatasetPtr& new_base, bool force_update) 
         return false;
     }
     if (was_duplicate_member) {
-        this->bottom_graph_->RemoveDuplicateId(inner_id);
+        if (not this->bottom_graph_->RemoveDuplicateId(inner_id)) {
+            return false;
+        }
         std::shared_lock rlock(this->global_mutex_);
         this->graph_add_one(new_base_vec, -1, inner_id);
     }

--- a/src/algorithm/hgraph/hgraph.cpp
+++ b/src/algorithm/hgraph/hgraph.cpp
@@ -585,8 +585,12 @@ HGraph::UpdateVector(int64_t id, const DatasetPtr& new_base, bool force_update) 
     void* new_base_vec = nullptr;
     uint64_t data_size = 0;
     get_vectors(data_type_, dim_, new_base, &new_base_vec, &data_size);
-    const bool was_duplicate_member =
-        this->support_duplicate_ && this->bottom_graph_->GetGroupId(inner_id) != inner_id;
+    std::vector<InnerIdType> duplicate_ids;
+    bool was_duplicate_member = false;
+    if (this->support_duplicate_) {
+        duplicate_ids = this->bottom_graph_->GetDuplicateIds(inner_id);
+        was_duplicate_member = this->bottom_graph_->GetGroupId(inner_id) != inner_id;
+    }
 
     if (not force_update) {
         std::shared_lock label_lock(this->label_lookup_mutex_);
@@ -642,6 +646,16 @@ HGraph::UpdateVector(int64_t id, const DatasetPtr& new_base, bool force_update) 
         }
         std::shared_lock rlock(this->global_mutex_);
         this->graph_add_one(new_base_vec, -1, inner_id);
+    } else if (not duplicate_ids.empty()) {
+        for (const auto duplicate_id : duplicate_ids) {
+            Vector<int8_t> duplicate_data(data_size, allocator_);
+            GetVectorByInnerId(duplicate_id, (float*)duplicate_data.data());
+            if (not this->bottom_graph_->RemoveDuplicateId(duplicate_id)) {
+                return false;
+            }
+            std::shared_lock rlock(this->global_mutex_);
+            this->graph_add_one(duplicate_data.data(), -1, duplicate_id);
+        }
     }
     return update_status;
 }

--- a/src/algorithm/hgraph/hgraph.cpp
+++ b/src/algorithm/hgraph/hgraph.cpp
@@ -585,6 +585,8 @@ HGraph::UpdateVector(int64_t id, const DatasetPtr& new_base, bool force_update) 
     void* new_base_vec = nullptr;
     uint64_t data_size = 0;
     get_vectors(data_type_, dim_, new_base, &new_base_vec, &data_size);
+    const bool was_duplicate_member =
+        this->support_duplicate_ && this->bottom_graph_->GetGroupId(inner_id) != inner_id;
 
     if (not force_update) {
         std::shared_lock label_lock(this->label_lookup_mutex_);
@@ -624,10 +626,20 @@ HGraph::UpdateVector(int64_t id, const DatasetPtr& new_base, bool force_update) 
 
     // note that only modify vector need to obtain unique lock
     // and the lock has been obtained inside datacell
-    auto codes = (has_precise_reorder()) ? high_precise_codes_ : basic_flatten_codes_;
     bool update_status = basic_flatten_codes_->UpdateVector(new_base_vec, inner_id);
     if (has_precise_reorder()) {
         update_status = update_status && high_precise_codes_->UpdateVector(new_base_vec, inner_id);
+    }
+    if (create_new_raw_vector_ && raw_vector_ != nullptr) {
+        update_status = update_status && raw_vector_->UpdateVector(new_base_vec, inner_id);
+    }
+    if (not update_status) {
+        return false;
+    }
+    if (was_duplicate_member) {
+        this->bottom_graph_->RemoveDuplicateId(inner_id);
+        std::shared_lock rlock(this->global_mutex_);
+        this->graph_add_one(new_base_vec, -1, inner_id);
     }
     return update_status;
 }

--- a/src/datacell/dense_duplicate_tracker.cpp
+++ b/src/datacell/dense_duplicate_tracker.cpp
@@ -55,8 +55,13 @@ DenseDuplicateTracker::RemoveDuplicateId(InnerIdType duplicate_id) {
     }
 
     auto previous_id = duplicate_id;
+    uint64_t count = 0;
+    const auto max_count = duplicate_ids_.size();
     while (duplicate_ids_[previous_id] != duplicate_id) {
         previous_id = duplicate_ids_[previous_id];
+        if (++count > max_count) {
+            return false;
+        }
     }
 
     const auto next_id = duplicate_ids_[duplicate_id];

--- a/src/datacell/dense_duplicate_tracker.cpp
+++ b/src/datacell/dense_duplicate_tracker.cpp
@@ -46,6 +46,31 @@ DenseDuplicateTracker::SetDuplicateId(InnerIdType group_id, InnerIdType duplicat
     duplicate_ids_[group_id] = duplicate_id;
 }
 
+bool
+DenseDuplicateTracker::RemoveDuplicateId(InnerIdType duplicate_id) {
+    std::scoped_lock lock(mutex_);
+
+    if (duplicate_id >= duplicate_ids_.size() || duplicate_ids_[duplicate_id] == duplicate_id) {
+        return false;
+    }
+
+    auto previous_id = duplicate_id;
+    while (duplicate_ids_[previous_id] != duplicate_id) {
+        previous_id = duplicate_ids_[previous_id];
+    }
+
+    const auto next_id = duplicate_ids_[duplicate_id];
+    duplicate_ids_[duplicate_id] = duplicate_id;
+    if (previous_id == next_id) {
+        duplicate_ids_[previous_id] = previous_id;
+        duplicate_count_--;
+        return true;
+    }
+
+    duplicate_ids_[previous_id] = next_id;
+    return true;
+}
+
 auto
 DenseDuplicateTracker::GetDuplicateIds(InnerIdType id) const -> std::vector<InnerIdType> {
     std::shared_lock lock(mutex_);

--- a/src/datacell/dense_duplicate_tracker.h
+++ b/src/datacell/dense_duplicate_tracker.h
@@ -29,6 +29,9 @@ public:
     void
     SetDuplicateId(InnerIdType group_id, InnerIdType duplicate_id) override;
 
+    bool
+    RemoveDuplicateId(InnerIdType duplicate_id) override;
+
     auto
     GetDuplicateIds(InnerIdType id) const -> std::vector<InnerIdType> override;
 

--- a/src/datacell/dense_duplicate_tracker_test.cpp
+++ b/src/datacell/dense_duplicate_tracker_test.cpp
@@ -67,6 +67,30 @@ TEST_CASE("DenseDuplicateTracker ignores duplicate reinsertion", "[ut][DenseDupl
     REQUIRE(tracker.GetDuplicateIds(0) == std::vector<InnerIdType>{1});
 }
 
+TEST_CASE("DenseDuplicateTracker removes duplicate ids", "[ut][DenseDuplicateTracker]") {
+    auto allocator = std::make_shared<DefaultAllocator>();
+    DenseDuplicateTracker tracker(allocator.get());
+    tracker.Resize(6);
+
+    tracker.SetDuplicateId(0, 1);
+    tracker.SetDuplicateId(0, 2);
+    tracker.SetDuplicateId(3, 4);
+
+    REQUIRE(tracker.RemoveDuplicateId(1));
+    REQUIRE(sorted_duplicates(tracker.GetDuplicateIds(0)) == std::vector<InnerIdType>{2});
+    REQUIRE(tracker.GetDuplicateIds(1).empty());
+    REQUIRE(tracker.GetGroupId(1) == 1);
+    REQUIRE(tracker.GetGroupId(2) == 0);
+
+    REQUIRE(tracker.RemoveDuplicateId(2));
+    REQUIRE(tracker.GetDuplicateIds(0).empty());
+    REQUIRE(tracker.GetGroupId(2) == 2);
+
+    REQUIRE(tracker.RemoveDuplicateId(4));
+    REQUIRE(tracker.GetDuplicateIds(3).empty());
+    REQUIRE_FALSE(tracker.RemoveDuplicateId(5));
+}
+
 TEST_CASE("DenseDuplicateTracker serialize and deserialize", "[ut][DenseDuplicateTracker]") {
     auto allocator = std::make_shared<DefaultAllocator>();
     DenseDuplicateTracker tracker(allocator.get());

--- a/src/datacell/duplicate_interface.h
+++ b/src/datacell/duplicate_interface.h
@@ -33,6 +33,9 @@ public:
     virtual void
     SetDuplicateId(InnerIdType group_id, InnerIdType duplicate_id) = 0;
 
+    virtual bool
+    RemoveDuplicateId(InnerIdType duplicate_id) = 0;
+
     [[nodiscard]] virtual auto
     GetDuplicateIds(InnerIdType id) const -> std::vector<InnerIdType> = 0;
 

--- a/src/datacell/graph_interface.h
+++ b/src/datacell/graph_interface.h
@@ -217,6 +217,14 @@ public:
         }
     }
 
+    bool
+    RemoveDuplicateId(InnerIdType duplicate_id) {
+        if (duplicate_tracker_) {
+            return duplicate_tracker_->RemoveDuplicateId(duplicate_id);
+        }
+        return false;
+    }
+
     std::vector<InnerIdType>
     GetDuplicateIds(InnerIdType id) const {
         if (duplicate_tracker_) {

--- a/src/datacell/sparse_duplicate_tracker.cpp
+++ b/src/datacell/sparse_duplicate_tracker.cpp
@@ -130,8 +130,15 @@ SparseDuplicateTracker::RemoveDuplicateId(InnerIdType duplicate_id) {
     auto previous_id = duplicate_id;
     uint64_t count = 0;
     const auto max_count = next_ids_.size();
-    while (next_ids_[previous_id] != duplicate_id) {
-        previous_id = next_ids_.at(previous_id);
+    while (true) {
+        const auto previous_iter = next_ids_.find(previous_id);
+        if (previous_iter == next_ids_.end()) {
+            return false;
+        }
+        if (previous_iter->second == duplicate_id) {
+            break;
+        }
+        previous_id = previous_iter->second;
         if (++count > max_count) {
             return false;
         }

--- a/src/datacell/sparse_duplicate_tracker.cpp
+++ b/src/datacell/sparse_duplicate_tracker.cpp
@@ -119,6 +119,31 @@ SparseDuplicateTracker::SetDuplicateId(InnerIdType group_id, InnerIdType duplica
     next_ids_[group_id] = duplicate_id;
 }
 
+bool
+SparseDuplicateTracker::RemoveDuplicateId(InnerIdType duplicate_id) {
+    std::scoped_lock lock(mutex_);
+
+    if (next_ids_.count(duplicate_id) == 0) {
+        return false;
+    }
+
+    auto previous_id = duplicate_id;
+    while (next_ids_[previous_id] != duplicate_id) {
+        previous_id = next_ids_[previous_id];
+    }
+
+    const auto next_id = next_ids_[duplicate_id];
+    next_ids_.erase(duplicate_id);
+    if (previous_id == next_id) {
+        next_ids_.erase(previous_id);
+        duplicate_count_--;
+        return true;
+    }
+
+    next_ids_[previous_id] = next_id;
+    return true;
+}
+
 auto
 SparseDuplicateTracker::GetDuplicateIds(InnerIdType id) const -> std::vector<InnerIdType> {
     std::shared_lock lock(mutex_);

--- a/src/datacell/sparse_duplicate_tracker.cpp
+++ b/src/datacell/sparse_duplicate_tracker.cpp
@@ -128,8 +128,13 @@ SparseDuplicateTracker::RemoveDuplicateId(InnerIdType duplicate_id) {
     }
 
     auto previous_id = duplicate_id;
+    uint64_t count = 0;
+    const auto max_count = next_ids_.size();
     while (next_ids_[previous_id] != duplicate_id) {
-        previous_id = next_ids_[previous_id];
+        previous_id = next_ids_.at(previous_id);
+        if (++count > max_count) {
+            return false;
+        }
     }
 
     const auto next_id = next_ids_[duplicate_id];

--- a/src/datacell/sparse_duplicate_tracker.h
+++ b/src/datacell/sparse_duplicate_tracker.h
@@ -29,6 +29,9 @@ public:
     void
     SetDuplicateId(InnerIdType group_id, InnerIdType duplicate_id) override;
 
+    bool
+    RemoveDuplicateId(InnerIdType duplicate_id) override;
+
     auto
     GetDuplicateIds(InnerIdType id) const -> std::vector<InnerIdType> override;
 

--- a/src/datacell/sparse_duplicate_tracker_test.cpp
+++ b/src/datacell/sparse_duplicate_tracker_test.cpp
@@ -79,6 +79,29 @@ TEST_CASE("SparseDuplicateTracker ignores duplicate reinsertion", "[ut][SparseDu
     REQUIRE(tracker.GetDuplicateIds(0) == std::vector<InnerIdType>{1});
 }
 
+TEST_CASE("SparseDuplicateTracker removes duplicate ids", "[ut][SparseDuplicateTracker]") {
+    auto allocator = std::make_shared<DefaultAllocator>();
+    SparseDuplicateTracker tracker(allocator.get());
+
+    tracker.SetDuplicateId(0, 1);
+    tracker.SetDuplicateId(0, 2);
+    tracker.SetDuplicateId(3, 4);
+
+    REQUIRE(tracker.RemoveDuplicateId(1));
+    REQUIRE(sorted_duplicates(tracker.GetDuplicateIds(0)) == std::vector<InnerIdType>{2});
+    REQUIRE(tracker.GetDuplicateIds(1).empty());
+    REQUIRE(tracker.GetGroupId(1) == 1);
+    REQUIRE(tracker.GetGroupId(2) == 0);
+
+    REQUIRE(tracker.RemoveDuplicateId(2));
+    REQUIRE(tracker.GetDuplicateIds(0).empty());
+    REQUIRE(tracker.GetGroupId(2) == 2);
+
+    REQUIRE(tracker.RemoveDuplicateId(4));
+    REQUIRE(tracker.GetDuplicateIds(3).empty());
+    REQUIRE_FALSE(tracker.RemoveDuplicateId(5));
+}
+
 TEST_CASE("SparseDuplicateTracker serialize and deserialize", "[ut][SparseDuplicateTracker]") {
     auto allocator = std::make_shared<DefaultAllocator>();
     SparseDuplicateTracker tracker(allocator.get());

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -386,6 +386,17 @@ RunWithGeneratedBlockSizeLimit(Fn&& fn) {
     vsag::Options::Instance().set_block_size_limit(origin_size);
 }
 
+bool
+FindDistanceById(const vsag::DatasetPtr& result, int64_t id, float& distance) {
+    for (int64_t i = 0; i < result->GetDim(); ++i) {
+        if (result->GetIds()[i] == id) {
+            distance = result->GetDistances()[i];
+            return true;
+        }
+    }
+    return false;
+}
+
 template <typename Cases, typename Fn>
 void
 ForEachHGraphCase(const fixtures::HGraphResourcePtr& resource, const Cases& test_cases, Fn&& fn) {
@@ -2031,6 +2042,93 @@ TestHGraphDuplicateBuild(const fixtures::HGraphTestIndexPtr& test_index,
 HGRAPH_PR_DAILY_CASE("HGraph Duplicate Build",
                      "[ft][build][duplicate][hgraph]",
                      TestHGraphDuplicateBuild)
+
+TEST_CASE("HGraph UpdateVector refreshes duplicate member state",
+          "[ft][hgraph][duplicate][update]") {
+    using namespace fixtures;
+
+    constexpr int64_t kEntryId = 10;
+    constexpr int64_t kRepresentativeId = 11;
+    constexpr int64_t kDuplicateId = 12;
+    constexpr int64_t kDim = 2;
+    constexpr float kNearRadius = 0.01F;
+    const std::string search_param = R"({"hgraph":{"ef_search":32}})";
+
+    auto make_updated_index = [&]() -> TestIndex::IndexPtr {
+        HGraphTestIndex::HGraphBuildParam build_param("l2", kDim, "fp32");
+        build_param.support_duplicate = true;
+        build_param.thread_count = 1;
+
+        auto param = HGraphTestIndex::GenerateHGraphBuildParametersString(build_param);
+        auto index = TestIndex::TestFactory(HGraphTestIndex::name, param, true);
+
+        float entry_vector[kDim] = {-1.0F, 0.0F};
+        int64_t entry_id[1] = {kEntryId};
+        auto entry = vsag::Dataset::Make();
+        entry->NumElements(1)->Dim(kDim)->Ids(entry_id)->Float32Vectors(entry_vector)->Owner(false);
+        REQUIRE(index->Build(entry).has_value());
+
+        float representative_vector[kDim] = {1.0F, 0.0F};
+        int64_t representative_id[1] = {kRepresentativeId};
+        auto representative = vsag::Dataset::Make();
+        representative->NumElements(1)
+            ->Dim(kDim)
+            ->Ids(representative_id)
+            ->Float32Vectors(representative_vector)
+            ->Owner(false);
+        REQUIRE(index->Add(representative).has_value());
+
+        float duplicate_vector[kDim] = {1.0F, 0.0F};
+        int64_t duplicate_id[1] = {kDuplicateId};
+        auto duplicate = vsag::Dataset::Make();
+        duplicate->NumElements(1)->Dim(kDim)->Ids(duplicate_id)->Float32Vectors(duplicate_vector);
+        duplicate->Owner(false);
+        REQUIRE(index->Add(duplicate).has_value());
+        REQUIRE(index->CheckIdExist(kDuplicateId));
+
+        float moved_vector[kDim] = {0.0F, 1.0F};
+        auto moved = vsag::Dataset::Make();
+        moved->NumElements(1)->Dim(kDim)->Float32Vectors(moved_vector);
+        moved->Owner(false);
+        auto update = index->UpdateVector(kDuplicateId, moved, true);
+        REQUIRE(update.has_value());
+        REQUIRE(update.value());
+
+        return index;
+    };
+
+    SECTION("search expansion uses the updated duplicate member distance") {
+        auto index = make_updated_index();
+        float representative_query_vector[kDim] = {1.0F, 0.0F};
+        auto query = vsag::Dataset::Make();
+        query->NumElements(1)->Dim(kDim)->Float32Vectors(representative_query_vector);
+        query->Owner(false);
+
+        auto result = index->KnnSearch(query, 3, search_param);
+        REQUIRE(result.has_value());
+
+        float returned_distance = 0.0F;
+        REQUIRE(FindDistanceById(result.value(), kDuplicateId, returned_distance));
+
+        auto exact_distance = index->CalcDistanceById(representative_query_vector, kDuplicateId);
+        REQUIRE(exact_distance.has_value());
+        REQUIRE(std::abs(returned_distance - exact_distance.value()) < 1e-5F);
+    }
+
+    SECTION("updated duplicate-only member is searchable at its new position") {
+        auto index = make_updated_index();
+        float moved_query_vector[kDim] = {0.0F, 1.0F};
+        auto query = vsag::Dataset::Make();
+        query->NumElements(1)->Dim(kDim)->Float32Vectors(moved_query_vector);
+        query->Owner(false);
+
+        auto result = index->RangeSearch(query, kNearRadius, search_param, 1);
+        REQUIRE(result.has_value());
+        REQUIRE(result.value()->GetDim() == 1);
+        REQUIRE(result.value()->GetIds()[0] == kDuplicateId);
+        REQUIRE(std::abs(result.value()->GetDistances()[0]) < 1e-5F);
+    }
+}
 
 static void
 TestHGraphEstimateMemoryAndGetMemoryUsage(const fixtures::HGraphTestIndexPtr& test_index,

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -2054,7 +2054,7 @@ TEST_CASE("HGraph UpdateVector refreshes duplicate member state",
     constexpr float kNearRadius = 0.01F;
     const std::string search_param = R"({"hgraph":{"ef_search":32}})";
 
-    auto make_updated_index = [&]() -> TestIndex::IndexPtr {
+    auto make_duplicate_index = [&]() -> TestIndex::IndexPtr {
         HGraphTestIndex::HGraphBuildParam build_param("l2", kDim, "fp32");
         build_param.support_duplicate = true;
         build_param.thread_count = 1;
@@ -2086,6 +2086,11 @@ TEST_CASE("HGraph UpdateVector refreshes duplicate member state",
         REQUIRE(index->Add(duplicate).has_value());
         REQUIRE(index->CheckIdExist(kDuplicateId));
 
+        return index;
+    };
+
+    auto make_updated_index = [&]() -> TestIndex::IndexPtr {
+        auto index = make_duplicate_index();
         float moved_vector[kDim] = {0.0F, 1.0F};
         auto moved = vsag::Dataset::Make();
         moved->NumElements(1)->Dim(kDim)->Float32Vectors(moved_vector);
@@ -2127,6 +2132,28 @@ TEST_CASE("HGraph UpdateVector refreshes duplicate member state",
         REQUIRE(result.value()->GetDim() == 1);
         REQUIRE(result.value()->GetIds()[0] == kDuplicateId);
         REQUIRE(std::abs(result.value()->GetDistances()[0]) < 1e-5F);
+    }
+
+    SECTION("updated duplicate representative detaches remaining members") {
+        auto index = make_duplicate_index();
+        float moved_vector[kDim] = {0.0F, 1.0F};
+        auto moved = vsag::Dataset::Make();
+        moved->NumElements(1)->Dim(kDim)->Float32Vectors(moved_vector);
+        moved->Owner(false);
+        auto update = index->UpdateVector(kRepresentativeId, moved, true);
+        REQUIRE(update.has_value());
+        REQUIRE(update.value());
+
+        float duplicate_query_vector[kDim] = {1.0F, 0.0F};
+        auto duplicate_query = vsag::Dataset::Make();
+        duplicate_query->NumElements(1)->Dim(kDim)->Float32Vectors(duplicate_query_vector);
+        duplicate_query->Owner(false);
+
+        auto duplicate_result = index->RangeSearch(duplicate_query, kNearRadius, search_param, 1);
+        REQUIRE(duplicate_result.has_value());
+        REQUIRE(duplicate_result.value()->GetDim() == 1);
+        REQUIRE(duplicate_result.value()->GetIds()[0] == kDuplicateId);
+        REQUIRE(std::abs(duplicate_result.value()->GetDistances()[0]) < 1e-5F);
     }
 }
 


### PR DESCRIPTION
## Summary

- add duplicate tracker removal support for dense and sparse duplicate trackers
- refresh HGraph duplicate-member state during `UpdateVector()` by removing stale duplicate membership and reconnecting the updated member to the bottom graph
- update raw vector storage when present and add regression coverage for duplicate update search correctness

## Root Cause

`HGraph::UpdateVector()` refreshed physical vector storage but left duplicate-only IDs in their old duplicate group and outside graph topology. Search-time duplicate expansion could then return the updated ID with the representative node's distance, and the updated ID was not searchable at its new position.

## Validation

- `git diff --check`
- `make test CASE='"DenseDuplicateTracker removes duplicate ids","SparseDuplicateTracker removes duplicate ids"'`
- `./build/tests/unittests -d yes "[DenseDuplicateTracker],[SparseDuplicateTracker]" --allow-running-no-tests ""`
- `make test CASE='"HGraph UpdateVector refreshes duplicate member state"'`

Fixes: #2322
