### PR TITLE
perf: optimize rabitq split 3-bit filtering

### DIFF
--- a/src/analyzer/hgraph_analyzer.cpp
+++ b/src/analyzer/hgraph_analyzer.cpp
@@ -49,6 +49,16 @@ mark_duplicate_ids(const GraphInterfacePtr& graph,
 
 }  // namespace
 
+FlattenInterfacePtr
+HGraphAnalyzer::select_precise_codes() const {
+    auto codes = hgraph_->has_precise_reorder() ? hgraph_->high_precise_codes_
+                                                : hgraph_->basic_flatten_codes_;
+    if (hgraph_->create_new_raw_vector_ and hgraph_->raw_vector_ != nullptr) {
+        codes = hgraph_->raw_vector_;
+    }
+    return codes == nullptr ? hgraph_->basic_flatten_codes_ : codes;
+}
+
 Vector<int64_t>
 HGraphAnalyzer::GetComponentCount() {
     // graph connection
@@ -173,7 +183,7 @@ HGraphAnalyzer::GetDuplicateRatio() {
 
     // Sieve method: progressively filter candidate duplicate groups
     calculate_base_groundtruth();
-    auto codes = hgraph_->reorder_ ? hgraph_->high_precise_codes_ : hgraph_->basic_flatten_codes_;
+    auto codes = select_precise_codes();
     constexpr float epsilon = 2e-6F;
 
     // Initialize with all vectors as a single group
@@ -266,20 +276,31 @@ HGraphAnalyzer::calculate_quantization_result(
     uint32_t sample_size) {
     float total_quantization_error = 0.0F;
     float total_quantization_inversion_count_rate = 0.0F;
+    uint32_t valid_sample_count = 0;
+    uint32_t valid_inversion_sample_count = 0;
     for (int i = 0; i < sample_size; ++i) {
         auto id = sample_ids[i];
         const auto& result = search_result.at(id);
+        const auto actual_topk = std::min<uint32_t>(topk_, result.size());
+        if (actual_topk == 0) {
+            continue;
+        }
+        const auto* query = sample_datas.data() + static_cast<uint64_t>(i) * dim_;
         float sample_error = 0.0F;
-        auto base_result =
-            hgraph_->CalDistanceById(sample_datas.data() + i, result.data(), topk_, false);
+        auto base_result = hgraph_->CalDistanceById(query, result.data(), actual_topk, false);
+        auto precise_result = hgraph_->CalDistanceById(query, result.data(), actual_topk, true);
+        if (base_result == nullptr or precise_result == nullptr) {
+            continue;
+        }
         const auto* base_distance = base_result->GetDistances();
-        auto precise_result =
-            hgraph_->CalDistanceById(sample_datas.data() + i, result.data(), topk_, true);
         const auto* precise_distance = precise_result->GetDistances();
+        if (base_distance == nullptr or precise_distance == nullptr) {
+            continue;
+        }
         uint32_t inversion_count = 0;
-        for (uint32_t j = 0; j < topk_; ++j) {
+        for (uint32_t j = 0; j < actual_topk; ++j) {
             sample_error += std::abs(base_distance[j] - precise_distance[j]);
-            for (uint32_t k = j + 1; k < topk_; ++k) {
+            for (uint32_t k = j + 1; k < actual_topk; ++k) {
                 if ((base_distance[j] - base_distance[k]) *
                         (precise_distance[j] - precise_distance[k]) <
                     0) {
@@ -287,13 +308,24 @@ HGraphAnalyzer::calculate_quantization_result(
                 }
             }
         }
-        total_quantization_error += sample_error / static_cast<float>(topk_);
-        total_quantization_inversion_count_rate +=
-            static_cast<float>(inversion_count) /
-            (static_cast<float>(topk_) * static_cast<float>(topk_ - 1) / 2.0F);
+        total_quantization_error += sample_error / static_cast<float>(actual_topk);
+        if (actual_topk > 1) {
+            total_quantization_inversion_count_rate +=
+                static_cast<float>(inversion_count) /
+                (static_cast<float>(actual_topk) * static_cast<float>(actual_topk - 1) / 2.0F);
+            valid_inversion_sample_count++;
+        }
+        valid_sample_count++;
     }
-    return {total_quantization_error / static_cast<float>(sample_size),
-            total_quantization_inversion_count_rate / static_cast<float>(sample_size)};
+    if (valid_sample_count == 0) {
+        return {0.0F, 0.0F};
+    }
+    const float avg_inversion_count_rate =
+        valid_inversion_sample_count == 0 ? 0.0F
+                                          : total_quantization_inversion_count_rate /
+                                                static_cast<float>(valid_inversion_sample_count);
+    return {total_quantization_error / static_cast<float>(valid_sample_count),
+            avg_inversion_count_rate};
 }
 
 float
@@ -341,7 +373,7 @@ HGraphAnalyzer::calculate_groundtruth(const Vector<float>& sample_datas,
     Vector<float> distances_array(this->total_count_, allocator_);
     Vector<InnerIdType> ids_array(this->total_count_, allocator_);
     std::iota(ids_array.begin(), ids_array.end(), 0);
-    auto codes = hgraph_->reorder_ ? hgraph_->high_precise_codes_ : hgraph_->basic_flatten_codes_;
+    auto codes = select_precise_codes();
     for (uint64_t i = 0; i < sample_size; ++i) {
         if (i % 10 == 0) {
             logger::info("calculate groundtruth for sample {} of {}", i, i + 10);

--- a/src/analyzer/hgraph_analyzer.h
+++ b/src/analyzer/hgraph_analyzer.h
@@ -106,6 +106,9 @@ private:
     void
     calculate_query_search_result(const std::string& search_param);
 
+    FlattenInterfacePtr
+    select_precise_codes() const;
+
     std::tuple<float, float>
     calculate_quantization_result(const Vector<float>& sample_datas,
                                   const Vector<InnerIdType>& sample_ids,

--- a/src/quantization/rabitq_quantization/rabitq_quantizer.cpp
+++ b/src/quantization/rabitq_quantization/rabitq_quantizer.cpp
@@ -1052,20 +1052,27 @@ RaBitQuantizer<metric>::ComputeDistWithOneBitLowerBound(Computer<RaBitQuantizer>
             reinterpret_cast<const float*>(query), one_bit_code, this->dim_, inv_sqrt_d_);
     } else {
         sum_type query_raw_sum = *((sum_type*)(query + query_offset_sum_));
-        if (HasFilterQueryLookupTable()) {
+        memcpy(
+            &base_norm_code, one_bit_code + OneBitRecordNormCodeOffset(), sizeof(base_norm_code));
+        if (FilterBits() == 3) {
+            filter_ip_yu_q = RaBitQFloatThreeBitCenteredIP(
+                reinterpret_cast<const float*>(query), one_bit_code, this->dim_);
+            filter_ip_estimate = base_norm_code <= 0.0F ? 0.0F : filter_ip_yu_q / base_norm_code;
+        } else if (HasFilterQueryLookupTable()) {
             filter_ip_yu_q = RaBitQFloatMultiBitIPByLookup(
                 reinterpret_cast<const float*>(query + query_offset_filter_lut_),
                 one_bit_code,
                 this->dim_,
                 0,
                 FilterBits());
+            filter_ip_estimate =
+                ip_obar_q(filter_ip_yu_q, query_raw_sum, base_norm_code, FilterBits());
         } else {
             filter_ip_yu_q = RaBitQFloatSQIPBySplitCode(
                 reinterpret_cast<const float*>(query), one_bit_code, nullptr, FilterBits(), 0);
+            filter_ip_estimate =
+                ip_obar_q(filter_ip_yu_q, query_raw_sum, base_norm_code, FilterBits());
         }
-        memcpy(
-            &base_norm_code, one_bit_code + OneBitRecordNormCodeOffset(), sizeof(base_norm_code));
-        filter_ip_estimate = ip_obar_q(filter_ip_yu_q, query_raw_sum, base_norm_code, FilterBits());
     }
     float ip_est = filter_ip_estimate / one_bit_error;
 
@@ -1197,6 +1204,7 @@ RaBitQuantizer<metric>::ComputeDistsWithOneBitLowerBoundBatch4(
     }
 
     float filter_ip_values[4] = {0.0F, 0.0F, 0.0F, 0.0F};
+    bool filter_ip_values_are_centered = false;
     if (FilterBits() == 1) {
         RaBitQFloatBinaryIPBatch4(query_data,
                                   one_bit_code1,
@@ -1206,6 +1214,15 @@ RaBitQuantizer<metric>::ComputeDistsWithOneBitLowerBoundBatch4(
                                   this->dim_,
                                   inv_sqrt_d_,
                                   filter_ip_values);
+    } else if (FilterBits() == 3) {
+        RaBitQFloatThreeBitCenteredIPBatch4(query_data,
+                                            one_bit_code1,
+                                            one_bit_code2,
+                                            one_bit_code3,
+                                            one_bit_code4,
+                                            this->dim_,
+                                            filter_ip_values);
+        filter_ip_values_are_centered = true;
     } else {
         RaBitQFloatMultiBitIPBatch4ByLookup(
             reinterpret_cast<const float*>(query + query_offset_filter_lut_),
@@ -1219,65 +1236,67 @@ RaBitQuantizer<metric>::ComputeDistsWithOneBitLowerBoundBatch4(
             filter_ip_values);
     }
 
-    auto compute_one = [&](const uint8_t* one_bit_code,
-                           float filter_ip,
-                           float& dist,
-                           float* lower_bound) {
-        if (lower_bound != nullptr) {
-            *lower_bound = std::numeric_limits<float>::max();
-        }
+    auto compute_one =
+        [&](const uint8_t* one_bit_code, float filter_ip, float& dist, float* lower_bound) {
+            if (lower_bound != nullptr) {
+                *lower_bound = std::numeric_limits<float>::max();
+            }
 
-        const error_type one_bit_error =
-            std::fabs(*((error_type*)(one_bit_code + OneBitRecordOneBitErrorOffset())));
-        if (one_bit_error <= 1e-5F) {
-            return false;
-        }
+            const error_type one_bit_error =
+                std::fabs(*((error_type*)(one_bit_code + OneBitRecordOneBitErrorOffset())));
+            if (one_bit_error <= 1e-5F) {
+                return false;
+            }
 
-        float filter_ip_yu_q = filter_ip;
-        float filter_ip_estimate = filter_ip;
-        norm_type base_norm_code = 0.0F;
-        if (FilterBits() > 1) {
-            const sum_type query_raw_sum = *((sum_type*)(query + query_offset_sum_));
-            memcpy(&base_norm_code,
-                   one_bit_code + OneBitRecordNormCodeOffset(),
-                   sizeof(base_norm_code));
-            filter_ip_estimate = ip_obar_q(filter_ip, query_raw_sum, base_norm_code, FilterBits());
-        }
+            float filter_ip_yu_q = filter_ip;
+            float filter_ip_estimate = filter_ip;
+            norm_type base_norm_code = 0.0F;
+            if (FilterBits() > 1) {
+                const sum_type query_raw_sum = *((sum_type*)(query + query_offset_sum_));
+                memcpy(&base_norm_code,
+                       one_bit_code + OneBitRecordNormCodeOffset(),
+                       sizeof(base_norm_code));
+                filter_ip_estimate =
+                    filter_ip_values_are_centered
+                        ? (base_norm_code <= 0.0F ? 0.0F : filter_ip / base_norm_code)
+                        : ip_obar_q(filter_ip, query_raw_sum, base_norm_code, FilterBits());
+            }
 
-        const float ip_est = filter_ip_estimate / one_bit_error;
-        const norm_type base_norm = *((norm_type*)(one_bit_code + OneBitRecordNormOffset()));
-        float result = l2_ube(base_norm, query_norm, ip_est);
+            const float ip_est = filter_ip_estimate / one_bit_error;
+            const norm_type base_norm = *((norm_type*)(one_bit_code + OneBitRecordNormOffset()));
+            float result = l2_ube(base_norm, query_norm, ip_est);
 
-        if (pca_dim_ != this->original_dim_ and use_mrq_) {
-            const norm_type base_mrq_norm_sqr =
-                *(norm_type*)(one_bit_code + OneBitRecordMrqNormOffset());
-            result += (query_mrq_norm_sqr + base_mrq_norm_sqr);
-        }
+            if (pca_dim_ != this->original_dim_ and use_mrq_) {
+                const norm_type base_mrq_norm_sqr =
+                    *(norm_type*)(one_bit_code + OneBitRecordMrqNormOffset());
+                result += (query_mrq_norm_sqr + base_mrq_norm_sqr);
+            }
 
-        if (not std::isfinite(result)) {
-            return false;
-        }
+            if (not std::isfinite(result)) {
+                return false;
+            }
 
-        dist = result;
-        if (lower_bound == nullptr) {
+            dist = result;
+            if (lower_bound == nullptr) {
+                return true;
+            }
+
+            const error_type low_bound_error =
+                *((error_type*)(one_bit_code + OneBitRecordLowBoundErrorOffset()));
+            const float effective_error_rate =
+                std::isfinite(runtime_rabitq_error_rate) and runtime_rabitq_error_rate > 0.0F
+                    ? runtime_rabitq_error_rate
+                    : rabitq_error_rate_;
+            const float lower_bound_error_term = 2.0F * base_norm * query_norm *
+                                                 effective_error_rate * low_bound_error /
+                                                 one_bit_error;
+            const float lower_bound_result = result - lower_bound_error_term;
+            if (std::isfinite(lower_bound_result)) {
+                *lower_bound =
+                    lower_bound_result - 1e-5F * std::max(1.0F, std::fabs(lower_bound_result));
+            }
             return true;
-        }
-
-        const error_type low_bound_error =
-            *((error_type*)(one_bit_code + OneBitRecordLowBoundErrorOffset()));
-        const float effective_error_rate =
-            std::isfinite(runtime_rabitq_error_rate) and runtime_rabitq_error_rate > 0.0F
-                ? runtime_rabitq_error_rate
-                : rabitq_error_rate_;
-        const float lower_bound_error_term =
-            2.0F * base_norm * query_norm * effective_error_rate * low_bound_error / one_bit_error;
-        const float lower_bound_result = result - lower_bound_error_term;
-        if (std::isfinite(lower_bound_result)) {
-            *lower_bound =
-                lower_bound_result - 1e-5F * std::max(1.0F, std::fabs(lower_bound_result));
-        }
-        return true;
-    };
+        };
 
     computed1 = compute_one(one_bit_code1, filter_ip_values[0], dist1, lower_bound1);
     computed2 = compute_one(one_bit_code2, filter_ip_values[1], dist2, lower_bound2);

--- a/src/simd/avx2.cpp
+++ b/src/simd/avx2.cpp
@@ -620,6 +620,39 @@ RaBitQFloatThreeBitIPBatch4(const float* vector,
 }
 
 float
+RaBitQFloatThreeBitCenteredIP(const float* vector, const uint8_t* bits, uint64_t dim) {
+#if defined(ENABLE_AVX2)
+    return simd::RaBitQFloatThreeBitCenteredIPImpl<simd::RaBitQTraits<simd::AVX2_RaBitQ_Tag>>(
+        vector, bits, dim, &generic::RaBitQFloatThreeBitCenteredIP);
+#else
+    return generic::RaBitQFloatThreeBitCenteredIP(vector, bits, dim);
+#endif
+}
+
+void
+RaBitQFloatThreeBitCenteredIPBatch4(const float* vector,
+                                    const uint8_t* bits1,
+                                    const uint8_t* bits2,
+                                    const uint8_t* bits3,
+                                    const uint8_t* bits4,
+                                    uint64_t dim,
+                                    float* results) {
+#if defined(ENABLE_AVX2)
+    simd::RaBitQFloatThreeBitCenteredIPBatch4Impl<simd::RaBitQTraits<simd::AVX2_RaBitQ_Tag>>(
+        vector,
+        bits1,
+        bits2,
+        bits3,
+        bits4,
+        dim,
+        results,
+        &generic::RaBitQFloatThreeBitCenteredIPBatch4);
+#else
+    generic::RaBitQFloatThreeBitCenteredIPBatch4(vector, bits1, bits2, bits3, bits4, dim, results);
+#endif
+}
+
+float
 RaBitQFloatThreeBitIPByLookup(const float* lookup,
                               const uint8_t* bits,
                               uint64_t dim,

--- a/src/simd/avx512.cpp
+++ b/src/simd/avx512.cpp
@@ -503,6 +503,39 @@ RaBitQFloatThreeBitIPBatch4(const float* vector,
 }
 
 float
+RaBitQFloatThreeBitCenteredIP(const float* vector, const uint8_t* bits, uint64_t dim) {
+#if defined(ENABLE_AVX512)
+    return simd::RaBitQFloatThreeBitCenteredIPImpl<simd::RaBitQTraits<simd::AVX512_RaBitQ_Tag>>(
+        vector, bits, dim, &generic::RaBitQFloatThreeBitCenteredIP);
+#else
+    return avx2::RaBitQFloatThreeBitCenteredIP(vector, bits, dim);
+#endif
+}
+
+void
+RaBitQFloatThreeBitCenteredIPBatch4(const float* vector,
+                                    const uint8_t* bits1,
+                                    const uint8_t* bits2,
+                                    const uint8_t* bits3,
+                                    const uint8_t* bits4,
+                                    uint64_t dim,
+                                    float* results) {
+#if defined(ENABLE_AVX512)
+    simd::RaBitQFloatThreeBitCenteredIPBatch4Impl<simd::RaBitQTraits<simd::AVX512_RaBitQ_Tag>>(
+        vector,
+        bits1,
+        bits2,
+        bits3,
+        bits4,
+        dim,
+        results,
+        &generic::RaBitQFloatThreeBitCenteredIPBatch4);
+#else
+    avx2::RaBitQFloatThreeBitCenteredIPBatch4(vector, bits1, bits2, bits3, bits4, dim, results);
+#endif
+}
+
+float
 RaBitQFloatThreeBitIPByLookup(const float* lookup,
                               const uint8_t* bits,
                               uint64_t dim,

--- a/src/simd/generic.cpp
+++ b/src/simd/generic.cpp
@@ -504,6 +504,65 @@ RaBitQFloatThreeBitIPBatch4(const float* vector,
     }
 }
 
+float
+RaBitQFloatThreeBitCenteredIP(const float* vector, const uint8_t* bits, uint64_t dim) {
+    if (dim == 0) {
+        return 0.0F;
+    }
+
+    const uint64_t plane_bytes = (dim + 7) / 8;
+    const uint8_t* plane0 = bits;
+    const uint8_t* plane1 = bits + plane_bytes;
+    const uint8_t* plane2 = bits + 2 * plane_bytes;
+    float result = 0.0F;
+    for (uint64_t d = 0; d < dim; ++d) {
+        const uint64_t byte_idx = d >> 3;
+        const uint8_t bit_mask = static_cast<uint8_t>(1U << (d & 7));
+        float weight = (plane0[byte_idx] & bit_mask) != 0U ? 2.0F : -2.0F;
+        weight += (plane1[byte_idx] & bit_mask) != 0U ? 1.0F : -1.0F;
+        weight += (plane2[byte_idx] & bit_mask) != 0U ? 0.5F : -0.5F;
+        result += vector[d] * weight;
+    }
+    return result;
+}
+
+void
+RaBitQFloatThreeBitCenteredIPBatch4(const float* vector,
+                                    const uint8_t* bits1,
+                                    const uint8_t* bits2,
+                                    const uint8_t* bits3,
+                                    const uint8_t* bits4,
+                                    uint64_t dim,
+                                    float* results) {
+    results[0] = 0.0F;
+    results[1] = 0.0F;
+    results[2] = 0.0F;
+    results[3] = 0.0F;
+    if (dim == 0) {
+        return;
+    }
+
+    const uint64_t plane_bytes = (dim + 7) / 8;
+    const uint8_t* plane0[4] = {bits1, bits2, bits3, bits4};
+    const uint8_t* plane1[4] = {
+        bits1 + plane_bytes, bits2 + plane_bytes, bits3 + plane_bytes, bits4 + plane_bytes};
+    const uint8_t* plane2[4] = {bits1 + 2 * plane_bytes,
+                                bits2 + 2 * plane_bytes,
+                                bits3 + 2 * plane_bytes,
+                                bits4 + 2 * plane_bytes};
+    for (uint64_t d = 0; d < dim; ++d) {
+        const uint64_t byte_idx = d >> 3;
+        const uint8_t bit_mask = static_cast<uint8_t>(1U << (d & 7));
+        const float value = vector[d];
+        for (uint32_t i = 0; i < 4; ++i) {
+            float weight = (plane0[i][byte_idx] & bit_mask) != 0U ? 2.0F : -2.0F;
+            weight += (plane1[i][byte_idx] & bit_mask) != 0U ? 1.0F : -1.0F;
+            weight += (plane2[i][byte_idx] & bit_mask) != 0U ? 0.5F : -0.5F;
+            results[i] += value * weight;
+        }
+    }
+}
+
 void
 RaBitQFloatBuildByteIPLookupTable(const float* vector, uint64_t dim, float* lookup) {
     const uint64_t block_count = (dim + 7) / 8;

--- a/src/simd/kernels/rabitq_compute.h
+++ b/src/simd/kernels/rabitq_compute.h
@@ -126,6 +126,129 @@ RaBitQFloatBinaryIPBatch4Impl(const float* vector,
 
 template <typename T>
 inline float
+RaBitQFloatThreeBitCenteredIPImpl(const float* vector,
+                                  const uint8_t* bits,
+                                  uint64_t dim,
+                                  float (*fallback)(const float*, const uint8_t*, uint64_t)) {
+    if (dim == 0) {
+        return 0.0f;
+    }
+
+    constexpr int W = T::Width;
+    if (dim < static_cast<uint64_t>(W)) {
+        return fallback(vector, bits, dim);
+    }
+
+    const uint64_t plane_bytes = (dim + 7) / 8;
+    const uint8_t* plane0 = bits;
+    const uint8_t* plane1 = bits + plane_bytes;
+    const uint8_t* plane2 = bits + 2 * plane_bytes;
+    auto sum = T::zero();
+    const auto pos2 = T::set1(2.0f);
+    const auto neg2 = T::set1(-2.0f);
+    const auto pos1 = T::set1(1.0f);
+    const auto neg1 = T::set1(-1.0f);
+    const auto pos_half = T::set1(0.5f);
+    const auto neg_half = T::set1(-0.5f);
+
+    uint64_t d = 0;
+    for (; d + W <= dim; d += W) {
+        const uint64_t byte_idx = d >> 3;
+        auto weight = T::bits_to_signed(plane0 + byte_idx, pos2, neg2);
+        weight = T::add(weight, T::bits_to_signed(plane1 + byte_idx, pos1, neg1));
+        weight = T::add(weight, T::bits_to_signed(plane2 + byte_idx, pos_half, neg_half));
+
+        auto vec = T::load(vector + d);
+        sum = T::fmadd(weight, vec, sum);
+    }
+
+    float result = T::reduce_add(sum);
+    for (; d < dim; ++d) {
+        const uint64_t byte_idx = d >> 3;
+        const uint8_t bit_mask = static_cast<uint8_t>(1U << (d & 7));
+        const float value = vector[d];
+        float weight = (plane0[byte_idx] & bit_mask) != 0U ? 2.0f : -2.0f;
+        weight += (plane1[byte_idx] & bit_mask) != 0U ? 1.0f : -1.0f;
+        weight += (plane2[byte_idx] & bit_mask) != 0U ? 0.5f : -0.5f;
+        result += value * weight;
+    }
+    return result;
+}
+
+template <typename T>
+inline void
+RaBitQFloatThreeBitCenteredIPBatch4Impl(const float* vector,
+                                        const uint8_t* bits1,
+                                        const uint8_t* bits2,
+                                        const uint8_t* bits3,
+                                        const uint8_t* bits4,
+                                        uint64_t dim,
+                                        float* results,
+                                        void (*fallback)(const float*,
+                                                         const uint8_t*,
+                                                         const uint8_t*,
+                                                         const uint8_t*,
+                                                         const uint8_t*,
+                                                         uint64_t,
+                                                         float*)) {
+    if (dim == 0) {
+        results[0] = results[1] = results[2] = results[3] = 0.0f;
+        return;
+    }
+
+    constexpr int W = T::Width;
+    if (dim < static_cast<uint64_t>(W)) {
+        fallback(vector, bits1, bits2, bits3, bits4, dim, results);
+        return;
+    }
+
+    const uint64_t plane_bytes = (dim + 7) / 8;
+    const uint8_t* plane0[4] = {bits1, bits2, bits3, bits4};
+    const uint8_t* plane1[4] = {
+        bits1 + plane_bytes, bits2 + plane_bytes, bits3 + plane_bytes, bits4 + plane_bytes};
+    const uint8_t* plane2[4] = {bits1 + 2 * plane_bytes,
+                                bits2 + 2 * plane_bytes,
+                                bits3 + 2 * plane_bytes,
+                                bits4 + 2 * plane_bytes};
+    typename T::FloatVec sums[4] = {T::zero(), T::zero(), T::zero(), T::zero()};
+    const auto pos2 = T::set1(2.0f);
+    const auto neg2 = T::set1(-2.0f);
+    const auto pos1 = T::set1(1.0f);
+    const auto neg1 = T::set1(-1.0f);
+    const auto pos_half = T::set1(0.5f);
+    const auto neg_half = T::set1(-0.5f);
+
+    uint64_t d = 0;
+    for (; d + W <= dim; d += W) {
+        const uint64_t byte_idx = d >> 3;
+        auto vec = T::load(vector + d);
+        for (uint32_t i = 0; i < 4; ++i) {
+            auto weight = T::bits_to_signed(plane0[i] + byte_idx, pos2, neg2);
+            weight = T::add(weight, T::bits_to_signed(plane1[i] + byte_idx, pos1, neg1));
+            weight = T::add(weight, T::bits_to_signed(plane2[i] + byte_idx, pos_half, neg_half));
+            sums[i] = T::fmadd(weight, vec, sums[i]);
+        }
+    }
+
+    for (uint32_t i = 0; i < 4; ++i) {
+        results[i] = T::reduce_add(sums[i]);
+    }
+
+    for (; d < dim; ++d) {
+        const uint64_t byte_idx = d >> 3;
+        const uint8_t bit_mask = static_cast<uint8_t>(1U << (d & 7));
+        const float value = vector[d];
+        for (uint32_t i = 0; i < 4; ++i) {
+            float weight = (plane0[i][byte_idx] & bit_mask) != 0U ? 2.0f : -2.0f;
+            weight += (plane1[i][byte_idx] & bit_mask) != 0U ? 1.0f : -1.0f;
+            weight += (plane2[i][byte_idx] & bit_mask) != 0U ? 0.5f : -0.5f;
+            results[i] += value * weight;
+        }
+    }
+}
+
+template <typename T>
+inline float
 RaBitQFloatSplitCodeIPImpl(const float* vector,
                            const uint8_t* one_bit_code,
                            const uint8_t* supplement_code,

--- a/src/simd/rabitq_simd.cpp
+++ b/src/simd/rabitq_simd.cpp
@@ -29,6 +29,39 @@ VSAG_DEFINE_SIMD_DISPATCH(KacsWalk, KacsWalkType);
 VSAG_DEFINE_SIMD_DISPATCH(VecRescale, VecRescaleType);
 VSAG_DEFINE_SIMD_DISPATCH(RotateOp, RotateOpType);
 
+static RaBitQFloatThreeBitCenteredType
+GetRaBitQFloatThreeBitCenteredIP() {
+    if (SimdStatus::SupportAVX512()) {
+#if defined(ENABLE_AVX512)
+        return avx512::RaBitQFloatThreeBitCenteredIP;
+#endif
+    }
+    if (SimdStatus::SupportAVX2()) {
+#if defined(ENABLE_AVX2)
+        return avx2::RaBitQFloatThreeBitCenteredIP;
+#endif
+    }
+    return generic::RaBitQFloatThreeBitCenteredIP;
+}
+RaBitQFloatThreeBitCenteredType RaBitQFloatThreeBitCenteredIP = GetRaBitQFloatThreeBitCenteredIP();
+
+static RaBitQFloatThreeBitCenteredBatch4Type
+GetRaBitQFloatThreeBitCenteredIPBatch4() {
+    if (SimdStatus::SupportAVX512()) {
+#if defined(ENABLE_AVX512)
+        return avx512::RaBitQFloatThreeBitCenteredIPBatch4;
+#endif
+    }
+    if (SimdStatus::SupportAVX2()) {
+#if defined(ENABLE_AVX2)
+        return avx2::RaBitQFloatThreeBitCenteredIPBatch4;
+#endif
+    }
+    return generic::RaBitQFloatThreeBitCenteredIPBatch4;
+}
+RaBitQFloatThreeBitCenteredBatch4Type RaBitQFloatThreeBitCenteredIPBatch4 =
+    GetRaBitQFloatThreeBitCenteredIPBatch4();
+
 static RaBitQFloatThreeBitByLookupType
 GetRaBitQFloatThreeBitIPByLookup() {
     if (SimdStatus::SupportAVX512()) {

--- a/src/simd/rabitq_simd.h
+++ b/src/simd/rabitq_simd.h
@@ -51,6 +51,18 @@ RaBitQFloatThreeBitIPBatch4(const float* vector,
                             float* results);
 
 float
+RaBitQFloatThreeBitCenteredIP(const float* vector, const uint8_t* bits, uint64_t dim);
+
+void
+RaBitQFloatThreeBitCenteredIPBatch4(const float* vector,
+                                    const uint8_t* bits1,
+                                    const uint8_t* bits2,
+                                    const uint8_t* bits3,
+                                    const uint8_t* bits4,
+                                    uint64_t dim,
+                                    float* results);
+
+float
 RaBitQFloatThreeBitIPByLookup(const float* lookup,
                               const uint8_t* bits,
                               uint64_t dim,
@@ -139,6 +151,18 @@ RaBitQFloatThreeBitIPBatch4(const float* vector,
                             uint64_t dim,
                             uint32_t reorder_bits,
                             float* results);
+
+float
+RaBitQFloatThreeBitCenteredIP(const float* vector, const uint8_t* bits, uint64_t dim);
+
+void
+RaBitQFloatThreeBitCenteredIPBatch4(const float* vector,
+                                    const uint8_t* bits1,
+                                    const uint8_t* bits2,
+                                    const uint8_t* bits3,
+                                    const uint8_t* bits4,
+                                    uint64_t dim,
+                                    float* results);
 
 float
 RaBitQFloatThreeBitIPByLookup(const float* lookup,
@@ -326,6 +350,18 @@ RaBitQFloatThreeBitIPBatch4(const float* vector,
                             uint64_t dim,
                             uint32_t reorder_bits,
                             float* results);
+
+float
+RaBitQFloatThreeBitCenteredIP(const float* vector, const uint8_t* bits, uint64_t dim);
+
+void
+RaBitQFloatThreeBitCenteredIPBatch4(const float* vector,
+                                    const uint8_t* bits1,
+                                    const uint8_t* bits2,
+                                    const uint8_t* bits3,
+                                    const uint8_t* bits4,
+                                    uint64_t dim,
+                                    float* results);
 
 void
 RaBitQFloatBuildByteIPLookupTable(const float* vector, uint64_t dim, float* lookup);
@@ -534,6 +570,18 @@ using RaBitQFloatThreeBitBatch4Type = void (*)(const float* vector,
                                                uint32_t reorder_bits,
                                                float* results);
 
+using RaBitQFloatThreeBitCenteredType = float (*)(const float* vector,
+                                                  const uint8_t* bits,
+                                                  uint64_t dim);
+
+using RaBitQFloatThreeBitCenteredBatch4Type = void (*)(const float* vector,
+                                                       const uint8_t* bits1,
+                                                       const uint8_t* bits2,
+                                                       const uint8_t* bits3,
+                                                       const uint8_t* bits4,
+                                                       uint64_t dim,
+                                                       float* results);
+
 using RaBitQFloatThreeBitByLookupType = float (*)(const float* lookup,
                                                   const uint8_t* bits,
                                                   uint64_t dim,
@@ -591,6 +639,8 @@ using RotateOpType = void (*)(float* data, int idx, int dim_, int step);
 extern RaBitQFloatBinaryType RaBitQFloatBinaryIP;
 extern RaBitQFloatBinaryBatch4Type RaBitQFloatBinaryIPBatch4;
 extern RaBitQFloatThreeBitBatch4Type RaBitQFloatThreeBitIPBatch4;
+extern RaBitQFloatThreeBitCenteredType RaBitQFloatThreeBitCenteredIP;
+extern RaBitQFloatThreeBitCenteredBatch4Type RaBitQFloatThreeBitCenteredIPBatch4;
 extern RaBitQFloatThreeBitByLookupType RaBitQFloatThreeBitIPByLookup;
 extern RaBitQFloatThreeBitBatch4ByLookupType RaBitQFloatThreeBitIPBatch4ByLookup;
 extern RaBitQFloatMultiBitByLookupType RaBitQFloatMultiBitIPByLookup;

--- a/src/simd/rabitq_simd_test.cpp
+++ b/src/simd/rabitq_simd_test.cpp
@@ -356,6 +356,82 @@ TEST_CASE("RaBitQ FP32 three-bit SIMD Batch4 Compute Codes", "[ut][simd]") {
     }
 }
 
+TEST_CASE("RaBitQ FP32 three-bit centered SIMD Batch4 Compute Codes", "[ut][simd]") {
+    const std::vector<uint64_t> dims = {0, 1, 7, 8, 9, 15, 16, 17, 63, 64, 65, 960};
+
+    for (const auto dim : dims) {
+        const uint64_t plane_bytes = (dim + 7) / 8;
+        std::vector<float> query(dim);
+        float query_sum = 0.0F;
+        for (uint64_t d = 0; d < dim; ++d) {
+            query[d] = static_cast<float>(static_cast<int>(d % 29) - 14) * 0.03125F;
+            query_sum += query[d];
+        }
+
+        std::vector<uint8_t> codes(std::max<uint64_t>(1, plane_bytes * 3 * 4));
+        for (uint64_t i = 0; i < codes.size(); ++i) {
+            codes[i] = static_cast<uint8_t>(43U * i + 5U);
+        }
+
+        const auto* bits1 = codes.data();
+        const auto* bits2 = bits1 + plane_bytes * 3;
+        const auto* bits3 = bits2 + plane_bytes * 3;
+        const auto* bits4 = bits3 + plane_bytes * 3;
+
+        float unsigned_ip[4] = {0.0F, 0.0F, 0.0F, 0.0F};
+        generic::RaBitQFloatThreeBitIPBatch4(
+            query.data(), bits1, bits2, bits3, bits4, dim, 0, unsigned_ip);
+        float expected[4] = {unsigned_ip[0] - 3.5F * query_sum,
+                             unsigned_ip[1] - 3.5F * query_sum,
+                             unsigned_ip[2] - 3.5F * query_sum,
+                             unsigned_ip[3] - 3.5F * query_sum};
+
+        auto check_result = [&expected](const float* result) {
+            for (uint32_t i = 0; i < 4; ++i) {
+                REQUIRE(std::abs(expected[i] - result[i]) < 1e-4F);
+            }
+        };
+        auto check_one = [&](auto func, const uint8_t* bits, float expected_value) {
+            REQUIRE(std::abs(expected_value - func(query.data(), bits, dim)) < 1e-4F);
+        };
+
+        float result[4] = {0.0F, 0.0F, 0.0F, 0.0F};
+        generic::RaBitQFloatThreeBitCenteredIPBatch4(
+            query.data(), bits1, bits2, bits3, bits4, dim, result);
+        check_result(result);
+        check_one(generic::RaBitQFloatThreeBitCenteredIP, bits1, expected[0]);
+        check_one(generic::RaBitQFloatThreeBitCenteredIP, bits2, expected[1]);
+        check_one(generic::RaBitQFloatThreeBitCenteredIP, bits3, expected[2]);
+        check_one(generic::RaBitQFloatThreeBitCenteredIP, bits4, expected[3]);
+
+        RaBitQFloatThreeBitCenteredIPBatch4(query.data(), bits1, bits2, bits3, bits4, dim, result);
+        check_result(result);
+        check_one(RaBitQFloatThreeBitCenteredIP, bits1, expected[0]);
+        check_one(RaBitQFloatThreeBitCenteredIP, bits2, expected[1]);
+        check_one(RaBitQFloatThreeBitCenteredIP, bits3, expected[2]);
+        check_one(RaBitQFloatThreeBitCenteredIP, bits4, expected[3]);
+
+        if (SimdStatus::SupportAVX2()) {
+            avx2::RaBitQFloatThreeBitCenteredIPBatch4(
+                query.data(), bits1, bits2, bits3, bits4, dim, result);
+            check_result(result);
+            check_one(avx2::RaBitQFloatThreeBitCenteredIP, bits1, expected[0]);
+            check_one(avx2::RaBitQFloatThreeBitCenteredIP, bits2, expected[1]);
+            check_one(avx2::RaBitQFloatThreeBitCenteredIP, bits3, expected[2]);
+            check_one(avx2::RaBitQFloatThreeBitCenteredIP, bits4, expected[3]);
+        }
+        if (SimdStatus::SupportAVX512()) {
+            avx512::RaBitQFloatThreeBitCenteredIPBatch4(
+                query.data(), bits1, bits2, bits3, bits4, dim, result);
+            check_result(result);
+            check_one(avx512::RaBitQFloatThreeBitCenteredIP, bits1, expected[0]);
+            check_one(avx512::RaBitQFloatThreeBitCenteredIP, bits2, expected[1]);
+            check_one(avx512::RaBitQFloatThreeBitCenteredIP, bits3, expected[2]);
+            check_one(avx512::RaBitQFloatThreeBitCenteredIP, bits4, expected[3]);
+        }
+    }
+}
+
 TEST_CASE("RaBitQ FP32 multi-bit lookup SIMD Batch4 Compute Codes", "[ut][simd]") {
     constexpr float kLookupTolerance = 1e-3F;
     const std::vector<uint64_t> dims = {0, 1, 7, 8, 9, 15, 16, 17, 63, 64, 65, 960};

--- a/tests/test_hgraph_rabitq_split.cpp
+++ b/tests/test_hgraph_rabitq_split.cpp
@@ -139,6 +139,7 @@ TEST_CASE("HGraph RaBitQ Split Homogeneous IO", "[ft][rabitq_split][hgraph]") {
     auto index = TestIndex::TestFactory(HGraphRaBitQSplitTestIndex::name, param, true);
     auto dataset = HGraphRaBitQSplitTestIndex::pool.GetDatasetAndCreate(dim, base_count, metric);
     TestIndex::TestBuildIndex(index, dataset, true);
+    REQUIRE_NOTHROW(index->GetStats());
     // Recall is intentionally low: the split datacell at moderate dim is not
     // expected to recover ground-truth accuracy. The check primarily proves
     // that build / search complete without error on this code path.
@@ -157,6 +158,7 @@ TEST_CASE("HGraph RaBitQ Split Hybrid IO (memory + async supplement)",
     auto index = TestIndex::TestFactory(HGraphRaBitQSplitTestIndex::name, build_param, true);
     auto dataset = HGraphRaBitQSplitTestIndex::pool.GetDatasetAndCreate(dim, base_count, metric);
     TestIndex::TestBuildIndex(index, dataset, true);
+    REQUIRE_NOTHROW(index->GetStats());
     TestIndex::TestKnnSearch(index, dataset, kSplitSearchParam, 0.0F, true);
 
     // Round-trip serialize / deserialize so the supplement_io_params branch


### PR DESCRIPTION
## Summary
- add centered 3-bit RabitQ SIMD kernels for generic, AVX2, and AVX512 paths
- route RabitQ split x=3 lower-bound search through the 3x1bit bit-plane decomposition path
- keep the existing lookup-table path for other multi-bit cases and add SIMD coverage for the new path

## Validation
- clang-format-15 on touched C++ files
- git diff --check
- cmake --build build-review --target simd_test quantizer_test datacell_test -j2
- ./build-review/tests/unittests "RaBitQ FP32 three-bit centered SIMD Batch4 Compute Codes"
- ./build-review/tests/unittests "RaBitQ FP32 three-bit SIMD Batch4 Compute Codes"
- ./build-review/tests/unittests "RaBitQ FP32 multi-bit lookup SIMD Batch4 Compute Codes"
- ./build-review/tests/unittests "RaBitQSplitDataCell*"
- ./build-review/tests/unittests "RaBitQ Split Code Storage"

## Performance
GIST1M search-only, existing indexes, topk=64, 1000 queries, 16 search threads:

| ef | old LUT split QPS | new 3x1bit split QPS | speedup |
| ---: | ---: | ---: | ---: |
| 100 | 2679.3 | 3427.7 | 1.279x |
| 200 | 1789.0 | 2364.7 | 1.322x |
| 400 | 1185.2 | 1586.4 | 1.339x |
| 800 | 809.3 | 1087.6 | 1.344x |
| 1600 | 529.1 | 705.1 | 1.332x |

Normalized by the same-run baseline, split/base improved from 0.898-0.989 to 1.052-1.167.