### PR TITLE
perf(pyramid): parallelize initial code encoding

### DIFF
--- a/src/algorithm/pyramid/pyramid.cpp
+++ b/src/algorithm/pyramid/pyramid.cpp
@@ -16,6 +16,7 @@
 #include "pyramid.h"
 
 #include <chrono>
+#include <exception>
 
 #include "algorithm/inner_index_interface.h"
 #include "analyzer/analyzer.h"
@@ -759,7 +760,7 @@ Pyramid::ExportModel(const IndexCommonParam& param) const {
 
 std::vector<int64_t>
 Pyramid::Add(const DatasetPtr& base) {
-    int64_t data_num = base->GetNumElements();
+    const int64_t data_num = base->GetNumElements();
     const auto* data_vectors = base->GetFloat32Vectors();
     const auto* data_ids = base->GetIds();
     std::vector<int64_t> failed_ids;
@@ -768,33 +769,99 @@ Pyramid::Add(const DatasetPtr& base) {
     {
         std::lock_guard lock(cur_element_count_mutex_);
         local_cur_element_count = cur_element_count_;
+        auto new_capacity = max_capacity_;
         if (max_capacity_ == 0) {
-            auto new_capacity = std::max(INIT_CAPACITY, data_num);
-            resize(new_capacity);
+            new_capacity = std::max(INIT_CAPACITY, data_num);
         } else if (max_capacity_ < data_num + cur_element_count_) {
-            auto new_capacity = std::min(MAX_CAPACITY_EXTEND, max_capacity_);
+            new_capacity = std::min(MAX_CAPACITY_EXTEND, max_capacity_);
             new_capacity = std::max(data_num + cur_element_count_ - max_capacity_, new_capacity) +
                            max_capacity_;
+        }
+        bool base_storage_resized = false;
+        bool precise_storage_resized = false;
+        if (new_capacity > max_capacity_) {
+            base_storage_resized = new_capacity > static_cast<int64_t>(base_codes_->max_capacity_);
+            precise_storage_resized =
+                not use_reorder_ ||
+                new_capacity > static_cast<int64_t>(precise_codes_->max_capacity_);
             resize(new_capacity);
         }
-        int64_t valid_id_count = 0;
+
+        data_biases.reserve(data_num);
         for (int64_t i = 0; i < data_num; ++i) {
             if (not label_table_->CheckLabel(data_ids[i])) {
-                label_table_->Insert(valid_id_count + local_cur_element_count, data_ids[i]);
-                base_codes_->InsertVector(data_vectors + dim_ * i,
-                                          valid_id_count + local_cur_element_count);
-                if (use_reorder_) {
-                    precise_codes_->InsertVector(data_vectors + dim_ * i,
-                                                 valid_id_count + local_cur_element_count);
-                }
-                valid_id_count++;
+                const auto inner_id =
+                    static_cast<InnerIdType>(local_cur_element_count + data_biases.size());
+                label_table_->Insert(inner_id, data_ids[i]);
                 data_biases.push_back(i);
             } else {
                 logger::warn("Label {} already exists, skip adding.", data_ids[i]);
                 failed_ids.push_back(data_ids[i]);
             }
         }
-        cur_element_count_ += valid_id_count;
+
+        const auto encode_range = [this, data_vectors, local_cur_element_count, &data_biases](
+                                      uint64_t begin, uint64_t end) {
+            for (uint64_t offset = begin; offset < end; ++offset) {
+                const auto* vector = data_vectors + dim_ * data_biases[offset];
+                const auto inner_id = static_cast<InnerIdType>(local_cur_element_count + offset);
+                base_codes_->InsertVector(vector, inner_id);
+                if (use_reorder_) {
+                    precise_codes_->InsertVector(vector, inner_id);
+                }
+            }
+        };
+        const auto supports_parallel_encode = [](const FlattenInterfacePtr& codes) {
+            const auto name = codes->GetQuantizerName();
+            return codes->InMemory() &&
+                   (name == QUANTIZATION_TYPE_VALUE_FP32 ||
+                    name == QUANTIZATION_TYPE_VALUE_RABITQ || name == QUANTIZATION_TYPE_VALUE_SQ8);
+        };
+        const bool use_parallel_encode =
+            local_cur_element_count == 0 && thread_pool_ != nullptr && build_thread_count_ > 1 &&
+            data_biases.size() > 1 && supports_parallel_encode(base_codes_) &&
+            (not use_reorder_ || supports_parallel_encode(precise_codes_)) &&
+            base_storage_resized && precise_storage_resized;
+        if (use_parallel_encode) {
+            const uint64_t worker_count =
+                std::min<uint64_t>(build_thread_count_, data_biases.size());
+            const uint64_t block_size = (data_biases.size() + worker_count - 1) / worker_count;
+            Vector<std::future<void>> futures(allocator_);
+            futures.reserve(worker_count);
+            const auto wait_futures = [&futures]() {
+                std::exception_ptr first_exception = nullptr;
+                for (auto& future : futures) {
+                    try {
+                        future.get();
+                    } catch (...) {
+                        if (not first_exception) {
+                            first_exception = std::current_exception();
+                        }
+                    }
+                }
+                if (first_exception) {
+                    std::rethrow_exception(first_exception);
+                }
+            };
+            try {
+                for (uint64_t begin = 0; begin < data_biases.size(); begin += block_size) {
+                    const uint64_t end = std::min<uint64_t>(begin + block_size, data_biases.size());
+                    futures.push_back(thread_pool_->GeneralEnqueue(
+                        [encode_range, begin, end]() { encode_range(begin, end); }));
+                }
+            } catch (...) {
+                const auto enqueue_exception = std::current_exception();
+                try {
+                    wait_futures();
+                } catch (...) {
+                }
+                std::rethrow_exception(enqueue_exception);
+            }
+            wait_futures();
+        } else {
+            encode_range(0, data_biases.size());
+        }
+        cur_element_count_ += static_cast<int64_t>(data_biases.size());
     }
     std::shared_lock<std::shared_mutex> lock(resize_mutex_);
 

--- a/src/algorithm/pyramid/pyramid_test.cpp
+++ b/src/algorithm/pyramid/pyramid_test.cpp
@@ -15,6 +15,7 @@
 
 #include "pyramid.h"
 
+#include <cmath>
 #include <vector>
 
 #include "impl/allocator/safe_allocator.h"
@@ -31,7 +32,9 @@ struct PyramidTestIndex {
 };
 
 PyramidTestIndex
-MakePyramidIndex(uint32_t index_min_size) {
+MakePyramidIndex(uint32_t index_min_size,
+                 uint64_t build_thread_count = 1,
+                 bool use_rabitq_with_sq8 = false) {
     PyramidTestIndex result;
     vsag::IndexCommonParam common_param;
     common_param.dim_ = PYRAMID_TEST_DIM;
@@ -51,6 +54,15 @@ MakePyramidIndex(uint32_t index_min_size) {
         "index_min_size": 3
     })");
     external_param[vsag::PYRAMID_INDEX_MIN_SIZE].SetInt(index_min_size);
+    external_param[vsag::PYRAMID_BUILD_THREAD_COUNT].SetUint64(build_thread_count);
+    if (use_rabitq_with_sq8) {
+        external_param[vsag::PYRAMID_BASE_QUANTIZATION_TYPE].SetString("rabitq");
+        external_param[vsag::PYRAMID_PRECISE_QUANTIZATION_TYPE].SetString("sq8");
+        external_param[vsag::PYRAMID_BASE_IO_TYPE].SetString("block_memory_io");
+        external_param[vsag::PYRAMID_PRECISE_IO_TYPE].SetString("block_memory_io");
+        external_param[vsag::PYRAMID_USE_REORDER].SetBool(true);
+        external_param[vsag::PYRAMID_RABITQ_BITS_PER_DIM_BASE].SetUint64(1);
+    }
     auto param = vsag::Pyramid::CheckAndMappingExternalParam(external_param, common_param);
     result.index = std::make_shared<vsag::Pyramid>(param, common_param);
     return result;
@@ -155,5 +167,33 @@ TEST_CASE("Pyramid promotes flat node at index minimum size", "[ut][pyramid]") {
         auto result =
             index->KnnSearch(query, 1, R"({"pyramid":{"ef_search":10}})", vsag::FilterPtr{});
         REQUIRE(result->GetIds()[0] == ids[i]);
+    }
+}
+
+TEST_CASE("Pyramid Build stores RaBitQ and SQ8 codes in parallel", "[ut][pyramid]") {
+    constexpr int64_t count = 804;
+    auto test_index = MakePyramidIndex(count + 1, 4, true);
+
+    std::vector<float> vectors(count * PYRAMID_TEST_DIM);
+    std::vector<int64_t> ids(count);
+    std::vector<std::string> paths(count, "tenant");
+    for (int64_t i = 0; i < count; ++i) {
+        ids[i] = i;
+        for (int64_t j = 0; j < PYRAMID_TEST_DIM; ++j) {
+            vectors[i * PYRAMID_TEST_DIM + j] = static_cast<float>((i + j) % 101) / 100.0F;
+        }
+    }
+
+    auto failed_ids = test_index.index->Build(
+        MakePyramidDataset(vectors.data(), ids.data(), paths.data(), count));
+
+    REQUIRE(failed_ids.empty());
+    REQUIRE(test_index.index->GetNumElements() == count);
+    for (const int64_t inner_id : {0, 401, 803}) {
+        std::vector<float> decoded(PYRAMID_TEST_DIM);
+        test_index.index->GetVectorByInnerId(inner_id, decoded.data());
+        for (int64_t j = 0; j < PYRAMID_TEST_DIM; ++j) {
+            REQUIRE(std::abs(decoded[j] - vectors[inner_id * PYRAMID_TEST_DIM + j]) < 0.02F);
+        }
     }
 }


### PR DESCRIPTION
## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement/Refactor
- [ ] Documentation
- [ ] CI/Build/Infra

## Linked Issue

- Closes: #2583

## What Changed

- Kept the existing NSW `Build() → Add()` flow unchanged.
- In the existing `Add()` encoding section, first finish label de-duplication and compact inner-ID assignment, then encode the initial base and precise codes over fixed, disjoint ranges on the existing build thread pool.
- Enable the parallel branch only for an empty index when the code stores have just been physically resized and use audited in-memory FP32, RaBitQ, or SQ8 implementations.
- Keep incremental `Add()`, non-memory IO, unsupported quantizers, and non-growing storage on the original serial encoding path.
- Path-tree construction, hierarchy insertion, and graph construction are unchanged.

## Test Evidence

- [ ] `make fmt`
- [ ] `make lint`
- [ ] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [x] Other (describe below)

Test details:

```text
$ ./build/tests/unittests '[ut][pyramid]'
All tests passed (39 assertions in 4 test cases)

$ /opt/homebrew/opt/llvm@15/bin/clang-format --dry-run --Werror \
    src/algorithm/pyramid/pyramid.cpp \
    src/algorithm/pyramid/pyramid.h \
    src/algorithm/pyramid/pyramid_test.cpp
Homebrew clang-format version 15.0.7

$ git diff --check
# no output
```

Focused 32-thread benchmark medians on the same host and path distribution:

- 20,000 × 4096D, RaBitQ + SQ8: 116.268 s → 22.046 s (5.27x)
- 20,000 × 2560D, RaBitQ + SQ8: 29.587 s → 5.723 s (5.17x)

## Compatibility Impact

- API/ABI compatibility: none
- Behavior changes: initial code encoding may run concurrently when `build_thread_count > 1`; code layout and incremental insertion behavior are unchanged.

## Performance and Concurrency Impact

- Performance impact: improved initial build throughput for expensive high-dimensional encoders.
- Concurrency/thread-safety impact: workers write fixed, non-overlapping inner-ID ranges only after storage resize completes. Incremental insertion and unsupported storage/quantizer combinations remain serial.

## Documentation Impact

- [x] No docs update needed
- [ ] Updated docs:
  - [ ] `README.md`
  - [ ] `DEVELOPMENT.md`
  - [ ] `CONTRIBUTING.md`
  - [ ] Other

## Risk and Rollback

- Risk level: medium
- Rollback plan: revert commit `d0356116` to restore serial code encoding.

## Checklist

- [x] I have linked the relevant issue.
- [x] I have added/updated tests for the changed behavior.
- [x] I have considered API compatibility impact.
- [x] I have updated docs if behavior/workflow changed.
- [x] My commit messages follow project conventions.