### PR TITLE
test(diskann): reduce pq_dim test runs from 3 to 1 in PR CI

### DIFF
--- a/tests/test_diskann.cpp
+++ b/tests/test_diskann.cpp
@@ -20,6 +20,7 @@
 #include <iostream>
 #include <nlohmann/json.hpp>
 
+#include "fixtures/core/random.h"
 #include "functest.h"
 #include "test_index.h"
 #include "vsag/errors.h"
@@ -146,7 +147,54 @@ TEST_CASE_METHOD(fixtures::DiskANNTestIndex,
     }
 }
 
-TEST_CASE_METHOD(fixtures::DiskANNTestIndex, "diskann pq_dim test", "[ft][diskann]") {
+TEST_CASE_METHOD(fixtures::DiskANNTestIndex, "(PR) diskann pq_dim test", "[ft][diskann][pr]") {
+    const std::vector<int> dims = {736, 1536, 2048, 2560, 3072};
+    const std::vector<std::string> all_metric_types = {"l2", "ip", "cosine"};
+    auto metric_type = fixtures::RandomSelect(all_metric_types)[0];
+    INFO("Randomly selected metric_type for PR CI: " << metric_type);
+    const std::string name = "diskann";
+    constexpr auto build_parameter_json = R"(
+        {{
+            "dtype": "float32",
+            "metric_type": "{}",
+            "dim": {},
+            "diskann": {{
+                "max_degree": 16,
+                "ef_construction": 200,
+                "pq_dims": {},
+                "pq_sample_rate": 0.5,
+                "use_pq_search": true
+            }}
+        }}
+    )";
+    constexpr auto search_param_template = R"(
+        {{
+            "diskann": {{
+                "ef_search": {},
+                "io_limit": 400,
+                "beam_search": 4,
+                "use_reorder": true
+            }}
+        }}
+    )";
+    for (auto dim : dims) {
+        auto build_parameters_str = fmt::format(build_parameter_json, metric_type, dim, dim / 4);
+        auto search_param = fmt::format(search_param_template, dim / 4);
+        auto param = GenerateDiskANNBuildParametersString(metric_type, dim);
+        auto index = TestFactory(name, param, true);
+        auto dataset = pool.GetDatasetAndCreate(dim, base_count, metric_type);
+        TestBuildIndex(index, dataset, true);
+        TestKnnSearch(index, dataset, search_param, 0.95, true);
+        TestRangeSearch(index, dataset, search_param, 0.95, 10, true);
+        TestRangeSearch(index, dataset, search_param, 0.45, 5, true);
+        TestFilterSearch(index, dataset, search_param, 0.95, true);
+        REQUIRE(index->GetIndexType() == vsag::IndexType::DISKANN);
+    }
+}
+
+TEST_CASE_METHOD(fixtures::DiskANNTestIndex,
+                 "(Daily) diskann pq_dim test",
+                 "[ft][diskann][daily]") {
     const std::vector<int> dims = {736, 1536, 2048, 2560, 3072};
     auto metric_type = GENERATE("l2", "ip", "cosine");
     const std::string name = "diskann";


### PR DESCRIPTION
## Summary

Reduce the  from 3 runs to 1 random run in PR CI by randomly selecting one metric_type from {l2, ip, cosine}. This saves ~5 minutes of CPU time per PR CI run.

Closes #2406

## Changes

- **PR version** (tagged ): Replaces  with  to randomly pick one metric_type, running only 1 test case instead of 3.
- **Daily version** (tagged ): Preserves the original full -based test for daily CI coverage of all 3 metric types.

## CI Behavior

| CI | Command | pq_dim runs | Coverage |
|---|---|---|---|
| PR CI |  | 1 (random) | Rotates across l2/ip/cosine over time |
| Daily CI |  | 3 (all) | Full metric_type coverage |

## Performance Impact

- PR CI: ~7.5min → ~2.5min (saves ~5min CPU time per PR)
- Daily CI: unchanged (still runs all 3 metric types)

Signed-off-by: opencode <opencode@lht.dev>