### PR TITLE
feat(hgraph): restore conjugate graph enhancement

### DIFF
--- a/docs/docs/en/src/advanced/enhance_graph.md
+++ b/docs/docs/en/src/advanced/enhance_graph.md
@@ -10,7 +10,8 @@ At build time:
 
 ```json
 {
-    "hnsw": {
+    "index_param": {
+        "base_quantization_type": "fp32",
         "max_degree": 32,
         "ef_construction": 400,
         "use_conjugate_graph": true
@@ -23,7 +24,7 @@ At search time, toggle it via the `use_conjugate_graph_search` key in the search
 
 ```cpp
 std::string search_param_json = R"({
-    "hnsw": {
+    "hgraph": {
         "ef_search": 100,
         "use_conjugate_graph_search": true
     }
@@ -33,9 +34,16 @@ auto result = index->KnnSearch(query, k, search_param_json);
 
 ## How It Works
 
-The conjugate graph is built by inverting "failure paths" over the training data on the original
-graph and then used as additional candidate edges during greedy expansion at search time. It is a
-lightweight patch on the main graph, typically below 10% of the main graph's size.
+Call `Feedback(query, k, search_parameters, global_optimum_id)` after a hard query when the exact
+nearest label is known. Omitting `global_optimum_id` makes HGraph compute it by an exact scan.
+For offline enhancement, `Pretrain(base_ids, k, search_parameters)` generates queries between the
+chosen float32 base vectors and their neighbors, then feeds the resulting failures back. Both
+methods return the number of newly inserted conjugate edges; redundant feedback returns zero.
+
+The conjugate graph maps local-result labels to known global optima and contributes extra
+candidates after HGraph's normal traversal. `use_conjugate_graph` is disabled by default; calling
+`Feedback` or `Pretrain` without it returns `UNSUPPORTED_INDEX_OPERATION`. Search enhancement is
+enabled by default for an enabled graph and can be disabled per search.
 
 ## Example
 
@@ -52,4 +60,6 @@ recall end-to-end.
 
 - Build time increases slightly when enabled.
 - Conjugate-graph data is serialized together with the index.
+- `UpdateId` updates conjugate edges as well as the HGraph label table.
+- `Pretrain` currently supports float32 HGraph indexes; `Feedback` supports all HGraph dtypes.
 - It can be combined with `Tune` — they target route quality and runtime parameters respectively.

--- a/docs/docs/en/src/indexes/hgraph.md
+++ b/docs/docs/en/src/indexes/hgraph.md
@@ -90,6 +90,7 @@ most users need; the exhaustive list is in [Index Parameters](../resources/index
 | `base_direct_read` / `precise_direct_read` | bool | `false` | With `uring_io`, open the corresponding file using direct IO instead of the page cache. |
 | `hgraph_init_capacity` | int | `100` | Initial capacity hint (doesn't cap the final size) |
 | `persist_source_id` | bool | `false` | Persist source-ID metadata during serialization so a restored index can later export a reusable build cache. |
+| `use_conjugate_graph` | bool | `false` | Enable `Feedback`/`Pretrain` graph enhancement; see [Graph Index Enhancement](../advanced/enhance_graph.md). |
 | `resize_increase_count_bit` | int | `10` | `log2` of the slot-growth batch. Valid range is `1` to `31`; `1` grows in 2-slot batches and `10` in 1,024-slot batches. Smaller values reduce preallocation but can increase reallocations. |
 
 `use_reverse_edges` is intended for workloads that need fast incoming-neighbor inspection, graph

--- a/docs/docs/en/src/resources/index_parameters.md
+++ b/docs/docs/en/src/resources/index_parameters.md
@@ -52,6 +52,7 @@ HGraph places its build parameters under the generic `index_param` key (see
 | `label_remap_type` | `pg` | Label-map implementation: `pg` (default) or `robin` |
 | `reorder_source` | `precise` | Reorder from the `precise` store or directly from `base`; RaBitQ x+y split, including `tq_chain="mrle, rabitq"`, selects `base` automatically |
 | `persist_source_id` | `false` | Include HGraph source-ID metadata in serialization; useful when a restored index must later export a build cache |
+| `use_conjugate_graph` | `false` | Enable HGraph feedback/pretraining and persist the auxiliary conjugate graph |
 | `mrle_dim` | `0` | MRLE output dimension in `[0, dim]`; `0` means input dimension |
 | `fast_encode_rabitq` | `true` | Use fast multi-bit RaBitQ encoding; `false` restores the exact encoder |
 | `fast_encode_rabitq_rounds` | `6` | Fast-encoder refinement rounds in `[1, 32]` |
@@ -64,6 +65,8 @@ At search time:
 
 `ef_search` accepts any positive signed 64-bit integer. It is no longer capped relative to
 `topk`; very large values can substantially increase latency and memory used by the frontier.
+`use_conjugate_graph_search` is a boolean (default `true`) that uses learned conjugate edges when
+the index was built with `use_conjugate_graph: true`.
 
 The `hgraph` search-param object also accepts `brute_force_threshold` (a float
 in `[0.0, 1.0]`, default `0.0`). When set above zero and the request carries a

--- a/docs/docs/zh/src/advanced/enhance_graph.md
+++ b/docs/docs/zh/src/advanced/enhance_graph.md
@@ -10,7 +10,8 @@ VSAG 通过 **Conjugate Graph**（共轭图）机制对这类查询进行在线/
 
 ```json
 {
-    "hnsw": {
+    "index_param": {
+        "base_quantization_type": "fp32",
         "max_degree": 32,
         "ef_construction": 400,
         "use_conjugate_graph": true
@@ -23,7 +24,7 @@ VSAG 通过 **Conjugate Graph**（共轭图）机制对这类查询进行在线/
 
 ```cpp
 std::string search_param_json = R"({
-    "hnsw": {
+    "hgraph": {
         "ef_search": 100,
         "use_conjugate_graph_search": true
     }
@@ -33,8 +34,15 @@ auto result = index->KnnSearch(query, k, search_param_json);
 
 ## 工作原理
 
-共轭图由原图在训练数据上的"失败路径"反向构建而成，在搜索时作为补充的候选边参与贪心扩展。
-它相当于对主图的一层轻量索引补丁，典型体积 < 主图 10%。
+已知困难查询的精确最近邻标签时，可调用
+`Feedback(query, k, search_parameters, global_optimum_id)`；省略 `global_optimum_id` 时，
+HGraph 会通过精确扫描计算。离线增强可调用 `Pretrain(base_ids, k, search_parameters)`，
+它会在选定的 float32 基础向量及其近邻之间生成查询并反馈失败路径。两个方法均返回新插入的
+共轭边数量，重复反馈返回 0。
+
+共轭图保存从局部结果标签到已知全局最优标签的映射，并在 HGraph 常规遍历后补充候选。
+`use_conjugate_graph` 默认关闭；未开启时调用 `Feedback` 或 `Pretrain` 会返回
+`UNSUPPORTED_INDEX_OPERATION`。索引启用共轭图后，搜索增强默认开启，也可按次搜索关闭。
 
 ## 示例
 
@@ -50,4 +58,6 @@ auto result = index->KnnSearch(query, k, search_param_json);
 
 - 启用后构建时间会略有增加。
 - 共轭图数据会随索引一并序列化。
+- `UpdateId` 会同时更新 HGraph 标签表与共轭边。
+- `Pretrain` 当前支持 float32 HGraph；`Feedback` 支持 HGraph 的全部数据类型。
 - 与 `Tune` 可以叠加使用，分别作用于路由质量与运行期参数。

--- a/docs/docs/zh/src/indexes/hgraph.md
+++ b/docs/docs/zh/src/indexes/hgraph.md
@@ -84,6 +84,7 @@ auto result = index->KnnSearch(
 | `base_direct_read` / `precise_direct_read` | bool | `false` | 使用 `uring_io` 时，以 direct IO 打开对应文件而非经过页缓存 |
 | `hgraph_init_capacity` | int | `100` | 初始容量提示（不会限制最终规模） |
 | `persist_source_id` | bool | `false` | 序列化时保留 Source ID 元数据，使恢复后的索引仍可导出可复用的构建缓存 |
+| `use_conjugate_graph` | bool | `false` | 启用 `Feedback`/`Pretrain` 图增强；详见[图索引增强](../advanced/enhance_graph.md) |
 | `resize_increase_count_bit` | int | `10` | 扩容批次 slot 数的 `log2`，取值范围为 `1` 到 `31`。`1` 表示每次按 2 个 slot 对齐，`10` 表示按 1024 个 slot 对齐。较小取值减少预分配，但可能增加重分配次数。 |
 
 `use_reverse_edges` 面向需要快速检查入邻居、图分析或图维护算法的负载。维护反向邻接表会让边

--- a/docs/docs/zh/src/resources/index_parameters.md
+++ b/docs/docs/zh/src/resources/index_parameters.md
@@ -49,6 +49,7 @@ HGraph 的构建参数使用通用的 `index_param` 键（参见 `examples/cpp/1
 | `label_remap_type` | `pg` | label map 实现：默认 `pg`，或 `robin` |
 | `reorder_source` | `precise` | 从 `precise` 存储或直接从 `base` 重排；RaBitQ x+y split（包括 `tq_chain="mrle, rabitq"`）会自动选择 `base` |
 | `persist_source_id` | `false` | 序列化 HGraph 时保留 Source ID 元数据；适用于恢复索引后继续导出构建缓存 |
+| `use_conjugate_graph` | `false` | 启用 HGraph 反馈/预训练并持久化辅助共轭图 |
 | `mrle_dim` | `0` | MRLE 输出维度，范围 `[0, dim]`；`0` 表示输入维度 |
 | `fast_encode_rabitq` | `true` | 使用多 bit RaBitQ 快速编码；设为 `false` 恢复精确编码器 |
 | `fast_encode_rabitq_rounds` | `6` | 快速编码器微调轮数，范围 `[1, 32]` |
@@ -61,6 +62,8 @@ HGraph 的构建参数使用通用的 `index_param` 键（参见 `examples/cpp/1
 
 `ef_search` 接受任意正的有符号 64 位整数，不再存在与 `topk` 相关的上限。非常大的取值会
 明显增加延迟和搜索前沿占用的内存。
+`use_conjugate_graph_search` 为布尔值（默认 `true`）；当构建时设置
+`use_conjugate_graph: true` 后，它控制是否使用已学习的共轭边。
 
 `hgraph` 搜索参数还接受 `brute_force_threshold`（`[0.0, 1.0]` 区间的 float，
 默认 `0.0`）。当取值 `> 0` 且当前请求的 filter 的 `ValidRatio()` 不超过该

--- a/examples/cpp/304_feature_enhance_graph.cpp
+++ b/examples/cpp/304_feature_enhance_graph.cpp
@@ -1,0 +1,173 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <vsag/vsag.h>
+
+#include <iostream>
+
+int
+main(int argc, char** argv) {
+    /******************* Prepare Base Dataset *****************/
+    int dim = 128;
+    int base_elements = 2000;
+    int query_elements = 1000;
+    int64_t k = 10;
+
+    auto base = vsag::Dataset::Make();
+    std::shared_ptr<int64_t[]> base_ids(new int64_t[base_elements]);
+    std::shared_ptr<float[]> base_data(new float[dim * base_elements]);
+    std::mt19937 rng;
+    rng.seed(47);
+    std::uniform_real_distribution<float> distribution_real(-1, 1);
+    for (int i = 0; i < base_elements; i++) {
+        base_ids[i] = i;
+
+        for (int d = 0; d < dim; d++) {
+            base_data[d + i * dim] = distribution_real(rng);
+        }
+    }
+    base->Dim(dim)
+        ->NumElements(base_elements)
+        ->Ids(base_ids.get())
+        ->Float32Vectors(base_data.get())
+        ->Owner(false);
+
+    /******************* Build HGraph Index *****************/
+    // When you want to use EnhanceGraph, the use_conjugate_graph must be set to true
+    auto hgraph_build_parameters = R"(
+    {
+        "dtype": "float32",
+        "metric_type": "l2",
+        "dim": 128,
+        "index_param": {
+            "base_quantization_type": "fp32",
+            "max_degree": 16,
+            "ef_construction": 100,
+            "use_conjugate_graph": true
+        }
+    }
+    )";
+    std::shared_ptr<vsag::Index> hgraph;
+    if (auto index = vsag::Factory::CreateIndex("hgraph", hgraph_build_parameters);
+        index.has_value()) {
+        hgraph = index.value();
+    } else {
+        std::cerr << "Failed to create HGraph: " << index.error().message << std::endl;
+        return -1;
+    }
+
+    if (const auto build_result = hgraph->Build(base); build_result.has_value()) {
+        std::cout << "After Build(), Index contains: " << hgraph->GetNumElements() << std::endl;
+    } else {
+        std::cerr << "Failed to build index: " << build_result.error().message << std::endl;
+        exit(-1);
+    }
+
+    /******************* Search HGraph Index without Conjugate Graph *****************/
+    // record the failed ids
+    std::set<std::pair<int, int64_t>> failed_queries;
+    // use_conjugate_graph_search indicates whether to use information from the conjugate_graph to enhance the search results.
+    auto before_enhance_parameters = R"(
+    {
+        "hgraph": {
+            "ef_search": 10,
+            "use_conjugate_graph_search": false
+        }
+    }
+    )";
+    {
+        int correct = 0;
+        std::cout << "====Search Stage====" << std::endl;
+
+        for (int i = 0; i < query_elements; i++) {
+            auto query = vsag::Dataset::Make();
+            query->Dim(dim)
+                ->Float32Vectors(base_data.get() + i * dim)
+                ->NumElements(1)
+                ->Owner(false);
+
+            auto result = hgraph->KnnSearch(query, k, before_enhance_parameters);
+            int64_t global_optimum = i;  // global optimum is itself
+            if (result.has_value()) {
+                int64_t local_optimum = result.value()->GetIds()[0];
+                if (local_optimum == global_optimum) {
+                    correct++;
+                } else {
+                    failed_queries.emplace(i, global_optimum);
+                }
+            } else {
+                std::cerr << "Search Error: " << result.error().message << std::endl;
+            }
+        }
+        std::cout << "Recall: " << correct / (1.0 * query_elements) << std::endl;
+    }
+
+    /******************* Enhance Phase *****************/
+    //
+    {
+        uint32_t error_fixed = 0;
+        std::cout << "====Feedback Stage====" << std::endl;
+        for (auto item : failed_queries) {
+            auto query = vsag::Dataset::Make();
+            query->Dim(dim)
+                ->Float32Vectors(base_data.get() + item.first * dim)
+                ->NumElements(1)
+                ->Owner(false);
+            auto feedback = hgraph->Feedback(query, 1, before_enhance_parameters, item.second);
+            if (not feedback.has_value()) {
+                std::cerr << "Feedback Error: " << feedback.error().message << std::endl;
+                return -1;
+            }
+            error_fixed += feedback.value();
+        }
+        std::cout << "Fixed queries num: " << error_fixed << std::endl;
+    }
+
+    /******************* Search HGraph Index with Conjugate Graph *****************/
+    auto after_enhance_parameters = R"(
+    {
+        "hgraph": {
+            "ef_search": 10,
+            "use_conjugate_graph_search": true
+        }
+    }
+    )";
+    {
+        int correct = 0;
+        std::cout << "====Enhanced Search Stage====" << std::endl;
+
+        for (int i = 0; i < query_elements; i++) {
+            auto query = vsag::Dataset::Make();
+            query->Dim(dim)
+                ->Float32Vectors(base_data.get() + i * dim)
+                ->NumElements(1)
+                ->Owner(false);
+
+            auto result = hgraph->KnnSearch(query, k, after_enhance_parameters);
+            int64_t global_optimum = i;  // global optimum is itself
+            if (result.has_value()) {
+                int64_t local_optimum = result.value()->GetIds()[0];
+                if (local_optimum == global_optimum) {
+                    correct++;
+                }
+            } else {
+                std::cerr << "Search Error: " << result.error().message << std::endl;
+            }
+        }
+        std::cout << "Enhanced Recall: " << correct / (1.0 * query_elements) << std::endl;
+    }
+
+    return 0;
+}

--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -62,6 +62,9 @@ target_link_libraries(302_feature_range_search vsag)
 add_executable (303_feature_remove 303_feature_remove.cpp)
 target_link_libraries (303_feature_remove vsag)
 
+add_executable(304_feature_enhance_graph 304_feature_enhance_graph.cpp)
+target_link_libraries(304_feature_enhance_graph vsag)
+
 # add_executable(305_feature_update 305_feature_update.cpp)
 # target_link_libraries(305_feature_update vsag)
 

--- a/include/vsag/constants.h
+++ b/include/vsag/constants.h
@@ -73,6 +73,8 @@ extern const char* const PARAMETER_REPR;
 extern const char* const REPR_DENSE;
 extern const char* const REPR_SPARSE;
 extern const char* const REPR_MULTI_VECTOR;
+extern const char* const PARAMETER_USE_CONJUGATE_GRAPH;
+extern const char* const PARAMETER_USE_CONJUGATE_GRAPH_SEARCH;
 extern const char* const PARAMETER_USE_OLD_SERIAL_FORMAT;
 
 extern const char* const ODESCENT_PARAMETER_ALPHA;

--- a/src/algorithm/hgraph/CMakeLists.txt
+++ b/src/algorithm/hgraph/CMakeLists.txt
@@ -8,6 +8,7 @@ set(HGRAPH_SRCS
     hgraph_param_mapping.cpp
     hgraph_search.cpp
     hgraph_serialize.cpp
+    hgraph_enhance.cpp
 )
 
 add_library(hgraph OBJECT ${HGRAPH_SRCS})

--- a/src/algorithm/hgraph/hgraph.cpp
+++ b/src/algorithm/hgraph/hgraph.cpp
@@ -63,7 +63,8 @@ HGraph::HGraph(const HGraphParameterPtr& hgraph_param, const vsag::IndexCommonPa
       graph_type_(hgraph_param->graph_type),
       hierarchical_datacell_param_(hgraph_param->hierarchical_graph_param),
       mci_parameters_(hgraph_param->mci_parameters),
-      use_old_serial_format_(common_param.use_old_serial_format_) {
+      use_old_serial_format_(common_param.use_old_serial_format_),
+      use_conjugate_graph_(hgraph_param->use_conjugate_graph) {
     this->support_duplicate_ = hgraph_param->support_duplicate;
     this->deduplicate_storage_ = hgraph_param->deduplicate_storage;
     const bool is_dense_vector = common_param.repr_ == RecordRepr::DENSE &&
@@ -91,6 +92,9 @@ HGraph::HGraph(const HGraphParameterPtr& hgraph_param, const vsag::IndexCommonPa
     this->mci_searcher_ = std::make_shared<MCISearcher>(common_param);
     if (this->mci_parameters_.enabled) {
         this->mci_cliques_ = std::make_shared<CliqueDataCell>(common_param.allocator_.get());
+    }
+    if (this->use_conjugate_graph_) {
+        this->conjugate_graph_ = std::make_shared<ConjugateGraph>(common_param.allocator_.get());
     }
 
     this->bottom_graph_ =
@@ -838,6 +842,10 @@ HGraph::cal_memory_usage() {
     }
     if (this->mci_cliques_ != nullptr) {
         memory += this->mci_cliques_->GetMemoryUsage();
+    }
+    if (this->conjugate_graph_ != nullptr) {
+        std::shared_lock graph_lock(this->conjugate_graph_mutex_);
+        memory += this->conjugate_graph_->GetMemoryUsage();
     }
 
     std::unique_lock lock(this->memory_usage_mutex_);

--- a/src/algorithm/hgraph/hgraph.h
+++ b/src/algorithm/hgraph/hgraph.h
@@ -37,6 +37,7 @@
 #include "datacell/sparse_graph_datacell_parameter.h"
 #include "hgraph_parameter.h"
 #include "impl/basic_optimizer.h"
+#include "impl/conjugate_graph.h"
 #include "impl/heap/distance_heap.h"
 #include "impl/reorder/flatten_reorder.h"
 #include "impl/searcher/basic_searcher.h"
@@ -216,6 +217,17 @@ public:
     uint32_t
     Remove(const std::vector<int64_t>& ids, RemoveMode mode = RemoveMode::MARK_REMOVE) override;
 
+    uint32_t
+    Feedback(const DatasetPtr& query,
+             int64_t k,
+             const std::string& parameters,
+             int64_t global_optimum_tag_id = std::numeric_limits<int64_t>::max()) override;
+
+    uint32_t
+    Pretrain(const std::vector<int64_t>& base_tag_ids,
+             uint32_t k,
+             const std::string& parameters) override;
+
     void
     Serialize(StreamWriter& writer) const override;
 
@@ -246,6 +258,9 @@ public:
 
     bool
     UpdateVector(int64_t id, const DatasetPtr& new_base, bool force_update = false) override;
+
+    bool
+    UpdateId(int64_t old_id, int64_t new_id) override;
 
     void
     UpdateAttribute(int64_t id, const AttributeSet& new_attrs) override;
@@ -895,9 +910,12 @@ private:
 
     bool use_old_serial_format_{false};  // true when deserialized from legacy format
 
-    bool support_duplicate_{false};             // allow duplicate external ids
-    bool deduplicate_storage_{false};           // share duplicate vector storage slots
-    bool support_force_remove_{false};          // enable physical deletion
+    bool support_duplicate_{false};     // allow duplicate external ids
+    bool deduplicate_storage_{false};   // share duplicate vector storage slots
+    bool support_force_remove_{false};  // enable physical deletion
+    bool use_conjugate_graph_{false};   // enable graph-enhancement feedback
+    std::shared_ptr<ConjugateGraph> conjugate_graph_{nullptr};
+    mutable std::shared_mutex conjugate_graph_mutex_;
     float duplicate_distance_threshold_{0.0F};  // distance threshold for duplicate detection
 
     bool persist_source_id_{false};  // whether to persist source_id in serialization

--- a/src/algorithm/hgraph/hgraph_enhance.cpp
+++ b/src/algorithm/hgraph/hgraph_enhance.cpp
@@ -1,0 +1,156 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <algorithm>
+#include <limits>
+
+#include "common.h"
+#include "dataset_impl.h"
+#include "hgraph.h"  // IWYU pragma: keep
+
+namespace vsag {
+
+uint32_t
+HGraph::Feedback(const DatasetPtr& query,
+                 int64_t k,
+                 const std::string& parameters,
+                 int64_t global_optimum_tag_id) {
+    if (not this->use_conjugate_graph_) {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "HGraph conjugate graph is not enabled");
+    }
+    CHECK_ARGUMENT(k > 0, "feedback k must be positive");
+    this->validate_knn_args(query, k);
+    if (this->GetNumElements() == 0) {
+        return 0;
+    }
+
+    if (global_optimum_tag_id == std::numeric_limits<int64_t>::max()) {
+        auto global_lock = this->acquire_global_read_lock();
+        QueryContext ctx{.alloc = this->allocator_};
+        auto exact = this->brute_force_search<InnerSearchMode::KNN_SEARCH>(
+            this->get_data(query), nullptr, 1, 0.0F, &ctx);
+        CHECK_ARGUMENT(not exact->Empty(), "feedback cannot find an exact nearest neighbor");
+        std::shared_lock label_lock(this->label_lookup_mutex_);
+        global_optimum_tag_id = this->label_table_->GetLabelById(exact->Top().second);
+    }
+
+    auto result = this->KnnSearch(query, k, parameters, nullptr);
+    const auto* ids = result->GetIds();
+    const auto result_size = result->GetDim();
+    uint32_t inserted = 0;
+    std::shared_lock label_lock(this->label_lookup_mutex_);
+    const auto [optimum_found, unused] =
+        this->label_table_->TryGetIdByLabel(global_optimum_tag_id, true);
+    CHECK_ARGUMENT(optimum_found, "feedback global optimum id does not belong to the index");
+    std::unique_lock graph_lock(this->conjugate_graph_mutex_);
+    uint64_t added_memory = 0;
+    for (int64_t i = 0; i < std::min(k, result_size); ++i) {
+        const auto [found, unused] = this->label_table_->TryGetIdByLabel(ids[i], true);
+        CHECK_ARGUMENT(found, "feedback search result does not belong to the index");
+        const auto memory_before = this->conjugate_graph_->GetMemoryUsage();
+        auto add_result = this->conjugate_graph_->AddNeighbor(ids[i], global_optimum_tag_id);
+        if (not add_result) {
+            throw VsagException(add_result.error().type, add_result.error().message);
+        }
+        if (add_result.value()) {
+            ++inserted;
+            added_memory += this->conjugate_graph_->GetMemoryUsage() - memory_before;
+        }
+    }
+    if (added_memory > 0) {
+        std::unique_lock memory_lock(this->memory_usage_mutex_);
+        this->current_memory_usage_.fetch_add(added_memory);
+    }
+    return inserted;
+}
+
+uint32_t
+HGraph::Pretrain(const std::vector<int64_t>& base_tag_ids,
+                 uint32_t k,
+                 const std::string& parameters) {
+    if (not this->use_conjugate_graph_) {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "HGraph conjugate graph is not enabled");
+    }
+    CHECK_ARGUMENT(k > 0, "pretrain k must be positive");
+    CHECK_ARGUMENT(this->data_type_ == DataTypes::DATA_TYPE_FLOAT,
+                   "HGraph pretrain currently supports float32 vectors only");
+    if (this->GetNumElements() == 0 or base_tag_ids.empty()) {
+        return 0;
+    }
+
+    Vector<float> base_vector(this->dim_, this->allocator_);
+    Vector<float> neighbor_vector(this->dim_, this->allocator_);
+    Vector<float> generated_vector(this->dim_, this->allocator_);
+    auto base = DatasetImpl::Make();
+    base->Dim(this->dim_)->NumElements(1)->Float32Vectors(base_vector.data())->Owner(false);
+    auto generated = DatasetImpl::Make();
+    generated->Dim(this->dim_)
+        ->NumElements(1)
+        ->Float32Vectors(generated_vector.data())
+        ->Owner(false);
+    const auto generate_parameters = fmt::format(
+        R"({{"hgraph":{{"ef_search":{},"use_conjugate_graph_search":false}}}})", GENERATE_SEARCH_L);
+
+    uint32_t inserted = 0;
+    for (const auto base_tag_id : base_tag_ids) {
+        InnerIdType base_inner_id;
+        {
+            std::shared_lock label_lock(this->label_lookup_mutex_);
+            const auto [found, inner_id] = this->label_table_->TryGetIdByLabel(base_tag_id, true);
+            CHECK_ARGUMENT(
+                found,
+                fmt::format("pretrain base id {} does not belong to the index", base_tag_id));
+            base_inner_id = inner_id;
+        }
+        this->GetVectorByInnerId(base_inner_id, base_vector.data());
+        auto neighbors = this->KnnSearch(base, GENERATE_SEARCH_K, generate_parameters, nullptr);
+        for (int64_t i = 0; i < neighbors->GetDim(); ++i) {
+            const auto neighbor_tag_id = neighbors->GetIds()[i];
+            if (neighbor_tag_id == base_tag_id) {
+                continue;
+            }
+            InnerIdType neighbor_inner_id;
+            {
+                std::shared_lock label_lock(this->label_lookup_mutex_);
+                const auto [found, inner_id] =
+                    this->label_table_->TryGetIdByLabel(neighbor_tag_id, true);
+                CHECK_ARGUMENT(found,
+                               fmt::format("pretrain neighbor id {} does not belong to the index",
+                                           neighbor_tag_id));
+                neighbor_inner_id = inner_id;
+            }
+            this->GetVectorByInnerId(neighbor_inner_id, neighbor_vector.data());
+            for (int64_t d = 0; d < this->dim_; ++d) {
+                generated_vector[d] =
+                    GENERATE_OMEGA * base_vector[d] + (1.0F - GENERATE_OMEGA) * neighbor_vector[d];
+            }
+            inserted += this->Feedback(generated, k, parameters, base_tag_id);
+        }
+    }
+    return inserted;
+}
+
+bool
+HGraph::UpdateId(int64_t old_id, int64_t new_id) {
+    const auto updated = InnerIndexInterface::UpdateId(old_id, new_id);
+    if (updated and this->use_conjugate_graph_) {
+        std::unique_lock graph_lock(this->conjugate_graph_mutex_);
+        (void)this->conjugate_graph_->UpdateId(old_id, new_id);
+    }
+    return updated;
+}
+
+}  // namespace vsag

--- a/src/algorithm/hgraph/hgraph_param_mapping.cpp
+++ b/src/algorithm/hgraph/hgraph_param_mapping.cpp
@@ -473,6 +473,12 @@ HGraph::map_hgraph_param(const JsonType& hgraph_json) {
             },
         },
         {
+            PARAMETER_USE_CONJUGATE_GRAPH,
+            {
+                PARAMETER_USE_CONJUGATE_GRAPH,
+            },
+        },
+        {
             HGRAPH_LABEL_REMAP_TYPE,
             {
                 LABEL_REMAP_TYPE_KEY,

--- a/src/algorithm/hgraph/hgraph_parameter.cpp
+++ b/src/algorithm/hgraph/hgraph_parameter.cpp
@@ -169,6 +169,9 @@ HGraphParameter::FromJson(const JsonType& json) {
     if (json.Contains(HGRAPH_PERSIST_SOURCE_ID_KEY)) {
         this->persist_source_id = json[HGRAPH_PERSIST_SOURCE_ID_KEY].GetBool();
     }
+    if (json.Contains(PARAMETER_USE_CONJUGATE_GRAPH)) {
+        this->use_conjugate_graph = json[PARAMETER_USE_CONJUGATE_GRAPH].GetBool();
+    }
     const bool has_mci_parameter =
         json.Contains(HGRAPH_MCI_MCS) or json.Contains(HGRAPH_MCI_CLIQUE_MAX) or
         json.Contains(HGRAPH_MCI_ALPHA) or json.Contains(HGRAPH_MCI_KNNG_SOURCE) or
@@ -255,6 +258,7 @@ HGraphParameter::ToJson() const {
     json[DUPLICATE_DISTANCE_THRESHOLD].SetFloat(this->duplicate_distance_threshold);
     json[SUPPORT_FORCE_REMOVE].SetBool(this->support_force_remove);
     json[HGRAPH_PERSIST_SOURCE_ID_KEY].SetBool(this->persist_source_id);
+    json[PARAMETER_USE_CONJUGATE_GRAPH].SetBool(this->use_conjugate_graph);
     if (this->mci_parameters.enabled) {
         json[HGRAPH_USE_MCI].SetBool(true);
         json[HGRAPH_MCI_MCS].SetInt(static_cast<int64_t>(this->mci_parameters.mcs));
@@ -303,6 +307,13 @@ HGraphParameter::CheckCompatibility(const ParamPtr& other) const {
     CHECK_FIELD_EQ(*this, *p, deduplicate_storage);
     CHECK_FIELD_EQ(*this, *p, duplicate_distance_threshold);
     CHECK_FIELD_EQ(*this, *p, support_force_remove);
+    // A conjugate-enabled reader can load an older index without the optional graph and start
+    // with an empty one. The reverse direction would discard serialized enhancement data.
+    if (not this->use_conjugate_graph and p->use_conjugate_graph) {
+        logger::error(
+            "HGraphParameter::CheckCompatibility: serialized conjugate graph is not supported");
+        return false;
+    }
     CHECK_FIELD_EQ(*this, *p, mci_parameters.enabled);
     CHECK_FIELD_EQ(*this, *p, mci_parameters.mcs);
     CHECK_FIELD_EQ(*this, *p, mci_parameters.clique_max);
@@ -352,6 +363,10 @@ HGraphSearchParameters::FromJson(const std::string& json_string) {
     }
     if (params[INDEX_TYPE_HGRAPH].Contains(HGRAPH_USE_MCI)) {
         obj.use_mci = params[INDEX_TYPE_HGRAPH][HGRAPH_USE_MCI].GetBool();
+    }
+    if (params[INDEX_TYPE_HGRAPH].Contains(PARAMETER_USE_CONJUGATE_GRAPH_SEARCH)) {
+        obj.use_conjugate_graph_search =
+            params[INDEX_TYPE_HGRAPH][PARAMETER_USE_CONJUGATE_GRAPH_SEARCH].GetBool();
     }
     CHECK_ARGUMENT(not params[INDEX_TYPE_HGRAPH].Contains(HGRAPH_MCI_SEED_COUNT_KEY),
                    "hgraph mci_seed_count is not supported; use mci_seed_ratio");

--- a/src/algorithm/hgraph/hgraph_parameter.h
+++ b/src/algorithm/hgraph/hgraph_parameter.h
@@ -82,6 +82,7 @@ public:
     bool support_force_remove{false};
 
     bool persist_source_id{false};
+    bool use_conjugate_graph{false};
 
     HGraphMCIParameters mci_parameters{};
 
@@ -102,6 +103,7 @@ public:
     bool use_extra_info_filter{false};
     bool rabitq_one_bit_search{false};
     bool use_mci{true};
+    bool use_conjugate_graph_search{true};
     float mci_seed_ratio{0.1F};
     float mci_hgraph_valid_ratio_threshold{0.05F};
     // If > 0 and the active filter's ValidRatio() <= brute_force_threshold,

--- a/src/algorithm/hgraph/hgraph_parameter_test.cpp
+++ b/src/algorithm/hgraph/hgraph_parameter_test.cpp
@@ -195,6 +195,18 @@ TEST_CASE("HGraph Parameters CheckCompatibility", "[ut][HGraphParameter][CheckCo
                             false)
     TEST_COMPATIBILITY_CASE(
         "different support force remove", support_force_remove, true, false, false)
+    SECTION("conjugate graph is backward compatible") {
+        HGraphDefaultParam default_param;
+        auto param_str = generate_hgraph_param(default_param);
+        auto enabled = std::make_shared<vsag::HGraphParameter>();
+        auto disabled = std::make_shared<vsag::HGraphParameter>();
+        enabled->FromString(param_str);
+        disabled->FromString(param_str);
+        enabled->use_conjugate_graph = true;
+
+        REQUIRE(enabled->CheckCompatibility(disabled));
+        REQUIRE_FALSE(disabled->CheckCompatibility(enabled));
+    }
 }
 // clang-format on
 
@@ -226,6 +238,26 @@ TEST_CASE("HGraph maps support_duplicate to graph parameter", "[ut][HGraphParame
     REQUIRE(typed_param->deduplicate_storage);
     REQUIRE(typed_param->duplicate_distance_threshold == 0.25F);
     REQUIRE(typed_param->bottom_graph_param->support_duplicate_);
+}
+
+TEST_CASE("HGraph maps conjugate graph parameters", "[ut][HGraphParameter]") {
+    vsag::IndexCommonParam common_param;
+    common_param.dim_ = 128;
+    common_param.data_type_ = vsag::DataTypes::DATA_TYPE_FLOAT;
+
+    auto external = vsag::JsonType::Parse(R"({"use_conjugate_graph": true})");
+    auto mapped = std::dynamic_pointer_cast<vsag::HGraphParameter>(
+        vsag::HGraph::CheckAndMappingExternalParam(external, common_param));
+    REQUIRE(mapped != nullptr);
+    REQUIRE(mapped->use_conjugate_graph);
+    REQUIRE(mapped->ToJson()[vsag::PARAMETER_USE_CONJUGATE_GRAPH].GetBool());
+
+    auto enabled = vsag::HGraphSearchParameters::FromJson(
+        R"({"hgraph":{"ef_search":10,"use_conjugate_graph_search":true}})");
+    REQUIRE(enabled.use_conjugate_graph_search);
+    auto disabled = vsag::HGraphSearchParameters::FromJson(
+        R"({"hgraph":{"ef_search":10,"use_conjugate_graph_search":false}})");
+    REQUIRE_FALSE(disabled.use_conjugate_graph_search);
 }
 
 TEST_CASE("HGraph maps resize increase count bit", "[ut][HGraphParameter]") {

--- a/src/algorithm/hgraph/hgraph_search.cpp
+++ b/src/algorithm/hgraph/hgraph_search.cpp
@@ -337,6 +337,7 @@ HGraph::brute_force_search(const void* query,
                            float radius,
                            QueryContext* ctx,
                            const std::optional<float>& threshold) const {
+    std::shared_lock codes_lock(this->persistent_codes_mutex_);
     Allocator* alloc = (ctx != nullptr && ctx->alloc != nullptr) ? ctx->alloc : this->allocator_;
 
     auto flatten = this->basic_flatten_codes_;
@@ -357,7 +358,10 @@ HGraph::brute_force_search(const void* query,
         return result;
     }
 
-    auto total = static_cast<InnerIdType>(this->total_count_.load());
+    // Add reserves logical ids before their code slots are published.
+    auto total =
+        this->using_dedup_storage() ? this->GetCodeStorageCounts().first : flatten->TotalCount();
+    total = std::min(total, static_cast<InnerIdType>(this->total_count_.load()));
     if (total == 0) {
         return result;
     }
@@ -591,6 +595,9 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
             use_custom_distance ? false : params.rabitq_one_bit_search;
     } else {
         search_param.ef = std::max(params.ef_search, k);
+        if (this->use_conjugate_graph_ and params.use_conjugate_graph_search) {
+            search_param.ef = std::max(search_param.ef, static_cast<uint64_t>(LOOK_AT_K));
+        }
         search_param.is_inner_id_allowed = ft;
         search_param.distance_threshold = request.threshold_;
         search_param.topk = static_cast<int64_t>(search_param.ef);
@@ -598,6 +605,9 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
             search_param.topk =
                 std::min(search_param.topk,
                          static_cast<int64_t>(static_cast<float>(k) * params.topk_factor));
+        }
+        if (this->use_conjugate_graph_ and params.use_conjugate_graph_search) {
+            search_param.topk = std::max(search_param.topk, LOOK_AT_K);
         }
         search_param.enable_reorder = use_custom_distance ? false : params.enable_reorder;
         search_param.consider_duplicate = true;
@@ -677,6 +687,9 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
     if (mci_result.route != "mci" and not brute_force_used and use_reorder_ and
         search_param.enable_reorder) {
         auto limit = is_range ? request.limited_size_ : k;
+        if (not is_range and this->use_conjugate_graph_ and params.use_conjugate_graph_search) {
+            limit = std::max(limit, LOOK_AT_K);
+        }
         auto reorder_threshold = is_range ? std::nullopt : request.threshold_;
         this->reorder(raw_query,
                       this->get_reorder_codes(),
@@ -689,6 +702,9 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
     } else if (mci_result.route != "mci" and not brute_force_used and
                search_param.enable_reorder and params.rabitq_one_bit_search) {
         auto limit = is_range ? request.limited_size_ : k;
+        if (not is_range and this->use_conjugate_graph_ and params.use_conjugate_graph_search) {
+            limit = std::max(limit, LOOK_AT_K);
+        }
         auto reorder_threshold = is_range ? std::nullopt : request.threshold_;
         this->reorder(raw_query,
                       this->basic_flatten_codes_,
@@ -698,6 +714,57 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
                       ctx,
                       nullptr,
                       reorder_threshold);
+    }
+
+    if (not is_range and this->use_conjugate_graph_ and params.use_conjugate_graph_search and
+        not search_result->Empty()) {
+        std::priority_queue<std::pair<float, LabelType>> label_results;
+        std::shared_lock label_lock(this->label_lookup_mutex_);
+        while (not search_result->Empty()) {
+            const auto record = search_result->Top();
+            search_result->Pop();
+            label_results.emplace(record.first, this->label_table_->GetLabelById(record.second));
+        }
+
+        const auto flatten = use_custom_distance ? nullptr : this->get_precise_codes();
+        const auto computer = use_custom_distance ? nullptr : flatten->FactoryComputer(raw_query);
+        Filter* attribute_filter = nullptr;
+        if (not search_param.executors.empty() and search_param.executors[0] != nullptr) {
+            search_param.executors[0]->Clear();
+            attribute_filter = search_param.executors[0]->Run();
+        }
+        const auto is_allowed = [&](InnerIdType inner_id) {
+            return (ft == nullptr or ft->CheckValid(inner_id)) and
+                   (attribute_filter == nullptr or attribute_filter->CheckValid(inner_id));
+        };
+        const auto distance_of_label = [&](int64_t label) {
+            const auto [found, inner_id] = this->label_table_->TryGetIdByLabel(label, true);
+            if (not found or not is_allowed(inner_id)) {
+                return std::numeric_limits<float>::max();
+            }
+            float distance = std::numeric_limits<float>::max();
+            if (use_custom_distance) {
+                request.distance_batch_func_(&label, 1, &distance);
+            } else {
+                flatten->Query(&distance, computer, &inner_id, 1, &ctx);
+            }
+            if (request.threshold_.has_value() and distance > request.threshold_.value()) {
+                return std::numeric_limits<float>::max();
+            }
+            return distance;
+        };
+        {
+            std::shared_lock graph_lock(this->conjugate_graph_mutex_);
+            (void)this->conjugate_graph_->EnhanceResult(label_results, distance_of_label);
+        }
+        while (not label_results.empty()) {
+            const auto record = label_results.top();
+            label_results.pop();
+            const auto [found, inner_id] = this->label_table_->TryGetIdByLabel(record.second, true);
+            if (found and is_allowed(inner_id)) {
+                search_result->Push(record.first, inner_id);
+            }
+        }
     }
 
     // Trim and pack results

--- a/src/algorithm/hgraph/hgraph_serialize.cpp
+++ b/src/algorithm/hgraph/hgraph_serialize.cpp
@@ -371,6 +371,10 @@ HGraph::Serialize(StreamWriter& writer) const {
 
     // FIXME(wxyu): this option is used for special purposes, like compatibility testing
     if (this->use_old_serial_format_) {
+        if (this->use_conjugate_graph_) {
+            throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                                "HGraph conjugate graph does not support v0.14 serialization");
+        }
         if (this->using_dedup_storage()) {
             throw VsagException(ErrorType::INVALID_ARGUMENT,
                                 "HGraph duplicate code slot mapping does not support v0.14 "
@@ -418,6 +422,10 @@ HGraph::Serialize(StreamWriter& writer) const {
     if (this->mci_parameters_.enabled and this->mci_cliques_ != nullptr) {
         this->mci_cliques_->Serialize(writer);
     }
+    if (this->use_conjugate_graph_) {
+        std::shared_lock graph_lock(this->conjugate_graph_mutex_);
+        this->conjugate_graph_->Serialize(writer);
+    }
 
     // serialize footer (introduced since v0.15)
     auto jsonify_basic_info = this->serialize_basic_info();
@@ -426,6 +434,7 @@ HGraph::Serialize(StreamWriter& writer) const {
     if (this->support_duplicate_) {
         metadata->Set("duplicate_format_version", 1);
     }
+    metadata->Set("has_conjugate_graph", this->use_conjugate_graph_);
     logger::debug(jsonify_basic_info.Dump());
 
     auto footer = std::make_shared<Footer>(metadata);
@@ -483,6 +492,10 @@ HGraph::collect_streaming_header() const {
     }
     if (create_new_raw_vector_) {
         auto tag = static_cast<uint32_t>(StreamSerializationTag::RAW_VECTOR);
+        append_manifest(tag, StreamSerializationTagCritical(tag));
+    }
+    if (this->use_conjugate_graph_) {
+        auto tag = static_cast<uint32_t>(StreamSerializationTag::CONJUGATE_GRAPH);
         append_manifest(tag, StreamSerializationTagCritical(tag));
     }
     metadata->Set("block_manifest", manifest);
@@ -556,6 +569,14 @@ HGraph::serialize_streaming_body(StreamWriter& writer) const {
         WriteStreamingBlock(
             writer, tag, StreamSerializationTagCritical(tag), [this](StreamWriter& block_writer) {
                 this->raw_vector_->Serialize(block_writer);
+            });
+    }
+    if (this->use_conjugate_graph_) {
+        auto tag = static_cast<uint32_t>(StreamSerializationTag::CONJUGATE_GRAPH);
+        WriteStreamingBlock(
+            writer, tag, StreamSerializationTagCritical(tag), [this](StreamWriter& block_writer) {
+                std::shared_lock graph_lock(this->conjugate_graph_mutex_);
+                this->conjugate_graph_->Serialize(block_writer);
             });
     }
 }
@@ -655,6 +676,7 @@ HGraph::read_streaming_body(StreamReader& reader,
     bool loaded_extra_info = false;
     bool loaded_attribute_filter = false;
     bool loaded_raw_vector = false;
+    bool loaded_conjugate_graph = false;
 
     while (true) {
         auto block_header = StreamBlockHeader::Read(reader);
@@ -780,6 +802,21 @@ HGraph::read_streaming_body(StreamReader& reader,
                     loaded_raw_vector = true;
                 }
                 break;
+            case StreamSerializationTag::CONJUGATE_GRAPH:
+                if (not this->use_conjugate_graph_) {
+                    throw VsagException(
+                        ErrorType::INVALID_ARGUMENT,
+                        "serialized HGraph uses conjugate graph but the target does not");
+                }
+                ReadSeekableBlockPayload(block_reader, block_header, [this](StreamReader& block) {
+                    std::unique_lock graph_lock(this->conjugate_graph_mutex_);
+                    auto result = this->conjugate_graph_->Deserialize(block);
+                    if (not result) {
+                        throw VsagException(result.error().type, result.error().message);
+                    }
+                });
+                loaded_conjugate_graph = true;
+                break;
             default:
                 if (block_header.IsCritical()) {
                     throw VsagException(
@@ -822,7 +859,6 @@ HGraph::read_streaming_body(StreamReader& reader,
         throw VsagException(ErrorType::READ_ERROR,
                             "HGraph streaming serialization raw vector block is missing");
     }
-
     auto new_size = max_capacity_.load();
     if (this->using_dedup_storage()) {
         auto logical_count = this->code_slot_map_->PublishedLogicalCount();
@@ -1039,6 +1075,16 @@ HGraph::Deserialize(StreamReader& reader) {
             }
             this->mci_cliques_->Deserialize(buffer_reader);
         }
+        if (metadata->Get("has_conjugate_graph").IsBool() &&
+            metadata->Get("has_conjugate_graph").GetBool()) {
+            CHECK_ARGUMENT(this->use_conjugate_graph_,
+                           "serialized HGraph uses conjugate graph but the target does not");
+            std::unique_lock graph_lock(this->conjugate_graph_mutex_);
+            auto result = this->conjugate_graph_->Deserialize(buffer_reader);
+            if (not result) {
+                throw VsagException(result.error().type, result.error().message);
+            }
+        }
         if (this->raw_vector_ != nullptr) {
             this->has_raw_vector_ = true;
         }
@@ -1104,6 +1150,10 @@ HGraph::GetMemoryUsageDetail() const {
     }
     if (this->mci_cliques_ != nullptr) {
         memory_usage["mci_cliques"] = this->mci_cliques_->GetMemoryUsage();
+    }
+    if (this->conjugate_graph_ != nullptr) {
+        std::shared_lock graph_lock(this->conjugate_graph_mutex_);
+        memory_usage["conjugate_graph"] = this->conjugate_graph_->GetMemoryUsage();
     }
     return memory_usage;
 }

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -71,6 +71,8 @@ const char* const PARAMETER_REPR = "repr";
 const char* const REPR_DENSE = "dense";
 const char* const REPR_SPARSE = "sparse";
 const char* const REPR_MULTI_VECTOR = "multi_vector";
+const char* const PARAMETER_USE_CONJUGATE_GRAPH = "use_conjugate_graph";
+const char* const PARAMETER_USE_CONJUGATE_GRAPH_SEARCH = "use_conjugate_graph_search";
 const char* const PARAMETER_USE_OLD_SERIAL_FORMAT = "use_old_serial_format";
 
 const char* const ODESCENT_PARAMETER_ALPHA = "alpha";

--- a/src/datacell/bucket_datacell_test.cpp
+++ b/src/datacell/bucket_datacell_test.cpp
@@ -174,7 +174,7 @@ public:
         if (size > 0) {
             std::memcpy(data_.data() + offset, data, size);
         }
-        this->size_ = std::max(this->size_, next_size);
+        this->PublishSize(next_size);
     }
 
     void

--- a/src/impl/conjugate_graph.cpp
+++ b/src/impl/conjugate_graph.cpp
@@ -15,6 +15,8 @@
 
 #include "conjugate_graph.h"
 
+#include <limits>
+
 #include "vsag_exception.h"
 
 namespace vsag {
@@ -30,28 +32,29 @@ ConjugateGraph::AddNeighbor(int64_t from_tag_id, int64_t to_tag_id) {
         return false;
     }
 
-    std::shared_ptr<UnorderedSet<int64_t>> neighbor_set;
     auto search_key = conjugate_graph_.find(from_tag_id);
-    if (search_key == conjugate_graph_.end()) {
-        neighbor_set = std::make_shared<UnorderedSet<int64_t>>(allocator_);
+    const bool new_source = search_key == conjugate_graph_.end();
+    if (not new_source and (search_key->second->size() >= MAXIMUM_DEGREE or
+                            search_key->second->count(to_tag_id) > 0)) {
+        return false;
+    }
+
+    uint64_t added_bytes = sizeof(to_tag_id);
+    if (new_source) {
+        added_bytes += sizeof(from_tag_id) + sizeof(uint64_t);
+    }
+    if (added_bytes > std::numeric_limits<uint32_t>::max() - memory_usage_) {
+        return tl::unexpected(
+            Error(ErrorType::INVALID_ARGUMENT, "conjugate graph serialization size overflow"));
+    }
+
+    if (new_source) {
+        auto neighbor_set = std::make_shared<UnorderedSet<int64_t>>(allocator_);
         conjugate_graph_.emplace(from_tag_id, neighbor_set);
-    } else {
-        neighbor_set = search_key->second;
+        search_key = conjugate_graph_.find(from_tag_id);
     }
-
-    if (neighbor_set->size() >= MAXIMUM_DEGREE) {
-        return false;
-    }
-    auto insert_result = neighbor_set->insert(to_tag_id);
-    if (!insert_result.second) {
-        return false;
-    }
-
-    if (neighbor_set->size() == 1) {
-        memory_usage_ += sizeof(from_tag_id);
-        memory_usage_ += sizeof(neighbor_set->size());
-    }
-    memory_usage_ += sizeof(to_tag_id);
+    search_key->second->insert(to_tag_id);
+    memory_usage_ += static_cast<uint32_t>(added_bytes);
     return true;
 }
 
@@ -170,6 +173,23 @@ ConjugateGraph::Serialize(std::ostream& out_stream) const {
     footer_.Serialize(out_stream);
 
     return {};
+}
+
+void
+ConjugateGraph::Serialize(StreamWriter& out_stream) const {
+    StreamWriter::WriteObj(out_stream, memory_usage_);
+    for (const auto& [tag_id, neighbor_ptr] : conjugate_graph_) {
+        StreamWriter::WriteObj(out_stream, tag_id);
+        uint64_t neighbor_set_size = neighbor_ptr->size();
+        StreamWriter::WriteObj(out_stream, neighbor_set_size);
+        for (const auto neighbor_tag_id : *neighbor_ptr) {
+            StreamWriter::WriteObj(out_stream, neighbor_tag_id);
+        }
+    }
+    std::stringstream footer_stream(std::ios::in | std::ios::out | std::ios::binary);
+    footer_.Serialize(footer_stream);
+    const auto footer_data = footer_stream.str();
+    out_stream.Write(footer_data.data(), footer_data.size());
 }
 
 tl::expected<void, Error>

--- a/src/impl/conjugate_graph.h
+++ b/src/impl/conjugate_graph.h
@@ -19,6 +19,7 @@
 
 #include "impl/logger/logger.h"
 #include "storage/footer.h"
+#include "storage/stream_writer.h"
 #include "typing.h"
 #include "vsag/index.h"
 
@@ -47,6 +48,9 @@ public:
 
     tl::expected<void, Error>
     Serialize(std::ostream& out_stream) const;
+
+    void
+    Serialize(StreamWriter& out_stream) const;
 
     tl::expected<void, Error>
     Deserialize(const Binary& binary);

--- a/src/io/async_io/async_io.cpp
+++ b/src/io/async_io/async_io.cpp
@@ -74,9 +74,7 @@ AsyncIO::WriteImpl(const uint8_t* data, uint64_t size, uint64_t offset) {
         throw VsagException(ErrorType::INTERNAL_ERROR,
                             fmt::format("write bytes {} less than {}", ret, size));
     }
-    if (size + offset > this->size_) {
-        this->size_ = size + offset;
-    }
+    this->PublishSize(size + offset);
     fsync(wfd_);
 }
 

--- a/src/io/buffer_io/buffer_io.cpp
+++ b/src/io/buffer_io/buffer_io.cpp
@@ -54,9 +54,7 @@ BufferIO::WriteImpl(const uint8_t* data, uint64_t size, uint64_t offset) {
         throw VsagException(ErrorType::INTERNAL_ERROR,
                             fmt::format("write bytes {} less than {}", ret, size));
     }
-    if (size + offset > this->size_) {
-        this->size_ = size + offset;
-    }
+    this->PublishSize(size + offset);
 }
 
 void

--- a/src/io/common/basic_io.h
+++ b/src/io/common/basic_io.h
@@ -18,6 +18,7 @@
 #include <fmt/format.h>
 
 #include <algorithm>
+#include <atomic>
 #include <cstdint>
 #include <cstring>
 #include <memory>
@@ -306,11 +307,12 @@ public:
      */
     inline void
     Serialize(StreamWriter& writer) {
-        StreamWriter::WriteObj(writer, this->size_);
+        const auto size = this->size_.load(std::memory_order_acquire);
+        StreamWriter::WriteObj(writer, size);
         ByteBuffer buffer(SERIALIZE_BUFFER_SIZE, this->allocator_);
         uint64_t offset = 0;
-        while (offset < this->size_) {
-            auto cur_size = std::min(SERIALIZE_BUFFER_SIZE, this->size_ - offset);
+        while (offset < size) {
+            auto cur_size = std::min(SERIALIZE_BUFFER_SIZE, size - offset);
             this->Read(cur_size, offset, buffer.data);
             writer.Write(reinterpret_cast<const char*>(buffer.data), cur_size);
             offset += cur_size;
@@ -330,7 +332,7 @@ public:
         this->start_ = reader.GetCursor();
         if constexpr (SkipDeserialize) {
             reader.Seek(reader.GetCursor() + size);
-            this->size_ = std::max(this->size_, size);
+            this->PublishSize(size);
         } else {
             // Reset the logical and physical extent so a shorter deserialization
             // cannot retain stale bytes from a previously opened file.
@@ -412,12 +414,13 @@ public:
         if constexpr (has_ResizeImpl<IOTmpl>::value) {
             cast().ResizeImpl(size);
         } else {
-            if (size <= this->size_) {
+            const auto current_size = this->size_.load(std::memory_order_acquire);
+            if (size <= current_size) {
                 return;
             }
             ByteBuffer buffer(SERIALIZE_BUFFER_SIZE, this->allocator_);
             memset(buffer.data, 0, SERIALIZE_BUFFER_SIZE);
-            uint64_t offset = this->size_;
+            uint64_t offset = current_size;
             while (offset < size) {
                 auto cur_size = std::min(SERIALIZE_BUFFER_SIZE, size - offset);
                 this->Write(buffer.data, cur_size, offset);
@@ -434,8 +437,8 @@ public:
         if constexpr (has_ShrinkImpl<IOTmpl>::value) {
             cast().ShrinkImpl(size);
         } else {
-            if (size <= this->size_) {
-                this->size_ = size;
+            if (size <= this->size_.load(std::memory_order_acquire)) {
+                this->size_.store(size, std::memory_order_release);
             }
         }
         if constexpr (not InMemory) {
@@ -448,7 +451,7 @@ public:
         if constexpr (has_GetMemoryUsageImpl<IOTmpl>::value) {
             return cast().GetMemoryUsageImpl();
         }
-        return this->size_;
+        return this->size_.load(std::memory_order_acquire);
     }
 
     [[nodiscard]] bool
@@ -496,10 +499,21 @@ public:
     /**
      * @brief The size of the IO object.
      */
-    uint64_t size_{0};
+    // Writers publish newly initialized storage through size_; readers acquire that publication
+    // before validating offsets. Some in-memory IO implementations append concurrently with reads.
+    std::atomic<uint64_t> size_{0};
     uint64_t start_{0};
 
 protected:
+    void
+    PublishSize(uint64_t size) {
+        auto current = size_.load(std::memory_order_relaxed);
+        while (current < size and
+               not size_.compare_exchange_weak(
+                   current, size, std::memory_order_release, std::memory_order_relaxed)) {
+        }
+    }
+
     /**
      * @brief Protected non-virtual destructor.
      *
@@ -525,7 +539,7 @@ protected:
     [[nodiscard]] inline bool
     check_valid_offset(uint64_t size) const {
         // Check if the given offset is within the bounds of the IO object.
-        return size <= this->size_;
+        return size <= this->size_.load(std::memory_order_acquire);
     }
 
 protected:
@@ -561,7 +575,8 @@ private:
 
     [[nodiscard]] bool
     IsValidRange(uint64_t size, uint64_t offset) const {
-        return offset <= size_ and size <= size_ - offset;
+        const auto total_size = size_.load(std::memory_order_acquire);
+        return offset <= total_size and size <= total_size - offset;
     }
 
     ReadCacheSnapshot
@@ -601,7 +616,8 @@ private:
             return nullptr;
         }
         const uint64_t offset = page_id * Page::DEFAULT_PAGE_SIZE;
-        if (offset >= size_) {
+        const auto total_size = size_.load(std::memory_order_acquire);
+        if (offset >= total_size) {
             return nullptr;
         }
         if (cache.cache == nullptr or page_id > UINT64_MAX - cache.page_id_base) {
@@ -630,7 +646,8 @@ private:
                 page = std::make_shared<Page>(allocator_);
                 success = page->Data() != nullptr;
                 if (success) {
-                    const uint64_t read_size = std::min(Page::DEFAULT_PAGE_SIZE, size_ - offset);
+                    const uint64_t read_size =
+                        std::min(Page::DEFAULT_PAGE_SIZE, total_size - offset);
                     success = cast().ReadImpl(read_size, offset, page->Data());
                 }
             } catch (...) {
@@ -728,17 +745,19 @@ private:
             loaded_pages.reserve(owned_loads.size());
             read_sizes.reserve(owned_loads.size());
             read_offsets.reserve(owned_loads.size());
+            const auto published_size = size_.load(std::memory_order_acquire);
             for (const auto& [page_id, _] : owned_loads) {
                 if (page_id > UINT64_MAX / Page::DEFAULT_PAGE_SIZE) {
                     success = false;
                     break;
                 }
                 const uint64_t offset = page_id * Page::DEFAULT_PAGE_SIZE;
-                if (offset >= size_) {
+                if (offset >= published_size) {
                     success = false;
                     break;
                 }
-                const uint64_t read_size = std::min(Page::DEFAULT_PAGE_SIZE, size_ - offset);
+                const uint64_t read_size =
+                    std::min(Page::DEFAULT_PAGE_SIZE, published_size - offset);
                 if (read_size > UINT64_MAX - total_size) {
                     success = false;
                     break;

--- a/src/io/memory_block_io/memory_block_io.cpp
+++ b/src/io/memory_block_io/memory_block_io.cpp
@@ -64,9 +64,7 @@ MemoryBlockIO::WriteImpl(const uint8_t* data, uint64_t size, uint64_t offset) {
         ++start_no;
         start_off = 0;
     }
-    if (size + offset > this->size_) {
-        this->size_ = size + offset;
-    }
+    this->PublishSize(size + offset);
 }
 
 bool

--- a/src/io/mmap_io/mmap_io.cpp
+++ b/src/io/mmap_io/mmap_io.cpp
@@ -101,8 +101,8 @@ MMapIO::MMapIO(std::string filename, Allocator* allocator)
                         saved_errno,
                         std::error_code(saved_errno, std::system_category()).message()));
     }
-    auto mmap_size = this->size_;
-    if (this->size_ == 0) {
+    auto mmap_size = this->size_.load(std::memory_order_relaxed);
+    if (mmap_size == 0) {
         mmap_size = DEFAULT_INIT_MMAP_SIZE;
         auto ret = IOSyscall::FTruncate(this->fd_, mmap_size);
         if (ret == -1) {
@@ -177,8 +177,8 @@ MMapIO::WriteImpl(const uint8_t* data, uint64_t size, uint64_t offset) {
 #endif
         this->mapped_size_ = new_size;
     }
-    this->size_ = std::max(this->size_, new_size);
     memcpy(this->mapped_ptr_ + offset, data, size);
+    this->PublishSize(new_size);
 }
 
 void
@@ -234,10 +234,11 @@ MMapIO::ResizeImpl(uint64_t size) {
 
 bool
 MMapIO::ReadImpl(uint64_t size, uint64_t offset, uint8_t* data) const {
-    if (offset + size > this->size_) {
+    const auto total_size = this->size_.load(std::memory_order_acquire);
+    if (offset + size > total_size) {
         throw VsagException(
             ErrorType::INTERNAL_ERROR,
-            fmt::format("read offset {} + size {} > size {}", offset, size, this->size_));
+            fmt::format("read offset {} + size {} > size {}", offset, size, total_size));
     }
     memcpy(data, this->mapped_ptr_ + offset, size);
     return true;

--- a/src/io/noncontinuous_io/noncontinuous_io.h
+++ b/src/io/noncontinuous_io/noncontinuous_io.h
@@ -98,9 +98,7 @@ public:
                 start_offset = start_area->first.offset;
             }
         }
-        if (offset + size > this->size_) {
-            this->size_ = offset + size;
-        }
+        this->PublishSize(offset + size);
     }
 
     /**

--- a/src/io/noncontinuous_io/noncontinuous_io_test.cpp
+++ b/src/io/noncontinuous_io/noncontinuous_io_test.cpp
@@ -50,7 +50,7 @@ public:
     WriteImpl(const uint8_t* data, uint64_t size, uint64_t offset) {
         state_->data_.resize(std::max<uint64_t>(state_->data_.size(), offset + size));
         std::memcpy(state_->data_.data() + offset, data, size);
-        this->size_ = std::max(this->size_, offset + size);
+        this->PublishSize(offset + size);
     }
 
     bool

--- a/src/io/reader_io/reader_io_test.cpp
+++ b/src/io/reader_io/reader_io_test.cpp
@@ -39,7 +39,7 @@ public:
     WriteImpl(const uint8_t* data, uint64_t size, uint64_t offset) {
         ++write_count_;
         REQUIRE(data != nullptr);
-        this->size_ = std::max(this->size_, offset + size);
+        this->PublishSize(offset + size);
     }
 
     uint64_t

--- a/src/io/uring_io/uring_io.cpp
+++ b/src/io/uring_io/uring_io.cpp
@@ -100,9 +100,7 @@ UringIO::WriteImpl(const uint8_t* data, uint64_t size, uint64_t offset) {
         throw VsagException(ErrorType::INTERNAL_ERROR,
                             fmt::format("write bytes {} less than {}", ret, size));
     }
-    if (size + offset > this->size_) {
-        this->size_ = size + offset;
-    }
+    this->PublishSize(size + offset);
 }
 
 void

--- a/src/layout/fixed_layout_test.cpp
+++ b/src/layout/fixed_layout_test.cpp
@@ -41,7 +41,7 @@ public:
 
     void
     WriteImpl(const uint8_t*, uint64_t size, uint64_t offset) {
-        this->size_ = std::max(this->size_, offset + size);
+        this->PublishSize(offset + size);
     }
 
     bool

--- a/src/storage/serialization_tags.h
+++ b/src/storage/serialization_tags.h
@@ -41,6 +41,7 @@ enum class StreamSerializationTag : uint32_t {
     CODE_SLOT_MAP = 15,
     IVF_BUCKET_GRAPH = 16,
     IVF_PRECISE_BUCKET = 17,
+    CONJUGATE_GRAPH = 18,
 };
 
 inline const char*
@@ -82,6 +83,8 @@ StreamSerializationTagName(uint32_t tag) {
             return "ivf_bucket_graph";
         case StreamSerializationTag::IVF_PRECISE_BUCKET:
             return "ivf_precise_bucket";
+        case StreamSerializationTag::CONJUGATE_GRAPH:
+            return "conjugate_graph";
     }
     return "unknown";
 }
@@ -109,6 +112,7 @@ StreamSerializationTagCritical(uint32_t tag) {
         case StreamSerializationTag::EXTRA_INFO:
         case StreamSerializationTag::RAW_VECTOR:
         case StreamSerializationTag::IVF_BUCKET_GRAPH:
+        case StreamSerializationTag::CONJUGATE_GRAPH:
             return false;
     }
     return false;
@@ -138,6 +142,7 @@ StreamSerializationBlockCurrentVersion(uint32_t tag) {
         case StreamSerializationTag::IVF_PRECISE_BUCKET:
             return kStreamSerializationBlockVersionV1;
         case StreamSerializationTag::IVF_BUCKET_GRAPH:
+        case StreamSerializationTag::CONJUGATE_GRAPH:
             return kStreamSerializationBlockVersionV1;
     }
     return kStreamSerializationBlockVersionV1;

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -576,6 +576,232 @@ RequireHGraphStreamingSearchMatches(const fixtures::TestIndex::IndexPtr& expecte
     }
 }
 
+TEST_CASE("HGraph conjugate graph feedback, update, and serialization",
+          "[ft][hgraph][conjugate_graph]") {
+    using namespace fixtures;
+    constexpr int64_t dim = 2;
+    HGraphTestIndex::HGraphBuildParam build_param("l2", dim, "fp32");
+    build_param.thread_count = 1;
+    build_param.use_attr_filter = true;
+    auto param_json =
+        vsag::JsonType::Parse(HGraphTestIndex::GenerateHGraphBuildParametersString(build_param));
+    param_json[vsag::INDEX_PARAM][vsag::PARAMETER_USE_CONJUGATE_GRAPH].SetBool(true);
+    auto param = param_json.Dump();
+
+    std::vector<int64_t> ids = {10, 20, 30};
+    std::vector<float> vectors = {0.0F, 0.0F, 1.0F, 0.0F, 2.0F, 0.0F};
+    std::vector<vsag::AttributeSet> attribute_sets(3);
+    std::vector<vsag::AttributeValue<std::string>> attributes(3);
+    for (uint64_t i = 0; i < attributes.size(); ++i) {
+        attributes[i].name_ = "group";
+        attributes[i].GetValue() = {i == 1 ? "allowed" : "excluded"};
+        attribute_sets[i].attrs_.push_back(&attributes[i]);
+    }
+    auto base = vsag::Dataset::Make();
+    base->NumElements(3)
+        ->Dim(dim)
+        ->Ids(ids.data())
+        ->Float32Vectors(vectors.data())
+        ->AttributeSets(attribute_sets.data())
+        ->Owner(false);
+    auto query = vsag::Dataset::Make();
+    query->NumElements(1)->Dim(dim)->Float32Vectors(vectors.data() + dim)->Owner(false);
+
+    auto index = TestIndex::TestFactory(HGraphTestIndex::name, param, true);
+    REQUIRE(index->Build(base).has_value());
+    const auto search_disabled = R"({"hgraph":{"ef_search":1,"use_conjugate_graph_search":false}})";
+    const auto search_enabled = R"({"hgraph":{"ef_search":1,"use_conjugate_graph_search":true}})";
+    const auto memory_before_feedback = index->GetMemoryUsage();
+    const auto graph_memory_before_feedback = index->GetMemoryUsageDetail().at("conjugate_graph");
+    REQUIRE(index->Feedback(query, 1, search_disabled, 30).value() == 1);
+    constexpr uint64_t serialized_edge_size = 2 * sizeof(int64_t) + sizeof(uint64_t);
+    REQUIRE(index->GetMemoryUsage() == memory_before_feedback + serialized_edge_size);
+    REQUIRE(index->GetMemoryUsageDetail().at("conjugate_graph") ==
+            graph_memory_before_feedback + serialized_edge_size);
+    REQUIRE(index->Feedback(query, 1, search_disabled, 30).value() == 0);
+    REQUIRE_FALSE(index->Feedback(query, 0, search_disabled, 30).has_value());
+    REQUIRE_FALSE(index->Feedback(query, 1, search_disabled, 99).has_value());
+    REQUIRE(index->UpdateId(30, 300).value());
+
+    auto enhanced = index->KnnSearch(query, 1, search_enabled).value();
+    REQUIRE(enhanced->GetIds()[0] == 20);
+
+    auto filtered_query = vsag::Dataset::Make();
+    filtered_query->NumElements(1)
+        ->Dim(dim)
+        ->Float32Vectors(vectors.data() + 2 * dim)
+        ->Owner(false);
+    vsag::SearchRequest filtered_request;
+    filtered_request.query_ = filtered_query;
+    filtered_request.topk_ = 1;
+    filtered_request.params_str_ = search_enabled;
+    filtered_request.enable_attribute_filter_ = true;
+    filtered_request.attribute_filter_str_ = R"(multi_in(group, "allowed", "|"))";
+    auto filtered = index->SearchWithRequest(filtered_request).value();
+    REQUIRE(filtered->GetDim() == 1);
+    REQUIRE(filtered->GetIds()[0] == 20);
+
+    REQUIRE(index->Pretrain({}, 1, search_disabled).value() == 0);
+    REQUIRE_FALSE(index->Pretrain({99}, 1, search_disabled).has_value());
+    auto pretrain = index->Pretrain({10}, 2, search_disabled);
+    REQUIRE(pretrain.has_value());
+    REQUIRE(pretrain.value() > 0);
+
+    auto verify = [&](const TestIndex::IndexPtr& restored) {
+        auto feedback = restored->Feedback(query, 1, search_disabled, 300);
+        REQUIRE(feedback.has_value());
+        REQUIRE(feedback.value() == 0);
+    };
+
+    auto binary = index->Serialize();
+    REQUIRE(binary.has_value());
+    auto binary_restored = TestIndex::TestFactory(HGraphTestIndex::name, param, true);
+    REQUIRE(binary_restored->Deserialize(binary.value()).has_value());
+    verify(binary_restored);
+
+    std::stringstream stream;
+    REQUIRE(index->SerializeStreaming(stream).has_value());
+    const auto bytes = stream.str();
+    auto block =
+        vsag::test::FindStreamingBlock(bytes, vsag::StreamSerializationTag::CONJUGATE_GRAPH);
+    REQUIRE(block.payload_size > 0);
+    auto stream_restored = TestIndex::TestFactory(HGraphTestIndex::name, param, true);
+    std::stringstream input(bytes);
+    REQUIRE(stream_restored->DeserializeStreaming(input).has_value());
+    verify(stream_restored);
+
+    param_json[vsag::INDEX_PARAM][vsag::PARAMETER_USE_CONJUGATE_GRAPH].SetBool(false);
+    const auto disabled_param = param_json.Dump();
+    auto disabled = TestIndex::TestFactory(HGraphTestIndex::name, disabled_param, true);
+    REQUIRE(disabled->Build(base).has_value());
+    REQUIRE_FALSE(disabled->Feedback(query, 1, search_disabled, 30).has_value());
+    REQUIRE_FALSE(disabled->Pretrain({10}, 1, search_disabled).has_value());
+
+    std::stringstream disabled_binary_stream;
+    REQUIRE(disabled->Serialize(disabled_binary_stream).has_value());
+    const auto disabled_binary_bytes = disabled_binary_stream.str();
+    auto disabled_binary_restored =
+        TestIndex::TestFactory(HGraphTestIndex::name, disabled_param, true);
+    std::stringstream disabled_binary_input(disabled_binary_bytes);
+    REQUIRE(disabled_binary_restored->Deserialize(disabled_binary_input).has_value());
+    auto binary_mismatched = TestIndex::TestFactory(HGraphTestIndex::name, param, true);
+    std::stringstream binary_mismatched_input(disabled_binary_bytes);
+    REQUIRE(binary_mismatched->Deserialize(binary_mismatched_input).has_value());
+    REQUIRE(binary_mismatched->Feedback(query, 1, search_disabled, 30).value() == 1);
+
+    std::stringstream disabled_stream;
+    REQUIRE(disabled->SerializeStreaming(disabled_stream).has_value());
+    const auto disabled_bytes = disabled_stream.str();
+    auto disabled_stream_restored =
+        TestIndex::TestFactory(HGraphTestIndex::name, disabled_param, true);
+    std::stringstream disabled_input(disabled_bytes);
+    REQUIRE(disabled_stream_restored->DeserializeStreaming(disabled_input).has_value());
+    auto mismatched = TestIndex::TestFactory(HGraphTestIndex::name, param, true);
+    std::stringstream enabled_mismatched_input(disabled_bytes);
+    REQUIRE(mismatched->DeserializeStreaming(enabled_mismatched_input).has_value());
+    REQUIRE(mismatched->Feedback(query, 1, search_disabled, 30).value() == 1);
+
+    auto disabled_mismatched = TestIndex::TestFactory(HGraphTestIndex::name, disabled_param, true);
+    std::stringstream mismatched_input(bytes);
+    REQUIRE_FALSE(disabled_mismatched->DeserializeStreaming(mismatched_input).has_value());
+}
+
+TEST_CASE("HGraph feedback exact search is safe during concurrent Add",
+          "[ft][hgraph][conjugate_graph][concurrent]") {
+    using namespace fixtures;
+    constexpr int64_t dim = 2;
+    HGraphTestIndex::HGraphBuildParam build_param("l2", dim, "fp32");
+    build_param.thread_count = 1;
+    auto param_json =
+        vsag::JsonType::Parse(HGraphTestIndex::GenerateHGraphBuildParametersString(build_param));
+    param_json[vsag::INDEX_PARAM][vsag::PARAMETER_USE_CONJUGATE_GRAPH].SetBool(true);
+    param_json[vsag::INDEX_PARAM][vsag::HGRAPH_INIT_CAPACITY].SetUint64(2);
+    param_json[vsag::INDEX_PARAM][vsag::RESIZE_INCREASE_COUNT_BIT].SetUint64(1);
+
+    std::vector<int64_t> ids = {10, 20};
+    std::vector<float> vectors = {0.0F, 0.0F, 1.0F, 0.0F};
+    auto base = vsag::Dataset::Make();
+    base->NumElements(2)->Dim(dim)->Ids(ids.data())->Float32Vectors(vectors.data())->Owner(false);
+    auto query = vsag::Dataset::Make();
+    query->NumElements(1)->Dim(dim)->Float32Vectors(vectors.data())->Owner(false);
+
+    auto index = TestIndex::TestFactory(HGraphTestIndex::name, param_json.Dump(), true);
+    REQUIRE(index->Build(base).has_value());
+    const auto search_parameters =
+        R"({"hgraph":{"ef_search":8,"use_conjugate_graph_search":false}})";
+    std::atomic<bool> start{false};
+    std::atomic<bool> add_succeeded{true};
+    std::atomic<bool> feedback_succeeded{true};
+
+    std::thread writer([&]() {
+        while (not start.load(std::memory_order_acquire)) {
+            std::this_thread::yield();
+        }
+        for (int64_t i = 0; i < 128; ++i) {
+            std::vector<int64_t> add_ids = {1000 + i};
+            std::vector<float> add_vectors = {static_cast<float>(i + 2), 0.0F};
+            auto add = vsag::Dataset::Make();
+            add->NumElements(1)
+                ->Dim(dim)
+                ->Ids(add_ids.data())
+                ->Float32Vectors(add_vectors.data())
+                ->Owner(false);
+            if (not index->Add(add).has_value()) {
+                add_succeeded.store(false, std::memory_order_release);
+                return;
+            }
+        }
+    });
+    std::thread reader([&]() {
+        while (not start.load(std::memory_order_acquire)) {
+            std::this_thread::yield();
+        }
+        for (int64_t i = 0; i < 128; ++i) {
+            if (not index->Feedback(query, 1, search_parameters).has_value()) {
+                feedback_succeeded.store(false, std::memory_order_release);
+                return;
+            }
+        }
+    });
+
+    start.store(true, std::memory_order_release);
+    writer.join();
+    reader.join();
+    REQUIRE(add_succeeded.load(std::memory_order_acquire));
+    REQUIRE(feedback_succeeded.load(std::memory_order_acquire));
+    REQUIRE(index->GetNumElements() == 130);
+}
+
+TEST_CASE("HGraph conjugate graph does not widen range reorder",
+          "[ft][hgraph][conjugate_graph][range]") {
+    const auto params = R"({
+        "dtype":"float32", "metric_type":"l2", "dim":1,
+        "index_param":{"base_quantization_type":"sq8","precise_quantization_type":"fp32",
+        "max_degree":16,"ef_construction":32,"use_reorder":true,"use_conjugate_graph":true}
+    })";
+    auto index = vsag::Factory::CreateIndex("hgraph", params).value();
+    constexpr int64_t count = 20;
+    std::vector<float> vectors(count);
+    std::vector<int64_t> ids(count);
+    std::iota(vectors.begin(), vectors.end(), 0.0F);
+    std::iota(ids.begin(), ids.end(), 0);
+    auto base = vsag::Dataset::Make();
+    base->NumElements(count)->Dim(1)->Ids(ids.data())->Float32Vectors(vectors.data())->Owner(false);
+    REQUIRE(index->Build(base).has_value());
+
+    const float query_vector = 0.0F;
+    auto query = vsag::Dataset::Make();
+    query->NumElements(1)->Dim(1)->Float32Vectors(&query_vector)->Owner(false);
+    auto result = index->RangeSearch(query,
+                                     std::numeric_limits<float>::max(),
+                                     R"({"hgraph":{"ef_search":20,"enable_reorder":true}})",
+                                     2);
+    REQUIRE(result.has_value());
+    REQUIRE(result.value()->GetDim() == 2);
+    auto statistics = vsag::JsonType::Parse(result.value()->GetStatistics());
+    REQUIRE(statistics["distance_evaluations_by_phase"]["rerank"].GetUint64() == 2);
+}
+
 #define HGRAPH_PR_DAILY_CASE(title, tags, helper)                        \
     TEST_CASE("(PR) " title, tags "[pr]") {                              \
         auto test_index = std::make_shared<fixtures::HGraphTestIndex>(); \


### PR DESCRIPTION
## Summary

- add HGraph-scoped conjugate-graph build/search parameters and maintained `Feedback`/`Pretrain` support
- integrate label updates, result enhancement, memory accounting, and binary/streaming serialization
- make exact feedback scans safe during concurrent Add by atomically publishing initialized I/O extents
- preserve older binary and streaming indexes when loading into a conjugate-enabled target, while rejecting data loss in the reverse direction
- bound exact scans to published logical code counts for deduplicated and regular storage
- migrate the runnable example and synchronize active English/Chinese HGraph documentation

## Validation

- clang-format 15
- clang-tidy 15 on changed implementation files
- focused HGraph parameter, ConjugateGraph, I/O, unsupported-default, and enhancement functional tests
- focused TSAN concurrent Add/Feedback regression
- HGraph enhancement example (recall 0.87 to 1.00)

Fixes: #2650