### PR TITLE
fix(hgraph): remove ef_search topk upper bound

### DIFF
--- a/src/algorithm/hgraph/hgraph_parameter.cpp
+++ b/src/algorithm/hgraph/hgraph_parameter.cpp
@@ -206,7 +206,14 @@ HGraphSearchParameters::FromJson(const std::string& json_string) {
         params[INDEX_TYPE_HGRAPH].Contains(HGRAPH_PARAMETER_EF_RUNTIME),
         fmt::format(
             "parameters[{}] must contains {}", INDEX_TYPE_HGRAPH, HGRAPH_PARAMETER_EF_RUNTIME));
-    obj.ef_search = params[INDEX_TYPE_HGRAPH][HGRAPH_PARAMETER_EF_RUNTIME].GetInt();
+    const auto& ef_search_json = params[INDEX_TYPE_HGRAPH][HGRAPH_PARAMETER_EF_RUNTIME];
+    CHECK_ARGUMENT(ef_search_json.IsNumberInteger(), "ef_search must be an integer");
+    if (ef_search_json.IsNumberUnsigned()) {
+        CHECK_ARGUMENT(ef_search_json.GetUint64() <=
+                           static_cast<uint64_t>(std::numeric_limits<int64_t>::max()),
+                       "ef_search exceeds int64_t range");
+    }
+    obj.ef_search = ef_search_json.GetInt();
     if (params[INDEX_TYPE_HGRAPH].Contains(HGRAPH_PARAMETER_HOPS_LIMIT)) {
         obj.hops_limit = params[INDEX_TYPE_HGRAPH][HGRAPH_PARAMETER_HOPS_LIMIT].GetInt();
     }

--- a/src/algorithm/hgraph/hgraph_parameter_test.cpp
+++ b/src/algorithm/hgraph/hgraph_parameter_test.cpp
@@ -231,6 +231,12 @@ TEST_CASE("HGraph Search Parameters parse RaBitQ error rate", "[ut][HGraphParame
     })"));
 }
 
+TEST_CASE("HGraph Search Parameters reject ef_search integer overflow",
+          "[ut][HGraphSearchParameters][ef_search]") {
+    REQUIRE_THROWS(vsag::HGraphSearchParameters::FromJson(
+        R"({"hgraph": {"ef_search": 9223372036854775808}})"));
+}
+
 TEST_CASE("HGraph maps label_remap_type to inner index parameter", "[ut][HGraphParameter]") {
     auto param = vsag::JsonType::Parse(R"({
         "base_quantization_type": "fp32",

--- a/src/algorithm/hgraph/hgraph_search.cpp
+++ b/src/algorithm/hgraph/hgraph_search.cpp
@@ -77,10 +77,9 @@ HGraph::KnnSearch(const DatasetPtr& query,
 
     auto params = HGraphSearchParameters::FromJson(parameters);
     ctx.rabitq_error_rate = params.rabitq_error_rate;
-    auto ef_search_threshold = std::max<int64_t>(AMPLIFICATION_FACTOR * k, 1000);
     CHECK_ARGUMENT(  // NOLINT
-        (1 <= params.ef_search) and (params.ef_search <= ef_search_threshold),
-        fmt::format("ef_search({}) must in range[1, {}]", params.ef_search, ef_search_threshold));
+        params.ef_search >= 1,
+        fmt::format("ef_search({}) must be at least 1", params.ef_search));
 
     std::shared_lock<std::shared_mutex> force_remove_rlock;
     std::shared_lock<std::shared_mutex> shared_lock;
@@ -390,10 +389,9 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
     auto params = HGraphSearchParameters::FromJson(request.params_str_);
     ctx.rabitq_error_rate = params.rabitq_error_rate;
 
-    auto ef_search_threshold = std::max<int64_t>(AMPLIFICATION_FACTOR * k, 1000);
     CHECK_ARGUMENT(  // NOLINT
-        (1 <= params.ef_search) and (params.ef_search <= ef_search_threshold),
-        fmt::format("ef_search({}) must in range[1, {}]", params.ef_search, ef_search_threshold));
+        params.ef_search >= 1,
+        fmt::format("ef_search({}) must be at least 1", params.ef_search));
 
     std::shared_lock<std::shared_mutex> force_remove_rlock;
     std::shared_lock<std::shared_mutex> shared_lock;
@@ -500,7 +498,7 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
         }
         search_param.parallel_search_thread_count = params.parallel_search_thread_count;
 
-        if (params.hops_limit <= static_cast<uint32_t>(params.ef_search)) {
+        if (static_cast<uint64_t>(params.hops_limit) <= static_cast<uint64_t>(params.ef_search)) {
             search_param.hops_limit = std::numeric_limits<uint32_t>::max();
             if (params.hops_limit != std::numeric_limits<uint32_t>::max()) {
                 logger::warn(fmt::format(

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -3164,6 +3164,15 @@ TEST_CASE("(PR) HGraph brute_force_threshold default is no-op",
         REQUIRE(std::abs(baseline.value()->GetDistances()[k] -
                          with_zero.value()->GetDistances()[k]) < 1e-6F);
     }
+
+    auto large_ef = index->KnnSearch(query, topk, R"({"hgraph": {"ef_search": 1001}})");
+    REQUIRE(large_ef.has_value());
+    REQUIRE(large_ef.value()->GetDim() == topk);
+
+    auto zero_ef = index->KnnSearch(query, topk, R"({"hgraph": {"ef_search": 0}})");
+    auto negative_ef = index->KnnSearch(query, topk, R"({"hgraph": {"ef_search": -1}})");
+    REQUIRE_FALSE(zero_ef.has_value());
+    REQUIRE_FALSE(negative_ef.has_value());
 }
 
 TEST_CASE("HGraph ExportCache + ImportCache + Build acceleration smoke test",


### PR DESCRIPTION
Fixes: #2409

## Rationale
HGraph currently rejects positive `ef_search` values above `max(10 * topk, 1000)`, preventing larger candidate frontiers for large-limit and highly selective workloads. The search implementation already represents the frontier as `int64_t`/`uint64_t`, so the k-relative cap is unnecessary.

## Behavior change
- Accept any positive `int64_t` HGraph `ef_search`; remove only the k-relative upper bound.
- Preserve rejection of zero/negative values and reject unsigned JSON values above `INT64_MAX`.
- Make `hops_limit` comparison overflow-safe when `ef_search` exceeds `uint32_t`.
- No changes to other indexes or search modes.

## Test plan
- Focused HGraph parameter tests: signed integer overflow rejection.
- Focused HGraph functional regression: `ef_search=1001` with `topk=3` succeeds; zero and negative values are rejected.
- Broader `[hgraph]` functional coverage: 7 cases passed; one long daily build/continue-add case was interrupted after 171.874s.
- `make release` passed.
- `make lint` passed with clang-tidy 15; direct clang-tidy 15 on changed implementations passed.
- clang-format 15 and `git diff --check` passed.