### PR TITLE
[Backport 0.18] fix(hgraph): tune from available fp32 codes

### DIFF
--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -531,8 +531,9 @@ HGraph::map_hgraph_param(const JsonType& hgraph_json) {
 
 bool
 HGraph::Tune(const std::string& parameters, bool disable_future_tuning) {
-    if (not this->index_feature_list_->CheckFeature(IndexFeature::SUPPORT_TUNE) or
-        not this->has_raw_vector_) {
+    std::scoped_lock lock(this->add_mutex_);
+    if (this->immutable_ or
+        not this->index_feature_list_->CheckFeature(IndexFeature::SUPPORT_TUNE)) {
         return false;
     }
 
@@ -557,56 +558,70 @@ HGraph::Tune(const std::string& parameters, bool disable_future_tuning) {
     auto new_basic_code =
         FlattenInterface::MakeInstance(hgraph_parameter->base_codes_param, common_param);
     FlattenInterfacePtr new_precise_code;
-    if (inner_parameter->use_reorder) {
+    const bool new_use_reorder = inner_parameter->use_reorder;
+    if (new_use_reorder) {
         new_precise_code =
             FlattenInterface::MakeInstance(hgraph_parameter->precise_codes_param, common_param);
     }
 
-    std::scoped_lock lock(this->add_mutex_);
+    const auto current_count = total_count_.load(std::memory_order_acquire);
+    auto covers_active_ids = [current_count](const FlattenInterfacePtr& codes) {
+        return codes != nullptr and codes->TotalCount() >= current_count;
+    };
 
-    // check which code need to tune and update create_param_ptr_
+    // Check which codes need to be rebuilt.
     bool is_tune_base_code = false;
     bool is_tune_precise_code = false;
-    bool new_use_reorder = use_reorder_;
-    bool drop_precise_codes = false;
-    auto param = std::dynamic_pointer_cast<HGraphParameter>(create_param_ptr_);
+    const bool drop_precise_codes = not new_use_reorder;
     if (basic_flatten_codes_->GetQuantizerName() != new_basic_code->GetQuantizerName()) {
-        // [case 1] base_code is not same
         is_tune_base_code = true;
     }
-    if (use_reorder_ and inner_parameter->use_reorder and
-        this->high_precise_codes_->GetQuantizerName() != new_precise_code->GetQuantizerName()) {
-        // [case 2] precise code is not same
-        is_tune_precise_code = true;
-    }
-    if (not inner_parameter->use_reorder) {
-        // [case 3] drop precise_code
-        new_use_reorder = false;
-        drop_precise_codes = true;
-        param->precise_codes_param.reset();
-        is_tune_precise_code = false;
-    }
-    if (not new_use_reorder and inner_parameter->use_reorder) {
-        // [case 4] assign new precise_code
-        new_use_reorder = true;
+    if (new_use_reorder and
+        (not covers_active_ids(high_precise_codes_) or
+         high_precise_codes_->GetQuantizerName() != new_precise_code->GetQuantizerName())) {
         is_tune_precise_code = true;
     }
 
-    // update create_param_ptr_
-    if (is_tune_base_code) {
-        param->base_codes_param = hgraph_parameter->base_codes_param;
+    FlattenInterfacePtr tune_source;
+    if (is_tune_base_code or is_tune_precise_code) {
+        if (covers_active_ids(raw_vector_)) {
+            tune_source = raw_vector_;
+        } else if (covers_active_ids(high_precise_codes_) and
+                   high_precise_codes_->GetQuantizerName() == QUANTIZATION_TYPE_VALUE_FP32) {
+            tune_source = high_precise_codes_;
+        } else if (covers_active_ids(basic_flatten_codes_) and
+                   basic_flatten_codes_->GetQuantizerName() == QUANTIZATION_TYPE_VALUE_FP32) {
+            tune_source = basic_flatten_codes_;
+        } else {
+            return false;
+        }
     }
-    if (is_tune_precise_code) {
-        param->precise_codes_param = hgraph_parameter->precise_codes_param;
-    }
-    param->use_reorder = new_use_reorder;
 
-    // export train data and train new_basic_code
+    auto decode_tune_source = [&](InnerIdType inner_id, float* data) {
+        bool need_release = false;
+        const auto* buffer = tune_source->GetCodesById(inner_id, need_release);
+        if (buffer == nullptr) {
+            throw VsagException(ErrorType::INTERNAL_ERROR,
+                                fmt::format("failed to get vector by inner id {}", inner_id));
+        }
+        try {
+            tune_source->Decode(buffer, data);
+        } catch (...) {
+            if (need_release) {
+                tune_source->Release(buffer);
+            }
+            throw;
+        }
+        if (need_release) {
+            tune_source->Release(buffer);
+        }
+    };
+
     auto train_count = std::min(this->train_sample_count_, this->GetNumElements());
     Vector<float> train_data(train_count * dim_, 0, allocator_);
     if (is_tune_base_code or is_tune_precise_code) {
         for (InnerIdType i = 0; i < train_count; i++) {
-            this->GetVectorByInnerId(i, (train_data.data() + i * dim_));
+            decode_tune_source(i, train_data.data() + i * dim_);
         }
     }
 
@@ -619,8 +634,8 @@ HGraph::Tune(const std::string& parameters, bool disable_future_tuning) {
             new_code->Train(train_data.data(), train_count);
 
             Vector<float> insert_buffer(dim_, 0, allocator_);
-            for (int64_t i = 0; i < total_count_; ++i) {
-                GetVectorByInnerId(i, insert_buffer.data());
+            for (int64_t i = 0; i < current_count; ++i) {
+                decode_tune_source(i, insert_buffer.data());
                 new_code->InsertVector(static_cast<const void*>(insert_buffer.data()), i);
             }
             return new_code;
@@ -634,11 +649,19 @@ HGraph::Tune(const std::string& parameters, bool disable_future_tuning) {
     // preventing concurrent searches from accessing partially updated state.
     {
         std::scoped_lock<std::shared_mutex> wlock(this->global_mutex_);
+        auto param = std::dynamic_pointer_cast<HGraphParameter>(create_param_ptr_);
         basic_flatten_codes_ = new_basic;
         if (drop_precise_codes) {
             high_precise_codes_.reset();
+            param->precise_codes_param.reset();
         } else {
             high_precise_codes_ = new_precise;
+            if (is_tune_precise_code) {
+                param->precise_codes_param = hgraph_parameter->precise_codes_param;
+            }
+        }
+        if (is_tune_base_code) {
+            param->base_codes_param = hgraph_parameter->base_codes_param;
         }
         use_reorder_ = new_use_reorder;
         param->use_reorder = new_use_reorder;

--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -532,8 +532,7 @@ HGraph::map_hgraph_param(const JsonType& hgraph_json) {
 bool
 HGraph::Tune(const std::string& parameters, bool disable_future_tuning) {
     std::scoped_lock lock(this->add_mutex_);
-    if (this->immutable_ or
-        not this->index_feature_list_->CheckFeature(IndexFeature::SUPPORT_TUNE)) {
+    if (not this->index_feature_list_->CheckFeature(IndexFeature::SUPPORT_TUNE)) {
         return false;
     }
 

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -997,6 +997,79 @@ TEST_CASE("(Daily) HGraph Tune", "[ft][hgraph][daily]") {
     TestHGraphTune(test_index, resource);
 }
 
+TEST_CASE("HGraph Tune uses available codes", "[ft][search][hgraph][tune_codes]") {
+    using namespace fixtures;
+
+    constexpr int64_t dim = 32;
+    constexpr int64_t base_count = 256;
+    auto dataset = HGraphTestIndex::pool.GetDatasetAndCreate(dim, base_count, "cosine");
+
+    auto make_parameters = [&](const std::string& quantization, bool store_raw = false) {
+        HGraphTestIndex::HGraphBuildParam build_param("cosine", dim, quantization);
+        build_param.thread_count = 1;
+        build_param.store_raw_vector = store_raw;
+        return HGraphTestIndex::GenerateHGraphBuildParametersString(build_param);
+    };
+    auto make_index = [&](const std::string& quantization, bool store_raw = false) {
+        auto index =
+            TestIndex::TestFactory("hgraph", make_parameters(quantization, store_raw), true);
+        TestIndex::TestBuildIndex(index, dataset, true);
+        return index;
+    };
+    auto require_fp32_accuracy = [&](const TestIndex::IndexPtr& index) {
+        constexpr float tolerance = 2e-6F;
+        const auto* queries = dataset->query_->GetFloat32Vectors();
+        const auto* gt_ids = dataset->ground_truth_->GetIds();
+        const auto* gt_distances = dataset->ground_truth_->GetDistances();
+        for (int64_t i = 0; i < dataset->query_->GetNumElements(); ++i) {
+            for (int64_t j = 0; j < dataset->top_k; ++j) {
+                auto pos = i * dataset->top_k + j;
+                auto result = index->CalcDistanceById(queries + i * dim, gt_ids[pos]);
+                REQUIRE(result.has_value());
+                REQUIRE(std::abs(result.value() - gt_distances[pos]) < tolerance);
+            }
+        }
+    };
+
+    SECTION("separate raw codes") {
+        auto index = make_index("sq8,bf16", true);
+        auto result = index->Tune(make_parameters("fp32"), true);
+        REQUIRE(result.has_value());
+        REQUIRE(result.value());
+        require_fp32_accuracy(index);
+    }
+
+    SECTION("precise fp32 codes") {
+        auto index = make_index("bf16,fp32");
+        auto result = index->Tune(make_parameters("fp32"), true);
+        REQUIRE(result.has_value());
+        REQUIRE(result.value());
+        require_fp32_accuracy(index);
+    }
+
+    SECTION("base fp32 codes") {
+        auto index = make_index("fp32,bf16");
+        auto result = index->Tune(make_parameters("fp32,fp32"), true);
+        REQUIRE(result.has_value());
+        REQUIRE(result.value());
+        require_fp32_accuracy(index);
+    }
+
+    SECTION("no usable codes") {
+        auto index = make_index("sq8,bf16");
+        auto result = index->Tune(make_parameters("bf16,bf16"));
+        REQUIRE(result.has_value());
+        REQUIRE_FALSE(result.value());
+    }
+
+    SECTION("no rebuild") {
+        auto index = make_index("sq8,bf16");
+        auto result = index->Tune(make_parameters("sq8"), true);
+        REQUIRE(result.has_value());
+        REQUIRE(result.value());
+    }
+}
+
 TEST_CASE("(PR) HGraph Tune with ignore_reorder", "[ft][hgraph][pr]") {
     using namespace fixtures;
     auto origin_size = vsag::Options::Instance().block_size_limit();

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -1065,7 +1065,8 @@ TEST_CASE("HGraph Tune uses available codes", "[ft][search][hgraph][tune_codes]"
         auto binary_set = index->Serialize();
         REQUIRE(binary_set.has_value());
 
-        auto reloaded = TestIndex::TestFactory("hgraph", parameters, true);
+        // ignore_reorder is a serialization-only option and is not persisted in 0.18.
+        auto reloaded = TestIndex::TestFactory("hgraph", make_parameters("fp32,fp32"), true);
         auto deserialize_result = reloaded->Deserialize(binary_set.value());
         REQUIRE(deserialize_result.has_value());
 

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -1055,6 +1055,26 @@ TEST_CASE("HGraph Tune uses available codes", "[ft][search][hgraph][tune_codes]"
         require_fp32_accuracy(index);
     }
 
+    SECTION("unloaded precise codes") {
+        auto parsed = vsag::JsonType::Parse(make_parameters("fp32,fp32"));
+        parsed[vsag::INDEX_PARAM]["ignore_reorder"].SetBool(true);
+        auto parameters = parsed.Dump();
+
+        auto index = TestIndex::TestFactory("hgraph", parameters, true);
+        TestIndex::TestBuildIndex(index, dataset, true);
+        auto binary_set = index->Serialize();
+        REQUIRE(binary_set.has_value());
+
+        auto reloaded = TestIndex::TestFactory("hgraph", parameters, true);
+        auto deserialize_result = reloaded->Deserialize(binary_set.value());
+        REQUIRE(deserialize_result.has_value());
+
+        auto tune_result = reloaded->Tune(make_parameters("fp32,fp32"), true);
+        REQUIRE(tune_result.has_value());
+        REQUIRE(tune_result.value());
+        require_fp32_accuracy(reloaded);
+    }
+
     SECTION("no usable codes") {
         auto index = make_index("sq8,bf16");
         auto result = index->Tune(make_parameters("bf16,bf16"));


### PR DESCRIPTION
## Summary

Backport #2466 to the `0.18` branch.

- Let HGraph Tune select an available lossless source from raw vectors, precise FP32 codes,
  or base FP32 codes instead of relying only on `store_raw_vector`.
- Require the selected codes to cover the current internal ID range.
- Rebuild precise codes whose payload was omitted by `ignore_reorder` serialization.
- Keep Tune state publication atomic and add source-selection and serialization regression
  coverage.

Fixes: #2465

## Backport adaptation

- Ported the implementation to the `0.18` single-file HGraph layout.
- Omitted `reorder_source` handling because that API does not exist in `0.18`.
- Omitted the ForceRemove regression because `RemoveMode::FORCE_REMOVE` is not available in
  `0.18`.

## Validation

```text
/opt/homebrew/opt/llvm@15/bin/clang-format --dry-run --Werror \
  src/algorithm/hgraph.cpp tests/test_hgraph.cpp
git diff --check upstream/0.18..HEAD
```

The `0.18` test binary was not run locally: its legacy build configuration is incompatible with
the current macOS toolchain before reaching the changed code. CI is expected to provide the
target-platform validation.

## Compatibility

- API/ABI impact: none.
