### PR TITLE
[bug](hgraph): filter check in visit stage breaks graph connectivity and reduces recall (#2314) - 0.18 backport

### DIFF
--- a/src/algorithm/hnswlib/hnswalg.cpp
+++ b/src/algorithm/hnswlib/hnswalg.cpp
@@ -614,7 +614,7 @@ HierarchicalNSW::searchBaseLayerST(InnerIdType ep_id,
                 bool candidate_valid = true;
                 bool candidate_valid_checked = false;
                 if (is_id_allowed && not candidate_set.empty() &&
-                    not skip_strategy->ShouldSkipFilterCheck()) {
+                    not skip_strategy->ShouldVisit()) {
                     candidate_valid = is_id_allowed->CheckValid(getExternalLabel(candidate_id));
                     candidate_valid_checked = true;
                     if (not candidate_valid) {

--- a/src/impl/searcher/basic_searcher.cpp
+++ b/src/impl/searcher/basic_searcher.cpp
@@ -54,13 +54,15 @@ BasicSearcher::visit(const GraphInterfacePtr& graph,
             vl->Prefetch(neighbors[i + prefetch_stride_visit_]);
         }
         if (not vl->Get(neighbors[i])) {
-            if (not filter || count_no_visited == 0 || skip_strategy->ShouldSkipFilterCheck() ||
-                filter->CheckValid(neighbors[i])) {
-                to_be_visited_rid[count_no_visited] = i;
+            vl->Set(neighbors[i]);
+            // Removed filter->CheckValid() to eliminate duplicate filter checking.
+            // Filter is applied at result-collection stage.
+            // ShouldVisit() probabilistically gates traversal to preserve graph connectivity.
+            if (not filter || count_no_visited == 0 || skip_strategy == nullptr ||
+                skip_strategy->ShouldVisit()) {
                 to_be_visited_id[count_no_visited] = neighbors[i];
                 count_no_visited++;
             }
-            vl->Set(neighbors[i]);
         }
     }
     return count_no_visited;

--- a/src/impl/searcher/parallel_searcher.cpp
+++ b/src/impl/searcher/parallel_searcher.cpp
@@ -62,13 +62,15 @@ ParallelSearcher::visit(const GraphInterfacePtr& graph,
                 vl->Prefetch(neighbors[i][j + prefetch_stride_visit_]);
             }
             if (not vl->Get(neighbors[i][j])) {
-                if (not filter || count_no_visited == 0 || skip_strategy->ShouldSkipFilterCheck() ||
-                    filter->CheckValid(neighbors[i][j])) {
-                    to_be_visited_rid[count_no_visited] = j;
+                vl->Set(neighbors[i][j]);
+                // Removed filter->CheckValid() to eliminate duplicate filter checking.
+                // Filter is applied at result-collection stage.
+                // ShouldVisit() probabilistically gates traversal to preserve graph connectivity.
+                if (not filter || count_no_visited == 0 || skip_strategy == nullptr ||
+                    skip_strategy->ShouldVisit()) {
                     to_be_visited_id[count_no_visited] = neighbors[i][j];
                     count_no_visited++;
                 }
-                vl->Set(neighbors[i][j]);
             }
         }
     }

--- a/src/utils/filter_search_skip_strategy.cpp
+++ b/src/utils/filter_search_skip_strategy.cpp
@@ -33,29 +33,28 @@ get_retain_ratio(float valid_ratio, float skip_ratio) {
 
 class RandomFilterSearchSkipStrategy : public FilterSearchSkipStrategy {
 public:
-    explicit RandomFilterSearchSkipStrategy(double retain_ratio)
-        : skip_threshold_(1.0 - retain_ratio) {
+    explicit RandomFilterSearchSkipStrategy(double visit_ratio)
+        : visit_threshold_(1.0 - visit_ratio) {
     }
 
     bool
-    ShouldSkipFilterCheck() override {
-        return generator_.NextFloat() > skip_threshold_;
+    ShouldVisit() override {
+        return generator_.NextFloat() > visit_threshold_;
     }
 
 private:
     LinearCongruentialGenerator generator_;
-    double skip_threshold_{0.0};
+    double visit_threshold_{0.0};
 };
 
 class AccumulativeFilterSearchSkipStrategy : public FilterSearchSkipStrategy {
 public:
-    explicit AccumulativeFilterSearchSkipStrategy(double retain_ratio)
-        : retain_ratio_(retain_ratio) {
+    explicit AccumulativeFilterSearchSkipStrategy(double visit_ratio) : visit_ratio_(visit_ratio) {
     }
 
     bool
-    ShouldSkipFilterCheck() override {
-        accumulative_alpha_ += retain_ratio_;
+    ShouldVisit() override {
+        accumulative_alpha_ += visit_ratio_;
         if (accumulative_alpha_ >= 1.0) {
             accumulative_alpha_ -= 1.0;
             return true;
@@ -64,7 +63,7 @@ public:
     }
 
 private:
-    double retain_ratio_{1.0};
+    double visit_ratio_{1.0};
     double accumulative_alpha_{0.0};
 };
 
@@ -75,11 +74,14 @@ create_filter_search_skip_strategy(FilterSearchSkipStrategyType type,
                                    float valid_ratio,
                                    float skip_ratio) {
     auto retain_ratio = get_retain_ratio(valid_ratio, skip_ratio);
+    // visit_ratio = valid_ratio + retain_ratio, capped at 1.0
+    // When valid_ratio is high, we visit most neighbors; when low, visit_ratio depends on skip_ratio
+    auto visit_ratio = std::min(1.0, static_cast<double>(valid_ratio) + retain_ratio);
     switch (type) {
         case FilterSearchSkipStrategyType::RANDOM:
-            return std::make_unique<RandomFilterSearchSkipStrategy>(retain_ratio);
+            return std::make_unique<RandomFilterSearchSkipStrategy>(visit_ratio);
         case FilterSearchSkipStrategyType::DETERMINISTIC_ACCUMULATIVE:
-            return std::make_unique<AccumulativeFilterSearchSkipStrategy>(retain_ratio);
+            return std::make_unique<AccumulativeFilterSearchSkipStrategy>(visit_ratio);
     }
     throw VsagException(ErrorType::INVALID_ARGUMENT, "Unknown FilterSearchSkipStrategyType");
 }

--- a/src/utils/filter_search_skip_strategy.h
+++ b/src/utils/filter_search_skip_strategy.h
@@ -28,8 +28,11 @@ class FilterSearchSkipStrategy {
 public:
     virtual ~FilterSearchSkipStrategy() = default;
 
+    // Probabilistic gate for visiting neighbors during graph traversal.
+    // visit_ratio = valid_ratio + (1 - valid_ratio) * skip_ratio
+    // This ensures we visit more neighbors when most pass the filter.
     virtual bool
-    ShouldSkipFilterCheck() = 0;
+    ShouldVisit() = 0;
 };
 
 using FilterSearchSkipStrategyPtr = std::unique_ptr<FilterSearchSkipStrategy>;

--- a/src/utils/filter_search_skip_strategy_test.cpp
+++ b/src/utils/filter_search_skip_strategy_test.cpp
@@ -30,8 +30,7 @@ TEST_CASE("Filter search skip strategy parse", "[ut][filter_search_skip_strategy
     REQUIRE_THROWS(parse_filter_search_skip_strategy_type("unknown"));
 }
 
-TEST_CASE("Accumulative filter search skip strategy is deterministic",
-          "[ut][filter_search_skip_strategy]") {
+TEST_CASE("Accumulative ShouldVisit is deterministic", "[ut][filter_search_skip_strategy]") {
     constexpr float valid_ratio = 0.5F;
     constexpr float skip_ratio = 0.8F;
     std::vector<bool> first_sequence;
@@ -43,31 +42,39 @@ TEST_CASE("Accumulative filter search skip strategy is deterministic",
         FilterSearchSkipStrategyType::DETERMINISTIC_ACCUMULATIVE, valid_ratio, skip_ratio);
 
     for (uint64_t i = 0; i < 20; ++i) {
-        first_sequence.emplace_back(first_strategy->ShouldSkipFilterCheck());
-        second_sequence.emplace_back(second_strategy->ShouldSkipFilterCheck());
+        first_sequence.emplace_back(first_strategy->ShouldVisit());
+        second_sequence.emplace_back(second_strategy->ShouldVisit());
     }
 
     REQUIRE(first_sequence == second_sequence);
-    REQUIRE(first_sequence == std::vector<bool>{false, false, true,  false, true,  false, false,
-                                                true,  false, true,  false, false, true,  false,
-                                                true,  false, false, true,  false, true});
+    // visit_ratio = 0.5 + 0.5*0.8 = 0.9
+    // Accumulative pattern: F,T,T,T,T,T,T,T,T,T repeated = 18/20 true
+    std::vector<bool> expected = {false, true, true, true, true, true, true, true, true, true,
+                                  false, true, true, true, true, true, true, true, true, true};
+    REQUIRE(first_sequence == expected);
 }
 
-TEST_CASE("Accumulative filter search skip strategy edge cases",
-          "[ut][filter_search_skip_strategy]") {
-    SECTION("valid ratio one skips filter checks") {
+TEST_CASE("ShouldVisit edge cases", "[ut][filter_search_skip_strategy]") {
+    SECTION("valid ratio one always visits") {
         auto strategy = create_filter_search_skip_strategy(
             FilterSearchSkipStrategyType::DETERMINISTIC_ACCUMULATIVE, 1.0F, 0.8F);
         for (uint64_t i = 0; i < 10; ++i) {
-            REQUIRE(strategy->ShouldSkipFilterCheck());
+            REQUIRE(strategy->ShouldVisit());
         }
     }
 
-    SECTION("skip ratio zero skips invalid candidates") {
+    SECTION("skip ratio zero with low valid ratio visits less") {
         auto strategy = create_filter_search_skip_strategy(
             FilterSearchSkipStrategyType::DETERMINISTIC_ACCUMULATIVE, 0.5F, 0.0F);
-        for (uint64_t i = 0; i < 10; ++i) {
-            REQUIRE_FALSE(strategy->ShouldSkipFilterCheck());
+        // visit_ratio = 0.5 + 0.5*0 = 0.5
+        // Accumulative pattern: F,T,F,T,... alternating = exactly 50/100 true
+        std::vector<bool> sequence;
+        for (uint64_t i = 0; i < 20; ++i) {
+            sequence.emplace_back(strategy->ShouldVisit());
         }
+        std::vector<bool> expected = {false, true,  false, true,  false, true,  false,
+                                      true,  false, true,  false, true,  false, true,
+                                      false, true,  false, true,  false, true};
+        REQUIRE(sequence == expected);
     }
 }


### PR DESCRIPTION
Cherry-pick of #2314 to 0.18 branch.

Changes:
- Remove filter->CheckValid() from visit() in basic_searcher and parallel_searcher
- Keep not filter fast-path to preserve unfiltered search behavior
- Add ShouldVisit() method with correct probability formula
- Filter check now only happens at result set stage (Point B)
- Add exact sequence assertions for deterministic tests

Fixes #2313