### PR TITLE
fix(pyramid): stop range trimming at an empty heap

### DIFF
--- a/src/algorithm/pyramid/pyramid.cpp
+++ b/src/algorithm/pyramid/pyramid.cpp
@@ -551,8 +551,8 @@ Pyramid::search_impl(const DatasetPtr& query,
         return DatasetImpl::MakeEmptyDataset();
     }
 
-    while (search_result->Size() > search_param.topk ||
-           search_result->Top().first > search_param.radius) {
+    while (not search_result->Empty() && (search_result->Size() > search_param.topk ||
+                                          search_result->Top().first > search_param.radius)) {
         search_result->Pop();
     }
 

--- a/tests/test_pyramid.cpp
+++ b/tests/test_pyramid.cpp
@@ -248,6 +248,23 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
 }
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
+                             "Pyramid RangeSearch Returns Empty Result",
+                             "[ft][pyramid]") {
+    PyramidParam pyramid_param;
+    const auto param = GeneratePyramidBuildParametersString("l2", 4, pyramid_param);
+    auto index = TestFactory("pyramid", param, true);
+
+    auto base = MakeDenseDataset(
+        {{{1.0F, 0.0F, 0.0F, 0.0F}}, {{2.0F, 0.0F, 0.0F, 0.0F}}}, {1, 2}, {"a/d/f", "a/d/f"});
+    REQUIRE(index->Build(base).has_value());
+
+    auto query = MakeSingleQuery({10.0F, 0.0F, 0.0F, 0.0F}, "a/d/f");
+    auto result = index->RangeSearch(query, 0.0F, GeneratePyramidSearchParametersString(20));
+    REQUIRE(result.has_value());
+    REQUIRE(result.value()->GetDim() == 0);
+}
+
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
                              "Pyramid Set Immutable",
                              "[ft][immutable][pyramid]") {
     const auto metric_type = "l2";


### PR DESCRIPTION
## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement/Refactor
- [ ] Documentation
- [ ] CI/Build/Infra

## Linked Issue

- Fixes: #2565

## What Changed

- Stop Pyramid range-result trimming when the result heap becomes empty before reading `Top()` again.
- Add a deterministic regression where every candidate lies outside the requested radius and verify that `RangeSearch` returns an empty result.

### Root cause

`Pyramid::search_impl` checked `search_result->Top()` after popping the final candidate. When all candidates were outside the radius, this accessed and popped an empty heap, causing undefined behavior that could leave the functional test spinning until the CI job timeout.

## Test Evidence

- [ ] `make fmt`
- [ ] `make lint`
- [ ] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [x] Other (described below)

Test details:

```text
# Before the fix: deterministic regression remained live and was interrupted after 17.8 s
./build/tests/functests "Pyramid RangeSearch Returns Empty Result" -d yes

# After the fix
./build/tests/functests "Pyramid RangeSearch Returns Empty Result" -d yes
All tests passed (6 assertions in 1 test case)

./build/tests/functests "Pyramid Build & ContinueAdd Test" -d yes
All tests passed (48144 assertions in 1 test case)

/opt/homebrew/Cellar/llvm@15/15.0.7/bin/clang-format --dry-run --Werror \
  src/algorithm/pyramid/pyramid.cpp tests/test_pyramid.cpp
git diff upstream/main...HEAD --check
```

## Compatibility Impact

- API/ABI compatibility: none
- Behavior changes: `RangeSearch` now returns an empty dataset instead of accessing an empty heap when all candidates are outside the radius.

## Performance and Concurrency Impact

- Performance impact: negligible; one emptiness check is added to the existing result-trimming loop.
- Concurrency/thread-safety impact: none.

## Documentation Impact

- [x] No docs update needed
- [ ] Updated docs:
  - [ ] `README.md`
  - [ ] `DEVELOPMENT.md`
  - [ ] `CONTRIBUTING.md`
  - [ ] Other:

## Risk and Rollback

- Risk level: low
- Rollback plan: revert the fix commit.

## Checklist

- [x] I have linked the relevant issue.
- [x] I have added/updated tests for the bug fix.
- [x] I have considered API compatibility impact.
- [x] No documentation update is required.
- [x] My commit message follows project conventions.
