### PR TITLE
Revert filter visit stage changes on v0.18

### DIFF
--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -944,8 +944,6 @@ HGraph::KnnSearch(const DatasetPtr& query,
         search_param.consider_duplicate = this->label_table_->CompressDuplicateData();
         search_param.parallel_search_thread_count = params.parallel_search_thread_count;
         search_param.min_distance = params.min_distance;
-        search_param.skip_ratio = params.skip_ratio;
-        search_param.skip_strategy_type = params.skip_strategy_type;
 
         search_result = this->search_one_graph(query_data,
                                                this->bottom_graph_,
@@ -1157,8 +1155,6 @@ HGraph::RangeSearch(const DatasetPtr& query,
     search_param.range_search_limit_size = static_cast<int>(limited_size);
     search_param.parallel_search_thread_count = params.parallel_search_thread_count;
     search_param.min_distance = params.min_distance;
-    search_param.skip_ratio = params.skip_ratio;
-    search_param.skip_strategy_type = params.skip_strategy_type;
 
     auto search_result = this->search_one_graph(raw_query,
                                                 this->bottom_graph_,
@@ -2204,8 +2200,6 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
     }
     search_param.parallel_search_thread_count = params.parallel_search_thread_count;
     search_param.min_distance = params.min_distance;
-    search_param.skip_ratio = params.skip_ratio;
-    search_param.skip_strategy_type = params.skip_strategy_type;
 
     // hops_limit only takes effect when it's greater than ef_search
     if (params.hops_limit <= static_cast<uint32_t>(params.ef_search)) {

--- a/src/algorithm/hgraph_parameter.cpp
+++ b/src/algorithm/hgraph_parameter.cpp
@@ -224,18 +224,6 @@ HGraphSearchParameters::FromJson(const std::string& json_string) {
         obj.min_distance = params[INDEX_TYPE_HGRAPH]["min_distance"].GetFloat();
     }
 
-    if (params[INDEX_TYPE_HGRAPH].Contains(HNSW_PARAMETER_SKIP_RATIO)) {
-        obj.skip_ratio = params[INDEX_TYPE_HGRAPH][HNSW_PARAMETER_SKIP_RATIO].GetFloat();
-        CHECK_ARGUMENT((0.0F <= obj.skip_ratio) and (obj.skip_ratio <= 1.0F),  // NOLINT
-                       fmt::format("skip_ratio({}) must be in range [0.0, 1.0]", obj.skip_ratio));
-    }
-    if (params[INDEX_TYPE_HGRAPH].Contains(HNSW_PARAMETER_SKIP_STRATEGY)) {
-        CHECK_ARGUMENT(
-            params[INDEX_TYPE_HGRAPH][HNSW_PARAMETER_SKIP_STRATEGY].IsString(),
-            fmt::format("parameters[{}] must be string type", HNSW_PARAMETER_SKIP_STRATEGY));
-        obj.skip_strategy_type = parse_filter_search_skip_strategy_type(
-            params[INDEX_TYPE_HGRAPH][HNSW_PARAMETER_SKIP_STRATEGY].GetString());
-    }
     return obj;
 }
 }  // namespace vsag

--- a/src/algorithm/hgraph_parameter.h
+++ b/src/algorithm/hgraph_parameter.h
@@ -20,7 +20,6 @@
 #include "data_type.h"
 #include "index_search_parameter.h"
 #include "inner_index_parameter.h"
-#include "utils/filter_search_skip_strategy.h"
 #include "utils/pointer_define.h"
 #include "vsag/constants.h"
 
@@ -83,9 +82,6 @@ public:
     bool use_reorder{false};
     bool use_extra_info_filter{false};
     float min_distance{std::numeric_limits<float>::lowest()};
-    float skip_ratio{0.2F};
-    FilterSearchSkipStrategyType skip_strategy_type{
-        FilterSearchSkipStrategyType::DETERMINISTIC_ACCUMULATIVE};
 
 private:
     HGraphSearchParameters() = default;

--- a/src/algorithm/hgraph_parameter_test.cpp
+++ b/src/algorithm/hgraph_parameter_test.cpp
@@ -228,32 +228,3 @@ TEST_CASE("HGraph maps label_remap_type to inner index parameter", "[ut][HGraphP
     REQUIRE(typed_param != nullptr);
     REQUIRE(typed_param->label_remap_type == vsag::LabelRemapType::ROBIN);
 }
-
-TEST_CASE("HGraphSearchParameters parses skip_ratio and skip_strategy",
-          "[ut][HGraphSearchParameters][skip_ratio]") {
-    SECTION("default values") {
-        auto params = vsag::HGraphSearchParameters::FromJson(R"({"hgraph": {"ef_search": 32}})");
-        REQUIRE(params.skip_ratio == 0.2F);
-        REQUIRE(params.skip_strategy_type ==
-                vsag::FilterSearchSkipStrategyType::DETERMINISTIC_ACCUMULATIVE);
-    }
-
-    SECTION("custom skip_ratio") {
-        auto params = vsag::HGraphSearchParameters::FromJson(
-            R"({"hgraph": {"ef_search": 32, "skip_ratio": 0.5}})");
-        REQUIRE(params.skip_ratio == 0.5F);
-    }
-
-    SECTION("custom skip_strategy") {
-        auto params = vsag::HGraphSearchParameters::FromJson(
-            R"({"hgraph": {"ef_search": 32, "skip_strategy": "random"}})");
-        REQUIRE(params.skip_strategy_type == vsag::FilterSearchSkipStrategyType::RANDOM);
-    }
-
-    SECTION("rejects out-of-range skip_ratio") {
-        REQUIRE_THROWS(vsag::HGraphSearchParameters::FromJson(
-            R"({"hgraph": {"ef_search": 32, "skip_ratio": 1.5}})"));
-        REQUIRE_THROWS(vsag::HGraphSearchParameters::FromJson(
-            R"({"hgraph": {"ef_search": 32, "skip_ratio": -0.1}})"));
-    }
-}

--- a/src/algorithm/hnswlib/hnswalg.cpp
+++ b/src/algorithm/hnswlib/hnswalg.cpp
@@ -617,7 +617,7 @@ HierarchicalNSW::searchBaseLayerST(InnerIdType ep_id,
                 bool candidate_valid = true;
                 bool candidate_valid_checked = false;
                 if (is_id_allowed && not candidate_set.empty() &&
-                    not skip_strategy->ShouldVisit()) {
+                    not skip_strategy->ShouldSkipFilterCheck()) {
                     candidate_valid = is_id_allowed->CheckValid(getExternalLabel(candidate_id));
                     candidate_valid_checked = true;
                     if (not candidate_valid) {

--- a/src/impl/inner_search_param.h
+++ b/src/impl/inner_search_param.h
@@ -43,7 +43,7 @@ public:
     uint64_t ef{10};
     uint32_t hops_limit{std::numeric_limits<uint32_t>::max()};
     FilterPtr is_inner_id_allowed{nullptr};
-    float skip_ratio{0.2F};
+    float skip_ratio{0.8F};
     FilterSearchSkipStrategyType skip_strategy_type{
         FilterSearchSkipStrategyType::DETERMINISTIC_ACCUMULATIVE};
     InnerSearchMode search_mode{KNN_SEARCH};

--- a/src/impl/searcher/basic_searcher.cpp
+++ b/src/impl/searcher/basic_searcher.cpp
@@ -54,15 +54,13 @@ BasicSearcher::visit(const GraphInterfacePtr& graph,
             vl->Prefetch(neighbors[i + prefetch_stride_visit_]);
         }
         if (not vl->Get(neighbors[i])) {
-            vl->Set(neighbors[i]);
-            // Removed filter->CheckValid() to eliminate duplicate filter checking.
-            // Filter is applied at result-collection stage.
-            // ShouldVisit() probabilistically gates traversal to preserve graph connectivity.
-            if (not filter || count_no_visited == 0 || skip_strategy == nullptr ||
-                skip_strategy->ShouldVisit()) {
+            if (not filter || count_no_visited == 0 || skip_strategy->ShouldSkipFilterCheck() ||
+                filter->CheckValid(neighbors[i])) {
+                to_be_visited_rid[count_no_visited] = i;
                 to_be_visited_id[count_no_visited] = neighbors[i];
                 count_no_visited++;
             }
+            vl->Set(neighbors[i]);
         }
     }
     return count_no_visited;

--- a/src/impl/searcher/parallel_searcher.cpp
+++ b/src/impl/searcher/parallel_searcher.cpp
@@ -62,15 +62,13 @@ ParallelSearcher::visit(const GraphInterfacePtr& graph,
                 vl->Prefetch(neighbors[i][j + prefetch_stride_visit_]);
             }
             if (not vl->Get(neighbors[i][j])) {
-                vl->Set(neighbors[i][j]);
-                // Removed filter->CheckValid() to eliminate duplicate filter checking.
-                // Filter is applied at result-collection stage.
-                // ShouldVisit() probabilistically gates traversal to preserve graph connectivity.
-                if (not filter || count_no_visited == 0 || skip_strategy == nullptr ||
-                    skip_strategy->ShouldVisit()) {
+                if (not filter || count_no_visited == 0 || skip_strategy->ShouldSkipFilterCheck() ||
+                    filter->CheckValid(neighbors[i][j])) {
+                    to_be_visited_rid[count_no_visited] = j;
                     to_be_visited_id[count_no_visited] = neighbors[i][j];
                     count_no_visited++;
                 }
+                vl->Set(neighbors[i][j]);
             }
         }
     }

--- a/src/index/hnsw_zparameters.h
+++ b/src/index/hnsw_zparameters.h
@@ -63,7 +63,7 @@ public:
 public:
     // required vars
     int64_t ef_search;
-    float skip_ratio{0.1F};
+    float skip_ratio{0.9};
     FilterSearchSkipStrategyType skip_strategy_type{
         FilterSearchSkipStrategyType::DETERMINISTIC_ACCUMULATIVE};
     bool use_conjugate_graph_search;

--- a/src/utils/filter_search_skip_strategy.cpp
+++ b/src/utils/filter_search_skip_strategy.cpp
@@ -25,7 +25,10 @@ constexpr const char* DETERMINISTIC_ACCUMULATIVE_SKIP_STRATEGY = "deterministic_
 
 double
 get_retain_ratio(float valid_ratio, float skip_ratio) {
-    return static_cast<double>(1.0F - valid_ratio) * static_cast<double>(1.0F - skip_ratio);
+    if (valid_ratio == 1.0F) {
+        return 1.0;
+    }
+    return static_cast<double>(1.0F - valid_ratio) * static_cast<double>(skip_ratio);
 }
 
 class RandomFilterSearchSkipStrategy : public FilterSearchSkipStrategy {
@@ -36,7 +39,7 @@ public:
 
     bool
     ShouldVisit() override {
-        return generator_.NextFloat() >= visit_threshold_;
+        return generator_.NextFloat() > visit_threshold_;
     }
 
 private:

--- a/src/utils/filter_search_skip_strategy.cpp
+++ b/src/utils/filter_search_skip_strategy.cpp
@@ -33,28 +33,29 @@ get_retain_ratio(float valid_ratio, float skip_ratio) {
 
 class RandomFilterSearchSkipStrategy : public FilterSearchSkipStrategy {
 public:
-    explicit RandomFilterSearchSkipStrategy(double visit_ratio)
-        : visit_threshold_(1.0 - visit_ratio) {
+    explicit RandomFilterSearchSkipStrategy(double retain_ratio)
+        : skip_threshold_(1.0 - retain_ratio) {
     }
 
     bool
-    ShouldVisit() override {
-        return generator_.NextFloat() > visit_threshold_;
+    ShouldSkipFilterCheck() override {
+        return generator_.NextFloat() > skip_threshold_;
     }
 
 private:
     LinearCongruentialGenerator generator_;
-    double visit_threshold_{0.0};
+    double skip_threshold_{0.0};
 };
 
 class AccumulativeFilterSearchSkipStrategy : public FilterSearchSkipStrategy {
 public:
-    explicit AccumulativeFilterSearchSkipStrategy(double visit_ratio) : visit_ratio_(visit_ratio) {
+    explicit AccumulativeFilterSearchSkipStrategy(double retain_ratio)
+        : retain_ratio_(retain_ratio) {
     }
 
     bool
-    ShouldVisit() override {
-        accumulative_alpha_ += visit_ratio_;
+    ShouldSkipFilterCheck() override {
+        accumulative_alpha_ += retain_ratio_;
         if (accumulative_alpha_ >= 1.0) {
             accumulative_alpha_ -= 1.0;
             return true;
@@ -63,7 +64,7 @@ public:
     }
 
 private:
-    double visit_ratio_{1.0};
+    double retain_ratio_{1.0};
     double accumulative_alpha_{0.0};
 };
 
@@ -74,14 +75,11 @@ create_filter_search_skip_strategy(FilterSearchSkipStrategyType type,
                                    float valid_ratio,
                                    float skip_ratio) {
     auto retain_ratio = get_retain_ratio(valid_ratio, skip_ratio);
-    // visit_ratio = valid_ratio + retain_ratio, capped at 1.0
-    // When valid_ratio is high, we visit most neighbors; when low, visit_ratio depends on skip_ratio
-    auto visit_ratio = std::min(1.0, static_cast<double>(valid_ratio) + retain_ratio);
     switch (type) {
         case FilterSearchSkipStrategyType::RANDOM:
-            return std::make_unique<RandomFilterSearchSkipStrategy>(visit_ratio);
+            return std::make_unique<RandomFilterSearchSkipStrategy>(retain_ratio);
         case FilterSearchSkipStrategyType::DETERMINISTIC_ACCUMULATIVE:
-            return std::make_unique<AccumulativeFilterSearchSkipStrategy>(visit_ratio);
+            return std::make_unique<AccumulativeFilterSearchSkipStrategy>(retain_ratio);
     }
     throw VsagException(ErrorType::INVALID_ARGUMENT, "Unknown FilterSearchSkipStrategyType");
 }

--- a/src/utils/filter_search_skip_strategy.h
+++ b/src/utils/filter_search_skip_strategy.h
@@ -28,11 +28,8 @@ class FilterSearchSkipStrategy {
 public:
     virtual ~FilterSearchSkipStrategy() = default;
 
-    // Probabilistic gate for visiting neighbors during graph traversal.
-    // visit_ratio = valid_ratio + (1 - valid_ratio) * skip_ratio
-    // This ensures we visit more neighbors when most pass the filter.
     virtual bool
-    ShouldVisit() = 0;
+    ShouldSkipFilterCheck() = 0;
 };
 
 using FilterSearchSkipStrategyPtr = std::unique_ptr<FilterSearchSkipStrategy>;

--- a/src/utils/filter_search_skip_strategy_test.cpp
+++ b/src/utils/filter_search_skip_strategy_test.cpp
@@ -30,7 +30,8 @@ TEST_CASE("Filter search skip strategy parse", "[ut][filter_search_skip_strategy
     REQUIRE_THROWS(parse_filter_search_skip_strategy_type("unknown"));
 }
 
-TEST_CASE("Accumulative ShouldVisit is deterministic", "[ut][filter_search_skip_strategy]") {
+TEST_CASE("Accumulative filter search skip strategy is deterministic",
+          "[ut][filter_search_skip_strategy]") {
     constexpr float valid_ratio = 0.5F;
     constexpr float skip_ratio = 0.8F;
     std::vector<bool> first_sequence;
@@ -42,39 +43,31 @@ TEST_CASE("Accumulative ShouldVisit is deterministic", "[ut][filter_search_skip_
         FilterSearchSkipStrategyType::DETERMINISTIC_ACCUMULATIVE, valid_ratio, skip_ratio);
 
     for (uint64_t i = 0; i < 20; ++i) {
-        first_sequence.emplace_back(first_strategy->ShouldVisit());
-        second_sequence.emplace_back(second_strategy->ShouldVisit());
+        first_sequence.emplace_back(first_strategy->ShouldSkipFilterCheck());
+        second_sequence.emplace_back(second_strategy->ShouldSkipFilterCheck());
     }
 
     REQUIRE(first_sequence == second_sequence);
-    // visit_ratio = 0.5 + 0.5*0.8 = 0.9
-    // Accumulative pattern: F,T,T,T,T,T,T,T,T,T repeated = 18/20 true
-    std::vector<bool> expected = {false, true, true, true, true, true, true, true, true, true,
-                                  false, true, true, true, true, true, true, true, true, true};
-    REQUIRE(first_sequence == expected);
+    REQUIRE(first_sequence == std::vector<bool>{false, false, true,  false, true,  false, false,
+                                                true,  false, true,  false, false, true,  false,
+                                                true,  false, false, true,  false, true});
 }
 
-TEST_CASE("ShouldVisit edge cases", "[ut][filter_search_skip_strategy]") {
-    SECTION("valid ratio one always visits") {
+TEST_CASE("Accumulative filter search skip strategy edge cases",
+          "[ut][filter_search_skip_strategy]") {
+    SECTION("valid ratio one skips filter checks") {
         auto strategy = create_filter_search_skip_strategy(
             FilterSearchSkipStrategyType::DETERMINISTIC_ACCUMULATIVE, 1.0F, 0.8F);
         for (uint64_t i = 0; i < 10; ++i) {
-            REQUIRE(strategy->ShouldVisit());
+            REQUIRE(strategy->ShouldSkipFilterCheck());
         }
     }
 
-    SECTION("skip ratio zero with low valid ratio visits less") {
+    SECTION("skip ratio zero skips invalid candidates") {
         auto strategy = create_filter_search_skip_strategy(
             FilterSearchSkipStrategyType::DETERMINISTIC_ACCUMULATIVE, 0.5F, 0.0F);
-        // visit_ratio = 0.5 + 0.5*0 = 0.5
-        // Accumulative pattern: F,T,F,T,... alternating = exactly 50/100 true
-        std::vector<bool> sequence;
-        for (uint64_t i = 0; i < 20; ++i) {
-            sequence.emplace_back(strategy->ShouldVisit());
+        for (uint64_t i = 0; i < 10; ++i) {
+            REQUIRE_FALSE(strategy->ShouldSkipFilterCheck());
         }
-        std::vector<bool> expected = {false, true,  false, true,  false, true,  false,
-                                      true,  false, true,  false, true,  false, true,
-                                      false, true,  false, true,  false, true};
-        REQUIRE(sequence == expected);
     }
 }

--- a/src/utils/filter_search_skip_strategy_test.cpp
+++ b/src/utils/filter_search_skip_strategy_test.cpp
@@ -25,8 +25,6 @@ TEST_CASE("Filter search skip strategy parse", "[ut][filter_search_skip_strategy
     REQUIRE(parse_filter_search_skip_strategy_type("deterministic_accumulative") ==
             FilterSearchSkipStrategyType::DETERMINISTIC_ACCUMULATIVE);
     REQUIRE(std::string(filter_search_skip_strategy_type_to_string(
-                FilterSearchSkipStrategyType::RANDOM)) == "random");
-    REQUIRE(std::string(filter_search_skip_strategy_type_to_string(
                 FilterSearchSkipStrategyType::DETERMINISTIC_ACCUMULATIVE)) ==
             "deterministic_accumulative");
     REQUIRE_THROWS(parse_filter_search_skip_strategy_type("unknown"));
@@ -34,7 +32,7 @@ TEST_CASE("Filter search skip strategy parse", "[ut][filter_search_skip_strategy
 
 TEST_CASE("Accumulative ShouldVisit is deterministic", "[ut][filter_search_skip_strategy]") {
     constexpr float valid_ratio = 0.5F;
-    constexpr float skip_ratio = 0.2F;
+    constexpr float skip_ratio = 0.8F;
     std::vector<bool> first_sequence;
     std::vector<bool> second_sequence;
 
@@ -49,7 +47,7 @@ TEST_CASE("Accumulative ShouldVisit is deterministic", "[ut][filter_search_skip_
     }
 
     REQUIRE(first_sequence == second_sequence);
-    // visit_ratio = 0.5 + (1-0.5)*(1-0.2) = 0.5 + 0.4 = 0.9
+    // visit_ratio = 0.5 + 0.5*0.8 = 0.9
     // Accumulative pattern: F,T,T,T,T,T,T,T,T,T repeated = 18/20 true
     std::vector<bool> expected = {false, true, true, true, true, true, true, true, true, true,
                                   false, true, true, true, true, true, true, true, true, true};
@@ -65,16 +63,18 @@ TEST_CASE("ShouldVisit edge cases", "[ut][filter_search_skip_strategy]") {
         }
     }
 
-    SECTION("skip ratio zero means no skipping") {
+    SECTION("skip ratio zero with low valid ratio visits less") {
         auto strategy = create_filter_search_skip_strategy(
             FilterSearchSkipStrategyType::DETERMINISTIC_ACCUMULATIVE, 0.5F, 0.0F);
-        // visit_ratio = 0.5 + (1-0.5)*(1-0.0) = 0.5 + 0.5 = 1.0
-        // Accumulative pattern: all true since visit_ratio = 1.0
+        // visit_ratio = 0.5 + 0.5*0 = 0.5
+        // Accumulative pattern: F,T,F,T,... alternating = exactly 50/100 true
         std::vector<bool> sequence;
         for (uint64_t i = 0; i < 20; ++i) {
             sequence.emplace_back(strategy->ShouldVisit());
         }
-        std::vector<bool> expected(20, true);  // All true since we visit everything
+        std::vector<bool> expected = {false, true,  false, true,  false, true,  false,
+                                      true,  false, true,  false, true,  false, true,
+                                      false, true,  false, true,  false, true};
         REQUIRE(sequence == expected);
     }
 }


### PR DESCRIPTION
Revert #2394 (d9679079) and #2369 (feb5e4a5) to restore the original filter->CheckValid() visit condition on v0.18 branch.

These two commits replaced the OR-condition (ShouldSkipFilterCheck || CheckValid) with a single probability gate (ShouldVisit), causing valid neighbors to be skipped and recall to drop in high-filter scenarios.