### PR TITLE
perf(simq): batch rerank IO via MultiRead for async IO backend

### DIFF
--- a/src/algorithm/simq/simq.cpp
+++ b/src/algorithm/simq/simq.cpp
@@ -746,20 +746,34 @@ SIMQ::KnnSearch(const DatasetPtr& query,
     }
     uint64_t rerank_candidate_count = coarse_results.size();
 
-    // Exact MaxSim rerank via MultiVectorDataCell
+    // Exact MaxSim rerank via MultiVectorDataCell (batched for async IO)
     auto computer = mv_codes_->FactoryComputer(&query_mvs[0]);
     std::vector<std::pair<float, InnerIdType>> reranked;
     reranked.reserve(coarse_results.size());
     uint64_t filtered_candidate_count = 0;
+
+    // Collect all valid doc_ids first
+    std::vector<InnerIdType> batch_ids;
+    batch_ids.reserve(coarse_results.size());
     for (auto& [doc_id, _] : coarse_results) {
         if (filter != nullptr && !filter->CheckValid(this->label_table_->GetLabelById(doc_id))) {
             ++filtered_candidate_count;
             continue;
         }
-        float dist = 0.0F;
-        mv_codes_->Query(&dist, computer, &doc_id, 1);
-        ++stats.dist_cmp;
-        reranked.emplace_back(dist, doc_id);
+        batch_ids.push_back(doc_id);
+    }
+
+    // Single batched Query call (enables MultiRead in MultiVectorDataCell)
+    if (!batch_ids.empty()) {
+        std::vector<float> batch_dists(batch_ids.size());
+        mv_codes_->Query(batch_dists.data(),
+                         computer,
+                         batch_ids.data(),
+                         static_cast<InnerIdType>(batch_ids.size()));
+        stats.dist_cmp += batch_ids.size();
+        for (uint64_t i = 0; i < batch_ids.size(); i++) {
+            reranked.emplace_back(batch_dists[i], batch_ids[i]);
+        }
     }
     std::sort(reranked.begin(), reranked.end(), [](const auto& a, const auto& b) {
         return a.first < b.first;

--- a/src/datacell/multi_vector_datacell.inl
+++ b/src/datacell/multi_vector_datacell.inl
@@ -202,19 +202,50 @@ MultiVectorDataCell<QuantTmpl, IOTmpl>::Query(float* result_dists,
     auto* mv_computer = dynamic_cast<MultiVectorComputer*>(computer.get());
     CHECK_ARGUMENT(mv_computer != nullptr, "computer is not a MultiVectorComputer");
 
-    for (InnerIdType i = 0; i < id_count; ++i) {
-        bool need_release = false;
-        const uint8_t* codes = this->GetCodesById(idx[i], need_release);
-
-        uint32_t token_count = 0;
-        std::memcpy(&token_count, codes, sizeof(uint32_t));
-
-        mv_computer->ComputeDist(codes + sizeof(uint32_t), token_count, result_dists + i);
-
-        if (need_release) {
-            this->Release(codes);
-        }
+    if (id_count == 0) {
+        return;
     }
+
+    // Step 1: Read all offsets (offset_io_ is MemoryBlockIO, in-memory, fast)
+    std::vector<uint64_t> offsets(id_count);
+    for (InnerIdType i = 0; i < id_count; ++i) {
+        offset_io_->Read(sizeof(uint64_t),
+                         static_cast<uint64_t>(idx[i]) * sizeof(uint64_t),
+                         reinterpret_cast<uint8_t*>(&offsets[i]));
+    }
+
+    // Step 2: Batch read all token counts via MultiRead (async IO)
+    std::vector<uint32_t> lens(id_count);
+    std::vector<uint64_t> len_sizes(id_count, sizeof(uint32_t));
+    this->io_->MultiRead(reinterpret_cast<uint8_t*>(lens.data()),
+                         len_sizes.data(),
+                         offsets.data(),
+                         static_cast<uint64_t>(id_count));
+
+    // Step 3: Batch read all data via MultiRead (async IO)
+    std::vector<uint64_t> data_sizes(id_count);
+    uint64_t total_size = 0;
+    for (InnerIdType i = 0; i < id_count; ++i) {
+        data_sizes[i] = sizeof(uint32_t) +
+                        static_cast<uint64_t>(lens[i]) * multi_vector_dim_ * sizeof(float);
+        total_size += data_sizes[i];
+    }
+    auto* all_codes = static_cast<uint8_t*>(this->allocator_->Allocate(total_size));
+    this->io_->MultiRead(all_codes,
+                         data_sizes.data(),
+                         offsets.data(),
+                         static_cast<uint64_t>(id_count));
+
+    // Step 4: Compute MaxSim distances
+    uint64_t cursor = 0;
+    for (InnerIdType i = 0; i < id_count; ++i) {
+        uint32_t token_count = lens[i];
+        mv_computer->ComputeDist(
+            all_codes + cursor + sizeof(uint32_t), token_count, result_dists + i);
+        cursor += data_sizes[i];
+    }
+
+    this->allocator_->Deallocate(all_codes);
 }
 
 template <typename QuantTmpl, typename IOTmpl>


### PR DESCRIPTION
Replace per-document Query calls in SIMQ rerank loop with a single batched Query call. MultiVectorDataCell::Query now uses MultiRead to batch-read offsets, token counts, and token data in bulk instead of calling GetCodesById one at a time, reducing async IO round-trips.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement/Refactor
- [ ] Documentation
- [ ] CI/Build/Infra

## Linked Issue

<!--
REQUIRED for `kind/bug` and `kind/feature` PRs. Use a GitHub-recognized
auto-closing keyword so the linked issue is closed when this PR merges:

  Fixes: #<number>
  Closes: #<number>
  Resolves: #<number>

Cross-repo references (`owner/repo#<number>`) and full issue URLs are
also accepted. `kind/improvement` and `kind/documentation` PRs may leave
this blank (delete the line below or keep it empty).
-->

- Fixes: <!-- #<number> -->

## What Changed

- <!-- Briefly describe the key changes -->

## Test Evidence

- [ ] `make fmt`
- [ ] `make lint`
- [ ] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [ ] Other (describe below)

Test details:

```text
<!-- Paste commands and key output here -->
```

## Compatibility Impact

- API/ABI compatibility: <!-- none / describe -->
- Behavior changes: <!-- none / describe -->

## Performance and Concurrency Impact

- Performance impact: <!-- none / improved / regressed / unknown -->
- Concurrency/thread-safety impact: <!-- none / describe -->

## Documentation Impact

- [ ] No docs update needed
- [ ] Updated docs:
  - [ ] `README.md`
  - [ ] `DEVELOPMENT.md`
  - [ ] `CONTRIBUTING.md`
  - [ ] Other: <!-- path -->

## Risk and Rollback

- Risk level: <!-- low / medium / high -->
- Rollback plan: <!-- how to revert safely -->

## Checklist

- [ ] I have linked the relevant issue (required for `kind/bug` and `kind/feature`; see "Linked Issue" above)
- [ ] I have added/updated tests for new behavior or bug fixes
- [ ] I have considered API compatibility impact
- [ ] I have updated docs if behavior/workflow changed
- [ ] My commit messages follow project conventions (Conventional Commits, optional `[skip ci]` prefix)
