### PR TITLE
fix: include cstdint in binaryset header

### DIFF
--- a/include/vsag/binaryset.h
+++ b/include/vsag/binaryset.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <algorithm>
+#include <cstdint>
 #include <memory>
 #include <set>
 #include <string>


### PR DESCRIPTION
## What changed

- Include `<cstdint>` directly from the public `binaryset.h` header.

## Why

`binaryset.h` declares a `uint64_t` member but did not include the standard header that defines it. Translation units without an incidental `<cstdint>` include failed to compile, including the debug build's `fixtures_framework` target under GCC 15.

## Impact

The public header is now self-contained. There is no API or ABI change.

## Validation

- Compiled a translation unit containing only `#include "vsag/binaryset.h"` with `c++ -std=c++17 -Iinclude -fsyntax-only`.
- Ran `make debug` successfully to 100%.
- Ran `git diff --check` successfully.

Fixes: #2698
