### PR TITLE
feat(logger): support VSAG_LOG_LEVEL

### DIFF
--- a/docs/docs/en/src/api/resource.md
+++ b/docs/docs/en/src/api/resource.md
@@ -123,6 +123,11 @@ vsag::Options::Instance().set_logger(&my_logger);
 Declared in `vsag/logger.h`. An abstract logging sink. Implement it and register it via
 `Options::set_logger` to route VSAG's log output through your application's logging system.
 
+The built-in logger defaults to `info`. Set `VSAG_LOG_LEVEL` before the built-in logger is
+created to choose `trace`, `debug`, `info`, `warn`/`warning`, `error`, `critical`, or `off`. Invalid
+values are ignored and keep the default level. An explicit `SetLevel` call still overrides the
+environment-derived level.
+
 ```cpp
 class Logger {
 public:

--- a/docs/docs/zh/src/api/resource.md
+++ b/docs/docs/zh/src/api/resource.md
@@ -122,6 +122,10 @@ vsag::Options::Instance().set_logger(&my_logger);
 声明于 `vsag/logger.h`。一个抽象的日志汇。实现它并通过 `Options::set_logger` 注册，即可把 VSAG 的日志
 输出路由到你应用的日志系统。
 
+内置 logger 默认使用 `info`。在内置 logger 创建前设置 `VSAG_LOG_LEVEL`，可选择 `trace`、
+`debug`、`info`、`warn`/`warning`、`error`、`critical` 或 `off`。无效值会被忽略，并保留默认等级。
+显式调用 `SetLevel` 仍会覆盖从环境变量得到的等级。
+
 ```cpp
 class Logger {
 public:

--- a/src/impl/logger/default_logger.cpp
+++ b/src/impl/logger/default_logger.cpp
@@ -17,16 +17,62 @@
 
 #include <unistd.h>
 
+#include <cctype>
 #include <chrono>
 #include <cstdlib>
 #include <ctime>
 #include <iomanip>
 #include <iostream>
 #include <sstream>
+#include <string>
 
 namespace vsag {
 
 namespace {
+
+[[nodiscard]] bool
+parse_log_level(std::string_view value, Logger::Level& log_level) {
+    if (value.size() < 3 or value.size() > 8) {
+        return false;
+    }
+
+    std::string normalized;
+    normalized.reserve(value.size());
+    for (const auto ch : value) {
+        normalized.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(ch))));
+    }
+
+    if (normalized == "trace") {
+        log_level = Logger::Level::kTRACE;
+        return true;
+    }
+    if (normalized == "debug") {
+        log_level = Logger::Level::kDEBUG;
+        return true;
+    }
+    if (normalized == "info") {
+        log_level = Logger::Level::kINFO;
+        return true;
+    }
+    if (normalized == "warn" or normalized == "warning") {
+        log_level = Logger::Level::kWARN;
+        return true;
+    }
+    if (normalized == "error") {
+        log_level = Logger::Level::kERR;
+        return true;
+    }
+    if (normalized == "critical") {
+        log_level = Logger::Level::kCRITICAL;
+        return true;
+    }
+    if (normalized == "off") {
+        log_level = Logger::Level::kOFF;
+        return true;
+    }
+
+    return false;
+}
 
 [[nodiscard]] std::string
 format_timestamp() {
@@ -131,6 +177,14 @@ get_level_color(Logger::Level log_level) {
 }
 
 }  // namespace
+
+DefaultLogger::DefaultLogger() {
+    const auto* log_level_env = std::getenv("VSAG_LOG_LEVEL");
+    Logger::Level log_level = Logger::Level::kINFO;
+    if (log_level_env != nullptr and parse_log_level(log_level_env, log_level)) {
+        level_.store(static_cast<int>(log_level), std::memory_order_relaxed);
+    }
+}
 
 void
 DefaultLogger::SetLevel(Logger::Level log_level) {

--- a/src/impl/logger/default_logger.h
+++ b/src/impl/logger/default_logger.h
@@ -26,6 +26,8 @@ namespace vsag {
 
 class DefaultLogger : public Logger {
 public:
+    DefaultLogger();
+
     void
     SetLevel(Logger::Level log_level) override;
 

--- a/src/impl/logger/default_logger_test.cpp
+++ b/src/impl/logger/default_logger_test.cpp
@@ -15,8 +15,65 @@
 
 #include "default_logger.h"
 
+#include <cstdlib>
+#include <iostream>
+#include <sstream>
+#include <string>
+
 #include "unittest.h"
 #include "vsag/logger.h"
+
+namespace {
+
+class ScopedEnv {
+public:
+    ScopedEnv(const char* name, const char* value) : name_(name) {
+        const auto* old_value = std::getenv(name_);
+        if (old_value != nullptr) {
+            had_old_value_ = true;
+            old_value_ = old_value;
+        }
+        setenv(name_, value, 1);
+    }
+
+    ~ScopedEnv() {
+        if (had_old_value_) {
+            setenv(name_, old_value_.c_str(), 1);
+        } else {
+            unsetenv(name_);
+        }
+    }
+
+private:
+    const char* name_;
+    bool had_old_value_{false};
+    std::string old_value_;
+};
+
+class ScopedStreamCapture {
+public:
+    explicit ScopedStreamCapture(std::ostream& stream)
+        : stream_(stream), old_buffer_(stream.rdbuf()) {
+        stream_.rdbuf(buffer_.rdbuf());
+    }
+
+    ~ScopedStreamCapture() {
+        stream_.rdbuf(old_buffer_);
+    }
+
+    [[nodiscard]] std::string
+    str() const {
+        return buffer_.str();
+    }
+
+private:
+    std::ostream& stream_;
+    std::streambuf* old_buffer_;
+    std::ostringstream buffer_;
+};
+
+}  // namespace
+
 TEST_CASE("DefaultLogger Basic Test", "[ut][logger]") {
     vsag::DefaultLogger logger;
     logger.SetLevel(vsag::Logger::Level::kTRACE);
@@ -26,4 +83,63 @@ TEST_CASE("DefaultLogger Basic Test", "[ut][logger]") {
     logger.Warn("this is a warn level message");
     logger.Error("this is a error level message");
     logger.Critical("this is a critical level message");
+}
+
+TEST_CASE("DefaultLogger uses VSAG_LOG_LEVEL", "[ut][logger]") {
+    ScopedEnv env("VSAG_LOG_LEVEL", "debug");
+    vsag::DefaultLogger logger;
+
+    ScopedStreamCapture capture(std::cout);
+    logger.Debug("debug from env");
+
+    REQUIRE(capture.str().find("debug from env") != std::string::npos);
+}
+
+TEST_CASE("DefaultLogger accepts warning alias in VSAG_LOG_LEVEL", "[ut][logger]") {
+    ScopedEnv env("VSAG_LOG_LEVEL", "warning");
+    vsag::DefaultLogger logger;
+
+    ScopedStreamCapture stdout_capture(std::cout);
+    logger.Info("info filtered by warning env");
+    REQUIRE(stdout_capture.str().find("info filtered by warning env") == std::string::npos);
+
+    ScopedStreamCapture stderr_capture(std::cerr);
+    logger.Warn("warn from warning env");
+    REQUIRE(stderr_capture.str().find("warn from warning env") != std::string::npos);
+}
+
+TEST_CASE("DefaultLogger ignores invalid VSAG_LOG_LEVEL", "[ut][logger]") {
+    ScopedEnv env("VSAG_LOG_LEVEL", "verbose");
+    vsag::DefaultLogger logger;
+
+    ScopedStreamCapture capture(std::cout);
+    logger.Debug("debug filtered by invalid env");
+    logger.Info("info from invalid env fallback");
+
+    REQUIRE(capture.str().find("debug filtered by invalid env") == std::string::npos);
+    REQUIRE(capture.str().find("info from invalid env fallback") != std::string::npos);
+}
+
+TEST_CASE("DefaultLogger supports off in VSAG_LOG_LEVEL", "[ut][logger]") {
+    ScopedEnv env("VSAG_LOG_LEVEL", "off");
+    vsag::DefaultLogger logger;
+
+    ScopedStreamCapture stdout_capture(std::cout);
+    logger.Info("info filtered by off env");
+    REQUIRE(stdout_capture.str().find("info filtered by off env") == std::string::npos);
+
+    ScopedStreamCapture stderr_capture(std::cerr);
+    logger.Critical("critical filtered by off env");
+    REQUIRE(stderr_capture.str().find("critical filtered by off env") == std::string::npos);
+}
+
+TEST_CASE("DefaultLogger SetLevel overrides VSAG_LOG_LEVEL", "[ut][logger]") {
+    ScopedEnv env("VSAG_LOG_LEVEL", "critical");
+    vsag::DefaultLogger logger;
+    logger.SetLevel(vsag::Logger::Level::kDEBUG);
+
+    ScopedStreamCapture capture(std::cout);
+    logger.Debug("debug from explicit level");
+
+    REQUIRE(capture.str().find("debug from explicit level") != std::string::npos);
 }


### PR DESCRIPTION
## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement/Refactor
- [ ] Documentation
- [ ] CI/Build/Infra

## Linked Issue

Not applicable for `kind/improvement`; no issue was provided.

## What Changed

- Added `VSAG_LOG_LEVEL` parsing for the built-in `DefaultLogger`.
- Supported values: `trace`, `debug`, `info`, `warn`/`warning`, `error`, and `critical`.
- Invalid values are ignored so the existing default `info` level remains in effect.
- Documented the environment variable in English and Chinese API resource docs.

## Test Evidence

- [ ] `make fmt`
- [ ] `make lint`
- [ ] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [x] Other (describe below)

Test details:

```text
# TDD check before implementation: failed as expected
./build/tests/unittests "DefaultLogger uses VSAG_LOG_LEVEL"

clang-format-15 -i src/impl/logger/default_logger.cpp src/impl/logger/default_logger.h src/impl/logger/default_logger_test.cpp
cmake --build ./build --target unittests --parallel 96
./build/tests/unittests "DefaultLogger*"
# All tests passed (6 assertions in 5 test cases)

./build/tests/unittests "[ut][logger]"
# All tests passed (11 assertions in 7 test cases)

git diff --check
```

## Compatibility Impact

- API/ABI compatibility: no public API change.
- Behavior changes: the built-in logger now reads `VSAG_LOG_LEVEL` when it is constructed; explicit `SetLevel` calls still override it.

## Performance and Concurrency Impact

- Performance impact: none expected; parsing happens once at logger construction.
- Concurrency/thread-safety impact: none expected.

## Documentation Impact

- [ ] No docs update needed
- [x] Updated docs:
  - [ ] `README.md`
  - [ ] `DEVELOPMENT.md`
  - [ ] `CONTRIBUTING.md`
  - [x] Other: `docs/docs/en/src/api/resource.md`, `docs/docs/zh/src/api/resource.md`

## Risk and Rollback

- Risk level: low
- Rollback plan: revert this commit.

## Checklist

- [ ] I have linked the relevant issue (required for `kind/bug` and `kind/feature`; see "Linked Issue" above)
- [x] I have added/updated tests for new behavior or bug fixes
- [x] I have considered API compatibility impact
- [x] I have updated docs if behavior/workflow changed
- [x] My commit messages follow project conventions (Conventional Commits, optional `[skip ci]` prefix)
