### PR TITLE
fix(hgraph): relax Tune source coverage

### DIFF
--- a/src/algorithm/hgraph/hgraph.cpp
+++ b/src/algorithm/hgraph/hgraph.cpp
@@ -197,18 +197,21 @@ HGraph::Tune(const std::string& parameters, bool disable_future_tuning) {
 
     FlattenInterfacePtr tune_source;
     if (is_tune_base_code or is_tune_precise_code or is_tune_raw_code) {
-        auto select_larger_source = [&](const FlattenInterfacePtr& codes, bool require_fp32) {
-            if (codes == nullptr or
-                (require_fp32 and codes->GetQuantizerName() != QUANTIZATION_TYPE_VALUE_FP32)) {
-                return;
-            }
-            if (tune_source == nullptr or codes->TotalCount() > tune_source->TotalCount()) {
+        auto select_tune_source = [&](bool require_coverage) {
+            auto select = [&](const FlattenInterfacePtr& codes, bool require_fp32) {
+                if (tune_source != nullptr or codes == nullptr or
+                    (require_fp32 and codes->GetQuantizerName() != QUANTIZATION_TYPE_VALUE_FP32) or
+                    (require_coverage and not covers_active_ids(codes))) {
+                    return;
+                }
                 tune_source = codes;
-            }
+            };
+            select(raw_vector_, false);
+            select(high_precise_codes_, true);
+            select(basic_flatten_codes_, true);
         };
-        select_larger_source(raw_vector_, false);
-        select_larger_source(high_precise_codes_, true);
-        select_larger_source(basic_flatten_codes_, true);
+        select_tune_source(true);
+        select_tune_source(false);
         if (tune_source == nullptr) {
             return false;
         }
@@ -234,12 +237,7 @@ HGraph::Tune(const std::string& parameters, bool disable_future_tuning) {
         }
     };
 
-    // Add failures can leave the published HGraph count ahead of the available FP32 source.
-    // Rebuild the source's readable prefix and leave Add-state recovery to the Add path.
-    const auto source_count =
-        std::min(static_cast<int64_t>(tune_source == nullptr ? 0 : tune_source->TotalCount()),
-                 static_cast<int64_t>(current_count));
-    auto train_count = std::min(this->train_sample_count_, source_count);
+    auto train_count = std::min(this->train_sample_count_, this->GetNumElements());
     Vector<float> train_data(train_count * dim_, 0, allocator_);
     if (is_tune_base_code or is_tune_precise_code or is_tune_raw_code) {
         for (InnerIdType i = 0; i < train_count; i++) {
@@ -270,7 +268,7 @@ HGraph::Tune(const std::string& parameters, bool disable_future_tuning) {
             new_code->Train(train_data.data(), train_count);
 
             Vector<float> insert_buffer(dim_, 0, allocator_);
-            for (int64_t i = 0; i < source_count; ++i) {
+            for (int64_t i = 0; i < current_count; ++i) {
                 decode_tune_source(i, insert_buffer.data());
                 new_code->InsertVector(static_cast<const void*>(insert_buffer.data()), i);
             }

--- a/src/algorithm/hgraph/hgraph.cpp
+++ b/src/algorithm/hgraph/hgraph.cpp
@@ -197,15 +197,19 @@ HGraph::Tune(const std::string& parameters, bool disable_future_tuning) {
 
     FlattenInterfacePtr tune_source;
     if (is_tune_base_code or is_tune_precise_code or is_tune_raw_code) {
-        if (covers_active_ids(raw_vector_)) {
-            tune_source = raw_vector_;
-        } else if (covers_active_ids(high_precise_codes_) and
-                   high_precise_codes_->GetQuantizerName() == QUANTIZATION_TYPE_VALUE_FP32) {
-            tune_source = high_precise_codes_;
-        } else if (covers_active_ids(basic_flatten_codes_) and
-                   basic_flatten_codes_->GetQuantizerName() == QUANTIZATION_TYPE_VALUE_FP32) {
-            tune_source = basic_flatten_codes_;
-        } else {
+        auto select_larger_source = [&](const FlattenInterfacePtr& codes, bool require_fp32) {
+            if (codes == nullptr or
+                (require_fp32 and codes->GetQuantizerName() != QUANTIZATION_TYPE_VALUE_FP32)) {
+                return;
+            }
+            if (tune_source == nullptr or codes->TotalCount() > tune_source->TotalCount()) {
+                tune_source = codes;
+            }
+        };
+        select_larger_source(raw_vector_, false);
+        select_larger_source(high_precise_codes_, true);
+        select_larger_source(basic_flatten_codes_, true);
+        if (tune_source == nullptr) {
             return false;
         }
     }
@@ -230,7 +234,12 @@ HGraph::Tune(const std::string& parameters, bool disable_future_tuning) {
         }
     };
 
-    auto train_count = std::min(this->train_sample_count_, this->GetNumElements());
+    // Add failures can leave the published HGraph count ahead of the available FP32 source.
+    // Rebuild the source's readable prefix and leave Add-state recovery to the Add path.
+    const auto source_count =
+        std::min(static_cast<int64_t>(tune_source == nullptr ? 0 : tune_source->TotalCount()),
+                 static_cast<int64_t>(current_count));
+    auto train_count = std::min(this->train_sample_count_, source_count);
     Vector<float> train_data(train_count * dim_, 0, allocator_);
     if (is_tune_base_code or is_tune_precise_code or is_tune_raw_code) {
         for (InnerIdType i = 0; i < train_count; i++) {
@@ -261,7 +270,7 @@ HGraph::Tune(const std::string& parameters, bool disable_future_tuning) {
             new_code->Train(train_data.data(), train_count);
 
             Vector<float> insert_buffer(dim_, 0, allocator_);
-            for (int64_t i = 0; i < total_count_; ++i) {
+            for (int64_t i = 0; i < source_count; ++i) {
                 decode_tune_source(i, insert_buffer.data());
                 new_code->InsertVector(static_cast<const void*>(insert_buffer.data()), i);
             }

--- a/src/algorithm/hgraph/hgraph.cpp
+++ b/src/algorithm/hgraph/hgraph.cpp
@@ -197,21 +197,17 @@ HGraph::Tune(const std::string& parameters, bool disable_future_tuning) {
 
     FlattenInterfacePtr tune_source;
     if (is_tune_base_code or is_tune_precise_code or is_tune_raw_code) {
-        auto select_tune_source = [&](bool require_coverage) {
-            auto select = [&](const FlattenInterfacePtr& codes, bool require_fp32) {
-                if (tune_source != nullptr or codes == nullptr or
-                    (require_fp32 and codes->GetQuantizerName() != QUANTIZATION_TYPE_VALUE_FP32) or
-                    (require_coverage and not covers_active_ids(codes))) {
-                    return;
-                }
-                tune_source = codes;
-            };
-            select(raw_vector_, false);
-            select(high_precise_codes_, true);
-            select(basic_flatten_codes_, true);
-        };
-        select_tune_source(true);
-        select_tune_source(false);
+        tune_source = raw_vector_;
+        if ((tune_source == nullptr or tune_source->TotalCount() == 0) and
+            high_precise_codes_ != nullptr and
+            high_precise_codes_->GetQuantizerName() == QUANTIZATION_TYPE_VALUE_FP32) {
+            tune_source = high_precise_codes_;
+        }
+        if ((tune_source == nullptr or tune_source->TotalCount() == 0) and
+            basic_flatten_codes_ != nullptr and
+            basic_flatten_codes_->GetQuantizerName() == QUANTIZATION_TYPE_VALUE_FP32) {
+            tune_source = basic_flatten_codes_;
+        }
         if (tune_source == nullptr) {
             return false;
         }

--- a/src/algorithm/hgraph/hgraph_add_test.cpp
+++ b/src/algorithm/hgraph/hgraph_add_test.cpp
@@ -15,8 +15,10 @@
 #include <algorithm>
 #include <atomic>
 #include <chrono>
+#include <functional>
 #include <future>
 #include <initializer_list>
+#include <new>
 #include <sstream>
 #include <string>
 #include <thread>
@@ -34,6 +36,38 @@
 #include "vsag/options.h"
 
 namespace {
+
+class ArmableRejectingThreadPool final : public vsag::ThreadPool {
+public:
+    void
+    WaitUntilEmpty() override {
+    }
+
+    void
+    SetQueueSizeLimit(uint64_t) override {
+    }
+
+    void
+    SetPoolSize(uint64_t) override {
+    }
+
+    std::future<void>
+    Enqueue(std::function<void(void)> task) override {
+        if (reject_submissions_.load(std::memory_order_acquire)) {
+            throw std::bad_alloc();
+        }
+        task();
+        return {};
+    }
+
+    void
+    SetRejectSubmissions(bool reject) {
+        reject_submissions_.store(reject, std::memory_order_release);
+    }
+
+private:
+    std::atomic<bool> reject_submissions_{false};
+};
 
 vsag::DatasetPtr
 MakeFloatDataset(std::vector<float>& vectors,
@@ -161,6 +195,62 @@ const std::string kBruteForceSearchParams =
     R"({"hgraph": {"ef_search": 32, "brute_force_threshold": 1.0}})";
 
 }  // namespace
+
+TEST_CASE("HGraph Tune accepts an incomplete source after Add failure",
+          "[ut][hgraph][add][hgraph_tune_incomplete_source]") {
+    constexpr int64_t dim = 4;
+    constexpr int64_t base_count = 2;
+
+    auto rejecting_pool = std::make_shared<ArmableRejectingThreadPool>();
+    auto common_param = MakeCommonParam(dim);
+    common_param.thread_pool_ = std::make_shared<vsag::SafeThreadPool>(rejecting_pool);
+    auto hgraph_json = vsag::JsonType::Parse(R"({
+        "base_quantization_type": "sq8",
+        "max_degree": 8,
+        "ef_construction": 32,
+        "build_thread_count": 1,
+        "store_raw_vector": true
+    })");
+    auto index = MakeHGraphIndex(hgraph_json, common_param);
+
+    std::vector<float> base_vectors = {
+        0.0F,
+        0.0F,
+        0.0F,
+        0.0F,
+        1.0F,
+        1.0F,
+        1.0F,
+        1.0F,
+    };
+    std::vector<int64_t> base_ids = {10, 20};
+    auto base = MakeFloatDataset(base_vectors, base_ids, dim, base_count);
+    REQUIRE(index->Build(base).has_value());
+    REQUIRE(index->GetNumElements() == base_count);
+
+    std::vector<float> add_vectors = {2.0F, 2.0F, 2.0F, 2.0F};
+    std::vector<int64_t> add_ids = {30};
+    auto add = MakeFloatDataset(add_vectors, add_ids, dim, 1);
+
+    rejecting_pool->SetRejectSubmissions(true);
+    auto add_result = index->Add(add);
+    rejecting_pool->SetRejectSubmissions(false);
+
+    REQUIRE_FALSE(add_result.has_value());
+    REQUIRE(add_result.error().type == vsag::ErrorType::NO_ENOUGH_MEMORY);
+    REQUIRE(index->GetNumElements() == base_count + 1);
+    REQUIRE(index->CheckIdExist(add_ids[0]));
+
+    auto tune_result = index->Tune(R"({
+        "index_param": {
+            "base_quantization_type": "bf16",
+            "max_degree": 8,
+            "ef_construction": 32
+        }
+    })");
+    REQUIRE(tune_result.has_value());
+    CHECK(tune_result.value());
+}
 
 TEST_CASE("HGraph exact duplicate fallback supports every dense data type",
           "[ut][hgraph][duplicate][data_type]") {


### PR DESCRIPTION
## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement/Refactor
- [ ] Documentation
- [ ] CI/Build/Infra

## Linked Issue

- Fixes: #2718

## What Changed

- Select the Tune source with direct raw, precise FP32, then base FP32 checks; only fall through when the current candidate is absent or empty.
- Do not require the selected source to cover the published ID range.
- Preserve the pre-#2466 training count and rebuild the complete published HGraph ID range.
- Add a regression test for an Add submission failure that leaves HGraph metadata ahead of codes.

## Test Evidence

- [x] Other (describe below)

Test details:

```text
clang-format-15 --dry-run --Werror src/algorithm/hgraph/hgraph.cpp src/algorithm/hgraph/hgraph_add_test.cpp
git diff --check
cmake --build build --target unittests functests --parallel 6
./build/tests/unittests '[hgraph_tune_incomplete_source]' --allow-running-no-tests
./build/tests/unittests '[tune]' --allow-running-no-tests
./build/tests/functests '[tune_codes]' --allow-running-no-tests
```

Results: 8 regression assertions, 7 deduplicated-Tune assertions, and 8040 Tune-source assertions passed.

## Compatibility Impact

- API/ABI compatibility: none
- Behavior changes: Tune no longer rejects an otherwise available raw/FP32 source solely because its logical count is behind the published HGraph count. Training and rebuilding retain the pre-#2466 ranges.

## Performance and Concurrency Impact

- Performance impact: consistent indexes are unchanged; inconsistent indexes rebuild the full published ID range, matching legacy Tune behavior.
- Concurrency/thread-safety impact: none; Tune keeps its existing Add serialization.

## Documentation Impact

- [x] No docs update needed
- [ ] Updated docs:
  - [ ] `README.md`
  - [ ] `DEVELOPMENT.md`
  - [ ] `CONTRIBUTING.md`
  - [ ] Other:

## Risk and Rollback

- Risk level: medium
- Residual risk: Add-state consistency and invalid individual slots remain outside this PR.
- Rollback plan: revert these commits to restore strict source coverage rejection.

## Checklist

- [x] I have linked the relevant issue.
- [x] I have added/updated tests for the bug fix.
- [x] I have considered API compatibility impact.
- [x] I have updated docs if behavior/workflow changed.
- [x] My commit messages follow project conventions.
