### PR TITLE
feat: add instance spec to init banner

### DIFF
--- a/docs/docs/en/src/api/resource.md
+++ b/docs/docs/en/src/api/resource.md
@@ -128,6 +128,28 @@ created to choose `trace`, `debug`, `info`, `warn`/`warning`, `error`, `critical
 values are ignored and keep the default level. An explicit `SetLevel` call still overrides the
 environment-derived level.
 
+### Startup init banner
+
+VSAG logs a startup initialization banner when `vsag::init()` runs. To suppress that banner, set
+`VSAG_SUPPRESS_INIT_BANNER` before starting the process. This is useful for tests, CI jobs, or
+applications that need quieter startup logs.
+
+Truthy values are `1`, `on`, and `true`; matching for `on` and `true` is ASCII case-insensitive, so
+`ON`, `On`, and `TRUE` also work. Other values leave the banner enabled.
+
+Set the variable before process start. VSAG also runs `vsag::init()` during static initialization,
+so setting the variable later from inside the process cannot suppress the first banner.
+
+The banner includes an `instance spec` value such as `48C503G`, combining the cpuinfo core count
+with total physical memory. Memory is reported in whole GiB using floor division by `1024^3`; if the
+platform query fails, the memory portion is shown as `?G`. SIMD lines, including `neon` and `sve`,
+retain their existing distribution/platform/using capability semantics.
+
+```bash
+VSAG_SUPPRESS_INIT_BANNER=1 ./your_vsag_app
+VSAG_SUPPRESS_INIT_BANNER=true ./your_vsag_test
+```
+
 ```cpp
 class Logger {
 public:

--- a/docs/docs/zh/src/api/resource.md
+++ b/docs/docs/zh/src/api/resource.md
@@ -126,6 +126,27 @@ vsag::Options::Instance().set_logger(&my_logger);
 `debug`、`info`、`warn`/`warning`、`error`、`critical` 或 `off`。无效值会被忽略，并保留默认等级。
 显式调用 `SetLevel` 仍会覆盖从环境变量得到的等级。
 
+### 启动 init banner
+
+VSAG 会在 `vsag::init()` 运行时输出启动初始化 banner。如需隐藏该 banner，
+请在进程启动前设置 `VSAG_SUPPRESS_INIT_BANNER`。这适用于测试、CI 任务，
+或需要更安静启动日志的应用。
+
+可识别的真值为 `1`、`on` 和 `true`；`on` 与 `true` 按 ASCII 大小写不敏感匹配，
+因此 `ON`、`On` 和 `TRUE` 也有效。其他值会保留 banner 输出。
+
+请务必在进程启动前设置该变量。VSAG 也会在静态初始化阶段运行
+`vsag::init()`，因此在进程内部稍后再设置该变量，无法隐藏首次 banner。
+
+banner 包含类似 `48C503G` 的 `instance spec` 值，将 cpuinfo 获取的核心数与物理内存总量合并展示。
+内存使用 `1024^3` 字节进行整 GiB 向下取整；如果平台查询失败，内存部分显示为 `?G`。包括
+`neon` 和 `sve` 在内的 SIMD 行，仍保持原有的 distribution/platform/using 能力语义。
+
+```bash
+VSAG_SUPPRESS_INIT_BANNER=1 ./your_vsag_app
+VSAG_SUPPRESS_INIT_BANNER=true ./your_vsag_test
+```
+
 ```cpp
 class Logger {
 public:

--- a/src/impl/logger/default_logger_test.cpp
+++ b/src/impl/logger/default_logger_test.cpp
@@ -15,40 +15,17 @@
 
 #include "default_logger.h"
 
-#include <cstdlib>
 #include <iostream>
 #include <sstream>
 #include <string>
 
+#include "test_env.h"
 #include "unittest.h"
 #include "vsag/logger.h"
 
 namespace {
 
-class ScopedEnv {
-public:
-    ScopedEnv(const char* name, const char* value) : name_(name) {
-        const auto* old_value = std::getenv(name_);
-        if (old_value != nullptr) {
-            had_old_value_ = true;
-            old_value_ = old_value;
-        }
-        setenv(name_, value, 1);
-    }
-
-    ~ScopedEnv() {
-        if (had_old_value_) {
-            setenv(name_, old_value_.c_str(), 1);
-        } else {
-            unsetenv(name_);
-        }
-    }
-
-private:
-    const char* name_;
-    bool had_old_value_{false};
-    std::string old_value_;
-};
+using vsag::test::ScopedEnv;
 
 class ScopedStreamCapture {
 public:

--- a/src/impl/logger/logger_test.cpp
+++ b/src/impl/logger/logger_test.cpp
@@ -15,10 +15,15 @@
 
 #include "logger.h"
 
+#include <algorithm>
+#include <regex>
+#include <string>
 #include <vector>
 
+#include "test_env.h"
 #include "unittest.h"
 #include "vsag/options.h"
+#include "vsag/vsag.h"
 namespace {
 
 class CollectLogger : public vsag::Logger {
@@ -62,6 +67,23 @@ public:
     std::vector<std::string> messages_;
 };
 
+class LoggerReplacer {
+public:
+    explicit LoggerReplacer(vsag::Logger* logger)
+        : origin_logger_(vsag::Options::Instance().logger()) {
+        vsag::Options::Instance().set_logger(logger);
+    }
+
+    ~LoggerReplacer() {
+        vsag::Options::Instance().set_logger(origin_logger_);
+    }
+
+private:
+    vsag::Logger* origin_logger_;
+};
+
+using vsag::test::ScopedEnv;
+
 }  // namespace
 
 TEST_CASE("Logger Test", "[ut][logger]") {
@@ -76,8 +98,7 @@ TEST_CASE("Logger Test", "[ut][logger]") {
 
 TEST_CASE("Logger Format Test", "[ut][logger]") {
     CollectLogger logger;
-    auto* origin_logger = vsag::Options::Instance().logger();
-    vsag::Options::Instance().set_logger(&logger);
+    LoggerReplacer logger_replacer(&logger);
 
     vsag::logger::set_level(vsag::logger::level::debug);
     vsag::logger::info("Welcome {}", "logger");
@@ -89,6 +110,40 @@ TEST_CASE("Logger Format Test", "[ut][logger]") {
     REQUIRE(logger.messages_[0] == "info:Welcome logger");
     REQUIRE(logger.messages_[1] == "warn:Easy padding in numbers like 00000012");
     REQUIRE(logger.messages_[2] == "critical:Support for int: 42; hex: 2a; oct: 52; bin: 101010");
+}
 
-    vsag::Options::Instance().set_logger(origin_logger);
+TEST_CASE("Init logs startup output by default", "[ut][logger]") {
+    ScopedEnv env("VSAG_SUPPRESS_INIT_BANNER");
+    CollectLogger logger;
+    LoggerReplacer logger_replacer(&logger);
+
+    REQUIRE(vsag::init());
+
+    auto startup_message =
+        std::find_if(logger.messages_.begin(), logger.messages_.end(), [](const auto& message) {
+            return message.find("info:\n====vsag start init====") != std::string::npos;
+        });
+    REQUIRE(startup_message != logger.messages_.end());
+    REQUIRE(std::regex_search(*startup_message,
+                              std::regex(R"(\ninstance spec: [0-9]+C([0-9]+|\?)G\n)")));
+    REQUIRE(startup_message->find("\ncpu sve >> ") != std::string::npos);
+}
+
+TEST_CASE("Init suppresses startup output when requested", "[ut][logger]") {
+    const std::vector<std::string> suppress_values{
+        "1", "on", "ON", "On", "oN", "true", "TRUE", "True", "TrUe"};
+
+    for (const auto& suppress_value : suppress_values) {
+        ScopedEnv env("VSAG_SUPPRESS_INIT_BANNER", suppress_value.c_str());
+        CollectLogger logger;
+        LoggerReplacer logger_replacer(&logger);
+
+        REQUIRE(vsag::init());
+
+        auto startup_message =
+            std::find_if(logger.messages_.begin(), logger.messages_.end(), [](const auto& message) {
+                return message.find("====vsag start init====") != std::string::npos;
+            });
+        REQUIRE(startup_message == logger.messages_.end());
+    }
 }

--- a/src/impl/logger/test_env.h
+++ b/src/impl/logger/test_env.h
@@ -1,0 +1,80 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdlib>
+#include <string>
+
+#include "unittest.h"
+
+namespace vsag::test {
+
+[[nodiscard]] inline bool
+set_env_value(const char* name, const char* value) {
+#ifdef _WIN32
+    return _putenv_s(name, value) == 0;
+#else
+    return setenv(name, value, 1) == 0;
+#endif
+}
+
+[[nodiscard]] inline bool
+unset_env_value(const char* name) {
+#ifdef _WIN32
+    return _putenv_s(name, "") == 0;
+#else
+    return unsetenv(name) == 0;
+#endif
+}
+
+class ScopedEnv {
+public:
+    explicit ScopedEnv(const char* name) : name_(name) {
+        save_old_value();
+        REQUIRE(unset_env_value(name_));
+    }
+
+    ScopedEnv(const char* name, const char* value) : name_(name) {
+        save_old_value();
+        REQUIRE(set_env_value(name_, value));
+    }
+
+    ~ScopedEnv() {
+        bool restored = false;
+        if (had_old_value_) {
+            restored = set_env_value(name_, old_value_.c_str());
+        } else {
+            restored = unset_env_value(name_);
+        }
+        (void)restored;
+    }
+
+private:
+    void
+    save_old_value() {
+        const auto* old_value = std::getenv(name_);
+        if (old_value != nullptr) {
+            had_old_value_ = true;
+            old_value_ = old_value;
+        }
+    }
+
+    const char* name_;
+    bool had_old_value_{false};
+    std::string old_value_;
+};
+
+}  // namespace vsag::test

--- a/src/vsag.cpp
+++ b/src/vsag.cpp
@@ -18,13 +18,114 @@
 #include <../extern/diskann/DiskANN/include/diskann_logger.h>
 #include <cpuinfo.h>
 
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <limits>
 #include <sstream>
+#include <string_view>
+
+#if defined(_WIN32)
+#include <windows.h>
+#elif defined(__APPLE__)
+#include <sys/sysctl.h>
+#elif defined(__linux__)
+#include <sys/sysinfo.h>
+#endif
 
 #include "impl/logger/logger.h"
 #include "simd/simd.h"
 #include "version.h"
 
 namespace vsag {
+namespace {
+
+[[nodiscard]] char
+ascii_lower(char value) {
+    if (value >= 'A' and value <= 'Z') {
+        return static_cast<char>(value - 'A' + 'a');
+    }
+    return value;
+}
+
+[[nodiscard]] bool
+equals_ignore_case(std::string_view lhs, std::string_view rhs) {
+    if (lhs.size() != rhs.size()) {
+        return false;
+    }
+
+    for (uint64_t i = 0; i < lhs.size(); ++i) {
+        if (ascii_lower(lhs[i]) != ascii_lower(rhs[i])) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+[[nodiscard]] bool
+is_truthy_env_value(std::string_view value) {
+    return value == "1" or equals_ignore_case(value, "on") or equals_ignore_case(value, "true");
+}
+
+[[nodiscard]] bool
+should_suppress_init_banner() {
+    const auto* suppress = std::getenv("VSAG_SUPPRESS_INIT_BANNER");
+    return suppress != nullptr and is_truthy_env_value(suppress);
+}
+
+[[nodiscard]] bool
+get_total_physical_memory(uint64_t& memory_bytes) {
+#if defined(_WIN32)
+    MEMORYSTATUSEX memory_status{};
+    memory_status.dwLength = sizeof(memory_status);
+    if (GlobalMemoryStatusEx(&memory_status) == 0) {
+        return false;
+    }
+    memory_bytes = memory_status.ullTotalPhys;
+    return true;
+#elif defined(__APPLE__)
+    uint64_t value = 0;
+    size_t value_size = sizeof(value);
+    if (sysctlbyname("hw.memsize", &value, &value_size, nullptr, 0) != 0 or value == 0) {
+        return false;
+    }
+    memory_bytes = value;
+    return true;
+#elif defined(__linux__)
+    struct sysinfo memory_info {};
+    if (sysinfo(&memory_info) != 0 or memory_info.totalram == 0 or memory_info.mem_unit == 0) {
+        return false;
+    }
+    if (static_cast<uint64_t>(memory_info.totalram) >
+        std::numeric_limits<uint64_t>::max() / memory_info.mem_unit) {
+        return false;
+    }
+    memory_bytes = static_cast<uint64_t>(memory_info.totalram) * memory_info.mem_unit;
+    return memory_bytes != 0;
+#else
+    (void)memory_bytes;
+    return false;
+#endif
+}
+
+[[nodiscard]] std::string
+instance_spec(uint64_t core_count) {
+    constexpr uint64_t bytes_per_gib = 1024ULL * 1024ULL * 1024ULL;
+    uint64_t memory_bytes = 0;
+    std::stringstream spec;
+    spec << core_count << "C";
+    if (get_total_physical_memory(memory_bytes)) {
+        // Report whole GiB by flooring the byte count for deterministic output.
+        spec << memory_bytes / bytes_per_gib;
+    } else {
+        spec << "?";
+    }
+    spec << "G";
+    return spec.str();
+}
+
+}  // namespace
 
 std::string
 version() {
@@ -39,24 +140,28 @@ init() {
 #endif
 
     cpuinfo_initialize();
-    std::stringstream ss;
-
-    ss << std::boolalpha;
-    ss << "\n====vsag start init====";
-    ss << "\nrunning on " << cpuinfo_get_package(0)->name;
-    ss << "\ncores count: " << cpuinfo_get_cores_count();
     auto simd_status = setup_simd();
-    ss << "\ncpu sse >> " << simd_status.sse();
-    ss << "\ncpu avx >> " << simd_status.avx();
-    ss << "\ncpu avx2 >> " << simd_status.avx2();
-    ss << "\ncpu avx512f >> " << simd_status.avx512f();
-    ss << "\ncpu avx512dq >> " << simd_status.avx512dq();
-    ss << "\ncpu avx512bw >> " << simd_status.avx512bw();
-    ss << "\ncpu avx512vl >> " << simd_status.avx512vl();
-    ss << "\ncpu avx512vpopcntdq >> " << simd_status.avx512vpopcntdq();
-    ss << "\ncpu neon >> " << simd_status.neon();
-    ss << "\n====vsag init done====";
-    logger::debug(ss.str());
+    if (not should_suppress_init_banner()) {
+        std::stringstream ss;
+
+        ss << std::boolalpha;
+        // Keep this leading newline to separate the banner from the preceding shell command.
+        ss << "\n====vsag start init====";
+        ss << "\nrunning on " << cpuinfo_get_package(0)->name;
+        ss << "\ninstance spec: " << instance_spec(cpuinfo_get_cores_count());
+        ss << "\ncpu sse >> " << simd_status.sse();
+        ss << "\ncpu avx >> " << simd_status.avx();
+        ss << "\ncpu avx2 >> " << simd_status.avx2();
+        ss << "\ncpu avx512f >> " << simd_status.avx512f();
+        ss << "\ncpu avx512dq >> " << simd_status.avx512dq();
+        ss << "\ncpu avx512bw >> " << simd_status.avx512bw();
+        ss << "\ncpu avx512vl >> " << simd_status.avx512vl();
+        ss << "\ncpu avx512vpopcntdq >> " << simd_status.avx512vpopcntdq();
+        ss << "\ncpu neon >> " << simd_status.neon();
+        ss << "\ncpu sve >> " << simd_status.sve();
+        ss << "\n====vsag init done====";
+        logger::info(ss.str());
+    }
 
     return true;
 }


### PR DESCRIPTION
## Summary

- Add portable total physical-memory reporting for Linux, macOS, and Windows to the startup init banner.
- Combine core count and floored binary-GiB memory into an `instance spec` value such as `2C8G`; use `?G` if the platform query fails.
- Add SVE reporting with the existing compile-time distribution/runtime platform semantics.
- Preserve the leading newline/comment, INFO and `VSAG_LOG_LEVEL` behavior, runtime suppression, and case-insensitive environment handling.
- Add focused host-independent regression coverage and synchronize English/Chinese resource documentation.

## Test Plan

- `cmake --build build --target unittests -j2`
- `./build/tests/unittests '[ut][logger]'`
- `clang-format-15 --dry-run --Werror src/vsag.cpp src/impl/logger/logger_test.cpp`
- `clang-tidy-15 -p build src/vsag.cpp --quiet`
- `git diff --check`

Memory display uses floor division by `1024^3` bytes for deterministic whole-GiB output.