### PR TITLE
fix(hgraph): expose skip_ratio and skip_strategy search parameters (v0.17 backport)

### DIFF
--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -375,6 +375,8 @@ HGraph::KnnSearch(const DatasetPtr& query,
         search_param.ef = std::max(params.ef_search, k);
         search_param.is_inner_id_allowed = ft;
         search_param.topk = static_cast<int64_t>(search_param.ef);
+        search_param.skip_ratio = params.skip_ratio;
+        search_param.skip_strategy_type = params.skip_strategy_type;
         search_result = this->search_one_graph(query_data,
                                                this->bottom_graph_,
                                                this->basic_flatten_codes_,
@@ -552,6 +554,8 @@ HGraph::RangeSearch(const DatasetPtr& query,
     search_param.search_mode = RANGE_SEARCH;
     search_param.consider_duplicate = true;
     search_param.range_search_limit_size = static_cast<int>(limited_size);
+    search_param.skip_ratio = params.skip_ratio;
+    search_param.skip_strategy_type = params.skip_strategy_type;
     auto search_result = this->search_one_graph(
         raw_query, this->bottom_graph_, this->basic_flatten_codes_, search_param);
     if (use_reorder_) {
@@ -1909,6 +1913,8 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
         search_param.time_cost->SetThreshold(params.timeout_ms);
         (*search_param.stats)["is_timeout"].SetBool(false);
     }
+    search_param.skip_ratio = params.skip_ratio;
+    search_param.skip_strategy_type = params.skip_strategy_type;
     auto search_result = this->search_one_graph(
         raw_query, this->bottom_graph_, this->basic_flatten_codes_, search_param);
 

--- a/src/algorithm/hgraph_parameter.cpp
+++ b/src/algorithm/hgraph_parameter.cpp
@@ -210,6 +210,18 @@ HGraphSearchParameters::FromJson(const std::string& json_string) {
         obj.topk_factor = params[INDEX_TYPE_HGRAPH][SEARCH_PARAM_FACTOR].GetFloat();
     }
 
+    if (params[INDEX_TYPE_HGRAPH].Contains(HNSW_PARAMETER_SKIP_RATIO)) {
+        obj.skip_ratio = params[INDEX_TYPE_HGRAPH][HNSW_PARAMETER_SKIP_RATIO].GetFloat();
+        CHECK_ARGUMENT((0.0F <= obj.skip_ratio) and (obj.skip_ratio <= 1.0F),  // NOLINT
+                       fmt::format("skip_ratio({}) must in range[0.0, 1.0]", obj.skip_ratio));
+    }
+    if (params[INDEX_TYPE_HGRAPH].Contains(HNSW_PARAMETER_SKIP_STRATEGY)) {
+        CHECK_ARGUMENT(
+            params[INDEX_TYPE_HGRAPH][HNSW_PARAMETER_SKIP_STRATEGY].IsString(),
+            fmt::format("parameters[{}] must be string type", HNSW_PARAMETER_SKIP_STRATEGY));
+        obj.skip_strategy_type = parse_filter_search_skip_strategy_type(
+            params[INDEX_TYPE_HGRAPH][HNSW_PARAMETER_SKIP_STRATEGY].GetString());
+    }
     return obj;
 }
 }  // namespace vsag

--- a/src/algorithm/hgraph_parameter.h
+++ b/src/algorithm/hgraph_parameter.h
@@ -17,6 +17,7 @@
 
 #include "data_type.h"
 #include "inner_index_parameter.h"
+#include "utils/filter_search_skip_strategy.h"
 #include "utils/pointer_define.h"
 #include "vsag/constants.h"
 
@@ -77,6 +78,9 @@ public:
     float topk_factor{0.0F};
     bool use_reorder{false};
     bool use_extra_info_filter{false};
+    float skip_ratio{0.2F};
+    FilterSearchSkipStrategyType skip_strategy_type{
+        FilterSearchSkipStrategyType::DETERMINISTIC_ACCUMULATIVE};
     bool enable_time_record{false};
     double timeout_ms{std::numeric_limits<double>::max()};
 

--- a/src/algorithm/hgraph_parameter_test.cpp
+++ b/src/algorithm/hgraph_parameter_test.cpp
@@ -125,37 +125,64 @@ generate_hgraph_param(const HGraphDefaultParam& param) {
                        param.support_duplicate);
 }
 
-TEST_CASE("HGraph Parameters CheckCompatibility", "[ut][HGraphParameter][CheckCompatibility]") {
-    SECTION("wrong parameter type") {
-        HGraphDefaultParam default_param;
-        auto param_str = generate_hgraph_param(default_param);
-        auto param = std::make_shared<vsag::HGraphParameter>();
-        param->FromString(param_str);
-        REQUIRE(param->CheckCompatibility(param));
-        REQUIRE_FALSE(param->CheckCompatibility(std::make_shared<vsag::EmptyParameter>()));
+TEST_CASE("HGraph Parameters CheckCompatibility", "[ut][HGraphParameter][CheckCompatibility]"){
+    SECTION("wrong parameter type"){HGraphDefaultParam default_param;
+auto param_str = generate_hgraph_param(default_param);
+auto param = std::make_shared<vsag::HGraphParameter>();
+param->FromString(param_str);
+REQUIRE(param->CheckCompatibility(param));
+REQUIRE_FALSE(param->CheckCompatibility(std::make_shared<vsag::EmptyParameter>()));
+}
+
+TEST_COMPATIBILITY_CASE(
+    "different base codes io type", base_codes_io_type, "memory_io", "block_memory_io", true)
+TEST_COMPATIBILITY_CASE("different pq dim", base_codes_pq_dim, 8, 16, false)
+TEST_COMPATIBILITY_CASE(
+    "different base codes quantization type", base_codes_quantization_type, "sq4", "sq8", false)
+TEST_COMPATIBILITY_CASE("different graph type", graph_storage_type, "flat", "compressed", false)
+TEST_COMPATIBILITY_CASE("different max degree", max_degree, 26, 30, false)
+TEST_COMPATIBILITY_CASE("different support remove", support_remove, true, false, false)
+TEST_COMPATIBILITY_CASE("different remove flag bit", remove_flag_bit, 8, 16, false)
+TEST_COMPATIBILITY_CASE("different use reorder", use_reorder, true, false, false)
+TEST_COMPATIBILITY_CASE(
+    "different precise codes io type", precise_codes_io_type, "memory_io", "block_memory_io", true)
+TEST_COMPATIBILITY_CASE("different precise codes quantization type",
+                        precise_codes_quantization_type,
+                        "fp32",
+                        "sq8",
+                        false)
+TEST_COMPATIBILITY_CASE("different use attribute filter", use_attribute_filter, true, false, false)
+TEST_COMPATIBILITY_CASE("different support duplicate", support_duplicate, true, false, false)
+}
+
+TEST_CASE("HGraphSearchParameters parses skip_ratio and skip_strategy",
+          "[ut][HGraphSearchParameters][skip_ratio]") {
+    SECTION("default values") {
+        auto params = vsag::HGraphSearchParameters::FromJson(R"({"hgraph": {"ef_search": 32}})");
+        REQUIRE(params.skip_ratio == 0.2F);
+        REQUIRE(params.skip_strategy_type ==
+                vsag::FilterSearchSkipStrategyType::DETERMINISTIC_ACCUMULATIVE);
     }
 
-    TEST_COMPATIBILITY_CASE(
-        "different base codes io type", base_codes_io_type, "memory_io", "block_memory_io", true)
-    TEST_COMPATIBILITY_CASE("different pq dim", base_codes_pq_dim, 8, 16, false)
-    TEST_COMPATIBILITY_CASE(
-        "different base codes quantization type", base_codes_quantization_type, "sq4", "sq8", false)
-    TEST_COMPATIBILITY_CASE("different graph type", graph_storage_type, "flat", "compressed", false)
-    TEST_COMPATIBILITY_CASE("different max degree", max_degree, 26, 30, false)
-    TEST_COMPATIBILITY_CASE("different support remove", support_remove, true, false, false)
-    TEST_COMPATIBILITY_CASE("different remove flag bit", remove_flag_bit, 8, 16, false)
-    TEST_COMPATIBILITY_CASE("different use reorder", use_reorder, true, false, false)
-    TEST_COMPATIBILITY_CASE("different precise codes io type",
-                            precise_codes_io_type,
-                            "memory_io",
-                            "block_memory_io",
-                            true)
-    TEST_COMPATIBILITY_CASE("different precise codes quantization type",
-                            precise_codes_quantization_type,
-                            "fp32",
-                            "sq8",
-                            false)
-    TEST_COMPATIBILITY_CASE(
-        "different use attribute filter", use_attribute_filter, true, false, false)
-    TEST_COMPATIBILITY_CASE("different support duplicate", support_duplicate, true, false, false)
+    SECTION("custom skip_ratio") {
+        auto params = vsag::HGraphSearchParameters::FromJson(
+            R"({"hgraph": {"ef_search": 32, "skip_ratio": 0.5}})");
+        REQUIRE(params.skip_ratio == 0.5F);
+    }
+
+    SECTION("custom skip_strategy") {
+        auto params = vsag::HGraphSearchParameters::FromJson(
+            R"({"hgraph": {"ef_search": 32, "skip_strategy": "random"}})");
+        REQUIRE(params.skip_strategy_type == vsag::FilterSearchSkipStrategyType::RANDOM);
+    }
+
+    SECTION("skip_ratio out of range - too high") {
+        REQUIRE_THROWS(vsag::HGraphSearchParameters::FromJson(
+            R"({"hgraph": {"ef_search": 32, "skip_ratio": 1.5}})"));
+    }
+
+    SECTION("skip_ratio out of range - negative") {
+        REQUIRE_THROWS(vsag::HGraphSearchParameters::FromJson(
+            R"({"hgraph": {"ef_search": 32, "skip_ratio": -0.1}})"));
+    }
 }

--- a/src/impl/inner_search_param.h
+++ b/src/impl/inner_search_param.h
@@ -41,7 +41,7 @@ public:
     InnerIdType ep{0};
     uint64_t ef{10};
     FilterPtr is_inner_id_allowed{nullptr};
-    float skip_ratio{0.8F};
+    float skip_ratio{0.2F};
     FilterSearchSkipStrategyType skip_strategy_type{
         FilterSearchSkipStrategyType::DETERMINISTIC_ACCUMULATIVE};
     InnerSearchMode search_mode{KNN_SEARCH};

--- a/src/index/hnsw_zparameters.h
+++ b/src/index/hnsw_zparameters.h
@@ -62,7 +62,7 @@ public:
 public:
     // required vars
     int64_t ef_search;
-    float skip_ratio{0.9};
+    float skip_ratio{0.1F};
     FilterSearchSkipStrategyType skip_strategy_type{
         FilterSearchSkipStrategyType::DETERMINISTIC_ACCUMULATIVE};
     bool use_conjugate_graph_search;

--- a/src/utils/filter_search_skip_strategy.cpp
+++ b/src/utils/filter_search_skip_strategy.cpp
@@ -14,7 +14,6 @@
 
 #include "filter_search_skip_strategy.h"
 
-#include <algorithm>
 #include <cmath>
 
 #include "linear_congruential_generator.h"
@@ -28,12 +27,7 @@ constexpr const char* DETERMINISTIC_ACCUMULATIVE_SKIP_STRATEGY = "deterministic_
 
 double
 get_retain_ratio(float valid_ratio, float skip_ratio) {
-    if (valid_ratio == 1.0F) {
-        return 1.0;
-    }
-    auto skip_check_probability =
-        static_cast<double>(1.0F - valid_ratio) * static_cast<double>(skip_ratio);
-    return std::clamp(skip_check_probability, 0.0, 1.0);
+    return static_cast<double>(1.0F - valid_ratio) * static_cast<double>(1.0F - skip_ratio);
 }
 
 class RandomFilterSearchSkipStrategy : public FilterSearchSkipStrategy {
@@ -44,7 +38,7 @@ public:
 
     bool
     ShouldVisit() override {
-        return generator_.NextFloat() > visit_threshold_;
+        return generator_.NextFloat() >= visit_threshold_;
     }
 
 private:
@@ -61,7 +55,7 @@ public:
     ShouldVisit() override {
         accumulative_alpha_ += visit_ratio_;
         if (accumulative_alpha_ >= 1.0) {
-            accumulative_alpha_ = std::fmod(accumulative_alpha_, 1.0);
+            accumulative_alpha_ -= 1.0;
             return true;
         }
         return false;
@@ -79,8 +73,6 @@ create_filter_search_skip_strategy(FilterSearchSkipStrategyType type,
                                    float valid_ratio,
                                    float skip_ratio) {
     auto retain_ratio = get_retain_ratio(valid_ratio, skip_ratio);
-    // visit_ratio = valid_ratio + retain_ratio, capped at 1.0
-    // When valid_ratio is high, we visit most neighbors; when low, visit_ratio depends on skip_ratio
     auto visit_ratio = std::min(1.0, static_cast<double>(valid_ratio) + retain_ratio);
     switch (type) {
         case FilterSearchSkipStrategyType::RANDOM:
@@ -100,8 +92,7 @@ parse_filter_search_skip_strategy_type(const std::string& strategy_name) {
         return FilterSearchSkipStrategyType::DETERMINISTIC_ACCUMULATIVE;
     }
     throw VsagException(ErrorType::INVALID_ARGUMENT,
-                        "invalid filter search skip strategy '" + strategy_name +
-                            "', valid values are 'random' and 'deterministic_accumulative'");
+                        "invalid filter search skip strategy: " + strategy_name);
 }
 
 const char*

--- a/src/utils/filter_search_skip_strategy_test.cpp
+++ b/src/utils/filter_search_skip_strategy_test.cpp
@@ -14,7 +14,6 @@
 
 #include "filter_search_skip_strategy.h"
 
-#include <algorithm>
 #include <catch2/catch_test_macros.hpp>
 #include <vector>
 
@@ -26,16 +25,16 @@ TEST_CASE("Filter search skip strategy parse", "[ut][filter_search_skip_strategy
     REQUIRE(parse_filter_search_skip_strategy_type("deterministic_accumulative") ==
             FilterSearchSkipStrategyType::DETERMINISTIC_ACCUMULATIVE);
     REQUIRE(std::string(filter_search_skip_strategy_type_to_string(
+                FilterSearchSkipStrategyType::RANDOM)) == "random");
+    REQUIRE(std::string(filter_search_skip_strategy_type_to_string(
                 FilterSearchSkipStrategyType::DETERMINISTIC_ACCUMULATIVE)) ==
             "deterministic_accumulative");
-    REQUIRE(std::string(filter_search_skip_strategy_type_to_string(
-                FilterSearchSkipStrategyType::RANDOM)) == "random");
     REQUIRE_THROWS(parse_filter_search_skip_strategy_type("unknown"));
 }
 
 TEST_CASE("Accumulative ShouldVisit is deterministic", "[ut][filter_search_skip_strategy]") {
     constexpr float valid_ratio = 0.5F;
-    constexpr float skip_ratio = 0.8F;
+    constexpr float skip_ratio = 0.2F;
     std::vector<bool> first_sequence;
     std::vector<bool> second_sequence;
 
@@ -50,7 +49,7 @@ TEST_CASE("Accumulative ShouldVisit is deterministic", "[ut][filter_search_skip_
     }
 
     REQUIRE(first_sequence == second_sequence);
-    // visit_ratio = 0.5 + 0.5*0.8 = 0.9
+    // visit_ratio = 0.5 + (1-0.5)*(1-0.2) = 0.5 + 0.4 = 0.9
     // Accumulative pattern: F,T,T,T,T,T,T,T,T,T repeated = 18/20 true
     std::vector<bool> expected = {false, true, true, true, true, true, true, true, true, true,
                                   false, true, true, true, true, true, true, true, true, true};
@@ -66,18 +65,16 @@ TEST_CASE("ShouldVisit edge cases", "[ut][filter_search_skip_strategy]") {
         }
     }
 
-    SECTION("skip ratio zero with low valid ratio visits less") {
+    SECTION("skip ratio zero means no skipping") {
         auto strategy = create_filter_search_skip_strategy(
             FilterSearchSkipStrategyType::DETERMINISTIC_ACCUMULATIVE, 0.5F, 0.0F);
-        // visit_ratio = 0.5 + 0.5*0 = 0.5
-        // Accumulative pattern: F,T,F,T,... alternating = exactly 50/100 true
+        // visit_ratio = 0.5 + (1-0.5)*(1-0.0) = 0.5 + 0.5 = 1.0
+        // Accumulative pattern: all true since visit_ratio = 1.0
         std::vector<bool> sequence;
         for (uint64_t i = 0; i < 20; ++i) {
             sequence.emplace_back(strategy->ShouldVisit());
         }
-        std::vector<bool> expected = {false, true,  false, true,  false, true,  false,
-                                      true,  false, true,  false, true,  false, true,
-                                      false, true,  false, true,  false, true};
+        std::vector<bool> expected(20, true);  // All true since we visit everything
         REQUIRE(sequence == expected);
     }
 }


### PR DESCRIPTION
Backport of #2367 to v0.17 branch.

Fixes #2368


## Breaking Change: skip_ratio semantics inverted

The skip_ratio parameter semantics have been inverted to match the parameter name.

Before: skip_ratio=0.8 meant visit 80% of invalid points.
After: skip_ratio=0.2 means skip 20% of invalid points (visit 80%).

Default values changed: HGraph 0.8 to 0.2, HNSW 0.9 to 0.1.

If using custom skip_ratio values, change to (1 - old_value) to maintain same behavior.



## Breaking Change: skip_ratio semantics inverted

The skip_ratio parameter semantics have been inverted to match the parameter name.

Before: skip_ratio=0.8 meant visit 80% of invalid points.
After: skip_ratio=0.2 means skip 20% of invalid points (visit 80%).

Default values changed: HGraph 0.8 to 0.2, HNSW 0.9 to 0.1.

If using custom skip_ratio values, change to (1 - old_value) to maintain same behavior.
