### PR TITLE
fix(hgraph): avoid GetStats crash for RabitQ split

### DIFF
--- a/src/analyzer/hgraph_analyzer.cpp
+++ b/src/analyzer/hgraph_analyzer.cpp
@@ -49,6 +49,16 @@ mark_duplicate_ids(const GraphInterfacePtr& graph,
 
 }  // namespace
 
+FlattenInterfacePtr
+HGraphAnalyzer::select_precise_codes() const {
+    auto codes = hgraph_->has_precise_reorder() ? hgraph_->high_precise_codes_
+                                                : hgraph_->basic_flatten_codes_;
+    if (hgraph_->create_new_raw_vector_ and hgraph_->raw_vector_ != nullptr) {
+        codes = hgraph_->raw_vector_;
+    }
+    return codes;
+}
+
 Vector<int64_t>
 HGraphAnalyzer::GetComponentCount() {
     // graph connection
@@ -173,7 +183,7 @@ HGraphAnalyzer::GetDuplicateRatio() {
 
     // Sieve method: progressively filter candidate duplicate groups
     calculate_base_groundtruth();
-    auto codes = hgraph_->reorder_ ? hgraph_->high_precise_codes_ : hgraph_->basic_flatten_codes_;
+    auto codes = select_precise_codes();
     constexpr float epsilon = 2e-6F;
 
     // Initialize with all vectors as a single group
@@ -266,20 +276,25 @@ HGraphAnalyzer::calculate_quantization_result(
     uint32_t sample_size) {
     float total_quantization_error = 0.0F;
     float total_quantization_inversion_count_rate = 0.0F;
+    uint32_t valid_sample_count = 0;
     for (int i = 0; i < sample_size; ++i) {
         auto id = sample_ids[i];
         const auto& result = search_result.at(id);
+        const auto actual_topk = std::min<uint32_t>(topk_, result.size());
+        if (actual_topk == 0) {
+            continue;
+        }
         float sample_error = 0.0F;
         auto base_result =
-            hgraph_->CalDistanceById(sample_datas.data() + i, result.data(), topk_, false);
+            hgraph_->CalDistanceById(sample_datas.data() + i, result.data(), actual_topk, false);
         const auto* base_distance = base_result->GetDistances();
         auto precise_result =
-            hgraph_->CalDistanceById(sample_datas.data() + i, result.data(), topk_, true);
+            hgraph_->CalDistanceById(sample_datas.data() + i, result.data(), actual_topk, true);
         const auto* precise_distance = precise_result->GetDistances();
         uint32_t inversion_count = 0;
-        for (uint32_t j = 0; j < topk_; ++j) {
+        for (uint32_t j = 0; j < actual_topk; ++j) {
             sample_error += std::abs(base_distance[j] - precise_distance[j]);
-            for (uint32_t k = j + 1; k < topk_; ++k) {
+            for (uint32_t k = j + 1; k < actual_topk; ++k) {
                 if ((base_distance[j] - base_distance[k]) *
                         (precise_distance[j] - precise_distance[k]) <
                     0) {
@@ -287,13 +302,19 @@ HGraphAnalyzer::calculate_quantization_result(
                 }
             }
         }
-        total_quantization_error += sample_error / static_cast<float>(topk_);
-        total_quantization_inversion_count_rate +=
-            static_cast<float>(inversion_count) /
-            (static_cast<float>(topk_) * static_cast<float>(topk_ - 1) / 2.0F);
+        total_quantization_error += sample_error / static_cast<float>(actual_topk);
+        if (actual_topk > 1) {
+            total_quantization_inversion_count_rate +=
+                static_cast<float>(inversion_count) /
+                (static_cast<float>(actual_topk) * static_cast<float>(actual_topk - 1) / 2.0F);
+        }
+        valid_sample_count++;
     }
-    return {total_quantization_error / static_cast<float>(sample_size),
-            total_quantization_inversion_count_rate / static_cast<float>(sample_size)};
+    if (valid_sample_count == 0) {
+        return {0.0F, 0.0F};
+    }
+    return {total_quantization_error / static_cast<float>(valid_sample_count),
+            total_quantization_inversion_count_rate / static_cast<float>(valid_sample_count)};
 }
 
 float
@@ -341,7 +362,7 @@ HGraphAnalyzer::calculate_groundtruth(const Vector<float>& sample_datas,
     Vector<float> distances_array(this->total_count_, allocator_);
     Vector<InnerIdType> ids_array(this->total_count_, allocator_);
     std::iota(ids_array.begin(), ids_array.end(), 0);
-    auto codes = hgraph_->reorder_ ? hgraph_->high_precise_codes_ : hgraph_->basic_flatten_codes_;
+    auto codes = select_precise_codes();
     for (uint64_t i = 0; i < sample_size; ++i) {
         if (i % 10 == 0) {
             logger::info("calculate groundtruth for sample {} of {}", i, i + 10);

--- a/src/analyzer/hgraph_analyzer.cpp
+++ b/src/analyzer/hgraph_analyzer.cpp
@@ -56,7 +56,7 @@ HGraphAnalyzer::select_precise_codes() const {
     if (hgraph_->create_new_raw_vector_ and hgraph_->raw_vector_ != nullptr) {
         codes = hgraph_->raw_vector_;
     }
-    return codes;
+    return codes == nullptr ? hgraph_->basic_flatten_codes_ : codes;
 }
 
 Vector<int64_t>
@@ -277,6 +277,7 @@ HGraphAnalyzer::calculate_quantization_result(
     float total_quantization_error = 0.0F;
     float total_quantization_inversion_count_rate = 0.0F;
     uint32_t valid_sample_count = 0;
+    uint32_t valid_inversion_sample_count = 0;
     for (int i = 0; i < sample_size; ++i) {
         auto id = sample_ids[i];
         const auto& result = search_result.at(id);
@@ -284,13 +285,18 @@ HGraphAnalyzer::calculate_quantization_result(
         if (actual_topk == 0) {
             continue;
         }
+        const auto* query = sample_datas.data() + static_cast<uint64_t>(i) * dim_;
         float sample_error = 0.0F;
-        auto base_result =
-            hgraph_->CalDistanceById(sample_datas.data() + i, result.data(), actual_topk, false);
+        auto base_result = hgraph_->CalDistanceById(query, result.data(), actual_topk, false);
+        auto precise_result = hgraph_->CalDistanceById(query, result.data(), actual_topk, true);
+        if (base_result == nullptr or precise_result == nullptr) {
+            continue;
+        }
         const auto* base_distance = base_result->GetDistances();
-        auto precise_result =
-            hgraph_->CalDistanceById(sample_datas.data() + i, result.data(), actual_topk, true);
         const auto* precise_distance = precise_result->GetDistances();
+        if (base_distance == nullptr or precise_distance == nullptr) {
+            continue;
+        }
         uint32_t inversion_count = 0;
         for (uint32_t j = 0; j < actual_topk; ++j) {
             sample_error += std::abs(base_distance[j] - precise_distance[j]);
@@ -307,14 +313,19 @@ HGraphAnalyzer::calculate_quantization_result(
             total_quantization_inversion_count_rate +=
                 static_cast<float>(inversion_count) /
                 (static_cast<float>(actual_topk) * static_cast<float>(actual_topk - 1) / 2.0F);
+            valid_inversion_sample_count++;
         }
         valid_sample_count++;
     }
     if (valid_sample_count == 0) {
         return {0.0F, 0.0F};
     }
+    const float avg_inversion_count_rate =
+        valid_inversion_sample_count == 0 ? 0.0F
+                                          : total_quantization_inversion_count_rate /
+                                                static_cast<float>(valid_inversion_sample_count);
     return {total_quantization_error / static_cast<float>(valid_sample_count),
-            total_quantization_inversion_count_rate / static_cast<float>(valid_sample_count)};
+            avg_inversion_count_rate};
 }
 
 float

--- a/src/analyzer/hgraph_analyzer.h
+++ b/src/analyzer/hgraph_analyzer.h
@@ -106,6 +106,9 @@ private:
     void
     calculate_query_search_result(const std::string& search_param);
 
+    FlattenInterfacePtr
+    select_precise_codes() const;
+
     std::tuple<float, float>
     calculate_quantization_result(const Vector<float>& sample_datas,
                                   const Vector<InnerIdType>& sample_ids,

--- a/tests/test_hgraph_rabitq_split.cpp
+++ b/tests/test_hgraph_rabitq_split.cpp
@@ -139,6 +139,7 @@ TEST_CASE("HGraph RaBitQ Split Homogeneous IO", "[ft][rabitq_split][hgraph]") {
     auto index = TestIndex::TestFactory(HGraphRaBitQSplitTestIndex::name, param, true);
     auto dataset = HGraphRaBitQSplitTestIndex::pool.GetDatasetAndCreate(dim, base_count, metric);
     TestIndex::TestBuildIndex(index, dataset, true);
+    REQUIRE_NOTHROW(index->GetStats());
     // Recall is intentionally low: the split datacell at moderate dim is not
     // expected to recover ground-truth accuracy. The check primarily proves
     // that build / search complete without error on this code path.
@@ -157,6 +158,7 @@ TEST_CASE("HGraph RaBitQ Split Hybrid IO (memory + async supplement)",
     auto index = TestIndex::TestFactory(HGraphRaBitQSplitTestIndex::name, build_param, true);
     auto dataset = HGraphRaBitQSplitTestIndex::pool.GetDatasetAndCreate(dim, base_count, metric);
     TestIndex::TestBuildIndex(index, dataset, true);
+    REQUIRE_NOTHROW(index->GetStats());
     TestIndex::TestKnnSearch(index, dataset, kSplitSearchParam, 0.0F, true);
 
     // Round-trip serialize / deserialize so the supplement_io_params branch


### PR DESCRIPTION
## Summary

Fix HGraph `GetStats()` crashing on RabitQ split indexes that use `reorder_source=base`.

The analyzer previously selected `high_precise_codes_` whenever reorder was enabled. For RabitQ split base-reorder indexes, reorder is enabled but there is no separate high-precision datacell, so `GetStats()` could dereference a null pointer while calculating ground truth. This change makes the analyzer use the same precise-code selection rule as HGraph distance calculation.

Also guard quantization stats against search results smaller than the requested top-k.

Fixes: #2359

## Tests

- `clang-format-15 -i src/analyzer/hgraph_analyzer.cpp src/analyzer/hgraph_analyzer.h tests/test_hgraph_rabitq_split.cpp`
- `cmake -G "Unix Makefiles" -S . -B build-getstats -DCMAKE_BUILD_TYPE=Debug -DENABLE_ASAN=OFF -DENABLE_CCACHE=ON -DENABLE_TESTS=ON -DENABLE_MOCKIMPL=OFF -DENABLE_INTEL_MKL=OFF -DENABLE_LIBAIO=ON -DVSAG_USE_SYSTEM_DEPS=AUTO -DENABLE_PYBINDS=OFF -DENABLE_TOOLS=OFF -DENABLE_EXAMPLES=OFF`
- `cmake --build build-getstats --target functests --parallel 6`
- `./build-getstats/tests/functests "[rabitq_split]" --allow-running-no-tests`
- `BUILD_DIR=$PWD/build-getstats scripts/perf_reports/check_gist1m_rabitq_split_getstats.sh /root/vsag-rabitq-split-hybrid-io/benchs/indexes/gist1m/vsag_hgraph_rabitq_split_1plus7_base_reorder /tmp/rabitq_split_1plus7_stats.json`
