### PR TITLE
fix: preserve pyramid reorder search stats

### DIFF
--- a/src/algorithm/pyramid/pyramid.cpp
+++ b/src/algorithm/pyramid/pyramid.cpp
@@ -286,7 +286,7 @@ Pyramid::KnnSearch(const DatasetPtr& query,
 
     std::string hierarchy_name =
         parsed_param.hierarchies.empty() ? "" : parsed_param.hierarchies[0];
-    auto result = this->search_impl(query, search_func, search_param, hierarchy_name);
+    auto result = this->search_impl(query, search_func, search_param, ctx, hierarchy_name);
     result->Statistics(stats.Dump());
     return result;
 }
@@ -329,7 +329,7 @@ Pyramid::RangeSearch(const DatasetPtr& query,
 
     std::string hierarchy_name =
         parsed_param.hierarchies.empty() ? "" : parsed_param.hierarchies[0];
-    auto result = this->search_impl(query, search_func, search_param, hierarchy_name);
+    auto result = this->search_impl(query, search_func, search_param, ctx, hierarchy_name);
     result->Statistics(stats.Dump());
     return result;
 }
@@ -338,10 +338,8 @@ DatasetPtr
 Pyramid::search_impl(const DatasetPtr& query,
                      const SearchFunc& search_func,
                      InnerSearchParam& search_param,
+                     QueryContext& ctx,
                      const std::string& hierarchy_name) const {
-    SearchStatistics stats;
-    QueryContext ctx{.stats = &stats};
-
     auto h_iter = hierarchies_.find(hierarchy_name);
     CHECK_ARGUMENT(h_iter != hierarchies_.end(),
                    fmt::format("unknown hierarchy name: '{}'", hierarchy_name));
@@ -1003,7 +1001,7 @@ Pyramid::search_node(const IndexNode* node,
 
         Vector<float> dists(id_count, allocator_);
         auto computer = codes->FactoryComputer(query->GetFloat32Vectors());
-        codes->Query(dists.data(), computer, ids_ptr, id_count);
+        codes->Query(dists.data(), computer, ids_ptr, id_count, &ctx);
 
         for (int i = 0; i < id_count; ++i) {
             results->Push(dists[i], ids_ptr[i]);

--- a/src/algorithm/pyramid/pyramid.h
+++ b/src/algorithm/pyramid/pyramid.h
@@ -298,6 +298,7 @@ private:
     search_impl(const DatasetPtr& query,
                 const SearchFunc& search_func,
                 InnerSearchParam& search_param,
+                QueryContext& ctx,
                 const std::string& hierarchy_name = "") const;
 
     /// Probabilistic check: should total_count trigger a new entry-point update?

--- a/src/datacell/flatten_datacell.h
+++ b/src/datacell/flatten_datacell.h
@@ -349,6 +349,11 @@ FlattenDataCell<QuantTmpl, IOTmpl>::query(float* result_dists,
             computer->ScanBatchDists(id_count, codes.data, result_dists);
             return;
         }
+
+        if (ctx != nullptr and ctx->stats != nullptr and id_count > 0) {
+            ctx->stats->io_cnt.fetch_add(static_cast<uint32_t>(id_count),
+                                         std::memory_order_relaxed);
+        }
     }
 
     memset(result_dists, 0, sizeof(float) * id_count);

--- a/tests/test_pyramid.cpp
+++ b/tests/test_pyramid.cpp
@@ -864,6 +864,30 @@ struct MultiHierarchyFixture {
             }
         })";
     }
+
+    static std::string
+    build_reorder_stats_param(const std::string& precise_file_path) {
+        return R"({
+            "dtype": "float32", "metric_type": "l2", "dim": 4,
+            "index_param": {
+                "max_degree": 32, "alpha": 1.2,
+                "graph_type": "nsw",
+                "graph_iter_turn": 15, "neighbor_sample_rate": 0.2,
+                "base_quantization_type": "rabitq",
+                "base_io_type": "memory_io",
+                "use_reorder": true,
+                "precise_quantization_type": "fp32",
+                "precise_io_type": "buffer_io",
+                "precise_file_path": ")" +
+               precise_file_path + R"(",
+                "index_min_size": 0, "support_duplicate": false,
+                "hierarchies": [
+                    {"name": "site", "no_build_levels": [0]},
+                    {"name": "cat", "no_build_levels": [0, 1]}
+                ]
+            }
+        })";
+    }
 };
 
 }  // namespace
@@ -1393,6 +1417,36 @@ TEST_CASE("Multi-Hierarchy: Reorder with multi-hierarchy", "[ft][pyramid][multi_
     auto cat_tech = f.search_ids(index.value(), "cat", "tech");
     REQUIRE(cat_tech.count(100) == 1);
     REQUIRE(cat_tech.count(101) == 1);
+}
+
+TEST_CASE("Multi-Hierarchy: Reorder statistics include precise IO",
+          "[ft][pyramid][multi_hierarchy]") {
+    MultiHierarchyFixture f;
+    fixtures::TempDir temp_dir("pyramid_reorder_stats");
+    auto index = vsag::Factory::CreateIndex(
+        "pyramid", f.build_reorder_stats_param(temp_dir.GenerateRandomFile(false)));
+    REQUIRE(index.has_value());
+    REQUIRE(index.value()->Build(f.make_base()).has_value());
+
+    auto* qv = new float[4]{1.0f, 0.0f, 0.0f, 0.0f};
+    auto* qp = new std::string[1]{"www/news"};
+    auto query = vsag::Dataset::Make();
+    query->NumElements(1)->Dim(4)->Float32Vectors(qv)->Paths("site", qp)->Owner(true);
+
+    std::string sp = R"({"pyramid": {"ef_search": 100, "hierarchies": ["site"]}})";
+    auto knn_result = index.value()->KnnSearch(query, 2, sp);
+    REQUIRE(knn_result.has_value());
+    auto knn_stats = knn_result.value()->GetStatistics({"io_cnt", "reorder_distance_count"});
+    REQUIRE(knn_stats.size() == 2);
+    REQUIRE(std::stoul(knn_stats[0]) > 0);
+    REQUIRE(std::stoul(knn_stats[1]) > 0);
+
+    auto range_result = index.value()->RangeSearch(query, 2.0f, sp);
+    REQUIRE(range_result.has_value());
+    auto range_stats = range_result.value()->GetStatistics({"io_cnt", "reorder_distance_count"});
+    REQUIRE(range_stats.size() == 2);
+    REQUIRE(std::stoul(range_stats[0]) > 0);
+    REQUIRE(std::stoul(range_stats[1]) > 0);
 }
 
 TEST_CASE("Multi-Hierarchy: Single hierarchy in hierarchies config",


### PR DESCRIPTION
## Summary
- Reuse Pyramid search caller QueryContext in search_impl so reorder stats are dumped with the result.
- Pass QueryContext into FLAT-node codes->Query so datacell IO counters are accumulated.
- Add a Pyramid regression test covering KNN and RangeSearch reorder statistics with precise codes backed by non-memory IO.

## Root Cause
Pyramid::search_impl created a local SearchStatistics/QueryContext for reorder. FlattenReorder and datacell IO updated that local stats object, but KnnSearch/RangeSearch only attached the outer stats to the Dataset.

## Validation
- clang-format-15 -i src/algorithm/pyramid/pyramid.cpp src/algorithm/pyramid/pyramid.h tests/test_pyramid.cpp
- cmake --build build --target functests -j2
- ./build/tests/functests "Multi-Hierarchy: Reorder statistics include precise IO"
- ./build/tests/functests "[pyramid][multi_hierarchy]"
- ./build/tests/functests "[pyramid]"

Fixes: #2415
