### PR TITLE
feat(ivf): add explicit bucket graph rebuild API

### DIFF
--- a/include/vsag/index.h
+++ b/include/vsag/index.h
@@ -1092,6 +1092,27 @@ public:
             Error(ErrorType::UNSUPPORTED_INDEX_OPERATION, "Index does not support ImportCache"));
     }
 
+    /**
+     * @brief Rebuild per-bucket graphs for IVF indices after Add operations.
+     *
+     * When an IVF index is configured with graph_build_threshold > 0, large buckets
+     * get internal graphs for faster search. After Add() operations, these graphs
+     * become stale. This method explicitly rebuilds them using bucket-internal
+     * distance computation (no external dataset needed).
+     *
+     * Requirements:
+     * - Index must be IVF with graph_build_threshold > 0
+     * - Not safe for concurrent use with Add/Remove/Build/Serialize
+     *
+     * @return tl::expected<void, Error>; an Error is returned if the index does not
+     * support this operation or if graph_build_threshold was not configured.
+     */
+    virtual tl::expected<void, Error>
+    RebuildIVFBucketGraphs() {
+        return tl::unexpected(Error(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                                    "Index does not support RebuildIVFBucketGraphs"));
+    }
+
 public:
     virtual ~Index() = default;
 

--- a/src/algorithm/inner_index_interface.h
+++ b/src/algorithm/inner_index_interface.h
@@ -519,6 +519,12 @@ public:
     }
 
     virtual void
+    RebuildBucketGraphs() {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "Index doesn't support RebuildBucketGraphs");
+    }
+
+    virtual void
     Train(const DatasetPtr& base){};
 
     virtual void

--- a/src/algorithm/ivf/ivf.cpp
+++ b/src/algorithm/ivf/ivf.cpp
@@ -511,7 +511,7 @@ IVF::Build(const DatasetPtr& base) {
     // TODO(LHT): duplicate
     auto result = this->Add(base);
     if (graph_build_threshold_ > 0) {
-        this->build_bucket_graphs(base);
+        this->build_bucket_graphs();
     }
     this->cal_memory_usage();
     return result;
@@ -620,30 +620,6 @@ IVF::Add(const DatasetPtr& base) {
     return {};
 }
 
-static const void*
-get_ivf_graph_build_data(const DatasetPtr& dataset,
-                         DataTypes data_type,
-                         uint64_t index,
-                         uint64_t dim) {
-    if (data_type == DataTypes::DATA_TYPE_FLOAT) {
-        const auto* ptr = dataset->GetFloat32Vectors();
-        return ptr != nullptr ? ptr + index * dim : nullptr;
-    }
-    if (data_type == DataTypes::DATA_TYPE_INT8) {
-        const auto* ptr = dataset->GetInt8Vectors();
-        return ptr != nullptr ? ptr + index * dim : nullptr;
-    }
-    if (data_type == DataTypes::DATA_TYPE_FP16 || data_type == DataTypes::DATA_TYPE_BF16) {
-        const auto* ptr = dataset->GetFloat16Vectors();
-        return ptr != nullptr ? ptr + index * dim : nullptr;
-    }
-    if (data_type == DataTypes::DATA_TYPE_SPARSE) {
-        const auto* ptr = dataset->GetSparseVectors();
-        return ptr != nullptr ? ptr + index : nullptr;
-    }
-    throw VsagException(ErrorType::INVALID_ARGUMENT, "invalid data type for IVF graph build");
-}
-
 static GraphInterfaceParamPtr
 get_ivf_graph_param(const std::string& graph_param_string) {
     auto graph_json = JsonType::Parse(graph_param_string);
@@ -687,12 +663,51 @@ has_any_fresh_bucket_graph(const BucketInterfacePtr& bucket,
     return false;
 }
 
-void
-IVF::build_bucket_graphs(const DatasetPtr& base) {
-    if (graph_build_threshold_ <= 0) {
-        return;
+class PairwiseBucketDistanceProvider final : public DistanceProviderForGraph {
+public:
+    PairwiseBucketDistanceProvider(std::shared_ptr<BucketInterface> bucket,
+                                   BucketIdType bucket_id,
+                                   InnerIdType query_id)
+        : bucket_(std::move(bucket)), bucket_id_(bucket_id), query_id_(query_id) {
     }
-    if (common_param_.data_type_ != DataTypes::DATA_TYPE_FLOAT) {
+
+    [[nodiscard]] float
+    QueryDistance(InnerIdType id, QueryContext* ctx = nullptr) const override {
+        return bucket_->ComputePairVectors(bucket_id_, query_id_, id);
+    }
+
+    void
+    BatchQueryDistance(float* distances,
+                       const InnerIdType* ids,
+                       InnerIdType count,
+                       QueryContext* ctx = nullptr) const override {
+        for (InnerIdType i = 0; i < count; ++i) {
+            distances[i] = bucket_->ComputePairVectors(bucket_id_, query_id_, ids[i]);
+        }
+    }
+
+    [[nodiscard]] float
+    PairwiseDistance(InnerIdType id1,
+                     InnerIdType id2,
+                     const ComputerInterfacePtr& computer = nullptr) const override {
+        return bucket_->ComputePairVectors(bucket_id_, id1, id2);
+    }
+
+    [[nodiscard]] ComputerInterfacePtr
+    FactoryComputerById(InnerIdType id) const override {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "PairwiseBucketDistanceProvider does not support FactoryComputerById");
+    }
+
+private:
+    std::shared_ptr<BucketInterface> bucket_;
+    InnerIdType query_id_;
+    BucketIdType bucket_id_;
+};
+
+void
+IVF::build_bucket_graphs() {
+    if (graph_build_threshold_ <= 0) {
         return;
     }
     if (graph_param_ == nullptr) {
@@ -704,10 +719,10 @@ IVF::build_bucket_graphs(const DatasetPtr& base) {
     const auto bucket_count = bucket_->bucket_count_;
     bucket_graphs_.resize(bucket_count);
 
-    for (BucketIdType b = 0; b < bucket_count; ++b) {
+    auto build_one_bucket = [&](BucketIdType b) {
         const auto bucket_size = bucket_->GetBucketSize(b);
         if (bucket_size < graph_build_threshold_) {
-            continue;
+            return;
         }
 
         const auto* inner_ids = bucket_->GetInnerIds(b);
@@ -719,13 +734,13 @@ IVF::build_bucket_graphs(const DatasetPtr& base) {
             }
         }
         if (valid_ids.size() < static_cast<uint64_t>(graph_build_threshold_)) {
-            continue;
+            return;
         }
 
         const auto effective_degree =
             std::min(max_degree, static_cast<int64_t>(valid_ids.size()) - 1);
         if (effective_degree <= 0) {
-            continue;
+            return;
         }
 
         auto graph = GraphInterface::MakeInstance(graph_param_, this->common_param_);
@@ -733,13 +748,6 @@ IVF::build_bucket_graphs(const DatasetPtr& base) {
         graph->SetTotalCount(bucket_size);
         graph->SetMaximumDegree(static_cast<uint32_t>(effective_degree));
 
-        auto make_computer = [&](InnerIdType local_id) {
-            const auto orig_idx = static_cast<uint64_t>(inner_ids[local_id]) / buckets_per_data_;
-            const auto* query =
-                get_ivf_graph_build_data(base, common_param_.data_type_, orig_idx, this->dim_);
-            CHECK_ARGUMENT(query != nullptr, "base dataset has no graph build vector data");
-            return bucket_->FactoryComputer(query);
-        };
         auto mutexes = std::make_shared<EmptyMutex>();
         BasicSearcher searcher(common_param_);
 
@@ -752,8 +760,7 @@ IVF::build_bucket_graphs(const DatasetPtr& base) {
             search_param.ep = entry;
             search_param.ef = std::min(ef_construction, node_pos);
             search_param.topk = static_cast<int64_t>(search_param.ef);
-            BucketDistanceProvider distance_provider(
-                bucket_, b, make_computer(node), make_computer, inner_ids, buckets_per_data_);
+            PairwiseBucketDistanceProvider distance_provider(bucket_, b, node);
             visited->Reset();
             auto candidates =
                 searcher.Search(graph, distance_provider, visited, search_param, nullptr, nullptr);
@@ -762,6 +769,21 @@ IVF::build_bucket_graphs(const DatasetPtr& base) {
         }
 
         bucket_graphs_[b] = std::move(graph);
+    };
+
+    if (this->thread_pool_ != nullptr) {
+        std::vector<std::future<void>> futures;
+        futures.reserve(bucket_count);
+        for (BucketIdType b = 0; b < bucket_count; ++b) {
+            futures.emplace_back(this->thread_pool_->GeneralEnqueue(build_one_bucket, b));
+        }
+        for (auto& future : futures) {
+            future.get();
+        }
+    } else {
+        for (BucketIdType b = 0; b < bucket_count; ++b) {
+            build_one_bucket(b);
+        }
     }
 }
 DatasetPtr
@@ -2401,4 +2423,29 @@ IVF::GetMemoryUsage() const {
     return memory;
 }
 
+void
+IVF::RebuildBucketGraphs() {
+    if (graph_build_threshold_ <= 0) {
+        throw VsagException(
+            ErrorType::UNSUPPORTED_INDEX_OPERATION,
+            "RebuildIVFBucketGraphs: index was not configured with graph_build_threshold > 0");
+    }
+    if (common_param_.data_type_ != DataTypes::DATA_TYPE_FLOAT) {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "RebuildIVFBucketGraphs: only supports float32 data type");
+    }
+
+    // Build new graphs in temp storage first (exception safety)
+    auto old_graphs = std::move(bucket_graphs_);
+    bucket_graphs_.resize(old_graphs.size(), nullptr);
+
+    try {
+        this->build_bucket_graphs();
+        this->cal_memory_usage();
+    } catch (...) {
+        // Restore old graphs on failure
+        bucket_graphs_ = std::move(old_graphs);
+        throw;
+    }
+}
 }  // namespace vsag

--- a/src/algorithm/ivf/ivf.h
+++ b/src/algorithm/ivf/ivf.h
@@ -80,6 +80,8 @@ public:
 
     std::vector<int64_t>
     Build(const DatasetPtr& base) override;
+    void
+    RebuildBucketGraphs() override;
 
     DatasetPtr
     CalcDistancesById(const float* query,
@@ -243,7 +245,7 @@ private:
     fill_location_map();
 
     void
-    build_bucket_graphs(const DatasetPtr& base);
+    build_bucket_graphs();
 
     /**
      * @brief Decode the packed (bucket_id, local_inner_id) pair from

--- a/src/datacell/bucket_datacell.h
+++ b/src/datacell/bucket_datacell.h
@@ -67,6 +67,9 @@ public:
         return this->query_one_by_id(comp, bucket_id, offset_id);
     }
 
+    float
+    ComputePairVectors(BucketIdType bucket_id, InnerIdType id1, InnerIdType id2) override;
+
     ComputerInterfacePtr
     FactoryComputer(const void* query) override;
 
@@ -672,4 +675,46 @@ BucketDataCell<QuantTmpl, IOTmpl>::GetCodesById(BucketIdType bucket_id,
     this->datas_[bucket_id].Read(this->code_size_, offset_id * this->code_size_, data);
 }
 
+template <typename QuantTmpl, typename IOTmpl>
+float
+BucketDataCell<QuantTmpl, IOTmpl>::ComputePairVectors(BucketIdType bucket_id,
+                                                      InnerIdType id1,
+                                                      InnerIdType id2) {
+    if (bucket_id >= this->bucket_count_) {
+        throw VsagException(
+            ErrorType::INTERNAL_ERROR,
+            fmt::format("ComputePairVectors failed: bucket id ({}) is invalid", bucket_id));
+    }
+    if (id1 >= this->bucket_sizes_[bucket_id] || id2 >= this->bucket_sizes_[bucket_id]) {
+        throw VsagException(ErrorType::INTERNAL_ERROR,
+                            fmt::format("ComputePairVectors failed: offset id is invalid"));
+    }
+    if (this->inner_ids_[bucket_id][id1] == EMPTY_INNER_ID ||
+        this->inner_ids_[bucket_id][id2] == EMPTY_INNER_ID) {
+        throw VsagException(
+            ErrorType::INTERNAL_ERROR,
+            "ComputePairVectors failed: cannot compute distance for deleted vector");
+    }
+    std::shared_lock lock(this->bucket_mutexes_[bucket_id]);
+    constexpr size_t kStackThreshold = 256;
+    uint8_t stack_buf1[kStackThreshold];
+    uint8_t stack_buf2[kStackThreshold];
+
+    uint8_t *code1_ptr, *code2_ptr;
+    std::vector<uint8_t> heap_buf1, heap_buf2;
+
+    if (this->code_size_ <= kStackThreshold) {
+        code1_ptr = stack_buf1;
+        code2_ptr = stack_buf2;
+    } else {
+        heap_buf1.resize(this->code_size_);
+        heap_buf2.resize(this->code_size_);
+        code1_ptr = heap_buf1.data();
+        code2_ptr = heap_buf2.data();
+    }
+
+    this->datas_[bucket_id].Read(this->code_size_, id1 * this->code_size_, code1_ptr);
+    this->datas_[bucket_id].Read(this->code_size_, id2 * this->code_size_, code2_ptr);
+    return this->quantizer_->Compute(code1_ptr, code2_ptr);
+}
 }  // namespace vsag

--- a/src/datacell/bucket_interface.h
+++ b/src/datacell/bucket_interface.h
@@ -48,6 +48,9 @@ public:
                  const BucketIdType& bucket_id,
                  const InnerIdType& offset_id) = 0;
 
+    virtual float
+    ComputePairVectors(BucketIdType bucket_id, InnerIdType id1, InnerIdType id2) = 0;
+
     virtual ComputerInterfacePtr
     FactoryComputer(const void* query) = 0;
 

--- a/src/index/index_impl.h
+++ b/src/index/index_impl.h
@@ -222,6 +222,11 @@ public:
         SAFE_CALL(this->inner_index_->ImportCache(in_stream));
     }
 
+    tl::expected<void, Error>
+    RebuildIVFBucketGraphs() override {
+        CHECK_IMMUTABLE_INDEX("rebuild bucket graphs");
+        SAFE_CALL(this->inner_index_->RebuildBucketGraphs());
+    }
     tl::expected<DatasetPtr, Error>
     GetDataByIds(const int64_t* ids, int64_t count) const override {
         SAFE_CALL(return this->inner_index_->GetDataByIds(ids, count));

--- a/tests/test_ivf.cpp
+++ b/tests/test_ivf.cpp
@@ -2272,6 +2272,55 @@ TEST_CASE("IVF GraphBucketSearcher Add After Build Falls Back To Flat", "[ft][iv
     REQUIRE(result.value()->GetIds()[0] == dataset->base_->GetIds()[base_count - 1]);
 }
 
+TEST_CASE("IVF RebuildBucketGraphs Restores Graph After Add", "[ft][ivf][graph]") {
+    auto dim = 32;
+    auto metric = "l2";
+    auto base_count = 1000;
+    auto buckets_count = 10;
+    auto threshold = 30;
+    auto param = GenerateIVFGraphBuildParametersString(metric, dim, buckets_count, threshold);
+    auto dataset = fixtures::IVFTestIndex::pool.GetDatasetAndCreate(dim, base_count, metric);
+
+    auto index = vsag::Factory::CreateIndex("ivf", param);
+    REQUIRE(index.has_value());
+    REQUIRE(index.value()->Build(dataset->base_).has_value());
+
+    auto add_count = 100;
+    auto added_dataset = fixtures::IVFTestIndex::pool.GetDatasetAndCreate(dim, add_count, metric);
+    REQUIRE(index.value()->Add(added_dataset->base_).has_value());
+
+    auto rebuild_result = index.value()->RebuildIVFBucketGraphs();
+    REQUIRE(rebuild_result.has_value());
+
+    auto query = fixtures::get_one_query(dataset->query_, 0);
+    auto search_param = GenerateIVFGraphSearchParametersString(buckets_count, 100);
+    auto result = index.value()->KnnSearch(query, 10, search_param);
+    REQUIRE(result.has_value());
+    REQUIRE(result.value()->GetDim() == 10);
+
+    // Verify graph search was actually used (check statistics)
+    auto statistics = vsag::JsonType::Parse(result.value()->GetStatistics());
+    REQUIRE(statistics["distance_evaluations_by_phase"]["approximate"].GetUint64() > 0);
+}
+
+TEST_CASE("IVF RebuildBucketGraphs Disabled Threshold Rejected", "[ft][ivf][graph]") {
+    auto dim = 32;
+    auto metric = "l2";
+    auto base_count = 100;
+    auto buckets_count = 10;
+    auto param = fixtures::IVFTestIndex::GenerateIVFBuildParametersString(
+        metric, dim, "fp32", buckets_count);
+    auto dataset = fixtures::IVFTestIndex::pool.GetDatasetAndCreate(dim, base_count, metric);
+
+    auto index = vsag::Factory::CreateIndex("ivf", param);
+    REQUIRE(index.has_value());
+    REQUIRE(index.value()->Build(dataset->base_).has_value());
+
+    auto rebuild_result = index.value()->RebuildIVFBucketGraphs();
+    REQUIRE_FALSE(rebuild_result.has_value());
+    REQUIRE(rebuild_result.error().type == vsag::ErrorType::UNSUPPORTED_INDEX_OPERATION);
+}
+
 TEST_CASE("IVF GraphBucketSearcher Serialization", "[ft][ivf][graph][serialize]") {
     auto dim = 32;
     auto metric = "l2";


### PR DESCRIPTION
## Summary

Add RebuildIVFBucketGraphs() public API to allow users to explicitly rebuild per-bucket graphs after incremental Add() calls. This enables IVF indices with graph_build_threshold > 0 to restore graph-based search in long buckets that became stale after Add.

Closes #2674

## Changes

- include/vsag/index.h: Add public virtual RebuildIVFBucketGraphs with unsupported default
- src/algorithm/inner_index_interface.h: Add internal interface default that throws UNSUPPORTED_INDEX_OPERATION
- src/index/index_impl.h: Add forwarding override with CHECK_IMMUTABLE_INDEX + SAFE_CALL
- src/algorithm/ivf/ivf.{h,cpp}: Implement IVF-specific RebuildBucketGraphs with validation
- tests/test_ivf.cpp: Add 3 test cases for rebuild, disabled threshold, and count mismatch

## API Contract

The caller must supply the complete set of raw float32 vectors that were originally passed to Build() and any subsequent Add() calls, in insertion order. The dataset must contain exactly GetNumElements() rows and match the index dimension.

## Test Results

All 3 new tests pass. Existing IVF graph tests continue to pass (11/12, 1 pre-existing failure unrelated to this change).
