### PR TITLE
perf(autotune): reuse HGraph builds across candidates

### DIFF
--- a/docs/docs/en/src/resources/autotune.md
+++ b/docs/docs/en/src/resources/autotune.md
@@ -139,6 +139,7 @@ from the dataset and need not be repeated. If provided, they must match the data
   "tuning_config": {
     "workspace_path": "/tmp/vsag_autotune",
     "keep_intermediate": false,
+    "allow_quantization_tune": false,
     "max_trials": 1000
   }
 }
@@ -161,6 +162,21 @@ is omitted, both indexes are evaluated.
 Candidates with identical concrete create parameters share one build. Each concrete search
 parameter set remains a separate trial. An adaptive `ef_search` range records only the concrete
 points that were actually evaluated.
+
+For HGraph, AutoTune reuses one native build at the largest degree for candidates that differ only
+in `max_degree`, independently within each `base_quantization_type`. Set
+`tuning_config.allow_quantization_tune` to `true` to additionally derive different
+`base_quantization_type` values from one canonical fp32 build. The option has no effect in
+search-only mode. `Index::Tune` produces and serializes an independent artifact
+for every candidate. An unsupported or failed transformation transparently falls back to a native
+build. This optimization is disabled when `build_seconds` or `build_and_search_seconds` is a
+constraint or the objective.
+
+A derived artifact is not guaranteed to have the same graph as a native build from its reported
+`create_params`: degree reduction inherits the larger graph's topology. When enabled,
+quantization tuning also does not rebuild that graph. The measured metrics describe the serialized
+artifact. Consumers must load that artifact with the reported `create_params` instead of
+rebuilding from the parameters.
 
 ## Existing Index
 
@@ -228,6 +244,11 @@ The following metrics can be used as constraints or as the objective:
 existing-index mode. `index_memory_mb` may be a constraint, but not the objective, because it is
 constant across search candidates for the same existing index and cannot rank them. The objective
 direction is inferred from the metric, so no `direction` field is needed.
+
+Build records identify `full_build` or `hgraph_tune` in `strategy`. For `hgraph_tune`,
+`transform_seconds` is the cumulative graph and quantization transformation time attributed to the
+artifact, and `metrics.build_seconds` is the canonical source build time plus that transformation
+time. It is not an independently rebuilt candidate's build time.
 
 AutoTune uses a dedicated latency/QPS pass and a separate recall/statistics pass, so a logical
 query runs more than once per trial. `search_seconds` covers both in-memory passes and metric

--- a/docs/docs/en/src/resources/autotune_api_v1.md
+++ b/docs/docs/en/src/resources/autotune_api_v1.md
@@ -21,7 +21,7 @@ passed to the concrete VSAG index and are validated when that index is created o
 | `workload` | object | Yes | The KNN workload being optimized. |
 | `constraints` | object | Yes | Non-empty metric-to-threshold map. |
 | `objective` | object | Yes | Metric used to rank feasible candidates. |
-| `tuning_config` | object | No | Workspace, artifact retention, and trial limit. |
+| `tuning_config` | object | No | Workspace, artifact retention, trial limit, and HGraph reuse policy. |
 | `output` | object | No | Report path and raw-eval control. |
 
 ### Dataset Rules
@@ -144,6 +144,20 @@ Candidates with the same normalized index name and identical concrete `create_pa
 one build group. AutoTune builds that group once, serializes it once as evidence, and evaluates
 every associated search candidate against the same in-memory index instance.
 
+By default, HGraph create candidates that differ only in `max_degree` may share one native build
+at the largest degree within each `base_quantization_type`. AutoTune uses `Index::Tune` to derive a
+separate final artifact for each concrete degree candidate. Set
+`tuning_config.allow_quantization_tune` to `true` to additionally share one canonical fp32 build
+across `base_quantization_type` values. Unsupported or failed transformations fall back to native
+builds for the affected candidates. If `build_seconds` or `build_and_search_seconds` is a
+constraint or the objective, this reuse is disabled.
+
+The derived artifact is authoritative. It is not guaranteed to be graph-equivalent to a native
+build from the same `create_params`, because degree reduction inherits source topology. When
+quantization tuning is enabled, changing quantization also does not rebuild the graph. Metrics
+come from evaluating the final serialized artifact; consumers must deserialize that artifact
+rather than rebuild it from the reported parameters.
+
 ### Existing-Index Mode
 
 With `index_path`:
@@ -260,6 +274,7 @@ repeat runs when latency or QPS drives selection.
   "tuning_config": {
     "workspace_path": "/tmp/vsag_autotune",
     "keep_intermediate": false,
+    "allow_quantization_tune": false,
     "max_trials": 1000
   },
   "output": {
@@ -273,6 +288,7 @@ repeat runs when latency or QPS drives selection.
 | --- | --- | --- |
 | `tuning_config.workspace_path` | `/tmp/vsag_autotune` | Run artifacts and CLI default reports. |
 | `tuning_config.keep_intermediate` | `false` | Keep all generated indexes. |
+| `tuning_config.allow_quantization_tune` | `false` | Allow one fp32 HGraph build to derive other `base_quantization_type` candidates; no effect in search-only mode. |
 | `tuning_config.max_trials` | `1000` | Maximum planned worst-case trials; hard maximum `100000`. |
 | `output.result_path` | `<workspace>/run-<id>.json` | CLI full report path. |
 | `output.include_raw_eval` | `false` | Include native eval JSON in build and trial records. |
@@ -370,6 +386,9 @@ then by normalized violation magnitude. It is only explanatory.
 | `build_id` | Stable ID referenced by trials. |
 | `index_name` | Concrete index type. |
 | `create_params` | Concrete create parameters. |
+| `strategy` | `full_build` or `hgraph_tune`. |
+| `source_build_id` | Canonical HGraph source identifier; present only for `hgraph_tune`. |
+| `transform_seconds` | Cumulative transformation time; present only for `hgraph_tune`. |
 | `status` | `success` or `failed`. |
 | `metrics` | Available build-shared metrics. |
 | `artifacts` | `source`, `index_path`, `use_existing_index`, and `retained`. |
@@ -407,11 +426,16 @@ Search trials in one build group reuse the same loaded index instance. A generat
 once and serialized once. In search-only mode the caller's index, or the index deserialized by the
 CLI adapter, is reused directly for every trial.
 
+For `strategy=hgraph_tune`, `transform_seconds` measures the graph and quantization transformations
+attributed to the artifact. Its `metrics.build_seconds` is the canonical source build duration plus
+`transform_seconds`, not the duration of an independent native build of the candidate.
+
 ### Artifact Semantics
 
-Artifact fields appear only in build-and-search records in V1. `artifacts.source` is `generated`,
-and `artifacts.index_path` is evidence of where the evaluated index was stored, not a promise that
-the path still exists. Check `artifacts.retained`:
+Artifact fields appear only in build-and-search records in V1. `artifacts.source` is `generated`
+for a native build or `hgraph_tune` for a derived HGraph artifact. `artifacts.index_path` is
+evidence of where the evaluated index was stored, not a promise that the path still exists. Check
+`artifacts.retained`:
 
 - `true`: this is the selected artifact, or retention of all generated indexes was requested;
 - `false`: AutoTune planned to remove or already removed the generated artifact.

--- a/docs/docs/zh/src/resources/autotune.md
+++ b/docs/docs/zh/src/resources/autotune.md
@@ -133,6 +133,7 @@ cmake --build build-release --target 326_feature_create_index_with_constraints -
   "tuning_config": {
     "workspace_path": "/tmp/vsag_autotune",
     "keep_intermediate": false,
+    "allow_quantization_tune": false,
     "max_trials": 1000
   }
 }
@@ -153,6 +154,17 @@ cmake --build build-release --target 326_feature_create_index_with_constraints -
 
 具体 create 参数相同的候选只构建一次；每组具体 search 参数仍然是独立 trial。自适应
 `ef_search` 范围只记录实际评测过的具体参数点。
+
+对于 HGraph，只有 `max_degree` 不同的候选默认会在每种量化类型内复用一次最大 degree
+的原生 build。这里的量化类型特指 `base_quantization_type`。设置
+`tuning_config.allow_quantization_tune=true` 后，还可以从一次 canonical fp32 build
+派生不同 `base_quantization_type` 候选；该选项在 search-only 模式下无效。`Index::Tune`
+会为每个候选生成并序列化独立 artifact。变换不支持或失败时会自动回退到原生构建。
+当 `build_seconds` 或 `build_and_search_seconds` 是约束或目标时，会禁用该优化。
+
+派生 artifact 不保证与使用其 `create_params` 原生构建的图相同：degree 裁剪会继承大图
+拓扑；开启量化 Tune 时，切换量化也不会重新构图。指标来自对最终序列化 artifact 的实际
+评测；使用方必须用返回的 `create_params` 加载该 artifact，而不能只按参数重新构建。
 
 ## 已有索引
 
@@ -216,6 +228,11 @@ Pyramid path 调优示例见
 已有索引模式不提供 `build_seconds`、`index_size_mb` 和 `build_and_search_seconds`。
 `index_memory_mb` 可以作为约束，但不能作为目标，因为同一个已有索引的所有 search 候选
 内存相同，无法据此排序。目标方向由指标本身决定，因此不需要 `direction` 字段。
+
+Build 记录通过 `strategy` 区分 `full_build` 和 `hgraph_tune`。对于 `hgraph_tune`，
+`transform_seconds` 是生成该 artifact 累计的图和量化变换耗时，
+`metrics.build_seconds` 是 canonical source build 耗时加该变换耗时，不代表独立原生
+重建该候选的耗时。
 
 AutoTune 使用独立的 latency/QPS pass 和 recall/statistics pass，因此同一条逻辑 query 在
 每个 trial 中会执行多次。`search_seconds` 包含两个内存 pass 和指标采集，但不包含索引

--- a/docs/docs/zh/src/resources/autotune_api_v1.md
+++ b/docs/docs/zh/src/resources/autotune_api_v1.md
@@ -20,7 +20,7 @@ HGraph/IVF 的构建和查询调优，以及一个使用全量 query 的 KNN wor
 | `workload` | object | 是 | 要优化的 KNN workload。 |
 | `constraints` | object | 是 | 非空的“指标到阈值”映射。 |
 | `objective` | object | 是 | 对可行候选排序的目标指标。 |
-| `tuning_config` | object | 否 | workspace、产物保留和 trial 上限。 |
+| `tuning_config` | object | 否 | workspace、产物保留、trial 上限和 HGraph 复用策略。 |
 | `output` | object | 否 | 报告路径和原始 eval 输出开关。 |
 
 ### 数据集规则
@@ -135,6 +135,19 @@ bucket 数量。AutoTune 无法推断已有 IVF 的 bucket 数量，因此 searc
 规范化索引名和具体 `create_params` 相同的候选属于同一个 build group。AutoTune 对该组
 只构建一次、序列化一次作为证据，再使用同一个内存索引实例执行所有关联的 search 候选。
 
+默认情况下，只有 `max_degree` 不同的 HGraph create 候选可以在每种量化类型内复用一次
+最大 degree 的原生 build。这里的量化类型特指 `base_quantization_type`。AutoTune 通过
+`Index::Tune` 为每个具体 degree 候选生成独立的
+最终 artifact。设置 `tuning_config.allow_quantization_tune=true` 后，还允许不同量化类型
+共享一次 canonical fp32 build。这里也仅指不同的 `base_quantization_type` 值。变换不支持
+或失败时，受影响的候选会回退到原生构建。
+当 `build_seconds` 或 `build_and_search_seconds` 是约束或目标时，禁用该复用。
+
+最终以派生 artifact 为准。它不保证与使用相同 `create_params` 原生构建的图等价，因为
+degree 裁剪会继承 source 拓扑；开启量化 Tune 时，切换量化也不会重新构图。指标来自对
+最终序列化 artifact 的实际评测；使用方必须反序列化该 artifact，而不能只按返回参数
+重新构建。
+
 ### 已有索引模式
 
 设置 `index_path` 后：
@@ -243,6 +256,7 @@ V1 指标口径：
   "tuning_config": {
     "workspace_path": "/tmp/vsag_autotune",
     "keep_intermediate": false,
+    "allow_quantization_tune": false,
     "max_trials": 1000
   },
   "output": {
@@ -256,6 +270,7 @@ V1 指标口径：
 | --- | --- | --- |
 | `tuning_config.workspace_path` | `/tmp/vsag_autotune` | run 产物和 CLI 默认报告目录。 |
 | `tuning_config.keep_intermediate` | `false` | 是否保留所有生成索引。 |
+| `tuning_config.allow_quantization_tune` | `false` | 是否允许从一个 fp32 HGraph build 派生其他 `base_quantization_type` 候选；search-only 模式下无效。 |
 | `tuning_config.max_trials` | `1000` | 计划最坏 trial 数上限；硬上限为 `100000`。 |
 | `output.result_path` | `<workspace>/run-<id>.json` | CLI 完整报告路径。 |
 | `output.include_raw_eval` | `false` | 在 build/trial 中包含原生 eval JSON。 |
@@ -348,6 +363,9 @@ search-only 模式的 `builds` 为空。build-and-search 模式下，每个 `bui
 | `build_id` | 被 trial 引用的稳定 ID。 |
 | `index_name` | 具体索引类型。 |
 | `create_params` | 具体创建参数。 |
+| `strategy` | `full_build` 或 `hgraph_tune`。 |
+| `source_build_id` | canonical HGraph source 标识；仅 `hgraph_tune` 存在。 |
+| `transform_seconds` | 累计变换耗时；仅 `hgraph_tune` 存在。 |
 | `status` | `success` 或 `failed`。 |
 | `metrics` | 可用的 build 共享指标。 |
 | `artifacts` | `source`、`index_path`、`use_existing_index` 和 `retained`。 |
@@ -385,11 +403,16 @@ query workload。
 一次。search-only 模式直接为所有 trial 复用调用方索引，或复用 CLI 适配器反序列化得到的
 索引。
 
+对于 `strategy=hgraph_tune`，`transform_seconds` 是生成该 artifact 所计入的图和量化
+变换耗时。其 `metrics.build_seconds` 是 canonical source build 耗时加
+`transform_seconds`，不是独立原生构建该候选的耗时。
+
 ### Artifact 语义
 
-V1 只在 build-and-search 记录中提供 artifact 字段。`artifacts.source` 为 `generated`；
-`artifacts.index_path` 用于说明被评测索引曾存放在哪里，不保证响应返回时路径仍然存在。
-需要检查 `artifacts.retained`：
+V1 只在 build-and-search 记录中提供 artifact 字段。原生构建的 `artifacts.source` 为
+`generated`，变换生成的 HGraph artifact 为 `hgraph_tune`。`artifacts.index_path` 用于
+说明被评测索引曾存放在哪里，不保证响应返回时路径仍然存在。需要检查
+`artifacts.retained`：
 
 - `true`：这是最终推荐产物，或者请求保留所有生成索引；
 - `false`：AutoTune 计划删除或已经删除生成产物。

--- a/src/algorithm/hgraph/CMakeLists.txt
+++ b/src/algorithm/hgraph/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(HGRAPH_SRCS
     hgraph.cpp
     hgraph_build.cpp
+    hgraph_degree_reduction.cpp
     hgraph_fast_build.cpp
     hgraph_modify.cpp
     hgraph_mci.cpp

--- a/src/algorithm/hgraph/hgraph.cpp
+++ b/src/algorithm/hgraph/hgraph.cpp
@@ -144,6 +144,7 @@ HGraph::Tune(const std::string& parameters, bool disable_future_tuning) {
     if (parsed_params.Contains(INDEX_PARAM)) {
         hgraph_json = parsed_params[INDEX_PARAM];
     }
+    const bool has_max_degree = hgraph_json.Contains(HGRAPH_GRAPH_MAX_DEGREE);
 
     // map
     auto inner_json = map_hgraph_param(hgraph_json);
@@ -158,6 +159,20 @@ HGraph::Tune(const std::string& parameters, bool disable_future_tuning) {
     hgraph_parameter->FromJson(inner_json);
     auto inner_parameter = std::make_shared<InnerIndexParameter>();
     inner_parameter->FromJson(inner_json);
+    const bool keep_raw_vector = hgraph_parameter->store_raw_vector;
+
+    const auto current_max_degree = this->bottom_graph_->MaximumDegree();
+    const auto target_max_degree = hgraph_parameter->bottom_graph_param->max_degree_;
+    if (has_max_degree and target_max_degree > current_max_degree) {
+        return false;
+    }
+    const bool reduce_max_degree = has_max_degree and target_max_degree < current_max_degree;
+    if (reduce_max_degree) {
+        std::shared_lock<std::shared_mutex> rlock(this->global_mutex_);
+        if (not this->can_reduce_max_degree_unlocked()) {
+            return false;
+        }
+    }
 
     // init new_basic_code obj
     auto common_param = this->basic_flatten_codes_->ExportCommonParam();
@@ -179,7 +194,7 @@ HGraph::Tune(const std::string& parameters, bool disable_future_tuning) {
     // Check which codes need to be rebuilt.
     bool is_tune_base_code = false;
     bool is_tune_precise_code = false;
-    const bool is_tune_raw_code = requires_raw_vector and not covers_active_ids(raw_vector_);
+    const bool is_tune_raw_code = keep_raw_vector and not covers_active_ids(raw_vector_);
     FlattenInterfacePtr new_raw_code;
     if (is_tune_raw_code) {
         new_raw_code =
@@ -277,6 +292,11 @@ HGraph::Tune(const std::string& parameters, bool disable_future_tuning) {
     // preventing concurrent searches from accessing partially updated state.
     {
         std::scoped_lock<std::shared_mutex> wlock(this->global_mutex_);
+        if (reduce_max_degree) {
+            this->prepare_degree_reduction_unlocked();
+            this->reduce_max_degree_unlocked(static_cast<uint32_t>(target_max_degree));
+        }
+
         auto param = std::dynamic_pointer_cast<HGraphParameter>(create_param_ptr_);
         basic_flatten_codes_ = new_basic;
         if (drop_precise_codes) {
@@ -296,10 +316,11 @@ HGraph::Tune(const std::string& parameters, bool disable_future_tuning) {
         param->use_reorder = new_use_reorder;
         param->reorder_source = inner_parameter->reorder_source;
 
-        if (requires_raw_vector) {
+        if (keep_raw_vector) {
             raw_vector_ = new_raw;
-            has_raw_vector_ = true;
-            create_new_raw_vector_ = true;
+            has_raw_vector_ = raw_vector_ != nullptr;
+            create_new_raw_vector_ =
+                raw_vector_ != basic_flatten_codes_ and raw_vector_ != high_precise_codes_;
             param->store_raw_vector = true;
             param->raw_vector_param = hgraph_parameter->raw_vector_param;
         } else {
@@ -310,12 +331,14 @@ HGraph::Tune(const std::string& parameters, bool disable_future_tuning) {
         // set status
         if (disable_future_tuning) {
             this->index_feature_list_->SetFeature(IndexFeature::SUPPORT_TUNE, false);
-            if (not requires_raw_vector) {
+            if (not keep_raw_vector) {
                 this->raw_vector_.reset();
                 has_raw_vector_ = false;
                 create_new_raw_vector_ = false;
+                param->store_raw_vector = false;
             }
         }
+        this->cal_memory_usage();
     }
     return true;
 }
@@ -491,6 +514,7 @@ void
 HGraph::Merge(const std::vector<MergeUnit>& merge_units) {
     CHECK_ARGUMENT(not this->using_dedup_storage(),
                    "HGraph deduplicate_storage does not support Merge");
+    this->degree_reduction_prepared_.store(false, std::memory_order_release);
     int64_t total_count = this->GetNumElements();
     for (const auto& unit : merge_units) {
         total_count += unit.index->GetNumElements();
@@ -790,6 +814,7 @@ HGraph::UpdateVector(int64_t id, const DatasetPtr& new_base, bool force_update) 
         map_lock = this->acquire_global_read_lock();
     }
     std::unique_lock<std::shared_mutex> codes_lock(this->persistent_codes_mutex_);
+    this->degree_reduction_prepared_.store(false, std::memory_order_release);
     bool update_status = basic_flatten_codes_->UpdateVector(new_base_vec, inner_id);
     if (has_precise_reorder()) {
         update_status = update_status && high_precise_codes_->UpdateVector(new_base_vec, inner_id);

--- a/src/algorithm/hgraph/hgraph.h
+++ b/src/algorithm/hgraph/hgraph.h
@@ -229,6 +229,17 @@ public:
     void
     SetImmutable() override;
 
+    // Internal AutoTune path. These methods rewrite graph storage between trials; normal build,
+    // search, Tune, and serialization entry points never call them.
+    [[nodiscard]] bool
+    CanReduceMaxDegree() const;
+
+    void
+    PrepareDegreeReduction();
+
+    void
+    ReduceMaxDegree(uint32_t max_degree);
+
     void
     ExportCache(std::ostream& out_stream) const override;
 
@@ -656,6 +667,12 @@ private:
     void
     cal_memory_usage();
 
+    [[nodiscard]] bool
+    can_reduce_max_degree_unlocked() const;
+
+    [[nodiscard]] FlattenInterfacePtr
+    get_degree_reduction_codes() const;
+
     /// True when reorder uses a separate high-precision flatten (not base codes).
     [[nodiscard]] bool
     has_precise_reorder() const {
@@ -907,5 +924,7 @@ private:
     float build_cache_hit_rate_{-1.0F};     // cache hit rate from last cache-based build
     uint64_t build_cache_hit_nodes_{0};     // number of nodes with cache hit
     uint64_t build_cache_missed_nodes_{0};  // number of nodes without cache hit
+
+    bool degree_reduction_prepared_{false};
 };
 }  // namespace vsag

--- a/src/algorithm/hgraph/hgraph.h
+++ b/src/algorithm/hgraph/hgraph.h
@@ -229,17 +229,6 @@ public:
     void
     SetImmutable() override;
 
-    // Internal AutoTune path. These methods rewrite graph storage between trials; normal build,
-    // search, Tune, and serialization entry points never call them.
-    [[nodiscard]] bool
-    CanReduceMaxDegree() const;
-
-    void
-    PrepareDegreeReduction();
-
-    void
-    ReduceMaxDegree(uint32_t max_degree);
-
     void
     ExportCache(std::ostream& out_stream) const override;
 
@@ -670,6 +659,12 @@ private:
     [[nodiscard]] bool
     can_reduce_max_degree_unlocked() const;
 
+    void
+    prepare_degree_reduction_unlocked();
+
+    void
+    reduce_max_degree_unlocked(uint32_t max_degree);
+
     [[nodiscard]] FlattenInterfacePtr
     get_degree_reduction_codes() const;
 
@@ -925,6 +920,6 @@ private:
     uint64_t build_cache_hit_nodes_{0};     // number of nodes with cache hit
     uint64_t build_cache_missed_nodes_{0};  // number of nodes without cache hit
 
-    bool degree_reduction_prepared_{false};
+    std::atomic<bool> degree_reduction_prepared_{false};
 };
 }  // namespace vsag

--- a/src/algorithm/hgraph/hgraph_build.cpp
+++ b/src/algorithm/hgraph/hgraph_build.cpp
@@ -562,6 +562,7 @@ HGraph::insert_one_logical_point(const void* data, const AddRow& row, const AddC
     };
 
     std::unique_lock<std::shared_mutex> add_lock(this->add_mutex_);
+    this->degree_reduction_prepared_.store(false, std::memory_order_release);
     auto needs_update_structure = this->unique_add_needs_structure_update(level);
     if (not needs_update_structure) {
         add_lock.unlock();

--- a/src/algorithm/hgraph/hgraph_degree_reduction.cpp
+++ b/src/algorithm/hgraph/hgraph_degree_reduction.cpp
@@ -1,0 +1,280 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <algorithm>
+#include <exception>
+#include <future>
+#include <memory>
+#include <vector>
+
+#include "datacell/graph_datacell_parameter.h"
+#include "datacell/graph_interface.h"
+#include "datacell/sparse_graph_datacell_parameter.h"
+#include "hgraph.h"
+#include "impl/pruning_strategy.h"
+#include "impl/thread_pool/safe_thread_pool.h"
+
+namespace vsag {
+
+namespace {
+
+template <typename Function>
+void
+parallel_for(uint64_t count,
+             uint64_t parallelism,
+             const SafeThreadPoolPtr& thread_pool,
+             const Function& function) {
+    const auto worker_count = std::min(count, std::max<uint64_t>(1, parallelism));
+    if (worker_count <= 1 || thread_pool == nullptr) {
+        for (uint64_t i = 0; i < count; ++i) {
+            function(i);
+        }
+        return;
+    }
+
+    const auto batch_size = (count + worker_count - 1) / worker_count;
+    std::vector<std::future<void>> futures;
+    futures.reserve(worker_count);
+    std::exception_ptr first_exception;
+    for (uint64_t worker = 0; worker < worker_count; ++worker) {
+        const auto begin = worker * batch_size;
+        const auto end = std::min(count, begin + batch_size);
+        if (begin == end) {
+            break;
+        }
+        try {
+            futures.emplace_back(thread_pool->GeneralEnqueue([begin, end, &function]() {
+                for (uint64_t i = begin; i < end; ++i) {
+                    function(i);
+                }
+            }));
+        } catch (...) {
+            first_exception = std::current_exception();
+            break;
+        }
+    }
+    for (auto& future : futures) {
+        try {
+            future.get();
+        } catch (...) {
+            if (first_exception == nullptr) {
+                first_exception = std::current_exception();
+            }
+        }
+    }
+    if (first_exception != nullptr) {
+        std::rethrow_exception(first_exception);
+    }
+}
+
+GraphInterfacePtr
+materialize_graph(const GraphInterfacePtr& source,
+                  const GraphInterfaceParamPtr& target_param,
+                  const FlattenInterfacePtr& flatten,
+                  Allocator* allocator,
+                  bool dense_ids,
+                  const SafeThreadPoolPtr& thread_pool,
+                  uint64_t parallelism) {
+    auto common_param = flatten->ExportCommonParam();
+    auto target = GraphInterface::MakeInstance(target_param, common_param);
+    CHECK_ARGUMENT(target != nullptr, "failed to create compact graph storage");
+    if (dense_ids) {
+        target->Resize(source->MaxCapacity());
+    }
+
+    const auto copy_neighbors = [&](InnerIdType id) {
+        Vector<InnerIdType> neighbors(allocator);
+        source->GetNeighbors(id, neighbors);
+        const auto target_degree = static_cast<uint64_t>(target_param->max_degree_);
+        if (neighbors.size() > target_degree) {
+            neighbors.resize(target_degree);
+        }
+        target->InsertNeighborsById(id, neighbors);
+    };
+
+    if (dense_ids) {
+        parallel_for(source->TotalCount(), parallelism, thread_pool, [&](uint64_t id) {
+            copy_neighbors(static_cast<InnerIdType>(id));
+        });
+    } else {
+        const auto ids = source->GetIds();
+        parallel_for(
+            ids.size(), parallelism, thread_pool, [&](uint64_t i) { copy_neighbors(ids[i]); });
+    }
+    target->SetDuplicateTracker(source->GetDuplicateTracker());
+    return target;
+}
+
+void
+rank_graph(const GraphInterfacePtr& graph,
+           const FlattenInterfacePtr& flatten,
+           Allocator* allocator,
+           float alpha,
+           bool dense_ids,
+           const SafeThreadPoolPtr& thread_pool,
+           uint64_t parallelism) {
+    const auto rank_neighbors = [&](InnerIdType id) {
+        Vector<InnerIdType> neighbors(allocator);
+        graph->GetNeighbors(id, neighbors);
+        if (!neighbors.empty()) {
+            const auto original = neighbors;
+            select_edges_by_heuristic(neighbors, id, neighbors.size(), flatten, allocator, alpha);
+            std::reverse(neighbors.begin(), neighbors.end());
+
+            std::vector<std::pair<float, InnerIdType>> remaining;
+            remaining.reserve(original.size() - neighbors.size());
+            for (const auto neighbor : original) {
+                if (std::find(neighbors.begin(), neighbors.end(), neighbor) == neighbors.end()) {
+                    remaining.emplace_back(flatten->ComputePairVectors(id, neighbor), neighbor);
+                }
+            }
+            std::sort(remaining.begin(), remaining.end());
+            neighbors.reserve(original.size());
+            for (const auto& candidate : remaining) {
+                neighbors.emplace_back(candidate.second);
+            }
+            graph->InsertNeighborsById(id, neighbors);
+        }
+    };
+
+    if (dense_ids) {
+        parallel_for(graph->TotalCount(), parallelism, thread_pool, [&](uint64_t id) {
+            rank_neighbors(static_cast<InnerIdType>(id));
+        });
+    } else {
+        const auto ids = graph->GetIds();
+        parallel_for(
+            ids.size(), parallelism, thread_pool, [&](uint64_t i) { rank_neighbors(ids[i]); });
+    }
+}
+
+}  // namespace
+
+bool
+HGraph::can_reduce_max_degree_unlocked() const {
+    if (this->immutable_.load(std::memory_order_acquire) ||
+        this->graph_type_ != GRAPH_TYPE_VALUE_NSW || this->bottom_graph_ == nullptr ||
+        !this->bottom_graph_->InMemory() || this->support_force_remove_) {
+        return false;
+    }
+    const auto hgraph_param = std::dynamic_pointer_cast<HGraphParameter>(this->create_param_ptr_);
+    if (hgraph_param == nullptr) {
+        return false;
+    }
+    const auto bottom_param =
+        std::dynamic_pointer_cast<GraphDataCellParameter>(hgraph_param->bottom_graph_param);
+    if (bottom_param == nullptr || bottom_param->support_remove_ ||
+        bottom_param->use_reverse_edges_) {
+        return false;
+    }
+    return this->hierarchical_datacell_param_ != nullptr &&
+           !this->hierarchical_datacell_param_->support_delete_ &&
+           !this->hierarchical_datacell_param_->use_reverse_edges_ &&
+           this->get_degree_reduction_codes() != nullptr;
+}
+
+FlattenInterfacePtr
+HGraph::get_degree_reduction_codes() const {
+    if (this->has_precise_reorder() && !this->build_by_base_) {
+        return this->high_precise_codes_;
+    }
+    if (this->basic_flatten_codes_->GetQuantizerName() == QUANTIZATION_TYPE_VALUE_RABITQ) {
+        return this->raw_vector_;
+    }
+    return this->basic_flatten_codes_;
+}
+
+bool
+HGraph::CanReduceMaxDegree() const {
+    std::scoped_lock lock(this->add_mutex_, this->global_mutex_);
+    return this->can_reduce_max_degree_unlocked();
+}
+
+void
+HGraph::PrepareDegreeReduction() {
+    std::scoped_lock lock(this->add_mutex_, this->global_mutex_);
+    CHECK_ARGUMENT(this->can_reduce_max_degree_unlocked(),
+                   "HGraph max-degree reduction does not support this index");
+    if (this->degree_reduction_prepared_) {
+        return;
+    }
+
+    const auto flatten = this->get_degree_reduction_codes();
+    rank_graph(this->bottom_graph_,
+               flatten,
+               this->allocator_,
+               this->alpha_,
+               true,
+               this->thread_pool_,
+               this->build_thread_count_);
+    for (const auto& route : this->route_graphs_) {
+        rank_graph(route,
+                   flatten,
+                   this->allocator_,
+                   this->alpha_,
+                   false,
+                   this->thread_pool_,
+                   this->build_thread_count_);
+    }
+
+    this->degree_reduction_prepared_ = true;
+}
+
+void
+HGraph::ReduceMaxDegree(uint32_t max_degree) {
+    std::scoped_lock lock(this->add_mutex_, this->global_mutex_);
+    CHECK_ARGUMENT(this->can_reduce_max_degree_unlocked(),
+                   "HGraph max-degree reduction does not support this index");
+    CHECK_ARGUMENT(this->degree_reduction_prepared_,
+                   "PrepareDegreeReduction must be called before ReduceMaxDegree");
+    CHECK_ARGUMENT(max_degree >= 4, "target max_degree must be at least 4");
+    CHECK_ARGUMENT(max_degree < this->bottom_graph_->MaximumDegree(),
+                   "target max_degree must be smaller than the current max_degree");
+
+    const auto hgraph_param = std::dynamic_pointer_cast<HGraphParameter>(this->create_param_ptr_);
+    auto bottom_param = std::make_shared<GraphDataCellParameter>(
+        *std::dynamic_pointer_cast<GraphDataCellParameter>(hgraph_param->bottom_graph_param));
+    bottom_param->max_degree_ = max_degree;
+    auto bottom = materialize_graph(this->bottom_graph_,
+                                    bottom_param,
+                                    this->basic_flatten_codes_,
+                                    this->allocator_,
+                                    true,
+                                    this->thread_pool_,
+                                    this->build_thread_count_);
+
+    auto route_param =
+        std::make_shared<SparseGraphDatacellParameter>(*this->hierarchical_datacell_param_);
+    route_param->max_degree_ = std::max<uint32_t>(1, max_degree / 2);
+    Vector<GraphInterfacePtr> routes(this->allocator_);
+    routes.reserve(this->route_graphs_.size());
+    for (const auto& route : this->route_graphs_) {
+        routes.emplace_back(materialize_graph(route,
+                                              route_param,
+                                              this->basic_flatten_codes_,
+                                              this->allocator_,
+                                              false,
+                                              this->thread_pool_,
+                                              this->build_thread_count_));
+    }
+
+    this->bottom_graph_ = std::move(bottom);
+    this->route_graphs_ = std::move(routes);
+    hgraph_param->bottom_graph_param = bottom_param;
+    hgraph_param->hierarchical_graph_param = route_param;
+    this->hierarchical_datacell_param_ = route_param;
+    this->cal_memory_usage();
+}
+
+}  // namespace vsag

--- a/src/algorithm/hgraph/hgraph_degree_reduction.cpp
+++ b/src/algorithm/hgraph/hgraph_degree_reduction.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <algorithm>
+#include <cmath>
 #include <exception>
 #include <future>
 #include <memory>
@@ -86,6 +87,10 @@ materialize_graph(const GraphInterfacePtr& source,
                   bool dense_ids,
                   const SafeThreadPoolPtr& thread_pool,
                   uint64_t parallelism) {
+    CHECK_ARGUMENT(source != nullptr, "source graph is required for max-degree reduction");
+    CHECK_ARGUMENT(target_param != nullptr,
+                   "target graph parameter is required for max-degree reduction");
+    CHECK_ARGUMENT(flatten != nullptr, "vector codes are required for max-degree reduction");
     auto common_param = flatten->ExportCommonParam();
     auto target = GraphInterface::MakeInstance(target_param, common_param);
     CHECK_ARGUMENT(target != nullptr, "failed to create compact graph storage");
@@ -181,6 +186,9 @@ HGraph::can_reduce_max_degree_unlocked() const {
     return this->hierarchical_datacell_param_ != nullptr &&
            !this->hierarchical_datacell_param_->support_delete_ &&
            !this->hierarchical_datacell_param_->use_reverse_edges_ &&
+           std::all_of(this->route_graphs_.begin(),
+                       this->route_graphs_.end(),
+                       [](const GraphInterfacePtr& route) { return route != nullptr; }) &&
            this->get_degree_reduction_codes() != nullptr;
 }
 
@@ -189,24 +197,20 @@ HGraph::get_degree_reduction_codes() const {
     if (this->has_precise_reorder() && !this->build_by_base_) {
         return this->high_precise_codes_;
     }
+    if (this->basic_flatten_codes_ == nullptr) {
+        return nullptr;
+    }
     if (this->basic_flatten_codes_->GetQuantizerName() == QUANTIZATION_TYPE_VALUE_RABITQ) {
         return this->raw_vector_;
     }
     return this->basic_flatten_codes_;
 }
 
-bool
-HGraph::CanReduceMaxDegree() const {
-    std::scoped_lock lock(this->add_mutex_, this->global_mutex_);
-    return this->can_reduce_max_degree_unlocked();
-}
-
 void
-HGraph::PrepareDegreeReduction() {
-    std::scoped_lock lock(this->add_mutex_, this->global_mutex_);
+HGraph::prepare_degree_reduction_unlocked() {
     CHECK_ARGUMENT(this->can_reduce_max_degree_unlocked(),
                    "HGraph max-degree reduction does not support this index");
-    if (this->degree_reduction_prepared_) {
+    if (this->degree_reduction_prepared_.load(std::memory_order_acquire)) {
         return;
     }
 
@@ -228,15 +232,14 @@ HGraph::PrepareDegreeReduction() {
                    this->build_thread_count_);
     }
 
-    this->degree_reduction_prepared_ = true;
+    this->degree_reduction_prepared_.store(true, std::memory_order_release);
 }
 
 void
-HGraph::ReduceMaxDegree(uint32_t max_degree) {
-    std::scoped_lock lock(this->add_mutex_, this->global_mutex_);
+HGraph::reduce_max_degree_unlocked(uint32_t max_degree) {
     CHECK_ARGUMENT(this->can_reduce_max_degree_unlocked(),
                    "HGraph max-degree reduction does not support this index");
-    CHECK_ARGUMENT(this->degree_reduction_prepared_,
+    CHECK_ARGUMENT(this->degree_reduction_prepared_.load(std::memory_order_acquire),
                    "PrepareDegreeReduction must be called before ReduceMaxDegree");
     CHECK_ARGUMENT(max_degree >= 4, "target max_degree must be at least 4");
     CHECK_ARGUMENT(max_degree < this->bottom_graph_->MaximumDegree(),
@@ -274,7 +277,7 @@ HGraph::ReduceMaxDegree(uint32_t max_degree) {
     hgraph_param->bottom_graph_param = bottom_param;
     hgraph_param->hierarchical_graph_param = route_param;
     this->hierarchical_datacell_param_ = route_param;
-    this->cal_memory_usage();
+    this->mult_ = 1 / std::log(1.0 * static_cast<double>(max_degree));
 }
 
 }  // namespace vsag

--- a/src/algorithm/hgraph/hgraph_degree_reduction_test.cpp
+++ b/src/algorithm/hgraph/hgraph_degree_reduction_test.cpp
@@ -1,0 +1,96 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <fmt/format.h>
+
+#include <algorithm>
+#include <numeric>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "hgraph.h"
+#include "index/index_impl.h"
+#include "unittest.h"
+#include "vsag/factory.h"
+
+namespace {
+
+std::string
+create_parameters(uint32_t max_degree) {
+    return fmt::format(R"({{"dim":8,"dtype":"float32","metric_type":"l2","index_param":{{)"
+                       R"("base_quantization_type":"fp32","max_degree":{},"ef_construction":40,)"
+                       R"("build_thread_count":1}}}})",
+                       max_degree);
+}
+
+}  // namespace
+
+TEST_CASE("HGraph materializes nested compact max-degree graphs", "[ut][hgraph_degree_reduction]") {
+    constexpr int64_t count = 256;
+    constexpr int64_t dim = 8;
+    std::vector<int64_t> ids(count);
+    std::iota(ids.begin(), ids.end(), 1000);
+    std::vector<float> vectors(count * dim);
+    for (int64_t i = 0; i < count; ++i) {
+        for (int64_t j = 0; j < dim; ++j) {
+            vectors[i * dim + j] = static_cast<float>((i * 17 + j * 29) % 257) / 257.0F;
+        }
+    }
+    auto base = vsag::Dataset::Make()
+                    ->NumElements(count)
+                    ->Dim(dim)
+                    ->Ids(ids.data())
+                    ->Float32Vectors(vectors.data())
+                    ->Owner(false);
+    auto query = vsag::Dataset::Make()
+                     ->NumElements(1)
+                     ->Dim(dim)
+                     ->Float32Vectors(vectors.data())
+                     ->Owner(false);
+
+    auto created = vsag::Factory::CreateIndex("hgraph", create_parameters(16));
+    REQUIRE(created.has_value());
+    auto index = std::dynamic_pointer_cast<vsag::IndexImpl<vsag::HGraph>>(created.value());
+    REQUIRE(index != nullptr);
+    REQUIRE(index->Build(base).has_value());
+    REQUIRE(index->KnnSearch(query, 10, R"({"hgraph":{"ef_search":40}})").has_value());
+
+    auto hgraph = std::dynamic_pointer_cast<vsag::HGraph>(index->GetInnerIndex());
+    REQUIRE(hgraph != nullptr);
+    REQUIRE(hgraph->CanReduceMaxDegree());
+    hgraph->PrepareDegreeReduction();
+
+    for (const auto degree : {8U, 4U}) {
+        hgraph->ReduceMaxDegree(degree);
+        const auto parameter =
+            std::dynamic_pointer_cast<vsag::HGraphParameter>(hgraph->create_param_ptr_);
+        REQUIRE(parameter != nullptr);
+        REQUIRE(parameter->bottom_graph_param->max_degree_ == degree);
+        REQUIRE(parameter->hierarchical_graph_param->max_degree_ ==
+                std::max<uint32_t>(1, degree / 2));
+
+        std::stringstream artifact;
+        REQUIRE(index->Serialize(artifact).has_value());
+        artifact.seekg(0, std::ios::beg);
+        auto restored = vsag::Factory::CreateIndex("hgraph", create_parameters(degree));
+        REQUIRE(restored.has_value());
+        REQUIRE(restored.value()->Deserialize(artifact).has_value());
+        REQUIRE(
+            restored.value()->KnnSearch(query, 10, R"({"hgraph":{"ef_search":40}})").has_value());
+    }
+
+    REQUIRE_THROWS(hgraph->ReduceMaxDegree(3));
+    REQUIRE_THROWS(hgraph->ReduceMaxDegree(4));
+}

--- a/src/algorithm/hgraph/hgraph_degree_reduction_test.cpp
+++ b/src/algorithm/hgraph/hgraph_degree_reduction_test.cpp
@@ -28,16 +28,24 @@
 namespace {
 
 std::string
-create_parameters(uint32_t max_degree) {
+create_parameters(uint32_t max_degree,
+                  const std::string& quantization = "fp32",
+                  bool store_raw_vector = false,
+                  bool support_force_remove = false) {
     return fmt::format(R"({{"dim":8,"dtype":"float32","metric_type":"l2","index_param":{{)"
-                       R"("base_quantization_type":"fp32","max_degree":{},"ef_construction":40,)"
-                       R"("build_thread_count":1}}}})",
-                       max_degree);
+                       R"("base_quantization_type":"{}","max_degree":{},)"
+                       R"("ef_construction":40,"build_thread_count":1,)"
+                       R"("store_raw_vector":{},"support_force_remove":{}}}}})",
+                       quantization,
+                       max_degree,
+                       store_raw_vector,
+                       support_force_remove);
 }
 
 }  // namespace
 
-TEST_CASE("HGraph materializes nested compact max-degree graphs", "[ut][hgraph_degree_reduction]") {
+TEST_CASE("HGraph Tune reduces max degree and changes quantization",
+          "[ut][hgraph_degree_reduction]") {
     constexpr int64_t count = 256;
     constexpr int64_t dim = 8;
     std::vector<int64_t> ids(count);
@@ -60,7 +68,7 @@ TEST_CASE("HGraph materializes nested compact max-degree graphs", "[ut][hgraph_d
                      ->Float32Vectors(vectors.data())
                      ->Owner(false);
 
-    auto created = vsag::Factory::CreateIndex("hgraph", create_parameters(16));
+    auto created = vsag::Factory::CreateIndex("hgraph", create_parameters(16, "fp32", true));
     REQUIRE(created.has_value());
     auto index = std::dynamic_pointer_cast<vsag::IndexImpl<vsag::HGraph>>(created.value());
     REQUIRE(index != nullptr);
@@ -69,28 +77,162 @@ TEST_CASE("HGraph materializes nested compact max-degree graphs", "[ut][hgraph_d
 
     auto hgraph = std::dynamic_pointer_cast<vsag::HGraph>(index->GetInnerIndex());
     REQUIRE(hgraph != nullptr);
-    REQUIRE(hgraph->CanReduceMaxDegree());
-    hgraph->PrepareDegreeReduction();
+    auto parameter = std::dynamic_pointer_cast<vsag::HGraphParameter>(hgraph->create_param_ptr_);
+    REQUIRE(parameter != nullptr);
+    auto no_degree = index->Tune(R"({"index_param":{"base_quantization_type":"fp32"}})");
+    REQUIRE(no_degree.has_value());
+    REQUIRE(no_degree.value());
+    REQUIRE(parameter->bottom_graph_param->max_degree_ == 16);
 
-    for (const auto degree : {8U, 4U}) {
-        hgraph->ReduceMaxDegree(degree);
-        const auto parameter =
-            std::dynamic_pointer_cast<vsag::HGraphParameter>(hgraph->create_param_ptr_);
-        REQUIRE(parameter != nullptr);
-        REQUIRE(parameter->bottom_graph_param->max_degree_ == degree);
-        REQUIRE(parameter->hierarchical_graph_param->max_degree_ ==
-                std::max<uint32_t>(1, degree / 2));
+    auto same_degree =
+        index->Tune(R"({"index_param":{"base_quantization_type":"fp32","max_degree":16}})");
+    REQUIRE(same_degree.has_value());
+    REQUIRE(same_degree.value());
+    REQUIRE(parameter->bottom_graph_param->max_degree_ == 16);
 
-        std::stringstream artifact;
-        REQUIRE(index->Serialize(artifact).has_value());
-        artifact.seekg(0, std::ios::beg);
-        auto restored = vsag::Factory::CreateIndex("hgraph", create_parameters(degree));
-        REQUIRE(restored.has_value());
-        REQUIRE(restored.value()->Deserialize(artifact).has_value());
-        REQUIRE(
-            restored.value()->KnnSearch(query, 10, R"({"hgraph":{"ef_search":40}})").has_value());
+    auto increased_degree =
+        index->Tune(R"({"index_param":{"base_quantization_type":"fp32","max_degree":32}})");
+    REQUIRE(increased_degree.has_value());
+    REQUIRE_FALSE(increased_degree.value());
+    REQUIRE(parameter->bottom_graph_param->max_degree_ == 16);
+
+    auto reduced_and_quantized =
+        index->Tune(R"({"index_param":{"base_quantization_type":"sq8","max_degree":8}})", true);
+    REQUIRE(reduced_and_quantized.has_value());
+    REQUIRE(reduced_and_quantized.value());
+    REQUIRE(parameter->bottom_graph_param->max_degree_ == 8);
+    REQUIRE(parameter->hierarchical_graph_param->max_degree_ == 4);
+    REQUIRE(parameter->base_codes_param->ToJson()["quantization_params"]["type"].GetString() ==
+            std::string("sq8"));
+    REQUIRE_FALSE(parameter->store_raw_vector);
+    const auto memory_detail = index->GetMemoryUsageDetail();
+    const auto measured_memory =
+        std::accumulate(memory_detail.begin(),
+                        memory_detail.end(),
+                        uint64_t{sizeof(vsag::HGraph)},
+                        [](auto sum, const auto& item) { return sum + item.second; });
+    REQUIRE(index->GetMemoryUsage() == measured_memory);
+    REQUIRE(index->KnnSearch(query, 10, R"({"hgraph":{"ef_search":40}})").has_value());
+
+    std::stringstream artifact;
+    REQUIRE(index->Serialize(artifact).has_value());
+    artifact.seekg(0, std::ios::beg);
+    auto restored = vsag::Factory::CreateIndex("hgraph", create_parameters(8, "sq8"));
+    REQUIRE(restored.has_value());
+    REQUIRE(restored.value()->Deserialize(artifact).has_value());
+    REQUIRE(restored.value()->KnnSearch(query, 10, R"({"hgraph":{"ef_search":40}})").has_value());
+
+    auto disabled =
+        index->Tune(R"({"index_param":{"base_quantization_type":"sq8","max_degree":4}})");
+    REQUIRE(disabled.has_value());
+    REQUIRE_FALSE(disabled.value());
+}
+
+TEST_CASE("HGraph Tune prepares degree reduction again after Add",
+          "[ut][hgraph_degree_reduction]") {
+    constexpr int64_t count = 128;
+    constexpr int64_t dim = 8;
+    std::vector<int64_t> ids(count);
+    std::iota(ids.begin(), ids.end(), 0);
+    std::vector<float> vectors(count * dim);
+    for (int64_t i = 0; i < count; ++i) {
+        for (int64_t j = 0; j < dim; ++j) {
+            vectors[i * dim + j] = static_cast<float>((i * 11 + j * 23) % 131) / 131.0F;
+        }
     }
+    auto base = vsag::Dataset::Make()
+                    ->NumElements(count)
+                    ->Dim(dim)
+                    ->Ids(ids.data())
+                    ->Float32Vectors(vectors.data())
+                    ->Owner(false);
+    auto created = vsag::Factory::CreateIndex("hgraph", create_parameters(16));
+    REQUIRE(created.has_value());
+    auto index = created.value();
+    REQUIRE(index->Build(base).has_value());
 
-    REQUIRE_THROWS(hgraph->ReduceMaxDegree(3));
-    REQUIRE_THROWS(hgraph->ReduceMaxDegree(4));
+    auto first_reduction =
+        index->Tune(R"({"index_param":{"base_quantization_type":"fp32","max_degree":8}})");
+    REQUIRE(first_reduction.has_value());
+    REQUIRE(first_reduction.value());
+
+    int64_t added_id = count;
+    std::vector<float> added_vector(dim, 0.25F);
+    auto added = vsag::Dataset::Make()
+                     ->NumElements(1)
+                     ->Dim(dim)
+                     ->Ids(&added_id)
+                     ->Float32Vectors(added_vector.data())
+                     ->Owner(false);
+    REQUIRE(index->Add(added).has_value());
+
+    auto second_reduction =
+        index->Tune(R"({"index_param":{"base_quantization_type":"fp32","max_degree":4}})");
+    REQUIRE(second_reduction.has_value());
+    REQUIRE(second_reduction.value());
+
+    auto query = vsag::Dataset::Make()
+                     ->NumElements(1)
+                     ->Dim(dim)
+                     ->Float32Vectors(added_vector.data())
+                     ->Owner(false);
+    REQUIRE(index->KnnSearch(query, 10, R"({"hgraph":{"ef_search":40}})").has_value());
+
+    std::stringstream artifact;
+    REQUIRE(index->Serialize(artifact).has_value());
+    artifact.seekg(0, std::ios::beg);
+    auto restored = vsag::Factory::CreateIndex("hgraph", create_parameters(4));
+    REQUIRE(restored.has_value());
+    REQUIRE(restored.value()->Deserialize(artifact).has_value());
+    REQUIRE(restored.value()->KnnSearch(query, 10, R"({"hgraph":{"ef_search":40}})").has_value());
+}
+
+TEST_CASE("HGraph Tune freeze keeps explicitly requested raw vectors",
+          "[ut][hgraph_degree_reduction]") {
+    constexpr int64_t count = 64;
+    constexpr int64_t dim = 8;
+    std::vector<int64_t> ids(count);
+    std::iota(ids.begin(), ids.end(), 0);
+    std::vector<float> vectors(count * dim);
+    std::iota(vectors.begin(), vectors.end(), 0.0F);
+    auto base = vsag::Dataset::Make()
+                    ->NumElements(count)
+                    ->Dim(dim)
+                    ->Ids(ids.data())
+                    ->Float32Vectors(vectors.data())
+                    ->Owner(false);
+
+    auto created = vsag::Factory::CreateIndex("hgraph", create_parameters(16, "fp32", true));
+    REQUIRE(created.has_value());
+    auto index = std::dynamic_pointer_cast<vsag::IndexImpl<vsag::HGraph>>(created.value());
+    REQUIRE(index != nullptr);
+    REQUIRE(index->Build(base).has_value());
+    auto hgraph = std::dynamic_pointer_cast<vsag::HGraph>(index->GetInnerIndex());
+    REQUIRE(hgraph != nullptr);
+    auto parameter = std::dynamic_pointer_cast<vsag::HGraphParameter>(hgraph->create_param_ptr_);
+    REQUIRE(parameter != nullptr);
+
+    auto tuned = index->Tune(R"({"index_param":{"base_quantization_type":"sq8","max_degree":8,)"
+                             R"("store_raw_vector":true}})",
+                             true);
+    REQUIRE(tuned.has_value());
+    REQUIRE(tuned.value());
+    REQUIRE(parameter->store_raw_vector);
+
+    std::stringstream artifact;
+    REQUIRE(index->Serialize(artifact).has_value());
+    artifact.seekg(0, std::ios::beg);
+    auto restored = vsag::Factory::CreateIndex("hgraph", create_parameters(8, "sq8", true));
+    REQUIRE(restored.has_value());
+    REQUIRE(restored.value()->Deserialize(artifact).has_value());
+}
+
+TEST_CASE("HGraph Tune rejects degree reduction for unsupported graphs",
+          "[ut][hgraph_degree_reduction]") {
+    auto created = vsag::Factory::CreateIndex("hgraph", create_parameters(16, "fp32", false, true));
+    REQUIRE(created.has_value());
+    auto tuned = created.value()->Tune(
+        R"({"index_param":{"base_quantization_type":"fp32","max_degree":8}})");
+    REQUIRE(tuned.has_value());
+    REQUIRE_FALSE(tuned.value());
 }

--- a/src/algorithm/hgraph/hgraph_serialize.cpp
+++ b/src/algorithm/hgraph/hgraph_serialize.cpp
@@ -906,6 +906,7 @@ HGraph::read_streaming_body(StreamReader& reader,
 
 void
 HGraph::Deserialize(StreamReader& reader) {
+    this->degree_reduction_prepared_.store(false, std::memory_order_release);
     // try to deserialize footer (only in new version)
     auto footer = Footer::Parse(reader);
 

--- a/tools/autotune/autotune.cpp
+++ b/tools/autotune/autotune.cpp
@@ -409,6 +409,7 @@ make_context(eval::EvalDatasetPtr dataset,
     RequestContext request;
     request.workspace_path =
         config.workspace_path.empty() ? "/tmp/vsag_autotune" : config.workspace_path;
+    request.allow_quantization_tune = config.allow_quantization_tune;
     request.keep_intermediate = config.keep_intermediate;
     request.include_raw_eval = config.include_raw_evaluation;
     request.max_trials = config.max_trials;
@@ -469,6 +470,7 @@ make_context(eval::EvalDatasetPtr dataset,
         {"objective", {{"metric", request.objective}}},
         {"config",
          {{"workspace_path", request.workspace_path},
+          {"allow_quantization_tune", request.allow_quantization_tune},
           {"keep_intermediate", request.keep_intermediate},
           {"max_trials", request.max_trials}}},
         {"output", {{"include_raw_evaluation", request.include_raw_eval}}}};
@@ -646,11 +648,17 @@ ParseRequest(const JsonType& input) {
         parse_metric(required_string(input["objective"], "metric", "request.objective"));
     if (input.contains("tuning_config")) {
         const auto& config = input["tuning_config"];
-        known_keys(
-            config, {"workspace_path", "keep_intermediate", "max_trials"}, "request.tuning_config");
+        known_keys(config,
+                   {"workspace_path", "allow_quantization_tune", "keep_intermediate", "max_trials"},
+                   "request.tuning_config");
         if (config.contains("workspace_path")) {
             typed.config.workspace_path =
                 required_string(config, "workspace_path", "request.tuning_config");
+        }
+        if (config.contains("allow_quantization_tune")) {
+            require(config["allow_quantization_tune"].is_boolean(),
+                    "request.tuning_config.allow_quantization_tune must be a boolean");
+            typed.config.allow_quantization_tune = config["allow_quantization_tune"].get<bool>();
         }
         if (config.contains("keep_intermediate")) {
             require(config["keep_intermediate"].is_boolean(),

--- a/tools/autotune/autotune.h
+++ b/tools/autotune/autotune.h
@@ -70,6 +70,8 @@ struct Config {
     /// Keep every generated index artifact instead of only the selected artifact.
     bool keep_intermediate{false};
     bool include_raw_evaluation{false};
+    /// Allow HGraph base_quantization_type candidates to share a canonical fp32 build.
+    bool allow_quantization_tune{false};
 };
 
 /// Candidate space for one concrete index type.

--- a/tools/autotune/autotune_evaluation.cpp
+++ b/tools/autotune/autotune_evaluation.cpp
@@ -13,12 +13,14 @@
 // limitations under the License.
 
 #include <chrono>
+#include <cstdint>
 #include <filesystem>
 #include <fstream>
 #include <map>
 #include <optional>
 #include <stdexcept>
 #include <system_error>
+#include <utility>
 
 #include "autotune_internal.h"
 #include "eval_config.h"
@@ -64,6 +66,20 @@ build_metrics(const JsonType& raw, const std::string& index_path) {
     if (!error) {
         metrics["index_size_mb"] = static_cast<double>(bytes) / BYTES_PER_MEBIBYTE;
     }
+    return metrics;
+}
+
+MetricMap
+tuned_build_metrics(const JsonType& source_raw,
+                    const IndexPtr& index,
+                    const std::string& index_path,
+                    double transform_seconds) {
+    auto metrics = build_metrics(source_raw, index_path);
+    const auto build = metrics.find("build_seconds");
+    if (build != metrics.end()) {
+        build->second += transform_seconds;
+    }
+    metrics["index_memory_mb"] = static_cast<double>(index->GetMemoryUsage()) / BYTES_PER_MEBIBYTE;
     return metrics;
 }
 
@@ -126,6 +142,20 @@ create_index(const Candidate& candidate) {
     return created.value();
 }
 
+IndexPtr
+deserialize_index(const Candidate& candidate, const std::string& path) {
+    auto index = create_index(candidate);
+    std::ifstream input(path, std::ios::binary);
+    if (!input.good()) {
+        throw std::runtime_error("failed to open index artifact: " + path);
+    }
+    auto deserialized = index->Deserialize(input);
+    if (!deserialized.has_value()) {
+        throw std::runtime_error(deserialized.error().message);
+    }
+    return index;
+}
+
 void
 serialize_index(const IndexPtr& index, const std::string& path) {
     const auto parent = std::filesystem::path(path).parent_path();
@@ -142,6 +172,94 @@ serialize_index(const IndexPtr& index, const std::string& path) {
     if (!output.good()) {
         throw std::runtime_error("failed to write index artifact: " + path);
     }
+}
+
+class TemporaryArtifact {
+public:
+    explicit TemporaryArtifact(std::string path) : path_(std::move(path)) {
+    }
+
+    ~TemporaryArtifact() {
+        std::error_code error;
+        std::filesystem::remove(path_, error);
+    }
+
+    TemporaryArtifact(const TemporaryArtifact&) = delete;
+    TemporaryArtifact&
+    operator=(const TemporaryArtifact&) = delete;
+
+private:
+    std::string path_;
+};
+
+std::optional<uint64_t>
+hgraph_max_degree(const Candidate& candidate) {
+    if (candidate.index_name != "hgraph" || !candidate.create_params.is_object() ||
+        !candidate.create_params.contains("index_param") ||
+        !candidate.create_params["index_param"].is_object()) {
+        return std::nullopt;
+    }
+    const auto& params = candidate.create_params["index_param"];
+    if (!params.contains("max_degree") || !params["max_degree"].is_number_integer()) {
+        return std::nullopt;
+    }
+    if (params["max_degree"].is_number_unsigned()) {
+        const auto degree = params["max_degree"].get<uint64_t>();
+        return degree > 0 ? std::optional<uint64_t>(degree) : std::nullopt;
+    }
+    const auto degree = params["max_degree"].get<int64_t>();
+    return degree > 0 ? std::optional<uint64_t>(static_cast<uint64_t>(degree)) : std::nullopt;
+}
+
+std::optional<std::string>
+hgraph_reuse_key(const Candidate& candidate, bool allow_quantization_tune) {
+    if (!hgraph_max_degree(candidate).has_value()) {
+        return std::nullopt;
+    }
+    auto create_params = candidate.create_params;
+    auto& params = create_params["index_param"];
+    if (!params.contains("base_quantization_type") ||
+        !params["base_quantization_type"].is_string()) {
+        return std::nullopt;
+    }
+    params.erase("max_degree");
+    if (allow_quantization_tune) {
+        params.erase("base_quantization_type");
+    }
+    return "hgraph_tune\n" + create_params.dump();
+}
+
+Candidate
+canonical_candidate(const Candidate& candidate, uint64_t max_degree, bool allow_quantization_tune) {
+    auto canonical = candidate;
+    auto& params = canonical.create_params["index_param"];
+    params["max_degree"] = max_degree;
+    if (allow_quantization_tune) {
+        params["base_quantization_type"] = "fp32";
+        params["store_raw_vector"] = true;
+    }
+    return canonical;
+}
+
+void
+tune_index(const IndexPtr& index, const Candidate& candidate, bool disable_future_tuning) {
+    auto target = candidate.create_params;
+    const auto preserve_tuning = target["index_param"].value("store_raw_vector", false);
+    auto tuned = index->Tune(target.dump(), disable_future_tuning && !preserve_tuning);
+    if (!tuned.has_value()) {
+        throw std::runtime_error(tuned.error().message);
+    }
+    if (!tuned.value()) {
+        throw std::runtime_error("index does not support the requested tuning transformation");
+    }
+}
+
+bool
+uses_build_cost(const RequestContext& request) {
+    return request.objective == "build_seconds" ||
+           request.objective == "build_and_search_seconds" ||
+           request.constraints.find("build_seconds") != request.constraints.end() ||
+           request.constraints.find("build_and_search_seconds") != request.constraints.end();
 }
 
 }  // namespace
@@ -193,76 +311,110 @@ EvaluateCandidates(const IndexTuningRequest& tuning_request,
     const auto& request = tuning_request.context;
     Evaluation evaluation;
     std::map<std::string, std::vector<uint64_t>> groups;
+    const auto reuse_hgraph_builds = !uses_build_cost(request);
     for (uint64_t i = 0; i < candidates.size(); ++i) {
-        const auto key = candidates[i].index_name + "\n" + candidates[i].create_params.dump();
+        auto key = candidates[i].index_name + "\n" + candidates[i].create_params.dump();
+        if (reuse_hgraph_builds) {
+            const auto reuse_key = hgraph_reuse_key(candidates[i], request.allow_quantization_tune);
+            if (reuse_key.has_value()) {
+                key = *reuse_key;
+            }
+        }
         groups[key].emplace_back(i);
     }
 
-    uint64_t build_number = 0;
-    uint64_t trial_number = 0;
-    for (const auto& [unused, indexes] : groups) {
-        (void)unused;
-        const auto& first = candidates[indexes.front()];
-        const auto build_id = "build-" + std::to_string(build_number++);
-        const auto index_path =
-            (std::filesystem::path(run_path) / "artifacts" / (build_id + ".index")).string();
-        JsonType build{{"build_id", build_id},
-                       {"index_name", first.index_name},
-                       {"create_params", first.create_params},
-                       {"status", "failed"},
-                       {"metrics", JsonType::object()},
-                       {"failure", nullptr},
-                       {"artifacts",
-                        {{"index_path", index_path},
-                         {"source", "generated"},
-                         {"use_existing_index", false},
-                         {"retained", true}}}};
-
-        MetricMap shared_metrics;
+    struct BuildState {
         IndexPtr index;
-        const auto build_start = std::chrono::steady_clock::now();
-        try {
-            index = create_index(first);
-            auto raw = eval::EvaluateBuild(index, request.dataset, build_config(first));
-            serialize_index(index, index_path);
-            shared_metrics = build_metrics(raw, index_path);
-            if (request.include_raw_eval) {
-                build["raw_eval_result"] = std::move(raw);
-            }
-            build["metrics"] = metrics_json(shared_metrics);
-            build["status"] = "success";
-        } catch (const std::exception& error) {
-            build["failure"] = Failure("build", "build_evaluation_failed", error.what());
-            std::error_code cleanup_error;
-            std::filesystem::remove(index_path, cleanup_error);
-            build["artifacts"]["retained"] = false;
-        }
-        build["elapsed_seconds"] = elapsed(build_start);
-        evaluation.builds.emplace_back(build);
+        JsonType report;
+        MetricMap metrics;
+        std::string path;
+    };
 
+    struct SourceState {
+        IndexPtr index;
+        Candidate candidate;
+        JsonType raw;
+        std::string id;
+    };
+
+    uint64_t build_number = 0;
+    uint64_t source_number = 0;
+    uint64_t trial_number = 0;
+
+    const auto artifact_path = [&run_path](const std::string& id) {
+        return (std::filesystem::path(run_path) / "artifacts" / (id + ".index")).string();
+    };
+
+    const auto new_build_state =
+        [&](const Candidate& candidate, const std::string& build_id, const std::string& strategy) {
+            const auto index_path = artifact_path(build_id);
+            const auto artifact_source = strategy == "full_build" ? "generated" : strategy;
+            return BuildState{nullptr,
+                              {{"build_id", build_id},
+                               {"index_name", candidate.index_name},
+                               {"create_params", candidate.create_params},
+                               {"strategy", strategy},
+                               {"status", "failed"},
+                               {"metrics", JsonType::object()},
+                               {"failure", nullptr},
+                               {"artifacts",
+                                {{"index_path", index_path},
+                                 {"source", artifact_source},
+                                 {"use_existing_index", false},
+                                 {"retained", true}}}},
+                              {},
+                              index_path};
+        };
+
+    const auto build_index = [&](const Candidate& candidate, const std::string& build_id) {
+        auto state = new_build_state(candidate, build_id, "full_build");
+        const auto start = std::chrono::steady_clock::now();
+        try {
+            state.index = create_index(candidate);
+            auto raw = eval::EvaluateBuild(state.index, request.dataset, build_config(candidate));
+            serialize_index(state.index, state.path);
+            state.metrics = build_metrics(raw, state.path);
+            if (request.include_raw_eval) {
+                state.report["raw_eval_result"] = std::move(raw);
+            }
+            state.report["metrics"] = metrics_json(state.metrics);
+            state.report["status"] = "success";
+        } catch (const std::exception& error) {
+            state.report["failure"] = Failure("build", "build_evaluation_failed", error.what());
+            std::error_code cleanup_error;
+            std::filesystem::remove(state.path, cleanup_error);
+            state.report["artifacts"]["retained"] = false;
+            state.index.reset();
+        }
+        state.report["elapsed_seconds"] = elapsed(start);
+        return state;
+    };
+
+    const auto evaluate_searches = [&](const BuildState& build,
+                                       const std::vector<uint64_t>& indexes) {
         const auto evaluate = [&](const Candidate& candidate) -> std::optional<double> {
             const auto trial_id = "trial-" + std::to_string(trial_number++);
             JsonType trial{{"trial_id", trial_id},
-                           {"build_id", build_id},
+                           {"build_id", build.report["build_id"]},
                            {"index_name", candidate.index_name},
                            {"create_params", candidate.create_params},
                            {"search_params", candidate.search_params},
                            {"status", "failed"},
-                           {"metrics", metrics_json(shared_metrics)},
+                           {"metrics", metrics_json(build.metrics)},
                            {"failure", nullptr},
-                           {"artifacts", build["artifacts"]}};
+                           {"artifacts", build.report["artifacts"]}};
             std::optional<double> recall;
             const auto search_start = std::chrono::steady_clock::now();
-            if (build["status"] != "success") {
+            if (build.report["status"] != "success") {
                 trial["failure"] =
                     Failure("search", "build_failed", "search skipped because build failed");
             } else {
                 try {
                     const auto measured_start = std::chrono::steady_clock::now();
                     auto raw = eval::EvaluateSearch(
-                        index, request.dataset, search_config(request, candidate));
+                        build.index, request.dataset, search_config(request, candidate));
                     auto metrics = search_metrics(raw, elapsed(measured_start));
-                    for (const auto& [name, value] : shared_metrics) {
+                    for (const auto& [name, value] : build.metrics) {
                         metrics.emplace(name, value);
                     }
                     if (metrics.find("build_seconds") != metrics.end()) {
@@ -298,6 +450,153 @@ EvaluateCandidates(const IndexTuningRequest& tuning_request,
                 return evaluate(concrete);
             };
             EvaluateEfSearchRange(*candidate.ef_search_range, recall_target, evaluate_ef_search);
+        }
+    };
+
+    const auto record_and_search = [&](BuildState state, const std::vector<uint64_t>& indexes) {
+        evaluation.builds.emplace_back(state.report);
+        evaluate_searches(state, indexes);
+    };
+
+    const auto evaluate_native = [&](const std::vector<uint64_t>& indexes,
+                                     std::optional<std::string> build_id = std::nullopt) {
+        const auto id =
+            build_id.has_value() ? *build_id : "build-" + std::to_string(build_number++);
+        record_and_search(build_index(candidates[indexes.front()], id), indexes);
+    };
+
+    for (const auto& [unused, indexes] : groups) {
+        (void)unused;
+        std::map<std::string, std::vector<uint64_t>> create_groups;
+        for (const auto candidate_index : indexes) {
+            create_groups[candidates[candidate_index].create_params.dump()].emplace_back(
+                candidate_index);
+        }
+        if (create_groups.size() <= 1) {
+            evaluate_native(indexes);
+            continue;
+        }
+
+        std::map<uint64_t, std::vector<std::string>, std::greater<>> degree_groups;
+        bool reusable = true;
+        for (const auto& [create_key, candidate_indexes] : create_groups) {
+            const auto degree = hgraph_max_degree(candidates[candidate_indexes.front()]);
+            if (!degree.has_value()) {
+                reusable = false;
+                break;
+            }
+            degree_groups[*degree].emplace_back(create_key);
+        }
+        if (!reusable) {
+            for (const auto& [create_key, candidate_indexes] : create_groups) {
+                (void)create_key;
+                evaluate_native(candidate_indexes);
+            }
+            continue;
+        }
+
+        const auto source_id = "source-build-" + std::to_string(source_number++);
+        const auto max_degree = degree_groups.begin()->first;
+        const auto& source_indexes = create_groups.at(degree_groups.begin()->second.front());
+        SourceState source{
+            nullptr,
+            canonical_candidate(
+                candidates[source_indexes.front()], max_degree, request.allow_quantization_tune),
+            JsonType::object(),
+            source_id};
+        try {
+            source.index = create_index(source.candidate);
+            source.raw =
+                eval::EvaluateBuild(source.index, request.dataset, build_config(source.candidate));
+        } catch (const std::exception&) {
+            reusable = false;
+        }
+        if (!reusable) {
+            for (const auto& [create_key, candidate_indexes] : create_groups) {
+                (void)create_key;
+                evaluate_native(candidate_indexes);
+            }
+            continue;
+        }
+
+        double degree_transform_seconds = 0.0;
+        for (auto degree = degree_groups.begin(); degree != degree_groups.end(); ++degree) {
+            if (!reusable) {
+                for (const auto& create_key : degree->second) {
+                    evaluate_native(create_groups.at(create_key));
+                }
+                continue;
+            }
+
+            source.candidate.create_params["index_param"]["max_degree"] = degree->first;
+            const auto snapshot_path =
+                artifact_path(source.id + "-" + std::to_string(degree->first));
+            const TemporaryArtifact snapshot(snapshot_path);
+            try {
+                serialize_index(source.index, snapshot_path);
+            } catch (const std::exception&) {
+                reusable = false;
+            }
+
+            if (reusable) {
+                for (const auto& create_key : degree->second) {
+                    const auto& candidate_indexes = create_groups.at(create_key);
+                    const auto& candidate = candidates[candidate_indexes.front()];
+                    const auto build_id = "build-" + std::to_string(build_number++);
+                    auto state = new_build_state(candidate, build_id, "hgraph_tune");
+                    bool tuned = false;
+                    try {
+                        state.index = deserialize_index(source.candidate, snapshot_path);
+                        const auto transform_start = std::chrono::steady_clock::now();
+                        tune_index(state.index, candidate, true);
+                        const auto transform_seconds =
+                            degree_transform_seconds + elapsed(transform_start);
+                        serialize_index(state.index, state.path);
+                        state.metrics = tuned_build_metrics(
+                            source.raw, state.index, state.path, transform_seconds);
+                        state.report["strategy"] = "hgraph_tune";
+                        state.report["source_build_id"] = source.id;
+                        state.report["transform_seconds"] = transform_seconds;
+                        state.report["metrics"] = metrics_json(state.metrics);
+                        state.report["status"] = "success";
+                        state.report["elapsed_seconds"] = elapsed(transform_start);
+                        if (request.include_raw_eval) {
+                            auto raw = source.raw;
+                            raw["duration(s)"] = state.metrics["build_seconds"];
+                            raw["index_info"] = candidate.create_params;
+                            raw["index_memory(B)"] = state.index->GetMemoryUsage();
+                            state.report["raw_eval_result"] = std::move(raw);
+                        }
+                        tuned = true;
+                    } catch (const std::exception&) {
+                        std::error_code cleanup_error;
+                        std::filesystem::remove(state.path, cleanup_error);
+                    }
+
+                    if (tuned) {
+                        record_and_search(std::move(state), candidate_indexes);
+                    } else {
+                        evaluate_native(candidate_indexes, build_id);
+                    }
+                }
+            } else {
+                for (const auto& create_key : degree->second) {
+                    evaluate_native(create_groups.at(create_key));
+                }
+            }
+
+            const auto next = std::next(degree);
+            if (!reusable || next == degree_groups.end()) {
+                continue;
+            }
+            source.candidate.create_params["index_param"]["max_degree"] = next->first;
+            try {
+                const auto transform_start = std::chrono::steady_clock::now();
+                tune_index(source.index, source.candidate, false);
+                degree_transform_seconds += elapsed(transform_start);
+            } catch (const std::exception&) {
+                reusable = false;
+            }
         }
     }
     return evaluation;

--- a/tools/autotune/autotune_internal.h
+++ b/tools/autotune/autotune_internal.h
@@ -57,6 +57,7 @@ struct RequestContext {
     bool enable_recall{false};
     bool keep_intermediate{false};
     bool include_raw_eval{false};
+    bool allow_quantization_tune{false};
 };
 
 struct IndexTuningRequest {

--- a/tools/autotune/autotune_test.cpp
+++ b/tools/autotune/autotune_test.cpp
@@ -514,6 +514,14 @@ TEST_CASE("AutoTune validates typed requests and optional ground truth") {
     const auto parsed = vsag::autotune::internal::ParseRequest(input);
     REQUIRE(parsed.context.dataset->GetTrainIds()[0] == fixture.base_ids[0]);
     REQUIRE(parsed.context.dataset->GetTrainIds()[1] == fixture.base_ids[1]);
+    REQUIRE_FALSE(parsed.context.allow_quantization_tune);
+    REQUIRE(parsed.context.effective_request["config"]["allow_quantization_tune"] == false);
+
+    input.config.allow_quantization_tune = true;
+    const auto quantization_tune = vsag::autotune::internal::ParseRequest(input);
+    REQUIRE(quantization_tune.context.allow_quantization_tune);
+    REQUIRE(quantization_tune.context.effective_request["config"]["allow_quantization_tune"] ==
+            true);
 
     input.constraints = {{vsag::autotune::Metric::LATENCY_AVG_MS, 1000.0}};
     input.workload.ground_truth = nullptr;
@@ -620,6 +628,15 @@ TEST_CASE("AutoTune keeps normalized offline request metadata") {
     auto input = request(dataset.Get(), workspace.Get());
     input.erase("indexes");
 
+    const auto default_parsed = vsag::autotune::internal::ParseRequest(input);
+    const auto& default_request =
+        std::get<vsag::autotune::internal::IndexTuningRequest>(default_parsed);
+    REQUIRE_FALSE(default_request.context.allow_quantization_tune);
+    REQUIRE(default_request.context.effective_request["config"]["allow_quantization_tune"] ==
+            false);
+
+    input["tuning_config"]["allow_quantization_tune"] = true;
+
     const auto parsed = vsag::autotune::internal::ParseRequest(input);
     const auto& index_request = std::get<vsag::autotune::internal::IndexTuningRequest>(parsed);
     const auto& effective = index_request.context.effective_request;
@@ -640,8 +657,15 @@ TEST_CASE("AutoTune keeps normalized offline request metadata") {
         REQUIRE(space["create_parameter_space"]["metric_type"] == "l2");
     }
     REQUIRE(effective["workload"]["concurrency"] == 2);
+    REQUIRE(index_request.context.allow_quantization_tune);
+    REQUIRE(effective["config"]["allow_quantization_tune"] == true);
     REQUIRE(effective["config"]["keep_intermediate"] == true);
     REQUIRE_FALSE(effective.contains("tuning_config"));
+
+    input["tuning_config"]["allow_quantization_tune"] = 1;
+    REQUIRE_THROWS_WITH(vsag::autotune::internal::ParseRequest(input),
+                        Catch::Matchers::ContainsSubstring(
+                            "request.tuning_config.allow_quantization_tune must be a boolean"));
 }
 
 TEST_CASE("AutoTune rejects index artifacts that fail to flush") {
@@ -760,13 +784,16 @@ TEST_CASE("AutoTune builds once per create candidate and supports an existing in
     ScopedPath workspace(temp_path("autotune-workspace"));
     write_dataset(dataset.Get());
 
-    const auto result = vsag::autotune::RunAutoTune(request(dataset.Get(), workspace.Get()));
+    auto input = request(dataset.Get(), workspace.Get());
+    input["tuning_config"]["allow_quantization_tune"] = true;
+    const auto result = vsag::autotune::RunAutoTune(input);
     INFO(result.dump(2));
     REQUIRE(result["status"] == "success");
     REQUIRE(omp_get_max_threads() == 3);
     REQUIRE(result["builds"].size() == 2);
     REQUIRE(result["trials"].size() == 4);
     REQUIRE(result["recommendation"]["create_params"]["dim"] == 8);
+    REQUIRE(result["request"]["config"]["allow_quantization_tune"] == true);
     for (const auto& build : result["builds"]) {
         REQUIRE(build["status"] == "success");
         REQUIRE(build["metrics"].contains("build_seconds"));
@@ -805,6 +832,149 @@ TEST_CASE("AutoTune builds once per create candidate and supports an existing in
     REQUIRE(existing_result["request"]["create_params"]["dim"] == 8);
     REQUIRE(existing_result["request"]["create_params"]["dtype"] == "float32");
     REQUIRE(existing_result["request"]["create_params"]["metric_type"] == "l2");
+}
+
+TEST_CASE("AutoTune derives HGraph degree and quantization candidates from canonical builds") {
+    vsag::Options::Instance().logger()->SetLevel(vsag::Logger::kOFF);
+    ScopedBlockSizeLimit block_size_limit(256UL * 1024);
+    ScopedPath workspace(temp_path("autotune-hgraph-reuse-workspace"));
+    MemoryFixture fixture;
+    auto input = fixture.Request(workspace.Get());
+    input.index_spaces[0].create_parameter_space =
+        R"({"index_param":{"base_quantization_type":["fp32","sq8_uniform"],)"
+        R"("max_degree":[8,12],"ef_construction":40,"build_thread_count":2,)"
+        R"("store_raw_vector":[false,true]}})";
+    input.constraints = {{vsag::autotune::Metric::RECALL_AT_K, 0.0}};
+    input.objective = vsag::autotune::Metric::INDEX_SIZE_MB;
+    input.config.allow_quantization_tune = true;
+    input.config.keep_intermediate = true;
+    input.config.max_trials = 8;
+
+    const auto tuned = vsag::autotune::TuneIndex(input);
+    REQUIRE(tuned.has_value());
+    const auto& report = tuned->report;
+    INFO(report.dump(2));
+    REQUIRE(report["builds"].size() == 8);
+    REQUIRE(report["trials"].size() == 8);
+    REQUIRE(std::all_of(report["builds"].begin(), report["builds"].end(), [](const auto& build) {
+        return build["status"] == "success" && build["strategy"] == "hgraph_tune";
+    }));
+    REQUIRE(std::all_of(report["builds"].begin(), report["builds"].end(), [](const auto& build) {
+        return build.contains("source_build_id") && build.contains("transform_seconds");
+    }));
+    REQUIRE(count_index_artifacts(workspace.Get()) == 8);
+    std::vector<std::string> source_ids;
+    std::string keep_raw_source;
+    std::string discard_raw_source;
+    for (const auto& build : report["builds"]) {
+        const auto source_id = build["source_build_id"].get<std::string>();
+        source_ids.emplace_back(source_id);
+        const auto keep_raw = build["create_params"]["index_param"]["store_raw_vector"].get<bool>();
+        auto& expected_source = keep_raw ? keep_raw_source : discard_raw_source;
+        if (expected_source.empty()) {
+            expected_source = source_id;
+        } else {
+            REQUIRE(expected_source == source_id);
+        }
+    }
+    std::sort(source_ids.begin(), source_ids.end());
+    source_ids.erase(std::unique(source_ids.begin(), source_ids.end()), source_ids.end());
+    REQUIRE(source_ids.size() == 2);
+    REQUIRE(keep_raw_source != discard_raw_source);
+
+    auto query = vsag::Dataset::Make()
+                     ->NumElements(1)
+                     ->Dim(MemoryFixture::DIM)
+                     ->Float32Vectors(fixture.test.data())
+                     ->Owner(false);
+    for (const auto& build : report["builds"]) {
+        const auto create_params = build["create_params"];
+        REQUIRE(create_params["index_param"]["store_raw_vector"].is_boolean());
+        auto restored = vsag::Factory::CreateIndex("hgraph", create_params.dump());
+        REQUIRE(restored.has_value());
+        std::ifstream artifact(build["artifacts"]["index_path"].get<std::string>(),
+                               std::ios::binary);
+        REQUIRE(artifact.good());
+        REQUIRE(restored.value()->Deserialize(artifact).has_value());
+        REQUIRE(
+            restored.value()->KnnSearch(query, 3, R"({"hgraph":{"ef_search":16}})").has_value());
+    }
+}
+
+TEST_CASE("AutoTune keeps HGraph quantization build families separate by default") {
+    vsag::Options::Instance().logger()->SetLevel(vsag::Logger::kOFF);
+    ScopedBlockSizeLimit block_size_limit(256UL * 1024);
+    ScopedPath workspace(temp_path("autotune-hgraph-degree-reuse-workspace"));
+    MemoryFixture fixture;
+    auto input = fixture.Request(workspace.Get());
+    input.index_spaces[0].create_parameter_space =
+        R"({"index_param":{"base_quantization_type":["fp32","sq8_uniform"],)"
+        R"("max_degree":[8,12],"ef_construction":40,"build_thread_count":2}})";
+    input.constraints = {{vsag::autotune::Metric::RECALL_AT_K, 0.0}};
+    input.objective = vsag::autotune::Metric::INDEX_SIZE_MB;
+    input.config.keep_intermediate = true;
+    input.config.max_trials = 4;
+
+    const auto tuned = vsag::autotune::TuneIndex(input);
+    REQUIRE(tuned.has_value());
+    const auto& report = tuned->report;
+    INFO(report.dump(2));
+    REQUIRE(report["request"]["config"]["allow_quantization_tune"] == false);
+    REQUIRE(report["builds"].size() == 4);
+    REQUIRE(report["trials"].size() == 4);
+
+    std::string fp32_source;
+    std::string sq8_source;
+    for (const auto& build : report["builds"]) {
+        REQUIRE(build["status"] == "success");
+        REQUIRE(build["strategy"] == "hgraph_tune");
+        const auto quantization =
+            build["create_params"]["index_param"]["base_quantization_type"].get<std::string>();
+        REQUIRE((quantization == "fp32" || quantization == "sq8_uniform"));
+        auto& source = quantization == "fp32" ? fp32_source : sq8_source;
+        const auto source_id = build["source_build_id"].get<std::string>();
+        if (source.empty()) {
+            source = source_id;
+        } else {
+            REQUIRE(source == source_id);
+        }
+    }
+    REQUIRE_FALSE(fp32_source.empty());
+    REQUIRE_FALSE(sq8_source.empty());
+    REQUIRE(fp32_source != sq8_source);
+}
+
+TEST_CASE("AutoTune disables HGraph build reuse for build-cost metrics") {
+    vsag::Options::Instance().logger()->SetLevel(vsag::Logger::kOFF);
+    ScopedBlockSizeLimit block_size_limit(256UL * 1024);
+    ScopedPath workspace(temp_path("autotune-hgraph-native-build-workspace"));
+    MemoryFixture fixture;
+    auto input = fixture.Request(workspace.Get());
+    input.index_spaces[0].create_parameter_space =
+        R"({"index_param":{"base_quantization_type":["fp32","sq8_uniform"],)"
+        R"("max_degree":[8,12],"ef_construction":40,"build_thread_count":2}})";
+    input.config.keep_intermediate = true;
+    input.config.max_trials = 4;
+
+    const auto require_native_builds = [](const auto& tuned) {
+        REQUIRE(tuned.has_value());
+        const auto& report = tuned->report;
+        INFO(report.dump(2));
+        REQUIRE(report["builds"].size() == 4);
+        REQUIRE(std::all_of(report["builds"].begin(),
+                            report["builds"].end(),
+                            [](const auto& build) { return build["strategy"] == "full_build"; }));
+    };
+
+    SECTION("constraint") {
+        require_native_builds(vsag::autotune::TuneIndex(input));
+    }
+
+    SECTION("objective") {
+        input.constraints = {{vsag::autotune::Metric::RECALL_AT_K, 0.0}};
+        input.objective = vsag::autotune::Metric::BUILD_SECONDS;
+        require_native_builds(vsag::autotune::TuneIndex(input));
+    }
 }
 
 TEST_CASE("AutoTune CLI keeps only the recommended artifact by default") {


### PR DESCRIPTION
## What changed

- extend HGraph `Index::Tune` with physical `max_degree` reduction;
- let AutoTune build the largest HGraph degree once and derive independent artifacts for smaller
  degree candidates;
- keep `base_quantization_type` families separate by default;
- add opt-in `allow_quantization_tune` support for deriving different base quantizations from one
  canonical fp32 build;
- fall back to native builds when reuse is unsupported or fails;
- disable build reuse when build time is a constraint or objective;
- document the request, report, artifact, and native-equivalence semantics in English and Chinese.

## Why

HGraph create spaces commonly combine several `max_degree` and quantization candidates. Building
every tuple independently repeats most graph-construction work and dominates AutoTune runtime.

The conservative default reuses work only across degree candidates within the same base
quantization. Cross-quantization Tune remains explicit because it changes vector codes without
rebuilding graph topology.

## Benchmark

SIFT1M, 1,000,000 × 128 L2 base vectors, 10,000 queries, 48 build threads,
`max_degree=[16,32,48]`, `base_quantization_type=[fp32,sq8]`, `ef_construction=400`,
`ef_search=100`, and six full-query trials:

| Strategy | Full builds | Elapsed | Speedup |
| --- | ---: | ---: | ---: |
| Native build per candidate | 6 | 302.42 s | 1.00x |
| Conservative degree reuse | 2 | 150.03 s | 2.02x |
| Opt-in cross-quantization reuse | 1 | 121.45 s | 2.49x |

The native and conservative runs both recommended sq8 with `max_degree=16`. Their measured recall
was 0.94824 and 0.95151, respectively.

## Semantics

A reduced-degree artifact inherits the larger graph's topology and is not guaranteed to equal a
native build from the same `create_params`. With opt-in quantization Tune, the graph is likewise
not rebuilt for the new quantization. AutoTune measures the final serialized artifact, which is
the authoritative output and should be loaded rather than recreated from parameters alone.

## Validation

- `clang-format-15 --dry-run --Werror` on changed C++ files
- `git diff --check`
- `autotune_test`: 341 assertions in 27 test cases
- HGraph degree-reduction tests: 55 assertions in 4 test cases
- existing deduplicated-storage Tune regression: 7 assertions in 1 test case
- SIFT1M end-to-end benchmark and artifact reload validation

Closes: #2672

Supersedes #2579.
