### PR TITLE
feat(sindi): integrate reasoning mechanism for search diagnostics

### DIFF
--- a/src/algorithm/sindi/sindi.cpp
+++ b/src/algorithm/sindi/sindi.cpp
@@ -21,6 +21,7 @@
 #include "analyzer/analyzer.h"
 #include "datacell/sparse_vector_datacell_parameter.h"
 #include "impl/heap/standard_heap.h"
+#include "impl/reasoning/search_reasoning.h"
 #include "index_feature_list.h"
 #include "io/memory_block_io/memory_block_io_parameter.h"
 #include "quantization/sparse_quantization/sparse_quantizer.h"
@@ -437,8 +438,8 @@ SINDI::KnnSearch(const DatasetPtr& query,
     inner_param.is_inner_id_allowed = this->create_search_filter(filter);
 
     SparseVector effective_query = sparse_query;
-    Vector<uint32_t> tmp_ids(allocator_);
-    Vector<float> tmp_vals(allocator_);
+    Vector<uint32_t> tmp_ids(allocator);
+    Vector<float> tmp_vals(allocator);
     if (remap_term_ids_) {
         effective_query = remap_sparse_vector_for_query(sparse_query, tmp_ids, tmp_vals);
         if (effective_query.len_ == 0) {
@@ -713,7 +714,8 @@ SINDI::immutable_search_impl(const SparseTermComputerPtr& computer,
                              const InnerSearchParam& inner_param,
                              Allocator* allocator,
                              bool use_term_lists_heap_insert,
-                             const SparseVector* original_query) const {
+                             const SparseVector* original_query,
+                             ReasoningContext* reasoning_ctx) const {
     Allocator* search_allocator = allocator != nullptr ? allocator : allocator_;
     MaxHeap heap(search_allocator);
     int64_t k = 0;
@@ -725,12 +727,30 @@ SINDI::immutable_search_impl(const SparseTermComputerPtr& computer,
     ImmutableMappedQueryTerms mapped_terms(search_allocator);
     auto filter = inner_param.is_inner_id_allowed;
     const auto [min_window_id, max_window_id] = this->get_min_max_window_id(filter);
+    auto selected_buckets = reasoning_ctx != nullptr
+                                ? std::make_unique<Vector<BucketIdType>>(search_allocator)
+                                : nullptr;
     for (auto cur = min_window_id; cur <= max_window_id; cur++) {
         const auto& window = immutable_data_->windows[static_cast<uint32_t>(cur)];
         const auto window_start_id = static_cast<uint32_t>(cur) * window_size_;
         map_immutable_query_terms(window, computer, mapped_terms);
         std::fill(dists.begin(), dists.end(), 0.0F);
         scan_immutable_window_by_mapped_terms(dists.data(), window, computer, mapped_terms);
+
+        if (reasoning_ctx != nullptr) {
+            selected_buckets->push_back(cur);
+            auto doc_count = static_cast<uint32_t>(std::min<int64_t>(
+                window_size_, cur_element_count_ - static_cast<int64_t>(window_start_id)));
+            for (uint32_t i = 0; i < doc_count; ++i) {
+                if (dists[i] != 0.0F) {
+                    auto inner_id = window_start_id + i;
+                    reasoning_ctx->RecordVisit(inner_id, 1.0F + dists[i], 0);
+                    if (filter and not filter->CheckValid(inner_id)) {
+                        reasoning_ctx->RecordFilterReject(inner_id);
+                    }
+                }
+            }
+        }
 
         if (use_term_lists_heap_insert) {
             if (inner_param.is_inner_id_allowed) {
@@ -763,6 +783,10 @@ SINDI::immutable_search_impl(const SparseTermComputerPtr& computer,
         }
     }
 
+    if (selected_buckets != nullptr and not selected_buckets->empty()) {
+        reasoning_ctx->RecordBucketSelection(*selected_buckets);
+    }
+
     if (use_reorder_) {
         float cur_heap_top = std::numeric_limits<float>::max();
         auto candidate_size = heap.size();
@@ -774,11 +798,20 @@ SINDI::immutable_search_impl(const SparseTermComputerPtr& computer,
             auto high_precise_distance =
                 calc_distance_by_id_unsafe(rerank_flat_, sorted_ids, sorted_vals, inner_id);
             auto label = label_table_->GetLabelById(inner_id);
+            if (reasoning_ctx != nullptr) {
+                reasoning_ctx->RecordReorder(
+                    inner_id, 1.0F + heap.top().first, high_precise_distance);
+            }
             if constexpr (mode == KNN_SEARCH) {
                 if (high_precise_distance < cur_heap_top or high_precise_heap->Size() < k) {
                     high_precise_heap->Push(high_precise_distance, label);
                 }
                 if (high_precise_heap->Size() > k) {
+                    if (reasoning_ctx != nullptr) {
+                        auto evicted_label = high_precise_heap->Top().second;
+                        auto evicted_inner_id = this->label_table_->GetIdByLabel(evicted_label);
+                        reasoning_ctx->RecordReorderEviction(evicted_inner_id, 0);
+                    }
                     high_precise_heap->Pop();
                 }
                 cur_heap_top = high_precise_heap->Top().first;
@@ -789,6 +822,11 @@ SINDI::immutable_search_impl(const SparseTermComputerPtr& computer,
                 }
                 if (inner_param.range_search_limit_size != -1 and
                     high_precise_heap->Size() > inner_param.range_search_limit_size) {
+                    if (reasoning_ctx != nullptr) {
+                        auto evicted_label = high_precise_heap->Top().second;
+                        auto evicted_inner_id = this->label_table_->GetIdByLabel(evicted_label);
+                        reasoning_ctx->RecordReorderEviction(evicted_inner_id, 0);
+                    }
                     high_precise_heap->Pop();
                 }
             }
@@ -825,7 +863,8 @@ SINDI::search_impl(const SparseTermComputerPtr& computer,
                    const InnerSearchParam& inner_param,
                    Allocator* allocator,
                    bool use_term_lists_heap_insert,
-                   const SparseVector* original_query) const {
+                   const SparseVector* original_query,
+                   ReasoningContext* reasoning_ctx) const {
     // computer and heap
     MaxHeap heap(allocator);
     int64_t k = 0;
@@ -838,12 +877,29 @@ SINDI::search_impl(const SparseTermComputerPtr& computer,
     Vector<float> dists(window_size_, 0.0, allocator);
     auto filter = inner_param.is_inner_id_allowed;
     const auto [min_window_id, max_window_id] = this->get_min_max_window_id(filter);
+    auto selected_buckets =
+        reasoning_ctx != nullptr ? std::make_unique<Vector<BucketIdType>>(allocator) : nullptr;
     for (auto cur = min_window_id; cur <= max_window_id; cur++) {
         auto window_start_id = cur * window_size_;
         auto term_list = this->window_term_list_[cur];
 
         // compute
         term_list->Query(dists.data(), computer);
+
+        if (reasoning_ctx != nullptr) {
+            selected_buckets->push_back(cur);
+            auto doc_count = static_cast<uint32_t>(std::min<int64_t>(
+                window_size_, cur_element_count_ - static_cast<int64_t>(window_start_id)));
+            for (uint32_t i = 0; i < doc_count; ++i) {
+                if (dists[i] != 0.0F) {
+                    auto inner_id = window_start_id + i;
+                    reasoning_ctx->RecordVisit(inner_id, 1.0F + dists[i], 0);
+                    if (filter and not filter->CheckValid(inner_id)) {
+                        reasoning_ctx->RecordFilterReject(inner_id);
+                    }
+                }
+            }
+        }
 
         // insert heap
         if (use_term_lists_heap_insert) {
@@ -865,6 +921,10 @@ SINDI::search_impl(const SparseTermComputerPtr& computer,
         }
     }
 
+    if (selected_buckets != nullptr and not selected_buckets->empty()) {
+        reasoning_ctx->RecordBucketSelection(*selected_buckets);
+    }
+
     // rerank
     if (use_reorder_) {
         // high precision
@@ -878,11 +938,20 @@ SINDI::search_impl(const SparseTermComputerPtr& computer,
             auto high_precise_distance =
                 calc_distance_by_id_unsafe(rerank_flat_, sorted_ids, sorted_vals, inner_id);
             auto label = label_table_->GetLabelById(inner_id);
+            if (reasoning_ctx != nullptr) {
+                reasoning_ctx->RecordReorder(
+                    inner_id, 1.0F + heap.top().first, high_precise_distance);
+            }
             if constexpr (mode == KNN_SEARCH) {
                 if (high_precise_distance < cur_heap_top or high_precise_heap->Size() < k) {
                     high_precise_heap->Push(high_precise_distance, label);
                 }
                 if (high_precise_heap->Size() > k) {
+                    if (reasoning_ctx != nullptr) {
+                        auto evicted_label = high_precise_heap->Top().second;
+                        auto evicted_inner_id = this->label_table_->GetIdByLabel(evicted_label);
+                        reasoning_ctx->RecordReorderEviction(evicted_inner_id, 0);
+                    }
                     high_precise_heap->Pop();
                 }
                 cur_heap_top = high_precise_heap->Top().first;
@@ -893,6 +962,11 @@ SINDI::search_impl(const SparseTermComputerPtr& computer,
                 }
                 if (inner_param.range_search_limit_size != -1 and
                     high_precise_heap->Size() > inner_param.range_search_limit_size) {
+                    if (reasoning_ctx != nullptr) {
+                        auto evicted_label = high_precise_heap->Top().second;
+                        auto evicted_inner_id = this->label_table_->GetIdByLabel(evicted_label);
+                        reasoning_ctx->RecordReorderEviction(evicted_inner_id, 0);
+                    }
                     high_precise_heap->Pop();
                 }
             }
@@ -975,6 +1049,137 @@ SINDI::RangeSearch(const DatasetPtr& query,
     }
     return search_impl<RANGE_SEARCH>(
         computer, inner_param, allocator_, UseTermListsHeapInsert(search_param), rerank_query);
+}
+
+DatasetPtr
+SINDI::SearchWithRequest(const SearchRequest& request) const {
+    std::shared_lock rlock(this->global_mutex_);
+
+    CHECK_ARGUMENT(request.query_ != nullptr, "query should not be null");
+    const auto* sparse_vectors = request.query_->GetSparseVectors();
+    CHECK_ARGUMENT(request.query_->GetNumElements() == 1, "num of query should be 1");
+    auto sparse_query = sparse_vectors[0];
+    CHECK_ARGUMENT(
+        sparse_query.len_ > 0,
+        fmt::format("query->GetSparseVectors()->len_ ({}) is invalid", sparse_query.len_));
+
+    SINDISearchParameter search_param;
+    search_param.FromJson(JsonType::Parse(request.params_str_));
+
+    Allocator* allocator = select_query_allocator(request.search_allocator_, this->allocator_);
+
+    bool is_range = (request.mode_ == SearchMode::RANGE_SEARCH);
+
+    InnerSearchParam inner_param;
+    const bool filter_enabled = request.enable_filter_ and request.filter_ != nullptr;
+    inner_param.is_inner_id_allowed =
+        filter_enabled ? this->create_search_filter(request.filter_) : nullptr;
+
+    std::shared_ptr<ReasoningContext> reasoning_ctx;
+    if (not request.expected_labels_.empty()) {
+        reasoning_ctx = std::make_shared<ReasoningContext>(this->allocator_);
+        reasoning_ctx->SetSearchParams(request.topk_, "SINDI", use_reorder_, filter_enabled);
+
+        UnorderedMap<int64_t, InnerIdType> label_to_inner_id(this->allocator_);
+        {
+            std::shared_lock<std::shared_mutex> lock(this->label_lookup_mutex_);
+            for (const auto& label : request.expected_labels_) {
+                auto [success, inner_id] = this->label_table_->TryGetIdByLabel(label, true);
+                if (success) {
+                    label_to_inner_id[label] = inner_id;
+                }
+            }
+        }
+
+        Vector<int64_t> expected_labels_vec(this->allocator_);
+        expected_labels_vec.reserve(request.expected_labels_.size());
+        for (const auto& label : request.expected_labels_) {
+            expected_labels_vec.push_back(label);
+        }
+        reasoning_ctx->InitializeExpectedTargets(expected_labels_vec, label_to_inner_id);
+    }
+
+    SparseVector effective_query = sparse_query;
+    Vector<uint32_t> tmp_ids(allocator);
+    Vector<float> tmp_vals(allocator);
+    if (remap_term_ids_) {
+        effective_query = remap_sparse_vector_for_query(sparse_query, tmp_ids, tmp_vals);
+        if (effective_query.len_ == 0) {
+            return make_empty_result();
+        }
+    }
+
+    auto computer = std::make_shared<SparseTermComputer>(effective_query, search_param, allocator);
+    const SparseVector* rerank_query = (remap_term_ids_ && use_reorder_) ? &sparse_query : nullptr;
+
+    DatasetPtr result;
+    if (is_range) {
+        inner_param.range_search_limit_size = static_cast<int>(request.limited_size_);
+        inner_param.radius = request.radius_;
+        if (immutable_data_ != nullptr) {
+            result = immutable_search_impl<RANGE_SEARCH>(computer,
+                                                         inner_param,
+                                                         allocator,
+                                                         UseTermListsHeapInsert(search_param),
+                                                         rerank_query,
+                                                         reasoning_ctx.get());
+        } else {
+            result = search_impl<RANGE_SEARCH>(computer,
+                                               inner_param,
+                                               allocator,
+                                               UseTermListsHeapInsert(search_param),
+                                               rerank_query,
+                                               reasoning_ctx.get());
+        }
+    } else {
+        CHECK_ARGUMENT(search_param.n_candidate <= SPARSE_AMPLIFICATION_FACTOR * request.topk_,
+                       fmt::format("n_candidate ({}) should be less than {} * k ({})",
+                                   search_param.n_candidate,
+                                   SPARSE_AMPLIFICATION_FACTOR,
+                                   request.topk_));
+        inner_param.ef = std::max(static_cast<int64_t>(search_param.n_candidate), request.topk_);
+        inner_param.topk = request.topk_;
+        if (immutable_data_ != nullptr) {
+            result = immutable_search_impl<KNN_SEARCH>(computer,
+                                                       inner_param,
+                                                       allocator,
+                                                       UseTermListsHeapInsert(search_param),
+                                                       rerank_query,
+                                                       reasoning_ctx.get());
+        } else {
+            result = search_impl<KNN_SEARCH>(computer,
+                                             inner_param,
+                                             allocator,
+                                             UseTermListsHeapInsert(search_param),
+                                             rerank_query,
+                                             reasoning_ctx.get());
+        }
+    }
+
+    this->AttachReasoningReport(result, reasoning_ctx.get());
+    return result;
+}
+
+void
+SINDI::AttachReasoningReport(const DatasetPtr& dataset_results,
+                             ReasoningContext* reasoning_ctx) const {
+    if (reasoning_ctx == nullptr or dataset_results == nullptr) {
+        return;
+    }
+    auto count = dataset_results->GetNumElements();
+    if (count > 0 and dataset_results->GetIds() != nullptr) {
+        Vector<InnerIdType> result_inner_ids(static_cast<uint64_t>(count), this->allocator_);
+        {
+            std::shared_lock<std::shared_mutex> lock(this->label_lookup_mutex_);
+            for (int64_t i = 0; i < count; ++i) {
+                result_inner_ids[i] =
+                    this->label_table_->GetIdByLabel(dataset_results->GetIds()[i]);
+            }
+        }
+        reasoning_ctx->MarkResult(result_inner_ids);
+    }
+    reasoning_ctx->DiagnoseExpectedTargets();
+    dataset_results->Reasoning(reasoning_ctx->GenerateReport());
 }
 
 bool

--- a/src/algorithm/sindi/sindi.h
+++ b/src/algorithm/sindi/sindi.h
@@ -25,6 +25,8 @@
 
 namespace vsag {
 
+class ReasoningContext;
+
 struct ImmutableSINDIWindow {
     explicit ImmutableSINDIWindow(Allocator* allocator)
         : sorted_global_to_local_terms(allocator),
@@ -131,6 +133,9 @@ public:
                 const FilterPtr& filter,
                 int64_t limited_size = -1) const override;
 
+    DatasetPtr
+    SearchWithRequest(const SearchRequest& request) const override;
+
     InnerIndexPtr
     Fork(const IndexCommonParam& param) override {
         return nullptr;
@@ -208,7 +213,8 @@ private:
                 const InnerSearchParam& inner_param,
                 Allocator* allocator,
                 bool use_term_lists_heap_insert,
-                const SparseVector* original_query = nullptr) const;
+                const SparseVector* original_query = nullptr,
+                ReasoningContext* reasoning_ctx = nullptr) const;
 
     template <InnerSearchMode mode>
     DatasetPtr
@@ -216,7 +222,8 @@ private:
                           const InnerSearchParam& inner_param,
                           Allocator* allocator,
                           bool use_term_lists_heap_insert,
-                          const SparseVector* original_query = nullptr) const;
+                          const SparseVector* original_query = nullptr,
+                          ReasoningContext* reasoning_ctx = nullptr) const;
 
     bool
     UseTermListsHeapInsert(const SINDISearchParameter& search_param) const;
@@ -287,6 +294,9 @@ private:
                                    MaxHeap& heap,
                                    const InnerSearchParam& param,
                                    uint32_t offset_id) const;
+
+    void
+    AttachReasoningReport(const DatasetPtr& dataset_results, ReasoningContext* reasoning_ctx) const;
 
     /// Recalculate and cache the memory-usage counter.
     void

--- a/tests/test_sindi.cpp
+++ b/tests/test_sindi.cpp
@@ -95,6 +95,19 @@ TestDatasetPool SINDITestIndex::pool{};
 
 }  // namespace fixtures
 
+// RejectAllFilter for testing
+class RejectAllFilter : public vsag::Filter {
+public:
+    bool
+    CheckValid(int64_t) const override {
+        return false;
+    }
+    bool
+    CheckValid(const char*) const override {
+        return false;
+    }
+};
+
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex,
                              "Invalid Build and Search Parameter",
                              "[ft][build][search][sindi]") {
@@ -368,4 +381,113 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex, "SINDI Mark Remove", "[ft
             REQUIRE(search_result.value()->GetIds()[j] != ids[i]);
         }
     }
+}
+
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex,
+                             "SINDI Reasoning Missed Target",
+                             "[ft][sindi][reasoning][pr]") {
+    fixtures::SINDIParam param;
+    auto build_param = fixtures::SINDITestIndex::GenerateBuildParameter(param);
+    auto index = TestFactory("sindi", build_param, true);
+    auto dataset = pool.GetSparseDatasetAndCreate(base_count, 128, 0.8);
+    TestBuildIndex(index, dataset, true);
+
+    auto query = vsag::Dataset::Make();
+    query->NumElements(1)->SparseVectors(dataset->base_->GetSparseVectors())->Owner(false);
+
+    vsag::SearchRequest req;
+    req.topk_ = 5;
+    req.params_str_ = fixtures::SINDITestIndex::search_param;
+    req.query_ = query;
+    req.expected_labels_ = {99999999};
+
+    auto result = index->SearchWithRequest(req);
+    REQUIRE(result.has_value());
+    REQUIRE_FALSE(result.value()->GetReasoning().empty());
+    REQUIRE(result.value()->GetReasoning().find("missed_targets") != std::string::npos);
+    REQUIRE(result.value()->GetReasoning().find("bucket_selection") != std::string::npos);
+}
+
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex,
+                             "SINDI Reasoning Found Target",
+                             "[ft][sindi][reasoning][pr]") {
+    fixtures::SINDIParam param;
+    auto build_param = fixtures::SINDITestIndex::GenerateBuildParameter(param);
+    auto index = TestFactory("sindi", build_param, true);
+    auto dataset = pool.GetSparseDatasetAndCreate(base_count, 128, 0.8);
+    TestBuildIndex(index, dataset, true);
+
+    auto query = vsag::Dataset::Make();
+    query->NumElements(1)->SparseVectors(dataset->base_->GetSparseVectors())->Owner(false);
+
+    vsag::SearchRequest req_no_reasoning;
+    req_no_reasoning.topk_ = 5;
+    req_no_reasoning.params_str_ = fixtures::SINDITestIndex::search_param;
+    req_no_reasoning.query_ = query;
+
+    auto result_no_reasoning = index->SearchWithRequest(req_no_reasoning);
+    REQUIRE(result_no_reasoning.has_value());
+    REQUIRE(result_no_reasoning.value()->GetNumElements() > 0);
+    REQUIRE(result_no_reasoning.value()->GetIds() != nullptr);
+
+    auto found_label = result_no_reasoning.value()->GetIds()[0];
+
+    vsag::SearchRequest req;
+    req.topk_ = 5;
+    req.params_str_ = fixtures::SINDITestIndex::search_param;
+    req.query_ = query;
+    req.expected_labels_ = {found_label};
+
+    auto result = index->SearchWithRequest(req);
+    REQUIRE(result.has_value());
+    REQUIRE_FALSE(result.value()->GetReasoning().empty());
+    REQUIRE(result.value()->GetReasoning().find("expected_analysis") != std::string::npos);
+}
+
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex,
+                             "SINDI Reasoning Empty Labels No Overhead",
+                             "[ft][sindi][reasoning][pr]") {
+    fixtures::SINDIParam param;
+    auto build_param = fixtures::SINDITestIndex::GenerateBuildParameter(param);
+    auto index = TestFactory("sindi", build_param, true);
+    auto dataset = pool.GetSparseDatasetAndCreate(base_count, 128, 0.8);
+    TestBuildIndex(index, dataset, true);
+
+    auto query = vsag::Dataset::Make();
+    query->NumElements(1)->SparseVectors(dataset->base_->GetSparseVectors())->Owner(false);
+
+    vsag::SearchRequest req;
+    req.topk_ = 5;
+    req.params_str_ = fixtures::SINDITestIndex::search_param;
+    req.query_ = query;
+    req.expected_labels_ = {};
+
+    auto result = index->SearchWithRequest(req);
+    REQUIRE(result.has_value());
+    REQUIRE(result.value()->GetReasoning().find("expected_analysis") == std::string::npos);
+}
+
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex,
+                             "SINDI Reasoning With Filter",
+                             "[ft][sindi][reasoning][pr]") {
+    fixtures::SINDIParam param;
+    auto build_param = fixtures::SINDITestIndex::GenerateBuildParameter(param);
+    auto index = TestFactory("sindi", build_param, true);
+    auto dataset = pool.GetSparseDatasetAndCreate(base_count, 128, 0.8);
+    TestBuildIndex(index, dataset, true);
+
+    auto query = vsag::Dataset::Make();
+    query->NumElements(1)->SparseVectors(dataset->base_->GetSparseVectors())->Owner(false);
+
+    vsag::SearchRequest req;
+    req.topk_ = 5;
+    req.params_str_ = fixtures::SINDITestIndex::search_param;
+    req.query_ = query;
+    req.expected_labels_ = {dataset->base_->GetIds()[0]};
+    req.enable_filter_ = true;
+    req.filter_ = std::make_shared<RejectAllFilter>();
+
+    auto result = index->SearchWithRequest(req);
+    REQUIRE(result.has_value());
+    REQUIRE_FALSE(result.value()->GetReasoning().empty());
 }


### PR DESCRIPTION
## Summary

Integrate the reasoning mechanism into the SINDI (Sparse Inverted Non-redundant Distance Index) to enable diagnostic analysis of sparse vector search recall.

## Changes

- `src/algorithm/sindi/sindi.h`: Added forward declaration for `ReasoningContext`, `SearchWithRequest` override, `AttachReasoningReport` method, modified `search_impl` and `immutable_search_impl` signatures
- `src/algorithm/sindi/sindi.cpp`: Implemented `SearchWithRequest`, added reasoning tracking in window loops (bucket selections, candidate visits, filter rejections), implemented `AttachReasoningReport`

## Design

SINDI reasoning tracks:
- **Window access**: which windows are visited during search
- **Candidate visits**: which expected targets are encountered with their distances
- **Filter rejections**: which expected targets are rejected by the filter

Zero overhead when `reasoning_ctx` is null.

## Related

- Closes #1831
- Parent: #1829
- Depends on: #1836
