### PR TITLE
perf(sindi): optimize DMQ codebooks and packed ID decoding

### DIFF
--- a/docs/docs/en/src/indexes/sindi.md
+++ b/docs/docs/en/src/indexes/sindi.md
@@ -78,6 +78,7 @@ and `metric_type` **must** be `"ip"`.
 | `use_quantization` | bool | `false` | Quantize stored term values to cut memory; when enabled, uses 8-bit scalar quantization (SQ8). |
 | `use_reorder` | bool | `false` | Keep a forward store and rescore candidates after coarse SINDI scoring. |
 | `rerank_type` | string | `"fp32"` | Forward-store type used when `use_reorder` is enabled. `fp32` keeps exact values; `dmq8` stores compressed 8-bit DMQ codes. |
+| `dmq_shared_codebook_threshold` | int | `1024` | With `rerank_type: "dmq8"`, terms occurring at most this many times share one codebook; more frequent terms keep independent codebooks. Set to `0` to disable sharing. |
 | `remap_term_ids` | bool | `false` | Remap term IDs before indexing; useful when term IDs are sparse or have large gaps. |
 | `avg_doc_term_length` | int | `100` | Hint for memory estimation only. |
 

--- a/docs/docs/zh/src/indexes/sindi.md
+++ b/docs/docs/zh/src/indexes/sindi.md
@@ -73,6 +73,7 @@ auto result = index->KnnSearch(
 | `use_quantization` | bool | `false` | 是否量化词项权重以降低内存；开启后使用 8-bit 标量量化（SQ8） |
 | `use_reorder` | bool | `false` | 是否保留一份正排存储，在 SINDI 粗排后对候选做精排 |
 | `rerank_type` | string | `"fp32"` | `use_reorder` 开启时使用的正排存储类型。`fp32` 保留精确值；`dmq8` 使用压缩的 8-bit DMQ 编码 |
+| `dmq_shared_codebook_threshold` | int | `1024` | `rerank_type: "dmq8"` 时，出现次数不超过该值的 term 共用一个 codebook；更高频的 term 保持独立 codebook。设为 `0` 可关闭共享 |
 | `remap_term_ids` | bool | `false` | 是否在建索引前重映射词项 ID，适用于词项 ID 很稀疏或存在大量空洞的词表 |
 | `avg_doc_term_length` | int | `100` | 仅用于内存估算 |
 

--- a/src/algorithm/sindi/sindi.cpp
+++ b/src/algorithm/sindi/sindi.cpp
@@ -192,6 +192,7 @@ SINDI::SINDI(const SINDIParameterPtr& param, const IndexCommonParam& common_para
       use_reorder_(param->use_reorder),
       sparse_value_quant_type_(param->sparse_value_quant_type),
       rerank_type_(param->rerank_type),
+      dmq_shared_codebook_threshold_(param->dmq_shared_codebook_threshold),
       term_id_limit_(param->term_id_limit),
       window_size_(param->window_size),
       doc_prune_ratio_(param->doc_prune_ratio),
@@ -1831,15 +1832,23 @@ SINDI::EstimateMemory(uint64_t num_elements) const {
     if (use_reorder_) {
         uint64_t total_sparse_values = static_cast<uint64_t>(avg_doc_term_length_) * num_elements;
         if (rerank_type_ == SPARSE_RERANK_TYPE_DMQ8) {
-            uint32_t rerank_id_bits =
-                remap_term_ids_ ? 32 : get_bits_for_term_id_limit(term_id_limit_);
+            const uint64_t estimated_term_count =
+                std::min<uint64_t>(term_id_limit_, total_sparse_values);
+            const uint32_t rerank_id_bits = get_bits_for_term_id_limit(
+                estimated_term_count == 0 ? 0 : static_cast<uint32_t>(estimated_term_count - 1));
             mem += (total_sparse_values * rerank_id_bits + 7) / 8;
             mem += total_sparse_values;
             mem += num_elements * (sizeof(uint64_t) + sizeof(SparseDmqQuantizer::EncodedHeader));
-            uint64_t estimated_codebook_count =
-                std::min<uint64_t>(term_id_limit_, total_sparse_values);
+            uint64_t estimated_codebook_count = estimated_term_count;
+            if (dmq_shared_codebook_threshold_ != 0 && total_sparse_values != 0) {
+                const uint64_t minimum_dedicated_term_frequency =
+                    static_cast<uint64_t>(dmq_shared_codebook_threshold_) + 1;
+                estimated_codebook_count =
+                    std::min(estimated_term_count,
+                             total_sparse_values / minimum_dedicated_term_frequency + 1);
+            }
             mem += estimated_codebook_count * sizeof(SparseDmqQuantizer::Codebook);
-            mem += estimated_codebook_count * sizeof(uint32_t);
+            mem += estimated_term_count * 2 * sizeof(uint32_t);
         } else {
             mem += num_elements *
                    (sizeof(uint32_t) + avg_doc_term_length_ * (sizeof(uint32_t) + sizeof(float)));

--- a/src/algorithm/sindi/sindi.cpp
+++ b/src/algorithm/sindi/sindi.cpp
@@ -87,9 +87,11 @@ collect_heap_results(const DistHeapPtr& results, Allocator* allocator) {
 FlattenInterfacePtr
 create_rerank_flat(const IndexCommonParam& common_param,
                    const std::string& rerank_type,
-                   uint32_t term_id_limit) {
+                   uint32_t term_id_limit,
+                   uint32_t dmq_shared_codebook_threshold) {
     if (rerank_type == SPARSE_RERANK_TYPE_DMQ8) {
-        return std::make_shared<SparseDmqDataCell>(term_id_limit, common_param);
+        return std::make_shared<SparseDmqDataCell>(
+            term_id_limit, common_param, dmq_shared_codebook_threshold);
     }
     auto rerank_param = std::make_shared<SparseVectorDataCellParameter>();
     rerank_param->io_parameter = std::make_shared<MemoryBlockIOParameter>();
@@ -208,7 +210,8 @@ SINDI::SINDI(const SINDIParameterPtr& param, const IndexCommonParam& common_para
     if (use_reorder_) {
         uint32_t rerank_term_id_limit =
             remap_term_ids_ ? std::numeric_limits<uint32_t>::max() : term_id_limit_;
-        rerank_flat_ = create_rerank_flat(common_param, rerank_type_, rerank_term_id_limit);
+        rerank_flat_ = create_rerank_flat(
+            common_param, rerank_type_, rerank_term_id_limit, param->dmq_shared_codebook_threshold);
     }
 }
 

--- a/src/algorithm/sindi/sindi.h
+++ b/src/algorithm/sindi/sindi.h
@@ -364,6 +364,7 @@ private:
     SparseValueQuantizationType sparse_value_quant_type_{SparseValueQuantizationType::FP32};
 
     std::string rerank_type_{"fp32"};
+    uint32_t dmq_shared_codebook_threshold_{DEFAULT_SPARSE_DMQ_SHARED_CODEBOOK_THRESHOLD};
 
     bool deserialize_without_footer_{false};  // backward-compat: old format lacks footer
     bool deserialize_without_buffer_{false};  // backward-compat: old format lacks buffer

--- a/src/algorithm/sindi/sindi_parameter.cpp
+++ b/src/algorithm/sindi/sindi_parameter.cpp
@@ -15,6 +15,8 @@
 
 #include "sindi_parameter.h"
 
+#include <limits>
+
 #include "impl/logger/logger.h"
 #include "inner_string_params.h"
 #include "utils/param_compat_macros.h"
@@ -137,6 +139,33 @@ SINDIParameter::FromJson(const JsonType& json) {
     CHECK_ARGUMENT(use_reorder || rerank_type == SPARSE_RERANK_TYPE_FP32,
                    "rerank_type=dmq8 requires use_reorder=true");
 
+    if (json.Contains(SPARSE_DMQ_SHARED_CODEBOOK_THRESHOLD)) {
+        const auto threshold_json = json[SPARSE_DMQ_SHARED_CODEBOOK_THRESHOLD];
+        CHECK_ARGUMENT(threshold_json.IsNumberInteger(),
+                       "dmq_shared_codebook_threshold must be an integer");
+        if (threshold_json.IsNumberUnsigned()) {
+            const auto threshold = threshold_json.GetUint64();
+            CHECK_ARGUMENT(threshold <= std::numeric_limits<uint32_t>::max(),
+                           fmt::format("dmq_shared_codebook_threshold must be in [0, {}], got {}",
+                                       std::numeric_limits<uint32_t>::max(),
+                                       threshold));
+            dmq_shared_codebook_threshold = static_cast<uint32_t>(threshold);
+        } else {
+            const auto threshold = threshold_json.GetInt();
+            CHECK_ARGUMENT(threshold >= 0,
+                           fmt::format("dmq_shared_codebook_threshold must be in [0, {}], got {}",
+                                       std::numeric_limits<uint32_t>::max(),
+                                       threshold));
+            CHECK_ARGUMENT(static_cast<uint64_t>(threshold) <= std::numeric_limits<uint32_t>::max(),
+                           fmt::format("dmq_shared_codebook_threshold must be in [0, {}], got {}",
+                                       std::numeric_limits<uint32_t>::max(),
+                                       threshold));
+            dmq_shared_codebook_threshold = static_cast<uint32_t>(threshold);
+        }
+    } else {
+        dmq_shared_codebook_threshold = DEFAULT_SPARSE_DMQ_SHARED_CODEBOOK_THRESHOLD;
+    }
+
     if (json.Contains(SPARSE_IMMUTABLE)) {
         immutable = json[SPARSE_IMMUTABLE].GetBool();
     }
@@ -160,6 +189,8 @@ SINDIParameter::ToJson() const {
         json[SPARSE_IMMUTABLE].SetBool(true);
     }
     json[SPARSE_RERANK_TYPE].SetString(rerank_type);
+    json[SPARSE_DMQ_SHARED_CODEBOOK_THRESHOLD].SetInt(
+        static_cast<int64_t>(dmq_shared_codebook_threshold));
     return json;
 }
 
@@ -175,6 +206,7 @@ SINDIParameter::CheckCompatibility(const vsag::ParamPtr& other) const {
     CHECK_FIELD_EQ(*this, *p, remap_term_ids);
     CHECK_FIELD_EQ(*this, *p, immutable);
     CHECK_FIELD_EQ(*this, *p, rerank_type);
+    CHECK_FIELD_EQ(*this, *p, dmq_shared_codebook_threshold);
     return true;
 }
 

--- a/src/algorithm/sindi/sindi_parameter.cpp
+++ b/src/algorithm/sindi/sindi_parameter.cpp
@@ -189,8 +189,10 @@ SINDIParameter::ToJson() const {
         json[SPARSE_IMMUTABLE].SetBool(true);
     }
     json[SPARSE_RERANK_TYPE].SetString(rerank_type);
-    json[SPARSE_DMQ_SHARED_CODEBOOK_THRESHOLD].SetInt(
-        static_cast<int64_t>(dmq_shared_codebook_threshold));
+    if (rerank_type == SPARSE_RERANK_TYPE_DMQ8) {
+        json[SPARSE_DMQ_SHARED_CODEBOOK_THRESHOLD].SetInt(
+            static_cast<int64_t>(dmq_shared_codebook_threshold));
+    }
     return json;
 }
 
@@ -206,7 +208,9 @@ SINDIParameter::CheckCompatibility(const vsag::ParamPtr& other) const {
     CHECK_FIELD_EQ(*this, *p, remap_term_ids);
     CHECK_FIELD_EQ(*this, *p, immutable);
     CHECK_FIELD_EQ(*this, *p, rerank_type);
-    CHECK_FIELD_EQ(*this, *p, dmq_shared_codebook_threshold);
+    if (rerank_type == SPARSE_RERANK_TYPE_DMQ8) {
+        CHECK_FIELD_EQ(*this, *p, dmq_shared_codebook_threshold);
+    }
     return true;
 }
 

--- a/src/algorithm/sindi/sindi_parameter.h
+++ b/src/algorithm/sindi/sindi_parameter.h
@@ -35,6 +35,9 @@ static constexpr const char* SPARSE_RERANK_TYPE = "rerank_type";
 static constexpr const char* SPARSE_RERANK_TYPE_FP32 = "fp32";
 static constexpr const char* SPARSE_RERANK_TYPE_DMQ8 = "dmq8";
 
+static constexpr const char* SPARSE_DMQ_SHARED_CODEBOOK_THRESHOLD = "dmq_shared_codebook_threshold";
+static constexpr uint32_t DEFAULT_SPARSE_DMQ_SHARED_CODEBOOK_THRESHOLD = 1024;
+
 std::string
 SparseValueQuantizationTypeToString(SparseValueQuantizationType type);
 
@@ -66,6 +69,8 @@ public:
     bool remap_term_ids{false};
 
     std::string rerank_type{SPARSE_RERANK_TYPE_FP32};
+
+    uint32_t dmq_shared_codebook_threshold{DEFAULT_SPARSE_DMQ_SHARED_CODEBOOK_THRESHOLD};
 
     bool immutable{false};
 

--- a/src/algorithm/sindi/sindi_parameter_test.cpp
+++ b/src/algorithm/sindi/sindi_parameter_test.cpp
@@ -50,6 +50,7 @@ struct SINDIDefaultParam {
     int avg_doc_term_length = 100;
     bool remap_term_ids = false;
     std::string rerank_type = SPARSE_RERANK_TYPE_FP32;
+    int64_t dmq_shared_codebook_threshold = DEFAULT_SPARSE_DMQ_SHARED_CODEBOOK_THRESHOLD;
     bool immutable = false;
 };
 
@@ -69,6 +70,7 @@ generate_sindi_param(const SINDIDefaultParam& param) {
     json[SPARSE_AVG_DOC_TERM_LENGTH].SetInt(param.avg_doc_term_length);
     json[SPARSE_REMAP_TERM_IDS].SetBool(param.remap_term_ids);
     json[SPARSE_RERANK_TYPE].SetString(param.rerank_type);
+    json[SPARSE_DMQ_SHARED_CODEBOOK_THRESHOLD].SetInt(param.dmq_shared_codebook_threshold);
     json[SPARSE_IMMUTABLE].SetBool(param.immutable);
     return json.Dump();
 }
@@ -88,6 +90,7 @@ TEST_CASE("SINDI Index Parameters Test", "[ut][SINDIParameter]") {
     REQUIRE(param->avg_doc_term_length == default_param.avg_doc_term_length);
     REQUIRE(param->remap_term_ids == default_param.remap_term_ids);
     REQUIRE(param->rerank_type == default_param.rerank_type);
+    REQUIRE(param->dmq_shared_codebook_threshold == default_param.dmq_shared_codebook_threshold);
     REQUIRE(param->immutable == default_param.immutable);
 
     vsag::ParameterTest::TestToJson(param);
@@ -135,6 +138,11 @@ TEST_CASE("SINDI Index Parameters Compatibility Test", "[ut][SINDIParameter]") {
         "avg_doc_term_length compatibility", avg_doc_term_length, 100, 200, false);
     TEST_COMPATIBILITY_CASE("remap_term_ids compatibility", remap_term_ids, false, true, false);
     TEST_COMPATIBILITY_CASE("immutable compatibility", immutable, false, true, false);
+    TEST_COMPATIBILITY_CASE("dmq shared codebook threshold compatibility",
+                            dmq_shared_codebook_threshold,
+                            1024,
+                            1025,
+                            false);
 
     SECTION("rerank_type compatibility") {
         SINDIDefaultParam fp32_param;
@@ -272,5 +280,29 @@ TEST_CASE("SINDI remap_term_ids Parameter", "[ut][SINDIParameter]") {
         auto param2 = std::make_shared<vsag::SINDIParameter>();
         param2->FromJson(json2);
         REQUIRE(param2->remap_term_ids == true);
+    }
+}
+
+TEST_CASE("SINDI DMQ shared codebook threshold Parameter", "[ut][SINDIParameter]") {
+    SECTION("default is 1024 when not specified") {
+        auto param = std::make_shared<vsag::SINDIParameter>();
+        param->FromString(R"({"term_id_limit":1000,"window_size":50000})");
+        REQUIRE(param->dmq_shared_codebook_threshold == 1024);
+        REQUIRE(param->ToJson()[SPARSE_DMQ_SHARED_CODEBOOK_THRESHOLD].GetInt() == 1024);
+    }
+
+    SECTION("zero disables sharing") {
+        SINDIDefaultParam default_param;
+        default_param.dmq_shared_codebook_threshold = 0;
+        auto param = std::make_shared<vsag::SINDIParameter>();
+        param->FromString(generate_sindi_param(default_param));
+        REQUIRE(param->dmq_shared_codebook_threshold == 0);
+    }
+
+    SECTION("negative values are rejected") {
+        SINDIDefaultParam default_param;
+        default_param.dmq_shared_codebook_threshold = -1;
+        auto param = std::make_shared<vsag::SINDIParameter>();
+        REQUIRE_THROWS(param->FromString(generate_sindi_param(default_param)));
     }
 }

--- a/src/algorithm/sindi/sindi_parameter_test.cpp
+++ b/src/algorithm/sindi/sindi_parameter_test.cpp
@@ -96,6 +96,7 @@ TEST_CASE("SINDI Index Parameters Test", "[ut][SINDIParameter]") {
     vsag::ParameterTest::TestToJson(param);
     REQUIRE_FALSE(param->ToJson().Contains(SPARSE_IMMUTABLE));
     REQUIRE_FALSE(param->ToJson().Contains("dmq_bits"));
+    REQUIRE_FALSE(param->ToJson().Contains(SPARSE_DMQ_SHARED_CODEBOOK_THRESHOLD));
 
     auto search_param_str = R"({
         "sindi": {
@@ -138,11 +139,25 @@ TEST_CASE("SINDI Index Parameters Compatibility Test", "[ut][SINDIParameter]") {
         "avg_doc_term_length compatibility", avg_doc_term_length, 100, 200, false);
     TEST_COMPATIBILITY_CASE("remap_term_ids compatibility", remap_term_ids, false, true, false);
     TEST_COMPATIBILITY_CASE("immutable compatibility", immutable, false, true, false);
-    TEST_COMPATIBILITY_CASE("dmq shared codebook threshold compatibility",
+    TEST_COMPATIBILITY_CASE("fp32 ignores dmq shared codebook threshold",
                             dmq_shared_codebook_threshold,
                             1024,
                             1025,
-                            false);
+                            true);
+
+    SECTION("dmq shared codebook threshold compatibility") {
+        SINDIDefaultParam param1;
+        SINDIDefaultParam param2;
+        param1.rerank_type = SPARSE_RERANK_TYPE_DMQ8;
+        param2.rerank_type = SPARSE_RERANK_TYPE_DMQ8;
+        param1.dmq_shared_codebook_threshold = 1024;
+        param2.dmq_shared_codebook_threshold = 1025;
+        auto sindi_param1 = std::make_shared<vsag::SINDIParameter>();
+        auto sindi_param2 = std::make_shared<vsag::SINDIParameter>();
+        sindi_param1->FromString(generate_sindi_param(param1));
+        sindi_param2->FromString(generate_sindi_param(param2));
+        REQUIRE_FALSE(sindi_param1->CheckCompatibility(sindi_param2));
+    }
 
     SECTION("rerank_type compatibility") {
         SINDIDefaultParam fp32_param;
@@ -286,7 +301,8 @@ TEST_CASE("SINDI remap_term_ids Parameter", "[ut][SINDIParameter]") {
 TEST_CASE("SINDI DMQ shared codebook threshold Parameter", "[ut][SINDIParameter]") {
     SECTION("default is 1024 when not specified") {
         auto param = std::make_shared<vsag::SINDIParameter>();
-        param->FromString(R"({"term_id_limit":1000,"window_size":50000})");
+        param->FromString(
+            R"({"term_id_limit":1000,"window_size":50000,"rerank_type":"dmq8","use_reorder":true})");
         REQUIRE(param->dmq_shared_codebook_threshold == 1024);
         REQUIRE(param->ToJson()[SPARSE_DMQ_SHARED_CODEBOOK_THRESHOLD].GetInt() == 1024);
     }

--- a/src/algorithm/sindi/sindi_test.cpp
+++ b/src/algorithm/sindi/sindi_test.cpp
@@ -1631,6 +1631,42 @@ TEST_CASE("SINDI Remap UpdateVector Compatibility", "[ut][SINDI]") {
     }
 }
 
+TEST_CASE("SINDI DMQ EstimateMemory uses compact IDs and shared codebooks", "[ut][SINDI]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    IndexCommonParam common_param;
+    common_param.allocator_ = allocator;
+    common_param.metric_ = MetricType::METRIC_TYPE_IP;
+    common_param.dim_ = 100000;
+
+    constexpr uint32_t term_id_limit = 100000;
+    constexpr uint64_t num_elements = 1000;
+    auto estimate_memory = [&](bool remap_term_ids, uint32_t shared_codebook_threshold) {
+        auto parameter = std::make_shared<SINDIParameter>();
+        parameter->FromString(fmt::format(R"({{
+            "use_reorder": true,
+            "rerank_type": "dmq8",
+            "term_id_limit": {},
+            "window_size": 10000,
+            "avg_doc_term_length": 100,
+            "remap_term_ids": {},
+            "dmq_shared_codebook_threshold": {}
+        }})",
+                                          term_id_limit,
+                                          remap_term_ids,
+                                          shared_codebook_threshold));
+        return SINDI(parameter, common_param).EstimateMemory(num_elements);
+    };
+
+    const uint64_t shared_memory = estimate_memory(false, 1024);
+    const uint64_t unshared_memory = estimate_memory(false, 0);
+    REQUIRE(shared_memory * 10 < unshared_memory);
+
+    const uint64_t remapped_shared_memory = estimate_memory(true, 1024);
+    constexpr uint64_t term_id_mapper_entry_memory_bytes = 54;
+    REQUIRE(remapped_shared_memory - shared_memory ==
+            term_id_limit * term_id_mapper_entry_memory_bytes);
+}
+
 TEST_CASE("SINDI Remap Memory Comparison", "[ut][SINDI]") {
     auto allocator = SafeAllocator::FactoryDefaultAllocator();
     IndexCommonParam common_param;

--- a/src/datacell/sparse_dmq_datacell.cpp
+++ b/src/datacell/sparse_dmq_datacell.cpp
@@ -23,6 +23,7 @@ namespace vsag {
 namespace {
 
 constexpr uint32_t K_SPARSE_DMQ_DATACELL_MAGIC = 0x53444D51U;
+constexpr uint32_t K_SPARSE_DMQ_DATACELL_VERSION = 6;
 
 }  // namespace
 
@@ -215,6 +216,7 @@ void
 SparseDmqDataCell::Serialize(StreamWriter& writer) {
     std::shared_lock lock(this->mutex_);
     StreamWriter::WriteObj(writer, K_SPARSE_DMQ_DATACELL_MAGIC);
+    StreamWriter::WriteObj(writer, K_SPARSE_DMQ_DATACELL_VERSION);
     StreamWriter::WriteObj(writer, this->total_count_);
     StreamWriter::WriteVector(writer, offsets_);
     StreamWriter::WriteVector(writer, codes_);
@@ -228,6 +230,10 @@ SparseDmqDataCell::Deserialize(lvalue_or_rvalue<StreamReader> reader) {
     StreamReader::ReadObj(reader, magic);
     CHECK_ARGUMENT(magic == K_SPARSE_DMQ_DATACELL_MAGIC,
                    "serialized DMQ datacell has invalid magic");
+    uint32_t version = 0;
+    StreamReader::ReadObj(reader, version);
+    CHECK_ARGUMENT(version == K_SPARSE_DMQ_DATACELL_VERSION,
+                   fmt::format("unsupported sparse DMQ datacell version {}", version));
     StreamReader::ReadObj(reader, this->total_count_);
     StreamReader::ReadVector(reader, offsets_);
     StreamReader::ReadVector(reader, codes_);

--- a/src/datacell/sparse_dmq_datacell.cpp
+++ b/src/datacell/sparse_dmq_datacell.cpp
@@ -23,13 +23,15 @@ namespace vsag {
 namespace {
 
 constexpr uint32_t K_SPARSE_DMQ_DATACELL_MAGIC = 0x53444D51U;
-constexpr uint32_t K_SPARSE_DMQ_DATACELL_VERSION = 5;
 
 }  // namespace
 
-SparseDmqDataCell::SparseDmqDataCell(uint32_t term_id_limit, const IndexCommonParam& common_param)
+SparseDmqDataCell::SparseDmqDataCell(uint32_t term_id_limit,
+                                     const IndexCommonParam& common_param,
+                                     uint32_t shared_codebook_threshold)
     : allocator_(common_param.allocator_.get()),
-      quantizer_(std::make_shared<SparseDmqQuantizer>(term_id_limit, allocator_)),
+      quantizer_(std::make_shared<SparseDmqQuantizer>(
+          term_id_limit, allocator_, shared_codebook_threshold)),
       offsets_(allocator_),
       codes_(allocator_) {
     offsets_.push_back(0);
@@ -213,7 +215,6 @@ void
 SparseDmqDataCell::Serialize(StreamWriter& writer) {
     std::shared_lock lock(this->mutex_);
     StreamWriter::WriteObj(writer, K_SPARSE_DMQ_DATACELL_MAGIC);
-    StreamWriter::WriteObj(writer, K_SPARSE_DMQ_DATACELL_VERSION);
     StreamWriter::WriteObj(writer, this->total_count_);
     StreamWriter::WriteVector(writer, offsets_);
     StreamWriter::WriteVector(writer, codes_);
@@ -224,13 +225,9 @@ void
 SparseDmqDataCell::Deserialize(lvalue_or_rvalue<StreamReader> reader) {
     std::unique_lock lock(this->mutex_);
     uint32_t magic = 0;
-    uint32_t version = 0;
     StreamReader::ReadObj(reader, magic);
-    StreamReader::ReadObj(reader, version);
     CHECK_ARGUMENT(magic == K_SPARSE_DMQ_DATACELL_MAGIC,
                    "serialized DMQ datacell has invalid magic");
-    CHECK_ARGUMENT(version == K_SPARSE_DMQ_DATACELL_VERSION,
-                   fmt::format("unsupported sparse DMQ datacell version {}", version));
     StreamReader::ReadObj(reader, this->total_count_);
     StreamReader::ReadVector(reader, offsets_);
     StreamReader::ReadVector(reader, codes_);

--- a/src/datacell/sparse_dmq_datacell.h
+++ b/src/datacell/sparse_dmq_datacell.h
@@ -22,7 +22,10 @@ namespace vsag {
 
 class SparseDmqDataCell : public FlattenInterface {
 public:
-    SparseDmqDataCell(uint32_t term_id_limit, const IndexCommonParam& common_param);
+    SparseDmqDataCell(
+        uint32_t term_id_limit,
+        const IndexCommonParam& common_param,
+        uint32_t shared_codebook_threshold = SparseDmqQuantizer::DEFAULT_SHARED_CODEBOOK_THRESHOLD);
 
     void
     Query(float* result_dists,

--- a/src/datacell/sparse_dmq_datacell_test.cpp
+++ b/src/datacell/sparse_dmq_datacell_test.cpp
@@ -15,6 +15,8 @@
 #include "sparse_dmq_datacell.h"
 
 #include <cmath>
+#include <cstring>
+#include <sstream>
 #include <vector>
 
 #include "impl/allocator/safe_allocator.h"
@@ -92,6 +94,34 @@ TEST_CASE("SparseDmqDataCell implements FlattenInterface", "[ut][SparseDmqDataCe
             restored_distances.data(), restored_computer, inner_ids.data(), inner_ids.size());
         REQUIRE(restored_distances == distances);
     }
+
+    SECTION("reject incompatible serialized version") {
+        std::stringstream stream;
+        IOStreamWriter writer(stream);
+        cell->Serialize(writer);
+        auto serialized = stream.str();
+        constexpr uint32_t old_version = 5;
+        constexpr uint64_t serialized_version_offset = sizeof(uint32_t);
+        std::memcpy(
+            serialized.data() + serialized_version_offset, &old_version, sizeof(old_version));
+
+        std::stringstream old_stream(serialized);
+        IOStreamReader reader(old_stream);
+        auto restored = std::make_shared<SparseDmqDataCell>(1024, common_param);
+        REQUIRE_THROWS_AS(restored->Deserialize(reader), VsagException);
+    }
+}
+
+TEST_CASE("SparseDmqDataCell serializes an empty model", "[ut][SparseDmqDataCell]") {
+    IndexCommonParam common_param;
+    common_param.allocator_ = SafeAllocator::FactoryDefaultAllocator();
+    common_param.metric_ = MetricType::METRIC_TYPE_IP;
+    common_param.dim_ = 1024;
+
+    SparseDmqDataCell cell(1024, common_param, 7);
+    SparseDmqDataCell restored(1, common_param, 0);
+    REQUIRE_NOTHROW(test_serializion(cell, restored));
+    REQUIRE(restored.TotalCount() == 0);
 }
 
 }  // namespace vsag

--- a/src/quantization/sparse_quantization/sparse_dmq_quantizer.cpp
+++ b/src/quantization/sparse_quantization/sparse_dmq_quantizer.cpp
@@ -46,6 +46,20 @@ get_bits_for_value_limit(uint32_t value_limit) {
     return bits;
 }
 
+uint32_t
+get_bits_for_value_count(uint64_t value_count) {
+    if (value_count <= 1) {
+        return 1;
+    }
+    uint64_t max_value = value_count - 1;
+    uint32_t bits = 0;
+    do {
+        ++bits;
+        max_value >>= 1;
+    } while (max_value > 0);
+    return bits;
+}
+
 uint64_t
 get_packed_size(uint64_t count, uint32_t bits) {
     return (count * bits + 7) / 8;
@@ -109,13 +123,17 @@ struct SparseDmqQuantizer::QueryData {
     bool has_lookup{false};
 };
 
-SparseDmqQuantizer::SparseDmqQuantizer(uint32_t term_id_limit, Allocator* allocator)
+SparseDmqQuantizer::SparseDmqQuantizer(uint32_t term_id_limit,
+                                       Allocator* allocator,
+                                       uint32_t shared_codebook_threshold)
     : Quantizer<SparseDmqQuantizer>(0, allocator),
-      codebook_term_ids_(allocator),
+      term_ids_(allocator),
       codebooks_(allocator),
-      codebook_index_by_term_id_(allocator),
-      codebook_index_lookup_(allocator),
-      id_bits_(get_bits_for_value_limit(term_id_limit)) {
+      codebook_index_by_compact_id_(allocator),
+      compact_id_by_term_id_(allocator),
+      compact_id_lookup_(allocator),
+      id_bits_(get_bits_for_value_limit(term_id_limit)),
+      shared_codebook_threshold_(shared_codebook_threshold) {
     this->metric_ = MetricType::METRIC_TYPE_IP;
     this->code_size_ = 0;
 }
@@ -133,38 +151,53 @@ SparseDmqQuantizer::GetEncodedLength(const uint8_t* codes) {
 }
 
 uint32_t
-SparseDmqQuantizer::GetCodebookIndex(uint32_t term_id) const {
-    if (term_id < codebook_index_lookup_.size() &&
-        codebook_index_lookup_[term_id] != K_INVALID_INDEX) {
-        return codebook_index_lookup_[term_id];
+SparseDmqQuantizer::GetCompactId(uint32_t term_id) const {
+    if (term_id < compact_id_lookup_.size() && compact_id_lookup_[term_id] != K_INVALID_INDEX) {
+        return compact_id_lookup_[term_id];
     }
-    auto iterator = codebook_index_by_term_id_.find(term_id);
-    CHECK_ARGUMENT(iterator != codebook_index_by_term_id_.end(),
-                   fmt::format("missing DMQ codebook for term id {}", term_id));
+    auto iterator = compact_id_by_term_id_.find(term_id);
+    CHECK_ARGUMENT(iterator != compact_id_by_term_id_.end(),
+                   fmt::format("missing DMQ compact ID for term ID {}", term_id));
     return iterator->second;
 }
 
+uint32_t
+SparseDmqQuantizer::GetCodebookIndex(uint32_t compact_id) const {
+    CHECK_ARGUMENT(compact_id < codebook_index_by_compact_id_.size(),
+                   fmt::format("invalid DMQ compact ID {}", compact_id));
+    const uint32_t codebook_index = codebook_index_by_compact_id_[compact_id];
+    CHECK_ARGUMENT(codebook_index < codebooks_.size(),
+                   fmt::format("invalid DMQ codebook index {}", codebook_index));
+    return codebook_index;
+}
+
 void
-SparseDmqQuantizer::RebuildCodebookLookup() {
-    codebook_index_lookup_.clear();
-    for (uint32_t index = 0; index < codebook_term_ids_.size(); ++index) {
-        AddCodebookLookup(codebook_term_ids_[index], index);
+SparseDmqQuantizer::RebuildCompactIdLookup() {
+    compact_id_by_term_id_.clear();
+    compact_id_lookup_.clear();
+    for (uint32_t compact_id = 0; compact_id < term_ids_.size(); ++compact_id) {
+        const auto [iterator, inserted] =
+            compact_id_by_term_id_.emplace(term_ids_[compact_id], compact_id);
+        (void)iterator;
+        CHECK_ARGUMENT(inserted,
+                       fmt::format("duplicate serialized DMQ term ID {}", term_ids_[compact_id]));
+        AddCompactIdLookup(term_ids_[compact_id], compact_id);
     }
 }
 
 void
-SparseDmqQuantizer::AddCodebookLookup(uint32_t term_id, uint32_t codebook_index) {
+SparseDmqQuantizer::AddCompactIdLookup(uint32_t term_id, uint32_t compact_id) {
     if (term_id >= K_MAX_LOOKUP_VALUES) {
         return;
     }
-    if (term_id >= codebook_index_lookup_.size()) {
-        codebook_index_lookup_.resize(static_cast<uint64_t>(term_id) + 1, K_INVALID_INDEX);
+    if (term_id >= compact_id_lookup_.size()) {
+        compact_id_lookup_.resize(static_cast<uint64_t>(term_id) + 1, K_INVALID_INDEX);
     }
-    codebook_index_lookup_[term_id] = codebook_index;
+    compact_id_lookup_[term_id] = compact_id;
 }
 
 void
-SparseDmqQuantizer::BuildCodebook(float* values, uint32_t length, Codebook* codebook) {
+SparseDmqQuantizer::BuildCodebook(float* values, uint64_t length, Codebook* codebook) {
     codebook->thresholds.fill(0.0F);
     codebook->values.fill(0.0F);
     if (length == 0) {
@@ -173,14 +206,15 @@ SparseDmqQuantizer::BuildCodebook(float* values, uint32_t length, Codebook* code
     std::sort(values, values + length);
     double sum = 0.0;
     double square_sum = 0.0;
-    for (uint32_t index = 0; index < length; ++index) {
+    for (uint64_t index = 0; index < length; ++index) {
         sum += values[index];
         square_sum += static_cast<double>(values[index]) * values[index];
     }
     double total_weight = 0.0;
-    for (uint32_t index = 0; index < length; ++index) {
+    for (uint64_t index = 0; index < length; ++index) {
         const double value = values[index];
-        total_weight += value * value * length + square_sum - 2.0 * value * sum;
+        total_weight +=
+            value * value * static_cast<double>(length) + square_sum - 2.0 * value * sum;
     }
     if (total_weight <= K_MIN_DENOMINATOR) {
         codebook->thresholds.fill(values[0]);
@@ -189,9 +223,10 @@ SparseDmqQuantizer::BuildCodebook(float* values, uint32_t length, Codebook* code
     }
     uint32_t partition = 1;
     double current_weight = 0.0;
-    for (uint32_t index = 0; index < length && partition < CODEBOOK_SIZE * 2; ++index) {
+    for (uint64_t index = 0; index < length && partition < CODEBOOK_SIZE * 2; ++index) {
         const double value = values[index];
-        current_weight += value * value * length + square_sum - 2.0 * value * sum;
+        current_weight +=
+            value * value * static_cast<double>(length) + square_sum - 2.0 * value * sum;
         while (current_weight * (CODEBOOK_SIZE * 2) + 1e-7 >= total_weight * partition) {
             if (((partition - 1) & 1U) != 0U) {
                 codebook->thresholds[(partition - 1) / 2] = values[index];
@@ -233,7 +268,7 @@ SparseDmqQuantizer::TrainImpl(const float* data, uint64_t count) {
     Vector<float> means(count, this->allocator_);
     UnorderedMap<uint32_t, uint32_t> term_indexes(this->allocator_);
     Vector<uint32_t> term_ids(this->allocator_);
-    Vector<uint32_t> term_counts(this->allocator_);
+    Vector<uint64_t> term_counts(this->allocator_);
     for (uint64_t vector_index = 0; vector_index < count; ++vector_index) {
         double sum = 0.0;
         for (uint32_t index = 0; index < vectors[vector_index].len_; ++index) {
@@ -244,7 +279,7 @@ SparseDmqQuantizer::TrainImpl(const float* data, uint64_t count) {
                                   : static_cast<float>(sum / vectors[vector_index].len_);
         for (uint32_t index = 0; index < vectors[vector_index].len_; ++index) {
             const uint32_t term_id = vectors[vector_index].ids_[index];
-            if (codebook_index_by_term_id_.find(term_id) != codebook_index_by_term_id_.end()) {
+            if (compact_id_by_term_id_.find(term_id) != compact_id_by_term_id_.end()) {
                 continue;
             }
             auto [iterator, inserted] =
@@ -256,29 +291,70 @@ SparseDmqQuantizer::TrainImpl(const float* data, uint64_t count) {
             ++term_counts[iterator->second];
         }
     }
-    Vector<uint64_t> offsets(term_ids.size() + 1, 0, this->allocator_);
-    for (uint32_t index = 0; index < term_ids.size(); ++index) {
-        offsets[index + 1] = offsets[index] + term_counts[index];
+
+    CHECK_ARGUMENT(
+        term_ids_.empty() or term_ids.empty(),
+        "SparseDmqQuantizer does not support adding new terms after compact IDs are assigned");
+    Vector<uint32_t> sorted_term_indexes(term_ids.size(), this->allocator_);
+    std::iota(sorted_term_indexes.begin(), sorted_term_indexes.end(), 0);
+    std::sort(
+        sorted_term_indexes.begin(),
+        sorted_term_indexes.end(),
+        [&term_ids](uint32_t left, uint32_t right) { return term_ids[left] < term_ids[right]; });
+
+    bool has_shared_codebook = false;
+    for (const uint32_t term_index : sorted_term_indexes) {
+        if (term_counts[term_index] <= shared_codebook_threshold_) {
+            has_shared_codebook = true;
+            break;
+        }
+    }
+    uint32_t training_bucket_count = has_shared_codebook ? 1 : 0;
+    Vector<uint32_t> training_bucket_by_term(term_ids.size(), this->allocator_);
+    for (const uint32_t term_index : sorted_term_indexes) {
+        if (term_counts[term_index] <= shared_codebook_threshold_) {
+            training_bucket_by_term[term_index] = 0;
+        } else {
+            training_bucket_by_term[term_index] = training_bucket_count++;
+        }
+    }
+
+    Vector<uint64_t> bucket_counts(training_bucket_count, 0, this->allocator_);
+    for (uint32_t term_index = 0; term_index < term_ids.size(); ++term_index) {
+        bucket_counts[training_bucket_by_term[term_index]] += term_counts[term_index];
+    }
+    Vector<uint64_t> offsets(static_cast<uint64_t>(training_bucket_count) + 1, 0, this->allocator_);
+    for (uint32_t bucket = 0; bucket < training_bucket_count; ++bucket) {
+        offsets[bucket + 1] = offsets[bucket] + bucket_counts[bucket];
     }
     Vector<uint64_t> cursors(offsets.begin(), offsets.end(), this->allocator_);
     Vector<float> residuals(offsets.back(), this->allocator_);
     for (uint64_t vector_index = 0; vector_index < count; ++vector_index) {
         for (uint32_t index = 0; index < vectors[vector_index].len_; ++index) {
             auto iterator = term_indexes.find(vectors[vector_index].ids_[index]);
-            if (iterator != term_indexes.end()) {
-                residuals[cursors[iterator->second]++] =
-                    vectors[vector_index].vals_[index] - means[vector_index];
+            if (iterator == term_indexes.end()) {
+                continue;
             }
+            const uint32_t bucket = training_bucket_by_term[iterator->second];
+            residuals[cursors[bucket]++] = vectors[vector_index].vals_[index] - means[vector_index];
         }
     }
-    for (uint32_t index = 0; index < term_ids.size(); ++index) {
-        const auto codebook_index = static_cast<uint32_t>(codebooks_.size());
-        codebook_index_by_term_id_[term_ids[index]] = codebook_index;
-        codebook_term_ids_.push_back(term_ids[index]);
+
+    const auto first_codebook_index = static_cast<uint32_t>(codebooks_.size());
+    for (uint32_t bucket = 0; bucket < training_bucket_count; ++bucket) {
         codebooks_.emplace_back();
-        BuildCodebook(residuals.data() + offsets[index], term_counts[index], &codebooks_.back());
-        AddCodebookLookup(term_ids[index], codebook_index);
+        BuildCodebook(
+            residuals.data() + offsets[bucket], bucket_counts[bucket], &codebooks_.back());
     }
+    for (const uint32_t term_index : sorted_term_indexes) {
+        const auto compact_id = static_cast<uint32_t>(term_ids_.size());
+        const uint32_t codebook_index = first_codebook_index + training_bucket_by_term[term_index];
+        term_ids_.push_back(term_ids[term_index]);
+        codebook_index_by_compact_id_.push_back(codebook_index);
+        compact_id_by_term_id_[term_ids[term_index]] = compact_id;
+        AddCompactIdLookup(term_ids[term_index], compact_id);
+    }
+    id_bits_ = get_bits_for_value_count(term_ids_.size());
     this->is_trained_ = true;
     return true;
 }
@@ -298,8 +374,10 @@ SparseDmqQuantizer::EncodeOneImpl(const float* data, uint8_t* codes) const {
     double numerator = 0.0;
     double denominator = 0.0;
     for (uint32_t index = 0; index < vector.len_; ++index) {
-        store_packed(packed_ids, index, id_bits_, ids[index]);
-        const auto& codebook = codebooks_[GetCodebookIndex(ids[index])];
+        const uint32_t compact_id = GetCompactId(ids[index]);
+        const uint32_t codebook_index = GetCodebookIndex(compact_id);
+        store_packed(packed_ids, index, id_bits_, compact_id);
+        const auto& codebook = codebooks_[codebook_index];
         const float residual = values[index] - header.factors.mean;
         value_codes[index] = EncodeResidual(residual, codebook);
         numerator += static_cast<double>(residual) * residual;
@@ -324,9 +402,13 @@ SparseDmqQuantizer::DecodeOneImpl(const uint8_t* codes, float* data) const {
     const auto* packed_ids = codes + sizeof(header);
     const auto* value_codes = packed_ids + get_packed_size(header.len, id_bits_);
     for (uint32_t index = 0; index < header.len; ++index) {
-        vector->ids_[index] = load_packed(packed_ids, index, id_bits_);
-        vector->vals_[index] = DecodeValue(
-            header.factors, codebooks_[GetCodebookIndex(vector->ids_[index])], value_codes[index]);
+        const uint32_t compact_id = load_packed(packed_ids, index, id_bits_);
+        CHECK_ARGUMENT(compact_id < term_ids_.size(),
+                       fmt::format("invalid DMQ compact ID {}", compact_id));
+        const uint32_t codebook_index = GetCodebookIndex(compact_id);
+        vector->ids_[index] = term_ids_[compact_id];
+        vector->vals_[index] =
+            DecodeValue(header.factors, codebooks_[codebook_index], value_codes[index]);
     }
     return true;
 }
@@ -364,7 +446,8 @@ SparseDmqQuantizer::ComputeImpl(const uint8_t* codes1, const uint8_t* codes2) co
         } else if (left_id > right_id) {
             ++right_index;
         } else {
-            const auto& codebook = codebooks_[GetCodebookIndex(left_id)];
+            const uint32_t codebook_index = GetCodebookIndex(left_id);
+            const auto& codebook = codebooks_[codebook_index];
             product += DecodeValue(left.factors, codebook, left_codes[left_index]) *
                        DecodeValue(right.factors, codebook, right_codes[right_index]);
             ++left_index;
@@ -381,8 +464,19 @@ SparseDmqQuantizer::ProcessQueryImpl(const float* query,
     auto* query_data = new (memory) QueryData(this->allocator_);
     auto [ids, values] =
         sort_sparse_vector(*reinterpret_cast<const SparseVector*>(query), this->allocator_);
-    query_data->ids = std::move(ids);
-    query_data->values = std::move(values);
+    Vector<uint32_t> compact_ids(this->allocator_);
+    Vector<float> matched_values(this->allocator_);
+    compact_ids.reserve(ids.size());
+    matched_values.reserve(values.size());
+    for (uint32_t index = 0; index < ids.size(); ++index) {
+        auto iterator = compact_id_by_term_id_.find(ids[index]);
+        if (iterator != compact_id_by_term_id_.end()) {
+            compact_ids.push_back(iterator->second);
+            matched_values.push_back(values[index]);
+        }
+    }
+    query_data->ids = std::move(compact_ids);
+    query_data->values = std::move(matched_values);
     if (!query_data->ids.empty() && query_data->ids.back() < K_MAX_LOOKUP_VALUES) {
         query_data->term_to_index.assign(query_data->ids.back() + 1, K_INVALID_INDEX);
         for (uint32_t index = 0; index < query_data->ids.size(); ++index) {
@@ -393,11 +487,8 @@ SparseDmqQuantizer::ProcessQueryImpl(const float* query,
     query_data->code_lut.resize(static_cast<uint64_t>(query_data->ids.size()) * CODEBOOK_SIZE,
                                 0.0F);
     for (uint32_t index = 0; index < query_data->ids.size(); ++index) {
-        auto iterator = codebook_index_by_term_id_.find(query_data->ids[index]);
-        if (iterator == codebook_index_by_term_id_.end()) {
-            continue;
-        }
-        const auto& codebook = codebooks_[iterator->second];
+        const uint32_t codebook_index = GetCodebookIndex(query_data->ids[index]);
+        const auto& codebook = codebooks_[codebook_index];
         for (uint32_t code = 0; code < CODEBOOK_SIZE; ++code) {
             query_data->code_lut[static_cast<uint64_t>(index) * CODEBOOK_SIZE + code] =
                 query_data->values[index] * codebook.values[code];
@@ -455,24 +546,33 @@ SparseDmqQuantizer::ReleaseComputerImpl(Computer<SparseDmqQuantizer>& computer) 
 void
 SparseDmqQuantizer::SerializeImpl(StreamWriter& writer) {
     StreamWriter::WriteObj(writer, id_bits_);
-    StreamWriter::WriteVector(writer, codebook_term_ids_);
+    StreamWriter::WriteVector(writer, term_ids_);
+    StreamWriter::WriteVector(writer, codebook_index_by_compact_id_);
     StreamWriter::WriteVector(writer, codebooks_);
 }
 
 void
 SparseDmqQuantizer::DeserializeImpl(StreamReader& reader) {
-    uint32_t serialized_id_bits = 0;
-    StreamReader::ReadObj(reader, serialized_id_bits);
-    CHECK_ARGUMENT(serialized_id_bits == id_bits_, "serialized DMQ id width does not match");
-    StreamReader::ReadVector(reader, codebook_term_ids_);
+    StreamReader::ReadObj(reader, id_bits_);
+    StreamReader::ReadVector(reader, term_ids_);
+    StreamReader::ReadVector(reader, codebook_index_by_compact_id_);
     StreamReader::ReadVector(reader, codebooks_);
-    CHECK_ARGUMENT(codebook_term_ids_.size() == codebooks_.size(),
-                   "serialized DMQ codebook metadata is inconsistent");
-    codebook_index_by_term_id_.clear();
-    for (uint32_t index = 0; index < codebook_term_ids_.size(); ++index) {
-        codebook_index_by_term_id_[codebook_term_ids_[index]] = index;
+    CHECK_ARGUMENT(term_ids_.size() == codebook_index_by_compact_id_.size(),
+                   "serialized DMQ term and codebook mappings are inconsistent");
+    CHECK_ARGUMENT(id_bits_ == get_bits_for_value_count(term_ids_.size()),
+                   "serialized DMQ compact ID width is inconsistent");
+    CHECK_ARGUMENT(term_ids_.empty() == codebooks_.empty(),
+                   "serialized DMQ term and codebook counts are inconsistent");
+    for (uint32_t compact_id = 0; compact_id < term_ids_.size(); ++compact_id) {
+        CHECK_ARGUMENT(codebook_index_by_compact_id_[compact_id] < codebooks_.size(),
+                       fmt::format("invalid serialized DMQ codebook index {}",
+                                   codebook_index_by_compact_id_[compact_id]));
+        if (compact_id != 0) {
+            CHECK_ARGUMENT(term_ids_[compact_id - 1] < term_ids_[compact_id],
+                           "serialized DMQ term IDs are not strictly ordered");
+        }
     }
-    RebuildCodebookLookup();
+    RebuildCompactIdLookup();
 }
 
 std::string
@@ -482,19 +582,21 @@ SparseDmqQuantizer::NameImpl() {
 
 uint64_t
 SparseDmqQuantizer::GetMemoryUsage() const {
-    return sizeof(*this) + codebook_term_ids_.capacity() * sizeof(uint32_t) +
+    return sizeof(*this) + term_ids_.capacity() * sizeof(uint32_t) +
            codebooks_.capacity() * sizeof(Codebook) +
-           codebook_index_by_term_id_.size() * sizeof(std::pair<uint32_t, uint32_t>) +
-           codebook_index_lookup_.capacity() * sizeof(uint32_t);
+           codebook_index_by_compact_id_.capacity() * sizeof(uint32_t) +
+           compact_id_by_term_id_.size() * sizeof(std::pair<uint32_t, uint32_t>) +
+           compact_id_lookup_.capacity() * sizeof(uint32_t);
 }
 
 void
 SparseDmqQuantizer::ExportModel(const SparseDmqQuantizer& other) {
-    CHECK_ARGUMENT(id_bits_ == other.id_bits_, "DMQ export target id width mismatch");
-    codebook_term_ids_ = other.codebook_term_ids_;
+    id_bits_ = other.id_bits_;
+    shared_codebook_threshold_ = other.shared_codebook_threshold_;
+    term_ids_ = other.term_ids_;
     codebooks_ = other.codebooks_;
-    codebook_index_by_term_id_ = other.codebook_index_by_term_id_;
-    RebuildCodebookLookup();
+    codebook_index_by_compact_id_ = other.codebook_index_by_compact_id_;
+    RebuildCompactIdLookup();
     this->is_trained_ = other.is_trained_;
 }
 

--- a/src/quantization/sparse_quantization/sparse_dmq_quantizer.cpp
+++ b/src/quantization/sparse_quantization/sparse_dmq_quantizer.cpp
@@ -80,18 +80,33 @@ store_packed(uint8_t* bytes, uint64_t index, uint32_t bits, uint32_t value) {
     }
 }
 
-uint32_t
-load_packed(const uint8_t* bytes, uint64_t index, uint32_t bits) {
-    const uint64_t bit_offset = index * bits;
-    uint32_t result = 0;
-    for (uint32_t bit = 0; bit < bits; ++bit) {
-        const uint64_t target_bit = bit_offset + bit;
-        if ((bytes[target_bit / 8] & (1U << (target_bit % 8))) != 0) {
-            result |= 1U << bit;
-        }
+class PackedReader {
+public:
+    PackedReader(const uint8_t* bytes, uint32_t bits) : cursor_(bytes), bits_(bits) {
+        CHECK_ARGUMENT(bits_ != 0, "packed value width must be in [1, 32]");
+        CHECK_ARGUMENT(bits_ <= 32, "packed value width must be in [1, 32]");
+        mask_ = bits_ == 32 ? std::numeric_limits<uint32_t>::max() : ((1U << bits_) - 1U);
     }
-    return result;
-}
+
+    uint32_t
+    Read() {
+        while (available_bits_ < bits_) {
+            bit_buffer_ |= static_cast<uint64_t>(*cursor_++) << available_bits_;
+            available_bits_ += 8;
+        }
+        const uint32_t result = static_cast<uint32_t>(bit_buffer_) & mask_;
+        bit_buffer_ >>= bits_;
+        available_bits_ -= bits_;
+        return result;
+    }
+
+private:
+    const uint8_t* cursor_;
+    uint64_t bit_buffer_{0};
+    uint32_t available_bits_{0};
+    uint32_t bits_;
+    uint32_t mask_;
+};
 
 std::tuple<Vector<uint32_t>, Vector<float>>
 sort_sparse_vector(const SparseVector& vector, Allocator* allocator) {
@@ -401,8 +416,9 @@ SparseDmqQuantizer::DecodeOneImpl(const uint8_t* codes, float* data) const {
     vector->vals_ = static_cast<float*>(this->allocator_->Allocate(sizeof(float) * header.len));
     const auto* packed_ids = codes + sizeof(header);
     const auto* value_codes = packed_ids + get_packed_size(header.len, id_bits_);
+    PackedReader id_reader(packed_ids, id_bits_);
     for (uint32_t index = 0; index < header.len; ++index) {
-        const uint32_t compact_id = load_packed(packed_ids, index, id_bits_);
+        const uint32_t compact_id = id_reader.Read();
         CHECK_ARGUMENT(compact_id < term_ids_.size(),
                        fmt::format("invalid DMQ compact ID {}", compact_id));
         const uint32_t codebook_index = GetCodebookIndex(compact_id);
@@ -435,16 +451,27 @@ SparseDmqQuantizer::ComputeImpl(const uint8_t* codes1, const uint8_t* codes2) co
     const auto* right_ids = codes2 + sizeof(right);
     const auto* left_codes = left_ids + get_packed_size(left.len, id_bits_);
     const auto* right_codes = right_ids + get_packed_size(right.len, id_bits_);
+    if (left.len == 0 || right.len == 0) {
+        return 1.0F;
+    }
+    PackedReader left_reader(left_ids, id_bits_);
+    PackedReader right_reader(right_ids, id_bits_);
     uint32_t left_index = 0;
     uint32_t right_index = 0;
+    uint32_t left_id = left_reader.Read();
+    uint32_t right_id = right_reader.Read();
     float product = 0.0F;
     while (left_index < left.len && right_index < right.len) {
-        const uint32_t left_id = load_packed(left_ids, left_index, id_bits_);
-        const uint32_t right_id = load_packed(right_ids, right_index, id_bits_);
         if (left_id < right_id) {
             ++left_index;
+            if (left_index < left.len) {
+                left_id = left_reader.Read();
+            }
         } else if (left_id > right_id) {
             ++right_index;
+            if (right_index < right.len) {
+                right_id = right_reader.Read();
+            }
         } else {
             const uint32_t codebook_index = GetCodebookIndex(left_id);
             const auto& codebook = codebooks_[codebook_index];
@@ -452,6 +479,12 @@ SparseDmqQuantizer::ComputeImpl(const uint8_t* codes1, const uint8_t* codes2) co
                        DecodeValue(right.factors, codebook, right_codes[right_index]);
             ++left_index;
             ++right_index;
+            if (left_index < left.len) {
+                left_id = left_reader.Read();
+            }
+            if (right_index < right.len) {
+                right_id = right_reader.Read();
+            }
         }
     }
     return 1.0F - product;
@@ -509,8 +542,9 @@ SparseDmqQuantizer::ComputeDistImpl(Computer<SparseDmqQuantizer>& computer,
     float query_sum = 0.0F;
     float qualifier_product = 0.0F;
     uint32_t query_index = 0;
+    PackedReader id_reader(packed_ids, id_bits_);
     for (uint32_t base_index = 0; base_index < header.len; ++base_index) {
-        const uint32_t id = load_packed(packed_ids, base_index, id_bits_);
+        const uint32_t id = id_reader.Read();
         uint32_t matched = K_INVALID_INDEX;
         if (query.has_lookup) {
             if (id < query.term_to_index.size()) {
@@ -545,6 +579,7 @@ SparseDmqQuantizer::ReleaseComputerImpl(Computer<SparseDmqQuantizer>& computer) 
 
 void
 SparseDmqQuantizer::SerializeImpl(StreamWriter& writer) {
+    StreamWriter::WriteObj(writer, shared_codebook_threshold_);
     StreamWriter::WriteObj(writer, id_bits_);
     StreamWriter::WriteVector(writer, term_ids_);
     StreamWriter::WriteVector(writer, codebook_index_by_compact_id_);
@@ -553,14 +588,20 @@ SparseDmqQuantizer::SerializeImpl(StreamWriter& writer) {
 
 void
 SparseDmqQuantizer::DeserializeImpl(StreamReader& reader) {
+    StreamReader::ReadObj(reader, shared_codebook_threshold_);
     StreamReader::ReadObj(reader, id_bits_);
     StreamReader::ReadVector(reader, term_ids_);
     StreamReader::ReadVector(reader, codebook_index_by_compact_id_);
     StreamReader::ReadVector(reader, codebooks_);
     CHECK_ARGUMENT(term_ids_.size() == codebook_index_by_compact_id_.size(),
                    "serialized DMQ term and codebook mappings are inconsistent");
-    CHECK_ARGUMENT(id_bits_ == get_bits_for_value_count(term_ids_.size()),
-                   "serialized DMQ compact ID width is inconsistent");
+    CHECK_ARGUMENT(id_bits_ != 0, "serialized DMQ compact ID width is out of range");
+    CHECK_ARGUMENT(id_bits_ <= 32, "serialized DMQ compact ID width is out of range");
+    const bool empty_untrained_model = not this->is_trained_ && term_ids_.empty();
+    if (not empty_untrained_model) {
+        CHECK_ARGUMENT(id_bits_ == get_bits_for_value_count(term_ids_.size()),
+                       "serialized DMQ compact ID width is inconsistent");
+    }
     CHECK_ARGUMENT(term_ids_.empty() == codebooks_.empty(),
                    "serialized DMQ term and codebook counts are inconsistent");
     for (uint32_t compact_id = 0; compact_id < term_ids_.size(); ++compact_id) {

--- a/src/quantization/sparse_quantization/sparse_dmq_quantizer.h
+++ b/src/quantization/sparse_quantization/sparse_dmq_quantizer.h
@@ -27,6 +27,7 @@ public:
     static constexpr uint32_t BITS = 8;
     static constexpr uint32_t CODEBOOK_SIZE = 1U << BITS;
     static constexpr uint32_t THRESHOLD_COUNT = CODEBOOK_SIZE - 1;
+    static constexpr uint32_t DEFAULT_SHARED_CODEBOOK_THRESHOLD = 1024;
 
     struct VectorFactors {
         float mean{0.0F};
@@ -44,7 +45,9 @@ public:
     };
     static_assert(sizeof(EncodedHeader) == 12, "DMQ encoded header layout must remain stable");
 
-    SparseDmqQuantizer(uint32_t term_id_limit, Allocator* allocator);
+    SparseDmqQuantizer(uint32_t term_id_limit,
+                       Allocator* allocator,
+                       uint32_t shared_codebook_threshold = DEFAULT_SHARED_CODEBOOK_THRESHOLD);
 
     bool
     TrainImpl(const float* data, uint64_t count);
@@ -93,6 +96,21 @@ public:
     [[nodiscard]] uint64_t
     GetMemoryUsage() const;
 
+    [[nodiscard]] uint32_t
+    GetIdBits() const {
+        return id_bits_;
+    }
+
+    [[nodiscard]] uint64_t
+    GetCodebookCount() const {
+        return codebooks_.size();
+    }
+
+    [[nodiscard]] uint32_t
+    GetSharedCodebookThreshold() const {
+        return shared_codebook_threshold_;
+    }
+
     void
     ExportModel(const SparseDmqQuantizer& other);
 
@@ -100,16 +118,19 @@ private:
     struct QueryData;
 
     [[nodiscard]] uint32_t
-    GetCodebookIndex(uint32_t term_id) const;
+    GetCompactId(uint32_t term_id) const;
+
+    [[nodiscard]] uint32_t
+    GetCodebookIndex(uint32_t compact_id) const;
 
     void
-    RebuildCodebookLookup();
+    RebuildCompactIdLookup();
 
     void
-    AddCodebookLookup(uint32_t term_id, uint32_t codebook_index);
+    AddCompactIdLookup(uint32_t term_id, uint32_t compact_id);
 
     static void
-    BuildCodebook(float* values, uint32_t length, Codebook* codebook);
+    BuildCodebook(float* values, uint64_t length, Codebook* codebook);
 
     [[nodiscard]] static uint8_t
     EncodeResidual(float residual, const Codebook& codebook);
@@ -118,11 +139,13 @@ private:
     DecodeValue(const VectorFactors& factors, const Codebook& codebook, uint8_t code);
 
 private:
-    Vector<uint32_t> codebook_term_ids_;
+    Vector<uint32_t> term_ids_;
     Vector<Codebook> codebooks_;
-    UnorderedMap<uint32_t, uint32_t> codebook_index_by_term_id_;
-    Vector<uint32_t> codebook_index_lookup_;
+    Vector<uint32_t> codebook_index_by_compact_id_;
+    UnorderedMap<uint32_t, uint32_t> compact_id_by_term_id_;
+    Vector<uint32_t> compact_id_lookup_;
     uint32_t id_bits_{32};
+    uint32_t shared_codebook_threshold_{DEFAULT_SHARED_CODEBOOK_THRESHOLD};
 };
 
 }  // namespace vsag

--- a/src/quantization/sparse_quantization/sparse_dmq_quantizer_test.cpp
+++ b/src/quantization/sparse_quantization/sparse_dmq_quantizer_test.cpp
@@ -183,9 +183,10 @@ TEST_CASE("SparseDmqQuantizer shares low frequency codebooks", "[ut][SparseDmqQu
     REQUIRE(exported.GetCodebookCount() == 3);
     REQUIRE(exported.GetSharedCodebookThreshold() == 2);
 
-    SparseDmqQuantizer restored(10, allocator.get(), 2);
+    SparseDmqQuantizer restored(10, allocator.get(), 0);
     test_serializion(shared, restored);
     REQUIRE(restored.GetCodebookCount() == 3);
+    REQUIRE(restored.GetSharedCodebookThreshold() == 2);
     std::vector<uint8_t> codes(shared.GetEncodedSize(vectors[0]));
     REQUIRE(shared.EncodeOne(reinterpret_cast<const float*>(&vectors[0]), codes.data()));
     auto expected_computer = shared.FactoryComputer();
@@ -197,6 +198,17 @@ TEST_CASE("SparseDmqQuantizer shares low frequency codebooks", "[ut][SparseDmqQu
     expected_computer->ComputeDist(codes.data(), &expected_distance);
     restored_computer->ComputeDist(codes.data(), &restored_distance);
     REQUIRE(restored_distance == expected_distance);
+}
+
+TEST_CASE("SparseDmqQuantizer serializes empty model metadata", "[ut][SparseDmqQuantizer]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    SparseDmqQuantizer empty(1024, allocator.get(), 7);
+    SparseDmqQuantizer restored(1, allocator.get(), 0);
+
+    REQUIRE_NOTHROW(test_serializion(empty, restored));
+    REQUIRE(restored.GetIdBits() == empty.GetIdBits());
+    REQUIRE(restored.GetCodebookCount() == 0);
+    REQUIRE(restored.GetSharedCodebookThreshold() == 7);
 }
 
 }  // namespace vsag

--- a/src/quantization/sparse_quantization/sparse_dmq_quantizer_test.cpp
+++ b/src/quantization/sparse_quantization/sparse_dmq_quantizer_test.cpp
@@ -14,7 +14,10 @@
 
 #include "sparse_dmq_quantizer.h"
 
+#include <algorithm>
 #include <cmath>
+#include <limits>
+#include <utility>
 #include <vector>
 
 #include "impl/allocator/safe_allocator.h"
@@ -52,8 +55,32 @@ TEST_CASE("SparseDmqQuantizer basic operations", "[ut][SparseDmqQuantizer]") {
         expected_distance -= decoded.vals_[index] * values_0[index];
     }
     REQUIRE(std::abs(distance - expected_distance) <= 1e-6F);
+
+    std::vector<uint8_t> codes_1(quantizer.GetEncodedSize(vectors[1]));
+    REQUIRE(quantizer.EncodeOne(reinterpret_cast<const float*>(&vectors[1]), codes_1.data()));
+    SparseVector decoded_1;
+    REQUIRE(quantizer.DecodeOne(codes_1.data(), reinterpret_cast<float*>(&decoded_1)));
+    float expected_pair_distance = 1.0F;
+    for (uint32_t index = 0; index < decoded.len_; ++index) {
+        expected_pair_distance -= decoded.vals_[index] * decoded_1.vals_[index];
+    }
+    REQUIRE(std::abs(quantizer.Compute(codes.data(), codes_1.data()) - expected_pair_distance) <=
+            1e-6F);
+
+    std::vector<uint32_t> query_ids{1, 4, 9, std::numeric_limits<uint32_t>::max()};
+    std::vector<float> query_values{0.0F, 0.5F, 1.0F, 100.0F};
+    SparseVector query{
+        static_cast<uint32_t>(query_ids.size()), query_ids.data(), query_values.data()};
+    auto unknown_term_computer = quantizer.FactoryComputer();
+    unknown_term_computer->SetQuery(reinterpret_cast<const float*>(&query));
+    float distance_with_unknown_term = 0.0F;
+    unknown_term_computer->ComputeDist(codes.data(), &distance_with_unknown_term);
+    REQUIRE(distance_with_unknown_term == distance);
+
     allocator->Deallocate(decoded.ids_);
     allocator->Deallocate(decoded.vals_);
+    allocator->Deallocate(decoded_1.ids_);
+    allocator->Deallocate(decoded_1.vals_);
 
     SparseDmqQuantizer restored(16, allocator.get());
     test_serializion(quantizer, restored);
@@ -87,6 +114,89 @@ TEST_CASE("SparseDmqQuantizer encodes inclusive term id limit", "[ut][SparseDmqQ
     float distance = 1.0F;
     computer->ComputeDist(codes.data(), &distance);
     REQUIRE(std::abs(distance) <= 1e-6F);
+}
+
+TEST_CASE("SparseDmqQuantizer packs compact term ids by distinct term count",
+          "[ut][SparseDmqQuantizer]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    const std::vector<std::pair<uint32_t, uint32_t>> cases{
+        {1, 1}, {2, 1}, {8, 3}, {9, 4}, {16, 4}, {17, 5}};
+
+    for (const auto& [term_count, expected_bits] : cases) {
+        std::vector<uint32_t> ids(term_count);
+        std::vector<float> values(term_count);
+        for (uint32_t index = 0; index < term_count; ++index) {
+            ids[index] = std::numeric_limits<uint32_t>::max() - index * 100;
+            values[index] = static_cast<float>(index + 1) / term_count;
+        }
+        SparseVector vector{term_count, ids.data(), values.data()};
+        SparseDmqQuantizer quantizer(std::numeric_limits<uint32_t>::max(), allocator.get());
+
+        REQUIRE(quantizer.TrainImpl(reinterpret_cast<const float*>(&vector), 1));
+        REQUIRE(quantizer.GetIdBits() == expected_bits);
+        REQUIRE(quantizer.GetEncodedSize(vector) ==
+                sizeof(SparseDmqQuantizer::EncodedHeader) +
+                    (static_cast<uint64_t>(term_count) * expected_bits + 7) / 8 + term_count);
+
+        std::vector<uint8_t> codes(quantizer.GetEncodedSize(vector));
+        REQUIRE(quantizer.EncodeOne(reinterpret_cast<const float*>(&vector), codes.data()));
+        SparseVector decoded;
+        REQUIRE(quantizer.DecodeOne(codes.data(), reinterpret_cast<float*>(&decoded)));
+        auto sorted_ids = ids;
+        std::sort(sorted_ids.begin(), sorted_ids.end());
+        REQUIRE(std::equal(sorted_ids.begin(), sorted_ids.end(), decoded.ids_));
+        allocator->Deallocate(decoded.ids_);
+        allocator->Deallocate(decoded.vals_);
+    }
+}
+
+TEST_CASE("SparseDmqQuantizer shares low frequency codebooks", "[ut][SparseDmqQuantizer]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    std::vector<uint32_t> ids_0{1, 2, 3, 5};
+    std::vector<float> values_0{0.1F, 0.2F, 0.3F, 0.4F};
+    std::vector<uint32_t> ids_1{1, 2, 3, 5};
+    std::vector<float> values_1{0.5F, 0.6F, 0.7F, 0.8F};
+    std::vector<uint32_t> ids_2{1, 4, 5};
+    std::vector<float> values_2{0.9F, 1.0F, 1.1F};
+    std::vector<SparseVector> vectors{
+        {4, ids_0.data(), values_0.data()},
+        {4, ids_1.data(), values_1.data()},
+        {3, ids_2.data(), values_2.data()},
+    };
+
+    SparseDmqQuantizer shared(10, allocator.get(), 2);
+    REQUIRE(shared.TrainImpl(reinterpret_cast<const float*>(vectors.data()), vectors.size()));
+    REQUIRE(shared.GetIdBits() == 3);
+    REQUIRE(shared.GetCodebookCount() == 3);
+
+    SparseDmqQuantizer disabled(10, allocator.get(), 0);
+    REQUIRE(disabled.TrainImpl(reinterpret_cast<const float*>(vectors.data()), vectors.size()));
+    REQUIRE(disabled.GetIdBits() == 3);
+    REQUIRE(disabled.GetCodebookCount() == 5);
+
+    SparseDmqQuantizer defaults(10, allocator.get());
+    REQUIRE(defaults.TrainImpl(reinterpret_cast<const float*>(vectors.data()), vectors.size()));
+    REQUIRE(defaults.GetCodebookCount() == 1);
+
+    SparseDmqQuantizer exported(10, allocator.get(), 0);
+    exported.ExportModel(shared);
+    REQUIRE(exported.GetCodebookCount() == 3);
+    REQUIRE(exported.GetSharedCodebookThreshold() == 2);
+
+    SparseDmqQuantizer restored(10, allocator.get(), 2);
+    test_serializion(shared, restored);
+    REQUIRE(restored.GetCodebookCount() == 3);
+    std::vector<uint8_t> codes(shared.GetEncodedSize(vectors[0]));
+    REQUIRE(shared.EncodeOne(reinterpret_cast<const float*>(&vectors[0]), codes.data()));
+    auto expected_computer = shared.FactoryComputer();
+    expected_computer->SetQuery(reinterpret_cast<const float*>(&vectors[2]));
+    auto restored_computer = restored.FactoryComputer();
+    restored_computer->SetQuery(reinterpret_cast<const float*>(&vectors[2]));
+    float expected_distance = 0.0F;
+    float restored_distance = 0.0F;
+    expected_computer->ComputeDist(codes.data(), &expected_distance);
+    restored_computer->ComputeDist(codes.data(), &restored_distance);
+    REQUIRE(restored_distance == expected_distance);
 }
 
 }  // namespace vsag


### PR DESCRIPTION
## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement/Refactor
- [ ] Documentation
- [ ] CI/Build/Infra

## What Changed

- Add `dmq_shared_codebook_threshold` so low-frequency terms share a DMQ codebook while frequent terms keep independent codebooks.
- Remap DMQ term IDs to compact IDs and bit-pack them in encoded sparse vectors.
- Replace per-bit packed-ID extraction with a sequential bit-buffer reader in decode and distance paths.
- Document the new SINDI parameter in English and Chinese and add parameter/quantizer coverage.

## Why

The compact-ID implementation originally decoded every ID one bit at a time. During reranking this repeated shifts, masks, and byte loads for every term of every candidate, making DMQ decoding dominate search latency. Sequential byte buffering removes that per-bit hot loop.

Sharing codebooks for infrequent terms also reduces DMQ model overhead while retaining dedicated codebooks for terms with enough training samples.

## Test Evidence

- [ ] `make fmt`
- [ ] `make lint`
- [ ] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [x] Other (described below)

Test details:

```text
clang-format-15 --dry-run --Werror <changed C++ files>
git diff --check
make release

Sparse4M, topk=10, query_prune_ratio=0.0:
n_candidate  old QPS  new QPS  old DMQ ms  new DMQ ms
100          156.15   427.13   4.299       0.257
200           90.24   373.38   8.871       0.518
500           40.03   266.58  22.481       1.311
1000          20.89   186.07  44.902       2.589
```

## Compatibility Impact

- API/ABI compatibility: no public API change; adds one optional SINDI JSON parameter.
- Behavior changes: `dmq_shared_codebook_threshold` defaults to `1024`; set it to `0` to disable sharing.
- Serialized-index compatibility: the DMQ quantizer metadata and compact-ID encoding change, so existing DMQ indexes must be rebuilt.

## Performance and Concurrency Impact

- Performance impact: DMQ packed-ID decode/rerank time is substantially reduced in the measured Sparse4M workload.
- Concurrency/thread-safety impact: none.

## Documentation Impact

- [ ] No docs update needed
- [x] Updated docs:
  - [ ] `README.md`
  - [ ] `DEVELOPMENT.md`
  - [ ] `CONTRIBUTING.md`
  - [x] Other: `docs/docs/{en,zh}/src/indexes/sindi.md`

## Risk and Rollback

- Risk level: medium, because the DMQ serialized representation changes.
- Rollback plan: revert the two commits and rebuild affected DMQ indexes with the prior format.

## Checklist

- [x] Linked issue is not required for `kind/improvement`
- [x] I have added/updated tests for the new behavior
- [x] I have considered API and serialized-index compatibility impact
- [x] I have updated docs for the new parameter
- [x] My commit messages follow project conventions
