### PR TITLE
fix(pyramid): remove immutable state shadowing in SetImmutable

### DIFF
--- a/src/algorithm/pyramid/pyramid.cpp
+++ b/src/algorithm/pyramid/pyramid.cpp
@@ -1311,14 +1311,14 @@ Pyramid::search_node(const IndexNode* node,
 }
 void
 Pyramid::SetImmutable() {
-    if (this->immutable_) {
+    if (this->immutable_.load(std::memory_order_acquire)) {
         return;
     }
     label_table_->SetImmutable();
     this->points_mutex_.reset();
     this->points_mutex_ = std::make_shared<EmptyMutex>();
     this->searcher_->SetMutexArray(this->points_mutex_);
-    immutable_ = true;
+    this->immutable_.store(true, std::memory_order_release);
 }
 
 float

--- a/src/algorithm/pyramid/pyramid.h
+++ b/src/algorithm/pyramid/pyramid.h
@@ -380,7 +380,6 @@ private:
     ReorderInterfacePtr reorder_{nullptr};  // reorder helper (if use_reorder_)
 
     uint32_t index_min_size_{0};  // min node size before graph is built
-    bool immutable_{false};       // true after SetImmutable()
 };
 
 }  // namespace vsag

--- a/tests/test_pyramid.cpp
+++ b/tests/test_pyramid.cpp
@@ -248,6 +248,37 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
 }
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
+                             "Pyramid Set Immutable",
+                             "[ft][immutable][pyramid]") {
+    const auto metric_type = "l2";
+    PyramidParam pyramid_param;
+    const auto param =
+        GeneratePyramidBuildParametersString(metric_type, dims.front(), pyramid_param);
+    auto index = TestFactory("pyramid", param, true);
+    auto dataset =
+        pool.GetDatasetAndCreate(dims.front(), base_count, metric_type, /*with_path=*/true);
+    TestBuildIndex(index, dataset, true);
+
+    REQUIRE(index->SetImmutable().has_value());
+    REQUIRE(index->SetImmutable().has_value());
+
+    auto add_result = index->Add(dataset->base_);
+    REQUIRE_FALSE(add_result.has_value());
+    REQUIRE(add_result.error().type == vsag::ErrorType::UNSUPPORTED_INDEX_OPERATION);
+
+    auto build_result = index->Build(dataset->base_);
+    REQUIRE_FALSE(build_result.has_value());
+    REQUIRE(build_result.error().type == vsag::ErrorType::UNSUPPORTED_INDEX_OPERATION);
+
+    std::vector<int64_t> ids{dataset->base_->GetIds()[0]};
+    auto remove_result = index->Remove(ids);
+    REQUIRE_FALSE(remove_result.has_value());
+    REQUIRE(remove_result.error().type == vsag::ErrorType::UNSUPPORTED_INDEX_OPERATION);
+
+    TestKnnSearch(index, dataset, GeneratePyramidSearchParametersString(100), 0.94, true);
+}
+
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
                              "Pyramid multi-bit RaBitQ fast encoding",
                              "[ft][pyramid][rabitq]") {
     constexpr int64_t dim = 64;


### PR DESCRIPTION
## Summary

Fix Pyramid immutable state shadowing bug where SetImmutable() did not actually block write operations.

## Changes

- Remove shadowing bool immutable_ member from Pyramid (was hiding base class atomic)
- Use inherited std::atomic<bool> immutable_ with proper memory ordering
- Match the pattern used by HGraph for consistency
- Add regression test to verify Add, Build, and Remove are rejected after SetImmutable()

## Testing

New test case Pyramid Set Immutable verifies:
- SetImmutable() can be called multiple times (idempotent)
- Add() returns UNSUPPORTED_INDEX_OPERATION after SetImmutable()
- Build() returns UNSUPPORTED_INDEX_OPERATION after SetImmutable()
- Remove() returns UNSUPPORTED_INDEX_OPERATION after SetImmutable()
- Search operations continue to work correctly

Fixes: #2548