### PR TITLE
[skip ci] feat(sindi): add hybrid Elias-Fano DMQ encoding

### DIFF
--- a/docs/docs/en/src/SUMMARY.md
+++ b/docs/docs/en/src/SUMMARY.md
@@ -33,6 +33,8 @@
 - [PQ FastScan](quantization/pqfs.md)
 - [RaBitQ](quantization/rabitq.md)
 - [RaBitQ x+y Split](quantization/rabitq_split.md)
+- [DMQ (Sparse Distribution Maintenance Quantization)](quantization/dmq.md)
+- [Elias–Fano Ordered Integer Compression](quantization/elias-fano.md)
 - [Transform Quantizer (TQ)](advanced/quantization_transform.md)
 
 # Developer Guide

--- a/docs/docs/en/src/indexes/sindi.md
+++ b/docs/docs/en/src/indexes/sindi.md
@@ -23,7 +23,8 @@ pairs and is the only VSAG index that accepts `dtype: "sparse"`.
    into a max-heap of size `n_candidate`, and returns the top-k. When `use_reorder`
    is enabled, the candidates are re-scored against a forward store. The default
    forward store keeps fp32 values, while `rerank_type: "dmq8"` uses a compressed
-   DMQ store to reduce rerank memory.
+   DMQ store to reduce rerank memory. DMQ compact term IDs use a per-vector hybrid of
+   fixed-width packing and Elias–Fano coding, selecting the smaller representation.
 
 Distance is returned as `1 - inner_product` so results sort ascending as in the
 dense indexes.

--- a/docs/docs/en/src/quantization/README.md
+++ b/docs/docs/en/src/quantization/README.md
@@ -73,13 +73,15 @@ the concrete quantizer based on the JSON `type` field.
 | `rabitq` | 1 or HGraph x+y | **yes** | no | 1-bit / low-bit split binary quantization, strongest compression |
 | `tq` | depends on chain | depends on terminal quantizer | no | [Transform Quantizer](../advanced/quantization_transform.md): prepend rotations / PCA before another quantizer |
 
-`int8` and `sparse` are not exposed as general-purpose
+`int8`, `sparse`, and `dmq8` are not exposed as general-purpose
 `base_quantization_type` values:
 
 - `int8` is selected automatically when `dtype: "int8"` is used; it is not a
   compression mode.
 - `sparse` backs the inverted lists of [SINDI](../indexes/sindi.md) and is
   not selectable on dense indexes.
+- `dmq8` backs SINDI's rerank forward store and is enabled only through
+  `rerank_type: "dmq8"`; see [DMQ](dmq.md).
 
 ## Training requirement
 
@@ -94,10 +96,10 @@ base quantizer.
 
 ## Metric compatibility
 
-All quantizers documented here support the three dense metrics
-(`l2` / `ip` / `cosine`). For `cosine`, the index normalizes vectors before
-quantization, so the underlying quantizer never sees the original magnitude.
-A few practical notes:
+All dense quantizers in the table support the three dense metrics
+(`l2` / `ip` / `cosine`). The SINDI-specific DMQ8 supports inner product
+only. For `cosine`, the index normalizes vectors before quantization, so the
+underlying quantizer never sees the original magnitude. A few practical notes:
 
 - `pq` / `pqfs` perform their distance lookup tables per subspace; very low
   `pq_dim` (≤ 4) on `ip` / `cosine` is more sensitive to anisotropy than `l2`.
@@ -159,4 +161,6 @@ Refer to each index page for its full parameter list.
 - [PQ FastScan](pqfs.md)
 - [RaBitQ](rabitq.md)
 - [RaBitQ x+y Split](rabitq_split.md)
+- [DMQ (Sparse Distribution Maintenance Quantization)](dmq.md)
+- [Elias–Fano Ordered Integer Compression](elias-fano.md)
 - [Transform Quantizer (TQ)](../advanced/quantization_transform.md)

--- a/docs/docs/en/src/quantization/dmq.md
+++ b/docs/docs/en/src/quantization/dmq.md
@@ -1,0 +1,435 @@
+# DMQ (Distribution Maintenance Quantization for Sparse Vectors)
+
+DMQ (Distribution Maintenance Quantization) is the sparse-vector quantization method implemented
+by VSAG for the [SINDI](../indexes/sindi.md) rerank forward store. The current implementation is
+named `dmq8`: every non-zero value uses an 8-bit code, while each document stores an additional
+mean and scale factor. Term IDs are mapped to compact IDs and then encoded with either fixed-width
+bit packing or Elias–Fano coding.
+
+This page describes the algorithm implemented by `SparseDmqQuantizer` in VSAG. DMQ is not
+currently a general quantizer selectable through `base_quantization_type` for dense indexes.
+
+## Background
+
+SINDI uses inverted lists to retrieve candidates. When `use_reorder` is enabled, it also stores a
+complete sparse vector for each document so that candidate inner products can be recomputed. If a
+document contains `L` non-zero entries, storing `uint32` term IDs and `float32` values directly
+requires about `8L` bytes for the two arrays alone. At corpus scale, this forward copy can become
+a significant memory cost.
+
+Global uniform quantization does not exploit two properties of sparse retrieval data:
+
+- value distributions may differ substantially across terms;
+- values within one document usually have a document-specific center and scale.
+
+DMQ therefore combines three levels of compression:
+
+1. **Per-document centering:** store a document mean and convert values to residuals;
+2. **Per-term modeling:** use an independent codebook for frequent terms and optionally share one
+   among infrequent terms;
+3. **Per-document calibration:** store a scale factor that adapts codebook representatives to the
+   document.
+
+DMQ also stores compact IDs only for terms observed during training and compresses the sorted ID
+sequence within each document.
+
+## Notation
+
+Let the training corpus be `D`. The sparse vector for document `d` is
+
+```text
+x_d = {(t_{d,i}, x_{d,i}) | i = 0, ..., L_d - 1}
+```
+
+where:
+
+- `L_d` is the number of non-zero entries;
+- `t_{d,i}` is a term ID;
+- `x_{d,i}` is its value;
+- `K = 2^8 = 256` is the number of DMQ8 codewords;
+- `τ` is the shared-codebook threshold for infrequent terms, 1024 by default.
+
+## Training
+
+### 1. Center each document
+
+DMQ first computes the mean of the non-zero values in every training document:
+
+```text
+μ_d = (1 / L_d) Σ_i x_{d,i}
+```
+
+It then computes residuals:
+
+```text
+r_{d,i} = x_{d,i} - μ_d
+```
+
+The mean of an empty vector is defined as zero. Only non-zero entries participate; absent sparse
+dimensions are not treated as zeros in this calculation.
+
+### 2. Assign term buckets and share codebooks
+
+Let `f_t` be the number of occurrences of term `t` in the training corpus. VSAG assigns
+training buckets as follows:
+
+```text
+f_t <= τ    -> all infrequent terms use one shared bucket
+f_t >  τ    -> term t uses its own bucket
+```
+
+Each bucket collects all residuals for its terms and trains one 256-entry codebook. Setting
+`dmq_shared_codebook_threshold: 0` gives every observed term an independent codebook.
+
+Sharing avoids storing a roughly 2 KiB codebook for every term with very few samples and combines
+their training data. The trade-off is that distinct infrequent terms use the same residual model.
+
+### 3. Build a distribution-weighted codebook
+
+Suppose a bucket contains `N` residuals, sorted as
+`z_0 ≤ z_1 ≤ ⋯ ≤ z_{N-1}`. The implementation assigns each sample the weight:
+
+```text
+w_i = Σ_j (z_i - z_j)²
+    = N z_i² + Σ_j z_j² - 2 z_i Σ_j z_j
+```
+
+The total weight is:
+
+```text
+W = Σ_i w_i
+```
+
+`w_i` measures the squared distance from residual `z_i` to the bucket distribution. Samples
+near the distribution body receive less weight, while tail samples receive more. The codebook
+therefore preserves more resolution in the distribution tails than an ordinary equal-frequency
+partition.
+
+Define the cumulative weight `C_i = Σ_{j=0}^{i} w_j`. For
+`k=0,…,K-1`, the representative value is:
+
+```text
+c_k = z_min{i : C_i >= ((2k + 1) / (2K)) W}
+```
+
+For `k=0,…,K-2`, the encoding threshold is:
+
+```text
+θ_k = z_min{i : C_i >= ((k + 1) / K) W}
+```
+
+The 256 representatives lie at weighted midpoints between the 255 thresholds, which map residuals
+to `[0, 255]`. If all residuals in a bucket are equal and `W` is effectively zero, every
+representative and threshold is set to that residual.
+
+## Encoding
+
+### 1. Compact term IDs
+
+After training, all observed terms are sorted by original ID and mapped to compact IDs in
+`[0, V - 1]`, where `V` is the number of distinct terms. Fixed-width coding requires:
+
+```text
+b = max(1, ceil(log₂ V))
+```
+
+A length-`L` ID sequence then occupies:
+
+```text
+B_packed = ceil(Lb / 8) bytes
+```
+
+The current serialization format also computes the Elias–Fano size for the same sorted sequence
+and selects the smaller representation per vector. Let:
+
+```text
+l = floor(log₂(V / L)), with l = 0 when V / L <= 1
+```
+
+The current Elias–Fano layout occupies:
+
+```text
+B_low  = ceil(Ll / 8)
+B_high = ceil((((V - 1) >> l) + L + 1) / 8)
+B_EF   = B_low + B_high
+```
+
+Elias–Fano is selected only when `B_{EF} < B_{packed}`; ties use bit packing.
+The Elias–Fano formula above assumes `L > 0`; an empty vector has a zero-byte ID payload.
+See [Elias–Fano Ordered Integer Compression](elias-fano.md) for the complete byte layout,
+worked example, streaming reader state, and complexity analysis.
+
+#### Elias–Fano data layout
+
+Let a document contain the ordered compact IDs
+`x_0 ≤ x_1 ≤ ... ≤ x_{L-1} < V`. Each ID is split at bit `l`:
+
+```text
+low_i  = x_i & (2^l - 1)
+high_i = x_i >> l
+```
+
+The encoded result contains two consecutive regions:
+
+```text
++-----------------------------+----------------------------------+
+| low bits                    | high bits                        |
+| L tightly packed l-bit ints | set bit at position high_i + i   |
++-----------------------------+----------------------------------+
+```
+
+The low region stores each `low_i` in ID order. The high region does not store `high_i`
+directly. Instead, its `i`-th one bit is placed at:
+
+```text
+p_i = high_i + i
+```
+
+Because the IDs are nondecreasing, `p_i` is strictly increasing. Duplicate IDs therefore still
+occupy distinct positions in the high bitmap. Its length is:
+
+```text
+((V - 1) >> l) + L + 1 bits
+```
+
+For example, with `V=16` and IDs `[3, 5, 8, 13]`, `L=4` and `l=2`:
+
+```text
+low  = [3, 1, 0, 1]
+high = [0, 1, 2, 3]
+p    = [0, 2, 4, 6]
+```
+
+Bits 0, 2, 4, and 6 are consequently set in the high bitmap.
+
+The current format does not store a per-document packed/EF tag. The decoder obtains `L` from the
+header and `V` from the DMQ model. Applying the same size comparison as the encoder determines
+both the ID representation and the start offset of the value codes.
+
+#### Elias–Fano encoding
+
+The encoder first calls `GetLayout(L, V)` to compute `l` and both region sizes, then clears the
+output:
+
+1. verify that every ID is less than `V` and that the sequence is nondecreasing;
+2. write `low_i` at bit offset `i·l` in the low-bit stream;
+3. set bit `high_i+i` in the high bitmap.
+
+The current `store_packed` implementation writes low bits one at a time, so its implementation
+cost is `O(L·l)`. With the fixed 32-bit ID bound, this can be treated as `O(L)`. The output space
+is:
+
+```text
+O(L log₂(V/L) + L) bits
+```
+
+Elias–Fano is most useful when `L` is small relative to `V` and the IDs are ordered. The hybrid
+strategy still compares actual byte counts for every document, avoiding EF whenever it does not
+save space.
+
+#### Elias–Fano streaming decode
+
+The reader maintains separate cursors for the low and high regions:
+
+1. extract the next `low_i` from the low-bit stream;
+2. find the next set-bit position `p_i` in the high bitmap;
+3. compute `high_i = p_i - i`;
+4. reconstruct `x_i = (high_i << l) | low_i`.
+
+`EliasFanoStreamReader` loads up to eight bytes of the high bitmap into a 64-bit buffer. It uses
+a trailing-zero count to find the lowest set bit, then clears it with `buffer &= buffer - 1`.
+When the buffer is zero, it skips that block and loads subsequent bytes. A separate 64-bit buffer
+refills the low-bit stream on demand.
+
+Sequentially decoding all `L` IDs costs:
+
+```text
+O(L + high_bits_count / machine_word_bits)
+```
+
+This is amortized `O(1)` per ID with `O(1)` reader state. It does not imply constant-time random
+access: the current reader has no select index, so reaching ID `i` requires continuing from the
+current stream position.
+
+The reader also exposes `ReadBatch`, which returns at most eight IDs per call. It extracts a group
+of high parts followed by their low parts and can be mixed with scalar `Read` calls. SINDI DMQ
+query reranking now uses `EliasFanoSeekReader` to locate query-term ordinals through high-bitmap
+buckets; `ReadBatch` remains an independent sequential-decode capability.
+
+#### Decode performance versus fixed-width packing
+
+A fixed-width packed decoder mainly performs loads, shifts, and masks. For every ID, EF must also
+maintain two bit streams, locate the next high one bit, handle refills across 64-bit blocks, and
+reconstruct `p_i-i`. Long zero runs in the high bitmap add refill work and branches.
+
+A per-ID scan reconstructs every candidate's complete forward ID sequence. With
+`n_candidate=1000`, that work repeats roughly 1000 times per query. The current seek path instead
+scans ordered query terms over 64-bit high-bitmap words, skips complete words with `popcount`,
+searches low bits only in target high buckets, and returns matching value-code ordinals directly.
+The hybrid layout is computed once when a candidate enters distance computation and is reused to
+select the ID reader and locate the value codes; it is no longer recomputed four times for the
+same candidate.
+
+### 2. Quantize values
+
+For a document `d` being encoded, DMQ recomputes its non-zero value mean `μ_d` and residuals
+`r_{d,i}`. Using the thresholds from the codebook associated with each term, it encodes:
+
+```text
+q_{d,i} = min{k | r_{d,i} <= θ_k}, or q_{d,i} = K - 1 if no such k exists
+```
+
+This matches the implementation's `lower_bound` over 255 thresholds. Let the representative for
+the resulting code be:
+
+```text
+ĉ_{d,i} = c_{q_{d,i}}
+```
+
+DMQ then computes one scale factor for the entire document:
+
+```text
+             Σ_i r_{d,i}²
+α_d = ---------------------------
+             Σ_i ĉ_{d,i} r_{d,i}
+```
+
+If the absolute denominator is at most `10^{-12}`, `α_d` is set to zero. This calibration
+ensures:
+
+```text
+Σ_i r_{d,i}(α_d ĉ_{d,i}) = Σ_i r_{d,i}²
+```
+
+The scaled quantized residual therefore preserves the original residual's projection along its
+own direction. This differs from an ordinary least-squares scale that minimizes mean squared
+reconstruction error.
+
+### 3. Per-vector layout
+
+A document with `L` non-zero entries is encoded as:
+
+```text
++----------------------+----------------------+------------------+
+| header (12 bytes)    | compact term IDs     | value codes      |
+| len, μ_d, α_d        | packed or Elias–Fano | L bytes          |
++----------------------+----------------------+------------------+
+```
+
+Its encoded size is:
+
+```text
+B_DMQ = 12 + min(B_packed, B_EF) + L bytes
+```
+
+An empty vector stores only the 12-byte header.
+
+Actual memory also includes one offset per document, global term mappings, and codebooks. A
+codebook contains 255 `float32` thresholds and 256 `float32` representatives, or 2044 bytes
+excluding container overhead.
+
+## Decoding and rerank scoring
+
+### Decoding
+
+Using the term's codebook, DMQ reconstructs an approximate value as:
+
+```text
+x̂_{d,i} = μ_d + α_d c_{q_{d,i}}
+```
+
+The compact ID is also mapped back to the original term ID.
+
+### Query scoring
+
+SINDI supports inner product only. For a query `q=\{(t,q_t)\}`, query preparation builds a
+256-entry lookup table for every known query term:
+
+```text
+LUT[t, k] = q_t c_{t,k}
+```
+
+The approximate inner product for candidate document `d` is:
+
+```text
+IP(q, x̂_d)
+  = Σ_{t ∈ supp(q) ∩ supp(d)} q_t (μ_d + α_d c_{t,q_{d,t}})
+  = μ_d Σ_t q_t + α_d Σ_t LUT[t, q_{d,t}]
+```
+
+VSAG returns:
+
+```text
+distance(q, d) = 1 - IP(q, x̂_d)
+```
+
+The implementation accumulates the mean and LUT terms directly from compressed data, without
+fully decoding candidate vectors. Query terms absent from the trained DMQ vocabulary do not
+contribute. An empty support intersection has inner product zero and distance one.
+
+## Algorithm flow
+
+```text
+Build
+raw sparse vectors
+  -> compute per-document means and residuals
+  -> assign independent/shared training buckets by term frequency
+  -> train a 256-entry distribution-weighted codebook per bucket
+  -> map term IDs to compact IDs
+  -> encode IDs, 8-bit value codes, mean, and scale per document
+
+Search
+SINDI inverted-list candidate retrieval
+  -> obtain n_candidate candidates
+  -> build the query's DMQ code LUT
+  -> scan compressed forward codes and compute approximate inner products
+  -> sort by 1 - inner_product and return top-k
+```
+
+## Configuration
+
+DMQ8 can only be used as SINDI's rerank forward format:
+
+```json
+{
+    "dtype": "sparse",
+    "metric_type": "ip",
+    "dim": 1024,
+    "index_param": {
+        "term_id_limit": 30000,
+        "window_size": 50000,
+        "doc_prune_ratio": 0.4,
+        "use_quantization": true,
+        "use_reorder": true,
+        "rerank_type": "dmq8",
+        "dmq_shared_codebook_threshold": 1024
+    }
+}
+```
+
+`use_quantization` controls the inverted posting value format, while `rerank_type` controls the
+rerank forward copy. They are independent. A common combination uses SQ8 postings and a DMQ8
+forward store.
+
+## Trade-offs and limitations
+
+- **Accuracy:** DMQ is lossy. Recall changes depend on the data distribution, candidate count, and
+  pruning parameters and should be evaluated on the target dataset.
+- **Memory:** values shrink from four bytes to one and term IDs are compressed. Savings must be
+  measured after including the 12-byte per-vector header, offsets, term mappings, and codebooks.
+- **Codebook sharing:** increasing `dmq_shared_codebook_threshold` reduces codebook memory but may
+  fit term-specific distributions less accurately.
+- **Inner product only:** `SparseDmqQuantizer` currently fixes its metric to inner product.
+- **Offline model only:** SINDI fixes the DMQ codebooks during the initial build and does not
+  support incremental `Add` or `UpdateVector`.
+- **Variable-length codes:** documents differ in non-zero count and ID representation, so DMQ does
+  not support the generic fixed-length batch encode/decode interface.
+
+## Related implementation
+
+- `src/quantization/sparse_quantization/sparse_dmq_quantizer.{h,cpp}`: training, encoding,
+  decoding, and distance computation;
+- `src/datacell/sparse_dmq_datacell.{h,cpp}`: variable-length code storage, offsets, and
+  serialization;
+- `src/impl/elias_fano_stream.{h,cpp}`: Elias–Fano coding for ordered compact IDs;
+- [SINDI](../indexes/sindi.md): index flow, build parameters, and search parameters.

--- a/docs/docs/en/src/quantization/elias-fano.md
+++ b/docs/docs/en/src/quantization/elias-fano.md
@@ -1,0 +1,344 @@
+# Elias–Fano Ordered Integer Compression
+
+This page documents the exact storage format, encoding and decoding algorithms implemented by
+VSAG's `EliasFanoStream`, and how SINDI DMQ uses it to compress forward-store term IDs.
+
+Elias–Fano (EF) is designed for monotone integer sequences with a known value range. The VSAG
+implementation accepts **nondecreasing** sequences, including duplicates. It provides sequential
+streaming decode but does not build a select index for random access.
+
+## Preconditions and notation
+
+The input sequence is:
+
+```text
+0 <= x_0 <= x_1 <= ... <= x_(N-1) < U
+```
+
+where:
+
+- `N` is the number of elements, or the number of non-zero terms in one document;
+- `U` is the exclusive universe bound, equal to the compact-term vocabulary size in DMQ;
+- `x_i` is compact term ID `i`.
+
+An empty sequence has a zero-byte payload. When `N>0`, `U` must be positive.
+
+## 1. Computing the layout
+
+EF splits every integer into high and low parts. The low width is:
+
+```text
+l = floor(log2(U / N)), with l = 0 when U / N <= 1
+```
+
+VSAG computes `U/N` with integer division and then takes its floor base-2 logarithm.
+
+The low region contains `N` tightly packed `l`-bit integers:
+
+```text
+low_bits_bytes = ceil(N * l / 8)
+```
+
+The valid bit count and stored byte count of the high bitmap are:
+
+```text
+high_bits_count = ((U - 1) >> l) + N + 1
+high_bits_bytes = ceil(high_bits_count / 8)
+```
+
+The complete payload size is:
+
+```text
+EF_bytes = low_bits_bytes + high_bits_bytes
+```
+
+`EliasFanoStreamLayout` stores these four results. A caller can compute the layout once and reuse
+it for size calculation, encoding, and reader construction.
+
+## 2. Encoding format
+
+### 2.1 Split high and low parts
+
+For every `x_i`:
+
+```text
+low_i  = x_i & (2^l - 1)
+high_i = x_i >> l
+```
+
+When `l=0`, there is no low region, `low_i=0`, and all information is in the high bitmap.
+
+### 2.2 Low region
+
+Each `low_i` is tightly packed in sequence order, starting at the least-significant bit of each
+byte:
+
+```text
+bit_offset(low_i) = i * l
+```
+
+An integer may cross a byte boundary. Unused bits at the end of the region remain zero.
+
+### 2.3 High region
+
+The high parts use a unary/select representation. The set-bit position for element `i` is:
+
+```text
+p_i = high_i + i
+```
+
+Because `high_i` is nondecreasing, `p_i` is strictly increasing and every element has a unique
+one bit. The `+i` term distinguishes elements even when `x_i == x_(i-1)`.
+
+The final in-memory layout is:
+
+```text
++-----------------------------+----------------------------------+
+| low bits                    | high bitmap                      |
+| N tightly packed l-bit ints | set the i-th one at high_i + i   |
++-----------------------------+----------------------------------+
+```
+
+The payload does not embed `N`, `U`, `l`, or an encoding tag. The caller must supply `N` and `U`,
+or a previously computed layout.
+
+## 3. Complete encoding example
+
+Let:
+
+```text
+U = 16
+N = 4
+x = [3, 5, 8, 13]
+```
+
+The low width is:
+
+```text
+l = floor(log2(16 / 4)) = 2
+```
+
+The split is:
+
+| `i` | `x_i` | `low_i` | `high_i` | `p_i = high_i + i` |
+| ---: | ---: | ---: | ---: | ---: |
+| 0 | 3 | 3 | 0 | 0 |
+| 1 | 5 | 1 | 1 | 2 |
+| 2 | 8 | 0 | 2 | 4 |
+| 3 | 13 | 1 | 3 | 6 |
+
+Packing the low parts LSB-first produces `0x47`. Setting high-bitmap positions 0, 2, 4, and 6
+produces `0x55`:
+
+```text
+payload = [0x47, 0x55]
+           low    high
+```
+
+The total is two bytes. Fixed-width coding with `ceil(log2 U)=4` bits also needs two bytes, so
+the DMQ hybrid strategy selects packed coding for this example because ties do not select EF.
+
+## 4. Encoding algorithm
+
+`EliasFanoStream::Encode` performs:
+
+```text
+layout = GetLayout(N, U)
+clear layout.SizeInBytes() bytes
+
+for i in [0, N):
+    verify x_i < U
+    verify i == 0 or x_(i-1) <= x_i
+    write low_i
+    high_bitmap[high_i + i] = 1
+```
+
+The current low-part writer processes one bit at a time, giving an encoding cost of `O(N*l)`.
+Because inputs are `uint32_t` and `l <= 31`, this can also be viewed as `O(N)` in the number of
+elements.
+
+The encoder clears the entire output first, adding initialization work proportional to payload
+bytes. It uses `O(1)` auxiliary space beyond the output buffer.
+
+## 5. Scalar streaming decode
+
+`EliasFanoStreamReader` maintains separate low and high state:
+
+- `low_cursor_`, `low_buffer_`, and `low_available_bits_`;
+- `high_cursor_`, `high_buffer_`, and `high_available_bits_`;
+- `high_base_position_`, the current 64-bit high block's position in the full bitmap;
+- `index_`, the next element index.
+
+A `Read()` call follows this order:
+
+### 5.1 Find the next high part
+
+If `high_buffer_` is zero, the reader loads up to eight bytes from the high region. It assembles
+the `uint64_t` with explicit byte shifts, making the operation independent of host endianness.
+
+If a loaded 64-bit block is still zero, the reader advances `high_base_position_` and continues
+until it finds a block containing a set bit. It then performs:
+
+```text
+bit_offset = count_trailing_zeros(high_buffer)
+high_buffer &= high_buffer - 1
+p_i = high_base_position + bit_offset
+high_i = p_i - i
+```
+
+Under GCC and Clang, `count_trailing_zeros` maps to `__builtin_ctzll`, which normally generates a
+hardware bit-scan/tzcnt instruction. `buffer &= buffer-1` clears the lowest consumed one bit.
+
+### 5.2 Read the low part
+
+When the low buffer contains fewer than `l` bits, the reader appends bytes until a complete
+`low_i` is available:
+
+```text
+low_i = low_buffer & low_mask
+low_buffer >>= l
+```
+
+For `l=0`, it returns zero without accessing the low region.
+
+### 5.3 Reconstruct the integer
+
+```text
+x_i = (high_i << l) | low_i
+```
+
+The reader then increments `index_`. Calling `Read()` after reaching `N` is an error.
+
+## 6. Batch decode
+
+`ReadBatch(values, max_count)` returns at most
+`EliasFanoStreamReader::MAX_BATCH_SIZE`, currently eight. It uses two passes:
+
+1. extract all `high_i` values for the batch;
+2. restore the batch's starting `index_`, read all `low_i` values, and reconstruct the results.
+
+This organization reduces alternation between high and low state and provides an entry point for
+future unrolling or SIMD work. Scalar and batch calls can be mixed, and the final partial batch
+returns its actual size.
+
+`ReadBatch` has correctness tests, but SINDI DMQ query reranking now uses
+`EliasFanoSeekReader` to locate query-term ordinals directly instead of using this batch API.
+The sequential reader remains in use for complete vector decode and vector-to-vector merge.
+
+## 7. Complexity
+
+### Space
+
+The implementation's space bound is:
+
+```text
+N*l + O(N) bits
+```
+
+For a strictly increasing sequence, where `N<=U`, this is the classic
+`N*floor(log2(U/N))+O(N)` Elias–Fano bound. The `l=0` form also covers the `N>U` case
+made possible by duplicate values.
+
+The exact byte count in this implementation is:
+
+```text
+ceil(N*l/8) + ceil((((U-1)>>l) + N + 1)/8)
+```
+
+### Time
+
+| Operation | Time | Auxiliary space |
+| --- | --- | --- |
+| Layout calculation | `O(log U)`, bounded by the 32-bit integer width | `O(1)` |
+| Encoding | current implementation `O(N*l)` | `O(1)` |
+| Decode all IDs sequentially | `O(N + high_bits_count/word_bits)` | `O(1)` |
+| Amortized sequential decode per ID | `O(1)` | `O(1)` |
+| Seek ordered query terms | `O(H_s/w + sum_q log(k_q+1) + M)` | `O(1)` |
+| Random access to ID `i` | not currently provided | — |
+
+Every high-bitmap machine word is loaded at most once and every one bit is consumed once, making
+a complete sequential scan linear. A large gap between adjacent high parts can make the reader
+skip several all-zero words; that work is included in the `high_bits_count/word_bits` term.
+
+## 8. SINDI DMQ hybrid strategy
+
+DMQ supports both fixed-width packed and EF coding. For compact-term vocabulary size `V`, the
+fixed width is:
+
+```text
+b = max(1, ceil(log2 V))
+packed_bytes = ceil(N*b/8)
+```
+
+Each document uses:
+
+```text
+EF_bytes < packed_bytes  -> Elias–Fano
+otherwise                -> packed
+```
+
+There is no extra format tag. During decode, the header's `N` and the model's `V` reproduce the
+same deterministic comparison, yielding the representation and the following value-code offset.
+An empty vector has no ID payload.
+
+The hybrid layout is computed once when a candidate enters distance computation and reused to:
+
+- select `EliasFanoStreamReader` or `PackedReader`;
+- obtain the ID payload byte count;
+- locate the DMQ value codes.
+
+This removes the earlier implementation's four layout calculations for the same candidate.
+
+Here, `H_s` is the number of high-bitmap bits scanned through the greatest query high part,
+`k_q` is the size of the query term's high bucket, and `M` is the number of matches.
+
+## 9. Query-driven seek and performance
+
+A fixed-width packed reader mainly performs loads, shifts, and masks. For every ID, EF must also:
+
+- maintain two independent bit streams;
+- locate the next one bit in the high bitmap;
+- clear the consumed bit;
+- refill across 64-bit boundaries and skip all-zero blocks;
+- compute `p_i-i` and combine the high and low parts;
+- handle additional data dependencies and branches.
+
+Scanning every candidate's complete ID sequence repeats these operations across roughly 1000
+documents when `n_candidate=1000`. Query scoring therefore now uses
+`EliasFanoSeekReader`:
+
+1. process query compact IDs in ascending order;
+2. treat zero bits in the high bitmap as high-bucket delimiters;
+3. use 64-bit `popcount` to skip a complete bitmap word at once;
+4. derive the bucket's ordinal range from the number of consumed one bits;
+5. binary-search low bits within that range;
+6. access the DMQ value code at the matching ordinal directly.
+
+This path no longer reconstructs every candidate ID and does not change the EF payload or index
+format. It is a scalar word-level skipping optimization, not an enabled SIMD implementation.
+Further SIMD work must still handle variable-length high bitmaps, block boundaries, and
+dependencies in the query-matching loop.
+
+## 10. Validation and edge cases
+
+The implementation validates:
+
+- `U > 0` for a non-empty sequence;
+- non-null input, output, and batch pointers when they are used;
+- every value satisfies `x_i < U`;
+- the input is nondecreasing;
+- the high bitmap does not end before `N` one bits are read;
+- `Read()` does not pass the sequence end;
+- a `ReadBatch` request does not exceed eight elements.
+
+Duplicate IDs are valid. Unordered IDs and IDs equal to or greater than `U` are rejected.
+
+## 11. Implementation and tests
+
+- `src/impl/elias_fano_stream.h`: layout, encoder, and reader interfaces;
+- `src/impl/elias_fano_stream.cpp`: layout, encoding, scalar decode, and batch decode;
+- `src/impl/elias_fano_stream_test.cpp`: ordered round trips, duplicates, batch reads, empty high
+  blocks, mixed scalar/batch calls, and invalid-input tests;
+- `src/quantization/sparse_quantization/sparse_dmq_quantizer.cpp`: hybrid packed/EF selection and
+  SINDI DMQ distance computation;
+- [DMQ](dmq.md): value quantization, forward layout, and rerank scoring.

--- a/docs/docs/zh/book.toml
+++ b/docs/docs/zh/book.toml
@@ -3,3 +3,6 @@ authors = []
 language = "zh"
 src = "src"
 title = "VSAG文档"
+
+[output.html]
+mathjax-support = true

--- a/docs/docs/zh/src/SUMMARY.md
+++ b/docs/docs/zh/src/SUMMARY.md
@@ -33,6 +33,8 @@
 - [PQ FastScan](quantization/pqfs.md)
 - [RaBitQ](quantization/rabitq.md)
 - [RaBitQ x+y Split](quantization/rabitq_split.md)
+- [DMQ（稀疏向量分布维持量化）](quantization/dmq.md)
+- [Elias–Fano 有序整数压缩](quantization/elias-fano.md)
 - [量化变换（TQ）](advanced/quantization_transform.md)
 
 # 开发者指南

--- a/docs/docs/zh/src/indexes/sindi.md
+++ b/docs/docs/zh/src/indexes/sindi.md
@@ -19,7 +19,8 @@ SINDI（**S**parse **IN**verted **D**ense **I**ndex）是 VSAG 面向 **稀疏�
 3. **打分。** 检索时，SINDI 遍历查询向量的非零项，按窗口访问对应的倒排表，使用大小为
    `n_candidate` 的大顶堆聚合得分，最后取 top-k。启用 `use_reorder` 时，候选会在正排
    存储上重打分。默认正排存储保留 fp32 值；设置 `rerank_type: "dmq8"` 时使用压缩的
-   DMQ 正排以降低重排内存。
+   DMQ 正排以降低重排内存。DMQ 的 compact term ID 会按向量在定宽 bit-pack 和
+   Elias–Fano 编码之间选择占用更小的格式。
 
 返回的距离为 `1 - inner_product`，使结果与稠密索引一样按升序排序。
 

--- a/docs/docs/zh/src/quantization/README.md
+++ b/docs/docs/zh/src/quantization/README.md
@@ -71,11 +71,13 @@ true`）。本章介绍每一种受支持的量化器：它做什么、接受哪
 | `rabitq` | 1 或 HGraph x+y | **是** | 否 | 1 比特 / 低比特 split 二值量化，最强压缩 |
 | `tq` | 取决于链路 | 取决于末端量化器 | 否 | [量化变换](../advanced/quantization_transform.md)：在另一个量化器之前串接旋转 / PCA |
 
-`int8` 与 `sparse` 不作为通用的 `base_quantization_type` 暴露：
+`int8`、`sparse` 与 `dmq8` 不作为通用的 `base_quantization_type` 暴露：
 
 - `int8` 在使用 `dtype: "int8"` 时被自动选用，并非一种压缩模式。
 - `sparse` 为 [SINDI](../indexes/sindi.md) 的倒排链表服务，密集索引不可
   直接选择。
+- `dmq8` 为 SINDI 的重排正排存储服务，仅可通过 `rerank_type: "dmq8"`
+  启用，详见 [DMQ](dmq.md)。
 
 ## 训练需求
 
@@ -88,9 +90,9 @@ true`）。本章介绍每一种受支持的量化器：它做什么、接受哪
 
 ## 度量兼容性
 
-本章所列量化器全部支持三种稠密度量（`l2` / `ip` / `cosine`）。对 `cosine`，
-索引会在量化前对向量做归一化，因此底层量化器看不到原始模长。一些实践
-要点：
+上表所列稠密量化器全部支持三种稠密度量（`l2` / `ip` / `cosine`）。
+SINDI 专用的 DMQ8 仅支持内积。对 `cosine`，索引会在量化前对向量做归一化，
+因此底层量化器看不到原始模长。一些实践要点：
 
 - `pq` / `pqfs` 在每个子空间上做距离查表；当 `pq_dim` 非常小（≤ 4），
   在 `ip` / `cosine` 上比 `l2` 更容易受各向异性影响。
@@ -148,4 +150,6 @@ true`）。本章介绍每一种受支持的量化器：它做什么、接受哪
 - [PQ FastScan](pqfs.md)
 - [RaBitQ](rabitq.md)
 - [RaBitQ x+y Split](rabitq_split.md)
+- [DMQ（稀疏向量分布维持量化）](dmq.md)
+- [Elias–Fano 有序整数压缩](elias-fano.md)
 - [量化变换（TQ）](../advanced/quantization_transform.md)

--- a/docs/docs/zh/src/quantization/dmq.md
+++ b/docs/docs/zh/src/quantization/dmq.md
@@ -1,0 +1,423 @@
+# DMQ（稀疏向量分布维持量化）
+
+DMQ（Distribution Maintenance Quantization，分布维持量化）是 VSAG 为
+[SINDI](../indexes/sindi.md) 重排正排存储实现的稀疏向量量化方法。当前实现
+名为 `dmq8`：每个非零 value 使用一个 8-bit code，每篇文档额外保存均值和
+缩放因子；term ID 则先映射为紧凑 ID，再选择定宽 bit-pack 或 Elias–Fano
+编码。
+
+本文描述的是 VSAG 中 `SparseDmqQuantizer` 的具体算法。DMQ 目前不是密集索引
+可以通过 `base_quantization_type` 选择的通用量化器。
+
+## 背景
+
+SINDI 使用倒排表完成候选召回。启用 `use_reorder` 后，还需要保存一份按文档
+组织的完整稀疏向量，用于对候选重新计算内积。若一篇文档含有 `L` 个
+非零项，直接保存 `uint32` term ID 和 `float32` value，仅两组数组
+就需要约 `8L` 字节；大规模语料中，这份正排副本会成为显著的内存开销。
+
+普通的全局均匀量化没有利用稀疏检索数据的两个特点：
+
+- 不同 term 的 value 分布可能明显不同；
+- 同一篇文档内的 value 通常具有文档相关的中心和尺度。
+
+DMQ 因此组合了三个层次的压缩：
+
+1. **按文档中心化：** 每篇文档保存自己的均值，将 value 转换为残差；
+2. **按 term 建模：** 高频 term 使用独立码本，低频 term 可共享码本；
+3. **按文档校准：** 每篇文档保存一个缩放因子，使量化代表值适配
+   该文档。
+
+此外，DMQ 只保存实际出现 term 的紧凑 ID，并利用一篇文档内 term ID 有序的
+特点压缩 ID 序列。
+
+## 符号
+
+设训练集包含文档集合 `D`。文档 `d` 的稀疏向量写作
+
+```text
+x_d = {(t_{d,i}, x_{d,i}) | i = 0, ..., L_d - 1}
+```
+
+其中：
+
+- `L_d` 是文档的非零项数；
+- `t_{d,i}` 是 term ID；
+- `x_{d,i}` 是对应 value；
+- `K = 2^8 = 256` 是 DMQ8 的码字数量；
+- `τ` 是低频 term 共享码本阈值，默认值为 1024。
+
+## 训练
+
+### 1. 文档中心化
+
+DMQ 先计算每篇训练文档非零 value 的均值：
+
+```text
+μ_d = (1 / L_d) Σ_i x_{d,i}
+```
+
+并得到残差：
+
+```text
+r_{d,i} = x_{d,i} - μ_d
+```
+
+空向量的均值定义为 0。只对非零项求均值，不把稀疏向量中未出现的维度
+当作 0 参与计算。
+
+### 2. term 分桶与共享码本
+
+记 term `t` 在训练集中的出现次数为 `f_t`。VSAG 按以下规则分配训练桶：
+
+```text
+f_t <= τ    -> 所有低频 term 进入同一个共享桶
+f_t >  τ    -> term t 使用自己的独立桶
+```
+
+每个桶收集其所属 term 的全部残差，并训练一个 256 项码本。设置
+`dmq_shared_codebook_threshold: 0` 时，每个已出现的 term 都使用独立码本。
+
+共享低频码本可以避免为样本很少的 term 分别保存约 2 KiB 的码本，同时让
+这些 term 合并训练样本。代价是不同低频 term 共用同一残差分布模型。
+
+### 3. 分布加权码本
+
+设某个训练桶包含 `N` 个残差，排序后为
+`z_0 ≤ z_1 ≤ ⋯ ≤ z_{N-1}`。实现为每个样本定义权重：
+
+```text
+w_i = Σ_j (z_i - z_j)²
+    = N z_i² + Σ_j z_j² - 2 z_i Σ_j z_j
+```
+
+总权重为：
+
+```text
+W = Σ_i w_i
+```
+
+`w_i` 衡量残差 `z_i` 与桶内整体分布的平方距离。靠近分布主体的
+样本权重较小，远离主体的样本权重较大，因此码本会给分布尾部保留更多
+分辨率，而不是简单地按样本数做等频切分。
+
+定义累计权重 `C_i = Σ_{j=0}^{i} w_j`。对于 `k=0,…,K-1`，码本代表值为：
+
+```text
+c_k = z_min{i : C_i >= ((2k + 1) / (2K)) W}
+```
+
+对于 `k=0,…,K-2`，编码阈值为：
+
+```text
+θ_k = z_min{i : C_i >= ((k + 1) / K) W}
+```
+
+因此 256 个代表值位于相邻阈值的加权中间位置，255 个阈值负责把
+残差映射到 `[0, 255]`。若桶内残差完全相同，使 `W` 接近 0，则所有
+代表值和阈值都设为该残差值。
+
+## 编码
+
+### 1. 紧凑 term ID
+
+训练完成后，所有实际出现的 term 按原始 ID 升序排列，并映射为
+`[0, V - 1]` 中的 compact ID，其中 `V` 是不同 term 的数量。定宽编码
+需要的位数为：
+
+```text
+b = max(1, ceil(log₂ V))
+```
+
+长度为 `L` 的 ID 序列使用 bit-pack 时占用：
+
+```text
+B_packed = ceil(Lb / 8) bytes
+```
+
+当前序列化格式还会计算同一有序 ID 序列的 Elias–Fano 大小，并逐向量选择
+更小的表示。令
+
+```text
+l = floor(log₂(V / L))，当 V / L <= 1 时 l = 0
+```
+
+则当前 Elias–Fano 布局的大小为：
+
+```text
+B_low  = ceil(Ll / 8)
+B_high = ceil((((V - 1) >> l) + L + 1) / 8)
+B_EF   = B_low + B_high
+```
+
+仅当 `B_{EF} < B_{packed}` 时选择 Elias–Fano；大小相等时仍使用 bit-pack。
+上述 Elias–Fano 公式假设 `L > 0`；空向量的 ID payload 为 0 字节。
+完整的字节布局、编码示例、流式解码状态和复杂度分析见
+[Elias–Fano 有序整数压缩](elias-fano.md)。
+
+#### Elias–Fano 数据布局
+
+设一篇文档的有序 compact ID 为
+`x_0 ≤ x_1 ≤ ... ≤ x_{L-1} < V`。对每个 ID 按 `l` 位拆分：
+
+```text
+low_i  = x_i & (2^l - 1)
+high_i = x_i >> l
+```
+
+编码结果由两个连续区域组成：
+
+```text
++---------------------------+--------------------------------+
+| low bits                  | high bits                      |
+| L 个 l-bit 整数，紧密排列 | 在位置 high_i + i 处设置一个 1 |
++---------------------------+--------------------------------+
+```
+
+低位区域按 ID 顺序保存 `low_i`。高位区域不直接保存 `high_i`，而是把第 `i`
+个 1 放在：
+
+```text
+p_i = high_i + i
+```
+
+因为 ID 单调不减，`p_i` 严格递增；即使两个 ID 相同，它们在高位 bitmap
+中仍占据不同位置。bitmap 的长度为：
+
+```text
+((V - 1) >> l) + L + 1 bits
+```
+
+例如 `V=16`、ID 序列为 `[3, 5, 8, 13]` 时，`L=4`、`l=2`：
+
+```text
+low  = [3, 1, 0, 1]
+high = [0, 1, 2, 3]
+p    = [0, 2, 4, 6]
+```
+
+因此高位 bitmap 的第 0、2、4、6 位为 1。
+
+当前格式不为每篇文档额外保存“packed/EF”标记。解码器从 header 得到 `L`，
+从 DMQ 模型得到 `V`，使用与编码端相同的大小比较规则，即可确定 ID 区域
+采用哪一种格式及 value codes 的起始偏移。
+
+#### Elias–Fano 编码过程
+
+编码器先调用 `GetLayout(L, V)` 计算 `l` 和两个区域的字节数，然后清零输出：
+
+1. 检查每个 ID 小于 `V`，且序列单调不减；
+2. 把 `low_i` 写入低位 bit stream 的第 `i·l` 位；
+3. 在高位 bitmap 的第 `high_i+i` 位设置 1。
+
+当前 `store_packed` 逐位写低位，因此实现成本为 `O(L·l)`；对固定的
+32-bit ID 上界可视为 `O(L)`。输出空间为：
+
+```text
+O(L log₂(V/L) + L) bits
+```
+
+Elias–Fano 的收益主要出现在 `L` 相对 `V` 较小、且 ID 有序的文档。Hybrid
+策略仍逐文档比较实际字节数，避免在 EF 不能节省空间时使用它。
+
+#### Elias–Fano 流式解码
+
+解码器同时维护低位和高位两个游标：
+
+1. 从低位 bit stream 取出下一个 `low_i`；
+2. 从高位 bitmap 找到下一个置位位置 `p_i`；
+3. 计算 `high_i = p_i - i`；
+4. 重建 `x_i = (high_i << l) | low_i`。
+
+`EliasFanoStreamReader` 每次最多加载 8 字节高位 bitmap 到一个 64-bit
+buffer。它使用 trailing-zero count 找到最低置位，随后执行
+`buffer &= buffer - 1` 清除该位。若 buffer 为 0，则跳过当前块并加载后续
+字节。低位也通过一个 64-bit buffer 按需补充。
+
+顺序解码全部 `L` 个 ID 的复杂度为：
+
+```text
+O(L + high_bits_count / machine_word_bits)
+```
+
+因此摊销到每个 ID 为 `O(1)`；额外 reader 状态为 `O(1)`。不过这是顺序解码
+保证，不代表任意位置都能常数时间随机访问。当前 reader 没有 select 索引，
+定位第 `i` 个 ID 需要从流的当前位置继续扫描。
+
+reader 还提供 `ReadBatch`，一次最多读取 8 个 ID。它先集中提取高位，再集中
+提取低位，并支持与标量 `Read` 混用。当前 SINDI DMQ 查询重排改用
+`EliasFanoSeekReader`，通过 high bitmap 的 bucket 直接定位查询 term 的
+ordinal；`ReadBatch` 仍用于独立的顺序解码能力。
+
+#### 与定宽 packed 解码的性能差异
+
+定宽 packed 解码主要是加载、移位和 mask。EF 每个 ID 还需要维护两条 bit
+stream、查找下一个高位 1、处理跨 64-bit 块的 refill，并执行
+`p_i-i` 重建。高位 bitmap 中出现长零区间时，还会增加 refill 和分支。
+
+逐项扫描会为每个候选文档恢复完整正排 ID 序列；当 `n_candidate=1000` 时，
+这些额外操作会重复约 1000 次。当前 seek 路径改为按有序查询 term 扫描
+64-bit high bitmap word，以 `popcount` 跳过整块，只在目标 high bucket 中
+查找 low bits，并直接返回匹配的 value-code ordinal。Hybrid 的 layout 在
+每个候选进入距离计算时计算一次，并被复用于确定 ID reader 和 value-code
+偏移，不再为同一候选重复计算四次。
+
+### 2. value 量化
+
+对待编码文档 `d`，重新计算其非零 value 均值 `μ_d` 和残差
+`r_{d,i}`。根据 term 对应码本的阈值，将每个残差编码为：
+
+```text
+q_{d,i} = min{k | r_{d,i} <= θ_k}，若不存在则 q_{d,i} = K - 1
+```
+
+这与实现中对 255 个阈值执行 `lower_bound` 一致。记该 code 对应的码本
+代表值为：
+
+```text
+ĉ_{d,i} = c_{q_{d,i}}
+```
+
+DMQ 再为整篇文档计算一个缩放因子：
+
+```text
+             Σ_i r_{d,i}²
+α_d = ---------------------------
+             Σ_i ĉ_{d,i} r_{d,i}
+```
+
+当分母绝对值不超过 `10^{-12}` 时，`α_d` 设为 0。该校准使
+
+```text
+Σ_i r_{d,i}(α_d ĉ_{d,i}) = Σ_i r_{d,i}²
+```
+
+也就是让缩放后的量化残差在原残差方向上保持相同的投影。它不同于
+以最小均方误差为目标的普通最小二乘缩放。
+
+### 3. 单向量布局
+
+一篇含 `L` 个非零项的文档编码为：
+
+```text
++----------------------+----------------------+------------------+
+| header (12 bytes)    | compact term IDs     | value codes      |
+| len, μ_d, α_d        | packed or Elias–Fano | L bytes          |
++----------------------+----------------------+------------------+
+```
+
+因此单向量编码大小为：
+
+```text
+B_DMQ = 12 + min(B_packed, B_EF) + L bytes
+```
+
+空向量只保存 12 字节 header。
+
+实际内存还包括每篇文档一个 offset、全局 term 映射和码本。每个码本包含
+255 个 `float32` 阈值与 256 个 `float32` 代表值，共 2044 字节，不含
+容器开销。
+
+## 解码与重排打分
+
+### 解码
+
+根据 term 所属码本，value 的近似重建值为：
+
+```text
+x̂_{d,i} = μ_d + α_d c_{q_{d,i}}
+```
+
+compact ID 同时被映射回原始 term ID。
+
+### 查询打分
+
+SINDI 只支持内积度量。对于查询
+`q=\{(t,q_t)\}`，DMQ 在查询准备阶段为每个已知查询 term 建立 256 项查找表：
+
+```text
+LUT[t, k] = q_t c_{t,k}
+```
+
+候选文档 `d` 的近似内积为：
+
+```text
+IP(q, x̂_d)
+  = Σ_{t ∈ supp(q) ∩ supp(d)} q_t (μ_d + α_d c_{t,q_{d,t}})
+  = μ_d Σ_t q_t + α_d Σ_t LUT[t, q_{d,t}]
+```
+
+VSAG 返回的距离为：
+
+```text
+distance(q, d) = 1 - IP(q, x̂_d)
+```
+
+实现直接在压缩数据上累加均值项和 LUT 项，不需要先完整解码候选向量。
+未出现在 DMQ 训练词表中的查询 term 不参与打分；空交集的内积为 0，
+距离为 1。
+
+## 算法流程
+
+```text
+构建阶段
+原始稀疏向量
+  -> 计算逐文档均值与残差
+  -> 按 term 频率分配独立/共享训练桶
+  -> 按残差分布权重训练 256 项码本
+  -> term ID 映射为 compact ID
+  -> 每篇文档编码 ID、8-bit value code、均值和缩放因子
+
+检索阶段
+SINDI 倒排粗排
+  -> 取得 n_candidate 个候选
+  -> 为查询构造 DMQ code LUT
+  -> 直接扫描候选的压缩正排编码并计算近似内积
+  -> 按 1 - inner_product 排序并返回 top-k
+```
+
+## 使用方式
+
+DMQ8 只能作为 SINDI 的重排正排格式使用：
+
+```json
+{
+    "dtype": "sparse",
+    "metric_type": "ip",
+    "dim": 1024,
+    "index_param": {
+        "term_id_limit": 30000,
+        "window_size": 50000,
+        "doc_prune_ratio": 0.4,
+        "use_quantization": true,
+        "use_reorder": true,
+        "rerank_type": "dmq8",
+        "dmq_shared_codebook_threshold": 1024
+    }
+}
+```
+
+`use_quantization` 控制倒排 posting value 的格式，而 `rerank_type` 控制重排正排
+副本的格式；两者彼此独立。常见组合是倒排使用 SQ8、正排使用 DMQ8。
+
+## 取舍与限制
+
+- **精度：** DMQ 是有损量化，最终召回变化取决于数据分布、候选数和剪枝
+  参数，应在目标数据集上评估。
+- **内存：** value 从 4 字节降为 1 字节，term ID 也被压缩；收益需扣除每向量
+  12 字节 header、offset、term 映射和码本。
+- **码本共享：** 增大 `dmq_shared_codebook_threshold` 会减少码本内存，但可能降低
+  term 专属分布的拟合能力。
+- **仅支持内积：** 当前 `SparseDmqQuantizer` 的度量固定为 inner product。
+- **只支持离线建模：** SINDI 的 DMQ 码本在首次构建时固定，不支持增量
+  `Add` 或 `UpdateVector`。
+- **编码长度可变：** 不同文档的非零项数量和 ID 编码方式不同，因此 DMQ
+  不支持通用的定长 batch encode/decode 接口。
+
+## 相关实现
+
+- `src/quantization/sparse_quantization/sparse_dmq_quantizer.{h,cpp}`：训练、编码、
+  解码与距离计算；
+- `src/datacell/sparse_dmq_datacell.{h,cpp}`：变长编码存储、offset 管理与序列化；
+- `src/impl/elias_fano_stream.{h,cpp}`：有序 compact ID 的 Elias–Fano 编解码；
+- [SINDI](../indexes/sindi.md)：索引流程、构建参数与检索参数。

--- a/docs/docs/zh/src/quantization/elias-fano.md
+++ b/docs/docs/zh/src/quantization/elias-fano.md
@@ -1,0 +1,388 @@
+# Elias–Fano 有序整数压缩
+
+本文描述 VSAG 中 `EliasFanoStream` 的实际存储格式、编码和解码算法，以及它在
+SINDI DMQ 正排 term ID 压缩中的使用方式。
+
+Elias–Fano（EF）适合压缩取值范围已知的单调整数序列。VSAG 当前实现支持
+**单调不减**序列，因此允许重复值；它提供顺序流式解码，不提供带 select
+索引的随机访问。
+
+## 适用条件与符号
+
+输入序列记为：
+
+$$
+0 \le x_0 \le x_1 \le \cdots \le x_{N-1} < U
+$$
+
+其中：
+
+- $N$：序列元素个数，对应一篇文档的非零 term 数；
+- $U$：值域上界，不包含在有效取值中；DMQ 中等于 compact term 词表大小；
+- $x_i$：第 $i$ 个 compact term ID。
+
+当 $N=0$ 时，编码 payload 为 0 字节。当 $N>0$ 时，$U$ 必须大于 0。
+
+## 1. Layout 计算
+
+EF 把每个整数拆成高位和低位。低位宽度为：
+
+$$
+l =
+\begin{cases}
+\left\lfloor \log_2 \left(\left\lfloor U/N \right\rfloor\right) \right\rfloor,
+    & \left\lfloor U/N \right\rfloor > 1, \\
+0,  & \left\lfloor U/N \right\rfloor \le 1.
+\end{cases}
+$$
+
+这里内层的 $\lfloor U/N \rfloor$ 表示 VSAG 使用整数除法计算商，再对商取
+向下整的 $\log_2$。
+
+低位区域包含 $N$ 个 $l$-bit 整数：
+
+$$
+B_{\mathrm{low}} = \left\lceil \frac{Nl}{8} \right\rceil
+$$
+
+高位 bitmap 的有效位数和存储字节数为：
+
+$$
+H = \left\lfloor \frac{U-1}{2^l} \right\rfloor + N + 1
+$$
+
+$$
+B_{\mathrm{high}} = \left\lceil \frac{H}{8} \right\rceil
+$$
+
+完整 payload 大小为：
+
+$$
+B_{\mathrm{EF}} = B_{\mathrm{low}} + B_{\mathrm{high}}
+$$
+
+`EliasFanoStreamLayout` 保存上述四个结果。调用方可以只计算一次 layout，并在
+大小计算、编码或 reader 构造时复用。
+
+## 2. 编码格式
+
+### 2.1 拆分高低位
+
+对每个 $x_i$：
+
+$$
+\operatorname{low}_i = x_i \bmod 2^l
+$$
+
+$$
+\operatorname{high}_i = \left\lfloor \frac{x_i}{2^l} \right\rfloor
+$$
+
+当 $l=0$ 时不存在低位区域，$\operatorname{low}_i=0$，所有信息都在高位
+bitmap 中。
+
+### 2.2 低位区域
+
+$\operatorname{low}_i$ 按序紧密排列，从每个字节的最低位开始写入：
+
+$$
+\operatorname{bitOffset}(\operatorname{low}_i) = il
+$$
+
+一个整数可以跨越字节边界。区域末尾不足一个字节的位保持为 0。
+
+### 2.3 高位区域
+
+高位使用 unary/select 形式编码。第 $i$ 个元素对应的置位位置为：
+
+$$
+p_i = \operatorname{high}_i + i
+$$
+
+因为 $\operatorname{high}_i$ 单调不减，$p_i$ 严格递增，所以每个元素都对应
+唯一的 1 bit。即使 $x_i=x_{i-1}$，额外的 $+i$ 仍能区分两个元素。
+
+最终内存布局为：
+
+```text
++-----------------------------+----------------------------------+
+| low bits                    | high bitmap                      |
+| N 个 l-bit 整数，紧密排列   | 在 high_i + i 处设置第 i 个 1   |
++-----------------------------+----------------------------------+
+```
+
+payload 本身不保存 $N$、$U$、$l$ 或编码类型。调用方必须从外部提供 $N$ 和
+$U$，或提供预先计算好的 layout。
+
+## 3. 完整编码示例
+
+设：
+
+$$
+U=16,\qquad N=4,\qquad \boldsymbol{x}=[3,5,8,13]
+$$
+
+低位宽度：
+
+$$
+l=\left\lfloor\log_2(16/4)\right\rfloor=2
+$$
+
+拆分结果：
+
+| $i$ | $x_i$ | $\operatorname{low}_i$ | $\operatorname{high}_i$ | $p_i=\operatorname{high}_i+i$ |
+| ---: | ---: | ---: | ---: | ---: |
+| 0 | 3 | 3 | 0 | 0 |
+| 1 | 5 | 1 | 1 | 2 |
+| 2 | 8 | 0 | 2 | 4 |
+| 3 | 13 | 1 | 3 | 6 |
+
+低位按 LSB-first 紧密排列后是 `0x47`，高位 bitmap 在第 0、2、4、6 位
+置 1，得到 `0x55`：
+
+```text
+payload = [0x47, 0x55]
+           low    high
+```
+
+总大小为 2 字节。若用 `uint32_t` 直接保存则需要 16 字节；若按
+$\lceil\log_2 U\rceil=4$ 位定宽打包，也需要 2 字节。因此 DMQ Hybrid 策略在这个
+例子中会选择 packed，因为大小相等时不选择 EF。
+
+## 4. 编码算法
+
+`EliasFanoStream::Encode` 的流程为：
+
+```text
+layout = GetLayout(N, U)
+清零 layout.SizeInBytes() 字节
+
+for i in [0, N):
+    检查 x_i < U
+    检查 i == 0 或 x_(i-1) <= x_i
+    写入 low_i
+    high_bitmap[high_i + i] = 1
+```
+
+当前低位写入函数逐 bit 处理，编码时间为 $O(Nl)$。由于输入是
+`uint32_t`，$l\le31$，也可以把它视为相对于元素个数的 $O(N)$。
+
+编码器首先清零整个输出，因此还需要与 payload 字节数成正比的初始化成本。
+除输出缓冲区外，编码过程只使用 $O(1)$ 额外空间。
+
+## 5. 标量流式解码
+
+`EliasFanoStreamReader` 分别维护低位和高位状态：
+
+- `low_cursor_`、`low_buffer_`、`low_available_bits_`；
+- `high_cursor_`、`high_buffer_`、`high_available_bits_`；
+- `high_base_position_`：当前 64-bit 高位块在完整 bitmap 中的起始位置；
+- `index_`：下一个要解码的元素序号。
+
+一次 `Read()` 的实际顺序如下：
+
+### 5.1 找到下一个高位
+
+如果 `high_buffer_` 为 0，reader 从高位区域加载最多 8 字节。字节通过显式
+移位组装为 `uint64_t`，因此不依赖主机端序。
+
+若加载出的 64-bit 块仍为 0，则增加 `high_base_position_` 并继续加载，
+直到找到包含置位的块。最低置位的块内偏移为：
+
+$$
+\delta_i=\operatorname{ctz}(\texttt{high\_buffer})
+$$
+
+清除最低置位后，恢复其绝对位置与高位：
+
+$$
+p_i=\texttt{high\_base\_position}+\delta_i
+$$
+
+$$
+\operatorname{high}_i=p_i-i
+$$
+
+对应的位操作为：
+
+```text
+high_buffer &= high_buffer - 1
+```
+
+`count_trailing_zeros` 在 GCC/Clang 下映射到 `__builtin_ctzll`，通常会生成
+硬件 bit-scan/tzcnt 指令。`buffer &= buffer-1` 清除刚消费的最低置位。
+
+### 5.2 读取低位
+
+当 low buffer 中不足 $l$ 位时，reader 逐字节补充，直到可以返回一个完整
+的 $\operatorname{low}_i$。数学上等价于：
+
+$$
+\operatorname{low}_i=\texttt{low\_buffer}\bmod 2^l
+$$
+
+然后通过右移 $l$ 位消费它：
+
+```text
+low_buffer >>= l
+```
+
+当 $l=0$ 时直接返回 0，不访问低位区域。
+
+### 5.3 重建整数
+
+$$
+x_i=\operatorname{high}_i\,2^l+\operatorname{low}_i
+$$
+
+随后 `index_` 加 1。reader 到达 $N$ 后再次调用 `Read()` 会报错。
+
+## 6. 批量解码
+
+`ReadBatch(values, max_count)` 最多返回
+`EliasFanoStreamReader::MAX_BATCH_SIZE`，当前值为 8。它分两轮处理：
+
+1. 连续提取本批元素的所有 $\operatorname{high}_i$；
+2. 恢复批次起始 `index_`，连续读取所有 $\operatorname{low}_i$ 并完成重建。
+
+这种组织减少了高低位状态交替带来的依赖，并为后续展开或 SIMD 化提供了
+入口。批量和标量调用可以混用，最后不足 8 个元素时返回实际数量。
+
+`ReadBatch` 已有正确性测试，但当前 SINDI DMQ 查询重排使用
+`EliasFanoSeekReader` 直接定位查询 term 的 ordinal，并不使用这个批量接口。
+顺序 reader 仍用于完整向量解码和向量间 merge。
+
+## 7. 复杂度
+
+### 空间
+
+当前实现的空间界为：
+
+$$
+Nl+O(N)\ \text{bits}
+$$
+
+当序列严格递增、因而 $N\le U$ 时，这就是经典的
+
+$$
+N\left\lfloor\log_2(U/N)\right\rfloor+O(N)
+$$
+
+Elias–Fano 空间界。使用 $l=0$ 时，该表达式也能覆盖允许重复值导致 $N>U$
+的情况。
+
+对应当前实现的精确字节数：
+
+$$
+B_{\mathrm{EF}}
+=
+\left\lceil\frac{Nl}{8}\right\rceil
++
+\left\lceil
+\frac{
+    \left\lfloor (U-1)/2^l \right\rfloor+N+1
+}{8}
+\right\rceil
+$$
+
+### 时间
+
+| 操作 | 时间复杂度 | 额外空间 |
+| --- | --- | --- |
+| layout 计算 | $O(\log U)$，最多 32-bit 整数宽度 | $O(1)$ |
+| 编码 | 当前实现 $O(Nl)$ | $O(1)$ |
+| 顺序解码全部 ID | $O(N+H/w)$，$w$ 为机器字位数 | $O(1)$ |
+| 摊销单个顺序解码 | $O(1)$ | $O(1)$ |
+| 有序查询 term 的 seek | $O(H_s/w+\sum_q\log(k_q+1)+M)$ | $O(1)$ |
+| 随机读取第 $i$ 个 ID | 当前未提供 | — |
+
+高位 bitmap 中的每个机器字最多加载一次，每个 1 bit 也只消费一次，因此完整
+顺序扫描是线性的。若相邻高位相差很大，reader 可能连续跳过多个全零机器字；
+该成本已经包含在 $H/w$ 项中。
+
+## 8. SINDI DMQ Hybrid 策略
+
+DMQ 同时支持定宽 packed 与 EF。设 compact term 词表大小为 $V$，定宽位数和
+payload 大小为：
+
+$$
+b=\max\left(1,\left\lceil\log_2 V\right\rceil\right)
+$$
+
+$$
+B_{\mathrm{packed}}=\left\lceil\frac{Nb}{8}\right\rceil
+$$
+
+每篇文档编码时比较：
+
+$$
+\text{encoding} =
+\begin{cases}
+\text{Elias--Fano}, & B_{\mathrm{EF}} < B_{\mathrm{packed}}, \\
+\text{packed},      & B_{\mathrm{EF}} \ge B_{\mathrm{packed}}.
+\end{cases}
+$$
+
+格式没有额外 tag。解码时使用 header 中的 $N$ 和模型中的 $V$ 重做相同的
+确定性比较，即可推导格式和后续 value codes 的偏移。空向量没有 ID payload。
+
+候选进入距离计算时只计算一次 Hybrid layout，结果同时用于：
+
+- 选择 `EliasFanoStreamReader` 或 `PackedReader`；
+- 得到 ID payload 字节数；
+- 定位 DMQ value codes。
+
+这避免了早期实现中同一候选重复计算四次 layout 的开销。
+
+其中 $H_s$ 是扫描到最大查询 high 所经过的 bitmap 位数，$k_q$ 是查询 term
+所在 high bucket 的元素数，$M$ 是实际匹配数。
+
+## 9. 查询驱动 seek 与性能
+
+定宽 packed reader 的核心操作是加载、移位和 mask。EF reader 每个 ID 还要：
+
+- 维护两条独立 bit stream；
+- 查找高位 bitmap 的下一个 1；
+- 清除已消费的置位；
+- 处理跨 64-bit 块的 refill 和全零块；
+- 执行 $p_i-i$ 和高低位合并；
+- 承担更多数据依赖与条件分支。
+
+若 SINDI reorder 对每个候选扫描完整 ID 序列，例如
+$n_{\mathrm{candidate}}=1000$，这些额外操作会重复约 1000 次。当前查询打分
+因此改用 `EliasFanoSeekReader`：
+
+1. 查询 compact ID 按升序处理；
+2. 将 high bitmap 中的 0 作为 high bucket 分隔符；
+3. 使用 64-bit `popcount` 一次跳过整个 bitmap word；
+4. 通过已消费的 1 数得到 bucket 对应的 ordinal 范围；
+5. 在该范围内二分查找 low bits；
+6. 命中后直接访问同 ordinal 的 DMQ value code。
+
+该路径不再逐项恢复候选的所有 ID，也不修改 EF payload 或索引格式。它是
+scalar word-level 跳跃优化，不等同于已经启用 SIMD。进一步 SIMD 化仍需解决
+变长高位 bitmap、跨块边界和查询匹配循环的数据依赖。
+
+## 10. 校验与边界条件
+
+实现会检查：
+
+- 非空序列的 $U>0$；
+- 输入、输出和 batch 指针在需要使用时非空；
+- 每个值满足 $x_i<U$；
+- 输入序列单调不减；
+- 高位 bitmap 在读完 $N$ 个置位前没有耗尽；
+- `Read()` 不超过序列结尾；
+- `ReadBatch` 的请求数量不超过 8。
+
+重复 ID 是合法输入；乱序 ID 和等于或超过 $U$ 的 ID 会被拒绝。
+
+## 11. 相关实现与测试
+
+- `src/impl/elias_fano_stream.h`：layout、编码器和 reader 接口；
+- `src/impl/elias_fano_stream.cpp`：layout、编码、标量和批量解码；
+- `src/impl/elias_fano_stream_test.cpp`：有序序列 round-trip、重复值、批量读取、
+  跨空高位块、标量/批量混用和错误输入测试；
+- `src/quantization/sparse_quantization/sparse_dmq_quantizer.cpp`：Hybrid
+  packed/EF 选择和 SINDI DMQ 距离计算；
+- [DMQ](dmq.md)：value 量化、正排布局和重排打分。

--- a/sindi_dmq_elias_fano_report.md
+++ b/sindi_dmq_elias_fano_report.md
@@ -1,0 +1,715 @@
+# SINDI DMQ Elias–Fano 正排压缩与检索优化报告
+
+日期：2026-07-30
+
+范围：SINDI DMQ 正排 term ID 的压缩、解码、集合交与候选重排
+
+## 1. 摘要
+
+SINDI 使用倒排表召回 candidate，并使用按文档组织的 DMQ 正排数据完成
+reorder。DMQ 将每个非零 value 压缩为 8-bit code，但原有 compact term ID
+仍采用定宽 packed 编码。
+
+本次工作利用文档内 term ID 单调有序的特点，引入 Hybrid Elias–Fano（EF）
+编码，并将 EF 重排从“完整解码候选文档 ID”优化为“查询 term 驱动的跳跃式
+位置查找”。
+
+主要结果：
+
+- 每篇文档分别计算 packed 与 EF 的实际字节数，只在 EF 更小时选择 EF；
+- EF payload 不额外保存格式 tag，seek 优化不改变已有 Hybrid EF payload；
+- EF 只负责有序 term ID 集合，DMQ value code 继续按 ordinal 平行存储；
+- 查询重排通过 EF seek 直接返回 ordinal，再访问 `value_codes[ordinal]`；
+- `wholenet-sparse-1m-ip` 上完整索引从 419.49 MiB 降至 401.00 MiB，
+  节省 18.49 MiB，即 4.41%；
+- DMQ rerank backend 从 146.96 MiB 降至 128.47 MiB，节省 12.58%；
+- EF seek 相对 EF 标量全量扫描，Release 延迟降低 5.74%，QPS 提升 5.96%；
+- Recall 保持 0.9863；
+- 单元测试共 13 个 case、2220 个断言，全部通过。
+
+## 2. 背景
+
+SINDI 的检索分为两个阶段：
+
+```text
+查询稀疏向量
+    |
+    v
+倒排 posting 累加
+    |
+    v
+取得 n_candidate 个候选
+    |
+    v
+读取候选的 DMQ 正排编码
+    |
+    v
+重新计算近似内积并返回 top-k
+```
+
+一篇包含 \(L\) 个非零项的文档，DMQ 正排布局为：
+
+```text
++----------------------+----------------------+------------------+
+| header               | compact term IDs     | value codes      |
+| len, mean, alpha     | packed or EF         | L bytes          |
++----------------------+----------------------+------------------+
+```
+
+其中：
+
+- header 固定为 12 字节；
+- compact term ID 是全局 term 映射后的有序整数；
+- 每个 value code 固定为 1 字节；
+- 第 \(i\) 个 term ID 与第 \(i\) 个 value code 一一对应。
+
+term ID 与 value code 的对应关系不需要额外 offset：
+
+```text
+term IDs:    [id_0, id_1, id_2, ...]
+value codes: [q_0,  q_1,  q_2,  ...]
+                 同一 ordinal
+```
+
+因此只要得到 term 在文档中的 ordinal \(i\)，即可直接读取
+`value_codes[i]`。
+
+## 3. Hybrid Packed / Elias–Fano 策略
+
+### 3.1 Compact term ID
+
+训练完成后，所有实际出现的 term 按原始 ID 升序映射到：
+
+$$
+[0,V-1]
+$$
+
+其中 \(V\) 是 DMQ 词表中的不同 term 数量。
+
+文档的 compact ID 序列满足：
+
+$$
+0\le x_0\le x_1\le\cdots\le x_{L-1}<V
+$$
+
+正常稀疏向量中的 term ID 唯一；底层 EF 实现同时允许重复值。
+
+### 3.2 Packed 大小
+
+定宽 packed 使用：
+
+$$
+b=\max\left(1,\left\lceil\log_2V\right\rceil\right)
+$$
+
+位保存每个 compact ID，payload 大小为：
+
+$$
+B_{\mathrm{packed}}
+=
+\left\lceil\frac{Lb}{8}\right\rceil
+$$
+
+字节。
+
+### 3.3 Elias–Fano 大小
+
+EF 低位宽度为：
+
+$$
+l=
+\begin{cases}
+\left\lfloor
+\log_2\left(\left\lfloor V/L\right\rfloor\right)
+\right\rfloor,
+& \left\lfloor V/L\right\rfloor>1,\\
+0,
+& \left\lfloor V/L\right\rfloor\le1.
+\end{cases}
+$$
+
+低位区域大小为：
+
+$$
+B_{\mathrm{low}}
+=
+\left\lceil\frac{Ll}{8}\right\rceil
+$$
+
+高位 bitmap 的有效位数为：
+
+$$
+H
+=
+\left\lfloor\frac{V-1}{2^l}\right\rfloor+L+1
+$$
+
+对应字节数为：
+
+$$
+B_{\mathrm{high}}
+=
+\left\lceil\frac{H}{8}\right\rceil
+$$
+
+因此：
+
+$$
+B_{\mathrm{EF}}
+=
+B_{\mathrm{low}}+B_{\mathrm{high}}
+$$
+
+### 3.4 逐文档选择
+
+Hybrid 策略为：
+
+$$
+\operatorname{encoding}
+=
+\begin{cases}
+\text{Elias--Fano},
+&B_{\mathrm{EF}}<B_{\mathrm{packed}},\\
+\text{packed},
+&B_{\mathrm{EF}}\ge B_{\mathrm{packed}}.
+\end{cases}
+$$
+
+大小相等时继续使用 packed，避免在没有空间收益时承担 EF 解码成本。
+
+格式没有额外 tag。解码端从文档 header 获得 \(L\)，从 DMQ 模型获得
+\(V\)，重做同一确定性比较，即可恢复：
+
+- ID payload 的编码类型；
+- ID payload 的字节数；
+- value codes 的起始位置。
+
+空向量的 ID payload 为 0 字节。
+
+## 4. Elias–Fano 编码布局
+
+每个 ID 拆分为：
+
+$$
+\operatorname{low}_i=x_i\bmod 2^l
+$$
+
+$$
+\operatorname{high}_i
+=
+\left\lfloor\frac{x_i}{2^l}\right\rfloor
+$$
+
+低位按顺序紧密排列。第 \(i\) 个高位在 bitmap 中的置位位置为：
+
+$$
+p_i=\operatorname{high}_i+i
+$$
+
+由于 \(\operatorname{high}_i\) 单调不减，\(p_i\) 严格递增，因此重复 ID
+也可以表示。
+
+最终布局：
+
+```text
++-----------------------------+----------------------------------+
+| low bits                    | high bitmap                      |
+| L 个 l-bit 整数，紧密排列   | 在 high_i + i 处设置第 i 个 1   |
++-----------------------------+----------------------------------+
+```
+
+完整的字节级示例与边界条件见：
+
+- `docs/docs/zh/src/quantization/elias-fano.md`
+- `src/impl/elias_fano_stream.{h,cpp}`
+
+## 5. 解码优化演进
+
+### 5.1 原始标量解码
+
+标量 reader 为每个 ID：
+
+1. 从 high bitmap 找到下一个 1；
+2. 计算 \(\operatorname{high}_i=p_i-i\)；
+3. 从 low bit stream 读取 \(\operatorname{low}_i\)；
+4. 重建：
+
+$$
+x_i
+=
+\operatorname{high}_i2^l+\operatorname{low}_i
+$$
+
+Packed 解码主要是 load、shift 和 mask；EF 还需要维护两条 bit stream、
+执行 trailing-zero count、跨 word refill 和位置重建。因此虽然顺序解码
+摊销复杂度为 \(O(1)\)，常数仍明显大于 packed。
+
+### 5.2 Stage A：64-bit word 优化
+
+第一阶段优化包括：
+
+- high bitmap 每次安全加载最多 8 字节；
+- 使用 64-bit buffer；
+- 使用 trailing-zero count 定位最低置位；
+- 使用 `buffer &= buffer - 1` 清除已消费置位；
+- 预计算 low mask；
+- 增加最多 8 个 ID 的 `ReadBatch`；
+- 支持标量与批量 reader 混用。
+
+在 `wholenet-sparse-1m-ip` 的干净 Release 测试中：
+
+| 指标 | Stage A 前 | Stage A 后 | 变化 |
+| --- | ---: | ---: | ---: |
+| QPS | 2802.13 | 2891.81 | +3.20% |
+| 平均延迟 | 2.854 ms | 2.760 ms | -3.30% |
+| Recall | 0.9863 | 0.9863 | 不变 |
+
+### 5.3 Layout 复用
+
+早期距离计算会为同一候选重复计算多次 Hybrid layout，用于：
+
+- 判断是否使用 EF；
+- 计算 ID payload 字节数；
+- 定位 value codes；
+- 构造 reader。
+
+当前实现只在候选进入距离计算时计算一次 layout，并复用其结果，消除了
+“每个候选重复计算四次 layout”的固定开销。
+
+## 6. 查询驱动的 EF Seek
+
+### 6.1 为什么不应完整扫描
+
+旧 EF 重排方式由文档驱动：
+
+```text
+for each document ID:
+    解码 id_i
+    判断 id_i 是否属于查询
+    若匹配则读取 value_codes[i]
+```
+
+这会恢复候选文档的全部 \(L\) 个 ID，即使查询只包含很少的 term。
+当 `n_candidate=1000` 时，该成本对每次查询重复约 1000 个文档。
+
+EF 本质上只负责有序 ID 集合。更合适的方式是由查询 term 驱动，直接寻找
+匹配 term 的 ordinal。
+
+### 6.2 High bitmap 的 bucket
+
+EF high bitmap 中的 0 可以视为 high bucket 分隔符。设第 \(h\) 个 0 的
+位置为：
+
+$$
+z_h=\operatorname{select}_0(h)
+$$
+
+则 high 等于 \(h\) 的 ordinal 范围为：
+
+$$
+\operatorname{begin}_h
+=
+\begin{cases}
+0,&h=0,\\
+\operatorname{rank}_1(z_{h-1}),&h>0,
+\end{cases}
+$$
+
+$$
+\operatorname{end}_h
+=
+\operatorname{rank}_1(z_h)
+$$
+
+目标 ID \(t\) 拆分为：
+
+$$
+h_t=t\mathbin{>>}l,
+\qquad
+low_t=t\bmod2^l
+$$
+
+Seek reader 先取得 high bucket 的 ordinal 范围，再在该范围内二分查找
+low bits。
+
+### 6.3 Word-level 跳跃
+
+当前实现不增加 rank/select 辅助索引，而是每次读取一个 64-bit high bitmap
+word：
+
+```text
+ones  = popcount(word)
+zeros = valid_bits - ones
+```
+
+如果目标 zero delimiter 不在当前 word，则一次跳过整个 word：
+
+```text
+ordinal   += ones
+zero_count += zeros
+```
+
+如果目标 delimiter 在当前 word，则在 zero mask 中找到目标 zero，并使用
+此前消费的 1 数量得到 bucket 的 ordinal 边界。
+
+查询 compact ID 已按升序排列，因此 high cursor 只向前移动；一个候选的
+high bitmap 最多扫描一次。
+
+### 6.4 Low bits 随机访问
+
+low bits 是定宽 packed 数组。ordinal \(i\) 的位偏移为：
+
+$$
+offset_i=il
+$$
+
+因此可以直接读取 `low[i]`，无需解码此前的 low values。同一 high bucket
+中的 low values 仍然有序，可以使用 `lower_bound` 和 `upper_bound` 得到
+目标 ID 的完整 ordinal range。
+
+返回 range 而不是单个位置，是为了保持底层重复 ID 的语义。正常稀疏向量
+term 唯一时，range 长度最多为 1。
+
+### 6.5 Value code 定位
+
+Seek 返回：
+
+```cpp
+struct EliasFanoOrdinalRange {
+    uint32_t begin;
+    uint32_t end;
+};
+```
+
+DMQ 直接使用 ordinal 访问 value code：
+
+```cpp
+for (uint32_t position = range.begin; position < range.end; ++position) {
+    qualifier_product +=
+        query.code_lut[query_index * 256 + value_codes[position]];
+}
+```
+
+这里有两个不同的位置：
+
+- `query_index`：term 在查询中的位置，用于选择 query value 和 LUT；
+- `position`：term 在候选文档中的 ordinal，用于读取 `value_codes[position]`。
+
+EF 不编码 value，也不需要在 EF payload 中保存 value offset。
+
+### 6.6 复杂度
+
+旧标量完整扫描为：
+
+$$
+O(L)
+$$
+
+查询驱动 seek 为：
+
+$$
+O\left(
+\frac{H_s}{w}
++\sum_{q\in Q}\log(k_q+1)
++M
+\right)
+$$
+
+其中：
+
+- \(H_s\)：扫描到最大查询 high 所经过的 bitmap 位数；
+- \(w=64\)：机器字位数；
+- \(k_q\)：查询 term 所在 high bucket 的元素数；
+- \(M\)：实际匹配数量。
+
+EF 的 \(l\) 选择使 high bitmap 总大小为 \(O(L)\)，因此最坏情况下的
+word 扫描约为 \(O(L/64)\)，并且只读取目标 bucket 的 low values。
+
+## 7. 实现改动
+
+### 7.1 EF stream
+
+文件：
+
+- `src/impl/elias_fano_stream.h`
+- `src/impl/elias_fano_stream.cpp`
+- `src/impl/elias_fano_stream_test.cpp`
+
+新增：
+
+- `EliasFanoStreamLayout`
+- `EliasFanoStream::Encode`
+- `EliasFanoStreamReader::Read`
+- `EliasFanoStreamReader::ReadBatch`
+- `EliasFanoSeekReader::FindEqualRange`
+- `EliasFanoOrdinalRange`
+
+### 7.2 DMQ
+
+文件：
+
+- `src/quantization/sparse_quantization/sparse_dmq_quantizer.h`
+- `src/quantization/sparse_quantization/sparse_dmq_quantizer.cpp`
+- `src/quantization/sparse_quantization/sparse_dmq_quantizer_test.cpp`
+
+主要改动：
+
+- 增加 Hybrid ID encoding type；
+- 逐文档计算 packed/EF layout；
+- 编码时选择更小格式；
+- Decode/Compute 支持 packed 与 EF；
+- Query ComputeDist 的 EF 分支使用 query-driven seek；
+- layout 在单个候选内只计算一次；
+- 内存估算同步考虑 packed/EF 最小值。
+
+### 7.3 SINDI 与 DataCell
+
+文件：
+
+- `src/algorithm/sindi/sindi.cpp`
+- `src/datacell/sparse_dmq_datacell.cpp`
+- `src/datacell/sparse_dmq_datacell_test.cpp`
+
+主要改动：
+
+- SINDI rerank backend 内存估算支持 Hybrid EF；
+- 可变长度 DMQ code 的 offset、序列化与恢复保持一致；
+- seek 优化不改变 Hybrid EF 索引结构和 DMQ value code 布局。
+
+## 8. 正确性验证
+
+### 8.1 EF 测试
+
+覆盖：
+
+- 单值序列；
+- 严格递增序列；
+- 单调不减与重复值；
+- \(l=0\)；
+- 标量 round-trip；
+- 完整与不完整 batch；
+- 标量和 batch 混用；
+- high bitmap 全零 word 跳过；
+- seek 命中和缺失；
+- 多个 query term 位于同一 high bucket；
+- 最后一个不完整字节的 padding；
+- seek target 单调约束；
+- 乱序和越界输入。
+
+Seek 结果与标准库 `equal_range` 逐项对照。
+
+### 8.2 DMQ 测试
+
+覆盖：
+
+- Hybrid 编码大小不超过 packed；
+- EF 编码后的完整 Decode；
+- EF seek 距离与完整解码后计算的距离一致；
+- 未知查询 term；
+- 模型序列化与恢复；
+- 共享码本；
+- 空模型。
+
+目标测试结果：
+
+```text
+13 test cases
+2220 assertions
+all passed
+```
+
+格式检查：
+
+- `clang-format-15 --dry-run --Werror` 通过；
+- `git diff --check` 通过。
+
+## 9. 实验环境
+
+主性能数据集：
+
+```text
+/root/data/wholenet-sparse-1m-ip.hdf5
+```
+
+配置：
+
+| 参数 | 值 |
+| --- | ---: |
+| base count | 1,000,000 |
+| query count | 1,000 |
+| metric | inner product |
+| top-k | 10 |
+| n_candidate | 1,000 |
+| query prune ratio | 0 |
+| term prune ratio | 0 |
+| search threads | 8 |
+| build type | Release |
+
+测试使用同一份 Hybrid EF 索引完成标量扫描与 seek A/B，避免构建差异影响。
+索引在测试后保留。
+
+## 10. 索引大小
+
+实际索引文件：
+
+```text
+Hybrid EF: /tmp/vsag_sindi_dmq_profile_hybrid.index
+Packed:    /tmp/vsag_sindi_dmq_profile_packed.index
+```
+
+结果：
+
+| 部分 | Hybrid EF | Packed | EF 节省 |
+| --- | ---: | ---: | ---: |
+| DMQ rerank backend | 128.47 MiB | 146.96 MiB | 18.49 MiB / 12.58% |
+| 完整 SINDI 索引 | 401.00 MiB | 419.49 MiB | 18.49 MiB / 4.41% |
+
+精确字节数：
+
+| 格式 | 字节 |
+| --- | ---: |
+| Hybrid EF | 420,474,836 |
+| Packed | 439,864,866 |
+| 差值 | 19,390,030 |
+
+完整索引的节省比例低于 rerank backend，是因为 EF 只压缩 DMQ 正排 term ID；
+倒排表、value codes、码本和其他公共结构约 272.52 MiB，均保持不变。
+
+## 11. 检索性能
+
+### 11.1 Packed 与标量 EF 的阶段分析
+
+在加入 query-driven seek 之前，对 Packed 与 Hybrid EF 标量路径进行了阶段
+计时：
+
+| 格式 | 倒排 candidate | 正排 reorder | 总延迟 |
+| --- | ---: | ---: | ---: |
+| Packed | 1.510 ms | 0.931 ms | 2.446 ms |
+| Hybrid EF 标量 | 1.504 ms | 1.364 ms | 2.890 ms |
+
+结论：
+
+- 倒排 candidate 阶段基本相同，差异属于测量波动；
+- 编码格式只影响正排 reorder；
+- 标量 EF reorder 比 Packed 慢约 46.6%；
+- 当时约 97.7% 的总延迟差来自 reorder。
+
+这说明优化重点应是 EF 集合交和 ordinal 定位，而不是倒排召回。
+
+### 11.2 EF Seek A/B
+
+同一 Release 构建方式、同一 Hybrid EF 索引、相同检索参数下：
+
+| 实现 | 轮数 | 平均延迟 | 平均 QPS |
+| --- | ---: | ---: | ---: |
+| EF 标量完整扫描 | 5 | 2.905 ms | 2750 |
+| EF query-driven seek | 10 | 2.738 ms | 2914 |
+| 变化 | — | -5.74% | +5.96% |
+
+两组 seek 分别相对标量基线取得：
+
+- 第一组：延迟降低 7.1%，QPS 提升 7.4%；
+- 第二组：延迟降低 4.4%，QPS 提升 4.5%。
+
+结果存在正常运行波动，但两组方向一致。
+
+### 11.3 Recall 与内存
+
+完整质量校验结果：
+
+| 指标 | 结果 |
+| --- | ---: |
+| Recall@10 | 0.9863 |
+| DMQ rerank backend | 134,712,241 bytes |
+| 额外 seek 索引 | 0 bytes |
+
+Recall 与 seek 优化前一致。
+
+## 12. 结果文件
+
+性能结果：
+
+- `/tmp/sindi_dmq_scalar_release.json`
+- `/tmp/sindi_dmq_seek_release.json`
+- `/tmp/sindi_dmq_seek_release_after.json`
+- `/tmp/sindi_dmq_seek_recall.json`
+- `/tmp/sindi_dmq_profile_hybrid_latency.json`
+- `/tmp/sindi_dmq_profile_packed_latency.json`
+
+保留索引：
+
+- `/tmp/vsag_sindi_dmq_profile_hybrid.index`
+- `/tmp/vsag_sindi_dmq_profile_packed.index`
+
+## 13. 取舍与限制
+
+### 13.1 空间与速度
+
+EF 节省 term ID 空间，但标量逐项解码常数高于 packed。Query-driven seek
+显著缩小差距，但当前结果仍不能说明 EF reorder 已达到 Packed 水平。
+
+### 13.2 查询分布
+
+Seek 最适合查询 term 数远小于候选文档 term 数的场景。短文档或查询非常
+稠密时，顺序扫描可能更快，后续可以根据 \(L\) 和查询 term 数自适应选择
+seek 或 scan。
+
+### 13.3 非严格随机访问
+
+当前 seek 不保存 rank/select checkpoint，而是以 64-bit word 为粒度向前
+跳跃。它不增加索引内存并兼容已有 Hybrid EF payload，但不是任意位置
+\(O(1)\) 的随机访问。
+
+### 13.4 SIMD
+
+当前优化使用 word-level `popcount`、trailing-zero count 和定宽 low random
+access，属于标量宽字优化。真正 SIMD 化仍需处理：
+
+- 变长 high bitmap；
+- 跨 word 边界；
+- 多查询 term 的 bucket 定位；
+- ordinal 到 value code 的不连续 gather；
+- LUT 累加的数据依赖。
+
+### 13.5 索引兼容性
+
+Query-driven seek 没有修改 EF payload，因此本次性能测试中 seek 前生成的
+Hybrid EF 索引可以直接复用。
+
+但从更早的 packed-only DMQ 格式升级到 Hybrid EF 时，payload 本身没有保存
+encoding tag 或格式版本。旧 packed-only 索引无法仅凭现有 header 与新
+Hybrid decoder 自动区分。正式合入前应通过索引版本、显式 encoding metadata
+或兼容分支明确处理 legacy packed DMQ 索引。
+
+## 14. 后续建议
+
+建议按以下顺序继续：
+
+1. 增加 seek/scan 自适应阈值，并在不同文档长度和查询长度上测试；
+2. 为 Packed 路径实现同样的 query-driven lower-bound，建立公平上限；
+3. 统计每个候选的 EF/Packed 选择比例和平均 bucket occupancy；
+4. 将 high-word `popcount`、zero select 和 low 比较做手工展开；
+5. 评估 BMI2 `pdep` 或平台相关 select-zero 加速；
+6. 仅对长文档评估稀疏 rank/select checkpoint，且把 checkpoint 内存计入
+   Hybrid 选择；
+7. 在 `codefilter-10k-384-angular-f32` 和更多稀疏数据集上补充泛化结果；
+8. 持续分别记录 candidate 与 reorder 阶段，避免仅看总 QPS。
+
+## 15. 结论
+
+Hybrid Elias–Fano 证明了 SINDI DMQ 正排 term ID 可以在不改变 value code
+布局、且不为每篇文档增加格式 tag 的前提下获得实际空间收益。Query-driven
+seek 继续复用相同 Hybrid EF payload；packed-only legacy 索引兼容性仍需在
+正式合入前显式解决。
+
+在 `wholenet-sparse-1m-ip` 上：
+
+- DMQ rerank backend 节省 12.58%；
+- 完整索引节省 4.41%；
+- query-driven EF seek 相对 EF 标量扫描降低 5.74% 延迟；
+- QPS 提升 5.96%；
+- Recall 保持 0.9863。
+
+EF 在该方案中的核心职责不是 value 解码，而是压缩有序 term ID 集合并返回
+集合交命中的 ordinal。DMQ 再利用 ordinal 访问平行存储的 value code。
+从完整扫描改为查询驱动 seek，是本次检索性能优化的关键。

--- a/src/algorithm/sindi/sindi.cpp
+++ b/src/algorithm/sindi/sindi.cpp
@@ -29,6 +29,7 @@
 #include "analyzer/analyzer.h"
 #include "datacell/sparse_dmq_datacell.h"
 #include "datacell/sparse_vector_datacell_parameter.h"
+#include "impl/elias_fano_stream.h"
 #include "impl/heap/standard_heap.h"
 #include "index_feature_list.h"
 #include "io/memory_block_io/memory_block_io_parameter.h"
@@ -1836,7 +1837,15 @@ SINDI::EstimateMemory(uint64_t num_elements) const {
                 std::min<uint64_t>(term_id_limit_, total_sparse_values);
             const uint32_t rerank_id_bits = get_bits_for_term_id_limit(
                 estimated_term_count == 0 ? 0 : static_cast<uint32_t>(estimated_term_count - 1));
-            mem += (total_sparse_values * rerank_id_bits + 7) / 8;
+            if (estimated_term_count != 0 && num_elements != 0) {
+                const uint64_t packed_id_bytes =
+                    (static_cast<uint64_t>(avg_doc_term_length_) * rerank_id_bits + 7) / 8;
+                const uint64_t elias_fano_id_bytes =
+                    EliasFanoStream::GetLayout(avg_doc_term_length_,
+                                               static_cast<uint32_t>(estimated_term_count))
+                        .SizeInBytes();
+                mem += num_elements * std::min(packed_id_bytes, elias_fano_id_bytes);
+            }
             mem += total_sparse_values;
             mem += num_elements * (sizeof(uint64_t) + sizeof(SparseDmqQuantizer::EncodedHeader));
             uint64_t estimated_codebook_count = estimated_term_count;

--- a/src/datacell/sparse_dmq_datacell.cpp
+++ b/src/datacell/sparse_dmq_datacell.cpp
@@ -23,7 +23,8 @@ namespace vsag {
 namespace {
 
 constexpr uint32_t K_SPARSE_DMQ_DATACELL_MAGIC = 0x53444D51U;
-constexpr uint32_t K_SPARSE_DMQ_DATACELL_VERSION = 6;
+constexpr uint32_t K_SPARSE_DMQ_DATACELL_LEGACY_VERSION = 6;
+constexpr uint32_t K_SPARSE_DMQ_DATACELL_VERSION = 7;
 
 }  // namespace
 
@@ -216,7 +217,11 @@ void
 SparseDmqDataCell::Serialize(StreamWriter& writer) {
     std::shared_lock lock(this->mutex_);
     StreamWriter::WriteObj(writer, K_SPARSE_DMQ_DATACELL_MAGIC);
-    StreamWriter::WriteObj(writer, K_SPARSE_DMQ_DATACELL_VERSION);
+    const uint32_t version =
+        quantizer_->GetIdEncodingType() == SparseDmqQuantizer::IdEncodingType::PACKED
+            ? K_SPARSE_DMQ_DATACELL_LEGACY_VERSION
+            : K_SPARSE_DMQ_DATACELL_VERSION;
+    StreamWriter::WriteObj(writer, version);
     StreamWriter::WriteObj(writer, this->total_count_);
     StreamWriter::WriteVector(writer, offsets_);
     StreamWriter::WriteVector(writer, codes_);
@@ -232,12 +237,16 @@ SparseDmqDataCell::Deserialize(lvalue_or_rvalue<StreamReader> reader) {
                    "serialized DMQ datacell has invalid magic");
     uint32_t version = 0;
     StreamReader::ReadObj(reader, version);
-    CHECK_ARGUMENT(version == K_SPARSE_DMQ_DATACELL_VERSION,
-                   fmt::format("unsupported sparse DMQ datacell version {}", version));
+    CHECK_ARGUMENT(
+        version == K_SPARSE_DMQ_DATACELL_LEGACY_VERSION || version == K_SPARSE_DMQ_DATACELL_VERSION,
+        fmt::format("unsupported sparse DMQ datacell version {}", version));
     StreamReader::ReadObj(reader, this->total_count_);
     StreamReader::ReadVector(reader, offsets_);
     StreamReader::ReadVector(reader, codes_);
     quantizer_->Deserialize(reader);
+    quantizer_->SetIdEncodingType(version == K_SPARSE_DMQ_DATACELL_LEGACY_VERSION
+                                      ? SparseDmqQuantizer::IdEncodingType::PACKED
+                                      : SparseDmqQuantizer::IdEncodingType::HYBRID_ELIAS_FANO);
     CHECK_ARGUMENT(offsets_.size() == static_cast<uint64_t>(this->total_count_) + 1,
                    "serialized DMQ offset count is inconsistent");
     CHECK_ARGUMENT(not offsets_.empty(), "serialized DMQ offsets are empty");

--- a/src/datacell/sparse_dmq_datacell_test.cpp
+++ b/src/datacell/sparse_dmq_datacell_test.cpp
@@ -112,6 +112,75 @@ TEST_CASE("SparseDmqDataCell implements FlattenInterface", "[ut][SparseDmqDataCe
     }
 }
 
+TEST_CASE("SparseDmqDataCell reads and preserves legacy packed IDs", "[ut][SparseDmqDataCell]") {
+    IndexCommonParam common_param;
+    common_param.allocator_ = SafeAllocator::FactoryDefaultAllocator();
+    common_param.metric_ = MetricType::METRIC_TYPE_IP;
+    common_param.dim_ = 1024;
+
+    std::vector<uint32_t> ids_0{2, 5, 9};
+    std::vector<float> vals_0{0.2F, 0.5F, 0.8F};
+    std::vector<uint32_t> ids_1{2, 7, 9};
+    std::vector<float> vals_1{0.6F, 0.3F, 0.4F};
+    std::vector<SparseVector> vectors{
+        {static_cast<uint32_t>(ids_0.size()), ids_0.data(), vals_0.data()},
+        {static_cast<uint32_t>(ids_1.size()), ids_1.data(), vals_1.data()},
+    };
+
+    SparseDmqQuantizer legacy_quantizer(1024, common_param.allocator_.get());
+    legacy_quantizer.SetIdEncodingType(SparseDmqQuantizer::IdEncodingType::PACKED);
+    REQUIRE(
+        legacy_quantizer.TrainImpl(reinterpret_cast<const float*>(vectors.data()), vectors.size()));
+    std::vector<uint64_t> offsets{0};
+    std::vector<uint8_t> codes;
+    for (const auto& vector : vectors) {
+        const uint64_t offset = codes.size();
+        codes.resize(offset + legacy_quantizer.GetEncodedSize(vector));
+        REQUIRE(legacy_quantizer.EncodeOneImpl(reinterpret_cast<const float*>(&vector),
+                                               codes.data() + offset));
+        offsets.push_back(codes.size());
+    }
+
+    std::stringstream stream;
+    IOStreamWriter writer(stream);
+    constexpr uint32_t magic = 0x53444D51U;
+    constexpr uint32_t legacy_version = 6;
+    const InnerIdType count = vectors.size();
+    StreamWriter::WriteObj(writer, magic);
+    StreamWriter::WriteObj(writer, legacy_version);
+    StreamWriter::WriteObj(writer, count);
+    StreamWriter::WriteVector(writer, offsets);
+    StreamWriter::WriteVector(writer, codes);
+    legacy_quantizer.Serialize(writer);
+
+    SparseDmqDataCell restored(1024, common_param);
+    IOStreamReader reader(stream);
+    REQUIRE_NOTHROW(restored.Deserialize(reader));
+    std::vector<uint32_t> query_ids{2, 9};
+    std::vector<float> query_vals{0.75F, 0.25F};
+    SparseVector query{
+        static_cast<uint32_t>(query_ids.size()), query_ids.data(), query_vals.data()};
+    auto computer = restored.FactoryComputer(&query);
+    std::vector<InnerIdType> inner_ids{0, 1};
+    std::vector<float> distances(inner_ids.size());
+    restored.Query(distances.data(), computer, inner_ids.data(), inner_ids.size());
+    for (uint64_t index = 0; index < vectors.size(); ++index) {
+        SparseVector decoded;
+        restored.GetSparseVectorByInnerId(index, &decoded, common_param.allocator_.get());
+        REQUIRE(std::abs(distances[index] - sparse_distance(query, decoded)) <= 1e-6F);
+        common_param.allocator_->Deallocate(decoded.ids_);
+        common_param.allocator_->Deallocate(decoded.vals_);
+    }
+
+    std::stringstream reserialized;
+    IOStreamWriter reserialized_writer(reserialized);
+    restored.Serialize(reserialized_writer);
+    const auto bytes = reserialized.str();
+    uint32_t reserialized_version = 0;
+    std::memcpy(&reserialized_version, bytes.data() + sizeof(uint32_t), sizeof(uint32_t));
+    REQUIRE(reserialized_version == legacy_version);
+}
+
 TEST_CASE("SparseDmqDataCell serializes an empty model", "[ut][SparseDmqDataCell]") {
     IndexCommonParam common_param;
     common_param.allocator_ = SafeAllocator::FactoryDefaultAllocator();

--- a/src/impl/elias_fano_stream.cpp
+++ b/src/impl/elias_fano_stream.cpp
@@ -1,0 +1,386 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "elias_fano_stream.h"
+
+#include <algorithm>
+#include <limits>
+
+#include "common.h"
+
+namespace vsag {
+namespace {
+
+uint32_t
+floor_log2(uint32_t value) {
+    uint32_t result = 0;
+    while (value > 1) {
+        value >>= 1;
+        ++result;
+    }
+    return result;
+}
+
+void
+store_packed(uint8_t* bytes, uint64_t index, uint32_t bits, uint32_t value) {
+    const uint64_t bit_offset = index * bits;
+    for (uint32_t bit = 0; bit < bits; ++bit) {
+        if ((value & (1U << bit)) != 0) {
+            const uint64_t target_bit = bit_offset + bit;
+            bytes[target_bit / 8] |= static_cast<uint8_t>(1U << (target_bit % 8));
+        }
+    }
+}
+
+uint32_t
+count_trailing_zeros(uint64_t value) {
+#ifdef __GNUC__
+    return static_cast<uint32_t>(__builtin_ctzll(value));
+#else
+    uint32_t result = 0;
+    while ((value & 1U) == 0) {
+        value >>= 1;
+        ++result;
+    }
+    return result;
+#endif
+}
+
+uint32_t
+count_ones(uint64_t value) {
+#ifdef __GNUC__
+    return static_cast<uint32_t>(__builtin_popcountll(value));
+#else
+    uint32_t result = 0;
+    while (value != 0) {
+        value &= value - 1;
+        ++result;
+    }
+    return result;
+#endif
+}
+
+uint64_t
+get_low_mask(uint32_t bits) {
+    if (bits == 0) {
+        return 0;
+    }
+    if (bits == 64) {
+        return std::numeric_limits<uint64_t>::max();
+    }
+    return (1ULL << bits) - 1ULL;
+}
+
+uint64_t
+load_little_endian(const uint8_t* cursor, const uint8_t* end, uint32_t max_bytes) {
+    const uint64_t remaining = static_cast<uint64_t>(end - cursor);
+    const uint32_t bytes = static_cast<uint32_t>(std::min<uint64_t>(remaining, max_bytes));
+    uint64_t result = 0;
+    for (uint32_t byte = 0; byte < bytes; ++byte) {
+        result |= static_cast<uint64_t>(cursor[byte]) << (byte * 8);
+    }
+    return result;
+}
+
+}  // namespace
+
+EliasFanoStreamLayout
+EliasFanoStream::GetLayout(uint32_t count, uint32_t universe) {
+    EliasFanoStreamLayout layout;
+    if (count == 0) {
+        return layout;
+    }
+    CHECK_ARGUMENT(universe > 0, "Elias-Fano universe must be positive");
+    const uint32_t quotient = universe / count;
+    layout.low_bits_width = quotient <= 1 ? 0 : floor_log2(quotient);
+    layout.low_bits_bytes = (static_cast<uint64_t>(count) * layout.low_bits_width + 7) / 8;
+    layout.high_bits_count =
+        ((static_cast<uint64_t>(universe) - 1) >> layout.low_bits_width) + count + 1;
+    layout.high_bits_bytes = (layout.high_bits_count + 7) / 8;
+    return layout;
+}
+
+void
+EliasFanoStream::Encode(const uint32_t* values, uint32_t count, uint32_t universe, uint8_t* codes) {
+    Encode(values, count, universe, GetLayout(count, universe), codes);
+}
+
+void
+EliasFanoStream::Encode(const uint32_t* values,
+                        uint32_t count,
+                        uint32_t universe,
+                        const EliasFanoStreamLayout& layout,
+                        uint8_t* codes) {
+    if (count == 0) {
+        return;
+    }
+    CHECK_ARGUMENT(values != nullptr, "Elias-Fano values are null");
+    CHECK_ARGUMENT(codes != nullptr, "Elias-Fano output codes are null");
+    std::fill_n(codes, layout.SizeInBytes(), 0);
+    uint32_t previous = 0;
+    const uint32_t low_mask =
+        layout.low_bits_width == 0
+            ? 0
+            : (layout.low_bits_width == 32 ? std::numeric_limits<uint32_t>::max()
+                                           : ((1U << layout.low_bits_width) - 1U));
+    auto* high_bits = codes + layout.low_bits_bytes;
+    for (uint32_t index = 0; index < count; ++index) {
+        const uint32_t value = values[index];
+        CHECK_ARGUMENT(value < universe, "Elias-Fano value exceeds its universe");
+        CHECK_ARGUMENT(index == 0 || previous <= value, "Elias-Fano values must be ordered");
+        if (layout.low_bits_width != 0) {
+            store_packed(codes, index, layout.low_bits_width, value & low_mask);
+        }
+        const uint64_t high = static_cast<uint64_t>(value) >> layout.low_bits_width;
+        const uint64_t position = high + index;
+        high_bits[position / 8] |= static_cast<uint8_t>(1U << (position % 8));
+        previous = value;
+    }
+}
+
+EliasFanoStreamReader::EliasFanoStreamReader(const uint8_t* codes,
+                                             uint32_t count,
+                                             uint32_t universe)
+    : EliasFanoStreamReader(codes, count, EliasFanoStream::GetLayout(count, universe)) {
+}
+
+EliasFanoStreamReader::EliasFanoStreamReader(const uint8_t* codes,
+                                             uint32_t count,
+                                             const EliasFanoStreamLayout& layout)
+    : count_(count) {
+    if (count == 0) {
+        return;
+    }
+    CHECK_ARGUMENT(codes != nullptr, "Elias-Fano codes are null");
+    low_cursor_ = codes;
+    high_cursor_ = codes + layout.low_bits_bytes;
+    high_end_ = high_cursor_ + layout.high_bits_bytes;
+    low_bits_width_ = layout.low_bits_width;
+    low_mask_ = low_bits_width_ == 32 ? std::numeric_limits<uint32_t>::max()
+                                      : ((1U << low_bits_width_) - 1U);
+}
+
+uint32_t
+EliasFanoStreamReader::ReadLowBits() {
+    if (low_bits_width_ == 0) {
+        return 0;
+    }
+    while (low_available_bits_ < low_bits_width_) {
+        low_buffer_ |= static_cast<uint64_t>(*low_cursor_++) << low_available_bits_;
+        low_available_bits_ += 8;
+    }
+    const uint32_t result = static_cast<uint32_t>(low_buffer_) & low_mask_;
+    low_buffer_ >>= low_bits_width_;
+    low_available_bits_ -= low_bits_width_;
+    return result;
+}
+
+void
+EliasFanoStreamReader::RefillHighBits() {
+    while (high_buffer_ == 0) {
+        high_base_position_ += high_available_bits_;
+        CHECK_ARGUMENT(high_cursor_ < high_end_, "Elias-Fano high bits are invalid");
+        const uint64_t remaining = static_cast<uint64_t>(high_end_ - high_cursor_);
+        const uint32_t bytes =
+            static_cast<uint32_t>(std::min<uint64_t>(remaining, sizeof(uint64_t)));
+        high_buffer_ = 0;
+        for (uint32_t byte = 0; byte < bytes; ++byte) {
+            high_buffer_ |= static_cast<uint64_t>(high_cursor_[byte]) << (byte * 8);
+        }
+        high_cursor_ += bytes;
+        high_available_bits_ = bytes * 8;
+    }
+}
+
+uint64_t
+EliasFanoStreamReader::ReadHighBits() {
+    RefillHighBits();
+    const uint32_t high_bit = count_trailing_zeros(high_buffer_);
+    high_buffer_ &= high_buffer_ - 1U;
+    const uint64_t position = high_base_position_ + high_bit;
+    CHECK_ARGUMENT(position >= index_, "Elias-Fano high bits are invalid");
+    return position - index_;
+}
+
+uint32_t
+EliasFanoStreamReader::Read() {
+    CHECK_ARGUMENT(index_ < count_, "Elias-Fano reader is exhausted");
+    const uint64_t high = ReadHighBits();
+    const uint32_t low = ReadLowBits();
+    ++index_;
+    return static_cast<uint32_t>((high << low_bits_width_) | low);
+}
+
+uint32_t
+EliasFanoStreamReader::ReadBatch(uint32_t* values, uint32_t max_count) {
+    CHECK_ARGUMENT(max_count <= MAX_BATCH_SIZE, "Elias-Fano batch size exceeds its limit");
+    const uint32_t batch_count = std::min(max_count, count_ - index_);
+    if (batch_count == 0) {
+        return 0;
+    }
+    CHECK_ARGUMENT(values != nullptr, "Elias-Fano batch output is null");
+
+    const uint32_t first_index = index_;
+    for (uint32_t offset = 0; offset < batch_count; ++offset) {
+        const uint64_t high = ReadHighBits();
+        values[offset] = static_cast<uint32_t>(high);
+        ++index_;
+    }
+    index_ = first_index;
+    for (uint32_t offset = 0; offset < batch_count; ++offset) {
+        const uint32_t low = ReadLowBits();
+        values[offset] =
+            static_cast<uint32_t>((static_cast<uint64_t>(values[offset]) << low_bits_width_) | low);
+        ++index_;
+    }
+    return batch_count;
+}
+
+EliasFanoSeekReader::EliasFanoSeekReader(const uint8_t* codes,
+                                         uint32_t count,
+                                         const EliasFanoStreamLayout& layout)
+    : high_remaining_bits_(layout.high_bits_count),
+      low_bits_width_(layout.low_bits_width),
+      low_mask_(static_cast<uint32_t>(get_low_mask(layout.low_bits_width))),
+      count_(count) {
+    if (count == 0) {
+        return;
+    }
+    CHECK_ARGUMENT(codes != nullptr, "Elias-Fano codes are null");
+    low_bits_ = codes;
+    low_end_ = codes + layout.low_bits_bytes;
+    high_cursor_ = low_end_;
+}
+
+void
+EliasFanoSeekReader::RefillHighBits() {
+    CHECK_ARGUMENT(high_available_bits_ == 0, "Elias-Fano high bits are not exhausted");
+    CHECK_ARGUMENT(high_remaining_bits_ != 0, "Elias-Fano high bits are invalid");
+    const uint32_t bits =
+        static_cast<uint32_t>(std::min<uint64_t>(high_remaining_bits_, sizeof(uint64_t) * 8));
+    const uint32_t bytes = (bits + 7) / 8;
+    high_buffer_ = load_little_endian(high_cursor_, high_cursor_ + bytes, bytes);
+    high_buffer_ &= get_low_mask(bits);
+    high_cursor_ += bytes;
+    high_available_bits_ = bits;
+    high_remaining_bits_ -= bits;
+}
+
+void
+EliasFanoSeekReader::ConsumeHighBits(uint32_t count) {
+    CHECK_ARGUMENT(count <= high_available_bits_, "Elias-Fano high bits are invalid");
+    const uint64_t consumed = high_buffer_ & get_low_mask(count);
+    const uint32_t ones = count_ones(consumed);
+    ordinal_ += ones;
+    zero_count_ += count - ones;
+    if (count == 64) {
+        high_buffer_ = 0;
+    } else {
+        high_buffer_ >>= count;
+    }
+    high_available_bits_ -= count;
+}
+
+void
+EliasFanoSeekReader::AdvanceToZeroCount(uint64_t target) {
+    CHECK_ARGUMENT(target >= zero_count_, "Elias-Fano seek target must be ordered");
+    while (zero_count_ < target) {
+        if (high_available_bits_ == 0) {
+            RefillHighBits();
+        }
+        const uint64_t valid_mask = get_low_mask(high_available_bits_);
+        const uint64_t zero_mask = (~high_buffer_) & valid_mask;
+        const uint32_t available_zeros = count_ones(zero_mask);
+        const uint64_t required_zeros = target - zero_count_;
+        if (available_zeros < required_zeros) {
+            ConsumeHighBits(high_available_bits_);
+            continue;
+        }
+
+        uint64_t remaining_zeros = zero_mask;
+        for (uint64_t rank = 1; rank < required_zeros; ++rank) {
+            remaining_zeros &= remaining_zeros - 1;
+        }
+        const uint32_t zero_position = count_trailing_zeros(remaining_zeros);
+        ConsumeHighBits(zero_position + 1);
+    }
+}
+
+uint32_t
+EliasFanoSeekReader::ReadLowBitsAt(uint32_t index) const {
+    if (low_bits_width_ == 0) {
+        return 0;
+    }
+    const uint64_t bit_offset = static_cast<uint64_t>(index) * low_bits_width_;
+    const auto* cursor = low_bits_ + bit_offset / 8;
+    const uint32_t shift = static_cast<uint32_t>(bit_offset % 8);
+    const uint64_t word = load_little_endian(cursor, low_end_, sizeof(uint64_t));
+    return static_cast<uint32_t>((word >> shift) & low_mask_);
+}
+
+uint32_t
+EliasFanoSeekReader::LowerBoundLow(uint32_t begin, uint32_t end, uint32_t target) const {
+    while (begin < end) {
+        const uint32_t middle = begin + (end - begin) / 2;
+        if (ReadLowBitsAt(middle) < target) {
+            begin = middle + 1;
+        } else {
+            end = middle;
+        }
+    }
+    return begin;
+}
+
+uint32_t
+EliasFanoSeekReader::UpperBoundLow(uint32_t begin, uint32_t end, uint32_t target) const {
+    while (begin < end) {
+        const uint32_t middle = begin + (end - begin) / 2;
+        if (ReadLowBitsAt(middle) <= target) {
+            begin = middle + 1;
+        } else {
+            end = middle;
+        }
+    }
+    return begin;
+}
+
+EliasFanoOrdinalRange
+EliasFanoSeekReader::FindEqualRange(uint32_t target) {
+    CHECK_ARGUMENT(!has_last_target_ || last_target_ <= target,
+                   "Elias-Fano seek target must be ordered");
+    has_last_target_ = true;
+    last_target_ = target;
+    if (count_ == 0) {
+        return {};
+    }
+
+    const uint32_t high = target >> low_bits_width_;
+    if (!has_cached_high_ || cached_high_ != high) {
+        AdvanceToZeroCount(high);
+        cached_range_.begin = ordinal_;
+        AdvanceToZeroCount(static_cast<uint64_t>(high) + 1);
+        cached_range_.end = ordinal_;
+        cached_high_ = high;
+        has_cached_high_ = true;
+    }
+
+    const uint32_t low = target & low_mask_;
+    const uint32_t begin = LowerBoundLow(cached_range_.begin, cached_range_.end, low);
+    if (begin == cached_range_.end || ReadLowBitsAt(begin) != low) {
+        return {begin, begin};
+    }
+    return {begin, UpperBoundLow(begin, cached_range_.end, low)};
+}
+
+}  // namespace vsag

--- a/src/impl/elias_fano_stream.h
+++ b/src/impl/elias_fano_stream.h
@@ -1,0 +1,140 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+
+namespace vsag {
+
+struct EliasFanoStreamLayout {
+    uint32_t low_bits_width{0};
+    uint64_t low_bits_bytes{0};
+    uint64_t high_bits_count{0};
+    uint64_t high_bits_bytes{0};
+
+    [[nodiscard]] uint64_t
+    SizeInBytes() const {
+        return low_bits_bytes + high_bits_bytes;
+    }
+};
+
+struct EliasFanoOrdinalRange {
+    uint32_t begin{0};
+    uint32_t end{0};
+};
+
+class EliasFanoStream {
+public:
+    [[nodiscard]] static EliasFanoStreamLayout
+    GetLayout(uint32_t count, uint32_t universe);
+
+    static void
+    Encode(const uint32_t* values, uint32_t count, uint32_t universe, uint8_t* codes);
+
+    static void
+    Encode(const uint32_t* values,
+           uint32_t count,
+           uint32_t universe,
+           const EliasFanoStreamLayout& layout,
+           uint8_t* codes);
+};
+
+class EliasFanoStreamReader {
+public:
+    static constexpr uint32_t MAX_BATCH_SIZE = 8;
+
+    EliasFanoStreamReader(const uint8_t* codes, uint32_t count, uint32_t universe);
+
+    EliasFanoStreamReader(const uint8_t* codes,
+                          uint32_t count,
+                          const EliasFanoStreamLayout& layout);
+
+    [[nodiscard]] uint32_t
+    Read();
+
+    [[nodiscard]] uint32_t
+    ReadBatch(uint32_t* values, uint32_t max_count);
+
+private:
+    [[nodiscard]] uint32_t
+    ReadLowBits();
+
+    [[nodiscard]] uint64_t
+    ReadHighBits();
+
+    void
+    RefillHighBits();
+
+private:
+    const uint8_t* low_cursor_{nullptr};
+    const uint8_t* high_cursor_{nullptr};
+    const uint8_t* high_end_{nullptr};
+    uint64_t low_buffer_{0};
+    uint64_t high_buffer_{0};
+    uint64_t high_base_position_{0};
+    uint32_t low_available_bits_{0};
+    uint32_t high_available_bits_{0};
+    uint32_t low_bits_width_{0};
+    uint32_t low_mask_{0};
+    uint32_t count_{0};
+    uint32_t index_{0};
+};
+
+class EliasFanoSeekReader {
+public:
+    EliasFanoSeekReader(const uint8_t* codes, uint32_t count, const EliasFanoStreamLayout& layout);
+
+    [[nodiscard]] EliasFanoOrdinalRange
+    FindEqualRange(uint32_t target);
+
+private:
+    void
+    AdvanceToZeroCount(uint64_t target);
+
+    void
+    ConsumeHighBits(uint32_t count);
+
+    void
+    RefillHighBits();
+
+    [[nodiscard]] uint32_t
+    ReadLowBitsAt(uint32_t index) const;
+
+    [[nodiscard]] uint32_t
+    LowerBoundLow(uint32_t begin, uint32_t end, uint32_t target) const;
+
+    [[nodiscard]] uint32_t
+    UpperBoundLow(uint32_t begin, uint32_t end, uint32_t target) const;
+
+private:
+    const uint8_t* low_bits_{nullptr};
+    const uint8_t* low_end_{nullptr};
+    const uint8_t* high_cursor_{nullptr};
+    uint64_t high_buffer_{0};
+    uint64_t high_remaining_bits_{0};
+    uint64_t zero_count_{0};
+    uint32_t high_available_bits_{0};
+    uint32_t low_bits_width_{0};
+    uint32_t low_mask_{0};
+    uint32_t ordinal_{0};
+    uint32_t count_{0};
+    uint32_t cached_high_{0};
+    EliasFanoOrdinalRange cached_range_;
+    uint32_t last_target_{0};
+    bool has_cached_high_{false};
+    bool has_last_target_{false};
+};
+
+}  // namespace vsag

--- a/src/impl/elias_fano_stream_test.cpp
+++ b/src/impl/elias_fano_stream_test.cpp
@@ -1,0 +1,163 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "elias_fano_stream.h"
+
+#include <algorithm>
+#include <vector>
+
+#include "unittest.h"
+
+namespace vsag {
+
+TEST_CASE("EliasFanoStream round trips ordered integers", "[ut][EliasFanoStream]") {
+    const std::vector<std::vector<uint32_t>> cases{
+        {0},
+        {0, 0, 1, 1, 2},
+        {3, 5, 8, 13},
+        {1, 31, 32, 63, 64, 1'000, 99'999},
+    };
+    const std::vector<uint32_t> universes{1, 3, 16, 100'000};
+
+    for (uint32_t case_index = 0; case_index < cases.size(); ++case_index) {
+        const auto& values = cases[case_index];
+        const uint32_t universe = universes[case_index];
+        const auto layout = EliasFanoStream::GetLayout(values.size(), universe);
+        std::vector<uint8_t> codes(layout.SizeInBytes());
+        EliasFanoStream::Encode(values.data(), values.size(), universe, layout, codes.data());
+        EliasFanoStreamReader reader(codes.data(), values.size(), layout);
+        for (const uint32_t value : values) {
+            REQUIRE(reader.Read() == value);
+        }
+    }
+}
+
+TEST_CASE("EliasFanoStream reads ordered integers in batches", "[ut][EliasFanoStream]") {
+    std::vector<uint32_t> values;
+    for (uint32_t index = 0; index < 73; ++index) {
+        values.push_back(index * index + index / 3);
+    }
+    const uint32_t universe = values.back() + 1;
+    const auto layout = EliasFanoStream::GetLayout(values.size(), universe);
+    std::vector<uint8_t> codes(layout.SizeInBytes());
+    EliasFanoStream::Encode(values.data(), values.size(), universe, layout, codes.data());
+
+    EliasFanoStreamReader reader(codes.data(), values.size(), layout);
+    std::vector<uint32_t> decoded;
+    uint32_t batch[EliasFanoStreamReader::MAX_BATCH_SIZE];
+    while (const uint32_t count = reader.ReadBatch(batch, EliasFanoStreamReader::MAX_BATCH_SIZE)) {
+        decoded.insert(decoded.end(), batch, batch + count);
+    }
+    REQUIRE(decoded == values);
+    REQUIRE(reader.ReadBatch(batch, EliasFanoStreamReader::MAX_BATCH_SIZE) == 0);
+}
+
+TEST_CASE("EliasFanoStream batch reader skips empty high words", "[ut][EliasFanoStream]") {
+    std::vector<uint32_t> values(73, 0);
+    const uint32_t universe = 1U << 20;
+    values.back() = universe - 1;
+    const auto layout = EliasFanoStream::GetLayout(values.size(), universe);
+    std::vector<uint8_t> codes(layout.SizeInBytes());
+    EliasFanoStream::Encode(values.data(), values.size(), universe, layout, codes.data());
+
+    EliasFanoStreamReader reader(codes.data(), values.size(), layout);
+    std::vector<uint32_t> decoded;
+    uint32_t batch[EliasFanoStreamReader::MAX_BATCH_SIZE];
+    REQUIRE(reader.ReadBatch(nullptr, 0) == 0);
+    while (const uint32_t count = reader.ReadBatch(batch, EliasFanoStreamReader::MAX_BATCH_SIZE)) {
+        decoded.insert(decoded.end(), batch, batch + count);
+    }
+    REQUIRE(decoded == values);
+}
+
+TEST_CASE("EliasFanoStream supports mixed scalar and batch reads", "[ut][EliasFanoStream]") {
+    const std::vector<uint32_t> values{0, 1, 1, 7, 31, 32, 100, 255, 1'024, 8'191, 65'535};
+    const uint32_t universe = values.back() + 1;
+    const auto layout = EliasFanoStream::GetLayout(values.size(), universe);
+    std::vector<uint8_t> codes(layout.SizeInBytes());
+    EliasFanoStream::Encode(values.data(), values.size(), universe, layout, codes.data());
+
+    EliasFanoStreamReader reader(codes.data(), values.size(), layout);
+    REQUIRE(reader.Read() == values[0]);
+    uint32_t batch[EliasFanoStreamReader::MAX_BATCH_SIZE];
+    REQUIRE(reader.ReadBatch(batch, 3) == 3);
+    REQUIRE(std::vector<uint32_t>(batch, batch + 3) ==
+            std::vector<uint32_t>(values.begin() + 1, values.begin() + 4));
+    REQUIRE(reader.Read() == values[4]);
+    REQUIRE(reader.ReadBatch(batch, EliasFanoStreamReader::MAX_BATCH_SIZE) == 6);
+    REQUIRE(std::vector<uint32_t>(batch, batch + 6) ==
+            std::vector<uint32_t>(values.begin() + 5, values.end()));
+    REQUIRE(reader.ReadBatch(nullptr, 0) == 0);
+    REQUIRE_THROWS(reader.ReadBatch(batch, EliasFanoStreamReader::MAX_BATCH_SIZE + 1));
+}
+
+TEST_CASE("EliasFanoSeekReader finds ordinal ranges", "[ut][EliasFanoStream]") {
+    const std::vector<std::vector<uint32_t>> cases{
+        {0, 0, 1, 1, 2, 3, 3},
+        {3, 5, 8, 13},
+        {0, 1, 7, 31, 32, 100, 255, 511, 1'023},
+    };
+    const std::vector<uint32_t> universes{4, 16, 1'024};
+
+    for (uint32_t case_index = 0; case_index < cases.size(); ++case_index) {
+        const auto& values = cases[case_index];
+        const uint32_t universe = universes[case_index];
+        const auto layout = EliasFanoStream::GetLayout(values.size(), universe);
+        std::vector<uint8_t> codes(layout.SizeInBytes());
+        EliasFanoStream::Encode(values.data(), values.size(), universe, layout, codes.data());
+
+        EliasFanoSeekReader reader(codes.data(), values.size(), layout);
+        for (uint32_t target = 0; target < universe; ++target) {
+            const auto expected = std::equal_range(values.begin(), values.end(), target);
+            const auto actual = reader.FindEqualRange(target);
+            REQUIRE(actual.begin == static_cast<uint32_t>(expected.first - values.begin()));
+            REQUIRE(actual.end == static_cast<uint32_t>(expected.second - values.begin()));
+        }
+    }
+}
+
+TEST_CASE("EliasFanoSeekReader skips high words and validates ordering", "[ut][EliasFanoStream]") {
+    std::vector<uint32_t> values(73, 0);
+    const uint32_t universe = 1U << 20;
+    values.back() = universe - 1;
+    const auto layout = EliasFanoStream::GetLayout(values.size(), universe);
+    std::vector<uint8_t> codes(layout.SizeInBytes());
+    EliasFanoStream::Encode(values.data(), values.size(), universe, layout, codes.data());
+
+    EliasFanoSeekReader reader(codes.data(), values.size(), layout);
+    REQUIRE(reader.FindEqualRange(0).begin == 0);
+    REQUIRE(reader.FindEqualRange(0).end == values.size() - 1);
+    const auto missing = reader.FindEqualRange(universe / 2);
+    REQUIRE(missing.begin == missing.end);
+    const auto last = reader.FindEqualRange(universe - 1);
+    REQUIRE(last.begin == values.size() - 1);
+    REQUIRE(last.end == values.size());
+
+    EliasFanoSeekReader unordered_reader(codes.data(), values.size(), layout);
+    REQUIRE_NOTHROW(unordered_reader.FindEqualRange(10));
+    REQUIRE_THROWS(unordered_reader.FindEqualRange(9));
+}
+
+TEST_CASE("EliasFanoStream validates its input", "[ut][EliasFanoStream]") {
+    std::vector<uint32_t> unordered{2, 1};
+    const auto layout = EliasFanoStream::GetLayout(unordered.size(), 3);
+    std::vector<uint8_t> codes(layout.SizeInBytes());
+    REQUIRE_THROWS(EliasFanoStream::Encode(unordered.data(), unordered.size(), 3, codes.data()));
+
+    std::vector<uint32_t> out_of_range{0, 3};
+    REQUIRE_THROWS(
+        EliasFanoStream::Encode(out_of_range.data(), out_of_range.size(), 3, codes.data()));
+}
+
+}  // namespace vsag

--- a/src/quantization/sparse_quantization/sparse_dmq_quantizer.cpp
+++ b/src/quantization/sparse_quantization/sparse_dmq_quantizer.cpp
@@ -24,6 +24,7 @@
 #include <utility>
 
 #include "common.h"
+#include "impl/elias_fano_stream.h"
 
 namespace vsag {
 namespace {
@@ -108,6 +109,31 @@ private:
     uint32_t mask_;
 };
 
+struct DmqIdEncodingLayout {
+    bool use_elias_fano{false};
+    uint64_t encoded_bytes{0};
+    EliasFanoStreamLayout elias_fano;
+};
+
+DmqIdEncodingLayout
+get_id_encoding_layout(uint32_t count,
+                       uint32_t universe,
+                       uint32_t packed_bits,
+                       SparseDmqQuantizer::IdEncodingType encoding_type) {
+    DmqIdEncodingLayout result;
+    result.encoded_bytes = get_packed_size(count, packed_bits);
+    if (encoding_type != SparseDmqQuantizer::IdEncodingType::HYBRID_ELIAS_FANO || count == 0) {
+        return result;
+    }
+    CHECK_ARGUMENT(universe != 0, "DMQ term model is empty");
+    result.elias_fano = EliasFanoStream::GetLayout(count, universe);
+    if (result.elias_fano.SizeInBytes() < result.encoded_bytes) {
+        result.use_elias_fano = true;
+        result.encoded_bytes = result.elias_fano.SizeInBytes();
+    }
+    return result;
+}
+
 std::tuple<Vector<uint32_t>, Vector<float>>
 sort_sparse_vector(const SparseVector& vector, Allocator* allocator) {
     Vector<uint32_t> indexes(vector.len_, allocator);
@@ -154,8 +180,36 @@ SparseDmqQuantizer::SparseDmqQuantizer(uint32_t term_id_limit,
 }
 
 uint64_t
+SparseDmqQuantizer::GetPackedIdSize(uint32_t count) const {
+    return get_packed_size(count, id_bits_);
+}
+
+uint64_t
+SparseDmqQuantizer::GetEliasFanoIdSize(uint32_t count) const {
+    if (count == 0) {
+        return 0;
+    }
+    CHECK_ARGUMENT(not term_ids_.empty(), "DMQ term model is empty");
+    return EliasFanoStream::GetLayout(count, static_cast<uint32_t>(term_ids_.size())).SizeInBytes();
+}
+
+bool
+SparseDmqQuantizer::UseEliasFano(uint32_t count) const {
+    return get_id_encoding_layout(
+               count, static_cast<uint32_t>(term_ids_.size()), id_bits_, id_encoding_type_)
+        .use_elias_fano;
+}
+
+uint64_t
+SparseDmqQuantizer::GetEncodedIdSize(uint32_t count) const {
+    return get_id_encoding_layout(
+               count, static_cast<uint32_t>(term_ids_.size()), id_bits_, id_encoding_type_)
+        .encoded_bytes;
+}
+
+uint64_t
 SparseDmqQuantizer::GetEncodedSize(const SparseVector& vector) const {
-    return sizeof(EncodedHeader) + get_packed_size(vector.len_, id_bits_) + vector.len_;
+    return sizeof(EncodedHeader) + GetEncodedIdSize(vector.len_) + vector.len_;
 }
 
 uint32_t
@@ -382,16 +436,29 @@ SparseDmqQuantizer::EncodeOneImpl(const float* data, uint8_t* codes) const {
     header.len = vector.len_;
     double sum = std::accumulate(values.begin(), values.end(), 0.0);
     header.factors.mean = vector.len_ == 0 ? 0.0F : static_cast<float>(sum / vector.len_);
-    auto* packed_ids = codes + sizeof(header);
-    const uint64_t id_bytes = get_packed_size(vector.len_, id_bits_);
-    std::fill_n(packed_ids, id_bytes, 0);
-    auto* value_codes = packed_ids + id_bytes;
+    auto* encoded_ids = codes + sizeof(header);
+    const auto id_layout = get_id_encoding_layout(
+        vector.len_, static_cast<uint32_t>(term_ids_.size()), id_bits_, id_encoding_type_);
+    auto* value_codes = encoded_ids + id_layout.encoded_bytes;
+    for (uint32_t index = 0; index < vector.len_; ++index) {
+        ids[index] = GetCompactId(ids[index]);
+    }
+    if (id_layout.use_elias_fano) {
+        EliasFanoStream::Encode(ids.data(),
+                                vector.len_,
+                                static_cast<uint32_t>(term_ids_.size()),
+                                id_layout.elias_fano,
+                                encoded_ids);
+    } else {
+        std::fill_n(encoded_ids, id_layout.encoded_bytes, 0);
+        for (uint32_t index = 0; index < vector.len_; ++index) {
+            store_packed(encoded_ids, index, id_bits_, ids[index]);
+        }
+    }
     double numerator = 0.0;
     double denominator = 0.0;
     for (uint32_t index = 0; index < vector.len_; ++index) {
-        const uint32_t compact_id = GetCompactId(ids[index]);
-        const uint32_t codebook_index = GetCodebookIndex(compact_id);
-        store_packed(packed_ids, index, id_bits_, compact_id);
+        const uint32_t codebook_index = GetCodebookIndex(ids[index]);
         const auto& codebook = codebooks_[codebook_index];
         const float residual = values[index] - header.factors.mean;
         value_codes[index] = EncodeResidual(residual, codebook);
@@ -414,17 +481,27 @@ SparseDmqQuantizer::DecodeOneImpl(const uint8_t* codes, float* data) const {
     vector->ids_ =
         static_cast<uint32_t*>(this->allocator_->Allocate(sizeof(uint32_t) * header.len));
     vector->vals_ = static_cast<float*>(this->allocator_->Allocate(sizeof(float) * header.len));
-    const auto* packed_ids = codes + sizeof(header);
-    const auto* value_codes = packed_ids + get_packed_size(header.len, id_bits_);
-    PackedReader id_reader(packed_ids, id_bits_);
-    for (uint32_t index = 0; index < header.len; ++index) {
-        const uint32_t compact_id = id_reader.Read();
-        CHECK_ARGUMENT(compact_id < term_ids_.size(),
-                       fmt::format("invalid DMQ compact ID {}", compact_id));
-        const uint32_t codebook_index = GetCodebookIndex(compact_id);
-        vector->ids_[index] = term_ids_[compact_id];
-        vector->vals_[index] =
-            DecodeValue(header.factors, codebooks_[codebook_index], value_codes[index]);
+    const auto* encoded_ids = codes + sizeof(header);
+    const auto id_layout = get_id_encoding_layout(
+        header.len, static_cast<uint32_t>(term_ids_.size()), id_bits_, id_encoding_type_);
+    const auto* value_codes = encoded_ids + id_layout.encoded_bytes;
+    auto decode = [&](auto& id_reader) {
+        for (uint32_t index = 0; index < header.len; ++index) {
+            const uint32_t compact_id = id_reader.Read();
+            CHECK_ARGUMENT(compact_id < term_ids_.size(),
+                           fmt::format("invalid DMQ compact ID {}", compact_id));
+            const uint32_t codebook_index = GetCodebookIndex(compact_id);
+            vector->ids_[index] = term_ids_[compact_id];
+            vector->vals_[index] =
+                DecodeValue(header.factors, codebooks_[codebook_index], value_codes[index]);
+        }
+    };
+    if (id_layout.use_elias_fano) {
+        EliasFanoStreamReader id_reader(encoded_ids, header.len, id_layout.elias_fano);
+        decode(id_reader);
+    } else {
+        PackedReader id_reader(encoded_ids, id_bits_);
+        decode(id_reader);
     }
     return true;
 }
@@ -449,45 +526,66 @@ SparseDmqQuantizer::ComputeImpl(const uint8_t* codes1, const uint8_t* codes2) co
     std::memcpy(&right, codes2, sizeof(right));
     const auto* left_ids = codes1 + sizeof(left);
     const auto* right_ids = codes2 + sizeof(right);
-    const auto* left_codes = left_ids + get_packed_size(left.len, id_bits_);
-    const auto* right_codes = right_ids + get_packed_size(right.len, id_bits_);
+    const uint32_t universe = static_cast<uint32_t>(term_ids_.size());
+    const auto left_layout =
+        get_id_encoding_layout(left.len, universe, id_bits_, id_encoding_type_);
+    const auto right_layout =
+        get_id_encoding_layout(right.len, universe, id_bits_, id_encoding_type_);
+    const auto* left_codes = left_ids + left_layout.encoded_bytes;
+    const auto* right_codes = right_ids + right_layout.encoded_bytes;
     if (left.len == 0 || right.len == 0) {
         return 1.0F;
     }
-    PackedReader left_reader(left_ids, id_bits_);
-    PackedReader right_reader(right_ids, id_bits_);
-    uint32_t left_index = 0;
-    uint32_t right_index = 0;
-    uint32_t left_id = left_reader.Read();
-    uint32_t right_id = right_reader.Read();
-    float product = 0.0F;
-    while (left_index < left.len && right_index < right.len) {
-        if (left_id < right_id) {
-            ++left_index;
-            if (left_index < left.len) {
-                left_id = left_reader.Read();
-            }
-        } else if (left_id > right_id) {
-            ++right_index;
-            if (right_index < right.len) {
-                right_id = right_reader.Read();
-            }
-        } else {
-            const uint32_t codebook_index = GetCodebookIndex(left_id);
-            const auto& codebook = codebooks_[codebook_index];
-            product += DecodeValue(left.factors, codebook, left_codes[left_index]) *
-                       DecodeValue(right.factors, codebook, right_codes[right_index]);
-            ++left_index;
-            ++right_index;
-            if (left_index < left.len) {
-                left_id = left_reader.Read();
-            }
-            if (right_index < right.len) {
-                right_id = right_reader.Read();
+    auto compute = [&](auto& left_reader, auto& right_reader) {
+        uint32_t left_index = 0;
+        uint32_t right_index = 0;
+        uint32_t left_id = left_reader.Read();
+        uint32_t right_id = right_reader.Read();
+        float product = 0.0F;
+        while (left_index < left.len && right_index < right.len) {
+            if (left_id < right_id) {
+                ++left_index;
+                if (left_index < left.len) {
+                    left_id = left_reader.Read();
+                }
+            } else if (left_id > right_id) {
+                ++right_index;
+                if (right_index < right.len) {
+                    right_id = right_reader.Read();
+                }
+            } else {
+                const uint32_t codebook_index = GetCodebookIndex(left_id);
+                const auto& codebook = codebooks_[codebook_index];
+                product += DecodeValue(left.factors, codebook, left_codes[left_index]) *
+                           DecodeValue(right.factors, codebook, right_codes[right_index]);
+                ++left_index;
+                ++right_index;
+                if (left_index < left.len) {
+                    left_id = left_reader.Read();
+                }
+                if (right_index < right.len) {
+                    right_id = right_reader.Read();
+                }
             }
         }
+        return 1.0F - product;
+    };
+    if (left_layout.use_elias_fano) {
+        EliasFanoStreamReader left_reader(left_ids, left.len, left_layout.elias_fano);
+        if (right_layout.use_elias_fano) {
+            EliasFanoStreamReader right_reader(right_ids, right.len, right_layout.elias_fano);
+            return compute(left_reader, right_reader);
+        }
+        PackedReader right_reader(right_ids, id_bits_);
+        return compute(left_reader, right_reader);
     }
-    return 1.0F - product;
+    PackedReader left_reader(left_ids, id_bits_);
+    if (right_layout.use_elias_fano) {
+        EliasFanoStreamReader right_reader(right_ids, right.len, right_layout.elias_fano);
+        return compute(left_reader, right_reader);
+    }
+    PackedReader right_reader(right_ids, id_bits_);
+    return compute(left_reader, right_reader);
 }
 
 void
@@ -537,34 +635,58 @@ SparseDmqQuantizer::ComputeDistImpl(Computer<SparseDmqQuantizer>& computer,
     const auto& query = *reinterpret_cast<const QueryData*>(computer.buf_);
     EncodedHeader header;
     std::memcpy(&header, codes, sizeof(header));
-    const auto* packed_ids = codes + sizeof(header);
-    const auto* value_codes = packed_ids + get_packed_size(header.len, id_bits_);
-    float query_sum = 0.0F;
-    float qualifier_product = 0.0F;
-    uint32_t query_index = 0;
-    PackedReader id_reader(packed_ids, id_bits_);
-    for (uint32_t base_index = 0; base_index < header.len; ++base_index) {
-        const uint32_t id = id_reader.Read();
-        uint32_t matched = K_INVALID_INDEX;
-        if (query.has_lookup) {
-            if (id < query.term_to_index.size()) {
-                matched = query.term_to_index[id];
-            }
-        } else {
-            while (query_index < query.ids.size() && query.ids[query_index] < id) {
-                ++query_index;
-            }
-            if (query_index < query.ids.size() && query.ids[query_index] == id) {
-                matched = query_index;
+    const auto* encoded_ids = codes + sizeof(header);
+    const auto id_layout = get_id_encoding_layout(
+        header.len, static_cast<uint32_t>(term_ids_.size()), id_bits_, id_encoding_type_);
+    const auto* value_codes = encoded_ids + id_layout.encoded_bytes;
+    if (id_layout.use_elias_fano) {
+        float query_sum = 0.0F;
+        float qualifier_product = 0.0F;
+        EliasFanoSeekReader id_reader(encoded_ids, header.len, id_layout.elias_fano);
+        for (uint32_t query_index = 0; query_index < query.ids.size(); ++query_index) {
+            const auto range = id_reader.FindEqualRange(query.ids[query_index]);
+            for (uint32_t position = range.begin; position < range.end; ++position) {
+                query_sum += query.values[query_index];
+                qualifier_product +=
+                    query.code_lut[static_cast<uint64_t>(query_index) * CODEBOOK_SIZE +
+                                   value_codes[position]];
             }
         }
-        if (matched != K_INVALID_INDEX) {
-            query_sum += query.values[matched];
-            qualifier_product += query.code_lut[static_cast<uint64_t>(matched) * CODEBOOK_SIZE +
-                                                value_codes[base_index]];
-        }
+        dists[0] =
+            1.0F - (header.factors.mean * query_sum + header.factors.alpha * qualifier_product);
+        return;
     }
-    dists[0] = 1.0F - (header.factors.mean * query_sum + header.factors.alpha * qualifier_product);
+
+    auto compute = [&](auto& id_reader) {
+        float query_sum = 0.0F;
+        float qualifier_product = 0.0F;
+        uint32_t query_index = 0;
+        for (uint32_t base_index = 0; base_index < header.len; ++base_index) {
+            const uint32_t id = id_reader.Read();
+            uint32_t matched = K_INVALID_INDEX;
+            if (query.has_lookup) {
+                if (id < query.term_to_index.size()) {
+                    matched = query.term_to_index[id];
+                }
+            } else {
+                while (query_index < query.ids.size() && query.ids[query_index] < id) {
+                    ++query_index;
+                }
+                if (query_index < query.ids.size() && query.ids[query_index] == id) {
+                    matched = query_index;
+                }
+            }
+            if (matched != K_INVALID_INDEX) {
+                query_sum += query.values[matched];
+                qualifier_product += query.code_lut[static_cast<uint64_t>(matched) * CODEBOOK_SIZE +
+                                                    value_codes[base_index]];
+            }
+        }
+        dists[0] =
+            1.0F - (header.factors.mean * query_sum + header.factors.alpha * qualifier_product);
+    };
+    PackedReader id_reader(encoded_ids, id_bits_);
+    compute(id_reader);
 }
 
 void
@@ -634,6 +756,7 @@ void
 SparseDmqQuantizer::ExportModel(const SparseDmqQuantizer& other) {
     id_bits_ = other.id_bits_;
     shared_codebook_threshold_ = other.shared_codebook_threshold_;
+    id_encoding_type_ = other.id_encoding_type_;
     term_ids_ = other.term_ids_;
     codebooks_ = other.codebooks_;
     codebook_index_by_compact_id_ = other.codebook_index_by_compact_id_;

--- a/src/quantization/sparse_quantization/sparse_dmq_quantizer.h
+++ b/src/quantization/sparse_quantization/sparse_dmq_quantizer.h
@@ -24,6 +24,11 @@ namespace vsag {
 
 class SparseDmqQuantizer : public Quantizer<SparseDmqQuantizer> {
 public:
+    enum class IdEncodingType : uint8_t {
+        PACKED,
+        HYBRID_ELIAS_FANO,
+    };
+
     static constexpr uint32_t BITS = 8;
     static constexpr uint32_t CODEBOOK_SIZE = 1U << BITS;
     static constexpr uint32_t THRESHOLD_COUNT = CODEBOOK_SIZE - 1;
@@ -90,6 +95,9 @@ public:
     [[nodiscard]] uint64_t
     GetEncodedSize(const SparseVector& vector) const;
 
+    [[nodiscard]] uint64_t
+    GetEncodedIdSize(uint32_t count) const;
+
     [[nodiscard]] static uint32_t
     GetEncodedLength(const uint8_t* codes);
 
@@ -109,6 +117,25 @@ public:
     [[nodiscard]] uint32_t
     GetSharedCodebookThreshold() const {
         return shared_codebook_threshold_;
+    }
+
+    [[nodiscard]] uint64_t
+    GetPackedIdSize(uint32_t count) const;
+
+    [[nodiscard]] uint64_t
+    GetEliasFanoIdSize(uint32_t count) const;
+
+    [[nodiscard]] bool
+    UseEliasFano(uint32_t count) const;
+
+    void
+    SetIdEncodingType(IdEncodingType type) {
+        id_encoding_type_ = type;
+    }
+
+    [[nodiscard]] IdEncodingType
+    GetIdEncodingType() const {
+        return id_encoding_type_;
     }
 
     void
@@ -146,6 +173,7 @@ private:
     Vector<uint32_t> compact_id_lookup_;
     uint32_t id_bits_{32};
     uint32_t shared_codebook_threshold_{DEFAULT_SHARED_CODEBOOK_THRESHOLD};
+    IdEncodingType id_encoding_type_{IdEncodingType::PACKED};
 };
 
 }  // namespace vsag

--- a/src/quantization/sparse_quantization/sparse_dmq_quantizer_test.cpp
+++ b/src/quantization/sparse_quantization/sparse_dmq_quantizer_test.cpp
@@ -134,9 +134,17 @@ TEST_CASE("SparseDmqQuantizer packs compact term ids by distinct term count",
 
         REQUIRE(quantizer.TrainImpl(reinterpret_cast<const float*>(&vector), 1));
         REQUIRE(quantizer.GetIdBits() == expected_bits);
-        REQUIRE(quantizer.GetEncodedSize(vector) ==
-                sizeof(SparseDmqQuantizer::EncodedHeader) +
-                    (static_cast<uint64_t>(term_count) * expected_bits + 7) / 8 + term_count);
+        const uint64_t packed_id_size = (static_cast<uint64_t>(term_count) * expected_bits + 7) / 8;
+        REQUIRE(quantizer.GetEncodedIdSize(term_count) <= packed_id_size);
+        REQUIRE(quantizer.GetEncodedSize(vector) == sizeof(SparseDmqQuantizer::EncodedHeader) +
+                                                        quantizer.GetEncodedIdSize(term_count) +
+                                                        term_count);
+
+        const uint64_t hybrid_size = quantizer.GetEncodedSize(vector);
+        quantizer.SetIdEncodingType(SparseDmqQuantizer::IdEncodingType::PACKED);
+        REQUIRE(quantizer.GetEncodedIdSize(term_count) == packed_id_size);
+        REQUIRE(quantizer.GetEncodedSize(vector) >= hybrid_size);
+        quantizer.SetIdEncodingType(SparseDmqQuantizer::IdEncodingType::HYBRID_ELIAS_FANO);
 
         std::vector<uint8_t> codes(quantizer.GetEncodedSize(vector));
         REQUIRE(quantizer.EncodeOne(reinterpret_cast<const float*>(&vector), codes.data()));
@@ -148,6 +156,52 @@ TEST_CASE("SparseDmqQuantizer packs compact term ids by distinct term count",
         allocator->Deallocate(decoded.ids_);
         allocator->Deallocate(decoded.vals_);
     }
+}
+
+TEST_CASE("SparseDmqQuantizer seeks Elias-Fano ids during query scoring",
+          "[ut][SparseDmqQuantizer]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    std::vector<uint32_t> training_ids(128);
+    std::vector<float> training_values(128);
+    for (uint32_t index = 0; index < training_ids.size(); ++index) {
+        training_ids[index] = index;
+        training_values[index] = static_cast<float>(index + 1) / training_ids.size();
+    }
+    SparseVector training{
+        static_cast<uint32_t>(training_ids.size()), training_ids.data(), training_values.data()};
+    SparseDmqQuantizer quantizer(127, allocator.get());
+    REQUIRE(quantizer.TrainImpl(reinterpret_cast<const float*>(&training), 1));
+
+    std::vector<uint32_t> base_ids{1, 17, 33, 64, 95, 127};
+    std::vector<float> base_values{0.1F, 0.2F, 0.3F, 0.4F, 0.5F, 0.6F};
+    SparseVector base{static_cast<uint32_t>(base_ids.size()), base_ids.data(), base_values.data()};
+    REQUIRE(quantizer.UseEliasFano(base.len_));
+    std::vector<uint8_t> codes(quantizer.GetEncodedSize(base));
+    REQUIRE(quantizer.EncodeOne(reinterpret_cast<const float*>(&base), codes.data()));
+
+    std::vector<uint32_t> query_ids{0, 1, 2, 17, 63, 64, 100, 127};
+    std::vector<float> query_values{0.2F, 0.3F, 0.4F, 0.5F, 0.6F, 0.7F, 0.8F, 0.9F};
+    SparseVector query{
+        static_cast<uint32_t>(query_ids.size()), query_ids.data(), query_values.data()};
+    auto computer = quantizer.FactoryComputer();
+    computer->SetQuery(reinterpret_cast<const float*>(&query));
+    float distance = 0.0F;
+    computer->ComputeDist(codes.data(), &distance);
+
+    SparseVector decoded;
+    REQUIRE(quantizer.DecodeOne(codes.data(), reinterpret_cast<float*>(&decoded)));
+    float expected_distance = 1.0F;
+    for (uint32_t index = 0; index < decoded.len_; ++index) {
+        const auto iterator =
+            std::lower_bound(query_ids.begin(), query_ids.end(), decoded.ids_[index]);
+        if (iterator != query_ids.end() && *iterator == decoded.ids_[index]) {
+            const uint32_t query_index = static_cast<uint32_t>(iterator - query_ids.begin());
+            expected_distance -= decoded.vals_[index] * query_values[query_index];
+        }
+    }
+    REQUIRE(std::abs(distance - expected_distance) <= 1e-6F);
+    allocator->Deallocate(decoded.ids_);
+    allocator->Deallocate(decoded.vals_);
 }
 
 TEST_CASE("SparseDmqQuantizer shares low frequency codebooks", "[ut][SparseDmqQuantizer]") {


### PR DESCRIPTION
> **Draft backup only. Do not merge.**
>
> This PR is used as cloud storage for the SINDI DMQ Elias–Fano experiment.
> CI is intentionally skipped and the PR should remain in Draft state.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement/Refactor
- [x] Documentation
- [ ] CI/Build/Infra

## Linked Issue

Not applicable for this draft improvement PR.

## What Changed

- Add per-vector Hybrid Packed/Elias–Fano coding for ordered DMQ compact term IDs.
- Add scalar, batch, and query-driven seek readers for the EF stream.
- Use EF ordinal ranges to access position-aligned DMQ value codes during reranking.
- Reuse the computed ID layout within each candidate.
- Add unit/regression tests and synchronized English/Chinese documentation.
- Add an experiment report with index-size and Release performance results.

## Test Evidence

- [x] Other (described below)

Test details:

```text
clang-format-15 --dry-run --Werror <changed C++ files>
git diff --check
build/tests/unittests '[ut][EliasFanoStream],[ut][SparseDmqQuantizer]'

All tests passed:
13 test cases
2220 assertions

Release benchmark:
wholenet-sparse-1m-ip, 8 search threads, topk=10, n_candidate=1000
EF scalar scan: 2.905 ms / 2750 QPS
EF query-driven seek: 2.738 ms / 2914 QPS
Recall@10: 0.9863
```

CI is intentionally skipped because this Draft PR is for cloud backup only.

## Compatibility Impact

- API/ABI compatibility: no public API changes.
- Behavior changes: new DMQ builds may choose EF for ordered compact term IDs.
- Legacy risk: packed-only DMQ indexes do not carry an encoding tag/version and
  need an explicit compatibility strategy before this work is considered mergeable.

## Performance and Concurrency Impact

- Performance impact: DMQ rerank backend size reduced by 12.58%; complete index
  size reduced by 4.41%; EF seek improved latency by 5.74% and QPS by 5.96%
  relative to scalar EF scanning on the measured workload.
- Concurrency/thread-safety impact: none; readers are query-local.

## Documentation Impact

- [x] Updated docs:
  - [x] Other: SINDI, DMQ, and Elias–Fano English/Chinese documentation and
    `sindi_dmq_elias_fano_report.md`.

## Risk and Rollback

- Risk level: high for merge until legacy packed-index compatibility is resolved.
- Rollback plan: revert commit `4fbd49969`.

## Checklist

- [x] I have added/updated tests for new behavior.
- [x] I have considered API and index compatibility impact.
- [x] I have updated documentation.
- [x] The commit message follows project conventions and starts with `[skip ci]`.
