### PR TITLE
perf: backport DiskANN stream-size optimization to 1.0

### DIFF
--- a/extern/diskann/DiskANN/src/disk_utils.cpp
+++ b/extern/diskann/DiskANN/src/disk_utils.cpp
@@ -22,6 +22,35 @@
 namespace diskann
 {
 
+static uint64_t get_stringstream_size(std::stringstream &stream)
+{
+    const auto old_state = stream.rdstate();
+    stream.clear();
+
+    const auto old_pos = stream.tellg();
+    stream.seekg(0, std::ios_base::end);
+    const auto end_pos = stream.tellg();
+
+    if (old_pos != std::streampos(-1))
+    {
+        stream.seekg(old_pos);
+    }
+    else
+    {
+        stream.seekg(0, std::ios_base::beg);
+    }
+
+    stream.clear(old_state);
+
+    if (end_pos == std::streampos(-1))
+    {
+        throw diskann::ANNException("Failed to get stringstream size", -1, __FUNCSIG__, __FILE__,
+                                    __LINE__);
+    }
+
+    return static_cast<uint64_t>(end_pos);
+}
+
 void add_new_file_to_single_index(std::string index_file, std::string new_file)
 {
     std::unique_ptr<uint64_t[]> metadata;
@@ -1041,7 +1070,7 @@ void create_disk_layout(const T *data, uint32_t npts, uint32_t ndims, const std:
         uint32_t npts_reorder_file = 0, ndims_reorder_file = 0;
 
         // create cached reader + writer
-        uint64_t actual_file_size = vamana_reader.str().size();
+        uint64_t actual_file_size = get_stringstream_size(vamana_reader);
         // diskann::cout << "Vamana index file size=" << actual_file_size << std::endl;
 
         // metadata: width, medoid

--- a/src/index/diskann_test.cpp
+++ b/src/index/diskann_test.cpp
@@ -15,9 +15,12 @@
 
 #include "diskann.h"
 
+#include <cstdint>
 #include <fstream>
 #include <nlohmann/json.hpp>
+#include <sstream>
 #include <tuple>
+#include <vector>
 
 #include "diskann_zparameters.h"
 #include "distance.h"
@@ -38,6 +41,63 @@ parse_diskann_params(vsag::IndexCommonParam index_common_param) {
     )";
     auto parsed_params = vsag::JsonType::Parse(build_parameter_json);
     return vsag::DiskannParameters::FromJson(parsed_params, index_common_param);
+}
+
+namespace {
+
+void
+write_value(std::stringstream& stream, const uint32_t& value) {
+    stream.write(reinterpret_cast<const char*>(&value), sizeof(value));
+}
+
+void
+write_value(std::stringstream& stream, const uint64_t& value) {
+    stream.write(reinterpret_cast<const char*>(&value), sizeof(value));
+}
+
+}  // namespace
+
+TEST_CASE("create_disk_layout reads stringstream after size lookup", "[ut][diskann]") {
+    constexpr uint32_t npts = 2;
+    constexpr uint32_t ndims = 2;
+    constexpr uint32_t width = 1;
+    constexpr uint32_t medoid = 0;
+    constexpr uint64_t frozen_num = 0;
+    constexpr uint64_t sector_len = 512;
+
+    constexpr uint64_t index_file_size = sizeof(uint64_t) + 2 * sizeof(uint32_t) +
+                                         sizeof(uint64_t) +
+                                         npts * (sizeof(uint32_t) + sizeof(uint32_t));
+
+    std::stringstream vamana_reader;
+    write_value(vamana_reader, index_file_size);
+    write_value(vamana_reader, width);
+    write_value(vamana_reader, medoid);
+    write_value(vamana_reader, frozen_num);
+
+    for (uint32_t i = 0; i < npts; ++i) {
+        const uint32_t nnbrs = 1;
+        const uint32_t neighbor = (i + 1) % npts;
+        write_value(vamana_reader, nnbrs);
+        write_value(vamana_reader, neighbor);
+    }
+
+    vamana_reader.seekg(0, std::ios_base::beg);
+    REQUIRE(vamana_reader.tellg() == std::streampos(0));
+
+    const std::vector<float> data = {1.0F, 2.0F, 3.0F, 4.0F};
+    const std::vector<uint64_t> skip_locs;
+    std::stringstream diskann_writer;
+
+    REQUIRE_NOTHROW(diskann::create_disk_layout<float>(data.data(),
+                                                       npts,
+                                                       ndims,
+                                                       skip_locs,
+                                                       vamana_reader,
+                                                       diskann_writer,
+                                                       sector_len,
+                                                       diskann::Metric::L2));
+    REQUIRE(diskann_writer.tellp() > std::streampos(0));
 }
 
 TEST_CASE("diskann build", "[ut][diskann]") {


### PR DESCRIPTION
## Summary

- avoid materializing a full copy of the Vamana `stringstream` when validating its size
- preserve the stream state and original read position across the size lookup
- add focused regression coverage for `create_disk_layout` consuming the stream correctly

Backport of [source PR #2622](https://github.com/antgroup/vsag/pull/2622) (merge commit `47e3a8f13f47f4de69eb4b2939cac88228dbff2c`).

## Validation

- `make fmt` (clang-format 15.0.7)
- `make test CASE='[ut][diskann]' COMPILE_JOBS=6` — 2,072 assertions in 11 test cases passed
- clean debug build completed as part of the focused test command

## Compatibility

No API or ABI changes. The port is limited to the compatible 1.0 DiskANN layout path and its regression test.