### PR TITLE
fix: reuse visited lists across sub-pools

### DIFF
--- a/src/utils/resource_object_pool.h
+++ b/src/utils/resource_object_pool.h
@@ -72,23 +72,31 @@ public:
             std::hash<std::thread::id>()(std::this_thread::get_id()) % kSubPoolCount};
         auto pool_id = prefer_pool_id_;
         while (true) {
-            if (sub_pool_mutexes_[pool_id].try_lock()) {
-                prefer_pool_id_ = pool_id;
-                if (pool_[pool_id]->empty()) {
-                    sub_pool_mutexes_[pool_id].unlock();
-                    auto obj = this->constructor_();
-                    obj->source_pool_id_ = pool_id;
-                    return obj;
+            uint64_t empty_pool_count = 0;
+            for (uint64_t i = 0; i < kSubPoolCount; ++i) {
+                if (sub_pool_mutexes_[pool_id].try_lock()) {
+                    if (pool_[pool_id]->empty()) {
+                        sub_pool_mutexes_[pool_id].unlock();
+                        ++empty_pool_count;
+                    } else {
+                        std::shared_ptr<T> obj = pool_[pool_id]->front();
+                        pool_[pool_id]->pop_front();
+                        sub_pool_mutexes_[pool_id].unlock();
+                        prefer_pool_id_ = pool_id;
+                        obj->source_pool_id_ = pool_id;
+                        obj->Reset();
+                        return obj;
+                    }
                 }
-                std::shared_ptr<T> obj = pool_[pool_id]->front();
-                pool_[pool_id]->pop_front();
-                sub_pool_mutexes_[pool_id].unlock();
-                obj->source_pool_id_ = pool_id;
-                obj->Reset();
+
+                ++pool_id;
+                pool_id %= kSubPoolCount;
+            }
+            if (empty_pool_count == kSubPoolCount) {
+                auto obj = this->constructor_();
+                obj->source_pool_id_ = prefer_pool_id_;
                 return obj;
             }
-            ++pool_id;
-            pool_id %= kSubPoolCount;
         }
     }
 

--- a/src/utils/visited_list_test.cpp
+++ b/src/utils/visited_list_test.cpp
@@ -121,3 +121,15 @@ TEST_CASE("VisitedListPool Basic Test", "[ut][VisitedListPool]") {
         }
     }
 }
+
+TEST_CASE("VisitedListPool reuses objects across sub-pools", "[ut][VisitedListPool]") {
+    auto allocator = std::make_shared<DefaultAllocator>();
+    auto pool = std::make_shared<VisitedListPool>(
+        VisitedListPool::kSubPoolCount, allocator.get(), 1000, allocator.get());
+    auto initial_memory_usage = pool->GetMemoryUsage();
+
+    auto first = pool->TakeOne();
+    auto second = pool->TakeOne();
+
+    REQUIRE(pool->GetMemoryUsage() == initial_memory_usage);
+}


### PR DESCRIPTION
## Change Type

- [x] Improvement/Refactor

## Linked Issue

- Fixes: #2427

## What Changed

- Scan all visited-list sub-pools for an idle object before allocating a new one.
- Preserve the existing thread-local sub-pool preference and non-blocking lock strategy.
- Add regression coverage for reusing an object from another sub-pool.

## Test Evidence

- [x] Other (described below)

Test details:

```text
clang-format 15.0.7 --dry-run --Werror (changed files): passed
make test CASE='[ut][VisitedListPool]':
All tests passed (10001 assertions in 2 test cases)
```

## Compatibility Impact

- API/ABI compatibility: none
- Behavior changes: pool allocation occurs only after all sub-pools are observed empty

## Performance and Concurrency Impact

- Performance impact: reduces unnecessary large visited-list allocations
- Concurrency/thread-safety impact: retains the existing per-sub-pool mutexes and `try_lock` behavior

## Documentation Impact

- [x] No docs update needed

## Risk and Rollback

- Risk level: low
- Rollback plan: revert the commit to restore the previous allocation policy

## Checklist

- [x] I have linked the relevant issue
- [x] I have added/updated tests for the changed behavior
- [x] I have considered API compatibility impact
- [x] My commit messages follow project conventions

---
_Drafted with AI assistant: Codex:gpt-5_
