### PR TITLE
fix: backport bounded DiskANN closest-center memory

### DIFF
--- a/extern/diskann/DiskANN/include/math_utils.h
+++ b/extern/diskann/DiskANN/include/math_utils.h
@@ -9,6 +9,10 @@
 namespace math_utils
 {
 
+// compute_closest_centers processes points in blocks so the GEMM scratch matrix stays bounded
+// to num_centers * kMaxClosestCenterBlockSize floats.
+constexpr uint64_t kMaxClosestCenterBlockSize = 65536;
+
 float calc_distance(float *vec_1, float *vec_2, uint64_t dim);
 
 // compute l2-squared norms of data stored in row major num_points * dim,

--- a/extern/diskann/DiskANN/src/math_utils.cpp
+++ b/extern/diskann/DiskANN/src/math_utils.cpp
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 #include <limits>
+#include <memory>
 #ifdef __APPLE__
 #include <cstdlib>
 #else
@@ -161,53 +162,58 @@ void compute_closest_centers(float *data, uint64_t num_points, uint64_t dim, flo
         return;
     }
 
+    if (num_points == 0 || k == 0)
+    {
+        return;
+    }
+
     bool is_norm_given_for_pts = (pts_norms_squared != NULL);
 
-    float *pivs_norms_squared = new float[num_centers];
+    std::unique_ptr<float[]> pivs_norms_squared(new float[num_centers]);
+    std::unique_ptr<float[]> owned_pts_norms_squared;
     if (!is_norm_given_for_pts)
-        pts_norms_squared = new float[num_points];
+    {
+        owned_pts_norms_squared.reset(new float[num_points]);
+        pts_norms_squared = owned_pts_norms_squared.get();
+    }
 
-    uint64_t PAR_BLOCK_SIZE = num_points;
-    uint64_t N_BLOCKS =
-        (num_points % PAR_BLOCK_SIZE) == 0 ? (num_points / PAR_BLOCK_SIZE) : (num_points / PAR_BLOCK_SIZE) + 1;
+    uint64_t par_block_size = std::min<uint64_t>(num_points, kMaxClosestCenterBlockSize);
+    uint64_t n_blocks = (num_points + par_block_size - 1) / par_block_size;
 
     if (!is_norm_given_for_pts)
         math_utils::compute_vecs_l2sq(pts_norms_squared, data, num_points, dim);
-    math_utils::compute_vecs_l2sq(pivs_norms_squared, pivot_data, num_centers, dim);
-    uint32_t *closest_centers = new uint32_t[PAR_BLOCK_SIZE * k];
-    float *distance_matrix = new float[num_centers * PAR_BLOCK_SIZE];
+    math_utils::compute_vecs_l2sq(pivs_norms_squared.get(), pivot_data, num_centers, dim);
+    std::unique_ptr<uint32_t[]> closest_centers(new uint32_t[par_block_size * k]);
+    std::unique_ptr<float[]> distance_matrix(new float[num_centers * par_block_size]);
 
-    for (uint64_t cur_blk = 0; cur_blk < N_BLOCKS; cur_blk++)
+    for (uint64_t cur_blk = 0; cur_blk < n_blocks; cur_blk++)
     {
-        float *data_cur_blk = data + cur_blk * PAR_BLOCK_SIZE * dim;
-        uint64_t num_pts_blk = std::min(PAR_BLOCK_SIZE, num_points - cur_blk * PAR_BLOCK_SIZE);
-        float *pts_norms_blk = pts_norms_squared + cur_blk * PAR_BLOCK_SIZE;
+        uint64_t block_begin = cur_blk * par_block_size;
+        float *data_cur_blk = data + block_begin * dim;
+        uint64_t num_pts_blk = std::min(par_block_size, num_points - block_begin);
+        float *pts_norms_blk = pts_norms_squared + block_begin;
 
-        math_utils::compute_closest_centers_in_block(data_cur_blk, num_pts_blk, dim, pivot_data, num_centers,
-                                                     pts_norms_blk, pivs_norms_squared, closest_centers,
-                                                     distance_matrix, k);
+        math_utils::compute_closest_centers_in_block(data_cur_blk, num_pts_blk, dim, pivot_data,
+                                                     num_centers, pts_norms_blk,
+                                                     pivs_norms_squared.get(), closest_centers.get(),
+                                                     distance_matrix.get(), k);
 
         // #pragma omp parallel for schedule(static, 1)
-        for (int64_t j = cur_blk * PAR_BLOCK_SIZE;
-             j < std::min((int64_t)num_points, (int64_t)((cur_blk + 1) * PAR_BLOCK_SIZE)); j++)
+        for (uint64_t local = 0; local < num_pts_blk; local++)
         {
+            uint64_t global = block_begin + local;
             for (uint64_t l = 0; l < k; l++)
             {
-                uint64_t this_center_id = closest_centers[(j - cur_blk * PAR_BLOCK_SIZE) * k + l];
-                closest_centers_ivf[j * k + l] = (uint32_t)this_center_id;
+                uint64_t this_center_id = closest_centers[local * k + l];
+                closest_centers_ivf[global * k + l] = (uint32_t)this_center_id;
                 if (inverted_index != NULL)
                 {
                     // #pragma omp critical
-                    inverted_index[this_center_id].push_back(j);
+                    inverted_index[this_center_id].push_back(global);
                 }
             }
         }
     }
-    delete[] closest_centers;
-    delete[] distance_matrix;
-    delete[] pivs_norms_squared;
-    if (!is_norm_given_for_pts)
-        delete[] pts_norms_squared;
 }
 
 // if to_subtract is 1, will subtract nearest center from each row. Else will

--- a/src/index/diskann_test.cpp
+++ b/src/index/diskann_test.cpp
@@ -15,6 +15,7 @@
 
 #include "diskann.h"
 
+#include <algorithm>
 #include <cstdint>
 #include <fstream>
 #include <nlohmann/json.hpp>
@@ -25,6 +26,7 @@
 #include "diskann_zparameters.h"
 #include "distance.h"
 #include "index_common_param.h"
+#include "math_utils.h"
 #include "unittest.h"
 #include "utils/timer.h"
 #include "vsag/errors.h"
@@ -53,6 +55,93 @@ write_value(std::stringstream& stream, const uint32_t& value) {
 void
 write_value(std::stringstream& stream, const uint64_t& value) {
     stream.write(reinterpret_cast<const char*>(&value), sizeof(value));
+}
+
+std::vector<float>
+make_centers(uint64_t num_centers, uint64_t dim) {
+    std::vector<float> values(num_centers * dim);
+    for (uint64_t i = 0; i < num_centers; ++i) {
+        for (uint64_t j = 0; j < dim; ++j) {
+            values[i * dim + j] = static_cast<float>(i * 32 + j) / 7.0F;
+        }
+    }
+    return values;
+}
+
+std::vector<float>
+make_points_near_centers(uint64_t num_points, uint64_t dim, uint64_t num_centers) {
+    std::vector<float> values(num_points * dim);
+    for (uint64_t i = 0; i < num_points; ++i) {
+        uint64_t center_id = i % num_centers;
+        float offset = static_cast<float>((i % 7) + 1) / 100.0F;
+        for (uint64_t j = 0; j < dim; ++j) {
+            values[i * dim + j] = static_cast<float>(center_id * 32 + j) / 7.0F + offset;
+        }
+    }
+    return values;
+}
+
+std::vector<float>
+compute_l2sq(const std::vector<float>& values, uint64_t count, uint64_t dim) {
+    std::vector<float> norms(count);
+    for (uint64_t i = 0; i < count; ++i) {
+        float norm = 0.0F;
+        for (uint64_t j = 0; j < dim; ++j) {
+            float value = values[i * dim + j];
+            norm += value * value;
+        }
+        norms[i] = norm;
+    }
+    return norms;
+}
+
+std::vector<uint32_t>
+compute_closest_centers_single_block(const std::vector<float>& data,
+                                     uint64_t num_points,
+                                     uint64_t dim,
+                                     const std::vector<float>& centers,
+                                     uint64_t num_centers,
+                                     const std::vector<float>& pts_norms,
+                                     uint64_t k) {
+    auto center_norms = compute_l2sq(centers, num_centers, dim);
+    std::vector<uint32_t> closest_centers(num_points * k);
+    std::vector<float> distance_matrix(num_points * num_centers);
+
+    math_utils::compute_closest_centers_in_block(data.data(),
+                                                 num_points,
+                                                 dim,
+                                                 centers.data(),
+                                                 num_centers,
+                                                 pts_norms.data(),
+                                                 center_norms.data(),
+                                                 closest_centers.data(),
+                                                 distance_matrix.data(),
+                                                 k);
+
+    return closest_centers;
+}
+
+void
+require_inverted_index_matches_assignments(const std::vector<std::vector<uint64_t>>& inverted_index,
+                                           const std::vector<uint32_t>& assignments,
+                                           uint64_t num_points,
+                                           uint64_t k) {
+    std::vector<uint64_t> seen_count(num_points);
+    for (uint64_t center_id = 0; center_id < inverted_index.size(); ++center_id) {
+        for (uint64_t point_id : inverted_index[center_id]) {
+            REQUIRE(point_id < num_points);
+            bool matched = false;
+            for (uint64_t rank = 0; rank < k; ++rank) {
+                matched = matched || assignments[point_id * k + rank] == center_id;
+            }
+            REQUIRE(matched);
+            ++seen_count[point_id];
+        }
+    }
+
+    for (uint64_t point_id = 0; point_id < num_points; ++point_id) {
+        REQUIRE(seen_count[point_id] == k);
+    }
 }
 
 }  // namespace
@@ -98,6 +187,86 @@ TEST_CASE("create_disk_layout reads stringstream after size lookup", "[ut][diska
                                                        sector_len,
                                                        diskann::Metric::L2));
     REQUIRE(diskann_writer.tellp() > std::streampos(0));
+}
+
+TEST_CASE("compute_closest_centers handles empty input", "[ut][diskann]") {
+    constexpr uint64_t num_points = 0;
+    constexpr uint64_t dim = 4;
+    constexpr uint64_t num_centers = 3;
+    constexpr uint64_t k = 1;
+
+    std::vector<uint32_t> closest_centers = {12345U};
+    std::vector<std::vector<uint64_t>> inverted_index(num_centers);
+
+    math_utils::compute_closest_centers(nullptr,
+                                        num_points,
+                                        dim,
+                                        nullptr,
+                                        num_centers,
+                                        k,
+                                        closest_centers.data(),
+                                        inverted_index.data(),
+                                        nullptr);
+
+    REQUIRE(closest_centers[0] == 12345U);
+    for (const auto& bucket : inverted_index) {
+        REQUIRE(bucket.empty());
+    }
+}
+
+TEST_CASE("compute_closest_centers handles zero closest-center request", "[ut][diskann]") {
+    constexpr uint64_t num_points = 4;
+    constexpr uint64_t dim = 3;
+    constexpr uint64_t num_centers = 0;
+    constexpr uint64_t k = 0;
+
+    std::vector<float> data(num_points * dim, 1.0F);
+    std::vector<uint32_t> closest_centers = {12345U};
+
+    math_utils::compute_closest_centers(data.data(),
+                                        num_points,
+                                        dim,
+                                        nullptr,
+                                        num_centers,
+                                        k,
+                                        closest_centers.data(),
+                                        nullptr,
+                                        nullptr);
+
+    REQUIRE(closest_centers[0] == 12345U);
+}
+
+TEST_CASE("compute_closest_centers matches single block reference", "[ut][diskann]") {
+    constexpr uint64_t num_points = math_utils::kMaxClosestCenterBlockSize + 11;
+    constexpr uint64_t dim = 5;
+    constexpr uint64_t num_centers = 32;
+    constexpr uint64_t k = 1;
+
+    auto centers = make_centers(num_centers, dim);
+    auto data = make_points_near_centers(num_points, dim, num_centers);
+    auto pts_norms = compute_l2sq(data, num_points, dim);
+    auto expected = compute_closest_centers_single_block(
+        data, num_points, dim, centers, num_centers, pts_norms, k);
+
+    std::vector<uint32_t> actual(num_points * k);
+    std::vector<std::vector<uint64_t>> inverted_index(num_centers);
+    math_utils::compute_closest_centers(data.data(),
+                                        num_points,
+                                        dim,
+                                        centers.data(),
+                                        num_centers,
+                                        k,
+                                        actual.data(),
+                                        inverted_index.data(),
+                                        pts_norms.data());
+
+    auto mismatch = std::mismatch(actual.begin(), actual.end(), expected.begin());
+    if (mismatch.first != actual.end()) {
+        auto mismatch_index = static_cast<uint64_t>(mismatch.first - actual.begin());
+        INFO("mismatch at assignment offset " << mismatch_index);
+    }
+    REQUIRE(mismatch.first == actual.end());
+    require_inverted_index_matches_assignments(inverted_index, actual, num_points, k);
 }
 
 TEST_CASE("diskann build", "[ut][diskann]") {


### PR DESCRIPTION
## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement/Refactor
- [ ] Documentation
- [ ] CI/Build/Infra

## Linked Issue

- Source PR: https://github.com/antgroup/vsag/pull/2629

## What Changed

- Process closest-center assignments in fixed 64K-point blocks so the GEMM distance scratch matrix stays bounded.
- Preserve global point IDs when assignments span multiple blocks.
- Keep empty input and zero requested centers as no-op operations.
- Add focused 1.0 regressions for both no-op cases and cross-block assignment/inverted-list correctness.

## Test Evidence

- [x] `make fmt`
- [ ] `make lint`
- [x] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [x] Other (describe below)

Test details:

```text
make test CASE='"[ut][diskann]"'
All tests passed (198719 assertions in 14 test cases)
```

## Compatibility Impact

- API/ABI compatibility: no public VSAG API or ABI change.
- Behavior changes: closest-center temporary distance storage is block-bounded; empty and zero-center requests remain no-ops.

## Performance and Concurrency Impact

- Performance impact: reduces peak closest-center scratch memory for large datasets.
- Concurrency/thread-safety impact: none.

## Documentation Impact

- [x] No docs update needed
- [ ] Updated docs:
  - [ ] `README.md`
  - [ ] `DEVELOPMENT.md`
  - [ ] `CONTRIBUTING.md`
  - [ ] Other:

## Risk and Rollback

- Risk level: low
- Rollback plan: revert the single backport commit.

## Checklist

- [x] I have linked the source pull request.
- [x] I have added/updated tests for new behavior or bug fixes.
- [x] I have considered API compatibility impact.
- [x] I have updated docs if behavior/workflow changed.
- [x] My commit messages follow project conventions.