### PR TITLE
fix(hgraph): tune from available fp32 codes

### DIFF
--- a/src/algorithm/hgraph/hgraph.cpp
+++ b/src/algorithm/hgraph/hgraph.cpp
@@ -136,6 +136,11 @@ HGraph::Tune(const std::string& parameters, bool disable_future_tuning) {
             FlattenInterface::MakeInstance(hgraph_parameter->precise_codes_param, common_param);
     }
 
+    const auto current_count = total_count_.load(std::memory_order_acquire);
+    auto covers_active_ids = [current_count](const FlattenInterfacePtr& codes) {
+        return codes != nullptr and codes->TotalCount() >= current_count;
+    };
+
     // Check which codes need to be rebuilt.
     bool is_tune_base_code = false;
     bool is_tune_precise_code = false;
@@ -144,19 +149,20 @@ HGraph::Tune(const std::string& parameters, bool disable_future_tuning) {
         is_tune_base_code = true;
     }
     if (need_precise_codes and
-        (high_precise_codes_ == nullptr or
+        (not covers_active_ids(high_precise_codes_) or
          high_precise_codes_->GetQuantizerName() != new_precise_code->GetQuantizerName())) {
         is_tune_precise_code = true;
     }
 
     FlattenInterfacePtr tune_source;
     if (is_tune_base_code or is_tune_precise_code) {
-        if (raw_vector_ != nullptr) {
+        if (covers_active_ids(raw_vector_)) {
             tune_source = raw_vector_;
-        } else if (high_precise_codes_ != nullptr and
+        } else if (covers_active_ids(high_precise_codes_) and
                    high_precise_codes_->GetQuantizerName() == QUANTIZATION_TYPE_VALUE_FP32) {
             tune_source = high_precise_codes_;
-        } else if (basic_flatten_codes_->GetQuantizerName() == QUANTIZATION_TYPE_VALUE_FP32) {
+        } else if (covers_active_ids(basic_flatten_codes_) and
+                   basic_flatten_codes_->GetQuantizerName() == QUANTIZATION_TYPE_VALUE_FP32) {
             tune_source = basic_flatten_codes_;
         } else {
             return false;

--- a/src/algorithm/hgraph/hgraph.cpp
+++ b/src/algorithm/hgraph/hgraph.cpp
@@ -101,8 +101,9 @@ HGraph::HGraph(const HGraphParameterPtr& hgraph_param, const vsag::IndexCommonPa
 
 bool
 HGraph::Tune(const std::string& parameters, bool disable_future_tuning) {
-    if (not this->index_feature_list_->CheckFeature(IndexFeature::SUPPORT_TUNE) or
-        not this->has_raw_vector_) {
+    std::scoped_lock lock(this->add_mutex_);
+    if (this->immutable_.load(std::memory_order_acquire) or
+        not this->index_feature_list_->CheckFeature(IndexFeature::SUPPORT_TUNE)) {
         return false;
     }
 
@@ -127,61 +128,66 @@ HGraph::Tune(const std::string& parameters, bool disable_future_tuning) {
     auto new_basic_code =
         FlattenInterface::MakeInstance(hgraph_parameter->base_codes_param, common_param);
     FlattenInterfacePtr new_precise_code;
-    bool new_reorder_by_base = inner_parameter->reorder_source == HGRAPH_REORDER_SOURCE_BASE;
-    if (inner_parameter->use_reorder && not new_reorder_by_base) {
+    const bool new_use_reorder = inner_parameter->use_reorder;
+    const bool new_reorder_by_base = inner_parameter->reorder_source == HGRAPH_REORDER_SOURCE_BASE;
+    const bool need_precise_codes = new_use_reorder and not new_reorder_by_base;
+    if (need_precise_codes) {
         new_precise_code =
             FlattenInterface::MakeInstance(hgraph_parameter->precise_codes_param, common_param);
     }
 
-    std::scoped_lock lock(this->add_mutex_);
-    if (this->immutable_.load(std::memory_order_acquire)) {
-        return false;
-    }
-
-    // check which code need to tune and update create_param_ptr_
+    // Check which codes need to be rebuilt.
     bool is_tune_base_code = false;
     bool is_tune_precise_code = false;
-    bool new_use_reorder = use_reorder_;
-    bool drop_precise_codes = false;
-    auto param = std::dynamic_pointer_cast<HGraphParameter>(create_param_ptr_);
+    const bool drop_precise_codes = not need_precise_codes;
     if (basic_flatten_codes_->GetQuantizerName() != new_basic_code->GetQuantizerName()) {
-        // [case 1] base_code is not same
         is_tune_base_code = true;
     }
-    if (has_precise_reorder() and inner_parameter->use_reorder and not new_reorder_by_base and
-        this->high_precise_codes_->GetQuantizerName() != new_precise_code->GetQuantizerName()) {
-        // [case 2] precise code is not same
-        is_tune_precise_code = true;
-    }
-    if (not inner_parameter->use_reorder or new_reorder_by_base) {
-        // [case 3] drop precise_code
-        new_use_reorder = inner_parameter->use_reorder;
-        drop_precise_codes = true;
-        param->precise_codes_param.reset();
-        is_tune_precise_code = false;
-    }
-    if (not new_use_reorder and inner_parameter->use_reorder and not new_reorder_by_base) {
-        // [case 4] assign new precise_code
-        new_use_reorder = true;
+    if (need_precise_codes and
+        (high_precise_codes_ == nullptr or
+         high_precise_codes_->GetQuantizerName() != new_precise_code->GetQuantizerName())) {
         is_tune_precise_code = true;
     }
 
-    // update create_param_ptr_
-    if (is_tune_base_code) {
-        param->base_codes_param = hgraph_parameter->base_codes_param;
+    FlattenInterfacePtr tune_source;
+    if (is_tune_base_code or is_tune_precise_code) {
+        if (raw_vector_ != nullptr) {
+            tune_source = raw_vector_;
+        } else if (high_precise_codes_ != nullptr and
+                   high_precise_codes_->GetQuantizerName() == QUANTIZATION_TYPE_VALUE_FP32) {
+            tune_source = high_precise_codes_;
+        } else if (basic_flatten_codes_->GetQuantizerName() == QUANTIZATION_TYPE_VALUE_FP32) {
+            tune_source = basic_flatten_codes_;
+        } else {
+            return false;
+        }
     }
-    if (is_tune_precise_code) {
-        param->precise_codes_param = hgraph_parameter->precise_codes_param;
-    }
-    param->use_reorder = new_use_reorder;
-    param->reorder_source = inner_parameter->reorder_source;
 
-    // export train data and train new_basic_code
+    auto decode_tune_source = [&](InnerIdType inner_id, float* data) {
+        bool need_release = false;
+        const auto* buffer = tune_source->GetCodesById(inner_id, need_release);
+        if (buffer == nullptr) {
+            throw VsagException(ErrorType::INTERNAL_ERROR,
+                                fmt::format("failed to get vector by inner id {}", inner_id));
+        }
+        try {
+            tune_source->Decode(buffer, data);
+        } catch (...) {
+            if (need_release) {
+                tune_source->Release(buffer);
+            }
+            throw;
+        }
+        if (need_release) {
+            tune_source->Release(buffer);
+        }
+    };
+
     auto train_count = std::min(this->train_sample_count_, this->GetNumElements());
     Vector<float> train_data(train_count * dim_, 0, allocator_);
     if (is_tune_base_code or is_tune_precise_code) {
         for (InnerIdType i = 0; i < train_count; i++) {
-            this->GetVectorByInnerId(i, (train_data.data() + i * dim_));
+            decode_tune_source(i, train_data.data() + i * dim_);
         }
     }
 
@@ -195,7 +201,7 @@ HGraph::Tune(const std::string& parameters, bool disable_future_tuning) {
 
             Vector<float> insert_buffer(dim_, 0, allocator_);
             for (int64_t i = 0; i < total_count_; ++i) {
-                GetVectorByInnerId(i, insert_buffer.data());
+                decode_tune_source(i, insert_buffer.data());
                 new_code->InsertVector(static_cast<const void*>(insert_buffer.data()), i);
             }
             return new_code;
@@ -209,15 +215,24 @@ HGraph::Tune(const std::string& parameters, bool disable_future_tuning) {
     // preventing concurrent searches from accessing partially updated state.
     {
         std::scoped_lock<std::shared_mutex> wlock(this->global_mutex_);
+        auto param = std::dynamic_pointer_cast<HGraphParameter>(create_param_ptr_);
         basic_flatten_codes_ = new_basic;
         if (drop_precise_codes) {
             high_precise_codes_.reset();
+            param->precise_codes_param.reset();
         } else {
             high_precise_codes_ = new_precise;
+            if (is_tune_precise_code) {
+                param->precise_codes_param = hgraph_parameter->precise_codes_param;
+            }
+        }
+        if (is_tune_base_code) {
+            param->base_codes_param = hgraph_parameter->base_codes_param;
         }
         use_reorder_ = new_use_reorder;
         reorder_by_base_ = new_reorder_by_base;
         param->use_reorder = new_use_reorder;
+        param->reorder_source = inner_parameter->reorder_source;
 
         check_and_init_raw_vector(param->raw_vector_param, common_param, false);
         init_resize_bit_and_reorder();

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -1373,6 +1373,44 @@ TEST_CASE("HGraph Tune uses available codes", "[ft][search][hgraph][tune_codes]"
         require_fp32_accuracy(index);
     }
 
+    SECTION("unloaded precise codes") {
+        auto parsed = vsag::JsonType::Parse(make_parameters("fp32,fp32"));
+        parsed[vsag::INDEX_PARAM]["ignore_reorder"].SetBool(true);
+        auto parameters = parsed.Dump();
+
+        auto index = TestIndex::TestFactory("hgraph", parameters, true);
+        TestIndex::TestBuildIndex(index, dataset, true);
+        auto binary_set = index->Serialize();
+        REQUIRE(binary_set.has_value());
+
+        auto reloaded = TestIndex::TestFactory("hgraph", parameters, true);
+        auto deserialize_result = reloaded->Deserialize(binary_set.value());
+        REQUIRE(deserialize_result.has_value());
+
+        auto tune_result = reloaded->Tune(make_parameters("fp32,fp32"), true);
+        REQUIRE(tune_result.has_value());
+        REQUIRE(tune_result.value());
+        require_fp32_accuracy(reloaded);
+    }
+
+    SECTION("force-removed codes still cover active ids") {
+        auto parsed = vsag::JsonType::Parse(make_parameters("fp32"));
+        parsed[vsag::INDEX_PARAM]["support_force_remove"].SetBool(true);
+        auto parameters = parsed.Dump();
+
+        auto index = TestIndex::TestFactory("hgraph", parameters, true);
+        TestIndex::TestBuildIndex(index, dataset, true);
+
+        auto remove_result =
+            index->Remove(dataset->base_->GetIds()[0], vsag::RemoveMode::FORCE_REMOVE);
+        REQUIRE(remove_result.has_value());
+        REQUIRE(remove_result.value() == 1);
+
+        auto tune_result = index->Tune(make_parameters("bf16"), true);
+        REQUIRE(tune_result.has_value());
+        REQUIRE(tune_result.value());
+    }
+
     SECTION("no usable codes") {
         auto index = make_index("sq8,bf16");
         auto result = index->Tune(make_parameters("bf16,bf16"));

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -1315,6 +1315,79 @@ TestHGraphTune(const fixtures::HGraphTestIndexPtr& test_index,
 
 HGRAPH_PR_DAILY_CASE("HGraph Tune", "[ft][search][hgraph]", TestHGraphTune)
 
+TEST_CASE("HGraph Tune uses available codes", "[ft][search][hgraph][tune_codes]") {
+    using namespace fixtures;
+
+    constexpr int64_t dim = 32;
+    constexpr int64_t base_count = 256;
+    auto dataset = HGraphTestIndex::pool.GetDatasetAndCreate(dim, base_count, "cosine");
+
+    auto make_parameters = [&](const std::string& quantization, bool store_raw = false) {
+        HGraphTestIndex::HGraphBuildParam build_param("cosine", dim, quantization);
+        build_param.thread_count = 1;
+        build_param.store_raw_vector = store_raw;
+        return HGraphTestIndex::GenerateHGraphBuildParametersString(build_param);
+    };
+    auto make_index = [&](const std::string& quantization, bool store_raw = false) {
+        auto index =
+            TestIndex::TestFactory("hgraph", make_parameters(quantization, store_raw), true);
+        TestIndex::TestBuildIndex(index, dataset, true);
+        return index;
+    };
+    auto require_fp32_accuracy = [&](const TestIndex::IndexPtr& index) {
+        constexpr float tolerance = 2e-6F;
+        const auto* queries = dataset->query_->GetFloat32Vectors();
+        const auto* gt_ids = dataset->ground_truth_->GetIds();
+        const auto* gt_distances = dataset->ground_truth_->GetDistances();
+        for (int64_t i = 0; i < dataset->query_->GetNumElements(); ++i) {
+            for (int64_t j = 0; j < dataset->top_k; ++j) {
+                auto pos = i * dataset->top_k + j;
+                auto result = index->CalcDistanceById(queries + i * dim, gt_ids[pos]);
+                REQUIRE(result.has_value());
+                REQUIRE(std::abs(result.value() - gt_distances[pos]) < tolerance);
+            }
+        }
+    };
+
+    SECTION("separate raw codes") {
+        auto index = make_index("sq8,bf16", true);
+        auto result = index->Tune(make_parameters("fp32"), true);
+        REQUIRE(result.has_value());
+        REQUIRE(result.value());
+        require_fp32_accuracy(index);
+    }
+
+    SECTION("precise fp32 codes") {
+        auto index = make_index("bf16,fp32");
+        auto result = index->Tune(make_parameters("fp32"), true);
+        REQUIRE(result.has_value());
+        REQUIRE(result.value());
+        require_fp32_accuracy(index);
+    }
+
+    SECTION("base fp32 codes") {
+        auto index = make_index("fp32,bf16");
+        auto result = index->Tune(make_parameters("fp32,fp32"), true);
+        REQUIRE(result.has_value());
+        REQUIRE(result.value());
+        require_fp32_accuracy(index);
+    }
+
+    SECTION("no usable codes") {
+        auto index = make_index("sq8,bf16");
+        auto result = index->Tune(make_parameters("bf16,bf16"));
+        REQUIRE(result.has_value());
+        REQUIRE_FALSE(result.value());
+    }
+
+    SECTION("no rebuild") {
+        auto index = make_index("sq8,bf16");
+        auto result = index->Tune(make_parameters("sq8"), true);
+        REQUIRE(result.has_value());
+        REQUIRE(result.value());
+    }
+}
+
 TEST_CASE("(PR) HGraph Tune with ignore_reorder", "[ft][search][hgraph][pr]") {
     using namespace fixtures;
     auto origin_size = vsag::Options::Instance().block_size_limit();


### PR DESCRIPTION
## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement/Refactor
- [ ] Documentation
- [ ] CI/Build/Infra

## Linked Issue

- Fixes: #2465

## What Changed

- Determine whether HGraph Tune can rebuild from the actual instantiated codes instead of the
  `store_raw_vector` configuration alone.
- Select the rebuild source in order: raw vectors, precise FP32 codes, then base FP32 codes.
- Require every selected source to cover the current internal ID range, so a precise-code object
  whose payload was omitted during `ignore_reorder` serialization cannot be selected.
- Allow no-rebuild transitions without a vector source, and publish code/parameter changes only
  after a successful rebuild.
- Serialize Tune state inspection with the existing add mutex and add regression coverage for
  source selection, unloaded precise codes, and ForceRemove followed by Tune.

## Test Evidence

- [ ] `make fmt`
- [ ] `make lint`
- [x] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [x] Other (describe below)

Test details:

```text
source ~/.zshrc && /opt/homebrew/opt/llvm@15/bin/clang-format --dry-run --Werror \
  src/algorithm/hgraph/hgraph.cpp tests/test_hgraph.cpp
git diff --check

source ~/.zshrc && make test CASE='[tune_codes]' COMPILE_JOBS=6
  All tests passed (8040 assertions in 1 test case)

source ~/.zshrc && make test CASE='"(PR) HGraph Tune"' COMPILE_JOBS=6
  All tests passed (331383 assertions in 1 test case)

source ~/.zshrc && make test CASE='"*Concurrent Tune*"' COMPILE_JOBS=6
  All tests passed (12 assertions in 3 test cases)

source ~/.zshrc && make test \
  CASE='"(PR) HGraph Tune with ignore_reorder"' COMPILE_JOBS=6
  All tests passed (8 assertions in 1 test case)

clang-tidy 15 could not complete because the Homebrew binary crashed while processing
/opt/homebrew/include/fmt/format.h in
bugprone-implicit-widening-of-multiplication-result.
```

## Compatibility Impact

- API/ABI compatibility: none
- Behavior changes: Tune now accepts an available FP32 precise or base code as its lossless
  rebuild source when raw vectors are absent.

## Performance and Concurrency Impact

- Performance impact: no search-path impact; Tune rebuild work is unchanged apart from source
  selection.
- Concurrency/thread-safety impact: concurrent Tune calls are serialized by the existing
  `add_mutex_` before reading or publishing code state.

## Documentation Impact

- [x] No docs update needed
- [ ] Updated docs:
  - [ ] `README.md`
  - [ ] `DEVELOPMENT.md`
  - [ ] `CONTRIBUTING.md`
  - [ ] Other

## Risk and Rollback

- Risk level: low
- Rollback plan: revert commits `28dea4c6` and `2a00dc71`.

## Checklist

- [x] I have linked the relevant issue (required for `kind/bug` and `kind/feature`; see "Linked Issue" above)
- [x] I have added/updated tests for new behavior or bug fixes
- [x] I have considered API compatibility impact
- [x] I have updated docs if behavior/workflow changed
- [x] My commit messages follow project conventions (Conventional Commits, optional `[skip ci]` prefix)
