### PR TITLE
perf: accelerate RaBitQ split IP search

### DIFF
--- a/src/algorithm/hgraph/hgraph_search.cpp
+++ b/src/algorithm/hgraph/hgraph_search.cpp
@@ -131,6 +131,7 @@ HGraph::KnnSearch(const DatasetPtr& query,
         search_param.topk = 1;
         search_param.ef = 1;
         search_param.is_inner_id_allowed = nullptr;
+        search_param.enable_rabitq_one_bit_search = params.rabitq_one_bit_search;
         if (search_param.ep == INVALID_ENTRY_POINT) {
             return make_empty_dataset_with_stats();
         }
@@ -445,6 +446,7 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
     search_param.topk = 1;
     search_param.ef = 1;
     search_param.is_inner_id_allowed = nullptr;
+    search_param.enable_rabitq_one_bit_search = params.rabitq_one_bit_search;
 
     if (search_param.ep == INVALID_ENTRY_POINT) {
         return make_empty_dataset_with_stats();

--- a/src/quantization/rabitq_quantization/rabitq_quantizer.cpp
+++ b/src/quantization/rabitq_quantization/rabitq_quantizer.cpp
@@ -163,11 +163,6 @@ RaBitQuantizer<metric>::RaBitQuantizer(int dim,
         this->query_code_size_ += ((sizeof(norm_type) + align_size - 1) / align_size) * align_size;
     }
 
-    if (HasFilterQueryLookupTable()) {
-        query_offset_filter_lut_ = this->query_code_size_;
-        this->query_code_size_ += AlignCodeField(FilterQueryLookupTableSize());
-    }
-
     if (SupportSplitCodeStorage()) {
         offset_low_bound_error_ = this->code_size_;
         this->code_size_ += ((sizeof(error_type) + align_size - 1) / align_size) * align_size;
@@ -799,19 +794,6 @@ RaBitQuantizer<metric>::AlignCodeField(uint64_t size) const {
 }
 
 template <MetricType metric>
-bool
-RaBitQuantizer<metric>::HasFilterQueryLookupTable() const {
-    return SupportSplitCodeStorage() && (FilterBits() == 2 or FilterBits() == 3) &&
-           num_bits_per_dim_query_ == 32;
-}
-
-template <MetricType metric>
-uint64_t
-RaBitQuantizer<metric>::FilterQueryLookupTableSize() const {
-    return PlaneBytes() * 256 * sizeof(float);
-}
-
-template <MetricType metric>
 uint64_t
 RaBitQuantizer<metric>::PlaneBytes() const {
     return (this->dim_ + 7) / 8;
@@ -1062,15 +1044,6 @@ RaBitQuantizer<metric>::ComputeDistWithOneBitLowerBound(Computer<RaBitQuantizer>
             filter_ip_yu_q = RaBitQFloatThreeBitCenteredIP(
                 reinterpret_cast<const float*>(query), one_bit_code, this->dim_);
             filter_ip_estimate = base_norm_code <= 0.0F ? 0.0F : filter_ip_yu_q / base_norm_code;
-        } else if (HasFilterQueryLookupTable()) {
-            filter_ip_yu_q = RaBitQFloatMultiBitIPByLookup(
-                reinterpret_cast<const float*>(query + query_offset_filter_lut_),
-                one_bit_code,
-                this->dim_,
-                0,
-                FilterBits());
-            filter_ip_estimate =
-                ip_obar_q(filter_ip_yu_q, query_raw_sum, base_norm_code, FilterBits());
         } else {
             filter_ip_yu_q = RaBitQFloatSQIPBySplitCode(
                 reinterpret_cast<const float*>(query), one_bit_code, nullptr, FilterBits(), 0);
@@ -1168,7 +1141,8 @@ RaBitQuantizer<metric>::ComputeDistsWithOneBitLowerBoundBatch4(
     bool& computed3,
     bool& computed4,
     float runtime_rabitq_error_rate) const {
-    if constexpr (metric != MetricType::METRIC_TYPE_L2SQR) {
+    if constexpr (metric != MetricType::METRIC_TYPE_L2SQR and
+                  metric != MetricType::METRIC_TYPE_IP) {
         computed1 = this->ComputeDistWithOneBitLowerBound(
             computer, one_bit_code1, &dist1, lower_bound1, runtime_rabitq_error_rate);
         computed2 = this->ComputeDistWithOneBitLowerBound(
@@ -1180,8 +1154,7 @@ RaBitQuantizer<metric>::ComputeDistsWithOneBitLowerBoundBatch4(
         return;
     }
 
-    if (FilterBits() != 1 and FilterBits() != 2 and FilterBits() != 3 and
-        not HasFilterQueryLookupTable()) {
+    if (FilterBits() != 1 and FilterBits() != 2 and FilterBits() != 3) {
         computed1 = this->ComputeDistWithOneBitLowerBound(
             computer, one_bit_code1, &dist1, lower_bound1, runtime_rabitq_error_rate);
         computed2 = this->ComputeDistWithOneBitLowerBound(
@@ -1196,6 +1169,10 @@ RaBitQuantizer<metric>::ComputeDistsWithOneBitLowerBoundBatch4(
     const auto* query = computer.buf_;
     const auto* query_data = reinterpret_cast<const float*>(query);
     const norm_type query_norm = *((norm_type*)(query + query_offset_norm_));
+    norm_type query_raw_norm = 0.0F;
+    if constexpr (metric == MetricType::METRIC_TYPE_IP) {
+        std::memcpy(&query_raw_norm, query + query_offset_raw_norm_, sizeof(query_raw_norm));
+    }
     const norm_type query_mrq_norm_sqr = pca_dim_ != this->original_dim_ and use_mrq_
                                              ? *(norm_type*)(query + query_offset_mrq_norm_)
                                              : 0.0F;
@@ -1237,17 +1214,6 @@ RaBitQuantizer<metric>::ComputeDistsWithOneBitLowerBoundBatch4(
                                             this->dim_,
                                             filter_ip_values);
         filter_ip_values_are_centered = true;
-    } else {
-        RaBitQFloatMultiBitIPBatch4ByLookup(
-            reinterpret_cast<const float*>(query + query_offset_filter_lut_),
-            one_bit_code1,
-            one_bit_code2,
-            one_bit_code3,
-            one_bit_code4,
-            this->dim_,
-            0,
-            FilterBits(),
-            filter_ip_values);
     }
 
     auto compute_one =
@@ -1286,6 +1252,20 @@ RaBitQuantizer<metric>::ComputeDistsWithOneBitLowerBoundBatch4(
                 result += (query_mrq_norm_sqr + base_mrq_norm_sqr);
             }
 
+            if constexpr (metric == MetricType::METRIC_TYPE_IP) {
+                norm_type base_raw_norm = 0.0F;
+                std::memcpy(&base_raw_norm,
+                            one_bit_code + OneBitRecordRawNormOffset(),
+                            sizeof(base_raw_norm));
+                if (is_approx_zero(query_raw_norm) or is_approx_zero(base_raw_norm)) {
+                    result = 1.0F;
+                } else {
+                    result = 1.0F - (query_raw_norm * query_raw_norm +
+                                     base_raw_norm * base_raw_norm - result) *
+                                        0.5F;
+                }
+            }
+
             if (not std::isfinite(result)) {
                 return false;
             }
@@ -1301,9 +1281,11 @@ RaBitQuantizer<metric>::ComputeDistsWithOneBitLowerBoundBatch4(
                 std::isfinite(runtime_rabitq_error_rate) and runtime_rabitq_error_rate > 0.0F
                     ? runtime_rabitq_error_rate
                     : rabitq_error_rate_;
-            const float lower_bound_error_term = 2.0F * base_norm * query_norm *
-                                                 effective_error_rate * low_bound_error /
-                                                 one_bit_error;
+            float lower_bound_error_term = 2.0F * base_norm * query_norm * effective_error_rate *
+                                           low_bound_error / one_bit_error;
+            if constexpr (metric == MetricType::METRIC_TYPE_IP) {
+                lower_bound_error_term *= 0.5F;
+            }
             const float lower_bound_result = result - lower_bound_error_term;
             if (std::isfinite(lower_bound_result)) {
                 *lower_bound =
@@ -1353,15 +1335,17 @@ RaBitQuantizer<metric>::ComputeDistWithSplitCode(Computer<RaBitQuantizer>& compu
     } else {
         sum_type query_raw_sum = *((sum_type*)(query + query_offset_sum_));
         float ip_yu_q = 0.0F;
-        if (HasFilterQueryLookupTable()) {
-            ip_yu_q = RaBitQFloatMultiBitIPByLookup(
-                reinterpret_cast<const float*>(query + query_offset_filter_lut_),
-                one_bit_code,
-                this->dim_,
-                ReorderBits(),
-                FilterBits());
-            ip_yu_q += RaBitQFloatSupplementCodeIP(
-                reinterpret_cast<const float*>(query), supplement_code, this->dim_, ReorderBits());
+        if (FilterBits() == 2 or FilterBits() == 3) {
+            const auto* query_data = reinterpret_cast<const float*>(query);
+            const float filter_centered_ip =
+                FilterBits() == 2
+                    ? RaBitQFloatTwoBitCenteredIP(query_data, one_bit_code, this->dim_)
+                    : RaBitQFloatThreeBitCenteredIP(query_data, one_bit_code, this->dim_);
+            const float filter_center = 0.5F * static_cast<float>((1U << FilterBits()) - 1U);
+            const float filter_ip_yu_q = filter_centered_ip + filter_center * query_raw_sum;
+            ip_yu_q = filter_ip_yu_q * static_cast<float>(1U << ReorderBits());
+            ip_yu_q +=
+                RaBitQFloatSupplementCodeIP(query_data, supplement_code, this->dim_, ReorderBits());
         } else {
             ip_yu_q = RaBitQFloatSQIPBySplitCode(reinterpret_cast<const float*>(query),
                                                  one_bit_code,
@@ -1432,12 +1416,12 @@ RaBitQuantizer<metric>::ComputeDistWithSplitCodeAndFilterDist(Computer<RaBitQuan
                                                               const uint8_t* supplement_code,
                                                               float filter_dist,
                                                               float* dists) const {
-    if constexpr (metric != MetricType::METRIC_TYPE_L2SQR) {
+    if constexpr (metric != MetricType::METRIC_TYPE_L2SQR and
+                  metric != MetricType::METRIC_TYPE_IP) {
         return false;
     }
 
-    if (not SupportSplitCodeStorage() or FilterBits() <= 1 or not HasFilterQueryLookupTable() or
-        not std::isfinite(filter_dist)) {
+    if (not SupportSplitCodeStorage() or FilterBits() <= 1 or not std::isfinite(filter_dist)) {
         return false;
     }
 
@@ -1456,7 +1440,20 @@ RaBitQuantizer<metric>::ComputeDistWithSplitCodeAndFilterDist(Computer<RaBitQuan
         return false;
     }
 
+    norm_type query_raw_norm = 0.0F;
+    norm_type base_raw_norm = 0.0F;
     float filter_l2 = filter_dist;
+    if constexpr (metric == MetricType::METRIC_TYPE_IP) {
+        std::memcpy(&query_raw_norm, query + query_offset_raw_norm_, sizeof(query_raw_norm));
+        std::memcpy(
+            &base_raw_norm, one_bit_code + OneBitRecordRawNormOffset(), sizeof(base_raw_norm));
+        if (is_approx_zero(query_raw_norm) or is_approx_zero(base_raw_norm)) {
+            *dists = 1.0F;
+            return true;
+        }
+        filter_l2 = query_raw_norm * query_raw_norm + base_raw_norm * base_raw_norm -
+                    2.0F * (1.0F - filter_dist);
+    }
     if (pca_dim_ != this->original_dim_ and use_mrq_) {
         const norm_type query_mrq_norm_sqr = *(norm_type*)(query + query_offset_mrq_norm_);
         const norm_type base_mrq_norm_sqr =
@@ -1503,6 +1500,11 @@ RaBitQuantizer<metric>::ComputeDistWithSplitCodeAndFilterDist(Computer<RaBitQuan
         norm_type base_mrq_norm_sqr = 0;
         memcpy(&base_mrq_norm_sqr, meta_field(offset_mrq_norm_), sizeof(base_mrq_norm_sqr));
         result += query_mrq_norm_sqr + base_mrq_norm_sqr;
+    }
+
+    if constexpr (metric == MetricType::METRIC_TYPE_IP) {
+        result = 1.0F -
+                 (query_raw_norm * query_raw_norm + base_raw_norm * base_raw_norm - result) * 0.5F;
     }
 
     if (not std::isfinite(result)) {
@@ -1808,13 +1810,6 @@ RaBitQuantizer<metric>::ProcessQueryImpl(const float* query,
                 query_raw_sum += normed_data[d];
             }
             *(sum_type*)(computer.buf_ + query_offset_sum_) = query_raw_sum;
-        }
-
-        if (HasFilterQueryLookupTable()) {
-            generic::RaBitQFloatBuildByteIPLookupTable(
-                normed_data.data(),
-                this->dim_,
-                reinterpret_cast<float*>(computer.buf_ + query_offset_filter_lut_));
         }
 
         // 5. store norm

--- a/src/quantization/rabitq_quantization/rabitq_quantizer.h
+++ b/src/quantization/rabitq_quantization/rabitq_quantizer.h
@@ -284,12 +284,6 @@ public:
     AlignCodeField(uint64_t size) const;
 
 private:
-    [[nodiscard]] bool
-    HasFilterQueryLookupTable() const;
-
-    [[nodiscard]] uint64_t
-    FilterQueryLookupTableSize() const;
-
     [[nodiscard]] norm_type
     ComputeScalarCodeNorm(const uint8_t* scalar_codes,
                           uint32_t code_bits,
@@ -329,8 +323,6 @@ private:
     uint64_t query_offset_norm_{0};
     uint64_t query_offset_mrq_norm_{0};
     uint64_t query_offset_raw_norm_{0};
-    uint64_t query_offset_filter_lut_{0};
-
     /***
      * code layout: bq-code(required) + norm(required) + error(required) + offset_norm_code(extend_rabitq) + sum(sq4) + mrq_norm(required)
      */

--- a/src/quantization/rabitq_quantization/rabitq_quantizer_test.cpp
+++ b/src/quantization/rabitq_quantization/rabitq_quantizer_test.cpp
@@ -258,6 +258,83 @@ TEST_CASE("RaBitQ Split Code Storage", "[ut][RaBitQuantizer]") {
     }
 }
 
+TEST_CASE("RaBitQ Split IP Batch4 and Reorder Hint", "[ut][RaBitQuantizer]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    constexpr uint64_t dim = 64;
+    constexpr uint64_t count = 32;
+    constexpr uint64_t base_bits = 8;
+    constexpr uint64_t filter_bits = 3;
+    auto vecs = fixtures::generate_vectors(count, dim);
+
+    RaBitQuantizer<MetricType::METRIC_TYPE_IP> quantizer(
+        dim,
+        dim,
+        32,
+        base_bits,
+        false,
+        false,
+        allocator.get(),
+        RaBitQuantizerParameter::RABITQ_VERSION_SPLIT,
+        RaBitQuantizerParameter::DEFAULT_RABITQ_ERROR_RATE,
+        filter_bits);
+    REQUIRE(quantizer.SupportSplitCodeStorage());
+    quantizer.TrainImpl(vecs.data(), count);
+
+    auto computer = quantizer.FactoryComputer();
+    computer->SetQuery(vecs.data() + 8 * dim);
+
+    std::vector<uint8_t> full_code(quantizer.GetCodeSize());
+    std::vector<uint8_t> supplement_code(quantizer.GetSupplementCodeSize());
+    std::vector<std::vector<uint8_t>> one_bit_codes(
+        4, std::vector<uint8_t>(quantizer.GetOneBitCodeSize()));
+    float single_dists[4] = {};
+    float single_lower_bounds[4] = {};
+
+    for (uint64_t i = 0; i < 4; ++i) {
+        REQUIRE(quantizer.EncodeOne(vecs.data() + i * dim, full_code.data()));
+        quantizer.SplitCode(full_code.data(), one_bit_codes[i].data(), supplement_code.data());
+
+        REQUIRE(quantizer.ComputeDistWithOneBitLowerBound(
+            *computer, one_bit_codes[i].data(), single_dists + i, single_lower_bounds + i));
+        float split_dist = 0.0F;
+        REQUIRE(quantizer.ComputeDistWithSplitCode(
+            *computer, one_bit_codes[i].data(), supplement_code.data(), &split_dist));
+        float hinted_split_dist = 0.0F;
+        REQUIRE(quantizer.ComputeDistWithSplitCodeAndFilterDist(*computer,
+                                                                one_bit_codes[i].data(),
+                                                                supplement_code.data(),
+                                                                single_dists[i],
+                                                                &hinted_split_dist));
+        REQUIRE(std::abs(split_dist - hinted_split_dist) <= 1e-5F);
+    }
+
+    float batch_dists[4] = {};
+    float batch_lower_bounds[4] = {};
+    bool computed[4] = {};
+    quantizer.ComputeDistsWithOneBitLowerBoundBatch4(*computer,
+                                                     one_bit_codes[0].data(),
+                                                     one_bit_codes[1].data(),
+                                                     one_bit_codes[2].data(),
+                                                     one_bit_codes[3].data(),
+                                                     batch_dists[0],
+                                                     batch_dists[1],
+                                                     batch_dists[2],
+                                                     batch_dists[3],
+                                                     batch_lower_bounds,
+                                                     batch_lower_bounds + 1,
+                                                     batch_lower_bounds + 2,
+                                                     batch_lower_bounds + 3,
+                                                     computed[0],
+                                                     computed[1],
+                                                     computed[2],
+                                                     computed[3]);
+    for (uint64_t i = 0; i < 4; ++i) {
+        REQUIRE(computed[i]);
+        REQUIRE(std::abs(single_dists[i] - batch_dists[i]) <= 1e-5F);
+        REQUIRE(std::abs(single_lower_bounds[i] - batch_lower_bounds[i]) <= 1e-5F);
+    }
+}
+
 TEST_CASE("RaBitQ Encode and Decode", "[ut][RaBitQuantizer]") {
     bool use_fht = GENERATE(true, false);
     auto num_bits_per_dim_query = GENERATE(4, 32);

--- a/tests/test_hgraph_rabitq_split.cpp
+++ b/tests/test_hgraph_rabitq_split.cpp
@@ -151,7 +151,7 @@ TEST_CASE("HGraph RaBitQ Split Hybrid IO (memory + async supplement)",
     using namespace fixtures;
     constexpr int64_t dim = 128;
     constexpr uint64_t base_count = 600;
-    const std::string metric = "l2";
+    const std::string metric = GENERATE("l2", "ip");
 
     auto build_param =
         HGraphRaBitQSplitTestIndex::GenerateBuildParam(metric, dim, "block_memory_io", "async_io");


### PR DESCRIPTION
## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement/Refactor
- [ ] Documentation
- [ ] CI/Build/Infra

## Linked Issue

Not required for `kind/improvement`.

## What Changed

- propagate `rabitq_one_bit_search` to HGraph route searches
- vectorize RaBitQ split IP Batch4 filtering and reuse filter distances during reorder
- remove the per-query 2/3-bit lookup table in favor of centered-IP SIMD kernels
- add IP regression coverage for Batch4, reorder hints, and split hybrid IO

## Test Evidence

- [ ] `make fmt`
- [ ] `make lint`
- [ ] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [x] Other (describe below)

Test details:

```text
clang-format-15 --dry-run --Werror <changed C++ files>          passed
git diff --check                                                passed
clang-tidy-15 -p build <changed production .cpp files>          passed

./build/tests/unittests -d yes --allow-running-no-tests
  All tests passed (85,421,538 assertions in 556 test cases)

./build/tests/functests -d yes '[pr]' --allow-running-no-tests
  All tests passed (1,021,124 assertions in 94 test cases)

./build/tests/functests -d yes '[rabitq_split]' --allow-running-no-tests
  All tests passed (3,837 assertions in 3 test cases)

./build/mockimpl/tests_mockimpl -d yes --allow-running-no-tests
  All tests passed (2 assertions in 1 test case)

After rebasing onto current origin/main:
  cmake --build build --parallel 6                               passed
  RaBitQ Split IP Batch4 and Reorder Hint                        33 assertions passed
  [rabitq_split]                                                 3,837 assertions passed

Note: unfiltered make test reached the Daily HGraph suite after the unit suite
and 75 functional cases had passed. The Daily Build & ContinueAdd case was
manually interrupted after 3,815 seconds; the reported SIGINT was not a code
assertion failure. The repository PR-tagged functional suite was then run in
full as shown above.
```

## Compatibility Impact

- API/ABI compatibility: none
- Behavior changes: `rabitq_one_bit_search` now consistently applies to route and base-layer searches; IP split search uses equivalent vectorized distance paths

## Performance and Concurrency Impact

- Performance impact: improved. On the supplied 768-d IP 3+5 split index at ef=200/topk=10, QPS increased from 93.079 to 152.829 and average latency decreased from 10.741 ms to 6.540 ms. Relative top-10 overlap against the 3+SQ8 result was 95.148%; no ground-truth recall file was available.
- Concurrency/thread-safety impact: none; query state remains per-computer/per-search

## Documentation Impact

- [x] No docs update needed
- [ ] Updated docs:
  - [ ] `README.md`
  - [ ] `DEVELOPMENT.md`
  - [ ] `CONTRIBUTING.md`
  - [ ] Other:

Existing English and Chinese RaBitQ split documentation already describes
`rabitq_one_bit_search` and the split filter-bit behavior; this change aligns
the IP implementation with that documented behavior.

## Risk and Rollback

- Risk level: medium
- Rollback plan: revert commit `e314f615`

## Checklist

- [ ] I have linked the relevant issue (not required for `kind/improvement`)
- [x] I have added/updated tests for new behavior or bug fixes
- [x] I have considered API compatibility impact
- [x] I have updated docs if behavior/workflow changed
- [x] My commit messages follow project conventions (Conventional Commits, optional `[skip ci]` prefix)
