### PR TITLE
fix: avoid virtual resize during PointsMutex construction

### DIFF
--- a/src/utils/lock_strategy.cpp
+++ b/src/utils/lock_strategy.cpp
@@ -19,7 +19,7 @@ namespace vsag {
 
 PointsMutex::PointsMutex(uint32_t element_num, Allocator* allocator)
     : allocator_(allocator), mutex_blocks_(allocator) {
-    this->Resize(element_num);
+    PointsMutex::Resize(element_num);
 }
 
 void

--- a/src/utils/lock_strategy_test.cpp
+++ b/src/utils/lock_strategy_test.cpp
@@ -76,6 +76,18 @@ TEST_CASE("LockStrategy Basic", "[ut][LockStrategy]") {
         REQUIRE(mutex_array.GetMemoryUsage() > 0);
     }
 
+    SECTION("points mutex initializes empty and resizes") {
+        PointsMutex mutex_array(0, allocator.get());
+        REQUIRE(mutex_array.GetMemoryUsage() == 0);
+
+        mutex_array.Resize(1);
+        const auto resized_memory = mutex_array.GetMemoryUsage();
+        REQUIRE(resized_memory > 0);
+
+        mutex_array.Resize(0);
+        REQUIRE(mutex_array.GetMemoryUsage() < resized_memory);
+    }
+
     SECTION("resize updates memory usage") {
         const auto block_size = PointsMutex::kMutexesPerBlock;
         PointsMutex mutex_array(block_size + 1, allocator.get());


### PR DESCRIPTION
Fixes: #2517
Fixes: #2510

## Root cause
`PointsMutex` constructed its lock storage by calling the virtual `Resize` method. clang-tidy correctly reports that virtual dispatch is bypassed during construction, and the Lint workflow promotes that diagnostic to an error.

## Fix
Call the class implementation directly from the constructor. Runtime resize behavior and the public API remain unchanged.

## Regression coverage
- Cover zero-size construction followed by grow/shrink resize and memory accounting.

## Test evidence
- `make release`
- `make test CASE="[LockStrategy]"` (13 assertions passed; filtered functional/mockimpl suites had no matching cases)
- `clang-format-15` on changed files
- `clang-tidy-15 -p build src/utils/lock_strategy.cpp --warnings-as-errors="*"`
- `clang-tidy-15 -p build src/utils/lock_strategy_test.cpp --warnings-as-errors="*"`
- `git diff --check`

## Scope
- target: `main`
- commit: `fda59524`