### PR TITLE
refactor: remove unused AddMode parameter from Index::Add

### DIFF
--- a/include/vsag/index.h
+++ b/include/vsag/index.h
@@ -74,14 +74,6 @@ using OffsetType = uint64_t;
 using SizeType = uint64_t;
 using WriteFuncType = std::function<void(OffsetType, SizeType, const void*)>;
 
-enum class AddMode {
-    /** try to reuse the memory of the deleted vector, no recovery check */
-    DEFAULT = 0,
-
-    /** always allocate new memory for the vector, but also check whether recovery from the same id */
-    KEEP_TOMBSTONE = 1,
-};
-
 enum class RemoveMode {
     /** mark the vector as deleted, but not remove it from index, no shrink and repair,
         * this mode is fast */
@@ -167,7 +159,7 @@ public:
       * @return IDs that failed to insert into the index
       */
     [[nodiscard]] virtual tl::expected<std::vector<int64_t>, Error>
-    Add(const DatasetPtr& base, AddMode mode = AddMode::DEFAULT) {
+    Add(const DatasetPtr& base) {
         return tl::unexpected(
             Error(ErrorType::UNSUPPORTED_INDEX_OPERATION, "Index does not support adding vectors"));
     }

--- a/mockimpl/vsag/simpleflat.cpp
+++ b/mockimpl/vsag/simpleflat.cpp
@@ -69,7 +69,7 @@ SimpleFlat::Build(const DatasetPtr& base) {
 }
 
 tl::expected<std::vector<int64_t>, Error>
-SimpleFlat::Add(const DatasetPtr& base, AddMode mode) {
+SimpleFlat::Add(const DatasetPtr& base) {
     std::vector<int64_t> failed_ids;
     if (not this->data_.empty()) {
         if (this->dim_ != base->GetDim()) {

--- a/mockimpl/vsag/simpleflat.h
+++ b/mockimpl/vsag/simpleflat.h
@@ -29,7 +29,7 @@ public:
     Build(const DatasetPtr& base) override;
 
     virtual tl::expected<std::vector<int64_t>, Error>
-    Add(const DatasetPtr& base, AddMode mode) override;
+    Add(const DatasetPtr& base) override;
 
     tl::expected<uint32_t, Error>
     Remove(const std::vector<int64_t>& ids, RemoveMode mode) override;

--- a/src/algorithm/bruteforce/bruteforce.cpp
+++ b/src/algorithm/bruteforce/bruteforce.cpp
@@ -185,7 +185,7 @@ BruteForce::add_multi_vector(const DatasetPtr& data) {
 }
 
 std::vector<int64_t>
-BruteForce::Add(const DatasetPtr& data, AddMode mode) {
+BruteForce::Add(const DatasetPtr& data) {
     if (is_multi_vector_) {
         return this->add_multi_vector(data);
     }

--- a/src/algorithm/bruteforce/bruteforce.h
+++ b/src/algorithm/bruteforce/bruteforce.h
@@ -47,7 +47,7 @@ public:
     ~BruteForce() override = default;
 
     std::vector<int64_t>
-    Add(const DatasetPtr& data, AddMode mode = AddMode::DEFAULT) override;
+    Add(const DatasetPtr& data) override;
 
     std::vector<int64_t>
     Build(const DatasetPtr& data) override;

--- a/src/algorithm/hgraph/hgraph.h
+++ b/src/algorithm/hgraph/hgraph.h
@@ -71,7 +71,7 @@ public:
     ~HGraph() override = default;
 
     std::vector<int64_t>
-    Add(const DatasetPtr& data, AddMode mode = AddMode::DEFAULT) override;
+    Add(const DatasetPtr& data) override;
 
     std::string
     AnalyzeIndexBySearch(const SearchRequest& request) override;

--- a/src/algorithm/hgraph/hgraph_build.cpp
+++ b/src/algorithm/hgraph/hgraph_build.cpp
@@ -227,7 +227,7 @@ HGraph::build_by_odescent(const DatasetPtr& data) {
 }
 
 std::vector<int64_t>
-HGraph::Add(const DatasetPtr& data, AddMode mode) {
+HGraph::Add(const DatasetPtr& data) {
     std::shared_lock<std::shared_mutex> force_remove_rlock;
     if (this->support_force_remove()) {
         force_remove_rlock = std::shared_lock<std::shared_mutex>(this->force_remove_mutex_);

--- a/src/algorithm/inner_index_interface.h
+++ b/src/algorithm/inner_index_interface.h
@@ -62,7 +62,7 @@ public:
     FastCreateIndex(const std::string& index_fast_str, const IndexCommonParam& common_param);
 
     virtual std::vector<int64_t>
-    Add(const DatasetPtr& base, AddMode mode = AddMode::DEFAULT) = 0;
+    Add(const DatasetPtr& base) = 0;
 
     virtual std::string
     AnalyzeIndexBySearch(const SearchRequest& request) {

--- a/src/algorithm/inner_index_interface_test.cpp
+++ b/src/algorithm/inner_index_interface_test.cpp
@@ -89,7 +89,7 @@ public:
     }
 
     std::vector<int64_t>
-    Add(const DatasetPtr& base, AddMode mode) override {
+    Add(const DatasetPtr& base) override {
         return {};
     }
 

--- a/src/algorithm/ivf/ivf.cpp
+++ b/src/algorithm/ivf/ivf.cpp
@@ -376,7 +376,7 @@ IVF::Train(const DatasetPtr& data) {
 }
 
 std::vector<int64_t>
-IVF::Add(const DatasetPtr& base, AddMode mode) {
+IVF::Add(const DatasetPtr& base) {
     // TODO(LHT): duplicate
     if (not partition_strategy_->is_trained_) {
         throw VsagException(ErrorType::INTERNAL_ERROR, "ivf index add without train error");

--- a/src/algorithm/ivf/ivf.h
+++ b/src/algorithm/ivf/ivf.h
@@ -70,7 +70,7 @@ public:
     ~IVF() override = default;
 
     std::vector<int64_t>
-    Add(const DatasetPtr& base, AddMode mode = AddMode::DEFAULT) override;
+    Add(const DatasetPtr& base) override;
 
     std::string
     AnalyzeIndexBySearch(const vsag::SearchRequest& request) override;

--- a/src/algorithm/lazy_hgraph/lazy_hgraph.cpp
+++ b/src/algorithm/lazy_hgraph/lazy_hgraph.cpp
@@ -161,17 +161,17 @@ LazyHGraph::Build(const DatasetPtr& data) {
 }
 
 std::vector<int64_t>
-LazyHGraph::Add(const DatasetPtr& data, AddMode mode) {
+LazyHGraph::Add(const DatasetPtr& data) {
     std::vector<int64_t> failed_ids;
     bool need_transition = false;
     {
         std::shared_lock lock(this->phase_mutex_);
         if (phase_.load(std::memory_order_acquire) == Phase::FLAT) {
-            failed_ids = flat_index_->Add(data, mode);
+            failed_ids = flat_index_->Add(data);
             need_transition =
                 static_cast<uint64_t>(flat_index_->GetNumElements()) >= transition_threshold_;
         } else {
-            failed_ids = graph_index_->Add(data, mode);
+            failed_ids = graph_index_->Add(data);
         }
     }
     if (need_transition) {

--- a/src/algorithm/lazy_hgraph/lazy_hgraph.h
+++ b/src/algorithm/lazy_hgraph/lazy_hgraph.h
@@ -58,7 +58,7 @@ public:
     LazyHGraph(const ParamPtr& param, const IndexCommonParam& common_param);
 
     std::vector<int64_t>
-    Add(const DatasetPtr& data, AddMode mode = AddMode::DEFAULT) override;
+    Add(const DatasetPtr& data) override;
 
     std::vector<int64_t>
     Build(const DatasetPtr& data) override;

--- a/src/algorithm/pyramid/pyramid.cpp
+++ b/src/algorithm/pyramid/pyramid.cpp
@@ -521,7 +521,7 @@ Pyramid::ExportModel(const IndexCommonParam& param) const {
 }
 
 std::vector<int64_t>
-Pyramid::Add(const DatasetPtr& base, AddMode mode) {
+Pyramid::Add(const DatasetPtr& base) {
     int64_t data_num = base->GetNumElements();
     const auto* data_vectors = base->GetFloat32Vectors();
     const auto* data_ids = base->GetIds();

--- a/src/algorithm/pyramid/pyramid.h
+++ b/src/algorithm/pyramid/pyramid.h
@@ -175,7 +175,7 @@ public:
     ~Pyramid() override = default;
 
     std::vector<int64_t>
-    Add(const DatasetPtr& base, AddMode mode = AddMode::DEFAULT) override;
+    Add(const DatasetPtr& base) override;
 
     std::vector<int64_t>
     Build(const DatasetPtr& base) override;

--- a/src/algorithm/sindi/sindi.cpp
+++ b/src/algorithm/sindi/sindi.cpp
@@ -86,7 +86,7 @@ SINDI::AnalyzeIndexBySearch(const SearchRequest& request) {
 }
 
 std::vector<int64_t>
-SINDI::Add(const DatasetPtr& base, AddMode mode) {
+SINDI::Add(const DatasetPtr& base) {
     std::scoped_lock wlock(this->global_mutex_);
     std::vector<int64_t> failed_ids;
 

--- a/src/algorithm/sindi/sindi.h
+++ b/src/algorithm/sindi/sindi.h
@@ -76,7 +76,7 @@ public:
     AnalyzeIndexBySearch(const SearchRequest& request) override;
 
     std::vector<int64_t>
-    Add(const DatasetPtr& base, AddMode mode = AddMode::DEFAULT) override;
+    Add(const DatasetPtr& base) override;
 
     std::vector<int64_t>
     Build(const DatasetPtr& base) override;

--- a/src/algorithm/sparse_index/sparse_index.cpp
+++ b/src/algorithm/sparse_index/sparse_index.cpp
@@ -115,7 +115,7 @@ SparseIndex::sort_sparse_vector(const SparseVector& vector) const {
 }
 
 std::vector<int64_t>
-SparseIndex::Add(const DatasetPtr& base, AddMode mode) {
+SparseIndex::Add(const DatasetPtr& base) {
     const auto* sparse_vectors = base->GetSparseVectors();
     auto data_num = base->GetNumElements();
     CHECK_ARGUMENT(data_num > 0, "data_num is zero when add vectors");

--- a/src/algorithm/sparse_index/sparse_index.h
+++ b/src/algorithm/sparse_index/sparse_index.h
@@ -45,7 +45,7 @@ public:
     ~SparseIndex() override;
 
     std::vector<int64_t>
-    Add(const DatasetPtr& base, AddMode mode = AddMode::DEFAULT) override;
+    Add(const DatasetPtr& base) override;
 
     DatasetPtr
     CalDistanceById(const DatasetPtr& query,

--- a/src/index/hnsw.h
+++ b/src/index/hnsw.h
@@ -87,8 +87,7 @@ public:
     }
 
     tl::expected<std::vector<int64_t>, Error>
-    Add(const DatasetPtr& base, AddMode mode = AddMode::DEFAULT) override {
-        // TODO(LHT): HNSW only support KEEP_TOMBSTONE mode
+    Add(const DatasetPtr& base) override {
         SAFE_CALL(return this->add(base));
     }
 

--- a/src/index/hnsw_test.cpp
+++ b/src/index/hnsw_test.cpp
@@ -1016,7 +1016,7 @@ TEST_CASE("extract/set data and graph", "[ut][hnsw]") {
         ->Ids(ids.data() + num_elements / 2)
         ->Float32Vectors(vectors.data() + num_elements / 2 * dim)
         ->Owner(false);
-    another_index->Add(dataset, AddMode::DEFAULT);
+    another_index->Add(dataset);
 
     JsonType search_parameters;
 

--- a/src/index/index_impl.h
+++ b/src/index/index_impl.h
@@ -70,10 +70,10 @@ public:
 
 public:
     tl::expected<std::vector<int64_t>, Error>
-    Add(const DatasetPtr& base, AddMode mode = AddMode::DEFAULT) override {
+    Add(const DatasetPtr& base) override {
         CHECK_IMMUTABLE_INDEX("add");
         CHECK_NONEMPTY_DATASET(base);
-        SAFE_CALL(return this->inner_index_->Add(base, mode));
+        SAFE_CALL(return this->inner_index_->Add(base));
     }
 
     std::string


### PR DESCRIPTION
## Summary

Remove the `AddMode` enum and the `mode` parameter from all `Add()` method signatures.

Closes #2365

## Problem

The `AddMode` enum (`DEFAULT`, `KEEP_TOMBSTONE`) was defined in the public API but never used by any implementation:

- All `Add()` methods accepted the `mode` parameter but had **zero conditional branches** on it
- The only reference to `KEEP_TOMBSTONE` was a TODO comment in HNSW (never implemented)
- The C API and Python bindings never exposed this parameter
- The parameter misleads callers into thinking the mode has an effect

## Changes

- Remove `enum class AddMode` from `include/vsag/index.h`
- Remove `AddMode mode` parameter from all `Add()` signatures (22 files)
- Remove the `KEEP_TOMBSTONE` TODO comment from `src/index/hnsw.h`
- Update `lazy_hgraph.cpp` forwarding calls to remove `mode`
- Update `index_impl.h` forwarding call to remove `mode`
- Update test code in `hnsw_test.cpp` and `inner_index_interface_test.cpp`
- Update mock implementation in `simpleflat.{h,cpp}`

## Impact

This is an API-breaking change for C++ users who explicitly pass `AddMode` to `Add()`. However, since no implementation uses the parameter, callers can simply remove the argument with no behavioral change. The C API and Python bindings are unaffected as they never exposed this parameter.

## Test Plan

- [ ] CI build passes
- [ ] Existing unit tests pass
- [ ] No functional change expected (parameter was never used)