### PR TITLE
fix: resolve clang-tidy linter failures

### DIFF
--- a/src/algorithm/hgraph/hgraph_serialize.cpp
+++ b/src/algorithm/hgraph/hgraph_serialize.cpp
@@ -37,7 +37,7 @@ namespace {
 
 std::string
 dump_basic_info_for_log(const JsonType& basic_info) {
-    JsonType log_basic_info = basic_info;
+    JsonType log_basic_info = basic_info;  // NOLINT(performance-unnecessary-copy-initialization)
     if (log_basic_info.Contains(INDEX_PARAM) and log_basic_info[INDEX_PARAM].IsString()) {
         auto index_param = JsonType::Parse(log_basic_info[INDEX_PARAM].GetString(), false);
         if (not index_param.IsDiscarded() and index_param.IsObject()) {
@@ -104,13 +104,13 @@ public:
 private:
     void
     checksum_range(uint64_t offset, uint64_t size) {
-        constexpr uint64_t kBufferSize = 8192;
-        std::array<char, kBufferSize> buffer{};
+        constexpr uint64_t k_buffer_size = 8192;
+        std::array<char, k_buffer_size> buffer{};
         const auto original_cursor = reader_.GetCursor();
         reader_.Seek(offset);
         uint64_t remaining = size;
         while (remaining > 0) {
-            const auto read_size = std::min<uint64_t>(remaining, kBufferSize);
+            const auto read_size = std::min<uint64_t>(remaining, k_buffer_size);
             reader_.Read(buffer.data(), read_size);
             crc_ = StreamHeader::UpdateChecksum(crc_, std::string_view(buffer.data(), read_size));
             remaining -= read_size;
@@ -641,9 +641,10 @@ HGraph::read_streaming_body(StreamReader& reader,
                 break;
             case StreamSerializationTag::HIGH_PRECISION_CODES:
                 if (this->has_precise_reorder()) {
-                    constexpr const char* kPreciseReader = "precise_reader";
-                    if (load_parameters != nullptr && load_parameters->HasReader(kPreciseReader)) {
-                        auto reader_ptr = load_parameters->GetReader(kPreciseReader);
+                    constexpr const char* k_precise_reader = "precise_reader";
+                    if (load_parameters != nullptr &&
+                        load_parameters->HasReader(k_precise_reader)) {
+                        auto reader_ptr = load_parameters->GetReader(k_precise_reader);
                         if (reader_ptr == nullptr) {
                             throw VsagException(ErrorType::INVALID_ARGUMENT,
                                                 "precise_reader is null");

--- a/src/algorithm/simq/simq.cpp
+++ b/src/algorithm/simq/simq.cpp
@@ -24,6 +24,7 @@
 #include <sstream>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 
 #include "dataset_impl.h"
 #include "index_feature_list.h"
@@ -87,12 +88,12 @@ public:
                             int64_t max_cluster_size,
                             int64_t split_start_idx,
                             int64_t random_seed,
-                            const IndexCommonParam& common_param)
+                            IndexCommonParam common_param)
         : init_cluster_ratio_(init_cluster_ratio),
           max_cluster_size_(static_cast<int>(max_cluster_size)),
           split_start_idx_(static_cast<int>(split_start_idx)),
           random_seed_(static_cast<int>(random_seed)),
-          common_param_(common_param) {
+          common_param_(std::move(common_param)) {
     }
 
     ~HGraphDynamicClustering() = default;

--- a/src/algorithm/sindi/sindi.cpp
+++ b/src/algorithm/sindi/sindi.cpp
@@ -433,9 +433,10 @@ SINDI::build_immutable(const DatasetPtr& base) {
         const auto window_start_id =
             static_cast<int64_t>(immutable_data_->windows.size()) * window_size_;
         const auto window_inner_id = cur_element_count_ - window_start_id;
-        CHECK_ARGUMENT(
-            window_inner_id >= 0 and window_inner_id <= std::numeric_limits<uint16_t>::max(),
-            "immutable SINDI window-local doc id overflows uint16_t");
+        if (window_inner_id < 0 or window_inner_id > std::numeric_limits<uint16_t>::max()) {
+            throw VsagException(ErrorType::INVALID_ARGUMENT,
+                                "immutable SINDI window-local doc id overflows uint16_t");
+        }
         auto inner_id = static_cast<uint16_t>(window_inner_id);
 
         try {
@@ -1310,7 +1311,9 @@ void
 SINDI::deserialize_windows(StreamReader& reader_ref) {
     uint64_t cur_element_count = 0;
     StreamReader::ReadObj(reader_ref, cur_element_count);
-    cur_element_count_.store(cur_element_count);
+    CHECK_ARGUMENT(cur_element_count <= static_cast<uint64_t>(std::numeric_limits<int64_t>::max()),
+                   "SINDI element count overflows int64_t");
+    cur_element_count_.store(static_cast<int64_t>(cur_element_count));
 
     if (sparse_value_quant_type_ == SparseValueQuantizationType::SQ8) {
         StreamReader::ReadObj(reader_ref, quantization_params_->min_val);
@@ -1520,7 +1523,9 @@ SINDI::Deserialize(StreamReader& reader) {
 
     uint64_t cur_element_count = 0;
     StreamReader::ReadObj(reader_ref, cur_element_count);
-    cur_element_count_.store(cur_element_count);
+    CHECK_ARGUMENT(cur_element_count <= static_cast<uint64_t>(std::numeric_limits<int64_t>::max()),
+                   "SINDI element count overflows int64_t");
+    cur_element_count_.store(static_cast<int64_t>(cur_element_count));
 
     if (sparse_value_quant_type_ == SparseValueQuantizationType::SQ8) {
         StreamReader::ReadObj(reader_ref, quantization_params_->min_val);
@@ -1610,9 +1615,11 @@ SINDI::compact_window_to_immutable(const SparseTermDataCell& term_list,
 
         const auto old_id_size = window.id_payloads.size();
         window.id_payloads.resize(old_id_size + posting_count);
+        const auto old_id_position =
+            static_cast<decltype(window.id_payloads)::difference_type>(old_id_size);
         std::copy(term_list.term_ids_[term]->begin(),
                   term_list.term_ids_[term]->end(),
-                  window.id_payloads.begin() + old_id_size);
+                  window.id_payloads.begin() + old_id_position);
 
         const auto payload_bytes = static_cast<uint64_t>(posting_count) * value_code_size;
         const auto old_value_size = window.value_payloads.size();

--- a/src/factory/factory.cpp
+++ b/src/factory/factory.cpp
@@ -169,13 +169,13 @@ apply_hgraph_streaming_load_parameters(JsonType& index_param, const std::string&
     }
 }
 
-struct StreamingIndexLoadTarget {
+struct streaming_index_load_target {
     IndexPtr index;
     InnerIndexPtr inner_index;
 };
 
 template <typename IndexT, typename ParamT>
-StreamingIndexLoadTarget
+streaming_index_load_target
 create_streaming_index(const JsonType& index_param, const IndexCommonParam& common_param) {
     auto param = std::make_shared<ParamT>();
     param->FromJson(index_param);
@@ -183,7 +183,7 @@ create_streaming_index(const JsonType& index_param, const IndexCommonParam& comm
     return {std::make_shared<IndexImpl<IndexT>>(inner_index, common_param), inner_index};
 }
 
-tl::expected<StreamingIndexLoadTarget, Error>
+tl::expected<streaming_index_load_target, Error>
 create_streaming_index_from_metadata(const MetadataPtr& metadata,
                                      const std::string& parameters,
                                      Allocator* allocator) {
@@ -270,7 +270,7 @@ Index::GetStreamingMetadata(std::istream& in_stream) {
             StreamingIndexMetadata result;
             result.metadata_json = std::move(stream_header.metadata_string);
 
-            struct ManifestBlock {
+            struct manifest_block {
                 std::string name;
                 uint32_t tag{0};
                 uint32_t version{0};
@@ -278,13 +278,13 @@ Index::GetStreamingMetadata(std::istream& in_stream) {
                 uint64_t payload_size{0};
                 bool has_payload_size{false};
             };
-            std::vector<ManifestBlock> manifest_blocks;
+            std::vector<manifest_block> manifest_blocks;
             auto manifest = stream_header.metadata->Get("block_manifest");
             if (manifest.IsArray()) {
                 const auto* manifest_json = manifest.GetInnerJson();
                 manifest_blocks.reserve(manifest_json->size());
                 for (const auto& block_json : *manifest_json) {
-                    ManifestBlock block;
+                    manifest_block block;
                     block.name = block_json.value("name", std::string{});
                     block.tag = block_json.value("tag", 0U);
                     block.version = block_json.value("version", 0U);
@@ -462,7 +462,7 @@ public:
         });
     }
 
-    uint64_t
+    [[nodiscard]] uint64_t
     Size() const override {
         return size_;
     }
@@ -510,7 +510,7 @@ public:
         }
     }
 
-    uint64_t
+    [[nodiscard]] uint64_t
     Size() const override {
         return size_;
     }

--- a/src/storage/tlv_section.cpp
+++ b/src/storage/tlv_section.cpp
@@ -38,7 +38,7 @@ namespace vsag {
 namespace {
 
 void
-SeekTemporaryFile(std::FILE* file, uint64_t offset) {
+seek_temporary_file(std::FILE* file, uint64_t offset) {
 #if defined(_WIN32)
     if (offset > static_cast<uint64_t>(std::numeric_limits<__int64>::max())) {
         throw VsagException(ErrorType::READ_ERROR,
@@ -206,7 +206,7 @@ SkipBlockPayload(StreamReader& reader, const StreamBlockHeader& header) {
 }
 
 void
-ValidateSeekableBlockCursor(const StreamReader& reader, const StreamBlockHeader& header) {
+validate_seekable_block_cursor(const StreamReader& reader, const StreamBlockHeader& header) {
     if (reader.GetCursor() > header.value_len) {
         throw VsagException(ErrorType::INVALID_BINARY,
                             "seekable streaming block reader cursor exceeds payload boundary");
@@ -270,7 +270,7 @@ ReadSeekableBlockPayload(StreamReader& reader,
         };
         ReadFuncStreamReader block_reader(read_func, 0, header.value_len);
         deserialize(block_reader);
-        ValidateSeekableBlockCursor(block_reader, header);
+        validate_seekable_block_cursor(block_reader, header);
         return;
     }
 
@@ -309,7 +309,7 @@ ReadSeekableBlockPayload(StreamReader& reader,
             throw VsagException(ErrorType::READ_ERROR,
                                 "seekable streaming block reader exceeds payload boundary");
         }
-        SeekTemporaryFile(temp_file.get(), offset);
+        seek_temporary_file(temp_file.get(), offset);
         if (size > 0 && std::fread(dest, 1, static_cast<size_t>(size), temp_file.get()) != size) {
             throw VsagException(ErrorType::READ_ERROR,
                                 "failed to read streaming block temporary file");
@@ -317,7 +317,7 @@ ReadSeekableBlockPayload(StreamReader& reader,
     };
     ReadFuncStreamReader block_reader(read_func, 0, header.value_len);
     deserialize(block_reader);
-    ValidateSeekableBlockCursor(block_reader, header);
+    validate_seekable_block_cursor(block_reader, header);
 }
 
 }  // namespace vsag


### PR DESCRIPTION
## Summary
- Fix clang-tidy 15 diagnostics reported by the linter workflow.
- Clean up related naming, nodiscard, pass-by-value, and narrowing-conversion warnings so full lint passes.

Fixes: #2431

## Validation
- make COMPILE_JOBS=96 VSAG_USE_SYSTEM_DEPS=OFF release
- make COMPILE_JOBS=96 lint

## Notes
- Configured local validation with bundled OpenBLAS because this machine's system cblas.h includes mkl_types.h, which is unavailable locally.