### PR TITLE
[0.16] fix(hgraph): support extra info filter in RangeSearch

### DIFF
--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -524,9 +524,14 @@ HGraph::RangeSearch(const DatasetPtr& query,
                     const std::string& parameters,
                     const FilterPtr& filter,
                     int64_t limited_size) const {
-    std::shared_ptr<InnerIdWrapperFilter> ft = nullptr;
+    auto params = HGraphSearchParameters::FromJson(parameters);
+    FilterPtr ft = nullptr;
     if (filter != nullptr) {
-        ft = std::make_shared<InnerIdWrapperFilter>(filter, *this->label_table_);
+        if (params.use_extra_info_filter && this->extra_infos_ != nullptr) {
+            ft = std::make_shared<ExtraInfoWrapperFilter>(filter, this->extra_infos_);
+        } else {
+            ft = std::make_shared<InnerIdWrapperFilter>(filter, *this->label_table_);
+        }
     }
     int64_t query_dim = query->GetDim();
     if (data_type_ != DataTypes::DATA_TYPE_SPARSE) {
@@ -559,8 +564,6 @@ HGraph::RangeSearch(const DatasetPtr& query,
             raw_query, this->route_graphs_[i], this->basic_flatten_codes_, search_param);
         search_param.ep = result->Top().second;
     }
-
-    auto params = HGraphSearchParameters::FromJson(parameters);
 
     CHECK_ARGUMENT((1 <= params.ef_search) and (params.ef_search <= 1000),  // NOLINT
                    fmt::format("ef_search({}) must in range[1, 1000]", params.ef_search));

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -28,6 +28,19 @@
 
 namespace fixtures {
 
+class RejectExtraInfoFilter : public vsag::Filter {
+public:
+    bool
+    CheckValid(int64_t) const override {
+        return true;
+    }
+
+    bool
+    CheckValid(const char*) const override {
+        return false;
+    }
+};
+
 class HGraphTestResource {
 public:
     std::vector<int> dims;
@@ -1826,6 +1839,16 @@ TestHGraphWithExtraInfo(const fixtures::HGraphTestIndexPtr& test_index,
                 TestIndex::TestKnnSearch(index, dataset, search_param, recall, true);
                 TestIndex::TestKnnSearchIter(index, dataset, search_param, recall, true);
                 TestIndex::TestRangeSearch(index, dataset, search_param, recall, 10, true);
+                auto query = vsag::Dataset::Make();
+                query->NumElements(1)
+                    ->Dim(dim)
+                    ->Float32Vectors(dataset->query_->GetFloat32Vectors())
+                    ->Owner(false);
+                auto filter = std::make_shared<RejectExtraInfoFilter>();
+                auto result = index->RangeSearch(
+                    query, std::numeric_limits<float>::max(), search_ex_filter_param, filter);
+                REQUIRE(result.has_value());
+                REQUIRE(result.value()->GetDim() == 0);
                 TestIndex::TestGetExtraInfoById(index, dataset, extra_info_size);
                 TestIndex::TestKnnSearchExFilter(
                     index, dataset, search_ex_filter_param, recall, true);


### PR DESCRIPTION
### Description

Backport the HGraph RangeSearch extra-info filter fix to the 0.16 branch. When `use_extra_info_filter` is enabled and extra-info storage is available, RangeSearch now wraps the caller filter with `ExtraInfoWrapperFilter` instead of always treating it as an ID filter.

This is the minimal branch-compatible equivalent of the behavior introduced on main by #2139.

### Changes

- Parse HGraph search parameters before constructing the filter wrapper.
- Select `ExtraInfoWrapperFilter` for extra-info filtering and keep `InnerIdWrapperFilter` as the fallback.
- Add a regression case whose ID predicate accepts all records while its extra-info predicate rejects all records.

### Testing

- Added focused regression coverage for the affected HGraph RangeSearch path.
- Ran `clang-format 15.0.7` on the changed C++ files.
- Ran `git diff --check`.
- Build and tests were not run: the current host is macOS, and the requested Linux container/network environment is not ready.

Fixes: #1087