### PR TITLE
fix(hgraph): backport ef_search limit removal to 0.18

### DIFF
--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -892,10 +892,9 @@ HGraph::KnnSearch(const DatasetPtr& query,
     }
 
     auto params = HGraphSearchParameters::FromJson(parameters);
-    auto ef_search_threshold = std::max(AMPLIFICATION_FACTOR * k, 1000L);
     CHECK_ARGUMENT(  // NOLINT
-        (1 <= params.ef_search) and (params.ef_search <= ef_search_threshold),
-        fmt::format("ef_search({}) must in range[1, {}]", params.ef_search, ef_search_threshold));
+        params.ef_search >= 1,
+        fmt::format("ef_search({}) must be at least 1", params.ef_search));
 
     std::shared_lock shared_lock(this->global_mutex_);
     // check k
@@ -2165,10 +2164,9 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
 
     auto params = HGraphSearchParameters::FromJson(request.params_str_);
 
-    auto ef_search_threshold = std::max(AMPLIFICATION_FACTOR * k, 1000L);
     CHECK_ARGUMENT(  // NOLINT
-        (1 <= params.ef_search) and (params.ef_search <= ef_search_threshold),
-        fmt::format("ef_search({}) must in range[1, {}]", params.ef_search, ef_search_threshold));
+        params.ef_search >= 1,
+        fmt::format("ef_search({}) must be at least 1", params.ef_search));
 
     std::shared_lock shared_lock(this->global_mutex_);
     // check k
@@ -2231,7 +2229,7 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
     search_param.min_distance = params.min_distance;
 
     // hops_limit only takes effect when it's greater than ef_search
-    if (params.hops_limit <= static_cast<uint32_t>(params.ef_search)) {
+    if (static_cast<uint64_t>(params.hops_limit) <= static_cast<uint64_t>(params.ef_search)) {
         search_param.hops_limit = std::numeric_limits<uint32_t>::max();
         if (params.hops_limit != std::numeric_limits<uint32_t>::max()) {
             logger::warn(

--- a/src/algorithm/hgraph_parameter.cpp
+++ b/src/algorithm/hgraph_parameter.cpp
@@ -15,6 +15,9 @@
 
 #include "hgraph_parameter.h"
 
+#include <limits>
+#include <nlohmann/json.hpp>
+
 #include "datacell/extra_info_datacell_parameter.h"
 #include "datacell/flatten_datacell_parameter.h"
 #include "datacell/graph_datacell_parameter.h"
@@ -211,7 +214,14 @@ HGraphSearchParameters::FromJson(const std::string& json_string) {
         params[INDEX_TYPE_HGRAPH].Contains(HGRAPH_PARAMETER_EF_RUNTIME),
         fmt::format(
             "parameters[{}] must contains {}", INDEX_TYPE_HGRAPH, HGRAPH_PARAMETER_EF_RUNTIME));
-    obj.ef_search = params[INDEX_TYPE_HGRAPH][HGRAPH_PARAMETER_EF_RUNTIME].GetInt();
+    const auto& ef_search_json = params[INDEX_TYPE_HGRAPH][HGRAPH_PARAMETER_EF_RUNTIME];
+    CHECK_ARGUMENT(ef_search_json.IsNumberInteger(), "ef_search must be an integer");
+    if (ef_search_json.GetInnerJson()->is_number_unsigned()) {
+        CHECK_ARGUMENT(ef_search_json.GetInnerJson()->get<uint64_t>() <=
+                           static_cast<uint64_t>(std::numeric_limits<int64_t>::max()),
+                       "ef_search exceeds int64_t range");
+    }
+    obj.ef_search = ef_search_json.GetInt();
     if (params[INDEX_TYPE_HGRAPH].Contains(HGRAPH_PARAMETER_HOPS_LIMIT)) {
         obj.hops_limit = params[INDEX_TYPE_HGRAPH][HGRAPH_PARAMETER_HOPS_LIMIT].GetInt();
     }

--- a/src/algorithm/hgraph_parameter_test.cpp
+++ b/src/algorithm/hgraph_parameter_test.cpp
@@ -17,6 +17,7 @@
 #include <fmt/format.h>
 
 #include <catch2/catch_test_macros.hpp>
+#include <limits>
 
 #include "hgraph.h"
 #include "parameter_test.h"
@@ -202,6 +203,24 @@ TEST_CASE("HGraph maps support_duplicate to graph parameter", "[ut][HGraphParame
     REQUIRE(typed_param != nullptr);
     REQUIRE(typed_param->support_duplicate);
     REQUIRE(typed_param->duplicate_distance_threshold == 0.25F);
+}
+
+TEST_CASE("HGraph Search Parameters validate ef_search integer",
+          "[ut][HGraphSearchParameters][ef_search]") {
+    SECTION("accept positive int64") {
+        auto params = vsag::HGraphSearchParameters::FromJson(
+            R"({"hgraph": {"ef_search": 9223372036854775807}})");
+        REQUIRE(params.ef_search == std::numeric_limits<int64_t>::max());
+    }
+
+    SECTION("reject non-integer") {
+        REQUIRE_THROWS(vsag::HGraphSearchParameters::FromJson(R"({"hgraph": {"ef_search": 1.5}})"));
+    }
+
+    SECTION("reject unsigned overflow") {
+        REQUIRE_THROWS(vsag::HGraphSearchParameters::FromJson(
+            R"({"hgraph": {"ef_search": 9223372036854775808}})"));
+    }
 }
 
 TEST_CASE("HGraph maps label_remap_type to inner index parameter", "[ut][HGraphParameter]") {

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -326,6 +326,54 @@ TEST_CASE("HGraph RangeSearch filters reranked distances", "[ft][hgraph][pr]") {
     REQUIRE(result.value()->GetIds()[0] == 0);
 }
 
+TEST_CASE("HGraph KNN accepts ef_search above topk limit", "[ft][hgraph][pr][ef_search]") {
+    constexpr int64_t dim = 4;
+    constexpr int64_t count = 16;
+    constexpr int64_t topk = 3;
+    std::vector<int64_t> ids(count);
+    std::vector<float> vectors(count * dim);
+    for (int64_t i = 0; i < count; ++i) {
+        ids[i] = i;
+        std::fill(
+            vectors.begin() + i * dim, vectors.begin() + (i + 1) * dim, static_cast<float>(i));
+    }
+
+    HGraphTestIndex::HGraphBuildParam build_param("l2", dim, "fp32");
+    auto parameters = HGraphTestIndex::GenerateHGraphBuildParametersString(build_param);
+    auto index = TestIndex::TestFactory(HGraphTestIndex::name, parameters, true);
+    auto base = vsag::Dataset::Make();
+    base->NumElements(count)
+        ->Dim(dim)
+        ->Ids(ids.data())
+        ->Float32Vectors(vectors.data())
+        ->Owner(false);
+    REQUIRE(index->Build(base).has_value());
+
+    std::vector<float> query_vector(dim, 0.0F);
+    auto query = vsag::Dataset::Make();
+    query->NumElements(1)->Dim(dim)->Float32Vectors(query_vector.data())->Owner(false);
+
+    constexpr auto large_ef = R"({"hgraph": {"ef_search": 1001}})";
+    auto result = index->KnnSearch(query, topk, large_ef);
+    REQUIRE(result.has_value());
+    REQUIRE(result.value()->GetDim() == topk);
+
+    vsag::IteratorContext* iter_ctx = nullptr;
+    auto iter_result = index->KnnSearch(query, topk, large_ef, nullptr, iter_ctx, false);
+    REQUIRE(iter_result.has_value());
+    REQUIRE(iter_result.value()->GetDim() == topk);
+    delete iter_ctx;
+
+    auto overflow_safe_hops =
+        index->KnnSearch(query, topk, R"({"hgraph": {"ef_search": 4294967296, "hops_limit": 1}})");
+    REQUIRE(overflow_safe_hops.has_value());
+    REQUIRE(overflow_safe_hops.value()->GetDim() == topk);
+
+    REQUIRE_FALSE(index->KnnSearch(query, topk, R"({"hgraph": {"ef_search": 0}})").has_value());
+    REQUIRE_FALSE(index->KnnSearch(query, topk, R"({"hgraph": {"ef_search": -1}})").has_value());
+    REQUIRE_FALSE(index->RangeSearch(query, 1.0F, large_ef, -1).has_value());
+}
+
 void
 HGraphTestIndex::TestGeneral(const TestIndex::IndexPtr& index,
                              const TestDatasetPtr& dataset,


### PR DESCRIPTION
## Summary

Backport the HGraph `ef_search` upper-bound fix from #2515 (and its 1.0 backport #2525) to the `0.18` maintenance branch.

## Adaptation

- Remove the k-relative upper bound from both 0.18 HGraph KNN paths.
- Keep positive int64 validation and reject fractional or unsigned-overflow values.
- Preserve the range-search cap and make the `hops_limit` comparison overflow-safe.
- Add focused parameter and functional regression coverage for the older 0.18 layout.

## Validation

- Focused HGraph parameter tests: 24 assertions passed across 4 cases.
- Focused HGraph functional regression: 11 assertions passed.
- `make debug`: passed.
- `make release`: passed (757 targets).
- clang-format 15, direct clang-tidy 15 on changed implementations, repository lint target, and `git diff --check`: passed.

Fixes: #2554