### PR TITLE
perf(simq): batch RangeSearch exact reranking

### DIFF
--- a/docs/docs/en/src/indexes/simq.md
+++ b/docs/docs/en/src/indexes/simq.md
@@ -175,6 +175,7 @@ auto values = result->GetStatistics(
 | `simq_coarse_candidate_count` | Unique document candidates produced by coarse search before applying `rerank_k` |
 | `simq_rerank_candidate_count` | Candidates retained after applying `rerank_k` |
 | `simq_filtered_candidate_count` | Rerank candidates rejected by the supplied filter |
+| `simq_rerank_batch_count` | Number of batched exact-rerank calls issued after filtering |
 | `simq_result_count` | Results returned after reranking and range/top-k limits |
 | `simq_limited_size_applied` | Whether `RangeSearch` truncated matches to `limited_size` |
 

--- a/docs/docs/zh/src/indexes/simq.md
+++ b/docs/docs/zh/src/indexes/simq.md
@@ -166,6 +166,7 @@ auto values = result->GetStatistics(
 | `simq_coarse_candidate_count` | 粗排产生且尚未应用 `rerank_k` 的唯一文档候选数 |
 | `simq_rerank_candidate_count` | 应用 `rerank_k` 后保留的候选数 |
 | `simq_filtered_candidate_count` | 被调用方 filter 排除的精排候选数 |
+| `simq_rerank_batch_count` | filter 之后执行的批量精确精排调用次数 |
 | `simq_result_count` | 精排并应用 range/top-k 限制后最终返回的结果数 |
 | `simq_limited_size_applied` | `RangeSearch` 是否因 `limited_size` 截断结果 |
 

--- a/src/algorithm/simq/simq.cpp
+++ b/src/algorithm/simq/simq.cpp
@@ -64,6 +64,7 @@ dump_simq_statistics(const SearchStatistics& stats,
                      uint64_t coarse_candidate_count,
                      uint64_t rerank_candidate_count,
                      uint64_t filtered_candidate_count,
+                     uint64_t rerank_batch_count,
                      uint64_t result_count,
                      bool limited_size_applied,
                      double coarse_ms,
@@ -78,6 +79,7 @@ dump_simq_statistics(const SearchStatistics& stats,
     json["simq_coarse_candidate_count"].SetUint64(coarse_candidate_count);
     json["simq_rerank_candidate_count"].SetUint64(rerank_candidate_count);
     json["simq_filtered_candidate_count"].SetUint64(filtered_candidate_count);
+    json["simq_rerank_batch_count"].SetUint64(rerank_batch_count);
     json["simq_result_count"].SetUint64(result_count);
     json["simq_limited_size_applied"].SetBool(limited_size_applied);
     json["simq_coarse_ms"].SetDouble(coarse_ms);
@@ -1378,7 +1380,7 @@ SIMQ::KnnSearch(const DatasetPtr& query,
     if (total_count_ == 0 || rep_hgraph_ == nullptr) {
         auto result = Dataset::Make();
         result->Statistics(
-            dump_simq_statistics(stats, 0, 0, 0, 0, 0, 0, false, 0.0, 0.0, 0.0, 0, 0, 0));
+            dump_simq_statistics(stats, 0, 0, 0, 0, 0, 0, 0, false, 0.0, 0.0, 0.0, 0, 0, 0));
         return result;
     }
 
@@ -1424,6 +1426,8 @@ SIMQ::KnnSearch(const DatasetPtr& query,
         }
         batch_ids.push_back(doc_id);
     }
+
+    const uint64_t rerank_batch_count = batch_ids.empty() ? 0 : 1;
 
     // Single batched Query call (enables MultiRead in MultiVectorDataCell)
     auto t_query_start = std::chrono::steady_clock::now();
@@ -1491,6 +1495,7 @@ SIMQ::KnnSearch(const DatasetPtr& query,
                                                coarse_candidate_count,
                                                rerank_candidate_count,
                                                filtered_candidate_count,
+                                               rerank_batch_count,
                                                static_cast<uint64_t>(result_count),
                                                limited_size_applied,
                                                coarse_ms,
@@ -1514,7 +1519,7 @@ SIMQ::RangeSearch(const DatasetPtr& query,
     if (total_count_ == 0 || rep_hgraph_ == nullptr) {
         auto result = Dataset::Make();
         result->Statistics(
-            dump_simq_statistics(stats, 0, 0, 0, 0, 0, 0, false, 0.0, 0.0, 0.0, 0, 0, 0));
+            dump_simq_statistics(stats, 0, 0, 0, 0, 0, 0, 0, false, 0.0, 0.0, 0.0, 0, 0, 0));
         return result;
     }
 
@@ -1550,17 +1555,41 @@ SIMQ::RangeSearch(const DatasetPtr& query,
     std::vector<std::pair<float, InnerIdType>> in_range;
     uint64_t filtered_candidate_count = 0;
     auto t_query_start = std::chrono::steady_clock::now();
+
+    std::vector<InnerIdType> batch_ids;
+    batch_ids.reserve(coarse_results.size());
     for (auto& [doc_id, _] : coarse_results) {
         if (filter != nullptr && !filter->CheckValid(this->label_table_->GetLabelById(doc_id))) {
             ++filtered_candidate_count;
             continue;
         }
-        float dist = 0.0F;
-        mv_codes_->Query(&dist, computer, &doc_id, 1);
-        stats.dist_cmp.fetch_add(1, std::memory_order_relaxed);
-        if (std::isfinite(dist) and dist <= radius) {
-            in_range.emplace_back(dist, doc_id);
+        batch_ids.push_back(doc_id);
+    }
+
+    const uint64_t rerank_batch_count = batch_ids.empty() ? 0 : 1;
+    uint32_t mv_io_ms = 0;
+    uint32_t mv_compute_ms = 0;
+    uint32_t mv_candidates = 0;
+    if (!batch_ids.empty()) {
+        in_range.reserve(batch_ids.size());
+        std::vector<float> batch_dists(batch_ids.size());
+        QueryContext query_context{.stats = &stats,
+                                   .distance_phase = DistanceEvaluationPhase::RERANK};
+        mv_codes_->Query(batch_dists.data(),
+                         computer,
+                         batch_ids.data(),
+                         static_cast<InnerIdType>(batch_ids.size()),
+                         &query_context);
+        stats.dist_cmp.fetch_add(static_cast<uint32_t>(batch_ids.size()),
+                                 std::memory_order_relaxed);
+        for (uint64_t i = 0; i < batch_ids.size(); ++i) {
+            if (std::isfinite(batch_dists[i]) and batch_dists[i] <= radius) {
+                in_range.emplace_back(batch_dists[i], batch_ids[i]);
+            }
         }
+        mv_io_ms = stats.mv_io_time_ms.load(std::memory_order_relaxed);
+        mv_compute_ms = stats.mv_compute_time_ms.load(std::memory_order_relaxed);
+        mv_candidates = stats.mv_candidate_count.load(std::memory_order_relaxed);
     }
     double query_ms =
         std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - t_query_start)
@@ -1591,14 +1620,15 @@ SIMQ::RangeSearch(const DatasetPtr& query,
                                                coarse_candidate_count,
                                                rerank_candidate_count,
                                                filtered_candidate_count,
+                                               rerank_batch_count,
                                                static_cast<uint64_t>(in_range.size()),
                                                limited_size_applied,
                                                coarse_ms,
                                                query_ms,
                                                sort_ms,
-                                               0,
-                                               0,
-                                               0));
+                                               mv_io_ms,
+                                               mv_compute_ms,
+                                               mv_candidates));
     return std::move(result_ds);
 }
 

--- a/tests/test_simq.cpp
+++ b/tests/test_simq.cpp
@@ -43,6 +43,7 @@
 #include <unistd.h>
 
 #include <algorithm>
+#include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
 #include <cmath>
@@ -294,6 +295,7 @@ struct SimqSearchStats {
     uint64_t coarse_candidate_count{0};
     uint64_t rerank_candidate_count{0};
     uint64_t filtered_candidate_count{0};
+    uint64_t rerank_batch_count{0};
     uint64_t result_count{0};
     std::string limited_size_applied;
 };
@@ -313,9 +315,10 @@ get_simq_search_stats(const vsag::DatasetPtr& result) {
                                          "simq_coarse_candidate_count",
                                          "simq_rerank_candidate_count",
                                          "simq_filtered_candidate_count",
+                                         "simq_rerank_batch_count",
                                          "simq_result_count",
                                          "simq_limited_size_applied"});
-    REQUIRE(values.size() == 8);
+    REQUIRE(values.size() == 9);
 
     SimqSearchStats stats;
     stats.dist_cmp = parse_u64(values[0]);
@@ -324,8 +327,9 @@ get_simq_search_stats(const vsag::DatasetPtr& result) {
     stats.coarse_candidate_count = parse_u64(values[3]);
     stats.rerank_candidate_count = parse_u64(values[4]);
     stats.filtered_candidate_count = parse_u64(values[5]);
-    stats.result_count = parse_u64(values[6]);
-    stats.limited_size_applied = values[7];
+    stats.rerank_batch_count = parse_u64(values[6]);
+    stats.result_count = parse_u64(values[7]);
+    stats.limited_size_applied = values[8];
     return stats;
 }
 
@@ -337,8 +341,26 @@ require_simq_search_stats(const vsag::DatasetPtr& result) {
     REQUIRE(stats.coarse_probe_count > 0);
     REQUIRE(stats.coarse_candidate_count >= stats.rerank_candidate_count);
     REQUIRE(stats.rerank_candidate_count >= stats.dist_cmp);
+    REQUIRE(stats.rerank_batch_count == 1);
     REQUIRE(stats.result_count == static_cast<uint64_t>(result->GetDim()));
 }
+
+class EvenLabelFilter : public vsag::Filter {
+public:
+    [[nodiscard]] bool
+    CheckValid(int64_t id) const override {
+        return id % 2 == 0;
+    }
+};
+
+class RejectAllFilter : public vsag::Filter {
+public:
+    [[nodiscard]] bool
+    CheckValid(int64_t id) const override {
+        (void)id;
+        return false;
+    }
+};
 
 TEST_CASE("SIMQ: one centroid counts nested HGraph entry point", "[simq][statistics]") {
     TempFile tmp;
@@ -578,6 +600,65 @@ TEST_CASE("SIMQ: range search", "[simq][range_search]") {
         REQUIRE(n <= limited);
         auto stats = get_simq_search_stats(rr.value());
         REQUIRE(stats.limited_size_applied == "true");
+    }
+
+    SECTION("matches thresholded KNN with filtering and limited_size") {
+        auto filter = std::make_shared<EvenLabelFilter>();
+        auto threshold_param = fmt::format(
+            R"({{"threshold": {}, "simq": {{"coarse_k": 10, "rerank_k": 1000}}}})", radius);
+        auto expected = index->KnnSearch(one_query, BASE_DOCS, threshold_param, filter);
+        REQUIRE(expected.has_value());
+
+        auto actual = index->RangeSearch(one_query, radius, search_param, filter);
+        REQUIRE(actual.has_value());
+        REQUIRE(actual.value()->GetDim() == expected.value()->GetDim());
+        for (int64_t i = 0; i < actual.value()->GetDim(); ++i) {
+            REQUIRE(actual.value()->GetIds()[i] == expected.value()->GetIds()[i]);
+            REQUIRE(actual.value()->GetDistances()[i] ==
+                    Catch::Approx(expected.value()->GetDistances()[i]).margin(1e-6F));
+        }
+
+        auto expected_stats = get_simq_search_stats(expected.value());
+        auto actual_stats = get_simq_search_stats(actual.value());
+        REQUIRE(actual_stats.coarse_candidate_count == expected_stats.coarse_candidate_count);
+        REQUIRE(actual_stats.rerank_candidate_count == expected_stats.rerank_candidate_count);
+        REQUIRE(actual_stats.filtered_candidate_count == expected_stats.filtered_candidate_count);
+        REQUIRE(actual_stats.dist_cmp == expected_stats.dist_cmp);
+        REQUIRE(actual_stats.rerank_batch_count == 1);
+
+        int64_t limited = std::min<int64_t>(3, expected.value()->GetDim());
+        auto limited_result = index->RangeSearch(one_query, radius, search_param, filter, limited);
+        REQUIRE(limited_result.has_value());
+        REQUIRE(limited_result.value()->GetDim() == limited);
+        for (int64_t i = 0; i < limited; ++i) {
+            REQUIRE(limited_result.value()->GetIds()[i] == expected.value()->GetIds()[i]);
+            REQUIRE(limited_result.value()->GetDistances()[i] ==
+                    Catch::Approx(expected.value()->GetDistances()[i]).margin(1e-6F));
+        }
+    }
+
+    SECTION("all-filtered candidates avoid rerank IO") {
+        auto result = index->RangeSearch(
+            one_query, radius, search_param, std::make_shared<RejectAllFilter>());
+        REQUIRE(result.has_value());
+        REQUIRE(result.value()->GetDim() == 0);
+        auto stats = get_simq_search_stats(result.value());
+        REQUIRE(stats.rerank_candidate_count > 1);
+        REQUIRE(stats.filtered_candidate_count == stats.rerank_candidate_count);
+        REQUIRE(stats.dist_cmp == 0);
+        REQUIRE(stats.rerank_batch_count == 0);
+        REQUIRE(stats.result_count == 0);
+    }
+
+    SECTION("empty radius still reranks in one batch") {
+        auto result = index->RangeSearch(
+            one_query, -std::numeric_limits<float>::infinity(), search_param, FilterPtr{});
+        REQUIRE(result.has_value());
+        REQUIRE(result.value()->GetDim() == 0);
+        auto stats = get_simq_search_stats(result.value());
+        REQUIRE(stats.dist_cmp > 1);
+        REQUIRE(stats.rerank_batch_count == 1);
+        REQUIRE(stats.result_count == 0);
     }
 }
 


### PR DESCRIPTION
## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement/Refactor
- [ ] Documentation
- [ ] CI/Build/Infra

## Linked Issue

Not required for `kind/improvement`.

## What Changed

- Collect SIMQ `RangeSearch` candidates that survive filtering and exact-rerank them with one batched `MultiVectorDataCell::Query` call instead of one call per candidate.
- Preserve radius filtering, result ordering, `limited_size`, filter behavior, distance-comparison accounting, and the timing/I/O statistics currently emitted on `main`.
- Add `simq_rerank_batch_count` search statistics (`0` when no batch is needed, otherwise `1`).
- Add regression coverage for exact result equivalence, filtering, `limited_size`, all-filtered candidates, and a radius that returns no results.
- Document the new statistic in the English and Chinese SIMQ documentation.

## Test Evidence

- [ ] `make fmt`
- [ ] `make lint`
- [ ] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [x] Other (described below)

Rebased and retested against `main` at `51545fbbcd85bfc0e03eaa7adc28c901678688ba`.

```text
clang-format 15.0.7 --dry-run --Werror (changed C++ files): passed
git diff --check main...HEAD: passed
Debug Ninja build (unittests and functests targets): passed

build-debug-ninja/tests/functests '[simq]' --durations yes
All tests passed (5130 assertions in 9 test cases)
```

The focused suite covers the full SIMQ lifecycle (build, KNN, range search, serialization/deserialization, parameter sweep, statistics, and incremental add). The five `RangeSearch` sections cover radius filtering, `limited_size`, exact equivalence with filtered KNN, the all-filtered/no-I/O path, and the no-result-radius/one-batch path.

### Performance

Environment: AMD Ryzen 7 9700X, Ubuntu 24.04.4, libaio enabled, system OpenBLAS with one BLAS thread, 1,000 documents x 8 token vectors, 100 queries x 4 token vectors, 128 dimensions, inner product, `coarse_k=10`, and five warmups.

The table reports medians of five independent processes for each implementation and parameter. Latency runs used one thread and 50 measured queries per process; throughput runs used four threads and 100 measured queries per process. Before/after order was alternated across repetitions.

| `rerank_k` | p50 before | p50 after | p50 speedup | p95 before | p95 after | 4-thread QPS before | 4-thread QPS after | QPS speedup |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 100 | 5,895.138 us | 730.660 us | 8.07x | 6,008.338 us | 873.949 us | 167.226 | 1,321.896 | 7.90x |
| 500 | 29,051.749 us | 3,982.244 us | 7.30x | 29,670.691 us | 4,214.872 us | 34.110 | 246.352 | 7.22x |
| 1000 | 57,187.394 us | 7,145.864 us | 8.00x | 59,272.096 us | 7,236.208 us | 17.427 | 131.807 | 7.56x |

- All 60 measurement records from 20 benchmark process invocations completed successfully. Every corresponding before/after run produced identical result counts and checksums over returned IDs and the exact IEEE-754 distance bits.
- Single-thread p50 latency decreased by 86.29%-87.61%; four-thread throughput increased by 622.23%-690.48%.
- Latency QPS ranges across the five processes were `162.580-169.996` before and `1230.157-1372.001` after at `rerank_k=100`, `34.171-34.358` and `243.239-268.413` at `rerank_k=500`, and `17.364-17.489` and `137.045-142.769` at `rerank_k=1000`.
- The benchmark was pinned to CPU 12 for latency and CPUs 12-15 for throughput, with `nice=10`, 4 GiB container limits, and no network. Whole-machine monitoring over 105 one-second samples recorded 97.44% average idle, so the comparison was not run under material host contention.
- The benchmark harness SHA-256 is `ecb02cd6bc3f3fe2503503a6f7ac0e19778d12d9dfe0fddcb8d73aec77366e70`. Baseline/current `libvsag` SHA-256 values are `dc9672190aa2476616daff32475278670496dd15bb6f03c75b3f2858ba29e820` and `df22e71dd268962d46aa214f6ade3cf29c7de1d6e41124ec7d19714a4643ec88`.

## Compatibility Impact

- API/ABI compatibility: none; only an additional key is emitted in search statistics.
- Behavior changes: exact-rerank execution is batched; returned IDs, distances, sorting, filtering, limits, and existing timing/I/O statistics are unchanged.

## Performance and Concurrency Impact

- Performance impact: improved as measured above.
- Concurrency/thread-safety impact: none; batch IDs and distances are request-local and no shared mutable state was added.

## Documentation Impact

- [ ] No docs update needed
- [x] Updated docs:
  - [ ] `README.md`
  - [ ] `DEVELOPMENT.md`
  - [ ] `CONTRIBUTING.md`
  - [x] Other: `docs/docs/{en,zh}/src/indexes/simq.md`

## Risk and Rollback

- Risk level: low.
- Rollback plan: revert this commit to restore per-candidate exact-rerank calls.

## Checklist

- [x] Issue link is not required for `kind/improvement`.
- [x] I have added/updated tests for the changed behavior.
- [x] I have considered API compatibility impact.
- [x] I have updated the English and Chinese docs.
- [x] My commit message follows Conventional Commits and includes DCO/AI-assistance trailers.
