### PR TITLE
fix(hgraph): enable MRLE split RaBitQ fast build

### DIFF
--- a/src/algorithm/hgraph/hgraph_add_test.cpp
+++ b/src/algorithm/hgraph/hgraph_add_test.cpp
@@ -24,6 +24,7 @@
 #include <vector>
 
 #include "hgraph.h"
+#include "hgraph_fast_build.h"
 #include "impl/allocator/safe_allocator.h"
 #include "impl/thread_pool/safe_thread_pool.h"
 #include "index/index_impl.h"
@@ -1239,4 +1240,27 @@ TEST_CASE("HGraph deduplicate_storage rejects unsupported graph type",
     hgraph_json["graph_type"].SetString("odescent");
 
     REQUIRE_THROWS(MakeHGraphIndex(hgraph_json, common_param));
+}
+
+TEST_CASE("HGraph optimized build accepts MRLE RaBitQ split with raw-vector storage",
+          "[ut][hgraph][optimized_build][MRLE]") {
+    constexpr int64_t dim = 64;
+    auto hgraph_json = vsag::JsonType::Parse(R"({
+        "base_quantization_type": "tq",
+        "tq_chain": "mrle, rabitq",
+        "mrle_dim": 32,
+        "precise_quantization_type": "rabitq",
+        "rabitq_bits_per_dim_base": 3,
+        "rabitq_bits_per_dim_precise": 5,
+        "use_reorder": true,
+        "build_by_base": false,
+        "max_degree": 8,
+        "ef_construction": 32
+    })");
+    auto index = MakeHGraphIndex(hgraph_json, MakeCommonParam(dim, 2));
+    auto hgraph = std::dynamic_pointer_cast<vsag::HGraph>(index->GetInnerIndex());
+    REQUIRE(hgraph != nullptr);
+
+    vsag::HGraphOptimizedBuildSession session(*hgraph);
+    REQUIRE(session.Active());
 }

--- a/src/algorithm/hgraph/hgraph_fast_build.cpp
+++ b/src/algorithm/hgraph/hgraph_fast_build.cpp
@@ -49,8 +49,7 @@ HGraphOptimizedBuildSession::HGraphOptimizedBuildSession(HGraph& hgraph) : hgrap
     if (hgraph.using_dedup_storage()) {
         return;
     }
-    const bool build_uses_base_codes =
-        hgraph.has_precise_reorder() ? hgraph.build_by_base_ : hgraph.raw_vector_ == nullptr;
+    const bool build_uses_base_codes = not hgraph.has_precise_reorder() or hgraph.build_by_base_;
     if (not build_uses_base_codes) {
         return;
     }


### PR DESCRIPTION
## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement/Refactor
- [ ] Documentation
- [ ] CI/Build/Infra

## Linked Issue

- Fixes: #2738

## What Changed

- Decouple optimized-build eligibility from the raw-vector storage retained by MRLE.
- Allow split RaBitQ base codes to use the optimized HGraph build session with MRLE reorder.
- Add regression coverage for the affected MRLE split configuration.

## Test Evidence

- [ ] `make fmt`
- [ ] `make lint`
- [ ] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [x] Other (describe below)

Test details:

```text
clang-format-15 and git diff --check: passed

HGraph optimized-build tests:
  2121 assertions in 4 test cases: passed

HGraph split RaBitQ tests:
  11804 assertions in 11 test cases: passed

MRLE functional build/search/tune/serialization tests:
  1715 assertions in 2 test cases: passed

Release build benchmark on /root/data/openai-1536-50k-angular.hdf5
(50,000 x 1536 float32, inner product, MRLE 1280, RaBitQ 3+5,
M=32, ef_construction=200, 24 build threads):
  fixed median build time: 17.791 seconds (3 runs)
  old path: did not complete within 20 minutes
```

## Compatibility Impact

- API/ABI compatibility: none
- Behavior changes: eligible MRLE split RaBitQ builds now use the optimized build path

## Performance and Concurrency Impact

- Performance impact: improved for MRLE split RaBitQ builds
- Concurrency/thread-safety impact: none; the existing optimized build session is reused

## Documentation Impact

- [x] No docs update needed
- [ ] Updated docs:
  - [ ] `README.md`
  - [ ] `DEVELOPMENT.md`
  - [ ] `CONTRIBUTING.md`
  - [ ] Other

## Risk and Rollback

- Risk level: low
- Rollback plan: revert commit `5a731d0ce`

## Checklist

- [x] I have linked the relevant issue
- [x] I have added/updated tests for the bug fix
- [x] I have considered API compatibility impact
- [x] I have updated docs if behavior/workflow changed
- [x] My commit messages follow project conventions
