### PR TITLE
[Backport 1.0] fix(hgraph): allow Tune to use incomplete FP32 sources

### DIFF
--- a/src/algorithm/hgraph/hgraph.cpp
+++ b/src/algorithm/hgraph/hgraph.cpp
@@ -101,8 +101,9 @@ HGraph::HGraph(const HGraphParameterPtr& hgraph_param, const vsag::IndexCommonPa
 
 bool
 HGraph::Tune(const std::string& parameters, bool disable_future_tuning) {
-    if (not this->index_feature_list_->CheckFeature(IndexFeature::SUPPORT_TUNE) or
-        not this->has_raw_vector_) {
+    std::scoped_lock lock(this->add_mutex_);
+    if (this->immutable_.load(std::memory_order_acquire) or
+        not this->index_feature_list_->CheckFeature(IndexFeature::SUPPORT_TUNE)) {
         return false;
     }
 
@@ -127,61 +128,75 @@ HGraph::Tune(const std::string& parameters, bool disable_future_tuning) {
     auto new_basic_code =
         FlattenInterface::MakeInstance(hgraph_parameter->base_codes_param, common_param);
     FlattenInterfacePtr new_precise_code;
-    bool new_reorder_by_base = inner_parameter->reorder_source == HGRAPH_REORDER_SOURCE_BASE;
-    if (inner_parameter->use_reorder && not new_reorder_by_base) {
+    const bool new_use_reorder = inner_parameter->use_reorder;
+    const bool new_reorder_by_base = inner_parameter->reorder_source == HGRAPH_REORDER_SOURCE_BASE;
+    const bool need_precise_codes = new_use_reorder and not new_reorder_by_base;
+    if (need_precise_codes) {
         new_precise_code =
             FlattenInterface::MakeInstance(hgraph_parameter->precise_codes_param, common_param);
     }
 
-    std::scoped_lock lock(this->add_mutex_);
-    if (this->immutable_.load(std::memory_order_acquire)) {
-        return false;
-    }
+    const auto current_count = total_count_.load(std::memory_order_acquire);
+    auto covers_active_ids = [current_count](const FlattenInterfacePtr& codes) {
+        return codes != nullptr and codes->TotalCount() >= current_count;
+    };
 
-    // check which code need to tune and update create_param_ptr_
+    // Check which codes need to be rebuilt.
     bool is_tune_base_code = false;
     bool is_tune_precise_code = false;
-    bool new_use_reorder = use_reorder_;
-    bool drop_precise_codes = false;
-    auto param = std::dynamic_pointer_cast<HGraphParameter>(create_param_ptr_);
+    const bool drop_precise_codes = not need_precise_codes;
     if (basic_flatten_codes_->GetQuantizerName() != new_basic_code->GetQuantizerName()) {
-        // [case 1] base_code is not same
         is_tune_base_code = true;
     }
-    if (has_precise_reorder() and inner_parameter->use_reorder and not new_reorder_by_base and
-        this->high_precise_codes_->GetQuantizerName() != new_precise_code->GetQuantizerName()) {
-        // [case 2] precise code is not same
-        is_tune_precise_code = true;
-    }
-    if (not inner_parameter->use_reorder or new_reorder_by_base) {
-        // [case 3] drop precise_code
-        new_use_reorder = inner_parameter->use_reorder;
-        drop_precise_codes = true;
-        param->precise_codes_param.reset();
-        is_tune_precise_code = false;
-    }
-    if (not new_use_reorder and inner_parameter->use_reorder and not new_reorder_by_base) {
-        // [case 4] assign new precise_code
-        new_use_reorder = true;
+    if (need_precise_codes and
+        (not covers_active_ids(high_precise_codes_) or
+         high_precise_codes_->GetQuantizerName() != new_precise_code->GetQuantizerName())) {
         is_tune_precise_code = true;
     }
 
-    // update create_param_ptr_
-    if (is_tune_base_code) {
-        param->base_codes_param = hgraph_parameter->base_codes_param;
+    FlattenInterfacePtr tune_source;
+    if (is_tune_base_code or is_tune_precise_code) {
+        tune_source = raw_vector_;
+        if ((tune_source == nullptr or tune_source->TotalCount() == 0) and
+            high_precise_codes_ != nullptr and
+            high_precise_codes_->GetQuantizerName() == QUANTIZATION_TYPE_VALUE_FP32) {
+            tune_source = high_precise_codes_;
+        }
+        if ((tune_source == nullptr or tune_source->TotalCount() == 0) and
+            basic_flatten_codes_ != nullptr and
+            basic_flatten_codes_->GetQuantizerName() == QUANTIZATION_TYPE_VALUE_FP32) {
+            tune_source = basic_flatten_codes_;
+        }
+        if (tune_source == nullptr) {
+            return false;
+        }
     }
-    if (is_tune_precise_code) {
-        param->precise_codes_param = hgraph_parameter->precise_codes_param;
-    }
-    param->use_reorder = new_use_reorder;
-    param->reorder_source = inner_parameter->reorder_source;
 
-    // export train data and train new_basic_code
+    auto decode_tune_source = [&](InnerIdType inner_id, float* data) {
+        bool need_release = false;
+        const auto* buffer = tune_source->GetCodesById(inner_id, need_release);
+        if (buffer == nullptr) {
+            throw VsagException(ErrorType::INTERNAL_ERROR,
+                                fmt::format("failed to get vector by inner id {}", inner_id));
+        }
+        try {
+            tune_source->Decode(buffer, data);
+        } catch (...) {
+            if (need_release) {
+                tune_source->Release(buffer);
+            }
+            throw;
+        }
+        if (need_release) {
+            tune_source->Release(buffer);
+        }
+    };
+
     auto train_count = std::min(this->train_sample_count_, this->GetNumElements());
     Vector<float> train_data(train_count * dim_, 0, allocator_);
     if (is_tune_base_code or is_tune_precise_code) {
         for (InnerIdType i = 0; i < train_count; i++) {
-            this->GetVectorByInnerId(i, (train_data.data() + i * dim_));
+            decode_tune_source(i, train_data.data() + i * dim_);
         }
     }
 
@@ -194,8 +209,8 @@ HGraph::Tune(const std::string& parameters, bool disable_future_tuning) {
             new_code->Train(train_data.data(), train_count);
 
             Vector<float> insert_buffer(dim_, 0, allocator_);
-            for (int64_t i = 0; i < total_count_; ++i) {
-                GetVectorByInnerId(i, insert_buffer.data());
+            for (int64_t i = 0; i < current_count; ++i) {
+                decode_tune_source(i, insert_buffer.data());
                 new_code->InsertVector(static_cast<const void*>(insert_buffer.data()), i);
             }
             return new_code;
@@ -209,15 +224,24 @@ HGraph::Tune(const std::string& parameters, bool disable_future_tuning) {
     // preventing concurrent searches from accessing partially updated state.
     {
         std::scoped_lock<std::shared_mutex> wlock(this->global_mutex_);
+        auto param = std::dynamic_pointer_cast<HGraphParameter>(create_param_ptr_);
         basic_flatten_codes_ = new_basic;
         if (drop_precise_codes) {
             high_precise_codes_.reset();
+            param->precise_codes_param.reset();
         } else {
             high_precise_codes_ = new_precise;
+            if (is_tune_precise_code) {
+                param->precise_codes_param = hgraph_parameter->precise_codes_param;
+            }
+        }
+        if (is_tune_base_code) {
+            param->base_codes_param = hgraph_parameter->base_codes_param;
         }
         use_reorder_ = new_use_reorder;
         reorder_by_base_ = new_reorder_by_base;
         param->use_reorder = new_use_reorder;
+        param->reorder_source = inner_parameter->reorder_source;
 
         check_and_init_raw_vector(param->raw_vector_param, common_param, false);
         init_resize_bit_and_reorder();

--- a/src/algorithm/hgraph/hgraph_tune_test.cpp
+++ b/src/algorithm/hgraph/hgraph_tune_test.cpp
@@ -1,0 +1,145 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <atomic>
+#include <functional>
+#include <future>
+#include <new>
+#include <utility>
+#include <vector>
+
+#include "hgraph.h"
+#include "impl/allocator/safe_allocator.h"
+#include "impl/thread_pool/safe_thread_pool.h"
+#include "index/index_impl.h"
+#include "index_common_param.h"
+#include "unittest.h"
+
+namespace {
+
+class ArmableRejectingThreadPool final : public vsag::ThreadPool {
+public:
+    void
+    WaitUntilEmpty() override {
+    }
+
+    void
+    SetQueueSizeLimit(uint64_t) override {
+    }
+
+    void
+    SetPoolSize(uint64_t) override {
+    }
+
+    std::future<void>
+    Enqueue(std::function<void(void)> task) override {
+        if (reject_submissions_.load(std::memory_order_acquire)) {
+            throw std::bad_alloc();
+        }
+        std::packaged_task<void()> packaged_task(std::move(task));
+        auto future = packaged_task.get_future();
+        packaged_task();
+        return future;
+    }
+
+    void
+    SetRejectSubmissions(bool reject) {
+        reject_submissions_.store(reject, std::memory_order_release);
+    }
+
+private:
+    std::atomic<bool> reject_submissions_{false};
+};
+
+vsag::DatasetPtr
+MakeFloatDataset(std::vector<float>& vectors,
+                 std::vector<int64_t>& ids,
+                 int64_t dim,
+                 int64_t count) {
+    auto dataset = vsag::Dataset::Make();
+    dataset->NumElements(count)
+        ->Dim(dim)
+        ->Ids(ids.data())
+        ->Float32Vectors(vectors.data())
+        ->Owner(false);
+    return dataset;
+}
+
+vsag::IndexCommonParam
+MakeCommonParam(int64_t dim) {
+    vsag::IndexCommonParam common_param;
+    common_param.dim_ = dim;
+    common_param.metric_ = vsag::MetricType::METRIC_TYPE_L2SQR;
+    common_param.data_type_ = vsag::DataTypes::DATA_TYPE_FLOAT;
+    common_param.allocator_ = vsag::SafeAllocator::FactoryDefaultAllocator();
+    return common_param;
+}
+
+}  // namespace
+
+TEST_CASE("HGraph Tune accepts an incomplete source after Add failure",
+          "[ut][hgraph][add][hgraph_tune_incomplete_source]") {
+    constexpr int64_t dim = 4;
+    constexpr int64_t base_count = 2;
+
+    auto rejecting_pool = std::make_shared<ArmableRejectingThreadPool>();
+    auto common_param = MakeCommonParam(dim);
+    common_param.thread_pool_ = std::make_shared<vsag::SafeThreadPool>(rejecting_pool);
+    auto hgraph_json = vsag::JsonType::Parse(R"({
+        "base_quantization_type": "sq8",
+        "max_degree": 8,
+        "ef_construction": 32,
+        "build_thread_count": 1,
+        "store_raw_vector": true
+    })");
+    auto index = std::make_shared<vsag::IndexImpl<vsag::HGraph>>(hgraph_json, common_param);
+
+    std::vector<float> base_vectors = {
+        0.0F,
+        0.0F,
+        0.0F,
+        0.0F,
+        1.0F,
+        1.0F,
+        1.0F,
+        1.0F,
+    };
+    std::vector<int64_t> base_ids = {10, 20};
+    auto base = MakeFloatDataset(base_vectors, base_ids, dim, base_count);
+    REQUIRE(index->Build(base).has_value());
+    REQUIRE(index->GetNumElements() == base_count);
+
+    std::vector<float> add_vectors = {2.0F, 2.0F, 2.0F, 2.0F};
+    std::vector<int64_t> add_ids = {30};
+    auto add = MakeFloatDataset(add_vectors, add_ids, dim, 1);
+
+    rejecting_pool->SetRejectSubmissions(true);
+    auto add_result = index->Add(add);
+    rejecting_pool->SetRejectSubmissions(false);
+
+    REQUIRE_FALSE(add_result.has_value());
+    REQUIRE(add_result.error().type == vsag::ErrorType::NO_ENOUGH_MEMORY);
+    REQUIRE(index->GetNumElements() == base_count + 1);
+    REQUIRE(index->CheckIdExist(add_ids[0]));
+
+    auto tune_result = index->Tune(R"({
+        "index_param": {
+            "base_quantization_type": "bf16",
+            "max_degree": 8,
+            "ef_construction": 32
+        }
+    })");
+    REQUIRE(tune_result.has_value());
+    CHECK(tune_result.value());
+}

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -1284,6 +1284,117 @@ TestHGraphTune(const fixtures::HGraphTestIndexPtr& test_index,
 
 HGRAPH_PR_DAILY_CASE("HGraph Tune", "[ft][search][hgraph]", TestHGraphTune)
 
+TEST_CASE("HGraph Tune uses available codes", "[ft][search][hgraph][tune_codes]") {
+    using namespace fixtures;
+
+    constexpr int64_t dim = 32;
+    constexpr int64_t base_count = 256;
+    auto dataset = HGraphTestIndex::pool.GetDatasetAndCreate(dim, base_count, "cosine");
+
+    auto make_parameters = [&](const std::string& quantization, bool store_raw = false) {
+        HGraphTestIndex::HGraphBuildParam build_param("cosine", dim, quantization);
+        build_param.thread_count = 1;
+        build_param.store_raw_vector = store_raw;
+        return HGraphTestIndex::GenerateHGraphBuildParametersString(build_param);
+    };
+    auto make_index = [&](const std::string& quantization, bool store_raw = false) {
+        auto index =
+            TestIndex::TestFactory("hgraph", make_parameters(quantization, store_raw), true);
+        TestIndex::TestBuildIndex(index, dataset, true);
+        return index;
+    };
+    auto require_fp32_accuracy = [&](const TestIndex::IndexPtr& index) {
+        constexpr float tolerance = 2e-6F;
+        const auto* queries = dataset->query_->GetFloat32Vectors();
+        const auto* gt_ids = dataset->ground_truth_->GetIds();
+        const auto* gt_distances = dataset->ground_truth_->GetDistances();
+        for (int64_t i = 0; i < dataset->query_->GetNumElements(); ++i) {
+            for (int64_t j = 0; j < dataset->top_k; ++j) {
+                auto pos = i * dataset->top_k + j;
+                auto result = index->CalcDistanceById(queries + i * dim, gt_ids[pos]);
+                REQUIRE(result.has_value());
+                REQUIRE(std::abs(result.value() - gt_distances[pos]) < tolerance);
+            }
+        }
+    };
+
+    SECTION("separate raw codes") {
+        auto index = make_index("sq8,bf16", true);
+        auto result = index->Tune(make_parameters("fp32"), true);
+        REQUIRE(result.has_value());
+        REQUIRE(result.value());
+        require_fp32_accuracy(index);
+    }
+
+    SECTION("precise fp32 codes") {
+        auto index = make_index("bf16,fp32");
+        auto result = index->Tune(make_parameters("fp32"), true);
+        REQUIRE(result.has_value());
+        REQUIRE(result.value());
+        require_fp32_accuracy(index);
+    }
+
+    SECTION("base fp32 codes") {
+        auto index = make_index("fp32,bf16");
+        auto result = index->Tune(make_parameters("fp32,fp32"), true);
+        REQUIRE(result.has_value());
+        REQUIRE(result.value());
+        require_fp32_accuracy(index);
+    }
+
+    SECTION("unloaded precise codes") {
+        auto parsed = vsag::JsonType::Parse(make_parameters("fp32,fp32"));
+        parsed[vsag::INDEX_PARAM]["ignore_reorder"].SetBool(true);
+        auto parameters = parsed.Dump();
+
+        auto index = TestIndex::TestFactory("hgraph", parameters, true);
+        TestIndex::TestBuildIndex(index, dataset, true);
+        auto binary_set = index->Serialize();
+        REQUIRE(binary_set.has_value());
+
+        auto reloaded = TestIndex::TestFactory("hgraph", parameters, true);
+        auto deserialize_result = reloaded->Deserialize(binary_set.value());
+        REQUIRE(deserialize_result.has_value());
+
+        auto tune_result = reloaded->Tune(make_parameters("fp32,fp32"), true);
+        REQUIRE(tune_result.has_value());
+        REQUIRE(tune_result.value());
+        require_fp32_accuracy(reloaded);
+    }
+
+    SECTION("force-removed codes still cover active ids") {
+        auto parsed = vsag::JsonType::Parse(make_parameters("fp32"));
+        parsed[vsag::INDEX_PARAM]["support_force_remove"].SetBool(true);
+        auto parameters = parsed.Dump();
+
+        auto index = TestIndex::TestFactory("hgraph", parameters, true);
+        TestIndex::TestBuildIndex(index, dataset, true);
+
+        auto remove_result =
+            index->Remove(dataset->base_->GetIds()[0], vsag::RemoveMode::FORCE_REMOVE);
+        REQUIRE(remove_result.has_value());
+        REQUIRE(remove_result.value() == 1);
+
+        auto tune_result = index->Tune(make_parameters("bf16"), true);
+        REQUIRE(tune_result.has_value());
+        REQUIRE(tune_result.value());
+    }
+
+    SECTION("no usable codes") {
+        auto index = make_index("sq8,bf16");
+        auto result = index->Tune(make_parameters("bf16,bf16"));
+        REQUIRE(result.has_value());
+        REQUIRE_FALSE(result.value());
+    }
+
+    SECTION("no rebuild") {
+        auto index = make_index("sq8,bf16");
+        auto result = index->Tune(make_parameters("sq8"), true);
+        REQUIRE(result.has_value());
+        REQUIRE(result.value());
+    }
+}
+
 TEST_CASE("(PR) HGraph Tune with ignore_reorder", "[ft][search][hgraph][pr]") {
     using namespace fixtures;
     auto origin_size = vsag::Options::Instance().block_size_limit();


### PR DESCRIPTION
## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Documentation

## Linked Issue

Fixes: #2718

## What Changed

- Backport raw, precise FP32, and base FP32 Tune-source support to the `1.0` branch.
- Select sources directly in raw, precise FP32, then base FP32 order; only fall through when the current candidate is absent or empty.
- Do not require the selected source to cover the published HGraph ID range.
- Preserve the legacy training count and rebuild the complete published ID range.
- Keep the locking, delayed parameter updates, and unloaded precise-code rebuild behavior.
- Add regression coverage for an Add submission failure that publishes an ID before vector insertion completes.

This is the `1.0` counterpart of #2719 and #2720.

## How It Was Tested

```text
clang-format-15 --dry-run --Werror src/algorithm/hgraph/hgraph.cpp src/algorithm/hgraph/hgraph_tune_test.cpp tests/test_hgraph.cpp
git diff --check
cmake --build build --target unittests functests --parallel 6
./build/tests/unittests '[hgraph_tune_incomplete_source]' --allow-running-no-tests
./build/tests/functests '[tune_codes]' --allow-running-no-tests
```

Results: 8 Add-failure regression assertions and 8040 Tune-source assertions passed.

## Compatibility and Risk

- No public API or ABI change.
- Consistent indexes retain their existing behavior.
- Inconsistent indexes rebuild the full published ID range, matching legacy Tune semantics.
- Add-state consistency and invalid individual slots remain outside this PR.

## Checklist

- [x] Linked the relevant issue
- [x] Added regression coverage
- [x] Existing Tune-source functional coverage passes
- [x] No documentation change required
