### PR TITLE
feat: support L1 distance metric and add unit tests

### DIFF
--- a/include/vsag/constants.h
+++ b/include/vsag/constants.h
@@ -49,6 +49,7 @@ extern const char* const SIMPLEFLAT_IDS;
 extern const char* const METRIC_L2;
 extern const char* const METRIC_COSINE;
 extern const char* const METRIC_IP;
+extern const char* const METRIC_L1;
 extern const char* const DATATYPE_FLOAT32;
 extern const char* const DATATYPE_FLOAT16;
 extern const char* const DATATYPE_INT8;

--- a/src/algorithm/hnswlib/hnswlib.h
+++ b/src/algorithm/hnswlib/hnswlib.h
@@ -41,4 +41,5 @@
 #include "hnswalg.h"
 #include "hnswalg_static.h"
 #include "space_ip.h"
+#include "space_l1.h"
 #include "space_l2.h"

--- a/src/algorithm/hnswlib/space_l1.h
+++ b/src/algorithm/hnswlib/space_l1.h
@@ -1,4 +1,3 @@
-
 // Copyright 2024-present the vsag project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,12 +14,36 @@
 
 #pragma once
 
-namespace vsag {
-enum class MetricType {
-    METRIC_TYPE_L2SQR = 0,
-    METRIC_TYPE_IP = 1,
-    METRIC_TYPE_COSINE = 2,
-    METRIC_TYPE_L1 = 3,
+#include "simd/basic_func.h"
+#include "space_interface.h"
+
+namespace hnswlib {
+
+class L1Space : public SpaceInterface {
+public:
+    explicit L1Space(uint64_t dim)
+        : fstdistfunc_(vsag::L1Distance), data_size_(dim * sizeof(float)), dim_(dim) {
+    }
+
+    size_t
+    get_data_size() override {
+        return data_size_;
+    }
+
+    DISTFUNC
+    get_dist_func() override {
+        return fstdistfunc_;
+    }
+
+    void*
+    get_dist_func_param() override {
+        return &dim_;
+    }
+
+private:
+    DISTFUNC fstdistfunc_;
+    size_t data_size_;
+    uint64_t dim_;
 };
 
-}  // namespace vsag
+}  // namespace hnswlib

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -53,6 +53,7 @@ const char* const SIMPLEFLAT_IDS = "simpleflat_ids";
 const char* const METRIC_L2 = "l2";
 const char* const METRIC_COSINE = "cosine";
 const char* const METRIC_IP = "ip";
+const char* const METRIC_L1 = "l1";
 const char* const DATATYPE_FLOAT32 = "float32";
 const char* const DATATYPE_FLOAT16 = "float16";
 const char* const DATATYPE_INT8 = "int8";

--- a/src/datacell/flatten_interface.cpp
+++ b/src/datacell/flatten_interface.cpp
@@ -156,6 +156,21 @@ template <typename IOTemp>
 static FlattenInterfacePtr
 make_instance(const FlattenInterfaceParamPtr& param, const IndexCommonParam& common_param) {
     auto metric = common_param.metric_;
+    if (metric == MetricType::METRIC_TYPE_L1) {
+        if (common_param.data_type_ != DataTypes::DATA_TYPE_FLOAT) {
+            throw VsagException(ErrorType::INVALID_ARGUMENT, "l1 metric must use float32 dtype");
+        }
+        if (param->name != FLATTEN_DATA_CELL) {
+            throw VsagException(ErrorType::INVALID_ARGUMENT,
+                                "l1 metric supports only flatten data cell");
+        }
+        if (param->quantizer_parameter->GetTypeName() != QUANTIZATION_TYPE_VALUE_FP32) {
+            throw VsagException(ErrorType::INVALID_ARGUMENT,
+                                "l1 metric supports only fp32 quantization");
+        }
+        return make_instance_flatten<FP32Quantizer<MetricType::METRIC_TYPE_L1>, IOTemp>(
+            param, common_param);
+    }
     if (metric == MetricType::METRIC_TYPE_L2SQR) {
         return make_instance<MetricType::METRIC_TYPE_L2SQR, IOTemp>(param, common_param);
     }

--- a/src/factory/engine.cpp
+++ b/src/factory/engine.cpp
@@ -64,6 +64,11 @@ Engine::CreateIndex(const std::string& origin_name, const std::string& parameter
         transform(name.begin(), name.end(), name.begin(), ::tolower);
         auto parsed_params = JsonType::Parse(parameters);
         auto index_common_params = IndexCommonParam::CheckAndCreate(parsed_params, this->resource_);
+        if (index_common_params.metric_ == MetricType::METRIC_TYPE_L1 && name != INDEX_HNSW &&
+            name != INDEX_HGRAPH) {
+            LOG_ERROR_AND_RETURNS(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                                  "l1 metric is supported only by the hnsw and hgraph indexes");
+        }
         if (name == INDEX_HNSW) {
             // read parameters from json, throw exception if not exists
             CHECK_ARGUMENT(parsed_params.Contains(INDEX_HNSW),

--- a/src/factory/factory_test.cpp
+++ b/src/factory/factory_test.cpp
@@ -108,8 +108,16 @@ TEST_CASE("Create Float32 L1 Index", "[ut][factory][l1]") {
 
     SECTION("float32 l1 hgraph rejects compressed quantization") {
         const char* unsupported_quantizations[] = {
-            "fp16", "bf16", "sq8", "sq4", "sq8_uniform",
-            "sq4_uniform", "pq", "pqfs", "rabitq", "tq",
+            "fp16",
+            "bf16",
+            "sq8",
+            "sq4",
+            "sq8_uniform",
+            "sq4_uniform",
+            "pq",
+            "pqfs",
+            "rabitq",
+            "tq",
         };
         for (const auto* quantization : unsupported_quantizations) {
             auto parameters = vsag::JsonType::Parse(R"(

--- a/src/factory/factory_test.cpp
+++ b/src/factory/factory_test.cpp
@@ -64,6 +64,75 @@ TEST_CASE("Create Index with Full Parameters", "[ut][factory]") {
     }
 }
 
+TEST_CASE("Create Float32 L1 Index", "[ut][factory][l1]") {
+    vsag::logger::set_level(vsag::logger::level::debug);
+
+    SECTION("float32 l1 supports hnsw and fp32 hgraph") {
+        auto parameters = vsag::JsonType::Parse(R"(
+        {
+            "dtype": "float32",
+            "metric_type": "l1",
+            "dim": 16,
+            "hnsw": {
+                "max_degree": 8,
+                "ef_construction": 100
+            }
+        }
+        )");
+
+        REQUIRE(vsag::Factory::CreateIndex("hnsw", parameters.Dump()).has_value());
+
+        auto hgraph_parameters = vsag::JsonType::Parse(R"(
+        {
+            "dtype": "float32",
+            "metric_type": "l1",
+            "dim": 16,
+            "index_param": {
+                "base_quantization_type": "fp32",
+                "max_degree": 8,
+                "ef_construction": 100,
+                "build_thread_count": 0,
+                "store_raw_vector": true
+            }
+        }
+        )");
+        REQUIRE(vsag::Factory::CreateIndex("hgraph", hgraph_parameters.Dump()).has_value());
+
+        const char* unsupported_indexes[] = {"fresh_hnsw", "brute_force", "diskann", "ivf"};
+        for (const auto* index_name : unsupported_indexes) {
+            auto index = vsag::Factory::CreateIndex(index_name, parameters.Dump());
+            REQUIRE_FALSE(index.has_value());
+            REQUIRE(index.error().type == vsag::ErrorType::UNSUPPORTED_INDEX_OPERATION);
+        }
+    }
+
+    SECTION("float32 l1 hgraph rejects compressed quantization") {
+        const char* unsupported_quantizations[] = {
+            "fp16", "bf16", "sq8", "sq4", "sq8_uniform",
+            "sq4_uniform", "pq", "pqfs", "rabitq", "tq",
+        };
+        for (const auto* quantization : unsupported_quantizations) {
+            auto parameters = vsag::JsonType::Parse(R"(
+            {
+                "dtype": "float32",
+                "metric_type": "l1",
+                "dim": 16,
+                "index_param": {
+                    "max_degree": 8,
+                    "ef_construction": 100,
+                    "build_thread_count": 0
+                }
+            }
+            )");
+            parameters["index_param"]["base_quantization_type"].SetString(quantization);
+
+            auto index = vsag::Factory::CreateIndex("hgraph", parameters.Dump());
+            REQUIRE_FALSE(index.has_value());
+            REQUIRE(index.error().type == vsag::ErrorType::INVALID_ARGUMENT);
+        }
+    }
+}
+
 TEST_CASE("Create Local File Reader", "[ut][factory]") {
     vsag::logger::set_level(vsag::logger::level::debug);
 

--- a/src/index/hnsw_test.cpp
+++ b/src/index/hnsw_test.cpp
@@ -16,6 +16,7 @@
 #include "hnsw.h"
 
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
 #include <cstdlib>
 #include <memory>
 #include <new>
@@ -47,6 +48,14 @@ parse_hnsw_params(IndexCommonParam index_common_param) {
     return HnswParameters::FromJson(parsed_params, index_common_param);
 }
 
+std::unique_ptr<hnswlib::SpaceInterface>
+make_hnsw_test_space(int64_t dim, MetricType metric_type) {
+    if (metric_type == MetricType::METRIC_TYPE_L1) {
+        return std::make_unique<hnswlib::L1Space>(dim);
+    }
+    return std::make_unique<hnswlib::L2Space>(dim);
+}
+
 TEST_CASE("build & add", "[ut][hnsw]") {
     logger::set_level(logger::level::debug);
     int64_t dim = 128;
@@ -55,7 +64,8 @@ TEST_CASE("build & add", "[ut][hnsw]") {
     IndexCommonParam common_param;
     common_param.dim_ = dim;
     common_param.data_type_ = DataTypes::DATA_TYPE_FLOAT;
-    common_param.metric_ = MetricType::METRIC_TYPE_L2SQR;
+    common_param.metric_ =
+        GENERATE(MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_L1);
     common_param.allocator_ = allocator;
 
     HnswParameters hnsw_obj = parse_hnsw_params(common_param);
@@ -96,7 +106,8 @@ TEST_CASE("build with allocator", "[ut][hnsw]") {
 
     common_param.dim_ = dim;
     common_param.data_type_ = DataTypes::DATA_TYPE_FLOAT;
-    common_param.metric_ = MetricType::METRIC_TYPE_L2SQR;
+    common_param.metric_ =
+        GENERATE(MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_L1);
     common_param.allocator_ = allocator;
 
     HnswParameters hnsw_obj = parse_hnsw_params(common_param);
@@ -125,7 +136,8 @@ TEST_CASE("knn_search", "[ut][hnsw]") {
     IndexCommonParam common_param;
     common_param.dim_ = dim;
     common_param.data_type_ = DataTypes::DATA_TYPE_FLOAT;
-    common_param.metric_ = MetricType::METRIC_TYPE_L2SQR;
+    common_param.metric_ =
+        GENERATE(MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_L1);
     common_param.allocator_ = SafeAllocator::FactoryDefaultAllocator();
 
     HnswParameters hnsw_obj = parse_hnsw_params(common_param);
@@ -247,7 +259,8 @@ TEST_CASE("iterator filter init allocation failure", "[ut][hnsw]") {
     IndexCommonParam common_param;
     common_param.dim_ = dim;
     common_param.data_type_ = DataTypes::DATA_TYPE_FLOAT;
-    common_param.metric_ = MetricType::METRIC_TYPE_L2SQR;
+    common_param.metric_ =
+        GENERATE(MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_L1);
     common_param.allocator_ = SafeAllocator::FactoryDefaultAllocator();
 
     HnswParameters hnsw_obj = parse_hnsw_params(common_param);
@@ -291,7 +304,8 @@ TEST_CASE("range_search", "[ut][hnsw]") {
     IndexCommonParam common_param;
     common_param.dim_ = dim;
     common_param.data_type_ = DataTypes::DATA_TYPE_FLOAT;
-    common_param.metric_ = MetricType::METRIC_TYPE_L2SQR;
+    common_param.metric_ =
+        GENERATE(MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_L1);
     common_param.allocator_ = SafeAllocator::FactoryDefaultAllocator();
 
     HnswParameters hnsw_obj = parse_hnsw_params(common_param);
@@ -388,7 +402,8 @@ TEST_CASE("serialize empty index", "[ut][hnsw]") {
     IndexCommonParam common_param;
     common_param.dim_ = dim;
     common_param.data_type_ = DataTypes::DATA_TYPE_FLOAT;
-    common_param.metric_ = MetricType::METRIC_TYPE_L2SQR;
+    common_param.metric_ =
+        GENERATE(MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_L1);
     common_param.allocator_ = SafeAllocator::FactoryDefaultAllocator();
 
     HnswParameters hnsw_obj = parse_hnsw_params(common_param);
@@ -425,7 +440,8 @@ TEST_CASE("deserialize on not empty index", "[ut][hnsw]") {
     IndexCommonParam common_param;
     common_param.dim_ = dim;
     common_param.data_type_ = DataTypes::DATA_TYPE_FLOAT;
-    common_param.metric_ = MetricType::METRIC_TYPE_L2SQR;
+    common_param.metric_ =
+        GENERATE(MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_L1);
     common_param.allocator_ = SafeAllocator::FactoryDefaultAllocator();
 
     HnswParameters hnsw_obj = parse_hnsw_params(common_param);
@@ -482,7 +498,8 @@ TEST_CASE("static hnsw", "[ut][hnsw]") {
     IndexCommonParam common_param;
     common_param.dim_ = dim;
     common_param.data_type_ = DataTypes::DATA_TYPE_FLOAT;
-    common_param.metric_ = MetricType::METRIC_TYPE_L2SQR;
+    common_param.metric_ =
+        GENERATE(MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_L1);
     common_param.allocator_ = SafeAllocator::FactoryDefaultAllocator();
 
     HnswParameters hnsw_obj = parse_hnsw_params(common_param);
@@ -548,7 +565,8 @@ TEST_CASE("hnsw add vector with duplicated id", "[ut][hnsw]") {
     IndexCommonParam common_param;
     common_param.dim_ = dim;
     common_param.data_type_ = DataTypes::DATA_TYPE_FLOAT;
-    common_param.metric_ = MetricType::METRIC_TYPE_L2SQR;
+    common_param.metric_ =
+        GENERATE(MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_L1);
     common_param.allocator_ = SafeAllocator::FactoryDefaultAllocator();
 
     HnswParameters hnsw_obj = parse_hnsw_params(common_param);
@@ -590,7 +608,8 @@ TEST_CASE("build with reversed edges", "[ut][hnsw]") {
     IndexCommonParam common_param;
     common_param.dim_ = dim;
     common_param.data_type_ = DataTypes::DATA_TYPE_FLOAT;
-    common_param.metric_ = MetricType::METRIC_TYPE_L2SQR;
+    common_param.metric_ =
+        GENERATE(MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_L1);
     common_param.allocator_ = SafeAllocator::FactoryDefaultAllocator();
 
     HnswParameters hnsw_obj = parse_hnsw_params(common_param);
@@ -691,7 +710,8 @@ TEST_CASE("feedback with invalid argument", "[ut][hnsw]") {
     IndexCommonParam common_param;
     common_param.dim_ = dim;
     common_param.data_type_ = DataTypes::DATA_TYPE_FLOAT;
-    common_param.metric_ = MetricType::METRIC_TYPE_L2SQR;
+    common_param.metric_ =
+        GENERATE(MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_L1);
     common_param.allocator_ = SafeAllocator::FactoryDefaultAllocator();
 
     HnswParameters hnsw_obj = parse_hnsw_params(common_param);
@@ -733,7 +753,8 @@ TEST_CASE("redundant feedback and empty enhancement", "[ut][hnsw]") {
     IndexCommonParam common_param;
     common_param.dim_ = 128;
     common_param.data_type_ = DataTypes::DATA_TYPE_FLOAT;
-    common_param.metric_ = MetricType::METRIC_TYPE_L2SQR;
+    common_param.metric_ =
+        GENERATE(MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_L1);
     common_param.allocator_ = SafeAllocator::FactoryDefaultAllocator();
 
     HnswParameters hnsw_obj = parse_hnsw_params(common_param);
@@ -797,7 +818,8 @@ TEST_CASE("feedback and pretrain without use conjugate graph", "[ut][hnsw]") {
     IndexCommonParam common_param;
     common_param.dim_ = dim;
     common_param.data_type_ = DataTypes::DATA_TYPE_FLOAT;
-    common_param.metric_ = MetricType::METRIC_TYPE_L2SQR;
+    common_param.metric_ =
+        GENERATE(MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_L1);
     common_param.allocator_ = SafeAllocator::FactoryDefaultAllocator();
 
     HnswParameters hnsw_obj = parse_hnsw_params(common_param);
@@ -844,7 +866,8 @@ TEST_CASE("feedback and pretrain on empty index", "[ut][hnsw]") {
     IndexCommonParam common_param;
     common_param.dim_ = dim;
     common_param.data_type_ = DataTypes::DATA_TYPE_FLOAT;
-    common_param.metric_ = MetricType::METRIC_TYPE_L2SQR;
+    common_param.metric_ =
+        GENERATE(MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_L1);
     common_param.allocator_ = SafeAllocator::FactoryDefaultAllocator();
 
     HnswParameters hnsw_obj = parse_hnsw_params(common_param);
@@ -893,7 +916,8 @@ TEST_CASE("invalid pretrain", "[ut][hnsw]") {
     IndexCommonParam common_param;
     common_param.dim_ = dim;
     common_param.data_type_ = DataTypes::DATA_TYPE_FLOAT;
-    common_param.metric_ = MetricType::METRIC_TYPE_L2SQR;
+    common_param.metric_ =
+        GENERATE(MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_L1);
     common_param.allocator_ = SafeAllocator::FactoryDefaultAllocator();
 
     HnswParameters hnsw_obj = parse_hnsw_params(common_param);
@@ -953,11 +977,13 @@ TEST_CASE("get distance by label", "[ut][hnsw]") {
     auto [base_ids, base_vectors] = fixtures::generate_ids_and_vectors(num_base, dim);
 
     // hnsw index
-    hnswlib::L2Space space(dim);
+    const auto metric_type =
+        GENERATE(MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_L1);
+    auto space = make_hnsw_test_space(dim, metric_type);
 
     SECTION("hnsw test") {
         DefaultAllocator allocator;
-        auto* alg_hnsw = new hnswlib::HierarchicalNSW(&space, 100, &allocator);
+        auto* alg_hnsw = new hnswlib::HierarchicalNSW(space.get(), 100, &allocator);
         alg_hnsw->init_memory_space();
         alg_hnsw->addPoint(base_vectors.data(), 0);
         fixtures::dist_t distance = alg_hnsw->getDistanceByLabel(0, base_vectors.data());
@@ -968,7 +994,8 @@ TEST_CASE("get distance by label", "[ut][hnsw]") {
 
     SECTION("static hnsw test") {
         DefaultAllocator allocator;
-        auto* alg_hnsw_static = new hnswlib::StaticHierarchicalNSW(&space, 100, &allocator);
+        auto* alg_hnsw_static =
+            new hnswlib::StaticHierarchicalNSW(space.get(), 100, &allocator);
         alg_hnsw_static->init_memory_space();
         alg_hnsw_static->addPoint(base_vectors.data(), 0);
         fixtures::dist_t distance = alg_hnsw_static->getDistanceByLabel(0, base_vectors.data());
@@ -989,11 +1016,13 @@ TEST_CASE("get min and max id", "[ut][hnsw]") {
     auto [base_ids, base_vectors] = fixtures::generate_ids_and_vectors(num_base, dim);
 
     // hnsw index
-    hnswlib::L2Space space(dim);
+    const auto metric_type =
+        GENERATE(MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_L1);
+    auto space = make_hnsw_test_space(dim, metric_type);
 
     SECTION("hnsw test") {
         DefaultAllocator allocator;
-        auto* alg_hnsw = new hnswlib::HierarchicalNSW(&space, 100, &allocator);
+        auto* alg_hnsw = new hnswlib::HierarchicalNSW(space.get(), 100, &allocator);
         alg_hnsw->init_memory_space();
         alg_hnsw->addPoint(base_vectors.data(), 0);
         alg_hnsw->addPoint(base_vectors.data(), 5);
@@ -1008,7 +1037,8 @@ TEST_CASE("get min and max id", "[ut][hnsw]") {
 
     SECTION("static hnsw test") {
         DefaultAllocator allocator;
-        auto* alg_hnsw_static = new hnswlib::StaticHierarchicalNSW(&space, 100, &allocator);
+        auto* alg_hnsw_static =
+            new hnswlib::StaticHierarchicalNSW(space.get(), 100, &allocator);
         alg_hnsw_static->init_memory_space();
         alg_hnsw_static->addPoint(base_vectors.data(), 0);
         alg_hnsw_static->addPoint(base_vectors.data(), 5);
@@ -1033,11 +1063,13 @@ TEST_CASE("get data by label", "[ut][hnsw]") {
     auto [base_ids, base_vectors] = fixtures::generate_ids_and_vectors(num_base, dim);
 
     // hnsw index
-    hnswlib::L2Space space(dim);
+    const auto metric_type =
+        GENERATE(MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_L1);
+    auto space = make_hnsw_test_space(dim, metric_type);
 
     SECTION("hnsw test") {
         DefaultAllocator allocator;
-        auto* alg_hnsw = new hnswlib::HierarchicalNSW(&space, 100, &allocator);
+        auto* alg_hnsw = new hnswlib::HierarchicalNSW(space.get(), 100, &allocator);
         std::shared_ptr<int8_t[]> base_data(new int8_t[dim * sizeof(float)]);
         alg_hnsw->init_memory_space();
         alg_hnsw->addPoint(base_vectors.data(), 0);
@@ -1054,7 +1086,8 @@ TEST_CASE("get data by label", "[ut][hnsw]") {
 
     SECTION("static hnsw test") {
         DefaultAllocator allocator;
-        auto* alg_hnsw_static = new hnswlib::StaticHierarchicalNSW(&space, 100, &allocator);
+        auto* alg_hnsw_static =
+            new hnswlib::StaticHierarchicalNSW(space.get(), 100, &allocator);
         std::shared_ptr<int8_t[]> base_data(new int8_t[dim * sizeof(float)]);
         alg_hnsw_static->init_memory_space();
         alg_hnsw_static->addPoint(base_vectors.data(), 0);
@@ -1081,7 +1114,8 @@ TEST_CASE("extract/set data and graph", "[ut][hnsw]") {
 
     common_param.dim_ = dim;
     common_param.data_type_ = DataTypes::DATA_TYPE_FLOAT;
-    common_param.metric_ = MetricType::METRIC_TYPE_L2SQR;
+    common_param.metric_ =
+        GENERATE(MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_L1);
     common_param.allocator_ = allocator;
 
     HnswParameters hnsw_obj = parse_hnsw_params(common_param);
@@ -1154,9 +1188,11 @@ TEST_CASE("update mark-deleted vector", "[ut][hnsw]") {
     int update_size = 50;
 
     // create hnsw
-    hnswlib::L2Space space(dim);
+    const auto metric_type =
+        GENERATE(MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_L1);
+    auto space = make_hnsw_test_space(dim, metric_type);
     auto allocator = SafeAllocator::FactoryDefaultAllocator();
-    auto* alg_hnsw = new hnswlib::HierarchicalNSW(&space, 100, allocator.get());
+    auto* alg_hnsw = new hnswlib::HierarchicalNSW(space.get(), 100, allocator.get());
     alg_hnsw->init_memory_space();
 
     // data and build index

--- a/src/index/hnsw_test.cpp
+++ b/src/index/hnsw_test.cpp
@@ -64,8 +64,7 @@ TEST_CASE("build & add", "[ut][hnsw]") {
     IndexCommonParam common_param;
     common_param.dim_ = dim;
     common_param.data_type_ = DataTypes::DATA_TYPE_FLOAT;
-    common_param.metric_ =
-        GENERATE(MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_L1);
+    common_param.metric_ = GENERATE(MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_L1);
     common_param.allocator_ = allocator;
 
     HnswParameters hnsw_obj = parse_hnsw_params(common_param);
@@ -106,8 +105,7 @@ TEST_CASE("build with allocator", "[ut][hnsw]") {
 
     common_param.dim_ = dim;
     common_param.data_type_ = DataTypes::DATA_TYPE_FLOAT;
-    common_param.metric_ =
-        GENERATE(MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_L1);
+    common_param.metric_ = GENERATE(MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_L1);
     common_param.allocator_ = allocator;
 
     HnswParameters hnsw_obj = parse_hnsw_params(common_param);
@@ -136,8 +134,7 @@ TEST_CASE("knn_search", "[ut][hnsw]") {
     IndexCommonParam common_param;
     common_param.dim_ = dim;
     common_param.data_type_ = DataTypes::DATA_TYPE_FLOAT;
-    common_param.metric_ =
-        GENERATE(MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_L1);
+    common_param.metric_ = GENERATE(MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_L1);
     common_param.allocator_ = SafeAllocator::FactoryDefaultAllocator();
 
     HnswParameters hnsw_obj = parse_hnsw_params(common_param);
@@ -259,8 +256,7 @@ TEST_CASE("iterator filter init allocation failure", "[ut][hnsw]") {
     IndexCommonParam common_param;
     common_param.dim_ = dim;
     common_param.data_type_ = DataTypes::DATA_TYPE_FLOAT;
-    common_param.metric_ =
-        GENERATE(MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_L1);
+    common_param.metric_ = GENERATE(MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_L1);
     common_param.allocator_ = SafeAllocator::FactoryDefaultAllocator();
 
     HnswParameters hnsw_obj = parse_hnsw_params(common_param);
@@ -304,8 +300,7 @@ TEST_CASE("range_search", "[ut][hnsw]") {
     IndexCommonParam common_param;
     common_param.dim_ = dim;
     common_param.data_type_ = DataTypes::DATA_TYPE_FLOAT;
-    common_param.metric_ =
-        GENERATE(MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_L1);
+    common_param.metric_ = GENERATE(MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_L1);
     common_param.allocator_ = SafeAllocator::FactoryDefaultAllocator();
 
     HnswParameters hnsw_obj = parse_hnsw_params(common_param);
@@ -402,8 +397,7 @@ TEST_CASE("serialize empty index", "[ut][hnsw]") {
     IndexCommonParam common_param;
     common_param.dim_ = dim;
     common_param.data_type_ = DataTypes::DATA_TYPE_FLOAT;
-    common_param.metric_ =
-        GENERATE(MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_L1);
+    common_param.metric_ = GENERATE(MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_L1);
     common_param.allocator_ = SafeAllocator::FactoryDefaultAllocator();
 
     HnswParameters hnsw_obj = parse_hnsw_params(common_param);
@@ -440,8 +434,7 @@ TEST_CASE("deserialize on not empty index", "[ut][hnsw]") {
     IndexCommonParam common_param;
     common_param.dim_ = dim;
     common_param.data_type_ = DataTypes::DATA_TYPE_FLOAT;
-    common_param.metric_ =
-        GENERATE(MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_L1);
+    common_param.metric_ = GENERATE(MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_L1);
     common_param.allocator_ = SafeAllocator::FactoryDefaultAllocator();
 
     HnswParameters hnsw_obj = parse_hnsw_params(common_param);
@@ -498,8 +491,7 @@ TEST_CASE("static hnsw", "[ut][hnsw]") {
     IndexCommonParam common_param;
     common_param.dim_ = dim;
     common_param.data_type_ = DataTypes::DATA_TYPE_FLOAT;
-    common_param.metric_ =
-        GENERATE(MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_L1);
+    common_param.metric_ = GENERATE(MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_L1);
     common_param.allocator_ = SafeAllocator::FactoryDefaultAllocator();
 
     HnswParameters hnsw_obj = parse_hnsw_params(common_param);
@@ -565,8 +557,7 @@ TEST_CASE("hnsw add vector with duplicated id", "[ut][hnsw]") {
     IndexCommonParam common_param;
     common_param.dim_ = dim;
     common_param.data_type_ = DataTypes::DATA_TYPE_FLOAT;
-    common_param.metric_ =
-        GENERATE(MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_L1);
+    common_param.metric_ = GENERATE(MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_L1);
     common_param.allocator_ = SafeAllocator::FactoryDefaultAllocator();
 
     HnswParameters hnsw_obj = parse_hnsw_params(common_param);
@@ -608,8 +599,7 @@ TEST_CASE("build with reversed edges", "[ut][hnsw]") {
     IndexCommonParam common_param;
     common_param.dim_ = dim;
     common_param.data_type_ = DataTypes::DATA_TYPE_FLOAT;
-    common_param.metric_ =
-        GENERATE(MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_L1);
+    common_param.metric_ = GENERATE(MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_L1);
     common_param.allocator_ = SafeAllocator::FactoryDefaultAllocator();
 
     HnswParameters hnsw_obj = parse_hnsw_params(common_param);
@@ -710,8 +700,7 @@ TEST_CASE("feedback with invalid argument", "[ut][hnsw]") {
     IndexCommonParam common_param;
     common_param.dim_ = dim;
     common_param.data_type_ = DataTypes::DATA_TYPE_FLOAT;
-    common_param.metric_ =
-        GENERATE(MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_L1);
+    common_param.metric_ = GENERATE(MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_L1);
     common_param.allocator_ = SafeAllocator::FactoryDefaultAllocator();
 
     HnswParameters hnsw_obj = parse_hnsw_params(common_param);
@@ -753,8 +742,7 @@ TEST_CASE("redundant feedback and empty enhancement", "[ut][hnsw]") {
     IndexCommonParam common_param;
     common_param.dim_ = 128;
     common_param.data_type_ = DataTypes::DATA_TYPE_FLOAT;
-    common_param.metric_ =
-        GENERATE(MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_L1);
+    common_param.metric_ = GENERATE(MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_L1);
     common_param.allocator_ = SafeAllocator::FactoryDefaultAllocator();
 
     HnswParameters hnsw_obj = parse_hnsw_params(common_param);
@@ -818,8 +806,7 @@ TEST_CASE("feedback and pretrain without use conjugate graph", "[ut][hnsw]") {
     IndexCommonParam common_param;
     common_param.dim_ = dim;
     common_param.data_type_ = DataTypes::DATA_TYPE_FLOAT;
-    common_param.metric_ =
-        GENERATE(MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_L1);
+    common_param.metric_ = GENERATE(MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_L1);
     common_param.allocator_ = SafeAllocator::FactoryDefaultAllocator();
 
     HnswParameters hnsw_obj = parse_hnsw_params(common_param);
@@ -866,8 +853,7 @@ TEST_CASE("feedback and pretrain on empty index", "[ut][hnsw]") {
     IndexCommonParam common_param;
     common_param.dim_ = dim;
     common_param.data_type_ = DataTypes::DATA_TYPE_FLOAT;
-    common_param.metric_ =
-        GENERATE(MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_L1);
+    common_param.metric_ = GENERATE(MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_L1);
     common_param.allocator_ = SafeAllocator::FactoryDefaultAllocator();
 
     HnswParameters hnsw_obj = parse_hnsw_params(common_param);
@@ -916,8 +902,7 @@ TEST_CASE("invalid pretrain", "[ut][hnsw]") {
     IndexCommonParam common_param;
     common_param.dim_ = dim;
     common_param.data_type_ = DataTypes::DATA_TYPE_FLOAT;
-    common_param.metric_ =
-        GENERATE(MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_L1);
+    common_param.metric_ = GENERATE(MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_L1);
     common_param.allocator_ = SafeAllocator::FactoryDefaultAllocator();
 
     HnswParameters hnsw_obj = parse_hnsw_params(common_param);
@@ -977,8 +962,7 @@ TEST_CASE("get distance by label", "[ut][hnsw]") {
     auto [base_ids, base_vectors] = fixtures::generate_ids_and_vectors(num_base, dim);
 
     // hnsw index
-    const auto metric_type =
-        GENERATE(MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_L1);
+    const auto metric_type = GENERATE(MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_L1);
     auto space = make_hnsw_test_space(dim, metric_type);
 
     SECTION("hnsw test") {
@@ -994,8 +978,7 @@ TEST_CASE("get distance by label", "[ut][hnsw]") {
 
     SECTION("static hnsw test") {
         DefaultAllocator allocator;
-        auto* alg_hnsw_static =
-            new hnswlib::StaticHierarchicalNSW(space.get(), 100, &allocator);
+        auto* alg_hnsw_static = new hnswlib::StaticHierarchicalNSW(space.get(), 100, &allocator);
         alg_hnsw_static->init_memory_space();
         alg_hnsw_static->addPoint(base_vectors.data(), 0);
         fixtures::dist_t distance = alg_hnsw_static->getDistanceByLabel(0, base_vectors.data());
@@ -1016,8 +999,7 @@ TEST_CASE("get min and max id", "[ut][hnsw]") {
     auto [base_ids, base_vectors] = fixtures::generate_ids_and_vectors(num_base, dim);
 
     // hnsw index
-    const auto metric_type =
-        GENERATE(MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_L1);
+    const auto metric_type = GENERATE(MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_L1);
     auto space = make_hnsw_test_space(dim, metric_type);
 
     SECTION("hnsw test") {
@@ -1037,8 +1019,7 @@ TEST_CASE("get min and max id", "[ut][hnsw]") {
 
     SECTION("static hnsw test") {
         DefaultAllocator allocator;
-        auto* alg_hnsw_static =
-            new hnswlib::StaticHierarchicalNSW(space.get(), 100, &allocator);
+        auto* alg_hnsw_static = new hnswlib::StaticHierarchicalNSW(space.get(), 100, &allocator);
         alg_hnsw_static->init_memory_space();
         alg_hnsw_static->addPoint(base_vectors.data(), 0);
         alg_hnsw_static->addPoint(base_vectors.data(), 5);
@@ -1063,8 +1044,7 @@ TEST_CASE("get data by label", "[ut][hnsw]") {
     auto [base_ids, base_vectors] = fixtures::generate_ids_and_vectors(num_base, dim);
 
     // hnsw index
-    const auto metric_type =
-        GENERATE(MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_L1);
+    const auto metric_type = GENERATE(MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_L1);
     auto space = make_hnsw_test_space(dim, metric_type);
 
     SECTION("hnsw test") {
@@ -1086,8 +1066,7 @@ TEST_CASE("get data by label", "[ut][hnsw]") {
 
     SECTION("static hnsw test") {
         DefaultAllocator allocator;
-        auto* alg_hnsw_static =
-            new hnswlib::StaticHierarchicalNSW(space.get(), 100, &allocator);
+        auto* alg_hnsw_static = new hnswlib::StaticHierarchicalNSW(space.get(), 100, &allocator);
         std::shared_ptr<int8_t[]> base_data(new int8_t[dim * sizeof(float)]);
         alg_hnsw_static->init_memory_space();
         alg_hnsw_static->addPoint(base_vectors.data(), 0);
@@ -1114,8 +1093,7 @@ TEST_CASE("extract/set data and graph", "[ut][hnsw]") {
 
     common_param.dim_ = dim;
     common_param.data_type_ = DataTypes::DATA_TYPE_FLOAT;
-    common_param.metric_ =
-        GENERATE(MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_L1);
+    common_param.metric_ = GENERATE(MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_L1);
     common_param.allocator_ = allocator;
 
     HnswParameters hnsw_obj = parse_hnsw_params(common_param);
@@ -1188,8 +1166,7 @@ TEST_CASE("update mark-deleted vector", "[ut][hnsw]") {
     int update_size = 50;
 
     // create hnsw
-    const auto metric_type =
-        GENERATE(MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_L1);
+    const auto metric_type = GENERATE(MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_L1);
     auto space = make_hnsw_test_space(dim, metric_type);
     auto allocator = SafeAllocator::FactoryDefaultAllocator();
     auto* alg_hnsw = new hnswlib::HierarchicalNSW(space.get(), 100, allocator.get());

--- a/src/index/hnsw_zparameters.cpp
+++ b/src/index/hnsw_zparameters.cpp
@@ -26,6 +26,10 @@ HnswParameters::FromJson(const JsonType& hnsw_param_obj,
                          const IndexCommonParam& index_common_param) {
     HnswParameters obj;
 
+    CHECK_ARGUMENT(index_common_param.metric_ != MetricType::METRIC_TYPE_L1 ||
+                       index_common_param.data_type_ == DataTypes::DATA_TYPE_FLOAT,
+                   "l1 metric must use float32 dtype");
+
     if (index_common_param.data_type_ == DataTypes::DATA_TYPE_FLOAT) {
         obj.type = DataTypes::DATA_TYPE_FLOAT;
     } else if (index_common_param.data_type_ == DataTypes::DATA_TYPE_INT8) {
@@ -43,6 +47,8 @@ HnswParameters::FromJson(const JsonType& hnsw_param_obj,
     } else if (index_common_param.metric_ == MetricType::METRIC_TYPE_COSINE) {
         obj.normalize = true;
         obj.space = std::make_shared<hnswlib::InnerProductSpace>(index_common_param.dim_, obj.type);
+    } else if (index_common_param.metric_ == MetricType::METRIC_TYPE_L1) {
+        obj.space = std::make_shared<hnswlib::L1Space>(index_common_param.dim_);
     }
 
     // set obj.max_degree

--- a/src/index/hnsw_zparameters_test.cpp
+++ b/src/index/hnsw_zparameters_test.cpp
@@ -33,6 +33,31 @@ TEST_CASE("create hnsw with correct parameter", "[ut][hnsw]") {
     vsag::HnswParameters::FromJson(parsed_params, common_param);
 }
 
+TEST_CASE("create float32 hnsw with l1 parameter", "[ut][hnsw][l1]") {
+    auto parsed_params = vsag::JsonType::Parse(R"(
+        {
+            "max_degree": 8,
+            "ef_construction": 100
+        }
+    )");
+    vsag::IndexCommonParam common_param;
+    common_param.dim_ = 5;
+    common_param.data_type_ = vsag::DataTypes::DATA_TYPE_FLOAT;
+    common_param.metric_ = vsag::MetricType::METRIC_TYPE_L1;
+
+    auto params = vsag::HnswParameters::FromJson(parsed_params, common_param);
+    REQUIRE(params.type == vsag::DataTypes::DATA_TYPE_FLOAT);
+    REQUIRE_FALSE(params.normalize);
+    REQUIRE(params.space->get_data_size() == 5 * sizeof(float));
+
+    const float lhs[5]{-1.0F, 2.5F, 4.0F, 0.0F, -2.0F};
+    const float rhs[5]{2.0F, -0.5F, 1.0F, 0.25F, 3.0F};
+    REQUIRE(params.space->get_dist_func()(lhs, rhs, params.space->get_dist_func_param()) == 14.25F);
+
+    common_param.data_type_ = vsag::DataTypes::DATA_TYPE_INT8;
+    REQUIRE_THROWS(vsag::HnswParameters::FromJson(parsed_params, common_param));
+}
+
 TEST_CASE("create hnsw with wrong parameter", "[ut][hnsw]") {
     vsag::IndexCommonParam common_param;
     common_param.dim_ = 128;

--- a/src/index_commom_param_test.cpp
+++ b/src/index_commom_param_test.cpp
@@ -76,8 +76,7 @@ TEST_CASE("IndexCommonParam Basic Test", "[ut][IndexCommonParam]") {
 }
 
 TEST_CASE("IndexCommonParam L1 Test", "[ut][IndexCommonParam][l1]") {
-    auto resource =
-        std::make_shared<vsag::ResourceOwnerWrapper>(new vsag::Resource(), true);
+    auto resource = std::make_shared<vsag::ResourceOwnerWrapper>(new vsag::Resource(), true);
 
     SECTION("float32 l1 succeeds") {
         auto params = vsag::JsonType::Parse(R"({

--- a/src/index_commom_param_test.cpp
+++ b/src/index_commom_param_test.cpp
@@ -74,3 +74,42 @@ TEST_CASE("IndexCommonParam Basic Test", "[ut][IndexCommonParam]") {
         REQUIRE(param.data_type_ == vsag::DataTypes::DATA_TYPE_FLOAT);
     }
 }
+
+TEST_CASE("IndexCommonParam L1 Test", "[ut][IndexCommonParam][l1]") {
+    auto resource =
+        std::make_shared<vsag::ResourceOwnerWrapper>(new vsag::Resource(), true);
+
+    SECTION("float32 l1 succeeds") {
+        auto params = vsag::JsonType::Parse(R"({
+            "metric_type": "l1",
+            "dtype": "float32",
+            "dim": 5
+        })");
+        auto common = vsag::IndexCommonParam::CheckAndCreate(params, resource);
+        REQUIRE(common.metric_ == vsag::MetricType::METRIC_TYPE_L1);
+        REQUIRE(common.data_type_ == vsag::DataTypes::DATA_TYPE_FLOAT);
+        REQUIRE(common.dim_ == 5);
+    }
+
+    SECTION("l1 rejects non-float32 dtype") {
+        const char* invalid_params[] = {
+            R"({"metric_type":"l1","dtype":"int8","dim":8})",
+            R"({"metric_type":"l1","dtype":"sparse","dim":8})",
+        };
+        for (const auto* param_str : invalid_params) {
+            auto params = vsag::JsonType::Parse(param_str);
+            REQUIRE_THROWS(vsag::IndexCommonParam::CheckAndCreate(params, resource));
+        }
+    }
+
+    SECTION("aliases are rejected") {
+        const char* invalid_params[] = {
+            R"({"metric_type":"manhattan","dtype":"float32","dim":5})",
+            R"({"metric_type":"L1","dtype":"float32","dim":5})",
+        };
+        for (const auto* param_str : invalid_params) {
+            auto params = vsag::JsonType::Parse(param_str);
+            REQUIRE_THROWS(vsag::IndexCommonParam::CheckAndCreate(params, resource));
+        }
+    }
+}

--- a/src/index_common_param.cpp
+++ b/src/index_common_param.cpp
@@ -57,13 +57,16 @@ fill_metrictype(IndexCommonParam& result, const JsonType& metric_obj) {
         result.metric_ = MetricType::METRIC_TYPE_IP;
     } else if (metric == METRIC_COSINE) {
         result.metric_ = MetricType::METRIC_TYPE_COSINE;
+    } else if (metric == METRIC_L1) {
+        result.metric_ = MetricType::METRIC_TYPE_L1;
     } else {
         throw VsagException(ErrorType::INVALID_ARGUMENT,
-                            fmt::format("parameters[{}] must in [{}, {}, {}], now is {}",
+                            fmt::format("parameters[{}] must in [{}, {}, {}, {}], now is {}",
                                         PARAMETER_METRIC_TYPE,
                                         METRIC_L2,
                                         METRIC_IP,
                                         METRIC_COSINE,
+                                        METRIC_L1,
                                         metric));
     }
 }
@@ -111,6 +114,10 @@ IndexCommonParam::CheckAndCreate(JsonType& params, const std::shared_ptr<Resourc
         }
         result.dim_ = MAX_DIM_SPARSE;
     }
+
+    CHECK_ARGUMENT(result.metric_ != MetricType::METRIC_TYPE_L1 ||
+                       result.data_type_ == DataTypes::DATA_TYPE_FLOAT,
+                   "l1 metric must use float32 dtype");
 
     if (params.Contains(EXTRA_INFO_SIZE)) {
         fill_extra_info_size(result, params[EXTRA_INFO_SIZE]);

--- a/src/quantization/fp32_quantizer.cpp
+++ b/src/quantization/fp32_quantizer.cpp
@@ -15,6 +15,7 @@
 
 #include "fp32_quantizer.h"
 
+#include "simd/basic_func.h"
 #include "simd/fp32_simd.h"
 #include "simd/normalize.h"
 #include "simd/simd.h"
@@ -121,6 +122,10 @@ FP32Quantizer<metric>::ComputeImpl(const uint8_t* codes1, const uint8_t* codes2)
                                 reinterpret_cast<const float*>(codes2),
                                 this->dim_);
     }
+    if (metric == MetricType::METRIC_TYPE_L1) {
+        const uint64_t dim = this->dim_;
+        return L1Distance(codes1, codes2, &dim);
+    }
     return 0.0F;
 }
 
@@ -178,6 +183,9 @@ FP32Quantizer<metric>::ComputeDistImpl(Computer<FP32Quantizer<metric>>& computer
         *dists = FP32ComputeL2Sqr(reinterpret_cast<const float*>(codes),
                                   reinterpret_cast<const float*>(computer.buf_),
                                   this->dim_);
+    } else if (metric == MetricType::METRIC_TYPE_L1) {
+        const uint64_t dim = this->dim_;
+        *dists = L1Distance(codes, computer.buf_, &dim);
     } else {
         *dists = 0.0F;
     }
@@ -245,6 +253,12 @@ FP32Quantizer<metric>::ComputeDistsBatch4Impl(Computer<FP32Quantizer<metric>>& c
                                dists2,
                                dists3,
                                dists4);
+    } else if constexpr (metric == MetricType::METRIC_TYPE_L1) {
+        const uint64_t dim = this->dim_;
+        dists1 = L1Distance(computer.buf_, codes1, &dim);
+        dists2 = L1Distance(computer.buf_, codes2, &dim);
+        dists3 = L1Distance(computer.buf_, codes3, &dim);
+        dists4 = L1Distance(computer.buf_, codes4, &dim);
     } else {
         dists1 = 0.0F;
         dists2 = 0.0F;
@@ -260,4 +274,5 @@ FP32Quantizer<metric>::ReleaseComputerImpl(Computer<FP32Quantizer<metric>>& comp
 }
 
 TEMPLATE_QUANTIZER(FP32Quantizer);
+template class FP32Quantizer<MetricType::METRIC_TYPE_L1>;
 }  // namespace vsag

--- a/src/quantization/fp32_quantizer_test.cpp
+++ b/src/quantization/fp32_quantizer_test.cpp
@@ -91,15 +91,8 @@ TEST_CASE("FP32 L1 Compute", "[ut][FP32Quantizer][l1]") {
     float dist2 = 0.0F;
     float dist3 = 0.0F;
     float dist4 = 0.0F;
-    quantizer.ComputeDistsBatch4(*computer,
-                                 lhs_codes,
-                                 rhs_codes,
-                                 lhs_codes,
-                                 rhs_codes,
-                                 dist1,
-                                 dist2,
-                                 dist3,
-                                 dist4);
+    quantizer.ComputeDistsBatch4(
+        *computer, lhs_codes, rhs_codes, lhs_codes, rhs_codes, dist1, dist2, dist3, dist4);
     REQUIRE(dist1 == 0.0F);
     REQUIRE(dist2 == 14.25F);
     REQUIRE(dist3 == 0.0F);

--- a/src/quantization/fp32_quantizer_test.cpp
+++ b/src/quantization/fp32_quantizer_test.cpp
@@ -71,6 +71,41 @@ TEST_CASE("FP32 Compute", "[ut][FP32Quantizer]") {
     }
 }
 
+TEST_CASE("FP32 L1 Compute", "[ut][FP32Quantizer][l1]") {
+    constexpr uint64_t dim = 5;
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    FP32Quantizer<MetricType::METRIC_TYPE_L1> quantizer(dim, allocator.get());
+    const float lhs[dim]{-1.0F, 2.5F, 4.0F, 0.0F, -2.0F};
+    const float rhs[dim]{2.0F, -0.5F, 1.0F, 0.25F, 3.0F};
+    uint8_t lhs_codes[dim * sizeof(float)]{};
+    uint8_t rhs_codes[dim * sizeof(float)]{};
+    REQUIRE(quantizer.EncodeOne(lhs, lhs_codes));
+    REQUIRE(quantizer.EncodeOne(rhs, rhs_codes));
+    REQUIRE(quantizer.Compute(lhs_codes, rhs_codes) == 14.25F);
+
+    auto computer = quantizer.FactoryComputer();
+    computer->SetQuery(lhs);
+    REQUIRE(quantizer.ComputeDist(*computer, rhs_codes) == 14.25F);
+
+    float dist1 = 0.0F;
+    float dist2 = 0.0F;
+    float dist3 = 0.0F;
+    float dist4 = 0.0F;
+    quantizer.ComputeDistsBatch4(*computer,
+                                 lhs_codes,
+                                 rhs_codes,
+                                 lhs_codes,
+                                 rhs_codes,
+                                 dist1,
+                                 dist2,
+                                 dist3,
+                                 dist4);
+    REQUIRE(dist1 == 0.0F);
+    REQUIRE(dist2 == 14.25F);
+    REQUIRE(dist3 == 0.0F);
+    REQUIRE(dist4 == 14.25F);
+}
+
 template <MetricType metric>
 void
 TestSerializeAndDeserializeMetricFP32(uint64_t dim, int count, float error = 1e-5) {

--- a/src/simd/basic_func.cpp
+++ b/src/simd/basic_func.cpp
@@ -20,6 +20,12 @@
 namespace vsag {
 
 static DistanceFuncType
+GetL1Distance() {
+    return generic::L1Distance;
+}
+DistanceFuncType L1Distance = GetL1Distance();
+
+static DistanceFuncType
 GetL2Sqr() {
     if (SimdStatus::SupportAVX512()) {
 #if defined(ENABLE_AVX512)

--- a/src/simd/basic_func.h
+++ b/src/simd/basic_func.h
@@ -22,6 +22,8 @@ namespace vsag {
 #define DECLARE_BASIC_FUNCTIONS(ns)                                                         \
     namespace ns {                                                                          \
     float                                                                                   \
+    L1Distance(const void* pVect1v, const void* pVect2v, const void* qty_ptr);              \
+    float                                                                                   \
     L2Sqr(const void* pVect1v, const void* pVect2v, const void* qty_ptr);                   \
     float                                                                                   \
     InnerProduct(const void* pVect1, const void* pVect2, const void* qty_ptr);              \
@@ -56,6 +58,7 @@ extern DistanceFuncType InnerProductDistance;
 extern DistanceFuncType INT8L2Sqr;
 extern DistanceFuncType INT8InnerProduct;
 extern DistanceFuncType INT8InnerProductDistance;
+extern DistanceFuncType L1Distance;
 
 using PQDistanceFuncType = void (*)(const void* single_dim_centers,
                                     float single_dim_val,

--- a/src/simd/basic_func_test.cpp
+++ b/src/simd/basic_func_test.cpp
@@ -68,6 +68,16 @@ TEST_CASE("L2Sqr & InnerProduct SIMD Compute", "[ut][simd]") {
     }
 }
 
+TEST_CASE("L1 distance computes absolute differences", "[ut][simd][l1]") {
+    const std::vector<float> lhs = {1.0F, -2.0F, 3.0F, -4.0F};
+    const std::vector<float> rhs = {-1.0F, -1.0F, 5.0F, 0.0F};
+    const uint64_t dim = lhs.size();
+
+    REQUIRE(generic::L1Distance(lhs.data(), rhs.data(), &dim) == 9.0F);
+    REQUIRE(L1Distance(lhs.data(), rhs.data(), &dim) == 9.0F);
+    REQUIRE(generic::L1Distance(lhs.data(), lhs.data(), &dim) == 0.0F);
+}
+
 TEST_CASE("Int8 SIMD Compute", "[ut][simd][int8]") {
     auto dims = fixtures::get_common_used_dims(8, 217);
     int64_t count = 100;

--- a/src/simd/generic.cpp
+++ b/src/simd/generic.cpp
@@ -14,9 +14,25 @@
 // limitations under the License.
 
 #include "simd.h"
+
+#include <cmath>
+
 #include "simd/int8_simd.h"
 
 namespace vsag::generic {
+
+float
+L1Distance(const void* query1, const void* query2, const void* dim_ptr) {
+    const auto* lhs = static_cast<const float*>(query1);
+    const auto* rhs = static_cast<const float*>(query2);
+    const uint64_t dim = *static_cast<const uint64_t*>(dim_ptr);
+    float distance = 0.0F;
+
+    for (uint64_t i = 0; i < dim; ++i) {
+        distance += std::fabs(lhs[i] - rhs[i]);
+    }
+    return distance;
+}
 
 float
 L2Sqr(const void* pVect1v, const void* pVect2v, const void* qty_ptr) {

--- a/src/simd/generic.cpp
+++ b/src/simd/generic.cpp
@@ -13,10 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "simd.h"
-
 #include <cmath>
 
+#include "simd.h"
 #include "simd/int8_simd.h"
 
 namespace vsag::generic {

--- a/tests/fixtures/test_dataset.cpp
+++ b/tests/fixtures/test_dataset.cpp
@@ -16,6 +16,7 @@
 #include "test_dataset.h"
 
 #include <algorithm>
+#include <cmath>
 #include <cstring>
 #include <functional>
 
@@ -140,6 +141,14 @@ CalDistanceFloatMetrix(const vsag::DatasetPtr query,
             vsag::Normalize(codes, norm_codes.get(), dim);
             return 1 - vsag::FP32ComputeIP(norm_query.get(), norm_codes.get(), dim);
         };
+    } else if (metric_str == "l1") {
+        dist_func = [](const float* query, const float* codes, uint64_t dim) -> float {
+            float distance = 0.0F;
+            for (uint64_t i = 0; i < dim; ++i) {
+                distance += std::fabs(query[i] - codes[i]);
+            }
+            return distance;
+        };
     }
     auto dim = base->GetDim();
 #pragma omp parallel for schedule(dynamic)
@@ -193,6 +202,14 @@ CalDistanceFloatMetrixWithExFilter(const vsag::DatasetPtr query,
             vsag::Normalize(query, norm_query.get(), dim);
             vsag::Normalize(codes, norm_codes.get(), dim);
             return 1 - vsag::FP32ComputeIP(norm_query.get(), norm_codes.get(), dim);
+        };
+    } else if (metric_str == "l1") {
+        dist_func = [](const float* query, const float* codes, uint64_t dim) -> float {
+            float distance = 0.0F;
+            for (uint64_t i = 0; i < dim; ++i) {
+                distance += std::fabs(query[i] - codes[i]);
+            }
+            return distance;
         };
     }
     auto dim = base->GetDim();

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -2989,8 +2989,22 @@ TEST_CASE("HGraph float32 L1", "[ft][hgraph][l1]") {
     constexpr int64_t base_count = 8;
     const std::vector<int64_t> ids = {1, 2, 3, 4, 5, 6, 7, 8};
     const std::vector<float> original_vectors = {
-        3.0F, 0.0F, 2.0F, 2.0F, 5.0F, 0.0F, 3.0F, 3.0F,
-        7.0F, 0.0F, 4.0F, 4.0F, 9.0F, 0.0F, 5.0F, 5.0F,
+        3.0F,
+        0.0F,
+        2.0F,
+        2.0F,
+        5.0F,
+        0.0F,
+        3.0F,
+        3.0F,
+        7.0F,
+        0.0F,
+        4.0F,
+        4.0F,
+        9.0F,
+        0.0F,
+        5.0F,
+        5.0F,
     };
     std::vector<float> base_vectors = original_vectors;
 
@@ -3020,10 +3034,7 @@ TEST_CASE("HGraph float32 L1", "[ft][hgraph][l1]") {
 
     const std::vector<float> query_vector = {0.0F, 0.0F};
     auto query = vsag::Dataset::Make();
-    query->NumElements(1)
-        ->Dim(dim)
-        ->Float32Vectors(query_vector.data())
-        ->Owner(false);
+    query->NumElements(1)->Dim(dim)->Float32Vectors(query_vector.data())->Owner(false);
     const std::string search_parameters = R"({"hgraph": {"ef_search": 100}})";
 
     auto result = index->KnnSearch(query, 2, search_parameters);

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -15,10 +15,12 @@
 
 #include <algorithm>
 #include <atomic>
+#include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
 #include <chrono>
 #include <limits>
+#include <set>
 #include <thread>
 
 #include "algorithm/hgraph.h"
@@ -2980,4 +2982,85 @@ TEST_CASE("HGraph Concurrent Tune and CalcDistanceById (single id)", "[ft][concu
     }
 
     REQUIRE(cal_count.load() > 0);
+}
+
+TEST_CASE("HGraph float32 L1", "[ft][hgraph][l1]") {
+    constexpr int64_t dim = 2;
+    constexpr int64_t base_count = 8;
+    const std::vector<int64_t> ids = {1, 2, 3, 4, 5, 6, 7, 8};
+    const std::vector<float> original_vectors = {
+        3.0F, 0.0F, 2.0F, 2.0F, 5.0F, 0.0F, 3.0F, 3.0F,
+        7.0F, 0.0F, 4.0F, 4.0F, 9.0F, 0.0F, 5.0F, 5.0F,
+    };
+    std::vector<float> base_vectors = original_vectors;
+
+    const std::string build_parameters = R"({
+        "dtype": "float32",
+        "metric_type": "l1",
+        "dim": 2,
+        "index_param": {
+            "base_quantization_type": "fp32",
+            "max_degree": 8,
+            "ef_construction": 100,
+            "build_thread_count": 0,
+            "store_raw_vector": true
+        }
+    })";
+    auto factory_result = vsag::Factory::CreateIndex("hgraph", build_parameters);
+    REQUIRE(factory_result.has_value());
+    auto index = std::move(factory_result.value());
+
+    auto base = vsag::Dataset::Make();
+    base->NumElements(base_count)
+        ->Dim(dim)
+        ->Ids(ids.data())
+        ->Float32Vectors(base_vectors.data())
+        ->Owner(false);
+    REQUIRE(index->Build(base).has_value());
+
+    const std::vector<float> query_vector = {0.0F, 0.0F};
+    auto query = vsag::Dataset::Make();
+    query->NumElements(1)
+        ->Dim(dim)
+        ->Float32Vectors(query_vector.data())
+        ->Owner(false);
+    const std::string search_parameters = R"({"hgraph": {"ef_search": 100}})";
+
+    auto result = index->KnnSearch(query, 2, search_parameters);
+    REQUIRE(result.has_value());
+    REQUIRE(result.value()->GetDim() == 2);
+    REQUIRE(result.value()->GetIds()[0] == 1);
+    REQUIRE(result.value()->GetIds()[1] == 2);
+    REQUIRE(result.value()->GetDistances()[0] == Catch::Approx(3.0F));
+    REQUIRE(result.value()->GetDistances()[1] == Catch::Approx(4.0F));
+
+    std::fill(base_vectors.begin(), base_vectors.end(), -999.0F);
+    auto raw = index->GetRawVectorByIds(ids.data(), base_count);
+    REQUIRE(raw.has_value());
+    REQUIRE(raw.value()->GetNumElements() == base_count);
+    REQUIRE(raw.value()->GetDim() == dim);
+    for (int64_t i = 0; i < base_count * dim; ++i) {
+        REQUIRE(raw.value()->GetFloat32Vectors()[i] ==
+                Catch::Approx(original_vectors[static_cast<uint64_t>(i)]));
+    }
+}
+
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::HGraphTestIndex,
+                             "HGraph float32 L1 recall",
+                             "[ft][hgraph][l1][recall]") {
+    constexpr int64_t dim = 128;
+    constexpr uint64_t dataset_base_count = 600;
+    constexpr float minimum_recall = 0.95F;
+
+    HGraphBuildParam build_param("l1", dim, "fp32");
+    build_param.store_raw_vector = true;
+    auto build_parameters = GenerateHGraphBuildParametersString(build_param);
+    auto index = TestFactory(name, build_parameters, true);
+    auto dataset = pool.GetDatasetAndCreate(dim, dataset_base_count, "l1");
+    TestBuildIndex(index, dataset, true);
+
+    const auto search_parameters = fmt::format(fixtures::search_param_tmp, 200, false);
+    TestKnnSearch(index, dataset, search_parameters, minimum_recall, true);
+    TestKnnSearchIter(index, dataset, search_parameters, minimum_recall, true);
+    TestGetRawVectorByIds(index, dataset, true);
 }

--- a/tests/test_hnsw.cpp
+++ b/tests/test_hnsw.cpp
@@ -579,10 +579,10 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Get Min Max ID", "[f
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Get Raw Vector", "[ft][hnsw]") {
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
-    const auto [dtype, metric_type] = GENERATE(
-        std::make_pair(std::string("float32"), std::string("l2")),
-        std::make_pair(std::string("float32"), std::string("l1")),
-        std::make_pair(std::string("int8"), std::string("ip")));
+    const auto [dtype, metric_type] =
+        GENERATE(std::make_pair(std::string("float32"), std::string("l2")),
+                 std::make_pair(std::string("float32"), std::string("l1")),
+                 std::make_pair(std::string("int8"), std::string("ip")));
     const std::string name = "hnsw";
     for (auto& dim : dims) {
         vsag::Options::Instance().set_block_size_limit(size);

--- a/tests/test_hnsw.cpp
+++ b/tests/test_hnsw.cpp
@@ -232,7 +232,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex,
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Estimate Memory", "[ft][hnsw]") {
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
-    auto metric_type = GENERATE("l2", "cosine");
+    auto metric_type = GENERATE("l2", "cosine", "l1");
 
     const std::string name = "hnsw";
     auto search_param = fmt::format(search_param_tmp, 200, false);
@@ -256,7 +256,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex,
                              "[ft][hnsw]") {
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
-    auto metric_type = GENERATE("l2", "ip", "cosine");
+    auto metric_type = GENERATE("l2", "ip", "cosine", "l1");
     const std::string name = "hnsw";
     auto search_param = fmt::format(search_param_tmp, 100);
     for (auto& dim : dims) {
@@ -280,7 +280,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex,
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Test non-standard IDs", "[ft][hnsw]") {
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
-    auto metric_type = GENERATE("l2");
+    auto metric_type = GENERATE("l2", "l1");
 
     const std::string name = "hnsw";
     auto search_param = fmt::format(search_param_tmp, 200);
@@ -320,7 +320,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex,
                              "[ft][hnsw]") {
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
-    auto metric_type = GENERATE("l2");
+    auto metric_type = GENERATE("l2", "l1");
     const std::string name = "hnsw";
     auto search_param = fmt::format(search_param_tmp, 100);
 
@@ -342,7 +342,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex,
                              "[ft][hnsw]") {
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
-    auto metric_type = GENERATE("l2", "ip", "cosine");
+    auto metric_type = GENERATE("l2", "ip", "cosine", "l1");
     auto dataset = pool.GetNanDataset(metric_type);
     auto dim = dataset->dim_;
     const std::string name = "hnsw";
@@ -359,7 +359,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex,
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Build", "[ft][hnsw]") {
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
-    auto metric_type = GENERATE("l2", "ip", "cosine");
+    auto metric_type = GENERATE("l2", "ip", "cosine", "l1");
     const std::string name = "hnsw";
     auto search_param = fmt::format(search_param_tmp, 100);
     for (auto& dim : dims) {
@@ -384,7 +384,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Build", "[ft][hnsw]"
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Merge", "[ft][hnsw]") {
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
-    auto metric_type = GENERATE("l2");
+    auto metric_type = GENERATE("l2", "l1");
     const std::string name = "hnsw";
     auto search_param = fmt::format(search_param_tmp, 100);
     for (auto& dim : dims) {
@@ -405,7 +405,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Merge", "[ft][hnsw]"
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Filter", "[ft][hnsw]") {
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
-    auto metric_type = GENERATE("l2");
+    auto metric_type = GENERATE("l2", "l1");
     const std::string name = "hnsw";
     auto search_param = fmt::format(search_param_tmp, 100);
     auto dim = 32;
@@ -427,7 +427,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Filter", "[ft][hnsw]
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Add", "[ft][hnsw]") {
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
-    auto metric_type = GENERATE("l2", "ip", "cosine");
+    auto metric_type = GENERATE("l2", "ip", "cosine", "l1");
     const std::string name = "hnsw";
     auto search_param = fmt::format(search_param_tmp, 100);
     for (auto& dim : dims) {
@@ -453,7 +453,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Add", "[ft][hnsw]") 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Concurrent Add", "[ft][hnsw]") {
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
-    auto metric_type = GENERATE("l2", "ip", "cosine");
+    auto metric_type = GENERATE("l2", "ip", "cosine", "l1");
     const std::string name = "hnsw";
     auto search_param = fmt::format(search_param_tmp, 100);
     for (auto& dim : dims) {
@@ -480,7 +480,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Remove", "[ft][hnsw]
     auto test_recovery = GENERATE(true, false);
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
-    std::vector<std::string> metric_types = {"l2", "ip", "cosine"};
+    std::vector<std::string> metric_types = {"l2", "ip", "cosine", "l1"};
     const std::string name = "hnsw";
     auto search_param = fmt::format(search_param_tmp, 100);
     for (auto& dim : dims) {
@@ -505,7 +505,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Remove", "[ft][hnsw]
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Update Id", "[ft][hnsw]") {
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
-    auto metric_type = GENERATE("l2", "ip", "cosine");
+    auto metric_type = GENERATE("l2", "ip", "cosine", "l1");
     const std::string name = "hnsw";
     auto search_param = fmt::format(search_param_tmp, 100);
     for (auto& dim : dims) {
@@ -522,7 +522,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Update Id", "[ft][hn
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Batch Calc Dis Id", "[ft][hnsw]") {
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
-    auto metric_type = GENERATE("l2", "ip", "cosine");
+    auto metric_type = GENERATE("l2", "ip", "cosine", "l1");
     const std::string name = "hnsw";
     auto search_param = fmt::format(search_param_tmp, 100);
     for (auto& dim : dims) {
@@ -541,7 +541,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex,
                              "[ft][hnsw]") {
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
-    auto metric_type = GENERATE("l2");
+    auto metric_type = GENERATE("l2", "l1");
     auto use_static = GENERATE(true);
     const std::string name = "hnsw";
     auto search_param = fmt::format(search_param_tmp, 100);
@@ -562,7 +562,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex,
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Get Min Max ID", "[ft][hnsw]") {
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
-    auto metric_type = GENERATE("l2");
+    auto metric_type = GENERATE("l2", "l1");
     auto use_static = GENERATE(true, false);
     const std::string name = "hnsw";
     auto search_param = fmt::format(search_param_tmp, 100);
@@ -579,13 +579,12 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Get Min Max ID", "[f
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Get Raw Vector", "[ft][hnsw]") {
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
-    auto dtype = GENERATE("float32", "int8");
-    auto metric_type = GENERATE("l2");
+    const auto [dtype, metric_type] = GENERATE(
+        std::make_pair(std::string("float32"), std::string("l2")),
+        std::make_pair(std::string("float32"), std::string("l1")),
+        std::make_pair(std::string("int8"), std::string("ip")));
     const std::string name = "hnsw";
     for (auto& dim : dims) {
-        if (dtype == std::string("int8")) {
-            metric_type = "ip";
-        }
         vsag::Options::Instance().set_block_size_limit(size);
         auto param = GenerateHNSWBuildParametersString(metric_type, dim, false, dtype);
         auto index = TestFactory(name, param, true);
@@ -599,7 +598,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Get Raw Vector", "[f
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex, "HNSW Update Vector", "[ft][hnsw]") {
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
-    auto metric_type = GENERATE("l2");
+    auto metric_type = GENERATE("l2", "l1");
     const std::string name = "hnsw";
     auto search_param = fmt::format(search_param_tmp, 100);
     for (auto& dim : dims) {
@@ -618,7 +617,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex,
                              "[ft][hnsw][serialization]") {
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
-    auto metric_type = GENERATE("l2", "ip", "cosine");
+    auto metric_type = GENERATE("l2", "ip", "cosine", "l1");
     const std::string name = "hnsw";
     auto search_param = fmt::format(search_param_tmp, 100);
 
@@ -641,7 +640,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex,
                              "[ft][hnsw][serialization]") {
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
-    auto metric_type = "l2";
+    auto metric_type = GENERATE("l2", "l1");
     const std::string name = "hnsw";
     auto search_param = fmt::format(search_param_tmp, 100);
     auto dim = 128;
@@ -675,7 +674,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex,
     auto allocator = std::make_shared<fixtures::RandomAllocator>();
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
-    auto metric_type = GENERATE("l2", "ip", "cosine");
+    auto metric_type = GENERATE("l2", "ip", "cosine", "l1");
     const std::string name = "hnsw";
     for (auto& dim : dims) {
         vsag::Options::Instance().set_block_size_limit(size);
@@ -695,7 +694,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex,
                              "[ft][hnsw][concurrent]") {
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
-    auto metric_type = GENERATE("l2", "ip", "cosine");
+    auto metric_type = GENERATE("l2", "ip", "cosine", "l1");
     const std::string name = "hnsw";
     auto search_param = fmt::format(search_param_tmp, 100);
     for (auto& dim : dims) {
@@ -720,7 +719,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex,
                              "[ft][hnsw][immutable]") {
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
-    auto metric_type = "l2";
+    auto metric_type = GENERATE("l2", "l1");
     const std::string name = "hnsw";
     auto dim = 128;
     auto search_param = fmt::format(search_param_tmp, 100);
@@ -746,7 +745,7 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::HNSWTestIndex,
                              "[ft][hnsw][immutable]") {
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);
-    auto metric_type = "l2";
+    auto metric_type = GENERATE("l2", "l1");
     const std::string name = "hnsw";
     auto dim = 128;
     auto search_param = fmt::format(search_param_tmp, 100);

--- a/tools/eval/eval_dataset.cpp
+++ b/tools/eval/eval_dataset.cpp
@@ -261,6 +261,8 @@ EvalDataset::Load(const std::string& filename) {
                                    std::sqrt(vsag::InnerProduct(query1, query1, qty_ptr) *
                                              vsag::InnerProduct(query2, query2, qty_ptr));
                 };
+            } else if (metric == "manhattan" || metric == "l1") {
+                obj->distance_func_ = vsag::L1Distance;
             }
         } else {
             if (metric == "ip") {


### PR DESCRIPTION
## Change Type
This feature adds support for the L1 distance metric in VSAG vector indexes.

## What Changed
Add a new distance metric by introducing L1Space for L1 distance computation and mapping VIDA_L1 to DISTANCE.

## Test
finish all unittest and do end 2 end test personally