### PR TITLE
fix(ci): reduce nested OpenBLAS build parallelism

### DIFF
--- a/.github/workflows/asan_build_and_test.yml
+++ b/.github/workflows/asan_build_and_test.yml
@@ -67,7 +67,7 @@ jobs:
           save: ${{ github.event_name != 'pull_request' }}
           key: build-aarch-${{ hashFiles('./CMakeLists.txt') }}-${{ hashFiles('./.circleci/fresh_ci_cache.commit') }}
       - name: Make Asan
-        run: export CMAKE_GENERATOR="Ninja"; make asan COMPILE_JOBS=4 VSAG_ENABLE_EXAMPLES=ON
+        run: export CMAKE_GENERATOR="Ninja"; make asan COMPILE_JOBS=3 VSAG_ENABLE_EXAMPLES=ON
       - name: Clean
         run: find ./build -type f -name "*.o" -exec rm -f {} +
       - name: Save Test

--- a/.github/workflows/daily_test.yml
+++ b/.github/workflows/daily_test.yml
@@ -36,7 +36,7 @@ jobs:
         # is what release artifacts depend on. PR CI / coverage / lint use the
         # system OpenBLAS for speed; this job is the one that keeps the
         # source-build path covered.
-        run: export CMAKE_GENERATOR="Ninja"; make asan COMPILE_JOBS=4 VSAG_ENABLE_EXAMPLES=ON
+        run: export CMAKE_GENERATOR="Ninja"; make asan COMPILE_JOBS=3 VSAG_ENABLE_EXAMPLES=ON
       - name: Clean
         run: find ./build -type f -name "*.o" -exec rm -f {} +
       - name: Save Test
@@ -71,7 +71,7 @@ jobs:
           save: false
           key: build-aarch-${{ hashFiles('./CMakeLists.txt') }}-${{ hashFiles('./.circleci/fresh_ci_cache.commit') }}
       - name: Make Asan
-        run: export CMAKE_GENERATOR="Ninja"; make asan VSAG_ENABLE_EXAMPLES=ON
+        run: export CMAKE_GENERATOR="Ninja"; make asan COMPILE_JOBS=3 VSAG_ENABLE_EXAMPLES=ON
       - name: Clean
         run: find ./build -type f -name "*.o" -exec rm -f {} +
       - name: Save Test
@@ -321,7 +321,7 @@ jobs:
           save: false
           key: build-tsan-${{ hashFiles('./CMakeLists.txt') }}-${{ hashFiles('./.circleci/fresh_ci_cache.commit') }}
       - name: Make Tsan
-        run: export CMAKE_GENERATOR="Ninja"; make tsan
+        run: export CMAKE_GENERATOR="Ninja"; make tsan COMPILE_JOBS=3
       - name: Clean
         run: find ./build -type f -name "*.o" -exec rm -f {} +
       - name: Save Test

--- a/.github/workflows/tsan_build_and_test.yml
+++ b/.github/workflows/tsan_build_and_test.yml
@@ -55,7 +55,7 @@ jobs:
           save: ${{ github.event_name != 'pull_request' }}
           key: build-tsan-${{ hashFiles('./CMakeLists.txt') }}-${{ hashFiles('./.circleci/fresh_ci_cache.commit') }}
       - name: Make Tsan
-        run: export CMAKE_GENERATOR="Ninja"; make tsan
+        run: export CMAKE_GENERATOR="Ninja"; make tsan COMPILE_JOBS=3
       - name: Clean
         run: find ./build -type f -name "*.o" -exec rm -f {} +
       - name: Save Test


### PR DESCRIPTION
## Summary

- Set `COMPILE_JOBS=3` on CI ASan/TSAN entry points that can build bundled OpenBLAS.
- Reuse the existing Makefile control so top-level Ninja and ExternalProject OpenBLAS gmake both run at three jobs.
- Leave explicit system-OpenBLAS, MKL, developer, and release fast paths unchanged.

## Evidence

The bundled OpenBLAS 0.3.23 build failed intermittently in the TSAN job while the wrapper invoked `make ... -j6` inside a Ninja build using parallelism 6:

- Failing run: https://github.com/antgroup/vsag/actions/runs/29809153995
- Failing job: https://github.com/antgroup/vsag/actions/runs/29809153995/job/88577346759
- Tracking issue: https://github.com/antgroup/vsag/issues/2439
- OpenBLAS 0.3.24 release notes: https://github.com/OpenMathLib/OpenBLAS/releases/tag/v0.3.24

Three jobs halves the nested fan-out while preserving useful parallelism on the hosted runners. This is a CI-only mitigation; it does not upgrade the bundled dependency or slow normal/release defaults.

Fixes: #2439

## Verification

- `git diff --check`
- PyYAML parse of all three changed workflows
- No-build CMake configuration with `-DNUM_BUILDING_JOBS=3 -DVSAG_USE_SYSTEM_DEPS=OFF`
- Confirmed generated OpenBLAS command ends in `-j3`
- `make -n tsan COMPILE_JOBS=3 CMAKE_GENERATOR=Ninja` confirmed top-level `cmake --build --parallel 3`

## Test plan

- Run the affected TSAN and ASAN CI jobs on this PR.
- Confirm bundled OpenBLAS reaches `-j3` and completes on the hosted runner variants.
