### PR TITLE
feat(pyramid): support path-aware AnalyzeIndexBySearch

### DIFF
--- a/docs/docs/en/src/indexes/pyramid.md
+++ b/docs/docs/en/src/indexes/pyramid.md
@@ -303,8 +303,12 @@ If you don't need path-based scoping, [HGraph](hgraph.md) is simpler and general
 faster.
 
 Use [Index Analysis](../resources/analyze_index.md) to inspect Pyramid tree structure,
-per-subindex quality, sampled base recall, and duplicate ratios reported by `GetStats()`. Pyramid
-does not currently expose query-driven metrics through `AnalyzeIndexBySearch`.
+per-subindex quality, sampled base recall, and duplicate ratios reported by `GetStats()`.
+`AnalyzeIndexBySearch` also reports path-scoped query recall, distance, latency, and, when reorder
+is enabled, quantization metrics. Its query dataset must carry the same default or named-hierarchy
+paths required by `KnnSearch`; when paths are required or supplied for a batched dataset, provide
+one path per query. The `analyze_index` tool cannot currently load hierarchy paths from its dense
+query file, so use the C++ API for path-scoped dynamic analysis.
 
 ## Mark remove
 

--- a/docs/docs/en/src/resources/analyze_index.md
+++ b/docs/docs/en/src/resources/analyze_index.md
@@ -17,7 +17,7 @@ AnalyzeIndexBySearch(const SearchRequest& request);
 
 - **Input**: a `SearchRequest` (query dataset + `topk` + search parameter JSON).
 - **Output**: a JSON-formatted string containing dynamic, query-driven metrics.
-- **Supported indexes**: currently `HGraph`, `IVF`, and `SINDI`. Indexes that do not
+- **Supported indexes**: currently `HGraph`, `IVF`, `Pyramid`, and `SINDI`. Indexes that do not
   implement this API will throw an exception when called.
 
 It is complementary to `Index::GetStats()`, which reports static structural properties of the
@@ -25,9 +25,15 @@ index without needing query data. For graph-based indexes, additional graph-heal
 as degree distribution, entry-point quality, sub-index recall and low-recall hot-spots are
 exposed through `GetStats()` rather than through `AnalyzeIndexBySearch`.
 
-Pyramid exposes its analyzer only through `GetStats()`. It does not currently override
-`AnalyzeIndexBySearch`, so calling that API—or using `analyze_index --query_path` with a Pyramid
-index—throws `UNSUPPORTED_INDEX_OPERATION`.
+Pyramid query analysis follows the same path-scoping rules as `KnnSearch`. For the default
+hierarchy, attach one path per query with `Dataset::Paths`. For a named hierarchy, attach paths
+with `Dataset::Paths(hierarchy_name, paths)` and select that hierarchy in the Pyramid search
+parameters. A path is required when the selected hierarchy's root is `NO_INDEX`. Batched query
+datasets must provide a corresponding path for every query when paths are required or supplied.
+Pyramid calculates ground truth only from vectors eligible for each query's hierarchy and path,
+excluding mark-removed vectors. Pyramid query analysis currently supports KNN requests only and
+uses `query_`, `topk_`, and `params_str_` from `SearchRequest`; filtered and iterator requests are
+not supported. Run analysis against a stable index without concurrent add or remove operations.
 
 ### Static metrics from `GetStats()`
 
@@ -103,6 +109,16 @@ SINDI `base_path` through the analyze parameters or the command-line option desc
 | `quantization_bias_ratio_query` | Quantization bias observed during query search |
 | `quantization_inversion_count_rate_query` | Query-time ordering errors introduced by quantization |
 
+#### Pyramid metrics
+
+| Metric | Meaning |
+| --- | --- |
+| `recall_query` | Recall against exact ground truth within each query's selected hierarchy and path |
+| `avg_distance_query` | Average distance of the path-scoped exact ground-truth neighbors |
+| `time_cost_query` | Average per-query latency in milliseconds |
+| `quantization_error_query` | Query-time distance error introduced by base quantization; emitted when reorder is enabled |
+| `quantization_inversion_ratio_query` | Query-time ordering inversion ratio introduced by base quantization; emitted when reorder is enabled |
+
 #### SINDI metrics
 
 | Metric | Meaning |
@@ -137,6 +153,9 @@ Quantization-related fields differ by index type — they are not unified across
 | `HGraph` | `quantization_inversion_count_rate_query` | Quantization-induced ordering errors during search |
 | `IVF` | `quantization_bias_ratio` | Quantization bias observed during search (only when `use_reorder_` is enabled) |
 | `IVF` | `quantization_inversion_count_rate` | Quantization-induced ordering errors during search (only when `use_reorder_` is enabled) |
+| `Pyramid` | `quantization_error_query` | Quantization distance error during search (only when reorder is enabled) |
+| `Pyramid` | `quantization_inversion_ratio_query` | Quantization-induced ordering inversions during search (only when reorder is enabled) |
+
 For static structure and health information, including degree distributions, entry-point
 analysis, and Pyramid subindex quality, use the `GetStats()` JSON.
 
@@ -166,7 +185,7 @@ cmake --build build-release -j
 | --- | --- | --- | --- |
 | `--index_path` | `-i` | **Yes** | Path to the serialized VSAG index file. |
 | `--build_parameter` | `-bp` | No | Build parameters (JSON) used when reloading the index. Defaults to the parameters embedded in the index file. |
-| `--query_path` | `-qp` | No | Binary query dataset path. If omitted, only static analysis is performed. |
+| `--query_path` | `-qp` | No | Binary query vector dataset path. This is not Pyramid hierarchy-path metadata. If omitted, only static analysis is performed. |
 | `--query_data_type` | | No | Query dataset type: `auto`, `dense`, or `sparse`. `auto` uses sparse loading for SINDI. |
 | `--base_path` | | No | Optional sparse CSR base dataset for SINDI analysis and ground-truth generation. |
 | `--groundtruth_path` | | No | Optional SINDI `.dev.gt` ground-truth file. If present, it is reused. |
@@ -176,6 +195,12 @@ cmake --build build-release -j
 
 The query file format is the simple binary `(uint32 rows, uint32 cols, float32 data...)` layout
 consumed by `load_query()` in `tools/analyze_index/analyze_index.cpp`.
+
+The dense query format contains vectors only. The tool does not currently provide a way to attach
+default or named Pyramid hierarchy paths to the loaded `Dataset`. Therefore it cannot express
+path-scoped Pyramid queries or run dynamic analysis when the selected hierarchy's root is
+`NO_INDEX`. Static Pyramid analysis through `GetStats()` remains available. For path-scoped
+dynamic analysis, call the C++ API and attach the paths to the query dataset.
 
 For SINDI, query and base datasets use CSR sparse binary layout:
 `int64 nrow, int64 ncol, int64 nnz`, followed by `int64 indptr[nrow + 1]`,

--- a/docs/docs/zh/src/indexes/pyramid.md
+++ b/docs/docs/zh/src/indexes/pyramid.md
@@ -288,8 +288,11 @@ new_index->Deserialize(binary_set);
 如果不需要按路径限定查询范围，[HGraph](hgraph.md) 更简洁，性能通常也更高。
 
 可以通过[索引分析](../resources/analyze_index.md)检查 Pyramid 的树结构、子索引质量、
-`GetStats()` 输出的 base 采样召回率和重复比例。Pyramid 目前不通过
-`AnalyzeIndexBySearch` 提供查询驱动指标。
+`GetStats()` 输出的 base 采样召回率和重复比例。`AnalyzeIndexBySearch` 还会输出按路径限定的
+query 召回率、距离、耗时，以及开启 reorder 时的量化指标。query 数据集必须包含与
+`KnnSearch` 相同的默认或命名 hierarchy 路径；批量数据集在需要或提供路径时，应为每条 query
+提供一条路径。`analyze_index` 工具当前无法从 dense query 文件加载 hierarchy 路径，因此
+按路径执行动态分析时请使用 C++ 接口。
 
 ## 标记删除
 

--- a/docs/docs/zh/src/resources/analyze_index.md
+++ b/docs/docs/zh/src/resources/analyze_index.md
@@ -16,16 +16,21 @@ AnalyzeIndexBySearch(const SearchRequest& request);
 
 - **输入**：`SearchRequest`（查询数据集 + `topk` + 搜索参数 JSON）。
 - **输出**：JSON 字符串，包含基于查询的动态指标。
-- **支持的索引类型**：当前支持 `HGraph`、`IVF` 与 `SINDI`。未实现该接口的
+- **支持的索引类型**：当前支持 `HGraph`、`IVF`、`Pyramid` 与 `SINDI`。未实现该接口的
   索引在调用时会抛出异常。
 
 该接口与 `Index::GetStats()` 互为补充：后者无需查询数据，只输出索引的静态结构指标。
 对于基于图的索引，度分布、入口点质量、子索引召回率以及低召回热点节点等图健康度信息，
 通过 `GetStats()` 而非 `AnalyzeIndexBySearch` 输出。
 
-Pyramid 只通过 `GetStats()` 暴露其 analyzer，目前没有覆写
-`AnalyzeIndexBySearch`。因此对 Pyramid 索引调用该接口，或使用
-`analyze_index --query_path`，都会抛出 `UNSUPPORTED_INDEX_OPERATION`。
+Pyramid 的查询分析遵循与 `KnnSearch` 相同的路径限定语义。对于默认 hierarchy，
+使用 `Dataset::Paths` 为每条 query 设置路径；对于命名 hierarchy，使用
+`Dataset::Paths(hierarchy_name, paths)` 设置路径，并在 Pyramid 搜索参数中选择该
+hierarchy。当选中 hierarchy 的根节点为 `NO_INDEX` 时必须提供路径。批量 query
+数据集在需要或提供路径时，必须为每条 query 提供对应路径。Pyramid 只在每条 query 的
+hierarchy 和路径所允许的向量中计算真值集，并排除已标记删除的向量。Pyramid 查询分析
+目前只支持 KNN 请求，并使用 `SearchRequest` 中的 `query_`、`topk_` 和 `params_str_`；不支持
+带过滤条件或 iterator 的请求。分析期间应保持索引稳定，不要并发执行 add 或 remove。
 
 ### `GetStats()` 输出的静态指标
 
@@ -101,6 +106,16 @@ Pyramid 只通过 `GetStats()` 暴露其 analyzer，目前没有覆写
 | `quantization_bias_ratio_query` | 查询阶段观察到的量化距离偏差 |
 | `quantization_inversion_count_rate_query` | 查询阶段量化导致的距离顺序倒置率 |
 
+#### Pyramid 指标
+
+| 指标 | 含义 |
+| --- | --- |
+| `recall_query` | 搜索结果相对每条 query 所选 hierarchy 和路径内精确真值集的召回率 |
+| `avg_distance_query` | 路径范围内精确真值邻居的平均距离 |
+| `time_cost_query` | 平均单次查询耗时，单位毫秒 |
+| `quantization_error_query` | base 量化引入的查询距离误差；开启 reorder 时输出 |
+| `quantization_inversion_ratio_query` | base 量化引入的查询顺序倒置率；开启 reorder 时输出 |
+
 #### SINDI 指标
 
 | 指标 | 含义 |
@@ -134,6 +149,9 @@ SINDI 动态召回和距离质量指标需要真值集。可通过 `groundtruth_
 | `HGraph` | `quantization_inversion_count_rate_query` | 搜索阶段量化引起的距离顺序倒置率 |
 | `IVF` | `quantization_bias_ratio` | 搜索阶段观察到的量化偏差（仅在 `use_reorder_` 启用时输出） |
 | `IVF` | `quantization_inversion_count_rate` | 搜索阶段量化引起的距离顺序倒置率（仅在 `use_reorder_` 启用时输出） |
+| `Pyramid` | `quantization_error_query` | 搜索阶段的量化距离误差（仅在开启 reorder 时输出） |
+| `Pyramid` | `quantization_inversion_ratio_query` | 搜索阶段量化引起的顺序倒置率（仅在开启 reorder 时输出） |
+
 静态结构和健康度信息（包括度分布、入口点分析与 Pyramid 子索引质量）请查看
 `GetStats()` 的 JSON 输出。
 
@@ -162,7 +180,7 @@ cmake --build build-release -j
 | --- | --- | --- | --- |
 | `--index_path` | `-i` | **是** | 待分析的 VSAG 索引文件路径。 |
 | `--build_parameter` | `-bp` | 否 | 加载索引时使用的构建参数（JSON）。默认使用索引文件内嵌的原始参数。 |
-| `--query_path` | `-qp` | 否 | 查询数据集路径。如果未提供，则只进行静态分析。 |
+| `--query_path` | `-qp` | 否 | 查询向量数据集的文件路径，不是 Pyramid hierarchy 路径元数据。如果未提供，则只进行静态分析。 |
 | `--query_data_type` | | 否 | 查询数据类型：`auto`、`dense` 或 `sparse`。`auto` 会对 SINDI 使用 sparse 加载。 |
 | `--base_path` | | 否 | SINDI 分析可选的 sparse CSR 原始 base 数据集路径。 |
 | `--groundtruth_path` | | 否 | SINDI 可选的 `.dev.gt` 真值集路径；提供后直接复用。 |
@@ -172,6 +190,11 @@ cmake --build build-release -j
 
 查询文件格式为 `tools/analyze_index/analyze_index.cpp` 中 `load_query()` 所读取的简单二进制
 布局：`(uint32 rows, uint32 cols, float32 data...)`。
+
+该 dense query 格式只包含向量。当前工具无法向加载后的 `Dataset` 附加默认或命名
+Pyramid hierarchy 路径。因此，工具无法表达按路径限定的 Pyramid query，也无法在选中
+hierarchy 的根节点为 `NO_INDEX` 时运行动态分析。通过 `GetStats()` 执行的 Pyramid 静态分析
+仍可正常使用。如需按路径执行动态分析，请调用 C++ 接口并为 query 数据集设置路径。
 
 SINDI 的 query/base 数据使用 CSR sparse 二进制布局：`int64 nrow, int64 ncol, int64 nnz`，
 随后是 `int64 indptr[nrow + 1]`、`int32 indices[nnz]` 和 `float32 data[nnz]`。SINDI 真值集

--- a/include/vsag/search_request.h
+++ b/include/vsag/search_request.h
@@ -42,7 +42,8 @@ public:
     /** 
      * @brief Query dataset containing the vector or vectors to search for
      * @details This DatasetPtr holds the query vector used for similarity search. 
-     *          IVF KNN requests support multiple query vectors; other requests allow one.
+     *          IVF KNN requests and supported AnalyzeIndexBySearch implementations accept
+     *          multiple query vectors; other requests allow one.
      */
     DatasetPtr query_{nullptr};
 

--- a/src/algorithm/pyramid/pyramid.cpp
+++ b/src/algorithm/pyramid/pyramid.cpp
@@ -19,6 +19,7 @@
 
 #include <chrono>
 #include <exception>
+#include <limits>
 
 #include "algorithm/inner_index_interface.h"
 #include "analyzer/analyzer.h"
@@ -1703,6 +1704,25 @@ Pyramid::GetStats() const {
     auto analyzer = CreateAnalyzer(this, analyzer_param);
     JsonType stats = analyzer->GetStats();
     return stats.Dump(4);
+}
+
+std::string
+Pyramid::AnalyzeIndexBySearch(const SearchRequest& request) {
+    CHECK_ARGUMENT(request.mode_ == SearchMode::KNN_SEARCH,
+                   "Pyramid AnalyzeIndexBySearch only supports KNN search");
+    CHECK_ARGUMENT(not request.enable_filter_ && not request.enable_bitset_filter_ &&
+                       not request.enable_attribute_filter_ && not request.enable_iterator_search_,
+                   "Pyramid AnalyzeIndexBySearch does not support filtered or iterator search");
+    CHECK_ARGUMENT(request.topk_ > 0,
+                   fmt::format("topk({}) must be greater than 0", request.topk_));
+    CHECK_ARGUMENT(request.topk_ <= static_cast<int64_t>(std::numeric_limits<uint32_t>::max()),
+                   fmt::format("topk({}) exceeds the supported maximum", request.topk_));
+    CHECK_ARGUMENT(base_codes_->TotalCount() > 0,
+                   "Pyramid AnalyzeIndexBySearch requires a built index");
+    AnalyzerParam analyzer_param(allocator_);
+    analyzer_param.topk = request.topk_;
+    auto analyzer = CreateAnalyzer(this, analyzer_param);
+    return analyzer->AnalyzeIndexBySearch(request).Dump(4);
 }
 
 }  // namespace vsag

--- a/src/algorithm/pyramid/pyramid.cpp
+++ b/src/algorithm/pyramid/pyramid.cpp
@@ -1710,8 +1710,10 @@ std::string
 Pyramid::AnalyzeIndexBySearch(const SearchRequest& request) {
     CHECK_ARGUMENT(request.mode_ == SearchMode::KNN_SEARCH,
                    "Pyramid AnalyzeIndexBySearch only supports KNN search");
-    CHECK_ARGUMENT(not request.enable_filter_ && not request.enable_bitset_filter_ &&
-                       not request.enable_attribute_filter_ && not request.enable_iterator_search_,
+    const bool is_supported_search =
+        not request.enable_filter_ && not request.enable_bitset_filter_ &&
+        not request.enable_attribute_filter_ && not request.enable_iterator_search_;
+    CHECK_ARGUMENT(is_supported_search,
                    "Pyramid AnalyzeIndexBySearch does not support filtered or iterator search");
     CHECK_ARGUMENT(request.topk_ > 0,
                    fmt::format("topk({}) must be greater than 0", request.topk_));

--- a/src/algorithm/pyramid/pyramid.h
+++ b/src/algorithm/pyramid/pyramid.h
@@ -242,6 +242,9 @@ public:
     std::string
     GetStats() const override;
 
+    std::string
+    AnalyzeIndexBySearch(const SearchRequest& request) override;
+
     void
     InitFeatures() override;
 

--- a/src/algorithm/pyramid/pyramid_test.cpp
+++ b/src/algorithm/pyramid/pyramid_test.cpp
@@ -385,8 +385,10 @@ TEST_CASE("Pyramid query analyzer supports a built root without query paths",
     REQUIRE(std::abs(stats["avg_distance_query"].GetFloat()) < 1e-6F);
 }
 
-TEST_CASE("Pyramid query analyzer uses stored raw vectors for ground truth",
+TEST_CASE("Pyramid query analyzer selects an available ground truth code source",
           "[ut][pyramid][raw_vector][analyzer]") {
+    const bool store_raw_vector = GENERATE(false, true);
+    CAPTURE(store_raw_vector);
     constexpr int64_t dim = 4;
     std::array<float, dim* 3> vectors = {
         0.0F, 0.0F, 0.0F, 0.0F, 0.123456F, 0.234567F, 0.345678F, 0.456789F, 1.0F, 1.0F, 1.0F, 1.0F};
@@ -408,9 +410,18 @@ TEST_CASE("Pyramid query analyzer uses stored raw vectors for ground truth",
         "rabitq_bits_per_dim_precise": 5,
         "max_degree": 4,
         "ef_construction": 8,
-        "no_build_levels": [0, 1]
+        "index_min_size": 4,
+        "no_build_levels": [0]
     })");
+    external_param[vsag::STORE_RAW_VECTOR].SetBool(store_raw_vector);
     auto param = vsag::Pyramid::CheckAndMappingExternalParam(external_param, common_param);
+    auto pyramid_param = std::dynamic_pointer_cast<vsag::PyramidParameters>(param);
+    REQUIRE(pyramid_param != nullptr);
+    REQUIRE(pyramid_param->store_raw_vector == store_raw_vector);
+    REQUIRE((pyramid_param->raw_vector_param != nullptr) == store_raw_vector);
+    REQUIRE(pyramid_param->precise_codes_param == nullptr);
+    REQUIRE(pyramid_param->base_codes_param != nullptr);
+    REQUIRE(pyramid_param->base_codes_param->name == vsag::RABITQ_SPLIT_DATA_CELL);
     auto index = std::make_shared<vsag::Pyramid>(param, common_param);
     auto base = vsag::Dataset::Make()
                     ->NumElements(3)
@@ -433,7 +444,12 @@ TEST_CASE("Pyramid query analyzer uses stored raw vectors for ground truth",
     request.params_str_ = R"({"pyramid":{"ef_search":10}})";
 
     auto stats = vsag::JsonType::Parse(index->AnalyzeIndexBySearch(request));
-    REQUIRE(std::abs(stats["avg_distance_query"].GetFloat()) < 1e-12F);
+    REQUIRE(std::abs(stats["recall_query"].GetFloat() - 1.0F) < 1e-6F);
+    const auto avg_distance = stats["avg_distance_query"].GetFloat();
+    REQUIRE(std::isfinite(avg_distance));
+    if (store_raw_vector) {
+        REQUIRE(std::abs(avg_distance) < 1e-12F);
+    }
 }
 
 TEST_CASE("Pyramid promotes flat node at index minimum size", "[ut][pyramid]") {

--- a/src/algorithm/pyramid/pyramid_test.cpp
+++ b/src/algorithm/pyramid/pyramid_test.cpp
@@ -210,6 +210,232 @@ TEST_CASE("Pyramid stats count duplicates within each leaf", "[ut][pyramid][anal
     REQUIRE(std::abs(GetPyramidDuplicateRatio(index) - 2.0F / static_cast<float>(count)) < 1e-6F);
 }
 
+TEST_CASE("Pyramid query analyzer honors paths and removals", "[ut][pyramid][analyzer]") {
+    vsag::IndexCommonParam common_param;
+    common_param.dim_ = PYRAMID_TEST_DIM;
+    common_param.data_type_ = vsag::DataTypes::DATA_TYPE_FLOAT;
+    common_param.metric_ = vsag::MetricType::METRIC_TYPE_L2SQR;
+    common_param.allocator_ = vsag::SafeAllocator::FactoryDefaultAllocator();
+    auto external_param = vsag::JsonType::Parse(R"({
+        "base_quantization_type": "fp32",
+        "max_degree": 4,
+        "ef_construction": 8,
+        "graph_type": "nsw",
+        "no_build_levels": [0, 1, 2],
+        "index_min_size": 28
+    })");
+    auto param = vsag::Pyramid::CheckAndMappingExternalParam(external_param, common_param);
+    auto index = std::make_shared<vsag::Pyramid>(param, common_param);
+
+    std::array<float, PYRAMID_TEST_DIM* 4> vectors = {10.0F,
+                                                      0.0F,
+                                                      0.0F,
+                                                      0.0F,
+                                                      1.0F,
+                                                      0.0F,
+                                                      0.0F,
+                                                      0.0F,
+                                                      0.0F,
+                                                      0.0F,
+                                                      0.0F,
+                                                      0.0F,
+                                                      100.0F,
+                                                      0.0F,
+                                                      0.0F,
+                                                      0.0F};
+    std::array<int64_t, 4> ids = {101, 102, 201, 202};
+    std::array<std::string, 4> paths = {"root/a/leaf", "root/a/leaf", "root/b/leaf", "root/b/leaf"};
+    auto base = vsag::Dataset::Make()
+                    ->NumElements(4)
+                    ->Dim(PYRAMID_TEST_DIM)
+                    ->Float32Vectors(vectors.data())
+                    ->Ids(ids.data())
+                    ->Paths(paths.data())
+                    ->Owner(false);
+    REQUIRE(index->Build(base).empty());
+
+    std::array<float, PYRAMID_TEST_DIM* 2> query_vectors = {
+        0.0F, 0.0F, 0.0F, 0.0F, 100.0F, 0.0F, 0.0F, 0.0F};
+    std::array<std::string, 2> query_paths = {"root/a/leaf", "root/b/leaf"};
+    auto query = vsag::Dataset::Make()
+                     ->NumElements(2)
+                     ->Dim(PYRAMID_TEST_DIM)
+                     ->Float32Vectors(query_vectors.data())
+                     ->Paths(query_paths.data())
+                     ->Owner(false);
+    vsag::SearchRequest request;
+    request.query_ = query;
+    request.topk_ = 1;
+    request.params_str_ = R"({"pyramid":{"ef_search":20}})";
+
+    auto stats = vsag::JsonType::Parse(index->AnalyzeIndexBySearch(request));
+    REQUIRE(std::abs(stats["recall_query"].GetFloat() - 1.0F) < 1e-6F);
+    REQUIRE(std::abs(stats["avg_distance_query"].GetFloat() - 0.5F) < 1e-6F);
+
+    REQUIRE(index->Remove(std::vector<int64_t>{102}, vsag::RemoveMode::MARK_REMOVE) == 1);
+    stats = vsag::JsonType::Parse(index->AnalyzeIndexBySearch(request));
+    REQUIRE(std::abs(stats["recall_query"].GetFloat() - 1.0F) < 1e-6F);
+    REQUIRE(std::abs(stats["avg_distance_query"].GetFloat() - 50.0F) < 1e-6F);
+
+    request.mode_ = vsag::SearchMode::RANGE_SEARCH;
+    REQUIRE_THROWS(index->AnalyzeIndexBySearch(request));
+}
+
+TEST_CASE("Pyramid query analyzer includes graph duplicates in path ground truth",
+          "[ut][pyramid][analyzer]") {
+    vsag::IndexCommonParam common_param;
+    common_param.dim_ = PYRAMID_TEST_DIM;
+    common_param.data_type_ = vsag::DataTypes::DATA_TYPE_FLOAT;
+    common_param.metric_ = vsag::MetricType::METRIC_TYPE_L2SQR;
+    common_param.allocator_ = vsag::SafeAllocator::FactoryDefaultAllocator();
+    auto external_param = vsag::JsonType::Parse(R"({
+        "base_quantization_type": "fp32",
+        "max_degree": 4,
+        "ef_construction": 8,
+        "graph_type": "nsw",
+        "no_build_levels": [0],
+        "index_min_size": 1,
+        "support_duplicate": true
+    })");
+    auto param = vsag::Pyramid::CheckAndMappingExternalParam(external_param, common_param);
+    auto index = std::make_shared<vsag::Pyramid>(param, common_param);
+
+    std::array<float, PYRAMID_TEST_DIM* 4> vectors = {1.0F,
+                                                      2.0F,
+                                                      3.0F,
+                                                      4.0F,
+                                                      1.0F,
+                                                      2.0F,
+                                                      3.0F,
+                                                      4.0F,
+                                                      1.0F,
+                                                      2.0F,
+                                                      3.0F,
+                                                      4.0F,
+                                                      9.0F,
+                                                      8.0F,
+                                                      7.0F,
+                                                      6.0F};
+    std::array<int64_t, 4> ids = {100, 101, 102, 103};
+    std::array<std::string, 4> paths = {"tenant", "tenant", "tenant", "tenant"};
+    auto base = vsag::Dataset::Make()
+                    ->NumElements(4)
+                    ->Dim(PYRAMID_TEST_DIM)
+                    ->Float32Vectors(vectors.data())
+                    ->Ids(ids.data())
+                    ->Paths(paths.data())
+                    ->Owner(false);
+    REQUIRE(index->Build(base).empty());
+    REQUIRE(index->Remove(std::vector<int64_t>{100}, vsag::RemoveMode::MARK_REMOVE) == 1);
+
+    auto query = MakePyramidDataset(vectors.data(), nullptr, paths.data(), 1);
+    vsag::SearchRequest request;
+    request.query_ = query;
+    request.topk_ = 1;
+    request.params_str_ = R"({"pyramid":{"ef_search":10}})";
+
+    auto stats = vsag::JsonType::Parse(index->AnalyzeIndexBySearch(request));
+    REQUIRE(std::abs(stats["recall_query"].GetFloat() - 1.0F) < 1e-6F);
+    REQUIRE(std::abs(stats["avg_distance_query"].GetFloat()) < 1e-6F);
+}
+
+TEST_CASE("Pyramid query analyzer supports a built root without query paths",
+          "[ut][pyramid][analyzer]") {
+    vsag::IndexCommonParam common_param;
+    common_param.dim_ = PYRAMID_TEST_DIM;
+    common_param.data_type_ = vsag::DataTypes::DATA_TYPE_FLOAT;
+    common_param.metric_ = vsag::MetricType::METRIC_TYPE_L2SQR;
+    common_param.allocator_ = vsag::SafeAllocator::FactoryDefaultAllocator();
+    auto external_param = vsag::JsonType::Parse(R"({
+        "base_quantization_type": "fp32",
+        "max_degree": 4,
+        "ef_construction": 8,
+        "graph_type": "odescent",
+        "no_build_levels": [],
+        "index_min_size": 100
+    })");
+    auto param = vsag::Pyramid::CheckAndMappingExternalParam(external_param, common_param);
+    auto index = std::make_shared<vsag::Pyramid>(param, common_param);
+
+    std::array<float, PYRAMID_TEST_DIM* 2> vectors = {
+        0.0F, 0.0F, 0.0F, 0.0F, 10.0F, 0.0F, 0.0F, 0.0F};
+    std::array<int64_t, 2> ids = {100, 101};
+    std::array<std::string, 2> paths = {"", ""};
+    auto base = vsag::Dataset::Make()
+                    ->NumElements(2)
+                    ->Dim(PYRAMID_TEST_DIM)
+                    ->Float32Vectors(vectors.data())
+                    ->Ids(ids.data())
+                    ->Paths(paths.data())
+                    ->Owner(false);
+    REQUIRE(index->Build(base).empty());
+
+    auto query = vsag::Dataset::Make()
+                     ->NumElements(1)
+                     ->Dim(PYRAMID_TEST_DIM)
+                     ->Float32Vectors(vectors.data())
+                     ->Owner(false);
+    vsag::SearchRequest request;
+    request.query_ = query;
+    request.topk_ = 1;
+    request.params_str_ = R"({"pyramid":{"ef_search":10}})";
+
+    auto stats = vsag::JsonType::Parse(index->AnalyzeIndexBySearch(request));
+    REQUIRE(std::abs(stats["recall_query"].GetFloat() - 1.0F) < 1e-6F);
+    REQUIRE(std::abs(stats["avg_distance_query"].GetFloat()) < 1e-6F);
+}
+
+TEST_CASE("Pyramid query analyzer uses stored raw vectors for ground truth",
+          "[ut][pyramid][raw_vector][analyzer]") {
+    constexpr int64_t dim = 4;
+    std::array<float, dim* 3> vectors = {
+        0.0F, 0.0F, 0.0F, 0.0F, 0.123456F, 0.234567F, 0.345678F, 0.456789F, 1.0F, 1.0F, 1.0F, 1.0F};
+    std::array<int64_t, 3> ids = {10, 11, 12};
+    std::array<std::string, 3> paths = {"leaf", "leaf", "leaf"};
+
+    vsag::IndexCommonParam common_param;
+    common_param.dim_ = dim;
+    common_param.data_type_ = vsag::DataTypes::DATA_TYPE_FLOAT;
+    common_param.metric_ = vsag::MetricType::METRIC_TYPE_L2SQR;
+    common_param.allocator_ = vsag::SafeAllocator::FactoryDefaultAllocator();
+    auto external_param = vsag::JsonType::Parse(R"({
+        "base_quantization_type": "tq",
+        "precise_quantization_type": "rabitq",
+        "use_reorder": true,
+        "tq_chain": "mrle, rabitq",
+        "mrle_dim": 2,
+        "rabitq_bits_per_dim_base": 3,
+        "rabitq_bits_per_dim_precise": 5,
+        "max_degree": 4,
+        "ef_construction": 8,
+        "no_build_levels": [0, 1]
+    })");
+    auto param = vsag::Pyramid::CheckAndMappingExternalParam(external_param, common_param);
+    auto index = std::make_shared<vsag::Pyramid>(param, common_param);
+    auto base = vsag::Dataset::Make()
+                    ->NumElements(3)
+                    ->Dim(dim)
+                    ->Float32Vectors(vectors.data())
+                    ->Ids(ids.data())
+                    ->Paths(paths.data())
+                    ->Owner(false);
+    REQUIRE(index->Build(base).empty());
+
+    auto query = vsag::Dataset::Make()
+                     ->NumElements(1)
+                     ->Dim(dim)
+                     ->Float32Vectors(vectors.data() + dim)
+                     ->Paths(paths.data() + 1)
+                     ->Owner(false);
+    vsag::SearchRequest request;
+    request.query_ = query;
+    request.topk_ = 1;
+    request.params_str_ = R"({"pyramid":{"ef_search":10}})";
+
+    auto stats = vsag::JsonType::Parse(index->AnalyzeIndexBySearch(request));
+    REQUIRE(std::abs(stats["avg_distance_query"].GetFloat()) < 1e-12F);
+}
+
 TEST_CASE("Pyramid promotes flat node at index minimum size", "[ut][pyramid]") {
     const bool split_rabitq = GENERATE(false, true);
     const bool build_all_at_once = GENERATE(false, true);

--- a/src/analyzer/pyramid_analyzer.cpp
+++ b/src/analyzer/pyramid_analyzer.cpp
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <limits>
 #include <random>
 
 #include "impl/heap/standard_heap.h"
@@ -99,36 +100,80 @@ PyramidAnalyzer::AnalyzeIndexBySearch(const SearchRequest& request) {
     }
 
     auto query = request.query_;
-    auto query_num = query->GetNumElements();
+    const auto query_num = query->GetNumElements();
     const float* query_vectors = query->GetFloat32Vectors();
-    if (query_vectors == nullptr || query_num == 0) {
+    if (query_num == 0) {
         return stats;
     }
+    CHECK_ARGUMENT(query_num > 0, fmt::format("query num({}) must be positive", query_num));
+    CHECK_ARGUMENT(static_cast<uint64_t>(query_num) <= std::numeric_limits<uint32_t>::max(),
+                   fmt::format("query num({}) exceeds the supported maximum", query_num));
+    CHECK_ARGUMENT(
+        query->GetDim() == dim_,
+        fmt::format("query.dim({}) must be equal to index.dim({})", query->GetDim(), dim_));
+    CHECK_ARGUMENT(query_vectors != nullptr, "query vectors is required");
+    const auto query_count = static_cast<uint32_t>(query_num);
+
+    auto parsed_param = PyramidSearchParameters::FromJson(request.params_str_);
+    CHECK_ARGUMENT(parsed_param.hierarchy_op == PyramidSearchParameters::HierarchyOp::SINGLE,
+                   "multi-hierarchy search (union/intersection) is not yet implemented");
+    const std::string hierarchy_name =
+        parsed_param.hierarchies.empty() ? "" : parsed_param.hierarchies[0];
+    auto h_iter = pyramid_->hierarchies_.find(hierarchy_name);
+    CHECK_ARGUMENT(h_iter != pyramid_->hierarchies_.end(),
+                   fmt::format("unknown hierarchy name: '{}'", hierarchy_name));
+
+    const auto* query_paths = query->GetPaths(hierarchy_name);
+    if (query_paths == nullptr) {
+        query_paths = query->GetPaths();
+    }
+    // NOLINTNEXTLINE(readability-simplify-boolean-expr)
+    CHECK_ARGUMENT(
+        query_paths != nullptr || h_iter->second->root->status_ != IndexNode::Status::NO_INDEX,
+        "query_path is required when level0 is not built");
 
     Vector<InnerIdType> query_ids(allocator_);
-    query_ids.resize(query_num);
+    query_ids.resize(query_count);
     std::iota(query_ids.begin(), query_ids.end(), 0);
 
     Vector<float> query_datas(allocator_);
-    query_datas.resize(static_cast<size_t>(query_num) * dim_);
-    std::memcpy(query_datas.data(), query_vectors, query_num * dim_ * sizeof(float));
+    query_datas.resize(static_cast<uint64_t>(query_count) * dim_);
+    std::memcpy(query_datas.data(),
+                query_vectors,
+                static_cast<uint64_t>(query_count) * dim_ * sizeof(float));
+
+    UnorderedSet<InnerIdType> deleted_ids(allocator_);
+    for (const auto id : pyramid_->label_table_->GetAllDeletedIds()) {
+        deleted_ids.insert(id);
+    }
 
     UnorderedMap<InnerIdType, DistHeapPtr> query_ground_truth(allocator_);
-    calculate_groundtruth(query_datas, query_ids, query_ground_truth, query_num);
+    calculate_groundtruth(query_datas,
+                          query_ids,
+                          query_ground_truth,
+                          query_count,
+                          hierarchy_name,
+                          query_paths,
+                          deleted_ids);
 
     UnorderedMap<InnerIdType, Vector<LabelType>> query_search_result(allocator_);
-    float query_time_ms = calculate_search_result(
-        query_datas, query_ids, query_search_result, request.params_str_, query_num);
+    float query_time_ms = calculate_search_result(query_datas,
+                                                  query_ids,
+                                                  query_search_result,
+                                                  request.params_str_,
+                                                  query_count,
+                                                  hierarchy_name,
+                                                  query_paths);
 
     stats["avg_distance_query"].SetFloat(
         get_avg_distance_from_groundtruth(query_ids, query_ground_truth));
-    stats["recall_query"].SetFloat(
-        get_search_recall(query_num, query_ids, query_ground_truth, query_search_result));
+    stats["recall_query"].SetFloat(get_search_recall(
+        query_count, query_datas, query_ids, query_ground_truth, query_search_result));
     stats["time_cost_query"].SetFloat(query_time_ms);
 
     if (pyramid_->use_reorder_) {
         auto [q_error, q_inversion] =
-            calculate_quantization_result(query_datas, query_ids, query_search_result, query_num);
+            calculate_quantization_result(query_datas, query_ids, query_search_result, query_count);
         stats["quantization_error_query"].SetFloat(q_error);
         stats["quantization_inversion_ratio_query"].SetFloat(q_inversion);
     }
@@ -514,32 +559,38 @@ void
 PyramidAnalyzer::calculate_groundtruth(const Vector<float>& sample_datas,
                                        const Vector<InnerIdType>& sample_ids,
                                        UnorderedMap<InnerIdType, DistHeapPtr>& ground_truth,
-                                       uint32_t sample_size) {
+                                       uint32_t sample_size,
+                                       const std::string& hierarchy_name,
+                                       const std::string* query_paths,
+                                       const UnorderedSet<InnerIdType>& deleted_ids) {
     if (not ground_truth.empty()) {
         return;
     }
 
-    Vector<float> distances_array(this->total_count_, allocator_);
-    Vector<InnerIdType> ids_array(this->total_count_, allocator_);
-    std::iota(ids_array.begin(), ids_array.end(), 0);
-
-    auto codes = pyramid_->has_precise_reorder() ? pyramid_->precise_codes_ : pyramid_->base_codes_;
+    auto codes = pyramid_->raw_vector_ != nullptr
+                     ? pyramid_->raw_vector_
+                     : (pyramid_->use_reorder_ ? pyramid_->precise_codes_ : pyramid_->base_codes_);
 
     for (uint32_t i = 0; i < sample_size; ++i) {
         if (i % 10 == 0) {
             logger::info("[calculate_groundtruth] Processing sample {} of {}", i, sample_size);
         }
 
+        const auto* query_path = query_paths == nullptr ? nullptr : query_paths + i;
+        auto ids_array = collect_search_scope_ids(hierarchy_name, query_path, deleted_ids);
+        Vector<float> distances_array(ids_array.size(), allocator_);
         auto comp = codes->FactoryComputer(sample_datas.data() + static_cast<size_t>(i) * dim_);
-        codes->Query(distances_array.data(), comp, ids_array.data(), this->total_count_);
+        if (not ids_array.empty()) {
+            codes->Query(distances_array.data(), comp, ids_array.data(), ids_array.size());
+        }
 
         DistHeapPtr gt = std::make_shared<StandardHeap<true, false>>(allocator_, -1);
-        for (uint32_t j = 0; j < this->total_count_; ++j) {
+        for (uint64_t j = 0; j < ids_array.size(); ++j) {
             float dist = distances_array[j];
             if (gt->Size() < topk_) {
-                gt->Push({dist, j});
+                gt->Push({dist, ids_array[j]});
             } else if (dist < gt->Top().first) {
-                gt->Push({dist, j});
+                gt->Push({dist, ids_array[j]});
                 gt->Pop();
             }
         }
@@ -547,6 +598,76 @@ PyramidAnalyzer::calculate_groundtruth(const Vector<float>& sample_datas,
     }
 
     logger::info("[calculate_groundtruth] Completed for {} samples", sample_size);
+}
+
+Vector<InnerIdType>
+PyramidAnalyzer::collect_search_scope_ids(const std::string& hierarchy_name,
+                                          const std::string* query_path,
+                                          const UnorderedSet<InnerIdType>& deleted_ids) {
+    Vector<InnerIdType> ids(allocator_);
+    UnorderedSet<InnerIdType> seen_ids(allocator_);
+    const auto& hierarchy = *pyramid_->hierarchies_.at(hierarchy_name);
+
+    if (query_path == nullptr) {
+        collect_searchable_node_ids(hierarchy.root.get(), deleted_ids, seen_ids, ids);
+        return ids;
+    }
+
+    for (const auto& one_path : Pyramid::parse_path(*query_path)) {
+        const IndexNode* node = hierarchy.root.get();
+        for (const auto& item : one_path) {
+            std::shared_lock lock(node->mutex_);
+            auto child = node->children_.find(item);
+            if (child == node->children_.end()) {
+                node = nullptr;
+                break;
+            }
+            node = child->second.get();
+        }
+        if (node != nullptr) {
+            collect_searchable_node_ids(node, deleted_ids, seen_ids, ids);
+        }
+    }
+    return ids;
+}
+
+void
+PyramidAnalyzer::collect_searchable_node_ids(const IndexNode* node,
+                                             const UnorderedSet<InnerIdType>& deleted_ids,
+                                             UnorderedSet<InnerIdType>& seen_ids,
+                                             Vector<InnerIdType>& ids) {
+    if (node == nullptr) {
+        return;
+    }
+
+    std::shared_lock lock(node->mutex_);
+    if (node->status_ != IndexNode::Status::NO_INDEX) {
+        Vector<InnerIdType> node_ids(allocator_);
+        if (node->status_ == IndexNode::Status::FLAT) {
+            node_ids = node->ids_;
+        } else if (node->graph_ != nullptr) {
+            node_ids = node->graph_->GetIds();
+        }
+        for (const auto id : node_ids) {
+            if (deleted_ids.find(id) == deleted_ids.end() && seen_ids.insert(id).second) {
+                ids.push_back(id);
+            }
+            if (node->graph_ == nullptr) {
+                continue;
+            }
+            for (const auto duplicate_id : node->graph_->GetDuplicateIds(id)) {
+                if (deleted_ids.find(duplicate_id) == deleted_ids.end() &&
+                    seen_ids.insert(duplicate_id).second) {
+                    ids.push_back(duplicate_id);
+                }
+            }
+        }
+        return;
+    }
+
+    for (const auto& [key, child] : node->children_) {
+        collect_searchable_node_ids(child.get(), deleted_ids, seen_ids, ids);
+    }
 }
 
 float
@@ -590,6 +711,8 @@ PyramidAnalyzer::calculate_quantization_result(
 
     float total_quantization_error = 0.0F;
     float total_quantization_inversion_count_rate = 0.0F;
+    uint32_t valid_sample_count = 0;
+    uint32_t valid_inversion_sample_count = 0;
 
     for (uint32_t i = 0; i < sample_size; ++i) {
         auto id = sample_ids[i];
@@ -598,30 +721,45 @@ PyramidAnalyzer::calculate_quantization_result(
         }
 
         const auto& result = search_result.at(id);
-        if (result.empty()) {
+        Vector<LabelType> unique_result(allocator_);
+        UnorderedSet<LabelType> seen_labels(allocator_);
+        unique_result.reserve(std::min<uint64_t>(result.size(), topk_));
+        for (const auto label : result) {
+            if (seen_labels.insert(label).second) {
+                unique_result.push_back(label);
+                if (unique_result.size() == topk_) {
+                    break;
+                }
+            }
+        }
+        if (unique_result.empty()) {
             continue;
         }
 
-        auto result_size = std::min(static_cast<uint32_t>(result.size()), topk_);
-        Vector<LabelType> topk_labels(allocator_);
-        topk_labels.assign(result.begin(), result.begin() + result_size);
-
+        auto result_size = static_cast<uint32_t>(unique_result.size());
         auto base_result =
             pyramid_->CalcDistancesById(sample_datas.data() + static_cast<size_t>(i) * dim_,
-                                        topk_labels.data(),
-                                        static_cast<int64_t>(topk_labels.size()),
+                                        unique_result.data(),
+                                        result_size,
                                         false);
-        const auto* base_distance = base_result->GetDistances();
-
         auto precise_result =
             pyramid_->CalcDistancesById(sample_datas.data() + static_cast<size_t>(i) * dim_,
-                                        topk_labels.data(),
-                                        static_cast<int64_t>(topk_labels.size()),
+                                        unique_result.data(),
+                                        result_size,
                                         true);
+        if (base_result == nullptr || precise_result == nullptr) {
+            continue;
+        }
+        const auto* base_distance = base_result->GetDistances();
         const auto* precise_distance = precise_result->GetDistances();
+        if (base_distance == nullptr || precise_distance == nullptr) {
+            continue;
+        }
 
+        float sample_error = 0.0F;
         uint32_t inversion_count = 0;
         for (uint32_t j = 0; j < result_size; ++j) {
+            sample_error += std::abs(base_distance[j] - precise_distance[j]);
             for (uint32_t k = j + 1; k < result_size; ++k) {
                 if ((base_distance[j] - base_distance[k]) *
                         (precise_distance[j] - precise_distance[k]) <
@@ -631,13 +769,25 @@ PyramidAnalyzer::calculate_quantization_result(
             }
         }
 
-        total_quantization_inversion_count_rate +=
-            static_cast<float>(inversion_count) /
-            (static_cast<float>(result_size) * static_cast<float>(result_size - 1) / 2.0F);
+        total_quantization_error += sample_error / static_cast<float>(result_size);
+        if (result_size > 1) {
+            total_quantization_inversion_count_rate +=
+                static_cast<float>(inversion_count) /
+                (static_cast<float>(result_size) * static_cast<float>(result_size - 1) / 2.0F);
+            valid_inversion_sample_count++;
+        }
+        valid_sample_count++;
     }
 
-    return {total_quantization_error / static_cast<float>(sample_size),
-            total_quantization_inversion_count_rate / static_cast<float>(sample_size)};
+    if (valid_sample_count == 0) {
+        return {0.0F, 0.0F};
+    }
+    const float avg_inversion_count_rate =
+        valid_inversion_sample_count == 0 ? 0.0F
+                                          : total_quantization_inversion_count_rate /
+                                                static_cast<float>(valid_inversion_sample_count);
+    return {total_quantization_error / static_cast<float>(valid_sample_count),
+            avg_inversion_count_rate};
 }
 
 float
@@ -646,12 +796,15 @@ PyramidAnalyzer::calculate_search_result(
     const Vector<InnerIdType>& sample_ids,
     UnorderedMap<InnerIdType, Vector<LabelType>>& search_result,
     const std::string& search_param,
-    uint32_t sample_size) {
+    uint32_t sample_size,
+    const std::string& hierarchy_name,
+    const std::string* query_paths) {
     float total_time = 0.0F;
     auto start_time = std::chrono::steady_clock::now();
 
+    const uint32_t progress_interval = std::max<uint32_t>(1, sample_size / 10);
     for (uint32_t i = 0; i < sample_size; ++i) {
-        if (i % 1 == 0) {
+        if (i % progress_interval == 0) {
             auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
                                   std::chrono::steady_clock::now() - start_time)
                                   .count();
@@ -672,6 +825,9 @@ PyramidAnalyzer::calculate_search_result(
         auto query = Dataset::Make();
         query->Dim(dim_)->NumElements(1)->Owner(false)->Float32Vectors(
             sample_datas.data() + static_cast<size_t>(i) * dim_);
+        if (query_paths != nullptr) {
+            query->Paths(hierarchy_name, query_paths + i);
+        }
 
         double single_query_time = 0.0;
         DatasetPtr result = nullptr;
@@ -682,10 +838,13 @@ PyramidAnalyzer::calculate_search_result(
 
         if (result != nullptr) {
             auto result_size = result->GetDim();
-            const auto* ids = result->GetIds();
             Vector<LabelType> result_labels(allocator_);
-            result_labels.resize(result_size);
-            std::memcpy(result_labels.data(), ids, result_size * sizeof(LabelType));
+            if (result_size > 0) {
+                const auto* ids = result->GetIds();
+                CHECK_ARGUMENT(ids != nullptr, "Pyramid search result ids are missing");
+                result_labels.resize(result_size);
+                std::memcpy(result_labels.data(), ids, result_size * sizeof(LabelType));
+            }
             search_result.insert({sample_ids[i], result_labels});
         }
 
@@ -710,6 +869,7 @@ PyramidAnalyzer::calculate_search_result(
 float
 PyramidAnalyzer::get_search_recall(
     uint32_t sample_size,
+    const Vector<float>& sample_datas,
     const Vector<InnerIdType>& sample_ids,
     const UnorderedMap<InnerIdType, DistHeapPtr>& ground_truth,
     const UnorderedMap<InnerIdType, Vector<LabelType>>& search_result) {
@@ -737,9 +897,24 @@ PyramidAnalyzer::get_search_recall(
         }
 
         uint32_t hit_count = 0;
+        UnorderedSet<LabelType> seen_result_labels(allocator_);
+        const float distance_threshold = gt->Top().first;
+        const float tie_tolerance = 1e-6F * std::max(1.0F, std::abs(distance_threshold));
         for (const auto& label : sr) {
-            if (gt_set.find(label) != gt_set.end()) {
+            if (not seen_result_labels.insert(label).second) {
+                continue;
+            }
+            bool is_hit = gt_set.find(label) != gt_set.end();
+            if (not is_hit) {
+                const auto distance = pyramid_->CalcDistanceById(
+                    sample_datas.data() + static_cast<uint64_t>(i) * dim_, label, true);
+                is_hit = distance <= distance_threshold + tie_tolerance;
+            }
+            if (is_hit) {
                 hit_count++;
+                if (hit_count == gt->Size()) {
+                    break;
+                }
             }
         }
 

--- a/src/analyzer/pyramid_analyzer.cpp
+++ b/src/analyzer/pyramid_analyzer.cpp
@@ -567,9 +567,7 @@ PyramidAnalyzer::calculate_groundtruth(const Vector<float>& sample_datas,
         return;
     }
 
-    auto codes = pyramid_->raw_vector_ != nullptr
-                     ? pyramid_->raw_vector_
-                     : (pyramid_->use_reorder_ ? pyramid_->precise_codes_ : pyramid_->base_codes_);
+    auto codes = pyramid_->decodable_codes();
 
     for (uint32_t i = 0; i < sample_size; ++i) {
         if (i % 10 == 0) {

--- a/src/analyzer/pyramid_analyzer.h
+++ b/src/analyzer/pyramid_analyzer.h
@@ -155,7 +155,21 @@ private:
     calculate_groundtruth(const Vector<float>& sample_datas,
                           const Vector<InnerIdType>& sample_ids,
                           UnorderedMap<InnerIdType, DistHeapPtr>& ground_truth,
-                          uint32_t sample_size);
+                          uint32_t sample_size,
+                          const std::string& hierarchy_name,
+                          const std::string* query_paths,
+                          const UnorderedSet<InnerIdType>& deleted_ids);
+
+    Vector<InnerIdType>
+    collect_search_scope_ids(const std::string& hierarchy_name,
+                             const std::string* query_path,
+                             const UnorderedSet<InnerIdType>& deleted_ids);
+
+    void
+    collect_searchable_node_ids(const IndexNode* node,
+                                const UnorderedSet<InnerIdType>& deleted_ids,
+                                UnorderedSet<InnerIdType>& seen_ids,
+                                Vector<InnerIdType>& ids);
 
     float
     get_avg_distance();
@@ -177,10 +191,13 @@ private:
                             const Vector<InnerIdType>& sample_ids,
                             UnorderedMap<InnerIdType, Vector<LabelType>>& search_result,
                             const std::string& search_param,
-                            uint32_t sample_size);
+                            uint32_t sample_size,
+                            const std::string& hierarchy_name,
+                            const std::string* query_paths);
 
     float
     get_search_recall(uint32_t sample_size,
+                      const Vector<float>& sample_datas,
                       const Vector<InnerIdType>& sample_ids,
                       const UnorderedMap<InnerIdType, DistHeapPtr>& ground_truth,
                       const UnorderedMap<InnerIdType, Vector<LabelType>>& search_result);

--- a/tests/test_pyramid.cpp
+++ b/tests/test_pyramid.cpp
@@ -1109,6 +1109,57 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
     }
 }
 
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
+                             "Pyramid AnalyzeIndexBySearch honors paths and removals",
+                             "[ft][pyramid][analyzer]") {
+    PyramidParam pyramid_param;
+    pyramid_param.no_build_levels = {0, 1, 2};
+
+    auto index =
+        TestFactory("pyramid", GeneratePyramidBuildParametersString("l2", 4, pyramid_param), true);
+    auto base = MakeDenseDataset({{{10.0F, 0.0F, 0.0F, 0.0F}},
+                                  {{1.0F, 0.0F, 0.0F, 0.0F}},
+                                  {{0.0F, 0.0F, 0.0F, 0.0F}},
+                                  {{100.0F, 0.0F, 0.0F, 0.0F}}},
+                                 {101, 102, 201, 202},
+                                 {"root/a/leaf", "root/a/leaf", "root/b/leaf", "root/b/leaf"});
+    REQUIRE(index->Build(base).has_value());
+
+    // The first query has an exact match in the other path. A global ground truth would therefore
+    // report only 50% recall for this batch, while path-scoped ground truth reports 100%.
+    auto query = MakeDenseDataset({{{0.0F, 0.0F, 0.0F, 0.0F}}, {{100.0F, 0.0F, 0.0F, 0.0F}}},
+                                  {0, 1},
+                                  {"root/a/leaf", "root/b/leaf"});
+    vsag::SearchRequest request;
+    request.query_ = query;
+    request.topk_ = 1;
+    request.params_str_ = GeneratePyramidSearchParametersString(20);
+
+    const auto analyze = [&]() {
+        const auto stats_string = index->AnalyzeIndexBySearch(request);
+        REQUIRE_FALSE(stats_string.empty());
+        auto stats = nlohmann::json::parse(stats_string);
+        REQUIRE(stats.contains("avg_distance_query"));
+        REQUIRE(stats.contains("recall_query"));
+        REQUIRE(stats.contains("time_cost_query"));
+        return stats;
+    };
+
+    const auto stats_before_remove = analyze();
+    REQUIRE(std::abs(stats_before_remove["recall_query"].get<float>() - 1.0F) <= 1e-6F);
+    REQUIRE(std::abs(stats_before_remove["avg_distance_query"].get<float>() - 0.5F) <= 1e-6F);
+
+    auto remove_result = index->Remove(std::vector<int64_t>{102}, vsag::RemoveMode::MARK_REMOVE);
+    REQUIRE(remove_result.has_value());
+    REQUIRE(remove_result.value() == 1);
+
+    // The removed vector was the nearest live candidate in root/a/leaf before removal. Ground
+    // truth must now use id 101, just as the actual path-scoped search does.
+    const auto stats_after_remove = analyze();
+    REQUIRE(std::abs(stats_after_remove["recall_query"].get<float>() - 1.0F) <= 1e-6F);
+    REQUIRE(std::abs(stats_after_remove["avg_distance_query"].get<float>() - 50.0F) <= 1e-6F);
+}
+
 // ============================================================================
 // Multi-Hierarchy Tests
 // ============================================================================
@@ -1636,6 +1687,80 @@ TEST_CASE("Multi-Hierarchy: Per-hierarchy build params take effect",
     auto cat_tech = f.search_ids(index.value(), "cat", "tech");
     REQUIRE(cat_tech.count(100) == 1);
     REQUIRE(cat_tech.count(101) == 1);
+}
+
+TEST_CASE("Multi-Hierarchy: AnalyzeIndexBySearch honors named query paths",
+          "[ft][pyramid][multi_hierarchy][analyzer]") {
+    MultiHierarchyFixture f;
+    auto index = vsag::Factory::CreateIndex("pyramid", f.build_param("odescent"));
+    REQUIRE(index.has_value());
+
+    auto* base_vectors = new float[16]{0.0F,
+                                       0.0F,
+                                       0.0F,
+                                       0.0F,
+                                       10.0F,
+                                       0.0F,
+                                       0.0F,
+                                       0.0F,
+                                       20.0F,
+                                       0.0F,
+                                       0.0F,
+                                       0.0F,
+                                       100.0F,
+                                       0.0F,
+                                       0.0F,
+                                       0.0F};
+    auto* base_ids = new int64_t[4]{100, 101, 102, 103};
+    auto* site_paths = new std::string[4]{"z", "x", "y", "z"};
+    auto* cat_paths = new std::string[4]{"z/zero", "y/leaf", "x/leaf", "z/hundred"};
+    auto base = vsag::Dataset::Make();
+    base->NumElements(4)
+        ->Dim(4)
+        ->Float32Vectors(base_vectors)
+        ->Ids(base_ids)
+        ->Paths("site", site_paths)
+        ->Paths("cat", cat_paths)
+        ->Owner(true);
+    REQUIRE(index.value()->Build(base).has_value());
+
+    auto* query_vectors = new float[8]{0.0F, 0.0F, 0.0F, 0.0F, 100.0F, 0.0F, 0.0F, 0.0F};
+    auto* query_paths = new std::string[2]{"x", "y"};
+    auto query = vsag::Dataset::Make();
+    query->NumElements(2)
+        ->Dim(4)
+        ->Float32Vectors(query_vectors)
+        ->Paths("cat", query_paths)
+        ->Owner(true);
+
+    vsag::SearchRequest request;
+    request.query_ = query;
+    request.topk_ = 1;
+    request.params_str_ = R"({"pyramid":{"ef_search":20,"hierarchies":["cat"]}})";
+
+    // Global GT is ids 100/103. If x/y were applied to site, its GT would be 101/102, while the
+    // selected cat hierarchy has GT 102/101. Only cat distances 400/8100 yield this average.
+    const auto stats = nlohmann::json::parse(index.value()->AnalyzeIndexBySearch(request));
+    REQUIRE(std::abs(stats["recall_query"].get<float>() - 1.0F) <= 1e-6F);
+    REQUIRE(std::abs(stats["avg_distance_query"].get<float>() - 4250.0F) <= 1e-6F);
+}
+
+TEST_CASE("Multi-Hierarchy: AnalyzeIndexBySearch topk one has finite quantization metrics",
+          "[ft][pyramid][multi_hierarchy][analyzer]") {
+    MultiHierarchyFixture f;
+    auto index = vsag::Factory::CreateIndex("pyramid", f.build_param("nsw", true));
+    REQUIRE(index.has_value());
+    REQUIRE(index.value()->Build(f.make_base()).has_value());
+
+    vsag::SearchRequest request;
+    request.query_ = f.make_query("cat", "tech/ai");
+    request.topk_ = 1;
+    request.params_str_ = R"({"pyramid":{"ef_search":20,"hierarchies":["cat"]}})";
+
+    const auto stats = nlohmann::json::parse(index.value()->AnalyzeIndexBySearch(request));
+    REQUIRE(std::isfinite(stats["quantization_error_query"].get<float>()));
+    REQUIRE(std::isfinite(stats["quantization_inversion_ratio_query"].get<float>()));
+    REQUIRE(stats["quantization_inversion_ratio_query"].get<float>() == 0.0F);
 }
 
 TEST_CASE("Multi-Hierarchy: Analyzer output format - multi hierarchy",


### PR DESCRIPTION
## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Improvement/Refactor
- [ ] Documentation
- [ ] CI/Build/Infra

## Linked Issue

- Fixes: #2661

## What Changed

- Expose `Pyramid::AnalyzeIndexBySearch` for supported KNN requests and query batches.
- Preserve each query's default or named-hierarchy path and calculate ground truth only from live vectors reachable in the same Pyramid search scope.
- Follow Pyramid node semantics when collecting candidates: stop at `FLAT` or `GRAPH`, recurse through `NO_INDEX`, union overlapping path scopes, expand graph duplicate groups, and exclude mark-removed IDs.
- Use the most precise vectors or codes retained by the index for ground truth, and report recall, average distance, latency, and finite reorder quantization metrics.
- Add unit and functional coverage for path scoping, removals, graph duplicates, named hierarchies, batched queries, validation, raw-vector ground truth, and `topk == 1` quantization metrics.
- Update the English and Chinese analysis documentation, including the current CLI hierarchy-path limitation.

## Test Evidence

- [ ] `make fmt`
- [ ] `make lint`
- [ ] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [x] Other (describe below)

Test details:

```text
make debug
# passed

clang-format 15 --dry-run --Werror <changed C++ files>
git diff --check
# passed

./build/tests/unittests '[ut][pyramid][analyzer]' -r compact
# All tests passed (18 assertions in 5 test cases)

./build/tests/functests '[ft][pyramid][analyzer]' -r compact
# All tests passed (60 assertions in 6 test cases)
```

## Compatibility Impact

- API/ABI compatibility: none; this implements an existing virtual API for Pyramid.
- Behavior changes: `AnalyzeIndexBySearch` now works for supported Pyramid KNN requests and uses path-scoped ground truth. Unsupported range, filtered, and iterator analysis requests are rejected explicitly.

## Performance and Concurrency Impact

- Performance impact: ground-truth cost is proportional to each query path's live candidate scope rather than the full index.
- Concurrency/thread-safety impact: analysis is read-only; the index must remain stable without concurrent `Add` or `Remove` operations during analysis.

## Documentation Impact

- [ ] No docs update needed
- [x] Updated docs:
  - [ ] `README.md`
  - [ ] `DEVELOPMENT.md`
  - [ ] `CONTRIBUTING.md`
  - [x] Other: `docs/docs/{en,zh}/src/{indexes/pyramid.md,resources/analyze_index.md}`

## Risk and Rollback

- Risk level: medium
- Rollback plan: revert this PR to restore the previous unsupported-operation behavior.

## Checklist

- [x] I have linked the relevant issue
- [x] I have added/updated tests for new behavior
- [x] I have considered API compatibility impact
- [x] I have updated docs because behavior changed
- [x] My commit message follows project conventions
