### PR TITLE
feat(sindi): add filter callback limit

### DIFF
--- a/docs/docs/en/src/indexes/sindi.md
+++ b/docs/docs/en/src/indexes/sindi.md
@@ -142,6 +142,7 @@ Search-time parameters live under the `sindi` sub-object:
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `n_candidate` | int | `0` | Candidate heap size. When `0`, defaults to `SPARSE_AMPLIFICATION_FACTOR · topk` (500×). If set, must satisfy `1 ≤ n_candidate ≤ SPARSE_AMPLIFICATION_FACTOR · topk`. |
+| `filter_callback_limit` | uint64 | `0` | Maximum user `Filter::CheckValid` callback invocations for one filtered search request. A value of `0` disables the limit. Internal checks such as the deleted-ID filter do not count. Reaching a positive limit stops candidate and window scanning after processing the final callback result and returns the already filtered candidates, so the result may be partial. The limit applies to KNN and range search through both the regular APIs and `SearchWithRequest`. |
 | `query_prune_ratio` | float | `0.0` | Fraction of lowest-weight query terms skipped (`[0.0, 1.0)`). |
 | `term_prune_ratio` | float | `0.0` | Fraction of the lowest-value postings skipped from each term list (`[0.0, 1.0)`). |
 | `term_retain_threshold` | uint64 | `0` | Maximum postings for one term across all windows. A value of `0` disables this limit; positive values allow each non-empty window posting list to scan at most `max(1, floor(threshold / window_count))` postings. |
@@ -160,7 +161,7 @@ ratios instead.
 ```cpp
 auto result = index->KnnSearch(
     query, topk,
-    R"({"sindi": {"n_candidate": 200, "query_prune_ratio": 0.1}})").value();
+    R"({"sindi": {"n_candidate": 200, "filter_callback_limit": 10000, "query_prune_ratio": 0.1}})").value();
 ```
 
 ## When to use SINDI

--- a/docs/docs/zh/src/indexes/sindi.md
+++ b/docs/docs/zh/src/indexes/sindi.md
@@ -132,6 +132,7 @@ auto result = index->KnnSearch(
 | 参数 | 类型 | 默认值 | 说明 |
 |------|------|--------|------|
 | `n_candidate` | int | `0` | 候选堆大小。为 `0` 时自动取 `SPARSE_AMPLIFICATION_FACTOR · topk`（500 倍）；若显式设置，须满足 `1 ≤ n_candidate ≤ SPARSE_AMPLIFICATION_FACTOR · topk` |
+| `filter_callback_limit` | uint64 | `0` | 单次带过滤检索最多调用用户 `Filter::CheckValid` 回调的次数；`0` 表示不限制。删除 ID 过滤器等内部检查不计数。达到正数上限时，在正常处理最后一次回调结果后停止候选及后续窗口扫描，并返回已经通过过滤的候选，因此结果可能不完整。该限制同时适用于 KNN、范围检索以及常规 API 和 `SearchWithRequest` |
 | `query_prune_ratio` | float | `0.0` | 查询时丢弃权重最低查询项的比例，取值范围为 `[0.0, 1.0)` |
 | `term_prune_ratio` | float | `0.0` | 每条倒排链中按 value 丢弃低权 posting 的比例，取值范围为 `[0.0, 1.0)` |
 | `term_retain_threshold` | uint64 | `0` | 单个 term 在所有 window 中最多扫描的 posting 总数；`0` 表示关闭此限制，正数使每个 window 的非空 posting list 最多扫描 `max(1, floor(threshold / window_count))` 个 |
@@ -146,7 +147,7 @@ SINDI 会根据构建阶段的 `doc_prune_ratio` 与检索阶段的 `query_prune
 ```cpp
 auto result = index->KnnSearch(
     query, topk,
-    R"({"sindi": {"n_candidate": 200, "query_prune_ratio": 0.1}})").value();
+    R"({"sindi": {"n_candidate": 200, "filter_callback_limit": 10000, "query_prune_ratio": 0.1}})").value();
 ```
 
 ## 何时选择 SINDI

--- a/src/algorithm/sindi/sindi.cpp
+++ b/src/algorithm/sindi/sindi.cpp
@@ -55,6 +55,51 @@ constexpr int64_t SINDI_RERANK_FLAT_FORMAT_DMQ = 3;
 constexpr const char* SINDI_POSTING_LIST_FORMAT_VERSION_KEY = "sindi_posting_list_format_version";
 constexpr int64_t SINDI_SORTED_POSTING_LIST_FORMAT_VERSION = 1;
 
+class FilterCallbackLimiter : public Filter {
+public:
+    FilterCallbackLimiter(FilterPtr filter, std::shared_ptr<uint64_t> remaining)
+        : filter_(std::move(filter)), remaining_(std::move(remaining)) {
+    }
+
+    [[nodiscard]] bool
+    CheckValid(int64_t id) const override {
+        if (*remaining_ == 0) {
+            return false;
+        }
+        const bool valid = filter_->CheckValid(id);
+        --(*remaining_);
+        return valid;
+    }
+
+    [[nodiscard]] float
+    ValidRatio() const override {
+        return filter_->ValidRatio();
+    }
+
+    [[nodiscard]] Distribution
+    FilterDistribution() const override {
+        return filter_->FilterDistribution();
+    }
+
+    void
+    GetValidIds(const int64_t** valid_ids, int64_t& count) const override {
+        filter_->GetValidIds(valid_ids, count);
+    }
+
+private:
+    FilterPtr filter_;
+    std::shared_ptr<uint64_t> remaining_;
+};
+
+FilterPtr
+create_filter_callback_limiter(const FilterPtr& filter,
+                               const std::shared_ptr<uint64_t>& remaining) {
+    if (filter == nullptr or remaining == nullptr) {
+        return filter;
+    }
+    return std::make_shared<FilterCallbackLimiter>(filter, remaining);
+}
+
 bool
 has_sorted_posting_lists(const JsonType& basic_info) {
     return basic_info.Contains(SINDI_POSTING_LIST_FORMAT_VERSION_KEY) and
@@ -625,8 +670,6 @@ SINDI::KnnSearch(const DatasetPtr& query,
                  vsag::Allocator* allocator) const {
     std::shared_lock rlock(this->global_mutex_);
 
-    // Due to concerns about the performance of this index
-    // We have not yet implemented search with filtering capabilities
     const auto* sparse_vectors = query->GetSparseVectors();
     CHECK_ARGUMENT(query->GetNumElements() == 1, "num of query should be 1");
     auto sparse_query = sparse_vectors[0];
@@ -649,7 +692,13 @@ SINDI::KnnSearch(const DatasetPtr& query,
     inner_param.distance_threshold = threshold;
     inner_param.enable_reorder = use_reorder_;
 
-    inner_param.is_inner_id_allowed = this->create_search_filter(filter);
+    auto filter_callback_remaining =
+        filter != nullptr and search_param.filter_callback_limit > 0
+            ? std::make_shared<uint64_t>(search_param.filter_callback_limit)
+            : nullptr;
+    const uint64_t* filter_callback_remaining_ptr = filter_callback_remaining.get();
+    inner_param.is_inner_id_allowed = this->create_search_filter(
+        create_filter_callback_limiter(filter, filter_callback_remaining));
 
     SearchStatistics statistics;
     SparseVector effective_query = sparse_query;
@@ -678,7 +727,8 @@ SINDI::KnnSearch(const DatasetPtr& query,
                                                    use_term_lists_heap_insert,
                                                    rerank_query,
                                                    nullptr,
-                                                   &statistics);
+                                                   &statistics,
+                                                   filter_callback_remaining_ptr);
     } else {
         result = search_impl<KNN_SEARCH>(computer,
                                          inner_param,
@@ -686,7 +736,8 @@ SINDI::KnnSearch(const DatasetPtr& query,
                                          use_term_lists_heap_insert,
                                          rerank_query,
                                          nullptr,
-                                         &statistics);
+                                         &statistics,
+                                         filter_callback_remaining_ptr);
     }
     result->Statistics(statistics.Dump());
     return FilterDatasetByThreshold(result, threshold, allocator, k);
@@ -856,7 +907,8 @@ SINDI::immutable_fill_heap_initial(uint32_t id,
     }
     if (dist < 0) {
         if constexpr (type == InnerSearchType::WITH_FILTER) {
-            if (not filter->CheckValid(id + offset_id)) {
+            const bool valid = filter->CheckValid(id + offset_id);
+            if (not valid) {
                 dist = 0;
                 return false;
             }
@@ -870,20 +922,27 @@ SINDI::immutable_fill_heap_initial(uint32_t id,
 }
 
 template <InnerSearchMode mode, InnerSearchType type>
-void
+bool
 SINDI::immutable_insert_heap_by_mapped_terms(float* dists,
                                              const ImmutableSINDIWindow& window,
                                              const SparseTermComputerPtr& computer,
                                              const ImmutableMappedQueryTerms& mapped_terms,
                                              MaxHeap& heap,
                                              const InnerSearchParam& param,
-                                             uint32_t offset_id) const {
+                                             uint32_t offset_id,
+                                             const uint64_t* filter_callback_limit) const {
     uint32_t id = 0;
     float cur_heap_top = std::numeric_limits<float>::max();
     auto n_candidate = param.ef;
     auto radius = param.radius;
     auto range_search_limit_size = param.range_search_limit_size;
     auto filter = param.is_inner_id_allowed;
+
+    if constexpr (mode == InnerSearchMode::KNN_SEARCH) {
+        if (heap.size() == n_candidate) {
+            cur_heap_top = heap.top().first;
+        }
+    }
 
     if constexpr (mode == InnerSearchMode::RANGE_SEARCH) {
         cur_heap_top = radius - 1;
@@ -901,7 +960,8 @@ SINDI::immutable_insert_heap_by_mapped_terms(float* dists,
             if (heap.size() < n_candidate) {
                 for (; i < term_count; ++i) {
                     id = ids[i];
-                    if (immutable_fill_heap_initial<type>(id,
+                    const bool heap_filled =
+                        immutable_fill_heap_initial<type>(id,
                                                           dists[id],
                                                           cur_heap_top,
                                                           heap,
@@ -909,7 +969,13 @@ SINDI::immutable_insert_heap_by_mapped_terms(float* dists,
                                                           n_candidate,
                                                           filter,
                                                           param.distance_threshold,
-                                                          param.enable_reorder)) {
+                                                          param.enable_reorder);
+                    if constexpr (type == InnerSearchType::WITH_FILTER) {
+                        if (filter_callback_limit != nullptr and *filter_callback_limit == 0) {
+                            return true;
+                        }
+                    }
+                    if (heap_filled) {
                         ++i;
                         break;
                     }
@@ -930,22 +996,35 @@ SINDI::immutable_insert_heap_by_mapped_terms(float* dists,
                                                              filter,
                                                              param.distance_threshold,
                                                              param.enable_reorder);
+            if constexpr (type == InnerSearchType::WITH_FILTER) {
+                if (filter_callback_limit != nullptr and *filter_callback_limit == 0) {
+                    return true;
+                }
+            }
         }
     }
+    return false;
 }
 
 template <InnerSearchMode mode, InnerSearchType type>
-void
+bool
 SINDI::immutable_insert_heap_by_dists(float* dists,
                                       uint32_t dists_size,
                                       MaxHeap& heap,
                                       const InnerSearchParam& param,
-                                      uint32_t offset_id) const {
+                                      uint32_t offset_id,
+                                      const uint64_t* filter_callback_limit) const {
     float cur_heap_top = std::numeric_limits<float>::max();
     auto n_candidate = param.ef;
     auto radius = param.radius;
     auto range_search_limit_size = param.range_search_limit_size;
     auto filter = param.is_inner_id_allowed;
+
+    if constexpr (mode == InnerSearchMode::KNN_SEARCH) {
+        if (heap.size() == n_candidate) {
+            cur_heap_top = heap.top().first;
+        }
+    }
 
     if constexpr (mode == InnerSearchMode::RANGE_SEARCH) {
         cur_heap_top = radius - 1;
@@ -955,15 +1034,21 @@ SINDI::immutable_insert_heap_by_dists(float* dists,
     if constexpr (mode == InnerSearchMode::KNN_SEARCH) {
         if (heap.size() < n_candidate) {
             for (; id < dists_size; ++id) {
-                if (immutable_fill_heap_initial<type>(id,
-                                                      dists[id],
-                                                      cur_heap_top,
-                                                      heap,
-                                                      offset_id,
-                                                      n_candidate,
-                                                      filter,
-                                                      param.distance_threshold,
-                                                      param.enable_reorder)) {
+                const bool heap_filled = immutable_fill_heap_initial<type>(id,
+                                                                           dists[id],
+                                                                           cur_heap_top,
+                                                                           heap,
+                                                                           offset_id,
+                                                                           n_candidate,
+                                                                           filter,
+                                                                           param.distance_threshold,
+                                                                           param.enable_reorder);
+                if constexpr (type == InnerSearchType::WITH_FILTER) {
+                    if (filter_callback_limit != nullptr and *filter_callback_limit == 0) {
+                        return true;
+                    }
+                }
+                if (heap_filled) {
                     ++id;
                     break;
                 }
@@ -983,7 +1068,13 @@ SINDI::immutable_insert_heap_by_dists(float* dists,
                                                          filter,
                                                          param.distance_threshold,
                                                          param.enable_reorder);
+        if constexpr (type == InnerSearchType::WITH_FILTER) {
+            if (filter_callback_limit != nullptr and *filter_callback_limit == 0) {
+                return true;
+            }
+        }
     }
+    return false;
 }
 
 template <InnerSearchMode mode>
@@ -994,7 +1085,8 @@ SINDI::immutable_search_impl(const SparseTermComputerPtr& computer,
                              bool use_term_lists_heap_insert,
                              const SparseVector* original_query,
                              ReasoningContext* reasoning_ctx,
-                             SearchStatistics* statistics) const {
+                             SearchStatistics* statistics,
+                             const uint64_t* filter_callback_limit) const {
     Allocator* search_allocator = allocator != nullptr ? allocator : allocator_;
     MaxHeap heap(search_allocator);
     int64_t k = 0;
@@ -1031,7 +1123,8 @@ SINDI::immutable_search_impl(const SparseTermComputerPtr& computer,
                 if (dists[i] != 0.0F) {
                     auto inner_id = window_start_id + i;
                     reasoning_ctx->RecordVisit(inner_id, 1.0F + dists[i], 0);
-                    if (filter and not filter->CheckValid(inner_id)) {
+                    if (filter_callback_limit == nullptr and filter and
+                        not filter->CheckValid(inner_id)) {
                         reasoning_ctx->RecordFilterReject(inner_id);
                     }
                 }
@@ -1040,13 +1133,18 @@ SINDI::immutable_search_impl(const SparseTermComputerPtr& computer,
 
         if (use_term_lists_heap_insert) {
             if (inner_param.is_inner_id_allowed) {
-                immutable_insert_heap_by_mapped_terms<mode, WITH_FILTER>(dists.data(),
-                                                                         window,
-                                                                         computer,
-                                                                         mapped_terms,
-                                                                         heap,
-                                                                         inner_param,
-                                                                         window_start_id);
+                const bool filter_callback_limit_reached =
+                    immutable_insert_heap_by_mapped_terms<mode, WITH_FILTER>(dists.data(),
+                                                                             window,
+                                                                             computer,
+                                                                             mapped_terms,
+                                                                             heap,
+                                                                             inner_param,
+                                                                             window_start_id,
+                                                                             filter_callback_limit);
+                if (filter_callback_limit_reached) {
+                    break;
+                }
             } else {
                 immutable_insert_heap_by_mapped_terms<mode, PURE>(dists.data(),
                                                                   window,
@@ -1054,17 +1152,26 @@ SINDI::immutable_search_impl(const SparseTermComputerPtr& computer,
                                                                   mapped_terms,
                                                                   heap,
                                                                   inner_param,
-                                                                  window_start_id);
+                                                                  window_start_id,
+                                                                  nullptr);
             }
         } else {
             const auto window_doc_count = static_cast<uint32_t>(std::min<int64_t>(
                 window_size_, cur_element_count_ - static_cast<int64_t>(window_start_id)));
             if (inner_param.is_inner_id_allowed) {
-                immutable_insert_heap_by_dists<mode, WITH_FILTER>(
-                    dists.data(), window_doc_count, heap, inner_param, window_start_id);
+                const bool filter_callback_limit_reached =
+                    immutable_insert_heap_by_dists<mode, WITH_FILTER>(dists.data(),
+                                                                      window_doc_count,
+                                                                      heap,
+                                                                      inner_param,
+                                                                      window_start_id,
+                                                                      filter_callback_limit);
+                if (filter_callback_limit_reached) {
+                    break;
+                }
             } else {
                 immutable_insert_heap_by_dists<mode, PURE>(
-                    dists.data(), window_doc_count, heap, inner_param, window_start_id);
+                    dists.data(), window_doc_count, heap, inner_param, window_start_id, nullptr);
             }
         }
     }
@@ -1159,7 +1266,8 @@ SINDI::search_impl(const SparseTermComputerPtr& computer,
                    bool use_term_lists_heap_insert,
                    const SparseVector* original_query,
                    ReasoningContext* reasoning_ctx,
-                   SearchStatistics* statistics) const {
+                   SearchStatistics* statistics,
+                   const uint64_t* filter_callback_limit) const {
     // computer and heap
     MaxHeap heap(allocator);
     int64_t k = 0;
@@ -1195,7 +1303,8 @@ SINDI::search_impl(const SparseTermComputerPtr& computer,
                 if (dists[i] != 0.0F) {
                     auto inner_id = window_start_id + i;
                     reasoning_ctx->RecordVisit(inner_id, 1.0F + dists[i], 0);
-                    if (filter and not filter->CheckValid(inner_id)) {
+                    if (filter_callback_limit == nullptr and filter and
+                        not filter->CheckValid(inner_id)) {
                         reasoning_ctx->RecordFilterReject(inner_id);
                     }
                 }
@@ -1205,19 +1314,35 @@ SINDI::search_impl(const SparseTermComputerPtr& computer,
         // insert heap
         if (use_term_lists_heap_insert) {
             if (inner_param.is_inner_id_allowed) {
-                term_list->InsertHeapByTermLists<mode, WITH_FILTER>(
-                    dists.data(), computer, heap, inner_param, window_start_id);
+                const bool filter_callback_limit_reached =
+                    term_list->InsertHeapByTermLists<mode, WITH_FILTER>(dists.data(),
+                                                                        computer,
+                                                                        heap,
+                                                                        inner_param,
+                                                                        window_start_id,
+                                                                        filter_callback_limit);
+                if (filter_callback_limit_reached) {
+                    break;
+                }
             } else {
                 term_list->InsertHeapByTermLists<mode, PURE>(
-                    dists.data(), computer, heap, inner_param, window_start_id);
+                    dists.data(), computer, heap, inner_param, window_start_id, nullptr);
             }
         } else {
             if (inner_param.is_inner_id_allowed) {
-                term_list->InsertHeapByDists<mode, WITH_FILTER>(
-                    dists.data(), dists.size(), heap, inner_param, window_start_id);
+                const bool filter_callback_limit_reached =
+                    term_list->InsertHeapByDists<mode, WITH_FILTER>(dists.data(),
+                                                                    dists.size(),
+                                                                    heap,
+                                                                    inner_param,
+                                                                    window_start_id,
+                                                                    filter_callback_limit);
+                if (filter_callback_limit_reached) {
+                    break;
+                }
             } else {
                 term_list->InsertHeapByDists<mode, PURE>(
-                    dists.data(), dists.size(), heap, inner_param, window_start_id);
+                    dists.data(), dists.size(), heap, inner_param, window_start_id, nullptr);
             }
         }
     }
@@ -1321,8 +1446,6 @@ SINDI::RangeSearch(const DatasetPtr& query,
                    int64_t limited_size) const {
     std::shared_lock rlock(this->global_mutex_);
 
-    // Due to concerns about the performance of this index
-    // We have not yet implemented search with filtering capabilities
     const auto* sparse_vectors = query->GetSparseVectors();
     CHECK_ARGUMENT(query->GetNumElements() == 1, "num of query should be 1");
     auto sparse_query = sparse_vectors[0];
@@ -1338,7 +1461,13 @@ SINDI::RangeSearch(const DatasetPtr& query,
     inner_param.range_search_limit_size = static_cast<int>(limited_size);
     inner_param.radius = radius;
 
-    inner_param.is_inner_id_allowed = this->create_search_filter(filter);
+    auto filter_callback_remaining =
+        filter != nullptr and search_param.filter_callback_limit > 0
+            ? std::make_shared<uint64_t>(search_param.filter_callback_limit)
+            : nullptr;
+    const uint64_t* filter_callback_remaining_ptr = filter_callback_remaining.get();
+    inner_param.is_inner_id_allowed = this->create_search_filter(
+        create_filter_callback_limiter(filter, filter_callback_remaining));
 
     SearchStatistics statistics;
     SparseVector effective_query = sparse_query;
@@ -1365,7 +1494,8 @@ SINDI::RangeSearch(const DatasetPtr& query,
                                                           UseTermListsHeapInsert(search_param),
                                                           rerank_query,
                                                           nullptr,
-                                                          &statistics);
+                                                          &statistics,
+                                                          filter_callback_remaining_ptr);
         result->Statistics(statistics.Dump());
         return result;
     }
@@ -1375,7 +1505,8 @@ SINDI::RangeSearch(const DatasetPtr& query,
                                             UseTermListsHeapInsert(search_param),
                                             rerank_query,
                                             nullptr,
-                                            &statistics);
+                                            &statistics,
+                                            filter_callback_remaining_ptr);
     result->Statistics(statistics.Dump());
     return result;
 }
@@ -1402,8 +1533,15 @@ SINDI::SearchWithRequest(const SearchRequest& request) const {
 
     InnerSearchParam inner_param;
     const bool filter_enabled = request.enable_filter_ and request.filter_ != nullptr;
-    inner_param.is_inner_id_allowed =
-        filter_enabled ? this->create_search_filter(request.filter_) : nullptr;
+    auto filter_callback_remaining =
+        filter_enabled and search_param.filter_callback_limit > 0
+            ? std::make_shared<uint64_t>(search_param.filter_callback_limit)
+            : nullptr;
+    const uint64_t* filter_callback_remaining_ptr = filter_callback_remaining.get();
+    const auto user_filter =
+        filter_enabled ? create_filter_callback_limiter(request.filter_, filter_callback_remaining)
+                       : nullptr;
+    inner_param.is_inner_id_allowed = this->create_search_filter(user_filter);
 
     std::shared_ptr<ReasoningContext> reasoning_ctx;
     if (not request.expected_labels_.empty()) {
@@ -1456,7 +1594,8 @@ SINDI::SearchWithRequest(const SearchRequest& request) const {
                                                          UseTermListsHeapInsert(search_param),
                                                          rerank_query,
                                                          reasoning_ctx.get(),
-                                                         &statistics);
+                                                         &statistics,
+                                                         filter_callback_remaining_ptr);
         } else {
             result = search_impl<RANGE_SEARCH>(computer,
                                                inner_param,
@@ -1464,7 +1603,8 @@ SINDI::SearchWithRequest(const SearchRequest& request) const {
                                                UseTermListsHeapInsert(search_param),
                                                rerank_query,
                                                reasoning_ctx.get(),
-                                               &statistics);
+                                               &statistics,
+                                               filter_callback_remaining_ptr);
         }
     } else {
         CHECK_ARGUMENT(search_param.n_candidate <= SPARSE_AMPLIFICATION_FACTOR * request.topk_,
@@ -1481,7 +1621,8 @@ SINDI::SearchWithRequest(const SearchRequest& request) const {
                                                        UseTermListsHeapInsert(search_param),
                                                        rerank_query,
                                                        reasoning_ctx.get(),
-                                                       &statistics);
+                                                       &statistics,
+                                                       filter_callback_remaining_ptr);
         } else {
             result = search_impl<KNN_SEARCH>(computer,
                                              inner_param,
@@ -1489,7 +1630,8 @@ SINDI::SearchWithRequest(const SearchRequest& request) const {
                                              UseTermListsHeapInsert(search_param),
                                              rerank_query,
                                              reasoning_ctx.get(),
-                                             &statistics);
+                                             &statistics,
+                                             filter_callback_remaining_ptr);
         }
     }
 

--- a/src/algorithm/sindi/sindi.h
+++ b/src/algorithm/sindi/sindi.h
@@ -221,7 +221,8 @@ private:
                 bool use_term_lists_heap_insert,
                 const SparseVector* original_query = nullptr,
                 ReasoningContext* reasoning_ctx = nullptr,
-                SearchStatistics* statistics = nullptr) const;
+                SearchStatistics* statistics = nullptr,
+                const uint64_t* filter_callback_limit = nullptr) const;
 
     template <InnerSearchMode mode>
     DatasetPtr
@@ -231,7 +232,8 @@ private:
                           bool use_term_lists_heap_insert,
                           const SparseVector* original_query = nullptr,
                           ReasoningContext* reasoning_ctx = nullptr,
-                          SearchStatistics* statistics = nullptr) const;
+                          SearchStatistics* statistics = nullptr,
+                          const uint64_t* filter_callback_limit = nullptr) const;
 
     bool
     UseTermListsHeapInsert(const SINDISearchParameter& search_param,
@@ -331,22 +333,24 @@ private:
                                 bool enable_reorder) const;
 
     template <InnerSearchMode mode, InnerSearchType type>
-    void
+    bool
     immutable_insert_heap_by_mapped_terms(float* dists,
                                           const ImmutableSINDIWindow& window,
                                           const SparseTermComputerPtr& computer,
                                           const ImmutableMappedQueryTerms& mapped_terms,
                                           MaxHeap& heap,
                                           const InnerSearchParam& param,
-                                          uint32_t offset_id) const;
+                                          uint32_t offset_id,
+                                          const uint64_t* filter_callback_limit) const;
 
     template <InnerSearchMode mode, InnerSearchType type>
-    void
+    bool
     immutable_insert_heap_by_dists(float* dists,
                                    uint32_t dists_size,
                                    MaxHeap& heap,
                                    const InnerSearchParam& param,
-                                   uint32_t offset_id) const;
+                                   uint32_t offset_id,
+                                   const uint64_t* filter_callback_limit) const;
 
     void
     AttachReasoningReport(const DatasetPtr& dataset_results, ReasoningContext* reasoning_ctx) const;

--- a/src/algorithm/sindi/sindi_parameter.cpp
+++ b/src/algorithm/sindi/sindi_parameter.cpp
@@ -221,6 +221,7 @@ SINDISearchParameter::FromJson(const JsonType& json) {
 
     term_prune_ratio = DEFAULT_TERM_PRUNE_RATIO;
     term_retain_threshold = DEFAULT_TERM_RETAIN_THRESHOLD;
+    filter_callback_limit = DEFAULT_FILTER_CALLBACK_LIMIT;
     if (json[INDEX_SINDI].Contains(SPARSE_TERM_PRUNE_RATIO)) {
         term_prune_ratio = json[INDEX_SINDI][SPARSE_TERM_PRUNE_RATIO].GetFloat();
         CHECK_ARGUMENT((0.0F <= term_prune_ratio and term_prune_ratio < 1.0F),
@@ -238,6 +239,20 @@ SINDISearchParameter::FromJson(const JsonType& json) {
                 threshold >= 0,
                 fmt::format("term_retain_threshold must be non-negative, got {}", threshold));
             term_retain_threshold = static_cast<uint64_t>(threshold);
+        }
+    }
+    if (json[INDEX_SINDI].Contains(SPARSE_FILTER_CALLBACK_LIMIT)) {
+        const auto limit_json = json[INDEX_SINDI][SPARSE_FILTER_CALLBACK_LIMIT];
+        CHECK_ARGUMENT(limit_json.IsNumberInteger(),
+                       "filter_callback_limit must be a non-negative integer");
+        if (limit_json.IsNumberUnsigned()) {
+            filter_callback_limit = limit_json.GetUint64();
+        } else {
+            const auto limit = limit_json.GetInt();
+            CHECK_ARGUMENT(
+                limit >= 0,
+                fmt::format("filter_callback_limit must be non-negative, got {}", limit));
+            filter_callback_limit = static_cast<uint64_t>(limit);
         }
     }
 
@@ -268,6 +283,7 @@ SINDISearchParameter::ToJson() const {
     json[INDEX_SINDI].SetJson(JsonType());
     json[INDEX_SINDI][SPARSE_QUERY_PRUNE_RATIO].SetFloat(query_prune_ratio);
     json[INDEX_SINDI][SPARSE_N_CANDIDATE].SetInt(n_candidate);
+    json[INDEX_SINDI][SPARSE_FILTER_CALLBACK_LIMIT].SetUint64(filter_callback_limit);
     json[INDEX_SINDI][SPARSE_TERM_PRUNE_RATIO].SetFloat(term_prune_ratio);
     json[INDEX_SINDI][SPARSE_TERM_RETAIN_THRESHOLD].SetUint64(term_retain_threshold);
     return json;

--- a/src/algorithm/sindi/sindi_parameter.h
+++ b/src/algorithm/sindi/sindi_parameter.h
@@ -94,6 +94,7 @@ public:
 public:
     // search
     uint32_t n_candidate{0};
+    uint64_t filter_callback_limit{0};
 
     // data cell
     float query_prune_ratio{0};

--- a/src/algorithm/sindi/sindi_parameter_test.cpp
+++ b/src/algorithm/sindi/sindi_parameter_test.cpp
@@ -103,7 +103,8 @@ TEST_CASE("SINDI Index Parameters Test", "[ut][SINDIParameter]") {
             "query_prune_ratio": 0.2,
             "n_candidate": 20,
             "term_prune_ratio": 0.1,
-            "term_retain_threshold": 100
+            "term_retain_threshold": 100,
+            "filter_callback_limit": 1000
         }
     })";
     auto search_param = std::make_shared<vsag::SINDISearchParameter>();
@@ -111,9 +112,11 @@ TEST_CASE("SINDI Index Parameters Test", "[ut][SINDIParameter]") {
     search_param->FromJson(search_param_json);
     REQUIRE(search_param->term_prune_ratio == 0.1F);
     REQUIRE(search_param->term_retain_threshold == 100);
+    REQUIRE(search_param->filter_callback_limit == 1000);
     vsag::ParameterTest::TestToJson(search_param);
     REQUIRE(search_param->ToJson()[INDEX_SINDI].Contains("term_prune_ratio"));
     REQUIRE(search_param->ToJson()[INDEX_SINDI].Contains("term_retain_threshold"));
+    REQUIRE(search_param->ToJson()[INDEX_SINDI].Contains("filter_callback_limit"));
     REQUIRE_FALSE(search_param->ToJson()[INDEX_SINDI].Contains("term_prune"));
     REQUIRE_FALSE(search_param->ToJson()[INDEX_SINDI].Contains("use_term_lists_heap_insert"));
 
@@ -129,6 +132,35 @@ TEST_CASE("SINDI Index Parameters Test", "[ut][SINDIParameter]") {
     legacy_search_param->FromJson(vsag::JsonType::Parse(legacy_search_param_str));
     REQUIRE_FALSE(
         legacy_search_param->ToJson()[INDEX_SINDI].Contains("use_term_lists_heap_insert"));
+}
+
+TEST_CASE("SINDI Filter Callback Limit Parameters", "[ut][SINDIParameter]") {
+    SECTION("uses unlimited default") {
+        SINDISearchParameter param;
+        param.FromJson(JsonType::Parse(R"({"sindi": {}})"));
+        REQUIRE(param.filter_callback_limit == DEFAULT_FILTER_CALLBACK_LIMIT);
+        REQUIRE(param.ToJson()[INDEX_SINDI][SPARSE_FILTER_CALLBACK_LIMIT].GetUint64() == 0);
+    }
+
+    SECTION("accepts zero and uint64 max") {
+        SINDISearchParameter param;
+        param.FromJson(JsonType::Parse(R"({"sindi": {"filter_callback_limit": 0}})"));
+        REQUIRE(param.filter_callback_limit == 0);
+
+        param.FromJson(
+            JsonType::Parse(R"({"sindi": {"filter_callback_limit": 18446744073709551615}})"));
+        REQUIRE(param.filter_callback_limit == std::numeric_limits<uint64_t>::max());
+    }
+
+    SECTION("rejects invalid values") {
+        for (const auto& invalid_param :
+             {R"({"sindi": {"filter_callback_limit": -1}})",
+              R"({"sindi": {"filter_callback_limit": 1.5}})",
+              R"({"sindi": {"filter_callback_limit": 18446744073709551616}})"}) {
+            SINDISearchParameter param;
+            REQUIRE_THROWS(param.FromJson(JsonType::Parse(invalid_param)));
+        }
+    }
 }
 
 TEST_CASE("SINDI Term Prune Parameters", "[ut][SINDIParameter]") {

--- a/src/algorithm/sindi/sindi_test.cpp
+++ b/src/algorithm/sindi/sindi_test.cpp
@@ -129,6 +129,198 @@ private:
     std::unordered_set<int64_t> valid_ids_set_;
 };
 
+class CountingFilter : public Filter {
+public:
+    explicit CountingFilter(int64_t only_valid_id, bool accept_all = false)
+        : only_valid_id_(only_valid_id), accept_all_(accept_all) {
+    }
+
+    [[nodiscard]] bool
+    CheckValid(int64_t id) const override {
+        ++count_;
+        return WouldAccept(id);
+    }
+
+    [[nodiscard]] bool
+    WouldAccept(int64_t id) const {
+        return accept_all_ or id == only_valid_id_;
+    }
+
+    [[nodiscard]] uint64_t
+    Count() const {
+        return count_;
+    }
+
+private:
+    int64_t only_valid_id_{-1};
+    bool accept_all_{false};
+    mutable uint64_t count_{0};
+};
+
+TEST_CASE("SINDI Filter Callback Limit", "[ut][SINDI]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    IndexCommonParam common_param;
+    common_param.allocator_ = allocator;
+    common_param.metric_ = MetricType::METRIC_TYPE_IP;
+    common_param.dim_ = 1;
+
+    const bool immutable = GENERATE(false, true);
+    const float query_prune_ratio = GENERATE(0.0F, 0.2F);
+    const auto search_mode = GENERATE(SearchMode::KNN_SEARCH, SearchMode::RANGE_SEARCH);
+    const bool use_search_request = GENERATE(false, true);
+    CAPTURE(immutable, query_prune_ratio, search_mode, use_search_request);
+
+    auto parameter = std::make_shared<SINDIParameter>();
+    parameter->term_id_limit = 8;
+    parameter->window_size = 4;
+    parameter->doc_prune_ratio = 0.0F;
+    parameter->avg_doc_term_length = 1;
+    parameter->immutable = immutable;
+
+    constexpr uint64_t count = 8;
+    uint32_t term = 3;
+    std::vector<float> values(count, 1.0F);
+    std::vector<int64_t> labels(count);
+    std::vector<SparseVector> vectors(count);
+    for (uint64_t i = 0; i < count; ++i) {
+        labels[i] = static_cast<int64_t>(i);
+        vectors[i] = SparseVector{1, &term, &values[i]};
+    }
+    auto base = Dataset::Make();
+    base->NumElements(count)->SparseVectors(vectors.data())->Ids(labels.data())->Owner(false);
+
+    SINDI index(parameter, common_param);
+    REQUIRE(index.Build(base).empty());
+
+    float query_value = 1.0F;
+    SparseVector query_vector{1, &term, &query_value};
+    auto query = Dataset::Make();
+    query->NumElements(1)->SparseVectors(&query_vector)->Owner(false);
+
+    const auto search = [&](const std::string& parameters, const FilterPtr& filter) {
+        if (use_search_request) {
+            SearchRequest request;
+            request.query_ = query;
+            request.mode_ = search_mode;
+            request.topk_ = 4;
+            request.radius_ = 0.0F;
+            request.limited_size_ = 4;
+            request.params_str_ = parameters;
+            request.enable_filter_ = true;
+            request.filter_ = filter;
+            request.expected_labels_ = {2};
+            return index.SearchWithRequest(request);
+        }
+        if (search_mode == SearchMode::RANGE_SEARCH) {
+            return index.RangeSearch(query, 0.0F, parameters, filter, 4);
+        }
+        return index.KnnSearch(query, 4, parameters, filter);
+    };
+
+    const auto limited_parameters = fmt::format(
+        R"({{"sindi": {{"n_candidate": 4, "query_prune_ratio": {}, "filter_callback_limit": 3}}}})",
+        query_prune_ratio);
+    auto limited_filter = std::make_shared<CountingFilter>(2);
+    auto limited_result = search(limited_parameters, limited_filter);
+
+    REQUIRE(limited_filter->Count() == 3);
+    REQUIRE(limited_result->GetDim() == 1);
+    REQUIRE(limited_result->GetIds()[0] == 2);
+    REQUIRE(limited_filter->WouldAccept(limited_result->GetIds()[0]));
+
+    auto rejecting_filter = std::make_shared<CountingFilter>(-1);
+    auto rejected_result = search(limited_parameters, rejecting_filter);
+    REQUIRE(rejecting_filter->Count() == 3);
+    REQUIRE(rejected_result->GetDim() == 0);
+
+    const auto unlimited_parameters = fmt::format(
+        R"({{"sindi": {{"n_candidate": 4, "query_prune_ratio": {}, "filter_callback_limit": 0}}}})",
+        query_prune_ratio);
+    auto unlimited_filter = std::make_shared<CountingFilter>(2);
+    auto unlimited_result = search(unlimited_parameters, unlimited_filter);
+
+    REQUIRE(unlimited_filter->Count() > 3);
+    REQUIRE(unlimited_result->GetDim() == 1);
+    REQUIRE(unlimited_result->GetIds()[0] == 2);
+
+    if (not immutable) {
+        REQUIRE(index.Remove(std::vector<int64_t>{0}, RemoveMode::MARK_REMOVE) == 1);
+        const auto deleted_parameters = fmt::format(
+            R"({{"sindi": {{"n_candidate": 4, "query_prune_ratio": {}, "filter_callback_limit": 1}}}})",
+            query_prune_ratio);
+        auto deleted_filter = std::make_shared<CountingFilter>(1);
+        auto deleted_result = search(deleted_parameters, deleted_filter);
+
+        REQUIRE(deleted_filter->Count() == 1);
+        REQUIRE(deleted_result->GetDim() == 1);
+        REQUIRE(deleted_result->GetIds()[0] == 1);
+
+        if (use_search_request) {
+            SearchRequest request;
+            request.query_ = query;
+            request.mode_ = search_mode;
+            request.topk_ = 4;
+            request.radius_ = 0.0F;
+            request.limited_size_ = 4;
+            request.params_str_ = deleted_parameters;
+            auto unfiltered_result = index.SearchWithRequest(request);
+
+            REQUIRE(unfiltered_result->GetDim() == 4);
+            for (int64_t i = 0; i < unfiltered_result->GetDim(); ++i) {
+                REQUIRE(unfiltered_result->GetIds()[i] != 0);
+            }
+        }
+    }
+}
+
+TEST_CASE("SINDI Filtered KNN Restores Heap Top Across Windows", "[ut][SINDI]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    IndexCommonParam common_param;
+    common_param.allocator_ = allocator;
+    common_param.metric_ = MetricType::METRIC_TYPE_IP;
+    common_param.dim_ = 1;
+
+    const bool immutable = GENERATE(false, true);
+    const float query_prune_ratio = GENERATE(0.0F, 0.2F);
+    CAPTURE(immutable, query_prune_ratio);
+
+    auto parameter = std::make_shared<SINDIParameter>();
+    parameter->term_id_limit = 8;
+    parameter->window_size = 4;
+    parameter->doc_prune_ratio = 0.0F;
+    parameter->avg_doc_term_length = 1;
+    parameter->immutable = immutable;
+
+    constexpr uint64_t count = 5;
+    uint32_t term = 3;
+    std::vector<float> values = {10.0F, 1.0F, 1.0F, 1.0F, 1.0F};
+    std::vector<int64_t> labels(count);
+    std::vector<SparseVector> vectors(count);
+    for (uint64_t i = 0; i < count; ++i) {
+        labels[i] = static_cast<int64_t>(i);
+        vectors[i] = SparseVector{1, &term, &values[i]};
+    }
+    auto base = Dataset::Make();
+    base->NumElements(count)->SparseVectors(vectors.data())->Ids(labels.data())->Owner(false);
+
+    SINDI index(parameter, common_param);
+    REQUIRE(index.Build(base).empty());
+
+    float query_value = 1.0F;
+    SparseVector query_vector{1, &term, &query_value};
+    auto query = Dataset::Make();
+    query->NumElements(1)->SparseVectors(&query_vector)->Owner(false);
+    const auto search_parameters = fmt::format(
+        R"({{"sindi": {{"n_candidate": 1, "query_prune_ratio": {}}}}})", query_prune_ratio);
+
+    auto filter = std::make_shared<CountingFilter>(-1, true);
+    auto result = index.KnnSearch(query, 1, search_parameters, filter);
+
+    REQUIRE(result->GetDim() == 1);
+    REQUIRE(result->GetIds()[0] == 0);
+    REQUIRE(filter->Count() == 1);
+}
+
 TEST_CASE("SINDI Heap Insert Strategy Test", "[ut][SINDI]") {
     auto allocator = SafeAllocator::FactoryDefaultAllocator();
     IndexCommonParam common_param;

--- a/src/common.h
+++ b/src/common.h
@@ -67,6 +67,7 @@ static constexpr const float DEFAULT_QUERY_PRUNE_RATIO = 0.0F;
 static constexpr const float DEFAULT_DOC_PRUNE_RATIO = 0.0F;
 static constexpr const float DEFAULT_TERM_PRUNE_RATIO = 0.0F;
 static constexpr const uint64_t DEFAULT_TERM_RETAIN_THRESHOLD = 0;
+static constexpr const uint64_t DEFAULT_FILTER_CALLBACK_LIMIT = 0;
 static constexpr const uint32_t DEFAULT_N_CANDIDATE = 0;
 static constexpr const uint32_t DEFAULT_AVG_DOC_TERM_LENGTH = 100;
 static constexpr const uint32_t INVALID_ENTRY_POINT = std::numeric_limits<uint32_t>::max();

--- a/src/datacell/sparse_term_datacell.cpp
+++ b/src/datacell/sparse_term_datacell.cpp
@@ -221,7 +221,8 @@ SparseTermDataCell::fill_heap_initial(uint32_t id,
     }
     if (dist < 0) {
         if constexpr (type == InnerSearchType::WITH_FILTER) {
-            if (not filter->CheckValid(id + offset_id)) {
+            const bool valid = filter->CheckValid(id + offset_id);
+            if (not valid) {
                 dist = 0;
                 return false;
             }
@@ -235,17 +236,24 @@ SparseTermDataCell::fill_heap_initial(uint32_t id,
 }
 
 template <InnerSearchMode mode, InnerSearchType type>
-void
+bool
 SparseTermDataCell::InsertHeapByTermLists(float* dists,
                                           const SparseTermComputerPtr& computer,
                                           MaxHeap& heap,
                                           const InnerSearchParam& param,
-                                          uint32_t offset_id) const {
+                                          uint32_t offset_id,
+                                          const uint64_t* filter_callback_limit) const {
     uint32_t id = 0;
     float cur_heap_top = std::numeric_limits<float>::max();
     auto n_candidate = param.ef;
     auto radius = param.radius;
     auto filter = param.is_inner_id_allowed;
+
+    if constexpr (mode == InnerSearchMode::KNN_SEARCH) {
+        if (heap.size() == n_candidate) {
+            cur_heap_top = heap.top().first;
+        }
+    }
 
     if constexpr (mode == InnerSearchMode::RANGE_SEARCH) {
         // note that radius = 1 - ip -> radius - 1 = 0 - ip
@@ -270,15 +278,22 @@ SparseTermDataCell::InsertHeapByTermLists(float* dists,
             if (heap.size() < n_candidate) {
                 for (; i < term_end; i++) {
                     id = one_term_ids[i];
-                    if (fill_heap_initial<type>(id,
-                                                dists[id],
-                                                cur_heap_top,
-                                                heap,
-                                                offset_id,
-                                                n_candidate,
-                                                filter,
-                                                param.distance_threshold,
-                                                param.enable_reorder)) {
+                    const bool heap_filled = fill_heap_initial<type>(id,
+                                                                     dists[id],
+                                                                     cur_heap_top,
+                                                                     heap,
+                                                                     offset_id,
+                                                                     n_candidate,
+                                                                     filter,
+                                                                     param.distance_threshold,
+                                                                     param.enable_reorder);
+                    if constexpr (type == InnerSearchType::WITH_FILTER) {
+                        if (filter_callback_limit != nullptr and *filter_callback_limit == 0) {
+                            computer->ResetTerm();
+                            return true;
+                        }
+                    }
+                    if (heap_filled) {
                         i++;
                         break;
                     }
@@ -298,22 +313,36 @@ SparseTermDataCell::InsertHeapByTermLists(float* dists,
                                                    filter,
                                                    param.distance_threshold,
                                                    param.enable_reorder);
+            if constexpr (type == InnerSearchType::WITH_FILTER) {
+                if (filter_callback_limit != nullptr and *filter_callback_limit == 0) {
+                    computer->ResetTerm();
+                    return true;
+                }
+            }
         }
     }
     computer->ResetTerm();
+    return false;
 }
 
 template <InnerSearchMode mode, InnerSearchType type>
-void
+bool
 SparseTermDataCell::InsertHeapByDists(float* dists,
                                       uint32_t dists_size,
                                       MaxHeap& heap,
                                       const InnerSearchParam& param,
-                                      uint32_t offset_id) const {
+                                      uint32_t offset_id,
+                                      const uint64_t* filter_callback_limit) const {
     float cur_heap_top = std::numeric_limits<float>::max();
     auto n_candidate = param.ef;
     auto radius = param.radius;
     auto filter = param.is_inner_id_allowed;
+
+    if constexpr (mode == InnerSearchMode::KNN_SEARCH) {
+        if (heap.size() == n_candidate) {
+            cur_heap_top = heap.top().first;
+        }
+    }
 
     if constexpr (mode == InnerSearchMode::RANGE_SEARCH) {
         cur_heap_top = radius - 1;
@@ -323,15 +352,21 @@ SparseTermDataCell::InsertHeapByDists(float* dists,
     if constexpr (mode == InnerSearchMode::KNN_SEARCH) {
         if (heap.size() < n_candidate) {
             for (; id < total_count_; id++) {
-                if (fill_heap_initial<type>(id,
-                                            dists[id],
-                                            cur_heap_top,
-                                            heap,
-                                            offset_id,
-                                            n_candidate,
-                                            filter,
-                                            param.distance_threshold,
-                                            param.enable_reorder)) {
+                const bool heap_filled = fill_heap_initial<type>(id,
+                                                                 dists[id],
+                                                                 cur_heap_top,
+                                                                 heap,
+                                                                 offset_id,
+                                                                 n_candidate,
+                                                                 filter,
+                                                                 param.distance_threshold,
+                                                                 param.enable_reorder);
+                if constexpr (type == InnerSearchType::WITH_FILTER) {
+                    if (filter_callback_limit != nullptr and *filter_callback_limit == 0) {
+                        return true;
+                    }
+                }
+                if (heap_filled) {
                     id++;
                     break;
                 }
@@ -350,7 +385,13 @@ SparseTermDataCell::InsertHeapByDists(float* dists,
                                                filter,
                                                param.distance_threshold,
                                                param.enable_reorder);
+        if constexpr (type == InnerSearchType::WITH_FILTER) {
+            if (filter_callback_limit != nullptr and *filter_callback_limit == 0) {
+                return true;
+            }
+        }
     }
+    return false;
 }
 
 void
@@ -727,70 +768,78 @@ SparseTermDataCell::Decode(const uint8_t* src, size_t size, float* dst) const {
     }
 }
 
-template void
+template bool
 SparseTermDataCell::InsertHeapByTermLists<InnerSearchMode::KNN_SEARCH, InnerSearchType::PURE>(
     float* dists,
     const SparseTermComputerPtr& computer,
     MaxHeap& heap,
     const InnerSearchParam& param,
-    uint32_t offset_id) const;
+    uint32_t offset_id,
+    const uint64_t* filter_callback_limit) const;
 
-template void
+template bool
 SparseTermDataCell::InsertHeapByTermLists<InnerSearchMode::KNN_SEARCH,
                                           InnerSearchType::WITH_FILTER>(
     float* dists,
     const SparseTermComputerPtr& computer,
     MaxHeap& heap,
     const InnerSearchParam& param,
-    uint32_t offset_id) const;
+    uint32_t offset_id,
+    const uint64_t* filter_callback_limit) const;
 
-template void
+template bool
 SparseTermDataCell::InsertHeapByTermLists<InnerSearchMode::RANGE_SEARCH, InnerSearchType::PURE>(
     float* dists,
     const SparseTermComputerPtr& computer,
     MaxHeap& heap,
     const InnerSearchParam& param,
-    uint32_t offset_id) const;
+    uint32_t offset_id,
+    const uint64_t* filter_callback_limit) const;
 
-template void
+template bool
 SparseTermDataCell::InsertHeapByTermLists<InnerSearchMode::RANGE_SEARCH,
                                           InnerSearchType::WITH_FILTER>(
     float* dists,
     const SparseTermComputerPtr& computer,
     MaxHeap& heap,
     const InnerSearchParam& param,
-    uint32_t offset_id) const;
+    uint32_t offset_id,
+    const uint64_t* filter_callback_limit) const;
 
-template void
+template bool
 SparseTermDataCell::InsertHeapByDists<InnerSearchMode::KNN_SEARCH, InnerSearchType::PURE>(
     float* dists,
     uint32_t dists_size,
     MaxHeap& heap,
     const InnerSearchParam& param,
-    uint32_t offset_id) const;
+    uint32_t offset_id,
+    const uint64_t* filter_callback_limit) const;
 
-template void
+template bool
 SparseTermDataCell::InsertHeapByDists<InnerSearchMode::KNN_SEARCH, InnerSearchType::WITH_FILTER>(
     float* dists,
     uint32_t dists_size,
     MaxHeap& heap,
     const InnerSearchParam& param,
-    uint32_t offset_id) const;
+    uint32_t offset_id,
+    const uint64_t* filter_callback_limit) const;
 
-template void
+template bool
 SparseTermDataCell::InsertHeapByDists<InnerSearchMode::RANGE_SEARCH, InnerSearchType::PURE>(
     float* dists,
     uint32_t dists_size,
     MaxHeap& heap,
     const InnerSearchParam& param,
-    uint32_t offset_id) const;
+    uint32_t offset_id,
+    const uint64_t* filter_callback_limit) const;
 
-template void
+template bool
 SparseTermDataCell::InsertHeapByDists<InnerSearchMode::RANGE_SEARCH, InnerSearchType::WITH_FILTER>(
     float* dists,
     uint32_t dists_size,
     MaxHeap& heap,
     const InnerSearchParam& param,
-    uint32_t offset_id) const;
+    uint32_t offset_id,
+    const uint64_t* filter_callback_limit) const;
 
 }  // namespace vsag

--- a/src/datacell/sparse_term_datacell.h
+++ b/src/datacell/sparse_term_datacell.h
@@ -107,12 +107,13 @@ public:
      */
     template <InnerSearchMode mode = InnerSearchMode::KNN_SEARCH,
               InnerSearchType type = InnerSearchType::PURE>
-    void
+    bool
     InsertHeapByTermLists(float* dists,
                           const SparseTermComputerPtr& computer,
                           MaxHeap& heap,
                           const InnerSearchParam& param,
-                          uint32_t offset_id) const;
+                          uint32_t offset_id,
+                          const uint64_t* filter_callback_limit = nullptr) const;
 
     /**
      * @brief Insert candidates into heap directly from precomputed distance array
@@ -125,12 +126,13 @@ public:
      */
     template <InnerSearchMode mode = InnerSearchMode::KNN_SEARCH,
               InnerSearchType type = InnerSearchType::PURE>
-    void
+    bool
     InsertHeapByDists(float* dists,
                       uint32_t dists_size,
                       MaxHeap& heap,
                       const InnerSearchParam& param,
-                      uint32_t offset_id) const;
+                      uint32_t offset_id,
+                      const uint64_t* filter_callback_limit = nullptr) const;
 
     void
     DocPrune(Vector<std::pair<uint32_t, float>>& sorted_base) const;

--- a/src/inner_string_params.h
+++ b/src/inner_string_params.h
@@ -130,6 +130,7 @@ const char* const SPARSE_QUERY_PRUNE_RATIO = "query_prune_ratio";
 const char* const SPARSE_DOC_PRUNE_RATIO = "doc_prune_ratio";
 const char* const SPARSE_TERM_PRUNE_RATIO = "term_prune_ratio";
 const char* const SPARSE_TERM_RETAIN_THRESHOLD = "term_retain_threshold";
+const char* const SPARSE_FILTER_CALLBACK_LIMIT = "filter_callback_limit";
 const char* const SPARSE_TERM_ID_LIMIT = "term_id_limit";
 const char* const SPARSE_WINDOW_SIZE = "window_size";
 const char* const SPARSE_DESERIALIZE_WITHOUT_FOOTER = "deserialize_without_footer";


### PR DESCRIPTION
## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Improvement/Refactor
- [ ] Documentation
- [ ] CI/Build/Infra

## Linked Issue

- Fixes: #2680

## What Changed

- Add the unsigned SINDI search parameter `filter_callback_limit`; omitted or `0` preserves unlimited behavior.
- Count only actual user `Filter::CheckValid` invocations with request-local state, excluding deleted-ID and other internal filter checks.
- Stop candidate and window processing immediately after the Nth callback result is handled, returning only candidates that already passed filtering.
- Apply the limit to KNN and range search, regular APIs and `SearchWithRequest`, mutable and immutable indexes, and term-list and distance-array heap insertion.
- Add parameter validation, a 16-combination behavior matrix, exact boundary and deleted-ID regression coverage, and synchronized English/Chinese SINDI documentation.

## Test Evidence

- [ ] `make fmt`
- [ ] `make lint`
- [x] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [x] Other (describe below)

Test details:

```text
clang-format 15.0.7 applied to changed C++ files
clang-format --dry-run --Werror <changed C++ files>
git diff --check
make debug
make test UT_FILTER='[SINDI]'
  unittests: 34 test cases, 184768 assertions passed
  functests: 15 test cases, 511467 assertions passed
./build/tests/unittests -d yes '[SINDIParameter]' --allow-running-no-tests
  10 test cases, 86 assertions passed
```

## Compatibility Impact

- API/ABI compatibility: additive search parameter only; no public API or serialized-index format changes.
- Behavior changes: positive `filter_callback_limit` enables deterministic early termination and may return partial results; omitted or `0` keeps existing behavior. In limited `SearchWithRequest` calls, reasoning avoids duplicate diagnostic-only filter callbacks so they cannot consume the hard callback budget.

## Performance and Concurrency Impact

- Performance impact: unlimited searches retain the existing path. Positive limits add a request-local filter wrapper and can reduce work by terminating candidate/window scans early.
- Concurrency/thread-safety impact: no shared counter is added; callback budget state is local to each search request, including when callers reuse the same `Filter` object.

## Documentation Impact

- [ ] No docs update needed
- [x] Updated docs:
  - [ ] `README.md`
  - [ ] `DEVELOPMENT.md`
  - [ ] `CONTRIBUTING.md`
  - [x] Other: `docs/docs/en/src/indexes/sindi.md`, `docs/docs/zh/src/indexes/sindi.md`

## Risk and Rollback

- Risk level: medium; the limit crosses multiple SINDI search implementations and insertion strategies, covered by the test matrix above.
- Rollback plan: revert commit `f6c854ae` to remove the parameter and restore the previous unlimited search path.

## Checklist

- [x] I have linked the relevant issue (required for `kind/bug` and `kind/feature`; see "Linked Issue" above)
- [x] I have added/updated tests for new behavior or bug fixes
- [x] I have considered API compatibility impact
- [x] I have updated docs if behavior/workflow changed
- [x] My commit messages follow project conventions (Conventional Commits, optional `[skip ci]` prefix)
