### PR TITLE
fix: use single-threaded build for OpenBLAS to avoid race condition

### DIFF
--- a/extern/openblas/openblas.cmake
+++ b/extern/openblas/openblas.cmake
@@ -209,7 +209,7 @@ if (NOT OPENBLAS_FOUND)
             OMP_NUM_THREADS=1
             PATH=/usr/lib/ccache:$ENV{PATH}
             LD_LIBRARY_PATH=/opt/alibaba-cloud-compiler/lib64/:$ENV{LD_LIBRARY_PATH}
-            make USE_THREAD=0 USE_LOCKING=1 DYNAMIC_ARCH=1 NOFORTRAN=1 -j${NUM_BUILDING_JOBS}
+            make USE_THREAD=0 USE_LOCKING=1 DYNAMIC_ARCH=1 NOFORTRAN=1 -j1
         INSTALL_COMMAND
             make DYNAMIC_ARCH=1 NOFORTRAN=1 PREFIX=${install_dir} install
         BUILD_IN_SOURCE 1


### PR DESCRIPTION
## Summary

OpenBLAS `DYNAMIC_ARCH=1` builds with parallel make can intermittently fail due to race conditions in kernel generation. This PR changes the build to use `-j1` to eliminate the race.

## Changes

- `extern/openblas/openblas.cmake`: Change `-j${NUM_BUILDING_JOBS}` to `-j1` in the BUILD_COMMAND

## Root Cause Analysis

OpenBLAS with `DYNAMIC_ARCH=1` needs to:
1. Build `getarch` to detect CPU capabilities
2. Generate `config.h` based on detection
3. Compile optimized kernels for multiple CPU architectures

With `-j3`, multiple parallel jobs can race to write the same generated files, causing intermittent build failures (exit code 2) in CI.

## Testing

- This is a build system change only; no functional code changes
- OpenBLAS compilation will take ~1-2 minutes longer but eliminates flaky CI failures
- The INSTALL step already runs without `-j` (single-threaded), so this makes BUILD consistent

Fixes: #2599