### PR TITLE
[Backport 1.0] perf(hgraph): reduce visited list memory

### DIFF
--- a/src/utils/visited_list.cpp
+++ b/src/utils/visited_list.cpp
@@ -22,6 +22,9 @@ namespace vsag {
 VisitedList::VisitedList(InnerIdType max_size, Allocator* allocator)
     : allocator_(allocator),
       word_count_((static_cast<uint64_t>(max_size) + kBitsPerWord - 1) / kBitsPerWord) {
+    if (word_count_ == 0) {
+        return;
+    }
     const auto words_bytes = word_count_ * sizeof(WordType);
     const auto tags_bytes = word_count_ * sizeof(TagType);
     auto* buffer = static_cast<uint8_t*>(allocator_->Allocate(words_bytes + tags_bytes));
@@ -31,13 +34,17 @@ VisitedList::VisitedList(InnerIdType max_size, Allocator* allocator)
 }
 
 VisitedList::~VisitedList() {
-    allocator_->Deallocate(words_);
+    if (words_ != nullptr) {
+        allocator_->Deallocate(words_);
+    }
 }
 
 void
 VisitedList::Reset() {
     if (tag_ == std::numeric_limits<TagType>::max()) {
-        memset(tags_, 0, word_count_ * sizeof(TagType));
+        if (word_count_ > 0) {
+            memset(tags_, 0, word_count_ * sizeof(TagType));
+        }
         tag_ = 1;
     } else {
         ++tag_;

--- a/src/utils/visited_list.cpp
+++ b/src/utils/visited_list.cpp
@@ -15,27 +15,32 @@
 
 #include "visited_list.h"
 
+#include <cstring>
 #include <limits>
 
 namespace vsag {
 VisitedList::VisitedList(InnerIdType max_size, Allocator* allocator)
-    : max_size_(max_size), allocator_(allocator) {
-    this->list_ = reinterpret_cast<VisitedListType*>(
-        allocator_->Allocate((uint64_t)max_size * sizeof(VisitedListType)));
-    memset(list_, 0, max_size_ * sizeof(VisitedListType));
-    tag_ = 1;
+    : allocator_(allocator),
+      word_count_((static_cast<uint64_t>(max_size) + kBitsPerWord - 1) / kBitsPerWord) {
+    const auto words_bytes = word_count_ * sizeof(WordType);
+    const auto tags_bytes = word_count_ * sizeof(TagType);
+    auto* buffer = static_cast<uint8_t*>(allocator_->Allocate(words_bytes + tags_bytes));
+    this->words_ = reinterpret_cast<WordType*>(buffer);
+    this->tags_ = reinterpret_cast<TagType*>(buffer + words_bytes);
+    memset(tags_, 0, tags_bytes);
 }
 
 VisitedList::~VisitedList() {
-    allocator_->Deallocate(list_);
+    allocator_->Deallocate(words_);
 }
 
 void
 VisitedList::Reset() {
-    if (tag_ == std::numeric_limits<VisitedListType>::max()) {
-        memset(list_, 0, max_size_ * sizeof(VisitedListType));
-        tag_ = 0;
+    if (tag_ == std::numeric_limits<TagType>::max()) {
+        memset(tags_, 0, word_count_ * sizeof(TagType));
+        tag_ = 1;
+    } else {
+        ++tag_;
     }
-    ++tag_;
 }
 }  // namespace vsag

--- a/src/utils/visited_list.h
+++ b/src/utils/visited_list.h
@@ -27,7 +27,9 @@ class Allocator;
 DEFINE_POINTER(VisitedList);
 class VisitedList : public ResourceObject {
 public:
-    using VisitedListType = uint16_t;
+    using WordType = uint64_t;
+    using TagType = uint16_t;
+    static constexpr uint64_t kBitsPerWord = sizeof(WordType) * 8;
 
 public:
     explicit VisitedList(InnerIdType max_size, Allocator* allocator);
@@ -35,17 +37,27 @@ public:
 
     void
     Set(const InnerIdType& id) {
-        this->list_[id] = this->tag_;
+        const auto word_id = static_cast<uint64_t>(id) / kBitsPerWord;
+        const auto mask = WordType{1} << (static_cast<uint64_t>(id) % kBitsPerWord);
+        if (this->tags_[word_id] != this->tag_) {
+            this->tags_[word_id] = this->tag_;
+            this->words_[word_id] = mask;
+        } else {
+            this->words_[word_id] |= mask;
+        }
     }
 
     [[nodiscard]] bool
     Get(const InnerIdType& id) {
-        return this->list_[id] == this->tag_;
+        const auto word_id = static_cast<uint64_t>(id) / kBitsPerWord;
+        const auto mask = WordType{1} << (static_cast<uint64_t>(id) % kBitsPerWord);
+        return this->tags_[word_id] == this->tag_ and (this->words_[word_id] & mask) != 0;
     }
 
     void
     Prefetch(const InnerIdType& id) {
-        PrefetchLines(this->list_ + id, 64);
+        const auto word_id = static_cast<uint64_t>(id) / kBitsPerWord;
+        PrefetchLines(this->tags_ + word_id, 64);
     }
 
     void
@@ -53,17 +65,19 @@ public:
 
     uint64_t
     GetMemoryUsage() const override {
-        return sizeof(VisitedList) + sizeof(VisitedListType) * this->max_size_;
+        return sizeof(VisitedList) + this->word_count_ * (sizeof(WordType) + sizeof(TagType));
     }
 
 private:
     Allocator* const allocator_{nullptr};
 
-    VisitedListType* list_{nullptr};
+    WordType* words_{nullptr};
 
-    VisitedListType tag_{1};
+    TagType* tags_{nullptr};
 
-    const InnerIdType max_size_{0};
+    TagType tag_{1};
+
+    const uint64_t word_count_{0};
 };
 
 using VisitedListPool = ResourceObjectPool<VisitedList>;

--- a/src/utils/visited_list_test.cpp
+++ b/src/utils/visited_list_test.cpp
@@ -24,6 +24,26 @@
 #include "unittest.h"
 using namespace vsag;
 
+namespace {
+class CountingAllocator : public DefaultAllocator {
+public:
+    void*
+    Allocate(uint64_t size) override {
+        ++allocate_count_;
+        return DefaultAllocator::Allocate(size);
+    }
+
+    void
+    Deallocate(void* p) override {
+        ++deallocate_count_;
+        DefaultAllocator::Deallocate(p);
+    }
+
+    uint64_t allocate_count_{0};
+    uint64_t deallocate_count_{0};
+};
+}  // namespace
+
 TEST_CASE("VisitedList Basic Test", "[ut][VisitedList]") {
     auto allocator = std::make_shared<DefaultAllocator>();
     auto size = 10000;
@@ -98,6 +118,19 @@ TEST_CASE("VisitedList Basic Test", "[ut][VisitedList]") {
         vl_ptr->Set(0);
         REQUIRE(vl_ptr->Get(0));
     }
+}
+
+TEST_CASE("VisitedList Zero Size Test", "[ut][VisitedList]") {
+    CountingAllocator allocator;
+    {
+        VisitedList visited_list(0, &allocator);
+        REQUIRE(visited_list.GetMemoryUsage() == sizeof(VisitedList));
+        for (uint64_t i = 0; i < std::numeric_limits<VisitedList::TagType>::max(); ++i) {
+            visited_list.Reset();
+        }
+    }
+    REQUIRE(allocator.allocate_count_ == 0);
+    REQUIRE(allocator.deallocate_count_ == 0);
 }
 
 TEST_CASE("VisitedList Randomized Differential Test", "[ut][VisitedList]") {

--- a/src/utils/visited_list_test.cpp
+++ b/src/utils/visited_list_test.cpp
@@ -15,6 +15,7 @@
 
 #include "visited_list.h"
 
+#include <limits>
 #include <thread>
 
 #include "impl/allocator/default_allocator.h"
@@ -57,6 +58,43 @@ TEST_CASE("VisitedList Basic Test", "[ut][VisitedList]") {
         for (auto& id : ids) {
             REQUIRE(vl_ptr->Get(id) == false);
         }
+    }
+
+    SECTION("test word boundaries and repeated sets") {
+        const std::vector<InnerIdType> ids = {0, 1, 63, 64, 65, static_cast<InnerIdType>(size - 1)};
+        for (const auto id : ids) {
+            vl_ptr->Set(id);
+            vl_ptr->Set(id);
+            REQUIRE(vl_ptr->Get(id));
+        }
+
+        vl_ptr->Reset();
+        for (const auto id : ids) {
+            REQUIRE_FALSE(vl_ptr->Get(id));
+        }
+
+        vl_ptr->Set(64);
+        REQUIRE(vl_ptr->Get(64));
+        vl_ptr->Reset();
+        REQUIRE_FALSE(vl_ptr->Get(64));
+    }
+
+    SECTION("test memory usage") {
+        const auto word_count = (static_cast<uint64_t>(size) + VisitedList::kBitsPerWord - 1) /
+                                VisitedList::kBitsPerWord;
+        const auto expected = sizeof(VisitedList) + word_count * (sizeof(VisitedList::WordType) +
+                                                                  sizeof(VisitedList::TagType));
+        REQUIRE(vl_ptr->GetMemoryUsage() == expected);
+    }
+
+    SECTION("test tag overflow") {
+        vl_ptr->Set(0);
+        for (uint64_t i = 0; i < std::numeric_limits<VisitedList::TagType>::max(); ++i) {
+            vl_ptr->Reset();
+        }
+        REQUIRE_FALSE(vl_ptr->Get(0));
+        vl_ptr->Set(0);
+        REQUIRE(vl_ptr->Get(0));
     }
 }
 

--- a/src/utils/visited_list_test.cpp
+++ b/src/utils/visited_list_test.cpp
@@ -15,7 +15,9 @@
 
 #include "visited_list.h"
 
+#include <algorithm>
 #include <limits>
+#include <random>
 #include <thread>
 
 #include "impl/allocator/default_allocator.h"
@@ -95,6 +97,37 @@ TEST_CASE("VisitedList Basic Test", "[ut][VisitedList]") {
         REQUIRE_FALSE(vl_ptr->Get(0));
         vl_ptr->Set(0);
         REQUIRE(vl_ptr->Get(0));
+    }
+}
+
+TEST_CASE("VisitedList Randomized Differential Test", "[ut][VisitedList]") {
+    auto allocator = std::make_shared<DefaultAllocator>();
+    std::mt19937_64 random_generator(20260715);
+    const std::vector<InnerIdType> sizes = {1, 2, 5, 63, 64, 65, 127, 128, 129, 10000};
+
+    for (const auto size : sizes) {
+        VisitedList visited_list(size, allocator.get());
+        std::vector<bool> reference(static_cast<uint64_t>(size), false);
+        std::uniform_int_distribution<uint64_t> id_distribution(0, static_cast<uint64_t>(size) - 1);
+        std::uniform_int_distribution<uint64_t> operation_distribution(0, 15);
+
+        for (uint64_t operation = 0; operation < 20000; ++operation) {
+            const auto id = static_cast<InnerIdType>(id_distribution(random_generator));
+            const auto operation_type = operation_distribution(random_generator);
+            if (operation_type == 0) {
+                visited_list.Reset();
+                std::fill(reference.begin(), reference.end(), false);
+            } else if (operation_type <= 8) {
+                visited_list.Set(id);
+                reference[static_cast<uint64_t>(id)] = true;
+            } else {
+                REQUIRE(visited_list.Get(id) == reference[static_cast<uint64_t>(id)]);
+            }
+        }
+
+        for (InnerIdType id = 0; id < size; ++id) {
+            REQUIRE(visited_list.Get(id) == reference[static_cast<uint64_t>(id)]);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Backports #2449 to the `1.0` branch.

- replace the per-node visitation generation array with generation-stamped bitmap words
- preserve lazy reset semantics while reducing visited-list scratch memory
- include boundary, wraparound, zero-capacity, and randomized differential coverage

## Validation

- `make fmt` with clang-format 15
- `git diff --check`
- compiled `src/utils/visited_list.cpp` and `src/utils/visited_list_test.cpp` with the CMake-generated compilation commands
- `make test CASE='[ut][VisitedList]'` was blocked before project compilation by external dependency download timeouts; CI will run the targeted and repository checks with its dependency cache

Backport of #2449.
