### PR TITLE
fix(hgraph): set batch distance result dimensions

### DIFF
--- a/src/algorithm/inner_index_interface.cpp
+++ b/src/algorithm/inner_index_interface.cpp
@@ -1066,7 +1066,7 @@ InnerIndexInterface::cal_distance_by_id(const float* query,
                                         const FlattenInterfacePtr& data,
                                         std::vector<bool>* validity) const {
     auto result = Dataset::Make();
-    result->Owner(true, allocator_);
+    result->NumElements(1)->Dim(count)->Owner(true, allocator_);
     auto* distances = (float*)allocator_->Allocate(sizeof(float) * count);
     result->Distances(distances);
     auto computer = data->FactoryComputer(query);

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -320,6 +320,15 @@ HGraphTestIndex::TestGeneral(const TestIndex::IndexPtr& index,
     TestCalcDistanceById(index, dataset, 1e-5, expect_success);
     TestGetRawVectorByIds(index, dataset, expect_success);
     TestBatchCalcDistanceById(index, dataset, 1e-5, expect_success);
+    if (expect_success && dataset->query_->GetFloat32Vectors() != nullptr) {
+        const auto count = dataset->top_k;
+        auto result = index->CalDistanceById(
+            dataset->query_->GetFloat32Vectors(), dataset->ground_truth_->GetIds(), count, -1);
+        REQUIRE(result.has_value());
+        REQUIRE(result.value()->GetDistances() != nullptr);
+        REQUIRE(result.value()->GetNumElements() == 1);
+        REQUIRE(result.value()->GetDim() == count);
+    }
     TestMultiQueryBatchCalcDistanceById(index, dataset, 1e-5, expect_success);
     TestSearchAllocator(index, dataset, search_param, recall, true);
     TestUpdateVector(index, dataset, search_param, false);

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -322,8 +322,11 @@ HGraphTestIndex::TestGeneral(const TestIndex::IndexPtr& index,
     TestBatchCalcDistanceById(index, dataset, 1e-5, expect_success);
     if (expect_success && dataset->query_->GetFloat32Vectors() != nullptr) {
         const auto count = dataset->top_k;
-        auto result = index->CalDistanceById(
-            dataset->query_->GetFloat32Vectors(), dataset->ground_truth_->GetIds(), count, -1);
+        auto result = index->CalcDistancesById(dataset->query_->GetFloat32Vectors(),
+                                               dataset->ground_truth_->GetIds(),
+                                               count,
+                                               true,
+                                               -1);
         REQUIRE(result.has_value());
         REQUIRE(result.value()->GetDistances() != nullptr);
         REQUIRE(result.value()->GetNumElements() == 1);

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -320,18 +320,6 @@ HGraphTestIndex::TestGeneral(const TestIndex::IndexPtr& index,
     TestCalcDistanceById(index, dataset, 1e-5, expect_success);
     TestGetRawVectorByIds(index, dataset, expect_success);
     TestBatchCalcDistanceById(index, dataset, 1e-5, expect_success);
-    if (expect_success && dataset->query_->GetFloat32Vectors() != nullptr) {
-        const auto count = dataset->top_k;
-        auto result = index->CalcDistancesById(dataset->query_->GetFloat32Vectors(),
-                                               dataset->ground_truth_->GetIds(),
-                                               count,
-                                               true,
-                                               -1);
-        REQUIRE(result.has_value());
-        REQUIRE(result.value()->GetDistances() != nullptr);
-        REQUIRE(result.value()->GetNumElements() == 1);
-        REQUIRE(result.value()->GetDim() == count);
-    }
     TestMultiQueryBatchCalcDistanceById(index, dataset, 1e-5, expect_success);
     TestSearchAllocator(index, dataset, search_param, recall, true);
     TestUpdateVector(index, dataset, search_param, false);
@@ -1050,6 +1038,28 @@ TestHGraphWithAttr(const fixtures::HGraphTestIndexPtr& test_index,
 }
 
 HGRAPH_PR_DAILY_CASE("HGraph With Attr", "[ft][filter_search][hgraph]", TestHGraphWithAttr)
+
+TEST_CASE("HGraph CalDistanceById default topk returns shaped result", "[ft][hgraph][pr]") {
+    using namespace fixtures;
+
+    HGraphTestIndex::HGraphBuildParam build_param("l2", 16, "fp32");
+    auto param = HGraphTestIndex::GenerateHGraphBuildParametersString(build_param);
+    auto index = TestIndex::TestFactory(HGraphTestIndex::name, param, true);
+    auto dataset = HGraphTestIndex::pool.GetDatasetAndCreate(16, 256, "l2");
+    TestIndex::TestBuildIndex(index, dataset, true);
+
+    const auto count = dataset->top_k;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    auto result = index->CalDistanceById(
+        dataset->query_->GetFloat32Vectors(), dataset->ground_truth_->GetIds(), count, true, -1);
+#pragma GCC diagnostic pop
+
+    REQUIRE(result.has_value());
+    REQUIRE(result.value()->GetDistances() != nullptr);
+    REQUIRE(result.value()->GetNumElements() == 1);
+    REQUIRE(result.value()->GetDim() == count);
+}
 
 TEST_CASE("(PR) HGraph SearchWithRequest Reasoning", "[ft][hgraph][pr]") {
     using namespace fixtures;

--- a/tests/test_index/test_index_calc.cpp
+++ b/tests/test_index/test_index_calc.cpp
@@ -85,6 +85,9 @@ TestIndex::TestBatchCalcDistanceById(const IndexPtr& index,
         if (not expected_success) {
             return;
         }
+        REQUIRE(result.has_value());
+        REQUIRE(result.value()->GetNumElements() == 1);
+        REQUIRE(result.value()->GetDim() == gt_topK);
         for (auto j = 0; j < gt_topK; ++j) {
             REQUIRE(std::abs(gts->GetDistances()[i * gt_topK + j] -
                              result.value()->GetDistances()[j]) < error);

--- a/tests/test_index/test_index_calc.cpp
+++ b/tests/test_index/test_index_calc.cpp
@@ -86,8 +86,6 @@ TestIndex::TestBatchCalcDistanceById(const IndexPtr& index,
             return;
         }
         REQUIRE(result.has_value());
-        REQUIRE(result.value()->GetNumElements() == 1);
-        REQUIRE(result.value()->GetDim() == gt_topK);
         for (auto j = 0; j < gt_topK; ++j) {
             REQUIRE(std::abs(gts->GetDistances()[i * gt_topK + j] -
                              result.value()->GetDistances()[j]) < error);


### PR DESCRIPTION
Fixes #2647. Sets the selected-flatten batch distance Dataset shape to one row by count and verifies it in the raw-pointer batch-distance regression test.\n\nValidation: make fmt passed. make test CASE=[hgraph] was blocked while fetching Boost because the configured cache returned HTTP 403.