### PR TITLE
fix(ci): prevent PR lint from being silently skipped on 1.0

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -96,13 +96,27 @@ jobs:
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           git fetch origin ${{ github.base_ref }} --depth=1
-          CHANGED=$(git diff --name-only origin/${{ github.base_ref }}..HEAD -- 'src/**/*.cpp' ':(exclude)src/**/*_test.cpp')
+          if ! CHANGED=$(git diff --name-only origin/${{ github.base_ref }}..HEAD -- 'src/**/*.cpp' ':(exclude)src/**/*_test.cpp'); then
+            echo "Failed to determine changed source files" >&2
+            exit 1
+          fi
           PATTERN=""
           if [ -n "$CHANGED" ]; then
-            PATTERN=$(echo "$CHANGED" | while IFS= read -r f; do
-              escaped=$(printf '%s' "$f" | sed 's/[][.\*^$()+?{|}]/\\&/g')
-              printf '%s$|' "$escaped"
-            done | sed 's/|$//')
+            if ! PATTERN=$(CHANGED="$CHANGED" python3 - <<'PY'
+          import os
+          import re
+
+          changed = os.environ["CHANGED"].splitlines()
+          print("|".join(f"{re.escape(path)}$" for path in changed))
+          PY
+            ); then
+              echo "Failed to build changed-source lint filter" >&2
+              exit 1
+            fi
+            if [ -z "$PATTERN" ]; then
+              echo "Changed source files were found, but the lint filter is empty" >&2
+              exit 1
+            fi
           fi
           echo "pattern=$PATTERN" >> "$GITHUB_OUTPUT"
       - name: Run Lint


### PR DESCRIPTION
## Summary

Backport the changed-source lint detection fix to the `1.0` branch.

## Root cause

The previous `sed` escaping expression was malformed. Its failure was not propagated, leaving the output pattern empty and causing the conditional `Run Lint` step to be skipped.

## Changes

- Use Python `re.escape` to build the changed-file regex safely.
- Fail the job when `git diff` or filter generation fails.
- Fail the job if changed source files exist but the resulting filter is empty.

Validation: YAML parsing, shell syntax, and `git diff --check` passed.

Fixes: #2482