### PR TITLE
feat(datacell): add bucket insert with explicit offset

### DIFF
--- a/src/algorithm/ivf/flat_bucket_searcher.cpp
+++ b/src/algorithm/ivf/flat_bucket_searcher.cpp
@@ -52,7 +52,7 @@ FlatBucketSearcher::Search(BucketIdType bucket_id,
     }
 
     const auto& ft = param.is_inner_id_allowed;
-    const uint64_t topk_u = static_cast<uint64_t>(topk);
+    const auto topk_u = static_cast<uint64_t>(topk);
     auto cur_heap_top = std::numeric_limits<float>::max();
     if (not heap->Empty() and heap->Size() == topk_u) {
         cur_heap_top = heap->Top().first;
@@ -60,6 +60,9 @@ FlatBucketSearcher::Search(BucketIdType bucket_id,
 
     if (param.search_mode == KNN_SEARCH) {
         for (int64_t j = 0; j < bucket_size; ++j) {
+            if (ids[j] == std::numeric_limits<InnerIdType>::max()) {
+                continue;
+            }
             auto origin_id = ids[j] / buckets_per_data;
             if (reasoning_ctx != nullptr) {
                 reasoning_ctx->RecordVisit(origin_id, dist[j], 0);
@@ -89,6 +92,9 @@ FlatBucketSearcher::Search(BucketIdType bucket_id,
         }
     } else {  // RANGE_SEARCH
         for (int64_t j = 0; j < bucket_size; ++j) {
+            if (ids[j] == std::numeric_limits<InnerIdType>::max()) {
+                continue;
+            }
             auto origin_id = ids[j] / buckets_per_data;
             if (reasoning_ctx != nullptr) {
                 reasoning_ctx->RecordVisit(origin_id, dist[j], 0);

--- a/src/algorithm/ivf/ivf.cpp
+++ b/src/algorithm/ivf/ivf.cpp
@@ -16,6 +16,7 @@
 #include "ivf.h"
 
 #include <atomic>
+#include <limits>
 #include <random>
 #include <set>
 
@@ -1349,6 +1350,9 @@ IVF::fill_location_map() {
         auto* ids = this->bucket_->GetInnerIds(i);
         auto bucket_size = this->bucket_->GetBucketSize(i);
         for (uint64_t j = 0; j < bucket_size; ++j) {
+            if (ids[j] == std::numeric_limits<InnerIdType>::max()) {
+                continue;
+            }
             if (ids[j] >= this->total_elements_ * buckets_per_data_) {
                 throw VsagException(ErrorType::INTERNAL_ERROR, "invalid inner_id");
             }

--- a/src/datacell/bucket_datacell.h
+++ b/src/datacell/bucket_datacell.h
@@ -15,7 +15,10 @@
 
 #pragma once
 
+#include <algorithm>
+#include <limits>
 #include <shared_mutex>
+#include <type_traits>
 
 #include "bucket_interface.h"
 #include "impl/inner_search_param.h"
@@ -59,6 +62,12 @@ public:
 
     InnerIdType
     InsertVector(const void* vector, BucketIdType bucket_id, InnerIdType inner_id) override;
+
+    void
+    InsertVectorWithOffset(const void* vector,
+                           BucketIdType bucket_id,
+                           InnerIdType inner_id,
+                           InnerIdType offset_id) override;
 
     InnerIdType*
     GetInnerIds(BucketIdType bucket_id) override {
@@ -148,6 +157,12 @@ private:
                     const InnerIdType& offset_id);
 
     inline void
+    encode_vector(const void* vector, BucketIdType bucket_id, ByteBuffer& codes, float& res_score);
+
+    inline void
+    check_valid_bucket_capacity(uint64_t next_size, bool need_resize);
+
+    inline void
     package_fastscan();
 
     inline void
@@ -169,6 +184,16 @@ private:
     Vector<Vector<float>> residual_bias_;
 
     MetricType metric_{MetricType::METRIC_TYPE_L2SQR};
+
+    static constexpr InnerIdType EMPTY_INNER_ID = std::numeric_limits<InnerIdType>::max();
+
+    // Bound sparse fixed-offset metadata growth to reject accidental huge hole allocation.
+    static constexpr uint64_t MAX_BUCKET_ENTRIES =
+        std::min(static_cast<uint64_t>(std::numeric_limits<InnerIdType>::max()),
+                 static_cast<uint64_t>(1) << 30);
+
+    // Zero-fill holes in chunks to keep the temporary buffer bounded while avoiding tiny writes.
+    static constexpr uint64_t ZERO_FILL_BLOCK_ENTRIES = 1024;
 };
 
 template <typename QuantTmpl, typename IOTmpl>
@@ -207,7 +232,14 @@ BucketDataCell<QuantTmpl, IOTmpl>::query_one_by_id(
     std::shared_lock lock(this->bucket_mutexes_[bucket_id]);
     this->check_valid_bucket_id(bucket_id);
     if (offset_id >= this->bucket_sizes_[bucket_id]) {
-        throw VsagException(ErrorType::INTERNAL_ERROR, "invalid offset id for bucket");
+        throw VsagException(ErrorType::INVALID_ARGUMENT, "invalid offset id for bucket");
+    }
+    if (this->inner_ids_[bucket_id][offset_id] == EMPTY_INNER_ID) {
+        throw VsagException(
+            ErrorType::INVALID_ARGUMENT,
+            fmt::format("visited empty offset in bucket: bucket_id={}, offset_id={}",
+                        bucket_id,
+                        offset_id));
     }
     float ret;
     bool need_release = false;
@@ -273,6 +305,11 @@ BucketDataCell<QuantTmpl, IOTmpl>::scan_bucket_by_id(float* result_dists,
             result_dists[i] -= ip_distance;
         }
     }
+    for (InnerIdType i = 0; i < offset; ++i) {
+        if (this->inner_ids_[bucket_id][i] == EMPTY_INNER_ID) {
+            result_dists[i] = std::numeric_limits<float>::max();
+        }
+    }
 }
 
 template <typename QuantTmpl, typename IOTmpl>
@@ -323,16 +360,15 @@ BucketDataCell<QuantTmpl, IOTmpl>::Train(const void* data, uint64_t count) {
 }
 
 template <typename QuantTmpl, typename IOTmpl>
-InnerIdType
-BucketDataCell<QuantTmpl, IOTmpl>::InsertVector(const void* vector,
-                                                BucketIdType bucket_id,
-                                                InnerIdType inner_id) {
-    check_valid_bucket_id(bucket_id);
-
+void
+BucketDataCell<QuantTmpl, IOTmpl>::encode_vector(const void* vector,
+                                                 BucketIdType bucket_id,
+                                                 ByteBuffer& codes,
+                                                 float& res_score) {
     Vector<float> centroid(this->quantizer_->GetDim(), this->allocator_);
     Vector<float> sub_data(this->quantizer_->GetDim(), this->allocator_);
     Vector<float> normalize_data(this->quantizer_->GetDim(), this->allocator_);
-    float res_score = 0.0F;
+    res_score = 0.0F;
     auto vector_ptr = static_cast<const float*>(vector);
     if (use_residual_) {
         strategy_->GetCentroid(bucket_id, centroid);
@@ -343,8 +379,6 @@ BucketDataCell<QuantTmpl, IOTmpl>::InsertVector(const void* vector,
         FP32Sub(vector_ptr, centroid.data(), sub_data.data(), quantizer_->GetDim());
         vector_ptr = sub_data.data();
     }
-    InnerIdType offset_id;
-    ByteBuffer codes(static_cast<uint64_t>(code_size_), this->allocator_);
     this->quantizer_->EncodeOne(static_cast<const float*>(vector_ptr), codes.data);
     if (use_residual_ && metric_ == MetricType::METRIC_TYPE_L2SQR) {
         this->quantizer_->DecodeOne(codes.data, normalize_data.data());
@@ -352,20 +386,129 @@ BucketDataCell<QuantTmpl, IOTmpl>::InsertVector(const void* vector,
             -2 * FP32ComputeIP(centroid.data(), normalize_data.data(), this->quantizer_->GetDim()) -
             FP32ComputeIP(centroid.data(), centroid.data(), this->quantizer_->GetDim());
     }
+}
+
+template <typename QuantTmpl, typename IOTmpl>
+void
+BucketDataCell<QuantTmpl, IOTmpl>::check_valid_bucket_capacity(uint64_t next_size,
+                                                               bool need_resize) {
+    if (need_resize && (next_size > MAX_BUCKET_ENTRIES ||
+                        next_size > std::numeric_limits<size_t>::max() / sizeof(InnerIdType) ||
+                        (use_residual_ && metric_ == MetricType::METRIC_TYPE_L2SQR &&
+                         next_size > std::numeric_limits<size_t>::max() / sizeof(float)) ||
+                        ZERO_FILL_BLOCK_ENTRIES > std::numeric_limits<uint64_t>::max() /
+                                                      static_cast<uint64_t>(code_size_))) {
+        throw VsagException(ErrorType::INVALID_ARGUMENT,
+                            "invalid offset id for bucket: exceeds maximum bucket capacity");
+    }
+}
+
+template <typename QuantTmpl, typename IOTmpl>
+InnerIdType
+BucketDataCell<QuantTmpl, IOTmpl>::InsertVector(const void* vector,
+                                                BucketIdType bucket_id,
+                                                InnerIdType inner_id) {
+    check_valid_bucket_id(bucket_id);
+    if (inner_id == EMPTY_INNER_ID) {
+        throw VsagException(ErrorType::INVALID_ARGUMENT, "invalid inner id for bucket");
+    }
+
+    InnerIdType offset_id;
+    float res_score = 0.0F;
+    ByteBuffer codes(static_cast<uint64_t>(code_size_), this->allocator_);
+    encode_vector(vector, bucket_id, codes, res_score);
     {
         std::unique_lock lock(this->bucket_mutexes_[bucket_id]);
         offset_id = this->bucket_sizes_[bucket_id];
-        this->datas_[bucket_id].Write(codes.data,
-                                      code_size_,
-                                      static_cast<uint64_t>(this->bucket_sizes_[bucket_id]) *
-                                          static_cast<uint64_t>(code_size_));
-        this->bucket_sizes_[bucket_id]++;
-        inner_ids_[bucket_id].emplace_back(inner_id);
-        if (use_residual_ && metric_ == MetricType::METRIC_TYPE_L2SQR) {
-            residual_bias_[bucket_id].emplace_back(res_score);
+        if (offset_id >= std::numeric_limits<InnerIdType>::max() ||
+            static_cast<uint64_t>(offset_id) >
+                std::numeric_limits<uint64_t>::max() / static_cast<uint64_t>(code_size_)) {
+            throw VsagException(ErrorType::INVALID_ARGUMENT, "invalid offset id for bucket");
         }
+        auto next_size = static_cast<uint64_t>(offset_id) + 1;
+        check_valid_bucket_capacity(next_size, this->inner_ids_[bucket_id].size() < next_size);
+        this->datas_[bucket_id].Write(
+            codes.data,
+            code_size_,
+            static_cast<uint64_t>(offset_id) * static_cast<uint64_t>(code_size_));
+        if (this->inner_ids_[bucket_id].size() < next_size) {
+            this->inner_ids_[bucket_id].resize(next_size, EMPTY_INNER_ID);
+            if (use_residual_ && metric_ == MetricType::METRIC_TYPE_L2SQR) {
+                this->residual_bias_[bucket_id].resize(next_size, 0.0F);
+            }
+        }
+        inner_ids_[bucket_id][offset_id] = inner_id;
+        if (use_residual_ && metric_ == MetricType::METRIC_TYPE_L2SQR) {
+            residual_bias_[bucket_id][offset_id] = res_score;
+        }
+        this->bucket_sizes_[bucket_id] = static_cast<InnerIdType>(next_size);
     }
     return offset_id;
+}
+
+template <typename QuantTmpl, typename IOTmpl>
+void
+BucketDataCell<QuantTmpl, IOTmpl>::InsertVectorWithOffset(const void* vector,
+                                                          BucketIdType bucket_id,
+                                                          InnerIdType inner_id,
+                                                          InnerIdType offset_id) {
+    check_valid_bucket_id(bucket_id);
+    if (inner_id == EMPTY_INNER_ID) {
+        throw VsagException(ErrorType::INVALID_ARGUMENT, "invalid inner id for bucket");
+    }
+    if constexpr (std::is_signed_v<InnerIdType>) {
+        if (offset_id < 0) {
+            throw VsagException(ErrorType::INVALID_ARGUMENT, "invalid offset id for bucket");
+        }
+    }
+    if (offset_id >= std::numeric_limits<InnerIdType>::max() ||
+        static_cast<uint64_t>(offset_id) >
+            std::numeric_limits<uint64_t>::max() / static_cast<uint64_t>(code_size_)) {
+        throw VsagException(ErrorType::INVALID_ARGUMENT, "invalid offset id for bucket");
+    }
+
+    float res_score = 0.0F;
+    ByteBuffer codes(static_cast<uint64_t>(code_size_), this->allocator_);
+    encode_vector(vector, bucket_id, codes, res_score);
+    {
+        std::unique_lock lock(this->bucket_mutexes_[bucket_id]);
+        auto next_size = static_cast<uint64_t>(offset_id) + 1;
+        auto need_resize = this->inner_ids_[bucket_id].size() < next_size;
+        check_valid_bucket_capacity(next_size, need_resize);
+        if (need_resize) {
+            this->inner_ids_[bucket_id].resize(next_size, EMPTY_INNER_ID);
+            if (use_residual_ && metric_ == MetricType::METRIC_TYPE_L2SQR) {
+                this->residual_bias_[bucket_id].resize(next_size, 0.0F);
+            }
+        }
+        if (offset_id > this->bucket_sizes_[bucket_id]) {
+            auto zero_fill_entries = std::min<uint64_t>(
+                static_cast<uint64_t>(offset_id - this->bucket_sizes_[bucket_id]),
+                ZERO_FILL_BLOCK_ENTRIES);
+            auto zero_fill_bytes = zero_fill_entries * static_cast<uint64_t>(code_size_);
+            ByteBuffer zero_codes(zero_fill_bytes, this->allocator_);
+            std::fill_n(zero_codes.data, zero_fill_bytes, 0);
+            for (auto hole_offset = this->bucket_sizes_[bucket_id]; hole_offset < offset_id;) {
+                auto fill_entries = std::min<uint64_t>(
+                    static_cast<uint64_t>(offset_id - hole_offset), ZERO_FILL_BLOCK_ENTRIES);
+                this->datas_[bucket_id].Write(
+                    zero_codes.data,
+                    fill_entries * static_cast<uint64_t>(code_size_),
+                    static_cast<uint64_t>(hole_offset) * static_cast<uint64_t>(code_size_));
+                hole_offset += static_cast<InnerIdType>(fill_entries);
+            }
+        }
+        this->datas_[bucket_id].Write(
+            codes.data,
+            code_size_,
+            static_cast<uint64_t>(offset_id) * static_cast<uint64_t>(code_size_));
+        this->inner_ids_[bucket_id][offset_id] = inner_id;
+        if (use_residual_ && metric_ == MetricType::METRIC_TYPE_L2SQR) {
+            this->residual_bias_[bucket_id][offset_id] = res_score;
+        }
+        this->bucket_sizes_[bucket_id] =
+            std::max(this->bucket_sizes_[bucket_id], static_cast<InnerIdType>(next_size));
+    }
 }
 
 template <typename QuantTmpl, typename IOTmpl>
@@ -487,7 +630,7 @@ BucketDataCell<QuantTmpl, IOTmpl>::MergeOther(const BucketInterfacePtr& other, I
         this->bucket_sizes_[i] += ptr->bucket_sizes_[i];
         this->inner_ids_[i].reserve(this->bucket_sizes_[i]);
         for (auto id : ptr->inner_ids_[i]) {
-            this->inner_ids_[i].emplace_back(id + bias);
+            this->inner_ids_[i].emplace_back(id == EMPTY_INNER_ID ? EMPTY_INNER_ID : id + bias);
         }
     }
 }

--- a/src/datacell/bucket_datacell_test.cpp
+++ b/src/datacell/bucket_datacell_test.cpp
@@ -17,6 +17,10 @@
 
 #include <algorithm>
 #include <cmath>
+#include <exception>
+#include <limits>
+#include <sstream>
+#include <thread>
 #include <utility>
 
 #include "impl/allocator/default_allocator.h"
@@ -245,5 +249,226 @@ TEST_CASE("BucketDataCell supports RabitQ", "[ut][BucketDataCell]") {
                 REQUIRE(std::isfinite(one_dist));
             }
         }
+    }
+}
+
+TEST_CASE("BucketDataCell InsertVectorWithOffset", "[ut][BucketDataCell]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    constexpr int64_t dim = 16;
+    constexpr uint64_t base_count = 32;
+    auto vectors = fixtures::generate_vectors(base_count, dim);
+    auto queries = fixtures::generate_vectors(1, dim, 23);
+
+    constexpr const char* param_str = R"(
+        {
+            "io_params": {
+                "type": "memory_io"
+            },
+            "quantization_params": {
+                "type": "fp32"
+            },
+            "buckets_count": 4
+        }
+        )";
+
+    auto make_bucket = [&]() {
+        auto param_json = JsonType::Parse(param_str);
+        auto param = std::make_shared<BucketDataCellParameter>();
+        param->FromJson(param_json);
+
+        IndexCommonParam common_param;
+        common_param.allocator_ = allocator;
+        common_param.dim_ = dim;
+        common_param.metric_ = MetricType::METRIC_TYPE_L2SQR;
+
+        auto bucket = BucketInterface::MakeInstance(param, common_param);
+        bucket->Train(vectors.data(), base_count);
+        return bucket;
+    };
+
+    SECTION("fixed offset write is queryable") {
+        auto appended = make_bucket();
+        auto fixed = make_bucket();
+        constexpr BucketIdType bucket_id = 2;
+        constexpr InnerIdType inner_id = 7;
+        constexpr InnerIdType offset_id = 5;
+
+        auto append_offset =
+            appended->InsertVector(vectors.data() + inner_id * dim, bucket_id, inner_id);
+        for (InnerIdType offset = 0; offset <= offset_id; ++offset) {
+            fixed->InsertVector(vectors.data() + offset * dim, bucket_id, offset);
+        }
+        fixed->InsertVectorWithOffset(
+            vectors.data() + inner_id * dim, bucket_id, inner_id, offset_id);
+
+        auto fixed_computer = fixed->FactoryComputer(queries.data());
+        auto appended_computer = appended->FactoryComputer(queries.data());
+        REQUIRE(fixed->GetBucketSize(bucket_id) == offset_id + 1);
+        REQUIRE(fixed->GetInnerIds(bucket_id)[offset_id] == inner_id);
+        REQUIRE(std::abs(fixed->QueryOneById(fixed_computer, bucket_id, offset_id) -
+                         appended->QueryOneById(appended_computer, bucket_id, append_offset)) <
+                1e-5F);
+    }
+
+    SECTION("append and fixed offset can be mixed") {
+        auto bucket = make_bucket();
+        constexpr BucketIdType bucket_id = 1;
+        auto offset0 = bucket->InsertVector(vectors.data(), bucket_id, 0);
+        auto offset1 = bucket->InsertVector(vectors.data() + dim, bucket_id, 1);
+        auto offset2 = bucket->InsertVector(vectors.data() + 2 * dim, bucket_id, 2);
+        REQUIRE(offset0 == 0);
+        REQUIRE(offset1 == 1);
+        REQUIRE(offset2 == 2);
+
+        constexpr InnerIdType appended_inner_id = 3;
+        bucket->InsertVectorWithOffset(
+            vectors.data() + appended_inner_id * dim, bucket_id, appended_inner_id, offset2 + 1);
+        constexpr InnerIdType fixed_inner_id = 9;
+        bucket->InsertVectorWithOffset(
+            vectors.data() + fixed_inner_id * dim, bucket_id, fixed_inner_id, offset1);
+
+        REQUIRE(bucket->GetBucketSize(bucket_id) == offset2 + 2);
+        REQUIRE(bucket->GetInnerIds(bucket_id)[offset1] == fixed_inner_id);
+        REQUIRE(bucket->GetInnerIds(bucket_id)[offset2 + 1] == appended_inner_id);
+    }
+
+    SECTION("empty sentinel inner id is rejected") {
+        auto bucket = make_bucket();
+        constexpr BucketIdType bucket_id = 0;
+        auto empty_inner_id = std::numeric_limits<InnerIdType>::max();
+
+        REQUIRE_THROWS(bucket->InsertVector(vectors.data(), bucket_id, empty_inner_id));
+        REQUIRE_THROWS(
+            bucket->InsertVectorWithOffset(vectors.data(), bucket_id, empty_inner_id, 0));
+    }
+
+    SECTION("out of order fixed offset writes keep holes") {
+        auto bucket = make_bucket();
+        constexpr BucketIdType bucket_id = 1;
+
+        bucket->InsertVectorWithOffset(vectors.data() + 2 * dim, bucket_id, 2, 2);
+        REQUIRE(bucket->GetBucketSize(bucket_id) == 3);
+        REQUIRE(bucket->GetInnerIds(bucket_id)[0] == std::numeric_limits<InnerIdType>::max());
+        REQUIRE(bucket->GetInnerIds(bucket_id)[1] == std::numeric_limits<InnerIdType>::max());
+        REQUIRE(bucket->GetInnerIds(bucket_id)[2] == 2);
+
+        std::vector<uint8_t> hole_codes(sizeof(float) * dim, 1);
+        bucket->GetCodesById(bucket_id, 0, hole_codes.data());
+        REQUIRE(std::all_of(
+            hole_codes.begin(), hole_codes.end(), [](uint8_t value) { return value == 0; }));
+        std::fill(hole_codes.begin(), hole_codes.end(), 1);
+        bucket->GetCodesById(bucket_id, 1, hole_codes.data());
+        REQUIRE(std::all_of(
+            hole_codes.begin(), hole_codes.end(), [](uint8_t value) { return value == 0; }));
+
+        bucket->InsertVectorWithOffset(vectors.data(), bucket_id, 0, 0);
+        REQUIRE(bucket->GetBucketSize(bucket_id) == 3);
+
+        bucket->InsertVectorWithOffset(vectors.data() + dim, bucket_id, 1, 1);
+        REQUIRE(bucket->GetBucketSize(bucket_id) == 3);
+        for (InnerIdType offset = 0; offset < 3; ++offset) {
+            REQUIRE(bucket->GetInnerIds(bucket_id)[offset] == offset);
+        }
+    }
+
+    SECTION("dense fixed offset writes match append layout") {
+        auto appended = make_bucket();
+        auto fixed = make_bucket();
+        constexpr BucketIdType bucket_id = 3;
+        constexpr uint64_t insert_count = 8;
+
+        for (uint64_t i = 0; i < insert_count; ++i) {
+            auto offset = appended->InsertVector(
+                vectors.data() + i * dim, bucket_id, static_cast<InnerIdType>(i));
+            fixed->InsertVectorWithOffset(
+                vectors.data() + i * dim, bucket_id, static_cast<InnerIdType>(i), offset);
+        }
+
+        REQUIRE(fixed->GetBucketSize(bucket_id) == appended->GetBucketSize(bucket_id));
+        std::vector<uint8_t> appended_codes(sizeof(float) * dim);
+        std::vector<uint8_t> fixed_codes(sizeof(float) * dim);
+        for (uint64_t i = 0; i < insert_count; ++i) {
+            REQUIRE(fixed->GetInnerIds(bucket_id)[i] == appended->GetInnerIds(bucket_id)[i]);
+            appended->GetCodesById(bucket_id, i, appended_codes.data());
+            fixed->GetCodesById(bucket_id, i, fixed_codes.data());
+            REQUIRE(appended_codes == fixed_codes);
+        }
+    }
+
+    SECTION("concurrent fixed offset writes do not conflict") {
+        auto bucket = make_bucket();
+        constexpr BucketIdType bucket_id = 0;
+        constexpr uint64_t insert_count = 16;
+        std::vector<std::thread> threads;
+        std::vector<std::exception_ptr> exceptions(insert_count);
+        threads.reserve(insert_count);
+
+        for (uint64_t i = 0; i < insert_count; ++i) {
+            threads.emplace_back([&, i]() {
+                try {
+                    bucket->InsertVectorWithOffset(vectors.data() + i * dim,
+                                                   bucket_id,
+                                                   static_cast<InnerIdType>(i + insert_count),
+                                                   static_cast<InnerIdType>(i));
+                } catch (...) {
+                    exceptions[i] = std::current_exception();
+                }
+            });
+        }
+        for (auto& thread : threads) {
+            thread.join();
+        }
+        for (auto& exception : exceptions) {
+            if (exception != nullptr) {
+                std::rethrow_exception(exception);
+            }
+        }
+
+        REQUIRE(bucket->GetBucketSize(bucket_id) == insert_count);
+        for (uint64_t i = 0; i < insert_count; ++i) {
+            REQUIRE(bucket->GetInnerIds(bucket_id)[i] == i + insert_count);
+        }
+    }
+
+    SECTION("out of order writes survive serialize deserialize") {
+        auto bucket = make_bucket();
+        constexpr BucketIdType bucket_id = 0;
+        bucket->InsertVectorWithOffset(vectors.data() + 2 * dim, bucket_id, 2, 2);
+        bucket->InsertVectorWithOffset(vectors.data() + dim, bucket_id, 1, 1);
+        bucket->InsertVectorWithOffset(vectors.data(), bucket_id, 0, 0);
+        REQUIRE(bucket->GetBucketSize(bucket_id) == 3);
+
+        std::stringstream ss;
+        IOStreamWriter writer(ss);
+        bucket->Serialize(writer);
+        ss.seekg(0, std::ios::beg);
+        IOStreamReader reader(ss);
+
+        auto restored = make_bucket();
+        restored->Deserialize(reader);
+        REQUIRE(restored->GetBucketSize(bucket_id) == 3);
+        for (InnerIdType offset = 0; offset < 3; ++offset) {
+            REQUIRE(restored->GetInnerIds(bucket_id)[offset] == offset);
+        }
+    }
+
+    SECTION("merge other remains overwriteable by fixed offset") {
+        auto dst = make_bucket();
+        auto src = make_bucket();
+        constexpr BucketIdType bucket_id = 0;
+        dst->InsertVector(vectors.data(), bucket_id, 10);
+        src->InsertVectorWithOffset(vectors.data() + dim, bucket_id, 20, 1);
+
+        dst->MergeOther(src, 5);
+        REQUIRE(dst->GetBucketSize(bucket_id) == 3);
+        REQUIRE(dst->GetInnerIds(bucket_id)[0] == 10);
+        REQUIRE(dst->GetInnerIds(bucket_id)[1] == std::numeric_limits<InnerIdType>::max());
+        REQUIRE(dst->GetInnerIds(bucket_id)[2] == 25);
+
+        dst->InsertVectorWithOffset(vectors.data() + 2 * dim, bucket_id, 30, 1);
+        REQUIRE(dst->GetBucketSize(bucket_id) == 3);
+        REQUIRE(dst->GetInnerIds(bucket_id)[0] == 10);
+        REQUIRE(dst->GetInnerIds(bucket_id)[1] == 30);
+        REQUIRE(dst->GetInnerIds(bucket_id)[2] == 25);
     }
 }

--- a/src/datacell/bucket_interface.h
+++ b/src/datacell/bucket_interface.h
@@ -56,6 +56,17 @@ public:
     virtual InnerIdType
     InsertVector(const void* vector, BucketIdType bucket_id, InnerIdType inner_id) = 0;
 
+    // Fixed-offset inserts may create holes: GetBucketSize() includes reserved offsets and
+    // GetInnerIds() reports holes as InnerIdType::max(). Therefore inner_id must not be max.
+    virtual void
+    InsertVectorWithOffset(const void* vector,
+                           BucketIdType bucket_id,
+                           InnerIdType inner_id,
+                           InnerIdType offset_id) {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "InsertVectorWithOffset not implemented");
+    }
+
     virtual InnerIdType*
     GetInnerIds(BucketIdType bucket_id) = 0;
 


### PR DESCRIPTION
## Summary
- add BucketInterface::InsertVectorWithOffset for writing to a specified bucket offset
- implement fixed-offset insertion in BucketDataCell while preserving append insertion behavior
- add BucketDataCell unit coverage for fixed-offset writes, append/fixed mixing, dense equivalence, and concurrent fixed writes

## Testing
- make fmt
- Not run local build/tests per maintainer request

Fixes #2481