### PR TITLE
[feat](hgraph): support ForceRemove with deduplicate_storage

### DIFF
--- a/docs/docs/en/src/indexes/hgraph.md
+++ b/docs/docs/en/src/indexes/hgraph.md
@@ -107,10 +107,13 @@ vectors share one physical code slot while retaining their individual labels. Th
 currently supports only dense-vector HGraph indexes using `graph_type: "nsw"`; it is not
 available for the separate HNSW index or for `graph_type: "odescent"`.
 
+`RemoveMode::FORCE_REMOVE` is supported when `support_force_remove: true`,
+`use_reverse_edges: true`, and flat graph storage are used. Removing one duplicate keeps the shared
+code slot; the slot is reclaimed after its last logical reference is removed.
+
 The following operations and configurations are not supported while storage deduplication
 is enabled:
 
-- force removal (`support_force_remove: true`);
 - cache-assisted build after `ImportCache()`;
 - `Merge`;
 - legacy v0.14 serialization.

--- a/docs/docs/zh/src/indexes/hgraph.md
+++ b/docs/docs/zh/src/indexes/hgraph.md
@@ -98,9 +98,12 @@ auto result = index->KnnSearch(
 同一个物理编码槽位，但仍保留各自的标签。该选项目前仅支持使用 `graph_type: "nsw"` 的
 稠密向量 HGraph 索引；独立的 HNSW 索引以及 `graph_type: "odescent"` 均不支持。
 
+使用 flat 图存储并设置 `support_force_remove: true`、`use_reverse_edges: true` 时，支持
+`RemoveMode::FORCE_REMOVE`。删除单个重复向量时会保留共享编码槽位；最后一个逻辑引用被
+删除后才回收该槽位。
+
 启用存储去重后，暂不支持以下操作和配置：
 
-- 强制删除（`support_force_remove: true`）；
 - 调用 `ImportCache()` 后基于缓存加速构建；
 - `Merge`；
 - v0.14 旧版序列化格式。

--- a/src/algorithm/hgraph/hgraph.cpp
+++ b/src/algorithm/hgraph/hgraph.cpp
@@ -132,6 +132,10 @@ HGraph::HGraph(const HGraphParameterPtr& hgraph_param, const vsag::IndexCommonPa
 
 bool
 HGraph::Tune(const std::string& parameters, bool disable_future_tuning) {
+    std::shared_lock<std::shared_mutex> force_remove_rlock;
+    if (this->using_dedup_storage() && this->support_force_remove()) {
+        force_remove_rlock = std::shared_lock<std::shared_mutex>(this->force_remove_mutex_);
+    }
     std::scoped_lock lock(this->add_mutex_);
     if (this->immutable_.load(std::memory_order_acquire) or
         not this->index_feature_list_->CheckFeature(IndexFeature::SUPPORT_TUNE)) {

--- a/src/algorithm/hgraph/hgraph.h
+++ b/src/algorithm/hgraph/hgraph.h
@@ -612,6 +612,26 @@ private:
     void
     move_id(InnerIdType from, InnerIdType to);
 
+    /// Move only graph-node identity across all layers, including the entry point.
+    void
+    move_graph_id(InnerIdType from, InnerIdType to);
+
+    /// Move logical metadata without touching graph nodes or physical vector codes.
+    void
+    move_logical_metadata(InnerIdType from, InnerIdType to);
+
+    /// Preserve canonical duplicate-group graph representatives for a deduplicated removal.
+    void
+    update_graphs_for_deduplicated_remove(InnerIdType inner_id, InnerIdType swap_id);
+
+    /// Compact physical code slots after a batch of deduplicated logical removals.
+    void
+    compact_deduplicated_codes();
+
+    /// Restore non-persisted reverse edges required by deduplicated force removal.
+    void
+    rebuild_reverse_edges_for_deduplicated_force_remove();
+
     /// Compact internal storage after deletions.
     void
     shrink_to_fit();

--- a/src/algorithm/hgraph/hgraph_add_test.cpp
+++ b/src/algorithm/hgraph/hgraph_add_test.cpp
@@ -603,6 +603,156 @@ TEST_CASE("HGraph deduplicate_storage handles duplicate chains", "[ut][hgraph][d
     }
 }
 
+TEST_CASE("HGraph deduplicate_storage ForceRemove preserves groups and compacts code slots",
+          "[ut][hgraph][duplicate][force_remove][serialize]") {
+    constexpr int64_t dim = 2;
+    auto common_param = MakeCommonParam(dim);
+    auto hgraph_json = MakeFp32HGraphJson();
+    hgraph_json["support_force_remove"].SetBool(true);
+    hgraph_json["use_reverse_edges"].SetBool(true);
+    auto index = MakeHGraphIndex(hgraph_json, common_param);
+
+    std::vector<float> vectors = {
+        0.0F,
+        0.0F,
+        10.0F,
+        0.0F,
+        10.0F,
+        0.0F,
+        20.0F,
+        0.0F,
+        20.0F,
+        0.0F,
+    };
+    std::vector<int64_t> ids = {10, 20, 21, 30, 31};
+    auto base = MakeFloatDataset(vectors, ids, dim, 5);
+    REQUIRE(index->Build(base).has_value());
+
+    auto require_counts = [](const std::shared_ptr<vsag::IndexImpl<vsag::HGraph>>& target,
+                             vsag::InnerIdType logical_count,
+                             vsag::CodeSlotIdType physical_count) {
+        auto hgraph = std::dynamic_pointer_cast<vsag::HGraph>(target->GetInnerIndex());
+        REQUIRE(hgraph != nullptr);
+        REQUIRE(hgraph->GetCodeStorageCounts() ==
+                std::pair<vsag::InnerIdType, vsag::CodeSlotIdType>{logical_count, physical_count});
+    };
+    auto require_graph_result = [](const std::shared_ptr<vsag::IndexImpl<vsag::HGraph>>& target,
+                                   std::vector<float>& query_vector,
+                                   std::initializer_list<int64_t> expected_ids) {
+        auto query = MakeFloatQuery(query_vector, dim);
+        auto result = target->KnnSearch(query, 1, R"({"hgraph": {"ef_search": 32}})");
+        REQUIRE(result.has_value());
+        REQUIRE(result.value()->GetDim() == 1);
+        const auto result_id = result.value()->GetIds()[0];
+        REQUIRE(std::find(expected_ids.begin(), expected_ids.end(), result_id) !=
+                expected_ids.end());
+    };
+    auto force_remove = [](const std::shared_ptr<vsag::IndexImpl<vsag::HGraph>>& target,
+                           int64_t id) {
+        auto result = target->Remove({id}, vsag::RemoveMode::FORCE_REMOVE);
+        REQUIRE(result.has_value());
+        REQUIRE(result.value() == 1);
+    };
+
+    std::vector<float> vector_b = {10.0F, 0.0F};
+    std::vector<float> vector_c = {20.0F, 0.0F};
+    require_counts(index, 5, 3);
+
+    // The last logical ID belongs to group C. Moving it into ID 0 also makes ID 0 the new graph
+    // representative for C, while physical slot 2 is compacted into the released slot 0.
+    force_remove(index, 10);
+    require_counts(index, 4, 2);
+    require_graph_result(index, vector_c, {30, 31});
+    auto query_c = MakeFloatQuery(vector_c, dim);
+    RequireRangeContains(index, query_c, {30, 31}, 2, 0.01F, kBruteForceSearchParams);
+
+    // Removing the representative with the last ID from the same group keeps the graph node at
+    // the compacted logical ID and only removes one logical binding.
+    force_remove(index, 31);
+    require_counts(index, 3, 2);
+    require_graph_result(index, vector_c, {30});
+
+    auto binary = index->Serialize();
+    REQUIRE(binary.has_value());
+    auto restored = MakeHGraphIndex(hgraph_json, common_param);
+    REQUIRE(restored->Deserialize(binary.value()).has_value());
+    require_counts(restored, 3, 2);
+    require_graph_result(restored, vector_c, {30});
+
+    // Removing the last reference to C reclaims its physical slot. Group B's last duplicate moves
+    // into the hole and becomes the new canonical graph representative.
+    force_remove(restored, 30);
+    require_counts(restored, 2, 1);
+    require_graph_result(restored, vector_b, {20, 21});
+    auto query_b = MakeFloatQuery(vector_b, dim);
+    RequireRangeContains(restored, query_b, {20, 21}, 2, 0.01F, kBruteForceSearchParams);
+
+    std::vector<float> add_vectors = {
+        10.0F,
+        0.0F,
+        30.0F,
+        0.0F,
+    };
+    std::vector<int64_t> add_ids = {40, 50};
+    auto add = MakeFloatDataset(add_vectors, add_ids, dim, 2);
+    REQUIRE(restored->Add(add).has_value());
+    require_counts(restored, 4, 2);
+    RequireRangeContains(restored, query_b, {20, 21, 40}, 3, 0.01F, kBruteForceSearchParams);
+
+    // The removed representative's group survives at its next canonical ID, while the last
+    // unique point moves into the logical hole.
+    force_remove(restored, 21);
+    require_counts(restored, 3, 2);
+    require_graph_result(restored, vector_b, {20, 40});
+    RequireRangeContains(restored, query_b, {20, 40}, 2, 0.01F, kBruteForceSearchParams);
+}
+
+TEST_CASE("HGraph deduplicate_storage rebuilds reverse edges before ForceRemove",
+          "[ut][hgraph][duplicate][force_remove][serialize]") {
+    constexpr int64_t dim = 2;
+    auto common_param = MakeCommonParam(dim);
+    auto hgraph_json = MakeFp32HGraphJson();
+    hgraph_json["support_force_remove"].SetBool(true);
+    hgraph_json["use_reverse_edges"].SetBool(true);
+
+    std::vector<float> vectors = {
+        0.0F,
+        0.0F,
+        0.0F,
+        0.0F,
+        10.0F,
+        0.0F,
+        20.0F,
+        0.0F,
+        30.0F,
+        0.0F,
+    };
+    std::vector<int64_t> ids = {10, 11, 20, 30, 40};
+    auto base = MakeFloatDataset(vectors, ids, dim, 5);
+    auto index = MakeHGraphIndex(hgraph_json, common_param);
+    REQUIRE(index->Build(base).has_value());
+
+    auto binary = index->Serialize();
+    REQUIRE(binary.has_value());
+    auto restored = MakeHGraphIndex(hgraph_json, common_param);
+    REQUIRE(restored->Deserialize(binary.value()).has_value());
+
+    // Removing the restored duplicate group's representative moves its graph node from 0 to 1.
+    // The last unique graph node then moves from 4 to 0, requiring restored incoming edges.
+    auto remove_result = restored->Remove({10}, vsag::RemoveMode::FORCE_REMOVE);
+    REQUIRE(remove_result.has_value());
+    REQUIRE(remove_result.value() == 1);
+
+    std::vector<float> query_vector = {30.0F, 0.0F};
+    auto query = MakeFloatQuery(query_vector, dim);
+    auto result = restored->KnnSearch(query, 4, R"({"hgraph": {"ef_search": 32}})");
+    REQUIRE(result.has_value());
+    REQUIRE(result.value()->GetDim() == 4);
+    for (const auto expected_id : std::vector<int64_t>{11, 20, 30, 40}) {
+        REQUIRE(ResultContainsId(result.value(), expected_id));
+    }
+}
+
 TEST_CASE("HGraph deduplicate_storage skips duplicate external labels without binding storage",
           "[ut][hgraph][duplicate][label][add]") {
     constexpr int64_t dim = 2;
@@ -749,6 +899,8 @@ TEST_CASE("HGraph deduplicate_storage supports precise reorder code path",
     constexpr int64_t dim = 4;
     auto common_param = MakeCommonParam(dim);
     auto hgraph_json = MakeFp32ReorderHGraphJson();
+    hgraph_json["support_force_remove"].SetBool(true);
+    hgraph_json["use_reverse_edges"].SetBool(true);
     auto index = MakeHGraphIndex(hgraph_json, common_param);
 
     std::vector<float> base_vectors = {
@@ -779,6 +931,20 @@ TEST_CASE("HGraph deduplicate_storage supports precise reorder code path",
     REQUIRE(knn.value()->GetDim() == 2);
     REQUIRE(ResultContainsId(knn.value(), 20));
     REQUIRE(ResultContainsId(knn.value(), 30));
+
+    auto remove_result = index->Remove({10}, vsag::RemoveMode::FORCE_REMOVE);
+    REQUIRE(remove_result.has_value());
+    REQUIRE(remove_result.value() == 1);
+    auto hgraph = std::dynamic_pointer_cast<vsag::HGraph>(index->GetInnerIndex());
+    REQUIRE(hgraph != nullptr);
+    REQUIRE(hgraph->GetCodeStorageCounts() ==
+            std::pair<vsag::InnerIdType, vsag::CodeSlotIdType>{2, 1});
+    auto base_distance = index->CalcDistanceById(duplicate_vector.data(), 20, false);
+    auto precise_distance = index->CalcDistanceById(duplicate_vector.data(), 20, true);
+    REQUIRE(base_distance.has_value());
+    REQUIRE(precise_distance.has_value());
+    REQUIRE(base_distance.value() == 0.0F);
+    REQUIRE(precise_distance.value() == 0.0F);
 }
 
 TEST_CASE("HGraph deduplicate_storage supports RabitQ raw-vector graph read path",
@@ -786,6 +952,8 @@ TEST_CASE("HGraph deduplicate_storage supports RabitQ raw-vector graph read path
     constexpr int64_t dim = 960;
     auto common_param = MakeCommonParam(dim);
     auto hgraph_json = MakeRabitQRawVectorHGraphJson();
+    hgraph_json["support_force_remove"].SetBool(true);
+    hgraph_json["use_reverse_edges"].SetBool(true);
     auto index = MakeHGraphIndex(hgraph_json, common_param);
 
     std::vector<float> base_vectors(dim * 3);
@@ -818,12 +986,30 @@ TEST_CASE("HGraph deduplicate_storage supports RabitQ raw-vector graph read path
     auto unique_distance = index->CalcDistanceById(unique_vector.data(), unique_id[0]);
     REQUIRE(unique_distance.has_value());
     REQUIRE(unique_distance.value() == 0.0F);
+    auto original_base_distance =
+        index->CalcDistanceById(unique_vector.data(), unique_id[0], false);
+    REQUIRE(original_base_distance.has_value());
 
     auto duplicate_query = MakeFloatQuery(duplicate_vector, dim);
     RequireRangeContains(index, duplicate_query, {20, 40}, 2, 0.01F, kBruteForceSearchParams);
 
     auto unique_query = MakeFloatQuery(unique_vector, dim);
     RequireRangeContains(index, unique_query, {50}, 1, 0.01F, kBruteForceSearchParams);
+
+    auto remove_result = index->Remove({10}, vsag::RemoveMode::FORCE_REMOVE);
+    REQUIRE(remove_result.has_value());
+    REQUIRE(remove_result.value() == 1);
+    auto hgraph = std::dynamic_pointer_cast<vsag::HGraph>(index->GetInnerIndex());
+    REQUIRE(hgraph != nullptr);
+    REQUIRE(hgraph->GetCodeStorageCounts() ==
+            std::pair<vsag::InnerIdType, vsag::CodeSlotIdType>{4, 3});
+    auto compacted_base_distance =
+        index->CalcDistanceById(unique_vector.data(), unique_id[0], false);
+    auto compacted_raw_distance = index->CalcDistanceById(unique_vector.data(), unique_id[0], true);
+    REQUIRE(compacted_base_distance.has_value());
+    REQUIRE(compacted_raw_distance.has_value());
+    REQUIRE(compacted_base_distance.value() == original_base_distance.value());
+    REQUIRE(compacted_raw_distance.value() == 0.0F);
 }
 
 TEST_CASE("HGraph deduplicate_storage Tune keeps physical slots isolated",

--- a/src/algorithm/hgraph/hgraph_build.cpp
+++ b/src/algorithm/hgraph/hgraph_build.cpp
@@ -627,6 +627,9 @@ HGraph::publish_unique_storage_if_needed(const void* data,
     if (not context.use_dedup_storage) {
         return;
     }
+    if (this->support_force_remove()) {
+        this->ensure_physical_code_capacity_unlocked(this->code_slot_map_->PhysicalCount() + 1);
+    }
     auto code_slot_id = this->code_slot_map_->AllocateSlot();
     this->ensure_physical_code_capacity_unlocked(code_slot_id + 1);
     this->insert_persistent_codes_to_slot(data, code_slot_id);
@@ -640,6 +643,14 @@ HGraph::publish_unique_storage_if_needed(const void* data,
                                          std::shared_lock<std::shared_mutex>& read_lock) {
     if (not context.use_dedup_storage) {
         return;
+    }
+    if (this->support_force_remove()) {
+        const auto required_capacity = this->code_slot_map_->PhysicalCount() + 1;
+        if (this->physical_code_capacity_.load(std::memory_order_acquire) < required_capacity) {
+            read_lock.unlock();
+            this->ensure_physical_code_capacity(required_capacity);
+            read_lock.lock();
+        }
     }
     auto code_slot_id = this->code_slot_map_->AllocateSlot();
     if (this->physical_code_capacity_.load(std::memory_order_acquire) < code_slot_id + 1) {
@@ -834,6 +845,9 @@ HGraph::ensure_physical_code_capacity_unlocked(CodeSlotIdType required_capacity)
 
     auto new_capacity = static_cast<InnerIdType>(
         next_multiple_of_power_of_two(required_capacity, this->resize_increase_count_bit_));
+    if (this->support_force_remove()) {
+        this->code_slot_map_->ReserveLogicalSize(new_capacity);
+    }
     GetCodeSlotPhysicalFlatten(this->basic_flatten_codes_)->Resize(new_capacity);
     if (has_precise_reorder()) {
         GetCodeSlotPhysicalFlatten(this->high_precise_codes_)->Resize(new_capacity);

--- a/src/algorithm/hgraph/hgraph_modify.cpp
+++ b/src/algorithm/hgraph/hgraph_modify.cpp
@@ -14,6 +14,7 @@
 
 #include <new>
 
+#include "datacell/dense_duplicate_tracker.h"
 #include "hgraph.h"  // IWYU pragma: keep
 #include "impl/pruning_strategy.h"
 #include "utils/util_functions.h"
@@ -34,6 +35,10 @@ HGraph::Remove(const std::vector<int64_t>& ids, RemoveMode mode) {
         CHECK_ARGUMENT(this->support_force_remove(),
                        "force remove requires index_param.support_force_remove to be true");
         std::unique_lock<std::shared_mutex> wlock(this->force_remove_mutex_);
+        std::unique_lock<std::shared_mutex> dedup_storage_lock;
+        if (this->using_dedup_storage()) {
+            dedup_storage_lock = std::unique_lock<std::shared_mutex>(this->global_mutex_);
+        }
         for (const auto& id : ids) {
             delete_count += this->force_remove_one(id);
         }
@@ -47,6 +52,9 @@ HGraph::Remove(const std::vector<int64_t>& ids, RemoveMode mode) {
                 // Deletion has already completed; compaction is best effort when memory is exhausted.
             } catch (const std::bad_alloc&) {
                 // SafeAllocator reports failed storage shrinking as std::bad_alloc.
+            }
+            if (this->using_dedup_storage()) {
+                this->cal_memory_usage();
             }
         }
         return delete_count;
@@ -164,6 +172,86 @@ HGraph::move_id(InnerIdType from, InnerIdType to) {
     }
 }
 
+void
+HGraph::move_graph_id(InnerIdType from, InnerIdType to) {
+    if (from == to) {
+        return;
+    }
+
+    bottom_graph_->Move(from, to);
+    for (const auto& route_graph : route_graphs_) {
+        route_graph->Move(from, to);
+    }
+    if (entry_point_id_ == from) {
+        entry_point_id_ = to;
+    }
+}
+
+void
+HGraph::move_logical_metadata(InnerIdType from, InnerIdType to) {
+    if (extra_infos_) {
+        extra_infos_->Move(from, to);
+    }
+    label_table_->Move(from, to);
+}
+
+void
+HGraph::update_graphs_for_deduplicated_remove(InnerIdType inner_id, InnerIdType swap_id) {
+    auto tracker = this->bottom_graph_->GetDuplicateTracker();
+    if (tracker == nullptr) {
+        throw VsagException(ErrorType::INTERNAL_ERROR,
+                            "deduplicated HGraph force remove requires a duplicate tracker");
+    }
+
+    const auto removed_representative = tracker->GetGroupId(inner_id);
+    const auto swap_representative = tracker->GetGroupId(swap_id);
+    const auto removed_duplicates = tracker->GetDuplicateIds(inner_id);
+    const bool same_group = removed_representative == swap_representative;
+    const bool removed_group_is_singleton = removed_duplicates.empty();
+    const bool removed_entry_point = entry_point_id_ == inner_id;
+
+    const auto graph_repair_codes = this->get_precise_codes();
+    auto remove_graph_id = [this, &graph_repair_codes](InnerIdType id) {
+        if (id == this->entry_point_id_) {
+            this->find_new_entry_point();
+        }
+        this->graph_force_remove_one(id, graph_repair_codes, this->bottom_graph_);
+        for (const auto& route_graph : this->route_graphs_) {
+            this->graph_force_remove_one(id, graph_repair_codes, route_graph);
+        }
+    };
+
+    if (same_group) {
+        if (removed_group_is_singleton) {
+            remove_graph_id(inner_id);
+        }
+    } else {
+        if (removed_representative == inner_id) {
+            if (removed_group_is_singleton) {
+                remove_graph_id(inner_id);
+            } else {
+                const auto new_representative =
+                    *std::min_element(removed_duplicates.begin(), removed_duplicates.end());
+                this->move_graph_id(inner_id, new_representative);
+            }
+        }
+
+        if (inner_id < swap_representative) {
+            this->move_graph_id(swap_representative, inner_id);
+        }
+    }
+
+    if (removed_group_is_singleton && removed_entry_point && entry_point_id_ == inner_id) {
+        if (swap_id != inner_id) {
+            entry_point_id_ = std::min(inner_id, swap_representative);
+        } else if (inner_id > 0) {
+            entry_point_id_ = tracker->GetGroupId(0);
+        } else {
+            entry_point_id_ = INVALID_ENTRY_POINT;
+        }
+    }
+}
+
 uint32_t
 HGraph::force_remove_one(int64_t label) {
     InnerIdType inner_id;
@@ -175,16 +263,18 @@ HGraph::force_remove_one(int64_t label) {
             return 0;
         }
     }
-    if (inner_id == this->entry_point_id_) {
-        this->find_new_entry_point();
-    }
-
-    graph_force_remove_one(inner_id, basic_flatten_codes_, bottom_graph_);
-
-    for (const auto& route_graph : route_graphs_) {
-        graph_force_remove_one(inner_id, basic_flatten_codes_, route_graph);
-    }
     InnerIdType swap_id = this->total_count_.load() - 1;
+    if (this->using_dedup_storage()) {
+        this->update_graphs_for_deduplicated_remove(inner_id, swap_id);
+    } else {
+        if (inner_id == this->entry_point_id_) {
+            this->find_new_entry_point();
+        }
+        graph_force_remove_one(inner_id, basic_flatten_codes_, bottom_graph_);
+        for (const auto& route_graph : route_graphs_) {
+            graph_force_remove_one(inner_id, basic_flatten_codes_, route_graph);
+        }
+    }
 
     bool was_mark_removed = false;
     {
@@ -192,7 +282,22 @@ HGraph::force_remove_one(int64_t label) {
         was_mark_removed = this->label_table_->IsRemoved(inner_id);
         this->label_table_->ForceRemove(label, inner_id);
         if (swap_id != inner_id) {
-            this->move_id(swap_id, inner_id);
+            if (this->using_dedup_storage()) {
+                this->move_logical_metadata(swap_id, inner_id);
+            } else {
+                this->move_id(swap_id, inner_id);
+            }
+        }
+        if (this->using_dedup_storage()) {
+            auto tracker = std::dynamic_pointer_cast<DenseDuplicateTracker>(
+                this->bottom_graph_->GetDuplicateTracker());
+            if (tracker == nullptr) {
+                throw VsagException(
+                    ErrorType::INTERNAL_ERROR,
+                    "deduplicated HGraph force remove requires a dense duplicate tracker");
+            }
+            tracker->RemoveAndSwapLast(inner_id, swap_id);
+            this->code_slot_map_->RemoveAndSwapLast(inner_id, swap_id);
         }
     }
     if (was_mark_removed) {
@@ -203,12 +308,48 @@ HGraph::force_remove_one(int64_t label) {
 }
 
 void
+HGraph::compact_deduplicated_codes() {
+    std::unique_lock<std::shared_mutex> codes_lock(this->persistent_codes_mutex_);
+    const auto physical_count =
+        this->code_slot_map_->CompactSlots([this](CodeSlotIdType from, CodeSlotIdType to) {
+            GetCodeSlotPhysicalFlatten(this->basic_flatten_codes_)->Move(from, to);
+            if (this->has_precise_reorder()) {
+                GetCodeSlotPhysicalFlatten(this->high_precise_codes_)->Move(from, to);
+            }
+            if (this->create_new_raw_vector_) {
+                GetCodeSlotPhysicalFlatten(this->raw_vector_)->Move(from, to);
+            }
+        });
+
+    GetCodeSlotPhysicalFlatten(this->basic_flatten_codes_)->SetTotalCount(physical_count);
+    if (this->has_precise_reorder()) {
+        GetCodeSlotPhysicalFlatten(this->high_precise_codes_)->SetTotalCount(physical_count);
+    }
+    if (this->create_new_raw_vector_) {
+        GetCodeSlotPhysicalFlatten(this->raw_vector_)->SetTotalCount(physical_count);
+    }
+    this->physical_code_capacity_.store(physical_count, std::memory_order_release);
+}
+
+void
 HGraph::shrink_to_fit() {
     auto total_count = this->total_count_.load();
 
-    basic_flatten_codes_->ShrinkToFit(total_count);
-    if (high_precise_codes_) {
-        high_precise_codes_->ShrinkToFit(total_count);
+    if (this->using_dedup_storage()) {
+        this->compact_deduplicated_codes();
+        const auto physical_count = this->code_slot_map_->PhysicalCount();
+        GetCodeSlotPhysicalFlatten(this->basic_flatten_codes_)->ShrinkToFit(physical_count);
+        if (this->has_precise_reorder()) {
+            GetCodeSlotPhysicalFlatten(this->high_precise_codes_)->ShrinkToFit(physical_count);
+        }
+        if (this->create_new_raw_vector_) {
+            GetCodeSlotPhysicalFlatten(this->raw_vector_)->ShrinkToFit(physical_count);
+        }
+    } else {
+        basic_flatten_codes_->ShrinkToFit(total_count);
+        if (high_precise_codes_) {
+            high_precise_codes_->ShrinkToFit(total_count);
+        }
     }
     bottom_graph_->ShrinkToFit(total_count);
     for (const auto& route_graph : route_graphs_) {

--- a/src/algorithm/hgraph/hgraph_parameter.cpp
+++ b/src/algorithm/hgraph/hgraph_parameter.cpp
@@ -160,11 +160,16 @@ HGraphParameter::FromJson(const JsonType& json) {
     if (json.Contains(SUPPORT_FORCE_REMOVE)) {
         this->support_force_remove = json[SUPPORT_FORCE_REMOVE].GetBool();
     }
-    if (this->deduplicate_storage && this->support_force_remove) {
+    const bool deduplicated_force_remove = this->deduplicate_storage && this->support_force_remove;
+    if (deduplicated_force_remove && this->bottom_graph_param->graph_storage_type_ !=
+                                         GraphStorageTypes::GRAPH_STORAGE_TYPE_VALUE_FLAT) {
+        throw VsagException(ErrorType::INVALID_ARGUMENT,
+                            "deduplicate_storage force remove only supports flat graph storage");
+    }
+    if (deduplicated_force_remove && not this->bottom_graph_param->use_reverse_edges_) {
         throw VsagException(
             ErrorType::INVALID_ARGUMENT,
-            "deduplicate_storage does not support force remove because duplicate groups share "
-            "physical vector slots");
+            "deduplicate_storage force remove requires use_reverse_edges to be true");
     }
     if (json.Contains(HGRAPH_PERSIST_SOURCE_ID_KEY)) {
         this->persist_source_id = json[HGRAPH_PERSIST_SOURCE_ID_KEY].GetBool();

--- a/src/algorithm/hgraph/hgraph_parameter_test.cpp
+++ b/src/algorithm/hgraph/hgraph_parameter_test.cpp
@@ -277,7 +277,7 @@ TEST_CASE("HGraph rejects deduplicate_storage without support_duplicate", "[ut][
     REQUIRE_THROWS(vsag::HGraph::CheckAndMappingExternalParam(param, common_param));
 }
 
-TEST_CASE("HGraph rejects deduplicate_storage with force remove", "[ut][HGraphParameter]") {
+TEST_CASE("HGraph supports deduplicate_storage with force remove", "[ut][HGraphParameter]") {
     auto param = vsag::JsonType::Parse(R"({
         "base_quantization_type": "fp32",
         "base_io_type": "block_memory_io",
@@ -291,7 +291,52 @@ TEST_CASE("HGraph rejects deduplicate_storage with force remove", "[ut][HGraphPa
         "support_duplicate": true,
         "deduplicate_storage": true,
         "support_force_remove": true,
+        "use_reverse_edges": true,
         "use_reorder": true
+    })");
+
+    vsag::IndexCommonParam common_param;
+    common_param.dim_ = 128;
+    common_param.data_type_ = vsag::DataTypes::DATA_TYPE_FLOAT;
+    auto result = vsag::HGraph::CheckAndMappingExternalParam(param, common_param);
+    auto hgraph_param = std::dynamic_pointer_cast<vsag::HGraphParameter>(result);
+    REQUIRE(hgraph_param != nullptr);
+    REQUIRE(hgraph_param->deduplicate_storage);
+    REQUIRE(hgraph_param->support_force_remove);
+}
+
+TEST_CASE("HGraph rejects deduplicate_storage force remove without reverse edges",
+          "[ut][HGraphParameter]") {
+    auto param = vsag::JsonType::Parse(R"({
+        "base_quantization_type": "fp32",
+        "base_io_type": "block_memory_io",
+        "graph_storage_type": "flat",
+        "graph_type": "nsw",
+        "max_degree": 32,
+        "ef_construction": 100,
+        "support_duplicate": true,
+        "deduplicate_storage": true,
+        "support_force_remove": true
+    })");
+
+    vsag::IndexCommonParam common_param;
+    common_param.dim_ = 128;
+    common_param.data_type_ = vsag::DataTypes::DATA_TYPE_FLOAT;
+    REQUIRE_THROWS(vsag::HGraph::CheckAndMappingExternalParam(param, common_param));
+}
+
+TEST_CASE("HGraph rejects deduplicate_storage force remove with compressed graph",
+          "[ut][HGraphParameter]") {
+    auto param = vsag::JsonType::Parse(R"({
+        "base_quantization_type": "fp32",
+        "base_io_type": "block_memory_io",
+        "graph_storage_type": "compressed",
+        "graph_type": "nsw",
+        "max_degree": 32,
+        "ef_construction": 100,
+        "support_duplicate": true,
+        "deduplicate_storage": true,
+        "support_force_remove": true
     })");
 
     vsag::IndexCommonParam common_param;

--- a/src/algorithm/hgraph/hgraph_serialize.cpp
+++ b/src/algorithm/hgraph/hgraph_serialize.cpp
@@ -897,10 +897,24 @@ HGraph::read_streaming_body(StreamReader& reader,
     if (this->raw_vector_ != nullptr) {
         this->has_raw_vector_ = true;
     }
+    this->rebuild_reverse_edges_for_deduplicated_force_remove();
     this->cal_memory_usage();
 
     if (use_elp_optimizer_) {
         elp_optimize();
+    }
+}
+
+void
+HGraph::rebuild_reverse_edges_for_deduplicated_force_remove() {
+    if (not this->using_dedup_storage() or not this->support_force_remove()) {
+        return;
+    }
+
+    const auto total_count = this->total_count_.load(std::memory_order_acquire);
+    this->bottom_graph_->RebuildReverseEdges(total_count);
+    for (const auto& route_graph : this->route_graphs_) {
+        route_graph->RebuildReverseEdges(total_count);
     }
 }
 
@@ -1069,6 +1083,7 @@ HGraph::Deserialize(StreamReader& reader) {
             (void)this->code_slot_map_->Resolve(inner_id);
         }
     }
+    this->rebuild_reverse_edges_for_deduplicated_force_remove();
     this->cal_memory_usage();
 
     // post serialize procedure

--- a/src/datacell/code_slot_map.cpp
+++ b/src/datacell/code_slot_map.cpp
@@ -16,6 +16,7 @@
 
 #include <fmt/format.h>
 
+#include <algorithm>
 #include <limits>
 #include <mutex>
 #include <new>
@@ -133,6 +134,80 @@ CodeSlotMap::ReserveLogicalSize(InnerIdType new_size) {
     this->EnsureLogicalSize(new_size);
 }
 
+void
+CodeSlotMap::RemoveAndSwapLast(InnerIdType removed_id, InnerIdType last_id) {
+    std::unique_lock lock(mutex_);
+
+    auto published_count = published_logical_count_.load(std::memory_order_acquire);
+    CHECK_ARGUMENT(  // NOLINT(readability-simplify-boolean-expr)
+        published_count > 0 && last_id == published_count - 1,
+        fmt::format(
+            "last_id({}) must be the last of {} published logical ids", last_id, published_count));
+    CHECK_ARGUMENT(removed_id <= last_id,
+                   fmt::format("removed_id({}) must not exceed last_id({})", removed_id, last_id));
+
+    auto removed_slot = inner_to_slot_[removed_id].load(std::memory_order_acquire);
+    auto last_slot = inner_to_slot_[last_id].load(std::memory_order_acquire);
+    CHECK_ARGUMENT(removed_slot != INVALID_CODE_SLOT,
+                   fmt::format("removed_id({}) has no bound code slot", removed_id));
+    CHECK_ARGUMENT(last_slot != INVALID_CODE_SLOT,
+                   fmt::format("last_id({}) has no bound code slot", last_id));
+
+    if (removed_id != last_id) {
+        inner_to_slot_[removed_id].store(last_slot, std::memory_order_release);
+    }
+    inner_to_slot_[last_id].store(INVALID_CODE_SLOT, std::memory_order_release);
+    published_logical_count_.fetch_sub(1, std::memory_order_acq_rel);
+}
+
+CodeSlotIdType
+CodeSlotMap::CompactSlots(const std::function<void(CodeSlotIdType, CodeSlotIdType)>& move_slot) {
+    std::unique_lock lock(mutex_);
+
+    const auto physical_count = physical_count_.load(std::memory_order_acquire);
+    const auto logical_count = published_logical_count_.load(std::memory_order_acquire);
+    Vector<CodeSlotIdType> slot_remap(physical_count, INVALID_CODE_SLOT, allocator_);
+    CodeSlotIdType referenced_count = 0;
+    for (InnerIdType inner_id = 0; inner_id < logical_count; ++inner_id) {
+        const auto slot = inner_to_slot_[inner_id].load(std::memory_order_acquire);
+        CHECK_ARGUMENT(slot < physical_count,
+                       fmt::format("inner_id({}) has invalid code slot {} for physical count {}",
+                                   inner_id,
+                                   slot,
+                                   physical_count));
+        if (slot_remap[slot] == INVALID_CODE_SLOT) {
+            slot_remap[slot] = slot;
+            ++referenced_count;
+        }
+    }
+
+    CodeSlotIdType source = physical_count;
+    for (CodeSlotIdType target = 0; target < referenced_count; ++target) {
+        if (slot_remap[target] != INVALID_CODE_SLOT) {
+            continue;
+        }
+        do {
+            --source;
+        } while (source >= referenced_count && slot_remap[source] == INVALID_CODE_SLOT);
+        CHECK_ARGUMENT(source >= referenced_count,
+                       "failed to find a referenced tail code slot during compaction");
+        move_slot(source, target);
+        slot_remap[source] = target;
+    }
+
+    for (InnerIdType inner_id = 0; inner_id < logical_count; ++inner_id) {
+        const auto old_slot = inner_to_slot_[inner_id].load(std::memory_order_acquire);
+        const auto new_slot = slot_remap[old_slot];
+        CHECK_ARGUMENT(new_slot != INVALID_CODE_SLOT,
+                       fmt::format("inner_id({}) lost its code slot during compaction", inner_id));
+        if (new_slot != old_slot) {
+            inner_to_slot_[inner_id].store(new_slot, std::memory_order_release);
+        }
+    }
+    physical_count_.store(referenced_count, std::memory_order_release);
+    return referenced_count;
+}
+
 CodeSlotIdType
 CodeSlotMap::PhysicalCount() const {
     return physical_count_.load(std::memory_order_acquire);
@@ -156,6 +231,8 @@ CodeSlotMap::Serialize(StreamWriter& writer) const {
         }
         --serialized_slot_count;
     }
+    serialized_slot_count =
+        std::max(serialized_slot_count, static_cast<InnerIdType>(physical_count));
     Vector<CodeSlotIdType> slots(allocator_);
     slots.resize(serialized_slot_count);
     for (InnerIdType inner_id = 0; inner_id < serialized_slot_count; ++inner_id) {

--- a/src/datacell/code_slot_map.h
+++ b/src/datacell/code_slot_map.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <atomic>
+#include <functional>
 #include <shared_mutex>
 
 #include "basic_types.h"
@@ -58,6 +59,25 @@ public:
 
     void
     ReserveLogicalSize(InnerIdType new_size);
+
+    /**
+     * Remove one active logical ID and move the last active logical binding into its position.
+     *
+     * Physical slots are left untouched so a batch of logical removals can compact them once.
+     */
+    void
+    RemoveAndSwapLast(InnerIdType removed_id, InnerIdType last_id);
+
+    /**
+     * Compact referenced physical slots into a dense prefix.
+     *
+     * move_slot is called before bindings are changed. Its source slots remain intact and its
+     * destination slots are unreferenced, so an exception leaves every published binding valid.
+     *
+     * @return The number of referenced physical slots after compaction.
+     */
+    CodeSlotIdType
+    CompactSlots(const std::function<void(CodeSlotIdType, CodeSlotIdType)>& move_slot);
 
     [[nodiscard]] CodeSlotIdType
     PhysicalCount() const;

--- a/src/datacell/code_slot_map_test.cpp
+++ b/src/datacell/code_slot_map_test.cpp
@@ -237,6 +237,91 @@ TEST_CASE("CodeSlotMap rejects invalid mappings", "[ut][datacell][code_slot_map]
     REQUIRE_THROWS(mapping.PublishSlot(1, slot + 1));
 }
 
+TEST_CASE("CodeSlotMap compacts logical and physical slots", "[ut][datacell][code_slot_map]") {
+    auto allocator = vsag::SafeAllocator::FactoryDefaultAllocator();
+    vsag::CodeSlotMap mapping(allocator.get());
+
+    mapping.ReserveLogicalSize(6);
+    mapping.PublishSlot(0, mapping.AllocateSlot());
+    auto shared_slot1 = mapping.AllocateSlot();
+    mapping.PublishSlot(1, shared_slot1);
+    mapping.PublishSlot(2, shared_slot1);
+    mapping.PublishSlot(3, mapping.AllocateSlot());
+    auto shared_slot3 = mapping.AllocateSlot();
+    mapping.PublishSlot(4, shared_slot3);
+    mapping.PublishSlot(5, shared_slot3);
+
+    mapping.RemoveAndSwapLast(0, 5);
+    mapping.RemoveAndSwapLast(3, 4);
+
+    std::vector<std::pair<vsag::CodeSlotIdType, vsag::CodeSlotIdType>> moves;
+    auto physical_count =
+        mapping.CompactSlots([&moves](vsag::CodeSlotIdType from, vsag::CodeSlotIdType to) {
+            moves.emplace_back(from, to);
+        });
+
+    REQUIRE(mapping.PublishedLogicalCount() == 4);
+    REQUIRE(physical_count == 2);
+    REQUIRE(mapping.PhysicalCount() == 2);
+    REQUIRE(moves ==
+            std::vector<std::pair<vsag::CodeSlotIdType, vsag::CodeSlotIdType>>{{shared_slot3, 0}});
+    REQUIRE(mapping.Resolve(0) == 0);
+    REQUIRE(mapping.Resolve(1) == 1);
+    REQUIRE(mapping.Resolve(2) == 1);
+    REQUIRE(mapping.Resolve(3) == 0);
+    REQUIRE_THROWS(mapping.Resolve(4));
+    REQUIRE_THROWS(mapping.Resolve(5));
+}
+
+TEST_CASE("CodeSlotMap keeps bindings serializable when physical compaction fails",
+          "[ut][datacell][code_slot_map]") {
+    auto allocator = vsag::SafeAllocator::FactoryDefaultAllocator();
+    vsag::CodeSlotMap mapping(allocator.get());
+
+    mapping.ReserveLogicalSize(6);
+    mapping.PublishSlot(0, mapping.AllocateSlot());
+    mapping.PublishSlot(1, mapping.AllocateSlot());
+    mapping.PublishSlot(2, mapping.AllocateSlot());
+    mapping.PublishSlot(3, mapping.AllocateSlot());
+    auto slot4 = mapping.AllocateSlot();
+    mapping.PublishSlot(4, slot4);
+    auto slot5 = mapping.AllocateSlot();
+    mapping.PublishSlot(5, slot5);
+    mapping.RemoveAndSwapLast(0, 5);
+    mapping.RemoveAndSwapLast(1, 4);
+
+    uint64_t move_count = 0;
+    REQUIRE_THROWS(mapping.CompactSlots([&move_count](vsag::CodeSlotIdType, vsag::CodeSlotIdType) {
+        if (++move_count == 2) {
+            throw std::bad_alloc();
+        }
+    }));
+    REQUIRE(move_count == 2);
+    REQUIRE(mapping.PublishedLogicalCount() == 4);
+    REQUIRE(mapping.PhysicalCount() == 6);
+    REQUIRE(mapping.Resolve(0) == slot5);
+    REQUIRE(mapping.Resolve(1) == slot4);
+    REQUIRE(mapping.Resolve(2) == 2);
+    REQUIRE(mapping.Resolve(3) == 3);
+
+    std::stringstream stream;
+    vsag::IOStreamWriter writer(stream);
+    mapping.Serialize(writer);
+
+    vsag::CodeSlotMap restored(allocator.get());
+    vsag::IOStreamReader reader(stream);
+    restored.Deserialize(reader);
+    REQUIRE(restored.PublishedLogicalCount() == 4);
+    REQUIRE(restored.PhysicalCount() == 6);
+    REQUIRE(restored.Resolve(0) == slot5);
+    REQUIRE(restored.Resolve(1) == slot4);
+    REQUIRE(restored.Resolve(2) == 2);
+    REQUIRE(restored.Resolve(3) == 3);
+
+    restored.ReserveLogicalSize(7);
+    REQUIRE(restored.AllocateSlot() == 6);
+}
+
 TEST_CASE("CodeSlotMap serializes logical to physical slots", "[ut][datacell][code_slot_map]") {
     auto allocator = vsag::SafeAllocator::FactoryDefaultAllocator();
     vsag::CodeSlotMap mapping(allocator.get());

--- a/src/datacell/dense_duplicate_tracker.cpp
+++ b/src/datacell/dense_duplicate_tracker.cpp
@@ -18,6 +18,7 @@
 
 #include <algorithm>
 
+#include "common.h"
 #include "vsag_exception.h"
 
 namespace vsag {
@@ -220,6 +221,60 @@ DenseDuplicateTracker::Resize(InnerIdType new_size) {
     for (size_t i = old_size; i < new_size; ++i) {
         duplicate_ids_[i] = static_cast<InnerIdType>(i);
     }
+}
+
+void
+DenseDuplicateTracker::RemoveAndSwapLast(InnerIdType removed_id, InnerIdType last_id) {
+    std::scoped_lock lock(mutex_);
+
+    CHECK_ARGUMENT(removed_id <= last_id,
+                   fmt::format("removed_id({}) must not exceed last_id({})", removed_id, last_id));
+    CHECK_ARGUMENT(
+        last_id < duplicate_ids_.size(),
+        fmt::format(
+            "last_id({}) exceeds duplicate tracker size({})", last_id, duplicate_ids_.size()));
+
+    this->DetachId(removed_id);
+    if (removed_id != last_id) {
+        this->RenameId(last_id, removed_id);
+    }
+}
+
+void
+DenseDuplicateTracker::DetachId(InnerIdType id) {
+    const auto next_id = duplicate_ids_[id];
+    if (next_id == id) {
+        return;
+    }
+
+    auto previous_id = next_id;
+    while (duplicate_ids_[previous_id] != id) {
+        previous_id = duplicate_ids_[previous_id];
+    }
+    duplicate_ids_[previous_id] = next_id;
+    duplicate_ids_[id] = id;
+
+    if (previous_id == next_id) {
+        duplicate_ids_[previous_id] = previous_id;
+        --duplicate_count_;
+    }
+}
+
+void
+DenseDuplicateTracker::RenameId(InnerIdType from, InnerIdType to) {
+    const auto next_id = duplicate_ids_[from];
+    if (next_id == from) {
+        duplicate_ids_[to] = to;
+        return;
+    }
+
+    auto previous_id = next_id;
+    while (duplicate_ids_[previous_id] != from) {
+        previous_id = duplicate_ids_[previous_id];
+    }
+    duplicate_ids_[previous_id] = to;
+    duplicate_ids_[to] = next_id;
+    duplicate_ids_[from] = from;
 }
 
 }  // namespace vsag

--- a/src/datacell/dense_duplicate_tracker.h
+++ b/src/datacell/dense_duplicate_tracker.h
@@ -47,7 +47,22 @@ public:
     void
     Resize(InnerIdType new_size) override;
 
+    /**
+     * Remove one active logical ID and move the last active ID into its position.
+     *
+     * This mirrors the swap-with-last compaction used by HGraph ForceRemove. The caller must pass
+     * the last active ID before the removal.
+     */
+    void
+    RemoveAndSwapLast(InnerIdType removed_id, InnerIdType last_id);
+
 private:
+    void
+    DetachId(InnerIdType id);
+
+    void
+    RenameId(InnerIdType from, InnerIdType to);
+
     Allocator* allocator_;
     Vector<InnerIdType> duplicate_ids_;
     mutable std::shared_mutex mutex_;

--- a/src/datacell/dense_duplicate_tracker_test.cpp
+++ b/src/datacell/dense_duplicate_tracker_test.cpp
@@ -103,6 +103,48 @@ TEST_CASE("DenseDuplicateTracker resize initializes new ids", "[ut][DenseDuplica
     REQUIRE(sorted_duplicates(tracker.GetDuplicateIds(4)) == std::vector<InnerIdType>{5});
 }
 
+TEST_CASE("DenseDuplicateTracker compacts ids after removal", "[ut][DenseDuplicateTracker]") {
+    auto allocator = std::make_shared<DefaultAllocator>();
+
+    SECTION("last id moves from another duplicate group") {
+        DenseDuplicateTracker tracker(allocator.get());
+        tracker.Resize(8);
+        tracker.SetDuplicateId(0, 2);
+        tracker.SetDuplicateId(4, 7);
+
+        tracker.RemoveAndSwapLast(0, 7);
+
+        REQUIRE(tracker.GetDuplicateIds(2).empty());
+        REQUIRE(sorted_duplicates(tracker.GetDuplicateIds(0)) == std::vector<InnerIdType>{4});
+        REQUIRE(tracker.GetGroupId(4) == 0);
+        REQUIRE(tracker.GetDuplicateIds(7).empty());
+    }
+
+    SECTION("removed and last ids belong to the same group") {
+        DenseDuplicateTracker tracker(allocator.get());
+        tracker.Resize(6);
+        tracker.SetDuplicateId(0, 3);
+        tracker.SetDuplicateId(0, 5);
+
+        tracker.RemoveAndSwapLast(0, 5);
+
+        REQUIRE(sorted_duplicates(tracker.GetDuplicateIds(0)) == std::vector<InnerIdType>{3});
+        REQUIRE(tracker.GetGroupId(3) == 0);
+        REQUIRE(tracker.GetDuplicateIds(5).empty());
+    }
+
+    SECTION("removing the last duplicate dissolves a two-member group") {
+        DenseDuplicateTracker tracker(allocator.get());
+        tracker.Resize(6);
+        tracker.SetDuplicateId(1, 5);
+
+        tracker.RemoveAndSwapLast(5, 5);
+
+        REQUIRE(tracker.GetDuplicateIds(1).empty());
+        REQUIRE(tracker.GetDuplicateIds(5).empty());
+    }
+}
+
 TEST_CASE("DenseDuplicateTracker deserializes legacy format", "[ut][DenseDuplicateTracker]") {
     auto allocator = std::make_shared<DefaultAllocator>();
 

--- a/src/datacell/flatten_interface.h
+++ b/src/datacell/flatten_interface.h
@@ -236,6 +236,12 @@ public:
         return this->total_count_;
     }
 
+    void
+    SetTotalCount(InnerIdType total_count) {
+        std::unique_lock lock(mutex_);
+        this->total_count_ = total_count;
+    }
+
     virtual void
     Serialize(StreamWriter& writer) {
         StreamWriter::WriteObj(writer, this->total_count_);

--- a/src/datacell/graph_interface.cpp
+++ b/src/datacell/graph_interface.cpp
@@ -48,6 +48,25 @@ GraphInterface::UpdateReverseEdges(InnerIdType id,
     }
 }
 
+void
+GraphInterface::RebuildReverseEdges(InnerIdType total_count) {
+    if (reverse_edges_ == nullptr) {
+        return;
+    }
+
+    reverse_edges_->Clear();
+    Vector<InnerIdType> neighbors(allocator_);
+    for (InnerIdType inner_id = 0; inner_id < total_count; ++inner_id) {
+        neighbors.clear();
+        this->GetNeighbors(inner_id, neighbors);
+        for (const auto neighbor : neighbors) {
+            if (neighbor < total_count) {
+                reverse_edges_->AddReverseEdge(inner_id, neighbor);
+            }
+        }
+    }
+}
+
 GraphInterfacePtr
 GraphInterface::MakeInstance(const GraphInterfaceParamPtr& graph_param,
                              const IndexCommonParam& common_param) {

--- a/src/datacell/graph_interface.h
+++ b/src/datacell/graph_interface.h
@@ -102,6 +102,14 @@ public:
         }
     }
 
+    /**
+     * Rebuild in-memory reverse edges from the persisted forward graph.
+     *
+     * Reverse edges are an acceleration structure and are not part of graph serialization.
+     */
+    void
+    RebuildReverseEdges(InnerIdType total_count);
+
     virtual void
     Move(InnerIdType from, InnerIdType to) {
         throw VsagException(ErrorType::INTERNAL_ERROR, "Move not implemented in GraphInterface");

--- a/src/datacell/sparse_graph_datacell_test.cpp
+++ b/src/datacell/sparse_graph_datacell_test.cpp
@@ -106,6 +106,30 @@ TEST_CASE("SparseGraphDataCell Reverse Edges", "[ut][SparseGraphDataCell]") {
     test.ReverseEdgeTest(100);
 }
 
+TEST_CASE("SparseGraphDataCell rebuilds reverse edges across missing ids",
+          "[ut][SparseGraphDataCell]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+
+    IndexCommonParam common_param;
+    common_param.dim_ = 32;
+    common_param.allocator_ = allocator;
+    auto graph_param = std::make_shared<SparseGraphDatacellParameter>();
+    graph_param->max_degree_ = 8;
+    graph_param->use_reverse_edges_ = true;
+
+    auto graph = GraphInterface::MakeInstance(graph_param, common_param);
+    Vector<InnerIdType> neighbors(allocator.get());
+    neighbors.emplace_back(2);
+    graph->InsertNeighborsById(1, neighbors);
+
+    graph->RebuildReverseEdges(5);
+
+    Vector<InnerIdType> incoming(allocator.get());
+    graph->GetIncomingNeighbors(2, incoming);
+    REQUIRE(incoming.size() == 1);
+    REQUIRE(incoming[0] == 1);
+}
+
 TEST_CASE("SparseGraphDataCell Move", "[ut][SparseGraphDataCell]") {
     auto allocator = SafeAllocator::FactoryDefaultAllocator();
     auto dim = 32;


### PR DESCRIPTION
## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Improvement/Refactor
- [ ] Documentation
- [ ] CI/Build/Infra

## Linked Issue

- Closes: #2589

## What Changed

- Support `ForceRemove` when HGraph uses `deduplicate_storage`, including duplicate-group
  updates and representative migration.
- Keep graph nodes, entry point, logical-to-physical mappings, and shared physical code
  slots consistent while compacting removed IDs.
- Rebuild reverse edges after deserialization and document that this combination requires a
  flat graph with reverse edges enabled.

## Test Evidence

- [ ] `make fmt`
- [ ] `make lint`
- [ ] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [x] Other (describe below)

Test details:

```text
cmake --build build --parallel 96
  passed

clang-format-15 on all modified C++ files
  passed

./scripts/linters/run-clang-tidy-15.sh -p build/ \
  -source-filter '^.*/src/(algorithm/hgraph/(hgraph|hgraph_build|hgraph_modify|hgraph_parameter|hgraph_serialize)|datacell/(code_slot_map|dense_duplicate_tracker|graph_interface))\.cpp$' \
  -j 96
  passed (8 production files)

build/tests/unittests \
  '[duplicate],[code_slot_map],[DenseDuplicateTracker],[HGraphParameter],"SparseGraphDataCell rebuilds reverse edges across missing ids"' \
  --colour-mode none
  passed: 69 test cases, 735 assertions

build/tests/fixtures/hgraph_functional_test --reporter compact \
  --test-case 'HGraph ForceRemove*' --section '!deduplicate_storage'
  passed: 8 test cases, 977 assertions

Full unit suite before rebasing the latest upstream/main:
  passed: 662 test cases, 85,542,281 assertions
```

## Compatibility Impact

- API/ABI compatibility: none
- Behavior changes: HGraph now accepts `ForceRemove` with `deduplicate_storage` for the
  documented flat-graph/reverse-edge configuration.

## Performance and Concurrency Impact

- Performance impact: the existing non-deduplicated path is unchanged; deduplicated removal
  compacts logical mappings and physical code slots.
- Concurrency/thread-safety impact: mutation locks and capacity pre-growth are enabled only
  for the deduplicated `ForceRemove` configuration.

## Documentation Impact

- [ ] No docs update needed
- [x] Updated docs:
  - [ ] `README.md`
  - [ ] `DEVELOPMENT.md`
  - [ ] `CONTRIBUTING.md`
  - [x] Other: `docs/docs/{en,zh}/src/indexes/hgraph.md`

## Risk and Rollback

- Risk level: medium
- Rollback plan: revert this commit to restore the previous unsupported configuration.

## Checklist

- [x] I have linked the relevant issue (required for `kind/bug` and `kind/feature`; see "Linked Issue" above)
- [x] I have added/updated tests for new behavior or bug fixes
- [x] I have considered API compatibility impact
- [x] I have updated docs if behavior/workflow changed
- [x] My commit messages follow project conventions (Conventional Commits, optional `[skip ci]` prefix)
