### PR TITLE
fix(ivf): expose routing HGraph parameters

### DIFF
--- a/docs/docs/en/src/indexes/ivf.md
+++ b/docs/docs/en/src/indexes/ivf.md
@@ -76,6 +76,8 @@ Build-time parameters live under `index_param`. See
 | `first_order_buckets_count` | int | `10` | First-level count (effective for `gno_imi`) |
 | `second_order_buckets_count` | int | `10` | Second-level count (effective for `gno_imi`) |
 | `ivf_train_type` | string | `"kmeans"` | Centroid training: `kmeans` or `random` |
+| `route_max_degree` | int | `64` | Routing HGraph maximum degree (effective for `ivf`) |
+| `route_ef_construction` | int | `300` | Routing HGraph construction search breadth (effective for `ivf`) |
 | `base_quantization_type` | string | `"fp32"` | `fp32`, `fp16`, `bf16`, `sq8`, `sq4`, `sq8_uniform`, `sq4_uniform`, `pq`, `pqfs`, `rabitq` — see the [Quantization chapter](../quantization/README.md) for per-quantizer details |
 | `base_pq_dim` | int | `1` | PQ subspaces (required with `pq` / `pqfs`) |
 | `rabitq_pca_dim` | int | `0` | Optional PCA preprocessing dimension for `base_quantization_type: "rabitq"` |

--- a/docs/docs/zh/src/indexes/ivf.md
+++ b/docs/docs/zh/src/indexes/ivf.md
@@ -70,6 +70,8 @@ auto result = index->KnnSearch(
 | `first_order_buckets_count` | int | `10` | 第一级桶数（`gno_imi` 策略下生效） |
 | `second_order_buckets_count` | int | `10` | 第二级桶数（`gno_imi` 策略下生效） |
 | `ivf_train_type` | string | `"kmeans"` | 中心训练方式：`kmeans` 或 `random` |
+| `route_max_degree` | int | `64` | 路由 HGraph 的最大度数（`ivf` 策略下生效） |
+| `route_ef_construction` | int | `300` | 路由 HGraph 的构建搜索宽度（`ivf` 策略下生效） |
 | `base_quantization_type` | string | `"fp32"` | `fp32`、`fp16`、`bf16`、`sq8`、`sq4`、`sq8_uniform`、`sq4_uniform`、`pq`、`pqfs`、`rabitq` —— 各量化器细节见[量化章节](../quantization/README.md) |
 | `base_pq_dim` | int | `1` | PQ 子空间数（`pq` / `pqfs` 时必填） |
 | `rabitq_pca_dim` | int | `0` | `base_quantization_type: "rabitq"` 时可选的 PCA 预处理维度 |

--- a/src/algorithm/ivf/ivf_nearest_partition.cpp
+++ b/src/algorithm/ivf/ivf_nearest_partition.cpp
@@ -161,8 +161,8 @@ IVFNearestPartition::factory_router_index(const IndexCommonParam& common_param) 
     ParamPtr param_ptr;
     JsonType hgraph_json;
     hgraph_json["base_quantization_type"].SetString("fp32");
-    hgraph_json["max_degree"].SetInt(64);
-    hgraph_json["ef_construction"].SetInt(300);
+    hgraph_json["max_degree"].SetInt(ivf_partition_strategy_param_->route_max_degree);
+    hgraph_json["ef_construction"].SetInt(ivf_partition_strategy_param_->route_ef_construction);
 
     param_ptr = HGraph::CheckAndMappingExternalParam(hgraph_json, common_param);
     this->route_index_ptr_ = std::make_shared<HGraph>(param_ptr, common_param);

--- a/src/algorithm/ivf/ivf_partition_strategy_parameter.cpp
+++ b/src/algorithm/ivf/ivf_partition_strategy_parameter.cpp
@@ -42,13 +42,17 @@ IVFPartitionStrategyParameters::FromJson(const JsonType& json) {
         this->partition_strategy_type = IVFPartitionStrategyType::GNO_IMI;
     }
     if (json.Contains(IVF_ROUTE_MAX_DEGREE_KEY)) {
-        this->route_max_degree = json[IVF_ROUTE_MAX_DEGREE_KEY].GetInt();
+        this->route_max_degree = static_cast<int32_t>(json[IVF_ROUTE_MAX_DEGREE_KEY].GetInt());
         CHECK_ARGUMENT(this->route_max_degree > 0, "route_max_degree must be positive");
     }
     if (json.Contains(IVF_ROUTE_EF_CONSTRUCTION_KEY)) {
-        this->route_ef_construction = json[IVF_ROUTE_EF_CONSTRUCTION_KEY].GetInt();
+        this->route_ef_construction =
+            static_cast<int32_t>(json[IVF_ROUTE_EF_CONSTRUCTION_KEY].GetInt());
         CHECK_ARGUMENT(this->route_ef_construction > 0, "route_ef_construction must be positive");
     }
+    CHECK_ARGUMENT(this->route_max_degree >= 4, "route_max_degree must be at least 4");
+    CHECK_ARGUMENT(this->route_ef_construction >= this->route_max_degree,
+                   "route_ef_construction must be no less than route_max_degree");
 
     this->gnoimi_param = std::make_shared<GNOIMIParameter>();
     if (this->partition_strategy_type == IVFPartitionStrategyType::GNO_IMI) {

--- a/src/algorithm/ivf/ivf_partition_strategy_parameter.cpp
+++ b/src/algorithm/ivf/ivf_partition_strategy_parameter.cpp
@@ -41,6 +41,14 @@ IVFPartitionStrategyParameters::FromJson(const JsonType& json) {
                IVF_PARTITION_STRATEGY_TYPE_GNO_IMI) {
         this->partition_strategy_type = IVFPartitionStrategyType::GNO_IMI;
     }
+    if (json.Contains(IVF_ROUTE_MAX_DEGREE_KEY)) {
+        this->route_max_degree = json[IVF_ROUTE_MAX_DEGREE_KEY].GetInt();
+        CHECK_ARGUMENT(this->route_max_degree > 0, "route_max_degree must be positive");
+    }
+    if (json.Contains(IVF_ROUTE_EF_CONSTRUCTION_KEY)) {
+        this->route_ef_construction = json[IVF_ROUTE_EF_CONSTRUCTION_KEY].GetInt();
+        CHECK_ARGUMENT(this->route_ef_construction > 0, "route_ef_construction must be positive");
+    }
 
     this->gnoimi_param = std::make_shared<GNOIMIParameter>();
     if (this->partition_strategy_type == IVFPartitionStrategyType::GNO_IMI) {
@@ -67,6 +75,8 @@ IVFPartitionStrategyParameters::ToJson() const {
     } else if (this->partition_strategy_type == IVFPartitionStrategyType::GNO_IMI) {
         json[IVF_PARTITION_STRATEGY_TYPE_KEY].SetString(IVF_PARTITION_STRATEGY_TYPE_GNO_IMI);
     }
+    json[IVF_ROUTE_MAX_DEGREE_KEY].SetInt(this->route_max_degree);
+    json[IVF_ROUTE_EF_CONSTRUCTION_KEY].SetInt(this->route_ef_construction);
     if (this->partition_strategy_type == IVFPartitionStrategyType::GNO_IMI) {
         json[IVF_PARTITION_STRATEGY_TYPE_GNO_IMI].SetJson(this->gnoimi_param->ToJson());
     }
@@ -77,6 +87,8 @@ bool
 IVFPartitionStrategyParameters::CheckCompatibility(const ParamPtr& other) const {
     PARAM_CAST_OR_RETURN(IVFPartitionStrategyParameters, p, other);
     CHECK_FIELD_EQ(*this, *p, partition_strategy_type);
+    CHECK_FIELD_EQ(*this, *p, route_max_degree);
+    CHECK_FIELD_EQ(*this, *p, route_ef_construction);
     CHECK_SUB_PARAM(*this, *p, gnoimi_param);
     return true;
 }

--- a/src/algorithm/ivf/ivf_partition_strategy_parameter.h
+++ b/src/algorithm/ivf/ivf_partition_strategy_parameter.h
@@ -51,6 +51,8 @@ public:
     IVFNearestPartitionTrainerType partition_train_type{
         IVFNearestPartitionTrainerType::KMeansTrainer};
     IVFPartitionStrategyType partition_strategy_type{IVFPartitionStrategyType::IVF};
+    int32_t route_max_degree{64};
+    int32_t route_ef_construction{300};
     GNOIMIParameterPtr gnoimi_param{nullptr};
 };
 

--- a/src/algorithm/ivf/ivf_partition_strategy_parameter_test.cpp
+++ b/src/algorithm/ivf/ivf_partition_strategy_parameter_test.cpp
@@ -87,4 +87,17 @@ TEST_CASE("IVF Partition Strategy Routing Parameters", "[ut][IVFPartitionStrateg
         "ivf_train_type": "kmeans",
         "route_ef_construction": 0
     })"));
+    REQUIRE_THROWS(param->FromString(R"(
+    {
+        "partition_strategy_type": "ivf",
+        "ivf_train_type": "kmeans",
+        "route_max_degree": 3
+    })"));
+    REQUIRE_THROWS(param->FromString(R"(
+    {
+        "partition_strategy_type": "ivf",
+        "ivf_train_type": "kmeans",
+        "route_max_degree": 512,
+        "route_ef_construction": 300
+    })"));
 }

--- a/src/algorithm/ivf/ivf_partition_strategy_parameter_test.cpp
+++ b/src/algorithm/ivf/ivf_partition_strategy_parameter_test.cpp
@@ -33,6 +33,8 @@ TEST_CASE("IVF Partition Strategy Parameters Test", "[ut][IVFPartitionStrategyPa
     REQUIRE(param->partition_train_type == vsag::IVFNearestPartitionTrainerType::RandomTrainer);
     REQUIRE(param->gnoimi_param->first_order_buckets_count == 200);
     REQUIRE(param->gnoimi_param->second_order_buckets_count == 50);
+    REQUIRE(param->route_max_degree == 64);
+    REQUIRE(param->route_ef_construction == 300);
 
     vsag::ParameterTest::TestToJson(param);
 }
@@ -53,4 +55,36 @@ TEST_CASE("IVF Partition Strategy Parameters CheckCompatibility",
     REQUIRE(param->CheckCompatibility(param));
     auto other_type_param = std::make_shared<vsag::EmptyParameter>();
     REQUIRE_FALSE(param->CheckCompatibility(other_type_param));
+}
+
+TEST_CASE("IVF Partition Strategy Routing Parameters", "[ut][IVFPartitionStrategyParameters]") {
+    auto param = std::make_shared<vsag::IVFPartitionStrategyParameters>();
+    param->FromString(R"(
+    {
+        "partition_strategy_type": "ivf",
+        "ivf_train_type": "kmeans",
+        "route_max_degree": 128,
+        "route_ef_construction": 512
+    })");
+
+    REQUIRE(param->route_max_degree == 128);
+    REQUIRE(param->route_ef_construction == 512);
+    vsag::ParameterTest::TestToJson(param);
+
+    auto incompatible = std::make_shared<vsag::IVFPartitionStrategyParameters>(*param);
+    incompatible->route_max_degree = 64;
+    REQUIRE_FALSE(param->CheckCompatibility(incompatible));
+
+    REQUIRE_THROWS(param->FromString(R"(
+    {
+        "partition_strategy_type": "ivf",
+        "ivf_train_type": "kmeans",
+        "route_max_degree": 0
+    })"));
+    REQUIRE_THROWS(param->FromString(R"(
+    {
+        "partition_strategy_type": "ivf",
+        "ivf_train_type": "kmeans",
+        "route_ef_construction": 0
+    })"));
 }

--- a/src/inner_string_params.h
+++ b/src/inner_string_params.h
@@ -167,6 +167,8 @@ const char* const IVF_PARTITION_STRATEGY_PARAMS_KEY = "partition_strategy";
 const char* const IVF_PARTITION_STRATEGY_TYPE_KEY = "partition_strategy_type";
 const char* const IVF_PARTITION_STRATEGY_TYPE_NEAREST = "ivf";
 const char* const IVF_PARTITION_STRATEGY_TYPE_GNO_IMI = "gno_imi";
+const char* const IVF_ROUTE_MAX_DEGREE_KEY = "route_max_degree";
+const char* const IVF_ROUTE_EF_CONSTRUCTION_KEY = "route_ef_construction";
 
 const char* const GNO_IMI_FIRST_ORDER_BUCKETS_COUNT_KEY = "first_order_buckets_count";
 const char* const GNO_IMI_SECOND_ORDER_BUCKETS_COUNT_KEY = "second_order_buckets_count";
@@ -287,6 +289,8 @@ const std::unordered_map<std::string, std::string> DEFAULT_MAP = {
     {"IVF_PARTITION_STRATEGY_PARAMS_KEY", IVF_PARTITION_STRATEGY_PARAMS_KEY},
     {"IVF_PARTITION_STRATEGY_TYPE_KEY", IVF_PARTITION_STRATEGY_TYPE_KEY},
     {"IVF_PARTITION_STRATEGY_TYPE_NEAREST", IVF_PARTITION_STRATEGY_TYPE_NEAREST},
+    {"IVF_ROUTE_MAX_DEGREE_KEY", IVF_ROUTE_MAX_DEGREE_KEY},
+    {"IVF_ROUTE_EF_CONSTRUCTION_KEY", IVF_ROUTE_EF_CONSTRUCTION_KEY},
     {"IVF_TRAIN_TYPE_KMEANS", IVF_TRAIN_TYPE_KMEANS},
     {"BUILD_THREAD_COUNT_KEY", BUILD_THREAD_COUNT_KEY},
     {"LABEL_REMAP_TYPE_KEY", LABEL_REMAP_TYPE_KEY},


### PR DESCRIPTION
## Summary
- expose IVF routing HGraph maximum degree and construction breadth as partition strategy parameters
- preserve the existing 64/300 defaults and validate positive values
- document the parameters and add serialization, compatibility, and validation coverage

## Testing
- `make fmt`
- `git diff --check`
- `make debug EXTRA_DEFINED="-DFETCHCONTENT_FULLY_DISCONNECTED=ON"` *(blocked: the configured Boost mirror returns HTTP 403; no cached Boost source is available on the remote host)*

Fixes: #2659