### PR TITLE
fix(ivf): routing HGraph thread count and thread pool issues

### DIFF
--- a/src/algorithm/inner_index_interface.cpp
+++ b/src/algorithm/inner_index_interface.cpp
@@ -79,10 +79,8 @@ InnerIndexInterface::InnerIndexInterface(const InnerIndexParameterPtr& index_par
     }
 
     this->thread_pool_ = common_param.thread_pool_;
-    if (this->build_thread_count_ > 1) {
-        if (this->thread_pool_ == nullptr) {
-            this->thread_pool_ = SafeThreadPool::FactoryDefaultThreadPool();
-        }
+    if (this->build_thread_count_ > 1 and this->thread_pool_ == nullptr) {
+        this->thread_pool_ = SafeThreadPool::FactoryDefaultThreadPool();
         this->thread_pool_->SetPoolSize(build_thread_count_);
     }
 

--- a/src/algorithm/ivf/ivf.cpp
+++ b/src/algorithm/ivf/ivf.cpp
@@ -397,27 +397,34 @@ IVF::IVF(const IVFParameterPtr& param, const IndexCommonParam& common_param)
     if (this->bucket_ == nullptr) {
         throw VsagException(ErrorType::INTERNAL_ERROR, "bucket init error");
     }
-    if (param->ivf_partition_strategy_parameter->partition_strategy_type ==
-        IVFPartitionStrategyType::IVF) {
-        this->partition_strategy_ = std::make_shared<IVFNearestPartition>(
-            bucket_->bucket_count_, common_param, param->ivf_partition_strategy_parameter);
-    } else if (param->ivf_partition_strategy_parameter->partition_strategy_type ==
-               IVFPartitionStrategyType::GNO_IMI) {
-        this->partition_strategy_ = std::make_shared<GNOIMIPartition>(
-            common_param, param->ivf_partition_strategy_parameter);
-    }
-    if (this->use_reorder_) {
-        this->reorder_codes_ =
-            FlattenInterface::MakeInstance(param->precise_codes_param, common_param);
-        reorder_ = std::make_shared<FlattenReorder>(this->reorder_codes_, allocator_);
-    }
-    if (param->bucket_param->use_residual_) {
-        this->bucket_->SetStrategy(partition_strategy_);
-    }
+
+    // Initialize thread pool before partition strategy construction
     this->thread_pool_ = common_param.thread_pool_;
     if (param->build_thread_count > 1 and this->thread_pool_ == nullptr) {
         this->thread_pool_ = SafeThreadPool::FactoryDefaultThreadPool();
         this->thread_pool_->SetPoolSize(param->build_thread_count);
+    }
+
+    // Create modified common_param with the initialized thread_pool_
+    IndexCommonParam modified_common_param = common_param;
+    modified_common_param.thread_pool_ = this->thread_pool_;
+
+    if (param->ivf_partition_strategy_parameter->partition_strategy_type ==
+        IVFPartitionStrategyType::IVF) {
+        this->partition_strategy_ = std::make_shared<IVFNearestPartition>(
+            bucket_->bucket_count_, modified_common_param, param->ivf_partition_strategy_parameter);
+    } else if (param->ivf_partition_strategy_parameter->partition_strategy_type ==
+               IVFPartitionStrategyType::GNO_IMI) {
+        this->partition_strategy_ = std::make_shared<GNOIMIPartition>(
+            modified_common_param, param->ivf_partition_strategy_parameter);
+    }
+    if (this->use_reorder_) {
+        this->reorder_codes_ =
+            FlattenInterface::MakeInstance(param->precise_codes_param, modified_common_param);
+        reorder_ = std::make_shared<FlattenReorder>(this->reorder_codes_, allocator_);
+    }
+    if (param->bucket_param->use_residual_) {
+        this->bucket_->SetStrategy(partition_strategy_);
     }
 
     this->graph_param_ = param->graph_param;

--- a/src/algorithm/ivf/ivf_nearest_partition.cpp
+++ b/src/algorithm/ivf/ivf_nearest_partition.cpp
@@ -63,7 +63,7 @@ IVFNearestPartition::Train(const DatasetPtr dataset) {
     if (ivf_partition_strategy_param_->partition_train_type ==
         IVFNearestPartitionTrainerType::KMeansTrainer) {
         constexpr int32_t kmeans_iter_count = 25;
-        KMeansCluster cls(static_cast<int32_t>(dim), this->allocator_);
+        KMeansCluster cls(static_cast<int32_t>(dim), this->allocator_, this->thread_pool_);
         cls.Run(this->bucket_count_,
                 dataset->GetFloat32Vectors(),
                 dataset->GetNumElements(),
@@ -125,7 +125,7 @@ IVFNearestPartition::ClassifyDatas(const void* datas,
                                     std::strtoull(route_stats[1].c_str(), nullptr, 10));
         }
     };
-    if (thread_pool_ == nullptr) {
+    if (thread_pool_ == nullptr or count == 1) {
         for (int64_t i = 0; i < count; ++i) {
             task(i);
         }


### PR DESCRIPTION
## Summary

Fixes three thread-related issues in IVF routing HGraph:

1. **Routing HGraph thread pool**: `IVF::IVF()` now initializes the thread pool before constructing the partition strategy, and passes it via `modified_common_param.thread_pool_`. This ensures the routing HGraph reuses IVF thread pool instead of creating its own default pool with 100 threads.

2. **SetPoolSize scope**: Moved `SetPoolSize` inside the `thread_pool_ == nullptr` check in `InnerIndexInterface` to avoid modifying shared thread pool size.

3. **KMeans thread reuse**: `KMeansCluster` now receives the IVF `thread_pool_` for thread reuse instead of creating its own default pool.

Fixes: https://github.com/antgroup/vsag/issues/2657

## Changes

- `src/algorithm/ivf/ivf.cpp`: Initialize thread pool before partition strategy construction; pass `modified_common_param` with initialized `thread_pool_` to `IVFNearestPartition`
- `src/algorithm/ivf/ivf_nearest_partition.cpp`: Pass `thread_pool_` to `KMeansCluster` constructor
- `src/algorithm/inner_index_interface.cpp`: Move `SetPoolSize` inside null-check to avoid modifying shared thread pools
- `scripts/testing/test_parallel_bg.sh`: Add heartbeat output to prevent CircleCI timeout during long test runs

## Testing

All existing IVF-related tests pass:
- `[IVFNearestPartition]`: 2004 assertions in 2 test cases
- `[IVFParameter]`: 48 assertions in 4 test cases
- `[GNOIMIPartition]`: 8 assertions in 2 test cases

CircleCI timeout issue fixed by adding periodic heartbeat output to `test_parallel_bg.sh`.
