### PR TITLE
fix(sindi): backport zero-distance range fix to 0.18

### DIFF
--- a/src/algorithm/sindi/sindi_test.cpp
+++ b/src/algorithm/sindi/sindi_test.cpp
@@ -17,6 +17,8 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
+#include <map>
+#include <set>
 
 #include "fixtures.h"
 #include "impl/allocator/safe_allocator.h"
@@ -244,6 +246,66 @@ TEST_CASE("SINDI Basic Test", "[ut][SINDI]") {
         delete[] item.vals_;
         delete[] item.ids_;
     }
+}
+
+TEST_CASE("SINDI range search ignores repeated zero-distance candidates", "[ut][SINDI]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    IndexCommonParam common_param;
+    common_param.allocator_ = allocator;
+
+    const bool immutable = GENERATE(false, true);
+    const bool use_reorder = GENERATE(false, true);
+    auto index_param = std::make_shared<SINDIParameter>();
+    index_param->FromJson(JsonType::Parse(fmt::format(R"({{
+        "use_reorder": {},
+        "use_quantization": false,
+        "doc_prune_ratio": 0.0,
+        "window_size": 60000,
+        "term_id_limit": 4000
+    }})",
+                                                      use_reorder)));
+    SINDI index(index_param, common_param);
+
+    std::vector<std::vector<uint32_t>> indices = {{5, 100, 2000}, {5, 50, 2000}, {10, 100, 3000}};
+    std::vector<std::vector<float>> values = {
+        {0.5F, 0.8F, 0.6F}, {0.3F, 0.9F, 0.1F}, {0.7F, 0.4F, 0.5F}};
+    std::vector<SparseVector> sparse_vectors(indices.size());
+    for (uint64_t i = 0; i < sparse_vectors.size(); ++i) {
+        sparse_vectors[i].len_ = static_cast<uint32_t>(indices[i].size());
+        sparse_vectors[i].ids_ = indices[i].data();
+        sparse_vectors[i].vals_ = values[i].data();
+    }
+    std::vector<int64_t> ids = {1, 2, 3};
+    auto base = Dataset::Make();
+    base->NumElements(static_cast<int64_t>(ids.size()))
+        ->Ids(ids.data())
+        ->SparseVectors(sparse_vectors.data())
+        ->Owner(false);
+    REQUIRE(index.Build(base).empty());
+    if (immutable) {
+        index.SetImmutable();
+    }
+
+    auto query = Dataset::Make();
+    query->NumElements(1)->SparseVectors(sparse_vectors.data())->Owner(false);
+    // Force term-list heap insertion while retaining terms shared by multiple documents.
+    const std::string search_params =
+        R"({"sindi": {"query_prune_ratio": 0.2, "n_candidate": 100}})";
+    auto result = index.RangeSearch(query, 1.0F, search_params, nullptr);
+
+    REQUIRE(result->GetDim() == 3);
+    const std::map<int64_t, float> expected_results =
+        use_reorder ? std::map<int64_t, float>{{1, -0.25F}, {2, 0.79F}, {3, 0.68F}}
+                    : std::map<int64_t, float>{{1, 0.0F}, {2, 0.94F}, {3, 0.68F}};
+    std::set<int64_t> result_ids;
+    for (int64_t i = 0; i < result->GetDim(); ++i) {
+        const auto id = result->GetIds()[i];
+        const auto expected = expected_results.find(id);
+        REQUIRE(expected != expected_results.end());
+        REQUIRE(std::abs(result->GetDistances()[i] - expected->second) < 1e-5F);
+        result_ids.insert(id);
+    }
+    REQUIRE(result_ids == std::set<int64_t>{1, 2, 3});
 }
 
 TEST_CASE("SINDI Quantization Test", "[ut][SINDI]") {

--- a/src/datacell/sparse_term_datacell.cpp
+++ b/src/datacell/sparse_term_datacell.cpp
@@ -62,6 +62,11 @@ SparseTermDataCell::insert_candidate_into_heap(uint32_t id,
                                                uint32_t offset_id,
                                                float radius,
                                                const FilterPtr& filter) const {
+    if constexpr (mode == InnerSearchMode::RANGE_SEARCH) {
+        if (dist == 0.0F) {
+            return;
+        }
+    }
     if constexpr (type == InnerSearchType::WITH_FILTER) {
 #if __cplusplus >= 202002L
         if (dist > cur_heap_top or not filter->CheckValid(id + offset_id)) [[likely]] {

--- a/src/datacell/sparse_term_datacell_test.cpp
+++ b/src/datacell/sparse_term_datacell_test.cpp
@@ -17,6 +17,7 @@
 
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
+#include <set>
 
 #include "impl/allocator/safe_allocator.h"
 
@@ -225,6 +226,26 @@ TEST_CASE("SparseTermDatacell Basic Test", "[ut][SparseTermDatacell]") {
         for (auto i = 0; i < range_topk; i++) {
             REQUIRE(std::abs(dists[i] - 0) < 1e-3);
         }
+    }
+
+    SECTION("test zero distance is ignored in range search") {
+        InnerSearchParam inner_param;
+        inner_param.radius = 1.0F;
+        std::vector<float> dists(count_base, 0.0F);
+        dists[2] = -0.25F;
+        dists[7] = -0.5F;
+        MaxHeap heap(allocator.get());
+
+        data_cell->InsertHeapByDists<RANGE_SEARCH, PURE>(
+            dists.data(), dists.size(), heap, inner_param, 0);
+
+        REQUIRE(heap.size() == 2);
+        std::set<int64_t> result_ids;
+        while (not heap.empty()) {
+            result_ids.insert(heap.top().second);
+            heap.pop();
+        }
+        REQUIRE(result_ids == std::set<int64_t>{2, 7});
     }
     // clean
     for (auto& item : sparse_vectors) {


### PR DESCRIPTION
## Summary

Backport the accepted behavior from #2678 so SINDI range search skips an exact zero temporary distance after a candidate has already been processed. This prevents the same document from being inserted repeatedly when it appears in multiple posting lists.

## Branch adaptation

The 0.18 branch uses the sparse-term datacell for SINDI range search and does not contain main's separate immutable storage/search implementation. The guard is therefore applied once in the shared datacell range-candidate path. Regression coverage exercises normal and SetImmutable() states with reorder enabled and disabled. KNN behavior and public API/ABI are unchanged.

## Validation

- Full debug build with tests enabled (optional bindings, tools, examples, and libaio disabled)
- Focused SINDI regression: 36 assertions passed
- SparseTermDatacell Basic Test: 281 assertions passed
- clang-format 15.0.7 dry-run on changed files
- clang-tidy 15.0.7 on the changed production file
- git diff --check

No documentation update is required, matching #2678.

Fixes: #2669