### PR TITLE
fix(pyramid): promote flat nodes at size threshold

### DIFF
--- a/src/algorithm/pyramid/pyramid.cpp
+++ b/src/algorithm/pyramid/pyramid.cpp
@@ -196,7 +196,12 @@ IndexNode::Search(const SearchFunc& search_func,
                   const VisitedListPtr& vl,
                   const DistHeapPtr& search_result,
                   uint64_t ef_search) const {
-    if (status_ != IndexNode::Status::NO_INDEX) {
+    bool has_index = false;
+    {
+        std::shared_lock lock(mutex_);
+        has_index = status_ != IndexNode::Status::NO_INDEX;
+    }
+    if (has_index) {
         auto self_search_result = search_func(this, vl);
         search_result->Merge(*self_search_result);
         while (search_result->Size() > ef_search) {
@@ -1042,6 +1047,33 @@ Pyramid::add_one_point(const Hierarchy& h,
 
     if (node->status_ == IndexNode::Status::FLAT) {
         node->ids_.push_back(inner_id);
+        if (node->ids_.size() < node->index_min_size_) {
+            return;
+        }
+
+        // Keep the FLAT node intact until the replacement graph is complete.
+        IndexNode graph_node(allocator_, node->graph_param_, node->index_min_size_);
+        graph_node.level_ = node->level_;
+        graph_node.ids_ = node->ids_;
+        graph_node.Init();
+
+        auto codes = use_reorder_ ? precise_codes_ : base_codes_;
+        Vector<float> decoded_vector(dim_, allocator_);
+        for (const auto id : node->ids_) {
+            bool need_release = false;
+            const auto* buffer = codes->GetCodesById(id, need_release);
+            codes->Decode(buffer, decoded_vector.data());
+            if (need_release) {
+                codes->Release(buffer);
+            }
+            add_one_point(h, &graph_node, id, decoded_vector.data());
+        }
+
+        node->graph_ = std::move(graph_node.graph_);
+        node->graph_param_ = std::move(graph_node.graph_param_);
+        node->entry_point_ = graph_node.entry_point_;
+        node->status_ = IndexNode::Status::GRAPH;
+        Vector<InnerIdType>(allocator_).swap(node->ids_);
         return;
     }
 

--- a/src/algorithm/pyramid/pyramid.h
+++ b/src/algorithm/pyramid/pyramid.h
@@ -92,6 +92,7 @@ public:
     void
     Deserialize(StreamReader& reader);
 
+    friend class Pyramid;
     friend class PyramidAnalyzer;
 
 public:

--- a/src/algorithm/pyramid/pyramid_test.cpp
+++ b/src/algorithm/pyramid/pyramid_test.cpp
@@ -15,7 +15,65 @@
 
 #include "pyramid.h"
 
+#include <vector>
+
+#include "impl/allocator/safe_allocator.h"
+#include "index_common_param.h"
 #include "unittest.h"
+
+namespace {
+
+constexpr int64_t PYRAMID_TEST_DIM = 4;
+
+struct PyramidTestIndex {
+    std::shared_ptr<vsag::Allocator> allocator;
+    std::shared_ptr<vsag::Pyramid> index;
+};
+
+PyramidTestIndex
+MakePyramidIndex(uint32_t index_min_size) {
+    PyramidTestIndex result;
+    vsag::IndexCommonParam common_param;
+    common_param.dim_ = PYRAMID_TEST_DIM;
+    common_param.data_type_ = vsag::DataTypes::DATA_TYPE_FLOAT;
+    common_param.metric_ = vsag::MetricType::METRIC_TYPE_L2SQR;
+    result.allocator = vsag::SafeAllocator::FactoryDefaultAllocator();
+    common_param.allocator_ = result.allocator;
+
+    auto external_param = vsag::JsonType::Parse(R"({
+        "base_quantization_type": "fp32",
+        "base_io_type": "memory_io",
+        "max_degree": 8,
+        "ef_construction": 8,
+        "alpha": 1.2,
+        "graph_type": "nsw",
+        "no_build_levels": [0],
+        "index_min_size": 3
+    })");
+    external_param[vsag::PYRAMID_INDEX_MIN_SIZE].SetInt(index_min_size);
+    auto param = vsag::Pyramid::CheckAndMappingExternalParam(external_param, common_param);
+    result.index = std::make_shared<vsag::Pyramid>(param, common_param);
+    return result;
+}
+
+vsag::DatasetPtr
+MakePyramidDataset(float* vectors, int64_t* ids, std::string* paths, int64_t count) {
+    return vsag::Dataset::Make()
+        ->NumElements(count)
+        ->Dim(PYRAMID_TEST_DIM)
+        ->Ids(ids)
+        ->Float32Vectors(vectors)
+        ->Paths(paths)
+        ->Owner(false);
+}
+
+int64_t
+GetPyramidSubindexCount(const std::shared_ptr<vsag::Pyramid>& index, const char* status) {
+    auto stats = vsag::JsonType::Parse(index->GetStats());
+    return stats["subindex_quality"][status].GetInt();
+}
+
+}  // namespace
 
 TEST_CASE("Split function tests", "[ut][pyramid]") {
     SECTION("Empty input string") {
@@ -56,5 +114,46 @@ TEST_CASE("Split function tests", "[ut][pyramid]") {
     SECTION("Mixed delimiters and spaces") {
         auto result = vsag::split("  , hello,  world  ", ',');
         REQUIRE(result == std::vector<std::string>{"  ", " hello", "  world  "});
+    }
+}
+
+TEST_CASE("Pyramid promotes flat node at index minimum size", "[ut][pyramid]") {
+    auto test_index = MakePyramidIndex(3);
+    const auto& index = test_index.index;
+    std::vector<float> vectors = {
+        0.0F,
+        0.0F,
+        0.0F,
+        0.0F,
+        1.0F,
+        1.0F,
+        1.0F,
+        1.0F,
+        2.0F,
+        2.0F,
+        2.0F,
+        2.0F,
+    };
+    std::vector<int64_t> ids = {100, 101, 102};
+    std::vector<std::string> paths(3, "tenant");
+
+    REQUIRE(index->Add(MakePyramidDataset(vectors.data(), ids.data(), paths.data(), 2)).empty());
+    REQUIRE(GetPyramidSubindexCount(index, "flat_subindexes") == 1);
+    REQUIRE(GetPyramidSubindexCount(index, "graph_subindexes") == 0);
+
+    REQUIRE(index
+                ->Add(MakePyramidDataset(
+                    vectors.data() + 2 * PYRAMID_TEST_DIM, ids.data() + 2, paths.data() + 2, 1))
+                .empty());
+    REQUIRE(GetPyramidSubindexCount(index, "flat_subindexes") == 0);
+    REQUIRE(GetPyramidSubindexCount(index, "graph_subindexes") == 1);
+    REQUIRE(GetPyramidSubindexCount(index, "total_vectors_in_graph") == 3);
+
+    for (int64_t i = 0; i < 3; ++i) {
+        auto query =
+            MakePyramidDataset(vectors.data() + i * PYRAMID_TEST_DIM, nullptr, paths.data() + i, 1);
+        auto result =
+            index->KnnSearch(query, 1, R"({"pyramid":{"ef_search":10}})", vsag::FilterPtr{});
+        REQUIRE(result->GetIds()[0] == ids[i]);
     }
 }


### PR DESCRIPTION
## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement/Refactor
- [ ] Documentation
- [ ] CI/Build/Infra

## Linked Issue

- Fixes: #2450

## What Changed

- Promote a Pyramid node from FLAT to NSW synchronously when its vector count reaches `index_min_size` during `Add()`.
- Build the replacement graph from all buffered IDs before swapping it into the node, so a failed build leaves the FLAT node searchable.
- Synchronize the node status read used by concurrent Add/Search and add a threshold regression test that verifies all buffered vectors survive promotion.

## Test Evidence

- [ ] `make fmt`
- [ ] `make lint`
- [ ] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [x] Other (describe below)

Test details:

```text
Red: regression test observed flat_subindexes == 1 after reaching the threshold.

cmake --build build-release --target unittests functests --parallel 6
./build-release/tests/unittests '*Pyramid*' --reporter compact
  All tests passed (102 assertions in 6 test cases)
./build-release/tests/functests '[ft][pyramid]' --reporter compact
  All tests passed (114089 assertions in 40 test cases)

clang-format 15.0.7 --dry-run --Werror (changed files): passed
git diff --check: passed

After rebasing onto the latest upstream/main, both pyramid.cpp and
pyramid_test.cpp compiled successfully with the existing dependency cache.
A clean full build was also attempted, but AppleClang 21 stops in the
pre-existing src/impl/heap/memmove_heap.cpp -Wnontrivial-memcall error.
```

## Compatibility Impact

- API/ABI compatibility: none
- Behavior changes: incremental `Add()` now matches `Build()` by promoting a node at the configured threshold

## Performance and Concurrency Impact

- Performance impact: the threshold-crossing `Add()` synchronously pays the one-time graph construction cost; subsequent searches use NSW instead of a growing flat scan
- Concurrency/thread-safety impact: promotion is hidden behind the existing per-node exclusive lock, and status reads use a shared-lock snapshot

## Documentation Impact

- [x] No docs update needed
- [ ] Updated docs:
  - [ ] `README.md`
  - [ ] `DEVELOPMENT.md`
  - [ ] `CONTRIBUTING.md`
  - [ ] Other

## Risk and Rollback

- Risk level: low
- Rollback plan: revert the commit to restore the previous FLAT-only incremental behavior

## Checklist

- [x] I have linked the relevant issue
- [x] I have added/updated tests for the bug fix
- [x] I have considered API compatibility impact
- [x] I have updated docs if behavior/workflow changed
- [x] My commit messages follow project conventions
