### PR TITLE
feat: expose mrle_dim parameter to HGraph public API

### DIFF
--- a/include/vsag/constants.h
+++ b/include/vsag/constants.h
@@ -172,6 +172,7 @@ extern const char* const RABITQ_BITS_PER_DIM_FILTER;
 extern const char* const RABITQ_ERROR_RATE;
 extern const char* const RABITQ_USE_FHT;
 extern const char* const INDEX_TQ_CHAIN;
+extern const char* const INDEX_MRLE_DIM;
 
 extern const char* const HGRAPH_SUPPORT_REMOVE;
 extern const char* const HGRAPH_SUPPORT_FORCE_REMOVE;

--- a/src/algorithm/hgraph/hgraph_param_mapping.cpp
+++ b/src/algorithm/hgraph/hgraph_param_mapping.cpp
@@ -359,6 +359,14 @@ HGraph::map_hgraph_param(const JsonType& hgraph_json) {
             },
         },
         {
+            INDEX_MRLE_DIM,
+            {
+                BASE_CODES_KEY,
+                QUANTIZATION_PARAMS_KEY,
+                MRLE_DIM_KEY,
+            },
+        },
+        {
             RABITQ_BITS_PER_DIM_QUERY,
             {
                 BASE_CODES_KEY,
@@ -494,6 +502,7 @@ HGraph::map_hgraph_param(const JsonType& hgraph_json) {
                 "{RABITQ_QUANTIZATION_BITS_PER_DIM_BASE_KEY}": 1,
                 "{RABITQ_QUANTIZATION_ERROR_RATE_KEY}": 1.9,
                 "{TQ_CHAIN_KEY}": "",
+                "mrle_dim": 0,
                 "nbits": 8,
                 "{PRODUCT_QUANTIZATION_DIM_KEY}": 1,
                 "{HOLD_MOLDS}": false
@@ -560,6 +569,16 @@ HGraph::CheckAndMappingExternalParam(const JsonType& external_param,
         inner_json[RAW_VECTOR_KEY][CODES_TYPE_KEY].SetString(SPARSE_CODES);
     }
 
+    if (external_param.Contains(INDEX_MRLE_DIM)) {
+        CHECK_ARGUMENT(external_param[INDEX_MRLE_DIM].IsNumberInteger(),
+                       fmt::format("mrle_dim must be an integer, got {}",
+                                   external_param[INDEX_MRLE_DIM].Dump()));
+        int64_t mrle_dim = external_param[INDEX_MRLE_DIM].GetInt();
+        CHECK_ARGUMENT(
+            mrle_dim >= 0 and mrle_dim <= static_cast<int64_t>(common_param.dim_),
+            fmt::format("mrle_dim({}) must be in range [0, {}]", mrle_dim, common_param.dim_));
+    }
+
     auto hgraph_parameter = std::make_shared<HGraphParameter>();
     hgraph_parameter->data_type = common_param.data_type_;
     hgraph_parameter->FromJson(inner_json);
@@ -577,6 +596,7 @@ HGraph::CheckAndMappingExternalParam(const JsonType& external_param,
                                hgraph_parameter->ef_construction,
                                max_degree,
                                construction_threshold));
+
     return hgraph_parameter;
 }
 

--- a/src/algorithm/hgraph/hgraph_parameter_test.cpp
+++ b/src/algorithm/hgraph/hgraph_parameter_test.cpp
@@ -21,6 +21,7 @@
 
 #include "hgraph.h"
 #include "index_common_param.h"
+#include "inner_string_params.h"
 #include "parameter_test.h"
 #include "unittest.h"
 
@@ -375,4 +376,97 @@ TEST_CASE("HGraph maps RaBitQ without y bits to standard RaBitQ", "[ut][HGraphPa
     REQUIRE(base_json["quantization_params"]["rabitq_version"].GetString() ==
             std::string("standard"));
     REQUIRE(base_json["quantization_params"]["rabitq_bits_per_dim_base"].GetInt() == 3);
+}
+
+TEST_CASE("HGraph maps mrle_dim external parameter", "[ut][HGraphParameter]") {
+    auto param = vsag::JsonType::Parse(R"({
+        "base_quantization_type": "tq",
+        "tq_chain": "mrle, fp32",
+        "base_io_type": "block_memory_io",
+        "precise_quantization_type": "fp32",
+        "precise_io_type": "block_memory_io",
+        "mrle_dim": 127,
+        "graph_io_type": "block_memory_io",
+        "graph_storage_type": "flat",
+        "graph_type": "nsw",
+        "max_degree": 32,
+        "ef_construction": 100,
+        "use_reorder": false
+    })");
+
+    vsag::IndexCommonParam common_param;
+    common_param.dim_ = 128;
+    common_param.data_type_ = vsag::DataTypes::DATA_TYPE_FLOAT;
+    auto hgraph_param = vsag::HGraph::CheckAndMappingExternalParam(param, common_param);
+    auto typed_param = std::dynamic_pointer_cast<vsag::HGraphParameter>(hgraph_param);
+
+    REQUIRE(typed_param != nullptr);
+    auto base_json = typed_param->base_codes_param->ToJson();
+    REQUIRE(base_json["quantization_params"][vsag::MRLE_DIM_KEY].GetInt() == 127);
+}
+
+TEST_CASE("HGraph mrle_dim validation rejects out-of-range values", "[ut][HGraphParameter]") {
+    vsag::IndexCommonParam common_param;
+    common_param.dim_ = 128;
+    common_param.data_type_ = vsag::DataTypes::DATA_TYPE_FLOAT;
+
+    SECTION("mrle_dim exceeds dim") {
+        auto param = vsag::JsonType::Parse(R"({
+            "base_quantization_type": "tq",
+            "tq_chain": "mrle, fp32",
+            "base_io_type": "block_memory_io",
+            "precise_quantization_type": "fp32",
+            "precise_io_type": "block_memory_io",
+            "graph_io_type": "block_memory_io",
+            "graph_storage_type": "flat",
+            "graph_type": "nsw",
+            "max_degree": 32,
+            "ef_construction": 100,
+            "use_reorder": false,
+            "mrle_dim": 200
+        })");
+        REQUIRE_THROWS(vsag::HGraph::CheckAndMappingExternalParam(param, common_param));
+    }
+
+    SECTION("mrle_dim is negative") {
+        auto param = vsag::JsonType::Parse(R"({
+            "base_quantization_type": "tq",
+            "tq_chain": "mrle, fp32",
+            "base_io_type": "block_memory_io",
+            "precise_quantization_type": "fp32",
+            "precise_io_type": "block_memory_io",
+            "graph_io_type": "block_memory_io",
+            "graph_storage_type": "flat",
+            "graph_type": "nsw",
+            "max_degree": 32,
+            "ef_construction": 100,
+            "use_reorder": false,
+            "mrle_dim": -1
+        })");
+        REQUIRE_THROWS(vsag::HGraph::CheckAndMappingExternalParam(param, common_param));
+    }
+
+    SECTION("mrle_dim default is 0 when omitted") {
+        auto param = vsag::JsonType::Parse(R"({
+            "base_quantization_type": "tq",
+            "tq_chain": "mrle, fp32",
+            "base_io_type": "block_memory_io",
+            "precise_quantization_type": "fp32",
+            "precise_io_type": "block_memory_io",
+            "graph_io_type": "block_memory_io",
+            "graph_storage_type": "flat",
+            "graph_type": "nsw",
+            "max_degree": 32,
+            "ef_construction": 100,
+            "use_reorder": false
+        })");
+        auto hgraph_param = vsag::HGraph::CheckAndMappingExternalParam(param, common_param);
+        auto typed_param = std::dynamic_pointer_cast<vsag::HGraphParameter>(hgraph_param);
+        REQUIRE(typed_param != nullptr);
+        auto base_json = typed_param->base_codes_param->ToJson();
+        REQUIRE(base_json.Contains("quantization_params"));
+        auto qp = base_json["quantization_params"];
+        REQUIRE(qp.Contains(vsag::MRLE_DIM_KEY));
+        REQUIRE(qp[vsag::MRLE_DIM_KEY].GetInt() == 0);
+    }
 }

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -151,6 +151,7 @@ const char* const RABITQ_BITS_PER_DIM_FILTER = "rabitq_bits_per_dim_filter";
 const char* const RABITQ_ERROR_RATE = "rabitq_error_rate";
 const char* const RABITQ_USE_FHT = "rabitq_use_fht";
 const char* const INDEX_TQ_CHAIN = "tq_chain";
+const char* const INDEX_MRLE_DIM = "mrle_dim";
 
 const char* const HGRAPH_SUPPORT_REMOVE = "support_remove";
 const char* const HGRAPH_SUPPORT_FORCE_REMOVE = "support_force_remove";


### PR DESCRIPTION
## Summary

Expose the internal `mrle_dim` parameter to the HGraph public API, allowing users to configure MRLE (Multi-Resolution Length Encoding) dimension truncation.

Fixes #2372

## Changes

- **`include/vsag/constants.h`**: Declare `INDEX_MRLE_DIM` external constant
- **`src/constants.cpp`**: Define `INDEX_MRLE_DIM = "mrle_dim"`
- **`src/algorithm/hgraph/hgraph_param_mapping.cpp`**:
  - Add mapping entry: `INDEX_MRLE_DIM` → `BASE_CODES_KEY/QUANTIZATION_PARAMS_KEY/MRLE_DIM_KEY`
  - Add default value `0` in JSON template
  - Add validation: `mrle_dim` must be in range [0, dim]
- **`src/algorithm/hgraph/hgraph_parameter_test.cpp`**: Add unit test verifying external param mapping

## Usage

```json
{
  "mrle_dim": 127
}
```

When `mrle_dim` is set to a non-zero value, the MRLE transformer truncates the vector dimension to that value.