### PR TITLE
[codex] fix main lint failures

### DIFF
--- a/src/algorithm/hgraph/hgraph_param_mapping.cpp
+++ b/src/algorithm/hgraph/hgraph_param_mapping.cpp
@@ -574,8 +574,9 @@ HGraph::CheckAndMappingExternalParam(const JsonType& external_param,
                        fmt::format("mrle_dim must be an integer, got {}",
                                    external_param[INDEX_MRLE_DIM].Dump()));
         int64_t mrle_dim = external_param[INDEX_MRLE_DIM].GetInt();
+        bool valid_mrle_dim = mrle_dim >= 0 and mrle_dim <= static_cast<int64_t>(common_param.dim_);
         CHECK_ARGUMENT(
-            mrle_dim >= 0 and mrle_dim <= static_cast<int64_t>(common_param.dim_),
+            valid_mrle_dim,
             fmt::format("mrle_dim({}) must be in range [0, {}]", mrle_dim, common_param.dim_));
     }
 

--- a/src/algorithm/simq/simq.cpp
+++ b/src/algorithm/simq/simq.cpp
@@ -179,7 +179,7 @@ HGraphDynamicClustering::split_cluster(int old_center_id, int64_t /*dim*/) {
     cluster_centers_.push_back(new_center_id);
 
     if (hgraph_ != nullptr) {
-        int64_t label = static_cast<int64_t>(new_center_id);
+        auto label = static_cast<int64_t>(new_center_id);
         auto new_ds = Dataset::Make();
         new_ds->NumElements(1)
             ->Dim(dim_)
@@ -334,7 +334,7 @@ SIMQ::run_clustering(const float* flat_vecs,
         init_cluster_ratio_, max_cluster_size_, split_start_idx_, random_seed_, common_param_);
     clustering.Fit(flat_vecs, num_vecs, dim);
 
-    int64_t nc = static_cast<int64_t>(clustering.cluster_centers_.size());
+    auto nc = static_cast<int64_t>(clustering.cluster_centers_.size());
     num_clusters_ = nc;
 
     std::unordered_map<int, int> center_to_idx;
@@ -370,7 +370,7 @@ SIMQ::run_clustering(const float* flat_vecs,
     cluster_token_counts_.assign(static_cast<uint64_t>(nc), 0);
     for (int64_t v = 0; v < num_vecs; ++v) {
         int cid = clustering.vec_to_cluster_[v];
-        InnerIdType idx = static_cast<InnerIdType>(center_to_idx.at(cid));
+        auto idx = static_cast<InnerIdType>(center_to_idx.at(cid));
         vec_to_cluster_[v] = idx;
         token_to_dist_[v] = vec_to_dist[v];
         ++cluster_token_counts_[idx];
@@ -461,7 +461,7 @@ SIMQ::Add(const DatasetPtr& data) {
     CHECK_ARGUMENT(labels != nullptr, "simq add: labels (ids) is nullptr");
 
     for (int64_t i = 0; i < num_docs; ++i) {
-        InnerIdType inner_id = static_cast<InnerIdType>(total_count_);
+        auto inner_id = static_cast<InnerIdType>(total_count_);
 
         mv_codes_->Resize(inner_id + 1);
         mv_codes_->InsertVector(&mvs[i], inner_id);
@@ -476,7 +476,7 @@ SIMQ::Add(const DatasetPtr& data) {
             auto result_ds =
                 rep_hgraph_->KnnSearch(query_ds, 1, R"({"hgraph": {"ef_search": 100}})", nullptr);
 
-            InnerIdType cluster_idx = static_cast<InnerIdType>(result_ds->GetIds()[0]);
+            auto cluster_idx = static_cast<InnerIdType>(result_ds->GetIds()[0]);
             float token_dist = result_ds->GetDistances()[0];
 
             vec_to_cluster_.push_back(cluster_idx);
@@ -523,7 +523,7 @@ SIMQ::split_cluster_incremental(InnerIdType cluster_idx) {
     // Median split: first half (closer) stays in old cluster,
     //               second half (farther) moves to new cluster.
     uint64_t half = n / 2;
-    InnerIdType new_cluster_idx = static_cast<InnerIdType>(num_clusters_);
+    auto new_cluster_idx = static_cast<InnerIdType>(num_clusters_);
 
     std::unordered_set<InnerIdType> old_docs;
     std::unordered_set<InnerIdType> new_docs;
@@ -558,15 +558,15 @@ SIMQ::split_cluster_incremental(InnerIdType cluster_idx) {
     InnerIdType rep_doc = token_to_doc_[rep_tid];
     uint32_t rep_offset = token_to_offset_[rep_tid];
     bool need_release = false;
-    auto* codes = mv_codes_->GetCodesById(rep_doc, need_release);
-    auto* all_toks = reinterpret_cast<const float*>(codes + sizeof(uint32_t));
+    const auto* codes = mv_codes_->GetCodesById(rep_doc, need_release);
+    const auto* all_toks = reinterpret_cast<const float*>(codes + sizeof(uint32_t));
     std::vector<float> new_rep_vec(all_toks + rep_offset * static_cast<uint64_t>(dim_),
                                    all_toks + (rep_offset + 1) * static_cast<uint64_t>(dim_));
     if (need_release) {
         mv_codes_->Release(codes);
     }
 
-    int64_t new_label = static_cast<int64_t>(new_cluster_idx);
+    auto new_label = static_cast<int64_t>(new_cluster_idx);
     auto new_ds = Dataset::Make();
     new_ds->NumElements(1)
         ->Dim(dim_)
@@ -583,8 +583,8 @@ SIMQ::split_cluster_incremental(InnerIdType cluster_idx) {
         InnerIdType doc_id = token_to_doc_[tid];
         uint32_t offset = token_to_offset_[tid];
         bool nr = false;
-        auto* c = mv_codes_->GetCodesById(doc_id, nr);
-        auto* tv = reinterpret_cast<const float*>(c + sizeof(uint32_t)) + offset * udim;
+        const auto* c = mv_codes_->GetCodesById(doc_id, nr);
+        const auto* tv = reinterpret_cast<const float*>(c + sizeof(uint32_t)) + offset * udim;
         float dot = 0.0F;
         for (uint64_t d = 0; d < udim; ++d) {
             dot += tv[d] * new_rep_vec[d];
@@ -632,7 +632,7 @@ SIMQ::coarse_search(const float* query_tokens, uint32_t query_token_count, int64
         cscores.reserve(static_cast<uint64_t>(nres));
         for (int64_t ri = 0; ri < nres; ++ri) {
             float cscore = 1.0F - rdists[ri];
-            InnerIdType cidx = static_cast<InnerIdType>(rids[ri]);
+            auto cidx = static_cast<InnerIdType>(rids[ri]);
             cscores.emplace_back(cscore, cidx);
         }
         std::sort(cscores.begin(), cscores.end(), [](const auto& a, const auto& b) {
@@ -798,7 +798,7 @@ SIMQ::serialize_rep_hgraph(StreamWriter& writer) const {
     IOStreamWriter tmp_writer(ss);
     rep_hgraph_->Serialize(tmp_writer);
     std::string blob = ss.str();
-    uint64_t blob_size = static_cast<uint64_t>(blob.size());
+    auto blob_size = static_cast<uint64_t>(blob.size());
     StreamWriter::WriteObj(writer, blob_size);
     writer.Write(blob.data(), blob_size);
 }
@@ -832,7 +832,7 @@ SIMQ::Serialize(StreamWriter& writer) const {
     StreamWriter::WriteObj(writer, total_count_val);
     StreamWriter::WriteObj(writer, num_clusters_);
 
-    uint64_t n_clusters = static_cast<uint64_t>(cluster_lists_.size());
+    auto n_clusters = static_cast<uint64_t>(cluster_lists_.size());
     StreamWriter::WriteObj(writer, n_clusters);
     for (const auto& list : cluster_lists_) {
         StreamWriter::WriteVector(writer, list);

--- a/src/algorithm/simq/simq_parameter.cpp
+++ b/src/algorithm/simq/simq_parameter.cpp
@@ -34,24 +34,30 @@ void
 SIMQParameter::FromJson(const JsonType& json) {
     InnerIndexParameter::FromJson(json);
 
-    if (json.Contains(SIMQ_INIT_CLUSTER_RATIO))
+    if (json.Contains(SIMQ_INIT_CLUSTER_RATIO)) {
         init_cluster_ratio = json[SIMQ_INIT_CLUSTER_RATIO].GetFloat();
-    if (json.Contains(SIMQ_MAX_CLUSTER_SIZE))
+    }
+    if (json.Contains(SIMQ_MAX_CLUSTER_SIZE)) {
         max_cluster_size = json[SIMQ_MAX_CLUSTER_SIZE].GetInt();
-    if (json.Contains(SIMQ_SPLIT_START_IDX))
+    }
+    if (json.Contains(SIMQ_SPLIT_START_IDX)) {
         split_start_idx = json[SIMQ_SPLIT_START_IDX].GetInt();
-    if (json.Contains(SIMQ_RANDOM_SEED))
+    }
+    if (json.Contains(SIMQ_RANDOM_SEED)) {
         random_seed = json[SIMQ_RANDOM_SEED].GetInt();
-    if (json.Contains(SIMQ_COARSE_K))
+    }
+    if (json.Contains(SIMQ_COARSE_K)) {
         coarse_k = json[SIMQ_COARSE_K].GetInt();
-    if (json.Contains(SIMQ_RERANK_K))
+    }
+    if (json.Contains(SIMQ_RERANK_K)) {
         rerank_k = json[SIMQ_RERANK_K].GetInt();
+    }
 
-    CHECK_ARGUMENT(init_cluster_ratio > 0.0f && init_cluster_ratio <= 1.0f,
-                   "simq: init_cluster_ratio must be in (0, 1]");
+    bool valid_init_cluster_ratio = init_cluster_ratio > 0.0F and init_cluster_ratio <= 1.0F;
+    CHECK_ARGUMENT(valid_init_cluster_ratio, "simq: init_cluster_ratio must be in (0, 1]");
     CHECK_ARGUMENT(max_cluster_size > 1, "simq: max_cluster_size must be > 1");
-    CHECK_ARGUMENT(split_start_idx > 1 && split_start_idx < max_cluster_size,
-                   "simq: split_start_idx must be in (1, max_cluster_size)");
+    bool valid_split_start_idx = split_start_idx > 1 and split_start_idx < max_cluster_size;
+    CHECK_ARGUMENT(valid_split_start_idx, "simq: split_start_idx must be in (1, max_cluster_size)");
     CHECK_ARGUMENT(coarse_k > 0, "simq: coarse_k must be > 0");
     CHECK_ARGUMENT(rerank_k > 0, "simq: rerank_k must be > 0");
 
@@ -97,10 +103,12 @@ SIMQSearchParameters::FromJson(const std::string& json_string) {
     }
     const auto& simq_params = params[INDEX_SIMQ];
     obj.IndexSearchParameter::FromJson(simq_params);
-    if (simq_params.Contains(SIMQ_COARSE_K))
+    if (simq_params.Contains(SIMQ_COARSE_K)) {
         obj.coarse_k = simq_params[SIMQ_COARSE_K].GetInt();
-    if (simq_params.Contains(SIMQ_RERANK_K))
+    }
+    if (simq_params.Contains(SIMQ_RERANK_K)) {
         obj.rerank_k = simq_params[SIMQ_RERANK_K].GetInt();
+    }
     return obj;
 }
 


### PR DESCRIPTION
## What changed

Fix clang-tidy-15 warnings that are currently breaking the upstream `main` `Lint / Lint (push)` workflow.

The changes are limited to source-style cleanups:
- avoid `CHECK_ARGUMENT(a && b)` macro expansions that trigger DeMorgan simplification warnings
- use `auto` for variables initialized from casts
- qualify read-only pointer deductions as `const auto*`
- add braces to single-line `if` statements and use uppercase floating-point literal suffixes

## Why

`main` has repeated failing `Lint` push runs. The latest inspected failure was:

https://github.com/antgroup/vsag/actions/runs/28505770748

`make lint` reports clang-tidy-15 warnings-as-errors in `hgraph_param_mapping.cpp`, `simq.cpp`, and `simq_parameter.cpp`.

Fixes: #2383

## Validation

- `clang-format -i src/algorithm/hgraph/hgraph_param_mapping.cpp src/algorithm/simq/simq.cpp src/algorithm/simq/simq_parameter.cpp`
- `git diff --check`
- `cmake --build build-release --parallel 4 --target vsag`

Note: local `./scripts/linters/run-clang-tidy-15.sh --version` correctly rejected the host clang-tidy because only clang-tidy 13 is installed locally. The PR's GitHub Actions lint job should provide the clang-tidy-15 verification.
