### PR TITLE
ci(workflows): switch runners to self-hosted

### DIFF
--- a/.github/workflows/asan_build_and_test.yml
+++ b/.github/workflows/asan_build_and_test.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build_asan_x86:
     name: Asan Build X86
-    runs-on: ubuntu-22.04
+    runs-on: [ linux, self-hosted, X64 ]
     container:
       image: vsaglib/vsag:ci-x86-mkl
       volumes:
@@ -125,7 +125,7 @@ jobs:
   test_asan_x86:
     name: Test X86
     needs: build_asan_x86
-    runs-on: ubuntu-22.04
+    runs-on: [ linux, self-hosted, X64 ]
     concurrency:
       group: test_asan_x86-${{ matrix.test_type }}-${{ github.event.pull_request.number || github.sha }}
       cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -246,7 +246,7 @@ jobs:
   test_example_x86:
     name: Test Example X86
     needs: build_asan_x86
-    runs-on: ubuntu-22.04
+    runs-on: [ linux, self-hosted, X64 ]
     container:
       image: vsaglib/vsag:ci-x86-mkl
       volumes:
@@ -276,7 +276,7 @@ jobs:
               $example
             fi
           done
-  
+
   test_example_aarch64:
     name: Test Example Aarch64
     needs: build_asan_aarch64

--- a/.github/workflows/asan_with_simd_option.yml
+++ b/.github/workflows/asan_with_simd_option.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build_asan_simd:
     name: Asan Build Simd
-    runs-on: ubuntu-22.04
+    runs-on: [ linux, self-hosted, X64 ]
     container:
       image: vsaglib/vsag:ci-x86-mkl
       volumes:
@@ -58,7 +58,7 @@ jobs:
   test_asan_simd:
     name: Unit Test Simd
     needs: build_asan_simd
-    runs-on: ubuntu-22.04
+    runs-on: [ linux, self-hosted ]
     strategy:
       matrix:
         test_type: [ unittests, functests ]

--- a/.github/workflows/daily_test.yml
+++ b/.github/workflows/daily_test.yml
@@ -3,12 +3,12 @@ name: Daily Build & Test
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 14 * * *' 
+    - cron: '0 14 * * *'
 
 jobs:
   daily_build_asan_x86:
     name: Asan Build X86
-    runs-on: ubuntu-22.04
+    runs-on: [ linux, self-hosted, X64 ]
     container:
       image: vsaglib/vsag:ci-x86-openblas
       volumes:
@@ -86,7 +86,7 @@ jobs:
   daily_test_asan_x86:
     name: Test X86
     needs: daily_build_asan_x86
-    runs-on: ubuntu-22.04
+    runs-on: [ linux, self-hosted, X64 ]
     concurrency:
       group: daily_test_x86-${{ matrix.test_type }}
       cancel-in-progress: true
@@ -196,7 +196,7 @@ jobs:
 
   daily_build_simd:
     name: Asan Build Simd
-    runs-on: ubuntu-22.04
+    runs-on: [ linux, self-hosted, X64 ]
     container:
       image: vsaglib/vsag:ci-x86-mkl
       volumes:
@@ -240,7 +240,7 @@ jobs:
   daily_test_asan_simd:
     name: Unit Test Simd
     needs: daily_build_simd
-    runs-on: ubuntu-22.04
+    runs-on: [ linux, self-hosted ]
     strategy:
       matrix:
         test_type: [ unittests, functests ]
@@ -303,7 +303,7 @@ jobs:
 
   daily_build_tsan:
     name: Daily Build with TSAN
-    runs-on: ubuntu-22.04
+    runs-on: [ linux, self-hosted, X64 ]
     concurrency:
       group: daily_build_tsan_x86
       cancel-in-progress: true
@@ -336,7 +336,7 @@ jobs:
   daily_test_tsan:
     name: Daily Run TSAN Tests
     needs: daily_build_tsan
-    runs-on: ubuntu-22.04
+    runs-on: [ linux, self-hosted, X64 ]
     concurrency:
       group: daily_test_tsan_x86
       cancel-in-progress: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,8 +10,7 @@ on:
 jobs:
   clang-tidy-check:
     name: Lint
-    runs-on: ubuntu-latest
-    # runs-on: self-hosted
+    runs-on: [ linux, self-hosted ]
     container:
       image: vsaglib/vsag:ci-x86-openblas
     env:

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -57,7 +57,7 @@ jobs:
     name: Format Check
     needs: changes
     if: needs.changes.outputs.cpp == 'true' || needs.changes.outputs.python == 'true'
-    runs-on: ubuntu-22.04
+    runs-on: [linux, self-hosted]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -74,7 +74,7 @@ jobs:
     name: ASan Build X86
     needs: [changes, format]
     if: needs.changes.outputs.cpp == 'true'
-    runs-on: ubuntu-22.04
+    runs-on: [linux, self-hosted, X64]
     env:
       VSAG_FETCHCONTENT_BASE_DIR: ${{ github.workspace }}/.ci-fetchcontent
       VSAG_THIRDPARTY_DOWNLOAD_DIR: ${{ github.workspace }}/.ci-downloads
@@ -161,7 +161,7 @@ jobs:
           name: build-x86-${{ github.run_id }}
           compression-level: 1
           retention-days: 1
-          overwrite: 'true'
+          overwrite: "true"
 
   build-asan-macos-arm64:
     name: ASan Build macOS arm64
@@ -194,10 +194,8 @@ jobs:
     name: Python Build X86
     needs: [changes, format]
     if: needs.changes.outputs.python == 'true' || needs.changes.outputs.cmake == 'true'
-    runs-on: ubuntu-22.04
+    runs-on: [linux, self-hosted, X64]
     steps:
-      - name: Free Disk Space
-        run: rm -rf /opt/hostedtoolcache
       - uses: actions/checkout@v4
       - name: Prepare Env
         run: sudo bash ./scripts/deps/install_deps_ubuntu.sh
@@ -222,13 +220,13 @@ jobs:
           name: wheelhouse-x86-${{ github.run_id }}
           compression-level: 1
           retention-days: 1
-          overwrite: 'true'
+          overwrite: "true"
 
   test-asan-x86-unittests:
     name: Test X86 Unittests
     needs: [changes, build-asan-x86]
     if: needs.changes.outputs.cpp == 'true'
-    runs-on: ubuntu-22.04
+    runs-on: [linux, self-hosted, X64]
     container:
       image: vsaglib/vsag:ci-x86-openblas
       volumes:
@@ -262,13 +260,13 @@ jobs:
           name: log-x86-unittests-${{ github.run_id }}
           compression-level: 1
           retention-days: 3
-          overwrite: 'true'
+          overwrite: "true"
 
   test-asan-x86-functests:
     name: Test X86 Functests
     needs: [changes, build-asan-x86]
     if: needs.changes.outputs.cpp == 'true'
-    runs-on: ubuntu-22.04
+    runs-on: [linux, self-hosted, X64]
     env:
       LD_LIBRARY_PATH: ${{ github.workspace }}/build/src
     container:
@@ -302,13 +300,13 @@ jobs:
           name: log-x86-functests-${{ github.run_id }}
           compression-level: 1
           retention-days: 3
-          overwrite: 'true'
+          overwrite: "true"
 
   test-example-x86:
     name: Test Example X86
     needs: [changes, build-asan-x86]
     if: needs.changes.outputs.cpp == 'true'
-    runs-on: ubuntu-22.04
+    runs-on: [linux, self-hosted, X64]
     container:
       image: vsaglib/vsag:ci-x86-openblas
       volumes:
@@ -342,7 +340,7 @@ jobs:
     name: Check Compatibility
     needs: [changes, build-asan-x86]
     if: needs.changes.outputs.cpp == 'true'
-    runs-on: ubuntu-22.04
+    runs-on: [linux, self-hosted, X64]
     env:
       LD_LIBRARY_PATH: ${{ github.workspace }}/build/src
     container:
@@ -393,7 +391,7 @@ jobs:
     name: Test Python X86
     needs: [changes, build-python-x86]
     if: needs.changes.outputs.python == 'true' || needs.changes.outputs.cmake == 'true'
-    runs-on: ubuntu-22.04
+    runs-on: [linux, self-hosted, X64]
     steps:
       - name: Free Disk Space
         run: rm -rf /opt/hostedtoolcache

--- a/.github/workflows/tsan_build_and_test.yml
+++ b/.github/workflows/tsan_build_and_test.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   changes:
     name: Detect Changes
-    runs-on: ubuntu-latest
+    runs-on: [ linux, self-hosted ]
     outputs:
       non_markdown: ${{ steps.changes.outputs.non_markdown }}
     steps:
@@ -34,7 +34,7 @@ jobs:
     name: Build with TSAN
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.non_markdown == 'true'
-    runs-on: ubuntu-22.04
+    runs-on: [ linux, self-hosted ]
     env:
       # TSan instruments VSAG, not third-party dependencies. The daily x86 ASan job
       # remains the dedicated guard for building bundled OpenBLAS from source.
@@ -75,7 +75,7 @@ jobs:
     name: Run TSAN Tests
     needs: [changes, build_tsan]
     if: github.event_name != 'pull_request' || needs.changes.outputs.non_markdown == 'true'
-    runs-on: ubuntu-22.04
+    runs-on: [ linux, self-hosted, X64 ]
     concurrency:
       group: test_tsan_x86-${{ github.event.pull_request.number || github.sha }}
       cancel-in-progress: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement/Refactor
- [ ] Documentation
- [x] CI/Build/Infra

## Linked Issue

None

## What Changed

- replace `ubuntu-22.04`/`ubuntu-latest` with self-hosted `linux` labels
- remove the `Free Disk Space` step from python build x86 job
- standardize `overwrite` values to double quotes

## Test Evidence

- [ ] `make fmt`
- [ ] `make lint`
- [ ] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [x] Other (describe below)

Test details:

Tested with [GitHub Action Lint](https://github.com/rhysd/actionlint)

**Note that this is not a full update, only the configurations with longer runtime are being updated. If it runs as expected, then a full update will follow next.**

## Documentation Impact

- [x] No docs update needed
- [ ] Updated docs:
  - [ ] `README.md`
  - [ ] `DEVELOPMENT.md`
  - [ ] `CONTRIBUTING.md`
  - [ ] Other: <!-- path -->

## Risk and Rollback

- Risk level: low
- Rollback plan: change back the origin configures

## Checklist

- [x] I have linked the relevant issue (required for `kind/bug` and `kind/feature`; see "Linked Issue" above)
- [x] I have added/updated tests for new behavior or bug fixes
- [x] I have considered API compatibility impact
- [x] I have updated docs if behavior/workflow changed
- [x] My commit messages follow project conventions (Conventional Commits, optional `[skip ci]` prefix)