### PR TITLE
feat(hgraph): support UpdateVector with deduplicate_storage

### DIFF
--- a/docs/docs/en/src/indexes/hgraph.md
+++ b/docs/docs/en/src/indexes/hgraph.md
@@ -115,8 +115,10 @@ is enabled:
 - `Merge`;
 - legacy v0.14 serialization.
 
-`UpdateVector` is supported only for IDs whose vector storage is not shared with another
-duplicate-group member.
+`UpdateVector` keeps the existing HGraph in-place update semantics. If the target logical ID still
+shares a physical code slot, HGraph writes the replacement vector to a private slot and atomically
+redirects only that ID. Graph topology and duplicate-group metadata remain unchanged, matching
+`UpdateVector` behavior when storage deduplication is disabled.
 
 Current serialization and streaming serialization are supported.
 

--- a/docs/docs/zh/src/indexes/hgraph.md
+++ b/docs/docs/zh/src/indexes/hgraph.md
@@ -105,7 +105,9 @@ auto result = index->KnnSearch(
 - `Merge`；
 - v0.14 旧版序列化格式。
 
-`UpdateVector` 仅支持尚未与其他重复组成员共享向量存储的 ID。
+`UpdateVector` 保持 HGraph 现有的原地更新语义。如果目标逻辑 ID 仍与其他成员共享物理编码
+槽位，HGraph 会将新向量写入独立槽位，并以原子方式仅重定向该 ID。图结构和重复组元数据均
+保持不变，与未启用存储去重时的 `UpdateVector` 行为一致。
 
 当前序列化格式和 streaming serialization 均受支持。
 

--- a/src/algorithm/hgraph/hgraph.cpp
+++ b/src/algorithm/hgraph/hgraph.cpp
@@ -751,29 +751,61 @@ HGraph::UpdateVector(int64_t id, const DatasetPtr& new_base, bool force_update) 
         }
     }
 
-    if (this->using_dedup_storage()) {
-        auto duplicate_tracker = this->bottom_graph_->GetDuplicateTracker();
-        CHECK_ARGUMENT(duplicate_tracker != nullptr,
-                       "deduplicate_storage update requires duplicate tracker");
-        if (duplicate_tracker->GetGroupSize(inner_id) > 1) {
-            throw VsagException(
-                ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                "updating a member of a deduplicated vector group is not supported");
+    if (not this->using_dedup_storage()) {
+        // Updating vector storage requires exclusive access; the datacell handles its own
+        // lower-level synchronization.
+        std::unique_lock<std::shared_mutex> codes_lock(this->persistent_codes_mutex_);
+        bool update_status = basic_flatten_codes_->UpdateVector(new_base_vec, inner_id);
+        if (has_precise_reorder()) {
+            update_status =
+                update_status && high_precise_codes_->UpdateVector(new_base_vec, inner_id);
+        }
+        return update_status;
+    }
+
+    // Deduplicated storage needs both locks exclusively: the global lock freezes Add/Search slot
+    // visibility while the codes lock pins every physical flatten used by MCI. std::lock avoids
+    // imposing a new order on existing paths that acquire these locks in opposite orders.
+    std::unique_lock<std::shared_mutex> global_lock(this->global_mutex_, std::defer_lock);
+    std::unique_lock<std::shared_mutex> codes_lock(this->persistent_codes_mutex_, std::defer_lock);
+    std::lock(global_lock, codes_lock);
+
+    const auto duplicate_tracker = this->bottom_graph_->GetDuplicateTracker();
+    CHECK_ARGUMENT(duplicate_tracker != nullptr,
+                   "deduplicate_storage update requires duplicate tracker");
+    const auto current_slot = this->code_slot_map_->Resolve(inner_id);
+    const auto duplicate_ids = duplicate_tracker->GetDuplicateIds(inner_id);
+    bool slot_is_shared = false;
+    for (const auto duplicate_id : duplicate_ids) {
+        if (this->code_slot_map_->Resolve(duplicate_id) == current_slot) {
+            slot_is_shared = true;
+            break;
         }
     }
 
-    // note that only modify vector need to obtain unique lock
-    // and the lock has been obtained inside datacell
-    std::shared_lock<std::shared_mutex> map_lock;
-    if (this->using_dedup_storage() && !this->immutable_.load(std::memory_order_acquire)) {
-        map_lock = this->acquire_global_read_lock();
+    if (not slot_is_shared) {
+        bool update_status = basic_flatten_codes_->UpdateVector(new_base_vec, inner_id);
+        if (has_precise_reorder()) {
+            update_status =
+                update_status && high_precise_codes_->UpdateVector(new_base_vec, inner_id);
+        }
+        // A member previously split from a shared slot must keep its private raw code in sync on
+        // later updates. Preserve the existing unique-ID behavior outside duplicate groups.
+        if (create_new_raw_vector_ and not duplicate_ids.empty()) {
+            update_status = update_status && raw_vector_->UpdateVector(new_base_vec, inner_id);
+        }
+        return update_status;
     }
-    std::unique_lock<std::shared_mutex> codes_lock(this->persistent_codes_mutex_);
-    bool update_status = basic_flatten_codes_->UpdateVector(new_base_vec, inner_id);
-    if (has_precise_reorder()) {
-        update_status = update_status && high_precise_codes_->UpdateVector(new_base_vec, inner_id);
-    }
-    return update_status;
+
+    // Keep the pre-dedup UpdateVector semantics: only this logical ID changes, while graph and
+    // duplicate metadata remain untouched. Fully initialize a private slot before publishing the
+    // new mapping so readers observe either the complete old vector or the complete new vector.
+    const auto next_slot = this->code_slot_map_->PhysicalCount();
+    this->ensure_physical_code_capacity_unlocked(next_slot + 1);
+    const auto new_slot = this->code_slot_map_->AllocateSlot();
+    this->insert_persistent_codes_to_slot(new_base_vec, new_slot);
+    this->code_slot_map_->RebindSlot(inner_id, current_slot, new_slot);
+    return true;
 }
 
 std::string

--- a/src/algorithm/hgraph/hgraph.h
+++ b/src/algorithm/hgraph/hgraph.h
@@ -666,7 +666,7 @@ private:
         return support_force_remove_;
     }
 
-    /// True when duplicate logical ids share physical vector storage slots.
+    /// True when logical-to-physical shared vector storage is enabled.
     [[nodiscard]] bool
     using_dedup_storage() const {
         return support_duplicate_ and deduplicate_storage_;

--- a/src/algorithm/hgraph/hgraph_add_test.cpp
+++ b/src/algorithm/hgraph/hgraph_add_test.cpp
@@ -942,7 +942,7 @@ TEST_CASE("HGraph deduplicate_storage ExportModel keeps an empty reusable model"
     REQUIRE(ResultContainsId(search_result.value(), 40));
 }
 
-TEST_CASE("HGraph deduplicate_storage rejects UpdateVector for a shared duplicate group",
+TEST_CASE("HGraph deduplicate_storage copy-on-write updates a shared duplicate group",
           "[ut][hgraph][duplicate][update]") {
     constexpr int64_t dim = 2;
     auto common_param = MakeCommonParam(dim);
@@ -956,17 +956,26 @@ TEST_CASE("HGraph deduplicate_storage rejects UpdateVector for a shared duplicat
         0.0F,
         1.0F,
         0.0F,
+        1.0F,
+        0.0F,
     };
-    std::vector<int64_t> ids = {10, 20, 30};
-    auto base = MakeFloatDataset(vectors, ids, dim, 3);
+    std::vector<int64_t> ids = {10, 20, 30, 40};
+    auto base = MakeFloatDataset(vectors, ids, dim, 4);
     REQUIRE(index->Build(base).has_value());
+
+    auto hgraph = std::dynamic_pointer_cast<vsag::HGraph>(index->GetInnerIndex());
+    REQUIRE(hgraph != nullptr);
+    REQUIRE(hgraph->GetCodeStorageCounts() ==
+            (std::pair<vsag::InnerIdType, vsag::CodeSlotIdType>{4, 2}));
 
     std::vector<float> updated_vector = {3.0F, 0.0F};
     std::vector<int64_t> update_id = {30};
     auto update_data = MakeFloatDataset(updated_vector, update_id, dim, 1);
-    auto update_result = index->UpdateVector(update_id[0], update_data, true);
-    REQUIRE_FALSE(update_result.has_value());
-    REQUIRE(update_result.error().type == vsag::ErrorType::UNSUPPORTED_INDEX_OPERATION);
+    auto update_result = index->UpdateVector(update_id[0], update_data);
+    REQUIRE(update_result.has_value());
+    REQUIRE(update_result.value());
+    REQUIRE(hgraph->GetCodeStorageCounts() ==
+            (std::pair<vsag::InnerIdType, vsag::CodeSlotIdType>{4, 3}));
 
     std::vector<float> original_duplicate_vector = {1.0F, 0.0F};
     auto representative_distance =
@@ -976,7 +985,46 @@ TEST_CASE("HGraph deduplicate_storage rejects UpdateVector for a shared duplicat
 
     auto duplicate_distance = index->CalcDistanceById(original_duplicate_vector.data(), 30, false);
     REQUIRE(duplicate_distance.has_value());
-    REQUIRE(duplicate_distance.value() == 0.0F);
+    REQUIRE(duplicate_distance.value() > 0.0F);
+    auto updated_distance = index->CalcDistanceById(updated_vector.data(), 30, false);
+    REQUIRE(updated_distance.has_value());
+    REQUIRE(updated_distance.value() == 0.0F);
+
+    std::vector<float> representative_update_vector = {4.0F, 0.0F};
+    std::vector<int64_t> representative_update_id = {20};
+    auto representative_update_data =
+        MakeFloatDataset(representative_update_vector, representative_update_id, dim, 1);
+    auto representative_update_result =
+        index->UpdateVector(representative_update_id[0], representative_update_data, true);
+    REQUIRE(representative_update_result.has_value());
+    REQUIRE(representative_update_result.value());
+    REQUIRE(hgraph->GetCodeStorageCounts() ==
+            (std::pair<vsag::InnerIdType, vsag::CodeSlotIdType>{4, 4}));
+
+    auto untouched_duplicate_distance =
+        index->CalcDistanceById(original_duplicate_vector.data(), 40, false);
+    REQUIRE(untouched_duplicate_distance.has_value());
+    REQUIRE(untouched_duplicate_distance.value() == 0.0F);
+
+    updated_vector[0] = 5.0F;
+    REQUIRE(index->UpdateVector(update_id[0], update_data, true).value());
+    representative_update_vector[0] = 6.0F;
+    REQUIRE(
+        index->UpdateVector(representative_update_id[0], representative_update_data, true).value());
+    REQUIRE(hgraph->GetCodeStorageCounts() ==
+            (std::pair<vsag::InnerIdType, vsag::CodeSlotIdType>{4, 4}));
+    REQUIRE(index->CalcDistanceById(updated_vector.data(), 30, false).value() == 0.0F);
+    REQUIRE(index->CalcDistanceById(representative_update_vector.data(), 20, false).value() ==
+            0.0F);
+
+    std::vector<float> last_sibling_update_vector = {7.0F, 0.0F};
+    std::vector<int64_t> last_sibling_update_id = {40};
+    auto last_sibling_update =
+        MakeFloatDataset(last_sibling_update_vector, last_sibling_update_id, dim, 1);
+    REQUIRE(index->UpdateVector(last_sibling_update_id[0], last_sibling_update, true).value());
+    REQUIRE(hgraph->GetCodeStorageCounts() ==
+            (std::pair<vsag::InnerIdType, vsag::CodeSlotIdType>{4, 4}));
+    REQUIRE(index->CalcDistanceById(last_sibling_update_vector.data(), 40, false).value() == 0.0F);
 
     std::vector<float> unique_update_vector = {4.0F, 0.0F};
     std::vector<int64_t> unique_update_id = {10};
@@ -988,6 +1036,169 @@ TEST_CASE("HGraph deduplicate_storage rejects UpdateVector for a shared duplicat
         index->CalcDistanceById(unique_update_vector.data(), unique_update_id[0], false);
     REQUIRE(unique_distance.has_value());
     REQUIRE(unique_distance.value() == 0.0F);
+    REQUIRE(hgraph->GetCodeStorageCounts() ==
+            (std::pair<vsag::InnerIdType, vsag::CodeSlotIdType>{4, 4}));
+
+    std::vector<float> added_duplicate_vector = representative_update_vector;
+    std::vector<int64_t> added_duplicate_id = {50};
+    auto added_duplicate = MakeFloatDataset(added_duplicate_vector, added_duplicate_id, dim, 1);
+    REQUIRE(index->Add(added_duplicate).has_value());
+    REQUIRE(hgraph->GetCodeStorageCounts() ==
+            (std::pair<vsag::InnerIdType, vsag::CodeSlotIdType>{5, 4}));
+
+    representative_update_vector[0] = 8.0F;
+    REQUIRE(
+        index->UpdateVector(representative_update_id[0], representative_update_data, true).value());
+    REQUIRE(hgraph->GetCodeStorageCounts() ==
+            (std::pair<vsag::InnerIdType, vsag::CodeSlotIdType>{5, 5}));
+    REQUIRE(index->CalcDistanceById(representative_update_vector.data(), 20, false).value() ==
+            0.0F);
+    REQUIRE(index->CalcDistanceById(added_duplicate_vector.data(), 50, false).value() == 0.0F);
+
+    auto binary = index->Serialize();
+    REQUIRE(binary.has_value());
+    auto restored = MakeHGraphIndex(hgraph_json, common_param);
+    REQUIRE(restored->Deserialize(binary.value()).has_value());
+    auto restored_hgraph = std::dynamic_pointer_cast<vsag::HGraph>(restored->GetInnerIndex());
+    REQUIRE(restored_hgraph != nullptr);
+    REQUIRE(restored_hgraph->GetCodeStorageCounts() ==
+            (std::pair<vsag::InnerIdType, vsag::CodeSlotIdType>{5, 5}));
+    REQUIRE(restored->CalcDistanceById(representative_update_vector.data(), 20, false).value() ==
+            0.0F);
+    REQUIRE(restored->CalcDistanceById(last_sibling_update_vector.data(), 40, false).value() ==
+            0.0F);
+    REQUIRE(restored->CalcDistanceById(added_duplicate_vector.data(), 50, false).value() == 0.0F);
+
+    representative_update_vector[0] = 9.0F;
+    REQUIRE(restored->UpdateVector(representative_update_id[0], representative_update_data, true)
+                .value());
+    REQUIRE(restored_hgraph->GetCodeStorageCounts() ==
+            (std::pair<vsag::InnerIdType, vsag::CodeSlotIdType>{5, 5}));
+    REQUIRE(restored->CalcDistanceById(representative_update_vector.data(), 20, false).value() ==
+            0.0F);
+}
+
+TEST_CASE("HGraph deduplicate_storage UpdateVector writes every private code layer",
+          "[ut][hgraph][duplicate][update]") {
+    SECTION("precise reorder codes") {
+        constexpr int64_t dim = 4;
+        auto common_param = MakeCommonParam(dim);
+        auto hgraph_json = MakeFp32ReorderHGraphJson();
+        auto index = MakeHGraphIndex(hgraph_json, common_param);
+
+        std::vector<float> vectors(dim * 2, 0.0F);
+        std::vector<int64_t> ids = {10, 20};
+        REQUIRE(index->Build(MakeFloatDataset(vectors, ids, dim, 2)).has_value());
+
+        std::vector<float> updated_vector = {2.0F, 0.0F, 0.0F, 0.0F};
+        std::vector<int64_t> update_id = {20};
+        auto update = MakeFloatDataset(updated_vector, update_id, dim, 1);
+        REQUIRE(index->UpdateVector(update_id[0], update, true).value());
+
+        auto hgraph = std::dynamic_pointer_cast<vsag::HGraph>(index->GetInnerIndex());
+        REQUIRE(hgraph != nullptr);
+        REQUIRE(hgraph->GetCodeStorageCounts() ==
+                (std::pair<vsag::InnerIdType, vsag::CodeSlotIdType>{2, 2}));
+        REQUIRE(index->CalcDistanceById(updated_vector.data(), 20, false).value() == 0.0F);
+        REQUIRE(index->CalcDistanceById(updated_vector.data(), 20, true).value() == 0.0F);
+        REQUIRE(index->CalcDistanceById(vectors.data(), 10, false).value() == 0.0F);
+        REQUIRE(index->CalcDistanceById(vectors.data(), 10, true).value() == 0.0F);
+    }
+
+    SECTION("separate raw vectors") {
+        constexpr int64_t dim = 960;
+        auto common_param = MakeCommonParam(dim);
+        auto hgraph_json = MakeRabitQRawVectorHGraphJson();
+        auto index = MakeHGraphIndex(hgraph_json, common_param);
+
+        std::vector<float> vectors(dim * 3);
+        for (int64_t d = 0; d < dim; ++d) {
+            vectors[d] = static_cast<float>(d % 17) * 0.01F;
+            vectors[dim + d] = 1.0F + static_cast<float>(d % 13) * 0.01F;
+            vectors[2 * dim + d] = vectors[dim + d];
+        }
+        std::vector<int64_t> ids = {10, 20, 30};
+        REQUIRE(index->Build(MakeFloatDataset(vectors, ids, dim, 3)).has_value());
+
+        std::vector<float> updated_vector(dim);
+        for (int64_t d = 0; d < dim; ++d) {
+            updated_vector[d] = 2.0F + static_cast<float>(d % 11) * 0.01F;
+        }
+        std::vector<int64_t> update_id = {30};
+        auto update = MakeFloatDataset(updated_vector, update_id, dim, 1);
+        const auto old_base_distance =
+            index->CalcDistanceById(updated_vector.data(), update_id[0], false).value();
+        REQUIRE(index->UpdateVector(update_id[0], update, true).value());
+
+        auto hgraph = std::dynamic_pointer_cast<vsag::HGraph>(index->GetInnerIndex());
+        REQUIRE(hgraph != nullptr);
+        REQUIRE(hgraph->GetCodeStorageCounts() ==
+                (std::pair<vsag::InnerIdType, vsag::CodeSlotIdType>{3, 3}));
+        REQUIRE(index->CalcDistanceById(updated_vector.data(), 30, false).value() <
+                old_base_distance);
+        REQUIRE(index->CalcDistanceById(updated_vector.data(), 30, true).value() == 0.0F);
+        REQUIRE(index->CalcDistanceById(vectors.data() + dim, 20, true).value() == 0.0F);
+
+        for (int64_t d = 0; d < dim; ++d) {
+            updated_vector[d] = 3.0F + static_cast<float>(d % 7) * 0.01F;
+        }
+        const auto previous_base_distance =
+            index->CalcDistanceById(updated_vector.data(), update_id[0], false).value();
+        REQUIRE(index->UpdateVector(update_id[0], update, true).value());
+        REQUIRE(hgraph->GetCodeStorageCounts() ==
+                (std::pair<vsag::InnerIdType, vsag::CodeSlotIdType>{3, 3}));
+        REQUIRE(index->CalcDistanceById(updated_vector.data(), 30, false).value() <
+                previous_base_distance);
+        REQUIRE(index->CalcDistanceById(updated_vector.data(), 30, true).value() == 0.0F);
+    }
+}
+
+TEST_CASE("HGraph deduplicate_storage concurrent updates allocate one private slot",
+          "[ut][hgraph][duplicate][concurrent][update]") {
+    constexpr int64_t dim = 2;
+    auto common_param = MakeCommonParam(dim);
+    auto hgraph_json = MakeFp32HGraphJson();
+    auto index = MakeHGraphIndex(hgraph_json, common_param);
+
+    std::vector<float> vectors(dim * 2, 0.0F);
+    std::vector<int64_t> ids = {10, 20};
+    REQUIRE(index->Build(MakeFloatDataset(vectors, ids, dim, 2)).has_value());
+
+    std::vector<float> first_vector = {2.0F, 0.0F};
+    std::vector<float> second_vector = {3.0F, 0.0F};
+    std::vector<int64_t> update_id = {20};
+    auto first_update = MakeFloatDataset(first_vector, update_id, dim, 1);
+    auto second_update = MakeFloatDataset(second_vector, update_id, dim, 1);
+
+    std::atomic<uint64_t> ready{0};
+    std::atomic<bool> start{false};
+    auto launch_update = [&](const vsag::DatasetPtr& update) {
+        return std::async(std::launch::async, [&, update]() {
+            ready.fetch_add(1, std::memory_order_release);
+            while (not start.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+            auto result = index->UpdateVector(update_id[0], update, true);
+            return result.has_value() and result.value();
+        });
+    };
+    auto first_result = launch_update(first_update);
+    auto second_result = launch_update(second_update);
+    while (ready.load(std::memory_order_acquire) < 2) {
+        std::this_thread::yield();
+    }
+    start.store(true, std::memory_order_release);
+
+    REQUIRE(first_result.get());
+    REQUIRE(second_result.get());
+    auto hgraph = std::dynamic_pointer_cast<vsag::HGraph>(index->GetInnerIndex());
+    REQUIRE(hgraph != nullptr);
+    REQUIRE(hgraph->GetCodeStorageCounts() ==
+            (std::pair<vsag::InnerIdType, vsag::CodeSlotIdType>{2, 2}));
+    REQUIRE(index->CalcDistanceById(vectors.data(), 10, false).value() == 0.0F);
+    const auto first_distance = index->CalcDistanceById(first_vector.data(), 20, false).value();
+    const auto second_distance = index->CalcDistanceById(second_vector.data(), 20, false).value();
+    REQUIRE((first_distance == 0.0F) != (second_distance == 0.0F));
 }
 
 TEST_CASE("HGraph deduplicate_storage batch Add supports internal parallel add",

--- a/src/datacell/code_slot_map.cpp
+++ b/src/datacell/code_slot_map.cpp
@@ -69,6 +69,35 @@ CodeSlotMap::PublishSlot(InnerIdType inner_id, CodeSlotIdType code_slot_id) {
     published_logical_count_.fetch_add(1, std::memory_order_acq_rel);
 }
 
+void
+// NOLINTNEXTLINE(readability-make-member-function-const): rebinding mutates slot bindings.
+CodeSlotMap::RebindSlot(InnerIdType inner_id,
+                        CodeSlotIdType expected_code_slot_id,
+                        CodeSlotIdType new_code_slot_id) {
+    const auto physical_count = physical_count_.load(std::memory_order_acquire);
+    CHECK_ARGUMENT(expected_code_slot_id < physical_count,
+                   fmt::format("expected code slot id({}) must be less than physical_count({})",
+                               expected_code_slot_id,
+                               physical_count));
+    CHECK_ARGUMENT(new_code_slot_id < physical_count,
+                   fmt::format("new code slot id({}) must be less than physical_count({})",
+                               new_code_slot_id,
+                               physical_count));
+    if (inner_id >= logical_capacity_) {
+        throw VsagException(ErrorType::INVALID_ARGUMENT,
+                            fmt::format("inner_id({}) has no bound code slot", inner_id));
+    }
+
+    auto expected = expected_code_slot_id;
+    const auto rebound = inner_to_slot_[inner_id].compare_exchange_strong(
+        expected, new_code_slot_id, std::memory_order_release, std::memory_order_acquire);
+    CHECK_ARGUMENT(rebound,
+                   fmt::format("inner_id({}) is bound to slot {}, expected slot {}",
+                               inner_id,
+                               expected,
+                               expected_code_slot_id));
+}
+
 CodeSlotIdType
 CodeSlotMap::Resolve(InnerIdType inner_id) const {
     if (inner_id >= logical_capacity_) {

--- a/src/datacell/code_slot_map.h
+++ b/src/datacell/code_slot_map.h
@@ -27,10 +27,10 @@ namespace vsag {
 using CodeSlotIdType = InnerIdType;
 
 // Maps logical inner IDs to physical slots in shared code storage. Resolve* translates logical
-// IDs to physical slot IDs, while PublishSlot atomically binds a logical ID to a slot.
+// IDs to physical slot IDs, while PublishSlot and RebindSlot atomically update those bindings.
 class CodeSlotMap {
 public:
-    // Capacity changes must be externally synchronized with Resolve, PublishSlot, and
+    // Capacity changes must be externally synchronized with Resolve, PublishSlot, RebindSlot, and
     // AllocateSlot. Slot bindings themselves are published and read atomically.
     explicit CodeSlotMap(Allocator* allocator);
 
@@ -41,6 +41,17 @@ public:
 
     void
     PublishSlot(InnerIdType inner_id, CodeSlotIdType code_slot_id);
+
+    /**
+     * Replace an existing logical-to-physical binding.
+     *
+     * The caller must fully initialize new_code_slot_id before publishing it here. The expected
+     * slot makes concurrent or stale rebinding attempts fail without changing the mapping.
+     */
+    void
+    RebindSlot(InnerIdType inner_id,
+               CodeSlotIdType expected_code_slot_id,
+               CodeSlotIdType new_code_slot_id);
 
     [[nodiscard]] CodeSlotIdType
     Resolve(InnerIdType inner_id) const;

--- a/src/datacell/code_slot_map_test.cpp
+++ b/src/datacell/code_slot_map_test.cpp
@@ -237,6 +237,34 @@ TEST_CASE("CodeSlotMap rejects invalid mappings", "[ut][datacell][code_slot_map]
     REQUIRE_THROWS(mapping.PublishSlot(1, slot + 1));
 }
 
+TEST_CASE("CodeSlotMap rebinds one logical id to an initialized slot",
+          "[ut][datacell][code_slot_map]") {
+    auto allocator = vsag::SafeAllocator::FactoryDefaultAllocator();
+    vsag::CodeSlotMap mapping(allocator.get());
+
+    mapping.ReserveLogicalSize(3);
+    auto shared_slot = mapping.AllocateSlot();
+    mapping.PublishSlot(0, shared_slot);
+    mapping.PublishSlot(1, shared_slot);
+    auto private_slot = mapping.AllocateSlot();
+    mapping.PublishSlot(2, private_slot);
+
+    auto replacement_slot = mapping.AllocateSlot();
+    mapping.RebindSlot(1, shared_slot, replacement_slot);
+
+    REQUIRE(mapping.Resolve(0) == shared_slot);
+    REQUIRE(mapping.Resolve(1) == replacement_slot);
+    REQUIRE(mapping.Resolve(2) == private_slot);
+    REQUIRE(mapping.PhysicalCount() == 3);
+    REQUIRE(mapping.PublishedLogicalCount() == 3);
+
+    REQUIRE_THROWS(mapping.RebindSlot(0, replacement_slot, private_slot));
+    REQUIRE_THROWS(mapping.RebindSlot(0, replacement_slot + 1, private_slot));
+    REQUIRE_THROWS(mapping.RebindSlot(0, shared_slot, replacement_slot + 1));
+    REQUIRE_THROWS(mapping.RebindSlot(3, shared_slot, private_slot));
+    REQUIRE(mapping.Resolve(0) == shared_slot);
+}
+
 TEST_CASE("CodeSlotMap serializes logical to physical slots", "[ut][datacell][code_slot_map]") {
     auto allocator = vsag::SafeAllocator::FactoryDefaultAllocator();
     vsag::CodeSlotMap mapping(allocator.get());


### PR DESCRIPTION
## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Improvement/Refactor
- [ ] Documentation
- [ ] CI/Build/Infra

## Linked Issue

- Closes: #2587
- Related: #2575
- Related: #2322

## What Changed

- Support `HGraph::UpdateVector` when a logical ID shares storage under `deduplicate_storage`.
- Detect sharing from current `CodeSlotMap` bindings rather than stale duplicate-group size.
- Use copy-on-write for a shared slot: grow physical storage, initialize base, precise-reorder, and separate raw-vector codes, then atomically rebind only the updated logical ID.
- Update an already private slot in place so repeated updates do not keep allocating storage.
- Add `CodeSlotMap::RebindSlot` with expected-slot validation and release/acquire publication.
- Preserve the existing HGraph behavior for graph topology and duplicate-group metadata; the broader consistency work remains tracked by #2322.
- Keep the non-deduplicated `UpdateVector` path unchanged.
- Update the English and Chinese HGraph documentation.

## Test Evidence

- [ ] `make fmt`
- [ ] `make lint`
- [ ] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [x] Other (targeted tests and changed-file checks)

Test details:

```text
Debug library and unit-test builds with 48 compile jobs: passed
HGraph duplicate tests: 27 cases / 334 assertions passed
Deduplicated UpdateVector tests: 3 cases / 72 assertions passed
CodeSlotMap tests: 7 cases / 196 assertions passed
Existing HGraph Build functional test: 1 case / 29,506 assertions passed

clang-format-15 --dry-run --Werror on changed C++ files: passed
clang-tidy-15 on changed production C++ files: passed
git diff --check: passed
```

## Compatibility Impact

- API/ABI compatibility: no public API or ABI changes; `CodeSlotMap::RebindSlot` is internal.
- Behavior changes: HGraph with `deduplicate_storage=true` now supports updating IDs that still share a physical code slot. Only the target ID is redirected to private storage.
- Existing graph-rebuild and duplicate-group update semantics are unchanged and remain tracked by #2322.

## Performance and Concurrency Impact

- Performance impact: limited to `UpdateVector`. The first update of a shared ID allocates one private physical slot; later updates of that ID are in place. Search, Build, Add, and the non-deduplicated update path are unchanged.
- Concurrency/thread-safety impact: deduplicated updates acquire the global and persistent-code locks together with deadlock avoidance. A new mapping is published only after every physical code layer is initialized, and concurrent updates of the same ID perform at most one copy-on-write allocation.

## Documentation Impact

- [ ] No docs update needed
- [x] Updated docs:
  - [ ] `README.md`
  - [ ] `DEVELOPMENT.md`
  - [ ] `CONTRIBUTING.md`
  - [x] Other:
    - `docs/docs/en/src/indexes/hgraph.md`
    - `docs/docs/zh/src/indexes/hgraph.md`

## Risk and Rollback

- Risk level: medium
- Main risk: keeping physical code layers and logical-to-physical bindings consistent while detaching one member of a shared group.
- Mitigation: initialize every code layer before atomic publication and cover representative, non-representative, repeated, concurrent, precise/raw, serialization, and last-shared-member cases.
- Rollback plan: revert this change to restore explicit rejection of updates on shared deduplicated storage.

## Checklist

- [x] I have linked the relevant issue (required for `kind/bug` and `kind/feature`; see "Linked Issue" above)
- [x] I have added/updated tests for new behavior or bug fixes
- [x] I have considered API compatibility impact
- [x] I have updated docs if behavior/workflow changed
- [x] My commit messages follow project conventions (Conventional Commits, optional `[skip ci]` prefix)
