### PR TITLE
fix(quantization): validate SQ4 uniform truncation rate

### DIFF
--- a/docs/docs/en/src/quantization/sq_uniform.md
+++ b/docs/docs/en/src/quantization/sq_uniform.md
@@ -66,7 +66,7 @@ the same recall.
 
 | Key | Type | Default | Applies to | Meaning |
 | --- | --- | --- | --- | --- |
-| `sq4_uniform_trunc_rate` | float | `0.05` | `sq4_uniform` only | Symmetric truncation rate for outliers (`src/quantization/scalar_quantization/sq4_uniform_quantizer_parameter.h:39`). Higher values clip more extreme coordinates, reducing range loss for the bulk of the data at the cost of clipping the tails. |
+| `sq4_uniform_trunc_rate` | float | `0.05` | `sq4_uniform` only | Finite symmetric truncation rate for outliers in the inclusive range `[0.0, 0.5]`. Higher values clip more extreme coordinates, reducing range loss for the bulk of the data at the cost of clipping the tails. |
 
 `sq8_uniform` has no quantizer-specific JSON parameters.
 

--- a/docs/docs/zh/src/quantization/sq_uniform.md
+++ b/docs/docs/zh/src/quantization/sq_uniform.md
@@ -58,7 +58,7 @@ scale 与 offset**。这在热路径上带来三点收益：
 
 | Key | 类型 | 默认 | 适用 | 含义 |
 | --- | --- | --- | --- | --- |
-| `sq4_uniform_trunc_rate` | float | `0.05` | 仅 `sq4_uniform` | 对离群值的对称截断比例（`src/quantization/scalar_quantization/sq4_uniform_quantizer_parameter.h:39`）。值越大，越多极端坐标被截断，从而减少主体数据的范围浪费，代价是尾部被裁掉。 |
+| `sq4_uniform_trunc_rate` | float | `0.05` | 仅 `sq4_uniform` | 对离群值的有限对称截断比例，取值范围为闭区间 `[0.0, 0.5]`。值越大，越多极端坐标被截断，从而减少主体数据的范围浪费，代价是尾部被裁掉。 |
 
 `sq8_uniform` 没有量化器专属的 JSON 参数。
 

--- a/src/quantization/scalar_quantization/sq4_uniform_quantizer.cpp
+++ b/src/quantization/scalar_quantization/sq4_uniform_quantizer.cpp
@@ -33,6 +33,8 @@ using norm_type = uint64_t;
 template <MetricType metric>
 SQ4UniformQuantizer<metric>::SQ4UniformQuantizer(int dim, Allocator* allocator, float trunc_rate)
     : Quantizer<SQ4UniformQuantizer<metric>>(dim, allocator), trunc_rate_(trunc_rate) {
+    SQ4UniformQuantizerParameter::ValidateTruncRate(trunc_rate);
+
     lower_bound_ = std::numeric_limits<float>::max();
     diff_ = std::numeric_limits<float>::lowest();
 

--- a/src/quantization/scalar_quantization/sq4_uniform_quantizer_parameter.cpp
+++ b/src/quantization/scalar_quantization/sq4_uniform_quantizer_parameter.cpp
@@ -15,6 +15,8 @@
 
 #include "sq4_uniform_quantizer_parameter.h"
 
+#include <cmath>
+
 #include "inner_string_params.h"
 #include "utils/param_compat_macros.h"
 
@@ -26,8 +28,18 @@ SQ4UniformQuantizerParameter::SQ4UniformQuantizerParameter()
 void
 SQ4UniformQuantizerParameter::FromJson(const JsonType& json) {
     if (json.Contains(SQ4_UNIFORM_QUANTIZATION_TRUNC_RATE_KEY)) {
-        this->trunc_rate_ =
-            json[SQ4_UNIFORM_QUANTIZATION_TRUNC_RATE_KEY].GetFloat();  // TODO(LHT): Check value
+        this->trunc_rate_ = json[SQ4_UNIFORM_QUANTIZATION_TRUNC_RATE_KEY].GetFloat();
+    }
+    ValidateTruncRate(this->trunc_rate_);
+}
+
+void
+SQ4UniformQuantizerParameter::ValidateTruncRate(float trunc_rate) {
+    if (not std::isfinite(trunc_rate) or trunc_rate < 0.0F or trunc_rate > 0.5F) {
+        throw VsagException(
+            ErrorType::INVALID_ARGUMENT,
+            fmt::format("sq4_uniform_trunc_rate must be finite and in [0, 0.5], but got {}",
+                        trunc_rate));
     }
 }
 

--- a/src/quantization/scalar_quantization/sq4_uniform_quantizer_parameter.cpp
+++ b/src/quantization/scalar_quantization/sq4_uniform_quantizer_parameter.cpp
@@ -35,7 +35,7 @@ SQ4UniformQuantizerParameter::FromJson(const JsonType& json) {
 
 void
 SQ4UniformQuantizerParameter::ValidateTruncRate(float trunc_rate) {
-    if (not std::isfinite(trunc_rate) or trunc_rate < 0.0F or trunc_rate > 0.5F) {
+    if (!std::isfinite(trunc_rate) || trunc_rate < 0.0F || trunc_rate > 0.5F) {
         throw VsagException(
             ErrorType::INVALID_ARGUMENT,
             fmt::format("sq4_uniform_trunc_rate must be finite and in [0, 0.5], but got {}",

--- a/src/quantization/scalar_quantization/sq4_uniform_quantizer_parameter.h
+++ b/src/quantization/scalar_quantization/sq4_uniform_quantizer_parameter.h
@@ -35,6 +35,9 @@ public:
     bool
     CheckCompatibility(const vsag::ParamPtr& other) const override;
 
+    static void
+    ValidateTruncRate(float trunc_rate);
+
 public:
     float trunc_rate_{0.05F};
 };

--- a/src/quantization/scalar_quantization/sq4_uniform_quantizer_parameter_test.cpp
+++ b/src/quantization/scalar_quantization/sq4_uniform_quantizer_parameter_test.cpp
@@ -15,6 +15,8 @@
 
 #include "sq4_uniform_quantizer_parameter.h"
 
+#include <limits>
+
 #include "parameter_test.h"
 #include "unittest.h"
 using namespace vsag;
@@ -31,4 +33,46 @@ TEST_CASE("SQ4 Uniform Quantizer Parameter ToJson Test", "[ut][SQ4UniformQuantiz
     ParameterTest::TestToJson(param);
 
     TestParamCheckCompatibility<SQ4UniformQuantizerParameter>(param_str);
+}
+
+TEST_CASE("SQ4 Uniform Quantizer Parameter validates truncation rate",
+          "[ut][SQ4UniformQuantizerParameter]") {
+    SECTION("keeps the default when the key is absent") {
+        auto param = std::make_shared<SQ4UniformQuantizerParameter>();
+        REQUIRE_NOTHROW(param->FromJson(JsonType{}));
+        REQUIRE(param->trunc_rate_ == 0.05F);
+    }
+
+    SECTION("accepts finite boundary values") {
+        for (const float rate : {0.0F, 0.05F, 0.5F}) {
+            CAPTURE(rate);
+            JsonType json;
+            json[SQ4_UNIFORM_QUANTIZATION_TRUNC_RATE_KEY].SetFloat(rate);
+
+            auto param = std::make_shared<SQ4UniformQuantizerParameter>();
+            REQUIRE_NOTHROW(param->FromJson(json));
+            REQUIRE(param->trunc_rate_ == rate);
+        }
+    }
+
+    SECTION("rejects non-finite and out-of-range values") {
+        const float invalid_rates[] = {-0.01F,
+                                       0.5001F,
+                                       std::numeric_limits<float>::quiet_NaN(),
+                                       std::numeric_limits<float>::infinity(),
+                                       -std::numeric_limits<float>::infinity()};
+        for (const float rate : invalid_rates) {
+            CAPTURE(rate);
+            JsonType json;
+            json[SQ4_UNIFORM_QUANTIZATION_TRUNC_RATE_KEY].SetFloat(rate);
+            auto param = std::make_shared<SQ4UniformQuantizerParameter>();
+
+            try {
+                param->FromJson(json);
+                FAIL("invalid SQ4 uniform truncation rate was accepted");
+            } catch (const VsagException& error) {
+                REQUIRE(error.error_.type == ErrorType::INVALID_ARGUMENT);
+            }
+        }
+    }
 }

--- a/src/quantization/scalar_quantization/sq4_uniform_quantizer_test.cpp
+++ b/src/quantization/scalar_quantization/sq4_uniform_quantizer_test.cpp
@@ -15,6 +15,8 @@
 
 #include "sq4_uniform_quantizer.h"
 
+#include <limits>
+
 #include "impl/allocator/safe_allocator.h"
 #include "quantization/quantizer_test.h"
 #include "scalar_quantizer_test_utils.h"
@@ -23,6 +25,35 @@ using namespace vsag;
 
 const auto dims = fixtures::get_common_used_dims();
 const auto counts = {10, 101};
+
+TEST_CASE("SQ4 Uniform validates truncation rate", "[ut][SQ4UniformQuantizer]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+
+    SECTION("accepts finite boundary values") {
+        for (const float rate : {0.0F, 0.05F, 0.5F}) {
+            CAPTURE(rate);
+            REQUIRE_NOTHROW(
+                SQ4UniformQuantizer<MetricType::METRIC_TYPE_L2SQR>(4, allocator.get(), rate));
+        }
+    }
+
+    SECTION("rejects non-finite and out-of-range values") {
+        const float invalid_rates[] = {-0.01F,
+                                       0.5001F,
+                                       std::numeric_limits<float>::quiet_NaN(),
+                                       std::numeric_limits<float>::infinity(),
+                                       -std::numeric_limits<float>::infinity()};
+        for (const float rate : invalid_rates) {
+            CAPTURE(rate);
+            try {
+                (void)SQ4UniformQuantizer<MetricType::METRIC_TYPE_L2SQR>(4, allocator.get(), rate);
+                FAIL("invalid SQ4 uniform truncation rate was accepted");
+            } catch (const VsagException& error) {
+                REQUIRE(error.error_.type == ErrorType::INVALID_ARGUMENT);
+            }
+        }
+    }
+}
 
 template <MetricType metric>
 void


### PR DESCRIPTION
## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement/Refactor
- [ ] Documentation
- [ ] CI/Build/Infra

## Linked Issue

- Fixes: #2695

## What Changed

- Validate `sq4_uniform_trunc_rate` as finite and within the inclusive range `[0.0, 0.5]`.
- Apply the same validation to JSON parameter parsing and direct `SQ4UniformQuantizer` construction.
- Cover the default, both valid boundaries, representative out-of-range values, NaN, and both infinities.
- Document the accepted range in the English and Chinese SQ uniform quantization guides.

## Test Evidence

- [x] `make fmt`
- [ ] `make lint`
- [ ] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [x] Other (describe below)

Test details:

```text
Target: Ubuntu 24.04, AMD Ryzen 7 9700X; test containers limited to 2 CPUs

./build/tests/unittests '~[daily]' --allow-running-no-tests
All tests passed (85285238 assertions in 685 test cases)

./build/tests/unittests '[SQ4UniformQuantizer],[SQ4UniformQuantizerParameter]'
All tests passed (3197042 assertions in 7 test cases)

./scripts/linters/run-clang-tidy-15.sh -p build/ <changed production sources>
clang-tidy 15 checked both changed production .cpp files with no user-code diagnostics

Functional coverage:
- HGraph ELP Optimizer with base_quantization_type=sq4_uniform:
  all 6 assertions passed in 1 test case
- IVF Search Disable Reorder with sq4_uniform,fp32:
  all 2863 assertions passed in 2 test cases
- eval monitor suite:
  all 33 assertions passed in 5 test cases

TDD checks confirmed that both parameter parsing and direct construction
accepted an invalid negative rate before the fix and reject it afterward.
```

## Compatibility Impact

- API/ABI compatibility: none; no public API or layout changes
- Behavior changes: invalid SQ4 uniform truncation rates now fail early with `INVALID_ARGUMENT`; the default and all valid values are unchanged

## Performance and Concurrency Impact

- Performance impact: negligible constant-time validation during parameter parsing or quantizer construction; no training or search hot-path changes
- Concurrency/thread-safety impact: none

## Documentation Impact

- [ ] No docs update needed
- [x] Updated docs:
  - [ ] `README.md`
  - [ ] `DEVELOPMENT.md`
  - [ ] `CONTRIBUTING.md`
  - [x] Other: `docs/docs/en/src/quantization/sq_uniform.md`, `docs/docs/zh/src/quantization/sq_uniform.md`

## Risk and Rollback

- Risk level: low
- Rollback plan: revert this commit to restore the previous permissive parsing and construction behavior

## Checklist

- [x] I have linked the relevant issue (required for `kind/bug` and `kind/feature`; see "Linked Issue" above)
- [x] I have added/updated tests for new behavior or bug fixes
- [x] I have considered API compatibility impact
- [x] I have updated docs if behavior/workflow changed
- [x] My commit messages follow project conventions (Conventional Commits, optional `[skip ci]` prefix)
