### PR TITLE
fix: reorder IVF custom-distance filters

### DIFF
--- a/src/algorithm/ivf/ivf.cpp
+++ b/src/algorithm/ivf/ivf.cpp
@@ -1863,21 +1863,6 @@ IVF::SearchWithRequest(const SearchRequest& request) const {
             param.executors.emplace_back(executor);
         }
     }
-    if (use_custom_distance) {
-        param.search_mode = KNN_SEARCH;
-        param.topk = request.topk_;
-        auto search_result = search_with_custom_distance(query, request, param, ctx);
-        filter_search_result_by_threshold(
-            search_result, request.threshold_, select_query_allocator(ctx.alloc, this->allocator_));
-        if (search_result == nullptr || search_result->Empty()) {
-            auto dataset_results = DatasetImpl::MakeEmptyDataset();
-            dataset_results->Statistics(stats.Dump());
-            return dataset_results;
-        }
-        auto dataset_results = this->pack_knn_result(search_result, ctx.alloc);
-        dataset_results->Statistics(stats.Dump());
-        return dataset_results;
-    }
     std::shared_ptr<ReasoningContext> reasoning_ctx;
     if (not request.expected_labels_.empty()) {
         reasoning_ctx = std::make_shared<ReasoningContext>(this->allocator_);
@@ -1913,6 +1898,25 @@ IVF::SearchWithRequest(const SearchRequest& request) const {
             reasoning_ctx->SetTrueDistance(inner_id, dist);
         }
         ctx.reasoning_ctx = reasoning_ctx.get();
+    }
+
+    if (use_custom_distance) {
+        param.search_mode = KNN_SEARCH;
+        param.topk = request.topk_;
+        auto search_result =
+            search_with_custom_distance(query, request, param, ctx, reasoning_ctx.get());
+        filter_search_result_by_threshold(
+            search_result, request.threshold_, select_query_allocator(ctx.alloc, this->allocator_));
+        if (search_result == nullptr || search_result->Empty()) {
+            auto dataset_results = DatasetImpl::MakeEmptyDataset();
+            this->AttachReasoningReport(dataset_results, reasoning_ctx.get());
+            dataset_results->Statistics(stats.Dump());
+            return dataset_results;
+        }
+        auto dataset_results = this->pack_knn_result(search_result, ctx.alloc);
+        this->AttachReasoningReport(dataset_results, reasoning_ctx.get());
+        dataset_results->Statistics(stats.Dump());
+        return dataset_results;
     }
 
     if (is_range) {

--- a/src/algorithm/ivf/ivf.cpp
+++ b/src/algorithm/ivf/ivf.cpp
@@ -1664,8 +1664,15 @@ IVF::search_with_custom_distance(const DatasetPtr& query,
         for (uint64_t i = 0; i < candidate_ids.size(); ++i) {
             CHECK_ARGUMENT(std::isfinite(scores[i]),
                            "custom query distance callback must return finite scores");
+            const auto origin_id = candidate_ids[i] / buckets_per_data_;
+            if (filter != nullptr and not filter->CheckValid(origin_id)) {
+                if (reasoning_ctx != nullptr) {
+                    reasoning_ctx->RecordFilterReject(origin_id);
+                }
+                continue;
+            }
             if (reasoning_ctx != nullptr) {
-                reasoning_ctx->RecordVisit(candidate_ids[i] / buckets_per_data_, scores[i], 0);
+                reasoning_ctx->RecordVisit(origin_id, scores[i], 0);
             }
             search_result->Push(scores[i], candidate_ids[i]);
             while (search_result->Size() > static_cast<uint64_t>(topk)) {
@@ -1703,12 +1710,6 @@ IVF::search_with_custom_distance(const DatasetPtr& query,
             }
             const auto origin_id = inner_id / buckets_per_data_;
             if (attr_filter != nullptr and not attr_filter->CheckValid(offset)) {
-                if (reasoning_ctx != nullptr) {
-                    reasoning_ctx->RecordFilterReject(origin_id);
-                }
-                continue;
-            }
-            if (filter != nullptr and not filter->CheckValid(origin_id)) {
                 if (reasoning_ctx != nullptr) {
                     reasoning_ctx->RecordFilterReject(origin_id);
                 }

--- a/tests/test_ivf.cpp
+++ b/tests/test_ivf.cpp
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <algorithm>
 #include <cstring>
 #include <limits>
 #include <sstream>
@@ -1911,6 +1912,72 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::IVFTestIndex,
     REQUIRE(result.value()->GetDim() == 1);
     REQUIRE(result.value()->GetIds()[0] == 20);
     REQUIRE(result.value()->GetDistances()[0] == 1.0F);
+class AllowEveryFourthLabelFilter : public vsag::Filter {
+public:
+    bool
+    CheckValid(int64_t label) const override {
+        return (label >> 16) % 4 == 0;
+    }
+};
+
+TEST_CASE("IVF custom distance applies general filtering after attribute callback",
+          "[ft][search][ivf][attribute][pr]") {
+    constexpr int64_t dim = 4;
+    constexpr int64_t count = 12;
+    auto base = vsag::Dataset::Make();
+    auto* vectors = new float[count * dim]{};
+    auto* labels = new int64_t[count];
+    auto* attribute_sets = new vsag::AttributeSet[count];
+    for (int64_t i = 0; i < count; ++i) {
+        labels[i] = i << 16;
+        auto* attribute = new vsag::AttributeValue<std::string>();
+        attribute->name_ = "group";
+        attribute->GetValue() = {i % 2 == 0 ? "callback" : "excluded"};
+        attribute_sets[i].attrs_.push_back(attribute);
+    }
+    base->NumElements(count)
+        ->Dim(dim)
+        ->Float32Vectors(vectors)
+        ->Ids(labels)
+        ->AttributeSets(attribute_sets)
+        ->Owner(true);
+
+    auto param = IVFTestIndex::GenerateIVFBuildParametersString(
+        "l2", dim, "fp32", 1, "kmeans", false, 1, true);
+    auto index = TestIndex::TestFactory(IVFTestIndex::name, param, true);
+    REQUIRE(index->Build(base).has_value());
+
+    std::vector<int64_t> callback_labels;
+    auto query = vsag::Dataset::Make();
+    query->NumElements(1)->Dim(dim)->Float32Vectors(vectors)->Owner(false);
+    vsag::SearchRequest request;
+    request.query_ = query;
+    request.topk_ = 3;
+    request.params_str_ = R"({"ivf":{"scan_buckets_count":1}})";
+    request.filter_ = std::make_shared<AllowEveryFourthLabelFilter>();
+    request.enable_attribute_filter_ = true;
+    request.attribute_filter_str_ = R"(multi_in(group, "callback", "|"))";
+    request.distance_batch_size_ = 2;
+    request.distance_batch_func_ = [&callback_labels](
+                                       const int64_t* ids, uint64_t size, float* distances) {
+        callback_labels.insert(callback_labels.end(), ids, ids + size);
+        for (uint64_t i = 0; i < size; ++i) {
+            distances[i] = static_cast<float>(ids[i]);
+        }
+    };
+
+    auto result = index->SearchWithRequest(request);
+    REQUIRE(result.has_value());
+    REQUIRE(callback_labels.size() == 6);
+    for (int64_t i = 0; i < count; ++i) {
+        const auto found = std::find(callback_labels.begin(), callback_labels.end(), labels[i]);
+        REQUIRE((found != callback_labels.end()) == (i % 2 == 0));
+    }
+    REQUIRE(result.value()->GetDim() == 3);
+    for (int64_t i = 0; i < result.value()->GetDim(); ++i) {
+        REQUIRE(result.value()->GetIds()[i] == labels[i * 4]);
+        REQUIRE(result.value()->GetDistances()[i] == static_cast<float>(labels[i * 4]));
+    }
 }
 
 // RejectAllFilter for testing empty results

--- a/tests/test_ivf.cpp
+++ b/tests/test_ivf.cpp
@@ -1912,6 +1912,8 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::IVFTestIndex,
     REQUIRE(result.value()->GetDim() == 1);
     REQUIRE(result.value()->GetIds()[0] == 20);
     REQUIRE(result.value()->GetDistances()[0] == 1.0F);
+}
+
 class AllowEveryFourthLabelFilter : public vsag::Filter {
 public:
     bool

--- a/tests/test_ivf.cpp
+++ b/tests/test_ivf.cpp
@@ -1942,9 +1942,9 @@ TEST_CASE("IVF custom distance applies general filtering after attribute callbac
         ->AttributeSets(attribute_sets)
         ->Owner(true);
 
-    auto param = IVFTestIndex::GenerateIVFBuildParametersString(
+    auto param = fixtures::IVFTestIndex::GenerateIVFBuildParametersString(
         "l2", dim, "fp32", 1, "kmeans", false, 1, true);
-    auto index = TestIndex::TestFactory(IVFTestIndex::name, param, true);
+    auto index = fixtures::TestIndex::TestFactory(fixtures::IVFTestIndex::name, param, true);
     REQUIRE(index->Build(base).has_value());
 
     std::vector<int64_t> callback_labels;


### PR DESCRIPTION
## Summary
- invoke custom distance callbacks for all attribute-matched candidates
- apply the general filter after callback scoring and before heap insertion
- cover custom distance, attribute filtering, and a general label filter together

## Testing
- make fmt
- make test UT_FILTER="IVF custom distance applies general filtering after attribute callback" (blocked: Boost mirror returned HTTP 403 while fetching boost_1_67_0.tar.gz)

Fixes #2612