### PR TITLE
perf(hgraph): reduce node lock memory overhead

### DIFF
--- a/src/utils/lock_strategy.cpp
+++ b/src/utils/lock_strategy.cpp
@@ -15,6 +15,8 @@
 
 #include "lock_strategy.h"
 
+#include <new>
+
 namespace vsag {
 
 PointsMutex::PointsMutex(uint32_t element_num, Allocator* allocator)
@@ -24,14 +26,31 @@ PointsMutex::PointsMutex(uint32_t element_num, Allocator* allocator)
 
 void
 PointsMutex::MutexBlockDeleter::operator()(MutexBlock* block) const {
-    allocator->Delete(block);
+    block->~MutexBlock();
+    allocator->Deallocate(allocation);
+}
+
+PointsMutex::MutexBlockPtr
+PointsMutex::NewMutexBlock() {
+    constexpr auto alignment = alignof(MutexBlock);
+    constexpr auto allocation_size = sizeof(MutexBlock) + alignment - 1;
+    void* allocation = allocator_->Allocate(allocation_size);
+    const auto address = reinterpret_cast<uintptr_t>(allocation);
+    void* aligned = reinterpret_cast<void*>((address + alignment - 1) & ~(alignment - 1));
+    try {
+        auto* block = ::new (aligned) MutexBlock();
+        return MutexBlockPtr(block, MutexBlockDeleter{allocator_, allocation});
+    } catch (...) {
+        allocator_->Deallocate(allocation);
+        throw;
+    }
 }
 
 std::shared_mutex&
 PointsMutex::GetMutex(uint32_t i) {
     const auto block_id = static_cast<uint64_t>(i) / kMutexesPerBlock;
     const auto offset = static_cast<uint64_t>(i) % kMutexesPerBlock;
-    return mutex_blocks_[block_id]->mutexes[offset];
+    return mutex_blocks_[block_id]->mutexes[offset].mutex;
 }
 
 void
@@ -61,8 +80,7 @@ PointsMutex::Resize(uint32_t new_element_num) {
     if (required_blocks > mutex_blocks_.size()) {
         mutex_blocks_.reserve(required_blocks);
         while (mutex_blocks_.size() < required_blocks) {
-            mutex_blocks_.emplace_back(allocator_->New<MutexBlock>(),
-                                       MutexBlockDeleter{allocator_});
+            mutex_blocks_.emplace_back(this->NewMutexBlock());
         }
     } else {
         while (mutex_blocks_.size() > required_blocks) {
@@ -74,7 +92,7 @@ PointsMutex::Resize(uint32_t new_element_num) {
 
 uint64_t
 PointsMutex::GetMemoryUsage() {
-    return mutex_blocks_.size() * sizeof(MutexBlock) +
+    return mutex_blocks_.size() * (sizeof(MutexBlock) + alignof(MutexBlock) - 1) +
            mutex_blocks_.capacity() * sizeof(MutexBlockPtr);
 }
 

--- a/src/utils/lock_strategy.cpp
+++ b/src/utils/lock_strategy.cpp
@@ -18,7 +18,7 @@
 namespace vsag {
 
 PointsMutex::PointsMutex(uint32_t element_num, Allocator* allocator)
-    : allocator_(allocator), mutex_blocks_(allocator), mutexes_(allocator) {
+    : allocator_(allocator), mutex_blocks_(allocator) {
     this->Resize(element_num);
 }
 
@@ -29,22 +29,22 @@ PointsMutex::MutexBlockDeleter::operator()(MutexBlock* block) const {
 
 void
 PointsMutex::SharedLock(uint32_t i) {
-    mutexes_[i]->lock_shared();
+    GetMutex(i).lock_shared();
 }
 
 void
 PointsMutex::SharedUnlock(uint32_t i) {
-    mutexes_[i]->unlock_shared();
+    GetMutex(i).unlock_shared();
 }
 
 void
 PointsMutex::Lock(uint32_t i) {
-    mutexes_[i]->lock();
+    GetMutex(i).lock();
 }
 
 void
 PointsMutex::Unlock(uint32_t i) {
-    mutexes_[i]->unlock();
+    GetMutex(i).unlock();
 }
 
 void
@@ -59,14 +59,7 @@ PointsMutex::Resize(uint32_t new_element_num) {
                                            MutexBlockDeleter{allocator_});
             }
         }
-        mutexes_.resize(new_element_num);
-        for (uint64_t i = element_num_; i < new_element_num; ++i) {
-            const auto block_id = i / kMutexesPerBlock;
-            const auto offset = i % kMutexesPerBlock;
-            mutexes_[i] = &mutex_blocks_[block_id]->mutexes[offset];
-        }
     } else if (new_element_num < element_num_) {
-        mutexes_.resize(new_element_num);
         while (mutex_blocks_.size() > required_blocks) {
             mutex_blocks_.pop_back();
         }
@@ -77,8 +70,7 @@ PointsMutex::Resize(uint32_t new_element_num) {
 uint64_t
 PointsMutex::GetMemoryUsage() {
     return mutex_blocks_.size() * sizeof(MutexBlock) +
-           mutex_blocks_.capacity() * sizeof(MutexBlockPtr) +
-           mutexes_.capacity() * sizeof(std::shared_mutex*);
+           mutex_blocks_.capacity() * sizeof(MutexBlockPtr);
 }
 
 }  // namespace vsag

--- a/src/utils/lock_strategy.cpp
+++ b/src/utils/lock_strategy.cpp
@@ -46,29 +46,24 @@ PointsMutex::NewMutexBlock() {
     }
 }
 
-std::shared_mutex&
-PointsMutex::GetMutex(uint32_t i) {
-    return *mutexes_[i];
-}
-
 void
 PointsMutex::SharedLock(uint32_t i) {
-    this->GetMutex(i).lock_shared();
+    mutexes_[i]->lock_shared();
 }
 
 void
 PointsMutex::SharedUnlock(uint32_t i) {
-    this->GetMutex(i).unlock_shared();
+    mutexes_[i]->unlock_shared();
 }
 
 void
 PointsMutex::Lock(uint32_t i) {
-    this->GetMutex(i).lock();
+    mutexes_[i]->lock();
 }
 
 void
 PointsMutex::Unlock(uint32_t i) {
-    this->GetMutex(i).unlock();
+    mutexes_[i]->unlock();
 }
 
 void

--- a/src/utils/lock_strategy.cpp
+++ b/src/utils/lock_strategy.cpp
@@ -18,40 +18,55 @@
 namespace vsag {
 
 PointsMutex::PointsMutex(uint32_t element_num, Allocator* allocator)
-    : allocator_(allocator),
-      neighbors_mutex_(element_num, nullptr, allocator),
-      element_num_(element_num) {
-    for (int i = 0; i < element_num_; ++i) {
-        neighbors_mutex_[i] = AllocateShared<std::shared_mutex>(allocator_);
-    }
+    : allocator_(allocator), mutex_blocks_(allocator) {
+    this->Resize(element_num);
+}
+
+void
+PointsMutex::MutexBlockDeleter::operator()(MutexBlock* block) const {
+    allocator->Delete(block);
+}
+
+std::shared_mutex&
+PointsMutex::GetMutex(uint32_t i) {
+    const auto block_id = static_cast<uint64_t>(i) / kMutexesPerBlock;
+    const auto offset = static_cast<uint64_t>(i) % kMutexesPerBlock;
+    return mutex_blocks_[block_id]->mutexes[offset];
 }
 
 void
 PointsMutex::SharedLock(uint32_t i) {
-    neighbors_mutex_[i]->lock_shared();
+    this->GetMutex(i).lock_shared();
 }
 
 void
 PointsMutex::SharedUnlock(uint32_t i) {
-    neighbors_mutex_[i]->unlock_shared();
+    this->GetMutex(i).unlock_shared();
 }
 
 void
 PointsMutex::Lock(uint32_t i) {
-    neighbors_mutex_[i]->lock();
+    this->GetMutex(i).lock();
 }
 
 void
 PointsMutex::Unlock(uint32_t i) {
-    neighbors_mutex_[i]->unlock();
+    this->GetMutex(i).unlock();
 }
 
 void
 PointsMutex::Resize(uint32_t new_element_num) {
-    neighbors_mutex_.resize(new_element_num);
-    if (new_element_num > element_num_) {
-        for (auto i = element_num_; i < new_element_num; ++i) {
-            neighbors_mutex_[i] = AllocateShared<std::shared_mutex>(allocator_);
+    const auto required_blocks =
+        (static_cast<uint64_t>(new_element_num) + kMutexesPerBlock - 1) / kMutexesPerBlock;
+    if (required_blocks > mutex_blocks_.size()) {
+        mutex_blocks_.reserve(required_blocks);
+        while (mutex_blocks_.size() < required_blocks) {
+            mutex_blocks_.emplace_back(allocator_->New<MutexBlock>(),
+                                       MutexBlockDeleter{allocator_});
+        }
+    } else {
+        while (mutex_blocks_.size() > required_blocks) {
+            mutex_blocks_.pop_back();
         }
     }
     element_num_ = new_element_num;
@@ -59,9 +74,8 @@ PointsMutex::Resize(uint32_t new_element_num) {
 
 uint64_t
 PointsMutex::GetMemoryUsage() {
-    return static_cast<uint64_t>(
-        neighbors_mutex_.size() *
-        (sizeof(std::shared_ptr<std::shared_mutex>) + sizeof(std::shared_mutex)));
+    return mutex_blocks_.size() * sizeof(MutexBlock) +
+           mutex_blocks_.capacity() * sizeof(MutexBlockPtr);
 }
 
 }  // namespace vsag

--- a/src/utils/lock_strategy.cpp
+++ b/src/utils/lock_strategy.cpp
@@ -15,8 +15,6 @@
 
 #include "lock_strategy.h"
 
-#include <new>
-
 namespace vsag {
 
 PointsMutex::PointsMutex(uint32_t element_num, Allocator* allocator)
@@ -26,24 +24,7 @@ PointsMutex::PointsMutex(uint32_t element_num, Allocator* allocator)
 
 void
 PointsMutex::MutexBlockDeleter::operator()(MutexBlock* block) const {
-    block->~MutexBlock();
-    allocator->Deallocate(allocation);
-}
-
-PointsMutex::MutexBlockPtr
-PointsMutex::NewMutexBlock() {
-    constexpr auto alignment = alignof(MutexBlock);
-    constexpr auto allocation_size = sizeof(MutexBlock) + alignment - 1;
-    void* allocation = allocator_->Allocate(allocation_size);
-    const auto address = reinterpret_cast<uintptr_t>(allocation);
-    void* aligned = reinterpret_cast<void*>((address + alignment - 1) & ~(alignment - 1));
-    try {
-        auto* block = ::new (aligned) MutexBlock();
-        return MutexBlockPtr(block, MutexBlockDeleter{allocator_, allocation});
-    } catch (...) {
-        allocator_->Deallocate(allocation);
-        throw;
-    }
+    allocator->Delete(block);
 }
 
 void
@@ -74,14 +55,15 @@ PointsMutex::Resize(uint32_t new_element_num) {
         if (required_blocks > mutex_blocks_.size()) {
             mutex_blocks_.reserve(required_blocks);
             while (mutex_blocks_.size() < required_blocks) {
-                mutex_blocks_.emplace_back(this->NewMutexBlock());
+                mutex_blocks_.emplace_back(allocator_->New<MutexBlock>(),
+                                           MutexBlockDeleter{allocator_});
             }
         }
         mutexes_.resize(new_element_num);
         for (uint64_t i = element_num_; i < new_element_num; ++i) {
             const auto block_id = i / kMutexesPerBlock;
             const auto offset = i % kMutexesPerBlock;
-            mutexes_[i] = &mutex_blocks_[block_id]->mutexes[offset].mutex;
+            mutexes_[i] = &mutex_blocks_[block_id]->mutexes[offset];
         }
     } else if (new_element_num < element_num_) {
         mutexes_.resize(new_element_num);
@@ -94,7 +76,7 @@ PointsMutex::Resize(uint32_t new_element_num) {
 
 uint64_t
 PointsMutex::GetMemoryUsage() {
-    return mutex_blocks_.size() * (sizeof(MutexBlock) + alignof(MutexBlock) - 1) +
+    return mutex_blocks_.size() * sizeof(MutexBlock) +
            mutex_blocks_.capacity() * sizeof(MutexBlockPtr) +
            mutexes_.capacity() * sizeof(std::shared_mutex*);
 }

--- a/src/utils/lock_strategy.cpp
+++ b/src/utils/lock_strategy.cpp
@@ -20,7 +20,7 @@
 namespace vsag {
 
 PointsMutex::PointsMutex(uint32_t element_num, Allocator* allocator)
-    : allocator_(allocator), mutex_blocks_(allocator) {
+    : allocator_(allocator), mutex_blocks_(allocator), mutexes_(allocator) {
     this->Resize(element_num);
 }
 
@@ -48,9 +48,7 @@ PointsMutex::NewMutexBlock() {
 
 std::shared_mutex&
 PointsMutex::GetMutex(uint32_t i) {
-    const auto block_id = static_cast<uint64_t>(i) / kMutexesPerBlock;
-    const auto offset = static_cast<uint64_t>(i) % kMutexesPerBlock;
-    return mutex_blocks_[block_id]->mutexes[offset].mutex;
+    return *mutexes_[i];
 }
 
 void
@@ -77,12 +75,21 @@ void
 PointsMutex::Resize(uint32_t new_element_num) {
     const auto required_blocks =
         (static_cast<uint64_t>(new_element_num) + kMutexesPerBlock - 1) / kMutexesPerBlock;
-    if (required_blocks > mutex_blocks_.size()) {
-        mutex_blocks_.reserve(required_blocks);
-        while (mutex_blocks_.size() < required_blocks) {
-            mutex_blocks_.emplace_back(this->NewMutexBlock());
+    if (new_element_num > element_num_) {
+        if (required_blocks > mutex_blocks_.size()) {
+            mutex_blocks_.reserve(required_blocks);
+            while (mutex_blocks_.size() < required_blocks) {
+                mutex_blocks_.emplace_back(this->NewMutexBlock());
+            }
         }
-    } else {
+        mutexes_.resize(new_element_num);
+        for (uint64_t i = element_num_; i < new_element_num; ++i) {
+            const auto block_id = i / kMutexesPerBlock;
+            const auto offset = i % kMutexesPerBlock;
+            mutexes_[i] = &mutex_blocks_[block_id]->mutexes[offset].mutex;
+        }
+    } else if (new_element_num < element_num_) {
+        mutexes_.resize(new_element_num);
         while (mutex_blocks_.size() > required_blocks) {
             mutex_blocks_.pop_back();
         }
@@ -93,7 +100,8 @@ PointsMutex::Resize(uint32_t new_element_num) {
 uint64_t
 PointsMutex::GetMemoryUsage() {
     return mutex_blocks_.size() * (sizeof(MutexBlock) + alignof(MutexBlock) - 1) +
-           mutex_blocks_.capacity() * sizeof(MutexBlockPtr);
+           mutex_blocks_.capacity() * sizeof(MutexBlockPtr) +
+           mutexes_.capacity() * sizeof(std::shared_mutex*);
 }
 
 }  // namespace vsag

--- a/src/utils/lock_strategy.h
+++ b/src/utils/lock_strategy.h
@@ -73,12 +73,21 @@ public:
     GetMemoryUsage() override;
 
 private:
+    static constexpr auto kMutexSlotAlignment =
+        sizeof(std::shared_mutex) <= 64 ? 64 : alignof(std::shared_mutex);
+
+    // Small mutex implementations get a dedicated cache line to avoid false sharing.
+    struct alignas(kMutexSlotAlignment) MutexSlot {
+        std::shared_mutex mutex;
+    };
+
     struct MutexBlock {
-        std::array<std::shared_mutex, kMutexesPerBlock> mutexes;
+        std::array<MutexSlot, kMutexesPerBlock> mutexes;
     };
 
     struct MutexBlockDeleter {
         Allocator* allocator{nullptr};
+        void* allocation{nullptr};
 
         void
         operator()(MutexBlock* block) const;
@@ -88,6 +97,9 @@ private:
 
     std::shared_mutex&
     GetMutex(uint32_t i);
+
+    MutexBlockPtr
+    NewMutexBlock();
 
     Allocator* const allocator_{nullptr};
     Vector<MutexBlockPtr> mutex_blocks_;

--- a/src/utils/lock_strategy.h
+++ b/src/utils/lock_strategy.h
@@ -86,9 +86,13 @@ private:
 
     using MutexBlockPtr = std::unique_ptr<MutexBlock, MutexBlockDeleter>;
 
+    std::shared_mutex&
+    GetMutex(uint32_t i) {
+        return mutex_blocks_[i / kMutexesPerBlock]->mutexes[i % kMutexesPerBlock];
+    }
+
     Allocator* const allocator_{nullptr};
     Vector<MutexBlockPtr> mutex_blocks_;
-    Vector<std::shared_mutex*> mutexes_;
     uint32_t element_num_{0};
 };
 

--- a/src/utils/lock_strategy.h
+++ b/src/utils/lock_strategy.h
@@ -73,30 +73,18 @@ public:
     GetMemoryUsage() override;
 
 private:
-    static constexpr auto kMutexSlotAlignment =
-        sizeof(std::shared_mutex) <= 64 ? 64 : alignof(std::shared_mutex);
-
-    // Small mutex implementations get a dedicated cache line to avoid false sharing.
-    struct alignas(kMutexSlotAlignment) MutexSlot {
-        std::shared_mutex mutex;
-    };
-
     struct MutexBlock {
-        std::array<MutexSlot, kMutexesPerBlock> mutexes;
+        std::array<std::shared_mutex, kMutexesPerBlock> mutexes;
     };
 
     struct MutexBlockDeleter {
         Allocator* allocator{nullptr};
-        void* allocation{nullptr};
 
         void
         operator()(MutexBlock* block) const;
     };
 
     using MutexBlockPtr = std::unique_ptr<MutexBlock, MutexBlockDeleter>;
-
-    MutexBlockPtr
-    NewMutexBlock();
 
     Allocator* const allocator_{nullptr};
     Vector<MutexBlockPtr> mutex_blocks_;

--- a/src/utils/lock_strategy.h
+++ b/src/utils/lock_strategy.h
@@ -15,6 +15,8 @@
 
 #pragma once
 
+#include <array>
+#include <memory>
 #include <shared_mutex>
 
 #include "typing.h"
@@ -48,6 +50,8 @@ public:
 
 class PointsMutex : public MutexArray {
 public:
+    static constexpr uint64_t kMutexesPerBlock = 1024;
+
     PointsMutex(uint32_t element_num, Allocator* allocator);
 
     void
@@ -69,8 +73,24 @@ public:
     GetMemoryUsage() override;
 
 private:
-    Vector<std::shared_ptr<std::shared_mutex>> neighbors_mutex_;
+    struct MutexBlock {
+        std::array<std::shared_mutex, kMutexesPerBlock> mutexes;
+    };
+
+    struct MutexBlockDeleter {
+        Allocator* allocator{nullptr};
+
+        void
+        operator()(MutexBlock* block) const;
+    };
+
+    using MutexBlockPtr = std::unique_ptr<MutexBlock, MutexBlockDeleter>;
+
+    std::shared_mutex&
+    GetMutex(uint32_t i);
+
     Allocator* const allocator_{nullptr};
+    Vector<MutexBlockPtr> mutex_blocks_;
     uint32_t element_num_{0};
 };
 

--- a/src/utils/lock_strategy.h
+++ b/src/utils/lock_strategy.h
@@ -103,6 +103,7 @@ private:
 
     Allocator* const allocator_{nullptr};
     Vector<MutexBlockPtr> mutex_blocks_;
+    Vector<std::shared_mutex*> mutexes_;
     uint32_t element_num_{0};
 };
 

--- a/src/utils/lock_strategy.h
+++ b/src/utils/lock_strategy.h
@@ -95,9 +95,6 @@ private:
 
     using MutexBlockPtr = std::unique_ptr<MutexBlock, MutexBlockDeleter>;
 
-    std::shared_mutex&
-    GetMutex(uint32_t i);
-
     MutexBlockPtr
     NewMutexBlock();
 

--- a/src/utils/lock_strategy_test.cpp
+++ b/src/utils/lock_strategy_test.cpp
@@ -15,12 +15,54 @@
 
 #include "lock_strategy.h"
 
+#include <mutex>
 #include <thread>
+#include <unordered_map>
 
 #include "impl/allocator/default_allocator.h"
 #include "unittest.h"
 
 using namespace vsag;
+
+namespace {
+class CountingAllocator : public DefaultAllocator {
+public:
+    void*
+    Allocate(uint64_t size) override {
+        auto* ptr = DefaultAllocator::Allocate(size);
+        std::lock_guard<std::mutex> lock(mutex_);
+        allocations_[ptr] = size;
+        live_bytes_ += size;
+        ++allocation_count_;
+        return ptr;
+    }
+
+    void
+    Deallocate(void* p) override {
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            live_bytes_ -= allocations_.at(p);
+            allocations_.erase(p);
+            ++deallocation_count_;
+        }
+        DefaultAllocator::Deallocate(p);
+    }
+
+    uint64_t
+    LiveBytes() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return live_bytes_;
+    }
+
+    uint64_t allocation_count_{0};
+    uint64_t deallocation_count_{0};
+
+private:
+    mutable std::mutex mutex_;
+    std::unordered_map<void*, uint64_t> allocations_;
+    uint64_t live_bytes_{0};
+};
+}  // namespace
 
 TEST_CASE("LockStrategy Basic", "[ut][LockStrategy]") {
     auto allocator = std::make_shared<DefaultAllocator>();
@@ -35,13 +77,38 @@ TEST_CASE("LockStrategy Basic", "[ut][LockStrategy]") {
     }
 
     SECTION("resize updates memory usage") {
-        PointsMutex mutex_array(4, allocator.get());
+        const auto block_size = PointsMutex::kMutexesPerBlock;
+        PointsMutex mutex_array(block_size + 1, allocator.get());
         auto before = mutex_array.GetMemoryUsage();
-        mutex_array.Resize(10);
+        mutex_array.Resize(block_size * 2 + 1);
         auto after = mutex_array.GetMemoryUsage();
         REQUIRE(after > before);
         mutex_array.Resize(2);
         REQUIRE(mutex_array.GetMemoryUsage() < after);
+    }
+
+    SECTION("locks across block boundaries") {
+        const auto block_size = PointsMutex::kMutexesPerBlock;
+        PointsMutex mutex_array(block_size + 1, allocator.get());
+        mutex_array.Lock(block_size - 1);
+        mutex_array.Unlock(block_size - 1);
+        mutex_array.SharedLock(block_size);
+        mutex_array.SharedUnlock(block_size);
+    }
+
+    SECTION("block allocation reduces allocator overhead") {
+        CountingAllocator counting_allocator;
+        const auto element_count = PointsMutex::kMutexesPerBlock * 2;
+        {
+            PointsMutex mutex_array(element_count, &counting_allocator);
+            REQUIRE(counting_allocator.allocation_count_ == 3);
+            REQUIRE(counting_allocator.LiveBytes() == mutex_array.GetMemoryUsage());
+            REQUIRE(mutex_array.GetMemoryUsage() <
+                    element_count *
+                        (sizeof(std::shared_ptr<std::shared_mutex>) + sizeof(std::shared_mutex)));
+        }
+        REQUIRE(counting_allocator.LiveBytes() == 0);
+        REQUIRE(counting_allocator.deallocation_count_ == 3);
     }
 
     SECTION("lock guards protect concurrent increment") {

--- a/src/utils/lock_strategy_test.cpp
+++ b/src/utils/lock_strategy_test.cpp
@@ -101,14 +101,14 @@ TEST_CASE("LockStrategy Basic", "[ut][LockStrategy]") {
         const auto element_count = PointsMutex::kMutexesPerBlock * 2;
         {
             PointsMutex mutex_array(element_count, &counting_allocator);
-            REQUIRE(counting_allocator.allocation_count_ == 4);
+            REQUIRE(counting_allocator.allocation_count_ == 3);
             REQUIRE(counting_allocator.LiveBytes() == mutex_array.GetMemoryUsage());
             REQUIRE(mutex_array.GetMemoryUsage() <
                     element_count *
                         (sizeof(std::shared_ptr<std::shared_mutex>) + sizeof(std::shared_mutex)));
         }
         REQUIRE(counting_allocator.LiveBytes() == 0);
-        REQUIRE(counting_allocator.deallocation_count_ == 4);
+        REQUIRE(counting_allocator.deallocation_count_ == 3);
     }
 
     SECTION("lock guards protect concurrent increment") {

--- a/src/utils/lock_strategy_test.cpp
+++ b/src/utils/lock_strategy_test.cpp
@@ -101,14 +101,14 @@ TEST_CASE("LockStrategy Basic", "[ut][LockStrategy]") {
         const auto element_count = PointsMutex::kMutexesPerBlock * 2;
         {
             PointsMutex mutex_array(element_count, &counting_allocator);
-            REQUIRE(counting_allocator.allocation_count_ == 3);
+            REQUIRE(counting_allocator.allocation_count_ == 4);
             REQUIRE(counting_allocator.LiveBytes() == mutex_array.GetMemoryUsage());
             REQUIRE(mutex_array.GetMemoryUsage() <
                     element_count *
                         (sizeof(std::shared_ptr<std::shared_mutex>) + sizeof(std::shared_mutex)));
         }
         REQUIRE(counting_allocator.LiveBytes() == 0);
-        REQUIRE(counting_allocator.deallocation_count_ == 3);
+        REQUIRE(counting_allocator.deallocation_count_ == 4);
     }
 
     SECTION("lock guards protect concurrent increment") {


### PR DESCRIPTION
## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement/Refactor
- [ ] Documentation
- [ ] CI/Build/Infra

## Linked Issue

- Closes: #2455

## What Changed

- Store node locks in allocator-owned blocks of 1024 direct `std::shared_mutex` objects.
- Locate each lock directly by block and offset, which compile to a shift and mask.
- Release complete unused blocks when `PointsMutex` shrinks.
- Cover block growth, shrink, lock operation, and memory accounting behavior with unit tests.

## Test Evidence

- [ ] `make fmt`
- [ ] `make lint`
- [ ] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [x] Other (describe below)

Test details:

```text
Focused LockStrategy tests: 10 assertions passed.
HGraph concurrency tests: 3 test cases and 36,677 assertions passed.

Allocator probe, 10,000,384 locks:
- requested bytes: 960,036,864 -> 560,177,760 (-41.7%)
- usable bytes: 1,040,044,032 -> 560,259,360 (-46.1%)
- allocation calls: 10,000,385 -> 9,767 (-99.9%)
- construction time: 3.440s -> 0.357s (-89.6%)

Per-node shared pointers vs block-plus-flat-pointer implementation, SIFT128 800k,
HGraph FP32, max_degree=16, ef_search=80, 7 paired E2E rounds:
- 34 threads: median QPS +0.216%, median P99 -1.946%
- 48 threads: median QPS +0.304%, median P99 +0.312%

Flat pointer table vs direct block lookup, same dataset, 7 paired E2E rounds:
- 34 threads: median QPS +0.572%, mean QPS -0.157%
- 48 threads: median QPS -0.839%, mean QPS -0.032%

Direct KnnSearch timing, 5 paired rounds:
- 34 threads: median average latency +0.480%, median P99 +2.681%
- 48 threads: median average latency -0.765%, median P99 +3.142%
- P99 changes alternated between positive and negative rounds with 3-8% CV; no repeatable regression was observed.
```

## Compatibility Impact

- API/ABI compatibility: none; the change is internal to `PointsMutex`.
- Behavior changes: none; lock type and per-node locking semantics are unchanged.

## Performance and Concurrency Impact

- Performance impact: substantially lower lock memory, allocation count, and construction time; no repeatable steady-state QPS or P99 regression was observed.
- Concurrency/thread-safety impact: none; `Resize()` retains the existing external-synchronization requirement, while lock/unlock paths remain thread-safe.

## Documentation Impact

- [x] No docs update needed
- [ ] Updated docs:
  - [ ] `README.md`
  - [ ] `DEVELOPMENT.md`
  - [ ] `CONTRIBUTING.md`
  - [ ] Other

## Risk and Rollback

- Risk level: low
- Rollback plan: revert this PR to restore per-node `shared_ptr<shared_mutex>` storage.

## Checklist

- [x] I have linked the relevant issue.
- [x] I have added/updated tests for new behavior or bug fixes.
- [x] I have considered API compatibility impact.
- [x] I have updated docs if behavior/workflow changed, or confirmed no docs update is needed.
- [x] My commit messages follow project conventions.
