### PR TITLE
fix: avoid clang-tidy shared pointer leak reports

### DIFF
--- a/src/factory/factory.cpp
+++ b/src/factory/factory.cpp
@@ -65,14 +65,12 @@ namespace {
 
 IndexCommonParam
 make_streaming_common_param(const MetadataPtr& metadata, Allocator* allocator) {
-    auto resource = allocator == nullptr
-                        ? std::make_shared<Resource>(Engine::CreateDefaultAllocator(), nullptr)
-                        : std::make_shared<Resource>(allocator, nullptr);
+    auto resource = allocator == nullptr ? Resource(Engine::CreateDefaultAllocator(), nullptr)
+                                         : Resource(allocator, nullptr);
 
     IndexCommonParam common_param;
-    common_param.allocator_ = resource->GetAllocator();
-    common_param.thread_pool_ =
-        std::dynamic_pointer_cast<SafeThreadPool>(resource->GetThreadPool());
+    common_param.allocator_ = resource.GetAllocator();
+    common_param.thread_pool_ = std::dynamic_pointer_cast<SafeThreadPool>(resource.GetThreadPool());
 
     auto basic_info = metadata->Get("basic_info");
     if (basic_info.Contains("dim")) {

--- a/src/storage/serialization.cpp
+++ b/src/storage/serialization.cpp
@@ -123,7 +123,10 @@ StreamHeader::ReadRaw(StreamReader& reader) {
         throw VsagException(ErrorType::INVALID_BINARY,
                             "streaming serialization metadata must be a JSON object");
     }
-    return {std::make_shared<Metadata>(metadata_json), std::move(metadata_string)};
+    StreamHeaderData result;
+    result.metadata = std::make_shared<Metadata>(std::move(metadata_json));
+    result.metadata_string = std::move(metadata_string);
+    return result;
 }
 
 FooterPtr


### PR DESCRIPTION
## Summary
- make streaming resource setup use a stack `Resource` before copying allocator/thread-pool handles into `IndexCommonParam`
- split `StreamHeaderData` construction from the return expression so clang-tidy 15 can track the `shared_ptr` control block cleanup

## Root Cause
clang-tidy 15's static analyzer reported `clang-analyzer-cplusplus.NewDeleteLeaks` on paths where `std::shared_ptr` control blocks were created inside compact return/temporary expressions. The ownership was valid, but the analyzer could not prove cleanup under the CI configuration.

## Validation
- `clang-tidy-15 -p build-release src/storage/serialization.cpp`
- `clang-tidy-15 -p build-release src/factory/factory.cpp`
- `make lint` was started and completed 196/197 files without errors; it was manually interrupted after the remaining unrelated `src/datacell/flatten_interface.cpp` analysis continued running for several minutes.

Fixes: #2432