### PR TITLE
refactor(autotune): make candidate choices explicit

### DIFF
--- a/docs/docs/en/src/resources/autotune.md
+++ b/docs/docs/en/src/resources/autotune.md
@@ -68,8 +68,8 @@ objective. Dataset buffers must remain valid until the synchronous call returns.
 
 `IndexSpace::create_parameter_space` and `search_parameter_space` remain JSON strings because each
 index owns its native parameter schema. An empty `index_spaces` vector selects the built-in HGraph
-and IVF spaces; otherwise arrays and `$range` expressions use the same semantics as the CLI
-contract.
+and IVF spaces; otherwise `$choices` and `$range` expressions use the same semantics as the CLI
+contract, while bare arrays remain native parameter values.
 
 The result contains the loaded `index`, `index_name`, complete concrete `create_parameters`,
 validated `search_parameters`, metrics, artifact path, and the complete report. `metrics` and
@@ -111,8 +111,8 @@ from the dataset and need not be repeated. If provided, they must match the data
       "name": "hgraph",
       "create_params": {
         "index_param": {
-          "base_quantization_type": ["fp32", "sq8_uniform"],
-          "max_degree": [16, 32],
+          "base_quantization_type": {"$choices": ["fp32", "sq8_uniform"]},
+          "max_degree": {"$choices": [16, 32]},
           "ef_construction": 200
         }
       },
@@ -150,13 +150,13 @@ Run it with:
 ./build-release/tools/autotune/autotune request.json
 ```
 
-Every parameter leaf may be a scalar, an array, or a `$range` with `start`, `stop`, and `step`.
-Explicit values are preserved. HGraph `ef_search` additionally accepts an integer `$range` without
-`step`; AutoTune then doubles from `start` until it brackets a passing value and binary-searches
-that interval for the smallest passing value. This assumes that recall does not decrease as
-`ef_search` increases for the fixed configuration. Every evaluated point uses all queries. For
-omitted tuning fields, V1 supplies a small built-in candidate set for HGraph or IVF. If `indexes`
-is omitted, both indexes are evaluated.
+Use `{"$choices": [...]}` for discrete candidates or a `$range` with `start`, `stop`, and `step`.
+Other JSON values, including arrays, remain exact native parameter values. HGraph `ef_search`
+additionally accepts an integer `$range` without `step`; AutoTune then doubles from `start` until it
+brackets a passing value and binary-searches that interval for the smallest passing value. This
+assumes that recall does not decrease as `ef_search` increases for the fixed configuration. Every
+evaluated point uses all queries. For omitted tuning fields, V1 supplies a small built-in candidate
+set for HGraph or IVF. If `indexes` is omitted, both indexes are evaluated.
 
 Candidates with identical concrete create parameters share one build. Each concrete search
 parameter set remains a separate trial. An adaptive `ef_search` range records only the concrete
@@ -175,7 +175,7 @@ Programmatic callers use a separate `SearchRequest` and call `TuneSearch`:
 vsag::autotune::SearchRequest request;
 request.index = existing_index;
 request.workload = {queries, ground_truth, 10, 48};
-request.parameter_space = R"({"hgraph":{"ef_search":[40,80,120]}})";
+request.parameter_space = R"({"hgraph":{"ef_search":{"$choices":[40,80,120]}}})";
 request.constraints = {{vsag::autotune::Metric::RECALL_AT_K, 0.95}};
 request.objective = vsag::autotune::Metric::LATENCY_AVG_MS;
 

--- a/docs/docs/en/src/resources/autotune_api_v1.md
+++ b/docs/docs/en/src/resources/autotune_api_v1.md
@@ -48,7 +48,7 @@ Each `indexes[]` item has the following shape:
   "name": "hgraph",
   "create_params": {
     "index_param": {
-      "max_degree": [16, 32]
+      "max_degree": {"$choices": [16, 32]}
     }
   },
   "search_params": {
@@ -71,10 +71,10 @@ Pyramid is accepted only with an existing in-memory or serialized index.
 
 ### Candidate Expressions
 
-Every leaf in `create_params` and `search_params` can be written as:
+Every field in `create_params` and `search_params` can be written as:
 
-- a scalar, which fixes that value;
-- a non-empty array, which provides discrete candidate values;
+- a concrete JSON value, including an array, which fixes that exact value;
+- a `$choices` object containing a non-empty array of discrete candidate values;
 - an inclusive `$range` containing exactly `start`, `stop`, and non-zero `step`.
 
 Examples:
@@ -82,11 +82,16 @@ Examples:
 ```json
 {
   "fixed": 32,
-  "choices": [16, 32, 48],
+  "literal_array": [0, 1],
+  "choices": {"$choices": [16, 32, 48]},
+  "array_choices": {"$choices": [[], [0], [0, 1]]},
   "integer_range": {"$range": {"start": 40, "stop": 120, "step": 40}},
   "float_range": {"$range": {"start": 0.1, "stop": 0.3, "step": 0.1}}
 }
 ```
+
+Each `$choices` item is one complete literal value; candidate expressions are not interpreted
+inside it. Duplicate items are removed. `$choices` cannot be empty or mixed with other keys.
 
 HGraph `ef_search` has one additional form:
 
@@ -107,9 +112,9 @@ other parameters and the workload remain fixed.
 Every probe evaluates the full query workload. If a probe fails to execute or does not produce
 recall, AutoTune stops that adaptive range because it cannot choose the next interval safely.
 
-V1 treats every JSON array and stepped range in these parameter objects as candidate choices. It
-computes their full Cartesian product and removes identical complete candidates. A no-step range
-is not accepted for other parameters.
+V1 treats every `$choices` and stepped range in these parameter objects as a candidate expression.
+It computes their full Cartesian product and removes identical complete candidates. Bare JSON
+arrays remain native parameter values. A no-step range is not accepted for other parameters.
 
 The request is rejected when the planned worst-case evaluation count exceeds
 `tuning_config.max_trials`. A normal concrete candidate costs one trial. An adaptive `ef_search`

--- a/docs/docs/zh/src/resources/autotune.md
+++ b/docs/docs/zh/src/resources/autotune.md
@@ -65,7 +65,8 @@ if (result.has_value() && result->status == vsag::autotune::TuneStatus::SUCCESS)
 
 每个索引拥有不同的原生参数模式，因此 `IndexSpace::create_parameter_space` 和
 `search_parameter_space` 仍使用 JSON 字符串。`index_spaces` 为空时使用内置 HGraph 和
-IVF 候选；显式参数中的数组和 `$range` 与 CLI 契约语义相同。
+IVF 候选；显式参数中的 `$choices` 和 `$range` 与 CLI 契约语义相同，裸数组保持为索引
+原生参数值。
 
 返回值包括已加载的 `index`、`index_name`、完整具体 `create_parameters`、经过验证的
 `search_parameters`、metrics、artifact 路径和完整报告。`metrics` 和 `report` 都是
@@ -105,8 +106,8 @@ cmake --build build-release --target 326_feature_create_index_with_constraints -
       "name": "hgraph",
       "create_params": {
         "index_param": {
-          "base_quantization_type": ["fp32", "sq8_uniform"],
-          "max_degree": [16, 32],
+          "base_quantization_type": {"$choices": ["fp32", "sq8_uniform"]},
+          "max_degree": {"$choices": [16, 32]},
           "ef_construction": 200
         }
       },
@@ -144,12 +145,12 @@ cmake --build build-release --target 326_feature_create_index_with_constraints -
 ./build-release/tools/autotune/autotune request.json
 ```
 
-参数叶子可以是标量、数组，或带有 `start`、`stop`、`step` 的 `$range`。HGraph
-`ef_search` 还可以省略 `step`；AutoTune 会从 `start` 倍增，找到首个满足 `recall_at_k`
-约束的区间，再在该区间内二分查找最小通过值。该策略假设固定其他配置时 recall 不会随
-`ef_search` 增大而降低。每个实际评测点都使用全部 query。用户显式提供的值保持不变；
-对于缺失的调优字段，V1 会补充一小组 HGraph 或 IVF 内置候选。省略 `indexes` 时会同时
-评测这两种索引。
+离散候选使用 `{"$choices": [...]}`，连续候选使用包含 `start`、`stop`、`step` 的
+`$range`。其他 JSON 值（包括数组）会保持为索引原生参数值。HGraph `ef_search` 还可以省略
+`step`；AutoTune 会从 `start` 倍增，找到首个满足 `recall_at_k` 约束的区间，再在该区间内
+二分查找最小通过值。该策略假设固定其他配置时 recall 不会随 `ef_search` 增大而降低。每个
+实际评测点都使用全部 query。对于缺失的调优字段，V1 会补充一小组 HGraph 或 IVF 内置候选。
+省略 `indexes` 时会同时评测这两种索引。
 
 具体 create 参数相同的候选只构建一次；每组具体 search 参数仍然是独立 trial。自适应
 `ef_search` 范围只记录实际评测过的具体参数点。
@@ -166,7 +167,7 @@ cmake --build build-release --target 326_feature_create_index_with_constraints -
 vsag::autotune::SearchRequest request;
 request.index = existing_index;
 request.workload = {queries, ground_truth, 10, 48};
-request.parameter_space = R"({"hgraph":{"ef_search":[40,80,120]}})";
+request.parameter_space = R"({"hgraph":{"ef_search":{"$choices":[40,80,120]}}})";
 request.constraints = {{vsag::autotune::Metric::RECALL_AT_K, 0.95}};
 request.objective = vsag::autotune::Metric::LATENCY_AVG_MS;
 

--- a/docs/docs/zh/src/resources/autotune_api_v1.md
+++ b/docs/docs/zh/src/resources/autotune_api_v1.md
@@ -45,7 +45,7 @@ AutoTune 从数据集读取 `dim`、`dtype` 和 `metric_type`，并注入每组�
   "name": "hgraph",
   "create_params": {
     "index_param": {
-      "max_degree": [16, 32]
+      "max_degree": {"$choices": [16, 32]}
     }
   },
   "search_params": {
@@ -68,10 +68,10 @@ Pyramid 只接受已有的内存索引或序列化索引。
 
 ### 候选表达式
 
-`create_params` 和 `search_params` 中的每个叶子都可以写成：
+`create_params` 和 `search_params` 中的每个字段都可以写成：
 
-- 标量：固定该值；
-- 非空数组：提供离散候选值；
+- 具体 JSON 值（包括数组）：固定为该完整值；
+- `$choices` 对象：其中包含非空数组，用于提供离散候选值；
 - `$range`：必须且只能包含 `start`、`stop` 和非零 `step`，范围包含端点。
 
 示例：
@@ -79,11 +79,16 @@ Pyramid 只接受已有的内存索引或序列化索引。
 ```json
 {
   "fixed": 32,
-  "choices": [16, 32, 48],
+  "literal_array": [0, 1],
+  "choices": {"$choices": [16, 32, 48]},
+  "array_choices": {"$choices": [[], [0], [0, 1]]},
   "integer_range": {"$range": {"start": 40, "stop": 120, "step": 40}},
   "float_range": {"$range": {"start": 0.1, "stop": 0.3, "step": 0.1}}
 }
 ```
+
+`$choices` 中的每一项都是一个完整的具体值，其中不再解释嵌套的候选表达式。重复项会被
+去除；`$choices` 不能为空，也不能和其他 key 混用。
 
 HGraph `ef_search` 还支持一种特殊写法：
 
@@ -102,8 +107,9 @@ latency 和 QPS 仍作为实测指标参与最终约束过滤和结果选择。�
 每个探测点都会评测完整 query workload。如果某个评测点执行失败或没有 recall，AutoTune
 会停止该自适应范围，因为此时无法安全选择下一个区间。
 
-V1 会把参数对象中的所有 JSON 数组和带 `step` 的范围解释成候选集合，计算完整笛卡尔积
-并去除完全相同的候选。其他参数不接受省略 `step` 的范围。
+V1 会把参数对象中的所有 `$choices` 和带 `step` 的范围解释成候选集合，计算完整笛卡尔积
+并去除完全相同的候选。裸 JSON 数组会保持为索引原生参数值。其他参数不接受省略 `step`
+的范围。
 
 计划的最坏评测次数超过 `tuning_config.max_trials` 时，请求失败。普通具体候选占一个
 trial；自适应 `ef_search` 在 `start == stop` 时占一个。否则，planner 会为每个可能的首次

--- a/examples/cpp/326_feature_create_index_with_constraints.cpp
+++ b/examples/cpp/326_feature_create_index_with_constraints.cpp
@@ -51,7 +51,7 @@ main() {
     request.index_spaces = {
         {"hgraph",
          R"({"index_param":{"base_quantization_type":"fp32","max_degree":8,"ef_construction":40}})",
-         R"({"hgraph":{"ef_search":[10,20]}})"}};
+         R"({"hgraph":{"ef_search":{"$choices":[10,20]}}})"}};
     request.constraints = {{vsag::autotune::Metric::RECALL_AT_K, 1.0},
                            {vsag::autotune::Metric::INDEX_MEMORY_MB, 1024.0}};
     request.objective = vsag::autotune::Metric::LATENCY_AVG_MS;

--- a/examples/cpp/327_feature_autotune_existing_index.cpp
+++ b/examples/cpp/327_feature_autotune_existing_index.cpp
@@ -84,7 +84,7 @@ main() {
     vsag::autotune::SearchRequest request;
     request.index = index;
     request.workload = {queries, ground_truth, 1, 1};
-    request.parameter_space = R"({"hgraph":{"ef_search":[4,8,16]}})";
+    request.parameter_space = R"({"hgraph":{"ef_search":{"$choices":[4,8,16]}}})";
     request.constraints = {{vsag::autotune::Metric::RECALL_AT_K, 1.0}};
     request.objective = vsag::autotune::Metric::LATENCY_AVG_MS;
     request.config.max_trials = 3;

--- a/examples/cpp/328_feature_autotune_existing_pyramid.cpp
+++ b/examples/cpp/328_feature_autotune_existing_pyramid.cpp
@@ -98,7 +98,7 @@ TunePath(const vsag::IndexPtr& index, const PathWorkload& workload) {
     vsag::autotune::SearchRequest request;
     request.index = index;
     request.workload = {workload.queries, workload.ground_truth, TOP_K, 1};
-    request.parameter_space = R"({"pyramid":{"ef_search":[10,20,40,80,160]}})";
+    request.parameter_space = R"({"pyramid":{"ef_search":{"$choices":[10,20,40,80,160]}}})";
     request.constraints = {{vsag::autotune::Metric::RECALL_AT_K, 0.80}};
     request.objective = vsag::autotune::Metric::LATENCY_AVG_MS;
     request.config.max_trials = 5;

--- a/tools/autotune/autotune.h
+++ b/tools/autotune/autotune.h
@@ -76,9 +76,11 @@ struct Config {
 struct IndexSpace {
     /// Concrete index type, currently hgraph or ivf.
     std::string name;
-    /// JSON object whose scalar, array, and range leaves define build candidates.
+    /// JSON object with concrete values, explicit $choices, or $range build expressions. Bare
+    /// arrays are concrete values.
     std::string create_parameter_space{"{}"};
-    /// JSON object whose scalar, array, and range leaves define search candidates.
+    /// JSON object with concrete values, explicit $choices, or $range search expressions. Bare
+    /// arrays are concrete values.
     std::string search_parameter_space{"{}"};
 };
 
@@ -100,7 +102,8 @@ struct SearchRequest {
     /// Existing index reused in place; TuneSearch neither rebuilds nor takes exclusive ownership.
     IndexPtr index;
     Workload workload;
-    /// JSON search candidate space; missing supported fields receive built-in proposals.
+    /// JSON search space with explicit $choices or $range candidate expressions; missing supported
+    /// fields receive built-in proposals.
     std::string parameter_space{"{}"};
     std::vector<Constraint> constraints;
     Metric objective{Metric::UNSPECIFIED};

--- a/tools/autotune/autotune_candidate.cpp
+++ b/tools/autotune/autotune_candidate.cpp
@@ -27,6 +27,11 @@ namespace {
 
 using Emit = std::function<void(const JsonType&)>;
 
+JsonType
+candidate_choices(JsonType values) {
+    return {{"$choices", std::move(values)}};
+}
+
 int64_t
 range_integer(const JsonType& value) {
     if (value.is_number_unsigned()) {
@@ -149,22 +154,36 @@ expand_range(const JsonType& range, const Emit& emit) {
 }
 
 void
+expand_choices(const JsonType& choices, const Emit& emit) {
+    if (!choices.is_array()) {
+        throw std::invalid_argument("$choices must be an array");
+    }
+    if (choices.empty()) {
+        throw std::invalid_argument("$choices must not be empty");
+    }
+
+    std::set<std::string> seen;
+    for (const auto& choice : choices) {
+        if (seen.emplace(choice.dump()).second) {
+            emit(choice);
+        }
+    }
+}
+
+void
 expand(const JsonType& value, const Emit& emit) {
     if (value.is_array()) {
-        if (value.empty()) {
-            throw std::invalid_argument("candidate array must not be empty");
-        }
-        std::set<std::string> seen;
-        for (const auto& item : value) {
-            expand(item, [&](const JsonType& expanded) {
-                if (seen.emplace(expanded.dump()).second) {
-                    emit(expanded);
-                }
-            });
-        }
+        emit(value);
         return;
     }
     if (value.is_object()) {
+        if (value.contains("$choices")) {
+            if (value.size() != 1) {
+                throw std::invalid_argument("$choices cannot be mixed with other keys");
+            }
+            expand_choices(value["$choices"], emit);
+            return;
+        }
         if (value.contains("$range")) {
             if (value.size() != 1) {
                 throw std::invalid_argument("$range cannot be mixed with other keys");
@@ -188,13 +207,14 @@ fill_hgraph_create(JsonType& create_params) {
         throw std::invalid_argument("hgraph create_params.index_param must be an object");
     }
     if (!params.contains("base_quantization_type")) {
-        params["base_quantization_type"] = JsonType::array({"fp32", "sq8_uniform"});
+        params["base_quantization_type"] =
+            candidate_choices(JsonType::array({"fp32", "sq8_uniform"}));
     }
     if (!params.contains("max_degree")) {
-        params["max_degree"] = JsonType::array({16, 32});
+        params["max_degree"] = candidate_choices(JsonType::array({16, 32}));
     }
     if (!params.contains("ef_construction")) {
-        params["ef_construction"] = JsonType::array({100, 200});
+        params["ef_construction"] = candidate_choices(JsonType::array({100, 200}));
     }
 }
 
@@ -208,13 +228,14 @@ fill_ivf_create(JsonType& create_params, uint64_t base_count) {
         throw std::invalid_argument("ivf create_params.index_param must be an object");
     }
     if (!params.contains("base_quantization_type")) {
-        params["base_quantization_type"] = JsonType::array({"fp32", "sq8_uniform"});
+        params["base_quantization_type"] =
+            candidate_choices(JsonType::array({"fp32", "sq8_uniform"}));
     }
     if (!params.contains("buckets_count")) {
         const auto first = std::min<uint64_t>(1024, base_count);
         const auto second = std::min<uint64_t>(2048, base_count);
         params["buckets_count"] =
-            first == second ? JsonType(first) : JsonType::array({first, second});
+            first == second ? JsonType(first) : candidate_choices(JsonType::array({first, second}));
     }
 }
 
@@ -231,7 +252,7 @@ fill_hgraph_search(JsonType& search_params, uint64_t top_k) {
         std::set<uint64_t> values{std::max<uint64_t>(40, top_k),
                                   std::max<uint64_t>(80, top_k * 2),
                                   std::max<uint64_t>(120, top_k * 4)};
-        params["ef_search"] = values;
+        params["ef_search"] = candidate_choices(values);
     }
 }
 
@@ -248,7 +269,7 @@ fill_pyramid_search(JsonType& search_params, uint64_t top_k) {
         std::set<uint64_t> values{std::max<uint64_t>(40, top_k),
                                   std::max<uint64_t>(80, top_k * 2),
                                   std::max<uint64_t>(120, top_k * 4)};
-        params["ef_search"] = values;
+        params["ef_search"] = candidate_choices(values);
     }
 }
 
@@ -268,7 +289,7 @@ fill_ivf_search(JsonType& search_params, const JsonType& create_params) {
     std::set<uint64_t> values;
     if (!create_params.contains("index_param") ||
         !create_params["index_param"].contains("buckets_count")) {
-        params["scan_buckets_count"] = std::set<uint64_t>{1, 4, 16, 64};
+        params["scan_buckets_count"] = candidate_choices(std::set<uint64_t>{1, 4, 16, 64});
         return;
     }
 
@@ -282,7 +303,7 @@ fill_ivf_search(JsonType& search_params, const JsonType& create_params) {
                   std::min<uint64_t>(32, buckets),
                   std::min<uint64_t>(64, buckets)};
     }
-    params["scan_buckets_count"] = values;
+    params["scan_buckets_count"] = candidate_choices(values);
 }
 
 bool

--- a/tools/autotune/autotune_test.cpp
+++ b/tools/autotune/autotune_test.cpp
@@ -201,29 +201,31 @@ write_dataset(const std::string& path) {
 
 JsonType
 request(const std::string& dataset, const std::string& workspace) {
-    return {{"version", 1},
-            {"data_path", dataset},
-            {"indexes",
-             JsonType::array({{{"name", "hgraph"},
-                               {"create_params",
-                                {{"index_param",
-                                  {{"base_quantization_type", "fp32"},
-                                   {"max_degree", 8},
-                                   {"ef_construction", 40},
-                                   {"build_thread_count", 2}}}}},
-                               {"search_params", {{"hgraph", {{"ef_search", {8, 16}}}}}}},
-                              {{"name", "ivf"},
-                               {"create_params",
-                                {{"index_param",
-                                  {{"base_quantization_type", "fp32"},
-                                   {"buckets_count", 4},
-                                   {"thread_count", 2}}}}},
-                               {"search_params", {{"ivf", {{"scan_buckets_count", {1, 4}}}}}}}})},
-            {"workload", {{"top_k", 3}, {"concurrency", 2}}},
-            {"constraints", {{"recall_at_k", 0.0}, {"build_seconds", 1000.0}}},
-            {"objective", {{"metric", "latency_avg_ms"}}},
-            {"tuning_config",
-             {{"workspace_path", workspace}, {"keep_intermediate", true}, {"max_trials", 4}}}};
+    return {
+        {"version", 1},
+        {"data_path", dataset},
+        {"indexes",
+         JsonType::array(
+             {{{"name", "hgraph"},
+               {"create_params",
+                {{"index_param",
+                  {{"base_quantization_type", "fp32"},
+                   {"max_degree", 8},
+                   {"ef_construction", 40},
+                   {"build_thread_count", 2}}}}},
+               {"search_params", {{"hgraph", {{"ef_search", {{"$choices", {8, 16}}}}}}}}},
+              {{"name", "ivf"},
+               {"create_params",
+                {{"index_param",
+                  {{"base_quantization_type", "fp32"},
+                   {"buckets_count", 4},
+                   {"thread_count", 2}}}}},
+               {"search_params", {{"ivf", {{"scan_buckets_count", {{"$choices", {1, 4}}}}}}}}}})},
+        {"workload", {{"top_k", 3}, {"concurrency", 2}}},
+        {"constraints", {{"recall_at_k", 0.0}, {"build_seconds", 1000.0}}},
+        {"objective", {{"metric", "latency_avg_ms"}}},
+        {"tuning_config",
+         {{"workspace_path", workspace}, {"keep_intermediate", true}, {"max_trials", 4}}}};
 }
 
 struct MemoryFixture {
@@ -285,11 +287,11 @@ struct MemoryFixture {
         result.base = base;
         result.metric_type = vsag::METRIC_L2;
         result.workload = {queries, ground_truth, 3, 2};
-        result.index_spaces = {
-            {"hgraph",
-             R"({"index_param":{"base_quantization_type":"fp32",)"
-             R"("max_degree":[8,12],"ef_construction":40,"build_thread_count":2}})",
-             R"({"hgraph":{"ef_search":16}})"}};
+        result.index_spaces = {{"hgraph",
+                                R"({"index_param":{"base_quantization_type":"fp32",)"
+                                R"("max_degree":{"$choices":[8,12]},"ef_construction":40,)"
+                                R"("build_thread_count":2}})",
+                                R"({"hgraph":{"ef_search":16}})"}};
         result.constraints = {{vsag::autotune::Metric::RECALL_AT_K, 0.0},
                               {vsag::autotune::Metric::BUILD_SECONDS, 1000.0}};
         result.objective = vsag::autotune::Metric::LATENCY_AVG_MS;
@@ -379,6 +381,76 @@ TEST_CASE("AutoTune candidate rules only fill missing fields") {
                         Catch::Matchers::ContainsSubstring("$range integer values must fit int64"));
 }
 
+TEST_CASE("AutoTune distinguishes native arrays from explicit choices") {
+    vsag::autotune::internal::IndexTuningRequest build_request;
+    build_request.context.top_k = 10;
+    build_request.context.max_trials = 3;
+    build_request.indexes = {{"pyramid",
+                              {{"index_param", {{"no_build_levels", JsonType::array({0, 1})}}}},
+                              {{"pyramid", {{"ef_search", 40}}}}}};
+
+    auto candidates = vsag::autotune::internal::GenerateCandidates(build_request);
+    REQUIRE(candidates.size() == 1);
+    REQUIRE(candidates[0].create_params["index_param"]["no_build_levels"] ==
+            JsonType::array({0, 1}));
+
+    build_request.indexes[0].create_params["index_param"]["no_build_levels"] = JsonType::array();
+    candidates = vsag::autotune::internal::GenerateCandidates(build_request);
+    REQUIRE(candidates.size() == 1);
+    REQUIRE(candidates[0].create_params["index_param"]["no_build_levels"] == JsonType::array());
+
+    build_request.indexes[0].create_params["index_param"]["no_build_levels"] = {
+        {"$choices",
+         JsonType::array({JsonType::array(), JsonType::array({0}), JsonType::array({0, 1})})}};
+    candidates = vsag::autotune::internal::GenerateCandidates(build_request);
+    REQUIRE(candidates.size() == 3);
+    REQUIRE(candidates[0].create_params["index_param"]["no_build_levels"] == JsonType::array());
+    REQUIRE(candidates[1].create_params["index_param"]["no_build_levels"] == JsonType::array({0}));
+    REQUIRE(candidates[2].create_params["index_param"]["no_build_levels"] ==
+            JsonType::array({0, 1}));
+
+    vsag::autotune::internal::SearchTuningRequest search_request;
+    search_request.context.top_k = 10;
+    search_request.context.max_trials = 2;
+    search_request.index_input = {"pyramid",
+                                  JsonType::object(),
+                                  {{"pyramid",
+                                    {{"ef_search", {{"$choices", {40, 80}}}},
+                                     {"hierarchies", JsonType::array({"site", "taxonomy"})}}}}};
+    candidates = vsag::autotune::internal::GenerateCandidates(search_request);
+    REQUIRE(candidates.size() == 2);
+    for (const auto& candidate : candidates) {
+        REQUIRE(candidate.search_params["pyramid"]["hierarchies"] ==
+                JsonType::array({"site", "taxonomy"}));
+    }
+}
+
+TEST_CASE("AutoTune validates explicit choices") {
+    vsag::autotune::internal::SearchTuningRequest request;
+    request.context.top_k = 10;
+    request.context.max_trials = 2;
+    request.index_input.name = "hgraph";
+
+    request.index_input.search_params = {{"hgraph", {{"ef_search", {{"$choices", 40}}}}}};
+    REQUIRE_THROWS_WITH(vsag::autotune::internal::GenerateCandidates(request),
+                        Catch::Matchers::ContainsSubstring("$choices must be an array"));
+
+    request.index_input.search_params = {
+        {"hgraph", {{"ef_search", {{"$choices", JsonType::array()}}}}}};
+    REQUIRE_THROWS_WITH(vsag::autotune::internal::GenerateCandidates(request),
+                        Catch::Matchers::ContainsSubstring("$choices must not be empty"));
+
+    request.index_input.search_params = {
+        {"hgraph", {{"ef_search", {{"$choices", {40, 80}}, {"other", true}}}}}};
+    REQUIRE_THROWS_WITH(
+        vsag::autotune::internal::GenerateCandidates(request),
+        Catch::Matchers::ContainsSubstring("$choices cannot be mixed with other keys"));
+
+    request.index_input.search_params = {{"hgraph", {{"ef_search", {{"$choices", {40, 40, 80}}}}}}};
+    const auto candidates = vsag::autotune::internal::GenerateCandidates(request);
+    REQUIRE(candidates.size() == 2);
+}
+
 TEST_CASE("AutoTune proposes conservative defaults for existing IVF indexes") {
     vsag::autotune::internal::SearchTuningRequest request;
     request.context.top_k = 10;
@@ -416,6 +488,9 @@ TEST_CASE("AutoTune plans an adaptive HGraph ef_search range") {
     request.context.objective = "latency_avg_ms";
     request.context.constraints = {{"recall_at_k", 0.95}};
     request.context.max_trials = 30;
+    const JsonType search_space = {{"hgraph",
+                                    {{"ef_search", {{"$range", {{"start", 40}, {"stop", 1000}}}}},
+                                     {"use_reorder", {{"$choices", {true, false}}}}}}};
     request.indexes = {
         {"hgraph",
          {{"dim", 8},
@@ -423,9 +498,7 @@ TEST_CASE("AutoTune plans an adaptive HGraph ef_search range") {
           {"metric_type", "l2"},
           {"index_param",
            {{"base_quantization_type", "fp32"}, {"max_degree", 24}, {"ef_construction", 80}}}},
-         {{"hgraph",
-           {{"ef_search", {{"$range", {{"start", 40}, {"stop", 1000}}}}},
-            {"use_reorder", {true, false}}}}}}};
+         search_space}};
 
     const auto candidates = vsag::autotune::internal::GenerateCandidates(request);
     REQUIRE(candidates.size() == 2);
@@ -787,10 +860,10 @@ TEST_CASE("AutoTune builds once per create candidate and supports an existing in
     REQUIRE(hgraph != result["builds"].end());
     auto existing = request(dataset.Get(), workspace.Get());
     existing["index_path"] = (*hgraph)["artifacts"]["index_path"];
-    existing["indexes"] =
-        JsonType::array({{{"name", "hgraph"},
-                          {"create_params", (*hgraph)["create_params"]},
-                          {"search_params", {{"hgraph", {{"ef_search", {8, 16}}}}}}}});
+    existing["indexes"] = JsonType::array(
+        {{{"name", "hgraph"},
+          {"create_params", (*hgraph)["create_params"]},
+          {"search_params", {{"hgraph", {{"ef_search", {{"$choices", {8, 16}}}}}}}}}});
     existing["constraints"] = {{"recall_at_k", 0.0}};
     existing["tuning_config"]["max_trials"] = 2;
 
@@ -845,7 +918,7 @@ TEST_CASE("AutoTune searches an in-memory existing index") {
     vsag::autotune::SearchRequest input;
     input.index = created.value();
     input.workload = {fixture.queries, fixture.ground_truth, 3, 2};
-    input.parameter_space = R"({"hgraph":{"ef_search":[8,16]}})";
+    input.parameter_space = R"({"hgraph":{"ef_search":{"$choices":[8,16]}}})";
     input.constraints = {{vsag::autotune::Metric::RECALL_AT_K, 0.0}};
     input.objective = vsag::autotune::Metric::LATENCY_AVG_MS;
     input.config.workspace_path = workspace.Get();
@@ -950,7 +1023,7 @@ TEST_CASE("AutoTune searches an existing Pyramid index for one path workload") {
     input.workload.ground_truth = fixture.ground_truth;
     input.workload.top_k = 3;
     input.workload.concurrency = 2;
-    input.parameter_space = R"({"pyramid":{"ef_search":[4,8]}})";
+    input.parameter_space = R"({"pyramid":{"ef_search":{"$choices":[4,8]}}})";
     input.constraints = {{vsag::autotune::Metric::RECALL_AT_K, 0.0}};
     input.objective = vsag::autotune::Metric::LATENCY_AVG_MS;
     input.config.workspace_path = workspace.Get();

--- a/tools/autotune/examples/README.md
+++ b/tools/autotune/examples/README.md
@@ -15,5 +15,6 @@ The command prints a compact summary. The complete report is written to
 
 This example expands six HGraph build configurations. For each build, AutoTune doubles
 `ef_search` from `40` until recall passes, then binary-searches that interval for the smallest
-passing value, capped at `1000`. Every evaluated point uses all queries. Add arrays or stepped
-`$range` expressions to other parameter leaves to change the tuning space.
+passing value, capped at `1000`. Every evaluated point uses all queries. Add `$choices` or stepped
+`$range` expressions to other parameter leaves to change the tuning space. Bare JSON arrays are
+passed through as native index parameter values.

--- a/tools/autotune/examples/sift_hgraph_autotune_request.json
+++ b/tools/autotune/examples/sift_hgraph_autotune_request.json
@@ -6,8 +6,8 @@
       "name": "hgraph",
       "create_params": {
         "index_param": {
-          "base_quantization_type": ["fp32","sq8"],
-          "max_degree": [16,32,48],
+          "base_quantization_type": {"$choices": ["fp32", "sq8"]},
+          "max_degree": {"$choices": [16, 32, 48]},
           "ef_construction": 400,
           "build_thread_count": 48
         }


### PR DESCRIPTION
## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement/Refactor
- [ ] Documentation
- [ ] CI/Build/Infra

## Linked Issue

- Fixes: #2727

## What Changed

- Treat bare JSON arrays as exact native index parameter values.
- Add explicit `{"$choices": [...]}` candidate expansion with validation, atomic alternatives,
  and duplicate removal while preserving existing `$range` behavior.
- Migrate built-in proposals, runnable examples, regression tests, and the English and Chinese
  AutoTune documentation to the unambiguous syntax.

## Test Evidence

- [ ] `make fmt`
- [ ] `make lint`
- [ ] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [x] Other (describe below)

Test details:

```text
clang-format-15 --dry-run --Werror <changed C++ files>
git diff --check
jq empty tools/autotune/examples/sift_hgraph_autotune_request.json
cmake --build build-release --target autotune_test --parallel 96
./build-release/tools/autotune/autotune_test --reporter compact
  All tests passed (265 assertions in 26 test cases)
./build-release/examples/cpp/326_feature_create_index_with_constraints
./build-release/examples/cpp/327_feature_autotune_existing_index
./build-release/examples/cpp/328_feature_autotune_existing_pyramid
  All three examples completed successfully with 2, 3, and 5 evaluated trials.
```

## Compatibility Impact

- API/ABI compatibility: No C++ API or ABI change; AutoTune remains an experimental build-tree API.
- Behavior changes: Bare arrays are now literal parameter values. Discrete candidates must use
  `$choices`. This intentionally replaces the ambiguous experimental grammar before adoption.

## Performance and Concurrency Impact

- Performance impact: None; candidate expansion complexity and trial planning are unchanged.
- Concurrency/thread-safety impact: None.

## Documentation Impact

- [ ] No docs update needed
- [x] Updated docs:
  - [ ] `README.md`
  - [ ] `DEVELOPMENT.md`
  - [ ] `CONTRIBUTING.md`
  - [x] Other: English/Chinese AutoTune guide and API contract, tool example README

## Risk and Rollback

- Risk level: Low.
- Rollback plan: Revert the commit to restore the previous experimental array expansion behavior.

## Checklist

- [x] I have linked the relevant issue (required for `kind/bug` and `kind/feature`; see "Linked Issue" above)
- [x] I have added/updated tests for new behavior or bug fixes
- [x] I have considered API compatibility impact
- [x] I have updated docs if behavior/workflow changed
- [x] My commit messages follow project conventions (Conventional Commits, optional `[skip ci]` prefix)
