### PR TITLE
test: stabilize filtered range search recall validation

### DIFF
--- a/tests/test_index/test_index_search.cpp
+++ b/tests/test_index/test_index_search.cpp
@@ -275,7 +275,10 @@ TestIndex::TestFilterSearch(const TestIndex::IndexPtr& index,
     auto gts = dataset->filter_ground_truth_;
     auto gt_topK = dataset->top_k;
     float cur_recall = 0.0f;
+    float range_recall = 0.0F;
     auto topk = gt_topK;
+    const bool support_filter_range =
+        index->CheckFeature(vsag::SUPPORT_RANGE_SEARCH_WITH_ID_FILTER);
     for (auto i = 0; i < query_count; ++i) {
         auto query = get_one_query(queries, i);
         tl::expected<DatasetPtr, vsag::Error> res;
@@ -302,20 +305,27 @@ TestIndex::TestFilterSearch(const TestIndex::IndexPtr& index,
             return;
         }
         REQUIRE(res.value()->GetDim() == topk);
-        if (index->CheckFeature(vsag::SUPPORT_RANGE_SEARCH_WITH_ID_FILTER)) {
-            auto threshold = res.value()->GetDistances()[topk - 1] + 1e-5;
+        auto gt = gts->GetIds() + gt_topK * i;
+        if (support_filter_range) {
+            const auto range_gt_count = gt_topK - 1;
+            const auto* gt_distances = gts->GetDistances() + gt_topK * i;
+            // KNN and RangeSearch use independent approximate candidate searches. Define the
+            // radius from exact ground truth and evaluate aggregate recall instead of requiring
+            // every RangeSearch result to be non-empty.
+            const auto threshold =
+                0.5F * (gt_distances[range_gt_count - 1] + gt_distances[range_gt_count]);
             auto range_result =
                 index->RangeSearch(query, threshold, search_param, dataset->filter_function_);
             REQUIRE(range_result.has_value());
-            REQUIRE(range_result.value()->GetDim() > 0);
-            if (range_result.value()->GetDim() < topk - 1) {
-                WARN(fmt::format("range search result dim {} is less than {}",
-                                 range_result.value()->GetDim(),
-                                 topk - 1));
+            const auto range_dim = range_result.value()->GetDim();
+            const auto* range_ids = range_result.value()->GetIds();
+            for (int64_t j = 0; j < range_dim; ++j) {
+                REQUIRE_FALSE(dataset->filter_function_(range_ids[j]));
             }
+            const auto hits = Intersection(gt, range_gt_count, range_ids, range_dim);
+            range_recall += static_cast<float>(hits) / static_cast<float>(range_gt_count);
         }
         auto result = res.value()->GetIds();
-        auto gt = gts->GetIds() + gt_topK * i;
         auto val = Intersection(gt, gt_topK, result, topk);
         cur_recall += static_cast<float>(val) / static_cast<float>(gt_topK);
     }
@@ -325,6 +335,14 @@ TestIndex::TestFilterSearch(const TestIndex::IndexPtr& index,
                          expected_recall * query_count));
     }
     REQUIRE(cur_recall > expected_recall * query_count * RECALL_THRESHOLD);
+    if (support_filter_range) {
+        if (range_recall <= expected_recall * query_count) {
+            WARN(fmt::format("range_recall({}) <= expected_recall * query_count({})",
+                             range_recall,
+                             expected_recall * query_count));
+        }
+        REQUIRE(range_recall > expected_recall * query_count * RECALL_THRESHOLD);
+    }
 }
 
 void


### PR DESCRIPTION
## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement/Refactor
- [ ] Documentation
- [x] CI/Build/Infra

## Linked Issue

- Fixes: #2631

## What Changed

- Derive the filtered range-search radius from exact filtered ground truth instead of an
  approximate KNN result.
- Evaluate filtered RangeSearch recall across all queries, counting an empty query as zero recall
  instead of failing that query immediately.
- Verify that every returned ID satisfies the requested filter.
- Keep Pyramid, HGraph, and all other production search behavior unchanged.

This supersedes #2634.

## Root Cause

`TestFilterSearch` derived a radius from an approximate KNN result and assumed that an independent
approximate RangeSearch must return at least one item for every query.

That implication is not guaranteed. KNN and RangeSearch use different ANN candidate-generation and
pruning paths. With low-dimensional RaBitQ data, RangeSearch can occasionally miss all in-radius
candidates before precise reordering, even though KNN found candidates. Random Pyramid dimensions
and paths made the per-query non-empty assertion flaky.

The revised test uses the midpoint between the ninth and tenth exact filtered ground-truth
distances, measures recall for the first nine neighbors, and enforces the existing aggregate recall
threshold. A single approximate miss is therefore measured as a recall loss, while a systematic
regression still fails the test. HGraph follows the same approximate-search model, so a
Pyramid-only retry would create inconsistent behavior and add a possible second traversal.

## Test Evidence

- [ ] `make fmt`
- [ ] `make lint`
- [ ] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [x] Other (described below)

Test details:

```text
clang-format 15.0.7 --dry-run --Werror tests/test_index/test_index_search.cpp
git diff --check
make test CASE='"Pyramid Build & ContinueAdd Test"'
  All tests passed (132,033 assertions in 1 test case)
./build/tests/functests "SINDI Build and Search" -d yes
  All tests passed (299,412 assertions in 1 test case)
./build/tests/functests "(PR) BruteForce Build & ContinueAdd Test" -d yes
  All tests passed (6,276 assertions in 1 test case)
./build/tests/functests "HNSW Filter" -d yes
  All tests passed (6,676 assertions in 1 test case)
./build/tests/functests "(PR) HGraph Build Test" -d yes
  All tests passed (37,116 assertions in 1 test case)
./build/tests/functests "(PR) IVF Build" -d yes
  All tests passed (19,750 assertions in 1 test case)
./build/tests/functests "diskann build and search" -d yes
  All tests passed (10,827 assertions in 1 test case)
```

## Compatibility Impact

- API/ABI compatibility: none
- Behavior changes: none; this only corrects the test contract

## Performance and Concurrency Impact

- Performance impact: none in production code
- Concurrency/thread-safety impact: none

## Documentation Impact

- [x] No docs update needed

## Risk and Rollback

- Risk level: low
- Rollback plan: revert the test-only commit

## Checklist

- [x] I have linked the relevant issue
- [x] I have added/updated tests for the reported failure
- [x] I have considered API compatibility impact
- [x] I have updated docs if behavior/workflow changed
- [x] My commit messages follow project conventions
