### PR TITLE
perf: eliminate TQ transform allocations

### DIFF
--- a/src/impl/transform/fht_kac_rotate_transformer.cpp
+++ b/src/impl/transform/fht_kac_rotate_transformer.cpp
@@ -61,9 +61,8 @@ FhtKacRotator::Train(const float* data, uint64_t count) {
     this->Train();
 }
 
-TransformerMetaPtr
-FhtKacRotator::Transform(const float* data, float* rotated_vec) const {
-    auto meta = std::make_shared<FHTMeta>();
+void
+FhtKacRotator::Transform(const float* data, float* rotated_vec, uint8_t* /*meta*/) const {
     auto dim = static_cast<uint64_t>(this->input_dim_);
     std::memcpy(rotated_vec, data, sizeof(float) * dim);
     if (trunc_dim_ == dim) {
@@ -72,7 +71,7 @@ FhtKacRotator::Transform(const float* data, float* rotated_vec) const {
             FHTRotate(rotated_vec, trunc_dim_);
             VecRescale(rotated_vec, trunc_dim_, fac_);
         }
-        return meta;
+        return;
     }
 
     uint64_t start = dim - trunc_dim_;
@@ -90,8 +89,6 @@ FhtKacRotator::Transform(const float* data, float* rotated_vec) const {
     }
     VecRescale(rotated_vec, dim, 0.25F);
     //origin vec(x,y), after kacs_walk_generic() -> (x+y, x-y),should be resize by sqrt(0.5) for each KacsWalk() to make the len of vector consistent
-
-    return meta;
 }
 void
 FhtKacRotator::InverseTransform(float const* data, float* rotated_vec) const {

--- a/src/impl/transform/fht_kac_rotate_transformer.h
+++ b/src/impl/transform/fht_kac_rotate_transformer.h
@@ -28,8 +28,8 @@ public:
 
     ~FhtKacRotator() override = default;
 
-    TransformerMetaPtr
-    Transform(const float* data, float* rotated_vec) const override;
+    void
+    Transform(const float* data, float* rotated_vec, uint8_t* meta = nullptr) const override;
 
     void
     InverseTransform(const float* data, float* rotated_vec) const override;

--- a/src/impl/transform/mrle_transformer.h
+++ b/src/impl/transform/mrle_transformer.h
@@ -15,6 +15,8 @@
 
 #pragma once
 
+#include <cstring>
+
 #include "metric_type.h"
 #include "simd/normalize.h"
 #include "vector_transformer.h"
@@ -33,14 +35,14 @@ public:
 
     ~MRLETransformer() override = default;
 
-    TransformerMetaPtr
-    Transform(const float* original_vec, float* transformed_vec) const override {
-        auto meta = std::make_shared<MRLETMeta>();
+    void
+    Transform(const float* original_vec,
+              float* transformed_vec,
+              uint8_t* /*meta*/ = nullptr) const override {
         memcpy(transformed_vec, original_vec, this->output_dim_ * sizeof(float));
         if constexpr (metric == MetricType::METRIC_TYPE_COSINE) {
             Normalize(transformed_vec, transformed_vec, this->output_dim_);
         }
-        return meta;
     }
 
     void

--- a/src/impl/transform/mrle_transformer_test.cpp
+++ b/src/impl/transform/mrle_transformer_test.cpp
@@ -35,8 +35,7 @@ TEST_CASE("MRLETransformer L2 Transform Test", "[ut][MRLETransformer]") {
         input[i] = static_cast<float>(i + 1);
     }
 
-    auto meta = transformer.Transform(input.data(), output.data());
-    REQUIRE(meta != nullptr);
+    transformer.Transform(input.data(), output.data());
 
     for (int64_t i = 0; i < dim; ++i) {
         REQUIRE(std::abs(output[i] - input[i]) < EPSILON);
@@ -55,8 +54,7 @@ TEST_CASE("MRLETransformer Cosine Transform Test", "[ut][MRLETransformer]") {
         input[i] = static_cast<float>(i + 1);
     }
 
-    auto meta = transformer.Transform(input.data(), output.data());
-    REQUIRE(meta != nullptr);
+    transformer.Transform(input.data(), output.data());
 
     float sum = 0.0F;
     for (int64_t i = 0; i < dim; ++i) {

--- a/src/impl/transform/pca_transformer.cpp
+++ b/src/impl/transform/pca_transformer.cpp
@@ -17,6 +17,7 @@
 
 #include <fmt/format.h>
 
+#include <cstring>
 #include <random>
 
 #include "impl/blas/blas_function.h"
@@ -62,9 +63,8 @@ PCATransformer::Train(const float* data, uint64_t count) {
     PerformEigenDecomposition(covariance_matrix.data());
 }
 
-TransformerMetaPtr
-PCATransformer::Transform(const float* input_vec, float* output_vec) const {
-    auto meta = std::make_shared<PCAMeta>();
+void
+PCATransformer::Transform(const float* input_vec, float* output_vec, uint8_t* meta) const {
     vsag::Vector<float> centralized_vec(allocator_);
     centralized_vec.resize(input_dim_, 0.0F);
 
@@ -89,7 +89,12 @@ PCATransformer::Transform(const float* input_vec, float* output_vec) const {
                         output_vec,
                         1);
 
-    return meta;
+    if (meta != nullptr) {
+        // Preserve the existing serialized code layout and value. The metadata is
+        // currently not consumed by RecoveryDistance.
+        const float residual_norm = 0.0F;
+        std::memcpy(meta, &residual_norm, sizeof(residual_norm));
+    }
 }
 
 void

--- a/src/impl/transform/pca_transformer.h
+++ b/src/impl/transform/pca_transformer.h
@@ -62,8 +62,8 @@ public:
     void
     Deserialize(StreamReader& reader) override;
 
-    TransformerMetaPtr
-    Transform(const float* input_vec, float* output_vec) const override;
+    void
+    Transform(const float* input_vec, float* output_vec, uint8_t* meta = nullptr) const override;
 
     void
     InverseTransform(const float* input_vec, float* output_vec) const override;

--- a/src/impl/transform/random_orthogonal_transformer.cpp
+++ b/src/impl/transform/random_orthogonal_transformer.cpp
@@ -55,9 +55,10 @@ RandomOrthogonalMatrix::CopyOrthogonalMatrix(float* out_matrix) const {
               out_matrix);
 }
 
-TransformerMetaPtr
-RandomOrthogonalMatrix::Transform(const float* original_vec, float* transformed_vec) const {
-    auto meta = std::make_shared<ROMMeta>();
+void
+RandomOrthogonalMatrix::Transform(const float* original_vec,
+                                  float* transformed_vec,
+                                  uint8_t* /*meta*/) const {
     // perform matrix-vector multiplication: y = Q * x
     auto dim = static_cast<int32_t>(this->input_dim_);
     BlasFunction::Sgemv(BlasFunction::RowMajor,
@@ -72,8 +73,6 @@ RandomOrthogonalMatrix::Transform(const float* original_vec, float* transformed_
                         0.0F,
                         transformed_vec,
                         1);
-
-    return meta;
 }
 
 void

--- a/src/impl/transform/random_orthogonal_transformer.h
+++ b/src/impl/transform/random_orthogonal_transformer.h
@@ -29,8 +29,10 @@ public:
 
     ~RandomOrthogonalMatrix() override = default;
 
-    TransformerMetaPtr
-    Transform(const float* original_vec, float* transformed_vec) const override;
+    void
+    Transform(const float* original_vec,
+              float* transformed_vec,
+              uint8_t* meta = nullptr) const override;
 
     void
     InverseTransform(const float* transformed_vec, float* original_vec) const override;

--- a/src/impl/transform/vector_transformer.h
+++ b/src/impl/transform/vector_transformer.h
@@ -50,10 +50,8 @@ public:
 
     virtual ~VectorTransformer() = default;
 
-    virtual TransformerMetaPtr
-    Transform(const float* input_vec, float* output_vec) const {
-        return nullptr;
-    };
+    virtual void
+    Transform(const float* input_vec, float* output_vec, uint8_t* meta = nullptr) const = 0;
 
     virtual void
     Serialize(StreamWriter& writer) const = 0;

--- a/src/quantization/computer.h
+++ b/src/quantization/computer.h
@@ -105,7 +105,10 @@ template <typename QuantImpl, MetricType metric>
 class Computer<TransformQuantizer<QuantImpl, metric>> : public ComputerInterface {
 public:
     explicit Computer(const TransformQuantizer<QuantImpl, metric>* quantizer, Allocator* allocator)
-        : quantizer_(quantizer), allocator_(allocator) {
+        : quantizer_(quantizer),
+          allocator_(allocator),
+          primary_scratch_(allocator),
+          secondary_scratch_(allocator) {
         inner_computer_ = new Computer<QuantImpl>(quantizer_->quantizer_.get(), allocator);
     }
 
@@ -167,6 +170,8 @@ public:
     const TransformQuantizer<QuantImpl, metric>* quantizer_{nullptr};
     uint8_t* buf_{nullptr};
     Computer<QuantImpl>* inner_computer_{nullptr};
+    Vector<float> primary_scratch_;
+    Vector<float> secondary_scratch_;
 };
 
 }  // namespace vsag

--- a/src/quantization/transform_quantization/transform_quantizer.h
+++ b/src/quantization/transform_quantization/transform_quantizer.h
@@ -114,13 +114,23 @@ public:
     void
     TransformBaseVector(const float* input, Vector<float>& output) const;
 
+    bool
+    EncodeOneWithScratch(const float* data,
+                         uint8_t* codes,
+                         Vector<float>& primary_scratch,
+                         Vector<float>& secondary_scratch) const;
+
 public:
     VectorTransformerPtr
     MakeTransformerInstance(std::string transform_str,
                             const VectorTransformerParameter& param) const;
 
-    void
-    ExecuteChainTransform(float* prev_data, const uint32_t* meta_offsets, uint8_t* codes) const;
+    const float*
+    ExecuteChainTransform(const float* input,
+                          const uint32_t* meta_offsets,
+                          uint8_t* codes,
+                          Vector<float>& primary_scratch,
+                          Vector<float>& secondary_scratch) const;
 
     float
     ExecuteChainDistanceRecovery(float quantize_dist,
@@ -245,11 +255,13 @@ TransformQuantizer<QuantTmpl, metric>::TrainImpl(const float* data, uint64_t cou
     // 2. execute transform on original data
     const uint64_t transformed_dim = this->GetTransformedDim();
     Vector<float> transformed_data(transformed_dim * count, 0, this->allocator_);
-    Vector<float> transformed_vector(this->allocator_);
+    Vector<float> primary_scratch(this->allocator_);
+    Vector<float> secondary_scratch(this->allocator_);
     for (uint64_t i = 0; i < count; ++i) {
-        this->TransformBaseVector(data + i * this->dim_, transformed_vector);
+        const auto* transformed = ExecuteChainTransform(
+            data + i * this->dim_, nullptr, nullptr, primary_scratch, secondary_scratch);
         memcpy(transformed_data.data() + i * transformed_dim,
-               transformed_vector.data(),
+               transformed,
                transformed_dim * sizeof(float));
     }
 
@@ -259,43 +271,75 @@ TransformQuantizer<QuantTmpl, metric>::TrainImpl(const float* data, uint64_t cou
 }
 
 template <typename QuantTmpl, MetricType metric>
-void
-TransformQuantizer<QuantTmpl, metric>::ExecuteChainTransform(float* prev_data,
-                                                             const uint32_t* meta_offsets,
-                                                             uint8_t* codes) const {
-    Vector<float> next_data(this->dim_, 0, this->allocator_);
-
-    for (uint32_t i = 0; i < this->transform_chain_.size(); i++) {
-        auto vector_transformer = this->transform_chain_[i];
-        auto meta = vector_transformer->Transform(prev_data, next_data.data());
-        if (codes != nullptr) {
-            meta->EncodeMeta(codes + meta_offsets[i]);
-        }
-
-        memcpy(prev_data, next_data.data(), vector_transformer->GetOutputDim() * sizeof(float));
+const float*
+TransformQuantizer<QuantTmpl, metric>::ExecuteChainTransform(
+    const float* input,
+    const uint32_t* meta_offsets,
+    uint8_t* codes,
+    Vector<float>& primary_scratch,
+    Vector<float>& secondary_scratch) const {
+    if (primary_scratch.size() < this->dim_) {
+        primary_scratch.resize(this->dim_, 0.0F);
     }
+
+    const float* current = input;
+    float* next = primary_scratch.data();
+    for (uint32_t i = 0; i < this->transform_chain_.size(); i++) {
+        const auto& vector_transformer = this->transform_chain_[i];
+        uint8_t* meta = nullptr;
+        if (codes != nullptr && meta_offsets != nullptr && vector_transformer->GetMetaSize() > 0) {
+            meta = codes + meta_offsets[i];
+        }
+        vector_transformer->Transform(current, next, meta);
+        current = next;
+
+        if (i + 1 < this->transform_chain_.size()) {
+            if (next == primary_scratch.data()) {
+                if (secondary_scratch.size() < this->dim_) {
+                    secondary_scratch.resize(this->dim_, 0.0F);
+                }
+                next = secondary_scratch.data();
+            } else {
+                next = primary_scratch.data();
+            }
+        }
+    }
+    return current;
 }
 
 template <typename QuantTmpl, MetricType metric>
 void
 TransformQuantizer<QuantTmpl, metric>::TransformBaseVector(const float* input,
                                                            Vector<float>& output) const {
-    output.assign(input, input + this->dim_);
-    ExecuteChainTransform(output.data(), nullptr, nullptr);
-    output.resize(this->GetTransformedDim());
+    Vector<float> secondary_scratch(this->allocator_);
+    const auto* transformed =
+        ExecuteChainTransform(input, nullptr, nullptr, output, secondary_scratch);
+    if (transformed == output.data()) {
+        output.resize(this->GetTransformedDim());
+    } else {
+        output.assign(transformed, transformed + this->GetTransformedDim());
+    }
+}
+
+template <typename QuantTmpl, MetricType metric>
+bool
+TransformQuantizer<QuantTmpl, metric>::EncodeOneWithScratch(
+    const float* data,
+    uint8_t* codes,
+    Vector<float>& primary_scratch,
+    Vector<float>& secondary_scratch) const {
+    const auto* transformed = ExecuteChainTransform(
+        data, base_meta_offsets_.data(), codes, primary_scratch, secondary_scratch);
+    return quantizer_->EncodeOne(transformed, codes);
 }
 
 template <typename QuantTmpl, MetricType metric>
 bool
 TransformQuantizer<QuantTmpl, metric>::EncodeOneImpl(const float* data, uint8_t* codes) const {
-    // 1. execute transform
-    Vector<float> data_buffer(this->dim_, 0, this->allocator_);
-    data_buffer.assign(data, data + this->dim_);
-    ExecuteChainTransform(data_buffer.data(), base_meta_offsets_.data(), codes);
-
-    // 2. execute quantize
-    return quantizer_->EncodeOne(data_buffer.data(), codes);
-};
+    Vector<float> primary_scratch(this->allocator_);
+    Vector<float> secondary_scratch(this->allocator_);
+    return EncodeOneWithScratch(data, codes, primary_scratch, secondary_scratch);
+}
 
 template <typename QuantTmpl, MetricType metric>
 void
@@ -313,14 +357,15 @@ TransformQuantizer<QuantTmpl, metric>::ProcessQueryImpl(
     }
 
     // 1. execute transform
-    Vector<float> data_buffer(this->dim_, 0, this->allocator_);
-    data_buffer.assign(query, query + this->dim_);
-    ExecuteChainTransform(
-        data_buffer.data(), query_meta_offsets_.data(), computer.inner_computer_->buf_);
+    const auto* transformed = ExecuteChainTransform(query,
+                                                    query_meta_offsets_.data(),
+                                                    computer.inner_computer_->buf_,
+                                                    computer.primary_scratch_,
+                                                    computer.secondary_scratch_);
 
     // 2. execute quantize
-    // note that only when computer.buf_ == nullptr, quantizer_ will allocate data to buf_
-    quantizer_->ProcessQuery(data_buffer.data(), *computer.inner_computer_);
+    // note that only when computer.inner_computer_->buf_ == nullptr, quantizer_ will allocate its query buffer
+    quantizer_->ProcessQuery(transformed, *computer.inner_computer_);
 };
 
 template <typename QuantTmpl, MetricType metric>
@@ -332,7 +377,7 @@ TransformQuantizer<QuantTmpl, metric>::ExecuteChainDistanceRecovery(float quanti
                                                                     const uint8_t* codes_2) const {
     auto dist = quantize_dist;
     for (uint32_t i = 0; i < this->transform_chain_.size(); i++) {
-        auto vector_transformer = this->transform_chain_[i];
+        const auto& vector_transformer = this->transform_chain_[i];
         const auto* meta_1 = codes_1 + meta_offsets_1[i];
         const auto* meta_2 = codes_2 + meta_offsets_2[i];
 
@@ -395,8 +440,15 @@ bool
 TransformQuantizer<QuantTmpl, metric>::EncodeBatchImpl(const float* data,
                                                        uint8_t* codes,
                                                        uint64_t count) const {
+    Vector<float> primary_scratch(this->allocator_);
+    Vector<float> secondary_scratch(this->allocator_);
     for (uint64_t i = 0; i < count; ++i) {
-        EncodeOneImpl(data + i * this->dim_, codes + i * this->code_size_);
+        if (not EncodeOneWithScratch(data + i * this->dim_,
+                                     codes + i * this->code_size_,
+                                     primary_scratch,
+                                     secondary_scratch)) {
+            return false;
+        }
     }
     return true;
 }


### PR DESCRIPTION
Summary: remove per-vector transform metadata allocation and reuse caller-owned scratch buffers. Query scratch is private to each computer; PCA metadata code layout remains unchanged.\n\nValidation: targeted TransformQuantizer and transformer tests pass after rebuilding against main; changed transformer implementations pass clang-tidy-15.\n\nRefs #2702