### PR TITLE
perf(autotune): prune searches for memory-infeasible candidates

### DIFF
--- a/docs/docs/en/src/resources/autotune.md
+++ b/docs/docs/en/src/resources/autotune.md
@@ -259,6 +259,7 @@ result.
 
 ## V1 Boundaries
 
-V1 evaluates one KNN workload and performs a full sweep except for the supported HGraph
-`ef_search` adaptive search. It does not provide filtered or range-search workloads, adaptive query
-sampling, cross-request build cache, or model-based candidate generation.
+V1 evaluates one KNN workload and plans a full sweep except for the supported HGraph `ef_search`
+adaptive search. It skips search for candidates already known to violate the index-memory
+constraint. It does not provide filtered or range-search workloads, adaptive query sampling,
+cross-request build cache, or model-based candidate generation.

--- a/docs/docs/en/src/resources/autotune_api_v1.md
+++ b/docs/docs/en/src/resources/autotune_api_v1.md
@@ -104,8 +104,9 @@ recall only; latency and QPS remain measured metrics used by final constraint ev
 selection. This strategy assumes that recall does not decrease as `ef_search` increases while all
 other parameters and the workload remain fixed.
 
-Every probe evaluates the full query workload. If a probe fails to execute or does not produce
-recall, AutoTune stops that adaptive range because it cannot choose the next interval safely.
+Every executed probe evaluates the full query workload. If a probe is pruned, fails to execute, or
+does not produce recall, AutoTune stops that adaptive range because it cannot choose the next
+interval safely.
 
 V1 treats every JSON array and stepped range in these parameter objects as candidate choices. It
 computes their full Cartesian product and removes identical complete candidates. A no-step range
@@ -312,9 +313,9 @@ A completed evaluation returns this top-level shape. The CLI also writes it to d
 | `version` | Report contract version, always `1`. |
 | `status` | `success`, `no_feasible_candidate`, or `failed`. |
 | `recommendation` | Best feasible trial, otherwise `null`. |
-| `best_effort` | Closest successful trial when constraints are infeasible, otherwise `null`. |
+| `best_effort` | Closest successful or pruned trial when constraints are infeasible, otherwise `null`. |
 | `builds` | One record per concrete generated build group; empty in search-only mode. |
-| `trials` | One record per executed concrete search candidate. |
+| `trials` | One record per executed or constraint-pruned concrete search candidate. |
 | `request` | Effective normalized request used by the tuning engine. |
 | `elapsed_seconds` | AutoTune wall time through artifact cleanup; excludes final report writing. |
 | `report_path` | Persisted full report path; CLI/JSON adapter only. |
@@ -333,11 +334,11 @@ present, `index_path` as top-level fields inside this normalized object.
 ### Status Semantics
 
 - `success`: at least one successful trial satisfies every constraint; `recommendation` is set.
-- `no_feasible_candidate`: successful trials exist, but none satisfies every constraint;
-  `best_effort` is set for explanation and is not a valid recommendation. Typed calls return a
-  value with `TuneStatus::NO_FEASIBLE_CANDIDATE`, not an error.
+- `no_feasible_candidate`: evaluated or constraint-pruned trials exist, but none satisfies every
+  constraint; `best_effort` is set for explanation and is not a valid recommendation. Typed calls
+  return a value with `TuneStatus::NO_FEASIBLE_CANDIDATE`, not an error.
 - `failed`: the request is invalid, execution/reporting fails, or no trial can be evaluated
-  successfully with the objective metric.
+  successfully with the objective metric and no pruned trial can explain infeasibility.
 
 ### Recommendation and Best Effort
 
@@ -358,8 +359,11 @@ In build-and-search mode, `recommendation` contains:
 In search-only mode, `create_params`, `artifacts`, and `evidence.build_id` are omitted; the
 recommendation contains the concrete search parameters, workload, metrics, and
 `evidence.trial_id`. `best_effort` has the same mode-specific fields plus
-`constraint_evaluation`. It is selected first by the number of violated or missing constraints,
-then by normalized violation magnitude. It is only explanatory.
+`constraint_evaluation`. AutoTune prefers fully evaluated successful trials; only when none exists
+does it select from pruned trials. Within that pool, it first compares the number of violated or
+missing constraints, then normalized violation magnitude. It is only explanatory. When every
+candidate is pruned before search, it contains only the available shared metrics; missing search
+metrics remain missing constraint violations.
 
 ### Build Records
 
@@ -388,17 +392,17 @@ Each `trials[]` item contains:
 | `index_name` | Concrete index type. |
 | `create_params` | Concrete create parameters; build-and-search mode only. |
 | `search_params` | Concrete search parameters. |
-| `status` | `success` or `failed`. |
+| `status` | `success`, `failed`, or `pruned`. |
 | `metrics` | Available metrics used by constraint evaluation and selection. |
 | `constraint_evaluation` | `satisfied` plus a `violations` array. |
 | `artifacts` | Artifact evidence copied from the build group; build-and-search mode only. |
 | `failure` | Structured failure or `null`. |
-| `elapsed_seconds` | Search trial wall time. |
+| `elapsed_seconds` | Trial evaluation wall time; a pruned trial does not run search. |
 | `raw_eval_result` | Present only when requested and native search eval succeeded. |
 
 For an adaptive HGraph `ef_search` range, the report contains one trial for each point actually
 evaluated. Every recorded `search_params` value is concrete; the `$range` expression remains only
-in the normalized request. Every recorded trial evaluates the full query workload.
+in the normalized request. Every successful trial evaluates the full query workload.
 
 A constraint violation contains `metric`, `comparison`, `expected`, and `actual`. `actual` is
 `null` when the required metric is missing or non-finite.
@@ -406,6 +410,11 @@ A constraint violation contains `metric`, `comparison`, `expected`, and `actual`
 Search trials in one build group reuse the same loaded index instance. A generated index is built
 once and serialized once. In search-only mode the caller's index, or the index deserialized by the
 CLI adapter, is reused directly for every trial.
+
+When a positive `GetMemoryUsage()` value already exceeds an `index_memory_mb` constraint,
+AutoTune records the affected trials as `pruned` and skips their searches automatically. The
+optimization requires no tuning configuration. A zero or unavailable memory value cannot prove a
+violation and therefore does not trigger pruning.
 
 ### Artifact Semantics
 

--- a/docs/docs/zh/src/resources/autotune.md
+++ b/docs/docs/zh/src/resources/autotune.md
@@ -244,6 +244,6 @@ typed `TuneIndex` 和 `TuneSearch` 绝不会写报告文件，而是通过返回
 
 ## V1 边界
 
-V1 评测一个 KNN workload；除已支持的 HGraph `ef_search` 自适应搜索外，其他候选仍完整遍历。
-它暂不支持过滤或范围查询 workload、query sampling、跨请求 build cache，以及基于模型的
-候选生成。
+V1 评测一个 KNN workload；除已支持的 HGraph `ef_search` 自适应搜索外，其他候选仍按完整
+空间规划。已知违反索引内存约束的候选会跳过 search。它暂不支持过滤或范围查询 workload、query
+sampling、跨请求 build cache，以及基于模型的候选生成。

--- a/docs/docs/zh/src/resources/autotune_api_v1.md
+++ b/docs/docs/zh/src/resources/autotune_api_v1.md
@@ -99,8 +99,8 @@ HGraph `ef_search` 还支持一种特殊写法：
 latency 和 QPS 仍作为实测指标参与最终约束过滤和结果选择。该策略假设其他参数和 workload
 固定时，recall 不会随 `ef_search` 增大而降低。
 
-每个探测点都会评测完整 query workload。如果某个评测点执行失败或没有 recall，AutoTune
-会停止该自适应范围，因为此时无法安全选择下一个区间。
+每个实际执行的探测点都会评测完整 query workload。如果某个探测点被剪枝、执行失败
+或没有 recall，AutoTune 会停止该自适应范围，因为此时无法安全选择下一个区间。
 
 V1 会把参数对象中的所有 JSON 数组和带 `step` 的范围解释成候选集合，计算完整笛卡尔积
 并去除完全相同的候选。其他参数不接受省略 `step` 的范围。
@@ -293,9 +293,9 @@ artifact，因此 `workspace_path` 和 `keep_intermediate` 对它没有影响。
 | `version` | 报告契约版本，固定为 `1`。 |
 | `status` | `success`、`no_feasible_candidate` 或 `failed`。 |
 | `recommendation` | 最优可行 trial；不存在时为 `null`。 |
-| `best_effort` | 约束不可行时最接近的成功 trial，否则为 `null`。 |
+| `best_effort` | 约束不可行时最接近的成功或已剪枝 trial，否则为 `null`。 |
 | `builds` | 每组具体生成 build 一条记录；search-only 模式为空数组。 |
-| `trials` | 每组已执行的具体 search 候选一条记录。 |
+| `trials` | 每组已执行或因约束被剪枝的具体 search 候选一条记录。 |
 | `request` | 调优引擎实际使用的有效规范化请求。 |
 | `elapsed_seconds` | AutoTune 墙钟时间包含 artifact 清理，不含最终报告写入。 |
 | `report_path` | 持久化完整报告路径；只在 CLI/JSON 适配器中存在。 |
@@ -313,10 +313,11 @@ config 和 output。build-and-search 模式还包含 `index_spaces`；search-onl
 ### Status 语义
 
 - `success`：至少一个成功 trial 满足全部约束，设置 `recommendation`。
-- `no_feasible_candidate`：存在成功 trial，但没有任何一个满足全部约束；设置
-  `best_effort` 用于解释，它不是有效推荐。typed 调用会返回带
+- `no_feasible_candidate`：存在已评测或因约束被剪枝的 trial，但没有任何一个满足全部
+  约束；设置 `best_effort` 用于解释，它不是有效推荐。typed 调用会返回带
   `TuneStatus::NO_FEASIBLE_CANDIDATE` 的值，而不是 error。
-- `failed`：请求非法、执行或报告阶段失败，或者没有成功且带目标指标的 trial。
+- `failed`：请求非法、执行或报告阶段失败，或者没有成功且带目标指标的 trial，同时也没有
+  可用于解释不可行性的已剪枝 trial。
 
 ### Recommendation 和 Best Effort
 
@@ -336,8 +337,10 @@ build-and-search 模式下，`recommendation` 包含：
 
 search-only 模式会省略 `create_params`、`artifacts` 和 `evidence.build_id`，只包含具体
 查询参数、workload、metrics 和 `evidence.trial_id`。`best_effort` 使用相同的模式相关
-字段，并额外包含 `constraint_evaluation`。它首先按违反或缺失约束数量选择，再比较归一化
-violation 大小，只用于解释。
+字段，并额外包含 `constraint_evaluation`。AutoTune 优先从完整评测成功的 trial 中选择；
+只有不存在这类 trial 时，才会从已剪枝 trial 中选择。在该范围内，它先按违反或缺失
+约束数量选择，再比较归一化 violation 大小，只用于解释。如果全部候选都在 search 前被剪枝，
+它只包含已有的共享指标；缺失的 search 指标仍会记录为 missing constraint violation。
 
 ### Build 记录
 
@@ -366,17 +369,17 @@ search-only 模式的 `builds` 为空。build-and-search 模式下，每个 `bui
 | `index_name` | 具体索引类型。 |
 | `create_params` | 具体创建参数；仅 build-and-search 模式存在。 |
 | `search_params` | 具体查询参数。 |
-| `status` | `success` 或 `failed`。 |
+| `status` | `success`、`failed` 或 `pruned`。 |
 | `metrics` | 用于约束评估和选择的可用指标。 |
 | `constraint_evaluation` | `satisfied` 和 `violations` 数组。 |
 | `artifacts` | 从 build group 复制的产物证据；仅 build-and-search 模式存在。 |
 | `failure` | 结构化失败或 `null`。 |
-| `elapsed_seconds` | search trial 墙钟时间。 |
+| `elapsed_seconds` | trial 评测墙钟时间；`pruned` trial 不执行 search。 |
 | `raw_eval_result` | 请求原始输出且原生 search eval 成功时出现。 |
 
 对于自适应 HGraph `ef_search` 范围，报告会为每个实际评测点记录一条 trial。每条记录中的
-`search_params` 都是具体值；`$range` 表达式只保留在规范化请求中。每条记录都会评测完整
-query workload。
+`search_params` 都是具体值；`$range` 表达式只保留在规范化请求中。每个成功 trial 都会评测
+完整 query workload。
 
 每条 constraint violation 包含 `metric`、`comparison`、`expected` 和 `actual`。指标缺失或
 非有限数时，`actual` 为 `null`。
@@ -384,6 +387,10 @@ query workload。
 同一 build group 的 search trial 复用同一个已加载索引实例。新生成的索引只构建和序列化
 一次。search-only 模式直接为所有 trial 复用调用方索引，或复用 CLI 适配器反序列化得到的
 索引。
+
+如果大于零的 `GetMemoryUsage()` 已经超过 `index_memory_mb` 约束，AutoTune 会自动把相关
+trial 记录为 `pruned` 并跳过 search，不需要任何额外调优配置。内存值为零或不可用时不能
+证明候选违反约束，因此不会触发剪枝。
 
 ### Artifact 语义
 

--- a/tools/autotune/autotune.cpp
+++ b/tools/autotune/autotune.cpp
@@ -735,10 +735,28 @@ SelectResult(const RequestContext& request, const Evaluation& evaluation) {
     JsonType trials = JsonType::array();
     int64_t best = -1;
     int64_t best_effort = -1;
+    int64_t best_pruned = -1;
     uint64_t best_violations = std::numeric_limits<uint64_t>::max();
+    uint64_t best_pruned_violations = std::numeric_limits<uint64_t>::max();
     double best_violation_score = std::numeric_limits<double>::infinity();
+    double best_pruned_violation_score = std::numeric_limits<double>::infinity();
     bool has_successful_trial = false;
     bool has_successful_objective = false;
+
+    const auto violation_rank = [](const JsonType& trial) {
+        const auto& violations = trial["constraint_evaluation"]["violations"];
+        double score = 0.0;
+        for (const auto& violation : violations) {
+            if (violation["actual"].is_null()) {
+                score += 1.0;
+            } else {
+                score += std::abs(violation["actual"].get<double>() -
+                                  violation["expected"].get<double>()) /
+                         std::max(violation["expected"].get<double>(), 1e-12);
+            }
+        }
+        return std::make_pair(static_cast<uint64_t>(violations.size()), score);
+    };
 
     for (const auto& source : evaluation.trials) {
         auto trial = source;
@@ -746,6 +764,18 @@ SelectResult(const RequestContext& request, const Evaluation& evaluation) {
         trials.push_back(std::move(trial));
         const auto stored_index = static_cast<int64_t>(trials.size() - 1);
         const auto& stored = trials.back();
+        if (stored["status"] == "pruned") {
+            const auto [violation_count, score] = violation_rank(stored);
+            if (violation_count > 0 &&
+                (best_pruned < 0 || violation_count < best_pruned_violations ||
+                 (violation_count == best_pruned_violations &&
+                  score < best_pruned_violation_score))) {
+                best_pruned = stored_index;
+                best_pruned_violations = violation_count;
+                best_pruned_violation_score = score;
+            }
+            continue;
+        }
         if (stored["status"] != "success") {
             continue;
         }
@@ -755,8 +785,7 @@ SelectResult(const RequestContext& request, const Evaluation& evaluation) {
         }
         has_successful_objective = true;
 
-        const auto violation_count =
-            static_cast<uint64_t>(stored["constraint_evaluation"]["violations"].size());
+        const auto [violation_count, score] = violation_rank(stored);
         if (violation_count == 0) {
             if (best < 0 ||
                 (higher_is_better(request.objective)
@@ -767,16 +796,6 @@ SelectResult(const RequestContext& request, const Evaluation& evaluation) {
             continue;
         }
 
-        double score = 0.0;
-        for (const auto& violation : stored["constraint_evaluation"]["violations"]) {
-            if (violation["actual"].is_null()) {
-                score += 1.0;
-            } else {
-                score += std::abs(violation["actual"].get<double>() -
-                                  violation["expected"].get<double>()) /
-                         std::max(violation["expected"].get<double>(), 1e-12);
-            }
-        }
         if (best_effort < 0 || violation_count < best_violations ||
             (violation_count == best_violations && score < best_violation_score)) {
             best_effort = stored_index;
@@ -796,6 +815,10 @@ SelectResult(const RequestContext& request, const Evaluation& evaluation) {
         result["best_effort"] = recommendation(request, result["trials"][best_effort]);
         result["best_effort"]["constraint_evaluation"] =
             result["trials"][best_effort]["constraint_evaluation"];
+    } else if (best_pruned >= 0 && !has_successful_trial) {
+        result["best_effort"] = recommendation(request, result["trials"][best_pruned]);
+        result["best_effort"]["constraint_evaluation"] =
+            result["trials"][best_pruned]["constraint_evaluation"];
     } else {
         result["status"] = "failed";
         result["failure"] =

--- a/tools/autotune/autotune_evaluation.cpp
+++ b/tools/autotune/autotune_evaluation.cpp
@@ -84,6 +84,28 @@ search_metrics(const JsonType& raw, double seconds) {
     return metrics;
 }
 
+MetricMap
+current_memory_metrics(const IndexPtr& index) {
+    MetricMap metrics;
+    try {
+        const auto memory = index->GetMemoryUsage();
+        if (memory > 0) {
+            metrics["index_memory_mb"] = static_cast<double>(memory) / BYTES_PER_MEBIBYTE;
+        }
+    } catch (const std::exception&) {
+        // An unavailable metric cannot prove that the candidate violates the constraint.
+    }
+    return metrics;
+}
+
+bool
+exceeds_memory_constraint(const RequestContext& request, const MetricMap& metrics) {
+    const auto limit = request.constraints.find("index_memory_mb");
+    const auto actual = metrics.find("index_memory_mb");
+    return limit != request.constraints.end() && actual != metrics.end() &&
+           actual->second > limit->second;
+}
+
 JsonType
 metrics_json(const MetricMap& metrics) {
     JsonType result = JsonType::object();
@@ -240,6 +262,9 @@ EvaluateCandidates(const IndexTuningRequest& tuning_request,
         build["elapsed_seconds"] = elapsed(build_start);
         evaluation.builds.emplace_back(build);
 
+        const auto prune_searches =
+            build["status"] == "success" && exceeds_memory_constraint(request, shared_metrics);
+
         const auto evaluate = [&](const Candidate& candidate) -> std::optional<double> {
             const auto trial_id = "trial-" + std::to_string(trial_number++);
             JsonType trial{{"trial_id", trial_id},
@@ -253,7 +278,9 @@ EvaluateCandidates(const IndexTuningRequest& tuning_request,
                            {"artifacts", build["artifacts"]}};
             std::optional<double> recall;
             const auto search_start = std::chrono::steady_clock::now();
-            if (build["status"] != "success") {
+            if (prune_searches) {
+                trial["status"] = "pruned";
+            } else if (build["status"] != "success") {
                 trial["failure"] =
                     Failure("search", "build_failed", "search skipped because build failed");
             } else {
@@ -309,29 +336,38 @@ EvaluateCandidates(const SearchTuningRequest& tuning_request,
     const auto& request = tuning_request.context;
     Evaluation evaluation;
     uint64_t trial_number = 0;
+    MetricMap shared_metrics;
+    if (request.constraints.find("index_memory_mb") != request.constraints.end()) {
+        shared_metrics = current_memory_metrics(tuning_request.index);
+    }
+    const auto prune_searches = exceeds_memory_constraint(request, shared_metrics);
 
     const auto evaluate = [&](const Candidate& candidate) -> std::optional<double> {
         JsonType trial{{"trial_id", "trial-" + std::to_string(trial_number++)},
                        {"index_name", candidate.index_name},
                        {"search_params", candidate.search_params},
                        {"status", "failed"},
-                       {"metrics", JsonType::object()},
+                       {"metrics", metrics_json(shared_metrics)},
                        {"failure", nullptr}};
         std::optional<double> recall;
         const auto start = std::chrono::steady_clock::now();
-        try {
-            const auto measured_start = std::chrono::steady_clock::now();
-            auto raw = eval::EvaluateSearch(
-                tuning_request.index, request.dataset, search_config(request, candidate));
-            const auto metrics = search_metrics(raw, elapsed(measured_start));
-            trial["metrics"] = metrics_json(metrics);
-            trial["status"] = "success";
-            recall = number(trial["metrics"], "recall_at_k");
-            if (request.include_raw_eval) {
-                trial["raw_eval_result"] = std::move(raw);
+        if (prune_searches) {
+            trial["status"] = "pruned";
+        } else {
+            try {
+                const auto measured_start = std::chrono::steady_clock::now();
+                auto raw = eval::EvaluateSearch(
+                    tuning_request.index, request.dataset, search_config(request, candidate));
+                const auto metrics = search_metrics(raw, elapsed(measured_start));
+                trial["metrics"] = metrics_json(metrics);
+                trial["status"] = "success";
+                recall = number(trial["metrics"], "recall_at_k");
+                if (request.include_raw_eval) {
+                    trial["raw_eval_result"] = std::move(raw);
+                }
+            } catch (const std::exception& error) {
+                trial["failure"] = Failure("search", "search_evaluation_failed", error.what());
             }
-        } catch (const std::exception& error) {
-            trial["failure"] = Failure("search", "search_evaluation_failed", error.what());
         }
         trial["elapsed_seconds"] = elapsed(start);
         evaluation.trials.emplace_back(std::move(trial));

--- a/tools/autotune/autotune_test.cpp
+++ b/tools/autotune/autotune_test.cpp
@@ -732,6 +732,57 @@ TEST_CASE("AutoTune reports the closest successful trial when constraints are in
     REQUIRE(result["best_effort"]["evidence"]["trial_id"] == "trial-0");
 }
 
+TEST_CASE("AutoTune reports the closest pruned trial when every candidate exceeds memory") {
+    vsag::autotune::internal::RequestContext request;
+    request.top_k = 10;
+    request.objective = "latency_avg_ms";
+    request.constraints = {{"index_memory_mb", 1.0}};
+    vsag::autotune::internal::Evaluation evaluation;
+    const auto trial = [](const std::string& id, double memory) {
+        return JsonType{{"trial_id", id},
+                        {"index_name", "hgraph"},
+                        {"search_params", JsonType::object()},
+                        {"status", "pruned"},
+                        {"metrics", {{"index_memory_mb", memory}}}};
+    };
+    evaluation.trials = {trial("trial-0", 3.0), trial("trial-1", 2.0)};
+
+    const auto result = vsag::autotune::internal::SelectResult(request, evaluation);
+    REQUIRE(result["status"] == "no_feasible_candidate");
+    REQUIRE(result["recommendation"].is_null());
+    REQUIRE(result["best_effort"]["evidence"]["trial_id"] == "trial-1");
+    REQUIRE(result["best_effort"]["constraint_evaluation"]["satisfied"] == false);
+    REQUIRE_FALSE(result.contains("failure"));
+}
+
+TEST_CASE("AutoTune prefers evaluated best effort over a closer pruned trial") {
+    vsag::autotune::internal::RequestContext request;
+    request.top_k = 10;
+    request.objective = "latency_avg_ms";
+    request.constraints = {
+        {"index_memory_mb", 1.0}, {"build_seconds", 1.0}, {"index_size_mb", 1.0}};
+    vsag::autotune::internal::Evaluation evaluation;
+    evaluation.trials = {
+        {{"trial_id", "pruned"},
+         {"index_name", "hgraph"},
+         {"search_params", JsonType::object()},
+         {"status", "pruned"},
+         {"metrics", {{"index_memory_mb", 1.1}, {"build_seconds", 0.5}, {"index_size_mb", 0.5}}}},
+        {{"trial_id", "evaluated"},
+         {"index_name", "hgraph"},
+         {"search_params", JsonType::object()},
+         {"status", "success"},
+         {"metrics",
+          {{"index_memory_mb", 0.5},
+           {"build_seconds", 10.0},
+           {"index_size_mb", 10.0},
+           {"latency_avg_ms", 1.0}}}}};
+
+    const auto result = vsag::autotune::internal::SelectResult(request, evaluation);
+    REQUIRE(result["status"] == "no_feasible_candidate");
+    REQUIRE(result["best_effort"]["evidence"]["trial_id"] == "evaluated");
+}
+
 TEST_CASE("AutoTune distinguishes a missing objective metric from failed trials") {
     vsag::autotune::internal::RequestContext request;
     request.top_k = 10;
@@ -807,6 +858,53 @@ TEST_CASE("AutoTune builds once per create candidate and supports an existing in
     REQUIRE(existing_result["request"]["create_params"]["metric_type"] == "l2");
 }
 
+TEST_CASE("AutoTune prunes searches for memory-infeasible build groups") {
+    vsag::Options::Instance().logger()->SetLevel(vsag::Logger::kOFF);
+    ScopedBlockSizeLimit block_size_limit(256UL * 1024);
+    ScopedPath dataset(temp_path("autotune-pruned-dataset", ".hdf5"));
+    ScopedPath workspace(temp_path("autotune-pruned-workspace"));
+    write_dataset(dataset.Get());
+
+    auto input = request(dataset.Get(), workspace.Get());
+    input["constraints"] = {{"index_memory_mb", 0.0}};
+    input["tuning_config"]["keep_intermediate"] = false;
+    const auto result = vsag::autotune::RunAutoTune(input);
+    INFO(result.dump(2));
+
+    REQUIRE(result["status"] == "no_feasible_candidate");
+    REQUIRE(result["recommendation"].is_null());
+    REQUIRE_FALSE(result["best_effort"].is_null());
+    REQUIRE(result["builds"].size() == 2);
+    REQUIRE(result["trials"].size() == 4);
+    for (const auto& build : result["builds"]) {
+        REQUIRE(build["status"] == "success");
+        REQUIRE(build["metrics"]["index_memory_mb"].get<double>() > 0.0);
+    }
+    for (const auto& trial : result["trials"]) {
+        REQUIRE(trial["status"] == "pruned");
+        REQUIRE(trial["failure"].is_null());
+        REQUIRE(trial["metrics"]["index_memory_mb"].get<double>() > 0.0);
+        REQUIRE_FALSE(trial["metrics"].contains("search_seconds"));
+        REQUIRE_FALSE(trial["metrics"].contains("latency_avg_ms"));
+        REQUIRE(trial["constraint_evaluation"]["satisfied"] == false);
+    }
+    REQUIRE(count_index_artifacts(workspace.Get()) == 0);
+
+    auto objective_input = request(dataset.Get(), workspace.Get());
+    objective_input["indexes"] = JsonType::array({objective_input["indexes"][0]});
+    objective_input["indexes"][0]["search_params"]["hgraph"]["ef_search"] = 8;
+    objective_input["constraints"] = {{"recall_at_k", 0.0}};
+    objective_input["objective"] = {{"metric", "index_memory_mb"}};
+    objective_input["tuning_config"]["keep_intermediate"] = false;
+    objective_input["tuning_config"]["max_trials"] = 1;
+    const auto objective_result = vsag::autotune::RunAutoTune(objective_input);
+    INFO(objective_result.dump(2));
+    REQUIRE(objective_result["status"] == "success");
+    REQUIRE(objective_result["trials"].size() == 1);
+    REQUIRE(objective_result["trials"][0]["status"] == "success");
+    REQUIRE(objective_result["trials"][0]["metrics"].contains("search_seconds"));
+}
+
 TEST_CASE("AutoTune CLI keeps only the recommended artifact by default") {
     vsag::Options::Instance().logger()->SetLevel(vsag::Logger::kOFF);
     ScopedBlockSizeLimit block_size_limit(256UL * 1024);
@@ -872,6 +970,18 @@ TEST_CASE("AutoTune searches an in-memory existing index") {
     REQUIRE_FALSE(latency_only->metrics.contains("recall_at_k"));
     REQUIRE_FALSE(latency_only->report.contains("report_path"));
     REQUIRE(load_json_reports(workspace.Get()).empty());
+
+    input.constraints = {{vsag::autotune::Metric::INDEX_MEMORY_MB, 0.0}};
+    const auto memory_pruned = vsag::autotune::TuneSearch(input);
+    REQUIRE(memory_pruned.has_value());
+    REQUIRE(memory_pruned->status == vsag::autotune::TuneStatus::NO_FEASIBLE_CANDIDATE);
+    REQUIRE(memory_pruned->report["trials"].size() == 2);
+    for (const auto& trial : memory_pruned->report["trials"]) {
+        REQUIRE(trial["status"] == "pruned");
+        REQUIRE(trial["metrics"]["index_memory_mb"].get<double>() > 0.0);
+        REQUIRE_FALSE(trial["metrics"].contains("search_seconds"));
+        REQUIRE_FALSE(trial["metrics"].contains("latency_avg_ms"));
+    }
 
     input.objective = vsag::autotune::Metric::INDEX_MEMORY_MB;
     REQUIRE_THROWS_WITH(
@@ -971,6 +1081,9 @@ TEST_CASE("AutoTune searches an existing Pyramid index for one path workload") {
     REQUIRE(memory_constrained.has_value());
     REQUIRE(memory_constrained->status == vsag::autotune::TuneStatus::NO_FEASIBLE_CANDIDATE);
     REQUIRE(memory_constrained->best_effort["constraint_evaluation"]["satisfied"] == false);
+    for (const auto& trial : memory_constrained->report["trials"]) {
+        REQUIRE(trial["status"] == "success");
+    }
 
     input.constraints.pop_back();
     input.workload.queries = fixture.queries;


### PR DESCRIPTION
## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement/Refactor
- [ ] Documentation
- [ ] CI/Build/Infra

## Linked Issue

- Fixes: #2688

## What Changed

- Skip every search trial in a build group when the built index already exceeds an
  `index_memory_mb` constraint.
- Apply the same one-time memory check when tuning search parameters on an existing index.
- Report skipped trials as `pruned`, keep their measured shared metrics and constraint evidence,
  and prevent them from becoming recommendations.
- Return `no_feasible_candidate` with an explanatory `best_effort` when every candidate is
  pruned, while preferring fully evaluated trials whenever one is available.
- Document the behavior and report contract in the English and Chinese AutoTune documentation.

## Test Evidence

- [ ] `make fmt`
- [ ] `make lint`
- [ ] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [x] Other (describe below)

Test details:

```text
clang-format-15 --dry-run --Werror \
  tools/autotune/autotune.cpp \
  tools/autotune/autotune_evaluation.cpp \
  tools/autotune/autotune_test.cpp
git diff --check

cmake --build build-release --target autotune_test --parallel 96
./build-release/tools/autotune/autotune_test
All tests passed (308 assertions in 27 test cases)

cmake --build build-release --target autotune --parallel 96
./build-release/tools/autotune/autotune .autotune_memory_pruning_e2e.json

E2E dataset: /tmp/sift-50k-100.hdf5
Index: HGraph, two ef_search candidates
Constraint: index_memory_mb <= 0
Observed: one successful build, two pruned trials, no search/latency metrics,
          no_feasible_candidate, report persisted, generated artifact removed
```

## Compatibility Impact

- API/ABI compatibility: none
- Behavior changes: trials known to violate the memory constraint now use `status: "pruned"` and
  skip search; an all-pruned request returns `no_feasible_candidate` instead of
  `all_trials_failed`.

## Performance and Concurrency Impact

- Performance impact: improved for memory-infeasible candidates by avoiding all associated query
  evaluation work
- Concurrency/thread-safety impact: none; existing-index memory is read once before its trials

## Documentation Impact

- [ ] No docs update needed
- [x] Updated docs:
  - [ ] `README.md`
  - [ ] `DEVELOPMENT.md`
  - [ ] `CONTRIBUTING.md`
  - [x] Other: English and Chinese AutoTune overview and V1 API contract

## Risk and Rollback

- Risk level: low
- Rollback plan: revert this PR to restore unconditional search evaluation

## Checklist

- [x] I have linked the relevant issue (required for `kind/bug` and `kind/feature`; see "Linked Issue" above)
- [x] I have added/updated tests for new behavior or bug fixes
- [x] I have considered API compatibility impact
- [x] I have updated docs if behavior/workflow changed
- [x] My commit messages follow project conventions (Conventional Commits, optional `[skip ci]` prefix)
