### PR TITLE
feat: unify memory statistics API signatures

### DIFF
--- a/docs/docs/en/src/advanced/memory.md
+++ b/docs/docs/en/src/advanced/memory.md
@@ -58,12 +58,27 @@ if (index->CheckFeature(vsag::SUPPORT_ESTIMATE_MEMORY)) {
 
 See `examples/cpp/308_feature_estimate_memory.cpp` for a full run.
 
+### `EstimateBuildMemory(num_elements)`
+
+`Index::EstimateBuildMemory(num_elements)` returns the estimated memory (in bytes) required
+**during the build process** for `num_elements` vectors. Unlike `EstimateMemory`, which
+estimates the steady-state size of the final index, this accounts for temporary buffers and
+intermediate data structures that exist only while `Build` is running. The peak memory during
+build is typically higher than the post-build footprint:
+
+```cpp
+uint64_t peak = index->EstimateBuildMemory(1000000);  // bytes
+```
+
+Currently only DiskANN provides a non-trivial implementation; other index types throw
+an exception by default.
+
 ### `GetMemoryUsage()`
 
 `Index::GetMemoryUsage()` returns the **current** memory footprint of an index in bytes:
 
 ```cpp
-int64_t bytes = index->GetMemoryUsage();
+uint64_t bytes = index->GetMemoryUsage();
 ```
 
 Properties:
@@ -85,6 +100,26 @@ Properties:
 
 See `examples/cpp/319_feature_get_memory_usage.cpp` for a runnable example, including a helper
 that compares the interface value with the process resident size.
+
+### `GetMemoryUsageDetail()`
+
+`Index::GetMemoryUsageDetail()` returns a breakdown of the **current** memory usage by
+component:
+
+```cpp
+std::unordered_map<std::string, uint64_t> detail = index->GetMemoryUsageDetail();
+for (const auto& [component, bytes] : detail) {
+    std::cout << component << ": " << bytes << " bytes\n";
+}
+```
+
+The returned map keys are component names and values are memory in bytes. This is useful for
+understanding *where* the memory is going inside an index.
+
+Currently only HGraph provides a meaningful implementation, returning components such as
+`basic_flatten_codes`, `bottom_graph`, `route_graph`, `neighbors_mutex`, `pool`,
+`label_table`, `high_precise_codes`, `extra_infos`, and `raw_vector`. SINDI returns an empty
+map. Other index types throw an exception by default.
 
 ### Capability Flags
 

--- a/docs/docs/zh/src/advanced/memory.md
+++ b/docs/docs/zh/src/advanced/memory.md
@@ -56,12 +56,24 @@ if (index->CheckFeature(vsag::SUPPORT_ESTIMATE_MEMORY)) {
 
 完整示例：`examples/cpp/308_feature_estimate_memory.cpp`。
 
+### `EstimateBuildMemory(num_elements)`
+
+`Index::EstimateBuildMemory(num_elements)` 返回构建 `num_elements` 条向量的索引时**构建过程中**
+所需的预估内存（字节数）。与 `EstimateMemory`（估算最终索引的稳态大小）不同，该接口考虑了构建
+过程中仅临时存在的缓冲区与中间数据结构。构建期间的峰值内存通常高于构建完成后的内存占用：
+
+```cpp
+uint64_t peak = index->EstimateBuildMemory(1000000);  // 字节
+```
+
+目前仅 DiskANN 提供了有效实现，其他索引类型默认抛出异常。
+
 ### `GetMemoryUsage()`
 
 `Index::GetMemoryUsage()` 返回索引**当前**占用的字节数：
 
 ```cpp
-int64_t bytes = index->GetMemoryUsage();
+uint64_t bytes = index->GetMemoryUsage();
 ```
 
 特性：
@@ -79,6 +91,23 @@ int64_t bytes = index->GetMemoryUsage();
 
 可运行示例：`examples/cpp/319_feature_get_memory_usage.cpp`，其中包含一个辅助函数将接口值与进程
 驻留内存进行对照。
+
+### `GetMemoryUsageDetail()`
+
+`Index::GetMemoryUsageDetail()` 返回索引**当前**内存占用按组件的细分：
+
+```cpp
+std::unordered_map<std::string, uint64_t> detail = index->GetMemoryUsageDetail();
+for (const auto& [component, bytes] : detail) {
+    std::cout << component << ": " << bytes << " bytes\n";
+}
+```
+
+返回的 map 的 key 为组件名，value 为对应内存字节数。该接口有助于了解索引内部的内存分布。
+
+目前仅 HGraph 提供了有效实现，返回的组件包括 `basic_flatten_codes`、`bottom_graph`、
+`route_graph`、`neighbors_mutex`、`pool`、`label_table`、`high_precise_codes`、
+`extra_infos` 和 `raw_vector`。SINDI 返回空 map，其他索引类型默认抛出异常。
 
 ### 能力标志
 

--- a/include/vsag/index.h
+++ b/include/vsag/index.h
@@ -22,6 +22,7 @@
 #include <stdexcept>
 #include <string>
 #include <tuple>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -900,18 +901,15 @@ public:
       *
       * @return number of bytes occupied by the index.
       */
-    [[nodiscard]] virtual int64_t
+    [[nodiscard]] virtual uint64_t
     GetMemoryUsage() const = 0;
 
     /**
       * @brief Return the memory usage of every component in the index
       *
-      * @return a json object that contains the memory usage of every component in the index
+      * @return a map from component name to memory usage in bytes
       */
-    // TODO(deming): implement func for every types of index
-    // [[nodiscard]] virtual JsonType
-    // GetMemoryUsageDetail() const = 0;
-    [[nodiscard]] virtual std::string
+    [[nodiscard]] virtual std::unordered_map<std::string, uint64_t>
     GetMemoryUsageDetail() const {
         throw std::runtime_error("Index does not support GetMemoryUsageDetail");
     }
@@ -933,9 +931,9 @@ public:
       * @param num_elements denotes the amount of data used to build the index.
       * @return estimated memory required during building.
       */
-    [[nodiscard]] virtual int64_t
-    GetEstimateBuildMemory(const int64_t num_elements) const {
-        throw std::runtime_error("Index does not support estimate the memory while building");
+    [[nodiscard]] virtual uint64_t
+    EstimateBuildMemory(uint64_t num_elements) const {
+        throw std::runtime_error("Index does not support EstimateBuildMemory");
     }
 
     /**

--- a/include/vsag/vsag_ext.h
+++ b/include/vsag/vsag_ext.h
@@ -167,7 +167,7 @@ public:
     int64_t
     GetNumElements() const;
 
-    int64_t
+    uint64_t
     GetMemoryUsage() const;
 
 private:

--- a/mockimpl/vsag/simpleflat.h
+++ b/mockimpl/vsag/simpleflat.h
@@ -76,7 +76,7 @@ public:
     tl::expected<void, Error>
     Deserialize(const ReaderSet& reader_set) override;
 
-    int64_t
+    uint64_t
     GetMemoryUsage() const override {
         size_t ids_size = num_elements_ * sizeof(int64_t);
         size_t vector_size = num_elements_ * dim_ * sizeof(float);

--- a/src/algorithm/bruteforce/bruteforce.cpp
+++ b/src/algorithm/bruteforce/bruteforce.cpp
@@ -1044,9 +1044,9 @@ BruteForce::cal_memory_usage() {
     this->current_memory_usage_.store(memory_usage);
 }
 
-int64_t
+uint64_t
 BruteForce::GetMemoryUsage() const {
-    int64_t memory = 0;
+    uint64_t memory = 0;
     {
         std::shared_lock lock(this->memory_usage_mutex_);
         memory = this->current_memory_usage_.load();

--- a/src/algorithm/bruteforce/bruteforce.h
+++ b/src/algorithm/bruteforce/bruteforce.h
@@ -135,7 +135,7 @@ public:
                     const AttributeSet& new_attrs,
                     const AttributeSet& origin_attrs) override;
 
-    int64_t
+    uint64_t
     GetMemoryUsage() const override;
 
 private:

--- a/src/algorithm/hgraph/hgraph.cpp
+++ b/src/algorithm/hgraph/hgraph.cpp
@@ -670,7 +670,7 @@ HGraph::cal_memory_usage() {
     }
 
     std::unique_lock lock(this->memory_usage_mutex_);
-    this->current_memory_usage_.store(static_cast<int64_t>(memory));
+    this->current_memory_usage_.store(memory);
 }
 
 }  // namespace vsag

--- a/src/algorithm/hgraph/hgraph.h
+++ b/src/algorithm/hgraph/hgraph.h
@@ -108,7 +108,7 @@ public:
     void
     GetCodeByInnerId(InnerIdType inner_id, uint8_t* data) const override;
 
-    std::string
+    std::unordered_map<std::string, uint64_t>
     GetMemoryUsageDetail() const override;
 
     std::pair<int64_t, int64_t>

--- a/src/algorithm/hgraph/hgraph_serialize.cpp
+++ b/src/algorithm/hgraph/hgraph_serialize.cpp
@@ -396,28 +396,29 @@ HGraph::Deserialize(StreamReader& reader) {
     }
 }
 
-std::string
+std::unordered_map<std::string, uint64_t>
 HGraph::GetMemoryUsageDetail() const {
-    JsonType memory_usage;
-    if (this->ignore_reorder_) {
-        this->use_reorder_ = false;
-    }
-    memory_usage["basic_flatten_codes"].SetUint64(this->basic_flatten_codes_->CalcSerializeSize());
-    memory_usage["bottom_graph"].SetUint64(this->bottom_graph_->CalcSerializeSize());
-    if (this->has_precise_reorder()) {
-        memory_usage["high_precise_codes"].SetUint64(
-            this->high_precise_codes_->CalcSerializeSize());
-    }
-    uint64_t route_graph_size = 0;
+    std::unordered_map<std::string, uint64_t> memory_usage;
+    memory_usage["neighbors_mutex"] = this->neighbors_mutex_->GetMemoryUsage();
+    memory_usage["pool"] = this->pool_->GetMemoryUsage();
+    memory_usage["label_table"] = this->label_table_->GetMemoryUsage();
+    memory_usage["basic_flatten_codes"] = this->basic_flatten_codes_->GetMemoryUsage();
+    memory_usage["bottom_graph"] = this->bottom_graph_->GetMemoryUsage();
+    uint64_t route_graph_memory = 0;
     for (const auto& route_graph : this->route_graphs_) {
-        route_graph_size += route_graph->CalcSerializeSize();
+        route_graph_memory += route_graph->GetMemoryUsage();
     }
-    memory_usage["route_graph"].SetUint64(route_graph_size);
+    memory_usage["route_graph"] = route_graph_memory;
+    if (this->has_precise_reorder()) {
+        memory_usage["high_precise_codes"] = this->high_precise_codes_->GetMemoryUsage();
+    }
     if (this->extra_info_size_ > 0 && this->extra_infos_ != nullptr) {
-        memory_usage["extra_infos"].SetUint64(this->extra_infos_->CalcSerializeSize());
+        memory_usage["extra_infos"] = this->extra_infos_->GetMemoryUsage();
     }
-    memory_usage["__total_size__"].SetUint64(this->CalSerializeSize());
-    return memory_usage.Dump();
+    if (this->create_new_raw_vector_ && this->raw_vector_ != nullptr) {
+        memory_usage["raw_vector"] = this->raw_vector_->GetMemoryUsage();
+    }
+    return memory_usage;
 }
 
 }  // namespace vsag

--- a/src/algorithm/inner_index_interface.h
+++ b/src/algorithm/inner_index_interface.h
@@ -17,6 +17,7 @@
 
 #include <atomic>
 #include <shared_mutex>
+#include <unordered_map>
 #include <vector>
 
 #include "container_types.h"
@@ -253,10 +254,10 @@ public:
     virtual DetailDataPtr
     GetDetailDataByName(const std::string& name, IndexDetailInfo& info) const;
 
-    [[nodiscard]] virtual int64_t
-    GetEstimateBuildMemory(const int64_t num_elements) const {
+    [[nodiscard]] virtual uint64_t
+    EstimateBuildMemory(uint64_t num_elements) const {
         throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                            "Index doesn't support GetEstimateBuildMemory");
+                            "Index doesn't support EstimateBuildMemory");
     }
 
     virtual void
@@ -265,15 +266,14 @@ public:
     [[nodiscard]] virtual IndexType
     GetIndexType() const = 0;
 
-    [[nodiscard]] virtual int64_t
+    [[nodiscard]] virtual uint64_t
     GetMemoryUsage() const {
         std::shared_lock lock(this->memory_usage_mutex_);
         return this->current_memory_usage_.load();
     }
 
-    [[nodiscard]] virtual std::string
+    [[nodiscard]] virtual std::unordered_map<std::string, uint64_t>
     GetMemoryUsageDetail() const {
-        // TODO(deming): implement func for every types of inner index
         throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
                             "Index doesn't support GetMemoryUsageDetail");
     }
@@ -572,7 +572,7 @@ public:
 protected:
     std::atomic<uint64_t> total_count_{0};
 
-    std::atomic<int64_t> current_memory_usage_{0};
+    std::atomic<uint64_t> current_memory_usage_{0};
     mutable std::shared_mutex memory_usage_mutex_{};
 
     bool has_raw_vector_{false};

--- a/src/algorithm/inner_index_interface_test.cpp
+++ b/src/algorithm/inner_index_interface_test.cpp
@@ -208,7 +208,7 @@ TEST_CASE("InnerIndexInterface NOT Implemented", "[ut][InnerIndexInterface]") {
     REQUIRE_THROWS(empty_index->Remove(0));
     REQUIRE_THROWS(empty_index->GetNumberRemoved());
     REQUIRE_THROWS(empty_index->EstimateMemory(1000));
-    REQUIRE_THROWS(empty_index->GetEstimateBuildMemory(1000));
+    REQUIRE_THROWS(empty_index->EstimateBuildMemory(1000));
     REQUIRE_THROWS(empty_index->Feedback(nullptr, 10, ""));
     REQUIRE_THROWS(empty_index->GetStats());
     REQUIRE_THROWS(empty_index->UpdateId(0, 1));

--- a/src/algorithm/ivf/ivf.cpp
+++ b/src/algorithm/ivf/ivf.cpp
@@ -1307,12 +1307,12 @@ IVF::cal_memory_usage() {
     memory += location_map_.size() * sizeof(uint64_t);
     memory += partition_strategy_->GetMemoryUsage();
     std::unique_lock lock(this->memory_usage_mutex_);
-    this->current_memory_usage_.store(static_cast<int64_t>(memory));
+    this->current_memory_usage_.store(memory);
 }
 
-int64_t
+uint64_t
 IVF::GetMemoryUsage() const {
-    int64_t memory = 0;
+    uint64_t memory = 0;
     {
         std::shared_lock lock(this->memory_usage_mutex_);
         memory = this->current_memory_usage_.load();

--- a/src/algorithm/ivf/ivf.h
+++ b/src/algorithm/ivf/ivf.h
@@ -169,7 +169,7 @@ public:
                     const AttributeSet& new_attrs,
                     const AttributeSet& origin_attrs) override;
 
-    [[nodiscard]] int64_t
+    [[nodiscard]] uint64_t
     GetMemoryUsage() const override;
 
 private:

--- a/src/algorithm/ivf/ivf_nearest_partition.cpp
+++ b/src/algorithm/ivf/ivf_nearest_partition.cpp
@@ -172,9 +172,9 @@ IVFNearestPartition::GetCentroid(BucketIdType bucket_id, Vector<float>& centroid
     this->route_index_ptr_->GetCodeByInnerId(bucket_id, (uint8_t*)centroid.data());
 }
 
-[[nodiscard]] int64_t
+[[nodiscard]] uint64_t
 IVFNearestPartition::GetMemoryUsage() const {
-    return static_cast<int64_t>(sizeof(IVFNearestPartition) +
-                                this->route_index_ptr_->GetMemoryUsage());
+    return static_cast<uint64_t>(sizeof(IVFNearestPartition) +
+                                 this->route_index_ptr_->GetMemoryUsage());
 }
 }  // namespace vsag

--- a/src/algorithm/ivf/ivf_nearest_partition.h
+++ b/src/algorithm/ivf/ivf_nearest_partition.h
@@ -47,7 +47,7 @@ public:
     void
     Deserialize(lvalue_or_rvalue<StreamReader> reader) override;
 
-    [[nodiscard]] int64_t
+    [[nodiscard]] uint64_t
     GetMemoryUsage() const override;
 
 public:

--- a/src/algorithm/ivf/ivf_partition_strategy.h
+++ b/src/algorithm/ivf/ivf_partition_strategy.h
@@ -90,7 +90,7 @@ public:
     GetResidual(
         uint64_t n, const float* x, float* residuals, float* centroids, BucketIdType* assign);
 
-    virtual int64_t
+    virtual uint64_t
     GetMemoryUsage() const {
         return 0;
     }

--- a/src/algorithm/lazy_hgraph/lazy_hgraph.cpp
+++ b/src/algorithm/lazy_hgraph/lazy_hgraph.cpp
@@ -325,7 +325,7 @@ LazyHGraph::GetExtraInfoByIds(const int64_t* ids, int64_t count, char* extra_inf
     ActiveIndex()->GetExtraInfoByIds(ids, count, extra_infos);
 }
 
-int64_t
+uint64_t
 LazyHGraph::GetMemoryUsage() const {
     std::shared_lock lock(this->phase_mutex_);
     return ActiveIndex()->GetMemoryUsage();

--- a/src/algorithm/lazy_hgraph/lazy_hgraph.h
+++ b/src/algorithm/lazy_hgraph/lazy_hgraph.h
@@ -112,7 +112,7 @@ public:
     void
     GetExtraInfoByIds(const int64_t* ids, int64_t count, char* extra_infos) const override;
 
-    [[nodiscard]] int64_t
+    [[nodiscard]] uint64_t
     GetMemoryUsage() const override;
 
     void

--- a/src/algorithm/pyramid/pyramid.cpp
+++ b/src/algorithm/pyramid/pyramid.cpp
@@ -498,7 +498,7 @@ Pyramid::Deserialize(StreamReader& reader) {
     }
 
     resize(max_capacity);
-    this->current_memory_usage_ = static_cast<int64_t>(this->CalSerializeSize());
+    this->current_memory_usage_ = this->CalSerializeSize();
 }
 
 InnerIndexPtr
@@ -516,7 +516,7 @@ Pyramid::ExportModel(const IndexCommonParam& param) const {
         }
         this->precise_codes_->ExportModel(index->precise_codes_);
     }
-    index->current_memory_usage_ = static_cast<int64_t>(index->CalSerializeSize());
+    index->current_memory_usage_ = index->CalSerializeSize();
     return index;
 }
 

--- a/src/algorithm/sindi/sindi.cpp
+++ b/src/algorithm/sindi/sindi.cpp
@@ -1016,7 +1016,7 @@ SINDI::cal_memory_usage() {
     }
 
     std::unique_lock lock(this->memory_usage_mutex_);
-    this->current_memory_usage_.store(static_cast<int64_t>(memory));
+    this->current_memory_usage_.store(memory);
 }
 
 void

--- a/src/algorithm/sindi/sindi.h
+++ b/src/algorithm/sindi/sindi.h
@@ -91,9 +91,9 @@ public:
     void
     InitFeatures() override;
 
-    std::string
+    std::unordered_map<std::string, uint64_t>
     GetMemoryUsageDetail() const override {
-        return "";
+        return {};
     }
 
     std::string

--- a/src/attr/attr_value_map.cpp
+++ b/src/attr/attr_value_map.cpp
@@ -117,18 +117,18 @@ AttrValueMap::Deserialize(StreamReader& reader) {
 }
 
 template <typename T>
-int64_t
+uint64_t
 get_memory_usage(const UnorderedMap<T, MultiBitsetManager*>& map) {
-    int64_t memory_usage = 0;
+    uint64_t memory_usage = 0;
     for (const auto& [key, value] : map) {
         memory_usage += sizeof(T) + value->GetMemoryUsage();
     }
     return memory_usage;
 }
 
-int64_t
+uint64_t
 AttrValueMap::GetMemoryUsage() const {
-    int64_t memory_usage = sizeof(AttrValueMap);
+    uint64_t memory_usage = sizeof(AttrValueMap);
     memory_usage += get_memory_usage(int64_to_bitset_);
     memory_usage += get_memory_usage(int32_to_bitset_);
     memory_usage += get_memory_usage(int16_to_bitset_);

--- a/src/attr/attr_value_map.h
+++ b/src/attr/attr_value_map.h
@@ -118,7 +118,7 @@ public:
     void
     Deserialize(StreamReader& reader);
 
-    int64_t
+    uint64_t
     GetMemoryUsage() const;
 
 private:

--- a/src/attr/multi_bitset_manager.cpp
+++ b/src/attr/multi_bitset_manager.cpp
@@ -105,7 +105,7 @@ MultiBitsetManager::Deserialize(lvalue_or_rvalue<StreamReader> reader) {
     }
 }
 
-int64_t
+uint64_t
 MultiBitsetManager::GetMemoryUsage() const {
     auto memory_usage = sizeof(MultiBitsetManager);
     memory_usage += bitsets_.size() * sizeof(std::nullptr_t);
@@ -113,7 +113,7 @@ MultiBitsetManager::GetMemoryUsage() const {
     for (auto* bitset : bitsets_) {
         memory_usage += bitset->GetMemoryUsage();
     }
-    return static_cast<int64_t>(memory_usage);
+    return static_cast<uint64_t>(memory_usage);
 }
 
 }  // namespace vsag

--- a/src/attr/multi_bitset_manager.h
+++ b/src/attr/multi_bitset_manager.h
@@ -122,7 +122,7 @@ public:
      * 
      * @return The current memory usage in bytes.
      */
-    int64_t
+    uint64_t
     GetMemoryUsage() const;
 
 private:

--- a/src/datacell/attribute_bucket_inverted_datacell.cpp
+++ b/src/datacell/attribute_bucket_inverted_datacell.cpp
@@ -308,7 +308,7 @@ AttributeBucketInvertedDataCell::GetAttribute(BucketIdType bucket_id,
     }
 }
 
-int64_t
+uint64_t
 AttributeBucketInvertedDataCell::GetMemoryUsage() const {
     auto memory_usage = sizeof(AttributeBucketInvertedDataCell);
 
@@ -316,7 +316,7 @@ AttributeBucketInvertedDataCell::GetMemoryUsage() const {
         memory_usage += value_map->GetMemoryUsage();
         memory_usage += name.size() + sizeof(ValueMapPtr);
     }
-    return static_cast<int64_t>(memory_usage);
+    return static_cast<uint64_t>(memory_usage);
 }
 
 }  // namespace vsag

--- a/src/datacell/attribute_bucket_inverted_datacell.h
+++ b/src/datacell/attribute_bucket_inverted_datacell.h
@@ -58,7 +58,7 @@ public:
     void
     GetAttribute(BucketIdType bucket_id, InnerIdType inner_id, AttributeSet* attr) override;
 
-    int64_t
+    uint64_t
     GetMemoryUsage() const override;
 
 private:

--- a/src/datacell/attribute_inverted_interface.h
+++ b/src/datacell/attribute_inverted_interface.h
@@ -88,7 +88,7 @@ public:
         return this->bitset_type_;
     }
 
-    virtual int64_t
+    virtual uint64_t
     GetMemoryUsage() const = 0;
 
 public:

--- a/src/datacell/bucket_datacell.h
+++ b/src/datacell/bucket_datacell.h
@@ -117,9 +117,9 @@ public:
     void
     GetCodesById(BucketIdType bucket_id, InnerIdType offset_id, uint8_t* data) const override;
 
-    [[nodiscard]] int64_t
+    [[nodiscard]] uint64_t
     GetMemoryUsage() const override {
-        int64_t memory = sizeof(BucketDataCell);
+        uint64_t memory = sizeof(BucketDataCell);
         for (BucketIdType bucket_id = 0; bucket_id < this->bucket_count_; bucket_id++) {
             memory += this->datas_[bucket_id].GetMemoryUsage();
             memory += this->inner_ids_[bucket_id].size() * sizeof(InnerIdType);

--- a/src/datacell/bucket_interface.h
+++ b/src/datacell/bucket_interface.h
@@ -119,7 +119,7 @@ public:
     virtual void
     Unpack(){};
 
-    [[nodiscard]] virtual int64_t
+    [[nodiscard]] virtual uint64_t
     GetMemoryUsage() const = 0;
 
 public:

--- a/src/datacell/compressed_graph_datacell.cpp
+++ b/src/datacell/compressed_graph_datacell.cpp
@@ -158,7 +158,7 @@ CompressedGraphDataCell::CheckIdExists(InnerIdType id) const {
     return id < neighbor_sets_.size() && neighbor_sets_[id] != nullptr;
 }
 
-int64_t
+uint64_t
 CompressedGraphDataCell::GetMemoryUsage() const {
     auto memory = sizeof(CompressedGraphDataCell);
     memory += neighbor_sets_.size() * sizeof(std::nullptr_t);
@@ -167,7 +167,7 @@ CompressedGraphDataCell::GetMemoryUsage() const {
             memory += encoder->SizeInBytes();
         }
     }
-    return static_cast<int64_t>(memory);
+    return static_cast<uint64_t>(memory);
 }
 
 Vector<InnerIdType>

--- a/src/datacell/compressed_graph_datacell.h
+++ b/src/datacell/compressed_graph_datacell.h
@@ -60,7 +60,7 @@ public:
     void
     Deserialize(StreamReader& reader) override;
 
-    int64_t
+    uint64_t
     GetMemoryUsage() const override;
 
     Vector<InnerIdType>

--- a/src/datacell/extra_info_datacell.h
+++ b/src/datacell/extra_info_datacell.h
@@ -80,7 +80,7 @@ public:
     void
     Deserialize(StreamReader& reader) override;
 
-    int64_t
+    uint64_t
     GetMemoryUsage() const override;
 
     void
@@ -185,9 +185,9 @@ ExtraInfoDataCell<IOTmpl>::Deserialize(StreamReader& reader) {
 }
 
 template <typename IOTmpl>
-int64_t
+uint64_t
 ExtraInfoDataCell<IOTmpl>::GetMemoryUsage() const {
-    int64_t memory = sizeof(ExtraInfoDataCell<IOTmpl>);
+    uint64_t memory = sizeof(ExtraInfoDataCell<IOTmpl>);
     if (IOTmpl::InMemory) {
         memory += this->io_->GetMemoryUsage();
     }

--- a/src/datacell/extra_info_interface.h
+++ b/src/datacell/extra_info_interface.h
@@ -68,7 +68,7 @@ public:
     virtual bool
     GetExtraInfoById(InnerIdType id, char* extra_info) const = 0;
 
-    virtual int64_t
+    virtual uint64_t
     GetMemoryUsage() const {
         return 0;
     }

--- a/src/datacell/flatten_datacell.h
+++ b/src/datacell/flatten_datacell.h
@@ -176,7 +176,7 @@ public:
         return common_param_;
     }
 
-    int64_t
+    uint64_t
     GetMemoryUsage() const override;
 
 public:
@@ -502,9 +502,9 @@ FlattenDataCell<QuantTmpl, IOTmpl>::MergeOther(const FlattenInterfacePtr& other,
 }
 
 template <typename QuantTmpl, typename IOTmpl>
-int64_t
+uint64_t
 FlattenDataCell<QuantTmpl, IOTmpl>::GetMemoryUsage() const {
-    int64_t memory = sizeof(FlattenDataCell<QuantTmpl, IOTmpl>);
+    uint64_t memory = sizeof(FlattenDataCell<QuantTmpl, IOTmpl>);
     if (IOTmpl::InMemory) {
         memory += this->io_->GetMemoryUsage();
     }

--- a/src/datacell/flatten_interface.h
+++ b/src/datacell/flatten_interface.h
@@ -145,7 +145,7 @@ public:
         throw VsagException(ErrorType::INTERNAL_ERROR,
                             "InitIO not implemented in FlattenInterface");
     }
-    virtual int64_t
+    virtual uint64_t
     GetMemoryUsage() const {
         return 0;
     }

--- a/src/datacell/graph_datacell.h
+++ b/src/datacell/graph_datacell.h
@@ -107,9 +107,9 @@ public:
     void
     MergeOther(GraphInterfacePtr other, uint64_t bias) override;
 
-    int64_t
+    uint64_t
     GetMemoryUsage() const override {
-        int64_t memory = sizeof(GraphDataCell) + node_versions_.size() * sizeof(uint8_t);
+        uint64_t memory = sizeof(GraphDataCell) + node_versions_.size() * sizeof(uint8_t);
         if (IOTmpl::InMemory) {
             memory += io_->GetMemoryUsage();
         }

--- a/src/datacell/graph_interface.h
+++ b/src/datacell/graph_interface.h
@@ -88,7 +88,7 @@ public:
                             "GetIds in GraphInterface is not implemented");
     }
 
-    virtual int64_t
+    virtual uint64_t
     GetMemoryUsage() const {
         return 0;
     }

--- a/src/datacell/multi_vector_datacell.h
+++ b/src/datacell/multi_vector_datacell.h
@@ -109,7 +109,7 @@ public:
     void
     Deserialize(lvalue_or_rvalue<StreamReader> reader) override;
 
-    int64_t
+    uint64_t
     GetMemoryUsage() const override;
 
 private:

--- a/src/datacell/multi_vector_datacell.inl
+++ b/src/datacell/multi_vector_datacell.inl
@@ -218,9 +218,9 @@ MultiVectorDataCell<QuantTmpl, IOTmpl>::Query(float* result_dists,
 }
 
 template <typename QuantTmpl, typename IOTmpl>
-int64_t
+uint64_t
 MultiVectorDataCell<QuantTmpl, IOTmpl>::GetMemoryUsage() const {
-    int64_t memory = sizeof(MultiVectorDataCell<QuantTmpl, IOTmpl>);
+    uint64_t memory = sizeof(MultiVectorDataCell<QuantTmpl, IOTmpl>);
     memory += this->offset_io_->size_;
     if (IOTmpl::InMemory) {
         memory += this->io_->GetMemoryUsage();

--- a/src/datacell/rabitq_split_datacell.h
+++ b/src/datacell/rabitq_split_datacell.h
@@ -117,7 +117,7 @@ public:
         io_->Deserialize(reader);
     }
 
-    [[nodiscard]] int64_t
+    [[nodiscard]] uint64_t
     GetMemoryUsage() const {
         if constexpr (IOTmpl::InMemory) {
             return io_->GetMemoryUsage();
@@ -655,9 +655,9 @@ public:
         this->max_capacity_ = capacity;
     }
 
-    int64_t
+    uint64_t
     GetMemoryUsage() const override {
-        int64_t memory = sizeof(RaBitQSplitDataCell<metric, OneBitIOTmpl, SupplementIOTmpl>);
+        uint64_t memory = sizeof(RaBitQSplitDataCell<metric, OneBitIOTmpl, SupplementIOTmpl>);
         memory += this->x_bit_cell_->GetMemoryUsage();
         memory += this->supplement_cell_->GetMemoryUsage();
         memory += sizeof(RaBitQuantizer<metric>);

--- a/src/datacell/sparse_graph_datacell.cpp
+++ b/src/datacell/sparse_graph_datacell.cpp
@@ -267,7 +267,7 @@ SparseGraphDataCell::GetIds() const {
     return ids;
 }
 
-int64_t
+uint64_t
 SparseGraphDataCell::GetMemoryUsage() const {
     auto memory = sizeof(SparseGraphDataCell);
     memory += neighbors_.size() * (sizeof(InnerIdType) + maximum_degree_ * sizeof(InnerIdType) +
@@ -276,7 +276,7 @@ SparseGraphDataCell::GetMemoryUsage() const {
     if (reverse_edges_) {
         memory += reverse_edges_->GetMemoryUsage();
     }
-    return static_cast<int64_t>(memory);
+    return static_cast<uint64_t>(memory);
 }
 
 void

--- a/src/datacell/sparse_graph_datacell.h
+++ b/src/datacell/sparse_graph_datacell.h
@@ -77,7 +77,7 @@ public:
     Vector<InnerIdType>
     GetIds() const override;
 
-    int64_t
+    uint64_t
     GetMemoryUsage() const override;
 
     DuplicateTrackerPtr

--- a/src/datacell/sparse_term_datacell.cpp
+++ b/src/datacell/sparse_term_datacell.cpp
@@ -394,7 +394,7 @@ SparseTermDataCell::CalcDistanceByInnerId(const SparseTermComputerPtr& computer,
     return 1 + ip;
 }
 
-int64_t
+uint64_t
 SparseTermDataCell::GetMemoryUsage() const {
     auto memory = sizeof(SparseTermDataCell);
     memory += term_ids_.capacity() * sizeof(std::unique_ptr<Vector<uint16_t>>);
@@ -413,7 +413,7 @@ SparseTermDataCell::GetMemoryUsage() const {
     }
     memory += sizeof(QuantizationParams);
     memory += term_sizes_.capacity() * sizeof(uint32_t);
-    return static_cast<int64_t>(memory);
+    return static_cast<uint64_t>(memory);
 }
 
 void

--- a/src/datacell/sparse_term_datacell.h
+++ b/src/datacell/sparse_term_datacell.h
@@ -115,7 +115,7 @@ public:
     void
     GetSparseVector(uint32_t base_id, SparseVector* data, Allocator* specified_allocator);
 
-    [[nodiscard]] int64_t
+    [[nodiscard]] uint64_t
     GetMemoryUsage() const;
 
 private:

--- a/src/datacell/sparse_vector_datacell.h
+++ b/src/datacell/sparse_vector_datacell.h
@@ -144,7 +144,7 @@ public:
         this->io_ = io;
     }
 
-    int64_t
+    uint64_t
     GetMemoryUsage() const override;
 
 private:

--- a/src/datacell/sparse_vector_datacell.inl
+++ b/src/datacell/sparse_vector_datacell.inl
@@ -289,9 +289,9 @@ SparseVectorDataCell<QuantTmpl, IOTmpl>::SparseVectorDataCell(
 }
 
 template <typename QuantTmpl, typename IOTmpl>
-int64_t
+uint64_t
 SparseVectorDataCell<QuantTmpl, IOTmpl>::GetMemoryUsage() const {
-    int64_t memory = sizeof(SparseVectorDataCell<QuantTmpl, IOTmpl>);
+    uint64_t memory = sizeof(SparseVectorDataCell<QuantTmpl, IOTmpl>);
     memory += this->offset_io_->size_;
     if (IOTmpl::InMemory) {
         memory += this->io_->GetMemoryUsage();

--- a/src/impl/bitset/computable_bitset.h
+++ b/src/impl/bitset/computable_bitset.h
@@ -139,7 +139,7 @@ public:
      * 
      * @return The current memory usage in bytes.
      */
-    virtual int64_t
+    virtual uint64_t
     GetMemoryUsage() const = 0;
 };
 

--- a/src/impl/bitset/fast_bitset.cpp
+++ b/src/impl/bitset/fast_bitset.cpp
@@ -272,9 +272,9 @@ FastBitset::resize(uint32_t new_size, uint64_t fill) {
     size_ = new_size;
 }
 
-int64_t
+uint64_t
 FastBitset::GetMemoryUsage() const {
-    return static_cast<int64_t>(sizeof(FastBitset) + this->size_ * sizeof(uint64_t));
+    return static_cast<uint64_t>(sizeof(FastBitset) + this->size_ * sizeof(uint64_t));
 }
 
 }  // namespace vsag

--- a/src/impl/bitset/fast_bitset.h
+++ b/src/impl/bitset/fast_bitset.h
@@ -77,7 +77,7 @@ public:
     std::string
     Dump() override;
 
-    int64_t
+    uint64_t
     GetMemoryUsage() const override;
 
 private:

--- a/src/impl/bitset/sparse_bitset.cpp
+++ b/src/impl/bitset/sparse_bitset.cpp
@@ -115,9 +115,9 @@ SparseBitset::Clear() {
     this->r_ = std::move(roaring::Roaring());
 }
 
-int64_t
+uint64_t
 SparseBitset::GetMemoryUsage() const {
-    return static_cast<int64_t>(sizeof(SparseBitset) + r_.getSizeInBytes());
+    return static_cast<uint64_t>(sizeof(SparseBitset) + r_.getSizeInBytes());
 }
 
 }  // namespace vsag

--- a/src/impl/bitset/sparse_bitset.h
+++ b/src/impl/bitset/sparse_bitset.h
@@ -76,7 +76,7 @@ public:
     void
     Clear() override;
 
-    int64_t
+    uint64_t
     GetMemoryUsage() const override;
 
 private:

--- a/src/impl/label_table/label_remap.h
+++ b/src/impl/label_table/label_remap.h
@@ -126,7 +126,7 @@ public:
      * @note This includes hash table overhead (buckets, pointers, load factor)
      *       The estimate uses a multiplier to account for container overhead
      */
-    int64_t
+    uint64_t
     GetMemoryUsage() const {
         return Size() * (sizeof(LabelType) + sizeof(InnerIdType)) * 2;
     }

--- a/src/impl/label_table/label_table.h
+++ b/src/impl/label_table/label_table.h
@@ -224,7 +224,7 @@ public:
      * Get memory usage of the label table.
      * @return The memory usage in bytes.
      */
-    int64_t
+    uint64_t
     GetMemoryUsage() {
         return sizeof(LabelTable) + label_table_.size() * sizeof(LabelType) +
                label_remap_.GetMemoryUsage() + deleted_ids_.size() * sizeof(InnerIdType) * 2;

--- a/src/impl/reverse_edge.cpp
+++ b/src/impl/reverse_edge.cpp
@@ -72,15 +72,15 @@ ReverseEdge::Clear() {
     reverse_edges_.clear();
 }
 
-int64_t
+uint64_t
 ReverseEdge::GetMemoryUsage() const {
     std::shared_lock<std::shared_mutex> rlock(mutex_);
-    int64_t usage = sizeof(ReverseEdge);
+    uint64_t usage = sizeof(ReverseEdge);
     for (const auto& [id, neighbors] : reverse_edges_) {
         usage += sizeof(id);
         usage += sizeof(std::unique_ptr<Vector<InnerIdType>>);
         if (neighbors) {
-            usage += static_cast<int64_t>(neighbors->capacity() * sizeof(InnerIdType));
+            usage += neighbors->capacity() * sizeof(InnerIdType);
         }
     }
     return usage;

--- a/src/impl/reverse_edge.h
+++ b/src/impl/reverse_edge.h
@@ -45,7 +45,7 @@ public:
     void
     Resize(InnerIdType new_size);
 
-    int64_t
+    uint64_t
     GetMemoryUsage() const;
 
 private:

--- a/src/impl/reverse_edge_test.cpp
+++ b/src/impl/reverse_edge_test.cpp
@@ -139,7 +139,7 @@ TEST_CASE("ReverseEdge Basic Operations", "[ut][ReverseEdge]") {
         reverse_edge.AddReverseEdge(1, 2);
         reverse_edge.AddReverseEdge(3, 2);
 
-        int64_t usage = reverse_edge.GetMemoryUsage();
+        uint64_t usage = reverse_edge.GetMemoryUsage();
         REQUIRE(usage > 0);
         REQUIRE(usage > sizeof(ReverseEdge));
     }

--- a/src/index/diskann.cpp
+++ b/src/index/diskann.cpp
@@ -1100,9 +1100,9 @@ DiskANN::GetStats() const {
     return j.Dump(4);
 }
 
-int64_t
-DiskANN::GetEstimateBuildMemory(const int64_t num_elements) const {
-    int64_t estimate_memory_usage = 0;
+uint64_t
+DiskANN::EstimateBuildMemory(uint64_t num_elements) const {
+    uint64_t estimate_memory_usage = 0;
     // Memory usage of graph (1.365 is the relaxation factor used by DiskANN during graph construction.)
     estimate_memory_usage += (num_elements * R_ * sizeof(uint32_t)  // NOLINT
                               + num_elements * (R_ + 1) * sizeof(uint32_t)) *

--- a/src/index/diskann.h
+++ b/src/index/diskann.h
@@ -174,7 +174,7 @@ public:
         return index_->get_data_num();
     }
 
-    int64_t
+    uint64_t
     GetMemoryUsage() const override {
         if (status_ == MEMORY) {
             return index_->get_memory_usage() + disk_pq_compressed_vectors_.str().size() +
@@ -186,8 +186,8 @@ public:
         return 0;
     }
 
-    int64_t
-    GetEstimateBuildMemory(const int64_t num_elements) const override;
+    uint64_t
+    EstimateBuildMemory(uint64_t num_elements) const override;
 
     std::string
     GetStats() const override;

--- a/src/index/hnsw.h
+++ b/src/index/hnsw.h
@@ -308,7 +308,7 @@ public:
         return this->get_num_elements();
     }
 
-    int64_t
+    uint64_t
     GetMemoryUsage() const override {
         return this->get_memory_usage();
     }

--- a/src/index/index_impl.h
+++ b/src/index/index_impl.h
@@ -232,9 +232,9 @@ public:
         SAFE_CALL(return this->inner_index_->GetDetailDataByName(name, info));
     }
 
-    [[nodiscard]] int64_t
-    GetEstimateBuildMemory(const int64_t num_elements) const override {
-        return this->inner_index_->GetEstimateBuildMemory(num_elements);
+    [[nodiscard]] uint64_t
+    EstimateBuildMemory(uint64_t num_elements) const override {
+        return this->inner_index_->EstimateBuildMemory(num_elements);
     }
 
     virtual tl::expected<void, Error>
@@ -247,12 +247,12 @@ public:
         return this->inner_index_->GetIndexType();
     }
 
-    [[nodiscard]] int64_t
+    [[nodiscard]] uint64_t
     GetMemoryUsage() const override {
         return this->inner_index_->GetMemoryUsage();
     }
 
-    [[nodiscard]] std::string
+    [[nodiscard]] std::unordered_map<std::string, uint64_t>
     GetMemoryUsageDetail() const override {
         return this->inner_index_->GetMemoryUsageDetail();
     }

--- a/src/io/async_io/aio_context.h
+++ b/src/io/async_io/aio_context.h
@@ -68,7 +68,7 @@ public:
      *
      * @return Memory usage in bytes (sizeof(IOContext) plus heap-allocated iocb pointers).
      */
-    int64_t
+    uint64_t
     GetMemoryUsage() const override {
         return sizeof(IOContext) + DEFAULT_REQUEST_COUNT * sizeof(struct iocb);
     }

--- a/src/utils/lock_strategy.cpp
+++ b/src/utils/lock_strategy.cpp
@@ -57,9 +57,9 @@ PointsMutex::Resize(uint32_t new_element_num) {
     element_num_ = new_element_num;
 }
 
-int64_t
+uint64_t
 PointsMutex::GetMemoryUsage() {
-    return static_cast<int64_t>(
+    return static_cast<uint64_t>(
         neighbors_mutex_.size() *
         (sizeof(std::shared_ptr<std::shared_mutex>) + sizeof(std::shared_mutex)));
 }

--- a/src/utils/lock_strategy.h
+++ b/src/utils/lock_strategy.h
@@ -42,7 +42,7 @@ public:
     virtual void
     Resize(uint32_t new_element_num) = 0;
 
-    virtual int64_t
+    virtual uint64_t
     GetMemoryUsage() = 0;
 };
 
@@ -65,7 +65,7 @@ public:
     void
     Resize(uint32_t new_element_num) override;
 
-    int64_t
+    uint64_t
     GetMemoryUsage() override;
 
 private:
@@ -96,7 +96,7 @@ public:
     Resize(uint32_t new_element_num) override {
     }
 
-    int64_t
+    uint64_t
     GetMemoryUsage() override {
         return 0;
     }

--- a/src/utils/resource_object.h
+++ b/src/utils/resource_object.h
@@ -53,9 +53,9 @@ public:
      * The memory usage should include all dynamically allocated memory, whether
      * directly or indirectly, used by the resource.
      *
-     * @return int64_t The memory usage of the resource object in bytes.
+     * @return uint64_t The memory usage of the resource object in bytes.
      */
-    virtual int64_t
+    virtual uint64_t
     GetMemoryUsage() const = 0;
 };
 

--- a/src/utils/visited_list.h
+++ b/src/utils/visited_list.h
@@ -51,7 +51,7 @@ public:
     void
     Reset() override;
 
-    int64_t
+    uint64_t
     GetMemoryUsage() const override {
         return sizeof(VisitedList) + sizeof(VisitedListType) * this->max_size_;
     }

--- a/src/vsag_ext.cpp
+++ b/src/vsag_ext.cpp
@@ -184,7 +184,7 @@ IndexHandler::GetNumElements() const {
     return index_->GetNumElements();
 }
 
-int64_t
+uint64_t
 IndexHandler::GetMemoryUsage() const {
     return index_->GetMemoryUsage();
 }

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -325,10 +325,10 @@ HGraphTestIndex::TestGeneral(const TestIndex::IndexPtr& index,
 
 void
 HGraphTestIndex::TestMemoryUsageDetail(const IndexPtr& index) {
-    auto memory_detail = vsag::JsonType::Parse(index->GetMemoryUsageDetail());
-    REQUIRE(memory_detail.Contains("basic_flatten_codes"));
-    REQUIRE(memory_detail.Contains("bottom_graph"));
-    REQUIRE(memory_detail.Contains("route_graph"));
+    auto memory_detail = index->GetMemoryUsageDetail();
+    REQUIRE(memory_detail.count("basic_flatten_codes") > 0);
+    REQUIRE(memory_detail.count("bottom_graph") > 0);
+    REQUIRE(memory_detail.count("route_graph") > 0);
 }
 }  // namespace fixtures
 

--- a/tests/test_random_index.cpp
+++ b/tests/test_random_index.cpp
@@ -136,5 +136,5 @@ TEST_CASE("Test Random Index", "[ft][random]") {
         REQUIRE(range_result.has_value());
     }
 
-    REQUIRE(diskann->GetMemoryUsage() < diskann->GetEstimateBuildMemory(max_elements) * 1.2);
+    REQUIRE(diskann->GetMemoryUsage() < diskann->EstimateBuildMemory(max_elements) * 6 / 5);
 }

--- a/tests/test_simple_index.cpp
+++ b/tests/test_simple_index.cpp
@@ -90,7 +90,7 @@ public:
         return 0;
     }
 
-    int64_t
+    uint64_t
     GetMemoryUsage() const override {
         return 0;
     }
@@ -114,7 +114,7 @@ TEST_CASE("Test Simple Index", "[ft][simple_index]") {
     REQUIRE_FALSE(index->Remove(0).has_value());
     REQUIRE_FALSE(index->CheckFeature(IndexFeature::SUPPORT_ESTIMATE_MEMORY));
     REQUIRE_THROWS(index->EstimateMemory(1000));
-    REQUIRE_THROWS(index->GetEstimateBuildMemory(1000));
+    REQUIRE_THROWS(index->EstimateBuildMemory(1000));
     REQUIRE_FALSE(index->Feedback(dataset->query_, 10, "").has_value());
     REQUIRE_THROWS_MATCHES(index->GetStats(),
                            std::runtime_error,

--- a/tools/eval/case/build_eval_case.cpp
+++ b/tools/eval/case/build_eval_case.cpp
@@ -105,13 +105,12 @@ BuildEvalCase::process_result() {
     result["index_info"] = JsonType::parse(config_.build_param);
     result["action"] = "build";
     result["index"] = config_.index_name;
-    // TODO(deming): remove try-catch after implement GetMemoryUsageDetail
     try {
-        result["memory_detail(B)"] = this->index_->GetMemoryUsageDetail();
-    } catch (std::runtime_error& e) {
-        // if GetMemoryUsageDetail not implemented
-        logger_->Error(e.what());
-    } catch (vsag::VsagException& e) {
+        auto detail = this->index_->GetMemoryUsageDetail();
+        for (const auto& [name, size] : detail) {
+            result["memory_detail(B)"][name] = size;
+        }
+    } catch (const std::exception& e) {
         logger_->Error(e.what());
     }
     return result;

--- a/tools/eval/case/search_eval_case.cpp
+++ b/tools/eval/case/search_eval_case.cpp
@@ -262,13 +262,12 @@ SearchEvalCase::process_result() {
     result["index_info"] = JsonType::parse(config_.build_param);
     result["search_param"] = config_.search_param;
     result["index"] = config_.index_name;
-    // TODO(deming): remove try-catch after implement GetMemoryUsageDetail
     try {
-        result["memory_detail(B)"] = this->index_->GetMemoryUsageDetail();
-    } catch (std::runtime_error& e) {
-        // if GetMemoryUsageDetail not implemented
-        logger_->Error(e.what());
-    } catch (vsag::VsagException& e) {
+        auto detail = this->index_->GetMemoryUsageDetail();
+        for (const auto& [name, size] : detail) {
+            result["memory_detail(B)"][name] = size;
+        }
+    } catch (const std::exception& e) {
         logger_->Error(e.what());
     }
     EvalCase::MergeJsonType(this->basic_info_, result);


### PR DESCRIPTION
## Background

The Index public API provides 4 memory statistics interfaces with inconsistent return types, parameter types, and naming conventions.

## Problem

1. **Inconsistent return types**: GetMemoryUsage returns int64_t, GetMemoryUsageDetail returns std::string (JSON), EstimateMemory returns uint64_t, GetEstimateBuildMemory returns int64_t. Memory size is inherently non-negative.
2. **Inconsistent parameter types**: EstimateMemory(uint64_t) vs GetEstimateBuildMemory(int64_t).
3. **Inconsistent naming**: GetMemoryUsage (Get prefix), EstimateMemory (no prefix), GetEstimateBuildMemory (mixed).
4. **GetMemoryUsageDetail implementation inconsistency**: HGraph used CalcSerializeSize() for detail but GetMemoryUsage() for total.
5. **GetMemoryUsageDetail incomplete coverage**: Only HGraph had a real implementation.
6. **JsonType not exposed**: Public API returned std::string JSON but JsonType was never exported.

## Proposed Changes

- GetMemoryUsage: int64_t -> uint64_t
- GetMemoryUsageDetail: std::string (JSON) -> std::unordered_map<std::string, uint64_t>
- GetEstimateBuildMemory -> EstimateBuildMemory, int64_t -> uint64_t
- current_memory_usage_ atomic: int64_t -> uint64_t
- HGraph GetMemoryUsageDetail now uses GetMemoryUsage() per component for runtime consistency
- Updated all index implementations, datacell layer, tests, and eval tools


Fixes #2387

