### PR TITLE
feat: add recall-target search for HGraph

### DIFF
--- a/docs/docs/en/src/api/index_class.md
+++ b/docs/docs/en/src/api/index_class.md
@@ -65,6 +65,24 @@ struct MergeUnit {
 For each source id, `id_map_func` returns `{keep, new_id}`: `keep == true` includes the vector under
 target id `new_id`. Used by [`Merge`](#merge).
 
+### `RecallTarget` and `RecallSearchResult`
+
+```cpp
+struct RecallTarget {
+    int64_t top_k{0};
+    float recall{0.0F};
+};
+
+struct RecallSearchResult {
+    int64_t top_k{0};
+    float recall{0.0F};
+    std::string search_parameters;
+};
+```
+
+`RecallTarget` declares one workload-average estimated-recall target.
+`RecallSearchResult` contains the concrete search parameters selected for that target.
+
 ### `Checkpoint`
 
 ```cpp
@@ -146,6 +164,29 @@ SearchWithRequest(const SearchRequest& request) const;
 Unified KNN or range search driven by [`SearchRequest`](search.md#searchrequest). This is the
 preferred API for new code; it supports attribute filters, callback filters, bitset filters, a
 per-search allocator, and iterator search through one struct.
+
+### Recall-target search
+
+```cpp
+tl::expected<std::vector<RecallSearchResult>, Error>
+CalibrateRecallSearch(const std::vector<RecallTarget>& targets,
+                      const DatasetPtr& calibration_queries);
+
+tl::expected<DatasetPtr, Error>
+KnnSearch(const DatasetPtr& query, int64_t k, float target_recall) const;
+```
+
+`CalibrateRecallSearch` synchronously selects implementation-specific search parameters for every
+declared target and returns the concrete mapping. The required `calibration_queries` must be
+non-empty, match the index dimension and input type, and represent the intended workload. A
+successful call atomically replaces the current mapping; a failed call leaves the previous mapping
+unchanged. Calling it again explicitly recalibrates the mapping.
+
+`target_recall` is workload-average recall relative to an implementation-specific reference, not
+necessarily exact brute-force recall. The `KnnSearch` overload selects one calibrated
+`(k, target_recall)` pair and does not accept a filter. Unsupported indexes return
+`UNSUPPORTED_INDEX_OPERATION`; see [HGraph](../indexes/hgraph.md#recall-target-search) for the first
+implementation and its current restrictions.
 
 ### `KnnSearch` overloads
 

--- a/docs/docs/en/src/indexes/hgraph.md
+++ b/docs/docs/en/src/indexes/hgraph.md
@@ -251,6 +251,48 @@ auto result = index->KnnSearch(
     query, topk, R"({"hgraph": {"ef_search": 200}})").value();
 ```
 
+### Recall-target search
+
+HGraph can explicitly calibrate `ef_search` for a finite set of workload-average recall targets:
+
+```cpp
+assert(index->SetImmutable().has_value());
+
+std::vector<vsag::RecallTarget> targets = {{10, 0.95F}, {100, 0.90F}};
+auto calibration = index->CalibrateRecallSearch(targets, calibration_queries).value();
+
+auto result = index->KnnSearch(query, 10, 0.95F).value();
+```
+
+Calibration is synchronous and uses all supplied queries. For each distinct `top_k`, HGraph obtains
+a high-`ef_search` reference and then binary-searches a lower `ef_search` that reaches each target
+relative to that reference. Internal effort limits keep calibration finite. This avoids scanning
+the entire index, but the reported recall is an estimate relative to an approximate HGraph
+reference, not an exact brute-force guarantee.
+
+The caller must supply queries representative of the intended workload; indexed vectors are not a
+substitute because they can produce an optimistically low `ef_search`. Estimated recall is averaged
+over the calibration queries; it is not a per-query guarantee.
+
+The returned `RecallSearchResult` entries contain concrete JSON `search_parameters`, so callers can
+inspect, persist, or pass them to the regular `KnnSearch` API. A successful calibration atomically
+replaces the complete mapping. A failed calibration leaves the previous mapping unchanged, and
+searches continue to use it. Call `CalibrateRecallSearch` again with a new representative query
+batch when explicit recalibration is needed.
+
+The first implementation intentionally has a narrow contract:
+
+- immutable, non-empty HGraph whose search path can evaluate the supplied query type;
+- only unfiltered `KnnSearch(query, k, target_recall)`; its `(k, target_recall)` pair must match a
+  calibrated target;
+- the mapping is runtime-only; after loading or cloning an index, mark the new index immutable if
+  needed and calibrate it again.
+
+Repeated identical target pairs are coalesced. If representative queries are unavailable, keep
+using the regular `KnnSearch` overload with an explicit `ef_search`. See
+[`326_feature_hgraph_recall_search.cpp`](https://github.com/antgroup/vsag/blob/main/examples/cpp/326_feature_hgraph_recall_search.cpp)
+for a complete example.
+
 ### Brute-force fallback under highly selective filters (`brute_force_threshold`)
 
 Graph traversal is the right strategy when most candidates pass the filter — the

--- a/docs/docs/zh/src/api/index_class.md
+++ b/docs/docs/zh/src/api/index_class.md
@@ -63,6 +63,24 @@ struct MergeUnit {
 对每个源 id，`id_map_func` 返回 `{keep, new_id}`：`keep == true` 表示将该向量以目标 id `new_id` 纳入。
 由 [`Merge`](#merge) 使用。
 
+### `RecallTarget` 与 `RecallSearchResult`
+
+```cpp
+struct RecallTarget {
+    int64_t top_k{0};
+    float recall{0.0F};
+};
+
+struct RecallSearchResult {
+    int64_t top_k{0};
+    float recall{0.0F};
+    std::string search_parameters;
+};
+```
+
+`RecallTarget` 声明一个工作负载平均估计召回率目标，`RecallSearchResult` 返回该目标最终选择的
+具体搜索参数。
+
 ### `Checkpoint`
 
 ```cpp
@@ -142,6 +160,26 @@ SearchWithRequest(const SearchRequest& request) const;
 
 由 [`SearchRequest`](search.md#searchrequest) 驱动的统一 KNN 或范围搜索。这是新代码首选的 API；它通过
 一个结构体即可支持属性过滤、回调过滤、bitset 过滤、逐次搜索 allocator 以及迭代式搜索。
+
+### 召回率目标搜索
+
+```cpp
+tl::expected<std::vector<RecallSearchResult>, Error>
+CalibrateRecallSearch(const std::vector<RecallTarget>& targets,
+                      const DatasetPtr& calibration_queries);
+
+tl::expected<DatasetPtr, Error>
+KnnSearch(const DatasetPtr& query, int64_t k, float target_recall) const;
+```
+
+`CalibrateRecallSearch` 同步为每个已声明档位选择索引实现特有的搜索参数，并返回具体映射。
+必填的 `calibration_queries` 必须非空、与索引的维度和输入类型一致，并能代表预期负载。
+校准成功后会原子替换当前映射；校准失败时继续保留旧映射。再次显式调用该接口即可重新校准。
+
+`target_recall` 表示相对于具体索引 reference 的工作负载平均召回率，不一定等同于精确暴搜召回率。
+新增的 `KnnSearch` 重载只能使用已校准的 `(k, target_recall)` 档位，并且不接受过滤条件。
+未实现该能力的索引返回 `UNSUPPORTED_INDEX_OPERATION`。首个实现及当前限制见
+[HGraph](../indexes/hgraph.md#召回率目标搜索)。
 
 ### KnnSearch 重载
 

--- a/docs/docs/zh/src/indexes/hgraph.md
+++ b/docs/docs/zh/src/indexes/hgraph.md
@@ -233,6 +233,42 @@ auto result = index->KnnSearch(
     query, topk, R"({"hgraph": {"ef_search": 200}})").value();
 ```
 
+### 召回率目标搜索
+
+HGraph 可以针对有限个工作负载平均召回率档位显式校准 `ef_search`：
+
+```cpp
+assert(index->SetImmutable().has_value());
+
+std::vector<vsag::RecallTarget> targets = {{10, 0.95F}, {100, 0.90F}};
+auto calibration = index->CalibrateRecallSearch(targets, calibration_queries).value();
+
+auto result = index->KnnSearch(query, 10, 0.95F).value();
+```
+
+校准同步执行，并使用全部 `calibration_queries`。对于每个不同的 `top_k`，HGraph 先获得一个高
+`ef_search` 的 reference，再二分选择相对于该 reference 满足各档位的较小 `ef_search`。内部评估
+上限保证校准过程能够结束。该方法避免扫描整个索引，但这里的 recall 是相对 HGraph 近似 reference
+的估计值，不是精确暴搜保证。
+
+调用方必须提供能代表预期负载的查询；库内向量不能替代真实查询分布，否则可能得到过于乐观的低
+`ef_search`。估计召回率是在整批校准查询上取平均值，并非逐查询保证。
+
+返回的 `RecallSearchResult` 包含具体 JSON `search_parameters`，调用方可以检查、保存或直接传给
+普通 `KnnSearch`。校准成功后会原子替换完整映射；校准失败时继续保留并使用旧映射。需要更新时，
+由调用方收集新的代表性查询并再次显式调用 `CalibrateRecallSearch`。
+
+首版刻意保持较窄的契约：
+
+- 非空、immutable，且搜索路径能够处理所提供查询类型的 HGraph；
+- 仅支持无过滤的 `KnnSearch(query, k, target_recall)`，其 `(k, target_recall)` 必须匹配已配置
+  档位；
+- 映射只存在于运行期；加载或克隆索引后，需要时先将新索引设为 immutable，再重新校准。
+
+重复的相同档位会被合并。如果没有具有代表性的查询，应继续通过普通 `KnnSearch` 显式传入
+`ef_search`。完整示例见
+[`326_feature_hgraph_recall_search.cpp`](https://github.com/antgroup/vsag/blob/main/examples/cpp/326_feature_hgraph_recall_search.cpp)。
+
 ### 高选择性过滤下的暴搜回退（`brute_force_threshold`）
 
 图搜索在大多数候选都能通过过滤时是最优策略——图遍历能很快进入查询邻域。但是当

--- a/examples/cpp/326_feature_hgraph_recall_search.cpp
+++ b/examples/cpp/326_feature_hgraph_recall_search.cpp
@@ -1,0 +1,102 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <vsag/vsag.h>
+
+#include <exception>
+#include <iostream>
+#include <random>
+#include <vector>
+
+int
+main() {
+    try {
+        constexpr int64_t dim = 8;
+        constexpr int64_t count = 100;
+
+        std::mt19937 random(47);
+        std::uniform_real_distribution<float> distribution;
+        std::vector<int64_t> ids(count);
+        std::vector<float> vectors(count * dim);
+        for (int64_t i = 0; i < count; ++i) {
+            ids[i] = i;
+        }
+        for (auto& value : vectors) {
+            value = distribution(random);
+        }
+
+        auto base = vsag::Dataset::Make()
+                        ->NumElements(count)
+                        ->Dim(dim)
+                        ->Ids(ids.data())
+                        ->Float32Vectors(vectors.data())
+                        ->Owner(false);
+        auto index = vsag::Factory::CreateIndex("hgraph", R"({
+        "dtype": "float32",
+        "metric_type": "l2",
+        "dim": 8,
+        "index_param": {
+            "base_quantization_type": "fp32",
+            "max_degree": 16,
+            "ef_construction": 100,
+            "build_thread_count": 1
+        }
+    })")
+                         .value();
+        index->Build(base).value();
+        auto immutable_result = index->SetImmutable();
+        if (not immutable_result.has_value()) {
+            std::cerr << "SetImmutable failed: " << immutable_result.error().message << '\n';
+            return 1;
+        }
+
+        std::vector<float> calibration_vectors(10 * dim);
+        for (auto& value : calibration_vectors) {
+            value = distribution(random);
+        }
+        auto calibration_queries = vsag::Dataset::Make()
+                                       ->NumElements(10)
+                                       ->Dim(dim)
+                                       ->Float32Vectors(calibration_vectors.data())
+                                       ->Owner(false);
+
+        const std::vector<vsag::RecallTarget> targets = {{5, 0.9F}, {10, 0.9F}};
+        auto calibration = index->CalibrateRecallSearch(targets, calibration_queries);
+        if (not calibration.has_value()) {
+            std::cerr << "CalibrateRecallSearch failed: " << calibration.error().message << '\n';
+            return 1;
+        }
+        for (const auto& result : calibration.value()) {
+            std::cout << "top_k=" << result.top_k << ", recall=" << result.recall
+                      << ", search_parameters=" << result.search_parameters << '\n';
+        }
+
+        auto query = vsag::Dataset::Make()
+                         ->NumElements(1)
+                         ->Dim(dim)
+                         ->Float32Vectors(calibration_vectors.data())
+                         ->Owner(false);
+        auto result = index->KnnSearch(query, 5, 0.9F).value();
+        for (int64_t i = 0; i < result->GetDim(); ++i) {
+            std::cout << result->GetIds()[i] << ": " << result->GetDistances()[i] << '\n';
+        }
+        return 0;
+    } catch (const std::exception& error) {
+        std::cerr << "Recall search example failed: " << error.what() << '\n';
+        return 1;
+    } catch (...) {
+        std::cerr << "Recall search example failed with an unknown error\n";
+        return 1;
+    }
+}

--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -154,3 +154,6 @@ target_link_libraries(324_feature_lazy_hgraph_extra_info vsag)
 
 add_executable(325_feature_uring_io 325_feature_uring_io.cpp)
 target_link_libraries(325_feature_uring_io vsag)
+
+add_executable(326_feature_hgraph_recall_search 326_feature_hgraph_recall_search.cpp)
+target_link_libraries(326_feature_hgraph_recall_search vsag)

--- a/examples/cpp/README.md
+++ b/examples/cpp/README.md
@@ -102,6 +102,7 @@ together when the directory is listed:
 | [`320_feature_extra_info.cpp`](320_feature_extra_info.cpp) | Attach per-vector extra info / payload. |
 | [`322_feature_hgraph_brute_force_threshold.cpp`](322_feature_hgraph_brute_force_threshold.cpp) | HGraph search-time `brute_force_threshold`: automatically switch to an exact scan under highly selective filters. |
 | [`324_feature_lazy_hgraph_extra_info.cpp`](324_feature_lazy_hgraph_extra_info.cpp) | LazyHGraph `extra_info` filtering across flat and graph phases. |
+| [`326_feature_hgraph_recall_search.cpp`](326_feature_hgraph_recall_search.cpp) | Calibrate and use HGraph `ef_search` for finite `(top_k, recall)` targets. |
 
 ### Persistence (`4xx`)
 

--- a/include/vsag/index.h
+++ b/include/vsag/index.h
@@ -52,6 +52,31 @@ struct MergeUnit {
     IdMapFunction id_map_func = nullptr;
 };
 
+/**
+ * @brief One workload target supported by recall-based search.
+ */
+struct RecallTarget {
+    /** Number of neighbors requested by this workload target. */
+    int64_t top_k{0};
+
+    /** Required workload-average estimated recall, in the range (0, 1]. */
+    float recall{0.0F};
+};
+
+/**
+ * @brief One calibrated recall-search mapping entry.
+ */
+struct RecallSearchResult {
+    /** Number of neighbors requested by this workload target. */
+    int64_t top_k{0};
+
+    /** Workload-average estimated recall target, in the range (0, 1]. */
+    float recall{0.0F};
+
+    /** Concrete parameters accepted by the regular KnnSearch API. */
+    std::string search_parameters;
+};
+
 enum class IndexType {
     HNSW,
     DISKANN,
@@ -1137,6 +1162,38 @@ public:
 #elif defined(_MSC_VER)
 #pragma warning(pop)
 #endif
+    }
+
+    /**
+     * @brief Calibrate search parameters for a finite set of workload recall targets.
+     *
+     * Calibration is synchronous. A successful call atomically replaces the active mapping;
+     * a failed call leaves the previous mapping unchanged.
+     *
+     * @param targets Finite set of supported (top-k, recall) pairs.
+     * @param calibration_queries Non-empty workload queries matching the index dimension and
+     *        input type. The caller is responsible for their representativeness.
+     * @return The calibrated mapping, or an error if recall search is unsupported or invalid.
+     */
+    [[nodiscard]] virtual tl::expected<std::vector<RecallSearchResult>, Error>
+    CalibrateRecallSearch(const std::vector<RecallTarget>& targets,
+                          const DatasetPtr& calibration_queries) {
+        return tl::unexpected(
+            Error(ErrorType::UNSUPPORTED_INDEX_OPERATION, "Index does not support recall search"));
+    }
+
+    /**
+     * @brief Run unfiltered KNN search using the calibrated parameter for a recall target.
+     *
+     * @param query One query vector.
+     * @param k Number of nearest neighbors.
+     * @param target_recall Configured workload-average estimated recall target.
+     * @return Search results, or an error if the pair has not been calibrated or is unsupported.
+     */
+    [[nodiscard]] virtual tl::expected<DatasetPtr, Error>
+    KnnSearch(const DatasetPtr& query, int64_t k, float target_recall) const {
+        return tl::unexpected(
+            Error(ErrorType::UNSUPPORTED_INDEX_OPERATION, "Index does not support recall search"));
     }
 };
 

--- a/src/algorithm/hgraph/CMakeLists.txt
+++ b/src/algorithm/hgraph/CMakeLists.txt
@@ -6,6 +6,7 @@ set(HGRAPH_SRCS
     hgraph_parameter.cpp
     hgraph_param_mapping.cpp
     hgraph_search.cpp
+    hgraph_recall_search.cpp
     hgraph_serialize.cpp
     hgraph_cache.cpp
 )

--- a/src/algorithm/hgraph/hgraph.h
+++ b/src/algorithm/hgraph/hgraph.h
@@ -211,6 +211,13 @@ public:
     [[nodiscard]] DatasetPtr
     SearchWithRequest(const SearchRequest& request) const override;
 
+    std::vector<RecallSearchResult>
+    CalibrateRecallSearch(const std::vector<RecallTarget>& targets,
+                          const DatasetPtr& calibration_queries) override;
+
+    [[nodiscard]] DatasetPtr
+    KnnSearch(const DatasetPtr& query, int64_t k, float target_recall) const override;
+
     uint32_t
     Remove(const std::vector<int64_t>& ids, RemoveMode mode = RemoveMode::MARK_REMOVE) override;
 
@@ -376,6 +383,12 @@ public:
                      DistanceRecordVector* rabitq_lower_bound_candidates = nullptr) const;
 
 private:
+    std::string
+    resolve_recall_search_parameters(int64_t top_k, float recall) const;
+
+    DatasetPtr
+    make_calibration_query(const DatasetPtr& queries, uint64_t index) const;
+
     [[nodiscard]] std::shared_lock<std::shared_mutex>
     acquire_global_read_lock() const {
         if (not this->physical_code_resize_pending_.load(std::memory_order_acquire)) {
@@ -845,5 +858,8 @@ private:
     float build_cache_hit_rate_{-1.0F};     // cache hit rate from last cache-based build
     uint64_t build_cache_hit_nodes_{0};     // number of nodes with cache hit
     uint64_t build_cache_missed_nodes_{0};  // number of nodes without cache hit
+
+    std::mutex recall_search_calibration_mutex_;
+    std::shared_ptr<const std::vector<RecallSearchResult>> recall_search_profile_{nullptr};
 };
 }  // namespace vsag

--- a/src/algorithm/hgraph/hgraph_recall_search.cpp
+++ b/src/algorithm/hgraph/hgraph_recall_search.cpp
@@ -1,0 +1,362 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <fmt/format.h>
+
+#include <algorithm>
+#include <cmath>
+#include <mutex>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "hgraph.h"
+#include "impl/logger/logger.h"
+
+namespace vsag {
+
+namespace {
+
+constexpr float RECALL_EPSILON = 1e-6F;
+constexpr double REFERENCE_STABILITY_THRESHOLD = 0.995;
+constexpr int64_t MIN_REFERENCE_EF_SEARCH = 256;
+constexpr int64_t DEFAULT_REFERENCE_EF_SEARCH_CAP = 4096;
+
+using SearchResults = std::vector<std::vector<int64_t>>;
+
+bool
+is_valid_recall(float recall) {
+    return std::isfinite(recall) and recall > 0.0F and recall <= 1.0F;
+}
+
+std::vector<int64_t>
+take_search_ids(const DatasetPtr& result, int64_t top_k) {
+    CHECK_ARGUMENT(result->GetDim() >= top_k,
+                   "not enough vectors to calculate recall-search accuracy");
+    return {result->GetIds(), result->GetIds() + top_k};
+}
+
+std::vector<int64_t>
+run_hgraph_search(const HGraph& index, const DatasetPtr& query, int64_t top_k, int64_t ef_search) {
+    SearchRequest request;
+    request.query_ = query;
+    request.topk_ = top_k;
+    request.params_str_ =
+        fmt::format(R"({{"hgraph":{{"ef_search":{},"parallelism":1}}}})", ef_search);
+
+    return take_search_ids(index.SearchWithRequest(request), top_k);
+}
+
+SearchResults
+run_hgraph_searches(const HGraph& index,
+                    const std::vector<DatasetPtr>& queries,
+                    int64_t top_k,
+                    int64_t ef_search) {
+    SearchResults results;
+    results.reserve(queries.size());
+    for (const auto& query : queries) {
+        results.push_back(run_hgraph_search(index, query, top_k, ef_search));
+    }
+    return results;
+}
+
+double
+recall_at_k(const std::vector<int64_t>& result,
+            const std::vector<int64_t>& reference,
+            int64_t top_k) {
+    CHECK_ARGUMENT(result.size() >= static_cast<uint64_t>(top_k),
+                   "not enough search results to calculate recall-search accuracy");
+    CHECK_ARGUMENT(reference.size() >= static_cast<uint64_t>(top_k),
+                   "not enough reference results to calculate recall-search accuracy");
+    std::unordered_multiset<int64_t> expected(reference.begin(), reference.begin() + top_k);
+    uint64_t recalled = 0;
+    for (int64_t i = 0; i < top_k; ++i) {
+        const auto match = expected.find(result[i]);
+        if (match != expected.end()) {
+            ++recalled;
+            expected.erase(match);
+        }
+    }
+    return static_cast<double>(recalled) / static_cast<double>(top_k);
+}
+
+double
+average_recall(const SearchResults& results, const SearchResults& references, int64_t top_k) {
+    CHECK_ARGUMENT(results.size() == references.size(),
+                   "recall-search result count does not match reference count");
+    double recall_sum = 0.0;
+    for (uint64_t i = 0; i < results.size(); ++i) {
+        recall_sum += recall_at_k(results[i], references[i], top_k);
+    }
+    return recall_sum / static_cast<double>(results.size());
+}
+
+double
+average_recall(const HGraph& index,
+               const std::vector<DatasetPtr>& queries,
+               const SearchResults& references,
+               int64_t top_k,
+               int64_t ef_search) {
+    return average_recall(run_hgraph_searches(index, queries, top_k, ef_search), references, top_k);
+}
+
+struct reference_results {
+    SearchResults results;
+    int64_t ef_search{0};
+};
+
+reference_results
+find_reference_results(const HGraph& index,
+                       const std::vector<DatasetPtr>& queries,
+                       int64_t top_k,
+                       int64_t index_size) {
+    const auto doubled_top_k = top_k > index_size / 2 ? index_size : top_k * 2;
+    auto reference_ef =
+        std::min(index_size, std::max<int64_t>(MIN_REFERENCE_EF_SEARCH, doubled_top_k));
+    auto reference = run_hgraph_searches(index, queries, top_k, reference_ef);
+    if (reference_ef == index_size) {
+        return {std::move(reference), reference_ef};
+    }
+
+    const auto doubled_start = reference_ef > index_size / 2 ? index_size : reference_ef * 2;
+    const auto max_reference_ef =
+        std::min(index_size, std::max<int64_t>(DEFAULT_REFERENCE_EF_SEARCH_CAP, doubled_start));
+    while (reference_ef < max_reference_ef) {
+        const auto next_ef =
+            reference_ef > max_reference_ef / 2 ? max_reference_ef : reference_ef * 2;
+        auto next_reference = run_hgraph_searches(index, queries, top_k, next_ef);
+        const auto stability = average_recall(next_reference, reference, top_k);
+        reference = std::move(next_reference);
+        reference_ef = next_ef;
+        if (stability + RECALL_EPSILON >= REFERENCE_STABILITY_THRESHOLD) {
+            logger::info(
+                "HGraph recall search selected reference ef_search={} for top_k={}, "
+                "stability={}",
+                reference_ef,
+                top_k,
+                stability);
+            return {std::move(reference), reference_ef};
+        }
+    }
+
+    CHECK_ARGUMENT(
+        reference_ef == index_size,
+        fmt::format("recall-search reference did not stabilize by ef_search={} for top_k={}",
+                    reference_ef,
+                    top_k));
+    return {std::move(reference), reference_ef};
+}
+
+std::vector<int64_t>
+calibrate_ef_search(const HGraph& index,
+                    const std::vector<DatasetPtr>& queries,
+                    const std::vector<RecallTarget>& targets,
+                    int64_t max_ef_search) {
+    CHECK_ARGUMENT(not queries.empty(), "recall search has no calibration queries");
+    CHECK_ARGUMENT(not targets.empty(), "recall search has no recall targets");
+
+    std::vector<int64_t> selected_efs(targets.size());
+    std::vector<uint64_t> target_order;
+    target_order.reserve(targets.size());
+    for (uint64_t i = 0; i < targets.size(); ++i) {
+        target_order.push_back(i);
+    }
+    std::sort(target_order.begin(), target_order.end(), [&targets](uint64_t lhs, uint64_t rhs) {
+        if (targets[lhs].top_k != targets[rhs].top_k) {
+            return targets[lhs].top_k < targets[rhs].top_k;
+        }
+        return targets[lhs].recall < targets[rhs].recall;
+    });
+
+    for (uint64_t group_begin = 0; group_begin < target_order.size();) {
+        const auto top_k = targets[target_order[group_begin]].top_k;
+        auto group_end = group_begin + 1;
+        while (group_end < target_order.size() and
+               targets[target_order[group_end]].top_k == top_k) {
+            ++group_end;
+        }
+
+        auto reference = find_reference_results(index, queries, top_k, max_ef_search);
+        std::unordered_map<int64_t, double> recall_cache;
+        recall_cache.emplace(reference.ef_search, 1.0);
+        auto get_recall = [&](int64_t ef_search) {
+            const auto cached = recall_cache.find(ef_search);
+            if (cached != recall_cache.end()) {
+                return cached->second;
+            }
+            const auto recall = average_recall(index, queries, reference.results, top_k, ef_search);
+            recall_cache.emplace(ef_search, recall);
+            return recall;
+        };
+
+        int64_t lower_bound = top_k;
+        for (auto position = group_begin; position < group_end; ++position) {
+            const auto target_index = target_order[position];
+            const auto& target = targets[target_index];
+            auto meets_recall = [&](int64_t ef_search) {
+                return get_recall(ef_search) + RECALL_EPSILON >= target.recall;
+            };
+
+            if (meets_recall(lower_bound)) {
+                selected_efs[target_index] = lower_bound;
+                continue;
+            }
+
+            int64_t low = lower_bound + 1;
+            int64_t high = lower_bound;
+            while (high < reference.ef_search) {
+                high = high > reference.ef_search / 2 ? reference.ef_search : high * 2;
+                if (meets_recall(high)) {
+                    break;
+                }
+                low = high + 1;
+            }
+            CHECK_ARGUMENT(
+                meets_recall(high),
+                fmt::format(
+                    "target recall {} at top_k {} cannot be reached", target.recall, top_k));
+
+            while (low < high) {
+                const auto middle = low + (high - low) / 2;
+                if (meets_recall(middle)) {
+                    high = middle;
+                } else {
+                    low = middle + 1;
+                }
+            }
+            selected_efs[target_index] = low;
+            lower_bound = low;
+        }
+        group_begin = group_end;
+    }
+    return selected_efs;
+}
+
+}  // namespace
+
+DatasetPtr
+HGraph::make_calibration_query(const DatasetPtr& queries, uint64_t index) const {
+    auto query = Dataset::Make()->NumElements(1)->Dim(this->dim_);
+    const auto offset = static_cast<int64_t>(index) * this->dim_;
+
+    if (this->data_type_ == DataTypes::DATA_TYPE_FLOAT) {
+        const auto* vectors = queries->GetFloat32Vectors();
+        CHECK_ARGUMENT(vectors != nullptr, "recall search query must contain float32 vectors");
+        query->Float32Vectors(vectors + offset);
+    } else if (this->data_type_ == DataTypes::DATA_TYPE_INT8) {
+        const auto* vectors = queries->GetInt8Vectors();
+        CHECK_ARGUMENT(vectors != nullptr, "recall search query must contain int8 vectors");
+        query->Int8Vectors(vectors + offset);
+    } else if (this->data_type_ == DataTypes::DATA_TYPE_FP16 or
+               this->data_type_ == DataTypes::DATA_TYPE_BF16) {
+        const auto* vectors = queries->GetFloat16Vectors();
+        CHECK_ARGUMENT(vectors != nullptr, "recall search query must contain float16 vectors");
+        query->Float16Vectors(vectors + offset);
+    } else if (this->data_type_ == DataTypes::DATA_TYPE_SPARSE) {
+        const auto* vectors = queries->GetSparseVectors();
+        CHECK_ARGUMENT(vectors != nullptr, "recall search query must contain sparse vectors");
+        query->SparseVectors(vectors + index);
+    } else {
+        throw VsagException(ErrorType::INVALID_ARGUMENT,
+                            "recall search does not support this query data type");
+    }
+    return query->Owner(false);
+}
+
+std::vector<RecallSearchResult>
+HGraph::CalibrateRecallSearch(const std::vector<RecallTarget>& targets,
+                              const DatasetPtr& calibration_queries) {
+    std::lock_guard calibration_lock(this->recall_search_calibration_mutex_);
+    CHECK_ARGUMENT(this->immutable_.load(std::memory_order_acquire),
+                   "recall search calibration requires an immutable index");
+    CHECK_ARGUMENT(this->GetNumElements() > 0, "cannot calibrate recall search on an empty index");
+    CHECK_ARGUMENT(not targets.empty(), "recall search targets cannot be empty");
+    CHECK_ARGUMENT(calibration_queries != nullptr,
+                   "recall search calibration_queries are required");
+    CHECK_ARGUMENT(calibration_queries->GetNumElements() > 0,
+                   "recall search calibration_queries cannot be empty");
+    CHECK_ARGUMENT(calibration_queries->GetDim() == this->dim_,
+                   "recall search calibration query dimension does not match the index");
+
+    std::vector<RecallTarget> unique_targets;
+    unique_targets.reserve(targets.size());
+    for (const auto& target : targets) {
+        CHECK_ARGUMENT(target.top_k > 0, "recall search top_k must be positive");
+        CHECK_ARGUMENT(target.top_k <= this->GetNumElements(),
+                       "recall search top_k cannot exceed the index size");
+        CHECK_ARGUMENT(is_valid_recall(target.recall),
+                       "recall search target must be finite and in (0, 1]");
+        const auto duplicate = std::find_if(
+            unique_targets.begin(), unique_targets.end(), [&target](const auto& existing) {
+                return existing.top_k == target.top_k and
+                       std::fabs(existing.recall - target.recall) <= RECALL_EPSILON;
+            });
+        if (duplicate == unique_targets.end()) {
+            unique_targets.push_back(target);
+        }
+    }
+
+    const auto query_count = static_cast<uint64_t>(calibration_queries->GetNumElements());
+    std::vector<DatasetPtr> queries;
+    queries.reserve(query_count);
+    for (uint64_t i = 0; i < query_count; ++i) {
+        queries.push_back(this->make_calibration_query(calibration_queries, i));
+    }
+
+    const auto selected_efs =
+        calibrate_ef_search(*this, queries, unique_targets, this->GetNumElements());
+    std::vector<RecallSearchResult> results;
+    results.reserve(unique_targets.size());
+    for (uint64_t i = 0; i < unique_targets.size(); ++i) {
+        const auto& target = unique_targets[i];
+        const auto parameters = fmt::format(R"({{"hgraph":{{"ef_search":{}}}}})", selected_efs[i]);
+        results.push_back({target.top_k, target.recall, parameters});
+        logger::info("HGraph recall search selected ef_search={} for top_k={}, recall={}",
+                     selected_efs[i],
+                     target.top_k,
+                     target.recall);
+    }
+
+    auto profile = std::make_shared<const std::vector<RecallSearchResult>>(results);
+    std::atomic_store_explicit(&this->recall_search_profile_, profile, std::memory_order_release);
+    return results;
+}
+
+std::string
+HGraph::resolve_recall_search_parameters(int64_t top_k, float recall) const {
+    const auto profile =
+        std::atomic_load_explicit(&this->recall_search_profile_, std::memory_order_acquire);
+    CHECK_ARGUMENT(profile != nullptr, "recall search has not been calibrated");
+    const auto target = std::find_if(profile->begin(), profile->end(), [&](const auto& candidate) {
+        return candidate.top_k == top_k and std::fabs(candidate.recall - recall) <= RECALL_EPSILON;
+    });
+    CHECK_ARGUMENT(target != profile->end(),
+                   "the requested (top_k, recall) pair has not been calibrated");
+    return target->search_parameters;
+}
+
+DatasetPtr
+HGraph::KnnSearch(const DatasetPtr& query, int64_t k, float target_recall) const {
+    CHECK_ARGUMENT(is_valid_recall(target_recall), "target_recall must be finite and in (0, 1]");
+    this->validate_knn_args(query, k);
+
+    SearchRequest request;
+    request.query_ = query;
+    request.topk_ = k;
+    request.params_str_ = this->resolve_recall_search_parameters(k, target_recall);
+    return this->SearchWithRequest(request);
+}
+
+}  // namespace vsag

--- a/src/algorithm/hgraph/hgraph_recall_search_test.cpp
+++ b/src/algorithm/hgraph/hgraph_recall_search_test.cpp
@@ -1,0 +1,236 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <limits>
+#include <memory>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include "hgraph.h"
+#include "impl/allocator/safe_allocator.h"
+#include "index/index_impl.h"
+#include "index_common_param.h"
+#include "unittest.h"
+
+namespace {
+
+constexpr int64_t DIM = 4;
+constexpr int64_t COUNT = 320;
+constexpr auto DEFAULT_INDEX_PARAMS = R"({
+    "base_quantization_type": "fp32",
+    "max_degree": 8,
+    "ef_construction": 32,
+    "build_thread_count": 1
+})";
+
+std::shared_ptr<vsag::IndexImpl<vsag::HGraph>>
+make_index(const std::string& params_json = DEFAULT_INDEX_PARAMS) {
+    vsag::IndexCommonParam common_param;
+    common_param.dim_ = DIM;
+    common_param.metric_ = vsag::MetricType::METRIC_TYPE_L2SQR;
+    common_param.data_type_ = vsag::DataTypes::DATA_TYPE_FLOAT;
+    common_param.allocator_ = vsag::SafeAllocator::FactoryDefaultAllocator();
+
+    auto params = vsag::JsonType::Parse(params_json);
+    return std::make_shared<vsag::IndexImpl<vsag::HGraph>>(params, common_param);
+}
+
+void
+build_index(const std::shared_ptr<vsag::IndexImpl<vsag::HGraph>>& index) {
+    std::vector<float> vectors(COUNT * DIM);
+    std::vector<int64_t> ids(COUNT);
+    for (int64_t i = 0; i < COUNT; ++i) {
+        ids[i] = 100 + i;
+        for (int64_t j = 0; j < DIM; ++j) {
+            vectors[i * DIM + j] = static_cast<float>(i * DIM + j);
+        }
+    }
+    auto base = vsag::Dataset::Make()
+                    ->NumElements(COUNT)
+                    ->Dim(DIM)
+                    ->Ids(ids.data())
+                    ->Float32Vectors(vectors.data())
+                    ->Owner(false);
+    REQUIRE(index->Build(base).has_value());
+}
+
+vsag::DatasetPtr
+make_queries(std::vector<float>& vectors, int64_t count) {
+    return vsag::Dataset::Make()
+        ->NumElements(count)
+        ->Dim(DIM)
+        ->Float32Vectors(vectors.data())
+        ->Owner(false);
+}
+
+double
+average_overlap(const std::shared_ptr<vsag::IndexImpl<vsag::HGraph>>& index,
+                std::vector<float>& query_vectors,
+                int64_t query_count,
+                int64_t top_k,
+                const std::string& parameters) {
+    const auto reference_parameters =
+        std::string(R"({"hgraph":{"ef_search":)") + std::to_string(COUNT) + "}}";
+    double overlap_sum = 0.0;
+    for (int64_t query_index = 0; query_index < query_count; ++query_index) {
+        auto query = vsag::Dataset::Make()
+                         ->NumElements(1)
+                         ->Dim(DIM)
+                         ->Float32Vectors(query_vectors.data() + query_index * DIM)
+                         ->Owner(false);
+        const auto result = index->KnnSearch(query, top_k, parameters).value();
+        const auto reference = index->KnnSearch(query, top_k, reference_parameters).value();
+        std::unordered_multiset<int64_t> expected(reference->GetIds(), reference->GetIds() + top_k);
+        int64_t overlap = 0;
+        for (int64_t i = 0; i < top_k; ++i) {
+            const auto found = expected.find(result->GetIds()[i]);
+            if (found != expected.end()) {
+                ++overlap;
+                expected.erase(found);
+            }
+        }
+        overlap_sum += static_cast<double>(overlap) / static_cast<double>(top_k);
+    }
+    return overlap_sum / static_cast<double>(query_count);
+}
+
+}  // namespace
+
+TEST_CASE("HGraph recall search validates calibration input", "[ut][hgraph][recall_search]") {
+    auto index = make_index();
+    build_index(index);
+    std::vector<float> calibration_vectors = {1.0F, 2.0F, 3.0F, 4.0F};
+    auto calibration_queries = make_queries(calibration_vectors, 1);
+    const std::vector<vsag::RecallTarget> valid{{3, 0.5F}};
+
+    auto result = index->CalibrateRecallSearch(valid, calibration_queries);
+    REQUIRE_FALSE(result.has_value());
+    REQUIRE(result.error().type == vsag::ErrorType::INVALID_ARGUMENT);
+    REQUIRE(index->SetImmutable().has_value());
+
+    SECTION("empty or invalid targets") {
+        REQUIRE_FALSE(index->CalibrateRecallSearch({}, calibration_queries).has_value());
+        REQUIRE_FALSE(index->CalibrateRecallSearch({{0, 0.5F}}, calibration_queries).has_value());
+        REQUIRE_FALSE(index->CalibrateRecallSearch({{3, 1.1F}}, calibration_queries).has_value());
+        REQUIRE_FALSE(index
+                          ->CalibrateRecallSearch({{3, std::numeric_limits<float>::quiet_NaN()}},
+                                                  calibration_queries)
+                          .has_value());
+        REQUIRE_FALSE(
+            index->CalibrateRecallSearch({{COUNT + 1, 0.5F}}, calibration_queries).has_value());
+    }
+
+    SECTION("duplicate targets are coalesced") {
+        result = index->CalibrateRecallSearch({{3, 0.5F}, {3, 0.5F}}, calibration_queries);
+        REQUIRE(result.has_value());
+        REQUIRE(result->size() == 1);
+    }
+
+    SECTION("invalid calibration queries") {
+        REQUIRE_FALSE(index->CalibrateRecallSearch(valid, nullptr).has_value());
+        auto empty_queries = vsag::Dataset::Make()->NumElements(0)->Dim(DIM);
+        REQUIRE_FALSE(index->CalibrateRecallSearch(valid, empty_queries).has_value());
+
+        std::vector<int8_t> int8_vectors(DIM);
+        auto wrong_type_queries = vsag::Dataset::Make()
+                                      ->NumElements(1)
+                                      ->Dim(DIM)
+                                      ->Int8Vectors(int8_vectors.data())
+                                      ->Owner(false);
+        REQUIRE_FALSE(index->CalibrateRecallSearch(valid, wrong_type_queries).has_value());
+
+        std::vector<float> vectors(DIM + 1);
+        auto wrong_dimension_queries = vsag::Dataset::Make()
+                                           ->NumElements(1)
+                                           ->Dim(DIM + 1)
+                                           ->Float32Vectors(vectors.data())
+                                           ->Owner(false);
+        REQUIRE_FALSE(index->CalibrateRecallSearch(valid, wrong_dimension_queries).has_value());
+    }
+
+    SECTION("quantized and duplicate-aware indexes") {
+        auto duplicate_index = make_index(R"({
+            "base_quantization_type": "fp32",
+            "max_degree": 8,
+            "ef_construction": 32,
+            "build_thread_count": 1,
+            "support_duplicate": true
+        })");
+        build_index(duplicate_index);
+        REQUIRE(duplicate_index->SetImmutable().has_value());
+        REQUIRE(duplicate_index->CalibrateRecallSearch(valid, calibration_queries).has_value());
+
+        auto sq8_index = make_index(R"({
+            "base_quantization_type": "sq8",
+            "max_degree": 8,
+            "ef_construction": 32,
+            "build_thread_count": 1
+        })");
+        build_index(sq8_index);
+        REQUIRE(sq8_index->SetImmutable().has_value());
+        REQUIRE(sq8_index->CalibrateRecallSearch(valid, calibration_queries).has_value());
+    }
+}
+
+TEST_CASE("HGraph recall search publishes and replaces an immutable profile",
+          "[ut][hgraph][recall_search]") {
+    auto index = make_index();
+    build_index(index);
+    REQUIRE(index->SetImmutable().has_value());
+
+    std::vector<float> calibration_vectors = {1.5F, 2.5F, 3.5F, 4.5F, 40.5F, 41.5F, 42.5F, 43.5F};
+    auto calibration_queries = make_queries(calibration_vectors, 2);
+    auto query = make_queries(calibration_vectors, 1);
+
+    REQUIRE_FALSE(index->KnnSearch(query, 3, 1.0F).has_value());
+    const std::vector<vsag::RecallTarget> targets{{3, 0.5F}, {3, 1.0F}, {5, 0.5F}};
+    const auto calibration = index->CalibrateRecallSearch(targets, calibration_queries);
+    REQUIRE(calibration.has_value());
+    REQUIRE(calibration->size() == targets.size());
+
+    for (const auto& result : calibration.value()) {
+        REQUIRE(result.top_k > 0);
+        REQUIRE(result.recall > 0.0F);
+        REQUIRE(result.search_parameters.find("ef_search") != std::string::npos);
+        REQUIRE(
+            average_overlap(index, calibration_vectors, 2, result.top_k, result.search_parameters) +
+                1e-6 >=
+            result.recall);
+
+        const auto recall_result = index->KnnSearch(query, result.top_k, result.recall);
+        const auto explicit_result =
+            index->KnnSearch(query, result.top_k, result.search_parameters);
+        REQUIRE(recall_result.has_value());
+        REQUIRE(explicit_result.has_value());
+        for (int64_t i = 0; i < result.top_k; ++i) {
+            REQUIRE(recall_result.value()->GetIds()[i] == explicit_result.value()->GetIds()[i]);
+        }
+    }
+
+    const auto replacement = index->CalibrateRecallSearch({{4, 0.5F}}, calibration_queries);
+    REQUIRE(replacement.has_value());
+    REQUIRE(replacement->size() == 1);
+    REQUIRE_FALSE(index->KnnSearch(query, 3, 0.5F).has_value());
+    REQUIRE(index->KnnSearch(query, 4, 0.5F).has_value());
+
+    REQUIRE_FALSE(index->CalibrateRecallSearch({}, calibration_queries).has_value());
+    REQUIRE(index->KnnSearch(query, 4, 0.5F).has_value());
+    const auto empty_query = vsag::Dataset::Make()->NumElements(0)->Dim(DIM);
+    const auto empty_result = index->KnnSearch(empty_query, 4, 0.5F);
+    REQUIRE(empty_result.has_value());
+    REQUIRE(empty_result.value()->GetDim() == 0);
+    REQUIRE_FALSE(index->KnnSearch(query, 4, -0.1F).has_value());
+    REQUIRE_FALSE(index->KnnSearch(query, 4, std::numeric_limits<float>::quiet_NaN()).has_value());
+}

--- a/src/algorithm/inner_index_interface.h
+++ b/src/algorithm/inner_index_interface.h
@@ -545,6 +545,19 @@ public:
                             "Index doesn't support UpdateVector");
     }
 
+    virtual std::vector<RecallSearchResult>
+    CalibrateRecallSearch(const std::vector<RecallTarget>& targets,
+                          const DatasetPtr& calibration_queries) {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "Index doesn't support recall search");
+    }
+
+    [[nodiscard]] virtual DatasetPtr
+    KnnSearch(const DatasetPtr& query, int64_t k, float target_recall) const {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "Index doesn't support recall search");
+    }
+
 protected:
     virtual MetadataPtr
     collect_streaming_header() const;

--- a/src/algorithm/inner_index_interface_test.cpp
+++ b/src/algorithm/inner_index_interface_test.cpp
@@ -225,6 +225,8 @@ TEST_CASE("InnerIndexInterface NOT Implemented", "[ut][InnerIndexInterface]") {
     REQUIRE_THROWS(empty_index->GetExtraInfoByIds(nullptr, 1, nullptr));
     REQUIRE_THROWS(empty_index->GetVectorByInnerId(1, nullptr));
     REQUIRE_THROWS(empty_index->SetImmutable());
+    REQUIRE_THROWS(empty_index->CalibrateRecallSearch({}, nullptr));
+    REQUIRE_THROWS(empty_index->KnnSearch(nullptr, 1, 0.9F));
 
     AttributeSet old_attrs;
     AttributeSet new_attrs;

--- a/src/index/index_impl.h
+++ b/src/index/index_impl.h
@@ -534,6 +534,18 @@ public:
         SAFE_CALL(return this->inner_index_->UpdateVector(id, new_base, force_update));
     }
 
+    [[nodiscard]] tl::expected<std::vector<RecallSearchResult>, Error>
+    CalibrateRecallSearch(const std::vector<RecallTarget>& targets,
+                          const DatasetPtr& calibration_queries) override {
+        SAFE_CALL(return this->inner_index_->CalibrateRecallSearch(targets, calibration_queries));
+    }
+
+    [[nodiscard]] tl::expected<DatasetPtr, Error>
+    KnnSearch(const DatasetPtr& query, int64_t k, float target_recall) const override {
+        CHECK_QUERY_RETURN_EMPTY_DATASET(query);
+        SAFE_CALL(return this->inner_index_->KnnSearch(query, k, target_recall));
+    }
+
 public:
     [[nodiscard]] inline InnerIndexPtr
     GetInnerIndex() const {


### PR DESCRIPTION
## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Improvement/Refactor
- [ ] Documentation
- [ ] CI/Build/Infra

## Linked Issue

- Fixes: #2562

## What Changed

- Add an explicit synchronous API for calibrating HGraph search parameters from representative queries and workload-average `(top_k, recall)` targets.
- Use a stabilized high-`ef_search` HGraph result as the approximate reference, then select the smallest qualifying `ef_search` with exponential bracketing and binary search.
- Publish a complete immutable recall-search profile atomically after successful calibration; failed recalibration preserves the previous profile.
- Add HGraph and unsupported-index tests, a C++ example, and English and Chinese API documentation.

## Test Evidence

- [ ] `make fmt`
- [ ] `make lint`
- [ ] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [x] Other (describe below)

Test details:

```text
clang-format-15 --dry-run --Werror <changed C++ files>
  passed

clang-tidy-15 <implementation and test files>
  passed

./build/tests/unittests "[recall_search]"
  2 test cases, 77 assertions passed

./build/tests/unittests "InnerIndexInterface NOT Implemented"
  1 test case, 32 assertions passed

cmake --build build-release --target 326_feature_hgraph_recall_search -j48
  passed

./build-release/examples/cpp/326_feature_hgraph_recall_search
  passed
```

## Compatibility Impact

- API/ABI compatibility: additive source API; adding virtual methods changes the C++ vtable, so consumers must rebuild against the new library.
- Behavior changes: none for existing search APIs; the new recall-target overload is opt-in and currently supported by HGraph only.

## Performance and Concurrency Impact

- Performance impact: calibration is synchronous and intentionally performs multiple searches; regular recall-target search adds only an immutable profile lookup before the existing HGraph search.
- Concurrency/thread-safety impact: calibration calls are serialized, and a successful profile is published atomically. Readers do not take the calibration mutex and failed recalibration leaves the previous profile active.

## Documentation Impact

- [ ] No docs update needed
- [x] Updated docs:
  - [ ] `README.md`
  - [ ] `DEVELOPMENT.md`
  - [ ] `CONTRIBUTING.md`
  - [x] Other: English and Chinese Index API/HGraph documentation, plus the C++ examples README

## Risk and Rollback

- Risk level: medium
- Rollback plan: revert the feature commit; existing APIs and serialized index formats are unchanged.

## Checklist

- [x] I have linked the relevant issue (required for `kind/bug` and `kind/feature`; see "Linked Issue" above)
- [x] I have added/updated tests for new behavior or bug fixes
- [x] I have considered API compatibility impact
- [x] I have updated docs if behavior/workflow changed
- [x] My commit messages follow project conventions (Conventional Commits, optional `[skip ci]` prefix)
