### PR TITLE
feat(pyramid): add fast multi-layer root routing

### DIFF
--- a/docs/docs/en/src/indexes/pyramid.md
+++ b/docs/docs/en/src/indexes/pyramid.md
@@ -93,6 +93,7 @@ Build-time parameters live under `index_param`.
 | `mrle_dim` | int | `0` | Prefix dimension retained by MRLE; `0` keeps the input dimension. |
 | `max_degree` | int | `64` | Maximum out-degree per node within a sub-graph. |
 | `graph_type` | string | `"nsw"` | `nsw` or `odescent`. |
+| `graph_storage_type` | string | `"flat"` | Bottom-graph storage for a `multi_layer` root: `flat` favors construction and search speed, while `compressed` reduces graph memory. Compressed storage requires `max_degree <= 255`. Single-layer roots, routing graphs, and child graphs remain sparse. |
 | `ef_construction` | int | `400` | Candidate list size for `nsw` builds. |
 | `alpha` | float | `1.2` | Pruning factor during graph construction. |
 | `graph_iter_turn` | int | — | ODescent iterations (effective with `graph_type: "odescent"`). |
@@ -109,9 +110,10 @@ Build-time parameters live under `index_param`.
 | `store_raw_vector` | bool | `false` | Preserve an FP32 copy for `GetRawVectorByIds` and precise distance-by-id calculations. |
 | `store_paths` | bool | `false` | Top-level switch that preserves the original paths supplied to `Build` and `Add` so `GetDataByIdsWithFlag` can return them when `DATA_FLAG_PATH` is selected. It applies to every configured hierarchy and cannot be overridden per hierarchy. |
 | `index_min_size` | int | `0` | Minimum sub-index size; smaller groups fall back to scan. |
+| `root_graph_type` | string | `"single_layer"` | Root graph layout: `single_layer` preserves the original sparse bottom graph; `multi_layer` uses a preallocated Flat or Compressed bottom graph with HGraph-style sparse routing layers and joint construction. `multi_layer` requires `graph_type: "nsw"`. Do not specify this option when `no_build_levels` disables level 0. |
 | `support_duplicate` | bool | `false` | Allow duplicate ids. |
 | `build_thread_count` | int | `1` | Threads used for parallel build. |
-| `hierarchies` | array | `[]` | Named hierarchy definitions. Each element is either a string (inherits all top-level params) or an object with `name` and optional overrides (`max_degree`, `ef_construction`, `alpha`, `no_build_levels`, `index_min_size`). When present, multi-hierarchy mode is activated and each hierarchy maintains its own independent path tree. |
+| `hierarchies` | array | `[]` | Named hierarchy definitions. Each element is either a string (inherits all top-level params) or an object with `name` and optional overrides (`max_degree`, `ef_construction`, `alpha`, `no_build_levels`, `index_min_size`, `root_graph_type`). When present, multi-hierarchy mode is activated and each hierarchy maintains its own independent path tree. |
 
 ### RaBitQ split configuration
 
@@ -165,7 +167,8 @@ Search-time parameters live under the `pyramid` sub-object:
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `ef_search` | int | `100` | Candidate list size for the leaf-level graph search. |
-| `hops_limit` | int | unlimited | Hard cap on hops for root-graph KNN search; ignored when it is not greater than `ef_search`. |
+| `factor` | float | unset | KNN reorder candidate multiplier. Values `<= 1` add no limit. When greater than `1`, Pyramid first completes the unchanged subgraph searches and merges their results, then sends at most `min(max(ef_search, topk), floor(topk * factor))` main-graph candidates to reorder. RaBitQ lower-bound safety candidates may be merged after this limit, matching HGraph; `reorder_candidate_count` reports the actual merged count. The value must be finite and positive. It has no effect on range search or when reorder is disabled. |
+| `hops_limit` | int | unlimited | Per-graph KNN hop cap for the root bottom graph and every non-root graph; ignored when it is not greater than `ef_search`. Sparse root routing layers are never hop-limited. FLAT scans and range search are unaffected. |
 | `subindex_ef_search` | int | `50` | Candidate list size used when traversing intermediate sub-graphs on the path. |
 | `hierarchies` | string[] | `[]` | Select which hierarchy to search. Empty means use the default (unnamed) hierarchy. |
 | `hierarchy_op` | string | `"single"` | How to combine results across hierarchies: `single` (search one hierarchy), `union`, or `intersection`. **Note:** `union` and `intersection` are not yet implemented — setting them will cause `KnnSearch`/`RangeSearch` to return an error. |
@@ -198,7 +201,17 @@ Add a `hierarchies` array inside `index_param`. Each element is either:
   `{"name": "category", "max_degree": 64, "no_build_levels": [0]}`
 
 Overridable per-hierarchy parameters: `max_degree`, `ef_construction`, `alpha`,
-`no_build_levels`, `index_min_size`.
+`no_build_levels`, `index_min_size`, `root_graph_type`.
+
+`root_graph_type: "multi_layer"` changes only the selected hierarchy's root. Its bottom graph uses
+the top-level `graph_storage_type`: Flat by default, or Compressed to trade construction and search
+speed for lower graph memory. Sparse routing graphs choose a better entry point before the bottom
+search; child graphs remain sparse. Bulk Build and incremental Add jointly construct the route and
+bottom layers with the same HGraph-style insertion protocol. This layout requires
+`graph_type: "nsw"`; combining `multi_layer` with `odescent` is rejected during parameter
+validation. Bottom and routing edges use the precise codes when an independent precise store
+exists, otherwise they use the base codes. Query traversal continues to use the base codes, and
+final reordering uses the configured reorder source.
 
 ```json
 {
@@ -339,6 +352,9 @@ faster.
 
 Use [Index Analysis](../resources/analyze_index.md) to inspect Pyramid tree structure,
 per-subindex quality, sampled base recall, and duplicate ratios reported by `GetStats()`.
+For each hierarchy, `root_graphs` reports `root_graph_type`, `bottom_graph_storage_type`,
+`bottom_graph_node_count`, `bottom_graph_size`, `route_graph_count`, `route_node_counts`, and
+`route_graph_size`.
 `AnalyzeIndexBySearch` also reports path-scoped query recall, distance, latency, and, when reorder
 is enabled, quantization metrics. Its query dataset must carry the same default or named-hierarchy
 paths required by `KnnSearch`; when paths are required or supplied for a batched dataset, provide

--- a/docs/docs/zh/src/indexes/pyramid.md
+++ b/docs/docs/zh/src/indexes/pyramid.md
@@ -88,6 +88,7 @@ auto result = index->KnnSearch(
 | `mrle_dim` | int | `0` | MRLE 保留的前缀维度；`0` 表示保持输入维度。 |
 | `max_degree` | int | `64` | 子图内节点的最大出度 |
 | `graph_type` | string | `"nsw"` | `nsw` 或 `odescent` |
+| `graph_storage_type` | string | `"flat"` | `multi_layer` 根节点的底图存储：`flat` 偏向构建和检索速度，`compressed` 减少图内存。压缩存储要求 `max_degree <= 255`。单层根图、路由图和子图仍使用 Sparse。 |
 | `ef_construction` | int | `400` | `nsw` 构图时的候选集大小 |
 | `alpha` | float | `1.2` | 构图剪枝系数 |
 | `graph_iter_turn` | int | — | ODescent 迭代轮数（`graph_type: "odescent"` 时生效） |
@@ -104,9 +105,10 @@ auto result = index->KnnSearch(
 | `store_raw_vector` | bool | `false` | 保留 FP32 原始向量，用于 `GetRawVectorByIds` 和精确的按 ID 距离计算 |
 | `store_paths` | bool | `false` | 顶层开关；保留传给 `Build` 和 `Add` 的原始路径，使 `GetDataByIdsWithFlag` 在选择 `DATA_FLAG_PATH` 时可以返回它们。该开关对所有已配置的 hierarchy 生效，不支持按 hierarchy 覆盖 |
 | `index_min_size` | int | `0` | 子索引的最小规模；小于该值的分区会退化为线性扫描 |
+| `root_graph_type` | string | `"single_layer"` | 根图结构：`single_layer` 保留原有稀疏底图；`multi_layer` 使用预分配的 Flat 或 Compressed 底图、类似 HGraph 的稀疏路由层以及联合构图流程。`multi_layer` 要求 `graph_type: "nsw"`。`no_build_levels` 禁用第 0 层时不要显式指定此选项。 |
 | `support_duplicate` | bool | `false` | 是否允许重复 ID |
 | `build_thread_count` | int | `1` | 构建阶段并发线程数 |
-| `hierarchies` | array | `[]` | 命名层级定义。每个元素可以是字符串（继承全部顶层参数）或对象（含 `name` 及可选覆盖参数：`max_degree`、`ef_construction`、`alpha`、`no_build_levels`、`index_min_size`）。设置后激活多层级模式，每个层级维护独立的路径树。 |
+| `hierarchies` | array | `[]` | 命名层级定义。每个元素可以是字符串（继承全部顶层参数）或对象（含 `name` 及可选覆盖参数：`max_degree`、`ef_construction`、`alpha`、`no_build_levels`、`index_min_size`、`root_graph_type`）。设置后激活多层级模式，每个层级维护独立的路径树。 |
 
 ### RaBitQ split 配置
 
@@ -159,7 +161,8 @@ Pyramid 使用 split code 的 code-code 距离完成增量 FLAT→GRAPH 晋升�
 | 参数 | 类型 | 默认值 | 说明 |
 |------|------|--------|------|
 | `ef_search` | int | `100` | 叶子层子图检索的候选集大小 |
-| `hops_limit` | int | 不限 | 根图 KNN 检索的最大跳数；不大于 `ef_search` 时忽略 |
+| `factor` | float | 未设置 | KNN 重排候选倍率。值 `<= 1` 时不增加限制；值大于 `1` 时，Pyramid 保持各子图原有搜索行为，先合并子图结果，再将至多 `min(max(ef_search, topk), floor(topk * factor))` 个主图候选送入重排。与 HGraph 一致，RaBitQ lower-bound 安全候选可在该限制后额外并入，`reorder_candidate_count` 记录实际合并数量。参数必须为有限正数；范围检索或关闭重排时不生效。 |
+| `hops_limit` | int | 不限 | 根节点底图及每个非根 GRAPH 的逐图 KNN 跳数上限；不大于 `ef_search` 时忽略。根节点的稀疏路由层不受限制，FLAT 扫描与范围检索不受影响。 |
 | `subindex_ef_search` | int | `50` | 沿路径向下遍历中间子图时的候选集大小 |
 | `hierarchies` | string[] | `[]` | 指定检索哪个层级。空数组表示使用默认（匿名）层级。 |
 | `hierarchy_op` | string | `"single"` | 多层级结果合并方式：`single`（检索单个层级）、`union`、`intersection`。**注意：** `union` 和 `intersection` 尚未实现——设置后 `KnnSearch`/`RangeSearch` 会返回错误。 |
@@ -189,7 +192,15 @@ auto result = index->KnnSearch(
   `{"name": "category", "max_degree": 64, "no_build_levels": [0]}`
 
 可按层级覆盖的参数：`max_degree`、`ef_construction`、`alpha`、`no_build_levels`、
-`index_min_size`。
+`index_min_size`、`root_graph_type`。
+
+`root_graph_type: "multi_layer"` 只改变所选层级的根节点。底图使用顶层
+`graph_storage_type`：默认使用 Flat，也可使用 Compressed，以构建和检索速度换取更低的图
+内存；路由图和子图仍使用 Sparse。稀疏路由图先选择更好的入口点，再进入底图检索。批量
+Build 与增量 Add 都使用类似 HGraph 的 route 与 bottom 联合插入流程。该结构要求
+`graph_type: "nsw"`；参数校验会拒绝 `multi_layer` 与 `odescent` 的组合。存在独立 precise
+storage 时，底图和路由图的边统一使用 precise codes 构建，否则使用 base codes；查询遍历
+继续使用 base codes，最终精排使用配置的 reorder source。
 
 ```json
 {
@@ -323,7 +334,10 @@ new_index->Deserialize(binary_set);
 如果不需要按路径限定查询范围，[HGraph](hgraph.md) 更简洁，性能通常也更高。
 
 可以通过[索引分析](../resources/analyze_index.md)检查 Pyramid 的树结构、子索引质量、
-`GetStats()` 输出的 base 采样召回率和重复比例。`AnalyzeIndexBySearch` 还会输出按路径限定的
+`GetStats()` 输出的 base 采样召回率和重复比例。每个 hierarchy 的 `root_graphs` 会报告
+`root_graph_type`、`bottom_graph_storage_type`、`bottom_graph_node_count`、
+`bottom_graph_size`、`route_graph_count`、`route_node_counts` 和 `route_graph_size`。
+`AnalyzeIndexBySearch` 还会输出按路径限定的
 query 召回率、距离、耗时，以及开启 reorder 时的量化指标。query 数据集必须包含与
 `KnnSearch` 相同的默认或命名 hierarchy 路径；批量数据集在需要或提供路径时，应为每条 query
 提供一条路径。`analyze_index` 工具当前无法从 dense query 文件加载 hierarchy 路径，因此

--- a/include/vsag/constants.h
+++ b/include/vsag/constants.h
@@ -121,6 +121,9 @@ extern const char* const PYRAMID_NO_BUILD_LEVELS;
 extern const char* const PYRAMID_HIERARCHIES;
 extern const char* const PYRAMID_INDEX_MIN_SIZE;
 extern const char* const PYRAMID_STORE_PATHS;
+extern const char* const PYRAMID_ROOT_GRAPH_TYPE;
+extern const char* const PYRAMID_ROOT_GRAPH_TYPE_SINGLE_LAYER;
+extern const char* const PYRAMID_ROOT_GRAPH_TYPE_MULTI_LAYER;
 
 extern const char PART_SLASH;
 extern const char PART_BAR;

--- a/src/algorithm/pyramid/pyramid.cpp
+++ b/src/algorithm/pyramid/pyramid.cpp
@@ -24,14 +24,17 @@
 
 #include "algorithm/inner_index_interface.h"
 #include "analyzer/analyzer.h"
+#include "datacell/compressed_graph_datacell_parameter.h"
 #include "datacell/flatten_datacell_parameter.h"
 #include "datacell/flatten_interface.h"
+#include "datacell/graph_datacell_parameter.h"
 #include "impl/distance_provider_for_graph.h"
 #include "impl/heap/standard_heap.h"
 #include "impl/odescent/odescent_graph_builder.h"
 #include "impl/pruning_strategy.h"
 #include "impl/reasoning/search_reasoning.h"
 #include "io/common/io_parameter.h"
+#include "io/memory_block_io/memory_block_io_parameter.h"
 #include "quantization/transform_quantization/transform_quantizer_parameter.h"
 #include "query_context.h"
 #include "storage/empty_index_binary_set.h"
@@ -42,10 +45,28 @@
 #include "utils/slow_task_timer.h"
 #include "utils/util_functions.h"
 namespace vsag {
+namespace {
+
+void
+drain_futures(Vector<std::future<void>>& futures, std::exception_ptr first_exception = nullptr) {
+    for (auto& future : futures) {
+        try {
+            future.get();
+        } catch (...) {
+            if (first_exception == nullptr) {
+                first_exception = std::current_exception();
+            }
+        }
+    }
+    if (first_exception != nullptr) {
+        std::rethrow_exception(first_exception);
+    }
+}
+
+}  // namespace
 
 const static float RADIUS_EPSILON = 1.1F;
 static constexpr uint64_t SOURCE_ID_TABLE_MAGIC = 0x534F555243454944ULL;  // SOURCEID
-
 FilterPtr
 create_request_filter(const SearchRequest& request) {
     FilterPtr filter = nullptr;
@@ -90,6 +111,16 @@ get_suitable_ef_search(int64_t topk, int64_t data_num, uint64_t subindex_ef_sear
     return std::max(static_cast<uint64_t>(4.0F * topk_float), subindex_ef_search * 8);
 }
 
+static inline std::optional<int64_t>
+get_reorder_candidate_limit(bool use_reorder, float factor, int64_t topk, uint64_t ef_search) {
+    if (not use_reorder or factor <= 1.0F) {
+        return std::nullopt;
+    }
+    const auto amplified_topk = std::floor(static_cast<double>(topk) * factor);
+    return amplified_topk >= static_cast<double>(ef_search) ? static_cast<int64_t>(ef_search)
+                                                            : static_cast<int64_t>(amplified_topk);
+}
+
 InnerSearchParam
 Pyramid::create_knn_search_param(const PyramidSearchParameters& parsed_param,
                                  int64_t k,
@@ -116,6 +147,19 @@ Pyramid::create_knn_search_param(const PyramidSearchParameters& parsed_param,
     search_param.enable_rabitq_one_bit_search = parsed_param.has_rabitq_one_bit_search
                                                     ? parsed_param.rabitq_one_bit_search
                                                     : default_rabitq_one_bit_search_;
+
+    // Keep the same contract as HGraph: a useful hop cap must exceed ef_search.
+    if (static_cast<uint64_t>(parsed_param.hops_limit) <= parsed_param.ef_search) {
+        search_param.hops_limit = std::numeric_limits<uint32_t>::max();
+        if (parsed_param.hops_limit != std::numeric_limits<uint32_t>::max()) {
+            logger::warn(
+                fmt::format("hops_limit({}) is not greater than ef_search({}), ignoring hops_limit",
+                            parsed_param.hops_limit,
+                            parsed_param.ef_search));
+        }
+    } else {
+        search_param.hops_limit = parsed_param.hops_limit;
+    }
     if (this->support_duplicate_) {
         search_param.consider_duplicate = true;
     }
@@ -127,6 +171,411 @@ Pyramid::create_knn_search_param(const PyramidSearchParameters& parsed_param,
 
     search_param.is_inner_id_allowed = this->create_search_filter(filter);
     return search_param;
+}
+
+GraphInterfaceParamPtr
+Pyramid::make_route_graph_param(const GraphInterfaceParamPtr& bottom_graph_param) {
+    auto bottom = std::static_pointer_cast<SparseGraphDatacellParameter>(bottom_graph_param);
+    auto route = std::make_shared<SparseGraphDatacellParameter>();
+    route->FromJson(bottom->ToJson());
+    route->max_degree_ = bottom->max_degree_ / 2;
+    return route;
+}
+
+GraphInterfaceParamPtr
+Pyramid::make_root_graph_param(const GraphInterfaceParamPtr& child_graph_param,
+                               GraphStorageTypes storage_type) {
+    auto child = std::static_pointer_cast<SparseGraphDatacellParameter>(child_graph_param);
+    if (storage_type == GraphStorageTypes::GRAPH_STORAGE_TYPE_VALUE_COMPRESSED) {
+        CHECK_ARGUMENT(child->max_degree_ <= std::numeric_limits<uint8_t>::max(),
+                       "Pyramid compressed root max_degree must not exceed 255");
+        CHECK_ARGUMENT(not child->use_reverse_edges_,
+                       "Pyramid compressed root does not support reverse edges");
+        auto root = std::make_shared<CompressedGraphDatacellParameter>();
+        root->max_degree_ = child->max_degree_;
+        root->support_duplicate_ = child->support_duplicate_;
+        return root;
+    }
+    auto root = std::make_shared<GraphDataCellParameter>();
+    root->max_degree_ = child->max_degree_;
+    root->support_remove_ = child->support_delete_;
+    root->remove_flag_bit_ = child->remove_flag_bit_;
+    root->support_duplicate_ = child->support_duplicate_;
+    root->use_reverse_edges_ = child->use_reverse_edges_;
+    root->io_parameter_ = std::make_shared<MemoryBlockIOParameter>();
+    return root;
+}
+
+std::unique_ptr<IndexNode>
+Pyramid::create_root_node(const GraphInterfaceParamPtr& child_graph_param,
+                          uint32_t index_min_size,
+                          const std::string& root_graph_type,
+                          GraphStorageTypes root_graph_storage_type) {
+    const bool multi_layer = root_graph_type == PYRAMID_ROOT_GRAPH_TYPE_MULTI_LAYER;
+    auto root_graph_param = multi_layer
+                                ? make_root_graph_param(child_graph_param, root_graph_storage_type)
+                                : child_graph_param;
+    auto root = std::make_unique<IndexNode>(
+        allocator_, root_graph_param, index_min_size, common_param_, child_graph_param);
+    if (multi_layer) {
+        root->enable_routing(make_route_graph_param(child_graph_param));
+    }
+    return root;
+}
+
+int
+Pyramid::draw_route_level(uint64_t max_degree) {
+    std::uniform_real_distribution<double> distribution(0.0, 1.0);
+    const auto sample =
+        std::max(distribution(level_generator_), std::numeric_limits<double>::min());
+    const double level_mult = 1.0 / std::log(static_cast<double>(max_degree));
+    return static_cast<int>(-std::log(sample) * level_mult) - 1;
+}
+
+Vector<int>
+Pyramid::sample_route_levels(const IndexNode& node, uint64_t count) {
+    Vector<int> levels(allocator_);
+    if (not node.has_routing()) {
+        return levels;
+    }
+    levels.resize(count, -1);
+    std::scoped_lock lock(random_generator_mutex_);
+    for (uint64_t i = 0; i < count; ++i) {
+        levels[i] = draw_route_level(node.graph_param_->max_degree_);
+    }
+    return levels;
+}
+
+void
+Pyramid::insert_route_graph_point(const Hierarchy& hierarchy,
+                                  const GraphInterfacePtr& graph,
+                                  const FlattenInterfacePtr& codes,
+                                  InnerIdType& entry_point,
+                                  InnerIdType inner_id,
+                                  const float* vector) {
+    if (graph->CheckIdExists(inner_id)) {
+        return;
+    }
+    LockGuard point_lock(points_mutex_, inner_id);
+    if (graph->TotalCount() == 0) {
+        graph->InsertNeighborsById(inner_id, Vector<InnerIdType>(allocator_));
+        entry_point = inner_id;
+        return;
+    }
+    InnerSearchParam param;
+    param.ep = entry_point;
+    param.ef = hierarchy.ef_construction;
+    param.topk = static_cast<int64_t>(param.ef);
+    param.search_mode = KNN_SEARCH;
+    param.hops_limit = std::numeric_limits<uint32_t>::max();
+    auto results = search_graph_for_add(graph, codes, inner_id, vector, param);
+    mutually_connect_new_element(
+        inner_id, results, graph, codes, points_mutex_, allocator_, hierarchy.alpha);
+}
+
+DistHeapPtr
+Pyramid::search_graph_for_add(const GraphInterfacePtr& graph,
+                              const FlattenInterfacePtr& codes,
+                              InnerIdType inner_id,
+                              const float* vector,
+                              InnerSearchParam& search_param) {
+    VisitedListGuard vl_guard(pool_.get());
+    if (vector != nullptr) {
+        return searcher_->Search(
+            graph, codes, vl_guard.get(), vector, search_param, (LabelTablePtr) nullptr, nullptr);
+    }
+
+    FlattenIdDistanceProvider distance_provider(codes, inner_id);
+    auto results =
+        searcher_->Search(graph, distance_provider, vl_guard.get(), search_param, nullptr, nullptr);
+    if (not search_param.find_duplicate || results->Empty()) {
+        return results;
+    }
+
+    const auto* data = results->GetData();
+    auto min_distance = data[0].first;
+    auto min_index = data[0].second;
+    for (uint32_t i = 1; i < results->Size(); ++i) {
+        if (data[i].first < min_distance) {
+            min_distance = data[i].first;
+            min_index = data[i].second;
+        }
+    }
+    if (search_param.duplicate_distance_threshold > 0.0F) {
+        if (min_distance <= search_param.duplicate_distance_threshold) {
+            search_param.duplicate_id = min_index;
+        }
+    } else if (codes->CompareVectors(inner_id, min_index)) {
+        search_param.duplicate_id = min_index;
+    }
+    return results;
+}
+
+void
+Pyramid::connect_cached_graph_point(InnerIdType inner_id,
+                                    const DistHeapPtr& candidates,
+                                    const GraphInterfacePtr& graph,
+                                    const FlattenInterfacePtr& codes,
+                                    float alpha) {
+    const auto max_degree = graph->MaximumDegree();
+
+    // Cache rows are all visible before parallel refinement starts. Never hold the current-row
+    // lock while acquiring a neighbor lock: two mutually selected rows would otherwise deadlock.
+    Vector<InnerIdType> forward_neighbors(allocator_);
+    {
+        LockGuard current_lock(points_mutex_, inner_id);
+        Vector<InnerIdType> existing_neighbors(allocator_);
+        graph->GetNeighbors(inner_id, existing_neighbors);
+
+        auto merged = std::make_shared<StandardHeap<true, false>>(allocator_, -1);
+        UnorderedSet<InnerIdType> seen(allocator_);
+        seen.reserve(existing_neighbors.size() + (candidates == nullptr ? 0 : candidates->Size()));
+        for (const auto neighbor : existing_neighbors) {
+            if (neighbor != inner_id && seen.emplace(neighbor).second) {
+                merged->Push(codes->ComputePairVectors(inner_id, neighbor), neighbor);
+            }
+        }
+        if (candidates != nullptr) {
+            while (not candidates->Empty()) {
+                const auto candidate = candidates->Top();
+                candidates->Pop();
+                if (candidate.second != inner_id && seen.emplace(candidate.second).second) {
+                    merged->Push(candidate.first, candidate.second);
+                }
+            }
+        }
+        if (not merged->Empty()) {
+            select_edges_by_heuristic(merged, max_degree, codes, allocator_, alpha);
+            forward_neighbors.reserve(merged->Size());
+            while (not merged->Empty()) {
+                forward_neighbors.push_back(merged->Top().second);
+                merged->Pop();
+            }
+        }
+        graph->InsertNeighborsById(inner_id, forward_neighbors);
+    }
+
+    Vector<InnerIdType> reverse_neighbors(allocator_);
+    for (const auto neighbor : forward_neighbors) {
+        LockGuard neighbor_lock(points_mutex_, neighbor);
+        reverse_neighbors.clear();
+        graph->GetNeighbors(neighbor, reverse_neighbors);
+        if (std::find(reverse_neighbors.begin(), reverse_neighbors.end(), inner_id) !=
+            reverse_neighbors.end()) {
+            continue;
+        }
+        if (reverse_neighbors.size() < max_degree) {
+            reverse_neighbors.push_back(inner_id);
+            graph->InsertNeighborsById(neighbor, reverse_neighbors);
+            continue;
+        }
+
+        auto reverse_candidates = std::make_shared<StandardHeap<true, false>>(allocator_, -1);
+        reverse_candidates->Push(codes->ComputePairVectors(neighbor, inner_id), inner_id);
+        for (const auto existing_neighbor : reverse_neighbors) {
+            reverse_candidates->Push(codes->ComputePairVectors(neighbor, existing_neighbor),
+                                     existing_neighbor);
+        }
+        select_edges_by_heuristic(reverse_candidates, max_degree, codes, allocator_, alpha);
+        reverse_neighbors.clear();
+        reverse_neighbors.reserve(reverse_candidates->Size());
+        while (not reverse_candidates->Empty()) {
+            reverse_neighbors.push_back(reverse_candidates->Top().second);
+            reverse_candidates->Pop();
+        }
+        graph->InsertNeighborsById(neighbor, reverse_neighbors);
+    }
+}
+
+void
+Pyramid::add_routed_point(const Hierarchy& hierarchy,
+                          IndexNode& node,
+                          InnerIdType inner_id,
+                          const float* vector,
+                          uint64_t ef_construction,
+                          bool use_self_as_entry,
+                          int sampled_level) {
+    const auto codes = construction_codes();
+
+    const auto insert_locked = [&]() {
+        const int current_top = static_cast<int>(node.routing_->graphs.size()) - 1;
+        const bool bottom_was_empty = node.graph_->TotalCount() == 0;
+        InnerIdType entry_point = node.entry_point_;
+
+        InnerSearchParam route_param;
+        route_param.ef = 1;
+        route_param.topk = 1;
+        route_param.search_mode = KNN_SEARCH;
+        route_param.hops_limit = std::numeric_limits<uint32_t>::max();
+        for (int route_level = current_top; route_level > sampled_level; --route_level) {
+            route_param.ep = entry_point;
+            auto result = search_graph_for_add(
+                node.routing_->graphs[route_level], codes, inner_id, vector, route_param);
+            if (not result->Empty()) {
+                entry_point = result->Top().second;
+            }
+        }
+
+        DistHeapPtr results = nullptr;
+        InnerSearchParam bottom_param;
+        bottom_param.ef = ef_construction == 0 ? hierarchy.ef_construction : ef_construction;
+        bottom_param.topk = static_cast<int64_t>(bottom_param.ef);
+        bottom_param.search_mode = KNN_SEARCH;
+        bottom_param.hops_limit = 10000;
+        if (support_duplicate_) {
+            bottom_param.find_duplicate = true;
+            bottom_param.duplicate_query_id = inner_id;
+        }
+
+        bool has_cached_neighbors = false;
+        if (use_self_as_entry) {
+            SharedLock point_lock(points_mutex_, inner_id);
+            has_cached_neighbors = node.graph_->GetNeighborSize(inner_id) > 0;
+        }
+        bottom_param.ep = use_self_as_entry && has_cached_neighbors ? inner_id : entry_point;
+        if (not bottom_was_empty) {
+            results = search_graph_for_add(node.graph_, codes, inner_id, vector, bottom_param);
+        }
+
+        if (support_duplicate_ && bottom_param.duplicate_id >= 0) {
+            std::unique_lock label_lock(label_lookup_mutex_);
+            node.graph_->SetDuplicateId(static_cast<InnerIdType>(bottom_param.duplicate_id),
+                                        inner_id);
+            return;
+        }
+
+        if (use_self_as_entry) {
+            connect_cached_graph_point(inner_id, results, node.graph_, codes, hierarchy.alpha);
+        } else {
+            LockGuard point_lock(points_mutex_, inner_id);
+            if (results == nullptr || results->Empty()) {
+                node.graph_->InsertNeighborsById(inner_id, Vector<InnerIdType>(allocator_));
+            } else {
+                mutually_connect_new_element(inner_id,
+                                             results,
+                                             node.graph_,
+                                             codes,
+                                             points_mutex_,
+                                             allocator_,
+                                             hierarchy.alpha);
+            }
+        }
+
+        for (int route_level = current_top + 1; route_level <= sampled_level; ++route_level) {
+            node.routing_->graphs.push_back(node.make_route_graph());
+        }
+        for (int route_level = 0; route_level <= sampled_level; ++route_level) {
+            insert_route_graph_point(hierarchy,
+                                     node.routing_->graphs[route_level],
+                                     codes,
+                                     entry_point,
+                                     inner_id,
+                                     vector);
+        }
+        if (bottom_was_empty || sampled_level > current_top) {
+            node.entry_point_ = inner_id;
+        }
+    };
+
+    std::shared_lock read_lock(node.mutex_);
+    const int current_top = static_cast<int>(node.routing_->graphs.size()) - 1;
+    const bool needs_structure_update =
+        node.graph_->TotalCount() == 0 || sampled_level > current_top;
+    if (not needs_structure_update) {
+        insert_locked();
+        return;
+    }
+    read_lock.unlock();
+    std::unique_lock write_lock(node.mutex_);
+    const int updated_top = static_cast<int>(node.routing_->graphs.size()) - 1;
+    const bool still_needs_structure_update =
+        node.graph_->TotalCount() == 0 || sampled_level > updated_top;
+    if (still_needs_structure_update) {
+        insert_locked();
+        return;
+    }
+    write_lock.unlock();
+    read_lock.lock();
+    insert_locked();
+}
+
+InnerIdType
+Pyramid::resolve_entry_point(const IndexNode& node,
+                             const VisitedListPtr& vl,
+                             const void* query,
+                             const FlattenInterfacePtr& codes,
+                             const ComputerInterfacePtr& computer,
+                             const InnerSearchParam& search_param,
+                             QueryContext& ctx) const {
+    InnerIdType entry_point = node.entry_point_;
+    if (not node.has_routing()) {
+        return entry_point;
+    }
+
+    InnerSearchParam route_param = search_param;
+    route_param.ef = 1;
+    route_param.topk = 1;
+    route_param.search_mode = KNN_SEARCH;
+    route_param.is_inner_id_allowed = nullptr;
+    route_param.consider_duplicate = false;
+    route_param.hops_limit = std::numeric_limits<uint32_t>::max();
+    ScopedDistancePhase route_phase(ctx, DistanceEvaluationPhase::ROUTING);
+    for (int64_t level = static_cast<int64_t>(node.routing_->graphs.size()) - 1; level >= 0;
+         --level) {
+        vl->Reset();
+        route_param.ep = entry_point;
+        auto result = searcher_->SearchWithPresetComputer(node.routing_->graphs[level],
+                                                          codes,
+                                                          vl,
+                                                          query,
+                                                          route_param,
+                                                          nullptr,
+                                                          &ctx,
+                                                          nullptr,
+                                                          computer);
+        if (not result->Empty()) {
+            entry_point = result->Top().second;
+        }
+    }
+    vl->Reset();
+    return entry_point;
+}
+
+void
+Pyramid::run_parallel_insertions(
+    const IndexNode& node,
+    uint64_t count,
+    const std::function<void(uint64_t index, int sampled_level)>& task) {
+    const auto sampled_levels = sample_route_levels(node, count);
+    const bool has_route_seed = not sampled_levels.empty();
+    uint64_t seed_index = 0;
+    if (has_route_seed) {
+        seed_index = static_cast<uint64_t>(
+            std::distance(sampled_levels.begin(),
+                          std::max_element(sampled_levels.begin(), sampled_levels.end())));
+        task(seed_index, sampled_levels[seed_index]);
+    }
+
+    Vector<std::future<void>> futures(allocator_);
+    futures.reserve(has_route_seed ? count - 1 : count);
+    std::exception_ptr submit_exception = nullptr;
+    try {
+        for (uint64_t index = 0; index < count; ++index) {
+            if (has_route_seed and index == seed_index) {
+                continue;
+            }
+            const int sampled_level =
+                has_route_seed ? sampled_levels[index] : std::numeric_limits<int>::min();
+            if (thread_pool_ != nullptr) {
+                futures.push_back(thread_pool_->GeneralEnqueue(task, index, sampled_level));
+            } else {
+                task(index, sampled_level);
+            }
+        }
+    } catch (...) {
+        submit_exception = std::current_exception();
+    }
+    drain_futures(futures, submit_exception);
 }
 
 std::vector<int64_t>
@@ -163,14 +612,14 @@ Pyramid::build_by_odescent(const DatasetPtr& base) {
             }
         }
     }
-    auto codes = has_precise_reorder() ? precise_codes_ : base_codes_;
+    auto codes = construction_codes();
 
     if (thread_pool_ != nullptr && hierarchies_.size() > 1) {
         auto build_flatten = ODescent::CreateBuildFlatten(codes, data_vectors, data_num);
         Vector<std::future<void>> futures(allocator_);
         for (const auto& [hname, h_ptr] : hierarchies_) {
-            auto* root_ptr = h_ptr->root.get();
-            futures.push_back(thread_pool_->GeneralEnqueue([&, codes, build_flatten, root_ptr]() {
+            auto* hierarchy = h_ptr.get();
+            futures.push_back(thread_pool_->GeneralEnqueue([&, codes, build_flatten, hierarchy]() {
                 ODescent builder(odescent_param_,
                                  codes,
                                  allocator_,
@@ -179,7 +628,7 @@ Pyramid::build_by_odescent(const DatasetPtr& base) {
                                  data_vectors,
                                  data_num,
                                  build_flatten);
-                root_ptr->Build(builder);
+                hierarchy->root->Build(builder);
             }));
         }
         for (auto& f : futures) {
@@ -212,52 +661,14 @@ Pyramid::KnnSearch(const DatasetPtr& query,
     const auto threshold = ParseSearchThreshold(parameters);
     auto parsed_param = PyramidSearchParameters::FromJson(parameters);
     ctx.rabitq_error_rate = parsed_param.rabitq_error_rate;
-    CHECK_ARGUMENT(k > 0, fmt::format("k({}) must be greater than 0", k));
-    CHECK_ARGUMENT(parsed_param.hierarchy_op == PyramidSearchParameters::HierarchyOp::SINGLE,
-                   "multi-hierarchy search (union/intersection) is not yet implemented");
-    auto ef_search_threshold = std::max<uint64_t>(AMPLIFICATION_FACTOR * k, 1000L);
-    CHECK_ARGUMENT(  // NOLINT
-        (1 <= parsed_param.ef_search) and (parsed_param.ef_search <= ef_search_threshold),
-        fmt::format(
-            "ef_search({}) must in range[1, {}]", parsed_param.ef_search, ef_search_threshold));
-
-    InnerSearchParam search_param;
-    search_param.ef = std::max<uint64_t>(parsed_param.ef_search, static_cast<uint64_t>(k));
-    search_param.radius = std::numeric_limits<float>::max();
-    search_param.topk = threshold.has_value() ? static_cast<int64_t>(search_param.ef) : k;
-    search_param.distance_threshold = threshold;
-    search_param.enable_reorder = use_reorder_;
-    search_param.search_mode = KNN_SEARCH;
-    search_param.parallel_search_thread_count = parsed_param.parallel_search_thread_count;
-    search_param.enable_rabitq_one_bit_search = parsed_param.has_rabitq_one_bit_search
-                                                    ? parsed_param.rabitq_one_bit_search
-                                                    : default_rabitq_one_bit_search_;
-
-    // Keep the same contract as HGraph: a useful hop cap must exceed ef_search.
-    if (static_cast<uint64_t>(parsed_param.hops_limit) <= parsed_param.ef_search) {
-        search_param.hops_limit = std::numeric_limits<uint32_t>::max();
-        if (parsed_param.hops_limit != std::numeric_limits<uint32_t>::max()) {
-            logger::warn(
-                fmt::format("hops_limit({}) is not greater than ef_search({}), ignoring hops_limit",
-                            parsed_param.hops_limit,
-                            parsed_param.ef_search));
-        }
-    } else {
-        search_param.hops_limit = parsed_param.hops_limit;
-    }
-    if (this->support_duplicate_) {
-        search_param.consider_duplicate = true;
-    }
-
-    if (parsed_param.enable_time_record) {
-        search_param.time_cost = std::make_shared<Timer>();
-        search_param.time_cost->SetThreshold(parsed_param.timeout_ms);
-    }
-
-    search_param.is_inner_id_allowed = this->create_search_filter(filter);
+    auto search_param = this->create_knn_search_param(parsed_param, k, filter, threshold);
+    const auto reorder_candidate_limit =
+        get_reorder_candidate_limit(use_reorder_, parsed_param.topk_factor, k, search_param.ef);
     const bool collect_rabitq_lower_bounds = search_param.enable_rabitq_one_bit_search and
                                              use_reorder_ and
                                              base_codes_->SupportSplitCodeStorage();
+    std::string hierarchy_name =
+        parsed_param.hierarchies.empty() ? "" : parsed_param.hierarchies[0];
     DistanceRecordVector rabitq_lower_bound_candidates(allocator_);
     std::mutex rabitq_lower_bound_mutex;
     SearchFunc search_func = [&](const IndexNode* node, const VisitedListPtr& vl) {
@@ -279,12 +690,12 @@ Pyramid::KnnSearch(const DatasetPtr& query,
         return result;
     };
 
-    std::string hierarchy_name =
-        parsed_param.hierarchies.empty() ? "" : parsed_param.hierarchies[0];
     auto result =
         this->search_impl(query,
                           search_func,
                           search_param,
+                          k,
+                          reorder_candidate_limit,
                           ctx,
                           hierarchy_name,
                           collect_rabitq_lower_bounds ? &rabitq_lower_bound_candidates : nullptr);
@@ -330,6 +741,8 @@ Pyramid::RangeSearch(const DatasetPtr& query,
     const bool collect_rabitq_lower_bounds = search_param.enable_rabitq_one_bit_search and
                                              use_reorder_ and
                                              base_codes_->SupportSplitCodeStorage();
+    std::string hierarchy_name =
+        parsed_param.hierarchies.empty() ? "" : parsed_param.hierarchies[0];
     DistanceRecordVector rabitq_lower_bound_candidates(allocator_);
     std::mutex rabitq_lower_bound_mutex;
     SearchFunc search_func = [&](const IndexNode* node, const VisitedListPtr& vl) {
@@ -351,12 +764,12 @@ Pyramid::RangeSearch(const DatasetPtr& query,
         return result;
     };
 
-    std::string hierarchy_name =
-        parsed_param.hierarchies.empty() ? "" : parsed_param.hierarchies[0];
     auto result =
         this->search_impl(query,
                           search_func,
                           search_param,
+                          search_param.topk,
+                          std::nullopt,
                           ctx,
                           hierarchy_name,
                           collect_rabitq_lower_bounds ? &rabitq_lower_bound_candidates : nullptr);
@@ -487,10 +900,17 @@ Pyramid::SearchWithRequest(const SearchRequest& request) const {
 
     std::string hierarchy_name =
         parsed_param.hierarchies.empty() ? "" : parsed_param.hierarchies[0];
+    const auto final_topk = is_knn ? request.topk_ : search_param.topk;
+    const auto reorder_candidate_limit =
+        is_knn ? get_reorder_candidate_limit(
+                     use_reorder_, parsed_param.topk_factor, request.topk_, search_param.ef)
+               : std::optional<int64_t>{};
     auto result =
         this->search_impl(query,
                           search_func,
                           search_param,
+                          final_topk,
+                          reorder_candidate_limit,
                           ctx,
                           hierarchy_name,
                           collect_rabitq_lower_bounds ? &rabitq_lower_bound_candidates : nullptr);
@@ -526,6 +946,8 @@ DatasetPtr
 Pyramid::search_impl(const DatasetPtr& query,
                      const SearchFunc& search_func,
                      InnerSearchParam& search_param,
+                     int64_t final_topk,
+                     std::optional<int64_t> reorder_candidate_limit,
                      QueryContext& ctx,
                      const std::string& hierarchy_name,
                      const DistanceRecordVector* rabitq_lower_bound_candidates) const {
@@ -557,19 +979,25 @@ Pyramid::search_impl(const DatasetPtr& query,
     }
 
     if (use_reorder_) {
-        search_result = this->reorder_->Reorder(search_result,
-                                                query->GetFloat32Vectors(),
-                                                search_param.topk,
-                                                ctx,
-                                                nullptr,
-                                                rabitq_lower_bound_candidates);
+        if (reorder_candidate_limit.has_value()) {
+            while (search_result->Size() > reorder_candidate_limit.value()) {
+                search_result->Pop();
+            }
+        }
+        search_result = this->reorder_->Reorder(
+            search_result,
+            query->GetFloat32Vectors(),
+            reorder_candidate_limit.has_value() ? final_topk : search_param.topk,
+            ctx,
+            nullptr,
+            rabitq_lower_bound_candidates);
     }
 
     if (search_result->Empty()) {
         return DatasetImpl::MakeEmptyDataset();
     }
 
-    while (not search_result->Empty() && (search_result->Size() > search_param.topk ||
+    while (not search_result->Empty() && (search_result->Size() > final_topk ||
                                           search_result->Top().first > search_param.radius)) {
         search_result->Pop();
     }
@@ -607,6 +1035,47 @@ Pyramid::GetNumberRemoved() const {
     return delete_count_.load();
 }
 
+uint64_t
+Pyramid::GetMemoryUsage() const {
+    auto detail = GetMemoryUsageDetail();
+    uint64_t memory = sizeof(Pyramid);
+    for (const auto& [name, usage] : detail) {
+        (void)name;
+        memory += usage;
+    }
+    return memory;
+}
+
+std::unordered_map<std::string, uint64_t>
+Pyramid::GetMemoryUsageDetail() const {
+    std::shared_lock resize_lock(resize_mutex_);
+    std::unordered_map<std::string, uint64_t> memory_usage;
+    memory_usage["points_mutex"] = points_mutex_ == nullptr ? 0 : points_mutex_->GetMemoryUsage();
+    memory_usage["pool"] = pool_ == nullptr ? 0 : pool_->GetMemoryUsage();
+    memory_usage["label_table"] = label_table_ == nullptr ? 0 : label_table_->GetMemoryUsage();
+    memory_usage["base_codes"] = base_codes_ == nullptr ? 0 : base_codes_->GetMemoryUsage();
+    if (precise_codes_ != nullptr) {
+        memory_usage["precise_codes"] = precise_codes_->GetMemoryUsage();
+    }
+    if (raw_vector_ != nullptr) {
+        memory_usage["raw_vector"] = raw_vector_->GetMemoryUsage();
+    }
+    uint64_t hierarchy_memory = hierarchies_.bucket_count() *
+                                (sizeof(decltype(hierarchies_)::value_type) + sizeof(uint32_t));
+    uint64_t route_memory = 0;
+    for (const auto& [name, hierarchy] : hierarchies_) {
+        hierarchy_memory +=
+            name.capacity() + 1 + sizeof(Hierarchy) + hierarchy->name.capacity() + 1;
+        hierarchy_memory += hierarchy->no_build_levels.capacity() * sizeof(int32_t);
+        const auto [node_memory, node_routing_memory] = hierarchy->root->get_memory_usage_detail();
+        hierarchy_memory += node_memory - node_routing_memory;
+        route_memory += node_routing_memory;
+    }
+    memory_usage["hierarchies"] = hierarchy_memory;
+    memory_usage["root_route_graphs"] = route_memory;
+    return memory_usage;
+}
+
 uint32_t
 Pyramid::Remove(const std::vector<int64_t>& ids, RemoveMode mode) {
     if (mode != RemoveMode::MARK_REMOVE) {
@@ -639,7 +1108,8 @@ Pyramid::Serialize(StreamWriter& writer) const {
             h_ptr->root->Serialize(writer);
         }
     } else {
-        hierarchies_.at("")->root->Serialize(writer);
+        const auto& hierarchy = *hierarchies_.at("");
+        hierarchy.root->Serialize(writer);
     }
 
     if (store_paths_) {
@@ -756,7 +1226,8 @@ Pyramid::serialize_hierarchies(StreamWriter& writer) const {
             h_ptr->root->Serialize(writer);
         }
     } else {
-        hierarchies_.at("")->root->Serialize(writer);
+        const auto& hierarchy = *hierarchies_.at("");
+        hierarchy.root->Serialize(writer);
     }
 }
 
@@ -855,7 +1326,6 @@ Pyramid::read_streaming_body(StreamReader& reader, const MetadataPtr& metadata) 
             throw VsagException(ErrorType::INVALID_ARGUMENT, message);
         }
     }
-
     bool loaded_label_table = false;
     bool loaded_base_codes = false;
     bool loaded_precise_codes = false;
@@ -990,13 +1460,15 @@ Pyramid::Deserialize(StreamReader& reader) {
     }
     auto max_capacity = basic_info["max_capacity"].GetInt();
     auto param_json = JsonType::Parse(basic_info[INDEX_PARAM].GetString());
-    const bool serialized_store_paths = param_json.Contains(PYRAMID_STORE_PATHS_KEY) &&
-                                        param_json[PYRAMID_STORE_PATHS_KEY].GetBool();
-    if (serialized_store_paths != store_paths_) {
-        throw VsagException(ErrorType::READ_ERROR,
-                            "serialized Pyramid store_paths does not match config");
+    auto index_param = std::make_shared<PyramidParameters>();
+    index_param->FromJson(param_json);
+    if (not this->create_param_ptr_->CheckCompatibility(index_param)) {
+        auto message = fmt::format("Pyramid index parameter not match, current: {}, new: {}",
+                                   this->create_param_ptr_->ToString(),
+                                   index_param->ToString());
+        logger::error(message);
+        throw VsagException(ErrorType::INVALID_ARGUMENT, message);
     }
-
     BufferStreamReader buffer_reader(
         &reader, std::numeric_limits<uint64_t>::max(), this->allocator_);
 
@@ -1071,148 +1543,148 @@ Pyramid::ExportModel(const IndexCommonParam& param) const {
 
 std::vector<int64_t>
 Pyramid::Add(const DatasetPtr& base) {
+    auto batch = prepare_add_batch(base);
+    insert_add_batch(base, batch);
+    return batch.failed_ids;
+}
+
+Pyramid::AddBatch
+Pyramid::prepare_add_batch(const DatasetPtr& base) {
     const int64_t data_num = base->GetNumElements();
-    const auto* data_vectors = base->GetFloat32Vectors();
     const auto* data_ids = base->GetIds();
     const auto* source_ids = base->GetSourceID();
-    std::vector<int64_t> failed_ids;
-    Vector<int64_t> data_biases(allocator_);
-    Vector<InnerIdType> accepted_inner_ids(allocator_);
-    int64_t local_cur_element_count = 0;
-    {
-        std::lock_guard lock(cur_element_count_mutex_);
-        local_cur_element_count = cur_element_count_;
-        auto new_capacity = max_capacity_;
-        if (max_capacity_ == 0) {
-            new_capacity = std::max(INIT_CAPACITY, data_num);
-        } else if (max_capacity_ < data_num + cur_element_count_) {
-            new_capacity = std::min(MAX_CAPACITY_EXTEND, max_capacity_);
-            new_capacity = std::max(data_num + cur_element_count_ - max_capacity_, new_capacity) +
-                           max_capacity_;
-        }
-        bool base_storage_resized = false;
-        bool precise_storage_resized = false;
-        bool raw_storage_resized = false;
-        if (new_capacity > max_capacity_) {
-            base_storage_resized = new_capacity > static_cast<int64_t>(base_codes_->max_capacity_);
-            precise_storage_resized =
-                not has_precise_reorder() ||
-                new_capacity > static_cast<int64_t>(precise_codes_->max_capacity_);
-            raw_storage_resized = raw_vector_ == nullptr ||
-                                  new_capacity > static_cast<int64_t>(raw_vector_->max_capacity_);
-            resize(new_capacity);
-        }
+    AddBatch batch(allocator_);
+    std::lock_guard lock(cur_element_count_mutex_);
+    batch.first_inner_id = cur_element_count_;
 
-        data_biases.reserve(data_num);
-        if (store_paths_) {
-            accepted_inner_ids.reserve(data_num);
-        }
-        for (int64_t i = 0; i < data_num; ++i) {
-            if (not label_table_->CheckLabel(data_ids[i])) {
-                const auto inner_id =
-                    static_cast<InnerIdType>(local_cur_element_count + data_biases.size());
-                label_table_->Insert(inner_id, data_ids[i]);
-                if (source_ids != nullptr) {
-                    label_table_->InsertSourceId(inner_id, source_ids[i]);
-                }
-                data_biases.push_back(i);
-                if (store_paths_) {
-                    accepted_inner_ids.push_back(inner_id);
-                }
-            } else {
-                logger::warn("Label {} already exists, skip adding.", data_ids[i]);
-                failed_ids.push_back(data_ids[i]);
-            }
-        }
-
-        if (local_cur_element_count == 0 and not data_biases.empty()) {
-            this->Train(base);
-        }
-
-        const auto encode_range = [this, data_vectors, local_cur_element_count, &data_biases](
-                                      uint64_t begin, uint64_t end) {
-            for (uint64_t offset = begin; offset < end; ++offset) {
-                const auto* vector = data_vectors + dim_ * data_biases[offset];
-                const auto inner_id = static_cast<InnerIdType>(local_cur_element_count + offset);
-                base_codes_->InsertVector(vector, inner_id);
-                if (has_precise_reorder()) {
-                    precise_codes_->InsertVector(vector, inner_id);
-                }
-                if (raw_vector_ != nullptr) {
-                    raw_vector_->InsertVector(vector, inner_id);
-                }
-            }
-        };
-        const auto supports_parallel_encode = [](const FlattenInterfacePtr& codes) {
-            const auto name = codes->GetQuantizerName();
-            return codes->InMemory() &&
-                   (name == QUANTIZATION_TYPE_VALUE_FP32 ||
-                    name == QUANTIZATION_TYPE_VALUE_RABITQ || name == QUANTIZATION_TYPE_VALUE_SQ8);
-        };
-        const bool use_parallel_encode =
-            local_cur_element_count == 0 && thread_pool_ != nullptr && build_thread_count_ > 1 &&
-            data_biases.size() > 1 && supports_parallel_encode(base_codes_) &&
-            (not has_precise_reorder() || supports_parallel_encode(precise_codes_)) &&
-            (raw_vector_ == nullptr || supports_parallel_encode(raw_vector_)) &&
-            base_storage_resized && precise_storage_resized && raw_storage_resized;
-        if (use_parallel_encode) {
-            const uint64_t worker_count =
-                std::min<uint64_t>(build_thread_count_, data_biases.size());
-            const uint64_t block_size = (data_biases.size() + worker_count - 1) / worker_count;
-            Vector<std::future<void>> futures(allocator_);
-            futures.reserve(worker_count);
-            const auto wait_futures = [&futures]() {
-                std::exception_ptr first_exception = nullptr;
-                for (auto& future : futures) {
-                    try {
-                        future.get();
-                    } catch (...) {
-                        if (not first_exception) {
-                            first_exception = std::current_exception();
-                        }
-                    }
-                }
-                if (first_exception) {
-                    std::rethrow_exception(first_exception);
-                }
-            };
-            try {
-                for (uint64_t begin = 0; begin < data_biases.size(); begin += block_size) {
-                    const uint64_t end = std::min<uint64_t>(begin + block_size, data_biases.size());
-                    futures.push_back(thread_pool_->GeneralEnqueue(
-                        [encode_range, begin, end]() { encode_range(begin, end); }));
-                }
-            } catch (...) {
-                const auto enqueue_exception = std::current_exception();
-                try {
-                    wait_futures();
-                } catch (...) {
-                }
-                std::rethrow_exception(enqueue_exception);
-            }
-            wait_futures();
-        } else {
-            encode_range(0, data_biases.size());
-        }
-        cur_element_count_ += static_cast<int64_t>(data_biases.size());
+    auto new_capacity = max_capacity_;
+    if (max_capacity_ == 0) {
+        new_capacity = std::max(INIT_CAPACITY, data_num);
+    } else if (max_capacity_ < data_num + cur_element_count_) {
+        new_capacity = std::min(MAX_CAPACITY_EXTEND, max_capacity_);
+        new_capacity =
+            std::max(data_num + cur_element_count_ - max_capacity_, new_capacity) + max_capacity_;
     }
-    std::shared_lock<std::shared_mutex> lock(resize_mutex_);
+    batch.storage_preallocated =
+        batch.first_inner_id == 0 and
+        new_capacity > static_cast<int64_t>(base_codes_->max_capacity_) and
+        (not has_precise_reorder() or
+         new_capacity > static_cast<int64_t>(precise_codes_->max_capacity_)) and
+        (raw_vector_ == nullptr or new_capacity > static_cast<int64_t>(raw_vector_->max_capacity_));
+    if (new_capacity > max_capacity_) {
+        resize(new_capacity);
+    }
 
+    batch.input_indices.reserve(data_num);
+    for (int64_t input_index = 0; input_index < data_num; ++input_index) {
+        if (not label_table_->CheckLabel(data_ids[input_index])) {
+            const auto inner_id =
+                static_cast<InnerIdType>(batch.first_inner_id + batch.input_indices.size());
+            label_table_->Insert(inner_id, data_ids[input_index]);
+            if (source_ids != nullptr) {
+                label_table_->InsertSourceId(inner_id, source_ids[input_index]);
+            }
+            batch.input_indices.push_back(input_index);
+        } else {
+            logger::warn("Label {} already exists, skip adding.", data_ids[input_index]);
+            batch.failed_ids.push_back(data_ids[input_index]);
+        }
+    }
+
+    if (batch.first_inner_id == 0 and not batch.input_indices.empty()) {
+        Train(base);
+    }
+    encode_add_batch(base, batch);
+    cur_element_count_ += static_cast<int64_t>(batch.input_indices.size());
+    return batch;
+}
+
+void
+Pyramid::encode_add_batch(const DatasetPtr& base, const AddBatch& batch) {
+    std::shared_lock<std::shared_mutex> storage_lock(resize_mutex_);
+    const auto required_capacity =
+        static_cast<uint64_t>(batch.first_inner_id) + batch.input_indices.size();
+    CHECK_ARGUMENT(base_codes_->max_capacity_ >= required_capacity,
+                   "base codes capacity is smaller than the encoded id range");
+    if (has_precise_reorder()) {
+        CHECK_ARGUMENT(precise_codes_->max_capacity_ >= required_capacity,
+                       "precise codes capacity is smaller than the encoded id range");
+    }
+    if (raw_vector_ != nullptr) {
+        CHECK_ARGUMENT(raw_vector_->max_capacity_ >= required_capacity,
+                       "raw vector capacity is smaller than the encoded id range");
+    }
+
+    const auto* data_vectors = base->GetFloat32Vectors();
+    const auto encode_range = [this, data_vectors, &batch](uint64_t begin, uint64_t end) {
+        for (uint64_t offset = begin; offset < end; ++offset) {
+            const auto* vector = data_vectors + dim_ * batch.input_indices[offset];
+            const auto inner_id = static_cast<InnerIdType>(batch.first_inner_id + offset);
+            base_codes_->InsertVector(vector, inner_id);
+            if (has_precise_reorder()) {
+                precise_codes_->InsertVector(vector, inner_id);
+            }
+            if (raw_vector_ != nullptr) {
+                raw_vector_->InsertVector(vector, inner_id);
+            }
+        }
+    };
+    const auto supports_parallel_encode = [](const FlattenInterfacePtr& codes) {
+        const auto name = codes->GetQuantizerName();
+        return codes->InMemory() &&
+               (name == QUANTIZATION_TYPE_VALUE_FP32 || name == QUANTIZATION_TYPE_VALUE_RABITQ ||
+                name == QUANTIZATION_TYPE_VALUE_SQ8);
+    };
+    const bool stores_support_parallel_encode =
+        supports_parallel_encode(base_codes_) &&
+        (not has_precise_reorder() || supports_parallel_encode(precise_codes_)) &&
+        (raw_vector_ == nullptr || supports_parallel_encode(raw_vector_));
+    if (batch.storage_preallocated and stores_support_parallel_encode and thread_pool_ != nullptr &&
+        build_thread_count_ > 1 and batch.input_indices.size() > 1) {
+        const uint64_t count = batch.input_indices.size();
+        const uint64_t worker_count = std::min<uint64_t>(build_thread_count_, count);
+        const uint64_t block_size = (count + worker_count - 1) / worker_count;
+        Vector<std::future<void>> futures(allocator_);
+        futures.reserve(worker_count);
+        std::exception_ptr submit_exception = nullptr;
+        try {
+            for (uint64_t worker = 0; worker < worker_count; ++worker) {
+                const uint64_t begin = worker * block_size;
+                const uint64_t end = std::min<uint64_t>(begin + block_size, count);
+                if (begin < end) {
+                    futures.push_back(thread_pool_->GeneralEnqueue(encode_range, begin, end));
+                }
+            }
+        } catch (...) {
+            submit_exception = std::current_exception();
+        }
+        drain_futures(futures, submit_exception);
+    } else {
+        encode_range(0, batch.input_indices.size());
+    }
+}
+
+void
+Pyramid::insert_add_batch(const DatasetPtr& base, const AddBatch& batch) {
+    std::shared_lock<std::shared_mutex> storage_lock(resize_mutex_);
+    const auto* data_vectors = base->GetFloat32Vectors();
     for (const auto& [hname, h_ptr] : hierarchies_) {
         const auto* hpath = base->GetPaths(hname);
         if (hpath != nullptr) {
-            if (store_paths_ and not accepted_inner_ids.empty()) {
+            if (store_paths_ and not batch.input_indices.empty()) {
                 auto writer = h_ptr->path_store->AcquireWriter();
-                writer.Prepare(static_cast<uint64_t>(accepted_inner_ids.back()) + 1,
-                               data_biases.size());
-                for (uint64_t offset = 0; offset < data_biases.size(); ++offset) {
-                    writer.Insert(accepted_inner_ids[offset], hpath[data_biases[offset]]);
+                const auto required_capacity =
+                    static_cast<uint64_t>(batch.first_inner_id) + batch.input_indices.size();
+                writer.Prepare(required_capacity, batch.input_indices.size());
+                for (uint64_t offset = 0; offset < batch.input_indices.size(); ++offset) {
+                    const auto inner_id = static_cast<InnerIdType>(batch.first_inner_id + offset);
+                    writer.Insert(inner_id, hpath[batch.input_indices[offset]]);
                 }
             }
-            add_to_hierarchy(*h_ptr, data_vectors, hpath, data_biases, local_cur_element_count);
+            add_to_hierarchy(
+                *h_ptr, data_vectors, hpath, batch.input_indices, batch.first_inner_id);
         }
     }
-    return failed_ids;
 }
 
 void
@@ -1231,6 +1703,9 @@ Pyramid::resize(int64_t new_max_capacity) {
         raw_vector_->Resize(new_max_capacity);
     }
     points_mutex_->Resize(new_max_capacity);
+    for (const auto& [name, hierarchy] : hierarchies_) {
+        hierarchy->root->resize_graph(static_cast<InnerIdType>(new_max_capacity));
+    }
     max_capacity_ = new_max_capacity;
 }
 
@@ -1353,6 +1828,7 @@ build_default_pyramid_param(const JsonType& external_param) {
     json[EF_CONSTRUCTION_KEY].SetInt(400);
     json[NO_BUILD_LEVELS].SetJson(JsonType::Parse("[]"));
     json[INDEX_MIN_SIZE].SetInt(0);
+    json[PYRAMID_ROOT_GRAPH_TYPE].SetString(PYRAMID_ROOT_GRAPH_TYPE_SINGLE_LAYER);
     json[SUPPORT_DUPLICATE].SetBool(false);
     json[PYRAMID_STORE_PATHS_KEY].SetBool(false);
     return json;
@@ -1475,6 +1951,8 @@ Pyramid::CheckAndMappingExternalParam(const JsonType& external_param,
             inner_json[GRAPH_KEY][ODESCENT_PARAMETER_NEIGHBOR_SAMPLE_RATE].SetJson(value);
         } else if (key == PYRAMID_INDEX_MIN_SIZE) {
             inner_json[INDEX_MIN_SIZE].SetJson(value);
+        } else if (key == PYRAMID_ROOT_GRAPH_TYPE) {
+            inner_json[PYRAMID_ROOT_GRAPH_TYPE].SetJson(value);
         } else if (key == PYRAMID_SUPPORT_DUPLICATE) {
             inner_json[SUPPORT_DUPLICATE].SetJson(value);
             inner_json[GRAPH_KEY][SUPPORT_DUPLICATE].SetJson(value);
@@ -1491,6 +1969,7 @@ Pyramid::CheckAndMappingExternalParam(const JsonType& external_param,
     }
     auto pyramid_params = std::make_shared<PyramidParameters>();
     pyramid_params->FromJson(inner_json);
+    validate_pyramid_external_root_graph_config(external_param, *pyramid_params);
     return pyramid_params;
 }
 
@@ -1507,8 +1986,7 @@ Pyramid::Train(const DatasetPtr& base) {
 std::vector<int64_t>
 Pyramid::Build(const DatasetPtr& base) {
     CHECK_ARGUMENT(GetNumElements() == 0, "index is not empty");
-    int64_t data_num = base->GetNumElements();
-
+    const auto data_num = base->GetNumElements();
     if (graph_type_ == GRAPH_TYPE_VALUE_NSW && not support_duplicate_ && has_loaded_cache() &&
         base->GetSourceID() != nullptr) {
         UnorderedSet<std::string> source_ids(allocator_);
@@ -1531,50 +2009,118 @@ Pyramid::Build(const DatasetPtr& base) {
         logger::warn(
             "[pyramid_build_cache] duplicate source_id or label; falling back to cold build");
     }
-
-    this->Train(base);
-    std::vector<int64_t> ret;
-
-    if (thread_pool_ != nullptr && hierarchies_.size() > 1) {
-        Vector<std::future<void>> futures(allocator_);
-        for (const auto& [hname, h_ptr] : hierarchies_) {
-            const auto* hpath = base->GetPaths(hname);
-            if (hpath != nullptr) {
-                futures.push_back(
-                    thread_pool_->GeneralEnqueue([&h = *h_ptr, hpath, data_num, this]() {
-                        populate_path_tree(h, hpath, data_num);
-                    }));
-            }
-        }
-        for (auto& f : futures) {
-            f.get();
-        }
-    } else {
-        for (const auto& [hname, h_ptr] : hierarchies_) {
-            const auto* hpath = base->GetPaths(hname);
-            if (hpath != nullptr) {
-                populate_path_tree(*h_ptr, hpath, data_num);
-            }
-        }
-    }
-
+    populate_hierarchy_trees(base);
     if (graph_type_ == GRAPH_TYPE_VALUE_NSW) {
-        ret = this->Add(base);
-    } else {
-        ret = this->build_by_odescent(base);
+        return this->Add(base);
     }
-    return ret;
+    this->Train(base);
+    return this->build_by_odescent(base);
 }
 
 void
-Pyramid::add_one_point(const Hierarchy& h,
+Pyramid::add_graph_point(const Hierarchy& hierarchy,
+                         IndexNode& node,
+                         InnerIdType inner_id,
+                         const float* vector,
+                         uint64_t ef_construction,
+                         bool use_self_as_entry,
+                         int sampled_route_level) {
+    if (node.has_routing()) {
+        add_routed_point(hierarchy,
+                         node,
+                         inner_id,
+                         vector,
+                         ef_construction,
+                         use_self_as_entry,
+                         sampled_route_level);
+        return;
+    }
+
+    add_bottom_graph_point(hierarchy, node, inner_id, vector, ef_construction, use_self_as_entry);
+}
+
+void
+Pyramid::add_bottom_graph_point(const Hierarchy& hierarchy,
+                                IndexNode& node,
+                                InnerIdType inner_id,
+                                const float* vector,
+                                uint64_t ef_construction,
+                                bool use_self_as_entry) {
+    std::unique_lock graph_lock(node.mutex_);
+    if (node.graph_->TotalCount() == 0) {
+        node.graph_->InsertNeighborsById(inner_id, Vector<InnerIdType>(allocator_));
+        node.entry_point_ = inner_id;
+    } else {
+        const uint64_t effective_ef =
+            ef_construction == 0 ? hierarchy.ef_construction : ef_construction;
+        InnerSearchParam search_param;
+        search_param.ef = effective_ef;
+        search_param.topk = static_cast<int64_t>(effective_ef);
+        search_param.search_mode = KNN_SEARCH;
+        search_param.hops_limit = 10000;
+        if (support_duplicate_) {
+            search_param.find_duplicate = true;
+            search_param.duplicate_query_id = inner_id;
+        }
+        auto codes = construction_codes();
+        bool update_entry_point;
+        {
+            std::scoped_lock<std::mutex> random_lock(random_generator_mutex_);
+            update_entry_point = is_update_entry_point(node.graph_->TotalCount());
+        }
+        bool has_cached_neighbors = false;
+        if (use_self_as_entry) {
+            SharedLock point_lock(points_mutex_, inner_id);
+            has_cached_neighbors = node.graph_->GetNeighborSize(inner_id) > 0;
+        }
+        search_param.ep = use_self_as_entry && has_cached_neighbors ? inner_id : node.entry_point_;
+        if (not update_entry_point) {
+            graph_lock.unlock();
+        }
+
+        auto results = search_graph_for_add(node.graph_, codes, inner_id, vector, search_param);
+        if (this->support_duplicate_ && search_param.duplicate_id >= 0) {
+            std::unique_lock lock(this->label_lookup_mutex_);
+            node.graph_->SetDuplicateId(static_cast<InnerIdType>(search_param.duplicate_id),
+                                        inner_id);
+            return;
+        }
+        if (use_self_as_entry) {
+            connect_cached_graph_point(inner_id, results, node.graph_, codes, hierarchy.alpha);
+        } else {
+            mutually_connect_new_element(
+                inner_id, results, node.graph_, codes, points_mutex_, allocator_, hierarchy.alpha);
+        }
+        if (update_entry_point) {
+            node.entry_point_ = inner_id;
+        }
+    }
+}
+
+void
+Pyramid::add_one_point(const Hierarchy& hierarchy,
                        IndexNode* node,
                        InnerIdType inner_id,
                        const float* vector,
                        uint64_t ef_construction,
-                       bool use_self_as_entry) {
-    std::unique_lock graph_lock(node->mutex_);
+                       bool use_self_as_entry,
+                       int sampled_route_level) {
+    {
+        std::shared_lock graph_lock(node->mutex_);
+        if (node->status_ == IndexNode::Status::GRAPH) {
+            graph_lock.unlock();
+            add_graph_point(hierarchy,
+                            *node,
+                            inner_id,
+                            vector,
+                            ef_construction,
+                            use_self_as_entry,
+                            sampled_route_level);
+            return;
+        }
+    }
 
+    std::unique_lock graph_lock(node->mutex_);
     if (node->status_ == IndexNode::Status::NO_INDEX) {
         node->Init();
         Vector<InnerIdType>(allocator_).swap(node->ids_);
@@ -1587,14 +2133,18 @@ Pyramid::add_one_point(const Hierarchy& h,
         }
 
         // Keep the FLAT node intact until the replacement graph is complete.
-        IndexNode graph_node(allocator_, node->graph_param_, node->index_min_size_);
+        IndexNode graph_node(allocator_,
+                             node->graph_param_,
+                             node->index_min_size_,
+                             node->common_param_,
+                             node->child_graph_param_);
         graph_node.level_ = node->level_;
         graph_node.ids_ = node->ids_;
         graph_node.Init();
 
         if (base_codes_->SupportSplitCodeStorage() and raw_vector_ == nullptr) {
             for (const auto id : node->ids_) {
-                add_one_point(h, &graph_node, id, nullptr);
+                add_one_point(hierarchy, &graph_node, id, nullptr);
             }
         } else {
             auto codes = decodable_codes();
@@ -1610,7 +2160,7 @@ Pyramid::add_one_point(const Hierarchy& h,
                     throw VsagException(ErrorType::INTERNAL_ERROR,
                                         "Pyramid graph promotion requires decodable vectors");
                 }
-                add_one_point(h, &graph_node, id, decoded_vector.data());
+                add_one_point(hierarchy, &graph_node, id, decoded_vector.data());
             }
         }
 
@@ -1622,98 +2172,14 @@ Pyramid::add_one_point(const Hierarchy& h,
         return;
     }
 
-    if (node->graph_->TotalCount() == 0) {
-        node->graph_->InsertNeighborsById(inner_id, Vector<InnerIdType>(allocator_));
-        node->entry_point_ = inner_id;
-    } else {
-        const uint64_t effective_ef = ef_construction == 0 ? h.ef_construction : ef_construction;
-        InnerSearchParam search_param;
-        search_param.ef = effective_ef;
-        search_param.topk = static_cast<int64_t>(effective_ef);
-        search_param.search_mode = KNN_SEARCH;
-        search_param.hops_limit = 10000;
-        if (support_duplicate_) {
-            search_param.find_duplicate = true;
-            search_param.duplicate_query_id = inner_id;
-        }
-        auto codes = has_precise_reorder() ? precise_codes_ : base_codes_;
-        bool update_entry_point;
-        {
-            std::scoped_lock<std::mutex> entry_point_lock(entry_point_mutex_);
-            update_entry_point = is_update_entry_point(node->graph_->TotalCount());
-        }
-        Vector<InnerIdType> cached_neighbors(allocator_);
-        node->graph_->GetNeighbors(inner_id, cached_neighbors);
-        search_param.ep =
-            (use_self_as_entry && not cached_neighbors.empty()) ? inner_id : node->entry_point_;
-        if (not update_entry_point) {
-            graph_lock.unlock();
-        }
-
-        VisitedListGuard vl_guard(pool_.get());
-        const VisitedListPtr& vl = vl_guard.get();
-        DistHeapPtr results;
-        if (vector != nullptr) {
-            results = searcher_->Search(
-                node->graph_, codes, vl, vector, search_param, (LabelTablePtr) nullptr, nullptr);
-        } else {
-            FlattenIdDistanceProvider distance_provider(base_codes_, inner_id);
-            results = searcher_->Search(
-                node->graph_, distance_provider, vl, search_param, nullptr, nullptr);
-            if (support_duplicate_ and not results->Empty()) {
-                // StandardHeap exposes heap storage rather than sorted output, so inspect every
-                // candidate to find the actual nearest neighbor for duplicate detection.
-                const auto* data = results->GetData();
-                auto min_distance = data[0].first;
-                auto min_index = data[0].second;
-                for (uint32_t i = 1; i < results->Size(); ++i) {
-                    if (data[i].first < min_distance) {
-                        min_distance = data[i].first;
-                        min_index = data[i].second;
-                    }
-                }
-                if (search_param.duplicate_distance_threshold > 0.0F) {
-                    if (min_distance <= search_param.duplicate_distance_threshold) {
-                        search_param.duplicate_id = min_index;
-                    }
-                } else if (codes->CompareVectors(inner_id, min_index)) {
-                    search_param.duplicate_id = min_index;
-                }
-            }
-        }
-        // HGraph-style cache-hit refinement: retain the restored row as local seeds,
-        // start from self, then merge current-vector search candidates. Cold/miss construction
-        // keeps its search heap unchanged and therefore does not allocate a merge heap.
-        if (use_self_as_entry && not cached_neighbors.empty()) {
-            auto merged_results = std::make_shared<StandardHeap<true, false>>(allocator_, -1);
-            UnorderedSet<InnerIdType> seen(allocator_);
-            seen.reserve(cached_neighbors.size() + results->Size());
-            for (const auto neighbor : cached_neighbors) {
-                if (neighbor != inner_id && seen.emplace(neighbor).second) {
-                    merged_results->Push(codes->ComputePairVectors(inner_id, neighbor), neighbor);
-                }
-            }
-            while (not results->Empty()) {
-                const auto candidate = results->Top();
-                results->Pop();
-                if (candidate.second != inner_id && seen.emplace(candidate.second).second) {
-                    merged_results->Push(candidate.first, candidate.second);
-                }
-            }
-            results = std::move(merged_results);
-        }
-        if (this->support_duplicate_ && search_param.duplicate_id >= 0) {
-            std::unique_lock lock(this->label_lookup_mutex_);
-            node->graph_->SetDuplicateId(static_cast<InnerIdType>(search_param.duplicate_id),
-                                         inner_id);
-            return;
-        }
-        mutually_connect_new_element(
-            inner_id, results, node->graph_, codes, points_mutex_, allocator_, h.alpha);
-        if (update_entry_point) {
-            node->entry_point_ = inner_id;
-        }
-    }
+    graph_lock.unlock();
+    add_graph_point(hierarchy,
+                    *node,
+                    inner_id,
+                    vector,
+                    ef_construction,
+                    use_self_as_entry,
+                    sampled_route_level);
 }
 
 void
@@ -1737,50 +2203,78 @@ Pyramid::populate_path_tree(Hierarchy& h, const std::string* paths, int64_t coun
 }
 
 void
-Pyramid::add_to_hierarchy(Hierarchy& h,
-                          const float* data_vectors,
-                          const std::string* paths,
-                          const Vector<int64_t>& data_biases,
-                          int64_t local_cur_element_count) {
-    auto add_func = [&](int64_t i, int64_t data_bias) {
-        std::string current_path = paths[data_bias];
-        auto path_slices = split(current_path, PART_SLASH);
-        IndexNode* node = h.root.get();
-        auto inner_id = static_cast<InnerIdType>(i + local_cur_element_count);
-        const auto* vector = base_codes_->SupportSplitCodeStorage() and raw_vector_ == nullptr
-                                 ? nullptr
-                                 : data_vectors + dim_ * data_bias;
-        int no_build_level_index = 0;
-        for (int j = 0; j <= static_cast<int>(path_slices.size()); ++j) {
-            IndexNode* new_node = nullptr;
-            if (j != static_cast<int>(path_slices.size())) {
-                new_node = node->GetChild(path_slices[j], true);
+Pyramid::populate_hierarchy_trees(const DatasetPtr& base) {
+    const auto data_num = base->GetNumElements();
+    if (thread_pool_ != nullptr && hierarchies_.size() > 1) {
+        Vector<std::future<void>> futures(allocator_);
+        for (const auto& [hname, hierarchy_ptr] : hierarchies_) {
+            const auto* paths = base->GetPaths(hname);
+            if (paths != nullptr) {
+                futures.push_back(thread_pool_->GeneralEnqueue(
+                    [&hierarchy = *hierarchy_ptr, paths, data_num, this]() {
+                        populate_path_tree(hierarchy, paths, data_num);
+                    }));
             }
-            if (no_build_level_index < static_cast<int>(h.no_build_levels.size()) &&
-                j == h.no_build_levels[no_build_level_index]) {
-                node = new_node;
-                no_build_level_index++;
-                continue;
-            }
-            add_one_point(h, node, inner_id, vector);
-            node = new_node;
         }
-    };
-
-    Vector<std::future<void>> futures(allocator_);
-    for (int64_t i = 0; i < static_cast<int64_t>(data_biases.size()); ++i) {
-        auto data_bias = data_biases[i];
-        if (this->thread_pool_ != nullptr) {
-            futures.push_back(this->thread_pool_->GeneralEnqueue(add_func, i, data_bias));
-        } else {
-            add_func(i, data_bias);
-        }
-    }
-    if (this->thread_pool_ != nullptr) {
         for (auto& future : futures) {
             future.get();
         }
+        return;
     }
+
+    for (const auto& [hname, hierarchy_ptr] : hierarchies_) {
+        const auto* paths = base->GetPaths(hname);
+        if (paths != nullptr) {
+            populate_path_tree(*hierarchy_ptr, paths, data_num);
+        }
+    }
+}
+
+void
+Pyramid::add_to_path(Hierarchy& hierarchy,
+                     const std::string& path,
+                     InnerIdType inner_id,
+                     const float* vector,
+                     int sampled_root_level) {
+    auto path_slices = split(path, PART_SLASH);
+    IndexNode* node = hierarchy.root.get();
+    int no_build_level_index = 0;
+    for (int depth = 0; depth <= static_cast<int>(path_slices.size()); ++depth) {
+        IndexNode* child = nullptr;
+        if (depth != static_cast<int>(path_slices.size())) {
+            child = node->GetChild(path_slices[depth], true);
+        }
+        if (no_build_level_index < static_cast<int>(hierarchy.no_build_levels.size()) &&
+            depth == hierarchy.no_build_levels[no_build_level_index]) {
+            node = child;
+            ++no_build_level_index;
+            continue;
+        }
+        add_one_point(hierarchy,
+                      node,
+                      inner_id,
+                      vector,
+                      0,
+                      false,
+                      depth == 0 ? sampled_root_level : std::numeric_limits<int>::min());
+        node = child;
+    }
+}
+
+void
+Pyramid::add_to_hierarchy(Hierarchy& h,
+                          const float* data_vectors,
+                          const std::string* paths,
+                          const Vector<int64_t>& input_indices,
+                          int64_t first_inner_id) {
+    run_parallel_insertions(*h.root, input_indices.size(), [&](uint64_t offset, int sampled_level) {
+        const auto input_index = input_indices[offset];
+        const auto inner_id = static_cast<InnerIdType>(offset + first_inner_id);
+        const auto* vector = base_codes_->SupportSplitCodeStorage() and raw_vector_ == nullptr
+                                 ? nullptr
+                                 : data_vectors + dim_ * input_index;
+        add_to_path(h, paths[input_index], inner_id, vector, sampled_level);
+    });
 }
 
 void
@@ -1859,6 +2353,8 @@ Pyramid::search_node(const IndexNode* node,
                      DistanceRecordVector* rabitq_lower_bound_candidates) const {
     std::shared_lock lock(node->mutex_);
     DistHeapPtr results = nullptr;
+    const auto* query_vector = query->GetFloat32Vectors();
+    const auto computer = codes->FactoryComputer(query_vector);
 
     if (node->status_ == IndexNode::Status::FLAT) {
         results = std::make_shared<StandardHeap<true, false>>(ctx.alloc, -1);
@@ -1886,7 +2382,6 @@ Pyramid::search_node(const IndexNode* node,
         }
 
         Vector<float> dists(id_count, ctx.alloc);
-        auto computer = codes->FactoryComputer(query->GetFloat32Vectors());
         codes->Query(dists.data(), computer, ids_ptr, id_count, &ctx);
 
         for (uint64_t i = 0; i < id_count; ++i) {
@@ -1909,9 +2404,9 @@ Pyramid::search_node(const IndexNode* node,
         }
     } else if (node->status_ == IndexNode::Status::GRAPH) {
         InnerSearchParam modified_param = search_param;
-        modified_param.ep = node->entry_point_;
+        modified_param.ep =
+            resolve_entry_point(*node, vl, query_vector, codes, computer, search_param, ctx);
         if (node->level_ != 0) {
-            modified_param.hops_limit = std::numeric_limits<uint32_t>::max();
             if (search_param.search_mode == KNN_SEARCH) {
                 modified_param.ef = std::min(
                     modified_param.ef,
@@ -1920,14 +2415,15 @@ Pyramid::search_node(const IndexNode* node,
             }
         }
         modified_param.topk = static_cast<int64_t>(modified_param.ef);
-        results = searcher_->Search(node->graph_,
-                                    codes,
-                                    vl,
-                                    query->GetFloat32Vectors(),
-                                    modified_param,
-                                    label_table_,
-                                    &ctx,
-                                    rabitq_lower_bound_candidates);
+        results = searcher_->SearchWithPresetComputer(node->graph_,
+                                                      codes,
+                                                      vl,
+                                                      query_vector,
+                                                      modified_param,
+                                                      label_table_,
+                                                      &ctx,
+                                                      rabitq_lower_bound_candidates,
+                                                      computer);
     }
 
     return results;
@@ -2019,6 +2515,13 @@ Pyramid::GetStats() const {
         stats["build_cache_hit_rate"]["skipped_reason"].SetString(
             "index was not built from an imported cache");
     }
+    uint64_t total_route_graph_size = 0;
+    for (const auto& [name, hierarchy] : hierarchies_) {
+        auto root_stats = hierarchy->root->get_graph_stats();
+        stats["root_graphs"][name.empty() ? "default" : name].SetJson(root_stats);
+        total_route_graph_size += root_stats["route_graph_size"].GetUint64();
+    }
+    stats["total_route_graph_size"].SetUint64(total_route_graph_size);
     return stats.Dump(4);
 }
 void
@@ -2084,7 +2587,7 @@ Pyramid::fulfill_cache(PyramidBuildCache& cache_snapshot) const {
         collect_graph_nodes(h_ptr->root.get(), std::string{}, graph_nodes);
         for (const auto& [node_path, gnode] : graph_nodes) {
             std::shared_lock lock(gnode->mutex_);
-            auto graph_ids = gnode->graph_->GetIds();
+            auto graph_ids = gnode->get_ids_unlocked();
             if (graph_ids.empty()) {
                 continue;
             }
@@ -2200,7 +2703,7 @@ Pyramid::build_with_cache(const DatasetPtr& base) {
         init_index_nodes_with_ids(h_ptr->root.get());
     }
 
-    auto codes = has_precise_reorder() ? precise_codes_ : base_codes_;
+    auto codes = construction_codes();
     std::vector<bool> global_hits(static_cast<size_t>(data_num), false);
 
     for (const auto& [hname, h_ptr] : hierarchies_) {
@@ -2297,44 +2800,17 @@ Pyramid::build_with_cache(const DatasetPtr& base) {
                                     const Vector<InnerIdType>& ids,
                                     uint64_t ef_construction,
                                     bool use_self_as_entry) {
-                auto refine_one =
-                    [this, &h, graph_node, data_vectors, ef_construction, use_self_as_entry](
-                        InnerIdType inner_id) {
+                run_parallel_insertions(
+                    *graph_node, ids.size(), [&](uint64_t offset, int sampled_level) {
+                        const auto inner_id = ids[offset];
                         add_one_point(h,
                                       graph_node,
                                       inner_id,
                                       data_vectors + dim_ * inner_id,
                                       ef_construction,
-                                      use_self_as_entry);
-                    };
-
-                Vector<std::future<void>> futures(allocator_);
-                // All futures are joined below before graph_node or data_vectors can go out of scope.
-                std::exception_ptr first_error;
-                for (const auto inner_id : ids) {
-                    try {
-                        if (thread_pool_ != nullptr) {
-                            futures.push_back(thread_pool_->GeneralEnqueue(refine_one, inner_id));
-                        } else {
-                            refine_one(inner_id);
-                        }
-                    } catch (...) {
-                        first_error = std::current_exception();
-                        break;
-                    }
-                }
-                for (auto& future : futures) {
-                    try {
-                        future.get();
-                    } catch (...) {
-                        if (first_error == nullptr) {
-                            first_error = std::current_exception();
-                        }
-                    }
-                }
-                if (first_error != nullptr) {
-                    std::rethrow_exception(first_error);
-                }
+                                      use_self_as_entry,
+                                      sampled_level);
+                    });
             };
 
             refine_nodes(node_missed_ids, h_ptr->ef_construction, false);

--- a/src/algorithm/pyramid/pyramid.h
+++ b/src/algorithm/pyramid/pyramid.h
@@ -15,6 +15,8 @@
 
 #pragma once
 
+#include <functional>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <shared_mutex>
@@ -31,6 +33,7 @@
 #include "impl/odescent/odescent_graph_builder.h"
 #include "impl/reorder/flatten_reorder.h"
 #include "impl/searcher/basic_searcher.h"
+#include "index_common_param.h"
 #include "index_feature_list.h"
 #include "io/memory_io/memory_io_parameter.h"
 #include "pyramid_index_node.h"
@@ -60,6 +63,7 @@ public:
 public:
     Pyramid(const PyramidParamPtr& pyramid_param, const IndexCommonParam& common_param)
         : InnerIndexInterface(pyramid_param, common_param),
+          common_param_(common_param),
           hierarchies_(common_param.allocator_.get()),
           odescent_param_(pyramid_param->odescent_param),
           index_min_size_(pyramid_param->index_min_size),
@@ -81,8 +85,10 @@ public:
                     new_gp->max_degree_ = h_param.max_degree;
                     graph_param = new_gp;
                 }
-                auto root =
-                    std::make_unique<IndexNode>(allocator_, graph_param, h_param.index_min_size);
+                auto root = create_root_node(graph_param,
+                                             h_param.index_min_size,
+                                             h_param.root_graph_type,
+                                             pyramid_param->root_graph_storage_type);
                 auto h = std::make_unique<Hierarchy>(h_param.name, std::move(root), allocator_);
                 h->no_build_levels.assign(h_param.no_build_levels.begin(),
                                           h_param.no_build_levels.end());
@@ -94,8 +100,10 @@ public:
                 hierarchies_.insert({h_param.name, std::move(h)});
             }
         } else {
-            auto root = std::make_unique<IndexNode>(
-                allocator_, pyramid_param->graph_param, index_min_size_);
+            auto root = create_root_node(pyramid_param->graph_param,
+                                         index_min_size_,
+                                         pyramid_param->root_graph_type,
+                                         pyramid_param->root_graph_storage_type);
             auto h = std::make_unique<Hierarchy>("", std::move(root), allocator_);
             h->no_build_levels.assign(pyramid_param->no_build_levels.begin(),
                                       pyramid_param->no_build_levels.end());
@@ -182,6 +190,12 @@ public:
 
     int64_t
     GetNumberRemoved() const override;
+
+    [[nodiscard]] uint64_t
+    GetMemoryUsage() const override;
+
+    [[nodiscard]] std::unordered_map<std::string, uint64_t>
+    GetMemoryUsageDetail() const override;
 
     uint32_t
     Remove(const std::vector<int64_t>& ids, RemoveMode mode) override;
@@ -304,17 +318,46 @@ private:
         }
     };
 
+    struct AddBatch {
+        explicit AddBatch(Allocator* allocator) : input_indices(allocator) {
+        }
+
+        int64_t first_inner_id{0};
+        Vector<int64_t> input_indices;
+        std::vector<int64_t> failed_ids;
+        bool storage_preallocated{false};
+    };
+
+    AddBatch
+    prepare_add_batch(const DatasetPtr& base);
+
+    void
+    encode_add_batch(const DatasetPtr& base, const AddBatch& batch);
+
+    void
+    insert_add_batch(const DatasetPtr& base, const AddBatch& batch);
+
     /// Pre-create the IndexNode tree structure from the path labels.
     static void
     populate_path_tree(Hierarchy& h, const std::string* paths, int64_t count);
+
+    void
+    populate_hierarchy_trees(const DatasetPtr& base);
 
     /// Insert vectors and their path labels into the hierarchy tree.
     void
     add_to_hierarchy(Hierarchy& h,
                      const float* data_vectors,
                      const std::string* paths,
-                     const Vector<int64_t>& data_biases,
-                     int64_t local_cur_element_count);
+                     const Vector<int64_t>& input_indices,
+                     int64_t first_inner_id);
+
+    void
+    add_to_path(Hierarchy& hierarchy,
+                const std::string& path,
+                InnerIdType inner_id,
+                const float* vector,
+                int sampled_root_level);
 
     /// Search a single hierarchy along a path prefix, accumulating candidates.
     void
@@ -335,6 +378,8 @@ private:
     search_impl(const DatasetPtr& query,
                 const SearchFunc& search_func,
                 InnerSearchParam& search_param,
+                int64_t final_topk,
+                std::optional<int64_t> reorder_candidate_limit,
                 QueryContext& ctx,
                 const std::string& hierarchy_name,
                 const DistanceRecordVector* rabitq_lower_bound_candidates = nullptr) const;
@@ -357,6 +402,88 @@ private:
     std::vector<int64_t>
     build_by_odescent(const DatasetPtr& base);
 
+    static GraphInterfaceParamPtr
+    make_route_graph_param(const GraphInterfaceParamPtr& bottom_graph_param);
+
+    static GraphInterfaceParamPtr
+    make_root_graph_param(const GraphInterfaceParamPtr& child_graph_param,
+                          GraphStorageTypes storage_type);
+
+    std::unique_ptr<IndexNode>
+    create_root_node(const GraphInterfaceParamPtr& child_graph_param,
+                     uint32_t index_min_size,
+                     const std::string& root_graph_type,
+                     GraphStorageTypes root_graph_storage_type);
+
+    int
+    draw_route_level(uint64_t max_degree);
+
+    Vector<int>
+    sample_route_levels(const IndexNode& node, uint64_t count);
+
+    void
+    insert_route_graph_point(const Hierarchy& hierarchy,
+                             const GraphInterfacePtr& graph,
+                             const FlattenInterfacePtr& codes,
+                             InnerIdType& entry_point,
+                             InnerIdType inner_id,
+                             const float* vector);
+
+    DistHeapPtr
+    search_graph_for_add(const GraphInterfacePtr& graph,
+                         const FlattenInterfacePtr& codes,
+                         InnerIdType inner_id,
+                         const float* vector,
+                         InnerSearchParam& search_param);
+
+    void
+    connect_cached_graph_point(InnerIdType inner_id,
+                               const DistHeapPtr& candidates,
+                               const GraphInterfacePtr& graph,
+                               const FlattenInterfacePtr& codes,
+                               float alpha);
+
+    void
+    add_routed_point(const Hierarchy& hierarchy,
+                     IndexNode& node,
+                     InnerIdType inner_id,
+                     const float* vector,
+                     uint64_t ef_construction,
+                     bool use_self_as_entry,
+                     int sampled_level);
+
+    void
+    add_graph_point(const Hierarchy& hierarchy,
+                    IndexNode& node,
+                    InnerIdType inner_id,
+                    const float* vector,
+                    uint64_t ef_construction,
+                    bool use_self_as_entry,
+                    int sampled_route_level);
+
+    void
+    add_bottom_graph_point(const Hierarchy& hierarchy,
+                           IndexNode& node,
+                           InnerIdType inner_id,
+                           const float* vector,
+                           uint64_t ef_construction,
+                           bool use_self_as_entry);
+
+    void
+    run_parallel_insertions(const IndexNode& node,
+                            uint64_t count,
+                            const std::function<void(uint64_t index, int sampled_level)>& task);
+
+    /// Resolve the bottom-graph entry for a node. The caller holds node.mutex_.
+    InnerIdType
+    resolve_entry_point(const IndexNode& node,
+                        const VisitedListPtr& vl,
+                        const void* query,
+                        const FlattenInterfacePtr& codes,
+                        const ComputerInterfacePtr& computer,
+                        const InnerSearchParam& search_param,
+                        QueryContext& ctx) const;
+
     /// Recursively insert a single vector into the hierarchy tree.
     void
     add_one_point(const Hierarchy& h,
@@ -364,7 +491,8 @@ private:
                   InnerIdType inner_id,
                   const float* vector,
                   uint64_t ef_construction = 0,
-                  bool use_self_as_entry = false);
+                  bool use_self_as_entry = false,
+                  int sampled_route_level = std::numeric_limits<int>::min());
 
     /// Split a path string into its hierarchical segments.
     static std::vector<std::vector<std::string>>
@@ -389,6 +517,11 @@ private:
     [[nodiscard]] FlattenInterfacePtr
     get_reorder_codes() const {
         return base_codes_->SupportSplitCodeStorage() ? base_codes_ : precise_codes_;
+    }
+
+    [[nodiscard]] FlattenInterfacePtr
+    construction_codes() const {
+        return has_precise_reorder() ? precise_codes_ : base_codes_;
     }
 
     [[nodiscard]] FlattenInterfacePtr
@@ -417,11 +550,12 @@ private:
     init_index_nodes_with_ids(IndexNode* node) const;
 
 private:
+    IndexCommonParam common_param_;
     ODescentParameterPtr odescent_param_{nullptr};  // ODescent build parameters
     UnorderedMap<std::string, std::unique_ptr<Hierarchy>> hierarchies_;  // named hierarchies
-    FlattenInterfacePtr base_codes_{nullptr};          // coarse codes for graph build/search
-    FlattenInterfacePtr precise_codes_{nullptr};       // precise codes for reorder (if enabled)
-    FlattenInterfacePtr raw_vector_{nullptr};          // original vectors for decode-only paths
+    FlattenInterfacePtr base_codes_{nullptr};     // coarse codes for online graph traversal
+    FlattenInterfacePtr precise_codes_{nullptr};  // default construction/reorder codes when present
+    FlattenInterfacePtr raw_vector_{nullptr};     // original vectors for decode-only paths
     std::unique_ptr<VisitedListPool> pool_ = nullptr;  // pool of visited-lists for search
 
     MutexArrayPtr points_mutex_{nullptr};                // per-point locks for concurrent access
@@ -430,13 +564,12 @@ private:
     int64_t cur_element_count_{0};                       // number of vectors currently stored
     std::atomic<int64_t> delete_count_{0};               // number of deleted vectors
     bool support_duplicate_{false};                      // whether to allow duplicate ids
+    mutable std::shared_mutex resize_mutex_;             // guards flatten storage resize/write/read
+    mutable std::mutex cur_element_count_mutex_;         // guards cur_element_count_ updates
+    std::string graph_type_{GRAPH_TYPE_VALUE_NSW};       // graph algorithm type
+    bool default_rabitq_one_bit_search_{false};          // default split lower-bound search
 
-    mutable std::shared_mutex resize_mutex_;        // guards resize operations
-    mutable std::mutex cur_element_count_mutex_;    // guards cur_element_count_ updates
-    std::string graph_type_{GRAPH_TYPE_VALUE_NSW};  // graph algorithm type
-    bool default_rabitq_one_bit_search_{false};     // default split lower-bound search
-
-    std::mutex entry_point_mutex_;  // guards entry-point selection
+    std::mutex random_generator_mutex_;
     std::default_random_engine level_generator_{
         2021};                              // random number generator for level promotion
     ReorderInterfacePtr reorder_{nullptr};  // reorder helper (if use_reorder_)

--- a/src/algorithm/pyramid/pyramid_index_node.cpp
+++ b/src/algorithm/pyramid/pyramid_index_node.cpp
@@ -14,11 +14,17 @@
 
 #include "pyramid_index_node.h"
 
+#include <fmt/format.h>
+
+#include "datacell/graph_datacell_parameter.h"
 #include "datacell/sparse_graph_datacell.h"
 #include "impl/reasoning/search_reasoning.h"
 #include "storage/serialization.h"
+#include "vsag/constants.h"
 
 namespace vsag {
+
+static constexpr uint64_t MAX_ROOT_ROUTE_GRAPH_COUNT = 1024;
 
 static inline uint64_t
 get_suitable_max_degree(int64_t data_num) {
@@ -33,12 +39,27 @@ get_suitable_max_degree(int64_t data_num) {
 
 IndexNode::IndexNode(Allocator* allocator,
                      GraphInterfaceParamPtr graph_param,
-                     uint32_t index_min_size)
+                     uint32_t index_min_size,
+                     const IndexCommonParam& common_param,
+                     GraphInterfaceParamPtr child_graph_param)
     : ids_(allocator),
+      index_min_size_(index_min_size),
       children_(allocator),
       allocator_(allocator),
+      common_param_(common_param),
       graph_param_(std::move(graph_param)),
-      index_min_size_(index_min_size) {
+      child_graph_param_(std::move(child_graph_param)) {
+}
+
+void
+IndexNode::enable_routing(GraphInterfaceParamPtr graph_param) {
+    routing_ = std::make_unique<RoutingOverlay>(allocator_, std::move(graph_param));
+}
+
+GraphInterfacePtr
+IndexNode::make_route_graph() const {
+    return std::make_shared<SparseGraphDataCell>(
+        std::dynamic_pointer_cast<SparseGraphDatacellParameter>(routing_->graph_param), allocator_);
 }
 
 void
@@ -63,7 +84,8 @@ IndexNode::Build(ODescent& odescent) {
 void
 IndexNode::AddChild(const std::string& key) {
     // AddChild is not thread-safe; ensure thread safety in calls to it.
-    children_[key] = std::make_unique<IndexNode>(allocator_, graph_param_, index_min_size_);
+    children_[key] = std::make_unique<IndexNode>(
+        allocator_, child_graph_param_, index_min_size_, common_param_, child_graph_param_);
     children_[key]->level_ = level_ + 1;
 }
 
@@ -90,9 +112,13 @@ IndexNode::Deserialize(StreamReader& reader) {
     // deserialize `status_`
     StreamReader::ReadObj(reader, status_);
     if (status_ == Status::GRAPH) {
-        graph_ = std::make_shared<SparseGraphDataCell>(
-            std::dynamic_pointer_cast<SparseGraphDatacellParameter>(graph_param_), allocator_);
+        graph_ = GraphInterface::MakeInstance(graph_param_, common_param_);
         graph_->Deserialize(reader);
+        if (graph_param_->graph_storage_type_ == GraphStorageTypes::GRAPH_STORAGE_TYPE_VALUE_FLAT ||
+            graph_param_->graph_storage_type_ ==
+                GraphStorageTypes::GRAPH_STORAGE_TYPE_VALUE_COMPRESSED) {
+            graph_capacity_ = graph_->MaxCapacity();
+        }
     } else if (status_ == Status::FLAT) {
         StreamReader::ReadVector(reader, ids_);
     }
@@ -104,10 +130,12 @@ IndexNode::Deserialize(StreamReader& reader) {
         AddChild(key);
         children_[key]->Deserialize(reader);
     }
+    deserialize_routing_unlocked(reader);
 }
 
 void
 IndexNode::Serialize(StreamWriter& writer) const {
+    std::unique_lock lock(mutex_);
     // serialize `entry_point_`
     StreamWriter::WriteObj(writer, entry_point_);
     // serialize `level_`
@@ -128,11 +156,143 @@ IndexNode::Serialize(StreamWriter& writer) const {
         // calculate size of `content`
         item.second->Serialize(writer);
     }
+    serialize_routing_unlocked(writer);
 }
+
+void
+IndexNode::serialize_routing_unlocked(StreamWriter& writer) const {
+    if (not has_routing()) {
+        return;
+    }
+    StreamWriter::WriteObj(writer, static_cast<uint64_t>(routing_->graphs.size()));
+    for (const auto& graph : routing_->graphs) {
+        graph->Serialize(writer);
+    }
+}
+
+void
+IndexNode::deserialize_routing_unlocked(StreamReader& reader) {
+    if (not has_routing()) {
+        return;
+    }
+    uint64_t route_count = 0;
+    StreamReader::ReadObj(reader, route_count);
+    CHECK_ARGUMENT(route_count <= MAX_ROOT_ROUTE_GRAPH_COUNT,
+                   fmt::format("invalid root route graph count: {}", route_count));
+    routing_->graphs.clear();
+    routing_->graphs.reserve(route_count);
+    for (uint64_t i = 0; i < route_count; ++i) {
+        auto graph = make_route_graph();
+        graph->Deserialize(reader);
+        routing_->graphs.push_back(std::move(graph));
+    }
+}
+
+std::pair<uint64_t, uint64_t>
+IndexNode::get_memory_usage_detail() const {
+    uint64_t memory = sizeof(IndexNode);
+    uint64_t routing_memory = 0;
+    std::shared_lock lock(mutex_);
+    if (has_routing()) {
+        routing_memory +=
+            sizeof(RoutingOverlay) + routing_->graphs.capacity() * sizeof(GraphInterfacePtr);
+        for (const auto& graph : routing_->graphs) {
+            routing_memory += graph->GetMemoryUsage();
+        }
+        memory += routing_memory;
+    }
+    memory += ids_.capacity() * sizeof(InnerIdType);
+    memory +=
+        children_.bucket_count() * (sizeof(decltype(children_)::value_type) + sizeof(uint32_t));
+    for (const auto& [key, child] : children_) {
+        memory += key.capacity() + 1;
+        const auto [child_memory, child_routing_memory] = child->get_memory_usage_detail();
+        memory += child_memory;
+        routing_memory += child_routing_memory;
+    }
+    if (graph_ != nullptr) {
+        memory += graph_->GetMemoryUsage();
+    }
+    return {memory, routing_memory};
+}
+
+JsonType
+IndexNode::get_graph_stats() const {
+    std::shared_lock lock(mutex_);
+    JsonType stats;
+    stats[PYRAMID_ROOT_GRAPH_TYPE].SetString(has_routing() ? PYRAMID_ROOT_GRAPH_TYPE_MULTI_LAYER
+                                                           : PYRAMID_ROOT_GRAPH_TYPE_SINGLE_LAYER);
+    const char* storage_type = "sparse";
+    if (graph_param_->graph_storage_type_ == GraphStorageTypes::GRAPH_STORAGE_TYPE_VALUE_FLAT) {
+        storage_type = GRAPH_STORAGE_TYPE_VALUE_FLAT;
+    } else if (graph_param_->graph_storage_type_ ==
+               GraphStorageTypes::GRAPH_STORAGE_TYPE_VALUE_COMPRESSED) {
+        storage_type = GRAPH_STORAGE_TYPE_VALUE_COMPRESSED;
+    }
+    stats["bottom_graph_storage_type"].SetString(storage_type);
+    stats["bottom_graph_node_count"].SetUint64(graph_ == nullptr ? 0 : graph_->TotalCount());
+    stats["bottom_graph_size"].SetUint64(graph_ == nullptr ? 0 : graph_->GetMemoryUsage());
+
+    const auto route_graph_count = has_routing() ? routing_->graphs.size() : 0;
+    stats["route_graph_count"].SetUint64(route_graph_count);
+    std::vector<int32_t> route_node_counts;
+    route_node_counts.reserve(route_graph_count);
+    uint64_t route_graph_size = 0;
+    if (has_routing()) {
+        for (const auto& graph : routing_->graphs) {
+            route_node_counts.push_back(static_cast<int32_t>(graph->TotalCount()));
+            route_graph_size += graph->GetMemoryUsage();
+        }
+    }
+    stats["route_node_counts"].SetVector(route_node_counts);
+    stats["route_graph_size"].SetUint64(route_graph_size);
+    return stats;
+}
+
+Vector<InnerIdType>
+IndexNode::get_ids_unlocked() const {
+    if (status_ == Status::FLAT) {
+        return ids_;
+    }
+    Vector<InnerIdType> ids(allocator_);
+    if (graph_ == nullptr) {
+        return ids;
+    }
+    if (graph_param_->graph_storage_type_ != GraphStorageTypes::GRAPH_STORAGE_TYPE_VALUE_FLAT) {
+        return graph_->GetIds();
+    }
+    const auto total_count = graph_->TotalCount();
+    ids.reserve(total_count);
+    for (InnerIdType id = 0; id < total_count; ++id) {
+        if (graph_->CheckIdExists(id)) {
+            ids.push_back(id);
+        }
+    }
+    return ids;
+}
+
+void
+IndexNode::resize_graph(InnerIdType new_capacity) {
+    std::unique_lock lock(mutex_);
+    if (graph_param_->graph_storage_type_ != GraphStorageTypes::GRAPH_STORAGE_TYPE_VALUE_FLAT &&
+        graph_param_->graph_storage_type_ !=
+            GraphStorageTypes::GRAPH_STORAGE_TYPE_VALUE_COMPRESSED) {
+        return;
+    }
+    graph_capacity_ = std::max(graph_capacity_, new_capacity);
+    auto flat_param = std::dynamic_pointer_cast<GraphDataCellParameter>(graph_param_);
+    if (flat_param != nullptr) {
+        flat_param->init_max_capacity_ = static_cast<uint64_t>(graph_capacity_);
+    }
+    if (graph_ != nullptr) {
+        graph_->Resize(graph_capacity_);
+    }
+}
+
 void
 IndexNode::Init() {
     if (status_ == Status::NO_INDEX) {
-        if (ids_.size() >= index_min_size_) {
+        if (has_routing() || ids_.size() >= index_min_size_) {
             if (not ids_.empty() and level_ != 0) {
                 auto new_max_degree = get_suitable_max_degree(static_cast<int64_t>(ids_.size()));
                 if (new_max_degree < graph_param_->max_degree_) {
@@ -143,8 +303,16 @@ IndexNode::Init() {
                     graph_param_ = new_graph_param;
                 }
             }
-            graph_ = std::make_shared<SparseGraphDataCell>(
-                std::dynamic_pointer_cast<SparseGraphDatacellParameter>(graph_param_), allocator_);
+            graph_ = GraphInterface::MakeInstance(graph_param_, common_param_);
+            if (graph_capacity_ == 0 && graph_param_->graph_storage_type_ ==
+                                            GraphStorageTypes::GRAPH_STORAGE_TYPE_VALUE_FLAT) {
+                const auto flat_param =
+                    std::static_pointer_cast<GraphDataCellParameter>(graph_param_);
+                graph_capacity_ = static_cast<InnerIdType>(flat_param->init_max_capacity_);
+            }
+            if (graph_capacity_ > 0) {
+                graph_->Resize(graph_capacity_);
+            }
             status_ = Status::GRAPH;
         } else {
             status_ = Status::FLAT;

--- a/src/algorithm/pyramid/pyramid_index_node.h
+++ b/src/algorithm/pyramid/pyramid_index_node.h
@@ -23,6 +23,7 @@
 #include "impl/allocator/safe_allocator.h"
 #include "impl/heap/distance_heap.h"
 #include "impl/odescent/odescent_graph_builder.h"
+#include "index_common_param.h"
 #include "utils/lock_strategy.h"
 #include "utils/visited_list.h"
 
@@ -45,7 +46,11 @@ public:
     enum class Status { NO_INDEX = 0, GRAPH = 1, FLAT = 2 };
 
 public:
-    IndexNode(Allocator* allocator_, GraphInterfaceParamPtr graph_param, uint32_t index_min_size);
+    IndexNode(Allocator* allocator,
+              GraphInterfaceParamPtr graph_param,
+              uint32_t index_min_size,
+              const IndexCommonParam& common_param,
+              GraphInterfaceParamPtr child_graph_param);
 
     /// Build the internal graph using ODescent over the stored ids.
     void
@@ -88,18 +93,65 @@ public:
 
 public:
     GraphInterfacePtr graph_{nullptr};  // graph over the ids in this node
-    InnerIdType entry_point_{0};        // entry point for graph search
-    uint32_t level_{0};                 // depth in the tree (root = 0)
-    mutable std::shared_mutex mutex_;   // per-node lock for concurrent add/search
+    // Bottom entry when no route exists; otherwise the highest route entry. A routed entry is also
+    // a physical member of the complete bottom graph.
+    InnerIdType entry_point_{0};
+    uint32_t level_{0};  // depth in the tree (root = 0)
+    // Guards node topology metadata: status, graph ownership, routing graph vector, and entry.
+    // Graph adjacency rows remain protected by Pyramid::points_mutex_.
+    mutable std::shared_mutex mutex_;
 
     Vector<InnerIdType> ids_;          // internal ids stored at this node
     uint32_t index_min_size_{0};       // threshold to trigger graph build
     Status status_{Status::NO_INDEX};  // current build state
 
 private:
+    class RoutingOverlay {
+    public:
+        RoutingOverlay(Allocator* allocator, GraphInterfaceParamPtr param)
+            : graphs(allocator), graph_param(std::move(param)) {
+        }
+
+        Vector<GraphInterfacePtr> graphs;
+        GraphInterfaceParamPtr graph_param{nullptr};
+    };
+
+    void
+    enable_routing(GraphInterfaceParamPtr graph_param);
+
+    [[nodiscard]] bool
+    has_routing() const {
+        return routing_ != nullptr;
+    }
+
+    GraphInterfacePtr
+    make_route_graph() const;
+
+    void
+    serialize_routing_unlocked(StreamWriter& writer) const;
+
+    void
+    deserialize_routing_unlocked(StreamReader& reader);
+
+    std::pair<uint64_t, uint64_t>
+    get_memory_usage_detail() const;
+
+    JsonType
+    get_graph_stats() const;
+
+    Vector<InnerIdType>
+    get_ids_unlocked() const;
+
+    void
+    resize_graph(InnerIdType new_capacity);
+
     UnorderedMap<std::string, std::unique_ptr<IndexNode>> children_;  // keyed by path segment
     Allocator* allocator_{nullptr};
+    const IndexCommonParam& common_param_;
     GraphInterfaceParamPtr graph_param_{nullptr};
+    GraphInterfaceParamPtr child_graph_param_{nullptr};
+    InnerIdType graph_capacity_{0};
+    std::unique_ptr<RoutingOverlay> routing_{nullptr};
 };
 
 }  // namespace vsag

--- a/src/algorithm/pyramid/pyramid_test.cpp
+++ b/src/algorithm/pyramid/pyramid_test.cpp
@@ -17,14 +17,20 @@
 
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <cmath>
+#include <future>
 #include <numeric>
+#include <set>
+#include <sstream>
+#include <thread>
 #include <vector>
 
 #include "impl/allocator/safe_allocator.h"
 #include "index/index_impl.h"
 #include "index_common_param.h"
 #include "unittest.h"
+#include "vsag/options.h"
 
 namespace {
 
@@ -33,6 +39,21 @@ constexpr int64_t PYRAMID_TEST_DIM = 4;
 struct PyramidTestIndex {
     std::shared_ptr<vsag::Allocator> allocator;
     std::shared_ptr<vsag::Pyramid> index;
+};
+
+class BlockSizeLimitGuard {
+public:
+    explicit BlockSizeLimitGuard(uint64_t block_size_limit)
+        : previous_limit_(vsag::Options::Instance().block_size_limit()) {
+        vsag::Options::Instance().set_block_size_limit(block_size_limit);
+    }
+
+    ~BlockSizeLimitGuard() {
+        vsag::Options::Instance().set_block_size_limit(previous_limit_);
+    }
+
+private:
+    uint64_t previous_limit_;
 };
 
 PyramidTestIndex
@@ -97,7 +118,7 @@ MakePyramidIndex(uint32_t index_min_size,
         external_param[vsag::PYRAMID_PRECISE_QUANTIZATION_TYPE].SetString("sq8");
         external_param[vsag::PYRAMID_BASE_IO_TYPE].SetString("block_memory_io");
         external_param[vsag::PYRAMID_PRECISE_IO_TYPE].SetString("block_memory_io");
-        external_param[vsag::PYRAMID_RABITQ_BITS_PER_DIM_BASE].SetUint64(1);
+        external_param[vsag::PYRAMID_RABITQ_BITS_PER_DIM_BASE].SetUint64(3);
     } else if (use_reorder) {
         external_param[vsag::PYRAMID_PRECISE_QUANTIZATION_TYPE].SetString(
             vsag::QUANTIZATION_TYPE_VALUE_FP32);
@@ -105,6 +126,61 @@ MakePyramidIndex(uint32_t index_min_size,
     auto param = vsag::Pyramid::CheckAndMappingExternalParam(external_param, common_param);
     result.index = std::make_shared<vsag::Pyramid>(param, common_param);
     return result;
+}
+
+PyramidTestIndex
+MakeRootPyramidIndex(const std::string& root_graph_type,
+                     bool use_reorder = false,
+                     const std::string& graph_type = vsag::GRAPH_TYPE_VALUE_NSW,
+                     bool support_duplicate = false,
+                     uint64_t build_thread_count = 1,
+                     bool use_rabitq_with_sq8 = false,
+                     const std::string& graph_storage_type = vsag::GRAPH_STORAGE_TYPE_VALUE_FLAT) {
+    PyramidTestIndex result;
+    vsag::IndexCommonParam common_param;
+    common_param.dim_ = PYRAMID_TEST_DIM;
+    common_param.data_type_ = vsag::DataTypes::DATA_TYPE_FLOAT;
+    common_param.metric_ = vsag::MetricType::METRIC_TYPE_L2SQR;
+    result.allocator = vsag::SafeAllocator::FactoryDefaultAllocator();
+    common_param.allocator_ = result.allocator;
+    auto external = vsag::JsonType::Parse(R"({
+        "base_quantization_type": "fp32",
+        "precise_quantization_type": "fp32",
+        "base_io_type": "memory_io",
+        "precise_io_type": "memory_io",
+        "max_degree": 8,
+        "ef_construction": 32,
+        "alpha": 1.2,
+        "no_build_levels": [],
+        "index_min_size": 1,
+        "build_thread_count": 1
+    })");
+    external[vsag::PYRAMID_ROOT_GRAPH_TYPE].SetString(root_graph_type);
+    external[vsag::PYRAMID_GRAPH_TYPE].SetString(graph_type);
+    external[vsag::PYRAMID_GRAPH_STORAGE_TYPE].SetString(graph_storage_type);
+    external[vsag::PYRAMID_USE_REORDER].SetBool(use_reorder || use_rabitq_with_sq8);
+    external[vsag::PYRAMID_SUPPORT_DUPLICATE].SetBool(support_duplicate);
+    external[vsag::PYRAMID_BUILD_THREAD_COUNT].SetUint64(build_thread_count);
+    if (use_rabitq_with_sq8) {
+        external[vsag::PYRAMID_BASE_QUANTIZATION_TYPE].SetString("rabitq");
+        external[vsag::PYRAMID_PRECISE_QUANTIZATION_TYPE].SetString("sq8");
+        external[vsag::PYRAMID_BASE_IO_TYPE].SetString("block_memory_io");
+        external[vsag::PYRAMID_PRECISE_IO_TYPE].SetString("block_memory_io");
+        external[vsag::PYRAMID_RABITQ_BITS_PER_DIM_BASE].SetUint64(3);
+    }
+    auto param = vsag::Pyramid::CheckAndMappingExternalParam(external, common_param);
+    result.index = std::make_shared<vsag::Pyramid>(param, common_param);
+    return result;
+}
+
+void
+FillRootVectors(std::vector<float>& vectors, int64_t count) {
+    for (int64_t i = 0; i < count; ++i) {
+        for (int64_t d = 0; d < PYRAMID_TEST_DIM; ++d) {
+            vectors[i * PYRAMID_TEST_DIM + d] =
+                static_cast<float>((i * (d + 3) + d * 17) % 997) / 997.0F;
+        }
+    }
 }
 
 vsag::DatasetPtr
@@ -456,7 +532,7 @@ TEST_CASE("Pyramid promotes flat node at index minimum size", "[ut][pyramid]") {
     const bool split_rabitq = GENERATE(false, true);
     const bool build_all_at_once = GENERATE(false, true);
     CAPTURE(split_rabitq, build_all_at_once);
-    auto test_index = MakePyramidIndex(3, 1, false, split_rabitq);
+    auto test_index = MakePyramidIndex(3, 4, false, split_rabitq);
     const auto& index = test_index.index;
     std::vector<float> vectors = {
         0.0F,
@@ -787,4 +863,499 @@ TEST_CASE("Pyramid rejects TQ-only fields for non-TQ quantizers", "[ut][pyramid]
     auto mrle_dim = vsag::JsonType::Parse(R"({"base_quantization_type":"int8",
                                                "mrle_dim":64})");
     REQUIRE_THROWS(vsag::Pyramid::CheckAndMappingExternalParam(mrle_dim, common_param));
+}
+
+TEST_CASE("Pyramid multi-layer root builds routes and survives serialization",
+          "[ut][pyramid][root_graph]") {
+    const auto graph_storage_type =
+        GENERATE(std::string(vsag::GRAPH_STORAGE_TYPE_VALUE_FLAT),
+                 std::string(vsag::GRAPH_STORAGE_TYPE_VALUE_COMPRESSED));
+    CAPTURE(graph_storage_type);
+    constexpr int64_t count = 512;
+    std::vector<float> vectors(count * PYRAMID_TEST_DIM);
+    FillRootVectors(vectors, count);
+    std::vector<int64_t> ids(count);
+    std::iota(ids.begin(), ids.end(), 0);
+    std::vector<std::string> paths(count, "");
+    auto source = MakeRootPyramidIndex(vsag::PYRAMID_ROOT_GRAPH_TYPE_MULTI_LAYER,
+                                       false,
+                                       vsag::GRAPH_TYPE_VALUE_NSW,
+                                       false,
+                                       1,
+                                       false,
+                                       graph_storage_type);
+    REQUIRE(source.index->Build(MakePyramidDataset(vectors.data(), ids.data(), paths.data(), count))
+                .empty());
+
+    auto stats = vsag::JsonType::Parse(source.index->GetStats());
+    auto root_stats = stats["root_graphs"]["default"];
+    REQUIRE(root_stats[vsag::PYRAMID_ROOT_GRAPH_TYPE].GetString() ==
+            vsag::PYRAMID_ROOT_GRAPH_TYPE_MULTI_LAYER);
+    REQUIRE(root_stats["bottom_graph_storage_type"].GetString() == graph_storage_type);
+    REQUIRE(root_stats["bottom_graph_node_count"].GetUint64() == count);
+    REQUIRE(root_stats["bottom_graph_size"].GetUint64() > 0);
+    REQUIRE(root_stats["route_graph_count"].GetUint64() > 0);
+    REQUIRE(root_stats["route_node_counts"].GetVector().front() < count);
+    REQUIRE(source.index->GetMemoryUsageDetail().at("root_route_graphs") > 0);
+
+    auto query = vsag::Dataset::Make()
+                     ->NumElements(1)
+                     ->Dim(PYRAMID_TEST_DIM)
+                     ->Float32Vectors(vectors.data() + 137 * PYRAMID_TEST_DIM)
+                     ->Owner(false);
+    const auto search_params = R"({"pyramid":{"ef_search":128,"hops_limit":256}})";
+    auto result = source.index->KnnSearch(query, 10, search_params, nullptr);
+    REQUIRE(result->GetDim() == 10);
+    auto search_stats = vsag::JsonType::Parse(result->GetStatistics());
+    REQUIRE(search_stats["distance_evaluations_by_phase"]["routing"].GetUint64() > 0);
+
+    constexpr int64_t added_count = 64;
+    std::vector<float> added_vectors(added_count * PYRAMID_TEST_DIM);
+    FillRootVectors(added_vectors, added_count);
+    std::vector<int64_t> added_ids(added_count);
+    std::iota(added_ids.begin(), added_ids.end(), count);
+    std::vector<std::string> added_paths(added_count, "");
+    REQUIRE(source.index
+                ->Add(MakePyramidDataset(
+                    added_vectors.data(), added_ids.data(), added_paths.data(), added_count))
+                .empty());
+    auto added_query = vsag::Dataset::Make()
+                           ->NumElements(1)
+                           ->Dim(PYRAMID_TEST_DIM)
+                           ->Float32Vectors(added_vectors.data())
+                           ->Owner(false);
+    REQUIRE(source.index->KnnSearch(added_query, 10, search_params, nullptr)->GetDim() == 10);
+    const auto source_result = source.index->KnnSearch(query, 10, search_params, nullptr);
+
+    std::stringstream stream;
+    vsag::IOStreamWriter writer(stream);
+    source.index->Serialize(writer);
+    auto restored = MakeRootPyramidIndex(vsag::PYRAMID_ROOT_GRAPH_TYPE_MULTI_LAYER,
+                                         false,
+                                         vsag::GRAPH_TYPE_VALUE_NSW,
+                                         false,
+                                         1,
+                                         false,
+                                         graph_storage_type);
+    vsag::IOStreamReader reader(stream);
+    restored.index->Deserialize(reader);
+    auto restored_result = restored.index->KnnSearch(query, 10, search_params, nullptr);
+    const auto source_stats = vsag::JsonType::Parse(source.index->GetStats());
+    const auto restored_stats = vsag::JsonType::Parse(restored.index->GetStats());
+    const auto source_root_stats = source_stats["root_graphs"]["default"];
+    const auto restored_root_stats = restored_stats["root_graphs"]["default"];
+    REQUIRE(restored_root_stats["bottom_graph_node_count"].GetUint64() == count + added_count);
+    REQUIRE(restored_root_stats["route_graph_count"].GetUint64() ==
+            source_root_stats["route_graph_count"].GetUint64());
+    REQUIRE(restored_root_stats["route_node_counts"].GetVector() ==
+            source_root_stats["route_node_counts"].GetVector());
+    REQUIRE(restored_result->GetDim() == source_result->GetDim());
+    REQUIRE(std::equal(source_result->GetIds(),
+                       source_result->GetIds() + source_result->GetDim(),
+                       restored_result->GetIds()));
+    for (uint64_t i = 0; i < source_result->GetDim(); ++i) {
+        REQUIRE(std::abs(restored_result->GetDistances()[i] - source_result->GetDistances()[i]) <
+                1e-6F);
+    }
+
+    constexpr int64_t post_restore_count = 512;
+    std::vector<float> post_restore_vectors(post_restore_count * PYRAMID_TEST_DIM);
+    FillRootVectors(post_restore_vectors, post_restore_count);
+    for (auto& value : post_restore_vectors) {
+        value += 2.0F;
+    }
+    std::vector<int64_t> post_restore_ids(post_restore_count);
+    std::iota(post_restore_ids.begin(), post_restore_ids.end(), count + added_count);
+    std::vector<std::string> post_restore_paths(post_restore_count, "");
+    REQUIRE(restored.index
+                ->Add(MakePyramidDataset(post_restore_vectors.data(),
+                                         post_restore_ids.data(),
+                                         post_restore_paths.data(),
+                                         post_restore_count))
+                .empty());
+    REQUIRE(restored.index->GetNumElements() == count + added_count + post_restore_count);
+    for (const int64_t offset : {int64_t{0}, post_restore_count - 1}) {
+        auto post_restore_query =
+            vsag::Dataset::Make()
+                ->NumElements(1)
+                ->Dim(PYRAMID_TEST_DIM)
+                ->Float32Vectors(post_restore_vectors.data() + offset * PYRAMID_TEST_DIM)
+                ->Owner(false);
+        const auto post_restore_result =
+            restored.index->KnnSearch(post_restore_query, 1, search_params, nullptr);
+        REQUIRE(post_restore_result->GetDim() == 1);
+        REQUIRE(post_restore_result->GetIds()[0] == post_restore_ids[offset]);
+        REQUIRE(std::abs(post_restore_result->GetDistances()[0]) < 1e-6F);
+    }
+}
+
+TEST_CASE("Pyramid NSW Build and empty Add share routed construction",
+          "[ut][pyramid][root_graph][build]") {
+    constexpr int64_t count = 512;
+    std::vector<float> vectors(count * PYRAMID_TEST_DIM);
+    FillRootVectors(vectors, count);
+    std::vector<int64_t> ids(count);
+    std::iota(ids.begin(), ids.end(), 0);
+    std::vector<std::string> paths(count, "");
+
+    auto built = MakeRootPyramidIndex(vsag::PYRAMID_ROOT_GRAPH_TYPE_MULTI_LAYER,
+                                      true,
+                                      vsag::GRAPH_TYPE_VALUE_NSW,
+                                      false,
+                                      1,
+                                      true);
+    auto added = MakeRootPyramidIndex(vsag::PYRAMID_ROOT_GRAPH_TYPE_MULTI_LAYER,
+                                      true,
+                                      vsag::GRAPH_TYPE_VALUE_NSW,
+                                      false,
+                                      1,
+                                      true);
+    auto dataset = MakePyramidDataset(vectors.data(), ids.data(), paths.data(), count);
+    REQUIRE(built.index->Build(dataset).empty());
+    REQUIRE(added.index->Add(dataset).empty());
+
+    const auto built_stats = vsag::JsonType::Parse(built.index->GetStats());
+    const auto added_stats = vsag::JsonType::Parse(added.index->GetStats());
+    const auto built_root = built_stats["root_graphs"]["default"];
+    const auto added_root = added_stats["root_graphs"]["default"];
+    REQUIRE(built_root["bottom_graph_node_count"].GetUint64() == count);
+    REQUIRE(added_root["bottom_graph_node_count"].GetUint64() == count);
+    REQUIRE(built_root["route_node_counts"].GetVector() ==
+            added_root["route_node_counts"].GetVector());
+
+    auto query = vsag::Dataset::Make()
+                     ->NumElements(1)
+                     ->Dim(PYRAMID_TEST_DIM)
+                     ->Float32Vectors(vectors.data() + 137 * PYRAMID_TEST_DIM)
+                     ->Owner(false);
+    const auto search_params = R"({"pyramid":{"ef_search":128,"hops_limit":256}})";
+    const auto built_result = built.index->KnnSearch(query, 10, search_params, nullptr);
+    const auto added_result = added.index->KnnSearch(query, 10, search_params, nullptr);
+    REQUIRE(std::equal(built_result->GetIds(),
+                       built_result->GetIds() + built_result->GetDim(),
+                       added_result->GetIds()));
+}
+
+TEST_CASE("Pyramid flat routed root crosses memory blocks and resizes",
+          "[ut][pyramid][root_graph][parallel]") {
+    BlockSizeLimitGuard block_size_guard(256 * 1024);
+    constexpr int64_t initial_count = 8192;
+    constexpr int64_t added_count = 1024;
+    constexpr int64_t total_count = initial_count + added_count;
+    std::vector<float> vectors(total_count * PYRAMID_TEST_DIM);
+    FillRootVectors(vectors, total_count);
+    std::vector<int64_t> ids(total_count);
+    std::iota(ids.begin(), ids.end(), 0);
+    std::vector<std::string> paths(total_count, "");
+
+    auto test_index = MakeRootPyramidIndex(
+        vsag::PYRAMID_ROOT_GRAPH_TYPE_MULTI_LAYER, false, vsag::GRAPH_TYPE_VALUE_NSW, false, 8);
+    REQUIRE(test_index.index
+                ->Build(MakePyramidDataset(vectors.data(), ids.data(), paths.data(), initial_count))
+                .empty());
+    REQUIRE(test_index.index
+                ->Add(MakePyramidDataset(vectors.data() + initial_count * PYRAMID_TEST_DIM,
+                                         ids.data() + initial_count,
+                                         paths.data() + initial_count,
+                                         added_count))
+                .empty());
+
+    const auto stats = vsag::JsonType::Parse(test_index.index->GetStats());
+    const auto root_stats = stats["root_graphs"]["default"];
+    REQUIRE(root_stats["bottom_graph_storage_type"].GetString() == "flat");
+    REQUIRE(root_stats["bottom_graph_node_count"].GetUint64() == total_count);
+    auto query = vsag::Dataset::Make()
+                     ->NumElements(1)
+                     ->Dim(PYRAMID_TEST_DIM)
+                     ->Float32Vectors(vectors.data() + (total_count - 1) * PYRAMID_TEST_DIM)
+                     ->Owner(false);
+    const auto result =
+        test_index.index->KnnSearch(query, 10, R"({"pyramid":{"ef_search":128}})", nullptr);
+    // A directed approximate graph does not guarantee that every query reaches k nodes. Verify
+    // that traversal remains usable and that the vector appended after the block resize is intact.
+    REQUIRE(result->GetDim() > 0);
+    REQUIRE(result->GetDim() <= 10);
+    REQUIRE(result->GetDistances()[0] < 1e-6F);
+    REQUIRE(
+        std::abs(test_index.index->CalcDistanceById(
+            vectors.data() + (total_count - 1) * PYRAMID_TEST_DIM, ids[total_count - 1], false)) <
+        1e-6F);
+}
+
+TEST_CASE("Pyramid routed root supports concurrent Add and Search",
+          "[ut][pyramid][root_graph][concurrent]") {
+    constexpr int64_t initial_count = 512;
+    constexpr int64_t added_count = 128;
+    std::vector<float> initial_vectors(initial_count * PYRAMID_TEST_DIM);
+    std::vector<float> added_vectors(added_count * PYRAMID_TEST_DIM);
+    FillRootVectors(initial_vectors, initial_count);
+    FillRootVectors(added_vectors, added_count);
+    std::vector<int64_t> initial_ids(initial_count);
+    std::vector<int64_t> added_ids(added_count);
+    std::iota(initial_ids.begin(), initial_ids.end(), 0);
+    std::iota(added_ids.begin(), added_ids.end(), initial_count);
+    std::vector<std::string> initial_paths(initial_count, "");
+    std::vector<std::string> added_paths(added_count, "");
+
+    auto source = MakeRootPyramidIndex(vsag::PYRAMID_ROOT_GRAPH_TYPE_MULTI_LAYER, true);
+    REQUIRE(
+        source.index
+            ->Build(MakePyramidDataset(
+                initial_vectors.data(), initial_ids.data(), initial_paths.data(), initial_count))
+            .empty());
+
+    auto add_future = std::async(std::launch::async, [&]() {
+        return source.index->Add(MakePyramidDataset(
+            added_vectors.data(), added_ids.data(), added_paths.data(), added_count));
+    });
+    auto query = vsag::Dataset::Make()
+                     ->NumElements(1)
+                     ->Dim(PYRAMID_TEST_DIM)
+                     ->Float32Vectors(initial_vectors.data() + 137 * PYRAMID_TEST_DIM)
+                     ->Owner(false);
+    const auto search_params = R"({"pyramid":{"ef_search":128,"hops_limit":256}})";
+    for (uint64_t i = 0; i < 32; ++i) {
+        REQUIRE(source.index->KnnSearch(query, 10, search_params, nullptr)->GetDim() == 10);
+    }
+    REQUIRE(add_future.get().empty());
+    const auto stats = vsag::JsonType::Parse(source.index->GetStats());
+    REQUIRE(stats["root_graphs"]["default"]["bottom_graph_node_count"].GetUint64() ==
+            initial_count + added_count);
+}
+
+TEST_CASE("Pyramid factor controls reorder candidates without changing final topk",
+          "[ut][pyramid][factor]") {
+    const auto root_graph_type = GENERATE(std::string(vsag::PYRAMID_ROOT_GRAPH_TYPE_SINGLE_LAYER),
+                                          std::string(vsag::PYRAMID_ROOT_GRAPH_TYPE_MULTI_LAYER));
+    constexpr int64_t count = 128;
+    std::vector<float> vectors(count * PYRAMID_TEST_DIM);
+    FillRootVectors(vectors, count);
+    std::vector<int64_t> ids(count);
+    std::iota(ids.begin(), ids.end(), 0);
+    std::vector<std::string> paths(count, "");
+    auto test_index = MakeRootPyramidIndex(root_graph_type, true);
+    REQUIRE(
+        test_index.index->Build(MakePyramidDataset(vectors.data(), ids.data(), paths.data(), count))
+            .empty());
+    auto query = vsag::Dataset::Make()
+                     ->NumElements(1)
+                     ->Dim(PYRAMID_TEST_DIM)
+                     ->Float32Vectors(vectors.data())
+                     ->Owner(false);
+    const std::array<std::pair<std::string, uint32_t>, 5> cases = {
+        std::pair{R"({"pyramid":{"ef_search":20}})", 20U},
+        std::pair{R"({"pyramid":{"ef_search":20,"factor":1.0}})", 20U},
+        std::pair{R"({"pyramid":{"ef_search":20,"factor":2.0}})", 10U},
+        std::pair{R"({"pyramid":{"ef_search":20,"factor":10.0}})", 20U},
+        std::pair{R"({"pyramid":{"ef_search":20,"factor":3.0e38}})", 20U}};
+    for (const auto& [params, expected_candidates] : cases) {
+        auto result = test_index.index->KnnSearch(query, 5, params, nullptr);
+        REQUIRE(result->GetDim() == 5);
+        auto stats = vsag::JsonType::Parse(result->GetStatistics());
+        REQUIRE(stats["reorder_candidate_count"].GetInt() == expected_candidates);
+        REQUIRE(stats["reorder_distance_count"].GetInt() == expected_candidates);
+    }
+
+    vsag::SearchRequest request;
+    request.query_ = query;
+    request.topk_ = 5;
+    request.params_str_ = R"({"pyramid":{"ef_search":20,"factor":2.0}})";
+    const auto request_result = test_index.index->SearchWithRequest(request);
+    REQUIRE(request_result->GetDim() == 5);
+    REQUIRE(vsag::JsonType::Parse(request_result->GetStatistics())["reorder_candidate_count"]
+                .GetUint64() == 10);
+
+    auto large_topk = test_index.index->KnnSearch(
+        query, 25, R"({"pyramid":{"ef_search":20,"factor":2.0}})", nullptr);
+    REQUIRE(large_topk->GetDim() == 25);
+    REQUIRE(
+        vsag::JsonType::Parse(large_topk->GetStatistics())["reorder_candidate_count"].GetInt() ==
+        25);
+
+    auto no_reorder = MakeRootPyramidIndex(root_graph_type, false);
+    REQUIRE(
+        no_reorder.index->Build(MakePyramidDataset(vectors.data(), ids.data(), paths.data(), count))
+            .empty());
+    auto no_reorder_result = no_reorder.index->KnnSearch(
+        query, 5, R"({"pyramid":{"ef_search":20,"factor":2.0}})", nullptr);
+    REQUIRE(no_reorder_result->GetDim() == 5);
+    REQUIRE(vsag::JsonType::Parse(no_reorder_result->GetStatistics())["reorder_candidate_count"]
+                .GetInt() == 0);
+
+    REQUIRE_THROWS(test_index.index->KnnSearch(
+        query, 5, R"({"pyramid":{"ef_search":20,"factor":0.0}})", nullptr));
+    REQUIRE_THROWS(test_index.index->KnnSearch(
+        query, 5, R"({"pyramid":{"ef_search":20,"factor":-1.0}})", nullptr));
+}
+
+TEST_CASE("Pyramid factor limits merged subgraph candidates without changing subgraph search",
+          "[ut][pyramid][factor]") {
+    constexpr int64_t count = 512;
+    std::vector<float> vectors(count * PYRAMID_TEST_DIM);
+    FillRootVectors(vectors, count);
+    std::vector<int64_t> ids(count);
+    std::iota(ids.begin(), ids.end(), 0);
+    std::vector<std::string> paths(count);
+    for (int64_t i = 0; i < count; ++i) {
+        paths[i] = i % 2 == 0 ? "tenant/left" : "tenant/right";
+    }
+    auto test_index = MakePyramidIndex(1, 1, false, false, false, false, true);
+    REQUIRE(
+        test_index.index->Build(MakePyramidDataset(vectors.data(), ids.data(), paths.data(), count))
+            .empty());
+
+    std::string query_path = "tenant/left|tenant/right";
+    auto query = vsag::Dataset::Make()
+                     ->NumElements(1)
+                     ->Dim(PYRAMID_TEST_DIM)
+                     ->Float32Vectors(vectors.data() + 137 * PYRAMID_TEST_DIM)
+                     ->Paths(&query_path)
+                     ->Owner(false);
+    const std::array<std::pair<std::string, uint32_t>, 3> cases = {
+        std::pair{R"({"pyramid":{"ef_search":100,"subindex_ef_search":20}})", 40U},
+        std::pair{R"({"pyramid":{"ef_search":100,"subindex_ef_search":20,"factor":1.0}})", 40U},
+        std::pair{R"({"pyramid":{"ef_search":100,"subindex_ef_search":20,"factor":2.0}})", 10U}};
+    uint64_t approximate_distance_count = 0;
+    for (uint64_t i = 0; i < cases.size(); ++i) {
+        const auto& [params, expected_candidates] = cases[i];
+        const auto result = test_index.index->KnnSearch(query, 5, params, nullptr);
+        REQUIRE(result->GetDim() == 5);
+        const auto stats = vsag::JsonType::Parse(result->GetStatistics());
+        REQUIRE(stats["reorder_candidate_count"].GetUint64() == expected_candidates);
+        const auto current_approximate_count =
+            stats["distance_evaluations_by_phase"]["approximate"].GetUint64();
+        if (i == 0) {
+            approximate_distance_count = current_approximate_count;
+        } else {
+            REQUIRE(current_approximate_count == approximate_distance_count);
+        }
+    }
+
+    auto split_index = MakePyramidIndex(1, 1, false, true);
+    REQUIRE(split_index.index
+                ->Build(MakePyramidDataset(vectors.data(), ids.data(), paths.data(), count))
+                .empty());
+    const auto no_factor = split_index.index->KnnSearch(
+        query,
+        5,
+        R"({"threshold":1e30,"pyramid":{"ef_search":100,"subindex_ef_search":1,"rabitq_one_bit_search":true,"rabitq_error_rate":1e-6}})",
+        nullptr);
+    const auto factor_one = split_index.index->KnnSearch(
+        query,
+        5,
+        R"({"threshold":1e30,"pyramid":{"ef_search":100,"subindex_ef_search":1,"rabitq_one_bit_search":true,"rabitq_error_rate":1e-6,"factor":1.0}})",
+        nullptr);
+    const auto no_factor_stats = vsag::JsonType::Parse(no_factor->GetStatistics());
+    const auto factor_one_stats = vsag::JsonType::Parse(factor_one->GetStatistics());
+    REQUIRE(no_factor->GetDim() == 5);
+    REQUIRE(factor_one->GetDim() == 5);
+    REQUIRE(no_factor_stats["reorder_candidate_count"].GetUint64() ==
+            factor_one_stats["reorder_candidate_count"].GetUint64());
+    REQUIRE(no_factor_stats["reorder_distance_count"].GetUint64() ==
+            factor_one_stats["reorder_distance_count"].GetUint64());
+    REQUIRE(no_factor_stats["reorder_candidate_count"].GetUint64() >= 100);
+    REQUIRE(no_factor_stats["reorder_lower_bound_probe_count"].GetUint64() > 0);
+    REQUIRE(no_factor_stats["reorder_distance_count"].GetUint64() >= 100);
+}
+
+TEST_CASE("Pyramid legacy deserialization rejects incompatible root graph type",
+          "[ut][pyramid][root_graph][serialization]") {
+    constexpr int64_t count = 32;
+    std::vector<float> vectors(count * PYRAMID_TEST_DIM);
+    FillRootVectors(vectors, count);
+    std::vector<int64_t> ids(count);
+    std::iota(ids.begin(), ids.end(), 0);
+    std::vector<std::string> paths(count, "");
+
+    const std::array<std::pair<std::string, std::string>, 2> cases = {
+        std::pair{std::string(vsag::PYRAMID_ROOT_GRAPH_TYPE_SINGLE_LAYER),
+                  std::string(vsag::PYRAMID_ROOT_GRAPH_TYPE_MULTI_LAYER)},
+        std::pair{std::string(vsag::PYRAMID_ROOT_GRAPH_TYPE_MULTI_LAYER),
+                  std::string(vsag::PYRAMID_ROOT_GRAPH_TYPE_SINGLE_LAYER)}};
+    for (const auto& [serialized_type, configured_type] : cases) {
+        auto source = MakeRootPyramidIndex(serialized_type);
+        REQUIRE(source.index
+                    ->Build(MakePyramidDataset(
+                        vectors.data(), ids.data(), paths.data(), static_cast<int64_t>(ids.size())))
+                    .empty());
+        std::stringstream stream;
+        vsag::IOStreamWriter writer(stream);
+        source.index->Serialize(writer);
+
+        auto target = MakeRootPyramidIndex(configured_type);
+        vsag::IOStreamReader reader(stream);
+        try {
+            target.index->Deserialize(reader);
+            FAIL("incompatible root graph type must be rejected");
+        } catch (const vsag::VsagException& error) {
+            REQUIRE(std::string(error.what()).find("Pyramid index parameter not match") !=
+                    std::string::npos);
+        }
+    }
+}
+
+TEST_CASE("Pyramid multi-layer root routes duplicate representatives",
+          "[ut][pyramid][root_graph][duplicate]") {
+    constexpr int64_t count = 512;
+    std::vector<float> vectors(count * PYRAMID_TEST_DIM);
+    std::vector<int64_t> ids(count);
+    std::vector<std::string> paths(count, "");
+    for (int64_t i = 0; i < count; ++i) {
+        ids[i] = i;
+        const auto representative = i / 2;
+        for (int64_t d = 0; d < PYRAMID_TEST_DIM; ++d) {
+            vectors[i * PYRAMID_TEST_DIM + d] =
+                static_cast<float>((representative * (d + 3) + d * 17) % 997) / 997.0F;
+        }
+    }
+    auto test_index = MakeRootPyramidIndex(
+        vsag::PYRAMID_ROOT_GRAPH_TYPE_MULTI_LAYER, false, vsag::GRAPH_TYPE_VALUE_NSW, true);
+    REQUIRE(
+        test_index.index->Build(MakePyramidDataset(vectors.data(), ids.data(), paths.data(), count))
+            .empty());
+    const auto stats = vsag::JsonType::Parse(test_index.index->GetStats());
+    const auto bottom_count =
+        stats["root_graphs"]["default"]["bottom_graph_node_count"].GetUint64();
+    REQUIRE(bottom_count < count);
+    REQUIRE(stats["root_graphs"]["default"]["route_node_counts"].GetVector().front() <
+            bottom_count);
+
+    auto query = vsag::Dataset::Make()
+                     ->NumElements(1)
+                     ->Dim(PYRAMID_TEST_DIM)
+                     ->Float32Vectors(vectors.data() + 200 * PYRAMID_TEST_DIM)
+                     ->Owner(false);
+    auto result = test_index.index->KnnSearch(
+        query, 10, R"({"pyramid":{"ef_search":256,"hops_limit":512}})", nullptr);
+    REQUIRE(result->GetDim() == 10);
+    std::set<int64_t> result_ids(result->GetIds(), result->GetIds() + result->GetDim());
+    REQUIRE(result_ids.count(200) == 1);
+}
+
+TEST_CASE("Pyramid applies hops limit to non-root graphs", "[ut][pyramid][hops_limit]") {
+    constexpr int64_t count = 512;
+    std::vector<float> vectors(count * PYRAMID_TEST_DIM);
+    FillRootVectors(vectors, count);
+    std::vector<int64_t> ids(count);
+    std::iota(ids.begin(), ids.end(), 0);
+    std::vector<std::string> paths(count, "tenant/leaf");
+    auto test_index = MakePyramidIndex(1);
+    REQUIRE(
+        test_index.index->Build(MakePyramidDataset(vectors.data(), ids.data(), paths.data(), count))
+            .empty());
+    std::string query_path = "tenant/leaf";
+    auto query = vsag::Dataset::Make()
+                     ->NumElements(1)
+                     ->Dim(PYRAMID_TEST_DIM)
+                     ->Float32Vectors(vectors.data() + 311 * PYRAMID_TEST_DIM)
+                     ->Paths(&query_path)
+                     ->Owner(false);
+    auto unlimited =
+        test_index.index->KnnSearch(query, 1, R"({"pyramid":{"ef_search":2}})", nullptr);
+    auto limited = test_index.index->KnnSearch(
+        query, 1, R"({"pyramid":{"ef_search":2,"hops_limit":3}})", nullptr);
+    const auto unlimited_stats = vsag::JsonType::Parse(unlimited->GetStatistics());
+    const auto limited_stats = vsag::JsonType::Parse(limited->GetStatistics());
+    REQUIRE(unlimited_stats["hops"].GetInt() > limited_stats["hops"].GetInt());
+    REQUIRE(limited_stats["hops"].GetInt() <= 3);
 }

--- a/src/algorithm/pyramid/pyramid_zparameters.cpp
+++ b/src/algorithm/pyramid/pyramid_zparameters.cpp
@@ -34,6 +34,76 @@
 namespace vsag {
 namespace {
 
+void
+validate_root_graph_type(const std::string& root_graph_type, const std::string& context) {
+    CHECK_ARGUMENT(root_graph_type == PYRAMID_ROOT_GRAPH_TYPE_SINGLE_LAYER ||
+                       root_graph_type == PYRAMID_ROOT_GRAPH_TYPE_MULTI_LAYER,
+                   fmt::format("{} root_graph_type must be '{}' or '{}', got '{}'",
+                               context,
+                               PYRAMID_ROOT_GRAPH_TYPE_SINGLE_LAYER,
+                               PYRAMID_ROOT_GRAPH_TYPE_MULTI_LAYER,
+                               root_graph_type));
+}
+
+GraphStorageTypes
+parse_root_graph_storage_type(const JsonType& graph_json) {
+    if (not graph_json.Contains(GRAPH_STORAGE_TYPE_KEY)) {
+        return GraphStorageTypes::GRAPH_STORAGE_TYPE_VALUE_FLAT;
+    }
+    CHECK_ARGUMENT(graph_json[GRAPH_STORAGE_TYPE_KEY].IsString(),
+                   "graph_storage_type must be a string");
+    const auto storage_type = graph_json[GRAPH_STORAGE_TYPE_KEY].GetString();
+    CHECK_ARGUMENT(storage_type == GRAPH_STORAGE_TYPE_VALUE_FLAT ||
+                       storage_type == GRAPH_STORAGE_TYPE_VALUE_COMPRESSED,
+                   fmt::format("invalid graph_storage_type: {}", storage_type));
+    return storage_type == GRAPH_STORAGE_TYPE_VALUE_COMPRESSED
+               ? GraphStorageTypes::GRAPH_STORAGE_TYPE_VALUE_COMPRESSED
+               : GraphStorageTypes::GRAPH_STORAGE_TYPE_VALUE_FLAT;
+}
+
+const char*
+root_graph_storage_type_to_string(GraphStorageTypes storage_type) {
+    if (storage_type == GraphStorageTypes::GRAPH_STORAGE_TYPE_VALUE_COMPRESSED) {
+        return GRAPH_STORAGE_TYPE_VALUE_COMPRESSED;
+    }
+    return GRAPH_STORAGE_TYPE_VALUE_FLAT;
+}
+
+bool
+has_multi_layer_root(const PyramidParameters& params) {
+    if (not params.has_hierarchies) {
+        return params.root_graph_type == PYRAMID_ROOT_GRAPH_TYPE_MULTI_LAYER;
+    }
+    return std::any_of(
+        params.hierarchies.begin(), params.hierarchies.end(), [](const auto& hierarchy) {
+            return hierarchy.root_graph_type == PYRAMID_ROOT_GRAPH_TYPE_MULTI_LAYER;
+        });
+}
+
+void
+validate_root_graph_config(const std::string& root_graph_type,
+                           const std::vector<int32_t>& no_build_levels,
+                           int64_t max_degree,
+                           const std::string& context) {
+    validate_root_graph_type(root_graph_type, context);
+    CHECK_ARGUMENT(
+        root_graph_type != PYRAMID_ROOT_GRAPH_TYPE_MULTI_LAYER ||
+            std::find(no_build_levels.begin(), no_build_levels.end(), 0) == no_build_levels.end(),
+        fmt::format("{} multi-layer root graph requires level 0 to be built", context));
+    CHECK_ARGUMENT(
+        root_graph_type != PYRAMID_ROOT_GRAPH_TYPE_MULTI_LAYER || max_degree > 1,
+        fmt::format("{} multi-layer root graph requires max_degree greater than 1", context));
+}
+
+void
+validate_root_graph_algorithm(const std::string& root_graph_type,
+                              const std::string& graph_type,
+                              const std::string& context) {
+    CHECK_ARGUMENT(
+        root_graph_type != PYRAMID_ROOT_GRAPH_TYPE_MULTI_LAYER || graph_type != GRAPH_TYPE_ODESCENT,
+        fmt::format("{} multi-layer root graph does not support odescent", context));
+}
+
 PyramidSearchParameters::HierarchyOp
 parse_hierarchy_op(const std::string& op) {
     if (op == "union") {
@@ -59,10 +129,45 @@ append_hierarchy_selector(PyramidSearchParameters& params,
 }  // namespace
 
 void
+validate_pyramid_external_root_graph_config(const JsonType& external_param,
+                                            const PyramidParameters& params) {
+    const bool root_graph_type_is_explicit = external_param.Contains(PYRAMID_ROOT_GRAPH_TYPE);
+    const auto validate_explicit_root_graph_type = [](bool is_explicit,
+                                                      const std::vector<int32_t>& no_build_levels,
+                                                      const std::string& context) {
+        CHECK_ARGUMENT(
+            not is_explicit || std::find(no_build_levels.begin(), no_build_levels.end(), 0) ==
+                                   no_build_levels.end(),
+            fmt::format("{} root_graph_type cannot be specified when level 0 is not built",
+                        context));
+    };
+
+    if (not params.has_hierarchies) {
+        validate_explicit_root_graph_type(
+            root_graph_type_is_explicit, params.no_build_levels, "Pyramid");
+        return;
+    }
+
+    const auto& hierarchy_values = *external_param[PYRAMID_HIERARCHIES].GetInnerJson();
+    for (uint64_t i = 0; i < params.hierarchies.size(); ++i) {
+        JsonType hierarchy_json;
+        *hierarchy_json.GetInnerJson() = hierarchy_values[i];
+        const bool hierarchy_root_graph_type_is_explicit =
+            root_graph_type_is_explicit ||
+            (hierarchy_json.IsObject() && hierarchy_json.Contains(PYRAMID_ROOT_GRAPH_TYPE));
+        validate_explicit_root_graph_type(hierarchy_root_graph_type_is_explicit,
+                                          params.hierarchies[i].no_build_levels,
+                                          fmt::format("hierarchy {}", params.hierarchies[i].name));
+    }
+}
+
+void
 PyramidHierarchyParameters::FromJson(const JsonType& json) {
     if (json.IsString()) {
         name = json.GetString();
         CHECK_ARGUMENT(not name.empty(), "hierarchy name must not be empty");
+        validate_root_graph_config(
+            root_graph_type, no_build_levels, max_degree, fmt::format("hierarchy {}", name));
         return;
     }
 
@@ -102,11 +207,18 @@ PyramidHierarchyParameters::FromJson(const JsonType& json) {
                        fmt::format("hierarchy {} index_min_size exceeds uint32_t", name));
         index_min_size = static_cast<uint32_t>(index_min_size_value);
     }
+    if (json.Contains(PYRAMID_ROOT_GRAPH_TYPE)) {
+        CHECK_ARGUMENT(json[PYRAMID_ROOT_GRAPH_TYPE].IsString(),
+                       fmt::format("hierarchy {} root_graph_type must be a string", name));
+        root_graph_type = json[PYRAMID_ROOT_GRAPH_TYPE].GetString();
+    }
     for (auto level : no_build_levels) {
         CHECK_ARGUMENT(
             level >= 0,
             fmt::format("hierarchy {} no_build_levels values must be non-negative", name));
     }
+    validate_root_graph_config(
+        root_graph_type, no_build_levels, max_degree, fmt::format("hierarchy {}", name));
 }
 
 JsonType
@@ -118,6 +230,7 @@ PyramidHierarchyParameters::ToJson() const {
     json[EF_CONSTRUCTION_KEY].SetUint64(ef_construction);
     json[ALPHA_KEY].SetFloat(alpha);
     json[INDEX_MIN_SIZE].SetInt(index_min_size);
+    json[PYRAMID_ROOT_GRAPH_TYPE].SetString(root_graph_type);
     return json;
 }
 
@@ -135,7 +248,8 @@ PyramidHierarchyParameters::CheckCompatibility(const PyramidHierarchyParameters&
         return false;
     }
     if (max_degree != other.max_degree || ef_construction != other.ef_construction ||
-        alpha != other.alpha || index_min_size != other.index_min_size) {
+        alpha != other.alpha || index_min_size != other.index_min_size ||
+        root_graph_type != other.root_graph_type) {
         logger::error(
             "PyramidHierarchyParameters::CheckCompatibility: build params are not compatible");
         return false;
@@ -151,6 +265,7 @@ PyramidParameters::FromJson(const JsonType& json) {
 
     graph_param = GraphInterfaceParameter::GetGraphParameterByJson(
         GraphStorageTypes::GRAPH_STORAGE_TYPE_SPARSE, graph_json);
+    this->root_graph_storage_type = parse_root_graph_storage_type(graph_json);
     this->alpha = graph_json[ALPHA_KEY].GetFloat();
     this->max_degree = graph_json[GRAPH_PARAM_MAX_DEGREE_KEY].GetInt();
 
@@ -158,11 +273,9 @@ PyramidParameters::FromJson(const JsonType& json) {
     if (this->graph_type == GRAPH_TYPE_ODESCENT) {
         this->odescent_param = std::make_shared<ODescentParameter>();
         this->odescent_param->FromJson(graph_json);
-    } else {
-        if (json.Contains(EF_CONSTRUCTION_KEY)) {
-            this->ef_construction = json[EF_CONSTRUCTION_KEY].GetUint64();
-            CHECK_ARGUMENT(this->ef_construction > 0, "ef_construction must be positive");
-        }
+    } else if (json.Contains(EF_CONSTRUCTION_KEY)) {
+        this->ef_construction = json[EF_CONSTRUCTION_KEY].GetUint64();
+        CHECK_ARGUMENT(this->ef_construction > 0, "ef_construction must be positive");
     }
 
     this->base_codes_param = CreateFlattenParam(json[BASE_CODES_KEY]);
@@ -188,6 +301,14 @@ PyramidParameters::FromJson(const JsonType& json) {
     if (json.Contains(INDEX_MIN_SIZE)) {
         this->index_min_size = json[INDEX_MIN_SIZE].GetInt();
     }
+    if (json.Contains(PYRAMID_ROOT_GRAPH_TYPE)) {
+        CHECK_ARGUMENT(json[PYRAMID_ROOT_GRAPH_TYPE].IsString(),
+                       "root_graph_type must be a string");
+        this->root_graph_type = json[PYRAMID_ROOT_GRAPH_TYPE].GetString();
+    }
+    validate_root_graph_config(
+        this->root_graph_type, this->no_build_levels, this->max_degree, "Pyramid");
+    validate_root_graph_algorithm(this->root_graph_type, this->graph_type, "Pyramid");
 
     if (json.Contains(PYRAMID_PERSIST_SOURCE_ID_KEY)) {
         this->persist_source_id = json[PYRAMID_PERSIST_SOURCE_ID_KEY].GetBool();
@@ -221,7 +342,11 @@ PyramidParameters::FromJson(const JsonType& json) {
             hierarchy.ef_construction = this->ef_construction;
             hierarchy.alpha = this->alpha;
             hierarchy.index_min_size = this->index_min_size;
+            hierarchy.root_graph_type = this->root_graph_type;
             hierarchy.FromJson(hierarchy_json);
+            validate_root_graph_algorithm(hierarchy.root_graph_type,
+                                          this->graph_type,
+                                          fmt::format("hierarchy {}", hierarchy.name));
             CHECK_ARGUMENT(seen_names.insert(hierarchy.name).second,
                            fmt::format("duplicate hierarchy name {}", hierarchy.name));
             this->hierarchies.emplace_back(std::move(hierarchy));
@@ -235,6 +360,8 @@ PyramidParameters::ToJson() const {
     json[BASE_CODES_KEY].SetJson(base_codes_param->ToJson());
 
     auto graph_json = graph_param->ToJson();
+    graph_json[GRAPH_STORAGE_TYPE_KEY].SetString(
+        root_graph_storage_type_to_string(this->root_graph_storage_type));
     graph_json[ALPHA_KEY].SetFloat(this->alpha);
     graph_json[GRAPH_TYPE_KEY].SetString(this->graph_type);
     if (this->graph_type == GRAPH_TYPE_ODESCENT) {
@@ -245,6 +372,7 @@ PyramidParameters::ToJson() const {
     json[GRAPH_KEY].SetJson(graph_json);
     json[USE_REORDER_KEY].SetBool(this->use_reorder);
     json[INDEX_MIN_SIZE].SetInt(index_min_size);
+    json[PYRAMID_ROOT_GRAPH_TYPE].SetString(root_graph_type);
     json[SUPPORT_DUPLICATE].SetBool(support_duplicate);
     json[PYRAMID_PERSIST_SOURCE_ID_KEY].SetBool(persist_source_id);
     json[PYRAMID_STORE_PATHS_KEY].SetBool(store_paths);
@@ -316,6 +444,10 @@ PyramidParameters::CheckCompatibility(const ParamPtr& other) const {
         CHECK_SUB_PARAM(*this, *p, raw_vector_param);
     }
     CHECK_FIELD_EQ(*this, *p, index_min_size);
+    CHECK_FIELD_EQ(*this, *p, root_graph_type);
+    if (has_multi_layer_root(*this)) {
+        CHECK_FIELD_EQ(*this, *p, root_graph_storage_type);
+    }
     CHECK_FIELD_EQ(*this, *p, support_duplicate);
     CHECK_FIELD_EQ(*this, *p, store_paths);
     return true;
@@ -331,6 +463,10 @@ PyramidSearchParameters::FromJson(const std::string& json_string) {
     CHECK_ARGUMENT(params.Contains(INDEX_PYRAMID),
                    fmt::format("parameters must contains {}", INDEX_PYRAMID));
     obj.IndexSearchParameter::FromJson(params[INDEX_PYRAMID]);
+    if (params[INDEX_PYRAMID].Contains(SEARCH_PARAM_FACTOR)) {
+        CHECK_ARGUMENT(std::isfinite(obj.topk_factor) && obj.topk_factor > 0.0F,
+                       fmt::format("factor({}) must be finite and positive", obj.topk_factor));
+    }
 
     CHECK_ARGUMENT(
         params[INDEX_PYRAMID].Contains(PYRAMID_PARAMETER_EF_SEARCH),

--- a/src/algorithm/pyramid/pyramid_zparameters.h
+++ b/src/algorithm/pyramid/pyramid_zparameters.h
@@ -53,6 +53,7 @@ public:
     uint64_t ef_construction{400};
     float alpha{1.2F};
     uint32_t index_min_size{0};
+    std::string root_graph_type{PYRAMID_ROOT_GRAPH_TYPE_SINGLE_LAYER};
 };
 
 struct PyramidParameters : public InnerIndexParameter {
@@ -78,6 +79,8 @@ public:
     std::string graph_type{GRAPH_TYPE_VALUE_NSW};
     float alpha{1.2F};
     uint32_t index_min_size{0};
+    std::string root_graph_type{PYRAMID_ROOT_GRAPH_TYPE_SINGLE_LAYER};
+    GraphStorageTypes root_graph_storage_type{GraphStorageTypes::GRAPH_STORAGE_TYPE_VALUE_FLAT};
 
     bool support_duplicate{false};
     bool has_hierarchies{false};
@@ -112,4 +115,9 @@ public:
 private:
     PyramidSearchParameters() = default;
 };
+
+void
+validate_pyramid_external_root_graph_config(const JsonType& external_param,
+                                            const PyramidParameters& params);
+
 }  // namespace vsag

--- a/src/algorithm/pyramid/pyramid_zparameters_test.cpp
+++ b/src/algorithm/pyramid/pyramid_zparameters_test.cpp
@@ -306,6 +306,21 @@ TEST_CASE("Pyramid Parameters CheckCompatibility", "[ut][PyramidParameter][Check
         "different base io type", base_io_type, "memory_io", "block_memory_io", true);
 
     TEST_COMPATIBILITY_CASE("different graph type", graph_type, "odescent", "nsw", true);
+    SECTION("root graph storage matters only for multi-layer roots") {
+        PyramidDefaultParam flat_param;
+        PyramidDefaultParam compressed_param;
+        flat_param.graph_storage_type = "flat";
+        compressed_param.graph_storage_type = "compressed";
+        auto flat = std::make_shared<vsag::PyramidParameters>();
+        auto compressed = std::make_shared<vsag::PyramidParameters>();
+        flat->FromString(generate_pyramid(flat_param));
+        compressed->FromString(generate_pyramid(compressed_param));
+
+        REQUIRE(flat->CheckCompatibility(compressed));
+        flat->root_graph_type = vsag::PYRAMID_ROOT_GRAPH_TYPE_MULTI_LAYER;
+        compressed->root_graph_type = vsag::PYRAMID_ROOT_GRAPH_TYPE_MULTI_LAYER;
+        REQUIRE_FALSE(flat->CheckCompatibility(compressed));
+    }
     TEST_COMPATIBILITY_CASE("different build thread count", build_thread_count, 4, 8, true);
     TEST_COMPATIBILITY_CASE(
         "different precise quantization type", precise_quantization_type, "fp32", "fp16", false);
@@ -717,4 +732,134 @@ TEST_CASE("Pyramid parses hops limit search parameter", "[ut][PyramidParameters]
         R"({"pyramid":{"ef_search":100,"hops_limit":-1}})"));
     REQUIRE_THROWS(vsag::PyramidSearchParameters::FromJson(
         R"({"pyramid":{"ef_search":100,"hops_limit":4294967296}})"));
+}
+
+TEST_CASE("Pyramid validates root graph type and hierarchy overrides", "[ut][PyramidParameters]") {
+    vsag::IndexCommonParam common_param;
+    common_param.dim_ = 128;
+    common_param.data_type_ = vsag::DataTypes::DATA_TYPE_FLOAT;
+
+    auto external = vsag::JsonType::Parse(R"({
+        "base_quantization_type": "fp32",
+        "root_graph_type": "single_layer",
+        "hierarchies": [
+            {"name": "single"},
+            {"name": "multi", "root_graph_type": "multi_layer", "no_build_levels": []}
+        ]
+    })");
+    auto mapped = std::dynamic_pointer_cast<vsag::PyramidParameters>(
+        vsag::Pyramid::CheckAndMappingExternalParam(external, common_param));
+    REQUIRE(mapped->root_graph_type == vsag::PYRAMID_ROOT_GRAPH_TYPE_SINGLE_LAYER);
+    REQUIRE(mapped->root_graph_storage_type ==
+            vsag::GraphStorageTypes::GRAPH_STORAGE_TYPE_VALUE_FLAT);
+    REQUIRE(mapped->hierarchies[0].root_graph_type == vsag::PYRAMID_ROOT_GRAPH_TYPE_SINGLE_LAYER);
+    REQUIRE(mapped->hierarchies[1].root_graph_type == vsag::PYRAMID_ROOT_GRAPH_TYPE_MULTI_LAYER);
+
+    external[vsag::PYRAMID_GRAPH_STORAGE_TYPE].SetString(vsag::GRAPH_STORAGE_TYPE_VALUE_COMPRESSED);
+    mapped = std::dynamic_pointer_cast<vsag::PyramidParameters>(
+        vsag::Pyramid::CheckAndMappingExternalParam(external, common_param));
+    REQUIRE(mapped->root_graph_storage_type ==
+            vsag::GraphStorageTypes::GRAPH_STORAGE_TYPE_VALUE_COMPRESSED);
+    REQUIRE(mapped->ToJson()[vsag::GRAPH_KEY][vsag::GRAPH_STORAGE_TYPE_KEY].GetString() ==
+            vsag::GRAPH_STORAGE_TYPE_VALUE_COMPRESSED);
+
+    external[vsag::PYRAMID_GRAPH_STORAGE_TYPE].SetString("unknown");
+    REQUIRE_THROWS(vsag::Pyramid::CheckAndMappingExternalParam(external, common_param));
+    external[vsag::PYRAMID_GRAPH_STORAGE_TYPE].SetString(vsag::GRAPH_STORAGE_TYPE_VALUE_FLAT);
+
+    external[vsag::PYRAMID_ROOT_GRAPH_TYPE].SetString("unknown");
+    REQUIRE_THROWS(vsag::Pyramid::CheckAndMappingExternalParam(external, common_param));
+
+    auto unbuilt_root = vsag::JsonType::Parse(R"({
+        "base_quantization_type": "fp32",
+        "root_graph_type": "multi_layer",
+        "no_build_levels": [0]
+    })");
+    REQUIRE_THROWS(vsag::Pyramid::CheckAndMappingExternalParam(unbuilt_root, common_param));
+
+    unbuilt_root = vsag::JsonType::Parse(R"({
+        "base_quantization_type": "fp32",
+        "root_graph_type": "single_layer",
+        "no_build_levels": [0]
+    })");
+    REQUIRE_THROWS(vsag::Pyramid::CheckAndMappingExternalParam(unbuilt_root, common_param));
+
+    auto default_unbuilt_root = vsag::JsonType::Parse(R"({
+        "base_quantization_type": "fp32",
+        "no_build_levels": [0]
+    })");
+    REQUIRE_NOTHROW(
+        vsag::Pyramid::CheckAndMappingExternalParam(default_unbuilt_root, common_param));
+
+    auto explicit_hierarchy_root = vsag::JsonType::Parse(R"({
+        "base_quantization_type": "fp32",
+        "hierarchies": [
+            {
+                "name": "site",
+                "root_graph_type": "single_layer",
+                "no_build_levels": [0]
+            }
+        ]
+    })");
+    REQUIRE_THROWS(
+        vsag::Pyramid::CheckAndMappingExternalParam(explicit_hierarchy_root, common_param));
+
+    auto inherited_explicit_root = vsag::JsonType::Parse(R"({
+        "base_quantization_type": "fp32",
+        "root_graph_type": "single_layer",
+        "no_build_levels": [0],
+        "hierarchies": ["site"]
+    })");
+    REQUIRE_THROWS(
+        vsag::Pyramid::CheckAndMappingExternalParam(inherited_explicit_root, common_param));
+
+    auto odescent_multi_layer = vsag::JsonType::Parse(R"({
+        "base_quantization_type": "fp32",
+        "graph_type": "odescent",
+        "root_graph_type": "multi_layer",
+        "max_degree": 8,
+        "ef_construction": 17
+    })");
+    REQUIRE_THROWS(vsag::Pyramid::CheckAndMappingExternalParam(odescent_multi_layer, common_param));
+
+    odescent_multi_layer[vsag::PYRAMID_ROOT_GRAPH_TYPE].SetString(
+        vsag::PYRAMID_ROOT_GRAPH_TYPE_SINGLE_LAYER);
+    REQUIRE_NOTHROW(
+        vsag::Pyramid::CheckAndMappingExternalParam(odescent_multi_layer, common_param));
+
+    auto odescent_hierarchy_multi_layer = vsag::JsonType::Parse(R"({
+        "base_quantization_type": "fp32",
+        "graph_type": "odescent",
+        "root_graph_type": "single_layer",
+        "hierarchies": [
+            {"name": "site", "root_graph_type": "multi_layer"}
+        ]
+    })");
+    REQUIRE_THROWS(
+        vsag::Pyramid::CheckAndMappingExternalParam(odescent_hierarchy_multi_layer, common_param));
+
+    auto invalid_hierarchy_degree = vsag::JsonType::Parse(R"({
+        "base_quantization_type": "fp32",
+        "max_degree": 8,
+        "hierarchies": [
+            {"name": "site", "root_graph_type": "multi_layer", "max_degree": 1}
+        ]
+    })");
+    REQUIRE_THROWS(
+        vsag::Pyramid::CheckAndMappingExternalParam(invalid_hierarchy_degree, common_param));
+}
+
+TEST_CASE("Pyramid validates explicit factor", "[ut][PyramidParameters]") {
+    auto absent = vsag::PyramidSearchParameters::FromJson(R"({"pyramid":{"ef_search":20}})");
+    REQUIRE(absent.topk_factor == 0.0F);
+
+    auto present =
+        vsag::PyramidSearchParameters::FromJson(R"({"pyramid":{"ef_search":20,"factor":1.5}})");
+    REQUIRE(std::abs(present.topk_factor - 1.5F) < 1e-6F);
+    REQUIRE_THROWS(
+        vsag::PyramidSearchParameters::FromJson(R"({"pyramid":{"ef_search":20,"factor":0}})"));
+    REQUIRE_THROWS(
+        vsag::PyramidSearchParameters::FromJson(R"({"pyramid":{"ef_search":20,"factor":-1}})"));
+    REQUIRE_THROWS(
+        vsag::PyramidSearchParameters::FromJson(R"({"pyramid":{"ef_search":20,"factor":1e100}})"));
 }

--- a/src/analyzer/pyramid_analyzer.cpp
+++ b/src/analyzer/pyramid_analyzer.cpp
@@ -640,12 +640,7 @@ PyramidAnalyzer::collect_searchable_node_ids(const IndexNode* node,
 
     std::shared_lock lock(node->mutex_);
     if (node->status_ != IndexNode::Status::NO_INDEX) {
-        Vector<InnerIdType> node_ids(allocator_);
-        if (node->status_ == IndexNode::Status::FLAT) {
-            node_ids = node->ids_;
-        } else if (node->graph_ != nullptr) {
-            node_ids = node->graph_->GetIds();
-        }
+        auto node_ids = node->get_ids_unlocked();
         for (const auto id : node_ids) {
             if (deleted_ids.find(id) == deleted_ids.end() && seen_ids.insert(id).second) {
                 ids.push_back(id);

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -254,6 +254,9 @@ const char* const PYRAMID_NO_BUILD_LEVELS = "no_build_levels";
 const char* const PYRAMID_HIERARCHIES = "hierarchies";
 const char* const PYRAMID_INDEX_MIN_SIZE = "index_min_size";
 const char* const PYRAMID_STORE_PATHS = "store_paths";
+const char* const PYRAMID_ROOT_GRAPH_TYPE = "root_graph_type";
+const char* const PYRAMID_ROOT_GRAPH_TYPE_SINGLE_LAYER = "single_layer";
+const char* const PYRAMID_ROOT_GRAPH_TYPE_MULTI_LAYER = "multi_layer";
 
 const char* const GNO_IMI_FIRST_ORDER_BUCKETS_COUNT = "first_order_buckets_count";
 const char* const GNO_IMI_SECOND_ORDER_BUCKETS_COUNT = "second_order_buckets_count";

--- a/src/impl/reorder/flatten_reorder.cpp
+++ b/src/impl/reorder/flatten_reorder.cpp
@@ -40,6 +40,14 @@ add_reorder_distance_count(QueryContext& ctx, uint64_t count) {
 }
 
 void
+add_reorder_candidate_count(QueryContext& ctx, uint64_t count) {
+    if (ctx.stats != nullptr) {
+        ctx.stats->reorder_candidate_count.fetch_add(static_cast<uint32_t>(count),
+                                                     std::memory_order_relaxed);
+    }
+}
+
+void
 add_reorder_lower_bound_probe_count(QueryContext& ctx, uint64_t count) {
     if (ctx.stats != nullptr) {
         ctx.stats->reorder_lower_bound_probe_count.fetch_add(static_cast<uint32_t>(count),
@@ -74,6 +82,7 @@ FlattenReorder::Reorder(const vsag::DistHeapPtr& input,
     };
     const uint64_t heap_candidate_size = input == nullptr ? 0 : input->Size();
     if (rabitq_lower_bound_candidates == nullptr) {
+        add_reorder_candidate_count(ctx, heap_candidate_size);
         topk = std::min(topk, static_cast<int64_t>(heap_candidate_size));
         auto reorder_heap = std::make_shared<StandardHeap<true, false>>(query_allocator, topk);
         auto computer = flatten_->FactoryComputer(query);
@@ -160,6 +169,8 @@ FlattenReorder::Reorder(const vsag::DistHeapPtr& input,
             }
         }
     }
+
+    add_reorder_candidate_count(ctx, candidate_size);
 
     topk = std::min(topk, static_cast<int64_t>(candidate_size));
     auto reorder_heap = std::make_shared<StandardHeap<true, false>>(query_allocator, topk);

--- a/src/query_context.h
+++ b/src/query_context.h
@@ -221,6 +221,8 @@ public:
         j["io_cnt"].SetInt(io_cnt.load(std::memory_order_relaxed));
         j["io_time_ms"].SetInt(io_time_ms.load(std::memory_order_relaxed));
         j["reorder_distance_count"].SetInt(reorder_distance_count.load(std::memory_order_relaxed));
+        j["reorder_candidate_count"].SetInt(
+            reorder_candidate_count.load(std::memory_order_relaxed));
         j["reorder_lower_bound_probe_count"].SetInt(
             reorder_lower_bound_probe_count.load(std::memory_order_relaxed));
         j["rabitq_filter_count"].SetInt(rabitq_filter_count.load(std::memory_order_relaxed));
@@ -257,6 +259,7 @@ public:
     std::atomic<uint32_t> io_cnt{0};
     std::atomic<uint32_t> io_time_ms{0};
     std::atomic<uint32_t> reorder_distance_count{0};
+    std::atomic<uint32_t> reorder_candidate_count{0};
     std::atomic<uint32_t> reorder_lower_bound_probe_count{0};
     std::atomic<uint32_t> rabitq_filter_count{0};
     std::atomic<uint32_t> rabitq_full_count{0};

--- a/tests/test_pyramid.cpp
+++ b/tests/test_pyramid.cpp
@@ -24,6 +24,7 @@
 #include <cstring>
 #include <memory>
 #include <nlohmann/json.hpp>
+#include <optional>
 #include <set>
 #include <sstream>
 
@@ -42,6 +43,8 @@ struct PyramidParam {
     bool support_duplicate = false;
     uint64_t rabitq_bits_per_dim_base = 1;
     bool fast_encode_rabitq = true;
+    std::optional<std::string> root_graph_type;
+    std::optional<std::string> graph_storage_type;
 };
 
 namespace fixtures {
@@ -99,11 +102,20 @@ PyramidTestIndex::GeneratePyramidBuildParametersString(const std::string& metric
             "fast_encode_rabitq_rounds": 6,
             "precise_quantization_type": "{}",
             "use_reorder": {},
-            "index_min_size": 28,
+            "index_min_size": 28{},
             "support_duplicate": {}
         }}
     }}
     )";
+    const auto root_graph_parameter =
+        param.root_graph_type.has_value()
+            ? fmt::format(",\n            \"root_graph_type\": \"{}\"", *param.root_graph_type)
+            : "";
+    const auto graph_storage_parameter =
+        param.graph_storage_type.has_value()
+            ? fmt::format(",\n            \"graph_storage_type\": \"{}\"",
+                          *param.graph_storage_type)
+            : "";
     auto build_parameters_str = fmt::format(parameter_temp,
                                             metric_type,
                                             dim,
@@ -114,6 +126,7 @@ PyramidTestIndex::GeneratePyramidBuildParametersString(const std::string& metric
                                             param.fast_encode_rabitq,
                                             param.precise_quantization_type,
                                             param.use_reorder,
+                                            root_graph_parameter + graph_storage_parameter,
                                             param.support_duplicate);
     return build_parameters_str;
 }
@@ -837,6 +850,98 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
         }
     }
     vsag::Options::Instance().set_block_size_limit(origin_size);
+}
+
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
+                             "Pyramid multi-layer root streaming serialization",
+                             "[ft][pyramid][root_graph][streaming]") {
+    const auto graph_storage_type = GENERATE(std::string("flat"), std::string("compressed"));
+    CAPTURE(graph_storage_type);
+    PyramidParam pyramid_param;
+    pyramid_param.no_build_levels = {1, 2};
+    pyramid_param.root_graph_type = "multi_layer";
+    pyramid_param.graph_storage_type = graph_storage_type;
+    const auto param = GeneratePyramidBuildParametersString("l2", 16, pyramid_param);
+    auto index = TestFactory("pyramid", param, true);
+    auto dataset = pool.GetDatasetAndCreate(16, 1000, "l2", /*with_path=*/true);
+    TestBuildIndex(index, dataset, true);
+    const auto search_param = GeneratePyramidSearchParametersString(100);
+
+    SECTION("binary set serialization") {
+        auto binary_set = index->Serialize();
+        REQUIRE(binary_set.has_value());
+        auto restored = TestFactory("pyramid", param, true);
+        REQUIRE(restored->Deserialize(binary_set.value()).has_value());
+        TestKnnSearch(restored, dataset, search_param, 0.94, true);
+    }
+
+    SECTION("streaming serialization and load") {
+        std::stringstream stream;
+        REQUIRE(index->SerializeStreaming(stream).has_value());
+        const auto bytes = stream.str();
+        auto restored = TestFactory("pyramid", param, true);
+        std::stringstream deserialize_stream(bytes);
+        REQUIRE(restored->DeserializeStreaming(deserialize_stream).has_value());
+        TestKnnSearch(restored, dataset, search_param, 0.94, true);
+
+        std::stringstream load_stream(bytes);
+        auto loaded = vsag::Index::Load(load_stream, "{}");
+        REQUIRE(loaded.has_value());
+        TestKnnSearch(loaded.value(), dataset, search_param, 0.94, true);
+    }
+}
+
+TEST_CASE("Pyramid applies root graph type per hierarchy",
+          "[ft][pyramid][root_graph][multi_hierarchy]") {
+    constexpr int64_t dim = 16;
+    constexpr int64_t count = 1000;
+    std::vector<float> vectors(count * dim);
+    std::vector<int64_t> ids(count);
+    std::vector<std::string> paths(count, "");
+    for (int64_t i = 0; i < count; ++i) {
+        ids[i] = i;
+        vectors[i * dim] = static_cast<float>(i);
+    }
+    const std::string params = R"({
+        "dtype":"float32","metric_type":"l2","dim":16,
+        "index_param":{
+            "base_quantization_type":"fp32","use_reorder":false,
+            "graph_type":"nsw","max_degree":32,"ef_construction":100,
+            "build_thread_count":4,"index_min_size":1,"no_build_levels":[],
+            "hierarchies":[
+                {"name":"single","root_graph_type":"single_layer"},
+                {"name":"multi","root_graph_type":"multi_layer"}
+            ]
+        }
+    })";
+    auto index = vsag::Factory::CreateIndex("pyramid", params);
+    REQUIRE(index.has_value());
+    auto base = vsag::Dataset::Make()
+                    ->NumElements(count)
+                    ->Dim(dim)
+                    ->Ids(ids.data())
+                    ->Float32Vectors(vectors.data())
+                    ->Paths("single", paths.data())
+                    ->Paths("multi", paths.data())
+                    ->Owner(false);
+    REQUIRE(index.value()->Build(base).has_value());
+
+    const auto stats = nlohmann::json::parse(index.value()->GetStats());
+    REQUIRE(stats["root_graphs"]["single"]["root_graph_type"] == "single_layer");
+    REQUIRE(stats["root_graphs"]["single"]["route_graph_count"] == 0);
+    REQUIRE(stats["root_graphs"]["multi"]["root_graph_type"] == "multi_layer");
+    REQUIRE(stats["root_graphs"]["multi"]["bottom_graph_node_count"] == count);
+    REQUIRE(stats["root_graphs"]["multi"]["route_graph_count"].get<uint64_t>() > 0);
+
+    auto query = vsag::Dataset::Make()
+                     ->NumElements(1)
+                     ->Dim(dim)
+                     ->Float32Vectors(vectors.data() + 321 * dim)
+                     ->Owner(false);
+    auto result = index.value()->KnnSearch(
+        query, 10, R"({"pyramid":{"ef_search":100,"hierarchies":["multi"]}})");
+    REQUIRE(result.has_value());
+    REQUIRE(result.value()->GetDim() == 10);
 }
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
@@ -2083,26 +2188,32 @@ TEST_CASE("Pyramid ExportCache + ImportCache + Build acceleration smoke test",
     constexpr int64_t TEST_DIM = 32;
     constexpr int64_t TEST_COUNT = 200;
     constexpr int64_t TOPK = 10;
+    const auto graph_storage_type = GENERATE(std::string("flat"), std::string("compressed"));
+    CAPTURE(graph_storage_type);
 
     // params must include persist_source_id: true so ExportCache produces a
     // usable cache after a Build that recorded source_ids. ef_construction equals
     // max_degree to match the HGraph cache-hit refinement eligibility.
-    const auto* param = R"(
-    {
+    const auto param = fmt::format(R"(
+    {{
         "dtype": "float32",
         "metric_type": "l2",
         "dim": 32,
-        "index_param": {
+        "index_param": {{
             "base_quantization_type": "fp32",
             "max_degree": 16,
             "ef_construction": 16,
-            "no_build_levels": [0, 1, 2],
+            "build_thread_count": 8,
+            "root_graph_type": "multi_layer",
+            "graph_storage_type": "{}",
+            "no_build_levels": [1, 2],
             "index_min_size": 28,
             "persist_source_id": true,
             "store_paths": true
-        }
-    }
-    )";
+        }}
+    }}
+    )",
+                                   graph_storage_type);
 
     std::mt19937 rng(42);
     std::uniform_real_distribution<float> dist(-1.0F, 1.0F);
@@ -2114,9 +2225,8 @@ TEST_CASE("Pyramid ExportCache + ImportCache + Build acceleration smoke test",
     for (int64_t i = 0; i < TEST_COUNT; ++i) {
         ids[i] = i + 1;
     }
-    // All vectors share a deep path so they all land in the same leaf
-    // IndexNode (depth 3 with no_build_levels=[0,1,2]), making that leaf
-    // exceed index_min_size and become a GRAPH that fulfill_cache() walks.
+    // All vectors share a deep path. Levels 1 and 2 remain NO_INDEX, while the root and the
+    // depth-3 leaf exceed index_min_size and become GRAPH nodes that fulfill_cache() walks.
     std::vector<std::string> paths(TEST_COUNT, "a/b/c");
     std::vector<std::string> source_ids(TEST_COUNT);
     for (int64_t i = 0; i < TEST_COUNT; ++i) {
@@ -2159,6 +2269,7 @@ TEST_CASE("Pyramid ExportCache + ImportCache + Build acceleration smoke test",
     REQUIRE(restored_data.value()->GetPaths()[0] == "a/b/c");
     auto warm_stats = vsag::JsonType::Parse(warmed->GetStats());
     REQUIRE(warm_stats["build_cache_hit_nodes"].GetInt() > 0);
+    REQUIRE(warm_stats["root_graphs"]["default"]["route_graph_count"].GetInt() > 0);
     std::vector<float> query_vec(TEST_DIM);
     std::copy(vectors.begin(), vectors.begin() + TEST_DIM, query_vec.begin());
     // Pyramid navigates by path; the query must reference the same leaf.

--- a/tools/autotune/autotune_test.cpp
+++ b/tools/autotune/autotune_test.cpp
@@ -942,7 +942,7 @@ TEST_CASE("AutoTune searches an existing Pyramid index for one path workload") {
     auto created = vsag::Factory::CreateIndex("pyramid", create_params);
     REQUIRE(created.has_value());
     REQUIRE(created.value()->Build(base).has_value());
-    REQUIRE(created.value()->GetMemoryUsage() == 0);
+    REQUIRE(created.value()->GetMemoryUsage() > 0);
 
     vsag::autotune::SearchRequest input;
     input.index = created.value();
@@ -966,7 +966,7 @@ TEST_CASE("AutoTune searches an existing Pyramid index for one path workload") {
     REQUIRE(result["recommendation"]["search_params"].contains("pyramid"));
     REQUIRE(result["builds"].empty());
 
-    input.constraints.push_back({vsag::autotune::Metric::INDEX_MEMORY_MB, 1.0});
+    input.constraints.push_back({vsag::autotune::Metric::INDEX_MEMORY_MB, 0.0});
     const auto memory_constrained = vsag::autotune::TuneSearch(input);
     REQUIRE(memory_constrained.has_value());
     REQUIRE(memory_constrained->status == vsag::autotune::TuneStatus::NO_FEASIBLE_CANDIDATE);


### PR DESCRIPTION
## Change Type

- [ ] Bug fix
- [x] New feature
- [x] Improvement/Refactor
- [ ] Documentation
- [ ] CI/Build/Infra

## Linked Issue

Fixes: #2712

## What Changed

- Add per-hierarchy `root_graph_type` with backward-compatible `single_layer` and opt-in `multi_layer`.
- Implement a multi-layer Pyramid root with a preallocated Flat or Compressed bottom graph plus sparse route graphs.
- Build bottom and route edges in one HGraph-style NSW insertion flow inside Pyramid.
- Sample route levels once per batch and insert the highest-level seed before parallel insertion so workers never grow the route-graph container concurrently.
- Parallelize cold-build encoding only for preallocated in-memory FP32, RaBitQ, and SQ8 stores. Keep the existing per-vector insertion submission after ablation showed no meaningful build-time gain from a fixed-worker/block scheduler.
- Apply Pyramid `factor` only after all subgraph candidates are merged, leaving subgraph search budgets unchanged while preserving the caller's final TopK; apply `hops_limit` to leaf searches and expose reorder candidate statistics.
- Keep route entry selection inside `IndexNode`: callers use one node-search path and do not inspect whether routing layers exist.
- Support Build, Add, cache refinement, serialization, streaming serialization, statistics, and memory accounting for both Flat and Compressed multi-layer roots.
- Add focused Build/Add, cache, concurrency, serialization, factor, hops-limit, graph resize, and RaBitQ 3-bit + SQ8 coverage.
- Update the English and Chinese Pyramid documentation.

The final diff contains no HGraph or DataCell implementation changes.

## Construction Design

For `multi_layer`, a Pyramid root owns a pre-sized Flat or Compressed bottom graph containing every root vector and sparse upper route graphs sampled from the same level assignment. Each vector traverses the route hierarchy, connects to the bottom graph, and then connects to its eligible route levels.

The build flow remains linear: populate hierarchy trees, prepare and encode the batch, then insert it. Route sampling, seed insertion, route creation, and point insertion remain internal to the Pyramid/node build path.

Cold Build resizes every configured code store before encoding. Parallel encoding retains main's in-memory FP32/RaBitQ/SQ8 capability boundary and additionally requires the requested ID range to be physically preallocated for every store; otherwise the same encoding path runs sequentially. No DataCell capability API or broader concurrency contract is added.

`multi_layer + odescent` is rejected during parameter validation. Single-layer ODescent remains unchanged. When independent precise storage exists, construction uses precise codes; otherwise it uses base codes. Search uses base codes for graph traversal and the configured reorder source for final reorder.

Warm-cache refinement uses one point lock at a time: it atomically merges, prunes, and writes the current row, releases that lock, then updates reverse rows one by one. This avoids both lost updates and lock-order deadlocks for Sparse, Flat, and Compressed graphs.

## Test Evidence

- [x] clang-format 15 on changed C++ files
- [x] targeted clang-tidy 15 on Pyramid production files
- [x] Debug Pyramid unit tests
- [x] Debug Pyramid root/cache functional tests, including Flat and Compressed warm-cache roots
- [x] ASAN/UBSAN focused Pyramid tests on the feature branch
- [x] Release build and SIFT1M comparison
- [ ] full test suite
- [ ] full coverage suite

```text
cmake --build build --target unittests functests -j96

build/tests/unittests '[ut][PyramidParameters]'
# 17 test cases, 161 assertions passed

build/tests/unittests '[ut][PyramidParameter][CheckCompatibility]'
# 1 test case, 21 assertions passed

build/tests/unittests '[ut][pyramid][factor]'
# 2 test cases, 67 assertions passed

build/tests/unittests '[ut][pyramid][root_graph]'
# 6 test cases, 128 assertions passed

build/tests/unittests '[pyramid_build_cache]'
# 4 test cases, 11 assertions passed

build/tests/functests '[ft][pyramid][cache]'
# 3 test cases, 93 assertions passed

build/tests/functests '[ft][pyramid][root_graph][streaming]'
# 1 test case, 1232 assertions passed

run-clang-tidy-15 -p build -j 2 -quiet \
  '.*src/algorithm/pyramid/(pyramid|pyramid_zparameters)\.cpp$'
git diff --check
# passed
```

Only tests related to the modified Pyramid paths were run locally, per review scope. PR CI remains required.

## SIFT1M Comparison

Configuration: SIFT1M, 1,000,000 x 128-d L2 vectors, RaBitQ 3-bit base + SQ8 precise reorder, NSW, `max_degree=64`, `ef_construction=400`, `alpha=1.0`, 96 build threads pinned to logical CPUs 0-95, TopK 10. HGraph uses Flat graph storage; Pyramid uses `root_graph_type: "multi_layer"` and `no_build_levels: [1]`.

The comparison executables use the same clean dynamic VSAG linkage and do not embed a second BLAS implementation. Search uses one pinned thread. The SIFT1M measurements were collected on the pre-rebase feature head. The current PR is rebased onto upstream main `5096a0a6`; the rebase adapted Pyramid to the upstream `IndexNode` split, retained upstream reasoning support, and removed redundant internal checks, while the latest additional main commit is documentation-only. These changes do not alter the measured cold-build scheduling or search algorithm.

### Pyramid Flat root vs upstream HGraph

| Index | Build wall | CPU time | Avg cores | CPU util. | Build throughput | Memory | Recall@10 | 1-thread QPS (`ef_search=100`) |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| HGraph upstream baseline | 66.878 s | 4296.031 s | 64.237 | 66.913% | 14,953 vec/s | 0.582 GiB | 0.97992 | 1020.4 |
| Pyramid multi-layer Flat root | 35.272 s | 3064.571 s | 86.885 | 90.505% | 28,351 vec/s | 0.612 GiB | 0.98010 | 1054.3 |

At effectively identical recall and the same search parameter, Pyramid builds 1.90x faster and reduces wall time by 47.26%. HGraph is unchanged upstream code.

### Pyramid Flat vs Compressed root

| Root storage | Build wall | CPU time | Avg cores | CPU util. | Build throughput | Index memory | Peak RSS | Bottom-root bytes |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Flat | 35.792 s | 3011.205 s | 84.131 | 87.636% | 27,939 vec/s | 0.613 GiB | 1,504,496 KiB | 268,435,584 |
| Compressed | 36.472 s | 3094.291 s | 84.839 | 88.374% | 27,418 vec/s | 0.457 GiB | 1,361,224 KiB | 100,603,200 |

Compressed saves 160.057 MiB (62.522%) in the bottom root and about 25.45% in total index memory, with a 1.9% build-time increase.

| `ef_search` | Flat recall@10 | Flat QPS | Compressed recall@10 | Compressed QPS |
| ---: | ---: | ---: | ---: | ---: |
| 100 | 0.979760 | 1046.4 | 0.979790 | 965.9 |
| 104 | 0.980220 | 1012.8 | 0.980330 | 931.2 |

## Compatibility Impact

- API/ABI: additive configuration and statistics only; no public signature changes.
- Existing configurations that omit `root_graph_type` retain the `single_layer` default, including hierarchies whose level 0 is disabled.
- Any configuration that explicitly specifies `root_graph_type` while its effective `no_build_levels` contains 0 is rejected, as required by #2712.
- `multi_layer` requires `max_degree > 1` and NSW construction; `multi_layer + odescent` is rejected.
- Released single-layer indexes remain loadable.
- Multi-layer routing data and bottom-graph storage type are included in binary and streaming serialization.
- Requests that omit `factor` or set it to a value no greater than 1 retain their existing behavior. Values greater than 1 limit only the merged main-graph candidates before reorder; explicit invalid factors are rejected.

## Performance and Concurrency Impact

- Per-vector insertion submission is retained. A fixed-worker/64-vector-block ablation did not produce a meaningful build improvement, so that scheduler was removed from this PR.
- Route levels are sampled once per batch; one seed establishes the route structure before parallel insertion.
- Parallel cold-build encoding writes disjoint, validated ID ranges only after all code stores are physically preallocated. Incremental Add, unsupported stores, and non-preallocated paths encode sequentially.
- Submitted tasks are all drained before the first submission or worker exception is rethrown.
- Existing Pyramid locks protect resize lifecycle, graph publication, Add/Search concurrency, cache refinement, and serialization.
- No HGraph construction behavior or DataCell concurrency contract is changed.

## Documentation Impact

- [x] `docs/docs/en/src/indexes/pyramid.md`
- [x] `docs/docs/zh/src/indexes/pyramid.md`

## Risk and Rollback

- Risk level: medium
- Main risks: Pyramid graph-construction concurrency, candidate-budget semantics, and multi-layer serialization.
- Rollback: revert the Pyramid feature/performance commits and rebuild indexes configured with `multi_layer`.

## Checklist

- [x] Linked the relevant issue
- [x] Added focused regression coverage
- [x] Considered compatibility impact
- [x] Updated user-facing docs
- [x] Commit messages follow project conventions
