### PR TITLE
refactor: extract index utility helpers

### DIFF
--- a/src/algorithm/bruteforce/bruteforce.cpp
+++ b/src/algorithm/bruteforce/bruteforce.cpp
@@ -23,6 +23,7 @@
 #include <optional>
 #include <tuple>
 
+#include "algorithm/index_utils.h"
 #include "attr/argparse.h"
 #include "attr/executor/executor.h"
 #include "datacell/attribute_inverted_interface.h"
@@ -387,13 +388,14 @@ BruteForce::SearchWithRequest(const SearchRequest& request) const {
             CHECK_ARGUMENT(request.radius_ >= 0.0F, "radius must be non-negative");
             CHECK_ARGUMENT(request.limited_size_ != 0, "limited_size must not be 0");
         } else if (not is_multi_vector_) {
-            this->validate_range_args(request.query_, request.radius_, request.limited_size_);
+            index_utils::ValidateRangeArgs(
+                data_type_, dim_, request.query_, request.radius_, request.limited_size_);
         }
     } else {
         if (use_custom_distance) {
             CHECK_ARGUMENT(request.topk_ > 0, "topk must be greater than 0");
         } else if (not is_multi_vector_) {
-            this->validate_knn_args(request.query_, request.topk_);
+            index_utils::ValidateKnnArgs(data_type_, dim_, request.query_, request.topk_);
         }
     }
 
@@ -404,7 +406,7 @@ BruteForce::SearchWithRequest(const SearchRequest& request) const {
     auto radius = is_range ? request.radius_ : std::numeric_limits<float>::max();
 
     if (total_count_.load() == 0) {
-        return make_empty_result();
+        return index_utils::MakeEmptyResult();
     }
 
     DistHeapPtr heap = nullptr;
@@ -678,7 +680,7 @@ BruteForce::Serialize(StreamWriter& writer) const {
     basic_info["has_extra_info"].SetBool(this->extra_info_size_ > 0 and
                                          this->extra_infos_ != nullptr);
     basic_info[INDEX_PARAM].SetString(this->create_param_ptr_->ToString());
-    write_index_footer(writer, basic_info);
+    index_utils::WriteIndexFooter(writer, basic_info);
 }
 
 MetadataPtr
@@ -977,7 +979,7 @@ BruteForce::read_streaming_body(StreamReader& reader,
 void
 BruteForce::Deserialize(StreamReader& reader) {
     JsonType basic_info;
-    bool has_footer = read_index_footer(reader, basic_info);
+    bool has_footer = index_utils::ReadIndexFooter(reader, basic_info);
 
     BufferStreamReader buffer_reader(
         &reader, std::numeric_limits<uint64_t>::max(), this->allocator_);

--- a/src/algorithm/hgraph/hgraph_search.cpp
+++ b/src/algorithm/hgraph/hgraph_search.cpp
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 
+#include "algorithm/index_utils.h"
 #include "attr/argparse.h"
 #include "dataset_impl.h"
 #include "hgraph.h"  // IWYU pragma: keep
@@ -74,7 +75,7 @@ HGraph::KnnSearch(const DatasetPtr& query,
     if (GetNumElements() == 0) {
         return DatasetImpl::MakeEmptyDataset();
     }
-    this->validate_knn_args(query, k);
+    index_utils::ValidateKnnArgs(data_type_, dim_, query, k);
 
     auto params = HGraphSearchParameters::FromJson(parameters);
     ctx.rabitq_error_rate = params.rabitq_error_rate;
@@ -390,11 +391,12 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
 
     if (is_range) {
         if (not use_custom_distance) {
-            this->validate_range_args(query, request.radius_, request.limited_size_);
+            index_utils::ValidateRangeArgs(
+                data_type_, dim_, query, request.radius_, request.limited_size_);
         }
     } else {
         if (not use_custom_distance) {
-            this->validate_knn_args(query, k);
+            index_utils::ValidateKnnArgs(data_type_, dim_, query, k);
         } else {
             CHECK_ARGUMENT(k > 0, "topk must be greater than 0");
         }

--- a/src/algorithm/index_utils.cpp
+++ b/src/algorithm/index_utils.cpp
@@ -1,0 +1,86 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "index_utils.h"
+
+#include <fmt/format.h>
+
+#include <memory>
+
+#include "common.h"
+#include "dataset_impl.h"
+#include "storage/serialization.h"
+#include "storage/stream_reader.h"
+#include "storage/stream_writer.h"
+
+namespace vsag::index_utils {
+
+DatasetPtr
+MakeEmptyResult(const std::string& stats_json) {
+    auto dataset_result = DatasetImpl::MakeEmptyDataset();
+    if (!stats_json.empty()) {
+        dataset_result->Statistics(stats_json);
+    }
+    return dataset_result;
+}
+
+void
+WriteIndexFooter(StreamWriter& writer, const JsonType& basic_info) {
+    auto metadata = std::make_shared<Metadata>();
+    metadata->Set("basic_info", basic_info);
+    auto footer = std::make_shared<Footer>(metadata);
+    footer->Write(writer);
+}
+
+bool
+ReadIndexFooter(StreamReader& reader, JsonType& basic_info) {
+    auto footer = Footer::Parse(reader);
+    if (footer == nullptr) {
+        return false;
+    }
+    auto metadata = footer->GetMetadata();
+    if (metadata == nullptr || metadata->EmptyIndex()) {
+        throw VsagException(ErrorType::INDEX_EMPTY, "index is empty");
+    }
+    basic_info = metadata->Get("basic_info");
+    return true;
+}
+
+void
+ValidateSearchQuery(DataTypes data_type, int64_t dim, const DatasetPtr& query) {
+    if (data_type != DataTypes::DATA_TYPE_SPARSE) {
+        int64_t query_dim = query->GetDim();
+        CHECK_ARGUMENT(query_dim == dim,
+                       fmt::format("query.dim({}) must be equal to index.dim({})", query_dim, dim));
+    }
+    CHECK_ARGUMENT(query->GetNumElements() == 1, "query dataset should contain 1 vector only");
+}
+
+void
+ValidateKnnArgs(DataTypes data_type, int64_t dim, const DatasetPtr& query, int64_t k) {
+    ValidateSearchQuery(data_type, dim, query);
+    CHECK_ARGUMENT(k > 0, fmt::format("k({}) must be greater than 0", k));
+}
+
+void
+ValidateRangeArgs(
+    DataTypes data_type, int64_t dim, const DatasetPtr& query, float radius, int64_t limited_size) {
+    ValidateSearchQuery(data_type, dim, query);
+    CHECK_ARGUMENT(radius >= 0.0F,
+                   fmt::format("radius({}) must be greater than or equal to 0", radius));
+    CHECK_ARGUMENT(limited_size != 0,
+                   fmt::format("limited_size({}) must not be equal to 0", limited_size));
+}
+
+}  // namespace vsag::index_utils

--- a/src/algorithm/index_utils.h
+++ b/src/algorithm/index_utils.h
@@ -1,0 +1,52 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+#include "data_type.h"
+#include "json_types.h"
+#include "vsag/dataset.h"
+
+namespace vsag {
+
+class StreamReader;
+class StreamWriter;
+
+namespace index_utils {
+
+DatasetPtr
+MakeEmptyResult(const std::string& stats_json = "");
+
+void
+WriteIndexFooter(StreamWriter& writer, const JsonType& basic_info);
+
+bool
+ReadIndexFooter(StreamReader& reader, JsonType& basic_info);
+
+void
+ValidateSearchQuery(DataTypes data_type, int64_t dim, const DatasetPtr& query);
+
+void
+ValidateKnnArgs(DataTypes data_type, int64_t dim, const DatasetPtr& query, int64_t k);
+
+void
+ValidateRangeArgs(
+    DataTypes data_type, int64_t dim, const DatasetPtr& query, float radius, int64_t limited_size);
+
+}  // namespace index_utils
+
+}  // namespace vsag

--- a/src/algorithm/index_utils_test.cpp
+++ b/src/algorithm/index_utils_test.cpp
@@ -1,0 +1,73 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "index_utils.h"
+
+#include <sstream>
+
+#include "storage/stream_reader.h"
+#include "storage/stream_writer.h"
+#include "unittest.h"
+
+using namespace vsag;
+
+TEST_CASE("Index utilities validate search arguments", "[ut][index_utils]") {
+    auto query = Dataset::Make()->Dim(4)->NumElements(1);
+
+    REQUIRE_NOTHROW(index_utils::ValidateKnnArgs(DataTypes::DATA_TYPE_FLOAT, 4, query, 1));
+    REQUIRE_THROWS(index_utils::ValidateKnnArgs(DataTypes::DATA_TYPE_FLOAT, 3, query, 1));
+    REQUIRE_THROWS(index_utils::ValidateKnnArgs(DataTypes::DATA_TYPE_FLOAT, 4, query, 0));
+    REQUIRE_NOTHROW(index_utils::ValidateRangeArgs(DataTypes::DATA_TYPE_FLOAT, 4, query, 0.0F, -1));
+    REQUIRE_THROWS(index_utils::ValidateRangeArgs(DataTypes::DATA_TYPE_FLOAT, 4, query, -1.0F, -1));
+    REQUIRE_THROWS(index_utils::ValidateRangeArgs(DataTypes::DATA_TYPE_FLOAT, 4, query, 0.0F, 0));
+}
+
+TEST_CASE("Index utilities accept sparse query dimensions", "[ut][index_utils]") {
+    auto query = Dataset::Make()->Dim(8)->NumElements(1);
+
+    REQUIRE_NOTHROW(index_utils::ValidateSearchQuery(DataTypes::DATA_TYPE_SPARSE, 4, query));
+}
+
+TEST_CASE("Index utilities build empty results", "[ut][index_utils]") {
+    auto default_result = index_utils::MakeEmptyResult();
+
+    REQUIRE(default_result->GetNumElements() == 1);
+    REQUIRE(default_result->GetStatistics().empty());
+
+    auto result = index_utils::MakeEmptyResult("{\"visited\": 0}");
+
+    REQUIRE(result->GetNumElements() == 1);
+    REQUIRE(result->GetStatistics() == "{\"visited\": 0}");
+}
+
+TEST_CASE("Index utilities round-trip index footers", "[ut][index_utils]") {
+    std::stringstream stream;
+    IOStreamWriter writer(stream);
+    JsonType basic_info;
+    basic_info["dim"].SetInt(4);
+    index_utils::WriteIndexFooter(writer, basic_info);
+
+    IOStreamReader reader(stream);
+    JsonType parsed_info;
+    REQUIRE(index_utils::ReadIndexFooter(reader, parsed_info));
+    REQUIRE(parsed_info["dim"].GetInt() == 4);
+}
+
+TEST_CASE("Index utilities detect missing index footers", "[ut][index_utils]") {
+    std::stringstream stream;
+    IOStreamReader reader(stream);
+    JsonType basic_info;
+
+    REQUIRE_FALSE(index_utils::ReadIndexFooter(reader, basic_info));
+}

--- a/src/algorithm/inner_index_interface.cpp
+++ b/src/algorithm/inner_index_interface.cpp
@@ -29,6 +29,7 @@
 
 #include "algorithm/bruteforce/bruteforce.h"
 #include "algorithm/hgraph/hgraph.h"
+#include "algorithm/index_utils.h"
 #include "impl/filter/filter_headers.h"
 #include "impl/label_table/label_table.h"
 #include "impl/thread_pool/safe_thread_pool.h"
@@ -1134,7 +1135,7 @@ InnerIndexInterface::create_search_filter(const FilterPtr& user_filter,
 DatasetPtr
 InnerIndexInterface::pack_knn_result(DistHeapPtr& heap, Allocator* allocator) const {
     if (heap == nullptr || heap->Empty()) {
-        return make_empty_result();
+        return index_utils::MakeEmptyResult();
     }
     auto* alloc = allocator != nullptr ? allocator : allocator_;
     auto count = static_cast<int64_t>(heap->Size());
@@ -1151,7 +1152,7 @@ DatasetPtr
 InnerIndexInterface::pack_knn_result_with_extra_info(DistHeapPtr& heap,
                                                      Allocator* allocator) const {
     if (heap == nullptr || heap->Empty()) {
-        return make_empty_result();
+        return index_utils::MakeEmptyResult();
     }
     auto* alloc = allocator != nullptr ? allocator : allocator_;
     auto count = static_cast<int64_t>(heap->Size());
@@ -1177,65 +1178,6 @@ InnerIndexInterface::pack_knn_result_with_extra_info(DistHeapPtr& heap,
         }
     }
     return std::move(dataset_results);
-}
-
-DatasetPtr
-InnerIndexInterface::make_empty_result(const std::string& stats_json) {
-    auto dataset_result = DatasetImpl::MakeEmptyDataset();
-    if (!stats_json.empty()) {
-        dataset_result->Statistics(stats_json);
-    }
-    return dataset_result;
-}
-
-void
-InnerIndexInterface::write_index_footer(StreamWriter& writer, const JsonType& basic_info) {
-    auto metadata = std::make_shared<Metadata>();
-    metadata->Set("basic_info", basic_info);
-    auto footer = std::make_shared<Footer>(metadata);
-    footer->Write(writer);
-}
-
-bool
-InnerIndexInterface::read_index_footer(StreamReader& reader, JsonType& basic_info) {
-    auto footer = Footer::Parse(reader);
-    if (footer == nullptr) {
-        // Old format - no footer found
-        return false;
-    }
-    auto metadata = footer->GetMetadata();
-    if (metadata == nullptr || metadata->EmptyIndex()) {
-        throw VsagException(ErrorType::INDEX_EMPTY, "index is empty");
-    }
-    basic_info = metadata->Get("basic_info");
-    return true;
-}
-
-void
-InnerIndexInterface::validate_search_query(const DatasetPtr& query) const {
-    if (data_type_ != DataTypes::DATA_TYPE_SPARSE) {
-        int64_t query_dim = query->GetDim();
-        CHECK_ARGUMENT(
-            query_dim == dim_,
-            fmt::format("query.dim({}) must be equal to index.dim({})", query_dim, dim_));
-    }
-    CHECK_ARGUMENT(query->GetNumElements() == 1, "query dataset should contain 1 vector only");
-}
-
-void
-InnerIndexInterface::validate_knn_args(const DatasetPtr& query, int64_t k) const {
-    validate_search_query(query);
-    CHECK_ARGUMENT(k > 0, fmt::format("k({}) must be greater than 0", k));
-}
-
-void
-InnerIndexInterface::validate_range_args(const DatasetPtr& query,
-                                         float radius,
-                                         int64_t limited_size) const {
-    validate_search_query(query);
-    CHECK_ARGUMENT(radius >= 0.0F, fmt::format("radius({}) must be greater equal than 0", radius));
-    CHECK_ARGUMENT(limited_size != 0,
-                   fmt::format("limited_size({}) must not be equal to 0", limited_size));
 }
 
 }  // namespace vsag

--- a/src/algorithm/inner_index_interface.h
+++ b/src/algorithm/inner_index_interface.h
@@ -26,7 +26,6 @@
 #include "datacell/attribute_inverted_interface.h"
 #include "datacell/extra_info_interface.h"
 #include "datacell/flatten_interface.h"
-#include "dataset_impl.h"
 #include "impl/heap/distance_heap.h"
 #include "impl/label_table/label_table.h"
 #include "inner_index_parameter.h"
@@ -642,30 +641,6 @@ protected:
     // Pack search results from a distance heap with extra info
     DatasetPtr
     pack_knn_result_with_extra_info(DistHeapPtr& heap, Allocator* allocator = nullptr) const;
-
-    // Create an empty search result with optional statistics
-    static DatasetPtr
-    make_empty_result(const std::string& stats_json = "");
-
-    // Write index footer with basic_info metadata
-    static void
-    write_index_footer(StreamWriter& writer, const JsonType& basic_info);
-
-    // Read index footer and return basic_info metadata; returns false if old format
-    static bool
-    read_index_footer(StreamReader& reader, JsonType& basic_info);
-
-    // Validate search query: checks dim and num_elements
-    void
-    validate_search_query(const DatasetPtr& query) const;
-
-    // Validate KNN search arguments: query, k
-    void
-    validate_knn_args(const DatasetPtr& query, int64_t k) const;
-
-    // Validate range search arguments: query, radius, limited_size
-    void
-    validate_range_args(const DatasetPtr& query, float radius, int64_t limited_size) const;
 
 public:
     LabelTablePtr label_table_{nullptr};

--- a/src/algorithm/ivf/ivf.cpp
+++ b/src/algorithm/ivf/ivf.cpp
@@ -29,6 +29,7 @@
 #include "datacell/flatten_interface.h"
 #include "datacell/graph_datacell_parameter.h"
 #include "datacell/graph_interface_parameter.h"
+#include "dataset_impl.h"
 #include "flat_bucket_searcher.h"
 #include "gno_imi_partition.h"
 #include "graph_bucket_searcher.h"

--- a/src/algorithm/pyramid/pyramid.cpp
+++ b/src/algorithm/pyramid/pyramid.cpp
@@ -18,9 +18,11 @@
 #include <chrono>
 #include <exception>
 
+#include "algorithm/index_utils.h"
 #include "algorithm/inner_index_interface.h"
 #include "analyzer/analyzer.h"
 #include "datacell/flatten_interface.h"
+#include "dataset_impl.h"
 #include "impl/heap/standard_heap.h"
 #include "impl/odescent/odescent_graph_builder.h"
 #include "impl/pruning_strategy.h"
@@ -456,7 +458,7 @@ Pyramid::Serialize(StreamWriter& writer) const {
     JsonType basic_info;
     basic_info["max_capacity"].SetInt(max_capacity_);
     basic_info[INDEX_PARAM].SetString(this->create_param_ptr_->ToString());
-    write_index_footer(writer, basic_info);
+    index_utils::WriteIndexFooter(writer, basic_info);
 }
 
 MetadataPtr
@@ -695,7 +697,7 @@ void
 Pyramid::Deserialize(StreamReader& reader) {
     // try to deserialize footer (only in new version)
     JsonType basic_info;
-    if (not read_index_footer(reader, basic_info)) {
+    if (not index_utils::ReadIndexFooter(reader, basic_info)) {
         throw VsagException(ErrorType::READ_ERROR, "failed to read index footer");
     }
     auto max_capacity = basic_info["max_capacity"].GetInt();

--- a/src/algorithm/simq/simq.cpp
+++ b/src/algorithm/simq/simq.cpp
@@ -26,6 +26,7 @@
 #include <unordered_set>
 #include <utility>
 
+#include "algorithm/index_utils.h"
 #include "dataset_impl.h"
 #include "index_feature_list.h"
 #include "inner_string_params.h"
@@ -953,7 +954,7 @@ SIMQ::Serialize(StreamWriter& writer) const {
     info["dim"].SetInt(dim_);
     info["total_count"].SetInt(total_count_.load());
     info[INDEX_PARAM].SetString(this->create_param_ptr_->ToString());
-    write_index_footer(writer, info);
+    index_utils::WriteIndexFooter(writer, info);
 }
 
 void
@@ -961,7 +962,7 @@ SIMQ::Deserialize(StreamReader& reader) {
     std::unique_lock lock(global_mutex_);
 
     JsonType info;
-    if (!read_index_footer(reader, info)) {
+    if (!index_utils::ReadIndexFooter(reader, info)) {
         throw VsagException(ErrorType::READ_ERROR, "simq: failed to read index footer");
     }
 

--- a/src/algorithm/sindi/sindi.cpp
+++ b/src/algorithm/sindi/sindi.cpp
@@ -26,6 +26,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "algorithm/index_utils.h"
 #include "analyzer/analyzer.h"
 #include "datacell/sparse_dmq_datacell.h"
 #include "datacell/sparse_vector_datacell_parameter.h"
@@ -618,7 +619,7 @@ SINDI::KnnSearch(const DatasetPtr& query,
     if (remap_term_ids_) {
         effective_query = remap_sparse_vector_for_query(sparse_query, tmp_ids, tmp_vals);
         if (effective_query.len_ == 0) {
-            return make_empty_result();
+            return index_utils::MakeEmptyResult();
         }
     }
 
@@ -910,7 +911,7 @@ SINDI::immutable_search_impl(const SparseTermComputerPtr& computer,
         scan_immutable_window_by_mapped_terms(dists.data(), window, computer, mapped_terms);
 
         if (reasoning_ctx != nullptr) {
-            selected_buckets->push_back(cur);
+            selected_buckets->push_back(static_cast<BucketIdType>(cur));
             auto doc_count = static_cast<uint32_t>(std::min<int64_t>(
                 window_size_, cur_element_count_ - static_cast<int64_t>(window_start_id)));
             for (uint32_t i = 0; i < doc_count; ++i) {
@@ -1059,7 +1060,7 @@ SINDI::search_impl(const SparseTermComputerPtr& computer,
         term_list->Query(dists.data(), computer);
 
         if (reasoning_ctx != nullptr) {
-            selected_buckets->push_back(cur);
+            selected_buckets->push_back(static_cast<BucketIdType>(cur));
             auto doc_count = static_cast<uint32_t>(std::min<int64_t>(
                 window_size_, cur_element_count_ - static_cast<int64_t>(window_start_id)));
             for (uint32_t i = 0; i < doc_count; ++i) {
@@ -1209,7 +1210,7 @@ SINDI::RangeSearch(const DatasetPtr& query,
     if (remap_term_ids_) {
         effective_query = remap_sparse_vector_for_query(sparse_query, tmp_ids, tmp_vals);
         if (effective_query.len_ == 0) {
-            return make_empty_result();
+            return index_utils::MakeEmptyResult();
         }
     }
 
@@ -1277,7 +1278,7 @@ SINDI::SearchWithRequest(const SearchRequest& request) const {
     if (remap_term_ids_) {
         effective_query = remap_sparse_vector_for_query(sparse_query, tmp_ids, tmp_vals);
         if (effective_query.len_ == 0) {
-            return make_empty_result();
+            return index_utils::MakeEmptyResult();
         }
     }
 
@@ -1457,7 +1458,7 @@ SINDI::Serialize(StreamWriter& writer) const {
     } else if (use_reorder_) {
         jsonify_basic_info[SINDI_RERANK_FLAT_FORMAT_KEY].SetInt(SINDI_RERANK_FLAT_FORMAT_DATACELL);
     }
-    write_index_footer(writer, jsonify_basic_info);
+    index_utils::WriteIndexFooter(writer, jsonify_basic_info);
 }
 
 MetadataPtr
@@ -1756,7 +1757,7 @@ SINDI::Deserialize(StreamReader& reader) {
     if (not deserialize_without_footer_) {
         JsonType jsonify_basic_info;
         try {
-            if (read_index_footer(reader, jsonify_basic_info)) {
+            if (index_utils::ReadIndexFooter(reader, jsonify_basic_info)) {
                 has_footer = true;
                 // Check if the index parameter is compatible
                 {

--- a/src/index/index_impl.h
+++ b/src/index/index_impl.h
@@ -18,6 +18,7 @@
 
 #include "algorithm/inner_index_interface.h"
 #include "common.h"
+#include "dataset_impl.h"
 #include "index_common_param.h"
 #include "vsag/index.h"
 namespace vsag {


### PR DESCRIPTION
## Summary
- Extract stateless index helper functions into algorithm/index_utils.
- Update index implementations to use the shared utilities.
- Add direct utility coverage for validation, empty results, and footers.

Closes #2570

## Verification
- make fmt
- cmake --build build --target algorithm --parallel 6
- git diff --check

Full test linking is blocked in this remote environment because the required Boost external dependency cannot be downloaded and its cached unpacked tree is not a valid CMake URL source.