### PR TITLE
docs: clarify agent contribution guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,8 +15,10 @@ Node.js/TypeScript bindings provided by `vsag`.
 
 - **Tool versions are fixed:** `clang-format` and `clang-tidy` **must be
   version 15 exactly**. Newer versions are not acceptable; CI enforces this.
-- **Formatting:** 4-space indentation, 100-character line limit, `.cpp`
-  (not `.cc`) suffix, every committed text file ends with a trailing newline.
+- **Formatting:** C++ source and header files use 4-space indentation and a
+  100-character line limit; Markdown and other non-C++ text files have no line
+  width limit. Use the `.cpp` (not `.cc`) suffix, and ensure every committed
+  text file ends with a trailing newline.
 - **Layout:** public APIs live in `include/vsag/`; implementation lives in
   `src/`; keep code in the `vsag` namespace unless the file clearly requires
   otherwise.
@@ -39,6 +41,10 @@ Node.js/TypeScript bindings provided by `vsag`.
   `Assisted-by: <AgentName>:<ModelVersion>` (e.g.
   `Assisted-by: OpenCode:claude-opus-4.7`). For `[skip ci]`, place it at
   the **start** of the subject line.
+- **PR pushes:** when preparing a pull request, prefer pushing the working
+  branch to the contributor's fork rather than directly to the main
+  `antgroup/vsag` repository. Push to the main repository only when explicitly
+  required or authorized.
 - **Pull requests need two labels:** one `kind/*` (`kind/bug`,
   `kind/feature`, `kind/improvement`, `kind/documentation`) and one
   `version/*` (e.g. `version/1.0`). Mergify enforces both.
@@ -71,7 +77,7 @@ Full build and environment details: [`docs/agents/build-and-test.md`](docs/agent
 | --- | --- |
 | Build / test / dev environment / tool versions | [`docs/agents/build-and-test.md`](docs/agents/build-and-test.md) |
 | C++ style, layout, common patterns, testing | [`docs/agents/coding-standards.md`](docs/agents/coding-standards.md) |
-| Branching, commits, DCO, `Assisted-by`, PR labels, doc sync | [`docs/agents/contribution-workflow.md`](docs/agents/contribution-workflow.md) |
+| Branching, fork-first PR pushes, commits, DCO, `Assisted-by`, PR labels, doc sync | [`docs/agents/contribution-workflow.md`](docs/agents/contribution-workflow.md) |
 | Drafting & submitting GitHub issues (`/create-issue`) | [`docs/agents/filing-issues.md`](docs/agents/filing-issues.md) |
 | Repository / docs map | [`docs/agents/docs-map.md`](docs/agents/docs-map.md) |
 

--- a/docs/agents/coding-standards.md
+++ b/docs/agents/coding-standards.md
@@ -2,13 +2,14 @@
 canonical: docs/agents/coding-standards.md
 purpose: C++ coding standards and common patterns enforced in VSAG
 key-facts:
-  - 4-space indent, 100-col limit, .cpp suffix, trailing newline required
+  - C++ files use 4-space indent and a 100-col limit; non-C++ text has no line-width limit
+  - .cpp suffix and trailing newline required
   - Public APIs live in include/vsag/; implementation in src/
   - Prefer uint64_t over size_t for macOS compatibility
 related:
   - ../../CONTRIBUTING.md
   - ../docs/en/src/development/code_structure.md
-last-reviewed: 2026-05-12
+last-reviewed: 2026-08-13
 -->
 
 # Coding Standards
@@ -17,9 +18,10 @@ Follow the Google C++ Style Guide with the project-specific rules below.
 
 ## Formatting
 
-- 4-space indentation
+- Use 4-space indentation in C++ source and header files.
 - Use `.cpp` instead of `.cc`
-- 100-character line limit
+- Keep C++ source and header files within a 100-character line limit.
+- Do not impose the C++ line limit on Markdown or other non-C++ text files.
 - Ensure committed text files end with a trailing newline
 
 ## Code layout

--- a/docs/agents/contribution-workflow.md
+++ b/docs/agents/contribution-workflow.md
@@ -1,7 +1,8 @@
 <!-- agent-hints
 canonical: docs/agents/contribution-workflow.md
-purpose: Branching, commits, DCO, Assisted-by, PR labels, doc sync rules
+purpose: Branching, fork-first PR pushes, commits, DCO, Assisted-by, PR labels, doc sync rules
 key-facts:
+  - Prefer pushing PR branches to a contributor fork, not antgroup/vsag
   - Use Conventional Commits with DCO sign-off; AI agents must NOT self-sign
   - AI agents: do NOT use `git commit -s` (it appends Signed-off-by last, with a blank line before it). Write both trailers manually in the commit body, deriving the human Signed-off-by from `git config user.name`/`user.email`
   - Trailer order: Signed-off-by first, Assisted-by immediately after, no blank line between them
@@ -10,7 +11,7 @@ key-facts:
 related:
   - ../../CONTRIBUTING.md
   - ../../.github/pull_request_template.md
-last-reviewed: 2026-05-12
+last-reviewed: 2026-08-13
 -->
 
 # Contribution Workflow
@@ -19,6 +20,11 @@ last-reviewed: 2026-05-12
 
 - Before modifying code, create and switch to a working branch from an
   up-to-date `main`.
+- When preparing a pull request, inspect the configured remotes and prefer the
+  contributor's fork as the push target. Treat `antgroup/vsag` as the upstream
+  repository, not the default destination for working branches.
+- Push a working branch directly to `antgroup/vsag` only when the task
+  explicitly requires it or the contributor has authorized it.
 - Keep changes scoped and reviewable.
 
 ## Commit messages


### PR DESCRIPTION
## Summary

- clarify that the 100-character line limit applies only to C++ source and header files
- explicitly leave Markdown and other non-C++ text files without a line-width limit
- direct agents preparing pull requests to prefer contributor forks over the main repository
- keep the entry-point guidance and detailed agent documentation in sync

## Impact

Agents can preserve natural Markdown formatting and will use a fork-first workflow when publishing pull-request branches.

## Validation

- `git diff --check`
- documentation-only change; no code tests required