### PR TITLE
fix: bound hgraph visited-list cache

### DIFF
--- a/src/algorithm/hgraph/hgraph.h
+++ b/src/algorithm/hgraph/hgraph.h
@@ -597,6 +597,7 @@ private:
     float alpha_{1.0};            // Relative Neighborhood Graph pruning coefficient
 
     std::shared_ptr<VisitedListPool> pool_{nullptr};  // pool of visited-lists for search
+    static constexpr uint64_t MAX_CACHED_VISITED_LIST_COUNT_PER_SUB_POOL = 1;
 
     mutable std::shared_mutex global_mutex_;        // guards total_count_, entry_point_id_
     mutable MutexArrayPtr neighbors_mutex_;         // per-node locks for neighbor lists

--- a/src/algorithm/hgraph/hgraph_build.cpp
+++ b/src/algorithm/hgraph/hgraph_build.cpp
@@ -558,6 +558,7 @@ HGraph::resize(uint64_t new_size) {
     if (cur_size < new_size_power_2) {
         this->neighbors_mutex_->Resize(new_size_power_2);
         pool_ = std::make_shared<VisitedListPool>(1, allocator_, new_size_power_2, allocator_);
+        pool_->SetMaxCachedObjectCountPerSubPool(MAX_CACHED_VISITED_LIST_COUNT_PER_SUB_POOL);
         this->label_table_->Resize(new_size_power_2);
         bottom_graph_->Resize(new_size_power_2);
         this->basic_flatten_codes_->Resize(new_size_power_2);

--- a/src/algorithm/hgraph/hgraph_serialize.cpp
+++ b/src/algorithm/hgraph/hgraph_serialize.cpp
@@ -752,6 +752,7 @@ HGraph::read_streaming_body(StreamReader& reader,
     auto new_size = max_capacity_.load();
     this->neighbors_mutex_->Resize(new_size);
     pool_ = std::make_shared<VisitedListPool>(1, allocator_, new_size, allocator_);
+    pool_->SetMaxCachedObjectCountPerSubPool(MAX_CACHED_VISITED_LIST_COUNT_PER_SUB_POOL);
     this->total_count_ = this->basic_flatten_codes_->TotalCount();
     if (this->raw_vector_ != nullptr) {
         this->has_raw_vector_ = true;
@@ -786,6 +787,7 @@ HGraph::Deserialize(StreamReader& reader) {
         this->neighbors_mutex_->Resize(new_size);
 
         pool_ = std::make_shared<VisitedListPool>(1, allocator_, new_size, allocator_);
+        pool_->SetMaxCachedObjectCountPerSubPool(MAX_CACHED_VISITED_LIST_COUNT_PER_SUB_POOL);
 
         if (this->extra_info_size_ > 0 && this->extra_infos_ != nullptr) {
             this->extra_infos_->Deserialize(reader);
@@ -826,6 +828,7 @@ HGraph::Deserialize(StreamReader& reader) {
         this->neighbors_mutex_->Resize(new_size);
 
         pool_ = std::make_shared<VisitedListPool>(1, allocator_, new_size, allocator_);
+        pool_->SetMaxCachedObjectCountPerSubPool(MAX_CACHED_VISITED_LIST_COUNT_PER_SUB_POOL);
 
         if (this->extra_info_size_ > 0 && this->extra_infos_ != nullptr) {
             this->extra_infos_->Deserialize(buffer_reader);

--- a/src/utils/resource_object_pool.h
+++ b/src/utils/resource_object_pool.h
@@ -18,6 +18,7 @@
 #include <atomic>
 #include <cstdint>
 #include <functional>
+#include <limits>
 #include <memory>
 #include <mutex>
 #include <thread>
@@ -95,8 +96,22 @@ public:
     void
     ReturnOne(std::shared_ptr<T>& obj) {
         auto pool_id = obj->source_pool_id_;
-        std::lock_guard<std::mutex> lock(sub_pool_mutexes_[pool_id]);
-        pool_[pool_id]->emplace_back(obj);
+        {
+            std::lock_guard<std::mutex> lock(sub_pool_mutexes_[pool_id]);
+            if (pool_[pool_id]->size() < max_cached_object_count_per_sub_pool_) {
+                pool_[pool_id]->emplace_back(obj);
+                return;
+            }
+        }
+
+        auto object_memory_usage = obj->GetMemoryUsage();
+        obj.reset();
+        memory_usage_.fetch_sub(object_memory_usage, std::memory_order_relaxed);
+    }
+
+    void
+    SetMaxCachedObjectCountPerSubPool(uint64_t max_cached_object_count) {
+        max_cached_object_count_per_sub_pool_ = max_cached_object_count;
     }
 
     inline int64_t
@@ -119,6 +134,7 @@ private:
     uint64_t init_size_{0};
 
     std::atomic<int64_t> memory_usage_{0};
+    uint64_t max_cached_object_count_per_sub_pool_{std::numeric_limits<uint64_t>::max()};
 
     ConstructFuncType constructor_{nullptr};
     Allocator* allocator_{nullptr};

--- a/src/utils/visited_list_test.cpp
+++ b/src/utils/visited_list_test.cpp
@@ -121,3 +121,22 @@ TEST_CASE("VisitedListPool Basic Test", "[ut][VisitedListPool]") {
         }
     }
 }
+
+TEST_CASE("VisitedListPool releases objects above the cache limit", "[ut][VisitedListPool]") {
+    auto allocator = std::make_shared<DefaultAllocator>();
+    auto pool = std::make_shared<VisitedListPool>(0, allocator.get(), 1000, allocator.get());
+    pool->SetMaxCachedObjectCountPerSubPool(1);
+    auto initial_memory_usage = pool->GetMemoryUsage();
+
+    std::vector<std::shared_ptr<VisitedList>> visited_lists;
+    for (uint64_t i = 0; i < 3; ++i) {
+        visited_lists.emplace_back(pool->TakeOne());
+    }
+    REQUIRE(pool->GetMemoryUsage() > initial_memory_usage);
+    auto object_memory_usage = visited_lists.front()->GetMemoryUsage();
+
+    for (auto& visited_list : visited_lists) {
+        pool->ReturnOne(visited_list);
+    }
+    REQUIRE(pool->GetMemoryUsage() == initial_memory_usage + object_memory_usage);
+}


### PR DESCRIPTION
## Change Type

- [x] Improvement/Refactor

## Linked Issue

- Fixes: #2428

## What Changed

- Add an optional per-sub-pool cache limit to `ResourceObjectPool`; existing callers remain unlimited by default.
- Configure HGraph to retain at most one idle visited list in each of its 16 sub-pools.
- Release excess returned objects and subtract their memory from pool statistics.
- Add regression coverage for memory usage falling after excess objects are returned.

## Test Evidence

- [x] Other (described below)

Test details:

```text
clang-format 15.0.7 --dry-run --Werror (changed files): passed
make test CASE='[ut][VisitedListPool]':
All tests passed (10002 assertions in 2 test cases)
```

## Compatibility Impact

- API/ABI compatibility: no public VSAG API changes
- Behavior changes: HGraph retains at most 16 idle visited lists instead of retaining the historical peak

## Performance and Concurrency Impact

- Performance impact: bounds idle scratch memory; workloads above 16 concurrent searches may reallocate excess lists on a later burst
- Concurrency/thread-safety impact: uses the existing per-sub-pool mutex and adds no global lock or background work

## Documentation Impact

- [x] No docs update needed

## Risk and Rollback

- Risk level: medium
- Rollback plan: revert the commit to restore unlimited HGraph visited-list caching

## Checklist

- [x] I have linked the relevant issue
- [x] I have added/updated tests for the changed behavior
- [x] I have considered API compatibility impact
- [x] My commit messages follow project conventions

---
_Drafted with AI assistant: Codex:gpt-5_
