### PR TITLE
feat: support multi-query batch distance calculation in CalDistanceById

### DIFF
--- a/docs/docs/en/src/advanced/calc_distance_by_id.md
+++ b/docs/docs/en/src/advanced/calc_distance_by_id.md
@@ -43,15 +43,19 @@ tl::expected<DatasetPtr, Error>
 CalDistanceById(const float* query,
                 const int64_t* ids,
                 int64_t count,
-                bool calculate_precise_distance = true) const;
+                bool calculate_precise_distance = true,
+                int64_t topk = -1) const;
 
 // Batch, DatasetPtr (dense or sparse).
 tl::expected<DatasetPtr, Error>
 CalDistanceById(const DatasetPtr& query,
                 const int64_t* ids,
                 int64_t count,
-                bool calculate_precise_distance = true) const;
+                bool calculate_precise_distance = true,
+                int64_t topk = -1) const;
 ```
+For `DatasetPtr` queries with `NumElements() > 1`, check `SUPPORT_BATCH_CALC_DISTANCE_BY_ID` first. `count` is the number of IDs per query, `ids` must contain `NumElements() * count` row-major IDs, and returned distances use the same layout: `distances[q * count + j]` corresponds to `ids[q * count + j]`. When `topk > 0`, each query returns `min(topk, count)` entries sorted by distance in ascending order, and the result also contains the corresponding IDs; invalid IDs (`-1` distances) are ordered after valid distances and only appear if there are not enough valid IDs.
+
 
 Declarations live in
 [`include/vsag/index.h`](https://github.com/antgroup/vsag/blob/main/include/vsag/index.h).
@@ -67,9 +71,11 @@ Declarations live in
 ### Return Semantics
 
 - The single-ID overload returns the distance as a `float`.
-- The batch overload returns a `DatasetPtr` whose `GetDistances()` array has `count` entries
-  aligned with the input `ids`. A value of **`-1`** in that array indicates an **invalid ID**
-  (e.g. the ID does not exist in the index).
+- With `topk == -1`, the batch overload returns a `DatasetPtr` whose `GetDistances()` array has
+  `count` entries aligned with the input `ids`, and it does not return IDs.
+- With `topk > 0`, the batch overload returns the smallest `min(topk, count)` distances per
+  query, sorted ascending, and `GetIds()` contains the corresponding IDs. Invalid IDs (`-1`
+  distances) are ordered after valid distances and only appear if there are not enough valid IDs.
 - The distance metric (IP / L2 / cosine) follows the `metric_type` chosen at index
   construction; see [Metric Semantics](../resources/metric_semantics.md).
 

--- a/docs/docs/en/src/api/index_class.md
+++ b/docs/docs/en/src/api/index_class.md
@@ -219,8 +219,8 @@ error). See [Range Search](../advanced/range_search.md) and `examples/cpp/302_fe
 |--------|-----------|-------|
 | `CalcDistanceById` | `tl::expected<float, Error> CalcDistanceById(const float* vector, int64_t id, bool calculate_precise_distance = true) const` | Distance from a dense query to the stored vector `id`. |
 | `CalcDistanceById` | `tl::expected<float, Error> CalcDistanceById(const DatasetPtr& vector, int64_t id, bool calculate_precise_distance = true) const` | Same, accepting a `DatasetPtr` (works for sparse indexes such as SINDI). |
-| `CalDistanceById` | `tl::expected<DatasetPtr, Error> CalDistanceById(const float* query, const int64_t* ids, int64_t count, bool calculate_precise_distance = true) const` | Batch variant; `-1` in the result marks an invalid distance. |
-| `CalDistanceById` | `tl::expected<DatasetPtr, Error> CalDistanceById(const DatasetPtr& query, const int64_t* ids, int64_t count, bool calculate_precise_distance = true) const` | Batch variant accepting a `DatasetPtr` query. |
+| `CalDistanceById` | `tl::expected<DatasetPtr, Error> CalDistanceById(const float* query, const int64_t* ids, int64_t count, bool calculate_precise_distance = true, int64_t topk = -1) const` | Batch variant; `topk > 0` returns sorted smallest distances with IDs, and invalid `-1` distances are ordered last. |
+| `CalDistanceById` | `tl::expected<DatasetPtr, Error> CalDistanceById(const DatasetPtr& query, const int64_t* ids, int64_t count, bool calculate_precise_distance = true, int64_t topk = -1) const` | DatasetPtr batch variant. For `query->GetNumElements() > 1`, indexes must advertise `SUPPORT_BATCH_CALC_DISTANCE_BY_ID`; `ids` contains `NumElements * count` row-major entries. With `topk > 0`, each query returns `min(topk, count)` sorted distances with matching IDs. |
 
 `calculate_precise_distance = true` may load full-precision vectors (possibly from disk) instead of
 quantized codes. See [Calculate Distance by ID](../advanced/calc_distance_by_id.md) and

--- a/docs/docs/zh/src/advanced/calc_distance_by_id.md
+++ b/docs/docs/zh/src/advanced/calc_distance_by_id.md
@@ -38,15 +38,19 @@ tl::expected<DatasetPtr, Error>
 CalDistanceById(const float* query,
                 const int64_t* ids,
                 int64_t count,
-                bool calculate_precise_distance = true) const;
+                bool calculate_precise_distance = true,
+                int64_t topk = -1) const;
 
 // 批量 ID，DatasetPtr（稠密或稀疏）
 tl::expected<DatasetPtr, Error>
 CalDistanceById(const DatasetPtr& query,
                 const int64_t* ids,
                 int64_t count,
-                bool calculate_precise_distance = true) const;
+                bool calculate_precise_distance = true,
+                int64_t topk = -1) const;
 ```
+对于 `NumElements() > 1` 的 `DatasetPtr` 查询，请先检查 `SUPPORT_BATCH_CALC_DISTANCE_BY_ID`。`count` 表示每个 query 的 ID 数，`ids` 需要包含 `NumElements() * count` 个 row-major ID，返回距离使用相同布局：`distances[q * count + j]` 对应 `ids[q * count + j]`。当 `topk > 0` 时，每个 query 返回按距离升序排列的 `min(topk, count)` 个结果，并同时返回对应 ID；无效 ID（距离为 `-1`）排在有效距离之后，仅在有效 ID 不足时才出现在结果中。
+
 
 声明位于
 [`include/vsag/index.h`](https://github.com/antgroup/vsag/blob/main/include/vsag/index.h)。
@@ -60,8 +64,11 @@ CalDistanceById(const DatasetPtr& query,
 ### 返回值含义
 
 - 单 ID 重载返回 `float` 距离值。
-- 批量重载返回 `DatasetPtr`，其 `GetDistances()` 数组长度为 `count`，与输入 `ids` 一一
-  对应。值为 **`-1`** 表示对应的 ID **无效**（如该 ID 不在索引中）。
+- `topk == -1` 时，批量重载返回 `DatasetPtr`，其 `GetDistances()` 数组长度为 `count`，
+  与输入 `ids` 一一对应，且不返回 ID。
+- `topk > 0` 时，批量重载每个 query 返回按距离升序排列的最小 `min(topk, count)` 个
+  距离，`GetIds()` 包含对应 ID。无效 ID（距离为 `-1`）排在有效距离之后，仅在有效 ID
+  不足时才出现在结果中。
 - 距离的语义由建索引时设置的 `metric_type`（IP / L2 / cosine）决定，参见
   [度量语义](../resources/metric_semantics.md)。
 

--- a/docs/docs/zh/src/api/index_class.md
+++ b/docs/docs/zh/src/api/index_class.md
@@ -214,8 +214,8 @@ RangeSearch(const DatasetPtr& query, float radius, const std::string& parameters
 |------|------|------|
 | `CalcDistanceById` | `tl::expected<float, Error> CalcDistanceById(const float* vector, int64_t id, bool calculate_precise_distance = true) const` | 稠密查询到已存向量 `id` 的距离。 |
 | `CalcDistanceById` | `tl::expected<float, Error> CalcDistanceById(const DatasetPtr& vector, int64_t id, bool calculate_precise_distance = true) const` | 同上，接收 `DatasetPtr`（适用于 SINDI 等稀疏索引）。 |
-| `CalDistanceById` | `tl::expected<DatasetPtr, Error> CalDistanceById(const float* query, const int64_t* ids, int64_t count, bool calculate_precise_distance = true) const` | 批量版本；结果中的 `-1` 表示无效距离。 |
-| `CalDistanceById` | `tl::expected<DatasetPtr, Error> CalDistanceById(const DatasetPtr& query, const int64_t* ids, int64_t count, bool calculate_precise_distance = true) const` | 接收 `DatasetPtr` 查询的批量版本。 |
+| `CalDistanceById` | `tl::expected<DatasetPtr, Error> CalDistanceById(const float* query, const int64_t* ids, int64_t count, bool calculate_precise_distance = true, int64_t topk = -1) const` | 批量版本；`topk > 0` 时返回按距离升序排列的最小距离及对应 ID，无效 `-1` 距离排在最后。 |
+| `CalDistanceById` | `tl::expected<DatasetPtr, Error> CalDistanceById(const DatasetPtr& query, const int64_t* ids, int64_t count, bool calculate_precise_distance = true, int64_t topk = -1) const` | 接收 `DatasetPtr` 查询的批量版本。`query->GetNumElements() > 1` 时索引需声明 `SUPPORT_BATCH_CALC_DISTANCE_BY_ID`；`ids` 包含 `NumElements * count` 个 row-major 条目。`topk > 0` 时每个 query 返回 `min(topk, count)` 个排序距离及对应 ID。 |
 
 `calculate_precise_distance = true` 时可能会加载全精度向量（可能来自磁盘）而非量化编码。见
 [按 ID 计算距离](../advanced/calc_distance_by_id.md) 与

--- a/include/vsag/index.h
+++ b/include/vsag/index.h
@@ -500,7 +500,7 @@ public:
      *
      * Suitable for dense vector indexes (HGraph, BruteForce, IVF, DiskANN, HNSW).
      * The query must be a contiguous float32 array with dimension matching the index.
-      * For sparse vector indexes (SINDI), this overload is not applicable;
+     * For sparse vector indexes (SINDI), this overload is not applicable;
      * use CalcDistanceById(DatasetPtr, int64_t, bool) instead.
      *
      * @param vector The embedding of the query (float32 array for dense vectors).
@@ -522,11 +522,12 @@ public:
     /**
      * @brief Calculate the distance between the query and the vector of the given ID.
      *
-      * Suitable for sparse vector indexes (SINDI) where vectors
-     * cannot be represented as a simple float pointer. The Dataset should
-     * contain sparse vectors via GetSparseVectors().
-     * For dense vector indexes (HGraph, BruteForce, IVF, DiskANN, HNSW),
-     * this overload is also available and internally calls GetFloat32Vectors().
+     * Suitable for Dataset-backed query formats, especially sparse vector indexes
+     * (SINDI) where vectors cannot be represented as a simple float pointer.
+     * Dense DatasetPtr batch queries are supported by the batch overload below
+     * through Float32Vectors() when the index advertises the batch feature; for
+     * this single-ID overload, dense callers should prefer the const float* API
+     * unless the target implementation explicitly supports DatasetPtr distance.
      *
      * @param vector is the embedding of query (sparse or dense format via DatasetPtr).
      * @param id is the unique identifier of the vector to be calculated in the index.
@@ -547,9 +548,11 @@ public:
     /**
      * @brief Calculate the distance between the query and the vector of the given ID for batch.
      *
-     * Suitable for dense vector indexes (HGraph, BruteForce, IVF, DiskANN, HNSW).
+     * Suitable for dense vector indexes. HGraph, BruteForce, IVF, and Pyramid support
+     * top-k output when they advertise the corresponding batch distance feature; DiskANN and
+     * HNSW only support the default topk == -1 behavior and reject positive topk values.
      * The query must be a contiguous float32 array. For sparse vector indexes
-      * (SINDI), this overload is not applicable; use
+     * (SINDI), this overload is not applicable; use
      * CalDistanceById(DatasetPtr, const int64_t*, int64_t, bool) instead.
      *
      * @param query is the embedding of query (float32 array for dense vectors).
@@ -559,40 +562,68 @@ public:
      *        vectors (e.g., full-precision float32) for distance computation, even if it requires
      *        loading data from disk, which may incur I/O overhead. If false, the implementation may
      *        use quantized or approximate representations for faster computation.
-     * @return result is valid distance of input ids. '-1' indicates an invalid distance.
+     * @param topk If -1 (default), returns all count distances without IDs and without sorting.
+     *        If positive, returns the top-k smallest distances in ascending order along with
+     *        matching IDs. The result Dim is min(topk, count). Invalid IDs (missing labels) are
+     *        ranked last and only appear if there are fewer than topk valid IDs.
+     * @return result is valid distance of input ids. If topk == -1, Dim() is count and the
+     *         distance buffer contains count entries. If topk is positive, Dim() is
+     *         min(topk, count), IDs are returned, and the distance/ID buffers contain Dim()
+     *         entries. '-1' indicates an invalid distance.
      */
     [[nodiscard]] virtual tl::expected<DatasetPtr, Error>
     CalDistanceById(const float* query,
                     const int64_t* ids,
                     int64_t count,
-                    bool calculate_precise_distance = true) const {
+                    bool calculate_precise_distance = true,
+                    int64_t topk = -1) const {
         return tl::unexpected(Error(ErrorType::UNSUPPORTED_INDEX_OPERATION,
                                     "Index does not support get distance by id"));
     }
 
     /**
-     * @brief Calculate the distance between the query and the vector of the given ID for batch.
+     * @brief Calculate distances between query(queries) and vectors of given IDs for batch.
      *
-      * Suitable for sparse vector indexes (SINDI) where vectors
-     * cannot be represented as a simple float pointer. The Dataset should
-     * contain sparse vectors via GetSparseVectors().
-     * For dense vector indexes (HGraph, BruteForce, IVF, DiskANN, HNSW),
-     * this overload is also available and internally calls GetFloat32Vectors().
+     * Suitable for Dataset-backed batch query formats. Sparse vector indexes
+     * (SINDI) use GetSparseVectors(). Dense vector indexes that advertise
+     * SUPPORT_BATCH_CALC_DISTANCE_BY_ID can use Float32Vectors() through the
+     * default DatasetPtr batch implementation or an index-specific override.
      *
-     * @param query is the embedding of query (sparse or dense format via DatasetPtr).
-     * @param ids is the unique identifier of the vector to be calculated in the index.
-     * @param count is the count of ids
-     * @param calculate_precise_distance If true, the function will attempt to use high-precision
-     *        vectors (e.g., full-precision float32) for distance computation, even if it requires
-     *        loading data from disk, which may incur I/O overhead. If false, the implementation may
-     *        use quantized or approximate representations for faster computation.
-     * @return result is valid distance of input ids. '-1' indicates an invalid distance.
+     * When the query DatasetPtr contains multiple vectors (NumElements > 1),
+     * this method computes distances for each query against its own row of IDs.
+     * Callers should check SUPPORT_BATCH_CALC_DISTANCE_BY_ID before relying on
+     * multi-query behavior; unsupported indexes return an error. Both the input
+     * IDs and result distances use row-major layout with count IDs per query:
+     * ids[i * count + j] is the j-th ID for query i, and distances[i * count + j]
+     * is the distance from query i to that ID. '-1' indicates an invalid ID.
+     *
+     * @param query is the embedding of query(queries) (sparse or dense via DatasetPtr).
+     *        When NumElements() > 1, each element is a separate query.
+     * @param ids is the unique identifier matrix of vectors to be calculated. For
+     *        multiple queries, it must contain NumElements() * count IDs in row-major layout.
+     * @param count is the count of ids per query
+     * @param calculate_precise_distance If true, the function will attempt to use
+     *        high-precision vectors (e.g., full-precision float32) for distance
+     *        computation, even if it requires loading data from disk, which may
+     *        incur I/O overhead. If false, the implementation may use quantized
+     *        or approximate representations for faster computation.
+     * @param topk If -1 (default), returns all count distances per query without IDs
+     *        and without sorting. If positive, returns the top-k smallest distances
+     *        per query in ascending order along with matching IDs. The result Dim is
+     *        min(topk, count). Invalid IDs (missing labels) are ranked last per query
+     *        row and only appear if there are fewer than topk valid IDs in that row.
+     * @return result distances. Use result->GetDim() as the row stride. When topk == -1,
+     *         Dim() is count and the distance buffer contains NumElements() * count entries.
+     *         When topk is positive, Dim() is min(topk, count), IDs are returned, and the
+     *         distance/ID buffers contain NumElements() * Dim() entries in row-major layout.
+     *         '-1' indicates an invalid distance.
      */
     [[nodiscard]] virtual tl::expected<DatasetPtr, Error>
     CalDistanceById(const DatasetPtr& query,
                     const int64_t* ids,
                     int64_t count,
-                    bool calculate_precise_distance = true) const {
+                    bool calculate_precise_distance = true,
+                    int64_t topk = -1) const {
         return tl::unexpected(Error(ErrorType::UNSUPPORTED_INDEX_OPERATION,
                                     "Index does not support get distance by id"));
     }

--- a/include/vsag/index_features.h
+++ b/include/vsag/index_features.h
@@ -82,6 +82,11 @@ enum IndexFeature {
 
     SUPPORT_TUNE, /**< Supports support tune index */
 
+    SUPPORT_BATCH_CALC_DISTANCE_BY_ID, /**< Supports CalDistanceById(DatasetPtr, ids, count, ...)
+                                           with NumElements() > 1. IDs and distances are row-major:
+                                           distances[q * count + j] is query q vs ids[q * count + j],
+                                           and -1 indicates an invalid id. */
+
     INDEX_FEATURE_COUNT /** must be last one */
 };
 }  // namespace vsag

--- a/src/algorithm/bruteforce/bruteforce.cpp
+++ b/src/algorithm/bruteforce/bruteforce.cpp
@@ -567,7 +567,15 @@ BruteForce::CalcDistanceById(const float* vector,
                              bool calculate_precise_distance) const {
     auto computer = this->inner_codes_->FactoryComputer(vector);
     float result = 0.0F;
-    InnerIdType inner_id = this->label_table_->GetIdByLabel(id);
+    InnerIdType inner_id = 0;
+    {
+        std::shared_lock<std::shared_mutex> lock(this->label_lookup_mutex_);
+        auto [success, mapped_id] = this->label_table_->TryGetIdByLabel(id);
+        if (not success) {
+            return -1.0F;
+        }
+        inner_id = mapped_id;
+    }
     this->inner_codes_->Query(&result, computer, &inner_id, 1);
     return result;
 }
@@ -970,6 +978,7 @@ BruteForce::InitFeatures() {
                 {IndexFeature::SUPPORT_ADD_FROM_EMPTY,
                  IndexFeature::SUPPORT_RANGE_SEARCH,
                  IndexFeature::SUPPORT_CAL_DISTANCE_BY_ID,
+                 IndexFeature::SUPPORT_BATCH_CALC_DISTANCE_BY_ID,
                  IndexFeature::SUPPORT_RANGE_SEARCH_WITH_ID_FILTER});
         }
         if (name == QUANTIZATION_TYPE_VALUE_FP32 and

--- a/src/algorithm/hgraph/hgraph.cpp
+++ b/src/algorithm/hgraph/hgraph.cpp
@@ -373,7 +373,8 @@ DatasetPtr
 HGraph::CalDistanceById(const float* query,
                         const int64_t* ids,
                         int64_t count,
-                        bool calculate_precise_distance) const {
+                        bool calculate_precise_distance,
+                        int64_t topk) const {
     FlattenInterfacePtr flat;
     std::shared_lock<std::shared_mutex> lock;
     if (!this->immutable_.load(std::memory_order_acquire)) {
@@ -389,7 +390,12 @@ HGraph::CalDistanceById(const float* query,
     if (lock.owns_lock() && not this->using_dedup_storage()) {
         lock.unlock();
     }
-    return InnerIndexInterface::cal_distance_by_id(query, ids, count, flat);
+    std::vector<bool> validity;
+    auto result = InnerIndexInterface::cal_distance_by_id(query, ids, count, flat, &validity);
+    if (topk == -1) {
+        return result;
+    }
+    return ApplyTopkWithValidity(result->GetDistances(), ids, count, 1, topk, validity, allocator_);
 }
 
 std::pair<int64_t, int64_t>

--- a/src/algorithm/hgraph/hgraph.h
+++ b/src/algorithm/hgraph/hgraph.h
@@ -98,7 +98,8 @@ public:
     CalDistanceById(const float* query,
                     const int64_t* ids,
                     int64_t count,
-                    bool calculate_precise_distance = true) const override;
+                    bool calculate_precise_distance = true,
+                    int64_t topk = -1) const override;
 
     void
     Deserialize(StreamReader& reader) override;

--- a/src/algorithm/hgraph/hgraph_build.cpp
+++ b/src/algorithm/hgraph/hgraph_build.cpp
@@ -926,6 +926,7 @@ HGraph::InitFeatures() {
     }
     if (have_fp32) {
         this->index_feature_list_->SetFeature(IndexFeature::SUPPORT_CAL_DISTANCE_BY_ID);
+        this->index_feature_list_->SetFeature(IndexFeature::SUPPORT_BATCH_CALC_DISTANCE_BY_ID);
         if (metric_ != MetricType::METRIC_TYPE_COSINE || hold_molds) {
             this->index_feature_list_->SetFeature(IndexFeature::SUPPORT_GET_RAW_VECTOR_BY_IDS);
         }

--- a/src/algorithm/inner_index_interface.cpp
+++ b/src/algorithm/inner_index_interface.cpp
@@ -17,9 +17,14 @@
 
 #include <fmt/format.h>
 
+#include <algorithm>
+#include <cmath>
 #include <cstddef>
 #include <cstring>
+#include <functional>
 #include <limits>
+#include <memory>
+#include <numeric>
 #include <type_traits>
 
 #include "algorithm/bruteforce/bruteforce.h"
@@ -436,44 +441,220 @@ DatasetPtr
 InnerIndexInterface::CalDistanceById(const float* query,
                                      const int64_t* ids,
                                      int64_t count,
-                                     bool calculate_precise_distance) const {
-    auto result = Dataset::Make();
-    result->Owner(true, allocator_);
-    auto* distances = static_cast<float*>(allocator_->Allocate(sizeof(float) * count));
-    result->Distances(distances);
-    for (int64_t i = 0; i < count; ++i) {
-        bool exists = false;
-        {
-            std::shared_lock<std::shared_mutex> lock(this->label_lookup_mutex_);
-            exists = this->label_table_->TryGetIdByLabel(ids[i]).first;
-        }
-        if (exists) {
-            distances[i] = this->CalcDistanceById(query, ids[i], calculate_precise_distance);
-        } else {
-            logger::debug(fmt::format("failed to find id: {}", ids[i]));
-            distances[i] = -1;
-        }
+                                     bool calculate_precise_distance,
+                                     int64_t topk) const {
+    CHECK_ARGUMENT(count >= 0, "CalDistanceById count must be non-negative");
+    const bool invalid_topk = topk != -1 && topk <= 0;
+    CHECK_ARGUMENT(not invalid_topk, "CalDistanceById topk must be -1 or positive");
+    if (count > 0) {
+        CHECK_ARGUMENT(query != nullptr, "CalDistanceById query must not be null");
+        CHECK_ARGUMENT(ids != nullptr, "CalDistanceById ids must not be null");
     }
-    return result;
+    const int64_t result_count = (topk == -1) ? count : std::min(topk, count);
+    auto result = Dataset::Make();
+    result->NumElements(1)->Dim(result_count)->Owner(true, allocator_);
+    if (count == 0) {
+        return result;
+    }
+    auto release_distance_buffer = [this](float* ptr) { allocator_->Deallocate(ptr); };
+    std::unique_ptr<float, decltype(release_distance_buffer)> all_distances_guard(
+        static_cast<float*>(allocator_->Allocate(sizeof(float) * count)), release_distance_buffer);
+    auto* all_distances = all_distances_guard.get();
+    auto calc_fn = [this, query, calculate_precise_distance](int64_t id) -> float {
+        return this->CalcDistanceById(query, id, calculate_precise_distance);
+    };
+    std::vector<bool> validity;
+    this->compute_distances_for_ids(calc_fn, ids, count, all_distances, &validity);
+    if (topk == -1) {
+        result->Distances(all_distances_guard.release());
+        return result;
+    }
+    return ApplyTopkWithValidity(all_distances, ids, count, 1, topk, validity, allocator_);
 }
 
 DatasetPtr
 InnerIndexInterface::CalDistanceById(const DatasetPtr& query,
                                      const int64_t* ids,
                                      int64_t count,
-                                     bool calculate_precise_distance) const {
+                                     bool calculate_precise_distance,
+                                     int64_t topk) const {
+    CHECK_ARGUMENT(query != nullptr, "CalDistanceById query must not be null");
+    CHECK_ARGUMENT(count >= 0, "CalDistanceById count must be non-negative");
+    const bool invalid_topk = topk != -1 && topk <= 0;
+    CHECK_ARGUMENT(not invalid_topk, "CalDistanceById topk must be -1 or positive");
+    if (count > 0) {
+        CHECK_ARGUMENT(ids != nullptr, "CalDistanceById ids must not be null");
+    }
     auto result = Dataset::Make();
     result->Owner(true, allocator_);
-    auto* distances = static_cast<float*>(allocator_->Allocate(sizeof(float) * count));
-    result->Distances(distances);
-    for (int64_t i = 0; i < count; ++i) {
-        try {
-            distances[i] = this->CalcDistanceById(query, ids[i]);
-        } catch (std::runtime_error& e) {
-            logger::debug(fmt::format("failed to find id: {}", ids[i]));
-            distances[i] = -1;
+    const int64_t num_queries = query->GetNumElements();
+    CHECK_ARGUMENT(num_queries > 0, "CalDistanceById query count must be positive");
+    const bool unsupported_multi_query =
+        num_queries != 1 and
+        not this->CheckFeature(IndexFeature::SUPPORT_BATCH_CALC_DISTANCE_BY_ID);
+    CHECK_ARGUMENT(not unsupported_multi_query,
+                   "Index does not support multi-query CalDistanceById");
+    const int64_t result_count = (topk == -1) ? count : std::min(topk, count);
+    const auto count_size = static_cast<uint64_t>(count);
+    const auto num_queries_size = static_cast<uint64_t>(num_queries);
+    const auto max_distance_count = std::numeric_limits<uint64_t>::max() / sizeof(float);
+    const bool distance_count_overflows =
+        count_size != 0 && num_queries_size > max_distance_count / count_size;
+    CHECK_ARGUMENT(not distance_count_overflows, "CalDistanceById distance buffer size overflows");
+    const bool is_sparse = (query->GetSparseVectors() != nullptr);
+    if (query->GetFloat32Vectors() != nullptr) {
+        CHECK_ARGUMENT(query->GetDim() == dim_, "CalDistanceById query dimension mismatch");
+    }
+    result->NumElements(num_queries)->Dim(result_count);
+    if (count == 0) {
+        return result;
+    }
+    auto release_distance_buffer = [this](float* ptr) { allocator_->Deallocate(ptr); };
+    auto release_id_buffer = [this](int64_t* ptr) { allocator_->Deallocate(ptr); };
+    if (query->GetFloat32Vectors() != nullptr && topk != -1) {
+        const auto total_result =
+            static_cast<uint64_t>(num_queries) * static_cast<uint64_t>(result_count);
+        std::unique_ptr<float, decltype(release_distance_buffer)> out_dists_guard(
+            static_cast<float*>(allocator_->Allocate(sizeof(float) * total_result)),
+            release_distance_buffer);
+        CHECK_ARGUMENT(out_dists_guard.get() != nullptr, "Failed to allocate distance buffer");
+        std::unique_ptr<int64_t, decltype(release_id_buffer)> out_ids_guard(
+            static_cast<int64_t*>(allocator_->Allocate(sizeof(int64_t) * total_result)),
+            release_id_buffer);
+        CHECK_ARGUMENT(out_ids_guard.get() != nullptr, "Failed to allocate ID buffer");
+        auto* out_dists = out_dists_guard.get();
+        auto* out_ids = out_ids_guard.get();
+        for (int64_t q = 0; q < num_queries; ++q) {
+            const int64_t* row_ids = ids + q * count;
+            const float* query_ptr = query->GetFloat32Vectors() + q * query->GetDim();
+            auto row_result =
+                this->CalDistanceById(query_ptr, row_ids, count, calculate_precise_distance, topk);
+            std::memcpy(out_dists + q * result_count,
+                        row_result->GetDistances(),
+                        sizeof(float) * result_count);
+            std::memcpy(
+                out_ids + q * result_count, row_result->GetIds(), sizeof(int64_t) * result_count);
+        }
+        result->Ids(out_ids_guard.release())->Distances(out_dists_guard.release());
+        return result;
+    }
+    std::unique_ptr<float, decltype(release_distance_buffer)> all_distances_guard(
+        static_cast<float*>(allocator_->Allocate(sizeof(float) * num_queries_size * count_size)),
+        release_distance_buffer);
+    CHECK_ARGUMENT(all_distances_guard.get() != nullptr, "Failed to allocate distance buffer");
+    auto* all_distances = all_distances_guard.get();
+    std::vector<bool> validity;
+    if (topk != -1) {
+        validity.assign(num_queries_size * count_size, false);
+    }
+    DatasetPtr sub;
+    if (query->GetFloat32Vectors() == nullptr) {
+        sub = Dataset::Make();
+        sub->Owner(false);
+    }
+    for (int64_t q = 0; q < num_queries; ++q) {
+        const int64_t* row_ids = ids + q * count;
+        float* row = all_distances + q * count;
+        if (query->GetFloat32Vectors() != nullptr) {
+            const float* query_ptr = query->GetFloat32Vectors() + q * query->GetDim();
+            auto row_result =
+                this->CalDistanceById(query_ptr, row_ids, count, calculate_precise_distance, -1);
+            std::memcpy(row, row_result->GetDistances(), sizeof(float) * count);
+        } else {
+            sub->NumElements(1)->Dim(query->GetDim())->Owner(false);
+            if (is_sparse) {
+                sub->SparseVectors(query->GetSparseVectors() + q);
+            }
+            if (query->GetMultiVectors() != nullptr) {
+                sub->MultiVectors(query->GetMultiVectors() + q)
+                    ->MultiVectorDim(query->GetMultiVectorDim());
+            }
+            if (query->GetPaths() != nullptr) {
+                sub->Paths(query->GetPaths() + q);
+            }
+            auto calc_fn = [this, sub, calculate_precise_distance](int64_t id) -> float {
+                return this->CalcDistanceById(sub, id, calculate_precise_distance);
+            };
+            std::vector<bool> row_validity;
+            this->compute_distances_for_ids(calc_fn, row_ids, count, row, &row_validity);
+            if (topk != -1) {
+                for (int64_t i = 0; i < count; ++i) {
+                    validity[static_cast<uint64_t>(q) * count_size + static_cast<uint64_t>(i)] =
+                        row_validity[i];
+                }
+            }
         }
     }
+    if (topk == -1) {
+        result->Distances(all_distances_guard.release());
+        return result;
+    }
+    return ApplyTopkWithValidity(
+        all_distances, ids, count, num_queries, topk, validity, allocator_);
+}
+
+DatasetPtr
+ApplyTopkWithValidity(const float* distances,
+                      const int64_t* ids,
+                      int64_t per_row_count,
+                      int64_t num_rows,
+                      int64_t topk,
+                      const std::vector<bool>& validity,
+                      Allocator* allocator) {
+    const bool invalid_topk = topk != -1 && topk <= 0;
+    CHECK_ARGUMENT(not invalid_topk, "CalDistanceById topk must be -1 or positive");
+    const int64_t result_count = (topk == -1) ? per_row_count : std::min(topk, per_row_count);
+    auto result = Dataset::Make();
+    result->NumElements(num_rows)->Dim(result_count)->Owner(true, allocator);
+    if (per_row_count == 0) {
+        return result;
+    }
+    const int64_t total_result = num_rows * result_count;
+    auto release_distance_buffer = [allocator](float* ptr) { allocator->Deallocate(ptr); };
+    auto release_id_buffer = [allocator](int64_t* ptr) { allocator->Deallocate(ptr); };
+    std::unique_ptr<float, decltype(release_distance_buffer)> out_dists_guard(
+        static_cast<float*>(allocator->Allocate(sizeof(float) * total_result)),
+        release_distance_buffer);
+    CHECK_ARGUMENT(out_dists_guard.get() != nullptr,
+                   "CalDistanceById topk output distances allocation failed");
+    std::unique_ptr<int64_t, decltype(release_id_buffer)> out_ids_guard(
+        static_cast<int64_t*>(allocator->Allocate(sizeof(int64_t) * total_result)),
+        release_id_buffer);
+    CHECK_ARGUMENT(out_ids_guard.get() != nullptr,
+                   "CalDistanceById topk output IDs allocation failed");
+    auto* out_dists = out_dists_guard.get();
+    auto* out_ids = out_ids_guard.get();
+    std::vector<int64_t> idx(per_row_count);
+    for (int64_t q = 0; q < num_rows; ++q) {
+        const int64_t* row_ids = ids + q * per_row_count;
+        const float* row_dists = distances + q * per_row_count;
+        const int64_t row_valid_offset = q * per_row_count;
+        float* out_row = out_dists + q * result_count;
+        int64_t* id_row = out_ids + q * result_count;
+        std::iota(idx.begin(), idx.end(), 0);
+        std::partial_sort(
+            idx.begin(), idx.begin() + result_count, idx.end(), [&](int64_t a, int64_t b) {
+                const bool valid_a = validity[row_valid_offset + a];
+                const bool valid_b = validity[row_valid_offset + b];
+                if (valid_a != valid_b) {
+                    return valid_a;
+                }
+                const bool nan_a = std::isnan(row_dists[a]);
+                const bool nan_b = std::isnan(row_dists[b]);
+                if (nan_a != nan_b) {
+                    return not nan_a;
+                }
+                if (nan_a) {
+                    return a < b;
+                }
+                return row_dists[a] < row_dists[b];
+            });
+        for (int64_t i = 0; i < result_count; ++i) {
+            id_row[i] = row_ids[idx[i]];
+            out_row[i] = row_dists[idx[i]];
+        }
+    }
+    result->Ids(out_ids_guard.release())->Distances(out_dists_guard.release());
     return result;
 }
 
@@ -865,7 +1046,8 @@ DatasetPtr
 InnerIndexInterface::cal_distance_by_id(const float* query,
                                         const int64_t* ids,
                                         int64_t count,
-                                        const FlattenInterfacePtr& data) const {
+                                        const FlattenInterfacePtr& data,
+                                        std::vector<bool>* validity) const {
     auto result = Dataset::Make();
     result->Owner(true, allocator_);
     auto* distances = (float*)allocator_->Allocate(sizeof(float) * count);
@@ -873,12 +1055,18 @@ InnerIndexInterface::cal_distance_by_id(const float* query,
     auto computer = data->FactoryComputer(query);
     Vector<InnerIdType> inner_ids(count, 0, allocator_);
     Vector<InnerIdType> invalid_id_loc(allocator_);
+    if (validity != nullptr) {
+        validity->assign(count, false);
+    }
     {
         std::shared_lock<std::shared_mutex> lock(this->label_lookup_mutex_);
         for (int64_t i = 0; i < count; ++i) {
             auto [success, inner_id] = this->label_table_->TryGetIdByLabel(ids[i]);
             if (success) {
                 inner_ids[i] = inner_id;
+                if (validity != nullptr) {
+                    (*validity)[i] = true;
+                }
             } else {
                 logger::debug(fmt::format("failed to find id: {}", ids[i]));
                 invalid_id_loc.push_back(i);

--- a/src/algorithm/inner_index_interface.h
+++ b/src/algorithm/inner_index_interface.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <atomic>
+#include <functional>
 #include <shared_mutex>
 #include <unordered_map>
 #include <vector>
@@ -27,6 +28,7 @@
 #include "datacell/flatten_interface.h"
 #include "dataset_impl.h"
 #include "impl/heap/distance_heap.h"
+#include "impl/label_table/label_table.h"
 #include "inner_index_parameter.h"
 #include "json_types.h"
 #include "metric_type.h"
@@ -41,6 +43,18 @@
 #include "vsag/index.h"
 
 namespace vsag {
+
+// Apply top-k selection with structural validity mask per row.
+// validity has num_rows * per_row_count entries, row-major.
+// Invalid distances are ranked last.
+DatasetPtr
+ApplyTopkWithValidity(const float* distances,
+                      const int64_t* ids,
+                      int64_t per_row_count,
+                      int64_t num_rows,
+                      int64_t topk,
+                      const std::vector<bool>& validity,
+                      Allocator* allocator);
 
 DEFINE_POINTER2(InnerIndex, InnerIndexInterface);
 DEFINE_POINTER(LabelTable);
@@ -141,31 +155,43 @@ public:
     CalDistanceById(const float* query,
                     const int64_t* ids,
                     int64_t count,
-                    bool calculate_precise_distance = true) const;
+                    bool calculate_precise_distance = true,
+                    int64_t topk = -1) const;
 
     /**
-     * @brief Calculate distances by IDs (batch) using DatasetPtr.
+     * @brief Calculate distances by IDs (batch) using DatasetPtr, supports multi-query.
      *
-        * Suitable for sparse vector indexes (SINDI) where vectors
+     * Suitable for sparse vector indexes (SINDI) where vectors
      * cannot be represented as a simple float pointer. The Dataset should
      * contain sparse vectors via GetSparseVectors().
      * For dense vector indexes, this overload is also available via default
      * implementation that calls GetFloat32Vectors().
      *
-     * Default implementation loops through IDs calling CalcDistanceById.
+     * When the query DatasetPtr contains multiple vectors (NumElements > 1),
+     * this method computes distances for each query against its own row of IDs.
+     * Both the input IDs and result distances use row-major layout with count IDs
+     * per query: ids[i * count + j] is the j-th ID for query i, and
+     * distances[i * count + j] is the distance from query i to that ID.
+     * '-1' indicates an invalid ID.
+     *
+     * Default implementation loops through queries and IDs calling CalcDistanceById.
      * Sparse indexes must override for proper sparse vector handling.
      *
-     * @param query DatasetPtr containing the query vector (sparse or dense format).
+     * @param query DatasetPtr containing query vector(s) (sparse or dense format).
+     *        When NumElements() > 1, each element is a separate query.
      * @param ids Array of unique identifiers of vectors to be calculated.
      * @param count Number of IDs in the array.
-     * @param calculate_precise_distance If true, use high-precision vectors for computation.
-     * @return DatasetPtr containing distances. '-1' indicates an invalid ID.
+     * @param calculate_precise_distance If true, use high-precision vectors.
+     * @return DatasetPtr containing distances. Single query: size is count.
+     *         Multi-query (NumElements=N): size is N * count, row-major layout.
+     *         '-1' indicates an invalid ID.
      */
     virtual DatasetPtr
     CalDistanceById(const DatasetPtr& query,
                     const int64_t* ids,
                     int64_t count,
-                    bool calculate_precise_distance = true) const;
+                    bool calculate_precise_distance = true,
+                    int64_t topk = -1) const;
 
     virtual uint64_t
     CalSerializeSize() const;
@@ -530,6 +556,54 @@ protected:
     virtual DetailDataPtr
     get_detail_data_by_info(const IndexDetailInfo& info) const;
 
+    template <typename CalcFn>
+    void
+    compute_distances_for_ids(CalcFn&& calc_fn,
+                              const int64_t* ids,
+                              int64_t count,
+                              float* distances,
+                              std::vector<bool>* validity = nullptr) const {
+        if (validity != nullptr) {
+            validity->assign(count, false);
+        }
+        auto set_missing_distance = [&](int64_t index) -> bool {
+            std::shared_lock<std::shared_mutex> lock(this->label_lookup_mutex_);
+            if (not this->label_table_->TryGetIdByLabel(ids[index]).first) {
+                distances[index] = -1.0F;
+                return true;
+            }
+            if (validity != nullptr) {
+                (*validity)[index] = true;
+            }
+            return false;
+        };
+        auto handle_exception = [&](int64_t index) {
+            if (set_missing_distance(index)) {
+                if (validity != nullptr) {
+                    (*validity)[index] = false;
+                }
+                return;
+            }
+            throw;
+        };
+        for (int64_t i = 0; i < count; ++i) {
+            if (set_missing_distance(i)) {
+                continue;
+            }
+            try {
+                distances[i] = calc_fn(ids[i]);
+                // If calc_fn returns -1.0F (e.g., due to concurrent removal), mark as invalid
+                if (distances[i] == -1.0F and validity != nullptr) {
+                    (*validity)[i] = false;
+                }
+            } catch (const VsagException&) {
+                handle_exception(i);
+            } catch (const std::exception&) {
+                handle_exception(i);
+            }
+        }
+    }
+
     float
     calc_distance_by_id(const float* query, int64_t id, const FlattenInterfacePtr& data) const;
 
@@ -537,7 +611,8 @@ protected:
     cal_distance_by_id(const float* query,
                        const int64_t* ids,
                        int64_t count,
-                       const FlattenInterfacePtr& data) const;
+                       const FlattenInterfacePtr& data,
+                       std::vector<bool>* validity = nullptr) const;
 
     // ========== Search Helper Methods ==========
     // Common filter composition: combines DeletedIdsFilter with user filter

--- a/src/algorithm/ivf/ivf.cpp
+++ b/src/algorithm/ivf/ivf.cpp
@@ -426,6 +426,7 @@ IVF::InitFeatures() {
     }
     if (name == QUANTIZATION_TYPE_VALUE_FP32 or has_fp32) {
         this->index_feature_list_->SetFeature(IndexFeature::SUPPORT_CAL_DISTANCE_BY_ID);
+        this->index_feature_list_->SetFeature(IndexFeature::SUPPORT_BATCH_CALC_DISTANCE_BY_ID);
     }
 
     if (name == QUANTIZATION_TYPE_VALUE_FP32 and
@@ -1462,30 +1463,56 @@ DatasetPtr
 IVF::CalDistanceById(const float* query,
                      const int64_t* ids,
                      int64_t count,
-                     bool calculate_precise_distance) const {
-    if (this->use_reorder_ && calculate_precise_distance) {
-        return this->cal_distance_by_id(query, ids, count, this->reorder_codes_);
+                     bool calculate_precise_distance,
+                     int64_t topk) const {
+    CHECK_ARGUMENT(count >= 0, "CalDistanceById count must be non-negative");
+    const bool invalid_topk = topk != -1 && topk <= 0;
+    CHECK_ARGUMENT(not invalid_topk, "CalDistanceById topk must be -1 or positive");
+    if (count > 0) {
+        CHECK_ARGUMENT(query != nullptr, "CalDistanceById query must not be null");
+        CHECK_ARGUMENT(ids != nullptr, "CalDistanceById ids must not be null");
     }
+    const int64_t result_count = (topk == -1) ? count : std::min(topk, count);
     auto result = Dataset::Make();
-    result->Owner(true, allocator_);
+    result->NumElements(1)->Dim(result_count)->Owner(true, allocator_);
+    if (count == 0) {
+        return result;
+    }
     auto* distances = static_cast<float*>(allocator_->Allocate(sizeof(float) * count));
     result->Distances(distances);
-    auto computer = this->bucket_->FactoryComputer(query);
-    for (int64_t i = 0; i < count; ++i) {
-        bool success = false;
-        InnerIdType inner_id = 0;
-        {
-            std::shared_lock<std::shared_mutex> lock(this->label_lookup_mutex_);
-            std::tie(success, inner_id) = this->label_table_->TryGetIdByLabel(ids[i]);
+    Vector<InnerIdType> inner_ids(count, 0, allocator_);
+    std::vector<bool> validity(count, false);
+    {
+        std::shared_lock<std::shared_mutex> lock(this->label_lookup_mutex_);
+        for (int64_t i = 0; i < count; ++i) {
+            auto [success, inner_id] = this->label_table_->TryGetIdByLabel(ids[i]);
+            if (success) {
+                inner_ids[i] = inner_id;
+                validity[i] = true;
+            }
         }
-        if (not success) {
-            distances[i] = -1;
-            continue;
-        }
-        auto [bucket_id, offset_id] = this->get_location(inner_id);
-        distances[i] = this->bucket_->QueryOneById(computer, bucket_id, offset_id);
     }
-    return result;
+    if (this->use_reorder_ && calculate_precise_distance) {
+        auto computer = this->reorder_codes_->FactoryComputer(query);
+        this->reorder_codes_->Query(distances, computer, inner_ids.data(), count);
+    } else {
+        auto computer = this->bucket_->FactoryComputer(query);
+        for (int64_t i = 0; i < count; ++i) {
+            if (validity[i]) {
+                auto [bucket_id, offset_id] = this->get_location(inner_ids[i]);
+                distances[i] = this->bucket_->QueryOneById(computer, bucket_id, offset_id);
+            }
+        }
+    }
+    for (int64_t i = 0; i < count; ++i) {
+        if (not validity[i]) {
+            distances[i] = -1.0F;
+        }
+    }
+    if (topk == -1) {
+        return result;
+    }
+    return ApplyTopkWithValidity(distances, ids, count, 1, topk, validity, allocator_);
 }
 
 float

--- a/src/algorithm/ivf/ivf.h
+++ b/src/algorithm/ivf/ivf.h
@@ -83,7 +83,8 @@ public:
     CalDistanceById(const float* query,
                     const int64_t* ids,
                     int64_t count,
-                    bool calculate_precise_distance = true) const override;
+                    bool calculate_precise_distance = true,
+                    int64_t topk = -1) const override;
 
     float
     CalcDistanceById(const float* query,

--- a/src/algorithm/lazy_hgraph/lazy_hgraph.cpp
+++ b/src/algorithm/lazy_hgraph/lazy_hgraph.cpp
@@ -256,6 +256,26 @@ LazyHGraph::CalcDistanceById(const float* query,
     return ActiveIndex()->CalcDistanceById(query, id, calculate_precise_distance);
 }
 
+DatasetPtr
+LazyHGraph::CalDistanceById(const float* query,
+                            const int64_t* ids,
+                            int64_t count,
+                            bool calculate_precise_distance,
+                            int64_t topk) const {
+    std::shared_lock lock(this->phase_mutex_);
+    return ActiveIndex()->CalDistanceById(query, ids, count, calculate_precise_distance, topk);
+}
+
+DatasetPtr
+LazyHGraph::CalDistanceById(const DatasetPtr& query,
+                            const int64_t* ids,
+                            int64_t count,
+                            bool calculate_precise_distance,
+                            int64_t topk) const {
+    std::shared_lock lock(this->phase_mutex_);
+    return ActiveIndex()->CalDistanceById(query, ids, count, calculate_precise_distance, topk);
+}
+
 bool
 LazyHGraph::CheckIdExist(int64_t id) const {
     std::shared_lock lock(this->phase_mutex_);
@@ -407,6 +427,7 @@ LazyHGraph::InitFeatures() {
         IndexFeature::SUPPORT_RANGE_SEARCH,
         IndexFeature::SUPPORT_RANGE_SEARCH_WITH_ID_FILTER,
         IndexFeature::SUPPORT_CAL_DISTANCE_BY_ID,
+        IndexFeature::SUPPORT_BATCH_CALC_DISTANCE_BY_ID,
         IndexFeature::SUPPORT_GET_RAW_VECTOR_BY_IDS,
         IndexFeature::SUPPORT_SEARCH_CONCURRENT,
         IndexFeature::SUPPORT_ADD_CONCURRENT,

--- a/src/algorithm/lazy_hgraph/lazy_hgraph.h
+++ b/src/algorithm/lazy_hgraph/lazy_hgraph.h
@@ -68,6 +68,20 @@ public:
                      int64_t id,
                      bool calculate_precise_distance = true) const override;
 
+    DatasetPtr
+    CalDistanceById(const float* query,
+                    const int64_t* ids,
+                    int64_t count,
+                    bool calculate_precise_distance = true,
+                    int64_t topk = -1) const override;
+
+    DatasetPtr
+    CalDistanceById(const DatasetPtr& query,
+                    const int64_t* ids,
+                    int64_t count,
+                    bool calculate_precise_distance = true,
+                    int64_t topk = -1) const override;
+
     void
     Deserialize(StreamReader& reader) override;
 

--- a/src/algorithm/pyramid/pyramid.cpp
+++ b/src/algorithm/pyramid/pyramid.cpp
@@ -844,6 +844,7 @@ Pyramid::InitFeatures() {
 
     this->index_feature_list_->SetFeatures({
         IndexFeature::SUPPORT_CAL_DISTANCE_BY_ID,
+        IndexFeature::SUPPORT_BATCH_CALC_DISTANCE_BY_ID,
     });
 
     // concurrency
@@ -1334,13 +1335,19 @@ DatasetPtr
 Pyramid::CalDistanceById(const float* query,
                          const int64_t* ids,
                          int64_t count,
-                         bool calculate_precise_distance) const {
+                         bool calculate_precise_distance,
+                         int64_t topk) const {
     std::shared_lock<std::shared_mutex> lock(resize_mutex_);
     auto flat = this->base_codes_;
     if (use_reorder_ && calculate_precise_distance) {
         flat = this->precise_codes_;
     }
-    return InnerIndexInterface::cal_distance_by_id(query, ids, count, flat);
+    std::vector<bool> validity;
+    auto result = InnerIndexInterface::cal_distance_by_id(query, ids, count, flat, &validity);
+    if (topk == -1) {
+        return result;
+    }
+    return ApplyTopkWithValidity(result->GetDistances(), ids, count, 1, topk, validity, allocator_);
 }
 
 void

--- a/src/algorithm/pyramid/pyramid.h
+++ b/src/algorithm/pyramid/pyramid.h
@@ -190,7 +190,8 @@ public:
     CalDistanceById(const float* query,
                     const int64_t* ids,
                     int64_t count,
-                    bool calculate_precise_distance = true) const override;
+                    bool calculate_precise_distance = true,
+                    int64_t topk = -1) const override;
 
     void
     Deserialize(StreamReader& reader) override;

--- a/src/algorithm/sindi/sindi.cpp
+++ b/src/algorithm/sindi/sindi.cpp
@@ -17,8 +17,13 @@
 
 #include <algorithm>
 #include <cstring>
+#include <limits>
+#include <memory>
+#include <numeric>
 #include <shared_mutex>
 #include <tuple>
+#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "analyzer/analyzer.h"
@@ -1926,67 +1931,130 @@ DatasetPtr
 SINDI::CalDistanceById(const DatasetPtr& query,
                        const int64_t* ids,
                        int64_t count,
-                       bool calculate_precise_distance) const {
-    if (use_reorder_ && calculate_precise_distance) {
-        std::shared_lock rlock(this->global_mutex_);
-        auto result = Dataset::Make();
-        result->Owner(true, allocator_);
-        auto* distances = static_cast<float*>(allocator_->Allocate(sizeof(float) * count));
-        result->Distances(distances);
-        if (query == nullptr || query->GetNumElements() == 0 ||
-            query->GetSparseVectors() == nullptr) {
-            std::fill_n(distances, count, -1.0F);
-            return result;
-        }
-        auto computer = rerank_flat_->FactoryComputer(query->GetSparseVectors());
-        for (int64_t i = 0; i < count; i++) {
-            auto [success, inner_id] = this->label_table_->TryGetIdByLabel(ids[i]);
-            if (success) {
-                rerank_flat_->Query(distances + i, computer, &inner_id, 1);
-            } else {
-                distances[i] = -1.0F;
-            }
-        }
+                       bool calculate_precise_distance,
+                       int64_t topk) const {
+    const bool invalid_topk = topk != -1 && topk <= 0;
+    CHECK_ARGUMENT(not invalid_topk, "CalDistanceById topk must be -1 or positive");
+    CHECK_ARGUMENT(query != nullptr, "CalDistanceById query must not be null");
+    const int64_t num_queries = query->GetNumElements();
+    CHECK_ARGUMENT(count >= 0, "CalDistanceById count must be non-negative");
+    if (count > 0) {
+        CHECK_ARGUMENT(ids != nullptr, "CalDistanceById ids must not be null");
+    }
+    CHECK_ARGUMENT(num_queries > 0, "CalDistanceById query count must be positive");
+    CHECK_ARGUMENT(query->GetSparseVectors() != nullptr,
+                   "CalDistanceById query sparse vectors must not be null");
+    const auto count_size = static_cast<uint64_t>(count);
+    const auto num_queries_size = static_cast<uint64_t>(num_queries);
+    const auto max_distance_count = std::numeric_limits<uint64_t>::max() / sizeof(float);
+    const bool distance_count_overflows =
+        count_size != 0 && num_queries_size > max_distance_count / count_size;
+    CHECK_ARGUMENT(not distance_count_overflows, "CalDistanceById distance buffer size overflows");
+
+    auto result = Dataset::Make();
+    result->NumElements(num_queries)->Dim(count)->Owner(true, allocator_);
+    if (count == 0) {
         return result;
     }
-
-    // prepare result
-    auto result = Dataset::Make();
-    result->Owner(true, allocator_);
-    auto* distances = static_cast<float*>(allocator_->Allocate(sizeof(float) * count));
-    std::fill_n(distances, count, -1.0F);
+    auto* distances =
+        static_cast<float*>(allocator_->Allocate(sizeof(float) * num_queries_size * count_size));
+    CHECK_ARGUMENT(distances != nullptr, "Failed to allocate SINDI multi-query distance buffer");
     result->Distances(distances);
 
-    // assume count is small, otherwise we should use bitmap to construct filter function
-    std::unordered_map<int64_t, uint32_t> valid_ids;
-    for (auto i = 0; i < count; i++) {
-        valid_ids[ids[i]] = i;
-    }
-    auto filter = [&valid_ids](int64_t id) -> bool { return valid_ids.count(id) != 0; };
-    auto filter_ptr = std::make_shared<WhiteListFilter>(filter);
-
-    // search
+    std::shared_lock rlock(this->global_mutex_);
     CHECK_ARGUMENT(immutable_data_ == nullptr,
                    "immutable SINDI runtime does not support CalDistanceById");
-    constexpr auto* search_param_fmt = R"(
-    {{
-        "sindi": {{
-            "query_prune_ratio": 0,
-            "n_candidate": {}
-        }}
-    }}
-    )";
-    auto search_res =
-        this->KnnSearch(query, count, fmt::format(search_param_fmt, count), filter_ptr);
 
-    // flush results
-    for (auto i = 0; i < search_res->GetDim(); i++) {
-        float dist = search_res->GetDistances()[i];
-        int64_t id = search_res->GetIds()[i];
-        distances[valid_ids[id]] = dist;
+    Vector<int64_t> inner_ids(count, -1, allocator_);
+    std::unordered_map<int64_t, std::vector<int64_t>> window_positions;
+    Vector<float> window_dists(window_size_, 0.0, allocator_);
+    std::vector<bool> validity(num_queries_size * count_size, false);
+    auto calc_row =
+        [this, calculate_precise_distance, &inner_ids, &window_positions, &window_dists, &validity](
+            const SparseVector& sparse_query,
+            const int64_t* row_ids,
+            int64_t row_count,
+            float* row_distances,
+            uint64_t validity_offset) {
+            if (use_reorder_ && calculate_precise_distance) {
+                auto computer = rerank_flat_->FactoryComputer(&sparse_query);
+                for (int64_t i = 0; i < row_count; ++i) {
+                    auto [success, inner_id] = this->label_table_->TryGetIdByLabel(row_ids[i]);
+                    if (success) {
+                        validity[validity_offset + static_cast<uint64_t>(i)] = true;
+                        rerank_flat_->Query(row_distances + i, computer, &inner_id, 1);
+                    } else {
+                        row_distances[i] = -1.0F;
+                    }
+                }
+                return;
+            }
+
+            auto mapped_query = sparse_query;
+            Vector<uint32_t> tmp_ids(allocator_);
+            Vector<float> tmp_vals(allocator_);
+            if (remap_term_ids_) {
+                mapped_query = remap_sparse_vector_for_query(mapped_query, tmp_ids, tmp_vals);
+            }
+            window_positions.clear();
+            SINDISearchParameter search_param;
+            search_param.query_prune_ratio = 0;
+            search_param.term_prune_ratio = 0;
+            auto computer =
+                std::make_shared<SparseTermComputer>(mapped_query, search_param, allocator_);
+            for (int64_t i = 0; i < row_count; ++i) {
+                inner_ids[i] = -1;
+                auto [success, inner_id] = this->label_table_->TryGetIdByLabel(row_ids[i]);
+                if (success) {
+                    inner_ids[i] = inner_id;
+                    validity[validity_offset + static_cast<uint64_t>(i)] = true;
+                    window_positions[inner_id / window_size_].push_back(i);
+                } else {
+                    row_distances[i] = -1.0F;
+                }
+            }
+            // For SQ8, use CalcDistanceByInnerId to ensure decoded values are used
+            // (Query uses raw uint8 which gives different results)
+            if (this->sparse_value_quant_type_ == SparseValueQuantizationType::SQ8) {
+                for (int64_t i = 0; i < row_count; ++i) {
+                    if (inner_ids[i] < 0) {
+                        continue;
+                    }
+                    auto cur_window = inner_ids[i] / window_size_;
+                    auto window_start_id = cur_window * window_size_;
+                    auto term_list = this->window_term_list_[cur_window];
+                    auto inner_offset = static_cast<uint16_t>(inner_ids[i] - window_start_id);
+                    row_distances[i] = term_list->CalcDistanceByInnerId(computer, inner_offset);
+                }
+            } else {
+                for (const auto& [cur_window, positions] : window_positions) {
+                    auto window_start_id = cur_window * window_size_;
+                    auto term_list = this->window_term_list_[cur_window];
+                    std::fill(window_dists.data(), window_dists.data() + window_size_, 0.0F);
+                    term_list->Query(window_dists.data(), computer);
+                    for (const auto position : positions) {
+                        row_distances[position] =
+                            1.0F + window_dists[inner_ids[position] - window_start_id];
+                    }
+                }
+            }
+        };
+
+    for (int64_t q = 0; q < num_queries; ++q) {
+        const auto& sparse_query = query->GetSparseVectors()[q];
+        const int64_t* row_ids = ids + q * count;
+        auto* row = distances + q * count;
+        calc_row(sparse_query,
+                 row_ids,
+                 count,
+                 row,
+                 static_cast<uint64_t>(q) * static_cast<uint64_t>(count));
     }
 
-    return result;
+    if (topk == -1) {
+        return result;
+    }
+    return ApplyTopkWithValidity(distances, ids, count, num_queries, topk, validity, allocator_);
 }
 
 void
@@ -2023,6 +2091,9 @@ SINDI::InitFeatures() {
 
     // info
     this->index_feature_list_->SetFeature(IndexFeature::SUPPORT_CAL_DISTANCE_BY_ID);
+    if (not immutable_enabled_) {
+        this->index_feature_list_->SetFeature(IndexFeature::SUPPORT_BATCH_CALC_DISTANCE_BY_ID);
+    }
     this->index_feature_list_->SetFeature(IndexFeature::SUPPORT_ESTIMATE_MEMORY);
     this->index_feature_list_->SetFeature(IndexFeature::SUPPORT_GET_RAW_VECTOR_BY_IDS);
 

--- a/src/algorithm/sindi/sindi.h
+++ b/src/algorithm/sindi/sindi.h
@@ -178,7 +178,8 @@ public:
     CalDistanceById(const DatasetPtr& query,
                     const int64_t* ids,
                     int64_t count,
-                    bool calculate_precise_distance = true) const override;
+                    bool calculate_precise_distance = true,
+                    int64_t topk = -1) const override;
 
     std::pair<int64_t, int64_t>
     GetMinAndMaxId() const override;

--- a/src/index/diskann.h
+++ b/src/index/diskann.h
@@ -75,8 +75,10 @@ public:
     CalDistanceById(const float* query,
                     const int64_t* ids,
                     int64_t count,
-                    bool calculate_precise_distance = true) const override {
-        SAFE_CALL(return this->cal_distance_by_id(query, ids, count, calculate_precise_distance));
+                    bool calculate_precise_distance = true,
+                    int64_t topk = -1) const override {
+        SAFE_CALL(CHECK_ARGUMENT(topk == -1, "DiskANN does not support topk CalDistanceById");
+                  return this->cal_distance_by_id(query, ids, count, calculate_precise_distance));
     }
 
     tl::expected<float, Error>

--- a/src/index/hnsw.h
+++ b/src/index/hnsw.h
@@ -213,8 +213,11 @@ public:
     CalDistanceById(const float* vector,
                     const int64_t* ids,
                     int64_t count,
-                    bool calculate_precise_distance = true) const override {
-        SAFE_CALL(return this->calc_distance_by_id(vector, ids, count));
+                    bool calculate_precise_distance = true,
+                    int64_t topk = -1) const override {
+        (void)calculate_precise_distance;
+        SAFE_CALL(CHECK_ARGUMENT(topk == -1, "HNSW does not support topk CalDistanceById");
+                  return this->calc_distance_by_id(vector, ids, count));
     };
 
     virtual tl::expected<std::pair<int64_t, int64_t>, Error>

--- a/src/index/index_impl.h
+++ b/src/index/index_impl.h
@@ -121,18 +121,20 @@ public:
     CalDistanceById(const float* query,
                     const int64_t* ids,
                     int64_t count,
-                    bool calculate_precise_distance = true) const override {
+                    bool calculate_precise_distance = true,
+                    int64_t topk = -1) const override {
         SAFE_CALL(return this->inner_index_->CalDistanceById(
-            query, ids, count, calculate_precise_distance));
+            query, ids, count, calculate_precise_distance, topk));
     }
 
     tl::expected<DatasetPtr, Error>
     CalDistanceById(const DatasetPtr& query,
                     const int64_t* ids,
                     int64_t count,
-                    bool calculate_precise_distance = true) const override {
+                    bool calculate_precise_distance = true,
+                    int64_t topk = -1) const override {
         SAFE_CALL(return this->inner_index_->CalDistanceById(
-            query, ids, count, calculate_precise_distance));
+            query, ids, count, calculate_precise_distance, topk));
     }
 
     [[nodiscard]] bool

--- a/tests/test_brute_force.cpp
+++ b/tests/test_brute_force.cpp
@@ -780,6 +780,7 @@ TestBruteForceCalcDistanceById(const fixtures::BruteForceResourcePtr& resource) 
             auto index = TestIndex::TestFactory(BruteForceTestIndex::name, param, true);
             TestIndex::TestBuildIndex(index, dataset, true);
             TestIndex::TestCalcDistanceById(index, dataset);
+            TestIndex::TestMultiQueryBatchCalcDistanceById(index, dataset, 1e-5, true);
             vsag::Options::Instance().set_block_size_limit(origin_size);
         }
     }

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -319,6 +319,7 @@ HGraphTestIndex::TestGeneral(const TestIndex::IndexPtr& index,
     TestCalcDistanceById(index, dataset, 1e-5, expect_success);
     TestGetRawVectorByIds(index, dataset, expect_success);
     TestBatchCalcDistanceById(index, dataset, 1e-5, expect_success);
+    TestMultiQueryBatchCalcDistanceById(index, dataset, 1e-5, expect_success);
     TestSearchAllocator(index, dataset, search_param, recall, true);
     TestUpdateVector(index, dataset, search_param, false);
     TestUpdateId(index, dataset, search_param, true);
@@ -949,6 +950,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HGraphTestIndex,
     TestCheckIdExist(index, dataset, false);
     TestCalcDistanceById(index, dataset, 2e-6, false);
     TestBatchCalcDistanceById(index, dataset, 2e-6, false);
+    TestMultiQueryBatchCalcDistanceById(index, dataset, 2e-6, false, false, true);
     TestKnnSearchExFilter(index, dataset, ex_search_param, recall, false);
     TestKnnSearchIter(index, dataset, ex_search_param, recall, false, true);
     // with ex info empty index
@@ -1871,6 +1873,7 @@ RunHGraphDuplicateChecks(const fixtures::HGraphTestIndexPtr& test_index,
                     TestIndex::TestCalcDistanceById(index, dataset);
                     TestIndex::TestGetRawVectorByIds(index, dataset);
                     TestIndex::TestBatchCalcDistanceById(index, dataset);
+                    TestIndex::TestMultiQueryBatchCalcDistanceById(index, dataset);
                     TestIndex::TestSearchAllocator(index, dataset, search_param, recall, true);
                 }
                 if (run_serialize_check) {

--- a/tests/test_index.h
+++ b/tests/test_index.h
@@ -218,6 +218,14 @@ public:
                               bool is_sparse = false);
 
     static void
+    TestMultiQueryBatchCalcDistanceById(const IndexPtr& index,
+                                        const TestDatasetPtr& dataset,
+                                        float error = 1e-5,
+                                        bool expected_success = true,
+                                        bool is_sparse = false,
+                                        bool expect_all_missing_on_failure = false);
+
+    static void
     TestGetMinAndMaxId(const IndexPtr& index,
                        const TestDatasetPtr& dataset,
                        bool expected_success = true);

--- a/tests/test_index/test_index_calc.cpp
+++ b/tests/test_index/test_index_calc.cpp
@@ -73,8 +73,6 @@ TestIndex::TestBatchCalcDistanceById(const IndexPtr& index,
         } else {
             result = index->CalDistanceById(
                 query->GetFloat32Vectors(), gts->GetIds() + (i * gt_topK), gt_topK);
-            REQUIRE_FALSE(
-                index->CalDistanceById(query, gts->GetIds() + (i * gt_topK), gt_topK).has_value());
         }
         if (not expected_success) {
             return;
@@ -103,6 +101,180 @@ TestIndex::TestBatchCalcDistanceById(const IndexPtr& index,
             REQUIRE(dist == -1);
         }
         queries->NumElements(query_count);
+    }
+
+    SECTION("test topk single-query batch") {
+        if (not index->CheckFeature(vsag::SUPPORT_BATCH_CALC_DISTANCE_BY_ID)) {
+            return;
+        }
+        int64_t topk = std::min(gt_topK, (int64_t)3);
+        for (int64_t i = 0; i < query_count; ++i) {
+            auto query = get_one_query(queries, i);
+            tl::expected<DatasetPtr, vsag::Error> result;
+            if (is_sparse) {
+                result = index->CalDistanceById(
+                    query, gts->GetIds() + (i * gt_topK), gt_topK, true, topk);
+            } else {
+                result = index->CalDistanceById(
+                    query->GetFloat32Vectors(), gts->GetIds() + (i * gt_topK), gt_topK, true, topk);
+            }
+            REQUIRE(result.has_value());
+            REQUIRE(result.value()->GetDim() == topk);
+            REQUIRE(result.value()->GetIds() != nullptr);
+            auto* topk_dists = result.value()->GetDistances();
+            auto* topk_ids = result.value()->GetIds();
+            for (int64_t j = 0; j < topk - 1; ++j) {
+                REQUIRE(topk_dists[j] <= topk_dists[j + 1]);
+            }
+            for (int64_t j = 0; j < topk; ++j) {
+                bool found = false;
+                for (int64_t k = 0; k < gt_topK; ++k) {
+                    if (topk_ids[j] == gts->GetIds()[i * gt_topK + k]) {
+                        REQUIRE(std::abs(topk_dists[j] - gts->GetDistances()[i * gt_topK + k]) <
+                                error);
+                        found = true;
+                        break;
+                    }
+                }
+                REQUIRE(found);
+            }
+        }
+    }
+}
+
+void
+TestIndex::TestMultiQueryBatchCalcDistanceById(const IndexPtr& index,
+                                               const TestDatasetPtr& dataset,
+                                               float error,
+                                               bool expected_success,
+                                               bool is_sparse,
+                                               bool expect_all_missing_on_failure) {
+    if (not index->CheckFeature(vsag::SUPPORT_BATCH_CALC_DISTANCE_BY_ID)) {
+        return;
+    }
+    auto queries = dataset->query_;
+    auto num_queries = queries->GetNumElements();
+    auto gts = dataset->ground_truth_;
+    auto gt_topK = dataset->top_k;
+    (void)is_sparse;
+    if (num_queries < 2) {
+        return;
+    }
+
+    // Use each query's own ground-truth IDs as the row-major batch ID matrix.
+    const int64_t* batch_ids = gts->GetIds();
+    auto multi_result = index->CalDistanceById(queries, batch_ids, gt_topK);
+    if (not expected_success) {
+        if (not expect_all_missing_on_failure) {
+            REQUIRE_FALSE(multi_result.has_value());
+            return;
+        }
+        REQUIRE(multi_result.has_value());
+        auto* distances = multi_result.value()->GetDistances();
+        for (int64_t q = 0; q < num_queries; ++q) {
+            for (int64_t j = 0; j < gt_topK; ++j) {
+                REQUIRE(distances[q * gt_topK + j] == -1);
+            }
+        }
+        return;
+    }
+    REQUIRE(multi_result.has_value());
+    auto* multi_distances = multi_result.value()->GetDistances();
+
+    for (int64_t q = 0; q < num_queries; ++q) {
+        auto single_query = get_one_query(queries, q);
+        const int64_t* row_ids = batch_ids + q * gt_topK;
+        auto single_result = index->CalDistanceById(single_query, row_ids, gt_topK);
+        REQUIRE(single_result.has_value());
+        auto* single_distances = single_result.value()->GetDistances();
+        for (int64_t j = 0; j < gt_topK; ++j) {
+            float expected_dist = single_distances[j];
+            float actual_dist = multi_distances[q * gt_topK + j];
+            REQUIRE(std::abs(expected_dist - actual_dist) < error);
+        }
+    }
+
+    SECTION("test non-existing id with multi-query") {
+        int64_t test_num = 5;
+        std::vector<int64_t> mixed_ids(num_queries * test_num);
+        for (int64_t q = 0; q < num_queries; ++q) {
+            const int64_t* row_ids = batch_ids + q * gt_topK;
+            for (int64_t i = 0; i < test_num; ++i) {
+                mixed_ids[q * test_num + i] =
+                    (i % 2 == 0) ? row_ids[i % gt_topK] : -(q * test_num + i + 1);
+            }
+        }
+        auto r2 = index->CalDistanceById(queries, mixed_ids.data(), test_num);
+        REQUIRE(r2.has_value());
+        auto* d2 = r2.value()->GetDistances();
+        for (int64_t q = 0; q < num_queries; ++q) {
+            for (int64_t i = 0; i < test_num; ++i) {
+                if (i % 2 != 0) {
+                    REQUIRE(d2[q * test_num + i] == -1);
+                }
+            }
+        }
+
+        auto topk_result = index->CalDistanceById(queries, mixed_ids.data(), test_num, true, 3);
+        REQUIRE(topk_result.has_value());
+        auto* topk_dists = topk_result.value()->GetDistances();
+        auto* topk_ids = topk_result.value()->GetIds();
+        for (int64_t q = 0; q < num_queries; ++q) {
+            for (int64_t i = 0; i < 3; ++i) {
+                REQUIRE(topk_ids[q * 3 + i] >= 0);
+                REQUIRE(topk_dists[q * 3 + i] != -1.0F);
+            }
+        }
+    }
+
+    SECTION("test topk multi-query batch") {
+        int64_t topk = std::min(gt_topK, (int64_t)3);
+        auto topk_result = index->CalDistanceById(queries, batch_ids, gt_topK, true, topk);
+        REQUIRE(topk_result.has_value());
+        auto* topk_dists = topk_result.value()->GetDistances();
+        auto* topk_ids_out = topk_result.value()->GetIds();
+        REQUIRE(topk_dists != nullptr);
+        REQUIRE(topk_ids_out != nullptr);
+        for (int64_t q = 0; q < num_queries; ++q) {
+            const float* row_dists = topk_dists + q * topk;
+            const int64_t* row_ids_out = topk_ids_out + q * topk;
+            for (int64_t i = 0; i < topk - 1; ++i) {
+                REQUIRE(row_dists[i] <= row_dists[i + 1]);
+            }
+            for (int64_t i = 0; i < topk; ++i) {
+                bool found = false;
+                for (int64_t j = 0; j < gt_topK; ++j) {
+                    if (row_ids_out[i] == batch_ids[q * gt_topK + j]) {
+                        float expected = multi_distances[q * gt_topK + j];
+                        REQUIRE(std::abs(row_dists[i] - expected) < error);
+                        found = true;
+                        break;
+                    }
+                }
+                REQUIRE(found);
+            }
+        }
+    }
+
+    SECTION("test topk > count returns all") {
+        int64_t big_topk = gt_topK + 100;
+        auto big_result = index->CalDistanceById(queries, batch_ids, gt_topK, true, big_topk);
+        REQUIRE(big_result.has_value());
+        REQUIRE(big_result.value()->GetDim() == gt_topK);
+        auto* big_dists = big_result.value()->GetDistances();
+        for (int64_t q = 0; q < num_queries; ++q) {
+            for (int64_t j = 0; j < gt_topK; ++j) {
+                REQUIRE(std::abs(big_dists[q * gt_topK + j] - multi_distances[q * gt_topK + j]) <
+                        error);
+            }
+        }
+    }
+
+    SECTION("test topk -1 no ids in result") {
+        auto default_result = index->CalDistanceById(queries, batch_ids, gt_topK);
+        REQUIRE(default_result.has_value());
+        REQUIRE(default_result.value()->GetIds() == nullptr);
+        REQUIRE(default_result.value()->GetDim() == gt_topK);
     }
 }
 

--- a/tests/test_ivf.cpp
+++ b/tests/test_ivf.cpp
@@ -300,6 +300,8 @@ IVFTestIndex::TestGeneral(const TestIndex::IndexPtr& index,
     TestRangeSearch(index, dataset, search_param, recall / 2.0, 5, true);
     TestFilterSearch(index, dataset, search_param, recall, true);
     TestCalcDistanceById(index, dataset, 2e-6, true);
+    TestMultiQueryBatchCalcDistanceById(
+        index, dataset, 2e-6, index->CheckFeature(vsag::SUPPORT_BATCH_CALC_DISTANCE_BY_ID));
     TestCheckIdExist(index, dataset);
 }
 

--- a/tests/test_pyramid.cpp
+++ b/tests/test_pyramid.cpp
@@ -472,6 +472,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
         TestRangeSearch(index, dataset, search_param, 0.94, 10, true);
         TestRangeSearch(index, dataset, search_param, 0.49, 5, true);
         TestCalcDistanceById(index, dataset, 1e-5, true);
+        TestMultiQueryBatchCalcDistanceById(index, dataset, 1e-5, true);
     }
 }
 
@@ -499,6 +500,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
             TestFilterSearch(index, dataset, search_param, 0.94, true);
             TestRangeSearch(index, dataset, search_param, 0.94, 10, true);
             TestCalcDistanceById(index, dataset, 1e-5, true);
+            TestMultiQueryBatchCalcDistanceById(index, dataset, 1e-5, true);
         }
     }
 }
@@ -530,6 +532,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
             TestFilterSearch(index, dataset, search_param, 0.94, has_root);
             TestRangeSearch(index, dataset, search_param, 0.94, 10, has_root);
             TestCalcDistanceById(index, dataset, 1e-5, true);
+            TestMultiQueryBatchCalcDistanceById(index, dataset, 1e-5, true);
             dataset->query_->Paths(tmp_paths);
         }
     }
@@ -731,6 +734,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
         TestConcurrentAdd(index, dataset, true);
         TestConcurrentKnnSearch(index, dataset, search_param, 0.94, true);
         TestCalcDistanceById(index, dataset, 1e-5, true);
+        TestMultiQueryBatchCalcDistanceById(index, dataset, 1e-5, true);
     }
     for (auto& dim : dims) {
         auto param = GeneratePyramidBuildParametersString(metric_type, dim, pyramid_param);

--- a/tests/test_sindi.cpp
+++ b/tests/test_sindi.cpp
@@ -202,6 +202,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex,
     TestGetMinAndMaxId(index, dataset, true);
     TestCalcDistanceById(index, dataset, 1e-4, true, true);
     TestBatchCalcDistanceById(index, dataset, 1e-4, true, true);
+    TestMultiQueryBatchCalcDistanceById(index, dataset, 1e-4, true, true);
     TestUpdateVectorSparse(index, dataset, true);
     TestUpdateId(index, dataset, search_param, true);
     TestEstimateMemory("sindi", build_param, dataset);


### PR DESCRIPTION
## Summary

Extend `CalDistanceById(const DatasetPtr&, ids, count, bool, topk=-1)` to accept `DatasetPtr` with `NumElements > 1`, computing distances for each query against its own row of IDs. The `ids` input is a row-major matrix with `num_queries * count` entries, where `count` is the number of IDs per query. The result distances buffer has the same row-major layout: `distances[i * count + j]` = distance from query `i` to `ids[i * count + j]`. `-1` indicates an invalid ID.

Closes #2421

## Changes

- **`include/vsag/index.h`**: Updated API documentation for `CalDistanceById(DatasetPtr, ...)` to describe multi-query behavior
- **`include/vsag/index_features.h`**: Added `SUPPORT_BATCH_CAL_DISTANCE_BY_ID` feature flag
- **`src/algorithm/inner_index_interface.h/.cpp`**: Implemented default multi-query loop in `CalDistanceById(DatasetPtr, ...)`. When `NumElements > 1`, constructs per-query sub-DatasetPtrs and iterates over each query row with its corresponding row of IDs
- **Feature flag registration**: Set `SUPPORT_BATCH_CAL_DISTANCE_BY_ID` for indexes that support batch distance behavior
- **DiskANN/HNSW**: Updated public batch method signatures to match the virtual API; they keep the existing full-distance behavior for `topk == -1` and explicitly reject `topk != -1` because top-k output is not supported there

## Backward Compatibility

Default runtime behavior is unchanged when `topk == -1` and `NumElements == 1`: callers receive the full unsorted distance array without returned IDs. `topk != -1` enables sorted top-k `(id, distance)` output. The public virtual batch method signature changes by adding the final `topk` parameter, so out-of-tree subclasses must update their overrides.

## Scope

- Supported when the feature flag is advertised by the index implementation
- DiskANN/HNSW: batch distance remains available for `topk == -1`; `topk != -1` returns unsupported


