### PR TITLE
[Backport 1.0] fix(build): upgrade bundled OpenBLAS to 0.3.24

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -164,7 +164,7 @@ remains as a deprecated compatibility fallback. The value may be a local filesys
 path or URL, making this the primary mechanism for offline,
 air-gapped, or internal-mirror builds.
 
-- **`VSAG_THIRDPARTY_OPENBLAS_0_3_23`** (representative `1.0` example)
+- **`VSAG_THIRDPARTY_OPENBLAS_0_3_24`** (representative `1.0` example)
   - Override the OpenBLAS source archive URL/path used by `ExternalProject_Add`
   - Useful for offline builds, local mirrors, or pre-downloaded archives
 

--- a/docs/docs/en/src/development/offline_build.md
+++ b/docs/docs/en/src/development/offline_build.md
@@ -90,7 +90,7 @@ The suffix is derived from the exact pinned identifier:
 | `VSAG_THIRDPARTY_JSON_3_11_3` | nlohmann/json 3.11.3 | `github.com/nlohmann/json/.../v3.11.3.tar.gz` | always |
 | `VSAG_THIRDPARTY_ANTLR4_4_13_2` | ANTLR4 runtime 4.13.2 | `github.com/antlr/antlr4/.../4.13.2.tar.gz` | always |
 | `VSAG_THIRDPARTY_BOOST_1_67_0` | Boost 1.67.0 (headers) | `archives.boost.io/.../boost_1_67_0.tar.gz` | always |
-| `VSAG_THIRDPARTY_OPENBLAS_0_3_23` | OpenBLAS 0.3.23 | `github.com/OpenMathLib/OpenBLAS/.../OpenBLAS-0.3.23.tar.gz` | default BLAS backend (when not using system / MKL) |
+| `VSAG_THIRDPARTY_OPENBLAS_0_3_24` | OpenBLAS 0.3.24 | `github.com/OpenMathLib/OpenBLAS/.../OpenBLAS-0.3.24.tar.gz` | default BLAS backend (when not using system / MKL) |
 | `VSAG_THIRDPARTY_CPUINFO_COMMIT_CA678952A9A8` | pytorch/cpuinfo | `github.com/pytorch/cpuinfo/archive/ca678952...tar.gz` | always |
 | `VSAG_THIRDPARTY_FMT_10_2_1` | fmt 10.2.1 | `github.com/fmtlib/fmt/.../10.2.1.tar.gz` | always (unless system fmt) |
 | `VSAG_THIRDPARTY_THREAD_POOL_COMMIT_3507796E172D` | log4cplus/ThreadPool | `github.com/log4cplus/ThreadPool/archive/3507796e...tar.gz` | always |
@@ -142,7 +142,7 @@ export VSAG_MIRROR=https://mirror.corp.example.com/vsag-thirdparty
 export VSAG_THIRDPARTY_JSON_3_11_3=$VSAG_MIRROR/v3.11.3.tar.gz
 export VSAG_THIRDPARTY_ANTLR4_4_13_2=$VSAG_MIRROR/antlr4-4.13.2.tar.gz
 export VSAG_THIRDPARTY_BOOST_1_67_0=$VSAG_MIRROR/boost_1_67_0.tar.gz
-export VSAG_THIRDPARTY_OPENBLAS_0_3_23=$VSAG_MIRROR/OpenBLAS-0.3.23.tar.gz
+export VSAG_THIRDPARTY_OPENBLAS_0_3_24=$VSAG_MIRROR/OpenBLAS-0.3.24.tar.gz
 export VSAG_THIRDPARTY_CPUINFO_COMMIT_CA678952A9A8=$VSAG_MIRROR/cpuinfo-ca678952.tar.gz
 export VSAG_THIRDPARTY_FMT_10_2_1=$VSAG_MIRROR/fmt-10.2.1.tar.gz
 export VSAG_THIRDPARTY_THREAD_POOL_COMMIT_3507796E172D=$VSAG_MIRROR/thread_pool-3507796e.tar.gz
@@ -163,7 +163,7 @@ On a machine that has *no* network at all, copy the archives onto the box first
 export VSAG_THIRDPARTY_JSON_3_11_3=/data/vsag-deps/v3.11.3.tar.gz
 export VSAG_THIRDPARTY_ANTLR4_4_13_2=/data/vsag-deps/antlr4-4.13.2.tar.gz
 export VSAG_THIRDPARTY_BOOST_1_67_0=/data/vsag-deps/boost_1_67_0.tar.gz
-export VSAG_THIRDPARTY_OPENBLAS_0_3_23=/data/vsag-deps/OpenBLAS-0.3.23.tar.gz
+export VSAG_THIRDPARTY_OPENBLAS_0_3_24=/data/vsag-deps/OpenBLAS-0.3.24.tar.gz
 export VSAG_THIRDPARTY_CPUINFO_COMMIT_CA678952A9A8=/data/vsag-deps/cpuinfo-ca678952.tar.gz
 export VSAG_THIRDPARTY_FMT_10_2_1=/data/vsag-deps/fmt-10.2.1.tar.gz
 export VSAG_THIRDPARTY_THREAD_POOL_COMMIT_3507796E172D=/data/vsag-deps/thread_pool-3507796e.tar.gz
@@ -182,7 +182,7 @@ If only one download is unreliable, override just that one and let the rest use
 the defaults:
 
 ```bash
-export VSAG_THIRDPARTY_OPENBLAS_0_3_23=https://mirror.example.com/OpenBLAS-0.3.23.tar.gz
+export VSAG_THIRDPARTY_OPENBLAS_0_3_24=https://mirror.example.com/OpenBLAS-0.3.24.tar.gz
 make release
 ```
 
@@ -197,7 +197,7 @@ export VSAG_THIRDPARTY_OPENBLAS_0_3_24=/data/vsag-deps/OpenBLAS-0.3.24.tar.gz
 export VSAG_THIRDPARTY_YAML_CPP_0_8_0=/data/vsag-deps/yaml-cpp-0.8.0.tar.gz
 export VSAG_THIRDPARTY_YAML_CPP_0_9_0=/data/vsag-deps/yaml-cpp-0.9.0.tar.gz
 
-git switch 1.0    # selects OpenBLAS 0.3.23 and yaml-cpp 0.9.0
+git switch 1.0    # selects OpenBLAS 0.3.24 and yaml-cpp 0.9.0
 make release
 ```
 

--- a/docs/docs/zh/src/development/offline_build.md
+++ b/docs/docs/zh/src/development/offline_build.md
@@ -76,7 +76,7 @@ VSAG 不提供项目控制的压缩包镜像。如需使用本地或内网镜像
 | `VSAG_THIRDPARTY_JSON_3_11_3` | nlohmann/json 3.11.3 | `github.com/nlohmann/json/.../v3.11.3.tar.gz` | 始终 |
 | `VSAG_THIRDPARTY_ANTLR4_4_13_2` | ANTLR4 runtime 4.13.2 | `github.com/antlr/antlr4/.../4.13.2.tar.gz` | 始终 |
 | `VSAG_THIRDPARTY_BOOST_1_67_0` | Boost 1.67.0（头文件） | `archives.boost.io/.../boost_1_67_0.tar.gz` | 始终 |
-| `VSAG_THIRDPARTY_OPENBLAS_0_3_23` | OpenBLAS 0.3.23 | `github.com/OpenMathLib/OpenBLAS/.../OpenBLAS-0.3.23.tar.gz` | 默认 BLAS 后端（未使用系统库 / MKL 时） |
+| `VSAG_THIRDPARTY_OPENBLAS_0_3_24` | OpenBLAS 0.3.24 | `github.com/OpenMathLib/OpenBLAS/.../OpenBLAS-0.3.24.tar.gz` | 默认 BLAS 后端（未使用系统库 / MKL 时） |
 | `VSAG_THIRDPARTY_CPUINFO_COMMIT_CA678952A9A8` | pytorch/cpuinfo | `github.com/pytorch/cpuinfo/archive/ca678952...tar.gz` | 始终 |
 | `VSAG_THIRDPARTY_FMT_10_2_1` | fmt 10.2.1 | `github.com/fmtlib/fmt/.../10.2.1.tar.gz` | 始终（除非使用系统 fmt） |
 | `VSAG_THIRDPARTY_THREAD_POOL_COMMIT_3507796E172D` | log4cplus/ThreadPool | `github.com/log4cplus/ThreadPool/archive/3507796e...tar.gz` | 始终 |
@@ -125,7 +125,7 @@ export VSAG_MIRROR=https://mirror.corp.example.com/vsag-thirdparty
 export VSAG_THIRDPARTY_JSON_3_11_3=$VSAG_MIRROR/v3.11.3.tar.gz
 export VSAG_THIRDPARTY_ANTLR4_4_13_2=$VSAG_MIRROR/antlr4-4.13.2.tar.gz
 export VSAG_THIRDPARTY_BOOST_1_67_0=$VSAG_MIRROR/boost_1_67_0.tar.gz
-export VSAG_THIRDPARTY_OPENBLAS_0_3_23=$VSAG_MIRROR/OpenBLAS-0.3.23.tar.gz
+export VSAG_THIRDPARTY_OPENBLAS_0_3_24=$VSAG_MIRROR/OpenBLAS-0.3.24.tar.gz
 export VSAG_THIRDPARTY_CPUINFO_COMMIT_CA678952A9A8=$VSAG_MIRROR/cpuinfo-ca678952.tar.gz
 export VSAG_THIRDPARTY_FMT_10_2_1=$VSAG_MIRROR/fmt-10.2.1.tar.gz
 export VSAG_THIRDPARTY_THREAD_POOL_COMMIT_3507796E172D=$VSAG_MIRROR/thread_pool-3507796e.tar.gz
@@ -146,7 +146,7 @@ make release
 export VSAG_THIRDPARTY_JSON_3_11_3=/data/vsag-deps/v3.11.3.tar.gz
 export VSAG_THIRDPARTY_ANTLR4_4_13_2=/data/vsag-deps/antlr4-4.13.2.tar.gz
 export VSAG_THIRDPARTY_BOOST_1_67_0=/data/vsag-deps/boost_1_67_0.tar.gz
-export VSAG_THIRDPARTY_OPENBLAS_0_3_23=/data/vsag-deps/OpenBLAS-0.3.23.tar.gz
+export VSAG_THIRDPARTY_OPENBLAS_0_3_24=/data/vsag-deps/OpenBLAS-0.3.24.tar.gz
 export VSAG_THIRDPARTY_CPUINFO_COMMIT_CA678952A9A8=/data/vsag-deps/cpuinfo-ca678952.tar.gz
 export VSAG_THIRDPARTY_FMT_10_2_1=/data/vsag-deps/fmt-10.2.1.tar.gz
 export VSAG_THIRDPARTY_THREAD_POOL_COMMIT_3507796E172D=/data/vsag-deps/thread_pool-3507796e.tar.gz
@@ -164,7 +164,7 @@ make release
 如果只有某一个下载不稳定，只覆盖它即可，其余继续使用默认地址：
 
 ```bash
-export VSAG_THIRDPARTY_OPENBLAS_0_3_23=https://mirror.example.com/OpenBLAS-0.3.23.tar.gz
+export VSAG_THIRDPARTY_OPENBLAS_0_3_24=https://mirror.example.com/OpenBLAS-0.3.24.tar.gz
 make release
 ```
 
@@ -179,7 +179,7 @@ export VSAG_THIRDPARTY_OPENBLAS_0_3_24=/data/vsag-deps/OpenBLAS-0.3.24.tar.gz
 export VSAG_THIRDPARTY_YAML_CPP_0_8_0=/data/vsag-deps/yaml-cpp-0.8.0.tar.gz
 export VSAG_THIRDPARTY_YAML_CPP_0_9_0=/data/vsag-deps/yaml-cpp-0.9.0.tar.gz
 
-git switch 1.0    # 选择 OpenBLAS 0.3.23 与 yaml-cpp 0.9.0
+git switch 1.0    # 选择 OpenBLAS 0.3.24 与 yaml-cpp 0.9.0
 make release
 ```
 

--- a/extern/openblas/openblas.cmake
+++ b/extern/openblas/openblas.cmake
@@ -172,9 +172,10 @@ if (NOT OPENBLAS_FOUND)
     message (STATUS "Building OpenBLAS from source")
 
     set (openblas_urls
-        https://github.com/OpenMathLib/OpenBLAS/releases/download/v0.3.23/OpenBLAS-0.3.23.tar.gz
+        https://github.com/OpenMathLib/OpenBLAS/releases/download/v0.3.24/OpenBLAS-0.3.24.tar.gz
+        https://sourceforge.net/projects/openblas/files/v0.3.24/OpenBLAS-0.3.24.tar.gz/download
     )
-    vsag_resolve_thirdparty_override (OPENBLAS v0.3.23 openblas_urls)
+    vsag_resolve_thirdparty_override (OPENBLAS v0.3.24 openblas_urls)
 
     # OpenBLAS build tools (getarch) require strict FP semantics; -Ofast
     # (which implies -ffast-math) breaks CPU detection. Replace with -O2.
@@ -188,8 +189,8 @@ if (NOT OPENBLAS_FOUND)
     ExternalProject_Add (
         ${name}
         URL ${openblas_urls}
-        URL_HASH MD5=115634b39007de71eb7e75cf7591dfb2
-        DOWNLOAD_NAME OpenBLAS-v0.3.23.tar.gz
+        URL_HASH MD5=23599a30e4ce887590957d94896789c8
+        DOWNLOAD_NAME OpenBLAS-v0.3.24.tar.gz
         PREFIX ${CMAKE_CURRENT_BINARY_DIR}/${name}
         TMP_DIR ${BUILD_INFO_DIR}
         STAMP_DIR ${BUILD_INFO_DIR}

--- a/tests/cmake/thirdparty_override_test.cmake
+++ b/tests/cmake/thirdparty_override_test.cmake
@@ -58,7 +58,7 @@ set (expected_dependencies
      ROARINGBITMAP TABULATE THREAD_POOL TSL YAML_CPP)
 set (expected_pins
      4.13.2 v3.1 1.67.0 v3.7.1 ca678952a9a8eaa6de112d154e8e104b22f9ab3f
-     10.2.1 hdf5_1.14.4 v0.35.0 v3.11.3 v0.3.23 v2.11.1 v3.0.1
+     10.2.1 hdf5_1.14.4 v0.35.0 v3.11.3 v0.3.24 v2.11.1 v3.0.1
      3a58301067bbc03da89ae5a51b3e05b7da719d38
      3507796e172d36555b47d6191f170823d9f6b12c v1.4.0 yaml-cpp-0.9.0)
 set (expected_variables
@@ -66,7 +66,7 @@ set (expected_variables
      VSAG_THIRDPARTY_BOOST_1_67_0 VSAG_THIRDPARTY_CATCH2_3_7_1
      VSAG_THIRDPARTY_CPUINFO_COMMIT_CA678952A9A8 VSAG_THIRDPARTY_FMT_10_2_1
      VSAG_THIRDPARTY_HDF5_1_14_4 VSAG_THIRDPARTY_HTTPLIB_0_35_0
-     VSAG_THIRDPARTY_JSON_3_11_3 VSAG_THIRDPARTY_OPENBLAS_0_3_23
+     VSAG_THIRDPARTY_JSON_3_11_3 VSAG_THIRDPARTY_OPENBLAS_0_3_24
      VSAG_THIRDPARTY_PYBIND11_2_11_1 VSAG_THIRDPARTY_ROARINGBITMAP_3_0_1
      VSAG_THIRDPARTY_TABULATE_COMMIT_3A58301067BB
      VSAG_THIRDPARTY_THREAD_POOL_COMMIT_3507796E172D VSAG_THIRDPARTY_TSL_1_4_0
@@ -181,6 +181,31 @@ run_fixture ("" "" output)
 assert_matches ("${output}" "source=default" "default source")
 assert_matches ("${output}" "TEST_SELECTION=default" "mismatched pin ignored")
 assert_not_matches ("${output}" "mismatched-archive" "ignored variable value")
+
+unset (ENV{VSAG_THIRDPARTY_OPENBLAS_0_3_24})
+unset (ENV{VSAG_THIRDPARTY_OPENBLAS})
+set (ENV{VSAG_THIRDPARTY_OPENBLAS_0_3_23} "obsolete-openblas-archive")
+set (openblas_urls default-openblas)
+vsag_resolve_thirdparty_override (OPENBLAS v0.3.24 openblas_urls)
+list (GET openblas_urls 0 selected_openblas_url)
+assert_equal ("${selected_openblas_url}" "default-openblas" "obsolete OpenBLAS pin ignored")
+
+set (ENV{VSAG_THIRDPARTY_OPENBLAS} "legacy-openblas-archive")
+set (openblas_urls default-openblas)
+vsag_resolve_thirdparty_override (OPENBLAS v0.3.24 openblas_urls)
+list (GET openblas_urls 0 selected_openblas_url)
+assert_equal ("${selected_openblas_url}" "legacy-openblas-archive"
+              "OpenBLAS legacy fallback")
+
+set (ENV{VSAG_THIRDPARTY_OPENBLAS_0_3_24} "pinned-openblas-archive")
+set (openblas_urls default-openblas)
+vsag_resolve_thirdparty_override (OPENBLAS v0.3.24 openblas_urls)
+list (GET openblas_urls 0 selected_openblas_url)
+assert_equal ("${selected_openblas_url}" "pinned-openblas-archive"
+              "OpenBLAS pinned precedence")
+unset (ENV{VSAG_THIRDPARTY_OPENBLAS_0_3_24})
+unset (ENV{VSAG_THIRDPARTY_OPENBLAS_0_3_23})
+unset (ENV{VSAG_THIRDPARTY_OPENBLAS})
 
 set (ENV{VSAG_THIRDPARTY_FMT} "https://user:legacy-secret@example.invalid/fmt.tar.gz")
 execute_process (


### PR DESCRIPTION
## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement/Refactor
- [ ] Documentation
- [x] CI/Build/Infra

## Linked Issue

- Fixes: #2507

## What Changed

- Backport the semantic OpenBLAS fix from #2459 to the current `1.0` dependency-override implementation from #2686.
- Upgrade bundled OpenBLAS from 0.3.23 to 0.3.24, using the authoritative GitHub and SourceForge URLs and verified MD5 `23599a30e4ce887590957d94896789c8` from current `main`.
- Select `VSAG_THIRDPARTY_OPENBLAS_0_3_24`, retain the deprecated unqualified fallback, and add regression coverage proving the obsolete `_0_3_23` variable is ignored.
- Synchronize the 1.0 inventory, developer guidance, and English/Chinese offline-build documentation.

OpenBLAS 0.3.24 is the first release documenting the relevant Sapphire Rapids,
Cooper Lake, and AMX `DYNAMIC_ARCH` fixes. Main received the upgrade in #2459;
this closes the remaining 1.0 release-line gap recorded in #2507.

## Test Evidence

- [x] `make fmt`
- [ ] `make lint`
- [ ] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [x] Other (described below)

Test details:

```text
make test-cmake
  Third-party pinned-variable tests passed
  Covers _0_3_24 precedence, unqualified legacy fallback, and ignored _0_3_23 mismatch

make fmt
  Using clang-format version 15 (required: 15)

Official OpenBLAS 0.3.24 GitHub release asset:
  MD5 23599a30e4ce887590957d94896789c8

Bundled configure with MKL/system OpenBLAS disabled and OpenBLAS overrides unset:
  dependency=OPENBLAS, pin=v0.3.24, source=default

ExternalProject production hash path:
  OpenBLAS-v0.3.24.tar.gz: hash match
  MD5=23599a30e4ce887590957d94896789c8

cmake --build <build> --target openblas --parallel 1
  Completed 'openblas' (NUM_BUILDING_JOBS=2)

cmake --build <build> --target vsag --parallel 4
  Linked src/libvsag.so.1.0.0

git diff --check
OSS cache URL scan under extern/
  passed
```

## Compatibility Impact

- API/ABI compatibility: none
- Behavior changes: bundled builds use OpenBLAS 0.3.24 and its pin-qualified override instead of 0.3.23

## Performance and Concurrency Impact

- Performance impact: none expected; no VSAG runtime code changed
- Concurrency/thread-safety impact: none; existing 1.0 build parallelism and system-OpenBLAS behavior are unchanged

## Documentation Impact

- [ ] No docs update needed
- [x] Updated docs:
  - [ ] `README.md`
  - [x] `DEVELOPMENT.md`
  - [ ] `CONTRIBUTING.md`
  - [x] Other: synchronized English/Chinese offline-build guides

## Risk and Rollback

- Risk level: low
- Rollback plan: revert the OpenBLAS pin, URLs, hash, inventory test, and documentation updates

## Checklist

- [x] I have linked the relevant issue (required for `kind/bug` and `kind/feature`; see "Linked Issue" above)
- [x] I have added/updated tests for new behavior or bug fixes
- [x] I have considered API compatibility impact
- [x] I have updated docs if behavior/workflow changed
- [x] My commit messages follow project conventions (Conventional Commits, optional `[skip ci]` prefix)
