### PR TITLE
fix(hgraph): backport #2515 to 1.0

### DIFF
--- a/src/algorithm/hgraph/hgraph_parameter.cpp
+++ b/src/algorithm/hgraph/hgraph_parameter.cpp
@@ -206,7 +206,14 @@ HGraphSearchParameters::FromJson(const std::string& json_string) {
         params[INDEX_TYPE_HGRAPH].Contains(HGRAPH_PARAMETER_EF_RUNTIME),
         fmt::format(
             "parameters[{}] must contains {}", INDEX_TYPE_HGRAPH, HGRAPH_PARAMETER_EF_RUNTIME));
-    obj.ef_search = params[INDEX_TYPE_HGRAPH][HGRAPH_PARAMETER_EF_RUNTIME].GetInt();
+    const auto& ef_search_json = params[INDEX_TYPE_HGRAPH][HGRAPH_PARAMETER_EF_RUNTIME];
+    CHECK_ARGUMENT(ef_search_json.IsNumberInteger(), "ef_search must be an integer");
+    if (ef_search_json.IsNumberUnsigned()) {
+        CHECK_ARGUMENT(ef_search_json.GetUint64() <=
+                           static_cast<uint64_t>(std::numeric_limits<int64_t>::max()),
+                       "ef_search exceeds int64_t range");
+    }
+    obj.ef_search = ef_search_json.GetInt();
     if (params[INDEX_TYPE_HGRAPH].Contains(HGRAPH_PARAMETER_HOPS_LIMIT)) {
         obj.hops_limit = params[INDEX_TYPE_HGRAPH][HGRAPH_PARAMETER_HOPS_LIMIT].GetInt();
     }

--- a/src/algorithm/hgraph/hgraph_parameter_test.cpp
+++ b/src/algorithm/hgraph/hgraph_parameter_test.cpp
@@ -231,6 +231,12 @@ TEST_CASE("HGraph Search Parameters parse RaBitQ error rate", "[ut][HGraphParame
     })"));
 }
 
+TEST_CASE("HGraph Search Parameters reject ef_search integer overflow",
+          "[ut][HGraphSearchParameters][ef_search]") {
+    REQUIRE_THROWS(vsag::HGraphSearchParameters::FromJson(
+        R"({"hgraph": {"ef_search": 9223372036854775808}})"));
+}
+
 TEST_CASE("HGraph maps label_remap_type to inner index parameter", "[ut][HGraphParameter]") {
     auto param = vsag::JsonType::Parse(R"({
         "base_quantization_type": "fp32",

--- a/src/algorithm/hgraph/hgraph_search.cpp
+++ b/src/algorithm/hgraph/hgraph_search.cpp
@@ -77,10 +77,9 @@ HGraph::KnnSearch(const DatasetPtr& query,
 
     auto params = HGraphSearchParameters::FromJson(parameters);
     ctx.rabitq_error_rate = params.rabitq_error_rate;
-    auto ef_search_threshold = std::max<int64_t>(AMPLIFICATION_FACTOR * k, 1000);
     CHECK_ARGUMENT(  // NOLINT
-        (1 <= params.ef_search) and (params.ef_search <= ef_search_threshold),
-        fmt::format("ef_search({}) must in range[1, {}]", params.ef_search, ef_search_threshold));
+        params.ef_search >= 1,
+        fmt::format("ef_search({}) must be at least 1", params.ef_search));
 
     std::shared_lock<std::shared_mutex> force_remove_rlock;
     std::shared_lock<std::shared_mutex> shared_lock;
@@ -389,10 +388,9 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
     auto params = HGraphSearchParameters::FromJson(request.params_str_);
     ctx.rabitq_error_rate = params.rabitq_error_rate;
 
-    auto ef_search_threshold = std::max<int64_t>(AMPLIFICATION_FACTOR * k, 1000);
     CHECK_ARGUMENT(  // NOLINT
-        (1 <= params.ef_search) and (params.ef_search <= ef_search_threshold),
-        fmt::format("ef_search({}) must in range[1, {}]", params.ef_search, ef_search_threshold));
+        params.ef_search >= 1,
+        fmt::format("ef_search({}) must be at least 1", params.ef_search));
 
     std::shared_lock<std::shared_mutex> force_remove_rlock;
     std::shared_lock<std::shared_mutex> shared_lock;
@@ -498,7 +496,7 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
         }
         search_param.parallel_search_thread_count = params.parallel_search_thread_count;
 
-        if (params.hops_limit <= static_cast<uint32_t>(params.ef_search)) {
+        if (static_cast<uint64_t>(params.hops_limit) <= static_cast<uint64_t>(params.ef_search)) {
             search_param.hops_limit = std::numeric_limits<uint32_t>::max();
             if (params.hops_limit != std::numeric_limits<uint32_t>::max()) {
                 logger::warn(fmt::format(

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -3022,6 +3022,15 @@ TEST_CASE("(PR) HGraph brute_force_threshold default is no-op",
         REQUIRE(std::abs(baseline.value()->GetDistances()[k] -
                          with_zero.value()->GetDistances()[k]) < 1e-6F);
     }
+
+    auto large_ef = index->KnnSearch(query, topk, R"({"hgraph": {"ef_search": 1001}})");
+    REQUIRE(large_ef.has_value());
+    REQUIRE(large_ef.value()->GetDim() == topk);
+
+    auto zero_ef = index->KnnSearch(query, topk, R"({"hgraph": {"ef_search": 0}})");
+    auto negative_ef = index->KnnSearch(query, topk, R"({"hgraph": {"ef_search": -1}})");
+    REQUIRE_FALSE(zero_ef.has_value());
+    REQUIRE_FALSE(negative_ef.has_value());
 }
 
 TEST_CASE("HGraph ExportCache + ImportCache + Build acceleration smoke test",


### PR DESCRIPTION
## Summary

Backport the complete HGraph `ef_search` upper-bound fix from [PR #2515](https://github.com/antgroup/vsag/pull/2515) to the `1.0` maintenance branch.

## Changes

- Remove the k-relative `ef_search` upper bound from both HGraph KNN search paths.
- Preserve positive-value validation, signed/unsigned integer range safety, and overflow-safe `hops_limit` handling.
- Include the parameter overflow regression test and functional coverage for `ef_search=1001`, zero, and negative values.

This cherry-pick applied cleanly to `origin/1.0`; no adaptation or conflict resolution was required. No unrelated main-only changes are included.

## Validation

- Focused HGraph parameter tests: 12 cases, 68 assertions passed.
- Focused HGraph functional regression tests: 2 cases, 30 assertions passed.
- `make release`: passed (309 targets).
- `make lint`: passed with clang-tidy 15 configuration; direct clang-tidy 15 on both changed implementations completed without findings.
- clang-format 15 dry-run and `git diff --check`: passed.
- Full `make test` build completed; the suite was interrupted during a long unrelated generated GraphDataCell case after 258 cases / 41,931,101 assertions passed.

Fixes: #2409
