### PR TITLE
refactor(ivf): reuse shared graph search primitives

### DIFF
--- a/src/algorithm/ivf/graph_bucket_searcher.cpp
+++ b/src/algorithm/ivf/graph_bucket_searcher.cpp
@@ -14,11 +14,13 @@
 
 #include "graph_bucket_searcher.h"
 
+#include <algorithm>
 #include <limits>
 
 #include "attr/executor/executor.h"
 #include "impl/reasoning/search_reasoning.h"
 #include "impl/searcher/basic_searcher.h"
+#include "vsag_exception.h"
 
 namespace vsag {
 
@@ -82,144 +84,61 @@ GraphBucketSearcher::search_graph(BucketIdType bucket_id,
                                   BucketIdType buckets_per_data,
                                   DistHeapPtr& heap,
                                   ReasoningContext* reasoning_ctx) const {
-    auto bucket_size = bucket->GetBucketSize(bucket_id);
+    const auto bucket_size = bucket->GetBucketSize(bucket_id);
     if (bucket_size == 0) {
         return;
     }
     const auto& graph = bucket_graphs_[bucket_id];
     const auto* ids = bucket->GetInnerIds(bucket_id);
-
-    uint64_t ef = param.ef;
-    if (param.search_mode == InnerSearchMode::KNN_SEARCH && ef < static_cast<uint64_t>(topk)) {
-        ef = static_cast<uint64_t>(topk);
-    }
-    // Cap ef at bucket_size to avoid full-graph traversal for unlimited RANGE_SEARCH
-    // where the caller sets topk to total index size.
-    if (ef > static_cast<uint64_t>(bucket_size)) {
-        ef = static_cast<uint64_t>(bucket_size);
-    }
-
-    VisitedList vl(bucket_size, allocator_);
-
-    StandardHeap<true, false> top_candidates(allocator_, -1);
-    StandardHeap<true, false> candidate_set(allocator_, -1);
-
-    const auto& ft = param.is_inner_id_allowed;
-    const auto topk_u = static_cast<uint64_t>(topk);
-
-    Filter* attr_ft = nullptr;
-    if (not param.executors.empty() and
-        static_cast<uint64_t>(thread_id) < param.executors.size() and
-        param.executors[thread_id] != nullptr) {
-        param.executors[thread_id]->Clear();
-        attr_ft = param.executors[thread_id]->Run(bucket_id);
-    }
-
-    auto check_func = [&ft, &attr_ft, &ids](InnerIdType local_id, InnerIdType origin_id) {
-        return (ft == nullptr or ft->CheckValid(origin_id)) and
-               (attr_ft == nullptr or attr_ft->CheckValid(local_id));
-    };
-
-    // Find a valid (non-hole) entry point
     InnerIdType entry = 0;
-    while (entry < static_cast<InnerIdType>(bucket_size) &&
-           ids[entry] == std::numeric_limits<InnerIdType>::max()) {
+    while (entry < bucket_size && ids[entry] == std::numeric_limits<InnerIdType>::max()) {
         ++entry;
     }
-    if (entry >= static_cast<InnerIdType>(bucket_size)) {
-        return;  // all entries are holes, fall back
-    }
-    float entry_dist = bucket->QueryOneById(computer, bucket_id, entry);
-    auto origin_entry = ids[entry] / buckets_per_data;
-    if (reasoning_ctx != nullptr) {
-        reasoning_ctx->RecordVisit(origin_entry, entry_dist, 0);
-    }
-    if (check_func(entry, origin_entry)) {
-        top_candidates.Push(entry_dist, entry);
-    } else if (reasoning_ctx != nullptr) {
-        reasoning_ctx->RecordFilterReject(origin_entry);
-    }
-    candidate_set.Push(-entry_dist, entry);
-    vl.Set(entry);
-
-    auto lower_bound = std::numeric_limits<float>::max();
-    if (not top_candidates.Empty()) {
-        lower_bound = top_candidates.Top().first;
+    if (entry == bucket_size) {
+        return;
     }
 
-    const auto max_degree = graph->MaximumDegree();
-    Vector<InnerIdType> neighbors(allocator_);
-
-    while (not candidate_set.Empty()) {
-        auto current_node_pair = candidate_set.Top();
-
-        if ((-current_node_pair.first) > lower_bound and top_candidates.Size() >= ef) {
-            break;
-        }
-        candidate_set.Pop();
-
-        const auto neighbor_count = graph->GetNeighborSize(current_node_pair.second);
-        if (neighbor_count > max_degree) {
-            continue;
-        }
-        graph->GetNeighbors(current_node_pair.second, neighbors);
-
-        for (const auto neighbor_id : neighbors) {
-            if (vl.Get(neighbor_id)) {
-                continue;
-            }
-            vl.Set(neighbor_id);
-
-            float d = bucket->QueryOneById(computer, bucket_id, neighbor_id);
-            auto origin_id = ids[neighbor_id] / buckets_per_data;
-            if (reasoning_ctx != nullptr) {
-                reasoning_ctx->RecordVisit(origin_id, d, 1);
-            }
-
-            if (top_candidates.Size() < ef or lower_bound > d or
-                (param.search_mode == RANGE_SEARCH and d <= param.radius + THRESHOLD_ERROR)) {
-                candidate_set.Push(-d, neighbor_id);
-                if (check_func(neighbor_id, origin_id)) {
-                    top_candidates.Push(d, neighbor_id);
-                } else if (reasoning_ctx != nullptr) {
-                    reasoning_ctx->RecordFilterReject(origin_id);
-                }
-                if (param.search_mode == KNN_SEARCH and top_candidates.Size() > ef) {
-                    if (reasoning_ctx != nullptr) {
-                        reasoning_ctx->RecordEviction(
-                            ids[top_candidates.Top().second] / buckets_per_data, 1);
-                    }
-                    top_candidates.Pop();
-                }
-                if (not top_candidates.Empty()) {
-                    lower_bound = top_candidates.Top().first;
-                }
-            }
-        }
+    Filter* attr_filter = nullptr;
+    if (not param.executors.empty() && static_cast<uint64_t>(thread_id) < param.executors.size() &&
+        param.executors[thread_id] != nullptr) {
+        param.executors[thread_id]->Clear();
+        attr_filter = param.executors[thread_id]->Run(bucket_id);
+    }
+    InnerSearchParam search_param = param;
+    search_param.ep = entry;
+    uint64_t result_limit = std::numeric_limits<uint64_t>::max();
+    if (search_param.search_mode == KNN_SEARCH) {
+        CHECK_ARGUMENT(topk > 0, "topk must be greater than 0");
+        result_limit = static_cast<uint64_t>(topk);
+        search_param.ef = std::max(search_param.ef, result_limit);
+    } else if (topk > 0) {
+        result_limit = static_cast<uint64_t>(topk);
+    }
+    search_param.ef = std::min<uint64_t>(search_param.ef, bucket_size);
+    search_param.topk = topk;
+    if (search_param.search_mode == RANGE_SEARCH) {
+        // BasicSearcher uses a non-positive range limit to mean unlimited; clamp only positive
+        // limits because InnerSearchParam stores this field as int.
+        search_param.range_search_limit_size =
+            topk > 0 ? static_cast<int>(std::min<int64_t>(topk, std::numeric_limits<int>::max()))
+                     : 0;
     }
 
-    if (param.search_mode == KNN_SEARCH) {
-        while (top_candidates.Size() > topk_u) {
-            top_candidates.Pop();
-        }
-    } else {
-        while (not top_candidates.Empty() and
-               top_candidates.Top().first > param.radius + THRESHOLD_ERROR) {
-            top_candidates.Pop();
-        }
-        if (topk_u > 0) {
-            while (top_candidates.Size() > topk_u) {
-                top_candidates.Pop();
-            }
-        }
+    // BucketInterface can create computers only from raw queries, not local IDs. Search only
+    // needs query distances, so use the no-factory provider and make pairwise misuse explicit.
+    BucketDistanceProvider distance_provider(bucket, bucket_id, computer, ids, buckets_per_data);
+    auto visited = std::make_shared<VisitedList>(bucket_size, allocator_);
+    QueryContext query_context{};
+    query_context.reasoning_ctx = reasoning_ctx;
+    BasicSearcher searcher(allocator_);
+    auto top_candidates = searcher.Search(
+        graph, distance_provider, visited, search_param, attr_filter, &query_context);
+    while (not top_candidates->Empty()) {
+        const auto [distance, local_id] = top_candidates->Top();
+        heap->Push(distance, ids[local_id]);
+        top_candidates->Pop();
     }
-
-    while (not top_candidates.Empty()) {
-        auto [d, local_id] = top_candidates.Top();
-        heap->Push(d, ids[local_id]);
-        top_candidates.Pop();
-    }
-    while (heap->Size() > topk_u) {
+    while (heap->Size() > result_limit) {
         heap->Pop();
     }
 }

--- a/src/algorithm/ivf/ivf.cpp
+++ b/src/algorithm/ivf/ivf.cpp
@@ -34,6 +34,7 @@
 #include "graph_bucket_searcher.h"
 #include "impl/heap/standard_heap.h"
 #include "impl/inner_search_param.h"
+#include "impl/pruning_strategy.h"
 #include "impl/reasoning/search_reasoning.h"
 #include "impl/reorder/flatten_reorder.h"
 #include "impl/searcher/basic_searcher.h"
@@ -738,131 +739,25 @@ IVF::build_bucket_graphs(const DatasetPtr& base) {
             CHECK_ARGUMENT(query != nullptr, "base dataset has no graph build vector data");
             return bucket_->FactoryComputer(query);
         };
-
-        // Adapted from HGraph select_edges_by_heuristic: retain close, diverse edges.
-        auto select_edges_by_heuristic = [&](InnerIdType source, Vector<InnerIdType>& neighbors) {
-            auto source_computer = make_computer(source);
-            Vector<std::pair<float, InnerIdType>> candidates(allocator_);
-            candidates.reserve(neighbors.size());
-            for (const auto neighbor : neighbors) {
-                if (neighbor == source || neighbor >= bucket_size ||
-                    inner_ids[neighbor] == std::numeric_limits<InnerIdType>::max()) {
-                    continue;
-                }
-                bool duplicate = false;
-                for (const auto& candidate : candidates) {
-                    if (candidate.second == neighbor) {
-                        duplicate = true;
-                        break;
-                    }
-                }
-                if (!duplicate) {
-                    candidates.emplace_back(bucket_->QueryOneById(source_computer, b, neighbor),
-                                            neighbor);
-                }
-            }
-            std::sort(candidates.begin(), candidates.end(), [](const auto& lhs, const auto& rhs) {
-                return lhs.first < rhs.first;
-            });
-
-            neighbors.clear();
-            Vector<ComputerInterfacePtr> selected_computers(allocator_);
-            for (const auto& candidate : candidates) {
-                bool good = true;
-                for (const auto& selected_comp : selected_computers) {
-                    const auto pair_distance =
-                        bucket_->QueryOneById(selected_comp, b, candidate.second);
-                    if (pair_distance < candidate.first) {
-                        good = false;
-                        break;
-                    }
-                }
-                if (good) {
-                    neighbors.push_back(candidate.second);
-                    selected_computers.push_back(make_computer(candidate.second));
-                    if (neighbors.size() == static_cast<uint64_t>(effective_degree)) {
-                        break;
-                    }
-                }
-            }
-        };
+        auto mutexes = std::make_shared<EmptyMutex>();
+        BasicSearcher searcher(common_param_);
 
         const auto entry = valid_ids.front();
         graph->InsertNeighborsById(entry, Vector<InnerIdType>(allocator_));
-        VisitedList visited(bucket_size, allocator_);
-        Vector<InnerIdType> graph_neighbors(effective_degree, allocator_);
-
+        auto visited = std::make_shared<VisitedList>(bucket_size, allocator_);
         for (uint64_t node_pos = 1; node_pos < valid_ids.size(); ++node_pos) {
             const auto node = valid_ids[node_pos];
-            auto computer = make_computer(node);
-            const auto entry_dist = bucket_->QueryOneById(computer, b, entry);
-            const auto ef = std::min(ef_construction, node_pos);
-
-            visited.Reset();
-            StandardHeap<true, false> top_candidates(allocator_, -1);
-            StandardHeap<true, false> candidate_set(allocator_, -1);
-            top_candidates.Push(entry_dist, entry);
-            candidate_set.Push(-entry_dist, entry);
-            visited.Set(entry);
-            auto lower_bound = entry_dist;
-
-            while (not candidate_set.Empty()) {
-                const auto current = candidate_set.Top();
-                if (-current.first > lower_bound && top_candidates.Size() >= ef) {
-                    break;
-                }
-                candidate_set.Pop();
-
-                graph->GetNeighbors(current.second, graph_neighbors);
-                const auto neighbor_count = graph->GetNeighborSize(current.second);
-                for (uint32_t i = 0; i < neighbor_count; ++i) {
-                    const auto neighbor = graph_neighbors[i];
-                    if (neighbor >= bucket_size || visited.Get(neighbor) ||
-                        inner_ids[neighbor] == std::numeric_limits<InnerIdType>::max()) {
-                        continue;
-                    }
-                    visited.Set(neighbor);
-                    const auto distance = bucket_->QueryOneById(computer, b, neighbor);
-                    if (top_candidates.Size() < ef || distance < lower_bound) {
-                        candidate_set.Push(-distance, neighbor);
-                        top_candidates.Push(distance, neighbor);
-                        if (top_candidates.Size() > ef) {
-                            top_candidates.Pop();
-                        }
-                        lower_bound = top_candidates.Top().first;
-                    }
-                }
-            }
-
-            Vector<std::pair<float, InnerIdType>> candidates(allocator_);
-            candidates.reserve(top_candidates.Size());
-            for (uint64_t i = 0; i < top_candidates.Size(); ++i) {
-                candidates.push_back(top_candidates.GetData()[i]);
-            }
-            std::sort(candidates.begin(), candidates.end(), [](const auto& lhs, const auto& rhs) {
-                return lhs.first < rhs.first;
-            });
-
-            // Adapted from HGraph mutually_connect_new_element.
-            Vector<InnerIdType> node_neighbors(allocator_);
-            node_neighbors.reserve(candidates.size());
-            for (const auto& candidate : candidates) {
-                node_neighbors.push_back(candidate.second);
-            }
-            select_edges_by_heuristic(node, node_neighbors);
-            graph->InsertNeighborsById(node, node_neighbors);
-
-            for (const auto neighbor : node_neighbors) {
-                Vector<InnerIdType> reciprocal(allocator_);
-                graph->GetNeighbors(neighbor, reciprocal);
-                if (reciprocal.size() < static_cast<uint64_t>(effective_degree)) {
-                    reciprocal.push_back(node);
-                } else {
-                    reciprocal.push_back(node);
-                    select_edges_by_heuristic(neighbor, reciprocal);
-                }
-                graph->InsertNeighborsById(neighbor, reciprocal);
-            }
+            InnerSearchParam search_param;
+            search_param.ep = entry;
+            search_param.ef = std::min(ef_construction, node_pos);
+            search_param.topk = static_cast<int64_t>(search_param.ef);
+            BucketDistanceProvider distance_provider(
+                bucket_, b, make_computer(node), make_computer, inner_ids, buckets_per_data_);
+            visited->Reset();
+            auto candidates =
+                searcher.Search(graph, distance_provider, visited, search_param, nullptr, nullptr);
+            mutually_connect_new_element(
+                node, candidates, graph, distance_provider, mutexes, allocator_);
         }
 
         bucket_graphs_[b] = std::move(graph);

--- a/src/impl/distance_provider_for_graph.cpp
+++ b/src/impl/distance_provider_for_graph.cpp
@@ -1,0 +1,94 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "impl/distance_provider_for_graph.h"
+
+#include <limits>
+
+#include "datacell/bucket_interface.h"
+
+namespace vsag {
+
+BucketDistanceProvider::BucketDistanceProvider(std::shared_ptr<BucketInterface> bucket,
+                                               BucketIdType bucket_id,
+                                               ComputerInterfacePtr computer,
+                                               ComputerFactory computer_factory,
+                                               const InnerIdType* inner_ids,
+                                               BucketIdType buckets_per_data)
+    : bucket_(std::move(bucket)),
+      bucket_id_(bucket_id),
+      computer_(std::move(computer)),
+      computer_factory_(std::move(computer_factory)),
+      inner_ids_(inner_ids),
+      buckets_per_data_(buckets_per_data) {
+    CHECK_ARGUMENT(buckets_per_data_ > 0, "buckets_per_data must be positive");
+}
+
+BucketDistanceProvider::BucketDistanceProvider(std::shared_ptr<BucketInterface> bucket,
+                                               BucketIdType bucket_id,
+                                               ComputerInterfacePtr computer,
+                                               const InnerIdType* inner_ids,
+                                               BucketIdType buckets_per_data)
+    : BucketDistanceProvider(
+          std::move(bucket), bucket_id, std::move(computer), {}, inner_ids, buckets_per_data) {
+}
+
+float
+BucketDistanceProvider::QueryDistance(InnerIdType id, QueryContext* /*ctx*/) const {
+    if (not IsValid(id)) {
+        return std::numeric_limits<float>::infinity();
+    }
+    return bucket_->QueryOneById(computer_, bucket_id_, id);
+}
+
+float
+BucketDistanceProvider::PairwiseDistance(InnerIdType id1,
+                                         InnerIdType id2,
+                                         const ComputerInterfacePtr& computer) const {
+    CHECK_ARGUMENT(IsValid(id1) && IsValid(id2), "cannot compute distance for a bucket hole");
+    return bucket_->QueryOneById(
+        computer != nullptr ? computer : FactoryComputerById(id1), bucket_id_, id2);
+}
+
+ComputerInterfacePtr
+BucketDistanceProvider::FactoryComputerById(InnerIdType id) const {
+    CHECK_ARGUMENT(IsValid(id), "cannot create a computer for a bucket hole");
+    if (not computer_factory_) {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "BucketDistanceProvider has no source-computer factory");
+    }
+    return computer_factory_(id);
+}
+
+void
+BucketDistanceProvider::Prefetch(InnerIdType id) const {
+    if (IsValid(id)) {
+        bucket_->Prefetch(bucket_id_, id);
+    }
+}
+
+InnerIdType
+BucketDistanceProvider::OriginalId(InnerIdType id) const {
+    return inner_ids_ == nullptr ? id
+                                 : (IsValid(id) ? inner_ids_[id] / buckets_per_data_
+                                                : std::numeric_limits<InnerIdType>::max());
+}
+
+bool
+BucketDistanceProvider::IsValid(InnerIdType id) const {
+    return inner_ids_ == nullptr || (id < bucket_->GetBucketSize(bucket_id_) &&
+                                     inner_ids_[id] != std::numeric_limits<InnerIdType>::max());
+}
+
+}  // namespace vsag

--- a/src/impl/distance_provider_for_graph.h
+++ b/src/impl/distance_provider_for_graph.h
@@ -1,0 +1,170 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <utility>
+
+#include "basic_types.h"
+#include "datacell/flatten_interface.h"
+#include "quantization/computer.h"
+#include "query_context.h"
+#include "vsag_exception.h"
+
+namespace vsag {
+
+class BucketInterface;
+
+class DistanceProviderForGraph {
+public:
+    virtual ~DistanceProviderForGraph() = default;
+
+    [[nodiscard]] virtual float
+    QueryDistance(InnerIdType id, QueryContext* ctx = nullptr) const = 0;
+
+    virtual void
+    BatchQueryDistance(float* distances,
+                       const InnerIdType* ids,
+                       InnerIdType count,
+                       QueryContext* ctx = nullptr) const {
+        for (InnerIdType i = 0; i < count; ++i) {
+            distances[i] = this->QueryDistance(ids[i], ctx);
+        }
+    }
+
+    [[nodiscard]] virtual float
+    PairwiseDistance(InnerIdType id1,
+                     InnerIdType id2,
+                     const ComputerInterfacePtr& computer = nullptr) const = 0;
+
+    [[nodiscard]] virtual ComputerInterfacePtr
+    FactoryComputerById(InnerIdType id) const = 0;
+
+    [[nodiscard]] virtual bool
+    SupportsComputerById() const {
+        return false;
+    }
+
+    virtual void
+    Prefetch(InnerIdType id) const {
+    }
+
+    [[nodiscard]] virtual InnerIdType
+    OriginalId(InnerIdType id) const {
+        return id;
+    }
+
+    [[nodiscard]] virtual bool
+    IsValid(InnerIdType) const {
+        return true;
+    }
+};
+
+class FlattenDistanceProvider final : public DistanceProviderForGraph {
+public:
+    FlattenDistanceProvider(FlattenInterfacePtr flatten, ComputerInterfacePtr computer)
+        : flatten_(std::move(flatten)), computer_(std::move(computer)) {
+    }
+
+    [[nodiscard]] float
+    QueryDistance(InnerIdType id, QueryContext* ctx = nullptr) const override {
+        float distance = 0.0F;
+        flatten_->Query(&distance, computer_, &id, 1, ctx);
+        return distance;
+    }
+
+    void
+    BatchQueryDistance(float* distances,
+                       const InnerIdType* ids,
+                       InnerIdType count,
+                       QueryContext* ctx = nullptr) const override {
+        flatten_->Query(distances, computer_, ids, count, ctx);
+    }
+
+    [[nodiscard]] float
+    PairwiseDistance(InnerIdType id1, InnerIdType id2, const ComputerInterfacePtr&) const override {
+        return flatten_->ComputePairVectors(id1, id2);
+    }
+
+    [[nodiscard]] ComputerInterfacePtr
+    FactoryComputerById(InnerIdType) const override {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "FlattenDistanceProvider cannot create a computer by vector ID");
+    }
+
+    void
+    Prefetch(InnerIdType id) const override {
+        flatten_->Prefetch(id);
+    }
+
+private:
+    FlattenInterfacePtr flatten_;
+    ComputerInterfacePtr computer_;
+};
+
+class BucketDistanceProvider final : public DistanceProviderForGraph {
+public:
+    using ComputerFactory = std::function<ComputerInterfacePtr(InnerIdType)>;
+
+    BucketDistanceProvider(std::shared_ptr<BucketInterface> bucket,
+                           BucketIdType bucket_id,
+                           ComputerInterfacePtr computer,
+                           ComputerFactory computer_factory,
+                           const InnerIdType* inner_ids = nullptr,
+                           BucketIdType buckets_per_data = 1);
+
+    // Query-only provider for searches. Pairwise operations require the factory overload above.
+    BucketDistanceProvider(std::shared_ptr<BucketInterface> bucket,
+                           BucketIdType bucket_id,
+                           ComputerInterfacePtr computer,
+                           const InnerIdType* inner_ids = nullptr,
+                           BucketIdType buckets_per_data = 1);
+
+    [[nodiscard]] float
+    QueryDistance(InnerIdType id, QueryContext* ctx = nullptr) const override;
+
+    [[nodiscard]] float
+    PairwiseDistance(InnerIdType id1,
+                     InnerIdType id2,
+                     const ComputerInterfacePtr& computer = nullptr) const override;
+
+    [[nodiscard]] ComputerInterfacePtr
+    FactoryComputerById(InnerIdType id) const override;
+
+    [[nodiscard]] bool
+    SupportsComputerById() const override {
+        return static_cast<bool>(computer_factory_);
+    }
+
+    void
+    Prefetch(InnerIdType id) const override;
+
+    [[nodiscard]] InnerIdType
+    OriginalId(InnerIdType id) const override;
+
+    [[nodiscard]] bool
+    IsValid(InnerIdType id) const override;
+
+private:
+    std::shared_ptr<BucketInterface> bucket_;
+    BucketIdType bucket_id_;
+    ComputerInterfacePtr computer_;
+    ComputerFactory computer_factory_;
+    const InnerIdType* inner_ids_;
+    BucketIdType buckets_per_data_;
+};
+
+}  // namespace vsag

--- a/src/impl/pruning_strategy.cpp
+++ b/src/impl/pruning_strategy.cpp
@@ -17,24 +17,62 @@
 
 #include "datacell/flatten_datacell.h"
 #include "datacell/graph_interface.h"
+#include "hash_types.h"
 #include "impl/heap/standard_heap.h"
 #include "utils/lock_strategy.h"
 namespace vsag {
+
+namespace {
+
+class PairwiseDistanceComputer {
+public:
+    PairwiseDistanceComputer(const DistanceProviderForGraph& distance_provider,
+                             Allocator* allocator)
+        : distance_provider_(distance_provider), computers_(allocator) {
+    }
+
+    PairwiseDistanceComputer(const PairwiseDistanceComputer&) = delete;
+    PairwiseDistanceComputer&
+    operator=(const PairwiseDistanceComputer&) = delete;
+    PairwiseDistanceComputer(PairwiseDistanceComputer&&) = delete;
+    PairwiseDistanceComputer&
+    operator=(PairwiseDistanceComputer&&) = delete;
+
+    float
+    PairwiseDistance(InnerIdType id1, InnerIdType id2) {
+        if (not distance_provider_.SupportsComputerById()) {
+            return distance_provider_.PairwiseDistance(id1, id2);
+        }
+        auto& computer = computers_[id1];
+        if (computer == nullptr) {
+            computer = distance_provider_.FactoryComputerById(id1);
+        }
+        return distance_provider_.PairwiseDistance(id1, id2, computer);
+    }
+
+private:
+    const DistanceProviderForGraph& distance_provider_;
+    // The helper lives for one pruning pass; its source IDs are bounded by the selected-edge limit.
+    UnorderedMap<InnerIdType, ComputerInterfacePtr> computers_;
+};
+
+}  // namespace
 
 void
 select_edges_by_heuristic(Vector<InnerIdType>& neighbors,
                           InnerIdType node_id,
                           uint64_t max_size,
-                          const FlattenInterfacePtr& flatten,
+                          const DistanceProviderForGraph& distance_provider,
                           Allocator* allocator,
                           float alpha) {
+    PairwiseDistanceComputer pairwise_distance(distance_provider, allocator);
     auto edges = std::make_shared<StandardHeap<true, false>>(allocator, -1);
     for (const auto& neighbor : neighbors) {
-        float dist = flatten->ComputePairVectors(node_id, neighbor);
+        float dist = pairwise_distance.PairwiseDistance(node_id, neighbor);
         edges->Push(dist, neighbor);
     }
 
-    select_edges_by_heuristic(edges, max_size, flatten, allocator, alpha);
+    select_edges_by_heuristic(edges, max_size, distance_provider, allocator, alpha);
 
     neighbors.clear();
     while (not edges->Empty()) {
@@ -46,7 +84,7 @@ select_edges_by_heuristic(Vector<InnerIdType>& neighbors,
 void
 select_edges_by_heuristic(const DistHeapPtr& edges,
                           uint64_t max_size,
-                          const FlattenInterfacePtr& flatten,
+                          const DistanceProviderForGraph& distance_provider,
                           Allocator* allocator,
                           float alpha) {
     if (edges->Size() < max_size) {
@@ -55,6 +93,7 @@ select_edges_by_heuristic(const DistHeapPtr& edges,
 
     auto queue_closest = std::make_shared<StandardHeap<true, false>>(allocator, -1);
     Vector<std::pair<float, InnerIdType>> return_list(allocator);
+    PairwiseDistanceComputer pairwise_distance(distance_provider, allocator);
     while (not edges->Empty()) {
         queue_closest->Push(-edges->Top().first, edges->Top().second);
         edges->Pop();
@@ -70,7 +109,8 @@ select_edges_by_heuristic(const DistHeapPtr& edges,
         bool good = true;
 
         for (const auto& second_pair : return_list) {
-            float curdist = flatten->ComputePairVectors(second_pair.second, current_pair.second);
+            float curdist =
+                pairwise_distance.PairwiseDistance(second_pair.second, current_pair.second);
             if (alpha * curdist < float_query) {
                 good = false;
                 break;
@@ -90,12 +130,13 @@ InnerIdType
 mutually_connect_new_element(InnerIdType cur_c,
                              const DistHeapPtr& top_candidates,
                              const GraphInterfacePtr& graph,
-                             const FlattenInterfacePtr& flatten,
+                             const DistanceProviderForGraph& distance_provider,
                              const MutexArrayPtr& neighbors_mutexes,
                              Allocator* allocator,
                              float alpha) {
+    PairwiseDistanceComputer pairwise_distance(distance_provider, allocator);
     const uint64_t max_size = graph->MaximumDegree();
-    select_edges_by_heuristic(top_candidates, max_size, flatten, allocator, alpha);
+    select_edges_by_heuristic(top_candidates, max_size, distance_provider, allocator, alpha);
     if (top_candidates->Size() > max_size) {
         throw VsagException(
             ErrorType::INTERNAL_ERROR,
@@ -135,17 +176,18 @@ mutually_connect_new_element(InnerIdType cur_c,
             graph->InsertNeighborsById(selected_neighbor, neighbors);
         } else {
             // finding the "weakest" element to replace it with the new one
-            float d_max = flatten->ComputePairVectors(cur_c, selected_neighbor);
+            float d_max = pairwise_distance.PairwiseDistance(selected_neighbor, cur_c);
 
             auto candidates = std::make_shared<StandardHeap<true, false>>(allocator, -1);
             candidates->Push(d_max, cur_c);
 
             for (uint64_t j = 0; j < sz_link_list_other; j++) {
-                candidates->Push(flatten->ComputePairVectors(neighbors[j], selected_neighbor),
-                                 neighbors[j]);
+                candidates->Push(
+                    pairwise_distance.PairwiseDistance(selected_neighbor, neighbors[j]),
+                    neighbors[j]);
             }
 
-            select_edges_by_heuristic(candidates, max_size, flatten, allocator, alpha);
+            select_edges_by_heuristic(candidates, max_size, distance_provider, allocator, alpha);
 
             Vector<InnerIdType> cand_neighbors(allocator);
             while (not candidates->Empty()) {
@@ -158,6 +200,40 @@ mutually_connect_new_element(InnerIdType cur_c,
     }
 
     return next_closest_entry_point;
+}
+
+void
+select_edges_by_heuristic(Vector<InnerIdType>& neighbors,
+                          InnerIdType node_id,
+                          uint64_t max_size,
+                          const FlattenInterfacePtr& flatten,
+                          Allocator* allocator,
+                          float alpha) {
+    FlattenDistanceProvider distance_provider(flatten, nullptr);
+    select_edges_by_heuristic(neighbors, node_id, max_size, distance_provider, allocator, alpha);
+}
+
+void
+select_edges_by_heuristic(const DistHeapPtr& edges,
+                          uint64_t max_size,
+                          const FlattenInterfacePtr& flatten,
+                          Allocator* allocator,
+                          float alpha) {
+    FlattenDistanceProvider distance_provider(flatten, nullptr);
+    select_edges_by_heuristic(edges, max_size, distance_provider, allocator, alpha);
+}
+
+InnerIdType
+mutually_connect_new_element(InnerIdType cur_c,
+                             const DistHeapPtr& top_candidates,
+                             const GraphInterfacePtr& graph,
+                             const FlattenInterfacePtr& flatten,
+                             const MutexArrayPtr& neighbors_mutexes,
+                             Allocator* allocator,
+                             float alpha) {
+    FlattenDistanceProvider distance_provider(flatten, nullptr);
+    return mutually_connect_new_element(
+        cur_c, top_candidates, graph, distance_provider, neighbors_mutexes, allocator, alpha);
 }
 
 }  // namespace vsag

--- a/src/impl/pruning_strategy.h
+++ b/src/impl/pruning_strategy.h
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include "impl/distance_provider_for_graph.h"
 #include "typing.h"
 #include "utils/pointer_define.h"
 
@@ -43,6 +44,13 @@ DEFINE_POINTER(MutexArray);
 void
 select_edges_by_heuristic(const DistHeapPtr& edges,
                           uint64_t max_size,
+                          const DistanceProviderForGraph& distance_provider,
+                          Allocator* allocator,
+                          float alpha = 1.0F);
+
+void
+select_edges_by_heuristic(const DistHeapPtr& edges,
+                          uint64_t max_size,
                           const FlattenInterfacePtr& flatten,
                           Allocator* allocator,
                           float alpha = 1.0F);
@@ -63,6 +71,14 @@ select_edges_by_heuristic(const DistHeapPtr& edges,
  * @param alpha Diversity parameter controlling the trade-off between proximity
  *              and diversity. Higher values allow more diverse neighbors.
  */
+void
+select_edges_by_heuristic(Vector<InnerIdType>& neighbors,
+                          InnerIdType node_id,
+                          uint64_t max_size,
+                          const DistanceProviderForGraph& distance_provider,
+                          Allocator* allocator,
+                          float alpha = 1.0F);
+
 void
 select_edges_by_heuristic(Vector<InnerIdType>& neighbors,
                           InnerIdType node_id,
@@ -89,6 +105,15 @@ select_edges_by_heuristic(Vector<InnerIdType>& neighbors,
  * @return InnerIdType The ID of the farthest selected neighbor, typically used
  *                     as an entry point for subsequent operations.
  */
+InnerIdType
+mutually_connect_new_element(InnerIdType cur_c,
+                             const DistHeapPtr& top_candidates,
+                             const GraphInterfacePtr& graph,
+                             const DistanceProviderForGraph& distance_provider,
+                             const MutexArrayPtr& neighbors_mutexes,
+                             Allocator* allocator,
+                             float alpha = 1.0F);
+
 InnerIdType
 mutually_connect_new_element(InnerIdType cur_c,
                              const DistHeapPtr& top_candidates,

--- a/src/impl/searcher/basic_searcher.cpp
+++ b/src/impl/searcher/basic_searcher.cpp
@@ -34,6 +34,10 @@ BasicSearcher::BasicSearcher(const IndexCommonParam& common_param, MutexArrayPtr
     : allocator_(common_param.allocator_.get()), mutex_array_(std::move(mutex_array)) {
 }
 
+BasicSearcher::BasicSearcher(Allocator* allocator, MutexArrayPtr mutex_array)
+    : allocator_(allocator), mutex_array_(std::move(mutex_array)) {
+}
+
 uint32_t
 BasicSearcher::visit(const GraphInterfacePtr& graph,
                      const VisitedListPtr& vl,
@@ -149,6 +153,144 @@ BasicSearcher::Search(const GraphInterfacePtr& graph,
                                          rabitq_lower_bound_candidates);
 }
 
+DistHeapPtr
+BasicSearcher::Search(const GraphInterfacePtr& graph,
+                      const DistanceProviderForGraph& distance_provider,
+                      const VisitedListPtr& vl,
+                      const InnerSearchParam& inner_search_param,
+                      Filter* attr_filter,
+                      QueryContext* ctx) const {
+    if (inner_search_param.search_mode == InnerSearchMode::RANGE_SEARCH) {
+        return this->search_impl<InnerSearchMode::RANGE_SEARCH>(
+            graph, distance_provider, vl, inner_search_param, attr_filter, ctx);
+    }
+    return this->search_impl<InnerSearchMode::KNN_SEARCH>(
+        graph, distance_provider, vl, inner_search_param, attr_filter, ctx);
+}
+
+template <InnerSearchMode mode>
+DistHeapPtr
+BasicSearcher::search_impl(const GraphInterfacePtr& graph,
+                           const DistanceProviderForGraph& distance_provider,
+                           const VisitedListPtr& vl,
+                           const InnerSearchParam& inner_search_param,
+                           Filter* attr_filter,
+                           QueryContext* ctx) const {
+    Allocator* alloc = select_query_allocator(ctx, allocator_);
+    auto top_candidates = std::make_shared<StandardHeap<true, false>>(alloc, -1);
+    auto candidate_set = std::make_shared<StandardHeap<true, false>>(alloc, -1);
+    if (not graph or not vl) {
+        return top_candidates;
+    }
+    const auto check_func = [&distance_provider, &inner_search_param, attr_filter](InnerIdType id) {
+        const auto original_id = distance_provider.OriginalId(id);
+        return distance_provider.IsValid(id) &&
+               (inner_search_param.is_inner_id_allowed == nullptr ||
+                inner_search_param.is_inner_id_allowed->CheckValid(original_id)) &&
+               (attr_filter == nullptr || attr_filter->CheckValid(id));
+    };
+    const auto ep = inner_search_param.ep;
+    const auto ef = inner_search_param.ef;
+    auto* reasoning = ctx == nullptr ? nullptr : ctx->reasoning_ctx;
+    float dist = distance_provider.QueryDistance(ep, ctx);
+    uint32_t hops = 0;
+    uint32_t dist_cmp = 1;
+    if (reasoning != nullptr) {
+        reasoning->RecordVisit(distance_provider.OriginalId(ep), dist, 0);
+    }
+    if (check_func(ep)) {
+        top_candidates->Push(dist, ep);
+    } else if (reasoning != nullptr) {
+        reasoning->RecordFilterReject(distance_provider.OriginalId(ep));
+    }
+    if constexpr (mode == InnerSearchMode::RANGE_SEARCH) {
+        if (dist > inner_search_param.radius + THRESHOLD_ERROR && not top_candidates->Empty()) {
+            top_candidates->Pop();
+        }
+    }
+    candidate_set->Push(-dist, ep);
+    vl->Set(ep);
+    auto lower_bound =
+        top_candidates->Empty() ? std::numeric_limits<float>::max() : top_candidates->Top().first;
+    Vector<InnerIdType> to_be_visited_id(graph->MaximumDegree(), alloc);
+    Vector<InnerIdType> neighbors(graph->MaximumDegree(), alloc);
+    Vector<float> line_dists(graph->MaximumDegree(), alloc);
+    while (not candidate_set->Empty()) {
+        ++hops;
+        if (hops >= inner_search_param.hops_limit) {
+            break;
+        }
+        if constexpr (mode == InnerSearchMode::KNN_SEARCH) {
+            if (-candidate_set->Top().first > lower_bound && top_candidates->Size() >= ef) {
+                break;
+            }
+        }
+        const auto current_node_pair = candidate_set->Top();
+        candidate_set->Pop();
+        if (not candidate_set->Empty()) {
+            graph->Prefetch(candidate_set->Top().second, 0);
+        }
+        const auto count_no_visited =
+            visit(graph, vl, current_node_pair, nullptr, nullptr, to_be_visited_id, neighbors);
+        distance_provider.BatchQueryDistance(
+            line_dists.data(), to_be_visited_id.data(), count_no_visited, ctx);
+        dist_cmp += count_no_visited;
+        for (uint32_t i = 0; i < count_no_visited; ++i) {
+            const auto id = to_be_visited_id[i];
+            dist = line_dists[i];
+            if (not distance_provider.IsValid(id)) {
+                continue;
+            }
+            if (reasoning != nullptr) {
+                reasoning->RecordVisit(distance_provider.OriginalId(id), dist, hops);
+            }
+            if (top_candidates->Size() < ef || lower_bound > dist ||
+                (mode == InnerSearchMode::RANGE_SEARCH &&
+                 dist <= inner_search_param.radius + THRESHOLD_ERROR)) {
+                candidate_set->Push(-dist, id);
+                distance_provider.Prefetch(candidate_set->Top().second);
+                if (check_func(id)) {
+                    top_candidates->Push(dist, id);
+                } else if (reasoning != nullptr) {
+                    reasoning->RecordFilterReject(distance_provider.OriginalId(id));
+                }
+                if constexpr (mode == InnerSearchMode::KNN_SEARCH) {
+                    if (top_candidates->Size() > ef) {
+                        if (reasoning != nullptr) {
+                            reasoning->RecordEviction(
+                                distance_provider.OriginalId(top_candidates->Top().second), hops);
+                        }
+                        top_candidates->Pop();
+                    }
+                }
+                if (not top_candidates->Empty()) {
+                    lower_bound = top_candidates->Top().first;
+                }
+            }
+        }
+    }
+    if constexpr (mode == InnerSearchMode::KNN_SEARCH) {
+        while (top_candidates->Size() > inner_search_param.topk) {
+            top_candidates->Pop();
+        }
+    } else {
+        if (inner_search_param.range_search_limit_size > 0) {
+            while (top_candidates->Size() > inner_search_param.range_search_limit_size) {
+                top_candidates->Pop();
+            }
+        }
+        while (not top_candidates->Empty() &&
+               top_candidates->Top().first > inner_search_param.radius + THRESHOLD_ERROR) {
+            top_candidates->Pop();
+        }
+    }
+    if (ctx != nullptr && ctx->stats != nullptr) {
+        ctx->stats->dist_cmp.fetch_add(dist_cmp, std::memory_order_relaxed);
+        ctx->stats->hops.fetch_add(hops, std::memory_order_relaxed);
+    }
+    return top_candidates;
+}
+
 template <InnerSearchMode mode>
 DistHeapPtr
 BasicSearcher::search_impl(const GraphInterfacePtr& graph,
@@ -253,7 +395,7 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
         auto current_node_pair = candidate_set->Top();
 
         if constexpr (mode == InnerSearchMode::KNN_SEARCH) {
-            if ((-current_node_pair.first) > lower_bound && top_candidates->Size() == ef) {
+            if ((-current_node_pair.first) > lower_bound && top_candidates->Size() >= ef) {
                 if (reasoning != nullptr) {
                     reasoning->SetTermination(ReasoningContext::kTerminationLowerBoundReached);
                 }
@@ -536,7 +678,7 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
         }
 
         if constexpr (mode == InnerSearchMode::KNN_SEARCH) {
-            if ((-current_node_pair.first) > lower_bound && top_candidates->Size() == ef) {
+            if ((-current_node_pair.first) > lower_bound && top_candidates->Size() >= ef) {
                 if (reasoning != nullptr) {
                     reasoning->SetTermination(ReasoningContext::kTerminationLowerBoundReached);
                 }

--- a/src/impl/searcher/basic_searcher.h
+++ b/src/impl/searcher/basic_searcher.h
@@ -20,6 +20,7 @@
 #include "datacell/flatten_interface.h"
 #include "datacell/graph_interface.h"
 #include "hash_types.h"
+#include "impl/distance_provider_for_graph.h"
 #include "impl/heap/distance_heap.h"
 #include "impl/inner_search_param.h"
 #include "impl/label_table/label_table.h"
@@ -42,6 +43,8 @@ class BasicSearcher {
 public:
     explicit BasicSearcher(const IndexCommonParam& common_param,
                            MutexArrayPtr mutex_array = nullptr);
+
+    explicit BasicSearcher(Allocator* allocator, MutexArrayPtr mutex_array = nullptr);
 
     virtual DistHeapPtr
     Search(const GraphInterfacePtr& graph,
@@ -74,6 +77,14 @@ public:
            QueryContext* ctx,
            DistanceRecordVector* rabitq_lower_bound_candidates = nullptr) const;
 
+    DistHeapPtr
+    Search(const GraphInterfacePtr& graph,
+           const DistanceProviderForGraph& distance_provider,
+           const VisitedListPtr& vl,
+           const InnerSearchParam& inner_search_param,
+           Filter* attr_filter,
+           QueryContext* ctx) const;
+
     virtual bool
     SetRuntimeParameters(const UnorderedMap<std::string, float>& new_params);
 
@@ -103,7 +114,7 @@ private:
           Vector<InnerIdType>& to_be_visited_id,
           Vector<InnerIdType>& neighbors) const;
 
-    template <InnerSearchMode mode = KNN_SEARCH>
+    template <InnerSearchMode mode = InnerSearchMode::KNN_SEARCH>
     DistHeapPtr
     search_impl(const GraphInterfacePtr& graph,
                 const FlattenInterfacePtr& flatten,
@@ -115,7 +126,7 @@ private:
                 DistanceRecordVector* rabitq_lower_bound_candidates,
                 const ComputerInterfacePtr& preset_computer) const;
 
-    template <InnerSearchMode mode = KNN_SEARCH>
+    template <InnerSearchMode mode = InnerSearchMode::KNN_SEARCH>
     DistHeapPtr
     search_impl(const GraphInterfacePtr& graph,
                 const FlattenInterfacePtr& flatten,
@@ -125,6 +136,15 @@ private:
                 IteratorFilterContext* iter_ctx,
                 QueryContext* ctx,
                 DistanceRecordVector* rabitq_lower_bound_candidates = nullptr) const;
+
+    template <InnerSearchMode mode = InnerSearchMode::KNN_SEARCH>
+    DistHeapPtr
+    search_impl(const GraphInterfacePtr& graph,
+                const DistanceProviderForGraph& distance_provider,
+                const VisitedListPtr& vl,
+                const InnerSearchParam& inner_search_param,
+                Filter* attr_filter,
+                QueryContext* ctx) const;
 
 private:
     Allocator* allocator_{nullptr};


### PR DESCRIPTION
## Summary

- Introduce graph distance providers for flattened and bucket-local data.
- Reuse BasicSearcher for IVF bucket graph search.
- Reuse shared pruning and mutual-connection logic for IVF bucket graph construction.
- Preserve bucket-local attribute filtering, original-ID filtering, and existing IVF graph parameters.

## Behavior

- KNN graph-bucket search raises per-bucket ef to at least the effective topk, then caps it by bucket size.
- This prevents early termination from returning fewer candidates than requested when ef is smaller than topk.
- Range-search behavior remains unchanged.

## Validation

- make fmt
- Focused production and existing test translation-unit compilation
- git diff --check
- Focused clang-tidy
- PR CI: ASan, TSAN, unit tests, functional tests, examples, compatibility, format, and DCO

Closes #2601.