### PR TITLE
refactor(datacell): extract variable record layouts

### DIFF
--- a/src/datacell/multi_vector_datacell.h
+++ b/src/datacell/multi_vector_datacell.h
@@ -18,6 +18,7 @@
 #include "flatten_interface.h"
 #include "io/common/basic_io.h"
 #include "io/memory_block_io/memory_block_io.h"
+#include "layout/variable_record_layout.h"
 #include "quantization/multi_vector_computer.h"
 #include "typing.h"
 #include "vsag/dataset.h"
@@ -120,12 +121,9 @@ public:
 
 private:
     std::shared_ptr<Quantizer<QuantTmpl>> quantizer_{nullptr};
-    std::shared_ptr<BasicIO<IOTmpl>> io_{nullptr};
 
     Allocator* const allocator_{nullptr};
-    std::shared_ptr<MemoryBlockIO> offset_io_{nullptr};
-    uint64_t current_offset_{0};
-    std::mutex current_offset_mutex_;
+    VariableRecordLayout<HeaderLengthLocationPolicy, MemoryBlockIO, IOTmpl> layout_{};
 
     uint32_t multi_vector_dim_{0};
     MetricType metric_{MetricType::METRIC_TYPE_L2SQR};

--- a/src/datacell/multi_vector_datacell.inl
+++ b/src/datacell/multi_vector_datacell.inl
@@ -18,6 +18,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cstring>
+#include <limits>
 #include <numeric>
 
 #include "common.h"
@@ -26,6 +27,20 @@
 #include "vsag/options.h"
 
 namespace vsag {
+namespace {
+
+uint64_t
+GetMultiVectorRecordSize(uint32_t token_count, uint64_t code_size_per_token) {
+    constexpr uint64_t header_size = sizeof(uint32_t);
+    if (code_size_per_token != 0 &&
+        token_count > (std::numeric_limits<uint64_t>::max() - header_size) / code_size_per_token) {
+        throw VsagException(ErrorType::INVALID_ARGUMENT,
+                            "MultiVectorDataCell: record size overflow");
+    }
+    return header_size + static_cast<uint64_t>(token_count) * code_size_per_token;
+}
+
+}  // namespace
 
 template <typename QuantTmpl, typename IOTmpl>
 MultiVectorDataCell<QuantTmpl, IOTmpl>::MultiVectorDataCell(
@@ -38,9 +53,11 @@ MultiVectorDataCell<QuantTmpl, IOTmpl>::MultiVectorDataCell(
     this->quantizer_ = std::make_shared<QuantTmpl>(quantization_param, common_param);
     this->backend_ =
         QuantizerDistanceBackend<QuantTmpl>::Get(static_cast<const QuantTmpl&>(*this->quantizer_));
-    this->io_ = std::make_shared<IOTmpl>(io_param, common_param);
-    this->offset_io_ =
+    auto io = std::make_shared<IOTmpl>(io_param, common_param);
+    auto offset_io =
         std::make_shared<MemoryBlockIO>(Options::Instance().block_size_limit(), allocator_);
+    layout_.SetIO(std::move(offset_io), std::move(io));
+    layout_.SetLocationPolicy(HeaderLengthLocationPolicy{this->quantizer_->GetCodeSize()});
     this->max_capacity_ = 0;
     this->code_size_ = 0;
 }
@@ -71,8 +88,7 @@ MultiVectorDataCell<QuantTmpl, IOTmpl>::InsertVector(const void* vector, InnerId
     }
 
     const uint64_t code_size_per_token = this->quantizer_->GetCodeSize();
-    const uint64_t payload_bytes = static_cast<uint64_t>(multi_vector->len_) * code_size_per_token;
-    const uint64_t code_size = sizeof(uint32_t) + payload_bytes;
+    const uint64_t code_size = GetMultiVectorRecordSize(multi_vector->len_, code_size_per_token);
     ByteBuffer codes(code_size, allocator_);
     std::memcpy(codes.data, &multi_vector->len_, sizeof(uint32_t));
 
@@ -86,22 +102,14 @@ MultiVectorDataCell<QuantTmpl, IOTmpl>::InsertVector(const void* vector, InnerId
             codes.data + sizeof(uint32_t) + static_cast<uint64_t>(t) * code_size_per_token);
     }
 
-    uint64_t old_offset = 0;
     {
-        std::lock_guard lock(current_offset_mutex_);
-        old_offset = current_offset_;
-        current_offset_ += code_size;
+        std::lock_guard lock(mutex_);
+        layout_.Write(idx, codes.data, code_size);
+        if (static_cast<uint64_t>(idx) >= token_counts_.size()) {
+            token_counts_.resize(static_cast<uint64_t>(idx) + 1, 0);
+        }
+        token_counts_[idx] = multi_vector->len_;
     }
-    offset_io_->Write(reinterpret_cast<const uint8_t*>(&old_offset),
-                      sizeof(old_offset),
-                      static_cast<uint64_t>(idx) * sizeof(old_offset));
-    io_->Write(codes.data, code_size, old_offset);
-
-    // Cache the token count in memory so Query can skip the disk read
-    if (static_cast<uint64_t>(idx) >= token_counts_.size()) {
-        token_counts_.resize(static_cast<uint64_t>(idx) + 1, 0);
-    }
-    token_counts_[idx] = multi_vector->len_;
 }
 
 template <typename QuantTmpl, typename IOTmpl>
@@ -130,14 +138,16 @@ MultiVectorDataCell<QuantTmpl, IOTmpl>::BatchInsertVector(const void* vectors,
 template <typename QuantTmpl, typename IOTmpl>
 void
 MultiVectorDataCell<QuantTmpl, IOTmpl>::Resize(InnerIdType new_capacity) {
-    if (new_capacity <= this->max_capacity_) {
+    std::lock_guard lock(mutex_);
+    const InnerIdType effective_capacity = std::max(new_capacity, total_count_);
+    if (effective_capacity <= this->max_capacity_) {
         return;
     }
-    this->offset_io_->Resize(static_cast<uint64_t>(new_capacity) * sizeof(uint64_t));
-    if (static_cast<uint64_t>(new_capacity) > token_counts_.size()) {
-        token_counts_.resize(static_cast<uint64_t>(new_capacity), 0);
+    layout_.ResizeLocations(effective_capacity);
+    if (static_cast<uint64_t>(effective_capacity) > token_counts_.size()) {
+        token_counts_.resize(static_cast<uint64_t>(effective_capacity), 0);
     }
-    this->max_capacity_ = new_capacity;
+    this->max_capacity_ = effective_capacity;
 }
 
 template <typename QuantTmpl, typename IOTmpl>
@@ -155,14 +165,31 @@ MultiVectorDataCell<QuantTmpl, IOTmpl>::GetMetricType() {
 template <typename QuantTmpl, typename IOTmpl>
 const uint8_t*
 MultiVectorDataCell<QuantTmpl, IOTmpl>::GetCodesById(InnerIdType id, bool& need_release) const {
-    uint64_t offset = 0;
-    offset_io_->Read(sizeof(offset), static_cast<uint64_t>(id) * sizeof(offset), (uint8_t*)&offset);
+    std::shared_lock lock(mutex_);
+    CHECK_ARGUMENT(id < total_count_, "MultiVectorDataCell id is out of range");
+    const uint64_t offset = layout_.ReadLocation(id);
     uint32_t len = 0;
-    io_->Read(sizeof(len), offset, (uint8_t*)&len);
+    if (not layout_.Payload().Read(offset, sizeof(len), reinterpret_cast<uint8_t*>(&len))) {
+        throw VsagException(ErrorType::READ_ERROR,
+                            "MultiVectorDataCell: failed to read token count");
+    }
     const uint64_t code_size_per_token = this->quantizer_->GetCodeSize();
-    uint64_t read_size = sizeof(uint32_t) + static_cast<uint64_t>(len) * code_size_per_token;
+    const uint64_t read_size = GetMultiVectorRecordSize(len, code_size_per_token);
+    const uint64_t payload_size = layout_.Payload().GetByteSize();
+    if (offset > payload_size || read_size > payload_size - offset) {
+        throw VsagException(ErrorType::READ_ERROR,
+                            "MultiVectorDataCell: token data range exceeds payload");
+    }
     auto* codes = static_cast<uint8_t*>(allocator_->Allocate(read_size));
-    io_->Read(read_size, offset, codes);
+    if (codes == nullptr) {
+        throw VsagException(ErrorType::NO_ENOUGH_MEMORY,
+                            "MultiVectorDataCell: failed to allocate buffer for GetCodesById");
+    }
+    if (not layout_.Payload().Read(offset, read_size, codes)) {
+        allocator_->Deallocate(codes);
+        throw VsagException(ErrorType::READ_ERROR,
+                            "MultiVectorDataCell: failed to read token data");
+    }
     need_release = true;
     return codes;
 }
@@ -184,9 +211,9 @@ void
 MultiVectorDataCell<QuantTmpl, IOTmpl>::Serialize(StreamWriter& writer) {
     FlattenInterface::Serialize(writer);
     StreamWriter::WriteObj(writer, multi_vector_dim_);
-    StreamWriter::WriteObj(writer, current_offset_);
-    this->offset_io_->Serialize(writer);
-    this->io_->Serialize(writer);
+    StreamWriter::WriteObj(writer, layout_.GetNextOffset());
+    layout_.Locations().Serialize(writer);
+    layout_.Payload().Serialize(writer);
     this->quantizer_->Serialize(writer);
 }
 
@@ -195,10 +222,13 @@ void
 MultiVectorDataCell<QuantTmpl, IOTmpl>::Deserialize(lvalue_or_rvalue<StreamReader> reader) {
     FlattenInterface::Deserialize(reader);
     StreamReader::ReadObj(reader, multi_vector_dim_);
-    StreamReader::ReadObj(reader, current_offset_);
-    this->offset_io_->Deserialize(reader);
-    this->io_->Deserialize(reader);
+    uint64_t current_offset = 0;
+    StreamReader::ReadObj(reader, current_offset);
+    layout_.SetNextOffset(current_offset);
+    layout_.Locations().Deserialize(reader);
+    layout_.Payload().Deserialize(reader);
     this->quantizer_->Deserialize(reader);
+    layout_.SetLocationPolicy(HeaderLengthLocationPolicy{this->quantizer_->GetCodeSize()});
     this->backend_ =
         QuantizerDistanceBackend<QuantTmpl>::Get(static_cast<const QuantTmpl&>(*this->quantizer_));
 
@@ -206,26 +236,24 @@ MultiVectorDataCell<QuantTmpl, IOTmpl>::Deserialize(lvalue_or_rvalue<StreamReade
     // a separate io_submit to fetch token counts from disk.
     if (this->total_count_ > 0) {
         std::vector<uint64_t> offsets(static_cast<uint64_t>(this->total_count_));
-        std::vector<uint64_t> off_sizes(static_cast<uint64_t>(this->total_count_),
-                                        sizeof(uint64_t));
-        std::vector<uint64_t> off_offs(static_cast<uint64_t>(this->total_count_));
+        std::vector<InnerIdType> ids(static_cast<uint64_t>(this->total_count_));
         for (InnerIdType i = 0; i < this->total_count_; ++i) {
-            off_offs[i] = static_cast<uint64_t>(i) * sizeof(uint64_t);
+            ids[i] = i;
         }
-        if (not offset_io_->MultiRead(reinterpret_cast<uint8_t*>(offsets.data()),
-                                      off_sizes.data(),
-                                      off_offs.data(),
-                                      static_cast<uint64_t>(this->total_count_))) {
+        if (not layout_.Locations().MultiRead(ids.data(),
+                                              static_cast<uint64_t>(this->total_count_),
+                                              reinterpret_cast<uint8_t*>(offsets.data()),
+                                              allocator_)) {
             throw VsagException(ErrorType::READ_ERROR,
                                 "MultiVectorDataCell: failed to read offsets in Deserialize");
         }
 
         token_counts_.resize(static_cast<uint64_t>(this->total_count_));
         std::vector<uint64_t> tc_sizes(static_cast<uint64_t>(this->total_count_), sizeof(uint32_t));
-        if (not this->io_->MultiRead(reinterpret_cast<uint8_t*>(token_counts_.data()),
-                                     tc_sizes.data(),
-                                     offsets.data(),
-                                     static_cast<uint64_t>(this->total_count_))) {
+        if (not layout_.Payload().MultiRead(offsets.data(),
+                                            tc_sizes.data(),
+                                            static_cast<uint64_t>(this->total_count_),
+                                            reinterpret_cast<uint8_t*>(token_counts_.data()))) {
             throw VsagException(ErrorType::READ_ERROR,
                                 "MultiVectorDataCell: failed to read token counts in Deserialize");
         }
@@ -258,21 +286,21 @@ MultiVectorDataCell<QuantTmpl, IOTmpl>::Query(float* result_dists,
     if (id_count == 0) {
         return;
     }
+    CHECK_ARGUMENT(idx != nullptr, "MultiVectorDataCell query ids are null");
+    std::shared_lock lock(mutex_);
+    for (InnerIdType i = 0; i < id_count; ++i) {
+        CHECK_ARGUMENT(idx[i] < total_count_, "MultiVectorDataCell query id is out of range");
+    }
 
     SearchStatistics* stats = (ctx != nullptr) ? ctx->stats : nullptr;
 
-    // Step 1: Batch read all offsets via MultiRead (offset_io_ is MemoryBlockIO, in-memory)
+    // Step 1: Batch read all offsets from the in-memory location layout.
     auto t_io_start = std::chrono::steady_clock::now();
     std::vector<uint64_t> offsets(id_count);
-    std::vector<uint64_t> offset_sizes(id_count, sizeof(uint64_t));
-    std::vector<uint64_t> offset_offsets(id_count);
-    for (InnerIdType i = 0; i < id_count; ++i) {
-        offset_offsets[i] = static_cast<uint64_t>(idx[i]) * sizeof(uint64_t);
-    }
-    if (not offset_io_->MultiRead(reinterpret_cast<uint8_t*>(offsets.data()),
-                                  offset_sizes.data(),
-                                  offset_offsets.data(),
-                                  static_cast<uint64_t>(id_count))) {
+    if (not layout_.Locations().MultiRead(idx,
+                                          static_cast<uint64_t>(id_count),
+                                          reinterpret_cast<uint8_t*>(offsets.data()),
+                                          allocator_)) {
         throw VsagException(ErrorType::READ_ERROR,
                             "MultiVectorDataCell: failed to read offsets in Query");
     }
@@ -289,7 +317,16 @@ MultiVectorDataCell<QuantTmpl, IOTmpl>::Query(float* result_dists,
                                     std::to_string(idx[i]));
         }
         const uint32_t token_count = token_counts_[idx[i]];
-        data_sizes[i] = sizeof(uint32_t) + static_cast<uint64_t>(token_count) * code_size_per_token;
+        data_sizes[i] = GetMultiVectorRecordSize(token_count, code_size_per_token);
+        const uint64_t payload_size = layout_.Payload().GetByteSize();
+        if (offsets[i] > payload_size || data_sizes[i] > payload_size - offsets[i]) {
+            throw VsagException(ErrorType::READ_ERROR,
+                                "MultiVectorDataCell: token data range exceeds payload");
+        }
+        if (data_sizes[i] > std::numeric_limits<uint64_t>::max() - total_size) {
+            throw VsagException(ErrorType::INVALID_ARGUMENT,
+                                "MultiVectorDataCell: batch record size overflow");
+        }
         total_size += data_sizes[i];
     }
 
@@ -319,10 +356,10 @@ MultiVectorDataCell<QuantTmpl, IOTmpl>::Query(float* result_dists,
         throw VsagException(ErrorType::NO_ENOUGH_MEMORY,
                             "MultiVectorDataCell: failed to allocate buffer for Query");
     }
-    if (not this->io_->MultiRead(all_codes,
-                                 sorted_data_sizes.data(),
-                                 sorted_offsets.data(),
-                                 static_cast<uint64_t>(id_count))) {
+    if (not layout_.Payload().MultiRead(sorted_offsets.data(),
+                                        sorted_data_sizes.data(),
+                                        static_cast<uint64_t>(id_count),
+                                        all_codes)) {
         this->allocator_->Deallocate(all_codes);
         throw VsagException(ErrorType::READ_ERROR,
                             "MultiVectorDataCell: failed to read data in Query");
@@ -390,10 +427,7 @@ template <typename QuantTmpl, typename IOTmpl>
 uint64_t
 MultiVectorDataCell<QuantTmpl, IOTmpl>::GetMemoryUsage() const {
     uint64_t memory = sizeof(MultiVectorDataCell<QuantTmpl, IOTmpl>);
-    memory += this->offset_io_->size_;
-    if (IOTmpl::InMemory) {
-        memory += this->io_->GetMemoryUsage();
-    }
+    memory += layout_.GetMemoryUsage();
     memory += sizeof(QuantTmpl);
     memory += token_counts_.capacity() * sizeof(uint32_t);
     return memory;

--- a/src/datacell/multi_vector_datacell_test.cpp
+++ b/src/datacell/multi_vector_datacell_test.cpp
@@ -137,6 +137,12 @@ TEST_CASE("MultiVectorDataCell batch insert reserves ids when idx is null",
         multi_vectors.data(), static_cast<InnerIdType>(multi_vectors.size()), nullptr);
 
     REQUIRE(data_cell->TotalCount() == token_counts.size());
+    REQUIRE_NOTHROW(data_cell->Resize(1));
+    bool need_release = false;
+    const auto* codes =
+        data_cell->GetCodesById(static_cast<InnerIdType>(multi_vectors.size() - 1), need_release);
+    REQUIRE(codes != nullptr);
+    data_cell->Release(codes);
 }
 
 TEST_CASE("MultiVectorDataCell GetCodesById reads back inserted data",
@@ -304,6 +310,11 @@ TEST_CASE("MultiVectorDataCell rejects invalid InsertVector inputs", "[ut][Multi
         MultiVector mv{2, nullptr};
         REQUIRE_THROWS(data_cell->InsertVector(&mv, 0));
     }
+
+    SECTION("out-of-range id") {
+        bool need_release = false;
+        REQUIRE_THROWS(data_cell->GetCodesById(0, need_release));
+    }
 }
 
 TEST_CASE("MultiVectorDataCell rejects invalid BatchInsertVector inputs",
@@ -336,6 +347,23 @@ TEST_CASE("MultiVectorDataCell rejects invalid FactoryComputer inputs",
     SECTION("nullptr query vectors") {
         MultiVector mv{2, nullptr};
         REQUIRE_THROWS(data_cell->FactoryComputer(&mv));
+    }
+
+    SECTION("nullptr query ids") {
+        std::vector<float> query(dim, 1.0F);
+        MultiVector mv{1, query.data()};
+        auto computer = data_cell->FactoryComputer(&mv);
+        float distance = 0.0F;
+        REQUIRE_THROWS(data_cell->Query(&distance, computer, nullptr, 1));
+    }
+
+    SECTION("out-of-range query id") {
+        std::vector<float> query(dim, 1.0F);
+        MultiVector mv{1, query.data()};
+        auto computer = data_cell->FactoryComputer(&mv);
+        const InnerIdType id = 0;
+        float distance = 0.0F;
+        REQUIRE_THROWS(data_cell->Query(&distance, computer, &id, 1));
     }
 }
 

--- a/src/datacell/sparse_vector_datacell.h
+++ b/src/datacell/sparse_vector_datacell.h
@@ -22,6 +22,7 @@
 #include "inner_string_params.h"
 #include "io/common/basic_io.h"
 #include "io/memory_block_io/memory_block_io.h"
+#include "layout/variable_record_layout.h"
 #include "quantization/sparse_quantization/sparse_quantizer.h"
 #include "vsag/dataset.h"
 
@@ -83,15 +84,23 @@ public:
 
     void
     Resize(InnerIdType new_capacity) override {
-        if (new_capacity <= this->max_capacity_) {
+        std::lock_guard lock(mutex_);
+        const InnerIdType effective_capacity = std::max(new_capacity, total_count_);
+        if (effective_capacity <= this->max_capacity_) {
             return;
         }
-        std::scoped_lock lock(mutex_, current_offset_mutex_);
-        uint64_t io_size =
-            static_cast<uint64_t>(new_capacity - total_count_) * max_code_size_ + current_offset_;
-        this->io_->Resize(io_size);
-        this->offset_io_->Resize(static_cast<uint64_t>(new_capacity) * sizeof(DocLocation));
-        this->max_capacity_ = new_capacity;
+        const uint64_t additional_count = static_cast<uint64_t>(effective_capacity - total_count_);
+        const uint64_t current_size = layout_.GetNextOffset();
+        if (max_code_size_ != 0 &&
+            additional_count >
+                (std::numeric_limits<uint64_t>::max() - current_size) / max_code_size_) {
+            throw VsagException(ErrorType::INVALID_ARGUMENT,
+                                "SparseVectorDataCell resize payload size overflow");
+        }
+        const uint64_t io_size = additional_count * max_code_size_ + current_size;
+        layout_.ReservePayload(io_size);
+        layout_.ResizeLocations(effective_capacity);
+        this->max_capacity_ = effective_capacity;
     }
 
     void
@@ -149,12 +158,12 @@ public:
 
     inline void
     SetIO(std::shared_ptr<BasicIO<IOTmpl>> io) {
-        this->io_ = io;
+        layout_.Payload().SetIO(std::move(io));
     }
 
     void
     InitIO(const IOParamPtr& io_param) override {
-        this->io_->InitIO(io_param);
+        layout_.Payload().InitIO(io_param);
     }
 
     uint64_t
@@ -185,15 +194,10 @@ private:
     get_codes_by_id_no_lock(InnerIdType id, bool& need_release) const;
 
 private:
-    // Packed so each entry is exactly 12 bytes on disk and in the offset_io_
-    // buffer. The unpacked layout would round sizeof up to 16 due to the
-    // uint64 alignment requirement, wasting 33% of the offset table.
-#pragma pack(push, 1)
-    struct DocLocation {
-        uint64_t offset{0};
-        uint32_t size{0};
-    };
-#pragma pack(pop)
+    // Packed so each entry is exactly 12 bytes on disk and in the layout location table. The
+    // unpacked layout would round sizeof up to 16 due to the uint64 alignment requirement,
+    // wasting 33% of the location table.
+    using DocLocation = OffsetAndLengthLocationPolicy::Entry;
     static_assert(sizeof(DocLocation) == 12, "DocLocation must be 12 bytes on disk");
 
     // Legacy on-disk layout: kept for backward-compatible deserialization of indexes
@@ -217,14 +221,11 @@ private:
     static constexpr uint32_t SERIALIZE_FORMAT_VERSION_V2 = 2;
 
     std::shared_ptr<Quantizer<QuantTmpl>> quantizer_{nullptr};
-    std::shared_ptr<BasicIO<IOTmpl>> io_{nullptr};
     QueryIOStrategy query_io_strategy_{QueryIOStrategy::MULTI_READ};
 
     Allocator* const allocator_{nullptr};
-    std::shared_ptr<MemoryBlockIO> offset_io_{nullptr};
-    uint64_t current_offset_{0};
+    VariableRecordLayout<OffsetAndLengthLocationPolicy, MemoryBlockIO, IOTmpl> layout_{};
     uint64_t max_code_size_{0};
-    std::mutex current_offset_mutex_;
 };
 
 }  // namespace vsag

--- a/src/datacell/sparse_vector_datacell.inl
+++ b/src/datacell/sparse_vector_datacell.inl
@@ -38,11 +38,11 @@ SparseVectorDataCell<QuantTmpl, IOTmpl>::query(float* result_dists,
     CHECK_ARGUMENT(idx != nullptr, "SparseVectorDataCell query ids are null");
 
     const auto load_location = [this](InnerIdType id) {
-        DocLocation location{};
-        const bool read_ok = offset_io_->Read(sizeof(location),
-                                              static_cast<uint64_t>(id) * sizeof(location),
-                                              reinterpret_cast<uint8_t*>(&location));
-        CHECK_ARGUMENT(read_ok, "SparseVectorDataCell failed to read document location");
+        const auto location = layout_.ReadLocation(id);
+        if (not layout_.IsValidLocation(location)) {
+            throw VsagException(ErrorType::READ_ERROR,
+                                "SparseVectorDataCell read an invalid document location");
+        }
         return location;
     };
 
@@ -50,7 +50,7 @@ SparseVectorDataCell<QuantTmpl, IOTmpl>::query(float* result_dists,
 
     const auto compute_direct = [&](const DocLocation& location, InnerIdType result_index) {
         bool need_release = false;
-        const auto* codes = io_->Read(location.size, location.offset, need_release);
+        const auto* codes = layout_.Read(location, need_release);
         if (codes == nullptr) {
             throw VsagException(ErrorType::READ_ERROR,
                                 "SparseVectorDataCell failed to read vector codes");
@@ -114,7 +114,7 @@ SparseVectorDataCell<QuantTmpl, IOTmpl>::query(float* result_dists,
     ranges.reserve(id_count);
     for (uint64_t i = 0; i < static_cast<uint64_t>(id_count); ++i) {
         const auto& location = locations[i].location;
-        const uint64_t location_end = location.offset + location.size;
+        const uint64_t location_end = location.offset + location.length;
         if (not ranges.empty()) {
             auto& range = ranges.back();
             const uint64_t range_end = range.offset + range.size;
@@ -127,7 +127,7 @@ SparseVectorDataCell<QuantTmpl, IOTmpl>::query(float* result_dists,
                 continue;
             }
         }
-        ranges.push_back({location.offset, location.size, i, i});
+        ranges.push_back({location.offset, location.length, i, i});
     }
 
     const uint64_t range_count = ranges.size();
@@ -143,7 +143,8 @@ SparseVectorDataCell<QuantTmpl, IOTmpl>::query(float* result_dists,
     }
 
     Vector<uint8_t> scratch(scratch_size, query_allocator);
-    if (not io_->MultiRead(scratch.data(), read_sizes.data(), read_offsets.data(), range_count)) {
+    if (not layout_.Payload().MultiRead(
+            read_offsets.data(), read_sizes.data(), range_count, scratch.data())) {
         throw VsagException(ErrorType::READ_ERROR,
                             "SparseVectorDataCell failed to read vector-code batch");
     }
@@ -176,13 +177,15 @@ SparseVectorDataCell<QuantTmpl, IOTmpl>::Deserialize(lvalue_or_rvalue<StreamRead
                 ErrorType::INVALID_ARGUMENT,
                 fmt::format("unsupported SparseVectorDataCell serialization version: {}", version));
         }
-        StreamReader::ReadObj(reader, current_offset_);
-        this->io_->Deserialize(reader);
-        this->offset_io_->Deserialize(reader);
+        uint64_t current_offset = 0;
+        StreamReader::ReadObj(reader, current_offset);
+        layout_.SetNextOffset(current_offset);
+        layout_.Payload().Deserialize(reader);
+        layout_.Locations().Deserialize(reader);
     } else {
         // Legacy 32-bit format. The uint32 we just read is the old current_offset_.
-        current_offset_ = static_cast<uint64_t>(maybe_sentinel);
-        this->io_->Deserialize(reader);
+        layout_.SetNextOffset(static_cast<uint64_t>(maybe_sentinel));
+        layout_.Payload().Deserialize(reader);
         // Legacy offset_io_ holds an array of 8-byte LegacyDocLocation records. We
         // load them and expand each entry to the new 12-byte DocLocation in memory
         // so the rest of the code can use a single internal representation.
@@ -195,7 +198,12 @@ SparseVectorDataCell<QuantTmpl, IOTmpl>::Deserialize(lvalue_or_rvalue<StreamRead
                                             legacy_offset_io_size));
         }
         const uint64_t doc_count = legacy_offset_io_size / legacy_entry_size;
-        this->offset_io_->Resize(doc_count * sizeof(DocLocation));
+        if (doc_count > std::numeric_limits<InnerIdType>::max() || doc_count < total_count_) {
+            throw VsagException(
+                ErrorType::INVALID_ARGUMENT,
+                fmt::format("invalid legacy SparseVectorDataCell document count: {}", doc_count));
+        }
+        layout_.ResizeLocations(doc_count);
         if (doc_count > 0) {
             constexpr uint64_t BATCH = 4096;
             Vector<LegacyDocLocation> legacy_batch(allocator_);
@@ -212,11 +220,10 @@ SparseVectorDataCell<QuantTmpl, IOTmpl>::Deserialize(lvalue_or_rvalue<StreamRead
                              batch * sizeof(LegacyDocLocation));
                 for (uint64_t i = 0; i < batch; ++i) {
                     new_batch[i].offset = static_cast<uint64_t>(legacy_batch[i].offset);
-                    new_batch[i].size = legacy_batch[i].size;
+                    new_batch[i].length = legacy_batch[i].size;
                 }
-                this->offset_io_->Write(reinterpret_cast<uint8_t*>(new_batch.data()),
-                                        batch * sizeof(DocLocation),
-                                        cursor * sizeof(DocLocation));
+                layout_.Locations().WriteRange(
+                    cursor, reinterpret_cast<uint8_t*>(new_batch.data()), batch);
                 cursor += batch;
                 remaining -= batch;
             }
@@ -235,9 +242,9 @@ SparseVectorDataCell<QuantTmpl, IOTmpl>::Serialize(StreamWriter& writer) {
     const uint32_t version = SERIALIZE_FORMAT_VERSION_V2;
     StreamWriter::WriteObj(writer, sentinel);
     StreamWriter::WriteObj(writer, version);
-    StreamWriter::WriteObj(writer, current_offset_);
-    this->io_->Serialize(writer);
-    this->offset_io_->Serialize(writer);
+    StreamWriter::WriteObj(writer, layout_.GetNextOffset());
+    layout_.Payload().Serialize(writer);
+    layout_.Locations().Serialize(writer);
     this->quantizer_->Serialize(writer);
 }
 
@@ -279,22 +286,11 @@ SparseVectorDataCell<QuantTmpl, IOTmpl>::InsertVector(const void* vector, InnerI
     }
     Vector<uint8_t> codes(code_size, allocator_);
     quantizer_->EncodeOne((const float*)vector, codes.data());
-    DocLocation location;
     {
-        std::scoped_lock lock(mutex_, current_offset_mutex_);
+        std::lock_guard lock(mutex_);
         total_count_ = std::max(total_count_, idx + 1);
         max_code_size_ = std::max(max_code_size_, code_size);
-        const auto required_size = current_offset_ + code_size;
-        if (required_size > this->io_->size_) {
-            this->io_->Resize(required_size);
-        }
-        location.offset = current_offset_;
-        location.size = static_cast<uint32_t>(code_size);
-        current_offset_ += code_size;
-        offset_io_->Write(reinterpret_cast<uint8_t*>(&location),
-                          sizeof(location),
-                          static_cast<uint64_t>(idx) * sizeof(location));
-        io_->Write(codes.data(), code_size, location.offset);
+        layout_.Write(idx, codes.data(), code_size);
     }
 }
 
@@ -315,12 +311,7 @@ template <typename QuantTmpl, typename IOTmpl>
 const uint8_t*
 SparseVectorDataCell<QuantTmpl, IOTmpl>::get_codes_by_id_no_lock(InnerIdType id,
                                                                  bool& need_release) const {
-    DocLocation location{};
-    const bool read_ok = offset_io_->Read(sizeof(location),
-                                          static_cast<uint64_t>(id) * sizeof(location),
-                                          reinterpret_cast<uint8_t*>(&location));
-    CHECK_ARGUMENT(read_ok, "SparseVectorDataCell failed to read document location");
-    const auto* codes = io_->Read(location.size, location.offset, need_release);
+    const auto* codes = layout_.Read(id, need_release);
     if (codes == nullptr) {
         throw VsagException(ErrorType::READ_ERROR,
                             "SparseVectorDataCell failed to read vector codes");
@@ -371,7 +362,7 @@ SparseVectorDataCell<QuantTmpl, IOTmpl>::GetSparseVectorByInnerId(
 template <typename QuantTmpl, typename IOTmpl>
 void
 SparseVectorDataCell<QuantTmpl, IOTmpl>::Release(const uint8_t* data) const {
-    io_->Release(data);
+    layout_.Release(data);
 }
 
 template <typename QuantTmpl, typename IOTmpl>
@@ -430,7 +421,7 @@ SparseVectorDataCell<QuantTmpl, IOTmpl>::SparseVectorDataCell(
     this->quantizer_ = std::make_shared<QuantTmpl>(quantization_param, common_param);
     this->backend_ =
         QuantizerDistanceBackend<QuantTmpl>::Get(static_cast<const QuantTmpl&>(*this->quantizer_));
-    this->io_ = std::make_shared<IOTmpl>(io_param, common_param);
+    auto io = std::make_shared<IOTmpl>(io_param, common_param);
     const auto& io_type = io_param->GetTypeName();
     if (io_type == IO_TYPE_VALUE_MEMORY_IO || io_type == IO_TYPE_VALUE_BLOCK_MEMORY_IO) {
         this->query_io_strategy_ = QueryIOStrategy::DIRECT_READ;
@@ -439,8 +430,9 @@ SparseVectorDataCell<QuantTmpl, IOTmpl>::SparseVectorDataCell(
     } else {
         this->query_io_strategy_ = QueryIOStrategy::MULTI_READ;
     }
-    this->offset_io_ =
+    auto offset_io =
         std::make_shared<MemoryBlockIO>(Options::Instance().block_size_limit(), allocator_);
+    layout_.SetIO(std::move(offset_io), std::move(io));
     this->max_code_size_ = std::max<uint64_t>(
         sizeof(uint32_t), (static_cast<uint64_t>(common_param.dim_) * 2 + 1) * sizeof(uint32_t));
     this->max_capacity_ = 0;
@@ -451,10 +443,7 @@ template <typename QuantTmpl, typename IOTmpl>
 uint64_t
 SparseVectorDataCell<QuantTmpl, IOTmpl>::GetMemoryUsage() const {
     uint64_t memory = sizeof(SparseVectorDataCell<QuantTmpl, IOTmpl>);
-    memory += this->offset_io_->size_;
-    if (IOTmpl::InMemory) {
-        memory += this->io_->GetMemoryUsage();
-    }
+    memory += layout_.GetMemoryUsage();
     memory += sizeof(QuantTmpl);
     return memory;
 }

--- a/src/datacell/sparse_vector_datacell_test.cpp
+++ b/src/datacell/sparse_vector_datacell_test.cpp
@@ -69,6 +69,7 @@ TEST_CASE("SparseDataCell Basic Test", "[ut][SparseDataCell] ") {
     data_cell->BatchInsertVector(sparse_vectors.data() + half_count + half_count / 2,
                                  half_count / 2,
                                  idx.data() + half_count + half_count / 2);
+    REQUIRE_NOTHROW(data_cell->Resize(base_count - 1));
 
     for (int i = 0; i < base_count - 1; ++i) {
         fixtures::dist_t distance = data_cell->ComputePairVectors(idx[i], idx[i + 1]);
@@ -579,6 +580,33 @@ TEST_CASE("SparseDataCell New Format Sentinel", "[ut][SparseDataCell]") {
         delete[] item.vals_;
         delete[] item.ids_;
     }
+}
+
+TEST_CASE("SparseDataCell rejects undersized legacy location tables", "[ut][SparseDataCell]") {
+    constexpr const char* param_str = R"({
+        "io_params": {"type": "memory_io"},
+        "quantization_params": {"type": "sparse"}
+    })";
+    JsonType parsed_json = JsonType::Parse(param_str);
+    auto param = std::make_shared<SparseVectorDataCellParameter>();
+    param->FromJson(parsed_json);
+    IndexCommonParam common_param;
+    common_param.allocator_ = SafeAllocator::FactoryDefaultAllocator();
+    common_param.metric_ = MetricType::METRIC_TYPE_IP;
+    common_param.dim_ = 100;
+
+    std::stringstream legacy_ss;
+    write_legacy_format(legacy_ss,
+                        /*total_count=*/2,
+                        /*max_capacity=*/2,
+                        /*code_size=*/0,
+                        /*io_bytes=*/{},
+                        /*legacy_entries=*/{{0, 0}},
+                        /*quantizer_bytes=*/{});
+
+    auto loaded = FlattenInterface::MakeInstance(param, common_param);
+    IOStreamReader reader(legacy_ss);
+    REQUIRE_THROWS_AS(loaded->Deserialize(reader), VsagException);
 }
 
 }  // namespace vsag

--- a/src/layout/byte_range_layout.h
+++ b/src/layout/byte_range_layout.h
@@ -1,0 +1,157 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <utility>
+
+#include "index_common_param.h"
+#include "io/common/basic_io.h"
+#include "storage/stream_reader.h"
+#include "storage/stream_writer.h"
+#include "vsag_exception.h"
+
+namespace vsag {
+
+/** Organizes opaque bytes addressed by an explicit byte offset and length. */
+template <typename IOTmpl>
+class ByteRangeLayout {
+public:
+    using IOType = IOTmpl;
+    static constexpr bool InMemory = IOTmpl::InMemory;
+
+    ByteRangeLayout() = default;
+
+    ByteRangeLayout(const IOParamPtr& io_param, const IndexCommonParam& common_param)
+        : io_(std::make_shared<IOTmpl>(io_param, common_param)) {
+    }
+
+    void
+    SetIO(std::shared_ptr<BasicIO<IOTmpl>> io) {
+        io_ = std::move(io);
+    }
+
+    void
+    Write(uint64_t offset, const uint8_t* data, uint64_t length) {
+        if (length > std::numeric_limits<uint64_t>::max() - offset) {
+            throw VsagException(ErrorType::INVALID_ARGUMENT, "byte range write offset overflow");
+        }
+        if (not IsValidRange(offset, length)) {
+            throw VsagException(ErrorType::INVALID_ARGUMENT,
+                                "byte range write exceeds allocated size");
+        }
+        io_->Write(data, length, offset);
+    }
+
+    bool
+    Read(uint64_t offset, uint64_t length, uint8_t* data) const {
+        if (not IsValidRange(offset, length)) {
+            return false;
+        }
+        return io_->Read(length, offset, data);
+    }
+
+    [[nodiscard]] const uint8_t*
+    Read(uint64_t offset, uint64_t length, bool& need_release) const {
+        if (not IsValidRange(offset, length)) {
+            need_release = false;
+            return nullptr;
+        }
+        return io_->Read(length, offset, need_release);
+    }
+
+    bool
+    MultiRead(uint64_t* offsets, uint64_t* lengths, uint64_t count, uint8_t* data) const {
+        if (count > 0 && (offsets == nullptr || lengths == nullptr)) {
+            return false;
+        }
+        uint64_t total_length = 0;
+        for (uint64_t i = 0; i < count; ++i) {
+            if (not IsValidRange(offsets[i], lengths[i]) ||
+                lengths[i] > std::numeric_limits<uint64_t>::max() - total_length) {
+                return false;
+            }
+            total_length += lengths[i];
+        }
+        if (total_length > 0 && data == nullptr) {
+            return false;
+        }
+        return io_->MultiRead(data, lengths, offsets, count);
+    }
+
+    void
+    Release(const uint8_t* data) const {
+        if (data != nullptr) {
+            io_->Release(data);
+        }
+    }
+
+    void
+    Prefetch(uint64_t offset, uint64_t length) {
+        io_->Prefetch(offset, length);
+    }
+
+    void
+    Resize(uint64_t byte_size) {
+        io_->Resize(byte_size);
+    }
+
+    void
+    Shrink(uint64_t byte_size) {
+        io_->Shrink(byte_size);
+    }
+
+    void
+    InitIO(const IOParamPtr& io_param) {
+        io_->InitIO(io_param);
+    }
+
+    void
+    Serialize(StreamWriter& writer) {
+        io_->Serialize(writer);
+    }
+
+    void
+    Deserialize(lvalue_or_rvalue<StreamReader> reader) {
+        io_->Deserialize(reader);
+    }
+
+    [[nodiscard]] uint64_t
+    GetMemoryUsage() const {
+        if constexpr (InMemory) {
+            const int64_t memory_usage = io_->GetMemoryUsage();
+            return memory_usage > 0 ? static_cast<uint64_t>(memory_usage) : 0;
+        }
+        return 0;
+    }
+
+    [[nodiscard]] uint64_t
+    GetByteSize() const {
+        return io_->size_;
+    }
+
+private:
+    [[nodiscard]] bool
+    IsValidRange(uint64_t offset, uint64_t length) const {
+        const uint64_t byte_size = GetByteSize();
+        return offset <= byte_size && length <= byte_size - offset;
+    }
+
+    std::shared_ptr<BasicIO<IOTmpl>> io_{nullptr};
+};
+
+}  // namespace vsag

--- a/src/layout/byte_range_layout_test.cpp
+++ b/src/layout/byte_range_layout_test.cpp
@@ -1,0 +1,109 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "layout/byte_range_layout.h"
+
+#include <array>
+#include <cstring>
+#include <limits>
+#include <sstream>
+
+#include "impl/allocator/safe_allocator.h"
+#include "io/memory_io/memory_io.h"
+#include "unittest.h"
+
+namespace vsag {
+
+TEST_CASE("ByteRangeLayout addresses opaque byte ranges", "[ut][ByteRangeLayout]") {
+    IndexCommonParam common_param;
+    common_param.allocator_ = SafeAllocator::FactoryDefaultAllocator();
+    ByteRangeLayout<MemoryIO> layout(nullptr, common_param);
+    layout.Resize(16);
+
+    const std::array<uint8_t, 4> first{1, 2, 3, 4};
+    const std::array<uint8_t, 3> second{7, 8, 9};
+    layout.Write(2, first.data(), first.size());
+    layout.Write(10, second.data(), second.size());
+
+    std::array<uint8_t, 4> output{};
+    REQUIRE(layout.Read(2, output.size(), output.data()));
+    REQUIRE(output == first);
+
+    std::array<uint64_t, 2> offsets{10, 2};
+    std::array<uint64_t, 2> lengths{3, 4};
+    std::array<uint8_t, 7> batch{};
+    REQUIRE(layout.MultiRead(offsets.data(), lengths.data(), offsets.size(), batch.data()));
+    const std::array<uint8_t, 7> expected{7, 8, 9, 1, 2, 3, 4};
+    REQUIRE(batch == expected);
+}
+
+TEST_CASE("ByteRangeLayout preserves underlying IO serialization", "[ut][ByteRangeLayout]") {
+    IndexCommonParam common_param;
+    common_param.allocator_ = SafeAllocator::FactoryDefaultAllocator();
+    ByteRangeLayout<MemoryIO> source(nullptr, common_param);
+    const std::array<uint8_t, 5> bytes{2, 4, 6, 8, 10};
+    source.Resize(bytes.size());
+    source.Write(0, bytes.data(), bytes.size());
+
+    std::stringstream stream;
+    IOStreamWriter writer(stream);
+    source.Serialize(writer);
+    stream.seekg(0, std::ios::beg);
+
+    ByteRangeLayout<MemoryIO> restored(nullptr, common_param);
+    IOStreamReader reader(stream);
+    restored.Deserialize(reader);
+    bool need_release = true;
+    const auto* result = restored.Read(0, bytes.size(), need_release);
+    REQUIRE(result != nullptr);
+    REQUIRE_FALSE(need_release);
+    REQUIRE(std::memcmp(result, bytes.data(), bytes.size()) == 0);
+    REQUIRE(restored.GetMemoryUsage() >= bytes.size());
+}
+
+TEST_CASE("ByteRangeLayout rejects invalid read ranges", "[ut][ByteRangeLayout]") {
+    IndexCommonParam common_param;
+    common_param.allocator_ = SafeAllocator::FactoryDefaultAllocator();
+    ByteRangeLayout<MemoryIO> layout(nullptr, common_param);
+    layout.Resize(16);
+
+    std::array<uint8_t, 2> output{};
+    REQUIRE_FALSE(layout.Read(15, output.size(), output.data()));
+    REQUIRE_FALSE(layout.Read(std::numeric_limits<uint64_t>::max(), output.size(), output.data()));
+
+    bool need_release = true;
+    REQUIRE(layout.Read(15, output.size(), need_release) == nullptr);
+    REQUIRE_FALSE(need_release);
+
+    std::array<uint64_t, 2> offsets{0, 15};
+    std::array<uint64_t, 2> lengths{1, 2};
+    REQUIRE_FALSE(layout.MultiRead(offsets.data(), lengths.data(), offsets.size(), output.data()));
+
+    offsets = {0, 1};
+    lengths = {1, 1};
+    REQUIRE_FALSE(layout.MultiRead(offsets.data(), lengths.data(), offsets.size(), nullptr));
+}
+
+TEST_CASE("ByteRangeLayout rejects overflowing write ranges", "[ut][ByteRangeLayout]") {
+    IndexCommonParam common_param;
+    common_param.allocator_ = SafeAllocator::FactoryDefaultAllocator();
+    ByteRangeLayout<MemoryIO> layout(nullptr, common_param);
+
+    const uint8_t data = 0;
+    REQUIRE_THROWS_AS(layout.Write(std::numeric_limits<uint64_t>::max(), &data, 2), VsagException);
+    layout.Resize(1);
+    REQUIRE_THROWS_AS(layout.Write(1, &data, 1), VsagException);
+}
+
+}  // namespace vsag

--- a/src/layout/variable_record_layout.h
+++ b/src/layout/variable_record_layout.h
@@ -1,0 +1,271 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <mutex>
+#include <utility>
+
+#include "layout/byte_range_layout.h"
+#include "layout/fixed_layout.h"
+#include "vsag_exception.h"
+
+namespace vsag {
+
+/** Default location policy for records whose offset and length are persisted. */
+struct OffsetAndLengthLocationPolicy {
+#pragma pack(push, 1)
+    struct Entry {
+        uint64_t offset{0};
+        uint32_t length{0};
+    };
+#pragma pack(pop)
+
+    static uint64_t
+    GetOffset(const Entry& entry) {
+        return entry.offset;
+    }
+
+    template <typename PayloadLayout>
+    static uint64_t
+    GetLength(const Entry& entry, const PayloadLayout&) {
+        return entry.length;
+    }
+
+    static Entry
+    Make(uint64_t offset, uint64_t length) {
+        if (length > std::numeric_limits<uint32_t>::max()) {
+            throw VsagException(ErrorType::INVALID_ARGUMENT,
+                                "variable record length exceeds uint32_t limit");
+        }
+        return {offset, static_cast<uint32_t>(length)};
+    }
+};
+
+/** Location policy for records whose byte length is derived from a uint32 header. */
+struct HeaderLengthLocationPolicy {
+    using Entry = uint64_t;
+
+    uint64_t bytes_per_element{0};
+
+    static uint64_t
+    GetOffset(const Entry& entry) {
+        return entry;
+    }
+
+    template <typename PayloadLayout>
+    uint64_t
+    GetLength(const Entry& entry, const PayloadLayout& payload) const {
+        if (bytes_per_element == 0) {
+            throw VsagException(ErrorType::INVALID_ARGUMENT,
+                                "variable record bytes per element must be positive");
+        }
+        uint32_t element_count = 0;
+        if (not payload.Read(
+                entry, sizeof(element_count), reinterpret_cast<uint8_t*>(&element_count))) {
+            throw VsagException(ErrorType::READ_ERROR,
+                                "failed to read variable record length header");
+        }
+        if (element_count >
+            (std::numeric_limits<uint64_t>::max() - sizeof(element_count)) / bytes_per_element) {
+            throw VsagException(ErrorType::INVALID_ARGUMENT,
+                                "variable record header length overflow");
+        }
+        return sizeof(element_count) + static_cast<uint64_t>(element_count) * bytes_per_element;
+    }
+
+    static Entry
+    Make(uint64_t offset, uint64_t) {
+        return offset;
+    }
+};
+
+/** Maps a logical record ID to an opaque variable-length payload. */
+template <typename LocationPolicy, typename LocationIO, typename PayloadIO>
+class VariableRecordLayout {
+public:
+    using LocationEntry = typename LocationPolicy::Entry;
+    using LocationLayout = FixedLayout<LocationIO>;
+    using PayloadLayout = ByteRangeLayout<PayloadIO>;
+
+    VariableRecordLayout() = default;
+
+    VariableRecordLayout(std::shared_ptr<BasicIO<LocationIO>> location_io,
+                         std::shared_ptr<BasicIO<PayloadIO>> payload_io) {
+        SetIO(std::move(location_io), std::move(payload_io));
+    }
+
+    void
+    SetIO(std::shared_ptr<BasicIO<LocationIO>> location_io,
+          std::shared_ptr<BasicIO<PayloadIO>> payload_io) {
+        locations_.SetCodeSize(sizeof(LocationEntry));
+        locations_.SetIO(std::move(location_io));
+        payload_.SetIO(std::move(payload_io));
+    }
+
+    void
+    SetLocationPolicy(LocationPolicy policy) {
+        location_policy_ = std::move(policy);
+    }
+
+    void
+    Write(InnerIdType id, const uint8_t* data, uint64_t length) {
+        std::lock_guard lock(append_mutex_);
+        const uint64_t offset = next_offset_;
+        if (length > std::numeric_limits<uint64_t>::max() - offset) {
+            throw VsagException(ErrorType::INVALID_ARGUMENT,
+                                "variable record payload offset overflow");
+        }
+        const uint64_t required_size = offset + length;
+        const auto location = location_policy_.Make(offset, length);
+        if (required_size > payload_.GetByteSize()) {
+            payload_.Resize(required_size);
+        }
+        payload_.Write(offset, data, length);
+        next_offset_ = required_size;
+        locations_.Write(id, reinterpret_cast<const uint8_t*>(&location));
+    }
+
+    [[nodiscard]] LocationEntry
+    ReadLocation(InnerIdType id) const {
+        LocationEntry location{};
+        if (not locations_.Read(id, reinterpret_cast<uint8_t*>(&location))) {
+            throw VsagException(ErrorType::READ_ERROR, "failed to read variable record location");
+        }
+        return location;
+    }
+
+    [[nodiscard]] uint64_t
+    GetRecordLength(const LocationEntry& location) const {
+        return location_policy_.GetLength(location, payload_);
+    }
+
+    [[nodiscard]] bool
+    IsValidLocation(const LocationEntry& location) const {
+        uint64_t offset = 0;
+        uint64_t length = 0;
+        return TryResolveRange(location, offset, length);
+    }
+
+    [[nodiscard]] const uint8_t*
+    Read(InnerIdType id, bool& need_release) const {
+        const auto location = ReadLocation(id);
+        return Read(location, need_release);
+    }
+
+    [[nodiscard]] const uint8_t*
+    Read(const LocationEntry& location, bool& need_release) const {
+        uint64_t offset = 0;
+        uint64_t length = 0;
+        if (not TryResolveRange(location, offset, length)) {
+            need_release = false;
+            return nullptr;
+        }
+        return payload_.Read(offset, length, need_release);
+    }
+
+    bool
+    MultiRead(const LocationEntry* locations,
+              uint64_t count,
+              uint8_t* data,
+              Allocator* allocator) const {
+        if (count > 0 && locations == nullptr) {
+            return false;
+        }
+        Vector<uint64_t> offsets(count, allocator);
+        Vector<uint64_t> lengths(count, allocator);
+        for (uint64_t i = 0; i < count; ++i) {
+            if (not TryResolveRange(locations[i], offsets[i], lengths[i])) {
+                return false;
+            }
+        }
+        return payload_.MultiRead(offsets.data(), lengths.data(), count, data);
+    }
+
+    void
+    Release(const uint8_t* data) const {
+        payload_.Release(data);
+    }
+
+    void
+    ResizeLocations(uint64_t capacity) {
+        locations_.Resize(capacity);
+    }
+
+    void
+    ReservePayload(uint64_t byte_size) {
+        if (byte_size > payload_.GetByteSize()) {
+            payload_.Resize(byte_size);
+        }
+    }
+
+    void
+    SetNextOffset(uint64_t offset) {
+        next_offset_ = offset;
+    }
+
+    [[nodiscard]] uint64_t
+    GetNextOffset() const {
+        return next_offset_;
+    }
+
+    LocationLayout&
+    Locations() {
+        return locations_;
+    }
+
+    PayloadLayout&
+    Payload() {
+        return payload_;
+    }
+
+    [[nodiscard]] const PayloadLayout&
+    Payload() const {
+        return payload_;
+    }
+
+    [[nodiscard]] const LocationLayout&
+    Locations() const {
+        return locations_;
+    }
+
+    [[nodiscard]] uint64_t
+    GetMemoryUsage() const {
+        return locations_.GetMemoryUsage() + payload_.GetMemoryUsage();
+    }
+
+private:
+    [[nodiscard]] bool
+    TryResolveRange(const LocationEntry& location, uint64_t& offset, uint64_t& length) const {
+        try {
+            offset = location_policy_.GetOffset(location);
+            length = GetRecordLength(location);
+            const uint64_t payload_size = payload_.GetByteSize();
+            return offset <= payload_size && length <= payload_size - offset;
+        } catch (...) {
+            return false;
+        }
+    }
+
+    LocationLayout locations_{};
+    PayloadLayout payload_{};
+    uint64_t next_offset_{0};
+    LocationPolicy location_policy_{};
+    std::mutex append_mutex_;
+};
+
+}  // namespace vsag

--- a/src/layout/variable_record_layout_test.cpp
+++ b/src/layout/variable_record_layout_test.cpp
@@ -1,0 +1,141 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "layout/variable_record_layout.h"
+
+#include <array>
+#include <cstring>
+#include <limits>
+
+#include "impl/allocator/safe_allocator.h"
+#include "io/memory_block_io/memory_block_io.h"
+#include "io/memory_io/memory_io.h"
+#include "unittest.h"
+#include "vsag/options.h"
+
+namespace vsag {
+
+TEST_CASE("VariableRecordLayout maps ids to appended records", "[ut][VariableRecordLayout]") {
+    IndexCommonParam common_param;
+    common_param.allocator_ = SafeAllocator::FactoryDefaultAllocator();
+    auto location_io = std::make_shared<MemoryBlockIO>(Options::Instance().block_size_limit(),
+                                                       common_param.allocator_.get());
+    auto payload_io = std::make_shared<MemoryIO>(IOParamPtr{}, common_param);
+    VariableRecordLayout<OffsetAndLengthLocationPolicy, MemoryBlockIO, MemoryIO> layout(location_io,
+                                                                                        payload_io);
+    layout.ResizeLocations(4);
+
+    const std::array<uint8_t, 3> first{1, 3, 5};
+    const std::array<uint8_t, 5> second{2, 4, 6, 8, 10};
+    layout.Write(2, first.data(), first.size());
+    layout.Write(0, second.data(), second.size());
+
+    const auto first_location = layout.ReadLocation(2);
+    const auto second_location = layout.ReadLocation(0);
+    REQUIRE(first_location.offset == 0);
+    REQUIRE(first_location.length == first.size());
+    REQUIRE(second_location.offset == first.size());
+    REQUIRE(second_location.length == second.size());
+    REQUIRE(layout.GetNextOffset() == first.size() + second.size());
+
+    bool need_release = true;
+    const auto* record = layout.Read(0, need_release);
+    REQUIRE(record != nullptr);
+    REQUIRE_FALSE(need_release);
+    REQUIRE(std::memcmp(record, second.data(), second.size()) == 0);
+
+    const std::array locations{second_location, first_location};
+    std::array<uint8_t, 8> batch{};
+    REQUIRE(layout.MultiRead(
+        locations.data(), locations.size(), batch.data(), common_param.allocator_.get()));
+    const std::array<uint8_t, 8> expected{2, 4, 6, 8, 10, 1, 3, 5};
+    REQUIRE(batch == expected);
+}
+
+TEST_CASE("HeaderLengthLocationPolicy rejects an unset element width",
+          "[ut][VariableRecordLayout]") {
+    IndexCommonParam common_param;
+    common_param.allocator_ = SafeAllocator::FactoryDefaultAllocator();
+    ByteRangeLayout<MemoryIO> payload(nullptr, common_param);
+    HeaderLengthLocationPolicy policy;
+    REQUIRE_THROWS_AS(policy.GetLength(0, payload), VsagException);
+
+    auto location_io = std::make_shared<MemoryBlockIO>(Options::Instance().block_size_limit(),
+                                                       common_param.allocator_.get());
+    auto payload_io = std::make_shared<MemoryIO>(IOParamPtr{}, common_param);
+    VariableRecordLayout<HeaderLengthLocationPolicy, MemoryBlockIO, MemoryIO> layout(location_io,
+                                                                                     payload_io);
+    REQUIRE_FALSE(layout.IsValidLocation(0));
+    const HeaderLengthLocationPolicy::Entry location = 0;
+    uint8_t output = 0;
+    REQUIRE_FALSE(layout.MultiRead(&location, 1, &output, common_param.allocator_.get()));
+}
+
+TEST_CASE("VariableRecordLayout validates a location before writing payload",
+          "[ut][VariableRecordLayout]") {
+    IndexCommonParam common_param;
+    common_param.allocator_ = SafeAllocator::FactoryDefaultAllocator();
+    auto location_io = std::make_shared<MemoryBlockIO>(Options::Instance().block_size_limit(),
+                                                       common_param.allocator_.get());
+    auto payload_io = std::make_shared<MemoryIO>(IOParamPtr{}, common_param);
+    VariableRecordLayout<OffsetAndLengthLocationPolicy, MemoryBlockIO, MemoryIO> layout(location_io,
+                                                                                        payload_io);
+    layout.ResizeLocations(1);
+
+    const uint8_t data = 0;
+    const auto payload_size = layout.Payload().GetByteSize();
+    const auto invalid_length = static_cast<uint64_t>(std::numeric_limits<uint32_t>::max()) + 1;
+    REQUIRE_THROWS_AS(layout.Write(0, &data, invalid_length), VsagException);
+    REQUIRE(layout.Payload().GetByteSize() == payload_size);
+    REQUIRE(layout.GetNextOffset() == 0);
+}
+
+TEST_CASE("VariableRecordLayout rejects out-of-bounds locations", "[ut][VariableRecordLayout]") {
+    IndexCommonParam common_param;
+    common_param.allocator_ = SafeAllocator::FactoryDefaultAllocator();
+    auto location_io = std::make_shared<MemoryBlockIO>(Options::Instance().block_size_limit(),
+                                                       common_param.allocator_.get());
+    auto payload_io = std::make_shared<MemoryIO>(IOParamPtr{}, common_param);
+    VariableRecordLayout<OffsetAndLengthLocationPolicy, MemoryBlockIO, MemoryIO> layout(location_io,
+                                                                                        payload_io);
+    layout.ReservePayload(8);
+
+    const OffsetAndLengthLocationPolicy::Entry overflow{std::numeric_limits<uint64_t>::max(), 2};
+    const OffsetAndLengthLocationPolicy::Entry out_of_bounds{7, 2};
+    REQUIRE_FALSE(layout.IsValidLocation(overflow));
+    REQUIRE_FALSE(layout.IsValidLocation(out_of_bounds));
+
+    bool need_release = true;
+    REQUIRE(layout.Read(overflow, need_release) == nullptr);
+    REQUIRE_FALSE(need_release);
+    need_release = true;
+    REQUIRE(layout.Read(out_of_bounds, need_release) == nullptr);
+    REQUIRE_FALSE(need_release);
+}
+
+TEST_CASE("VariableRecordLayout payload reserve is grow-only", "[ut][VariableRecordLayout]") {
+    IndexCommonParam common_param;
+    common_param.allocator_ = SafeAllocator::FactoryDefaultAllocator();
+    auto location_io = std::make_shared<MemoryBlockIO>(Options::Instance().block_size_limit(),
+                                                       common_param.allocator_.get());
+    auto payload_io = std::make_shared<MemoryIO>(IOParamPtr{}, common_param);
+    VariableRecordLayout<OffsetAndLengthLocationPolicy, MemoryBlockIO, MemoryIO> layout(location_io,
+                                                                                        payload_io);
+
+    layout.ReservePayload(16);
+    layout.ReservePayload(8);
+    REQUIRE(layout.Payload().GetByteSize() == 16);
+}
+
+}  // namespace vsag


### PR DESCRIPTION
## What

- Add `ByteRangeLayout` for explicit `(offset, length)` access to opaque bytes.
- Add policy-based `VariableRecordLayout` composed from `FixedLayout` and `ByteRangeLayout`.
- Migrate `SparseVectorDataCell` while preserving the V2 and legacy location schemas.
- Migrate `MultiVectorDataCell` while preserving its `uint64_t` offset table and serialized byte order.

## Design boundary

Layout owns addressing, byte organization, IO delegation, append allocation, and serialization primitives. It does not interpret quantized codes or perform distance computation.

Sparse query range merging remains in the DataCell because it coordinates result ordering and computation.

## Tests

- Focused unit tests: 17 cases and 14,292 assertions passed.
- Debug build passed.
- Release build passed.