### PR TITLE
ci: trial self-hosted runner for PR change detection

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   changes:
     name: Detect Changes
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     outputs:
       cpp: ${{ steps.changes.outputs.cpp }}
       cmake: ${{ steps.changes.outputs.cmake }}


### PR DESCRIPTION
## What changed

- run the PR CI `Detect Changes` job on runners labeled `self-hosted`
- keep build, test, and macOS jobs on their existing GitHub-hosted runners for the initial trial

## Why

New self-hosted runners are available for the repository. Routing the lightweight PR change-detection gate to them validates scheduling and basic action execution before migrating jobs that install host packages, delete hosted-tool caches, or mount host paths into containers.

## Impact

Every PR CI run now requires an available `self-hosted` runner for change detection. The remaining jobs retain their current runner environments.

## Validation

- `git diff --check`
- workflow YAML parsed successfully with Ruby Psych
