### PR TITLE
perf(hgraph): reduce visited list memory

### DIFF
--- a/src/utils/visited_list.cpp
+++ b/src/utils/visited_list.cpp
@@ -22,6 +22,9 @@ namespace vsag {
 VisitedList::VisitedList(InnerIdType max_size, Allocator* allocator)
     : allocator_(allocator),
       word_count_((static_cast<uint64_t>(max_size) + kBitsPerWord - 1) / kBitsPerWord) {
+    if (word_count_ == 0) {
+        return;
+    }
     const auto words_bytes = word_count_ * sizeof(WordType);
     const auto tags_bytes = word_count_ * sizeof(TagType);
     auto* buffer = static_cast<uint8_t*>(allocator_->Allocate(words_bytes + tags_bytes));
@@ -31,13 +34,17 @@ VisitedList::VisitedList(InnerIdType max_size, Allocator* allocator)
 }
 
 VisitedList::~VisitedList() {
-    allocator_->Deallocate(words_);
+    if (words_ != nullptr) {
+        allocator_->Deallocate(words_);
+    }
 }
 
 void
 VisitedList::Reset() {
     if (tag_ == std::numeric_limits<TagType>::max()) {
-        memset(tags_, 0, word_count_ * sizeof(TagType));
+        if (word_count_ > 0) {
+            memset(tags_, 0, word_count_ * sizeof(TagType));
+        }
         tag_ = 1;
     } else {
         ++tag_;

--- a/src/utils/visited_list.cpp
+++ b/src/utils/visited_list.cpp
@@ -15,27 +15,32 @@
 
 #include "visited_list.h"
 
+#include <cstring>
 #include <limits>
 
 namespace vsag {
 VisitedList::VisitedList(InnerIdType max_size, Allocator* allocator)
-    : max_size_(max_size), allocator_(allocator) {
-    this->list_ = reinterpret_cast<VisitedListType*>(
-        allocator_->Allocate((uint64_t)max_size * sizeof(VisitedListType)));
-    memset(list_, 0, max_size_ * sizeof(VisitedListType));
-    tag_ = 1;
+    : allocator_(allocator),
+      word_count_((static_cast<uint64_t>(max_size) + kBitsPerWord - 1) / kBitsPerWord) {
+    const auto words_bytes = word_count_ * sizeof(WordType);
+    const auto tags_bytes = word_count_ * sizeof(TagType);
+    auto* buffer = static_cast<uint8_t*>(allocator_->Allocate(words_bytes + tags_bytes));
+    this->words_ = reinterpret_cast<WordType*>(buffer);
+    this->tags_ = reinterpret_cast<TagType*>(buffer + words_bytes);
+    memset(tags_, 0, tags_bytes);
 }
 
 VisitedList::~VisitedList() {
-    allocator_->Deallocate(list_);
+    allocator_->Deallocate(words_);
 }
 
 void
 VisitedList::Reset() {
-    if (tag_ == std::numeric_limits<VisitedListType>::max()) {
-        memset(list_, 0, max_size_ * sizeof(VisitedListType));
-        tag_ = 0;
+    if (tag_ == std::numeric_limits<TagType>::max()) {
+        memset(tags_, 0, word_count_ * sizeof(TagType));
+        tag_ = 1;
+    } else {
+        ++tag_;
     }
-    ++tag_;
 }
 }  // namespace vsag

--- a/src/utils/visited_list.h
+++ b/src/utils/visited_list.h
@@ -27,7 +27,9 @@ class Allocator;
 DEFINE_POINTER(VisitedList);
 class VisitedList : public ResourceObject {
 public:
-    using VisitedListType = uint16_t;
+    using WordType = uint64_t;
+    using TagType = uint16_t;
+    static constexpr uint64_t kBitsPerWord = sizeof(WordType) * 8;
 
 public:
     explicit VisitedList(InnerIdType max_size, Allocator* allocator);
@@ -35,17 +37,27 @@ public:
 
     void
     Set(const InnerIdType& id) {
-        this->list_[id] = this->tag_;
+        const auto word_id = static_cast<uint64_t>(id) / kBitsPerWord;
+        const auto mask = WordType{1} << (static_cast<uint64_t>(id) % kBitsPerWord);
+        if (this->tags_[word_id] != this->tag_) {
+            this->tags_[word_id] = this->tag_;
+            this->words_[word_id] = mask;
+        } else {
+            this->words_[word_id] |= mask;
+        }
     }
 
     [[nodiscard]] bool
     Get(const InnerIdType& id) {
-        return this->list_[id] == this->tag_;
+        const auto word_id = static_cast<uint64_t>(id) / kBitsPerWord;
+        const auto mask = WordType{1} << (static_cast<uint64_t>(id) % kBitsPerWord);
+        return this->tags_[word_id] == this->tag_ and (this->words_[word_id] & mask) != 0;
     }
 
     void
     Prefetch(const InnerIdType& id) {
-        PrefetchLines(this->list_ + id, 64);
+        const auto word_id = static_cast<uint64_t>(id) / kBitsPerWord;
+        PrefetchLines(this->tags_ + word_id, 64);
     }
 
     void
@@ -53,17 +65,19 @@ public:
 
     uint64_t
     GetMemoryUsage() const override {
-        return sizeof(VisitedList) + sizeof(VisitedListType) * this->max_size_;
+        return sizeof(VisitedList) + this->word_count_ * (sizeof(WordType) + sizeof(TagType));
     }
 
 private:
     Allocator* const allocator_{nullptr};
 
-    VisitedListType* list_{nullptr};
+    WordType* words_{nullptr};
 
-    VisitedListType tag_{1};
+    TagType* tags_{nullptr};
 
-    const InnerIdType max_size_{0};
+    TagType tag_{1};
+
+    const uint64_t word_count_{0};
 };
 
 using VisitedListPool = ResourceObjectPool<VisitedList>;

--- a/src/utils/visited_list_test.cpp
+++ b/src/utils/visited_list_test.cpp
@@ -24,6 +24,26 @@
 #include "unittest.h"
 using namespace vsag;
 
+namespace {
+class CountingAllocator : public DefaultAllocator {
+public:
+    void*
+    Allocate(uint64_t size) override {
+        ++allocate_count_;
+        return DefaultAllocator::Allocate(size);
+    }
+
+    void
+    Deallocate(void* p) override {
+        ++deallocate_count_;
+        DefaultAllocator::Deallocate(p);
+    }
+
+    uint64_t allocate_count_{0};
+    uint64_t deallocate_count_{0};
+};
+}  // namespace
+
 TEST_CASE("VisitedList Basic Test", "[ut][VisitedList]") {
     auto allocator = std::make_shared<DefaultAllocator>();
     auto size = 10000;
@@ -98,6 +118,19 @@ TEST_CASE("VisitedList Basic Test", "[ut][VisitedList]") {
         vl_ptr->Set(0);
         REQUIRE(vl_ptr->Get(0));
     }
+}
+
+TEST_CASE("VisitedList Zero Size Test", "[ut][VisitedList]") {
+    CountingAllocator allocator;
+    {
+        VisitedList visited_list(0, &allocator);
+        REQUIRE(visited_list.GetMemoryUsage() == sizeof(VisitedList));
+        for (uint64_t i = 0; i < std::numeric_limits<VisitedList::TagType>::max(); ++i) {
+            visited_list.Reset();
+        }
+    }
+    REQUIRE(allocator.allocate_count_ == 0);
+    REQUIRE(allocator.deallocate_count_ == 0);
 }
 
 TEST_CASE("VisitedList Randomized Differential Test", "[ut][VisitedList]") {

--- a/src/utils/visited_list_test.cpp
+++ b/src/utils/visited_list_test.cpp
@@ -15,6 +15,7 @@
 
 #include "visited_list.h"
 
+#include <limits>
 #include <thread>
 
 #include "impl/allocator/default_allocator.h"
@@ -57,6 +58,43 @@ TEST_CASE("VisitedList Basic Test", "[ut][VisitedList]") {
         for (auto& id : ids) {
             REQUIRE(vl_ptr->Get(id) == false);
         }
+    }
+
+    SECTION("test word boundaries and repeated sets") {
+        const std::vector<InnerIdType> ids = {0, 1, 63, 64, 65, static_cast<InnerIdType>(size - 1)};
+        for (const auto id : ids) {
+            vl_ptr->Set(id);
+            vl_ptr->Set(id);
+            REQUIRE(vl_ptr->Get(id));
+        }
+
+        vl_ptr->Reset();
+        for (const auto id : ids) {
+            REQUIRE_FALSE(vl_ptr->Get(id));
+        }
+
+        vl_ptr->Set(64);
+        REQUIRE(vl_ptr->Get(64));
+        vl_ptr->Reset();
+        REQUIRE_FALSE(vl_ptr->Get(64));
+    }
+
+    SECTION("test memory usage") {
+        const auto word_count = (static_cast<uint64_t>(size) + VisitedList::kBitsPerWord - 1) /
+                                VisitedList::kBitsPerWord;
+        const auto expected = sizeof(VisitedList) + word_count * (sizeof(VisitedList::WordType) +
+                                                                  sizeof(VisitedList::TagType));
+        REQUIRE(vl_ptr->GetMemoryUsage() == expected);
+    }
+
+    SECTION("test tag overflow") {
+        vl_ptr->Set(0);
+        for (uint64_t i = 0; i < std::numeric_limits<VisitedList::TagType>::max(); ++i) {
+            vl_ptr->Reset();
+        }
+        REQUIRE_FALSE(vl_ptr->Get(0));
+        vl_ptr->Set(0);
+        REQUIRE(vl_ptr->Get(0));
     }
 }
 

--- a/src/utils/visited_list_test.cpp
+++ b/src/utils/visited_list_test.cpp
@@ -15,7 +15,9 @@
 
 #include "visited_list.h"
 
+#include <algorithm>
 #include <limits>
+#include <random>
 #include <thread>
 
 #include "impl/allocator/default_allocator.h"
@@ -95,6 +97,37 @@ TEST_CASE("VisitedList Basic Test", "[ut][VisitedList]") {
         REQUIRE_FALSE(vl_ptr->Get(0));
         vl_ptr->Set(0);
         REQUIRE(vl_ptr->Get(0));
+    }
+}
+
+TEST_CASE("VisitedList Randomized Differential Test", "[ut][VisitedList]") {
+    auto allocator = std::make_shared<DefaultAllocator>();
+    std::mt19937_64 random_generator(20260715);
+    const std::vector<InnerIdType> sizes = {1, 2, 5, 63, 64, 65, 127, 128, 129, 10000};
+
+    for (const auto size : sizes) {
+        VisitedList visited_list(size, allocator.get());
+        std::vector<bool> reference(static_cast<uint64_t>(size), false);
+        std::uniform_int_distribution<uint64_t> id_distribution(0, static_cast<uint64_t>(size) - 1);
+        std::uniform_int_distribution<uint64_t> operation_distribution(0, 15);
+
+        for (uint64_t operation = 0; operation < 20000; ++operation) {
+            const auto id = static_cast<InnerIdType>(id_distribution(random_generator));
+            const auto operation_type = operation_distribution(random_generator);
+            if (operation_type == 0) {
+                visited_list.Reset();
+                std::fill(reference.begin(), reference.end(), false);
+            } else if (operation_type <= 8) {
+                visited_list.Set(id);
+                reference[static_cast<uint64_t>(id)] = true;
+            } else {
+                REQUIRE(visited_list.Get(id) == reference[static_cast<uint64_t>(id)]);
+            }
+        }
+
+        for (InnerIdType id = 0; id < size; ++id) {
+            REQUIRE(visited_list.Get(id) == reference[static_cast<uint64_t>(id)]);
+        }
     }
 }
 


### PR DESCRIPTION
## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement/Refactor
- [ ] Documentation
- [ ] CI/Build/Infra

## Linked Issue

- Fixes: #2448

## What Changed

- Replace the per-node `uint16_t` visited generation with a 64-bit bitmap and a
  generation tag shared by each 64-node block.
- Preserve constant-time lazy reset and clear only the compact tag array when the
  generation counter wraps.
- Update memory accounting, prefetching, and focused coverage for word boundaries,
  repeated sets, generation overflow, and allocation size.
- Add a deterministic randomized differential test against a `std::vector<bool>`
  reference model across boundary-heavy list sizes.

## Test Evidence

- [x] `make fmt`
- [ ] `make lint`
- [ ] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [x] Other (describe below)

Test details:

```text
make fmt
Using clang-format version 15 (required: 15)
Code formatting completed with clang-format-15

visited_list_tests '[VisitedList]' --reporter compact
All tests passed (108678 assertions in 2 test cases)

visited_list_tests '[VisitedListPool]' --reporter compact
All tests passed (10000 assertions in 1 test case)
```

No full test-suite run was performed; validation was intentionally limited to the
affected component.

## Compatibility Impact

- API/ABI compatibility: no public API or serialized-index changes
- Behavior changes: none; visited results and HGraph traversal statistics remain identical

## Performance and Concurrency Impact

- Performance impact: one-million-capacity visited-list allocation falls from 2,097,192 B
  to 163,896 B (92.185%, about 12.8x smaller). Across 1/16/48 search threads, pool memory
  fell from 4.002/36.003/122.004 MiB to 0.315/2.972/9.224 MiB. FP32 single-thread QPS
  improved by 3.03%-3.42% across `ef_search=32/80/256`; SQ8 improved by 3.02% at
  `ef_search=80`. The 16-thread results were neutral, and the noisier 48-thread confidence
  intervals crossed zero.
- Concurrency/thread-safety impact: none; each borrowed visited list remains exclusive to
  one search operation

The A/B benchmark used Release builds of parent `7768d172` and candidate `0c335358`, the
same serialized 800k-vector 128-dimensional HGraph index, 20,000 queries per case, and 10
paired rounds with alternating execution order. Recall was 1.0 in the correctness case,
and all paired runs produced identical traversal statistics.

This change complements #2435 and #2436: those PRs reduce the number of retained visited
lists, while this PR reduces the size of every list.

## Documentation Impact

- [x] No docs update needed
- [ ] Updated docs:
  - [ ] `README.md`
  - [ ] `DEVELOPMENT.md`
  - [ ] `CONTRIBUTING.md`
  - [ ] Other

This is an internal scratch-buffer representation change with no user-facing configuration
or behavior change.

## Risk and Rollback

- Risk level: low
- Rollback plan: revert the two commits in this PR to restore the per-node generation array

## Checklist

- [x] I have linked the relevant issue
- [x] I have added/updated tests for new behavior or bug fixes
- [x] I have considered API compatibility impact
- [x] I have updated docs if behavior/workflow changed
- [x] My commit messages follow project conventions

---
_Drafted with AI assistant: Codex:gpt-5_
