### PR TITLE
fix(ivf): drain add tasks after allocation failure

### DIFF
--- a/src/algorithm/ivf/ivf.cpp
+++ b/src/algorithm/ivf/ivf.cpp
@@ -18,6 +18,7 @@
 #include <algorithm>
 #include <atomic>
 #include <cmath>
+#include <exception>
 #include <limits>
 #include <random>
 #include <set>
@@ -599,19 +600,32 @@ IVF::Add(const DatasetPtr& base) {
         }
     };
     std::vector<std::future<void>> futures;
-    for (int64_t i = 0; i < num_element; ++i) {
-        if (this->thread_pool_ != nullptr) {
-            auto future = thread_pool_->GeneralEnqueue(add_func, i);
-            futures.emplace_back(std::move(future));
-        } else {
-            add_func(i);
+    std::exception_ptr first_exception = nullptr;
+    try {
+        for (int64_t i = 0; i < num_element; ++i) {
+            if (this->thread_pool_ != nullptr) {
+                futures.emplace_back(thread_pool_->GeneralEnqueue(add_func, i));
+            } else {
+                add_func(i);
+            }
         }
+    } catch (...) {
+        first_exception = std::current_exception();
     }
 
     if (this->thread_pool_ != nullptr) {
         for (auto& future : futures) {
-            future.get();
+            try {
+                future.get();
+            } catch (...) {
+                if (first_exception == nullptr) {
+                    first_exception = std::current_exception();
+                }
+            }
         }
+    }
+    if (first_exception != nullptr) {
+        std::rethrow_exception(first_exception);
     }
     this->bucket_->Package();
     if (need_cal_memory_usage) {

--- a/tests/fixtures/allocator/random_allocator.cpp
+++ b/tests/fixtures/allocator/random_allocator.cpp
@@ -23,19 +23,21 @@ RandomAllocator::Name() {
     return "random_allocator";
 }
 
-RandomAllocator::RandomAllocator() {
-    rd_ = std::make_shared<std::random_device>();
-    gen_ = std::make_shared<std::mt19937>((*rd_)());
-    std::uniform_int_distribution<int> seed_random;
-    int seed = seed_random(*gen_);
-    gen_->seed(seed);
-    error_ratio_ = 0.025f;
+RandomAllocator::RandomAllocator() : RandomAllocator(std::random_device{}()) {
+}
+
+RandomAllocator::RandomAllocator(uint32_t seed) : gen_(seed) {
+}
+
+bool
+RandomAllocator::ShouldFail() {
+    std::lock_guard lock(mutex_);
+    return dis_(gen_) < error_ratio_;
 }
 
 void*
 RandomAllocator::Allocate(uint64_t size) {
-    auto number = dis_(*gen_);
-    if (number < error_ratio_) {
+    if (ShouldFail()) {
         return nullptr;
     }
     return malloc(size);
@@ -48,8 +50,7 @@ RandomAllocator::Deallocate(void* p) {
 
 void*
 RandomAllocator::Reallocate(void* p, uint64_t size) {
-    auto number = dis_(*gen_);
-    if (number < error_ratio_) {
+    if (ShouldFail()) {
         return nullptr;
     }
     return realloc(p, size);

--- a/tests/fixtures/allocator/random_allocator.h
+++ b/tests/fixtures/allocator/random_allocator.h
@@ -19,7 +19,8 @@
 
 #pragma once
 
-#include <memory>
+#include <cstdint>
+#include <mutex>
 #include <random>
 
 #include "vsag/allocator.h"
@@ -47,6 +48,11 @@ public:
     RandomAllocator();
 
     /**
+     * @brief Constructs a RandomAllocator with a reproducible seed.
+     */
+    explicit RandomAllocator(uint32_t seed);
+
+    /**
      * @brief Attempts allocation, may randomly return nullptr.
      * @param size The number of bytes to allocate.
      * @return Pointer to allocated memory or nullptr (randomly).
@@ -71,10 +77,13 @@ public:
     Reallocate(void* p, uint64_t size) override;
 
 private:
-    std::shared_ptr<std::random_device> rd_;  // Random device for seeding.
-    std::shared_ptr<std::mt19937> gen_;       // Mersenne twister generator.
-    std::uniform_real_distribution<> dis_;    // Uniform distribution for randomness.
-    float error_ratio_ = 0.0f;                // Probability of allocation failure.
+    bool
+    ShouldFail();
+
+    std::mutex mutex_;
+    std::mt19937 gen_;
+    std::uniform_real_distribution<> dis_;
+    float error_ratio_ = 0.025F;
 };
 
 }  // namespace fixtures

--- a/tests/test_index/test_index_build.cpp
+++ b/tests/test_index/test_index_build.cpp
@@ -142,7 +142,10 @@ TestIndex::TestContinueAddIgnoreRequire(const TestIndex::IndexPtr& index,
         ->Paths(dataset->base_->GetPaths())
         ->Float32Vectors(dataset->base_->GetFloat32Vectors())
         ->Owner(false);
-    index->Build(temp_dataset);
+    auto build_result = index->Build(temp_dataset);
+    if (not build_result.has_value()) {
+        return;
+    }
     for (uint64_t j = temp_count; j < base_count; ++j) {
         auto data_one = vsag::Dataset::Make();
         data_one->Dim(dim)
@@ -152,6 +155,9 @@ TestIndex::TestContinueAddIgnoreRequire(const TestIndex::IndexPtr& index,
             ->Float32Vectors(dataset->base_->GetFloat32Vectors() + j * dim)
             ->Owner(false);
         auto add_index = index->Add(data_one);
+        if (not add_index.has_value()) {
+            return;
+        }
     }
 }
 

--- a/tests/test_ivf.cpp
+++ b/tests/test_ivf.cpp
@@ -1386,7 +1386,9 @@ IVF_PR_DAILY_CASE("IVF Clone", "[ft][clone][ivf]", TestIVFClone)
 
 static void
 TestIVFRandomAllocator(const fixtures::IVFResourcePtr& resource) {
-    auto allocator = std::make_shared<fixtures::RandomAllocator>();
+    constexpr uint32_t allocator_seed = 1544291908U;
+    auto allocator = std::make_shared<fixtures::RandomAllocator>(allocator_seed);
+    INFO(fmt::format("allocator_seed: {}", allocator_seed));
     using namespace fixtures;
     auto origin_size = vsag::Options::Instance().block_size_limit();
     auto size = GENERATE(1024 * 1024 * 2);


### PR DESCRIPTION
## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement/Refactor
- [ ] Documentation
- [ ] CI/Build/Infra

## Linked Issue

- Fixes #2547
- Related to #2593

Issue #2547 is the focused bug report for the IVF random-allocator crash fixed
by this PR. Issue #2593 is retained as the aggregate Coverage CI context; its
latest occurrence (`31368887531`) is an unrelated Pyramid recall failure.

## Problem Analysis

The complete CI logs reveal concrete failures that were not visible in the
abbreviated aggregate issue excerpt:

- The failure recorded in #2547 crashed with `SIGSEGV` after repeated injected
  `bad_alloc` errors in `(PR) IVF Build & ContinueAdd Test With Random
  Allocator`.
- Coverage run `30974462951` reproduced the same IVF random-allocator crash.
- Coverage run `30611548134` separately showed why accepted asynchronous work
  must be drained before an exceptional build path returns: the HGraph
  enqueue-failure regression observed an accepted task still running.

The IVF crash had three contributing conditions:

1. `IVF::Add` stopped immediately when task submission or one worker future
   threw. Other successfully submitted tasks could still be running while the
   call stack and captured state were being unwound.
2. `RandomAllocator` shared one `std::mt19937` across parallel allocation paths
   without synchronization, which introduced a data race in the failure
   injector itself.
3. The allocation-failure helper continued calling `Add` after `Build` or a
   previous `Add` had failed, exercising an index whose mutation was only
   partially completed.

The `/bin/sh: redirection unexpected` message around the lcov exception test
is not the terminal failure: the workflow continues into compilation and test
execution afterward.

## What Changed

- Preserve the first enqueue or worker exception in `IVF::Add`, drain every
  successfully submitted future, then rethrow the original failure.
- Serialize access to the random failure generator and add a seedable
  `RandomAllocator` constructor for repeatable fault injection.
- Stop the continue-add failure helper after the first failed mutation.
- Pin and report the IVF allocator seed that reproduced the crash.

## Test Evidence

- [x] `clang-format-15`
- [x] `clang-tidy-15 -p build src/algorithm/ivf/ivf.cpp --quiet`
- [x] Coverage build of `functests` and `unittests`
- [x] Full `unittests`: 712 test cases and 85,747,687 assertions passed
- [x] IVF random-allocator regression: 500 consecutive passes before rebase
- [x] HGraph enqueue-failure regression: 200 consecutive passes before rebase
- [x] Post-rebase regression: IVF 100/100 and HGraph 100/100
- [x] Related HNSW, Pyramid, and BruteForce random-allocator tests passed
- [x] `git diff --check`

## Compatibility Impact

- API/ABI compatibility: none; the allocator changes are test-fixture-only.
- Behavior changes: `IVF::Add` now waits for accepted work before propagating
  an exception.

## Performance and Concurrency Impact

- Performance impact: no new production hot-path synchronization; exception
  collection only affects failure handling.
- Concurrency/thread-safety impact: removes the test allocator RNG data race
  and prevents accepted IVF tasks from outliving exceptional unwinding.

## Documentation Impact

- [x] No docs update needed

## Risk and Rollback

- Risk level: low
- Rollback plan: revert this commit if fault propagation behavior regresses.

## Checklist

- [x] I have linked the relevant issue.
- [x] I have added or updated regression coverage.
- [x] I have considered API compatibility impact.
- [x] No user-facing documentation update is required.
- [x] The commit message follows project conventions.
