### PR TITLE
improve(ivf): let train_sample_count scale with buckets_count

### DIFF
--- a/src/algorithm/inner_index_parameter.cpp
+++ b/src/algorithm/inner_index_parameter.cpp
@@ -242,10 +242,6 @@ InnerIndexParameter::FromJson(const JsonType& json) {
             this->train_sample_count >= 512,
             fmt::format("train_sample_count must be greater than or equal to 512, got: {}",
                         this->train_sample_count));
-        CHECK_ARGUMENT(
-            this->train_sample_count <= 65536L,
-            fmt::format("train_sample_count must be less than or equal to 65536, got: {}",
-                        this->train_sample_count));
     }
 }
 

--- a/src/algorithm/inner_index_parameter_test.cpp
+++ b/src/algorithm/inner_index_parameter_test.cpp
@@ -55,7 +55,7 @@ TEST_CASE("Parameters Train Sample Count Test", "[ut][InnerIndexParameter][train
 
     REQUIRE_THROWS_AS(param->FromJson(param_json), vsag::VsagException);
 
-    // Test invalid value exceeding maximum 65536
+    // Explicit values may exceed the default maximum 65536
     json_obj = vsag::JsonType::Parse(param_str);
     json_obj["train_sample_count"].SetInt(1000000);
     modified_param_str = json_obj.Dump();
@@ -63,7 +63,8 @@ TEST_CASE("Parameters Train Sample Count Test", "[ut][InnerIndexParameter][train
     param_json = vsag::JsonType::Parse(modified_param_str);
     param = std::make_shared<vsag::InnerIndexParameter>();
 
-    REQUIRE_THROWS_AS(param->FromJson(param_json), vsag::VsagException);
+    REQUIRE_NOTHROW(param->FromJson(param_json));
+    REQUIRE(param->train_sample_count == 1000000);
 }
 
 TEST_CASE("Sampling Logic Test", "[ut][InnerIndexParameter][sampling]") {

--- a/src/algorithm/ivf/ivf_parameter.cpp
+++ b/src/algorithm/ivf/ivf_parameter.cpp
@@ -17,6 +17,9 @@
 
 #include <fmt/format.h>
 
+#include <algorithm>
+#include <limits>
+
 #include "inner_string_params.h"
 #include "utils/param_compat_macros.h"
 #include "vsag/constants.h"
@@ -47,6 +50,18 @@ IVFParameter::FromJson(const JsonType& json) {
         this->bucket_param->buckets_count = static_cast<BucketIdType>(
             this->ivf_partition_strategy_parameter->gnoimi_param->first_order_buckets_count *
             this->ivf_partition_strategy_parameter->gnoimi_param->second_order_buckets_count);
+    }
+
+    // Automatically scale train_sample_count based on buckets_count if not explicitly set
+    if (not json.Contains(TRAIN_SAMPLE_COUNT_KEY)) {
+        constexpr int64_t samples_per_bucket = 64;
+        const auto max_train_sample_count = std::numeric_limits<int64_t>::max();
+        const auto bucket_sample_count =
+            this->bucket_param->buckets_count > max_train_sample_count / samples_per_bucket
+                ? max_train_sample_count
+                : this->bucket_param->buckets_count * samples_per_bucket;
+        this->train_sample_count =
+            std::max(static_cast<int64_t>(MAX_TRAIN_COUNT), bucket_sample_count);
     }
 
     if (json.Contains(GRAPH_BUILD_THRESHOLD_KEY)) {

--- a/src/algorithm/ivf/ivf_parameter.h
+++ b/src/algorithm/ivf/ivf_parameter.h
@@ -47,7 +47,6 @@ public:
     BucketDataCellParamPtr bucket_param{nullptr};
     IVFPartitionStrategyParametersPtr ivf_partition_strategy_parameter{nullptr};
     BucketIdType buckets_per_data{1};
-    int64_t train_sample_count{65536L};
     GraphInterfaceParamPtr graph_param{nullptr};
     int64_t graph_build_threshold{0};
 };

--- a/src/algorithm/ivf/ivf_parameter_test.cpp
+++ b/src/algorithm/ivf/ivf_parameter_test.cpp
@@ -103,7 +103,7 @@ TEST_CASE("IVF Parameters Test", "[ut][IVFParameter]") {
     REQUIRE(param->use_reorder == true);
     REQUIRE(param->build_thread_count == 3);
     REQUIRE(param->precise_codes_param->quantizer_parameter->GetTypeName() == "fp32");
-    REQUIRE(param->train_sample_count == 65536L);
+    REQUIRE(param->train_sample_count == 65536L);  // buckets_count=3, so max(65536, 3*64)=65536
 
     index_param.ivf_train_type = "random";
     index_param.partition_strategy_type = "gno_imi";
@@ -122,6 +122,14 @@ TEST_CASE("IVF Parameters Test", "[ut][IVFParameter]") {
     REQUIRE(param->ivf_partition_strategy_parameter->gnoimi_param->second_order_buckets_count ==
             50);
     REQUIRE(param->buckets_per_data == 2);
+    // buckets_count=10000, so train_sample_count=max(65536, 10000*64)=640000
+    REQUIRE(param->train_sample_count == 640000);
+
+    // Test explicit train_sample_count overrides automatic scaling
+    param_json["train_sample_count"].SetInt(1000000);
+    param = std::make_shared<vsag::IVFParameter>();
+    param->FromJson(param_json);
+    REQUIRE(param->train_sample_count == 1000000);
 
     vsag::ParameterTest::TestToJson(param);
 
@@ -305,6 +313,30 @@ TEST_CASE("SampleTrainingData Function Test", "[ut][sample_train_data]") {
     REQUIRE(result != normal_dataset);
     REQUIRE(result->GetNumElements() == 512);  // Should use min_train_size
     REQUIRE(result->GetDim() == large_dim);
+}
+
+TEST_CASE("sample_train_data honors large explicit values", "[ut][sample_train_data]") {
+    auto allocator = vsag::SafeAllocator::FactoryDefaultAllocator();
+    const int64_t dim = 10;
+    const int64_t total = 100000;
+    const int64_t requested = 70000;  // Above former 65536 cap
+
+    std::vector<float> data(dim * total);
+    std::iota(data.begin(), data.end(), 0.0f);
+    std::vector<int64_t> ids(total);
+    std::iota(ids.begin(), ids.end(), 0);
+
+    auto dataset = vsag::Dataset::Make();
+    dataset->Dim(dim)
+        ->NumElements(total)
+        ->Ids(ids.data())
+        ->Float32Vectors(data.data())
+        ->Owner(false);
+
+    auto result = vsag::sample_train_data(dataset, total, dim, requested, allocator.get());
+    REQUIRE(result != dataset);
+    REQUIRE(result->GetNumElements() == requested);
+    REQUIRE(result->GetDim() == dim);
 }
 
 TEST_CASE("IVF maps fast RaBitQ to base and precise quantizers", "[ut][IVFParameter]") {

--- a/src/utils/util_functions.cpp
+++ b/src/utils/util_functions.cpp
@@ -277,10 +277,8 @@ sample_train_data(const vsag::DatasetPtr& data,
                   int64_t train_sample_count,
                   Allocator* allocator) {
     const int64_t min_train_size = 512;
-    const int64_t max_train_size = 65536;
 
-    int64_t sample_count =
-        std::min({max_train_size, total_elements, std::max(min_train_size, train_sample_count)});
+    int64_t sample_count = std::min(total_elements, std::max(min_train_size, train_sample_count));
 
     // If no sampling is needed, return the original dataset
     if (sample_count >= total_elements) {


### PR DESCRIPTION
## Summary

Add automatic scaling of `train_sample_count` based on `buckets_count` to improve KMeans training quality for large IVF configurations.

## Changes

- When `train_sample_count` is not explicitly set in JSON, IVF automatically scales it based on `buckets_count` (64 samples per bucket, minimum 65536)
- Remove the 65536 hard limit in `sample_train_data()` and parameter validation to allow explicit values to pass through
- Fix IVFParameter member shadowing bug where `train_sample_count` field was duplicated in both base and derived class

## Problem

The `train_sample_count` was hardcoded to a maximum of 65536, but `buckets_count` had no validation. As `buckets_count` increases, each centroid receives fewer training samples, degrading KMeans quality:

| buckets_count | samples/centroid | KMeans quality |
|---------------|------------------|----------------|
| 1024          | ~64              | Healthy        |
| 4096          | ~16              | Degraded       |
| 16384         | ~4               | Severely degraded |

## Solution

Use `json.Contains(TRAIN_SAMPLE_COUNT_KEY)` to distinguish between default and explicitly configured values:
- **Default** (not in JSON): Automatically scale to `max(65536, buckets_count * 64)` for better training quality
- **Explicit** (in JSON): Trust user configuration, no 65536 limit

This maintains backward compatibility while enabling better training quality for large-scale deployments.

## Testing

Added test coverage for:
- Default scaling behavior with different bucket counts (e.g., buckets_count=10000 → train_sample_count=640000)
- Explicit values overriding automatic scaling
- Explicit values exceeding 65536
- Actual sampling with large train_sample_count values

Fixes: #2658