### PR TITLE
feat(ivf): support multi-query batch search with bucket_ids bypass

### DIFF
--- a/docs/docs/en/src/api/search.md
+++ b/docs/docs/en/src/api/search.md
@@ -34,7 +34,7 @@ enum class SearchMode {
 
 | Field | Type | Default | Meaning |
 |-------|------|---------|---------|
-| `query_` | `DatasetPtr` | `nullptr` | The query. Exactly one query vector is allowed. |
+| `query_` | `DatasetPtr` | `nullptr` | The query. IVF KNN requests support multiple query vectors; other requests allow one. |
 | `mode_` | `SearchMode` | `KNN_SEARCH` | KNN vs. range search. |
 | `topk_` | `int64_t` | `10` | Neighbors to return (KNN mode). Must be positive. |
 | `radius_` | `float` | `0.5` | Distance threshold (range mode). Non-negative. |
@@ -101,9 +101,13 @@ selection and scans only the specified buckets.
 **Semantics:**
 - **Empty** (default): Use normal bucket routing via `ClassifyDatasForSearch`.
 - **Non-empty**: Skip routing and scan only the provided bucket IDs.
+- **Batch IVF KNN**: One outer `bucket_ids_` entry per query vector.
+  Result is rectangular: `NumElements()` is query count, `Dim()` is `topk_`.
+  Missing neighbors are `-1` with infinite distance.
 
 **Constraints:**
-- Currently only single-query is supported; the outer vector must contain exactly one entry.
+- Batch IVF search supports KNN only; custom query distance and reasoning labels are unsupported.
+- A non-empty outer vector must contain exactly one non-empty entry per query vector.
 - Each bucket ID must be in range `[0, bucket_count)`.
 - Duplicate bucket IDs are rejected.
 - Incompatible with `disable_bucket_scan` mode.

--- a/docs/docs/zh/src/api/search.md
+++ b/docs/docs/zh/src/api/search.md
@@ -34,7 +34,7 @@ enum class SearchMode {
 
 | 字段 | 类型 | 默认值 | 含义 |
 |------|------|--------|------|
-| `query_` | `DatasetPtr` | `nullptr` | 查询。只允许恰好一个查询向量。 |
+| `query_` | `DatasetPtr` | `nullptr` | 查询。IVF KNN 请求支持多个查询向量，其他请求只允许一个。 |
 | `mode_` | `SearchMode` | `KNN_SEARCH` | KNN 还是范围搜索。 |
 | `topk_` | `int64_t` | `10` | 要返回的邻居数（KNN 模式）。必须为正。 |
 | `radius_` | `float` | `0.5` | 距离阈值（范围模式）。非负。 |
@@ -95,9 +95,13 @@ reasoning 选项均会被忽略。
 **语义：**
 - **空**（默认）：使用正常的桶路由（`ClassifyDatasForSearch`）。
 - **非空**：跳过路由，仅扫描提供的桶 ID。
+- **批量 IVF KNN**：`bucket_ids_` 外层每项对应一个查询向量。
+  结果为矩形：`NumElements()` 是查询数，`Dim()` 是 `topk_`。
+  缺失邻居用 `-1` 和无穷距离填充。
 
 **约束：**
-- 当前仅支持单查询；外层向量必须恰好包含一个条目。
+- 批量 IVF 搜索仅支持 KNN；不支持自定义查询距离和 reasoning labels。
+- 非空外层向量必须为每个查询向量提供一个非空条目。
 - 每个桶 ID 必须在 `[0, bucket_count)` 范围内。
 - 重复的桶 ID 会被拒绝。
 - 与 `disable_bucket_scan` 模式不兼容。

--- a/include/vsag/search_request.h
+++ b/include/vsag/search_request.h
@@ -40,9 +40,9 @@ class SearchRequest {
 public:
     // basic params
     /** 
-     * @brief Query dataset containing the vector to search for
+     * @brief Query dataset containing the vector or vectors to search for
      * @details This DatasetPtr holds the query vector used for similarity search. 
-     *          Only one query vector is allowed.
+     *          IVF KNN requests support multiple query vectors; other requests allow one.
      */
     DatasetPtr query_{nullptr};
 
@@ -218,7 +218,7 @@ public:
 
     /**
      * @brief Pre-selected bucket IDs for bypassing IVF bucket routing (ClassifyDatasForSearch)
-     * @details Currently only single-query is supported; outer vector must contain exactly one entry.
+     * @details The outer vector contains one entry per query vector.
      *          Inner vector contains ordered bucket IDs (caller is responsible for ordering).
      *          When non-empty with at least one ID, skips ClassifyDatasForSearch and searches only
      *          the specified buckets. Empty means "use default bucket routing".

--- a/src/algorithm/ivf/ivf.cpp
+++ b/src/algorithm/ivf/ivf.cpp
@@ -1855,31 +1855,12 @@ IVF::SearchWithRequest(const SearchRequest& request) const {
     param.query_context = &ctx;
 
     if (not request.bucket_ids_.empty()) {
-        CHECK_ARGUMENT(request.bucket_ids_.size() == 1,
-                       fmt::format("bucket_ids_ currently supports only single-query mode; "
-                                   "expected size 1, got {}",
-                                   request.bucket_ids_.size()));
-        const auto& ids = request.bucket_ids_[0];
-        CHECK_ARGUMENT(not ids.empty(),
-                       "bucket_ids_[0] must not be empty; "
-                       "use empty outer vector for default routing");
-        std::set<int64_t> seen_ids;
-        param.bucket_ids.reserve(ids.size());
-        for (auto id : ids) {
-            CHECK_ARGUMENT(
-                id >= 0,
-                fmt::format("bucket_id {} out of range [0, {})", id, this->bucket_->bucket_count_));
-            CHECK_ARGUMENT(
-                id < static_cast<int64_t>(this->bucket_->bucket_count_),
-                fmt::format("bucket_id {} out of range [0, {})", id, this->bucket_->bucket_count_));
-            CHECK_ARGUMENT(seen_ids.insert(id).second, fmt::format("duplicate bucket_id {}", id));
-            param.bucket_ids.push_back(id);
-        }
         auto query_check = request.query_;
         CHECK_ARGUMENT(query_check != nullptr, "query dataset cannot be null");
-        CHECK_ARGUMENT(query_check->GetNumElements() == 1,
-                       fmt::format("bucket_ids_ currently supports only single-query mode; "
-                                   "expected 1 query, got {}",
+        CHECK_ARGUMENT(request.bucket_ids_.size() == query_check->GetNumElements(),
+                       fmt::format("bucket_ids_ size must match the number of query vectors; "
+                                   "got {} bucket lists for {} queries",
+                                   request.bucket_ids_.size(),
                                    query_check->GetNumElements()));
         CHECK_ARGUMENT(query_check->GetFloat32Vectors() != nullptr,
                        "query float32 vectors cannot be null");
@@ -1887,6 +1868,29 @@ IVF::SearchWithRequest(const SearchRequest& request) const {
                        "query dimension must match index dimension");
         CHECK_ARGUMENT(not param.disable_bucket_scan,
                        "bucket_ids_ is incompatible with disable_bucket_scan mode");
+        for (uint64_t query_idx = 0; query_idx < request.bucket_ids_.size(); ++query_idx) {
+            const auto& ids = request.bucket_ids_[query_idx];
+            CHECK_ARGUMENT(not ids.empty(),
+                           fmt::format("bucket_ids_[{}] must not be empty; "
+                                       "use empty outer vector for default routing",
+                                       query_idx));
+            std::set<int64_t> seen_ids;
+            for (auto id : ids) {
+                CHECK_ARGUMENT(
+                    id >= 0,
+                    fmt::format(
+                        "bucket_id {} out of range [0, {})", id, this->bucket_->bucket_count_));
+                CHECK_ARGUMENT(
+                    id < static_cast<int64_t>(this->bucket_->bucket_count_),
+                    fmt::format(
+                        "bucket_id {} out of range [0, {})", id, this->bucket_->bucket_count_));
+                CHECK_ARGUMENT(seen_ids.insert(id).second,
+                               fmt::format("duplicate bucket_id {}", id));
+            }
+        }
+        if (query_check->GetNumElements() == 1) {
+            param.bucket_ids.assign(request.bucket_ids_[0].begin(), request.bucket_ids_[0].end());
+        }
     }
 
     auto query = request.query_;
@@ -1908,6 +1912,81 @@ IVF::SearchWithRequest(const SearchRequest& request) const {
         CHECK_ARGUMENT(not request.threshold_.has_value(),
                        "threshold filtering is not supported with disable_bucket_scan");
         auto result = this->route_buckets_only(query, param, ctx);
+        result->Statistics(stats.Dump());
+        return result;
+    }
+
+    if (query != nullptr && query->GetNumElements() > 1) {
+        CHECK_ARGUMENT(not is_range, "IVF batch search only supports KNN search");
+        CHECK_ARGUMENT(not use_custom_distance,
+                       "IVF batch search does not support custom query distance");
+        CHECK_ARGUMENT(request.expected_labels_.empty(),
+                       "IVF batch search does not support expected labels");
+        CHECK_ARGUMENT(request.topk_ > 0, "topk must be greater than 0");
+        CHECK_ARGUMENT(query->GetFloat32Vectors() != nullptr,
+                       "query float32 vectors cannot be null");
+        CHECK_ARGUMENT(query->GetDim() == this->dim_, "query dimension must match index dimension");
+
+        const auto num_queries = query->GetNumElements();
+        const auto total_slots = num_queries * request.topk_;
+        auto* alloc = select_query_allocator(ctx.alloc, this->allocator_);
+        auto* ids = static_cast<int64_t*>(alloc->Allocate(sizeof(int64_t) * total_slots));
+        auto* distances = static_cast<float*>(alloc->Allocate(sizeof(float) * total_slots));
+        std::fill_n(ids, total_slots, -1);
+        std::fill_n(distances, total_slots, std::numeric_limits<float>::infinity());
+
+        const auto* query_data = query->GetFloat32Vectors();
+        auto base_request = request;
+        base_request.expected_labels_.clear();
+        if (not request.bucket_ids_.empty()) {
+            base_request.bucket_ids_.clear();
+        }
+        auto search_func = [&](int64_t query_idx) -> void {
+            auto one_query = Dataset::Make();
+            one_query->NumElements(1)
+                ->Dim(query->GetDim())
+                ->Float32Vectors(query_data + query_idx * query->GetDim())
+                ->Owner(false);
+
+            auto one_request = base_request;
+            one_request.query_ = one_query;
+            if (not request.bucket_ids_.empty()) {
+                one_request.bucket_ids_ = {request.bucket_ids_[query_idx]};
+            }
+            JsonType json = JsonType::Parse(base_request.params_str_);
+            if (json.Contains("ivf")) {
+                json["ivf"]["parallelism"].SetInt64(1);
+            }
+            one_request.params_str_ = json.Dump();
+            auto one_result = this->SearchWithRequest(one_request);
+            const auto count = std::min(request.topk_, one_result->GetDim());
+            if (count > 0) {
+                std::copy_n(one_result->GetIds(), count, ids + query_idx * request.topk_);
+                std::copy_n(
+                    one_result->GetDistances(), count, distances + query_idx * request.topk_);
+            }
+        };
+
+        if (this->thread_pool_ != nullptr and param.parallel_search_thread_count > 1) {
+            std::vector<std::future<void>> futures;
+            for (int64_t query_idx = 0; query_idx < num_queries; ++query_idx) {
+                auto future = this->thread_pool_->GeneralEnqueue(search_func, query_idx);
+                futures.emplace_back(std::move(future));
+            }
+            for (auto& future : futures) {
+                future.get();
+            }
+        } else {
+            for (int64_t query_idx = 0; query_idx < num_queries; ++query_idx) {
+                search_func(query_idx);
+            }
+        }
+        auto result = Dataset::Make()
+                          ->NumElements(num_queries)
+                          ->Dim(request.topk_)
+                          ->Ids(ids)
+                          ->Distances(distances)
+                          ->Owner(true, alloc);
         result->Statistics(stats.Dump());
         return result;
     }

--- a/src/algorithm/ivf/ivf.cpp
+++ b/src/algorithm/ivf/ivf.cpp
@@ -1845,31 +1845,12 @@ IVF::SearchWithRequest(const SearchRequest& request) const {
     }
 
     if (not request.bucket_ids_.empty()) {
-        CHECK_ARGUMENT(request.bucket_ids_.size() == 1,
-                       fmt::format("bucket_ids_ currently supports only single-query mode; "
-                                   "expected size 1, got {}",
-                                   request.bucket_ids_.size()));
-        const auto& ids = request.bucket_ids_[0];
-        CHECK_ARGUMENT(not ids.empty(),
-                       "bucket_ids_[0] must not be empty; "
-                       "use empty outer vector for default routing");
-        std::set<int64_t> seen_ids;
-        param.bucket_ids.reserve(ids.size());
-        for (auto id : ids) {
-            CHECK_ARGUMENT(
-                id >= 0,
-                fmt::format("bucket_id {} out of range [0, {})", id, this->bucket_->bucket_count_));
-            CHECK_ARGUMENT(
-                id < static_cast<int64_t>(this->bucket_->bucket_count_),
-                fmt::format("bucket_id {} out of range [0, {})", id, this->bucket_->bucket_count_));
-            CHECK_ARGUMENT(seen_ids.insert(id).second, fmt::format("duplicate bucket_id {}", id));
-            param.bucket_ids.push_back(id);
-        }
         auto query_check = request.query_;
         CHECK_ARGUMENT(query_check != nullptr, "query dataset cannot be null");
-        CHECK_ARGUMENT(query_check->GetNumElements() == 1,
-                       fmt::format("bucket_ids_ currently supports only single-query mode; "
-                                   "expected 1 query, got {}",
+        CHECK_ARGUMENT(request.bucket_ids_.size() == query_check->GetNumElements(),
+                       fmt::format("bucket_ids_ size must match the number of query vectors; "
+                                   "got {} bucket lists for {} queries",
+                                   request.bucket_ids_.size(),
                                    query_check->GetNumElements()));
         CHECK_ARGUMENT(query_check->GetFloat32Vectors() != nullptr,
                        "query float32 vectors cannot be null");
@@ -1877,6 +1858,29 @@ IVF::SearchWithRequest(const SearchRequest& request) const {
                        "query dimension must match index dimension");
         CHECK_ARGUMENT(not param.disable_bucket_scan,
                        "bucket_ids_ is incompatible with disable_bucket_scan mode");
+        for (uint64_t query_idx = 0; query_idx < request.bucket_ids_.size(); ++query_idx) {
+            const auto& ids = request.bucket_ids_[query_idx];
+            CHECK_ARGUMENT(not ids.empty(),
+                           fmt::format("bucket_ids_[{}] must not be empty; "
+                                       "use empty outer vector for default routing",
+                                       query_idx));
+            std::set<int64_t> seen_ids;
+            for (auto id : ids) {
+                CHECK_ARGUMENT(
+                    id >= 0,
+                    fmt::format(
+                        "bucket_id {} out of range [0, {})", id, this->bucket_->bucket_count_));
+                CHECK_ARGUMENT(
+                    id < static_cast<int64_t>(this->bucket_->bucket_count_),
+                    fmt::format(
+                        "bucket_id {} out of range [0, {})", id, this->bucket_->bucket_count_));
+                CHECK_ARGUMENT(seen_ids.insert(id).second,
+                               fmt::format("duplicate bucket_id {}", id));
+            }
+        }
+        if (query_check->GetNumElements() == 1) {
+            param.bucket_ids.assign(request.bucket_ids_[0].begin(), request.bucket_ids_[0].end());
+        }
     }
 
     auto query = request.query_;
@@ -1898,6 +1902,60 @@ IVF::SearchWithRequest(const SearchRequest& request) const {
         CHECK_ARGUMENT(not request.threshold_.has_value(),
                        "threshold filtering is not supported with disable_bucket_scan");
         auto result = this->route_buckets_only(query, param, ctx);
+        result->Statistics(stats.Dump());
+        return result;
+    }
+
+    if (query != nullptr && query->GetNumElements() > 1) {
+        CHECK_ARGUMENT(not is_range, "IVF batch search only supports KNN search");
+        CHECK_ARGUMENT(not use_custom_distance,
+                       "IVF batch search does not support custom query distance");
+        CHECK_ARGUMENT(request.expected_labels_.empty(),
+                       "IVF batch search does not support expected labels");
+        CHECK_ARGUMENT(request.topk_ > 0, "topk must be greater than 0");
+        CHECK_ARGUMENT(query->GetFloat32Vectors() != nullptr,
+                       "query float32 vectors cannot be null");
+        CHECK_ARGUMENT(query->GetDim() == this->dim_, "query dimension must match index dimension");
+
+        const auto num_queries = query->GetNumElements();
+        const auto total_slots = num_queries * request.topk_;
+        auto* alloc = select_query_allocator(ctx.alloc, this->allocator_);
+        auto* ids = static_cast<int64_t*>(alloc->Allocate(sizeof(int64_t) * total_slots));
+        auto* distances = static_cast<float*>(alloc->Allocate(sizeof(float) * total_slots));
+        std::fill_n(ids, total_slots, -1);
+        std::fill_n(distances, total_slots, std::numeric_limits<float>::infinity());
+
+        const auto* query_data = query->GetFloat32Vectors();
+        auto one_request = request;
+        one_request.expected_labels_.clear();
+        if (not request.bucket_ids_.empty()) {
+            one_request.bucket_ids_.clear();
+        }
+        for (int64_t query_idx = 0; query_idx < num_queries; ++query_idx) {
+            auto one_query = Dataset::Make();
+            one_query->NumElements(1)
+                ->Dim(query->GetDim())
+                ->Float32Vectors(query_data + query_idx * query->GetDim())
+                ->Owner(false);
+
+            one_request.query_ = one_query;
+            if (not request.bucket_ids_.empty()) {
+                one_request.bucket_ids_ = {request.bucket_ids_[query_idx]};
+            }
+            auto one_result = this->SearchWithRequest(one_request);
+            const auto count = std::min(request.topk_, one_result->GetDim());
+            if (count > 0) {
+                std::copy_n(one_result->GetIds(), count, ids + query_idx * request.topk_);
+                std::copy_n(
+                    one_result->GetDistances(), count, distances + query_idx * request.topk_);
+            }
+        }
+        auto result = Dataset::Make()
+                          ->NumElements(num_queries)
+                          ->Dim(request.topk_)
+                          ->Ids(ids)
+                          ->Distances(distances)
+                          ->Owner(true, alloc);
         result->Statistics(stats.Dump());
         return result;
     }

--- a/src/index/index_impl.h
+++ b/src/index/index_impl.h
@@ -501,28 +501,43 @@ public:
     SearchWithRequest(const SearchRequest& request) const override {
         // Validate bucket_ids_ structural constraints before empty-index early return
         if (not request.bucket_ids_.empty()) {
-            if (request.bucket_ids_.size() != 1) {
-                return tl::unexpected(Error(
-                    ErrorType::INVALID_ARGUMENT,
-                    "bucket_ids_ currently supports only single-query mode; expected size 1, got " +
-                        std::to_string(request.bucket_ids_.size())));
-            }
-            const auto& ids = request.bucket_ids_[0];
-            if (ids.empty()) {
+            if (request.query_ == nullptr) {
                 return tl::unexpected(Error(ErrorType::INVALID_ARGUMENT,
-                                            "bucket_ids_[0] must not be empty; use empty outer "
-                                            "vector for default routing"));
+                                            "query_ cannot be null when bucket_ids_ is set"));
             }
-            std::set<int64_t> seen_ids;
-            for (auto id : ids) {
-                if (id < 0) {
+            if (request.bucket_ids_.size() !=
+                static_cast<size_t>(request.query_->GetNumElements())) {
+                return tl::unexpected(
+                    Error(ErrorType::INVALID_ARGUMENT,
+                          "bucket_ids_ size (" + std::to_string(request.bucket_ids_.size()) +
+                              ") must match the number of query vectors (" +
+                              std::to_string(request.query_->GetNumElements()) + ")"));
+            }
+            if (this->GetIndexType() != IndexType::IVF && request.bucket_ids_.size() != 1) {
+                return tl::unexpected(
+                    Error(ErrorType::INVALID_ARGUMENT,
+                          "bucket_ids_ supports multiple query vectors only for IVF indexes"));
+            }
+            for (uint64_t query_idx = 0; query_idx < request.bucket_ids_.size(); ++query_idx) {
+                const auto& ids = request.bucket_ids_[query_idx];
+                if (ids.empty()) {
                     return tl::unexpected(
                         Error(ErrorType::INVALID_ARGUMENT,
-                              "bucket_id " + std::to_string(id) + " is negative"));
+                              "bucket_ids_[" + std::to_string(query_idx) +
+                                  "] must not be empty; use an empty outer vector "
+                                  "for default routing"));
                 }
-                if (not seen_ids.insert(id).second) {
-                    return tl::unexpected(Error(ErrorType::INVALID_ARGUMENT,
-                                                "duplicate bucket_id " + std::to_string(id)));
+                std::set<int64_t> seen_ids;
+                for (auto id : ids) {
+                    if (id < 0) {
+                        return tl::unexpected(
+                            Error(ErrorType::INVALID_ARGUMENT,
+                                  "bucket_id " + std::to_string(id) + " is negative"));
+                    }
+                    if (not seen_ids.insert(id).second) {
+                        return tl::unexpected(Error(ErrorType::INVALID_ARGUMENT,
+                                                    "duplicate bucket_id " + std::to_string(id)));
+                    }
                 }
             }
             try {

--- a/src/index/index_impl.h
+++ b/src/index/index_impl.h
@@ -500,28 +500,43 @@ public:
     SearchWithRequest(const SearchRequest& request) const override {
         // Validate bucket_ids_ structural constraints before empty-index early return
         if (not request.bucket_ids_.empty()) {
-            if (request.bucket_ids_.size() != 1) {
-                return tl::unexpected(Error(
-                    ErrorType::INVALID_ARGUMENT,
-                    "bucket_ids_ currently supports only single-query mode; expected size 1, got " +
-                        std::to_string(request.bucket_ids_.size())));
-            }
-            const auto& ids = request.bucket_ids_[0];
-            if (ids.empty()) {
+            if (request.query_ == nullptr) {
                 return tl::unexpected(Error(ErrorType::INVALID_ARGUMENT,
-                                            "bucket_ids_[0] must not be empty; use empty outer "
-                                            "vector for default routing"));
+                                            "query_ cannot be null when bucket_ids_ is set"));
             }
-            std::set<int64_t> seen_ids;
-            for (auto id : ids) {
-                if (id < 0) {
+            if (request.bucket_ids_.size() !=
+                static_cast<size_t>(request.query_->GetNumElements())) {
+                return tl::unexpected(
+                    Error(ErrorType::INVALID_ARGUMENT,
+                          "bucket_ids_ size (" + std::to_string(request.bucket_ids_.size()) +
+                              ") must match the number of query vectors (" +
+                              std::to_string(request.query_->GetNumElements()) + ")"));
+            }
+            if (this->GetIndexType() != IndexType::IVF && request.bucket_ids_.size() != 1) {
+                return tl::unexpected(
+                    Error(ErrorType::INVALID_ARGUMENT,
+                          "bucket_ids_ supports multiple query vectors only for IVF indexes"));
+            }
+            for (uint64_t query_idx = 0; query_idx < request.bucket_ids_.size(); ++query_idx) {
+                const auto& ids = request.bucket_ids_[query_idx];
+                if (ids.empty()) {
                     return tl::unexpected(
                         Error(ErrorType::INVALID_ARGUMENT,
-                              "bucket_id " + std::to_string(id) + " is negative"));
+                              "bucket_ids_[" + std::to_string(query_idx) +
+                                  "] must not be empty; use an empty outer vector "
+                                  "for default routing"));
                 }
-                if (not seen_ids.insert(id).second) {
-                    return tl::unexpected(Error(ErrorType::INVALID_ARGUMENT,
-                                                "duplicate bucket_id " + std::to_string(id)));
+                std::set<int64_t> seen_ids;
+                for (auto id : ids) {
+                    if (id < 0) {
+                        return tl::unexpected(
+                            Error(ErrorType::INVALID_ARGUMENT,
+                                  "bucket_id " + std::to_string(id) + " is negative"));
+                    }
+                    if (not seen_ids.insert(id).second) {
+                        return tl::unexpected(Error(ErrorType::INVALID_ARGUMENT,
+                                                    "duplicate bucket_id " + std::to_string(id)));
+                    }
                 }
             }
             try {

--- a/tests/test_ivf.cpp
+++ b/tests/test_ivf.cpp
@@ -2419,6 +2419,12 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::IVFTestIndex,
                                     dataset->base_->GetFloat32Vectors() + dim);
     auto query = vsag::Dataset::Make();
     query->NumElements(1)->Dim(dim)->Float32Vectors(query_vector.data())->Owner(false);
+    std::vector<float> batch_query_vectors(query_vector.begin(), query_vector.end());
+    batch_query_vectors.insert(batch_query_vectors.end(),
+                               dataset->base_->GetFloat32Vectors() + dim,
+                               dataset->base_->GetFloat32Vectors() + 2 * dim);
+    auto batch_query = vsag::Dataset::Make();
+    batch_query->NumElements(2)->Dim(dim)->Float32Vectors(batch_query_vectors.data())->Owner(false);
 
     auto param = IVFTestIndex::GenerateIVFBuildParametersString("l2", dim, "fp32", buckets_count);
     auto index = TestIndex::TestFactory(IVFTestIndex::name, param, true);
@@ -2530,12 +2536,92 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::IVFTestIndex,
         REQUIRE_FALSE(result.has_value());
     }
 
-    SECTION("reject multiple query entries") {
+    SECTION("batch queries use corresponding bucket ID lists") {
+        std::vector<int64_t> all_bucket_ids;
+        for (int64_t i = 0; i < buckets_count; ++i) {
+            all_bucket_ids.push_back(i);
+        }
         vsag::SearchRequest request;
-        request.query_ = query;
+        request.query_ = batch_query;
+        request.topk_ = 10;
+        request.params_str_ = search_param_all;
+        request.bucket_ids_ = {all_bucket_ids, all_bucket_ids};
+        auto batch_result = index->SearchWithRequest(request);
+        REQUIRE(batch_result.has_value());
+        REQUIRE(batch_result.value()->GetNumElements() == 2);
+        REQUIRE(batch_result.value()->GetDim() == request.topk_);
+
+        vsag::SearchRequest first_request = request;
+        first_request.query_ = query;
+        first_request.bucket_ids_ = {all_bucket_ids};
+        auto first_result = index->SearchWithRequest(first_request);
+        REQUIRE(first_result.has_value());
+
+        auto second_query = vsag::Dataset::Make();
+        second_query->NumElements(1)
+            ->Dim(dim)
+            ->Float32Vectors(batch_query_vectors.data() + dim)
+            ->Owner(false);
+        vsag::SearchRequest second_request = first_request;
+        second_request.query_ = second_query;
+        auto second_result = index->SearchWithRequest(second_request);
+        REQUIRE(second_result.has_value());
+
+        const auto* batch_ids = batch_result.value()->GetIds();
+        const auto* batch_dists = batch_result.value()->GetDistances();
+        for (int64_t i = 0; i < request.topk_; ++i) {
+            REQUIRE(batch_ids[i] == first_result.value()->GetIds()[i]);
+            REQUIRE(batch_dists[i] == first_result.value()->GetDistances()[i]);
+            REQUIRE(batch_ids[request.topk_ + i] == second_result.value()->GetIds()[i]);
+            REQUIRE(batch_dists[request.topk_ + i] == second_result.value()->GetDistances()[i]);
+        }
+    }
+
+    SECTION("batch queries with default routing (no bucket_ids)") {
+        vsag::SearchRequest request;
+        request.query_ = batch_query;
+        request.topk_ = 10;
+        request.params_str_ = search_param_all;
+        auto batch_result = index->SearchWithRequest(request);
+        REQUIRE(batch_result.has_value());
+        REQUIRE(batch_result.value()->GetNumElements() == 2);
+        REQUIRE(batch_result.value()->GetDim() == request.topk_);
+
+        vsag::SearchRequest single_req;
+        single_req.query_ = query;
+        single_req.topk_ = 10;
+        single_req.params_str_ = search_param_all;
+        auto first_result = index->SearchWithRequest(single_req);
+        REQUIRE(first_result.has_value());
+
+        auto second_query = vsag::Dataset::Make();
+        second_query->NumElements(1)
+            ->Dim(dim)
+            ->Float32Vectors(batch_query_vectors.data() + dim)
+            ->Owner(false);
+        vsag::SearchRequest second_req;
+        second_req.query_ = second_query;
+        second_req.topk_ = 10;
+        second_req.params_str_ = search_param_all;
+        auto second_result = index->SearchWithRequest(second_req);
+        REQUIRE(second_result.has_value());
+
+        const auto* batch_ids = batch_result.value()->GetIds();
+        const auto* batch_dists = batch_result.value()->GetDistances();
+        for (int64_t i = 0; i < request.topk_; ++i) {
+            REQUIRE(batch_ids[i] == first_result.value()->GetIds()[i]);
+            REQUIRE(batch_dists[i] == first_result.value()->GetDistances()[i]);
+            REQUIRE(batch_ids[request.topk_ + i] == second_result.value()->GetIds()[i]);
+            REQUIRE(batch_dists[request.topk_ + i] == second_result.value()->GetDistances()[i]);
+        }
+    }
+
+    SECTION("reject bucket ID lists that do not match query count") {
+        vsag::SearchRequest request;
+        request.query_ = batch_query;
         request.topk_ = 10;
         request.params_str_ = search_param;
-        request.bucket_ids_ = {{0}, {1}};
+        request.bucket_ids_ = {{0}};
         auto result = index->SearchWithRequest(request);
         REQUIRE_FALSE(result.has_value());
     }

--- a/tests/test_ivf.cpp
+++ b/tests/test_ivf.cpp
@@ -2428,6 +2428,12 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::IVFTestIndex,
                                     dataset->base_->GetFloat32Vectors() + dim);
     auto query = vsag::Dataset::Make();
     query->NumElements(1)->Dim(dim)->Float32Vectors(query_vector.data())->Owner(false);
+    std::vector<float> batch_query_vectors(query_vector.begin(), query_vector.end());
+    batch_query_vectors.insert(batch_query_vectors.end(),
+                               dataset->base_->GetFloat32Vectors() + dim,
+                               dataset->base_->GetFloat32Vectors() + 2 * dim);
+    auto batch_query = vsag::Dataset::Make();
+    batch_query->NumElements(2)->Dim(dim)->Float32Vectors(batch_query_vectors.data())->Owner(false);
 
     auto param = IVFTestIndex::GenerateIVFBuildParametersString("l2", dim, "fp32", buckets_count);
     auto index = TestIndex::TestFactory(IVFTestIndex::name, param, true);
@@ -2539,12 +2545,92 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::IVFTestIndex,
         REQUIRE_FALSE(result.has_value());
     }
 
-    SECTION("reject multiple query entries") {
+    SECTION("batch queries use corresponding bucket ID lists") {
+        std::vector<int64_t> all_bucket_ids;
+        for (int64_t i = 0; i < buckets_count; ++i) {
+            all_bucket_ids.push_back(i);
+        }
         vsag::SearchRequest request;
-        request.query_ = query;
+        request.query_ = batch_query;
+        request.topk_ = 10;
+        request.params_str_ = search_param_all;
+        request.bucket_ids_ = {all_bucket_ids, all_bucket_ids};
+        auto batch_result = index->SearchWithRequest(request);
+        REQUIRE(batch_result.has_value());
+        REQUIRE(batch_result.value()->GetNumElements() == 2);
+        REQUIRE(batch_result.value()->GetDim() == request.topk_);
+
+        vsag::SearchRequest first_request = request;
+        first_request.query_ = query;
+        first_request.bucket_ids_ = {all_bucket_ids};
+        auto first_result = index->SearchWithRequest(first_request);
+        REQUIRE(first_result.has_value());
+
+        auto second_query = vsag::Dataset::Make();
+        second_query->NumElements(1)
+            ->Dim(dim)
+            ->Float32Vectors(batch_query_vectors.data() + dim)
+            ->Owner(false);
+        vsag::SearchRequest second_request = first_request;
+        second_request.query_ = second_query;
+        auto second_result = index->SearchWithRequest(second_request);
+        REQUIRE(second_result.has_value());
+
+        const auto* batch_ids = batch_result.value()->GetIds();
+        const auto* batch_dists = batch_result.value()->GetDistances();
+        for (int64_t i = 0; i < request.topk_; ++i) {
+            REQUIRE(batch_ids[i] == first_result.value()->GetIds()[i]);
+            REQUIRE(batch_dists[i] == first_result.value()->GetDistances()[i]);
+            REQUIRE(batch_ids[request.topk_ + i] == second_result.value()->GetIds()[i]);
+            REQUIRE(batch_dists[request.topk_ + i] == second_result.value()->GetDistances()[i]);
+        }
+    }
+
+    SECTION("batch queries with default routing (no bucket_ids)") {
+        vsag::SearchRequest request;
+        request.query_ = batch_query;
+        request.topk_ = 10;
+        request.params_str_ = search_param_all;
+        auto batch_result = index->SearchWithRequest(request);
+        REQUIRE(batch_result.has_value());
+        REQUIRE(batch_result.value()->GetNumElements() == 2);
+        REQUIRE(batch_result.value()->GetDim() == request.topk_);
+
+        vsag::SearchRequest single_req;
+        single_req.query_ = query;
+        single_req.topk_ = 10;
+        single_req.params_str_ = search_param_all;
+        auto first_result = index->SearchWithRequest(single_req);
+        REQUIRE(first_result.has_value());
+
+        auto second_query = vsag::Dataset::Make();
+        second_query->NumElements(1)
+            ->Dim(dim)
+            ->Float32Vectors(batch_query_vectors.data() + dim)
+            ->Owner(false);
+        vsag::SearchRequest second_req;
+        second_req.query_ = second_query;
+        second_req.topk_ = 10;
+        second_req.params_str_ = search_param_all;
+        auto second_result = index->SearchWithRequest(second_req);
+        REQUIRE(second_result.has_value());
+
+        const auto* batch_ids = batch_result.value()->GetIds();
+        const auto* batch_dists = batch_result.value()->GetDistances();
+        for (int64_t i = 0; i < request.topk_; ++i) {
+            REQUIRE(batch_ids[i] == first_result.value()->GetIds()[i]);
+            REQUIRE(batch_dists[i] == first_result.value()->GetDistances()[i]);
+            REQUIRE(batch_ids[request.topk_ + i] == second_result.value()->GetIds()[i]);
+            REQUIRE(batch_dists[request.topk_ + i] == second_result.value()->GetDistances()[i]);
+        }
+    }
+
+    SECTION("reject bucket ID lists that do not match query count") {
+        vsag::SearchRequest request;
+        request.query_ = batch_query;
         request.topk_ = 10;
         request.params_str_ = search_param;
-        request.bucket_ids_ = {{0}, {1}};
+        request.bucket_ids_ = {{0}};
         auto result = index->SearchWithRequest(request);
         REQUIRE_FALSE(result.has_value());
     }
@@ -2566,5 +2652,65 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::IVFTestIndex,
         request.bucket_ids_ = {{0}};
         auto result = index->SearchWithRequest(request);
         REQUIRE_FALSE(result.has_value());
+    }
+}
+
+TEST_CASE("IVF Batch Search Parallel", "[ft][ivf][pr]") {
+    constexpr auto dim = 32;
+    constexpr auto buckets_count = 10;
+    constexpr auto base_count = 200;
+    constexpr auto num_queries = 4;
+
+    auto dataset = fixtures::IVFTestIndex::pool.GetDatasetAndCreate(dim, base_count, "l2");
+
+    auto param = fixtures::IVFTestIndex::GenerateIVFBuildParametersString(
+        "l2", dim, "fp32", buckets_count, "kmeans", false, 1, false, 2);
+    auto index = vsag::Factory::CreateIndex("ivf", param);
+    REQUIRE(index.has_value());
+    auto build_result = index.value()->Build(dataset->base_);
+    REQUIRE(build_result.has_value());
+
+    std::vector<float> batch_query_vectors;
+    for (int64_t i = 0; i < num_queries; ++i) {
+        batch_query_vectors.insert(batch_query_vectors.end(),
+                                   dataset->base_->GetFloat32Vectors() + i * dim,
+                                   dataset->base_->GetFloat32Vectors() + (i + 1) * dim);
+    }
+    auto batch_query = vsag::Dataset::Make();
+    batch_query->NumElements(num_queries)
+        ->Dim(dim)
+        ->Float32Vectors(batch_query_vectors.data())
+        ->Owner(false);
+
+    auto search_param_serial = R"({"ivf":{"scan_buckets_count":5,"parallelism":1}})";
+    auto search_param_parallel = R"({"ivf":{"scan_buckets_count":5,"parallelism":2}})";
+
+    vsag::SearchRequest serial_request;
+    serial_request.query_ = batch_query;
+    serial_request.topk_ = 10;
+    serial_request.params_str_ = search_param_serial;
+    auto serial_result = index.value()->SearchWithRequest(serial_request);
+    REQUIRE(serial_result.has_value());
+
+    vsag::SearchRequest parallel_request;
+    parallel_request.query_ = batch_query;
+    parallel_request.topk_ = 10;
+    parallel_request.params_str_ = search_param_parallel;
+    auto parallel_result = index.value()->SearchWithRequest(parallel_request);
+    REQUIRE(parallel_result.has_value());
+
+    REQUIRE(serial_result.value()->GetNumElements() == num_queries);
+    REQUIRE(parallel_result.value()->GetNumElements() == num_queries);
+    REQUIRE(serial_result.value()->GetDim() == 10);
+    REQUIRE(parallel_result.value()->GetDim() == 10);
+
+    const auto* serial_ids = serial_result.value()->GetIds();
+    const auto* serial_dists = serial_result.value()->GetDistances();
+    const auto* parallel_ids = parallel_result.value()->GetIds();
+    const auto* parallel_dists = parallel_result.value()->GetDistances();
+
+    for (int64_t i = 0; i < num_queries * 10; ++i) {
+        REQUIRE(serial_ids[i] == parallel_ids[i]);
+        REQUIRE(serial_dists[i] == parallel_dists[i]);
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #2597. Relaxes the bucket_ids_ constraint from exactly 1 query to matching the query count, and adds a batch KNN path for IVF SearchWithRequest.

Fixes: #2597

## Changes

- IndexImpl validation: outer bucket_ids_ size must match query_->GetNumElements(); non-IVF indexes still restricted to 1 entry
- IVF batch path: per-query recursive call to SearchWithRequest with 1-row non-owning Dataset view plus corresponding bucket list, aggregated into rectangular Dataset(NumElements=num_queries, Dim=topk)
- Padding: missing neighbors filled with id=-1, distance=+inf
- Restrictions: batch IVF rejects range search, custom distance callback, and reasoning labels
- Tests: batch correctness vs individual single-query results, query-count mismatch rejection, batch default routing
- Docs: updated en/zh API reference for query_ and bucket_ids_