### PR TITLE
refactor: remove virtual destructor from BasicIO to restore CRTP zero-overhead

### DIFF
--- a/src/io/async_io/async_io.h
+++ b/src/io/async_io/async_io.h
@@ -65,7 +65,7 @@ public:
     /**
      * @brief Destructor that closes file descriptors and optionally removes the file.
      */
-    ~AsyncIO() override;
+    ~AsyncIO();
 
 public:
     /**

--- a/src/io/buffer_io/buffer_io.h
+++ b/src/io/buffer_io/buffer_io.h
@@ -69,7 +69,7 @@ public:
      *
      * If exist_file_ is false (file was newly created), the file is removed.
      */
-    ~BufferIO() override {
+    ~BufferIO() {
         close(this->fd_);
         // remove file
         if (not this->exist_file_) {

--- a/src/io/common/basic_io.h
+++ b/src/io/common/basic_io.h
@@ -54,11 +54,6 @@ public:
     explicit BasicIO<IOTmpl>(Allocator* allocator) : allocator_(allocator){};
 
     /**
-     * @brief Virtual destructor to ensure proper cleanup in derived classes.
-     */
-    virtual ~BasicIO() = default;
-
-    /**
      * @brief Writes data to the IO object at a specified offset.
      *
      * If the IO object has a WriteImpl method, it is called.
@@ -262,6 +257,19 @@ public:
     uint64_t start_{0};
 
 protected:
+    /**
+     * @brief Protected non-virtual destructor.
+     *
+     * BasicIO uses CRTP for static polymorphism, so dynamic dispatch is never needed.
+     * The destructor is non-virtual to avoid introducing a vptr.
+     *
+     * The destructor is protected (not public) to prevent deletion through a raw
+     * BasicIO pointer at compile time. Note that std::shared_ptr<BasicIO<IOTmpl>>
+     * (used in some datacells) remains safe because the deleter is bound to the
+     * concrete IOTmpl type at construction time (e.g. via std::make_shared<IOTmpl>).
+     */
+    ~BasicIO() = default;
+
     /**
      * @brief Checks if the given offset is valid.
      *

--- a/src/io/memory_block_io/memory_block_io.h
+++ b/src/io/memory_block_io/memory_block_io.h
@@ -66,7 +66,7 @@ public:
     /**
      * @brief Destructor that deallocates all memory blocks.
      */
-    ~MemoryBlockIO() override;
+    ~MemoryBlockIO();
 
     /**
      * @brief Writes data to the blocks at a specified offset.

--- a/src/io/memory_io/memory_io.h
+++ b/src/io/memory_io/memory_io.h
@@ -78,7 +78,7 @@ public:
     /**
      * @brief Destructor that deallocates the memory buffer.
      */
-    ~MemoryIO() override {
+    ~MemoryIO() {
         this->allocator_->Deallocate(buffer_);
     }
 

--- a/src/io/mmap_io/mmap_io.h
+++ b/src/io/mmap_io/mmap_io.h
@@ -66,7 +66,7 @@ public:
     /**
      * @brief Destructor that unmaps memory and closes file; optionally removes file.
      */
-    ~MMapIO() override;
+    ~MMapIO();
 
     /**
      * @brief Writes data to the mapped memory at a specified offset.

--- a/src/io/noncontinuous_io/noncontinuous_io.h
+++ b/src/io/noncontinuous_io/noncontinuous_io.h
@@ -66,7 +66,7 @@ public:
     /**
      * @brief Default destructor.
      */
-    ~NonContinuousIO() override = default;
+    ~NonContinuousIO() = default;
 
     /**
      * @brief Writes data to non-continuous regions at a specified logical offset.

--- a/src/io/reader_io/reader_io.h
+++ b/src/io/reader_io/reader_io.h
@@ -64,7 +64,7 @@ public:
     /**
      * @brief Default destructor.
      */
-    ~ReaderIO() override = default;
+    ~ReaderIO() = default;
 
     /**
      * @brief Writes data to the IO object (no-op for read-only IO).


### PR DESCRIPTION
## Summary

Remove the unnecessary `virtual` destructor from `BasicIO<IOTmpl>` (CRTP base class) to eliminate the vptr overhead and restore the zero-overhead static polymorphism design.

## Changes

- `src/io/basic_io.h`: change `virtual ~BasicIO() = default;` to `protected: ~BasicIO() = default;`
- Remove `override` keyword from all 7 subclass destructors:
  - `MemoryIO`, `BufferIO`, `MMapIO`, `AsyncIO`, `ReaderIO`, `MemoryBlockIO`, `NonContinuousIO`

## Rationale

`BasicIO` uses CRTP for static polymorphism — all `*Impl` methods are dispatched via `static_cast<IOTmpl&>(*this)`. The virtual destructor was the only virtual function in the hierarchy, introducing an unnecessary vptr (8 bytes) per IO object. No IO object is ever deleted through a base pointer, so the virtual destructor serves no purpose.

## Impact

- **-8 bytes** per IO object (vptr elimination)
- Eliminates unnecessary virtual dispatch overhead
- `protected` destructor prevents external deletion through base pointer at compile time

Fixes: #2397