### PR TITLE
docs: document features added since v0.18

### DIFF
--- a/docs/docs/en/src/SUMMARY.md
+++ b/docs/docs/en/src/SUMMARY.md
@@ -7,6 +7,7 @@
 - [Installation](guide/installation.md)
 - [Creating an Index](guide/create_index.md)
 - [k-Nearest Neighbor Search](guide/knn_search.md)
+- [C API](guide/c_api.md)
 - [pyvsag](guide/pyvsag.md)
 
 # Indexes
@@ -46,6 +47,7 @@
 # Advanced Features
 
 - [Build and Train](advanced/build_and_train.md)
+- [HGraph Build Cache](advanced/build_cache.md)
 - [Range Search](advanced/range_search.md)
 - [Calculate Distance by ID](advanced/calc_distance_by_id.md)
 - [Filtered Search](advanced/filtered_search.md)

--- a/docs/docs/en/src/advanced/build_cache.md
+++ b/docs/docs/en/src/advanced/build_cache.md
@@ -1,0 +1,122 @@
+# HGraph Build Cache
+
+HGraph can export graph-neighbor information from one build and import it before a later
+`Build()`. Vectors are matched by stable string source IDs, so unchanged data can warm-start from
+the previous graph while new or changed data is refined normally.
+
+This workflow is intended for recurring snapshot builds, such as rebuilding an index every day
+from a mostly overlapping corpus. It is a build accelerator, not an index serialization format:
+use the normal [Serialization](serialization.md) APIs to persist a searchable index.
+
+## Requirements
+
+- The index type must be HGraph.
+- Every base dataset used in the workflow must set `Dataset::SourceID`.
+- Source IDs must be stable and unique for the logical records you want to match across builds.
+- Import the cache into a fresh, empty, compatible HGraph before calling `Build()`.
+- Keep dimensions, metrics, and storage/quantization parameters compatible between builds.
+
+The numeric label in `Dataset::Ids` may change between snapshots. Cache matching uses the
+corresponding `SourceID` string instead.
+
+## First build and cache export
+
+Provide one source ID per vector when building the source index:
+
+```cpp
+std::vector<std::string> source_ids = load_stable_source_ids();
+
+auto base = vsag::Dataset::Make();
+base->NumElements(count)
+    ->Dim(dim)
+    ->Ids(ids.data())
+    ->Float32Vectors(vectors.data())
+    ->SourceID(source_ids.data())
+    ->Owner(false);
+
+auto index = vsag::Factory::CreateIndex("hgraph", build_params).value();
+index->Build(base).value();
+
+std::ofstream cache_out("hgraph.cache", std::ios::binary);
+index->ExportCache(cache_out).value();
+```
+
+Keep the `std::string` array alive for the duration of `Build()`. The cache contains source-ID to
+neighbor information used by a later build; it is not directly searchable.
+
+## Warm-starting a later build
+
+Create an empty compatible HGraph, import the previous cache, and then build with the new snapshot:
+
+```cpp
+auto next_index = vsag::Factory::CreateIndex("hgraph", build_params).value();
+
+std::ifstream cache_in("hgraph.cache", std::ios::binary);
+next_index->ImportCache(cache_in).value();
+
+auto next_base = vsag::Dataset::Make();
+next_base->NumElements(next_count)
+    ->Dim(dim)
+    ->Ids(next_ids.data())
+    ->Float32Vectors(next_vectors.data())
+    ->SourceID(next_source_ids.data())
+    ->Owner(false);
+
+next_index->Build(next_base).value();
+```
+
+`Build()` automatically takes the cache-assisted path after `ImportCache()`. Source IDs found in
+both snapshots are warm-started from cached neighbors; unmatched records are treated as cache
+misses and refined by the normal build path. Calling cache-assisted `Build()` without
+`Dataset::SourceID` returns an invalid-argument error.
+
+## Persisting source IDs with the index
+
+Source-ID metadata is not included in HGraph serialization by default. Set
+`persist_source_id: true` in `index_param` when a deserialized index must later call
+`ExportCache()`:
+
+```json
+{
+    "dtype": "float32",
+    "metric_type": "l2",
+    "dim": 128,
+    "index_param": {
+        "base_quantization_type": "sq8",
+        "max_degree": 32,
+        "ef_construction": 400,
+        "persist_source_id": true
+    }
+}
+```
+
+This option adds source-ID metadata to the serialized index. It is unnecessary if cache export
+always happens from the original in-memory build and the restored index never needs the source
+mapping.
+
+## Measuring cache reuse
+
+After the warm-started build, call `GetStats()` and inspect:
+
+| Field | Meaning |
+| --- | --- |
+| `build_cache_hit_rate` | Fraction of nodes warm-started from the imported cache |
+| `build_cache_hit_nodes` | Matched node count |
+| `build_cache_missed_nodes` | Nodes built without a matching cache entry |
+
+When no imported cache participated in the last build, the statistics include a
+`skipped_reason` instead. See [Index Analysis](../resources/analyze_index.md) for the rest of the
+HGraph statistics.
+
+## Limitations and operational guidance
+
+- Import before `Build()`; cache-assisted build requires an empty index.
+- A build cache is tied to compatible HGraph configuration and should be regenerated after
+  incompatible parameter changes.
+- `deduplicate_storage: true` cannot be combined with cache-assisted build.
+- Validate recall and build time against a full rebuild before adopting the cache in production.
+- Check stream-open and API return values. A cache file is separate from the searchable serialized
+  index and should be versioned or replaced atomically with the snapshot that produced it.
+
+API signatures are listed under [Index Cache](../api/index_class.md#cache-build-acceleration), and
+the source-ID dataset field is documented on the [Dataset](../api/dataset.md) page.

--- a/docs/docs/en/src/advanced/calc_distance_by_id.md
+++ b/docs/docs/en/src/advanced/calc_distance_by_id.md
@@ -54,7 +54,11 @@ CalDistanceById(const DatasetPtr& query,
                 bool calculate_precise_distance = true,
                 int64_t topk = -1) const;
 ```
-For `DatasetPtr` queries with `NumElements() > 1`, check `SUPPORT_BATCH_CALC_DISTANCE_BY_ID` first. `count` is the number of IDs per query, `ids` must contain `NumElements() * count` row-major IDs, and returned distances use the same layout: `distances[q * count + j]` corresponds to `ids[q * count + j]`. When `topk > 0`, each query returns `min(topk, count)` entries sorted by distance in ascending order, and the result also contains the corresponding IDs; invalid IDs (`-1` distances) are ordered after valid distances and only appear if there are not enough valid IDs.
+For `DatasetPtr` queries with `NumElements() > 1`, check
+`SUPPORT_BATCH_CALC_DISTANCE_BY_ID` first. `count` is the number of IDs per query, `ids` must
+contain `NumElements() * count` row-major IDs, and returned distances use the same layout. When
+`topk > 0`, each query returns `min(topk, count)` entries sorted by distance in ascending order,
+and the result also contains the corresponding IDs.
 
 
 Declarations live in
@@ -71,8 +75,9 @@ Declarations live in
 ### Return Semantics
 
 - The single-ID overload returns the distance as a `float`.
-- With `topk == -1`, the batch overload returns a `DatasetPtr` whose `GetDistances()` array has
-  `count` entries aligned with the input `ids`, and it does not return IDs.
+- With `topk == -1`, the raw-pointer batch overload returns one row with `count` distances. The
+  `DatasetPtr` overload returns `NumElements()` rows with `count` distances each. Both preserve
+  input order and do not return IDs.
 - With `topk > 0`, the batch overload returns the smallest `min(topk, count)` distances per
   query, sorted ascending, and `GetIds()` contains the corresponding IDs. Invalid IDs (`-1`
   distances) are ordered after valid distances and only appear if there are not enough valid IDs.
@@ -109,6 +114,45 @@ if (result.has_value()) {
 }
 ```
 
+## Multiple Queries
+
+The `DatasetPtr` batch overload accepts more than one query when the index advertises
+`SUPPORT_BATCH_CALC_DISTANCE_BY_ID`. Candidate IDs and outputs are row-major. For LazyHGraph, the
+call is delegated to the active internal index, so actual support can change after a phase
+transition even though the wrapper advertises the feature; handle a returned error:
+
+```cpp
+// Two dense queries and three candidate IDs per query.
+auto queries = vsag::Dataset::Make()
+                   ->NumElements(2)
+                   ->Dim(dim)
+                   ->Float32Vectors(query_vectors.data())
+                   ->Owner(false);
+std::vector<int64_t> candidate_ids = {
+    10, 11, 12,  // candidates for query 0
+    20, 21, 22   // candidates for query 1
+};
+
+if (index->CheckFeature(vsag::SUPPORT_BATCH_CALC_DISTANCE_BY_ID)) {
+    auto result = index->CalDistanceById(queries, candidate_ids.data(), 3, true, /*topk=*/2);
+    if (result.has_value()) {
+        auto batch = result.value();
+        // batch has NumElements() == 2 and Dim() == 2.
+        for (int64_t q = 0; q < batch->GetNumElements(); ++q) {
+            for (int64_t j = 0; j < batch->GetDim(); ++j) {
+                const int64_t offset = q * batch->GetDim() + j;
+                std::cout << batch->GetIds()[offset] << ": "
+                          << batch->GetDistances()[offset] << '\n';
+            }
+        }
+    }
+}
+```
+
+With `topk == -1`, `GetDim()` is `count` and position `q * count + j` corresponds to input ID
+`ids[q * count + j]`. With positive `topk`, the row stride is `GetDim()`, and each row contains
+the closest valid candidates followed by invalid IDs only when fewer than `topk` valid IDs exist.
+
 A runnable example is provided in
 [`examples/cpp/306_feature_calculate_distance_by_id.cpp`](https://github.com/antgroup/vsag/blob/main/examples/cpp/306_feature_calculate_distance_by_id.cpp).
 
@@ -127,13 +171,16 @@ auto d = index->CalcDistanceById(query, /*id=*/42);
 
 ## Support Matrix
 
-| Index type   | Dense overload (`const float*`) | DatasetPtr overload | Notes |
-|--------------|---------------------------------|---------------------|-------|
-| hgraph       | yes                             | yes                 | Honors `calculate_precise_distance`. |
-| ivf          | yes                             | yes (default loop)  | |
-| brute_force  | yes                             | yes (default loop)  | Always precise (no quantization). |
-| pyramid      | yes                             | yes (default loop)  | |
-| sindi        | no                              | yes                 | Sparse vectors only. |
+| Index type | Single-ID dense (`const float*`) | Single-ID DatasetPtr | Multi-query DatasetPtr batch | Notes |
+|------------|-----------------------------------|----------------------|------------------------------|-------|
+| hgraph | yes | yes | when the feature is advertised | Honors `calculate_precise_distance`. |
+| ivf | yes | yes | when the feature is advertised | Availability depends on retained precise storage. |
+| brute_force | yes | yes | when the feature is advertised | Dense single-vector indexes only. |
+| pyramid | yes | yes | yes | |
+| lazy_hgraph | yes | no | depends on the active internal index | DatasetPtr batch calls delegate to the active BruteForce/HGraph; availability can change after a phase transition. |
+| sindi | no | yes | yes | Sparse vectors only. |
+| hnsw | yes | no | no | Dense batch supports `topk == -1` only. |
+| diskann | yes | no | no | Dense batch supports `topk == -1` only. |
 
 Indexes that do not implement the API surface for a given overload return an
 `UNSUPPORTED_INDEX_OPERATION` error.

--- a/docs/docs/en/src/advanced/introspection.md
+++ b/docs/docs/en/src/advanced/introspection.md
@@ -51,8 +51,12 @@ query_ds->NumElements(1)->SparseVectors(/* ... */);
 auto r = index->CalDistanceById(query_ds, ids, count, /*calculate_precise_distance=*/true);
 ```
 
-The result `Dataset` holds `count` distances in `GetDistances()`. A value of `-1.0F` means the
-corresponding id was invalid (not present in the index).
+The raw-pointer overload returns one row of `count` distances. The `DatasetPtr` overload can
+process several queries on indexes that advertise `SUPPORT_BATCH_CALC_DISTANCE_BY_ID`: candidate
+IDs and distances then form `NumElements() * count` row-major matrices. A value of `-1.0F` means
+the corresponding ID was invalid. A positive `topk` returns the nearest candidates per row,
+sorted by distance, together with their IDs. See
+[Calculate Distance by ID](calc_distance_by_id.md) for the layout and support matrix.
 
 ### `calculate_precise_distance`
 

--- a/docs/docs/en/src/advanced/quantization_transform.md
+++ b/docs/docs/en/src/advanced/quantization_transform.md
@@ -133,16 +133,19 @@ The transformer JSON is read by `VectorTransformerParameter::FromJson`
 
 ### HGraph external mapping
 
-When using HGraph, two top-level shortcuts are mapped into the nested quantizer params
-(`src/algorithm/hgraph.cpp:370-385`):
+When using HGraph, top-level shortcuts are mapped into the nested quantizer params:
 
 - `tq_chain` → `base_codes.quantization_params.tq_chain`
 - `rabitq_pca_dim` → `base_codes.quantization_params.pca_dim`
+- `mrle_dim` → `base_codes.quantization_params.mrle_dim`
 
 The name `rabitq_pca_dim` predates Transform Quantizer; when the chain includes `pca`, it
 drives the **`pca` transformer's output dim** (it is not RaBitQ-specific). When the chain
 ends in `rabitq` without `pca`, the same key configures RaBitQ's own PCA preprocessing
 (`src/quantization/rabitq_quantization/rabitq_quantizer_parameter.cpp:30`).
+
+`mrle_dim` accepts an integer in `[0, dim]`; `0` means the input dimension. It has an effect when
+`tq_chain` includes `mrle`, which must remain the first transform in the chain.
 
 ## Reordering and the precise codes store
 

--- a/docs/docs/en/src/api/dataset.md
+++ b/docs/docs/en/src/api/dataset.md
@@ -55,7 +55,8 @@ DatasetPtr DeepCopy(Allocator* allocator = nullptr) const;  // independent copy
 
 ## Vector payloads
 
-A dataset carries exactly one vector representation, chosen to match the index's `dtype`:
+A dataset carries exactly one vector representation. Select the payload setter from both the
+index's scalar `dtype` and record-layout `repr`:
 
 | Setter | Getter | Element type | Use with |
 |--------|--------|--------------|----------|
@@ -65,6 +66,8 @@ A dataset carries exactly one vector representation, chosen to match the index's
 | `SparseVectors(const SparseVector*)` | `GetSparseVectors()` | [`SparseVector`](#sparsevector) | `dtype: sparse` (SINDI) |
 
 Dense vectors are laid out row-major: element `i`, dimension `j` lives at `vectors[i * dim + j]`.
+Multi-vector datasets use `repr: multi_vector` with a scalar `dtype`, normally `float32`, and the
+payload described below.
 
 ### Multi-vector payloads
 
@@ -85,10 +88,11 @@ For documents that hold several dense sub-vectors each:
 | `ExtraInfoSize(int64_t)` | `GetExtraInfoSize()` | `int64_t` | Bytes per extra-info blob. |
 | `Paths(const std::string*)` | `GetPaths()` | `const std::string*` | Hierarchy paths (Pyramid). Default hierarchy. |
 | `Paths(const std::string& hierarchy, const std::string*)` | `GetPaths(const std::string& hierarchy)` | `const std::string*` | Paths for a named hierarchy. |
-| `SourceID(const std::string*)` | `GetSourceID()` | `const std::string*` | Optional source identifier. |
+| `SourceID(const std::string*)` | `GetSourceID()` | `const std::string*` | Optional stable source identifier per element; HGraph uses it to match build-cache entries across snapshots. |
 
-See [Attribute Filter (Hybrid Search)](../advanced/attribute_filter.md) and
-[Extra Info](../advanced/extra_info.md).
+See [Attribute Filter (Hybrid Search)](../advanced/attribute_filter.md),
+[Extra Info](../advanced/extra_info.md), and
+[HGraph Build Cache](../advanced/build_cache.md).
 
 ## Diagnostics payloads
 

--- a/docs/docs/en/src/api/index_class.md
+++ b/docs/docs/en/src/api/index_class.md
@@ -285,6 +285,10 @@ and `examples/cpp/401_persistent_kv.cpp` / `402_persistent_streaming.cpp`.
 | `ExportCache` | `tl::expected<void, Error> ExportCache(std::ostream& out_stream) const` | Writes a build-time cache (e.g. graph neighbors) that can accelerate a later `Build`. |
 | `ImportCache` | `tl::expected<void, Error> ImportCache(std::istream& in_stream)` | Loads a previously exported cache; the next `Build` reuses it. |
 
+HGraph matches cache entries by `Dataset::SourceID`. Import into an empty compatible index before
+`Build()`; see [HGraph Build Cache](../advanced/build_cache.md) for the complete workflow,
+`persist_source_id`, and hit-rate diagnostics.
+
 ## Statistics & introspection
 
 Unless noted, these return values directly. **The methods marked "throws" raise

--- a/docs/docs/en/src/development/building.md
+++ b/docs/docs/en/src/development/building.md
@@ -4,11 +4,12 @@ This page documents how to build VSAG from source.
 
 ## Prerequisites
 
-- **OS**: Ubuntu 20.04+ or CentOS 7+
-- **Compiler**: GCC 9.4.0+ or Clang 13.0.0+
+- **OS**: Ubuntu 20.04+, CentOS 7+, or macOS 14+ on Apple Silicon
+- **Compiler**: GCC 9.4.0+, Clang 13.0.0+, or Apple Clang from Xcode Command Line Tools
 - **CMake**: 3.18.0+
 - **clang-format / clang-tidy**: exactly version 15 (enforced)
-- Optional: HDF5 (for `tools/eval/eval_performance`), libaio (for DiskANN async IO), Intel MKL.
+- Optional: HDF5 (for `tools/eval/eval_performance`), libaio (for DiskANN async IO),
+  liburing (for `uring_io` on Linux), Intel MKL.
 
 We recommend using the official Docker dev image, which already contains the matching toolchain:
 
@@ -44,8 +45,12 @@ clean       Remove build trees
 ```bash
 git clone https://github.com/antgroup/vsag.git
 cd vsag
+./scripts/deps/install_deps.sh
 make release
 ```
+
+The dependency script selects the matching Linux distribution or macOS installer. macOS support
+currently targets the arm64 C++ build; published archives and Python wheels remain Linux-focused.
 
 Resulting binaries from a plain `make release`:
 
@@ -66,6 +71,7 @@ cache options (`ENABLE_*`). Defaults below reflect a plain `make release`.
 | `VSAG_ENABLE_LIBAIO` | `ENABLE_LIBAIO` | `ON` on Linux | Enable DiskANN async IO via libaio |
 | `VSAG_ENABLE_TOOLS` | `ENABLE_TOOLS` | `OFF` | Build utilities under `tools/` |
 | `VSAG_ENABLE_EXAMPLES` | `ENABLE_EXAMPLES` | `OFF` | Build sample programs under `examples/cpp/` |
+| n/a | `ENABLE_LIBURING` | `OFF` | Enable the Linux `uring_io` backend when liburing is installed |
 | n/a | `CMAKE_BUILD_TYPE` | driven by Makefile target | Debug / Release |
 
 When invoking CMake directly instead of using `make`, use the underlying CMake cache option names:
@@ -74,6 +80,10 @@ When invoking CMake directly instead of using `make`, use the underlying CMake c
 cmake -S . -B build-release -DCMAKE_BUILD_TYPE=Release -DENABLE_INTEL_MKL=ON
 cmake --build build-release -j
 ```
+
+To enable `io_uring`, install liburing and add `-DENABLE_LIBURING=ON`. On non-Linux systems or
+when liburing is unavailable, VSAG compiles without native `io_uring` support; a configuration
+that requests `uring_io` then logs a one-time warning and falls back to `buffer_io`.
 
 ## Offline / Air-gapped Builds
 

--- a/docs/docs/en/src/guide/c_api.md
+++ b/docs/docs/en/src/guide/c_api.md
@@ -1,0 +1,118 @@
+# C API
+
+VSAG exports a C ABI in `include/vsag/vsag_c_api.h`. It wraps the same index implementations as
+the C++ API and is useful for language bindings and applications that need opaque handles and
+C-style functions.
+
+The current installed header is not directly includable from a C translation unit: it contains an
+unguarded `extern "C"` block and uses C++ `bool`. Compile the translation unit that includes this
+header as C++ (for example, use a `.cpp` file). If the rest of the application is written in C,
+expose the required operations through a small application-owned C wrapper.
+
+## Lifecycle
+
+Include the installed header from a C++ translation unit and link the normal VSAG library:
+
+```cpp
+#include <vsag/vsag_c_api.h>
+```
+
+The basic lifecycle is:
+
+1. Create an opaque `vsag_index_t` with `vsag_index_factory`.
+2. Build or train/add vectors.
+3. Search, update, serialize, or query the index.
+4. Release the handle with `vsag_index_destroy`.
+
+`vsag_index_factory` returns `nullptr` when creation fails. Other functions return `Error_t`;
+`code == VSAG_SUCCESS` indicates success and `message` contains error details otherwise.
+
+```cpp
+const char* build_params =
+    "{\"dtype\":\"float32\",\"metric_type\":\"l2\",\"dim\":128,"
+    "\"index_param\":{\"base_quantization_type\":\"fp32\","
+    "\"max_degree\":32,\"ef_construction\":200}}";
+
+vsag_index_t index = vsag_index_factory("hgraph", build_params);
+if (index == nullptr) {
+    /* handle creation failure */
+}
+
+Error_t error = vsag_index_build(index, base, ids, 128, count);
+if (error.code != VSAG_SUCCESS) {
+    /* inspect error.message */
+}
+
+vsag_index_destroy(index);
+```
+
+## Search result buffers
+
+The caller owns the `ids` and `dists` buffers in `SearchResult_t`. Allocate at least `k` entries
+for both buffers before KNN or range search. VSAG writes no more than `k` results and stores the
+actual number in `count`.
+
+```cpp
+int64_t result_ids[10];
+float result_dists[10];
+SearchResult_t result{};
+result.dists = result_dists;
+result.ids = result_ids;
+
+Error_t error =
+    vsag_index_knn_search(index, query, 128, 10, "{\"hgraph\":{\"ef_search\":100}}", &result);
+```
+
+The filter variants accept a `FilterFunc_t`. Returning `true` means the ID is valid and may be
+returned.
+
+## Range search result cap
+
+Both C range-search functions require an explicit positive result cap:
+
+```cpp
+Error_t
+vsag_index_range_search(vsag_index_t index,
+                        const float* query,
+                        uint64_t dim,
+                        float radius,
+                        int64_t k,
+                        const char* parameters,
+                        SearchResult_t* result);
+```
+
+`k` must be at least `1`. It is forwarded to the C++ range-search `limited_size` argument and
+also protects the caller-owned buffers: `result.count` never exceeds `k`. Applications upgrading
+from the older signature must add this argument to both `vsag_index_range_search` and
+`vsag_index_range_search_with_filter`.
+
+## API groups
+
+- **Create and destroy:** `vsag_index_factory`, `vsag_index_destroy`.
+- **Populate:** `vsag_index_build`, `vsag_index_train`, `vsag_index_add`.
+- **Search:** `vsag_index_knn_search`, `vsag_index_range_search`, and their filter variants.
+- **Read and update:** `vsag_index_calculate_distance_by_ids`,
+  `vsag_index_get_vector_by_ids`, `vsag_index_update_ids`, `vsag_index_update_vector`, and
+  `vsag_index_update_vector_force`.
+- **Copy and reuse:** `vsag_index_clone`, `vsag_index_export_model`.
+- **Persistence:** `vsag_serialize_file`, `vsag_deserialize_file`,
+  `vsag_serialize_write_func`, and `vsag_deserialize_read_func`.
+
+Support still depends on the selected index. An unsupported operation returns
+`VSAG_UNSUPPORTED_INDEX_OPERATION`.
+
+## Persistence errors
+
+`vsag_serialize_file` and `vsag_deserialize_file` validate that the target file can be opened.
+Check the returned `Error_t` for `VSAG_READ_ERROR`, `VSAG_MISSING_FILE`, or another non-success
+code instead of assuming a file operation completed.
+
+The callback-based persistence functions are available when the application manages its own
+storage. Their callback offsets and sizes use the `OffsetType` and `SizeType` aliases declared in
+the header.
+
+## Reference
+
+`include/vsag/vsag_c_api.h` is the complete source-level reference for signatures, error codes,
+callbacks, and structures. Search parameters use the same JSON objects documented on the
+corresponding [index pages](../indexes/README.md).

--- a/docs/docs/en/src/guide/installation.md
+++ b/docs/docs/en/src/guide/installation.md
@@ -17,8 +17,8 @@ docker run -it --rm -v $(pwd):/work -w /work vsaglib/vsag:ubuntu bash
 
 ### Requirements
 
-- **Operating System**: Ubuntu 20.04+ or CentOS 7+
-- **Compiler**: GCC 9.4.0+ or Clang 13.0.0+
+- **Operating System**: Ubuntu 20.04+, CentOS 7+, or macOS 14+ on Apple Silicon
+- **Compiler**: GCC 9.4.0+, Clang 13.0.0+, or Apple Clang from Xcode Command Line Tools
 - **CMake**: 3.18.0+
 - **clang-format / clang-tidy**: exactly version **15** (enforced by `make fmt` / `make lint`)
 
@@ -27,8 +27,14 @@ docker run -it --rm -v $(pwd):/work -w /work vsaglib/vsag:ubuntu bash
 ```bash
 git clone https://github.com/antgroup/vsag.git
 cd vsag
+./scripts/deps/install_deps.sh
 make release
 ```
+
+The dependency script detects Linux versus macOS. On macOS it installs or locates the
+Homebrew dependencies and uses Apple's Accelerate framework where appropriate. The supported
+macOS path is the arm64 C++ library build; published C++ archives and `pyvsag` wheels remain
+Linux-focused.
 
 Other common Makefile targets:
 
@@ -62,9 +68,11 @@ Enable or disable at CMake configure time with these cache options:
 
 - `ENABLE_INTEL_MKL=ON` — Intel MKL acceleration.
 - `ENABLE_LIBAIO=ON` — Linux AIO for DiskANN async IO.
+- `ENABLE_LIBURING=ON` — Linux `io_uring` backend; requires liburing.
 - `ENABLE_TOOLS=ON` — build tools under `tools/` (including `eval_performance`).
 - `ENABLE_EXAMPLES=ON` — build sample programs under `examples/cpp/`.
 
 If you build through the project Makefile, the corresponding environment variables are
 `VSAG_ENABLE_INTEL_MKL=ON`, `VSAG_ENABLE_LIBAIO=ON`, `VSAG_ENABLE_TOOLS=ON`, and
-`VSAG_ENABLE_EXAMPLES=ON`.
+`VSAG_ENABLE_EXAMPLES=ON`. `ENABLE_LIBURING` is currently a direct CMake option; configure it
+with `cmake -S . -B build-release -DENABLE_LIBURING=ON`.

--- a/docs/docs/en/src/guide/pyvsag.md
+++ b/docs/docs/en/src/guide/pyvsag.md
@@ -64,6 +64,50 @@ new_index = pyvsag.Index("hgraph", index_params)
 new_index.load("index.bin")
 ```
 
+The current `save` and `load` wrappers do not propagate errors returned by the underlying
+serialization and deserialization operations. Verify that the output file was created and
+round-trip important indexes before relying on persisted data.
+
+## Index Operations
+
+The Python binding exposes the following index-management methods in addition to build, search,
+save, and load:
+
+| Method | Result | Notes |
+| --- | --- | --- |
+| `get_num_elements()` | `int` | Current number of elements. |
+| `get_memory_usage()` | `int` | Index memory usage in bytes. |
+| `check_id_exist(id)` | `bool` | Whether an ID currently exists. |
+| `get_min_max_id()` | `(min_id, max_id)` | Returns `(-1, -1)` if the operation fails. |
+| `add(vectors, ids, num_elements, dim)` | `None` | Adds a contiguous dense vector matrix; dtype must match the index. |
+| `remove(ids)` | `int` | Removes a one-dimensional `int64` ID array. Returns `0` both when no ID is removed and when the underlying operation fails. |
+| `cal_distance_by_id(query, ids)` | `numpy.ndarray` | Returns one float32 distance per ID. Invalid IDs produce `-1`; an underlying operation failure leaves the entire result at `-1`. |
+
+```python
+# Add two dense vectors.
+new_vectors = np.random.random((2, dim)).astype(np.float32)
+new_ids = np.array([10_001, 10_002], dtype=np.int64)
+index.add(new_vectors, new_ids, len(new_ids), dim)
+
+assert index.check_id_exist(10_001)
+print(index.get_num_elements(), index.get_memory_usage())
+print(index.get_min_max_id())
+
+# Calculate distances from one query to a candidate list.
+candidate_ids = np.array([10_001, 10_002], dtype=np.int64)
+distances = index.cal_distance_by_id(query, candidate_ids)
+
+# Remove IDs; the return value is the number actually removed.
+removed = index.remove(candidate_ids)
+```
+
+`add` accepts a flat contiguous array or a row-major two-dimensional matrix. For
+`dtype: "float16"`, pass `numpy.float16`; for `dtype: "bfloat16"`, pass a `numpy.uint16`
+array containing BF16 bit patterns. Operation support remains index-dependent. Input validation
+and operations such as `add` raise Python exceptions, but `remove`, `cal_distance_by_id`, `save`,
+and `load` use the sentinel or unchecked behaviors described above instead of consistently
+propagating underlying operation failures.
+
 ## Relationship with the C++ Library
 
 `pyvsag` wraps the same `vsag::Index` API as C++ and shares the underlying index binaries. You can

--- a/docs/docs/en/src/indexes/hgraph.md
+++ b/docs/docs/en/src/indexes/hgraph.md
@@ -68,9 +68,15 @@ most users need; the exhaustive list is in [Index Parameters](../resources/index
 | `max_degree` | int | `64` | Maximum out-degree per graph node |
 | `ef_construction` | int | `400` | Candidate list size during build (higher = better recall, slower build) |
 | `graph_type` | string | `"nsw"` | Graph algorithm: `nsw` or `odescent` |
+| `use_reverse_edges` | bool | `false` | Track incoming neighbors for O(1) reverse-edge lookup. Roughly doubles edge storage and is unsupported with `graph_storage_type: "compressed"`. |
+| `label_remap_type` | string | `"pg"` | Label-to-inner-ID map implementation: `"pg"` or `"robin"`. Keep the same value when restoring or combining compatible indexes. |
 | `use_reorder` | bool | `false` | Keep a high-precision copy and re-rank after the coarse search |
+| `reorder_source` | string | `"precise"` | Reorder from `"precise"` codes or directly from `"base"` codes. RaBitQ x+y split sets `"base"` automatically. |
 | `precise_quantization_type` | string | `"fp32"` | Quantizer used for reordering (takes effect only with `use_reorder: true`) |
 | `base_pq_dim` | int | `1` | Number of PQ subspaces. When using `pq` / `pqfs`, set this explicitly instead of relying on the default. |
+| `mrle_dim` | int | `0` | Output dimension for an MRLE transform in `tq_chain`; allowed range `[0, dim]`, where `0` means the input dimension. |
+| `fast_encode_rabitq` | bool | `true` | Use the fast multi-bit RaBitQ encoder; set to `false` for the previous exact encoder. |
+| `fast_encode_rabitq_rounds` | int | `6` | Fast RaBitQ coordinate-refinement rounds, in `[1, 32]`. |
 | `build_thread_count` | int | `100` | Threads used to parallelise build |
 | `support_duplicate` | bool | `false` | Enable duplicate-ID detection on insert |
 | `deduplicate_storage` | bool | `false` | Share vector storage between duplicates; requires `support_duplicate: true` |
@@ -79,9 +85,19 @@ most users need; the exhaustive list is in [Index Parameters](../resources/index
 | `support_force_remove` | bool | `false` | Enable `RemoveMode::FORCE_REMOVE` and its extra synchronization on the built index |
 | `store_raw_vector` | bool | `false` | Keep the raw vector in addition to the quantized copy (useful for `cosine`) |
 | `use_elp_optimizer` | bool | `false` | Auto-tune search parameters after build |
-| `base_io_type` / `precise_io_type` | string | `"block_memory_io"` | Storage backend (`memory_io`, `block_memory_io`, `buffer_io`, `async_io`, `mmap_io`) |
-| `base_file_path` / `precise_file_path` | string | — | File path; required when the corresponding `*_io_type` is disk-backed (`buffer_io`, `async_io`, `mmap_io`) |
+| `base_io_type` / `precise_io_type` | string | `"block_memory_io"` | Storage backend (`memory_io`, `block_memory_io`, `buffer_io`, `async_io`, `uring_io`, `mmap_io`) |
+| `base_file_path` / `precise_file_path` | string | — | File path; required when the corresponding `*_io_type` is disk-backed (`buffer_io`, `async_io`, `uring_io`, `mmap_io`) |
+| `base_direct_read` / `precise_direct_read` | bool | `false` | With `uring_io`, open the corresponding file using direct IO instead of the page cache. |
 | `hgraph_init_capacity` | int | `100` | Initial capacity hint (doesn't cap the final size) |
+| `persist_source_id` | bool | `false` | Persist source-ID metadata during serialization so a restored index can later export a reusable build cache. |
+
+`use_reverse_edges` is intended for workloads that need fast incoming-neighbor inspection, graph
+analysis, or future graph-maintenance algorithms. It is disabled by default because maintaining
+the reverse adjacency approximately doubles edge storage.
+
+`label_remap_type` changes the internal label map, not user-visible IDs. `"pg"` is the default;
+`"robin"` selects the alternate robin-map implementation. Benchmark the target ID distribution
+before changing it.
 
 ### Deduplicating vector storage
 
@@ -222,7 +238,7 @@ Search-time parameters live under the `hgraph` sub-object:
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `ef_search` | int | — (required) | Size of the search frontier. Larger = higher recall, slower query. |
+| `ef_search` | int64 | — (required) | Positive search-frontier size. Any value up to `INT64_MAX` is accepted; there is no `topk`-relative upper bound. Larger values increase recall, latency, and frontier memory. |
 | `hops_limit` | int | unlimited | Hard cap on the number of hops the beam search performs before returning the current frontier. |
 | `skip_ratio` | float | `0.2` | Performance tuning parameter for filtered search. Controls the ratio of invalid points to skip, in range `[0.0, 1.0]`. `skip_ratio=0.2` means skip 20% of invalid points and only check 80%. Higher values improve performance but may reduce recall. Only applies to searches with filters. See [Filter Skip Strategy](#filter-skip-strategy-skip_ratio-and-skip_strategy) below. |
 | `skip_strategy` | string | `"deterministic_accumulative"` | Strategy for filter skipping. Options: `"random"` (random skipping) or `"deterministic_accumulative"` (deterministic cumulative skipping). See [Filter Skip Strategy](#filter-skip-strategy-skip_ratio-and-skip_strategy) below. |
@@ -343,6 +359,10 @@ Important notes:
 - Mixed workloads with incremental insertion (optionally force removal via `support_force_remove`).
 - Memory-constrained deployments that benefit from `sq8` / `sq4_uniform` / `pq` — often
   in combination with `use_reorder` to recover recall.
+
+For repeated daily or snapshot builds with stable source identifiers, see
+[HGraph Build Cache](../advanced/build_cache.md). It documents `Dataset::SourceID`,
+`ExportCache`/`ImportCache`, `persist_source_id`, and cache hit-rate diagnostics.
 
 If your workload is partition-heavy (coarse-grained buckets scanned per query) or
 strongly I/O-bound on a SSD, compare against [IVF](ivf.md) before committing to HGraph.

--- a/docs/docs/en/src/indexes/ivf.md
+++ b/docs/docs/en/src/indexes/ivf.md
@@ -88,8 +88,8 @@ Build-time parameters live under `index_param`. See
 | `fast_encode_rabitq_rounds` | int | `6` | CAQ adjustment rounds; allowed range is `[1, 32]` |
 | `use_reorder` | bool | `false` | Keep a high-precision copy and re-rank after the coarse scan |
 | `precise_quantization_type` | string | `"fp32"` | Quantizer used for reordering (with `use_reorder: true`) |
-| `base_io_type` | string | `"memory_io"` | Storage backend for coarse codes |
-| `precise_io_type` | string | `"block_memory_io"` | Storage backend for precise codes (`memory_io`, `block_memory_io`, `mmap_io`, `buffer_io`, `async_io`, `reader_io`) |
+| `base_io_type` | string | `"memory_io"` | Storage backend for coarse codes; supports `uring_io` when built with liburing |
+| `precise_io_type` | string | `"block_memory_io"` | Storage backend for precise codes (`memory_io`, `block_memory_io`, `mmap_io`, `buffer_io`, `async_io`, `uring_io`, `reader_io`) |
 | `precise_file_path` | string | `""` | File path when the precise IO type is disk-backed |
 
 A rule of thumb for `buckets_count` is `sqrt(N)` to `4 * sqrt(N)` where `N` is the

--- a/docs/docs/en/src/indexes/pyramid.md
+++ b/docs/docs/en/src/indexes/pyramid.md
@@ -94,6 +94,10 @@ Build-time parameters live under `index_param`.
 | `no_build_levels` | int[] | `[]` | Tree levels that skip graph construction (0-indexed from the root). |
 | `use_reorder` | bool | `false` | Keep a high-precision copy for rescoring. |
 | `precise_quantization_type` | string | `"fp32"` | Quantizer for reordering. |
+| `fast_encode_rabitq` | bool | `true` | Use the fast multi-bit RaBitQ encoder for RaBitQ base or precise storage; set to `false` for the exact encoder. |
+| `fast_encode_rabitq_rounds` | int | `6` | Fast RaBitQ refinement rounds in `[1, 32]`. |
+| `base_io_type` / `precise_io_type` | string | `"block_memory_io"` | Base and reorder storage backends; `uring_io` is available in builds with liburing. |
+| `base_file_path` / `precise_file_path` | string | — | Required for disk-backed storage such as `buffer_io`, `async_io`, `uring_io`, or `mmap_io`. |
 | `index_min_size` | int | `0` | Minimum sub-index size; smaller groups fall back to scan. |
 | `support_duplicate` | bool | `false` | Allow duplicate ids. |
 | `build_thread_count` | int | `1` | Threads used for parallel build. |
@@ -249,6 +253,10 @@ new_index->Deserialize(binary_set);
 
 If you don't need path-based scoping, [HGraph](hgraph.md) is simpler and generally
 faster.
+
+Use [Index Analysis](../resources/analyze_index.md) to inspect Pyramid tree structure,
+per-subindex quality, sampled base recall, and duplicate ratios reported by `GetStats()`. Pyramid
+does not currently expose query-driven metrics through `AnalyzeIndexBySearch`.
 
 ## Mark remove
 

--- a/docs/docs/en/src/indexes/simq.md
+++ b/docs/docs/en/src/indexes/simq.md
@@ -115,10 +115,11 @@ SIMQ-specific build parameters live under `index_param`. The common fields
 | `rerank_k` | int | `100` | Default max rerank candidates at build time. |
 
 - **`dim`** — shared across all documents and queries.
-- **`base_io_type`** — supported values: `async_io`, `memory_io`,
-  `block_memory_io`, `buffer_io`, `mmap_io`, `reader_io`.
+- **`base_io_type`** — supported values: `async_io`, `uring_io`, `memory_io`,
+  `block_memory_io`, `buffer_io`, `mmap_io`, `reader_io`. Native `uring_io`
+  requires a build with liburing; otherwise it falls back to `buffer_io`.
 - **`base_file_path`** — the default is a placeholder; provide a real path
-  when using a disk-backed type (`async_io`, `buffer_io`, `mmap_io`).
+  when using a disk-backed type (`async_io`, `uring_io`, `buffer_io`, `mmap_io`).
 - **`init_cluster_ratio`** — range `(0, 1]`. Smaller values yield fewer,
   larger clusters; larger values produce more, finer-grained clusters.
 - **`max_cluster_size`** — must be > 1.
@@ -154,6 +155,31 @@ auto result = index->KnnSearch(
     query, topk,
     R"({"simq": {"coarse_k": 600, "rerank_k": 5000}})").value();
 ```
+
+## Search statistics
+
+`KnnSearch` and `RangeSearch` attach a JSON statistics object to the returned dataset. Read the
+complete object or request individual values:
+
+```cpp
+std::cout << result->GetStatistics() << '\n';
+auto values = result->GetStatistics(
+    {"simq_coarse_candidate_count", "simq_rerank_candidate_count"});
+```
+
+| Key | Meaning |
+|-----|---------|
+| `dist_cmp` | Exact MaxSim distance comparisons during reranking |
+| `simq_coarse_dist_cmp` | Distance comparisons performed by representative-graph searches |
+| `simq_coarse_probe_count` | Representative clusters probed across all query tokens |
+| `simq_coarse_candidate_count` | Unique document candidates produced by coarse search before applying `rerank_k` |
+| `simq_rerank_candidate_count` | Candidates retained after applying `rerank_k` |
+| `simq_filtered_candidate_count` | Rerank candidates rejected by the supplied filter |
+| `simq_result_count` | Results returned after reranking and range/top-k limits |
+| `simq_limited_size_applied` | Whether `RangeSearch` truncated matches to `limited_size` |
+
+These counters make it possible to distinguish a narrow coarse candidate pool from filtering,
+reranking, and output-limit effects when tuning recall and latency.
 
 ## When to use SIMQ
 

--- a/docs/docs/en/src/indexes/sindi.md
+++ b/docs/docs/en/src/indexes/sindi.md
@@ -16,8 +16,8 @@ pairs and is the only VSAG index that accepts `dtype: "sparse"`.
    (`window_size`). Within each window, an inverted list per term maps a term id
    to the `(doc_id, value)` pairs that mention it.
 2. **Optional pruning and quantization.** During construction, `doc_prune_ratio`
-   drops low-weight terms per document, and `use_quantization` compresses the term
-   values to shrink memory further.
+   drops low-weight terms per document. `use_quantization: true` stores SQ8 values,
+   while `use_quantization: "fp16"` stores half-precision values.
 3. **Scoring.** At query time, SINDI iterates the non-zero terms of the query,
    walks the corresponding inverted lists in each window, aggregates contributions
    into a max-heap of size `n_candidate`, and returns the top-k. When `use_reorder`
@@ -75,16 +75,62 @@ and `metric_type` **must** be `"ip"`.
 | `term_id_limit` | int | `1000000` | Upper bound on term id values (≥ max term id + 1, up to 50 000 000). |
 | `window_size` | int | `50000` | Documents per window (range: 10 000 – 60 000). |
 | `doc_prune_ratio` | float | `0.0` | Fraction of lowest-weight terms dropped per doc at build time (0.0 – 0.9). |
-| `use_quantization` | bool | `false` | Quantize stored term values to cut memory; when enabled, uses 8-bit scalar quantization (SQ8). |
+| `use_quantization` | bool or string | `false` | `false` stores FP32 values, `true` stores SQ8 values, and `"fp16"` stores FP16 values. |
 | `use_reorder` | bool | `false` | Keep a forward store and rescore candidates after coarse SINDI scoring. |
 | `rerank_type` | string | `"fp32"` | Forward-store type used when `use_reorder` is enabled. `fp32` keeps exact values; `dmq8` stores compressed 8-bit DMQ codes. |
 | `remap_term_ids` | bool | `false` | Remap term IDs before indexing; useful when term IDs are sparse or have large gaps. |
 | `avg_doc_term_length` | int | `100` | Hint for memory estimation only. |
+| `immutable` | bool | `false` | Build or load the compact read-only runtime. `Build()` compacts completed windows as it proceeds to reduce peak memory; incremental `Add()` is rejected. |
 
 > **`dim` vs `term_id_limit`.** For the sparse vector `{0:0.1, 2:0.5, 177:0.8}`,
 > `dim` is `3` (three non-zero entries) while `term_id_limit` must be ≥ `178`
 > (largest term id + 1). Sizing `term_id_limit` to your vocabulary is the most
 > common first-time mistake.
+
+### Sparse value formats
+
+`use_quantization` retains its legacy boolean behavior and also accepts one string value:
+
+| Value | Stored value format | Trade-off |
+| --- | --- | --- |
+| `false` | FP32 | Highest value precision and largest posting payload |
+| `true` | SQ8 | Smallest posting values; quantization range is learned during the initial build |
+| `"fp16"` | FP16 | Half the FP32 value bytes without SQ8 range calibration |
+
+Indexes built with `false` or `true` retain the legacy serialization representation. Older VSAG
+versions cannot parse a SINDI index that uses the new `"fp16"` value format; upgrade readers
+before deploying FP16 artifacts.
+
+### Immutable low-memory build
+
+Set `immutable: true` when the completed SINDI index is read-only:
+
+```json
+{
+    "dtype": "sparse",
+    "metric_type": "ip",
+    "dim": 1024,
+    "index_param": {
+        "term_id_limit": 30000,
+        "window_size": 50000,
+        "use_quantization": "fp16",
+        "remap_term_ids": true,
+        "immutable": true
+    }
+}
+```
+
+During `Build()`, each completed mutable window is compacted into an immutable payload and the
+temporary window is released before construction continues. In the Sparse4M FP16 measurement
+reported with this feature, peak build memory fell from 27.03 GB to 6.08 GB (77.51% lower), while
+build time increased from about 330 seconds to 599 seconds. Treat these figures as workload-specific
+evidence, not a capacity guarantee.
+
+The immutable runtime supports KNN and range search plus legacy `Serialize`/`Deserialize`.
+It rejects incremental `Add`, `GetSparseVectorByInnerId`, `CalcDistanceById`, and
+`CalDistanceById`. Streaming serialization is not supported for immutable SINDI; use the matching
+legacy serialization APIs or keep the index mutable when the streaming format is required.
+The serialized index must be loaded into a SINDI created with the same `immutable` setting.
 
 ## Search parameters
 
@@ -115,10 +161,12 @@ auto result = index->KnnSearch(
 - Sparse retrieval with BM25, SPLADE, uniCOIL, or similar learned-sparse encoders.
 - Hybrid dense+sparse pipelines where SINDI handles the sparse leg in parallel with
   HGraph / IVF for dense embeddings.
-- Memory-constrained deployments of sparse corpora (`use_quantization: true`
-  roughly halves inverted-list memory with a small recall loss; `use_reorder:
+- Memory-constrained deployments of sparse corpora (`use_quantization: true` selects SQ8,
+  while `"fp16"` halves FP32 value bytes; `use_reorder:
   true` trades forward-store memory for recall, and `rerank_type: "dmq8"` reduces
   that forward-store overhead).
+- Read-only snapshots that need lower peak build memory (`immutable: true`), accepting slower
+  construction and no incremental writes.
 
 SINDI does **not** accept dense vectors and supports only inner-product similarity.
 Range search and id-based filtering are supported; see the example for usage.
@@ -156,6 +204,9 @@ When `rerank_type` is `dmq8`, codebooks are fixed by the initial build, so incre
      range, such as hash-based tokenizers, external vocabulary IDs, or vocabularies
      with large gaps, enable `remap_term_ids: true`. This avoids managing many
      empty posting lists and helps stay below the `term_id_limit` ceiling.
+5. Read-only low-memory build. Add `immutable: true`, normally together with
+     `use_quantization: "fp16"` and `remap_term_ids: true`, when peak build memory matters more
+     than build speed and the finished index will not receive incremental writes.
 
 ## Mark remove
 

--- a/docs/docs/en/src/resources/analyze_index.md
+++ b/docs/docs/en/src/resources/analyze_index.md
@@ -17,14 +17,17 @@ AnalyzeIndexBySearch(const SearchRequest& request);
 
 - **Input**: a `SearchRequest` (query dataset + `topk` + search parameter JSON).
 - **Output**: a JSON-formatted string containing dynamic, query-driven metrics.
-- **Supported indexes**: currently `HGraph`, `IVF`, and `SINDI`. `Pyramid` only supports static
-  analysis through `GetStats()` — it does not yet override `AnalyzeIndexBySearch`. Indexes that do
-  not implement this API will throw an exception when called.
+- **Supported indexes**: currently `HGraph`, `IVF`, and `SINDI`. Indexes that do not
+  implement this API will throw an exception when called.
 
 It is complementary to `Index::GetStats()`, which reports static structural properties of the
 index without needing query data. For graph-based indexes, additional graph-health details such
 as degree distribution, entry-point quality, sub-index recall and low-recall hot-spots are
 exposed through `GetStats()` rather than through `AnalyzeIndexBySearch`.
+
+Pyramid exposes its analyzer only through `GetStats()`. It does not currently override
+`AnalyzeIndexBySearch`, so calling that API—or using `analyze_index --query_path` with a Pyramid
+index—throws `UNSUPPORTED_INDEX_OPERATION`.
 
 ### Static metrics from `GetStats()`
 
@@ -48,6 +51,20 @@ exposed through `GetStats()` rather than through `AnalyzeIndexBySearch`.
 | `quantization_inversion_count_rate` | Rate of distance-order inversions caused by quantization |
 | `build_cache_hit_rate` | Fraction of nodes warm-started from an imported cache during the last `Build()`; emits a `skipped_reason` when the index was not built from a cache imported via `ImportCache()` |
 | `build_cache_hit_nodes` / `build_cache_missed_nodes` | Node counts behind `build_cache_hit_rate` (only present when the index was built from an imported cache) |
+
+#### Pyramid metrics
+
+| Metric | Meaning |
+| --- | --- |
+| `total_count` | Total number of vectors in the index |
+| `index_node_structure` | Path-tree node count, depth, nodes by level, and node-status distribution |
+| `leaf_node_size_distribution` | Distribution of vector counts across leaf nodes |
+| `subindex_quality` | Per-leaf GRAPH/FLAT status and size, plus graph/flat counts and vector coverage |
+| `recall_base` | Size-weighted recall across graph-backed nodes; present when sampling and analysis search parameters are available |
+| `graph_node_count` / `total_graph_size` | Number and combined size of graph-backed nodes included in recall analysis |
+| `skipped_node_count` / `low_recall_nodes` | Nodes excluded from recall analysis and details of nodes below the recall threshold |
+| `duplicate_ratio` | Duplicate-vector ratio within the hierarchy |
+| `hierarchy_count` / `hierarchies` | Multi-hierarchy count and a per-name object containing the metrics above; single unnamed hierarchies expose them at the top level |
 
 #### SINDI metrics
 
@@ -120,10 +137,8 @@ Quantization-related fields differ by index type — they are not unified across
 | `HGraph` | `quantization_inversion_count_rate_query` | Quantization-induced ordering errors during search |
 | `IVF` | `quantization_bias_ratio` | Quantization bias observed during search (only when `use_reorder_` is enabled) |
 | `IVF` | `quantization_inversion_count_rate` | Quantization-induced ordering errors during search (only when `use_reorder_` is enabled) |
-
-If you also need degree distribution, entry-point analysis or sub-index quality breakdown, look
-in the `GetStats()` JSON instead — `AnalyzeIndexBySearch` focuses on dynamic, query-driven
-signals.
+For static structure and health information, including degree distributions, entry-point
+analysis, and Pyramid subindex quality, use the `GetStats()` JSON.
 
 ## The `analyze_index` Tool
 

--- a/docs/docs/en/src/resources/disk_index.md
+++ b/docs/docs/en/src/resources/disk_index.md
@@ -63,13 +63,47 @@ The IO backends you can assign to a cell:
 | `buffer_io` | Disk (buffered `pread`) | Yes | Portable disk reads; works everywhere |
 | `mmap_io` | Disk (mmap + page cache) | Yes | Near-memory speed when the working set fits the page cache |
 | `async_io` | Disk (Linux libaio) | Yes | High-concurrency disk reads; **Linux + libaio only**, otherwise falls back to `buffer_io` |
+| `uring_io` | Disk (Linux io_uring) | Yes | Optional io_uring backend; requires a build with `ENABLE_LIBURING=ON`, otherwise falls back to `buffer_io` |
 | `reader_io` | Custom `Reader` | No | Read through a user `ReaderSet` at load time (e.g. remote / object storage) |
 
 Each cell is wired with a flat pair of build parameters: `graph_io_type` / `graph_file_path`,
 `base_io_type` / `base_file_path`, `precise_io_type` / `precise_file_path`, and
 `raw_vector_io_type` / `raw_vector_file_path`. A `*_file_path` is **required** whenever the
-matching `*_io_type` is disk-backed (`buffer_io`, `mmap_io`, or `async_io`); the in-memory
+matching `*_io_type` is disk-backed (`buffer_io`, `mmap_io`, `async_io`, or `uring_io`); the in-memory
 backends ignore it. All cells default to `block_memory_io` (fully in memory).
+
+### Enabling `uring_io`
+
+`uring_io` is an optional Linux backend. Install liburing and enable it when configuring CMake:
+
+```bash
+cmake -S . -B build-release \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DENABLE_LIBURING=ON \
+    -DENABLE_EXAMPLES=ON
+cmake --build build-release --target 325_feature_uring_io -j
+```
+
+Select it with any supported disk cell parameter, for example:
+
+```json
+{
+    "index_param": {
+        "base_io_type": "uring_io",
+        "base_file_path": "/data/vsag/hgraph_base.data",
+        "base_direct_read": true
+    }
+}
+```
+
+For HGraph, `base_direct_read` and `precise_direct_read` default to `false`. Set the matching flag
+to `true` to open a `uring_io` file with direct IO and bypass the page cache. Confirm that the
+target filesystem supports direct IO and benchmark both modes for the workload.
+
+When VSAG is built without liburing, the same configuration remains loadable but logs a one-time
+warning and uses `buffer_io`. This fallback is functional, but it does not provide io_uring
+submission/completion batching. See `examples/cpp/325_feature_uring_io.cpp` for an end-to-end load
+example.
 
 ## Recommended configuration: base in memory, precise on disk
 
@@ -121,6 +155,9 @@ only a bounded number of reads per query rather than one read per hop.
   (including on macOS), `async_io` logs a one-time warning and falls back to `buffer_io`, so
   configs remain portable but lose asynchronous batching. For production throughput, build on
   Linux with libaio.
+- **`uring_io` requires Linux with liburing and is opt-in.** Configure with
+  `-DENABLE_LIBURING=ON`; otherwise it falls back to `buffer_io`. Benchmark `uring_io` and
+  `async_io` with the target kernel, queue depth, and SSD rather than assuming one always wins.
 - **Warm the page cache** for `mmap_io` cells after load (e.g. a sequential read of the file,
   or a warm-up query pass) so early queries do not pay cold-miss latency.
 - **Plan file paths and lifecycle.** Disk-backed cells write to the `*_file_path` you supply;

--- a/docs/docs/en/src/resources/index_parameters.md
+++ b/docs/docs/en/src/resources/index_parameters.md
@@ -9,13 +9,21 @@ enumeration, consult the source:
 
 ## Common Fields
 
-Every index requires these top-level fields at build time:
+Every index accepts these top-level fields at build time. `dtype` and `metric_type` are required;
+`repr` is optional. `dim` is required for non-sparse data and defaults to `4096` for
+`dtype: "sparse"` when omitted:
 
 | Field | Values | Description |
 |-------|--------|-------------|
 | `dim` | positive integer | Vector dimensionality; cannot change after build |
-| `dtype` | `float32` / `fp16` / `bf16` / `int8` | Vector data type; determines internal representation |
+| `dtype` | `float32` / `fp16` / `bf16` / `int8` / `sparse` | Scalar value type. `sparse` is retained for sparse-index compatibility. |
+| `repr` | `dense` / `sparse` / `multi_vector` | Optional data layout. When omitted, VSAG infers `sparse` from `dtype: "sparse"` and otherwise uses `dense`. |
 | `metric_type` | `l2` / `ip` / `cosine` | Distance metric |
+
+`dtype` and `repr` describe different properties: `dtype` is the scalar encoding, while `repr`
+is the record layout. `dtype: "sparse"` requires `repr: "sparse"` when `repr` is explicit.
+Use `repr: "multi_vector"` with a supported multi-vector index and a scalar `dtype` such as
+`float32`.
 
 ## HGraph
 
@@ -40,12 +48,22 @@ HGraph places its build parameters under the generic `index_param` key (see
 | `max_degree` | 16–48 | Maximum out-degree per node |
 | `ef_construction` | 200–500 | Candidate set size during build; larger = higher recall, slower build |
 | `base_quantization_type` | `fp32` / `fp16` / `bf16` / `sq8` / `sq4` / `pq` | Quantization of the base storage — see the [Quantization chapter](../quantization/README.md) for all supported values |
+| `use_reverse_edges` | `false` | Track incoming neighbors for O(1) reverse-edge lookup; roughly doubles edge storage and is unsupported with compressed graph storage |
+| `label_remap_type` | `pg` | Label-map implementation: `pg` (default) or `robin` |
+| `reorder_source` | `precise` | Reorder from the `precise` store or directly from `base`; RaBitQ x+y split selects `base` automatically |
+| `persist_source_id` | `false` | Include HGraph source-ID metadata in serialization; useful when a restored index must later export a build cache |
+| `mrle_dim` | `0` | MRLE output dimension in `[0, dim]`; `0` means input dimension |
+| `fast_encode_rabitq` | `true` | Use fast multi-bit RaBitQ encoding; `false` restores the exact encoder |
+| `fast_encode_rabitq_rounds` | `6` | Fast-encoder refinement rounds in `[1, 32]` |
 
 At search time:
 
 ```json
 {"hgraph": {"ef_search": 100}}
 ```
+
+`ef_search` accepts any positive signed 64-bit integer. It is no longer capped relative to
+`topk`; very large values can substantially increase latency and memory used by the frontier.
 
 The `hgraph` search-param object also accepts `brute_force_threshold` (a float
 in `[0.0, 1.0]`, default `0.0`). When set above zero and the request carries a
@@ -114,12 +132,15 @@ No extra parameters.
 
 ## Pyramid
 
-Pyramid supports organising multiple subgraphs by tag:
+Pyramid build parameters also live under `index_param`:
 
 ```json
 {
-    "pyramid": {
-        "tag_dim": 1,
+    "dtype": "float32",
+    "metric_type": "l2",
+    "dim": 128,
+    "index_param": {
+        "base_quantization_type": "sq8",
         "max_degree": 24,
         "ef_construction": 300
     }
@@ -130,12 +151,18 @@ Pyramid supports organising multiple subgraphs by tag:
 
 ```json
 {
-    "sindi": {
-        "top_k": 32,
+    "dtype": "sparse",
+    "metric_type": "ip",
+    "dim": 1024,
+    "index_param": {
+        "term_id_limit": 30000,
         "doc_prune_ratio": 0.1
     }
 }
 ```
+
+See the [SINDI page](../indexes/sindi.md) for `use_quantization`, immutable builds, and search
+parameters such as `n_candidate`.
 
 ## Runtime Parameters
 

--- a/docs/docs/zh/src/SUMMARY.md
+++ b/docs/docs/zh/src/SUMMARY.md
@@ -7,6 +7,7 @@
 - [安装](guide/installation.md)
 - [创建索引](guide/create_index.md)
 - [k-近邻搜索](guide/knn_search.md)
+- [C API](guide/c_api.md)
 - [pyvsag](guide/pyvsag.md)
 
 # 索引
@@ -46,6 +47,7 @@
 # 高级功能
 
 - [索引构建与训练](advanced/build_and_train.md)
+- [HGraph 构建缓存](advanced/build_cache.md)
 - [范围搜索](advanced/range_search.md)
 - [按 ID 计算距离](advanced/calc_distance_by_id.md)
 - [带过滤的搜索](advanced/filtered_search.md)

--- a/docs/docs/zh/src/advanced/build_cache.md
+++ b/docs/docs/zh/src/advanced/build_cache.md
@@ -1,0 +1,116 @@
+# HGraph 构建缓存
+
+HGraph 可以从一次构建中导出图邻居信息，并在下一次 `Build()` 前导入。向量通过稳定的
+字符串 Source ID 匹配，因此未变化的数据可以从旧图 warm-start，新数据或已变化数据
+仍走正常的 refine 流程。
+
+该流程适用于周期性快照构建，例如每天从大部分重叠的语料重建索引。它是构建加速器，
+不是索引序列化格式；可搜索索引仍应使用普通[序列化](serialization.md)接口持久化。
+
+## 使用条件
+
+- 索引类型必须是 HGraph。
+- 流程中的每个 base Dataset 都必须设置 `Dataset::SourceID`。
+- 希望跨构建匹配的逻辑记录必须使用稳定且唯一的 Source ID。
+- 在调用 `Build()` 前，把缓存导入全新、为空且兼容的 HGraph。
+- 两次构建的维度、度量和存储/量化参数应保持兼容。
+
+不同快照中的 `Dataset::Ids` 数字 label 可以变化；缓存使用对应的 `SourceID`
+字符串匹配。
+
+## 首次构建并导出缓存
+
+构建源索引时，为每个向量提供一个 Source ID：
+
+```cpp
+std::vector<std::string> source_ids = load_stable_source_ids();
+
+auto base = vsag::Dataset::Make();
+base->NumElements(count)
+    ->Dim(dim)
+    ->Ids(ids.data())
+    ->Float32Vectors(vectors.data())
+    ->SourceID(source_ids.data())
+    ->Owner(false);
+
+auto index = vsag::Factory::CreateIndex("hgraph", build_params).value();
+index->Build(base).value();
+
+std::ofstream cache_out("hgraph.cache", std::ios::binary);
+index->ExportCache(cache_out).value();
+```
+
+在 `Build()` 执行期间要保持 `std::string` 数组有效。缓存包含后续构建使用的
+Source ID 到邻居信息映射，本身不可直接用于搜索。
+
+## Warm-start 下一次构建
+
+创建空的兼容 HGraph，导入旧缓存，再构建新快照：
+
+```cpp
+auto next_index = vsag::Factory::CreateIndex("hgraph", build_params).value();
+
+std::ifstream cache_in("hgraph.cache", std::ios::binary);
+next_index->ImportCache(cache_in).value();
+
+auto next_base = vsag::Dataset::Make();
+next_base->NumElements(next_count)
+    ->Dim(dim)
+    ->Ids(next_ids.data())
+    ->Float32Vectors(next_vectors.data())
+    ->SourceID(next_source_ids.data())
+    ->Owner(false);
+
+next_index->Build(next_base).value();
+```
+
+调用 `ImportCache()` 后，`Build()` 会自动进入缓存辅助路径。两个快照中都存在的
+Source ID 使用缓存邻居 warm-start；未匹配记录作为 cache miss 走正常构建 refine。
+缓存辅助 `Build()` 未设置 `Dataset::SourceID` 时会返回参数错误。
+
+## 随索引持久化 Source ID
+
+HGraph 默认不会在序列化中写入 Source ID 元数据。如果反序列化后的索引还需要
+调用 `ExportCache()`，请在 `index_param` 中设置 `persist_source_id: true`：
+
+```json
+{
+    "dtype": "float32",
+    "metric_type": "l2",
+    "dim": 128,
+    "index_param": {
+        "base_quantization_type": "sq8",
+        "max_degree": 32,
+        "ef_construction": 400,
+        "persist_source_id": true
+    }
+}
+```
+
+该选项会给序列化索引增加 Source ID 元数据。如果缓存始终从首次内存构建中导出，
+恢复后的索引不需要 Source ID 映射，则无需开启。
+
+## 度量缓存复用
+
+warm-start 构建完成后调用 `GetStats()`，检查：
+
+| 字段 | 含义 |
+| --- | --- |
+| `build_cache_hit_rate` | 构建节点中成功匹配并从导入缓存 warm-start 的比例 |
+| `build_cache_hit_nodes` | 成功匹配的节点数量 |
+| `build_cache_missed_nodes` | 没有匹配缓存条目、按正常路径构建的节点数量 |
+
+如果上一次构建没有使用导入缓存，统计会输出 `skipped_reason`。其他 HGraph
+指标见[索引分析](../resources/analyze_index.md)。
+
+## 限制与运维建议
+
+- 必须先 Import 再 `Build()`；缓存辅助构建要求索引为空。
+- 构建缓存依赖兼容的 HGraph 配置；参数发生不兼容变化后应重新生成。
+- `deduplicate_storage: true` 不能与缓存辅助构建组合。
+- 生产使用前，应和完整重建对比召回率与构建时间。
+- 检查文件流是否成功打开，并处理 API 返回值。缓存文件与可搜索的序列化索引相互独立，
+  应和生成它的快照一起版本化，或通过原子方式替换。
+
+API 签名见 [Index 缓存接口](../api/index_class.md#缓存构建加速)，Source ID 字段见
+[Dataset](../api/dataset.md)。

--- a/docs/docs/zh/src/advanced/calc_distance_by_id.md
+++ b/docs/docs/zh/src/advanced/calc_distance_by_id.md
@@ -49,7 +49,10 @@ CalDistanceById(const DatasetPtr& query,
                 bool calculate_precise_distance = true,
                 int64_t topk = -1) const;
 ```
-对于 `NumElements() > 1` 的 `DatasetPtr` 查询，请先检查 `SUPPORT_BATCH_CALC_DISTANCE_BY_ID`。`count` 表示每个 query 的 ID 数，`ids` 需要包含 `NumElements() * count` 个 row-major ID，返回距离使用相同布局：`distances[q * count + j]` 对应 `ids[q * count + j]`。当 `topk > 0` 时，每个 query 返回按距离升序排列的 `min(topk, count)` 个结果，并同时返回对应 ID；无效 ID（距离为 `-1`）排在有效距离之后，仅在有效 ID 不足时才出现在结果中。
+对于 `NumElements() > 1` 的 `DatasetPtr` 查询，请先检查
+`SUPPORT_BATCH_CALC_DISTANCE_BY_ID`。`count` 表示每个 query 的 ID 数，`ids` 需要包含
+`NumElements() * count` 个 row-major ID，返回距离使用相同布局。当 `topk > 0` 时，
+每个 query 返回按距离升序排列的 `min(topk, count)` 个结果，并同时返回对应 ID。
 
 
 声明位于
@@ -64,8 +67,8 @@ CalDistanceById(const DatasetPtr& query,
 ### 返回值含义
 
 - 单 ID 重载返回 `float` 距离值。
-- `topk == -1` 时，批量重载返回 `DatasetPtr`，其 `GetDistances()` 数组长度为 `count`，
-  与输入 `ids` 一一对应，且不返回 ID。
+- `topk == -1` 时，裸指针批量重载返回一行 `count` 个距离；`DatasetPtr` 重载返回
+  `NumElements()` 行、每行 `count` 个距离。两者都保持输入顺序，且不返回 ID。
 - `topk > 0` 时，批量重载每个 query 返回按距离升序排列的最小 `min(topk, count)` 个
   距离，`GetIds()` 包含对应 ID。无效 ID（距离为 `-1`）排在有效距离之后，仅在有效 ID
   不足时才出现在结果中。
@@ -102,6 +105,44 @@ if (result.has_value()) {
 }
 ```
 
+## 多查询
+
+当索引公布 `SUPPORT_BATCH_CALC_DISTANCE_BY_ID` 能力时，`DatasetPtr` 批量重载可以一次接收
+多个 query。候选 ID 和输出都采用 row-major 布局。对于 LazyHGraph，调用会委托给当前生效的
+内部索引；即使 wrapper 公布了该能力，实际支持也可能在 phase 切换后改变，因此仍需处理返回错误：
+
+```cpp
+// 两个稠密 query，每个 query 三个候选 ID。
+auto queries = vsag::Dataset::Make()
+                   ->NumElements(2)
+                   ->Dim(dim)
+                   ->Float32Vectors(query_vectors.data())
+                   ->Owner(false);
+std::vector<int64_t> candidate_ids = {
+    10, 11, 12,  // query 0 的候选
+    20, 21, 22   // query 1 的候选
+};
+
+if (index->CheckFeature(vsag::SUPPORT_BATCH_CALC_DISTANCE_BY_ID)) {
+    auto result = index->CalDistanceById(queries, candidate_ids.data(), 3, true, /*topk=*/2);
+    if (result.has_value()) {
+        auto batch = result.value();
+        // batch 的 NumElements() == 2，Dim() == 2。
+        for (int64_t q = 0; q < batch->GetNumElements(); ++q) {
+            for (int64_t j = 0; j < batch->GetDim(); ++j) {
+                const int64_t offset = q * batch->GetDim() + j;
+                std::cout << batch->GetIds()[offset] << ": "
+                          << batch->GetDistances()[offset] << '\n';
+            }
+        }
+    }
+}
+```
+
+`topk == -1` 时，`GetDim()` 等于 `count`，位置 `q * count + j` 对应输入 ID
+`ids[q * count + j]`。`topk` 为正数时，行跨度为 `GetDim()`；每行先放最近的有效候选，
+只有有效 ID 少于 `topk` 时才会在行尾保留无效 ID。
+
 可运行的完整示例见
 [`examples/cpp/306_feature_calculate_distance_by_id.cpp`](https://github.com/antgroup/vsag/blob/main/examples/cpp/306_feature_calculate_distance_by_id.cpp)。
 
@@ -119,13 +160,16 @@ auto d = index->CalcDistanceById(query, /*id=*/42);
 
 ## 支持矩阵
 
-| 索引类型     | 稠密重载（`const float*`） | DatasetPtr 重载 | 说明 |
-|--------------|----------------------------|------------------|------|
-| hgraph       | 支持                       | 支持             | 遵循 `calculate_precise_distance`。 |
-| ivf          | 支持                       | 支持（默认循环） | |
-| brute_force  | 支持                       | 支持（默认循环） | 总是精确（无量化）。 |
-| pyramid      | 支持                       | 支持（默认循环） | |
-| sindi        | 不支持                     | 支持             | 仅稀疏向量。 |
+| 索引类型 | 单 ID 稠密重载（`const float*`） | 单 ID DatasetPtr | 多查询 DatasetPtr 批量重载 | 说明 |
+|----------|---------------------------------|------------------|---------------------------|------|
+| hgraph | 支持 | 支持 | 公布能力时支持 | 遵循 `calculate_precise_distance`。 |
+| ivf | 支持 | 支持 | 公布能力时支持 | 可用性取决于是否保留精确存储。 |
+| brute_force | 支持 | 支持 | 公布能力时支持 | 仅稠密单向量索引。 |
+| pyramid | 支持 | 支持 | 支持 | |
+| lazy_hgraph | 支持 | 不支持 | 取决于当前生效的内部索引 | DatasetPtr 批量调用会委托给当前 BruteForce/HGraph；可用性可能在 phase 切换后改变。 |
+| sindi | 不支持 | 支持 | 支持 | 仅稀疏向量。 |
+| hnsw | 支持 | 不支持 | 不支持 | 稠密批量接口仅支持 `topk == -1`。 |
+| diskann | 支持 | 不支持 | 不支持 | 稠密批量接口仅支持 `topk == -1`。 |
 
 对于未实现某重载的索引，调用会返回 `UNSUPPORTED_INDEX_OPERATION` 错误。
 

--- a/docs/docs/zh/src/advanced/introspection.md
+++ b/docs/docs/zh/src/advanced/introspection.md
@@ -47,8 +47,11 @@ query_ds->NumElements(1)->SparseVectors(/* ... */);
 auto r = index->CalDistanceById(query_ds, ids, count, /*calculate_precise_distance=*/true);
 ```
 
-结果 `Dataset` 中 `GetDistances()` 持有 `count` 个距离。若某个 id 无效（不在索引中），对应位置
-返回 `-1.0F`。
+裸指针重载返回一行 `count` 个距离。对于公布 `SUPPORT_BATCH_CALC_DISTANCE_BY_ID` 能力的
+索引，`DatasetPtr` 重载可以处理多个 query，此时候选 ID 和距离是
+`NumElements() * count` 的 row-major 矩阵。无效 ID 对应 `-1.0F`。传入正数 `topk`
+时，每行会返回按距离排序的最近候选及其 ID。完整布局和支持矩阵见
+[按 ID 计算距离](calc_distance_by_id.md)。
 
 ### `calculate_precise_distance`
 

--- a/docs/docs/zh/src/advanced/quantization_transform.md
+++ b/docs/docs/zh/src/advanced/quantization_transform.md
@@ -120,16 +120,19 @@ token 两侧的空白会被自动 trim
 
 ### HGraph 顶层映射
 
-使用 HGraph 时，两个顶层快捷键会被映射到嵌套的量化器参数中
-（`src/algorithm/hgraph.cpp:370-385`）：
+使用 HGraph 时，顶层快捷键会被映射到嵌套的量化器参数中：
 
 - `tq_chain` → `base_codes.quantization_params.tq_chain`
 - `rabitq_pca_dim` → `base_codes.quantization_params.pca_dim`
+- `mrle_dim` → `base_codes.quantization_params.mrle_dim`
 
 `rabitq_pca_dim` 这个名字早于 Transform Quantizer 引入；当链中包含 `pca` 时，它实际
 驱动的是 **`pca` 变换的输出维**（与 RaBitQ 无关）。如果链以 `rabitq` 结尾且未使用
 `pca`，则同一个键会配置 RaBitQ 自身的 PCA 预处理
 （`src/quantization/rabitq_quantization/rabitq_quantizer_parameter.cpp:30`）。
+
+`mrle_dim` 接受 `[0, dim]` 内的整数；`0` 表示输入维度。它在 `tq_chain` 包含
+`mrle` 时生效，且 `mrle` 必须保持为链中的第一个变换。
 
 ## Reorder 与精确码存储
 

--- a/docs/docs/zh/src/api/dataset.md
+++ b/docs/docs/zh/src/api/dataset.md
@@ -54,7 +54,8 @@ DatasetPtr DeepCopy(Allocator* allocator = nullptr) const;  // 独立副本
 
 ## 向量负载
 
-一个 dataset 只携带一种向量表示，需与索引的 `dtype` 匹配：
+一个 dataset 只携带一种向量表示。需要同时根据索引的标量 `dtype` 与记录布局 `repr`
+选择对应的 payload setter：
 
 | Setter | Getter | 元素类型 | 配合使用 |
 |--------|--------|----------|----------|
@@ -64,6 +65,8 @@ DatasetPtr DeepCopy(Allocator* allocator = nullptr) const;  // 独立副本
 | `SparseVectors(const SparseVector*)` | `GetSparseVectors()` | [`SparseVector`](#sparsevector) | `dtype: sparse`（SINDI） |
 
 稠密向量按行主序排列：元素 `i` 的维度 `j` 位于 `vectors[i * dim + j]`。
+多向量数据集使用 `repr: multi_vector`，并配合标量 `dtype`（通常为 `float32`）及下文的
+多向量 payload。
 
 ### 多向量负载
 
@@ -84,10 +87,11 @@ DatasetPtr DeepCopy(Allocator* allocator = nullptr) const;  // 独立副本
 | `ExtraInfoSize(int64_t)` | `GetExtraInfoSize()` | `int64_t` | 每个 extra-info 数据块的字节数。 |
 | `Paths(const std::string*)` | `GetPaths()` | `const std::string*` | 层级路径（Pyramid）。默认层级。 |
 | `Paths(const std::string& hierarchy, const std::string*)` | `GetPaths(const std::string& hierarchy)` | `const std::string*` | 命名层级的路径。 |
-| `SourceID(const std::string*)` | `GetSourceID()` | `const std::string*` | 可选的来源标识。 |
+| `SourceID(const std::string*)` | `GetSourceID()` | `const std::string*` | 每个元素可选的稳定来源标识；HGraph 用它跨快照匹配构建缓存条目。 |
 
-见 [属性过滤（混合搜索）](../advanced/attribute_filter.md) 与
-[Extra Info（附加信息）](../advanced/extra_info.md)。
+见 [属性过滤（混合搜索）](../advanced/attribute_filter.md)、
+[Extra Info（附加信息）](../advanced/extra_info.md)与
+[HGraph 构建缓存](../advanced/build_cache.md)。
 
 ## 诊断负载
 

--- a/docs/docs/zh/src/api/index_class.md
+++ b/docs/docs/zh/src/api/index_class.md
@@ -279,6 +279,9 @@ RangeSearch(const DatasetPtr& query, float radius, const std::string& parameters
 | `ExportCache` | `tl::expected<void, Error> ExportCache(std::ostream& out_stream) const` | 写出构建期缓存（如图邻居），可加速后续的 `Build`。 |
 | `ImportCache` | `tl::expected<void, Error> ImportCache(std::istream& in_stream)` | 加载之前导出的缓存；下一次 `Build` 会复用它。 |
 
+HGraph 通过 `Dataset::SourceID` 匹配缓存条目。应在 `Build()` 前导入空的兼容索引；完整流程、
+`persist_source_id` 与命中率诊断见 [HGraph 构建缓存](../advanced/build_cache.md)。
+
 ## 统计与自省
 
 除非另有说明，这些方法直接返回值。**标注为“抛出”的方法在索引不支持时会抛出 `std::runtime_error`**

--- a/docs/docs/zh/src/development/building.md
+++ b/docs/docs/zh/src/development/building.md
@@ -2,6 +2,20 @@
 
 VSAG 是一个 C++ 项目，使用 CMake 构建。项目源码使用 C++17 标准编写，请确保你使用的编译器支持 C++17 的语法。我们建议你使用 GCC 9.4.0 或者 Clang 13.0.0 以后的版本，因为这些版本在我们的开发中工作良好。
 
+支持的平台包括 Ubuntu 20.04+、CentOS 7+，以及 Apple Silicon 上的 macOS 14+。
+macOS 使用 Xcode Command Line Tools 提供的 Apple Clang 和 Homebrew 依赖；当前支持范围是
+arm64 核心 C++ 构建，预编译 C++ 包与 Python wheel 仍以 Linux 为主。首次构建前运行：
+
+```bash
+./scripts/deps/install_deps.sh
+```
+
+脚本会自动选择 Linux 发行版或 macOS 对应的依赖安装流程。
+
+如果需要启用 Linux `io_uring` 后端，请安装 liburing，并在直接配置 CMake 时添加
+`-DENABLE_LIBURING=ON`。默认值为 `OFF`；在非 Linux 平台或未找到 liburing 时，
+请求 `uring_io` 的配置会打印一次性告警并回退到 `buffer_io`。
+
 在 CMake 配置中，有许多参数和编译目标。为了方便使用，我们将常用的编译目标（或命令）写到了 Makefile 中，使用 Unix Makefiles 进行管理，已避免记忆各种配置或者从命令行输入大段参数。这些编译目标（或命令）可以通过在项目根目录运行 `make help` 查看：
 
 ```bash

--- a/docs/docs/zh/src/guide/c_api.md
+++ b/docs/docs/zh/src/guide/c_api.md
@@ -1,0 +1,114 @@
+# C API
+
+VSAG 在 `include/vsag/vsag_c_api.h` 中导出 C ABI。它封装了与 C++ API 相同的索引实现，
+适合需要不透明句柄和 C 风格函数的应用及语言绑定。
+
+当前安装的头文件不能直接被 C 编译单元包含：其中使用了未加条件保护的 `extern "C"`
+代码块和 C++ `bool`。请将包含该头文件的编译单元按 C++ 编译（例如使用 `.cpp` 文件）。
+如果应用的其余部分使用 C，请在这个 C++ 编译单元中封装所需操作，再导出应用自己的
+C 接口。
+
+## 生命周期
+
+在 C++ 编译单元中包含安装后的头文件，并链接普通 VSAG 库：
+
+```cpp
+#include <vsag/vsag_c_api.h>
+```
+
+基本生命周期如下：
+
+1. 使用 `vsag_index_factory` 创建不透明的 `vsag_index_t`。
+2. 构建索引，或先训练再增量添加向量。
+3. 执行搜索、更新、序列化或读取操作。
+4. 使用 `vsag_index_destroy` 释放句柄。
+
+创建失败时，`vsag_index_factory` 返回 `nullptr`。其他函数返回 `Error_t`；
+`code == VSAG_SUCCESS` 表示成功，否则可从 `message` 读取错误详情。
+
+```cpp
+const char* build_params =
+    "{\"dtype\":\"float32\",\"metric_type\":\"l2\",\"dim\":128,"
+    "\"index_param\":{\"base_quantization_type\":\"fp32\","
+    "\"max_degree\":32,\"ef_construction\":200}}";
+
+vsag_index_t index = vsag_index_factory("hgraph", build_params);
+if (index == nullptr) {
+    /* 处理创建失败 */
+}
+
+Error_t error = vsag_index_build(index, base, ids, 128, count);
+if (error.code != VSAG_SUCCESS) {
+    /* 检查 error.message */
+}
+
+vsag_index_destroy(index);
+```
+
+## 搜索结果缓冲区
+
+`SearchResult_t` 中的 `ids` 与 `dists` 缓冲区由调用方持有。执行 KNN 或范围
+搜索前，两个缓冲区都至少分配 `k` 个元素。VSAG 最多写入 `k` 条结果，并把实际
+数量写入 `count`。
+
+```cpp
+int64_t result_ids[10];
+float result_dists[10];
+SearchResult_t result{};
+result.dists = result_dists;
+result.ids = result_ids;
+
+Error_t error =
+    vsag_index_knn_search(index, query, 128, 10, "{\"hgraph\":{\"ef_search\":100}}", &result);
+```
+
+带过滤器的重载接收 `FilterFunc_t`。回调返回 `true` 表示该 ID 有效，可以出现
+在结果中。
+
+## 范围搜索结果上限
+
+两个 C 范围搜索接口都要求显式传入正数结果上限：
+
+```cpp
+Error_t
+vsag_index_range_search(vsag_index_t index,
+                        const float* query,
+                        uint64_t dim,
+                        float radius,
+                        int64_t k,
+                        const char* parameters,
+                        SearchResult_t* result);
+```
+
+`k` 必须至少为 `1`。它会传递给 C++ 范围搜索的 `limited_size` 参数，同时保护
+调用方缓冲区：`result.count` 不会超过 `k`。从旧签名升级时，需要为
+`vsag_index_range_search` 和 `vsag_index_range_search_with_filter` 同时补上该参数。
+
+## 接口分组
+
+- **创建与释放：** `vsag_index_factory`、`vsag_index_destroy`。
+- **写入数据：** `vsag_index_build`、`vsag_index_train`、`vsag_index_add`。
+- **搜索：** `vsag_index_knn_search`、`vsag_index_range_search` 及其过滤器重载。
+- **读取与更新：** `vsag_index_calculate_distance_by_ids`、
+  `vsag_index_get_vector_by_ids`、`vsag_index_update_ids`、`vsag_index_update_vector`
+  及 `vsag_index_update_vector_force`。
+- **复制与复用：** `vsag_index_clone`、`vsag_index_export_model`。
+- **持久化：** `vsag_serialize_file`、`vsag_deserialize_file`、
+  `vsag_serialize_write_func` 及 `vsag_deserialize_read_func`。
+
+具体接口是否可用仍取决于索引类型。不支持的操作返回
+`VSAG_UNSUPPORTED_INDEX_OPERATION`。
+
+## 持久化错误
+
+`vsag_serialize_file` 与 `vsag_deserialize_file` 会校验目标文件是否成功打开。
+不要假定文件操作已经完成；应检查返回的 `Error_t` 是否为 `VSAG_READ_ERROR`、
+`VSAG_MISSING_FILE` 或其他非成功状态。
+
+应用自行管理存储时，可以使用基于回调的持久化接口。回调中的 offset 和 size
+使用头文件里声明的 `OffsetType` 与 `SizeType`。
+
+## 参考
+
+`include/vsag/vsag_c_api.h` 是函数签名、错误码、回调和结构体的完整源码级
+参考。搜索参数 JSON 与对应[索引页面](../indexes/README.md)中的 C++ API 相同。

--- a/docs/docs/zh/src/guide/installation.md
+++ b/docs/docs/zh/src/guide/installation.md
@@ -1,6 +1,8 @@
 # 安装
 
-VSAG 是一个向量检索库，支持在 C++、Python 和 Node.js / TypeScript 程序中使用。VSAG 核心库使用 C++ 编写，由于依赖的部分第三方库是 Linux 特有的，当前 VSAG **仅支持在 Linux 系统上运行**。
+VSAG 是一个向量检索库，支持在 C++、Python 和 Node.js / TypeScript 程序中使用。核心 C++
+库支持 Linux，也支持在 Apple Silicon 上使用 macOS 14 或更高版本从源码构建。完整 CI
+仍以 Linux 为主；预编译 C++ 包和 `pyvsag` wheel 当前也主要面向 Linux。
 
 如果使用的是 Python，可以从官方第三方包仓库 PyPI 下载，包名为 [`pyvsag`](https://pypi.org/project/pyvsag/)。`pyvsag` 的版本与源代码版本一一对应，版本功能可以直接参考 [GitHub 发布日志](https://github.com/antgroup/vsag/releases)。Python 包使用 manylinux2014 构建，可以在绝大部分 Linux 环境中运行。通过如下命令获得最新版本：
 
@@ -37,36 +39,43 @@ docker pull vsaglib/vsag:ubuntu
 
 ## 从源代码构建
 
-VSAG 可以使用 CMake 从源代码构建，支持 `x86_64` 和 `aarch64` 架构的 Linux 环境，包括在 Apple Silicon 上运行的 Linux 容器。
+VSAG 可以使用 CMake 从源代码构建，支持 Linux `x86_64` / `aarch64`，以及 macOS
+arm64。macOS 当前验证范围是核心 C++ 库的 `make debug`、`make release` 与
+`make test`；Python wheel 打包仍以 Linux 为主。
 
 构建依赖：
 
 - 操作系统：
   - **Ubuntu 20.04** 或更高版本
   - 或 **CentOS 7** 或更高版本
+  - 或 **macOS 14** 或更高版本（Apple Silicon）
 - 编译器：
   - **GCC 9.4.0** 或更高版本
   - 或 **Clang 13.0.0** 或更高版本
+  - macOS 使用 Xcode Command Line Tools 提供的 Apple Clang
 - 构建工具：
   - **CMake 3.18.0** 或更高版本
   - **clang-format 15**（精确版本，用于代码格式化）
   - **clang-tidy 15**（精确版本，用于静态检查）
 - 其他依赖项：
-  - gfortran
-  - openmp
-  - libaio
-  - Python 3.6+
-  - curl
+  - Linux：gfortran、OpenMP、libaio、Python 3.6+、curl
+  - macOS：Xcode Command Line Tools、Homebrew
 
 依赖项可以通过以下脚本安装：
 
 ```bash
-# Debian / Ubuntu
-./scripts/deps/install_deps_ubuntu.sh
+# 自动识别当前平台
+./scripts/deps/install_deps.sh
 
-# CentOS / AliOS
-./scripts/deps/install_deps_centos.sh
+# 也可以直接调用平台脚本
+./scripts/deps/install_deps_ubuntu.sh  # Debian / Ubuntu
+./scripts/deps/install_deps_centos.sh  # CentOS / AliOS
+./scripts/deps/install_deps_macos.sh   # macOS
 ```
+
+如需 Linux `io_uring` 存储后端，请安装 liburing，并在直接配置 CMake 时添加
+`-DENABLE_LIBURING=ON`。未启用时，`uring_io` 配置会回退到 `buffer_io`。用法与
+限制见[磁盘索引](../resources/disk_index.md#启用-uring_io)。
 
 VSAG 使用 CMake 管理工程，常用构建目标封装在项目根目录的 `Makefile` 中。运行以下命令可以在发布模式下编译并安装：
 

--- a/docs/docs/zh/src/guide/pyvsag.md
+++ b/docs/docs/zh/src/guide/pyvsag.md
@@ -60,6 +60,56 @@ for rid, rdist in zip(result_ids, result_dists):
 
 完整示例请查阅仓库中的 [`examples/python/`](https://github.com/antgroup/vsag/tree/main/examples/python) 目录，建议从 `103_index_hgraph.py` 开始。
 
+## 保存与加载
+
+```python
+index.save("index.bin")
+
+new_index = pyvsag.Index("hgraph", index_params)
+new_index.load("index.bin")
+```
+
+当前 `save` 与 `load` 包装不会传播底层序列化和反序列化操作返回的错误。请确认输出文件
+已经生成，并对重要索引执行保存后重新加载的 round-trip 校验，再依赖持久化结果。
+
+## 索引操作
+
+除构建、搜索、保存与加载外，Python 绑定还提供以下索引管理方法：
+
+| 方法 | 返回值 | 说明 |
+| --- | --- | --- |
+| `get_num_elements()` | `int` | 索引当前元素数量 |
+| `get_memory_usage()` | `int` | 索引占用的内存字节数 |
+| `check_id_exist(id)` | `bool` | 指定 ID 当前是否存在 |
+| `get_min_max_id()` | `(min_id, max_id)` | 操作失败时返回 `(-1, -1)` |
+| `add(vectors, ids, num_elements, dim)` | `None` | 添加连续的稠密向量矩阵；dtype 必须与索引一致 |
+| `remove(ids)` | `int` | 删除一维 `int64` ID 数组；没有 ID 被删除和底层操作失败时都会返回 `0` |
+| `cal_distance_by_id(query, ids)` | `numpy.ndarray` | 每个 ID 返回一个 float32 距离；无效 ID 为 `-1`，底层操作失败时整个结果保持为 `-1` |
+
+```python
+# 添加两条稠密向量
+new_vectors = np.random.random((2, dim)).astype(np.float32)
+new_ids = np.array([10_001, 10_002], dtype=np.int64)
+index.add(new_vectors, new_ids, len(new_ids), dim)
+
+assert index.check_id_exist(10_001)
+print(index.get_num_elements(), index.get_memory_usage())
+print(index.get_min_max_id())
+
+# 计算一个 query 到候选 ID 列表的距离
+candidate_ids = np.array([10_001, 10_002], dtype=np.int64)
+distances = index.cal_distance_by_id(query, candidate_ids)
+
+# 删除 ID；返回值为实际删除数量
+removed = index.remove(candidate_ids)
+```
+
+`add` 接受展开的连续数组或 row-major 二维矩阵。`dtype: "float16"` 时传入
+`numpy.float16`；`dtype: "bfloat16"` 时传入包含 BF16 位模式的 `numpy.uint16` 数组。
+具体操作是否受支持仍取决于索引类型。输入校验和 `add` 等操作会抛出 Python 异常；
+`remove`、`cal_distance_by_id`、`save` 与 `load` 则使用上述 sentinel 或未检查行为，
+不会统一传播底层操作错误。
+
 ## 与 C++ 库的关系
 
 `pyvsag` 绑定的是同一份核心 C++ 实现，行为和性能特征与 C++ 版本保持一致。因此：

--- a/docs/docs/zh/src/indexes/hgraph.md
+++ b/docs/docs/zh/src/indexes/hgraph.md
@@ -62,9 +62,15 @@ auto result = index->KnnSearch(
 | `max_degree` | int | `64` | 图节点最大出度 |
 | `ef_construction` | int | `400` | 构建阶段的候选集大小（越大召回越高，构建越慢） |
 | `graph_type` | string | `"nsw"` | 构图算法：`nsw` 或 `odescent` |
+| `use_reverse_edges` | bool | `false` | 跟踪入边，实现 O(1) 反向邻居查找；边存储约翻倍，且 `graph_storage_type: "compressed"` 不支持 |
+| `label_remap_type` | string | `"pg"` | label 到内部 ID 的 map 实现：`"pg"` 或 `"robin"`；恢复或组合兼容索引时应保持一致 |
 | `use_reorder` | bool | `false` | 是否额外保留一份高精度副本用于精排 |
+| `reorder_source` | string | `"precise"` | 从 `"precise"` 编码或直接从 `"base"` 编码重排；RaBitQ x+y split 会自动设置为 `"base"` |
 | `precise_quantization_type` | string | `"fp32"` | 精排使用的量化类型（仅在 `use_reorder: true` 时生效） |
 | `base_pq_dim` | int | `1` | PQ 子空间数（`pq` / `pqfs` 时必填） |
+| `mrle_dim` | int | `0` | `tq_chain` 中 MRLE 的输出维度，范围 `[0, dim]`；`0` 表示输入维度 |
+| `fast_encode_rabitq` | bool | `true` | 使用多 bit RaBitQ 快速编码；设为 `false` 使用原有精确编码器 |
+| `fast_encode_rabitq_rounds` | int | `6` | RaBitQ 快速编码的坐标微调轮数，范围 `[1, 32]` |
 | `build_thread_count` | int | `100` | 构建阶段并发线程数 |
 | `support_duplicate` | bool | `false` | 是否在插入时做重复 ID 检测 |
 | `deduplicate_storage` | bool | `false` | 让重复向量共享存储；需同时设置 `support_duplicate: true` |
@@ -73,9 +79,17 @@ auto result = index->KnnSearch(
 | `support_force_remove` | bool | `false` | 是否启用 `RemoveMode::FORCE_REMOVE` 及其额外同步 |
 | `store_raw_vector` | bool | `false` | 除量化副本外再保留原始向量（`cosine` 场景有用） |
 | `use_elp_optimizer` | bool | `false` | 构建完成后自动调优检索参数 |
-| `base_io_type` / `precise_io_type` | string | `"block_memory_io"` | 存储后端（`memory_io`、`block_memory_io`、`buffer_io`、`async_io`、`mmap_io`） |
-| `base_file_path` / `precise_file_path` | string | — | 磁盘后端时的文件路径（使用 `mmap_io` / `async_io` / `buffer_io` 时必填） |
+| `base_io_type` / `precise_io_type` | string | `"block_memory_io"` | 存储后端（`memory_io`、`block_memory_io`、`buffer_io`、`async_io`、`uring_io`、`mmap_io`） |
+| `base_file_path` / `precise_file_path` | string | — | 磁盘后端时的文件路径（使用 `mmap_io` / `async_io` / `uring_io` / `buffer_io` 时必填） |
+| `base_direct_read` / `precise_direct_read` | bool | `false` | 使用 `uring_io` 时，以 direct IO 打开对应文件而非经过页缓存 |
 | `hgraph_init_capacity` | int | `100` | 初始容量提示（不会限制最终规模） |
+| `persist_source_id` | bool | `false` | 序列化时保留 Source ID 元数据，使恢复后的索引仍可导出可复用的构建缓存 |
+
+`use_reverse_edges` 面向需要快速检查入邻居、图分析或图维护算法的负载。维护反向邻接表会让边
+存储约翻倍，因此默认关闭。
+
+`label_remap_type` 只改变内部 label map，不改变用户 ID。默认值为 `"pg"`；
+`"robin"` 选择另一种 robin-map 实现，建议针对实际 ID 分布实测后再调整。
 
 ### 向量存储去重
 
@@ -206,7 +220,7 @@ base->NumElements(num_vectors)->Dim(dim)->Ids(ids)
 
 | 参数 | 类型 | 默认值 | 说明 |
 |------|------|--------|------|
-| `ef_search` | int | —（必填） | 搜索前沿候选集的大小，越大召回越高、查询越慢。 |
+| `ef_search` | int64 | —（必填） | 正数搜索前沿大小；接受到 `INT64_MAX`，不存在与 `topk` 相关的上限。值越大，召回、延迟和前沿内存通常都越高。 |
 | `hops_limit` | int | 不限 | beam search 在返回当前前沿前允许的最大跳数。 |
 | `skip_ratio` | float | `0.2` | 过滤场景下的性能调优参数。控制跳过无效点的比例，取值范围 `[0.0, 1.0]`。`skip_ratio=0.2` 表示跳过 20% 的无效点，只检查 80% 的无效点。值越大性能越好但召回率可能越低。仅在带 filter 的搜索中生效。详见下文[过滤跳过策略](#过滤跳过策略skip_ratio-与-skip_strategy)。 |
 | `skip_strategy` | string | `"deterministic_accumulative"` | 过滤跳过的策略。可选值：`"random"`（随机跳过）或 `"deterministic_accumulative"`（确定性累积跳过）。详见下文[过滤跳过策略](#过滤跳过策略skip_ratio-与-skip_strategy)。 |
@@ -315,6 +329,10 @@ auto result = index->KnnSearch(query, topk, params, my_filter).value();
 - 对延迟敏感且要求高召回的场景。
 - 需要增量插入（可选通过 `support_force_remove` 打开物理删除）的混合负载。
 - 内存受限环境，可用 `sq8` / `sq4_uniform` / `pq` 压缩，再配合 `use_reorder` 弥补召回。
+
+对于 Source ID 稳定的每日构建或快照构建，参见
+[HGraph 构建缓存](../advanced/build_cache.md)。其中说明了 `Dataset::SourceID`、
+`ExportCache`/`ImportCache`、`persist_source_id` 与缓存命中率诊断。
 
 如果你的业务偏向粗粒度分桶（每次查询只扫部分桶）或严重受 SSD I/O 制约，建议先对比
 [IVF](ivf.md) 再决定是否选择 HGraph。

--- a/docs/docs/zh/src/indexes/ivf.md
+++ b/docs/docs/zh/src/indexes/ivf.md
@@ -82,8 +82,8 @@ auto result = index->KnnSearch(
 | `fast_encode_rabitq_rounds` | int | `6` | CAQ 微调轮数，允许范围 `[1, 32]` |
 | `use_reorder` | bool | `false` | 是否保留高精度副本用于精排 |
 | `precise_quantization_type` | string | `"fp32"` | 精排量化类型（`use_reorder: true` 时使用） |
-| `base_io_type` | string | `"memory_io"` | 粗排向量的存储后端 |
-| `precise_io_type` | string | `"block_memory_io"` | 精排向量的存储后端（`memory_io`、`block_memory_io`、`mmap_io`、`buffer_io`、`async_io`、`reader_io`） |
+| `base_io_type` | string | `"memory_io"` | 粗排向量的存储后端；以 liburing 构建时支持 `uring_io` |
+| `precise_io_type` | string | `"block_memory_io"` | 精排向量的存储后端（`memory_io`、`block_memory_io`、`mmap_io`、`buffer_io`、`async_io`、`uring_io`、`reader_io`） |
 | `precise_file_path` | string | `""` | 当精排 IO 为磁盘后端时的文件路径 |
 
 `buckets_count` 的经验值一般为 `sqrt(N)` ~ `4 * sqrt(N)`，其中 `N` 是语料规模。

--- a/docs/docs/zh/src/indexes/pyramid.md
+++ b/docs/docs/zh/src/indexes/pyramid.md
@@ -89,6 +89,10 @@ auto result = index->KnnSearch(
 | `no_build_levels` | int[] | `[]` | 跳过构图的层级（从根节点开始的 0-based 下标） |
 | `use_reorder` | bool | `false` | 是否保留高精度副本用于精排 |
 | `precise_quantization_type` | string | `"fp32"` | 精排使用的量化类型 |
+| `fast_encode_rabitq` | bool | `true` | 对 RaBitQ 底层或精排存储使用多 bit 快速编码器；设为 `false` 使用精确编码器 |
+| `fast_encode_rabitq_rounds` | int | `6` | RaBitQ 快速编码的微调轮数，范围 `[1, 32]` |
+| `base_io_type` / `precise_io_type` | string | `"block_memory_io"` | 底层与精排存储后端；以 liburing 构建时可用 `uring_io` |
+| `base_file_path` / `precise_file_path` | string | — | `buffer_io`、`async_io`、`uring_io`、`mmap_io` 等磁盘存储必须设置 |
 | `index_min_size` | int | `0` | 子索引的最小规模；小于该值的分区会退化为线性扫描 |
 | `support_duplicate` | bool | `false` | 是否允许重复 ID |
 | `build_thread_count` | int | `1` | 构建阶段并发线程数 |
@@ -235,6 +239,10 @@ new_index->Deserialize(binary_set);
   构图的分区。
 
 如果不需要按路径限定查询范围，[HGraph](hgraph.md) 更简洁，性能通常也更高。
+
+可以通过[索引分析](../resources/analyze_index.md)检查 Pyramid 的树结构、子索引质量、
+`GetStats()` 输出的 base 采样召回率和重复比例。Pyramid 目前不通过
+`AnalyzeIndexBySearch` 提供查询驱动指标。
 
 ## 标记删除
 

--- a/docs/docs/zh/src/indexes/simq.md
+++ b/docs/docs/zh/src/indexes/simq.md
@@ -109,10 +109,11 @@ SIMQ 专属构建参数放在 `index_param` 下。`dim`、`dtype`、`metric_type
 | `rerank_k` | int | `100` | 构建时进入精排的候选文档数量上限 |
 
 - **`dim`** — 所有文档和查询中的所有 token 共享同一维度
-- **`base_io_type`** — 可选值：`async_io`、`memory_io`、
-  `block_memory_io`、`buffer_io`、`mmap_io`、`reader_io`
+- **`base_io_type`** — 可选值：`async_io`、`uring_io`、`memory_io`、
+  `block_memory_io`、`buffer_io`、`mmap_io`、`reader_io`。原生 `uring_io`
+  需要以 liburing 构建，否则回退到 `buffer_io`
 - **`base_file_path`** — 默认值为占位符，使用磁盘类型（`async_io`、
-  `buffer_io`、`mmap_io`）时需提供真实路径
+  `uring_io`、`buffer_io`、`mmap_io`）时需提供真实路径
 - **`init_cluster_ratio`** — 取值范围 `(0, 1]`。值越小簇越少越大，
   值越大簇越多越细
 - **`max_cluster_size`** — 必须 > 1
@@ -145,6 +146,30 @@ auto result = index->KnnSearch(
     query, topk,
     R"({"simq": {"coarse_k": 600, "rerank_k": 5000}})").value();
 ```
+
+## 搜索统计
+
+`KnnSearch` 与 `RangeSearch` 会在返回的 dataset 上附带 JSON 统计对象。可以读取完整对象，
+也可以按 key 获取单项值：
+
+```cpp
+std::cout << result->GetStatistics() << '\n';
+auto values = result->GetStatistics(
+    {"simq_coarse_candidate_count", "simq_rerank_candidate_count"});
+```
+
+| Key | 含义 |
+|-----|------|
+| `dist_cmp` | 精排阶段执行的精确 MaxSim 距离计算次数 |
+| `simq_coarse_dist_cmp` | 代表图搜索执行的距离计算次数 |
+| `simq_coarse_probe_count` | 所有 query token 探测的代表簇数量 |
+| `simq_coarse_candidate_count` | 粗排产生且尚未应用 `rerank_k` 的唯一文档候选数 |
+| `simq_rerank_candidate_count` | 应用 `rerank_k` 后保留的候选数 |
+| `simq_filtered_candidate_count` | 被调用方 filter 排除的精排候选数 |
+| `simq_result_count` | 精排并应用 range/top-k 限制后最终返回的结果数 |
+| `simq_limited_size_applied` | `RangeSearch` 是否因 `limited_size` 截断结果 |
+
+这些计数器可以在调节召回和延迟时，区分候选池过窄、过滤、精排和输出上限各自的影响。
 
 ## 何时选择 SIMQ
 

--- a/docs/docs/zh/src/indexes/sindi.md
+++ b/docs/docs/zh/src/indexes/sindi.md
@@ -15,7 +15,7 @@ SINDI（**S**parse **IN**verted **D**ense **I**ndex）是 VSAG 面向 **稀疏�
 1. **基于窗口的倒排表。** 文档按固定窗口大小（`window_size`）分组，每个窗口独立维护一套
    倒排表——即“词项 → `(doc_id, value)` 列表”的映射。
 2. **可选的剪枝与量化。** 构建时可通过 `doc_prune_ratio` 按文档粒度丢弃权重最低的词项；
-   通过 `use_quantization` 压缩词项权重以进一步节省内存。
+   `use_quantization: true` 使用 SQ8，`use_quantization: "fp16"` 使用半精度值。
 3. **打分。** 检索时，SINDI 遍历查询向量的非零项，按窗口访问对应的倒排表，使用大小为
    `n_candidate` 的大顶堆聚合得分，最后取 top-k。启用 `use_reorder` 时，候选会在正排
    存储上重打分。默认正排存储保留 fp32 值；设置 `rerank_type: "dmq8"` 时使用压缩的
@@ -70,15 +70,57 @@ auto result = index->KnnSearch(
 | `term_id_limit` | int | `1000000` | 词项 ID 的上界（应 ≥ 最大词项 ID + 1，最高 50 000 000） |
 | `window_size` | int | `50000` | 每个窗口容纳的文档数（取值范围 10 000 – 60 000） |
 | `doc_prune_ratio` | float | `0.0` | 构建阶段按文档丢弃权重最低词项的比例（0.0 – 0.9） |
-| `use_quantization` | bool | `false` | 是否量化词项权重以降低内存；开启后使用 8-bit 标量量化（SQ8） |
+| `use_quantization` | bool 或 string | `false` | `false` 存 FP32，`true` 存 SQ8，`"fp16"` 存 FP16 |
 | `use_reorder` | bool | `false` | 是否保留一份正排存储，在 SINDI 粗排后对候选做精排 |
 | `rerank_type` | string | `"fp32"` | `use_reorder` 开启时使用的正排存储类型。`fp32` 保留精确值；`dmq8` 使用压缩的 8-bit DMQ 编码 |
 | `remap_term_ids` | bool | `false` | 是否在建索引前重映射词项 ID，适用于词项 ID 很稀疏或存在大量空洞的词表 |
 | `avg_doc_term_length` | int | `100` | 仅用于内存估算 |
+| `immutable` | bool | `false` | 构建或加载紧凑的只读运行态；`Build()` 会逐窗口压缩以降低峰值内存，增量 `Add()` 会被拒绝 |
 
 > **`dim` 与 `term_id_limit` 的区别。** 对于稀疏向量 `{0:0.1, 2:0.5, 177:0.8}`，
 > `dim` 为 `3`（三个非零项），而 `term_id_limit` 至少应为 `178`（最大词项 ID + 1）。
 > `term_id_limit` 要按词表大小估计，这是使用时最常见的坑。
+
+### 稀疏值格式
+
+`use_quantization` 保留原有 bool 行为，同时新增一个字符串取值：
+
+| 取值 | 存储格式 | 取舍 |
+| --- | --- | --- |
+| `false` | FP32 | 词项权重精度最高，posting payload 最大 |
+| `true` | SQ8 | 权重存储最小；首次构建时学习量化范围 |
+| `"fp16"` | FP16 | 权重字节数为 FP32 的一半，不需要 SQ8 范围校准 |
+
+使用 `false` 或 `true` 构建的索引仍保留旧版序列化表示。旧版本 VSAG 无法解析使用新
+`"fp16"` 格式的 SINDI 索引；部署 FP16 产物前应先升级读取端。
+
+### 不可变低内存构建
+
+完成后的 SINDI 只读时，可以设置 `immutable: true`：
+
+```json
+{
+    "dtype": "sparse",
+    "metric_type": "ip",
+    "dim": 1024,
+    "index_param": {
+        "term_id_limit": 30000,
+        "window_size": 50000,
+        "use_quantization": "fp16",
+        "remap_term_ids": true,
+        "immutable": true
+    }
+}
+```
+
+`Build()` 会把每个完成的可变窗口压缩成不可变 payload，并在继续构建前释放临时窗口。该功能
+提交时的 Sparse4M FP16 实测中，构建峰值内存从 27.03 GB 降到 6.08 GB（降低 77.51%），
+构建时间则从约 330 秒增加到 599 秒。这些数字是特定负载的实测证据，不是容量保证。
+
+不可变运行态支持 KNN、范围搜索以及旧版 `Serialize`/`Deserialize`。它不支持增量
+`Add`、`GetSparseVectorByInnerId`、`CalcDistanceById` 与 `CalDistanceById`。
+不可变 SINDI 不支持流式序列化；需要流式格式时应保持索引可变，或使用匹配的旧版序列化接口。
+反序列化时，新建 SINDI 的 `immutable` 设置必须与存储格式一致。
 
 ## 检索参数
 
@@ -105,8 +147,10 @@ auto result = index->KnnSearch(
 
 - 使用 BM25、SPLADE、uniCOIL 等学习稀疏编码器的稀疏检索场景。
 - 稠密 + 稀疏的混合检索管线：SINDI 负责稀疏一路，HGraph / IVF 负责稠密 embedding。
-- 稀疏语料的内存受限部署：`use_quantization: true` 大致能把倒排内存减半，略损召回；
+- 稀疏语料的内存受限部署：`use_quantization: true` 选择 SQ8，`"fp16"` 把 FP32
+  权重字节数减半；
   `use_reorder: true` 以正排内存换召回，`rerank_type: "dmq8"` 可降低这部分正排开销。
+- 需要降低构建峰值内存的只读快照：使用 `immutable: true`，接受更慢的构建和不能增量写入。
 
 SINDI **不支持** 稠密向量，只支持内积相似度。范围检索与基于 ID 的过滤均已支持，
 具体用法参见示例代码。
@@ -138,6 +182,9 @@ SINDI **不支持** 稠密向量，只支持内积相似度。范围检索与基
      分词器、外部词表 ID，或存在大量空白区间的词表，建议设置 `remap_term_ids: true`。
      这样可以避免管理大量空倒排列表带来的内存浪费，也能降低触达 `term_id_limit`
      上限的风险。
+5. 只读低内存构建。当构建峰值内存比构建速度更重要，且完成后不再增量写入时，增加
+     `immutable: true`，通常配合 `use_quantization: "fp16"` 与
+     `remap_term_ids: true` 使用。
 
 ## 标记删除
 

--- a/docs/docs/zh/src/resources/analyze_index.md
+++ b/docs/docs/zh/src/resources/analyze_index.md
@@ -16,12 +16,16 @@ AnalyzeIndexBySearch(const SearchRequest& request);
 
 - **输入**：`SearchRequest`（查询数据集 + `topk` + 搜索参数 JSON）。
 - **输出**：JSON 字符串，包含基于查询的动态指标。
-- **支持的索引类型**：当前支持 `HGraph`、`IVF` 与 `SINDI`。`Pyramid` 仅通过 `GetStats()` 提供
-  静态分析，尚未 override `AnalyzeIndexBySearch`。未实现该接口的索引在调用时会抛出异常。
+- **支持的索引类型**：当前支持 `HGraph`、`IVF` 与 `SINDI`。未实现该接口的
+  索引在调用时会抛出异常。
 
 该接口与 `Index::GetStats()` 互为补充：后者无需查询数据，只输出索引的静态结构指标。
 对于基于图的索引，度分布、入口点质量、子索引召回率以及低召回热点节点等图健康度信息，
 通过 `GetStats()` 而非 `AnalyzeIndexBySearch` 输出。
+
+Pyramid 只通过 `GetStats()` 暴露其 analyzer，目前没有覆写
+`AnalyzeIndexBySearch`。因此对 Pyramid 索引调用该接口，或使用
+`analyze_index --query_path`，都会抛出 `UNSUPPORTED_INDEX_OPERATION`。
 
 ### `GetStats()` 输出的静态指标
 
@@ -45,6 +49,20 @@ AnalyzeIndexBySearch(const SearchRequest& request);
 | `quantization_inversion_count_rate` | 量化导致的距离顺序倒置比率 |
 | `build_cache_hit_rate` | 上一次 `Build()` 中从导入缓存完成 warm-start 的节点占比；当索引并非由 `ImportCache()` 导入的缓存构建时，输出 `skipped_reason` |
 | `build_cache_hit_nodes` / `build_cache_missed_nodes` | `build_cache_hit_rate` 背后的命中 / 未命中节点数（仅在索引由导入缓存构建时存在） |
+
+#### Pyramid 指标
+
+| 指标 | 含义 |
+| --- | --- |
+| `total_count` | 索引中的向量总数 |
+| `index_node_structure` | 路径树节点数、深度、逐层节点数及节点状态分布 |
+| `leaf_node_size_distribution` | 各叶节点向量数量的分布 |
+| `subindex_quality` | 各叶子 GRAPH/FLAT 子索引的状态与规模，以及图/暴搜数量和向量覆盖率 |
+| `recall_base` | 各图节点按规模加权的召回率；仅在采样和分析搜索参数可用时输出 |
+| `graph_node_count` / `total_graph_size` | 参与召回分析的图节点数量及总规模 |
+| `skipped_node_count` / `low_recall_nodes` | 未参与召回分析的节点数，以及低于召回阈值的节点详情 |
+| `duplicate_ratio` | 当前 hierarchy 内的重复向量比例 |
+| `hierarchy_count` / `hierarchies` | 多 hierarchy 数量及按名称组织的上述指标；单个匿名 hierarchy 直接在顶层输出 |
 
 #### SINDI 指标
 
@@ -116,9 +134,8 @@ SINDI 动态召回和距离质量指标需要真值集。可通过 `groundtruth_
 | `HGraph` | `quantization_inversion_count_rate_query` | 搜索阶段量化引起的距离顺序倒置率 |
 | `IVF` | `quantization_bias_ratio` | 搜索阶段观察到的量化偏差（仅在 `use_reorder_` 启用时输出） |
 | `IVF` | `quantization_inversion_count_rate` | 搜索阶段量化引起的距离顺序倒置率（仅在 `use_reorder_` 启用时输出） |
-
-如需度分布、入口点分析或子索引质量分布等图健康度信息，请查看 `GetStats()` 的 JSON 输出——
-`AnalyzeIndexBySearch` 仅关注查询驱动的动态信号。
+静态结构和健康度信息（包括度分布、入口点分析与 Pyramid 子索引质量）请查看
+`GetStats()` 的 JSON 输出。
 
 ## `analyze_index` 工具
 

--- a/docs/docs/zh/src/resources/disk_index.md
+++ b/docs/docs/zh/src/resources/disk_index.md
@@ -55,12 +55,46 @@ HGraph 把一个索引拆成若干个相互独立的 **cell（数据单元）**�
 | `buffer_io` | 磁盘（带缓冲 `pread`） | 是 | 通用磁盘读取，各平台可用 |
 | `mmap_io` | 磁盘（mmap + 页缓存） | 是 | 工作集能放入页缓存时接近内存速度 |
 | `async_io` | 磁盘（Linux libaio） | 是 | 高并发磁盘读；**仅限 Linux + libaio**，否则回退 `buffer_io` |
+| `uring_io` | 磁盘（Linux io_uring） | 是 | 可选 io_uring 后端；需以 `ENABLE_LIBURING=ON` 构建，否则回退 `buffer_io` |
 | `reader_io` | 自定义 `Reader` | 否 | 加载期通过用户 `ReaderSet` 读取（如远程 / 对象存储） |
 
 每个 cell 通过一组扁平参数配置：`graph_io_type` / `graph_file_path`、`base_io_type` /
 `base_file_path`、`precise_io_type` / `precise_file_path`，以及 `raw_vector_io_type` /
 `raw_vector_file_path`。当对应的 `*_io_type` 为磁盘型（`buffer_io`、`mmap_io`、`async_io`）时，
-`*_file_path` **必填**；内存型后端会忽略它。所有 cell 默认均为 `block_memory_io`（全内存）。
+`*_file_path` **必填**；这里的磁盘型后端包括 `buffer_io`、`mmap_io`、`async_io` 与
+`uring_io`。内存型后端会忽略路径。所有 cell 默认均为 `block_memory_io`（全内存）。
+
+### 启用 `uring_io`
+
+`uring_io` 是可选的 Linux 后端。安装 liburing，并在配置 CMake 时开启：
+
+```bash
+cmake -S . -B build-release \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DENABLE_LIBURING=ON \
+    -DENABLE_EXAMPLES=ON
+cmake --build build-release --target 325_feature_uring_io -j
+```
+
+它可以用于支持磁盘 IO 的 cell，例如：
+
+```json
+{
+    "index_param": {
+        "base_io_type": "uring_io",
+        "base_file_path": "/data/vsag/hgraph_base.data",
+        "base_direct_read": true
+    }
+}
+```
+
+HGraph 的 `base_direct_read` 与 `precise_direct_read` 默认都是 `false`。将对应参数设为
+`true`，可让 `uring_io` 通过 direct IO 打开文件并绕过页缓存。请确认目标文件系统支持
+direct IO，并针对实际负载对比两种模式。
+
+如果 VSAG 构建时没有找到 liburing，相同配置仍可加载，但会打印一次性告警并回退到
+`buffer_io`。回退后功能保持可用，但不具备 io_uring 的提交/完成批处理能力。完整加载示例见
+`examples/cpp/325_feature_uring_io.cpp`。
 
 ## 推荐配置：base 留内存，precise 落磁盘
 
@@ -106,6 +140,9 @@ HGraph 把一个索引拆成若干个相互独立的 **cell（数据单元）**�
   Makefile 也会自动传入 `VSAG_ENABLE_LIBAIO=ON`；只有当此前的构建关闭过 libaio 时，才需要用这些
   开关把它重新打开。当 libaio 缺失时（包括 macOS），`async_io` 会打印一次性告警并回退
   `buffer_io`，配置因此保持可移植但失去异步批量能力。生产吞吐场景请在 Linux 上编译进 libaio。
+- **`uring_io` 需要 Linux + liburing，且默认关闭。** 使用
+  `-DENABLE_LIBURING=ON` 开启；否则会回退到 `buffer_io`。请在目标内核、队列深度和 SSD
+  上实测 `uring_io` 与 `async_io`，不要假定其中一个始终更快。
 - **预热页缓存。** 对 `mmap_io` 的 cell，加载后先做一次预热（如顺序读一遍文件、或跑一轮预热
   查询），避免最初的查询承担冷未命中延迟。
 - **规划文件路径与生命周期。** 磁盘型 cell 会写入你提供的 `*_file_path`；请放在快速、专用、

--- a/docs/docs/zh/src/resources/index_parameters.md
+++ b/docs/docs/zh/src/resources/index_parameters.md
@@ -8,13 +8,19 @@
 
 ## 通用参数
 
-所有索引在构建时都需要提供以下顶层字段：
+所有索引在构建时都接受以下顶层字段。其中 `dtype`、`metric_type` 必填，`repr` 可选。
+非稀疏数据必须提供 `dim`；`dtype: "sparse"` 省略 `dim` 时默认使用 `4096`：
 
 | 字段 | 取值 | 说明 |
 |------|------|------|
 | `dim` | 正整数 | 向量维度，构建后不可更改 |
-| `dtype` | `float32` / `fp16` / `bf16` / `int8` | 向量数据类型，决定索引内部表示 |
+| `dtype` | `float32` / `fp16` / `bf16` / `int8` / `sparse` | 标量值类型；`sparse` 为稀疏索引兼容取值 |
+| `repr` | `dense` / `sparse` / `multi_vector` | 可选的数据布局；省略时，`dtype: "sparse"` 推断为 `sparse`，其他类型推断为 `dense` |
 | `metric_type` | `l2` / `ip` / `cosine` | 距离度量 |
+
+`dtype` 与 `repr` 描述不同维度：前者是标量编码，后者是记录布局。显式设置 `repr` 时，
+`dtype: "sparse"` 要求 `repr: "sparse"`。受支持的多向量索引使用
+`repr: "multi_vector"`，并配合 `float32` 等标量 `dtype`。
 
 ## HGraph
 
@@ -39,12 +45,22 @@ HGraph 的构建参数使用通用的 `index_param` 键（参见 `examples/cpp/1
 | `max_degree` | 16~48 | 每节点最大出边数 |
 | `ef_construction` | 200~500 | 构建阶段候选集大小，越大召回越高、构建越慢 |
 | `base_quantization_type` | `fp32` / `fp16` / `bf16` / `sq8` / `sq4` / `pq` | 主存储的量化策略 —— 支持的全部取值见[量化章节](../quantization/README.md) |
+| `use_reverse_edges` | `false` | 跟踪入边，实现 O(1) 反向邻居查找；边存储约翻倍，且压缩图存储不支持 |
+| `label_remap_type` | `pg` | label map 实现：默认 `pg`，或 `robin` |
+| `reorder_source` | `precise` | 从 `precise` 存储或直接从 `base` 重排；RaBitQ x+y split 会自动选择 `base` |
+| `persist_source_id` | `false` | 序列化 HGraph 时保留 Source ID 元数据；适用于恢复索引后继续导出构建缓存 |
+| `mrle_dim` | `0` | MRLE 输出维度，范围 `[0, dim]`；`0` 表示输入维度 |
+| `fast_encode_rabitq` | `true` | 使用多 bit RaBitQ 快速编码；设为 `false` 恢复精确编码器 |
+| `fast_encode_rabitq_rounds` | `6` | 快速编码器微调轮数，范围 `[1, 32]` |
 
 搜索时：
 
 ```json
 {"hgraph": {"ef_search": 100}}
 ```
+
+`ef_search` 接受任意正的有符号 64 位整数，不再存在与 `topk` 相关的上限。非常大的取值会
+明显增加延迟和搜索前沿占用的内存。
 
 `hgraph` 搜索参数还接受 `brute_force_threshold`（`[0.0, 1.0]` 区间的 float，
 默认 `0.0`）。当取值 `> 0` 且当前请求的 filter 的 `ValidRatio()` 不超过该
@@ -109,12 +125,15 @@ LazyHGraph 只支持 `dtype: "float32"`。搜索参数使用 `hgraph` 对象，�
 
 ## Pyramid
 
-Pyramid 支持按 tag 组织多棵子图：
+Pyramid 构建参数同样放在 `index_param` 下：
 
 ```json
 {
-    "pyramid": {
-        "tag_dim": 1,
+    "dtype": "float32",
+    "metric_type": "l2",
+    "dim": 128,
+    "index_param": {
+        "base_quantization_type": "sq8",
         "max_degree": 24,
         "ef_construction": 300
     }
@@ -125,12 +144,18 @@ Pyramid 支持按 tag 组织多棵子图：
 
 ```json
 {
-    "sindi": {
-        "top_k": 32,
+    "dtype": "sparse",
+    "metric_type": "ip",
+    "dim": 1024,
+    "index_param": {
+        "term_id_limit": 30000,
         "doc_prune_ratio": 0.1
     }
 }
 ```
+
+`use_quantization`、不可变构建与 `n_candidate` 等搜索参数见
+[SINDI 页面](../indexes/sindi.md)。
 
 ## 运行期参数
 


### PR DESCRIPTION
## Summary

- document platform and I/O changes since v0.18, including macOS support and the io_uring backend
- cover C and Python API additions, batched distance queries, HGraph build cache, parameters, and statistics
- cover SINDI immutable/FP16 support, Pyramid Analyzer, SIMQ statistics, RaBitQ, `repr`, and `ef_search` behavior
- keep the English and Chinese website documentation synchronized

## Validation

- `git diff --cached --check`
- verified every changed English page has a matching Chinese page
- verified relative Markdown link targets exist
- parsed JSON code blocks in the changed pages

Not run: code build, tests, or mdBook build, per the docs-only/local-resource constraint.