### PR TITLE
fix: support debug builds with GCC 15

### DIFF
--- a/extern/openblas/openblas.cmake
+++ b/extern/openblas/openblas.cmake
@@ -184,6 +184,13 @@ if (NOT OPENBLAS_FOUND)
     # (which implies -ffast-math) breaks CPU detection. Replace with -O2.
     string (REPLACE "-Ofast" "-O2" _openblas_c_flags "${VSAG_THIRDPARTY_C_FLAGS}")
     string (REPLACE "-ffast-math" "" _openblas_c_flags "${_openblas_c_flags}")
+    # GCC 15 defaults to GNU C23, where an empty parameter list means that a function takes
+    # no arguments. OpenBLAS' f2c-generated LAPACK sources use empty parameter lists with the
+    # pre-C23 "unspecified arguments" meaning, so compile the bundled release as GNU C17.
+    if (CMAKE_C_COMPILER_ID STREQUAL "GNU" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 15)
+        string (APPEND _openblas_c_flags
+                " -std=gnu17 -Wno-error=incompatible-pointer-types")
+    endif ()
     string (REPLACE "-Ofast" "-O2" _openblas_cxx_flags "${VSAG_THIRDPARTY_CXX_FLAGS}")
     string (REPLACE "-ffast-math" "" _openblas_cxx_flags "${_openblas_cxx_flags}")
     string (STRIP "${_openblas_c_flags}" _openblas_c_flags)

--- a/include/vsag/attribute.h
+++ b/include/vsag/attribute.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>

--- a/src/attr/attribute.cpp
+++ b/src/attr/attribute.cpp
@@ -17,6 +17,7 @@
 
 #include <cstring>
 #include <memory>
+#include <type_traits>
 
 namespace vsag {
 

--- a/src/attr/expression.h
+++ b/src/attr/expression.h
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <limits>
 #include <memory>
 #include <stdexcept>

--- a/src/storage/tlv_section.cpp
+++ b/src/storage/tlv_section.cpp
@@ -37,7 +37,7 @@ namespace vsag {
 
 namespace {
 
-struct FileCloser {
+struct file_closer {
     void
     operator()(std::FILE* file) const {
         std::fclose(file);
@@ -281,7 +281,7 @@ ReadSeekableBlockPayload(StreamReader& reader,
         return;
     }
 
-    std::unique_ptr<std::FILE, FileCloser> temp_file(std::tmpfile());
+    std::unique_ptr<std::FILE, file_closer> temp_file(std::tmpfile());
     if (temp_file == nullptr) {
         throw VsagException(ErrorType::READ_ERROR,
                             "failed to create temporary file for streaming block payload");

--- a/src/storage/tlv_section.cpp
+++ b/src/storage/tlv_section.cpp
@@ -37,6 +37,13 @@ namespace vsag {
 
 namespace {
 
+struct FileCloser {
+    void
+    operator()(std::FILE* file) const {
+        std::fclose(file);
+    }
+};
+
 void
 seek_temporary_file(std::FILE* file, uint64_t offset) {
 #if defined(_WIN32)
@@ -274,7 +281,7 @@ ReadSeekableBlockPayload(StreamReader& reader,
         return;
     }
 
-    std::unique_ptr<std::FILE, decltype(&std::fclose)> temp_file(std::tmpfile(), std::fclose);
+    std::unique_ptr<std::FILE, FileCloser> temp_file(std::tmpfile());
     if (temp_file == nullptr) {
         throw VsagException(ErrorType::READ_ERROR,
                             "failed to create temporary file for streaming block payload");


### PR DESCRIPTION
## What changed

- Compile bundled OpenBLAS as GNU C17 when using GCC 15 or newer.
- Keep OpenBLAS' legacy incompatible-pointer diagnostic as a warning under GCC 15.
- Add direct standard-library includes required by GCC 15/libstdc++ 15.
- Replace the attributed `std::fclose` function-pointer deleter with a named deleter.

## Why

GCC 15 defaults C compilation to GNU C23. In C23, an empty function parameter list means
that the function accepts no arguments, while OpenBLAS' f2c-generated LAPACK sources depend
on the pre-C23 unspecified-arguments behavior. GCC 15 also exposes stricter diagnostics and
header self-containment issues that prevented `make debug` from completing.

The OpenBLAS compatibility flags are scoped to GNU C compiler version 15 or newer, so older
GCC versions and Clang retain their existing behavior.

## Validation

- `CCACHE_DIR=/tmp/vsag-ccache make debug`
- `git diff --check`

The GCC 15.2 build completed both `vsag` and `vsag_static` targets successfully.
