### PR TITLE
fix(ci): simplify docs sync lease handling

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -3,11 +3,12 @@ name: Sync Docs to Repo VSAGIO
 
 on:
   push:
-    branches:
-      - main
-    paths:
-      - 'docs/**'
+    branches: [main]
+    paths: ['docs/**']
   workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   sync:
@@ -16,8 +17,9 @@ jobs:
       - name: Checkout Repo VSAG
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.sha }}
           path: repo-vsag
-
+          persist-credentials: false
       - name: Checkout Repo VSAGIO
         uses: actions/checkout@v4
         with:
@@ -25,35 +27,62 @@ jobs:
           token: ${{ secrets.GH_PAT }}
           ref: main
           path: repo-vsagio
-
+      - name: Prepare shared sync branch
+        working-directory: repo-vsagio
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin main
+          expected_remote_oid="$(git ls-remote origin refs/heads/sync | awk 'NR == 1 { print $1 }')"
+          if [[ -n "$expected_remote_oid" ]]; then
+            [[ "$expected_remote_oid" =~ ^[0-9a-f]{40}$ ]]
+            git fetch --no-tags origin \
+              "refs/heads/sync:refs/remotes/origin/sync"
+          else
+            expected_remote_oid=0000000000000000000000000000000000000000
+          fi
+          git checkout -B sync origin/main
+          echo "EXPECTED_REMOTE_OID=$expected_remote_oid" >> "$GITHUB_ENV"
       - name: Sync docs books (zh, en)
         run: |
+          set -euo pipefail
           mkdir -p repo-vsagio/docs
           rsync -av --delete repo-vsag/docs/docs/zh/ repo-vsagio/docs/zh/
           rsync -av --delete repo-vsag/docs/docs/en/ repo-vsagio/docs/en/
-
       - name: Sync blogs books (zh, en)
         run: |
+          set -euo pipefail
           mkdir -p repo-vsagio/blogs
           rsync -av --delete repo-vsag/docs/blog/zh/ repo-vsagio/blogs/zh/
           rsync -av --delete repo-vsag/docs/blog/en/ repo-vsagio/blogs/en/
-
       - name: Sync landing page (site root)
         run: |
+          set -euo pipefail
           mkdir -p repo-vsagio/landing
           rsync -av --delete repo-vsag/docs/landing/ repo-vsagio/landing/
-
-      - name: Commit and Push to sync branch
+      - name: Commit and publish shared snapshot
+        working-directory: repo-vsagio
+        shell: bash
         run: |
-          cd repo-vsagio
+          set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git checkout -B sync origin/main
           git add -A docs blogs landing
-          if [[ -z $(git status --porcelain) ]]; then
-            echo "No changes to commit."
-            git push --force origin sync
+          if [[ -n "$(git status --porcelain)" ]]; then
+            git commit -m "docs: sync from vsag@${GITHUB_SHA}"
+          fi
+          set +e
+          push_output="$(git push \
+            --force-with-lease="refs/heads/sync:${EXPECTED_REMOTE_OID}" \
+            origin sync 2>&1)"
+          push_status=$?
+          set -e
+          if [[ "$push_status" -eq 0 ]]; then
             exit 0
           fi
-          git commit -m "docs: sync from vsag@${{ github.sha }}"
-          git push --force origin sync
+          printf '%s\n' "$push_output" >&2
+          if grep -Fq 'stale info' <<< "$push_output"; then
+            echo "Warning: shared sync branch changed during this run; keeping the other snapshot." >&2
+            exit 0
+          fi
+          exit "$push_status"


### PR DESCRIPTION
## Summary

Sync documentation from the current target `main` snapshot into the cumulative shared `sync` branch. The workflow reads the remote `sync` OID, publishes with `--force-with-lease`, and treats only a stale-lease rejection as a successful concurrent winner. Authentication, connectivity, and other push failures remain visible and fail the job.

The source-SHA-specific branches, unique-PR machinery, retry/adoption logic, and target-side freshness guard are removed.

## Validation

- YAML and shell syntax checked.
- Local simulation covers successful lease publication and stale-lease rejection.
- No merge or deployment is requested.