### PR TITLE
fix(hgraph): optimize rabitq split 2bit search

### DIFF
--- a/src/quantization/rabitq_quantization/rabitq_quantizer.cpp
+++ b/src/quantization/rabitq_quantization/rabitq_quantizer.cpp
@@ -1054,7 +1054,11 @@ RaBitQuantizer<metric>::ComputeDistWithOneBitLowerBound(Computer<RaBitQuantizer>
         sum_type query_raw_sum = *((sum_type*)(query + query_offset_sum_));
         memcpy(
             &base_norm_code, one_bit_code + OneBitRecordNormCodeOffset(), sizeof(base_norm_code));
-        if (FilterBits() == 3) {
+        if (FilterBits() == 2) {
+            filter_ip_yu_q = RaBitQFloatTwoBitCenteredIP(
+                reinterpret_cast<const float*>(query), one_bit_code, this->dim_);
+            filter_ip_estimate = base_norm_code <= 0.0F ? 0.0F : filter_ip_yu_q / base_norm_code;
+        } else if (FilterBits() == 3) {
             filter_ip_yu_q = RaBitQFloatThreeBitCenteredIP(
                 reinterpret_cast<const float*>(query), one_bit_code, this->dim_);
             filter_ip_estimate = base_norm_code <= 0.0F ? 0.0F : filter_ip_yu_q / base_norm_code;
@@ -1176,7 +1180,8 @@ RaBitQuantizer<metric>::ComputeDistsWithOneBitLowerBoundBatch4(
         return;
     }
 
-    if (FilterBits() != 1 and not HasFilterQueryLookupTable()) {
+    if (FilterBits() != 1 and FilterBits() != 2 and FilterBits() != 3 and
+        not HasFilterQueryLookupTable()) {
         computed1 = this->ComputeDistWithOneBitLowerBound(
             computer, one_bit_code1, &dist1, lower_bound1, runtime_rabitq_error_rate);
         computed2 = this->ComputeDistWithOneBitLowerBound(
@@ -1214,6 +1219,15 @@ RaBitQuantizer<metric>::ComputeDistsWithOneBitLowerBoundBatch4(
                                   this->dim_,
                                   inv_sqrt_d_,
                                   filter_ip_values);
+    } else if (FilterBits() == 2) {
+        RaBitQFloatTwoBitCenteredIPBatch4(query_data,
+                                          one_bit_code1,
+                                          one_bit_code2,
+                                          one_bit_code3,
+                                          one_bit_code4,
+                                          this->dim_,
+                                          filter_ip_values);
+        filter_ip_values_are_centered = true;
     } else if (FilterBits() == 3) {
         RaBitQFloatThreeBitCenteredIPBatch4(query_data,
                                             one_bit_code1,

--- a/src/quantization/rabitq_quantization/rabitq_quantizer_test.cpp
+++ b/src/quantization/rabitq_quantization/rabitq_quantizer_test.cpp
@@ -196,6 +196,65 @@ TEST_CASE("RaBitQ Split Code Storage", "[ut][RaBitQuantizer]") {
                 REQUIRE(std::abs(split_dist - hinted_split_dist) <= 1e-5F);
             }
         }
+
+        if (filter_bits == 2) {
+            std::vector<std::vector<uint8_t>> batch_one_bit_codes(4);
+            std::vector<uint8_t> batch_supplement_code(quantizer.GetSupplementCodeSize());
+            std::vector<float> single_dists(4, 0.0F);
+            std::vector<float> single_lower_bounds(4, std::numeric_limits<float>::max());
+            for (uint32_t i = 0; i < 4; ++i) {
+                batch_one_bit_codes[i].resize(quantizer.GetOneBitCodeSize());
+                quantizer.EncodeOne(vecs.data() + i * dim, full_code.data());
+                quantizer.SplitCode(
+                    full_code.data(), batch_one_bit_codes[i].data(), batch_supplement_code.data());
+                REQUIRE(quantizer.ComputeDistWithOneBitLowerBound(*computer,
+                                                                  batch_one_bit_codes[i].data(),
+                                                                  &single_dists[i],
+                                                                  &single_lower_bounds[i]));
+            }
+
+            float batch_dist1 = 0.0F;
+            float batch_dist2 = 0.0F;
+            float batch_dist3 = 0.0F;
+            float batch_dist4 = 0.0F;
+            float batch_lower_bound1 = std::numeric_limits<float>::max();
+            float batch_lower_bound2 = std::numeric_limits<float>::max();
+            float batch_lower_bound3 = std::numeric_limits<float>::max();
+            float batch_lower_bound4 = std::numeric_limits<float>::max();
+            bool computed1 = false;
+            bool computed2 = false;
+            bool computed3 = false;
+            bool computed4 = false;
+            quantizer.ComputeDistsWithOneBitLowerBoundBatch4(*computer,
+                                                             batch_one_bit_codes[0].data(),
+                                                             batch_one_bit_codes[1].data(),
+                                                             batch_one_bit_codes[2].data(),
+                                                             batch_one_bit_codes[3].data(),
+                                                             batch_dist1,
+                                                             batch_dist2,
+                                                             batch_dist3,
+                                                             batch_dist4,
+                                                             &batch_lower_bound1,
+                                                             &batch_lower_bound2,
+                                                             &batch_lower_bound3,
+                                                             &batch_lower_bound4,
+                                                             computed1,
+                                                             computed2,
+                                                             computed3,
+                                                             computed4);
+
+            REQUIRE(computed1);
+            REQUIRE(computed2);
+            REQUIRE(computed3);
+            REQUIRE(computed4);
+            const float batch_dists[4] = {batch_dist1, batch_dist2, batch_dist3, batch_dist4};
+            const float batch_lower_bounds[4] = {
+                batch_lower_bound1, batch_lower_bound2, batch_lower_bound3, batch_lower_bound4};
+            for (uint32_t i = 0; i < 4; ++i) {
+                REQUIRE(std::abs(batch_dists[i] - single_dists[i]) <= 1e-5F);
+                REQUIRE(std::abs(batch_lower_bounds[i] - single_lower_bounds[i]) <= 1e-5F);
+            }
+        }
     }
 }
 

--- a/src/simd/avx2.cpp
+++ b/src/simd/avx2.cpp
@@ -724,6 +724,39 @@ RaBitQFloatThreeBitIPBatch4(const float* vector,
 }
 
 float
+RaBitQFloatTwoBitCenteredIP(const float* vector, const uint8_t* bits, uint64_t dim) {
+#if defined(ENABLE_AVX2)
+    return simd::RaBitQFloatTwoBitCenteredIPImpl<simd::RaBitQTraits<simd::AVX2_RaBitQ_Tag>>(
+        vector, bits, dim, &generic::RaBitQFloatTwoBitCenteredIP);
+#else
+    return generic::RaBitQFloatTwoBitCenteredIP(vector, bits, dim);
+#endif
+}
+
+void
+RaBitQFloatTwoBitCenteredIPBatch4(const float* vector,
+                                  const uint8_t* bits1,
+                                  const uint8_t* bits2,
+                                  const uint8_t* bits3,
+                                  const uint8_t* bits4,
+                                  uint64_t dim,
+                                  float* results) {
+#if defined(ENABLE_AVX2)
+    simd::RaBitQFloatTwoBitCenteredIPBatch4Impl<simd::RaBitQTraits<simd::AVX2_RaBitQ_Tag>>(
+        vector,
+        bits1,
+        bits2,
+        bits3,
+        bits4,
+        dim,
+        results,
+        &generic::RaBitQFloatTwoBitCenteredIPBatch4);
+#else
+    generic::RaBitQFloatTwoBitCenteredIPBatch4(vector, bits1, bits2, bits3, bits4, dim, results);
+#endif
+}
+
+float
 RaBitQFloatThreeBitCenteredIP(const float* vector, const uint8_t* bits, uint64_t dim) {
 #if defined(ENABLE_AVX2)
     return simd::RaBitQFloatThreeBitCenteredIPImpl<simd::RaBitQTraits<simd::AVX2_RaBitQ_Tag>>(

--- a/src/simd/avx512.cpp
+++ b/src/simd/avx512.cpp
@@ -684,6 +684,39 @@ RaBitQFloatThreeBitIPBatch4(const float* vector,
 }
 
 float
+RaBitQFloatTwoBitCenteredIP(const float* vector, const uint8_t* bits, uint64_t dim) {
+#if defined(ENABLE_AVX512)
+    return simd::RaBitQFloatTwoBitCenteredIPImpl<simd::RaBitQTraits<simd::AVX512_RaBitQ_Tag>>(
+        vector, bits, dim, &generic::RaBitQFloatTwoBitCenteredIP);
+#else
+    return avx2::RaBitQFloatTwoBitCenteredIP(vector, bits, dim);
+#endif
+}
+
+void
+RaBitQFloatTwoBitCenteredIPBatch4(const float* vector,
+                                  const uint8_t* bits1,
+                                  const uint8_t* bits2,
+                                  const uint8_t* bits3,
+                                  const uint8_t* bits4,
+                                  uint64_t dim,
+                                  float* results) {
+#if defined(ENABLE_AVX512)
+    simd::RaBitQFloatTwoBitCenteredIPBatch4Impl<simd::RaBitQTraits<simd::AVX512_RaBitQ_Tag>>(
+        vector,
+        bits1,
+        bits2,
+        bits3,
+        bits4,
+        dim,
+        results,
+        &generic::RaBitQFloatTwoBitCenteredIPBatch4);
+#else
+    avx2::RaBitQFloatTwoBitCenteredIPBatch4(vector, bits1, bits2, bits3, bits4, dim, results);
+#endif
+}
+
+float
 RaBitQFloatThreeBitCenteredIP(const float* vector, const uint8_t* bits, uint64_t dim) {
 #if defined(ENABLE_AVX512)
     return simd::RaBitQFloatThreeBitCenteredIPImpl<simd::RaBitQTraits<simd::AVX512_RaBitQ_Tag>>(

--- a/src/simd/generic.cpp
+++ b/src/simd/generic.cpp
@@ -538,6 +538,58 @@ RaBitQFloatThreeBitIPBatch4(const float* vector,
 }
 
 float
+RaBitQFloatTwoBitCenteredIP(const float* vector, const uint8_t* bits, uint64_t dim) {
+    if (dim == 0) {
+        return 0.0F;
+    }
+
+    const uint64_t plane_bytes = (dim + 7) / 8;
+    const uint8_t* plane0 = bits;
+    const uint8_t* plane1 = bits + plane_bytes;
+    float result = 0.0F;
+    for (uint64_t d = 0; d < dim; ++d) {
+        const uint64_t byte_idx = d >> 3;
+        const uint8_t bit_mask = static_cast<uint8_t>(1U << (d & 7));
+        float weight = (plane0[byte_idx] & bit_mask) != 0U ? 1.0F : -1.0F;
+        weight += (plane1[byte_idx] & bit_mask) != 0U ? 0.5F : -0.5F;
+        result += vector[d] * weight;
+    }
+    return result;
+}
+
+void
+RaBitQFloatTwoBitCenteredIPBatch4(const float* vector,
+                                  const uint8_t* bits1,
+                                  const uint8_t* bits2,
+                                  const uint8_t* bits3,
+                                  const uint8_t* bits4,
+                                  uint64_t dim,
+                                  float* results) {
+    results[0] = 0.0F;
+    results[1] = 0.0F;
+    results[2] = 0.0F;
+    results[3] = 0.0F;
+    if (dim == 0) {
+        return;
+    }
+
+    const uint64_t plane_bytes = (dim + 7) / 8;
+    const uint8_t* plane0[4] = {bits1, bits2, bits3, bits4};
+    const uint8_t* plane1[4] = {
+        bits1 + plane_bytes, bits2 + plane_bytes, bits3 + plane_bytes, bits4 + plane_bytes};
+    for (uint64_t d = 0; d < dim; ++d) {
+        const uint64_t byte_idx = d >> 3;
+        const uint8_t bit_mask = static_cast<uint8_t>(1U << (d & 7));
+        const float value = vector[d];
+        for (uint32_t i = 0; i < 4; ++i) {
+            float weight = (plane0[i][byte_idx] & bit_mask) != 0U ? 1.0F : -1.0F;
+            weight += (plane1[i][byte_idx] & bit_mask) != 0U ? 0.5F : -0.5F;
+            results[i] += value * weight;
+        }
+    }
+}
+
+float
 RaBitQFloatThreeBitCenteredIP(const float* vector, const uint8_t* bits, uint64_t dim) {
     if (dim == 0) {
         return 0.0F;

--- a/src/simd/kernels/rabitq_compute.h
+++ b/src/simd/kernels/rabitq_compute.h
@@ -126,6 +126,116 @@ RaBitQFloatBinaryIPBatch4Impl(const float* vector,
 
 template <typename T>
 inline float
+RaBitQFloatTwoBitCenteredIPImpl(const float* vector,
+                                const uint8_t* bits,
+                                uint64_t dim,
+                                float (*fallback)(const float*, const uint8_t*, uint64_t)) {
+    if (dim == 0) {
+        return 0.0f;
+    }
+
+    constexpr int W = T::Width;
+    if (dim < static_cast<uint64_t>(W)) {
+        return fallback(vector, bits, dim);
+    }
+
+    const uint64_t plane_bytes = (dim + 7) / 8;
+    const uint8_t* plane0 = bits;
+    const uint8_t* plane1 = bits + plane_bytes;
+    auto sum = T::zero();
+    const auto pos1 = T::set1(1.0f);
+    const auto neg1 = T::set1(-1.0f);
+    const auto pos_half = T::set1(0.5f);
+    const auto neg_half = T::set1(-0.5f);
+
+    uint64_t d = 0;
+    for (; d + W <= dim; d += W) {
+        const uint64_t byte_idx = d >> 3;
+        auto weight = T::bits_to_signed(plane0 + byte_idx, pos1, neg1);
+        weight = T::add(weight, T::bits_to_signed(plane1 + byte_idx, pos_half, neg_half));
+
+        auto vec = T::load(vector + d);
+        sum = T::fmadd(weight, vec, sum);
+    }
+
+    float result = T::reduce_add(sum);
+    for (; d < dim; ++d) {
+        const uint64_t byte_idx = d >> 3;
+        const uint8_t bit_mask = static_cast<uint8_t>(1U << (d & 7));
+        const float value = vector[d];
+        float weight = (plane0[byte_idx] & bit_mask) != 0U ? 1.0f : -1.0f;
+        weight += (plane1[byte_idx] & bit_mask) != 0U ? 0.5f : -0.5f;
+        result += value * weight;
+    }
+    return result;
+}
+
+template <typename T>
+inline void
+RaBitQFloatTwoBitCenteredIPBatch4Impl(const float* vector,
+                                      const uint8_t* bits1,
+                                      const uint8_t* bits2,
+                                      const uint8_t* bits3,
+                                      const uint8_t* bits4,
+                                      uint64_t dim,
+                                      float* results,
+                                      void (*fallback)(const float*,
+                                                       const uint8_t*,
+                                                       const uint8_t*,
+                                                       const uint8_t*,
+                                                       const uint8_t*,
+                                                       uint64_t,
+                                                       float*)) {
+    if (dim == 0) {
+        results[0] = results[1] = results[2] = results[3] = 0.0f;
+        return;
+    }
+
+    constexpr int W = T::Width;
+    if (dim < static_cast<uint64_t>(W)) {
+        fallback(vector, bits1, bits2, bits3, bits4, dim, results);
+        return;
+    }
+
+    const uint64_t plane_bytes = (dim + 7) / 8;
+    const uint8_t* plane0[4] = {bits1, bits2, bits3, bits4};
+    const uint8_t* plane1[4] = {
+        bits1 + plane_bytes, bits2 + plane_bytes, bits3 + plane_bytes, bits4 + plane_bytes};
+    typename T::FloatVec sums[4] = {T::zero(), T::zero(), T::zero(), T::zero()};
+    const auto pos1 = T::set1(1.0f);
+    const auto neg1 = T::set1(-1.0f);
+    const auto pos_half = T::set1(0.5f);
+    const auto neg_half = T::set1(-0.5f);
+
+    uint64_t d = 0;
+    for (; d + W <= dim; d += W) {
+        const uint64_t byte_idx = d >> 3;
+        auto vec = T::load(vector + d);
+        for (uint32_t i = 0; i < 4; ++i) {
+            auto weight = T::bits_to_signed(plane0[i] + byte_idx, pos1, neg1);
+            weight = T::add(weight, T::bits_to_signed(plane1[i] + byte_idx, pos_half, neg_half));
+            sums[i] = T::fmadd(weight, vec, sums[i]);
+        }
+    }
+
+    for (uint32_t i = 0; i < 4; ++i) {
+        results[i] = T::reduce_add(sums[i]);
+    }
+
+    for (; d < dim; ++d) {
+        const uint64_t byte_idx = d >> 3;
+        const uint8_t bit_mask = static_cast<uint8_t>(1U << (d & 7));
+        const float value = vector[d];
+        for (uint32_t i = 0; i < 4; ++i) {
+            float weight = (plane0[i][byte_idx] & bit_mask) != 0U ? 1.0f : -1.0f;
+            weight += (plane1[i][byte_idx] & bit_mask) != 0U ? 0.5f : -0.5f;
+            results[i] += value * weight;
+        }
+    }
+}
+
+template <typename T>
+inline float
 RaBitQFloatThreeBitCenteredIPImpl(const float* vector,
                                   const uint8_t* bits,
                                   uint64_t dim,

--- a/src/simd/rabitq_simd.cpp
+++ b/src/simd/rabitq_simd.cpp
@@ -29,6 +29,39 @@ VSAG_DEFINE_SIMD_DISPATCH(KacsWalk, KacsWalkType);
 VSAG_DEFINE_SIMD_DISPATCH(VecRescale, VecRescaleType);
 VSAG_DEFINE_SIMD_DISPATCH(RotateOp, RotateOpType);
 
+static RaBitQFloatTwoBitCenteredType
+GetRaBitQFloatTwoBitCenteredIP() {
+    if (SimdStatus::SupportAVX512()) {
+#if defined(ENABLE_AVX512)
+        return avx512::RaBitQFloatTwoBitCenteredIP;
+#endif
+    }
+    if (SimdStatus::SupportAVX2()) {
+#if defined(ENABLE_AVX2)
+        return avx2::RaBitQFloatTwoBitCenteredIP;
+#endif
+    }
+    return generic::RaBitQFloatTwoBitCenteredIP;
+}
+RaBitQFloatTwoBitCenteredType RaBitQFloatTwoBitCenteredIP = GetRaBitQFloatTwoBitCenteredIP();
+
+static RaBitQFloatTwoBitCenteredBatch4Type
+GetRaBitQFloatTwoBitCenteredIPBatch4() {
+    if (SimdStatus::SupportAVX512()) {
+#if defined(ENABLE_AVX512)
+        return avx512::RaBitQFloatTwoBitCenteredIPBatch4;
+#endif
+    }
+    if (SimdStatus::SupportAVX2()) {
+#if defined(ENABLE_AVX2)
+        return avx2::RaBitQFloatTwoBitCenteredIPBatch4;
+#endif
+    }
+    return generic::RaBitQFloatTwoBitCenteredIPBatch4;
+}
+RaBitQFloatTwoBitCenteredBatch4Type RaBitQFloatTwoBitCenteredIPBatch4 =
+    GetRaBitQFloatTwoBitCenteredIPBatch4();
+
 static RaBitQFloatThreeBitCenteredType
 GetRaBitQFloatThreeBitCenteredIP() {
     if (SimdStatus::SupportAVX512()) {

--- a/src/simd/rabitq_simd.h
+++ b/src/simd/rabitq_simd.h
@@ -51,6 +51,18 @@ RaBitQFloatThreeBitIPBatch4(const float* vector,
                             float* results);
 
 float
+RaBitQFloatTwoBitCenteredIP(const float* vector, const uint8_t* bits, uint64_t dim);
+
+void
+RaBitQFloatTwoBitCenteredIPBatch4(const float* vector,
+                                  const uint8_t* bits1,
+                                  const uint8_t* bits2,
+                                  const uint8_t* bits3,
+                                  const uint8_t* bits4,
+                                  uint64_t dim,
+                                  float* results);
+
+float
 RaBitQFloatThreeBitCenteredIP(const float* vector, const uint8_t* bits, uint64_t dim);
 
 void
@@ -151,6 +163,18 @@ RaBitQFloatThreeBitIPBatch4(const float* vector,
                             uint64_t dim,
                             uint32_t reorder_bits,
                             float* results);
+
+float
+RaBitQFloatTwoBitCenteredIP(const float* vector, const uint8_t* bits, uint64_t dim);
+
+void
+RaBitQFloatTwoBitCenteredIPBatch4(const float* vector,
+                                  const uint8_t* bits1,
+                                  const uint8_t* bits2,
+                                  const uint8_t* bits3,
+                                  const uint8_t* bits4,
+                                  uint64_t dim,
+                                  float* results);
 
 float
 RaBitQFloatThreeBitCenteredIP(const float* vector, const uint8_t* bits, uint64_t dim);
@@ -350,6 +374,18 @@ RaBitQFloatThreeBitIPBatch4(const float* vector,
                             uint64_t dim,
                             uint32_t reorder_bits,
                             float* results);
+
+float
+RaBitQFloatTwoBitCenteredIP(const float* vector, const uint8_t* bits, uint64_t dim);
+
+void
+RaBitQFloatTwoBitCenteredIPBatch4(const float* vector,
+                                  const uint8_t* bits1,
+                                  const uint8_t* bits2,
+                                  const uint8_t* bits3,
+                                  const uint8_t* bits4,
+                                  uint64_t dim,
+                                  float* results);
 
 float
 RaBitQFloatThreeBitCenteredIP(const float* vector, const uint8_t* bits, uint64_t dim);
@@ -570,6 +606,18 @@ using RaBitQFloatThreeBitBatch4Type = void (*)(const float* vector,
                                                uint32_t reorder_bits,
                                                float* results);
 
+using RaBitQFloatTwoBitCenteredType = float (*)(const float* vector,
+                                                const uint8_t* bits,
+                                                uint64_t dim);
+
+using RaBitQFloatTwoBitCenteredBatch4Type = void (*)(const float* vector,
+                                                     const uint8_t* bits1,
+                                                     const uint8_t* bits2,
+                                                     const uint8_t* bits3,
+                                                     const uint8_t* bits4,
+                                                     uint64_t dim,
+                                                     float* results);
+
 using RaBitQFloatThreeBitCenteredType = float (*)(const float* vector,
                                                   const uint8_t* bits,
                                                   uint64_t dim);
@@ -639,6 +687,8 @@ using RotateOpType = void (*)(float* data, int idx, int dim_, int step);
 extern RaBitQFloatBinaryType RaBitQFloatBinaryIP;
 extern RaBitQFloatBinaryBatch4Type RaBitQFloatBinaryIPBatch4;
 extern RaBitQFloatThreeBitBatch4Type RaBitQFloatThreeBitIPBatch4;
+extern RaBitQFloatTwoBitCenteredType RaBitQFloatTwoBitCenteredIP;
+extern RaBitQFloatTwoBitCenteredBatch4Type RaBitQFloatTwoBitCenteredIPBatch4;
 extern RaBitQFloatThreeBitCenteredType RaBitQFloatThreeBitCenteredIP;
 extern RaBitQFloatThreeBitCenteredBatch4Type RaBitQFloatThreeBitCenteredIPBatch4;
 extern RaBitQFloatThreeBitByLookupType RaBitQFloatThreeBitIPByLookup;

--- a/src/simd/rabitq_simd_test.cpp
+++ b/src/simd/rabitq_simd_test.cpp
@@ -356,6 +356,86 @@ TEST_CASE("RaBitQ FP32 three-bit SIMD Batch4 Compute Codes", "[ut][simd]") {
     }
 }
 
+TEST_CASE("RaBitQ FP32 two-bit centered SIMD Batch4 Compute Codes", "[ut][simd]") {
+    const std::vector<uint64_t> dims = {0, 1, 7, 8, 9, 15, 16, 17, 63, 64, 65, 960};
+
+    for (const auto dim : dims) {
+        const uint64_t plane_bytes = (dim + 7) / 8;
+        std::vector<float> query(dim);
+        for (uint64_t d = 0; d < dim; ++d) {
+            query[d] = static_cast<float>(static_cast<int>(d % 29) - 14) * 0.03125F;
+        }
+
+        std::vector<uint8_t> codes(std::max<uint64_t>(1, plane_bytes * 2 * 4));
+        for (uint64_t i = 0; i < codes.size(); ++i) {
+            codes[i] = static_cast<uint8_t>(43U * i + 5U);
+        }
+
+        const auto* bits1 = codes.data();
+        const auto* bits2 = bits1 + plane_bytes * 2;
+        const auto* bits3 = bits2 + plane_bytes * 2;
+        const auto* bits4 = bits3 + plane_bytes * 2;
+        const uint8_t* all_bits[4] = {bits1, bits2, bits3, bits4};
+
+        float expected[4] = {0.0F, 0.0F, 0.0F, 0.0F};
+        for (uint64_t d = 0; d < dim; ++d) {
+            const uint64_t byte_idx = d >> 3;
+            const uint8_t bit_mask = static_cast<uint8_t>(1U << (d & 7));
+            for (uint32_t i = 0; i < 4; ++i) {
+                const uint8_t* plane0 = all_bits[i];
+                const uint8_t* plane1 = all_bits[i] + plane_bytes;
+                float weight = (plane0[byte_idx] & bit_mask) != 0U ? 1.0F : -1.0F;
+                weight += (plane1[byte_idx] & bit_mask) != 0U ? 0.5F : -0.5F;
+                expected[i] += query[d] * weight;
+            }
+        }
+
+        auto check_result = [&expected](const float* result) {
+            for (uint32_t i = 0; i < 4; ++i) {
+                REQUIRE(std::abs(expected[i] - result[i]) < 1e-4F);
+            }
+        };
+        auto check_one = [&](auto func, const uint8_t* bits, float expected_value) {
+            REQUIRE(std::abs(expected_value - func(query.data(), bits, dim)) < 1e-4F);
+        };
+
+        float result[4] = {0.0F, 0.0F, 0.0F, 0.0F};
+        generic::RaBitQFloatTwoBitCenteredIPBatch4(
+            query.data(), bits1, bits2, bits3, bits4, dim, result);
+        check_result(result);
+        check_one(generic::RaBitQFloatTwoBitCenteredIP, bits1, expected[0]);
+        check_one(generic::RaBitQFloatTwoBitCenteredIP, bits2, expected[1]);
+        check_one(generic::RaBitQFloatTwoBitCenteredIP, bits3, expected[2]);
+        check_one(generic::RaBitQFloatTwoBitCenteredIP, bits4, expected[3]);
+
+        RaBitQFloatTwoBitCenteredIPBatch4(query.data(), bits1, bits2, bits3, bits4, dim, result);
+        check_result(result);
+        check_one(RaBitQFloatTwoBitCenteredIP, bits1, expected[0]);
+        check_one(RaBitQFloatTwoBitCenteredIP, bits2, expected[1]);
+        check_one(RaBitQFloatTwoBitCenteredIP, bits3, expected[2]);
+        check_one(RaBitQFloatTwoBitCenteredIP, bits4, expected[3]);
+
+        if (SimdStatus::SupportAVX2()) {
+            avx2::RaBitQFloatTwoBitCenteredIPBatch4(
+                query.data(), bits1, bits2, bits3, bits4, dim, result);
+            check_result(result);
+            check_one(avx2::RaBitQFloatTwoBitCenteredIP, bits1, expected[0]);
+            check_one(avx2::RaBitQFloatTwoBitCenteredIP, bits2, expected[1]);
+            check_one(avx2::RaBitQFloatTwoBitCenteredIP, bits3, expected[2]);
+            check_one(avx2::RaBitQFloatTwoBitCenteredIP, bits4, expected[3]);
+        }
+        if (SimdStatus::SupportAVX512()) {
+            avx512::RaBitQFloatTwoBitCenteredIPBatch4(
+                query.data(), bits1, bits2, bits3, bits4, dim, result);
+            check_result(result);
+            check_one(avx512::RaBitQFloatTwoBitCenteredIP, bits1, expected[0]);
+            check_one(avx512::RaBitQFloatTwoBitCenteredIP, bits2, expected[1]);
+            check_one(avx512::RaBitQFloatTwoBitCenteredIP, bits3, expected[2]);
+            check_one(avx512::RaBitQFloatTwoBitCenteredIP, bits4, expected[3]);
+        }
+    }
+}
+
 TEST_CASE("RaBitQ FP32 three-bit centered SIMD Batch4 Compute Codes", "[ut][simd]") {
     const std::vector<uint64_t> dims = {0, 1, 7, 8, 9, 15, 16, 17, 63, 64, 65, 960};
 


### PR DESCRIPTION
## Summary
- add centered two-bit RaBitQ SIMD kernels for single and batch4 search
- route FilterBits() == 2 lower-bound search to the centered 2bit path
- add SIMD and quantizer batch4 regression coverage

## Tests
- cmake --build build-review --target unittests -j2
- ./build-review/tests/unittests "RaBitQ FP32 two-bit centered SIMD Batch4 Compute Codes"
- ./build-review/tests/unittests "RaBitQ Split Code Storage"
- ./build-review/tests/unittests "RaBitQ FP32 three-bit centered SIMD Batch4 Compute Codes"
- ./build-review/tests/unittests "RaBitQ FP32 multi-bit lookup SIMD Batch4 Compute Codes"
- ./build-review/tests/unittests "RaBitQSplitDataCell*"
- git diff --check