### PR TITLE
docs: add HGraph-based disk index best practices guide

### DIFF
--- a/docs/docs/en/src/SUMMARY.md
+++ b/docs/docs/en/src/SUMMARY.md
@@ -61,6 +61,7 @@
 # Performance and Tuning
 
 - [Best Practices](resources/best_practices.md)
+- [Disk-Based Index Best Practices](resources/disk_index.md)
 - [Metric Semantics](resources/metric_semantics.md)
 - [Optimizer (Tune)](advanced/optimizer.md)
 - [Benchmarks](resources/performance.md)

--- a/docs/docs/en/src/figures/resources/disk-index-overview.svg
+++ b/docs/docs/en/src/figures/resources/disk-index-overview.svg
@@ -1,0 +1,221 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 470" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="12">
+  <title>Disk-backed HGraph overview</title>
+  <desc>A disk-backed HGraph splits its storage across two tiers. In memory it keeps the proximity graph adjacency and a very compact base quantization code (for example a 3-bit RaBitQ code); these are read on every hop. On disk it keeps a higher-precision precise copy (for example sq8). A query traverses the graph over the in-memory base codes to shortlist a small set of ef_search finalists, then the optional reorder pass reads the precise copy from disk for only those finalists and rescores them into the returned top-k. Graph traversal never touches the disk; disk I/O happens once at the end for a bounded number of candidates.</desc>
+
+  <defs>
+    <marker id="arrow-flow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#e8590c"/>
+    </marker>
+  </defs>
+
+  <style>
+    .title    { fill: #1a1a1a; font-size: 16px; font-weight: 600; }
+    .subtitle { fill: #6b7280; font-size: 12px; }
+    .lbl      { fill: #1f2937; }
+    .lbl-mute { fill: #6b7280; }
+    .zone-lbl { fill: #475569; font-size: 11px; font-weight: 600; letter-spacing: 0.6px; }
+    .zone-sub { fill: #94a3b8; font-size: 11px; }
+
+    .band-mem  { fill: #eef2ff; stroke: #c7d2fe; stroke-width: 1; }
+    .band-disk { fill: #f8fafc; stroke: #e2e8f0; stroke-width: 1; }
+
+    .chip     { fill: #ffffff; stroke: #cbd5e1; stroke-width: 1; }
+    .chip-lbl { fill: #334155; font-size: 11px; font-weight: 600; }
+
+    .node       { fill: #ffffff; stroke: #94a3b8; stroke-width: 1; }
+    .node-cand  { fill: #ffd8a8; stroke: #e8590c; stroke-width: 1.5; }
+    .node-result{ fill: #e03131; stroke: #a61e1e; stroke-width: 1.4; }
+
+    .slot      { fill: #ffffff; stroke: #cbd5e1; stroke-width: 1; }
+    .slot-read { fill: #ffd8a8; stroke: #e8590c; stroke-width: 1.4; }
+
+    .edge   { stroke: #cbd5e1; stroke-width: 0.9; fill: none; }
+    .flow   { stroke: #e8590c; stroke-width: 2; fill: none; stroke-linecap: round; }
+    .read   { stroke: #e8590c; stroke-width: 1.6; fill: none; stroke-dasharray: 4 3; }
+    .out    { stroke: #e8590c; stroke-width: 1.8; fill: none; stroke-linecap: round; }
+
+    .pill      { fill: #ffffff; stroke: #e03131; stroke-width: 1.3; }
+    .pill-lbl  { fill: #a61e1e; font-size: 11px; font-weight: 600; }
+
+    .step-badge { fill: #e8590c; stroke: #ffffff; stroke-width: 2; }
+    .step-num   { fill: #ffffff; font-size: 11px; font-weight: 700; }
+    .note-box   { fill: #ffffff; stroke: #e2e8f0; stroke-width: 1; }
+  </style>
+
+  <!-- Header -->
+  <text class="title"    x="40" y="34">Disk-backed HGraph</text>
+  <text class="subtitle" x="40" y="53">Traverse compact codes in memory · read the precise copy from disk only for the finalists</text>
+
+  <!-- =========================================================
+       MEMORY tier (top): graph adjacency + compact base codes
+       ========================================================= -->
+  <rect class="band-mem" x="40" y="72" width="520" height="210" rx="10"/>
+  <text class="zone-lbl" x="58"  y="98">MEMORY</text>
+  <text class="zone-sub" x="128" y="98">graph + base codes · read on every hop</text>
+
+  <rect class="chip" x="398" y="84" width="70" height="22" rx="6"/>
+  <text class="chip-lbl" x="433" y="99" text-anchor="middle">graph</text>
+  <rect class="chip" x="476" y="84" width="80" height="22" rx="6"/>
+  <text class="chip-lbl" x="516" y="99" text-anchor="middle">base · rabitq</text>
+
+  <!-- proximity-graph edges -->
+  <line class="edge" x1="74"  y1="132" x2="120" y2="152"/>
+  <line class="edge" x1="74"  y1="132" x2="102" y2="198"/>
+  <line class="edge" x1="120" y1="152" x2="168" y2="140"/>
+  <line class="edge" x1="120" y1="152" x2="152" y2="194"/>
+  <line class="edge" x1="102" y1="198" x2="152" y2="194"/>
+  <line class="edge" x1="168" y1="140" x2="152" y2="194"/>
+  <line class="edge" x1="168" y1="140" x2="216" y2="158"/>
+  <line class="edge" x1="152" y1="194" x2="208" y2="206"/>
+  <line class="edge" x1="216" y1="158" x2="208" y2="206"/>
+  <line class="edge" x1="216" y1="158" x2="274" y2="152"/>
+  <line class="edge" x1="274" y1="152" x2="286" y2="204"/>
+  <line class="edge" x1="208" y1="206" x2="286" y2="204"/>
+  <line class="edge" x1="152" y1="194" x2="184" y2="240"/>
+  <line class="edge" x1="208" y1="206" x2="242" y2="240"/>
+  <line class="edge" x1="286" y1="204" x2="300" y2="240"/>
+  <line class="edge" x1="216" y1="158" x2="242" y2="240"/>
+  <line class="edge" x1="184" y1="240" x2="242" y2="240"/>
+  <line class="edge" x1="242" y1="240" x2="300" y2="240"/>
+
+  <!-- greedy traversal over the in-memory base codes -->
+  <path class="flow" d="M 74 132 Q 118 150 152 178 Q 200 214 242 240"/>
+
+  <!-- plain graph nodes -->
+  <circle class="node" cx="74"  cy="132" r="5.5"/>
+  <circle class="node" cx="120" cy="152" r="4.5"/>
+  <circle class="node" cx="102" cy="198" r="4.5"/>
+  <circle class="node" cx="168" cy="140" r="4.5"/>
+  <circle class="node" cx="152" cy="194" r="4.5"/>
+  <circle class="node" cx="216" cy="158" r="4.5"/>
+  <circle class="node" cx="208" cy="206" r="4.5"/>
+  <circle class="node" cx="274" cy="152" r="4.5"/>
+  <circle class="node" cx="286" cy="204" r="4.5"/>
+  <text class="lbl-mute" x="74" y="120" text-anchor="middle" font-size="10">entry</text>
+
+  <!-- finalists (shortlist) -->
+  <circle class="node-cand" cx="184" cy="240" r="6"/>
+  <circle class="node-cand" cx="242" cy="240" r="6"/>
+  <circle class="node-cand" cx="300" cy="240" r="6"/>
+
+  <!-- query -->
+  <g transform="translate(252,212)">
+    <polygon points="0,-7 1.646,-2.265 6.657,-2.163 2.663,0.865 4.114,5.663 0,2.8 -4.114,5.663 -2.663,0.865 -6.657,-2.163 -1.646,-2.265"
+             fill="#e03131" stroke="#a61e1e" stroke-width="1.1" stroke-linejoin="round"/>
+  </g>
+  <text class="lbl" x="264" y="216" font-size="11" font-weight="700" fill="#a61e1e">q</text>
+
+  <!-- =========================================================
+       DISK tier (bottom): high-precision copy, read for finalists
+       ========================================================= -->
+  <rect class="band-disk" x="40" y="306" width="520" height="120" rx="10"/>
+  <text class="zone-lbl" x="58"  y="332">DISK</text>
+  <rect class="chip" x="104" y="318" width="96" height="22" rx="6"/>
+  <text class="chip-lbl" x="152" y="333" text-anchor="middle">precise · sq8</text>
+
+  <!-- top-k output pill -->
+  <rect class="pill" x="470" y="314" width="66" height="24" rx="12"/>
+  <text class="pill-lbl" x="503" y="330" text-anchor="middle">top-k</text>
+
+  <!-- precise records (filmstrip); three are read for the finalists -->
+  <rect class="slot"      x="64"  y="356" width="28" height="42" rx="3"/>
+  <rect class="slot"      x="100" y="356" width="28" height="42" rx="3"/>
+  <rect class="slot"      x="136" y="356" width="28" height="42" rx="3"/>
+  <rect class="slot"      x="172" y="356" width="28" height="42" rx="3"/>
+  <rect class="slot-read" x="208" y="356" width="28" height="42" rx="3"/>
+  <rect class="slot"      x="244" y="356" width="28" height="42" rx="3"/>
+  <rect class="slot"      x="280" y="356" width="28" height="42" rx="3"/>
+  <rect class="slot-read" x="316" y="356" width="28" height="42" rx="3"/>
+  <rect class="slot"      x="352" y="356" width="28" height="42" rx="3"/>
+  <rect class="slot"      x="388" y="356" width="28" height="42" rx="3"/>
+  <rect class="slot-read" x="424" y="356" width="28" height="42" rx="3"/>
+  <rect class="slot"      x="460" y="356" width="28" height="42" rx="3"/>
+
+  <!-- reorder reads the precise copy from disk for the finalists (random reads) -->
+  <path class="read" d="M 184 250 L 222 354" marker-end="url(#arrow-flow)"/>
+  <path class="read" d="M 242 250 L 330 354" marker-end="url(#arrow-flow)"/>
+  <path class="read" d="M 300 250 L 438 354" marker-end="url(#arrow-flow)"/>
+
+  <!-- rescored finalists -> top-k -->
+  <path class="out" d="M 452 362 L 498 340" marker-end="url(#arrow-flow)"/>
+
+  <text class="zone-sub" x="276" y="417" text-anchor="middle">precise copy · read only for the finalists · one bounded batch of reads per query</text>
+
+  <!-- step badges -->
+  <g>
+    <circle class="step-badge" cx="120" cy="116" r="11"/>
+    <text class="step-num" x="120" y="120" text-anchor="middle">1</text>
+    <circle class="step-badge" cx="344" cy="240" r="11"/>
+    <text class="step-num" x="344" y="244" text-anchor="middle">2</text>
+    <circle class="step-badge" cx="150" cy="296" r="11"/>
+    <text class="step-num" x="150" y="300" text-anchor="middle">3</text>
+    <circle class="step-badge" cx="452" cy="322" r="11"/>
+    <text class="step-num" x="452" y="326" text-anchor="middle">4</text>
+  </g>
+
+  <!-- =========================================================
+       Right-side legend and storage note
+       ========================================================= -->
+  <g transform="translate(600, 96)">
+    <g>
+      <circle class="step-badge" cx="10" cy="10" r="9"/>
+      <text x="10" y="14" text-anchor="middle" fill="#fff" font-size="10" font-weight="700">1</text>
+      <text class="lbl" x="28" y="8" font-weight="600">Traverse in memory</text>
+      <text class="lbl-mute" x="28" y="22" font-size="11">hop over graph + base codes</text>
+    </g>
+    <g transform="translate(0, 44)">
+      <circle class="step-badge" cx="10" cy="10" r="9"/>
+      <text x="10" y="14" text-anchor="middle" fill="#fff" font-size="10" font-weight="700">2</text>
+      <text class="lbl" x="28" y="8" font-weight="600">Shortlist finalists</text>
+      <text class="lbl-mute" x="28" y="22" font-size="11">keep the ef_search candidates</text>
+    </g>
+    <g transform="translate(0, 88)">
+      <circle class="step-badge" cx="10" cy="10" r="9"/>
+      <text x="10" y="14" text-anchor="middle" fill="#fff" font-size="10" font-weight="700">3</text>
+      <text class="lbl" x="28" y="8" font-weight="600">Read precise from disk</text>
+      <text class="lbl-mute" x="28" y="22" font-size="11">reorder fetches the precise copy</text>
+    </g>
+    <g transform="translate(0, 132)">
+      <circle class="step-badge" cx="10" cy="10" r="9"/>
+      <text x="10" y="14" text-anchor="middle" fill="#fff" font-size="10" font-weight="700">4</text>
+      <text class="lbl" x="28" y="8" font-weight="600">Return top-k</text>
+      <text class="lbl-mute" x="28" y="22" font-size="11">rescored nearest neighbours</text>
+    </g>
+
+    <g transform="translate(0, 178)">
+      <rect class="note-box" x="0" y="0" width="168" height="96" rx="6"/>
+      <text class="zone-lbl" x="12" y="20" font-size="10">STORAGE</text>
+      <text class="lbl-mute" x="12" y="38" font-size="11">in memory · base</text>
+      <text class="lbl"      x="12" y="52" font-size="11">rabitq · compact codes</text>
+      <line x1="12" y1="60" x2="156" y2="60" stroke="#e2e8f0"/>
+      <text class="lbl-mute" x="12" y="76" font-size="11">on disk · precise</text>
+      <text class="lbl"      x="12" y="90" font-size="11">sq8 · async_io · use_reorder</text>
+    </g>
+  </g>
+
+  <!-- =========================================================
+       Bottom legend
+       ========================================================= -->
+  <g transform="translate(40, 452)">
+    <circle class="node" cx="6" cy="0" r="5"/>
+    <text class="lbl-mute" x="16" y="4">graph node · base code</text>
+
+    <circle class="node-cand" cx="176" cy="0" r="5"/>
+    <text class="lbl-mute" x="186" y="4">finalist</text>
+
+    <g transform="translate(250, 0)">
+      <polygon points="0,-6 1.4,-1.9 5.7,-1.85 2.3,0.74 3.5,4.85 0,2.4 -3.5,4.85 -2.3,0.74 -5.7,-1.85 -1.4,-1.9"
+               fill="#e03131" stroke="#a61e1e" stroke-width="1" stroke-linejoin="round"/>
+    </g>
+    <text class="lbl-mute" x="262" y="4">query q</text>
+
+    <rect class="slot-read" x="330" y="-7" width="14" height="14" rx="2"/>
+    <text class="lbl-mute" x="352" y="4">precise record</text>
+
+    <line class="read" x1="462" y1="0" x2="492" y2="0" marker-end="url(#arrow-flow)"/>
+    <text class="lbl-mute" x="500" y="4">disk read</text>
+
+    <rect class="pill" x="576" y="-9" width="44" height="18" rx="9"/>
+    <text class="pill-lbl" x="598" y="4" text-anchor="middle">top-k</text>
+  </g>
+</svg>

--- a/docs/docs/en/src/resources/disk_index.md
+++ b/docs/docs/en/src/resources/disk_index.md
@@ -1,0 +1,175 @@
+# Disk-Based Index Best Practices
+
+![Disk-backed HGraph: the graph and compact base codes stay in memory for traversal, while a higher-precision precise copy on disk is read only for the ef_search finalists during reorder](../figures/resources/disk-index-overview.svg)
+
+When a corpus grows past the point where every vector fits in RAM, moving the coldest,
+largest part of the index onto an SSD is the most direct way to control cost. VSAG does
+this by letting each part of an index choose its own storage backend, so hot data stays
+in memory while cold data is served from disk. This page covers
+**[HGraph](../indexes/hgraph.md) with disk-backed IO** and shows copy-pasteable
+configurations, a capacity model, and a tuning checklist.
+
+> "Disk index" here means **tiering the index data across memory and disk**. It is
+> unrelated to filtering by scalar attributes alongside the vector — for that, see
+> [Attribute Filter (Hybrid Search)](../advanced/attribute_filter.md).
+
+## When to move to disk
+
+A large corpus does not automatically require disk. Weigh these signals first:
+
+| Signal | In-memory is fine | Consider disk |
+|--------|-------------------|---------------|
+| Corpus size | ≤ tens of millions | Hundreds of millions / billions |
+| Full `fp32` fits in RAM | Yes | No |
+| Latency budget | Sub-millisecond, strict | A few to low-tens of milliseconds is acceptable |
+| Cost structure | RAM cost is acceptable | Want to replace most RAM with SSD |
+
+A quick memory estimate: a full `fp32` copy occupies about `N × dim × 4` bytes. For
+example `1e9 × 128 × 4 ≈ 512 GB` and `1e8 × 768 × 4 ≈ 307 GB` — sizes that rarely fit in a
+single machine's RAM, which is exactly the disk-index target.
+
+The cost of going to disk is a few random-read I/Os per query, so **latency is higher than
+a pure in-memory index**. If your service needs sub-millisecond latency and the data can be
+compressed to fit in RAM, prefer in-memory [HGraph](../indexes/hgraph.md) with quantization
+instead.
+
+## The core idea
+
+VSAG's disk-backed indexing follows one principle: **keep a small, approximate representation
+in memory to navigate, and keep the large, precise representation on disk to rank.** Graph
+traversal touches only the in-memory approximate codes; a small number of finalists are then
+re-scored ("reordered") against the precise copy read from disk.
+Because the disk reads happen only at the end, for only a handful of candidates, the I/O
+cost stays bounded while recall is recovered by the precise rescore.
+
+## How HGraph tiers storage
+
+HGraph stores an index as several independent **cells**, and each cell can be pointed at its
+own **IO backend**. That is what enables "hot in memory, cold on disk":
+
+| Cell | Holds | Access pattern | Recommended placement |
+|------|-------|----------------|-----------------------|
+| `graph` | Adjacency lists of the proximity graph | Read on every hop | Memory (or `mmap_io` under pressure) |
+| `base` | Quantized codes used to traverse and prune | Read on every hop | Memory |
+| `precise` | High-precision copy used to reorder (`use_reorder`) | Read for a few finalists | **Disk** |
+| `raw_vector` | Optional raw vectors (`store_raw_vector`) | Rarely, e.g. `cosine`/exact | Memory or disk |
+
+The IO backends you can assign to a cell:
+
+| Backend (`*_io_type`) | Location | Needs `*_file_path` | Notes |
+|-----------------------|----------|---------------------|-------|
+| `memory_io` | Memory (contiguous) | No | Basic in-memory storage |
+| `block_memory_io` | Memory (block-allocated) | No | Default backend for large cells |
+| `buffer_io` | Disk (buffered `pread`) | Yes | Portable disk reads; works everywhere |
+| `mmap_io` | Disk (mmap + page cache) | Yes | Near-memory speed when the working set fits the page cache |
+| `async_io` | Disk (Linux libaio) | Yes | High-concurrency disk reads; **Linux + libaio only**, otherwise falls back to `buffer_io` |
+| `reader_io` | Custom `Reader` | No | Read through a user `ReaderSet` at load time (e.g. remote / object storage) |
+
+Each cell is wired with a flat pair of build parameters: `graph_io_type` / `graph_file_path`,
+`base_io_type` / `base_file_path`, `precise_io_type` / `precise_file_path`, and
+`raw_vector_io_type` / `raw_vector_file_path`. A `*_file_path` is **required** whenever the
+matching `*_io_type` is disk-backed (`buffer_io`, `mmap_io`, or `async_io`); the in-memory
+backends ignore it. All cells default to `block_memory_io` (fully in memory).
+
+## Recommended configuration: base in memory, precise on disk
+
+The workhorse layout keeps a very compact 3-bit RaBitQ base in memory for traversal and pushes
+a higher-precision `sq8` copy to disk for reorder, with `use_reorder` turned on so the
+finalists are re-ranked against it:
+
+```json
+{
+    "dtype": "float32",
+    "metric_type": "l2",
+    "dim": 128,
+    "index_param": {
+        "base_quantization_type": "rabitq",
+        "rabitq_bits_per_dim_base": 3,
+        "max_degree": 32,
+        "ef_construction": 400,
+        "use_reorder": true,
+        "precise_quantization_type": "sq8",
+        "precise_io_type": "async_io",
+        "precise_file_path": "/data/vsag/hgraph_precise.data"
+    }
+}
+```
+
+Here `rabitq_bits_per_dim_base` selects the standard multi-bit RaBitQ base code (range `[1, 8]`);
+leave `rabitq_bits_per_dim_precise` unset so the base stays a plain RaBitQ code rather than
+switching to the x+y split variant.
+
+Search is unchanged — set `ef_search` as usual and reorder transparently reads the precise
+copy from disk:
+
+```json
+{"hgraph": {"ef_search": 200}}
+```
+
+The per-query data flow: graph traversal reads only the in-memory `base` codes and `graph`
+adjacency; disk I/O happens solely at the end, when reorder fetches the precise copy for
+the small candidate set before returning the top-k. This is why a disk-backed HGraph adds
+only a bounded number of reads per query rather than one read per hop.
+
+## Hardware and deployment
+
+- **Use NVMe SSDs.** Disk-backed vector search is dominated by random-read latency; NVMe is
+  an order of magnitude better than SATA SSDs and essential for `async_io` / `mmap_io`.
+- **`async_io` requires Linux with libaio, which is enabled by default.** The CMake option
+  `ENABLE_LIBAIO` defaults to `ON`, and the Makefile passes `VSAG_ENABLE_LIBAIO=ON`; you only
+  set these flags to turn libaio back on if a previous build disabled it. When libaio is absent
+  (including on macOS), `async_io` logs a one-time warning and falls back to `buffer_io`, so
+  configs remain portable but lose asynchronous batching. For production throughput, build on
+  Linux with libaio.
+- **Warm the page cache** for `mmap_io` cells after load (e.g. a sequential read of the file,
+  or a warm-up query pass) so early queries do not pay cold-miss latency.
+- **Plan file paths and lifecycle.** Disk-backed cells write to the `*_file_path` you supply;
+  place them on a fast, dedicated volume with enough space for the precise copy, and clean up
+  stale files when rebuilding. Serialize and load the index through the normal
+  [Serialization](../advanced/serialization.md) API — the backing files are managed with it.
+
+## Capacity planning
+
+Approximate per-vector storage for the main quantizers (plus small per-vector metadata such
+as norms and errors):
+
+| Representation | Bytes per vector | Typical placement |
+|----------------|------------------|-------------------|
+| `fp32` (precise) | `dim × 4` | Disk |
+| `fp16` / `bf16` | `dim × 2` | Memory or disk |
+| `sq8` | `dim × 1` | Memory or disk |
+| `sq4` | `dim × 0.5` | Memory |
+| `rabitq` (b-bit) | `dim × b / 8` | Memory |
+
+Worked example for `N = 1e9`, `dim = 128`:
+
+- 3-bit `rabitq` base in memory: `1e9 × 128 × 3 / 8 ≈ 48 GB` RAM.
+- `sq8` precise on disk: `1e9 × 128 × 1 ≈ 128 GB` SSD.
+- A full `fp32` precise instead (maximum reorder accuracy): `1e9 × 128 × 4 ≈ 512 GB` SSD.
+- Add the graph: roughly `N × max_degree × 4` bytes for neighbor ids (memory or `mmap_io`).
+
+This is how a billion-scale index that would need ~0.5 TB of RAM as pure `fp32` collapses to
+tens of GB of RAM plus an SSD.
+
+## Tuning and troubleshooting
+
+| Symptom | Likely cause | Action |
+|---------|--------------|--------|
+| Recall too low | Base quantization too coarse, or reorder off | Keep `use_reorder: true`; raise `precise_quantization_type` toward `fp32`; increase `ef_search` |
+| Latency too high | Too many disk reads per query | Lower `ef_search`; keep `graph`/`base` in memory; ensure precise-only is on disk; use NVMe + `async_io` |
+| Memory still too high | Base or graph too large | Move base to `sq4` / `pq` / `rabitq`; push `graph` to `mmap_io` |
+| `async_io` seems synchronous | libaio not compiled in | Rebuild with `VSAG_ENABLE_LIBAIO=ON` on Linux; check for the fallback warning |
+| Cold-start latency spikes (mmap) | Page cache not warm | Warm the file after load before serving traffic |
+
+Treat these as starting points and validate with [`eval_performance`](eval.md) against a
+realistic query distribution; the [Optimizer (Tune)](../advanced/optimizer.md) can then
+settle search-time parameters automatically.
+
+## See also
+
+- [HGraph](../indexes/hgraph.md) — the flagship index and its full parameter table
+- [Quantization Overview](../quantization/README.md) — choosing a base/precise quantizer
+- [Best Practices](best_practices.md) — general production guidance
+- [Serialization](../advanced/serialization.md) — persisting and loading indexes
+- [Evaluation Tool](eval.md) and [Optimizer (Tune)](../advanced/optimizer.md) — measuring and
+  tuning

--- a/docs/docs/zh/src/SUMMARY.md
+++ b/docs/docs/zh/src/SUMMARY.md
@@ -61,6 +61,7 @@
 # 性能与调优
 
 - [最佳实践](resources/best_practices.md)
+- [磁盘索引最佳实践](resources/disk_index.md)
 - [度量语义](resources/metric_semantics.md)
 - [优化器](advanced/optimizer.md)
 - [标准环境性能参考](resources/performance.md)

--- a/docs/docs/zh/src/figures/resources/disk-index-overview.svg
+++ b/docs/docs/zh/src/figures/resources/disk-index-overview.svg
@@ -1,0 +1,221 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 470" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="12">
+  <title>磁盘版 HGraph 概览</title>
+  <desc>磁盘版 HGraph 把存储分为两层。内存中保存邻近图的邻接关系和非常紧凑的 base 量化编码（例如 3 位 RaBitQ 编码），每一跳都会读取它们。磁盘上保存精度更高的 precise 副本（例如 sq8）。查询在内存的 base 编码上遍历图，筛出少量 ef_search 入围候选；随后可选的重排（reorder）仅为这些入围候选从磁盘读取 precise 副本，并把它们重排序为返回的 top-k。图遍历从不访问磁盘；磁盘 I/O 只在最后为有限个候选发生一次。</desc>
+
+  <defs>
+    <marker id="arrow-flow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#e8590c"/>
+    </marker>
+  </defs>
+
+  <style>
+    .title    { fill: #1a1a1a; font-size: 16px; font-weight: 600; }
+    .subtitle { fill: #6b7280; font-size: 12px; }
+    .lbl      { fill: #1f2937; }
+    .lbl-mute { fill: #6b7280; }
+    .zone-lbl { fill: #475569; font-size: 11px; font-weight: 600; letter-spacing: 0.6px; }
+    .zone-sub { fill: #94a3b8; font-size: 11px; }
+
+    .band-mem  { fill: #eef2ff; stroke: #c7d2fe; stroke-width: 1; }
+    .band-disk { fill: #f8fafc; stroke: #e2e8f0; stroke-width: 1; }
+
+    .chip     { fill: #ffffff; stroke: #cbd5e1; stroke-width: 1; }
+    .chip-lbl { fill: #334155; font-size: 11px; font-weight: 600; }
+
+    .node       { fill: #ffffff; stroke: #94a3b8; stroke-width: 1; }
+    .node-cand  { fill: #ffd8a8; stroke: #e8590c; stroke-width: 1.5; }
+    .node-result{ fill: #e03131; stroke: #a61e1e; stroke-width: 1.4; }
+
+    .slot      { fill: #ffffff; stroke: #cbd5e1; stroke-width: 1; }
+    .slot-read { fill: #ffd8a8; stroke: #e8590c; stroke-width: 1.4; }
+
+    .edge   { stroke: #cbd5e1; stroke-width: 0.9; fill: none; }
+    .flow   { stroke: #e8590c; stroke-width: 2; fill: none; stroke-linecap: round; }
+    .read   { stroke: #e8590c; stroke-width: 1.6; fill: none; stroke-dasharray: 4 3; }
+    .out    { stroke: #e8590c; stroke-width: 1.8; fill: none; stroke-linecap: round; }
+
+    .pill      { fill: #ffffff; stroke: #e03131; stroke-width: 1.3; }
+    .pill-lbl  { fill: #a61e1e; font-size: 11px; font-weight: 600; }
+
+    .step-badge { fill: #e8590c; stroke: #ffffff; stroke-width: 2; }
+    .step-num   { fill: #ffffff; font-size: 11px; font-weight: 700; }
+    .note-box   { fill: #ffffff; stroke: #e2e8f0; stroke-width: 1; }
+  </style>
+
+  <!-- 页眉 -->
+  <text class="title"    x="40" y="34">磁盘版 HGraph</text>
+  <text class="subtitle" x="40" y="53">内存中遍历紧凑编码 · 仅为入围候选从磁盘读取精确副本</text>
+
+  <!-- =========================================================
+       内存层（上）：graph 邻接 + 紧凑 base 编码
+       ========================================================= -->
+  <rect class="band-mem" x="40" y="72" width="520" height="210" rx="10"/>
+  <text class="zone-lbl" x="58"  y="98">内存</text>
+  <text class="zone-sub" x="104" y="98">graph + base 编码 · 每跳都读</text>
+
+  <rect class="chip" x="398" y="84" width="70" height="22" rx="6"/>
+  <text class="chip-lbl" x="433" y="99" text-anchor="middle">graph</text>
+  <rect class="chip" x="476" y="84" width="80" height="22" rx="6"/>
+  <text class="chip-lbl" x="516" y="99" text-anchor="middle">base · rabitq</text>
+
+  <!-- 邻近图的边 -->
+  <line class="edge" x1="74"  y1="132" x2="120" y2="152"/>
+  <line class="edge" x1="74"  y1="132" x2="102" y2="198"/>
+  <line class="edge" x1="120" y1="152" x2="168" y2="140"/>
+  <line class="edge" x1="120" y1="152" x2="152" y2="194"/>
+  <line class="edge" x1="102" y1="198" x2="152" y2="194"/>
+  <line class="edge" x1="168" y1="140" x2="152" y2="194"/>
+  <line class="edge" x1="168" y1="140" x2="216" y2="158"/>
+  <line class="edge" x1="152" y1="194" x2="208" y2="206"/>
+  <line class="edge" x1="216" y1="158" x2="208" y2="206"/>
+  <line class="edge" x1="216" y1="158" x2="274" y2="152"/>
+  <line class="edge" x1="274" y1="152" x2="286" y2="204"/>
+  <line class="edge" x1="208" y1="206" x2="286" y2="204"/>
+  <line class="edge" x1="152" y1="194" x2="184" y2="240"/>
+  <line class="edge" x1="208" y1="206" x2="242" y2="240"/>
+  <line class="edge" x1="286" y1="204" x2="300" y2="240"/>
+  <line class="edge" x1="216" y1="158" x2="242" y2="240"/>
+  <line class="edge" x1="184" y1="240" x2="242" y2="240"/>
+  <line class="edge" x1="242" y1="240" x2="300" y2="240"/>
+
+  <!-- 在内存 base 编码上做贪心遍历 -->
+  <path class="flow" d="M 74 132 Q 118 150 152 178 Q 200 214 242 240"/>
+
+  <!-- 普通图节点 -->
+  <circle class="node" cx="74"  cy="132" r="5.5"/>
+  <circle class="node" cx="120" cy="152" r="4.5"/>
+  <circle class="node" cx="102" cy="198" r="4.5"/>
+  <circle class="node" cx="168" cy="140" r="4.5"/>
+  <circle class="node" cx="152" cy="194" r="4.5"/>
+  <circle class="node" cx="216" cy="158" r="4.5"/>
+  <circle class="node" cx="208" cy="206" r="4.5"/>
+  <circle class="node" cx="274" cy="152" r="4.5"/>
+  <circle class="node" cx="286" cy="204" r="4.5"/>
+  <text class="lbl-mute" x="74" y="120" text-anchor="middle" font-size="10">入口</text>
+
+  <!-- 入围候选 -->
+  <circle class="node-cand" cx="184" cy="240" r="6"/>
+  <circle class="node-cand" cx="242" cy="240" r="6"/>
+  <circle class="node-cand" cx="300" cy="240" r="6"/>
+
+  <!-- 查询 -->
+  <g transform="translate(252,212)">
+    <polygon points="0,-7 1.646,-2.265 6.657,-2.163 2.663,0.865 4.114,5.663 0,2.8 -4.114,5.663 -2.663,0.865 -6.657,-2.163 -1.646,-2.265"
+             fill="#e03131" stroke="#a61e1e" stroke-width="1.1" stroke-linejoin="round"/>
+  </g>
+  <text class="lbl" x="264" y="216" font-size="11" font-weight="700" fill="#a61e1e">q</text>
+
+  <!-- =========================================================
+       磁盘层（下）：高精度 precise 副本，仅为入围候选读取
+       ========================================================= -->
+  <rect class="band-disk" x="40" y="306" width="520" height="120" rx="10"/>
+  <text class="zone-lbl" x="58"  y="332">磁盘</text>
+  <rect class="chip" x="104" y="318" width="96" height="22" rx="6"/>
+  <text class="chip-lbl" x="152" y="333" text-anchor="middle">precise · sq8</text>
+
+  <!-- top-k 输出 -->
+  <rect class="pill" x="470" y="314" width="66" height="24" rx="12"/>
+  <text class="pill-lbl" x="503" y="330" text-anchor="middle">top-k</text>
+
+  <!-- precise 记录（连续存储）；其中三条为入围候选读取 -->
+  <rect class="slot"      x="64"  y="356" width="28" height="42" rx="3"/>
+  <rect class="slot"      x="100" y="356" width="28" height="42" rx="3"/>
+  <rect class="slot"      x="136" y="356" width="28" height="42" rx="3"/>
+  <rect class="slot"      x="172" y="356" width="28" height="42" rx="3"/>
+  <rect class="slot-read" x="208" y="356" width="28" height="42" rx="3"/>
+  <rect class="slot"      x="244" y="356" width="28" height="42" rx="3"/>
+  <rect class="slot"      x="280" y="356" width="28" height="42" rx="3"/>
+  <rect class="slot-read" x="316" y="356" width="28" height="42" rx="3"/>
+  <rect class="slot"      x="352" y="356" width="28" height="42" rx="3"/>
+  <rect class="slot"      x="388" y="356" width="28" height="42" rx="3"/>
+  <rect class="slot-read" x="424" y="356" width="28" height="42" rx="3"/>
+  <rect class="slot"      x="460" y="356" width="28" height="42" rx="3"/>
+
+  <!-- 重排为入围候选从磁盘读取 precise 副本（随机读） -->
+  <path class="read" d="M 184 250 L 222 354" marker-end="url(#arrow-flow)"/>
+  <path class="read" d="M 242 250 L 330 354" marker-end="url(#arrow-flow)"/>
+  <path class="read" d="M 300 250 L 438 354" marker-end="url(#arrow-flow)"/>
+
+  <!-- 重排序后的入围候选 -> top-k -->
+  <path class="out" d="M 452 362 L 498 340" marker-end="url(#arrow-flow)"/>
+
+  <text class="zone-sub" x="276" y="417" text-anchor="middle">精确副本 · 仅为入围候选读取 · 每次查询一批有限次读取</text>
+
+  <!-- 步骤徽标 -->
+  <g>
+    <circle class="step-badge" cx="120" cy="116" r="11"/>
+    <text class="step-num" x="120" y="120" text-anchor="middle">1</text>
+    <circle class="step-badge" cx="344" cy="240" r="11"/>
+    <text class="step-num" x="344" y="244" text-anchor="middle">2</text>
+    <circle class="step-badge" cx="150" cy="296" r="11"/>
+    <text class="step-num" x="150" y="300" text-anchor="middle">3</text>
+    <circle class="step-badge" cx="452" cy="322" r="11"/>
+    <text class="step-num" x="452" y="326" text-anchor="middle">4</text>
+  </g>
+
+  <!-- =========================================================
+       右侧图例与存储说明
+       ========================================================= -->
+  <g transform="translate(600, 96)">
+    <g>
+      <circle class="step-badge" cx="10" cy="10" r="9"/>
+      <text x="10" y="14" text-anchor="middle" fill="#fff" font-size="10" font-weight="700">1</text>
+      <text class="lbl" x="28" y="8" font-weight="600">内存中遍历</text>
+      <text class="lbl-mute" x="28" y="22" font-size="11">在 graph + base 编码上逐跳</text>
+    </g>
+    <g transform="translate(0, 44)">
+      <circle class="step-badge" cx="10" cy="10" r="9"/>
+      <text x="10" y="14" text-anchor="middle" fill="#fff" font-size="10" font-weight="700">2</text>
+      <text class="lbl" x="28" y="8" font-weight="600">筛出入围候选</text>
+      <text class="lbl-mute" x="28" y="22" font-size="11">保留 ef_search 个候选</text>
+    </g>
+    <g transform="translate(0, 88)">
+      <circle class="step-badge" cx="10" cy="10" r="9"/>
+      <text x="10" y="14" text-anchor="middle" fill="#fff" font-size="10" font-weight="700">3</text>
+      <text class="lbl" x="28" y="8" font-weight="600">从磁盘读 precise</text>
+      <text class="lbl-mute" x="28" y="22" font-size="11">重排读取精确副本</text>
+    </g>
+    <g transform="translate(0, 132)">
+      <circle class="step-badge" cx="10" cy="10" r="9"/>
+      <text x="10" y="14" text-anchor="middle" fill="#fff" font-size="10" font-weight="700">4</text>
+      <text class="lbl" x="28" y="8" font-weight="600">返回 top-k</text>
+      <text class="lbl-mute" x="28" y="22" font-size="11">重排序后的最近邻</text>
+    </g>
+
+    <g transform="translate(0, 178)">
+      <rect class="note-box" x="0" y="0" width="168" height="96" rx="6"/>
+      <text class="zone-lbl" x="12" y="20" font-size="10">存储</text>
+      <text class="lbl-mute" x="12" y="38" font-size="11">内存 · base</text>
+      <text class="lbl"      x="12" y="52" font-size="11">rabitq · 紧凑编码</text>
+      <line x1="12" y1="60" x2="156" y2="60" stroke="#e2e8f0"/>
+      <text class="lbl-mute" x="12" y="76" font-size="11">磁盘 · precise</text>
+      <text class="lbl"      x="12" y="90" font-size="11">sq8 · async_io · use_reorder</text>
+    </g>
+  </g>
+
+  <!-- =========================================================
+       底部图例
+       ========================================================= -->
+  <g transform="translate(40, 452)">
+    <circle class="node" cx="6" cy="0" r="5"/>
+    <text class="lbl-mute" x="16" y="4">图节点 · base 编码</text>
+
+    <circle class="node-cand" cx="164" cy="0" r="5"/>
+    <text class="lbl-mute" x="174" y="4">入围候选</text>
+
+    <g transform="translate(248, 0)">
+      <polygon points="0,-6 1.4,-1.9 5.7,-1.85 2.3,0.74 3.5,4.85 0,2.4 -3.5,4.85 -2.3,0.74 -5.7,-1.85 -1.4,-1.9"
+               fill="#e03131" stroke="#a61e1e" stroke-width="1" stroke-linejoin="round"/>
+    </g>
+    <text class="lbl-mute" x="260" y="4">查询 q</text>
+
+    <rect class="slot-read" x="330" y="-7" width="14" height="14" rx="2"/>
+    <text class="lbl-mute" x="352" y="4">precise 记录</text>
+
+    <line class="read" x1="452" y1="0" x2="482" y2="0" marker-end="url(#arrow-flow)"/>
+    <text class="lbl-mute" x="490" y="4">磁盘读取</text>
+
+    <rect class="pill" x="566" y="-9" width="44" height="18" rx="9"/>
+    <text class="pill-lbl" x="588" y="4" text-anchor="middle">top-k</text>
+  </g>
+</svg>

--- a/docs/docs/zh/src/resources/disk_index.md
+++ b/docs/docs/zh/src/resources/disk_index.md
@@ -1,0 +1,155 @@
+# 磁盘索引最佳实践
+
+![磁盘版 HGraph：图结构与紧凑 base 编码留在内存中用于遍历，更高精度的 precise 副本存于磁盘，仅在重排阶段为 ef_search 入围候选读取](../figures/resources/disk-index-overview.svg)
+
+当数据规模增长到内存放不下全量向量时，把最冷、最大的那部分索引下沉到 SSD，是控制成本最直接的
+手段。VSAG 让索引的每个部分各自选择存储后端，从而实现热数据留内存、冷数据从磁盘读取。本文介绍
+**[HGraph](../indexes/hgraph.md) + 磁盘 IO**，给出可直接复制的配置、容量模型与调优
+清单。
+
+> 这里的“磁盘索引”指**把索引数据分层存放在内存与磁盘之间**，与“向量 + 标量属性”的混合检索无关；
+> 后者请参见[属性过滤（混合搜索）](../advanced/attribute_filter.md)。
+
+## 什么时候该上磁盘
+
+数据规模大并不必然要上磁盘。先用下面几个信号判断：
+
+| 信号 | 纯内存即可 | 考虑磁盘 |
+|------|-----------|---------|
+| 数据规模 | 千万级及以内 | 亿级 / 十亿级 |
+| 全量 `fp32` 是否放得下内存 | 放得下 | 放不下 |
+| 延迟预算 | 亚毫秒、极敏感 | 几毫秒～十几毫秒可接受 |
+| 成本结构 | 内存成本可接受 | 希望用 SSD 替换大部分内存 |
+
+一个快速的内存估算：全量 `fp32` 副本约占用 `N × dim × 4` 字节。例如 `1e9 × 128 × 4 ≈ 512 GB`、
+`1e8 × 768 × 4 ≈ 307 GB`——这类规模在单机内存里几乎放不下，正是磁盘索引的目标场景。
+
+磁盘路线的代价是每次查询会引入若干次随机读 I/O，因此**延迟会高于纯内存索引**。如果你的服务要求
+亚毫秒级延迟且数据能压缩进内存，优先考虑纯内存的 [HGraph](../indexes/hgraph.md) + 量化。
+
+## 核心思想
+
+VSAG 的磁盘路线遵循同一原则：**内存放小而近似的表示用于导航，磁盘放大而精确的表示用于
+排序。** 图遍历只访问内存中的近似量化码；随后仅对少量入围候选，用从磁盘读回的
+精确副本做重排（reorder）。由于磁盘读取只发生在最后、且只针对少量候选，I/O 成本被限制在很小
+范围，而召回则由精确重排补回。
+
+## HGraph 如何分层存储
+
+HGraph 把一个索引拆成若干个相互独立的 **cell（数据单元）**，每个 cell 都能单独指向自己的
+**IO 后端**。这正是“热数据在内存、冷数据在磁盘”的实现基础：
+
+| Cell | 存放内容 | 访问模式 | 建议放置 |
+|------|---------|---------|---------|
+| `graph` | 邻近图的邻接表 | 每一跳都读 | 内存（内存紧张时可用 `mmap_io`） |
+| `base` | 用于遍历和剪枝的量化码 | 每一跳都读 | 内存 |
+| `precise` | 用于重排的高精度副本（`use_reorder`） | 只为少量入围候选读取 | **磁盘** |
+| `raw_vector` | 可选的原始向量（`store_raw_vector`） | 很少访问，如 `cosine` / 精确计算 | 内存或磁盘 |
+
+可分配给 cell 的 IO 后端：
+
+| 后端（`*_io_type`） | 位置 | 是否需要 `*_file_path` | 说明 |
+|---------------------|------|------------------------|------|
+| `memory_io` | 内存（连续） | 否 | 基础内存存储 |
+| `block_memory_io` | 内存（分块分配） | 否 | 大 cell 的默认后端 |
+| `buffer_io` | 磁盘（带缓冲 `pread`） | 是 | 通用磁盘读取，各平台可用 |
+| `mmap_io` | 磁盘（mmap + 页缓存） | 是 | 工作集能放入页缓存时接近内存速度 |
+| `async_io` | 磁盘（Linux libaio） | 是 | 高并发磁盘读；**仅限 Linux + libaio**，否则回退 `buffer_io` |
+| `reader_io` | 自定义 `Reader` | 否 | 加载期通过用户 `ReaderSet` 读取（如远程 / 对象存储） |
+
+每个 cell 通过一组扁平参数配置：`graph_io_type` / `graph_file_path`、`base_io_type` /
+`base_file_path`、`precise_io_type` / `precise_file_path`，以及 `raw_vector_io_type` /
+`raw_vector_file_path`。当对应的 `*_io_type` 为磁盘型（`buffer_io`、`mmap_io`、`async_io`）时，
+`*_file_path` **必填**；内存型后端会忽略它。所有 cell 默认均为 `block_memory_io`（全内存）。
+
+## 推荐配置：base 留内存，precise 落磁盘
+
+最常用的分层方案：内存里保留极为紧凑的 3 位 RaBitQ base 用于遍历，把精度更高的 `sq8` 副本下沉磁盘，
+并开启 `use_reorder`，让入围候选用它重排：
+
+```json
+{
+    "dtype": "float32",
+    "metric_type": "l2",
+    "dim": 128,
+    "index_param": {
+        "base_quantization_type": "rabitq",
+        "rabitq_bits_per_dim_base": 3,
+        "max_degree": 32,
+        "ef_construction": 400,
+        "use_reorder": true,
+        "precise_quantization_type": "sq8",
+        "precise_io_type": "async_io",
+        "precise_file_path": "/data/vsag/hgraph_precise.data"
+    }
+}
+```
+
+其中 `rabitq_bits_per_dim_base` 选择标准多 bit RaBitQ 的 base 编码位数（范围 `[1, 8]`）；不要设置
+`rabitq_bits_per_dim_precise`，以保持 base 为普通 RaBitQ 编码，而非切换到 x+y split 变体。
+
+搜索方式不变——照常设置 `ef_search`，重排会透明地从磁盘读取精确副本：
+
+```json
+{"hgraph": {"ef_search": 200}}
+```
+
+单次查询的数据流：图遍历只读内存中的 `base` 量化码与 `graph` 邻接表；磁盘 I/O 仅发生在最后，
+由重排为少量候选读取精确副本，然后返回 top-k。这正是磁盘 HGraph 每次查询只增加有限次读取、
+而非每跳一次读取的原因。
+
+## 硬件与部署
+
+- **使用 NVMe SSD。** 磁盘向量检索的瓶颈在随机读延迟；NVMe 比 SATA SSD 低一个数量级，对
+  `async_io` / `mmap_io` 是必需的。
+- **`async_io` 需要 Linux + libaio，且默认开启。** CMake 选项 `ENABLE_LIBAIO` 默认为 `ON`，
+  Makefile 也会自动传入 `VSAG_ENABLE_LIBAIO=ON`；只有当此前的构建关闭过 libaio 时，才需要用这些
+  开关把它重新打开。当 libaio 缺失时（包括 macOS），`async_io` 会打印一次性告警并回退
+  `buffer_io`，配置因此保持可移植但失去异步批量能力。生产吞吐场景请在 Linux 上编译进 libaio。
+- **预热页缓存。** 对 `mmap_io` 的 cell，加载后先做一次预热（如顺序读一遍文件、或跑一轮预热
+  查询），避免最初的查询承担冷未命中延迟。
+- **规划文件路径与生命周期。** 磁盘型 cell 会写入你提供的 `*_file_path`；请放在快速、专用、
+  容量足够的卷上，并在重建时清理陈旧文件。索引的序列化与加载走常规
+  [序列化格式](../advanced/serialization.md) API，后端文件随之管理。
+
+## 容量规划
+
+主要量化器的每向量近似存储（另加少量每向量元数据，如范数与误差）：
+
+| 表示 | 每向量字节数 | 典型放置 |
+|------|-------------|---------|
+| `fp32`（精确） | `dim × 4` | 磁盘 |
+| `fp16` / `bf16` | `dim × 2` | 内存或磁盘 |
+| `sq8` | `dim × 1` | 内存或磁盘 |
+| `sq4` | `dim × 0.5` | 内存 |
+| `rabitq`（b 位） | `dim × b / 8` | 内存 |
+
+以 `N = 1e9`、`dim = 128` 为例：
+
+- 内存中的 3 位 `rabitq` base：`1e9 × 128 × 3 / 8 ≈ 48 GB` 内存。
+- 磁盘上的 `sq8` 精确副本：`1e9 × 128 × 1 ≈ 128 GB` SSD。
+- 若改用全精度 `fp32`（重排精度最高）：`1e9 × 128 × 4 ≈ 512 GB` SSD。
+- 再加上图：邻居 id 约 `N × max_degree × 4` 字节（内存或 `mmap_io`）。
+
+这就是一个若以纯 `fp32` 需要约 0.5 TB 内存的十亿级索引，如何被压缩到几十 GB 内存 + 一块 SSD。
+
+## 调优与排错
+
+| 现象 | 可能原因 | 处理 |
+|------|---------|------|
+| 召回过低 | base 量化过粗，或未开启重排 | 保持 `use_reorder: true`；将 `precise_quantization_type` 提升至 `fp32`；增大 `ef_search` |
+| 延迟过高 | 每次查询磁盘读取过多 | 降低 `ef_search`；把 `graph`/`base` 留内存；仅让 precise 落磁盘；用 NVMe + `async_io` |
+| 内存仍然偏高 | base 或 graph 过大 | 把 base 改为 `sq4` / `pq` / `rabitq`；把 `graph` 放到 `mmap_io` |
+| `async_io` 表现为同步 | 未编译 libaio | 在 Linux 上以 `VSAG_ENABLE_LIBAIO=ON` 重新编译；留意回退告警 |
+| 冷启动延迟抖动（mmap） | 页缓存未预热 | 加载后、对外服务前先预热文件 |
+
+以上仅为起点，请用 [`eval_performance`](eval.md) 在真实查询分布上验证；随后可用
+[优化器](../advanced/optimizer.md) 自动确定搜索期参数。
+
+## 参见
+
+- [HGraph](../indexes/hgraph.md)——旗舰索引及其完整参数表
+- [量化总览](../quantization/README.md)——如何选择 base/precise 量化器
+- [最佳实践](best_practices.md)——通用生产建议
+- [序列化格式](../advanced/serialization.md)——索引的持久化与加载
+- [性能评估工具](eval.md) 与 [优化器](../advanced/optimizer.md)——度量与调优


### PR DESCRIPTION
## Summary

Adds a bilingual (EN/ZH) **Disk-Based Index Best Practices** page centered on **HGraph**, and wires it into the navigation under *Performance and Tuning* (right after *Best Practices*).

The page covers:
- **When to move to disk** — decision signals and a quick `N × dim × 4` memory estimate.
- **The core idea** — keep a small approximate representation in memory to navigate, and the large precise representation on disk to rank, so disk reads stay bounded to the reorder step.
- **How HGraph tiers storage** — the `graph` / `base` / `precise` / `raw_vector` cells and the pluggable IO backends (`memory_io`, `block_memory_io`, `buffer_io`, `mmap_io`, `async_io`, `reader_io`), with the flat `*_io_type` / `*_file_path` build params.
- **Recommended config** — `sq8` base in memory + `fp32` precise on `async_io` with `use_reorder`, plus a tighter `rabitq` + `mmap_io` graph variant for smaller memory budgets.
- **Hardware & deployment, capacity planning, and a tuning/troubleshooting table.**

## Notes

- Focused on HGraph with disk-backed IO; it intentionally does **not** reference DiskANN, consistent with the ongoing effort to remove HNSW/DiskANN references from the docs.
- All parameter names, defaults, IO backends, and the libaio fallback were verified against the source (`src/io/io_parameter.cpp`, `src/algorithm/hgraph/hgraph_param_mapping.cpp`, `src/constants.cpp`, `src/datacell/flatten_interface.cpp`, `cmake/`, `Makefile`).
- Docs-only change; all internal links verified to resolve.