### PR TITLE
fix(hgraph): expose skip_ratio and skip_strategy search parameters (v0.18 backport)

### DIFF
--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -944,6 +944,8 @@ HGraph::KnnSearch(const DatasetPtr& query,
         search_param.consider_duplicate = this->label_table_->CompressDuplicateData();
         search_param.parallel_search_thread_count = params.parallel_search_thread_count;
         search_param.min_distance = params.min_distance;
+        search_param.skip_ratio = params.skip_ratio;
+        search_param.skip_strategy_type = params.skip_strategy_type;
 
         search_result = this->search_one_graph(query_data,
                                                this->bottom_graph_,
@@ -1155,6 +1157,8 @@ HGraph::RangeSearch(const DatasetPtr& query,
     search_param.range_search_limit_size = static_cast<int>(limited_size);
     search_param.parallel_search_thread_count = params.parallel_search_thread_count;
     search_param.min_distance = params.min_distance;
+    search_param.skip_ratio = params.skip_ratio;
+    search_param.skip_strategy_type = params.skip_strategy_type;
 
     auto search_result = this->search_one_graph(raw_query,
                                                 this->bottom_graph_,
@@ -2200,6 +2204,8 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
     }
     search_param.parallel_search_thread_count = params.parallel_search_thread_count;
     search_param.min_distance = params.min_distance;
+    search_param.skip_ratio = params.skip_ratio;
+    search_param.skip_strategy_type = params.skip_strategy_type;
 
     // hops_limit only takes effect when it's greater than ef_search
     if (params.hops_limit <= static_cast<uint32_t>(params.ef_search)) {

--- a/src/algorithm/hgraph_parameter.cpp
+++ b/src/algorithm/hgraph_parameter.cpp
@@ -224,6 +224,18 @@ HGraphSearchParameters::FromJson(const std::string& json_string) {
         obj.min_distance = params[INDEX_TYPE_HGRAPH]["min_distance"].GetFloat();
     }
 
+    if (params[INDEX_TYPE_HGRAPH].Contains(HNSW_PARAMETER_SKIP_RATIO)) {
+        obj.skip_ratio = params[INDEX_TYPE_HGRAPH][HNSW_PARAMETER_SKIP_RATIO].GetFloat();
+        CHECK_ARGUMENT((0.0F <= obj.skip_ratio) and (obj.skip_ratio <= 1.0F),  // NOLINT
+                       fmt::format("skip_ratio({}) must be in range [0.0, 1.0]", obj.skip_ratio));
+    }
+    if (params[INDEX_TYPE_HGRAPH].Contains(HNSW_PARAMETER_SKIP_STRATEGY)) {
+        CHECK_ARGUMENT(
+            params[INDEX_TYPE_HGRAPH][HNSW_PARAMETER_SKIP_STRATEGY].IsString(),
+            fmt::format("parameters[{}] must be string type", HNSW_PARAMETER_SKIP_STRATEGY));
+        obj.skip_strategy_type = parse_filter_search_skip_strategy_type(
+            params[INDEX_TYPE_HGRAPH][HNSW_PARAMETER_SKIP_STRATEGY].GetString());
+    }
     return obj;
 }
 }  // namespace vsag

--- a/src/algorithm/hgraph_parameter.h
+++ b/src/algorithm/hgraph_parameter.h
@@ -20,6 +20,7 @@
 #include "data_type.h"
 #include "index_search_parameter.h"
 #include "inner_index_parameter.h"
+#include "utils/filter_search_skip_strategy.h"
 #include "utils/pointer_define.h"
 #include "vsag/constants.h"
 
@@ -82,6 +83,9 @@ public:
     bool use_reorder{false};
     bool use_extra_info_filter{false};
     float min_distance{std::numeric_limits<float>::lowest()};
+    float skip_ratio{0.2F};
+    FilterSearchSkipStrategyType skip_strategy_type{
+        FilterSearchSkipStrategyType::DETERMINISTIC_ACCUMULATIVE};
 
 private:
     HGraphSearchParameters() = default;

--- a/src/algorithm/hgraph_parameter_test.cpp
+++ b/src/algorithm/hgraph_parameter_test.cpp
@@ -228,3 +228,32 @@ TEST_CASE("HGraph maps label_remap_type to inner index parameter", "[ut][HGraphP
     REQUIRE(typed_param != nullptr);
     REQUIRE(typed_param->label_remap_type == vsag::LabelRemapType::ROBIN);
 }
+
+TEST_CASE("HGraphSearchParameters parses skip_ratio and skip_strategy",
+          "[ut][HGraphSearchParameters][skip_ratio]") {
+    SECTION("default values") {
+        auto params = vsag::HGraphSearchParameters::FromJson(R"({"hgraph": {"ef_search": 32}})");
+        REQUIRE(params.skip_ratio == 0.2F);
+        REQUIRE(params.skip_strategy_type ==
+                vsag::FilterSearchSkipStrategyType::DETERMINISTIC_ACCUMULATIVE);
+    }
+
+    SECTION("custom skip_ratio") {
+        auto params = vsag::HGraphSearchParameters::FromJson(
+            R"({"hgraph": {"ef_search": 32, "skip_ratio": 0.5}})");
+        REQUIRE(params.skip_ratio == 0.5F);
+    }
+
+    SECTION("custom skip_strategy") {
+        auto params = vsag::HGraphSearchParameters::FromJson(
+            R"({"hgraph": {"ef_search": 32, "skip_strategy": "random"}})");
+        REQUIRE(params.skip_strategy_type == vsag::FilterSearchSkipStrategyType::RANDOM);
+    }
+
+    SECTION("rejects out-of-range skip_ratio") {
+        REQUIRE_THROWS(vsag::HGraphSearchParameters::FromJson(
+            R"({"hgraph": {"ef_search": 32, "skip_ratio": 1.5}})"));
+        REQUIRE_THROWS(vsag::HGraphSearchParameters::FromJson(
+            R"({"hgraph": {"ef_search": 32, "skip_ratio": -0.1}})"));
+    }
+}

--- a/src/impl/inner_search_param.h
+++ b/src/impl/inner_search_param.h
@@ -43,7 +43,7 @@ public:
     uint64_t ef{10};
     uint32_t hops_limit{std::numeric_limits<uint32_t>::max()};
     FilterPtr is_inner_id_allowed{nullptr};
-    float skip_ratio{0.8F};
+    float skip_ratio{0.2F};
     FilterSearchSkipStrategyType skip_strategy_type{
         FilterSearchSkipStrategyType::DETERMINISTIC_ACCUMULATIVE};
     InnerSearchMode search_mode{KNN_SEARCH};

--- a/src/index/hnsw_zparameters.h
+++ b/src/index/hnsw_zparameters.h
@@ -63,7 +63,7 @@ public:
 public:
     // required vars
     int64_t ef_search;
-    float skip_ratio{0.9};
+    float skip_ratio{0.1F};
     FilterSearchSkipStrategyType skip_strategy_type{
         FilterSearchSkipStrategyType::DETERMINISTIC_ACCUMULATIVE};
     bool use_conjugate_graph_search;

--- a/src/utils/filter_search_skip_strategy.cpp
+++ b/src/utils/filter_search_skip_strategy.cpp
@@ -25,10 +25,7 @@ constexpr const char* DETERMINISTIC_ACCUMULATIVE_SKIP_STRATEGY = "deterministic_
 
 double
 get_retain_ratio(float valid_ratio, float skip_ratio) {
-    if (valid_ratio == 1.0F) {
-        return 1.0;
-    }
-    return static_cast<double>(1.0F - valid_ratio) * static_cast<double>(skip_ratio);
+    return static_cast<double>(1.0F - valid_ratio) * static_cast<double>(1.0F - skip_ratio);
 }
 
 class RandomFilterSearchSkipStrategy : public FilterSearchSkipStrategy {
@@ -39,7 +36,7 @@ public:
 
     bool
     ShouldVisit() override {
-        return generator_.NextFloat() > visit_threshold_;
+        return generator_.NextFloat() >= visit_threshold_;
     }
 
 private:

--- a/src/utils/filter_search_skip_strategy_test.cpp
+++ b/src/utils/filter_search_skip_strategy_test.cpp
@@ -25,6 +25,8 @@ TEST_CASE("Filter search skip strategy parse", "[ut][filter_search_skip_strategy
     REQUIRE(parse_filter_search_skip_strategy_type("deterministic_accumulative") ==
             FilterSearchSkipStrategyType::DETERMINISTIC_ACCUMULATIVE);
     REQUIRE(std::string(filter_search_skip_strategy_type_to_string(
+                FilterSearchSkipStrategyType::RANDOM)) == "random");
+    REQUIRE(std::string(filter_search_skip_strategy_type_to_string(
                 FilterSearchSkipStrategyType::DETERMINISTIC_ACCUMULATIVE)) ==
             "deterministic_accumulative");
     REQUIRE_THROWS(parse_filter_search_skip_strategy_type("unknown"));
@@ -32,7 +34,7 @@ TEST_CASE("Filter search skip strategy parse", "[ut][filter_search_skip_strategy
 
 TEST_CASE("Accumulative ShouldVisit is deterministic", "[ut][filter_search_skip_strategy]") {
     constexpr float valid_ratio = 0.5F;
-    constexpr float skip_ratio = 0.8F;
+    constexpr float skip_ratio = 0.2F;
     std::vector<bool> first_sequence;
     std::vector<bool> second_sequence;
 
@@ -47,7 +49,7 @@ TEST_CASE("Accumulative ShouldVisit is deterministic", "[ut][filter_search_skip_
     }
 
     REQUIRE(first_sequence == second_sequence);
-    // visit_ratio = 0.5 + 0.5*0.8 = 0.9
+    // visit_ratio = 0.5 + (1-0.5)*(1-0.2) = 0.5 + 0.4 = 0.9
     // Accumulative pattern: F,T,T,T,T,T,T,T,T,T repeated = 18/20 true
     std::vector<bool> expected = {false, true, true, true, true, true, true, true, true, true,
                                   false, true, true, true, true, true, true, true, true, true};
@@ -63,18 +65,16 @@ TEST_CASE("ShouldVisit edge cases", "[ut][filter_search_skip_strategy]") {
         }
     }
 
-    SECTION("skip ratio zero with low valid ratio visits less") {
+    SECTION("skip ratio zero means no skipping") {
         auto strategy = create_filter_search_skip_strategy(
             FilterSearchSkipStrategyType::DETERMINISTIC_ACCUMULATIVE, 0.5F, 0.0F);
-        // visit_ratio = 0.5 + 0.5*0 = 0.5
-        // Accumulative pattern: F,T,F,T,... alternating = exactly 50/100 true
+        // visit_ratio = 0.5 + (1-0.5)*(1-0.0) = 0.5 + 0.5 = 1.0
+        // Accumulative pattern: all true since visit_ratio = 1.0
         std::vector<bool> sequence;
         for (uint64_t i = 0; i < 20; ++i) {
             sequence.emplace_back(strategy->ShouldVisit());
         }
-        std::vector<bool> expected = {false, true,  false, true,  false, true,  false,
-                                      true,  false, true,  false, true,  false, true,
-                                      false, true,  false, true,  false, true};
+        std::vector<bool> expected(20, true);  // All true since we visit everything
         REQUIRE(sequence == expected);
     }
 }


### PR DESCRIPTION
Backport of #2367 to v0.18 branch.

Fixes #2368


## Breaking Change: skip_ratio semantics inverted

The skip_ratio parameter semantics have been inverted to match the parameter name.

Before: skip_ratio=0.8 meant visit 80% of invalid points.
After: skip_ratio=0.2 means skip 20% of invalid points (visit 80%).

Default values changed: HGraph 0.8 to 0.2, HNSW 0.9 to 0.1.

If using custom skip_ratio values, change to (1 - old_value) to maintain same behavior.
