### PR TITLE
fix(simq): remove AddMode parameter from SIMQ::Add

### DIFF
--- a/src/algorithm/simq/simq.cpp
+++ b/src/algorithm/simq/simq.cpp
@@ -445,7 +445,7 @@ SIMQ::build_rep_hgraph(const float* flat_vecs, int64_t dim) {
 // ─────────────────────────────────────────────────────────────────────────────
 
 std::vector<int64_t>
-SIMQ::Add(const DatasetPtr& data, AddMode /*mode*/) {
+SIMQ::Add(const DatasetPtr& data) {
     std::unique_lock lock(global_mutex_);
 
     if (rep_hgraph_ == nullptr) {

--- a/src/algorithm/simq/simq.h
+++ b/src/algorithm/simq/simq.h
@@ -46,7 +46,7 @@ public:
     Build(const DatasetPtr& data) override;
 
     std::vector<int64_t>
-    Add(const DatasetPtr& data, AddMode mode = AddMode::DEFAULT) override;
+    Add(const DatasetPtr& data) override;
 
     DatasetPtr
     KnnSearch(const DatasetPtr& query,


### PR DESCRIPTION
Fixes #2374

PR #2366 removed `AddMode` from `Index::Add` but missed updating SIMQ, causing compilation failure.

## Changes
- `src/algorithm/simq/simq.h`: `Add(const DatasetPtr& data, AddMode mode = AddMode::DEFAULT)` → `Add(const DatasetPtr& data)`
- `src/algorithm/simq/simq.cpp`: `SIMQ::Add(const DatasetPtr& data, AddMode /*mode*/)` → `SIMQ::Add(const DatasetPtr& data)`