### PR TITLE
perf: cache DiskANN artifact sizes for memory usage

### DIFF
--- a/src/index/diskann.cpp
+++ b/src/index/diskann.cpp
@@ -177,12 +177,14 @@ convert_stream_to_binary(const std::stringstream& stream) {
     return std::move(binary);
 }
 
-void
+uint64_t
 convert_binary_to_stream(const Binary& binary, std::stringstream& stream) {
     stream.str("");
     if (binary.data && binary.size > 0) {
         stream.write((const char*)binary.data.get(), static_cast<int64_t>(binary.size));
+        return binary.size;
     }
+    return 0;
 }
 
 void
@@ -342,6 +344,8 @@ DiskANN::build(const DatasetPtr& base) {
             tag_stream_.write((char*)&data_num_int32, sizeof(data_num_int32));
             tag_stream_.write((char*)&data_dim_int32, sizeof(data_dim_int32));
             tag_stream_.write((char*)ids, static_cast<std::streamsize>(data_num * sizeof(ids)));
+            graph_stream_size_ = get_stringstream_size(graph_stream_);
+            tag_stream_size_ = get_stringstream_size(tag_stream_);
         } else if (diskann_params_.graph_type == DISKANN_GRAPH_TYPE_VAMANA) {
             SlowTaskTimer t("diskann build full (graph)");
             // build graph
@@ -356,6 +360,8 @@ DiskANN::build(const DatasetPtr& base) {
                 build_index_->build(vectors, data_num, index_build_params, tags, use_reference_);
             build_index_->save(graph_stream_, tag_stream_);
             build_index_.reset();
+            graph_stream_size_ = get_stringstream_size(graph_stream_);
+            tag_stream_size_ = get_stringstream_size(tag_stream_);
         }
         {
             SlowTaskTimer t("diskann build full (pq)");
@@ -370,6 +376,9 @@ DiskANN::build(const DatasetPtr& base) {
                                                          disk_pq_dims_,
                                                          use_opq_,
                                                          use_bsa_);
+            pq_pivots_stream_size_ = get_stringstream_size(pq_pivots_stream_);
+            disk_pq_compressed_vectors_size_ =
+                get_stringstream_size(disk_pq_compressed_vectors_);
         }
         {
             SlowTaskTimer t("diskann build full (disk layout)");
@@ -381,6 +390,7 @@ DiskANN::build(const DatasetPtr& base) {
                                                disk_layout_stream_,
                                                sector_len_,
                                                metric_);
+            disk_layout_stream_size_ = get_stringstream_size(disk_layout_stream_);
         }
 
         std::vector<int64_t> failed_ids;
@@ -774,7 +784,8 @@ DiskANN::deserialize(const BinarySet& binary_set) {
             return {};
         }
 
-        convert_binary_to_stream(binary_set.Get(DISKANN_LAYOUT_FILE), disk_layout_stream_);
+        disk_layout_stream_size_ =
+            convert_binary_to_stream(binary_set.Get(DISKANN_LAYOUT_FILE), disk_layout_stream_);
         auto graph = binary_set.Get(DISKANN_GRAPH);
         if (/* trying to use graph-preload mode if parameter sets */ preload_) {
             if (not metadata->Get("support_preload").GetBool()) {
@@ -782,7 +793,7 @@ DiskANN::deserialize(const BinarySet& binary_set) {
                     ErrorType::MISSING_FILE,
                     fmt::format("missing file: {} when deserialize diskann index", DISKANN_GRAPH));
             }
-            convert_binary_to_stream(graph, graph_stream_);
+            graph_stream_size_ = convert_binary_to_stream(graph, graph_stream_);
         } else if (/* not use graph-preload mode, but contains */ graph.data) {
             logger::warn("serialize without using file: {} ", DISKANN_GRAPH);
         }
@@ -802,11 +813,12 @@ DiskANN::deserialize(const BinarySet& binary_set) {
         return {};
     }
 
-    convert_binary_to_stream(binary_set.Get(DISKANN_LAYOUT_FILE), disk_layout_stream_);
+    disk_layout_stream_size_ =
+        convert_binary_to_stream(binary_set.Get(DISKANN_LAYOUT_FILE), disk_layout_stream_);
     auto graph = binary_set.Get(DISKANN_GRAPH);
     if (preload_) {
         if (graph.data) {
-            convert_binary_to_stream(graph, graph_stream_);
+            graph_stream_size_ = convert_binary_to_stream(graph, graph_stream_);
         } else {
             LOG_ERROR_AND_RETURNS(
                 ErrorType::MISSING_FILE,
@@ -1086,6 +1098,19 @@ DiskANN::deserialize(std::istream& in_stream) {
     return {};
 }
 
+uint64_t
+DiskANN::GetMemoryUsage() const {
+    std::shared_lock lock(rw_mutex_);
+    if (status_ == MEMORY) {
+        return index_->get_memory_usage() + disk_pq_compressed_vectors_size_ +
+               pq_pivots_stream_size_ + disk_layout_stream_size_ + tag_stream_size_ +
+               graph_stream_size_;
+    } else if (status_ == HYBRID) {
+        return index_->get_memory_usage();
+    }
+    return 0;
+}
+
 std::string
 DiskANN::GetStats() const {
     JsonType j;
@@ -1260,6 +1285,9 @@ DiskANN::continue_build(const DatasetPtr& base, const BinarySet& binary_set) {
                                                              p_val_,
                                                              disk_pq_dims_,
                                                              use_opq_);
+                pq_pivots_stream_size_ = get_stringstream_size(pq_pivots_stream_);
+                disk_pq_compressed_vectors_size_ =
+                    get_stringstream_size(disk_pq_compressed_vectors_);
                 after_binary_set = binary_set;
                 after_binary_set.Set(DISKANN_PQ, convert_stream_to_binary(pq_pivots_stream_));
                 after_binary_set.Set(DISKANN_COMPRESSED_VECTOR,
@@ -1271,7 +1299,8 @@ DiskANN::continue_build(const DatasetPtr& base, const BinarySet& binary_set) {
                 SlowTaskTimer t(fmt::format("diskann build (disk layout)"));
                 auto failed_locs = deserialize_vector_from_binary<uint64_t>(
                     after_binary_set.Get(BUILD_FAILED_LOC));
-                convert_binary_to_stream(binary_set.Get(DISKANN_GRAPH), graph_stream_);
+                graph_stream_size_ =
+                    convert_binary_to_stream(binary_set.Get(DISKANN_GRAPH), graph_stream_);
                 diskann::create_disk_layout<float>(base->GetFloat32Vectors(),
                                                    base->GetNumElements(),
                                                    dim_,
@@ -1280,6 +1309,7 @@ DiskANN::continue_build(const DatasetPtr& base, const BinarySet& binary_set) {
                                                    disk_layout_stream_,
                                                    sector_len_,
                                                    metric_);
+                disk_layout_stream_size_ = get_stringstream_size(disk_layout_stream_);
                 load_disk_index(binary_set);
                 build_status = BuildStatus::FINISH;
                 status_ = IndexStatus::MEMORY;
@@ -1337,6 +1367,8 @@ DiskANN::build_partial_graph(const DatasetPtr& base,
                                 static_cast<int32_t>(build_batch_num_),
                                 &builded_nodes);
         build_index_->save(graph_stream_, tag_stream_);
+        graph_stream_size_ = get_stringstream_size(graph_stream_);
+        tag_stream_size_ = get_stringstream_size(tag_stream_);
         after_binary_set.Set(BUILD_NODES,
                              serialize_to_binary<std::unordered_set<uint32_t>>(builded_nodes));
         after_binary_set.Set(BUILD_FAILED_LOC, serialize_vector_to_binary<uint64_t>(failed_locs));
@@ -1354,15 +1386,17 @@ DiskANN::load_disk_index(const BinarySet& binary_set) {
     index_.reset(new diskann::PQFlashIndex<float, int64_t>(
         reader_, metric_, sector_len_, dim_, use_bsa_, support_calc_distance_by_id_));
 
-    convert_binary_to_stream(binary_set.Get(DISKANN_COMPRESSED_VECTOR),
-                             disk_pq_compressed_vectors_);
-    convert_binary_to_stream(binary_set.Get(DISKANN_PQ), pq_pivots_stream_);
-    convert_binary_to_stream(binary_set.Get(DISKANN_TAG_FILE), tag_stream_);
+    disk_pq_compressed_vectors_size_ = convert_binary_to_stream(
+        binary_set.Get(DISKANN_COMPRESSED_VECTOR), disk_pq_compressed_vectors_);
+    pq_pivots_stream_size_ = convert_binary_to_stream(binary_set.Get(DISKANN_PQ),
+                                                      pq_pivots_stream_);
+    tag_stream_size_ = convert_binary_to_stream(binary_set.Get(DISKANN_TAG_FILE), tag_stream_);
     index_->load_from_separate_paths(pq_pivots_stream_, disk_pq_compressed_vectors_, tag_stream_);
     if (preload_) {
         index_->load_graph(graph_stream_);
     } else {
         graph_stream_.str("");
+        graph_stream_size_ = 0;
     }
     return {};
 }

--- a/src/index/diskann.h
+++ b/src/index/diskann.h
@@ -177,16 +177,7 @@ public:
     }
 
     uint64_t
-    GetMemoryUsage() const override {
-        if (status_ == MEMORY) {
-            return index_->get_memory_usage() + disk_pq_compressed_vectors_.str().size() +
-                   pq_pivots_stream_.str().size() + disk_layout_stream_.str().size() +
-                   tag_stream_.str().size() + graph_stream_.str().size();
-        } else if (status_ == HYBRID) {
-            return index_->get_memory_usage();
-        }
-        return 0;
-    }
+    GetMemoryUsage() const override;
 
     uint64_t
     EstimateBuildMemory(uint64_t num_elements) const override;
@@ -277,6 +268,11 @@ private:
     std::stringstream disk_layout_stream_;
     std::stringstream tag_stream_;
     std::stringstream graph_stream_;
+    uint64_t pq_pivots_stream_size_ = 0;
+    uint64_t disk_pq_compressed_vectors_size_ = 0;
+    uint64_t disk_layout_stream_size_ = 0;
+    uint64_t tag_stream_size_ = 0;
+    uint64_t graph_stream_size_ = 0;
 
     const IndexCommonParam index_common_param_;
 

--- a/src/index/diskann_test.cpp
+++ b/src/index/diskann_test.cpp
@@ -40,6 +40,15 @@ parse_diskann_params(vsag::IndexCommonParam index_common_param) {
     return vsag::DiskannParameters::FromJson(parsed_params, index_common_param);
 }
 
+uint64_t
+get_diskann_artifact_size(const vsag::BinarySet& binary_set) {
+    return binary_set.Get(vsag::DISKANN_PQ).size +
+           binary_set.Get(vsag::DISKANN_COMPRESSED_VECTOR).size +
+           binary_set.Get(vsag::DISKANN_LAYOUT_FILE).size +
+           binary_set.Get(vsag::DISKANN_TAG_FILE).size +
+           binary_set.Get(vsag::DISKANN_GRAPH).size;
+}
+
 TEST_CASE("diskann build", "[ut][diskann]") {
     vsag::logger::set_level(vsag::logger::level::debug);
     vsag::IndexCommonParam common_param;
@@ -449,6 +458,49 @@ TEST_CASE("deserialize on not empty index", "[ut][diskann]") {
     auto voidresult = index->Deserialize(binary_set.value());
     REQUIRE_FALSE(voidresult.has_value());
     REQUIRE(voidresult.error().type == vsag::ErrorType::INDEX_NOT_EMPTY);
+}
+
+TEST_CASE("diskann memory usage accounts cached artifacts", "[ut][diskann]") {
+    vsag::logger::set_level(vsag::logger::level::debug);
+    vsag::IndexCommonParam common_param;
+    common_param.dim_ = 128;
+    common_param.data_type_ = vsag::DataTypes::DATA_TYPE_FLOAT;
+    common_param.metric_ = vsag::MetricType::METRIC_TYPE_L2SQR;
+    vsag::DiskannParameters diskann_obj = parse_diskann_params(common_param);
+    diskann_obj.metric = diskann::Metric::L2;
+    diskann_obj.pq_sample_rate = 1.0f;
+    diskann_obj.pq_dims = 16;
+    diskann_obj.max_degree = 12;
+    diskann_obj.ef_construction = 100;
+    diskann_obj.use_bsa = false;
+    diskann_obj.use_reference = false;
+    diskann_obj.use_preload = true;
+
+    auto index = std::make_shared<vsag::DiskANN>(diskann_obj, common_param);
+
+    int64_t num_elements = 100;
+    auto [ids, vectors] = fixtures::generate_ids_and_vectors(num_elements, common_param.dim_);
+
+    auto dataset = vsag::Dataset::Make();
+    dataset->Dim(common_param.dim_)
+        ->NumElements(num_elements)
+        ->Ids(ids.data())
+        ->Float32Vectors(vectors.data())
+        ->Owner(false);
+    auto result = index->Build(dataset);
+    REQUIRE(result.has_value());
+
+    auto binary_set = index->Serialize();
+    REQUIRE(binary_set.has_value());
+
+    const auto artifact_size = get_diskann_artifact_size(binary_set.value());
+    REQUIRE(artifact_size > 0);
+    REQUIRE(index->GetMemoryUsage() >= artifact_size);
+
+    auto restored_index = std::make_shared<vsag::DiskANN>(diskann_obj, common_param);
+    auto deserialize_result = restored_index->Deserialize(binary_set.value());
+    REQUIRE(deserialize_result.has_value());
+    REQUIRE(restored_index->GetMemoryUsage() >= artifact_size);
 }
 
 TEST_CASE("split building process", "[ut][diskann]") {


### PR DESCRIPTION
## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement/Refactor
- [ ] Documentation
- [ ] CI/Build/Infra

## Linked Issue

Not required for `kind/improvement`.

## What Changed

- Added cached byte sizes for DiskANN's memory-backed artifact streams.
- Updated the cache when graph, tag, PQ, compressed-vector, and disk-layout streams are generated or loaded from `BinarySet`.
- Changed `GetMemoryUsage()` to read cached artifact sizes instead of calling `stringstream::str().size()`.
- Added a regression test covering cached artifact accounting after build and BinarySet deserialize.

## Test Evidence

- [x] `git diff --check -- src/index/diskann.cpp src/index/diskann.h src/index/diskann_test.cpp`
- [x] `cmake --build build --target unittests -j2` using a Nix shell with `cmake`, `ninja`, and OpenMP paths
- [x] `./build/tests/unittests "diskann memory usage accounts cached artifacts"`

## Compatibility Impact

- API/ABI compatibility: none
- Behavior changes: none intended; memory accounting should report the same artifact sizes without materializing string copies in `GetMemoryUsage()`

## Performance and Concurrency Impact

- Performance impact: improved; avoids full `std::string` materialization in `GetMemoryUsage()` for DiskANN memory-backed artifacts
- Concurrency/thread-safety impact: improved; `GetMemoryUsage()` now reads cached sizes under the existing shared mutex instead of touching stream cursor/state

## Documentation Impact

- [x] No docs update needed
- [ ] Updated docs:
  - [ ] `README.md`
  - [ ] `DEVELOPMENT.md`
  - [ ] `CONTRIBUTING.md`
  - [ ] Other: <!-- path -->

## Risk and Rollback

- Risk level: low
- Rollback plan: revert this commit to restore direct `stringstream::str().size()` accounting in `GetMemoryUsage()`

## Checklist

- [ ] I have linked the relevant issue (required for `kind/bug` and `kind/feature`; see "Linked Issue" above)
- [x] I have added/updated tests for new behavior or bug fixes
- [x] I have considered API compatibility impact
- [x] I have updated docs if behavior/workflow changed
- [x] My commit messages follow project conventions (Conventional Commits, optional `[skip ci]` prefix)