### PR TITLE
fix(eval): correct knn latency and QPS measurements

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -27,6 +27,7 @@ jobs:
               - 'src/**'
               - 'include/**'
               - 'tests/**'
+              - 'tools/**'
               - 'CMakeLists.txt'
               - 'Makefile'
               - 'extern/**'
@@ -263,6 +264,8 @@ jobs:
           export LSAN_OPTIONS=suppressions=omp.supp
           chmod +x ./build/tests/functests
           ./scripts/testing/test_parallel_by_name.sh functests
+          chmod +x ./build/tests/eval_monitor_test
+          ./build/tests/eval_monitor_test -d yes
       - name: Upload Log
         uses: actions/upload-artifact@v5
         with:

--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,7 @@ test:                    ## Build and run unit tests.
 	cmake --build ${DEBUG_BUILD_DIR} --parallel ${COMPILE_JOBS}
 	./build/tests/unittests -d yes ${UT_FILTER} --allow-running-no-tests ${UT_SHARD}
 	./build/tests/functests -d yes ${UT_FILTER} --allow-running-no-tests ${UT_SHARD}
+	./build/tests/eval_monitor_test -d yes ${UT_FILTER} --allow-running-no-tests ${UT_SHARD}
 	./build/mockimpl/tests_mockimpl -d yes ${UT_FILTER} --allow-running-no-tests ${UT_SHARD}
 
 .PHONY: asan

--- a/docs/docs/en/src/resources/eval.md
+++ b/docs/docs/en/src/resources/eval.md
@@ -87,6 +87,24 @@ Note: under `global.exporters`, each entry is a **named** exporter (a YAML map),
 - **Latency**: average, P50/P95/P99
 - **Resource**: peak memory usage
 
+### Search Measurement Semantics
+
+- **Latency** is the elapsed wall duration of each measured `Index::KnnSearch` call, measured
+  with the monotonic `std::chrono::steady_clock`.
+- **QPS** is the number of successful queries divided by the wall duration, in seconds, of the
+  measured search pass.
+- Statistics extraction, recall calculation, and memory sampling run outside the performance
+  pass and do not contribute to latency or QPS.
+- Every measured query is included, including the first query on each worker. The tool does not
+  apply an implicit warm-up; run any desired warm-up explicitly before the measured pass.
+
+JSON results include `measurement_method`, `measurement_sample_count`,
+`measurement_successful_query_count`, and `measurement_duration(s)` so the measurement population
+and method can be audited.
+
+Results produced by older versions that measured intervals between monitor callbacks are not
+directly comparable with results that use these semantics.
+
 ## Search Modes
 
 `search_mode` accepts `knn`, `range`, `knn_filter`, and `range_filter`.

--- a/docs/docs/zh/src/resources/eval.md
+++ b/docs/docs/zh/src/resources/eval.md
@@ -82,6 +82,23 @@ eval_case1:
 - **延迟**：平均延迟、P50/P95/P99 延迟
 - **资源**：峰值内存占用
 
+### 搜索指标计量语义
+
+- **延迟**是每次被测 `Index::KnnSearch` 调用的墙钟耗时，使用单调时钟
+  `std::chrono::steady_clock` 测量。
+- **QPS** 是成功查询数除以被测搜索阶段的墙钟时间（秒）。
+- 统计信息提取、召回率计算和内存采样在性能测试阶段之外执行，不计入延迟
+  或 QPS。
+- 所有被测查询均计入结果，包括每个工作线程的首个查询。工具不会隐式预热；
+  如有需要，应在被测阶段之前显式执行预热。
+
+JSON 结果会输出 `measurement_method`、`measurement_sample_count`、
+`measurement_successful_query_count` 和 `measurement_duration(s)`，用于核对测量方法
+及其样本范围。
+
+旧版本使用相邻监控回调间隔计算指标，其结果不能与采用上述语义的结果
+直接比较。
+
 ## 搜索模式
 
 `search_mode` 支持 `knn`、`range`、`knn_filter`、`range_filter` 四种。

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -60,6 +60,23 @@ endif()
 
 add_dependencies (unittests Catch2 vsag)
 
+add_executable (eval_monitor_test
+        ${PROJECT_SOURCE_DIR}/tools/eval/monitor/latency_monitor_test.cpp
+        ${PROJECT_SOURCE_DIR}/tools/eval/monitor/latency_monitor.cpp
+        ${PROJECT_SOURCE_DIR}/tools/eval/monitor/monitor.cpp
+)
+
+target_include_directories (eval_monitor_test PRIVATE
+        ${PROJECT_SOURCE_DIR}/tools/eval
+)
+
+target_link_libraries (eval_monitor_test PRIVATE
+        Catch2::Catch2WithMain
+        nlohmann_json::nlohmann_json
+)
+
+add_dependencies (eval_monitor_test Catch2)
+
 # function tests
 file (GLOB FUNCTION_TESTS "test_*.cpp")
 file (GLOB FUNCTION_TEST_INDEX_SOURCES "test_index/*.cpp")

--- a/tools/eval/case/search_eval_case.cpp
+++ b/tools/eval/case/search_eval_case.cpp
@@ -17,15 +17,18 @@
 
 #include <omp.h>
 
+#include <chrono>
 #include <cstdio>
 #include <cstdlib>
 #include <fstream>
 #include <iostream>
 #include <stdexcept>
+#include <utility>
 
 #include "../monitor/latency_monitor.h"
 #include "../monitor/memory_peak_monitor.h"
 #include "../monitor/recall_monitor.h"
+#include "search_timing.h"
 #include "typing.h"
 #include "vsag/filter.h"
 #include "vsag_exception.h"
@@ -82,18 +85,17 @@ SearchEvalCase::init_monitor() {
 void
 SearchEvalCase::init_latency_monitor() {
     if (config_.enable_latency or config_.enable_tps or config_.enable_percent_latency) {
-        auto latency_monitor =
-            std::make_shared<LatencyMonitor>(this->dataset_ptr_->GetNumberOfQuery());
+        this->latency_monitor_ = std::make_shared<LatencyMonitor>();
         if (config_.enable_qps) {
-            latency_monitor->SetMetrics("qps");
+            this->latency_monitor_->SetMetrics("qps");
         }
         if (config_.enable_latency) {
-            latency_monitor->SetMetrics("avg_latency");
+            this->latency_monitor_->SetMetrics("avg_latency");
         }
         if (config_.enable_percent_latency) {
-            latency_monitor->SetMetrics("percent_latency");
+            this->latency_monitor_->SetMetrics("percent_latency");
         }
-        this->monitors_.emplace_back(std::move(latency_monitor));
+        this->monitors_.emplace_back(this->latency_monitor_);
     }
 }
 
@@ -156,27 +158,66 @@ SearchEvalCase::do_knn_search() {
     auto query_count = this->dataset_ptr_->GetNumberOfQuery();
     this->logger_->Debug("query count is " + std::to_string(query_count));
     auto min_query = std::max(static_cast<uint64_t>(query_count), config_.search_query_count);
-    for (uint64_t monitor_id = 0; monitor_id < this->monitors_.size(); ++monitor_id) {
-        auto& monitor = this->monitors_[monitor_id];
-        const bool collect_statistics = monitor_id == 0;
+
+    auto prepare_query = [this](uint64_t query_id) {
+        auto query = vsag::Dataset::Make();
+        query->NumElements(1)->Dim(this->dataset_ptr_->GetDim())->Owner(false);
+        const void* query_vector = this->dataset_ptr_->GetOneTest(query_id);
+        if (this->dataset_ptr_->GetVectorType() == DENSE_VECTORS) {
+            if (this->dataset_ptr_->GetTestDataType() == vsag::DATATYPE_FLOAT32) {
+                query->Float32Vectors((const float*)query_vector);
+            } else if (this->dataset_ptr_->GetTestDataType() == vsag::DATATYPE_INT8) {
+                query->Int8Vectors((const int8_t*)query_vector);
+            }
+        } else {
+            query->SparseVectors((const SparseVector*)query_vector);
+        }
+        return std::make_pair(std::move(query), query_vector);
+    };
+
+    bool statistics_collected = false;
+    for (auto& monitor : this->monitors_) {
+        const bool is_latency_monitor =
+            this->latency_monitor_ != nullptr and monitor.get() == this->latency_monitor_.get();
+        // Statistics share the first non-performance pass, or use the fallback pass below.
+        const bool collect_statistics = not is_latency_monitor and not statistics_collected;
         monitor->Start();
 
         omp_set_num_threads(config_.num_threads_searching);
+        if (is_latency_monitor) {
+            using Clock = std::chrono::steady_clock;
+            std::vector<double> latency_records(min_query);
+            const auto wall_start = Clock::now();
+#pragma omp parallel for schedule(dynamic)
+            for (int64_t id = 0; id < min_query; ++id) {
+                auto i = static_cast<uint64_t>(id) % query_count;
+                auto query_and_vector = prepare_query(i);
+                auto& query = query_and_vector.first;
+                auto [result, latency_ms] = MeasureSearch(
+                    [&]() { return this->index_->KnnSearch(query, topk, config_.search_param); });
+                if (not result.has_value()) {
+                    std::cerr << "query error: " << result.error().message << std::endl;
+                    exit(-1);
+                }
+                latency_records[static_cast<uint64_t>(id)] = latency_ms;
+            }
+            const auto wall_end = Clock::now();
+            auto timing_batch = LatencyTimingBatch{
+                std::move(latency_records),
+                min_query,
+                std::chrono::duration<double>(wall_end - wall_start).count(),
+            };
+            this->latency_monitor_->SetTimingBatch(std::move(timing_batch));
+            monitor->Stop();
+            continue;
+        }
+
 #pragma omp parallel for schedule(dynamic)
         for (int64_t id = 0; id < min_query; ++id) {
-            auto i = id % query_count;
-            auto query = vsag::Dataset::Make();
-            query->NumElements(1)->Dim(this->dataset_ptr_->GetDim())->Owner(false);
-            const void* query_vector = this->dataset_ptr_->GetOneTest(i);
-            if (this->dataset_ptr_->GetVectorType() == DENSE_VECTORS) {
-                if (this->dataset_ptr_->GetTestDataType() == vsag::DATATYPE_FLOAT32) {
-                    query->Float32Vectors((const float*)query_vector);
-                } else if (this->dataset_ptr_->GetTestDataType() == vsag::DATATYPE_INT8) {
-                    query->Int8Vectors((const int8_t*)query_vector);
-                }
-            } else {
-                query->SparseVectors((const SparseVector*)query_vector);
-            }
+            auto i = static_cast<uint64_t>(id) % query_count;
+            auto query_and_vector = prepare_query(i);
+            auto& query = query_and_vector.first;
+            const void* query_vector = query_and_vector.second;
             auto result = this->index_->KnnSearch(query, topk, config_.search_param);
             if (not result.has_value()) {
                 std::cerr << "query error: " << result.error().message << std::endl;
@@ -195,6 +236,23 @@ SearchEvalCase::do_knn_search() {
             monitor->Record(&record);
         }
         monitor->Stop();
+        statistics_collected = statistics_collected or collect_statistics;
+    }
+
+    if (not statistics_collected and not this->monitors_.empty()) {
+        omp_set_num_threads(config_.num_threads_searching);
+#pragma omp parallel for schedule(dynamic)
+        for (int64_t id = 0; id < min_query; ++id) {
+            auto i = static_cast<uint64_t>(id) % query_count;
+            auto query_and_vector = prepare_query(i);
+            auto& query = query_and_vector.first;
+            auto result = this->index_->KnnSearch(query, topk, config_.search_param);
+            if (not result.has_value()) {
+                std::cerr << "query error: " << result.error().message << std::endl;
+                exit(-1);
+            }
+            this->record_statistics(result.value());
+        }
     }
 }
 
@@ -217,7 +275,46 @@ SearchEvalCase::do_knn_filter_search() {
     this->logger_->Debug("query count is " + std::to_string(query_count));
     auto min_query = std::max<int64_t>(query_count, 10000);
     for (auto& monitor : this->monitors_) {
+        const bool is_latency_monitor =
+            this->latency_monitor_ != nullptr and monitor.get() == this->latency_monitor_.get();
         monitor->Start();
+        if (is_latency_monitor) {
+            using Clock = std::chrono::steady_clock;
+            std::vector<double> latency_records(min_query);
+            const auto wall_start = Clock::now();
+            for (int64_t id = 0; id < min_query; ++id) {
+                auto i = id % query_count;
+                auto query = vsag::Dataset::Make();
+                query->NumElements(1)->Dim(this->dataset_ptr_->GetDim())->Owner(false);
+                const void* query_vector = this->dataset_ptr_->GetOneTest(i);
+                if (this->dataset_ptr_->GetTestDataType() == vsag::DATATYPE_FLOAT32) {
+                    query->Float32Vectors((const float*)query_vector);
+                } else if (this->dataset_ptr_->GetTestDataType() == vsag::DATATYPE_INT8) {
+                    query->Int8Vectors((const int8_t*)query_vector);
+                }
+                auto test_label = test_labels[i];
+                auto filter = std::make_shared<FilterObj>(
+                    train_labels, test_label, this->dataset_ptr_->GetValidRatio(test_label));
+                auto [result, latency_ms] = MeasureSearch([&]() {
+                    return this->index_->KnnSearch(query, topk, config_.search_param, filter);
+                });
+                if (not result.has_value()) {
+                    std::cerr << "query error: " << result.error().message << std::endl;
+                    exit(-1);
+                }
+                latency_records[static_cast<uint64_t>(id)] = latency_ms;
+            }
+            const auto wall_end = Clock::now();
+            auto timing_batch = LatencyTimingBatch{
+                std::move(latency_records),
+                static_cast<uint64_t>(min_query),
+                std::chrono::duration<double>(wall_end - wall_start).count(),
+            };
+            this->latency_monitor_->SetTimingBatch(std::move(timing_batch));
+            monitor->Stop();
+            continue;
+        }
+
         for (int64_t id = 0; id < min_query; ++id) {
             auto i = id % query_count;
             auto query = vsag::Dataset::Make();

--- a/tools/eval/case/search_eval_case.h
+++ b/tools/eval/case/search_eval_case.h
@@ -23,6 +23,8 @@
 
 namespace vsag::eval {
 
+class LatencyMonitor;
+
 class SearchEvalCase : public EvalCase {
 public:
     SearchEvalCase(const std::string& dataset_path,
@@ -84,6 +86,8 @@ private:
 
 private:
     std::vector<MonitorPtr> monitors_{};
+
+    std::shared_ptr<LatencyMonitor> latency_monitor_{nullptr};
 
     SearchType search_type_{SearchType::KNN};
 

--- a/tools/eval/case/search_timing.h
+++ b/tools/eval/case/search_timing.h
@@ -1,0 +1,32 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <chrono>
+#include <utility>
+
+namespace vsag::eval {
+
+template <typename Clock = std::chrono::steady_clock, typename Search>
+auto
+MeasureSearch(Search&& search) {
+    const auto start = Clock::now();
+    auto result = std::forward<Search>(search)();
+    const auto end = Clock::now();
+    const auto latency_ms = std::chrono::duration<double, std::milli>(end - start).count();
+    return std::make_pair(std::move(result), latency_ms);
+}
+
+}  // namespace vsag::eval

--- a/tools/eval/monitor/latency_monitor.cpp
+++ b/tools/eval/monitor/latency_monitor.cpp
@@ -15,18 +15,21 @@
 
 #include "latency_monitor.h"
 
-#include <mutex>
+#include <algorithm>
+#include <cmath>
+#include <numeric>
+#include <utility>
 
 namespace vsag::eval {
 
-LatencyMonitor::LatencyMonitor(uint64_t max_record_counts) : Monitor("latency_monitor") {
-    if (max_record_counts > 0) {
-        this->latency_records_.reserve(max_record_counts);
-    }
+LatencyMonitor::LatencyMonitor() : Monitor("latency_monitor") {
 }
 
 void
 LatencyMonitor::Start() {
+    this->latency_records_.clear();
+    this->successful_query_count_ = 0;
+    this->wall_time_seconds_ = 0.0;
 }
 void
 LatencyMonitor::Stop() {
@@ -38,22 +41,30 @@ LatencyMonitor::GetResult() {
     for (auto& metric : metrics_) {
         this->cal_and_set_result(metric, result);
     }
+    result["measurement_method"]["latency"] = "steady_clock_around_knn_search";
+    result["measurement_method"]["qps"] = "successful_queries_per_wall_time";
+    result["measurement_sample_count"] = static_cast<uint64_t>(this->latency_records_.size());
+    result["measurement_successful_query_count"] = this->successful_query_count_;
+    result["measurement_duration(s)"] = this->wall_time_seconds_;
     return result;
 }
+
 void
-LatencyMonitor::Record(void* input) {
-    std::lock_guard<std::mutex> lock(record_mutex_);
-    std::thread::id thread_id = std::this_thread::get_id();
-    if (cur_time_.find(thread_id) == cur_time_.end()) {
-        cur_time_[thread_id] = Clock::now();
-        return;
-    }
-    auto end_time = Clock::now();
-    double duration =
-        std::chrono::duration<double, std::milli>(end_time - cur_time_[thread_id]).count();
-    this->latency_records_.emplace_back(duration);
-    this->cur_time_[thread_id] = Clock::now();
+LatencyMonitor::SetTimingBatch(LatencyTimingBatch timing_batch) {
+    this->latency_records_ = std::move(timing_batch.latency_ms);
+    this->latency_records_.erase(
+        std::remove_if(
+            this->latency_records_.begin(),
+            this->latency_records_.end(),
+            [](double latency_ms) { return not std::isfinite(latency_ms) or latency_ms < 0; }),
+        this->latency_records_.end());
+    this->successful_query_count_ = timing_batch.successful_query_count;
+    this->wall_time_seconds_ =
+        std::isfinite(timing_batch.wall_time_seconds) and timing_batch.wall_time_seconds > 0.0
+            ? timing_batch.wall_time_seconds
+            : 0.0;
 }
+
 void
 LatencyMonitor::SetMetrics(std::string metric) {
     this->metrics_.emplace_back(std::move(metric));
@@ -76,23 +87,28 @@ LatencyMonitor::cal_and_set_result(const std::string& metric, Monitor::JsonType&
 }
 
 double
-LatencyMonitor::cal_qps() {
-    double total_time_cost =
-        std::accumulate(this->latency_records_.begin(), this->latency_records_.end(), double(0));
-    auto thread_num = cur_time_.size();
-    auto query_num = latency_records_.size();
-    return static_cast<double>(query_num) * thread_num * 1000.0 / total_time_cost;
+LatencyMonitor::cal_qps() const {
+    if (this->successful_query_count_ == 0 or this->wall_time_seconds_ <= 0.0) {
+        return 0.0;
+    }
+    return static_cast<double>(this->successful_query_count_) / this->wall_time_seconds_;
 }
 
 double
-LatencyMonitor::cal_avg_latency() {
+LatencyMonitor::cal_avg_latency() const {
+    if (this->latency_records_.empty()) {
+        return 0.0;
+    }
     double total_time_cost =
         std::accumulate(this->latency_records_.begin(), this->latency_records_.end(), double(0));
-    auto query_num = latency_records_.size();
-    return total_time_cost / static_cast<double>(query_num);
+    return total_time_cost / static_cast<double>(this->latency_records_.size());
 }
+
 double
 LatencyMonitor::cal_latency_rate(double rate) {
+    if (this->latency_records_.empty()) {
+        return 0.0;
+    }
     std::sort(this->latency_records_.begin(), this->latency_records_.end());
     auto pos = static_cast<uint64_t>(rate * static_cast<double>(this->latency_records_.size() - 1));
     return latency_records_[pos];

--- a/tools/eval/monitor/latency_monitor.h
+++ b/tools/eval/monitor/latency_monitor.h
@@ -15,16 +15,21 @@
 
 #pragma once
 
-#include <chrono>
-#include <thread>
-#include <unordered_map>
+#include <cstdint>
+#include <vector>
 
 #include "monitor.h"
 namespace vsag::eval {
 
+struct LatencyTimingBatch {
+    std::vector<double> latency_ms;
+    uint64_t successful_query_count{0};
+    double wall_time_seconds{0.0};
+};
+
 class LatencyMonitor : public Monitor {
 public:
-    explicit LatencyMonitor(uint64_t max_record_counts = 0);
+    LatencyMonitor();
 
     ~LatencyMonitor() override = default;
 
@@ -38,7 +43,7 @@ public:
     GetResult() override;
 
     void
-    Record(void* input) override;
+    SetTimingBatch(LatencyTimingBatch timing_batch);
 
     void
     SetMetrics(std::string metric);
@@ -48,10 +53,10 @@ private:
     cal_and_set_result(const std::string& metric, JsonType& result);
 
     double
-    cal_qps();
+    cal_qps() const;
 
     double
-    cal_avg_latency();
+    cal_avg_latency() const;
 
     double
     cal_latency_rate(double rate);
@@ -59,8 +64,9 @@ private:
 private:
     std::vector<double> latency_records_;
 
-    using Clock = std::chrono::high_resolution_clock;
-    std::unordered_map<std::thread::id, decltype(Clock::now())> cur_time_;
+    uint64_t successful_query_count_{0};
+
+    double wall_time_seconds_{0.0};
 
     std::vector<std::string> metrics_;
 };

--- a/tools/eval/monitor/latency_monitor_test.cpp
+++ b/tools/eval/monitor/latency_monitor_test.cpp
@@ -1,0 +1,164 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "latency_monitor.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "../case/search_timing.h"
+
+namespace vsag::eval {
+namespace {
+
+class ManualClock {
+public:
+    using rep = int64_t;
+    using period = std::milli;
+    using duration = std::chrono::duration<rep, period>;
+    using time_point = std::chrono::time_point<ManualClock>;
+    static constexpr bool is_steady = true;
+
+    static time_point
+    now() noexcept {
+        return time_point(duration(now_ms_));
+    }
+
+    static void
+    Set(int64_t now_ms) {
+        now_ms_ = now_ms;
+    }
+
+    static void
+    Advance(int64_t duration_ms) {
+        now_ms_ += duration_ms;
+    }
+
+private:
+    inline static int64_t now_ms_{0};
+};
+
+void
+EnableAllMetrics(LatencyMonitor& monitor) {
+    monitor.SetMetrics("qps");
+    monitor.SetMetrics("avg_latency");
+    monitor.SetMetrics("percent_latency");
+}
+
+void
+RequireNear(double actual, double expected) {
+    REQUIRE(std::abs(actual - expected) < 1e-9);
+}
+
+void
+RequireAllPercentiles(const Monitor::JsonType& result, double expected) {
+    for (const auto* percentile : {"p50", "p80", "p90", "p95", "p99"}) {
+        RequireNear(result["latency_detail(ms)"][percentile].get<double>(), expected);
+    }
+}
+
+}  // namespace
+
+TEST_CASE("MeasureSearch excludes query preparation and statistics",
+          "[ut][eval][latency_monitor]") {
+    ManualClock::Set(0);
+    ManualClock::Advance(11);
+
+    auto [result, latency_ms] = MeasureSearch<ManualClock>([]() {
+        ManualClock::Advance(7);
+        return 42;
+    });
+
+    ManualClock::Advance(13);
+
+    REQUIRE(result == 42);
+    RequireNear(latency_ms, 7.0);
+    REQUIRE(ManualClock::now().time_since_epoch().count() == 31);
+}
+
+TEST_CASE("LatencyMonitor retains the first query sample", "[ut][eval][latency_monitor]") {
+    LatencyMonitor monitor;
+    EnableAllMetrics(monitor);
+
+    monitor.Start();
+    monitor.SetTimingBatch(LatencyTimingBatch{{7.0}, 1, 0.25});
+    monitor.Stop();
+    const auto result = monitor.GetResult();
+
+    RequireNear(result["qps"].get<double>(), 4.0);
+    RequireNear(result["latency_avg(ms)"].get<double>(), 7.0);
+    RequireAllPercentiles(result, 7.0);
+    REQUIRE(result["measurement_sample_count"].get<uint64_t>() == 1);
+    REQUIRE(result["measurement_successful_query_count"].get<uint64_t>() == 1);
+    RequireNear(result["measurement_duration(s)"].get<double>(), 0.25);
+    REQUIRE(result["measurement_method"]["latency"].get<std::string>() ==
+            "steady_clock_around_knn_search");
+    REQUIRE(result["measurement_method"]["qps"].get<std::string>() ==
+            "successful_queries_per_wall_time");
+}
+
+TEST_CASE("LatencyMonitor uses batch wall time for imbalanced workers",
+          "[ut][eval][latency_monitor]") {
+    std::vector<double> latency_ms{100.0};
+    latency_ms.insert(latency_ms.end(), 10, 1.0);
+
+    LatencyMonitor monitor;
+    EnableAllMetrics(monitor);
+    monitor.Start();
+    monitor.SetTimingBatch(LatencyTimingBatch{std::move(latency_ms), 11, 0.1});
+    monitor.Stop();
+    const auto result = monitor.GetResult();
+
+    RequireNear(result["qps"].get<double>(), 110.0);
+    RequireNear(result["latency_avg(ms)"].get<double>(), 10.0);
+    REQUIRE(result["measurement_sample_count"].get<uint64_t>() == 11);
+    REQUIRE(result["measurement_successful_query_count"].get<uint64_t>() == 11);
+    RequireNear(result["measurement_duration(s)"].get<double>(), 0.1);
+}
+
+TEST_CASE("LatencyMonitor computes QPS from successful queries", "[ut][eval][latency_monitor]") {
+    LatencyMonitor monitor;
+    monitor.SetMetrics("qps");
+    monitor.Start();
+    monitor.SetTimingBatch(LatencyTimingBatch{{1.0, 2.0, 3.0}, 2, 0.5});
+    monitor.Stop();
+
+    const auto result = monitor.GetResult();
+    RequireNear(result["qps"].get<double>(), 4.0);
+    REQUIRE(result["measurement_sample_count"].get<uint64_t>() == 3);
+    REQUIRE(result["measurement_successful_query_count"].get<uint64_t>() == 2);
+}
+
+TEST_CASE("LatencyMonitor handles an empty timing batch", "[ut][eval][latency_monitor]") {
+    LatencyMonitor monitor;
+    EnableAllMetrics(monitor);
+    monitor.Start();
+    monitor.SetTimingBatch(LatencyTimingBatch{{}, 0, 0.0});
+    monitor.Stop();
+
+    const auto result = monitor.GetResult();
+    RequireNear(result["qps"].get<double>(), 0.0);
+    RequireNear(result["latency_avg(ms)"].get<double>(), 0.0);
+    RequireAllPercentiles(result, 0.0);
+    REQUIRE(result["measurement_sample_count"].get<uint64_t>() == 0);
+    REQUIRE(result["measurement_successful_query_count"].get<uint64_t>() == 0);
+    RequireNear(result["measurement_duration(s)"].get<double>(), 0.0);
+}
+
+}  // namespace vsag::eval


### PR DESCRIPTION
## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement/Refactor
- [x] Documentation
- [x] CI/Build/Infra

## Linked Issue

- Fixes: #2470

## What Changed

- Root cause: `LatencyMonitor` inferred latency from gaps between per-thread
  `Record()` callbacks. This dropped each worker's first query and included
  query preparation, statistics extraction, scheduling, and monitor-lock
  contention. QPS was then estimated from those intervals and active-thread
  count instead of measured wall time, producing biased results for imbalanced
  workloads.
- Measure every KNN and filtered-KNN search directly around
  `Index::KnnSearch` with `std::chrono::steady_clock`, including the first
  query.
- Compute QPS as successful query count divided by the measured search-pass
  wall time.
- Store latency samples in preallocated per-iteration slots and publish the
  batch after workers join, avoiding a lock in the timed path.
- Keep statistics extraction, recall calculation, and memory sampling outside
  the latency/QPS pass.
- Preserve existing metric keys and add measurement method, sample count,
  successful query count, and duration metadata.
- Handle empty or invalid timing batches safely.
- Add deterministic regression coverage, wire it into the default test target
  and PR CI, and document the new semantics in English and Chinese.

## Test Evidence

- [ ] `make fmt`
- [ ] `make lint`
- [ ] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [x] Other (describe below)

Test details:

```text
eval_monitor_test: 5 test cases, 33 assertions passed
ASan target with ENABLE_TOOLS=OFF: eval_monitor_test passed
clang 15 + libomp compile check for search_eval_case.cpp: passed
clang-format 15 validation: passed
git diff --check: passed
GitHub workflow YAML parse: passed

A complete tools build with the default Apple clang remains blocked by the
repository's existing raw -fopenmp flag:
clang++: error: unsupported option '-fopenmp'
The changed search source was independently validated with clang 15 + libomp.
```

## Compatibility Impact

- API/ABI compatibility: None. The change is internal to `eval_performance`;
  existing metric keys are preserved and JSON output is extended with metadata.
- Behavior changes: Latency and QPS now use explicit search-boundary
  measurements. Results from the previous callback-interval implementation are
  not directly comparable.

## Performance and Concurrency Impact

- Performance impact: Measurement accuracy is improved. The timed path adds
  steady-clock reads but removes callback locking; configurations that need a
  separate statistics pass may take longer overall.
- Concurrency/thread-safety impact: Each OpenMP iteration writes to a unique
  preallocated sample slot, and the monitor receives the completed batch after
  the parallel region.

## Documentation Impact

- [ ] No docs update needed
- [x] Updated docs:
  - [ ] `README.md`
  - [ ] `DEVELOPMENT.md`
  - [ ] `CONTRIBUTING.md`
  - [x] Other: `docs/docs/en/src/resources/eval.md`,
    `docs/docs/zh/src/resources/eval.md`

## Risk and Rollback

- Risk level: Medium, because benchmark semantics intentionally change.
- Rollback plan: Revert this PR to restore the previous callback-interval
  implementation and output semantics.

## Checklist

- [x] I have linked the relevant issue (required for `kind/bug` and
  `kind/feature`; see "Linked Issue" above)
- [x] I have added/updated tests for new behavior or bug fixes
- [x] I have considered API compatibility impact
- [x] I have updated docs if behavior/workflow changed
- [x] My commit messages follow project conventions (Conventional Commits,
  optional `[skip ci]` prefix)
