### PR TITLE
test: make filtered range recall diagnostic

### DIFF
--- a/tests/test_index/test_index_search.cpp
+++ b/tests/test_index/test_index_search.cpp
@@ -341,7 +341,6 @@ TestIndex::TestFilterSearch(const TestIndex::IndexPtr& index,
                              range_recall,
                              expected_recall * query_count));
         }
-        REQUIRE(range_recall > expected_recall * query_count * RECALL_THRESHOLD);
     }
 }
 


### PR DESCRIPTION
## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement/Refactor
- [ ] Documentation
- [ ] CI/Build/Infra

## Linked Issue

- Closes: #2654

## What Changed

- Remove the hard aggregate recall requirement for filtered RangeSearch.
- Keep the existing diagnostic warning when aggregate recall is below the expected baseline.
- Preserve hard assertions for KNN recall, RangeSearch API success, and returned-ID filter correctness.

The hard gate reused a KNN recall target for an independent approximate or quantized
RangeSearch candidate path. Because the radius is derived from exact FP32 ground truth,
boundary quantization error can cause nondeterministic misses that are unrelated to the
change under test.

## Test Evidence

- [ ] `make fmt`
- [ ] `make lint`
- [ ] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [x] Other (describe below)

Test details:

```text
/opt/homebrew/opt/llvm@15/bin/clang-format --dry-run --Werror \
  tests/test_index/test_index_search.cpp
git diff --check
cmake --build build --target functests --parallel 6
./build/tests/functests -d yes "(PR) BruteForce Add Test" --allow-running-no-tests
  All tests passed (4063 assertions in 1 test case)
./build/tests/functests -d yes "Pyramid Build & ContinueAdd Test" --allow-running-no-tests
  All tests passed (71684 assertions in 1 test case)
```

The Pyramid case retained diagnostic filtered RangeSearch warnings for observed aggregate
recall values between 73.33 and 78.56.

## Compatibility Impact

- API/ABI compatibility: none
- Behavior changes: low aggregate filtered RangeSearch recall remains a warning but no longer fails the test

## Performance and Concurrency Impact

- Performance impact: none
- Concurrency/thread-safety impact: none

## Documentation Impact

- [x] No docs update needed
- [ ] Updated docs:
  - [ ] `README.md`
  - [ ] `DEVELOPMENT.md`
  - [ ] `CONTRIBUTING.md`
  - [ ] Other

## Risk and Rollback

- Risk level: low
- Rollback plan: restore the hard requirement after a deterministic, RangeSearch-specific threshold is calibrated

## Checklist

- [x] I have linked the relevant issue
- [x] I have added/updated tests for new behavior or bug fixes
- [x] I have considered API compatibility impact
- [x] I have updated docs if behavior/workflow changed
- [x] My commit messages follow project conventions
