### PR TITLE
perf(pyramid): reuse query computers in stats

### DIFF
--- a/src/algorithm/pyramid/pyramid_test.cpp
+++ b/src/algorithm/pyramid/pyramid_test.cpp
@@ -16,6 +16,7 @@
 #include "pyramid.h"
 
 #include <cmath>
+#include <numeric>
 #include <vector>
 
 #include "impl/allocator/safe_allocator.h"
@@ -85,6 +86,12 @@ GetPyramidSubindexCount(const std::shared_ptr<vsag::Pyramid>& index, const char*
     return stats["subindex_quality"][status].GetInt();
 }
 
+float
+GetPyramidDuplicateRatio(const std::shared_ptr<vsag::Pyramid>& index) {
+    auto stats = vsag::JsonType::Parse(index->GetStats());
+    return stats["duplicate_ratio"].GetFloat();
+}
+
 }  // namespace
 
 TEST_CASE("Split function tests", "[ut][pyramid]") {
@@ -127,6 +134,28 @@ TEST_CASE("Split function tests", "[ut][pyramid]") {
         auto result = vsag::split("  , hello,  world  ", ',');
         REQUIRE(result == std::vector<std::string>{"  ", " hello", "  world  "});
     }
+}
+
+TEST_CASE("Pyramid stats count duplicates within each leaf", "[ut][pyramid][analyzer]") {
+    constexpr int64_t count = 7;
+    auto test_index = MakePyramidIndex(100, 1, true);
+    const auto& index = test_index.index;
+    std::vector<float> vectors = {
+        1.0F, 2.0F, 3.0F, 4.0F,  // leaf a: representative
+        1.0F, 2.0F, 3.0F, 4.0F,  // leaf a: duplicate
+        2.0F, 3.0F, 4.0F, 5.0F,  // leaf a: unique
+        1.0F, 2.0F, 3.0F, 4.0F,  // leaf b: not a cross-leaf duplicate
+        6.0F, 7.0F, 8.0F, 9.0F,  // leaf c: representative
+        6.0F, 7.0F, 8.0F, 9.0F,  // leaf c: duplicate
+        9.0F, 8.0F, 7.0F, 6.0F,  // leaf d: singleton
+    };
+    std::vector<int64_t> ids(count);
+    std::iota(ids.begin(), ids.end(), 0);
+    std::vector<std::string> paths = {"a", "a", "a", "b", "c", "c", "d"};
+
+    REQUIRE(
+        index->Build(MakePyramidDataset(vectors.data(), ids.data(), paths.data(), count)).empty());
+    REQUIRE(std::abs(GetPyramidDuplicateRatio(index) - 2.0F / static_cast<float>(count)) < 1e-6F);
 }
 
 TEST_CASE("Pyramid promotes flat node at index minimum size", "[ut][pyramid]") {

--- a/src/analyzer/pyramid_analyzer.cpp
+++ b/src/analyzer/pyramid_analyzer.cpp
@@ -471,6 +471,7 @@ PyramidAnalyzer::sample_global() {
         return;
     }
 
+    duplicate_computers_.clear();
     sample_ids_.clear();
     sample_datas_.clear();
 
@@ -1351,7 +1352,7 @@ PyramidAnalyzer::get_graph_node_recall_stats(IndexNode* root, const std::string&
                         uint32_t entry_point_group_size = 0;
 
                         if (!node_ids.empty()) {
-                            duplicate_ratio = get_node_duplicate_ratio(node, node_ids);
+                            duplicate_ratio = get_node_duplicate_ratio(node_ids);
                             if (node->status_ == IndexNode::Status::GRAPH && node->graph_) {
                                 entry_point_duplicate = check_entry_point_duplicate(
                                     node, node_ids, entry_point_group_size);
@@ -1434,7 +1435,7 @@ PyramidAnalyzer::GetDuplicateRatio(IndexNode* root) {
                 return;
             }
 
-            float duplicate_ratio = get_node_duplicate_ratio(node, node_ids);
+            float duplicate_ratio = get_node_duplicate_ratio(node_ids);
             auto duplicate_count =
                 static_cast<uint32_t>(duplicate_ratio * static_cast<float>(node_ids.size()));
 
@@ -1454,10 +1455,26 @@ PyramidAnalyzer::GetDuplicateRatio(IndexNode* root) {
                : 0.0F;
 }
 
+const Vector<ComputerInterfacePtr>&
+PyramidAnalyzer::get_duplicate_computers() {
+    if (duplicate_computers_.empty() && not sample_datas_.empty()) {
+        auto codes = pyramid_->base_codes_;
+        duplicate_computers_.reserve(sample_ids_.size());
+        for (uint64_t q = 0; q < sample_ids_.size(); ++q) {
+            duplicate_computers_.push_back(codes->FactoryComputer(sample_datas_.data() + q * dim_));
+        }
+    }
+    return duplicate_computers_;
+}
+
 float
-PyramidAnalyzer::get_node_duplicate_ratio(const IndexNode* node,
-                                          const Vector<InnerIdType>& node_ids) {
+PyramidAnalyzer::get_node_duplicate_ratio(const Vector<InnerIdType>& node_ids) {
     if (node_ids.empty() || sample_datas_.empty()) {
+        return 0.0F;
+    }
+
+    const auto& computers = get_duplicate_computers();
+    if (computers.empty()) {
         return 0.0F;
     }
 
@@ -1467,10 +1484,8 @@ PyramidAnalyzer::get_node_duplicate_ratio(const IndexNode* node,
     Vector<Vector<InnerIdType>> groups(allocator_);
     groups.emplace_back(node_ids.begin(), node_ids.end(), allocator_);
 
-    auto query_count = static_cast<uint32_t>(sample_ids_.size());
-    for (uint32_t q = 0; q < query_count && !groups.empty(); ++q) {
+    for (uint64_t q = 0; q < computers.size() && not groups.empty(); ++q) {
         Vector<Vector<InnerIdType>> new_groups(allocator_);
-        auto comp = codes->FactoryComputer(sample_datas_.data() + static_cast<size_t>(q) * dim_);
 
         for (auto& group : groups) {
             if (group.empty()) {
@@ -1478,10 +1493,10 @@ PyramidAnalyzer::get_node_duplicate_ratio(const IndexNode* node,
             }
 
             Vector<float> dists(group.size(), allocator_);
-            codes->Query(dists.data(), comp, group.data(), group.size());
+            codes->Query(dists.data(), computers[q], group.data(), group.size());
 
             Vector<std::pair<float, InnerIdType>> sorted(group.size(), allocator_);
-            for (size_t i = 0; i < group.size(); ++i) {
+            for (uint64_t i = 0; i < group.size(); ++i) {
                 sorted[i] = {dists[i], group[i]};
             }
             std::sort(sorted.begin(), sorted.end());
@@ -1490,7 +1505,7 @@ PyramidAnalyzer::get_node_duplicate_ratio(const IndexNode* node,
             sub.push_back(sorted[0].second);
             float first_dist = sorted[0].first;
 
-            for (size_t i = 1; i < sorted.size(); ++i) {
+            for (uint64_t i = 1; i < sorted.size(); ++i) {
                 if (sorted[i].first - first_dist <= epsilon) {
                     sub.push_back(sorted[i].second);
                 } else {

--- a/src/analyzer/pyramid_analyzer.h
+++ b/src/analyzer/pyramid_analyzer.h
@@ -26,6 +26,7 @@ public:
           sample_ids_(pyramid->allocator_),
           sample_datas_(pyramid->allocator_),
           subindex_stats_(pyramid->allocator_),
+          duplicate_computers_(pyramid->allocator_),
           ground_truth_(pyramid->allocator_),
           search_result_(pyramid->allocator_),
           low_recall_nodes_(pyramid->allocator_),
@@ -188,8 +189,11 @@ private:
     get_avg_distance_from_groundtruth(const Vector<InnerIdType>& sample_ids,
                                       const UnorderedMap<InnerIdType, DistHeapPtr>& ground_truth);
 
+    const Vector<ComputerInterfacePtr>&
+    get_duplicate_computers();
+
     float
-    get_node_duplicate_ratio(const IndexNode* node, const Vector<InnerIdType>& node_ids);
+    get_node_duplicate_ratio(const Vector<InnerIdType>& node_ids);
 
     bool
     check_entry_point_duplicate(const IndexNode* node,
@@ -202,6 +206,7 @@ private:
     Vector<float> sample_datas_;
     uint32_t sample_size_;
     Vector<SubIndexStats> subindex_stats_;
+    Vector<ComputerInterfacePtr> duplicate_computers_;
 
     UnorderedMap<InnerIdType, DistHeapPtr> ground_truth_;
     UnorderedMap<InnerIdType, Vector<LabelType>> search_result_;


### PR DESCRIPTION
## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement/Refactor
- [ ] Documentation
- [ ] CI/Build/Infra

## Linked Issue

Not required for `kind/improvement`.

## What Changed

- Cache one query `Computer` per Pyramid analyzer sample and reuse it across all leaf nodes.
- Clear the cached computers whenever the analyzer regenerates its sample data.
- Preserve the existing duplicate grouping, counting, and output semantics.
- Add a RabitQ + SQ8 regression test covering duplicate statistics across multiple leaves.

### Root cause

`GetDuplicateRatio()` previously created a new query computer inside the per-leaf loop. For
RabitQ with the default dense random orthogonal transform, `FactoryComputer()` preprocesses the
query with a `dim x dim` matrix-vector multiplication. A Pyramid containing many small leaves
therefore repeated the same expensive preprocessing for the same sample queries at every leaf,
even though all leaves share the same globally trained `base_codes_` quantizer.

The cached computer depends only on the sample query and the shared quantizer; each leaf still
passes its own IDs to `Query()` exactly as before.

## Test Evidence

- [ ] `make fmt`
- [ ] `make lint`
- [x] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [x] Other (clang-format 15 dry-run and `git diff --check`)

Test details:

```text
make test COMPILE_JOBS=12 UT_FILTER='[ut][pyramid]' EXTRA_DEFINED=-DENABLE_CCACHE=ON

All tests passed (34 assertions in 4 test cases)
```

The parsed pre-change and post-change JSON objects were also compared on the 5K and 10K
benchmark datasets and were identical.

## Compatibility Impact

- API/ABI compatibility: no public API or serialized format changes
- Behavior changes: none; duplicate-statistics semantics are unchanged

## Performance and Concurrency Impact

- Performance impact: substantially improved for high-dimensional RabitQ indexes with many leaves
- Concurrency/thread-safety impact: none; the analyzer continues to traverse leaves sequentially

Release benchmark configuration:

- L2, 4096 dimensions
- RabitQ 1-bit base codes, SQ8 precise codes, `use_fht=false`
- approximately 24.9% duplicates
- approximately 4.84 vectors per leaf

| Vectors | Leaves | Before | After | Speedup |
| ---: | ---: | ---: | ---: | ---: |
| 5,000 | 1,009 | 5.272 s | 0.027 s | 195x |
| 10,000 | 1,999 | 10.771 s | 0.045 s | 239x |
| 20,000 | 4,133 | 21.768 s | 0.084 s | 259x |

Sampling the pre-change 4096-dimensional run showed approximately 99% of the sampled
`GetDuplicateRatio()` time under RabitQ query preprocessing and its dense `Sgemv` transform.

## Documentation Impact

- [x] No docs update needed
- [ ] Updated docs

## Risk and Rollback

- Risk level: low
- Rollback plan: revert the single performance commit

## Checklist

- [x] Linked issue is not required for this `kind/improvement` PR
- [x] I have added/updated tests for the optimized behavior
- [x] I have considered API compatibility impact
- [x] Documentation is not affected
- [x] My commit message follows project conventions
