### PR TITLE
feat(ivf): add graph bucket searcher for large bucket approximate search

### DIFF
--- a/examples/cpp/113_index_ivf_graph_bucket.cpp
+++ b/examples/cpp/113_index_ivf_graph_bucket.cpp
@@ -1,0 +1,99 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <vsag/vsag.h>
+
+#include <iostream>
+
+int
+main(int argc, char** argv) {
+    vsag::init();
+
+    /******************* Prepare Base Dataset *****************/
+    int64_t num_vectors = 10000;
+    int64_t dim = 128;
+    std::vector<int64_t> ids(num_vectors);
+    std::vector<float> datas(num_vectors * dim);
+    std::mt19937 rng(47);
+    std::uniform_real_distribution<float> distrib_real;
+    for (int64_t i = 0; i < num_vectors; ++i) {
+        ids[i] = i;
+    }
+    for (int64_t i = 0; i < dim * num_vectors; ++i) {
+        datas[i] = distrib_real(rng);
+    }
+    auto base = vsag::Dataset::Make();
+    base->NumElements(num_vectors)
+        ->Dim(dim)
+        ->Ids(ids.data())
+        ->Float32Vectors(datas.data())
+        ->Owner(false);
+
+    /******************* Create IVF Index with Graph Bucket Searcher *****************/
+    // Enable graph bucket searcher by setting graph_build_threshold > 0
+    // Buckets with size >= threshold will use graph-based approximate search
+    // Buckets with size < threshold will use flat brute-force search
+    std::string ivf_build_params = R"(
+    {
+        "dtype": "float32",
+        "metric_type": "l2",
+        "dim": 128,
+        "index_param": {
+            "buckets_count": 50,
+            "base_quantization_type": "fp32",
+            "partition_strategy_type": "ivf",
+            "ivf_train_type": "kmeans",
+            "train_sample_count": 8000,
+            "graph_build_threshold": 100
+        }
+    }
+    )";
+    auto index = vsag::Factory::CreateIndex("ivf", ivf_build_params).value();
+
+    /******************* Build IVF Index *****************/
+    if (auto build_result = index->Build(base); build_result.has_value()) {
+        std::cout << "After Build(), Index IVF contains: " << index->GetNumElements() << std::endl;
+    } else if (build_result.error().type == vsag::ErrorType::INTERNAL_ERROR) {
+        std::cerr << "Failed to build index: internalError" << std::endl;
+        exit(-1);
+    }
+
+    /******************* Prepare Query Dataset *****************/
+    std::vector<float> query_vector(dim);
+    for (int64_t i = 0; i < dim; ++i) {
+        query_vector[i] = distrib_real(rng);
+    }
+    auto query = vsag::Dataset::Make();
+    query->NumElements(1)->Dim(dim)->Float32Vectors(query_vector.data())->Owner(false);
+
+    /******************* KnnSearch For IVF Index with Graph Search *****************/
+    // ef_search controls the beam search width in graph traversal
+    auto ivf_search_parameters = R"(
+    {
+        "ivf": {
+            "scan_buckets_count": 10,
+            "ef_search": 100
+        }
+    })";
+    int64_t topk = 10;
+    auto result = index->KnnSearch(query, topk, ivf_search_parameters).value();
+
+    /******************* Print Search Result *****************/
+    std::cout << "results: " << std::endl;
+    for (int64_t i = 0; i < result->GetDim(); ++i) {
+        std::cout << result->GetIds()[i] << ": " << result->GetDistances()[i] << std::endl;
+    }
+
+    return 0;
+}

--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -50,6 +50,9 @@ target_link_libraries (111_index_lazy_hgraph vsag)
 add_executable (112_index_pyramid_multi_hierarchy 112_index_pyramid_multi_hierarchy.cpp)
 target_link_libraries (112_index_pyramid_multi_hierarchy vsag)
 
+add_executable (113_index_ivf_graph_bucket 113_index_ivf_graph_bucket.cpp)
+target_link_libraries (113_index_ivf_graph_bucket vsag)
+
 add_executable (201_custom_allocator 201_custom_allocator.cpp)
 target_link_libraries (201_custom_allocator vsag)
 

--- a/src/algorithm/ivf/CMakeLists.txt
+++ b/src/algorithm/ivf/CMakeLists.txt
@@ -19,6 +19,7 @@ set (IVF_SRCS
         ivf_parameter.cpp
         ivf_partition_strategy.cpp
         flat_bucket_searcher.cpp
+        graph_bucket_searcher.cpp
         ivf_partition_strategy_parameter.cpp
         ivf_nearest_partition.cpp
         gno_imi_partition.cpp

--- a/src/algorithm/ivf/graph_bucket_searcher.cpp
+++ b/src/algorithm/ivf/graph_bucket_searcher.cpp
@@ -1,0 +1,227 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "graph_bucket_searcher.h"
+
+#include <limits>
+
+#include "attr/executor/executor.h"
+#include "impl/reasoning/search_reasoning.h"
+#include "impl/searcher/basic_searcher.h"
+
+namespace vsag {
+
+GraphBucketSearcher::GraphBucketSearcher(int64_t graph_build_threshold,
+                                         const Vector<GraphInterfacePtr>& bucket_graphs,
+                                         Allocator* allocator)
+    : graph_build_threshold_(graph_build_threshold),
+      bucket_graphs_(bucket_graphs),
+      allocator_(allocator),
+      flat_searcher_(std::make_shared<FlatBucketSearcher>()) {
+}
+
+void
+GraphBucketSearcher::Search(BucketIdType bucket_id,
+                            const BucketInterfacePtr& bucket,
+                            const ComputerInterfacePtr& computer,
+                            const InnerSearchParam& param,
+                            int64_t thread_id,
+                            int64_t topk,
+                            BucketIdType buckets_per_data,
+                            DistHeapPtr& heap,
+                            Vector<float>& dist,
+                            ReasoningContext* reasoning_ctx) const {
+    auto bucket_size = bucket->GetBucketSize(bucket_id);
+    bool has_graph = (bucket_id < static_cast<BucketIdType>(bucket_graphs_.size()) &&
+                      bucket_graphs_[bucket_id] != nullptr);
+
+    bool graph_fresh = has_graph && bucket_graphs_[bucket_id]->TotalCount() ==
+                                        static_cast<InnerIdType>(bucket_size);
+    if (graph_fresh && bucket_size >= graph_build_threshold_) {
+        search_graph(bucket_id,
+                     bucket,
+                     computer,
+                     param,
+                     thread_id,
+                     topk,
+                     buckets_per_data,
+                     heap,
+                     reasoning_ctx);
+    } else {
+        flat_searcher_->Search(bucket_id,
+                               bucket,
+                               computer,
+                               param,
+                               thread_id,
+                               topk,
+                               buckets_per_data,
+                               heap,
+                               dist,
+                               reasoning_ctx);
+    }
+}
+
+void
+GraphBucketSearcher::search_graph(BucketIdType bucket_id,
+                                  const BucketInterfacePtr& bucket,
+                                  const ComputerInterfacePtr& computer,
+                                  const InnerSearchParam& param,
+                                  int64_t thread_id,
+                                  int64_t topk,
+                                  BucketIdType buckets_per_data,
+                                  DistHeapPtr& heap,
+                                  ReasoningContext* reasoning_ctx) const {
+    auto bucket_size = bucket->GetBucketSize(bucket_id);
+    if (bucket_size == 0) {
+        return;
+    }
+    const auto& graph = bucket_graphs_[bucket_id];
+    const auto* ids = bucket->GetInnerIds(bucket_id);
+
+    uint64_t ef = param.ef;
+    if (param.search_mode == InnerSearchMode::KNN_SEARCH && ef < static_cast<uint64_t>(topk)) {
+        ef = static_cast<uint64_t>(topk);
+    }
+    // Cap ef at bucket_size to avoid full-graph traversal for unlimited RANGE_SEARCH
+    // where the caller sets topk to total index size.
+    if (ef > static_cast<uint64_t>(bucket_size)) {
+        ef = static_cast<uint64_t>(bucket_size);
+    }
+
+    VisitedList vl(bucket_size, allocator_);
+
+    StandardHeap<true, false> top_candidates(allocator_, -1);
+    StandardHeap<true, false> candidate_set(allocator_, -1);
+
+    const auto& ft = param.is_inner_id_allowed;
+    const auto topk_u = static_cast<uint64_t>(topk);
+
+    Filter* attr_ft = nullptr;
+    if (not param.executors.empty() and
+        static_cast<uint64_t>(thread_id) < param.executors.size() and
+        param.executors[thread_id] != nullptr) {
+        param.executors[thread_id]->Clear();
+        attr_ft = param.executors[thread_id]->Run(bucket_id);
+    }
+
+    auto check_func = [&ft, &attr_ft, &ids](InnerIdType local_id, InnerIdType origin_id) {
+        return (ft == nullptr or ft->CheckValid(origin_id)) and
+               (attr_ft == nullptr or attr_ft->CheckValid(local_id));
+    };
+
+    // Find a valid (non-hole) entry point
+    InnerIdType entry = 0;
+    while (entry < static_cast<InnerIdType>(bucket_size) &&
+           ids[entry] == std::numeric_limits<InnerIdType>::max()) {
+        ++entry;
+    }
+    if (entry >= static_cast<InnerIdType>(bucket_size)) {
+        return;  // all entries are holes, fall back
+    }
+    float entry_dist = bucket->QueryOneById(computer, bucket_id, entry);
+    auto origin_entry = ids[entry] / buckets_per_data;
+    if (reasoning_ctx != nullptr) {
+        reasoning_ctx->RecordVisit(origin_entry, entry_dist, 0);
+    }
+    if (check_func(entry, origin_entry)) {
+        top_candidates.Push(entry_dist, entry);
+    } else if (reasoning_ctx != nullptr) {
+        reasoning_ctx->RecordFilterReject(origin_entry);
+    }
+    candidate_set.Push(-entry_dist, entry);
+    vl.Set(entry);
+
+    auto lower_bound = std::numeric_limits<float>::max();
+    if (not top_candidates.Empty()) {
+        lower_bound = top_candidates.Top().first;
+    }
+
+    const auto max_degree = graph->MaximumDegree();
+    Vector<InnerIdType> neighbors(allocator_);
+
+    while (not candidate_set.Empty()) {
+        auto current_node_pair = candidate_set.Top();
+
+        if ((-current_node_pair.first) > lower_bound and top_candidates.Size() >= ef) {
+            break;
+        }
+        candidate_set.Pop();
+
+        const auto neighbor_count = graph->GetNeighborSize(current_node_pair.second);
+        if (neighbor_count > max_degree) {
+            continue;
+        }
+        graph->GetNeighbors(current_node_pair.second, neighbors);
+
+        for (const auto neighbor_id : neighbors) {
+            if (vl.Get(neighbor_id)) {
+                continue;
+            }
+            vl.Set(neighbor_id);
+
+            float d = bucket->QueryOneById(computer, bucket_id, neighbor_id);
+            auto origin_id = ids[neighbor_id] / buckets_per_data;
+            if (reasoning_ctx != nullptr) {
+                reasoning_ctx->RecordVisit(origin_id, d, 1);
+            }
+
+            if (top_candidates.Size() < ef or lower_bound > d or
+                (param.search_mode == RANGE_SEARCH and d <= param.radius + THRESHOLD_ERROR)) {
+                candidate_set.Push(-d, neighbor_id);
+                if (check_func(neighbor_id, origin_id)) {
+                    top_candidates.Push(d, neighbor_id);
+                } else if (reasoning_ctx != nullptr) {
+                    reasoning_ctx->RecordFilterReject(origin_id);
+                }
+                if (param.search_mode == KNN_SEARCH and top_candidates.Size() > ef) {
+                    if (reasoning_ctx != nullptr) {
+                        reasoning_ctx->RecordEviction(
+                            ids[top_candidates.Top().second] / buckets_per_data, 1);
+                    }
+                    top_candidates.Pop();
+                }
+                if (not top_candidates.Empty()) {
+                    lower_bound = top_candidates.Top().first;
+                }
+            }
+        }
+    }
+
+    if (param.search_mode == KNN_SEARCH) {
+        while (top_candidates.Size() > topk_u) {
+            top_candidates.Pop();
+        }
+    } else {
+        while (not top_candidates.Empty() and
+               top_candidates.Top().first > param.radius + THRESHOLD_ERROR) {
+            top_candidates.Pop();
+        }
+        if (topk_u > 0) {
+            while (top_candidates.Size() > topk_u) {
+                top_candidates.Pop();
+            }
+        }
+    }
+
+    while (not top_candidates.Empty()) {
+        auto [d, local_id] = top_candidates.Top();
+        heap->Push(d, ids[local_id]);
+        top_candidates.Pop();
+    }
+    while (heap->Size() > topk_u) {
+        heap->Pop();
+    }
+}
+
+}  // namespace vsag

--- a/src/algorithm/ivf/graph_bucket_searcher.h
+++ b/src/algorithm/ivf/graph_bucket_searcher.h
@@ -1,0 +1,67 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+
+#include "container_types.h"
+#include "datacell/graph_interface.h"
+#include "flat_bucket_searcher.h"
+#include "impl/heap/distance_heap.h"
+#include "impl/heap/standard_heap.h"
+#include "ivf_bucket_searcher.h"
+#include "typing.h"
+#include "utils/visited_list.h"
+
+namespace vsag {
+
+class GraphBucketSearcher : public IVFBucketSearcher {
+public:
+    GraphBucketSearcher(int64_t graph_build_threshold,
+                        const Vector<GraphInterfacePtr>& bucket_graphs,
+                        Allocator* allocator);
+
+    void
+    Search(BucketIdType bucket_id,
+           const BucketInterfacePtr& bucket,
+           const ComputerInterfacePtr& computer,
+           const InnerSearchParam& param,
+           int64_t thread_id,
+           int64_t topk,
+           BucketIdType buckets_per_data,
+           DistHeapPtr& heap,
+           Vector<float>& dist,
+           ReasoningContext* reasoning_ctx) const override;
+
+private:
+    void
+    search_graph(BucketIdType bucket_id,
+                 const BucketInterfacePtr& bucket,
+                 const ComputerInterfacePtr& computer,
+                 const InnerSearchParam& param,
+                 int64_t thread_id,
+                 int64_t topk,
+                 BucketIdType buckets_per_data,
+                 DistHeapPtr& heap,
+                 ReasoningContext* reasoning_ctx) const;
+
+    int64_t graph_build_threshold_;
+    // Owned by IVF and must outlive this searcher.
+    const Vector<GraphInterfacePtr>& bucket_graphs_;
+    Allocator* allocator_;
+    std::shared_ptr<FlatBucketSearcher> flat_searcher_;
+};
+
+}  // namespace vsag

--- a/src/algorithm/ivf/ivf.cpp
+++ b/src/algorithm/ivf/ivf.cpp
@@ -25,8 +25,11 @@
 #include "attr/argparse.h"
 #include "attr/executor/executor.h"
 #include "datacell/flatten_interface.h"
+#include "datacell/graph_datacell_parameter.h"
+#include "datacell/graph_interface_parameter.h"
 #include "flat_bucket_searcher.h"
 #include "gno_imi_partition.h"
+#include "graph_bucket_searcher.h"
 #include "impl/heap/standard_heap.h"
 #include "impl/inner_search_param.h"
 #include "impl/reasoning/search_reasoning.h"
@@ -44,6 +47,7 @@
 #include "storage/stream_writer.h"
 #include "storage/tlv_section.h"
 #include "utils/util_functions.h"
+#include "utils/visited_list.h"
 #include "vsag_exception.h"
 
 namespace vsag {
@@ -104,7 +108,8 @@ static constexpr const char* IVF_PARAMS_TEMPLATE =
         },
         "{ATTR_PARAMS_KEY}": {
             "{ATTR_HAS_BUCKETS_KEY}": true
-        }
+        },
+        "{GRAPH_BUILD_THRESHOLD_KEY}": 0
     })";
 
 ParamPtr
@@ -321,6 +326,12 @@ IVF::CheckAndMappingExternalParam(const JsonType& external_param,
                 TRAIN_SAMPLE_COUNT_KEY,
             },
         },
+        {
+            GRAPH_BUILD_THRESHOLD_KEY,
+            {
+                GRAPH_BUILD_THRESHOLD_KEY,
+            },
+        },
     };
 
     if (common_param.data_type_ == DataTypes::DATA_TYPE_INT8) {
@@ -342,6 +353,8 @@ IVF::IVF(const IVFParameterPtr& param, const IndexCommonParam& common_param)
     : InnerIndexInterface(param, common_param),
       buckets_per_data_(param->buckets_per_data),
       location_map_(common_param.allocator_.get()),
+      bucket_graphs_(common_param.allocator_.get()),
+      common_param_(common_param),
       bucket_searcher_(std::make_shared<FlatBucketSearcher>()) {
     this->bucket_ = BucketInterface::MakeInstance(param->bucket_param, common_param);
     if (this->bucket_ == nullptr) {
@@ -368,6 +381,13 @@ IVF::IVF(const IVFParameterPtr& param, const IndexCommonParam& common_param)
     if (param->build_thread_count > 1 and this->thread_pool_ == nullptr) {
         this->thread_pool_ = SafeThreadPool::FactoryDefaultThreadPool();
         this->thread_pool_->SetPoolSize(param->build_thread_count);
+    }
+
+    this->graph_param_ = param->graph_param;
+    this->graph_build_threshold_ = param->graph_build_threshold;
+    if (this->graph_build_threshold_ > 0) {
+        this->bucket_searcher_ = std::make_shared<GraphBucketSearcher>(
+            this->graph_build_threshold_, this->bucket_graphs_, this->allocator_);
     }
 
     if (bucket_->GetQuantizerName() == QUANTIZATION_TYPE_VALUE_FP32) {
@@ -447,9 +467,17 @@ IVF::InitFeatures() {
 
 std::vector<int64_t>
 IVF::Build(const DatasetPtr& base) {
+    if (graph_build_threshold_ > 0) {
+        CHECK_ARGUMENT(this->total_elements_ == 0,
+                       "graph bucket searcher requires a fresh Build with no prior data");
+    }
     this->Train(base);
     // TODO(LHT): duplicate
     auto result = this->Add(base);
+    if (graph_build_threshold_ > 0) {
+        this->build_bucket_graphs(base);
+    }
+    this->cal_memory_usage();
     return result;
 }
 
@@ -556,6 +584,256 @@ IVF::Add(const DatasetPtr& base) {
     return {};
 }
 
+static const void*
+get_ivf_graph_build_data(const DatasetPtr& dataset,
+                         DataTypes data_type,
+                         uint64_t index,
+                         uint64_t dim) {
+    if (data_type == DataTypes::DATA_TYPE_FLOAT) {
+        const auto* ptr = dataset->GetFloat32Vectors();
+        return ptr != nullptr ? ptr + index * dim : nullptr;
+    }
+    if (data_type == DataTypes::DATA_TYPE_INT8) {
+        const auto* ptr = dataset->GetInt8Vectors();
+        return ptr != nullptr ? ptr + index * dim : nullptr;
+    }
+    if (data_type == DataTypes::DATA_TYPE_FP16 || data_type == DataTypes::DATA_TYPE_BF16) {
+        const auto* ptr = dataset->GetFloat16Vectors();
+        return ptr != nullptr ? ptr + index * dim : nullptr;
+    }
+    if (data_type == DataTypes::DATA_TYPE_SPARSE) {
+        const auto* ptr = dataset->GetSparseVectors();
+        return ptr != nullptr ? ptr + index : nullptr;
+    }
+    throw VsagException(ErrorType::INVALID_ARGUMENT, "invalid data type for IVF graph build");
+}
+
+static GraphInterfaceParamPtr
+get_ivf_graph_param(const std::string& graph_param_string) {
+    auto graph_json = JsonType::Parse(graph_param_string);
+    if (!graph_json.Contains(IO_PARAMS_KEY) || !graph_json.Contains(GRAPH_STORAGE_TYPE_KEY) ||
+        graph_json[GRAPH_STORAGE_TYPE_KEY].GetString() != GRAPH_STORAGE_TYPE_VALUE_FLAT) {
+        throw VsagException(ErrorType::INVALID_BINARY,
+                            "bucket graph requires flat storage with memory-backed IO");
+    }
+
+    auto param = std::dynamic_pointer_cast<GraphDataCellParameter>(
+        GraphInterfaceParameter::GetGraphParameterByJson(
+            GraphStorageTypes::GRAPH_STORAGE_TYPE_VALUE_FLAT, graph_json));
+    if (param == nullptr || param->io_parameter_ == nullptr || param->support_remove_) {
+        throw VsagException(ErrorType::INVALID_BINARY, "invalid bucket graph parameters");
+    }
+
+    const auto io_type = param->io_parameter_->GetTypeName();
+    if (io_type != IO_TYPE_VALUE_MEMORY_IO && io_type != IO_TYPE_VALUE_BLOCK_MEMORY_IO) {
+        throw VsagException(ErrorType::INVALID_BINARY,
+                            fmt::format("unsupported bucket graph IO type: {}", io_type));
+    }
+    return param;
+}
+
+static JsonType
+serialize_ivf_graph_param(const GraphInterfaceParamPtr& graph_param) {
+    auto graph_json = graph_param->ToJson();
+    graph_json[GRAPH_STORAGE_TYPE_KEY].SetString(GRAPH_STORAGE_TYPE_VALUE_FLAT);
+    return graph_json;
+}
+
+static bool
+has_any_fresh_bucket_graph(const BucketInterfacePtr& bucket,
+                           const Vector<GraphInterfacePtr>& bucket_graphs) {
+    for (BucketIdType b = 0; b < static_cast<BucketIdType>(bucket_graphs.size()); ++b) {
+        if (bucket_graphs[b] != nullptr &&
+            bucket_graphs[b]->TotalCount() == bucket->GetBucketSize(b)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void
+IVF::build_bucket_graphs(const DatasetPtr& base) {
+    if (graph_build_threshold_ <= 0) {
+        return;
+    }
+    if (common_param_.data_type_ != DataTypes::DATA_TYPE_FLOAT) {
+        return;
+    }
+    if (graph_param_ == nullptr) {
+        graph_param_ = std::make_shared<GraphDataCellParameter>();
+    }
+
+    constexpr int64_t max_degree = 64;
+    constexpr uint64_t ef_construction = 300;
+    const auto bucket_count = bucket_->bucket_count_;
+    bucket_graphs_.resize(bucket_count);
+
+    for (BucketIdType b = 0; b < bucket_count; ++b) {
+        const auto bucket_size = bucket_->GetBucketSize(b);
+        if (bucket_size < graph_build_threshold_) {
+            continue;
+        }
+
+        const auto* inner_ids = bucket_->GetInnerIds(b);
+        Vector<InnerIdType> valid_ids(allocator_);
+        valid_ids.reserve(bucket_size);
+        for (InnerIdType i = 0; i < static_cast<InnerIdType>(bucket_size); ++i) {
+            if (inner_ids[i] != std::numeric_limits<InnerIdType>::max()) {
+                valid_ids.push_back(i);
+            }
+        }
+        if (valid_ids.size() < static_cast<uint64_t>(graph_build_threshold_)) {
+            continue;
+        }
+
+        const auto effective_degree =
+            std::min(max_degree, static_cast<int64_t>(valid_ids.size()) - 1);
+        if (effective_degree <= 0) {
+            continue;
+        }
+
+        auto graph = GraphInterface::MakeInstance(graph_param_, this->common_param_);
+        graph->Resize(bucket_size);
+        graph->SetTotalCount(bucket_size);
+        graph->SetMaximumDegree(static_cast<uint32_t>(effective_degree));
+
+        auto make_computer = [&](InnerIdType local_id) {
+            const auto orig_idx = static_cast<uint64_t>(inner_ids[local_id]) / buckets_per_data_;
+            const auto* query =
+                get_ivf_graph_build_data(base, common_param_.data_type_, orig_idx, this->dim_);
+            CHECK_ARGUMENT(query != nullptr, "base dataset has no graph build vector data");
+            return bucket_->FactoryComputer(query);
+        };
+
+        // Adapted from HGraph select_edges_by_heuristic: retain close, diverse edges.
+        auto select_edges_by_heuristic = [&](InnerIdType source, Vector<InnerIdType>& neighbors) {
+            auto source_computer = make_computer(source);
+            Vector<std::pair<float, InnerIdType>> candidates(allocator_);
+            candidates.reserve(neighbors.size());
+            for (const auto neighbor : neighbors) {
+                if (neighbor == source || neighbor >= bucket_size ||
+                    inner_ids[neighbor] == std::numeric_limits<InnerIdType>::max()) {
+                    continue;
+                }
+                bool duplicate = false;
+                for (const auto& candidate : candidates) {
+                    if (candidate.second == neighbor) {
+                        duplicate = true;
+                        break;
+                    }
+                }
+                if (!duplicate) {
+                    candidates.emplace_back(bucket_->QueryOneById(source_computer, b, neighbor),
+                                            neighbor);
+                }
+            }
+            std::sort(candidates.begin(), candidates.end(), [](const auto& lhs, const auto& rhs) {
+                return lhs.first < rhs.first;
+            });
+
+            neighbors.clear();
+            Vector<ComputerInterfacePtr> selected_computers(allocator_);
+            for (const auto& candidate : candidates) {
+                bool good = true;
+                for (const auto& selected_comp : selected_computers) {
+                    const auto pair_distance =
+                        bucket_->QueryOneById(selected_comp, b, candidate.second);
+                    if (pair_distance < candidate.first) {
+                        good = false;
+                        break;
+                    }
+                }
+                if (good) {
+                    neighbors.push_back(candidate.second);
+                    selected_computers.push_back(make_computer(candidate.second));
+                    if (neighbors.size() == static_cast<uint64_t>(effective_degree)) {
+                        break;
+                    }
+                }
+            }
+        };
+
+        const auto entry = valid_ids.front();
+        graph->InsertNeighborsById(entry, Vector<InnerIdType>(allocator_));
+        VisitedList visited(bucket_size, allocator_);
+        Vector<InnerIdType> graph_neighbors(effective_degree, allocator_);
+
+        for (uint64_t node_pos = 1; node_pos < valid_ids.size(); ++node_pos) {
+            const auto node = valid_ids[node_pos];
+            auto computer = make_computer(node);
+            const auto entry_dist = bucket_->QueryOneById(computer, b, entry);
+            const auto ef = std::min(ef_construction, node_pos);
+
+            visited.Reset();
+            StandardHeap<true, false> top_candidates(allocator_, -1);
+            StandardHeap<true, false> candidate_set(allocator_, -1);
+            top_candidates.Push(entry_dist, entry);
+            candidate_set.Push(-entry_dist, entry);
+            visited.Set(entry);
+            auto lower_bound = entry_dist;
+
+            while (not candidate_set.Empty()) {
+                const auto current = candidate_set.Top();
+                if (-current.first > lower_bound && top_candidates.Size() >= ef) {
+                    break;
+                }
+                candidate_set.Pop();
+
+                graph->GetNeighbors(current.second, graph_neighbors);
+                const auto neighbor_count = graph->GetNeighborSize(current.second);
+                for (uint32_t i = 0; i < neighbor_count; ++i) {
+                    const auto neighbor = graph_neighbors[i];
+                    if (neighbor >= bucket_size || visited.Get(neighbor) ||
+                        inner_ids[neighbor] == std::numeric_limits<InnerIdType>::max()) {
+                        continue;
+                    }
+                    visited.Set(neighbor);
+                    const auto distance = bucket_->QueryOneById(computer, b, neighbor);
+                    if (top_candidates.Size() < ef || distance < lower_bound) {
+                        candidate_set.Push(-distance, neighbor);
+                        top_candidates.Push(distance, neighbor);
+                        if (top_candidates.Size() > ef) {
+                            top_candidates.Pop();
+                        }
+                        lower_bound = top_candidates.Top().first;
+                    }
+                }
+            }
+
+            Vector<std::pair<float, InnerIdType>> candidates(allocator_);
+            candidates.reserve(top_candidates.Size());
+            for (uint64_t i = 0; i < top_candidates.Size(); ++i) {
+                candidates.push_back(top_candidates.GetData()[i]);
+            }
+            std::sort(candidates.begin(), candidates.end(), [](const auto& lhs, const auto& rhs) {
+                return lhs.first < rhs.first;
+            });
+
+            // Adapted from HGraph mutually_connect_new_element.
+            Vector<InnerIdType> node_neighbors(allocator_);
+            node_neighbors.reserve(candidates.size());
+            for (const auto& candidate : candidates) {
+                node_neighbors.push_back(candidate.second);
+            }
+            select_edges_by_heuristic(node, node_neighbors);
+            graph->InsertNeighborsById(node, node_neighbors);
+
+            for (const auto neighbor : node_neighbors) {
+                Vector<InnerIdType> reciprocal(allocator_);
+                graph->GetNeighbors(neighbor, reciprocal);
+                if (reciprocal.size() < static_cast<uint64_t>(effective_degree)) {
+                    reciprocal.push_back(node);
+                } else {
+                    reciprocal.push_back(node);
+                    select_edges_by_heuristic(neighbor, reciprocal);
+                }
+                graph->InsertNeighborsById(neighbor, reciprocal);
+            }
+        }
+
+        bucket_graphs_[b] = std::move(graph);
+    }
+}
 DatasetPtr
 IVF::KnnSearch(const DatasetPtr& query,
                int64_t k,
@@ -665,6 +943,32 @@ IVF::Serialize(StreamWriter& writer) const {
         WRITE_DATACELL_WITH_NAME(writer, "attr_filter_index", attr_filter_index_);
     }
 
+    if (graph_build_threshold_ > 0 && graph_param_ != nullptr &&
+        has_any_fresh_bucket_graph(bucket_, bucket_graphs_)) {
+        datacell_offsets["bucket_graphs"].SetInt(offset);
+        auto bucket_graphs_start = writer.GetCursor();
+        StreamWriter::WriteObj(writer, graph_build_threshold_);
+        StreamWriter::WriteString(writer, serialize_ivf_graph_param(graph_param_).Dump());
+        int64_t graph_count = 0;
+        for (BucketIdType b = 0; b < static_cast<BucketIdType>(bucket_graphs_.size()); ++b) {
+            if (bucket_graphs_[b] != nullptr &&
+                bucket_graphs_[b]->TotalCount() == bucket_->GetBucketSize(b)) {
+                ++graph_count;
+            }
+        }
+        StreamWriter::WriteObj(writer, graph_count);
+        for (BucketIdType b = 0; b < static_cast<BucketIdType>(bucket_graphs_.size()); ++b) {
+            if (bucket_graphs_[b] != nullptr &&
+                bucket_graphs_[b]->TotalCount() == bucket_->GetBucketSize(b)) {
+                StreamWriter::WriteObj(writer, b);
+                bucket_graphs_[b]->Serialize(writer);
+            }
+        }
+        auto bucket_graphs_size = writer.GetCursor() - bucket_graphs_start;
+        datacell_sizes["bucket_graphs"].SetInt(bucket_graphs_size);
+        offset += bucket_graphs_size;
+    }
+
     // serialize footer (introduced since v0.15)
     JsonType basic_info;
     basic_info["total_elements"].SetInt(this->total_elements_);
@@ -732,6 +1036,14 @@ IVF::collect_streaming_header() const {
                                      StreamSerializationBlockCurrentVersion(tag),
                                      StreamSerializationTagCritical(tag));
     }
+    if (graph_build_threshold_ > 0 && graph_param_ != nullptr &&
+        has_any_fresh_bucket_graph(bucket_, bucket_graphs_)) {
+        auto tag = static_cast<uint32_t>(StreamSerializationTag::IVF_BUCKET_GRAPH);
+        AppendStreamingManifestBlock(manifest,
+                                     tag,
+                                     StreamSerializationBlockCurrentVersion(tag),
+                                     StreamSerializationTagCritical(tag));
+    }
     metadata->Set("block_manifest", manifest);
     metadata->SetEmptyIndex(this->GetNumElements() == 0);
     return metadata;
@@ -767,6 +1079,27 @@ IVF::serialize_streaming_body(StreamWriter& writer) const {
         WriteStreamingBlock(
             writer, tag, StreamSerializationTagCritical(tag), [this](StreamWriter& w) {
                 this->attr_filter_index_->Serialize(w);
+            });
+    }
+    if (graph_build_threshold_ > 0 && graph_param_ != nullptr &&
+        has_any_fresh_bucket_graph(bucket_, bucket_graphs_)) {
+        auto tag = static_cast<uint32_t>(StreamSerializationTag::IVF_BUCKET_GRAPH);
+        WriteStreamingBlock(
+            writer, tag, StreamSerializationTagCritical(tag), [this](StreamWriter& w) {
+                StreamWriter::WriteObj(w, graph_build_threshold_);
+                StreamWriter::WriteString(w, serialize_ivf_graph_param(graph_param_).Dump());
+                auto graph_count = static_cast<uint64_t>(bucket_graphs_.size());
+                StreamWriter::WriteObj(w, graph_count);
+                for (uint64_t i = 0; i < graph_count; ++i) {
+                    bool has_graph = (bucket_graphs_[i] != nullptr &&
+                                      bucket_graphs_[i]->TotalCount() ==
+                                          bucket_->GetBucketSize(static_cast<BucketIdType>(i)));
+                    StreamWriter::WriteObj(w, has_graph);
+                    if (has_graph) {
+                        StreamWriter::WriteObj(w, static_cast<BucketIdType>(i));
+                        bucket_graphs_[i]->Serialize(w);
+                    }
+                }
             });
     }
 }
@@ -868,6 +1201,66 @@ IVF::read_streaming_body(StreamReader& reader, const MetadataPtr& metadata) {
                     this->has_attribute_ = true;
                 }
                 break;
+            case StreamSerializationTag::IVF_BUCKET_GRAPH: {
+                ReadSeekableBlockPayload(block_reader, block_header, [this](StreamReader& block) {
+                    StreamReader::ReadObj(block, this->graph_build_threshold_);
+                    this->graph_param_ = get_ivf_graph_param(StreamReader::ReadString(block));
+                    uint64_t graph_count = 0;
+                    StreamReader::ReadObj(block, graph_count);
+                    auto bucket_count = this->bucket_->bucket_count_;
+                    if (graph_count > static_cast<uint64_t>(bucket_count)) {
+                        throw VsagException(
+                            ErrorType::INVALID_BINARY,
+                            fmt::format("bucket graph_count {} exceeds bucket_count {}",
+                                        graph_count,
+                                        bucket_count));
+                    }
+                    this->bucket_graphs_.resize(bucket_count);
+                    for (uint64_t i = 0; i < graph_count; ++i) {
+                        bool has_graph = false;
+                        StreamReader::ReadObj(block, has_graph);
+                        if (has_graph) {
+                            BucketIdType bid = 0;
+                            StreamReader::ReadObj(block, bid);
+                            auto graph = GraphInterface::MakeInstance(this->graph_param_,
+                                                                      this->common_param_);
+                            graph->Deserialize(block);
+                            if (bid >= 0 && bid < static_cast<BucketIdType>(bucket_count)) {
+                                const auto total = graph->TotalCount();
+                                const auto expected_total = bucket_->GetBucketSize(bid);
+                                if (total != expected_total || total > graph->MaxCapacity()) {
+                                    throw VsagException(
+                                        ErrorType::INVALID_BINARY,
+                                        "corrupt bucket graph: invalid total count");
+                                }
+                                for (InnerIdType nid = 0; nid < total; ++nid) {
+                                    if (graph->GetNeighborSize(nid) > graph->MaximumDegree()) {
+                                        throw VsagException(ErrorType::INVALID_BINARY,
+                                                            "corrupt bucket graph: neighbor count "
+                                                            "exceeds maximum degree");
+                                    }
+                                    Vector<InnerIdType> nbrs(this->allocator_);
+                                    graph->GetNeighbors(nid, nbrs);
+                                    for (auto nb : nbrs) {
+                                        if (nb >= total) {
+                                            throw VsagException(
+                                                ErrorType::INVALID_BINARY,
+                                                "corrupt bucket graph: neighbor ID out of range");
+                                        }
+                                    }
+                                }
+                                this->bucket_graphs_[bid] = std::move(graph);
+                            }
+                        }
+                    }
+                });
+                if (graph_build_threshold_ > 0 && this->bucket_searcher_ != nullptr) {
+                    // Replace flat searcher with graph searcher now that graphs are loaded.
+                    this->bucket_searcher_ = std::make_shared<GraphBucketSearcher>(
+                        graph_build_threshold_, bucket_graphs_, allocator_);
+                }
+                break;
+            }
             default:
                 if (block_header.IsCritical()) {
                     throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
@@ -978,6 +1371,57 @@ IVF::Deserialize(StreamReader& reader) {
         if (this->bucket_->GetQuantizerName() == QUANTIZATION_TYPE_VALUE_FP32) {
             this->has_raw_vector_ = true;
         }
+
+        if (datacell_offsets.Contains("bucket_graphs")) {
+            auto bucket_count = bucket_->bucket_count_;
+            bucket_graphs_.resize(bucket_count);
+            buffer_reader.PushSeek(datacell_offsets["bucket_graphs"].GetInt());
+            auto graph_reader = buffer_reader.Slice(datacell_sizes["bucket_graphs"].GetInt());
+            int64_t stored_threshold = 0;
+            StreamReader::ReadObj(graph_reader, stored_threshold);
+            graph_build_threshold_ = stored_threshold;
+            graph_param_ = get_ivf_graph_param(StreamReader::ReadString(graph_reader));
+            int64_t graph_count = 0;
+            StreamReader::ReadObj(graph_reader, graph_count);
+            CHECK_ARGUMENT(graph_count >= 0, "bucket graph_count is negative");
+            CHECK_ARGUMENT(graph_count <= bucket_count, "bucket graph_count exceeds bucket_count");
+            for (int64_t g = 0; g < graph_count; ++g) {
+                BucketIdType bid = 0;
+                StreamReader::ReadObj(graph_reader, bid);
+                auto graph = GraphInterface::MakeInstance(graph_param_, this->common_param_);
+                graph->Deserialize(graph_reader);
+                if (bid >= 0 && bid < bucket_count) {
+                    const auto total = graph->TotalCount();
+                    const auto expected_total = bucket_->GetBucketSize(bid);
+                    if (total != expected_total || total > graph->MaxCapacity()) {
+                        throw VsagException(ErrorType::INVALID_BINARY,
+                                            "corrupt bucket graph: invalid total count");
+                    }
+                    for (InnerIdType nid = 0; nid < total; ++nid) {
+                        if (graph->GetNeighborSize(nid) > graph->MaximumDegree()) {
+                            throw VsagException(
+                                ErrorType::INVALID_BINARY,
+                                "corrupt bucket graph: neighbor count exceeds maximum degree");
+                        }
+                        Vector<InnerIdType> nbrs(allocator_);
+                        graph->GetNeighbors(nid, nbrs);
+                        for (auto nb : nbrs) {
+                            if (nb >= total) {
+                                throw VsagException(
+                                    ErrorType::INVALID_BINARY,
+                                    "corrupt bucket graph: neighbor ID out of range");
+                            }
+                        }
+                    }
+                    bucket_graphs_[bid] = std::move(graph);
+                }
+            }
+            buffer_reader.PopSeek();
+            if (graph_build_threshold_ > 0) {
+                this->bucket_searcher_ = std::make_shared<GraphBucketSearcher>(
+                    graph_build_threshold_, bucket_graphs_, allocator_);
+            }
+        }
     }
     this->fill_location_map();
     this->cal_memory_usage();
@@ -999,6 +1443,7 @@ IVF::create_search_param(const std::string& parameters, const FilterPtr& filter)
     param.enable_reorder = search_param.enable_reorder;
     param.first_order_scan_ratio = search_param.first_order_scan_ratio;
     param.parallel_search_thread_count = search_param.parallel_search_thread_count;
+    param.ef = static_cast<uint64_t>(search_param.ef_search);
     if (search_param.enable_time_record) {
         param.time_cost = std::make_shared<Timer>();
         param.time_cost->SetThreshold(search_param.timeout_ms);
@@ -1190,6 +1635,12 @@ IVF::search(const DatasetPtr& query,
             auto size = heap->Size();
             const auto* data = heap->GetData();
             for (int i = 0; i < size; ++i) {
+                if (reasoning_ctx != nullptr and
+                    search_result->Size() >= static_cast<uint64_t>(topk) and
+                    data[i].first < search_result->Top().first) {
+                    reasoning_ctx->RecordEviction(search_result->Top().second / buckets_per_data_,
+                                                  1);
+                }
                 search_result->Push(data[i]);
             }
         }
@@ -1254,12 +1705,11 @@ IVF::check_merge_illegal(const vsag::MergeUnit& unit) const {
     auto other_ivf_index = std::dynamic_pointer_cast<IVF>(
         std::dynamic_pointer_cast<IndexImpl<IVF>>(unit.index)->GetInnerIndex());
     if (other_ivf_index->use_reorder_ != this->use_reorder_) {
-        throw VsagException(
-            ErrorType::INVALID_ARGUMENT,
-            fmt::format(
-                "Merge Failed: ivf use_reorder not match, current index is {}, other index is {}",
-                this->use_reorder_,
-                other_ivf_index->use_reorder_));
+        throw VsagException(ErrorType::INVALID_ARGUMENT,
+                            fmt::format("Merge Failed: ivf use_reorder not match, current "
+                                        "index is {}, other index is {}",
+                                        this->use_reorder_,
+                                        other_ivf_index->use_reorder_));
     }
     auto cur_model = this->ExportModel(index->GetCommonParam());
     std::stringstream ss1;
@@ -1647,6 +2097,11 @@ IVF::cal_memory_usage() {
     memory += this->label_table_->GetMemoryUsage();
     memory += location_map_.size() * sizeof(uint64_t);
     memory += partition_strategy_->GetMemoryUsage();
+    for (auto& g : bucket_graphs_) {
+        if (g != nullptr) {
+            memory += g->GetMemoryUsage();
+        }
+    }
     std::unique_lock lock(this->memory_usage_mutex_);
     this->current_memory_usage_.store(memory);
 }

--- a/src/algorithm/ivf/ivf.h
+++ b/src/algorithm/ivf/ivf.h
@@ -19,6 +19,8 @@
 #include "datacell/attribute_bucket_inverted_datacell.h"
 #include "datacell/bucket_datacell.h"
 #include "datacell/flatten_interface.h"
+#include "datacell/graph_interface.h"
+#include "datacell/graph_interface_parameter.h"
 #include "impl/heap/distance_heap.h"
 #include "impl/reorder/reorder.h"
 #include "impl/searcher/basic_searcher.h"
@@ -226,6 +228,9 @@ private:
     void
     fill_location_map();
 
+    void
+    build_bucket_graphs(const DatasetPtr& base);
+
     /**
      * @brief Decode the packed (bucket_id, local_inner_id) pair from
      *        location_map_[inner_id].
@@ -257,6 +262,10 @@ private:
 private:
     BucketInterfacePtr bucket_{nullptr};  // bucket storage (raw or attribute-aware)
     IVFBucketSearcherPtr bucket_searcher_{nullptr};
+    Vector<GraphInterfacePtr> bucket_graphs_;
+    GraphInterfaceParamPtr graph_param_{nullptr};
+    int64_t graph_build_threshold_{0};
+    IndexCommonParam common_param_;
 
     IVFPartitionStrategyPtr partition_strategy_{nullptr};  // centroid / partition logic
     BucketIdType buckets_per_data_;                        // buckets each vector is assigned to

--- a/src/algorithm/ivf/ivf_parameter.cpp
+++ b/src/algorithm/ivf/ivf_parameter.cpp
@@ -48,6 +48,26 @@ IVFParameter::FromJson(const JsonType& json) {
             this->ivf_partition_strategy_parameter->gnoimi_param->first_order_buckets_count *
             this->ivf_partition_strategy_parameter->gnoimi_param->second_order_buckets_count);
     }
+
+    if (json.Contains(GRAPH_BUILD_THRESHOLD_KEY)) {
+        this->graph_build_threshold = json[GRAPH_BUILD_THRESHOLD_KEY].GetInt();
+        if (this->graph_build_threshold < 0) {
+            throw VsagException(ErrorType::INVALID_ARGUMENT,
+                                fmt::format("graph_build_threshold must be non-negative, got {}",
+                                            this->graph_build_threshold));
+        }
+        if (this->graph_build_threshold > 0) {
+            auto graph_json = JsonType::Parse(R"({
+                "io_params": {"type": "memory_io"},
+                "graph_storage_type": "flat",
+                "max_degree": 64,
+                "init_capacity": 100,
+                "support_remove": false
+            })");
+            this->graph_param = GraphInterfaceParameter::GetGraphParameterByJson(
+                GraphStorageTypes::GRAPH_STORAGE_TYPE_VALUE_FLAT, graph_json);
+        }
+    }
 }
 
 JsonType
@@ -58,6 +78,7 @@ IVFParameter::ToJson() const {
     json[IVF_PARTITION_STRATEGY_PARAMS_KEY].SetJson(
         this->ivf_partition_strategy_parameter->ToJson());
     json[BUCKET_PER_DATA_KEY].SetInt(this->buckets_per_data);
+    json[GRAPH_BUILD_THRESHOLD_KEY].SetInt(this->graph_build_threshold);
     return json;
 }
 bool
@@ -67,8 +88,12 @@ IVFParameter::CheckCompatibility(const ParamPtr& other) const {
     }
     PARAM_CAST_OR_RETURN(IVFParameter, p, other);
     CHECK_FIELD_EQ(*this, *p, buckets_per_data);
+    CHECK_FIELD_EQ(*this, *p, graph_build_threshold);
     CHECK_SUB_PARAM(*this, *p, bucket_param);
     CHECK_SUB_PARAM(*this, *p, ivf_partition_strategy_parameter);
+    if (this->graph_build_threshold > 0) {
+        CHECK_SUB_PARAM(*this, *p, graph_param);
+    }
     return true;
 }
 
@@ -99,6 +124,13 @@ IVFSearchParameters::FromJson(const std::string& json_string) {
     if (params[INDEX_TYPE_IVF].Contains(GNO_IMI_SEARCH_PARAM_FIRST_ORDER_SCAN_RATIO)) {
         obj.first_order_scan_ratio =
             params[INDEX_TYPE_IVF][GNO_IMI_SEARCH_PARAM_FIRST_ORDER_SCAN_RATIO].GetFloat();
+    }
+
+    if (params[INDEX_TYPE_IVF].Contains(IVF_SEARCH_PARAM_EF_SEARCH)) {
+        auto ef_val = params[INDEX_TYPE_IVF][IVF_SEARCH_PARAM_EF_SEARCH].GetInt();
+        if (ef_val > 0) {
+            obj.ef_search = ef_val;
+        }
     }
 
     return obj;

--- a/src/algorithm/ivf/ivf_parameter.h
+++ b/src/algorithm/ivf/ivf_parameter.h
@@ -20,6 +20,7 @@
 #include "algorithm/inner_index_parameter.h"
 #include "datacell/bucket_datacell_parameter.h"
 #include "datacell/flatten_datacell_parameter.h"
+#include "datacell/graph_interface_parameter.h"
 #include "inner_string_params.h"
 #include "ivf_nearest_partition.h"
 #include "ivf_partition_strategy_parameter.h"
@@ -47,6 +48,8 @@ public:
     IVFPartitionStrategyParametersPtr ivf_partition_strategy_parameter{nullptr};
     BucketIdType buckets_per_data{1};
     int64_t train_sample_count{65536L};
+    GraphInterfaceParamPtr graph_param{nullptr};
+    int64_t graph_build_threshold{0};
 };
 
 class IVFSearchParameters : public IndexSearchParameter {
@@ -58,6 +61,7 @@ public:
     int64_t scan_buckets_count{30};
     bool disable_bucket_scan{false};
     float first_order_scan_ratio{1.0F};
+    int64_t ef_search{100};
 
 private:
     IVFSearchParameters() {

--- a/src/datacell/compressed_graph_datacell.cpp
+++ b/src/datacell/compressed_graph_datacell.cpp
@@ -120,6 +120,10 @@ CompressedGraphDataCell::Deserialize(StreamReader& reader) {
     GraphInterface::Deserialize(reader);
     uint64_t vertex_num;
     StreamReader::ReadObj(reader, vertex_num);
+    if (vertex_num < this->TotalCount()) {
+        throw VsagException(ErrorType::INVALID_BINARY,
+                            "compressed graph vertex count is smaller than total count");
+    }
     Resize(vertex_num);
     for (uint64_t id = 0; id < vertex_num; ++id) {
         uint8_t num_elements = 0;

--- a/src/inner_string_params.h
+++ b/src/inner_string_params.h
@@ -199,6 +199,9 @@ const char* const SEARCH_PARALLELISM = "parallelism";
 const char* const SEARCH_MAX_TIME_COST_MS = "timeout_ms";
 const char* const SPARSE_N_CANDIDATE = "n_candidate";
 
+const char* const GRAPH_BUILD_THRESHOLD_KEY = "graph_build_threshold";
+const char* const IVF_SEARCH_PARAM_EF_SEARCH = "ef_search";
+
 const char* const DISKANN_SUPPORT_CALC_DISTANCE_BY_ID = "support_calc_distance_by_id";
 
 const std::unordered_map<std::string, std::string> DEFAULT_MAP = {
@@ -300,6 +303,8 @@ const std::unordered_map<std::string, std::string> DEFAULT_MAP = {
     {"TQ_CHAIN_KEY", TQ_CHAIN_KEY},
     {"NO_BUILD_LEVELS", NO_BUILD_LEVELS},
     {"GRAPH_TYPE_KEY", GRAPH_TYPE_KEY},
-    {"SUPPORT_FORCE_REMOVE", SUPPORT_FORCE_REMOVE}};
+    {"SUPPORT_FORCE_REMOVE", SUPPORT_FORCE_REMOVE},
+    {"GRAPH_BUILD_THRESHOLD_KEY", GRAPH_BUILD_THRESHOLD_KEY},
+};
 
 }  // namespace vsag

--- a/src/storage/serialization_tags.h
+++ b/src/storage/serialization_tags.h
@@ -39,6 +39,7 @@ enum class StreamSerializationTag : uint32_t {
     SINDI_TERM_ID_MAPPER = 13,
     PYRAMID_HIERARCHIES = 14,
     CODE_SLOT_MAP = 15,
+    IVF_BUCKET_GRAPH = 16,
 };
 
 inline const char*
@@ -76,6 +77,8 @@ StreamSerializationTagName(uint32_t tag) {
             return "pyramid_hierarchies";
         case StreamSerializationTag::CODE_SLOT_MAP:
             return "code_slot_map";
+        case StreamSerializationTag::IVF_BUCKET_GRAPH:
+            return "ivf_bucket_graph";
     }
     return "unknown";
 }
@@ -101,6 +104,7 @@ StreamSerializationTagCritical(uint32_t tag) {
         case StreamSerializationTag::ATTRIBUTE_FILTER:
         case StreamSerializationTag::EXTRA_INFO:
         case StreamSerializationTag::RAW_VECTOR:
+        case StreamSerializationTag::IVF_BUCKET_GRAPH:
             return false;
     }
     return false;
@@ -127,6 +131,8 @@ StreamSerializationBlockCurrentVersion(uint32_t tag) {
         case StreamSerializationTag::SINDI_TERM_ID_MAPPER:
         case StreamSerializationTag::PYRAMID_HIERARCHIES:
         case StreamSerializationTag::CODE_SLOT_MAP:
+            return kStreamSerializationBlockVersionV1;
+        case StreamSerializationTag::IVF_BUCKET_GRAPH:
             return kStreamSerializationBlockVersionV1;
     }
     return kStreamSerializationBlockVersionV1;

--- a/tests/test_ivf.cpp
+++ b/tests/test_ivf.cpp
@@ -1828,3 +1828,268 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::IVFTestIndex,
     REQUIRE_FALSE(result.value()->GetReasoning().empty());
     REQUIRE(result.value()->GetReasoning().find("missed_targets") != std::string::npos);
 }
+
+// ============ Graph Bucket Searcher Tests ============
+
+static std::string
+GenerateIVFGraphBuildParametersString(const std::string& metric_type,
+                                      int64_t dim,
+                                      int buckets_count,
+                                      int64_t graph_build_threshold) {
+    constexpr auto parameter_temp = R"(
+    {{
+        "dtype": "float32",
+        "metric_type": "{}",
+        "dim": {},
+        "index_param": {{
+            "buckets_count": {},
+            "base_quantization_type": "fp32",
+            "ivf_train_type": "random",
+            "graph_build_threshold": {}
+        }}
+    }}
+    )";
+    return fmt::format(parameter_temp, metric_type, dim, buckets_count, graph_build_threshold);
+}
+
+static std::string
+GenerateIVFGraphSearchParametersString(int scan_buckets_count, int ef_search) {
+    constexpr auto search_param_template = R"(
+    {{
+        "ivf": {{
+            "scan_buckets_count": {},
+            "factor": 4.0,
+            "first_order_scan_ratio": 1.0,
+            "ef_search": {}
+        }}
+    }})";
+    return fmt::format(search_param_template, scan_buckets_count, ef_search);
+}
+
+TEST_CASE("IVF GraphBucketSearcher Basic", "[ft][ivf][graph]") {
+    auto dim = 32;
+    auto metric = "l2";
+    auto base_count = 2000;
+    auto buckets_count = 10;
+    auto threshold = 50;
+
+    auto build_param = GenerateIVFGraphBuildParametersString(metric, dim, buckets_count, threshold);
+    auto index = vsag::Factory::CreateIndex("ivf", build_param);
+    REQUIRE(index.has_value());
+
+    auto dataset = fixtures::IVFTestIndex::pool.GetDatasetAndCreate(dim, base_count, metric);
+    auto build_result = index.value()->Build(dataset->base_);
+    REQUIRE(build_result.has_value());
+
+    auto query = fixtures::get_one_query(dataset->query_, 0);
+    auto search_param = GenerateIVFGraphSearchParametersString(buckets_count, 100);
+    auto result = index.value()->KnnSearch(query, 10, search_param);
+    REQUIRE(result.has_value());
+    REQUIRE(result.value()->GetDim() == 10);
+}
+
+TEST_CASE("IVF GraphBucketSearcher Flat Fallback", "[ft][ivf][graph]") {
+    auto dim = 32;
+    auto metric = "l2";
+    auto base_count = 500;
+    auto buckets_count = 20;
+    auto threshold = 10000;  // higher than any bucket -> all flat fallback
+
+    auto build_param = GenerateIVFGraphBuildParametersString(metric, dim, buckets_count, threshold);
+    auto index = vsag::Factory::CreateIndex("ivf", build_param);
+    REQUIRE(index.has_value());
+
+    auto dataset = fixtures::IVFTestIndex::pool.GetDatasetAndCreate(dim, base_count, metric);
+    auto build_result = index.value()->Build(dataset->base_);
+    REQUIRE(build_result.has_value());
+
+    auto query = fixtures::get_one_query(dataset->query_, 0);
+    auto search_param = GenerateIVFGraphSearchParametersString(buckets_count, 100);
+    auto result = index.value()->KnnSearch(query, 10, search_param);
+    REQUIRE(result.has_value());
+    REQUIRE(result.value()->GetDim() > 0);
+}
+
+TEST_CASE("IVF GraphBucketSearcher Add After Build Falls Back To Flat", "[ft][ivf][graph]") {
+    constexpr int64_t dim = 32;
+    constexpr int64_t base_count = 100;
+    constexpr int64_t buckets_count = 1;
+    constexpr int64_t threshold = 30;
+
+    auto build_param = GenerateIVFGraphBuildParametersString("l2", dim, buckets_count, threshold);
+    auto index = vsag::Factory::CreateIndex("ivf", build_param);
+    REQUIRE(index.has_value());
+
+    auto dataset = fixtures::IVFTestIndex::pool.GetDatasetAndCreate(dim, base_count, "l2");
+    auto initial = vsag::Dataset::Make();
+    initial->Dim(dim)
+        ->Ids(dataset->base_->GetIds())
+        ->NumElements(base_count - 1)
+        ->Float32Vectors(dataset->base_->GetFloat32Vectors())
+        ->Owner(false);
+    REQUIRE(index.value()->Build(initial).has_value());
+
+    auto added = vsag::Dataset::Make();
+    added->Dim(dim)
+        ->Ids(dataset->base_->GetIds() + base_count - 1)
+        ->NumElements(1)
+        ->Float32Vectors(dataset->base_->GetFloat32Vectors() + (base_count - 1) * dim)
+        ->Owner(false);
+    REQUIRE(index.value()->Add(added).has_value());
+
+    auto query = vsag::Dataset::Make();
+    query->Dim(dim)
+        ->NumElements(1)
+        ->Float32Vectors(dataset->base_->GetFloat32Vectors() + (base_count - 1) * dim)
+        ->Owner(false);
+    auto search_param = GenerateIVFGraphSearchParametersString(buckets_count, 100);
+    auto result = index.value()->KnnSearch(query, 1, search_param);
+    REQUIRE(result.has_value());
+    REQUIRE(result.value()->GetIds()[0] == dataset->base_->GetIds()[base_count - 1]);
+}
+
+TEST_CASE("IVF GraphBucketSearcher Serialization", "[ft][ivf][graph][serialize]") {
+    auto dim = 32;
+    auto metric = "l2";
+    auto base_count = 1000;
+    auto buckets_count = 10;
+    auto threshold = 30;
+
+    auto build_param = GenerateIVFGraphBuildParametersString(metric, dim, buckets_count, threshold);
+    auto index = vsag::Factory::CreateIndex("ivf", build_param);
+    REQUIRE(index.has_value());
+
+    auto dataset = fixtures::IVFTestIndex::pool.GetDatasetAndCreate(dim, base_count, metric);
+    auto build_result = index.value()->Build(dataset->base_);
+    REQUIRE(build_result.has_value());
+
+    auto query = fixtures::get_one_query(dataset->query_, 0);
+    auto search_param = GenerateIVFGraphSearchParametersString(buckets_count, 100);
+    auto before = index.value()->KnnSearch(query, 10, search_param);
+    REQUIRE(before.has_value());
+
+    // Serialize
+    auto serial_result = index.value()->Serialize();
+    REQUIRE(serial_result.has_value());
+
+    // Deserialize
+    auto restored = vsag::Factory::CreateIndex("ivf", build_param);
+    REQUIRE(restored.has_value());
+    auto load_result = restored.value()->Deserialize(serial_result.value());
+    REQUIRE(load_result.has_value());
+
+    auto after = restored.value()->KnnSearch(query, 10, search_param);
+    REQUIRE(after.has_value());
+    REQUIRE(after.value()->GetDim() == before.value()->GetDim());
+    for (int64_t i = 0; i < before.value()->GetDim(); ++i) {
+        REQUIRE(before.value()->GetIds()[i] == after.value()->GetIds()[i]);
+    }
+}
+
+TEST_CASE("IVF GraphBucketSearcher Streaming Serialization", "[ft][ivf][graph][streaming]") {
+    struct BlockSizeLimitRestore {
+        uint64_t origin_size;
+        ~BlockSizeLimitRestore() {
+            vsag::Options::Instance().set_block_size_limit(origin_size);
+        }
+    };
+    BlockSizeLimitRestore block_size_limit_restore{vsag::Options::Instance().block_size_limit()};
+    vsag::Options::Instance().set_block_size_limit(1024 * 1024 * 2);
+
+    auto dim = 32;
+    auto metric = "l2";
+    auto base_count = 1000;
+    auto buckets_count = 10;
+    auto threshold = 30;
+
+    auto build_param = GenerateIVFGraphBuildParametersString(metric, dim, buckets_count, threshold);
+    auto index = vsag::Factory::CreateIndex("ivf", build_param);
+    REQUIRE(index.has_value());
+
+    auto dataset = fixtures::IVFTestIndex::pool.GetDatasetAndCreate(dim, base_count, metric);
+    auto build_result = index.value()->Build(dataset->base_);
+    REQUIRE(build_result.has_value());
+
+    auto query = fixtures::get_one_query(dataset->query_, 0);
+    auto search_param = GenerateIVFGraphSearchParametersString(buckets_count, 100);
+    auto before = index.value()->KnnSearch(query, 10, search_param);
+    REQUIRE(before.has_value());
+
+    // Streaming serialize
+    std::stringstream stream;
+    REQUIRE(index.value()->SerializeStreaming(stream).has_value());
+    const auto bytes = stream.str();
+
+    // Streaming deserialize
+    auto restored = vsag::Factory::CreateIndex("ivf", build_param);
+    REQUIRE(restored.has_value());
+    std::stringstream load_stream(bytes);
+    REQUIRE(restored.value()->DeserializeStreaming(load_stream).has_value());
+
+    auto after = restored.value()->KnnSearch(query, 10, search_param);
+    REQUIRE(after.has_value());
+    REQUIRE(after.value()->GetDim() == before.value()->GetDim());
+}
+
+TEST_CASE("IVF GraphBucketSearcher Range Search", "[ft][ivf][graph][range]") {
+    auto dim = 32;
+    auto metric = "l2";
+    auto base_count = 1000;
+    auto buckets_count = 10;
+    auto threshold = 30;
+
+    auto build_param = GenerateIVFGraphBuildParametersString(metric, dim, buckets_count, threshold);
+    auto index = vsag::Factory::CreateIndex("ivf", build_param);
+    REQUIRE(index.has_value());
+
+    auto dataset = fixtures::IVFTestIndex::pool.GetDatasetAndCreate(dim, base_count, metric);
+    auto build_result = index.value()->Build(dataset->base_);
+    REQUIRE(build_result.has_value());
+
+    auto query = fixtures::get_one_query(dataset->query_, 0);
+    auto search_param = GenerateIVFGraphSearchParametersString(buckets_count, 100);
+    auto result = index.value()->RangeSearch(query, 100.0f, search_param);
+    REQUIRE(result.has_value());
+    REQUIRE(result.value()->GetDim() > 0);
+}
+
+TEST_CASE("IVF GraphBucketSearcher Memory Usage", "[ft][ivf][graph][memory]") {
+    auto dim = 32;
+    auto metric = "l2";
+    auto base_count = 1000;
+    auto buckets_count = 10;
+    auto threshold = 30;
+
+    auto build_param = GenerateIVFGraphBuildParametersString(metric, dim, buckets_count, threshold);
+    auto index = vsag::Factory::CreateIndex("ivf", build_param);
+    REQUIRE(index.has_value());
+
+    auto dataset = fixtures::IVFTestIndex::pool.GetDatasetAndCreate(dim, base_count, metric);
+    auto build_result = index.value()->Build(dataset->base_);
+    REQUIRE(build_result.has_value());
+
+    auto memory_usage = index.value()->GetMemoryUsage();
+    REQUIRE(memory_usage > 0);
+}
+
+TEST_CASE("IVF GraphBucketSearcher Without Graph", "[ft][ivf][graph]") {
+    auto dim = 32;
+    auto metric = "l2";
+    auto base_count = 500;
+    auto buckets_count = 10;
+    auto threshold = 0;  // disabled
+
+    auto build_param = GenerateIVFGraphBuildParametersString(metric, dim, buckets_count, threshold);
+    auto index = vsag::Factory::CreateIndex("ivf", build_param);
+    REQUIRE(index.has_value());
+
+    auto dataset = fixtures::IVFTestIndex::pool.GetDatasetAndCreate(dim, base_count, metric);
+    auto build_result = index.value()->Build(dataset->base_);
+    REQUIRE(build_result.has_value());
+
+    auto query = fixtures::get_one_query(dataset->query_, 0);
+    auto search_param = GenerateIVFGraphSearchParametersString(buckets_count, 100);
+    auto result = index.value()->KnnSearch(query, 10, search_param);
+    REQUIRE(result.has_value());
+    REQUIRE(result.value()->GetDim() > 0);
+}


### PR DESCRIPTION
## Summary

Add GraphBucketSearcher that uses beam search on per-bucket graphs for large buckets while falling back to flat brute-force scan for small ones.

Closes #2493

## Changes

- New graph_bucket_searcher.h/cpp implementing IVFBucketSearcher interface
- Graph built in batch after Build() completes (not during Add)
- Configurable threshold via graph_build_threshold parameter
- ef_search parameter controls beam width during search
- Serialization/deserialization support for bucket graphs
- Small buckets (size < threshold) use exact flat scan
- Default behavior (threshold=0) unchanged from current IVF

## Files Changed

- src/algorithm/ivf/graph_bucket_searcher.h (new)
- src/algorithm/ivf/graph_bucket_searcher.cpp (new)
- src/algorithm/ivf/ivf.h (modified)
- src/algorithm/ivf/ivf.cpp (modified)
- src/algorithm/ivf/ivf_parameter.h (modified)
- src/algorithm/ivf/ivf_parameter.cpp (modified)
- src/algorithm/ivf/CMakeLists.txt (modified)
- src/inner_string_params.h (modified)