### PR TITLE
perf(io): batch cache misses in multiread

### DIFF
--- a/src/io/common/basic_io.h
+++ b/src/io/common/basic_io.h
@@ -18,11 +18,15 @@
 #include <fmt/format.h>
 
 #include <algorithm>
+#include <condition_variable>
 #include <cstdint>
 #include <cstring>
 #include <memory>
 #include <mutex>
 #include <type_traits>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
 
 #include "io/common/io_parameter.h"
 #include "io/read_cache/lru_page_cache.h"
@@ -160,9 +164,41 @@ public:
         static_assert(has_MultiReadImpl<IOTmpl>::value);
         if constexpr (not InMemory) {
             if (cache_ != nullptr) {
+                std::vector<uint64_t> page_ids;
+                std::unordered_set<uint64_t> seen_page_ids;
                 for (uint64_t i = 0; i < count; ++i) {
-                    if (not ReadCached(sizes[i], offsets[i], datas)) {
+                    if (not IsValidRange(sizes[i], offsets[i])) {
                         return false;
+                    }
+                    if (sizes[i] == 0) {
+                        continue;
+                    }
+                    const uint64_t first_page = offsets[i] / Page::DEFAULT_PAGE_SIZE;
+                    const uint64_t last_page =
+                        (offsets[i] + sizes[i] - 1) / Page::DEFAULT_PAGE_SIZE;
+                    for (uint64_t page_id = first_page; page_id <= last_page; ++page_id) {
+                        if (seen_page_ids.emplace(page_id).second) {
+                            page_ids.emplace_back(page_id);
+                        }
+                    }
+                }
+
+                std::unordered_map<uint64_t, PagePtr> pages;
+                if (not LoadCachedPages(page_ids, pages)) {
+                    return false;
+                }
+
+                for (uint64_t i = 0; i < count; ++i) {
+                    uint64_t copied = 0;
+                    while (copied < sizes[i]) {
+                        const uint64_t current_offset = offsets[i] + copied;
+                        const uint64_t page_id = current_offset / Page::DEFAULT_PAGE_SIZE;
+                        const uint64_t page_offset = current_offset % Page::DEFAULT_PAGE_SIZE;
+                        const uint64_t copy_size =
+                            std::min(sizes[i] - copied, Page::DEFAULT_PAGE_SIZE - page_offset);
+                        const auto& page = pages.at(page_id);
+                        std::memcpy(datas + copied, page->Data() + page_offset, copy_size);
+                        copied += copy_size;
                     }
                     datas += sizes[i];
                 }
@@ -406,6 +442,13 @@ protected:
     Allocator* const allocator_;
 
 private:
+    struct LoadingPage {
+        std::condition_variable cv;
+        PagePtr page;
+        bool done{false};
+        bool stale{false};
+    };
+
     /**
      * @brief Casts the current object to the underlying IO object type.
      *
@@ -457,24 +500,110 @@ private:
         if (page_id > UINT64_MAX / Page::DEFAULT_PAGE_SIZE) {
             return nullptr;
         }
-        uint64_t offset = page_id * Page::DEFAULT_PAGE_SIZE;
+        const uint64_t offset = page_id * Page::DEFAULT_PAGE_SIZE;
         if (offset >= size_) {
             return nullptr;
         }
-        std::scoped_lock<std::mutex> lock(cache_mutex_);
-        auto page = cache_->Get(page_id);
-        if (page != nullptr) {
-            return page;
-        }
-        auto new_page = std::make_shared<Page>(allocator_);
-        if (new_page->Data() == nullptr) {
+        std::unordered_map<uint64_t, PagePtr> pages;
+        if (not LoadCachedPages({page_id}, pages)) {
             return nullptr;
         }
-        uint64_t read_size = std::min(Page::DEFAULT_PAGE_SIZE, size_ - offset);
-        if (not cast().ReadImpl(read_size, offset, new_page->Data())) {
-            return nullptr;
+        return pages.at(page_id);
+    }
+
+    bool
+    LoadCachedPages(const std::vector<uint64_t>& page_ids,
+                    std::unordered_map<uint64_t, PagePtr>& pages) const {
+        std::vector<std::pair<uint64_t, std::shared_ptr<LoadingPage>>> owned_loads;
+        std::vector<std::pair<uint64_t, std::shared_ptr<LoadingPage>>> waiting_loads;
+        {
+            std::scoped_lock<std::mutex> lock(cache_mutex_);
+            for (const uint64_t page_id : page_ids) {
+                if (const auto page = cache_->Get(page_id); page != nullptr) {
+                    pages.emplace(page_id, page);
+                    continue;
+                }
+                if (const auto iter = loading_pages_.find(page_id); iter != loading_pages_.end()) {
+                    waiting_loads.emplace_back(page_id, iter->second);
+                    continue;
+                }
+                auto state = std::make_shared<LoadingPage>();
+                loading_pages_.emplace(page_id, state);
+                owned_loads.emplace_back(page_id, std::move(state));
+            }
         }
-        return cache_->Insert(page_id, std::move(new_page));
+
+        std::vector<PagePtr> loaded_pages;
+        std::vector<uint64_t> read_sizes;
+        std::vector<uint64_t> read_offsets;
+        std::vector<uint8_t> read_data;
+        bool success = true;
+        try {
+            uint64_t total_size = 0;
+            for (const auto& [page_id, state] : owned_loads) {
+                const uint64_t offset = page_id * Page::DEFAULT_PAGE_SIZE;
+                const uint64_t read_size = std::min(Page::DEFAULT_PAGE_SIZE, size_ - offset);
+                auto page = std::make_shared<Page>(allocator_);
+                if (page->Data() == nullptr) {
+                    success = false;
+                    break;
+                }
+                loaded_pages.emplace_back(std::move(page));
+                read_sizes.emplace_back(read_size);
+                read_offsets.emplace_back(offset);
+                total_size += read_size;
+            }
+            if (success and not owned_loads.empty()) {
+                read_data.resize(total_size);
+                success = cast().MultiReadImpl(
+                    read_data.data(), read_sizes.data(), read_offsets.data(), owned_loads.size());
+                uint64_t copied = 0;
+                for (uint64_t i = 0; success and i < loaded_pages.size(); ++i) {
+                    std::memcpy(loaded_pages[i]->Data(), read_data.data() + copied, read_sizes[i]);
+                    copied += read_sizes[i];
+                }
+            }
+        } catch (...) {
+            FinishPageLoads(owned_loads, loaded_pages, false, pages);
+            throw;
+        }
+
+        FinishPageLoads(owned_loads, loaded_pages, success, pages);
+        if (not success) {
+            return false;
+        }
+
+        for (const auto& [page_id, state] : waiting_loads) {
+            std::unique_lock<std::mutex> lock(cache_mutex_);
+            state->cv.wait(lock, [&state] { return state->done; });
+            pages.emplace(page_id, state->page);
+        }
+        return std::all_of(
+            pages.begin(), pages.end(), [](const auto& page) { return page.second != nullptr; });
+    }
+
+    void
+    FinishPageLoads(
+        const std::vector<std::pair<uint64_t, std::shared_ptr<LoadingPage>>>& owned_loads,
+        const std::vector<PagePtr>& loaded_pages,
+        bool success,
+        std::unordered_map<uint64_t, PagePtr>& pages) const {
+        {
+            std::scoped_lock<std::mutex> lock(cache_mutex_);
+            for (uint64_t i = 0; i < owned_loads.size(); ++i) {
+                const auto& [page_id, state] = owned_loads[i];
+                if (success) {
+                    state->page =
+                        state->stale ? loaded_pages[i] : cache_->Insert(page_id, loaded_pages[i]);
+                    pages.emplace(page_id, state->page);
+                }
+                state->done = true;
+                loading_pages_.erase(page_id);
+            }
+        }
+        for (const auto& [page_id, state] : owned_loads) {
+            state->cv.notify_all();
+        }
     }
 
     void
@@ -491,6 +620,9 @@ private:
         uint64_t last_page = (offset + size - 1) / Page::DEFAULT_PAGE_SIZE;
         for (uint64_t page_id = first_page; page_id <= last_page; ++page_id) {
             cache_->Remove(page_id);
+            if (const auto iter = loading_pages_.find(page_id); iter != loading_pages_.end()) {
+                iter->second->stale = true;
+            }
         }
     }
 
@@ -499,6 +631,9 @@ private:
         if (cache_ != nullptr) {
             std::scoped_lock<std::mutex> lock(cache_mutex_);
             cache_->Clear();
+            for (const auto& [page_id, state] : loading_pages_) {
+                state->stale = true;
+            }
         }
     }
 
@@ -509,6 +644,7 @@ private:
 
     mutable std::mutex cache_mutex_;
     mutable std::unique_ptr<PageCache> cache_;
+    mutable std::unordered_map<uint64_t, std::shared_ptr<LoadingPage>> loading_pages_;
     bool has_deserialized_{false};
 
 private:

--- a/src/io/common/basic_io.h
+++ b/src/io/common/basic_io.h
@@ -23,7 +23,9 @@
 #include <memory>
 #include <mutex>
 #include <type_traits>
+#include <vector>
 
+#include "hash_types.h"
 #include "io/common/io_parameter.h"
 #include "io/read_cache/lru_page_cache.h"
 #include "io/read_cache/page.h"
@@ -52,6 +54,15 @@ struct SupportsZeroSizeResize<T, std::void_t<decltype(T::SupportsZeroSizeResize)
  */
 template <typename IOTmpl>
 class BasicIO {
+private:
+    using PageIdList = std::vector<uint64_t, AllocatorWrapper<uint64_t>>;
+
+    class ReadCacheSnapshot {
+    public:
+        std::shared_ptr<PageCache> cache;
+        uint64_t page_id_base{0};
+    };
+
 public:
     /// Checks if the IO object is in-memory.
     static constexpr bool InMemory = IOTmpl::InMemory;
@@ -65,7 +76,8 @@ public:
      *
      * @param allocator A pointer to the Allocator object.
      */
-    explicit BasicIO<IOTmpl>(Allocator* allocator) : allocator_(allocator){};
+    explicit BasicIO<IOTmpl>(Allocator* allocator)
+        : allocator_(allocator), cached_direct_reads_(allocator){};
 
     /**
      * @brief Writes data to the IO object at a specified offset.
@@ -101,8 +113,9 @@ public:
     Read(uint64_t size, uint64_t offset, uint8_t* data) const {
         static_assert(has_ReadImpl<IOTmpl>::value);
         if constexpr (not InMemory) {
-            if (cache_ != nullptr) {
-                return ReadCached(size, offset, data);
+            const auto cache = GetReadCacheSnapshot();
+            if (cache.cache != nullptr) {
+                return ReadCached(size, offset, data, cache);
             }
         }
         return cast().ReadImpl(size, offset, data);
@@ -123,7 +136,8 @@ public:
     Read(uint64_t size, uint64_t offset, bool& need_release) const {
         static_assert(has_DirectReadImpl<IOTmpl>::value);
         if constexpr (not InMemory) {
-            if (cache_ != nullptr) {
+            const auto cache = GetReadCacheSnapshot();
+            if (cache.cache != nullptr) {
                 need_release = false;
                 if (size == 0 or not IsValidRange(size, offset)) {
                     return nullptr;
@@ -132,11 +146,19 @@ public:
                 if (data == nullptr) {
                     return nullptr;
                 }
-                if (not ReadCached(size, offset, data)) {
+                if (not ReadCached(size, offset, data, cache)) {
                     allocator_->Deallocate(data);
                     return nullptr;
                 }
                 need_release = true;
+                try {
+                    std::scoped_lock<std::mutex> lock(cached_direct_reads_mutex_);
+                    cached_direct_reads_.emplace(data);
+                } catch (...) {
+                    need_release = false;
+                    allocator_->Deallocate(data);
+                    throw;
+                }
                 return data;
             }
         }
@@ -159,14 +181,103 @@ public:
     MultiRead(uint8_t* datas, uint64_t* sizes, uint64_t* offsets, uint64_t count) const {
         static_assert(has_MultiReadImpl<IOTmpl>::value);
         if constexpr (not InMemory) {
-            if (cache_ != nullptr) {
+            const auto cache = GetReadCacheSnapshot();
+            if (cache.cache != nullptr) {
+                if (count == 0) {
+                    return true;
+                }
+                if (sizes == nullptr or offsets == nullptr) {
+                    return false;
+                }
+                bool has_data = false;
                 for (uint64_t i = 0; i < count; ++i) {
-                    if (not ReadCached(sizes[i], offsets[i], datas)) {
+                    if (not IsValidRange(sizes[i], offsets[i])) {
                         return false;
                     }
-                    datas += sizes[i];
+                    has_data = has_data or sizes[i] > 0;
                 }
-                return true;
+                if (not has_data) {
+                    return true;
+                }
+                if (datas == nullptr) {
+                    return false;
+                }
+                class PageCopy {
+                public:
+                    uint64_t page_id;
+                    uint64_t page_offset;
+                    uint64_t output_offset;
+                    uint64_t size;
+                };
+                using PageCopyList = std::vector<PageCopy, AllocatorWrapper<PageCopy>>;
+                PageIdList page_ids(allocator_);
+                PageCopyList page_copies(allocator_);
+                UnorderedSet<uint64_t> seen_page_ids(allocator_);
+                uint64_t output_offset = 0;
+                for (uint64_t i = 0; i < count; ++i) {
+                    if (sizes[i] > UINT64_MAX - output_offset) {
+                        return false;
+                    }
+                    if (sizes[i] == 0) {
+                        continue;
+                    }
+                    uint64_t copied = 0;
+                    while (copied < sizes[i]) {
+                        const uint64_t current_offset = offsets[i] + copied;
+                        const uint64_t page_id = current_offset / Page::DEFAULT_PAGE_SIZE;
+                        const uint64_t page_offset = current_offset % Page::DEFAULT_PAGE_SIZE;
+                        const uint64_t copy_size =
+                            std::min(sizes[i] - copied, Page::DEFAULT_PAGE_SIZE - page_offset);
+                        if (seen_page_ids.emplace(page_id).second) {
+                            page_ids.emplace_back(page_id);
+                        }
+                        page_copies.emplace_back(
+                            PageCopy{page_id, page_offset, output_offset + copied, copy_size});
+                        copied += copy_size;
+                    }
+                    output_offset += sizes[i];
+                }
+
+                std::sort(page_ids.begin(), page_ids.end());
+                std::sort(
+                    page_copies.begin(), page_copies.end(), [](const auto& lhs, const auto& rhs) {
+                        return lhs.page_id < rhs.page_id;
+                    });
+                // Each miss temporarily needs both a Page and contiguous MultiRead storage.
+                // Keep that temporary working set near 8 MiB while preserving batched backend IO.
+                constexpr uint64_t MAX_BATCH_READ_TEMP_BYTES = 8ULL * 1024ULL * 1024ULL;
+                const uint64_t max_batch_pages = std::max<uint64_t>(
+                    1, MAX_BATCH_READ_TEMP_BYTES / (2 * Page::DEFAULT_PAGE_SIZE));
+                UnorderedMap<uint64_t, PagePtr> pages(allocator_);
+                uint64_t copy_index = 0;
+                for (uint64_t batch_begin = 0; batch_begin < page_ids.size();
+                     batch_begin += max_batch_pages) {
+                    const uint64_t batch_end =
+                        std::min<uint64_t>(page_ids.size(), batch_begin + max_batch_pages);
+                    PageIdList batch_page_ids(allocator_);
+                    batch_page_ids.reserve(batch_end - batch_begin);
+                    for (uint64_t i = batch_begin; i < batch_end; ++i) {
+                        batch_page_ids.emplace_back(page_ids[i]);
+                    }
+                    pages.clear();
+                    if (not LoadCachedPages(batch_page_ids, pages, true, cache)) {
+                        return false;
+                    }
+                    const uint64_t last_page_id = page_ids[batch_end - 1];
+                    while (copy_index < page_copies.size() and
+                           page_copies[copy_index].page_id <= last_page_id) {
+                        const auto& copy = page_copies[copy_index];
+                        const auto iter = pages.find(copy.page_id);
+                        if (iter == pages.end() or iter->second == nullptr) {
+                            return false;
+                        }
+                        std::memcpy(datas + copy.output_offset,
+                                    iter->second->Data() + copy.page_offset,
+                                    copy.size);
+                        ++copy_index;
+                    }
+                }
+                return copy_index == page_copies.size();
             }
         }
         return cast().MultiReadImpl(datas, sizes, offsets, count);
@@ -259,7 +370,8 @@ public:
     inline void
     Release(const uint8_t* data) const {
         if constexpr (not InMemory) {
-            if (cache_ != nullptr) {
+            std::scoped_lock<std::mutex> lock(cached_direct_reads_mutex_);
+            if (cached_direct_reads_.erase(data) != 0) {
                 allocator_->Deallocate(const_cast<uint8_t*>(data));
                 return;
             }
@@ -281,7 +393,8 @@ public:
     inline void
     InitIO(const IOParamPtr& io_param) {
         if constexpr (not InMemory) {
-            if (cache_ == nullptr) {
+            const auto cache = GetReadCacheSnapshot();
+            if (cache.cache == nullptr) {
                 EnableReadCache(io_param);
             } else if (io_param != nullptr and io_param->enable_read_cache_) {
                 EnableReadCache(io_param);
@@ -346,6 +459,7 @@ public:
     void
     EnableReadCache(const IOParamPtr& io_param) {
         if constexpr (not InMemory) {
+            std::scoped_lock<std::mutex> lock(cache_mutex_);
             if (io_param == nullptr or not io_param->enable_read_cache_) {
                 cache_.reset();
                 cache_page_id_base_ = 0;
@@ -450,8 +564,18 @@ private:
         return offset <= size_ and size <= size_ - offset;
     }
 
+    ReadCacheSnapshot
+    GetReadCacheSnapshot() const {
+        std::scoped_lock<std::mutex> lock(cache_mutex_);
+        // An in-flight operation intentionally keeps using the cache generation it started with.
+        return {cache_, cache_page_id_base_};
+    }
+
     bool
-    ReadCached(uint64_t size, uint64_t offset, uint8_t* data) const {
+    ReadCached(uint64_t size,
+               uint64_t offset,
+               uint8_t* data,
+               const ReadCacheSnapshot& cache) const {
         if (not IsValidRange(size, offset)) {
             return false;
         }
@@ -461,7 +585,7 @@ private:
             uint64_t page_id = current_offset / Page::DEFAULT_PAGE_SIZE;
             uint64_t page_offset = current_offset % Page::DEFAULT_PAGE_SIZE;
             uint64_t copy_size = std::min(size - copied, Page::DEFAULT_PAGE_SIZE - page_offset);
-            auto page = GetOrLoadPage(page_id);
+            auto page = GetOrLoadPage(page_id, cache);
             if (page == nullptr) {
                 return false;
             }
@@ -472,52 +596,249 @@ private:
     }
 
     PagePtr
-    GetOrLoadPage(uint64_t page_id) const {
+    GetOrLoadPage(uint64_t page_id, const ReadCacheSnapshot& cache) const {
         if (page_id > UINT64_MAX / Page::DEFAULT_PAGE_SIZE) {
             return nullptr;
         }
-        uint64_t offset = page_id * Page::DEFAULT_PAGE_SIZE;
+        const uint64_t offset = page_id * Page::DEFAULT_PAGE_SIZE;
         if (offset >= size_) {
             return nullptr;
         }
-        std::scoped_lock<std::mutex> lock(cache_mutex_);
-        if (page_id > UINT64_MAX - cache_page_id_base_) {
+        if (cache.cache == nullptr or page_id > UINT64_MAX - cache.page_id_base) {
             return nullptr;
         }
-        uint64_t cache_page_id = cache_page_id_base_ + page_id;
-        auto page = cache_->Get(cache_page_id);
-        if (page != nullptr) {
-            return page;
-        }
-        auto new_page = std::make_shared<Page>(allocator_);
-        if (new_page->Data() == nullptr) {
+        const uint64_t cache_page_id = cache.page_id_base + page_id;
+        while (true) {
+            auto result = cache.cache->Acquire(cache_page_id);
+            if (result.page != nullptr) {
+                return result.page;
+            }
+            if (not result.should_load) {
+                auto page = cache.cache->Wait(result.handle);
+                if (page != nullptr) {
+                    return page;
+                }
+                if (cache.cache->IsStale(result.handle)) {
+                    continue;
+                }
+                return nullptr;
+            }
+
+            PagePtr page = nullptr;
+            bool success = false;
+            try {
+                page = std::make_shared<Page>(allocator_);
+                success = page->Data() != nullptr;
+                if (success) {
+                    const uint64_t read_size = std::min(Page::DEFAULT_PAGE_SIZE, size_ - offset);
+                    success = cast().ReadImpl(read_size, offset, page->Data());
+                }
+            } catch (...) {
+                cache.cache->Complete(cache_page_id, result.handle, nullptr, false);
+                throw;
+            }
+            page = cache.cache->Complete(
+                cache_page_id, result.handle, success ? std::move(page) : nullptr, success);
+            if (page != nullptr) {
+                return page;
+            }
+            if (cache.cache->IsStale(result.handle)) {
+                continue;
+            }
             return nullptr;
         }
-        uint64_t read_size = std::min(Page::DEFAULT_PAGE_SIZE, size_ - offset);
-        if (not cast().ReadImpl(read_size, offset, new_page->Data())) {
-            return nullptr;
+    }
+
+    bool
+    LoadCachedPages(const PageIdList& page_ids,
+                    UnorderedMap<uint64_t, PagePtr>& pages,
+                    bool batch_read,
+                    const ReadCacheSnapshot& cache) const {
+        PageIdList ordered_page_ids(page_ids.begin(), page_ids.end(), allocator_);
+        std::sort(ordered_page_ids.begin(), ordered_page_ids.end());
+
+        while (true) {
+            pages.clear();
+            bool stale = false;
+            const bool loaded =
+                LoadCachedPagesOnce(ordered_page_ids, pages, batch_read, stale, cache);
+            if (loaded and not stale) {
+                return true;
+            }
+            if (not stale) {
+                return false;
+            }
         }
-        return cache_->Insert(cache_page_id, std::move(new_page));
+    }
+
+    bool
+    LoadCachedPagesOnce(const PageIdList& page_ids,
+                        UnorderedMap<uint64_t, PagePtr>& pages,
+                        bool batch_read,
+                        bool& stale,
+                        const ReadCacheSnapshot& cache) const {
+        stale = false;
+        if (cache.cache == nullptr or
+            std::any_of(page_ids.begin(), page_ids.end(), [&cache](uint64_t page_id) {
+                return page_id > UINT64_MAX - cache.page_id_base;
+            })) {
+            return false;
+        }
+        using PageLoadList =
+            std::vector<std::pair<uint64_t, PageCache::LoadHandle>,
+                        AllocatorWrapper<std::pair<uint64_t, PageCache::LoadHandle>>>;
+        PageLoadList owned_loads(allocator_);
+        pages.reserve(page_ids.size());
+        owned_loads.reserve(page_ids.size());
+        const auto abandon_owned_loads = [&cache, &owned_loads]() {
+            for (const auto& [page_id, handle] : owned_loads) {
+                cache.cache->Complete(cache.page_id_base + page_id, handle, nullptr, false);
+            }
+            owned_loads.clear();
+        };
+        try {
+            for (const uint64_t page_id : page_ids) {
+                auto result = cache.cache->Acquire(cache.page_id_base + page_id);
+                if (result.page != nullptr) {
+                    pages.emplace(page_id, std::move(result.page));
+                } else if (result.should_load) {
+                    owned_loads.emplace_back(page_id, std::move(result.handle));
+                } else {
+                    auto page = cache.cache->Wait(result.handle);
+                    stale = stale or cache.cache->IsStale(result.handle);
+                    if (page == nullptr or stale) {
+                        abandon_owned_loads();
+                        return false;
+                    }
+                    pages.emplace(page_id, std::move(page));
+                }
+            }
+        } catch (...) {
+            abandon_owned_loads();
+            throw;
+        }
+
+        std::vector<PagePtr, AllocatorWrapper<PagePtr>> loaded_pages(allocator_);
+        std::vector<uint64_t, AllocatorWrapper<uint64_t>> read_sizes(allocator_);
+        std::vector<uint64_t, AllocatorWrapper<uint64_t>> read_offsets(allocator_);
+        std::vector<uint8_t, AllocatorWrapper<uint8_t>> read_data(allocator_);
+        bool success = true;
+        try {
+            uint64_t total_size = 0;
+            loaded_pages.reserve(owned_loads.size());
+            read_sizes.reserve(owned_loads.size());
+            read_offsets.reserve(owned_loads.size());
+            for (const auto& [page_id, _] : owned_loads) {
+                if (page_id > UINT64_MAX / Page::DEFAULT_PAGE_SIZE) {
+                    success = false;
+                    break;
+                }
+                const uint64_t offset = page_id * Page::DEFAULT_PAGE_SIZE;
+                if (offset >= size_) {
+                    success = false;
+                    break;
+                }
+                const uint64_t read_size = std::min(Page::DEFAULT_PAGE_SIZE, size_ - offset);
+                if (read_size > UINT64_MAX - total_size) {
+                    success = false;
+                    break;
+                }
+                auto page = std::make_shared<Page>(allocator_);
+                if (page->Data() == nullptr) {
+                    success = false;
+                    break;
+                }
+                loaded_pages.emplace_back(std::move(page));
+                read_sizes.emplace_back(read_size);
+                read_offsets.emplace_back(offset);
+                total_size += read_size;
+            }
+            if (success and not owned_loads.empty()) {
+                if (batch_read) {
+                    read_data.resize(total_size);
+                    success = cast().MultiReadImpl(read_data.data(),
+                                                   read_sizes.data(),
+                                                   read_offsets.data(),
+                                                   owned_loads.size());
+                    uint64_t copied = 0;
+                    for (uint64_t i = 0; success and i < loaded_pages.size(); ++i) {
+                        std::memcpy(
+                            loaded_pages[i]->Data(), read_data.data() + copied, read_sizes[i]);
+                        copied += read_sizes[i];
+                    }
+                } else {
+                    for (uint64_t i = 0; success and i < loaded_pages.size(); ++i) {
+                        success = cast().ReadImpl(
+                            read_sizes[i], read_offsets[i], loaded_pages[i]->Data());
+                    }
+                }
+            }
+        } catch (...) {
+            for (const auto& [page_id, handle] : owned_loads) {
+                cache.cache->Complete(cache.page_id_base + page_id, handle, nullptr, false);
+            }
+            throw;
+        }
+
+        for (uint64_t i = 0; i < owned_loads.size(); ++i) {
+            const auto& [page_id, handle] = owned_loads[i];
+            PagePtr loaded_page = nullptr;
+            if (success) {
+                loaded_page = std::move(loaded_pages[i]);
+            }
+            try {
+                auto page = cache.cache->Complete(
+                    cache.page_id_base + page_id, handle, std::move(loaded_page), success);
+                stale = stale or cache.cache->IsStale(handle);
+                if (page != nullptr) {
+                    pages.emplace(page_id, std::move(page));
+                }
+            } catch (...) {
+                for (uint64_t j = i + 1; j < owned_loads.size(); ++j) {
+                    const auto& [remaining_page_id, remaining_handle] = owned_loads[j];
+                    cache.cache->Complete(
+                        cache.page_id_base + remaining_page_id, remaining_handle, nullptr, false);
+                }
+                throw;
+            }
+        }
+        if (not success) {
+            return false;
+        }
+
+        return std::all_of(page_ids.begin(), page_ids.end(), [&pages](uint64_t page_id) {
+            const auto iter = pages.find(page_id);
+            return iter != pages.end() and iter->second != nullptr;
+        });
     }
 
     void
     InvalidateCacheRange(uint64_t size, uint64_t offset) {
-        if (cache_ == nullptr or size == 0) {
+        if (size == 0) {
             return;
         }
-        std::scoped_lock<std::mutex> lock(cache_mutex_);
+        std::shared_ptr<PageCache> cache;
+        uint64_t cache_page_id_base;
+        {
+            std::scoped_lock<std::mutex> lock(cache_mutex_);
+            cache = cache_;
+            cache_page_id_base = cache_page_id_base_;
+        }
+        if (cache == nullptr) {
+            return;
+        }
         if (offset > UINT64_MAX - (size - 1)) {
-            cache_->Clear();
+            cache->Clear();
             return;
         }
         uint64_t first_page = offset / Page::DEFAULT_PAGE_SIZE;
         uint64_t last_page = (offset + size - 1) / Page::DEFAULT_PAGE_SIZE;
-        if (last_page > UINT64_MAX - cache_page_id_base_) {
-            cache_->Clear();
+        if (last_page > UINT64_MAX - cache_page_id_base) {
+            cache->Clear();
             return;
         }
         for (uint64_t page_id = first_page;; ++page_id) {
-            cache_->Remove(cache_page_id_base_ + page_id);
+            cache->Remove(cache_page_id_base + page_id);
             if (page_id == last_page) {
                 break;
             }
@@ -526,9 +847,13 @@ private:
 
     void
     ClearCache() {
-        if (cache_ != nullptr) {
+        std::shared_ptr<PageCache> cache;
+        {
             std::scoped_lock<std::mutex> lock(cache_mutex_);
-            cache_->Clear();
+            cache = cache_;
+        }
+        if (cache != nullptr) {
+            cache->Clear();
         }
     }
 
@@ -540,6 +865,9 @@ private:
     mutable std::mutex cache_mutex_;
     mutable std::shared_ptr<PageCache> cache_;
     uint64_t cache_page_id_base_{0};
+    mutable std::mutex cached_direct_reads_mutex_;
+    // Outstanding cached direct reads; each pointer must be released exactly once.
+    mutable UnorderedSet<const uint8_t*> cached_direct_reads_;
     bool has_deserialized_{false};
 
 private:

--- a/src/io/read_cache/page_cache.cpp
+++ b/src/io/read_cache/page_cache.cpp
@@ -15,8 +15,18 @@
 #include "io/read_cache/page_cache.h"
 
 #include <algorithm>
+#include <condition_variable>
+#include <exception>
 
 namespace vsag {
+
+class PageCache::LoadingPage {
+public:
+    std::condition_variable cv;
+    PagePtr page;
+    bool done{false};
+    bool stale{false};
+};
 
 PageCache::PageCache(uint64_t max_pages) : max_pages_(max_pages) {
 }
@@ -32,9 +42,77 @@ PageCache::Get(uint64_t page_id) {
     return it->second;
 }
 
+PageCache::LoadResult
+PageCache::Acquire(uint64_t page_id) {
+    std::scoped_lock<std::mutex> lock(mutex_);
+    if (const auto iter = pages_.find(page_id); iter != pages_.end()) {
+        OnAccess(page_id);
+        LoadResult result;
+        result.page = iter->second;
+        return result;
+    }
+    if (const auto iter = loading_pages_.find(page_id); iter != loading_pages_.end()) {
+        LoadResult result;
+        result.handle.state_ = iter->second;
+        return result;
+    }
+    auto state = std::make_shared<LoadingPage>();
+    loading_pages_.emplace(page_id, state);
+    LoadResult result;
+    result.handle.state_ = std::move(state);
+    result.should_load = true;
+    return result;
+}
+
+PagePtr
+PageCache::Wait(const LoadHandle& handle) {
+    std::unique_lock<std::mutex> lock(mutex_);
+    handle.state_->cv.wait(lock, [&handle] { return handle.state_->done; });
+    return handle.state_->page;
+}
+
+bool
+PageCache::IsStale(const LoadHandle& handle) const {
+    std::scoped_lock<std::mutex> lock(mutex_);
+    return handle.state_->stale;
+}
+
+PagePtr
+PageCache::Complete(uint64_t page_id, const LoadHandle& handle, PagePtr page, bool success) {
+    PagePtr result;
+    std::exception_ptr error;
+    {
+        std::scoped_lock<std::mutex> lock(mutex_);
+        const auto state = handle.state_;
+        try {
+            if (success and not state->stale) {
+                result = InsertLocked(page_id, std::move(page));
+            }
+        } catch (...) {
+            error = std::current_exception();
+        }
+        state->page = result;
+        state->done = true;
+        if (const auto iter = loading_pages_.find(page_id);
+            iter != loading_pages_.end() and iter->second == state) {
+            loading_pages_.erase(iter);
+        }
+    }
+    handle.state_->cv.notify_all();
+    if (error != nullptr) {
+        std::rethrow_exception(error);
+    }
+    return result;
+}
+
 PagePtr
 PageCache::Insert(uint64_t page_id, PagePtr page) {
     std::scoped_lock<std::mutex> lock(mutex_);
+    return InsertLocked(page_id, std::move(page));
+}
+
+PagePtr
+PageCache::InsertLocked(uint64_t page_id, PagePtr page) {
     auto existing = pages_.find(page_id);
     if (existing != pages_.end()) {
         OnAccess(page_id);
@@ -64,6 +142,9 @@ PageCache::Remove(uint64_t page_id) {
         OnRemove(page_id);
         pages_.erase(it);
     }
+    if (const auto loading = loading_pages_.find(page_id); loading != loading_pages_.end()) {
+        loading->second->stale = true;
+    }
 }
 
 void
@@ -73,6 +154,12 @@ PageCache::Clear() {
         OnRemove(page_pair.first);
     }
     pages_.clear();
+    for (const auto& [page_id, state] : loading_pages_) {
+        state->stale = true;
+        state->done = true;
+        state->cv.notify_all();
+    }
+    loading_pages_.clear();
 }
 
 uint64_t

--- a/src/io/read_cache/page_cache.h
+++ b/src/io/read_cache/page_cache.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 #include <mutex>
 #include <unordered_map>
 
@@ -31,7 +32,24 @@ namespace vsag {
  * from the cache concurrently.
  */
 class PageCache {
+private:
+    class LoadingPage;
+
 public:
+    class LoadHandle {
+        friend class PageCache;
+
+    private:
+        std::shared_ptr<LoadingPage> state_;
+    };
+
+    class LoadResult {
+    public:
+        PagePtr page;
+        LoadHandle handle;
+        bool should_load{false};
+    };
+
     explicit PageCache(uint64_t max_pages);
 
     virtual ~PageCache() = default;
@@ -44,6 +62,32 @@ public:
      */
     virtual PagePtr
     Get(uint64_t page_id);
+
+    /**
+     * @brief Get a cached page or register a single owner to load a cache miss.
+     *
+     * Other callers for the same miss receive a handle that can be waited on.
+     */
+    LoadResult
+    Acquire(uint64_t page_id);
+
+    /**
+     * @brief Wait for an in-flight page load to complete.
+     */
+    PagePtr
+    Wait(const LoadHandle& handle);
+
+    /**
+     * @brief Returns whether an in-flight load was invalidated before completion.
+     */
+    bool
+    IsStale(const LoadHandle& handle) const;
+
+    /**
+     * @brief Publish a page load result and wake callers waiting on the page.
+     */
+    PagePtr
+    Complete(uint64_t page_id, const LoadHandle& handle, PagePtr page, bool success);
 
     /**
      * @brief Insert a page, evicting victims first if the cache is full.
@@ -90,9 +134,13 @@ protected:
     virtual uint64_t
     PickVictim() = 0;
 
+    PagePtr
+    InsertLocked(uint64_t page_id, PagePtr page);
+
 protected:
     mutable std::mutex mutex_;
     std::unordered_map<uint64_t, PagePtr> pages_;
+    std::unordered_map<uint64_t, std::shared_ptr<LoadingPage>> loading_pages_;
     uint64_t max_pages_{0};
 };
 

--- a/src/io/read_cache/page_cache_test.cpp
+++ b/src/io/read_cache/page_cache_test.cpp
@@ -15,7 +15,10 @@
 #include "io/read_cache/page_cache.h"
 
 #include <algorithm>
+#include <chrono>
 #include <deque>
+#include <future>
+#include <stdexcept>
 
 #include "impl/allocator/safe_allocator.h"
 #include "unittest.h"
@@ -50,6 +53,9 @@ protected:
 
     uint64_t
     PickVictim() override {
+        if (throw_on_pick_) {
+            throw std::runtime_error("pick failed");
+        }
         if (order_.empty()) {
             return UINT64_MAX;
         }
@@ -58,6 +64,8 @@ protected:
 
 public:
     uint64_t last_access_{UINT64_MAX};
+
+    bool throw_on_pick_{false};
 
 private:
     std::deque<uint64_t> order_;
@@ -111,4 +119,53 @@ TEST_CASE("PageCache Eviction Test", "[PageCache][ut]") {
     REQUIRE(cache.Get(1) == nullptr);
     REQUIRE(cache.Get(2) != nullptr);
     REQUIRE(cache.Get(3) != nullptr);
+}
+
+TEST_CASE("PageCache Complete wakes waiters when insertion throws", "[PageCache][ut]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    FifoPageCache cache(1);
+    cache.Insert(1, MakePage(allocator.get(), 1));
+
+    auto owner = cache.Acquire(2);
+    REQUIRE(owner.should_load);
+    auto waiter = cache.Acquire(2);
+    REQUIRE_FALSE(waiter.should_load);
+
+    auto waited_page = std::async(std::launch::async,
+                                  [&cache, handle = waiter.handle] { return cache.Wait(handle); });
+
+    cache.throw_on_pick_ = true;
+    REQUIRE_THROWS_AS(cache.Complete(2, owner.handle, MakePage(allocator.get(), 2), true),
+                      std::runtime_error);
+    REQUIRE(waited_page.wait_for(std::chrono::seconds(1)) == std::future_status::ready);
+    REQUIRE(waited_page.get() == nullptr);
+
+    cache.throw_on_pick_ = false;
+    auto retry = cache.Acquire(2);
+    REQUIRE(retry.should_load);
+    auto retried_page = MakePage(allocator.get(), 2);
+    REQUIRE(cache.Complete(2, retry.handle, retried_page, true) == retried_page);
+}
+
+TEST_CASE("PageCache Clear wakes in-flight waiters", "[PageCache][ut]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    FifoPageCache cache(1);
+
+    auto owner = cache.Acquire(2);
+    REQUIRE(owner.should_load);
+    auto waiter = cache.Acquire(2);
+    REQUIRE_FALSE(waiter.should_load);
+
+    auto waited_page = std::async(std::launch::async,
+                                  [&cache, handle = waiter.handle] { return cache.Wait(handle); });
+
+    cache.Clear();
+    REQUIRE(waited_page.wait_for(std::chrono::seconds(1)) == std::future_status::ready);
+    REQUIRE(waited_page.get() == nullptr);
+    REQUIRE(cache.IsStale(waiter.handle));
+
+    auto retry = cache.Acquire(2);
+    REQUIRE(retry.should_load);
+    auto retried_page = MakePage(allocator.get(), 2);
+    REQUIRE(cache.Complete(2, retry.handle, retried_page, true) == retried_page);
 }

--- a/src/io/read_cache/read_cache_test.cpp
+++ b/src/io/read_cache/read_cache_test.cpp
@@ -12,7 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
 #include <cstring>
+#include <mutex>
+#include <thread>
 #include <vector>
 
 #include "impl/allocator/safe_allocator.h"
@@ -61,6 +67,143 @@ public:
 
 private:
     const std::vector<uint8_t>& data_;
+};
+
+class CountingIO : public BasicIO<CountingIO> {
+public:
+    static constexpr bool InMemory = false;
+    static constexpr bool SkipDeserialize = false;
+
+    explicit CountingIO(Allocator* allocator) : BasicIO<CountingIO>(allocator) {
+    }
+
+    void
+    WriteImpl(const uint8_t* data, uint64_t size, uint64_t offset) {
+        std::scoped_lock<std::mutex> lock(multi_read_mutex_);
+        if (data_.size() < offset + size) {
+            data_.resize(offset + size);
+            size_ = offset + size;
+        }
+        std::memcpy(data_.data() + offset, data, size);
+    }
+
+    bool
+    ReadImpl(uint64_t size, uint64_t offset, uint8_t* data) const {
+        ++read_count;
+        {
+            std::unique_lock<std::mutex> lock(read_mutex_);
+            if (block_read_) {
+                read_blocked_ = true;
+                read_blocked_cv_.notify_all();
+                read_resume_cv_.wait(lock, [this] { return not block_read_; });
+            }
+        }
+        std::scoped_lock<std::mutex> lock(multi_read_mutex_);
+        std::memcpy(data, data_.data() + offset, size);
+        return true;
+    }
+
+    const uint8_t*
+    DirectReadImpl(uint64_t size, uint64_t offset, bool& need_release) const {
+        std::scoped_lock<std::mutex> lock(multi_read_mutex_);
+        need_release = true;
+        if (offset > data_.size() or size > data_.size() - offset) {
+            return nullptr;
+        }
+        return data_.data() + offset;
+    }
+
+    void
+    ReleaseImpl(const uint8_t*) const {
+        ++release_count;
+    }
+
+    bool
+    MultiReadImpl(uint8_t* datas, uint64_t* sizes, uint64_t* offsets, uint64_t count) const {
+        ++multi_read_count;
+        {
+            std::unique_lock<std::mutex> lock(multi_read_mutex_);
+            if (block_multi_read_) {
+                multi_read_blocked_ = true;
+                multi_read_blocked_cv_.notify_all();
+                multi_read_resume_cv_.wait(lock, [this] { return not block_multi_read_; });
+            }
+        }
+        if (fail_next_multi_read.exchange(false)) {
+            return false;
+        }
+        std::scoped_lock<std::mutex> lock(multi_read_mutex_);
+        for (uint64_t i = 0; i < count; ++i) {
+            std::memcpy(datas, data_.data() + offsets[i], sizes[i]);
+            datas += sizes[i];
+        }
+        return true;
+    }
+
+    void
+    BlockMultiRead() {
+        std::scoped_lock<std::mutex> lock(multi_read_mutex_);
+        block_multi_read_ = true;
+        multi_read_blocked_ = false;
+    }
+
+    bool
+    WaitForMultiReadBlock() const {
+        std::unique_lock<std::mutex> lock(multi_read_mutex_);
+        return multi_read_blocked_cv_.wait_for(
+            lock, std::chrono::seconds(5), [this] { return multi_read_blocked_; });
+    }
+
+    void
+    UnblockMultiRead() {
+        {
+            std::scoped_lock<std::mutex> lock(multi_read_mutex_);
+            block_multi_read_ = false;
+        }
+        multi_read_resume_cv_.notify_all();
+    }
+
+    void
+    BlockRead() {
+        std::scoped_lock<std::mutex> lock(read_mutex_);
+        block_read_ = true;
+        read_blocked_ = false;
+    }
+
+    bool
+    WaitForReadBlock() const {
+        std::unique_lock<std::mutex> lock(read_mutex_);
+        return read_blocked_cv_.wait_for(
+            lock, std::chrono::seconds(5), [this] { return read_blocked_; });
+    }
+
+    void
+    UnblockRead() {
+        {
+            std::scoped_lock<std::mutex> lock(read_mutex_);
+            block_read_ = false;
+        }
+        read_resume_cv_.notify_all();
+    }
+
+    mutable std::atomic<uint64_t> read_count{0};
+    mutable std::atomic<uint64_t> multi_read_count{0};
+    mutable std::atomic<bool> fail_next_multi_read{false};
+
+    mutable std::atomic<uint64_t> release_count{0};
+
+private:
+    std::vector<uint8_t> data_;
+    mutable std::mutex multi_read_mutex_;
+    mutable std::condition_variable multi_read_blocked_cv_;
+    mutable std::condition_variable multi_read_resume_cv_;
+    mutable bool block_multi_read_{false};
+    mutable bool multi_read_blocked_{false};
+    mutable std::mutex read_mutex_;
+    mutable std::condition_variable read_blocked_cv_;
+    mutable std::condition_variable read_resume_cv_;
+    mutable bool block_read_{false};
+    mutable bool read_blocked_{false};
 };
 
 }  // namespace
@@ -120,6 +263,257 @@ TEST_CASE("BasicIO cache component direct and multi read", "[ReadCache][ut]") {
     std::vector<uint8_t> result(70);
     REQUIRE(io.MultiRead(result.data(), sizes, offsets, 2));
     REQUIRE(std::memcmp(result.data(), data.data(), result.size()) == 0);
+}
+
+TEST_CASE("BasicIO cache releases direct-read buffers by their allocation source",
+          "[ReadCache][ut]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    CountingIO io(allocator.get());
+    io.EnableReadCache(MakeReadCacheParam());
+
+    std::vector<uint8_t> source(128, 0x5A);
+    io.Write(source.data(), source.size(), 0);
+
+    bool need_release = false;
+    const auto* cached = io.Read(source.size(), 0, need_release);
+    REQUIRE(cached != nullptr);
+    REQUIRE(need_release);
+    REQUIRE(std::memcmp(cached, source.data(), source.size()) == 0);
+
+    io.SetReadCache(nullptr);
+    io.Release(cached);
+    REQUIRE(io.release_count == 0);
+
+    const auto* direct = io.Read(source.size(), 0, need_release);
+    REQUIRE(direct != nullptr);
+    REQUIRE(need_release);
+    io.Release(direct);
+    REQUIRE(io.release_count == 1);
+}
+
+TEST_CASE("BasicIO cache validates multi-read pointers", "[ReadCache][ut]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    CountingIO io(allocator.get());
+    io.EnableReadCache(MakeReadCacheParam());
+
+    std::vector<uint8_t> source(Page::DEFAULT_PAGE_SIZE, 0x5A);
+    io.Write(source.data(), source.size(), 0);
+
+    uint64_t zero = 0;
+    uint64_t one = 1;
+    REQUIRE(io.MultiRead(nullptr, nullptr, nullptr, 0));
+    REQUIRE_FALSE(io.MultiRead(nullptr, nullptr, &zero, 1));
+    REQUIRE_FALSE(io.MultiRead(nullptr, &zero, nullptr, 1));
+    REQUIRE(io.MultiRead(nullptr, &zero, &zero, 1));
+    REQUIRE_FALSE(io.MultiRead(nullptr, &one, &zero, 1));
+}
+
+TEST_CASE("BasicIO cache batches missing pages", "[ReadCache][ut]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    CountingIO io(allocator.get());
+    io.EnableReadCache(MakeReadCacheParam(4));
+
+    std::vector<uint8_t> source(Page::DEFAULT_PAGE_SIZE * 3);
+    for (uint64_t i = 0; i < source.size(); ++i) {
+        source[i] = static_cast<uint8_t>(i);
+    }
+    io.Write(source.data(), source.size(), 0);
+
+    uint64_t sizes[] = {32, 64, 48};
+    uint64_t offsets[] = {Page::DEFAULT_PAGE_SIZE - 16,
+                          Page::DEFAULT_PAGE_SIZE + 20,
+                          Page::DEFAULT_PAGE_SIZE * 2 + 40};
+    std::vector<uint8_t> result(144);
+    REQUIRE(io.MultiRead(result.data(), sizes, offsets, 3));
+    REQUIRE(io.multi_read_count == 1);
+    REQUIRE(io.read_count == 0);
+    REQUIRE(std::memcmp(result.data(), source.data() + offsets[0], sizes[0]) == 0);
+    REQUIRE(std::memcmp(result.data() + sizes[0], source.data() + offsets[1], sizes[1]) == 0);
+    REQUIRE(std::memcmp(
+                result.data() + sizes[0] + sizes[1], source.data() + offsets[2], sizes[2]) == 0);
+}
+
+TEST_CASE("BasicIO cache bounds sparse multi-read batches", "[ReadCache][ut]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    CountingIO io(allocator.get());
+    io.EnableReadCache(MakeReadCacheParam(4));
+
+    constexpr uint64_t temp_budget = 8ULL * 1024ULL * 1024ULL;
+    const uint64_t page_count = temp_budget / (2 * Page::DEFAULT_PAGE_SIZE) + 1;
+    std::vector<uint8_t> source(page_count * Page::DEFAULT_PAGE_SIZE);
+    std::vector<uint64_t> sizes(page_count, 1);
+    std::vector<uint64_t> offsets(page_count);
+    std::vector<uint8_t> result(page_count);
+    for (uint64_t i = 0; i < page_count; ++i) {
+        offsets[i] = i * Page::DEFAULT_PAGE_SIZE;
+        source[offsets[i]] = static_cast<uint8_t>(i);
+    }
+    io.Write(source.data(), source.size(), 0);
+
+    REQUIRE(io.MultiRead(result.data(), sizes.data(), offsets.data(), page_count));
+    REQUIRE(io.multi_read_count == 2);
+    for (uint64_t i = 0; i < page_count; ++i) {
+        REQUIRE(result[i] == source[offsets[i]]);
+    }
+}
+
+TEST_CASE("BasicIO cache uses single-read backend for direct reads", "[ReadCache][ut]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    CountingIO io(allocator.get());
+    io.EnableReadCache(MakeReadCacheParam());
+
+    std::vector<uint8_t> source(Page::DEFAULT_PAGE_SIZE, 0xA5);
+    std::vector<uint8_t> result(source.size());
+    io.Write(source.data(), source.size(), 0);
+
+    REQUIRE(io.Read(result.size(), 0, result.data()));
+    REQUIRE(io.read_count == 1);
+    REQUIRE(io.multi_read_count == 0);
+    REQUIRE(result == source);
+}
+
+TEST_CASE("BasicIO cache shares in-flight page loads and retries failures", "[ReadCache][ut]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    CountingIO io(allocator.get());
+    io.EnableReadCache(MakeReadCacheParam());
+
+    std::vector<uint8_t> source(Page::DEFAULT_PAGE_SIZE, 0xA5);
+    io.Write(source.data(), source.size(), 0);
+    io.BlockMultiRead();
+    std::mutex start_mutex;
+    std::condition_variable start_cv;
+    uint64_t readers_ready = 0;
+    bool start = false;
+    std::vector<uint8_t> first(source.size());
+    std::vector<uint8_t> second(source.size());
+    std::atomic<bool> first_succeeded{false};
+    std::atomic<bool> second_succeeded{false};
+    auto read_page = [&](std::vector<uint8_t>& result, std::atomic<bool>& succeeded) {
+        {
+            std::unique_lock<std::mutex> lock(start_mutex);
+            ++readers_ready;
+            start_cv.notify_all();
+            if (not start_cv.wait_for(lock, std::chrono::seconds(5), [&] { return start; })) {
+                return;
+            }
+        }
+        uint64_t size = result.size();
+        uint64_t offset = 0;
+        succeeded = io.MultiRead(result.data(), &size, &offset, 1);
+    };
+    std::thread first_reader(read_page, std::ref(first), std::ref(first_succeeded));
+    std::thread second_reader(read_page, std::ref(second), std::ref(second_succeeded));
+    bool readers_ready_in_time = false;
+    {
+        std::unique_lock<std::mutex> lock(start_mutex);
+        readers_ready_in_time =
+            start_cv.wait_for(lock, std::chrono::seconds(5), [&] { return readers_ready == 2; });
+        start = true;
+    }
+    start_cv.notify_all();
+    const bool multi_read_blocked = io.WaitForMultiReadBlock();
+    io.UnblockMultiRead();
+    first_reader.join();
+    second_reader.join();
+
+    REQUIRE(readers_ready_in_time);
+    REQUIRE(multi_read_blocked);
+    REQUIRE(first_succeeded);
+    REQUIRE(second_succeeded);
+    REQUIRE(io.multi_read_count == 1);
+    REQUIRE(first == source);
+    REQUIRE(second == source);
+
+    CountingIO failing_io(allocator.get());
+    failing_io.EnableReadCache(MakeReadCacheParam());
+    failing_io.Write(source.data(), source.size(), 0);
+    failing_io.fail_next_multi_read = true;
+    uint64_t size = source.size();
+    uint64_t offset = 0;
+    std::vector<uint8_t> result(source.size());
+    REQUIRE_FALSE(failing_io.MultiRead(result.data(), &size, &offset, 1));
+    REQUIRE(failing_io.MultiRead(result.data(), &size, &offset, 1));
+    REQUIRE(failing_io.multi_read_count == 2);
+    REQUIRE(result == source);
+}
+
+TEST_CASE("BasicIO cache keeps an in-flight multi-read snapshot", "[ReadCache][ut]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    CountingIO io(allocator.get());
+    io.EnableReadCache(MakeReadCacheParam());
+
+    std::vector<uint8_t> source(Page::DEFAULT_PAGE_SIZE, 0xA5);
+    std::vector<uint8_t> result(source.size());
+    io.Write(source.data(), source.size(), 0);
+    io.BlockMultiRead();
+
+    std::atomic<bool> read_succeeded{false};
+    std::thread reader([&] {
+        uint64_t size = result.size();
+        uint64_t offset = 0;
+        read_succeeded = io.MultiRead(result.data(), &size, &offset, 1);
+    });
+    const bool multi_read_blocked = io.WaitForMultiReadBlock();
+    io.SetReadCache(nullptr);
+    io.UnblockMultiRead();
+    reader.join();
+
+    REQUIRE(multi_read_blocked);
+    REQUIRE(read_succeeded);
+    REQUIRE(result == source);
+    REQUIRE(io.multi_read_count == 1);
+}
+
+TEST_CASE("BasicIO cache reloads invalidated in-flight pages", "[ReadCache][ut]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    CountingIO io(allocator.get());
+    io.EnableReadCache(MakeReadCacheParam());
+
+    std::vector<uint8_t> source(Page::DEFAULT_PAGE_SIZE, 0xA5);
+    std::vector<uint8_t> result(source.size());
+    io.Write(source.data(), source.size(), 0);
+    io.BlockMultiRead();
+
+    std::atomic<bool> read_succeeded{false};
+    std::thread reader([&] {
+        uint64_t size = result.size();
+        uint64_t offset = 0;
+        read_succeeded = io.MultiRead(result.data(), &size, &offset, 1);
+    });
+    const bool multi_read_blocked = io.WaitForMultiReadBlock();
+    source[0] = 0x5A;
+    io.Write(source.data(), 1, 0);
+    io.UnblockMultiRead();
+    reader.join();
+
+    REQUIRE(multi_read_blocked);
+    REQUIRE(read_succeeded);
+    REQUIRE(result == source);
+    REQUIRE(io.multi_read_count == 2);
+}
+
+TEST_CASE("BasicIO cache reloads invalidated direct reads", "[ReadCache][ut]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    CountingIO io(allocator.get());
+    io.EnableReadCache(MakeReadCacheParam());
+
+    std::vector<uint8_t> source(Page::DEFAULT_PAGE_SIZE, 0xA5);
+    std::vector<uint8_t> result(source.size());
+    io.Write(source.data(), source.size(), 0);
+    io.BlockRead();
+
+    std::atomic<bool> read_succeeded{false};
+    std::thread reader([&] { read_succeeded = io.Read(result.size(), 0, result.data()); });
+    const bool read_blocked = io.WaitForReadBlock();
+    source[0] = 0x5A;
+    io.Write(source.data(), 1, 0);
+    io.UnblockRead();
+    reader.join();
+
+    REQUIRE(read_blocked);
+    REQUIRE(read_succeeded);
+    REQUIRE(result == source);
+    REQUIRE(io.read_count == 2);
 }
 
 TEST_CASE("BasicIO cache component initializes ReaderIO", "[ReadCache][ut]") {

--- a/src/io/read_cache/read_cache_test.cpp
+++ b/src/io/read_cache/read_cache_test.cpp
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <atomic>
+#include <chrono>
 #include <cstring>
+#include <thread>
 #include <vector>
 
 #include "impl/allocator/safe_allocator.h"
@@ -61,6 +64,55 @@ public:
 
 private:
     const std::vector<uint8_t>& data_;
+};
+
+class CountingIO : public BasicIO<CountingIO> {
+public:
+    static constexpr bool InMemory = false;
+    static constexpr bool SkipDeserialize = false;
+
+    explicit CountingIO(Allocator* allocator) : BasicIO<CountingIO>(allocator) {
+    }
+
+    void
+    WriteImpl(const uint8_t* data, uint64_t size, uint64_t offset) {
+        if (data_.size() < offset + size) {
+            data_.resize(offset + size);
+        }
+        std::memcpy(data_.data() + offset, data, size);
+        size_ = data_.size();
+    }
+
+    bool
+    ReadImpl(uint64_t size, uint64_t offset, uint8_t* data) const {
+        ++read_count;
+        std::memcpy(data, data_.data() + offset, size);
+        return true;
+    }
+
+    bool
+    MultiReadImpl(uint8_t* datas, uint64_t* sizes, uint64_t* offsets, uint64_t count) const {
+        ++multi_read_count;
+        if (delay_multi_read) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        }
+        if (fail_next_multi_read.exchange(false)) {
+            return false;
+        }
+        for (uint64_t i = 0; i < count; ++i) {
+            std::memcpy(datas, data_.data() + offsets[i], sizes[i]);
+            datas += sizes[i];
+        }
+        return true;
+    }
+
+    mutable std::atomic<uint64_t> read_count{0};
+    mutable std::atomic<uint64_t> multi_read_count{0};
+    std::atomic<bool> delay_multi_read{false};
+    mutable std::atomic<bool> fail_next_multi_read{false};
+
+private:
+    std::vector<uint8_t> data_;
 };
 
 }  // namespace
@@ -120,6 +172,73 @@ TEST_CASE("BasicIO cache component direct and multi read", "[ReadCache][ut]") {
     std::vector<uint8_t> result(70);
     REQUIRE(io.MultiRead(result.data(), sizes, offsets, 2));
     REQUIRE(std::memcmp(result.data(), data.data(), result.size()) == 0);
+}
+
+TEST_CASE("BasicIO cache batches missing pages", "[ReadCache][ut]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    CountingIO io(allocator.get());
+    io.EnableReadCache(MakeReadCacheParam(4));
+
+    std::vector<uint8_t> source(Page::DEFAULT_PAGE_SIZE * 3);
+    for (uint64_t i = 0; i < source.size(); ++i) {
+        source[i] = static_cast<uint8_t>(i);
+    }
+    io.Write(source.data(), source.size(), 0);
+
+    uint64_t sizes[] = {32, 64, 48};
+    uint64_t offsets[] = {Page::DEFAULT_PAGE_SIZE - 16,
+                          Page::DEFAULT_PAGE_SIZE + 20,
+                          Page::DEFAULT_PAGE_SIZE * 2 + 40};
+    std::vector<uint8_t> result(144);
+    REQUIRE(io.MultiRead(result.data(), sizes, offsets, 3));
+    REQUIRE(io.multi_read_count == 1);
+    REQUIRE(io.read_count == 0);
+    REQUIRE(std::memcmp(result.data(), source.data() + offsets[0], sizes[0]) == 0);
+    REQUIRE(std::memcmp(result.data() + sizes[0], source.data() + offsets[1], sizes[1]) == 0);
+    REQUIRE(std::memcmp(
+                result.data() + sizes[0] + sizes[1], source.data() + offsets[2], sizes[2]) == 0);
+}
+
+TEST_CASE("BasicIO cache shares in-flight page loads and retries failures", "[ReadCache][ut]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    CountingIO io(allocator.get());
+    io.EnableReadCache(MakeReadCacheParam());
+
+    std::vector<uint8_t> source(Page::DEFAULT_PAGE_SIZE, 0xA5);
+    io.Write(source.data(), source.size(), 0);
+    io.delay_multi_read = true;
+
+    std::atomic<bool> start{false};
+    std::vector<uint8_t> first(source.size());
+    std::vector<uint8_t> second(source.size());
+    auto read_page = [&](std::vector<uint8_t>& result) {
+        while (not start.load()) {
+        }
+        uint64_t size = result.size();
+        uint64_t offset = 0;
+        REQUIRE(io.MultiRead(result.data(), &size, &offset, 1));
+    };
+    std::thread first_reader(read_page, std::ref(first));
+    std::thread second_reader(read_page, std::ref(second));
+    start = true;
+    first_reader.join();
+    second_reader.join();
+
+    REQUIRE(io.multi_read_count == 1);
+    REQUIRE(first == source);
+    REQUIRE(second == source);
+
+    CountingIO failing_io(allocator.get());
+    failing_io.EnableReadCache(MakeReadCacheParam());
+    failing_io.Write(source.data(), source.size(), 0);
+    failing_io.fail_next_multi_read = true;
+    uint64_t size = source.size();
+    uint64_t offset = 0;
+    std::vector<uint8_t> result(source.size());
+    REQUIRE_FALSE(failing_io.MultiRead(result.data(), &size, &offset, 1));
+    REQUIRE(failing_io.MultiRead(result.data(), &size, &offset, 1));
+    REQUIRE(failing_io.multi_read_count == 2);
+    REQUIRE(result == source);
 }
 
 TEST_CASE("BasicIO cache component initializes ReaderIO", "[ReadCache][ut]") {

--- a/tests/test_ivf.cpp
+++ b/tests/test_ivf.cpp
@@ -691,7 +691,7 @@ TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
                      expected_search.value()->GetDistances()[0]) < 2e-6F);
     REQUIRE(precise_reader->ReadBytes() > 0);
     if (enable_read_cache) {
-        REQUIRE(precise_reader->ReadCalls() > 0);
+        REQUIRE(precise_reader->ReadCalls() + precise_reader->MultiReadCalls() > 0);
         precise_reader->ResetCounters();
         auto cached_search = loaded.value()->KnnSearch(query, 1, search_param);
         REQUIRE(cached_search.has_value());
@@ -723,7 +723,7 @@ TEST_CASE_PERSISTENT_FIXTURE(IVFTestIndex,
         auto first_distances =
             fresh_loaded.value()->CalcDistancesById(query_vector, ids, batch_count);
         REQUIRE(first_distances.has_value());
-        REQUIRE(fresh_reader->ReadCalls() > 0);
+        REQUIRE(fresh_reader->ReadCalls() + fresh_reader->MultiReadCalls() > 0);
         REQUIRE(fresh_reader->ReadBytes() > 0);
         for (int64_t i = 0; i < batch_count; ++i) {
             REQUIRE(std::abs(first_distances.value()->GetDistances()[i] -


### PR DESCRIPTION
Closes #2638\n\nSummary: deduplicate cached MultiRead pages and load owned misses through one backend MultiReadImpl call. Share in-flight page loads, prevent stale in-flight pages from entering the cache, and add coverage for batched misses, cross-page reads, concurrent loads, and failed-load retry.\n\nValidation: make fmt; make test CASE=[ReadCache]; make release.