### PR TITLE
fix: correct sindi n_candidate error message and doc

### DIFF
--- a/docs/docs/en/src/indexes/sindi.md
+++ b/docs/docs/en/src/indexes/sindi.md
@@ -141,7 +141,7 @@ Search-time parameters live under the `sindi` sub-object:
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `n_candidate` | int | `0` | Candidate heap size. When `0`, defaults to `SPARSE_AMPLIFICATION_FACTOR · topk` (500×). If set, must satisfy `1 ≤ n_candidate ≤ SPARSE_AMPLIFICATION_FACTOR · topk`. |
+| `n_candidate` | int | `0` | Candidate heap size. The effective candidate effort is `max(n_candidate, topk)`, so the default `0` keeps the heap at `topk` with no candidate amplification. Must satisfy `0 ≤ n_candidate ≤ SPARSE_AMPLIFICATION_FACTOR · topk` (500×). |
 | `query_prune_ratio` | float | `0.0` | Fraction of lowest-weight query terms skipped (`[0.0, 1.0)`). |
 | `term_prune_ratio` | float | `0.0` | Fraction of the lowest-value postings skipped from each term list (`[0.0, 1.0)`). |
 | `term_retain_threshold` | uint64 | `0` | Maximum postings for one term across all windows. A value of `0` disables this limit; positive values allow each non-empty window posting list to scan at most `max(1, floor(threshold / window_count))` postings. |

--- a/docs/docs/zh/src/indexes/sindi.md
+++ b/docs/docs/zh/src/indexes/sindi.md
@@ -131,7 +131,7 @@ auto result = index->KnnSearch(
 
 | 参数 | 类型 | 默认值 | 说明 |
 |------|------|--------|------|
-| `n_candidate` | int | `0` | 候选堆大小。为 `0` 时自动取 `SPARSE_AMPLIFICATION_FACTOR · topk`（500 倍）；若显式设置，须满足 `1 ≤ n_candidate ≤ SPARSE_AMPLIFICATION_FACTOR · topk` |
+| `n_candidate` | int | `0` | 候选堆大小。实际候选规模为 `max(n_candidate, topk)`，缺省 `0` 时候选堆大小等于 `topk`，不做候选放大；须满足 `0 ≤ n_candidate ≤ SPARSE_AMPLIFICATION_FACTOR · topk`（500 倍） |
 | `query_prune_ratio` | float | `0.0` | 查询时丢弃权重最低查询项的比例，取值范围为 `[0.0, 1.0)` |
 | `term_prune_ratio` | float | `0.0` | 每条倒排链中按 value 丢弃低权 posting 的比例，取值范围为 `[0.0, 1.0)` |
 | `term_retain_threshold` | uint64 | `0` | 单个 term 在所有 window 中最多扫描的 posting 总数；`0` 表示关闭此限制，正数使每个 window 的非空 posting list 最多扫描 `max(1, floor(threshold / window_count))` 个 |

--- a/src/algorithm/sindi/sindi.cpp
+++ b/src/algorithm/sindi/sindi.cpp
@@ -641,7 +641,7 @@ SINDI::KnnSearch(const DatasetPtr& query,
     CHECK_ARGUMENT(search_param.n_candidate <= SPARSE_AMPLIFICATION_FACTOR * k,
                    fmt::format("n_candidate ({}) should be less than {} * k ({})",
                                search_param.n_candidate,
-                               AMPLIFICATION_FACTOR,
+                               SPARSE_AMPLIFICATION_FACTOR,
                                k));
     InnerSearchParam inner_param;
     inner_param.ef = std::max(static_cast<int64_t>(search_param.n_candidate), k);

--- a/tests/test_sindi.cpp
+++ b/tests/test_sindi.cpp
@@ -201,6 +201,31 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex,
 }
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex,
+                             "n_candidate Limit Matches Error Message",
+                             "[ft][search][sindi]") {
+    fixtures::SINDIParam param;
+    auto index = TestFactory("sindi", GenerateBuildParameter(param), true);
+    auto dataset = pool.GetSparseDatasetAndCreate(base_count, 128, 0.8);
+    TestBuildIndex(index, dataset, true);
+    auto query = fixtures::get_one_query(dataset->query_, 0);
+
+    const auto make_param = [](uint32_t n_candidate) {
+        return fmt::format(R"({{"sindi":{{"n_candidate":{},"query_prune_ratio":0.0,)"
+                           R"("term_prune_ratio":0.0}}}})",
+                           n_candidate);
+    };
+
+    constexpr int64_t k = 1;
+    // the error message must cite the same factor (500) used by the check
+    auto result = index->KnnSearch(query, k, make_param(500 * k + 1));
+    REQUIRE_FALSE(result.has_value());
+    REQUIRE(result.error().message.find("should be less than 500 * k") != std::string::npos);
+
+    result = index->KnnSearch(query, k, make_param(500 * k));
+    REQUIRE(result.has_value());
+}
+
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex,
                              "SINDI Build and Search",
                              "[ft][build][search][sindi]") {
     fixtures::SINDIParam param;


### PR DESCRIPTION
# fix: correct sindi n_candidate error message and doc

Fixes: #2708

## Description

The `SINDI::KnnSearch` parameter check validates `n_candidate` against `SPARSE_AMPLIFICATION_FACTOR * k` (500x), but the error message printed `AMPLIFICATION_FACTOR * k` (100x). This mismatch misleads users when tuning the parameter.

Additionally, the SINDI documentation stated that `n_candidate = 0` defaults to `SPARSE_AMPLIFICATION_FACTOR * topk` (500x), which does not match the actual implementation. The code uses `ef = max(n_candidate, k)`, so the default candidate heap size is `topk`.

## Changes

- `src/algorithm/sindi/sindi.cpp`: use `SPARSE_AMPLIFICATION_FACTOR` in the error message.
- `docs/docs/en/src/indexes/sindi.md`: correct the description of `n_candidate` default behavior and allowed range.
- `docs/docs/zh/src/indexes/sindi.md`: sync the Chinese documentation.
- `tests/test_sindi.cpp`: add a test verifying that the error message matches the actual limit (`500 * k`).

## Testing

- Built with `make release` in the `vsaglib/vsag:ubuntu` Docker development image.
- Ran the new SINDI test: the boundary case `n_candidate = 500 * k` succeeds, and `n_candidate = 500 * k + 1` fails with a message containing `"should be less than 500 * k"`.
- Ran `make fmt` and `make lint`; no new issues introduced.

## Checklist

- [x] Code follows the project coding style.
- [x] Added/updated unit tests for the bug fix.
- [x] Updated both English and Chinese documentation.
- [x] Verified the build and tests pass.