### PR TITLE
[Backport 1.0] fix(ci): scope OpenBLAS workaround to regular TSAN

### DIFF
--- a/.github/workflows/tsan_build_and_test.yml
+++ b/.github/workflows/tsan_build_and_test.yml
@@ -35,11 +35,15 @@ jobs:
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.non_markdown == 'true'
     runs-on: ubuntu-22.04
+    env:
+      # TSan instruments VSAG, not third-party dependencies. Daily TSan stays on MKL
+      # to preserve coverage of that backend.
+      EXTRA_DEFINED: -DVSAG_USE_SYSTEM_OPENBLAS=ON
     concurrency:
       group: test_tsan_x86-${{ github.event.pull_request.number || github.sha }}
       cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     container:
-      image: vsaglib/vsag:ci-x86-mkl
+      image: vsaglib/vsag:ci-x86-openblas
       volumes:
         - /opt:/useless
     steps:
@@ -76,7 +80,7 @@ jobs:
       group: test_tsan_x86-${{ github.event.pull_request.number || github.sha }}
       cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     container:
-      image: vsaglib/vsag:ci-x86-mkl
+      image: vsaglib/vsag:ci-x86-openblas
     steps:
       - uses: actions/checkout@v4
       - name: Clean Env


### PR DESCRIPTION
## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement/Refactor
- [ ] Documentation
- [x] CI/Build/Infra

## Linked Issue

Fixes: #2514

## What Changed

- Backports the intended behavior from source PR #2618.
- Runs regular TSAN build and test jobs in `vsaglib/vsag:ci-x86-openblas`.
- Passes `-DVSAG_USE_SYSTEM_OPENBLAS=ON` through `EXTRA_DEFINED` for the regular TSAN build.
- Preserves 1.0 branch triggers and existing build parallelism; leaves daily TSAN unchanged on MKL.

Source PR: https://github.com/antgroup/vsag/pull/2618

## Test Evidence

- [ ] `make fmt`
- [ ] `make lint`
- [ ] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [x] Other (describe below)

Test details:

```text
PyYAML parse: passed for regular and daily workflows
Explicit regular-TSAN OpenBLAS / daily-TSAN MKL assertions: passed
make -n tsan EXTRA_DEFINED=-DVSAG_USE_SYSTEM_OPENBLAS=ON: flag propagated
Focused TSAN/system-OpenBLAS CMake configure: passed; system libopenblas selected
git diff --check: passed
```

## Compatibility Impact

- API/ABI compatibility: none
- Behavior changes: regular TSAN CI reuses system OpenBLAS; daily TSAN retains MKL coverage

## Performance and Concurrency Impact

- Performance impact: avoids rebuilding bundled OpenBLAS in regular TSAN CI
- Concurrency/thread-safety impact: none

## Documentation Impact

- [x] No docs update needed
- [ ] Updated docs

## Risk and Rollback

- Risk level: low
- Rollback plan: revert this commit to restore the prior regular TSAN image and dependency selection

## Checklist

- [x] I have linked the relevant issue
- [x] I have considered API compatibility impact
- [x] My commit messages follow project conventions