### PR TITLE
[0.18] fix(hgraph): relax Tune source coverage

### DIFF
--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -583,15 +583,19 @@ HGraph::Tune(const std::string& parameters, bool disable_future_tuning) {
 
     FlattenInterfacePtr tune_source;
     if (is_tune_base_code or is_tune_precise_code) {
-        if (covers_active_ids(raw_vector_)) {
-            tune_source = raw_vector_;
-        } else if (covers_active_ids(high_precise_codes_) and
-                   high_precise_codes_->GetQuantizerName() == QUANTIZATION_TYPE_VALUE_FP32) {
-            tune_source = high_precise_codes_;
-        } else if (covers_active_ids(basic_flatten_codes_) and
-                   basic_flatten_codes_->GetQuantizerName() == QUANTIZATION_TYPE_VALUE_FP32) {
-            tune_source = basic_flatten_codes_;
-        } else {
+        auto select_larger_source = [&](const FlattenInterfacePtr& codes, bool require_fp32) {
+            if (codes == nullptr or
+                (require_fp32 and codes->GetQuantizerName() != QUANTIZATION_TYPE_VALUE_FP32)) {
+                return;
+            }
+            if (tune_source == nullptr or codes->TotalCount() > tune_source->TotalCount()) {
+                tune_source = codes;
+            }
+        };
+        select_larger_source(raw_vector_, false);
+        select_larger_source(high_precise_codes_, true);
+        select_larger_source(basic_flatten_codes_, true);
+        if (tune_source == nullptr) {
             return false;
         }
     }
@@ -616,7 +620,12 @@ HGraph::Tune(const std::string& parameters, bool disable_future_tuning) {
         }
     };
 
-    auto train_count = std::min(this->train_sample_count_, this->GetNumElements());
+    // Add failures can leave the published HGraph count ahead of the available FP32 source.
+    // Rebuild the source's readable prefix and leave Add-state recovery to the Add path.
+    const auto source_count =
+        std::min(static_cast<int64_t>(tune_source == nullptr ? 0 : tune_source->TotalCount()),
+                 static_cast<int64_t>(current_count));
+    auto train_count = std::min(this->train_sample_count_, source_count);
     Vector<float> train_data(train_count * dim_, 0, allocator_);
     if (is_tune_base_code or is_tune_precise_code) {
         for (InnerIdType i = 0; i < train_count; i++) {
@@ -633,7 +642,7 @@ HGraph::Tune(const std::string& parameters, bool disable_future_tuning) {
             new_code->Train(train_data.data(), train_count);
 
             Vector<float> insert_buffer(dim_, 0, allocator_);
-            for (int64_t i = 0; i < current_count; ++i) {
+            for (int64_t i = 0; i < source_count; ++i) {
                 decode_tune_source(i, insert_buffer.data());
                 new_code->InsertVector(static_cast<const void*>(insert_buffer.data()), i);
             }

--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -583,18 +583,21 @@ HGraph::Tune(const std::string& parameters, bool disable_future_tuning) {
 
     FlattenInterfacePtr tune_source;
     if (is_tune_base_code or is_tune_precise_code) {
-        auto select_larger_source = [&](const FlattenInterfacePtr& codes, bool require_fp32) {
-            if (codes == nullptr or
-                (require_fp32 and codes->GetQuantizerName() != QUANTIZATION_TYPE_VALUE_FP32)) {
-                return;
-            }
-            if (tune_source == nullptr or codes->TotalCount() > tune_source->TotalCount()) {
+        auto select_tune_source = [&](bool require_coverage) {
+            auto select = [&](const FlattenInterfacePtr& codes, bool require_fp32) {
+                if (tune_source != nullptr or codes == nullptr or
+                    (require_fp32 and codes->GetQuantizerName() != QUANTIZATION_TYPE_VALUE_FP32) or
+                    (require_coverage and not covers_active_ids(codes))) {
+                    return;
+                }
                 tune_source = codes;
-            }
+            };
+            select(raw_vector_, false);
+            select(high_precise_codes_, true);
+            select(basic_flatten_codes_, true);
         };
-        select_larger_source(raw_vector_, false);
-        select_larger_source(high_precise_codes_, true);
-        select_larger_source(basic_flatten_codes_, true);
+        select_tune_source(true);
+        select_tune_source(false);
         if (tune_source == nullptr) {
             return false;
         }
@@ -620,12 +623,7 @@ HGraph::Tune(const std::string& parameters, bool disable_future_tuning) {
         }
     };
 
-    // Add failures can leave the published HGraph count ahead of the available FP32 source.
-    // Rebuild the source's readable prefix and leave Add-state recovery to the Add path.
-    const auto source_count =
-        std::min(static_cast<int64_t>(tune_source == nullptr ? 0 : tune_source->TotalCount()),
-                 static_cast<int64_t>(current_count));
-    auto train_count = std::min(this->train_sample_count_, source_count);
+    auto train_count = std::min(this->train_sample_count_, this->GetNumElements());
     Vector<float> train_data(train_count * dim_, 0, allocator_);
     if (is_tune_base_code or is_tune_precise_code) {
         for (InnerIdType i = 0; i < train_count; i++) {
@@ -642,7 +640,7 @@ HGraph::Tune(const std::string& parameters, bool disable_future_tuning) {
             new_code->Train(train_data.data(), train_count);
 
             Vector<float> insert_buffer(dim_, 0, allocator_);
-            for (int64_t i = 0; i < source_count; ++i) {
+            for (int64_t i = 0; i < current_count; ++i) {
                 decode_tune_source(i, insert_buffer.data());
                 new_code->InsertVector(static_cast<const void*>(insert_buffer.data()), i);
             }

--- a/src/algorithm/hgraph.cpp
+++ b/src/algorithm/hgraph.cpp
@@ -583,21 +583,17 @@ HGraph::Tune(const std::string& parameters, bool disable_future_tuning) {
 
     FlattenInterfacePtr tune_source;
     if (is_tune_base_code or is_tune_precise_code) {
-        auto select_tune_source = [&](bool require_coverage) {
-            auto select = [&](const FlattenInterfacePtr& codes, bool require_fp32) {
-                if (tune_source != nullptr or codes == nullptr or
-                    (require_fp32 and codes->GetQuantizerName() != QUANTIZATION_TYPE_VALUE_FP32) or
-                    (require_coverage and not covers_active_ids(codes))) {
-                    return;
-                }
-                tune_source = codes;
-            };
-            select(raw_vector_, false);
-            select(high_precise_codes_, true);
-            select(basic_flatten_codes_, true);
-        };
-        select_tune_source(true);
-        select_tune_source(false);
+        tune_source = raw_vector_;
+        if ((tune_source == nullptr or tune_source->TotalCount() == 0) and
+            high_precise_codes_ != nullptr and
+            high_precise_codes_->GetQuantizerName() == QUANTIZATION_TYPE_VALUE_FP32) {
+            tune_source = high_precise_codes_;
+        }
+        if ((tune_source == nullptr or tune_source->TotalCount() == 0) and
+            basic_flatten_codes_ != nullptr and
+            basic_flatten_codes_->GetQuantizerName() == QUANTIZATION_TYPE_VALUE_FP32) {
+            tune_source = basic_flatten_codes_;
+        }
         if (tune_source == nullptr) {
             return false;
         }

--- a/src/algorithm/hgraph_add_test.cpp
+++ b/src/algorithm/hgraph_add_test.cpp
@@ -1,0 +1,141 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <atomic>
+#include <catch2/catch_test_macros.hpp>
+#include <functional>
+#include <future>
+#include <new>
+#include <vector>
+
+#include "hgraph.h"
+#include "impl/allocator/safe_allocator.h"
+#include "impl/thread_pool/safe_thread_pool.h"
+#include "index/index_impl.h"
+
+namespace {
+
+class ArmableRejectingThreadPool final : public vsag::ThreadPool {
+public:
+    void
+    WaitUntilEmpty() override {
+    }
+
+    void
+    SetQueueSizeLimit(std::size_t) override {
+    }
+
+    void
+    SetPoolSize(std::size_t) override {
+    }
+
+    std::future<void>
+    Enqueue(std::function<void(void)> task) override {
+        if (reject_submissions_.load(std::memory_order_acquire)) {
+            throw std::bad_alloc();
+        }
+        task();
+        return {};
+    }
+
+    void
+    SetRejectSubmissions(bool reject) {
+        reject_submissions_.store(reject, std::memory_order_release);
+    }
+
+private:
+    std::atomic<bool> reject_submissions_{false};
+};
+
+vsag::DatasetPtr
+MakeFloatDataset(std::vector<float>& vectors,
+                 std::vector<int64_t>& ids,
+                 int64_t dim,
+                 int64_t count) {
+    auto dataset = vsag::Dataset::Make();
+    dataset->NumElements(count)
+        ->Dim(dim)
+        ->Ids(ids.data())
+        ->Float32Vectors(vectors.data())
+        ->Owner(false);
+    return dataset;
+}
+
+vsag::IndexCommonParam
+MakeCommonParam(int64_t dim) {
+    vsag::IndexCommonParam common_param;
+    common_param.dim_ = dim;
+    common_param.metric_ = vsag::MetricType::METRIC_TYPE_L2SQR;
+    common_param.data_type_ = vsag::DataTypes::DATA_TYPE_FLOAT;
+    common_param.allocator_ = vsag::SafeAllocator::FactoryDefaultAllocator();
+    return common_param;
+}
+
+}  // namespace
+
+TEST_CASE("HGraph Tune accepts an incomplete source after Add failure",
+          "[ut][hgraph][add][hgraph_tune_incomplete_source]") {
+    constexpr int64_t dim = 4;
+    constexpr int64_t base_count = 2;
+
+    auto rejecting_pool = std::make_shared<ArmableRejectingThreadPool>();
+    auto common_param = MakeCommonParam(dim);
+    common_param.thread_pool_ = std::make_shared<vsag::SafeThreadPool>(rejecting_pool);
+    auto hgraph_json = vsag::JsonType::Parse(R"({
+        "base_quantization_type": "sq8",
+        "max_degree": 8,
+        "ef_construction": 32,
+        "build_thread_count": 1,
+        "store_raw_vector": true
+    })");
+    auto index = std::make_shared<vsag::IndexImpl<vsag::HGraph>>(hgraph_json, common_param);
+
+    std::vector<float> base_vectors = {
+        0.0F,
+        0.0F,
+        0.0F,
+        0.0F,
+        1.0F,
+        1.0F,
+        1.0F,
+        1.0F,
+    };
+    std::vector<int64_t> base_ids = {10, 20};
+    auto base = MakeFloatDataset(base_vectors, base_ids, dim, base_count);
+    REQUIRE(index->Build(base).has_value());
+    REQUIRE(index->GetNumElements() == base_count);
+
+    std::vector<float> add_vectors = {2.0F, 2.0F, 2.0F, 2.0F};
+    std::vector<int64_t> add_ids = {30};
+    auto add = MakeFloatDataset(add_vectors, add_ids, dim, 1);
+
+    rejecting_pool->SetRejectSubmissions(true);
+    auto add_result = index->Add(add);
+    rejecting_pool->SetRejectSubmissions(false);
+
+    REQUIRE_FALSE(add_result.has_value());
+    REQUIRE(add_result.error().type == vsag::ErrorType::NO_ENOUGH_MEMORY);
+    REQUIRE(index->GetNumElements() == base_count + 1);
+    REQUIRE(index->CheckIdExist(add_ids[0]));
+
+    auto tune_result = index->Tune(R"({
+        "index_param": {
+            "base_quantization_type": "bf16",
+            "max_degree": 8,
+            "ef_construction": 32
+        }
+    })");
+    REQUIRE(tune_result.has_value());
+    CHECK(tune_result.value());
+}


### PR DESCRIPTION
## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Documentation

## Linked Issue

Fixes: #2718

## What Changed

- Select the Tune source with direct raw, precise FP32, then base FP32 checks; only fall through when the current candidate is absent or empty.
- Do not require the selected source to cover the published ID range.
- Preserve the pre-#2476 training count and rebuild the complete published HGraph ID range.
- Add regression coverage for a failed Add that publishes an ID before vector insertion completes.

This is the `0.18` backport of the fix proposed for `main`.

## How It Was Tested

- `clang-format-15 --dry-run --Werror src/algorithm/hgraph.cpp src/algorithm/hgraph_add_test.cpp`
- `git diff --check`
- Built `unittests` and `functests`
- `./build/tests/unittests '[hgraph_tune_incomplete_source]' --allow-running-no-tests` (8 assertions)
- `./build/tests/functests '[tune_codes]' --allow-running-no-tests` (8033 assertions)

## Compatibility and Risk

- No public API or ABI change.
- Consistent indexes are unchanged.
- Inconsistent indexes rebuild the full published ID range, matching pre-#2476 Tune behavior.
- Add-state consistency and invalid individual slots remain outside this PR.

## Checklist

- [x] Regression test added
- [x] Existing Tune functional test passes
- [x] No public API change
- [x] No documentation change required
