### PR TITLE
perf(hgraph): add reusable max_degree graph reduction

### DIFF
--- a/src/algorithm/hgraph/CMakeLists.txt
+++ b/src/algorithm/hgraph/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(HGRAPH_SRCS
     hgraph.cpp
     hgraph_build.cpp
+    hgraph_degree_reduction.cpp
     hgraph_fast_build.cpp
     hgraph_modify.cpp
     hgraph_parameter.cpp

--- a/src/algorithm/hgraph/hgraph.h
+++ b/src/algorithm/hgraph/hgraph.h
@@ -227,6 +227,17 @@ public:
     void
     SetImmutable() override;
 
+    // Internal AutoTune path. These methods rewrite graph storage between trials; normal build,
+    // search, Tune, and serialization entry points never call them.
+    [[nodiscard]] bool
+    CanReduceMaxDegree() const;
+
+    void
+    PrepareDegreeReduction();
+
+    void
+    ReduceMaxDegree(uint32_t max_degree);
+
     void
     ExportCache(std::ostream& out_stream) const override;
 
@@ -652,6 +663,12 @@ private:
     void
     cal_memory_usage();
 
+    [[nodiscard]] bool
+    can_reduce_max_degree_unlocked() const;
+
+    [[nodiscard]] FlattenInterfacePtr
+    get_degree_reduction_codes() const;
+
     /// True when reorder uses a separate high-precision flatten (not base codes).
     [[nodiscard]] bool
     has_precise_reorder() const {
@@ -845,5 +862,7 @@ private:
     float build_cache_hit_rate_{-1.0F};     // cache hit rate from last cache-based build
     uint64_t build_cache_hit_nodes_{0};     // number of nodes with cache hit
     uint64_t build_cache_missed_nodes_{0};  // number of nodes without cache hit
+
+    bool degree_reduction_prepared_{false};
 };
 }  // namespace vsag

--- a/src/algorithm/hgraph/hgraph_degree_reduction.cpp
+++ b/src/algorithm/hgraph/hgraph_degree_reduction.cpp
@@ -1,0 +1,280 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <algorithm>
+#include <exception>
+#include <future>
+#include <memory>
+#include <vector>
+
+#include "datacell/graph_datacell_parameter.h"
+#include "datacell/graph_interface.h"
+#include "datacell/sparse_graph_datacell_parameter.h"
+#include "hgraph.h"
+#include "impl/pruning_strategy.h"
+#include "impl/thread_pool/safe_thread_pool.h"
+
+namespace vsag {
+
+namespace {
+
+template <typename Function>
+void
+parallel_for(uint64_t count,
+             uint64_t parallelism,
+             const SafeThreadPoolPtr& thread_pool,
+             const Function& function) {
+    const auto worker_count = std::min(count, std::max<uint64_t>(1, parallelism));
+    if (worker_count <= 1 || thread_pool == nullptr) {
+        for (uint64_t i = 0; i < count; ++i) {
+            function(i);
+        }
+        return;
+    }
+
+    const auto batch_size = (count + worker_count - 1) / worker_count;
+    std::vector<std::future<void>> futures;
+    futures.reserve(worker_count);
+    std::exception_ptr first_exception;
+    for (uint64_t worker = 0; worker < worker_count; ++worker) {
+        const auto begin = worker * batch_size;
+        const auto end = std::min(count, begin + batch_size);
+        if (begin == end) {
+            break;
+        }
+        try {
+            futures.emplace_back(thread_pool->GeneralEnqueue([begin, end, &function]() {
+                for (uint64_t i = begin; i < end; ++i) {
+                    function(i);
+                }
+            }));
+        } catch (...) {
+            first_exception = std::current_exception();
+            break;
+        }
+    }
+    for (auto& future : futures) {
+        try {
+            future.get();
+        } catch (...) {
+            if (first_exception == nullptr) {
+                first_exception = std::current_exception();
+            }
+        }
+    }
+    if (first_exception != nullptr) {
+        std::rethrow_exception(first_exception);
+    }
+}
+
+GraphInterfacePtr
+materialize_graph(const GraphInterfacePtr& source,
+                  const GraphInterfaceParamPtr& target_param,
+                  const FlattenInterfacePtr& flatten,
+                  Allocator* allocator,
+                  bool dense_ids,
+                  const SafeThreadPoolPtr& thread_pool,
+                  uint64_t parallelism) {
+    auto common_param = flatten->ExportCommonParam();
+    auto target = GraphInterface::MakeInstance(target_param, common_param);
+    CHECK_ARGUMENT(target != nullptr, "failed to create compact graph storage");
+    if (dense_ids) {
+        target->Resize(source->MaxCapacity());
+    }
+
+    const auto copy_neighbors = [&](InnerIdType id) {
+        Vector<InnerIdType> neighbors(allocator);
+        source->GetNeighbors(id, neighbors);
+        const auto target_degree = static_cast<uint64_t>(target_param->max_degree_);
+        if (neighbors.size() > target_degree) {
+            neighbors.resize(target_degree);
+        }
+        target->InsertNeighborsById(id, neighbors);
+    };
+
+    if (dense_ids) {
+        parallel_for(source->TotalCount(), parallelism, thread_pool, [&](uint64_t id) {
+            copy_neighbors(static_cast<InnerIdType>(id));
+        });
+    } else {
+        const auto ids = source->GetIds();
+        parallel_for(
+            ids.size(), parallelism, thread_pool, [&](uint64_t i) { copy_neighbors(ids[i]); });
+    }
+    target->SetDuplicateTracker(source->GetDuplicateTracker());
+    return target;
+}
+
+void
+rank_graph(const GraphInterfacePtr& graph,
+           const FlattenInterfacePtr& flatten,
+           Allocator* allocator,
+           float alpha,
+           bool dense_ids,
+           const SafeThreadPoolPtr& thread_pool,
+           uint64_t parallelism) {
+    const auto rank_neighbors = [&](InnerIdType id) {
+        Vector<InnerIdType> neighbors(allocator);
+        graph->GetNeighbors(id, neighbors);
+        if (!neighbors.empty()) {
+            const auto original = neighbors;
+            select_edges_by_heuristic(neighbors, id, neighbors.size(), flatten, allocator, alpha);
+            std::reverse(neighbors.begin(), neighbors.end());
+
+            std::vector<std::pair<float, InnerIdType>> remaining;
+            remaining.reserve(original.size() - neighbors.size());
+            for (const auto neighbor : original) {
+                if (std::find(neighbors.begin(), neighbors.end(), neighbor) == neighbors.end()) {
+                    remaining.emplace_back(flatten->ComputePairVectors(id, neighbor), neighbor);
+                }
+            }
+            std::sort(remaining.begin(), remaining.end());
+            neighbors.reserve(original.size());
+            for (const auto& candidate : remaining) {
+                neighbors.emplace_back(candidate.second);
+            }
+            graph->InsertNeighborsById(id, neighbors);
+        }
+    };
+
+    if (dense_ids) {
+        parallel_for(graph->TotalCount(), parallelism, thread_pool, [&](uint64_t id) {
+            rank_neighbors(static_cast<InnerIdType>(id));
+        });
+    } else {
+        const auto ids = graph->GetIds();
+        parallel_for(
+            ids.size(), parallelism, thread_pool, [&](uint64_t i) { rank_neighbors(ids[i]); });
+    }
+}
+
+}  // namespace
+
+bool
+HGraph::can_reduce_max_degree_unlocked() const {
+    if (this->immutable_.load(std::memory_order_acquire) ||
+        this->graph_type_ != GRAPH_TYPE_VALUE_NSW || this->bottom_graph_ == nullptr ||
+        !this->bottom_graph_->InMemory() || this->support_force_remove_) {
+        return false;
+    }
+    const auto hgraph_param = std::dynamic_pointer_cast<HGraphParameter>(this->create_param_ptr_);
+    if (hgraph_param == nullptr) {
+        return false;
+    }
+    const auto bottom_param =
+        std::dynamic_pointer_cast<GraphDataCellParameter>(hgraph_param->bottom_graph_param);
+    if (bottom_param == nullptr || bottom_param->support_remove_ ||
+        bottom_param->use_reverse_edges_) {
+        return false;
+    }
+    return this->hierarchical_datacell_param_ != nullptr &&
+           !this->hierarchical_datacell_param_->support_delete_ &&
+           !this->hierarchical_datacell_param_->use_reverse_edges_ &&
+           this->get_degree_reduction_codes() != nullptr;
+}
+
+FlattenInterfacePtr
+HGraph::get_degree_reduction_codes() const {
+    if (this->has_precise_reorder() && !this->build_by_base_) {
+        return this->high_precise_codes_;
+    }
+    if (this->basic_flatten_codes_->GetQuantizerName() == QUANTIZATION_TYPE_VALUE_RABITQ) {
+        return this->raw_vector_;
+    }
+    return this->basic_flatten_codes_;
+}
+
+bool
+HGraph::CanReduceMaxDegree() const {
+    std::scoped_lock lock(this->add_mutex_, this->global_mutex_);
+    return this->can_reduce_max_degree_unlocked();
+}
+
+void
+HGraph::PrepareDegreeReduction() {
+    std::scoped_lock lock(this->add_mutex_, this->global_mutex_);
+    CHECK_ARGUMENT(this->can_reduce_max_degree_unlocked(),
+                   "HGraph max-degree reduction does not support this index");
+    if (this->degree_reduction_prepared_) {
+        return;
+    }
+
+    const auto flatten = this->get_degree_reduction_codes();
+    rank_graph(this->bottom_graph_,
+               flatten,
+               this->allocator_,
+               this->alpha_,
+               true,
+               this->thread_pool_,
+               this->build_thread_count_);
+    for (const auto& route : this->route_graphs_) {
+        rank_graph(route,
+                   flatten,
+                   this->allocator_,
+                   this->alpha_,
+                   false,
+                   this->thread_pool_,
+                   this->build_thread_count_);
+    }
+
+    this->degree_reduction_prepared_ = true;
+}
+
+void
+HGraph::ReduceMaxDegree(uint32_t max_degree) {
+    std::scoped_lock lock(this->add_mutex_, this->global_mutex_);
+    CHECK_ARGUMENT(this->can_reduce_max_degree_unlocked(),
+                   "HGraph max-degree reduction does not support this index");
+    CHECK_ARGUMENT(this->degree_reduction_prepared_,
+                   "PrepareDegreeReduction must be called before ReduceMaxDegree");
+    CHECK_ARGUMENT(max_degree >= 4, "target max_degree must be at least 4");
+    CHECK_ARGUMENT(max_degree < this->bottom_graph_->MaximumDegree(),
+                   "target max_degree must be smaller than the current max_degree");
+
+    const auto hgraph_param = std::dynamic_pointer_cast<HGraphParameter>(this->create_param_ptr_);
+    auto bottom_param = std::make_shared<GraphDataCellParameter>(
+        *std::dynamic_pointer_cast<GraphDataCellParameter>(hgraph_param->bottom_graph_param));
+    bottom_param->max_degree_ = max_degree;
+    auto bottom = materialize_graph(this->bottom_graph_,
+                                    bottom_param,
+                                    this->basic_flatten_codes_,
+                                    this->allocator_,
+                                    true,
+                                    this->thread_pool_,
+                                    this->build_thread_count_);
+
+    auto route_param =
+        std::make_shared<SparseGraphDatacellParameter>(*this->hierarchical_datacell_param_);
+    route_param->max_degree_ = std::max<uint32_t>(1, max_degree / 2);
+    Vector<GraphInterfacePtr> routes(this->allocator_);
+    routes.reserve(this->route_graphs_.size());
+    for (const auto& route : this->route_graphs_) {
+        routes.emplace_back(materialize_graph(route,
+                                              route_param,
+                                              this->basic_flatten_codes_,
+                                              this->allocator_,
+                                              false,
+                                              this->thread_pool_,
+                                              this->build_thread_count_));
+    }
+
+    this->bottom_graph_ = std::move(bottom);
+    this->route_graphs_ = std::move(routes);
+    hgraph_param->bottom_graph_param = bottom_param;
+    hgraph_param->hierarchical_graph_param = route_param;
+    this->hierarchical_datacell_param_ = route_param;
+    this->cal_memory_usage();
+}
+
+}  // namespace vsag

--- a/src/algorithm/hgraph/hgraph_degree_reduction_test.cpp
+++ b/src/algorithm/hgraph/hgraph_degree_reduction_test.cpp
@@ -1,0 +1,96 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <fmt/format.h>
+
+#include <algorithm>
+#include <numeric>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "hgraph.h"
+#include "index/index_impl.h"
+#include "unittest.h"
+#include "vsag/factory.h"
+
+namespace {
+
+std::string
+create_parameters(uint32_t max_degree) {
+    return fmt::format(R"({{"dim":8,"dtype":"float32","metric_type":"l2","index_param":{{)"
+                       R"("base_quantization_type":"fp32","max_degree":{},"ef_construction":40,)"
+                       R"("build_thread_count":1}}}})",
+                       max_degree);
+}
+
+}  // namespace
+
+TEST_CASE("HGraph materializes nested compact max-degree graphs", "[ut][hgraph_degree_reduction]") {
+    constexpr int64_t count = 256;
+    constexpr int64_t dim = 8;
+    std::vector<int64_t> ids(count);
+    std::iota(ids.begin(), ids.end(), 1000);
+    std::vector<float> vectors(count * dim);
+    for (int64_t i = 0; i < count; ++i) {
+        for (int64_t j = 0; j < dim; ++j) {
+            vectors[i * dim + j] = static_cast<float>((i * 17 + j * 29) % 257) / 257.0F;
+        }
+    }
+    auto base = vsag::Dataset::Make()
+                    ->NumElements(count)
+                    ->Dim(dim)
+                    ->Ids(ids.data())
+                    ->Float32Vectors(vectors.data())
+                    ->Owner(false);
+    auto query = vsag::Dataset::Make()
+                     ->NumElements(1)
+                     ->Dim(dim)
+                     ->Float32Vectors(vectors.data())
+                     ->Owner(false);
+
+    auto created = vsag::Factory::CreateIndex("hgraph", create_parameters(16));
+    REQUIRE(created.has_value());
+    auto index = std::dynamic_pointer_cast<vsag::IndexImpl<vsag::HGraph>>(created.value());
+    REQUIRE(index != nullptr);
+    REQUIRE(index->Build(base).has_value());
+    REQUIRE(index->KnnSearch(query, 10, R"({"hgraph":{"ef_search":40}})").has_value());
+
+    auto hgraph = std::dynamic_pointer_cast<vsag::HGraph>(index->GetInnerIndex());
+    REQUIRE(hgraph != nullptr);
+    REQUIRE(hgraph->CanReduceMaxDegree());
+    hgraph->PrepareDegreeReduction();
+
+    for (const auto degree : {8U, 4U}) {
+        hgraph->ReduceMaxDegree(degree);
+        const auto parameter =
+            std::dynamic_pointer_cast<vsag::HGraphParameter>(hgraph->create_param_ptr_);
+        REQUIRE(parameter != nullptr);
+        REQUIRE(parameter->bottom_graph_param->max_degree_ == degree);
+        REQUIRE(parameter->hierarchical_graph_param->max_degree_ ==
+                std::max<uint32_t>(1, degree / 2));
+
+        std::stringstream artifact;
+        REQUIRE(index->Serialize(artifact).has_value());
+        artifact.seekg(0, std::ios::beg);
+        auto restored = vsag::Factory::CreateIndex("hgraph", create_parameters(degree));
+        REQUIRE(restored.has_value());
+        REQUIRE(restored.value()->Deserialize(artifact).has_value());
+        REQUIRE(
+            restored.value()->KnnSearch(query, 10, R"({"hgraph":{"ef_search":40}})").has_value());
+    }
+
+    REQUIRE_THROWS(hgraph->ReduceMaxDegree(3));
+    REQUIRE_THROWS(hgraph->ReduceMaxDegree(4));
+}


### PR DESCRIPTION
## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement/Refactor
- [ ] Documentation
- [ ] CI/Build/Infra

## Linked Issue

- Closes: #2578

## What Changed

- Add an internal HGraph capability to derive a lower-`max_degree` graph from an already built
  higher-degree graph.
- Rank existing adjacency lists once with the existing diversity heuristic, then materialize the
  selected prefixes into ordinary compact graph storage.
- Support successive reductions, serialization, deserialization, and search through the normal
  HGraph paths.
- Restrict the capability to compatible mutable in-memory NSW configurations and reject invalid
  or unsupported reductions.
- Add focused tests for degree reduction, repeated reduction, invalid input, serialization,
  deserialization, and search.

This PR intentionally provides only the HGraph primitive. AutoTune or any other consumer can call
it later, but no AutoTune dependency or orchestration is included here.

## Test Evidence

- [ ] `make fmt`
- [ ] `make lint`
- [ ] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [x] Other (describe below)

Test details:

```text
cmake --build build-release --target algorithm_test -j$(nproc)
  passed

cmake --build build-release --target vsag -j$(nproc)
  passed

/tmp/hgraph_degree_reduction_test
  All tests passed (22 assertions in 1 test case)

clang-format-15 --dry-run --Werror <changed C++ files>
  passed

clang-tidy-15 -p build-release \
  src/algorithm/hgraph/hgraph_degree_reduction.cpp --quiet
  passed

git diff --check upstream/main...HEAD
  passed
```

Performance validation used the first 500,000 vectors from SIFT1M, fp32, NSW,
`ef_construction=100`, 48 build threads, and degrees 16/32/64. Serialization was excluded:

```text
Independent M16/M32/M64 builds: 23.70s
M64 build + M32/M16 projection:  9.61s
Conservative construction speedup: 2.47x
Construction time reduction:       59.4%
```

A separate five-repeat SIFT 20K comparison found median recall deltas from -0.0002 to +0.0112
and a maximum median projected-versus-independent latency increase of 6.9%. Searching the same
M64 artifact before and after this change produced identical recall and no measurable normal-path
latency regression.

## Compatibility Impact

- API/ABI compatibility: No installed public API or ABI change. The new methods are internal to
  HGraph.
- Behavior changes: None unless an internal caller explicitly invokes degree reduction.
- Serialization: No format change; reduced graphs use the existing physical graph format.

## Performance and Concurrency Impact

- Performance impact: Consumers evaluating multiple `max_degree` values can replace repeated full
  graph construction with one construction plus inexpensive reductions. Normal build and search
  paths are unchanged.
- Concurrency/thread-safety impact: Preparation and reduction take the existing HGraph add/global
  locks.

## Documentation Impact

- [x] No docs update needed
- [ ] Updated docs

This is an internal capability with no user-facing workflow in this PR.

## Risk and Rollback

- Risk level: medium
- Rollback plan: Revert commit `9df7758a`; normal HGraph paths and the serialization format are
  otherwise unchanged.

The reduced graph has the requested compact degree but inherits topology and hierarchy from the
larger graph. It is not byte-for-byte or topology-equivalent to a graph independently built with
the smaller `max_degree`, so consumers must evaluate the reduced artifact itself.

## Checklist

- [x] I have linked the relevant issue
- [x] I have added/updated tests for new behavior or bug fixes
- [x] I have considered API compatibility impact
- [x] I have updated docs if behavior/workflow changed
- [x] My commit messages follow project conventions
