### PR TITLE
feat(sindi): add low-memory immutable build

### DIFF
--- a/src/algorithm/sindi/sindi.cpp
+++ b/src/algorithm/sindi/sindi.cpp
@@ -15,6 +15,7 @@
 
 #include "sindi.h"
 
+#include <cstring>
 #include <vector>
 
 #include "algorithm/sparse_distance.h"
@@ -349,6 +350,10 @@ SINDI::Add(const DatasetPtr& base) {
 
 std::vector<int64_t>
 SINDI::Build(const DatasetPtr& base) {
+    if (immutable_enabled_) {
+        return this->build_immutable(base);
+    }
+
     // note that there's a wlock in Add()
     auto failed_ids = this->Add(base);
     {
@@ -358,6 +363,127 @@ SINDI::Build(const DatasetPtr& base) {
         }
         this->cal_memory_usage();
     }
+    return failed_ids;
+}
+
+std::vector<int64_t>
+SINDI::build_immutable(const DatasetPtr& base) {
+    std::scoped_lock wlock(this->global_mutex_);
+    CHECK_ARGUMENT(immutable_data_ == nullptr, "immutable SINDI has already been built");
+    std::vector<int64_t> failed_ids;
+
+    auto data_num = base->GetNumElements();
+    CHECK_ARGUMENT(data_num > 0, "data_num is zero when add vectors");
+
+    const auto* sparse_vectors = base->GetSparseVectors();
+    const auto* ids = base->GetIds();
+    const auto* extra_info = base->GetExtraInfos();
+    const auto extra_info_size = base->GetExtraInfoSize();
+
+    if (sparse_value_quant_type_ == SparseValueQuantizationType::SQ8 && cur_element_count_ == 0) {
+        float min_val = std::numeric_limits<float>::max();
+        float max_val = std::numeric_limits<float>::lowest();
+        for (int64_t i = 0; i < data_num; ++i) {
+            const auto& vec = sparse_vectors[i];
+            for (int j = 0; j < vec.len_; ++j) {
+                float val = vec.vals_[j];
+                min_val = std::min(min_val, val);
+                max_val = std::max(max_val, val);
+            }
+        }
+        quantization_params_->min_val = min_val;
+        quantization_params_->max_val = max_val;
+        quantization_params_->diff = max_val - min_val;
+        if (quantization_params_->diff < 1e-6) {
+            quantization_params_->diff = 1.0F;
+        }
+    }
+
+    immutable_data_ = std::make_unique<ImmutableSINDIData>(allocator_);
+    immutable_data_->sparse_value_quant_type = sparse_value_quant_type_;
+    immutable_data_->value_code_size = sparse_value_code_size(sparse_value_quant_type_);
+    immutable_data_->windows.reserve(align_up(data_num, window_size_) / window_size_);
+
+    SparseTermDataCellPtr current_window = nullptr;
+    Vector<uint32_t> tmp_ids(allocator_);
+    for (int64_t i = 0; i < data_num; ++i) {
+        if (current_window == nullptr) {
+            current_window = std::make_shared<SparseTermDataCell>(doc_retain_ratio_,
+                                                                  term_id_limit_,
+                                                                  allocator_,
+                                                                  sparse_value_quant_type_,
+                                                                  quantization_params_);
+        }
+
+        const auto& sparse_vector = sparse_vectors[i];
+        if (label_table_->CheckLabel(ids[i])) {
+            failed_ids.push_back(ids[i]);
+            logger::warn("id ({}) already exists", ids[i]);
+            continue;
+        }
+        if (sparse_vector.len_ <= 0) {
+            failed_ids.push_back(ids[i]);
+            logger::warn(
+                "sparse_vector.len_ ({}) is invalid for id ({})", sparse_vector.len_, ids[i]);
+            continue;
+        }
+
+        const auto window_start_id =
+            static_cast<int64_t>(immutable_data_->windows.size()) * window_size_;
+        const auto window_inner_id = cur_element_count_ - window_start_id;
+        CHECK_ARGUMENT(
+            window_inner_id >= 0 and window_inner_id <= std::numeric_limits<uint16_t>::max(),
+            "immutable SINDI window-local doc id overflows uint16_t");
+        auto inner_id = static_cast<uint16_t>(window_inner_id);
+
+        try {
+            if (remap_term_ids_) {
+                auto remapped = remap_sparse_vector_for_build(sparse_vector, tmp_ids);
+                current_window->InsertVector(remapped, inner_id);
+            } else {
+                current_window->InsertVector(sparse_vector, inner_id);
+            }
+        } catch (const std::runtime_error& e) {
+            failed_ids.push_back(ids[i]);
+            logger::warn("runtime error: {}", e.what());
+            continue;
+        } catch (const VsagException& e) {
+            failed_ids.push_back(ids[i]);
+            logger::warn("vsag exception: {}", e.what());
+            continue;
+        } catch (const std::bad_alloc& e) {
+            failed_ids.push_back(ids[i]);
+            logger::warn("memory allocation failed: {}", e.what());
+            continue;
+        }
+
+        label_table_->Insert(cur_element_count_, ids[i]);
+
+        if (extra_info_size > 0) {
+            extra_infos_->InsertExtraInfo(extra_info + i * extra_info_size, cur_element_count_);
+        }
+
+        cur_element_count_++;
+
+        if (use_reorder_) {
+            rerank_flat_->InsertVector(sparse_vectors + i, cur_element_count_ - 1);
+        }
+
+        if (cur_element_count_ % window_size_ == 0) {
+            immutable_data_->windows.emplace_back(allocator_);
+            compact_window_to_immutable(*current_window, immutable_data_->windows.back());
+            current_window.reset();
+        }
+    }
+
+    if (current_window != nullptr && current_window->total_count_ > 0) {
+        immutable_data_->windows.emplace_back(allocator_);
+        compact_window_to_immutable(*current_window, immutable_data_->windows.back());
+    }
+    current_window.reset();
+    window_term_list_.clear();
+    window_term_list_.shrink_to_fit();
+    this->cal_memory_usage();
     return failed_ids;
 }
 
@@ -460,14 +586,11 @@ std::optional<uint32_t>
 SINDI::get_immutable_local_term(const ImmutableSINDIWindow& window, uint32_t term) const {
     if (remap_term_ids_) {
         auto it = std::lower_bound(
-            window.sorted_global_to_local_terms.begin(),
-            window.sorted_global_to_local_terms.end(),
-            std::make_pair(term, uint32_t{0}),
-            [](const auto& lhs, const auto& rhs) { return lhs.first < rhs.first; });
-        if (it == window.sorted_global_to_local_terms.end() || it->first != term) {
+            window.sorted_global_terms.begin(), window.sorted_global_terms.end(), term);
+        if (it == window.sorted_global_terms.end() || *it != term) {
             return std::nullopt;
         }
-        return it->second;
+        return static_cast<uint32_t>(it - window.sorted_global_terms.begin());
     }
     if (term >= window.offsets.size()) {
         return std::nullopt;
@@ -527,7 +650,7 @@ SINDI::scan_immutable_window_by_mapped_terms(float* dists,
         const auto* values =
             window.value_payloads.data() + static_cast<uint64_t>(begin_doc) * value_code_size;
         if (sparse_value_quant_type_ == SparseValueQuantizationType::SQ8) {
-            computer->ScanForAccumulate(it, ids, values, term_count, dists);
+            computer->ScanForAccumulateSQ8(it, ids, values, term_count, dists);
         } else if (sparse_value_quant_type_ == SparseValueQuantizationType::FP16) {
             computer->ScanForAccumulateFP16Bytes(it, ids, values, term_count, dists);
         } else {
@@ -993,8 +1116,7 @@ SINDI::cal_memory_usage() {
         memory += sizeof(ImmutableSINDIData);
         memory += immutable_data_->windows.size() * sizeof(ImmutableSINDIWindow);
         for (const auto& window : immutable_data_->windows) {
-            memory +=
-                window.sorted_global_to_local_terms.size() * sizeof(std::pair<uint32_t, uint32_t>);
+            memory += window.sorted_global_terms.size() * sizeof(uint32_t);
             memory += window.offsets.size() * sizeof(uint32_t);
             memory += window.id_payloads.size() * sizeof(uint16_t);
             memory += window.value_payloads.size() * sizeof(uint8_t);
@@ -1022,8 +1144,6 @@ SINDI::cal_memory_usage() {
 void
 SINDI::Serialize(StreamWriter& writer) const {
     std::shared_lock rlock(this->global_mutex_);
-    const bool mutable_runtime = not immutable_enabled_ and immutable_data_ == nullptr;
-    CHECK_ARGUMENT(mutable_runtime, "immutable SINDI runtime does not support Serialize");
 
     if (cur_element_count_ == 0) {
         StreamWriter::WriteObj(writer, cur_element_count_);
@@ -1051,10 +1171,17 @@ SINDI::Serialize(StreamWriter& writer) const {
         StreamWriter::WriteObj(writer, quantization_params_->diff);
     }
 
-    uint32_t window_term_list_size = window_term_list_.size();
+    uint32_t window_term_list_size =
+        immutable_data_ != nullptr ? immutable_data_->windows.size() : window_term_list_.size();
     StreamWriter::WriteObj(writer, window_term_list_size);
-    for (const auto& window : window_term_list_) {
-        window->Serialize(writer);
+    if (immutable_data_ != nullptr) {
+        for (const auto& window : immutable_data_->windows) {
+            serialize_immutable_window(writer, window);
+        }
+    } else {
+        for (const auto& window : window_term_list_) {
+            window->Serialize(writer);
+        }
     }
 
     label_table_->Serialize(writer);
@@ -1180,6 +1307,124 @@ SINDI::Deserialize(StreamReader& reader) {
 }
 
 void
+SINDI::compact_window_to_immutable(const SparseTermDataCell& term_list,
+                                   ImmutableSINDIWindow& window) const {
+    const auto value_code_size = sparse_value_code_size(sparse_value_quant_type_);
+    uint64_t total_posting_count = 0;
+    window.offsets.clear();
+    window.id_payloads.clear();
+    window.value_payloads.clear();
+    window.sorted_global_terms.clear();
+
+    if (not remap_term_ids_) {
+        window.offsets.reserve(static_cast<uint64_t>(term_list.term_capacity_) + 1);
+    }
+    window.offsets.push_back(0);
+
+    for (uint32_t term = 0; term < term_list.term_capacity_; ++term) {
+        const auto posting_count = term_list.term_sizes_[term];
+        if (posting_count == 0) {
+            if (not remap_term_ids_) {
+                window.offsets.push_back(static_cast<uint32_t>(total_posting_count));
+            }
+            continue;
+        }
+
+        if (total_posting_count >
+            std::numeric_limits<uint32_t>::max() - static_cast<uint64_t>(posting_count)) {
+            throw VsagException(ErrorType::INVALID_ARGUMENT,
+                                "immutable SINDI posting offset overflows uint32_t");
+        }
+        if (remap_term_ids_) {
+            window.sorted_global_terms.push_back(term);
+        }
+
+        const auto old_id_size = window.id_payloads.size();
+        window.id_payloads.resize(old_id_size + posting_count);
+        std::copy(term_list.term_ids_[term]->begin(),
+                  term_list.term_ids_[term]->end(),
+                  window.id_payloads.begin() + old_id_size);
+
+        const auto payload_bytes = static_cast<uint64_t>(posting_count) * value_code_size;
+        const auto old_value_size = window.value_payloads.size();
+        window.value_payloads.resize(old_value_size + payload_bytes);
+        std::memcpy(window.value_payloads.data() + old_value_size,
+                    term_list.term_datas_[term]->data(),
+                    payload_bytes);
+
+        total_posting_count += posting_count;
+        window.offsets.push_back(static_cast<uint32_t>(total_posting_count));
+    }
+}
+
+void
+SINDI::serialize_immutable_window(StreamWriter& writer, const ImmutableSINDIWindow& window) const {
+    uint32_t term_capacity = 0;
+    if (remap_term_ids_) {
+        if (not window.sorted_global_terms.empty()) {
+            term_capacity = window.sorted_global_terms.back() + 1;
+        }
+    } else if (not window.offsets.empty()) {
+        term_capacity = static_cast<uint32_t>(window.offsets.size() - 1);
+    }
+    StreamWriter::WriteObj(writer, term_capacity);
+
+    Vector<float> empty_data(allocator_);
+    Vector<uint32_t> empty_ids(allocator_);
+    Vector<float> buffer_data(allocator_);
+    Vector<uint32_t> buffer_ids(allocator_);
+    Vector<uint32_t> term_sizes(term_capacity, 0, allocator_);
+    uint32_t next_remap_pos = 0;
+    const auto value_code_size = sparse_value_code_size(sparse_value_quant_type_);
+
+    for (uint32_t term = 0; term < term_capacity; ++term) {
+        std::optional<uint32_t> local_term;
+        if (remap_term_ids_) {
+            if (next_remap_pos < window.sorted_global_terms.size() &&
+                window.sorted_global_terms[next_remap_pos] == term) {
+                local_term = next_remap_pos;
+                ++next_remap_pos;
+            }
+        } else {
+            local_term = term;
+        }
+
+        if (not local_term.has_value()) {
+            StreamWriter::WriteVector(writer, empty_ids);
+            StreamWriter::WriteVector(writer, empty_data);
+            continue;
+        }
+
+        const auto begin = window.offsets[local_term.value()];
+        const auto end = window.offsets[local_term.value() + 1];
+        const auto posting_count = end - begin;
+        term_sizes[term] = posting_count;
+        if (posting_count == 0) {
+            StreamWriter::WriteVector(writer, empty_ids);
+            StreamWriter::WriteVector(writer, empty_data);
+            continue;
+        }
+
+        buffer_ids.resize(posting_count);
+        std::copy(window.id_payloads.begin() + begin,
+                  window.id_payloads.begin() + end,
+                  buffer_ids.begin());
+        StreamWriter::WriteVector(writer, buffer_ids);
+
+        const auto payload_bytes = static_cast<uint64_t>(posting_count) * value_code_size;
+        const auto buffer_size =
+            align_up(static_cast<int64_t>(payload_bytes), sizeof(float)) / sizeof(float);
+        buffer_data.resize(buffer_size);
+        std::memset(buffer_data.data(), 0, buffer_size * sizeof(float));
+        std::memcpy(buffer_data.data(),
+                    window.value_payloads.data() + static_cast<uint64_t>(begin) * value_code_size,
+                    payload_bytes);
+        StreamWriter::WriteVector(writer, buffer_data);
+    }
+    StreamWriter::WriteVector(writer, term_sizes);
+}
+
+void
 SINDI::deserialize_immutable_window(StreamReader& reader_ref, ImmutableSINDIWindow& window) const {
     uint32_t term_capacity = 0;
     StreamReader::ReadObj(reader_ref, term_capacity);
@@ -1188,8 +1433,6 @@ SINDI::deserialize_immutable_window(StreamReader& reader_ref, ImmutableSINDIWind
     const auto value_code_size = sparse_value_code_size(sparse_value_quant_type_);
 
     Vector<uint32_t> ids_buffer(allocator_);
-    Vector<uint32_t> observed_term_sizes(allocator_);
-    observed_term_sizes.reserve(term_capacity);
 
     if (not remap_term_ids_) {
         window.offsets.reserve(static_cast<uint64_t>(term_capacity) + 1);
@@ -1214,7 +1457,6 @@ SINDI::deserialize_immutable_window(StreamReader& reader_ref, ImmutableSINDIWind
         CHECK_ARGUMENT(data_count <= std::numeric_limits<uint64_t>::max() / sizeof(float),
                        "immutable SINDI value payload size overflows uint64_t");
 
-        observed_term_sizes.push_back(static_cast<uint32_t>(posting_count));
         if (posting_count > std::numeric_limits<uint32_t>::max() - total_posting_count) {
             throw VsagException(ErrorType::INVALID_ARGUMENT,
                                 "immutable SINDI posting offset overflows uint32_t");
@@ -1237,8 +1479,8 @@ SINDI::deserialize_immutable_window(StreamReader& reader_ref, ImmutableSINDIWind
 
         uint32_t local_term = term;
         if (remap_term_ids_) {
-            local_term = static_cast<uint32_t>(window.sorted_global_to_local_terms.size());
-            window.sorted_global_to_local_terms.emplace_back(term, local_term);
+            local_term = static_cast<uint32_t>(window.sorted_global_terms.size());
+            window.sorted_global_terms.push_back(term);
         }
 
         const auto old_id_size = window.id_payloads.size();
@@ -1271,14 +1513,12 @@ SINDI::deserialize_immutable_window(StreamReader& reader_ref, ImmutableSINDIWind
         }
     }
 
-    Vector<uint32_t> term_sizes(allocator_);
-    StreamReader::ReadVector(reader_ref, term_sizes);
-    CHECK_ARGUMENT(term_sizes.size() == observed_term_sizes.size(),
-                   "immutable SINDI term_sizes length mismatch");
-    for (uint32_t term = 0; term < term_sizes.size(); ++term) {
-        CHECK_ARGUMENT(term_sizes[term] == observed_term_sizes[term],
-                       "immutable SINDI term_sizes value mismatch");
-    }
+    uint64_t term_sizes_count = 0;
+    StreamReader::ReadObj(reader_ref, term_sizes_count);
+    CHECK_ARGUMENT(term_sizes_count == term_capacity, "immutable SINDI term_sizes length mismatch");
+    CHECK_ARGUMENT(term_sizes_count <= (std::numeric_limits<uint64_t>::max() / sizeof(uint32_t)),
+                   "immutable SINDI term_sizes payload size overflows uint64_t");
+    reader_ref.Seek(reader_ref.GetCursor() + term_sizes_count * sizeof(uint32_t));
 
     const auto expected_payload_size = (window.offsets.empty() ? 0 : window.offsets.back()) *
                                        static_cast<uint64_t>(value_code_size);

--- a/src/algorithm/sindi/sindi.h
+++ b/src/algorithm/sindi/sindi.h
@@ -27,13 +27,13 @@ namespace vsag {
 
 struct ImmutableSINDIWindow {
     explicit ImmutableSINDIWindow(Allocator* allocator)
-        : sorted_global_to_local_terms(allocator),
+        : sorted_global_terms(allocator),
           offsets(allocator),
           id_payloads(allocator),
           value_payloads(allocator) {
     }
 
-    Vector<std::pair<uint32_t, uint32_t>> sorted_global_to_local_terms;
+    Vector<uint32_t> sorted_global_terms;
     Vector<uint32_t> offsets;
     Vector<uint16_t> id_payloads;
     Vector<uint8_t> value_payloads;
@@ -234,6 +234,16 @@ private:
 
     void
     deserialize_immutable_window(StreamReader& reader_ref, ImmutableSINDIWindow& window) const;
+
+    void
+    serialize_immutable_window(StreamWriter& writer, const ImmutableSINDIWindow& window) const;
+
+    void
+    compact_window_to_immutable(const SparseTermDataCell& term_list,
+                                ImmutableSINDIWindow& window) const;
+
+    std::vector<int64_t>
+    build_immutable(const DatasetPtr& base);
 
     std::optional<uint32_t>
     get_immutable_local_term(const ImmutableSINDIWindow& window, uint32_t term) const;

--- a/src/algorithm/sindi/sindi_test.cpp
+++ b/src/algorithm/sindi/sindi_test.cpp
@@ -18,6 +18,7 @@
 
 #include <array>
 #include <set>
+#include <tuple>
 
 #include "impl/allocator/safe_allocator.h"
 #include "index_common_param.h"
@@ -596,7 +597,149 @@ TEST_CASE("SINDI Immutable Runtime Rejects Mutable Operations", "[ut][SINDI]") {
 
     std::stringstream ss;
     vsag::IOStreamWriter writer(ss);
-    REQUIRE_THROWS_AS(index.Serialize(writer), vsag::VsagException);
+    REQUIRE_NOTHROW(index.Serialize(writer));
+}
+
+TEST_CASE("SINDI Immutable Build Search And Serialize Test", "[ut][SINDI]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    IndexCommonParam common_param;
+    common_param.allocator_ = allocator;
+    common_param.metric_ = MetricType::METRIC_TYPE_IP;
+
+    auto param_tuple = GENERATE(std::make_tuple("fp32", false, false),
+                                std::make_tuple("sq8", false, true),
+                                std::make_tuple("fp16", true, false),
+                                std::make_tuple("fp32", true, true));
+    const auto* sparse_value_quant_type = std::get<0>(param_tuple);
+    const bool remap_term_ids = std::get<1>(param_tuple);
+    const bool use_reorder = std::get<2>(param_tuple);
+    const std::string use_quantization =
+        std::string(sparse_value_quant_type) == "fp16"
+            ? R"("fp16")"
+            : (std::string(sparse_value_quant_type) == "sq8" ? "true" : "false");
+
+    constexpr uint32_t num_base = 10050;
+    constexpr uint32_t num_query = 2;
+    constexpr uint32_t window_size = 10000;
+    constexpr int64_t max_dim = 48;
+    constexpr int64_t max_id = 1000;
+    constexpr uint32_t id_offset = 700000;
+
+    std::vector<int64_t> ids(num_base);
+    for (uint32_t i = 0; i < num_base; ++i) {
+        ids[i] = i;
+    }
+
+    auto sv_base = fixtures::GenerateSparseVectors(num_base, max_dim, max_id, 0, 10, 2243);
+    std::set<uint32_t> unique_terms;
+    for (uint32_t i = 0; i < num_base; ++i) {
+        for (uint32_t j = 0; j < sv_base[i].len_; ++j) {
+            if (remap_term_ids) {
+                sv_base[i].ids_[j] += id_offset;
+            }
+            unique_terms.insert(sv_base[i].ids_[j]);
+        }
+    }
+
+    auto base = vsag::Dataset::Make();
+    base->NumElements(num_base)->SparseVectors(sv_base.data())->Ids(ids.data())->Owner(false);
+
+    uint32_t term_id_limit = remap_term_ids ? static_cast<uint32_t>(unique_terms.size()) + 10
+                                            : static_cast<uint32_t>(max_id) + 1;
+    auto mutable_param_str = fmt::format(R"({{
+        "use_reorder": {},
+        "use_quantization": {},
+        "doc_prune_ratio": 0.0,
+        "window_size": {},
+        "term_id_limit": {},
+        "remap_term_ids": {},
+        "avg_doc_term_length": 48,
+        "immutable": false
+    }})",
+                                         use_reorder,
+                                         use_quantization,
+                                         window_size,
+                                         term_id_limit,
+                                         remap_term_ids);
+    auto immutable_param_str = fmt::format(R"({{
+        "use_reorder": {},
+        "use_quantization": {},
+        "doc_prune_ratio": 0.0,
+        "window_size": {},
+        "term_id_limit": {},
+        "remap_term_ids": {},
+        "avg_doc_term_length": 48,
+        "immutable": true
+    }})",
+                                           use_reorder,
+                                           use_quantization,
+                                           window_size,
+                                           term_id_limit,
+                                           remap_term_ids);
+
+    auto mutable_param = std::make_shared<vsag::SINDIParameter>();
+    mutable_param->FromJson(vsag::JsonType::Parse(mutable_param_str));
+    auto immutable_param = std::make_shared<vsag::SINDIParameter>();
+    immutable_param->FromJson(vsag::JsonType::Parse(immutable_param_str));
+    auto mutable_index = std::make_unique<SINDI>(mutable_param, common_param);
+    auto immutable_index = std::make_unique<SINDI>(immutable_param, common_param);
+
+    REQUIRE(mutable_index->Build(base).empty());
+    REQUIRE(immutable_index->Build(base).empty());
+    REQUIRE(immutable_index->GetNumElements() == num_base);
+
+    auto add_data = vsag::Dataset::Make();
+    add_data->NumElements(1)->SparseVectors(sv_base.data())->Ids(ids.data())->Owner(false);
+    REQUIRE_THROWS_AS(immutable_index->Add(add_data), vsag::VsagException);
+
+    auto mutable_from_immutable = std::make_unique<SINDI>(mutable_param, common_param);
+    auto immutable_from_immutable = std::make_unique<SINDI>(immutable_param, common_param);
+    test_serializion(*immutable_index, *mutable_from_immutable);
+    test_serializion(*immutable_index, *immutable_from_immutable);
+
+    static constexpr auto search_param_str = R"(
+    {
+        "sindi": {
+            "query_prune_ratio": 0.0,
+            "term_prune_ratio": 0.0,
+            "n_candidate": 40,
+            "use_term_lists_heap_insert": true
+        }
+    }
+    )";
+
+    auto query = vsag::Dataset::Make();
+    for (uint32_t i = 0; i < num_query; ++i) {
+        query->NumElements(1)->SparseVectors(sv_base.data() + i)->Owner(false);
+        auto expected = mutable_index->KnnSearch(query, 10, search_param_str, nullptr);
+        auto built = immutable_index->KnnSearch(query, 10, search_param_str, nullptr);
+        auto mutable_roundtrip =
+            mutable_from_immutable->KnnSearch(query, 10, search_param_str, nullptr);
+        auto immutable_roundtrip =
+            immutable_from_immutable->KnnSearch(query, 10, search_param_str, nullptr);
+        REQUIRE(built->GetDim() == expected->GetDim());
+        REQUIRE(mutable_roundtrip->GetDim() == expected->GetDim());
+        REQUIRE(immutable_roundtrip->GetDim() == expected->GetDim());
+        for (int64_t j = 0; j < expected->GetDim(); ++j) {
+            REQUIRE(built->GetIds()[j] == expected->GetIds()[j]);
+            REQUIRE(mutable_roundtrip->GetIds()[j] == expected->GetIds()[j]);
+            REQUIRE(immutable_roundtrip->GetIds()[j] == expected->GetIds()[j]);
+            REQUIRE(std::abs(built->GetDistances()[j] - expected->GetDistances()[j]) < 1e-3);
+            REQUIRE(std::abs(mutable_roundtrip->GetDistances()[j] - expected->GetDistances()[j]) <
+                    1e-3);
+            REQUIRE(std::abs(immutable_roundtrip->GetDistances()[j] - expected->GetDistances()[j]) <
+                    1e-3);
+        }
+
+        auto expected_range = mutable_index->RangeSearch(query, 0.0F, search_param_str, nullptr);
+        auto built_range = immutable_index->RangeSearch(query, 0.0F, search_param_str, nullptr);
+        REQUIRE(built_range->GetDim() == expected_range->GetDim());
+    }
+
+    for (auto& item : sv_base) {
+        delete[] item.vals_;
+        delete[] item.ids_;
+    }
 }
 
 TEST_CASE("SINDI Remap Basic Test", "[ut][SINDI]") {

--- a/src/analyzer/sindi_analyzer.cpp
+++ b/src/analyzer/sindi_analyzer.cpp
@@ -276,7 +276,6 @@ SINDIAnalyzer::collect_doc_prune_candidates(const SparseVector& query,
     const bool use_term_lists_heap_insert = sindi_->UseTermListsHeapInsert(search_param);
 
     Vector<float> dists(sindi_->window_size_, 0.0F, sindi_->allocator_);
-    Vector<float> decoded_values(sindi_->allocator_);
 
     for (int64_t cur = 0; cur < static_cast<int64_t>(sindi_->window_term_list_.size()); ++cur) {
         auto window_start_id = static_cast<uint32_t>(cur * sindi_->window_size_);
@@ -299,14 +298,11 @@ SINDIAnalyzer::collect_doc_prune_candidates(const SparseVector& query,
             }
 
             if (is_sq8_value_quantization(term_list->sparse_value_quant_type_)) {
-                decoded_values.resize(term_size);
-                term_list->Decode(
-                    term_list->term_datas_[term]->data(), term_size, decoded_values.data());
-                computer->ScanForAccumulate(term_idx,
-                                            term_list->term_ids_[term]->data(),
-                                            decoded_values.data(),
-                                            term_size,
-                                            dists.data());
+                computer->ScanForAccumulateSQ8(term_idx,
+                                               term_list->term_ids_[term]->data(),
+                                               term_list->term_datas_[term]->data(),
+                                               term_size,
+                                               dists.data());
             } else if (term_list->sparse_value_quant_type_ == SparseValueQuantizationType::FP16) {
                 computer->ScanForAccumulateFP16Bytes(term_idx,
                                                      term_list->term_ids_[term]->data(),

--- a/src/datacell/sparse_term_datacell.cpp
+++ b/src/datacell/sparse_term_datacell.cpp
@@ -45,7 +45,7 @@ SparseTermDataCell::Query(float* global_dists, const SparseTermComputerPtr& comp
                                                computer->term_retain_ratio_);
 
         if (sparse_value_quant_type_ == SparseValueQuantizationType::SQ8) {
-            computer->ScanForAccumulate(
+            computer->ScanForAccumulateSQ8(
                 it, term_ids_[term]->data(), term_datas_[term]->data(), term_size, global_dists);
         } else if (sparse_value_quant_type_ == SparseValueQuantizationType::FP16) {
             computer->ScanForAccumulateFP16Bytes(

--- a/src/quantization/sparse_quantization/sparse_term_computer.h
+++ b/src/quantization/sparse_quantization/sparse_term_computer.h
@@ -67,13 +67,12 @@ public:
         }
     }
 
-    template <class T>
     void
-    ScanForAccumulate(uint32_t term_iterator,
-                      const uint16_t* term_ids,
-                      const T* term_datas,
-                      uint32_t term_count,
-                      float* global_dists) {
+    ScanForAccumulateSQ8(uint32_t term_iterator,
+                         const uint16_t* term_ids,
+                         const uint8_t* term_datas,
+                         uint32_t term_count,
+                         float* global_dists) {
         float query_val = sorted_query_[term_iterator].second;
 
         // TODO(ZXY): add prefetch to decrease cache miss like:
@@ -81,25 +80,7 @@ public:
         //  __builtin_prefetch(term_datas + term_count / 2, 0, 3);
         //  __builtin_prefetch(global_dists + term_ids[term_count / 2], 0, 3);
 
-        if constexpr (std::is_same_v<T, float>) {
-            FP32SparseAccumulate(global_dists, term_ids, term_datas, query_val, term_count);
-        } else if constexpr (std::is_same_v<T, uint8_t>) {
-            SQ8SparseAccumulate(global_dists, term_ids, term_datas, query_val, term_count);
-        } else {
-            for (uint32_t i = 0; i < term_count; i++) {
-                global_dists[term_ids[i]] += query_val * term_datas[i];
-            }
-        }
-    }
-
-    void
-    ScanForAccumulateFP16(uint32_t term_iterator,
-                          const uint16_t* term_ids,
-                          const uint16_t* term_datas,
-                          uint32_t term_count,
-                          float* global_dists) {
-        float query_val = sorted_query_[term_iterator].second;
-        FP16SparseAccumulate(global_dists, term_ids, term_datas, query_val, term_count);
+        SQ8SparseAccumulate(global_dists, term_ids, term_datas, query_val, term_count);
     }
 
     void
@@ -109,12 +90,7 @@ public:
                                uint32_t term_count,
                                float* global_dists) {
         float query_val = sorted_query_[term_iterator].second;
-        for (uint32_t i = 0; i < term_count; ++i) {
-            uint16_t value = 0;
-            std::memcpy(
-                &value, term_datas + static_cast<uint64_t>(i) * sizeof(value), sizeof(value));
-            global_dists[term_ids[i]] += query_val * generic::FP16ToFloat(value);
-        }
+        AccumulateFP16Bytes(global_dists, term_ids, term_datas, query_val, term_count);
     }
 
     void
@@ -124,12 +100,7 @@ public:
                                 uint32_t term_count,
                                 float* global_dists) {
         float query_val = sorted_query_[term_iterator].second;
-        for (uint32_t i = 0; i < term_count; ++i) {
-            float value = 0.0F;
-            std::memcpy(
-                &value, term_datas + static_cast<uint64_t>(i) * sizeof(value), sizeof(value));
-            global_dists[term_ids[i]] += query_val * value;
-        }
+        AccumulateFloatBytes(global_dists, term_ids, term_datas, query_val, term_count);
     }
 
     inline void
@@ -207,6 +178,49 @@ public:
     uint32_t
     GetTerm(uint32_t term_iterator) {
         return sorted_query_[term_iterator].first;
+    }
+
+private:
+    static constexpr uint32_t BYTE_ACCUMULATE_BATCH_SIZE = 32;
+
+    static void
+    AccumulateFP16Bytes(float* global_dists,
+                        const uint16_t* term_ids,
+                        const uint8_t* term_datas,
+                        float query_val,
+                        uint32_t term_count) {
+        uint32_t offset = 0;
+        while (offset < term_count) {
+            const uint32_t remaining = term_count - offset;
+            const uint32_t batch_size =
+                remaining < BYTE_ACCUMULATE_BATCH_SIZE ? remaining : BYTE_ACCUMULATE_BATCH_SIZE;
+            uint16_t values[BYTE_ACCUMULATE_BATCH_SIZE];
+            std::memcpy(values,
+                        term_datas + static_cast<uint64_t>(offset) * sizeof(uint16_t),
+                        static_cast<uint64_t>(batch_size) * sizeof(uint16_t));
+            FP16SparseAccumulate(global_dists, term_ids + offset, values, query_val, batch_size);
+            offset += batch_size;
+        }
+    }
+
+    static void
+    AccumulateFloatBytes(float* global_dists,
+                         const uint16_t* term_ids,
+                         const uint8_t* term_datas,
+                         float query_val,
+                         uint32_t term_count) {
+        uint32_t offset = 0;
+        while (offset < term_count) {
+            const uint32_t remaining = term_count - offset;
+            const uint32_t batch_size =
+                remaining < BYTE_ACCUMULATE_BATCH_SIZE ? remaining : BYTE_ACCUMULATE_BATCH_SIZE;
+            float values[BYTE_ACCUMULATE_BATCH_SIZE];
+            std::memcpy(values,
+                        term_datas + static_cast<uint64_t>(offset) * sizeof(float),
+                        static_cast<uint64_t>(batch_size) * sizeof(float));
+            FP32SparseAccumulate(global_dists, term_ids + offset, values, query_val, batch_size);
+            offset += batch_size;
+        }
     }
 
 public:

--- a/src/quantization/sparse_quantization/sparse_term_computer_test.cpp
+++ b/src/quantization/sparse_quantization/sparse_term_computer_test.cpp
@@ -69,42 +69,14 @@ TEST_CASE("SparseTermComputer Basic Test", "[ut][SparseTermComputer]") {
     REQUIRE(std::abs(query_val - (-1.0 * query_id)) < 1e-3);
     std::vector<uint16_t> term_ids = {0, 2, 4, 6, 8};
 
-    SECTION("Scan with non-quantized data (float)") {
-        std::vector<float> dists(10, 0);
-        std::vector<float> term_vals = {0.1f, 2.2f, 4.3f, 6.4f, 8.5f};
-        computer->ScanForAccumulate(
-            test_term_it, term_ids.data(), term_vals.data(), term_ids.size(), dists.data());
-        for (uint64_t i = 0; i < term_ids.size(); i++) {
-            auto id = term_ids[i];
-            REQUIRE(std::abs(dists[id] - (term_vals[i] * query_val)) < 1e-3);
-        }
-    }
-
     SECTION("Scan with quantized data (uint8_t)") {
         std::vector<float> dists(10, 0);
         std::vector<uint8_t> term_vals{0, 2, 4, 6, 8};
-        computer->ScanForAccumulate(
+        computer->ScanForAccumulateSQ8(
             test_term_it, term_ids.data(), term_vals.data(), term_ids.size(), dists.data());
         for (uint64_t i = 0; i < term_ids.size(); i++) {
             auto id = term_ids[i];
             REQUIRE(std::abs(dists[id] - (term_vals[i] * query_val)) < 1e-3);
-        }
-    }
-
-    SECTION("Scan with fp16 data") {
-        std::vector<float> dists(10, 0);
-        std::vector<float> raw_term_vals = {0.1F, 2.2F, 4.3F, 6.4F, 8.5F};
-        std::vector<uint16_t> term_vals(raw_term_vals.size());
-        for (uint64_t i = 0; i < raw_term_vals.size(); ++i) {
-            term_vals[i] = generic::FloatToFP16(raw_term_vals[i]);
-        }
-
-        computer->ScanForAccumulateFP16(
-            test_term_it, term_ids.data(), term_vals.data(), term_ids.size(), dists.data());
-        for (uint64_t i = 0; i < term_ids.size(); i++) {
-            auto id = term_ids[i];
-            auto expected = generic::FP16ToFloat(term_vals[i]) * query_val;
-            REQUIRE(std::abs(dists[id] - expected) < 1e-3);
         }
     }
 

--- a/src/simd/sse.cpp
+++ b/src/simd/sse.cpp
@@ -127,16 +127,11 @@ FP32SparseAccumulate(float* RESTRICT dists,
         __m128 val_vec = _mm_loadu_ps(vals + i);
         __m128 delta_vec = _mm_mul_ps(val_vec, q_vec);
 
-        __m128i id_vec = _mm_loadl_epi64(reinterpret_cast<const __m128i*>(ids + i));
-        __m128i idx_vec = _mm_cvtepu16_epi32(id_vec);
-
         alignas(16) float res[4];
-        alignas(16) int32_t indices[4];
         _mm_store_ps(res, delta_vec);
-        _mm_store_si128(reinterpret_cast<__m128i*>(indices), idx_vec);
 
         for (int k = 0; k < 4; ++k) {
-            dists[indices[k]] += res[k];
+            dists[ids[i + k]] += res[k];
         }
     }
     for (; i < num; ++i) {
@@ -381,22 +376,17 @@ SQ8SparseAccumulate(float* RESTRICT dists,
     __m128 q_vec = _mm_set1_ps(query_val);
     uint32_t i = 0;
     for (; i + 4 <= num; i += 4) {
-        uint32_t packed_vals = 0;
-        std::memcpy(&packed_vals, vals + i, sizeof(packed_vals));
-        __m128i val_i32 = _mm_cvtepu8_epi32(_mm_cvtsi32_si128(static_cast<int>(packed_vals)));
-        __m128 val_vec = _mm_cvtepi32_ps(val_i32);
+        __m128 val_vec = _mm_set_ps(static_cast<float>(vals[i + 3]),
+                                    static_cast<float>(vals[i + 2]),
+                                    static_cast<float>(vals[i + 1]),
+                                    static_cast<float>(vals[i]));
         __m128 delta_vec = _mm_mul_ps(val_vec, q_vec);
 
-        __m128i id_vec = _mm_loadl_epi64(reinterpret_cast<const __m128i*>(ids + i));
-        __m128i idx_vec = _mm_cvtepu16_epi32(id_vec);
-
         alignas(16) float res[4];
-        alignas(16) int32_t indices[4];
         _mm_store_ps(res, delta_vec);
-        _mm_store_si128(reinterpret_cast<__m128i*>(indices), idx_vec);
 
         for (int k = 0; k < 4; ++k) {
-            dists[indices[k]] += res[k];
+            dists[ids[i + k]] += res[k];
         }
     }
     for (; i < num; ++i) {


### PR DESCRIPTION
## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Improvement/Refactor
- [ ] Documentation
- [ ] CI/Build/Infra

## Linked Issue

- Fixes: #2243

## What Changed

- Added a low-memory `immutable=true` SINDI build path that compacts each completed mutable window into `ImmutableSINDIWindow` payloads during `Build()` and releases the mutable datacell before continuing.
- Enabled immutable build results to search directly through the immutable runtime path, including the final partial window.
- Added serialization support for immutable runtime windows by writing mutable-compatible window bytes.
- Reduced immutable remap metadata by storing sorted global terms and deriving local term IDs from the lower-bound position.
- Avoided materializing and validating the serialized trailing `term_sizes` vector during immutable deserialize.
- Ensured sparse FP32/FP16/SQ8 search accumulation paths for mutable and immutable search route through the SIMD dispatch entry points.
- Added SINDI coverage for immutable build search, range search, serialization, remap/reorder/quantization combinations, and Add rejection after immutable build.

## Build Memory Peak Comparison

Sparse4M fp16 build, `remap_term_ids=true`, `window_size=50000`, `term_id_limit=9999999`:

| Build path | immutable | Memory(build) | BuildTime | TPS |
| --- | --- | ---: | ---: | ---: |
| Previous fp16 mutable build | false | 27.03 GB | 329.615662 s | 13200.674805 |
| New fp16 immutable low-memory build | true | 6.08 GB | 599.424683 s | 7258.875488 |

The new immutable build path reduces eval `Memory(build)` by 20.95 GB, from 27.03 GB to 6.08 GB, a 77.51% reduction (about 4.45x lower peak build memory). The tradeoff is longer build time because completed windows are compacted into immutable payloads during build.

## Search Performance Evidence

Sparse4M immutable fp16 search after SIMD dispatch fixes and one warm-up run:

| Search path | Memory(search) | QPS | LatencyAvg | RecallAvg |
| --- | ---: | ---: | ---: | ---: |
| Current immutable fp16 measured search | 132.00 KB | 212.656891 | 4.702411 ms | 0.998900 |

Note: this `Memory(search)` value is the search-phase delta reported by the current eval monitor. It should not be compared directly with older full-process search memory readings.

## Test Evidence

- [ ] `make fmt`
- [ ] `make lint`
- [ ] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [x] Other (describe below)

Test details:

```text
cmake --build ./build --target unittests --parallel 6
./build/tests/unittests "SINDI*"
  All tests passed (183175 assertions in 20 test cases)

./build/tests/unittests "SparseTermComputer*"
  All tests passed (213 assertions in 1 test case)

git diff --check
  passed
```

## Compatibility Impact

- API/ABI compatibility: no public API changes.
- Behavior changes: `immutable=true` now affects `Build()` by using the low-memory immutable build path. Mutable `Add()` remains rejected for immutable runtimes.

## Performance and Concurrency Impact

- Performance impact: significantly lower fp16 build memory peak for immutable builds; build time increases due to per-window compaction. Search uses the immutable runtime path directly after build.
- Concurrency/thread-safety impact: build still uses the existing SINDI write lock.

## Documentation Impact

- [x] No docs update needed

## Risk and Rollback

- Risk level: medium, because this changes the internal build path for `immutable=true` SINDI indexes.
- Rollback plan: revert this commit to restore the previous mutable build behavior and immutable runtime serialization restrictions.

## Checklist

- [x] I have linked the relevant issue (required for `kind/bug` and `kind/feature`; see "Linked Issue" above)
- [x] I have added/updated tests for new behavior or bug fixes
- [x] I have considered API compatibility impact
- [x] I have updated docs if behavior/workflow changed
- [x] My commit messages follow project conventions (Conventional Commits, optional `[skip ci]` prefix)
