### PR TITLE
feat(ivf): support bucket-aligned precise codes

### DIFF
--- a/docs/docs/en/src/advanced/new_serialization.md
+++ b/docs/docs/en/src/advanced/new_serialization.md
@@ -177,11 +177,14 @@ IVF writes these streaming blocks in order:
 | `ivf_bucket` | bucket datacell payloads for inverted lists | yes |
 | `ivf_partition_strategy` | partition strategy state, such as trained centroids | yes |
 | `label_table` | external labels and label remap | yes |
-| `high_precision_codes` | reorder codes when IVF reorder is enabled | conditional |
+| `high_precision_codes` | flat reorder codes when IVF reorder uses the `flat` layout | conditional |
+| `ivf_precise_bucket` | bucket-aligned reorder codes when IVF reorder uses the `bucket` layout | conditional |
 | `attribute_filter` | optional attribute filter index | conditional |
 
 `DeserializeStreaming` restores the full in-memory IVF index. `Index::Load` can create the IVF
 index directly from streaming metadata and currently loads all emitted IVF blocks into memory.
+The two precise-code blocks are mutually exclusive and are selected by
+`precise_codes_layout`.
 
 ## SINDI Blocks
 

--- a/docs/docs/en/src/advanced/new_serialization.md
+++ b/docs/docs/en/src/advanced/new_serialization.md
@@ -184,7 +184,9 @@ IVF writes these streaming blocks in order:
 `DeserializeStreaming` restores the full in-memory IVF index. `Index::Load` can create the IVF
 index directly from streaming metadata and currently loads all emitted IVF blocks into memory.
 The two precise-code blocks are mutually exclusive and are selected by
-`precise_codes_layout`.
+`precise_codes_layout`. For file-backed bucket-aligned precise codes, create an IVF destination
+with an independent `precise_file_path` and use `DeserializeStreaming`; static `Index::Load` is
+rejected until it can accept an independent target path.
 
 ## SINDI Blocks
 

--- a/docs/docs/en/src/advanced/new_serialization.md
+++ b/docs/docs/en/src/advanced/new_serialization.md
@@ -184,9 +184,7 @@ IVF writes these streaming blocks in order:
 `DeserializeStreaming` restores the full in-memory IVF index. `Index::Load` can create the IVF
 index directly from streaming metadata and currently loads all emitted IVF blocks into memory.
 The two precise-code blocks are mutually exclusive and are selected by
-`precise_codes_layout`. For file-backed bucket-aligned precise codes, create an IVF destination
-with an independent `precise_file_path` and use `DeserializeStreaming`; static `Index::Load` is
-rejected until it can accept an independent target path.
+`precise_codes_layout`.
 
 ## SINDI Blocks
 

--- a/docs/docs/en/src/advanced/new_serialization.md
+++ b/docs/docs/en/src/advanced/new_serialization.md
@@ -73,8 +73,8 @@ blocks. The parameters object can be built from a JSON string and can also carry
 with `SetReader`. Unsupported policies return an error instead of silently falling back. The API
 currently supports streaming BruteForce, HGraph, IVF, SINDI, and Pyramid indexes. BruteForce
 supports limited block placement policies. HGraph can bind `high_precision_codes` to an external
-reader through `precise_reader`. IVF, SINDI, and Pyramid currently load all emitted streaming
-blocks into memory.
+reader through `precise_reader`. IVF can do the same for either precise-code layout. SINDI and
+Pyramid currently load all emitted streaming blocks into memory.
 
 ## File Layout
 
@@ -178,13 +178,20 @@ IVF writes these streaming blocks in order:
 | `ivf_partition_strategy` | partition strategy state, such as trained centroids | yes |
 | `label_table` | external labels and label remap | yes |
 | `high_precision_codes` | flat reorder codes when IVF reorder uses the `flat` layout | conditional |
-| `ivf_precise_bucket` | bucket-aligned reorder codes when IVF reorder uses the `bucket` layout | conditional |
+| `ivf_precise_bucket` | bucket-aligned reorder codes when IVF uses the `bucket` layout | conditional |
 | `attribute_filter` | optional attribute filter index | conditional |
 
+`Load` can bind either precise-code block to an external reader. Set `precise_io_type` to
+`reader_io`, provide `precise_reader`, and make the reader expose exactly the
+`high_precision_codes` payload for `flat` or the `ivf_precise_bucket` payload for `bucket`. `Load`
+validates its size and checksum before the returned index can query it.
+`precise_enable_read_cache` and `precise_cache_total_size` configure the normal read cache for
+the remote precise codes.
+
 `DeserializeStreaming` restores the full in-memory IVF index. `Index::Load` can create the IVF
-index directly from streaming metadata and currently loads all emitted IVF blocks into memory.
-The two precise-code blocks are mutually exclusive and are selected by
-`precise_codes_layout`.
+index directly from streaming metadata. It loads IVF blocks into memory by default; reader-backed
+precise codes remain external. The two precise-code blocks are mutually exclusive and are selected
+by `precise_codes_layout`.
 
 ## SINDI Blocks
 

--- a/docs/docs/en/src/indexes/ivf.md
+++ b/docs/docs/en/src/indexes/ivf.md
@@ -64,37 +64,6 @@ auto result = index->KnnSearch(
     R"({"ivf": {"scan_buckets_count": 16}})").value();
 ```
 
-### Bucket-aligned precise codes
-
-For disk-backed precise reordering, enable the bucket layout while keeping the
-existing precise quantization and IO parameters:
-
-```cpp
-std::string params = R"({
-    "dtype": "float32",
-    "metric_type": "l2",
-    "dim": 128,
-    "index_param": {
-        "buckets_count": 256,
-        "buckets_per_data": 1,
-        "base_quantization_type": "sq8",
-        "partition_strategy_type": "ivf",
-        "ivf_train_type": "kmeans",
-
-        "use_reorder": true,
-        "precise_quantization_type": "fp32",
-        "precise_codes_layout": "bucket",
-        "precise_io_type": "buffer_io",
-        "precise_file_path": "/data/ivf-precise.bin"
-    }
-})";
-
-auto index = vsag::Factory::CreateIndex("ivf", params).value();
-```
-
-`precise_codes_layout` is the only new parameter in this example. Build and
-search use the same APIs and search parameters as the regular IVF quick start.
-
 ## Build parameters
 
 Build-time parameters live under `index_param`. See

--- a/docs/docs/en/src/indexes/ivf.md
+++ b/docs/docs/en/src/indexes/ivf.md
@@ -94,12 +94,17 @@ Build-time parameters live under `index_param`. See
 | `precise_file_path` | string | `""` | File path when the precise IO type is disk-backed |
 
 `precise_codes_layout: "bucket"` requires `use_reorder: true`. It supports
-`memory_io`, `block_memory_io`, `mmap_io`, `buffer_io`, `async_io`, and `uring_io`
-(when io_uring is available);
-`reader_io` and `pqfs` precise quantization are not supported. When
+`memory_io`, `block_memory_io`, `buffer_io`, `async_io`, and `uring_io`
+(when io_uring is available); `mmap_io`, `reader_io`, and `pqfs` precise
+quantization are not supported. When
 `buckets_per_data` is greater than one, the precise vector is duplicated for every
 basic posting, preserving exact bucket-offset alignment at the corresponding storage
 cost.
+
+For file-backed bucket-aligned precise codes, `Clone`, `ExportModel`, `Merge`, and static
+`Index::Load` are rejected because those operations cannot yet assign an independent target
+file. To restore a streaming index on disk, create the destination IVF with a different
+`precise_file_path` and call `DeserializeStreaming`.
 
 A rule of thumb for `buckets_count` is `sqrt(N)` to `4 * sqrt(N)` where `N` is the
 corpus size.

--- a/docs/docs/en/src/indexes/ivf.md
+++ b/docs/docs/en/src/indexes/ivf.md
@@ -64,6 +64,37 @@ auto result = index->KnnSearch(
     R"({"ivf": {"scan_buckets_count": 16}})").value();
 ```
 
+### Bucket-aligned precise codes
+
+For disk-backed precise reordering, enable the bucket layout while keeping the
+existing precise quantization and IO parameters:
+
+```cpp
+std::string params = R"({
+    "dtype": "float32",
+    "metric_type": "l2",
+    "dim": 128,
+    "index_param": {
+        "buckets_count": 256,
+        "buckets_per_data": 1,
+        "base_quantization_type": "sq8",
+        "partition_strategy_type": "ivf",
+        "ivf_train_type": "kmeans",
+
+        "use_reorder": true,
+        "precise_quantization_type": "fp32",
+        "precise_codes_layout": "bucket",
+        "precise_io_type": "buffer_io",
+        "precise_file_path": "/data/ivf-precise.bin"
+    }
+})";
+
+auto index = vsag::Factory::CreateIndex("ivf", params).value();
+```
+
+`precise_codes_layout` is the only new parameter in this example. Build and
+search use the same APIs and search parameters as the regular IVF quick start.
+
 ## Build parameters
 
 Build-time parameters live under `index_param`. See

--- a/docs/docs/en/src/indexes/ivf.md
+++ b/docs/docs/en/src/indexes/ivf.md
@@ -88,9 +88,18 @@ Build-time parameters live under `index_param`. See
 | `fast_encode_rabitq_rounds` | int | `6` | CAQ adjustment rounds; allowed range is `[1, 32]` |
 | `use_reorder` | bool | `false` | Keep a high-precision copy and re-rank after the coarse scan |
 | `precise_quantization_type` | string | `"fp32"` | Quantizer used for reordering (with `use_reorder: true`) |
+| `precise_codes_layout` | string | `"flat"` | Storage layout for precise codes: `"flat"` keeps the legacy one-code-per-vector layout; `"bucket"` mirrors every basic posting in the same bucket and offset |
 | `base_io_type` | string | `"memory_io"` | Storage backend for coarse codes; supports `uring_io` when built with liburing |
 | `precise_io_type` | string | `"block_memory_io"` | Storage backend for precise codes (`memory_io`, `block_memory_io`, `mmap_io`, `buffer_io`, `async_io`, `uring_io`, `reader_io`) |
 | `precise_file_path` | string | `""` | File path when the precise IO type is disk-backed |
+
+`precise_codes_layout: "bucket"` requires `use_reorder: true`. It supports
+`memory_io`, `block_memory_io`, `mmap_io`, `buffer_io`, `async_io`, and `uring_io`
+(when io_uring is available);
+`reader_io` and `pqfs` precise quantization are not supported. When
+`buckets_per_data` is greater than one, the precise vector is duplicated for every
+basic posting, preserving exact bucket-offset alignment at the corresponding storage
+cost.
 
 A rule of thumb for `buckets_count` is `sqrt(N)` to `4 * sqrt(N)` where `N` is the
 corpus size.

--- a/docs/docs/en/src/indexes/ivf.md
+++ b/docs/docs/en/src/indexes/ivf.md
@@ -88,7 +88,7 @@ Build-time parameters live under `index_param`. See
 | `fast_encode_rabitq_rounds` | int | `6` | CAQ adjustment rounds; allowed range is `[1, 32]` |
 | `use_reorder` | bool | `false` | Keep a high-precision copy and re-rank after the coarse scan |
 | `precise_quantization_type` | string | `"fp32"` | Quantizer used for reordering (with `use_reorder: true`) |
-| `precise_codes_layout` | string | `"flat"` | Storage layout for precise codes: `"flat"` keeps the legacy one-code-per-vector layout; `"bucket"` mirrors every basic posting in the same bucket and offset |
+| `precise_codes_layout` | string | `"flat"` | Storage layout for precise codes: `"flat"` keeps the legacy one-code-per-vector layout; `"bucket"` stores the precise code in the same bucket and offset as its basic posting |
 | `base_io_type` | string | `"memory_io"` | Storage backend for coarse codes; supports `uring_io` when built with liburing |
 | `precise_io_type` | string | `"block_memory_io"` | Storage backend for precise codes (`memory_io`, `block_memory_io`, `mmap_io`, `buffer_io`, `async_io`, `uring_io`, `reader_io`) |
 | `precise_file_path` | string | `""` | File path when the precise IO type is disk-backed |
@@ -96,10 +96,8 @@ Build-time parameters live under `index_param`. See
 `precise_codes_layout: "bucket"` requires `use_reorder: true`. It supports
 `memory_io`, `block_memory_io`, `buffer_io`, `async_io`, and `uring_io`
 (when io_uring is available); `mmap_io`, `reader_io`, and `pqfs` precise
-quantization are not supported. When
-`buckets_per_data` is greater than one, the precise vector is duplicated for every
-basic posting, preserving exact bucket-offset alignment at the corresponding storage
-cost.
+quantization are not supported. The bucket layout currently requires
+`buckets_per_data: 1`; configurations that assign one vector to multiple buckets are rejected.
 
 For file-backed bucket-aligned precise codes, `Clone`, `ExportModel`, `Merge`, and static
 `Index::Load` are rejected because those operations cannot yet assign an independent target

--- a/docs/docs/en/src/indexes/ivf.md
+++ b/docs/docs/en/src/indexes/ivf.md
@@ -101,11 +101,6 @@ Build-time parameters live under `index_param`. See
 quantization are not supported. The bucket layout currently requires
 `buckets_per_data: 1`; configurations that assign one vector to multiple buckets are rejected.
 
-For file-backed bucket-aligned precise codes, `Clone`, `ExportModel`, `Merge`, and static
-`Index::Load` are rejected because those operations cannot yet assign an independent target
-file. To restore a streaming index on disk, create the destination IVF with a different
-`precise_file_path` and call `DeserializeStreaming`.
-
 A rule of thumb for `buckets_count` is `sqrt(N)` to `4 * sqrt(N)` where `N` is the
 corpus size.
 

--- a/docs/docs/en/src/indexes/ivf.md
+++ b/docs/docs/en/src/indexes/ivf.md
@@ -97,9 +97,27 @@ Build-time parameters live under `index_param`. See
 
 `precise_codes_layout: "bucket"` requires `use_reorder: true`. It supports
 `memory_io`, `block_memory_io`, `buffer_io`, `async_io`, and `uring_io`
-(when io_uring is available); `mmap_io`, `reader_io`, and `pqfs` precise
-quantization are not supported. The bucket layout currently requires
+(when io_uring is available).
+`mmap_io` and `pqfs` precise quantization are not supported. The bucket layout currently requires
 `buckets_per_data: 1`; configurations that assign one vector to multiple buckets are rejected.
+
+For both `flat` and `bucket` layouts, serialized precise codes can be loaded read-only from an
+external `Reader`. Pass `precise_io_type: "reader_io"` and `precise_reader` to `Index::Load`.
+The reader must expose exactly the `high_precision_codes` block payload for `flat`, or the
+`ivf_precise_bucket` block payload for `bucket`. `reader_io` uses the normal read cache when
+`precise_enable_read_cache` is enabled.
+
+```cpp
+vsag::LoadParameters load_parameters;
+load_parameters.Set("precise_io_type", "reader_io")
+    .Set("precise_enable_read_cache", true)
+    .Set("precise_cache_total_size", 256ULL * 1024 * 1024)
+    .SetReader("precise_reader", precise_codes_reader);
+auto loaded = vsag::Index::Load(stream, load_parameters).value();
+```
+
+`reader_io` is a load-and-query placement policy. Build the index with a writable precise IO,
+serialize it, and then use the external reader when loading it for search.
 
 A rule of thumb for `buckets_count` is `sqrt(N)` to `4 * sqrt(N)` where `N` is the
 corpus size.

--- a/docs/docs/en/src/indexes/ivf.md
+++ b/docs/docs/en/src/indexes/ivf.md
@@ -90,7 +90,7 @@ Build-time parameters live under `index_param`. See
 | `fast_encode_rabitq_rounds` | int | `6` | CAQ adjustment rounds; allowed range is `[1, 32]` |
 | `use_reorder` | bool | `false` | Keep a high-precision copy and re-rank after the coarse scan |
 | `precise_quantization_type` | string | `"fp32"` | Quantizer used for reordering (with `use_reorder: true`) |
-| `precise_codes_layout` | string | `"flat"` | Storage layout for precise codes: `"flat"` keeps the legacy one-code-per-vector layout; `"bucket"` mirrors every basic posting in the same bucket and offset |
+| `precise_codes_layout` | string | `"flat"` | Storage layout for precise codes: `"flat"` keeps the legacy one-code-per-vector layout; `"bucket"` stores the precise code in the same bucket and offset as its basic posting |
 | `base_io_type` | string | `"memory_io"` | Storage backend for coarse codes; supports `uring_io` when built with liburing |
 | `precise_io_type` | string | `"block_memory_io"` | Storage backend for precise codes (`memory_io`, `block_memory_io`, `mmap_io`, `buffer_io`, `async_io`, `uring_io`, `reader_io`) |
 | `precise_file_path` | string | `""` | File path when the precise IO type is disk-backed |
@@ -98,10 +98,8 @@ Build-time parameters live under `index_param`. See
 `precise_codes_layout: "bucket"` requires `use_reorder: true`. It supports
 `memory_io`, `block_memory_io`, `buffer_io`, `async_io`, and `uring_io`
 (when io_uring is available); `mmap_io`, `reader_io`, and `pqfs` precise
-quantization are not supported. When
-`buckets_per_data` is greater than one, the precise vector is duplicated for every
-basic posting, preserving exact bucket-offset alignment at the corresponding storage
-cost.
+quantization are not supported. The bucket layout currently requires
+`buckets_per_data: 1`; configurations that assign one vector to multiple buckets are rejected.
 
 For file-backed bucket-aligned precise codes, `Clone`, `ExportModel`, `Merge`, and static
 `Index::Load` are rejected because those operations cannot yet assign an independent target

--- a/docs/docs/en/src/indexes/ivf.md
+++ b/docs/docs/en/src/indexes/ivf.md
@@ -96,12 +96,17 @@ Build-time parameters live under `index_param`. See
 | `precise_file_path` | string | `""` | File path when the precise IO type is disk-backed |
 
 `precise_codes_layout: "bucket"` requires `use_reorder: true`. It supports
-`memory_io`, `block_memory_io`, `mmap_io`, `buffer_io`, `async_io`, and `uring_io`
-(when io_uring is available);
-`reader_io` and `pqfs` precise quantization are not supported. When
+`memory_io`, `block_memory_io`, `buffer_io`, `async_io`, and `uring_io`
+(when io_uring is available); `mmap_io`, `reader_io`, and `pqfs` precise
+quantization are not supported. When
 `buckets_per_data` is greater than one, the precise vector is duplicated for every
 basic posting, preserving exact bucket-offset alignment at the corresponding storage
 cost.
+
+For file-backed bucket-aligned precise codes, `Clone`, `ExportModel`, `Merge`, and static
+`Index::Load` are rejected because those operations cannot yet assign an independent target
+file. To restore a streaming index on disk, create the destination IVF with a different
+`precise_file_path` and call `DeserializeStreaming`.
 
 A rule of thumb for `buckets_count` is `sqrt(N)` to `4 * sqrt(N)` where `N` is the
 corpus size.

--- a/docs/docs/en/src/indexes/ivf.md
+++ b/docs/docs/en/src/indexes/ivf.md
@@ -90,9 +90,18 @@ Build-time parameters live under `index_param`. See
 | `fast_encode_rabitq_rounds` | int | `6` | CAQ adjustment rounds; allowed range is `[1, 32]` |
 | `use_reorder` | bool | `false` | Keep a high-precision copy and re-rank after the coarse scan |
 | `precise_quantization_type` | string | `"fp32"` | Quantizer used for reordering (with `use_reorder: true`) |
+| `precise_codes_layout` | string | `"flat"` | Storage layout for precise codes: `"flat"` keeps the legacy one-code-per-vector layout; `"bucket"` mirrors every basic posting in the same bucket and offset |
 | `base_io_type` | string | `"memory_io"` | Storage backend for coarse codes; supports `uring_io` when built with liburing |
 | `precise_io_type` | string | `"block_memory_io"` | Storage backend for precise codes (`memory_io`, `block_memory_io`, `mmap_io`, `buffer_io`, `async_io`, `uring_io`, `reader_io`) |
 | `precise_file_path` | string | `""` | File path when the precise IO type is disk-backed |
+
+`precise_codes_layout: "bucket"` requires `use_reorder: true`. It supports
+`memory_io`, `block_memory_io`, `mmap_io`, `buffer_io`, `async_io`, and `uring_io`
+(when io_uring is available);
+`reader_io` and `pqfs` precise quantization are not supported. When
+`buckets_per_data` is greater than one, the precise vector is duplicated for every
+basic posting, preserving exact bucket-offset alignment at the corresponding storage
+cost.
 
 A rule of thumb for `buckets_count` is `sqrt(N)` to `4 * sqrt(N)` where `N` is the
 corpus size.

--- a/docs/docs/zh/src/advanced/new_serialization.md
+++ b/docs/docs/zh/src/advanced/new_serialization.md
@@ -163,7 +163,9 @@ IVF 按顺序写入以下 streaming blocks：
 
 `DeserializeStreaming` 会恢复完整的内存 IVF 索引。`Index::Load` 可以直接从 streaming metadata
 创建 IVF 索引对象，当前会把写出的 IVF blocks 都加载到内存中。两种精排 codes block 互斥，
-由 `precise_codes_layout` 选择。
+由 `precise_codes_layout` 选择。对于文件型 bucket 精排 codes，请使用独立的
+`precise_file_path` 创建 IVF 目标对象并调用 `DeserializeStreaming`；在静态 `Index::Load`
+能够接收独立目标路径之前，该组合会被拒绝。
 
 ## SINDI Blocks
 

--- a/docs/docs/zh/src/advanced/new_serialization.md
+++ b/docs/docs/zh/src/advanced/new_serialization.md
@@ -157,11 +157,13 @@ IVF 按顺序写入以下 streaming blocks：
 | `ivf_bucket` | 倒排列表使用的 bucket datacell 数据 | 是 |
 | `ivf_partition_strategy` | partition strategy 状态，例如已训练的中心点 | 是 |
 | `label_table` | 外部 label 和 label remap | 是 |
-| `high_precision_codes` | IVF reorder 开启时的 reorder codes | 条件必需 |
+| `high_precision_codes` | IVF reorder 使用 `flat` 布局时的精排 codes | 条件必需 |
+| `ivf_precise_bucket` | IVF reorder 使用 `bucket` 布局时按桶对齐的精排 codes | 条件必需 |
 | `attribute_filter` | 开启属性过滤时写入的可选属性过滤索引 | 条件必需 |
 
 `DeserializeStreaming` 会恢复完整的内存 IVF 索引。`Index::Load` 可以直接从 streaming metadata
-创建 IVF 索引对象，当前会把写出的 IVF blocks 都加载到内存中。
+创建 IVF 索引对象，当前会把写出的 IVF blocks 都加载到内存中。两种精排 codes block 互斥，
+由 `precise_codes_layout` 选择。
 
 ## SINDI Blocks
 

--- a/docs/docs/zh/src/advanced/new_serialization.md
+++ b/docs/docs/zh/src/advanced/new_serialization.md
@@ -65,8 +65,9 @@ auto loaded = vsag::Index::Load(in, load_parameters).value();
 parameters 用来控制已支持 block 的加载策略；参数对象既可以从 JSON 字符串构造，也可以通过
 `SetReader` 携带 reader 对象。不支持的策略会返回错误，不会静默 fallback。当前该 API 支持 streaming
 BruteForce、HGraph、IVF、SINDI 和 Pyramid 索引。其中 BruteForce 支持有限的 block placement 策略；
-HGraph 支持通过 `precise_reader` 将 `high_precision_codes` 绑定到外部 reader；IVF、SINDI 和 Pyramid
-目前会把写出的 streaming blocks 加载到内存。
+HGraph 支持通过 `precise_reader` 将 `high_precision_codes` 绑定到外部 reader；IVF 的两种
+精排 codes 布局也都支持外部 reader；SINDI 和 Pyramid 目前会把写出的 streaming blocks
+加载到内存。
 
 ## 文件布局
 
@@ -158,12 +159,18 @@ IVF 按顺序写入以下 streaming blocks：
 | `ivf_partition_strategy` | partition strategy 状态，例如已训练的中心点 | 是 |
 | `label_table` | 外部 label 和 label remap | 是 |
 | `high_precision_codes` | IVF reorder 使用 `flat` 布局时的精排 codes | 条件必需 |
-| `ivf_precise_bucket` | IVF reorder 使用 `bucket` 布局时按桶对齐的精排 codes | 条件必需 |
+| `ivf_precise_bucket` | IVF 使用 `bucket` 布局时与倒排桶对齐的精排 codes | 条件必需 |
 | `attribute_filter` | 开启属性过滤时写入的可选属性过滤索引 | 条件必需 |
 
+`Load` 可以把任一种精排 codes block 绑定到外部 reader。设置
+`precise_io_type: "reader_io"` 并提供 `precise_reader`；`flat` 布局的 reader 必须恰好
+对应 `high_precision_codes` payload，`bucket` 布局则对应 `ivf_precise_bucket` payload。
+`Load` 会先校验 reader 的大小和 checksum，再返回可查询的索引。
+`precise_enable_read_cache` 和 `precise_cache_total_size` 用于配置远程精排 codes 的通用读缓存。
+
 `DeserializeStreaming` 会恢复完整的内存 IVF 索引。`Index::Load` 可以直接从 streaming metadata
-创建 IVF 索引对象，当前会把写出的 IVF blocks 都加载到内存中。两种精排 codes block 互斥，
-由 `precise_codes_layout` 选择。
+创建 IVF 索引对象。默认情况下会把 IVF blocks 加载到内存；使用 reader 的精排 codes
+会保留在外部。两种精排 codes block 互斥，由 `precise_codes_layout` 选择。
 
 ## SINDI Blocks
 

--- a/docs/docs/zh/src/advanced/new_serialization.md
+++ b/docs/docs/zh/src/advanced/new_serialization.md
@@ -163,9 +163,7 @@ IVF 按顺序写入以下 streaming blocks：
 
 `DeserializeStreaming` 会恢复完整的内存 IVF 索引。`Index::Load` 可以直接从 streaming metadata
 创建 IVF 索引对象，当前会把写出的 IVF blocks 都加载到内存中。两种精排 codes block 互斥，
-由 `precise_codes_layout` 选择。对于文件型 bucket 精排 codes，请使用独立的
-`precise_file_path` 创建 IVF 目标对象并调用 `DeserializeStreaming`；在静态 `Index::Load`
-能够接收独立目标路径之前，该组合会被拒绝。
+由 `precise_codes_layout` 选择。
 
 ## SINDI Blocks
 

--- a/docs/docs/zh/src/indexes/ivf.md
+++ b/docs/docs/zh/src/indexes/ivf.md
@@ -59,36 +59,6 @@ auto result = index->KnnSearch(
     R"({"ivf": {"scan_buckets_count": 16}})").value();
 ```
 
-### Bucket 对齐的精排 codes
-
-精排数据存储在磁盘上时，可以在复用现有精排量化与 IO 参数的基础上启用 bucket 布局：
-
-```cpp
-std::string params = R"({
-    "dtype": "float32",
-    "metric_type": "l2",
-    "dim": 128,
-    "index_param": {
-        "buckets_count": 256,
-        "buckets_per_data": 1,
-        "base_quantization_type": "sq8",
-        "partition_strategy_type": "ivf",
-        "ivf_train_type": "kmeans",
-
-        "use_reorder": true,
-        "precise_quantization_type": "fp32",
-        "precise_codes_layout": "bucket",
-        "precise_io_type": "buffer_io",
-        "precise_file_path": "/data/ivf-precise.bin"
-    }
-})";
-
-auto index = vsag::Factory::CreateIndex("ivf", params).value();
-```
-
-这个示例中唯一新增的参数是 `precise_codes_layout`。构建、查询接口及查询参数与普通 IVF
-快速开始示例完全相同。
-
 ## 构建参数
 
 构建参数放在 `index_param` 下。完整列表请见 [索引参数](../resources/index_parameters.md)。

--- a/docs/docs/zh/src/indexes/ivf.md
+++ b/docs/docs/zh/src/indexes/ivf.md
@@ -59,6 +59,36 @@ auto result = index->KnnSearch(
     R"({"ivf": {"scan_buckets_count": 16}})").value();
 ```
 
+### Bucket 对齐的精排 codes
+
+精排数据存储在磁盘上时，可以在复用现有精排量化与 IO 参数的基础上启用 bucket 布局：
+
+```cpp
+std::string params = R"({
+    "dtype": "float32",
+    "metric_type": "l2",
+    "dim": 128,
+    "index_param": {
+        "buckets_count": 256,
+        "buckets_per_data": 1,
+        "base_quantization_type": "sq8",
+        "partition_strategy_type": "ivf",
+        "ivf_train_type": "kmeans",
+
+        "use_reorder": true,
+        "precise_quantization_type": "fp32",
+        "precise_codes_layout": "bucket",
+        "precise_io_type": "buffer_io",
+        "precise_file_path": "/data/ivf-precise.bin"
+    }
+})";
+
+auto index = vsag::Factory::CreateIndex("ivf", params).value();
+```
+
+这个示例中唯一新增的参数是 `precise_codes_layout`。构建、查询接口及查询参数与普通 IVF
+快速开始示例完全相同。
+
 ## 构建参数
 
 构建参数放在 `index_param` 下。完整列表请见 [索引参数](../resources/index_parameters.md)。

--- a/docs/docs/zh/src/indexes/ivf.md
+++ b/docs/docs/zh/src/indexes/ivf.md
@@ -88,10 +88,14 @@ auto result = index->KnnSearch(
 | `precise_file_path` | string | `""` | 当精排 IO 为磁盘后端时的文件路径 |
 
 `precise_codes_layout: "bucket"` 要求 `use_reorder: true`，支持 `memory_io`、
-`block_memory_io`、`mmap_io`、`buffer_io`、`async_io` 和 `uring_io`
-（需要构建环境支持 io_uring），不支持
-`reader_io` 和 `pqfs` 精排量化。当 `buckets_per_data` 大于 1 时，每个 basic posting
+`block_memory_io`、`buffer_io`、`async_io` 和 `uring_io`
+（需要构建环境支持 io_uring），不支持 `mmap_io`、`reader_io` 和 `pqfs`
+精排量化。当 `buckets_per_data` 大于 1 时，每个 basic posting
 都会保存一份高精度向量，从而保持完全相同的 bucket-offset 对齐，同时占用相应倍数的存储空间。
+
+对于文件型 bucket 精排 codes，暂不支持 `Clone`、`ExportModel`、`Merge` 和静态
+`Index::Load`，因为这些操作目前无法为目标索引指定独立文件。若需从 streaming 数据恢复磁盘索引，
+请使用不同的 `precise_file_path` 创建目标 IVF，然后调用 `DeserializeStreaming`。
 
 `buckets_count` 的经验值一般为 `sqrt(N)` ~ `4 * sqrt(N)`，其中 `N` 是语料规模。
 

--- a/docs/docs/zh/src/indexes/ivf.md
+++ b/docs/docs/zh/src/indexes/ivf.md
@@ -82,9 +82,16 @@ auto result = index->KnnSearch(
 | `fast_encode_rabitq_rounds` | int | `6` | CAQ 微调轮数，允许范围 `[1, 32]` |
 | `use_reorder` | bool | `false` | 是否保留高精度副本用于精排 |
 | `precise_quantization_type` | string | `"fp32"` | 精排量化类型（`use_reorder: true` 时使用） |
+| `precise_codes_layout` | string | `"flat"` | 精排 codes 的存储布局：`"flat"` 保持旧的一向量一码布局；`"bucket"` 为 basic 的每个 posting 在相同 bucket 和 offset 保存一份高精度 code |
 | `base_io_type` | string | `"memory_io"` | 粗排向量的存储后端；以 liburing 构建时支持 `uring_io` |
 | `precise_io_type` | string | `"block_memory_io"` | 精排向量的存储后端（`memory_io`、`block_memory_io`、`mmap_io`、`buffer_io`、`async_io`、`uring_io`、`reader_io`） |
 | `precise_file_path` | string | `""` | 当精排 IO 为磁盘后端时的文件路径 |
+
+`precise_codes_layout: "bucket"` 要求 `use_reorder: true`，支持 `memory_io`、
+`block_memory_io`、`mmap_io`、`buffer_io`、`async_io` 和 `uring_io`
+（需要构建环境支持 io_uring），不支持
+`reader_io` 和 `pqfs` 精排量化。当 `buckets_per_data` 大于 1 时，每个 basic posting
+都会保存一份高精度向量，从而保持完全相同的 bucket-offset 对齐，同时占用相应倍数的存储空间。
 
 `buckets_count` 的经验值一般为 `sqrt(N)` ~ `4 * sqrt(N)`，其中 `N` 是语料规模。
 

--- a/docs/docs/zh/src/indexes/ivf.md
+++ b/docs/docs/zh/src/indexes/ivf.md
@@ -82,7 +82,7 @@ auto result = index->KnnSearch(
 | `fast_encode_rabitq_rounds` | int | `6` | CAQ 微调轮数，允许范围 `[1, 32]` |
 | `use_reorder` | bool | `false` | 是否保留高精度副本用于精排 |
 | `precise_quantization_type` | string | `"fp32"` | 精排量化类型（`use_reorder: true` 时使用） |
-| `precise_codes_layout` | string | `"flat"` | 精排 codes 的存储布局：`"flat"` 保持旧的一向量一码布局；`"bucket"` 为 basic 的每个 posting 在相同 bucket 和 offset 保存一份高精度 code |
+| `precise_codes_layout` | string | `"flat"` | 精排 codes 的存储布局：`"flat"` 保持旧的一向量一码布局；`"bucket"` 在 basic posting 的相同 bucket 和 offset 保存高精度 code |
 | `base_io_type` | string | `"memory_io"` | 粗排向量的存储后端；以 liburing 构建时支持 `uring_io` |
 | `precise_io_type` | string | `"block_memory_io"` | 精排向量的存储后端（`memory_io`、`block_memory_io`、`mmap_io`、`buffer_io`、`async_io`、`uring_io`、`reader_io`） |
 | `precise_file_path` | string | `""` | 当精排 IO 为磁盘后端时的文件路径 |
@@ -90,8 +90,8 @@ auto result = index->KnnSearch(
 `precise_codes_layout: "bucket"` 要求 `use_reorder: true`，支持 `memory_io`、
 `block_memory_io`、`buffer_io`、`async_io` 和 `uring_io`
 （需要构建环境支持 io_uring），不支持 `mmap_io`、`reader_io` 和 `pqfs`
-精排量化。当 `buckets_per_data` 大于 1 时，每个 basic posting
-都会保存一份高精度向量，从而保持完全相同的 bucket-offset 对齐，同时占用相应倍数的存储空间。
+精排量化。bucket 布局当前要求 `buckets_per_data: 1`；一个向量分配到多个 bucket
+的配置会被拒绝。
 
 对于文件型 bucket 精排 codes，暂不支持 `Clone`、`ExportModel`、`Merge` 和静态
 `Index::Load`，因为这些操作目前无法为目标索引指定独立文件。若需从 streaming 数据恢复磁盘索引，

--- a/docs/docs/zh/src/indexes/ivf.md
+++ b/docs/docs/zh/src/indexes/ivf.md
@@ -90,10 +90,14 @@ auto result = index->KnnSearch(
 | `precise_file_path` | string | `""` | 当精排 IO 为磁盘后端时的文件路径 |
 
 `precise_codes_layout: "bucket"` 要求 `use_reorder: true`，支持 `memory_io`、
-`block_memory_io`、`mmap_io`、`buffer_io`、`async_io` 和 `uring_io`
-（需要构建环境支持 io_uring），不支持
-`reader_io` 和 `pqfs` 精排量化。当 `buckets_per_data` 大于 1 时，每个 basic posting
+`block_memory_io`、`buffer_io`、`async_io` 和 `uring_io`
+（需要构建环境支持 io_uring），不支持 `mmap_io`、`reader_io` 和 `pqfs`
+精排量化。当 `buckets_per_data` 大于 1 时，每个 basic posting
 都会保存一份高精度向量，从而保持完全相同的 bucket-offset 对齐，同时占用相应倍数的存储空间。
+
+对于文件型 bucket 精排 codes，暂不支持 `Clone`、`ExportModel`、`Merge` 和静态
+`Index::Load`，因为这些操作目前无法为目标索引指定独立文件。若需从 streaming 数据恢复磁盘索引，
+请使用不同的 `precise_file_path` 创建目标 IVF，然后调用 `DeserializeStreaming`。
 
 `buckets_count` 的经验值一般为 `sqrt(N)` ~ `4 * sqrt(N)`，其中 `N` 是语料规模。
 

--- a/docs/docs/zh/src/indexes/ivf.md
+++ b/docs/docs/zh/src/indexes/ivf.md
@@ -84,7 +84,7 @@ auto result = index->KnnSearch(
 | `fast_encode_rabitq_rounds` | int | `6` | CAQ 微调轮数，允许范围 `[1, 32]` |
 | `use_reorder` | bool | `false` | 是否保留高精度副本用于精排 |
 | `precise_quantization_type` | string | `"fp32"` | 精排量化类型（`use_reorder: true` 时使用） |
-| `precise_codes_layout` | string | `"flat"` | 精排 codes 的存储布局：`"flat"` 保持旧的一向量一码布局；`"bucket"` 为 basic 的每个 posting 在相同 bucket 和 offset 保存一份高精度 code |
+| `precise_codes_layout` | string | `"flat"` | 精排 codes 的存储布局：`"flat"` 保持旧的一向量一码布局；`"bucket"` 在 basic posting 的相同 bucket 和 offset 保存高精度 code |
 | `base_io_type` | string | `"memory_io"` | 粗排向量的存储后端；以 liburing 构建时支持 `uring_io` |
 | `precise_io_type` | string | `"block_memory_io"` | 精排向量的存储后端（`memory_io`、`block_memory_io`、`mmap_io`、`buffer_io`、`async_io`、`uring_io`、`reader_io`） |
 | `precise_file_path` | string | `""` | 当精排 IO 为磁盘后端时的文件路径 |
@@ -92,8 +92,8 @@ auto result = index->KnnSearch(
 `precise_codes_layout: "bucket"` 要求 `use_reorder: true`，支持 `memory_io`、
 `block_memory_io`、`buffer_io`、`async_io` 和 `uring_io`
 （需要构建环境支持 io_uring），不支持 `mmap_io`、`reader_io` 和 `pqfs`
-精排量化。当 `buckets_per_data` 大于 1 时，每个 basic posting
-都会保存一份高精度向量，从而保持完全相同的 bucket-offset 对齐，同时占用相应倍数的存储空间。
+精排量化。bucket 布局当前要求 `buckets_per_data: 1`；一个向量分配到多个 bucket
+的配置会被拒绝。
 
 对于文件型 bucket 精排 codes，暂不支持 `Clone`、`ExportModel`、`Merge` 和静态
 `Index::Load`，因为这些操作目前无法为目标索引指定独立文件。若需从 streaming 数据恢复磁盘索引，

--- a/docs/docs/zh/src/indexes/ivf.md
+++ b/docs/docs/zh/src/indexes/ivf.md
@@ -84,9 +84,16 @@ auto result = index->KnnSearch(
 | `fast_encode_rabitq_rounds` | int | `6` | CAQ 微调轮数，允许范围 `[1, 32]` |
 | `use_reorder` | bool | `false` | 是否保留高精度副本用于精排 |
 | `precise_quantization_type` | string | `"fp32"` | 精排量化类型（`use_reorder: true` 时使用） |
+| `precise_codes_layout` | string | `"flat"` | 精排 codes 的存储布局：`"flat"` 保持旧的一向量一码布局；`"bucket"` 为 basic 的每个 posting 在相同 bucket 和 offset 保存一份高精度 code |
 | `base_io_type` | string | `"memory_io"` | 粗排向量的存储后端；以 liburing 构建时支持 `uring_io` |
 | `precise_io_type` | string | `"block_memory_io"` | 精排向量的存储后端（`memory_io`、`block_memory_io`、`mmap_io`、`buffer_io`、`async_io`、`uring_io`、`reader_io`） |
 | `precise_file_path` | string | `""` | 当精排 IO 为磁盘后端时的文件路径 |
+
+`precise_codes_layout: "bucket"` 要求 `use_reorder: true`，支持 `memory_io`、
+`block_memory_io`、`mmap_io`、`buffer_io`、`async_io` 和 `uring_io`
+（需要构建环境支持 io_uring），不支持
+`reader_io` 和 `pqfs` 精排量化。当 `buckets_per_data` 大于 1 时，每个 basic posting
+都会保存一份高精度向量，从而保持完全相同的 bucket-offset 对齐，同时占用相应倍数的存储空间。
 
 `buckets_count` 的经验值一般为 `sqrt(N)` ~ `4 * sqrt(N)`，其中 `N` 是语料规模。
 

--- a/docs/docs/zh/src/indexes/ivf.md
+++ b/docs/docs/zh/src/indexes/ivf.md
@@ -91,9 +91,26 @@ auto result = index->KnnSearch(
 
 `precise_codes_layout: "bucket"` 要求 `use_reorder: true`，支持 `memory_io`、
 `block_memory_io`、`buffer_io`、`async_io` 和 `uring_io`
-（需要构建环境支持 io_uring），不支持 `mmap_io`、`reader_io` 和 `pqfs`
-精排量化。bucket 布局当前要求 `buckets_per_data: 1`；一个向量分配到多个 bucket
-的配置会被拒绝。
+（需要构建环境支持 io_uring）。不支持 `mmap_io` 和 `pqfs` 精排量化。bucket 布局当前
+要求 `buckets_per_data: 1`；一个向量分配到多个 bucket 的配置会被拒绝。
+
+对于 `flat` 和 `bucket` 两种布局，序列化后的精排 codes 都可以通过外部 `Reader`
+只读加载。向 `Index::Load` 传入 `precise_io_type: "reader_io"` 和 `precise_reader`。
+`flat` 布局的 reader 必须恰好对应 `high_precision_codes` block payload，`bucket` 布局
+则必须对应 `ivf_precise_bucket` block payload。启用 `precise_enable_read_cache` 后，
+`reader_io` 会使用通用读缓存。
+
+```cpp
+vsag::LoadParameters load_parameters;
+load_parameters.Set("precise_io_type", "reader_io")
+    .Set("precise_enable_read_cache", true)
+    .Set("precise_cache_total_size", 256ULL * 1024 * 1024)
+    .SetReader("precise_reader", precise_codes_reader);
+auto loaded = vsag::Index::Load(stream, load_parameters).value();
+```
+
+`reader_io` 是加载与查询阶段的只读放置策略。构建时应使用可写的 precise IO，序列化后
+再在查询服务加载索引时绑定外部 reader。
 
 `buckets_count` 的经验值一般为 `sqrt(N)` ~ `4 * sqrt(N)`，其中 `N` 是语料规模。
 

--- a/docs/docs/zh/src/indexes/ivf.md
+++ b/docs/docs/zh/src/indexes/ivf.md
@@ -95,10 +95,6 @@ auto result = index->KnnSearch(
 精排量化。bucket 布局当前要求 `buckets_per_data: 1`；一个向量分配到多个 bucket
 的配置会被拒绝。
 
-对于文件型 bucket 精排 codes，暂不支持 `Clone`、`ExportModel`、`Merge` 和静态
-`Index::Load`，因为这些操作目前无法为目标索引指定独立文件。若需从 streaming 数据恢复磁盘索引，
-请使用不同的 `precise_file_path` 创建目标 IVF，然后调用 `DeserializeStreaming`。
-
 `buckets_count` 的经验值一般为 `sqrt(N)` ~ `4 * sqrt(N)`，其中 `N` 是语料规模。
 
 ## 检索参数

--- a/examples/cpp/326_feature_ivf_precise_bucket.cpp
+++ b/examples/cpp/326_feature_ivf_precise_bucket.cpp
@@ -1,0 +1,134 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <vsag/vsag.h>
+
+#include <chrono>
+#include <cstdlib>
+#include <filesystem>
+#include <iostream>
+#include <random>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+
+constexpr int64_t NUM_VECTORS = 1000;
+constexpr int64_t DIM = 32;
+
+}  // namespace
+
+int
+main() {
+    vsag::init();
+
+    /******************* Prepare Dataset *****************/
+    std::vector<int64_t> ids(NUM_VECTORS);
+    std::vector<float> vectors(NUM_VECTORS * DIM);
+    std::mt19937 rng(47);
+    std::uniform_real_distribution<float> distribution;
+    for (int64_t i = 0; i < NUM_VECTORS; ++i) {
+        ids[i] = i;
+    }
+    for (auto& value : vectors) {
+        value = distribution(rng);
+    }
+    auto base = vsag::Dataset::Make()
+                    ->NumElements(NUM_VECTORS)
+                    ->Dim(DIM)
+                    ->Ids(ids.data())
+                    ->Float32Vectors(vectors.data())
+                    ->Owner(false);
+
+    /******************* Create Disk-Backed Precise Codes *****************/
+    const auto unique_id = std::chrono::steady_clock::now().time_since_epoch().count();
+    const auto temp_dir = std::filesystem::temp_directory_path() /
+                          ("vsag-ivf-precise-bucket-" + std::to_string(unique_id));
+    std::filesystem::create_directories(temp_dir);
+    const auto precise_file_path = (temp_dir / "precise.codes").generic_string();
+
+    // precise_codes_layout is the only parameter introduced by bucket-aligned precise storage.
+    // The existing precise quantizer and IO settings are reused.
+    const auto build_params = std::string(R"(
+    {
+        "dtype": "float32",
+        "metric_type": "l2",
+        "dim": 32,
+        "index_param": {
+            "buckets_count": 16,
+            "buckets_per_data": 1,
+            "base_quantization_type": "sq8",
+            "partition_strategy_type": "ivf",
+            "ivf_train_type": "kmeans",
+            "use_reorder": true,
+            "precise_quantization_type": "fp32",
+            "precise_codes_layout": "bucket",
+            "precise_io_type": "buffer_io",
+            "precise_file_path": ")") +
+                              precise_file_path + R"("
+        }
+    }
+    )";
+
+    auto create_result = vsag::Factory::CreateIndex("ivf", build_params);
+    if (not create_result.has_value()) {
+        std::cerr << "Create index failed: " << create_result.error().message << std::endl;
+        std::filesystem::remove_all(temp_dir);
+        return EXIT_FAILURE;
+    }
+    auto index = std::move(create_result.value());
+
+    auto build_result = index->Build(base);
+    if (not build_result.has_value()) {
+        std::cerr << "Build failed: " << build_result.error().message << std::endl;
+        index.reset();
+        std::filesystem::remove_all(temp_dir);
+        return EXIT_FAILURE;
+    }
+
+    /******************* Search With Precise Reordering *****************/
+    auto query = vsag::Dataset::Make()
+                     ->NumElements(1)
+                     ->Dim(DIM)
+                     ->Float32Vectors(vectors.data())
+                     ->Owner(false);
+    const auto search_params = R"(
+    {
+        "ivf": {
+            "scan_buckets_count": 16,
+            "factor": 4.0
+        }
+    }
+    )";
+    {
+        auto search_result = index->KnnSearch(query, 10, search_params);
+        if (not search_result.has_value()) {
+            std::cerr << "Search failed: " << search_result.error().message << std::endl;
+            index.reset();
+            std::filesystem::remove_all(temp_dir);
+            return EXIT_FAILURE;
+        }
+
+        std::cout << "Top-" << search_result.value()->GetDim() << " results:" << std::endl;
+        for (int64_t i = 0; i < search_result.value()->GetDim(); ++i) {
+            std::cout << "  id=" << search_result.value()->GetIds()[i]
+                      << "  dist=" << search_result.value()->GetDistances()[i] << std::endl;
+        }
+    }
+
+    index.reset();
+    std::filesystem::remove_all(temp_dir);
+    return EXIT_SUCCESS;
+}

--- a/examples/cpp/329_feature_ivf_precise_bucket.cpp
+++ b/examples/cpp/329_feature_ivf_precise_bucket.cpp
@@ -1,0 +1,134 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <vsag/vsag.h>
+
+#include <chrono>
+#include <cstdlib>
+#include <filesystem>
+#include <iostream>
+#include <random>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+
+constexpr int64_t NUM_VECTORS = 1000;
+constexpr int64_t DIM = 32;
+
+}  // namespace
+
+int
+main() {
+    vsag::init();
+
+    /******************* Prepare Dataset *****************/
+    std::vector<int64_t> ids(NUM_VECTORS);
+    std::vector<float> vectors(NUM_VECTORS * DIM);
+    std::mt19937 rng(47);
+    std::uniform_real_distribution<float> distribution;
+    for (int64_t i = 0; i < NUM_VECTORS; ++i) {
+        ids[i] = i;
+    }
+    for (auto& value : vectors) {
+        value = distribution(rng);
+    }
+    auto base = vsag::Dataset::Make()
+                    ->NumElements(NUM_VECTORS)
+                    ->Dim(DIM)
+                    ->Ids(ids.data())
+                    ->Float32Vectors(vectors.data())
+                    ->Owner(false);
+
+    /******************* Create Disk-Backed Precise Codes *****************/
+    const auto unique_id = std::chrono::steady_clock::now().time_since_epoch().count();
+    const auto temp_dir = std::filesystem::temp_directory_path() /
+                          ("vsag-ivf-precise-bucket-" + std::to_string(unique_id));
+    std::filesystem::create_directories(temp_dir);
+    const auto precise_file_path = (temp_dir / "precise.codes").generic_string();
+
+    // precise_codes_layout is the only parameter introduced by bucket-aligned precise storage.
+    // The existing precise quantizer and IO settings are reused.
+    const auto build_params = std::string(R"(
+    {
+        "dtype": "float32",
+        "metric_type": "l2",
+        "dim": 32,
+        "index_param": {
+            "buckets_count": 16,
+            "buckets_per_data": 1,
+            "base_quantization_type": "sq8",
+            "partition_strategy_type": "ivf",
+            "ivf_train_type": "kmeans",
+            "use_reorder": true,
+            "precise_quantization_type": "fp32",
+            "precise_codes_layout": "bucket",
+            "precise_io_type": "buffer_io",
+            "precise_file_path": ")") +
+                              precise_file_path + R"("
+        }
+    }
+    )";
+
+    auto create_result = vsag::Factory::CreateIndex("ivf", build_params);
+    if (not create_result.has_value()) {
+        std::cerr << "Create index failed: " << create_result.error().message << std::endl;
+        std::filesystem::remove_all(temp_dir);
+        return EXIT_FAILURE;
+    }
+    auto index = std::move(create_result.value());
+
+    auto build_result = index->Build(base);
+    if (not build_result.has_value()) {
+        std::cerr << "Build failed: " << build_result.error().message << std::endl;
+        index.reset();
+        std::filesystem::remove_all(temp_dir);
+        return EXIT_FAILURE;
+    }
+
+    /******************* Search With Precise Reordering *****************/
+    auto query = vsag::Dataset::Make()
+                     ->NumElements(1)
+                     ->Dim(DIM)
+                     ->Float32Vectors(vectors.data())
+                     ->Owner(false);
+    const auto search_params = R"(
+    {
+        "ivf": {
+            "scan_buckets_count": 16,
+            "factor": 4.0
+        }
+    }
+    )";
+    {
+        auto search_result = index->KnnSearch(query, 10, search_params);
+        if (not search_result.has_value()) {
+            std::cerr << "Search failed: " << search_result.error().message << std::endl;
+            index.reset();
+            std::filesystem::remove_all(temp_dir);
+            return EXIT_FAILURE;
+        }
+
+        std::cout << "Top-" << search_result.value()->GetDim() << " results:" << std::endl;
+        for (int64_t i = 0; i < search_result.value()->GetDim(); ++i) {
+            std::cout << "  id=" << search_result.value()->GetIds()[i]
+                      << "  dist=" << search_result.value()->GetDistances()[i] << std::endl;
+        }
+    }
+
+    index.reset();
+    std::filesystem::remove_all(temp_dir);
+    return EXIT_SUCCESS;
+}

--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -162,3 +162,6 @@ target_link_libraries(406_feature_read_cache vsag)
 
 add_executable(407_feature_ivf_read_cache 407_feature_ivf_read_cache.cpp)
 target_link_libraries(407_feature_ivf_read_cache vsag)
+
+add_executable(326_feature_ivf_precise_bucket 326_feature_ivf_precise_bucket.cpp)
+target_link_libraries(326_feature_ivf_precise_bucket vsag)

--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -164,3 +164,6 @@ if (TARGET vsag::autotune)
         328_feature_autotune_existing_pyramid.cpp)
     target_link_libraries (328_feature_autotune_existing_pyramid vsag::autotune)
 endif ()
+
+add_executable(329_feature_ivf_precise_bucket 329_feature_ivf_precise_bucket.cpp)
+target_link_libraries(329_feature_ivf_precise_bucket vsag)

--- a/examples/cpp/README.md
+++ b/examples/cpp/README.md
@@ -102,6 +102,7 @@ together when the directory is listed:
 | [`320_feature_extra_info.cpp`](320_feature_extra_info.cpp) | Attach per-vector extra info / payload. |
 | [`322_feature_hgraph_brute_force_threshold.cpp`](322_feature_hgraph_brute_force_threshold.cpp) | HGraph search-time `brute_force_threshold`: automatically switch to an exact scan under highly selective filters. |
 | [`324_feature_lazy_hgraph_extra_info.cpp`](324_feature_lazy_hgraph_extra_info.cpp) | LazyHGraph `extra_info` filtering across flat and graph phases. |
+| [`326_feature_ivf_precise_bucket.cpp`](326_feature_ivf_precise_bucket.cpp) | Disk-backed IVF precise codes using the bucket-aligned layout. |
 
 ### Persistence (`4xx`)
 

--- a/examples/cpp/README.md
+++ b/examples/cpp/README.md
@@ -98,6 +98,7 @@ together when the directory is listed:
 | [`320_feature_extra_info.cpp`](320_feature_extra_info.cpp) | Attach per-vector extra info / payload. |
 | [`322_feature_hgraph_brute_force_threshold.cpp`](322_feature_hgraph_brute_force_threshold.cpp) | HGraph search-time `brute_force_threshold`: automatically switch to an exact scan under highly selective filters. |
 | [`324_feature_lazy_hgraph_extra_info.cpp`](324_feature_lazy_hgraph_extra_info.cpp) | LazyHGraph `extra_info` filtering across flat and graph phases. |
+| [`329_feature_ivf_precise_bucket.cpp`](329_feature_ivf_precise_bucket.cpp) | Disk-backed IVF precise codes using the bucket-aligned layout. |
 
 ### Persistence (`4xx`)
 

--- a/include/vsag/constants.h
+++ b/include/vsag/constants.h
@@ -280,6 +280,9 @@ extern const char* const IVF_PRECISE_CACHE_TOTAL_SIZE;
 extern const char* const IVF_PRECISE_QUANTIZATION_TYPE;
 extern const char* const IVF_PRECISE_IO_TYPE;
 extern const char* const IVF_PRECISE_FILE_PATH;
+extern const char* const IVF_PRECISE_CODES_LAYOUT;
+extern const char* const IVF_PRECISE_CODES_LAYOUT_FLAT;
+extern const char* const IVF_PRECISE_CODES_LAYOUT_BUCKET;
 extern const char* const USE_ATTRIBUTE_FILTER;
 extern const char* const IVF_THREAD_COUNT;
 

--- a/include/vsag/constants.h
+++ b/include/vsag/constants.h
@@ -251,6 +251,9 @@ extern const char* const IVF_PRECISE_CACHE_TOTAL_SIZE;
 extern const char* const IVF_PRECISE_QUANTIZATION_TYPE;
 extern const char* const IVF_PRECISE_IO_TYPE;
 extern const char* const IVF_PRECISE_FILE_PATH;
+extern const char* const IVF_PRECISE_CODES_LAYOUT;
+extern const char* const IVF_PRECISE_CODES_LAYOUT_FLAT;
+extern const char* const IVF_PRECISE_CODES_LAYOUT_BUCKET;
 extern const char* const USE_ATTRIBUTE_FILTER;
 extern const char* const IVF_THREAD_COUNT;
 

--- a/src/algorithm/ivf/ivf.cpp
+++ b/src/algorithm/ivf/ivf.cpp
@@ -1591,10 +1591,23 @@ IVF::reorder_with_precise_bucket(const DistHeapPtr& input,
 
     auto computer = precise_bucket_->FactoryComputer(query);
     const auto* candidates = input->GetData();
+    Vector<BucketIdType> bucket_ids(candidate_count, query_allocator);
+    Vector<InnerIdType> offset_ids(candidate_count, query_allocator);
+    Vector<float> precise_distances(candidate_count, query_allocator);
+    for (uint64_t i = 0; i < candidate_count; ++i) {
+        const auto [bucket_id, offset_id] = this->get_location(candidates[i].second);
+        bucket_ids[i] = bucket_id;
+        offset_ids[i] = offset_id;
+    }
+    precise_bucket_->Query(precise_distances.data(),
+                           computer,
+                           bucket_ids.data(),
+                           offset_ids.data(),
+                           static_cast<InnerIdType>(candidate_count),
+                           &ctx);
     for (uint64_t i = 0; i < candidate_count; ++i) {
         const auto [coarse_distance, inner_id] = candidates[i];
-        const auto [bucket_id, offset_id] = this->get_location(inner_id);
-        auto precise_distance = precise_bucket_->QueryOneById(computer, bucket_id, offset_id);
+        const auto precise_distance = precise_distances[i];
         if (ctx.reasoning_ctx != nullptr) {
             ctx.reasoning_ctx->RecordReorder(inner_id, coarse_distance, precise_distance);
         }
@@ -2265,13 +2278,37 @@ IVF::CalDistanceById(const float* query,
     if (this->use_reorder_ && calculate_precise_distance && reorder_codes_ != nullptr) {
         auto computer = this->reorder_codes_->FactoryComputer(query);
         this->reorder_codes_->Query(distances, computer, inner_ids.data(), count);
-    } else {
-        auto codes = this->use_reorder_ && calculate_precise_distance ? precise_bucket_ : bucket_;
-        auto computer = codes->FactoryComputer(query);
+    } else if (this->use_reorder_ && calculate_precise_distance && precise_bucket_ != nullptr) {
+        auto computer = this->precise_bucket_->FactoryComputer(query);
+        Vector<BucketIdType> bucket_ids(allocator_);
+        Vector<InnerIdType> offset_ids(allocator_);
+        Vector<int64_t> result_indices(allocator_);
+        bucket_ids.reserve(count);
+        offset_ids.reserve(count);
+        result_indices.reserve(count);
         for (int64_t i = 0; i < count; ++i) {
             if (validity[i]) {
                 auto [bucket_id, offset_id] = this->get_location(inner_ids[i]);
-                distances[i] = codes->QueryOneById(computer, bucket_id, offset_id);
+                bucket_ids.emplace_back(bucket_id);
+                offset_ids.emplace_back(offset_id);
+                result_indices.emplace_back(i);
+            }
+        }
+        Vector<float> valid_distances(result_indices.size(), allocator_);
+        this->precise_bucket_->Query(valid_distances.data(),
+                                     computer,
+                                     bucket_ids.data(),
+                                     offset_ids.data(),
+                                     static_cast<InnerIdType>(result_indices.size()));
+        for (uint64_t i = 0; i < result_indices.size(); ++i) {
+            distances[result_indices[i]] = valid_distances[i];
+        }
+    } else {
+        auto computer = this->bucket_->FactoryComputer(query);
+        for (int64_t i = 0; i < count; ++i) {
+            if (validity[i]) {
+                auto [bucket_id, offset_id] = this->get_location(inner_ids[i]);
+                distances[i] = this->bucket_->QueryOneById(computer, bucket_id, offset_id);
             }
         }
     }

--- a/src/algorithm/ivf/ivf.cpp
+++ b/src/algorithm/ivf/ivf.cpp
@@ -58,6 +58,20 @@ namespace vsag {
 
 static constexpr BucketIdType INVALID_BUCKET_ID = static_cast<BucketIdType>(-1);
 
+namespace {
+
+BucketDataCellParamPtr
+make_precise_bucket_param(const IVFParameterPtr& param) {
+    auto precise_bucket_param = std::make_shared<BucketDataCellParameter>();
+    precise_bucket_param->io_parameter = param->precise_codes_param->io_parameter;
+    precise_bucket_param->quantizer_parameter = param->precise_codes_param->quantizer_parameter;
+    precise_bucket_param->buckets_count = param->bucket_param->buckets_count;
+    precise_bucket_param->use_residual_ = false;
+    return precise_bucket_param;
+}
+
+}  // namespace
+
 static constexpr const char* IVF_PARAMS_TEMPLATE =
     R"(
     {
@@ -97,6 +111,7 @@ static constexpr const char* IVF_PARAMS_TEMPLATE =
         },
         "{BUCKET_PER_DATA_KEY}": 1,
         "{USE_REORDER_KEY}": false,
+        "{PRECISE_CODES_LAYOUT_KEY}": "{PRECISE_CODES_LAYOUT_VALUE_FLAT}",
         "{PRECISE_CODES_KEY}": {
             "{IO_PARAMS_KEY}": {
                 "{TYPE_KEY}": "{IO_TYPE_VALUE_BLOCK_MEMORY_IO}",
@@ -231,6 +246,12 @@ IVF::CheckAndMappingExternalParam(const JsonType& external_param,
             IVF_USE_REORDER,
             {
                 USE_REORDER_KEY,
+            },
+        },
+        {
+            IVF_PRECISE_CODES_LAYOUT,
+            {
+                PRECISE_CODES_LAYOUT_KEY,
             },
         },
         {
@@ -406,9 +427,16 @@ IVF::IVF(const IVFParameterPtr& param, const IndexCommonParam& common_param)
             common_param, param->ivf_partition_strategy_parameter);
     }
     if (this->use_reorder_) {
-        this->reorder_codes_ =
-            FlattenInterface::MakeInstance(param->precise_codes_param, common_param);
-        reorder_ = std::make_shared<FlattenReorder>(this->reorder_codes_, allocator_);
+        if (param->precise_codes_layout == PRECISE_CODES_LAYOUT_VALUE_BUCKET) {
+            this->precise_bucket_ =
+                BucketInterface::MakeInstance(make_precise_bucket_param(param), common_param);
+            CHECK_ARGUMENT(this->precise_bucket_ != nullptr,
+                           "unsupported IO or quantizer for IVF precise bucket");
+        } else {
+            this->reorder_codes_ =
+                FlattenInterface::MakeInstance(param->precise_codes_param, common_param);
+            reorder_ = std::make_shared<FlattenReorder>(this->reorder_codes_, allocator_);
+        }
     }
     if (param->bucket_param->use_residual_) {
         this->bucket_->SetStrategy(partition_strategy_);
@@ -477,8 +505,11 @@ IVF::InitFeatures() {
     }
 
     bool has_fp32 = false;
-    if (use_reorder_ && reorder_codes_->GetQuantizerName() == QUANTIZATION_TYPE_VALUE_FP32) {
-        has_fp32 = true;
+    if (use_reorder_) {
+        const auto precise_quantizer_name = precise_bucket_ != nullptr
+                                                ? precise_bucket_->GetQuantizerName()
+                                                : reorder_codes_->GetQuantizerName();
+        has_fp32 = precise_quantizer_name == QUANTIZATION_TYPE_VALUE_FP32;
     }
     if (name == QUANTIZATION_TYPE_VALUE_FP32 or has_fp32) {
         this->index_feature_list_->SetFeature(IndexFeature::SUPPORT_CAL_DISTANCE_BY_ID);
@@ -534,7 +565,11 @@ IVF::Train(const DatasetPtr& data) {
     const auto* data_ptr = train_data->GetFloat32Vectors();
     this->bucket_->Train(data_ptr, sample_count);
     if (use_reorder_) {
-        this->reorder_codes_->Train(data->GetFloat32Vectors(), data->GetNumElements());
+        if (precise_bucket_ != nullptr) {
+            this->precise_bucket_->Train(data->GetFloat32Vectors(), data->GetNumElements());
+        } else {
+            this->reorder_codes_->Train(data->GetFloat32Vectors(), data->GetNumElements());
+        }
     }
     this->is_trained_ = true;
 }
@@ -546,6 +581,9 @@ IVF::Add(const DatasetPtr& base) {
         throw VsagException(ErrorType::INTERNAL_ERROR, "ivf index add without train error");
     }
     this->bucket_->Unpack();
+    if (precise_bucket_ != nullptr) {
+        this->precise_bucket_->Unpack();
+    }
     auto num_element = base->GetNumElements();
     const auto* ids = base->GetIds();
     const auto* vectors = base->GetFloat32Vectors();
@@ -559,7 +597,7 @@ IVF::Add(const DatasetPtr& base) {
     bool need_cal_memory_usage = false;
     {
         std::lock_guard lock(label_lookup_mutex_);
-        if (use_reorder_) {
+        if (use_reorder_ and precise_bucket_ == nullptr) {
             this->reorder_codes_->BatchInsertVector(base->GetFloat32Vectors(),
                                                     base->GetNumElements());
         }
@@ -579,8 +617,15 @@ IVF::Add(const DatasetPtr& base) {
         for (int64_t j = 0; j < buckets_per_data_; ++j) {
             const auto* data_ptr = vectors + i * dim_;
             auto idx = i * buckets_per_data_ + j;
-            InnerIdType offset_id = bucket_->InsertVector(
-                data_ptr, buckets[idx], idx + current_num * buckets_per_data_);
+            auto posting_id = static_cast<InnerIdType>(idx + current_num * buckets_per_data_);
+            InnerIdType offset_id;
+            if (precise_bucket_ != nullptr) {
+                // Publish the basic posting only after its precise mirror is ready.
+                offset_id = precise_bucket_->InsertVector(data_ptr, buckets[idx], posting_id);
+                bucket_->InsertVectorWithOffset(data_ptr, buckets[idx], posting_id, offset_id);
+            } else {
+                offset_id = bucket_->InsertVector(data_ptr, buckets[idx], posting_id);
+            }
             if (j == 0) {
                 std::lock_guard lock(label_lookup_mutex_);
                 location_map_[i + current_num] =
@@ -614,6 +659,9 @@ IVF::Add(const DatasetPtr& base) {
         }
     }
     this->bucket_->Package();
+    if (precise_bucket_ != nullptr) {
+        this->precise_bucket_->Package();
+    }
     if (need_cal_memory_usage) {
         this->cal_memory_usage();
     }
@@ -807,11 +855,17 @@ IVF::GetNumElements() const {
 void
 IVF::Merge(const std::vector<MergeUnit>& merge_units) {
     this->bucket_->Unpack();
+    if (precise_bucket_ != nullptr) {
+        this->precise_bucket_->Unpack();
+    }
     for (const auto& unit : merge_units) {
         this->merge_one_unit(unit);
     }
     this->fill_location_map();
     this->bucket_->Package();
+    if (precise_bucket_ != nullptr) {
+        this->precise_bucket_->Package();
+    }
 }
 
 std::pair<BucketIdType, InnerIdType>
@@ -867,7 +921,11 @@ IVF::Serialize(StreamWriter& writer) const {
     WRITE_DATACELL_WITH_NAME(writer, "label_table", label_table_);
 
     if (use_reorder_) {
-        WRITE_DATACELL_WITH_NAME(writer, "reorder_codes", reorder_codes_);
+        if (precise_bucket_ != nullptr) {
+            WRITE_DATACELL_WITH_NAME(writer, "precise_bucket", precise_bucket_);
+        } else {
+            WRITE_DATACELL_WITH_NAME(writer, "reorder_codes", reorder_codes_);
+        }
     }
 
     if (use_attribute_filter_) {
@@ -954,7 +1012,9 @@ IVF::collect_streaming_header() const {
                                  StreamSerializationBlockCurrentVersion(label_tag),
                                  StreamSerializationTagCritical(label_tag));
     if (this->use_reorder_) {
-        auto tag = static_cast<uint32_t>(StreamSerializationTag::HIGH_PRECISION_CODES);
+        auto tag = static_cast<uint32_t>(precise_bucket_ != nullptr
+                                             ? StreamSerializationTag::IVF_PRECISE_BUCKET
+                                             : StreamSerializationTag::HIGH_PRECISION_CODES);
         AppendStreamingManifestBlock(manifest,
                                      tag,
                                      StreamSerializationBlockCurrentVersion(tag),
@@ -999,10 +1059,16 @@ IVF::serialize_streaming_body(StreamWriter& writer) const {
             this->label_table_->Serialize(w);
         });
     if (this->use_reorder_) {
-        auto tag = static_cast<uint32_t>(StreamSerializationTag::HIGH_PRECISION_CODES);
+        auto tag = static_cast<uint32_t>(precise_bucket_ != nullptr
+                                             ? StreamSerializationTag::IVF_PRECISE_BUCKET
+                                             : StreamSerializationTag::HIGH_PRECISION_CODES);
         WriteStreamingBlock(
             writer, tag, StreamSerializationTagCritical(tag), [this](StreamWriter& w) {
-                this->reorder_codes_->Serialize(w);
+                if (this->precise_bucket_ != nullptr) {
+                    this->precise_bucket_->Serialize(w);
+                } else {
+                    this->reorder_codes_->Serialize(w);
+                }
             });
     }
     if (this->use_attribute_filter_) {
@@ -1054,6 +1120,10 @@ IVF::read_streaming_body(StreamReader& reader, const MetadataPtr& metadata) {
     this->total_elements_ = basic_info["total_elements"].GetInt();
     this->use_reorder_ = basic_info["use_reorder"].GetBool();
     this->is_trained_ = basic_info["is_trained"].GetBool();
+    if (precise_bucket_ != nullptr and not basic_info.Contains(INDEX_PARAM)) {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "IVF precise bucket requires persisted index parameters");
+    }
     if (basic_info.Contains(INDEX_PARAM)) {
         auto index_param = std::make_shared<IVFParameter>();
         index_param->FromString(basic_info[INDEX_PARAM].GetString());
@@ -1069,7 +1139,7 @@ IVF::read_streaming_body(StreamReader& reader, const MetadataPtr& metadata) {
     bool loaded_bucket = false;
     bool loaded_partition = false;
     bool loaded_label_table = false;
-    bool loaded_reorder_codes = false;
+    bool loaded_precise_codes = false;
     bool loaded_attribute_filter = false;
 
     while (true) {
@@ -1114,12 +1184,21 @@ IVF::read_streaming_body(StreamReader& reader, const MetadataPtr& metadata) {
                 loaded_label_table = true;
                 break;
             case StreamSerializationTag::HIGH_PRECISION_CODES:
-                if (this->use_reorder_) {
+                if (this->use_reorder_ and this->reorder_codes_ != nullptr) {
                     ReadSeekableBlockPayload(
                         block_reader, block_header, [this](StreamReader& block) {
                             this->reorder_codes_->Deserialize(block);
                         });
-                    loaded_reorder_codes = true;
+                    loaded_precise_codes = true;
+                }
+                break;
+            case StreamSerializationTag::IVF_PRECISE_BUCKET:
+                if (this->use_reorder_ and this->precise_bucket_ != nullptr) {
+                    ReadSeekableBlockPayload(
+                        block_reader, block_header, [this](StreamReader& block) {
+                            this->precise_bucket_->Deserialize(block);
+                        });
+                    loaded_precise_codes = true;
                 }
                 break;
             case StreamSerializationTag::ATTRIBUTE_FILTER:
@@ -1213,7 +1292,7 @@ IVF::read_streaming_body(StreamReader& reader, const MetadataPtr& metadata) {
         throw VsagException(ErrorType::READ_ERROR,
                             "IVF streaming serialization required block is missing");
     }
-    if (this->use_reorder_ && !loaded_reorder_codes) {
+    if (this->use_reorder_ && !loaded_precise_codes) {
         throw VsagException(ErrorType::READ_ERROR,
                             "IVF streaming serialization reorder block is missing");
     }
@@ -1242,6 +1321,10 @@ IVF::Deserialize(StreamReader& reader) {
         &reader, std::numeric_limits<uint64_t>::max(), this->allocator_);
 
     if (footer == nullptr) {  // old format, DON'T EDIT, remove in the future
+        if (precise_bucket_ != nullptr) {
+            throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                                "legacy IVF serialization does not support precise bucket");
+        }
         logger::debug("parse with v0.14 version format");
 
         StreamReader::ReadObj(buffer_reader, this->total_elements_);
@@ -1271,6 +1354,10 @@ IVF::Deserialize(StreamReader& reader) {
         this->total_elements_ = basic_info["total_elements"].GetInt();
         this->use_reorder_ = basic_info["use_reorder"].GetBool();
         this->is_trained_ = basic_info["is_trained"].GetBool();
+        if (precise_bucket_ != nullptr and not basic_info.Contains(INDEX_PARAM)) {
+            throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                                "IVF precise bucket requires persisted index parameters");
+        }
         if (basic_info.Contains(INDEX_PARAM)) {
             auto param_str = basic_info[INDEX_PARAM].GetString();
             auto index_param = std::make_shared<IVFParameter>();
@@ -1293,7 +1380,11 @@ IVF::Deserialize(StreamReader& reader) {
         READ_DATACELL_WITH_NAME(buffer_reader, "partition_strategy", this->partition_strategy_);
         READ_DATACELL_WITH_NAME(buffer_reader, "label_table", this->label_table_);
         if (use_reorder_) {
-            READ_DATACELL_WITH_NAME(buffer_reader, "reorder_codes", this->reorder_codes_);
+            if (precise_bucket_ != nullptr) {
+                READ_DATACELL_WITH_NAME(buffer_reader, "precise_bucket", this->precise_bucket_);
+            } else {
+                READ_DATACELL_WITH_NAME(buffer_reader, "reorder_codes", this->reorder_codes_);
+            }
         }
         if (use_attribute_filter_) {
             READ_DATACELL_WITH_NAME(buffer_reader, "attr_filter_index", this->attr_filter_index_);
@@ -1459,11 +1550,60 @@ IVF::reorder(int64_t topk,
              QueryContext& ctx,
              ReasoningContext* reasoning_ctx,
              const std::optional<float>& distance_threshold) const {
-    auto reorder_heap =
-        reorder_->Reorder(input, query, topk, ctx, nullptr, nullptr, distance_threshold);
+    auto reorder_heap = precise_bucket_ != nullptr
+                            ? this->reorder_with_precise_bucket(
+                                  input, query, topk, ctx, distance_threshold)
+                            : reorder_->Reorder(
+                                  input, query, topk, ctx, nullptr, nullptr, distance_threshold);
     auto dataset_results = this->pack_knn_result(reorder_heap, ctx.alloc);
 
     return dataset_results;
+}
+
+DistHeapPtr
+IVF::reorder_with_precise_bucket(const DistHeapPtr& input,
+                                 const float* query,
+                                 int64_t topk,
+                                 QueryContext& ctx,
+                                 const std::optional<float>& distance_threshold) const {
+    Allocator* query_allocator = select_query_allocator(ctx.alloc, allocator_);
+    const uint64_t candidate_count = input == nullptr ? 0 : input->Size();
+    topk = std::min(topk, static_cast<int64_t>(candidate_count));
+    auto reorder_heap = std::make_shared<StandardHeap<true, false>>(query_allocator, topk);
+    if (candidate_count == 0 or topk == 0) {
+        return reorder_heap;
+    }
+
+    if (ctx.stats != nullptr) {
+        ctx.stats->reorder_distance_count.fetch_add(static_cast<uint32_t>(candidate_count),
+                                                    std::memory_order_relaxed);
+    }
+
+    auto computer = precise_bucket_->FactoryComputer(query);
+    const auto* candidates = input->GetData();
+    for (uint64_t i = 0; i < candidate_count; ++i) {
+        const auto [coarse_distance, inner_id] = candidates[i];
+        const auto [bucket_id, offset_id] = this->get_location(inner_id);
+        auto precise_distance = precise_bucket_->QueryOneById(computer, bucket_id, offset_id);
+        if (ctx.reasoning_ctx != nullptr) {
+            ctx.reasoning_ctx->RecordReorder(inner_id, coarse_distance, precise_distance);
+        }
+        if (distance_threshold.has_value() and
+            (not std::isfinite(precise_distance) or
+             precise_distance > distance_threshold.value())) {
+            continue;
+        }
+        if (reorder_heap->Size() < topk or precise_distance < reorder_heap->Top().first) {
+            reorder_heap->Push(precise_distance, inner_id);
+            if (reorder_heap->Size() > topk) {
+                if (ctx.reasoning_ctx != nullptr) {
+                    ctx.reasoning_ctx->RecordReorderEviction(reorder_heap->Top().second, 0);
+                }
+                reorder_heap->Pop();
+            }
+        }
+    }
+    return reorder_heap;
 }
 
 InnerIndexPtr
@@ -1472,7 +1612,11 @@ IVF::ExportModel(const IndexCommonParam& param) const {
     IVFPartitionStrategy::Clone(this->partition_strategy_, index->partition_strategy_);
     this->bucket_->ExportModel(index->bucket_);
     if (use_reorder_) {
-        this->reorder_codes_->ExportModel(index->reorder_codes_);
+        if (precise_bucket_ != nullptr) {
+            this->precise_bucket_->ExportModel(index->precise_bucket_);
+        } else {
+            this->reorder_codes_->ExportModel(index->reorder_codes_);
+        }
     }
     index->is_trained_ = this->is_trained_;
     return index;
@@ -1765,7 +1909,13 @@ IVF::merge_one_unit(const MergeUnit& unit) {
     other_index->bucket_->Package();
 
     if (this->use_reorder_) {
-        this->reorder_codes_->MergeOther(other_index->reorder_codes_, this->total_elements_);
+        if (precise_bucket_ != nullptr) {
+            other_index->precise_bucket_->Unpack();
+            this->precise_bucket_->MergeOther(other_index->precise_bucket_, bucket_bias);
+            other_index->precise_bucket_->Package();
+        } else {
+            this->reorder_codes_->MergeOther(other_index->reorder_codes_, this->total_elements_);
+        }
     }
     this->total_elements_ += other_index->total_elements_;
 }
@@ -1786,6 +1936,10 @@ IVF::check_merge_illegal(const vsag::MergeUnit& unit) const {
                                         "index is {}, other index is {}",
                                         this->use_reorder_,
                                         other_ivf_index->use_reorder_));
+    }
+    if ((other_ivf_index->precise_bucket_ == nullptr) != (this->precise_bucket_ == nullptr)) {
+        throw VsagException(ErrorType::INVALID_ARGUMENT,
+                            "Merge Failed: IVF precise codes layout does not match");
     }
     auto cur_model = this->ExportModel(index->GetCommonParam());
     std::stringstream ss1;
@@ -2014,10 +2168,27 @@ void
 IVF::fill_location_map() {
     this->location_map_.resize(this->total_elements_ * buckets_per_data_);
     auto bucket_count = this->bucket_->bucket_count_;
+    if (precise_bucket_ != nullptr and precise_bucket_->GetBucketCount() != bucket_count) {
+        throw VsagException(ErrorType::INTERNAL_ERROR,
+                            "basic and precise bucket counts do not match");
+    }
     for (BucketIdType i = 0; i < bucket_count; ++i) {
         auto* ids = this->bucket_->GetInnerIds(i);
         auto bucket_size = this->bucket_->GetBucketSize(i);
+        InnerIdType* precise_ids = nullptr;
+        if (precise_bucket_ != nullptr) {
+            auto precise_bucket_size = precise_bucket_->GetBucketSize(i);
+            if (precise_bucket_size != bucket_size) {
+                throw VsagException(ErrorType::INTERNAL_ERROR,
+                                    "basic and precise bucket sizes do not match");
+            }
+            precise_ids = precise_bucket_->GetInnerIds(i);
+        }
         for (uint64_t j = 0; j < bucket_size; ++j) {
+            if (precise_ids != nullptr and precise_ids[j] != ids[j]) {
+                throw VsagException(ErrorType::INTERNAL_ERROR,
+                                    "basic and precise bucket inner ids do not match");
+            }
             if (ids[j] == std::numeric_limits<InnerIdType>::max()) {
                 continue;
             }
@@ -2077,15 +2248,16 @@ IVF::CalDistanceById(const float* query,
             }
         }
     }
-    if (this->use_reorder_ && calculate_precise_distance) {
+    if (this->use_reorder_ && calculate_precise_distance && reorder_codes_ != nullptr) {
         auto computer = this->reorder_codes_->FactoryComputer(query);
         this->reorder_codes_->Query(distances, computer, inner_ids.data(), count);
     } else {
-        auto computer = this->bucket_->FactoryComputer(query);
+        auto codes = this->use_reorder_ && calculate_precise_distance ? precise_bucket_ : bucket_;
+        auto computer = codes->FactoryComputer(query);
         for (int64_t i = 0; i < count; ++i) {
             if (validity[i]) {
                 auto [bucket_id, offset_id] = this->get_location(inner_ids[i]);
-                distances[i] = this->bucket_->QueryOneById(computer, bucket_id, offset_id);
+                distances[i] = codes->QueryOneById(computer, bucket_id, offset_id);
             }
         }
     }
@@ -2107,15 +2279,16 @@ IVF::CalcDistanceById(const float* query, int64_t id, bool calculate_precise_dis
     if (not success) {
         return -1.0F;
     }
-    if (this->use_reorder_ && calculate_precise_distance) {
+    if (this->use_reorder_ && calculate_precise_distance && reorder_codes_ != nullptr) {
         float dist = 0.0F;
         auto computer = this->reorder_codes_->FactoryComputer(query);
         this->reorder_codes_->Query(&dist, computer, &inner_id, 1);
         return dist;
     }
-    auto computer = this->bucket_->FactoryComputer(query);
+    auto codes = this->use_reorder_ && calculate_precise_distance ? precise_bucket_ : bucket_;
+    auto computer = codes->FactoryComputer(query);
     auto [bucket_id, offset_id] = this->get_location(inner_id);
-    return this->bucket_->QueryOneById(computer, bucket_id, offset_id);
+    return codes->QueryOneById(computer, bucket_id, offset_id);
 }
 
 void
@@ -2224,7 +2397,8 @@ IVF::cal_memory_usage() {
     auto memory = sizeof(IVF);
     memory += this->bucket_->GetMemoryUsage();
     if (use_reorder_) {
-        memory += this->reorder_codes_->GetMemoryUsage();
+        memory += precise_bucket_ != nullptr ? precise_bucket_->GetMemoryUsage()
+                                             : reorder_codes_->GetMemoryUsage();
     }
     if (this->extra_info_size_ > 0 and this->extra_infos_ != nullptr) {
         memory += this->extra_infos_->GetMemoryUsage();

--- a/src/algorithm/ivf/ivf.cpp
+++ b/src/algorithm/ivf/ivf.cpp
@@ -413,6 +413,7 @@ IVF::IVF(const IVFParameterPtr& param, const IndexCommonParam& common_param)
       bucket_graphs_(common_param.allocator_.get()),
       common_param_(common_param),
       bucket_searcher_(std::make_shared<FlatBucketSearcher>()) {
+    this->disk_backed_precise_bucket_ = param->UsesDiskBackedPreciseBucket();
     this->bucket_ = BucketInterface::MakeInstance(param->bucket_param, common_param);
     if (this->bucket_ == nullptr) {
         throw VsagException(ErrorType::INTERNAL_ERROR, "bucket init error");
@@ -526,6 +527,11 @@ IVF::InitFeatures() {
                                             IndexFeature::SUPPORT_EXPORT_MODEL,
                                             IndexFeature::SUPPORT_GET_MEMORY_USAGE,
                                             IndexFeature::SUPPORT_MERGE_INDEX});
+    if (this->disk_backed_precise_bucket_) {
+        this->index_feature_list_->SetFeature(IndexFeature::SUPPORT_CLONE, false);
+        this->index_feature_list_->SetFeature(IndexFeature::SUPPORT_EXPORT_MODEL, false);
+        this->index_feature_list_->SetFeature(IndexFeature::SUPPORT_MERGE_INDEX, false);
+    }
 
     if (this->bucket_->GetQuantizerName() == QUANTIZATION_TYPE_VALUE_PQFS) {
         this->index_feature_list_->SetFeature(IndexFeature::SUPPORT_ADD_AFTER_BUILD, false);
@@ -854,6 +860,10 @@ IVF::GetNumElements() const {
 
 void
 IVF::Merge(const std::vector<MergeUnit>& merge_units) {
+    if (this->disk_backed_precise_bucket_) {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "Merge does not support disk-backed IVF precise buckets");
+    }
     this->bucket_->Unpack();
     if (precise_bucket_ != nullptr) {
         this->precise_bucket_->Unpack();
@@ -1608,6 +1618,10 @@ IVF::reorder_with_precise_bucket(const DistHeapPtr& input,
 
 InnerIndexPtr
 IVF::ExportModel(const IndexCommonParam& param) const {
+    if (this->disk_backed_precise_bucket_) {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "ExportModel does not support disk-backed IVF precise buckets");
+    }
     auto index = std::make_shared<IVF>(this->create_param_ptr_, param);
     IVFPartitionStrategy::Clone(this->partition_strategy_, index->partition_strategy_);
     this->bucket_->ExportModel(index->bucket_);

--- a/src/algorithm/ivf/ivf.cpp
+++ b/src/algorithm/ivf/ivf.cpp
@@ -1560,11 +1560,10 @@ IVF::reorder(int64_t topk,
              QueryContext& ctx,
              ReasoningContext* reasoning_ctx,
              const std::optional<float>& distance_threshold) const {
-    auto reorder_heap = precise_bucket_ != nullptr
-                            ? this->reorder_with_precise_bucket(
-                                  input, query, topk, ctx, distance_threshold)
-                            : reorder_->Reorder(
-                                  input, query, topk, ctx, nullptr, nullptr, distance_threshold);
+    auto reorder_heap =
+        precise_bucket_ != nullptr
+            ? this->reorder_with_precise_bucket(input, query, topk, ctx, distance_threshold)
+            : reorder_->Reorder(input, query, topk, ctx, nullptr, nullptr, distance_threshold);
     auto dataset_results = this->pack_knn_result(reorder_heap, ctx.alloc);
 
     return dataset_results;
@@ -1611,9 +1610,8 @@ IVF::reorder_with_precise_bucket(const DistHeapPtr& input,
         if (ctx.reasoning_ctx != nullptr) {
             ctx.reasoning_ctx->RecordReorder(inner_id, coarse_distance, precise_distance);
         }
-        if (distance_threshold.has_value() and
-            (not std::isfinite(precise_distance) or
-             precise_distance > distance_threshold.value())) {
+        if (distance_threshold.has_value() and (not std::isfinite(precise_distance) or
+                                                precise_distance > distance_threshold.value())) {
             continue;
         }
         if (reorder_heap->Size() < topk or precise_distance < reorder_heap->Top().first) {

--- a/src/algorithm/ivf/ivf.cpp
+++ b/src/algorithm/ivf/ivf.cpp
@@ -1607,11 +1607,10 @@ IVF::reorder(int64_t topk,
              QueryContext& ctx,
              ReasoningContext* reasoning_ctx,
              const std::optional<float>& distance_threshold) const {
-    auto reorder_heap = precise_bucket_ != nullptr
-                            ? this->reorder_with_precise_bucket(
-                                  input, query, topk, ctx, distance_threshold)
-                            : reorder_->Reorder(
-                                  input, query, topk, ctx, nullptr, nullptr, distance_threshold);
+    auto reorder_heap =
+        precise_bucket_ != nullptr
+            ? this->reorder_with_precise_bucket(input, query, topk, ctx, distance_threshold)
+            : reorder_->Reorder(input, query, topk, ctx, nullptr, nullptr, distance_threshold);
     auto dataset_results = this->pack_knn_result(reorder_heap, ctx.alloc);
 
     return dataset_results;
@@ -1658,9 +1657,8 @@ IVF::reorder_with_precise_bucket(const DistHeapPtr& input,
         if (ctx.reasoning_ctx != nullptr) {
             ctx.reasoning_ctx->RecordReorder(inner_id, coarse_distance, precise_distance);
         }
-        if (distance_threshold.has_value() and
-            (not std::isfinite(precise_distance) or
-             precise_distance > distance_threshold.value())) {
+        if (distance_threshold.has_value() and (not std::isfinite(precise_distance) or
+                                                precise_distance > distance_threshold.value())) {
             continue;
         }
         if (reorder_heap->Size() < topk or precise_distance < reorder_heap->Top().first) {

--- a/src/algorithm/ivf/ivf.cpp
+++ b/src/algorithm/ivf/ivf.cpp
@@ -1638,10 +1638,23 @@ IVF::reorder_with_precise_bucket(const DistHeapPtr& input,
 
     auto computer = precise_bucket_->FactoryComputer(query);
     const auto* candidates = input->GetData();
+    Vector<BucketIdType> bucket_ids(candidate_count, query_allocator);
+    Vector<InnerIdType> offset_ids(candidate_count, query_allocator);
+    Vector<float> precise_distances(candidate_count, query_allocator);
+    for (uint64_t i = 0; i < candidate_count; ++i) {
+        const auto [bucket_id, offset_id] = this->get_location(candidates[i].second);
+        bucket_ids[i] = bucket_id;
+        offset_ids[i] = offset_id;
+    }
+    precise_bucket_->Query(precise_distances.data(),
+                           computer,
+                           bucket_ids.data(),
+                           offset_ids.data(),
+                           static_cast<InnerIdType>(candidate_count),
+                           &ctx);
     for (uint64_t i = 0; i < candidate_count; ++i) {
         const auto [coarse_distance, inner_id] = candidates[i];
-        const auto [bucket_id, offset_id] = this->get_location(inner_id);
-        auto precise_distance = precise_bucket_->QueryOneById(computer, bucket_id, offset_id);
+        const auto precise_distance = precise_distances[i];
         if (ctx.reasoning_ctx != nullptr) {
             ctx.reasoning_ctx->RecordReorder(inner_id, coarse_distance, precise_distance);
         }
@@ -2455,13 +2468,37 @@ IVF::CalDistanceById(const float* query,
     if (this->use_reorder_ && calculate_precise_distance && reorder_codes_ != nullptr) {
         auto computer = this->reorder_codes_->FactoryComputer(query);
         this->reorder_codes_->Query(distances, computer, inner_ids.data(), count);
-    } else {
-        auto codes = this->use_reorder_ && calculate_precise_distance ? precise_bucket_ : bucket_;
-        auto computer = codes->FactoryComputer(query);
+    } else if (this->use_reorder_ && calculate_precise_distance && precise_bucket_ != nullptr) {
+        auto computer = this->precise_bucket_->FactoryComputer(query);
+        Vector<BucketIdType> bucket_ids(allocator_);
+        Vector<InnerIdType> offset_ids(allocator_);
+        Vector<int64_t> result_indices(allocator_);
+        bucket_ids.reserve(count);
+        offset_ids.reserve(count);
+        result_indices.reserve(count);
         for (int64_t i = 0; i < count; ++i) {
             if (validity[i]) {
                 auto [bucket_id, offset_id] = this->get_location(inner_ids[i]);
-                distances[i] = codes->QueryOneById(computer, bucket_id, offset_id);
+                bucket_ids.emplace_back(bucket_id);
+                offset_ids.emplace_back(offset_id);
+                result_indices.emplace_back(i);
+            }
+        }
+        Vector<float> valid_distances(result_indices.size(), allocator_);
+        this->precise_bucket_->Query(valid_distances.data(),
+                                     computer,
+                                     bucket_ids.data(),
+                                     offset_ids.data(),
+                                     static_cast<InnerIdType>(result_indices.size()));
+        for (uint64_t i = 0; i < result_indices.size(); ++i) {
+            distances[result_indices[i]] = valid_distances[i];
+        }
+    } else {
+        auto computer = this->bucket_->FactoryComputer(query);
+        for (int64_t i = 0; i < count; ++i) {
+            if (validity[i]) {
+                auto [bucket_id, offset_id] = this->get_location(inner_ids[i]);
+                distances[i] = this->bucket_->QueryOneById(computer, bucket_id, offset_id);
             }
         }
     }

--- a/src/algorithm/ivf/ivf.cpp
+++ b/src/algorithm/ivf/ivf.cpp
@@ -414,6 +414,7 @@ IVF::IVF(const IVFParameterPtr& param, const IndexCommonParam& common_param)
       bucket_graphs_(common_param.allocator_.get()),
       common_param_(common_param),
       bucket_searcher_(std::make_shared<FlatBucketSearcher>()) {
+    this->disk_backed_precise_bucket_ = param->UsesDiskBackedPreciseBucket();
     this->bucket_ = BucketInterface::MakeInstance(param->bucket_param, common_param);
     if (this->bucket_ == nullptr) {
         throw VsagException(ErrorType::INTERNAL_ERROR, "bucket init error");
@@ -534,6 +535,11 @@ IVF::InitFeatures() {
                                             IndexFeature::SUPPORT_EXPORT_MODEL,
                                             IndexFeature::SUPPORT_GET_MEMORY_USAGE,
                                             IndexFeature::SUPPORT_MERGE_INDEX});
+    if (this->disk_backed_precise_bucket_) {
+        this->index_feature_list_->SetFeature(IndexFeature::SUPPORT_CLONE, false);
+        this->index_feature_list_->SetFeature(IndexFeature::SUPPORT_EXPORT_MODEL, false);
+        this->index_feature_list_->SetFeature(IndexFeature::SUPPORT_MERGE_INDEX, false);
+    }
 
     if (this->bucket_->GetQuantizerName() == QUANTIZATION_TYPE_VALUE_PQFS) {
         this->index_feature_list_->SetFeature(IndexFeature::SUPPORT_ADD_AFTER_BUILD, false);
@@ -897,6 +903,10 @@ IVF::GetNumElements() const {
 
 void
 IVF::Merge(const std::vector<MergeUnit>& merge_units) {
+    if (this->disk_backed_precise_bucket_) {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "Merge does not support disk-backed IVF precise buckets");
+    }
     this->bucket_->Unpack();
     if (precise_bucket_ != nullptr) {
         this->precise_bucket_->Unpack();
@@ -1655,6 +1665,10 @@ IVF::reorder_with_precise_bucket(const DistHeapPtr& input,
 
 InnerIndexPtr
 IVF::ExportModel(const IndexCommonParam& param) const {
+    if (this->disk_backed_precise_bucket_) {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "ExportModel does not support disk-backed IVF precise buckets");
+    }
     auto index = std::make_shared<IVF>(this->create_param_ptr_, param);
     IVFPartitionStrategy::Clone(this->partition_strategy_, index->partition_strategy_);
     this->bucket_->ExportModel(index->bucket_);

--- a/src/algorithm/ivf/ivf.cpp
+++ b/src/algorithm/ivf/ivf.cpp
@@ -414,7 +414,6 @@ IVF::IVF(const IVFParameterPtr& param, const IndexCommonParam& common_param)
       bucket_graphs_(common_param.allocator_.get()),
       common_param_(common_param),
       bucket_searcher_(std::make_shared<FlatBucketSearcher>()) {
-    this->disk_backed_precise_bucket_ = param->UsesDiskBackedPreciseBucket();
     this->bucket_ = BucketInterface::MakeInstance(param->bucket_param, common_param);
     if (this->bucket_ == nullptr) {
         throw VsagException(ErrorType::INTERNAL_ERROR, "bucket init error");
@@ -535,12 +534,6 @@ IVF::InitFeatures() {
                                             IndexFeature::SUPPORT_EXPORT_MODEL,
                                             IndexFeature::SUPPORT_GET_MEMORY_USAGE,
                                             IndexFeature::SUPPORT_MERGE_INDEX});
-    if (this->disk_backed_precise_bucket_) {
-        this->index_feature_list_->SetFeature(IndexFeature::SUPPORT_CLONE, false);
-        this->index_feature_list_->SetFeature(IndexFeature::SUPPORT_EXPORT_MODEL, false);
-        this->index_feature_list_->SetFeature(IndexFeature::SUPPORT_MERGE_INDEX, false);
-    }
-
     if (this->bucket_->GetQuantizerName() == QUANTIZATION_TYPE_VALUE_PQFS) {
         this->index_feature_list_->SetFeature(IndexFeature::SUPPORT_ADD_AFTER_BUILD, false);
     }
@@ -903,10 +896,6 @@ IVF::GetNumElements() const {
 
 void
 IVF::Merge(const std::vector<MergeUnit>& merge_units) {
-    if (this->disk_backed_precise_bucket_) {
-        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                            "Merge does not support disk-backed IVF precise buckets");
-    }
     this->bucket_->Unpack();
     if (precise_bucket_ != nullptr) {
         this->precise_bucket_->Unpack();
@@ -1676,10 +1665,6 @@ IVF::reorder_with_precise_bucket(const DistHeapPtr& input,
 
 InnerIndexPtr
 IVF::ExportModel(const IndexCommonParam& param) const {
-    if (this->disk_backed_precise_bucket_) {
-        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                            "ExportModel does not support disk-backed IVF precise buckets");
-    }
     auto index = std::make_shared<IVF>(this->create_param_ptr_, param);
     IVFPartitionStrategy::Clone(this->partition_strategy_, index->partition_strategy_);
     this->bucket_->ExportModel(index->bucket_);

--- a/src/algorithm/ivf/ivf.cpp
+++ b/src/algorithm/ivf/ivf.cpp
@@ -37,11 +37,13 @@
 #include "impl/inner_search_param.h"
 #include "impl/pruning_strategy.h"
 #include "impl/reasoning/search_reasoning.h"
+#include "impl/reorder/bucket_reorder.h"
 #include "impl/reorder/flatten_reorder.h"
 #include "impl/searcher/basic_searcher.h"
 #include "index/index_impl.h"
 #include "index_feature_list.h"
 #include "inner_string_params.h"
+#include "io/reader_io/reader_io_parameter.h"
 #include "ivf_nearest_partition.h"
 #include "query_context.h"
 #include "simd/normalize.h"
@@ -445,6 +447,10 @@ IVF::IVF(const IVFParameterPtr& param, const IndexCommonParam& common_param)
                                                                   modified_common_param);
             CHECK_ARGUMENT(this->precise_bucket_ != nullptr,
                            "unsupported IO or quantizer for IVF precise bucket");
+            this->reorder_ = std::make_shared<BucketReorder>(
+                this->precise_bucket_,
+                [this](InnerIdType inner_id) { return this->get_location(inner_id); },
+                allocator_);
         } else {
             this->reorder_codes_ =
                 FlattenInterface::MakeInstance(param->precise_codes_param, modified_common_param);
@@ -604,6 +610,21 @@ IVF::Add(const DatasetPtr& base) {
     bool need_cal_memory_usage = false;
     {
         std::lock_guard lock(label_lookup_mutex_);
+        current_num = this->total_elements_;
+        if (precise_bucket_ != nullptr) {
+            if (num_element < 0 or current_num < 0) {
+                throw VsagException(ErrorType::INVALID_ARGUMENT,
+                                    "invalid IVF precise bucket element count");
+            }
+            const auto posting_count = static_cast<uint64_t>(num_element);
+            const auto current_count = static_cast<uint64_t>(current_num);
+            const auto max_inner_id =
+                static_cast<uint64_t>(std::numeric_limits<InnerIdType>::max());
+            if (posting_count > max_inner_id or current_count > max_inner_id - posting_count) {
+                throw VsagException(ErrorType::INVALID_ARGUMENT,
+                                    "IVF precise bucket batch exceeds inner id capacity");
+            }
+        }
         if (use_reorder_ and precise_bucket_ == nullptr) {
             this->reorder_codes_->BatchInsertVector(base->GetFloat32Vectors(),
                                                     base->GetNumElements());
@@ -611,13 +632,27 @@ IVF::Add(const DatasetPtr& base) {
         for (int64_t i = 0; i < num_element; ++i) {
             this->label_table_->Insert(i + total_elements_, ids[i]);
         }
-        current_num = this->total_elements_;
         this->total_elements_ += num_element;
         if (this->total_elements_ - last_cal_memory_element_ >= cal_memory_element_interval_) {
             need_cal_memory_usage = true;
             last_cal_memory_element_ = this->total_elements_;
         }
         location_map_.resize(this->total_elements_);
+    }
+
+    Vector<InnerIdType> precise_offsets(allocator_);
+    if (precise_bucket_ != nullptr) {
+        const auto posting_count = static_cast<uint64_t>(num_element);
+        Vector<InnerIdType> posting_ids(posting_count, allocator_);
+        precise_offsets.resize(posting_count);
+        for (uint64_t i = 0; i < posting_count; ++i) {
+            posting_ids[i] = static_cast<InnerIdType>(i + static_cast<uint64_t>(current_num));
+        }
+        precise_bucket_->BatchInsertVector(vectors,
+                                           buckets.data(),
+                                           posting_ids.data(),
+                                           static_cast<InnerIdType>(posting_count),
+                                           precise_offsets.data());
     }
 
     auto add_func = [&](int64_t i) -> void {
@@ -628,7 +663,7 @@ IVF::Add(const DatasetPtr& base) {
             InnerIdType offset_id;
             if (precise_bucket_ != nullptr) {
                 // Publish the basic posting only after its precise mirror is ready.
-                offset_id = precise_bucket_->InsertVector(data_ptr, buckets[idx], posting_id);
+                offset_id = precise_offsets[idx];
                 bucket_->InsertVectorWithOffset(data_ptr, buckets[idx], posting_id, offset_id);
             } else {
                 offset_id = bucket_->InsertVector(data_ptr, buckets[idx], posting_id);
@@ -1152,12 +1187,13 @@ void
 IVF::load_streaming_body(StreamReader& reader,
                          const MetadataPtr& metadata,
                          const LoadParameters& parameters) {
-    (void)parameters;
-    this->read_streaming_body(reader, metadata);
+    this->read_streaming_body(reader, metadata, &parameters);
 }
 
 void
-IVF::read_streaming_body(StreamReader& reader, const MetadataPtr& metadata) {
+IVF::read_streaming_body(StreamReader& reader,
+                         const MetadataPtr& metadata,
+                         const LoadParameters* load_parameters) {
     auto basic_info = metadata->Get(BASIC_INFO);
     this->total_elements_ = basic_info["total_elements"].GetInt();
     this->use_reorder_ = basic_info["use_reorder"].GetBool();
@@ -1184,6 +1220,29 @@ IVF::read_streaming_body(StreamReader& reader, const MetadataPtr& metadata) {
     bool loaded_precise_codes = false;
     bool loaded_attribute_filter = false;
 
+    ReaderIOParamPtr precise_reader_param = nullptr;
+    auto ivf_param = std::dynamic_pointer_cast<IVFParameter>(create_param_ptr_);
+    if (ivf_param != nullptr && ivf_param->precise_codes_param != nullptr &&
+        ivf_param->precise_codes_param->io_parameter != nullptr &&
+        ivf_param->precise_codes_param->io_parameter->GetTypeName() == IO_TYPE_VALUE_READER_IO) {
+        constexpr const char* precise_reader_key = "precise_reader";
+        if (load_parameters == nullptr or not load_parameters->HasReader(precise_reader_key)) {
+            throw VsagException(ErrorType::INVALID_ARGUMENT,
+                                "reader-backed IVF precise codes require precise_reader");
+        }
+        auto precise_reader = load_parameters->GetReader(precise_reader_key);
+        if (precise_reader == nullptr) {
+            throw VsagException(ErrorType::INVALID_ARGUMENT, "precise_reader is null");
+        }
+        precise_reader_param = std::dynamic_pointer_cast<ReaderIOParameter>(
+            ivf_param->precise_codes_param->io_parameter);
+        if (precise_reader_param == nullptr) {
+            throw VsagException(ErrorType::INTERNAL_ERROR,
+                                "IVF precise reader IO parameter is invalid");
+        }
+        precise_reader_param->reader = std::move(precise_reader);
+    }
+
     while (true) {
         auto block_header = StreamBlockHeader::Read(reader);
         if (block_header.IsSectionEnd()) {
@@ -1206,6 +1265,16 @@ IVF::read_streaming_body(StreamReader& reader, const MetadataPtr& metadata) {
             continue;
         }
 
+        auto read_precise_block = [&](const auto& deserialize, const auto& init_io) {
+            if (precise_reader_param == nullptr) {
+                ReadSeekableBlockPayload(block_reader, block_header, deserialize);
+                return;
+            }
+            block_reader.SkipRemaining();
+            ReadExternalBlockPayload(precise_reader_param->reader, block_header, deserialize);
+            init_io(precise_reader_param);
+        };
+
         switch (static_cast<StreamSerializationTag>(block_header.tag)) {
             case StreamSerializationTag::IVF_BUCKET:
                 ReadSeekableBlockPayload(block_reader, block_header, [this](StreamReader& block) {
@@ -1227,18 +1296,20 @@ IVF::read_streaming_body(StreamReader& reader, const MetadataPtr& metadata) {
                 break;
             case StreamSerializationTag::HIGH_PRECISION_CODES:
                 if (this->use_reorder_ and this->reorder_codes_ != nullptr) {
-                    ReadSeekableBlockPayload(
-                        block_reader, block_header, [this](StreamReader& block) {
-                            this->reorder_codes_->Deserialize(block);
+                    read_precise_block(
+                        [this](StreamReader& block) { this->reorder_codes_->Deserialize(block); },
+                        [this](const IOParamPtr& io_param) {
+                            this->reorder_codes_->InitIO(io_param);
                         });
                     loaded_precise_codes = true;
                 }
                 break;
             case StreamSerializationTag::IVF_PRECISE_BUCKET:
                 if (this->use_reorder_ and this->precise_bucket_ != nullptr) {
-                    ReadSeekableBlockPayload(
-                        block_reader, block_header, [this](StreamReader& block) {
-                            this->precise_bucket_->Deserialize(block);
+                    read_precise_block(
+                        [this](StreamReader& block) { this->precise_bucket_->Deserialize(block); },
+                        [this](const IOParamPtr& io_param) {
+                            this->precise_bucket_->InitIO(io_param);
                         });
                     loaded_precise_codes = true;
                 }
@@ -1597,70 +1668,10 @@ IVF::reorder(int64_t topk,
              ReasoningContext* reasoning_ctx,
              const std::optional<float>& distance_threshold) const {
     auto reorder_heap =
-        precise_bucket_ != nullptr
-            ? this->reorder_with_precise_bucket(input, query, topk, ctx, distance_threshold)
-            : reorder_->Reorder(input, query, topk, ctx, nullptr, nullptr, distance_threshold);
+        reorder_->Reorder(input, query, topk, ctx, nullptr, nullptr, distance_threshold);
     auto dataset_results = this->pack_knn_result(reorder_heap, ctx.alloc);
 
     return dataset_results;
-}
-
-DistHeapPtr
-IVF::reorder_with_precise_bucket(const DistHeapPtr& input,
-                                 const float* query,
-                                 int64_t topk,
-                                 QueryContext& ctx,
-                                 const std::optional<float>& distance_threshold) const {
-    Allocator* query_allocator = select_query_allocator(ctx.alloc, allocator_);
-    const uint64_t candidate_count = input == nullptr ? 0 : input->Size();
-    topk = std::min(topk, static_cast<int64_t>(candidate_count));
-    auto reorder_heap = std::make_shared<StandardHeap<true, false>>(query_allocator, topk);
-    if (candidate_count == 0 or topk == 0) {
-        return reorder_heap;
-    }
-
-    if (ctx.stats != nullptr) {
-        ctx.stats->reorder_distance_count.fetch_add(static_cast<uint32_t>(candidate_count),
-                                                    std::memory_order_relaxed);
-    }
-
-    auto computer = precise_bucket_->FactoryComputer(query);
-    const auto* candidates = input->GetData();
-    Vector<BucketIdType> bucket_ids(candidate_count, query_allocator);
-    Vector<InnerIdType> offset_ids(candidate_count, query_allocator);
-    Vector<float> precise_distances(candidate_count, query_allocator);
-    for (uint64_t i = 0; i < candidate_count; ++i) {
-        const auto [bucket_id, offset_id] = this->get_location(candidates[i].second);
-        bucket_ids[i] = bucket_id;
-        offset_ids[i] = offset_id;
-    }
-    precise_bucket_->Query(precise_distances.data(),
-                           computer,
-                           bucket_ids.data(),
-                           offset_ids.data(),
-                           static_cast<InnerIdType>(candidate_count),
-                           &ctx);
-    for (uint64_t i = 0; i < candidate_count; ++i) {
-        const auto [coarse_distance, inner_id] = candidates[i];
-        const auto precise_distance = precise_distances[i];
-        if (ctx.reasoning_ctx != nullptr) {
-            ctx.reasoning_ctx->RecordReorder(inner_id, coarse_distance, precise_distance);
-        }
-        if (distance_threshold.has_value() and (not std::isfinite(precise_distance) or
-                                                precise_distance > distance_threshold.value())) {
-            continue;
-        }
-        if (reorder_heap->Size() < topk or precise_distance < reorder_heap->Top().first) {
-            reorder_heap->Push(precise_distance, inner_id);
-            if (reorder_heap->Size() > topk) {
-                if (ctx.reasoning_ctx != nullptr) {
-                    ctx.reasoning_ctx->RecordReorderEviction(reorder_heap->Top().second, 0);
-                }
-                reorder_heap->Pop();
-            }
-        }
-    }
-    return reorder_heap;
 }
 
 InnerIndexPtr

--- a/src/algorithm/ivf/ivf.cpp
+++ b/src/algorithm/ivf/ivf.cpp
@@ -59,6 +59,20 @@ namespace vsag {
 
 static constexpr BucketIdType INVALID_BUCKET_ID = static_cast<BucketIdType>(-1);
 
+namespace {
+
+BucketDataCellParamPtr
+make_precise_bucket_param(const IVFParameterPtr& param) {
+    auto precise_bucket_param = std::make_shared<BucketDataCellParameter>();
+    precise_bucket_param->io_parameter = param->precise_codes_param->io_parameter;
+    precise_bucket_param->quantizer_parameter = param->precise_codes_param->quantizer_parameter;
+    precise_bucket_param->buckets_count = param->bucket_param->buckets_count;
+    precise_bucket_param->use_residual_ = false;
+    return precise_bucket_param;
+}
+
+}  // namespace
+
 static constexpr const char* IVF_PARAMS_TEMPLATE =
     R"(
     {
@@ -98,6 +112,7 @@ static constexpr const char* IVF_PARAMS_TEMPLATE =
         },
         "{BUCKET_PER_DATA_KEY}": 1,
         "{USE_REORDER_KEY}": false,
+        "{PRECISE_CODES_LAYOUT_KEY}": "{PRECISE_CODES_LAYOUT_VALUE_FLAT}",
         "{PRECISE_CODES_KEY}": {
             "{IO_PARAMS_KEY}": {
                 "{TYPE_KEY}": "{IO_TYPE_VALUE_BLOCK_MEMORY_IO}",
@@ -232,6 +247,12 @@ IVF::CheckAndMappingExternalParam(const JsonType& external_param,
             IVF_USE_REORDER,
             {
                 USE_REORDER_KEY,
+            },
+        },
+        {
+            IVF_PRECISE_CODES_LAYOUT,
+            {
+                PRECISE_CODES_LAYOUT_KEY,
             },
         },
         {
@@ -419,9 +440,16 @@ IVF::IVF(const IVFParameterPtr& param, const IndexCommonParam& common_param)
             modified_common_param, param->ivf_partition_strategy_parameter);
     }
     if (this->use_reorder_) {
-        this->reorder_codes_ =
-            FlattenInterface::MakeInstance(param->precise_codes_param, modified_common_param);
-        reorder_ = std::make_shared<FlattenReorder>(this->reorder_codes_, allocator_);
+        if (param->precise_codes_layout == PRECISE_CODES_LAYOUT_VALUE_BUCKET) {
+            this->precise_bucket_ = BucketInterface::MakeInstance(make_precise_bucket_param(param),
+                                                                  modified_common_param);
+            CHECK_ARGUMENT(this->precise_bucket_ != nullptr,
+                           "unsupported IO or quantizer for IVF precise bucket");
+        } else {
+            this->reorder_codes_ =
+                FlattenInterface::MakeInstance(param->precise_codes_param, modified_common_param);
+            reorder_ = std::make_shared<FlattenReorder>(this->reorder_codes_, allocator_);
+        }
     }
     if (param->bucket_param->use_residual_) {
         this->bucket_->SetStrategy(partition_strategy_);
@@ -485,8 +513,11 @@ IVF::InitFeatures() {
     }
 
     bool has_fp32 = false;
-    if (use_reorder_ && reorder_codes_->GetQuantizerName() == QUANTIZATION_TYPE_VALUE_FP32) {
-        has_fp32 = true;
+    if (use_reorder_) {
+        const auto precise_quantizer_name = precise_bucket_ != nullptr
+                                                ? precise_bucket_->GetQuantizerName()
+                                                : reorder_codes_->GetQuantizerName();
+        has_fp32 = precise_quantizer_name == QUANTIZATION_TYPE_VALUE_FP32;
     }
     if (name == QUANTIZATION_TYPE_VALUE_FP32 or has_fp32) {
         this->index_feature_list_->SetFeature(IndexFeature::SUPPORT_CAL_DISTANCE_BY_ID);
@@ -542,7 +573,11 @@ IVF::Train(const DatasetPtr& data) {
     const auto* data_ptr = train_data->GetFloat32Vectors();
     this->bucket_->Train(data_ptr, sample_count);
     if (use_reorder_) {
-        this->reorder_codes_->Train(data->GetFloat32Vectors(), data->GetNumElements());
+        if (precise_bucket_ != nullptr) {
+            this->precise_bucket_->Train(data->GetFloat32Vectors(), data->GetNumElements());
+        } else {
+            this->reorder_codes_->Train(data->GetFloat32Vectors(), data->GetNumElements());
+        }
     }
     this->is_trained_ = true;
 }
@@ -554,6 +589,9 @@ IVF::Add(const DatasetPtr& base) {
         throw VsagException(ErrorType::INTERNAL_ERROR, "ivf index add without train error");
     }
     this->bucket_->Unpack();
+    if (precise_bucket_ != nullptr) {
+        this->precise_bucket_->Unpack();
+    }
     auto num_element = base->GetNumElements();
     const auto* ids = base->GetIds();
     const auto* vectors = base->GetFloat32Vectors();
@@ -567,7 +605,7 @@ IVF::Add(const DatasetPtr& base) {
     bool need_cal_memory_usage = false;
     {
         std::lock_guard lock(label_lookup_mutex_);
-        if (use_reorder_) {
+        if (use_reorder_ and precise_bucket_ == nullptr) {
             this->reorder_codes_->BatchInsertVector(base->GetFloat32Vectors(),
                                                     base->GetNumElements());
         }
@@ -587,8 +625,15 @@ IVF::Add(const DatasetPtr& base) {
         for (int64_t j = 0; j < buckets_per_data_; ++j) {
             const auto* data_ptr = vectors + i * dim_;
             auto idx = i * buckets_per_data_ + j;
-            InnerIdType offset_id = bucket_->InsertVector(
-                data_ptr, buckets[idx], idx + current_num * buckets_per_data_);
+            auto posting_id = static_cast<InnerIdType>(idx + current_num * buckets_per_data_);
+            InnerIdType offset_id;
+            if (precise_bucket_ != nullptr) {
+                // Publish the basic posting only after its precise mirror is ready.
+                offset_id = precise_bucket_->InsertVector(data_ptr, buckets[idx], posting_id);
+                bucket_->InsertVectorWithOffset(data_ptr, buckets[idx], posting_id, offset_id);
+            } else {
+                offset_id = bucket_->InsertVector(data_ptr, buckets[idx], posting_id);
+            }
             if (j == 0) {
                 std::lock_guard lock(label_lookup_mutex_);
                 location_map_[i + current_num] =
@@ -635,6 +680,9 @@ IVF::Add(const DatasetPtr& base) {
         std::rethrow_exception(first_exception);
     }
     this->bucket_->Package();
+    if (precise_bucket_ != nullptr) {
+        this->precise_bucket_->Package();
+    }
     if (need_cal_memory_usage) {
         this->cal_memory_usage();
     }
@@ -850,11 +898,17 @@ IVF::GetNumElements() const {
 void
 IVF::Merge(const std::vector<MergeUnit>& merge_units) {
     this->bucket_->Unpack();
+    if (precise_bucket_ != nullptr) {
+        this->precise_bucket_->Unpack();
+    }
     for (const auto& unit : merge_units) {
         this->merge_one_unit(unit);
     }
     this->fill_location_map();
     this->bucket_->Package();
+    if (precise_bucket_ != nullptr) {
+        this->precise_bucket_->Package();
+    }
 }
 
 std::pair<BucketIdType, InnerIdType>
@@ -910,7 +964,11 @@ IVF::Serialize(StreamWriter& writer) const {
     WRITE_DATACELL_WITH_NAME(writer, "label_table", label_table_);
 
     if (use_reorder_) {
-        WRITE_DATACELL_WITH_NAME(writer, "reorder_codes", reorder_codes_);
+        if (precise_bucket_ != nullptr) {
+            WRITE_DATACELL_WITH_NAME(writer, "precise_bucket", precise_bucket_);
+        } else {
+            WRITE_DATACELL_WITH_NAME(writer, "reorder_codes", reorder_codes_);
+        }
     }
 
     if (use_attribute_filter_) {
@@ -997,7 +1055,9 @@ IVF::collect_streaming_header() const {
                                  StreamSerializationBlockCurrentVersion(label_tag),
                                  StreamSerializationTagCritical(label_tag));
     if (this->use_reorder_) {
-        auto tag = static_cast<uint32_t>(StreamSerializationTag::HIGH_PRECISION_CODES);
+        auto tag = static_cast<uint32_t>(precise_bucket_ != nullptr
+                                             ? StreamSerializationTag::IVF_PRECISE_BUCKET
+                                             : StreamSerializationTag::HIGH_PRECISION_CODES);
         AppendStreamingManifestBlock(manifest,
                                      tag,
                                      StreamSerializationBlockCurrentVersion(tag),
@@ -1042,10 +1102,16 @@ IVF::serialize_streaming_body(StreamWriter& writer) const {
             this->label_table_->Serialize(w);
         });
     if (this->use_reorder_) {
-        auto tag = static_cast<uint32_t>(StreamSerializationTag::HIGH_PRECISION_CODES);
+        auto tag = static_cast<uint32_t>(precise_bucket_ != nullptr
+                                             ? StreamSerializationTag::IVF_PRECISE_BUCKET
+                                             : StreamSerializationTag::HIGH_PRECISION_CODES);
         WriteStreamingBlock(
             writer, tag, StreamSerializationTagCritical(tag), [this](StreamWriter& w) {
-                this->reorder_codes_->Serialize(w);
+                if (this->precise_bucket_ != nullptr) {
+                    this->precise_bucket_->Serialize(w);
+                } else {
+                    this->reorder_codes_->Serialize(w);
+                }
             });
     }
     if (this->use_attribute_filter_) {
@@ -1097,6 +1163,10 @@ IVF::read_streaming_body(StreamReader& reader, const MetadataPtr& metadata) {
     this->total_elements_ = basic_info["total_elements"].GetInt();
     this->use_reorder_ = basic_info["use_reorder"].GetBool();
     this->is_trained_ = basic_info["is_trained"].GetBool();
+    if (precise_bucket_ != nullptr and not basic_info.Contains(INDEX_PARAM)) {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "IVF precise bucket requires persisted index parameters");
+    }
     if (basic_info.Contains(INDEX_PARAM)) {
         auto index_param = std::make_shared<IVFParameter>();
         index_param->FromString(basic_info[INDEX_PARAM].GetString());
@@ -1112,7 +1182,7 @@ IVF::read_streaming_body(StreamReader& reader, const MetadataPtr& metadata) {
     bool loaded_bucket = false;
     bool loaded_partition = false;
     bool loaded_label_table = false;
-    bool loaded_reorder_codes = false;
+    bool loaded_precise_codes = false;
     bool loaded_attribute_filter = false;
 
     while (true) {
@@ -1157,12 +1227,21 @@ IVF::read_streaming_body(StreamReader& reader, const MetadataPtr& metadata) {
                 loaded_label_table = true;
                 break;
             case StreamSerializationTag::HIGH_PRECISION_CODES:
-                if (this->use_reorder_) {
+                if (this->use_reorder_ and this->reorder_codes_ != nullptr) {
                     ReadSeekableBlockPayload(
                         block_reader, block_header, [this](StreamReader& block) {
                             this->reorder_codes_->Deserialize(block);
                         });
-                    loaded_reorder_codes = true;
+                    loaded_precise_codes = true;
+                }
+                break;
+            case StreamSerializationTag::IVF_PRECISE_BUCKET:
+                if (this->use_reorder_ and this->precise_bucket_ != nullptr) {
+                    ReadSeekableBlockPayload(
+                        block_reader, block_header, [this](StreamReader& block) {
+                            this->precise_bucket_->Deserialize(block);
+                        });
+                    loaded_precise_codes = true;
                 }
                 break;
             case StreamSerializationTag::ATTRIBUTE_FILTER:
@@ -1256,7 +1335,7 @@ IVF::read_streaming_body(StreamReader& reader, const MetadataPtr& metadata) {
         throw VsagException(ErrorType::READ_ERROR,
                             "IVF streaming serialization required block is missing");
     }
-    if (this->use_reorder_ && !loaded_reorder_codes) {
+    if (this->use_reorder_ && !loaded_precise_codes) {
         throw VsagException(ErrorType::READ_ERROR,
                             "IVF streaming serialization reorder block is missing");
     }
@@ -1285,6 +1364,10 @@ IVF::Deserialize(StreamReader& reader) {
         &reader, std::numeric_limits<uint64_t>::max(), this->allocator_);
 
     if (footer == nullptr) {  // old format, DON'T EDIT, remove in the future
+        if (precise_bucket_ != nullptr) {
+            throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                                "legacy IVF serialization does not support precise bucket");
+        }
         logger::debug("parse with v0.14 version format");
 
         StreamReader::ReadObj(buffer_reader, this->total_elements_);
@@ -1314,6 +1397,10 @@ IVF::Deserialize(StreamReader& reader) {
         this->total_elements_ = basic_info["total_elements"].GetInt();
         this->use_reorder_ = basic_info["use_reorder"].GetBool();
         this->is_trained_ = basic_info["is_trained"].GetBool();
+        if (precise_bucket_ != nullptr and not basic_info.Contains(INDEX_PARAM)) {
+            throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                                "IVF precise bucket requires persisted index parameters");
+        }
         if (basic_info.Contains(INDEX_PARAM)) {
             auto param_str = basic_info[INDEX_PARAM].GetString();
             auto index_param = std::make_shared<IVFParameter>();
@@ -1336,7 +1423,11 @@ IVF::Deserialize(StreamReader& reader) {
         READ_DATACELL_WITH_NAME(buffer_reader, "partition_strategy", this->partition_strategy_);
         READ_DATACELL_WITH_NAME(buffer_reader, "label_table", this->label_table_);
         if (use_reorder_) {
-            READ_DATACELL_WITH_NAME(buffer_reader, "reorder_codes", this->reorder_codes_);
+            if (precise_bucket_ != nullptr) {
+                READ_DATACELL_WITH_NAME(buffer_reader, "precise_bucket", this->precise_bucket_);
+            } else {
+                READ_DATACELL_WITH_NAME(buffer_reader, "reorder_codes", this->reorder_codes_);
+            }
         }
         if (use_attribute_filter_) {
             READ_DATACELL_WITH_NAME(buffer_reader, "attr_filter_index", this->attr_filter_index_);
@@ -1506,11 +1597,60 @@ IVF::reorder(int64_t topk,
              QueryContext& ctx,
              ReasoningContext* reasoning_ctx,
              const std::optional<float>& distance_threshold) const {
-    auto reorder_heap =
-        reorder_->Reorder(input, query, topk, ctx, nullptr, nullptr, distance_threshold);
+    auto reorder_heap = precise_bucket_ != nullptr
+                            ? this->reorder_with_precise_bucket(
+                                  input, query, topk, ctx, distance_threshold)
+                            : reorder_->Reorder(
+                                  input, query, topk, ctx, nullptr, nullptr, distance_threshold);
     auto dataset_results = this->pack_knn_result(reorder_heap, ctx.alloc);
 
     return dataset_results;
+}
+
+DistHeapPtr
+IVF::reorder_with_precise_bucket(const DistHeapPtr& input,
+                                 const float* query,
+                                 int64_t topk,
+                                 QueryContext& ctx,
+                                 const std::optional<float>& distance_threshold) const {
+    Allocator* query_allocator = select_query_allocator(ctx.alloc, allocator_);
+    const uint64_t candidate_count = input == nullptr ? 0 : input->Size();
+    topk = std::min(topk, static_cast<int64_t>(candidate_count));
+    auto reorder_heap = std::make_shared<StandardHeap<true, false>>(query_allocator, topk);
+    if (candidate_count == 0 or topk == 0) {
+        return reorder_heap;
+    }
+
+    if (ctx.stats != nullptr) {
+        ctx.stats->reorder_distance_count.fetch_add(static_cast<uint32_t>(candidate_count),
+                                                    std::memory_order_relaxed);
+    }
+
+    auto computer = precise_bucket_->FactoryComputer(query);
+    const auto* candidates = input->GetData();
+    for (uint64_t i = 0; i < candidate_count; ++i) {
+        const auto [coarse_distance, inner_id] = candidates[i];
+        const auto [bucket_id, offset_id] = this->get_location(inner_id);
+        auto precise_distance = precise_bucket_->QueryOneById(computer, bucket_id, offset_id);
+        if (ctx.reasoning_ctx != nullptr) {
+            ctx.reasoning_ctx->RecordReorder(inner_id, coarse_distance, precise_distance);
+        }
+        if (distance_threshold.has_value() and
+            (not std::isfinite(precise_distance) or
+             precise_distance > distance_threshold.value())) {
+            continue;
+        }
+        if (reorder_heap->Size() < topk or precise_distance < reorder_heap->Top().first) {
+            reorder_heap->Push(precise_distance, inner_id);
+            if (reorder_heap->Size() > topk) {
+                if (ctx.reasoning_ctx != nullptr) {
+                    ctx.reasoning_ctx->RecordReorderEviction(reorder_heap->Top().second, 0);
+                }
+                reorder_heap->Pop();
+            }
+        }
+    }
+    return reorder_heap;
 }
 
 InnerIndexPtr
@@ -1519,7 +1659,11 @@ IVF::ExportModel(const IndexCommonParam& param) const {
     IVFPartitionStrategy::Clone(this->partition_strategy_, index->partition_strategy_);
     this->bucket_->ExportModel(index->bucket_);
     if (use_reorder_) {
-        this->reorder_codes_->ExportModel(index->reorder_codes_);
+        if (precise_bucket_ != nullptr) {
+            this->precise_bucket_->ExportModel(index->precise_bucket_);
+        } else {
+            this->reorder_codes_->ExportModel(index->reorder_codes_);
+        }
     }
     index->is_trained_ = this->is_trained_;
     return index;
@@ -1832,7 +1976,13 @@ IVF::merge_one_unit(const MergeUnit& unit) {
     other_index->bucket_->Package();
 
     if (this->use_reorder_) {
-        this->reorder_codes_->MergeOther(other_index->reorder_codes_, this->total_elements_);
+        if (precise_bucket_ != nullptr) {
+            other_index->precise_bucket_->Unpack();
+            this->precise_bucket_->MergeOther(other_index->precise_bucket_, bucket_bias);
+            other_index->precise_bucket_->Package();
+        } else {
+            this->reorder_codes_->MergeOther(other_index->reorder_codes_, this->total_elements_);
+        }
     }
     this->total_elements_ += other_index->total_elements_;
 }
@@ -1853,6 +2003,10 @@ IVF::check_merge_illegal(const vsag::MergeUnit& unit) const {
                                         "index is {}, other index is {}",
                                         this->use_reorder_,
                                         other_ivf_index->use_reorder_));
+    }
+    if ((other_ivf_index->precise_bucket_ == nullptr) != (this->precise_bucket_ == nullptr)) {
+        throw VsagException(ErrorType::INVALID_ARGUMENT,
+                            "Merge Failed: IVF precise codes layout does not match");
     }
     auto cur_model = this->ExportModel(index->GetCommonParam());
     std::stringstream ss1;
@@ -2204,10 +2358,27 @@ void
 IVF::fill_location_map() {
     this->location_map_.resize(this->total_elements_ * buckets_per_data_);
     auto bucket_count = this->bucket_->bucket_count_;
+    if (precise_bucket_ != nullptr and precise_bucket_->GetBucketCount() != bucket_count) {
+        throw VsagException(ErrorType::INTERNAL_ERROR,
+                            "basic and precise bucket counts do not match");
+    }
     for (BucketIdType i = 0; i < bucket_count; ++i) {
         auto* ids = this->bucket_->GetInnerIds(i);
         auto bucket_size = this->bucket_->GetBucketSize(i);
+        InnerIdType* precise_ids = nullptr;
+        if (precise_bucket_ != nullptr) {
+            auto precise_bucket_size = precise_bucket_->GetBucketSize(i);
+            if (precise_bucket_size != bucket_size) {
+                throw VsagException(ErrorType::INTERNAL_ERROR,
+                                    "basic and precise bucket sizes do not match");
+            }
+            precise_ids = precise_bucket_->GetInnerIds(i);
+        }
         for (uint64_t j = 0; j < bucket_size; ++j) {
+            if (precise_ids != nullptr and precise_ids[j] != ids[j]) {
+                throw VsagException(ErrorType::INTERNAL_ERROR,
+                                    "basic and precise bucket inner ids do not match");
+            }
             if (ids[j] == std::numeric_limits<InnerIdType>::max()) {
                 continue;
             }
@@ -2267,15 +2438,16 @@ IVF::CalDistanceById(const float* query,
             }
         }
     }
-    if (this->use_reorder_ && calculate_precise_distance) {
+    if (this->use_reorder_ && calculate_precise_distance && reorder_codes_ != nullptr) {
         auto computer = this->reorder_codes_->FactoryComputer(query);
         this->reorder_codes_->Query(distances, computer, inner_ids.data(), count);
     } else {
-        auto computer = this->bucket_->FactoryComputer(query);
+        auto codes = this->use_reorder_ && calculate_precise_distance ? precise_bucket_ : bucket_;
+        auto computer = codes->FactoryComputer(query);
         for (int64_t i = 0; i < count; ++i) {
             if (validity[i]) {
                 auto [bucket_id, offset_id] = this->get_location(inner_ids[i]);
-                distances[i] = this->bucket_->QueryOneById(computer, bucket_id, offset_id);
+                distances[i] = codes->QueryOneById(computer, bucket_id, offset_id);
             }
         }
     }
@@ -2297,15 +2469,16 @@ IVF::CalcDistanceById(const float* query, int64_t id, bool calculate_precise_dis
     if (not success) {
         return -1.0F;
     }
-    if (this->use_reorder_ && calculate_precise_distance) {
+    if (this->use_reorder_ && calculate_precise_distance && reorder_codes_ != nullptr) {
         float dist = 0.0F;
         auto computer = this->reorder_codes_->FactoryComputer(query);
         this->reorder_codes_->Query(&dist, computer, &inner_id, 1);
         return dist;
     }
-    auto computer = this->bucket_->FactoryComputer(query);
+    auto codes = this->use_reorder_ && calculate_precise_distance ? precise_bucket_ : bucket_;
+    auto computer = codes->FactoryComputer(query);
     auto [bucket_id, offset_id] = this->get_location(inner_id);
-    return this->bucket_->QueryOneById(computer, bucket_id, offset_id);
+    return codes->QueryOneById(computer, bucket_id, offset_id);
 }
 
 void
@@ -2414,7 +2587,8 @@ IVF::cal_memory_usage() {
     auto memory = sizeof(IVF);
     memory += this->bucket_->GetMemoryUsage();
     if (use_reorder_) {
-        memory += this->reorder_codes_->GetMemoryUsage();
+        memory += precise_bucket_ != nullptr ? precise_bucket_->GetMemoryUsage()
+                                             : reorder_codes_->GetMemoryUsage();
     }
     if (this->extra_info_size_ > 0 and this->extra_infos_ != nullptr) {
         memory += this->extra_infos_->GetMemoryUsage();

--- a/src/algorithm/ivf/ivf.h
+++ b/src/algorithm/ivf/ivf.h
@@ -106,7 +106,20 @@ public:
     ExportModel(const IndexCommonParam& param) const override;
 
     [[nodiscard]] InnerIndexPtr
+    Clone(const IndexCommonParam& param) override {
+        if (this->disk_backed_precise_bucket_) {
+            throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                                "Clone does not support disk-backed IVF precise buckets");
+        }
+        return InnerIndexInterface::Clone(param);
+    }
+
+    [[nodiscard]] InnerIndexPtr
     Fork(const IndexCommonParam& param) override {
+        if (this->disk_backed_precise_bucket_) {
+            throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                                "Clone does not support disk-backed IVF precise buckets");
+        }
         return std::make_shared<IVF>(this->create_param_ptr_, param);
     }
 
@@ -297,6 +310,7 @@ private:
     FlattenInterfacePtr reorder_codes_{nullptr};  // legacy high-precision flat codes
     BucketInterfacePtr precise_bucket_{nullptr};  // high-precision codes mirroring basic buckets
     ReorderInterfacePtr reorder_{nullptr};        // flat-code reordering engine
+    bool disk_backed_precise_bucket_{false};
 
     std::shared_ptr<SafeThreadPool> thread_pool_{nullptr};  // for parallel bucket scans
 

--- a/src/algorithm/ivf/ivf.h
+++ b/src/algorithm/ivf/ivf.h
@@ -227,6 +227,13 @@ private:
             ReasoningContext* reasoning_ctx = nullptr,
             const std::optional<float>& distance_threshold = std::nullopt) const;
 
+    DistHeapPtr
+    reorder_with_precise_bucket(const DistHeapPtr& input,
+                                const float* query,
+                                int64_t topk,
+                                QueryContext& ctx,
+                                const std::optional<float>& distance_threshold) const;
+
     void
     AttachReasoningReport(const DatasetPtr& dataset_results, ReasoningContext* reasoning_ctx) const;
 
@@ -287,8 +294,9 @@ private:
     int64_t total_elements_{0};  // total inserted (incl. deleted)
     bool is_trained_{false};     // true after Train() succeeds
 
-    FlattenInterfacePtr reorder_codes_{nullptr};  // high-precision codes for reranking
-    ReorderInterfacePtr reorder_{nullptr};        // reordering engine
+    FlattenInterfacePtr reorder_codes_{nullptr};  // legacy high-precision flat codes
+    BucketInterfacePtr precise_bucket_{nullptr};  // high-precision codes mirroring basic buckets
+    ReorderInterfacePtr reorder_{nullptr};        // flat-code reordering engine
 
     std::shared_ptr<SafeThreadPool> thread_pool_{nullptr};  // for parallel bucket scans
 

--- a/src/algorithm/ivf/ivf.h
+++ b/src/algorithm/ivf/ivf.h
@@ -118,7 +118,7 @@ public:
     Fork(const IndexCommonParam& param) override {
         if (this->disk_backed_precise_bucket_) {
             throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                                "Clone does not support disk-backed IVF precise buckets");
+                                "Fork does not support disk-backed IVF precise buckets");
         }
         return std::make_shared<IVF>(this->create_param_ptr_, param);
     }

--- a/src/algorithm/ivf/ivf.h
+++ b/src/algorithm/ivf/ivf.h
@@ -108,7 +108,20 @@ public:
     ExportModel(const IndexCommonParam& param) const override;
 
     [[nodiscard]] InnerIndexPtr
+    Clone(const IndexCommonParam& param) override {
+        if (this->disk_backed_precise_bucket_) {
+            throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                                "Clone does not support disk-backed IVF precise buckets");
+        }
+        return InnerIndexInterface::Clone(param);
+    }
+
+    [[nodiscard]] InnerIndexPtr
     Fork(const IndexCommonParam& param) override {
+        if (this->disk_backed_precise_bucket_) {
+            throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                                "Clone does not support disk-backed IVF precise buckets");
+        }
         return std::make_shared<IVF>(this->create_param_ptr_, param);
     }
 
@@ -299,6 +312,7 @@ private:
     FlattenInterfacePtr reorder_codes_{nullptr};  // legacy high-precision flat codes
     BucketInterfacePtr precise_bucket_{nullptr};  // high-precision codes mirroring basic buckets
     ReorderInterfacePtr reorder_{nullptr};        // flat-code reordering engine
+    bool disk_backed_precise_bucket_{false};
 
     std::shared_ptr<SafeThreadPool> thread_pool_{nullptr};  // for parallel bucket scans
 

--- a/src/algorithm/ivf/ivf.h
+++ b/src/algorithm/ivf/ivf.h
@@ -108,20 +108,7 @@ public:
     ExportModel(const IndexCommonParam& param) const override;
 
     [[nodiscard]] InnerIndexPtr
-    Clone(const IndexCommonParam& param) override {
-        if (this->disk_backed_precise_bucket_) {
-            throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                                "Clone does not support disk-backed IVF precise buckets");
-        }
-        return InnerIndexInterface::Clone(param);
-    }
-
-    [[nodiscard]] InnerIndexPtr
     Fork(const IndexCommonParam& param) override {
-        if (this->disk_backed_precise_bucket_) {
-            throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                                "Fork does not support disk-backed IVF precise buckets");
-        }
         return std::make_shared<IVF>(this->create_param_ptr_, param);
     }
 
@@ -312,7 +299,6 @@ private:
     FlattenInterfacePtr reorder_codes_{nullptr};  // legacy high-precision flat codes
     BucketInterfacePtr precise_bucket_{nullptr};  // high-precision codes mirroring basic buckets
     ReorderInterfacePtr reorder_{nullptr};        // flat-code reordering engine
-    bool disk_backed_precise_bucket_{false};
 
     std::shared_ptr<SafeThreadPool> thread_pool_{nullptr};  // for parallel bucket scans
 

--- a/src/algorithm/ivf/ivf.h
+++ b/src/algorithm/ivf/ivf.h
@@ -229,6 +229,13 @@ private:
             ReasoningContext* reasoning_ctx = nullptr,
             const std::optional<float>& distance_threshold = std::nullopt) const;
 
+    DistHeapPtr
+    reorder_with_precise_bucket(const DistHeapPtr& input,
+                                const float* query,
+                                int64_t topk,
+                                QueryContext& ctx,
+                                const std::optional<float>& distance_threshold) const;
+
     void
     AttachReasoningReport(const DatasetPtr& dataset_results, ReasoningContext* reasoning_ctx) const;
 
@@ -289,8 +296,9 @@ private:
     int64_t total_elements_{0};  // total inserted (incl. deleted)
     bool is_trained_{false};     // true after Train() succeeds
 
-    FlattenInterfacePtr reorder_codes_{nullptr};  // high-precision codes for reranking
-    ReorderInterfacePtr reorder_{nullptr};        // reordering engine
+    FlattenInterfacePtr reorder_codes_{nullptr};  // legacy high-precision flat codes
+    BucketInterfacePtr precise_bucket_{nullptr};  // high-precision codes mirroring basic buckets
+    ReorderInterfacePtr reorder_{nullptr};        // flat-code reordering engine
 
     std::shared_ptr<SafeThreadPool> thread_pool_{nullptr};  // for parallel bucket scans
 

--- a/src/algorithm/ivf/ivf.h
+++ b/src/algorithm/ivf/ivf.h
@@ -120,7 +120,7 @@ public:
     Fork(const IndexCommonParam& param) override {
         if (this->disk_backed_precise_bucket_) {
             throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                                "Clone does not support disk-backed IVF precise buckets");
+                                "Fork does not support disk-backed IVF precise buckets");
         }
         return std::make_shared<IVF>(this->create_param_ptr_, param);
     }

--- a/src/algorithm/ivf/ivf.h
+++ b/src/algorithm/ivf/ivf.h
@@ -229,13 +229,6 @@ private:
             ReasoningContext* reasoning_ctx = nullptr,
             const std::optional<float>& distance_threshold = std::nullopt) const;
 
-    DistHeapPtr
-    reorder_with_precise_bucket(const DistHeapPtr& input,
-                                const float* query,
-                                int64_t topk,
-                                QueryContext& ctx,
-                                const std::optional<float>& distance_threshold) const;
-
     void
     AttachReasoningReport(const DatasetPtr& dataset_results, ReasoningContext* reasoning_ctx) const;
 
@@ -276,7 +269,9 @@ private:
                         const LoadParameters& parameters) override;
 
     void
-    read_streaming_body(StreamReader& reader, const MetadataPtr& metadata);
+    read_streaming_body(StreamReader& reader,
+                        const MetadataPtr& metadata,
+                        const LoadParameters* load_parameters = nullptr);
 
     /// Recalculate and cache the memory-usage counter (throttled).
     void
@@ -298,7 +293,7 @@ private:
 
     FlattenInterfacePtr reorder_codes_{nullptr};  // legacy high-precision flat codes
     BucketInterfacePtr precise_bucket_{nullptr};  // high-precision codes mirroring basic buckets
-    ReorderInterfacePtr reorder_{nullptr};        // flat-code reordering engine
+    ReorderInterfacePtr reorder_{nullptr};        // high-precision reordering engine
 
     std::shared_ptr<SafeThreadPool> thread_pool_{nullptr};  // for parallel bucket scans
 

--- a/src/algorithm/ivf/ivf_parameter.cpp
+++ b/src/algorithm/ivf/ivf_parameter.cpp
@@ -48,6 +48,10 @@ IVFParameter::FromJson(const JsonType& json) {
         CHECK_ARGUMENT(this->precise_codes_param->quantizer_parameter->GetTypeName() !=
                            QUANTIZATION_TYPE_VALUE_PQFS,
                        "precise_codes_layout=bucket does not support pqfs precise quantization");
+        CHECK_ARGUMENT(
+            this->precise_codes_param->io_parameter == nullptr ||
+                this->precise_codes_param->io_parameter->GetTypeName() != IO_TYPE_VALUE_MMAP_IO,
+            "precise_codes_layout=bucket does not support mmap_io");
     }
 
     if (json.Contains(BUCKET_PER_DATA_KEY)) {
@@ -92,6 +96,17 @@ IVFParameter::FromJson(const JsonType& json) {
                 GraphStorageTypes::GRAPH_STORAGE_TYPE_VALUE_FLAT, graph_json);
         }
     }
+}
+
+bool
+IVFParameter::UsesDiskBackedPreciseBucket() const {
+    if (this->precise_codes_layout != PRECISE_CODES_LAYOUT_VALUE_BUCKET ||
+        this->precise_codes_param == nullptr ||
+        this->precise_codes_param->io_parameter == nullptr) {
+        return false;
+    }
+    const auto io_type = this->precise_codes_param->io_parameter->GetTypeName();
+    return io_type != IO_TYPE_VALUE_MEMORY_IO && io_type != IO_TYPE_VALUE_BLOCK_MEMORY_IO;
 }
 
 JsonType

--- a/src/algorithm/ivf/ivf_parameter.cpp
+++ b/src/algorithm/ivf/ivf_parameter.cpp
@@ -26,6 +26,30 @@ void
 IVFParameter::FromJson(const JsonType& json) {
     InnerIndexParameter::FromJson(json);
 
+    this->precise_codes_layout = PRECISE_CODES_LAYOUT_VALUE_FLAT;
+    if (json.Contains(PRECISE_CODES_LAYOUT_KEY)) {
+        this->precise_codes_layout = json[PRECISE_CODES_LAYOUT_KEY].GetString();
+    }
+    CHECK_ARGUMENT(
+        this->precise_codes_layout == PRECISE_CODES_LAYOUT_VALUE_FLAT ||
+            this->precise_codes_layout == PRECISE_CODES_LAYOUT_VALUE_BUCKET,
+        fmt::format("invalid precise_codes_layout: {}, supported values are \"{}\" and \"{}\"",
+                    this->precise_codes_layout,
+                    PRECISE_CODES_LAYOUT_VALUE_FLAT,
+                    PRECISE_CODES_LAYOUT_VALUE_BUCKET));
+
+    if (this->precise_codes_layout == PRECISE_CODES_LAYOUT_VALUE_BUCKET) {
+        CHECK_ARGUMENT(this->use_reorder, "precise_codes_layout=bucket requires use_reorder=true");
+        CHECK_ARGUMENT(this->reorder_source == HGRAPH_REORDER_SOURCE_PRECISE,
+                       "precise_codes_layout=bucket requires reorder_source=precise");
+        CHECK_ARGUMENT(this->precise_codes_param != nullptr &&
+                           this->precise_codes_param->name == FLATTEN_DATA_CELL,
+                       "precise_codes_layout=bucket requires ordinary flatten precise_codes");
+        CHECK_ARGUMENT(this->precise_codes_param->quantizer_parameter->GetTypeName() !=
+                           QUANTIZATION_TYPE_VALUE_PQFS,
+                       "precise_codes_layout=bucket does not support pqfs precise quantization");
+    }
+
     if (json.Contains(BUCKET_PER_DATA_KEY)) {
         this->buckets_per_data = static_cast<BucketIdType>(json[BUCKET_PER_DATA_KEY].GetInt());
     }
@@ -77,6 +101,7 @@ IVFParameter::ToJson() const {
     json[BUCKET_PARAMS_KEY].SetJson(this->bucket_param->ToJson());
     json[IVF_PARTITION_STRATEGY_PARAMS_KEY].SetJson(
         this->ivf_partition_strategy_parameter->ToJson());
+    json[PRECISE_CODES_LAYOUT_KEY].SetString(this->precise_codes_layout);
     json[BUCKET_PER_DATA_KEY].SetInt(this->buckets_per_data);
     json[GRAPH_BUILD_THRESHOLD_KEY].SetInt(this->graph_build_threshold);
     return json;
@@ -87,6 +112,7 @@ IVFParameter::CheckCompatibility(const ParamPtr& other) const {
         return false;
     }
     PARAM_CAST_OR_RETURN(IVFParameter, p, other);
+    CHECK_FIELD_EQ(*this, *p, precise_codes_layout);
     CHECK_FIELD_EQ(*this, *p, buckets_per_data);
     CHECK_FIELD_EQ(*this, *p, graph_build_threshold);
     CHECK_SUB_PARAM(*this, *p, bucket_param);

--- a/src/algorithm/ivf/ivf_parameter.cpp
+++ b/src/algorithm/ivf/ivf_parameter.cpp
@@ -38,8 +38,14 @@ IVFParameter::FromJson(const JsonType& json) {
                     PRECISE_CODES_LAYOUT_VALUE_FLAT,
                     PRECISE_CODES_LAYOUT_VALUE_BUCKET));
 
+    if (json.Contains(BUCKET_PER_DATA_KEY)) {
+        this->buckets_per_data = static_cast<BucketIdType>(json[BUCKET_PER_DATA_KEY].GetInt());
+    }
+
     if (this->precise_codes_layout == PRECISE_CODES_LAYOUT_VALUE_BUCKET) {
         CHECK_ARGUMENT(this->use_reorder, "precise_codes_layout=bucket requires use_reorder=true");
+        CHECK_ARGUMENT(this->buckets_per_data == 1,
+                       "precise_codes_layout=bucket requires buckets_per_data=1");
         CHECK_ARGUMENT(this->reorder_source == HGRAPH_REORDER_SOURCE_PRECISE,
                        "precise_codes_layout=bucket requires reorder_source=precise");
         CHECK_ARGUMENT(this->precise_codes_param != nullptr &&
@@ -52,10 +58,6 @@ IVFParameter::FromJson(const JsonType& json) {
             this->precise_codes_param->io_parameter == nullptr ||
                 this->precise_codes_param->io_parameter->GetTypeName() != IO_TYPE_VALUE_MMAP_IO,
             "precise_codes_layout=bucket does not support mmap_io");
-    }
-
-    if (json.Contains(BUCKET_PER_DATA_KEY)) {
-        this->buckets_per_data = static_cast<BucketIdType>(json[BUCKET_PER_DATA_KEY].GetInt());
     }
 
     this->bucket_param = std::make_shared<BucketDataCellParameter>();

--- a/src/algorithm/ivf/ivf_parameter.cpp
+++ b/src/algorithm/ivf/ivf_parameter.cpp
@@ -41,8 +41,14 @@ IVFParameter::FromJson(const JsonType& json) {
                     PRECISE_CODES_LAYOUT_VALUE_FLAT,
                     PRECISE_CODES_LAYOUT_VALUE_BUCKET));
 
+    if (json.Contains(BUCKET_PER_DATA_KEY)) {
+        this->buckets_per_data = static_cast<BucketIdType>(json[BUCKET_PER_DATA_KEY].GetInt());
+    }
+
     if (this->precise_codes_layout == PRECISE_CODES_LAYOUT_VALUE_BUCKET) {
         CHECK_ARGUMENT(this->use_reorder, "precise_codes_layout=bucket requires use_reorder=true");
+        CHECK_ARGUMENT(this->buckets_per_data == 1,
+                       "precise_codes_layout=bucket requires buckets_per_data=1");
         CHECK_ARGUMENT(this->reorder_source == HGRAPH_REORDER_SOURCE_PRECISE,
                        "precise_codes_layout=bucket requires reorder_source=precise");
         CHECK_ARGUMENT(this->precise_codes_param != nullptr &&
@@ -55,10 +61,6 @@ IVFParameter::FromJson(const JsonType& json) {
             this->precise_codes_param->io_parameter == nullptr ||
                 this->precise_codes_param->io_parameter->GetTypeName() != IO_TYPE_VALUE_MMAP_IO,
             "precise_codes_layout=bucket does not support mmap_io");
-    }
-
-    if (json.Contains(BUCKET_PER_DATA_KEY)) {
-        this->buckets_per_data = static_cast<BucketIdType>(json[BUCKET_PER_DATA_KEY].GetInt());
     }
 
     this->bucket_param = std::make_shared<BucketDataCellParameter>();

--- a/src/algorithm/ivf/ivf_parameter.cpp
+++ b/src/algorithm/ivf/ivf_parameter.cpp
@@ -51,6 +51,10 @@ IVFParameter::FromJson(const JsonType& json) {
         CHECK_ARGUMENT(this->precise_codes_param->quantizer_parameter->GetTypeName() !=
                            QUANTIZATION_TYPE_VALUE_PQFS,
                        "precise_codes_layout=bucket does not support pqfs precise quantization");
+        CHECK_ARGUMENT(
+            this->precise_codes_param->io_parameter == nullptr ||
+                this->precise_codes_param->io_parameter->GetTypeName() != IO_TYPE_VALUE_MMAP_IO,
+            "precise_codes_layout=bucket does not support mmap_io");
     }
 
     if (json.Contains(BUCKET_PER_DATA_KEY)) {
@@ -107,6 +111,17 @@ IVFParameter::FromJson(const JsonType& json) {
                 GraphStorageTypes::GRAPH_STORAGE_TYPE_VALUE_FLAT, graph_json);
         }
     }
+}
+
+bool
+IVFParameter::UsesDiskBackedPreciseBucket() const {
+    if (this->precise_codes_layout != PRECISE_CODES_LAYOUT_VALUE_BUCKET ||
+        this->precise_codes_param == nullptr ||
+        this->precise_codes_param->io_parameter == nullptr) {
+        return false;
+    }
+    const auto io_type = this->precise_codes_param->io_parameter->GetTypeName();
+    return io_type != IO_TYPE_VALUE_MEMORY_IO && io_type != IO_TYPE_VALUE_BLOCK_MEMORY_IO;
 }
 
 JsonType

--- a/src/algorithm/ivf/ivf_parameter.cpp
+++ b/src/algorithm/ivf/ivf_parameter.cpp
@@ -29,6 +29,30 @@ void
 IVFParameter::FromJson(const JsonType& json) {
     InnerIndexParameter::FromJson(json);
 
+    this->precise_codes_layout = PRECISE_CODES_LAYOUT_VALUE_FLAT;
+    if (json.Contains(PRECISE_CODES_LAYOUT_KEY)) {
+        this->precise_codes_layout = json[PRECISE_CODES_LAYOUT_KEY].GetString();
+    }
+    CHECK_ARGUMENT(
+        this->precise_codes_layout == PRECISE_CODES_LAYOUT_VALUE_FLAT ||
+            this->precise_codes_layout == PRECISE_CODES_LAYOUT_VALUE_BUCKET,
+        fmt::format("invalid precise_codes_layout: {}, supported values are \"{}\" and \"{}\"",
+                    this->precise_codes_layout,
+                    PRECISE_CODES_LAYOUT_VALUE_FLAT,
+                    PRECISE_CODES_LAYOUT_VALUE_BUCKET));
+
+    if (this->precise_codes_layout == PRECISE_CODES_LAYOUT_VALUE_BUCKET) {
+        CHECK_ARGUMENT(this->use_reorder, "precise_codes_layout=bucket requires use_reorder=true");
+        CHECK_ARGUMENT(this->reorder_source == HGRAPH_REORDER_SOURCE_PRECISE,
+                       "precise_codes_layout=bucket requires reorder_source=precise");
+        CHECK_ARGUMENT(this->precise_codes_param != nullptr &&
+                           this->precise_codes_param->name == FLATTEN_DATA_CELL,
+                       "precise_codes_layout=bucket requires ordinary flatten precise_codes");
+        CHECK_ARGUMENT(this->precise_codes_param->quantizer_parameter->GetTypeName() !=
+                           QUANTIZATION_TYPE_VALUE_PQFS,
+                       "precise_codes_layout=bucket does not support pqfs precise quantization");
+    }
+
     if (json.Contains(BUCKET_PER_DATA_KEY)) {
         this->buckets_per_data = static_cast<BucketIdType>(json[BUCKET_PER_DATA_KEY].GetInt());
     }
@@ -92,6 +116,7 @@ IVFParameter::ToJson() const {
     json[BUCKET_PARAMS_KEY].SetJson(this->bucket_param->ToJson());
     json[IVF_PARTITION_STRATEGY_PARAMS_KEY].SetJson(
         this->ivf_partition_strategy_parameter->ToJson());
+    json[PRECISE_CODES_LAYOUT_KEY].SetString(this->precise_codes_layout);
     json[BUCKET_PER_DATA_KEY].SetInt(this->buckets_per_data);
     json[GRAPH_BUILD_THRESHOLD_KEY].SetInt(this->graph_build_threshold);
     return json;
@@ -102,6 +127,7 @@ IVFParameter::CheckCompatibility(const ParamPtr& other) const {
         return false;
     }
     PARAM_CAST_OR_RETURN(IVFParameter, p, other);
+    CHECK_FIELD_EQ(*this, *p, precise_codes_layout);
     CHECK_FIELD_EQ(*this, *p, buckets_per_data);
     CHECK_FIELD_EQ(*this, *p, graph_build_threshold);
     CHECK_SUB_PARAM(*this, *p, bucket_param);

--- a/src/algorithm/ivf/ivf_parameter.cpp
+++ b/src/algorithm/ivf/ivf_parameter.cpp
@@ -69,6 +69,9 @@ IVFParameter::FromJson(const JsonType& json) {
                    fmt::format("ivf parameters must contains {}", BUCKET_PARAMS_KEY));
 
     this->bucket_param->FromJson(json[BUCKET_PARAMS_KEY]);
+    CHECK_ARGUMENT(this->bucket_param->io_parameter == nullptr ||
+                       this->bucket_param->io_parameter->GetTypeName() != IO_TYPE_VALUE_READER_IO,
+                   "IVF base codes do not support reader_io");
 
     this->ivf_partition_strategy_parameter = std::make_shared<IVFPartitionStrategyParameters>();
     if (json.Contains(IVF_PARTITION_STRATEGY_PARAMS_KEY)) {

--- a/src/algorithm/ivf/ivf_parameter.cpp
+++ b/src/algorithm/ivf/ivf_parameter.cpp
@@ -115,17 +115,6 @@ IVFParameter::FromJson(const JsonType& json) {
     }
 }
 
-bool
-IVFParameter::UsesDiskBackedPreciseBucket() const {
-    if (this->precise_codes_layout != PRECISE_CODES_LAYOUT_VALUE_BUCKET ||
-        this->precise_codes_param == nullptr ||
-        this->precise_codes_param->io_parameter == nullptr) {
-        return false;
-    }
-    const auto io_type = this->precise_codes_param->io_parameter->GetTypeName();
-    return io_type != IO_TYPE_VALUE_MEMORY_IO && io_type != IO_TYPE_VALUE_BLOCK_MEMORY_IO;
-}
-
 JsonType
 IVFParameter::ToJson() const {
     JsonType json = InnerIndexParameter::ToJson();

--- a/src/algorithm/ivf/ivf_parameter.h
+++ b/src/algorithm/ivf/ivf_parameter.h
@@ -43,6 +43,9 @@ public:
     bool
     CheckCompatibility(const vsag::ParamPtr& other) const override;
 
+    [[nodiscard]] bool
+    UsesDiskBackedPreciseBucket() const;
+
 public:
     BucketDataCellParamPtr bucket_param{nullptr};
     IVFPartitionStrategyParametersPtr ivf_partition_strategy_parameter{nullptr};

--- a/src/algorithm/ivf/ivf_parameter.h
+++ b/src/algorithm/ivf/ivf_parameter.h
@@ -46,6 +46,7 @@ public:
 public:
     BucketDataCellParamPtr bucket_param{nullptr};
     IVFPartitionStrategyParametersPtr ivf_partition_strategy_parameter{nullptr};
+    std::string precise_codes_layout{PRECISE_CODES_LAYOUT_VALUE_FLAT};
     BucketIdType buckets_per_data{1};
     int64_t train_sample_count{65536L};
     GraphInterfaceParamPtr graph_param{nullptr};

--- a/src/algorithm/ivf/ivf_parameter.h
+++ b/src/algorithm/ivf/ivf_parameter.h
@@ -46,6 +46,7 @@ public:
 public:
     BucketDataCellParamPtr bucket_param{nullptr};
     IVFPartitionStrategyParametersPtr ivf_partition_strategy_parameter{nullptr};
+    std::string precise_codes_layout{PRECISE_CODES_LAYOUT_VALUE_FLAT};
     BucketIdType buckets_per_data{1};
     GraphInterfaceParamPtr graph_param{nullptr};
     int64_t graph_build_threshold{0};

--- a/src/algorithm/ivf/ivf_parameter.h
+++ b/src/algorithm/ivf/ivf_parameter.h
@@ -43,9 +43,6 @@ public:
     bool
     CheckCompatibility(const vsag::ParamPtr& other) const override;
 
-    [[nodiscard]] bool
-    UsesDiskBackedPreciseBucket() const;
-
 public:
     BucketDataCellParamPtr bucket_param{nullptr};
     IVFPartitionStrategyParametersPtr ivf_partition_strategy_parameter{nullptr};

--- a/src/algorithm/ivf/ivf_parameter_test.cpp
+++ b/src/algorithm/ivf/ivf_parameter_test.cpp
@@ -32,6 +32,7 @@ struct IVFDefaultParam {
     bool use_reorder = true;
     std::string precise_codes_io_type = "block_memory_io";
     std::string precise_codes_quantization_type = "fp32";
+    std::string precise_codes_layout = "flat";
     std::string partition_strategy_type = "ivf";
     std::string ivf_train_type = "kmeans";
     int buckets_per_data = 1;
@@ -54,6 +55,7 @@ generate_ivf_param(const IVFDefaultParam& param) {
             "use_residual": {}
         }},
         "use_reorder": {},
+        "precise_codes_layout": "{}",
         "partition_strategy": {{
             "partition_strategy_type": "{}",
             "ivf_train_type": "{}",
@@ -79,6 +81,7 @@ generate_ivf_param(const IVFDefaultParam& param) {
                        param.buckets_count,
                        param.use_residual,
                        param.use_reorder,
+                       param.precise_codes_layout,
                        param.partition_strategy_type,
                        param.ivf_train_type,
                        param.precise_codes_io_type,
@@ -103,6 +106,7 @@ TEST_CASE("IVF Parameters Test", "[ut][IVFParameter]") {
     REQUIRE(param->use_reorder == true);
     REQUIRE(param->build_thread_count == 3);
     REQUIRE(param->precise_codes_param->quantizer_parameter->GetTypeName() == "fp32");
+    REQUIRE(param->precise_codes_layout == "flat");
     REQUIRE(param->train_sample_count == 65536L);
 
     index_param.ivf_train_type = "random";
@@ -145,6 +149,83 @@ TEST_CASE("IVF Parameters Test", "[ut][IVFParameter]") {
     search_param = vsag::IVFSearchParameters::FromJson(param_str);
     REQUIRE(search_param.scan_buckets_count == 20);
     REQUIRE(search_param.first_order_scan_ratio == 0.1f);
+}
+
+TEST_CASE("IVF precise codes layout parameter", "[ut][IVFParameter]") {
+    SECTION("missing layout defaults to flat") {
+        IVFDefaultParam index_param;
+        auto param_json = vsag::JsonType::Parse(generate_ivf_param(index_param));
+        param_json.Erase(vsag::PRECISE_CODES_LAYOUT_KEY);
+
+        auto param = std::make_shared<vsag::IVFParameter>();
+        param->FromJson(param_json);
+
+        REQUIRE(param->precise_codes_layout == vsag::PRECISE_CODES_LAYOUT_VALUE_FLAT);
+        REQUIRE(param->ToJson()[vsag::PRECISE_CODES_LAYOUT_KEY].GetString() ==
+                vsag::PRECISE_CODES_LAYOUT_VALUE_FLAT);
+    }
+
+    SECTION("bucket layout supports multiple postings per data") {
+        IVFDefaultParam index_param;
+        index_param.precise_codes_layout = "bucket";
+        index_param.buckets_per_data = 3;
+
+        auto param = std::make_shared<vsag::IVFParameter>();
+        param->FromString(generate_ivf_param(index_param));
+
+        REQUIRE(param->precise_codes_layout == vsag::PRECISE_CODES_LAYOUT_VALUE_BUCKET);
+        REQUIRE(param->buckets_per_data == 3);
+        vsag::ParameterTest::TestToJson(param);
+    }
+
+    SECTION("reject invalid layout") {
+        IVFDefaultParam index_param;
+        index_param.precise_codes_layout = "invalid";
+        auto param = std::make_shared<vsag::IVFParameter>();
+        REQUIRE_THROWS(param->FromString(generate_ivf_param(index_param)));
+    }
+
+    SECTION("bucket layout requires reorder") {
+        IVFDefaultParam index_param;
+        index_param.precise_codes_layout = "bucket";
+        index_param.use_reorder = false;
+        auto param = std::make_shared<vsag::IVFParameter>();
+        REQUIRE_THROWS(param->FromString(generate_ivf_param(index_param)));
+    }
+
+    SECTION("bucket layout requires precise reorder source") {
+        IVFDefaultParam index_param;
+        index_param.precise_codes_layout = "bucket";
+        auto param_json = vsag::JsonType::Parse(generate_ivf_param(index_param));
+        param_json[vsag::REORDER_SOURCE_KEY].SetString(vsag::HGRAPH_REORDER_SOURCE_BASE);
+
+        auto param = std::make_shared<vsag::IVFParameter>();
+        REQUIRE_THROWS(param->FromJson(param_json));
+    }
+
+    SECTION("bucket layout requires ordinary flatten precise codes") {
+        IVFDefaultParam index_param;
+        index_param.precise_codes_layout = "bucket";
+        auto param_json = vsag::JsonType::Parse(generate_ivf_param(index_param));
+        param_json[vsag::PRECISE_CODES_KEY][vsag::CODES_TYPE_KEY].SetString(
+            vsag::RABITQ_SPLIT_CODES);
+        param_json[vsag::PRECISE_CODES_KEY][vsag::QUANTIZATION_PARAMS_KEY][vsag::TYPE_KEY]
+            .SetString(vsag::QUANTIZATION_TYPE_VALUE_RABITQ);
+
+        auto param = std::make_shared<vsag::IVFParameter>();
+        REQUIRE_THROWS(param->FromJson(param_json));
+    }
+
+    SECTION("bucket layout rejects pqfs") {
+        IVFDefaultParam index_param;
+        index_param.precise_codes_layout = "bucket";
+        auto param_json = vsag::JsonType::Parse(generate_ivf_param(index_param));
+        param_json[vsag::PRECISE_CODES_KEY][vsag::QUANTIZATION_PARAMS_KEY][vsag::TYPE_KEY]
+            .SetString(vsag::QUANTIZATION_TYPE_VALUE_PQFS);
+
+        auto param = std::make_shared<vsag::IVFParameter>();
+        REQUIRE_THROWS(param->FromJson(param_json));
+    }
 }
 
 TEST_CASE("IVF maps RabitQ external parameters", "[ut][IVFParameter]") {
@@ -207,6 +288,20 @@ TEST_CASE("IVF Parameters CheckCompatibility", "[ut][IVFParameter][CheckCompatib
         REQUIRE_FALSE(param->CheckCompatibility(std::make_shared<vsag::EmptyParameter>()));
     }
 
+    SECTION("missing layout is compatible with explicit flat layout") {
+        IVFDefaultParam index_param;
+        auto legacy_json = vsag::JsonType::Parse(generate_ivf_param(index_param));
+        legacy_json.Erase(vsag::PRECISE_CODES_LAYOUT_KEY);
+
+        auto legacy_param = std::make_shared<vsag::IVFParameter>();
+        legacy_param->FromJson(legacy_json);
+        auto explicit_flat_param = std::make_shared<vsag::IVFParameter>();
+        explicit_flat_param->FromString(generate_ivf_param(index_param));
+
+        REQUIRE(legacy_param->CheckCompatibility(explicit_flat_param));
+        REQUIRE(explicit_flat_param->CheckCompatibility(legacy_param));
+    }
+
     TEST_COMPATIBILITY_CASE("ivf buckets_count", buckets_count, 3, 4, false);
     TEST_COMPATIBILITY_CASE(
         "ivf bucket io type", buckect_io_type, "block_memory_io", "memory_io", true);
@@ -224,6 +319,8 @@ TEST_CASE("IVF Parameters CheckCompatibility", "[ut][IVFParameter][CheckCompatib
     TEST_COMPATIBILITY_CASE(
         "ivf partition_strategy_type", partition_strategy_type, "ivf", "gno_imi", false);
     TEST_COMPATIBILITY_CASE("ivf ivf_train_type", ivf_train_type, "kmeans", "random", true);
+    TEST_COMPATIBILITY_CASE(
+        "ivf precise_codes_layout", precise_codes_layout, "flat", "bucket", false);
     TEST_COMPATIBILITY_CASE("ivf buckets_per_data", buckets_per_data, 3, 2, false);
     TEST_COMPATIBILITY_CASE("ivf use_attribute_filter", use_attribute_filter, true, false, false);
 }

--- a/src/algorithm/ivf/ivf_parameter_test.cpp
+++ b/src/algorithm/ivf/ivf_parameter_test.cpp
@@ -23,6 +23,7 @@
 #include "quantization/rabitq_quantization/rabitq_quantizer_parameter.h"
 #include "unittest.h"
 #include "utils/util_functions.h"
+#include "vsag_exception.h"
 
 struct IVFDefaultParam {
     std::string buckect_io_type = "block_memory_io";
@@ -225,6 +226,23 @@ TEST_CASE("IVF precise codes layout parameter", "[ut][IVFParameter]") {
 
         auto param = std::make_shared<vsag::IVFParameter>();
         REQUIRE_THROWS(param->FromJson(param_json));
+    }
+
+    SECTION("bucket layout rejects mmap io") {
+        IVFDefaultParam index_param;
+        index_param.precise_codes_layout = "bucket";
+        index_param.precise_codes_io_type = "mmap_io";
+        auto param_json = vsag::JsonType::Parse(generate_ivf_param(index_param));
+        param_json[vsag::PRECISE_CODES_KEY][vsag::IO_PARAMS_KEY][vsag::IO_FILE_PATH_KEY].SetString(
+            "ivf_precise_mmap_test");
+
+        auto param = std::make_shared<vsag::IVFParameter>();
+        try {
+            param->FromJson(param_json);
+            FAIL("mmap_io should be rejected for bucket-aligned precise codes");
+        } catch (const vsag::VsagException& error) {
+            REQUIRE(error.error_.type == vsag::ErrorType::INVALID_ARGUMENT);
+        }
     }
 }
 

--- a/src/algorithm/ivf/ivf_parameter_test.cpp
+++ b/src/algorithm/ivf/ivf_parameter_test.cpp
@@ -166,17 +166,32 @@ TEST_CASE("IVF precise codes layout parameter", "[ut][IVFParameter]") {
                 vsag::PRECISE_CODES_LAYOUT_VALUE_FLAT);
     }
 
-    SECTION("bucket layout supports multiple postings per data") {
+    SECTION("bucket layout supports one posting per data") {
         IVFDefaultParam index_param;
         index_param.precise_codes_layout = "bucket";
-        index_param.buckets_per_data = 3;
 
         auto param = std::make_shared<vsag::IVFParameter>();
         param->FromString(generate_ivf_param(index_param));
 
         REQUIRE(param->precise_codes_layout == vsag::PRECISE_CODES_LAYOUT_VALUE_BUCKET);
-        REQUIRE(param->buckets_per_data == 3);
+        REQUIRE(param->buckets_per_data == 1);
         vsag::ParameterTest::TestToJson(param);
+    }
+
+    SECTION("bucket layout rejects multiple postings per data") {
+        IVFDefaultParam index_param;
+        index_param.precise_codes_layout = "bucket";
+        index_param.buckets_per_data = 2;
+
+        auto param = std::make_shared<vsag::IVFParameter>();
+        try {
+            param->FromString(generate_ivf_param(index_param));
+            FAIL("multiple postings should be rejected for bucket-aligned precise codes");
+        } catch (const vsag::VsagException& error) {
+            REQUIRE(error.error_.type == vsag::ErrorType::INVALID_ARGUMENT);
+            REQUIRE(error.error_.message ==
+                    "precise_codes_layout=bucket requires buckets_per_data=1");
+        }
     }
 
     SECTION("reject invalid layout") {

--- a/src/algorithm/ivf/ivf_parameter_test.cpp
+++ b/src/algorithm/ivf/ivf_parameter_test.cpp
@@ -174,17 +174,32 @@ TEST_CASE("IVF precise codes layout parameter", "[ut][IVFParameter]") {
                 vsag::PRECISE_CODES_LAYOUT_VALUE_FLAT);
     }
 
-    SECTION("bucket layout supports multiple postings per data") {
+    SECTION("bucket layout supports one posting per data") {
         IVFDefaultParam index_param;
         index_param.precise_codes_layout = "bucket";
-        index_param.buckets_per_data = 3;
 
         auto param = std::make_shared<vsag::IVFParameter>();
         param->FromString(generate_ivf_param(index_param));
 
         REQUIRE(param->precise_codes_layout == vsag::PRECISE_CODES_LAYOUT_VALUE_BUCKET);
-        REQUIRE(param->buckets_per_data == 3);
+        REQUIRE(param->buckets_per_data == 1);
         vsag::ParameterTest::TestToJson(param);
+    }
+
+    SECTION("bucket layout rejects multiple postings per data") {
+        IVFDefaultParam index_param;
+        index_param.precise_codes_layout = "bucket";
+        index_param.buckets_per_data = 2;
+
+        auto param = std::make_shared<vsag::IVFParameter>();
+        try {
+            param->FromString(generate_ivf_param(index_param));
+            FAIL("multiple postings should be rejected for bucket-aligned precise codes");
+        } catch (const vsag::VsagException& error) {
+            REQUIRE(error.error_.type == vsag::ErrorType::INVALID_ARGUMENT);
+            REQUIRE(error.error_.message ==
+                    "precise_codes_layout=bucket requires buckets_per_data=1");
+        }
     }
 
     SECTION("reject invalid layout") {

--- a/src/algorithm/ivf/ivf_parameter_test.cpp
+++ b/src/algorithm/ivf/ivf_parameter_test.cpp
@@ -32,6 +32,7 @@ struct IVFDefaultParam {
     bool use_reorder = true;
     std::string precise_codes_io_type = "block_memory_io";
     std::string precise_codes_quantization_type = "fp32";
+    std::string precise_codes_layout = "flat";
     std::string partition_strategy_type = "ivf";
     std::string ivf_train_type = "kmeans";
     int buckets_per_data = 1;
@@ -54,6 +55,7 @@ generate_ivf_param(const IVFDefaultParam& param) {
             "use_residual": {}
         }},
         "use_reorder": {},
+        "precise_codes_layout": "{}",
         "partition_strategy": {{
             "partition_strategy_type": "{}",
             "ivf_train_type": "{}",
@@ -79,6 +81,7 @@ generate_ivf_param(const IVFDefaultParam& param) {
                        param.buckets_count,
                        param.use_residual,
                        param.use_reorder,
+                       param.precise_codes_layout,
                        param.partition_strategy_type,
                        param.ivf_train_type,
                        param.precise_codes_io_type,
@@ -103,6 +106,7 @@ TEST_CASE("IVF Parameters Test", "[ut][IVFParameter]") {
     REQUIRE(param->use_reorder == true);
     REQUIRE(param->build_thread_count == 3);
     REQUIRE(param->precise_codes_param->quantizer_parameter->GetTypeName() == "fp32");
+    REQUIRE(param->precise_codes_layout == "flat");
     REQUIRE(param->train_sample_count == 65536L);  // buckets_count=3, so max(65536, 3*64)=65536
 
     index_param.ivf_train_type = "random";
@@ -153,6 +157,83 @@ TEST_CASE("IVF Parameters Test", "[ut][IVFParameter]") {
     search_param = vsag::IVFSearchParameters::FromJson(param_str);
     REQUIRE(search_param.scan_buckets_count == 20);
     REQUIRE(search_param.first_order_scan_ratio == 0.1f);
+}
+
+TEST_CASE("IVF precise codes layout parameter", "[ut][IVFParameter]") {
+    SECTION("missing layout defaults to flat") {
+        IVFDefaultParam index_param;
+        auto param_json = vsag::JsonType::Parse(generate_ivf_param(index_param));
+        param_json.Erase(vsag::PRECISE_CODES_LAYOUT_KEY);
+
+        auto param = std::make_shared<vsag::IVFParameter>();
+        param->FromJson(param_json);
+
+        REQUIRE(param->precise_codes_layout == vsag::PRECISE_CODES_LAYOUT_VALUE_FLAT);
+        REQUIRE(param->ToJson()[vsag::PRECISE_CODES_LAYOUT_KEY].GetString() ==
+                vsag::PRECISE_CODES_LAYOUT_VALUE_FLAT);
+    }
+
+    SECTION("bucket layout supports multiple postings per data") {
+        IVFDefaultParam index_param;
+        index_param.precise_codes_layout = "bucket";
+        index_param.buckets_per_data = 3;
+
+        auto param = std::make_shared<vsag::IVFParameter>();
+        param->FromString(generate_ivf_param(index_param));
+
+        REQUIRE(param->precise_codes_layout == vsag::PRECISE_CODES_LAYOUT_VALUE_BUCKET);
+        REQUIRE(param->buckets_per_data == 3);
+        vsag::ParameterTest::TestToJson(param);
+    }
+
+    SECTION("reject invalid layout") {
+        IVFDefaultParam index_param;
+        index_param.precise_codes_layout = "invalid";
+        auto param = std::make_shared<vsag::IVFParameter>();
+        REQUIRE_THROWS(param->FromString(generate_ivf_param(index_param)));
+    }
+
+    SECTION("bucket layout requires reorder") {
+        IVFDefaultParam index_param;
+        index_param.precise_codes_layout = "bucket";
+        index_param.use_reorder = false;
+        auto param = std::make_shared<vsag::IVFParameter>();
+        REQUIRE_THROWS(param->FromString(generate_ivf_param(index_param)));
+    }
+
+    SECTION("bucket layout requires precise reorder source") {
+        IVFDefaultParam index_param;
+        index_param.precise_codes_layout = "bucket";
+        auto param_json = vsag::JsonType::Parse(generate_ivf_param(index_param));
+        param_json[vsag::REORDER_SOURCE_KEY].SetString(vsag::HGRAPH_REORDER_SOURCE_BASE);
+
+        auto param = std::make_shared<vsag::IVFParameter>();
+        REQUIRE_THROWS(param->FromJson(param_json));
+    }
+
+    SECTION("bucket layout requires ordinary flatten precise codes") {
+        IVFDefaultParam index_param;
+        index_param.precise_codes_layout = "bucket";
+        auto param_json = vsag::JsonType::Parse(generate_ivf_param(index_param));
+        param_json[vsag::PRECISE_CODES_KEY][vsag::CODES_TYPE_KEY].SetString(
+            vsag::RABITQ_SPLIT_CODES);
+        param_json[vsag::PRECISE_CODES_KEY][vsag::QUANTIZATION_PARAMS_KEY][vsag::TYPE_KEY]
+            .SetString(vsag::QUANTIZATION_TYPE_VALUE_RABITQ);
+
+        auto param = std::make_shared<vsag::IVFParameter>();
+        REQUIRE_THROWS(param->FromJson(param_json));
+    }
+
+    SECTION("bucket layout rejects pqfs") {
+        IVFDefaultParam index_param;
+        index_param.precise_codes_layout = "bucket";
+        auto param_json = vsag::JsonType::Parse(generate_ivf_param(index_param));
+        param_json[vsag::PRECISE_CODES_KEY][vsag::QUANTIZATION_PARAMS_KEY][vsag::TYPE_KEY]
+            .SetString(vsag::QUANTIZATION_TYPE_VALUE_PQFS);
+
+        auto param = std::make_shared<vsag::IVFParameter>();
+        REQUIRE_THROWS(param->FromJson(param_json));
+    }
 }
 
 TEST_CASE("IVF maps RabitQ external parameters", "[ut][IVFParameter]") {
@@ -215,6 +296,20 @@ TEST_CASE("IVF Parameters CheckCompatibility", "[ut][IVFParameter][CheckCompatib
         REQUIRE_FALSE(param->CheckCompatibility(std::make_shared<vsag::EmptyParameter>()));
     }
 
+    SECTION("missing layout is compatible with explicit flat layout") {
+        IVFDefaultParam index_param;
+        auto legacy_json = vsag::JsonType::Parse(generate_ivf_param(index_param));
+        legacy_json.Erase(vsag::PRECISE_CODES_LAYOUT_KEY);
+
+        auto legacy_param = std::make_shared<vsag::IVFParameter>();
+        legacy_param->FromJson(legacy_json);
+        auto explicit_flat_param = std::make_shared<vsag::IVFParameter>();
+        explicit_flat_param->FromString(generate_ivf_param(index_param));
+
+        REQUIRE(legacy_param->CheckCompatibility(explicit_flat_param));
+        REQUIRE(explicit_flat_param->CheckCompatibility(legacy_param));
+    }
+
     TEST_COMPATIBILITY_CASE("ivf buckets_count", buckets_count, 3, 4, false);
     TEST_COMPATIBILITY_CASE(
         "ivf bucket io type", buckect_io_type, "block_memory_io", "memory_io", true);
@@ -232,6 +327,8 @@ TEST_CASE("IVF Parameters CheckCompatibility", "[ut][IVFParameter][CheckCompatib
     TEST_COMPATIBILITY_CASE(
         "ivf partition_strategy_type", partition_strategy_type, "ivf", "gno_imi", false);
     TEST_COMPATIBILITY_CASE("ivf ivf_train_type", ivf_train_type, "kmeans", "random", true);
+    TEST_COMPATIBILITY_CASE(
+        "ivf precise_codes_layout", precise_codes_layout, "flat", "bucket", false);
     TEST_COMPATIBILITY_CASE("ivf buckets_per_data", buckets_per_data, 3, 2, false);
     TEST_COMPATIBILITY_CASE("ivf use_attribute_filter", use_attribute_filter, true, false, false);
 }

--- a/src/algorithm/ivf/ivf_parameter_test.cpp
+++ b/src/algorithm/ivf/ivf_parameter_test.cpp
@@ -269,6 +269,22 @@ TEST_CASE("IVF precise codes layout parameter", "[ut][IVFParameter]") {
     }
 }
 
+TEST_CASE("IVF rejects reader IO for base codes", "[ut][IVFParameter]") {
+    IVFDefaultParam index_param;
+    auto param_json = vsag::JsonType::Parse(generate_ivf_param(index_param));
+    param_json[vsag::BUCKET_PARAMS_KEY][vsag::IO_PARAMS_KEY][vsag::TYPE_KEY].SetString(
+        vsag::IO_TYPE_VALUE_READER_IO);
+
+    auto param = std::make_shared<vsag::IVFParameter>();
+    try {
+        param->FromJson(param_json);
+        FAIL("reader_io should be rejected for IVF base codes");
+    } catch (const vsag::VsagException& error) {
+        REQUIRE(error.error_.type == vsag::ErrorType::INVALID_ARGUMENT);
+        REQUIRE(error.error_.message == "IVF base codes do not support reader_io");
+    }
+}
+
 TEST_CASE("IVF maps RabitQ external parameters", "[ut][IVFParameter]") {
     auto external_param = vsag::JsonType::Parse(R"({
         "base_quantization_type": "rabitq",

--- a/src/algorithm/ivf/ivf_parameter_test.cpp
+++ b/src/algorithm/ivf/ivf_parameter_test.cpp
@@ -23,6 +23,7 @@
 #include "quantization/rabitq_quantization/rabitq_quantizer_parameter.h"
 #include "unittest.h"
 #include "utils/util_functions.h"
+#include "vsag_exception.h"
 
 struct IVFDefaultParam {
     std::string buckect_io_type = "block_memory_io";
@@ -233,6 +234,23 @@ TEST_CASE("IVF precise codes layout parameter", "[ut][IVFParameter]") {
 
         auto param = std::make_shared<vsag::IVFParameter>();
         REQUIRE_THROWS(param->FromJson(param_json));
+    }
+
+    SECTION("bucket layout rejects mmap io") {
+        IVFDefaultParam index_param;
+        index_param.precise_codes_layout = "bucket";
+        index_param.precise_codes_io_type = "mmap_io";
+        auto param_json = vsag::JsonType::Parse(generate_ivf_param(index_param));
+        param_json[vsag::PRECISE_CODES_KEY][vsag::IO_PARAMS_KEY][vsag::IO_FILE_PATH_KEY].SetString(
+            "ivf_precise_mmap_test");
+
+        auto param = std::make_shared<vsag::IVFParameter>();
+        try {
+            param->FromJson(param_json);
+            FAIL("mmap_io should be rejected for bucket-aligned precise codes");
+        } catch (const vsag::VsagException& error) {
+            REQUIRE(error.error_.type == vsag::ErrorType::INVALID_ARGUMENT);
+        }
     }
 }
 

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -285,6 +285,9 @@ const char* const GNO_IMI_SECOND_ORDER_BUCKETS_COUNT = "second_order_buckets_cou
 const char* const IVF_PRECISE_QUANTIZATION_TYPE = "precise_quantization_type";
 const char* const IVF_PRECISE_IO_TYPE = "precise_io_type";
 const char* const IVF_PRECISE_FILE_PATH = "precise_file_path";
+const char* const IVF_PRECISE_CODES_LAYOUT = "precise_codes_layout";
+const char* const IVF_PRECISE_CODES_LAYOUT_FLAT = "flat";
+const char* const IVF_PRECISE_CODES_LAYOUT_BUCKET = "bucket";
 const char* const USE_ATTRIBUTE_FILTER = "use_attribute_filter";
 const char* const IVF_THREAD_COUNT = "thread_count";
 

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -256,6 +256,9 @@ const char* const GNO_IMI_SECOND_ORDER_BUCKETS_COUNT = "second_order_buckets_cou
 const char* const IVF_PRECISE_QUANTIZATION_TYPE = "precise_quantization_type";
 const char* const IVF_PRECISE_IO_TYPE = "precise_io_type";
 const char* const IVF_PRECISE_FILE_PATH = "precise_file_path";
+const char* const IVF_PRECISE_CODES_LAYOUT = "precise_codes_layout";
+const char* const IVF_PRECISE_CODES_LAYOUT_FLAT = "flat";
+const char* const IVF_PRECISE_CODES_LAYOUT_BUCKET = "bucket";
 const char* const USE_ATTRIBUTE_FILTER = "use_attribute_filter";
 const char* const IVF_THREAD_COUNT = "thread_count";
 

--- a/src/datacell/bucket_datacell.h
+++ b/src/datacell/bucket_datacell.h
@@ -27,6 +27,7 @@
 #include "quantization/product_quantization/pq_fastscan_quantizer.h"
 #include "simd/fp32_simd.h"
 #include "utils/byte_buffer.h"
+#include "utils/timer.h"
 
 namespace vsag {
 
@@ -65,6 +66,22 @@ public:
                  const InnerIdType& offset_id) override {
         auto comp = std::static_pointer_cast<Computer<QuantTmpl>>(computer);
         return this->query_one_by_id(comp, bucket_id, offset_id);
+    }
+
+    void
+    Query(float* result_dists,
+          const ComputerInterfacePtr& computer,
+          const BucketIdType* bucket_ids,
+          const InnerIdType* offset_ids,
+          InnerIdType id_count,
+          QueryContext* ctx = nullptr) override {
+        if (id_count > 0 and GetQuantizerName() == QUANTIZATION_TYPE_VALUE_PQFS) {
+            throw VsagException(ErrorType::INTERNAL_ERROR,
+                                "PQFastScan doesn't support ComputeDist, only support "
+                                "ComputeBatchDist");
+        }
+        auto comp = static_cast<Computer<QuantTmpl>*>(computer.get());
+        this->query(result_dists, comp, bucket_ids, offset_ids, id_count, ctx);
     }
 
     ComputerInterfacePtr
@@ -168,6 +185,14 @@ private:
     query_one_by_id(const std::shared_ptr<Computer<QuantTmpl>>& computer,
                     const BucketIdType& bucket_id,
                     const InnerIdType& offset_id);
+
+    inline void
+    query(float* result_dists,
+          Computer<QuantTmpl>* computer,
+          const BucketIdType* bucket_ids,
+          const InnerIdType* offset_ids,
+          InnerIdType id_count,
+          QueryContext* ctx);
 
     inline void
     encode_vector(const void* vector, BucketIdType bucket_id, ByteBuffer& codes, float& res_score);
@@ -277,6 +302,148 @@ BucketDataCell<QuantTmpl, IOTmpl>::query_one_by_id(
         ret -= ip_distance;
     }
     return ret;
+}
+
+template <typename QuantTmpl, typename IOTmpl>
+void
+BucketDataCell<QuantTmpl, IOTmpl>::query(float* result_dists,
+                                         Computer<QuantTmpl>* computer,
+                                         const BucketIdType* bucket_ids,
+                                         const InnerIdType* offset_ids,
+                                         InnerIdType id_count,
+                                         QueryContext* ctx) {
+    if (id_count == 0) {
+        return;
+    }
+
+    struct QueryRequest {
+        BucketIdType bucket_id;
+        InnerIdType offset_id;
+        InnerIdType result_index;
+    };
+
+    Allocator* search_alloc = select_query_allocator(ctx, allocator_);
+    Vector<QueryRequest> requests(search_alloc);
+    requests.reserve(id_count);
+    for (InnerIdType i = 0; i < id_count; ++i) {
+        check_valid_bucket_id(bucket_ids[i]);
+        requests.emplace_back(QueryRequest{bucket_ids[i], offset_ids[i], i});
+    }
+    std::sort(requests.begin(), requests.end(), [](const auto& lhs, const auto& rhs) {
+        if (lhs.bucket_id != rhs.bucket_id) {
+            return lhs.bucket_id < rhs.bucket_id;
+        }
+        if (lhs.offset_id != rhs.offset_id) {
+            return lhs.offset_id < rhs.offset_id;
+        }
+        return lhs.result_index < rhs.result_index;
+    });
+
+    uint64_t io_count = 0;
+    double io_cost_ms = 0.0F;
+    Vector<InnerIdType> unique_offsets(search_alloc);
+    Vector<uint64_t> read_sizes(search_alloc);
+    Vector<uint64_t> read_offsets(search_alloc);
+    unique_offsets.reserve(id_count);
+    read_sizes.reserve(id_count);
+    read_offsets.reserve(id_count);
+    ByteBuffer codes(static_cast<uint64_t>(id_count) * code_size_, search_alloc);
+    Vector<float> unique_dists(id_count, 0.0F, search_alloc);
+    uint64_t group_begin = 0;
+    while (group_begin < requests.size()) {
+        const auto bucket_id = requests[group_begin].bucket_id;
+        uint64_t group_end = group_begin + 1;
+        while (group_end < requests.size() and requests[group_end].bucket_id == bucket_id) {
+            ++group_end;
+        }
+
+        std::shared_lock lock(this->bucket_mutexes_[bucket_id]);
+        for (uint64_t i = group_begin; i < group_end; ++i) {
+            const auto offset_id = requests[i].offset_id;
+            if (offset_id >= this->bucket_sizes_[bucket_id]) {
+                throw VsagException(ErrorType::INVALID_ARGUMENT, "invalid offset id for bucket");
+            }
+            if (this->inner_ids_[bucket_id][offset_id] == EMPTY_INNER_ID) {
+                throw VsagException(
+                    ErrorType::INVALID_ARGUMENT,
+                    fmt::format("visited empty offset in bucket: bucket_id={}, offset_id={}",
+                                bucket_id,
+                                offset_id));
+            }
+        }
+
+        unique_offsets.clear();
+        for (uint64_t i = group_begin; i < group_end; ++i) {
+            const auto offset_id = requests[i].offset_id;
+            if (unique_offsets.empty() or unique_offsets.back() != offset_id) {
+                unique_offsets.emplace_back(offset_id);
+            }
+        }
+
+        read_sizes.clear();
+        read_offsets.clear();
+        for (const auto offset_id : unique_offsets) {
+            if (not read_offsets.empty() and
+                read_offsets.back() + read_sizes.back() ==
+                    static_cast<uint64_t>(offset_id) * code_size_ and
+                code_size_ <= static_cast<uint64_t>(std::numeric_limits<int32_t>::max()) and
+                read_sizes.back() <=
+                    static_cast<uint64_t>(std::numeric_limits<int32_t>::max()) - code_size_) {
+                read_sizes.back() += code_size_;
+            } else {
+                read_sizes.emplace_back(code_size_);
+                read_offsets.emplace_back(static_cast<uint64_t>(offset_id) * code_size_);
+            }
+        }
+
+        bool read_success = false;
+        double group_io_cost_ms = 0.0F;
+        {
+            Timer timer(group_io_cost_ms);
+            read_success = this->datas_[bucket_id].MultiRead(
+                codes.data, read_sizes.data(), read_offsets.data(), read_sizes.size());
+        }
+        if (not read_success) {
+            throw VsagException(ErrorType::READ_ERROR, "failed to batch read bucket data");
+        }
+        io_count += read_sizes.size();
+        io_cost_ms += group_io_cost_ms;
+
+        computer->ScanBatchDists(unique_offsets.size(), codes.data, unique_dists.data());
+        if (use_residual_) {
+            Vector<float> centroid(this->quantizer_->GetDim(), search_alloc);
+            strategy_->GetCentroid(bucket_id, centroid);
+            auto ip_distance = FP32ComputeIP(
+                computer->raw_query_.data(), centroid.data(), this->quantizer_->GetDim());
+            if (metric_ == MetricType::METRIC_TYPE_L2SQR) {
+                ip_distance *= 2;
+                for (uint64_t i = 0; i < unique_offsets.size(); ++i) {
+                    unique_dists[i] -= residual_bias_[bucket_id][unique_offsets[i]];
+                }
+            }
+            for (uint64_t i = 0; i < unique_offsets.size(); ++i) {
+                unique_dists[i] -= ip_distance;
+            }
+        }
+
+        uint64_t unique_index = 0;
+        for (uint64_t i = group_begin; i < group_end; ++i) {
+            if (i > group_begin and requests[i].offset_id != requests[i - 1].offset_id) {
+                ++unique_index;
+            }
+            result_dists[requests[i].result_index] = unique_dists[unique_index];
+        }
+        group_begin = group_end;
+    }
+
+    if constexpr (not IOTmpl::InMemory) {
+        if (ctx != nullptr and ctx->stats != nullptr) {
+            ctx->stats->io_cnt.fetch_add(static_cast<uint32_t>(io_count),
+                                         std::memory_order_relaxed);
+            ctx->stats->io_time_ms.fetch_add(static_cast<uint32_t>(io_cost_ms),
+                                             std::memory_order_relaxed);
+        }
+    }
 }
 
 template <typename QuantTmpl, typename IOTmpl>

--- a/src/datacell/bucket_datacell.h
+++ b/src/datacell/bucket_datacell.h
@@ -554,6 +554,25 @@ BucketDataCell<QuantTmpl, IOTmpl>::Deserialize(lvalue_or_rvalue<StreamReader> re
         }
     }
     StreamReader::ReadVector(reader, this->bucket_sizes_);
+    if (this->bucket_sizes_.size() != static_cast<uint64_t>(this->bucket_count_)) {
+        throw VsagException(ErrorType::INVALID_BINARY,
+                            "serialized bucket size vector does not match bucket count");
+    }
+    for (BucketIdType i = 0; i < this->bucket_count_; ++i) {
+        const auto bucket_size = static_cast<uint64_t>(this->bucket_sizes_[i]);
+        if (this->inner_ids_[i].size() < bucket_size) {
+            throw VsagException(
+                ErrorType::INVALID_BINARY,
+                fmt::format("serialized bucket {} inner id count is smaller than bucket size", i));
+        }
+        if (this->use_residual_ and this->metric_ == MetricType::METRIC_TYPE_L2SQR and
+            this->residual_bias_[i].size() < bucket_size) {
+            throw VsagException(
+                ErrorType::INVALID_BINARY,
+                fmt::format("serialized bucket {} residual bias count is smaller than bucket size",
+                            i));
+        }
+    }
 }
 
 template <typename QuantTmpl, typename IOTmpl>

--- a/src/datacell/bucket_datacell.h
+++ b/src/datacell/bucket_datacell.h
@@ -561,6 +561,25 @@ BucketDataCell<QuantTmpl, IOTmpl>::Deserialize(lvalue_or_rvalue<StreamReader> re
         }
     }
     StreamReader::ReadVector(reader, this->bucket_sizes_);
+    if (this->bucket_sizes_.size() != static_cast<uint64_t>(this->bucket_count_)) {
+        throw VsagException(ErrorType::INVALID_BINARY,
+                            "serialized bucket size vector does not match bucket count");
+    }
+    for (BucketIdType i = 0; i < this->bucket_count_; ++i) {
+        const auto bucket_size = static_cast<uint64_t>(this->bucket_sizes_[i]);
+        if (this->inner_ids_[i].size() < bucket_size) {
+            throw VsagException(
+                ErrorType::INVALID_BINARY,
+                fmt::format("serialized bucket {} inner id count is smaller than bucket size", i));
+        }
+        if (this->use_residual_ and this->metric_ == MetricType::METRIC_TYPE_L2SQR and
+            this->residual_bias_[i].size() < bucket_size) {
+            throw VsagException(
+                ErrorType::INVALID_BINARY,
+                fmt::format("serialized bucket {} residual bias count is smaller than bucket size",
+                            i));
+        }
+    }
 }
 
 template <typename QuantTmpl, typename IOTmpl>

--- a/src/datacell/bucket_datacell.h
+++ b/src/datacell/bucket_datacell.h
@@ -27,6 +27,7 @@
 #include "quantization/product_quantization/pq_fastscan_quantizer.h"
 #include "simd/fp32_simd.h"
 #include "utils/byte_buffer.h"
+#include "utils/timer.h"
 
 namespace vsag {
 
@@ -69,6 +70,22 @@ public:
 
     float
     ComputePairVectors(BucketIdType bucket_id, InnerIdType id1, InnerIdType id2) override;
+
+    void
+    Query(float* result_dists,
+          const ComputerInterfacePtr& computer,
+          const BucketIdType* bucket_ids,
+          const InnerIdType* offset_ids,
+          InnerIdType id_count,
+          QueryContext* ctx = nullptr) override {
+        if (id_count > 0 and GetQuantizerName() == QUANTIZATION_TYPE_VALUE_PQFS) {
+            throw VsagException(ErrorType::INTERNAL_ERROR,
+                                "PQFastScan doesn't support ComputeDist, only support "
+                                "ComputeBatchDist");
+        }
+        auto comp = static_cast<Computer<QuantTmpl>*>(computer.get());
+        this->query(result_dists, comp, bucket_ids, offset_ids, id_count, ctx);
+    }
 
     ComputerInterfacePtr
     FactoryComputer(const void* query) override;
@@ -171,6 +188,14 @@ private:
     query_one_by_id(const std::shared_ptr<Computer<QuantTmpl>>& computer,
                     const BucketIdType& bucket_id,
                     const InnerIdType& offset_id);
+
+    inline void
+    query(float* result_dists,
+          Computer<QuantTmpl>* computer,
+          const BucketIdType* bucket_ids,
+          const InnerIdType* offset_ids,
+          InnerIdType id_count,
+          QueryContext* ctx);
 
     inline void
     encode_vector(const void* vector, BucketIdType bucket_id, ByteBuffer& codes, float& res_score);
@@ -282,6 +307,148 @@ BucketDataCell<QuantTmpl, IOTmpl>::query_one_by_id(
         ret -= ip_distance;
     }
     return ret;
+}
+
+template <typename QuantTmpl, typename IOTmpl>
+void
+BucketDataCell<QuantTmpl, IOTmpl>::query(float* result_dists,
+                                         Computer<QuantTmpl>* computer,
+                                         const BucketIdType* bucket_ids,
+                                         const InnerIdType* offset_ids,
+                                         InnerIdType id_count,
+                                         QueryContext* ctx) {
+    if (id_count == 0) {
+        return;
+    }
+
+    struct QueryRequest {
+        BucketIdType bucket_id;
+        InnerIdType offset_id;
+        InnerIdType result_index;
+    };
+
+    Allocator* search_alloc = select_query_allocator(ctx, allocator_);
+    Vector<QueryRequest> requests(search_alloc);
+    requests.reserve(id_count);
+    for (InnerIdType i = 0; i < id_count; ++i) {
+        check_valid_bucket_id(bucket_ids[i]);
+        requests.emplace_back(QueryRequest{bucket_ids[i], offset_ids[i], i});
+    }
+    std::sort(requests.begin(), requests.end(), [](const auto& lhs, const auto& rhs) {
+        if (lhs.bucket_id != rhs.bucket_id) {
+            return lhs.bucket_id < rhs.bucket_id;
+        }
+        if (lhs.offset_id != rhs.offset_id) {
+            return lhs.offset_id < rhs.offset_id;
+        }
+        return lhs.result_index < rhs.result_index;
+    });
+
+    uint64_t io_count = 0;
+    double io_cost_ms = 0.0F;
+    Vector<InnerIdType> unique_offsets(search_alloc);
+    Vector<uint64_t> read_sizes(search_alloc);
+    Vector<uint64_t> read_offsets(search_alloc);
+    unique_offsets.reserve(id_count);
+    read_sizes.reserve(id_count);
+    read_offsets.reserve(id_count);
+    ByteBuffer codes(static_cast<uint64_t>(id_count) * code_size_, search_alloc);
+    Vector<float> unique_dists(id_count, 0.0F, search_alloc);
+    uint64_t group_begin = 0;
+    while (group_begin < requests.size()) {
+        const auto bucket_id = requests[group_begin].bucket_id;
+        uint64_t group_end = group_begin + 1;
+        while (group_end < requests.size() and requests[group_end].bucket_id == bucket_id) {
+            ++group_end;
+        }
+
+        std::shared_lock lock(this->bucket_mutexes_[bucket_id]);
+        for (uint64_t i = group_begin; i < group_end; ++i) {
+            const auto offset_id = requests[i].offset_id;
+            if (offset_id >= this->bucket_sizes_[bucket_id]) {
+                throw VsagException(ErrorType::INVALID_ARGUMENT, "invalid offset id for bucket");
+            }
+            if (this->inner_ids_[bucket_id][offset_id] == EMPTY_INNER_ID) {
+                throw VsagException(
+                    ErrorType::INVALID_ARGUMENT,
+                    fmt::format("visited empty offset in bucket: bucket_id={}, offset_id={}",
+                                bucket_id,
+                                offset_id));
+            }
+        }
+
+        unique_offsets.clear();
+        for (uint64_t i = group_begin; i < group_end; ++i) {
+            const auto offset_id = requests[i].offset_id;
+            if (unique_offsets.empty() or unique_offsets.back() != offset_id) {
+                unique_offsets.emplace_back(offset_id);
+            }
+        }
+
+        read_sizes.clear();
+        read_offsets.clear();
+        for (const auto offset_id : unique_offsets) {
+            if (not read_offsets.empty() and
+                read_offsets.back() + read_sizes.back() ==
+                    static_cast<uint64_t>(offset_id) * code_size_ and
+                code_size_ <= static_cast<uint64_t>(std::numeric_limits<int32_t>::max()) and
+                read_sizes.back() <=
+                    static_cast<uint64_t>(std::numeric_limits<int32_t>::max()) - code_size_) {
+                read_sizes.back() += code_size_;
+            } else {
+                read_sizes.emplace_back(code_size_);
+                read_offsets.emplace_back(static_cast<uint64_t>(offset_id) * code_size_);
+            }
+        }
+
+        bool read_success = false;
+        double group_io_cost_ms = 0.0F;
+        {
+            Timer timer(group_io_cost_ms);
+            read_success = this->datas_[bucket_id].MultiRead(
+                codes.data, read_sizes.data(), read_offsets.data(), read_sizes.size());
+        }
+        if (not read_success) {
+            throw VsagException(ErrorType::READ_ERROR, "failed to batch read bucket data");
+        }
+        io_count += read_sizes.size();
+        io_cost_ms += group_io_cost_ms;
+
+        computer->ScanBatchDists(unique_offsets.size(), codes.data, unique_dists.data());
+        if (use_residual_) {
+            Vector<float> centroid(this->quantizer_->GetDim(), search_alloc);
+            strategy_->GetCentroid(bucket_id, centroid);
+            auto ip_distance = FP32ComputeIP(
+                computer->raw_query_.data(), centroid.data(), this->quantizer_->GetDim());
+            if (metric_ == MetricType::METRIC_TYPE_L2SQR) {
+                ip_distance *= 2;
+                for (uint64_t i = 0; i < unique_offsets.size(); ++i) {
+                    unique_dists[i] -= residual_bias_[bucket_id][unique_offsets[i]];
+                }
+            }
+            for (uint64_t i = 0; i < unique_offsets.size(); ++i) {
+                unique_dists[i] -= ip_distance;
+            }
+        }
+
+        uint64_t unique_index = 0;
+        for (uint64_t i = group_begin; i < group_end; ++i) {
+            if (i > group_begin and requests[i].offset_id != requests[i - 1].offset_id) {
+                ++unique_index;
+            }
+            result_dists[requests[i].result_index] = unique_dists[unique_index];
+        }
+        group_begin = group_end;
+    }
+
+    if constexpr (not IOTmpl::InMemory) {
+        if (ctx != nullptr and ctx->stats != nullptr) {
+            ctx->stats->io_cnt.fetch_add(static_cast<uint32_t>(io_count),
+                                         std::memory_order_relaxed);
+            ctx->stats->io_time_ms.fetch_add(static_cast<uint32_t>(io_cost_ms),
+                                             std::memory_order_relaxed);
+        }
+    }
 }
 
 template <typename QuantTmpl, typename IOTmpl>

--- a/src/datacell/bucket_datacell.h
+++ b/src/datacell/bucket_datacell.h
@@ -24,6 +24,7 @@
 #include "impl/inner_search_param.h"
 #include "io/container/io_array.h"
 #include "io/read_cache/page.h"
+#include "io/reader_io/reader_io_parameter.h"
 #include "quantization/product_quantization/pq_fastscan_quantizer.h"
 #include "simd/fp32_simd.h"
 #include "utils/byte_buffer.h"
@@ -40,7 +41,13 @@ AdjustBucketReadCacheParam(const IOParamPtr& io_param, BucketIdType bucket_count
     uint64_t total_pages = io_param->read_cache_total_size_ / Page::DEFAULT_PAGE_SIZE;
     uint64_t pages_per_bucket = total_pages / bucket_count;
     json[READ_CACHE_TOTAL_CACHE_SIZE_KEY].SetUint64(pages_per_bucket * Page::DEFAULT_PAGE_SIZE);
-    return IOParameter::GetIOParameterByJson(json);
+    auto adjusted_io_param = IOParameter::GetIOParameterByJson(json);
+    auto source_reader_param = std::dynamic_pointer_cast<ReaderIOParameter>(io_param);
+    auto adjusted_reader_param = std::dynamic_pointer_cast<ReaderIOParameter>(adjusted_io_param);
+    if (source_reader_param != nullptr and adjusted_reader_param != nullptr) {
+        adjusted_reader_param->reader = source_reader_param->reader;
+    }
+    return adjusted_io_param;
 }
 
 template <typename QuantTmpl, typename IOTmpl>
@@ -97,6 +104,13 @@ public:
     InsertVector(const void* vector, BucketIdType bucket_id, InnerIdType inner_id) override;
 
     void
+    BatchInsertVector(const void* vectors,
+                      const BucketIdType* bucket_ids,
+                      const InnerIdType* inner_ids,
+                      InnerIdType count,
+                      InnerIdType* out_offsets) override;
+
+    void
     InsertVectorWithOffset(const void* vector,
                            BucketIdType bucket_id,
                            InnerIdType inner_id,
@@ -139,6 +153,14 @@ public:
 
     void
     Deserialize(lvalue_or_rvalue<StreamReader> reader) override;
+
+    void
+    InitIO(const IOParamPtr& io_param) override {
+        auto adjusted_io_param = AdjustBucketReadCacheParam(io_param, this->bucket_count_);
+        for (BucketIdType bucket_id = 0; bucket_id < this->bucket_count_; ++bucket_id) {
+            this->datas_[bucket_id].InitIO(adjusted_io_param);
+        }
+    }
 
     [[nodiscard]] std::string
     GetQuantizerName() override {
@@ -198,7 +220,7 @@ private:
           QueryContext* ctx);
 
     inline void
-    encode_vector(const void* vector, BucketIdType bucket_id, ByteBuffer& codes, float& res_score);
+    encode_vector(const void* vector, BucketIdType bucket_id, uint8_t* codes, float& res_score);
 
     inline void
     check_valid_bucket_capacity(uint64_t next_size, bool need_resize);
@@ -225,6 +247,8 @@ private:
     Vector<Vector<float>> residual_bias_;
 
     MetricType metric_{MetricType::METRIC_TYPE_L2SQR};
+
+    uint64_t input_dim_{0};
 
     static constexpr InnerIdType EMPTY_INNER_ID = std::numeric_limits<InnerIdType>::max();
 
@@ -254,7 +278,8 @@ BucketDataCell<QuantTmpl, IOTmpl>::BucketDataCell(const QuantizerParamPtr& quant
       bucket_mutexes_(bucket_count, common_param.allocator_.get()),
       allocator_(common_param.allocator_.get()),
       residual_bias_(bucket_count, Vector<float>(allocator_), allocator_),
-      metric_(common_param.metric_) {
+      metric_(common_param.metric_),
+      input_dim_(common_param.dim_) {
     this->bucket_count_ = bucket_count;
     this->quantizer_ = std::make_shared<QuantTmpl>(quantization_param, common_param);
     this->code_size_ = quantizer_->GetCodeSize();
@@ -550,25 +575,28 @@ template <typename QuantTmpl, typename IOTmpl>
 void
 BucketDataCell<QuantTmpl, IOTmpl>::encode_vector(const void* vector,
                                                  BucketIdType bucket_id,
-                                                 ByteBuffer& codes,
+                                                 uint8_t* codes,
                                                  float& res_score) {
+    auto vector_ptr = static_cast<const float*>(vector);
+    res_score = 0.0F;
+    if (not use_residual_) {
+        this->quantizer_->EncodeOne(vector_ptr, codes);
+        return;
+    }
+
     Vector<float> centroid(this->quantizer_->GetDim(), this->allocator_);
     Vector<float> sub_data(this->quantizer_->GetDim(), this->allocator_);
     Vector<float> normalize_data(this->quantizer_->GetDim(), this->allocator_);
-    res_score = 0.0F;
-    auto vector_ptr = static_cast<const float*>(vector);
-    if (use_residual_) {
-        strategy_->GetCentroid(bucket_id, centroid);
-        if (metric_ == MetricType::METRIC_TYPE_COSINE) {
-            Normalize(vector_ptr, normalize_data.data(), quantizer_->GetDim());
-            vector_ptr = normalize_data.data();
-        }
-        FP32Sub(vector_ptr, centroid.data(), sub_data.data(), quantizer_->GetDim());
-        vector_ptr = sub_data.data();
+    strategy_->GetCentroid(bucket_id, centroid);
+    if (metric_ == MetricType::METRIC_TYPE_COSINE) {
+        Normalize(vector_ptr, normalize_data.data(), quantizer_->GetDim());
+        vector_ptr = normalize_data.data();
     }
-    this->quantizer_->EncodeOne(static_cast<const float*>(vector_ptr), codes.data);
-    if (use_residual_ && metric_ == MetricType::METRIC_TYPE_L2SQR) {
-        this->quantizer_->DecodeOne(codes.data, normalize_data.data());
+    FP32Sub(vector_ptr, centroid.data(), sub_data.data(), quantizer_->GetDim());
+    vector_ptr = sub_data.data();
+    this->quantizer_->EncodeOne(vector_ptr, codes);
+    if (metric_ == MetricType::METRIC_TYPE_L2SQR) {
+        this->quantizer_->DecodeOne(codes, normalize_data.data());
         res_score =
             -2 * FP32ComputeIP(centroid.data(), normalize_data.data(), this->quantizer_->GetDim()) -
             FP32ComputeIP(centroid.data(), centroid.data(), this->quantizer_->GetDim());
@@ -603,7 +631,7 @@ BucketDataCell<QuantTmpl, IOTmpl>::InsertVector(const void* vector,
     InnerIdType offset_id;
     float res_score = 0.0F;
     ByteBuffer codes(static_cast<uint64_t>(code_size_), this->allocator_);
-    encode_vector(vector, bucket_id, codes, res_score);
+    encode_vector(vector, bucket_id, codes.data, res_score);
     {
         std::unique_lock lock(this->bucket_mutexes_[bucket_id]);
         offset_id = this->bucket_sizes_[bucket_id];
@@ -635,6 +663,121 @@ BucketDataCell<QuantTmpl, IOTmpl>::InsertVector(const void* vector,
 
 template <typename QuantTmpl, typename IOTmpl>
 void
+BucketDataCell<QuantTmpl, IOTmpl>::BatchInsertVector(const void* vectors,
+                                                     const BucketIdType* bucket_ids,
+                                                     const InnerIdType* inner_ids,
+                                                     InnerIdType count,
+                                                     InnerIdType* out_offsets) {
+    if (count == 0) {
+        return;
+    }
+    if (vectors == nullptr or bucket_ids == nullptr or inner_ids == nullptr or
+        out_offsets == nullptr) {
+        throw VsagException(ErrorType::INVALID_ARGUMENT,
+                            "batch bucket insert requires non-null inputs and output");
+    }
+    if (this->bucket_count_ <= 0 or input_dim_ == 0 or code_size_ == 0 or
+        (use_residual_ and strategy_ == nullptr)) {
+        throw VsagException(ErrorType::INVALID_ARGUMENT, "invalid batch bucket insert size");
+    }
+    const auto bucket_count = static_cast<uint64_t>(this->bucket_count_);
+    const auto batch_count = static_cast<uint64_t>(count);
+    const auto max_allocation_size = std::numeric_limits<size_t>::max();
+    if (bucket_count == std::numeric_limits<uint64_t>::max() or
+        bucket_count + 1 > max_allocation_size / sizeof(uint64_t) or
+        batch_count > max_allocation_size / sizeof(uint64_t) or
+        batch_count > max_allocation_size / sizeof(InnerIdType) or
+        batch_count > max_allocation_size / sizeof(float) / input_dim_) {
+        throw VsagException(ErrorType::INVALID_ARGUMENT, "invalid batch bucket insert size");
+    }
+
+    Vector<uint64_t> bucket_counts(bucket_count, 0, this->allocator_);
+    for (uint64_t i = 0; i < batch_count; ++i) {
+        check_valid_bucket_id(bucket_ids[i]);
+        if (inner_ids[i] == EMPTY_INNER_ID) {
+            throw VsagException(ErrorType::INVALID_ARGUMENT, "invalid inner id for bucket");
+        }
+        ++bucket_counts[bucket_ids[i]];
+    }
+
+    Vector<uint64_t> bucket_begins(bucket_count + 1, 0, this->allocator_);
+    for (uint64_t bucket_id = 0; bucket_id < bucket_count; ++bucket_id) {
+        bucket_begins[bucket_id + 1] = bucket_begins[bucket_id] + bucket_counts[bucket_id];
+    }
+    Vector<uint64_t> next_positions(
+        bucket_begins.begin(), bucket_begins.end() - 1, this->allocator_);
+    Vector<InnerIdType> order(batch_count, 0, this->allocator_);
+    for (uint64_t i = 0; i < batch_count; ++i) {
+        const auto position = next_positions[bucket_ids[i]]++;
+        order[position] = static_cast<InnerIdType>(i);
+    }
+
+    const auto* float_vectors = static_cast<const float*>(vectors);
+    for (uint64_t bucket_id = 0; bucket_id < bucket_count; ++bucket_id) {
+        const auto bucket_insert_count = bucket_counts[bucket_id];
+        if (bucket_insert_count == 0) {
+            continue;
+        }
+        if (bucket_insert_count > max_allocation_size / static_cast<uint64_t>(code_size_)) {
+            throw VsagException(ErrorType::INVALID_ARGUMENT, "invalid batch bucket insert size");
+        }
+
+        const auto group_begin = bucket_begins[bucket_id];
+        ByteBuffer codes(bucket_insert_count * static_cast<uint64_t>(code_size_), this->allocator_);
+        Vector<float> residual_scores(this->allocator_);
+        if (use_residual_ and metric_ == MetricType::METRIC_TYPE_L2SQR) {
+            residual_scores.resize(bucket_insert_count);
+        }
+        for (uint64_t local_index = 0; local_index < bucket_insert_count; ++local_index) {
+            const auto position = group_begin + local_index;
+            const auto input_index = order[position];
+            float residual_score = 0.0F;
+            encode_vector(float_vectors + input_index * input_dim_,
+                          static_cast<BucketIdType>(bucket_id),
+                          codes.data + local_index * static_cast<uint64_t>(code_size_),
+                          residual_score);
+            if (not residual_scores.empty()) {
+                residual_scores[local_index] = residual_score;
+            }
+        }
+
+        std::unique_lock lock(this->bucket_mutexes_[bucket_id]);
+        const auto append_begin = static_cast<uint64_t>(this->bucket_sizes_[bucket_id]);
+        if (bucket_insert_count >
+            static_cast<uint64_t>(std::numeric_limits<InnerIdType>::max()) - append_begin) {
+            throw VsagException(ErrorType::INVALID_ARGUMENT, "invalid offset id for bucket");
+        }
+        const auto next_size = append_begin + bucket_insert_count;
+        if (next_size > std::numeric_limits<uint64_t>::max() / static_cast<uint64_t>(code_size_)) {
+            throw VsagException(ErrorType::INVALID_ARGUMENT, "invalid offset id for bucket");
+        }
+        check_valid_bucket_capacity(next_size, this->inner_ids_[bucket_id].size() < next_size);
+        this->datas_[bucket_id].Write(codes.data,
+                                      bucket_insert_count * static_cast<uint64_t>(code_size_),
+                                      append_begin * static_cast<uint64_t>(code_size_));
+        if (this->inner_ids_[bucket_id].size() < next_size) {
+            this->inner_ids_[bucket_id].resize(next_size, EMPTY_INNER_ID);
+        }
+        if (not residual_scores.empty() and this->residual_bias_[bucket_id].size() < next_size) {
+            this->residual_bias_[bucket_id].resize(next_size, 0.0F);
+        }
+        for (uint64_t local_index = 0; local_index < bucket_insert_count; ++local_index) {
+            const auto position = group_begin + local_index;
+            const auto input_index = order[position];
+            const auto offset = append_begin + local_index;
+            this->inner_ids_[bucket_id][offset] = inner_ids[input_index];
+            if (not residual_scores.empty()) {
+                this->residual_bias_[bucket_id][offset] = residual_scores[local_index];
+            }
+            out_offsets[input_index] = static_cast<InnerIdType>(offset);
+        }
+        this->bucket_sizes_[bucket_id] =
+            static_cast<InnerIdType>(append_begin + bucket_insert_count);
+    }
+}
+
+template <typename QuantTmpl, typename IOTmpl>
+void
 BucketDataCell<QuantTmpl, IOTmpl>::InsertVectorWithOffset(const void* vector,
                                                           BucketIdType bucket_id,
                                                           InnerIdType inner_id,
@@ -656,7 +799,7 @@ BucketDataCell<QuantTmpl, IOTmpl>::InsertVectorWithOffset(const void* vector,
 
     float res_score = 0.0F;
     ByteBuffer codes(static_cast<uint64_t>(code_size_), this->allocator_);
-    encode_vector(vector, bucket_id, codes, res_score);
+    encode_vector(vector, bucket_id, codes.data, res_score);
     {
         std::unique_lock lock(this->bucket_mutexes_[bucket_id]);
         auto next_size = static_cast<uint64_t>(offset_id) + 1;

--- a/src/datacell/bucket_datacell.h
+++ b/src/datacell/bucket_datacell.h
@@ -23,6 +23,7 @@
 #include "bucket_interface.h"
 #include "impl/inner_search_param.h"
 #include "io/container/io_array.h"
+#include "io/read_cache/lru_page_cache.h"
 #include "io/read_cache/page.h"
 #include "io/reader_io/reader_io_parameter.h"
 #include "quantization/product_quantization/pq_fastscan_quantizer.h"
@@ -156,6 +157,10 @@ public:
 
     void
     InitIO(const IOParamPtr& io_param) override {
+        if constexpr (IOTmpl::SkipDeserialize) {
+            this->init_shared_read_cache_io(io_param);
+            return;
+        }
         auto adjusted_io_param = AdjustBucketReadCacheParam(io_param, this->bucket_count_);
         for (BucketIdType bucket_id = 0; bucket_id < this->bucket_count_; ++bucket_id) {
             this->datas_[bucket_id].InitIO(adjusted_io_param);
@@ -194,6 +199,48 @@ public:
     }
 
 private:
+    void
+    init_shared_read_cache_io(const IOParamPtr& io_param) {
+        for (BucketIdType bucket_id = 0; bucket_id < this->bucket_count_; ++bucket_id) {
+            this->datas_[bucket_id].SetReadCache(nullptr);
+        }
+        for (BucketIdType bucket_id = 0; bucket_id < this->bucket_count_; ++bucket_id) {
+            this->datas_[bucket_id].InitIO(io_param);
+        }
+
+        if (io_param == nullptr or not io_param->enable_read_cache_) {
+            return;
+        }
+        uint64_t cache_page_count = io_param->read_cache_total_size_ / Page::DEFAULT_PAGE_SIZE;
+        if (cache_page_count == 0) {
+            return;
+        }
+
+        uint64_t page_id_base = 0;
+        for (BucketIdType bucket_id = 0; bucket_id < this->bucket_count_; ++bucket_id) {
+            uint64_t bucket_page_count = get_page_count(this->datas_[bucket_id].size_);
+            if (bucket_page_count > UINT64_MAX - page_id_base) {
+                throw VsagException(ErrorType::INVALID_BINARY,
+                                    "bucket read cache page id overflow");
+            }
+            page_id_base += bucket_page_count;
+        }
+
+        auto shared_cache = std::make_shared<LRUPageCache>(cache_page_count);
+        page_id_base = 0;
+        for (BucketIdType bucket_id = 0; bucket_id < this->bucket_count_; ++bucket_id) {
+            uint64_t bucket_page_count = get_page_count(this->datas_[bucket_id].size_);
+            this->datas_[bucket_id].SetReadCache(shared_cache, page_id_base);
+            page_id_base += bucket_page_count;
+        }
+    }
+
+    static uint64_t
+    get_page_count(uint64_t data_size) {
+        return data_size / Page::DEFAULT_PAGE_SIZE +
+               static_cast<uint64_t>(data_size % Page::DEFAULT_PAGE_SIZE != 0);
+    }
+
     inline void
     check_valid_bucket_id(BucketIdType bucket_id) {
         if (bucket_id >= this->bucket_count_ or bucket_id < 0) {

--- a/src/datacell/bucket_datacell_test.cpp
+++ b/src/datacell/bucket_datacell_test.cpp
@@ -17,6 +17,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstring>
 #include <exception>
 #include <limits>
 #include <sstream>
@@ -198,6 +199,86 @@ TEST_CASE("BucketDataCell rejects invalid parameters", "[ut][BucketDataCell]") {
     IndexCommonParam common_param;
 
     REQUIRE(BucketInterface::MakeInstance(nullptr, common_param) == nullptr);
+}
+
+TEST_CASE("BucketDataCell rejects inconsistent serialized metadata", "[ut][BucketDataCell]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    constexpr int64_t dim = 4;
+    constexpr const char* param_str = R"(
+        {
+            "io_params": {
+                "type": "memory_io"
+            },
+            "quantization_params": {
+                "type": "fp32"
+            },
+            "buckets_count": 1
+        }
+        )";
+
+    auto make_bucket = [&]() {
+        auto param_json = JsonType::Parse(param_str);
+        auto param = std::make_shared<BucketDataCellParameter>();
+        param->FromJson(param_json);
+
+        IndexCommonParam common_param;
+        common_param.allocator_ = allocator;
+        common_param.dim_ = dim;
+        common_param.metric_ = MetricType::METRIC_TYPE_L2SQR;
+        return BucketInterface::MakeInstance(param, common_param);
+    };
+
+    auto bucket = make_bucket();
+    auto vectors = fixtures::generate_vectors(1, dim);
+    bucket->Train(vectors.data(), 1);
+    bucket->InsertVector(vectors.data(), 0, 0);
+
+    std::stringstream stream;
+    IOStreamWriter writer(stream);
+    bucket->Serialize(writer);
+    const auto serialized = stream.str();
+
+    SECTION("inner id vector is shorter than bucket size") {
+        auto malformed = serialized;
+        constexpr InnerIdType invalid_bucket_size = 2;
+        std::memcpy(malformed.data() + malformed.size() - sizeof(invalid_bucket_size),
+                    &invalid_bucket_size,
+                    sizeof(invalid_bucket_size));
+
+        std::stringstream malformed_stream(malformed);
+        IOStreamReader reader(malformed_stream);
+        auto restored = make_bucket();
+        try {
+            restored->Deserialize(reader);
+            FAIL("inconsistent inner id metadata should be rejected");
+        } catch (const VsagException& error) {
+            REQUIRE(error.error_.type == ErrorType::INVALID_BINARY);
+            REQUIRE(error.error_.message ==
+                    "serialized bucket 0 inner id count is smaller than bucket size");
+        }
+    }
+
+    SECTION("bucket size vector does not cover every bucket") {
+        auto malformed = serialized;
+        constexpr uint64_t invalid_bucket_size_count = 0;
+        const uint64_t count_offset =
+            static_cast<uint64_t>(malformed.size()) - sizeof(InnerIdType) - sizeof(uint64_t);
+        std::memcpy(malformed.data() + count_offset,
+                    &invalid_bucket_size_count,
+                    sizeof(invalid_bucket_size_count));
+
+        std::stringstream malformed_stream(malformed);
+        IOStreamReader reader(malformed_stream);
+        auto restored = make_bucket();
+        try {
+            restored->Deserialize(reader);
+            FAIL("inconsistent bucket size metadata should be rejected");
+        } catch (const VsagException& error) {
+            REQUIRE(error.error_.type == ErrorType::INVALID_BINARY);
+            REQUIRE(error.error_.message ==
+                    "serialized bucket size vector does not match bucket count");
+        }
+    }
 }
 
 TEST_CASE("BucketDataCell supports RabitQ", "[ut][BucketDataCell]") {

--- a/src/datacell/bucket_datacell_test.cpp
+++ b/src/datacell/bucket_datacell_test.cpp
@@ -33,6 +33,34 @@
 
 using namespace vsag;
 
+namespace {
+
+class FixedCentroidPartitionStrategy : public IVFPartitionStrategy {
+public:
+    FixedCentroidPartitionStrategy(const IndexCommonParam& common_param, BucketIdType bucket_count)
+        : IVFPartitionStrategy(common_param, bucket_count) {
+    }
+
+    void
+    Train(const DatasetPtr) override {
+        is_trained_ = true;
+    }
+
+    Vector<BucketIdType>
+    ClassifyDatas(const void*, int64_t count, BucketIdType, QueryContext*) const override {
+        return Vector<BucketIdType>(count, 0, allocator_);
+    }
+
+    void
+    GetCentroid(BucketIdType bucket_id, Vector<float>& centroid) override {
+        for (uint64_t i = 0; i < centroid.size(); ++i) {
+            centroid[i] = static_cast<float>((bucket_id + 1) * (i + 1)) * 0.01F;
+        }
+    }
+};
+
+}  // namespace
+
 namespace vsag {
 class BucketInterfaceTest {
 public:
@@ -277,6 +305,262 @@ TEST_CASE("BucketDataCell rejects inconsistent serialized metadata", "[ut][Bucke
             REQUIRE(error.error_.type == ErrorType::INVALID_BINARY);
             REQUIRE(error.error_.message ==
                     "serialized bucket size vector does not match bucket count");
+        }
+    }
+}
+
+TEST_CASE("BucketDataCell batch query", "[ut][BucketDataCell]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    auto query_allocator = SafeAllocator::FactoryDefaultAllocator();
+    constexpr int64_t dim = 8;
+    constexpr uint64_t bucket_count = 3;
+    constexpr uint64_t vectors_per_bucket = 4;
+    constexpr uint64_t base_count = bucket_count * vectors_per_bucket;
+    const auto io_type = GENERATE(std::string("memory_io"), std::string("buffer_io"));
+    auto vectors = fixtures::generate_vectors(base_count, dim);
+    auto queries = fixtures::generate_vectors(1, dim, 41);
+    fixtures::TempDir temp_dir("vsag_bucket_batch_query_test");
+
+    auto make_bucket = [&]() {
+        auto file_path = temp_dir.GenerateRandomFile(false);
+        auto param_json = JsonType::Parse(fmt::format(
+            R"({{
+                "io_params": {{
+                    "type": "{}",
+                    "file_path": "{}"
+                }},
+                "quantization_params": {{
+                    "type": "fp32"
+                }},
+                "buckets_count": {}
+            }})",
+            io_type,
+            file_path,
+            bucket_count));
+        auto param = std::make_shared<BucketDataCellParameter>();
+        param->FromJson(param_json);
+
+        IndexCommonParam common_param;
+        common_param.allocator_ = allocator;
+        common_param.dim_ = dim;
+        common_param.metric_ = MetricType::METRIC_TYPE_L2SQR;
+        auto bucket = BucketInterface::MakeInstance(param, common_param);
+        bucket->Train(vectors.data(), base_count);
+        return bucket;
+    };
+
+    auto bucket = make_bucket();
+    for (uint64_t bucket_id = 0; bucket_id < bucket_count; ++bucket_id) {
+        for (uint64_t offset_id = 0; offset_id < vectors_per_bucket; ++offset_id) {
+            auto inner_id = bucket_id * vectors_per_bucket + offset_id;
+            bucket->InsertVector(vectors.data() + inner_id * dim,
+                                 static_cast<BucketIdType>(bucket_id),
+                                 static_cast<InnerIdType>(inner_id));
+        }
+    }
+
+    std::vector<BucketIdType> bucket_ids{2, 0, 1, 0, 2, 1, 0};
+    std::vector<InnerIdType> offset_ids{3, 1, 2, 2, 3, 0, 1};
+    std::vector<float> expected(bucket_ids.size());
+    std::vector<float> actual(bucket_ids.size());
+    auto computer = bucket->FactoryComputer(queries.data());
+    for (uint64_t i = 0; i < bucket_ids.size(); ++i) {
+        expected[i] = bucket->QueryOneById(computer, bucket_ids[i], offset_ids[i]);
+    }
+
+    SearchStatistics stats;
+    QueryContext ctx{query_allocator.get(), &stats};
+    bucket->Query(actual.data(),
+                  computer,
+                  bucket_ids.data(),
+                  offset_ids.data(),
+                  static_cast<InnerIdType>(bucket_ids.size()),
+                  &ctx);
+    REQUIRE(actual == expected);
+    if (io_type == "buffer_io") {
+        // Four contiguous read ranges remain after sorting and de-duplicating the locations.
+        REQUIRE(stats.io_cnt.load(std::memory_order_relaxed) == 4);
+    }
+
+    REQUIRE_NOTHROW(bucket->Query(nullptr, ComputerInterfacePtr{}, nullptr, nullptr, 0, &ctx));
+
+    SECTION("invalid bucket is rejected") {
+        BucketIdType invalid_bucket_id = -1;
+        InnerIdType offset_id = 0;
+        float dist = 0.0F;
+        REQUIRE_THROWS(bucket->Query(&dist, computer, &invalid_bucket_id, &offset_id, 1));
+    }
+
+    SECTION("invalid offset is rejected") {
+        BucketIdType bucket_id = 0;
+        InnerIdType invalid_offset_id = 100;
+        float dist = 0.0F;
+        REQUIRE_THROWS(bucket->Query(&dist, computer, &bucket_id, &invalid_offset_id, 1));
+    }
+
+    SECTION("hole is rejected") {
+        auto sparse_bucket = make_bucket();
+        sparse_bucket->InsertVectorWithOffset(vectors.data() + 2 * dim, 0, 2, 2);
+        auto sparse_computer = sparse_bucket->FactoryComputer(queries.data());
+        BucketIdType bucket_id = 0;
+        InnerIdType hole_offset_id = 0;
+        float dist = 0.0F;
+        REQUIRE_THROWS(
+            sparse_bucket->Query(&dist, sparse_computer, &bucket_id, &hole_offset_id, 1));
+    }
+}
+
+TEST_CASE("BucketDataCell batch query preserves residual correction", "[ut][BucketDataCell]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    constexpr int64_t dim = 8;
+    constexpr uint64_t bucket_count = 2;
+    constexpr uint64_t base_count = 8;
+    auto vectors = fixtures::generate_vectors(base_count, dim);
+    auto queries = fixtures::generate_vectors(1, dim, 43);
+    MetricType metrics[] = {
+        MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_IP, MetricType::METRIC_TYPE_COSINE};
+
+    for (auto metric : metrics) {
+        auto param_json = JsonType::Parse(R"({
+            "io_params": {
+                "type": "memory_io"
+            },
+            "quantization_params": {
+                "type": "fp32"
+            },
+            "buckets_count": 2,
+            "use_residual": true
+        })");
+        auto param = std::make_shared<BucketDataCellParameter>();
+        param->FromJson(param_json);
+
+        IndexCommonParam common_param;
+        common_param.allocator_ = allocator;
+        common_param.dim_ = dim;
+        common_param.metric_ = metric;
+        auto bucket = BucketInterface::MakeInstance(param, common_param);
+        auto strategy =
+            std::make_shared<FixedCentroidPartitionStrategy>(common_param, bucket_count);
+        bucket->SetStrategy(strategy);
+        bucket->Train(vectors.data(), base_count);
+        for (uint64_t i = 0; i < base_count; ++i) {
+            bucket->InsertVector(vectors.data() + i * dim,
+                                 static_cast<BucketIdType>(i % bucket_count),
+                                 static_cast<InnerIdType>(i));
+        }
+
+        std::vector<BucketIdType> bucket_ids{1, 0, 1, 0, 1};
+        std::vector<InnerIdType> offset_ids{2, 3, 0, 1, 2};
+        std::vector<float> expected(bucket_ids.size());
+        std::vector<float> actual(bucket_ids.size());
+        auto computer = bucket->FactoryComputer(queries.data());
+        for (uint64_t i = 0; i < bucket_ids.size(); ++i) {
+            expected[i] = bucket->QueryOneById(computer, bucket_ids[i], offset_ids[i]);
+        }
+        bucket->Query(actual.data(),
+                      computer,
+                      bucket_ids.data(),
+                      offset_ids.data(),
+                      static_cast<InnerIdType>(bucket_ids.size()));
+        for (uint64_t i = 0; i < actual.size(); ++i) {
+            REQUIRE(std::abs(actual[i] - expected[i]) < 1e-5F);
+        }
+    }
+}
+
+TEST_CASE("BucketDataCell batch query handles all bucket quantizers", "[ut][BucketDataCell]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    constexpr int64_t dim = 64;
+    constexpr uint64_t train_count = 300;
+    constexpr uint64_t bucket_count = 2;
+    constexpr uint64_t vectors_per_bucket = 64;
+    auto vectors = fixtures::generate_vectors(train_count, dim);
+    auto queries = fixtures::generate_vectors(1, dim, 47);
+    fixtures::TempDir temp_dir("vsag_bucket_batch_quantizers_test");
+
+    const std::vector<std::pair<std::string, std::string>> quantizers = {
+        {"fp32", R"({"type": "fp32"})"},
+        {"sq8", R"({"type": "sq8"})"},
+        {"sq4", R"({"type": "sq4"})"},
+        {"sq4_uniform", R"({"type": "sq4_uniform"})"},
+        {"sq8_uniform", R"({"type": "sq8_uniform"})"},
+        {"bf16", R"({"type": "bf16"})"},
+        {"fp16", R"({"type": "fp16"})"},
+        {"pq", R"({"type": "pq", "pq_dim": 8, "pq_bits": 8})"},
+        {"pqfs", R"({"type": "pqfs", "pq_dim": 8})"},
+        {"rabitq",
+         R"({"type": "rabitq", "rabitq_bits_per_dim_query": 32, "rabitq_bits_per_dim_base": 1})"},
+    };
+
+    for (const auto& io_type : {std::string("memory_io"), std::string("buffer_io")}) {
+        for (const auto& [quantizer_name, quantizer_json] : quantizers) {
+            CAPTURE(io_type, quantizer_name);
+            JsonType param_json;
+            JsonType io_json;
+            io_json["type"].SetString(io_type);
+            io_json["file_path"].SetString(temp_dir.GenerateRandomFile(false));
+            param_json["io_params"].SetJson(io_json);
+            param_json["quantization_params"].SetJson(JsonType::Parse(quantizer_json));
+            param_json["buckets_count"].SetInt(bucket_count);
+            auto param = std::make_shared<BucketDataCellParameter>();
+            param->FromJson(param_json);
+
+            IndexCommonParam common_param;
+            common_param.allocator_ = allocator;
+            common_param.dim_ = dim;
+            common_param.metric_ = MetricType::METRIC_TYPE_L2SQR;
+            auto bucket = BucketInterface::MakeInstance(param, common_param);
+            bucket->Train(vectors.data(), train_count);
+            for (uint64_t bucket_id = 0; bucket_id < bucket_count; ++bucket_id) {
+                for (uint64_t offset_id = 0; offset_id < vectors_per_bucket; ++offset_id) {
+                    auto inner_id = bucket_id * vectors_per_bucket + offset_id;
+                    bucket->InsertVector(vectors.data() + inner_id * dim,
+                                         static_cast<BucketIdType>(bucket_id),
+                                         static_cast<InnerIdType>(inner_id));
+                }
+            }
+            // PQFS queries require its normal IVF package state; Package is a no-op for others.
+            bucket->Package();
+
+            auto computer = bucket->FactoryComputer(queries.data());
+            std::vector<BucketIdType> bucket_ids{1, 0, 1, 0, 1, 0};
+            std::vector<InnerIdType> offset_ids{33, 1, 2, 34, 33, 2};
+            std::vector<float> actual(bucket_ids.size());
+            if (quantizer_name == "pqfs") {
+                try {
+                    bucket->Query(actual.data(),
+                                  computer,
+                                  bucket_ids.data(),
+                                  offset_ids.data(),
+                                  static_cast<InnerIdType>(bucket_ids.size()));
+                    FAIL("PQFS batch point query should preserve QueryOneById rejection");
+                } catch (const VsagException& error) {
+                    REQUIRE(error.error_.type == ErrorType::INTERNAL_ERROR);
+                    REQUIRE(error.error_.message ==
+                            "PQFastScan doesn't support ComputeDist, only support "
+                            "ComputeBatchDist");
+                }
+                continue;
+            }
+
+            std::vector<float> expected(bucket_ids.size());
+            for (uint64_t i = 0; i < expected.size(); ++i) {
+                expected[i] = bucket->QueryOneById(computer, bucket_ids[i], offset_ids[i]);
+            }
+            SearchStatistics stats;
+            QueryContext ctx{nullptr, &stats};
+            bucket->Query(actual.data(),
+                          computer,
+                          bucket_ids.data(),
+                          offset_ids.data(),
+                          static_cast<InnerIdType>(bucket_ids.size()),
+                          &ctx);
+            for (uint64_t i = 0; i < actual.size(); ++i) {
+                REQUIRE(std::abs(actual[i] - expected[i]) < 1e-5F);
+            }
+            if (io_type == "buffer_io") {
+                REQUIRE(stats.io_cnt.load(std::memory_order_relaxed) == 4);
+            }
         }
     }
 }

--- a/src/datacell/bucket_datacell_test.cpp
+++ b/src/datacell/bucket_datacell_test.cpp
@@ -33,6 +33,34 @@
 
 using namespace vsag;
 
+namespace {
+
+class FixedCentroidPartitionStrategy : public IVFPartitionStrategy {
+public:
+    FixedCentroidPartitionStrategy(const IndexCommonParam& common_param, BucketIdType bucket_count)
+        : IVFPartitionStrategy(common_param, bucket_count) {
+    }
+
+    void
+    Train(const DatasetPtr) override {
+        is_trained_ = true;
+    }
+
+    Vector<BucketIdType>
+    ClassifyDatas(const void*, int64_t count, BucketIdType, QueryContext*) const override {
+        return Vector<BucketIdType>(count, 0, allocator_);
+    }
+
+    void
+    GetCentroid(BucketIdType bucket_id, Vector<float>& centroid) override {
+        for (uint64_t i = 0; i < centroid.size(); ++i) {
+            centroid[i] = static_cast<float>((bucket_id + 1) * (i + 1)) * 0.01F;
+        }
+    }
+};
+
+}  // namespace
+
 namespace vsag {
 class BucketInterfaceTest {
 public:
@@ -279,6 +307,262 @@ TEST_CASE("BucketDataCell rejects inconsistent serialized metadata", "[ut][Bucke
             REQUIRE(error.error_.type == ErrorType::INVALID_BINARY);
             REQUIRE(error.error_.message ==
                     "serialized bucket size vector does not match bucket count");
+        }
+    }
+}
+
+TEST_CASE("BucketDataCell batch query", "[ut][BucketDataCell]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    auto query_allocator = SafeAllocator::FactoryDefaultAllocator();
+    constexpr int64_t dim = 8;
+    constexpr uint64_t bucket_count = 3;
+    constexpr uint64_t vectors_per_bucket = 4;
+    constexpr uint64_t base_count = bucket_count * vectors_per_bucket;
+    const auto io_type = GENERATE(std::string("memory_io"), std::string("buffer_io"));
+    auto vectors = fixtures::generate_vectors(base_count, dim);
+    auto queries = fixtures::generate_vectors(1, dim, 41);
+    fixtures::TempDir temp_dir("vsag_bucket_batch_query_test");
+
+    auto make_bucket = [&]() {
+        auto file_path = temp_dir.GenerateRandomFile(false);
+        auto param_json = JsonType::Parse(fmt::format(
+            R"({{
+                "io_params": {{
+                    "type": "{}",
+                    "file_path": "{}"
+                }},
+                "quantization_params": {{
+                    "type": "fp32"
+                }},
+                "buckets_count": {}
+            }})",
+            io_type,
+            file_path,
+            bucket_count));
+        auto param = std::make_shared<BucketDataCellParameter>();
+        param->FromJson(param_json);
+
+        IndexCommonParam common_param;
+        common_param.allocator_ = allocator;
+        common_param.dim_ = dim;
+        common_param.metric_ = MetricType::METRIC_TYPE_L2SQR;
+        auto bucket = BucketInterface::MakeInstance(param, common_param);
+        bucket->Train(vectors.data(), base_count);
+        return bucket;
+    };
+
+    auto bucket = make_bucket();
+    for (uint64_t bucket_id = 0; bucket_id < bucket_count; ++bucket_id) {
+        for (uint64_t offset_id = 0; offset_id < vectors_per_bucket; ++offset_id) {
+            auto inner_id = bucket_id * vectors_per_bucket + offset_id;
+            bucket->InsertVector(vectors.data() + inner_id * dim,
+                                 static_cast<BucketIdType>(bucket_id),
+                                 static_cast<InnerIdType>(inner_id));
+        }
+    }
+
+    std::vector<BucketIdType> bucket_ids{2, 0, 1, 0, 2, 1, 0};
+    std::vector<InnerIdType> offset_ids{3, 1, 2, 2, 3, 0, 1};
+    std::vector<float> expected(bucket_ids.size());
+    std::vector<float> actual(bucket_ids.size());
+    auto computer = bucket->FactoryComputer(queries.data());
+    for (uint64_t i = 0; i < bucket_ids.size(); ++i) {
+        expected[i] = bucket->QueryOneById(computer, bucket_ids[i], offset_ids[i]);
+    }
+
+    SearchStatistics stats;
+    QueryContext ctx{query_allocator.get(), &stats};
+    bucket->Query(actual.data(),
+                  computer,
+                  bucket_ids.data(),
+                  offset_ids.data(),
+                  static_cast<InnerIdType>(bucket_ids.size()),
+                  &ctx);
+    REQUIRE(actual == expected);
+    if (io_type == "buffer_io") {
+        // Four contiguous read ranges remain after sorting and de-duplicating the locations.
+        REQUIRE(stats.io_cnt.load(std::memory_order_relaxed) == 4);
+    }
+
+    REQUIRE_NOTHROW(bucket->Query(nullptr, ComputerInterfacePtr{}, nullptr, nullptr, 0, &ctx));
+
+    SECTION("invalid bucket is rejected") {
+        BucketIdType invalid_bucket_id = -1;
+        InnerIdType offset_id = 0;
+        float dist = 0.0F;
+        REQUIRE_THROWS(bucket->Query(&dist, computer, &invalid_bucket_id, &offset_id, 1));
+    }
+
+    SECTION("invalid offset is rejected") {
+        BucketIdType bucket_id = 0;
+        InnerIdType invalid_offset_id = 100;
+        float dist = 0.0F;
+        REQUIRE_THROWS(bucket->Query(&dist, computer, &bucket_id, &invalid_offset_id, 1));
+    }
+
+    SECTION("hole is rejected") {
+        auto sparse_bucket = make_bucket();
+        sparse_bucket->InsertVectorWithOffset(vectors.data() + 2 * dim, 0, 2, 2);
+        auto sparse_computer = sparse_bucket->FactoryComputer(queries.data());
+        BucketIdType bucket_id = 0;
+        InnerIdType hole_offset_id = 0;
+        float dist = 0.0F;
+        REQUIRE_THROWS(
+            sparse_bucket->Query(&dist, sparse_computer, &bucket_id, &hole_offset_id, 1));
+    }
+}
+
+TEST_CASE("BucketDataCell batch query preserves residual correction", "[ut][BucketDataCell]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    constexpr int64_t dim = 8;
+    constexpr uint64_t bucket_count = 2;
+    constexpr uint64_t base_count = 8;
+    auto vectors = fixtures::generate_vectors(base_count, dim);
+    auto queries = fixtures::generate_vectors(1, dim, 43);
+    MetricType metrics[] = {
+        MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_IP, MetricType::METRIC_TYPE_COSINE};
+
+    for (auto metric : metrics) {
+        auto param_json = JsonType::Parse(R"({
+            "io_params": {
+                "type": "memory_io"
+            },
+            "quantization_params": {
+                "type": "fp32"
+            },
+            "buckets_count": 2,
+            "use_residual": true
+        })");
+        auto param = std::make_shared<BucketDataCellParameter>();
+        param->FromJson(param_json);
+
+        IndexCommonParam common_param;
+        common_param.allocator_ = allocator;
+        common_param.dim_ = dim;
+        common_param.metric_ = metric;
+        auto bucket = BucketInterface::MakeInstance(param, common_param);
+        auto strategy =
+            std::make_shared<FixedCentroidPartitionStrategy>(common_param, bucket_count);
+        bucket->SetStrategy(strategy);
+        bucket->Train(vectors.data(), base_count);
+        for (uint64_t i = 0; i < base_count; ++i) {
+            bucket->InsertVector(vectors.data() + i * dim,
+                                 static_cast<BucketIdType>(i % bucket_count),
+                                 static_cast<InnerIdType>(i));
+        }
+
+        std::vector<BucketIdType> bucket_ids{1, 0, 1, 0, 1};
+        std::vector<InnerIdType> offset_ids{2, 3, 0, 1, 2};
+        std::vector<float> expected(bucket_ids.size());
+        std::vector<float> actual(bucket_ids.size());
+        auto computer = bucket->FactoryComputer(queries.data());
+        for (uint64_t i = 0; i < bucket_ids.size(); ++i) {
+            expected[i] = bucket->QueryOneById(computer, bucket_ids[i], offset_ids[i]);
+        }
+        bucket->Query(actual.data(),
+                      computer,
+                      bucket_ids.data(),
+                      offset_ids.data(),
+                      static_cast<InnerIdType>(bucket_ids.size()));
+        for (uint64_t i = 0; i < actual.size(); ++i) {
+            REQUIRE(std::abs(actual[i] - expected[i]) < 1e-5F);
+        }
+    }
+}
+
+TEST_CASE("BucketDataCell batch query handles all bucket quantizers", "[ut][BucketDataCell]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    constexpr int64_t dim = 64;
+    constexpr uint64_t train_count = 300;
+    constexpr uint64_t bucket_count = 2;
+    constexpr uint64_t vectors_per_bucket = 64;
+    auto vectors = fixtures::generate_vectors(train_count, dim);
+    auto queries = fixtures::generate_vectors(1, dim, 47);
+    fixtures::TempDir temp_dir("vsag_bucket_batch_quantizers_test");
+
+    const std::vector<std::pair<std::string, std::string>> quantizers = {
+        {"fp32", R"({"type": "fp32"})"},
+        {"sq8", R"({"type": "sq8"})"},
+        {"sq4", R"({"type": "sq4"})"},
+        {"sq4_uniform", R"({"type": "sq4_uniform"})"},
+        {"sq8_uniform", R"({"type": "sq8_uniform"})"},
+        {"bf16", R"({"type": "bf16"})"},
+        {"fp16", R"({"type": "fp16"})"},
+        {"pq", R"({"type": "pq", "pq_dim": 8, "pq_bits": 8})"},
+        {"pqfs", R"({"type": "pqfs", "pq_dim": 8})"},
+        {"rabitq",
+         R"({"type": "rabitq", "rabitq_bits_per_dim_query": 32, "rabitq_bits_per_dim_base": 1})"},
+    };
+
+    for (const auto& io_type : {std::string("memory_io"), std::string("buffer_io")}) {
+        for (const auto& [quantizer_name, quantizer_json] : quantizers) {
+            CAPTURE(io_type, quantizer_name);
+            JsonType param_json;
+            JsonType io_json;
+            io_json["type"].SetString(io_type);
+            io_json["file_path"].SetString(temp_dir.GenerateRandomFile(false));
+            param_json["io_params"].SetJson(io_json);
+            param_json["quantization_params"].SetJson(JsonType::Parse(quantizer_json));
+            param_json["buckets_count"].SetInt(bucket_count);
+            auto param = std::make_shared<BucketDataCellParameter>();
+            param->FromJson(param_json);
+
+            IndexCommonParam common_param;
+            common_param.allocator_ = allocator;
+            common_param.dim_ = dim;
+            common_param.metric_ = MetricType::METRIC_TYPE_L2SQR;
+            auto bucket = BucketInterface::MakeInstance(param, common_param);
+            bucket->Train(vectors.data(), train_count);
+            for (uint64_t bucket_id = 0; bucket_id < bucket_count; ++bucket_id) {
+                for (uint64_t offset_id = 0; offset_id < vectors_per_bucket; ++offset_id) {
+                    auto inner_id = bucket_id * vectors_per_bucket + offset_id;
+                    bucket->InsertVector(vectors.data() + inner_id * dim,
+                                         static_cast<BucketIdType>(bucket_id),
+                                         static_cast<InnerIdType>(inner_id));
+                }
+            }
+            // PQFS queries require its normal IVF package state; Package is a no-op for others.
+            bucket->Package();
+
+            auto computer = bucket->FactoryComputer(queries.data());
+            std::vector<BucketIdType> bucket_ids{1, 0, 1, 0, 1, 0};
+            std::vector<InnerIdType> offset_ids{33, 1, 2, 34, 33, 2};
+            std::vector<float> actual(bucket_ids.size());
+            if (quantizer_name == "pqfs") {
+                try {
+                    bucket->Query(actual.data(),
+                                  computer,
+                                  bucket_ids.data(),
+                                  offset_ids.data(),
+                                  static_cast<InnerIdType>(bucket_ids.size()));
+                    FAIL("PQFS batch point query should preserve QueryOneById rejection");
+                } catch (const VsagException& error) {
+                    REQUIRE(error.error_.type == ErrorType::INTERNAL_ERROR);
+                    REQUIRE(error.error_.message ==
+                            "PQFastScan doesn't support ComputeDist, only support "
+                            "ComputeBatchDist");
+                }
+                continue;
+            }
+
+            std::vector<float> expected(bucket_ids.size());
+            for (uint64_t i = 0; i < expected.size(); ++i) {
+                expected[i] = bucket->QueryOneById(computer, bucket_ids[i], offset_ids[i]);
+            }
+            SearchStatistics stats;
+            QueryContext ctx{nullptr, &stats};
+            bucket->Query(actual.data(),
+                          computer,
+                          bucket_ids.data(),
+                          offset_ids.data(),
+                          static_cast<InnerIdType>(bucket_ids.size()),
+                          &ctx);
+            for (uint64_t i = 0; i < actual.size(); ++i) {
+                REQUIRE(std::abs(actual[i] - expected[i]) < 1e-5F);
+            }
+            if (io_type == "buffer_io") {
+                REQUIRE(stats.io_cnt.load(std::memory_order_relaxed) == 4);
+            }
         }
     }
 }

--- a/src/datacell/bucket_datacell_test.cpp
+++ b/src/datacell/bucket_datacell_test.cpp
@@ -27,6 +27,8 @@
 #include "impl/allocator/default_allocator.h"
 #include "impl/allocator/safe_allocator.h"
 #include "index_common_param.h"
+#include "io/reader_io/reader_io_parameter.h"
+#include "quantization/fp32_quantizer.h"
 #include "simd/simd.h"
 #include "storage/serialization_template_test.h"
 #include "unittest.h"
@@ -57,6 +59,165 @@ public:
             centroid[i] = static_cast<float>((bucket_id + 1) * (i + 1)) * 0.01F;
         }
     }
+};
+
+class TrackingReader : public Reader {
+public:
+    explicit TrackingReader(std::shared_ptr<std::string> data) : data_(std::move(data)) {
+    }
+
+    void
+    Read(uint64_t offset, uint64_t len, void* dest) override {
+        ++read_calls_;
+        copy(offset, len, dest);
+    }
+
+    void
+    AsyncRead(uint64_t offset, uint64_t len, void* dest, CallBack callback) override {
+        copy(offset, len, dest);
+        callback(IOErrorCode::IO_SUCCESS, "success");
+    }
+
+    bool
+    MultiRead(uint8_t* dests,
+              const uint64_t* lens,
+              const uint64_t* offsets,
+              uint64_t count) override {
+        ++multi_read_calls_;
+        multi_read_ranges_ += count;
+        for (uint64_t i = 0; i < count; ++i) {
+            copy(offsets[i], lens[i], dests);
+            dests += lens[i];
+        }
+        return true;
+    }
+
+    [[nodiscard]] uint64_t
+    Size() const override {
+        return data_->size();
+    }
+
+    void
+    ResetStats() {
+        read_calls_ = 0;
+        multi_read_calls_ = 0;
+        multi_read_ranges_ = 0;
+    }
+
+    uint64_t read_calls_{0};
+    uint64_t multi_read_calls_{0};
+    uint64_t multi_read_ranges_{0};
+
+private:
+    void
+    copy(uint64_t offset, uint64_t len, void* dest) const {
+        if (offset > data_->size() or len > data_->size() - offset) {
+            throw VsagException(ErrorType::READ_ERROR, "tracking reader read out of bounds");
+        }
+        std::memcpy(dest, data_->data() + offset, len);
+    }
+
+    std::shared_ptr<std::string> data_;
+};
+
+struct TrackingWrite {
+    uint64_t size{0};
+    uint64_t offset{0};
+};
+
+struct TrackingWriteIOState {
+    std::vector<std::vector<TrackingWrite>> writes_by_bucket;
+};
+
+class TrackingWriteIOParameter : public IOParameter {
+public:
+    explicit TrackingWriteIOParameter(std::shared_ptr<TrackingWriteIOState> state)
+        : IOParameter("tracking_write_io"), state_(std::move(state)) {
+    }
+
+    void
+    FromJson(const JsonType&) override {
+    }
+
+    JsonType
+    ToJson() const override {
+        return JsonType();
+    }
+
+    std::shared_ptr<TrackingWriteIOState> state_;
+};
+
+class TrackingWriteIO : public BasicIO<TrackingWriteIO> {
+public:
+    static constexpr bool InMemory = true;
+    static constexpr bool SkipDeserialize = false;
+
+    TrackingWriteIO(const IOParamPtr& param, const IndexCommonParam& common_param)
+        : BasicIO<TrackingWriteIO>(common_param.allocator_.get()) {
+        auto tracking_param = std::dynamic_pointer_cast<TrackingWriteIOParameter>(param);
+        if (tracking_param == nullptr or tracking_param->state_ == nullptr) {
+            throw VsagException(ErrorType::INVALID_ARGUMENT,
+                                "TrackingWriteIO requires tracking state");
+        }
+        state_ = tracking_param->state_;
+        bucket_id_ = state_->writes_by_bucket.size();
+        state_->writes_by_bucket.emplace_back();
+    }
+
+    void
+    WriteImpl(const uint8_t* data, uint64_t size, uint64_t offset) {
+        state_->writes_by_bucket[bucket_id_].emplace_back(TrackingWrite{size, offset});
+        const auto next_size = offset + size;
+        if (data_.size() < next_size) {
+            data_.resize(next_size);
+        }
+        if (size > 0) {
+            std::memcpy(data_.data() + offset, data, size);
+        }
+        this->size_ = std::max(this->size_, next_size);
+    }
+
+    void
+    ResizeImpl(uint64_t size) {
+        data_.resize(size);
+        this->size_ = size;
+    }
+
+    bool
+    ReadImpl(uint64_t size, uint64_t offset, uint8_t* data) const {
+        if (offset > data_.size() or size > data_.size() - offset) {
+            return false;
+        }
+        if (size > 0) {
+            std::memcpy(data, data_.data() + offset, size);
+        }
+        return true;
+    }
+
+    [[nodiscard]] const uint8_t*
+    DirectReadImpl(uint64_t size, uint64_t offset, bool& need_release) const {
+        need_release = false;
+        if (offset > data_.size() or size > data_.size() - offset) {
+            return nullptr;
+        }
+        return data_.data() + offset;
+    }
+
+    bool
+    MultiReadImpl(uint8_t* data, uint64_t* sizes, uint64_t* offsets, uint64_t count) const {
+        for (uint64_t i = 0; i < count; ++i) {
+            if (not ReadImpl(sizes[i], offsets[i], data)) {
+                return false;
+            }
+            data += sizes[i];
+        }
+        return true;
+    }
+
+private:
+    std::shared_ptr<TrackingWriteIOState> state_;
+    uint64_t bucket_id_{0};
+    std::vector<uint8_t> data_;
 };
 
 }  // namespace
@@ -311,6 +472,111 @@ TEST_CASE("BucketDataCell rejects inconsistent serialized metadata", "[ut][Bucke
     }
 }
 
+TEST_CASE("BucketDataCell ReaderIO queries serialized bucket codes",
+          "[ut][BucketDataCell][ReaderIO]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    constexpr int64_t dim = 4;
+    constexpr BucketIdType bucket_count = 3;
+    constexpr uint64_t base_count = 6;
+    auto vectors = fixtures::generate_vectors(base_count, dim);
+    auto query = fixtures::generate_vectors(1, dim, 53);
+
+    auto make_bucket = [&](const std::string& io_type) {
+        auto param_json = JsonType::Parse(fmt::format(
+            R"({{
+                "io_params": {{
+                    "type": "{}"
+                }},
+                "quantization_params": {{
+                    "type": "fp32"
+                }},
+                "buckets_count": {}
+            }})",
+            io_type,
+            bucket_count));
+        auto param = std::make_shared<BucketDataCellParameter>();
+        param->FromJson(param_json);
+
+        IndexCommonParam common_param;
+        common_param.allocator_ = allocator;
+        common_param.dim_ = dim;
+        common_param.metric_ = MetricType::METRIC_TYPE_L2SQR;
+        return BucketInterface::MakeInstance(param, common_param);
+    };
+
+    auto source = make_bucket("memory_io");
+    source->Train(vectors.data(), base_count);
+    std::vector<BucketIdType> inserted_bucket_ids{0, 1, 2, 0, 1, 2};
+    for (InnerIdType inner_id = 0; inner_id < base_count; ++inner_id) {
+        source->InsertVector(vectors.data() + static_cast<uint64_t>(inner_id) * dim,
+                             inserted_bucket_ids[inner_id],
+                             inner_id);
+    }
+
+    std::stringstream stream;
+    IOStreamWriter writer(stream);
+    source->Serialize(writer);
+    auto serialized = std::make_shared<std::string>(stream.str());
+
+    uint64_t deserialized_read_bytes = 0;
+    ReadFuncStreamReader stream_reader(
+        [&](uint64_t offset, uint64_t size, void* dest) {
+            if (offset > serialized->size() or size > serialized->size() - offset) {
+                throw VsagException(ErrorType::READ_ERROR, "serialized bucket read out of bounds");
+            }
+            deserialized_read_bytes += size;
+            std::memcpy(dest, serialized->data() + offset, size);
+        },
+        0,
+        serialized->size());
+    auto restored = make_bucket("reader_io");
+    REQUIRE(restored != nullptr);
+    restored->Deserialize(stream_reader);
+
+    constexpr uint64_t serialized_code_bytes = base_count * dim * sizeof(float);
+    REQUIRE(stream_reader.GetCursor() == serialized->size());
+    REQUIRE(deserialized_read_bytes == serialized->size() - serialized_code_bytes);
+
+    auto restored_computer = restored->FactoryComputer(query.data());
+    REQUIRE_THROWS(restored->QueryOneById(restored_computer, 0, 0));
+
+    auto tracking_reader = std::make_shared<TrackingReader>(serialized);
+    auto reader_param = std::make_shared<ReaderIOParameter>();
+    reader_param->reader = tracking_reader;
+    restored->InitIO(reader_param);
+
+    auto source_computer = source->FactoryComputer(query.data());
+    for (BucketIdType bucket_id = 0; bucket_id < bucket_count; ++bucket_id) {
+        for (InnerIdType offset_id = 0; offset_id < 2; ++offset_id) {
+            REQUIRE(restored->QueryOneById(restored_computer, bucket_id, offset_id) ==
+                    source->QueryOneById(source_computer, bucket_id, offset_id));
+        }
+    }
+
+    std::vector<BucketIdType> bucket_ids{2, 0, 1, 0, 2, 1, 0};
+    std::vector<InnerIdType> offset_ids{1, 0, 1, 1, 0, 0, 0};
+    std::vector<float> expected(bucket_ids.size());
+    std::vector<float> actual(bucket_ids.size());
+    for (uint64_t i = 0; i < bucket_ids.size(); ++i) {
+        expected[i] = source->QueryOneById(source_computer, bucket_ids[i], offset_ids[i]);
+    }
+
+    tracking_reader->ResetStats();
+    SearchStatistics stats;
+    QueryContext ctx{nullptr, &stats};
+    restored->Query(actual.data(),
+                    restored_computer,
+                    bucket_ids.data(),
+                    offset_ids.data(),
+                    static_cast<InnerIdType>(bucket_ids.size()),
+                    &ctx);
+    REQUIRE(actual == expected);
+    REQUIRE(tracking_reader->read_calls_ == 0);
+    REQUIRE(tracking_reader->multi_read_calls_ == bucket_count);
+    REQUIRE(tracking_reader->multi_read_ranges_ == bucket_count);
+    REQUIRE(stats.io_cnt.load(std::memory_order_relaxed) == bucket_count);
+}
+
 TEST_CASE("BucketDataCell batch query", "[ut][BucketDataCell]") {
     auto allocator = SafeAllocator::FactoryDefaultAllocator();
     auto query_allocator = SafeAllocator::FactoryDefaultAllocator();
@@ -563,6 +829,222 @@ TEST_CASE("BucketDataCell batch query handles all bucket quantizers", "[ut][Buck
             if (io_type == "buffer_io") {
                 REQUIRE(stats.io_cnt.load(std::memory_order_relaxed) == 4);
             }
+        }
+    }
+}
+
+TEST_CASE("BucketDataCell batch insert groups one write per bucket", "[ut][BucketDataCell]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    constexpr uint64_t dim = 8;
+    constexpr BucketIdType bucket_count = 3;
+    constexpr uint64_t base_count = 10;
+    constexpr uint64_t code_size = dim * sizeof(float);
+    auto vectors = fixtures::generate_vectors(base_count, dim);
+    auto state = std::make_shared<TrackingWriteIOState>();
+    auto io_param = std::make_shared<TrackingWriteIOParameter>(state);
+    auto quantizer_param = std::make_shared<FP32QuantizerParameter>();
+
+    IndexCommonParam common_param;
+    common_param.allocator_ = allocator;
+    common_param.dim_ = dim;
+    common_param.metric_ = MetricType::METRIC_TYPE_L2SQR;
+    auto bucket = std::make_shared<
+        BucketDataCell<FP32Quantizer<MetricType::METRIC_TYPE_L2SQR>, TrackingWriteIO>>(
+        quantizer_param, io_param, common_param, bucket_count);
+    bucket->Train(vectors.data(), base_count);
+
+    std::vector<BucketIdType> first_bucket_ids{2, 0, 2, 1, 0, 2};
+    std::vector<InnerIdType> first_inner_ids{100, 101, 102, 103, 104, 105};
+    std::vector<InnerIdType> first_offsets(first_bucket_ids.size(),
+                                           std::numeric_limits<InnerIdType>::max());
+    bucket->BatchInsertVector(vectors.data(),
+                              first_bucket_ids.data(),
+                              first_inner_ids.data(),
+                              first_bucket_ids.size(),
+                              first_offsets.data());
+
+    REQUIRE(first_offsets == std::vector<InnerIdType>{0, 0, 1, 0, 1, 2});
+    REQUIRE(state->writes_by_bucket.size() == bucket_count);
+    REQUIRE(state->writes_by_bucket[0].size() == 1);
+    REQUIRE(state->writes_by_bucket[0][0].size == 2 * code_size);
+    REQUIRE(state->writes_by_bucket[0][0].offset == 0);
+    REQUIRE(state->writes_by_bucket[1].size() == 1);
+    REQUIRE(state->writes_by_bucket[1][0].size == code_size);
+    REQUIRE(state->writes_by_bucket[1][0].offset == 0);
+    REQUIRE(state->writes_by_bucket[2].size() == 1);
+    REQUIRE(state->writes_by_bucket[2][0].size == 3 * code_size);
+    REQUIRE(state->writes_by_bucket[2][0].offset == 0);
+
+    std::vector<BucketIdType> second_bucket_ids{1, 2, 1, 0};
+    std::vector<InnerIdType> second_inner_ids{200, 201, 202, 203};
+    std::vector<InnerIdType> second_offsets(second_bucket_ids.size(),
+                                            std::numeric_limits<InnerIdType>::max());
+    bucket->BatchInsertVector(vectors.data() + first_bucket_ids.size() * dim,
+                              second_bucket_ids.data(),
+                              second_inner_ids.data(),
+                              second_bucket_ids.size(),
+                              second_offsets.data());
+
+    REQUIRE(second_offsets == std::vector<InnerIdType>{1, 3, 2, 2});
+    for (BucketIdType bucket_id = 0; bucket_id < bucket_count; ++bucket_id) {
+        REQUIRE(state->writes_by_bucket[bucket_id].size() == 2);
+    }
+    REQUIRE(state->writes_by_bucket[0][1].size == code_size);
+    REQUIRE(state->writes_by_bucket[0][1].offset == 2 * code_size);
+    REQUIRE(state->writes_by_bucket[1][1].size == 2 * code_size);
+    REQUIRE(state->writes_by_bucket[1][1].offset == code_size);
+    REQUIRE(state->writes_by_bucket[2][1].size == code_size);
+    REQUIRE(state->writes_by_bucket[2][1].offset == 3 * code_size);
+
+    const std::vector<std::vector<InnerIdType>> expected_inner_ids{
+        {101, 104, 203}, {103, 200, 202}, {100, 102, 105, 201}};
+    const std::vector<std::vector<uint64_t>> expected_vector_ids{
+        {1, 4, 9}, {3, 6, 8}, {0, 2, 5, 7}};
+    std::vector<uint8_t> actual_codes(code_size);
+    for (BucketIdType bucket_id = 0; bucket_id < bucket_count; ++bucket_id) {
+        REQUIRE(bucket->GetBucketSize(bucket_id) == expected_inner_ids[bucket_id].size());
+        for (uint64_t offset = 0; offset < expected_inner_ids[bucket_id].size(); ++offset) {
+            REQUIRE(bucket->GetInnerIds(bucket_id)[offset] ==
+                    expected_inner_ids[bucket_id][offset]);
+            bucket->GetCodesById(bucket_id, offset, actual_codes.data());
+            const auto* expected_codes = reinterpret_cast<const uint8_t*>(
+                vectors.data() + expected_vector_ids[bucket_id][offset] * dim);
+            REQUIRE(std::memcmp(actual_codes.data(), expected_codes, code_size) == 0);
+        }
+    }
+}
+
+TEST_CASE("BucketDataCell batch insert validates before writing", "[ut][BucketDataCell]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    constexpr uint64_t dim = 4;
+    constexpr BucketIdType bucket_count = 3;
+    constexpr uint64_t count = 3;
+    auto vectors = fixtures::generate_vectors(count, dim);
+    auto state = std::make_shared<TrackingWriteIOState>();
+    auto io_param = std::make_shared<TrackingWriteIOParameter>(state);
+    auto quantizer_param = std::make_shared<FP32QuantizerParameter>();
+
+    IndexCommonParam common_param;
+    common_param.allocator_ = allocator;
+    common_param.dim_ = dim;
+    common_param.metric_ = MetricType::METRIC_TYPE_L2SQR;
+    auto bucket = std::make_shared<
+        BucketDataCell<FP32Quantizer<MetricType::METRIC_TYPE_L2SQR>, TrackingWriteIO>>(
+        quantizer_param, io_param, common_param, bucket_count);
+    bucket->Train(vectors.data(), count);
+
+    std::vector<BucketIdType> bucket_ids{0, 1, 2};
+    std::vector<InnerIdType> inner_ids{10, 11, 12};
+    std::vector<InnerIdType> offsets(count, std::numeric_limits<InnerIdType>::max());
+    auto require_unchanged = [&]() {
+        REQUIRE(state->writes_by_bucket.size() == bucket_count);
+        for (BucketIdType bucket_id = 0; bucket_id < bucket_count; ++bucket_id) {
+            REQUIRE(state->writes_by_bucket[bucket_id].empty());
+            REQUIRE(bucket->GetBucketSize(bucket_id) == 0);
+        }
+    };
+
+    REQUIRE_NOTHROW(bucket->BatchInsertVector(nullptr, nullptr, nullptr, 0, nullptr));
+    require_unchanged();
+
+    REQUIRE_THROWS(bucket->BatchInsertVector(
+        nullptr, bucket_ids.data(), inner_ids.data(), count, offsets.data()));
+    require_unchanged();
+    REQUIRE_THROWS(bucket->BatchInsertVector(
+        vectors.data(), nullptr, inner_ids.data(), count, offsets.data()));
+    require_unchanged();
+    REQUIRE_THROWS(bucket->BatchInsertVector(
+        vectors.data(), bucket_ids.data(), nullptr, count, offsets.data()));
+    require_unchanged();
+    REQUIRE_THROWS(bucket->BatchInsertVector(
+        vectors.data(), bucket_ids.data(), inner_ids.data(), count, nullptr));
+    require_unchanged();
+
+    auto invalid_bucket_ids = bucket_ids;
+    invalid_bucket_ids[1] = bucket_count;
+    REQUIRE_THROWS(bucket->BatchInsertVector(
+        vectors.data(), invalid_bucket_ids.data(), inner_ids.data(), count, offsets.data()));
+    require_unchanged();
+
+    auto invalid_inner_ids = inner_ids;
+    invalid_inner_ids[1] = std::numeric_limits<InnerIdType>::max();
+    REQUIRE_THROWS(bucket->BatchInsertVector(
+        vectors.data(), bucket_ids.data(), invalid_inner_ids.data(), count, offsets.data()));
+    require_unchanged();
+}
+
+TEST_CASE("BucketDataCell batch insert preserves RaBitQ PCA input stride", "[ut][BucketDataCell]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    constexpr uint64_t dim = 32;
+    constexpr uint64_t pca_dim = 16;
+    constexpr uint64_t train_count = 64;
+    constexpr uint64_t insert_count = 8;
+    constexpr BucketIdType bucket_count = 2;
+    auto vectors = fixtures::generate_vectors(train_count, dim);
+    auto queries = fixtures::generate_vectors(3, dim, 61);
+
+    auto make_bucket = [&]() {
+        auto param_json = JsonType::Parse(fmt::format(
+            R"({{
+                "io_params": {{
+                    "type": "memory_io"
+                }},
+                "quantization_params": {{
+                    "type": "rabitq",
+                    "pca_dim": {},
+                    "rabitq_bits_per_dim_query": 32,
+                    "rabitq_bits_per_dim_base": 1,
+                    "fast_encode_rabitq": false
+                }},
+                "buckets_count": {}
+            }})",
+            pca_dim,
+            bucket_count));
+        auto param = std::make_shared<BucketDataCellParameter>();
+        param->FromJson(param_json);
+
+        IndexCommonParam common_param;
+        common_param.allocator_ = allocator;
+        common_param.dim_ = dim;
+        common_param.metric_ = MetricType::METRIC_TYPE_L2SQR;
+        return BucketInterface::MakeInstance(param, common_param);
+    };
+
+    auto incremental = make_bucket();
+    auto batched = make_bucket();
+    incremental->Train(vectors.data(), train_count);
+    incremental->ExportModel(batched);
+
+    std::vector<BucketIdType> bucket_ids{1, 0, 1, 1, 0, 0, 1, 0};
+    std::vector<InnerIdType> inner_ids{70, 71, 72, 73, 74, 75, 76, 77};
+    std::vector<InnerIdType> expected_offsets(insert_count);
+    for (uint64_t i = 0; i < insert_count; ++i) {
+        expected_offsets[i] =
+            incremental->InsertVector(vectors.data() + i * dim, bucket_ids[i], inner_ids[i]);
+    }
+
+    std::vector<InnerIdType> actual_offsets(insert_count, std::numeric_limits<InnerIdType>::max());
+    batched->BatchInsertVector(
+        vectors.data(), bucket_ids.data(), inner_ids.data(), insert_count, actual_offsets.data());
+    REQUIRE(actual_offsets == expected_offsets);
+
+    for (BucketIdType bucket_id = 0; bucket_id < bucket_count; ++bucket_id) {
+        REQUIRE(batched->GetBucketSize(bucket_id) == incremental->GetBucketSize(bucket_id));
+        for (InnerIdType offset = 0; offset < incremental->GetBucketSize(bucket_id); ++offset) {
+            REQUIRE(batched->GetInnerIds(bucket_id)[offset] ==
+                    incremental->GetInnerIds(bucket_id)[offset]);
+        }
+    }
+
+    for (uint64_t query_id = 0; query_id < 3; ++query_id) {
+        auto incremental_computer = incremental->FactoryComputer(queries.data() + query_id * dim);
+        auto batched_computer = batched->FactoryComputer(queries.data() + query_id * dim);
+        for (uint64_t i = 0; i < insert_count; ++i) {
+            const auto expected =
+                incremental->QueryOneById(incremental_computer, bucket_ids[i], expected_offsets[i]);
+            const auto actual =
+                batched->QueryOneById(batched_computer, bucket_ids[i], actual_offsets[i]);
+            REQUIRE(std::abs(actual - expected) < 1e-5F);
         }
     }
 }

--- a/src/datacell/bucket_datacell_test.cpp
+++ b/src/datacell/bucket_datacell_test.cpp
@@ -17,6 +17,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstring>
 #include <exception>
 #include <limits>
 #include <sstream>
@@ -200,6 +201,86 @@ TEST_CASE("BucketDataCell rejects invalid parameters", "[ut][BucketDataCell]") {
     IndexCommonParam common_param;
 
     REQUIRE(BucketInterface::MakeInstance(nullptr, common_param) == nullptr);
+}
+
+TEST_CASE("BucketDataCell rejects inconsistent serialized metadata", "[ut][BucketDataCell]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    constexpr int64_t dim = 4;
+    constexpr const char* param_str = R"(
+        {
+            "io_params": {
+                "type": "memory_io"
+            },
+            "quantization_params": {
+                "type": "fp32"
+            },
+            "buckets_count": 1
+        }
+        )";
+
+    auto make_bucket = [&]() {
+        auto param_json = JsonType::Parse(param_str);
+        auto param = std::make_shared<BucketDataCellParameter>();
+        param->FromJson(param_json);
+
+        IndexCommonParam common_param;
+        common_param.allocator_ = allocator;
+        common_param.dim_ = dim;
+        common_param.metric_ = MetricType::METRIC_TYPE_L2SQR;
+        return BucketInterface::MakeInstance(param, common_param);
+    };
+
+    auto bucket = make_bucket();
+    auto vectors = fixtures::generate_vectors(1, dim);
+    bucket->Train(vectors.data(), 1);
+    bucket->InsertVector(vectors.data(), 0, 0);
+
+    std::stringstream stream;
+    IOStreamWriter writer(stream);
+    bucket->Serialize(writer);
+    const auto serialized = stream.str();
+
+    SECTION("inner id vector is shorter than bucket size") {
+        auto malformed = serialized;
+        constexpr InnerIdType invalid_bucket_size = 2;
+        std::memcpy(malformed.data() + malformed.size() - sizeof(invalid_bucket_size),
+                    &invalid_bucket_size,
+                    sizeof(invalid_bucket_size));
+
+        std::stringstream malformed_stream(malformed);
+        IOStreamReader reader(malformed_stream);
+        auto restored = make_bucket();
+        try {
+            restored->Deserialize(reader);
+            FAIL("inconsistent inner id metadata should be rejected");
+        } catch (const VsagException& error) {
+            REQUIRE(error.error_.type == ErrorType::INVALID_BINARY);
+            REQUIRE(error.error_.message ==
+                    "serialized bucket 0 inner id count is smaller than bucket size");
+        }
+    }
+
+    SECTION("bucket size vector does not cover every bucket") {
+        auto malformed = serialized;
+        constexpr uint64_t invalid_bucket_size_count = 0;
+        const uint64_t count_offset =
+            static_cast<uint64_t>(malformed.size()) - sizeof(InnerIdType) - sizeof(uint64_t);
+        std::memcpy(malformed.data() + count_offset,
+                    &invalid_bucket_size_count,
+                    sizeof(invalid_bucket_size_count));
+
+        std::stringstream malformed_stream(malformed);
+        IOStreamReader reader(malformed_stream);
+        auto restored = make_bucket();
+        try {
+            restored->Deserialize(reader);
+            FAIL("inconsistent bucket size metadata should be rejected");
+        } catch (const VsagException& error) {
+            REQUIRE(error.error_.type == ErrorType::INVALID_BINARY);
+            REQUIRE(error.error_.message ==
+                    "serialized bucket size vector does not match bucket count");
+        }
+    }
 }
 
 TEST_CASE("BucketDataCell supports RabitQ", "[ut][BucketDataCell]") {

--- a/src/datacell/bucket_datacell_test.cpp
+++ b/src/datacell/bucket_datacell_test.cpp
@@ -577,6 +577,128 @@ TEST_CASE("BucketDataCell ReaderIO queries serialized bucket codes",
     REQUIRE(stats.io_cnt.load(std::memory_order_relaxed) == bucket_count);
 }
 
+TEST_CASE("BucketDataCell ReaderIO shares one read cache across buckets",
+          "[ut][BucketDataCell][ReaderIO][ReadCache]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    constexpr BucketIdType bucket_count = 2;
+    constexpr uint64_t cache_page_count = 2;
+    constexpr int64_t dim = Page::DEFAULT_PAGE_SIZE / sizeof(float);
+    const auto cache_size = cache_page_count * Page::DEFAULT_PAGE_SIZE;
+
+    auto make_bucket = [&](const std::string& io_type) {
+        auto param_json = JsonType::Parse(fmt::format(
+            R"({{
+                "io_params": {{
+                    "type": "{}",
+                    "enable_read_cache": true,
+                    "total_cache_size": {}
+                }},
+                "quantization_params": {{
+                    "type": "fp32"
+                }},
+                "buckets_count": {}
+            }})",
+            io_type,
+            cache_size,
+            bucket_count));
+        auto param = std::make_shared<BucketDataCellParameter>();
+        param->FromJson(param_json);
+
+        IndexCommonParam common_param;
+        common_param.allocator_ = allocator;
+        common_param.dim_ = dim;
+        common_param.metric_ = MetricType::METRIC_TYPE_L2SQR;
+        return BucketInterface::MakeInstance(param, common_param);
+    };
+
+    auto build_source = [&](float first_value) {
+        auto source = make_bucket("memory_io");
+        std::vector<float> first(dim, first_value);
+        std::vector<float> second(dim, first_value + 1.0F);
+        std::vector<float> third(dim, first_value + 2.0F);
+        source->Train(first.data(), 1);
+        source->InsertVector(first.data(), 0, 0);
+        source->InsertVector(second.data(), 0, 1);
+        source->InsertVector(third.data(), 1, 2);
+
+        std::stringstream stream;
+        IOStreamWriter writer(stream);
+        source->Serialize(writer);
+        return std::make_pair(source, std::make_shared<std::string>(stream.str()));
+    };
+
+    auto [first_source, first_serialized] = build_source(1.0F);
+    auto [second_source, second_serialized] = build_source(11.0F);
+    REQUIRE(second_serialized->size() == first_serialized->size());
+
+    auto restored = make_bucket("reader_io");
+    std::stringstream stream(*first_serialized);
+    IOStreamReader stream_reader(stream);
+    restored->Deserialize(stream_reader);
+
+    auto make_reader_param = [&](const std::shared_ptr<TrackingReader>& reader) {
+        auto reader_param = std::make_shared<ReaderIOParameter>();
+        reader_param->reader = reader;
+        reader_param->enable_read_cache_ = true;
+        reader_param->read_cache_total_size_ = cache_size;
+        return reader_param;
+    };
+
+    std::vector<float> query(dim, 0.0F);
+    auto first_computer = first_source->FactoryComputer(query.data());
+    auto restored_computer = restored->FactoryComputer(query.data());
+    auto first_reader = std::make_shared<TrackingReader>(first_serialized);
+    restored->InitIO(make_reader_param(first_reader));
+
+    first_reader->ResetStats();
+    REQUIRE(restored->QueryOneById(restored_computer, 0, 0) ==
+            first_source->QueryOneById(first_computer, 0, 0));
+    REQUIRE(restored->QueryOneById(restored_computer, 0, 1) ==
+            first_source->QueryOneById(first_computer, 0, 1));
+    REQUIRE(restored->QueryOneById(restored_computer, 0, 0) ==
+            first_source->QueryOneById(first_computer, 0, 0));
+    REQUIRE(first_reader->read_calls_ == cache_page_count);
+    REQUIRE(first_reader->multi_read_calls_ == 0);
+
+    const auto reads_before_other_bucket = first_reader->read_calls_;
+    REQUIRE(restored->QueryOneById(restored_computer, 1, 0) ==
+            first_source->QueryOneById(first_computer, 1, 0));
+    REQUIRE(first_reader->read_calls_ == reads_before_other_bucket + 1);
+
+    auto second_reader = std::make_shared<TrackingReader>(second_serialized);
+    restored->InitIO(make_reader_param(second_reader));
+    second_reader->ResetStats();
+    auto second_computer = second_source->FactoryComputer(query.data());
+    REQUIRE(restored->QueryOneById(restored_computer, 1, 0) ==
+            second_source->QueryOneById(second_computer, 1, 0));
+    REQUIRE(second_reader->read_calls_ == 1);
+
+    std::vector<BucketIdType> bucket_ids{1, 0, 0, 1, 0};
+    std::vector<InnerIdType> offset_ids{0, 1, 0, 0, 1};
+    std::vector<float> expected(bucket_ids.size());
+    std::vector<float> actual(bucket_ids.size());
+    for (uint64_t i = 0; i < bucket_ids.size(); ++i) {
+        expected[i] = second_source->QueryOneById(second_computer, bucket_ids[i], offset_ids[i]);
+    }
+    restored->Query(actual.data(),
+                    restored_computer,
+                    bucket_ids.data(),
+                    offset_ids.data(),
+                    static_cast<InnerIdType>(bucket_ids.size()));
+    REQUIRE(actual == expected);
+
+    auto no_cache_param = make_reader_param(second_reader);
+    no_cache_param->enable_read_cache_ = false;
+    no_cache_param->read_cache_total_size_ = 0;
+    restored->InitIO(no_cache_param);
+    second_reader->ResetStats();
+    REQUIRE(restored->QueryOneById(restored_computer, 0, 0) ==
+            second_source->QueryOneById(second_computer, 0, 0));
+    REQUIRE(restored->QueryOneById(restored_computer, 0, 0) ==
+            second_source->QueryOneById(second_computer, 0, 0));
+    REQUIRE(second_reader->read_calls_ == 2);
+}
+
 TEST_CASE("BucketDataCell batch query", "[ut][BucketDataCell]") {
     auto allocator = SafeAllocator::FactoryDefaultAllocator();
     auto query_allocator = SafeAllocator::FactoryDefaultAllocator();

--- a/src/datacell/bucket_interface.cpp
+++ b/src/datacell/bucket_interface.cpp
@@ -46,6 +46,9 @@ BucketInterface::MakeInstance(const BucketDataCellParamPtr& param,
     if (io_type_name == IO_TYPE_VALUE_BUFFER_IO) {
         return MakeBufferBucketDataCell(param, common_param);
     }
+    if (io_type_name == IO_TYPE_VALUE_READER_IO) {
+        return MakeReaderBucketDataCell(param, common_param);
+    }
     return nullptr;
 }
 }  // namespace vsag

--- a/src/datacell/bucket_interface.h
+++ b/src/datacell/bucket_interface.h
@@ -21,6 +21,7 @@
 #include "bucket_datacell_parameter.h"
 #include "index_common_param.h"
 #include "quantization/computer.h"
+#include "query_context.h"
 #include "storage/stream_reader.h"
 #include "storage/stream_writer.h"
 #include "typing.h"
@@ -46,6 +47,19 @@ public:
     QueryOneById(const ComputerInterfacePtr& computer,
                  const BucketIdType& bucket_id,
                  const InnerIdType& offset_id) = 0;
+
+    virtual void
+    Query(float* result_dists,
+          const ComputerInterfacePtr& computer,
+          const BucketIdType* bucket_ids,
+          const InnerIdType* offset_ids,
+          InnerIdType id_count,
+          QueryContext* ctx = nullptr) {
+        (void)ctx;
+        for (InnerIdType i = 0; i < id_count; ++i) {
+            result_dists[i] = QueryOneById(computer, bucket_ids[i], offset_ids[i]);
+        }
+    }
 
     virtual ComputerInterfacePtr
     FactoryComputer(const void* query) = 0;

--- a/src/datacell/bucket_interface.h
+++ b/src/datacell/bucket_interface.h
@@ -51,6 +51,19 @@ public:
     virtual float
     ComputePairVectors(BucketIdType bucket_id, InnerIdType id1, InnerIdType id2) = 0;
 
+    virtual void
+    Query(float* result_dists,
+          const ComputerInterfacePtr& computer,
+          const BucketIdType* bucket_ids,
+          const InnerIdType* offset_ids,
+          InnerIdType id_count,
+          QueryContext* ctx = nullptr) {
+        (void)ctx;
+        for (InnerIdType i = 0; i < id_count; ++i) {
+            result_dists[i] = QueryOneById(computer, bucket_ids[i], offset_ids[i]);
+        }
+    }
+
     virtual ComputerInterfacePtr
     FactoryComputer(const void* query) = 0;
 

--- a/src/datacell/bucket_interface.h
+++ b/src/datacell/bucket_interface.h
@@ -73,6 +73,13 @@ public:
     virtual InnerIdType
     InsertVector(const void* vector, BucketIdType bucket_id, InnerIdType inner_id) = 0;
 
+    virtual void
+    BatchInsertVector(const void* vectors,
+                      const BucketIdType* bucket_ids,
+                      const InnerIdType* inner_ids,
+                      InnerIdType count,
+                      InnerIdType* out_offsets) = 0;
+
     // Fixed-offset inserts may create holes: GetBucketSize() includes reserved offsets and
     // GetInnerIds() reports holes as InnerIdType::max(). Therefore inner_id must not be max.
     virtual void
@@ -139,6 +146,11 @@ public:
     Deserialize(lvalue_or_rvalue<StreamReader> reader) {
         StreamReader::ReadObj(reader, this->bucket_count_);
         StreamReader::ReadObj(reader, this->code_size_);
+    }
+
+    virtual void
+    InitIO(const IOParamPtr& io_param) {
+        throw VsagException(ErrorType::INTERNAL_ERROR, "InitIO not implemented in BucketInterface");
     }
 
     virtual void

--- a/src/datacell/bucket_interface_factory.h
+++ b/src/datacell/bucket_interface_factory.h
@@ -37,4 +37,7 @@ MakeUringBucketDataCell(const BucketDataCellParamPtr& param, const IndexCommonPa
 BucketInterfacePtr
 MakeBufferBucketDataCell(const BucketDataCellParamPtr& param, const IndexCommonParam& common_param);
 
+BucketInterfacePtr
+MakeReaderBucketDataCell(const BucketDataCellParamPtr& param, const IndexCommonParam& common_param);
+
 }  // namespace vsag

--- a/src/datacell/bucket_interface_reader_io.cpp
+++ b/src/datacell/bucket_interface_reader_io.cpp
@@ -1,0 +1,27 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "bucket_interface_factory.h"
+#include "bucket_interface_factory_impl.h"
+#include "io/reader_io/reader_io.h"
+
+namespace vsag {
+
+BucketInterfacePtr
+MakeReaderBucketDataCell(const BucketDataCellParamPtr& param,
+                         const IndexCommonParam& common_param) {
+    return MakeBucketDataCellInstance<ReaderIO>(param, common_param);
+}
+
+}  // namespace vsag

--- a/src/factory/factory.cpp
+++ b/src/factory/factory.cpp
@@ -245,7 +245,15 @@ create_streaming_index_from_metadata(const MetadataPtr& metadata,
         return create_streaming_index<HGraph, HGraphParameter>(index_param, common_param);
     }
     if (index_name == INDEX_IVF) {
-        return create_streaming_index<IVF, IVFParameter>(index_param, common_param);
+        auto param = std::make_shared<IVFParameter>();
+        param->FromJson(index_param);
+        if (param->UsesDiskBackedPreciseBucket()) {
+            throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                                "Index::Load does not support disk-backed IVF precise buckets");
+        }
+        auto inner_index = std::make_shared<IVF>(param, common_param);
+        return streaming_index_load_target{
+            std::make_shared<IndexImpl<IVF>>(inner_index, common_param), inner_index};
     }
     if (index_name == INDEX_PYRAMID) {
         return create_streaming_index<Pyramid, PyramidParameters>(index_param, common_param);

--- a/src/factory/factory.cpp
+++ b/src/factory/factory.cpp
@@ -245,15 +245,7 @@ create_streaming_index_from_metadata(const MetadataPtr& metadata,
         return create_streaming_index<HGraph, HGraphParameter>(index_param, common_param);
     }
     if (index_name == INDEX_IVF) {
-        auto param = std::make_shared<IVFParameter>();
-        param->FromJson(index_param);
-        if (param->UsesDiskBackedPreciseBucket()) {
-            throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                                "Index::Load does not support disk-backed IVF precise buckets");
-        }
-        auto inner_index = std::make_shared<IVF>(param, common_param);
-        return streaming_index_load_target{
-            std::make_shared<IndexImpl<IVF>>(inner_index, common_param), inner_index};
+        return create_streaming_index<IVF, IVFParameter>(index_param, common_param);
     }
     if (index_name == INDEX_PYRAMID) {
         return create_streaming_index<Pyramid, PyramidParameters>(index_param, common_param);

--- a/src/factory/factory.cpp
+++ b/src/factory/factory.cpp
@@ -184,6 +184,46 @@ apply_hgraph_streaming_load_parameters(JsonType& index_param, const std::string&
     }
 }
 
+void
+apply_ivf_streaming_load_parameters(JsonType& index_param, const LoadParameters& parameters) {
+    constexpr const char* precise_reader_key = "precise_reader";
+    auto parameter_string = parameters.Dump();
+    auto load_json = JsonType::Parse(parameter_string.empty() ? "{}" : parameter_string);
+
+    const bool has_precise_reader = parameters.HasReader(precise_reader_key);
+    bool requests_reader_io = false;
+    if (load_json.Contains(IVF_PRECISE_IO_TYPE)) {
+        require_string_load_parameter(load_json, IVF_PRECISE_IO_TYPE);
+        CHECK_ARGUMENT(load_json[IVF_PRECISE_IO_TYPE].GetString() == IO_TYPE_VALUE_READER_IO,
+                       "IVF precise streaming load only supports reader_io");
+        requests_reader_io = true;
+    }
+    if (not has_precise_reader and not requests_reader_io) {
+        return;
+    }
+
+    CHECK_ARGUMENT(has_precise_reader, "IVF precise_io_type=reader_io requires precise_reader");
+    CHECK_ARGUMENT(parameters.GetReader(precise_reader_key) != nullptr, "precise_reader is null");
+    CHECK_ARGUMENT(requests_reader_io, "precise_reader requires precise_io_type=reader_io");
+    CHECK_ARGUMENT(index_param.Contains(USE_REORDER_KEY) && index_param[USE_REORDER_KEY].IsBool() &&
+                       index_param[USE_REORDER_KEY].GetBool(),
+                   "IVF precise_reader requires use_reorder=true");
+    set_streaming_io_override(index_param, PRECISE_CODES_KEY, IO_TYPE_VALUE_READER_IO, nullptr);
+
+    if (load_json.Contains(IVF_PRECISE_ENABLE_READ_CACHE)) {
+        CHECK_ARGUMENT(load_json[IVF_PRECISE_ENABLE_READ_CACHE].IsBool(),
+                       "precise_enable_read_cache must be a boolean");
+        index_param[PRECISE_CODES_KEY][IO_PARAMS_KEY][READ_CACHE_ENABLED_KEY].SetBool(
+            load_json[IVF_PRECISE_ENABLE_READ_CACHE].GetBool());
+    }
+    if (load_json.Contains(IVF_PRECISE_CACHE_TOTAL_SIZE)) {
+        CHECK_ARGUMENT(load_json[IVF_PRECISE_CACHE_TOTAL_SIZE].IsNumberUnsigned(),
+                       "precise_cache_total_size must be a non-negative integer");
+        index_param[PRECISE_CODES_KEY][IO_PARAMS_KEY][READ_CACHE_TOTAL_CACHE_SIZE_KEY].SetUint64(
+            load_json[IVF_PRECISE_CACHE_TOTAL_SIZE].GetUint64());
+    }
+}
+
 struct streaming_index_load_target {
     IndexPtr index;
     InnerIndexPtr inner_index;
@@ -200,7 +240,7 @@ create_streaming_index(const JsonType& index_param, const IndexCommonParam& comm
 
 tl::expected<streaming_index_load_target, Error>
 create_streaming_index_from_metadata(const MetadataPtr& metadata,
-                                     const std::string& parameters,
+                                     const LoadParameters& parameters,
                                      Allocator* allocator) {
     auto index_name_json = metadata->Get("index_name");
     if (!index_name_json.IsString()) {
@@ -241,10 +281,11 @@ create_streaming_index_from_metadata(const MetadataPtr& metadata,
         return create_streaming_index<BruteForce, BruteForceParameter>(index_param, common_param);
     }
     if (index_name == INDEX_HGRAPH) {
-        apply_hgraph_streaming_load_parameters(index_param, parameters);
+        apply_hgraph_streaming_load_parameters(index_param, parameters.Dump());
         return create_streaming_index<HGraph, HGraphParameter>(index_param, common_param);
     }
     if (index_name == INDEX_IVF) {
+        apply_ivf_streaming_load_parameters(index_param, parameters);
         return create_streaming_index<IVF, IVFParameter>(index_param, common_param);
     }
     if (index_name == INDEX_PYRAMID) {
@@ -406,7 +447,7 @@ Index::Load(std::istream& in_stream, const LoadParameters& parameters, Allocator
         ForwardStreamReader reader(in_stream);
         auto metadata = StreamHeader::Read(reader);
 
-        auto index = create_streaming_index_from_metadata(metadata, parameter_string, allocator);
+        auto index = create_streaming_index_from_metadata(metadata, parameters, allocator);
         if (not index.has_value()) {
             return tl::unexpected(index.error());
         }

--- a/src/impl/reorder/CMakeLists.txt
+++ b/src/impl/reorder/CMakeLists.txt
@@ -15,6 +15,8 @@
 
 
 set (REORDER_SRC
+        bucket_reorder.cpp
+        bucket_reorder.h
         flatten_reorder.cpp
         flatten_reorder.h
         reorder.h

--- a/src/impl/reorder/bucket_reorder.cpp
+++ b/src/impl/reorder/bucket_reorder.cpp
@@ -1,0 +1,97 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "bucket_reorder.h"
+
+#include <algorithm>
+#include <atomic>
+#include <cmath>
+
+#include "impl/heap/standard_heap.h"
+#include "impl/reasoning/search_reasoning.h"
+#include "query_context.h"
+#include "vsag_exception.h"
+
+namespace vsag {
+
+DistHeapPtr
+BucketReorder::Reorder(const DistHeapPtr& input,
+                       const void* query,
+                       int64_t topk,
+                       QueryContext& ctx,
+                       IteratorFilterContext* iter_ctx,
+                       const DistanceRecordVector* rabitq_lower_bound_candidates,
+                       const std::optional<float>& distance_threshold) {
+    if (iter_ctx != nullptr) {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "BucketReorder does not support iterator filtering");
+    }
+    if (rabitq_lower_bound_candidates != nullptr) {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "BucketReorder does not support RaBitQ lower-bound candidates");
+    }
+
+    Allocator* query_allocator = select_query_allocator(ctx.alloc, allocator_);
+    const uint64_t candidate_count = input == nullptr ? 0 : input->Size();
+    topk = std::min(topk, static_cast<int64_t>(candidate_count));
+    auto reorder_heap = std::make_shared<StandardHeap<true, false>>(query_allocator, topk);
+    if (candidate_count == 0 or topk == 0) {
+        return reorder_heap;
+    }
+
+    if (ctx.stats != nullptr) {
+        ctx.stats->reorder_distance_count.fetch_add(static_cast<uint32_t>(candidate_count),
+                                                    std::memory_order_relaxed);
+    }
+
+    auto computer = bucket_->FactoryComputer(query);
+    const auto* candidates = input->GetData();
+    Vector<BucketIdType> bucket_ids(candidate_count, query_allocator);
+    Vector<InnerIdType> offset_ids(candidate_count, query_allocator);
+    Vector<float> precise_distances(candidate_count, query_allocator);
+    for (uint64_t i = 0; i < candidate_count; ++i) {
+        const auto [bucket_id, offset_id] = location_resolver_(candidates[i].second);
+        bucket_ids[i] = bucket_id;
+        offset_ids[i] = offset_id;
+    }
+    bucket_->Query(precise_distances.data(),
+                   computer,
+                   bucket_ids.data(),
+                   offset_ids.data(),
+                   static_cast<InnerIdType>(candidate_count),
+                   &ctx);
+    for (uint64_t i = 0; i < candidate_count; ++i) {
+        const auto [coarse_distance, inner_id] = candidates[i];
+        const auto precise_distance = precise_distances[i];
+        if (ctx.reasoning_ctx != nullptr) {
+            ctx.reasoning_ctx->RecordReorder(inner_id, coarse_distance, precise_distance);
+        }
+        if (distance_threshold.has_value() and (not std::isfinite(precise_distance) or
+                                                precise_distance > distance_threshold.value())) {
+            continue;
+        }
+        if (reorder_heap->Size() < topk or precise_distance < reorder_heap->Top().first) {
+            reorder_heap->Push(precise_distance, inner_id);
+            if (reorder_heap->Size() > topk) {
+                if (ctx.reasoning_ctx != nullptr) {
+                    ctx.reasoning_ctx->RecordReorderEviction(reorder_heap->Top().second, 0);
+                }
+                reorder_heap->Pop();
+            }
+        }
+    }
+    return reorder_heap;
+}
+
+}  // namespace vsag

--- a/src/impl/reorder/bucket_reorder.h
+++ b/src/impl/reorder/bucket_reorder.h
@@ -1,0 +1,53 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <functional>
+#include <utility>
+
+#include "datacell/bucket_interface.h"
+#include "impl/reorder/reorder.h"
+
+namespace vsag {
+
+class BucketReorder final : public ReorderInterface {
+public:
+    using LocationResolver =
+        std::function<std::pair<BucketIdType, InnerIdType>(InnerIdType inner_id)>;
+
+    BucketReorder(BucketInterfacePtr bucket,
+                  LocationResolver location_resolver,
+                  Allocator* allocator)
+        : bucket_(std::move(bucket)),
+          location_resolver_(std::move(location_resolver)),
+          allocator_(allocator) {
+    }
+
+    DistHeapPtr
+    Reorder(const DistHeapPtr& input,
+            const void* query,
+            int64_t topk,
+            QueryContext& ctx,
+            IteratorFilterContext* iter_ctx = nullptr,
+            const DistanceRecordVector* rabitq_lower_bound_candidates = nullptr,
+            const std::optional<float>& distance_threshold = std::nullopt) override;
+
+private:
+    const BucketInterfacePtr bucket_;
+    const LocationResolver location_resolver_;
+    Allocator* allocator_{nullptr};
+};
+
+}  // namespace vsag

--- a/src/impl/reorder/bucket_reorder_test.cpp
+++ b/src/impl/reorder/bucket_reorder_test.cpp
@@ -1,0 +1,127 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "bucket_reorder.h"
+
+#include <limits>
+#include <memory>
+#include <optional>
+#include <utility>
+#include <vector>
+
+#include "datacell/bucket_datacell_parameter.h"
+#include "impl/filter/iterator_filter.h"
+#include "impl/heap/standard_heap.h"
+#include "index_common_param.h"
+#include "io/memory_io/memory_io_parameter.h"
+#include "quantization/fp32_quantizer_parameter.h"
+#include "query_context.h"
+#include "unittest.h"
+#include "vsag/engine.h"
+#include "vsag_exception.h"
+
+namespace vsag {
+
+TEST_CASE("BucketReorder reranks bucket locations", "[ut][reorder][bucket]") {
+    auto allocator = Engine::CreateDefaultAllocator();
+    auto bucket_param = std::make_shared<BucketDataCellParameter>();
+    bucket_param->quantizer_parameter = std::make_shared<FP32QuantizerParameter>();
+    bucket_param->io_parameter = std::make_shared<MemoryIOParameter>();
+    bucket_param->buckets_count = 2;
+
+    IndexCommonParam common_param;
+    common_param.allocator_ = allocator;
+    common_param.metric_ = MetricType::METRIC_TYPE_L2SQR;
+    common_param.dim_ = 1;
+    auto bucket = BucketInterface::MakeInstance(bucket_param, common_param);
+
+    float vectors[] = {std::numeric_limits<float>::quiet_NaN(), 1.0F, 2.0F, 3.0F};
+    bucket->Train(vectors, 4);
+    bucket->InsertVector(vectors, 0, 0);
+    bucket->InsertVector(vectors + 1, 1, 1);
+    bucket->InsertVector(vectors + 2, 0, 2);
+    bucket->InsertVector(vectors + 3, 1, 3);
+
+    std::vector<std::pair<BucketIdType, InnerIdType>> locations{{0, 0}, {1, 0}, {0, 1}, {1, 1}};
+    std::vector<InnerIdType> resolved_ids;
+    BucketReorder reorder(
+        bucket,
+        [&locations, &resolved_ids](InnerIdType inner_id) {
+            resolved_ids.emplace_back(inner_id);
+            return locations[inner_id];
+        },
+        allocator.get());
+
+    auto candidates = std::make_shared<StandardHeap<true, false>>(allocator.get(), -1);
+    candidates->Push(20.0F, 2);
+    candidates->Push(40.0F, 0);
+    candidates->Push(10.0F, 3);
+    candidates->Push(30.0F, 1);
+    std::vector<InnerIdType> candidate_order;
+    for (uint64_t i = 0; i < candidates->Size(); ++i) {
+        candidate_order.emplace_back(candidates->GetData()[i].second);
+    }
+
+    float query = 0.0F;
+    SearchStatistics stats;
+    QueryContext ctx{.alloc = allocator.get(), .stats = &stats};
+    auto result =
+        reorder.Reorder(candidates, &query, 2, ctx, nullptr, nullptr, std::optional<float>{4.0F});
+
+    REQUIRE(resolved_ids == candidate_order);
+    REQUIRE(stats.reorder_distance_count.load(std::memory_order_relaxed) == candidates->Size());
+    REQUIRE(result->Size() == 2);
+    REQUIRE(result->Top().second == 2);
+    REQUIRE(result->Top().first == 4.0F);
+    result->Pop();
+    REQUIRE(result->Top().second == 1);
+    REQUIRE(result->Top().first == 1.0F);
+
+    SECTION("resolver observes updated locations") {
+        locations[3] = locations[2];
+        auto remapped_candidate = std::make_shared<StandardHeap<true, false>>(allocator.get(), -1);
+        remapped_candidate->Push(1.0F, 3);
+        QueryContext remapped_ctx{.alloc = allocator.get()};
+        auto remapped = reorder.Reorder(remapped_candidate, &query, 1, remapped_ctx);
+        REQUIRE(remapped->Size() == 1);
+        REQUIRE(remapped->Top().second == 3);
+        REQUIRE(remapped->Top().first == 4.0F);
+    }
+
+    SECTION("unsupported optional inputs are rejected") {
+        auto require_unsupported = [](const auto& operation) {
+            try {
+                operation();
+                FAIL("unsupported BucketReorder input should be rejected");
+            } catch (const VsagException& error) {
+                REQUIRE(error.error_.type == ErrorType::UNSUPPORTED_INDEX_OPERATION);
+            }
+        };
+
+        IteratorFilterContext iter_ctx;
+        QueryContext iter_query_ctx{.alloc = allocator.get()};
+        require_unsupported(
+            [&]() { (void)reorder.Reorder(candidates, &query, 1, iter_query_ctx, &iter_ctx); });
+
+        DistanceRecordVector lower_bound_candidates(allocator.get());
+        lower_bound_candidates.emplace_back(0.0F, 0);
+        QueryContext lower_bound_query_ctx{.alloc = allocator.get()};
+        require_unsupported([&]() {
+            (void)reorder.Reorder(
+                candidates, &query, 1, lower_bound_query_ctx, nullptr, &lower_bound_candidates);
+        });
+    }
+}
+
+}  // namespace vsag

--- a/src/inner_string_params.h
+++ b/src/inner_string_params.h
@@ -38,6 +38,9 @@ const char* const BUILD_THREAD_COUNT_KEY = "build_thread_count";
 const char* const LABEL_REMAP_TYPE_KEY = "label_remap_type";
 const char* const BASE_CODES_KEY = "base_codes";
 const char* const PRECISE_CODES_KEY = "precise_codes";
+const char* const PRECISE_CODES_LAYOUT_KEY = "precise_codes_layout";
+const char* const PRECISE_CODES_LAYOUT_VALUE_FLAT = "flat";
+const char* const PRECISE_CODES_LAYOUT_VALUE_BUCKET = "bucket";
 const char* const STORE_RAW_VECTOR_KEY = "store_raw_vector";
 const char* const RAW_VECTOR_KEY = "raw_vector";
 const char* const ATTR_HAS_BUCKETS_KEY = "has_buckets";
@@ -225,6 +228,9 @@ const std::unordered_map<std::string, std::string> DEFAULT_MAP = {
     {"GRAPH_KEY", GRAPH_KEY},
     {"BASE_CODES_KEY", BASE_CODES_KEY},
     {"PRECISE_CODES_KEY", PRECISE_CODES_KEY},
+    {"PRECISE_CODES_LAYOUT_KEY", PRECISE_CODES_LAYOUT_KEY},
+    {"PRECISE_CODES_LAYOUT_VALUE_FLAT", PRECISE_CODES_LAYOUT_VALUE_FLAT},
+    {"PRECISE_CODES_LAYOUT_VALUE_BUCKET", PRECISE_CODES_LAYOUT_VALUE_BUCKET},
     {"HGRAPH_SUPPORT_DUPLICATE", HGRAPH_SUPPORT_DUPLICATE},
     {"HGRAPH_DEDUPLICATE_STORAGE", HGRAPH_DEDUPLICATE_STORAGE},
     {"HGRAPH_DUPLICATE_DISTANCE_THRESHOLD", HGRAPH_DUPLICATE_DISTANCE_THRESHOLD},

--- a/src/inner_string_params.h
+++ b/src/inner_string_params.h
@@ -38,6 +38,9 @@ const char* const BUILD_THREAD_COUNT_KEY = "build_thread_count";
 const char* const LABEL_REMAP_TYPE_KEY = "label_remap_type";
 const char* const BASE_CODES_KEY = "base_codes";
 const char* const PRECISE_CODES_KEY = "precise_codes";
+const char* const PRECISE_CODES_LAYOUT_KEY = "precise_codes_layout";
+const char* const PRECISE_CODES_LAYOUT_VALUE_FLAT = "flat";
+const char* const PRECISE_CODES_LAYOUT_VALUE_BUCKET = "bucket";
 const char* const STORE_RAW_VECTOR_KEY = "store_raw_vector";
 const char* const RAW_VECTOR_KEY = "raw_vector";
 const char* const ATTR_HAS_BUCKETS_KEY = "has_buckets";
@@ -226,6 +229,9 @@ const std::unordered_map<std::string, std::string> DEFAULT_MAP = {
     {"GRAPH_KEY", GRAPH_KEY},
     {"BASE_CODES_KEY", BASE_CODES_KEY},
     {"PRECISE_CODES_KEY", PRECISE_CODES_KEY},
+    {"PRECISE_CODES_LAYOUT_KEY", PRECISE_CODES_LAYOUT_KEY},
+    {"PRECISE_CODES_LAYOUT_VALUE_FLAT", PRECISE_CODES_LAYOUT_VALUE_FLAT},
+    {"PRECISE_CODES_LAYOUT_VALUE_BUCKET", PRECISE_CODES_LAYOUT_VALUE_BUCKET},
     {"HGRAPH_SUPPORT_DUPLICATE", HGRAPH_SUPPORT_DUPLICATE},
     {"HGRAPH_DEDUPLICATE_STORAGE", HGRAPH_DEDUPLICATE_STORAGE},
     {"HGRAPH_DUPLICATE_DISTANCE_THRESHOLD", HGRAPH_DUPLICATE_DISTANCE_THRESHOLD},

--- a/src/io/common/basic_io.h
+++ b/src/io/common/basic_io.h
@@ -348,14 +348,33 @@ public:
         if constexpr (not InMemory) {
             if (io_param == nullptr or not io_param->enable_read_cache_) {
                 cache_.reset();
+                cache_page_id_base_ = 0;
                 return;
             }
             auto page_count = io_param->read_cache_total_size_ / Page::DEFAULT_PAGE_SIZE;
             if (page_count == 0) {
                 cache_.reset();
+                cache_page_id_base_ = 0;
                 return;
             }
-            cache_ = std::make_unique<LRUPageCache>(page_count);
+            cache_ = std::make_shared<LRUPageCache>(page_count);
+            cache_page_id_base_ = 0;
+        }
+    }
+
+    /**
+     * @brief Replaces this IO's read cache with a shared cache.
+     *
+     * The page id base gives each logical IO a disjoint key range in the shared cache.
+     * Passing nullptr detaches the current cache without clearing caches shared by other IOs.
+     * This is intended for read-only logical IO views initialized before queries start.
+     */
+    void
+    SetReadCache(const std::shared_ptr<PageCache>& cache, uint64_t page_id_base = 0) {
+        if constexpr (not InMemory) {
+            std::scoped_lock<std::mutex> lock(cache_mutex_);
+            cache_ = cache;
+            cache_page_id_base_ = page_id_base;
         }
     }
 
@@ -462,7 +481,11 @@ private:
             return nullptr;
         }
         std::scoped_lock<std::mutex> lock(cache_mutex_);
-        auto page = cache_->Get(page_id);
+        if (page_id > UINT64_MAX - cache_page_id_base_) {
+            return nullptr;
+        }
+        uint64_t cache_page_id = cache_page_id_base_ + page_id;
+        auto page = cache_->Get(cache_page_id);
         if (page != nullptr) {
             return page;
         }
@@ -474,7 +497,7 @@ private:
         if (not cast().ReadImpl(read_size, offset, new_page->Data())) {
             return nullptr;
         }
-        return cache_->Insert(page_id, std::move(new_page));
+        return cache_->Insert(cache_page_id, std::move(new_page));
     }
 
     void
@@ -489,8 +512,15 @@ private:
         }
         uint64_t first_page = offset / Page::DEFAULT_PAGE_SIZE;
         uint64_t last_page = (offset + size - 1) / Page::DEFAULT_PAGE_SIZE;
-        for (uint64_t page_id = first_page; page_id <= last_page; ++page_id) {
-            cache_->Remove(page_id);
+        if (last_page > UINT64_MAX - cache_page_id_base_) {
+            cache_->Clear();
+            return;
+        }
+        for (uint64_t page_id = first_page;; ++page_id) {
+            cache_->Remove(cache_page_id_base_ + page_id);
+            if (page_id == last_page) {
+                break;
+            }
         }
     }
 
@@ -508,7 +538,8 @@ private:
     static constexpr uint64_t SERIALIZE_BUFFER_SIZE = 1024 * 1024 * 2;
 
     mutable std::mutex cache_mutex_;
-    mutable std::unique_ptr<PageCache> cache_;
+    mutable std::shared_ptr<PageCache> cache_;
+    uint64_t cache_page_id_base_{0};
     bool has_deserialized_{false};
 
 private:

--- a/src/io/container/io_array.h
+++ b/src/io/container/io_array.h
@@ -25,8 +25,8 @@ class Allocator;
  * @brief Container for managing multiple IO objects with delayed creation.
  *
  * This template class manages a dynamic array of IO objects, creating them
- * on-demand when the array is resized. It supports both in-memory and file-based
- * IO implementations, with special handling for non-continuous storage allocation.
+ * on-demand when the array is resized. It supports in-memory and read-only IO
+ * implementations directly, with special handling for writable file-based storage.
  *
  * @tparam IOTmpl The type of IO object to manage (e.g., MemoryIO, BufferIO).
  */
@@ -52,7 +52,7 @@ public:
         non_continuous_allocator_ = std::make_unique<NonContinuousAllocator>(allocator);
         using ArgsTuple = std::tuple<std::decay_t<Args>...>;
         ArgsTuple args_tuple(std::forward<Args>(args)...);
-        if constexpr (InMemory) {
+        if constexpr (InMemory or IOTmpl::SkipDeserialize) {
             io_create_func_ = [args_tuple =
                                    std::move(args_tuple)]() mutable -> std::shared_ptr<IOTmpl> {
                 return std::apply(

--- a/src/io/noncontinuous_io/noncontinuous_allocator.h
+++ b/src/io/noncontinuous_io/noncontinuous_allocator.h
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <cstdint>
 
 namespace vsag {
@@ -83,8 +84,8 @@ public:
     Require(uint64_t size) {
         // 4k align
         size = (size + ALOGN_SIZE - 1) & ~(ALOGN_SIZE - 1);
-        NonContinuousArea area{last_offset_, size};
-        last_offset_ += size;
+        auto offset = last_offset_.fetch_add(size, std::memory_order_relaxed);
+        NonContinuousArea area{offset, size};
         return area;
     }
 
@@ -93,7 +94,7 @@ private:
     Allocator* const allocator_{nullptr};
 
     /// Last allocated offset for tracking non-overlapping areas.
-    uint64_t last_offset_{0};
+    std::atomic<uint64_t> last_offset_{0};
 
     /// Alignment size for area allocation (4KB).
     static constexpr uint64_t ALOGN_SIZE = 4096;

--- a/src/io/noncontinuous_io/noncontinuous_io.h
+++ b/src/io/noncontinuous_io/noncontinuous_io.h
@@ -173,12 +173,61 @@ public:
      */
     bool
     MultiReadImpl(uint8_t* datas, uint64_t* sizes, uint64_t* offsets, uint64_t count) const {
-        bool ret = true;
-        for (uint64_t i = 0; i < count; i++) {
-            ret &= this->ReadImpl(sizes[i], offsets[i], datas);
-            datas += sizes[i];
+        if (count == 0) {
+            return true;
         }
-        return ret;
+        if (sizes == nullptr or offsets == nullptr) {
+            return false;
+        }
+
+        bool has_data = false;
+        for (uint64_t i = 0; i < count; ++i) {
+            if (offsets[i] > this->size_ or sizes[i] > this->size_ - offsets[i]) {
+                return false;
+            }
+            has_data |= sizes[i] > 0;
+        }
+        if (not has_data) {
+            return true;
+        }
+        if (datas == nullptr) {
+            return false;
+        }
+
+        std::vector<uint64_t> physical_sizes;
+        std::vector<uint64_t> physical_offsets;
+        physical_sizes.reserve(count);
+        physical_offsets.reserve(count);
+        for (uint64_t i = 0; i < count; ++i) {
+            uint64_t remaining_size = sizes[i];
+            uint64_t logical_offset = offsets[i];
+            if (remaining_size == 0) {
+                continue;
+            }
+
+            auto area_it = this->get_area(logical_offset);
+            while (remaining_size > 0) {
+                if (area_it == areas_.end()) {
+                    return false;
+                }
+                const auto& area = area_it->first;
+                uint64_t logical_area_start = area_it->second - area.size;
+                if (logical_offset < logical_area_start or logical_offset >= area_it->second) {
+                    return false;
+                }
+                uint64_t fragment_size = std::min(remaining_size, area_it->second - logical_offset);
+                physical_sizes.emplace_back(fragment_size);
+                physical_offsets.emplace_back(area.offset + logical_offset - logical_area_start);
+                logical_offset += fragment_size;
+                remaining_size -= fragment_size;
+                ++area_it;
+            }
+        }
+
+        return inner_io_->MultiRead(datas,
+                                    physical_sizes.data(),
+                                    physical_offsets.data(),
+                                    static_cast<uint64_t>(physical_sizes.size()));
     }
 
     /**

--- a/src/io/noncontinuous_io/noncontinuous_io_test.cpp
+++ b/src/io/noncontinuous_io/noncontinuous_io_test.cpp
@@ -15,6 +15,11 @@
 
 #include "io/noncontinuous_io/noncontinuous_io.h"
 
+#include <algorithm>
+#include <atomic>
+#include <thread>
+#include <vector>
+
 #include "impl/allocator/safe_allocator.h"
 #include "io/async_io/async_io.h"
 #include "io/buffer_io/buffer_io.h"
@@ -88,4 +93,51 @@ TEST_CASE("NonContinuousIO Serialize Test", "[NonContinuousIO][ut]") {
     NonContinuousIOTestSerialize<MMapIO>();
     NonContinuousIOTestSerialize<BufferIO>();
     NonContinuousIOTestSerialize<AsyncIO>();
+}
+
+TEST_CASE("NonContinuousAllocator allocates unique regions concurrently",
+          "[NonContinuousIO][ut][concurrent]") {
+    constexpr uint64_t thread_count = 16;
+    constexpr uint64_t allocations_per_thread = 4096;
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    NonContinuousAllocator non_continuous_allocator(allocator.get());
+    std::atomic<uint64_t> ready{0};
+    std::atomic<bool> start{false};
+    std::vector<std::vector<NonContinuousArea>> thread_areas(thread_count);
+    std::vector<std::thread> threads;
+    threads.reserve(thread_count);
+
+    for (uint64_t thread_id = 0; thread_id < thread_count; ++thread_id) {
+        threads.emplace_back([&, thread_id]() {
+            auto& areas = thread_areas[thread_id];
+            areas.reserve(allocations_per_thread);
+            ready.fetch_add(1, std::memory_order_release);
+            while (not start.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+            for (uint64_t i = 0; i < allocations_per_thread; ++i) {
+                areas.emplace_back(non_continuous_allocator.Require(1));
+            }
+        });
+    }
+
+    while (ready.load(std::memory_order_acquire) != thread_count) {
+        std::this_thread::yield();
+    }
+    start.store(true, std::memory_order_release);
+    for (auto& thread : threads) {
+        thread.join();
+    }
+
+    std::vector<NonContinuousArea> areas;
+    areas.reserve(thread_count * allocations_per_thread);
+    for (const auto& thread_area : thread_areas) {
+        areas.insert(areas.end(), thread_area.begin(), thread_area.end());
+    }
+    std::sort(areas.begin(), areas.end(), [](const auto& lhs, const auto& rhs) {
+        return lhs.offset < rhs.offset;
+    });
+    for (uint64_t i = 1; i < areas.size(); ++i) {
+        REQUIRE(areas[i - 1].offset + areas[i - 1].size <= areas[i].offset);
+    }
 }

--- a/src/io/noncontinuous_io/noncontinuous_io_test.cpp
+++ b/src/io/noncontinuous_io/noncontinuous_io_test.cpp
@@ -17,6 +17,9 @@
 
 #include <algorithm>
 #include <atomic>
+#include <cstring>
+#include <limits>
+#include <memory>
 #include <thread>
 #include <vector>
 
@@ -27,6 +30,48 @@
 #include "io/mmap_io/mmap_io.h"
 #include "unittest.h"
 namespace vsag {
+struct TrackingIOState {
+    std::vector<uint8_t> data_;
+    uint64_t multi_read_calls_{0};
+    std::vector<uint64_t> last_sizes_;
+    std::vector<uint64_t> last_offsets_;
+};
+
+class TrackingIO : public BasicIO<TrackingIO> {
+public:
+    static constexpr bool InMemory = true;
+    static constexpr bool SkipDeserialize = false;
+
+    TrackingIO(std::shared_ptr<TrackingIOState> state, Allocator* allocator)
+        : BasicIO<TrackingIO>(allocator), state_(std::move(state)) {
+    }
+
+    void
+    WriteImpl(const uint8_t* data, uint64_t size, uint64_t offset) {
+        state_->data_.resize(std::max<uint64_t>(state_->data_.size(), offset + size));
+        std::memcpy(state_->data_.data() + offset, data, size);
+        this->size_ = std::max(this->size_, offset + size);
+    }
+
+    bool
+    MultiReadImpl(uint8_t* datas, uint64_t* sizes, uint64_t* offsets, uint64_t count) const {
+        ++state_->multi_read_calls_;
+        state_->last_sizes_.assign(sizes, sizes + count);
+        state_->last_offsets_.assign(offsets, offsets + count);
+        for (uint64_t i = 0; i < count; ++i) {
+            if (offsets[i] > state_->data_.size() or sizes[i] > state_->data_.size() - offsets[i]) {
+                return false;
+            }
+            std::memcpy(datas, state_->data_.data() + offsets[i], sizes[i]);
+            datas += sizes[i];
+        }
+        return true;
+    }
+
+private:
+    std::shared_ptr<TrackingIOState> state_;
+};
+
 template <typename IOTmpl>
 class NonContinuousIOTest {
 public:
@@ -93,6 +138,95 @@ TEST_CASE("NonContinuousIO Serialize Test", "[NonContinuousIO][ut]") {
     NonContinuousIOTestSerialize<MMapIO>();
     NonContinuousIOTestSerialize<BufferIO>();
     NonContinuousIOTestSerialize<AsyncIO>();
+}
+
+TEST_CASE("NonContinuousIO batches physical fragments", "[NonContinuousIO][ut]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    auto non_continuous_allocator = std::make_unique<NonContinuousAllocator>(allocator.get());
+    auto state = std::make_shared<TrackingIOState>();
+    NonContinuousIOTest<TrackingIO> test;
+    std::unique_ptr<NonContinuousIO<TrackingIO>> io(test.CreateNonContinuousIO(
+        non_continuous_allocator.get(), allocator.get(), state, allocator.get()));
+    std::unique_ptr<NonContinuousIO<TrackingIO>> spacer(test.CreateNonContinuousIO(
+        non_continuous_allocator.get(), allocator.get(), state, allocator.get()));
+
+    constexpr uint64_t page_size = 4096;
+    std::vector<uint8_t> logical_data(page_size * 3);
+    for (uint64_t i = 0; i < logical_data.size(); ++i) {
+        logical_data[i] = static_cast<uint8_t>(i % 251);
+    }
+    std::vector<uint8_t> spacer_data(page_size, 0xFF);
+    io->Write(logical_data.data(), page_size, 0);
+    spacer->Write(spacer_data.data(), page_size, 0);
+    io->Write(logical_data.data() + page_size, page_size, page_size);
+    spacer->Write(spacer_data.data(), page_size, page_size);
+    io->Write(logical_data.data() + page_size * 2, page_size, page_size * 2);
+
+    std::vector<uint64_t> sizes{12, 0, 5, 12, 8};
+    std::vector<uint64_t> offsets{
+        page_size * 2 - 4, page_size * 3, 7, page_size * 2 - 4, page_size - 2};
+    std::vector<uint8_t> output(37);
+    REQUIRE(io->MultiRead(output.data(), sizes.data(), offsets.data(), sizes.size()));
+
+    std::vector<uint8_t> expected;
+    expected.reserve(output.size());
+    for (uint64_t i = 0; i < sizes.size(); ++i) {
+        expected.insert(expected.end(),
+                        logical_data.begin() + offsets[i],
+                        logical_data.begin() + offsets[i] + sizes[i]);
+    }
+    REQUIRE(output == expected);
+    REQUIRE(state->multi_read_calls_ == 1);
+    REQUIRE(state->last_sizes_ == std::vector<uint64_t>{4, 8, 5, 4, 8, 2, 6});
+    REQUIRE(state->last_offsets_ == std::vector<uint64_t>{page_size * 3 - 4,
+                                                          page_size * 4,
+                                                          7,
+                                                          page_size * 3 - 4,
+                                                          page_size * 4,
+                                                          page_size - 2,
+                                                          page_size * 2});
+}
+
+TEST_CASE("NonContinuousIO validates batch ranges and empty reads", "[NonContinuousIO][ut]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    auto non_continuous_allocator = std::make_unique<NonContinuousAllocator>(allocator.get());
+    auto state = std::make_shared<TrackingIOState>();
+    NonContinuousIOTest<TrackingIO> test;
+    std::unique_ptr<NonContinuousIO<TrackingIO>> io(test.CreateNonContinuousIO(
+        non_continuous_allocator.get(), allocator.get(), state, allocator.get()));
+
+    constexpr uint64_t page_size = 4096;
+    std::vector<uint8_t> data(page_size, 0x5A);
+    io->Write(data.data(), data.size(), 0);
+
+    REQUIRE(io->MultiRead(nullptr, nullptr, nullptr, 0));
+    REQUIRE(state->multi_read_calls_ == 0);
+
+    std::vector<uint64_t> empty_sizes{0, 0, 0};
+    std::vector<uint64_t> empty_offsets{0, page_size / 2, page_size};
+    REQUIRE(io->MultiRead(nullptr, empty_sizes.data(), empty_offsets.data(), empty_sizes.size()));
+    REQUIRE(state->multi_read_calls_ == 0);
+
+    std::vector<uint64_t> invalid_sizes{4, 1};
+    std::vector<uint64_t> invalid_offsets{0, page_size};
+    std::vector<uint8_t> output(5, 0xA5);
+    REQUIRE_FALSE(io->MultiRead(
+        output.data(), invalid_sizes.data(), invalid_offsets.data(), invalid_sizes.size()));
+    REQUIRE(output == std::vector<uint8_t>(5, 0xA5));
+    REQUIRE(state->multi_read_calls_ == 0);
+
+    uint64_t overflow_size = 16;
+    uint64_t overflow_offset = std::numeric_limits<uint64_t>::max() - 7;
+    REQUIRE_FALSE(io->MultiRead(&output[0], &overflow_size, &overflow_offset, 1));
+    REQUIRE(state->multi_read_calls_ == 0);
+
+    uint64_t zero_size = 0;
+    uint64_t past_end_offset = page_size + 1;
+    REQUIRE_FALSE(io->MultiRead(nullptr, &zero_size, &past_end_offset, 1));
+    REQUIRE_FALSE(io->MultiRead(nullptr, &overflow_size, &zero_size, 1));
+    REQUIRE_FALSE(io->MultiRead(output.data(), nullptr, &zero_size, 1));
+    REQUIRE_FALSE(io->MultiRead(output.data(), &zero_size, nullptr, 1));
+    REQUIRE(state->multi_read_calls_ == 0);
 }
 
 TEST_CASE("NonContinuousAllocator allocates unique regions concurrently",

--- a/src/storage/serialization_tags.h
+++ b/src/storage/serialization_tags.h
@@ -40,6 +40,7 @@ enum class StreamSerializationTag : uint32_t {
     PYRAMID_HIERARCHIES = 14,
     CODE_SLOT_MAP = 15,
     IVF_BUCKET_GRAPH = 16,
+    IVF_PRECISE_BUCKET = 17,
 };
 
 inline const char*
@@ -79,6 +80,8 @@ StreamSerializationTagName(uint32_t tag) {
             return "code_slot_map";
         case StreamSerializationTag::IVF_BUCKET_GRAPH:
             return "ivf_bucket_graph";
+        case StreamSerializationTag::IVF_PRECISE_BUCKET:
+            return "ivf_precise_bucket";
     }
     return "unknown";
 }
@@ -100,6 +103,7 @@ StreamSerializationTagCritical(uint32_t tag) {
         case StreamSerializationTag::SINDI_TERM_ID_MAPPER:
         case StreamSerializationTag::PYRAMID_HIERARCHIES:
         case StreamSerializationTag::CODE_SLOT_MAP:
+        case StreamSerializationTag::IVF_PRECISE_BUCKET:
             return true;
         case StreamSerializationTag::ATTRIBUTE_FILTER:
         case StreamSerializationTag::EXTRA_INFO:
@@ -131,6 +135,7 @@ StreamSerializationBlockCurrentVersion(uint32_t tag) {
         case StreamSerializationTag::SINDI_TERM_ID_MAPPER:
         case StreamSerializationTag::PYRAMID_HIERARCHIES:
         case StreamSerializationTag::CODE_SLOT_MAP:
+        case StreamSerializationTag::IVF_PRECISE_BUCKET:
             return kStreamSerializationBlockVersionV1;
         case StreamSerializationTag::IVF_BUCKET_GRAPH:
             return kStreamSerializationBlockVersionV1;

--- a/src/storage/streaming_serialization_test.cpp
+++ b/src/storage/streaming_serialization_test.cpp
@@ -12,14 +12,55 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstring>
 #include <limits>
+#include <memory>
 #include <sstream>
+#include <string>
+#include <utility>
 
 #include "serialization.h"
 #include "serialization_tags.h"
 #include "tlv_section.h"
 #include "unittest.h"
 #include "vsag/options.h"
+#include "vsag_exception.h"
+
+namespace {
+
+class StringReader : public vsag::Reader {
+public:
+    explicit StringReader(std::string data) : data_(std::move(data)) {
+    }
+
+    void
+    Read(uint64_t offset, uint64_t len, void* dest) override {
+        if (offset > data_.size() or len > data_.size() - offset) {
+            throw vsag::VsagException(vsag::ErrorType::READ_ERROR, "read exceeds string");
+        }
+        std::memcpy(dest, data_.data() + offset, len);
+    }
+
+    void
+    AsyncRead(uint64_t offset, uint64_t len, void* dest, vsag::CallBack callback) override {
+        try {
+            Read(offset, len, dest);
+            callback(vsag::IOErrorCode::IO_SUCCESS, "success");
+        } catch (const std::exception& error) {
+            callback(vsag::IOErrorCode::IO_ERROR, error.what());
+        }
+    }
+
+    [[nodiscard]] uint64_t
+    Size() const override {
+        return data_.size();
+    }
+
+private:
+    std::string data_;
+};
+
+}  // namespace
 
 TEST_CASE("StreamHeader", "[ut][streaming_serialization]") {
     auto metadata = std::make_shared<vsag::Metadata>();
@@ -170,6 +211,28 @@ TEST_CASE("ReadSeekableBlockPayload rejects cursor past spilled payload",
         }));
 
     vsag::Options::Instance().set_block_size_limit(origin_size);
+}
+
+TEST_CASE("ReadExternalBlockPayload validates checksum before deserializing",
+          "[ut][streaming_serialization]") {
+    const std::string payload = "abcdefgh";
+    auto corrupted = payload;
+    corrupted[3] = 'x';
+    auto reader = std::make_shared<StringReader>(std::move(corrupted));
+    vsag::StreamBlockHeader header;
+    header.value_len = payload.size();
+    header.payload_checksum = vsag::StreamHeader::CalculateChecksum(payload);
+    bool deserialize_called = false;
+
+    try {
+        vsag::ReadExternalBlockPayload(reader, header, [&deserialize_called](vsag::StreamReader&) {
+            deserialize_called = true;
+        });
+        FAIL("corrupted external payload should be rejected");
+    } catch (const vsag::VsagException& error) {
+        REQUIRE(error.error_.type == vsag::ErrorType::INVALID_BINARY);
+    }
+    REQUIRE_FALSE(deserialize_called);
 }
 
 TEST_CASE("ValidateAndSkipBlockPayload", "[ut][streaming_serialization]") {

--- a/src/storage/tlv_section.cpp
+++ b/src/storage/tlv_section.cpp
@@ -337,7 +337,7 @@ ReadExternalBlockPayload(const ReaderPtr& reader,
                         header.value_len));
     }
 
-    constexpr uint64_t checksum_buffer_size = 1024 * 1024;
+    constexpr uint64_t checksum_buffer_size = uint64_t{1024} * 1024;
     std::vector<char> checksum_buffer(
         static_cast<size_t>(std::min(header.value_len, checksum_buffer_size)));
     uint32_t crc = StreamHeader::InitialChecksum();

--- a/src/storage/tlv_section.cpp
+++ b/src/storage/tlv_section.cpp
@@ -14,6 +14,8 @@
 
 #include "tlv_section.h"
 
+#include <fmt/format.h>
+
 #include <algorithm>
 #include <array>
 #include <cstdio>
@@ -318,6 +320,50 @@ ReadSeekableBlockPayload(StreamReader& reader,
     ReadFuncStreamReader block_reader(read_func, 0, header.value_len);
     deserialize(block_reader);
     validate_seekable_block_cursor(block_reader, header);
+}
+
+void
+ReadExternalBlockPayload(const ReaderPtr& reader,
+                         const StreamBlockHeader& header,
+                         const std::function<void(StreamReader&)>& deserialize) {
+    if (reader == nullptr) {
+        throw VsagException(ErrorType::INVALID_ARGUMENT, "external block reader is null");
+    }
+    if (reader->Size() != header.value_len) {
+        throw VsagException(
+            ErrorType::INVALID_ARGUMENT,
+            fmt::format("external reader size {} does not match streaming block payload size {}",
+                        reader->Size(),
+                        header.value_len));
+    }
+
+    constexpr uint64_t checksum_buffer_size = 1024 * 1024;
+    std::vector<char> checksum_buffer(
+        static_cast<size_t>(std::min(header.value_len, checksum_buffer_size)));
+    uint32_t crc = StreamHeader::InitialChecksum();
+    uint64_t checksum_offset = 0;
+    while (checksum_offset < header.value_len) {
+        const auto read_size = std::min(checksum_buffer_size, header.value_len - checksum_offset);
+        reader->Read(checksum_offset, read_size, checksum_buffer.data());
+        crc = StreamHeader::UpdateChecksum(
+            crc, std::string_view(checksum_buffer.data(), static_cast<size_t>(read_size)));
+        checksum_offset += read_size;
+    }
+    if (StreamHeader::FinalizeChecksum(crc) != header.payload_checksum) {
+        throw VsagException(ErrorType::INVALID_BINARY, "streaming block payload checksum mismatch");
+    }
+
+    auto read_func = [reader, payload_size = header.value_len](
+                         uint64_t offset, uint64_t size, void* dest) {
+        if (offset > payload_size or size > payload_size - offset) {
+            throw VsagException(ErrorType::READ_ERROR,
+                                "external block reader exceeds payload boundary");
+        }
+        reader->Read(offset, size, dest);
+    };
+    ReadFuncStreamReader external_reader(read_func, 0, header.value_len);
+    deserialize(external_reader);
+    validate_seekable_block_cursor(external_reader, header);
 }
 
 }  // namespace vsag

--- a/src/storage/tlv_section.h
+++ b/src/storage/tlv_section.h
@@ -19,6 +19,7 @@
 
 #include "stream_reader.h"
 #include "stream_writer.h"
+#include "vsag/readerset.h"
 
 namespace vsag {
 
@@ -66,6 +67,11 @@ ValidateAndSkipBlockPayload(StreamReader& reader, const StreamBlockHeader& heade
 
 void
 ReadSeekableBlockPayload(StreamReader& reader,
+                         const StreamBlockHeader& header,
+                         const std::function<void(StreamReader&)>& deserialize);
+
+void
+ReadExternalBlockPayload(const ReaderPtr& reader,
                          const StreamBlockHeader& header,
                          const std::function<void(StreamReader&)>& deserialize);
 

--- a/tests/test_ivf.cpp
+++ b/tests/test_ivf.cpp
@@ -212,12 +212,17 @@ private:
 std::string
 GenerateBucketPreciseParameters(const std::string& precise_io_type = "block_memory_io",
                                 const std::string& precise_file_path = "",
-                                int thread_count = 1) {
+                                int thread_count = 1,
+                                bool enable_read_cache = false) {
     auto params = nlohmann::json::parse(IVFTestIndex::GenerateIVFBuildParametersString(
         "l2", 16, "sq8,fp32", 16, "random", false, 1, false, thread_count));
     params["index_param"]["precise_codes_layout"] = "bucket";
     params["index_param"]["precise_io_type"] = precise_io_type;
     params["index_param"]["precise_file_path"] = precise_file_path;
+    if (enable_read_cache) {
+        params["index_param"]["precise_enable_read_cache"] = true;
+        params["index_param"]["precise_cache_total_size"] = 128 * 1024;
+    }
     return params.dump();
 }
 
@@ -429,11 +434,14 @@ TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
     constexpr int64_t base_count = 128;
     constexpr int64_t buckets_count = 16;
     const auto precise_io_type = GENERATE("block_memory_io", "buffer_io");
+    const bool enable_read_cache = precise_io_type == std::string("buffer_io");
     INFO(fmt::format("precise_io_type: {}", precise_io_type));
+    INFO(fmt::format("enable_read_cache: {}", enable_read_cache));
 
     const auto precise_file_path =
         precise_io_type == std::string("buffer_io") ? dir.GenerateRandomFile(false) : std::string();
-    const auto params = GenerateBucketPreciseParameters(precise_io_type, precise_file_path);
+    const auto params =
+        GenerateBucketPreciseParameters(precise_io_type, precise_file_path, 1, enable_read_cache);
     const auto search_param = fmt::format(search_param_tmp, buckets_count);
     auto dataset = pool.GetDatasetAndCreate(dim, base_count, "l2");
     auto index = TestFactory(name, params, true);
@@ -447,7 +455,7 @@ TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
     const auto restored_file_path =
         precise_io_type == std::string("buffer_io") ? dir.GenerateRandomFile(false) : std::string();
     const auto restored_params =
-        GenerateBucketPreciseParameters(precise_io_type, restored_file_path);
+        GenerateBucketPreciseParameters(precise_io_type, restored_file_path, 1, enable_read_cache);
     auto restored = TestFactory(name, restored_params, true);
     TestSerializeBinarySet(index, restored, dataset, search_param, true);
     CheckBucketPreciseIndex(restored, dataset, search_param);

--- a/tests/test_ivf.cpp
+++ b/tests/test_ivf.cpp
@@ -194,6 +194,21 @@ namespace {
 using vsag::test::EraseStreamingBlock;
 using vsag::test::InsertUnknownStreamingBlock;
 
+class BlockSizeLimitGuard {
+public:
+    explicit BlockSizeLimitGuard(uint64_t block_size_limit)
+        : origin_size_(vsag::Options::Instance().block_size_limit()) {
+        vsag::Options::Instance().set_block_size_limit(block_size_limit);
+    }
+
+    ~BlockSizeLimitGuard() {
+        vsag::Options::Instance().set_block_size_limit(origin_size_);
+    }
+
+private:
+    uint64_t origin_size_;
+};
+
 std::string
 GenerateBucketPreciseParameters(int buckets_per_data,
                                 const std::string& precise_io_type = "block_memory_io",
@@ -398,6 +413,7 @@ TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
 TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
                              "IVF bucket precise mirrors basic postings",
                              "[ft][ivf][reorder][serialize][pr]") {
+    BlockSizeLimitGuard block_size_limit_guard(2ULL * 1024 * 1024);
     constexpr int64_t dim = 16;
     constexpr int64_t base_count = 128;
     constexpr int64_t buckets_count = 16;
@@ -433,6 +449,7 @@ TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
 TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
                              "IVF bucket precise streaming",
                              "[ft][ivf][reorder][serialize][streaming][pr]") {
+    BlockSizeLimitGuard block_size_limit_guard(2ULL * 1024 * 1024);
     constexpr int64_t dim = 16;
     constexpr int64_t base_count = 128;
     constexpr int64_t buckets_count = 16;
@@ -471,6 +488,7 @@ TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
 TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
                              "IVF disk bucket precise rejects aliased ownership operations",
                              "[ft][ivf][reorder][serialize][streaming][export][pr]") {
+    BlockSizeLimitGuard block_size_limit_guard(2ULL * 1024 * 1024);
     constexpr int64_t dim = 16;
     constexpr int64_t base_count = 128;
     const auto precise_file_path = dir.GenerateRandomFile(false);
@@ -552,6 +570,7 @@ TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
 TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
                              "IVF bucket precise merge",
                              "[ft][ivf][reorder][merge][pr]") {
+    BlockSizeLimitGuard block_size_limit_guard(2ULL * 1024 * 1024);
     constexpr int64_t dim = 16;
     constexpr int64_t base_count = 128;
     constexpr int64_t buckets_count = 16;

--- a/tests/test_ivf.cpp
+++ b/tests/test_ivf.cpp
@@ -15,6 +15,7 @@
 
 #include <cstring>
 #include <limits>
+#include <nlohmann/json.hpp>
 #include <sstream>
 
 #include "functest.h"
@@ -192,6 +193,42 @@ namespace {
 using vsag::test::EraseStreamingBlock;
 using vsag::test::InsertUnknownStreamingBlock;
 
+std::string
+GenerateBucketPreciseParameters(int buckets_per_data,
+                                const std::string& precise_io_type = "block_memory_io",
+                                const std::string& precise_file_path = "",
+                                int thread_count = 1) {
+    auto params = nlohmann::json::parse(IVFTestIndex::GenerateIVFBuildParametersString(
+        "l2", 16, "sq8,fp32", 16, "random", false, buckets_per_data, false, thread_count));
+    params["index_param"]["precise_codes_layout"] = "bucket";
+    params["index_param"]["precise_io_type"] = precise_io_type;
+    params["index_param"]["precise_file_path"] = precise_file_path;
+    return params.dump();
+}
+
+void
+CheckBucketPreciseIndex(const TestIndex::IndexPtr& index,
+                        const TestDatasetPtr& dataset,
+                        const std::string& search_param) {
+    constexpr int64_t query_id = 3;
+    auto query = vsag::Dataset::Make();
+    query->NumElements(1)
+        ->Dim(dataset->base_->GetDim())
+        ->Float32Vectors(dataset->base_->GetFloat32Vectors() + query_id * dataset->base_->GetDim())
+        ->Owner(false);
+
+    auto result = index->KnnSearch(query, 1, search_param);
+    REQUIRE(result.has_value());
+    REQUIRE(result.value()->GetDim() == 1);
+    REQUIRE(result.value()->GetIds()[0] == dataset->base_->GetIds()[query_id]);
+    REQUIRE(std::abs(result.value()->GetDistances()[0]) < 2e-6F);
+
+    auto distance =
+        index->CalcDistanceById(query->GetFloat32Vectors(), dataset->base_->GetIds()[query_id]);
+    REQUIRE(distance.has_value());
+    REQUIRE(std::abs(distance.value()) < 2e-6F);
+}
+
 }  // namespace
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::IVFTestIndex, "IVF GetStatus", "[ft][ivf]") {
@@ -311,7 +348,7 @@ TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
     auto origin_size = vsag::Options::Instance().block_size_limit();
     vsag::Options::Instance().set_block_size_limit(1024 * 1024 * 2);
 
-    auto param = IVFTestIndex::GenerateIVFBuildParametersString("l2", 16, "sq8", 32, "random");
+    auto param = IVFTestIndex::GenerateIVFBuildParametersString("l2", 16, "sq8,fp32", 32, "random");
     auto index = TestIndex::TestFactory(IVFTestIndex::name, param, true);
     auto dataset = IVFTestIndex::pool.GetDatasetAndCreate(16, 200, "l2");
     TestIndex::TestBuildIndex(index, dataset, true);
@@ -355,6 +392,96 @@ TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
     }
 
     vsag::Options::Instance().set_block_size_limit(origin_size);
+}
+
+TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
+                             "IVF bucket precise mirrors basic postings",
+                             "[ft][ivf][reorder][serialize][pr]") {
+    constexpr int64_t dim = 16;
+    constexpr int64_t base_count = 128;
+    constexpr int64_t buckets_count = 16;
+    const auto buckets_per_data = GENERATE(1, 2);
+    const auto precise_io_type = GENERATE("block_memory_io", "buffer_io");
+    INFO(fmt::format("buckets_per_data: {}", buckets_per_data));
+    INFO(fmt::format("precise_io_type: {}", precise_io_type));
+
+    const auto precise_file_path =
+        precise_io_type == std::string("buffer_io") ? dir.GenerateRandomFile(false) : std::string();
+    const auto params =
+        GenerateBucketPreciseParameters(buckets_per_data, precise_io_type, precise_file_path);
+    const auto search_param = fmt::format(search_param_tmp, buckets_count);
+    auto dataset = pool.GetDatasetAndCreate(dim, base_count, "l2");
+    auto index = TestFactory(name, params, true);
+
+    TestContinueAdd(index, dataset, true);
+    CheckBucketPreciseIndex(index, dataset, search_param);
+    TestCalcDistanceById(index, dataset, 2e-6F, true);
+    TestBatchCalcDistanceById(index, dataset, 2e-6F, true);
+
+    const auto restored_file_path =
+        precise_io_type == std::string("buffer_io") ? dir.GenerateRandomFile(false) : std::string();
+    const auto restored_params =
+        GenerateBucketPreciseParameters(buckets_per_data, precise_io_type, restored_file_path);
+    auto restored = TestFactory(name, restored_params, true);
+    TestSerializeBinarySet(index, restored, dataset, search_param, true);
+    CheckBucketPreciseIndex(restored, dataset, search_param);
+    TestCalcDistanceById(restored, dataset, 2e-6F, true);
+    TestBatchCalcDistanceById(restored, dataset, 2e-6F, true);
+}
+
+TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
+                             "IVF bucket precise streaming",
+                             "[ft][ivf][reorder][serialize][streaming][pr]") {
+    constexpr int64_t dim = 16;
+    constexpr int64_t base_count = 128;
+    constexpr int64_t buckets_count = 16;
+    const auto params = GenerateBucketPreciseParameters(2, "block_memory_io", "", 4);
+    const auto search_param = fmt::format(search_param_tmp, buckets_count);
+    auto dataset = pool.GetDatasetAndCreate(dim, base_count, "l2");
+    auto index = TestFactory(name, params, true);
+    TestBuildIndex(index, dataset, true);
+
+    std::stringstream stream;
+    REQUIRE(index->SerializeStreaming(stream).has_value());
+    const auto bytes = stream.str();
+
+    auto restored = TestFactory(name, params, true);
+    std::stringstream deserialize_stream(bytes);
+    REQUIRE(restored->DeserializeStreaming(deserialize_stream).has_value());
+    CheckBucketPreciseIndex(restored, dataset, search_param);
+    TestBatchCalcDistanceById(restored, dataset, 2e-6F, true);
+
+    std::stringstream load_stream(bytes);
+    auto loaded = vsag::Index::Load(load_stream, "{}");
+    REQUIRE(loaded.has_value());
+    CheckBucketPreciseIndex(loaded.value(), dataset, search_param);
+    TestBatchCalcDistanceById(loaded.value(), dataset, 2e-6F, true);
+
+    auto missing_precise =
+        EraseStreamingBlock(bytes, vsag::StreamSerializationTag::IVF_PRECISE_BUCKET);
+    auto invalid_restored = TestFactory(name, params, true);
+    std::stringstream missing_deserialize_stream(missing_precise);
+    REQUIRE_FALSE(invalid_restored->DeserializeStreaming(missing_deserialize_stream).has_value());
+    std::stringstream missing_load_stream(missing_precise);
+    REQUIRE_FALSE(vsag::Index::Load(missing_load_stream, "{}").has_value());
+}
+
+TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
+                             "IVF bucket precise merge",
+                             "[ft][ivf][reorder][merge][pr]") {
+    constexpr int64_t dim = 16;
+    constexpr int64_t base_count = 128;
+    constexpr int64_t buckets_count = 16;
+    const auto params = GenerateBucketPreciseParameters(2);
+    const auto search_param = fmt::format(search_param_tmp, buckets_count);
+    auto dataset = pool.GetDatasetAndCreate(dim, base_count, "l2");
+    auto model = TestFactory(name, params, true);
+    REQUIRE(model->Train(dataset->base_).has_value());
+
+    auto merged = TestMergeIndexWithSameModel(model, dataset, 3, true);
+    CheckBucketPreciseIndex(merged, dataset, search_param);
+    TestCalcDistanceById(merged, dataset, 2e-6F, true);
+    TestBatchCalcDistanceById(merged, dataset, 2e-6F, true);
 }
 }  // namespace fixtures
 

--- a/tests/test_ivf.cpp
+++ b/tests/test_ivf.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 #include <cstring>
+#include <filesystem>
 #include <limits>
 #include <nlohmann/json.hpp>
 #include <sstream>
@@ -440,6 +441,7 @@ TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
     auto dataset = pool.GetDatasetAndCreate(dim, base_count, "l2");
     auto index = TestFactory(name, params, true);
     TestBuildIndex(index, dataset, true);
+    REQUIRE(index->ExportModel().has_value());
 
     std::stringstream stream;
     REQUIRE(index->SerializeStreaming(stream).has_value());
@@ -464,6 +466,87 @@ TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
     REQUIRE_FALSE(invalid_restored->DeserializeStreaming(missing_deserialize_stream).has_value());
     std::stringstream missing_load_stream(missing_precise);
     REQUIRE_FALSE(vsag::Index::Load(missing_load_stream, "{}").has_value());
+}
+
+TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
+                             "IVF disk bucket precise rejects aliased ownership operations",
+                             "[ft][ivf][reorder][serialize][streaming][export][pr]") {
+    constexpr int64_t dim = 16;
+    constexpr int64_t base_count = 128;
+    const auto precise_file_path = dir.GenerateRandomFile(false);
+    const auto params = GenerateBucketPreciseParameters(1, "buffer_io", precise_file_path);
+    auto dataset = pool.GetDatasetAndCreate(dim, base_count, "l2");
+    auto index = TestFactory(name, params, true);
+    TestBuildIndex(index, dataset, true);
+    REQUIRE_FALSE(index->CheckFeature(vsag::SUPPORT_CLONE));
+    REQUIRE_FALSE(index->CheckFeature(vsag::SUPPORT_EXPORT_MODEL));
+    REQUIRE_FALSE(index->CheckFeature(vsag::SUPPORT_MERGE_INDEX));
+
+    SECTION("rejects export model") {
+        auto result = index->ExportModel();
+        REQUIRE_FALSE(result.has_value());
+        REQUIRE(result.error().type == vsag::ErrorType::UNSUPPORTED_INDEX_OPERATION);
+    }
+
+    SECTION("rejects clone") {
+        auto result = index->Clone();
+        REQUIRE_FALSE(result.has_value());
+        REQUIRE(result.error().type == vsag::ErrorType::UNSUPPORTED_INDEX_OPERATION);
+    }
+
+    SECTION("rejects merge") {
+        auto result = index->Merge({});
+        REQUIRE_FALSE(result.has_value());
+        REQUIRE(result.error().type == vsag::ErrorType::UNSUPPORTED_INDEX_OPERATION);
+    }
+
+    SECTION("rejects streaming load") {
+        std::stringstream stream;
+        REQUIRE(index->SerializeStreaming(stream).has_value());
+        std::stringstream load_stream(stream.str());
+        auto result = vsag::Index::Load(load_stream, "{}");
+        REQUIRE_FALSE(result.has_value());
+        REQUIRE(result.error().type == vsag::ErrorType::UNSUPPORTED_INDEX_OPERATION);
+    }
+
+    SECTION("rejects empty streaming load") {
+        const auto empty_file_path = dir.GenerateRandomFile(false);
+        const auto empty_params = GenerateBucketPreciseParameters(1, "buffer_io", empty_file_path);
+        auto empty_index = TestFactory(name, empty_params, true);
+        std::stringstream stream;
+        REQUIRE(empty_index->SerializeStreaming(stream).has_value());
+        std::stringstream load_stream(stream.str());
+        auto result = vsag::Index::Load(load_stream, "{}");
+        REQUIRE_FALSE(result.has_value());
+        REQUIRE(result.error().type == vsag::ErrorType::UNSUPPORTED_INDEX_OPERATION);
+    }
+
+    SECTION("rejects mmap before creating the precise file") {
+        const auto mmap_file_path = dir.GenerateRandomFile(false);
+        const auto mmap_params = GenerateBucketPreciseParameters(1, "mmap_io", mmap_file_path);
+        auto result = vsag::Factory::CreateIndex(name, mmap_params);
+        REQUIRE_FALSE(result.has_value());
+        REQUIRE(result.error().type == vsag::ErrorType::INVALID_ARGUMENT);
+        REQUIRE_FALSE(std::filesystem::exists(mmap_file_path));
+    }
+
+    SECTION("allows streaming deserialize into an independent precise file") {
+        std::stringstream stream;
+        REQUIRE(index->SerializeStreaming(stream).has_value());
+        const auto restored_file_path = dir.GenerateRandomFile(false);
+        const auto restored_params =
+            GenerateBucketPreciseParameters(1, "buffer_io", restored_file_path);
+        auto restored = TestFactory(name, restored_params, true);
+        std::stringstream deserialize_stream(stream.str());
+        REQUIRE(restored->DeserializeStreaming(deserialize_stream).has_value());
+        const auto search_param = fmt::format(search_param_tmp, 16);
+        CheckBucketPreciseIndex(restored, dataset, search_param);
+        TestBatchCalcDistanceById(restored, dataset, 2e-6F, true);
+    }
+
+    const auto search_param = fmt::format(search_param_tmp, 16);
+    CheckBucketPreciseIndex(index, dataset, search_param);
+    TestBatchCalcDistanceById(index, dataset, 2e-6F, true);
 }
 
 TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,

--- a/tests/test_ivf.cpp
+++ b/tests/test_ivf.cpp
@@ -221,7 +221,9 @@ GenerateBucketPreciseParameters(const std::string& precise_io_type = "block_memo
     params["index_param"]["precise_file_path"] = precise_file_path;
     if (enable_read_cache) {
         params["index_param"]["precise_enable_read_cache"] = true;
-        params["index_param"]["precise_cache_total_size"] = 128 * 1024;
+        // BucketDataCell divides the cache budget across the 16 buckets. Allocate one
+        // 128-KiB cache page per bucket so this case exercises the read-cache path.
+        params["index_param"]["precise_cache_total_size"] = 16 * 128 * 1024;
     }
     return params.dump();
 }

--- a/tests/test_ivf.cpp
+++ b/tests/test_ivf.cpp
@@ -245,6 +245,12 @@ CheckBucketPreciseIndex(const TestIndex::IndexPtr& index,
     REQUIRE(result.value()->GetIds()[0] == dataset->base_->GetIds()[query_id]);
     REQUIRE(std::abs(result.value()->GetDistances()[0]) < 2e-6F);
 
+    auto threshold_search_param = nlohmann::json::parse(search_param);
+    threshold_search_param["threshold"] = -1.0F;
+    auto threshold_result = index->KnnSearch(query, 1, threshold_search_param.dump());
+    REQUIRE(threshold_result.has_value());
+    REQUIRE(threshold_result.value()->GetDim() == 0);
+
     auto distance =
         index->CalcDistanceById(query->GetFloat32Vectors(), dataset->base_->GetIds()[query_id]);
     REQUIRE(distance.has_value());

--- a/tests/test_ivf.cpp
+++ b/tests/test_ivf.cpp
@@ -434,6 +434,7 @@ TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
     CheckBucketPreciseIndex(index, dataset, search_param);
     TestCalcDistanceById(index, dataset, 2e-6F, true);
     TestBatchCalcDistanceById(index, dataset, 2e-6F, true);
+    TestMultiQueryBatchCalcDistanceById(index, dataset, 2e-6F, true);
 
     const auto restored_file_path =
         precise_io_type == std::string("buffer_io") ? dir.GenerateRandomFile(false) : std::string();

--- a/tests/test_ivf.cpp
+++ b/tests/test_ivf.cpp
@@ -210,12 +210,11 @@ private:
 };
 
 std::string
-GenerateBucketPreciseParameters(int buckets_per_data,
-                                const std::string& precise_io_type = "block_memory_io",
+GenerateBucketPreciseParameters(const std::string& precise_io_type = "block_memory_io",
                                 const std::string& precise_file_path = "",
                                 int thread_count = 1) {
     auto params = nlohmann::json::parse(IVFTestIndex::GenerateIVFBuildParametersString(
-        "l2", 16, "sq8,fp32", 16, "random", false, buckets_per_data, false, thread_count));
+        "l2", 16, "sq8,fp32", 16, "random", false, 1, false, thread_count));
     params["index_param"]["precise_codes_layout"] = "bucket";
     params["index_param"]["precise_io_type"] = precise_io_type;
     params["index_param"]["precise_file_path"] = precise_file_path;
@@ -410,6 +409,18 @@ TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
     vsag::Options::Instance().set_block_size_limit(origin_size);
 }
 
+TEST_CASE("IVF bucket precise rejects multiple postings per data", "[ft][ivf][reorder][pr]") {
+    auto params = nlohmann::json::parse(GenerateBucketPreciseParameters());
+    params["index_param"]["buckets_per_data"] = 2;
+
+    auto result = vsag::Factory::CreateIndex(IVFTestIndex::name, params.dump());
+
+    REQUIRE_FALSE(result.has_value());
+    REQUIRE(result.error().type == vsag::ErrorType::INVALID_ARGUMENT);
+    REQUIRE(result.error().message.find(
+                "precise_codes_layout=bucket requires buckets_per_data=1") != std::string::npos);
+}
+
 TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
                              "IVF bucket precise mirrors basic postings",
                              "[ft][ivf][reorder][serialize][pr]") {
@@ -417,15 +428,12 @@ TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
     constexpr int64_t dim = 16;
     constexpr int64_t base_count = 128;
     constexpr int64_t buckets_count = 16;
-    const auto buckets_per_data = GENERATE(1, 2);
     const auto precise_io_type = GENERATE("block_memory_io", "buffer_io");
-    INFO(fmt::format("buckets_per_data: {}", buckets_per_data));
     INFO(fmt::format("precise_io_type: {}", precise_io_type));
 
     const auto precise_file_path =
         precise_io_type == std::string("buffer_io") ? dir.GenerateRandomFile(false) : std::string();
-    const auto params =
-        GenerateBucketPreciseParameters(buckets_per_data, precise_io_type, precise_file_path);
+    const auto params = GenerateBucketPreciseParameters(precise_io_type, precise_file_path);
     const auto search_param = fmt::format(search_param_tmp, buckets_count);
     auto dataset = pool.GetDatasetAndCreate(dim, base_count, "l2");
     auto index = TestFactory(name, params, true);
@@ -439,7 +447,7 @@ TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
     const auto restored_file_path =
         precise_io_type == std::string("buffer_io") ? dir.GenerateRandomFile(false) : std::string();
     const auto restored_params =
-        GenerateBucketPreciseParameters(buckets_per_data, precise_io_type, restored_file_path);
+        GenerateBucketPreciseParameters(precise_io_type, restored_file_path);
     auto restored = TestFactory(name, restored_params, true);
     TestSerializeBinarySet(index, restored, dataset, search_param, true);
     CheckBucketPreciseIndex(restored, dataset, search_param);
@@ -454,7 +462,7 @@ TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
     constexpr int64_t dim = 16;
     constexpr int64_t base_count = 128;
     constexpr int64_t buckets_count = 16;
-    const auto params = GenerateBucketPreciseParameters(2, "block_memory_io", "", 4);
+    const auto params = GenerateBucketPreciseParameters("block_memory_io", "", 4);
     const auto search_param = fmt::format(search_param_tmp, buckets_count);
     auto dataset = pool.GetDatasetAndCreate(dim, base_count, "l2");
     auto index = TestFactory(name, params, true);
@@ -493,7 +501,7 @@ TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
     constexpr int64_t dim = 16;
     constexpr int64_t base_count = 128;
     const auto precise_file_path = dir.GenerateRandomFile(false);
-    const auto params = GenerateBucketPreciseParameters(1, "buffer_io", precise_file_path);
+    const auto params = GenerateBucketPreciseParameters("buffer_io", precise_file_path);
     auto dataset = pool.GetDatasetAndCreate(dim, base_count, "l2");
     auto index = TestFactory(name, params, true);
     TestBuildIndex(index, dataset, true);
@@ -530,7 +538,7 @@ TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
 
     SECTION("rejects empty streaming load") {
         const auto empty_file_path = dir.GenerateRandomFile(false);
-        const auto empty_params = GenerateBucketPreciseParameters(1, "buffer_io", empty_file_path);
+        const auto empty_params = GenerateBucketPreciseParameters("buffer_io", empty_file_path);
         auto empty_index = TestFactory(name, empty_params, true);
         std::stringstream stream;
         REQUIRE(empty_index->SerializeStreaming(stream).has_value());
@@ -542,7 +550,7 @@ TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
 
     SECTION("rejects mmap before creating the precise file") {
         const auto mmap_file_path = dir.GenerateRandomFile(false);
-        const auto mmap_params = GenerateBucketPreciseParameters(1, "mmap_io", mmap_file_path);
+        const auto mmap_params = GenerateBucketPreciseParameters("mmap_io", mmap_file_path);
         auto result = vsag::Factory::CreateIndex(name, mmap_params);
         REQUIRE_FALSE(result.has_value());
         REQUIRE(result.error().type == vsag::ErrorType::INVALID_ARGUMENT);
@@ -554,7 +562,7 @@ TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
         REQUIRE(index->SerializeStreaming(stream).has_value());
         const auto restored_file_path = dir.GenerateRandomFile(false);
         const auto restored_params =
-            GenerateBucketPreciseParameters(1, "buffer_io", restored_file_path);
+            GenerateBucketPreciseParameters("buffer_io", restored_file_path);
         auto restored = TestFactory(name, restored_params, true);
         std::stringstream deserialize_stream(stream.str());
         REQUIRE(restored->DeserializeStreaming(deserialize_stream).has_value());
@@ -575,7 +583,7 @@ TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
     constexpr int64_t dim = 16;
     constexpr int64_t base_count = 128;
     constexpr int64_t buckets_count = 16;
-    const auto params = GenerateBucketPreciseParameters(2);
+    const auto params = GenerateBucketPreciseParameters();
     const auto search_param = fmt::format(search_param_tmp, buckets_count);
     auto dataset = pool.GetDatasetAndCreate(dim, base_count, "l2");
     auto model = TestFactory(name, params, true);

--- a/tests/test_ivf.cpp
+++ b/tests/test_ivf.cpp
@@ -435,6 +435,7 @@ TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
     CheckBucketPreciseIndex(index, dataset, search_param);
     TestCalcDistanceById(index, dataset, 2e-6F, true);
     TestBatchCalcDistanceById(index, dataset, 2e-6F, true);
+    TestMultiQueryBatchCalcDistanceById(index, dataset, 2e-6F, true);
 
     const auto restored_file_path =
         precise_io_type == std::string("buffer_io") ? dir.GenerateRandomFile(false) : std::string();

--- a/tests/test_ivf.cpp
+++ b/tests/test_ivf.cpp
@@ -246,6 +246,12 @@ CheckBucketPreciseIndex(const TestIndex::IndexPtr& index,
     REQUIRE(result.value()->GetIds()[0] == dataset->base_->GetIds()[query_id]);
     REQUIRE(std::abs(result.value()->GetDistances()[0]) < 2e-6F);
 
+    auto threshold_search_param = nlohmann::json::parse(search_param);
+    threshold_search_param["threshold"] = -1.0F;
+    auto threshold_result = index->KnnSearch(query, 1, threshold_search_param.dump());
+    REQUIRE(threshold_result.has_value());
+    REQUIRE(threshold_result.value()->GetDim() == 0);
+
     auto distance =
         index->CalcDistanceById(query->GetFloat32Vectors(), dataset->base_->GetIds()[query_id]);
     REQUIRE(distance.has_value());

--- a/tests/test_ivf.cpp
+++ b/tests/test_ivf.cpp
@@ -16,6 +16,7 @@
 #include <algorithm>
 #include <cstring>
 #include <limits>
+#include <nlohmann/json.hpp>
 #include <sstream>
 
 #include "functest.h"
@@ -193,6 +194,42 @@ namespace {
 using vsag::test::EraseStreamingBlock;
 using vsag::test::InsertUnknownStreamingBlock;
 
+std::string
+GenerateBucketPreciseParameters(int buckets_per_data,
+                                const std::string& precise_io_type = "block_memory_io",
+                                const std::string& precise_file_path = "",
+                                int thread_count = 1) {
+    auto params = nlohmann::json::parse(IVFTestIndex::GenerateIVFBuildParametersString(
+        "l2", 16, "sq8,fp32", 16, "random", false, buckets_per_data, false, thread_count));
+    params["index_param"]["precise_codes_layout"] = "bucket";
+    params["index_param"]["precise_io_type"] = precise_io_type;
+    params["index_param"]["precise_file_path"] = precise_file_path;
+    return params.dump();
+}
+
+void
+CheckBucketPreciseIndex(const TestIndex::IndexPtr& index,
+                        const TestDatasetPtr& dataset,
+                        const std::string& search_param) {
+    constexpr int64_t query_id = 3;
+    auto query = vsag::Dataset::Make();
+    query->NumElements(1)
+        ->Dim(dataset->base_->GetDim())
+        ->Float32Vectors(dataset->base_->GetFloat32Vectors() + query_id * dataset->base_->GetDim())
+        ->Owner(false);
+
+    auto result = index->KnnSearch(query, 1, search_param);
+    REQUIRE(result.has_value());
+    REQUIRE(result.value()->GetDim() == 1);
+    REQUIRE(result.value()->GetIds()[0] == dataset->base_->GetIds()[query_id]);
+    REQUIRE(std::abs(result.value()->GetDistances()[0]) < 2e-6F);
+
+    auto distance =
+        index->CalcDistanceById(query->GetFloat32Vectors(), dataset->base_->GetIds()[query_id]);
+    REQUIRE(distance.has_value());
+    REQUIRE(std::abs(distance.value()) < 2e-6F);
+}
+
 }  // namespace
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::IVFTestIndex, "IVF GetStatus", "[ft][ivf]") {
@@ -312,7 +349,7 @@ TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
     auto origin_size = vsag::Options::Instance().block_size_limit();
     vsag::Options::Instance().set_block_size_limit(1024 * 1024 * 2);
 
-    auto param = IVFTestIndex::GenerateIVFBuildParametersString("l2", 16, "sq8", 32, "random");
+    auto param = IVFTestIndex::GenerateIVFBuildParametersString("l2", 16, "sq8,fp32", 32, "random");
     auto index = TestIndex::TestFactory(IVFTestIndex::name, param, true);
     auto dataset = IVFTestIndex::pool.GetDatasetAndCreate(16, 200, "l2");
     TestIndex::TestBuildIndex(index, dataset, true);
@@ -356,6 +393,96 @@ TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
     }
 
     vsag::Options::Instance().set_block_size_limit(origin_size);
+}
+
+TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
+                             "IVF bucket precise mirrors basic postings",
+                             "[ft][ivf][reorder][serialize][pr]") {
+    constexpr int64_t dim = 16;
+    constexpr int64_t base_count = 128;
+    constexpr int64_t buckets_count = 16;
+    const auto buckets_per_data = GENERATE(1, 2);
+    const auto precise_io_type = GENERATE("block_memory_io", "buffer_io");
+    INFO(fmt::format("buckets_per_data: {}", buckets_per_data));
+    INFO(fmt::format("precise_io_type: {}", precise_io_type));
+
+    const auto precise_file_path =
+        precise_io_type == std::string("buffer_io") ? dir.GenerateRandomFile(false) : std::string();
+    const auto params =
+        GenerateBucketPreciseParameters(buckets_per_data, precise_io_type, precise_file_path);
+    const auto search_param = fmt::format(search_param_tmp, buckets_count);
+    auto dataset = pool.GetDatasetAndCreate(dim, base_count, "l2");
+    auto index = TestFactory(name, params, true);
+
+    TestContinueAdd(index, dataset, true);
+    CheckBucketPreciseIndex(index, dataset, search_param);
+    TestCalcDistanceById(index, dataset, 2e-6F, true);
+    TestBatchCalcDistanceById(index, dataset, 2e-6F, true);
+
+    const auto restored_file_path =
+        precise_io_type == std::string("buffer_io") ? dir.GenerateRandomFile(false) : std::string();
+    const auto restored_params =
+        GenerateBucketPreciseParameters(buckets_per_data, precise_io_type, restored_file_path);
+    auto restored = TestFactory(name, restored_params, true);
+    TestSerializeBinarySet(index, restored, dataset, search_param, true);
+    CheckBucketPreciseIndex(restored, dataset, search_param);
+    TestCalcDistanceById(restored, dataset, 2e-6F, true);
+    TestBatchCalcDistanceById(restored, dataset, 2e-6F, true);
+}
+
+TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
+                             "IVF bucket precise streaming",
+                             "[ft][ivf][reorder][serialize][streaming][pr]") {
+    constexpr int64_t dim = 16;
+    constexpr int64_t base_count = 128;
+    constexpr int64_t buckets_count = 16;
+    const auto params = GenerateBucketPreciseParameters(2, "block_memory_io", "", 4);
+    const auto search_param = fmt::format(search_param_tmp, buckets_count);
+    auto dataset = pool.GetDatasetAndCreate(dim, base_count, "l2");
+    auto index = TestFactory(name, params, true);
+    TestBuildIndex(index, dataset, true);
+
+    std::stringstream stream;
+    REQUIRE(index->SerializeStreaming(stream).has_value());
+    const auto bytes = stream.str();
+
+    auto restored = TestFactory(name, params, true);
+    std::stringstream deserialize_stream(bytes);
+    REQUIRE(restored->DeserializeStreaming(deserialize_stream).has_value());
+    CheckBucketPreciseIndex(restored, dataset, search_param);
+    TestBatchCalcDistanceById(restored, dataset, 2e-6F, true);
+
+    std::stringstream load_stream(bytes);
+    auto loaded = vsag::Index::Load(load_stream, "{}");
+    REQUIRE(loaded.has_value());
+    CheckBucketPreciseIndex(loaded.value(), dataset, search_param);
+    TestBatchCalcDistanceById(loaded.value(), dataset, 2e-6F, true);
+
+    auto missing_precise =
+        EraseStreamingBlock(bytes, vsag::StreamSerializationTag::IVF_PRECISE_BUCKET);
+    auto invalid_restored = TestFactory(name, params, true);
+    std::stringstream missing_deserialize_stream(missing_precise);
+    REQUIRE_FALSE(invalid_restored->DeserializeStreaming(missing_deserialize_stream).has_value());
+    std::stringstream missing_load_stream(missing_precise);
+    REQUIRE_FALSE(vsag::Index::Load(missing_load_stream, "{}").has_value());
+}
+
+TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
+                             "IVF bucket precise merge",
+                             "[ft][ivf][reorder][merge][pr]") {
+    constexpr int64_t dim = 16;
+    constexpr int64_t base_count = 128;
+    constexpr int64_t buckets_count = 16;
+    const auto params = GenerateBucketPreciseParameters(2);
+    const auto search_param = fmt::format(search_param_tmp, buckets_count);
+    auto dataset = pool.GetDatasetAndCreate(dim, base_count, "l2");
+    auto model = TestFactory(name, params, true);
+    REQUIRE(model->Train(dataset->base_).has_value());
+
+    auto merged = TestMergeIndexWithSameModel(model, dataset, 3, true);
+    CheckBucketPreciseIndex(merged, dataset, search_param);
+    TestCalcDistanceById(merged, dataset, 2e-6F, true);
+    TestBatchCalcDistanceById(merged, dataset, 2e-6F, true);
 }
 }  // namespace fixtures
 

--- a/tests/test_ivf.cpp
+++ b/tests/test_ivf.cpp
@@ -195,6 +195,21 @@ namespace {
 using vsag::test::EraseStreamingBlock;
 using vsag::test::InsertUnknownStreamingBlock;
 
+class BlockSizeLimitGuard {
+public:
+    explicit BlockSizeLimitGuard(uint64_t block_size_limit)
+        : origin_size_(vsag::Options::Instance().block_size_limit()) {
+        vsag::Options::Instance().set_block_size_limit(block_size_limit);
+    }
+
+    ~BlockSizeLimitGuard() {
+        vsag::Options::Instance().set_block_size_limit(origin_size_);
+    }
+
+private:
+    uint64_t origin_size_;
+};
+
 std::string
 GenerateBucketPreciseParameters(int buckets_per_data,
                                 const std::string& precise_io_type = "block_memory_io",
@@ -399,6 +414,7 @@ TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
 TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
                              "IVF bucket precise mirrors basic postings",
                              "[ft][ivf][reorder][serialize][pr]") {
+    BlockSizeLimitGuard block_size_limit_guard(2ULL * 1024 * 1024);
     constexpr int64_t dim = 16;
     constexpr int64_t base_count = 128;
     constexpr int64_t buckets_count = 16;
@@ -434,6 +450,7 @@ TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
 TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
                              "IVF bucket precise streaming",
                              "[ft][ivf][reorder][serialize][streaming][pr]") {
+    BlockSizeLimitGuard block_size_limit_guard(2ULL * 1024 * 1024);
     constexpr int64_t dim = 16;
     constexpr int64_t base_count = 128;
     constexpr int64_t buckets_count = 16;
@@ -472,6 +489,7 @@ TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
 TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
                              "IVF disk bucket precise rejects aliased ownership operations",
                              "[ft][ivf][reorder][serialize][streaming][export][pr]") {
+    BlockSizeLimitGuard block_size_limit_guard(2ULL * 1024 * 1024);
     constexpr int64_t dim = 16;
     constexpr int64_t base_count = 128;
     const auto precise_file_path = dir.GenerateRandomFile(false);
@@ -553,6 +571,7 @@ TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
 TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
                              "IVF bucket precise merge",
                              "[ft][ivf][reorder][merge][pr]") {
+    BlockSizeLimitGuard block_size_limit_guard(2ULL * 1024 * 1024);
     constexpr int64_t dim = 16;
     constexpr int64_t base_count = 128;
     constexpr int64_t buckets_count = 16;

--- a/tests/test_ivf.cpp
+++ b/tests/test_ivf.cpp
@@ -14,11 +14,13 @@
 // limitations under the License.
 
 #include <algorithm>
+#include <atomic>
 #include <cstring>
 #include <filesystem>
 #include <limits>
 #include <nlohmann/json.hpp>
 #include <sstream>
+#include <stdexcept>
 
 #include "functest.h"
 #include "storage/serialization_tags.h"
@@ -193,6 +195,7 @@ IVFTestIndex::GenerateIVFBuildParametersString(const std::string& metric_type,
 namespace {
 
 using vsag::test::EraseStreamingBlock;
+using vsag::test::FindStreamingBlock;
 using vsag::test::InsertUnknownStreamingBlock;
 
 class BlockSizeLimitGuard {
@@ -209,6 +212,101 @@ public:
 private:
     uint64_t origin_size_;
 };
+
+class CountingMemoryReader : public vsag::Reader {
+public:
+    explicit CountingMemoryReader(std::string bytes, bool fail_reads = false)
+        : bytes_(std::move(bytes)), fail_reads_(fail_reads) {
+    }
+
+    void
+    Read(uint64_t offset, uint64_t len, void* dest) override {
+        read_calls_.fetch_add(1, std::memory_order_relaxed);
+        read_bytes_.fetch_add(len, std::memory_order_relaxed);
+        this->CheckRead(offset, len);
+        std::memcpy(dest, bytes_.data() + offset, len);
+    }
+
+    void
+    AsyncRead(uint64_t offset, uint64_t len, void* dest, const vsag::CallBack callback) override {
+        try {
+            this->Read(offset, len, dest);
+            callback(vsag::IOErrorCode::IO_SUCCESS, "success");
+        } catch (const std::exception& error) {
+            callback(vsag::IOErrorCode::IO_ERROR, error.what());
+        }
+    }
+
+    bool
+    MultiRead(uint8_t* dests,
+              const uint64_t* lens,
+              const uint64_t* offsets,
+              uint64_t count) override {
+        multi_read_calls_.fetch_add(1, std::memory_order_relaxed);
+        auto* dest = dests;
+        for (uint64_t i = 0; i < count; ++i) {
+            read_bytes_.fetch_add(lens[i], std::memory_order_relaxed);
+            this->CheckRead(offsets[i], lens[i]);
+            std::memcpy(dest, bytes_.data() + offsets[i], lens[i]);
+            dest += lens[i];
+        }
+        return true;
+    }
+
+    [[nodiscard]] uint64_t
+    Size() const override {
+        return bytes_.size();
+    }
+
+    void
+    ResetCounters() {
+        read_calls_.store(0, std::memory_order_relaxed);
+        multi_read_calls_.store(0, std::memory_order_relaxed);
+        read_bytes_.store(0, std::memory_order_relaxed);
+    }
+
+    [[nodiscard]] uint64_t
+    ReadCalls() const {
+        return read_calls_.load(std::memory_order_relaxed);
+    }
+
+    [[nodiscard]] uint64_t
+    MultiReadCalls() const {
+        return multi_read_calls_.load(std::memory_order_relaxed);
+    }
+
+    [[nodiscard]] uint64_t
+    ReadBytes() const {
+        return read_bytes_.load(std::memory_order_relaxed);
+    }
+
+private:
+    void
+    CheckRead(uint64_t offset, uint64_t len) const {
+        if (fail_reads_) {
+            throw std::runtime_error("injected remote reader failure");
+        }
+        if (offset > bytes_.size() || len > bytes_.size() - offset) {
+            throw std::out_of_range("remote reader range is out of bounds");
+        }
+    }
+
+    const std::string bytes_;
+    const bool fail_reads_;
+    std::atomic<uint64_t> read_calls_{0};
+    std::atomic<uint64_t> multi_read_calls_{0};
+    std::atomic<uint64_t> read_bytes_{0};
+};
+
+std::string
+ExtractPreciseCodesPayload(const std::string& bytes, const std::string& precise_codes_layout) {
+    const auto tag = precise_codes_layout == "bucket"
+                         ? vsag::StreamSerializationTag::IVF_PRECISE_BUCKET
+                         : vsag::StreamSerializationTag::HIGH_PRECISION_CODES;
+    const auto block = FindStreamingBlock(bytes, tag);
+    REQUIRE(block.payload_size > 0);
+    return bytes.substr(block.payload_offset, block.payload_size);
+}
 
 std::string
 GenerateBucketPreciseParameters(const std::string& precise_io_type = "block_memory_io",
@@ -227,6 +325,15 @@ GenerateBucketPreciseParameters(const std::string& precise_io_type = "block_memo
         params["index_param"]["precise_cache_total_size"] = 16 * 128 * 1024;
     }
     return params.dump();
+}
+
+std::string
+GeneratePreciseParameters(const std::string& precise_codes_layout) {
+    if (precise_codes_layout == "bucket") {
+        return GenerateBucketPreciseParameters();
+    }
+    return IVFTestIndex::GenerateIVFBuildParametersString(
+        "l2", 16, "sq8,fp32", 16, "random", false, 1, false, 1);
 }
 
 void
@@ -455,7 +562,23 @@ TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
     auto dataset = pool.GetDatasetAndCreate(dim, base_count, "l2");
     auto index = TestFactory(name, params, true);
 
-    TestContinueAdd(index, dataset, true);
+    constexpr int64_t first_batch_count = base_count / 2;
+    auto first_batch = vsag::Dataset::Make()
+                           ->NumElements(first_batch_count)
+                           ->Dim(dim)
+                           ->Ids(dataset->base_->GetIds())
+                           ->Float32Vectors(dataset->base_->GetFloat32Vectors())
+                           ->Owner(false);
+    auto second_batch =
+        vsag::Dataset::Make()
+            ->NumElements(base_count - first_batch_count)
+            ->Dim(dim)
+            ->Ids(dataset->base_->GetIds() + first_batch_count)
+            ->Float32Vectors(dataset->base_->GetFloat32Vectors() + first_batch_count * dim)
+            ->Owner(false);
+    REQUIRE(index->Build(first_batch).has_value());
+    REQUIRE(index->Add(second_batch).has_value());
+    REQUIRE(index->GetNumElements() == base_count);
     CheckBucketPreciseIndex(index, dataset, search_param);
     TestCalcDistanceById(index, dataset, 2e-6F, true);
     TestBatchCalcDistanceById(index, dataset, 2e-6F, true);
@@ -509,6 +632,244 @@ TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
     REQUIRE_FALSE(invalid_restored->DeserializeStreaming(missing_deserialize_stream).has_value());
     std::stringstream missing_load_stream(missing_precise);
     REQUIRE_FALSE(vsag::Index::Load(missing_load_stream, "{}").has_value());
+}
+
+TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
+                             "IVF precise codes load from an external reader",
+                             "[ft][ivf][reorder][serialize][streaming][reader_io][pr]") {
+    BlockSizeLimitGuard block_size_limit_guard(2ULL * 1024 * 1024);
+    constexpr int64_t dim = 16;
+    constexpr int64_t base_count = 128;
+    constexpr int64_t buckets_count = 16;
+    constexpr int64_t query_id = 3;
+    constexpr int64_t batch_count = 8;
+    const auto precise_codes_layout = GENERATE(std::string("flat"), std::string("bucket"));
+    const bool enable_read_cache = GENERATE(false, true);
+    CAPTURE(precise_codes_layout);
+    CAPTURE(enable_read_cache);
+
+    const auto params = GeneratePreciseParameters(precise_codes_layout);
+    const auto search_param = fmt::format(search_param_tmp, buckets_count);
+    auto dataset = pool.GetDatasetAndCreate(dim, base_count, "l2");
+    auto index = TestFactory(name, params, true);
+    TestBuildIndex(index, dataset, true);
+
+    std::stringstream stream;
+    REQUIRE(index->SerializeStreaming(stream).has_value());
+    const auto bytes = stream.str();
+    const auto precise_payload = ExtractPreciseCodesPayload(bytes, precise_codes_layout);
+    auto load_with_reader = [&](const std::shared_ptr<CountingMemoryReader>& reader) {
+        vsag::LoadParameters load_parameters;
+        load_parameters.Set("precise_io_type", "reader_io")
+            .Set("precise_enable_read_cache", enable_read_cache)
+            .Set("precise_cache_total_size", 16ULL * 128 * 1024)
+            .SetReader("precise_reader", reader);
+        std::stringstream load_stream(bytes);
+        return vsag::Index::Load(load_stream, load_parameters);
+    };
+    auto precise_reader = std::make_shared<CountingMemoryReader>(precise_payload);
+    auto loaded = load_with_reader(precise_reader);
+    REQUIRE(loaded.has_value());
+
+    auto query = vsag::Dataset::Make();
+    query->NumElements(1)
+        ->Dim(dim)
+        ->Float32Vectors(dataset->base_->GetFloat32Vectors() + query_id * dim)
+        ->Owner(false);
+    auto expected_search = index->KnnSearch(query, 1, search_param);
+    REQUIRE(expected_search.has_value());
+
+    // Loading validates the external block checksum through the Reader. Clear those accesses so
+    // the following count proves that querying, rather than loading, reads remote precise codes.
+    precise_reader->ResetCounters();
+    auto actual_search = loaded.value()->KnnSearch(query, 1, search_param);
+    REQUIRE(actual_search.has_value());
+    REQUIRE(actual_search.value()->GetDim() == expected_search.value()->GetDim());
+    REQUIRE(actual_search.value()->GetIds()[0] == expected_search.value()->GetIds()[0]);
+    REQUIRE(std::abs(actual_search.value()->GetDistances()[0] -
+                     expected_search.value()->GetDistances()[0]) < 2e-6F);
+    REQUIRE(precise_reader->ReadBytes() > 0);
+    if (enable_read_cache) {
+        REQUIRE(precise_reader->ReadCalls() > 0);
+        precise_reader->ResetCounters();
+        auto cached_search = loaded.value()->KnnSearch(query, 1, search_param);
+        REQUIRE(cached_search.has_value());
+        REQUIRE(precise_reader->ReadCalls() == 0);
+        REQUIRE(precise_reader->MultiReadCalls() == 0);
+        REQUIRE(precise_reader->ReadBytes() == 0);
+    } else {
+        REQUIRE(precise_reader->MultiReadCalls() > 0);
+    }
+
+    const auto* query_vector = query->GetFloat32Vectors();
+    const auto* ids = dataset->base_->GetIds();
+    auto expected_distances = index->CalcDistancesById(query_vector, ids, batch_count);
+    auto actual_distances = loaded.value()->CalcDistancesById(query_vector, ids, batch_count);
+    REQUIRE(expected_distances.has_value());
+    REQUIRE(actual_distances.has_value());
+    REQUIRE(actual_distances.value()->GetDim() == expected_distances.value()->GetDim());
+    for (int64_t i = 0; i < batch_count; ++i) {
+        REQUIRE(std::abs(actual_distances.value()->GetDistances()[i] -
+                         expected_distances.value()->GetDistances()[i]) < 2e-6F);
+    }
+
+    if (precise_codes_layout == "bucket" && enable_read_cache) {
+        auto fresh_reader = std::make_shared<CountingMemoryReader>(precise_payload);
+        auto fresh_loaded = load_with_reader(fresh_reader);
+        REQUIRE(fresh_loaded.has_value());
+
+        fresh_reader->ResetCounters();
+        auto first_distances =
+            fresh_loaded.value()->CalcDistancesById(query_vector, ids, batch_count);
+        REQUIRE(first_distances.has_value());
+        REQUIRE(fresh_reader->ReadCalls() > 0);
+        REQUIRE(fresh_reader->ReadBytes() > 0);
+        for (int64_t i = 0; i < batch_count; ++i) {
+            REQUIRE(std::abs(first_distances.value()->GetDistances()[i] -
+                             expected_distances.value()->GetDistances()[i]) < 2e-6F);
+        }
+
+        fresh_reader->ResetCounters();
+        auto cached_distances =
+            fresh_loaded.value()->CalcDistancesById(query_vector, ids, batch_count);
+        REQUIRE(cached_distances.has_value());
+        REQUIRE(fresh_reader->ReadCalls() == 0);
+        REQUIRE(fresh_reader->MultiReadCalls() == 0);
+        REQUIRE(fresh_reader->ReadBytes() == 0);
+        for (int64_t i = 0; i < batch_count; ++i) {
+            REQUIRE(std::abs(cached_distances.value()->GetDistances()[i] -
+                             expected_distances.value()->GetDistances()[i]) < 2e-6F);
+        }
+    }
+}
+
+TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
+                             "IVF precise codes validate their external reader",
+                             "[ft][ivf][reorder][serialize][streaming][reader_io][pr]") {
+    BlockSizeLimitGuard block_size_limit_guard(2ULL * 1024 * 1024);
+    const auto precise_codes_layout = GENERATE(std::string("flat"), std::string("bucket"));
+    CAPTURE(precise_codes_layout);
+    const auto params = GeneratePreciseParameters(precise_codes_layout);
+    auto dataset = pool.GetDatasetAndCreate(16, 128, "l2");
+    auto index = TestFactory(name, params, true);
+    TestBuildIndex(index, dataset, true);
+
+    std::stringstream stream;
+    REQUIRE(index->SerializeStreaming(stream).has_value());
+    const auto bytes = stream.str();
+    const auto precise_payload = ExtractPreciseCodesPayload(bytes, precise_codes_layout);
+
+    auto load_with_reader = [&bytes](const vsag::ReaderPtr& reader,
+                                     const std::string& precise_io_type = "reader_io") {
+        vsag::LoadParameters load_parameters;
+        if (not precise_io_type.empty()) {
+            load_parameters.Set("precise_io_type", precise_io_type);
+        }
+        load_parameters.SetReader("precise_reader", reader);
+        std::stringstream load_stream(bytes);
+        return vsag::Index::Load(load_stream, load_parameters);
+    };
+
+    SECTION("rejects a precise reader without an explicit reader io type") {
+        auto reader = std::make_shared<CountingMemoryReader>(precise_payload);
+        auto result = load_with_reader(reader, "");
+        REQUIRE_FALSE(result.has_value());
+        REQUIRE(result.error().type == vsag::ErrorType::INVALID_ARGUMENT);
+    }
+
+    SECTION("rejects a precise reader combined with another io type") {
+        auto reader = std::make_shared<CountingMemoryReader>(precise_payload);
+        auto result = load_with_reader(reader, "memory_io");
+        REQUIRE_FALSE(result.has_value());
+        REQUIRE(result.error().type == vsag::ErrorType::INVALID_ARGUMENT);
+    }
+
+    SECTION("rejects reader io without a precise reader") {
+        vsag::LoadParameters load_parameters;
+        load_parameters.Set("precise_io_type", "reader_io");
+        std::stringstream load_stream(bytes);
+        auto result = vsag::Index::Load(load_stream, load_parameters);
+        REQUIRE_FALSE(result.has_value());
+        REQUIRE(result.error().type == vsag::ErrorType::INVALID_ARGUMENT);
+    }
+
+    SECTION("validates precise reader load parameter types") {
+        const std::vector<std::string> invalid_parameters{
+            R"({"precise_io_type": 1})",
+            R"({"precise_io_type": "unknown_io"})",
+            R"({"precise_io_type": "reader_io", "precise_enable_read_cache": "true"})",
+            R"({"precise_io_type": "reader_io", "precise_cache_total_size": -1})",
+        };
+        for (const auto& parameters : invalid_parameters) {
+            vsag::LoadParameters load_parameters(parameters);
+            load_parameters.SetReader("precise_reader",
+                                      std::make_shared<CountingMemoryReader>(precise_payload));
+            std::stringstream load_stream(bytes);
+            auto result = vsag::Index::Load(load_stream, load_parameters);
+            REQUIRE_FALSE(result.has_value());
+            REQUIRE(result.error().type == vsag::ErrorType::INVALID_ARGUMENT);
+        }
+    }
+
+    SECTION("rejects an invalid precise IO override without a reader") {
+        for (const auto& parameters :
+             {R"({"precise_io_type": 1})", R"({"precise_io_type": "unknown_io"})"}) {
+            std::stringstream load_stream(bytes);
+            auto result = vsag::Index::Load(load_stream, parameters);
+            REQUIRE_FALSE(result.has_value());
+            REQUIRE(result.error().type == vsag::ErrorType::INVALID_ARGUMENT);
+        }
+    }
+
+    SECTION("rejects a null precise reader") {
+        auto result = load_with_reader(nullptr);
+        REQUIRE_FALSE(result.has_value());
+        REQUIRE(result.error().type == vsag::ErrorType::INVALID_ARGUMENT);
+    }
+
+    SECTION("rejects a precise reader with the wrong payload size") {
+        REQUIRE(precise_payload.size() > 1);
+        auto reader = std::make_shared<CountingMemoryReader>(
+            precise_payload.substr(0, precise_payload.size() - 1));
+        auto result = load_with_reader(reader);
+        REQUIRE_FALSE(result.has_value());
+        REQUIRE(result.error().type == vsag::ErrorType::INVALID_ARGUMENT);
+    }
+
+    SECTION("rejects a precise reader with a corrupted payload") {
+        REQUIRE_FALSE(precise_payload.empty());
+        auto corrupted_payload = precise_payload;
+        corrupted_payload[corrupted_payload.size() / 2] ^= 1;
+        auto reader = std::make_shared<CountingMemoryReader>(std::move(corrupted_payload));
+        auto result = load_with_reader(reader);
+        REQUIRE_FALSE(result.has_value());
+        REQUIRE(result.error().type == vsag::ErrorType::INVALID_BINARY);
+    }
+
+    SECTION("propagates a precise reader failure") {
+        auto reader = std::make_shared<CountingMemoryReader>(precise_payload, true);
+        auto result = load_with_reader(reader);
+        REQUIRE_FALSE(result.has_value());
+    }
+}
+
+TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
+                             "IVF rejects a precise reader without precise codes",
+                             "[ft][ivf][reader_io][pr]") {
+    const auto params = GenerateIVFBuildParametersString("l2", 16, "sq8", 16, "random");
+    auto dataset = pool.GetDatasetAndCreate(16, 128, "l2");
+    auto index = TestFactory(name, params, true);
+    TestBuildIndex(index, dataset, true);
+
+    std::stringstream stream;
+    REQUIRE(index->SerializeStreaming(stream).has_value());
+    vsag::LoadParameters load_parameters;
+    load_parameters.Set("precise_io_type", "reader_io")
+        .SetReader("precise_reader", std::make_shared<CountingMemoryReader>(""));
+    std::stringstream load_stream(stream.str());
+    auto result = vsag::Index::Load(load_stream, load_parameters);
+    REQUIRE_FALSE(result.has_value());
+    REQUIRE(result.error().type == vsag::ErrorType::INVALID_ARGUMENT);
 }
 
 TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,

--- a/tests/test_ivf.cpp
+++ b/tests/test_ivf.cpp
@@ -512,8 +512,8 @@ TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
 }
 
 TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
-                             "IVF disk bucket precise rejects aliased ownership operations",
-                             "[ft][ivf][reorder][serialize][streaming][export][pr]") {
+                             "IVF disk bucket precise",
+                             "[ft][ivf][reorder][serialize][streaming][pr]") {
     BlockSizeLimitGuard block_size_limit_guard(2ULL * 1024 * 1024);
     constexpr int64_t dim = 16;
     constexpr int64_t base_count = 128;
@@ -522,48 +522,6 @@ TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
     auto dataset = pool.GetDatasetAndCreate(dim, base_count, "l2");
     auto index = TestFactory(name, params, true);
     TestBuildIndex(index, dataset, true);
-    REQUIRE_FALSE(index->CheckFeature(vsag::SUPPORT_CLONE));
-    REQUIRE_FALSE(index->CheckFeature(vsag::SUPPORT_EXPORT_MODEL));
-    REQUIRE_FALSE(index->CheckFeature(vsag::SUPPORT_MERGE_INDEX));
-
-    SECTION("rejects export model") {
-        auto result = index->ExportModel();
-        REQUIRE_FALSE(result.has_value());
-        REQUIRE(result.error().type == vsag::ErrorType::UNSUPPORTED_INDEX_OPERATION);
-    }
-
-    SECTION("rejects clone") {
-        auto result = index->Clone();
-        REQUIRE_FALSE(result.has_value());
-        REQUIRE(result.error().type == vsag::ErrorType::UNSUPPORTED_INDEX_OPERATION);
-    }
-
-    SECTION("rejects merge") {
-        auto result = index->Merge({});
-        REQUIRE_FALSE(result.has_value());
-        REQUIRE(result.error().type == vsag::ErrorType::UNSUPPORTED_INDEX_OPERATION);
-    }
-
-    SECTION("rejects streaming load") {
-        std::stringstream stream;
-        REQUIRE(index->SerializeStreaming(stream).has_value());
-        std::stringstream load_stream(stream.str());
-        auto result = vsag::Index::Load(load_stream, "{}");
-        REQUIRE_FALSE(result.has_value());
-        REQUIRE(result.error().type == vsag::ErrorType::UNSUPPORTED_INDEX_OPERATION);
-    }
-
-    SECTION("rejects empty streaming load") {
-        const auto empty_file_path = dir.GenerateRandomFile(false);
-        const auto empty_params = GenerateBucketPreciseParameters("buffer_io", empty_file_path);
-        auto empty_index = TestFactory(name, empty_params, true);
-        std::stringstream stream;
-        REQUIRE(empty_index->SerializeStreaming(stream).has_value());
-        std::stringstream load_stream(stream.str());
-        auto result = vsag::Index::Load(load_stream, "{}");
-        REQUIRE_FALSE(result.has_value());
-        REQUIRE(result.error().type == vsag::ErrorType::UNSUPPORTED_INDEX_OPERATION);
-    }
 
     SECTION("rejects mmap before creating the precise file") {
         const auto mmap_file_path = dir.GenerateRandomFile(false);

--- a/tests/test_ivf.cpp
+++ b/tests/test_ivf.cpp
@@ -222,7 +222,9 @@ GenerateBucketPreciseParameters(const std::string& precise_io_type = "block_memo
     params["index_param"]["precise_file_path"] = precise_file_path;
     if (enable_read_cache) {
         params["index_param"]["precise_enable_read_cache"] = true;
-        params["index_param"]["precise_cache_total_size"] = 128 * 1024;
+        // BucketDataCell divides the cache budget across the 16 buckets. Allocate one
+        // 128-KiB cache page per bucket so this case exercises the read-cache path.
+        params["index_param"]["precise_cache_total_size"] = 16 * 128 * 1024;
     }
     return params.dump();
 }

--- a/tests/test_ivf.cpp
+++ b/tests/test_ivf.cpp
@@ -15,6 +15,7 @@
 
 #include <algorithm>
 #include <cstring>
+#include <filesystem>
 #include <limits>
 #include <nlohmann/json.hpp>
 #include <sstream>
@@ -441,6 +442,7 @@ TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
     auto dataset = pool.GetDatasetAndCreate(dim, base_count, "l2");
     auto index = TestFactory(name, params, true);
     TestBuildIndex(index, dataset, true);
+    REQUIRE(index->ExportModel().has_value());
 
     std::stringstream stream;
     REQUIRE(index->SerializeStreaming(stream).has_value());
@@ -465,6 +467,87 @@ TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
     REQUIRE_FALSE(invalid_restored->DeserializeStreaming(missing_deserialize_stream).has_value());
     std::stringstream missing_load_stream(missing_precise);
     REQUIRE_FALSE(vsag::Index::Load(missing_load_stream, "{}").has_value());
+}
+
+TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
+                             "IVF disk bucket precise rejects aliased ownership operations",
+                             "[ft][ivf][reorder][serialize][streaming][export][pr]") {
+    constexpr int64_t dim = 16;
+    constexpr int64_t base_count = 128;
+    const auto precise_file_path = dir.GenerateRandomFile(false);
+    const auto params = GenerateBucketPreciseParameters(1, "buffer_io", precise_file_path);
+    auto dataset = pool.GetDatasetAndCreate(dim, base_count, "l2");
+    auto index = TestFactory(name, params, true);
+    TestBuildIndex(index, dataset, true);
+    REQUIRE_FALSE(index->CheckFeature(vsag::SUPPORT_CLONE));
+    REQUIRE_FALSE(index->CheckFeature(vsag::SUPPORT_EXPORT_MODEL));
+    REQUIRE_FALSE(index->CheckFeature(vsag::SUPPORT_MERGE_INDEX));
+
+    SECTION("rejects export model") {
+        auto result = index->ExportModel();
+        REQUIRE_FALSE(result.has_value());
+        REQUIRE(result.error().type == vsag::ErrorType::UNSUPPORTED_INDEX_OPERATION);
+    }
+
+    SECTION("rejects clone") {
+        auto result = index->Clone();
+        REQUIRE_FALSE(result.has_value());
+        REQUIRE(result.error().type == vsag::ErrorType::UNSUPPORTED_INDEX_OPERATION);
+    }
+
+    SECTION("rejects merge") {
+        auto result = index->Merge({});
+        REQUIRE_FALSE(result.has_value());
+        REQUIRE(result.error().type == vsag::ErrorType::UNSUPPORTED_INDEX_OPERATION);
+    }
+
+    SECTION("rejects streaming load") {
+        std::stringstream stream;
+        REQUIRE(index->SerializeStreaming(stream).has_value());
+        std::stringstream load_stream(stream.str());
+        auto result = vsag::Index::Load(load_stream, "{}");
+        REQUIRE_FALSE(result.has_value());
+        REQUIRE(result.error().type == vsag::ErrorType::UNSUPPORTED_INDEX_OPERATION);
+    }
+
+    SECTION("rejects empty streaming load") {
+        const auto empty_file_path = dir.GenerateRandomFile(false);
+        const auto empty_params = GenerateBucketPreciseParameters(1, "buffer_io", empty_file_path);
+        auto empty_index = TestFactory(name, empty_params, true);
+        std::stringstream stream;
+        REQUIRE(empty_index->SerializeStreaming(stream).has_value());
+        std::stringstream load_stream(stream.str());
+        auto result = vsag::Index::Load(load_stream, "{}");
+        REQUIRE_FALSE(result.has_value());
+        REQUIRE(result.error().type == vsag::ErrorType::UNSUPPORTED_INDEX_OPERATION);
+    }
+
+    SECTION("rejects mmap before creating the precise file") {
+        const auto mmap_file_path = dir.GenerateRandomFile(false);
+        const auto mmap_params = GenerateBucketPreciseParameters(1, "mmap_io", mmap_file_path);
+        auto result = vsag::Factory::CreateIndex(name, mmap_params);
+        REQUIRE_FALSE(result.has_value());
+        REQUIRE(result.error().type == vsag::ErrorType::INVALID_ARGUMENT);
+        REQUIRE_FALSE(std::filesystem::exists(mmap_file_path));
+    }
+
+    SECTION("allows streaming deserialize into an independent precise file") {
+        std::stringstream stream;
+        REQUIRE(index->SerializeStreaming(stream).has_value());
+        const auto restored_file_path = dir.GenerateRandomFile(false);
+        const auto restored_params =
+            GenerateBucketPreciseParameters(1, "buffer_io", restored_file_path);
+        auto restored = TestFactory(name, restored_params, true);
+        std::stringstream deserialize_stream(stream.str());
+        REQUIRE(restored->DeserializeStreaming(deserialize_stream).has_value());
+        const auto search_param = fmt::format(search_param_tmp, 16);
+        CheckBucketPreciseIndex(restored, dataset, search_param);
+        TestBatchCalcDistanceById(restored, dataset, 2e-6F, true);
+    }
+
+    const auto search_param = fmt::format(search_param_tmp, 16);
+    CheckBucketPreciseIndex(index, dataset, search_param);
+    TestBatchCalcDistanceById(index, dataset, 2e-6F, true);
 }
 
 TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,

--- a/tests/test_ivf.cpp
+++ b/tests/test_ivf.cpp
@@ -213,12 +213,17 @@ private:
 std::string
 GenerateBucketPreciseParameters(const std::string& precise_io_type = "block_memory_io",
                                 const std::string& precise_file_path = "",
-                                int thread_count = 1) {
+                                int thread_count = 1,
+                                bool enable_read_cache = false) {
     auto params = nlohmann::json::parse(IVFTestIndex::GenerateIVFBuildParametersString(
         "l2", 16, "sq8,fp32", 16, "random", false, 1, false, thread_count));
     params["index_param"]["precise_codes_layout"] = "bucket";
     params["index_param"]["precise_io_type"] = precise_io_type;
     params["index_param"]["precise_file_path"] = precise_file_path;
+    if (enable_read_cache) {
+        params["index_param"]["precise_enable_read_cache"] = true;
+        params["index_param"]["precise_cache_total_size"] = 128 * 1024;
+    }
     return params.dump();
 }
 
@@ -430,11 +435,14 @@ TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
     constexpr int64_t base_count = 128;
     constexpr int64_t buckets_count = 16;
     const auto precise_io_type = GENERATE("block_memory_io", "buffer_io");
+    const bool enable_read_cache = precise_io_type == std::string("buffer_io");
     INFO(fmt::format("precise_io_type: {}", precise_io_type));
+    INFO(fmt::format("enable_read_cache: {}", enable_read_cache));
 
     const auto precise_file_path =
         precise_io_type == std::string("buffer_io") ? dir.GenerateRandomFile(false) : std::string();
-    const auto params = GenerateBucketPreciseParameters(precise_io_type, precise_file_path);
+    const auto params =
+        GenerateBucketPreciseParameters(precise_io_type, precise_file_path, 1, enable_read_cache);
     const auto search_param = fmt::format(search_param_tmp, buckets_count);
     auto dataset = pool.GetDatasetAndCreate(dim, base_count, "l2");
     auto index = TestFactory(name, params, true);
@@ -448,7 +456,7 @@ TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
     const auto restored_file_path =
         precise_io_type == std::string("buffer_io") ? dir.GenerateRandomFile(false) : std::string();
     const auto restored_params =
-        GenerateBucketPreciseParameters(precise_io_type, restored_file_path);
+        GenerateBucketPreciseParameters(precise_io_type, restored_file_path, 1, enable_read_cache);
     auto restored = TestFactory(name, restored_params, true);
     TestSerializeBinarySet(index, restored, dataset, search_param, true);
     CheckBucketPreciseIndex(restored, dataset, search_param);

--- a/tests/test_ivf.cpp
+++ b/tests/test_ivf.cpp
@@ -211,12 +211,11 @@ private:
 };
 
 std::string
-GenerateBucketPreciseParameters(int buckets_per_data,
-                                const std::string& precise_io_type = "block_memory_io",
+GenerateBucketPreciseParameters(const std::string& precise_io_type = "block_memory_io",
                                 const std::string& precise_file_path = "",
                                 int thread_count = 1) {
     auto params = nlohmann::json::parse(IVFTestIndex::GenerateIVFBuildParametersString(
-        "l2", 16, "sq8,fp32", 16, "random", false, buckets_per_data, false, thread_count));
+        "l2", 16, "sq8,fp32", 16, "random", false, 1, false, thread_count));
     params["index_param"]["precise_codes_layout"] = "bucket";
     params["index_param"]["precise_io_type"] = precise_io_type;
     params["index_param"]["precise_file_path"] = precise_file_path;
@@ -411,6 +410,18 @@ TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
     vsag::Options::Instance().set_block_size_limit(origin_size);
 }
 
+TEST_CASE("IVF bucket precise rejects multiple postings per data", "[ft][ivf][reorder][pr]") {
+    auto params = nlohmann::json::parse(GenerateBucketPreciseParameters());
+    params["index_param"]["buckets_per_data"] = 2;
+
+    auto result = vsag::Factory::CreateIndex(IVFTestIndex::name, params.dump());
+
+    REQUIRE_FALSE(result.has_value());
+    REQUIRE(result.error().type == vsag::ErrorType::INVALID_ARGUMENT);
+    REQUIRE(result.error().message.find(
+                "precise_codes_layout=bucket requires buckets_per_data=1") != std::string::npos);
+}
+
 TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
                              "IVF bucket precise mirrors basic postings",
                              "[ft][ivf][reorder][serialize][pr]") {
@@ -418,15 +429,12 @@ TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
     constexpr int64_t dim = 16;
     constexpr int64_t base_count = 128;
     constexpr int64_t buckets_count = 16;
-    const auto buckets_per_data = GENERATE(1, 2);
     const auto precise_io_type = GENERATE("block_memory_io", "buffer_io");
-    INFO(fmt::format("buckets_per_data: {}", buckets_per_data));
     INFO(fmt::format("precise_io_type: {}", precise_io_type));
 
     const auto precise_file_path =
         precise_io_type == std::string("buffer_io") ? dir.GenerateRandomFile(false) : std::string();
-    const auto params =
-        GenerateBucketPreciseParameters(buckets_per_data, precise_io_type, precise_file_path);
+    const auto params = GenerateBucketPreciseParameters(precise_io_type, precise_file_path);
     const auto search_param = fmt::format(search_param_tmp, buckets_count);
     auto dataset = pool.GetDatasetAndCreate(dim, base_count, "l2");
     auto index = TestFactory(name, params, true);
@@ -440,7 +448,7 @@ TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
     const auto restored_file_path =
         precise_io_type == std::string("buffer_io") ? dir.GenerateRandomFile(false) : std::string();
     const auto restored_params =
-        GenerateBucketPreciseParameters(buckets_per_data, precise_io_type, restored_file_path);
+        GenerateBucketPreciseParameters(precise_io_type, restored_file_path);
     auto restored = TestFactory(name, restored_params, true);
     TestSerializeBinarySet(index, restored, dataset, search_param, true);
     CheckBucketPreciseIndex(restored, dataset, search_param);
@@ -455,7 +463,7 @@ TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
     constexpr int64_t dim = 16;
     constexpr int64_t base_count = 128;
     constexpr int64_t buckets_count = 16;
-    const auto params = GenerateBucketPreciseParameters(2, "block_memory_io", "", 4);
+    const auto params = GenerateBucketPreciseParameters("block_memory_io", "", 4);
     const auto search_param = fmt::format(search_param_tmp, buckets_count);
     auto dataset = pool.GetDatasetAndCreate(dim, base_count, "l2");
     auto index = TestFactory(name, params, true);
@@ -494,7 +502,7 @@ TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
     constexpr int64_t dim = 16;
     constexpr int64_t base_count = 128;
     const auto precise_file_path = dir.GenerateRandomFile(false);
-    const auto params = GenerateBucketPreciseParameters(1, "buffer_io", precise_file_path);
+    const auto params = GenerateBucketPreciseParameters("buffer_io", precise_file_path);
     auto dataset = pool.GetDatasetAndCreate(dim, base_count, "l2");
     auto index = TestFactory(name, params, true);
     TestBuildIndex(index, dataset, true);
@@ -531,7 +539,7 @@ TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
 
     SECTION("rejects empty streaming load") {
         const auto empty_file_path = dir.GenerateRandomFile(false);
-        const auto empty_params = GenerateBucketPreciseParameters(1, "buffer_io", empty_file_path);
+        const auto empty_params = GenerateBucketPreciseParameters("buffer_io", empty_file_path);
         auto empty_index = TestFactory(name, empty_params, true);
         std::stringstream stream;
         REQUIRE(empty_index->SerializeStreaming(stream).has_value());
@@ -543,7 +551,7 @@ TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
 
     SECTION("rejects mmap before creating the precise file") {
         const auto mmap_file_path = dir.GenerateRandomFile(false);
-        const auto mmap_params = GenerateBucketPreciseParameters(1, "mmap_io", mmap_file_path);
+        const auto mmap_params = GenerateBucketPreciseParameters("mmap_io", mmap_file_path);
         auto result = vsag::Factory::CreateIndex(name, mmap_params);
         REQUIRE_FALSE(result.has_value());
         REQUIRE(result.error().type == vsag::ErrorType::INVALID_ARGUMENT);
@@ -555,7 +563,7 @@ TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
         REQUIRE(index->SerializeStreaming(stream).has_value());
         const auto restored_file_path = dir.GenerateRandomFile(false);
         const auto restored_params =
-            GenerateBucketPreciseParameters(1, "buffer_io", restored_file_path);
+            GenerateBucketPreciseParameters("buffer_io", restored_file_path);
         auto restored = TestFactory(name, restored_params, true);
         std::stringstream deserialize_stream(stream.str());
         REQUIRE(restored->DeserializeStreaming(deserialize_stream).has_value());
@@ -576,7 +584,7 @@ TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
     constexpr int64_t dim = 16;
     constexpr int64_t base_count = 128;
     constexpr int64_t buckets_count = 16;
-    const auto params = GenerateBucketPreciseParameters(2);
+    const auto params = GenerateBucketPreciseParameters();
     const auto search_param = fmt::format(search_param_tmp, buckets_count);
     auto dataset = pool.GetDatasetAndCreate(dim, base_count, "l2");
     auto model = TestFactory(name, params, true);

--- a/tests/test_ivf.cpp
+++ b/tests/test_ivf.cpp
@@ -643,6 +643,7 @@ TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
     constexpr int64_t buckets_count = 16;
     constexpr int64_t query_id = 3;
     constexpr int64_t batch_count = 8;
+    constexpr uint64_t precise_cache_total_size = 16ULL * 128 * 1024;
     const auto precise_codes_layout = GENERATE(std::string("flat"), std::string("bucket"));
     const bool enable_read_cache = GENERATE(false, true);
     CAPTURE(precise_codes_layout);
@@ -662,7 +663,7 @@ TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
         vsag::LoadParameters load_parameters;
         load_parameters.Set("precise_io_type", "reader_io")
             .Set("precise_enable_read_cache", enable_read_cache)
-            .Set("precise_cache_total_size", 16ULL * 128 * 1024)
+            .Set("precise_cache_total_size", precise_cache_total_size)
             .SetReader("precise_reader", reader);
         std::stringstream load_stream(bytes);
         return vsag::Index::Load(load_stream, load_parameters);


### PR DESCRIPTION
## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Improvement/Refactor
- [ ] Documentation
- [ ] CI/Build/Infra

## Linked Issue

- Closes: #2519

## What Changed

- Add `precise_codes_layout: "flat" | "bucket"` and keep `flat` as the compatibility default.
- Store bucket-layout precise codes with the same posting id, bucket, and offset as the corresponding basic posting.
- Require `buckets_per_data: 1` for the first bucket-layout version and reject multi-assignment explicitly.
- Cover train, add, reorder, distance-by-id, serialization, streaming load, model export, merge, and alignment validation.
- Add a dedicated critical streaming tag for the bucket payload.
- Add a runnable C++ example for disk-backed bucket-aligned precise codes.
- Document the new layout and supported IO backends in English and Chinese.
- Validate serialized `BucketDataCell` metadata before indexing logical bucket entries.

The first implementation intentionally keeps per-candidate `QueryOneById` reads. Grouped batch
reads remain a follow-up optimization. Bucket-aligned precise codes inherit the shared read-cache
options from `main` (`precise_enable_read_cache` and `precise_cache_total_size`), covered with
`buffer_io`.

The shared disk-backed `BucketDataCell` memory-accounting bug found during review is tracked
separately in #2573; it also affects basic IVF buckets on `main`.

## Test Evidence

- [x] `clang-format` 15 dry-run
- [ ] `make lint`
- [ ] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [x] Other (describe below)

Test details:

```text
cmake --build build --target unittests -j 3
cmake --build build --target functests 326_feature_ivf_precise_bucket -j 3
Both builds completed successfully.

./build/tests/unittests "BucketDataCell rejects inconsistent serialized metadata" ...
All tests passed (4 assertions in 1 test case).

./build/tests/unittests '[ut][BucketDataCell]' ...
All tests passed (1327200 assertions in 5 test cases).

./build/tests/unittests '[IVFParameter]' ...
All tests passed (65 assertions in 5 test cases).

./build/tests/functests '[ivf][reorder][pr]' ...
All tests passed (136697 assertions in 5 test cases).

./build/tests/functests '[ivf]' '~[daily]' ...
All tests passed (412648 assertions in 45 test cases).

./build/examples/cpp/326_feature_ivf_precise_bucket
The example completed successfully; the self-query returned id=0 with distance=0.
```

Coverage includes `buckets_per_data=1` plus rejection coverage for `>1`, `buffer_io` disk files,
precise read cache, ContinueAdd, four-thread in-memory build, BinarySet and streaming round trips,
Index::Load, merge, scalar/batch distance-by-id, and malformed bucket metadata rejection.

## Compatibility Impact

- API/ABI compatibility: additive public constants and one optional IVF parameter.
- Behavior changes: none for existing configurations. Missing `precise_codes_layout` defaults to
  `flat`, so existing flat indexes remain readable. New bucket indexes persist their layout and
  use a distinct streaming block.

## Performance and Concurrency Impact

- Performance impact: the bucket layout enables precise-code locality for disk-backed IVF and
  uses the shared precise read-cache options from `main`; comparative performance measurement is
  deferred to a dedicated POC. The first version rejects `buckets_per_data > 1`, so reranking
  always reads the unique aligned posting.
- Concurrency/thread-safety impact: precise postings are written before publishing their basic
  mirrors. The shared `NonContinuousIO` allocation path is synchronized, and four-thread
  in-memory construction is covered.

## Documentation Impact

- [ ] No docs update needed
- [x] Updated docs:
  - [ ] `README.md`
  - [ ] `DEVELOPMENT.md`
  - [ ] `CONTRIBUTING.md`
  - [x] Other: IVF website docs and `examples/cpp/README.md`

## Risk and Rollback

- Risk level: medium; the new layout touches IVF persistence and merge paths but is opt-in.
- Rollback plan: revert this PR. Existing indexes continue to use the unchanged default flat
  layout.

## Checklist

- [x] I have linked the relevant issue.
- [x] I have added/updated tests for new behavior.
- [x] I have considered API compatibility impact.
- [x] I have updated docs for the new behavior.
- [x] My commit message follows project conventions.
