### PR TITLE
fix: restore filter->CheckValid() in visit condition to fix recall drop

### DIFF
--- a/src/impl/searcher/basic_searcher.cpp
+++ b/src/impl/searcher/basic_searcher.cpp
@@ -56,11 +56,8 @@ BasicSearcher::visit(const GraphInterfacePtr& graph,
         }
         if (not vl->Get(neighbors[i])) {
             vl->Set(neighbors[i]);
-            // Removed filter->CheckValid() to eliminate duplicate filter checking.
-            // Filter is applied at result-collection stage.
-            // ShouldVisit() probabilistically gates traversal to preserve graph connectivity.
             if (not filter || count_no_visited == 0 || skip_strategy == nullptr ||
-                skip_strategy->ShouldVisit()) {
+                skip_strategy->ShouldVisit() || filter->CheckValid(neighbors[i])) {
                 to_be_visited_id[count_no_visited] = neighbors[i];
                 count_no_visited++;
             }

--- a/src/impl/searcher/parallel_searcher.cpp
+++ b/src/impl/searcher/parallel_searcher.cpp
@@ -66,11 +66,8 @@ ParallelSearcher::visit(const GraphInterfacePtr& graph,
             }
             if (not vl->Get(neighbors[i][j])) {
                 vl->Set(neighbors[i][j]);
-                // Removed filter->CheckValid() to eliminate duplicate filter checking.
-                // Filter is applied at result-collection stage.
-                // ShouldVisit() probabilistically gates traversal to preserve graph connectivity.
                 if (not filter || count_no_visited == 0 || skip_strategy == nullptr ||
-                    skip_strategy->ShouldVisit()) {
+                    skip_strategy->ShouldVisit() || filter->CheckValid(neighbors[i][j])) {
                     to_be_visited_id[count_no_visited] = neighbors[i][j];
                     count_no_visited++;
                 }


### PR DESCRIPTION
## Problem

PR #2314 removed filter->CheckValid() from the visit condition in basic_searcher.cpp and parallel_searcher.cpp, replacing the OR condition with a single probability gate (ShouldVisit()). This caused valid neighbors to be skipped when visit_ratio < 1.0, leading to recall degradation in high-filter scenarios.

## Root Cause

Old code: filter->CheckValid() as OR clause → valid neighbors visited 100%
New code: Only ShouldVisit() → valid neighbors visited at visit_ratio probability (e.g., 0.65 when valid_ratio=0.3)

## Fix

Restore filter->CheckValid(neighbors[i]) as an OR clause in the visit condition:

    if (not filter || count_no_visited == 0 || skip_strategy == nullptr ||
        skip_strategy->ShouldVisit() || filter->CheckValid(neighbors[i])) {

This ensures:
- All filter-valid neighbors are 100% visited (restored OR semantics)
- ShouldVisit() additionally visits some invalid neighbors for connectivity

## Related

- Fixes #2313
- Reverts the problematic part of #2314