### PR TITLE
chore: split bucket interface factory compilation

### DIFF
--- a/src/datacell/bucket_datacell_test.cpp
+++ b/src/datacell/bucket_datacell_test.cpp
@@ -190,6 +190,12 @@ TEST_CASE("BucketDataCell Basic Test", "[ut][BucketDataCell] ") {
     TestBucketDataCell(param1, param2, common_param, quantizer_error.second);
 }
 
+TEST_CASE("BucketDataCell rejects invalid parameters", "[ut][BucketDataCell]") {
+    IndexCommonParam common_param;
+
+    REQUIRE(BucketInterface::MakeInstance(nullptr, common_param) == nullptr);
+}
+
 TEST_CASE("BucketDataCell supports RabitQ", "[ut][BucketDataCell]") {
     auto allocator = SafeAllocator::FactoryDefaultAllocator();
     constexpr uint64_t dim = 64;

--- a/src/datacell/bucket_interface.cpp
+++ b/src/datacell/bucket_interface.cpp
@@ -1,4 +1,3 @@
-
 // Copyright 2024-present the vsag project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,102 +14,32 @@
 
 #include "bucket_interface.h"
 
-#include <fmt/format.h>
-
-#include "bucket_datacell.h"
+#include "bucket_interface_factory.h"
 #include "inner_string_params.h"
-#include "io/io_headers.h"
-#include "quantization/quantizer_headers.h"
 
 namespace vsag {
-template <typename QuantTemp, typename IOTemp>
-static BucketInterfacePtr
-make_instance(const BucketDataCellParamPtr& param, const IndexCommonParam& common_param) {
-    auto& io_param = param->io_parameter;
-    auto& quantizer_param = param->quantizer_parameter;
-
-    return std::make_shared<BucketDataCell<QuantTemp, IOTemp>>(
-        quantizer_param,
-        io_param,
-        common_param,
-        static_cast<BucketIdType>(param->buckets_count),
-        param->use_residual_);
-}
-
-template <MetricType metric, typename IOTemp>
-static BucketInterfacePtr
-make_instance(const BucketDataCellParamPtr& param, const IndexCommonParam& common_param) {
-    std::string quantization_string = param->quantizer_parameter->GetTypeName();
-    if (quantization_string == QUANTIZATION_TYPE_VALUE_SQ8) {
-        return make_instance<SQ8Quantizer<metric>, IOTemp>(param, common_param);
-    }
-    if (quantization_string == QUANTIZATION_TYPE_VALUE_FP32) {
-        return make_instance<FP32Quantizer<metric>, IOTemp>(param, common_param);
-    }
-    if (quantization_string == QUANTIZATION_TYPE_VALUE_SQ4) {
-        return make_instance<SQ4Quantizer<metric>, IOTemp>(param, common_param);
-    }
-    if (quantization_string == QUANTIZATION_TYPE_VALUE_SQ4_UNIFORM) {
-        return make_instance<SQ4UniformQuantizer<metric>, IOTemp>(param, common_param);
-    }
-    if (quantization_string == QUANTIZATION_TYPE_VALUE_SQ8_UNIFORM) {
-        return make_instance<SQ8UniformQuantizer<metric>, IOTemp>(param, common_param);
-    }
-    if (quantization_string == QUANTIZATION_TYPE_VALUE_PQ) {
-        return make_instance<ProductQuantizer<metric>, IOTemp>(param, common_param);
-    }
-    if (quantization_string == QUANTIZATION_TYPE_VALUE_PQFS) {
-        return make_instance<PQFastScanQuantizer<metric>, IOTemp>(param, common_param);
-    }
-    if (quantization_string == QUANTIZATION_TYPE_VALUE_BF16) {
-        return make_instance<BF16Quantizer<metric>, IOTemp>(param, common_param);
-    }
-    if (quantization_string == QUANTIZATION_TYPE_VALUE_FP16) {
-        return make_instance<FP16Quantizer<metric>, IOTemp>(param, common_param);
-    }
-    if (quantization_string == QUANTIZATION_TYPE_VALUE_RABITQ) {
-        return make_instance<RaBitQuantizer<metric>, IOTemp>(param, common_param);
-    }
-    return nullptr;
-}
-
-template <typename IOTemp>
-static BucketInterfacePtr
-make_instance(const BucketDataCellParamPtr& param, const IndexCommonParam& common_param) {
-    auto metric = common_param.metric_;
-    if (metric == MetricType::METRIC_TYPE_L2SQR) {
-        return make_instance<MetricType::METRIC_TYPE_L2SQR, IOTemp>(param, common_param);
-    }
-    if (metric == MetricType::METRIC_TYPE_IP) {
-        return make_instance<MetricType::METRIC_TYPE_IP, IOTemp>(param, common_param);
-    }
-    if (metric == MetricType::METRIC_TYPE_COSINE) {
-        if (param->use_residual_) {
-            return make_instance<MetricType::METRIC_TYPE_IP, IOTemp>(param, common_param);
-        }
-        return make_instance<MetricType::METRIC_TYPE_COSINE, IOTemp>(param, common_param);
-    }
-    return nullptr;
-}
 
 BucketInterfacePtr
 BucketInterface::MakeInstance(const BucketDataCellParamPtr& param,
                               const IndexCommonParam& common_param) {
+    if (!param || !param->io_parameter || !param->quantizer_parameter) {
+        return nullptr;
+    }
     auto io_type_name = param->io_parameter->GetTypeName();
     if (io_type_name == IO_TYPE_VALUE_BLOCK_MEMORY_IO) {
-        return make_instance<MemoryBlockIO>(param, common_param);
+        return MakeMemoryBlockBucketDataCell(param, common_param);
     }
     if (io_type_name == IO_TYPE_VALUE_MEMORY_IO) {
-        return make_instance<MemoryIO>(param, common_param);
+        return MakeMemoryBucketDataCell(param, common_param);
     }
     if (io_type_name == IO_TYPE_VALUE_MMAP_IO) {
-        return make_instance<NonContinuousIO<MMapIO>>(param, common_param);
+        return MakeMMapBucketDataCell(param, common_param);
     }
     if (io_type_name == IO_TYPE_VALUE_ASYNC_IO) {
-        return make_instance<NonContinuousIO<AsyncIO>>(param, common_param);
+        return MakeAsyncBucketDataCell(param, common_param);
     }
     if (io_type_name == IO_TYPE_VALUE_BUFFER_IO) {
-        return make_instance<NonContinuousIO<BufferIO>>(param, common_param);
+        return MakeBufferBucketDataCell(param, common_param);
     }
     return nullptr;
 }

--- a/src/datacell/bucket_interface_async_io.cpp
+++ b/src/datacell/bucket_interface_async_io.cpp
@@ -1,0 +1,27 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "bucket_interface_factory.h"
+#include "bucket_interface_factory_impl.h"
+#include "io/async_io/async_io.h"
+#include "io/noncontinuous_io/noncontinuous_io.h"
+
+namespace vsag {
+
+BucketInterfacePtr
+MakeAsyncBucketDataCell(const BucketDataCellParamPtr& param, const IndexCommonParam& common_param) {
+    return MakeBucketDataCellInstance<NonContinuousIO<AsyncIO>>(param, common_param);
+}
+
+}  // namespace vsag

--- a/src/datacell/bucket_interface_buffer_io.cpp
+++ b/src/datacell/bucket_interface_buffer_io.cpp
@@ -1,0 +1,28 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "bucket_interface_factory.h"
+#include "bucket_interface_factory_impl.h"
+#include "io/buffer_io/buffer_io.h"
+#include "io/noncontinuous_io/noncontinuous_io.h"
+
+namespace vsag {
+
+BucketInterfacePtr
+MakeBufferBucketDataCell(const BucketDataCellParamPtr& param,
+                         const IndexCommonParam& common_param) {
+    return MakeBucketDataCellInstance<NonContinuousIO<BufferIO>>(param, common_param);
+}
+
+}  // namespace vsag

--- a/src/datacell/bucket_interface_factory.h
+++ b/src/datacell/bucket_interface_factory.h
@@ -1,0 +1,37 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "bucket_interface.h"
+
+namespace vsag {
+
+BucketInterfacePtr
+MakeMemoryBlockBucketDataCell(const BucketDataCellParamPtr& param,
+                              const IndexCommonParam& common_param);
+
+BucketInterfacePtr
+MakeMemoryBucketDataCell(const BucketDataCellParamPtr& param, const IndexCommonParam& common_param);
+
+BucketInterfacePtr
+MakeMMapBucketDataCell(const BucketDataCellParamPtr& param, const IndexCommonParam& common_param);
+
+BucketInterfacePtr
+MakeAsyncBucketDataCell(const BucketDataCellParamPtr& param, const IndexCommonParam& common_param);
+
+BucketInterfacePtr
+MakeBufferBucketDataCell(const BucketDataCellParamPtr& param, const IndexCommonParam& common_param);
+
+}  // namespace vsag

--- a/src/datacell/bucket_interface_factory_impl.h
+++ b/src/datacell/bucket_interface_factory_impl.h
@@ -1,0 +1,103 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "bucket_datacell.h"
+#include "inner_string_params.h"
+#include "quantization/fp32_quantizer.h"
+#include "quantization/product_quantization/pq_fastscan_quantizer.h"
+#include "quantization/product_quantization/product_quantizer.h"
+#include "quantization/rabitq_quantization/rabitq_quantizer.h"
+#include "quantization/scalar_quantization/sq_headers.h"
+
+namespace vsag {
+
+template <typename QuantTemp, typename IOTemp>
+BucketInterfacePtr
+MakeBucketDataCellInstance(const BucketDataCellParamPtr& param,
+                           const IndexCommonParam& common_param) {
+    auto& io_param = param->io_parameter;
+    auto& quantizer_param = param->quantizer_parameter;
+
+    return std::make_shared<BucketDataCell<QuantTemp, IOTemp>>(
+        quantizer_param,
+        io_param,
+        common_param,
+        static_cast<BucketIdType>(param->buckets_count),
+        param->use_residual_);
+}
+
+template <MetricType metric, typename IOTemp>
+BucketInterfacePtr
+MakeBucketDataCellInstance(const BucketDataCellParamPtr& param,
+                           const IndexCommonParam& common_param) {
+    std::string quantization_string = param->quantizer_parameter->GetTypeName();
+    if (quantization_string == QUANTIZATION_TYPE_VALUE_SQ8) {
+        return MakeBucketDataCellInstance<SQ8Quantizer<metric>, IOTemp>(param, common_param);
+    }
+    if (quantization_string == QUANTIZATION_TYPE_VALUE_FP32) {
+        return MakeBucketDataCellInstance<FP32Quantizer<metric>, IOTemp>(param, common_param);
+    }
+    if (quantization_string == QUANTIZATION_TYPE_VALUE_SQ4) {
+        return MakeBucketDataCellInstance<SQ4Quantizer<metric>, IOTemp>(param, common_param);
+    }
+    if (quantization_string == QUANTIZATION_TYPE_VALUE_SQ4_UNIFORM) {
+        return MakeBucketDataCellInstance<SQ4UniformQuantizer<metric>, IOTemp>(param, common_param);
+    }
+    if (quantization_string == QUANTIZATION_TYPE_VALUE_SQ8_UNIFORM) {
+        return MakeBucketDataCellInstance<SQ8UniformQuantizer<metric>, IOTemp>(param, common_param);
+    }
+    if (quantization_string == QUANTIZATION_TYPE_VALUE_PQ) {
+        return MakeBucketDataCellInstance<ProductQuantizer<metric>, IOTemp>(param, common_param);
+    }
+    if (quantization_string == QUANTIZATION_TYPE_VALUE_PQFS) {
+        return MakeBucketDataCellInstance<PQFastScanQuantizer<metric>, IOTemp>(param, common_param);
+    }
+    if (quantization_string == QUANTIZATION_TYPE_VALUE_BF16) {
+        return MakeBucketDataCellInstance<BF16Quantizer<metric>, IOTemp>(param, common_param);
+    }
+    if (quantization_string == QUANTIZATION_TYPE_VALUE_FP16) {
+        return MakeBucketDataCellInstance<FP16Quantizer<metric>, IOTemp>(param, common_param);
+    }
+    if (quantization_string == QUANTIZATION_TYPE_VALUE_RABITQ) {
+        return MakeBucketDataCellInstance<RaBitQuantizer<metric>, IOTemp>(param, common_param);
+    }
+    return nullptr;
+}
+
+template <typename IOTemp>
+BucketInterfacePtr
+MakeBucketDataCellInstance(const BucketDataCellParamPtr& param,
+                           const IndexCommonParam& common_param) {
+    auto metric = common_param.metric_;
+    if (metric == MetricType::METRIC_TYPE_L2SQR) {
+        return MakeBucketDataCellInstance<MetricType::METRIC_TYPE_L2SQR, IOTemp>(param,
+                                                                                 common_param);
+    }
+    if (metric == MetricType::METRIC_TYPE_IP) {
+        return MakeBucketDataCellInstance<MetricType::METRIC_TYPE_IP, IOTemp>(param, common_param);
+    }
+    if (metric == MetricType::METRIC_TYPE_COSINE) {
+        if (param->use_residual_) {
+            return MakeBucketDataCellInstance<MetricType::METRIC_TYPE_IP, IOTemp>(param,
+                                                                                  common_param);
+        }
+        return MakeBucketDataCellInstance<MetricType::METRIC_TYPE_COSINE, IOTemp>(param,
+                                                                                  common_param);
+    }
+    return nullptr;
+}
+
+}  // namespace vsag

--- a/src/datacell/bucket_interface_memory_block_io.cpp
+++ b/src/datacell/bucket_interface_memory_block_io.cpp
@@ -1,0 +1,27 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "bucket_interface_factory.h"
+#include "bucket_interface_factory_impl.h"
+#include "io/memory_block_io/memory_block_io.h"
+
+namespace vsag {
+
+BucketInterfacePtr
+MakeMemoryBlockBucketDataCell(const BucketDataCellParamPtr& param,
+                              const IndexCommonParam& common_param) {
+    return MakeBucketDataCellInstance<MemoryBlockIO>(param, common_param);
+}
+
+}  // namespace vsag

--- a/src/datacell/bucket_interface_memory_io.cpp
+++ b/src/datacell/bucket_interface_memory_io.cpp
@@ -1,0 +1,27 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "bucket_interface_factory.h"
+#include "bucket_interface_factory_impl.h"
+#include "io/memory_io/memory_io.h"
+
+namespace vsag {
+
+BucketInterfacePtr
+MakeMemoryBucketDataCell(const BucketDataCellParamPtr& param,
+                         const IndexCommonParam& common_param) {
+    return MakeBucketDataCellInstance<MemoryIO>(param, common_param);
+}
+
+}  // namespace vsag

--- a/src/datacell/bucket_interface_mmap_io.cpp
+++ b/src/datacell/bucket_interface_mmap_io.cpp
@@ -1,0 +1,27 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "bucket_interface_factory.h"
+#include "bucket_interface_factory_impl.h"
+#include "io/mmap_io/mmap_io.h"
+#include "io/noncontinuous_io/noncontinuous_io.h"
+
+namespace vsag {
+
+BucketInterfacePtr
+MakeMMapBucketDataCell(const BucketDataCellParamPtr& param, const IndexCommonParam& common_param) {
+    return MakeBucketDataCellInstance<NonContinuousIO<MMapIO>>(param, common_param);
+}
+
+}  // namespace vsag


### PR DESCRIPTION
## What changed

- Split the heavy bucket interface factory translation unit into IO-specific implementation files.
- Kept `BucketInterface::MakeInstance` as the lightweight IO type dispatcher.
- Moved the shared quantizer/metric factory templates into an internal helper header.

## Why

`bucket_interface.cpp` instantiated every IO x metric x quantizer combination in one release translation unit, making that file a serial build bottleneck. Splitting by IO type lets Ninja compile those instantiations in parallel while preserving the same runtime factory behavior.

## Validation

- `clang-format-15 -i` on the changed C++ files.
- `git diff --check`.
- `cmake --build ./build-release/ --parallel 6`.
- Release compile timing with `CCACHE_DISABLE=1`: original single TU `120.346s`; split factory shards `30.1505s`.
