### PR TITLE
fix(hgraph): reset state after removing all elements

### DIFF
--- a/src/algorithm/hgraph/hgraph_modify.cpp
+++ b/src/algorithm/hgraph/hgraph_modify.cpp
@@ -198,7 +198,15 @@ HGraph::force_remove_one(int64_t label) {
     if (was_mark_removed) {
         this->delete_count_.fetch_sub(1);
     }
-    this->total_count_.fetch_sub(1);
+    {
+        std::scoped_lock lock(this->global_mutex_);
+        if (this->total_count_.load() == 1) {
+            this->entry_point_id_ = INVALID_ENTRY_POINT;
+            this->bottom_graph_->SetTotalCount(0);
+            this->route_graphs_.clear();
+        }
+        this->total_count_.fetch_sub(1);
+    }
     return 1;
 }
 

--- a/src/algorithm/hgraph/hgraph_search.cpp
+++ b/src/algorithm/hgraph/hgraph_search.cpp
@@ -402,7 +402,11 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
         }
         shared_lock = this->acquire_global_read_lock();
     }
-    k = std::min(k, GetNumElements());
+    const auto element_count = GetNumElements();
+    if (element_count == 0) {
+        return make_empty_dataset_with_stats();
+    }
+    k = std::min(k, element_count);
 
     // Setup reasoning context (KNN only)
     std::shared_ptr<ReasoningContext> reasoning_ctx;

--- a/tests/test_hgraph_remove.cpp
+++ b/tests/test_hgraph_remove.cpp
@@ -15,6 +15,7 @@
 #include <atomic>
 #include <catch2/catch_test_macros.hpp>
 #include <future>
+#include <limits>
 #include <mutex>
 #include <nlohmann/json.hpp>
 #include <thread>
@@ -287,6 +288,26 @@ TEST_CASE("HGraph ForceRemove All Elements", "[ft][hgraph]") {
     auto empty_result = index->KnnSearch(empty_query, 10, search_param);
     REQUIRE(empty_result.has_value());
     REQUIRE(empty_result.value()->GetDim() == 0);
+
+    auto empty_range_result =
+        index->RangeSearch(empty_query, std::numeric_limits<float>::max(), search_param);
+    REQUIRE(empty_range_result.has_value());
+    REQUIRE(empty_range_result.value()->GetDim() == 0);
+
+    int64_t new_id = NUM_ELEMENTS;
+    auto new_dataset = vsag::Dataset::Make();
+    new_dataset->Dim(DIM)
+        ->NumElements(1)
+        ->Ids(&new_id)
+        ->Float32Vectors(vectors.data())
+        ->Owner(false);
+    auto add_result = index->Add(new_dataset);
+    REQUIRE(add_result.has_value());
+
+    auto rebuilt_result = index->KnnSearch(empty_query, 10, search_param);
+    REQUIRE(rebuilt_result.has_value());
+    REQUIRE(rebuilt_result.value()->GetDim() == 1);
+    REQUIRE(rebuilt_result.value()->GetIds()[0] == new_id);
 }
 
 TEST_CASE("HGraph ForceRemove All Elements Twice", "[ft][hgraph]") {


### PR DESCRIPTION
## Summary
- reset the HGraph entry point and graph state when the final element is force-removed
- short-circuit empty SearchWithRequest queries
- cover empty KNN, empty range search, and re-adding an element

Fixes #2581

## Validation
- `./build/tests/functests "HGraph ForceRemove All Elements" -d yes`
- `make release`
- `make lint`