### PR TITLE
refactor(datacell): extract fixed layout storage

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,7 @@
 
 add_subdirectory (simd)
 add_subdirectory (io)
+add_subdirectory (layout)
 add_subdirectory (quantization)
 add_subdirectory (impl)
 add_subdirectory (storage)

--- a/src/datacell/extra_info_datacell.h
+++ b/src/datacell/extra_info_datacell.h
@@ -17,21 +17,20 @@
 #include <algorithm>
 #include <limits>
 #include <memory>
+#include <utility>
 
 #include "extra_info_interface.h"
-#include "io/common/basic_io.h"
-#include "io/memory_block_io/memory_block_io.h"
-#include "quantization/quantizer.h"
-#include "utils/byte_buffer.h"
+#include "layout/fixed_layout.h"
 
 namespace vsag {
 /*
 * thread unsafe
 */
-template <typename IOTmpl>
+template <typename LayoutTmpl>
 class ExtraInfoDataCell : public ExtraInfoInterface {
 public:
-    ExtraInfoDataCell() = default;
+    ExtraInfoDataCell() : layout_(std::make_shared<LayoutTmpl>()) {
+    }
 
     explicit ExtraInfoDataCell(const IOParamPtr& io_param, const IndexCommonParam& common_param);
 
@@ -43,7 +42,7 @@ public:
 
     void
     Prefetch(InnerIdType id) override {
-        io_->Prefetch(id * extra_info_size_, extra_info_size_);
+        layout_->Prefetch(id, extra_info_size_);
     };
 
     void
@@ -51,9 +50,7 @@ public:
         if (new_capacity <= this->max_capacity_) {
             return;
         }
-        uint64_t io_size =
-            static_cast<uint64_t>(new_capacity) * static_cast<uint64_t>(extra_info_size_);
-        this->io_->Resize(io_size);
+        this->layout_->Resize(new_capacity);
         this->max_capacity_ = new_capacity;
     }
 
@@ -62,7 +59,7 @@ public:
         if (extra_info == nullptr) {
             return;
         }
-        io_->Release(reinterpret_cast<const uint8_t*>(extra_info));
+        layout_->Release(reinterpret_cast<const uint8_t*>(extra_info));
     }
 
     [[nodiscard]] bool
@@ -88,57 +85,49 @@ public:
 
     void
     ShrinkToFit(InnerIdType capacity) override {
-        uint64_t io_size =
-            static_cast<uint64_t>(capacity) * static_cast<uint64_t>(extra_info_size_);
-        this->io_->Shrink(io_size);
+        this->layout_->Shrink(capacity);
         this->max_capacity_ = capacity;
         this->total_count_ = std::min(this->total_count_, capacity);
     }
 
     inline void
-    SetIO(std::shared_ptr<BasicIO<IOTmpl>> io) {
-        this->io_ = io;
+    SetIO(std::shared_ptr<BasicIO<typename LayoutTmpl::IOType>> io) {
+        this->layout_->SetIO(std::move(io));
     }
 
 public:
-    std::shared_ptr<BasicIO<IOTmpl>> io_{nullptr};
+    std::shared_ptr<LayoutTmpl> layout_{nullptr};
 
     Allocator* const allocator_{nullptr};
 };
 
-template <typename IOTmpl>
-ExtraInfoDataCell<IOTmpl>::ExtraInfoDataCell(const IOParamPtr& io_param,
-                                             const IndexCommonParam& common_param)
+template <typename LayoutTmpl>
+ExtraInfoDataCell<LayoutTmpl>::ExtraInfoDataCell(const IOParamPtr& io_param,
+                                                 const IndexCommonParam& common_param)
     : allocator_(common_param.allocator_.get()) {
     this->extra_info_size_ = common_param.extra_info_size_;
-    this->io_ = std::make_shared<IOTmpl>(io_param, common_param);
+    this->layout_ = std::make_shared<LayoutTmpl>(this->extra_info_size_, io_param, common_param);
 }
 
-template <typename IOTmpl>
+template <typename LayoutTmpl>
 void
-ExtraInfoDataCell<IOTmpl>::InsertExtraInfo(const char* extra_info, InnerIdType idx) {
+ExtraInfoDataCell<LayoutTmpl>::InsertExtraInfo(const char* extra_info, InnerIdType idx) {
     if (idx == std::numeric_limits<InnerIdType>::max()) {
         idx = total_count_;
         ++total_count_;
     } else {
         total_count_ = std::max(total_count_, idx + 1);
     }
-    io_->Write(reinterpret_cast<const uint8_t*>(extra_info),
-               extra_info_size_,
-               static_cast<uint64_t>(idx) * static_cast<uint64_t>(extra_info_size_));
+    layout_->Write(idx, reinterpret_cast<const uint8_t*>(extra_info));
 }
 
-template <typename IOTmpl>
+template <typename LayoutTmpl>
 void
-ExtraInfoDataCell<IOTmpl>::BatchInsertExtraInfo(const char* extra_infos,
-                                                InnerIdType count,
-                                                InnerIdType* idx) {
+ExtraInfoDataCell<LayoutTmpl>::BatchInsertExtraInfo(const char* extra_infos,
+                                                    InnerIdType count,
+                                                    InnerIdType* idx) {
     if (idx == nullptr) {
-        // length of extra info is fixed currently
-        io_->Write(reinterpret_cast<const uint8_t*>(extra_infos),
-                   static_cast<uint64_t>(count) * static_cast<uint64_t>(extra_info_size_),
-                   static_cast<uint64_t>(total_count_) * static_cast<uint64_t>(extra_info_size_));
-
+        layout_->WriteRange(total_count_, reinterpret_cast<const uint8_t*>(extra_infos), count);
         total_count_ += count;
     } else {
         for (int64_t i = 0; i < count; ++i) {
@@ -147,63 +136,52 @@ ExtraInfoDataCell<IOTmpl>::BatchInsertExtraInfo(const char* extra_infos,
     }
 }
 
-template <typename IOTmpl>
+template <typename LayoutTmpl>
 bool
-ExtraInfoDataCell<IOTmpl>::InMemory() const {
-    return IOTmpl::InMemory;
+ExtraInfoDataCell<LayoutTmpl>::InMemory() const {
+    return LayoutTmpl::InMemory;
 }
 
-template <typename IOTmpl>
+template <typename LayoutTmpl>
 bool
-ExtraInfoDataCell<IOTmpl>::GetExtraInfoById(InnerIdType id, char* extra_info) const {
-    return io_->Read(extra_info_size_,
-                     static_cast<uint64_t>(id) * static_cast<uint64_t>(extra_info_size_),
-                     reinterpret_cast<uint8_t*>(extra_info));
+ExtraInfoDataCell<LayoutTmpl>::GetExtraInfoById(InnerIdType id, char* extra_info) const {
+    return layout_->Read(id, reinterpret_cast<uint8_t*>(extra_info));
 }
 
-template <typename IOTmpl>
+template <typename LayoutTmpl>
 const char*
-ExtraInfoDataCell<IOTmpl>::GetExtraInfoById(InnerIdType id, bool& need_release) const {
-    return reinterpret_cast<const char*>(
-        io_->Read(extra_info_size_,
-                  static_cast<uint64_t>(id) * static_cast<uint64_t>(extra_info_size_),
-                  need_release));
+ExtraInfoDataCell<LayoutTmpl>::GetExtraInfoById(InnerIdType id, bool& need_release) const {
+    return reinterpret_cast<const char*>(layout_->Read(id, need_release));
 }
 
-template <typename IOTmpl>
+template <typename LayoutTmpl>
 void
-ExtraInfoDataCell<IOTmpl>::Serialize(StreamWriter& writer) {
+ExtraInfoDataCell<LayoutTmpl>::Serialize(StreamWriter& writer) {
     ExtraInfoInterface::Serialize(writer);
-    this->io_->Serialize(writer);
+    this->layout_->Serialize(writer);
 }
 
-template <typename IOTmpl>
+template <typename LayoutTmpl>
 void
-ExtraInfoDataCell<IOTmpl>::Deserialize(StreamReader& reader) {
+ExtraInfoDataCell<LayoutTmpl>::Deserialize(StreamReader& reader) {
     ExtraInfoInterface::Deserialize(reader);
-    this->io_->Deserialize(reader);
+    this->layout_->SetCodeSize(this->extra_info_size_);
+    this->layout_->Deserialize(reader);
 }
 
-template <typename IOTmpl>
+template <typename LayoutTmpl>
 uint64_t
-ExtraInfoDataCell<IOTmpl>::GetMemoryUsage() const {
-    uint64_t memory = sizeof(ExtraInfoDataCell<IOTmpl>);
-    if (IOTmpl::InMemory) {
-        memory += this->io_->GetMemoryUsage();
+ExtraInfoDataCell<LayoutTmpl>::GetMemoryUsage() const {
+    uint64_t memory = sizeof(ExtraInfoDataCell<LayoutTmpl>);
+    if (LayoutTmpl::InMemory) {
+        memory += this->layout_->GetMemoryUsage();
     }
     return memory;
 }
 
-template <typename IOTmpl>
+template <typename LayoutTmpl>
 void
-ExtraInfoDataCell<IOTmpl>::Move(InnerIdType from, InnerIdType to) {
-    bool need_release = false;
-    const char* extra_info = this->GetExtraInfoById(from, need_release);
-    this->io_->Write(reinterpret_cast<const uint8_t*>(extra_info),
-                     extra_info_size_,
-                     static_cast<uint64_t>(to) * static_cast<uint64_t>(extra_info_size_));
-    if (need_release) {
-        this->io_->Release(reinterpret_cast<const uint8_t*>(extra_info));
-    }
+ExtraInfoDataCell<LayoutTmpl>::Move(InnerIdType from, InnerIdType to) {
+    this->layout_->Move(from, to);
 }
 }  // namespace vsag

--- a/src/datacell/extra_info_interface.cpp
+++ b/src/datacell/extra_info_interface.cpp
@@ -27,7 +27,7 @@ template <typename IOTemp>
 static ExtraInfoInterfacePtr
 make_instance(const ExtraInfoDataCellParamPtr& param, const IndexCommonParam& common_param) {
     auto& io_param = param->io_parameter;
-    return std::make_shared<ExtraInfoDataCell<IOTemp>>(io_param, common_param);
+    return std::make_shared<ExtraInfoDataCell<FixedLayout<IOTemp>>>(io_param, common_param);
 }
 
 ExtraInfoInterfacePtr

--- a/src/datacell/flatten_datacell.h
+++ b/src/datacell/flatten_datacell.h
@@ -25,9 +25,7 @@
 #include "common.h"
 #include "flatten_interface.h"
 #include "index_common_param.h"
-#include "io/common/basic_io.h"
-#include "io/memory_block_io/memory_block_io.h"
-#include "io/memory_io/memory_io.h"
+#include "layout/fixed_layout.h"
 #include "quantization/quantizer.h"
 #include "query_context.h"
 #include "utils/byte_buffer.h"
@@ -37,10 +35,11 @@ namespace vsag {
 /*
 * thread unsafe
 */
-template <typename QuantTmpl, typename IOTmpl>
+template <typename QuantTmpl, typename LayoutTmpl>
 class FlattenDataCell : public FlattenInterface {
 public:
-    FlattenDataCell() = default;
+    FlattenDataCell() : layout_(std::make_shared<LayoutTmpl>()) {
+    }
 
     explicit FlattenDataCell(const QuantizerParamPtr& quantization_param,
                              const IOParamPtr& io_param,
@@ -92,14 +91,13 @@ public:
         if (new_capacity <= this->max_capacity_) {
             return;
         }
-        uint64_t io_size = static_cast<uint64_t>(new_capacity) * static_cast<uint64_t>(code_size_);
-        this->io_->Resize(io_size);
+        this->layout_->Resize(new_capacity);
         this->max_capacity_ = new_capacity;
     }
 
     void
     Prefetch(InnerIdType id) override {
-        io_->Prefetch(id * code_size_, code_size_);
+        layout_->Prefetch(id, code_size_);
     };
 
     void
@@ -109,7 +107,7 @@ public:
         this->quantizer_->Serialize(writer);
         ss.seekg(0, std::ios::beg);
         IOStreamReader reader(ss);
-        auto ptr = std::dynamic_pointer_cast<FlattenDataCell<QuantTmpl, IOTmpl>>(other);
+        auto ptr = std::dynamic_pointer_cast<FlattenDataCell<QuantTmpl, LayoutTmpl>>(other);
         if (ptr == nullptr) {
             throw VsagException(ErrorType::INTERNAL_ERROR,
                                 "Export model's flatten datacell failed");
@@ -125,8 +123,7 @@ public:
 
     void
     ShrinkToFit(InnerIdType capacity) override {
-        uint64_t io_size = static_cast<uint64_t>(capacity) * static_cast<uint64_t>(code_size_);
-        this->io_->Shrink(io_size);
+        this->layout_->Shrink(capacity);
         this->max_capacity_ = capacity;
     }
 
@@ -159,12 +156,15 @@ public:
         if (this->GetQuantizerName() != QUANTIZATION_TYPE_VALUE_FP32) {
             return nullptr;
         }
-        if constexpr (std::is_same_v<IOTmpl, MemoryIO>) {
-            auto memory_io = std::static_pointer_cast<MemoryIO>(this->io_);
+        if constexpr (LayoutTmpl::InMemory) {
+            const auto* data = this->layout_->TryGetContiguousData();
+            if (data == nullptr) {
+                return nullptr;
+            }
             if (row_stride != nullptr) {
                 *row_stride = this->code_size_ / sizeof(float);
             }
-            return reinterpret_cast<const float*>(memory_io->GetReadOnlyRawData());
+            return reinterpret_cast<const float*>(data);
         }
         return nullptr;
     }
@@ -179,18 +179,19 @@ public:
     SetQuantizer(std::shared_ptr<Quantizer<QuantTmpl>> quantizer) {
         this->quantizer_ = quantizer;
         this->code_size_ = quantizer_->GetCodeSize();
+        this->layout_->SetCodeSize(this->code_size_);
         this->backend_ =
             QuantizerDistanceBackend<QuantTmpl>::Get(static_cast<const QuantTmpl&>(*quantizer_));
     }
 
     inline void
-    SetIO(std::shared_ptr<BasicIO<IOTmpl>> io) {
-        this->io_ = io;
+    SetIO(std::shared_ptr<BasicIO<typename LayoutTmpl::IOType>> io) {
+        this->layout_->SetIO(std::move(io));
     }
 
     void
     InitIO(const IOParamPtr& io_param) override {
-        this->io_->InitIO(io_param);
+        this->layout_->InitIO(io_param);
     }
 
     IndexCommonParam
@@ -205,7 +206,7 @@ public:
     IndexCommonParam common_param_;
 
     std::shared_ptr<Quantizer<QuantTmpl>> quantizer_{nullptr};
-    std::shared_ptr<BasicIO<IOTmpl>> io_{nullptr};
+    std::shared_ptr<LayoutTmpl> layout_{nullptr};
 
     Allocator* const allocator_{nullptr};
 
@@ -225,42 +226,42 @@ private:
     }
 };
 
-template <typename QuantTmpl, typename IOTmpl>
+template <typename QuantTmpl, typename LayoutTmpl>
 void
-FlattenDataCell<QuantTmpl, IOTmpl>::Release(const uint8_t* data) const {
-    this->io_->Release(data);
+FlattenDataCell<QuantTmpl, LayoutTmpl>::Release(const uint8_t* data) const {
+    this->layout_->Release(data);
 }
 
-template <typename QuantTmpl, typename IOTmpl>
+template <typename QuantTmpl, typename LayoutTmpl>
 bool
-FlattenDataCell<QuantTmpl, IOTmpl>::HoldMolds() const {
+FlattenDataCell<QuantTmpl, LayoutTmpl>::HoldMolds() const {
     return this->quantizer_->HoldMolds();
 }
 
-template <typename QuantTmpl, typename IOTmpl>
-FlattenDataCell<QuantTmpl, IOTmpl>::FlattenDataCell(const QuantizerParamPtr& quantization_param,
-                                                    const IOParamPtr& io_param,
-                                                    const IndexCommonParam& common_param)
+template <typename QuantTmpl, typename LayoutTmpl>
+FlattenDataCell<QuantTmpl, LayoutTmpl>::FlattenDataCell(const QuantizerParamPtr& quantization_param,
+                                                        const IOParamPtr& io_param,
+                                                        const IndexCommonParam& common_param)
     : allocator_(common_param.allocator_.get()) {
     this->common_param_ = common_param;
     this->quantizer_ = std::make_shared<QuantTmpl>(quantization_param, common_param);
-    this->io_ = std::make_shared<IOTmpl>(io_param, common_param);
     this->code_size_ = quantizer_->GetCodeSize();
+    this->layout_ = std::make_shared<LayoutTmpl>(this->code_size_, io_param, common_param);
     this->backend_ =
         QuantizerDistanceBackend<QuantTmpl>::Get(static_cast<const QuantTmpl&>(*quantizer_));
 }
 
-template <typename QuantTmpl, typename IOTmpl>
+template <typename QuantTmpl, typename LayoutTmpl>
 void
-FlattenDataCell<QuantTmpl, IOTmpl>::Train(const void* data, uint64_t count) {
+FlattenDataCell<QuantTmpl, LayoutTmpl>::Train(const void* data, uint64_t count) {
     if (this->quantizer_) {
         this->quantizer_->Train(static_cast<const float*>(data), count);
     }
 }
 
-template <typename QuantTmpl, typename IOTmpl>
+template <typename QuantTmpl, typename LayoutTmpl>
 void
-FlattenDataCell<QuantTmpl, IOTmpl>::InsertVector(const void* vector, InnerIdType idx) {
+FlattenDataCell<QuantTmpl, LayoutTmpl>::InsertVector(const void* vector, InnerIdType idx) {
     {
         std::lock_guard lock(mutex_);
         if (idx == std::numeric_limits<InnerIdType>::max()) {
@@ -272,29 +273,27 @@ FlattenDataCell<QuantTmpl, IOTmpl>::InsertVector(const void* vector, InnerIdType
     }
     ByteBuffer codes(static_cast<uint64_t>(code_size_), allocator_);
     quantizer_->EncodeOne(static_cast<const float*>(vector), codes.data);
-    io_->Write(
-        codes.data, code_size_, static_cast<uint64_t>(idx) * static_cast<uint64_t>(code_size_));
+    layout_->Write(idx, codes.data);
 }
 
-template <typename QuantTmpl, typename IOTmpl>
+template <typename QuantTmpl, typename LayoutTmpl>
 bool
-FlattenDataCell<QuantTmpl, IOTmpl>::UpdateVector(const void* vector, InnerIdType idx) {
+FlattenDataCell<QuantTmpl, LayoutTmpl>::UpdateVector(const void* vector, InnerIdType idx) {
     if (idx >= total_count_) {
         return false;
     }
     std::lock_guard lock(mutex_);
     ByteBuffer codes(static_cast<uint64_t>(code_size_), allocator_);
     quantizer_->EncodeOne(static_cast<const float*>(vector), codes.data);
-    io_->Write(
-        codes.data, code_size_, static_cast<uint64_t>(idx) * static_cast<uint64_t>(code_size_));
+    layout_->Write(idx, codes.data);
     return true;
 }
 
-template <typename QuantTmpl, typename IOTmpl>
+template <typename QuantTmpl, typename LayoutTmpl>
 void
-FlattenDataCell<QuantTmpl, IOTmpl>::BatchInsertVector(const void* vectors,
-                                                      InnerIdType count,
-                                                      InnerIdType* idx_vec) {
+FlattenDataCell<QuantTmpl, LayoutTmpl>::BatchInsertVector(const void* vectors,
+                                                          InnerIdType count,
+                                                          InnerIdType* idx_vec) {
     if (idx_vec == nullptr) {
         ByteBuffer codes(static_cast<uint64_t>(count) * static_cast<uint64_t>(code_size_),
                          allocator_);
@@ -305,9 +304,7 @@ FlattenDataCell<QuantTmpl, IOTmpl>::BatchInsertVector(const void* vectors,
             cur_count = total_count_;
             total_count_ += count;
         }
-        io_->Write(codes.data,
-                   static_cast<uint64_t>(count) * static_cast<uint64_t>(code_size_),
-                   cur_count * static_cast<uint64_t>(code_size_));
+        layout_->WriteRange(cur_count, codes.data, count);
     } else {
         auto dim = quantizer_->GetDim();
         for (int64_t i = 0; i < count; ++i) {
@@ -316,52 +313,45 @@ FlattenDataCell<QuantTmpl, IOTmpl>::BatchInsertVector(const void* vectors,
     }
 }
 
-template <typename QuantTmpl, typename IOTmpl>
+template <typename QuantTmpl, typename LayoutTmpl>
 std::string
-FlattenDataCell<QuantTmpl, IOTmpl>::GetQuantizerName() {
+FlattenDataCell<QuantTmpl, LayoutTmpl>::GetQuantizerName() {
     return this->quantizer_->Name();
 }
 
-template <typename QuantTmpl, typename IOTmpl>
+template <typename QuantTmpl, typename LayoutTmpl>
 MetricType
-FlattenDataCell<QuantTmpl, IOTmpl>::GetMetricType() {
+FlattenDataCell<QuantTmpl, LayoutTmpl>::GetMetricType() {
     return this->quantizer_->Metric();
 }
 
-template <typename QuantTmpl, typename IOTmpl>
+template <typename QuantTmpl, typename LayoutTmpl>
 bool
-FlattenDataCell<QuantTmpl, IOTmpl>::InMemory() const {
-    return IOTmpl::InMemory;
+FlattenDataCell<QuantTmpl, LayoutTmpl>::InMemory() const {
+    return LayoutTmpl::InMemory;
 }
 
-template <typename QuantTmpl, typename IOTmpl>
+template <typename QuantTmpl, typename LayoutTmpl>
 void
-FlattenDataCell<QuantTmpl, IOTmpl>::query(float* result_dists,
-                                          Computer<QuantTmpl>* computer,
-                                          const InnerIdType* idx,
-                                          InnerIdType id_count,
-                                          QueryContext* ctx) {
+FlattenDataCell<QuantTmpl, LayoutTmpl>::query(float* result_dists,
+                                              Computer<QuantTmpl>* computer,
+                                              const InnerIdType* idx,
+                                              InnerIdType id_count,
+                                              QueryContext* ctx) {
     Allocator* search_alloc = select_query_allocator(ctx, allocator_);
 
     for (uint32_t i = 0; i < this->prefetch_stride_code_ and i < id_count; i++) {
-        this->io_->Prefetch(static_cast<uint64_t>(idx[i]) * static_cast<uint64_t>(code_size_),
-                            this->prefetch_depth_code_ * 64);
+        this->layout_->Prefetch(idx[i], this->prefetch_depth_code_ * 64);
     }
-    if constexpr (not IOTmpl::InMemory) {
+    if constexpr (not LayoutTmpl::InMemory) {
         if (id_count > 1) {
             ByteBuffer codes(
                 static_cast<uint64_t>(id_count) * static_cast<uint64_t>(this->code_size_),
                 search_alloc);
-            Vector<uint64_t> sizes(id_count, this->code_size_, search_alloc);
-            Vector<uint64_t> offsets(id_count, this->code_size_, search_alloc);
-            for (int64_t i = 0; i < id_count; ++i) {
-                offsets[i] = static_cast<uint64_t>(idx[i]) * this->code_size_;
-            }
-
             double io_cost_ms = 0.0F;
             {
                 Timer timer(io_cost_ms);
-                this->io_->MultiRead(codes.data, sizes.data(), offsets.data(), id_count);
+                this->layout_->MultiRead(idx, id_count, codes.data, search_alloc);
             }
 
             if (ctx != nullptr and ctx->stats != nullptr) {
@@ -387,10 +377,8 @@ FlattenDataCell<QuantTmpl, IOTmpl>::query(float* result_dists,
     for (; i + 3 < id_count; i += 4) {
         for (int64_t j = 0; j < 4; ++j) {
             if (i + j + this->prefetch_stride_code_ < id_count) {
-                this->io_->Prefetch(
-                    static_cast<uint64_t>(idx[i + j + this->prefetch_stride_code_]) *
-                        static_cast<uint64_t>(code_size_),
-                    this->prefetch_depth_code_ * 64);
+                this->layout_->Prefetch(idx[i + j + this->prefetch_stride_code_],
+                                        this->prefetch_depth_code_ * 64);
             }
         }
         bool release1 = false, release2 = false, release3 = false, release4 = false;
@@ -400,16 +388,16 @@ FlattenDataCell<QuantTmpl, IOTmpl>::query(float* result_dists,
         const uint8_t* codes4 = nullptr;
         auto release_batch = [&]() {
             if (release1 && codes1) {
-                this->io_->Release(codes1);
+                this->layout_->Release(codes1);
             }
             if (release2 && codes2) {
-                this->io_->Release(codes2);
+                this->layout_->Release(codes2);
             }
             if (release3 && codes3) {
-                this->io_->Release(codes3);
+                this->layout_->Release(codes3);
             }
             if (release4 && codes4) {
-                this->io_->Release(codes4);
+                this->layout_->Release(codes4);
             }
         };
         try {
@@ -439,30 +427,30 @@ FlattenDataCell<QuantTmpl, IOTmpl>::query(float* result_dists,
             computer->ComputeDist(codes, result_dists + i);
         } catch (...) {
             if (release && codes) {
-                this->io_->Release(codes);
+                this->layout_->Release(codes);
             }
             throw;
         }
         if (release && codes) {
-            this->io_->Release(codes);
+            this->layout_->Release(codes);
         }
     }
     if (ctx != nullptr and ctx->stats != nullptr and ctx->track_distance_evaluations)
         ctx->stats->AddDistance(ctx->distance_phase, backend_, static_cast<uint64_t>(id_count));
 }
 
-template <typename QuantTmpl, typename IOTmpl>
+template <typename QuantTmpl, typename LayoutTmpl>
 float
-FlattenDataCell<QuantTmpl, IOTmpl>::ComputePairVectors(InnerIdType id1, InnerIdType id2) {
+FlattenDataCell<QuantTmpl, LayoutTmpl>::ComputePairVectors(InnerIdType id1, InnerIdType id2) {
     bool release1 = false, release2 = false;
     const uint8_t* codes1 = nullptr;
     const uint8_t* codes2 = nullptr;
     auto release_pair = [&]() {
         if (release1 && codes1) {
-            this->io_->Release(codes1);
+            this->layout_->Release(codes1);
         }
         if (release2 && codes2) {
-            this->io_->Release(codes2);
+            this->layout_->Release(codes2);
         }
     };
     try {
@@ -477,86 +465,77 @@ FlattenDataCell<QuantTmpl, IOTmpl>::ComputePairVectors(InnerIdType id1, InnerIdT
     }
 }
 
-template <typename QuantTmpl, typename IOTmpl>
+template <typename QuantTmpl, typename LayoutTmpl>
 const uint8_t*
-FlattenDataCell<QuantTmpl, IOTmpl>::GetCodesById(InnerIdType id, bool& need_release) const {
-    return io_->Read(
-        code_size_, static_cast<uint64_t>(id) * static_cast<uint64_t>(code_size_), need_release);
+FlattenDataCell<QuantTmpl, LayoutTmpl>::GetCodesById(InnerIdType id, bool& need_release) const {
+    return layout_->Read(id, need_release);
 }
 
-template <typename QuantTmpl, typename IOTmpl>
+template <typename QuantTmpl, typename LayoutTmpl>
 bool
-FlattenDataCell<QuantTmpl, IOTmpl>::GetCodesById(InnerIdType id, uint8_t* codes) const {
-    return io_->Read(
-        code_size_, static_cast<uint64_t>(id) * static_cast<uint64_t>(code_size_), codes);
+FlattenDataCell<QuantTmpl, LayoutTmpl>::GetCodesById(InnerIdType id, uint8_t* codes) const {
+    return layout_->Read(id, codes);
 }
 
-template <typename QuantTmpl, typename IOTmpl>
+template <typename QuantTmpl, typename LayoutTmpl>
 void
-FlattenDataCell<QuantTmpl, IOTmpl>::Serialize(StreamWriter& writer) {
+FlattenDataCell<QuantTmpl, LayoutTmpl>::Serialize(StreamWriter& writer) {
     FlattenInterface::Serialize(writer);
-    this->io_->Serialize(writer);
+    this->layout_->Serialize(writer);
     this->quantizer_->Serialize(writer);
 }
 
-template <typename QuantTmpl, typename IOTmpl>
+template <typename QuantTmpl, typename LayoutTmpl>
 void
-FlattenDataCell<QuantTmpl, IOTmpl>::Deserialize(lvalue_or_rvalue<StreamReader> reader) {
+FlattenDataCell<QuantTmpl, LayoutTmpl>::Deserialize(lvalue_or_rvalue<StreamReader> reader) {
     FlattenInterface::Deserialize(reader);
-    this->io_->Deserialize(reader);
+    this->layout_->SetCodeSize(this->code_size_);
+    this->layout_->Deserialize(reader);
     this->quantizer_->Deserialize(reader);
     this->backend_ =
         QuantizerDistanceBackend<QuantTmpl>::Get(static_cast<const QuantTmpl&>(*this->quantizer_));
 }
 
-template <typename QuantTmpl, typename IOTmpl>
+template <typename QuantTmpl, typename LayoutTmpl>
 void
-FlattenDataCell<QuantTmpl, IOTmpl>::MergeOther(const FlattenInterfacePtr& other, InnerIdType bias) {
-    auto ptr = std::dynamic_pointer_cast<FlattenDataCell<QuantTmpl, IOTmpl>>(other);
+FlattenDataCell<QuantTmpl, LayoutTmpl>::MergeOther(const FlattenInterfacePtr& other,
+                                                   InnerIdType bias) {
+    auto ptr = std::dynamic_pointer_cast<FlattenDataCell<QuantTmpl, LayoutTmpl>>(other);
     if (ptr == nullptr) {
         throw VsagException(ErrorType::INTERNAL_ERROR,
                             "Merge flatten datacell failed: not match type");
     }
     constexpr uint64_t BUFFER_SIZE = 1024 * 1024 * 10;
     uint64_t total_count = ptr->total_count_;
-    uint64_t offset = static_cast<uint64_t>(bias) * static_cast<uint64_t>(code_size_);
     uint64_t read_count = 0;
     while (read_count < total_count) {
         bool need_release = false;
         uint64_t count = std::min(BUFFER_SIZE / this->code_size_, total_count - read_count);
-        uint64_t size = count * this->code_size_;
-        auto* buffer = ptr->io_->Read(size, read_count * this->code_size_, need_release);
-        this->io_->Write(buffer, size, offset);
+        auto* buffer = ptr->layout_->ReadRange(read_count, count, need_release);
+        this->layout_->WriteRange(bias + read_count, buffer, count);
         if (need_release) {
-            ptr->io_->Release(buffer);
+            ptr->layout_->Release(buffer);
         }
-        offset += size;
         read_count += count;
     }
     this->total_count_ += total_count;
 }
 
-template <typename QuantTmpl, typename IOTmpl>
+template <typename QuantTmpl, typename LayoutTmpl>
 uint64_t
-FlattenDataCell<QuantTmpl, IOTmpl>::GetMemoryUsage() const {
-    uint64_t memory = sizeof(FlattenDataCell<QuantTmpl, IOTmpl>);
-    if (IOTmpl::InMemory) {
-        memory += this->io_->GetMemoryUsage();
+FlattenDataCell<QuantTmpl, LayoutTmpl>::GetMemoryUsage() const {
+    uint64_t memory = sizeof(FlattenDataCell<QuantTmpl, LayoutTmpl>);
+    if (LayoutTmpl::InMemory) {
+        memory += this->layout_->GetMemoryUsage();
     }
     memory += sizeof(QuantTmpl);
     return memory;
 }
 
-template <typename QuantTmpl, typename IOTmpl>
+template <typename QuantTmpl, typename LayoutTmpl>
 void
-FlattenDataCell<QuantTmpl, IOTmpl>::Move(InnerIdType from, InnerIdType to) {
-    bool need_release = false;
-    const uint8_t* codes = this->GetCodesById(from, need_release);
-    this->io_->Write(
-        codes, code_size_, static_cast<uint64_t>(to) * static_cast<uint64_t>(code_size_));
-    if (need_release) {
-        this->io_->Release(codes);
-    }
+FlattenDataCell<QuantTmpl, LayoutTmpl>::Move(InnerIdType from, InnerIdType to) {
+    this->layout_->Move(from, to);
 }
 
 }  // namespace vsag

--- a/src/datacell/flatten_datacell_test.cpp
+++ b/src/datacell/flatten_datacell_test.cpp
@@ -146,6 +146,25 @@ TEST_CASE("FlattenDataCell Basic Test", "[ut][FlattenDataCell] ") {
     }
 }
 
+TEST_CASE("FlattenDataCell only reports a stride for contiguous raw data",
+          "[ut][FlattenDataCell]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    auto param = std::make_shared<FlattenDataCellParameter>();
+    param->FromJson(JsonType::Parse(R"({
+        "io_params": {"type": "block_memory_io"},
+        "quantization_params": {"type": "fp32"}
+    })"));
+    IndexCommonParam common_param;
+    common_param.allocator_ = allocator;
+    common_param.dim_ = 4;
+    common_param.metric_ = MetricType::METRIC_TYPE_L2SQR;
+
+    auto flatten = FlattenInterface::MakeInstance(param, common_param);
+    uint64_t row_stride = 123;
+    REQUIRE(flatten->TryGetContiguousRawFloatData(&row_stride) == nullptr);
+    REQUIRE(row_stride == 0);
+}
+
 TEST_CASE("RaBitQSplitDataCell direct split compute", "[ut][RaBitQSplitDataCell]") {
     auto allocator = SafeAllocator::FactoryDefaultAllocator();
     constexpr uint64_t dim = 64;

--- a/src/datacell/flatten_interface.cpp
+++ b/src/datacell/flatten_interface.cpp
@@ -40,7 +40,7 @@ make_instance_flatten(const FlattenInterfaceParamPtr& param, const IndexCommonPa
     auto& io_param = param->io_parameter;
     auto& quantizer_param = param->quantizer_parameter;
     if (param->name == FLATTEN_DATA_CELL) {
-        return std::make_shared<FlattenDataCell<QuantTemp, IOTemp>>(
+        return std::make_shared<FlattenDataCell<QuantTemp, FixedLayout<IOTemp>>>(
             quantizer_param, io_param, common_param);
     }
     throw VsagException(ErrorType::INVALID_ARGUMENT,

--- a/src/datacell/rabitq_split_datacell.h
+++ b/src/datacell/rabitq_split_datacell.h
@@ -38,6 +38,7 @@
 #include "io/memory_io/memory_io.h"
 #include "io/memory_io/memory_io_parameter.h"
 #include "io/mmap_io/mmap_io_parameter.h"
+#include "layout/fixed_layout.h"
 #include "quantization/bottom_quantizer_accessor.h"
 #include "quantization/rabitq_quantization/rabitq_quantizer.h"
 #include "query_context.h"
@@ -50,96 +51,6 @@
 namespace vsag {
 
 class MMapIO;
-
-template <typename IOTmpl>
-class RaBitQSplitCodeStorage {
-public:
-    static constexpr bool InMemory = IOTmpl::InMemory;
-
-    RaBitQSplitCodeStorage(const IOParamPtr& io_param, const IndexCommonParam& common_param)
-        : io_(std::make_shared<IOTmpl>(io_param, common_param)) {
-    }
-
-    void
-    SetCodeSize(uint64_t code_size) {
-        code_size_ = code_size;
-    }
-
-    [[nodiscard]] uint64_t
-    GetCodeSize() const {
-        return code_size_;
-    }
-
-    void
-    Resize(uint64_t new_capacity) {
-        io_->Resize(new_capacity * code_size_);
-    }
-
-    void
-    Shrink(uint64_t new_capacity) {
-        io_->Shrink(new_capacity * code_size_);
-    }
-
-    void
-    Write(const uint8_t* code, InnerIdType id) {
-        io_->Write(code, code_size_, static_cast<uint64_t>(id) * code_size_);
-    }
-
-    bool
-    Read(InnerIdType id, uint8_t* dst) const {
-        return io_->Read(code_size_, static_cast<uint64_t>(id) * code_size_, dst);
-    }
-
-    [[nodiscard]] const uint8_t*
-    Read(InnerIdType id, bool& need_release) const {
-        return io_->Read(code_size_, static_cast<uint64_t>(id) * code_size_, need_release);
-    }
-
-    void
-    Release(const uint8_t* code) const {
-        if (code != nullptr) {
-            io_->Release(code);
-        }
-    }
-
-    void
-    Prefetch(InnerIdType id, uint64_t bytes) const {
-        io_->Prefetch(static_cast<uint64_t>(id) * code_size_,
-                      std::min<uint64_t>(bytes, code_size_));
-    }
-
-    void
-    MultiRead(uint8_t* dst, uint64_t* sizes, uint64_t* offsets, uint64_t count) const {
-        io_->MultiRead(dst, sizes, offsets, count);
-    }
-
-    void
-    InitIO(const IOParamPtr& io_param) {
-        io_->InitIO(io_param);
-    }
-
-    void
-    Serialize(StreamWriter& writer) {
-        io_->Serialize(writer);
-    }
-
-    void
-    Deserialize(lvalue_or_rvalue<StreamReader> reader) {
-        io_->Deserialize(reader);
-    }
-
-    [[nodiscard]] uint64_t
-    GetMemoryUsage() const {
-        if constexpr (IOTmpl::InMemory) {
-            return io_->GetMemoryUsage();
-        }
-        return 0;
-    }
-
-private:
-    std::shared_ptr<BasicIO<IOTmpl>> io_{nullptr};
-    uint64_t code_size_{0};
-};
 
 template <MetricType metric,
           typename OneBitIOTmpl,
@@ -197,10 +108,10 @@ public:
         if (supplement_io_param != nullptr) {
             this->supplement_io_type_ = supplement_io_param->GetTypeName();
         }
-        this->x_bit_cell_ =
-            std::make_shared<RaBitQSplitCodeStorage<OneBitIOTmpl>>(one_bit_io_param, common_param);
-        this->supplement_cell_ =
-            std::make_shared<RaBitQSplitCodeStorage<SupplementIOTmpl>>(supp_io_param, common_param);
+        this->x_bit_layout_ =
+            std::make_shared<FixedLayout<OneBitIOTmpl>>(one_bit_io_param, common_param);
+        this->supplement_layout_ =
+            std::make_shared<FixedLayout<SupplementIOTmpl>>(supp_io_param, common_param);
         this->refresh_code_sizes();
     }
 
@@ -273,7 +184,7 @@ public:
         }
 
         bool need_release = false;
-        const auto* query_code = this->optimized_build_scalar_codes_->Read(query_id, need_release);
+        const auto* query_code = this->optimized_build_scalar_layout_->Read(query_id, need_release);
         if (query_code == nullptr) {
             throw VsagException(ErrorType::INTERNAL_ERROR,
                                 "failed to read temporary scalar RaBitQ query code");
@@ -286,12 +197,12 @@ public:
                                                    id_count);
         } catch (...) {
             if (need_release) {
-                this->optimized_build_scalar_codes_->Release(query_code);
+                this->optimized_build_scalar_layout_->Release(query_code);
             }
             throw;
         }
         if (need_release) {
-            this->optimized_build_scalar_codes_->Release(query_code);
+            this->optimized_build_scalar_layout_->Release(query_code);
         }
         this->add_distance_evaluations(ctx, id_count);
     }
@@ -548,7 +459,7 @@ public:
         if (this->optimized_build_active_) {
             auto computer = std::make_shared<OptimizedBuildComputer>(
                 this->optimized_build_record_size_, this->allocator_);
-            if (not this->optimized_build_scalar_codes_->Read(id, computer->scalar_code_.data)) {
+            if (not this->optimized_build_scalar_layout_->Read(id, computer->scalar_code_.data)) {
                 throw VsagException(ErrorType::INTERNAL_ERROR,
                                     "failed to read scalar RaBitQ build query code");
             }
@@ -572,15 +483,14 @@ public:
             return false;
         }
         auto io_param = std::make_shared<MemoryIOParameter>();
-        auto build_codes =
-            std::make_shared<RaBitQSplitCodeStorage<MemoryIO>>(io_param, this->common_param_);
+        auto build_codes = std::make_shared<FixedLayout<MemoryIO>>(io_param, this->common_param_);
         build_codes->SetCodeSize(this->bottom_quantizer().GetScalarCodeSize());
         auto code_sums = std::make_unique<Vector<uint64_t>>(this->allocator_);
         if (this->max_capacity_ > 0) {
             build_codes->Resize(this->max_capacity_);
             code_sums->resize(this->max_capacity_, 0);
         }
-        this->optimized_build_scalar_codes_ = build_codes;
+        this->optimized_build_scalar_layout_ = build_codes;
         this->optimized_build_code_sums_ = std::move(code_sums);
         this->optimized_build_record_size_ = this->bottom_quantizer().GetScalarCodeSize();
         this->optimized_build_context_ = context;
@@ -597,8 +507,8 @@ public:
         // Finalize workers write disjoint IDs, but the backing IO must already be fully sized so
         // no worker enters a concurrent reallocation path.
         const InnerIdType final_capacity = std::max(this->max_capacity_, this->total_count_);
-        this->x_bit_cell_->Resize(final_capacity);
-        this->supplement_cell_->Resize(final_capacity);
+        this->x_bit_layout_->Resize(final_capacity);
+        this->supplement_layout_->Resize(final_capacity);
         this->max_capacity_ = final_capacity;
 
         auto finalize_range = [this](InnerIdType begin, InnerIdType end) {
@@ -607,7 +517,7 @@ public:
             for (InnerIdType id = begin; id < end; ++id) {
                 bool need_release = false;
                 const auto* scalar_code =
-                    this->optimized_build_scalar_codes_->Read(id, need_release);
+                    this->optimized_build_scalar_layout_->Read(id, need_release);
                 if (scalar_code == nullptr) {
                     throw VsagException(ErrorType::INTERNAL_ERROR,
                                         "failed to read temporary scalar RaBitQ build code");
@@ -615,16 +525,16 @@ public:
                 try {
                     this->bottom_quantizer().PackScalarCodeToSplitCode(
                         scalar_code, one_bit_code.data, supplement_code.data);
-                    this->x_bit_cell_->Write(one_bit_code.data, id);
-                    this->supplement_cell_->Write(supplement_code.data, id);
+                    this->x_bit_layout_->Write(id, one_bit_code.data);
+                    this->supplement_layout_->Write(id, supplement_code.data);
                 } catch (...) {
                     if (need_release) {
-                        this->optimized_build_scalar_codes_->Release(scalar_code);
+                        this->optimized_build_scalar_layout_->Release(scalar_code);
                     }
                     throw;
                 }
                 if (need_release) {
-                    this->optimized_build_scalar_codes_->Release(scalar_code);
+                    this->optimized_build_scalar_layout_->Release(scalar_code);
                 }
             }
         };
@@ -681,7 +591,7 @@ public:
         }
 
         this->optimized_build_active_ = false;
-        this->optimized_build_scalar_codes_.reset();
+        this->optimized_build_scalar_layout_.reset();
         this->optimized_build_code_sums_.reset();
         this->optimized_build_record_size_ = 0;
         this->optimized_build_context_ = {};
@@ -690,7 +600,7 @@ public:
     void
     AbortOptimizedBuild() noexcept override {
         this->optimized_build_active_ = false;
-        this->optimized_build_scalar_codes_.reset();
+        this->optimized_build_scalar_layout_.reset();
         this->optimized_build_code_sums_.reset();
         this->optimized_build_record_size_ = 0;
         this->optimized_build_context_ = {};
@@ -745,14 +655,14 @@ public:
         if (this->optimized_build_active_) {
             bool release1 = false;
             bool release2 = false;
-            const auto* codes1 = this->optimized_build_scalar_codes_->Read(id1, release1);
-            const auto* codes2 = this->optimized_build_scalar_codes_->Read(id2, release2);
+            const auto* codes1 = this->optimized_build_scalar_layout_->Read(id1, release1);
+            const auto* codes2 = this->optimized_build_scalar_layout_->Read(id2, release2);
             if (codes1 == nullptr or codes2 == nullptr) {
                 if (release1) {
-                    this->optimized_build_scalar_codes_->Release(codes1);
+                    this->optimized_build_scalar_layout_->Release(codes1);
                 }
                 if (release2) {
-                    this->optimized_build_scalar_codes_->Release(codes2);
+                    this->optimized_build_scalar_layout_->Release(codes2);
                 }
                 throw VsagException(ErrorType::INTERNAL_ERROR,
                                     "failed to read temporary scalar RaBitQ build codes");
@@ -766,18 +676,18 @@ public:
                     (*optimized_build_code_sums_)[id2]);
             } catch (...) {
                 if (release1) {
-                    this->optimized_build_scalar_codes_->Release(codes1);
+                    this->optimized_build_scalar_layout_->Release(codes1);
                 }
                 if (release2) {
-                    this->optimized_build_scalar_codes_->Release(codes2);
+                    this->optimized_build_scalar_layout_->Release(codes2);
                 }
                 throw;
             }
             if (release1) {
-                this->optimized_build_scalar_codes_->Release(codes1);
+                this->optimized_build_scalar_layout_->Release(codes1);
             }
             if (release2) {
-                this->optimized_build_scalar_codes_->Release(codes2);
+                this->optimized_build_scalar_layout_->Release(codes2);
             }
             return distance;
         }
@@ -793,10 +703,10 @@ public:
         if (new_capacity <= this->max_capacity_) {
             return;
         }
-        this->x_bit_cell_->Resize(new_capacity);
-        this->supplement_cell_->Resize(new_capacity);
+        this->x_bit_layout_->Resize(new_capacity);
+        this->supplement_layout_->Resize(new_capacity);
         if (this->optimized_build_active_) {
-            this->optimized_build_scalar_codes_->Resize(new_capacity);
+            this->optimized_build_scalar_layout_->Resize(new_capacity);
             this->optimized_build_code_sums_->resize(new_capacity, 0);
         }
         this->max_capacity_ = new_capacity;
@@ -805,7 +715,7 @@ public:
     void
     Prefetch(InnerIdType id) override {
         if (this->optimized_build_active_) {
-            this->optimized_build_scalar_codes_->Prefetch(id, this->optimized_build_record_size_);
+            this->optimized_build_scalar_layout_->Prefetch(id, this->optimized_build_record_size_);
             return;
         }
         this->prefetch_one_bit(id);
@@ -831,27 +741,27 @@ public:
     void
     InitIO(const IOParamPtr& io_param) override {
         const bool shares_io_param = this->supplement_io_type_.empty();
-        this->x_bit_cell_->InitIO(SuffixIOParam(io_param, "_onebit", shares_io_param));
+        this->x_bit_layout_->InitIO(SuffixIOParam(io_param, "_onebit", shares_io_param));
         // In hybrid mode (one-bit and supplement use different IO backends)
         // the caller-facing `io_param` is the one-bit IO parameter type and
-        // cannot be passed directly to `supplement_cell_`. Rebuild a fresh
+        // cannot be passed directly to `supplement_layout_`. Rebuild a fresh
         // IOParameter of the recorded supplement type so the underlying IO
         // implementation receives the correct parameter subclass.
-        this->supplement_cell_->InitIO(RebuildSupplementIOParam(io_param));
+        this->supplement_layout_->InitIO(RebuildSupplementIOParam(io_param));
     }
 
     void
     InitIO(const IOParamPtr& one_bit_io_param, const IOParamPtr& supplement_io_param) {
         const bool shares_io_param = supplement_io_param == nullptr;
-        this->x_bit_cell_->InitIO(SuffixIOParam(one_bit_io_param, "_onebit", shares_io_param));
+        this->x_bit_layout_->InitIO(SuffixIOParam(one_bit_io_param, "_onebit", shares_io_param));
         if (supplement_io_param != nullptr) {
             // Refresh the recorded supplement type so subsequent
             // single-parameter InitIO calls (e.g. from Deserialize) can
             // reconstruct the same IO subtype.
             this->supplement_io_type_ = supplement_io_param->GetTypeName();
-            this->supplement_cell_->InitIO(supplement_io_param);
+            this->supplement_layout_->InitIO(supplement_io_param);
         } else {
-            this->supplement_cell_->InitIO(RebuildSupplementIOParam(one_bit_io_param));
+            this->supplement_layout_->InitIO(RebuildSupplementIOParam(one_bit_io_param));
         }
     }
 
@@ -912,21 +822,21 @@ public:
     GetCodesById(InnerIdType id, uint8_t* codes) const override {
         if (this->optimized_build_active_) {
             bool need_release = false;
-            const auto* scalar_code = this->optimized_build_scalar_codes_->Read(id, need_release);
+            const auto* scalar_code = this->optimized_build_scalar_layout_->Read(id, need_release);
             if (scalar_code == nullptr) {
                 return false;
             }
             memset(codes, 0, this->code_size_);
             this->bottom_quantizer().PackScalarCode(scalar_code, codes);
             if (need_release) {
-                this->optimized_build_scalar_codes_->Release(scalar_code);
+                this->optimized_build_scalar_layout_->Release(scalar_code);
             }
             return true;
         }
         ByteBuffer one_bit(one_bit_code_size_, allocator_);
         ByteBuffer supplement(supplement_code_size_, allocator_);
-        bool one_bit_ok = this->x_bit_cell_->Read(id, one_bit.data);
-        bool supplement_ok = this->supplement_cell_->Read(id, supplement.data);
+        bool one_bit_ok = this->x_bit_layout_->Read(id, one_bit.data);
+        bool supplement_ok = this->supplement_layout_->Read(id, supplement.data);
         if (not one_bit_ok or not supplement_ok) {
             return false;
         }
@@ -951,8 +861,8 @@ public:
                        "cannot serialize RaBitQ split codes during optimized build");
         FlattenInterface::Serialize(writer);
         StreamWriter::WriteString(writer, this->supplement_io_type_);
-        this->x_bit_cell_->Serialize(writer);
-        this->supplement_cell_->Serialize(writer);
+        this->x_bit_layout_->Serialize(writer);
+        this->supplement_layout_->Serialize(writer);
         this->quantizer_->Serialize(writer);
     }
 
@@ -960,8 +870,8 @@ public:
     Deserialize(lvalue_or_rvalue<StreamReader> reader) override {
         FlattenInterface::Deserialize(reader);
         this->DeserializeSupplementIOType(reader);
-        this->x_bit_cell_->Deserialize(reader);
-        this->supplement_cell_->Deserialize(reader);
+        this->x_bit_layout_->Deserialize(reader);
+        this->supplement_layout_->Deserialize(reader);
         this->quantizer_->Deserialize(reader);
         this->refresh_code_sizes();
     }
@@ -978,11 +888,11 @@ public:
         for (InnerIdType i = 0; i < ptr->total_count_; ++i) {
             ByteBuffer one_bit(one_bit_code_size_, allocator_);
             ByteBuffer supplement(supplement_code_size_, allocator_);
-            ptr->x_bit_cell_->Read(i, one_bit.data);
-            ptr->supplement_cell_->Read(i, supplement.data);
+            ptr->x_bit_layout_->Read(i, one_bit.data);
+            ptr->supplement_layout_->Read(i, supplement.data);
             auto target_id = static_cast<InnerIdType>(bias + i);
-            this->x_bit_cell_->Write(one_bit.data, target_id);
-            this->supplement_cell_->Write(supplement.data, target_id);
+            this->x_bit_layout_->Write(target_id, one_bit.data);
+            this->supplement_layout_->Write(target_id, supplement.data);
         }
         this->total_count_ = std::max(this->total_count_, bias + ptr->total_count_);
     }
@@ -991,25 +901,25 @@ public:
     Move(InnerIdType from, InnerIdType to) override {
         if (this->optimized_build_active_) {
             ByteBuffer build_record(this->optimized_build_record_size_, allocator_);
-            this->optimized_build_scalar_codes_->Read(from, build_record.data);
-            this->optimized_build_scalar_codes_->Write(build_record.data, to);
+            this->optimized_build_scalar_layout_->Read(from, build_record.data);
+            this->optimized_build_scalar_layout_->Write(to, build_record.data);
             (*this->optimized_build_code_sums_)[to] = (*this->optimized_build_code_sums_)[from];
             return;
         }
         ByteBuffer one_bit(one_bit_code_size_, allocator_);
         ByteBuffer supplement(supplement_code_size_, allocator_);
-        this->x_bit_cell_->Read(from, one_bit.data);
-        this->supplement_cell_->Read(from, supplement.data);
-        this->x_bit_cell_->Write(one_bit.data, to);
-        this->supplement_cell_->Write(supplement.data, to);
+        this->x_bit_layout_->Read(from, one_bit.data);
+        this->supplement_layout_->Read(from, supplement.data);
+        this->x_bit_layout_->Write(to, one_bit.data);
+        this->supplement_layout_->Write(to, supplement.data);
     }
 
     void
     ShrinkToFit(InnerIdType capacity) override {
-        this->x_bit_cell_->Shrink(capacity);
-        this->supplement_cell_->Shrink(capacity);
+        this->x_bit_layout_->Shrink(capacity);
+        this->supplement_layout_->Shrink(capacity);
         if (this->optimized_build_active_) {
-            this->optimized_build_scalar_codes_->Shrink(capacity);
+            this->optimized_build_scalar_layout_->Shrink(capacity);
             this->optimized_build_code_sums_->resize(capacity);
             this->optimized_build_code_sums_->shrink_to_fit();
         }
@@ -1020,10 +930,10 @@ public:
     GetMemoryUsage() const override {
         uint64_t memory =
             sizeof(RaBitQSplitDataCell<metric, OneBitIOTmpl, SupplementIOTmpl, QuantizerT>);
-        memory += this->x_bit_cell_->GetMemoryUsage();
-        memory += this->supplement_cell_->GetMemoryUsage();
-        if (this->optimized_build_scalar_codes_ != nullptr) {
-            memory += this->optimized_build_scalar_codes_->GetMemoryUsage();
+        memory += this->x_bit_layout_->GetMemoryUsage();
+        memory += this->supplement_layout_->GetMemoryUsage();
+        if (this->optimized_build_scalar_layout_ != nullptr) {
+            memory += this->optimized_build_scalar_layout_->GetMemoryUsage();
         }
         if (this->optimized_build_code_sums_ != nullptr) {
             memory += this->optimized_build_code_sums_->capacity() * sizeof(uint64_t);
@@ -1035,9 +945,9 @@ public:
 public:
     IndexCommonParam common_param_;
     std::shared_ptr<QuantizerT> quantizer_{nullptr};
-    std::shared_ptr<RaBitQSplitCodeStorage<OneBitIOTmpl>> x_bit_cell_{nullptr};
-    std::shared_ptr<RaBitQSplitCodeStorage<SupplementIOTmpl>> supplement_cell_{nullptr};
-    std::shared_ptr<RaBitQSplitCodeStorage<MemoryIO>> optimized_build_scalar_codes_{nullptr};
+    std::shared_ptr<FixedLayout<OneBitIOTmpl>> x_bit_layout_{nullptr};
+    std::shared_ptr<FixedLayout<SupplementIOTmpl>> supplement_layout_{nullptr};
+    std::shared_ptr<FixedLayout<MemoryIO>> optimized_build_scalar_layout_{nullptr};
     std::unique_ptr<Vector<uint64_t>> optimized_build_code_sums_{nullptr};
     FlattenOptimizedBuildContext optimized_build_context_{};
 
@@ -1050,7 +960,7 @@ public:
     // storage" (the legacy single-IO behaviour). Recorded so that the
     // single-parameter `InitIO(const IOParamPtr&)` overload (e.g. invoked
     // from Deserialize) can rebuild a parameter of the correct concrete
-    // IOParameter subclass for `supplement_cell_` instead of feeding it the
+    // IOParameter subclass for `supplement_layout_` instead of feeding it the
     // mismatched one-bit IO parameter type.
     std::string supplement_io_type_{};
     bool optimized_build_active_{false};
@@ -1089,13 +999,13 @@ private:
         return IOParameter::GetIOParameterByJson(json);
     }
 
-    // Builds the IO parameter that should be handed to `supplement_cell_`
+    // Builds the IO parameter that should be handed to `supplement_layout_`
     // given the caller-supplied `io_param` (which is always typed for the
     // one-bit storage). If `supplement_io_type_` is empty the two storages
     // share the same IO type and we fall back to the legacy file-path-suffix
     // behaviour. Otherwise the JSON is cloned, its `type` field rewritten to
     // the recorded supplement type, the optional file path suffixed, and a
-    // new IOParameter is constructed via the factory so `supplement_cell_`
+    // new IOParameter is constructed via the factory so `supplement_layout_`
     // receives the IOParameter subclass it actually expects.
     IOParamPtr
     RebuildSupplementIOParam(const IOParamPtr& io_param) const {
@@ -1154,8 +1064,8 @@ private:
         this->code_size_ = static_cast<uint32_t>(quantizer_->GetCodeSize());
         this->one_bit_code_size_ = this->bottom_quantizer().GetOneBitCodeSize();
         this->supplement_code_size_ = this->bottom_quantizer().GetSupplementCodeSize();
-        this->x_bit_cell_->SetCodeSize(one_bit_code_size_);
-        this->supplement_cell_->SetCodeSize(supplement_code_size_);
+        this->x_bit_layout_->SetCodeSize(one_bit_code_size_);
+        this->supplement_layout_->SetCodeSize(supplement_code_size_);
     }
 
     void
@@ -1172,7 +1082,7 @@ private:
                                     "failed to encode temporary scalar RaBitQ build code");
             }
             (*this->optimized_build_code_sums_)[idx] = code_sum;
-            this->optimized_build_scalar_codes_->Write(scalar_code.data, idx);
+            this->optimized_build_scalar_layout_->Write(idx, scalar_code.data);
             return;
         }
         ByteBuffer full_code(this->code_size_, allocator_);
@@ -1180,8 +1090,8 @@ private:
         ByteBuffer one_bit_code(one_bit_code_size_, allocator_);
         ByteBuffer supplement_code(supplement_code_size_, allocator_);
         this->bottom_quantizer().SplitCode(full_code.data, one_bit_code.data, supplement_code.data);
-        this->x_bit_cell_->Write(one_bit_code.data, idx);
-        this->supplement_cell_->Write(supplement_code.data, idx);
+        this->x_bit_layout_->Write(idx, one_bit_code.data);
+        this->supplement_layout_->Write(idx, supplement_code.data);
     }
 
     void
@@ -1203,7 +1113,7 @@ private:
         for (InnerIdType i = 0; i < id_count; ++i) {
             bool need_release = false;
             const auto* scalar_code =
-                this->optimized_build_scalar_codes_->Read(idx[i], need_release);
+                this->optimized_build_scalar_layout_->Read(idx[i], need_release);
             if (scalar_code == nullptr) {
                 throw VsagException(ErrorType::INTERNAL_ERROR,
                                     "failed to read temporary scalar RaBitQ build code");
@@ -1213,12 +1123,12 @@ private:
                     *comp, scalar_code, result_dists + i);
             } catch (...) {
                 if (need_release) {
-                    this->optimized_build_scalar_codes_->Release(scalar_code);
+                    this->optimized_build_scalar_layout_->Release(scalar_code);
                 }
                 throw;
             }
             if (need_release) {
-                this->optimized_build_scalar_codes_->Release(scalar_code);
+                this->optimized_build_scalar_layout_->Release(scalar_code);
             }
         }
     }
@@ -1230,15 +1140,16 @@ private:
                                      const InnerIdType* idx,
                                      InnerIdType id_count) const {
         for (uint32_t i = 0; i < this->prefetch_stride_code_ and i < id_count; ++i) {
-            this->optimized_build_scalar_codes_->Prefetch(idx[i], this->prefetch_depth_code_ * 64);
+            this->optimized_build_scalar_layout_->Prefetch(idx[i], this->prefetch_depth_code_ * 64);
         }
         for (InnerIdType i = 0; i < id_count; ++i) {
             if (i + this->prefetch_stride_code_ < id_count) {
-                this->optimized_build_scalar_codes_->Prefetch(idx[i + this->prefetch_stride_code_],
-                                                              this->prefetch_depth_code_ * 64);
+                this->optimized_build_scalar_layout_->Prefetch(idx[i + this->prefetch_stride_code_],
+                                                               this->prefetch_depth_code_ * 64);
             }
             bool need_release = false;
-            const auto* base_code = this->optimized_build_scalar_codes_->Read(idx[i], need_release);
+            const auto* base_code =
+                this->optimized_build_scalar_layout_->Read(idx[i], need_release);
             if (base_code == nullptr) {
                 throw VsagException(ErrorType::INTERNAL_ERROR,
                                     "failed to read temporary scalar RaBitQ build code");
@@ -1248,24 +1159,24 @@ private:
                     query_code, query_sum, base_code, (*this->optimized_build_code_sums_)[idx[i]]);
             } catch (...) {
                 if (need_release) {
-                    this->optimized_build_scalar_codes_->Release(base_code);
+                    this->optimized_build_scalar_layout_->Release(base_code);
                 }
                 throw;
             }
             if (need_release) {
-                this->optimized_build_scalar_codes_->Release(base_code);
+                this->optimized_build_scalar_layout_->Release(base_code);
             }
         }
     }
 
     void
     prefetch_one_bit(InnerIdType id) {
-        this->x_bit_cell_->Prefetch(id, this->prefetch_depth_code_ * 64);
+        this->x_bit_layout_->Prefetch(id, this->prefetch_depth_code_ * 64);
     }
 
     void
     prefetch_supplement(InnerIdType id) {
-        this->supplement_cell_->Prefetch(id, this->prefetch_depth_code_ * 64);
+        this->supplement_layout_->Prefetch(id, this->prefetch_depth_code_ * 64);
     }
 
     void
@@ -1276,25 +1187,25 @@ private:
 
     const uint8_t*
     get_one_bit_code(InnerIdType id, bool& need_release) const {
-        return this->x_bit_cell_->Read(id, need_release);
+        return this->x_bit_layout_->Read(id, need_release);
     }
 
     void
     release_one_bit_code(const uint8_t* code, bool need_release) const {
         if (need_release) {
-            this->x_bit_cell_->Release(code);
+            this->x_bit_layout_->Release(code);
         }
     }
 
     const uint8_t*
     get_supplement_code(InnerIdType id, bool& need_release) const {
-        return this->supplement_cell_->Read(id, need_release);
+        return this->supplement_layout_->Read(id, need_release);
     }
 
     void
     release_supplement_code(const uint8_t* code, bool need_release) const {
         if (need_release) {
-            this->supplement_cell_->Release(code);
+            this->supplement_layout_->Release(code);
         }
     }
 
@@ -1359,17 +1270,10 @@ private:
                                            QueryContext* ctx) const {
         Allocator* search_alloc = select_query_allocator(ctx, allocator_);
         ByteBuffer one_bit_codes(id_count * one_bit_code_size_, search_alloc);
-        Vector<uint64_t> sizes(id_count, one_bit_code_size_, search_alloc);
-        Vector<uint64_t> offsets(id_count, one_bit_code_size_, search_alloc);
-        for (InnerIdType i = 0; i < id_count; ++i) {
-            offsets[i] = static_cast<uint64_t>(idx[i]) * one_bit_code_size_;
-        }
-
         double io_cost_ms = 0.0F;
         {
             Timer timer(io_cost_ms);
-            this->x_bit_cell_->MultiRead(
-                one_bit_codes.data, sizes.data(), offsets.data(), id_count);
+            this->x_bit_layout_->MultiRead(idx, id_count, one_bit_codes.data, search_alloc);
         }
         if (ctx != nullptr and ctx->stats != nullptr) {
             ctx->stats->io_cnt.fetch_add(id_count, std::memory_order_relaxed);
@@ -1456,22 +1360,11 @@ private:
         Allocator* search_alloc = select_query_allocator(ctx, allocator_);
         ByteBuffer one_bit_codes(id_count * one_bit_code_size_, search_alloc);
         ByteBuffer supplement_codes(id_count * supplement_code_size_, search_alloc);
-        Vector<uint64_t> one_bit_sizes(id_count, one_bit_code_size_, search_alloc);
-        Vector<uint64_t> one_bit_offsets(id_count, 0, search_alloc);
-        Vector<uint64_t> supp_sizes(id_count, supplement_code_size_, search_alloc);
-        Vector<uint64_t> supp_offsets(id_count, 0, search_alloc);
-        for (InnerIdType i = 0; i < id_count; ++i) {
-            one_bit_offsets[i] = static_cast<uint64_t>(idx[i]) * one_bit_code_size_;
-            supp_offsets[i] = static_cast<uint64_t>(idx[i]) * supplement_code_size_;
-        }
-
         double io_cost_ms = 0.0F;
         {
             Timer timer(io_cost_ms);
-            this->x_bit_cell_->MultiRead(
-                one_bit_codes.data, one_bit_sizes.data(), one_bit_offsets.data(), id_count);
-            this->supplement_cell_->MultiRead(
-                supplement_codes.data, supp_sizes.data(), supp_offsets.data(), id_count);
+            this->x_bit_layout_->MultiRead(idx, id_count, one_bit_codes.data, search_alloc);
+            this->supplement_layout_->MultiRead(idx, id_count, supplement_codes.data, search_alloc);
         }
         if (ctx != nullptr and ctx->stats != nullptr) {
             ctx->stats->io_cnt.fetch_add(id_count * 2, std::memory_order_relaxed);
@@ -1498,17 +1391,10 @@ private:
                                             const float* hint_dists = nullptr) const {
         Allocator* search_alloc = select_query_allocator(ctx, allocator_);
         ByteBuffer supplement_codes(id_count * supplement_code_size_, search_alloc);
-        Vector<uint64_t> supp_sizes(id_count, supplement_code_size_, search_alloc);
-        Vector<uint64_t> supp_offsets(id_count, 0, search_alloc);
-        for (InnerIdType i = 0; i < id_count; ++i) {
-            supp_offsets[i] = static_cast<uint64_t>(idx[i]) * supplement_code_size_;
-        }
-
         double io_cost_ms = 0.0F;
         {
             Timer timer(io_cost_ms);
-            this->supplement_cell_->MultiRead(
-                supplement_codes.data, supp_sizes.data(), supp_offsets.data(), id_count);
+            this->supplement_layout_->MultiRead(idx, id_count, supplement_codes.data, search_alloc);
         }
         if (ctx != nullptr and ctx->stats != nullptr) {
             ctx->stats->io_cnt.fetch_add(id_count, std::memory_order_relaxed);

--- a/src/datacell/sparse_vector_datacell.h
+++ b/src/datacell/sparse_vector_datacell.h
@@ -17,6 +17,7 @@
 
 #include <limits>
 
+#include "flatten_datacell.h"
 #include "flatten_interface.h"
 #include "io/common/basic_io.h"
 #include "io/memory_block_io/memory_block_io.h"
@@ -100,7 +101,8 @@ public:
         this->quantizer_->Serialize(writer);
         ss.seekg(0, std::ios::beg);
         IOStreamReader reader(ss);
-        auto ptr = std::dynamic_pointer_cast<FlattenDataCell<QuantTmpl, IOTmpl>>(other);
+        auto ptr =
+            std::dynamic_pointer_cast<FlattenDataCell<QuantTmpl, FixedLayout<IOTmpl>>>(other);
         if (ptr == nullptr) {
             throw VsagException(ErrorType::INTERNAL_ERROR,
                                 "Export model's sparse flatten datacell failed");

--- a/src/impl/searcher/basic_searcher_test.cpp
+++ b/src/impl/searcher/basic_searcher_test.cpp
@@ -40,9 +40,9 @@ TEST_CASE("BasicSearcher supports KNN, range, filters, and empty data cells",
         JsonType::Parse(fmt::format(param_temp, "fp32")));
     auto io_param =
         IOParameter::GetIOParameterByJson(JsonType::Parse(fmt::format(param_temp, "memory_io")));
-    auto flatten =
-        std::make_shared<FlattenDataCell<FP32Quantizer<MetricType::METRIC_TYPE_L2SQR>, MemoryIO>>(
-            quantizer_param, io_param, common);
+    auto flatten = std::make_shared<
+        FlattenDataCell<FP32Quantizer<MetricType::METRIC_TYPE_L2SQR>, FixedLayout<MemoryIO>>>(
+        quantizer_param, io_param, common);
     flatten->SetQuantizer(
         std::make_shared<FP32Quantizer<MetricType::METRIC_TYPE_L2SQR>>(1, allocator.get()));
     flatten->SetIO(std::make_unique<MemoryIO>(allocator.get()));
@@ -107,9 +107,9 @@ TEST_CASE("Search with stored vector ID", "[ut][BasicSearcher][DistanceProvider]
         JsonType::Parse(fmt::format(param_temp, "fp32")));
     auto io_param =
         IOParameter::GetIOParameterByJson(JsonType::Parse(fmt::format(param_temp, "memory_io")));
-    auto flatten =
-        std::make_shared<FlattenDataCell<FP32Quantizer<MetricType::METRIC_TYPE_L2SQR>, MemoryIO>>(
-            fp32_param, io_param, common);
+    auto flatten = std::make_shared<
+        FlattenDataCell<FP32Quantizer<MetricType::METRIC_TYPE_L2SQR>, FixedLayout<MemoryIO>>>(
+        fp32_param, io_param, common);
 
     const std::vector<float> vectors = {
         0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,
@@ -189,12 +189,13 @@ TEST_CASE("Optimize SQ4", "[ut][BasicOptimizer]") {
     FlattenInterfacePtr vector_data_cell;
     if (quantizer_type == std::string("sq4_uniform")) {
         vector_data_cell = std::make_shared<
-            FlattenDataCell<SQ4UniformQuantizer<vsag::MetricType::METRIC_TYPE_L2SQR>, MemoryIO>>(
-            quantizer_param, io_param, common);
+            FlattenDataCell<SQ4UniformQuantizer<vsag::MetricType::METRIC_TYPE_L2SQR>,
+                            FixedLayout<MemoryIO>>>(quantizer_param, io_param, common);
     } else {
-        vector_data_cell = std::make_shared<
-            FlattenDataCell<FP32Quantizer<vsag::MetricType::METRIC_TYPE_L2SQR>, MemoryIO>>(
-            quantizer_param, io_param, common);
+        vector_data_cell =
+            std::make_shared<FlattenDataCell<FP32Quantizer<vsag::MetricType::METRIC_TYPE_L2SQR>,
+                                             FixedLayout<MemoryIO>>>(
+                quantizer_param, io_param, common);
     }
 
     vector_data_cell->Train(base_vectors.data(), base_size);
@@ -243,7 +244,7 @@ TEST_CASE("BasicSearcher duplicate threshold keeps nearest owner",
         IOParameter::GetIOParameterByJson(JsonType::Parse(fmt::format(param_temp, "memory_io")));
 
     auto vector_data_cell = std::make_shared<
-        FlattenDataCell<FP32Quantizer<vsag::MetricType::METRIC_TYPE_L2SQR>, MemoryIO>>(
+        FlattenDataCell<FP32Quantizer<vsag::MetricType::METRIC_TYPE_L2SQR>, FixedLayout<MemoryIO>>>(
         quantizer_param, io_param, common);
     vector_data_cell->SetQuantizer(
         std::make_shared<FP32Quantizer<vsag::MetricType::METRIC_TYPE_L2SQR>>(2, allocator.get()));
@@ -327,7 +328,7 @@ TEST_CASE("BasicSearcher iterator drain path handles sign and lower_bound correc
     common.metric_ = vsag::MetricType::METRIC_TYPE_L2SQR;
 
     auto vector_data_cell = std::make_shared<
-        FlattenDataCell<FP32Quantizer<vsag::MetricType::METRIC_TYPE_L2SQR>, MemoryIO>>(
+        FlattenDataCell<FP32Quantizer<vsag::MetricType::METRIC_TYPE_L2SQR>, FixedLayout<MemoryIO>>>(
         fp32_param, io_param, common);
     vector_data_cell->SetQuantizer(
         std::make_shared<FP32Quantizer<vsag::MetricType::METRIC_TYPE_L2SQR>>(dim, allocator.get()));
@@ -416,9 +417,9 @@ TEST_CASE("BasicSearcher traverses through a non-finite-distance bridge",
         JsonType::Parse(fmt::format(param_temp, "fp32")));
     auto io_param =
         IOParameter::GetIOParameterByJson(JsonType::Parse(fmt::format(param_temp, "memory_io")));
-    auto flatten =
-        std::make_shared<FlattenDataCell<FP32Quantizer<MetricType::METRIC_TYPE_L2SQR>, MemoryIO>>(
-            quantizer_param, io_param, common);
+    auto flatten = std::make_shared<
+        FlattenDataCell<FP32Quantizer<MetricType::METRIC_TYPE_L2SQR>, FixedLayout<MemoryIO>>>(
+        quantizer_param, io_param, common);
     flatten->SetQuantizer(
         std::make_shared<FP32Quantizer<MetricType::METRIC_TYPE_L2SQR>>(1, allocator.get()));
     flatten->SetIO(std::make_unique<MemoryIO>(allocator.get()));

--- a/src/impl/searcher/mci_searcher_test.cpp
+++ b/src/impl/searcher/mci_searcher_test.cpp
@@ -31,9 +31,9 @@ TEST_CASE("MCISearcher threshold results backfill past non-finite traversal seed
         JsonType::Parse(fmt::format(param_template, "fp32")));
     auto io_param = IOParameter::GetIOParameterByJson(
         JsonType::Parse(fmt::format(param_template, "memory_io")));
-    auto flatten =
-        std::make_shared<FlattenDataCell<FP32Quantizer<MetricType::METRIC_TYPE_IP>, MemoryIO>>(
-            quantizer_param, io_param, common);
+    auto flatten = std::make_shared<
+        FlattenDataCell<FP32Quantizer<MetricType::METRIC_TYPE_IP>, FixedLayout<MemoryIO>>>(
+        quantizer_param, io_param, common);
     flatten->SetQuantizer(
         std::make_shared<FP32Quantizer<MetricType::METRIC_TYPE_IP>>(1, allocator.get()));
     flatten->SetIO(std::make_unique<MemoryIO>(allocator.get()));

--- a/src/impl/searcher/parallel_searcher_test.cpp
+++ b/src/impl/searcher/parallel_searcher_test.cpp
@@ -41,9 +41,9 @@ TEST_CASE("ParallelSearcher matches BasicSearcher on a generic graph", "[ut][Par
         JsonType::Parse(fmt::format(param_template, "fp32")));
     auto io_param = IOParameter::GetIOParameterByJson(
         JsonType::Parse(fmt::format(param_template, "memory_io")));
-    auto flatten =
-        std::make_shared<FlattenDataCell<FP32Quantizer<MetricType::METRIC_TYPE_L2SQR>, MemoryIO>>(
-            quantizer_param, io_param, common);
+    auto flatten = std::make_shared<
+        FlattenDataCell<FP32Quantizer<MetricType::METRIC_TYPE_L2SQR>, FixedLayout<MemoryIO>>>(
+        quantizer_param, io_param, common);
     flatten->Train(base_vectors.data(), base_size);
     flatten->BatchInsertVector(base_vectors.data(), base_size, ids.data());
 
@@ -102,9 +102,9 @@ TEST_CASE("ParallelSearcher traverses through a non-finite-distance bridge",
         JsonType::Parse(fmt::format(param_temp, "fp32")));
     auto io_param =
         IOParameter::GetIOParameterByJson(JsonType::Parse(fmt::format(param_temp, "memory_io")));
-    auto flatten =
-        std::make_shared<FlattenDataCell<FP32Quantizer<MetricType::METRIC_TYPE_L2SQR>, MemoryIO>>(
-            quantizer_param, io_param, common);
+    auto flatten = std::make_shared<
+        FlattenDataCell<FP32Quantizer<MetricType::METRIC_TYPE_L2SQR>, FixedLayout<MemoryIO>>>(
+        quantizer_param, io_param, common);
     flatten->SetQuantizer(
         std::make_shared<FP32Quantizer<MetricType::METRIC_TYPE_L2SQR>>(1, allocator.get()));
     flatten->SetIO(std::make_unique<MemoryIO>(allocator.get()));

--- a/src/layout/CMakeLists.txt
+++ b/src/layout/CMakeLists.txt
@@ -1,0 +1,20 @@
+# Copyright 2024-present the vsag project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if (ENABLE_TESTS)
+    file (GLOB LAYOUT_TESTS "*_test.cpp")
+    add_library (layout_test STATIC ${LAYOUT_TESTS})
+    target_link_libraries (layout_test PRIVATE Catch2::Catch2 vsag_static unittest_deps)
+    add_dependencies (layout_test Catch2)
+endif ()

--- a/src/layout/fixed_layout.h
+++ b/src/layout/fixed_layout.h
@@ -1,0 +1,199 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <type_traits>
+
+#include "common.h"
+#include "index_common_param.h"
+#include "io/common/basic_io.h"
+#include "io/memory_io/memory_io.h"
+#include "storage/stream_reader.h"
+#include "storage/stream_writer.h"
+#include "vsag_exception.h"
+
+namespace vsag {
+
+/**
+ * A fixed-size record layout backed by a concrete CRTP IO type.
+ *
+ * FixedLayout maps a logical record ID to the byte range
+ * `[id * code_size, (id + 1) * code_size)`. It only organizes and transports
+ * opaque bytes; interpretation of those bytes remains in the DataCell.
+ */
+template <typename IOTmpl>
+class FixedLayout {
+public:
+    using IOType = IOTmpl;
+    static constexpr bool InMemory = IOTmpl::InMemory;
+
+    FixedLayout() = default;
+
+    FixedLayout(const IOParamPtr& io_param, const IndexCommonParam& common_param)
+        : FixedLayout(0, io_param, common_param) {
+    }
+
+    FixedLayout(uint64_t code_size,
+                const IOParamPtr& io_param,
+                const IndexCommonParam& common_param)
+        : code_size_(code_size), io_(std::make_shared<IOTmpl>(io_param, common_param)) {
+    }
+
+    [[nodiscard]] uint64_t
+    GetCodeSize() const {
+        return code_size_;
+    }
+
+    void
+    SetCodeSize(uint64_t code_size) {
+        code_size_ = code_size;
+    }
+
+    void
+    SetIO(std::shared_ptr<BasicIO<IOTmpl>> io) {
+        io_ = std::move(io);
+    }
+
+    void
+    Write(InnerIdType id, const uint8_t* code) {
+        io_->Write(code, code_size_, GetOffset(id));
+    }
+
+    void
+    WriteRange(InnerIdType begin_id, const uint8_t* codes, uint64_t count) {
+        io_->Write(codes, GetByteSize(count), GetOffset(begin_id));
+    }
+
+    bool
+    Read(InnerIdType id, uint8_t* code) const {
+        return io_->Read(code_size_, GetOffset(id), code);
+    }
+
+    [[nodiscard]] const uint8_t*
+    Read(InnerIdType id, bool& need_release) const {
+        return io_->Read(code_size_, GetOffset(id), need_release);
+    }
+
+    [[nodiscard]] const uint8_t*
+    ReadRange(InnerIdType begin_id, uint64_t count, bool& need_release) const {
+        return io_->Read(GetByteSize(count), GetOffset(begin_id), need_release);
+    }
+
+    bool
+    MultiRead(const InnerIdType* ids, uint64_t count, uint8_t* codes, Allocator* allocator) const {
+        Vector<uint64_t> sizes(count, code_size_, allocator);
+        Vector<uint64_t> offsets(count, 0, allocator);
+        for (uint64_t i = 0; i < count; ++i) {
+            offsets[i] = GetOffset(ids[i]);
+        }
+        return io_->MultiRead(codes, sizes.data(), offsets.data(), count);
+    }
+
+    void
+    Release(const uint8_t* code) const {
+        if (code != nullptr) {
+            io_->Release(code);
+        }
+    }
+
+    void
+    Prefetch(InnerIdType id, uint64_t bytes) {
+        io_->Prefetch(GetOffset(id), bytes);
+    }
+
+    void
+    Resize(uint64_t capacity) {
+        io_->Resize(GetByteSize(capacity));
+    }
+
+    void
+    Shrink(uint64_t capacity) {
+        io_->Shrink(GetByteSize(capacity));
+    }
+
+    void
+    Move(InnerIdType from, InnerIdType to) {
+        bool need_release = false;
+        const auto* code = Read(from, need_release);
+        if (code == nullptr) {
+            throw VsagException(ErrorType::READ_ERROR, "failed to read fixed layout record");
+        }
+        try {
+            Write(to, code);
+        } catch (...) {
+            if (need_release and code != nullptr) {
+                Release(code);
+            }
+            throw;
+        }
+        if (need_release and code != nullptr) {
+            Release(code);
+        }
+    }
+
+    void
+    InitIO(const IOParamPtr& io_param) {
+        io_->InitIO(io_param);
+    }
+
+    void
+    Serialize(StreamWriter& writer) {
+        io_->Serialize(writer);
+    }
+
+    void
+    Deserialize(lvalue_or_rvalue<StreamReader> reader) {
+        io_->Deserialize(reader);
+    }
+
+    [[nodiscard]] uint64_t
+    GetMemoryUsage() const {
+        if constexpr (InMemory) {
+            return static_cast<uint64_t>(io_->GetMemoryUsage());
+        }
+        return 0;
+    }
+
+    [[nodiscard]] const uint8_t*
+    TryGetContiguousData() const {
+        if constexpr (std::is_same_v<IOTmpl, MemoryIO>) {
+            return std::static_pointer_cast<MemoryIO>(io_)->GetReadOnlyRawData();
+        }
+        return nullptr;
+    }
+
+private:
+    [[nodiscard]] uint64_t
+    GetOffset(InnerIdType id) const {
+        return GetByteSize(static_cast<uint64_t>(id));
+    }
+
+    [[nodiscard]] uint64_t
+    GetByteSize(uint64_t count) const {
+        if (code_size_ != 0 and count > std::numeric_limits<uint64_t>::max() / code_size_) {
+            throw VsagException(ErrorType::INVALID_ARGUMENT, "fixed layout byte size overflow");
+        }
+        return count * code_size_;
+    }
+
+    uint64_t code_size_{0};
+    std::shared_ptr<BasicIO<IOTmpl>> io_{nullptr};
+};
+
+}  // namespace vsag

--- a/src/layout/fixed_layout_test.cpp
+++ b/src/layout/fixed_layout_test.cpp
@@ -1,0 +1,153 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "layout/fixed_layout.h"
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <sstream>
+
+#include "impl/allocator/safe_allocator.h"
+#include "io/memory_io/memory_io.h"
+#include "storage/stream_reader.h"
+#include "storage/stream_writer.h"
+#include "unittest.h"
+
+using namespace vsag;
+
+namespace {
+
+class NonMemoryReviewIO : public BasicIO<NonMemoryReviewIO> {
+public:
+    static constexpr bool InMemory = false;
+    static constexpr bool SkipDeserialize = false;
+
+    NonMemoryReviewIO(const IOParamPtr&, const IndexCommonParam& common_param)
+        : BasicIO<NonMemoryReviewIO>(common_param.allocator_.get()) {
+    }
+
+    void
+    WriteImpl(const uint8_t*, uint64_t size, uint64_t offset) {
+        this->size_ = std::max(this->size_, offset + size);
+    }
+
+    bool
+    ReadImpl(uint64_t, uint64_t, uint8_t*) const {
+        return false;
+    }
+
+    [[nodiscard]] const uint8_t*
+    DirectReadImpl(uint64_t, uint64_t, bool& need_release) const {
+        need_release = false;
+        return nullptr;
+    }
+};
+
+IndexCommonParam
+MakeCommonParam() {
+    IndexCommonParam common_param;
+    common_param.allocator_ = SafeAllocator::FactoryDefaultAllocator();
+    return common_param;
+}
+
+}  // namespace
+
+TEST_CASE("FixedLayout maps ids to fixed records", "[ut][FixedLayout]") {
+    auto common_param = MakeCommonParam();
+    FixedLayout<MemoryIO> layout(4, nullptr, common_param);
+    layout.Resize(4);
+
+    const std::array<uint8_t, 4> first{1, 2, 3, 4};
+    const std::array<uint8_t, 4> second{5, 6, 7, 8};
+    const std::array<uint8_t, 4> replacement{9, 10, 11, 12};
+    layout.Write(1, first.data());
+    layout.Write(3, second.data());
+
+    std::array<uint8_t, 4> output{};
+    REQUIRE(layout.Read(1, output.data()));
+    REQUIRE(output == first);
+    REQUIRE(layout.Read(3, output.data()));
+    REQUIRE(output == second);
+
+    layout.Write(1, replacement.data());
+    REQUIRE(layout.Read(1, output.data()));
+    REQUIRE(output == replacement);
+}
+
+TEST_CASE("FixedLayout supports ranges and id batch reads", "[ut][FixedLayout]") {
+    auto common_param = MakeCommonParam();
+    FixedLayout<MemoryIO> layout(2, nullptr, common_param);
+    layout.Resize(4);
+
+    const std::array<uint8_t, 8> records{1, 2, 3, 4, 5, 6, 7, 8};
+    layout.WriteRange(0, records.data(), 4);
+
+    bool need_release = true;
+    const auto* range = layout.ReadRange(1, 2, need_release);
+    REQUIRE(range != nullptr);
+    REQUIRE_FALSE(need_release);
+    REQUIRE(std::memcmp(range, records.data() + 2, 4) == 0);
+
+    const std::array<InnerIdType, 4> ids{3, 1, 3, 0};
+    std::array<uint8_t, 8> batch{};
+    REQUIRE(layout.MultiRead(ids.data(), ids.size(), batch.data(), common_param.allocator_.get()));
+    const std::array<uint8_t, 8> expected{7, 8, 3, 4, 7, 8, 1, 2};
+    REQUIRE(batch == expected);
+
+    std::array<uint8_t, 1> empty_batch{};
+    REQUIRE(layout.MultiRead(nullptr, 0, empty_batch.data(), common_param.allocator_.get()));
+
+    REQUIRE(layout.TryGetContiguousData() != nullptr);
+    REQUIRE(std::memcmp(layout.TryGetContiguousData(), records.data(), records.size()) == 0);
+}
+
+TEST_CASE("FixedLayout preserves io serialization bytes", "[ut][FixedLayout]") {
+    auto common_param = MakeCommonParam();
+    FixedLayout<MemoryIO> source(3, nullptr, common_param);
+    source.Resize(2);
+    const std::array<uint8_t, 6> records{1, 3, 5, 7, 9, 11};
+    source.WriteRange(0, records.data(), 2);
+
+    std::stringstream stream;
+    IOStreamWriter writer(stream);
+    source.Serialize(writer);
+    stream.seekg(0, std::ios::beg);
+
+    FixedLayout<MemoryIO> restored(3, nullptr, common_param);
+    IOStreamReader reader(stream);
+    restored.Deserialize(reader);
+
+    bool need_release = false;
+    const auto* restored_records = restored.ReadRange(0, 2, need_release);
+    REQUIRE(restored_records != nullptr);
+    REQUIRE_FALSE(need_release);
+    REQUIRE(std::memcmp(restored_records, records.data(), records.size()) == 0);
+}
+
+TEST_CASE("FixedLayout rejects overflowing byte ranges", "[ut][FixedLayout]") {
+    auto common_param = MakeCommonParam();
+    FixedLayout<MemoryIO> layout(std::numeric_limits<uint64_t>::max(), nullptr, common_param);
+    REQUIRE_THROWS_AS(layout.Resize(2), VsagException);
+}
+
+TEST_CASE("FixedLayout handles non-memory accounting and failed moves", "[ut][FixedLayout]") {
+    auto common_param = MakeCommonParam();
+    FixedLayout<NonMemoryReviewIO> layout(4, nullptr, common_param);
+    layout.Resize(2);
+
+    REQUIRE(layout.GetMemoryUsage() == 0);
+    REQUIRE_THROWS_AS(layout.Move(0, 1), VsagException);
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,7 +29,7 @@ target_link_libraries (unittests
         PRIVATE
         Catch2::Catch2 
         simd_test vsag_test algorithm_test factory_test attr_test
-        datacell_test quantizer_test storage_test io_test utils_test impl_test
+        datacell_test layout_test quantizer_test storage_test io_test utils_test impl_test
         vsag_static
 )
 
@@ -42,6 +42,7 @@ if (APPLE)
         "-Wl,-force_load,$<TARGET_FILE:factory_test>"
         "-Wl,-force_load,$<TARGET_FILE:attr_test>"
         "-Wl,-force_load,$<TARGET_FILE:datacell_test>"
+        "-Wl,-force_load,$<TARGET_FILE:layout_test>"
         "-Wl,-force_load,$<TARGET_FILE:quantizer_test>"
         "-Wl,-force_load,$<TARGET_FILE:storage_test>"
         "-Wl,-force_load,$<TARGET_FILE:io_test>"
@@ -53,7 +54,7 @@ else()
                         PRIVATE
                         "-Wl,--whole-archive"
                         simd_test vsag_test algorithm_test factory_test attr_test
-                        datacell_test quantizer_test storage_test io_test utils_test impl_test
+                        datacell_test layout_test quantizer_test storage_test io_test utils_test impl_test
                         "-Wl,--no-whole-archive"
         )
 endif()


### PR DESCRIPTION
## Summary
- introduce a statically IO-bound FixedLayout for opaque fixed-size records
- compose FlattenDataCell and ExtraInfoDataCell with Layout instead of directly owning IO
- reuse FixedLayout for RaBitQ split code storage while preserving serialization order
- add focused FixedLayout unit coverage

## Validation
- Release build
- clang-format 15
- VSAG lint check
- FixedLayout: 18 assertions in 4 test cases
- FlattenDataCell: 8,654,544 assertions in 1 test case
- ExtraInfoDataCell: 17,080 assertions in 1 test case
- RaBitQSplitDataCell: 9,593 assertions in 8 test cases

Complex Daily suites were intentionally skipped after focused validation.