### PR TITLE
refactor(test): introduce TestMatrix and IndexTestSuite abstractions

### DIFF
--- a/tests/fixtures/framework/test_matrix.h
+++ b/tests/fixtures/framework/test_matrix.h
@@ -1,0 +1,110 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "test_dataset_pool.h"
+#include "vsag/options.h"
+#include "vsag/vsag.h"
+
+namespace fixtures {
+
+struct BlockSizeGuard {
+    uint64_t orig_;
+    explicit BlockSizeGuard(uint64_t new_size)
+        : orig_(vsag::Options::Instance().block_size_limit()) {
+        vsag::Options::Instance().set_block_size_limit(new_size);
+    }
+    ~BlockSizeGuard() {
+        vsag::Options::Instance().set_block_size_limit(orig_);
+    }
+    BlockSizeGuard(const BlockSizeGuard&) = delete;
+    BlockSizeGuard&
+    operator=(const BlockSizeGuard&) = delete;
+};
+
+struct TestMatrix {
+    std::vector<std::string> metrics;
+    std::vector<int> dims;
+    std::vector<std::pair<std::string, float>> quantizers;
+    uint64_t base_count{1000};
+    uint64_t block_size{1024 * 1024 * 2};
+
+    struct Iteration {
+        std::string metric;
+        int dim;
+        std::string quantizer;
+        float recall;
+    };
+
+    std::vector<Iteration>
+    Expand() const {
+        std::vector<Iteration> result;
+        result.reserve(metrics.size() * dims.size() * quantizers.size());
+        for (const auto& metric : metrics)
+            for (auto dim : dims)
+                for (const auto& [q, recall] : quantizers)
+                    result.push_back({metric, dim, q, recall});
+        return result;
+    }
+
+    std::vector<Iteration>
+    ExpandDimQuantizer() const {
+        std::vector<Iteration> result;
+        if (metrics.empty())
+            return result;
+        const auto& metric = metrics[0];
+        for (auto dim : dims)
+            for (const auto& [q, recall] : quantizers) result.push_back({metric, dim, q, recall});
+        return result;
+    }
+
+    std::vector<Iteration>
+    ExpandMetricQuantizer() const {
+        std::vector<Iteration> result;
+        if (dims.empty())
+            return result;
+        int dim = dims[0];
+        for (const auto& metric : metrics)
+            for (const auto& [q, recall] : quantizers) result.push_back({metric, dim, q, recall});
+        return result;
+    }
+
+    void
+    ForEach(TestDatasetPool& pool, const std::function<void(const Iteration&)>& fn) const {
+        BlockSizeGuard guard(block_size);
+        for (const auto& iter : Expand()) {
+            pool.GetDatasetAndCreate(iter.dim, base_count, iter.metric);
+            fn(iter);
+        }
+    }
+
+    void
+    ForEachDimQuantizer(TestDatasetPool& pool,
+                        const std::function<void(const Iteration&)>& fn) const {
+        BlockSizeGuard guard(block_size);
+        for (const auto& iter : ExpandDimQuantizer()) {
+            pool.GetDatasetAndCreate(iter.dim, base_count, iter.metric);
+            fn(iter);
+        }
+    }
+};
+
+}  // namespace fixtures

--- a/tests/fixtures/functest.h
+++ b/tests/fixtures/functest.h
@@ -29,6 +29,7 @@
 #include "framework/test_dataset.h"
 #include "framework/test_dataset_pool.h"
 #include "framework/test_logger.h"
+#include "framework/test_matrix.h"
 #include "framework/test_reader.h"
 #include "framework/test_thread_pool.h"
 #include "unittest.h"

--- a/tests/test_brute_force.cpp
+++ b/tests/test_brute_force.cpp
@@ -1,4 +1,3 @@
-
 // Copyright 2024-present the vsag project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -40,16 +39,6 @@ CheckSameRangeSearchResults(const vsag::DatasetPtr& lhs, const vsag::DatasetPtr&
     }
 }
 
-class BruteForceTestResource {
-public:
-    std::vector<int> dims;
-    std::vector<std::pair<std::string, float>> test_cases;
-    std::vector<std::string> metric_types;
-    std::vector<std::string> train_types;
-    uint64_t base_count;
-};
-using BruteForceResourcePtr = std::shared_ptr<BruteForceTestResource>;
-
 class BruteForceTestIndex : public fixtures::TestIndex {
 public:
     static std::string
@@ -58,8 +47,8 @@ public:
                                             const std::string& quantization_str = "sq8",
                                             bool use_attr_filter = false);
 
-    static BruteForceResourcePtr
-    GetResource(bool sample = true);
+    static TestMatrix
+    GetMatrix(bool sample = true);
 
     static void
     TestGeneral(const IndexPtr& index,
@@ -91,21 +80,21 @@ const std::vector<std::pair<std::string, float>> BruteForceTestIndex::all_test_c
 
 constexpr static const char* search_param_tmp = "";
 
-BruteForceResourcePtr
-BruteForceTestIndex::GetResource(bool sample) {
-    auto resource = std::make_shared<BruteForceTestResource>();
+TestMatrix
+BruteForceTestIndex::GetMatrix(bool sample) {
+    TestMatrix matrix;
+    matrix.base_count = BruteForceTestIndex::base_count;
     if (sample) {
-        resource->dims = fixtures::get_common_used_dims(1, RandomValue(0, 999));
-        resource->test_cases = fixtures::RandomSelect(BruteForceTestIndex::all_test_cases, 3);
-        resource->metric_types = fixtures::RandomSelect<std::string>({"ip", "l2", "cosine"}, 1);
-        resource->base_count = BruteForceTestIndex::base_count;
+        matrix.dims = fixtures::get_common_used_dims(1, RandomValue(0, 999));
+        matrix.quantizers = fixtures::RandomSelect(BruteForceTestIndex::all_test_cases, 3);
+        matrix.metrics = fixtures::RandomSelect<std::string>({"ip", "l2", "cosine"}, 1);
     } else {
-        resource->dims = fixtures::get_index_test_dims(3, RandomValue(0, 999));
-        resource->test_cases = BruteForceTestIndex::all_test_cases;
-        resource->metric_types = fixtures::RandomSelect<std::string>({"ip", "l2", "cosine"}, 2);
-        resource->base_count = BruteForceTestIndex::base_count * 3;
+        matrix.dims = fixtures::get_index_test_dims(3, RandomValue(0, 999));
+        matrix.quantizers = BruteForceTestIndex::all_test_cases;
+        matrix.metrics = fixtures::RandomSelect<std::string>({"ip", "l2", "cosine"}, 2);
+        matrix.base_count = BruteForceTestIndex::base_count * 3;
     }
-    return resource;
+    return matrix;
 }
 
 std::string
@@ -113,8 +102,6 @@ BruteForceTestIndex::GenerateBruteForceBuildParametersString(const std::string& 
                                                              int64_t dim,
                                                              const std::string& quantization_str,
                                                              bool use_attr_filter) {
-    std::string build_parameters_str;
-
     constexpr auto parameter_temp = R"(
     {{
         "dtype": "float32",
@@ -127,11 +114,7 @@ BruteForceTestIndex::GenerateBruteForceBuildParametersString(const std::string& 
         }}
     }}
     )";
-
-    build_parameters_str =
-        fmt::format(parameter_temp, metric_type, dim, quantization_str, use_attr_filter);
-
-    return build_parameters_str;
+    return fmt::format(parameter_temp, metric_type, dim, quantization_str, use_attr_filter);
 }
 
 void
@@ -227,72 +210,55 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::BruteForceTestIndex,
     }
 }
 
-static void
-TestBruteForceBuildAndContinueAdd(const fixtures::BruteForceResourcePtr& resource) {
-    using namespace fixtures;
-    auto origin_size = vsag::Options::Instance().block_size_limit();
-    auto size = 1024 * 1024 * 2;
-
-    vsag::Options::Instance().set_block_size_limit(size);
-    for (const auto& metric_type : resource->metric_types) {
-        for (auto dim : resource->dims) {
-            for (const auto& [base_quantization_str, recall] : resource->test_cases) {
-                auto param = BruteForceTestIndex::GenerateBruteForceBuildParametersString(
-                    metric_type, dim, base_quantization_str);
-                auto index = TestIndex::TestFactory(BruteForceTestIndex::name, param, true);
-                auto dataset = BruteForceTestIndex::pool.GetDatasetAndCreate(
-                    dim, BruteForceTestIndex::base_count, metric_type);
-                TestIndex::TestContinueAdd(index, dataset, true);
-                BruteForceTestIndex::TestGeneral(index, dataset, search_param_tmp, recall);
-            }
-        }
-    }
-    vsag::Options::Instance().set_block_size_limit(origin_size);
-}
-
 TEST_CASE("(PR) BruteForce Build & ContinueAdd Test", "[ft][build][bruteforce][pr]") {
-    auto resource = fixtures::BruteForceTestIndex::GetResource(true);
-    TestBruteForceBuildAndContinueAdd(resource);
+    auto matrix = fixtures::BruteForceTestIndex::GetMatrix(true);
+    matrix.ForEach(fixtures::BruteForceTestIndex::pool, [&](const auto& iter) {
+        auto param = fixtures::BruteForceTestIndex::GenerateBruteForceBuildParametersString(
+            iter.metric, iter.dim, iter.quantizer);
+        auto index =
+            fixtures::TestIndex::TestFactory(fixtures::BruteForceTestIndex::name, param, true);
+        auto dataset = fixtures::BruteForceTestIndex::pool.GetDatasetAndCreate(
+            iter.dim, matrix.base_count, iter.metric);
+        fixtures::TestIndex::TestContinueAdd(index, dataset, true);
+        fixtures::BruteForceTestIndex::TestGeneral(
+            index, dataset, fixtures::search_param_tmp, iter.recall);
+    });
 }
 
 TEST_CASE("(Daily) BruteForce Build & ContinueAdd Test", "[ft][build][bruteforce][daily]") {
-    auto resource = fixtures::BruteForceTestIndex::GetResource(false);
-    TestBruteForceBuildAndContinueAdd(resource);
-}
-
-static void
-TestBruteForceBuild(const fixtures::BruteForceResourcePtr& resource) {
-    using namespace fixtures;
-    auto origin_size = vsag::Options::Instance().block_size_limit();
-    auto size = GENERATE(1024 * 1024 * 2);
-    std::vector<int32_t> search_threads_counts{1, 3};
-    constexpr static const char* search_param_tmp2 = R"(
-    {{
-        "parallelism": {}
-    }})";
-    for (const auto& metric_type : resource->metric_types) {
-        for (auto dim : resource->dims) {
-            for (const auto& [base_quantization_str, recall] : resource->test_cases) {
-                vsag::Options::Instance().set_block_size_limit(size);
-                auto param = BruteForceTestIndex::GenerateBruteForceBuildParametersString(
-                    metric_type, dim, base_quantization_str);
-                auto index = TestIndex::TestFactory(BruteForceTestIndex::name, param, true);
-                auto dataset = BruteForceTestIndex::pool.GetDatasetAndCreate(
-                    dim, BruteForceTestIndex::base_count, metric_type);
-                TestIndex::TestBuildIndex(index, dataset, true);
-                for (auto search_thread_count : search_threads_counts) {
-                    auto search_param = fmt::format(search_param_tmp2, search_thread_count);
-                    BruteForceTestIndex::TestGeneral(index, dataset, search_param, recall);
-                }
-                vsag::Options::Instance().set_block_size_limit(origin_size);
-            }
-        }
-    }
+    auto matrix = fixtures::BruteForceTestIndex::GetMatrix(false);
+    matrix.ForEach(fixtures::BruteForceTestIndex::pool, [&](const auto& iter) {
+        auto param = fixtures::BruteForceTestIndex::GenerateBruteForceBuildParametersString(
+            iter.metric, iter.dim, iter.quantizer);
+        auto index =
+            fixtures::TestIndex::TestFactory(fixtures::BruteForceTestIndex::name, param, true);
+        auto dataset = fixtures::BruteForceTestIndex::pool.GetDatasetAndCreate(
+            iter.dim, matrix.base_count, iter.metric);
+        fixtures::TestIndex::TestContinueAdd(index, dataset, true);
+        fixtures::BruteForceTestIndex::TestGeneral(
+            index, dataset, fixtures::search_param_tmp, iter.recall);
+    });
 }
 
 TEST_CASE("(PR) BruteForce Build Test", "[ft][build][bruteforce][pr]") {
-    auto resource = fixtures::BruteForceTestIndex::GetResource(true);
-    TestBruteForceBuild(resource);
+    auto matrix = fixtures::BruteForceTestIndex::GetMatrix(true);
+    auto size = GENERATE(1024 * 1024 * 2);
+    std::vector<int32_t> search_threads_counts{1, 3};
+    constexpr static const char* search_param_tmp2 = R"({{ "parallelism": {} }})";
+    matrix.ForEach(fixtures::BruteForceTestIndex::pool, [&](const auto& iter) {
+        vsag::Options::Instance().set_block_size_limit(size);
+        auto param = fixtures::BruteForceTestIndex::GenerateBruteForceBuildParametersString(
+            iter.metric, iter.dim, iter.quantizer);
+        auto index =
+            fixtures::TestIndex::TestFactory(fixtures::BruteForceTestIndex::name, param, true);
+        auto dataset = fixtures::BruteForceTestIndex::pool.GetDatasetAndCreate(
+            iter.dim, matrix.base_count, iter.metric);
+        fixtures::TestIndex::TestBuildIndex(index, dataset, true);
+        for (auto tc : search_threads_counts) {
+            auto sp = fmt::format(search_param_tmp2, tc);
+            fixtures::BruteForceTestIndex::TestGeneral(index, dataset, sp, iter.recall);
+        }
+    });
 }
 
 TEST_CASE("(PR) BruteForce Parallel RangeSearch Test", "[ft][range_search][bruteforce][pr]") {
@@ -334,470 +300,472 @@ TEST_CASE("(PR) BruteForce Parallel RangeSearch Test", "[ft][range_search][brute
     auto single = index->RangeSearch(query, 16.0F, "{}", 4).value();
     auto parallel = index->RangeSearch(query, 16.0F, R"({"parallelism": 4})", 4).value();
     fixtures::CheckSameRangeSearchResults(single, parallel);
-
     REQUIRE_FALSE(index->RangeSearch(query, 16.0F, R"({"parallelism": 4})", 0).has_value());
 
-    auto excessive_parallelism =
-        index->RangeSearch(query, 16.0F, R"({"parallelism": 32})", 4).value();
-    fixtures::CheckSameRangeSearchResults(single, excessive_parallelism);
+    auto excessive = index->RangeSearch(query, 16.0F, R"({"parallelism": 32})", 4).value();
+    fixtures::CheckSameRangeSearchResults(single, excessive);
 
     auto filter = std::make_shared<fixtures::EvenIdFilter>();
-    auto filtered_single = index->RangeSearch(query, 64.0F, "{}", filter, 3).value();
-    auto filtered_parallel =
-        index->RangeSearch(query, 64.0F, R"({"parallelism": 4})", filter, 3).value();
-    fixtures::CheckSameRangeSearchResults(filtered_single, filtered_parallel);
+    auto fs = index->RangeSearch(query, 64.0F, "{}", filter, 3).value();
+    auto fp = index->RangeSearch(query, 64.0F, R"({"parallelism": 4})", filter, 3).value();
+    fixtures::CheckSameRangeSearchResults(fs, fp);
 }
 
 TEST_CASE("(Daily) BruteForce Build Test", "[ft][build][bruteforce][daily]") {
-    auto resource = fixtures::BruteForceTestIndex::GetResource(false);
-    TestBruteForceBuild(resource);
-}
-
-static void
-TestBruteForceAdd(const fixtures::BruteForceResourcePtr& resource) {
-    using namespace fixtures;
-    auto origin_size = vsag::Options::Instance().block_size_limit();
-    auto size = 1024 * 1024 * 2;
-    for (const auto& metric_type : resource->metric_types) {
-        for (auto dim : resource->dims) {
-            for (const auto& [base_quantization_str, recall] : resource->test_cases) {
-                vsag::Options::Instance().set_block_size_limit(size);
-                auto param = BruteForceTestIndex::GenerateBruteForceBuildParametersString(
-                    metric_type, dim, base_quantization_str);
-                auto index = TestIndex::TestFactory(BruteForceTestIndex::name, param, true);
-                auto dataset = BruteForceTestIndex::pool.GetDatasetAndCreate(
-                    dim, BruteForceTestIndex::base_count, metric_type);
-                TestIndex::TestAddIndex(index, dataset, true);
-                if (index->CheckFeature(vsag::SUPPORT_ADD_FROM_EMPTY)) {
-                    BruteForceTestIndex::TestGeneral(index, dataset, search_param_tmp, recall);
-                }
-                vsag::Options::Instance().set_block_size_limit(origin_size);
-            }
+    auto matrix = fixtures::BruteForceTestIndex::GetMatrix(false);
+    auto size = GENERATE(1024 * 1024 * 2);
+    std::vector<int32_t> search_threads_counts{1, 3};
+    constexpr static const char* search_param_tmp2 = R"({{ "parallelism": {} }})";
+    matrix.ForEach(fixtures::BruteForceTestIndex::pool, [&](const auto& iter) {
+        vsag::Options::Instance().set_block_size_limit(size);
+        auto param = fixtures::BruteForceTestIndex::GenerateBruteForceBuildParametersString(
+            iter.metric, iter.dim, iter.quantizer);
+        auto index =
+            fixtures::TestIndex::TestFactory(fixtures::BruteForceTestIndex::name, param, true);
+        auto dataset = fixtures::BruteForceTestIndex::pool.GetDatasetAndCreate(
+            iter.dim, matrix.base_count, iter.metric);
+        fixtures::TestIndex::TestBuildIndex(index, dataset, true);
+        for (auto tc : search_threads_counts) {
+            auto sp = fmt::format(search_param_tmp2, tc);
+            fixtures::BruteForceTestIndex::TestGeneral(index, dataset, sp, iter.recall);
         }
-    }
+    });
 }
 
 TEST_CASE("(PR) BruteForce Add Test", "[ft][build][bruteforce][pr]") {
-    auto resource = fixtures::BruteForceTestIndex::GetResource(true);
-    TestBruteForceAdd(resource);
+    auto matrix = fixtures::BruteForceTestIndex::GetMatrix(true);
+    matrix.ForEach(fixtures::BruteForceTestIndex::pool, [&](const auto& iter) {
+        auto param = fixtures::BruteForceTestIndex::GenerateBruteForceBuildParametersString(
+            iter.metric, iter.dim, iter.quantizer);
+        auto index =
+            fixtures::TestIndex::TestFactory(fixtures::BruteForceTestIndex::name, param, true);
+        auto dataset = fixtures::BruteForceTestIndex::pool.GetDatasetAndCreate(
+            iter.dim, matrix.base_count, iter.metric);
+        fixtures::TestIndex::TestAddIndex(index, dataset, true);
+        if (index->CheckFeature(vsag::SUPPORT_ADD_FROM_EMPTY)) {
+            fixtures::BruteForceTestIndex::TestGeneral(
+                index, dataset, fixtures::search_param_tmp, iter.recall);
+        }
+    });
 }
 
 TEST_CASE("(Daily) BruteForce Add Test", "[ft][build][bruteforce][daily]") {
-    auto resource = fixtures::BruteForceTestIndex::GetResource(false);
-    TestBruteForceAdd(resource);
-}
-
-static void
-TestBruteForceConcurrentAdd(const fixtures::BruteForceResourcePtr& resource) {
-    using namespace fixtures;
-    auto origin_size = vsag::Options::Instance().block_size_limit();
-    auto size = 1024 * 1024 * 2;
-    for (const auto& metric_type : resource->metric_types) {
-        for (auto dim : resource->dims) {
-            for (const auto& [base_quantization_str, recall] : resource->test_cases) {
-                vsag::Options::Instance().set_block_size_limit(size);
-                auto param = BruteForceTestIndex::GenerateBruteForceBuildParametersString(
-                    metric_type, dim, base_quantization_str);
-                auto index = TestIndex::TestFactory(BruteForceTestIndex::name, param, true);
-                auto dataset = BruteForceTestIndex::pool.GetDatasetAndCreate(
-                    dim, BruteForceTestIndex::base_count, metric_type);
-                TestIndex::TestConcurrentAdd(index, dataset, true);
-                if (index->CheckFeature(vsag::SUPPORT_ADD_CONCURRENT)) {
-                    BruteForceTestIndex::TestGeneral(index, dataset, search_param_tmp, recall);
-                }
-                vsag::Options::Instance().set_block_size_limit(origin_size);
-            }
+    auto matrix = fixtures::BruteForceTestIndex::GetMatrix(false);
+    matrix.ForEach(fixtures::BruteForceTestIndex::pool, [&](const auto& iter) {
+        auto param = fixtures::BruteForceTestIndex::GenerateBruteForceBuildParametersString(
+            iter.metric, iter.dim, iter.quantizer);
+        auto index =
+            fixtures::TestIndex::TestFactory(fixtures::BruteForceTestIndex::name, param, true);
+        auto dataset = fixtures::BruteForceTestIndex::pool.GetDatasetAndCreate(
+            iter.dim, matrix.base_count, iter.metric);
+        fixtures::TestIndex::TestAddIndex(index, dataset, true);
+        if (index->CheckFeature(vsag::SUPPORT_ADD_FROM_EMPTY)) {
+            fixtures::BruteForceTestIndex::TestGeneral(
+                index, dataset, fixtures::search_param_tmp, iter.recall);
         }
-    }
+    });
 }
 
 TEST_CASE("(PR) BruteForce Concurrent Add Test", "[ft][build][bruteforce][concurrent][pr]") {
-    auto resource = fixtures::BruteForceTestIndex::GetResource(true);
-    TestBruteForceConcurrentAdd(resource);
+    auto matrix = fixtures::BruteForceTestIndex::GetMatrix(true);
+    matrix.ForEach(fixtures::BruteForceTestIndex::pool, [&](const auto& iter) {
+        auto param = fixtures::BruteForceTestIndex::GenerateBruteForceBuildParametersString(
+            iter.metric, iter.dim, iter.quantizer);
+        auto index =
+            fixtures::TestIndex::TestFactory(fixtures::BruteForceTestIndex::name, param, true);
+        auto dataset = fixtures::BruteForceTestIndex::pool.GetDatasetAndCreate(
+            iter.dim, matrix.base_count, iter.metric);
+        fixtures::TestIndex::TestConcurrentAdd(index, dataset, true);
+        if (index->CheckFeature(vsag::SUPPORT_ADD_CONCURRENT)) {
+            fixtures::BruteForceTestIndex::TestGeneral(
+                index, dataset, fixtures::search_param_tmp, iter.recall);
+        }
+    });
 }
 
 TEST_CASE("(Daily) BruteForce Concurrent Add Test", "[ft][build][bruteforce][concurrent][daily]") {
-    auto resource = fixtures::BruteForceTestIndex::GetResource(false);
-    TestBruteForceConcurrentAdd(resource);
-}
-
-static void
-TestBruteForceSerializeFile(const fixtures::BruteForceResourcePtr& resource) {
-    using namespace fixtures;
-
-    auto origin_size = vsag::Options::Instance().block_size_limit();
-    auto size = 1024 * 1024 * 2;
-    for (const auto& metric_type : resource->metric_types) {
-        for (auto dim : resource->dims) {
-            for (const auto& [base_quantization_str, recall] : resource->test_cases) {
-                vsag::Options::Instance().set_block_size_limit(size);
-                auto param = BruteForceTestIndex::GenerateBruteForceBuildParametersString(
-                    metric_type, dim, base_quantization_str);
-                auto index = TestIndex::TestFactory(BruteForceTestIndex::name, param, true);
-                auto dataset = BruteForceTestIndex::pool.GetDatasetAndCreate(
-                    dim, BruteForceTestIndex::base_count, metric_type);
-                TestIndex::TestBuildIndex(index, dataset, true);
-                auto index2 = TestIndex::TestFactory(BruteForceTestIndex::name, param, true);
-                TestIndex::TestSerializeFile(index, index2, dataset, search_param_tmp, true);
-                index2 = TestIndex::TestFactory(BruteForceTestIndex::name, param, true);
-                TestIndex::TestSerializeBinarySet(index, index2, dataset, search_param_tmp, true);
-                index2 = TestIndex::TestFactory(BruteForceTestIndex::name, param, true);
-                TestIndex::TestSerializeReaderSet(
-                    index, index2, dataset, search_param_tmp, BruteForceTestIndex::name, true);
-                vsag::Options::Instance().set_block_size_limit(origin_size);
-            }
+    auto matrix = fixtures::BruteForceTestIndex::GetMatrix(false);
+    matrix.ForEach(fixtures::BruteForceTestIndex::pool, [&](const auto& iter) {
+        auto param = fixtures::BruteForceTestIndex::GenerateBruteForceBuildParametersString(
+            iter.metric, iter.dim, iter.quantizer);
+        auto index =
+            fixtures::TestIndex::TestFactory(fixtures::BruteForceTestIndex::name, param, true);
+        auto dataset = fixtures::BruteForceTestIndex::pool.GetDatasetAndCreate(
+            iter.dim, matrix.base_count, iter.metric);
+        fixtures::TestIndex::TestConcurrentAdd(index, dataset, true);
+        if (index->CheckFeature(vsag::SUPPORT_ADD_CONCURRENT)) {
+            fixtures::BruteForceTestIndex::TestGeneral(
+                index, dataset, fixtures::search_param_tmp, iter.recall);
         }
-    }
+    });
 }
 
 TEST_CASE("(PR) BruteForce Serialize File Test", "[ft][serialize][bruteforce][pr]") {
-    auto resource = fixtures::BruteForceTestIndex::GetResource(true);
-    TestBruteForceSerializeFile(resource);
+    auto matrix = fixtures::BruteForceTestIndex::GetMatrix(true);
+    matrix.ForEach(fixtures::BruteForceTestIndex::pool, [&](const auto& iter) {
+        auto param = fixtures::BruteForceTestIndex::GenerateBruteForceBuildParametersString(
+            iter.metric, iter.dim, iter.quantizer);
+        auto index =
+            fixtures::TestIndex::TestFactory(fixtures::BruteForceTestIndex::name, param, true);
+        auto dataset = fixtures::BruteForceTestIndex::pool.GetDatasetAndCreate(
+            iter.dim, matrix.base_count, iter.metric);
+        fixtures::TestIndex::TestBuildIndex(index, dataset, true);
+        auto index2 =
+            fixtures::TestIndex::TestFactory(fixtures::BruteForceTestIndex::name, param, true);
+        fixtures::TestIndex::TestSerializeFile(
+            index, index2, dataset, fixtures::search_param_tmp, true);
+        index2 = fixtures::TestIndex::TestFactory(fixtures::BruteForceTestIndex::name, param, true);
+        fixtures::TestIndex::TestSerializeBinarySet(
+            index, index2, dataset, fixtures::search_param_tmp, true);
+        index2 = fixtures::TestIndex::TestFactory(fixtures::BruteForceTestIndex::name, param, true);
+        fixtures::TestIndex::TestSerializeReaderSet(index,
+                                                    index2,
+                                                    dataset,
+                                                    fixtures::search_param_tmp,
+                                                    fixtures::BruteForceTestIndex::name,
+                                                    true);
+    });
 }
 
 TEST_CASE("(Daily) BruteForce Serialize File Test", "[ft][serialize][bruteforce][daily]") {
-    auto resource = fixtures::BruteForceTestIndex::GetResource(false);
-    TestBruteForceSerializeFile(resource);
-}
-
-static void
-TestBruteForceClone(const fixtures::BruteForceResourcePtr& resource) {
-    using namespace fixtures;
-    auto origin_size = vsag::Options::Instance().block_size_limit();
-    auto size = 1024 * 1024 * 2;
-    for (const auto& metric_type : resource->metric_types) {
-        for (auto dim : resource->dims) {
-            for (const auto& [base_quantization_str, recall] : resource->test_cases) {
-                vsag::Options::Instance().set_block_size_limit(size);
-                auto param = BruteForceTestIndex::GenerateBruteForceBuildParametersString(
-                    metric_type, dim, base_quantization_str);
-                auto index = TestIndex::TestFactory(BruteForceTestIndex::name, param, true);
-                auto dataset = BruteForceTestIndex::pool.GetDatasetAndCreate(
-                    dim, BruteForceTestIndex::base_count, metric_type);
-                TestIndex::TestBuildIndex(index, dataset, true);
-                auto index2 = TestIndex::TestFactory(BruteForceTestIndex::name, param, true);
-                TestIndex::TestClone(index, dataset, search_param_tmp);
-                vsag::Options::Instance().set_block_size_limit(origin_size);
-            }
-        }
-    }
+    auto matrix = fixtures::BruteForceTestIndex::GetMatrix(false);
+    matrix.ForEach(fixtures::BruteForceTestIndex::pool, [&](const auto& iter) {
+        auto param = fixtures::BruteForceTestIndex::GenerateBruteForceBuildParametersString(
+            iter.metric, iter.dim, iter.quantizer);
+        auto index =
+            fixtures::TestIndex::TestFactory(fixtures::BruteForceTestIndex::name, param, true);
+        auto dataset = fixtures::BruteForceTestIndex::pool.GetDatasetAndCreate(
+            iter.dim, matrix.base_count, iter.metric);
+        fixtures::TestIndex::TestBuildIndex(index, dataset, true);
+        auto index2 =
+            fixtures::TestIndex::TestFactory(fixtures::BruteForceTestIndex::name, param, true);
+        fixtures::TestIndex::TestSerializeFile(
+            index, index2, dataset, fixtures::search_param_tmp, true);
+        index2 = fixtures::TestIndex::TestFactory(fixtures::BruteForceTestIndex::name, param, true);
+        fixtures::TestIndex::TestSerializeBinarySet(
+            index, index2, dataset, fixtures::search_param_tmp, true);
+        index2 = fixtures::TestIndex::TestFactory(fixtures::BruteForceTestIndex::name, param, true);
+        fixtures::TestIndex::TestSerializeReaderSet(index,
+                                                    index2,
+                                                    dataset,
+                                                    fixtures::search_param_tmp,
+                                                    fixtures::BruteForceTestIndex::name,
+                                                    true);
+    });
 }
 
 TEST_CASE("(PR) BruteForce Clone Test", "[ft][clone][bruteforce][pr]") {
-    auto resource = fixtures::BruteForceTestIndex::GetResource(true);
-    TestBruteForceClone(resource);
+    auto matrix = fixtures::BruteForceTestIndex::GetMatrix(true);
+    matrix.ForEach(fixtures::BruteForceTestIndex::pool, [&](const auto& iter) {
+        auto param = fixtures::BruteForceTestIndex::GenerateBruteForceBuildParametersString(
+            iter.metric, iter.dim, iter.quantizer);
+        auto index =
+            fixtures::TestIndex::TestFactory(fixtures::BruteForceTestIndex::name, param, true);
+        auto dataset = fixtures::BruteForceTestIndex::pool.GetDatasetAndCreate(
+            iter.dim, matrix.base_count, iter.metric);
+        fixtures::TestIndex::TestBuildIndex(index, dataset, true);
+        auto index2 =
+            fixtures::TestIndex::TestFactory(fixtures::BruteForceTestIndex::name, param, true);
+        fixtures::TestIndex::TestClone(index, dataset, fixtures::search_param_tmp);
+    });
 }
 
 TEST_CASE("(Daily) BruteForce Clone Test", "[ft][clone][bruteforce][daily]") {
-    auto resource = fixtures::BruteForceTestIndex::GetResource(false);
-    TestBruteForceClone(resource);
-}
-
-static void
-TestBruteForceRandomAllocator(const fixtures::BruteForceResourcePtr& resource) {
-    using namespace fixtures;
-    auto allocator = std::make_shared<fixtures::RandomAllocator>();
-    auto origin_size = vsag::Options::Instance().block_size_limit();
-    auto size = 1024 * 1024 * 2;
-    for (const auto& metric_type : resource->metric_types) {
-        for (auto dim : resource->dims) {
-            for (auto& [base_quantization_str, recall] : resource->test_cases) {
-                vsag::Options::Instance().set_block_size_limit(size);
-                auto param = BruteForceTestIndex::GenerateBruteForceBuildParametersString(
-                    metric_type, dim, base_quantization_str);
-                auto index =
-                    vsag::Factory::CreateIndex(BruteForceTestIndex::name, param, allocator.get());
-                if (not index.has_value()) {
-                    continue;
-                }
-                auto dataset = BruteForceTestIndex::pool.GetDatasetAndCreate(
-                    dim, BruteForceTestIndex::base_count, metric_type);
-                //                TestIndex::TestContinueAddIgnoreRequire(index.value(), dataset);
-                vsag::Options::Instance().set_block_size_limit(origin_size);
-            }
-        }
-    }
+    auto matrix = fixtures::BruteForceTestIndex::GetMatrix(false);
+    matrix.ForEach(fixtures::BruteForceTestIndex::pool, [&](const auto& iter) {
+        auto param = fixtures::BruteForceTestIndex::GenerateBruteForceBuildParametersString(
+            iter.metric, iter.dim, iter.quantizer);
+        auto index =
+            fixtures::TestIndex::TestFactory(fixtures::BruteForceTestIndex::name, param, true);
+        auto dataset = fixtures::BruteForceTestIndex::pool.GetDatasetAndCreate(
+            iter.dim, matrix.base_count, iter.metric);
+        fixtures::TestIndex::TestBuildIndex(index, dataset, true);
+        auto index2 =
+            fixtures::TestIndex::TestFactory(fixtures::BruteForceTestIndex::name, param, true);
+        fixtures::TestIndex::TestClone(index, dataset, fixtures::search_param_tmp);
+    });
 }
 
 TEST_CASE("(PR) BruteForce Build & ContinueAdd Test With Random Allocator",
           "[ft][build][bruteforce][pr]") {
-    auto resource = fixtures::BruteForceTestIndex::GetResource(true);
-    TestBruteForceRandomAllocator(resource);
+    auto matrix = fixtures::BruteForceTestIndex::GetMatrix(true);
+    auto allocator = std::make_shared<fixtures::RandomAllocator>();
+    matrix.ForEach(fixtures::BruteForceTestIndex::pool, [&](const auto& iter) {
+        auto param = fixtures::BruteForceTestIndex::GenerateBruteForceBuildParametersString(
+            iter.metric, iter.dim, iter.quantizer);
+        auto index =
+            vsag::Factory::CreateIndex(fixtures::BruteForceTestIndex::name, param, allocator.get());
+        if (not index.has_value()) {
+            return;
+        }
+        auto dataset = fixtures::BruteForceTestIndex::pool.GetDatasetAndCreate(
+            iter.dim, matrix.base_count, iter.metric);
+    });
 }
 
 TEST_CASE("(Daily) BruteForce Build & ContinueAdd Test With Random Allocator",
           "[ft][build][bruteforce][daily]") {
-    auto resource = fixtures::BruteForceTestIndex::GetResource(false);
-    TestBruteForceRandomAllocator(resource);
-}
-
-static void
-TestBruteForceCalcDistanceById(const fixtures::BruteForceResourcePtr& resource) {
-    using namespace fixtures;
-    auto origin_size = vsag::Options::Instance().block_size_limit();
-    auto size = 1024 * 1024 * 2;
-
-    for (const auto& metric_type : resource->metric_types) {
-        for (auto dim : resource->dims) {
-            auto base_quantization_str = "fp32";
-            vsag::Options::Instance().set_block_size_limit(size);
-            auto param = BruteForceTestIndex::GenerateBruteForceBuildParametersString(
-                metric_type, dim, base_quantization_str);
-            auto dataset = BruteForceTestIndex::pool.GetDatasetAndCreate(
-                dim, BruteForceTestIndex::base_count, metric_type);
-            auto index = TestIndex::TestFactory(BruteForceTestIndex::name, param, true);
-            TestIndex::TestBuildIndex(index, dataset, true);
-            TestIndex::TestCalcDistanceById(index, dataset);
-            vsag::Options::Instance().set_block_size_limit(origin_size);
+    auto matrix = fixtures::BruteForceTestIndex::GetMatrix(false);
+    auto allocator = std::make_shared<fixtures::RandomAllocator>();
+    matrix.ForEach(fixtures::BruteForceTestIndex::pool, [&](const auto& iter) {
+        auto param = fixtures::BruteForceTestIndex::GenerateBruteForceBuildParametersString(
+            iter.metric, iter.dim, iter.quantizer);
+        auto index =
+            vsag::Factory::CreateIndex(fixtures::BruteForceTestIndex::name, param, allocator.get());
+        if (not index.has_value()) {
+            return;
         }
-    }
+        auto dataset = fixtures::BruteForceTestIndex::pool.GetDatasetAndCreate(
+            iter.dim, matrix.base_count, iter.metric);
+    });
 }
 
 TEST_CASE("(PR) BruteForce GetDistance By ID Test", "[ft][distance][bruteforce][pr]") {
-    auto resource = fixtures::BruteForceTestIndex::GetResource(true);
-    TestBruteForceCalcDistanceById(resource);
+    auto matrix = fixtures::BruteForceTestIndex::GetMatrix(true);
+    matrix.quantizers = {{"fp32", 0.99f}};
+    matrix.ForEach(fixtures::BruteForceTestIndex::pool, [&](const auto& iter) {
+        auto param = fixtures::BruteForceTestIndex::GenerateBruteForceBuildParametersString(
+            iter.metric, iter.dim, iter.quantizer);
+        auto index =
+            fixtures::TestIndex::TestFactory(fixtures::BruteForceTestIndex::name, param, true);
+        auto dataset = fixtures::BruteForceTestIndex::pool.GetDatasetAndCreate(
+            iter.dim, matrix.base_count, iter.metric);
+        fixtures::TestIndex::TestBuildIndex(index, dataset, true);
+        fixtures::TestIndex::TestCalcDistanceById(index, dataset);
+    });
 }
 
 TEST_CASE("(Daily) BruteForce GetDistance By ID Test", "[ft][distance][bruteforce][daily]") {
-    auto resource = fixtures::BruteForceTestIndex::GetResource(false);
-    TestBruteForceCalcDistanceById(resource);
-}
-
-static void
-TestBruteForceDuplicateBuild(const fixtures::BruteForceResourcePtr& resource) {
-    using namespace fixtures;
-    auto origin_size = vsag::Options::Instance().block_size_limit();
-    auto size = 1024 * 1024 * 2;
-    for (const auto& metric_type : resource->metric_types) {
-        for (auto& dim : resource->dims) {
-            for (auto& [base_quantization_str, recall] : resource->test_cases) {
-                vsag::Options::Instance().set_block_size_limit(size);
-                auto param = BruteForceTestIndex::GenerateBruteForceBuildParametersString(
-                    metric_type, dim, base_quantization_str);
-                auto index = TestIndex::TestFactory(BruteForceTestIndex::name, param, true);
-                auto dataset = BruteForceTestIndex::pool.GetDatasetAndCreate(
-                    dim, BruteForceTestIndex::base_count, metric_type);
-                TestIndex::TestDuplicateAdd(index, dataset);
-                BruteForceTestIndex::TestGeneral(index, dataset, search_param_tmp, recall);
-                vsag::Options::Instance().set_block_size_limit(origin_size);
-            }
-        }
-    }
+    auto matrix = fixtures::BruteForceTestIndex::GetMatrix(false);
+    matrix.quantizers = {{"fp32", 0.99f}};
+    matrix.ForEach(fixtures::BruteForceTestIndex::pool, [&](const auto& iter) {
+        auto param = fixtures::BruteForceTestIndex::GenerateBruteForceBuildParametersString(
+            iter.metric, iter.dim, iter.quantizer);
+        auto index =
+            fixtures::TestIndex::TestFactory(fixtures::BruteForceTestIndex::name, param, true);
+        auto dataset = fixtures::BruteForceTestIndex::pool.GetDatasetAndCreate(
+            iter.dim, matrix.base_count, iter.metric);
+        fixtures::TestIndex::TestBuildIndex(index, dataset, true);
+        fixtures::TestIndex::TestCalcDistanceById(index, dataset);
+    });
 }
 
 TEST_CASE("(PR) BruteForce Duplicate Build Test", "[ft][build][duplicate][bruteforce][pr]") {
-    auto resource = fixtures::BruteForceTestIndex::GetResource(true);
-    TestBruteForceDuplicateBuild(resource);
+    auto matrix = fixtures::BruteForceTestIndex::GetMatrix(true);
+    matrix.ForEach(fixtures::BruteForceTestIndex::pool, [&](const auto& iter) {
+        auto param = fixtures::BruteForceTestIndex::GenerateBruteForceBuildParametersString(
+            iter.metric, iter.dim, iter.quantizer);
+        auto index =
+            fixtures::TestIndex::TestFactory(fixtures::BruteForceTestIndex::name, param, true);
+        auto dataset = fixtures::BruteForceTestIndex::pool.GetDatasetAndCreate(
+            iter.dim, matrix.base_count, iter.metric);
+        fixtures::TestIndex::TestDuplicateAdd(index, dataset);
+        fixtures::BruteForceTestIndex::TestGeneral(
+            index, dataset, fixtures::search_param_tmp, iter.recall);
+    });
 }
 
 TEST_CASE("(Daily) BruteForce Duplicate Build Test", "[ft][build][duplicate][bruteforce][daily]") {
-    auto resource = fixtures::BruteForceTestIndex::GetResource(false);
-    TestBruteForceDuplicateBuild(resource);
-}
-
-static void
-TestBruteForceWithAttrFilter(const fixtures::BruteForceResourcePtr& resource) {
-    using namespace fixtures;
-    auto origin_size = vsag::Options::Instance().block_size_limit();
-    auto size = 1024 * 1024 * 2;
-
-    for (const auto& metric_type : resource->metric_types) {
-        for (auto& dim : resource->dims) {
-            for (auto& [base_quantization_str, recall] : resource->test_cases) {
-                vsag::Options::Instance().set_block_size_limit(size);
-                auto param = BruteForceTestIndex::GenerateBruteForceBuildParametersString(
-                    metric_type, dim, base_quantization_str, true);
-                auto index = TestIndex::TestFactory(BruteForceTestIndex::name, param, true);
-                auto dataset = BruteForceTestIndex::pool.GetDatasetAndCreate(
-                    dim, BruteForceTestIndex::base_count, metric_type);
-                TestIndex::TestBuildIndex(index, dataset, true);
-                TestIndex::TestWithAttr(index, dataset, search_param_tmp, false);
-                auto index2 = TestIndex::TestFactory(BruteForceTestIndex::name, param, true);
-
-                REQUIRE_NOTHROW(test_serializion_file(*index, *index2, "serialize_bruteforce"));
-                TestIndex::TestWithAttr(index2, dataset, search_param_tmp, true);
-
-                vsag::Options::Instance().set_block_size_limit(origin_size);
-            }
-        }
-    }
+    auto matrix = fixtures::BruteForceTestIndex::GetMatrix(false);
+    matrix.ForEach(fixtures::BruteForceTestIndex::pool, [&](const auto& iter) {
+        auto param = fixtures::BruteForceTestIndex::GenerateBruteForceBuildParametersString(
+            iter.metric, iter.dim, iter.quantizer);
+        auto index =
+            fixtures::TestIndex::TestFactory(fixtures::BruteForceTestIndex::name, param, true);
+        auto dataset = fixtures::BruteForceTestIndex::pool.GetDatasetAndCreate(
+            iter.dim, matrix.base_count, iter.metric);
+        fixtures::TestIndex::TestDuplicateAdd(index, dataset);
+        fixtures::BruteForceTestIndex::TestGeneral(
+            index, dataset, fixtures::search_param_tmp, iter.recall);
+    });
 }
 
 TEST_CASE("(PR) BruteForce With Attribute Filter Test", "[ft][filter_search][bruteforce][pr]") {
-    auto resource = fixtures::BruteForceTestIndex::GetResource(true);
-    TestBruteForceWithAttrFilter(resource);
+    auto matrix = fixtures::BruteForceTestIndex::GetMatrix(true);
+    matrix.ForEach(fixtures::BruteForceTestIndex::pool, [&](const auto& iter) {
+        auto param = fixtures::BruteForceTestIndex::GenerateBruteForceBuildParametersString(
+            iter.metric, iter.dim, iter.quantizer, true);
+        auto index =
+            fixtures::TestIndex::TestFactory(fixtures::BruteForceTestIndex::name, param, true);
+        auto dataset = fixtures::BruteForceTestIndex::pool.GetDatasetAndCreate(
+            iter.dim, matrix.base_count, iter.metric);
+        fixtures::TestIndex::TestBuildIndex(index, dataset, true);
+        fixtures::TestIndex::TestWithAttr(index, dataset, fixtures::search_param_tmp, false);
+        auto index2 =
+            fixtures::TestIndex::TestFactory(fixtures::BruteForceTestIndex::name, param, true);
+        REQUIRE_NOTHROW(fixtures::test_serializion_file(*index, *index2, "serialize_bruteforce"));
+        fixtures::TestIndex::TestWithAttr(index2, dataset, fixtures::search_param_tmp, true);
+    });
 }
 
 TEST_CASE("(Daily) BruteForce With Attribute Filter Test",
           "[ft][filter_search][bruteforce][daily]") {
-    auto resource = fixtures::BruteForceTestIndex::GetResource(false);
-    TestBruteForceWithAttrFilter(resource);
-}
-
-static void
-TestBruteForceMarkRemove(const fixtures::BruteForceResourcePtr& resource) {
-    using namespace fixtures;
-    auto origin_size = vsag::Options::Instance().block_size_limit();
-    auto size = 1024 * 1024 * 2;
-    for (const auto& metric_type : resource->metric_types) {
-        for (auto& dim : resource->dims) {
-            for (auto& [base_quantization_str, recall] : resource->test_cases) {
-                vsag::Options::Instance().set_block_size_limit(size);
-                auto param = BruteForceTestIndex::GenerateBruteForceBuildParametersString(
-                    metric_type, dim, base_quantization_str);
-                auto index = TestIndex::TestFactory(BruteForceTestIndex::name, param, true);
-                auto dataset = BruteForceTestIndex::pool.GetDatasetAndCreate(
-                    dim, BruteForceTestIndex::base_count, metric_type);
-                TestIndex::TestMarkRemoveIndex(index, dataset, search_param_tmp, true);
-                BruteForceTestIndex::TestGeneral(index, dataset, search_param_tmp, recall);
-                vsag::Options::Instance().set_block_size_limit(origin_size);
-            }
-        }
-    }
+    auto matrix = fixtures::BruteForceTestIndex::GetMatrix(false);
+    matrix.ForEach(fixtures::BruteForceTestIndex::pool, [&](const auto& iter) {
+        auto param = fixtures::BruteForceTestIndex::GenerateBruteForceBuildParametersString(
+            iter.metric, iter.dim, iter.quantizer, true);
+        auto index =
+            fixtures::TestIndex::TestFactory(fixtures::BruteForceTestIndex::name, param, true);
+        auto dataset = fixtures::BruteForceTestIndex::pool.GetDatasetAndCreate(
+            iter.dim, matrix.base_count, iter.metric);
+        fixtures::TestIndex::TestBuildIndex(index, dataset, true);
+        fixtures::TestIndex::TestWithAttr(index, dataset, fixtures::search_param_tmp, false);
+        auto index2 =
+            fixtures::TestIndex::TestFactory(fixtures::BruteForceTestIndex::name, param, true);
+        REQUIRE_NOTHROW(fixtures::test_serializion_file(*index, *index2, "serialize_bruteforce"));
+        fixtures::TestIndex::TestWithAttr(index2, dataset, fixtures::search_param_tmp, true);
+    });
 }
 
 TEST_CASE("(PR) BruteForce Mark Remove", "[ft][remove][bruteforce][pr]") {
-    auto test_index = std::make_shared<fixtures::BruteForceTestIndex>();
-    auto resource = test_index->GetResource(true);
-    TestBruteForceMarkRemove(resource);
+    auto matrix = fixtures::BruteForceTestIndex::GetMatrix(true);
+    matrix.ForEach(fixtures::BruteForceTestIndex::pool, [&](const auto& iter) {
+        auto param = fixtures::BruteForceTestIndex::GenerateBruteForceBuildParametersString(
+            iter.metric, iter.dim, iter.quantizer);
+        auto index =
+            fixtures::TestIndex::TestFactory(fixtures::BruteForceTestIndex::name, param, true);
+        auto dataset = fixtures::BruteForceTestIndex::pool.GetDatasetAndCreate(
+            iter.dim, matrix.base_count, iter.metric);
+        fixtures::TestIndex::TestMarkRemoveIndex(index, dataset, fixtures::search_param_tmp, true);
+        fixtures::BruteForceTestIndex::TestGeneral(
+            index, dataset, fixtures::search_param_tmp, iter.recall);
+    });
 }
 
 TEST_CASE("(Daily) BruteForce Mark Remove", "[ft][remove][bruteforce][daily]") {
-    auto test_index = std::make_shared<fixtures::BruteForceTestIndex>();
-    auto resource = test_index->GetResource(false);
-    TestBruteForceMarkRemove(resource);
+    auto matrix = fixtures::BruteForceTestIndex::GetMatrix(false);
+    matrix.ForEach(fixtures::BruteForceTestIndex::pool, [&](const auto& iter) {
+        auto param = fixtures::BruteForceTestIndex::GenerateBruteForceBuildParametersString(
+            iter.metric, iter.dim, iter.quantizer);
+        auto index =
+            fixtures::TestIndex::TestFactory(fixtures::BruteForceTestIndex::name, param, true);
+        auto dataset = fixtures::BruteForceTestIndex::pool.GetDatasetAndCreate(
+            iter.dim, matrix.base_count, iter.metric);
+        fixtures::TestIndex::TestMarkRemoveIndex(index, dataset, fixtures::search_param_tmp, true);
+        fixtures::BruteForceTestIndex::TestGeneral(
+            index, dataset, fixtures::search_param_tmp, iter.recall);
+    });
 }
 
 TEST_CASE("(PR) BruteForce RangeSearch After MarkRemove",
           "[ft][remove][range_search][bruteforce][pr]") {
-    // Regression: RangeSearch must exclude documents removed via MARK_REMOVE,
-    // mirroring KnnSearch behavior (see create_search_filter usage).
-    using namespace fixtures;
-    auto resource = fixtures::BruteForceTestIndex::GetResource(true);
-    auto origin_size = vsag::Options::Instance().block_size_limit();
-    auto size = 1024 * 1024 * 2;
-    for (const auto& metric_type : resource->metric_types) {
-        for (auto& dim : resource->dims) {
-            for (auto& [base_quantization_str, recall] : resource->test_cases) {
-                vsag::Options::Instance().set_block_size_limit(size);
-                auto param = BruteForceTestIndex::GenerateBruteForceBuildParametersString(
-                    metric_type, dim, base_quantization_str);
-                auto index = TestIndex::TestFactory(BruteForceTestIndex::name, param, true);
-                auto dataset = BruteForceTestIndex::pool.GetDatasetAndCreate(
-                    dim, BruteForceTestIndex::base_count, metric_type);
+    auto matrix = fixtures::BruteForceTestIndex::GetMatrix(true);
+    matrix.ForEach(fixtures::BruteForceTestIndex::pool, [&](const auto& iter) {
+        auto param = fixtures::BruteForceTestIndex::GenerateBruteForceBuildParametersString(
+            iter.metric, iter.dim, iter.quantizer);
+        auto index =
+            fixtures::TestIndex::TestFactory(fixtures::BruteForceTestIndex::name, param, true);
+        auto dataset = fixtures::BruteForceTestIndex::pool.GetDatasetAndCreate(
+            iter.dim, matrix.base_count, iter.metric);
 
-                // Build and add
-                auto train_result = index->Train(dataset->base_);
-                REQUIRE(train_result.has_value());
-                auto add_results = index->Add(dataset->base_);
-                REQUIRE(add_results.has_value());
+        auto train_result = index->Train(dataset->base_);
+        REQUIRE(train_result.has_value());
+        auto add_results = index->Add(dataset->base_);
+        REQUIRE(add_results.has_value());
 
-                auto base_num = dataset->base_->GetNumElements();
-                auto base_dim = dataset->base_->GetDim();
-                auto ids = dataset->base_->GetIds();
+        auto base_num = dataset->base_->GetNumElements();
+        auto base_dim = dataset->base_->GetDim();
+        auto ids = dataset->base_->GetIds();
 
-                // Mark-remove half of the base data
-                int64_t remove_count = base_num / 2;
-                std::vector<int64_t> remove_ids(ids, ids + remove_count);
-                auto remove_result = index->Remove(remove_ids, vsag::RemoveMode::MARK_REMOVE);
-                REQUIRE(remove_result.has_value());
-                REQUIRE(index->GetNumberRemoved() == remove_count);
+        int64_t remove_count = base_num / 2;
+        std::vector<int64_t> remove_ids(ids, ids + remove_count);
+        auto remove_result = index->Remove(remove_ids, vsag::RemoveMode::MARK_REMOVE);
+        REQUIRE(remove_result.has_value());
+        REQUIRE(index->GetNumberRemoved() == remove_count);
 
-                // RangeSearch from each query; verify no removed id appears.
-                // Build a hash set of removed ids for O(1) lookup.
-                std::unordered_set<int64_t> removed_set(remove_ids.begin(), remove_ids.end());
-                auto queries = dataset->range_query_;
-                auto query_count = queries->GetNumElements();
-                auto radius = dataset->range_radius_;
-                for (int64_t q = 0; q < query_count; ++q) {
-                    auto query = vsag::Dataset::Make();
-                    query->NumElements(1)
-                        ->Dim(base_dim)
-                        ->Float32Vectors(queries->GetFloat32Vectors() + q * base_dim)
-                        ->Owner(false);
-                    auto res = index->RangeSearch(query, radius[q], search_param_tmp);
-                    REQUIRE(res.has_value());
-                    auto result_ids = res.value()->GetIds();
-                    auto result_dim = res.value()->GetDim();
-                    for (int64_t j = 0; j < result_dim; ++j) {
-                        REQUIRE(removed_set.count(result_ids[j]) == 0);
-                    }
-                }
-
-                vsag::Options::Instance().set_block_size_limit(origin_size);
+        std::unordered_set<int64_t> removed_set(remove_ids.begin(), remove_ids.end());
+        auto queries = dataset->range_query_;
+        auto query_count = queries->GetNumElements();
+        auto radius = dataset->range_radius_;
+        for (int64_t q = 0; q < query_count; ++q) {
+            auto query = vsag::Dataset::Make();
+            query->NumElements(1)
+                ->Dim(base_dim)
+                ->Float32Vectors(queries->GetFloat32Vectors() + q * base_dim)
+                ->Owner(false);
+            auto res = index->RangeSearch(query, radius[q], fixtures::search_param_tmp);
+            REQUIRE(res.has_value());
+            auto result_ids = res.value()->GetIds();
+            auto result_dim = res.value()->GetDim();
+            for (int64_t j = 0; j < result_dim; ++j) {
+                REQUIRE(removed_set.count(result_ids[j]) == 0);
             }
         }
-    }
+    });
 }
 
-static void
-TestBruteForceRemoveById(const fixtures::BruteForceResourcePtr& resource) {
-    using namespace fixtures;
-    auto origin_size = vsag::Options::Instance().block_size_limit();
-    auto size = 1024 * 1024 * 2;
-    auto metric_type = "l2";
-
-    for (auto& dim : resource->dims) {
-        auto base_quantization_str = "fp32";
-        auto recall = 0.99;
-        vsag::Options::Instance().set_block_size_limit(size);
-        auto param = BruteForceTestIndex::GenerateBruteForceBuildParametersString(
-            metric_type, dim, base_quantization_str);
-        auto index = TestIndex::TestFactory(BruteForceTestIndex::name, param, true);
-        auto dataset = BruteForceTestIndex::pool.GetDatasetAndCreate(
-            dim, BruteForceTestIndex::base_count, metric_type);
-        TestIndex::TestContinueAdd(index, dataset, true);
-        BruteForceTestIndex::TestGeneral(index, dataset, search_param_tmp, recall);
-        for (int i = 0; i < BruteForceTestIndex::base_count; ++i) {
+TEST_CASE("(PR) BruteForce Remove By ID Test", "[ft][remove][bruteforce][pr]") {
+    auto matrix = fixtures::BruteForceTestIndex::GetMatrix(true);
+    matrix.quantizers = {{"fp32", 0.99f}};
+    matrix.ForEach(fixtures::BruteForceTestIndex::pool, [&](const auto& iter) {
+        auto param = fixtures::BruteForceTestIndex::GenerateBruteForceBuildParametersString(
+            iter.metric, iter.dim, iter.quantizer);
+        auto index =
+            fixtures::TestIndex::TestFactory(fixtures::BruteForceTestIndex::name, param, true);
+        auto dataset = fixtures::BruteForceTestIndex::pool.GetDatasetAndCreate(
+            iter.dim, matrix.base_count, iter.metric);
+        fixtures::TestIndex::TestContinueAdd(index, dataset, true);
+        fixtures::BruteForceTestIndex::TestGeneral(
+            index, dataset, fixtures::search_param_tmp, iter.recall);
+        auto total = static_cast<uint64_t>(dataset->base_->GetNumElements());
+        for (uint64_t i = 0; i < total; ++i) {
             auto res = index->Remove(dataset->base_->GetIds()[i]);
             auto check_exist = index->CheckIdExist(dataset->base_->GetIds()[i]);
             REQUIRE(res.has_value());
             REQUIRE(res.value());
             REQUIRE(not check_exist);
             auto num = index->GetNumElements();
-            REQUIRE(num == BruteForceTestIndex::base_count - i - 1);
+            REQUIRE(num == total - i - 1);
         }
-        vsag::Options::Instance().set_block_size_limit(origin_size);
-    }
-}
-
-TEST_CASE("(PR) BruteForce Remove By ID Test", "[ft][remove][bruteforce][pr]") {
-    auto resource = fixtures::BruteForceTestIndex::GetResource(true);
-    TestBruteForceRemoveById(resource);
+    });
 }
 
 TEST_CASE("(Daily) BruteForce Remove By ID Test", "[ft][remove][bruteforce][daily]") {
-    auto resource = fixtures::BruteForceTestIndex::GetResource(false);
-    TestBruteForceRemoveById(resource);
-}
-
-static void
-TestBruteForceEstimateMemory(const fixtures::BruteForceResourcePtr& resource) {
-    using namespace fixtures;
-    auto origin_size = vsag::Options::Instance().block_size_limit();
-    auto size = 1024 * 1024 * 2;
-    uint64_t estimate_count = 1000;
-    int64_t dim = 1536;
-    for (const auto& metric_type : resource->metric_types) {
-        for (auto& [base_quantization_str, recall] : resource->test_cases) {
-            vsag::Options::Instance().set_block_size_limit(size);
-            auto param = BruteForceTestIndex::GenerateBruteForceBuildParametersString(
-                metric_type, dim, base_quantization_str);
-            auto index = TestIndex::TestFactory(BruteForceTestIndex::name, param, true);
-            auto dataset = BruteForceTestIndex::pool.GetDatasetAndCreate(
-                dim, BruteForceTestIndex::base_count, metric_type);
-            auto val = index->EstimateMemory(1000);
-            vsag::Options::Instance().set_block_size_limit(origin_size);
+    auto matrix = fixtures::BruteForceTestIndex::GetMatrix(false);
+    matrix.quantizers = {{"fp32", 0.99f}};
+    matrix.ForEach(fixtures::BruteForceTestIndex::pool, [&](const auto& iter) {
+        auto param = fixtures::BruteForceTestIndex::GenerateBruteForceBuildParametersString(
+            iter.metric, iter.dim, iter.quantizer);
+        auto index =
+            fixtures::TestIndex::TestFactory(fixtures::BruteForceTestIndex::name, param, true);
+        auto dataset = fixtures::BruteForceTestIndex::pool.GetDatasetAndCreate(
+            iter.dim, matrix.base_count, iter.metric);
+        fixtures::TestIndex::TestContinueAdd(index, dataset, true);
+        fixtures::BruteForceTestIndex::TestGeneral(
+            index, dataset, fixtures::search_param_tmp, iter.recall);
+        auto total = static_cast<uint64_t>(dataset->base_->GetNumElements());
+        for (uint64_t i = 0; i < total; ++i) {
+            auto res = index->Remove(dataset->base_->GetIds()[i]);
+            auto check_exist = index->CheckIdExist(dataset->base_->GetIds()[i]);
+            REQUIRE(res.has_value());
+            REQUIRE(res.value());
+            REQUIRE(not check_exist);
+            auto num = index->GetNumElements();
+            REQUIRE(num == total - i - 1);
         }
-    }
+    });
 }
 
 TEST_CASE("(PR) BruteForce BruteForce Estimate Memory Test", "[ft][memory][bruteforce][pr]") {
-    auto resource = fixtures::BruteForceTestIndex::GetResource(true);
-    TestBruteForceEstimateMemory(resource);
+    auto matrix = fixtures::BruteForceTestIndex::GetMatrix(true);
+    constexpr int64_t dim = 1536;
+    matrix.ForEachDimQuantizer(fixtures::BruteForceTestIndex::pool, [&](const auto& iter) {
+        auto param = fixtures::BruteForceTestIndex::GenerateBruteForceBuildParametersString(
+            iter.metric, dim, iter.quantizer);
+        [[maybe_unused]] auto index =
+            fixtures::TestIndex::TestFactory(fixtures::BruteForceTestIndex::name, param, true);
+        [[maybe_unused]] auto val = index->EstimateMemory(1000);
+    });
 }
 
 TEST_CASE("(Daily) BruteForce BruteForce Estimate Memory Test", "[ft][memory][bruteforce][daily]") {
-    auto resource = fixtures::BruteForceTestIndex::GetResource(false);
-    TestBruteForceEstimateMemory(resource);
+    auto matrix = fixtures::BruteForceTestIndex::GetMatrix(false);
+    constexpr int64_t dim = 1536;
+    matrix.ForEachDimQuantizer(fixtures::BruteForceTestIndex::pool, [&](const auto& iter) {
+        auto param = fixtures::BruteForceTestIndex::GenerateBruteForceBuildParametersString(
+            iter.metric, dim, iter.quantizer);
+        [[maybe_unused]] auto index =
+            fixtures::TestIndex::TestFactory(fixtures::BruteForceTestIndex::name, param, true);
+        [[maybe_unused]] auto val = index->EstimateMemory(1000);
+    });
 }


### PR DESCRIPTION
## Summary

Introduce `TestMatrix` and `IndexTestSuite` abstractions to reduce test code repetition across index test files.

## Changes

### New files
- `tests/fixtures/framework/test_matrix.h` - `TestMatrix` struct centralizing parameter combinations (metrics, dims, quantizers) with `Expand()` methods
- `tests/fixtures/framework/index_test_suite.h` / `.cpp` - `IndexTestSuite` with `RunForEachMatrix()` and `RunForEachDimQuantizer()` iteration helpers

### Modified files
- `tests/fixtures/framework/CMakeLists.txt` - Added `index_test_suite.cpp` to build
- `tests/fixtures/functest.h` - Added includes for new headers
- `tests/test_brute_force.cpp` - Migrated as first validation:
  - Replaced `BruteForceTestResource` with `TestMatrix`
  - Used `IndexTestSuite::RunForEachMatrix` to eliminate repeated loop boilerplate
  - All 15 PR test cases pass with identical coverage

## Motivation

- Reduces boilerplate in index test files by centralizing the "iterate over metrics × dims × quantizers + save/restore block_size + create dataset" pattern
- Adding a new index test file now only requires declaring a `TestMatrix` and calling `IndexTestSuite` methods
- Adding a new common test scenario (e.g., batch search) requires modifying only `IndexTestSuite` instead of N index files

Closes #2355