### PR TITLE
feat(ivf): abstract bucket searcher interface for extensibility

### DIFF
--- a/src/algorithm/ivf/CMakeLists.txt
+++ b/src/algorithm/ivf/CMakeLists.txt
@@ -18,6 +18,7 @@ set (IVF_SRCS
         ivf.cpp
         ivf_parameter.cpp
         ivf_partition_strategy.cpp
+        flat_bucket_searcher.cpp
         ivf_partition_strategy_parameter.cpp
         ivf_nearest_partition.cpp
         gno_imi_partition.cpp

--- a/src/algorithm/ivf/flat_bucket_searcher.cpp
+++ b/src/algorithm/ivf/flat_bucket_searcher.cpp
@@ -1,0 +1,122 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "flat_bucket_searcher.h"
+
+#include <limits>
+
+#include "attr/executor/executor.h"
+#include "impl/reasoning/search_reasoning.h"
+#include "impl/searcher/basic_searcher.h"
+
+namespace vsag {
+
+void
+FlatBucketSearcher::Search(BucketIdType bucket_id,
+                           const BucketInterfacePtr& bucket,
+                           const ComputerInterfacePtr& computer,
+                           const InnerSearchParam& param,
+                           int64_t thread_id,
+                           int64_t topk,
+                           BucketIdType buckets_per_data,
+                           DistHeapPtr& heap,
+                           Vector<float>& dist,
+                           ReasoningContext* reasoning_ctx) const {
+    auto bucket_size = bucket->GetBucketSize(bucket_id);
+    const auto* ids = bucket->GetInnerIds(bucket_id);
+    if (bucket_size > static_cast<int64_t>(dist.size())) {
+        dist.resize(bucket_size);
+    }
+
+    bucket->ScanBucketById(dist.data(), computer, bucket_id);
+
+    Filter* attr_ft = nullptr;
+    size_t tid = 0;
+    if (thread_id >= 0 and param.executors.size() > static_cast<uint64_t>(thread_id)) {
+        tid = static_cast<size_t>(thread_id);
+        if (param.executors[tid] != nullptr) {
+            param.executors[tid]->Clear();
+            attr_ft = param.executors[tid]->Run(bucket_id);
+        }
+    }
+
+    const auto& ft = param.is_inner_id_allowed;
+    const uint64_t topk_u = static_cast<uint64_t>(topk);
+    auto cur_heap_top = std::numeric_limits<float>::max();
+    if (not heap->Empty() and heap->Size() == topk_u) {
+        cur_heap_top = heap->Top().first;
+    }
+
+    if (param.search_mode == KNN_SEARCH) {
+        for (int64_t j = 0; j < bucket_size; ++j) {
+            auto origin_id = ids[j] / buckets_per_data;
+            if (reasoning_ctx != nullptr) {
+                reasoning_ctx->RecordVisit(origin_id, dist[j], 0);
+            }
+            if (attr_ft != nullptr and not attr_ft->CheckValid(j)) {
+                if (reasoning_ctx != nullptr) {
+                    reasoning_ctx->RecordFilterReject(origin_id);
+                }
+                continue;
+            }
+            if (ft == nullptr or ft->CheckValid(origin_id)) {
+                if (heap->Size() < topk_u or dist[j] < cur_heap_top) {
+                    heap->Push(dist[j], ids[j]);
+                }
+                while (heap->Size() > topk_u) {
+                    if (reasoning_ctx != nullptr) {
+                        reasoning_ctx->RecordEviction(heap->Top().second / buckets_per_data, 0);
+                    }
+                    heap->Pop();
+                }
+                if (not heap->Empty() and heap->Size() == topk_u) {
+                    cur_heap_top = heap->Top().first;
+                }
+            } else if (reasoning_ctx != nullptr) {
+                reasoning_ctx->RecordFilterReject(origin_id);
+            }
+        }
+    } else {  // RANGE_SEARCH
+        for (int64_t j = 0; j < bucket_size; ++j) {
+            auto origin_id = ids[j] / buckets_per_data;
+            if (reasoning_ctx != nullptr) {
+                reasoning_ctx->RecordVisit(origin_id, dist[j], 0);
+            }
+            if (attr_ft != nullptr and not attr_ft->CheckValid(j)) {
+                if (reasoning_ctx != nullptr) {
+                    reasoning_ctx->RecordFilterReject(origin_id);
+                }
+                continue;
+            }
+            if (ft == nullptr or ft->CheckValid(origin_id)) {
+                if (dist[j] <= param.radius + THRESHOLD_ERROR and dist[j] < cur_heap_top) {
+                    heap->Push(dist[j], ids[j]);
+                }
+                while (heap->Size() > topk_u) {
+                    if (reasoning_ctx != nullptr) {
+                        reasoning_ctx->RecordEviction(heap->Top().second / buckets_per_data, 0);
+                    }
+                    heap->Pop();
+                }
+                if (not heap->Empty() and heap->Size() == topk_u) {
+                    cur_heap_top = heap->Top().first;
+                }
+            } else if (reasoning_ctx != nullptr) {
+                reasoning_ctx->RecordFilterReject(origin_id);
+            }
+        }
+    }
+}
+
+}  // namespace vsag

--- a/src/algorithm/ivf/flat_bucket_searcher.h
+++ b/src/algorithm/ivf/flat_bucket_searcher.h
@@ -1,0 +1,36 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "ivf_bucket_searcher.h"
+
+namespace vsag {
+
+class FlatBucketSearcher : public IVFBucketSearcher {
+public:
+    void
+    Search(BucketIdType bucket_id,
+           const BucketInterfacePtr& bucket,
+           const ComputerInterfacePtr& computer,
+           const InnerSearchParam& param,
+           int64_t thread_id,
+           int64_t topk,
+           BucketIdType buckets_per_data,
+           DistHeapPtr& heap,
+           Vector<float>& dist,
+           ReasoningContext* reasoning_ctx) const override;
+};
+
+}  // namespace vsag

--- a/src/algorithm/ivf/ivf.cpp
+++ b/src/algorithm/ivf/ivf.cpp
@@ -23,6 +23,7 @@
 #include "attr/argparse.h"
 #include "attr/executor/executor.h"
 #include "datacell/flatten_interface.h"
+#include "flat_bucket_searcher.h"
 #include "gno_imi_partition.h"
 #include "impl/heap/standard_heap.h"
 #include "impl/inner_search_param.h"
@@ -335,7 +336,8 @@ IVF::CheckAndMappingExternalParam(const JsonType& external_param,
 IVF::IVF(const IVFParameterPtr& param, const IndexCommonParam& common_param)
     : InnerIndexInterface(param, common_param),
       buckets_per_data_(param->buckets_per_data),
-      location_map_(common_param.allocator_.get()) {
+      location_map_(common_param.allocator_.get()),
+      bucket_searcher_(std::make_shared<FlatBucketSearcher>()) {
     this->bucket_ = BucketInterface::MakeInstance(param->bucket_param, common_param);
     if (this->bucket_ == nullptr) {
         throw VsagException(ErrorType::INTERNAL_ERROR, "bucket init error");
@@ -1035,7 +1037,6 @@ IVF::search(const DatasetPtr& query,
     }
     auto computer = bucket_->FactoryComputer(query_data);
 
-    auto cur_heap_top = std::numeric_limits<float>::max();
     int64_t topk = param.topk;
     if constexpr (mode == RANGE_SEARCH) {
         topk = param.range_search_limit_size;
@@ -1054,7 +1055,6 @@ IVF::search(const DatasetPtr& query,
     }
 
     DistHeapPtr search_result = nullptr;
-    const auto& ft = param.is_inner_id_allowed;
 
     auto bucket_count = candidate_buckets.size();
     auto search_thread_count = param.parallel_search_thread_count;
@@ -1066,7 +1066,6 @@ IVF::search(const DatasetPtr& query,
     auto search_func = [&](int64_t thread_id) -> void {
         heaps[thread_id] = DistanceHeap::MakeInstanceBySize<true, false>(this->allocator_, topk);
         auto& heap = heaps[thread_id];
-        Vector<float> centroid(dim_, allocator_);
         Vector<float> dist(allocator_);
         uint64_t i = cur_bucket_num.fetch_add(1);
         for (; i < bucket_count; i = cur_bucket_num.fetch_add(1)) {
@@ -1079,53 +1078,16 @@ IVF::search(const DatasetPtr& query,
             if (bucket_id == -1) {
                 break;
             }
-            auto bucket_size = bucket_->GetBucketSize(bucket_id);
-            const auto* ids = bucket_->GetInnerIds(bucket_id);
-            if (bucket_size > dist.size()) {
-                dist.resize(bucket_size);
-            }
-
-            bucket_->ScanBucketById(dist.data(), computer, bucket_id);
-            Filter* attr_ft = nullptr;
-            if (param.executors.size() > thread_id and param.executors[thread_id] != nullptr) {
-                param.executors[thread_id]->Clear();
-                attr_ft = param.executors[thread_id]->Run(bucket_id);
-            }
-            for (int j = 0; j < bucket_size; ++j) {
-                auto origin_id = ids[j] / buckets_per_data_;
-                if (reasoning_ctx != nullptr) {
-                    reasoning_ctx->RecordVisit(origin_id, dist[j], 0);
-                }
-                if (attr_ft != nullptr and not attr_ft->CheckValid(j)) {
-                    if (reasoning_ctx != nullptr) {
-                        reasoning_ctx->RecordFilterReject(origin_id);
-                    }
-                    continue;
-                }
-                if (ft == nullptr or ft->CheckValid(origin_id)) {
-                    if constexpr (mode == KNN_SEARCH) {
-                        if (heap->Size() < topk or dist[j] < cur_heap_top) {
-                            heap->Push(dist[j], ids[j]);
-                        }
-                    } else if constexpr (mode == RANGE_SEARCH) {
-                        if (dist[j] <= param.radius + THRESHOLD_ERROR and dist[j] < cur_heap_top) {
-                            heap->Push(dist[j], ids[j]);
-                        }
-                    }
-                    if (heap->Size() > topk) {
-                        if (reasoning_ctx != nullptr) {
-                            reasoning_ctx->RecordEviction(heap->Top().second / buckets_per_data_,
-                                                          0);
-                        }
-                        heap->Pop();
-                    }
-                    if (not heap->Empty() and heap->Size() == topk) {
-                        cur_heap_top = heap->Top().first;
-                    }
-                } else if (reasoning_ctx != nullptr) {
-                    reasoning_ctx->RecordFilterReject(origin_id);
-                }
-            }
+            bucket_searcher_->Search(bucket_id,
+                                     bucket_,
+                                     computer,
+                                     param,
+                                     thread_id,
+                                     topk,
+                                     buckets_per_data_,
+                                     heap,
+                                     dist,
+                                     reasoning_ctx);
         }
     };
     std::vector<std::future<void>> futures;

--- a/src/algorithm/ivf/ivf.h
+++ b/src/algorithm/ivf/ivf.h
@@ -23,6 +23,7 @@
 #include "impl/reorder/reorder.h"
 #include "impl/searcher/basic_searcher.h"
 #include "index_common_param.h"
+#include "ivf_bucket_searcher.h"
 #include "ivf_parameter.h"
 #include "ivf_partition_strategy.h"
 #include "query_context.h"
@@ -249,6 +250,7 @@ private:
 
 private:
     BucketInterfacePtr bucket_{nullptr};  // bucket storage (raw or attribute-aware)
+    IVFBucketSearcherPtr bucket_searcher_{nullptr};
 
     IVFPartitionStrategyPtr partition_strategy_{nullptr};  // centroid / partition logic
     BucketIdType buckets_per_data_;                        // buckets each vector is assigned to

--- a/src/algorithm/ivf/ivf_bucket_searcher.h
+++ b/src/algorithm/ivf/ivf_bucket_searcher.h
@@ -1,0 +1,54 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+
+#include "container_types.h"
+#include "datacell/bucket_interface.h"
+#include "impl/heap/distance_heap.h"
+#include "impl/inner_search_param.h"
+#include "typing.h"
+
+namespace vsag {
+
+class ReasoningContext;
+class ComputerInterface;
+using ComputerInterfacePtr = std::shared_ptr<ComputerInterface>;
+
+class IVFBucketSearcher {
+public:
+    virtual ~IVFBucketSearcher() = default;
+
+    /// Search a single bucket for candidate vectors.
+    /// Implementations must be thread-safe and must not mutate shared state
+    /// unless synchronized. The heap and dist parameters are per-thread scratch.
+    virtual void
+    Search(BucketIdType bucket_id,
+           const BucketInterfacePtr& bucket,
+           const ComputerInterfacePtr& computer,
+           const InnerSearchParam& param,
+           int64_t thread_id,
+           int64_t topk,
+           BucketIdType buckets_per_data,
+           DistHeapPtr& heap,
+           Vector<float>& dist,
+           ReasoningContext* reasoning_ctx) const = 0;
+};
+
+using IVFBucketSearcherPtr = std::shared_ptr<IVFBucketSearcher>;
+
+}  // namespace vsag


### PR DESCRIPTION
## Summary

Extract per-bucket search logic from `IVF::search()` into a new `IVFBucketSearcher` abstract interface with `FlatBucketSearcher` as the default implementation. This preserves the exact original flat scan behavior while enabling future alternative bucket-level search strategies (e.g. quantized scanners) without modifying the IVF core.

## Changes

- **Add `IVFBucketSearcher` interface** (`ivf_bucket_searcher.h`): abstract interface with virtual `Search()` method
- **Implement `FlatBucketSearcher`** (`flat_bucket_searcher.h/cpp`): replicates the original per-bucket scan logic
- **Refactor `IVF::search()`**: replace inline per-bucket code with single `bucket_searcher_->Search()` call
- **Update CMakeLists.txt**: add `flat_bucket_searcher.cpp` to IVF sources

## Design Decisions

- Used runtime `param.search_mode` instead of template parameter for KNN/RANGE branching (virtual methods cannot be templated)
- No new parameters or serialization changes — pure abstraction, flat behavior preserved
- `FlatBucketSearcher` is the default, created in IVF constructor

## Impact

No behavior change for existing users.

Closes #2463
