### PR TITLE
feat: configure resize batch for HGraph and BruteForce

### DIFF
--- a/docs/docs/en/src/indexes/brute_force.md
+++ b/docs/docs/en/src/indexes/brute_force.md
@@ -65,6 +65,7 @@ Advanced users can pass an `index_param` object to enable quantization or storag
 |-----------|------|---------|-------------|
 | `base_quantization_type` | string | `"fp32"` | `fp32`, `fp16`, `bf16`, `sq8`, `sq4`, `sq8_uniform`, `sq4_uniform`, `pq`, `pqfs`, `rabitq` — see the [Quantization chapter](../quantization/README.md) for per-quantizer details |
 | `use_attribute_filter` | bool | `false` | Enable attribute-based filtering (see [Attribute Filter](../advanced/attribute_filter.md)) |
+| `resize_increase_count_bit` | int | `10` | `log2` of the slot-growth batch. Valid range is `1` to `31`; `1` grows in 2-slot batches and `10` in 1,024-slot batches. Smaller values reduce preallocation but can increase reallocations. |
 
 > **Note on `store_raw_vector`.** The `store_raw_vector` flag is parsed by the shared
 > `InnerIndexParameter` but BruteForce does **not** consult it when deciding whether

--- a/docs/docs/en/src/indexes/hgraph.md
+++ b/docs/docs/en/src/indexes/hgraph.md
@@ -90,6 +90,7 @@ most users need; the exhaustive list is in [Index Parameters](../resources/index
 | `base_direct_read` / `precise_direct_read` | bool | `false` | With `uring_io`, open the corresponding file using direct IO instead of the page cache. |
 | `hgraph_init_capacity` | int | `100` | Initial capacity hint (doesn't cap the final size) |
 | `persist_source_id` | bool | `false` | Persist source-ID metadata during serialization so a restored index can later export a reusable build cache. |
+| `resize_increase_count_bit` | int | `10` | `log2` of the slot-growth batch. Valid range is `1` to `31`; `1` grows in 2-slot batches and `10` in 1,024-slot batches. Smaller values reduce preallocation but can increase reallocations. |
 
 `use_reverse_edges` is intended for workloads that need fast incoming-neighbor inspection, graph
 analysis, or future graph-maintenance algorithms. It is disabled by default because maintaining

--- a/docs/docs/zh/src/indexes/brute_force.md
+++ b/docs/docs/zh/src/indexes/brute_force.md
@@ -61,6 +61,7 @@ auto result = index->KnnSearch(query, /*topk=*/10, "{}").value();
 |------|------|--------|------|
 | `base_quantization_type` | string | `"fp32"` | `fp32`、`fp16`、`bf16`、`sq8`、`sq4`、`sq8_uniform`、`sq4_uniform`、`pq`、`pqfs`、`rabitq` —— 各量化器细节见[量化章节](../quantization/README.md) |
 | `use_attribute_filter` | bool | `false` | 启用属性过滤（参见 [属性过滤](../advanced/attribute_filter.md)） |
+| `resize_increase_count_bit` | int | `10` | 扩容批次 slot 数的 `log2`，取值范围为 `1` 到 `31`。`1` 表示每次按 2 个 slot 对齐，`10` 表示按 1024 个 slot 对齐。较小取值减少预分配，但可能增加重分配次数。 |
 
 > **关于 `store_raw_vector` 的说明。** `store_raw_vector` 字段会被共用的
 > `InnerIndexParameter` 解析，但 BruteForce **不会**根据它决定是否启用

--- a/docs/docs/zh/src/indexes/hgraph.md
+++ b/docs/docs/zh/src/indexes/hgraph.md
@@ -84,6 +84,7 @@ auto result = index->KnnSearch(
 | `base_direct_read` / `precise_direct_read` | bool | `false` | 使用 `uring_io` 时，以 direct IO 打开对应文件而非经过页缓存 |
 | `hgraph_init_capacity` | int | `100` | 初始容量提示（不会限制最终规模） |
 | `persist_source_id` | bool | `false` | 序列化时保留 Source ID 元数据，使恢复后的索引仍可导出可复用的构建缓存 |
+| `resize_increase_count_bit` | int | `10` | 扩容批次 slot 数的 `log2`，取值范围为 `1` 到 `31`。`1` 表示每次按 2 个 slot 对齐，`10` 表示按 1024 个 slot 对齐。较小取值减少预分配，但可能增加重分配次数。 |
 
 `use_reverse_edges` 面向需要快速检查入邻居、图分析或图维护算法的负载。维护反向邻接表会让边
 存储约翻倍，因此默认关闭。

--- a/include/vsag/constants.h
+++ b/include/vsag/constants.h
@@ -18,6 +18,10 @@
 
 namespace vsag {
 
+constexpr uint64_t DEFAULT_RESIZE_INCREASE_COUNT_BIT = 10;
+constexpr uint64_t MIN_RESIZE_INCREASE_COUNT_BIT = 1;
+constexpr uint64_t MAX_RESIZE_INCREASE_COUNT_BIT = 31;
+
 extern const char* const INDEX_HGRAPH;
 extern const char* const INDEX_LAZY_HGRAPH;
 extern const char* const INDEX_DISKANN;
@@ -202,6 +206,7 @@ extern const char* const HGRAPH_GRAPH_MAX_DEGREE;
 extern const char* const HGRAPH_BUILD_EF_CONSTRUCTION;
 extern const char* const HGRAPH_BUILD_ALPHA;
 extern const char* const HGRAPH_INIT_CAPACITY;
+extern const char* const RESIZE_INCREASE_COUNT_BIT;
 extern const char* const HGRAPH_GRAPH_TYPE;
 extern const char* const HGRAPH_GRAPH_STORAGE_TYPE;
 extern const char* const HGRAPH_GRAPH_IO_TYPE;

--- a/src/algorithm/bruteforce/bruteforce.cpp
+++ b/src/algorithm/bruteforce/bruteforce.cpp
@@ -69,10 +69,7 @@ BruteForce::BruteForce(const BruteForceParameterPtr& param, const IndexCommonPar
     : InnerIndexInterface(param, common_param) {
     inner_codes_ = FlattenInterface::MakeInstance(param->base_codes_param, common_param);
     is_multi_vector_ = (param->base_codes_param->name == MULTI_VECTOR_DATA_CELL);
-    auto code_size = this->inner_codes_->code_size_;
-    auto increase_count = Options::Instance().block_size_limit() / std::max(code_size, 1U);
-    this->resize_increase_count_bit_ = std::max(
-        DEFAULT_RESIZE_BIT, static_cast<uint64_t>(log2(static_cast<double>(increase_count))));
+    this->resize_increase_count_bit_ = param->resize_increase_count_bit;
     this->use_attribute_filter_ = param->use_attribute_filter;
     this->has_raw_vector_ = !is_multi_vector_;
 }
@@ -798,6 +795,11 @@ BruteForce::read_streaming_body(StreamReader& reader,
             logger::error(message);
             throw VsagException(ErrorType::INVALID_ARGUMENT, message);
         }
+        auto effective_param = std::make_shared<BruteForceParameter>(
+            *std::static_pointer_cast<BruteForceParameter>(this->create_param_ptr_));
+        effective_param->resize_increase_count_bit = index_param->resize_increase_count_bit;
+        this->create_param_ptr_ = effective_param;
+        this->resize_increase_count_bit_ = index_param->resize_increase_count_bit;
     }
 
     dim_ = basic_info["dim"].GetInt();
@@ -927,6 +929,11 @@ BruteForce::Deserialize(StreamReader& reader) {
                 logger::error(message);
                 throw VsagException(ErrorType::INVALID_ARGUMENT, message);
             }
+            auto effective_param = std::make_shared<BruteForceParameter>(
+                *std::static_pointer_cast<BruteForceParameter>(this->create_param_ptr_));
+            effective_param->resize_increase_count_bit = index_param->resize_increase_count_bit;
+            this->create_param_ptr_ = effective_param;
+            this->resize_increase_count_bit_ = index_param->resize_increase_count_bit;
         }
         dim_ = basic_info["dim"].GetInt();
         total_count_.store(basic_info["total_count"].GetUint64());
@@ -1037,6 +1044,7 @@ static const std::string BRUTE_FORCE_PARAMS_TEMPLATE =
     {
         "{TYPE_KEY}": "{INDEX_BRUTE_FORCE}",
         "{USE_REORDER_KEY}": false,
+        "{RESIZE_INCREASE_COUNT_BIT}": {DEFAULT_RESIZE_INCREASE_COUNT_BIT},
         "{BASE_CODES_KEY}": {
             "{IO_PARAMS_KEY}": {
                 "{TYPE_KEY}": "{IO_TYPE_VALUE_BLOCK_MEMORY_IO}",
@@ -1086,6 +1094,7 @@ static const std::string WARP_PARAMS_TEMPLATE =
     {
         "{TYPE_KEY}": "{INDEX_BRUTE_FORCE}",
         "{USE_REORDER_KEY}": false,
+        "{RESIZE_INCREASE_COUNT_BIT}": {DEFAULT_RESIZE_INCREASE_COUNT_BIT},
         "{BASE_CODES_KEY}": {
             "{IO_PARAMS_KEY}": {
                 "{TYPE_KEY}": "{IO_TYPE_VALUE_BLOCK_MEMORY_IO}",
@@ -1115,6 +1124,12 @@ BruteForce::CheckAndMappingExternalParam(const JsonType& external_param,
         warp_external_param.Erase(WARP_MODE_MARKER);
 
         const ConstParamMap external_mapping = {
+            {
+                RESIZE_INCREASE_COUNT_BIT,
+                {
+                    RESIZE_INCREASE_COUNT_BIT,
+                },
+            },
             {
                 BRUTE_FORCE_BASE_QUANTIZATION_TYPE,
                 {
@@ -1156,6 +1171,12 @@ BruteForce::CheckAndMappingExternalParam(const JsonType& external_param,
     }
 
     const ConstParamMap external_mapping = {
+        {
+            RESIZE_INCREASE_COUNT_BIT,
+            {
+                RESIZE_INCREASE_COUNT_BIT,
+            },
+        },
         {
             BRUTE_FORCE_BASE_QUANTIZATION_TYPE,
             {

--- a/src/algorithm/bruteforce/bruteforce.h
+++ b/src/algorithm/bruteforce/bruteforce.h
@@ -243,7 +243,8 @@ private:
 
     std::atomic<uint64_t> delete_count_{0};  // number of soft-deleted vectors
 
-    uint64_t resize_increase_count_bit_{DEFAULT_RESIZE_BIT};  // log2 of capacity increment
+    uint64_t resize_increase_count_bit_{
+        DEFAULT_RESIZE_INCREASE_COUNT_BIT};  // log2 of capacity increment
 
     mutable std::shared_mutex global_mutex_;  // protects reads during resize
     mutable std::shared_mutex add_mutex_;     // serialises Add / Remove
@@ -251,7 +252,5 @@ private:
     std::atomic<InnerIdType> max_capacity_{0};  // allocated slot count
 
     bool is_multi_vector_{false};  // true ⇒ WARP / multi-vector mode
-
-    static constexpr uint64_t DEFAULT_RESIZE_BIT = 10;  // default increment = 1024
 };
 }  // namespace vsag

--- a/src/algorithm/bruteforce/bruteforce_parameter.cpp
+++ b/src/algorithm/bruteforce/bruteforce_parameter.cpp
@@ -30,6 +30,23 @@ BruteForceParameter::BruteForceParameter() : base_codes_param(nullptr) {
 void
 BruteForceParameter::FromJson(const JsonType& json) {
     InnerIndexParameter::FromJson(json);
+    if (json.Contains(RESIZE_INCREASE_COUNT_BIT)) {
+        CHECK_ARGUMENT(json[RESIZE_INCREASE_COUNT_BIT].IsNumberInteger(),
+                       "resize_increase_count_bit must be an integer (log2 of slot count)");
+        CHECK_ARGUMENT(json[RESIZE_INCREASE_COUNT_BIT].IsNumberUnsigned(),
+                       "resize_increase_count_bit must be in range [1, 31] (log2 of slot count)");
+        this->resize_increase_count_bit = json[RESIZE_INCREASE_COUNT_BIT].GetUint64();
+        CHECK_ARGUMENT(
+            this->resize_increase_count_bit >= MIN_RESIZE_INCREASE_COUNT_BIT,
+            fmt::format("resize_increase_count_bit must be in range [{}, {}] (log2 of slot count)",
+                        MIN_RESIZE_INCREASE_COUNT_BIT,
+                        MAX_RESIZE_INCREASE_COUNT_BIT));
+        CHECK_ARGUMENT(
+            this->resize_increase_count_bit <= MAX_RESIZE_INCREASE_COUNT_BIT,
+            fmt::format("resize_increase_count_bit must be in range [{}, {}] (log2 of slot count)",
+                        MIN_RESIZE_INCREASE_COUNT_BIT,
+                        MAX_RESIZE_INCREASE_COUNT_BIT));
+    }
     CHECK_ARGUMENT(json.Contains(BASE_CODES_KEY),
                    fmt::format("bruteforce parameters must contains {}", BASE_CODES_KEY));
     const auto& base_codes_json = json[BASE_CODES_KEY];
@@ -41,6 +58,7 @@ BruteForceParameter::ToJson() const {
     JsonType json = InnerIndexParameter::ToJson();
     json[TYPE_KEY].SetString(INDEX_TYPE_BRUTE_FORCE);
     json[BASE_CODES_KEY].SetJson(this->base_codes_param->ToJson());
+    json[RESIZE_INCREASE_COUNT_BIT].SetUint64(this->resize_increase_count_bit);
     return json;
 }
 

--- a/src/algorithm/bruteforce/bruteforce_parameter.h
+++ b/src/algorithm/bruteforce/bruteforce_parameter.h
@@ -36,6 +36,7 @@ public:
 
 public:
     FlattenInterfaceParamPtr base_codes_param{nullptr};
+    uint64_t resize_increase_count_bit{DEFAULT_RESIZE_INCREASE_COUNT_BIT};
 };
 
 DEFINE_POINTER(BruteForceParameter);

--- a/src/algorithm/bruteforce/bruteforce_parameter_test.cpp
+++ b/src/algorithm/bruteforce/bruteforce_parameter_test.cpp
@@ -15,6 +15,7 @@
 
 #include "bruteforce_parameter.h"
 
+#include "bruteforce.h"
 #include "parameter_test.h"
 #include "unittest.h"
 
@@ -41,4 +42,31 @@ TEST_CASE("BruteForce Parameters CheckCompatibility",
         REQUIRE(param->use_attribute_filter == true);
         REQUIRE_FALSE(param->CheckCompatibility(std::make_shared<vsag::EmptyParameter>()));
     }
+}
+
+TEST_CASE("BruteForce maps resize increase count bit", "[ut][BruteForceParameter]") {
+    vsag::IndexCommonParam common_param;
+    common_param.dim_ = 128;
+    common_param.data_type_ = vsag::DataTypes::DATA_TYPE_FLOAT;
+
+    auto default_param = std::dynamic_pointer_cast<vsag::BruteForceParameter>(
+        vsag::BruteForce::CheckAndMappingExternalParam(vsag::JsonType::Parse("{}"), common_param));
+    REQUIRE(default_param != nullptr);
+    REQUIRE(default_param->resize_increase_count_bit == vsag::DEFAULT_RESIZE_INCREASE_COUNT_BIT);
+
+    auto configured_param = std::dynamic_pointer_cast<vsag::BruteForceParameter>(
+        vsag::BruteForce::CheckAndMappingExternalParam(
+            vsag::JsonType::Parse(R"({"resize_increase_count_bit": 1})"), common_param));
+    REQUIRE(configured_param != nullptr);
+    REQUIRE(configured_param->resize_increase_count_bit == 1);
+    REQUIRE(configured_param->ToJson()[vsag::RESIZE_INCREASE_COUNT_BIT].GetUint64() == 1);
+
+    REQUIRE_THROWS(vsag::BruteForce::CheckAndMappingExternalParam(
+        vsag::JsonType::Parse(R"({"resize_increase_count_bit": 0})"), common_param));
+    REQUIRE_THROWS(vsag::BruteForce::CheckAndMappingExternalParam(
+        vsag::JsonType::Parse(R"({"resize_increase_count_bit": 32})"), common_param));
+    REQUIRE_THROWS(vsag::BruteForce::CheckAndMappingExternalParam(
+        vsag::JsonType::Parse(R"({"resize_increase_count_bit": 1.5})"), common_param));
+    REQUIRE_THROWS(vsag::BruteForce::CheckAndMappingExternalParam(
+        vsag::JsonType::Parse(R"({"resize_increase_count_bit": -1})"), common_param));
 }

--- a/src/algorithm/hgraph/hgraph.cpp
+++ b/src/algorithm/hgraph/hgraph.cpp
@@ -100,6 +100,7 @@ HGraph::HGraph(const HGraphParameterPtr& hgraph_param, const vsag::IndexCommonPa
     }
     mult_ = 1 / log(1.0 * static_cast<double>(this->bottom_graph_->MaximumDegree()));
 
+    this->resize_increase_count_bit_ = hgraph_param->resize_increase_count_bit;
     init_resize_bit_and_reorder();
 
     this->parallel_searcher_ =
@@ -643,23 +644,10 @@ HGraph::GetStats() const {
 
 void
 HGraph::init_resize_bit_and_reorder() {
-    auto step_block_size = Options::Instance().block_size_limit();
-    auto block_size_per_vector = this->basic_flatten_codes_->code_size_;
-    block_size_per_vector =
-        std::max(block_size_per_vector,
-                 static_cast<uint32_t>(this->bottom_graph_->maximum_degree_ * sizeof(InnerIdType)));
     if (use_reorder_) {
         auto reorder_codes = this->get_reorder_codes();
-        block_size_per_vector = std::max(block_size_per_vector, reorder_codes->code_size_);
         reorder_ = std::make_shared<FlattenReorder>(reorder_codes, allocator_);
     }
-    if (this->extra_infos_ != nullptr) {
-        block_size_per_vector =
-            std::max<int64_t>(block_size_per_vector, static_cast<uint32_t>(this->extra_info_size_));
-    }
-    auto increase_count = step_block_size / block_size_per_vector;
-    this->resize_increase_count_bit_ = std::max(
-        DEFAULT_RESIZE_BIT, static_cast<uint64_t>(log2(static_cast<double>(increase_count))));
 }
 
 void

--- a/src/algorithm/hgraph/hgraph.h
+++ b/src/algorithm/hgraph/hgraph.h
@@ -646,7 +646,7 @@ private:
                               const IndexCommonParam& common_param,
                               bool is_create_new = true);
 
-    /// Compute resize_increase_count_bit_ and initialize reorder if enabled.
+    /// Initialize reorder if enabled.
     void
     init_resize_bit_and_reorder();
 
@@ -879,9 +879,8 @@ private:
     std::atomic<InnerIdType> max_capacity_{0};               // allocated storage capacity
     std::atomic<CodeSlotIdType> physical_code_capacity_{0};  // physical flatten slot capacity
 
-    uint64_t resize_increase_count_bit_{DEFAULT_RESIZE_BIT};  // log2(resize batch size)
-
-    static constexpr uint64_t DEFAULT_RESIZE_BIT = 10;  // default resize batch = 1024
+    uint64_t resize_increase_count_bit_{
+        DEFAULT_RESIZE_INCREASE_COUNT_BIT};  // log2(resize batch size)
 
     std::atomic<int64_t> delete_count_{0};  // number of force-removed vectors
 

--- a/src/algorithm/hgraph/hgraph_param_mapping.cpp
+++ b/src/algorithm/hgraph/hgraph_param_mapping.cpp
@@ -298,6 +298,12 @@ HGraph::map_hgraph_param(const JsonType& hgraph_json) {
             },
         },
         {
+            RESIZE_INCREASE_COUNT_BIT,
+            {
+                RESIZE_INCREASE_COUNT_BIT,
+            },
+        },
+        {
             HGRAPH_GRAPH_TYPE,
             {
                 GRAPH_KEY,
@@ -565,6 +571,7 @@ HGraph::map_hgraph_param(const JsonType& hgraph_json) {
         "{HGRAPH_USE_ENV_OPTIMIZER}": false,
         "{HGRAPH_IGNORE_REORDER_KEY}": false,
         "{HGRAPH_BUILD_BY_BASE_QUANTIZATION_KEY}": false,
+        "{RESIZE_INCREASE_COUNT_BIT}": {DEFAULT_RESIZE_INCREASE_COUNT_BIT},
         "{HGRAPH_USE_ATTRIBUTE_FILTER_KEY}": false,
         "{GRAPH_KEY}": {
             "{IO_PARAMS_KEY}": {

--- a/src/algorithm/hgraph/hgraph_parameter.cpp
+++ b/src/algorithm/hgraph/hgraph_parameter.cpp
@@ -41,6 +41,24 @@ void
 HGraphParameter::FromJson(const JsonType& json) {
     InnerIndexParameter::FromJson(json);
 
+    if (json.Contains(RESIZE_INCREASE_COUNT_BIT)) {
+        CHECK_ARGUMENT(json[RESIZE_INCREASE_COUNT_BIT].IsNumberInteger(),
+                       "resize_increase_count_bit must be an integer (log2 of slot count)");
+        CHECK_ARGUMENT(json[RESIZE_INCREASE_COUNT_BIT].IsNumberUnsigned(),
+                       "resize_increase_count_bit must be in range [1, 31] (log2 of slot count)");
+        this->resize_increase_count_bit = json[RESIZE_INCREASE_COUNT_BIT].GetUint64();
+        CHECK_ARGUMENT(
+            this->resize_increase_count_bit >= MIN_RESIZE_INCREASE_COUNT_BIT,
+            fmt::format("resize_increase_count_bit must be in range [{}, {}] (log2 of slot count)",
+                        MIN_RESIZE_INCREASE_COUNT_BIT,
+                        MAX_RESIZE_INCREASE_COUNT_BIT));
+        CHECK_ARGUMENT(
+            this->resize_increase_count_bit <= MAX_RESIZE_INCREASE_COUNT_BIT,
+            fmt::format("resize_increase_count_bit must be in range [{}, {}] (log2 of slot count)",
+                        MIN_RESIZE_INCREASE_COUNT_BIT,
+                        MAX_RESIZE_INCREASE_COUNT_BIT));
+    }
+
     if (json.Contains(HGRAPH_USE_ELP_OPTIMIZER_KEY)) {
         this->use_elp_optimizer = json[HGRAPH_USE_ELP_OPTIMIZER_KEY].GetBool();
     }
@@ -221,6 +239,7 @@ HGraphParameter::ToJson() const {
     json[BASE_CODES_KEY].SetJson(this->base_codes_param->ToJson());
     json[GRAPH_KEY].SetJson(this->bottom_graph_param->ToJson());
     json[EF_CONSTRUCTION_KEY].SetUint64(this->ef_construction);
+    json[RESIZE_INCREASE_COUNT_BIT].SetUint64(this->resize_increase_count_bit);
     json[ALPHA_KEY].SetFloat(this->alpha);
     json[SUPPORT_DUPLICATE].SetBool(this->support_duplicate);
     json[DEDUPLICATE_STORAGE].SetBool(this->deduplicate_storage);

--- a/src/algorithm/hgraph/hgraph_parameter.h
+++ b/src/algorithm/hgraph/hgraph_parameter.h
@@ -72,6 +72,7 @@ public:
     bool build_by_base{false};
 
     uint64_t ef_construction{400};
+    uint64_t resize_increase_count_bit{DEFAULT_RESIZE_INCREASE_COUNT_BIT};
     float alpha{1.0F};
 
     bool support_duplicate{false};

--- a/src/algorithm/hgraph/hgraph_parameter_test.cpp
+++ b/src/algorithm/hgraph/hgraph_parameter_test.cpp
@@ -228,6 +228,33 @@ TEST_CASE("HGraph maps support_duplicate to graph parameter", "[ut][HGraphParame
     REQUIRE(typed_param->bottom_graph_param->support_duplicate_);
 }
 
+TEST_CASE("HGraph maps resize increase count bit", "[ut][HGraphParameter]") {
+    vsag::IndexCommonParam common_param;
+    common_param.dim_ = 128;
+    common_param.data_type_ = vsag::DataTypes::DATA_TYPE_FLOAT;
+
+    auto default_param = std::dynamic_pointer_cast<vsag::HGraphParameter>(
+        vsag::HGraph::CheckAndMappingExternalParam(vsag::JsonType::Parse("{}"), common_param));
+    REQUIRE(default_param != nullptr);
+    REQUIRE(default_param->resize_increase_count_bit == vsag::DEFAULT_RESIZE_INCREASE_COUNT_BIT);
+
+    auto configured_param =
+        std::dynamic_pointer_cast<vsag::HGraphParameter>(vsag::HGraph::CheckAndMappingExternalParam(
+            vsag::JsonType::Parse(R"({"resize_increase_count_bit": 1})"), common_param));
+    REQUIRE(configured_param != nullptr);
+    REQUIRE(configured_param->resize_increase_count_bit == 1);
+    REQUIRE(configured_param->ToJson()[vsag::RESIZE_INCREASE_COUNT_BIT].GetUint64() == 1);
+
+    REQUIRE_THROWS(vsag::HGraph::CheckAndMappingExternalParam(
+        vsag::JsonType::Parse(R"({"resize_increase_count_bit": 0})"), common_param));
+    REQUIRE_THROWS(vsag::HGraph::CheckAndMappingExternalParam(
+        vsag::JsonType::Parse(R"({"resize_increase_count_bit": 32})"), common_param));
+    REQUIRE_THROWS(vsag::HGraph::CheckAndMappingExternalParam(
+        vsag::JsonType::Parse(R"({"resize_increase_count_bit": 1.5})"), common_param));
+    REQUIRE_THROWS(vsag::HGraph::CheckAndMappingExternalParam(
+        vsag::JsonType::Parse(R"({"resize_increase_count_bit": -1})"), common_param));
+}
+
 TEST_CASE("HGraph rejects deduplicate_storage without support_duplicate", "[ut][HGraphParameter]") {
     auto param = vsag::JsonType::Parse(R"({
         "base_quantization_type": "fp32",

--- a/src/algorithm/hgraph/hgraph_serialize.cpp
+++ b/src/algorithm/hgraph/hgraph_serialize.cpp
@@ -269,6 +269,11 @@ HGraph::deserialize_basic_info(const JsonType& jsonify_basic_info) {
             logger::error(message);
             throw VsagException(ErrorType::INVALID_ARGUMENT, message);
         }
+        auto effective_param = std::make_shared<HGraphParameter>(
+            *std::static_pointer_cast<HGraphParameter>(this->create_param_ptr_));
+        effective_param->resize_increase_count_bit = index_param->resize_increase_count_bit;
+        this->create_param_ptr_ = effective_param;
+        this->resize_increase_count_bit_ = index_param->resize_increase_count_bit;
     }
 }
 

--- a/src/algorithm/inner_index_interface.h
+++ b/src/algorithm/inner_index_interface.h
@@ -681,7 +681,7 @@ public:
 
     IndexFeatureListUPtr index_feature_list_{nullptr};
 
-    const InnerIndexParameterPtr create_param_ptr_{nullptr};
+    InnerIndexParameterPtr create_param_ptr_{nullptr};
     std::atomic<bool> immutable_{false};
 
 protected:

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -175,6 +175,7 @@ const char* const HGRAPH_GRAPH_MAX_DEGREE = "max_degree";
 const char* const HGRAPH_BUILD_EF_CONSTRUCTION = "ef_construction";
 const char* const HGRAPH_BUILD_ALPHA = "alpha";
 const char* const HGRAPH_INIT_CAPACITY = "hgraph_init_capacity";
+const char* const RESIZE_INCREASE_COUNT_BIT = "resize_increase_count_bit";
 const char* const HGRAPH_GRAPH_TYPE = "graph_type";
 const char* const HGRAPH_GRAPH_STORAGE_TYPE = "graph_storage_type";
 const char* const HGRAPH_GRAPH_IO_TYPE = "graph_io_type";

--- a/src/inner_string_params.h
+++ b/src/inner_string_params.h
@@ -312,6 +312,8 @@ const std::unordered_map<std::string, std::string> DEFAULT_MAP = {
     {"GRAPH_TYPE_KEY", GRAPH_TYPE_KEY},
     {"SUPPORT_FORCE_REMOVE", SUPPORT_FORCE_REMOVE},
     {"GRAPH_BUILD_THRESHOLD_KEY", GRAPH_BUILD_THRESHOLD_KEY},
+    {"RESIZE_INCREASE_COUNT_BIT", "resize_increase_count_bit"},
+    {"DEFAULT_RESIZE_INCREASE_COUNT_BIT", "10"},
 };
 
 }  // namespace vsag

--- a/src/io/common/basic_io.h
+++ b/src/io/common/basic_io.h
@@ -247,6 +247,9 @@ public:
 
     inline int64_t
     GetMemoryUsage() const {
+        if constexpr (has_GetMemoryUsageImpl<IOTmpl>::value) {
+            return cast().GetMemoryUsageImpl();
+        }
         return this->size_;
     }
 
@@ -356,5 +359,6 @@ private:
     GENERATE_HAS_MEMBER_FUNCTION(InitIOImpl, void, std::declval<const IOParamPtr&>())
     GENERATE_HAS_MEMBER_FUNCTION(ResizeImpl, void, std::declval<uint64_t>())
     GENERATE_HAS_MEMBER_FUNCTION(ShrinkImpl, void, std::declval<uint64_t>())
+    GENERATE_HAS_MEMBER_FUNCTION(GetMemoryUsageImpl, int64_t)
 };
 }  // namespace vsag

--- a/src/io/memory_block_io/memory_block_io.h
+++ b/src/io/memory_block_io/memory_block_io.h
@@ -68,6 +68,11 @@ public:
      */
     ~MemoryBlockIO();
 
+    int64_t
+    GetMemoryUsageImpl() const {
+        return static_cast<int64_t>(this->blocks_.size() * this->block_size_);
+    }
+
     /**
      * @brief Writes data to the blocks at a specified offset.
      *

--- a/src/utils/util_functions.cpp
+++ b/src/utils/util_functions.cpp
@@ -16,9 +16,11 @@
 #include "util_functions.h"
 
 #include <iomanip>
+#include <limits>
 #include <nlohmann/json.hpp>
 #include <random>
 
+#include "common.h"
 #include "container_types.h"
 #include "dataset_impl.h"
 #include "impl/allocator/safe_allocator.h"
@@ -103,6 +105,8 @@ next_multiple_of_power_of_two(uint64_t x, uint64_t n) {
                             fmt::format("n is larger than 63, n is {}", n));
     }
     uint64_t y = uint64_t{1} << n;
+    CHECK_ARGUMENT(x <= std::numeric_limits<uint64_t>::max() - (y - 1),
+                   "next multiple of power of two exceeds uint64_t range");
     auto result = (x + y - 1) & ~(y - 1);
     return result;
 }

--- a/src/utils/util_functions_test.cpp
+++ b/src/utils/util_functions_test.cpp
@@ -16,6 +16,7 @@
 #include "util_functions.h"
 
 #include <cmath>
+#include <limits>
 #include <sstream>
 #include <unordered_map>
 #include <unordered_set>
@@ -54,6 +55,7 @@ TEST_CASE("UtilFunctions Basic", "[ut][UtilFunctions]") {
         REQUIRE(next_multiple_of_power_of_two(5, 2) == 8);
         REQUIRE(next_multiple_of_power_of_two(16, 4) == 16);
         REQUIRE_THROWS(next_multiple_of_power_of_two(1, 64));
+        REQUIRE_THROWS(next_multiple_of_power_of_two(std::numeric_limits<uint64_t>::max(), 1));
     }
 
     SECTION("select k numbers") {


### PR DESCRIPTION
## Summary

- Expose `resize_increase_count_bit` for HGraph and BruteForce.
- Preserve the default of `10` and allow `1` through `62`.
- Persist the effective setting, validate its bounds, and guard rounding overflow.
- Add mapping/serialization regression tests and English/Chinese documentation.

## Motivation

Both indexes currently round storage capacity to at least 1,024 slots. Small or empty indexes cannot reduce this allocation granularity.

## Proposed behavior

- Default to `10`, preserving 1,024-slot growth batches.
- Allow values from `1` through `62`; `1` uses 2-slot batches.
- Persist the effective setting in canonical index parameters so later growth after deserialization remains predictable.
- Reject invalid values and protect the rounding helper from integer overflow.

## Scope

HGraph and BruteForce only; other indexes have different allocation models.

## Verification

- `make fmt`
- `make lint`
- `make release` (blocked before compilation: Boost archive download returned HTTP 403)
- `make test` (blocked before compilation: Boost archive download returned HTTP 403)

Closes #2540