### PR TITLE
feat: add threshold filtering to knn search

### DIFF
--- a/docs/docs/en/src/guide/knn_search.md
+++ b/docs/docs/en/src/guide/knn_search.md
@@ -87,3 +87,31 @@ for (int64_t i = 0; i < result->GetDim(); ++i) {
 ```
 
 The result contains up to `k` neighbors sorted by ascending distance to the query.
+
+## Threshold Filtering
+
+Threshold filtering is supported by the maintained indexes: BruteForce, HGraph, IVF, Pyramid,
+SINDI, and SIMQ. HNSW and DiskANN are deprecated and are explicit unsupported
+non-goals; this option does not add or change behavior for either legacy index.
+
+KNN search accepts an optional top-level `threshold` in the JSON search parameters:
+
+```json
+{
+  "threshold": 4.0,
+  "hgraph": { "ef_search": 64 }
+}
+```
+
+When present, the result contains at most `k` neighbors and every returned distance is less than
+or equal to `threshold`. The boundary is inclusive, results remain sorted by ascending distance,
+and fewer than `k` results—or no results—may be returned. When omitted, KNN behavior is unchanged.
+The value uses the index metric's returned distance: squared L2 for `l2`, `1 - inner_product` for
+`ip`, and `1 - cosine_similarity` for `cosine`. Therefore negative thresholds can be meaningful
+for `ip`; the threshold must be a finite JSON number.
+
+The same option is available through `SearchRequest::threshold_` on BruteForce, HGraph, and IVF;
+Pyramid, SINDI, and SIMQ support the option through their KNN JSON parameters. These are the six
+maintained indexes supported by this feature. It only limits KNN results; use `RangeSearch` and
+its `radius` argument for range-search requests. Existing index-specific search parameters can be
+supplied alongside `threshold`.

--- a/docs/docs/zh/src/guide/knn_search.md
+++ b/docs/docs/zh/src/guide/knn_search.md
@@ -92,6 +92,30 @@ BruteForce 索引支持用 Build 和 Add 方法写入数据，这里我们用 Ad
 
 搜索请求至多返回 k 个结果，这些结果按照最近邻和查询向量的距离升序排序。输出的结果类似于：
 
+## 按阈值过滤
+
+阈值过滤支持仍在维护的索引：BruteForce、HGraph、IVF、Pyramid、SINDI 和 SIMQ。
+HNSW 和 DiskANN 已弃用，是明确不在范围内的目标；本选项不会为这两个旧索引新增或修改行为。
+
+KNN 搜索参数支持在 JSON 顶层设置可选的 `threshold`：
+
+```json
+{
+  "threshold": 4.0,
+  "hgraph": { "ef_search": 64 }
+}
+```
+
+设置后，结果至多返回 `k` 个邻居，并且每个返回距离都小于或等于 `threshold`。
+边界值会被包含，结果仍按距离升序排列，因此可能返回少于 `k` 个结果，甚至没有结果。
+不设置该字段时，KNN 行为保持不变。阈值使用索引返回的距离语义：`l2` 为 L2 平方距离，
+`ip` 为 `1 - inner_product`，`cosine` 为 `1 - cosine_similarity`。因此 `ip` 可以使用负阈值；
+阈值必须是有限的 JSON 数字。
+
+通过统一请求接口时，BruteForce、HGraph 和 IVF 支持使用 `SearchRequest::threshold_`；
+Pyramid、SINDI 和 SIMQ 通过 KNN JSON 参数支持该选项。这六种索引是本功能支持的仍在维护的索引。
+该选项只限制 KNN 结果；范围搜索请使用 `RangeSearch` 及其 `radius` 参数。`threshold` 可以和现有索引专用搜索参数同时传入。
+
 ```bash
 results:
 6519: 13.855
@@ -105,4 +129,3 @@ results:
 8703: 16.1161
 5583: 16.1256
 ```
-

--- a/include/vsag/search_request.h
+++ b/include/vsag/search_request.h
@@ -16,6 +16,7 @@
 
 #include <cstdint>
 #include <functional>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -206,6 +207,14 @@ public:
      *          Default is empty (no reasoning enabled).
      */
     std::vector<int64_t> expected_labels_{};
+
+    /**
+     * @brief Optional inclusive distance threshold for KNN search mode
+     * @details When set, at most topk_ results are returned and every returned
+     *          distance is less than or equal to this threshold. An unset value
+     *          preserves the default KNN behavior.
+     */
+    std::optional<float> threshold_{std::nullopt};
 };
 
 }  // namespace vsag

--- a/src/algorithm/bruteforce/bruteforce.cpp
+++ b/src/algorithm/bruteforce/bruteforce.cpp
@@ -38,6 +38,7 @@
 #include "storage/serialization_tags.h"
 #include "storage/tlv_section.h"
 #include "typing.h"
+#include "utils/search_threshold.h"
 #include "utils/slow_task_timer.h"
 #include "utils/util_functions.h"
 namespace vsag {
@@ -359,6 +360,7 @@ BruteForce::KnnSearch(const DatasetPtr& query,
     req.query_ = query;
     req.topk_ = k;
     req.params_str_ = parameters;
+    req.threshold_ = ParseSearchThreshold(parameters);
     if (filter != nullptr) {
         req.filter_ = filter;
     }
@@ -367,6 +369,7 @@ BruteForce::KnnSearch(const DatasetPtr& query,
 
 DatasetPtr
 BruteForce::SearchWithRequest(const SearchRequest& request) const {
+    ValidateSearchThreshold(request.threshold_);
     std::shared_lock read_lock(this->global_mutex_);
 
     const bool use_custom_distance = request.distance_batch_func_ != nullptr;
@@ -529,7 +532,9 @@ BruteForce::SearchWithRequest(const SearchRequest& request) const {
                     if (is_range and dist > radius) {
                         continue;
                     }
-                    cur_heap->Push(dist, i);
+                    if (is_range or not request.threshold_.has_value() or std::isfinite(dist)) {
+                        cur_heap->Push(dist, i);
+                    }
                 }
             } else {
                 if (reasoning != nullptr) {
@@ -578,6 +583,13 @@ BruteForce::SearchWithRequest(const SearchRequest& request) const {
         for (auto i = 1; i < parallel_count; ++i) {
             heap->Merge(*heaps[i]);
         }
+    }
+
+    if (not is_range) {
+        filter_search_result_by_threshold(
+            heap,
+            request.threshold_,
+            select_query_allocator(request.search_allocator_, this->allocator_));
     }
 
     // Collect result inner IDs before pack_knn_result_with_extra_info consumes the heap,

--- a/src/algorithm/hgraph/hgraph.h
+++ b/src/algorithm/hgraph/hgraph.h
@@ -623,7 +623,8 @@ private:
                        const FilterPtr& filter,
                        int64_t topk,
                        float radius,
-                       QueryContext* ctx) const;
+                       QueryContext* ctx,
+                       const std::optional<float>& threshold = std::nullopt) const;
 
 private:
     /// Reorder the candidate heap using precise codes, updating in-place.
@@ -634,7 +635,8 @@ private:
             int64_t k,
             IteratorFilterContext* iter_ctx,
             QueryContext& ctx,
-            const DistanceRecordVector* rabitq_lower_bound_candidates = nullptr) const;
+            const DistanceRecordVector* rabitq_lower_bound_candidates = nullptr,
+            const std::optional<float>& distance_threshold = std::nullopt) const;
 
     /// Run ELP (Edge-Link Pruning) optimizer on the bottom graph.
     void

--- a/src/algorithm/hgraph/hgraph_build.cpp
+++ b/src/algorithm/hgraph/hgraph_build.cpp
@@ -715,7 +715,9 @@ HGraph::probe_graph_for_add(const void* data,
     for (auto j = static_cast<int64_t>(this->route_graphs_.size()) - 1; j > level; --j) {
         result = this->search_graph_for_build(
             data, route_graphs_[j], flatten_codes, param, build_computer);
-        param.ep = result->Top().second;
+        if (not result->Empty()) {
+            param.ep = result->Top().second;
+        }
     }
 
     param.ef = this->ef_construct_;
@@ -751,7 +753,7 @@ HGraph::publish_unique_to_bottom_graph(InnerIdType inner_id,
                                        const DistHeapPtr& neighbors,
                                        const FlattenInterfacePtr& flatten_codes) {
     LockGuard cur_lock(neighbors_mutex_, inner_id);
-    if (neighbors != nullptr) {
+    if (neighbors != nullptr and not neighbors->Empty()) {
         mutually_connect_new_element(inner_id,
                                      neighbors,
                                      this->bottom_graph_,
@@ -786,13 +788,17 @@ HGraph::publish_unique_to_route_graphs(const void* data,
                 }
             }
             LockGuard cur_lock(neighbors_mutex_, inner_id);
-            mutually_connect_new_element(inner_id,
-                                         filtered_result,
-                                         route_graphs_[j],
-                                         flatten_codes,
-                                         neighbors_mutex_,
-                                         allocator_,
-                                         alpha_);
+            if (not filtered_result->Empty()) {
+                mutually_connect_new_element(inner_id,
+                                             filtered_result,
+                                             route_graphs_[j],
+                                             flatten_codes,
+                                             neighbors_mutex_,
+                                             allocator_,
+                                             alpha_);
+            } else {
+                route_graphs_[j]->InsertNeighborsById(inner_id, Vector<InnerIdType>(allocator_));
+            }
         } else {
             LockGuard cur_lock(neighbors_mutex_, inner_id);
             route_graphs_[j]->InsertNeighborsById(inner_id, Vector<InnerIdType>(allocator_));
@@ -1005,7 +1011,8 @@ HGraph::reorder(const void* query,
                 int64_t k,
                 IteratorFilterContext* iter_ctx,
                 QueryContext& ctx,
-                const DistanceRecordVector* rabitq_lower_bound_candidates) const {
+                const DistanceRecordVector* rabitq_lower_bound_candidates,
+                const std::optional<float>& distance_threshold) const {
     uint64_t size = candidate_heap->Size();
     if (k <= 0) {
         k = static_cast<int64_t>(size);
@@ -1019,7 +1026,8 @@ HGraph::reorder(const void* query,
                                               k,
                                               ctx,
                                               iter_ctx,
-                                              rabitq_lower_bound_candidates);
+                                              rabitq_lower_bound_candidates,
+                                              distance_threshold);
     candidate_heap = reorder_heap;
 }
 

--- a/src/algorithm/hgraph/hgraph_search.cpp
+++ b/src/algorithm/hgraph/hgraph_search.cpp
@@ -15,6 +15,7 @@
 #include <fmt/format.h>
 
 #include <algorithm>
+#include <cmath>
 
 #include "attr/argparse.h"
 #include "dataset_impl.h"
@@ -22,6 +23,7 @@
 #include "impl/filter/iterator_filter.h"
 #include "impl/heap/standard_heap.h"
 #include "impl/reasoning/search_reasoning.h"
+#include "utils/search_threshold.h"
 #include "utils/util_functions.h"
 
 namespace vsag {
@@ -53,6 +55,7 @@ HGraph::KnnSearch(const DatasetPtr& query,
     req.topk_ = k;
     req.filter_ = filter;
     req.params_str_ = parameters;
+    req.threshold_ = ParseSearchThreshold(parameters);
     req.search_allocator_ = allocator;
     return this->SearchWithRequest(req);
 }
@@ -77,6 +80,7 @@ HGraph::KnnSearch(const DatasetPtr& query,
     this->validate_knn_args(query, k);
 
     auto params = HGraphSearchParameters::FromJson(parameters);
+    const auto threshold = ParseSearchThreshold(parameters);
     ctx.rabitq_error_rate = params.rabitq_error_rate;
     CHECK_ARGUMENT(  // NOLINT
         params.ef_search >= 1,
@@ -110,7 +114,6 @@ HGraph::KnnSearch(const DatasetPtr& query,
     }
 
     auto* iter_filter_ctx = static_cast<IteratorFilterContext*>(iter_ctx);
-    auto search_result = DistanceHeap::MakeInstanceBySize<true, false>(ctx.alloc, k);
     const auto* query_data = get_data(query);
     // Note: brute_force_threshold is intentionally not applied here. The
     // iterator KnnSearch API pages results across multiple calls via
@@ -118,106 +121,141 @@ HGraph::KnnSearch(const DatasetPtr& query,
     // that pagination state itself or be wasted on subsequent calls. The
     // non-iterator KnnSearch overload (which delegates to SearchWithRequest)
     // still benefits from the brute-force fallback.
-    if (is_last_filter) {
-        while (!iter_filter_ctx->Empty()) {
-            uint32_t cur_inner_id = iter_filter_ctx->GetTopID();
-            float cur_dist = iter_filter_ctx->GetTopDist();
-            search_result->Push(cur_dist, cur_inner_id);
-            iter_filter_ctx->PopDiscard();
-        }
-    } else {
-        InnerSearchParam search_param;
-        search_param.ep = this->entry_point_id_;
-        search_param.topk = 1;
-        search_param.ef = 1;
-        search_param.is_inner_id_allowed = nullptr;
-        search_param.enable_rabitq_one_bit_search = params.rabitq_one_bit_search;
-        if (search_param.ep == INVALID_ENTRY_POINT) {
-            return make_empty_dataset_with_stats();
-        }
-        if (iter_filter_ctx->IsFirstUsed()) {
-            for (auto i = static_cast<int64_t>(this->route_graphs_.size() - 1); i >= 0; --i) {
-                auto result = this->search_one_graph(query_data,
-                                                     this->route_graphs_[i],
-                                                     this->basic_flatten_codes_,
-                                                     search_param,
-                                                     (VisitedListPtr) nullptr,
-                                                     &ctx);
-                search_param.ep = result->Top().second;
+    while (true) {
+        auto search_result = DistanceHeap::MakeInstanceBySize<true, false>(ctx.alloc, k);
+        if (is_last_filter) {
+            while (!iter_filter_ctx->Empty()) {
+                uint32_t cur_inner_id = iter_filter_ctx->GetTopID();
+                float cur_dist = iter_filter_ctx->GetTopDist();
+                search_result->Push(cur_dist, cur_inner_id);
+                iter_filter_ctx->PopDiscard();
+            }
+        } else {
+            InnerSearchParam search_param;
+            search_param.ep = this->entry_point_id_;
+            search_param.topk = 1;
+            search_param.ef = 1;
+            search_param.is_inner_id_allowed = nullptr;
+            search_param.enable_rabitq_one_bit_search = params.rabitq_one_bit_search;
+            if (search_param.ep == INVALID_ENTRY_POINT) {
+                return make_empty_dataset_with_stats();
+            }
+            if (iter_filter_ctx->IsFirstUsed()) {
+                for (auto i = static_cast<int64_t>(this->route_graphs_.size() - 1); i >= 0; --i) {
+                    auto result = this->search_one_graph(query_data,
+                                                         this->route_graphs_[i],
+                                                         this->basic_flatten_codes_,
+                                                         search_param,
+                                                         (VisitedListPtr) nullptr,
+                                                         &ctx);
+                    // An unrankable route seed can still bridge to finite bottom-layer results.
+                    if (not result->Empty()) {
+                        search_param.ep = result->Top().second;
+                    }
+                }
+            }
+
+            search_param.ef = std::max(params.ef_search, k);
+            search_param.is_inner_id_allowed = ft;
+            search_param.distance_threshold = threshold;
+            search_param.topk = static_cast<int64_t>(search_param.ef);
+            search_param.parallel_search_thread_count = params.parallel_search_thread_count;
+            search_param.enable_reorder = params.enable_reorder;
+            search_param.enable_rabitq_one_bit_search = params.rabitq_one_bit_search;
+            search_param.skip_ratio = params.skip_ratio;
+            search_param.skip_strategy_type = params.skip_strategy_type;
+
+            DistanceRecordVector rabitq_lower_bound_candidates(ctx.alloc);
+            auto* rabitq_lower_bound_candidates_ptr =
+                search_param.enable_rabitq_one_bit_search and use_reorder_ and
+                        search_param.enable_reorder and reorder_by_base_
+                    ? &rabitq_lower_bound_candidates
+                    : nullptr;
+
+            search_result = this->search_one_graph(query_data,
+                                                   this->bottom_graph_,
+                                                   this->basic_flatten_codes_,
+                                                   search_param,
+                                                   iter_filter_ctx,
+                                                   &ctx,
+                                                   rabitq_lower_bound_candidates_ptr);
+
+            if (use_reorder_ and search_param.enable_reorder) {
+                this->reorder(query_data,
+                              this->get_reorder_codes(),
+                              search_result,
+                              k,
+                              iter_filter_ctx,
+                              ctx,
+                              rabitq_lower_bound_candidates_ptr,
+                              threshold);
+            } else if (search_param.enable_reorder and params.rabitq_one_bit_search) {
+                this->reorder(query_data,
+                              this->basic_flatten_codes_,
+                              search_result,
+                              k,
+                              iter_filter_ctx,
+                              ctx,
+                              nullptr,
+                              threshold);
             }
         }
 
-        search_param.ef = std::max(params.ef_search, k);
-        search_param.is_inner_id_allowed = ft;
-        search_param.topk = static_cast<int64_t>(search_param.ef);
-        search_param.parallel_search_thread_count = params.parallel_search_thread_count;
-        search_param.enable_reorder = params.enable_reorder;
-        search_param.enable_rabitq_one_bit_search = params.rabitq_one_bit_search;
-        search_param.skip_ratio = params.skip_ratio;
-        search_param.skip_strategy_type = params.skip_strategy_type;
-
-        DistanceRecordVector rabitq_lower_bound_candidates(ctx.alloc);
-        auto* rabitq_lower_bound_candidates_ptr =
-            search_param.enable_rabitq_one_bit_search and use_reorder_ and
-                    search_param.enable_reorder and reorder_by_base_
-                ? &rabitq_lower_bound_candidates
-                : nullptr;
-
-        search_result = this->search_one_graph(query_data,
-                                               this->bottom_graph_,
-                                               this->basic_flatten_codes_,
-                                               search_param,
-                                               iter_filter_ctx,
-                                               &ctx,
-                                               rabitq_lower_bound_candidates_ptr);
-
-        if (use_reorder_ and search_param.enable_reorder) {
-            this->reorder(query_data,
-                          this->get_reorder_codes(),
-                          search_result,
-                          k,
-                          iter_filter_ctx,
-                          ctx,
-                          rabitq_lower_bound_candidates_ptr);
-        } else if (search_param.enable_reorder and params.rabitq_one_bit_search) {
-            this->reorder(
-                query_data, this->basic_flatten_codes_, search_result, k, iter_filter_ctx, ctx);
+        if (threshold.has_value()) {
+            DistanceRecordVector valid_records(ctx.alloc);
+            valid_records.reserve(search_result->Size());
+            while (not search_result->Empty()) {
+                const auto record = search_result->Top();
+                search_result->Pop();
+                if (std::isfinite(record.first) and record.first <= threshold.value()) {
+                    valid_records.push_back(record);
+                } else {
+                    iter_filter_ctx->SetPoint(record.second);
+                }
+            }
+            for (const auto& record : valid_records) {
+                search_result->Push(record);
+            }
         }
-    }
-
-    while (search_result->Size() > k) {
-        auto curr = search_result->Top();
-        iter_filter_ctx->AddDiscardNode(curr.first, curr.second);
-        search_result->Pop();
-    }
-
-    // return an empty dataset directly if searcher returns nothing
-    if (search_result->Empty()) {
-        return DatasetImpl::MakeEmptyDataset();
-    }
-    auto count = static_cast<const int64_t>(search_result->Size());
-    auto [dataset_results, dists, ids] = create_fast_dataset(count, ctx.alloc);
-    char* extra_infos = nullptr;
-    if (extra_info_size_ > 0) {
-        extra_infos =
-            static_cast<char*>(ctx.alloc->Allocate(extra_info_size_ * search_result->Size()));
-        dataset_results->ExtraInfos(extra_infos)
-            ->ExtraInfoSize(static_cast<int64_t>(extra_info_size_));
-    }
-    for (int64_t j = count - 1; j >= 0; --j) {
-        dists[j] = search_result->Top().first;
-        ids[j] = this->label_table_->GetLabelById(search_result->Top().second);
-        iter_filter_ctx->SetPoint(search_result->Top().second);
-        if (extra_infos != nullptr) {
-            this->extra_infos_->GetExtraInfoById(search_result->Top().second,
-                                                 extra_infos + extra_info_size_ * j);
+        while (search_result->Size() > k) {
+            auto curr = search_result->Top();
+            iter_filter_ctx->AddDiscardNode(curr.first, curr.second);
+            search_result->Pop();
         }
-        search_result->Pop();
-    }
-    iter_filter_ctx->SetOFFFirstUsed();
 
-    dataset_results->Statistics(stats.Dump());
-    return std::move(dataset_results);
+        // An empty page is terminal to iterator callers, so consume retained traversal state
+        // internally until an eligible result is found or the discard heap is exhausted.
+        if (search_result->Empty()) {
+            iter_filter_ctx->SetOFFFirstUsed();
+            if (not iter_filter_ctx->Empty()) {
+                continue;
+            }
+            return DatasetImpl::MakeEmptyDataset();
+        }
+        auto count = static_cast<const int64_t>(search_result->Size());
+        auto [dataset_results, dists, ids] = create_fast_dataset(count, ctx.alloc);
+        char* extra_infos = nullptr;
+        if (extra_info_size_ > 0) {
+            extra_infos =
+                static_cast<char*>(ctx.alloc->Allocate(extra_info_size_ * search_result->Size()));
+            dataset_results->ExtraInfos(extra_infos)
+                ->ExtraInfoSize(static_cast<int64_t>(extra_info_size_));
+        }
+        for (int64_t j = count - 1; j >= 0; --j) {
+            dists[j] = search_result->Top().first;
+            ids[j] = this->label_table_->GetLabelById(search_result->Top().second);
+            iter_filter_ctx->SetPoint(search_result->Top().second);
+            if (extra_infos != nullptr) {
+                this->extra_infos_->GetExtraInfoById(search_result->Top().second,
+                                                     extra_infos + extra_info_size_ * j);
+            }
+            search_result->Pop();
+        }
+        iter_filter_ctx->SetOFFFirstUsed();
+
+        dataset_results->Statistics(stats.Dump());
+        return std::move(dataset_results);
+    }
 }
 
 template <InnerSearchMode mode>
@@ -291,7 +329,8 @@ HGraph::brute_force_search(const void* query,
                            const FilterPtr& filter,
                            int64_t topk,
                            float radius,
-                           QueryContext* ctx) const {
+                           QueryContext* ctx,
+                           const std::optional<float>& threshold) const {
     Allocator* alloc = (ctx != nullptr && ctx->alloc != nullptr) ? ctx->alloc : this->allocator_;
 
     auto flatten = this->basic_flatten_codes_;
@@ -343,7 +382,8 @@ HGraph::brute_force_search(const void* query,
                 if (dist <= radius) {
                     result->Push(dist, inner_id);
                 }
-            } else {
+            } else if (not threshold.has_value() or
+                       (std::isfinite(dist) and dist <= threshold.value())) {
                 result->Push(dist, inner_id);
             }
         }
@@ -371,6 +411,7 @@ HGraph::RangeSearch(const DatasetPtr& query,
 
 [[nodiscard]] DatasetPtr
 HGraph::SearchWithRequest(const SearchRequest& request) const {
+    ValidateSearchThreshold(request.threshold_);
     SearchStatistics stats;
     QueryContext ctx{.alloc = this->allocator_, .stats = &stats};
     if (request.search_allocator_ != nullptr) {
@@ -511,7 +552,10 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
     for (auto i = static_cast<int64_t>(this->route_graphs_.size() - 1); i >= 0; --i) {
         auto result = this->search_one_graph(
             raw_query, this->route_graphs_[i], this->basic_flatten_codes_, search_param, vt, &ctx);
-        search_param.ep = result->Top().second;
+        // An unrankable route seed can still bridge to finite bottom-layer results.
+        if (not result->Empty()) {
+            search_param.ep = result->Top().second;
+        }
     }
 
     FilterPtr ft = this->create_search_filter(request.filter_, params.use_extra_info_filter);
@@ -538,6 +582,7 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
     } else {
         search_param.ef = std::max(params.ef_search, k);
         search_param.is_inner_id_allowed = ft;
+        search_param.distance_threshold = request.threshold_;
         search_param.topk = static_cast<int64_t>(search_param.ef);
         if (params.topk_factor > 1.0F) {
             search_param.topk =
@@ -589,7 +634,7 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
                     raw_query, ft, request.limited_size_, request.radius_, &ctx);
             } else {
                 search_result = this->brute_force_search<InnerSearchMode::KNN_SEARCH>(
-                    raw_query, ft, k, 0.0F, &ctx);
+                    raw_query, ft, k, 0.0F, &ctx, request.threshold_);
             }
             brute_force_used = true;
             mci_result.route = "brute_force";
@@ -622,17 +667,27 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
     if (mci_result.route != "mci" and not brute_force_used and use_reorder_ and
         search_param.enable_reorder) {
         auto limit = is_range ? request.limited_size_ : k;
+        auto reorder_threshold = is_range ? std::nullopt : request.threshold_;
         this->reorder(raw_query,
                       this->get_reorder_codes(),
                       search_result,
                       limit,
                       nullptr,
                       ctx,
-                      rabitq_lower_bound_candidates_ptr);
+                      rabitq_lower_bound_candidates_ptr,
+                      reorder_threshold);
     } else if (mci_result.route != "mci" and not brute_force_used and
                search_param.enable_reorder and params.rabitq_one_bit_search) {
         auto limit = is_range ? request.limited_size_ : k;
-        this->reorder(raw_query, this->basic_flatten_codes_, search_result, limit, nullptr, ctx);
+        auto reorder_threshold = is_range ? std::nullopt : request.threshold_;
+        this->reorder(raw_query,
+                      this->basic_flatten_codes_,
+                      search_result,
+                      limit,
+                      nullptr,
+                      ctx,
+                      nullptr,
+                      reorder_threshold);
     }
 
     // Trim and pack results
@@ -651,7 +706,22 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
         return result;
     }
 
-    // KNN mode: trim by k
+    // NaN is unordered and cannot be returned. Infinity remains a valid legacy result only when
+    // threshold filtering is absent; the searcher has already kept it out of threshold heaps.
+    DistanceRecordVector finite_records(ctx.alloc);
+    finite_records.reserve(search_result->Size());
+    while (not search_result->Empty()) {
+        const auto record = search_result->Top();
+        search_result->Pop();
+        if (not std::isnan(record.first) and
+            (not request.threshold_.has_value() or std::isfinite(record.first))) {
+            finite_records.push_back(record);
+        }
+    }
+    for (const auto& record : finite_records) {
+        search_result->Push(record);
+    }
+    filter_search_result_by_threshold(search_result, request.threshold_, ctx.alloc);
     while (search_result->Size() > static_cast<uint64_t>(k)) {
         search_result->Pop();
     }

--- a/src/algorithm/inner_index_interface.cpp
+++ b/src/algorithm/inner_index_interface.cpp
@@ -1147,6 +1147,27 @@ InnerIndexInterface::pack_knn_result(DistHeapPtr& heap, Allocator* allocator) co
     return std::move(dataset_results);
 }
 
+void
+InnerIndexInterface::filter_search_result_by_threshold(DistHeapPtr& result,
+                                                       const std::optional<float>& threshold,
+                                                       Allocator* allocator) {
+    if (not threshold.has_value() or result == nullptr) {
+        return;
+    }
+    DistanceRecordVector valid_records(allocator);
+    valid_records.reserve(result->Size());
+    while (not result->Empty()) {
+        const auto record = result->Top();
+        result->Pop();
+        if (std::isfinite(record.first) and record.first <= threshold.value()) {
+            valid_records.push_back(record);
+        }
+    }
+    for (const auto& record : valid_records) {
+        result->Push(record);
+    }
+}
+
 DatasetPtr
 InnerIndexInterface::pack_knn_result_with_extra_info(DistHeapPtr& heap,
                                                      Allocator* allocator) const {

--- a/src/algorithm/inner_index_interface.h
+++ b/src/algorithm/inner_index_interface.h
@@ -667,6 +667,11 @@ protected:
     void
     validate_range_args(const DatasetPtr& query, float radius, int64_t limited_size) const;
 
+    static void
+    filter_search_result_by_threshold(DistHeapPtr& result,
+                                      const std::optional<float>& threshold,
+                                      Allocator* allocator);
+
 public:
     LabelTablePtr label_table_{nullptr};
     mutable std::shared_mutex label_lookup_mutex_{};  // lock for label_lookup_ & labels_

--- a/src/algorithm/ivf/flat_bucket_searcher.cpp
+++ b/src/algorithm/ivf/flat_bucket_searcher.cpp
@@ -14,6 +14,7 @@
 
 #include "flat_bucket_searcher.h"
 
+#include <cmath>
 #include <limits>
 
 #include "attr/executor/executor.h"
@@ -66,6 +67,11 @@ FlatBucketSearcher::Search(BucketIdType bucket_id,
             auto origin_id = ids[j] / buckets_per_data;
             if (reasoning_ctx != nullptr) {
                 reasoning_ctx->RecordVisit(origin_id, dist[j], 0);
+            }
+            if (param.distance_threshold.has_value() and
+                (not std::isfinite(dist[j]) or
+                 (not param.enable_reorder and dist[j] > param.distance_threshold.value()))) {
+                continue;
             }
             if (attr_ft != nullptr and not attr_ft->CheckValid(j)) {
                 if (reasoning_ctx != nullptr) {

--- a/src/algorithm/ivf/ivf.cpp
+++ b/src/algorithm/ivf/ivf.cpp
@@ -49,6 +49,7 @@
 #include "storage/stream_reader.h"
 #include "storage/stream_writer.h"
 #include "storage/tlv_section.h"
+#include "utils/search_threshold.h"
 #include "utils/util_functions.h"
 #include "utils/visited_list.h"
 #include "vsag_exception.h"
@@ -773,6 +774,7 @@ IVF::KnnSearch(const DatasetPtr& query,
     req.query_ = query;
     req.topk_ = k;
     req.params_str_ = parameters;
+    req.threshold_ = ParseSearchThreshold(parameters);
     if (filter != nullptr) {
         req.filter_ = filter;
     }
@@ -1455,11 +1457,11 @@ IVF::reorder(int64_t topk,
              const float* query,
              const InnerSearchParam& param,
              QueryContext& ctx,
-             ReasoningContext* reasoning_ctx) const {
-    auto reorder_heap = reorder_->Reorder(input, query, topk, ctx);
+             ReasoningContext* reasoning_ctx,
+             const std::optional<float>& distance_threshold) const {
+    auto reorder_heap =
+        reorder_->Reorder(input, query, topk, ctx, nullptr, nullptr, distance_threshold);
     auto dataset_results = this->pack_knn_result(reorder_heap, ctx.alloc);
-
-    this->AttachReasoningReport(dataset_results, reasoning_ctx);
 
     return dataset_results;
 }
@@ -1807,6 +1809,7 @@ IVF::check_merge_illegal(const vsag::MergeUnit& unit) const {
 
 DatasetPtr
 IVF::SearchWithRequest(const SearchRequest& request) const {
+    ValidateSearchThreshold(request.threshold_);
     SearchStatistics stats;
     QueryContext ctx{.alloc = request.search_allocator_, .stats = &stats};
 
@@ -1842,6 +1845,8 @@ IVF::SearchWithRequest(const SearchRequest& request) const {
         CHECK_ARGUMENT(query->GetFloat32Vectors() != nullptr,
                        "query float32 vectors cannot be null");
         CHECK_ARGUMENT(query->GetDim() == this->dim_, "query dimension must match index dimension");
+        CHECK_ARGUMENT(not request.threshold_.has_value(),
+                       "threshold filtering is not supported with disable_bucket_scan");
         auto result = this->route_buckets_only(query, param, ctx);
         result->Statistics(stats.Dump());
         return result;
@@ -1861,6 +1866,8 @@ IVF::SearchWithRequest(const SearchRequest& request) const {
         param.search_mode = KNN_SEARCH;
         param.topk = request.topk_;
         auto search_result = search_with_custom_distance(query, request, param, ctx);
+        filter_search_result_by_threshold(
+            search_result, request.threshold_, select_query_allocator(ctx.alloc, this->allocator_));
         if (search_result == nullptr || search_result->Empty()) {
             auto dataset_results = DatasetImpl::MakeEmptyDataset();
             dataset_results->Statistics(stats.Dump());
@@ -1925,6 +1932,7 @@ IVF::SearchWithRequest(const SearchRequest& request) const {
             auto result = reorder(
                 k, search_result, query->GetFloat32Vectors(), param, ctx, reasoning_ctx.get());
             result->Statistics(stats.Dump());
+            this->AttachReasoningReport(result, reasoning_ctx.get());
             return result;
         }
         auto dataset_results = this->pack_knn_result(search_result, ctx.alloc);
@@ -1941,18 +1949,30 @@ IVF::SearchWithRequest(const SearchRequest& request) const {
             param.factor > 0.0F,
             fmt::format("factor must be positive when use_reorder is true, got {}", param.factor));
         param.topk = static_cast<int64_t>(param.factor * static_cast<float>(request.topk_));
+        if (request.threshold_.has_value()) {
+            param.topk = std::max(param.topk, request.topk_);
+        }
     }
+    const bool reorder_enabled = use_reorder_ and param.enable_reorder;
+    // Reordered searches defer the finite bound to exact distances, but bucket selection still
+    // needs threshold-mode state so non-finite approximations cannot consume the rerank pool.
+    param.distance_threshold = request.threshold_;
     auto search_result = this->search<KNN_SEARCH>(query, param, ctx, reasoning_ctx.get());
-    if (use_reorder_ and param.enable_reorder) {
-        auto result = reorder(request.topk_,
+    if (reorder_enabled) {
+        auto result = reorder(request.threshold_.has_value() ? param.topk : request.topk_,
                               search_result,
                               query->GetFloat32Vectors(),
                               param,
                               ctx,
-                              reasoning_ctx.get());
+                              reasoning_ctx.get(),
+                              request.threshold_);
+        result = FilterDatasetByThreshold(result, request.threshold_, ctx.alloc, request.topk_);
+        AttachReasoningReport(result, reasoning_ctx.get());
         result->Statistics(stats.Dump());
         return result;
     }
+    filter_search_result_by_threshold(
+        search_result, request.threshold_, select_query_allocator(ctx.alloc, this->allocator_));
     if (search_result == nullptr || search_result->Empty()) {
         auto dataset_results = DatasetImpl::MakeEmptyDataset();
         this->AttachReasoningReport(dataset_results, reasoning_ctx.get());
@@ -1974,7 +1994,7 @@ IVF::AttachReasoningReport(const DatasetPtr& dataset_results,
     if (reasoning_ctx == nullptr) {
         return;
     }
-    auto count = dataset_results->GetNumElements();
+    auto count = dataset_results->GetDim();
     if (count > 0 and dataset_results->GetIds() != nullptr) {
         Vector<InnerIdType> result_inner_ids(static_cast<uint64_t>(count), this->allocator_);
         {

--- a/src/algorithm/ivf/ivf.h
+++ b/src/algorithm/ivf/ivf.h
@@ -224,7 +224,8 @@ private:
             const float* query,
             const InnerSearchParam& param,
             QueryContext& ctx,
-            ReasoningContext* reasoning_ctx = nullptr) const;
+            ReasoningContext* reasoning_ctx = nullptr,
+            const std::optional<float>& distance_threshold = std::nullopt) const;
 
     void
     AttachReasoningReport(const DatasetPtr& dataset_results, ReasoningContext* reasoning_ctx) const;

--- a/src/algorithm/pyramid/pyramid.cpp
+++ b/src/algorithm/pyramid/pyramid.cpp
@@ -30,6 +30,7 @@
 #include "storage/serialization.h"
 #include "storage/serialization_tags.h"
 #include "storage/tlv_section.h"
+#include "utils/search_threshold.h"
 #include "utils/slow_task_timer.h"
 #include "utils/util_functions.h"
 namespace vsag {
@@ -261,6 +262,7 @@ Pyramid::KnnSearch(const DatasetPtr& query,
     SearchStatistics stats;
     QueryContext ctx{.stats = &stats};
 
+    const auto threshold = ParseSearchThreshold(parameters);
     auto parsed_param = PyramidSearchParameters::FromJson(parameters);
     CHECK_ARGUMENT(k > 0, fmt::format("k({}) must be greater than 0", k));
     CHECK_ARGUMENT(parsed_param.hierarchy_op == PyramidSearchParameters::HierarchyOp::SINGLE,
@@ -274,7 +276,9 @@ Pyramid::KnnSearch(const DatasetPtr& query,
     InnerSearchParam search_param;
     search_param.ef = std::max<uint64_t>(parsed_param.ef_search, static_cast<uint64_t>(k));
     search_param.radius = std::numeric_limits<float>::max();
-    search_param.topk = k;
+    search_param.topk = threshold.has_value() ? static_cast<int64_t>(search_param.ef) : k;
+    search_param.distance_threshold = threshold;
+    search_param.enable_reorder = use_reorder_;
     search_param.search_mode = KNN_SEARCH;
     search_param.parallel_search_thread_count = parsed_param.parallel_search_thread_count;
     if (this->support_duplicate_) {
@@ -296,7 +300,7 @@ Pyramid::KnnSearch(const DatasetPtr& query,
         parsed_param.hierarchies.empty() ? "" : parsed_param.hierarchies[0];
     auto result = this->search_impl(query, search_func, search_param, ctx, hierarchy_name);
     result->Statistics(stats.Dump());
-    return result;
+    return FilterDatasetByThreshold(result, threshold, allocator_, k);
 }
 
 DatasetPtr
@@ -1350,6 +1354,12 @@ Pyramid::search_node(const IndexNode* node,
         codes->Query(dists.data(), computer, ids_ptr, id_count, &ctx);
 
         for (int i = 0; i < id_count; ++i) {
+            if (search_param.distance_threshold.has_value() and
+                (not std::isfinite(dists[i]) ||
+                 (not search_param.enable_reorder and
+                  dists[i] > search_param.distance_threshold.value()))) {
+                continue;
+            }
             results->Push(dists[i], ids_ptr[i]);
             if (results->Size() > search_param.ef) {
                 results->Pop();

--- a/src/algorithm/simq/simq.cpp
+++ b/src/algorithm/simq/simq.cpp
@@ -31,10 +31,12 @@
 #include "inner_string_params.h"
 #include "metric_type.h"
 #include "query_context.h"
+#include "simq_utils.h"
 #include "storage/serialization.h"
 #include "storage/stream_reader.h"
 #include "storage/stream_writer.h"
 #include "typing.h"
+#include "utils/search_threshold.h"
 #include "utils/util_functions.h"
 
 namespace vsag {
@@ -716,6 +718,7 @@ SIMQ::KnnSearch(const DatasetPtr& query,
                 const FilterPtr& filter) const {
     std::shared_lock lock(global_mutex_);
     SearchStatistics stats;
+    const auto threshold = ParseSearchThreshold(parameters);
 
     if (total_count_ == 0 || rep_hgraph_ == nullptr) {
         auto result = Dataset::Make();
@@ -776,15 +779,31 @@ SIMQ::KnnSearch(const DatasetPtr& query,
             reranked.emplace_back(batch_dists[i], batch_ids[i]);
         }
     }
-    std::sort(reranked.begin(), reranked.end(), [](const auto& a, const auto& b) {
-        return a.first < b.first;
-    });
+    std::sort(reranked.begin(), reranked.end(), simq_distance_less);
 
-    int64_t result_count = std::min(k, static_cast<int64_t>(reranked.size()));
+    int64_t result_count = 0;
+    for (const auto& [distance, _] : reranked) {
+        if (result_count >= k) {
+            break;
+        }
+        if (not threshold.has_value() or
+            (std::isfinite(distance) and distance <= threshold.value())) {
+            ++result_count;
+        }
+    }
     auto [result_ds, dists, ids] = create_fast_dataset(result_count, allocator_);
-    for (int64_t i = 0; i < result_count; ++i) {
-        dists[i] = reranked[i].first;
-        ids[i] = this->label_table_->GetLabelById(reranked[i].second);
+    int64_t result_index = 0;
+    for (const auto& [distance, inner_id] : reranked) {
+        if (result_index >= result_count) {
+            break;
+        }
+        if (threshold.has_value() and
+            (not std::isfinite(distance) or distance > threshold.value())) {
+            continue;
+        }
+        dists[result_index] = distance;
+        ids[result_index] = this->label_table_->GetLabelById(inner_id);
+        ++result_index;
     }
     result_ds->Statistics(dump_simq_statistics(stats,
                                                coarse_dist_cmp,
@@ -792,9 +811,9 @@ SIMQ::KnnSearch(const DatasetPtr& query,
                                                coarse_candidate_count,
                                                rerank_candidate_count,
                                                filtered_candidate_count,
-                                               static_cast<uint64_t>(result_count),
+                                               static_cast<uint64_t>(result_ds->GetDim()),
                                                false));
-    return std::move(result_ds);
+    return result_ds;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/algorithm/simq/simq_utils.h
+++ b/src/algorithm/simq/simq_utils.h
@@ -1,4 +1,3 @@
-
 // Copyright 2024-present the vsag project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,26 +14,23 @@
 
 #pragma once
 
-#include <optional>
+#include <cmath>
+#include <utility>
 
-#include "impl/heap/distance_heap.h"
-#include "utils/pointer_define.h"
+#include "typing.h"
 
 namespace vsag {
-class IteratorFilterContext;
 
-DEFINE_POINTER(ReorderInterface)
-
-class ReorderInterface {
-public:
-    virtual DistHeapPtr
-    Reorder(const DistHeapPtr& input,
-            const void* query,
-            int64_t topk,
-            QueryContext& ctx,
-            IteratorFilterContext* iter_ctx = nullptr,
-            const DistanceRecordVector* rabitq_lower_bound_candidates = nullptr,
-            const std::optional<float>& distance_threshold = std::nullopt) = 0;
-};
+inline bool
+simq_distance_less(const std::pair<float, InnerIdType>& lhs,
+                   const std::pair<float, InnerIdType>& rhs) {
+    if (std::isnan(lhs.first)) {
+        return false;
+    }
+    if (std::isnan(rhs.first)) {
+        return true;
+    }
+    return lhs.first < rhs.first;
+}
 
 }  // namespace vsag

--- a/src/algorithm/sindi/sindi.cpp
+++ b/src/algorithm/sindi/sindi.cpp
@@ -39,6 +39,7 @@
 #include "storage/serialization.h"
 #include "storage/serialization_tags.h"
 #include "storage/tlv_section.h"
+#include "utils/search_threshold.h"
 #include "utils/util_functions.h"
 #include "vsag/allocator.h"
 #include "vsag/options.h"
@@ -601,6 +602,7 @@ SINDI::KnnSearch(const DatasetPtr& query,
     // search parameter
     SINDISearchParameter search_param;
     search_param.FromJson(JsonType::Parse(parameters));
+    const auto threshold = ParseSearchThreshold(parameters);
     CHECK_ARGUMENT(search_param.n_candidate <= SPARSE_AMPLIFICATION_FACTOR * k,
                    fmt::format("n_candidate ({}) should be less than {} * k ({})",
                                search_param.n_candidate,
@@ -608,7 +610,9 @@ SINDI::KnnSearch(const DatasetPtr& query,
                                k));
     InnerSearchParam inner_param;
     inner_param.ef = std::max(static_cast<int64_t>(search_param.n_candidate), k);
-    inner_param.topk = k;
+    inner_param.topk = threshold.has_value() ? static_cast<int64_t>(inner_param.ef) : k;
+    inner_param.distance_threshold = threshold;
+    inner_param.enable_reorder = use_reorder_;
 
     inner_param.is_inner_id_allowed = this->create_search_filter(filter);
 
@@ -624,12 +628,16 @@ SINDI::KnnSearch(const DatasetPtr& query,
 
     auto computer = std::make_shared<SparseTermComputer>(effective_query, search_param, allocator_);
     const SparseVector* rerank_query = (remap_term_ids_ && use_reorder_) ? &sparse_query : nullptr;
+    DatasetPtr result;
+    const bool use_term_lists_heap_insert = UseTermListsHeapInsert(search_param, threshold);
     if (immutable_data_ != nullptr) {
-        return immutable_search_impl<KNN_SEARCH>(
-            computer, inner_param, allocator, UseTermListsHeapInsert(search_param), rerank_query);
+        result = immutable_search_impl<KNN_SEARCH>(
+            computer, inner_param, allocator, use_term_lists_heap_insert, rerank_query);
+    } else {
+        result = search_impl<KNN_SEARCH>(
+            computer, inner_param, allocator, use_term_lists_heap_insert, rerank_query);
     }
-    return search_impl<KNN_SEARCH>(
-        computer, inner_param, allocator, UseTermListsHeapInsert(search_param), rerank_query);
+    return FilterDatasetByThreshold(result, threshold, allocator, k);
 }
 
 std::optional<uint32_t>
@@ -717,9 +725,18 @@ SINDI::immutable_insert_candidate_into_heap(uint32_t id,
                                             float& cur_heap_top,
                                             MaxHeap& heap,
                                             uint32_t offset_id,
+                                            uint32_t n_candidate,
                                             float radius,
                                             int range_search_limit_size,
-                                            const FilterPtr& filter) const {
+                                            const FilterPtr& filter,
+                                            const std::optional<float>& threshold,
+                                            bool enable_reorder) const {
+    if constexpr (mode == InnerSearchMode::KNN_SEARCH) {
+        if (threshold.has_value() and
+            (not std::isfinite(dist) or (not enable_reorder and 1.0F + dist > threshold.value()))) {
+            return;
+        }
+    }
     if constexpr (mode == InnerSearchMode::RANGE_SEARCH) {
         if (range_search_limit_size == 0) {
             dist = 0;
@@ -748,8 +765,11 @@ SINDI::immutable_insert_candidate_into_heap(uint32_t id,
     }
     heap.emplace(dist, id + offset_id);
     if constexpr (mode == InnerSearchMode::KNN_SEARCH) {
-        heap.pop();
-        cur_heap_top = heap.top().first;
+        if (heap.size() > n_candidate) {
+            heap.pop();
+        }
+        cur_heap_top =
+            heap.size() == n_candidate ? heap.top().first : std::numeric_limits<float>::max();
     }
     if constexpr (mode == InnerSearchMode::RANGE_SEARCH) {
         if (range_search_limit_size > 0 and
@@ -772,7 +792,13 @@ SINDI::immutable_fill_heap_initial(uint32_t id,
                                    MaxHeap& heap,
                                    uint32_t offset_id,
                                    uint32_t n_candidate,
-                                   const FilterPtr& filter) const {
+                                   const FilterPtr& filter,
+                                   const std::optional<float>& threshold,
+                                   bool enable_reorder) const {
+    if (threshold.has_value() and
+        (not std::isfinite(dist) or (not enable_reorder and 1.0F + dist > threshold.value()))) {
+        return false;
+    }
     if (dist < 0) {
         if constexpr (type == InnerSearchType::WITH_FILTER) {
             if (not filter->CheckValid(id + offset_id)) {
@@ -821,8 +847,15 @@ SINDI::immutable_insert_heap_by_mapped_terms(float* dists,
             if (heap.size() < n_candidate) {
                 for (; i < term_count; ++i) {
                     id = ids[i];
-                    if (immutable_fill_heap_initial<type>(
-                            id, dists[id], cur_heap_top, heap, offset_id, n_candidate, filter)) {
+                    if (immutable_fill_heap_initial<type>(id,
+                                                          dists[id],
+                                                          cur_heap_top,
+                                                          heap,
+                                                          offset_id,
+                                                          n_candidate,
+                                                          filter,
+                                                          param.distance_threshold,
+                                                          param.enable_reorder)) {
                         ++i;
                         break;
                     }
@@ -837,9 +870,12 @@ SINDI::immutable_insert_heap_by_mapped_terms(float* dists,
                                                              cur_heap_top,
                                                              heap,
                                                              offset_id,
+                                                             n_candidate,
                                                              radius,
                                                              range_search_limit_size,
-                                                             filter);
+                                                             filter,
+                                                             param.distance_threshold,
+                                                             param.enable_reorder);
         }
     }
 }
@@ -865,8 +901,15 @@ SINDI::immutable_insert_heap_by_dists(float* dists,
     if constexpr (mode == InnerSearchMode::KNN_SEARCH) {
         if (heap.size() < n_candidate) {
             for (; id < dists_size; ++id) {
-                if (immutable_fill_heap_initial<type>(
-                        id, dists[id], cur_heap_top, heap, offset_id, n_candidate, filter)) {
+                if (immutable_fill_heap_initial<type>(id,
+                                                      dists[id],
+                                                      cur_heap_top,
+                                                      heap,
+                                                      offset_id,
+                                                      n_candidate,
+                                                      filter,
+                                                      param.distance_threshold,
+                                                      param.enable_reorder)) {
                     ++id;
                     break;
                 }
@@ -875,8 +918,17 @@ SINDI::immutable_insert_heap_by_dists(float* dists,
     }
 
     for (; id < dists_size; ++id) {
-        immutable_insert_candidate_into_heap<mode, type>(
-            id, dists[id], cur_heap_top, heap, offset_id, radius, range_search_limit_size, filter);
+        immutable_insert_candidate_into_heap<mode, type>(id,
+                                                         dists[id],
+                                                         cur_heap_top,
+                                                         heap,
+                                                         offset_id,
+                                                         n_candidate,
+                                                         radius,
+                                                         range_search_limit_size,
+                                                         filter,
+                                                         param.distance_threshold,
+                                                         param.enable_reorder);
     }
 }
 
@@ -910,7 +962,7 @@ SINDI::immutable_search_impl(const SparseTermComputerPtr& computer,
         scan_immutable_window_by_mapped_terms(dists.data(), window, computer, mapped_terms);
 
         if (reasoning_ctx != nullptr) {
-            selected_buckets->push_back(cur);
+            selected_buckets->push_back(static_cast<BucketIdType>(cur));
             auto doc_count = static_cast<uint32_t>(std::min<int64_t>(
                 window_size_, cur_element_count_ - static_cast<int64_t>(window_start_id)));
             for (uint32_t i = 0; i < doc_count; ++i) {
@@ -975,18 +1027,23 @@ SINDI::immutable_search_impl(const SparseTermComputerPtr& computer,
                     inner_id, 1.0F + heap.top().first, high_precise_distance);
             }
             if constexpr (mode == KNN_SEARCH) {
-                if (high_precise_distance < cur_heap_top or high_precise_heap->Size() < k) {
+                const bool eligible =
+                    not inner_param.distance_threshold.has_value() or
+                    (std::isfinite(high_precise_distance) and
+                     high_precise_distance <= inner_param.distance_threshold.value());
+                if (eligible and
+                    (high_precise_distance < cur_heap_top or high_precise_heap->Size() < k)) {
                     high_precise_heap->Push(high_precise_distance, label);
-                }
-                if (high_precise_heap->Size() > k) {
-                    if (reasoning_ctx != nullptr) {
-                        auto evicted_label = high_precise_heap->Top().second;
-                        auto evicted_inner_id = this->label_table_->GetIdByLabel(evicted_label);
-                        reasoning_ctx->RecordReorderEviction(evicted_inner_id, 0);
+                    if (high_precise_heap->Size() > k) {
+                        if (reasoning_ctx != nullptr) {
+                            auto evicted_label = high_precise_heap->Top().second;
+                            auto evicted_inner_id = this->label_table_->GetIdByLabel(evicted_label);
+                            reasoning_ctx->RecordReorderEviction(evicted_inner_id, 0);
+                        }
+                        high_precise_heap->Pop();
                     }
-                    high_precise_heap->Pop();
+                    cur_heap_top = high_precise_heap->Top().first;
                 }
-                cur_heap_top = high_precise_heap->Top().first;
             }
             if constexpr (mode == RANGE_SEARCH) {
                 if (high_precise_distance <= inner_param.radius) {
@@ -1059,7 +1116,7 @@ SINDI::search_impl(const SparseTermComputerPtr& computer,
         term_list->Query(dists.data(), computer);
 
         if (reasoning_ctx != nullptr) {
-            selected_buckets->push_back(cur);
+            selected_buckets->push_back(static_cast<BucketIdType>(cur));
             auto doc_count = static_cast<uint32_t>(std::min<int64_t>(
                 window_size_, cur_element_count_ - static_cast<int64_t>(window_start_id)));
             for (uint32_t i = 0; i < doc_count; ++i) {
@@ -1115,18 +1172,23 @@ SINDI::search_impl(const SparseTermComputerPtr& computer,
                     inner_id, 1.0F + heap.top().first, high_precise_distance);
             }
             if constexpr (mode == KNN_SEARCH) {
-                if (high_precise_distance < cur_heap_top or high_precise_heap->Size() < k) {
+                const bool eligible =
+                    not inner_param.distance_threshold.has_value() or
+                    (std::isfinite(high_precise_distance) and
+                     high_precise_distance <= inner_param.distance_threshold.value());
+                if (eligible and
+                    (high_precise_distance < cur_heap_top or high_precise_heap->Size() < k)) {
                     high_precise_heap->Push(high_precise_distance, label);
-                }
-                if (high_precise_heap->Size() > k) {
-                    if (reasoning_ctx != nullptr) {
-                        auto evicted_label = high_precise_heap->Top().second;
-                        auto evicted_inner_id = this->label_table_->GetIdByLabel(evicted_label);
-                        reasoning_ctx->RecordReorderEviction(evicted_inner_id, 0);
+                    if (high_precise_heap->Size() > k) {
+                        if (reasoning_ctx != nullptr) {
+                            auto evicted_label = high_precise_heap->Top().second;
+                            auto evicted_inner_id = this->label_table_->GetIdByLabel(evicted_label);
+                            reasoning_ctx->RecordReorderEviction(evicted_inner_id, 0);
+                        }
+                        high_precise_heap->Pop();
                     }
-                    high_precise_heap->Pop();
+                    cur_heap_top = high_precise_heap->Top().first;
                 }
-                cur_heap_top = high_precise_heap->Top().first;
             }
             if constexpr (mode == RANGE_SEARCH) {
                 if (high_precise_distance <= inner_param.radius) {
@@ -1355,12 +1417,19 @@ SINDI::AttachReasoningReport(const DatasetPtr& dataset_results,
 }
 
 bool
-SINDI::UseTermListsHeapInsert(const SINDISearchParameter& search_param) const {
+SINDI::UseTermListsHeapInsert(const SINDISearchParameter& search_param,
+                              const std::optional<float>& distance_threshold) const {
     // Low build-time doc pruning and low search-time query pruning keep the old
     // distance-array heap insertion path for accuracy. Once either side exceeds the
     // threshold, term-list heap insertion avoids scanning the whole window for heap updates.
-    return doc_prune_ratio_ > SINDI::K_TERM_LISTS_HEAP_INSERT_PRUNE_THRESHOLD ||
-           search_param.query_prune_ratio > SINDI::K_TERM_LISTS_HEAP_INSERT_PRUNE_THRESHOLD;
+    const bool term_lists_enabled =
+        doc_prune_ratio_ > SINDI::K_TERM_LISTS_HEAP_INSERT_PRUNE_THRESHOLD ||
+        search_param.query_prune_ratio > SINDI::K_TERM_LISTS_HEAP_INSERT_PRUNE_THRESHOLD;
+    if (not term_lists_enabled or not distance_threshold.has_value()) {
+        return term_lists_enabled;
+    }
+    // Posting lists omit zero-overlap documents, whose non-reorder distance is exactly 1.
+    return not use_reorder_ and distance_threshold.value() < 1.0F;
 }
 
 void

--- a/src/algorithm/sindi/sindi.h
+++ b/src/algorithm/sindi/sindi.h
@@ -232,7 +232,8 @@ private:
                           ReasoningContext* reasoning_ctx = nullptr) const;
 
     bool
-    UseTermListsHeapInsert(const SINDISearchParameter& search_param) const;
+    UseTermListsHeapInsert(const SINDISearchParameter& search_param,
+                           const std::optional<float>& distance_threshold = std::nullopt) const;
 
 #ifdef VSAG_SINDI_TEST_ACCESS
     friend class SINDITestAccess;
@@ -302,9 +303,12 @@ private:
                                          float& cur_heap_top,
                                          MaxHeap& heap,
                                          uint32_t offset_id,
+                                         uint32_t n_candidate,
                                          float radius,
                                          int range_search_limit_size,
-                                         const FilterPtr& filter) const;
+                                         const FilterPtr& filter,
+                                         const std::optional<float>& threshold,
+                                         bool enable_reorder) const;
 
     template <InnerSearchType type>
     bool
@@ -314,7 +318,9 @@ private:
                                 MaxHeap& heap,
                                 uint32_t offset_id,
                                 uint32_t n_candidate,
-                                const FilterPtr& filter) const;
+                                const FilterPtr& filter,
+                                const std::optional<float>& threshold,
+                                bool enable_reorder) const;
 
     template <InnerSearchMode mode, InnerSearchType type>
     void

--- a/src/algorithm/sindi/sindi_test.cpp
+++ b/src/algorithm/sindi/sindi_test.cpp
@@ -35,8 +35,10 @@ namespace vsag {
 class SINDITestAccess {
 public:
     static bool
-    UseTermListsHeapInsert(const SINDI& index, const SINDISearchParameter& search_param) {
-        return index.UseTermListsHeapInsert(search_param);
+    UseTermListsHeapInsert(const SINDI& index,
+                           const SINDISearchParameter& search_param,
+                           const std::optional<float>& distance_threshold = std::nullopt) {
+        return index.UseTermListsHeapInsert(search_param, distance_threshold);
     }
 
     static float
@@ -109,13 +111,15 @@ TEST_CASE("SINDI Heap Insert Strategy Test", "[ut][SINDI]") {
     auto allocator = SafeAllocator::FactoryDefaultAllocator();
     IndexCommonParam common_param;
     common_param.allocator_ = allocator;
+    common_param.metric_ = MetricType::METRIC_TYPE_IP;
 
-    auto make_index = [&](float doc_prune_ratio) {
+    auto make_index = [&](float doc_prune_ratio, bool use_reorder = false) {
         auto param = std::make_shared<vsag::SINDIParameter>();
         param->term_id_limit = 30001;
         param->window_size = 10000;
         param->doc_prune_ratio = doc_prune_ratio;
         param->avg_doc_term_length = 100;
+        param->use_reorder = use_reorder;
         return SINDI(param, common_param);
     };
 
@@ -145,6 +149,16 @@ TEST_CASE("SINDI Heap Insert Strategy Test", "[ut][SINDI]") {
         REQUIRE(SINDITestAccess::UseTermListsHeapInsert(index, search_param) ==
                 (doc_prune_ratio > SINDITestAccess::TermListsHeapInsertPruneThreshold() ||
                  query_prune_ratio > SINDITestAccess::TermListsHeapInsertPruneThreshold()));
+    }
+
+    SECTION("retains term-list insertion only for safe KNN thresholds") {
+        auto search_param = make_search_param(0.2F);
+        auto non_reorder = make_index(0.0F);
+        REQUIRE(SINDITestAccess::UseTermListsHeapInsert(non_reorder, search_param, 0.5F));
+        REQUIRE_FALSE(SINDITestAccess::UseTermListsHeapInsert(non_reorder, search_param, 1.0F));
+
+        auto reorder = make_index(0.0F, true);
+        REQUIRE_FALSE(SINDITestAccess::UseTermListsHeapInsert(reorder, search_param, 0.5F));
     }
 }
 

--- a/src/datacell/sparse_term_datacell.cpp
+++ b/src/datacell/sparse_term_datacell.cpp
@@ -65,8 +65,18 @@ SparseTermDataCell::insert_candidate_into_heap(uint32_t id,
                                                float& cur_heap_top,
                                                MaxHeap& heap,
                                                uint32_t offset_id,
+                                               uint32_t n_candidate,
                                                float radius,
-                                               const FilterPtr& filter) const {
+                                               const FilterPtr& filter,
+                                               const std::optional<float>& threshold,
+                                               bool enable_reorder) const {
+    if constexpr (mode == InnerSearchMode::KNN_SEARCH) {
+        if (threshold.has_value() and
+            (not std::isfinite(dist) or (not enable_reorder and 1.0F + dist > threshold.value()))) {
+            dist = 0.0F;
+            return;
+        }
+    }
     if constexpr (type == InnerSearchType::WITH_FILTER) {
 #if __cplusplus >= 202002L
         if (dist > cur_heap_top or not filter->CheckValid(id + offset_id)) [[likely]] {
@@ -88,8 +98,11 @@ SparseTermDataCell::insert_candidate_into_heap(uint32_t id,
     }
     heap.emplace(dist, id + offset_id);
     if constexpr (mode == InnerSearchMode::KNN_SEARCH) {
-        heap.pop();
-        cur_heap_top = heap.top().first;
+        if (heap.size() > n_candidate) {
+            heap.pop();
+        }
+        cur_heap_top =
+            heap.size() == n_candidate ? heap.top().first : std::numeric_limits<float>::max();
     }
     if constexpr (mode == InnerSearchMode::RANGE_SEARCH) {
         cur_heap_top = radius - 1;
@@ -105,7 +118,14 @@ SparseTermDataCell::fill_heap_initial(uint32_t id,
                                       MaxHeap& heap,
                                       uint32_t offset_id,
                                       uint32_t n_candidate,
-                                      const FilterPtr& filter) const {
+                                      const FilterPtr& filter,
+                                      const std::optional<float>& threshold,
+                                      bool enable_reorder) const {
+    if (threshold.has_value() and
+        (not std::isfinite(dist) or (not enable_reorder and 1.0F + dist > threshold.value()))) {
+        dist = 0.0F;
+        return false;
+    }
     if (dist < 0) {
         if constexpr (type == InnerSearchType::WITH_FILTER) {
             if (not filter->CheckValid(id + offset_id)) {
@@ -156,8 +176,15 @@ SparseTermDataCell::InsertHeapByTermLists(float* dists,
             if (heap.size() < n_candidate) {
                 for (; i < term_size; i++) {
                     id = one_term_ids[i];
-                    if (fill_heap_initial<type>(
-                            id, dists[id], cur_heap_top, heap, offset_id, n_candidate, filter)) {
+                    if (fill_heap_initial<type>(id,
+                                                dists[id],
+                                                cur_heap_top,
+                                                heap,
+                                                offset_id,
+                                                n_candidate,
+                                                filter,
+                                                param.distance_threshold,
+                                                param.enable_reorder)) {
                         i++;
                         break;
                     }
@@ -167,8 +194,16 @@ SparseTermDataCell::InsertHeapByTermLists(float* dists,
 
         for (; i < term_size; i++) {
             id = one_term_ids[i];
-            insert_candidate_into_heap<mode, type>(
-                id, dists[id], cur_heap_top, heap, offset_id, radius, filter);
+            insert_candidate_into_heap<mode, type>(id,
+                                                   dists[id],
+                                                   cur_heap_top,
+                                                   heap,
+                                                   offset_id,
+                                                   n_candidate,
+                                                   radius,
+                                                   filter,
+                                                   param.distance_threshold,
+                                                   param.enable_reorder);
         }
     }
     computer->ResetTerm();
@@ -194,8 +229,15 @@ SparseTermDataCell::InsertHeapByDists(float* dists,
     if constexpr (mode == InnerSearchMode::KNN_SEARCH) {
         if (heap.size() < n_candidate) {
             for (; id < total_count_; id++) {
-                if (fill_heap_initial<type>(
-                        id, dists[id], cur_heap_top, heap, offset_id, n_candidate, filter)) {
+                if (fill_heap_initial<type>(id,
+                                            dists[id],
+                                            cur_heap_top,
+                                            heap,
+                                            offset_id,
+                                            n_candidate,
+                                            filter,
+                                            param.distance_threshold,
+                                            param.enable_reorder)) {
                     id++;
                     break;
                 }
@@ -204,8 +246,16 @@ SparseTermDataCell::InsertHeapByDists(float* dists,
     }
 
     for (; id < total_count_; id++) {
-        insert_candidate_into_heap<mode, type>(
-            id, dists[id], cur_heap_top, heap, offset_id, radius, filter);
+        insert_candidate_into_heap<mode, type>(id,
+                                               dists[id],
+                                               cur_heap_top,
+                                               heap,
+                                               offset_id,
+                                               n_candidate,
+                                               radius,
+                                               filter,
+                                               param.distance_threshold,
+                                               param.enable_reorder);
     }
 }
 

--- a/src/datacell/sparse_term_datacell.h
+++ b/src/datacell/sparse_term_datacell.h
@@ -126,8 +126,11 @@ private:
                                float& cur_heap_top,
                                MaxHeap& heap,
                                uint32_t offset_id,
+                               uint32_t n_candidate,
                                float radius,
-                               const FilterPtr& filter) const;
+                               const FilterPtr& filter,
+                               const std::optional<float>& threshold,
+                               bool enable_reorder) const;
 
     template <InnerSearchType type>
     bool
@@ -137,7 +140,9 @@ private:
                       MaxHeap& heap,
                       uint32_t offset_id,
                       uint32_t n_candidate,
-                      const FilterPtr& filter) const;
+                      const FilterPtr& filter,
+                      const std::optional<float>& threshold,
+                      bool enable_reorder) const;
 
 public:
     uint32_t term_id_limit_{0};

--- a/src/impl/inner_search_param.h
+++ b/src/impl/inner_search_param.h
@@ -17,6 +17,7 @@
 
 #include <limits>
 #include <mutex>
+#include <optional>
 
 #include "typing.h"
 #include "utils/filter_search_skip_strategy.h"
@@ -60,6 +61,7 @@ public:
     float factor{2.0F};
     bool enable_reorder{true};
     float first_order_scan_ratio{1.0F};
+    std::optional<float> distance_threshold{std::nullopt};
     std::vector<ExecutorPtr> executors;
 
     // deal with duplicate ids

--- a/src/impl/reorder/flatten_reorder.cpp
+++ b/src/impl/reorder/flatten_reorder.cpp
@@ -55,9 +55,23 @@ FlattenReorder::Reorder(const vsag::DistHeapPtr& input,
                         int64_t topk,
                         QueryContext& ctx,
                         IteratorFilterContext* iter_ctx,
-                        const DistanceRecordVector* rabitq_lower_bound_candidates) {
+                        const DistanceRecordVector* rabitq_lower_bound_candidates,
+                        const std::optional<float>& distance_threshold) {
     // set query allocator
     Allocator* query_allocator = select_query_allocator(ctx.alloc, allocator_);
+    auto is_distance_eligible = [&distance_threshold](float distance) {
+        return not distance_threshold.has_value() or
+               (std::isfinite(distance) and distance <= distance_threshold.value());
+    };
+    auto consume_if_ineligible = [&](float distance, InnerIdType id) {
+        if (is_distance_eligible(distance)) {
+            return false;
+        }
+        if (iter_ctx != nullptr) {
+            iter_ctx->SetPoint(id);
+        }
+        return true;
+    };
     const uint64_t heap_candidate_size = input == nullptr ? 0 : input->Size();
     if (rabitq_lower_bound_candidates == nullptr) {
         topk = std::min(topk, static_cast<int64_t>(heap_candidate_size));
@@ -75,6 +89,9 @@ FlattenReorder::Reorder(const vsag::DistHeapPtr& input,
             if (ctx.reasoning_ctx != nullptr) {
                 ctx.reasoning_ctx->RecordReorder(
                     candidate_result[i].second, candidate_result[i].first, dists[i]);
+            }
+            if (consume_if_ineligible(dists[i], candidate_result[i].second)) {
+                continue;
             }
             if (reorder_heap->Size() < topk || dists[i] < reorder_heap->Top().first) {
                 reorder_heap->Push(dists[i], candidate_result[i].second);
@@ -166,6 +183,9 @@ FlattenReorder::Reorder(const vsag::DistHeapPtr& input,
                 ctx.reasoning_ctx->RecordReorder(
                     all_ids[i], lower_bounds[i], lower_bound_probe_dists[i]);
             }
+            if (consume_if_ineligible(lower_bound_probe_dists[i], all_ids[i])) {
+                continue;
+            }
             if (reorder_heap->Size() < topk or
                 lower_bound_probe_dists[i] < reorder_heap->Top().first) {
                 reorder_heap->Push(lower_bound_probe_dists[i], all_ids[i]);
@@ -212,7 +232,9 @@ FlattenReorder::Reorder(const vsag::DistHeapPtr& input,
             const auto idx = order[i];
             ctx.reasoning_ctx->RecordReorder(ids[i], lower_bound_probe_dists[idx], dists[i]);
         }
-        reorder_heap->Push(dists[i], ids[i]);
+        if (not consume_if_ineligible(dists[i], ids[i])) {
+            reorder_heap->Push(dists[i], ids[i]);
+        }
     }
 
     uint64_t cursor = bootstrap_size;
@@ -222,11 +244,13 @@ FlattenReorder::Reorder(const vsag::DistHeapPtr& input,
             break;
         }
 
-        const auto threshold = reorder_heap->Top().first;
+        const auto pruning_threshold = reorder_heap->Size() == topk
+                                           ? reorder_heap->Top().first
+                                           : std::numeric_limits<float>::max();
         uint64_t batch_count = 0;
         while (cursor < candidate_size && batch_count < batch_size) {
             const auto idx = order[cursor];
-            if (lower_bounds[idx] >= threshold) {
+            if (lower_bounds[idx] >= pruning_threshold) {
                 break;
             }
             ids[batch_count] = all_ids[idx];
@@ -249,7 +273,10 @@ FlattenReorder::Reorder(const vsag::DistHeapPtr& input,
                 ctx.reasoning_ctx->RecordReorder(
                     ids[i], lower_bound_probe_dists[batch_indices[i]], dists[i]);
             }
-            if (dists[i] < reorder_heap->Top().first) {
+            if (consume_if_ineligible(dists[i], ids[i])) {
+                continue;
+            }
+            if (reorder_heap->Size() < topk or dists[i] < reorder_heap->Top().first) {
                 reorder_heap->Push(dists[i], ids[i]);
                 if (reorder_heap->Size() > topk) {
                     if (iter_ctx != nullptr) {

--- a/src/impl/reorder/flatten_reorder.h
+++ b/src/impl/reorder/flatten_reorder.h
@@ -35,7 +35,8 @@ public:
             int64_t topk,
             QueryContext& ctx,
             IteratorFilterContext* iter_ctx = nullptr,
-            const DistanceRecordVector* rabitq_lower_bound_candidates = nullptr) override;
+            const DistanceRecordVector* rabitq_lower_bound_candidates = nullptr,
+            const std::optional<float>& distance_threshold = std::nullopt) override;
 
 private:
     const FlattenInterfacePtr flatten_;

--- a/src/impl/reorder/flatten_reorder_test.cpp
+++ b/src/impl/reorder/flatten_reorder_test.cpp
@@ -1,0 +1,69 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "flatten_reorder.h"
+
+#include <limits>
+#include <memory>
+#include <optional>
+
+#include "datacell/flatten_datacell_parameter.h"
+#include "impl/filter/iterator_filter.h"
+#include "impl/heap/standard_heap.h"
+#include "index_common_param.h"
+#include "io/memory_io/memory_io_parameter.h"
+#include "quantization/fp32_quantizer_parameter.h"
+#include "query_context.h"
+#include "unittest.h"
+#include "vsag/engine.h"
+
+namespace vsag {
+
+TEST_CASE("FlattenReorder filters non-finite exact distances before top-k",
+          "[ut][reorder][threshold][nonfinite]") {
+    auto allocator = Engine::CreateDefaultAllocator();
+    auto flatten_param = std::make_shared<FlattenDataCellParameter>();
+    flatten_param->quantizer_parameter = std::make_shared<FP32QuantizerParameter>();
+    flatten_param->io_parameter = std::make_shared<MemoryIOParameter>();
+
+    IndexCommonParam common_param;
+    common_param.allocator_ = allocator;
+    common_param.metric_ = MetricType::METRIC_TYPE_L2SQR;
+    common_param.dim_ = 1;
+    auto flatten = FlattenInterface::MakeInstance(flatten_param, common_param);
+
+    float vectors[] = {std::numeric_limits<float>::quiet_NaN(), 1.0F, 0.0F};
+    flatten->Train(vectors, 3);
+    flatten->BatchInsertVector(vectors, 3);
+
+    auto candidates = std::make_shared<StandardHeap<true, false>>(allocator.get(), -1);
+    candidates->Push(100.0F, 0);
+    candidates->Push(1.0F, 1);
+    candidates->Push(2.0F, 2);
+
+    float query = 1.0F;
+    QueryContext ctx{.alloc = allocator.get()};
+    IteratorFilterContext iter_ctx;
+    REQUIRE(iter_ctx.init(3, 3, allocator.get()).has_value());
+    FlattenReorder reorder(flatten, allocator.get());
+    auto result =
+        reorder.Reorder(candidates, &query, 1, ctx, &iter_ctx, nullptr, std::optional<float>{0.0F});
+
+    REQUIRE(result->Size() == 1);
+    REQUIRE(result->Top().second == 1);
+    REQUIRE(result->Top().first == 0.0F);
+    REQUIRE_FALSE(iter_ctx.CheckPoint(0));
+}
+
+}  // namespace vsag

--- a/src/impl/searcher/basic_searcher.cpp
+++ b/src/impl/searcher/basic_searcher.cpp
@@ -25,6 +25,7 @@
 #include "impl/filter/iterator_filter.h"
 #include "impl/heap/standard_heap.h"
 #include "impl/reasoning/search_reasoning.h"
+#include "impl/searcher/searcher_utils.h"
 #include "utils/filter_search_skip_strategy.h"
 #include "vsag/allocator.h"
 
@@ -199,7 +200,9 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
         reasoning->RecordVisit(distance_provider.OriginalId(ep), dist, 0);
     }
     if (check_func(ep)) {
-        top_candidates->Push(dist, ep);
+        if (is_result_distance_eligible<mode>(dist, inner_search_param)) {
+            top_candidates->Push(dist, ep);
+        }
     } else if (reasoning != nullptr) {
         reasoning->RecordFilterReject(distance_provider.OriginalId(ep));
     }
@@ -208,7 +211,7 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
             top_candidates->Pop();
         }
     }
-    candidate_set->Push(-dist, ep);
+    candidate_set->Push(traversal_priority(dist), ep);
     vl->Set(ep);
     auto lower_bound =
         top_candidates->Empty() ? std::numeric_limits<float>::max() : top_candidates->Top().first;
@@ -243,6 +246,29 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
             }
             if (reasoning != nullptr) {
                 reasoning->RecordVisit(distance_provider.OriginalId(id), dist, hops);
+            }
+            if (not std::isfinite(dist)) {
+                candidate_set->Push(traversal_priority(dist), id);
+                if (check_func(id) and
+                    is_result_distance_eligible<mode>(dist, inner_search_param)) {
+                    top_candidates->Push(dist, id);
+                    if constexpr (mode == InnerSearchMode::KNN_SEARCH) {
+                        if (top_candidates->Size() > ef) {
+                            if (reasoning != nullptr) {
+                                reasoning->RecordEviction(
+                                    distance_provider.OriginalId(top_candidates->Top().second),
+                                    hops);
+                            }
+                            top_candidates->Pop();
+                        }
+                    } else if (dist > inner_search_param.radius) {
+                        top_candidates->Pop();
+                    }
+                }
+                if (not top_candidates->Empty()) {
+                    lower_bound = top_candidates->Top().first;
+                }
+                continue;
             }
             if (top_candidates->Size() < ef || lower_bound > dist ||
                 (mode == InnerSearchMode::RANGE_SEARCH &&
@@ -351,8 +377,10 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
                 flatten->Query(&cur_dist, computer, &cur_inner_id, 1, ctx);
                 // Sign convention: top_candidates stores positive distances (nearest = smallest);
                 // candidate_set is a max-heap, so distances are negated (nearest = largest, popped first).
-                top_candidates->Push(cur_dist, cur_inner_id);
-                candidate_set->Push(-cur_dist, cur_inner_id);
+                if (is_result_distance_eligible<mode>(cur_dist, inner_search_param)) {
+                    top_candidates->Push(cur_dist, cur_inner_id);
+                }
+                candidate_set->Push(traversal_priority(cur_dist), cur_inner_id);
                 if constexpr (mode == InnerSearchMode::RANGE_SEARCH) {
                     if (cur_dist > inner_search_param.radius and not top_candidates->Empty()) {
                         top_candidates->Pop();
@@ -380,10 +408,12 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
             flatten->Query(&dist, computer, &ep, 1, ctx);
         }
         if (not is_id_allowed || is_id_allowed->CheckValid(ep)) {
-            top_candidates->Push(dist, ep);
-            lower_bound = top_candidates->Top().first;
+            if (is_result_distance_eligible<mode>(dist, inner_search_param)) {
+                top_candidates->Push(dist, ep);
+                lower_bound = top_candidates->Top().first;
+            }
         }
-        candidate_set->Push(-dist, ep);
+        candidate_set->Push(traversal_priority(dist), ep);
         vl->Set(ep);
     }
 
@@ -443,6 +473,31 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
         for (uint32_t i = 0; i < count_no_visited; i++) {
             dist = line_dists[i];
             const auto cur_id = to_be_visited_id[i];
+            if (not std::isfinite(dist)) {
+                if (is_result_distance_eligible<mode>(dist, inner_search_param) and
+                    (not is_id_allowed || is_id_allowed->CheckValid(cur_id))) {
+                    top_candidates->Push(dist, cur_id);
+                    if constexpr (mode == KNN_SEARCH) {
+                        if (top_candidates->Size() > ef) {
+                            const auto evicted = top_candidates->Top();
+                            if (iter_ctx->CheckPoint(evicted.second)) {
+                                iter_ctx->AddDiscardNode(evicted.first, evicted.second);
+                            }
+                            top_candidates->Pop();
+                        }
+                    } else if (dist > inner_search_param.radius) {
+                        top_candidates->Pop();
+                    }
+                }
+                if (iter_ctx->CheckPoint(cur_id)) {
+                    candidate_set->Push(traversal_priority(dist), cur_id);
+                    flatten->Prefetch(cur_id);
+                }
+                if (not top_candidates->Empty()) {
+                    lower_bound = top_candidates->Top().first;
+                }
+                continue;
+            }
             const bool id_allowed = not is_id_allowed || is_id_allowed->CheckValid(cur_id);
             if constexpr (mode == KNN_SEARCH) {
                 if (collect_rabitq_lower_bound and lower_bound_dists[i] < lower_bound and
@@ -637,20 +692,35 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
         flatten->Query(&dist, computer, &ep, 1, ctx);
     }
     ++dist_cmp;
-    if (check_func(ep)) {
+    if (check_func(ep) and is_result_distance_eligible<mode>(dist, inner_search_param)) {
         top_candidates->Push(dist, ep);
-        lower_bound = top_candidates->Top().first;
+    }
+    if (not std::isfinite(dist) and inner_search_param.consider_duplicate and
+        not use_custom_distance and is_result_distance_eligible<mode>(dist, inner_search_param)) {
+        for (const auto duplicate_id : graph->GetDuplicateIds(ep)) {
+            if (check_func(duplicate_id)) {
+                top_candidates->Push(dist, duplicate_id);
+            }
+        }
+        if constexpr (mode == KNN_SEARCH) {
+            while (top_candidates->Size() > ef) {
+                top_candidates->Pop();
+            }
+        }
     }
     if constexpr (mode == InnerSearchMode::RANGE_SEARCH) {
-        if (dist > inner_search_param.radius and not top_candidates->Empty()) {
+        while (dist > inner_search_param.radius and not top_candidates->Empty()) {
             top_candidates->Pop();
         }
+    }
+    if (not top_candidates->Empty()) {
+        lower_bound = top_candidates->Top().first;
     }
     if (use_custom_distance and inner_search_param.consider_duplicate) {
         const auto duplicate_ids = graph->GetDuplicateIds(ep);
         score_duplicates(duplicate_ids, hops);
     }
-    candidate_set->Push(-dist, ep);
+    candidate_set->Push(traversal_priority(dist), ep);
     vl->Set(ep);
 
     while (not candidate_set->Empty()) {
@@ -733,6 +803,36 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
             if (use_custom_distance and inner_search_param.consider_duplicate) {
                 const auto duplicate_ids = graph->GetDuplicateIds(cur_id);
                 score_duplicates(duplicate_ids, hops);
+            }
+            if (not std::isfinite(dist)) {
+                candidate_set->Push(traversal_priority(dist), cur_id);
+                auto push_result = [&](InnerIdType result_id) {
+                    if (not is_result_distance_eligible<mode>(dist, inner_search_param) or
+                        not check_func(result_id)) {
+                        return;
+                    }
+                    top_candidates->Push(dist, result_id);
+                    if constexpr (mode == KNN_SEARCH) {
+                        while (top_candidates->Size() > ef) {
+                            if (reasoning != nullptr) {
+                                reasoning->RecordEviction(top_candidates->Top().second, hops);
+                            }
+                            top_candidates->Pop();
+                        }
+                    } else if (dist > inner_search_param.radius) {
+                        top_candidates->Pop();
+                    }
+                };
+                push_result(cur_id);
+                if (inner_search_param.consider_duplicate and not use_custom_distance) {
+                    for (const auto duplicate_id : graph->GetDuplicateIds(cur_id)) {
+                        push_result(duplicate_id);
+                    }
+                }
+                if (not top_candidates->Empty()) {
+                    lower_bound = top_candidates->Top().first;
+                }
+                continue;
             }
             if constexpr (mode == KNN_SEARCH) {
                 if (collect_rabitq_lower_bound and lower_bound_dists[i] < lower_bound and

--- a/src/impl/searcher/basic_searcher_test.cpp
+++ b/src/impl/searcher/basic_searcher_test.cpp
@@ -517,3 +517,53 @@ TEST_CASE("BasicSearcher iterator drain path handles sign and lower_bound correc
 
     delete iter_ctx;
 }
+
+TEST_CASE("BasicSearcher traverses through a non-finite-distance bridge",
+          "[ut][BasicSearcher][nonfinite]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    IndexCommonParam common;
+    common.dim_ = 1;
+    common.allocator_ = allocator;
+    common.metric_ = MetricType::METRIC_TYPE_L2SQR;
+
+    constexpr const char* param_temp = R"({{"type": "{}"}})";
+    auto quantizer_param = QuantizerParameter::GetQuantizerParameterByJson(
+        JsonType::Parse(fmt::format(param_temp, "fp32")));
+    auto io_param =
+        IOParameter::GetIOParameterByJson(JsonType::Parse(fmt::format(param_temp, "memory_io")));
+    auto flatten =
+        std::make_shared<FlattenDataCell<FP32Quantizer<MetricType::METRIC_TYPE_L2SQR>, MemoryIO>>(
+            quantizer_param, io_param, common);
+    flatten->SetQuantizer(
+        std::make_shared<FP32Quantizer<MetricType::METRIC_TYPE_L2SQR>>(1, allocator.get()));
+    flatten->SetIO(std::make_unique<MemoryIO>(allocator.get()));
+    const auto bridge_distance =
+        GENERATE(std::numeric_limits<float>::max(), std::numeric_limits<float>::quiet_NaN());
+    std::vector<float> vectors = {
+        10.0F, bridge_distance, bridge_distance, bridge_distance, bridge_distance, 1.0F};
+    std::vector<InnerIdType> ids = {0, 1, 2, 3, 4, 5};
+    flatten->Train(vectors.data(), ids.size());
+    flatten->BatchInsertVector(vectors.data(), ids.size(), ids.data());
+
+    auto graph = std::make_shared<MockGraphDataCell>(
+        std::vector<std::vector<InnerIdType>>{{1}, {2}, {3}, {4}, {5}, {}});
+    auto pool = std::make_shared<VisitedListPool>(1, allocator.get(), ids.size(), allocator.get());
+    InnerSearchParam param;
+    param.ep = 0;
+    param.ef = 2;
+    param.topk = 2;
+    float query = 0.0F;
+    auto vl = pool->TakeOne();
+    QueryContext* ctx = nullptr;
+    auto result =
+        BasicSearcher(common).Search(graph, flatten, vl, &query, param, LabelTablePtr{}, ctx);
+    pool->ReturnOne(vl);
+
+    REQUIRE(result->Size() <= param.ef);
+    bool found_target = false;
+    while (not result->Empty()) {
+        found_target = found_target or result->Top().second == 5;
+        result->Pop();
+    }
+    REQUIRE(found_target);
+}

--- a/src/impl/searcher/mci_searcher.cpp
+++ b/src/impl/searcher/mci_searcher.cpp
@@ -24,6 +24,7 @@
 
 #include "impl/heap/search_candidate_queue.h"
 #include "impl/heap/standard_heap.h"
+#include "impl/searcher/searcher_utils.h"
 #include "index_common_param.h"
 #include "simd/fp32_simd.h"
 #include "vsag/filter.h"
@@ -123,7 +124,7 @@ search_precise_float_csr(const CliqueDataCellBaseView& view,
                          Allocator* allocator) {
     const auto candidate_limit =
         std::max<int64_t>(inner_search_param.topk, static_cast<int64_t>(inner_search_param.ef));
-    auto heap = DistanceHeap::MakeInstanceBySize<true, true>(allocator, candidate_limit);
+    auto result_heap = DistanceHeap::MakeInstanceBySize<true, true>(allocator, candidate_limit);
     thread_local MCIEpochMarks visited_nodes;
     thread_local MCIEpochMarks visited_cliques;
     SearchCandidateQueue candidates(allocator);
@@ -158,6 +159,9 @@ search_precise_float_csr(const CliqueDataCellBaseView& view,
             query, vector, dim, metric, cosine_query_inv_norm, cosine_hold_mold);
         ++dist_cmp;
         insert_candidate(dist, inner_id);
+        if (is_result_distance_eligible<KNN_SEARCH>(dist, inner_search_param)) {
+            result_heap->Push(dist, inner_id);
+        }
         return true;
     };
 
@@ -221,15 +225,11 @@ search_precise_float_csr(const CliqueDataCellBaseView& view,
         }
     }
 
-    for (uint64_t i = 0; i < candidates.Size(); ++i) {
-        const auto& candidate = candidates.Data()[i];
-        heap->Push(candidate.distance, candidate.inner_id);
-    }
     if (ctx != nullptr and ctx->stats != nullptr) {
         ctx->stats->dist_cmp.fetch_add(dist_cmp, std::memory_order_relaxed);
         ctx->stats->hops.fetch_add(hops, std::memory_order_relaxed);
     }
-    return heap;
+    return result_heap;
 }
 
 }  // namespace
@@ -328,6 +328,9 @@ MCISearcher::Search(const CliqueDataCellPtr& cliques,
         flatten->Query(&dist, computer, &inner_id, 1, ctx);
         ++dist_cmp;
         insert_candidate(dist, inner_id);
+        if (is_result_distance_eligible<KNN_SEARCH>(dist, inner_search_param)) {
+            heap->Push(dist, inner_id);
+        }
         return true;
     };
 
@@ -392,9 +395,6 @@ MCISearcher::Search(const CliqueDataCellPtr& cliques,
         }
     }
 
-    for (const auto& candidate : candidates) {
-        heap->Push(candidate.distance, candidate.inner_id);
-    }
     if (ctx != nullptr and ctx->stats != nullptr) {
         ctx->stats->dist_cmp.fetch_add(dist_cmp, std::memory_order_relaxed);
         ctx->stats->hops.fetch_add(hops, std::memory_order_relaxed);

--- a/src/impl/searcher/mci_searcher_test.cpp
+++ b/src/impl/searcher/mci_searcher_test.cpp
@@ -1,0 +1,87 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "mci_searcher.h"
+
+#include "searcher_test.h"
+
+using namespace vsag;
+
+TEST_CASE("MCISearcher threshold results backfill past non-finite traversal seeds",
+          "[ut][MCISearcher][threshold][nonfinite]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    IndexCommonParam common;
+    common.dim_ = 1;
+    common.allocator_ = allocator;
+    common.metric_ = MetricType::METRIC_TYPE_IP;
+
+    constexpr const char* param_template = R"({{"type": "{}"}})";
+    auto quantizer_param = QuantizerParameter::GetQuantizerParameterByJson(
+        JsonType::Parse(fmt::format(param_template, "fp32")));
+    auto io_param = IOParameter::GetIOParameterByJson(
+        JsonType::Parse(fmt::format(param_template, "memory_io")));
+    auto flatten =
+        std::make_shared<FlattenDataCell<FP32Quantizer<MetricType::METRIC_TYPE_IP>, MemoryIO>>(
+            quantizer_param, io_param, common);
+    flatten->SetQuantizer(
+        std::make_shared<FP32Quantizer<MetricType::METRIC_TYPE_IP>>(1, allocator.get()));
+    flatten->SetIO(std::make_unique<MemoryIO>(allocator.get()));
+
+    std::vector<float> vectors = {std::numeric_limits<float>::max(), 0.0F};
+    std::vector<InnerIdType> ids = {0, 1};
+    flatten->Train(vectors.data(), ids.size());
+    flatten->BatchInsertVector(vectors.data(), ids.size(), ids.data());
+
+    auto cliques = std::make_shared<CliqueDataCell>(allocator.get());
+    Vector<InnerIdType> p_maxc(allocator.get());
+    Vector<InnerIdType> maxcs(allocator.get());
+    Vector<InnerIdType> p_node_to_cid(allocator.get());
+    Vector<InnerIdType> node_to_cids(allocator.get());
+    p_maxc.insert(p_maxc.end(), {0, 2});
+    maxcs.insert(maxcs.end(), {0, 1});
+    p_node_to_cid.insert(p_node_to_cid.end(), {0, 1, 2});
+    node_to_cids.insert(node_to_cids.end(), {0, 0});
+    cliques->Assign(std::move(p_maxc),
+                    std::move(maxcs),
+                    std::move(p_node_to_cid),
+                    std::move(node_to_cids),
+                    ids.size());
+
+    InnerSearchParam search_param;
+    search_param.ef = 1;
+    search_param.topk = 1;
+    search_param.distance_threshold = 1.0F;
+    Vector<InnerIdType> seeds(allocator.get());
+    seeds.push_back(0);
+
+    const bool use_precise_csr = GENERATE(false, true);
+    bool used_precise_csr = false;
+    MCISearcherParam mci_param;
+    mci_param.seed_count = 1;
+    mci_param.seed_inner_ids = &seeds;
+    mci_param.precise_vectors = use_precise_csr ? vectors.data() : nullptr;
+    mci_param.dim = 1;
+    mci_param.precise_vector_stride = 1;
+    mci_param.metric = MetricType::METRIC_TYPE_IP;
+    mci_param.used_precise_float_csr = &used_precise_csr;
+
+    const float query = std::numeric_limits<float>::max();
+    auto result =
+        MCISearcher(common).Search(cliques, flatten, &query, search_param, mci_param, nullptr);
+
+    REQUIRE(used_precise_csr == use_precise_csr);
+    REQUIRE(result->Size() == 1);
+    REQUIRE(result->Top().second == 1);
+    REQUIRE(result->Top().first == 1.0F);
+}

--- a/src/impl/searcher/parallel_searcher.cpp
+++ b/src/impl/searcher/parallel_searcher.cpp
@@ -16,6 +16,7 @@
 #include "parallel_searcher.h"
 
 #include <atomic>
+#include <cmath>
 #include <future>
 #include <limits>
 #include <tuple>
@@ -24,6 +25,7 @@
 
 #include "datacell/flatten_interface.h"
 #include "impl/heap/standard_heap.h"
+#include "impl/searcher/searcher_utils.h"
 #include "utils/filter_search_skip_strategy.h"
 #include "utils/spsc_queue.h"
 
@@ -173,19 +175,34 @@ ParallelSearcher::search_impl(const GraphInterfacePtr& graph,
     } else {
         flatten->Query(&dist, computer, &ep, 1, ctx);
     }
-    if (check_func(ep)) {
+    if (check_func(ep) and is_result_distance_eligible<mode>(dist, inner_search_param)) {
         top_candidates->Push(dist, ep);
-        lower_bound = top_candidates->Top().first;
+    }
+    if (not std::isfinite(dist) and inner_search_param.consider_duplicate and
+        is_result_distance_eligible<mode>(dist, inner_search_param)) {
+        for (const auto duplicate_id : graph->GetDuplicateIds(ep)) {
+            if (check_func(duplicate_id)) {
+                top_candidates->Push(dist, duplicate_id);
+            }
+        }
+        if constexpr (mode == KNN_SEARCH) {
+            while (top_candidates->Size() > ef) {
+                top_candidates->Pop();
+            }
+        }
     }
     if constexpr (mode == InnerSearchMode::RANGE_SEARCH) {
-        if (dist > inner_search_param.radius and not top_candidates->Empty()) {
+        while (dist > inner_search_param.radius and not top_candidates->Empty()) {
             top_candidates->Pop();
         }
+    }
+    if (not top_candidates->Empty()) {
+        lower_bound = top_candidates->Top().first;
     }
     if (dist < THRESHOLD_ERROR) {
         inner_search_param.duplicate_id = ep;
     }
-    candidate_set->Push(-dist, ep);
+    candidate_set->Push(traversal_priority(dist), ep);
     vl->Set(ep);
 
     auto num_threads = inner_search_param.parallel_search_thread_count - 1;
@@ -308,6 +325,33 @@ ParallelSearcher::search_impl(const GraphInterfacePtr& graph,
         for (uint64_t i = 0; i < count_no_visited; i++) {
             dist = line_dists[i];
             const auto cur_id = to_be_visited_id[i];
+            if (not std::isfinite(dist)) {
+                auto push_result = [&](InnerIdType result_id) {
+                    if (not is_result_distance_eligible<mode>(dist, inner_search_param) or
+                        not check_func(result_id)) {
+                        return;
+                    }
+                    top_candidates->Push(dist, result_id);
+                    if constexpr (mode == KNN_SEARCH) {
+                        while (top_candidates->Size() > ef) {
+                            top_candidates->Pop();
+                        }
+                    } else if (dist > inner_search_param.radius) {
+                        top_candidates->Pop();
+                    }
+                };
+                push_result(cur_id);
+                if (inner_search_param.consider_duplicate) {
+                    for (const auto duplicate_id : graph->GetDuplicateIds(cur_id)) {
+                        push_result(duplicate_id);
+                    }
+                }
+                candidate_set->Push(traversal_priority(dist), cur_id);
+                if (not top_candidates->Empty()) {
+                    lower_bound = top_candidates->Top().first;
+                }
+                continue;
+            }
             if constexpr (mode == KNN_SEARCH) {
                 if (collect_rabitq_lower_bound and lower_bound_dists[i] < lower_bound and
                     check_func(cur_id)) {

--- a/src/impl/searcher/parallel_searcher_test.cpp
+++ b/src/impl/searcher/parallel_searcher_test.cpp
@@ -176,3 +176,53 @@ TEST_CASE("Parallel search with HNSW", "[ut][ParallelSearcher]") {
         }
     }
 }
+
+TEST_CASE("ParallelSearcher traverses through a non-finite-distance bridge",
+          "[ut][ParallelSearcher][nonfinite]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    IndexCommonParam common;
+    common.dim_ = 1;
+    common.allocator_ = allocator;
+    common.metric_ = MetricType::METRIC_TYPE_L2SQR;
+
+    constexpr const char* param_temp = R"({{"type": "{}"}})";
+    auto quantizer_param = QuantizerParameter::GetQuantizerParameterByJson(
+        JsonType::Parse(fmt::format(param_temp, "fp32")));
+    auto io_param =
+        IOParameter::GetIOParameterByJson(JsonType::Parse(fmt::format(param_temp, "memory_io")));
+    auto flatten =
+        std::make_shared<FlattenDataCell<FP32Quantizer<MetricType::METRIC_TYPE_L2SQR>, MemoryIO>>(
+            quantizer_param, io_param, common);
+    flatten->SetQuantizer(
+        std::make_shared<FP32Quantizer<MetricType::METRIC_TYPE_L2SQR>>(1, allocator.get()));
+    flatten->SetIO(std::make_unique<MemoryIO>(allocator.get()));
+    const auto bridge_distance =
+        GENERATE(std::numeric_limits<float>::max(), std::numeric_limits<float>::quiet_NaN());
+    std::vector<float> vectors = {
+        10.0F, bridge_distance, bridge_distance, bridge_distance, bridge_distance, 1.0F};
+    std::vector<InnerIdType> ids = {0, 1, 2, 3, 4, 5};
+    flatten->Train(vectors.data(), ids.size());
+    flatten->BatchInsertVector(vectors.data(), ids.size(), ids.data());
+
+    auto graph = std::make_shared<MockGraphDataCell>(
+        std::vector<std::vector<InnerIdType>>{{1}, {2}, {3}, {4}, {5}, {}});
+    auto pool = std::make_shared<VisitedListPool>(1, allocator.get(), ids.size(), allocator.get());
+    InnerSearchParam param;
+    param.ep = 0;
+    param.ef = 2;
+    param.topk = 2;
+    param.parallel_search_thread_count = 2;
+    float query = 0.0F;
+    auto vl = pool->TakeOne();
+    auto result = ParallelSearcher(common, SafeThreadPool::FactoryDefaultThreadPool())
+                      .Search(graph, flatten, vl, &query, param);
+    pool->ReturnOne(vl);
+
+    REQUIRE(result->Size() <= param.ef);
+    bool found_target = false;
+    while (not result->Empty()) {
+        found_target = found_target or result->Top().second == 5;
+        result->Pop();
+    }
+    REQUIRE(found_target);
+}

--- a/src/impl/searcher/searcher_utils.h
+++ b/src/impl/searcher/searcher_utils.h
@@ -1,0 +1,43 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cmath>
+#include <limits>
+
+#include "impl/inner_search_param.h"
+
+namespace vsag {
+
+template <InnerSearchMode mode>
+inline bool
+is_result_distance_eligible(float distance, const InnerSearchParam& search_param) {
+    if constexpr (mode == InnerSearchMode::RANGE_SEARCH) {
+        return not std::isnan(distance);
+    }
+    // The finite threshold bound is applied after bounded selection. Only non-finite values must
+    // be rejected here because negative infinity could otherwise displace eligible finite results.
+    return not std::isnan(distance) and
+           (not search_param.distance_threshold.has_value() or std::isfinite(distance));
+}
+
+inline float
+traversal_priority(float distance) {
+    // Keep unordered/non-finite bridge nodes traversable without ranking them by their distance;
+    // the max-heap consumes this sentinel promptly while result eligibility remains independent.
+    return std::isfinite(distance) ? -distance : std::numeric_limits<float>::max();
+}
+
+}  // namespace vsag

--- a/src/index/index_impl.h
+++ b/src/index/index_impl.h
@@ -19,6 +19,7 @@
 #include "algorithm/inner_index_interface.h"
 #include "common.h"
 #include "index_common_param.h"
+#include "utils/search_threshold.h"
 #include "vsag/index.h"
 namespace vsag {
 
@@ -302,6 +303,10 @@ public:
               int64_t k,
               const std::string& parameters,
               BitsetPtr invalid = nullptr) const override {
+        auto threshold_validation = ValidateThresholdParameters(parameters);
+        if (not threshold_validation.has_value()) {
+            return tl::unexpected(threshold_validation.error());
+        }
         CHECK_QUERY_RETURN_EMPTY_DATASET(query);
         if (GetNumElements() == 0 && !this->ShouldSkipEmptyCheck(parameters)) {
             return DatasetImpl::MakeEmptyDataset();
@@ -314,6 +319,10 @@ public:
               int64_t k,
               const std::string& parameters,
               const std::function<bool(int64_t)>& filter) const override {
+        auto threshold_validation = ValidateThresholdParameters(parameters);
+        if (not threshold_validation.has_value()) {
+            return tl::unexpected(threshold_validation.error());
+        }
         CHECK_QUERY_RETURN_EMPTY_DATASET(query);
         if (GetNumElements() == 0 && !this->ShouldSkipEmptyCheck(parameters)) {
             return DatasetImpl::MakeEmptyDataset();
@@ -326,6 +335,10 @@ public:
               int64_t k,
               const std::string& parameters,
               const FilterPtr& filter) const override {
+        auto threshold_validation = ValidateThresholdParameters(parameters);
+        if (not threshold_validation.has_value()) {
+            return tl::unexpected(threshold_validation.error());
+        }
         CHECK_QUERY_RETURN_EMPTY_DATASET(query);
         if (GetNumElements() == 0 && !this->ShouldSkipEmptyCheck(parameters)) {
             return DatasetImpl::MakeEmptyDataset();
@@ -335,6 +348,10 @@ public:
 
     tl::expected<DatasetPtr, Error>
     KnnSearch(const DatasetPtr& query, int64_t k, SearchParam& search_param) const override {
+        auto threshold_validation = ValidateThresholdParameters(search_param.parameters);
+        if (not threshold_validation.has_value()) {
+            return tl::unexpected(threshold_validation.error());
+        }
         CHECK_QUERY_RETURN_EMPTY_DATASET(query);
         if (GetNumElements() == 0 && !this->ShouldSkipEmptyCheck(search_param.parameters)) {
             return DatasetImpl::MakeEmptyDataset();
@@ -360,6 +377,10 @@ public:
               const FilterPtr& filter,
               IteratorContext*& iter_ctx,
               bool is_last_filter) const override {
+        auto threshold_validation = ValidateThresholdParameters(parameters);
+        if (not threshold_validation.has_value()) {
+            return tl::unexpected(threshold_validation.error());
+        }
         CHECK_QUERY_RETURN_EMPTY_DATASET(query);
         if (GetNumElements() == 0 && !this->ShouldSkipEmptyCheck(parameters)) {
             return DatasetImpl::MakeEmptyDataset();
@@ -476,10 +497,10 @@ public:
 
     [[nodiscard]] tl::expected<DatasetPtr, Error>
     SearchWithRequest(const SearchRequest& request) const override {
-        if (GetNumElements() == 0 && !this->ShouldSkipEmptyCheck(request.params_str_)) {
-            return DatasetImpl::MakeEmptyDataset();
-        }
-        SAFE_CALL(return this->inner_index_->SearchWithRequest(request));
+        SAFE_CALL(ValidateSearchThreshold(request.threshold_);
+                  if (GetNumElements() == 0 && !this->ShouldSkipEmptyCheck(request.params_str_)) {
+                      return DatasetImpl::MakeEmptyDataset();
+                  } return this->inner_index_->SearchWithRequest(request));
     }
 
     tl::expected<void, Error>
@@ -557,6 +578,18 @@ private:
     }
 
 private:
+    tl::expected<void, Error>
+    ValidateThresholdParameters(const std::string& parameters) const {
+        try {
+            ParseSearchThreshold(parameters);
+            return {};
+        } catch (const VsagException& e) {
+            return tl::unexpected(e.error_);
+        } catch (const std::exception& e) {
+            return tl::unexpected(Error(ErrorType::UNKNOWN_ERROR, e.what()));
+        }
+    }
+
     bool
     ShouldSkipEmptyCheck(const std::string& params_str) const {
         if (GetNumElements() != 0 || params_str.empty()) {

--- a/src/json_wrapper.cpp
+++ b/src/json_wrapper.cpp
@@ -93,6 +93,11 @@ JsonWrapper::IsNumberUnsigned() const {
 }
 
 bool
+JsonWrapper::IsNumber() const {
+    return json_->is_number();
+}
+
+bool
 JsonWrapper::IsString() const {
     return json_->is_string();
 }

--- a/src/json_wrapper.h
+++ b/src/json_wrapper.h
@@ -45,6 +45,9 @@ public:
     IsNumberUnsigned() const;
 
     bool
+    IsNumber() const;
+
+    bool
     IsString() const;
 
     bool

--- a/src/utils/search_threshold.h
+++ b/src/utils/search_threshold.h
@@ -1,0 +1,125 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <new>
+#include <optional>
+#include <string>
+
+#include "common.h"
+#include "json_types.h"
+#include "vsag/dataset.h"
+
+namespace vsag {
+
+inline constexpr const char* SEARCH_THRESHOLD = "threshold";
+
+inline std::optional<float>
+ParseSearchThreshold(const std::string& parameters) {
+    if (parameters.empty()) {
+        return std::nullopt;
+    }
+    const auto json = JsonType::Parse(parameters);
+    if (not json.Contains(SEARCH_THRESHOLD)) {
+        return std::nullopt;
+    }
+    CHECK_ARGUMENT(json[SEARCH_THRESHOLD].IsNumber(), "search threshold must be a number");
+    const auto threshold = json[SEARCH_THRESHOLD].GetFloat();
+    CHECK_ARGUMENT(std::isfinite(threshold), "search threshold must be finite");
+    return threshold;
+}
+
+inline void
+ValidateSearchThreshold(const std::optional<float>& threshold) {
+    if (threshold.has_value()) {
+        CHECK_ARGUMENT(std::isfinite(threshold.value()), "search threshold must be finite");
+    }
+}
+
+template <typename T>
+inline T*
+AllocateThresholdArray(uint64_t count, Allocator* allocator) {
+    if (count == 0) {
+        return nullptr;
+    }
+    if (allocator != nullptr) {
+        auto* result = static_cast<T*>(allocator->Allocate(sizeof(T) * count));
+        if (result == nullptr) {
+            throw std::bad_alloc();
+        }
+        return result;
+    }
+    return new T[count];
+}
+
+inline DatasetPtr
+FilterDatasetByThreshold(const DatasetPtr& input,
+                         const std::optional<float>& threshold,
+                         Allocator* allocator = nullptr,
+                         int64_t max_results = -1) {
+    if (not threshold.has_value()) {
+        return input;
+    }
+    // Count first so allocator-owned output arrays are exact-sized while preserving result order
+    // and extra-info alignment without a temporary owning container.
+    int64_t result_count = 0;
+    for (int64_t i = 0; i < input->GetDim(); ++i) {
+        if (std::isfinite(input->GetDistances()[i]) and
+            input->GetDistances()[i] <= threshold.value()) {
+            ++result_count;
+            if (max_results > 0 and result_count == max_results) {
+                break;
+            }
+        }
+    }
+    auto result = Dataset::Make();
+    result->NumElements(1)->Owner(true, allocator);
+    auto* result_ids = AllocateThresholdArray<int64_t>(result_count, allocator);
+    result->Dim(result_count)->Ids(result_ids);
+    auto* result_distances = AllocateThresholdArray<float>(result_count, allocator);
+    result->Distances(result_distances);
+    const auto extra_size = input->GetExtraInfoSize();
+    const auto* input_extra_infos = input->GetExtraInfos();
+    char* extra_infos = nullptr;
+    if (result_count > 0 and extra_size > 0 and input_extra_infos != nullptr) {
+        extra_infos = AllocateThresholdArray<char>(static_cast<uint64_t>(result_count) * extra_size,
+                                                   allocator);
+        result->ExtraInfos(extra_infos)->ExtraInfoSize(extra_size);
+    }
+    int64_t result_index = 0;
+    for (int64_t i = 0; i < input->GetDim() and result_index < result_count; ++i) {
+        if (std::isfinite(input->GetDistances()[i]) and
+            input->GetDistances()[i] <= threshold.value()) {
+            result_ids[result_index] = input->GetIds()[i];
+            result_distances[result_index] = input->GetDistances()[i];
+            if (extra_infos != nullptr) {
+                std::memcpy(extra_infos + result_index * extra_size,
+                            input_extra_infos + i * extra_size,
+                            extra_size);
+            }
+            ++result_index;
+        }
+    }
+    if (result_count == 0) {
+        result->ExtraInfos(nullptr)->ExtraInfoSize(0);
+    }
+    result->Statistics(input->GetStatistics())->Reasoning(input->GetReasoning());
+    return result;
+}
+
+}  // namespace vsag

--- a/tests/test_brute_force.cpp
+++ b/tests/test_brute_force.cpp
@@ -24,11 +24,13 @@
 #include <sstream>
 #include <thread>
 #include <unordered_map>
+#include <unordered_set>
 
 #include "functest.h"
 #include "storage/serialization_tags.h"
 #include "storage/streaming_serialization_test_utils.h"
 #include "test_index.h"
+#include "utils/search_threshold.h"
 #include "vsag/constants.h"
 #include "vsag/options.h"
 #include "vsag/search_request.h"
@@ -52,6 +54,7 @@ public:
         if (ptr != nullptr) {
             allocations_[ptr] = size;
             allocated_bytes_ += size;
+            allocation_count_ += 1;
         }
         return ptr;
     }
@@ -104,6 +107,12 @@ public:
         return allocated_bytes_;
     }
 
+    uint64_t
+    AllocationCount() const {
+        std::scoped_lock lock(mutex_);
+        return allocation_count_;
+    }
+
     void
     SetAllocationLimit(uint64_t limit) {
         std::scoped_lock lock(mutex_);
@@ -114,6 +123,7 @@ private:
     mutable std::mutex mutex_;
     std::unordered_map<void*, uint64_t> allocations_;
     uint64_t allocated_bytes_{0};
+    uint64_t allocation_count_{0};
     uint64_t allocation_limit_{std::numeric_limits<uint64_t>::max()};
 };
 
@@ -1286,6 +1296,215 @@ TEST_CASE("(PR) BruteForce SearchWithRequest Reasoning", "[ft][bruteforce][reaso
     REQUIRE_FALSE(empty_result.value()->GetReasoning().empty());
     REQUIRE(empty_result.value()->GetReasoning().find("missed_targets") != std::string::npos);
     REQUIRE(empty_result.value()->GetReasoning().find("filter_rejected") != std::string::npos);
+}
+
+TEST_CASE("(PR) BruteForce KnnSearch threshold filtering", "[ft][bruteforce][threshold][pr]") {
+    using namespace fixtures;
+
+    auto param = BruteForceTestIndex::GenerateBruteForceBuildParametersString("l2", 1, "fp32");
+    auto index = TestIndex::TestFactory(BruteForceTestIndex::name, param, true);
+    auto base = vsag::Dataset::Make();
+    int64_t ids[] = {10, 11, 12, 13};
+    float vectors[] = {0.0F, 1.0F, 2.0F, 3.0F};
+    base->NumElements(4)->Dim(1)->Ids(ids)->Float32Vectors(vectors)->Owner(false);
+    REQUIRE(index->Build(base).has_value());
+
+    auto query = vsag::Dataset::Make();
+    float query_vector[] = {0.0F};
+    query->NumElements(1)->Dim(1)->Float32Vectors(query_vector)->Owner(false);
+
+    auto baseline = index->KnnSearch(query, 4, "{}").value();
+    auto no_threshold = index->KnnSearch(query, 4, R"({"threshold": 100.0})").value();
+    REQUIRE(no_threshold->GetDim() == baseline->GetDim());
+    for (int64_t i = 0; i < baseline->GetDim(); ++i) {
+        REQUIRE(no_threshold->GetIds()[i] == baseline->GetIds()[i]);
+        REQUIRE(no_threshold->GetDistances()[i] == baseline->GetDistances()[i]);
+    }
+
+    auto filtered = index->KnnSearch(query, 3, R"({"threshold": 4.0})").value();
+    REQUIRE(filtered->GetDim() == 3);
+    REQUIRE(filtered->GetIds()[0] == 10);
+    REQUIRE(filtered->GetIds()[1] == 11);
+    REQUIRE(filtered->GetIds()[2] == 12);
+    REQUIRE(filtered->GetDistances()[2] == 4.0F);
+
+    auto empty = index->KnnSearch(query, 3, R"({"threshold": -0.1})").value();
+    REQUIRE(empty->GetDim() == 0);
+
+    auto overflow_index = TestIndex::TestFactory(BruteForceTestIndex::name, param, true);
+    float overflow_vector[] = {-std::numeric_limits<float>::max()};
+    auto overflow_base = vsag::Dataset::Make();
+    overflow_base->NumElements(1)->Dim(1)->Ids(ids)->Float32Vectors(overflow_vector)->Owner(false);
+    REQUIRE(overflow_index->Build(overflow_base).has_value());
+    float overflow_query_value = std::numeric_limits<float>::max();
+    auto overflow_query = vsag::Dataset::Make();
+    overflow_query->NumElements(1)->Dim(1)->Float32Vectors(&overflow_query_value)->Owner(false);
+    auto overflow_result = overflow_index->KnnSearch(overflow_query, 1, "{}").value();
+    REQUIRE(overflow_result->GetDim() == 1);
+    REQUIRE(std::isinf(overflow_result->GetDistances()[0]));
+    auto overflow_filtered =
+        overflow_index->KnnSearch(overflow_query, 1, R"({"threshold": 0.0})").value();
+    REQUIRE(overflow_filtered->GetDim() == 0);
+
+    vsag::SearchRequest request;
+    request.query_ = query;
+    request.topk_ = 4;
+    request.threshold_ = 1.0F;
+    TrackingAllocator request_allocator;
+    request.search_allocator_ = &request_allocator;
+    auto request_result = index->SearchWithRequest(request).value();
+    REQUIRE(request_result->GetDim() == 2);
+    REQUIRE(request_result->GetDistances()[0] <= request_result->GetDistances()[1]);
+    REQUIRE(request_result->GetDistances()[1] == 1.0F);
+    REQUIRE(request_allocator.AllocationCount() > 0);
+    REQUIRE(request_allocator.AllocatedBytes() == 0);
+
+    for (const auto threshold : {std::numeric_limits<float>::quiet_NaN(),
+                                 std::numeric_limits<float>::infinity(),
+                                 -std::numeric_limits<float>::infinity()}) {
+        request.threshold_ = threshold;
+        REQUIRE_FALSE(index->SearchWithRequest(request).has_value());
+    }
+    REQUIRE_FALSE(index->KnnSearch(query, 1, R"({"threshold":"bad"})").has_value());
+
+    auto nan_index = TestIndex::TestFactory(BruteForceTestIndex::name, param, true);
+    float nan_vectors[] = {std::numeric_limits<float>::quiet_NaN(), 0.0F};
+    auto nan_base = vsag::Dataset::Make();
+    nan_base->NumElements(2)->Dim(1)->Ids(ids)->Float32Vectors(nan_vectors)->Owner(false);
+    REQUIRE(nan_index->Build(nan_base).has_value());
+    auto nan_filtered = nan_index->KnnSearch(query, 1, R"({"threshold": 0.0})").value();
+    REQUIRE(nan_filtered->GetDim() == 1);
+    REQUIRE(nan_filtered->GetIds()[0] == 11);
+    REQUIRE(nan_filtered->GetDistances()[0] == 0.0F);
+
+    auto ip_param = BruteForceTestIndex::GenerateBruteForceBuildParametersString("ip", 1, "fp32");
+    auto ip_index = TestIndex::TestFactory(BruteForceTestIndex::name, ip_param, true);
+    float ip_vectors[] = {1.0F, 0.5F, 0.0F};
+    auto ip_base = vsag::Dataset::Make();
+    ip_base->NumElements(3)->Dim(1)->Ids(ids)->Float32Vectors(ip_vectors)->Owner(false);
+    REQUIRE(ip_index->Build(ip_base).has_value());
+    auto ip_query = vsag::Dataset::Make();
+    float ip_query_vector[] = {1.0F};
+    ip_query->NumElements(1)->Dim(1)->Float32Vectors(ip_query_vector)->Owner(false);
+    auto ip_filtered = ip_index->KnnSearch(ip_query, 3, R"({"threshold": 0.5})").value();
+    REQUIRE(ip_filtered->GetDim() == 2);
+    REQUIRE(ip_filtered->GetDistances()[0] == 0.0F);
+    REQUIRE(ip_filtered->GetDistances()[1] == 0.5F);
+
+    auto ip_overflow_index = TestIndex::TestFactory(BruteForceTestIndex::name, ip_param, true);
+    float ip_overflow_vector = std::numeric_limits<float>::max();
+    auto ip_overflow_base = vsag::Dataset::Make();
+    ip_overflow_base->NumElements(1)
+        ->Dim(1)
+        ->Ids(ids)
+        ->Float32Vectors(&ip_overflow_vector)
+        ->Owner(false);
+    REQUIRE(ip_overflow_index->Build(ip_overflow_base).has_value());
+    auto ip_overflow_query = vsag::Dataset::Make();
+    ip_overflow_query->NumElements(1)->Dim(1)->Float32Vectors(&ip_overflow_vector)->Owner(false);
+    vsag::SearchRequest range_request;
+    range_request.mode_ = vsag::SearchMode::RANGE_SEARCH;
+    range_request.query_ = ip_overflow_query;
+    range_request.radius_ = 0.0F;
+    range_request.threshold_ = 0.0F;
+    auto range_result = ip_overflow_index->SearchWithRequest(range_request).value();
+    REQUIRE(range_result->GetDim() == 1);
+    REQUIRE(std::isinf(range_result->GetDistances()[0]));
+    REQUIRE(range_result->GetDistances()[0] < 0.0F);
+
+    auto empty_index = TestIndex::TestFactory(BruteForceTestIndex::name, param, true);
+    auto malformed_empty = empty_index->KnnSearch(query, 1, R"({"threshold":"bad"})");
+    REQUIRE_FALSE(malformed_empty.has_value());
+    auto nonfinite_empty = empty_index->KnnSearch(query, 1, R"({"threshold":1e100})");
+    REQUIRE_FALSE(nonfinite_empty.has_value());
+}
+
+TEST_CASE("(PR) SearchRequest preserves legacy aggregate initialization",
+          "[ut][search_request][compatibility][pr]") {
+    vsag::SearchRequest request{nullptr,
+                                vsag::SearchMode::RANGE_SEARCH,
+                                7,
+                                1.5F,
+                                3,
+                                "{}",
+                                nullptr,
+                                1,
+                                true,
+                                "attr",
+                                true,
+                                nullptr,
+                                true,
+                                nullptr,
+                                nullptr,
+                                true,
+                                nullptr,
+                                false,
+                                {42}};
+
+    REQUIRE(request.mode_ == vsag::SearchMode::RANGE_SEARCH);
+    REQUIRE(request.topk_ == 7);
+    REQUIRE(request.radius_ == 1.5F);
+    REQUIRE(request.limited_size_ == 3);
+    REQUIRE(request.params_str_ == "{}");
+    REQUIRE_FALSE(request.distance_batch_func_);
+    REQUIRE(request.distance_batch_size_ == 1);
+    REQUIRE(request.enable_attribute_filter_);
+    REQUIRE(request.attribute_filter_str_ == "attr");
+    REQUIRE(request.enable_filter_);
+    REQUIRE(request.enable_bitset_filter_);
+    REQUIRE(request.enable_iterator_search_);
+    REQUIRE_FALSE(request.is_last_search_);
+    REQUIRE(request.expected_labels_ == std::vector<int64_t>{42});
+    REQUIRE_FALSE(request.threshold_.has_value());
+}
+
+TEST_CASE("(PR) Threshold filtering preserves allocator ownership", "[ft][threshold][pr]") {
+    int64_t ids[] = {1, 2, 3};
+    float distances[] = {0.0F, 1.0F, 2.0F};
+    const char extra_info[] = "aabbcc";
+    auto input = vsag::Dataset::Make();
+    input->NumElements(1)
+        ->Dim(3)
+        ->Ids(ids)
+        ->Distances(distances)
+        ->ExtraInfoSize(2)
+        ->ExtraInfos(extra_info)
+        ->Owner(false);
+
+    TrackingAllocator allocator;
+    {
+        auto result = vsag::FilterDatasetByThreshold(input, 1.0F, &allocator);
+        REQUIRE(result->GetDim() == 2);
+        REQUIRE(result->GetIds()[0] == 1);
+        REQUIRE(result->GetIds()[1] == 2);
+        REQUIRE(std::memcmp(result->GetExtraInfos(), "aabb", 4) == 0);
+        REQUIRE(allocator.AllocatedBytes() > 0);
+    }
+    REQUIRE(allocator.AllocatedBytes() == 0);
+
+    auto empty = vsag::FilterDatasetByThreshold(input, -1.0F, &allocator);
+    REQUIRE(empty->GetDim() == 0);
+    REQUIRE(empty->GetExtraInfoSize() == 0);
+    REQUIRE(empty->GetExtraInfos() == nullptr);
+
+    int64_t non_finite_ids[] = {7, 8, 9};
+    float non_finite_distances[] = {-std::numeric_limits<float>::infinity(), 0.0F, 1.0F};
+    auto non_finite_input = vsag::Dataset::Make();
+    non_finite_input->NumElements(1)
+        ->Dim(3)
+        ->Ids(non_finite_ids)
+        ->Distances(non_finite_distances)
+        ->Owner(false);
+    auto finite_only = vsag::FilterDatasetByThreshold(non_finite_input, 1.0F, &allocator, 1);
+    REQUIRE(finite_only->GetDim() == 1);
+    REQUIRE(finite_only->GetIds()[0] == 8);
+    REQUIRE(finite_only->GetDistances()[0] == 0.0F);
+    finite_only.reset();
+    REQUIRE(allocator.AllocatedBytes() == 0);
+
+    allocator.SetAllocationLimit(sizeof(int64_t) * 2);
+    REQUIRE_THROWS_AS(vsag::FilterDatasetByThreshold(input, 1.0F, &allocator), std::bad_alloc);
+    REQUIRE(allocator.AllocatedBytes() == 0);
 }
 
 TEST_CASE("(PR) BruteForce Reasoning Found Verification", "[ft][bruteforce][reasoning][pr]") {

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -25,6 +25,7 @@
 #include <thread>
 
 #include "functest.h"
+#include "impl/filter/iterator_filter.h"
 #include "inner_string_params.h"
 #include "storage/serialization_tags.h"
 #include "storage/streaming_serialization_test_utils.h"
@@ -3369,6 +3370,293 @@ TEST_CASE("(PR) HGraph brute_force_threshold default is no-op",
     auto negative_ef = index->KnnSearch(query, topk, R"({"hgraph": {"ef_search": -1}})");
     REQUIRE_FALSE(zero_ef.has_value());
     REQUIRE_FALSE(negative_ef.has_value());
+}
+
+TEST_CASE("(PR) HGraph threshold iterator consumes rejected pages",
+          "[ft][hgraph][threshold][iterator][pr]") {
+    constexpr int64_t dim = 1;
+    constexpr int64_t base_count = 32;
+    std::string params = R"({
+        "dtype":"float32", "metric_type":"l2", "dim":1,
+        "index_param":{"base_quantization_type":"fp32","max_degree":16,
+        "ef_construction":64,"use_reorder":false}
+    })";
+    auto index = vsag::Factory::CreateIndex("hgraph", params).value();
+    std::vector<float> vectors(base_count);
+    std::vector<int64_t> ids(base_count);
+    for (int64_t i = 0; i < base_count; ++i) {
+        vectors[i] = static_cast<float>(i);
+        ids[i] = i;
+    }
+    auto base = vsag::Dataset::Make();
+    base->NumElements(base_count)
+        ->Dim(dim)
+        ->Ids(ids.data())
+        ->Float32Vectors(vectors.data())
+        ->Owner(false);
+    REQUIRE(index->Build(base).has_value());
+    auto query = vsag::Dataset::Make();
+    float query_value = 0.0F;
+    query->NumElements(1)->Dim(dim)->Float32Vectors(&query_value)->Owner(false);
+
+    vsag::IteratorContext* iter_ctx = nullptr;
+    const auto search_params = R"({"hgraph":{"ef_search":8},"threshold":-1.0})";
+    auto first =
+        index->KnnSearch(query, 1, search_params, vsag::FilterPtr(nullptr), iter_ctx, false);
+    REQUIRE(first.has_value());
+    REQUIRE(first.value()->GetDim() == 0);
+    auto* filter_ctx = static_cast<vsag::IteratorFilterContext*>(iter_ctx);
+    REQUIRE(filter_ctx->GetDiscardElementNum() == 0);
+    delete iter_ctx;
+}
+
+TEST_CASE("(PR) HGraph ignores non-finite entry distances",
+          "[ft][hgraph][threshold][nonfinite][pr]") {
+    const auto params = R"({
+        "dtype":"float32", "metric_type":"l2", "dim":1,
+        "index_param":{"base_quantization_type":"fp32","max_degree":16,
+        "ef_construction":32,"use_reorder":false}
+    })";
+    auto index = vsag::Factory::CreateIndex("hgraph", params).value();
+    std::vector<float> vectors = {0.0F, std::numeric_limits<float>::max()};
+    std::vector<int64_t> ids = {0, 1};
+    auto base = vsag::Dataset::Make();
+    base->NumElements(2)->Dim(1)->Ids(ids.data())->Float32Vectors(vectors.data())->Owner(false);
+    REQUIRE(index->Build(base).has_value());
+
+    float overflow_query_value = std::numeric_limits<float>::max();
+    auto overflow_query = vsag::Dataset::Make();
+    overflow_query->NumElements(1)->Dim(1)->Float32Vectors(&overflow_query_value)->Owner(false);
+    auto overflow_result = index->KnnSearch(overflow_query, 1, R"({"hgraph":{"ef_search":8}})");
+    REQUIRE(overflow_result.has_value());
+    REQUIRE(overflow_result.value()->GetDim() == 1);
+    REQUIRE(overflow_result.value()->GetIds()[0] == 1);
+    REQUIRE(overflow_result.value()->GetDistances()[0] == 0.0F);
+
+    float nan_query_value = std::numeric_limits<float>::quiet_NaN();
+    auto nan_query = vsag::Dataset::Make();
+    nan_query->NumElements(1)->Dim(1)->Float32Vectors(&nan_query_value)->Owner(false);
+    auto nan_result = index->KnnSearch(nan_query, 1, R"({"hgraph":{"ef_search":8}})");
+    REQUIRE(nan_result.has_value());
+    for (int64_t i = 0; i < nan_result.value()->GetDim(); ++i) {
+        REQUIRE(std::isfinite(nan_result.value()->GetDistances()[i]));
+    }
+}
+
+TEST_CASE("(PR) HGraph filters non-finite candidates before threshold selection",
+          "[ft][hgraph][threshold][nonfinite][pr]") {
+    const auto params = R"({
+        "dtype":"float32", "metric_type":"ip", "dim":1,
+        "index_param":{"base_quantization_type":"fp32","max_degree":16,
+        "ef_construction":32,"use_reorder":false}
+    })";
+    auto index = vsag::Factory::CreateIndex("hgraph", params).value();
+    std::vector<float> vectors = {std::numeric_limits<float>::max(), 0.0F};
+    std::vector<int64_t> ids = {10, 20};
+    auto base = vsag::Dataset::Make();
+    base->NumElements(2)->Dim(1)->Ids(ids.data())->Float32Vectors(vectors.data())->Owner(false);
+    REQUIRE(index->Build(base).has_value());
+
+    float query_value = std::numeric_limits<float>::max();
+    auto query = vsag::Dataset::Make();
+    query->NumElements(1)->Dim(1)->Float32Vectors(&query_value)->Owner(false);
+    auto result = index->KnnSearch(query, 1, R"({"threshold":1.0,"hgraph":{"ef_search":1}})");
+    REQUIRE(result.has_value());
+    REQUIRE(result.value()->GetDim() == 1);
+    REQUIRE(result.value()->GetIds()[0] == 20);
+    REQUIRE(result.value()->GetDistances()[0] == 1.0F);
+
+    auto brute_result = index->KnnSearch(
+        query, 1, R"({"threshold":1.0,"hgraph":{"ef_search":1,"brute_force_threshold":1.0}})");
+    REQUIRE(brute_result.has_value());
+    REQUIRE(brute_result.value()->GetDim() == 1);
+    REQUIRE(brute_result.value()->GetIds()[0] == 20);
+    REQUIRE(brute_result.value()->GetDistances()[0] == 1.0F);
+}
+
+TEST_CASE("(PR) HGraph continues below an unrankable route seed",
+          "[ft][hgraph][threshold][nonfinite][route][pr]") {
+    const auto params = R"({
+        "dtype":"float32", "metric_type":"ip", "dim":2,
+        "index_param":{"base_quantization_type":"fp32","max_degree":16,
+        "ef_construction":32,"use_reorder":false}
+    })";
+    auto index = vsag::Factory::CreateIndex("hgraph", params).value();
+    const auto max = std::numeric_limits<float>::max();
+    const auto min = std::numeric_limits<float>::min();
+    std::vector<float> vectors = {max, -max, 0.0F, min};
+    std::vector<int64_t> ids = {10, 20};
+    auto base = vsag::Dataset::Make();
+    base->NumElements(2)->Dim(2)->Ids(ids.data())->Float32Vectors(vectors.data())->Owner(false);
+    REQUIRE(index->Build(base).has_value());
+
+    std::vector<float> query_vector = {max, max};
+    auto query = vsag::Dataset::Make();
+    query->NumElements(1)->Dim(2)->Float32Vectors(query_vector.data())->Owner(false);
+    const auto search_params = R"({"hgraph":{"ef_search":2},"threshold":0.0})";
+
+    auto result = index->KnnSearch(query, 1, search_params);
+    REQUIRE(result.has_value());
+    REQUIRE(result.value()->GetDim() == 1);
+    REQUIRE(result.value()->GetIds()[0] == 20);
+    REQUIRE(std::isfinite(result.value()->GetDistances()[0]));
+
+    vsag::IteratorContext* iter_ctx = nullptr;
+    auto iterator_result =
+        index->KnnSearch(query, 1, search_params, vsag::FilterPtr(nullptr), iter_ctx, false);
+    REQUIRE(iterator_result.has_value());
+    REQUIRE(iterator_result.value()->GetDim() == 1);
+    REQUIRE(iterator_result.value()->GetIds()[0] == 20);
+    REQUIRE(std::isfinite(iterator_result.value()->GetDistances()[0]));
+    delete iter_ctx;
+}
+
+TEST_CASE("(PR) HGraph iterator preserves infinity without threshold",
+          "[ft][hgraph][threshold][iterator][nonfinite][pr]") {
+    const auto params = R"({
+        "dtype":"float32", "metric_type":"ip", "dim":1,
+        "index_param":{"base_quantization_type":"fp32","max_degree":16,
+        "ef_construction":32,"use_reorder":false}
+    })";
+    auto index = vsag::Factory::CreateIndex("hgraph", params).value();
+    std::vector<float> vectors = {std::numeric_limits<float>::max(), 0.0F};
+    std::vector<int64_t> ids = {42, 43};
+    auto base = vsag::Dataset::Make();
+    base->NumElements(2)->Dim(1)->Ids(ids.data())->Float32Vectors(vectors.data())->Owner(false);
+    REQUIRE(index->Build(base).has_value());
+
+    auto query = vsag::Dataset::Make();
+    query->NumElements(1)->Dim(1)->Float32Vectors(vectors.data())->Owner(false);
+    const auto search_params = R"({"hgraph":{"ef_search":8}})";
+
+    vsag::IteratorContext* iter_ctx = nullptr;
+    auto ordinary =
+        index->KnnSearch(query, 1, search_params, vsag::FilterPtr(nullptr), iter_ctx, false);
+    REQUIRE(ordinary.has_value());
+    REQUIRE(ordinary.value()->GetDim() == 1);
+    REQUIRE(ordinary.value()->GetIds()[0] == ids[0]);
+    REQUIRE(std::isinf(ordinary.value()->GetDistances()[0]));
+    REQUIRE(ordinary.value()->GetDistances()[0] < 0.0F);
+    delete iter_ctx;
+
+    for (const int64_t thread_count : {1, 2}) {
+        const auto params_with_threads = fmt::format(
+            R"({{"hgraph":{{"ef_search":8,"parallel_search_thread_count":{}}}}})", thread_count);
+        auto range = index->RangeSearch(query, 1.0F, params_with_threads);
+        REQUIRE(range.has_value());
+        REQUIRE(range.value()->GetDim() == 2);
+        REQUIRE(range.value()->GetIds()[0] == ids[0]);
+        REQUIRE(std::isinf(range.value()->GetDistances()[0]));
+        REQUIRE(range.value()->GetDistances()[0] < 0.0F);
+    }
+
+    iter_ctx = nullptr;
+    auto threshold = index->KnnSearch(query,
+                                      1,
+                                      R"({"hgraph":{"ef_search":1},"threshold":1.0})",
+                                      vsag::FilterPtr(nullptr),
+                                      iter_ctx,
+                                      false);
+    REQUIRE(threshold.has_value());
+    REQUIRE(threshold.value()->GetDim() == 1);
+    REQUIRE(threshold.value()->GetIds()[0] == ids[1]);
+    REQUIRE(threshold.value()->GetDistances()[0] == 1.0F);
+    delete iter_ctx;
+}
+
+TEST_CASE("HGraph build tolerates empty non-finite graph probes",
+          "[ft][hgraph][build][nonfinite]") {
+    const auto params = R"({
+        "dtype":"float32", "metric_type":"l2", "dim":64,
+        "index_param":{"base_quantization_type":"fp32","max_degree":16,
+        "ef_construction":32,"use_reorder":false}
+    })";
+    auto index = vsag::Factory::CreateIndex("hgraph", params).value();
+    constexpr int64_t count = 128;
+    std::vector<float> vectors(count * 64, std::numeric_limits<float>::quiet_NaN());
+    std::vector<int64_t> ids(count);
+    std::iota(ids.begin(), ids.end(), 0);
+    auto base = vsag::Dataset::Make();
+    base->NumElements(count)
+        ->Dim(64)
+        ->Ids(ids.data())
+        ->Float32Vectors(vectors.data())
+        ->Owner(false);
+    REQUIRE(index->Build(base).has_value());
+
+    std::iota(ids.begin(), ids.end(), count);
+    REQUIRE(index->Add(base).has_value());
+
+    std::vector<float> query_vector(64, 0.0F);
+    auto query = vsag::Dataset::Make();
+    query->NumElements(1)->Dim(64)->Float32Vectors(query_vector.data())->Owner(false);
+    for (uint64_t i = 0; i < 4; ++i) {
+        auto result = index->KnnSearch(query, 1, R"({"hgraph":{"ef_search":8}})");
+        REQUIRE(result.has_value());
+        REQUIRE(result.value()->GetDim() == 0);
+    }
+}
+
+TEST_CASE("HGraph range reorder ignores KNN threshold", "[ft][hgraph][range][reorder][threshold]") {
+    const auto params = R"({
+        "dtype":"float32", "metric_type":"l2", "dim":1,
+        "index_param":{"base_quantization_type":"sq8","precise_quantization_type":"fp32",
+        "max_degree":16,"ef_construction":32,"use_reorder":true}
+    })";
+    auto index = vsag::Factory::CreateIndex("hgraph", params).value();
+    std::vector<float> vectors = {0.0F, 1.0F};
+    std::vector<int64_t> ids = {10, 20};
+    auto base = vsag::Dataset::Make();
+    base->NumElements(2)->Dim(1)->Ids(ids.data())->Float32Vectors(vectors.data())->Owner(false);
+    REQUIRE(index->Build(base).has_value());
+
+    const float query_vector = 0.0F;
+    auto query = vsag::Dataset::Make();
+    query->NumElements(1)->Dim(1)->Float32Vectors(&query_vector)->Owner(false);
+    vsag::SearchRequest request;
+    request.mode_ = vsag::SearchMode::RANGE_SEARCH;
+    request.query_ = query;
+    request.radius_ = 1.0F;
+    request.limited_size_ = 2;
+    request.threshold_ = 0.0F;
+    request.params_str_ = R"({"hgraph":{"ef_search":8,"enable_reorder":true}})";
+
+    auto result = index->SearchWithRequest(request);
+    REQUIRE(result.has_value());
+    REQUIRE(result.value()->GetDim() == 2);
+}
+
+TEST_CASE("HGraph returns non-finite duplicate labels within ef",
+          "[ft][hgraph][duplicate][nonfinite]") {
+    const auto params = R"({
+        "dtype":"float32", "metric_type":"ip", "dim":1,
+        "index_param":{"base_quantization_type":"fp32","max_degree":16,
+        "ef_construction":32,"use_reorder":false,"support_duplicate":true,
+        "deduplicate_storage":true}
+    })";
+    auto index = vsag::Factory::CreateIndex("hgraph", params).value();
+    std::vector<float> vectors = {
+        0.0F, std::numeric_limits<float>::max(), std::numeric_limits<float>::max()};
+    std::vector<int64_t> ids = {10, 20, 30};
+    auto base = vsag::Dataset::Make();
+    base->NumElements(3)->Dim(1)->Ids(ids.data())->Float32Vectors(vectors.data())->Owner(false);
+    REQUIRE(index->Build(base).has_value());
+
+    const float query_vector = std::numeric_limits<float>::max();
+    auto query = vsag::Dataset::Make();
+    query->NumElements(1)->Dim(1)->Float32Vectors(&query_vector)->Owner(false);
+    for (const int64_t thread_count : {1, 2}) {
+        const auto search_params = fmt::format(
+            R"({{"hgraph":{{"ef_search":2,"parallel_search_thread_count":{}}}}})", thread_count);
+        auto result = index->KnnSearch(query, 2, search_params);
+        REQUIRE(result.has_value());
+        REQUIRE(result.value()->GetDim() == 2);
+        std::set<int64_t> result_ids(result.value()->GetIds(),
+                                     result.value()->GetIds() + result.value()->GetDim());
+        REQUIRE(result_ids == std::set<int64_t>{20, 30});
+        REQUIRE(std::isinf(result.value()->GetDistances()[0]));
+        REQUIRE(std::isinf(result.value()->GetDistances()[1]));
+    }
 }
 
 TEST_CASE("HGraph ExportCache + ImportCache + Build acceleration smoke test",

--- a/tests/test_ivf.cpp
+++ b/tests/test_ivf.cpp
@@ -1771,6 +1771,12 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::IVFTestIndex,
                 static_cast<float>(result.value()->GetIds()[i]));
     }
 
+    request.threshold_ = -1.0F;
+    auto threshold_result = index->SearchWithRequest(request);
+    REQUIRE(threshold_result.has_value());
+    REQUIRE(threshold_result.value()->GetDim() == 0);
+    request.threshold_.reset();
+
     request.mode_ = vsag::SearchMode::RANGE_SEARCH;
     auto range_result = index->SearchWithRequest(request);
     REQUIRE_FALSE(range_result.has_value());
@@ -1792,6 +1798,119 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::IVFTestIndex,
     auto parallel_result = index->SearchWithRequest(request);
     REQUIRE_FALSE(parallel_result.has_value());
     REQUIRE(parallel_result.error().type == vsag::ErrorType::INVALID_ARGUMENT);
+}
+
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::IVFTestIndex,
+                             "IVF reorder applies threshold to exact distances",
+                             "[ft][search][ivf][threshold][pr]") {
+    constexpr int64_t dim = 16;
+    auto param = IVFTestIndex::GenerateIVFBuildParametersString("l2", dim, "sq8,fp32", 10);
+    auto index = TestIndex::TestFactory(IVFTestIndex::name, param, true);
+    auto dataset = IVFTestIndex::pool.GetDatasetAndCreate(dim, 200, "l2");
+    TestIndex::TestBuildIndex(index, dataset, true);
+
+    auto query = vsag::Dataset::Make();
+    query->NumElements(1)
+        ->Dim(dim)
+        ->Float32Vectors(dataset->base_->GetFloat32Vectors())
+        ->Owner(false);
+    auto result = index->KnnSearch(
+        query, 2, R"({"ivf":{"scan_buckets_count":10,"factor":4.0},"threshold":0.0})");
+    REQUIRE(result.has_value());
+    REQUIRE(result.value()->GetDim() >= 1);
+    REQUIRE(result.value()->GetDim() <= 2);
+    REQUIRE(result.value()->GetIds()[0] == dataset->base_->GetIds()[0]);
+    for (int64_t i = 0; i < result.value()->GetDim(); ++i) {
+        REQUIRE(result.value()->GetDistances()[i] <= 0.0F);
+        if (i > 0) {
+            REQUIRE(result.value()->GetDistances()[i - 1] <= result.value()->GetDistances()[i]);
+        }
+    }
+
+    vsag::SearchRequest reasoning_request;
+    reasoning_request.query_ = query;
+    reasoning_request.topk_ = 2;
+    reasoning_request.params_str_ = R"({"ivf":{"scan_buckets_count":10,"factor":4.0}})";
+    reasoning_request.threshold_ = -1.0F;
+    reasoning_request.expected_labels_ = {dataset->base_->GetIds()[0]};
+    auto reasoning_result = index->SearchWithRequest(reasoning_request);
+    REQUIRE(reasoning_result.has_value());
+    REQUIRE(reasoning_result.value()->GetDim() == 0);
+    REQUIRE(reasoning_result.value()->GetReasoning().find("0/1 expected labels found") !=
+            std::string::npos);
+
+    auto post_filter_baseline = index->KnnSearch(
+        query, 2, R"({"ivf":{"scan_buckets_count":10,"factor":4.0},"threshold":1e9})");
+    REQUIRE(post_filter_baseline.has_value());
+    REQUIRE(post_filter_baseline.value()->GetDim() == 2);
+    reasoning_request.threshold_ = 1e9F;
+    reasoning_request.expected_labels_ = {post_filter_baseline.value()->GetIds()[1]};
+    auto post_filter_reasoning = index->SearchWithRequest(reasoning_request);
+    REQUIRE(post_filter_reasoning.has_value());
+    REQUIRE(post_filter_reasoning.value()->GetReasoning().find("1/1 expected labels found") !=
+            std::string::npos);
+}
+
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::IVFTestIndex,
+                             "IVF threshold filters before top-k selection",
+                             "[ft][search][ivf][threshold][nonfinite][pr]") {
+    auto param = IVFTestIndex::GenerateIVFBuildParametersString("ip", 1, "fp32", 1, "random");
+    auto index = TestIndex::TestFactory(IVFTestIndex::name, param, true);
+    std::vector<float> vectors = {std::numeric_limits<float>::max(), 0.0F};
+    std::vector<int64_t> ids = {10, 20};
+    auto base = vsag::Dataset::Make();
+    base->NumElements(2)->Dim(1)->Ids(ids.data())->Float32Vectors(vectors.data())->Owner(false);
+    REQUIRE(index->Build(base).has_value());
+
+    auto query = vsag::Dataset::Make();
+    query->NumElements(1)->Dim(1)->Float32Vectors(vectors.data())->Owner(false);
+    auto result = index->KnnSearch(query, 1, R"({"ivf":{"scan_buckets_count":1},"threshold":1.0})");
+    REQUIRE(result.has_value());
+    REQUIRE(result.value()->GetDim() == 1);
+    REQUIRE(result.value()->GetIds()[0] == 20);
+    REQUIRE(result.value()->GetDistances()[0] == 1.0F);
+}
+
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::IVFTestIndex,
+                             "IVF reorder filters non-finite exact distances before selection",
+                             "[ft][search][ivf][reorder][threshold][nonfinite][pr]") {
+    auto param = IVFTestIndex::GenerateIVFBuildParametersString("ip", 1, "sq8,fp32", 1, "random");
+    auto index = TestIndex::TestFactory(IVFTestIndex::name, param, true);
+    std::vector<float> vectors = {std::numeric_limits<float>::max(), 0.0F};
+    std::vector<int64_t> ids = {10, 20};
+    auto base = vsag::Dataset::Make();
+    base->NumElements(2)->Dim(1)->Ids(ids.data())->Float32Vectors(vectors.data())->Owner(false);
+    REQUIRE(index->Build(base).has_value());
+
+    auto query = vsag::Dataset::Make();
+    query->NumElements(1)->Dim(1)->Float32Vectors(vectors.data())->Owner(false);
+    auto result = index->KnnSearch(
+        query, 1, R"({"ivf":{"scan_buckets_count":1,"factor":2.0},"threshold":1.0})");
+    REQUIRE(result.has_value());
+    REQUIRE(result.value()->GetDim() == 1);
+    REQUIRE(result.value()->GetIds()[0] == 20);
+    REQUIRE(result.value()->GetDistances()[0] == 1.0F);
+}
+
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::IVFTestIndex,
+                             "IVF reorder filters non-finite approximate distances before capping",
+                             "[ft][search][ivf][reorder][threshold][nonfinite][pr]") {
+    auto param = IVFTestIndex::GenerateIVFBuildParametersString("ip", 1, "fp32,fp32", 1, "random");
+    auto index = TestIndex::TestFactory(IVFTestIndex::name, param, true);
+    std::vector<float> vectors = {std::numeric_limits<float>::max(), 0.0F};
+    std::vector<int64_t> ids = {10, 20};
+    auto base = vsag::Dataset::Make();
+    base->NumElements(2)->Dim(1)->Ids(ids.data())->Float32Vectors(vectors.data())->Owner(false);
+    REQUIRE(index->Build(base).has_value());
+
+    auto query = vsag::Dataset::Make();
+    query->NumElements(1)->Dim(1)->Float32Vectors(vectors.data())->Owner(false);
+    auto result = index->KnnSearch(
+        query, 1, R"({"ivf":{"scan_buckets_count":1,"factor":1.0},"threshold":1.0})");
+    REQUIRE(result.has_value());
+    REQUIRE(result.value()->GetDim() == 1);
+    REQUIRE(result.value()->GetIds()[0] == 20);
+    REQUIRE(result.value()->GetDistances()[0] == 1.0F);
 }
 
 // RejectAllFilter for testing empty results
@@ -1993,6 +2112,26 @@ TEST_CASE("IVF GraphBucketSearcher Basic", "[ft][ivf][graph]") {
     auto result = index.value()->KnnSearch(query, 10, search_param);
     REQUIRE(result.has_value());
     REQUIRE(result.value()->GetDim() == 10);
+}
+
+TEST_CASE("IVF GraphBucketSearcher excludes non-finite threshold results",
+          "[ft][ivf][graph][threshold][nonfinite]") {
+    auto build_param = GenerateIVFGraphBuildParametersString("ip", 1, 1, 1);
+    auto index = vsag::Factory::CreateIndex("ivf", build_param).value();
+    std::vector<float> vectors = {std::numeric_limits<float>::max(), 0.0F};
+    std::vector<int64_t> ids = {10, 20};
+    auto base = vsag::Dataset::Make();
+    base->NumElements(2)->Dim(1)->Ids(ids.data())->Float32Vectors(vectors.data())->Owner(false);
+    REQUIRE(index->Build(base).has_value());
+
+    auto query = vsag::Dataset::Make();
+    query->NumElements(1)->Dim(1)->Float32Vectors(vectors.data())->Owner(false);
+    auto result = index->KnnSearch(
+        query, 1, R"({"ivf":{"scan_buckets_count":1,"ef_search":2},"threshold":1.0})");
+    REQUIRE(result.has_value());
+    REQUIRE(result.value()->GetDim() == 1);
+    REQUIRE(result.value()->GetIds()[0] == 20);
+    REQUIRE(result.value()->GetDistances()[0] == 1.0F);
 }
 
 TEST_CASE("IVF GraphBucketSearcher Flat Fallback", "[ft][ivf][graph]") {

--- a/tests/test_pyramid.cpp
+++ b/tests/test_pyramid.cpp
@@ -481,6 +481,38 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
         index->KnnSearch(query, topk, GeneratePyramidSearchParametersString(ef_search));
     REQUIRE(search_result.has_value());
     REQUIRE(search_result.value()->GetDim() == topk);
+
+    auto threshold_result =
+        index->KnnSearch(query, topk, R"({"threshold": 0.0, "pyramid": {"ef_search": 5}})");
+    REQUIRE(threshold_result.has_value());
+    REQUIRE(threshold_result.value()->GetDim() == 1);
+}
+
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
+                             "Pyramid threshold filters before flat-node pruning",
+                             "[ft][search][pyramid][threshold][nonfinite]") {
+    PyramidParam pyramid_param;
+    pyramid_param.no_build_levels = {};
+    const auto param = GeneratePyramidBuildParametersString("ip", 4, pyramid_param);
+    auto index = TestFactory("pyramid", param, true);
+
+    std::vector<std::array<float, 4>> vectors = {
+        {std::numeric_limits<float>::max(), 0.0F, 0.0F, 0.0F}, {0.0F, 0.0F, 0.0F, 0.0F}};
+    std::vector<int64_t> ids = {10, 20};
+    std::vector<std::string> paths = {"all", "all"};
+    REQUIRE(index->Build(MakeDenseDataset(vectors, ids, paths)).has_value());
+
+    std::array<float, 4> query_vector = {std::numeric_limits<float>::max(), 0.0F, 0.0F, 0.0F};
+    auto query = MakeSingleQuery(query_vector, "all");
+    auto ordinary = index->KnnSearch(query, 2, R"({"pyramid":{"ef_search":2}})");
+    REQUIRE(ordinary.has_value());
+    REQUIRE(ordinary.value()->GetDim() == 2);
+    CAPTURE(ordinary.value()->GetDistances()[0], ordinary.value()->GetDistances()[1]);
+    auto result = index->KnnSearch(query, 1, R"({"threshold":1.0,"pyramid":{"ef_search":1}})");
+    REQUIRE(result.has_value());
+    REQUIRE(result.value()->GetDim() == 1);
+    REQUIRE(result.value()->GetIds()[0] == 20);
+    REQUIRE(result.value()->GetDistances()[0] == 1.0F);
 }
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,

--- a/tests/test_simq.cpp
+++ b/tests/test_simq.cpp
@@ -55,6 +55,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "algorithm/simq/simq_utils.h"
 #include "framework/test_dataset.h"
 #include "framework/test_dataset_pool.h"
 #include "test_index.h"
@@ -63,6 +64,16 @@
 #include "vsag/vsag.h"
 
 using namespace vsag;
+
+TEST_CASE("SIMQ distance ordering places NaN after finite results", "[simq][threshold]") {
+    std::vector<std::pair<float, InnerIdType>> results = {
+        {2.0F, 0}, {0.0F, 1}, {std::numeric_limits<float>::quiet_NaN(), 2}, {1.0F, 3}};
+    std::sort(results.begin(), results.end(), simq_distance_less);
+    REQUIRE(results[0].first == 0.0F);
+    REQUIRE(results[1].first == 1.0F);
+    REQUIRE(results[2].first == 2.0F);
+    REQUIRE(std::isnan(results[3].first));
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Helpers
@@ -370,6 +381,20 @@ TEST_CASE("SIMQ: build and knn search recall", "[simq][build][search]") {
             index->KnnSearch(one_query, TOP_K, search_param, vsag::FilterPtr(nullptr));
         REQUIRE(search_result.has_value());
         require_simq_search_stats(search_result.value());
+
+        if (q == 0) {
+            auto zero_result = index->KnnSearch(one_query, 0, search_param);
+            REQUIRE(zero_result.has_value());
+            REQUIRE(zero_result.value()->GetDim() == 0);
+            REQUIRE(get_simq_search_stats(zero_result.value()).result_count == 0);
+
+            auto threshold_result = index->KnnSearch(
+                one_query, TOP_K, R"({"threshold": -1000000.0, "simq": {"coarse_k": 10}})");
+            REQUIRE(threshold_result.has_value());
+            REQUIRE(threshold_result.value()->GetDim() == 0);
+            auto threshold_stats = get_simq_search_stats(threshold_result.value());
+            REQUIRE(threshold_stats.result_count == 0);
+        }
 
         auto* ret_ids = search_result.value()->GetIds();
         float r = recall_at_k(ret_ids, TOP_K, ds.gt_ids[q].data(), static_cast<int64_t>(TOP_K));

--- a/tests/test_sindi.cpp
+++ b/tests/test_sindi.cpp
@@ -15,6 +15,8 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
+#include <limits>
+#include <numeric>
 
 #include "functest.h"
 #include "test_index.h"
@@ -220,6 +222,115 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex,
     TestUpdateId(index, dataset, search_param, true);
     TestEstimateMemory("sindi", build_param, dataset);
     TestIndexStatus(index);
+}
+
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex,
+                             "SINDI threshold backfills after non-finite candidates",
+                             "[ft][search][sindi][threshold][nonfinite][pr]") {
+    fixtures::SINDIParam param;
+    param.use_reorder = GENERATE(false, true);
+    param.sparse_value_quant_type = "fp32";
+    auto index = TestFactory("sindi", GenerateBuildParameter(param), true);
+
+    std::vector<uint32_t> term_ids = {1};
+    std::vector<float> overflow_value = {std::numeric_limits<float>::max()};
+    std::vector<float> finite_value = {0.25F};
+    vsag::SparseVector base_vectors[2];
+    base_vectors[0] = {1, term_ids.data(), overflow_value.data()};
+    base_vectors[1] = {1, term_ids.data(), finite_value.data()};
+    int64_t ids[] = {10, 20};
+    auto base = vsag::Dataset::Make();
+    base->NumElements(2)->Ids(ids)->SparseVectors(base_vectors)->Owner(false);
+    REQUIRE(index->Build(base).has_value());
+    if (GENERATE(false, true)) {
+        REQUIRE(index->SetImmutable().has_value());
+    }
+
+    std::vector<float> query_value = {2.0F};
+    vsag::SparseVector query_vector{1, term_ids.data(), query_value.data()};
+    auto query = vsag::Dataset::Make();
+    query->NumElements(1)->SparseVectors(&query_vector)->Owner(false);
+    auto result = index->KnnSearch(query,
+                                   1,
+                                   R"({"sindi":{"n_candidate":1,"query_prune_ratio":0.0,
+                                   "term_prune_ratio":0.0},"threshold":1.0})");
+    REQUIRE(result.has_value());
+    REQUIRE(result.value()->GetDim() == 1);
+    REQUIRE(result.value()->GetIds()[0] == 20);
+    REQUIRE(result.value()->GetDistances()[0] == 0.5F);
+}
+
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex,
+                             "SINDI clears threshold-rejected scores between windows",
+                             "[ft][search][sindi][threshold][window][pr]") {
+    fixtures::SINDIParam param;
+    param.use_reorder = false;
+    param.sparse_value_quant_type = "fp32";
+    auto index = TestFactory("sindi", GenerateBuildParameter(param), true);
+
+    constexpr int64_t count = 10001;
+    uint32_t query_term = 1;
+    uint32_t other_term = 2;
+    float first_window_value = 0.1F;
+    float second_window_value = 0.4F;
+    float other_value = 0.1F;
+    std::vector<vsag::SparseVector> base_vectors(count,
+                                                 vsag::SparseVector{1, &other_term, &other_value});
+    base_vectors[0] = {1, &query_term, &first_window_value};
+    base_vectors[count - 1] = {1, &query_term, &second_window_value};
+    std::vector<int64_t> ids(count);
+    std::iota(ids.begin(), ids.end(), 0);
+    auto base = vsag::Dataset::Make();
+    base->NumElements(count)->Ids(ids.data())->SparseVectors(base_vectors.data())->Owner(false);
+    REQUIRE(index->Build(base).has_value());
+
+    float query_value = 1.0F;
+    vsag::SparseVector query_vector{1, &query_term, &query_value};
+    auto query = vsag::Dataset::Make();
+    query->NumElements(1)->SparseVectors(&query_vector)->Owner(false);
+    auto result = index->KnnSearch(query,
+                                   1,
+                                   R"({"sindi":{"n_candidate":1,"query_prune_ratio":0.0,
+                                   "term_prune_ratio":0.0},"threshold":0.5})");
+    REQUIRE(result.has_value());
+    REQUIRE(result.value()->GetDim() == 0);
+}
+
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex,
+                             "SINDI threshold retains safe term-list insertion",
+                             "[ft][search][sindi][threshold][term-list][pr]") {
+    fixtures::SINDIParam param;
+    param.use_reorder = false;
+    param.doc_prune_ratio = 0.2F;
+    param.sparse_value_quant_type = "fp32";
+    auto index = TestFactory("sindi", GenerateBuildParameter(param), true);
+
+    uint32_t query_term = 1;
+    uint32_t other_term = 2;
+    float matching_value = 0.5F;
+    float other_value = 1.0F;
+    vsag::SparseVector base_vectors[] = {{1, &query_term, &matching_value},
+                                         {1, &other_term, &other_value}};
+    int64_t ids[] = {10, 20};
+    auto base = vsag::Dataset::Make();
+    base->NumElements(2)->Ids(ids)->SparseVectors(base_vectors)->Owner(false);
+    REQUIRE(index->Build(base).has_value());
+    if (GENERATE(false, true)) {
+        REQUIRE(index->SetImmutable().has_value());
+    }
+
+    float query_value = 1.0F;
+    vsag::SparseVector query_vector{1, &query_term, &query_value};
+    auto query = vsag::Dataset::Make();
+    query->NumElements(1)->SparseVectors(&query_vector)->Owner(false);
+    auto result = index->KnnSearch(query,
+                                   2,
+                                   R"({"sindi":{"n_candidate":2,"query_prune_ratio":0.0,
+                                   "term_prune_ratio":0.0},"threshold":0.5})");
+    REQUIRE(result.has_value());
+    REQUIRE(result.value()->GetDim() == 1);
+    REQUIRE(result.value()->GetIds()[0] == 10);
+    REQUIRE(result.value()->GetDistances()[0] == 0.5F);
 }
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex, "SINDI Analyze", "[ft][analyze][sindi]") {


### PR DESCRIPTION
## Summary

Add inclusive top-level distance threshold filtering for KNN in the maintained indexes only:

- BruteForce
- HGraph
- IVF
- Pyramid
- SINDI
- SIMQ

HNSW and DiskANN are outside this PR's scope. Their source, test, and documentation paths are absent from the full PR diff.

Threshold filtering excludes non-finite values before bounded result selection and allows eligible finite candidates to backfill. Non-reorder IVF, HGraph, Pyramid, and SINDI apply eligibility before bounded selection; reordered paths apply the bound to precise distances. HGraph iterator search consumes rejected pages and retained discard state internally. Ordinary KNN and range search preserve eligible infinite results while non-finite graph nodes remain safe traversal seeds. Threshold scratch storage uses the active request allocator.

## Validation

- One Conventional Commit with DCO plus Assisted-by trailers.
- clang-format-15, clang-tidy-15, a clean bounded rebuild, and git diff --check passed.
- Threshold regressions passed: 210 assertions in 18 cases.
- Exact reorder non-finite regression passed: 5 assertions.
- Basic and parallel searcher suites passed: 243,441 assertions in 6 cases.
- The exact failed dirty-vector RNG seed passed for PR and Daily variants: 5,660 assertions in 2 cases.
- A broad unit run passed all 674 cases and 85,558,877 assertions.
- The full PR path diff has zero HNSW/DiskANN source, test, or documentation paths.
- All 78 review threads were answered inline and resolved.

Fixes: #2081
